### PR TITLE
avoid single letter names and code cleanup

### DIFF
--- a/RecoVertex/PrimaryVertexProducer/interface/DAClusterizerInZT_vect.h
+++ b/RecoVertex/PrimaryVertexProducer/interface/DAClusterizerInZT_vect.h
@@ -19,119 +19,142 @@
 
 #include <memory>
 
+//#define USEVTXDT2
+
 class DAClusterizerInZT_vect final : public TrackClusterizerInZ {
 public:
-  // Internal data structure to
+  // internal data structure for tracks
   struct track_t {
-    void addItem(
-        double new_z, double new_t, double new_dz2, double new_dt2, const reco::TransientTrack *new_tt, double new_pi) {
-      z.push_back(new_z);
-      t.push_back(new_t);
-      dz2.push_back(new_dz2);
-      dt2.push_back(new_dt2);
-      tt.push_back(new_tt);
+    std::vector<double> zpca_vec;                  // z-coordinate at point of closest approach to the beamline
+    std::vector<double> tpca_vec;                  // t-coordinate at point of closest approach to the beamline
+    std::vector<double> dz2_vec;                   // square of the error of z(pca)
+    std::vector<double> dt2_vec;                   // square of the error of t(pca)
+    std::vector<double> Z_sum_vec;                 // track contribution to the partition function, Z
+    std::vector<double> tkwt_vec;                  // track weight, close to 1.0 for most tracks
+    std::vector<unsigned int> kmin;                // index of the first cluster within zrange
+    std::vector<unsigned int> kmax;                // 1 + index of the last cluster within zrange
+    std::vector<const reco::TransientTrack *> tt;  // a pointer to the Transient Track
 
-      pi.push_back(new_pi);  // track weight
-      Z_sum.push_back(1.0);  // Z[i]   for DA clustering, initial value as done in ::fill
+    void addItem(double new_zpca,
+                 double new_tpca,
+                 double new_dz2,
+                 double new_dt2,
+                 const reco::TransientTrack *new_tt,
+                 double new_tkwt) {
+      zpca_vec.push_back(new_zpca);
+      tpca_vec.push_back(new_tpca);
+      dz2_vec.push_back(new_dz2);
+      dt2_vec.push_back(new_dt2);
+      tt.push_back(new_tt);
+      tkwt_vec.push_back(new_tkwt);
+      Z_sum_vec.push_back(1.0);
       kmin.push_back(0);
       kmax.push_back(0);
     }
 
-    unsigned int getSize() const { return z.size(); }
+    void insertItem(unsigned int i,
+                    double new_zpca,
+                    double new_tpca,
+                    double new_dz2,
+                    double new_dt2,
+                    const reco::TransientTrack *new_tt,
+                    double new_tkwt) {
+      zpca_vec.insert(zpca_vec.begin() + i, new_zpca);
+      tpca_vec.insert(tpca_vec.begin() + i, new_tpca);
+      dz2_vec.insert(dz2_vec.begin() + i, new_dz2);
+      dt2_vec.insert(dt2_vec.begin() + i, new_dt2);
+      tt.insert(tt.begin() + i, new_tt);
+      tkwt_vec.insert(tkwt_vec.begin() + i, new_tkwt);
+      Z_sum_vec.insert(Z_sum_vec.begin() + i, 1.0);
+      kmin.insert(kmin.begin() + i, 0);
+      kmax.insert(kmax.begin() + i, 0);
+    }
+
+    unsigned int getSize() const { return zpca_vec.size(); }
 
     // has to be called everytime the items are modified
     void extractRaw() {
-      z_ptr = &z.front();
-      t_ptr = &t.front();
-      dz2_ptr = &dz2.front();
-      dt2_ptr = &dt2.front();
-      pi_ptr = &pi.front();
-      Z_sum_ptr = &Z_sum.front();
+      zpca = &zpca_vec.front();
+      tpca = &tpca_vec.front();
+      dz2 = &dz2_vec.front();
+      dt2 = &dt2_vec.front();
+      tkwt = &tkwt_vec.front();
+      Z_sum = &Z_sum_vec.front();
     }
 
-    double *z_ptr;   // z-coordinate at point of closest approach to the beamline
-    double *t_ptr;   // t-coordinate at point of closest approach to the beamline
-    double *pi_ptr;  // track weight
-
-    double *dz2_ptr;    // square of the error of z(pca)
-    double *dt2_ptr;    // square of the error of t(pca)
-    double *Z_sum_ptr;  // Z[i]   for DA clustering
-
-    std::vector<double> z;      // z-coordinate at point of closest approach to the beamline
-    std::vector<double> t;      // t-coordinate at point of closest approach to the beamline
-    std::vector<double> dz2;    // square of the error of z(pca)
-    std::vector<double> dt2;    // square of the error of t(pca)
-    std::vector<double> Z_sum;  // Z[i]   for DA clustering
-    std::vector<double> pi;     // track weight
-    std::vector<unsigned int> kmin;
-    std::vector<unsigned int> kmax;
-    std::vector<const reco::TransientTrack *> tt;  // a pointer to the Transient Track
+    // pointers to the first element of vectors, needed for vectorized code
+    double *__restrict__ zpca;
+    double *__restrict__ tpca;
+    double *__restrict__ dz2;
+    double *__restrict__ dt2;
+    double *__restrict__ tkwt;
+    double *__restrict__ Z_sum;
   };
 
+  // internal data structure for clusters
   struct vertex_t {
-    void addItem(double new_z, double new_t, double new_pk) {
-      z.push_back(new_z);
-      t.push_back(new_t);
-      pk.push_back(new_pk);
+    std::vector<double> zvtx_vec;  // z coordinate
+    std::vector<double> tvtx_vec;  // t coordinate
+    std::vector<double> rho_vec;   //  vertex "mass" for mass-constrained clustering
+#ifdef USEVTXDT2
+    std::vector<double> dt2_vec;   // only used with vertex time uncertainties
+    std::vector<double> sumw_vec;  // only used with vertex time uncertainties
+#endif
+    // --- temporary numbers, used during update
+    std::vector<double> exp_arg_vec;
+    std::vector<double> exp_vec;
+    std::vector<double> sw_vec;
+    std::vector<double> swz_vec;
+    std::vector<double> swt_vec;
+    std::vector<double> se_vec;
+    std::vector<double> nuz_vec;
+    std::vector<double> nut_vec;
+    std::vector<double> szz_vec;
+    std::vector<double> stt_vec;
+    std::vector<double> szt_vec;
 
-      ei_cache.push_back(0.0);
-      ei.push_back(0.0);
-      swz.push_back(0.0);
-      swt.push_back(0.0);
-      se.push_back(0.0);
-      nuz.push_back(0.0);
-      nut.push_back(0.0);
-      szz.push_back(0.0);
-      stt.push_back(0.0);
-      szt.push_back(0.0);
+    unsigned int getSize() const { return zvtx_vec.size(); }
 
-      dt2.push_back(0.0);
-      sumw.push_back(0.0);
+    void addItem(double new_zvtx, double new_tvtx, double new_rho) {
+      zvtx_vec.push_back(new_zvtx);
+      tvtx_vec.push_back(new_tvtx);
+      rho_vec.push_back(new_rho);
+      exp_arg_vec.push_back(0.0);
+      exp_vec.push_back(0.0);
+      swz_vec.push_back(0.0);
+      swt_vec.push_back(0.0);
+      se_vec.push_back(0.0);
+      nuz_vec.push_back(0.0);
+      nut_vec.push_back(0.0);
+      szz_vec.push_back(0.0);
+      stt_vec.push_back(0.0);
+      szt_vec.push_back(0.0);
+#ifdef USEVTXDT2
+      dt2_vec.push_back(0.0);
+      sumw_vec.push_back(0.0);
+#endif
 
       extractRaw();
     }
 
-    unsigned int getSize() const { return z.size(); }
-
-    // has to be called everytime the items are modified
-    void extractRaw() {
-      z_ptr = &z.front();
-      t_ptr = &t.front();
-      pk_ptr = &pk.front();
-      dt2_ptr = &dt2.front();
-      sumw_ptr = &sumw.front();
-
-      ei_ptr = &ei.front();
-      swz_ptr = &swz.front();
-      swt_ptr = &swt.front();
-      se_ptr = &se.front();
-      nuz_ptr = &nuz.front();
-      nut_ptr = &nut.front();
-      szz_ptr = &szz.front();
-      stt_ptr = &stt.front();
-      szt_ptr = &szt.front();
-
-      ei_cache_ptr = &ei_cache.front();
-    }
-
-    void insertItem(unsigned int k, double new_z, double new_t, double new_pk, track_t &tks) {
-      z.insert(z.begin() + k, new_z);
-      t.insert(t.begin() + k, new_t);
-      pk.insert(pk.begin() + k, new_pk);
-      dt2.insert(dt2.begin() + k, 0.0);
-      sumw.insert(sumw.begin() + k, 0.0);
-
-      ei_cache.insert(ei_cache.begin() + k, 0.0);
-      ei.insert(ei.begin() + k, 0.0);
-      swz.insert(swz.begin() + k, 0.0);
-      swt.insert(swt.begin() + k, 0.0);
-      se.insert(se.begin() + k, 0.0);
-
-      nuz.insert(nuz.begin() + k, 0.0);
-      nut.insert(nut.begin() + k, 0.0);
-      szz.insert(szz.begin() + k, 0.0);
-      stt.insert(stt.begin() + k, 0.0);
-      szt.insert(szt.begin() + k, 0.0);
+    void insertItem(unsigned int k, double new_zvtx, double new_tvtx, double new_rho, track_t &tks) {
+      zvtx_vec.insert(zvtx_vec.begin() + k, new_zvtx);
+      tvtx_vec.insert(tvtx_vec.begin() + k, new_tvtx);
+      rho_vec.insert(rho_vec.begin() + k, new_rho);
+      exp_arg_vec.insert(exp_arg_vec.begin() + k, 0.0);
+      exp_vec.insert(exp_vec.begin() + k, 0.0);
+      swz_vec.insert(swz_vec.begin() + k, 0.0);
+      swt_vec.insert(swt_vec.begin() + k, 0.0);
+      se_vec.insert(se_vec.begin() + k, 0.0);
+      nuz_vec.insert(nuz_vec.begin() + k, 0.0);
+      nut_vec.insert(nut_vec.begin() + k, 0.0);
+      szz_vec.insert(szz_vec.begin() + k, 0.0);
+      stt_vec.insert(stt_vec.begin() + k, 0.0);
+      szt_vec.insert(szt_vec.begin() + k, 0.0);
+#ifdef USEVTXDT2
+      dt2_vec.insert(dt2_vec.begin() + k, 0.0);
+      sumw_vec.insert(sumw_vec.begin() + k, 0.0);
+#endif
 
       // adjust vertex lists of tracks
       for (unsigned int i = 0; i < tks.getSize(); i++) {
@@ -145,24 +168,25 @@ public:
 
       extractRaw();
     }
+
     void removeItem(unsigned int k, track_t &tks) {
-      z.erase(z.begin() + k);
-      t.erase(t.begin() + k);
-      pk.erase(pk.begin() + k);
-      dt2.erase(dt2.begin() + k);
-      sumw.erase(sumw.begin() + k);
-
-      ei_cache.erase(ei_cache.begin() + k);
-      ei.erase(ei.begin() + k);
-      swz.erase(swz.begin() + k);
-      swt.erase(swt.begin() + k);
-      se.erase(se.begin() + k);
-
-      nuz.erase(nuz.begin() + k);
-      nut.erase(nut.begin() + k);
-      szz.erase(szz.begin() + k);
-      stt.erase(stt.begin() + k);
-      szt.erase(szt.begin() + k);
+      zvtx_vec.erase(zvtx_vec.begin() + k);
+      tvtx_vec.erase(tvtx_vec.begin() + k);
+      rho_vec.erase(rho_vec.begin() + k);
+      exp_arg_vec.erase(exp_arg_vec.begin() + k);
+      exp_vec.erase(exp_vec.begin() + k);
+      swz_vec.erase(swz_vec.begin() + k);
+      swt_vec.erase(swt_vec.begin() + k);
+      se_vec.erase(se_vec.begin() + k);
+      nuz_vec.erase(nuz_vec.begin() + k);
+      nut_vec.erase(nut_vec.begin() + k);
+      szz_vec.erase(szz_vec.begin() + k);
+      stt_vec.erase(stt_vec.begin() + k);
+      szt_vec.erase(szt_vec.begin() + k);
+#ifdef USEVTXDT2
+      dt2_vec.erase(dt2_vec.begin() + k);
+      sumw_vec.erase(sumw_vec.begin() + k);
+#endif
 
       // adjust vertex lists of tracks
       for (unsigned int i = 0; i < tks.getSize(); i++) {
@@ -177,15 +201,15 @@ public:
       extractRaw();
     }
 
-    unsigned int insertOrdered(double z, double t, double pk, track_t &tks) {
+    unsigned int insertOrdered(double zvtx, double tvtx, double rho, track_t &tks) {
       // insert a new cluster according to it's z-position, return the index at which it was inserted
 
       unsigned int k = 0;
       for (; k < getSize(); k++) {
-        if (z < z_ptr[k])
+        if (zvtx < zvtx_vec[k])
           break;
       }
-      insertItem(k, z, t, pk, tks);
+      insertItem(k, zvtx, tvtx, rho, tks);
       return k;
     }
 
@@ -193,47 +217,49 @@ public:
       std::cout << "vertex_t size: " << getSize() << std::endl;
 
       for (unsigned int i = 0; i < getSize(); ++i) {
-        std::cout << " z = " << z_ptr[i] << " t = " << t_ptr[i] << " pk = " << pk_ptr[i] << std::endl;
+        std::cout << " z = " << zvtx[i] << " t = " << tvtx[i] << " rho = " << rho[i] << std::endl;
       }
     }
 
-    std::vector<double> z;     // z coordinate
-    std::vector<double> t;     // t coordinate
-    std::vector<double> pk;    // vertex weight for "constrained" clustering
-    std::vector<double> dt2;   // only used with vertex time uncertainties
-    std::vector<double> sumw;  // only used with vertex time uncertainties
+    // pointers to the first element of vectors, needed for vectorized code
+    double *__restrict__ zvtx;
+    double *__restrict__ tvtx;
+    double *__restrict__ rho;
+    double *__restrict__ exp_arg;
+    double *__restrict__ exp;
+    double *__restrict__ swt;
+    double *__restrict__ swz;
+    double *__restrict__ se;
+    double *__restrict__ nuz;
+    double *__restrict__ nut;
+    double *__restrict__ szz;
+    double *__restrict__ stt;
+    double *__restrict__ szt;
+#ifdef USEVTXDT2
+    double *__restrict__ dt2;
+    double *__restrict__ sumw;
+#endif
 
-    double *z_ptr;
-    double *t_ptr;
-    double *pk_ptr;
-    double *dt2_ptr;
-    double *sumw_ptr;
-
-    double *ei_cache_ptr;
-    double *ei_ptr;
-    double *swz_ptr;
-    double *swt_ptr;
-    double *se_ptr;
-    double *szz_ptr;
-    double *stt_ptr;
-    double *szt_ptr;
-    double *nuz_ptr;
-    double *nut_ptr;
-
-    // --- temporary numbers, used during update
-    std::vector<double> ei_cache;
-    std::vector<double> ei;
-    std::vector<double> swz;
-    std::vector<double> swt;
-    std::vector<double> se;
-    std::vector<double> nuz;
-    std::vector<double> nut;
-    std::vector<double> szz;
-    std::vector<double> stt;
-    std::vector<double> szt;
-
-    // copy made at the beginning of thermalize
-    std::vector<double> z0;  //           z coordinate at last vtx range fixing
+    // has to be called everytime the items are modified
+    void extractRaw() {
+      zvtx = &zvtx_vec.front();
+      tvtx = &tvtx_vec.front();
+      rho = &rho_vec.front();
+      exp_arg = &exp_arg_vec.front();
+      exp = &exp_vec.front();
+      swz = &swz_vec.front();
+      swt = &swt_vec.front();
+      se = &se_vec.front();
+      nuz = &nuz_vec.front();
+      nut = &nut_vec.front();
+      szz = &szz_vec.front();
+      stt = &stt_vec.front();
+      szt = &szt_vec.front();
+#ifdef USEVTXDT2
+      dt2 = &dt2_vec.front();
+      sumw = &sumw_vec.front();
+#endif
+    }
   };
 
   DAClusterizerInZT_vect(const edm::ParameterSet &conf);

--- a/RecoVertex/PrimaryVertexProducer/interface/DAClusterizerInZT_vect.h
+++ b/RecoVertex/PrimaryVertexProducer/interface/DAClusterizerInZT_vect.h
@@ -1,5 +1,5 @@
-#ifndef DAClusterizerInZT_vect_h
-#define DAClusterizerInZT_vect_h
+#ifndef RecoVertex_PrimaryVertexProducer_DAClusterizerInZT_vect_h
+#define RecoVertex_PrimaryVertexProducer_DAClusterizerInZT_vect_h
 
 /**\class DAClusterizerInZT_vect
 
@@ -29,7 +29,7 @@ public:
     std::vector<double> tpca_vec;                  // t-coordinate at point of closest approach to the beamline
     std::vector<double> dz2_vec;                   // square of the error of z(pca)
     std::vector<double> dt2_vec;                   // square of the error of t(pca)
-    std::vector<double> Z_sum_vec;                 // track contribution to the partition function, Z
+    std::vector<double> sum_Z_vec;                 // track contribution to the partition function, Z
     std::vector<double> tkwt_vec;                  // track weight, close to 1.0 for most tracks
     std::vector<unsigned int> kmin;                // index of the first cluster within zrange
     std::vector<unsigned int> kmax;                // 1 + index of the last cluster within zrange
@@ -47,7 +47,7 @@ public:
       dt2_vec.push_back(new_dt2);
       tt.push_back(new_tt);
       tkwt_vec.push_back(new_tkwt);
-      Z_sum_vec.push_back(1.0);
+      sum_Z_vec.push_back(1.0);
       kmin.push_back(0);
       kmax.push_back(0);
     }
@@ -65,7 +65,7 @@ public:
       dt2_vec.insert(dt2_vec.begin() + i, new_dt2);
       tt.insert(tt.begin() + i, new_tt);
       tkwt_vec.insert(tkwt_vec.begin() + i, new_tkwt);
-      Z_sum_vec.insert(Z_sum_vec.begin() + i, 1.0);
+      sum_Z_vec.insert(sum_Z_vec.begin() + i, 1.0);
       kmin.insert(kmin.begin() + i, 0);
       kmax.insert(kmax.begin() + i, 0);
     }
@@ -79,7 +79,7 @@ public:
       dz2 = &dz2_vec.front();
       dt2 = &dt2_vec.front();
       tkwt = &tkwt_vec.front();
-      Z_sum = &Z_sum_vec.front();
+      sum_Z = &sum_Z_vec.front();
     }
 
     // pointers to the first element of vectors, needed for vectorized code
@@ -88,7 +88,7 @@ public:
     double *__restrict__ dz2;
     double *__restrict__ dt2;
     double *__restrict__ tkwt;
-    double *__restrict__ Z_sum;
+    double *__restrict__ sum_Z;
   };
 
   // internal data structure for clusters
@@ -213,14 +213,6 @@ public:
       return k;
     }
 
-    void debugOut() {
-      std::cout << "vertex_t size: " << getSize() << std::endl;
-
-      for (unsigned int i = 0; i < getSize(); ++i) {
-        std::cout << " z = " << zvtx[i] << " t = " << tvtx[i] << " rho = " << rho[i] << std::endl;
-      }
-    }
-
     // pointers to the first element of vectors, needed for vectorized code
     double *__restrict__ zvtx;
     double *__restrict__ tvtx;
@@ -267,7 +259,7 @@ public:
   std::vector<std::vector<reco::TransientTrack> > clusterize(
       const std::vector<reco::TransientTrack> &tracks) const override;
 
-  std::vector<TransientVertex> vertices(const std::vector<reco::TransientTrack> &tracks, const int verbosity = 0) const;
+  std::vector<TransientVertex> vertices(const std::vector<reco::TransientTrack> &tracks) const;
 
   track_t fill(const std::vector<reco::TransientTrack> &tracks) const;
 
@@ -278,7 +270,8 @@ public:
   unsigned int thermalize(
       double beta, track_t &gtracks, vertex_t &gvertices, const double delta_max, const double rho0 = 0.) const;
 
-  double update(double beta, track_t &gtracks, vertex_t &gvertices, const double rho0 = 0) const;
+  double update(
+      double beta, track_t &gtracks, vertex_t &gvertices, const double rho0 = 0, const bool updateTc = false) const;
 
   void dump(const double beta, const vertex_t &y, const track_t &tks, const int verbosity = 0) const;
   bool zorder(vertex_t &y) const;
@@ -293,7 +286,6 @@ public:
   void verify(const vertex_t &v, const track_t &tks, unsigned int nv = 999999, unsigned int nt = 999999) const;
 
 private:
-  bool verbose_;
   double zdumpcenter_;
   double zdumpwidth_;
 

--- a/RecoVertex/PrimaryVertexProducer/interface/DAClusterizerInZ_vect.h
+++ b/RecoVertex/PrimaryVertexProducer/interface/DAClusterizerInZ_vect.h
@@ -1,5 +1,5 @@
-#ifndef DAClusterizerInZ_vect_h
-#define DAClusterizerInZ_vect_h
+#ifndef RecoVertex_PrimaryVertexProducer_DAClusterizerInZ_vect_h
+#define RecoVertex_PrimaryVertexProducer_DAClusterizerInZ_vect_h
 
 /**\class DAClusterizerInZ_vect
 
@@ -23,7 +23,7 @@ public:
   struct track_t {
     std::vector<double> zpca_vec;                  // z-coordinate at point of closest approach to the beamline
     std::vector<double> dz2_vec;                   // square of the error of z(pca)
-    std::vector<double> Z_sum_vec;                 // track contribution to the partition function, Z
+    std::vector<double> sum_Z_vec;                 // track contribution to the partition function, Z
     std::vector<double> tkwt_vec;                  // track weight, close to 1.0 for most tracks
     std::vector<unsigned int> kmin;                // index of the first cluster within zrange
     std::vector<unsigned int> kmax;                // 1 + index of the last cluster within zrange
@@ -45,7 +45,7 @@ public:
       dz2_vec.insert(dz2_vec.begin() + i, new_dz2);
       tt.insert(tt.begin() + i, new_tt);
       tkwt_vec.insert(tkwt_vec.begin() + i, new_tkwt);
-      Z_sum_vec.insert(Z_sum_vec.begin() + i, 1.0);
+      sum_Z_vec.insert(sum_Z_vec.begin() + i, 1.0);
       kmin.insert(kmin.begin() + i, 0);
       kmax.insert(kmax.begin() + i, 0);
     }
@@ -57,14 +57,14 @@ public:
       zpca = &zpca_vec.front();
       dz2 = &dz2_vec.front();
       tkwt = &tkwt_vec.front();
-      Z_sum = &Z_sum_vec.front();
+      sum_Z = &sum_Z_vec.front();
     }
 
     // pointers to the first element of vectors, needed for vectorized code
     double *__restrict__ zpca;
     double *__restrict__ dz2;
     double *__restrict__ tkwt;
-    double *__restrict__ Z_sum;
+    double *__restrict__ sum_Z;
   };
 
   // internal data structure for clusters
@@ -142,14 +142,6 @@ public:
       extractRaw();
     }
 
-    void DebugOut() {
-      std::cout << "vertex_t size: " << getSize() << std::endl;
-
-      for (unsigned int i = 0; i < getSize(); ++i) {
-        std::cout << " z = " << zvtx[i] << " rho = " << rho[i] << std::endl;
-      }
-    }
-
     // pointers to the first element of vectors, needed for vectorized code
     double *__restrict__ zvtx;
     double *__restrict__ rho;
@@ -178,7 +170,7 @@ public:
   std::vector<std::vector<reco::TransientTrack> > clusterize(
       const std::vector<reco::TransientTrack> &tracks) const override;
 
-  std::vector<TransientVertex> vertices(const std::vector<reco::TransientTrack> &tracks, const int verbosity = 0) const;
+  std::vector<TransientVertex> vertices(const std::vector<reco::TransientTrack> &tracks) const;
 
   track_t fill(const std::vector<reco::TransientTrack> &tracks) const;
 
@@ -189,8 +181,8 @@ public:
   unsigned int thermalize(
       double beta, track_t &gtracks, vertex_t &gvertices, const double delta_max, const double rho0 = 0.) const;
 
-  double update(double beta, track_t &gtracks, vertex_t &gvertices, const double rho0 = 0) const;
-  double updateTc(double beta, track_t &gtracks, vertex_t &gvertices, const double rho0 = 0) const;
+  double update(
+      double beta, track_t &gtracks, vertex_t &gvertices, const double rho0 = 0, const bool updateTc = false) const;
 
   void dump(const double beta, const vertex_t &y, const track_t &tks, const int verbosity = 0) const;
   bool merge(vertex_t &y, track_t &tks, double &beta) const;
@@ -198,11 +190,9 @@ public:
   bool split(const double beta, track_t &t, vertex_t &y, double threshold = 1.) const;
 
   double beta0(const double betamax, track_t const &tks, vertex_t const &y) const;
-  double evalF(const double beta, track_t const &tks, vertex_t const &v) const;
   void verify(const vertex_t &v, const track_t &tks, unsigned int nv = 999999, unsigned int nt = 999999) const;
 
 private:
-  bool verbose_;
   double zdumpcenter_;
   double zdumpwidth_;
 

--- a/RecoVertex/PrimaryVertexProducer/interface/DAClusterizerInZ_vect.h
+++ b/RecoVertex/PrimaryVertexProducer/interface/DAClusterizerInZ_vect.h
@@ -19,118 +19,91 @@
 
 class DAClusterizerInZ_vect final : public TrackClusterizerInZ {
 public:
-  // Internal data structure to
+  // internal data structure for tracks
   struct track_t {
-    void addItem(double new_z, double new_dz2, const reco::TransientTrack *new_tt, double new_pi) {
-      z.push_back(new_z);
-      dz2.push_back(new_dz2);
-      tt.push_back(new_tt);
+    std::vector<double> zpca_vec;                  // z-coordinate at point of closest approach to the beamline
+    std::vector<double> dz2_vec;                   // square of the error of z(pca)
+    std::vector<double> Z_sum_vec;                 // track contribution to the partition function, Z
+    std::vector<double> tkwt_vec;                  // track weight, close to 1.0 for most tracks
+    std::vector<unsigned int> kmin;                // index of the first cluster within zrange
+    std::vector<unsigned int> kmax;                // 1 + index of the last cluster within zrange
+    std::vector<const reco::TransientTrack *> tt;  // a pointer to the Transient Track
 
-      pi.push_back(new_pi);  // track weight
-      Z_sum.push_back(1.0);  // Z[i]   for DA clustering, initial value as done in ::fill
-
-      kmin.push_back(0);
-      kmax.push_back(0);
-    }
-
-    void addItemSorted(double new_z, double new_dz2, const reco::TransientTrack *new_tt, double new_pi) {
+    void addItemSorted(double new_zpca, double new_dz2, const reco::TransientTrack *new_tt, double new_tkwt) {
       // sort tracks with decreasing resolution (note that dz2 = 1/sigma^2)
       unsigned int i = 0;
-      for (i = 0; i < z.size(); i++) {
-        if (new_dz2 > dz2[i])
+      for (i = 0; i < zpca_vec.size(); i++) {
+        if (new_dz2 > dz2_vec[i])
           break;
       }
-      insertItem(i, new_z, new_dz2, new_tt, new_pi);
+      insertItem(i, new_zpca, new_dz2, new_tt, new_tkwt);
     }
 
-    void insertItem(unsigned int i, double new_z, double new_dz2, const reco::TransientTrack *new_tt, double new_pi) {
-      z.insert(z.begin() + i, new_z);
-      dz2.insert(dz2.begin() + i, new_dz2);
+    void insertItem(
+        unsigned int i, double new_zpca, double new_dz2, const reco::TransientTrack *new_tt, double new_tkwt) {
+      zpca_vec.insert(zpca_vec.begin() + i, new_zpca);
+      dz2_vec.insert(dz2_vec.begin() + i, new_dz2);
       tt.insert(tt.begin() + i, new_tt);
-      pi.insert(pi.begin() + i, new_pi);  // track weight
-
-      Z_sum.insert(Z_sum.begin() + i, 1.0);  // Z[i]   for DA clustering, initial value as done in ::fill
+      tkwt_vec.insert(tkwt_vec.begin() + i, new_tkwt);
+      Z_sum_vec.insert(Z_sum_vec.begin() + i, 1.0);
       kmin.insert(kmin.begin() + i, 0);
       kmax.insert(kmax.begin() + i, 0);
     }
 
-    unsigned int getSize() const { return z.size(); }
+    unsigned int getSize() const { return zpca_vec.size(); }
 
     // has to be called everytime the items are modified
     void extractRaw() {
-      z_ptr = &z.front();
-      dz2_ptr = &dz2.front();
-      Z_sum_ptr = &Z_sum.front();
-      pi_ptr = &pi.front();
+      zpca = &zpca_vec.front();
+      dz2 = &dz2_vec.front();
+      tkwt = &tkwt_vec.front();
+      Z_sum = &Z_sum_vec.front();
     }
 
-    double *__restrict__ z_ptr;    // z-coordinate at point of closest approach to the beamline
-    double *__restrict__ dz2_ptr;  // square of the error of z(pca)
-
-    double *__restrict__ Z_sum_ptr;  // Z[i]   for DA clustering
-    double *__restrict__ pi_ptr;     // track weight
-
-    std::vector<double> z;      // z-coordinate at point of closest approach to the beamline
-    std::vector<double> dz2;    // square of the error of z(pca)
-    std::vector<double> Z_sum;  // Z[i]   for DA clustering
-    std::vector<double> pi;     // track weight
-    std::vector<unsigned int> kmin;
-    std::vector<unsigned int> kmax;
-    std::vector<const reco::TransientTrack *> tt;  // a pointer to the Transient Track
+    // pointers to the first element of vectors, needed for vectorized code
+    double *__restrict__ zpca;
+    double *__restrict__ dz2;
+    double *__restrict__ tkwt;
+    double *__restrict__ Z_sum;
   };
 
+  // internal data structure for clusters
   struct vertex_t {
-    std::vector<double> z;   //           z coordinate
-    std::vector<double> pk;  //           vertex weight for "constrained" clustering
-
+    std::vector<double> zvtx_vec;  // z coordinate
+    std::vector<double> rho_vec;   // vertex "mass" for mass-constrained clustering
     // --- temporary numbers, used during update
-    std::vector<double> ei_cache;
-    std::vector<double> ei;
-    std::vector<double> sw;
-    std::vector<double> swz;
-    std::vector<double> se;
-    std::vector<double> swE;
+    std::vector<double> exp_arg_vec;
+    std::vector<double> exp_vec;
+    std::vector<double> sw_vec;
+    std::vector<double> swz_vec;
+    std::vector<double> se_vec;
+    std::vector<double> swE_vec;
 
-    unsigned int getSize() const { return z.size(); }
+    unsigned int getSize() const { return zvtx_vec.size(); }
 
-    void addItem(double new_z, double new_pk) {
-      z.push_back(new_z);
-      pk.push_back(new_pk);
-
-      ei_cache.push_back(0.0);
-      ei.push_back(0.0);
-      sw.push_back(0.0);
-      swz.push_back(0.0);
-      se.push_back(0.0);
-      swE.push_back(0.0);
-
-      extractRaw();
-    }
-
-    void insertItem(unsigned int k, double new_z, double new_pk) {
-      z.insert(z.begin() + k, new_z);
-      pk.insert(pk.begin() + k, new_pk);
-
-      ei_cache.insert(ei_cache.begin() + k, 0.0);
-      ei.insert(ei.begin() + k, 0.0);
-      sw.insert(sw.begin() + k, 0.0);
-      swz.insert(swz.begin() + k, 0.0);
-      se.insert(se.begin() + k, 0.0);
-      swE.insert(swE.begin() + k, 0.0);
+    void addItem(double new_zvtx, double new_rho) {
+      zvtx_vec.push_back(new_zvtx);
+      rho_vec.push_back(new_rho);
+      exp_arg_vec.push_back(0.0);
+      exp_vec.push_back(0.0);
+      sw_vec.push_back(0.0);
+      swz_vec.push_back(0.0);
+      se_vec.push_back(0.0);
+      swE_vec.push_back(0.0);
 
       extractRaw();
     }
 
-    void insertItem(unsigned int k, double new_z, double new_pk, track_t &tks) {
-      z.insert(z.begin() + k, new_z);
-      pk.insert(pk.begin() + k, new_pk);
+    void insertItem(unsigned int k, double new_zvtx, double new_rho, track_t &tks) {
+      zvtx_vec.insert(zvtx_vec.begin() + k, new_zvtx);
+      rho_vec.insert(rho_vec.begin() + k, new_rho);
 
-      ei_cache.insert(ei_cache.begin() + k, 0.0);
-      ei.insert(ei.begin() + k, 0.0);
-      sw.insert(sw.begin() + k, 0.0);
-      swz.insert(swz.begin() + k, 0.0);
-      se.insert(se.begin() + k, 0.0);
-      swE.insert(swE.begin() + k, 0.0);
+      exp_arg_vec.insert(exp_arg_vec.begin() + k, 0.0);
+      exp_vec.insert(exp_vec.begin() + k, 0.0);
+      sw_vec.insert(sw_vec.begin() + k, 0.0);
+      swz_vec.insert(swz_vec.begin() + k, 0.0);
+      se_vec.insert(se_vec.begin() + k, 0.0);
+      swE_vec.insert(swE_vec.begin() + k, 0.0);
 
       // adjust vertex lists of tracks
       for (unsigned int i = 0; i < tks.getSize(); i++) {
@@ -146,15 +119,15 @@ public:
     }
 
     void removeItem(unsigned int k, track_t &tks) {
-      z.erase(z.begin() + k);
-      pk.erase(pk.begin() + k);
+      zvtx_vec.erase(zvtx_vec.begin() + k);
+      rho_vec.erase(rho_vec.begin() + k);
 
-      ei_cache.erase(ei_cache.begin() + k);
-      ei.erase(ei.begin() + k);
-      sw.erase(sw.begin() + k);
-      swz.erase(swz.begin() + k);
-      se.erase(se.begin() + k);
-      swE.erase(swE.begin() + k);
+      exp_arg_vec.erase(exp_arg_vec.begin() + k);
+      exp_vec.erase(exp_vec.begin() + k);
+      sw_vec.erase(sw_vec.begin() + k);
+      swz_vec.erase(swz_vec.begin() + k);
+      se_vec.erase(se_vec.begin() + k);
+      swE_vec.erase(swE_vec.begin() + k);
 
       // adjust vertex lists of tracks
       for (unsigned int i = 0; i < tks.getSize(); i++) {
@@ -173,32 +146,31 @@ public:
       std::cout << "vertex_t size: " << getSize() << std::endl;
 
       for (unsigned int i = 0; i < getSize(); ++i) {
-        std::cout << " z = " << z_ptr[i] << " pk = " << pk_ptr[i] << std::endl;
+        std::cout << " z = " << zvtx[i] << " rho = " << rho[i] << std::endl;
       }
     }
 
+    // pointers to the first element of vectors, needed for vectorized code
+    double *__restrict__ zvtx;
+    double *__restrict__ rho;
+    double *__restrict__ exp_arg;
+    double *__restrict__ exp;
+    double *__restrict__ sw;
+    double *__restrict__ swz;
+    double *__restrict__ se;
+    double *__restrict__ swE;
+
     // has to be called everytime the items are modified
     void extractRaw() {
-      z_ptr = &z.front();
-      pk_ptr = &pk.front();
-
-      ei_ptr = &ei.front();
-      sw_ptr = &sw.front();
-      swz_ptr = &swz.front();
-      se_ptr = &se.front();
-      swE_ptr = &swE.front();
-      ei_cache_ptr = &ei_cache.front();
+      zvtx = &zvtx_vec.front();
+      rho = &rho_vec.front();
+      exp = &exp_vec.front();
+      sw = &sw_vec.front();
+      swz = &swz_vec.front();
+      se = &se_vec.front();
+      swE = &swE_vec.front();
+      exp_arg = &exp_arg_vec.front();
     }
-
-    double *__restrict__ z_ptr;
-    double *__restrict__ pk_ptr;
-
-    double *__restrict__ ei_cache_ptr;
-    double *__restrict__ ei_ptr;
-    double *__restrict__ sw_ptr;
-    double *__restrict__ swz_ptr;
-    double *__restrict__ se_ptr;
-    double *__restrict__ swE_ptr;
   };
 
   DAClusterizerInZ_vect(const edm::ParameterSet &conf);

--- a/RecoVertex/PrimaryVertexProducer/src/DAClusterizerInZT_vect.cc
+++ b/RecoVertex/PrimaryVertexProducer/src/DAClusterizerInZT_vect.cc
@@ -398,11 +398,11 @@ double DAClusterizerInZT_vect::update(
     return ZTemp;
   };
 
-  auto kernel_calc_normalization_range = [beta, updateTc](const unsigned int track_num,
-                                                          track_t& tracks,
-                                                          vertex_t& vertices,
-                                                          const unsigned int kmin,
-                                                          const unsigned int kmax) {
+  auto kernel_calc_normalization_range = [updateTc](const unsigned int track_num,
+                                                    track_t& tracks,
+                                                    vertex_t& vertices,
+                                                    const unsigned int kmin,
+                                                    const unsigned int kmax) {
     auto tmp_trk_tkwt = tracks.tkwt[track_num];
     auto o_trk_sum_Z = 1. / tracks.sum_Z[track_num];
     auto o_trk_err_z = tracks.dz2[track_num];

--- a/RecoVertex/PrimaryVertexProducer/src/DAClusterizerInZT_vect.cc
+++ b/RecoVertex/PrimaryVertexProducer/src/DAClusterizerInZT_vect.cc
@@ -17,8 +17,6 @@ using namespace std;
 #define DEBUGLEVEL 0
 #endif
 
-//#define USEVTXDT2
-
 DAClusterizerInZT_vect::DAClusterizerInZT_vect(const edm::ParameterSet& conf) {
   // hardcoded parameters
   maxIterations_ = 1000;
@@ -74,27 +72,28 @@ DAClusterizerInZT_vect::DAClusterizerInZT_vect(const edm::ParameterSet& conf) {
 
   if (convergence_mode_ > 1) {
     edm::LogWarning("DAClusterizerinZT_vect")
-        << "DAClusterizerInZT_vect: invalid convergence_mode" << convergence_mode_ << "  reset to default " << 0;
+        << "DAClusterizerInZT_vect: invalid convergence_mode " << convergence_mode_ << "  reset to default " << 0;
     convergence_mode_ = 0;
   }
 
   if (minT == 0) {
+    betamax_ = 1.0;
     edm::LogWarning("DAClusterizerinZT_vect")
-        << "DAClusterizerInZT_vect: invalid Tmin" << minT << "  reset to default " << 1. / betamax_;
+        << "DAClusterizerInZT_vect: invalid Tmin " << minT << "  reset to default " << 1. / betamax_;
   } else {
     betamax_ = 1. / minT;
   }
 
   if ((purgeT > minT) || (purgeT == 0)) {
     edm::LogWarning("DAClusterizerinZT_vect")
-        << "DAClusterizerInZT_vect: invalid Tpurge" << purgeT << "  set to " << minT;
+        << "DAClusterizerInZT_vect: invalid Tpurge " << purgeT << "  set to " << minT;
     purgeT = minT;
   }
   betapurge_ = 1. / purgeT;
 
   if ((stopT > purgeT) || (stopT == 0)) {
     edm::LogWarning("DAClusterizerinZT_vect")
-        << "DAClusterizerInZT_vect: invalid Tstop" << stopT << "  set to  " << max(1., purgeT);
+        << "DAClusterizerInZT_vect: invalid Tstop " << stopT << "  set to  " << max(1., purgeT);
     stopT = max(1., purgeT);
   }
   betastop_ = 1. / stopT;
@@ -132,71 +131,68 @@ void DAClusterizerInZT_vect::verify(const vertex_t& v, const track_t& tks, unsig
   }
 
   // clusters
-  assert(v.z.size() == nv);
-  assert(v.t.size() == nv);
+  assert(v.zvtx_vec.size() == nv);
+  assert(v.tvtx_vec.size() == nv);
 #ifdef USEVTXDT2
-  assert(v.dt2.size() == nv);
+  assert(v.dt2_vec.size() == nv);
+  assert(v.sumw_vec.size() == nv);
 #endif
-  assert(v.sumw.size() == nv);
-  assert(v.pk.size() == nv);
-  assert(v.swz.size() == nv);
-  assert(v.swt.size() == nv);
-  assert(v.ei_cache.size() == nv);
-  assert(v.ei.size() == nv);
-  assert(v.se.size() == nv);
-  assert(v.nuz.size() == nv);
-  assert(v.nut.size() == nv);
-  assert(v.szz.size() == nv);
-  assert(v.stt.size() == nv);
-  assert(v.szt.size() == nv);
+  assert(v.rho_vec.size() == nv);
+  assert(v.swz_vec.size() == nv);
+  assert(v.swt_vec.size() == nv);
+  assert(v.exp_arg_vec.size() == nv);
+  assert(v.exp_vec.size() == nv);
+  assert(v.se_vec.size() == nv);
+  assert(v.nuz_vec.size() == nv);
+  assert(v.nut_vec.size() == nv);
+  assert(v.szz_vec.size() == nv);
+  assert(v.stt_vec.size() == nv);
+  assert(v.szt_vec.size() == nv);
 
-  assert(v.z_ptr == &v.z.front());
-  assert(v.t_ptr == &v.t.front());
-  assert(v.pk_ptr == &v.pk.front());
-  assert(v.ei_cache_ptr == &v.ei_cache.front());
-  assert(v.swz_ptr == &v.swz.front());
-  assert(v.swt_ptr == &v.swt.front());
-  assert(v.se_ptr == &v.se.front());
-  assert(v.nuz_ptr == &v.nuz.front());
-  assert(v.nut_ptr == &v.nut.front());
-  assert(v.szz_ptr == &v.szz.front());
-  assert(v.stt_ptr == &v.stt.front());
-  assert(v.szt_ptr == &v.szt.front());
-  assert(v.sumw_ptr == &v.sumw.front());
-
+  assert(v.zvtx == &v.zvtx_vec.front());
+  assert(v.tvtx == &v.tvtx_vec.front());
+  assert(v.rho == &v.rho_vec.front());
+  assert(v.exp_arg == &v.exp_arg_vec.front());
+  assert(v.swz == &v.swz_vec.front());
+  assert(v.swt == &v.swt_vec.front());
+  assert(v.se == &v.se_vec.front());
+  assert(v.nuz == &v.nuz_vec.front());
+  assert(v.nut == &v.nut_vec.front());
+  assert(v.szz == &v.szz_vec.front());
+  assert(v.stt == &v.stt_vec.front());
+  assert(v.szt == &v.szt_vec.front());
 #ifdef USEVTXDT2
-  assert(v.dt2_ptr == &v.dt2.front());
+  assert(v.sumw == &v.sumw_vec.front());
+  assert(v.dt2 == &v.dt2_vec.front());
 #endif
 
   for (unsigned int k = 0; k < nv - 1; k++) {
-    if (v.z[k] <= v.z[k + 1])
+    if (v.zvtx[k] <= v.zvtx[k + 1])
       continue;
-    cout << " ZT, cluster z-ordering assertion failure   z[" << k << "] =" << v.z[k] << "    z[" << k + 1
-         << "] =" << v.z[k + 1] << endl;
+    cout << " ZT, cluster z-ordering assertion failure   z[" << k << "] =" << v.zvtx[k] << "    z[" << k + 1
+         << "] =" << v.zvtx[k + 1] << endl;
   }
   //for(unsigned int k=0; k< nv-1; k++){
   //assert( v.z[k] <= v.z[k+1]);
   //}
 
   // tracks
-  assert(nt == tks.z.size());
-  assert(nt == tks.t.size());
-  assert(nt == tks.dz2.size());
-#ifdef USEVTXDT2
-  assert(nt == tks.dt2.size());
-#endif
+  assert(nt == tks.zpca_vec.size());
+  assert(nt == tks.tpca_vec.size());
+  assert(nt == tks.dz2_vec.size());
+  assert(nt == tks.dt2_vec.size());
   assert(nt == tks.tt.size());
-  assert(nt == tks.pi.size());
-  assert(nt == tks.Z_sum.size());
+  assert(nt == tks.tkwt_vec.size());
+  assert(nt == tks.Z_sum_vec.size());
   assert(nt == tks.kmin.size());
   assert(nt == tks.kmax.size());
 
-  assert(tks.z_ptr == &tks.z.front());
-  assert(tks.t_ptr == &tks.t.front());
-  assert(tks.dz2_ptr == &tks.dz2.front());
-  assert(tks.dt2_ptr == &tks.dt2.front());
-  assert(tks.pi_ptr == &tks.pi.front());
-  assert(tks.Z_sum_ptr == &tks.Z_sum.front());
+  assert(tks.zpca == &tks.zpca_vec.front());
+  assert(tks.tpca == &tks.tpca_vec.front());
+  assert(tks.dz2 == &tks.dz2_vec.front());
+  assert(tks.dt2 == &tks.dt2_vec.front());
+  assert(tks.tkwt == &tks.tkwt_vec.front());
+  assert(tks.Z_sum == &tks.Z_sum_vec.front());
 
   for (unsigned int i = 0; i < nt; i++) {
     if ((tks.kmin[i] < tks.kmax[i]) && (tks.kmax[i] <= nv))
@@ -217,7 +213,7 @@ DAClusterizerInZT_vect::track_t DAClusterizerInZT_vect::fill(const vector<reco::
   for (const auto& tk : tracks) {
     if (!tk.isValid())
       continue;
-    double t_pi = 1.;
+    double t_tkwt = 1.;
     double t_z = tk.stateAtBeamLine().trackStateAtPCA().position().z();
     double t_t = tk.timeExt();
 
@@ -256,15 +252,15 @@ DAClusterizerInZT_vect::track_t DAClusterizerInZT_vect::fill(const vector<reco::
 
     if (d0CutOff_ > 0) {
       Measurement1D atIP = tk.stateAtBeamLine().transverseImpactParameter();  // error contains beamspot
-      t_pi = 1. / (1. + local_exp(std::pow(atIP.value() / atIP.error(), 2) -
-                                  std::pow(d0CutOff_, 2)));  // reduce weight for high ip tracks
-      if (edm::isNotFinite(t_pi) || t_pi < std::numeric_limits<double>::epsilon()) {
-        std::cout << "DAClusterizerInZT_vect.fill rejected track t_pu " << t_pi << std::endl;
+      t_tkwt = 1. / (1. + local_exp(std::pow(atIP.value() / atIP.error(), 2) -
+                                    std::pow(d0CutOff_, 2)));  // reduce weight for high ip tracks
+      if (edm::isNotFinite(t_tkwt) || t_tkwt < std::numeric_limits<double>::epsilon()) {
+        std::cout << "DAClusterizerInZT_vect.fill rejected track t_tkwt " << t_tkwt << std::endl;
         continue;  // usually is > 0.99
       }
     }
 
-    tks.addItem(t_z, t_t, t_dz2, t_dt2, &tk, t_pi);
+    tks.addItem(t_z, t_t, t_dz2, t_dt2, &tk, t_tkwt);
   }
   tks.extractRaw();
 #ifdef DEBUG
@@ -294,29 +290,29 @@ void DAClusterizerInZT_vect::set_vtx_range(double beta, track_t& gtracks, vertex
   for (auto itrack = 0U; itrack < nt; ++itrack) {
     double zrange = max(sel_zrange_ / sqrt(beta * gtracks.dz2[itrack]), zrange_min_);
 
-    double zmin = gtracks.z_ptr[itrack] - zrange;
+    double zmin = gtracks.zpca[itrack] - zrange;
     unsigned int kmin = min(nv - 1, gtracks.kmin[itrack]);
     // find the smallest vertex_z that is larger than zmin
-    if (gvertices.z_ptr[kmin] > zmin) {
-      while ((kmin > 0) && (gvertices.z_ptr[kmin - 1] > zmin)) {
+    if (gvertices.zvtx[kmin] > zmin) {
+      while ((kmin > 0) && (gvertices.zvtx[kmin - 1] > zmin)) {
         kmin--;
       }
     } else {
-      while ((kmin < (nv - 1)) && (gvertices.z_ptr[kmin] < zmin)) {
+      while ((kmin < (nv - 1)) && (gvertices.zvtx[kmin] < zmin)) {
         kmin++;
       }
     }
 
-    double zmax = gtracks.z_ptr[itrack] + zrange;
+    double zmax = gtracks.zpca[itrack] + zrange;
     unsigned int kmax = min(nv - 1, gtracks.kmax[itrack] - 1);
     // note: kmax points to the last vertex in the range, while gtracks.kmax points to the entry BEHIND the last vertex
     // find the largest vertex_z that is smaller than zmax
-    if (gvertices.z_ptr[kmax] < zmax) {
-      while ((kmax < (nv - 1)) && (gvertices.z_ptr[kmax + 1] < zmax)) {
+    if (gvertices.zvtx[kmax] < zmax) {
+      while ((kmax < (nv - 1)) && (gvertices.zvtx[kmax + 1] < zmax)) {
         kmax++;
       }
     } else {
-      while ((kmax > 0) && (gvertices.z_ptr[kmax] > zmax)) {
+      while ((kmax > 0) && (gvertices.zvtx[kmax] > zmax)) {
         kmax--;
       }
     }
@@ -357,7 +353,7 @@ double DAClusterizerInZT_vect::update(double beta, track_t& gtracks, vertex_t& g
   const unsigned int nv = gvertices.getSize();
 
   //initialize sums
-  double sumpi = 0.;
+  double sumtkwt = 0.;
 
   // to return how much the prototype moved
   double delta = 0.;
@@ -376,21 +372,21 @@ double DAClusterizerInZT_vect::update(double beta, track_t& gtracks, vertex_t& g
                                           vertex_t const& vertices,
                                           const unsigned int kmin,
                                           const unsigned int kmax) {
-    const auto track_z = tracks.z_ptr[itrack];
-    const auto track_t = tracks.t_ptr[itrack];
-    const auto botrack_dz2 = -beta * tracks.dz2_ptr[itrack];
+    const auto track_z = tracks.zpca[itrack];
+    const auto track_t = tracks.tpca[itrack];
+    const auto botrack_dz2 = -beta * tracks.dz2[itrack];
 #ifndef USEVTXDT2
-    const auto botrack_dt2 = -beta * tracks.dt2_ptr[itrack];
+    const auto botrack_dt2 = -beta * tracks.dt2[itrack];
 #endif
     // auto-vectorized
     for (unsigned int ivertex = kmin; ivertex < kmax; ++ivertex) {
-      const auto mult_resz = track_z - vertices.z_ptr[ivertex];
-      const auto mult_rest = track_t - vertices.t_ptr[ivertex];
+      const auto mult_resz = track_z - vertices.zvtx[ivertex];
+      const auto mult_rest = track_t - vertices.tvtx[ivertex];
 #ifdef USEVTXDT2
-      const auto botrack_dt2 = -beta * tracks.dt2_ptr[itrack] * vertices.dt2_ptr[ivertex] /
-                               (tracks.dt2_ptr[itrack] + vertices.dt2_ptr[ivertex] + 1.e-10);
+      const auto botrack_dt2 =
+          -beta * tracks.dt2[itrack] * vertices.dt2[ivertex] / (tracks.dt2[itrack] + vertices.dt2[ivertex] + 1.e-10);
 #endif
-      vertices.ei_cache_ptr[ivertex] = botrack_dz2 * (mult_resz * mult_resz) + botrack_dt2 * (mult_rest * mult_rest);
+      vertices.exp_arg[ivertex] = botrack_dz2 * (mult_resz * mult_resz) + botrack_dt2 * (mult_rest * mult_rest);
     }
   };
 
@@ -398,57 +394,57 @@ double DAClusterizerInZT_vect::update(double beta, track_t& gtracks, vertex_t& g
                                 vertex_t const& vertices, const unsigned int kmin, const unsigned int kmax) -> double {
     double ZTemp = Z_init;
     for (unsigned int ivertex = kmin; ivertex < kmax; ++ivertex) {
-      ZTemp += vertices.pk_ptr[ivertex] * vertices.ei_ptr[ivertex];
+      ZTemp += vertices.rho[ivertex] * vertices.exp[ivertex];
     }
     return ZTemp;
   };
 
   auto kernel_calc_normalization_range = [](const unsigned int track_num,
-                                            track_t& tks_vec,
-                                            vertex_t& y_vec,
+                                            track_t& tracks,
+                                            vertex_t& vertices,
                                             const unsigned int kmin,
                                             const unsigned int kmax) {
-    auto tmp_trk_pi = tks_vec.pi_ptr[track_num];
-    auto o_trk_Z_sum = 1. / tks_vec.Z_sum_ptr[track_num];
-    auto o_trk_err_z = tks_vec.dz2_ptr[track_num];
-    auto o_trk_err_t = tks_vec.dt2_ptr[track_num];
-    auto tmp_trk_z = tks_vec.z_ptr[track_num];
-    auto tmp_trk_t = tks_vec.t_ptr[track_num];
+    auto tmp_trk_tkwt = tracks.tkwt[track_num];
+    auto o_trk_Z_sum = 1. / tracks.Z_sum[track_num];
+    auto o_trk_err_z = tracks.dz2[track_num];
+    auto o_trk_err_t = tracks.dt2[track_num];
+    auto tmp_trk_z = tracks.zpca[track_num];
+    auto tmp_trk_t = tracks.tpca[track_num];
     // auto-vectorized
 #pragma GCC ivdep
     for (unsigned int k = kmin; k < kmax; ++k) {
       // parens are important for numerical stability
-      y_vec.se_ptr[k] += tmp_trk_pi * (y_vec.ei_ptr[k] * o_trk_Z_sum);
-      const auto w = tmp_trk_pi * (y_vec.pk_ptr[k] * y_vec.ei_ptr[k] * o_trk_Z_sum);  // p_{ik}
+      vertices.se[k] += tmp_trk_tkwt * (vertices.exp[k] * o_trk_Z_sum);
+      const auto w = tmp_trk_tkwt * (vertices.rho[k] * vertices.exp[k] * o_trk_Z_sum);  // p_{ik}
       const auto wz = w * o_trk_err_z;
       const auto wt = w * o_trk_err_t;
 #ifdef USEVTXDT2
-      y_vec.sumw_ptr[k] += w;  // for vtxdt2
+      vertices.sumw[k] += w;  // for vtxdt2
 #endif
-      y_vec.nuz_ptr[k] += wz;
-      y_vec.nut_ptr[k] += wt;
-      y_vec.swz_ptr[k] += wz * tmp_trk_z;
-      y_vec.swt_ptr[k] += wt * tmp_trk_t;
+      vertices.nuz[k] += wz;
+      vertices.nut[k] += wt;
+      vertices.swz[k] += wz * tmp_trk_z;
+      vertices.swt[k] += wt * tmp_trk_t;
       /* this is really only needed when we want to get Tc too, maybe better to do it elsewhere? */
-      const auto dsz = (tmp_trk_z - y_vec.z_ptr[k]) * o_trk_err_z;
-      const auto dst = (tmp_trk_t - y_vec.t_ptr[k]) * o_trk_err_t;
-      y_vec.szz_ptr[k] += w * dsz * dsz;
-      y_vec.stt_ptr[k] += w * dst * dst;
-      y_vec.szt_ptr[k] += w * dsz * dst;
+      const auto dsz = (tmp_trk_z - vertices.zvtx[k]) * o_trk_err_z;
+      const auto dst = (tmp_trk_t - vertices.tvtx[k]) * o_trk_err_t;
+      vertices.szz[k] += w * dsz * dsz;
+      vertices.stt[k] += w * dst * dst;
+      vertices.szt[k] += w * dsz * dst;
     }
   };
 
   for (auto ivertex = 0U; ivertex < nv; ++ivertex) {
-    gvertices.se_ptr[ivertex] = 0.0;
-    gvertices.nuz_ptr[ivertex] = 0.0;
-    gvertices.nut_ptr[ivertex] = 0.0;
-    gvertices.swz_ptr[ivertex] = 0.0;
-    gvertices.swt_ptr[ivertex] = 0.0;
-    gvertices.szz_ptr[ivertex] = 0.0;
-    gvertices.stt_ptr[ivertex] = 0.0;
-    gvertices.szt_ptr[ivertex] = 0.0;
+    gvertices.se[ivertex] = 0.0;
+    gvertices.nuz[ivertex] = 0.0;
+    gvertices.nut[ivertex] = 0.0;
+    gvertices.swz[ivertex] = 0.0;
+    gvertices.swt[ivertex] = 0.0;
+    gvertices.szz[ivertex] = 0.0;
+    gvertices.stt[ivertex] = 0.0;
+    gvertices.szt[ivertex] = 0.0;
 #ifdef USEVTXDT2
-    gvertices.sumw_ptr[k] = 0.0;
+    gvertices.sumw[ivertex] = 0.0;
 #endif
   }
 
@@ -459,67 +455,67 @@ double DAClusterizerInZT_vect::update(double beta, track_t& gtracks, vertex_t& g
 
 #ifdef DEBUG
     assert((kmin < kmax) && (kmax <= nv));
-    assert(itrack < gtracks.Z_sum.size());
+    assert(itrack < gtracks.Z_sum_vec.size());
 #endif
 
     kernel_calc_exp_arg_range(itrack, gtracks, gvertices, kmin, kmax);
-    local_exp_list_range(gvertices.ei_cache_ptr, gvertices.ei_ptr, kmin, kmax);
+    local_exp_list_range(gvertices.exp_arg, gvertices.exp, kmin, kmax);
 
-    gtracks.Z_sum_ptr[itrack] = kernel_add_Z_range(gvertices, kmin, kmax);
-    if (edm::isNotFinite(gtracks.Z_sum_ptr[itrack]))
-      gtracks.Z_sum_ptr[itrack] = 0.0;
+    gtracks.Z_sum[itrack] = kernel_add_Z_range(gvertices, kmin, kmax);
+    if (edm::isNotFinite(gtracks.Z_sum[itrack]))
+      gtracks.Z_sum[itrack] = 0.0;
     // used in the next major loop to follow
-    sumpi += gtracks.pi_ptr[itrack];
+    sumtkwt += gtracks.tkwt[itrack];
 
-    if (gtracks.Z_sum_ptr[itrack] > 1.e-100) {
+    if (gtracks.Z_sum[itrack] > 1.e-100) {
       kernel_calc_normalization_range(itrack, gtracks, gvertices, kmin, kmax);
     }
   }
 
-  // now update z, t, and pk
-  auto kernel_calc_zt = [sumpi, nv](vertex_t& vertices) -> double {
+  // now update z, t, and rho
+  auto kernel_calc_zt = [sumtkwt, nv](vertex_t& vertices) -> double {
     double delta = 0;
 
-    // does not vectorizes
+    // does not vectorize
     for (unsigned int ivertex = 0; ivertex < nv; ++ivertex) {
-      if (vertices.nuz_ptr[ivertex] > 0.) {
-        auto znew = vertices.swz_ptr[ivertex] / vertices.nuz_ptr[ivertex];
-        delta = max(std::abs(vertices.z_ptr[ivertex] - znew), delta);
-        vertices.z_ptr[ivertex] = znew;
+      if (vertices.nuz[ivertex] > 0.) {
+        auto znew = vertices.swz[ivertex] / vertices.nuz[ivertex];
+        delta = max(std::abs(vertices.zvtx[ivertex] - znew), delta);
+        vertices.zvtx[ivertex] = znew;
       }
 
-      if (vertices.nut_ptr[ivertex] > 0.) {
-        auto tnew = vertices.swt_ptr[ivertex] / vertices.nut_ptr[ivertex];
-        //delta = max(std::abs(vertices.t_ptr[ ivertex ] - tnew), delta); // FIXME
-        vertices.t_ptr[ivertex] = tnew;
+      if (vertices.nut[ivertex] > 0.) {
+        auto tnew = vertices.swt[ivertex] / vertices.nut[ivertex];
+        //delta = max(std::abs(vertices.t[ ivertex ] - tnew), delta); // FIXME
+        vertices.tvtx[ivertex] = tnew;
 #ifdef USEVTXDT2
-        vertices.dt2_ptr[ivertex] = vertices.nut_ptr[ivertex] / vertices.sumw_ptr[ivertex];
+        vertices.dt2[ivertex] = vertices.nut[ivertex] / vertices.sumw[ivertex];
 #endif
       } else {
         // FIXME
         // apparently this cluster has not timing info attached
         // this should be taken into account somehow, otherwise we might fail to attach
         // new tracks that do have timing information
-        vertices.t_ptr[ivertex] = 0;
+        vertices.tvtx[ivertex] = 0;
 #ifdef USEVTXDT2
-        vertices.dt2_ptr[ivertex] = 0;
+        vertices.dt2[ivertex] = 0;
 #endif
       }
 
 #ifdef DEBUG
-      if ((vertices.nut_ptr[ivertex] <= 0.) && (vertices.nuz_ptr[ivertex] <= 0.)) {
+      if ((vertices.nut[ivertex] <= 0.) && (vertices.nuz[ivertex] <= 0.)) {
         edm::LogInfo("sumw") << "invalid sum of weights in fit: " << endl;
         std::cout << " a cluster melted away ?  "
-                  << "  zk=" << vertices.z_ptr[ivertex] << "  pk=" << vertices.pk_ptr[ivertex]
-                  << " sumw(z,t) =" << vertices.nuz_ptr[ivertex] << "," << vertices.nut_ptr[ivertex] << endl;
+                  << "  zk=" << vertices.zvtx[ivertex] << "  rho=" << vertices.rho[ivertex]
+                  << " sumw(z,t) =" << vertices.nuz[ivertex] << "," << vertices.nut[ivertex] << endl;
         // FIXME: discard this cluster
       }
 #endif
     }
 
-    auto osumpi = 1. / sumpi;
+    auto osumtkwt = 1. / sumtkwt;
     for (unsigned int ivertex = 0; ivertex < nv; ++ivertex) {
-      vertices.pk_ptr[ivertex] = vertices.pk_ptr[ivertex] * vertices.se_ptr[ivertex] * osumpi;
+      vertices.rho[ivertex] = vertices.rho[ivertex] * vertices.se[ivertex] * osumtkwt;
     }
 
     return delta;
@@ -539,10 +535,9 @@ bool DAClusterizerInZT_vect::zorder(vertex_t& y) const {
   const unsigned int nv = y.getSize();
 
 #ifdef DEBUG
-  assert(y.z.size() == nv);
-  assert(y.t.size() == nv);
-  //  assert(y.dt2.size() == nv);
-  assert(y.pk.size() == nv);
+  assert(y.zvtx_vec.size() == nv);
+  assert(y.tvtx_vec.size() == nv);
+  assert(y.rho_vec.size() == nv);
 #endif
 
   if (nv < 2)
@@ -554,21 +549,21 @@ bool DAClusterizerInZT_vect::zorder(vertex_t& y) const {
   while (reordering) {
     reordering = false;
     for (unsigned int k = 0; (k + 1) < nv; k++) {
-      if (y.z[k + 1] < y.z[k]) {
-        auto ztemp = y.z[k];
-        y.z[k] = y.z[k + 1];
-        y.z[k + 1] = ztemp;
-        auto ttemp = y.t[k];
-        y.t[k] = y.t[k + 1];
-        y.t[k + 1] = ttemp;
+      if (y.zvtx[k + 1] < y.zvtx[k]) {
+        auto ztemp = y.zvtx[k];
+        y.zvtx[k] = y.zvtx[k + 1];
+        y.zvtx[k + 1] = ztemp;
+        auto ttemp = y.tvtx[k];
+        y.tvtx[k] = y.tvtx[k + 1];
+        y.tvtx[k + 1] = ttemp;
 #ifdef USEVTXDT2
         auto dt2temp = y.dt2[k];
         y.dt2[k] = y.dt2[k + 1];
         y.dt2[k + 1] = dt2temp;
 #endif
-        auto ptemp = y.pk[k];
-        y.pk[k] = y.pk[k + 1];
-        y.pk[k + 1] = ptemp;
+        auto ptemp = y.rho[k];
+        y.rho[k] = y.rho[k + 1];
+        y.rho[k + 1] = ptemp;
         reordering = true;
       }
     }
@@ -599,7 +594,7 @@ bool DAClusterizerInZT_vect::find_nearest(
   // find nearest in z, binary search later
   unsigned int k = 0;
   for (unsigned int k0 = 1; k0 < nv; k0++) {
-    if (std::abs(y.z_ptr[k0] - z) < std::abs(y.z_ptr[k] - z)) {
+    if (std::abs(y.zvtx[k0] - z) < std::abs(y.zvtx[k] - z)) {
       k = k0;
     }
   }
@@ -608,8 +603,8 @@ bool DAClusterizerInZT_vect::find_nearest(
 
   //search left
   unsigned int k1 = k;
-  while ((k1 > 0) && ((y.z[k] - y.z[--k1]) < dz)) {
-    auto delta = std::pow((y.z_ptr[k] - y.z_ptr[k1]) / dz, 2) + std::pow((y.t_ptr[k] - y.t_ptr[k1]) / dt, 2);
+  while ((k1 > 0) && ((y.zvtx[k] - y.zvtx[--k1]) < dz)) {
+    auto delta = std::pow((y.zvtx[k] - y.zvtx[k1]) / dz, 2) + std::pow((y.tvtx[k] - y.tvtx[k1]) / dt, 2);
     if (delta < delta_min) {
       k_min = k1;
       delta_min = delta;
@@ -618,8 +613,8 @@ bool DAClusterizerInZT_vect::find_nearest(
 
   //search right
   k1 = k;
-  while (((++k1) < nv) && ((y.z[k1] - y.z[k]) < dz)) {
-    auto delta = std::pow((y.z_ptr[k1] - y.z_ptr[k]) / dz, 2) + std::pow((y.t_ptr[k1] - y.t_ptr[k]) / dt, 2);
+  while (((++k1) < nv) && ((y.zvtx[k1] - y.zvtx[k]) < dz)) {
+    auto delta = std::pow((y.zvtx[k1] - y.zvtx[k]) / dz, 2) + std::pow((y.tvtx[k1] - y.tvtx[k]) / dt, 2);
     if (delta < delta_min) {
       k_min = k1;
       delta_min = delta;
@@ -645,7 +640,7 @@ unsigned int DAClusterizerInZT_vect::thermalize(
   set_vtx_range(beta, tks, v);
 
   double delta_sum_range = 0;  // accumulate max(|delta-z|) as a lower bound
-  std::vector<double> z0 = v.z;
+  std::vector<double> z0 = v.zvtx_vec;
 
   while (niter++ < maxIterations_) {
     delta = update(beta, tks, v, rho0);
@@ -653,11 +648,11 @@ unsigned int DAClusterizerInZT_vect::thermalize(
 
     if (delta_sum_range > zrange_min_) {
       for (unsigned int k = 0; k < v.getSize(); k++) {
-        if (std::abs(v.z[k] - z0[k]) > zrange_min_) {
+        if (std::abs(v.zvtx_vec[k] - z0[k]) > zrange_min_) {
           zorder(v);
           set_vtx_range(beta, tks, v);
           delta_sum_range = 0;
-          z0 = v.z;
+          z0 = v.zvtx_vec;
           break;
         }
       }
@@ -694,9 +689,8 @@ bool DAClusterizerInZT_vect::merge(vertex_t& y, track_t& tks, double& beta) cons
 
   for (unsigned int k1 = 0; (k1 + 1) < nv; k1++) {
     unsigned int k2 = k1;
-    while ((++k2 < nv) && (std::fabs(y.z[k2] - y.z_ptr[k1]) < zmerge_)) {
-      auto delta =
-          std::pow((y.z_ptr[k2] - y.z_ptr[k1]) / zmerge_, 2) + std::pow((y.t_ptr[k2] - y.t_ptr[k1]) / tmerge_, 2);
+    while ((++k2 < nv) && (std::fabs(y.zvtx[k2] - y.zvtx[k1]) < zmerge_)) {
+      auto delta = std::pow((y.zvtx[k2] - y.zvtx[k1]) / zmerge_, 2) + std::pow((y.tvtx[k2] - y.tvtx[k1]) / tmerge_, 2);
       if ((delta < delta_min) || (k1_min == k2_min)) {
         k1_min = k1;
         k2_min = k2;
@@ -709,28 +703,28 @@ bool DAClusterizerInZT_vect::merge(vertex_t& y, track_t& tks, double& beta) cons
     return false;
   }
 
-  double rho = y.pk_ptr[k1_min] + y.pk_ptr[k2_min];
+  double rho = y.rho[k1_min] + y.rho[k2_min];
 
 #ifdef DEBUG
   assert((k1_min < nv) && (k2_min < nv));
   if (DEBUGLEVEL > 1) {
-    std::cout << "merging (" << setw(8) << fixed << setprecision(4) << y.z_ptr[k1_min] << ',' << y.t_ptr[k1_min]
-              << ") and (" << y.z_ptr[k2_min] << ',' << y.t_ptr[k2_min] << ")"
+    std::cout << "merging (" << setw(8) << fixed << setprecision(4) << y.zvtx[k1_min] << ',' << y.tvtx[k1_min]
+              << ") and (" << y.zvtx[k2_min] << ',' << y.tvtx[k2_min] << ")"
               << "  idx=" << k1_min << "," << k2_min << std::endl;
   }
 #endif
 
   if (rho > 0) {
-    y.z_ptr[k1_min] = (y.pk_ptr[k1_min] * y.z_ptr[k1_min] + y.pk_ptr[k2_min] * y.z_ptr[k2_min]) / rho;
-    y.t_ptr[k1_min] = (y.pk_ptr[k1_min] * y.t_ptr[k1_min] + y.pk_ptr[k2_min] * y.t_ptr[k2_min]) / rho;
+    y.zvtx[k1_min] = (y.rho[k1_min] * y.zvtx[k1_min] + y.rho[k2_min] * y.zvtx[k2_min]) / rho;
+    y.tvtx[k1_min] = (y.rho[k1_min] * y.tvtx[k1_min] + y.rho[k2_min] * y.tvtx[k2_min]) / rho;
 #ifdef USEVTXDT2
-    y.dt2_ptr[k1_min] = (y.pk_ptr[k1_min] * y.dt2_ptr[k1_min] + y.pk_ptr[k2_min] * y.dt2_ptr[k2_min]) / rho;
+    y.dt2[k1_min] = (y.rho[k1_min] * y.dt2[k1_min] + y.rho[k2_min] * y.dt2[k2_min]) / rho;
 #endif
   } else {
-    y.z_ptr[k1_min] = 0.5 * (y.z_ptr[k1_min] + y.z_ptr[k2_min]);
-    y.t_ptr[k1_min] = 0.5 * (y.t_ptr[k1_min] + y.t_ptr[k2_min]);
+    y.zvtx[k1_min] = 0.5 * (y.zvtx[k1_min] + y.zvtx[k2_min]);
+    y.tvtx[k1_min] = 0.5 * (y.tvtx[k1_min] + y.tvtx[k2_min]);
   }
-  y.pk_ptr[k1_min] = rho;
+  y.rho[k1_min] = rho;
   y.removeItem(k2_min, tks);
 
   zorder(y);
@@ -764,23 +758,23 @@ bool DAClusterizerInZT_vect::purge(vertex_t& y, track_t& tks, double& rho0, cons
   peik_cache = eik_cache.data();
   ppcut_cache = pcut_cache.data();
   for (unsigned i = 0; i < nt; ++i) {
-    inverse_zsums[i] = tks.Z_sum_ptr[i] > eps ? 1. / tks.Z_sum_ptr[i] : 0.0;
+    inverse_zsums[i] = tks.Z_sum[i] > eps ? 1. / tks.Z_sum[i] : 0.0;
   }
   const auto rhoconst = rho0 * local_exp(-beta * dzCutOff_ * dzCutOff_);
   for (unsigned int k = 0; k < nv; ++k) {
-    const double pmax = y.pk_ptr[k] / (y.pk_ptr[k] + rhoconst);
+    const double pmax = y.rho[k] / (y.rho[k] + rhoconst);
     ppcut_cache[k] = uniquetrkweight_ * pmax;
   }
 
   for (unsigned int k = 0; k < nv; ++k) {
     for (unsigned i = 0; i < nt; ++i) {
-      const auto track_z = tks.z_ptr[i];
-      const auto track_t = tks.t_ptr[i];
-      const auto botrack_dz2 = -beta * tks.dz2_ptr[i];
-      const auto botrack_dt2 = -beta * tks.dt2_ptr[i];  // FIXME usevtxdt2?
+      const auto track_z = tks.zpca[i];
+      const auto track_t = tks.tpca[i];
+      const auto botrack_dz2 = -beta * tks.dz2[i];
+      const auto botrack_dt2 = -beta * tks.dt2[i];  // FIXME usevtxdt2?
 
-      const auto mult_resz = track_z - y.z_ptr[k];
-      const auto mult_rest = track_t - y.t_ptr[k];
+      const auto mult_resz = track_z - y.zvtx[k];
+      const auto mult_rest = track_t - y.tvtx[k];
       parg_cache[i] = botrack_dz2 * (mult_resz * mult_resz) + botrack_dt2 * (mult_rest * mult_rest);
     }
     local_exp_list(parg_cache, peik_cache, nt);
@@ -788,9 +782,9 @@ bool DAClusterizerInZT_vect::purge(vertex_t& y, track_t& tks, double& rho0, cons
     nUnique = 0;
     sump = 0;
     for (unsigned int i = 0; i < nt; ++i) {
-      const auto p = y.pk_ptr[k] * peik_cache[i] * pinverse_zsums[i];
+      const auto p = y.rho[k] * peik_cache[i] * pinverse_zsums[i];
       sump += p;
-      nUnique += ((p > ppcut_cache[k]) & (tks.pi_ptr[i] > 0)) ? 1 : 0;
+      nUnique += ((p > ppcut_cache[k]) & (tks.tkwt[i] > 0)) ? 1 : 0;
     }
 
     if ((nUnique < 2) && (sump < sumpmin)) {
@@ -803,8 +797,8 @@ bool DAClusterizerInZT_vect::purge(vertex_t& y, track_t& tks, double& rho0, cons
 #ifdef DEBUG
     assert(k0 < y.getSize());
     if (DEBUGLEVEL > 1) {
-      std::cout << "eliminating prototype at " << std::setw(10) << std::setprecision(4) << y.z_ptr[k0] << ","
-                << y.t_ptr[k0] << " with sump=" << sumpmin << "  rho*nt =" << y.pk_ptr[k0] * nt << endl;
+      std::cout << "eliminating prototype at " << std::setw(10) << std::setprecision(4) << y.zvtx[k0] << ","
+                << y.tvtx[k0] << " with sump=" << sumpmin << "  rho*nt =" << y.rho[k0] * nt << endl;
     }
 #endif
     y.removeItem(k0, tks);
@@ -828,28 +822,28 @@ double DAClusterizerInZT_vect::beta0(double betamax, track_t const& tks, vertex_
     double sumw_z = 0;
     double sumw_t = 0;
     for (unsigned int i = 0; i < nt; i++) {
-      double w_z = tks.pi_ptr[i] * tks.dz2_ptr[i];
-      double w_t = tks.pi_ptr[i] * tks.dt2_ptr[i];
-      sumwz += w_z * tks.z_ptr[i];
-      sumwt += w_t * tks.t_ptr[i];
+      double w_z = tks.tkwt[i] * tks.dz2[i];
+      double w_t = tks.tkwt[i] * tks.dt2[i];
+      sumwz += w_z * tks.zpca[i];
+      sumwt += w_t * tks.tpca[i];
       sumw_z += w_z;
       sumw_t += w_t;
     }
-    y.z_ptr[k] = sumwz / sumw_z;
-    y.t_ptr[k] = sumwt / sumw_t;
+    y.zvtx[k] = sumwz / sumw_z;
+    y.tvtx[k] = sumwt / sumw_t;
 
     // estimate Tc, eventually do this in the same loop
     double szz = 0, stt = 0, szt = 0;
     double nuz = 0, nut = 0;
     for (unsigned int i = 0; i < nt; i++) {
-      double dz = (tks.z_ptr[i] - y.z_ptr[k]) * tks.dz2_ptr[i];
-      double dt = (tks.t_ptr[i] - y.t_ptr[k]) * tks.dt2_ptr[i];
-      double w = tks.pi_ptr[i];
+      double dz = (tks.zpca[i] - y.zvtx[k]) * tks.dz2[i];
+      double dt = (tks.tpca[i] - y.tvtx[k]) * tks.dt2[i];
+      double w = tks.tkwt[i];
       szz += w * dz * dz;
       stt += w * dt * dt;
       szt += w * dz * dt;
-      nuz += w * tks.dz2_ptr[i];
-      nut += w * tks.dt2_ptr[i];
+      nuz += w * tks.dz2[i];
+      nut += w * tks.dt2[i];
     }
     double Tz = szz / nuz;
     double Tt = 0;
@@ -883,11 +877,11 @@ double DAClusterizerInZT_vect::beta0(double betamax, track_t const& tks, vertex_
 }
 
 double DAClusterizerInZT_vect::get_Tc(const vertex_t& y, int k) const {
-  double Tz = y.szz_ptr[k] / y.nuz_ptr[k];  // actually 0.5*Tc(z)
+  double Tz = y.szz[k] / y.nuz[k];  // actually 0.5*Tc(z)
   double Tt = 0.;
-  if (y.nut_ptr[k] > 0) {
-    Tt = y.stt_ptr[k] / y.nut_ptr[k];
-    double mx = y.szt_ptr[k] / y.nuz_ptr[k] * y.szt_ptr[k] / y.nut_ptr[k];
+  if (y.nut[k] > 0) {
+    Tt = y.stt[k] / y.nut[k];
+    double mx = y.szt[k] / y.nuz[k] * y.szt[k] / y.nut[k];
     return Tz + Tt + sqrt(pow(Tz - Tt, 2) + 4 * mx);
   }
   return 2 * Tz;
@@ -925,16 +919,16 @@ bool DAClusterizerInZT_vect::split(const double beta, track_t& tks, vertex_t& y,
 
     // split direction in the (z,t)-plane
 
-    double Mzz = y.nuz_ptr[k] - twoBeta * y.szz_ptr[k];
-    double Mtt = y.nut_ptr[k] - twoBeta * y.stt_ptr[k];
-    double Mzt = -twoBeta * y.szt_ptr[k];
+    double Mzz = y.nuz[k] - twoBeta * y.szz[k];
+    double Mtt = y.nut[k] - twoBeta * y.stt[k];
+    double Mzt = -twoBeta * y.szt[k];
     const double twoMzt = 2.0 * Mzt;
     double D = sqrt(pow(Mtt - Mzz, 2) + twoMzt * twoMzt);
     double q1 = atan2(-Mtt + Mzz + D, -twoMzt);
     double l1 = 0.5 * (-Mzz - Mtt + D);
     double l2 = 0.5 * (-Mzz - Mtt - D);
     if ((std::abs(l1) < 1e-4) && (std::abs(l2) < 1e-4)) {
-      edm::LogWarning("DAClusterizerInZT_vect") << "warning, bad eigenvalues!  idx=" << k << " z= " << y.z_ptr[k]
+      edm::LogWarning("DAClusterizerInZT_vect") << "warning, bad eigenvalues!  idx=" << k << " z= " << y.zvtx[k]
                                                 << " Mzz=" << Mzz << "   Mtt=" << Mtt << "  Mzt=" << Mzt << endl;
     }
 
@@ -950,34 +944,33 @@ bool DAClusterizerInZT_vect::split(const double beta, track_t& tks, vertex_t& y,
     double p1 = 0, z1 = 0, t1 = 0, wz1 = 0, wt1 = 0;
     double p2 = 0, z2 = 0, t2 = 0, wz2 = 0, wt2 = 0;
     for (unsigned int i = 0; i < nt; ++i) {
-      if (tks.Z_sum_ptr[i] > 1.e-100) {
-        double lr = (tks.z_ptr[i] - y.z_ptr[k]) * cq + (tks.t[i] - y.t_ptr[k]) * sq;
+      if (tks.Z_sum[i] > 1.e-100) {
+        double lr = (tks.zpca[i] - y.zvtx[k]) * cq + (tks.tpca[i] - y.tvtx[k]) * sq;
         // winner-takes-all, usually overestimates splitting
         double tl = lr < 0 ? 1. : 0.;
         double tr = 1. - tl;
 
         // soften it, especially at low T
-        double arg = lr * std::sqrt(beta * (cq * cq * tks.dz2_ptr[i] + sq * sq * tks.dt2_ptr[i]));
+        double arg = lr * std::sqrt(beta * (cq * cq * tks.dz2[i] + sq * sq * tks.dt2[i]));
         if (std::abs(arg) < 20) {
           double t = local_exp(-arg);
           tl = t / (t + 1.);
           tr = 1 / (t + 1.);
         }
 
-        double p =
-            y.pk_ptr[k] * tks.pi_ptr[i] *
-            local_exp(-beta * Eik(tks.z_ptr[i], y.z_ptr[k], tks.dz2_ptr[i], tks.t_ptr[i], y.t_ptr[k], tks.dt2_ptr[i])) /
-            tks.Z_sum_ptr[i];
-        double wz = p * tks.dz2_ptr[i];
-        double wt = p * tks.dt2_ptr[i];
+        double p = y.rho[k] * tks.tkwt[i] *
+                   local_exp(-beta * Eik(tks.zpca[i], y.zvtx[k], tks.dz2[i], tks.tpca[i], y.tvtx[k], tks.dt2[i])) /
+                   tks.Z_sum[i];
+        double wz = p * tks.dz2[i];
+        double wt = p * tks.dt2[i];
         p1 += p * tl;
-        z1 += wz * tl * tks.z_ptr[i];
-        t1 += wt * tl * tks.t_ptr[i];
+        z1 += wz * tl * tks.zpca[i];
+        t1 += wt * tl * tks.tpca[i];
         wz1 += wz * tl;
         wt1 += wt * tl;
         p2 += p * tr;
-        z2 += wz * tr * tks.z_ptr[i];
-        t2 += wt * tr * tks.t_ptr[i];
+        z2 += wz * tr * tks.zpca[i];
+        t2 += wt * tr * tks.tpca[i];
         wz2 += wz * tr;
         wt2 += wt * tr;
       }
@@ -986,25 +979,25 @@ bool DAClusterizerInZT_vect::split(const double beta, track_t& tks, vertex_t& y,
     if (wz1 > 0) {
       z1 /= wz1;
     } else {
-      z1 = y.z_ptr[k] - epsilonz * cq;
+      z1 = y.zvtx[k] - epsilonz * cq;
       edm::LogWarning("DAClusterizerInZT_vect") << "warning, wz1 = " << scientific << wz1 << endl;
     }
     if (wt1 > 0) {
       t1 /= wt1;
     } else {
-      t1 = y.t_ptr[k] - epsilont * sq;
+      t1 = y.tvtx[k] - epsilont * sq;
       edm::LogWarning("DAClusterizerInZT_vect") << "warning, wt1 = " << scientific << wt1 << endl;
     }
     if (wz2 > 0) {
       z2 /= wz2;
     } else {
-      z2 = y.z_ptr[k] + epsilonz * cq;
+      z2 = y.zvtx[k] + epsilonz * cq;
       edm::LogWarning("DAClusterizerInZT_vect") << "warning, wz2 = " << scientific << wz2 << endl;
     }
     if (wt2 > 0) {
       t2 /= wt2;
     } else {
-      t2 = y.t_ptr[k] + epsilont * sq;
+      t2 = y.tvtx[k] + epsilont * sq;
       edm::LogWarning("DAClusterizerInZT_vect") << "warning, wt2 = " << scientific << wt2 << endl;
     }
 
@@ -1013,19 +1006,19 @@ bool DAClusterizerInZT_vect::split(const double beta, track_t& tks, vertex_t& y,
     while (((find_nearest(z1, t1, y, k_min1, epsilonz, epsilont) && (k_min1 != k)) ||
             (find_nearest(z2, t2, y, k_min2, epsilonz, epsilont) && (k_min2 != k))) &&
            (std::abs(z2 - z1) > spliteps || std::abs(t2 - t1) > spliteps)) {
-      z1 = 0.5 * (z1 + y.z_ptr[k]);
-      t1 = 0.5 * (t1 + y.t_ptr[k]);
-      z2 = 0.5 * (z2 + y.z_ptr[k]);
-      t2 = 0.5 * (t2 + y.t_ptr[k]);
+      z1 = 0.5 * (z1 + y.zvtx[k]);
+      t1 = 0.5 * (t1 + y.tvtx[k]);
+      z2 = 0.5 * (z2 + y.zvtx[k]);
+      t2 = 0.5 * (t2 + y.tvtx[k]);
     }
 
 #ifdef DEBUG
     assert(k < nv);
     if (DEBUGLEVEL > 1) {
-      if (std::fabs(y.z_ptr[k] - zdumpcenter_) < zdumpwidth_) {
+      if (std::fabs(y.zvtx[k] - zdumpcenter_) < zdumpwidth_) {
         std::cout << " T= " << std::setw(10) << std::setprecision(1) << 1. / beta << " Tc= " << critical[ic].first
                   << " direction =" << std::setprecision(4) << qsplit << "    splitting (" << std::setw(8) << std::fixed
-                  << std::setprecision(4) << y.z_ptr[k] << "," << y.t_ptr[k] << ")"
+                  << std::setprecision(4) << y.zvtx[k] << "," << y.tvtx[k] << ")"
                   << " --> (" << z1 << ',' << t1 << "),(" << z2 << ',' << t2 << ")     [" << p1 << "," << p2 << "]";
         if (std::fabs(z2 - z1) > epsilonz || std::fabs(t2 - t1) > epsilont) {
           std::cout << std::endl;
@@ -1053,12 +1046,12 @@ bool DAClusterizerInZT_vect::split(const double beta, track_t& tks, vertex_t& y,
     // split if the new subclusters are significantly separated
     if (std::fabs(z2 - z1) > epsilonz || std::fabs(t2 - t1) > epsilont) {
       split = true;
-      double pk1 = p1 * y.pk_ptr[k] / (p1 + p2);
-      double pk2 = p2 * y.pk_ptr[k] / (p1 + p2);
+      double rho1 = p1 * y.rho[k] / (p1 + p2);
+      double rho2 = p2 * y.rho[k] / (p1 + p2);
 
       // replace the original by (z2,t2)
       y.removeItem(k, tks);
-      unsigned int k2 = y.insertOrdered(z2, t2, pk2, tks);
+      unsigned int k2 = y.insertOrdered(z2, t2, rho2, tks);
 
 #ifdef DEBUG
       if (k2 < k) {
@@ -1079,16 +1072,15 @@ bool DAClusterizerInZT_vect::split(const double beta, track_t& tks, vertex_t& y,
       }
 
       // insert (z1,t1) where it belongs
-      unsigned int k1 = y.insertOrdered(z1, t1, pk1, tks);
+      unsigned int k1 = y.insertOrdered(z1, t1, rho1, tks);
       nv++;
 
       // adjust remaining pointers
       for (unsigned int jc = ic; jc < critical.size(); jc++) {
         if (critical[jc].second >= k1) {
           critical[jc].second++;
-        }  // need to backport the ">-"?
+        }
       }
-
     } else {
 #ifdef DEBUG
       std::cout << "warning ! split rejected, too small." << endl;
@@ -1293,40 +1285,38 @@ vector<TransientVertex> DAClusterizerInZT_vect::vertices(const vector<reco::Tran
   // ensure correct normalization of probabilities, should makes double assignment reasonably impossible
   const unsigned int nv = y.getSize();
   for (unsigned int k = 0; k < nv; k++)
-    if (edm::isNotFinite(y.pk_ptr[k]) || edm::isNotFinite(y.z_ptr[k])) {
-      y.pk_ptr[k] = 0;
-      y.z_ptr[k] = 0;
+    if (edm::isNotFinite(y.rho[k]) || edm::isNotFinite(y.zvtx[k])) {
+      y.rho[k] = 0;
+      y.zvtx[k] = 0;
     }
 
   const auto z_sum_init = rho0 * local_exp(-beta * dzCutOff_ * dzCutOff_);
   for (unsigned int i = 0; i < nt; i++)  // initialize
-    tks.Z_sum_ptr[i] = z_sum_init;
+    tks.Z_sum[i] = z_sum_init;
 
   // improve vectorization (does not require reduction ....)
   for (unsigned int k = 0; k < nv; k++) {
     for (unsigned int i = 0; i < nt; i++)
-      tks.Z_sum_ptr[i] +=
-          y.pk_ptr[k] *
-          local_exp(-beta * Eik(tks.z_ptr[i], y.z_ptr[k], tks.dz2_ptr[i], tks.t_ptr[i], y.t_ptr[k], tks.dt2_ptr[i]));
+      tks.Z_sum[i] +=
+          y.rho[k] * local_exp(-beta * Eik(tks.zpca[i], y.zvtx[k], tks.dz2[i], tks.tpca[i], y.tvtx[k], tks.dt2[i]));
   }
 
   for (unsigned int k = 0; k < nv; k++) {
-    GlobalPoint pos(0, 0, y.z_ptr[k]);
+    GlobalPoint pos(0, 0, y.zvtx[k]);
 
     vector<reco::TransientTrack> vertexTracks;
     for (unsigned int i = 0; i < nt; i++) {
-      if (tks.Z_sum_ptr[i] > 1e-100) {
-        double p =
-            y.pk_ptr[k] *
-            local_exp(-beta * Eik(tks.z_ptr[i], y.z_ptr[k], tks.dz2_ptr[i], tks.t_ptr[i], y.t_ptr[k], tks.dt2_ptr[i])) /
-            tks.Z_sum_ptr[i];
-        if ((tks.pi_ptr[i] > 0) && (p > mintrkweight_)) {
+      if (tks.Z_sum[i] > 1e-100) {
+        double p = y.rho[k] *
+                   local_exp(-beta * Eik(tks.zpca[i], y.zvtx[k], tks.dz2[i], tks.tpca[i], y.tvtx[k], tks.dt2[i])) /
+                   tks.Z_sum[i];
+        if ((tks.tkwt[i] > 0) && (p > mintrkweight_)) {
           vertexTracks.push_back(*(tks.tt[i]));
-          tks.Z_sum_ptr[i] = 0;  // setting Z=0 excludes double assignment
+          tks.Z_sum[i] = 0;  // setting Z=0 excludes double assignment
         }
       }
     }
-    TransientVertex v(pos, y.t_ptr[k], dummyError, vertexTracks, 0);
+    TransientVertex v(pos, y.tvtx[k], dummyError, vertexTracks, 0);
     clusters.push_back(v);
   }
 
@@ -1371,13 +1361,13 @@ void DAClusterizerInZT_vect::dump(const double beta, const vertex_t& y, const tr
   for (unsigned int j = 0; j < nt; j++) {
     iz.push_back(j);
   }
-  std::sort(iz.begin(), iz.end(), [tks](unsigned int a, unsigned int b) { return tks.z_ptr[a] < tks.z_ptr[b]; });
+  std::sort(iz.begin(), iz.end(), [tks](unsigned int a, unsigned int b) { return tks.zpca[a] < tks.zpca[b]; });
   std::cout << std::endl;
   std::cout << "-----DAClusterizerInZT::dump ----" << nv << "  clusters " << std::endl;
   string h = "                                                                                 ";
   std::cout << h << " k= ";
   for (unsigned int ivertex = 0; ivertex < nv; ++ivertex) {
-    if (std::fabs(y.z_ptr[ivertex] - zdumpcenter_) < zdumpwidth_) {
+    if (std::fabs(y.zvtx[ivertex] - zdumpcenter_) < zdumpwidth_) {
       std::cout << setw(8) << fixed << ivertex;
     }
   }
@@ -1386,8 +1376,8 @@ void DAClusterizerInZT_vect::dump(const double beta, const vertex_t& y, const tr
   std::cout << h << " z= ";
   std::cout << setprecision(4);
   for (unsigned int ivertex = 0; ivertex < nv; ++ivertex) {
-    if (std::fabs(y.z_ptr[ivertex] - zdumpcenter_) < zdumpwidth_) {
-      std::cout << setw(8) << fixed << y.z_ptr[ivertex];
+    if (std::fabs(y.zvtx[ivertex] - zdumpcenter_) < zdumpwidth_) {
+      std::cout << setw(8) << fixed << y.zvtx[ivertex];
     }
   }
   std::cout << endl;
@@ -1395,8 +1385,8 @@ void DAClusterizerInZT_vect::dump(const double beta, const vertex_t& y, const tr
   std::cout << h << " t= ";
   std::cout << setprecision(4);
   for (unsigned int ivertex = 0; ivertex < nv; ++ivertex) {
-    if (std::fabs(y.z_ptr[ivertex] - zdumpcenter_) < zdumpwidth_) {
-      std::cout << setw(8) << fixed << y.t_ptr[ivertex];
+    if (std::fabs(y.zvtx[ivertex] - zdumpcenter_) < zdumpwidth_) {
+      std::cout << setw(8) << fixed << y.tvtx[ivertex];
     }
   }
   std::cout << endl;
@@ -1404,29 +1394,29 @@ void DAClusterizerInZT_vect::dump(const double beta, const vertex_t& y, const tr
   std::cout << "T=" << setw(15) << 1. / beta << " Tmin =" << setw(10) << 1. / betamax_
             << "                                               Tc= ";
   for (unsigned int ivertex = 0; ivertex < nv; ++ivertex) {
-    if (std::fabs(y.z_ptr[ivertex] - zdumpcenter_) < zdumpwidth_) {
+    if (std::fabs(y.zvtx[ivertex] - zdumpcenter_) < zdumpwidth_) {
       double Tc = get_Tc(y, ivertex);
       std::cout << setw(8) << fixed << setprecision(1) << Tc;
     }
   }
   std::cout << endl;
 
-  std::cout << h << "pk= ";
-  double sumpk = 0;
+  std::cout << h << "rho= ";
+  double sumrho = 0;
   for (unsigned int ivertex = 0; ivertex < nv; ++ivertex) {
-    sumpk += y.pk_ptr[ivertex];
-    if (std::fabs(y.z_ptr[ivertex] - zdumpcenter_) > zdumpwidth_)
+    sumrho += y.rho[ivertex];
+    if (std::fabs(y.zvtx[ivertex] - zdumpcenter_) > zdumpwidth_)
       continue;
-    std::cout << setw(8) << setprecision(4) << fixed << y.pk_ptr[ivertex];
+    std::cout << setw(8) << setprecision(4) << fixed << y.rho[ivertex];
   }
   std::cout << endl;
 
   std::cout << h << "nt= ";
   for (unsigned int ivertex = 0; ivertex < nv; ++ivertex) {
-    sumpk += y.pk_ptr[ivertex];
-    if (std::fabs(y.z_ptr[ivertex] - zdumpcenter_) > zdumpwidth_)
+    sumrho += y.rho[ivertex];
+    if (std::fabs(y.zvtx[ivertex] - zdumpcenter_) > zdumpwidth_)
       continue;
-    std::cout << setw(8) << setprecision(1) << fixed << y.pk_ptr[ivertex] * nt;
+    std::cout << setw(8) << setprecision(1) << fixed << y.rho[ivertex] * nt;
   }
   std::cout << endl;
 
@@ -1438,19 +1428,18 @@ void DAClusterizerInZT_vect::dump(const double beta, const vertex_t& y, const tr
     std::cout << setprecision(4);
     for (unsigned int i0 = 0; i0 < nt; i0++) {
       unsigned int i = iz[i0];
-      if (tks.Z_sum_ptr[i] > 0) {
-        F -= std::log(tks.Z_sum_ptr[i]) / beta;
+      if (tks.Z_sum[i] > 0) {
+        F -= std::log(tks.Z_sum[i]) / beta;
       }
-      double tz = tks.z_ptr[i];
+      double tz = tks.zpca[i];
 
       if (std::fabs(tz - zdumpcenter_) > zdumpwidth_)
         continue;
       std::cout << setw(4) << i << ")" << setw(8) << fixed << setprecision(4) << tz << " +/-" << setw(6)
-                << sqrt(1. / tks.dz2_ptr[i]);
+                << sqrt(1. / tks.dz2[i]);
 
-      if (tks.dt2_ptr[i] > 0) {
-        std::cout << setw(8) << fixed << setprecision(4) << tks.t_ptr[i] << " +/-" << setw(6)
-                  << sqrt(1. / tks.dt2_ptr[i]);
+      if (tks.dt2[i] > 0) {
+        std::cout << setw(8) << fixed << setprecision(4) << tks.tpca[i] << " +/-" << setw(6) << sqrt(1. / tks.dt2[i]);
       } else {
         std::cout << "                  ";
       }
@@ -1486,16 +1475,15 @@ void DAClusterizerInZT_vect::dump(const double beta, const vertex_t& y, const tr
 
       double sump = 0.;
       for (unsigned int ivertex = 0; ivertex < nv; ++ivertex) {
-        if (std::fabs(y.z_ptr[ivertex] - zdumpcenter_) > zdumpwidth_)
+        if (std::fabs(y.zvtx[ivertex] - zdumpcenter_) > zdumpwidth_)
           continue;
 
-        if ((tks.pi_ptr[i] > 0) && (tks.Z_sum_ptr[i] > 0)) {
+        if ((tks.tkwt[i] > 0) && (tks.Z_sum[i] > 0)) {
           double p =
-              y.pk_ptr[ivertex] *
-              local_exp(
-                  -beta *
-                  Eik(tks.z_ptr[i], y.z_ptr[ivertex], tks.dz2_ptr[i], tks.t_ptr[i], y.t_ptr[ivertex], tks.dt2_ptr[i])) /
-              tks.Z_sum_ptr[i];
+              y.rho[ivertex] *
+              local_exp(-beta *
+                        Eik(tks.zpca[i], y.zvtx[ivertex], tks.dz2[i], tks.tpca[i], y.tvtx[ivertex], tks.dt2[i])) /
+              tks.Z_sum[i];
 
           if ((ivertex >= tks.kmin[i]) && (ivertex < tks.kmax[i])) {
             if (p > 0.0001) {
@@ -1503,8 +1491,7 @@ void DAClusterizerInZT_vect::dump(const double beta, const vertex_t& y, const tr
             } else {
               std::cout << "    _   ";  // tiny but in the cluster list
             }
-            E +=
-                p * Eik(tks.z_ptr[i], y.z_ptr[ivertex], tks.dz2_ptr[i], tks.t_ptr[i], y.t_ptr[ivertex], tks.dt2_ptr[i]);
+            E += p * Eik(tks.zpca[i], y.zvtx[ivertex], tks.dz2[i], tks.tpca[i], y.tvtx[ivertex], tks.dt2[i]);
             sump += p;
           } else {
             if (p > 0.1) {
@@ -1524,7 +1511,7 @@ void DAClusterizerInZT_vect::dump(const double beta, const vertex_t& y, const tr
     }
     std::cout << "                                                                                    ";
     for (unsigned int ivertex = 0; ivertex < nv; ++ivertex) {
-      if (std::fabs(y.z_ptr[ivertex] - zdumpcenter_) < zdumpwidth_) {
+      if (std::fabs(y.zvtx[ivertex] - zdumpcenter_) < zdumpwidth_) {
         std::cout << "   " << setw(3) << ivertex << "  ";
       }
     }
@@ -1532,8 +1519,8 @@ void DAClusterizerInZT_vect::dump(const double beta, const vertex_t& y, const tr
     std::cout << "                                                                                 z= ";
     std::cout << setprecision(4);
     for (unsigned int ivertex = 0; ivertex < nv; ++ivertex) {
-      if (std::fabs(y.z_ptr[ivertex] - zdumpcenter_) < zdumpwidth_) {
-        std::cout << setw(8) << fixed << y.z_ptr[ivertex];
+      if (std::fabs(y.zvtx[ivertex] - zdumpcenter_) < zdumpwidth_) {
+        std::cout << setw(8) << fixed << y.zvtx[ivertex];
       }
     }
     std::cout << endl;

--- a/RecoVertex/PrimaryVertexProducer/src/DAClusterizerInZT_vect.cc
+++ b/RecoVertex/PrimaryVertexProducer/src/DAClusterizerInZT_vect.cc
@@ -23,9 +23,10 @@ DAClusterizerInZT_vect::DAClusterizerInZT_vect(const edm::ParameterSet& conf) {
   mintrkweight_ = 0.5;
 
   // configurable debug output
-  verbose_ = conf.getUntrackedParameter<bool>("verbose", false);
+#ifdef DEBUG
   zdumpcenter_ = conf.getUntrackedParameter<double>("zdumpcenter", 0.);
   zdumpwidth_ = conf.getUntrackedParameter<double>("zdumpwidth", 20.);
+#endif
 
   // configurable parameters
   double minT = conf.getParameter<double>("Tmin");
@@ -41,32 +42,29 @@ DAClusterizerInZT_vect::DAClusterizerInZT_vect(const edm::ParameterSet& conf) {
   uniquetrkweight_ = conf.getParameter<double>("uniquetrkweight");
   zmerge_ = conf.getParameter<double>("zmerge");
   tmerge_ = conf.getParameter<double>("tmerge");
-
   sel_zrange_ = conf.getParameter<double>("zrange");
   convergence_mode_ = conf.getParameter<int>("convergence_mode");
   delta_lowT_ = conf.getParameter<double>("delta_lowT");
   delta_highT_ = conf.getParameter<double>("delta_highT");
 
-  if (verbose_) {
-    std::cout << "DAClusterizerInZT_vect: mintrkweight = " << mintrkweight_ << std::endl;
-    std::cout << "DAClusterizerInZT_vect: uniquetrkweight = " << uniquetrkweight_ << std::endl;
-    std::cout << "DAClusterizerInZT_vect: zmerge = " << zmerge_ << std::endl;
-    std::cout << "DAClusterizerInZT_vect: tmerge = " << tmerge_ << std::endl;
-    std::cout << "DAClusterizerInZT_vect: Tmin = " << minT << std::endl;
-    std::cout << "DAClusterizerInZT_vect: Tpurge = " << purgeT << std::endl;
-    std::cout << "DAClusterizerInZT_vect: Tstop = " << stopT << std::endl;
-    std::cout << "DAClusterizerInZT_vect: vertexSize = " << vertexSize_ << std::endl;
-    std::cout << "DAClusterizerInZT_vect: vertexSizeTime = " << vertexSizeTime_ << std::endl;
-    std::cout << "DAClusterizerInZT_vect: coolingFactor = " << coolingFactor_ << std::endl;
-    std::cout << "DAClusterizerInZT_vect: d0CutOff = " << d0CutOff_ << std::endl;
-    std::cout << "DAClusterizerInZT_vect: dzCutOff = " << dzCutOff_ << std::endl;
-    std::cout << "DAClusterizerInZT_vect: dtCutoff = " << dtCutOff_ << std::endl;
-    std::cout << "DAClusterizerInZT_vect: zrange = " << sel_zrange_ << std::endl;
-    std::cout << "DAClusterizerinZT_vect: convergence mode = " << convergence_mode_ << std::endl;
-    std::cout << "DAClusterizerinZT_vect: delta_highT = " << delta_highT_ << std::endl;
-    std::cout << "DAClusterizerinZT_vect: delta_lowT = " << delta_lowT_ << std::endl;
-  }
 #ifdef DEBUG
+  std::cout << "DAClusterizerInZT_vect: mintrkweight = " << mintrkweight_ << std::endl;
+  std::cout << "DAClusterizerInZT_vect: uniquetrkweight = " << uniquetrkweight_ << std::endl;
+  std::cout << "DAClusterizerInZT_vect: zmerge = " << zmerge_ << std::endl;
+  std::cout << "DAClusterizerInZT_vect: tmerge = " << tmerge_ << std::endl;
+  std::cout << "DAClusterizerInZT_vect: Tmin = " << minT << std::endl;
+  std::cout << "DAClusterizerInZT_vect: Tpurge = " << purgeT << std::endl;
+  std::cout << "DAClusterizerInZT_vect: Tstop = " << stopT << std::endl;
+  std::cout << "DAClusterizerInZT_vect: vertexSize = " << vertexSize_ << std::endl;
+  std::cout << "DAClusterizerInZT_vect: vertexSizeTime = " << vertexSizeTime_ << std::endl;
+  std::cout << "DAClusterizerInZT_vect: coolingFactor = " << coolingFactor_ << std::endl;
+  std::cout << "DAClusterizerInZT_vect: d0CutOff = " << d0CutOff_ << std::endl;
+  std::cout << "DAClusterizerInZT_vect: dzCutOff = " << dzCutOff_ << std::endl;
+  std::cout << "DAClusterizerInZT_vect: dtCutoff = " << dtCutOff_ << std::endl;
+  std::cout << "DAClusterizerInZT_vect: zrange = " << sel_zrange_ << std::endl;
+  std::cout << "DAClusterizerinZT_vect: convergence mode = " << convergence_mode_ << std::endl;
+  std::cout << "DAClusterizerinZT_vect: delta_highT = " << delta_highT_ << std::endl;
+  std::cout << "DAClusterizerinZT_vect: delta_lowT = " << delta_lowT_ << std::endl;
   std::cout << "DAClusterizerinZT_vect: DEBUGLEVEL " << DEBUGLEVEL << std::endl;
 #endif
 
@@ -183,7 +181,7 @@ void DAClusterizerInZT_vect::verify(const vertex_t& v, const track_t& tks, unsig
   assert(nt == tks.dt2_vec.size());
   assert(nt == tks.tt.size());
   assert(nt == tks.tkwt_vec.size());
-  assert(nt == tks.Z_sum_vec.size());
+  assert(nt == tks.sum_Z_vec.size());
   assert(nt == tks.kmin.size());
   assert(nt == tks.kmax.size());
 
@@ -192,7 +190,7 @@ void DAClusterizerInZT_vect::verify(const vertex_t& v, const track_t& tks, unsig
   assert(tks.dz2 == &tks.dz2_vec.front());
   assert(tks.dt2 == &tks.dt2_vec.front());
   assert(tks.tkwt == &tks.tkwt_vec.front());
-  assert(tks.Z_sum == &tks.Z_sum_vec.front());
+  assert(tks.sum_Z == &tks.sum_Z_vec.front());
 
   for (unsigned int i = 0; i < nt; i++) {
     if ((tks.kmin[i] < tks.kmax[i]) && (tks.kmax[i] <= nv))
@@ -233,7 +231,7 @@ DAClusterizerInZT_vect::track_t DAClusterizerInZT_vect::fill(const vector<reco::
                    + std::pow(vertexSize_, 2);  // intrinsic vertex size, safer for outliers and short lived decays
     t_dz2 = 1. / t_dz2;
     if (edm::isNotFinite(t_dz2) || t_dz2 < std::numeric_limits<double>::min()) {
-      std::cout << "DAClusterizerInZT_vect.fill rejected track t_dz2 " << t_dz2 << std::endl;
+      edm::LogWarning("DAClusterizerinZT_vect") << "rejected track t_dz2 " << t_dz2;
       continue;
     }
 
@@ -245,7 +243,7 @@ DAClusterizerInZT_vect::track_t DAClusterizerInZT_vect::fill(const vector<reco::
     } else {
       t_dt2 = 1. / t_dt2;
       if (edm::isNotFinite(t_dt2) || t_dt2 < std::numeric_limits<double>::min()) {
-        std::cout << "DAClusterizerInZT_vect.fill rejected track t_dt2 " << t_dt2 << std::endl;
+        edm::LogWarning("DAClusterizerinZT_vect") << "rejected track t_dt2 " << t_dt2;
         continue;
       }
     }
@@ -255,7 +253,7 @@ DAClusterizerInZT_vect::track_t DAClusterizerInZT_vect::fill(const vector<reco::
       t_tkwt = 1. / (1. + local_exp(std::pow(atIP.value() / atIP.error(), 2) -
                                     std::pow(d0CutOff_, 2)));  // reduce weight for high ip tracks
       if (edm::isNotFinite(t_tkwt) || t_tkwt < std::numeric_limits<double>::epsilon()) {
-        std::cout << "DAClusterizerInZT_vect.fill rejected track t_tkwt " << t_tkwt << std::endl;
+        edm::LogWarning("DAClusterizerinZT_vect") << "rejected track t_tkwt " << t_tkwt;
         continue;  // usually is > 0.99
       }
     }
@@ -344,10 +342,11 @@ void DAClusterizerInZT_vect::clear_vtx_range(track_t& gtracks, vertex_t& gvertic
   }
 }
 
-double DAClusterizerInZT_vect::update(double beta, track_t& gtracks, vertex_t& gvertices, const double rho0) const {
+double DAClusterizerInZT_vect::update(
+    double beta, track_t& gtracks, vertex_t& gvertices, const double rho0, const bool updateTc) const {
   //update weights and vertex positions
-  // mass constrained annealing without noise
   // returns the maximum of changes of vertex positions
+  // sums needed for Tc are only updated if updateTC == true
 
   const unsigned int nt = gtracks.getSize();
   const unsigned int nv = gvertices.getSize();
@@ -399,38 +398,55 @@ double DAClusterizerInZT_vect::update(double beta, track_t& gtracks, vertex_t& g
     return ZTemp;
   };
 
-  auto kernel_calc_normalization_range = [](const unsigned int track_num,
-                                            track_t& tracks,
-                                            vertex_t& vertices,
-                                            const unsigned int kmin,
-                                            const unsigned int kmax) {
+  auto kernel_calc_normalization_range = [beta, updateTc](const unsigned int track_num,
+                                                          track_t& tracks,
+                                                          vertex_t& vertices,
+                                                          const unsigned int kmin,
+                                                          const unsigned int kmax) {
     auto tmp_trk_tkwt = tracks.tkwt[track_num];
-    auto o_trk_Z_sum = 1. / tracks.Z_sum[track_num];
+    auto o_trk_sum_Z = 1. / tracks.sum_Z[track_num];
     auto o_trk_err_z = tracks.dz2[track_num];
     auto o_trk_err_t = tracks.dt2[track_num];
     auto tmp_trk_z = tracks.zpca[track_num];
     auto tmp_trk_t = tracks.tpca[track_num];
     // auto-vectorized
+    if (updateTc) {
 #pragma GCC ivdep
-    for (unsigned int k = kmin; k < kmax; ++k) {
-      // parens are important for numerical stability
-      vertices.se[k] += tmp_trk_tkwt * (vertices.exp[k] * o_trk_Z_sum);
-      const auto w = tmp_trk_tkwt * (vertices.rho[k] * vertices.exp[k] * o_trk_Z_sum);  // p_{ik}
-      const auto wz = w * o_trk_err_z;
-      const auto wt = w * o_trk_err_t;
+      for (unsigned int k = kmin; k < kmax; ++k) {
+        // parens are important for numerical stability
+        vertices.se[k] += tmp_trk_tkwt * (vertices.exp[k] * o_trk_sum_Z);
+        const auto w = tmp_trk_tkwt * (vertices.rho[k] * vertices.exp[k] * o_trk_sum_Z);  // p_{ik}
+        const auto wz = w * o_trk_err_z;
+        const auto wt = w * o_trk_err_t;
 #ifdef USEVTXDT2
-      vertices.sumw[k] += w;  // for vtxdt2
+        vertices.sumw[k] += w;  // for vtxdt2
 #endif
-      vertices.nuz[k] += wz;
-      vertices.nut[k] += wt;
-      vertices.swz[k] += wz * tmp_trk_z;
-      vertices.swt[k] += wt * tmp_trk_t;
-      /* this is really only needed when we want to get Tc too, maybe better to do it elsewhere? */
-      const auto dsz = (tmp_trk_z - vertices.zvtx[k]) * o_trk_err_z;
-      const auto dst = (tmp_trk_t - vertices.tvtx[k]) * o_trk_err_t;
-      vertices.szz[k] += w * dsz * dsz;
-      vertices.stt[k] += w * dst * dst;
-      vertices.szt[k] += w * dsz * dst;
+        vertices.nuz[k] += wz;
+        vertices.nut[k] += wt;
+        vertices.swz[k] += wz * tmp_trk_z;
+        vertices.swt[k] += wt * tmp_trk_t;
+        // the following lines are only needed for Tc updates
+        const auto dsz = (tmp_trk_z - vertices.zvtx[k]) * o_trk_err_z;
+        const auto dst = (tmp_trk_t - vertices.tvtx[k]) * o_trk_err_t;
+        vertices.szz[k] += w * dsz * dsz;
+        vertices.stt[k] += w * dst * dst;
+        vertices.szt[k] += w * dsz * dst;
+      }
+    } else {
+#pragma GCC ivdep
+      for (unsigned int k = kmin; k < kmax; ++k) {
+        vertices.se[k] += tmp_trk_tkwt * (vertices.exp[k] * o_trk_sum_Z);
+        const auto w = tmp_trk_tkwt * (vertices.rho[k] * vertices.exp[k] * o_trk_sum_Z);  // p_{ik}
+        const auto wz = w * o_trk_err_z;
+        const auto wt = w * o_trk_err_t;
+#ifdef USEVTXDT2
+        vertices.sumw[k] += w;  // for vtxdt2
+#endif
+        vertices.nuz[k] += wz;
+        vertices.nut[k] += wt;
+        vertices.swz[k] += wz * tmp_trk_z;
+        vertices.swt[k] += wt * tmp_trk_t;
+      }
     }
   };
 
@@ -455,19 +471,19 @@ double DAClusterizerInZT_vect::update(double beta, track_t& gtracks, vertex_t& g
 
 #ifdef DEBUG
     assert((kmin < kmax) && (kmax <= nv));
-    assert(itrack < gtracks.Z_sum_vec.size());
+    assert(itrack < gtracks.sum_Z_vec.size());
 #endif
 
     kernel_calc_exp_arg_range(itrack, gtracks, gvertices, kmin, kmax);
     local_exp_list_range(gvertices.exp_arg, gvertices.exp, kmin, kmax);
 
-    gtracks.Z_sum[itrack] = kernel_add_Z_range(gvertices, kmin, kmax);
-    if (edm::isNotFinite(gtracks.Z_sum[itrack]))
-      gtracks.Z_sum[itrack] = 0.0;
+    gtracks.sum_Z[itrack] = kernel_add_Z_range(gvertices, kmin, kmax);
+    if (edm::isNotFinite(gtracks.sum_Z[itrack]))
+      gtracks.sum_Z[itrack] = 0.0;
     // used in the next major loop to follow
     sumtkwt += gtracks.tkwt[itrack];
 
-    if (gtracks.Z_sum[itrack] > 1.e-100) {
+    if (gtracks.sum_Z[itrack] > 1.e-100) {
       kernel_calc_normalization_range(itrack, gtracks, gvertices, kmin, kmax);
     }
   }
@@ -758,7 +774,7 @@ bool DAClusterizerInZT_vect::purge(vertex_t& y, track_t& tks, double& rho0, cons
   peik_cache = eik_cache.data();
   ppcut_cache = pcut_cache.data();
   for (unsigned i = 0; i < nt; ++i) {
-    inverse_zsums[i] = tks.Z_sum[i] > eps ? 1. / tks.Z_sum[i] : 0.0;
+    inverse_zsums[i] = tks.sum_Z[i] > eps ? 1. / tks.sum_Z[i] : 0.0;
   }
   const auto rhoconst = rho0 * local_exp(-beta * dzCutOff_ * dzCutOff_);
   for (unsigned int k = 0; k < nv; ++k) {
@@ -944,7 +960,7 @@ bool DAClusterizerInZT_vect::split(const double beta, track_t& tks, vertex_t& y,
     double p1 = 0, z1 = 0, t1 = 0, wz1 = 0, wt1 = 0;
     double p2 = 0, z2 = 0, t2 = 0, wz2 = 0, wt2 = 0;
     for (unsigned int i = 0; i < nt; ++i) {
-      if (tks.Z_sum[i] > 1.e-100) {
+      if (tks.sum_Z[i] > 1.e-100) {
         double lr = (tks.zpca[i] - y.zvtx[k]) * cq + (tks.tpca[i] - y.tvtx[k]) * sq;
         // winner-takes-all, usually overestimates splitting
         double tl = lr < 0 ? 1. : 0.;
@@ -960,7 +976,7 @@ bool DAClusterizerInZT_vect::split(const double beta, track_t& tks, vertex_t& y,
 
         double p = y.rho[k] * tks.tkwt[i] *
                    local_exp(-beta * Eik(tks.zpca[i], y.zvtx[k], tks.dz2[i], tks.tpca[i], y.tvtx[k], tks.dt2[i])) /
-                   tks.Z_sum[i];
+                   tks.sum_Z[i];
         double wz = p * tks.dz2[i];
         double wt = p * tks.dt2[i];
         p1 += p * tl;
@@ -1090,8 +1106,7 @@ bool DAClusterizerInZT_vect::split(const double beta, track_t& tks, vertex_t& y,
   return split;
 }
 
-vector<TransientVertex> DAClusterizerInZT_vect::vertices(const vector<reco::TransientTrack>& tracks,
-                                                         const int verbosity) const {
+vector<TransientVertex> DAClusterizerInZT_vect::vertices(const vector<reco::TransientTrack>& tracks) const {
   track_t&& tks = fill(tracks);
   tks.extractRaw();
 
@@ -1122,11 +1137,11 @@ vector<TransientVertex> DAClusterizerInZT_vect::vertices(const vector<reco::Tran
   double betafreeze = betamax_ * sqrt(coolingFactor_);
 
   while (beta < betafreeze) {
-    update(beta, tks, y, rho0);
+    update(beta, tks, y, rho0, true);
     while (merge(y, tks, beta)) {
       if (zorder(y))
         set_vtx_range(beta, tks, y);
-      update(beta, tks, y, rho0);
+      update(beta, tks, y, rho0, true);
     }
     split(beta, tks, y);
 
@@ -1145,12 +1160,13 @@ vector<TransientVertex> DAClusterizerInZT_vect::vertices(const vector<reco::Tran
 
   zorder(y);
   set_vtx_range(beta, tks, y);
-  update(beta, tks, y, rho0);  // make sure Tc is up-to-date
+  // ZT_vect version of merge() does not use Tc, but split() does
+  update(beta, tks, y, rho0, true);
 
   while (merge(y, tks, beta)) {
     zorder(y);
     set_vtx_range(beta, tks, y);
-    update(beta, tks, y, rho0);
+    update(beta, tks, y, rho0, true);
   }
 
 #ifdef DEBUG
@@ -1169,7 +1185,7 @@ vector<TransientVertex> DAClusterizerInZT_vect::vertices(const vector<reco::Tran
     while (merge(y, tks, beta)) {
       if (zorder(y))
         set_vtx_range(beta, tks, y);
-      update(beta, tks, y, rho0);
+      update(beta, tks, y, rho0, true);  // updateTc in case we go back to split
     }
 
 #ifdef DEBUG
@@ -1292,12 +1308,12 @@ vector<TransientVertex> DAClusterizerInZT_vect::vertices(const vector<reco::Tran
 
   const auto z_sum_init = rho0 * local_exp(-beta * dzCutOff_ * dzCutOff_);
   for (unsigned int i = 0; i < nt; i++)  // initialize
-    tks.Z_sum[i] = z_sum_init;
+    tks.sum_Z[i] = z_sum_init;
 
   // improve vectorization (does not require reduction ....)
   for (unsigned int k = 0; k < nv; k++) {
     for (unsigned int i = 0; i < nt; i++)
-      tks.Z_sum[i] +=
+      tks.sum_Z[i] +=
           y.rho[k] * local_exp(-beta * Eik(tks.zpca[i], y.zvtx[k], tks.dz2[i], tks.tpca[i], y.tvtx[k], tks.dt2[i]));
   }
 
@@ -1306,13 +1322,13 @@ vector<TransientVertex> DAClusterizerInZT_vect::vertices(const vector<reco::Tran
 
     vector<reco::TransientTrack> vertexTracks;
     for (unsigned int i = 0; i < nt; i++) {
-      if (tks.Z_sum[i] > 1e-100) {
+      if (tks.sum_Z[i] > 1e-100) {
         double p = y.rho[k] *
                    local_exp(-beta * Eik(tks.zpca[i], y.zvtx[k], tks.dz2[i], tks.tpca[i], y.tvtx[k], tks.dt2[i])) /
-                   tks.Z_sum[i];
+                   tks.sum_Z[i];
         if ((tks.tkwt[i] > 0) && (p > mintrkweight_)) {
           vertexTracks.push_back(*(tks.tt[i]));
-          tks.Z_sum[i] = 0;  // setting Z=0 excludes double assignment
+          tks.sum_Z[i] = 0;  // setting Z=0 excludes double assignment
         }
       }
     }
@@ -1428,8 +1444,8 @@ void DAClusterizerInZT_vect::dump(const double beta, const vertex_t& y, const tr
     std::cout << setprecision(4);
     for (unsigned int i0 = 0; i0 < nt; i0++) {
       unsigned int i = iz[i0];
-      if (tks.Z_sum[i] > 0) {
-        F -= std::log(tks.Z_sum[i]) / beta;
+      if (tks.sum_Z[i] > 0) {
+        F -= std::log(tks.sum_Z[i]) / beta;
       }
       double tz = tks.zpca[i];
 
@@ -1478,12 +1494,12 @@ void DAClusterizerInZT_vect::dump(const double beta, const vertex_t& y, const tr
         if (std::fabs(y.zvtx[ivertex] - zdumpcenter_) > zdumpwidth_)
           continue;
 
-        if ((tks.tkwt[i] > 0) && (tks.Z_sum[i] > 0)) {
+        if ((tks.tkwt[i] > 0) && (tks.sum_Z[i] > 0)) {
           double p =
               y.rho[ivertex] *
               local_exp(-beta *
                         Eik(tks.zpca[i], y.zvtx[ivertex], tks.dz2[i], tks.tpca[i], y.tvtx[ivertex], tks.dt2[i])) /
-              tks.Z_sum[i];
+              tks.sum_Z[i];
 
           if ((ivertex >= tks.kmin[i]) && (ivertex < tks.kmax[i])) {
             if (p > 0.0001) {

--- a/RecoVertex/PrimaryVertexProducer/src/DAClusterizerInZ_vect.cc
+++ b/RecoVertex/PrimaryVertexProducer/src/DAClusterizerInZ_vect.cc
@@ -24,7 +24,7 @@ DAClusterizerInZ_vect::DAClusterizerInZ_vect(const edm::ParameterSet& conf) {
   maxIterations_ = 1000;
   mintrkweight_ = 0.5;
 
-  // configurable debug outptut debug output
+  // configurable debug outptut
   verbose_ = conf.getUntrackedParameter<bool>("verbose", false);
   zdumpcenter_ = conf.getUntrackedParameter<double>("zdumpcenter", 0.);
   zdumpwidth_ = conf.getUntrackedParameter<double>("zdumpwidth", 20.);
@@ -66,27 +66,28 @@ DAClusterizerInZ_vect::DAClusterizerInZ_vect(const edm::ParameterSet& conf) {
 
   if (convergence_mode_ > 1) {
     edm::LogWarning("DAClusterizerinZ_vect")
-        << "DAClusterizerInZ_vect: invalid convergence_mode" << convergence_mode_ << "  reset to default " << 0;
+        << "DAClusterizerInZ_vect: invalid convergence_mode " << convergence_mode_ << "  reset to default " << 0;
     convergence_mode_ = 0;
   }
 
   if (Tmin == 0) {
+    betamax_ = 1.0;
     edm::LogWarning("DAClusterizerinZ_vect")
-        << "DAClusterizerInZ_vect: invalid Tmin" << Tmin << "  reset to default " << 1. / betamax_;
+        << "DAClusterizerInZ_vect: invalid Tmin " << Tmin << "  reset to default " << 1. / betamax_;
   } else {
     betamax_ = 1. / Tmin;
   }
 
   if ((Tpurge > Tmin) || (Tpurge == 0)) {
     edm::LogWarning("DAClusterizerinZ_vect")
-        << "DAClusterizerInZ_vect: invalid Tpurge" << Tpurge << "  set to " << Tmin;
+        << "DAClusterizerInZ_vect: invalid Tpurge " << Tpurge << "  set to " << Tmin;
     Tpurge = Tmin;
   }
   betapurge_ = 1. / Tpurge;
 
   if ((Tstop > Tpurge) || (Tstop == 0)) {
     edm::LogWarning("DAClusterizerinZ_vect")
-        << "DAClusterizerInZ_vect: invalid Tstop" << Tstop << "  set to  " << max(1., Tpurge);
+        << "DAClusterizerInZ_vect: invalid Tstop " << Tstop << "  set to  " << max(1., Tpurge);
     Tstop = max(1., Tpurge);
   }
   betastop_ = 1. / Tstop;
@@ -123,44 +124,42 @@ void DAClusterizerInZ_vect::verify(const vertex_t& v, const track_t& tks, unsign
     nt = tks.getSize();
   }
 
-  assert(v.z.size() == nv);
-  assert(v.pk.size() == nv);
-  assert(v.swz.size() == nv);
-  assert(v.ei_cache.size() == nv);
-  assert(v.ei.size() == nv);
-  assert(v.se.size() == nv);
-  assert(v.swz.size() == nv);
-  assert(v.swE.size() == nv);
+  assert(v.zvtx_vec.size() == nv);
+  assert(v.rho_vec.size() == nv);
+  assert(v.swz_vec.size() == nv);
+  assert(v.exp_arg_vec.size() == nv);
+  assert(v.exp_vec.size() == nv);
+  assert(v.se_vec.size() == nv);
+  assert(v.swz_vec.size() == nv);
+  assert(v.swE_vec.size() == nv);
 
-  assert(v.z_ptr == &v.z.front());
-  assert(v.pk_ptr == &v.pk.front());
-  assert(v.ei_cache_ptr == &v.ei_cache.front());
-  assert(v.swz_ptr == &v.swz.front());
-  assert(v.se_ptr == &v.se.front());
-  assert(v.swE_ptr == &v.swE.front());
+  assert(v.zvtx == &v.zvtx_vec.front());
+  assert(v.rho == &v.rho_vec.front());
+  assert(v.exp_arg == &v.exp_arg_vec.front());
+  assert(v.sw == &v.sw_vec.front());
+  assert(v.swz == &v.swz_vec.front());
+  assert(v.se == &v.se_vec.front());
+  assert(v.swE == &v.swE_vec.front());
 
   for (unsigned int k = 0; k < nv - 1; k++) {
-    if (v.z[k] <= v.z[k + 1])
+    if (v.zvtx_vec[k] <= v.zvtx_vec[k + 1])
       continue;
-    cout << " Z, cluster z-ordering assertion failure   z[" << k << "] =" << v.z[k] << "    z[" << k + 1
-         << "] =" << v.z[k + 1] << endl;
+    cout << " Z, cluster z-ordering assertion failure   z[" << k << "] =" << v.zvtx_vec[k] << "    z[" << k + 1
+         << "] =" << v.zvtx_vec[k + 1] << endl;
   }
-  //for(unsigned int k=0; k< nv-1; k++){
-  //  assert( v.z[k] <= v.z[k+1]);
-  //}
 
-  assert(nt == tks.z.size());
-  assert(nt == tks.dz2.size());
+  assert(nt == tks.zpca_vec.size());
+  assert(nt == tks.dz2_vec.size());
   assert(nt == tks.tt.size());
-  assert(nt == tks.pi.size());
-  assert(nt == tks.Z_sum.size());
+  assert(nt == tks.tkwt_vec.size());
+  assert(nt == tks.Z_sum_vec.size());
   assert(nt == tks.kmin.size());
   assert(nt == tks.kmax.size());
 
-  assert(tks.z_ptr == &tks.z.front());
-  assert(tks.dz2_ptr == &tks.dz2.front());
-  assert(tks.pi_ptr == &tks.pi.front());
-  assert(tks.Z_sum_ptr == &tks.Z_sum.front());
+  assert(tks.zpca == &tks.zpca_vec.front());
+  assert(tks.dz2 == &tks.dz2_vec.front());
+  assert(tks.tkwt == &tks.tkwt_vec.front());
+  assert(tks.Z_sum == &tks.Z_sum_vec.front());
 
   for (unsigned int i = 0; i < nt; i++) {
     if ((tks.kmin[i] < tks.kmax[i]) && (tks.kmax[i] <= nv))
@@ -174,14 +173,13 @@ void DAClusterizerInZ_vect::verify(const vertex_t& v, const track_t& tks, unsign
   }
 }
 
-//todo: use r-value possibility of c++11 here
 DAClusterizerInZ_vect::track_t DAClusterizerInZ_vect::fill(const vector<reco::TransientTrack>& tracks) const {
   // prepare track data for clustering
   track_t tks;
   for (auto it = tracks.begin(); it != tracks.end(); it++) {
     if (!(*it).isValid())
       continue;
-    double t_pi = 1.;
+    double t_tkwt = 1.;
     double t_z = ((*it).stateAtBeamLine().trackStateAtPCA()).position().z();
     if (std::fabs(t_z) > 1000.)
       continue;
@@ -197,13 +195,13 @@ DAClusterizerInZ_vect::track_t DAClusterizerInZ_vect::fill(const vector<reco::Tr
       continue;
     if (d0CutOff_ > 0) {
       Measurement1D atIP = (*it).stateAtBeamLine().transverseImpactParameter();  // error contains beamspot
-      t_pi = 1. / (1. + local_exp(std::pow(atIP.value() / atIP.error(), 2) -
-                                  std::pow(d0CutOff_, 2)));  // reduce weight for high ip tracks
-      if (edm::isNotFinite(t_pi) || t_pi < std::numeric_limits<double>::epsilon())
+      t_tkwt = 1. / (1. + local_exp(std::pow(atIP.value() / atIP.error(), 2) -
+                                    std::pow(d0CutOff_, 2)));  // reduce weight for high ip tracks
+      if (edm::isNotFinite(t_tkwt) || t_tkwt < std::numeric_limits<double>::epsilon())
         continue;  // usually is > 0.99
     }
-    LogTrace("DAClusterizerinZ_vect") << t_z << ' ' << t_dz2 << ' ' << t_pi;
-    tks.addItemSorted(t_z, t_dz2, &(*it), t_pi);
+    LogTrace("DAClusterizerinZ_vect") << t_z << ' ' << t_dz2 << ' ' << t_tkwt;
+    tks.addItemSorted(t_z, t_dz2, &(*it), t_tkwt);
   }
 
   tks.extractRaw();
@@ -232,29 +230,29 @@ void DAClusterizerInZ_vect::set_vtx_range(double beta, track_t& gtracks, vertex_
   for (auto itrack = 0U; itrack < nt; ++itrack) {
     double zrange = max(sel_zrange_ / sqrt(beta * gtracks.dz2[itrack]), zrange_min_);
 
-    double zmin = gtracks.z[itrack] - zrange;
+    double zmin = gtracks.zpca[itrack] - zrange;
     unsigned int kmin = min(nv - 1, gtracks.kmin[itrack]);
     // find the smallest vertex_z that is larger than zmin
-    if (gvertices.z_ptr[kmin] > zmin) {
-      while ((kmin > 0) && (gvertices.z_ptr[kmin - 1] > zmin)) {
+    if (gvertices.zvtx[kmin] > zmin) {
+      while ((kmin > 0) && (gvertices.zvtx[kmin - 1] > zmin)) {
         kmin--;
       }
     } else {
-      while ((kmin < (nv - 1)) && (gvertices.z_ptr[kmin] < zmin)) {
+      while ((kmin < (nv - 1)) && (gvertices.zvtx[kmin] < zmin)) {
         kmin++;
       }
     }
 
-    double zmax = gtracks.z[itrack] + zrange;
+    double zmax = gtracks.zpca[itrack] + zrange;
     unsigned int kmax = min(nv - 1, gtracks.kmax[itrack] - 1);
     // note: kmax points to the last vertex in the range, while gtracks.kmax points to the entry BEHIND the last vertex
     // find the largest vertex_z that is smaller than zmax
-    if (gvertices.z_ptr[kmax] < zmax) {
-      while ((kmax < (nv - 1)) && (gvertices.z_ptr[kmax + 1] < zmax)) {
+    if (gvertices.zvtx[kmax] < zmax) {
+      while ((kmax < (nv - 1)) && (gvertices.zvtx[kmax + 1] < zmax)) {
         kmax++;
       }
     } else {
-      while ((kmax > 0) && (gvertices.z_ptr[kmax] > zmax)) {
+      while ((kmax > 0) && (gvertices.zvtx[kmax] > zmax)) {
         kmax--;
       }
     }
@@ -288,7 +286,7 @@ double DAClusterizerInZ_vect::update(double beta, track_t& gtracks, vertex_t& gv
   const unsigned int nv = gvertices.getSize();
 
   //initialize sums
-  double sumpi = 0;
+  double sumtkwt = 0;
 
   // to return how much the prototype moved
   double delta = 0;
@@ -306,13 +304,13 @@ double DAClusterizerInZ_vect::update(double beta, track_t& gtracks, vertex_t& gv
                                           vertex_t const& vertices,
                                           const unsigned int kmin,
                                           const unsigned int kmax) {
-    const double track_z = tracks.z_ptr[itrack];
-    const double botrack_dz2 = -beta * tracks.dz2_ptr[itrack];
+    const double track_z = tracks.zpca[itrack];
+    const double botrack_dz2 = -beta * tracks.dz2[itrack];
 
     // auto-vectorized
     for (unsigned int ivertex = kmin; ivertex < kmax; ++ivertex) {
-      auto mult_res = track_z - vertices.z_ptr[ivertex];
-      vertices.ei_cache_ptr[ivertex] = botrack_dz2 * (mult_res * mult_res);
+      auto mult_res = track_z - vertices.zvtx[ivertex];
+      vertices.exp_arg[ivertex] = botrack_dz2 * (mult_res * mult_res);
     }
   };
 
@@ -320,34 +318,34 @@ double DAClusterizerInZ_vect::update(double beta, track_t& gtracks, vertex_t& gv
                                 vertex_t const& vertices, const unsigned int kmin, const unsigned int kmax) -> double {
     double ZTemp = Z_init;
     for (unsigned int ivertex = kmin; ivertex < kmax; ++ivertex) {
-      ZTemp += vertices.pk_ptr[ivertex] * vertices.ei_ptr[ivertex];
+      ZTemp += vertices.rho[ivertex] * vertices.exp[ivertex];
     }
     return ZTemp;
   };
 
   auto kernel_calc_normalization_range = [](const unsigned int track_num,
-                                            track_t& tks_vec,
-                                            vertex_t& y_vec,
+                                            track_t& tracks,
+                                            vertex_t& vertices,
                                             const unsigned int kmin,
                                             const unsigned int kmax) {
-    auto tmp_trk_pi = tks_vec.pi_ptr[track_num];
-    auto o_trk_Z_sum = 1. / tks_vec.Z_sum_ptr[track_num];
-    auto o_trk_dz2 = tks_vec.dz2_ptr[track_num];
-    auto tmp_trk_z = tks_vec.z_ptr[track_num];
+    auto tmp_trk_tkwt = tracks.tkwt[track_num];
+    auto o_trk_Z_sum = 1. / tracks.Z_sum[track_num];
+    auto o_trk_dz2 = tracks.dz2[track_num];
+    auto tmp_trk_z = tracks.zpca[track_num];
 
     // auto-vectorized
     for (unsigned int k = kmin; k < kmax; ++k) {
-      y_vec.se_ptr[k] += y_vec.ei_ptr[k] * (tmp_trk_pi * o_trk_Z_sum);
-      auto w = y_vec.pk_ptr[k] * y_vec.ei_ptr[k] * (tmp_trk_pi * o_trk_Z_sum * o_trk_dz2);
-      y_vec.sw_ptr[k] += w;
-      y_vec.swz_ptr[k] += w * tmp_trk_z;
+      vertices.se[k] += vertices.exp[k] * (tmp_trk_tkwt * o_trk_Z_sum);
+      auto w = vertices.rho[k] * vertices.exp[k] * (tmp_trk_tkwt * o_trk_Z_sum * o_trk_dz2);
+      vertices.sw[k] += w;
+      vertices.swz[k] += w * tmp_trk_z;
     }
   };
 
   for (auto ivertex = 0U; ivertex < nv; ++ivertex) {
-    gvertices.se_ptr[ivertex] = 0.0;
-    gvertices.sw_ptr[ivertex] = 0.0;
-    gvertices.swz_ptr[ivertex] = 0.0;
+    gvertices.se[ivertex] = 0.0;
+    gvertices.sw[ivertex] = 0.0;
+    gvertices.swz[ivertex] = 0.0;
   }
 
   // loop over tracks
@@ -357,38 +355,38 @@ double DAClusterizerInZ_vect::update(double beta, track_t& gtracks, vertex_t& gv
 
 #ifdef DEBUG
     assert((kmin < kmax) && (kmax <= nv));
-    assert(itrack < gtracks.Z_sum.size());
+    assert(itrack < gtracks.Z_sum_vec.size());
 #endif
 
     kernel_calc_exp_arg_range(itrack, gtracks, gvertices, kmin, kmax);
-    local_exp_list_range(gvertices.ei_cache_ptr, gvertices.ei_ptr, kmin, kmax);
-    gtracks.Z_sum_ptr[itrack] = kernel_add_Z_range(gvertices, kmin, kmax);
+    local_exp_list_range(gvertices.exp_arg, gvertices.exp, kmin, kmax);
+    gtracks.Z_sum[itrack] = kernel_add_Z_range(gvertices, kmin, kmax);
 
-    if (edm::isNotFinite(gtracks.Z_sum_ptr[itrack]))
-      gtracks.Z_sum_ptr[itrack] = 0.0;
+    if (edm::isNotFinite(gtracks.Z_sum[itrack]))
+      gtracks.Z_sum[itrack] = 0.0;
     // used in the next major loop to follow
-    sumpi += gtracks.pi_ptr[itrack];
+    sumtkwt += gtracks.tkwt[itrack];
 
-    if (gtracks.Z_sum_ptr[itrack] > 1.e-100) {
+    if (gtracks.Z_sum[itrack] > 1.e-100) {
       kernel_calc_normalization_range(itrack, gtracks, gvertices, kmin, kmax);
     }
   }
 
-  // now update z and pk
-  auto kernel_calc_z = [sumpi, nv](vertex_t& vertices) -> double {
+  // now update vertex position and mass
+  auto kernel_calc_z = [sumtkwt, nv](vertex_t& vertices) -> double {
     double delta = 0;
     // does not vectorize(?)
     for (unsigned int ivertex = 0; ivertex < nv; ++ivertex) {
-      if (vertices.sw_ptr[ivertex] > 0) {
-        auto znew = vertices.swz_ptr[ivertex] / vertices.sw_ptr[ivertex];
-        delta = max(std::abs(vertices.z_ptr[ivertex] - znew), delta);
-        vertices.z_ptr[ivertex] = znew;
+      if (vertices.sw[ivertex] > 0) {
+        auto znew = vertices.swz[ivertex] / vertices.sw[ivertex];
+        delta = max(std::abs(vertices.zvtx[ivertex] - znew), delta);
+        vertices.zvtx[ivertex] = znew;
       }
     }
 
-    auto osumpi = 1. / sumpi;
+    auto osumtkwt = 1. / sumtkwt;
     for (unsigned int ivertex = 0; ivertex < nv; ++ivertex)
-      vertices.pk_ptr[ivertex] = vertices.pk_ptr[ivertex] * vertices.se_ptr[ivertex] * osumpi;
+      vertices.rho[ivertex] = vertices.rho[ivertex] * vertices.se[ivertex] * osumtkwt;
 
     return delta;
   };
@@ -407,7 +405,7 @@ double DAClusterizerInZ_vect::updateTc(double beta, track_t& gtracks, vertex_t& 
   const unsigned int nv = gvertices.getSize();
 
   //initialize sums
-  double sumpi = 0;
+  double sumtkwt = 0;
 
   // to return how much the prototype moved
   double delta = 0;
@@ -424,13 +422,13 @@ double DAClusterizerInZ_vect::updateTc(double beta, track_t& gtracks, vertex_t& 
                                           vertex_t const& vertices,
                                           const unsigned int kmin,
                                           const unsigned int kmax) {
-    const double track_z = tracks.z_ptr[itrack];
-    const double botrack_dz2 = -beta * tracks.dz2_ptr[itrack];
+    const double track_z = tracks.zpca[itrack];
+    const double botrack_dz2 = -beta * tracks.dz2[itrack];
 
     // auto-vectorized
     for (unsigned int ivertex = kmin; ivertex < kmax; ++ivertex) {
-      auto mult_res = track_z - vertices.z_ptr[ivertex];
-      vertices.ei_cache_ptr[ivertex] = botrack_dz2 * (mult_res * mult_res);
+      auto mult_res = track_z - vertices.zvtx[ivertex];
+      vertices.exp_arg[ivertex] = botrack_dz2 * (mult_res * mult_res);
     }
   };
 
@@ -438,37 +436,37 @@ double DAClusterizerInZ_vect::updateTc(double beta, track_t& gtracks, vertex_t& 
                                 vertex_t const& vertices, const unsigned int kmin, const unsigned int kmax) -> double {
     double ZTemp = Z_init;
     for (unsigned int ivertex = kmin; ivertex < kmax; ++ivertex) {
-      ZTemp += vertices.pk_ptr[ivertex] * vertices.ei_ptr[ivertex];
+      ZTemp += vertices.rho[ivertex] * vertices.exp[ivertex];
     }
     return ZTemp;
   };
 
   auto kernel_calc_normalization_range = [beta](const unsigned int track_num,
-                                                track_t& tks_vec,
-                                                vertex_t& y_vec,
+                                                track_t& tracks,
+                                                vertex_t& vertices,
                                                 const unsigned int kmin,
                                                 const unsigned int kmax) {
-    auto tmp_trk_pi = tks_vec.pi_ptr[track_num];
-    auto o_trk_Z_sum = 1. / tks_vec.Z_sum_ptr[track_num];
-    auto o_trk_dz2 = tks_vec.dz2_ptr[track_num];
-    auto tmp_trk_z = tks_vec.z_ptr[track_num];
+    auto tmp_trk_tkwt = tracks.tkwt[track_num];
+    auto o_trk_Z_sum = 1. / tracks.Z_sum[track_num];
+    auto o_trk_dz2 = tracks.dz2[track_num];
+    auto tmp_trk_z = tracks.zpca[track_num];
     auto obeta = -1. / beta;
 
     // auto-vectorized
     for (unsigned int k = kmin; k < kmax; ++k) {
-      y_vec.se_ptr[k] += y_vec.ei_ptr[k] * (tmp_trk_pi * o_trk_Z_sum);
-      auto w = y_vec.pk_ptr[k] * y_vec.ei_ptr[k] * (tmp_trk_pi * o_trk_Z_sum * o_trk_dz2);
-      y_vec.sw_ptr[k] += w;
-      y_vec.swz_ptr[k] += w * tmp_trk_z;
-      y_vec.swE_ptr[k] += w * y_vec.ei_cache_ptr[k] * obeta;
+      vertices.se[k] += vertices.exp[k] * (tmp_trk_tkwt * o_trk_Z_sum);
+      auto w = vertices.rho[k] * vertices.exp[k] * (tmp_trk_tkwt * o_trk_Z_sum * o_trk_dz2);
+      vertices.sw[k] += w;
+      vertices.swz[k] += w * tmp_trk_z;
+      vertices.swE[k] += w * vertices.exp_arg[k] * obeta;
     }
   };
 
   for (auto ivertex = 0U; ivertex < nv; ++ivertex) {
-    gvertices.se_ptr[ivertex] = 0.0;
-    gvertices.sw_ptr[ivertex] = 0.0;
-    gvertices.swz_ptr[ivertex] = 0.0;
-    gvertices.swE_ptr[ivertex] = 0.0;
+    gvertices.se[ivertex] = 0.0;
+    gvertices.sw[ivertex] = 0.0;
+    gvertices.swz[ivertex] = 0.0;
+    gvertices.swE[ivertex] = 0.0;
   }
 
   // loop over tracks
@@ -477,35 +475,35 @@ double DAClusterizerInZ_vect::updateTc(double beta, track_t& gtracks, vertex_t& 
     unsigned int kmax = gtracks.kmax[itrack];
 
     kernel_calc_exp_arg_range(itrack, gtracks, gvertices, kmin, kmax);
-    local_exp_list_range(gvertices.ei_cache_ptr, gvertices.ei_ptr, kmin, kmax);
-    gtracks.Z_sum_ptr[itrack] = kernel_add_Z_range(gvertices, kmin, kmax);
+    local_exp_list_range(gvertices.exp_arg, gvertices.exp, kmin, kmax);
+    gtracks.Z_sum[itrack] = kernel_add_Z_range(gvertices, kmin, kmax);
 
-    if (edm::isNotFinite(gtracks.Z_sum_ptr[itrack]))
-      gtracks.Z_sum_ptr[itrack] = 0.0;
+    if (edm::isNotFinite(gtracks.Z_sum[itrack]))
+      gtracks.Z_sum[itrack] = 0.0;
     // used in the next major loop to follow
-    sumpi += gtracks.pi_ptr[itrack];
+    sumtkwt += gtracks.tkwt[itrack];
 
-    if (gtracks.Z_sum_ptr[itrack] > 1.e-100) {
+    if (gtracks.Z_sum[itrack] > 1.e-100) {
       kernel_calc_normalization_range(itrack, gtracks, gvertices, kmin, kmax);
     }
   }
 
   // now update z and pk
-  auto kernel_calc_z = [sumpi, nv](vertex_t& vertices) -> double {
+  auto kernel_calc_z = [sumtkwt, nv](vertex_t& vertices) -> double {
     double delta = 0;
-    // does not vectorizes
+    // does not vectorize
     for (unsigned int ivertex = 0; ivertex < nv; ++ivertex) {
-      if (vertices.sw_ptr[ivertex] > 0) {
-        auto znew = vertices.swz_ptr[ivertex] / vertices.sw_ptr[ivertex];
+      if (vertices.sw[ivertex] > 0) {
+        auto znew = vertices.swz[ivertex] / vertices.sw[ivertex];
         // prevents from vectorizing if
-        delta = max(std::abs(vertices.z_ptr[ivertex] - znew), delta);
-        vertices.z_ptr[ivertex] = znew;
+        delta = max(std::abs(vertices.zvtx[ivertex] - znew), delta);
+        vertices.zvtx[ivertex] = znew;
       }
     }
 
-    auto osumpi = 1. / sumpi;
+    auto osumtkwt = 1. / sumtkwt;
     for (unsigned int ivertex = 0; ivertex < nv; ++ivertex)
-      vertices.pk_ptr[ivertex] = vertices.pk_ptr[ivertex] * vertices.se_ptr[ivertex] * osumpi;
+      vertices.rho[ivertex] = vertices.rho[ivertex] * vertices.se[ivertex] * osumtkwt;
 
     return delta;
   };
@@ -524,13 +522,13 @@ double DAClusterizerInZ_vect::evalF(const double beta, track_t const& tks, verte
   for (auto i = 0U; i < nt; i++) {
     double Z = 0;
     for (auto k = 0u; k < nv; k++) {
-      double Eik = (tks.z[k] - v.z[i]) * (tks.z[k] - v.z[i]) * tks.dz2[i];
+      double Eik = (tks.zpca_vec[k] - v.zvtx_vec[i]) * (tks.zpca_vec[k] - v.zvtx_vec[i]) * tks.dz2_vec[i];
       if ((beta * Eik) < 30) {
-        Z += v.pk[k] * local_exp(-beta * Eik);
+        Z += v.rho_vec[k] * local_exp(-beta * Eik);
       }
     }
     if (Z > 0) {
-      F += tks.pi[i] * log(Z);
+      F += tks.tkwt_vec[i] * log(Z);
     }
   }
   std::cout << "F(full) = " << -F / beta << std::endl;
@@ -551,7 +549,7 @@ unsigned int DAClusterizerInZ_vect::thermalize(
 
   set_vtx_range(beta, tks, v);
   double delta_sum_range = 0;  // accumulate max(|delta-z|) as a lower bound
-  std::vector<double> z0 = v.z;
+  std::vector<double> z0 = v.zvtx_vec;
 
   while (niter++ < maxIterations_) {
     delta = update(beta, tks, v, rho0);
@@ -559,10 +557,10 @@ unsigned int DAClusterizerInZ_vect::thermalize(
 
     if (delta_sum_range > zrange_min_) {
       for (unsigned int k = 0; k < v.getSize(); k++) {
-        if (std::abs(v.z[k] - z0[k]) > zrange_min_) {
+        if (std::abs(v.zvtx_vec[k] - z0[k]) > zrange_min_) {
           set_vtx_range(beta, tks, v);
           delta_sum_range = 0;
-          z0 = v.z;
+          z0 = v.zvtx_vec;
           break;
         }
       }
@@ -597,8 +595,8 @@ bool DAClusterizerInZ_vect::merge(vertex_t& y, track_t& tks, double& beta) const
   // merge the smallest distance clusters first
   std::vector<std::pair<double, unsigned int> > critical;
   for (unsigned int k = 0; (k + 1) < nv; k++) {
-    if (std::fabs(y.z_ptr[k + 1] - y.z_ptr[k]) < zmerge_) {
-      critical.push_back(make_pair(std::fabs(y.z_ptr[k + 1] - y.z_ptr[k]), k));
+    if (std::fabs(y.zvtx[k + 1] - y.zvtx[k]) < zmerge_) {
+      critical.push_back(make_pair(std::fabs(y.zvtx[k + 1] - y.zvtx[k]), k));
     }
   }
   if (critical.empty())
@@ -608,28 +606,27 @@ bool DAClusterizerInZ_vect::merge(vertex_t& y, track_t& tks, double& beta) const
 
   for (unsigned int ik = 0; ik < critical.size(); ik++) {
     unsigned int k = critical[ik].second;
-    double rho = y.pk_ptr[k] + y.pk_ptr[k + 1];
-    double swE = y.swE_ptr[k] + y.swE_ptr[k + 1] -
-                 y.pk_ptr[k] * y.pk_ptr[k + 1] / rho * std::pow(y.z_ptr[k + 1] - y.z_ptr[k], 2);
-    double Tc = 2 * swE / (y.sw_ptr[k] + y.sw_ptr[k + 1]);
+    double rho = y.rho[k] + y.rho[k + 1];
+    double swE = y.swE[k] + y.swE[k + 1] - y.rho[k] * y.rho[k + 1] / rho * std::pow(y.zvtx[k + 1] - y.zvtx[k], 2);
+    double Tc = 2 * swE / (y.sw[k] + y.sw[k + 1]);
 
     if (Tc * beta < 1) {
 #ifdef DEBUG
       assert((k + 1) < nv);
       if (DEBUGLEVEL > 1) {
-        std::cout << "merging " << fixed << setprecision(4) << y.z_ptr[k + 1] << " and " << y.z_ptr[k]
-                  << "  Tc = " << Tc << "  sw = " << y.sw_ptr[k] + y.sw_ptr[k + 1] << std::endl;
+        std::cout << "merging " << fixed << setprecision(4) << y.zvtx[k + 1] << " and " << y.zvtx[k] << "  Tc = " << Tc
+                  << "  sw = " << y.sw[k] + y.sw[k + 1] << std::endl;
       }
 #endif
 
       if (rho > 0) {
-        y.z_ptr[k] = (y.pk_ptr[k] * y.z_ptr[k] + y.pk_ptr[k + 1] * y.z_ptr[k + 1]) / rho;
+        y.zvtx[k] = (y.rho[k] * y.zvtx[k] + y.rho[k + 1] * y.zvtx[k + 1]) / rho;
       } else {
-        y.z_ptr[k] = 0.5 * (y.z_ptr[k] + y.z_ptr[k + 1]);
+        y.zvtx[k] = 0.5 * (y.zvtx[k] + y.zvtx[k + 1]);
       }
-      y.pk_ptr[k] = rho;
-      y.sw_ptr[k] += y.sw_ptr[k + 1];
-      y.swE_ptr[k] = swE;
+      y.rho[k] = rho;
+      y.sw[k] += y.sw[k + 1];
+      y.swE[k] = swE;
       y.removeItem(k + 1, tks);
       set_vtx_range(beta, tks, y);
       y.extractRaw();
@@ -662,19 +659,19 @@ bool DAClusterizerInZ_vect::purge(vertex_t& y, track_t& tks, double& rho0, const
   peik_cache = eik_cache.data();
   ppcut_cache = pcut_cache.data();
   for (unsigned i = 0; i < nt; ++i) {
-    inverse_zsums[i] = tks.Z_sum_ptr[i] > eps ? 1. / tks.Z_sum_ptr[i] : 0.0;
+    inverse_zsums[i] = tks.Z_sum[i] > eps ? 1. / tks.Z_sum[i] : 0.0;
   }
   const auto rhoconst = rho0 * local_exp(-beta * dzCutOff_ * dzCutOff_);
   for (unsigned int k = 0; k < nv; k++) {
-    const double pmax = y.pk_ptr[k] / (y.pk_ptr[k] + rhoconst);
+    const double pmax = y.rho[k] / (y.rho[k] + rhoconst);
     ppcut_cache[k] = uniquetrkweight_ * pmax;
   }
 
   for (unsigned int k = 0; k < nv; k++) {
     for (unsigned int i = 0; i < nt; ++i) {
-      const auto track_z = tks.z_ptr[i];
-      const auto botrack_dz2 = -beta * tks.dz2_ptr[i];
-      const auto mult_resz = track_z - y.z_ptr[k];
+      const auto track_z = tks.zpca[i];
+      const auto botrack_dz2 = -beta * tks.dz2[i];
+      const auto mult_resz = track_z - y.zvtx[k];
       parg_cache[i] = botrack_dz2 * (mult_resz * mult_resz);
     }
     local_exp_list(parg_cache, peik_cache, nt);
@@ -682,9 +679,9 @@ bool DAClusterizerInZ_vect::purge(vertex_t& y, track_t& tks, double& rho0, const
     int nUnique = 0;
     double sump = 0;
     for (unsigned int i = 0; i < nt; ++i) {
-      const auto p = y.pk_ptr[k] * peik_cache[i] * pinverse_zsums[i];
+      const auto p = y.rho[k] * peik_cache[i] * pinverse_zsums[i];
       sump += p;
-      nUnique += ((p > ppcut_cache[k]) & (tks.pi_ptr[i] > 0)) ? 1 : 0;
+      nUnique += ((p > ppcut_cache[k]) & (tks.tkwt[i] > 0)) ? 1 : 0;
     }
 
     if ((nUnique < 2) && (sump < sumpmin)) {
@@ -697,8 +694,8 @@ bool DAClusterizerInZ_vect::purge(vertex_t& y, track_t& tks, double& rho0, const
 #ifdef DEBUG
     assert(k0 < y.getSize());
     if (DEBUGLEVEL > 1) {
-      std::cout << "eliminating prototype at " << std::setw(10) << std::setprecision(4) << y.z_ptr[k0]
-                << " with sump=" << sumpmin << "  rho*nt =" << y.pk_ptr[k0] * nt << endl;
+      std::cout << "eliminating prototype at " << std::setw(10) << std::setprecision(4) << y.zvtx[k0]
+                << " with sump=" << sumpmin << "  rho*nt =" << y.rho[k0] * nt << endl;
     }
 #endif
 
@@ -721,19 +718,19 @@ double DAClusterizerInZ_vect::beta0(double betamax, track_t const& tks, vertex_t
     double sumwz = 0;
     double sumw = 0;
     for (unsigned int i = 0; i < nt; i++) {
-      double w = tks.pi_ptr[i] * tks.dz2_ptr[i];
-      sumwz += w * tks.z_ptr[i];
+      double w = tks.tkwt[i] * tks.dz2[i];
+      sumwz += w * tks.zpca[i];
       sumw += w;
     }
 
-    y.z_ptr[k] = sumwz / sumw;
+    y.zvtx[k] = sumwz / sumw;
 
     // estimate Tcrit
     double a = 0, b = 0;
     for (unsigned int i = 0; i < nt; i++) {
-      double dx = tks.z_ptr[i] - y.z_ptr[k];
-      double w = tks.pi_ptr[i] * tks.dz2_ptr[i];
-      a += w * std::pow(dx, 2) * tks.dz2_ptr[i];
+      double dx = tks.zpca[i] - y.zvtx[k];
+      double w = tks.tkwt[i] * tks.dz2[i];
+      a += w * std::pow(dx, 2) * tks.dz2[i];
       b += w;
     }
     double Tc = 2. * a / b;  // the critical temperature of this vertex
@@ -773,7 +770,7 @@ bool DAClusterizerInZ_vect::split(const double beta, track_t& tks, vertex_t& y, 
 
   std::vector<std::pair<double, unsigned int> > critical;
   for (unsigned int k = 0; k < nv; k++) {
-    double Tc = 2 * y.swE_ptr[k] / y.sw_ptr[k];
+    double Tc = 2 * y.swE[k] / y.sw[k];
     if (beta * Tc > threshold) {
       critical.push_back(make_pair(Tc, k));
     }
@@ -793,27 +790,26 @@ bool DAClusterizerInZ_vect::split(const double beta, track_t& tks, vertex_t& y, 
     double p1 = 0, z1 = 0, w1 = 0;
     double p2 = 0, z2 = 0, w2 = 0;
     for (unsigned int i = 0; i < nt; i++) {
-      if (tks.Z_sum_ptr[i] > 1.e-100) {
+      if (tks.Z_sum[i] > 1.e-100) {
         // winner-takes-all, usually overestimates splitting
-        double tl = tks.z_ptr[i] < y.z_ptr[k] ? 1. : 0.;
+        double tl = tks.zpca[i] < y.zvtx[k] ? 1. : 0.;
         double tr = 1. - tl;
 
         // soften it, especially at low T
-        double arg = (tks.z_ptr[i] - y.z_ptr[k]) * sqrt(beta * tks.dz2_ptr[i]);
+        double arg = (tks.zpca[i] - y.zvtx[k]) * sqrt(beta * tks.dz2[i]);
         if (std::fabs(arg) < 20) {
           double t = local_exp(-arg);
           tl = t / (t + 1.);
           tr = 1 / (t + 1.);
         }
 
-        double p = y.pk_ptr[k] * tks.pi_ptr[i] * local_exp(-beta * Eik(tks.z_ptr[i], y.z_ptr[k], tks.dz2_ptr[i])) /
-                   tks.Z_sum_ptr[i];
-        double w = p * tks.dz2_ptr[i];
+        double p = y.rho[k] * tks.tkwt[i] * local_exp(-beta * Eik(tks.zpca[i], y.zvtx[k], tks.dz2[i])) / tks.Z_sum[i];
+        double w = p * tks.dz2[i];
         p1 += p * tl;
-        z1 += w * tl * tks.z_ptr[i];
+        z1 += w * tl * tks.zpca[i];
         w1 += w * tl;
         p2 += p * tr;
-        z2 += w * tr * tks.z_ptr[i];
+        z2 += w * tr * tks.zpca[i];
         w2 += w * tr;
       }
     }
@@ -821,28 +817,28 @@ bool DAClusterizerInZ_vect::split(const double beta, track_t& tks, vertex_t& y, 
     if (w1 > 0) {
       z1 = z1 / w1;
     } else {
-      z1 = y.z_ptr[k] - epsilon;
+      z1 = y.zvtx[k] - epsilon;
     }
     if (w2 > 0) {
       z2 = z2 / w2;
     } else {
-      z2 = y.z_ptr[k] + epsilon;
+      z2 = y.zvtx[k] + epsilon;
     }
 
     // reduce split size if there is not enough room
-    if ((k > 0) && (z1 < (0.6 * y.z_ptr[k] + 0.4 * y.z_ptr[k - 1]))) {
-      z1 = 0.6 * y.z_ptr[k] + 0.4 * y.z_ptr[k - 1];
+    if ((k > 0) && (z1 < (0.6 * y.zvtx[k] + 0.4 * y.zvtx[k - 1]))) {
+      z1 = 0.6 * y.zvtx[k] + 0.4 * y.zvtx[k - 1];
     }
-    if ((k + 1 < nv) && (z2 > (0.6 * y.z_ptr[k] + 0.4 * y.z_ptr[k + 1]))) {
-      z2 = 0.6 * y.z_ptr[k] + 0.4 * y.z_ptr[k + 1];
+    if ((k + 1 < nv) && (z2 > (0.6 * y.zvtx[k] + 0.4 * y.zvtx[k + 1]))) {
+      z2 = 0.6 * y.zvtx[k] + 0.4 * y.zvtx[k + 1];
     }
 
 #ifdef DEBUG
     assert(k < nv);
     if (DEBUGLEVEL > 1) {
-      if (std::fabs(y.z_ptr[k] - zdumpcenter_) < zdumpwidth_) {
+      if (std::fabs(y.zvtx[k] - zdumpcenter_) < zdumpwidth_) {
         std::cout << " T= " << std::setw(8) << 1. / beta << " Tc= " << critical[ic].first << "    splitting "
-                  << std::fixed << std::setprecision(4) << y.z_ptr[k] << " --> " << z1 << "," << z2 << "     [" << p1
+                  << std::fixed << std::setprecision(4) << y.zvtx[k] << " --> " << z1 << "," << z2 << "     [" << p1
                   << "," << p2 << "]";
         if (std::fabs(z2 - z1) > epsilon) {
           std::cout << std::endl;
@@ -856,10 +852,10 @@ bool DAClusterizerInZ_vect::split(const double beta, track_t& tks, vertex_t& y, 
     // split if the new subclusters are significantly separated
     if ((z2 - z1) > epsilon) {
       split = true;
-      double pk1 = p1 * y.pk_ptr[k] / (p1 + p2);
-      double pk2 = p2 * y.pk_ptr[k] / (p1 + p2);
-      y.z_ptr[k] = z2;
-      y.pk_ptr[k] = pk2;
+      double pk1 = p1 * y.rho[k] / (p1 + p2);
+      double pk2 = p2 * y.rho[k] / (p1 + p2);
+      y.zvtx[k] = z2;
+      y.rho[k] = pk2;
       y.insertItem(k, z1, pk1, tks);
       if (k == 0)
         y.extractRaw();
@@ -872,6 +868,10 @@ bool DAClusterizerInZ_vect::split(const double beta, track_t& tks, vertex_t& y, 
           critical[jc].second++;
         }
       }
+    } else {
+#ifdef DEBUG
+      std::cout << "warning ! split rejected, too small." << endl;
+#endif
     }
   }
 
@@ -1046,31 +1046,31 @@ vector<TransientVertex> DAClusterizerInZ_vect::vertices(const vector<reco::Trans
   // ensure correct normalization of probabilities, should makes double assignment reasonably impossible
   const unsigned int nv = y.getSize();
   for (unsigned int k = 0; k < nv; k++)
-    if (edm::isNotFinite(y.pk_ptr[k]) || edm::isNotFinite(y.z_ptr[k])) {
-      y.pk_ptr[k] = 0;
-      y.z_ptr[k] = 0;
+    if (edm::isNotFinite(y.rho[k]) || edm::isNotFinite(y.zvtx[k])) {
+      y.rho[k] = 0;
+      y.zvtx[k] = 0;
     }
 
   const auto z_sum_init = rho0 * local_exp(-beta * dzCutOff_ * dzCutOff_);
   for (unsigned int i = 0; i < nt; i++)  // initialize
-    tks.Z_sum_ptr[i] = z_sum_init;
+    tks.Z_sum[i] = z_sum_init;
 
   // improve vectorization (does not require reduction ....)
   for (unsigned int k = 0; k < nv; k++) {
     for (unsigned int i = 0; i < nt; i++)
-      tks.Z_sum_ptr[i] += y.pk_ptr[k] * local_exp(-beta * Eik(tks.z_ptr[i], y.z_ptr[k], tks.dz2_ptr[i]));
+      tks.Z_sum[i] += y.rho[k] * local_exp(-beta * Eik(tks.zpca[i], y.zvtx[k], tks.dz2[i]));
   }
 
   for (unsigned int k = 0; k < nv; k++) {
-    GlobalPoint pos(0, 0, y.z_ptr[k]);
+    GlobalPoint pos(0, 0, y.zvtx[k]);
 
     vector<reco::TransientTrack> vertexTracks;
     for (unsigned int i = 0; i < nt; i++) {
-      if (tks.Z_sum_ptr[i] > 1e-100) {
-        double p = y.pk_ptr[k] * local_exp(-beta * Eik(tks.z_ptr[i], y.z_ptr[k], tks.dz2_ptr[i])) / tks.Z_sum_ptr[i];
-        if ((tks.pi_ptr[i] > 0) && (p > mintrkweight_)) {
+      if (tks.Z_sum[i] > 1e-100) {
+        double p = y.rho[k] * local_exp(-beta * Eik(tks.zpca[i], y.zvtx[k], tks.dz2[i])) / tks.Z_sum[i];
+        if ((tks.tkwt[i] > 0) && (p > mintrkweight_)) {
           vertexTracks.push_back(*(tks.tt[i]));
-          tks.Z_sum_ptr[i] = 0;  // setting Z=0 excludes double assignment
+          tks.Z_sum[i] = 0;  // setting Z=0 excludes double assignment
         }
       }
     }
@@ -1133,12 +1133,12 @@ void DAClusterizerInZ_vect::dump(const double beta, const vertex_t& y, const tra
   for (unsigned int j = 0; j < nt; j++) {
     iz.push_back(j);
   }
-  std::sort(iz.begin(), iz.end(), [tks](unsigned int a, unsigned int b) { return tks.z_ptr[a] < tks.z_ptr[b]; });
+  std::sort(iz.begin(), iz.end(), [tks](unsigned int a, unsigned int b) { return tks.zpca[a] < tks.zpca[b]; });
   std::cout << std::endl;
   std::cout << "-----DAClusterizerInZ::dump ----" << nv << "  clusters " << std::endl;
   std::cout << "                                                                   ";
   for (unsigned int ivertex = 0; ivertex < nv; ++ivertex) {
-    if (std::fabs(y.z_ptr[ivertex] - zdumpcenter_) < zdumpwidth_) {
+    if (std::fabs(y.zvtx[ivertex] - zdumpcenter_) < zdumpwidth_) {
       std::cout << "   " << setw(3) << ivertex << "  ";
     }
   }
@@ -1146,16 +1146,16 @@ void DAClusterizerInZ_vect::dump(const double beta, const vertex_t& y, const tra
   std::cout << "                                                                z= ";
   std::cout << setprecision(4);
   for (unsigned int ivertex = 0; ivertex < nv; ++ivertex) {
-    if (std::fabs(y.z_ptr[ivertex] - zdumpcenter_) < zdumpwidth_) {
-      std::cout << setw(8) << fixed << y.z_ptr[ivertex];
+    if (std::fabs(y.zvtx[ivertex] - zdumpcenter_) < zdumpwidth_) {
+      std::cout << setw(8) << fixed << y.zvtx[ivertex];
     }
   }
   std::cout << endl
             << "T=" << setw(15) << 1. / beta << " Tmin =" << setw(10) << 1. / betamax_
             << "                             Tc= ";
   for (unsigned int ivertex = 0; ivertex < nv; ++ivertex) {
-    if (std::fabs(y.z_ptr[ivertex] - zdumpcenter_) < zdumpwidth_) {
-      double Tc = 2 * y.swE_ptr[ivertex] / y.sw_ptr[ivertex];
+    if (std::fabs(y.zvtx[ivertex] - zdumpcenter_) < zdumpwidth_) {
+      double Tc = 2 * y.swE[ivertex] / y.sw[ivertex];
       std::cout << setw(8) << fixed << setprecision(1) << Tc;
     }
   }
@@ -1164,18 +1164,18 @@ void DAClusterizerInZ_vect::dump(const double beta, const vertex_t& y, const tra
   std::cout << "                                                               pk= ";
   double sumpk = 0;
   for (unsigned int ivertex = 0; ivertex < nv; ++ivertex) {
-    sumpk += y.pk_ptr[ivertex];
-    if (std::fabs(y.z_ptr[ivertex] - zdumpcenter_) > zdumpwidth_)
+    sumpk += y.rho[ivertex];
+    if (std::fabs(y.zvtx[ivertex] - zdumpcenter_) > zdumpwidth_)
       continue;
-    std::cout << setw(8) << setprecision(4) << fixed << y.pk_ptr[ivertex];
+    std::cout << setw(8) << setprecision(4) << fixed << y.rho[ivertex];
   }
   std::cout << endl;
 
   std::cout << "                                                               nt= ";
   for (unsigned int ivertex = 0; ivertex < nv; ++ivertex) {
-    if (std::fabs(y.z_ptr[ivertex] - zdumpcenter_) > zdumpwidth_)
+    if (std::fabs(y.zvtx[ivertex] - zdumpcenter_) > zdumpwidth_)
       continue;
-    std::cout << setw(8) << setprecision(1) << fixed << y.pk_ptr[ivertex] * nt;
+    std::cout << setw(8) << setprecision(1) << fixed << y.rho[ivertex] * nt;
   }
   std::cout << endl;
 
@@ -1186,15 +1186,15 @@ void DAClusterizerInZ_vect::dump(const double beta, const vertex_t& y, const tra
     std::cout << setprecision(4);
     for (unsigned int i0 = 0; i0 < nt; i0++) {
       unsigned int i = iz[i0];
-      if (tks.Z_sum_ptr[i] > 0) {
-        F -= std::log(tks.Z_sum_ptr[i]) / beta;
+      if (tks.Z_sum[i] > 0) {
+        F -= std::log(tks.Z_sum[i]) / beta;
       }
-      double tz = tks.z_ptr[i];
+      double tz = tks.zpca[i];
 
       if (std::fabs(tz - zdumpcenter_) > zdumpwidth_)
         continue;
       std::cout << setw(4) << i << ")" << setw(8) << fixed << setprecision(4) << tz << " +/-" << setw(6)
-                << sqrt(1. / tks.dz2_ptr[i]);
+                << sqrt(1. / tks.dz2[i]);
       if ((tks.tt[i] == nullptr)) {
         std::cout << "          effective track                             ";
       } else {
@@ -1230,19 +1230,18 @@ void DAClusterizerInZ_vect::dump(const double beta, const vertex_t& y, const tra
 
       double sump = 0.;
       for (unsigned int ivertex = 0; ivertex < nv; ++ivertex) {
-        if (std::fabs(y.z_ptr[ivertex] - zdumpcenter_) > zdumpwidth_)
+        if (std::fabs(y.zvtx[ivertex] - zdumpcenter_) > zdumpwidth_)
           continue;
 
-        if ((tks.pi_ptr[i] > 0) && (tks.Z_sum_ptr[i] > 0)) {
+        if ((tks.tkwt[i] > 0) && (tks.Z_sum[i] > 0)) {
           //double p=pik(beta,tks[i],*k);
-          double p = y.pk_ptr[ivertex] * local_exp(-beta * Eik(tks.z_ptr[i], y.z_ptr[ivertex], tks.dz2_ptr[i])) /
-                     tks.Z_sum_ptr[i];
+          double p = y.rho[ivertex] * local_exp(-beta * Eik(tks.zpca[i], y.zvtx[ivertex], tks.dz2[i])) / tks.Z_sum[i];
           if (p > 0.0001) {
             std::cout << setw(8) << setprecision(3) << p;
           } else {
             std::cout << "    .   ";
           }
-          E += p * Eik(tks.z_ptr[i], y.z_ptr[ivertex], tks.dz2_ptr[i]);
+          E += p * Eik(tks.zpca[i], y.zvtx[ivertex], tks.dz2[i]);
           sump += p;
         } else {
           std::cout << "        ";
@@ -1253,7 +1252,7 @@ void DAClusterizerInZ_vect::dump(const double beta, const vertex_t& y, const tra
     }
     std::cout << "                                                                   ";
     for (unsigned int ivertex = 0; ivertex < nv; ++ivertex) {
-      if (std::fabs(y.z_ptr[ivertex] - zdumpcenter_) < zdumpwidth_) {
+      if (std::fabs(y.zvtx[ivertex] - zdumpcenter_) < zdumpwidth_) {
         std::cout << "   " << setw(3) << ivertex << "  ";
       }
     }
@@ -1261,8 +1260,8 @@ void DAClusterizerInZ_vect::dump(const double beta, const vertex_t& y, const tra
     std::cout << "                                                                z= ";
     std::cout << setprecision(4);
     for (unsigned int ivertex = 0; ivertex < nv; ++ivertex) {
-      if (std::fabs(y.z_ptr[ivertex] - zdumpcenter_) < zdumpwidth_) {
-        std::cout << setw(8) << fixed << y.z_ptr[ivertex];
+      if (std::fabs(y.zvtx[ivertex] - zdumpcenter_) < zdumpwidth_) {
+        std::cout << setw(8) << fixed << y.zvtx[ivertex];
       }
     }
     std::cout << endl;


### PR DESCRIPTION
#### PR description:

This pull request is following up a request that arose in the context of PR #29626 to rename single letter variables which was deferred to later. It is done now in preparation of further development for cmssw_11_3.
May other variables were renamed as well to improve clarity and readability. No functionality changes have been introduced by this.
There were also some other cosmetic changes concerning comments and white-spaces.
Two unused/obsolete methods were removed from the structs in the header files.
A missing initialization of the variable betastop_ has been added. This only affects the results when Tmin was initialized with an illegal value, which of course should never happen.


#### PR validation:

The code was tested in CMSSW_11_3_0_pre2 against relvals and no difference was found to the original code.
runTheMatrix resulted in no failures.