### PR TITLE
Change the default phase 2 PF reconstruction for endcap from simPF to pfTICL

### DIFF
--- a/RecoHGCal/TICL/python/iterativeTICL_cff.py
+++ b/RecoHGCal/TICL/python/iterativeTICL_cff.py
@@ -42,35 +42,3 @@ iterHFNoseTICLTask = cms.Task(
     ticlHFNoseMIPStepTask,
     ticlHFNoseEMStepTask
 )
-
-def _findIndicesByModule(process,name):
-    ret = []
-    if getattr(process,'particleFlowBlock', None):
-        for i, pset in enumerate(process.particleFlowBlock.elementImporters):
-            if pset.importerName.value() == name:
-                ret.append(i)
-    return ret
-
-from Configuration.Eras.Modifier_phase2_hgcal_cff import phase2_hgcal
-def injectTICLintoPF(process):
-    if getattr(process,'particleFlowTmp', None):
-      process.particleFlowTmp.src = ['particleFlowTmpBarrel', 'pfTICL']
-
-    if getattr(process,'particleFlowTmpBarrel', None):
-      process.particleFlowTmpBarrel.vetoEndcap = True
-
-    _insertTrackImportersWithVeto = {}
-    _trackImporters = ['GeneralTracksImporter','ConvBremTrackImporter',
-                   'ConversionTrackImporter','NuclearInteractionTrackImporter']
-    for importer in _trackImporters:
-        for idx in _findIndicesByModule(process,importer):
-            _insertTrackImportersWithVeto[idx] = dict(
-                vetoMode = cms.uint32(2), # pfTICL candidate list
-                vetoSrc = cms.InputTag("pfTICL")
-            )
-    phase2_hgcal.toModify(
-      process.particleFlowBlock,
-      elementImporters = _insertTrackImportersWithVeto
-    )
-
-    return process

--- a/RecoParticleFlow/Configuration/python/RecoParticleFlow_cff.py
+++ b/RecoParticleFlow/Configuration/python/RecoParticleFlow_cff.py
@@ -113,7 +113,7 @@ mlpf.toReplaceWith(particleFlowRecoTask, _mlpfTask)
 # switch from pfTICL to simPF
 def _findIndicesByModule(process,name):
     ret = []
-    if getattr(process,'particleFlowBlock', None):
+    if hasattr(process,'particleFlowBlock'):
         for i, pset in enumerate(process.particleFlowBlock.elementImporters):
             if pset.importerName.value() == name:
                 ret.append(i)
@@ -121,10 +121,10 @@ def _findIndicesByModule(process,name):
 
 from Configuration.Eras.Modifier_phase2_hgcal_cff import phase2_hgcal
 def replaceTICLwithSimPF(process):
-    if getattr(process,'particleFlowTmp', None):
+    if hasattr(process,'particleFlowTmp'):
       process.particleFlowTmp.src = ['particleFlowTmpBarrel', 'simPFProducer']
 
-    if getattr(process,'particleFlowTmpBarrel', None):
+    if hasattr(process,'particleFlowTmpBarrel'):
       process.particleFlowTmpBarrel.vetoEndcap = False
 
     _insertTrackImportersWithVeto = {}

--- a/RecoParticleFlow/Configuration/python/RecoParticleFlow_cff.py
+++ b/RecoParticleFlow/Configuration/python/RecoParticleFlow_cff.py
@@ -14,7 +14,7 @@ from RecoParticleFlow.PFProducer.pfPhotonTranslator_cff import *
 #from RecoParticleFlow.PFProducer.pfGsfElectronCiCSelector_cff import *
 from RecoParticleFlow.PFProducer.pfGsfElectronMVASelector_cff import *
 
-from RecoParticleFlow.PFProducer.pfLinker_cff import * 
+from RecoParticleFlow.PFProducer.pfLinker_cff import *
 
 from CommonTools.ParticleFlow.pfParticleSelection_cff import *
 
@@ -34,7 +34,7 @@ particleFlowRecoTask = cms.Task( particleFlowTrackWithDisplacedVertexTask,
                                  particleFlowEGammaFullTask,
                                  particleFlowTmpTask,
                                  fixedGridRhoFastjetAllTmp,
-                                 particleFlowTmpPtrs,         
+                                 particleFlowTmpPtrs,
                                  particleFlowEGammaFinalTask,
                                  pfParticleSelectionTask )
 particleFlowReco = cms.Sequence(particleFlowRecoTask)
