### PR TITLE
drop type specifications in RecoJets

### DIFF
--- a/RecoJets/Configuration/python/RecoCaloTowersGR_cff.py
+++ b/RecoJets/Configuration/python/RecoCaloTowersGR_cff.py
@@ -8,9 +8,8 @@ from RecoJets.Configuration.CaloTowersES_cfi import *
 from RecoJets.JetProducers.CaloTowerSchemeBWithHO_cfi import *
 
 from RecoJets.JetProducers.CaloTowerSchemeB_cfi import *
-towerMaker.HBThreshold = cms.double(0.6)
-towerMaker.HBThreshold1 = cms.double(0.6)
-towerMaker.HBThreshold2 = cms.double(0.6)
-
+towerMaker.HBThreshold  = 0.6
+towerMaker.HBThreshold1 = 0.6
+towerMaker.HBThreshold2 = 0.6
 recoCaloTowersGRTask = cms.Task(towerMaker,towerMakerWithHO)
 recoCaloTowersGR = cms.Sequence(recoCaloTowersGRTask)

--- a/RecoJets/JetPlusTracks/python/JetPlusTrackCorrections_cff.py
+++ b/RecoJets/JetPlusTracks/python/JetPlusTrackCorrections_cff.py
@@ -38,9 +38,9 @@ JetPlusTrackZSPCorJetAntiKt4 = cms.EDProducer(
     dRcone = cms.double(0.4)
     )
 
-JetPlusTrackZSPCorJetAntiKt4.JetTracksAssociationAtVertex = cms.InputTag("ak4JetTracksAssociatorAtVertexJPT")
-JetPlusTrackZSPCorJetAntiKt4.JetTracksAssociationAtCaloFace = cms.InputTag("ak4JetTracksAssociatorAtCaloFace")
-JetPlusTrackZSPCorJetAntiKt4.JetSplitMerge = cms.int32(2)
+JetPlusTrackZSPCorJetAntiKt4.JetTracksAssociationAtVertex   = "ak4JetTracksAssociatorAtVertexJPT"
+JetPlusTrackZSPCorJetAntiKt4.JetTracksAssociationAtCaloFace = "ak4JetTracksAssociatorAtCaloFace"
+JetPlusTrackZSPCorJetAntiKt4.JetSplitMerge = 2
 
 ### ---------- Sequences
 

--- a/RecoJets/JetProducers/python/PileupJetIDParams_cfi.py
+++ b/RecoJets/JetProducers/python/PileupJetIDParams_cfi.py
@@ -127,43 +127,50 @@ trainingVariables_102X_Eta3To5.remove('beta')
 trainingVariables_102X_Eta3To5.remove('jetRchg')
 trainingVariables_102X_Eta3To5.remove('nCharged')
 
-full_102x_chs = full_81x_chs.clone(JetIdParams = full_102x_chs_wp)
-full_102x_chs.trainings[0].tmvaWeights = "RecoJets/JetProducers/data/pileupJetId_102X_Eta0p0To2p5_chs_BDT.weights.xml.gz"
-full_102x_chs.trainings[0].tmvaVariables = trainingVariables_102X_Eta0To3
-full_102x_chs.trainings[1].tmvaWeights = "RecoJets/JetProducers/data/pileupJetId_102X_Eta2p5To2p75_chs_BDT.weights.xml.gz"
-full_102x_chs.trainings[1].tmvaVariables = trainingVariables_102X_Eta0To3
-full_102x_chs.trainings[2].tmvaWeights = "RecoJets/JetProducers/data/pileupJetId_102X_Eta2p75To3p0_chs_BDT.weights.xml.gz"
-full_102x_chs.trainings[2].tmvaVariables = trainingVariables_102X_Eta0To3
-full_102x_chs.trainings[3].tmvaWeights = "RecoJets/JetProducers/data/pileupJetId_102X_Eta3p0To5p0_chs_BDT.weights.xml.gz"
-full_102x_chs.trainings[3].tmvaVariables = trainingVariables_102X_Eta3To5
-
+####################################################################################################################
+full_102x_chs = full_81x_chs.clone(
+    JetIdParams = full_102x_chs_wp,
+    trainings = {0: dict(tmvaWeights   = "RecoJets/JetProducers/data/pileupJetId_102X_Eta0p0To2p5_chs_BDT.weights.xml.gz",
+                         tmvaVariables = trainingVariables_102X_Eta0To3),
+                 1: dict(tmvaWeights   = "RecoJets/JetProducers/data/pileupJetId_102X_Eta2p5To2p75_chs_BDT.weights.xml.gz",
+                         tmvaVariables = trainingVariables_102X_Eta0To3),
+                 2: dict(tmvaWeights   = "RecoJets/JetProducers/data/pileupJetId_102X_Eta2p75To3p0_chs_BDT.weights.xml.gz",
+                         tmvaVariables = trainingVariables_102X_Eta0To3),
+                 3: dict(tmvaWeights = "RecoJets/JetProducers/data/pileupJetId_102X_Eta3p0To5p0_chs_BDT.weights.xml.gz",
+                         tmvaVariables = trainingVariables_102X_Eta3To5)
+    }
+)
 ####################################################################################################################
 trainingVariables_94X_Eta0To3 = list(trainingVariables_102X_Eta0To3)
 trainingVariables_94X_Eta3To5 = list(trainingVariables_102X_Eta3To5)
