### PR TITLE
fix wrong es consumes transitions in SiStripAnalyser

### DIFF
--- a/DQM/SiStripMonitorClient/plugins/SiStripAnalyser.h
+++ b/DQM/SiStripMonitorClient/plugins/SiStripAnalyser.h
@@ -68,8 +68,8 @@ private:
   const SiStripDetCabling* detCabling_;
   edm::ESGetToken<SiStripDetCabling, SiStripDetCablingRcd> detCablingToken_;
   edm::ESWatcher<SiStripFedCablingRcd> fedCablingWatcher_;
-  edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> tTopoTokenELB_, tTopoTokenER_;
-  edm::ESGetToken<TkDetMap, TrackerTopologyRcd> tkDetMapTokenELB_, tkDetMapTokenER_;
+  edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> tTopoToken_, tTopoTokenELB_, tTopoTokenBR_;
+  edm::ESGetToken<TkDetMap, TrackerTopologyRcd> tkDetMapToken_, tkDetMapTokenELB_, tkDetMapTokenBR_;
   edm::ESGetToken<SiStripQuality, SiStripQualityRcd> stripQualityToken_;
 
   int nLumiSecs_{};


### PR DESCRIPTION
#### PR description:

Addresses issue https://github.com/cms-sw/cmssw/issues/32770

#### PR validation:
``` bash
cd DQM/Integration/python/clients
mkdir upload
cmsRun sistrip_dqm_sourceclient-live_cfg.py unitTest=True
```

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Not a backport, no backport needed.