### PR TITLE
Fix small bugs in geometry DB payload scripts -- Backport of #32361

### DIFF
--- a/CondTools/Geometry/plugins/CSCRecoIdealDBLoader.cc
+++ b/CondTools/Geometry/plugins/CSCRecoIdealDBLoader.cc
@@ -31,7 +31,7 @@ private:
 };
 
 CSCRecoIdealDBLoader::CSCRecoIdealDBLoader(const edm::ParameterSet& iC) {
-  fromDD4Hep_ = iC.getParameter<bool>("fromDD4Hep");
+  fromDD4Hep_ = iC.getUntrackedParameter<bool>("fromDD4Hep", false);
 }
 
 void CSCRecoIdealDBLoader::beginRun(const edm::Run&, edm::EventSetup const& es) {

--- a/CondTools/Geometry/test/geometrywriter.py
+++ b/CondTools/Geometry/test/geometrywriter.py
@@ -18,11 +18,6 @@ process.XMLGeometryWriter = cms.EDAnalyzer("XMLGeometryBuilder",
                                            ZIP = cms.untracked.bool(True)
                                            )
 
-process.TrackerGeometricDetESModule = cms.ESProducer( "TrackerGeometricDetESModule",
-                                                      fromDDD = cms.bool( True )
-                                                     )
-
-
 process.TrackerGeometryWriter = cms.EDAnalyzer("PGeometricDetBuilder",fromDD4hep=cms.bool( False ))
 process.TrackerParametersWriter = cms.EDAnalyzer("PTrackerParametersDBBuilder", fromDD4hep=cms.bool( False ))
 

--- a/CondTools/Geometry/test/writehelpers/geometryExtended2021_writer.py
+++ b/CondTools/Geometry/test/writehelpers/geometryExtended2021_writer.py
@@ -28,9 +28,6 @@ process.XMLGeometryWriter = cms.EDAnalyzer("XMLGeometryBuilder",
                                            XMLFileName = cms.untracked.string("./geSingleBigFile.xml"),
                                            ZIP = cms.untracked.bool(True)
                                            )
-process.TrackerGeometricDetESModule = cms.ESProducer( "TrackerGeometricDetESModule",
-                                                      fromDDD = cms.bool( True )
-                                                     )
 
 process.TrackerGeometryWriter = cms.EDAnalyzer("PGeometricDetBuilder",fromDD4hep=cms.bool(False))
 process.TrackerParametersWriter = cms.EDAnalyzer("PTrackerParametersDBBuilder",fromDD4hep=cms.bool(False))

--- a/CondTools/Geometry/test/writehelpers/geometrywriter.py
+++ b/CondTools/Geometry/test/writehelpers/geometrywriter.py
@@ -28,9 +28,6 @@ process.XMLGeometryWriter = cms.EDAnalyzer("XMLGeometryBuilder",
                                            XMLFileName = cms.untracked.string("./geSingleBigFile.xml"),
                                            ZIP = cms.untracked.bool(True)
                                            )
-process.TrackerGeometricDetESModule = cms.ESProducer( "TrackerGeometricDetESModule",
-                                                      fromDDD = cms.bool( True )
-                                                     )
 process.TrackerGeometryWriter = cms.EDAnalyzer("PGeometricDetBuilder",fromDD4hep=cms.bool(False))
 process.TrackerParametersWriter = cms.EDAnalyzer("PTrackerParametersDBBuilder",fromDD4hep=cms.bool(False))
 

--- a/Geometry/TrackerGeometryBuilder/test/python/trackerModuleInfoLocalDB_cfg.py
+++ b/Geometry/TrackerGeometryBuilder/test/python/trackerModuleInfoLocalDB_cfg.py
@@ -14,10 +14,6 @@ process.maxEvents = cms.untracked.PSet(
     input = cms.untracked.int32(1)
 )
 
-process.TrackerGeometricDetESModule = cms.ESProducer( "TrackerGeometricDetESModule",
-                                                      fromDDD = cms.bool( False )
-                                                     )
-
 process.CondDB.timetype = cms.untracked.string('runnumber')
 process.CondDB.connect = cms.string('sqlite_file:myfile.db')
 process.PoolDBESSourceGeometry = cms.ESSource("PoolDBESSource",

--- a/Validation/Geometry/test/dddvsdb/runDDDvsDBGeometryValidation.sh
+++ b/Validation/Geometry/test/dddvsdb/runDDDvsDBGeometryValidation.sh
@@ -48,7 +48,8 @@ echo $geometry
 sed -i "{s/GeometryExtended/${geometry}/}" geometryxmlwriter.py >  GeometryValidation.log
 cmsRun geometryxmlwriter.py >>  GeometryValidation.log
 
-cp $CMSSW_RELEASE_BASE/src/CondTools/Geometry/test/geometrywriter.py .
+# cp $CMSSW_RELEASE_BASE/src/CondTools/Geometry/test/geometrywriter.py .
+cp $CMSSW_BASE/src/CondTools/Geometry/test/geometrywriter.py .
 sed -i "{s/GeometryExtended/${geometry}/}" geometrywriter.py >>  GeometryValidation.log
 sed -i "{s/geTagXX.xml/geSingleBigFile.xml/g}" geometrywriter.py >>  GeometryValidation.log
 cmsRun geometrywriter.py >>  GeometryValidation.log
@@ -117,16 +118,15 @@ mkdir tkddd
 cp myfile.db tkdblocal
 
 cd tkdb
-# cp $CMSSW_BASE/src/Geometry/TrackerGeometryBuilder/test/trackerModuleInfoDB_cfg.py .
-cp $CMSSW_RELEASE_BASE/src/Geometry/TrackerGeometryBuilder/test/trackerModuleInfoDB_cfg.py .
-sed -i "{/process.GlobalTag.globaltag/d}" trackerModuleInfoDB_cfg.py >> ../GeometryValidation.log
-sed -i "/FrontierConditions_GlobalTag_cff/ a\from Configuration.AlCa.GlobalTag import GlobalTag\nprocess.GlobalTag = GlobalTag(process.GlobalTag, '${gtag}', '')" trackerModuleInfoDB_cfg.py >> ../GeometryValidation.log 
-sed -i "/FrontierConditions_GlobalTag_cff/ a\process.XMLFromDBSource.label = cms.string('${condlabel}')" trackerModuleInfoDB_cfg.py >> ../GeometryValidation.log 
+cp $CMSSW_RELEASE_BASE/src/Geometry/TrackerGeometryBuilder/test/python/testTrackerModuleInfoDB_cfg.py .
+sed -i "{/process.GlobalTag.globaltag/d}" testTrackerModuleInfoDB_cfg.py >> ../GeometryValidation.log
+sed -i "/FrontierConditions_GlobalTag_cff/ a\from Configuration.AlCa.GlobalTag import GlobalTag\nprocess.GlobalTag = GlobalTag(process.GlobalTag, '${gtag}', '')" testTrackerModuleInfoDB_cfg.py >> ../GeometryValidation.log 
+sed -i "/FrontierConditions_GlobalTag_cff/ a\process.XMLFromDBSource.label = cms.string('${condlabel}')" testTrackerModuleInfoDB_cfg.py >> ../GeometryValidation.log 
 if ( "${roundFlag}" == round ) then                                                               
-  sed -i "/tolerance/s/1.0e-23/${tolerance}/" trackerModuleInfoDB_cfg.py >> GeometryValidation.log
+  sed -i "/tolerance/s/1.0e-23/${tolerance}/" testTrackerModuleInfoDB_cfg.py >> GeometryValidation.log
 endif
-cmsRun trackerModuleInfoDB_cfg.py >> ../GeometryValidation.log
-mv trackerModuleInfoDB_cfg.py ../
+cmsRun testTrackerModuleInfoDB_cfg.py >> ../GeometryValidation.log
+mv testTrackerModuleInfoDB_cfg.py ../
 if ( -s ModuleInfo.log ) then
     echo "TK test from DB run ok" | tee -a ../GeometryValidation.log
 else
@@ -135,8 +135,8 @@ else
 endif
 
 cd ../tkdblocal
-# cp $CMSSW_BASE/src/Geometry/TrackerGeometryBuilder/test/trackerModuleInfoLocalDB_cfg.py .
-cp $CMSSW_RELEASE_BASE/src/Geometry/TrackerGeometryBuilder/test/trackerModuleInfoLocalDB_cfg.py .
+# cp $CMSSW_RELEASE_BASE/src/Geometry/TrackerGeometryBuilder/test/python/trackerModuleInfoLocalDB_cfg.py .
+cp $CMSSW_BASE/src/Geometry/TrackerGeometryBuilder/test/python/trackerModuleInfoLocalDB_cfg.py .
 sed -i "{/process.GlobalTag.globaltag/d}" trackerModuleInfoLocalDB_cfg.py >> ../GeometryValidation.log
 sed -i "/FrontierConditions_GlobalTag_cff/ a\from Configuration.AlCa.GlobalTag import GlobalTag\nprocess.GlobalTag = GlobalTag(process.GlobalTag, '${gtag}', '')" trackerModuleInfoLocalDB_cfg.py >> ../GeometryValidation.log 
 sed -i "/FrontierConditions_GlobalTag_cff/ a\process.XMLFromDBSource.label = cms.string('${condlabel}')" trackerModuleInfoLocalDB_cfg.py >> ../GeometryValidation.log 
@@ -153,16 +153,15 @@ else
 endif
 
 cd ../tkddd
-# cp $CMSSW_BASE/src/Geometry/TrackerGeometryBuilder/test/trackerModuleInfoDDD_cfg.py .
-cp $CMSSW_RELEASE_BASE/src/Geometry/TrackerGeometryBuilder/test/trackerModuleInfoDDD_cfg.py .
-sed -i "{s/GeometryExtended/${geometry}/}" trackerModuleInfoDDD_cfg.py >>  ../GeometryValidation.log
-sed -i "{/process.GlobalTag.globaltag/d}" trackerModuleInfoDDD_cfg.py >> ../GeometryValidation.log
-sed -i "/FrontierConditions_GlobalTag_cff/ a\from Configuration.AlCa.GlobalTag import GlobalTag\nprocess.GlobalTag = GlobalTag(process.GlobalTag, '${gtag}', '')" trackerModuleInfoDDD_cfg.py >> ../GeometryValidation.log 
+cp $CMSSW_RELEASE_BASE/src/Geometry/TrackerGeometryBuilder/test/python/testTrackerModuleInfoDDD_cfg.py .
+sed -i "{s/GeometryExtended/${geometry}/}" testTrackerModuleInfoDDD_cfg.py >>  ../GeometryValidation.log
+sed -i "{/process.GlobalTag.globaltag/d}" testTrackerModuleInfoDDD_cfg.py >> ../GeometryValidation.log
+sed -i "/FrontierConditions_GlobalTag_cff/ a\from Configuration.AlCa.GlobalTag import GlobalTag\nprocess.GlobalTag = GlobalTag(process.GlobalTag, '${gtag}', '')" testTrackerModuleInfoDDD_cfg.py >> ../GeometryValidation.log 
 if ( "${roundFlag}" == round ) then                                                               
-  sed -i "/tolerance/s/1.0e-23/${tolerance}/" trackerModuleInfoDDD_cfg.py >> GeometryValidation.log
+  sed -i "/tolerance/s/1.0e-23/${tolerance}/" testTrackerModuleInfoDDD_cfg.py >> GeometryValidation.log
 endif
-cmsRun trackerModuleInfoDDD_cfg.py >> ../GeometryValidation.log
-mv trackerModuleInfoDDD_cfg.py ../
+cmsRun testTrackerModuleInfoDDD_cfg.py >> ../GeometryValidation.log
+mv testTrackerModuleInfoDDD_cfg.py ../
 if ( -s ModuleInfo.log ) then
     echo "TK test from DDD run ok" | tee -a ../GeometryValidation.log
 else

--- a/Validation/Geometry/test/dddvsdb/runDDDvsDBGeometryValidation.sh
+++ b/Validation/Geometry/test/dddvsdb/runDDDvsDBGeometryValidation.sh
@@ -48,8 +48,8 @@ echo $geometry
 sed -i "{s/GeometryExtended/${geometry}/}" geometryxmlwriter.py >  GeometryValidation.log
 cmsRun geometryxmlwriter.py >>  GeometryValidation.log
 
-# cp $CMSSW_RELEASE_BASE/src/CondTools/Geometry/test/geometrywriter.py .
-cp $CMSSW_BASE/src/CondTools/Geometry/test/geometrywriter.py .
+cp $CMSSW_RELEASE_BASE/src/CondTools/Geometry/test/geometrywriter.py .
+# cp $CMSSW_BASE/src/CondTools/Geometry/test/geometrywriter.py .
 sed -i "{s/GeometryExtended/${geometry}/}" geometrywriter.py >>  GeometryValidation.log
 sed -i "{s/geTagXX.xml/geSingleBigFile.xml/g}" geometrywriter.py >>  GeometryValidation.log
 cmsRun geometrywriter.py >>  GeometryValidation.log
@@ -135,8 +135,8 @@ else
 endif
 
 cd ../tkdblocal
-# cp $CMSSW_RELEASE_BASE/src/Geometry/TrackerGeometryBuilder/test/python/trackerModuleInfoLocalDB_cfg.py .
-cp $CMSSW_BASE/src/Geometry/TrackerGeometryBuilder/test/python/trackerModuleInfoLocalDB_cfg.py .
+cp $CMSSW_RELEASE_BASE/src/Geometry/TrackerGeometryBuilder/test/python/trackerModuleInfoLocalDB_cfg.py .
+# cp $CMSSW_BASE/src/Geometry/TrackerGeometryBuilder/test/python/trackerModuleInfoLocalDB_cfg.py .
 sed -i "{/process.GlobalTag.globaltag/d}" trackerModuleInfoLocalDB_cfg.py >> ../GeometryValidation.log
 sed -i "/FrontierConditions_GlobalTag_cff/ a\from Configuration.AlCa.GlobalTag import GlobalTag\nprocess.GlobalTag = GlobalTag(process.GlobalTag, '${gtag}', '')" trackerModuleInfoLocalDB_cfg.py >> ../GeometryValidation.log 
 sed -i "/FrontierConditions_GlobalTag_cff/ a\process.XMLFromDBSource.label = cms.string('${condlabel}')" trackerModuleInfoLocalDB_cfg.py >> ../GeometryValidation.log 


### PR DESCRIPTION
Several recent PRs inadvertently caused problems for the scripts that create and check geometry DB payloads. This PR fixes those problems.

PR validation:

These scripts are run by experts to create and check geometry DB payloads. They are not used in workflows. These changes were tested during the creation of new payloads.

This PR is a backport of #32361 from 11_3. It is needed because the GEM group has requested new geometry DB payloads for 11_2.