-full_94x_chs = full_81x_chs.clone(JetIdParams = full_94x_chs_wp)
-full_94x_chs.trainings[0].tmvaWeights = "RecoJets/JetProducers/data/pileupJetId_94X_Eta0p0To2p5_chs_BDT.weights.xml.gz"
-full_94x_chs.trainings[0].tmvaVariables = trainingVariables_94X_Eta0To3
-full_94x_chs.trainings[1].tmvaWeights = "RecoJets/JetProducers/data/pileupJetId_94X_Eta2p5To2p75_chs_BDT.weights.xml.gz"
-full_94x_chs.trainings[1].tmvaVariables = trainingVariables_94X_Eta0To3
-full_94x_chs.trainings[2].tmvaWeights = "RecoJets/JetProducers/data/pileupJetId_94X_Eta2p75To3p0_chs_BDT.weights.xml.gz"
-full_94x_chs.trainings[2].tmvaVariables = trainingVariables_94X_Eta0To3
-full_94x_chs.trainings[3].tmvaWeights = "RecoJets/JetProducers/data/pileupJetId_94X_Eta3p0To5p0_chs_BDT.weights.xml.gz"
-full_94x_chs.trainings[3].tmvaVariables = trainingVariables_94X_Eta3To5
-
+full_94x_chs = full_81x_chs.clone(
+    JetIdParams = full_94x_chs_wp,
+    trainings = {0: dict(tmvaWeights   = "RecoJets/JetProducers/data/pileupJetId_94X_Eta0p0To2p5_chs_BDT.weights.xml.gz",
+                         tmvaVariables = trainingVariables_94X_Eta0To3),
+                 1: dict(tmvaWeights   = "RecoJets/JetProducers/data/pileupJetId_94X_Eta2p5To2p75_chs_BDT.weights.xml.gz",
+                         tmvaVariables = trainingVariables_94X_Eta0To3),
+                 2: dict(tmvaWeights   = "RecoJets/JetProducers/data/pileupJetId_94X_Eta2p75To3p0_chs_BDT.weights.xml.gz",
+                         tmvaVariables = trainingVariables_94X_Eta0To3),
+                 3: dict(tmvaWeights   = "RecoJets/JetProducers/data/pileupJetId_94X_Eta3p0To5p0_chs_BDT.weights.xml.gz",
+                         tmvaVariables = trainingVariables_94X_Eta3To5)
+    }
+)
 ####################################################################################################################
 trainingVariables_106X_Eta0To3 = list(trainingVariables_102X_Eta0To3)
 trainingVariables_106X_Eta3To5 = list(trainingVariables_102X_Eta3To5)
