### PR TITLE
Include <memory> in FileBlob.h for std::unique_ptr

### DIFF
--- a/CondFormats/Common/interface/FileBlob.h
+++ b/CondFormats/Common/interface/FileBlob.h
@@ -6,6 +6,7 @@
 #include <vector>
 #include <string>
 #include <iostream>
+#include <memory>
 
 class FileBlob {
 public:


### PR DESCRIPTION
#### PR description:

Fixes a build error I get on my laptop with gcc 10.2.0.

I hope the preprocessor variable name `CondFormats_FileBlob_no_cint` is acceptable.

#### PR validation:

CMSSW compiles.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

No backport intended.