### PR TITLE
Include <algorithm> in CSCDBL1TPParametersExtended.cc for std::find

### DIFF
--- a/CondFormats/CSCObjects/src/CSCDBL1TPParametersExtended.cc
+++ b/CondFormats/CSCObjects/src/CSCDBL1TPParametersExtended.cc
@@ -1,5 +1,7 @@
 #include "CondFormats/CSCObjects/interface/CSCDBL1TPParametersExtended.h"
 
+#include <algorithm>
+
 CSCDBL1TPParametersExtended::CSCDBL1TPParametersExtended() {
   paramsInt_.resize(paramNamesInt_.size());
   paramsBool_.resize(paramNamesBool_.size());
@@ -8,21 +10,21 @@ CSCDBL1TPParametersExtended::CSCDBL1TPParametersExtended() {
 CSCDBL1TPParametersExtended::~CSCDBL1TPParametersExtended() {}
 
 int CSCDBL1TPParametersExtended::getValueInt(const std::string& s) const {
-  const int index = find(paramNamesInt_.begin(), paramNamesInt_.end(), s) - paramNamesInt_.begin();
+  const int index = std::find(paramNamesInt_.begin(), paramNamesInt_.end(), s) - paramNamesInt_.begin();
   return paramsInt_[index];
 }
 
 bool CSCDBL1TPParametersExtended::getValueBool(const std::string& s) const {
-  const int index = find(paramNamesBool_.begin(), paramNamesBool_.end(), s) - paramNamesBool_.begin();
+  const int index = std::find(paramNamesBool_.begin(), paramNamesBool_.end(), s) - paramNamesBool_.begin();
   return paramsBool_[index];
 }
 
 void CSCDBL1TPParametersExtended::setValue(const std::string& s, int v) {
-  const int index = find(paramNamesInt_.begin(), paramNamesInt_.end(), s) - paramNamesInt_.begin();
+  const int index = std::find(paramNamesInt_.begin(), paramNamesInt_.end(), s) - paramNamesInt_.begin();
   paramsInt_[index] = v;
 }
 
 void CSCDBL1TPParametersExtended::setValue(const std::string& s, bool v) {
-  const int index = find(paramNamesBool_.begin(), paramNamesBool_.end(), s) - paramNamesBool_.begin();
+  const int index = std::find(paramNamesBool_.begin(), paramNamesBool_.end(), s) - paramNamesBool_.begin();
   paramsBool_[index] = v;
 }


### PR DESCRIPTION
#### PR description:

Adding a missing include to build the CondFormats on my laptop with gcc 10.2.0.

#### PR validation:

CMSSW compiles.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

No backport intended.