@@ -42,31 +42,46 @@ particleFlowReco = cms.Sequence(particleFlowRecoTask)
 particleFlowLinksTask = cms.Task( particleFlow, particleFlowPtrs, chargedHadronPFTrackIsolation, particleBasedIsolationTask)
 particleFlowLinks = cms.Sequence(particleFlowLinksTask)
 
-from RecoParticleFlow.PFTracking.hgcalTrackCollection_cfi import *
-from RecoParticleFlow.PFProducer.simPFProducer_cff import *
-from SimTracker.TrackerHitAssociation.tpClusterProducer_cfi import *
-from SimTracker.TrackAssociatorProducers.quickTrackAssociatorByHits_cfi import *
+#
+# for phase 2
 particleFlowTmpBarrel = particleFlowTmp.clone()
 _phase2_hgcal_particleFlowTmp = cms.EDProducer(
     "PFCandidateListMerger",
     src = cms.VInputTag("particleFlowTmpBarrel",
-                        "simPFProducer")
-    
-)
+                        "pfTICL")
 
-_phase2_hgcal_simPFTask = cms.Task( pfTrack ,
-                                    hgcalTrackCollection , 
-                                    tpClusterProducer ,
-                                    quickTrackAssociatorByHits ,
-                                    simPFProducer )
-_phase2_hgcal_simPFSequence = cms.Sequence(_phase2_hgcal_simPFTask) 
-_phase2_hgcal_particleFlowRecoTask = cms.Task( _phase2_hgcal_simPFTask , particleFlowRecoTask.copy() )
-_phase2_hgcal_particleFlowRecoTask.replace( particleFlowTmpTask, cms.Task( particleFlowTmpBarrel, particleFlowTmp ) )
+)
 
 from Configuration.Eras.Modifier_phase2_hgcal_cff import phase2_hgcal
 phase2_hgcal.toReplaceWith( particleFlowTmp, _phase2_hgcal_particleFlowTmp )
+phase2_hgcal.toModify(
+    particleFlowTmpBarrel,
+    vetoEndcap = True
+    # If true, PF(Muon)Algo will ignore muon candidates incorporated via pfTICL
+    # in addMissingMuons. This will prevent potential double-counting.
+)
+
+#
+# for simPF
+from RecoParticleFlow.PFTracking.hgcalTrackCollection_cfi import *
+from RecoParticleFlow.PFProducer.simPFProducer_cff import *
+from SimTracker.TrackerHitAssociation.tpClusterProducer_cfi import *
+from SimTracker.TrackAssociatorProducers.quickTrackAssociatorByHits_cfi import *
+
+_phase2_hgcal_simPFTask = cms.Task( pfTrack ,
+                                    hgcalTrackCollection ,
+                                    tpClusterProducer ,
+                                    quickTrackAssociatorByHits ,
+                                    simPFProducer )
+_phase2_hgcal_simPFSequence = cms.Sequence(_phase2_hgcal_simPFTask)
+
+_phase2_hgcal_particleFlowRecoTask = cms.Task( _phase2_hgcal_simPFTask , particleFlowRecoTask.copy() )
+_phase2_hgcal_particleFlowRecoTask.replace( particleFlowTmpTask, cms.Task( particleFlowTmpBarrel, particleFlowTmp ) )
+
 phase2_hgcal.toReplaceWith( particleFlowRecoTask, _phase2_hgcal_particleFlowRecoTask )
 
+#
+# for heavy ion
 from Configuration.Eras.Modifier_pp_on_XeXe_2017_cff import pp_on_XeXe_2017
 from Configuration.ProcessModifiers.pp_on_AA_cff import pp_on_AA
 
@@ -84,11 +99,46 @@ for e in [pp_on_XeXe_2017, pp_on_AA]:
     e.toModify(pfPileUpIso, enable = cms.bool(False))
     e.toModify(pfNoPileUp, enable = cms.bool(False))
     e.toModify(pfPileUp, enable = cms.bool(False))
-    
 