-full_106x_UL17_chs = full_81x_chs.clone(JetIdParams = full_106x_UL17_chs_wp)
-full_106x_UL17_chs.trainings[0].tmvaWeights = "RecoJets/JetProducers/data/pileupJetId_UL17_Eta0p0To2p5_chs_BDT.weights.xml.gz"
-full_106x_UL17_chs.trainings[0].tmvaVariables = trainingVariables_106X_Eta0To3
-full_106x_UL17_chs.trainings[1].tmvaWeights = "RecoJets/JetProducers/data/pileupJetId_UL17_Eta2p5To2p75_chs_BDT.weights.xml.gz"
-full_106x_UL17_chs.trainings[1].tmvaVariables = trainingVariables_106X_Eta0To3
-full_106x_UL17_chs.trainings[2].tmvaWeights = "RecoJets/JetProducers/data/pileupJetId_UL17_Eta2p75To3p0_chs_BDT.weights.xml.gz"
-full_106x_UL17_chs.trainings[2].tmvaVariables = trainingVariables_106X_Eta0To3
-full_106x_UL17_chs.trainings[3].tmvaWeights = "RecoJets/JetProducers/data/pileupJetId_UL17_Eta3p0To5p0_chs_BDT.weights.xml.gz"
-full_106x_UL17_chs.trainings[3].tmvaVariables = trainingVariables_106X_Eta3To5
-
-####################################################################################################################
+full_106x_UL17_chs = full_81x_chs.clone(
+    JetIdParams = full_106x_UL17_chs_wp,
+    trainings = {0: dict(tmvaWeights   = "RecoJets/JetProducers/data/pileupJetId_UL17_Eta0p0To2p5_chs_BDT.weights.xml.gz",
+                         tmvaVariables = trainingVariables_106X_Eta0To3),
+                 1: dict(tmvaWeights   = "RecoJets/JetProducers/data/pileupJetId_UL17_Eta2p5To2p75_chs_BDT.weights.xml.gz",
+                         tmvaVariables = trainingVariables_106X_Eta0To3),
+                 2: dict(tmvaWeights   = "RecoJets/JetProducers/data/pileupJetId_UL17_Eta2p75To3p0_chs_BDT.weights.xml.gz",
+                         tmvaVariables = trainingVariables_106X_Eta0To3),
+                 3: dict(tmvaWeights   = "RecoJets/JetProducers/data/pileupJetId_UL17_Eta3p0To5p0_chs_BDT.weights.xml.gz",
+                         tmvaVariables = trainingVariables_106X_Eta3To5)
+    }
+)
+#######################################################################################################################
 full_80x_chs = cms.PSet(
         impactParTkThreshold = cms.double(1.),
         cutBased = cms.bool(False),

--- a/RecoJets/JetProducers/python/caSubjetFilterGenJets_cfi.py
+++ b/RecoJets/JetProducers/python/caSubjetFilterGenJets_cfi.py
@@ -19,4 +19,4 @@ caSubjetFilterGenJets = cms.EDProducer(
     asymmCut     = cms.double(0.3),
     asymmCutLater= cms.bool(True)
     )
-caSubjetFilterGenJets.doAreaFastjet= cms.bool(True)
+caSubjetFilterGenJets.doAreaFastjet = True

--- a/RecoJets/JetProducers/python/caSubjetFilterPFJets_cfi.py
+++ b/RecoJets/JetProducers/python/caSubjetFilterPFJets_cfi.py
@@ -19,4 +19,4 @@ caSubjetFilterPFJets = cms.EDProducer(
     asymmCut     = cms.double(0.3),
     asymmCutLater= cms.bool(True)
     )
-caSubjetFilterPFJets.doAreaFastjet= cms.bool(True)
+caSubjetFilterPFJets.doAreaFastjet = True


### PR DESCRIPTION
#### PR description: 
Update the safer syntax for existing parameter :
- drop type specifications where the original parameter exists.
- move all parameter inside the clone/modifier

Instead of modifying parameters with full type specs, which can be interpreted as an insertion of a new parameter, it is a safer way to protect from parameter name mistakes and will also help in possible parameter migrations.
(submitted PR for RecoJets is [PR#31162](https://github.com/cms-sw/cmssw/pull/31162). )

In this PR, a total of 5 files changed. 

RecoJets/Configuration 1 file
RecoJets/JetPlusTracks 1 file
RecoJets/JetProducers 3 file

#### PR validation:
Event Content comparison check was also done and there is no change with these updates.
Tested in CMSSW_11_2_X, the basic test all passed in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html).