+#
+# for MLPF
 from Configuration.ProcessModifiers.mlpf_cff import mlpf
 from RecoParticleFlow.PFProducer.mlpfProducer_cfi import mlpfProducer
 
 _mlpfTask = cms.Task(mlpfProducer, particleFlowRecoTask.copy())
 
 mlpf.toReplaceWith(particleFlowRecoTask, _mlpfTask)
+
+#
+# switch from pfTICL to simPF
+def _findIndicesByModule(process,name):
+    ret = []
+    if getattr(process,'particleFlowBlock', None):
+        for i, pset in enumerate(process.particleFlowBlock.elementImporters):
+            if pset.importerName.value() == name:
+                ret.append(i)
+    return ret
+
+from Configuration.Eras.Modifier_phase2_hgcal_cff import phase2_hgcal
+def replaceTICLwithSimPF(process):
+    if getattr(process,'particleFlowTmp', None):
+      process.particleFlowTmp.src = ['particleFlowTmpBarrel', 'simPFProducer']
+
+    if getattr(process,'particleFlowTmpBarrel', None):
+      process.particleFlowTmpBarrel.vetoEndcap = False
+
+    _insertTrackImportersWithVeto = {}
+    _trackImporters = ['GeneralTracksImporter','ConvBremTrackImporter',
+                   'ConversionTrackImporter','NuclearInteractionTrackImporter']
+    for importer in _trackImporters:
+        for idx in _findIndicesByModule(process,importer):
+            _insertTrackImportersWithVeto[idx] = dict(
+                vetoMode = cms.uint32(0), # HGCal-region PFTrack list for simPF
+                vetoSrc = cms.InputTag('hgcalTrackCollection:TracksInHGCal')
+            )
+    phase2_hgcal.toModify(
+      process.particleFlowBlock,
+      elementImporters = _insertTrackImportersWithVeto
+    )
+
+    return process

--- a/RecoParticleFlow/PFProducer/python/particleFlowBlock_cfi.py
+++ b/RecoParticleFlow/PFProducer/python/particleFlowBlock_cfi.py
@@ -157,6 +157,8 @@ egamma_lowPt_exclusive.toModify(_scImporter,
                                 minSuperClusterPt = 1.0,
                                 minPTforBypass = 0.0)
 
+#
+# kill pfTICL tracks
 def _findIndicesByModule(name):
    ret = []
    for i, pset in enumerate(particleFlowBlock.elementImporters):
@@ -164,8 +166,6 @@ def _findIndicesByModule(name):
             ret.append(i)
    return ret
 
-#
-# kill tracks in the HGCal
 from Configuration.Eras.Modifier_phase2_hgcal_cff import phase2_hgcal
 _insertTrackImportersWithVeto = {}
 _trackImporters = ['GeneralTracksImporter','ConvBremTrackImporter',
@@ -174,8 +174,8 @@ for importer in _trackImporters:
   for idx in _findIndicesByModule(importer):
     _insertTrackImportersWithVeto[idx] = dict(
       vetoEndcap = True,
-      vetoMode = cms.uint32(0), # HGCal-region PFTrack list for simPF
-      vetoSrc = cms.InputTag('hgcalTrackCollection:TracksInHGCal')
+      vetoMode = cms.uint32(2), # pfTICL candidate list
+      vetoSrc = cms.InputTag("pfTICL")
     )
 phase2_hgcal.toModify(
     particleFlowBlock,


### PR DESCRIPTION
#### PR description:

This PR will change the default phase 2 PF reconstruction for endcap from simPF to pfTICL. This is based on the agreed plan between the PF group and HGCAL DPG that we will make this switch when #32291 is integrated (which happened a couple of days ago). The simPFProducer is still run for now, but not injected to the PF candidate list.

#### PR validation:

I ran this PR with the default setting (pfTICL) and also with `--customise RecoParticleFlow/Configuration/RecoParticleFlow_cff.replaceTICLwithSimPF`, and compared PF candidate outputs (actually packedCandidates) with those without this PR with the default (SimPF) and pfTICL injected. The test was done with 23234.0_TTbar 2026D49 without PU. I confirmed identical results when pfTICL or simPF is used for both without and with this PR.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This is not a backport.

@bendavid @rovere @felicepantaleo @jnsandhya @zeratul87