### PR TITLE
PPS direct simulation: optional efficiency effects

### DIFF
--- a/CalibPPS/ESProducers/plugins/CTPPSCompositeESSource.cc
+++ b/CalibPPS/ESProducers/plugins/CTPPSCompositeESSource.cc
@@ -230,9 +230,12 @@ void CTPPSCompositeESSource::fillDescriptions(edm::ConfigurationDescriptions &de
   desc_profile_ctppsDirectSimuData.add<std::string>("timeResolutionDiamonds45");
   desc_profile_ctppsDirectSimuData.add<std::string>("timeResolutionDiamonds56");
 
-  desc_profile_ctppsDirectSimuData.add<std::string>("effTimePath");
-  desc_profile_ctppsDirectSimuData.add<std::string>("effTimeObject45");
-  desc_profile_ctppsDirectSimuData.add<std::string>("effTimeObject56");
+  edm::ParameterSetDescription eps_desc;
+  eps_desc.add<unsigned int>("rpId")->setComment("RP id");
+  eps_desc.add<std::string>("file")->setComment("file name");
+  eps_desc.add<std::string>("object")->setComment("path to the efficiency histogram");
+  desc_profile_ctppsDirectSimuData.addVPSet("efficienciesPerRP", eps_desc, std::vector<edm::ParameterSet>());
+  desc_profile_ctppsDirectSimuData.addVPSet("efficienciesPerPlane", eps_desc, std::vector<edm::ParameterSet>());
 
   desc_profile.add<edm::ParameterSetDescription>("ctppsDirectSimuData", desc_profile_ctppsDirectSimuData);
 
@@ -254,9 +257,19 @@ void CTPPSCompositeESSource::buildDirectSimuData(const edm::ParameterSet &profil
   pData.directSimuData.setTimeResolutionDiamonds56(
       ctppsDirectSimuData.getParameter<std::string>("timeResolutionDiamonds56"));
 
-  pData.directSimuData.setEffTimePath(ctppsDirectSimuData.getParameter<std::string>("effTimePath"));
-  pData.directSimuData.setEffTimeObject45(ctppsDirectSimuData.getParameter<std::string>("effTimeObject45"));
-  pData.directSimuData.setEffTimeObject56(ctppsDirectSimuData.getParameter<std::string>("effTimeObject56"));
+  for (const auto &ps : ctppsDirectSimuData.getParameterSetVector("efficienciesPerRP")) {
+    const auto rpId = ps.getParameter<unsigned int>("rpId");
+    const auto &file = ps.getParameter<std::string>("file");
+    const auto &object = ps.getParameter<std::string>("object");
+    pData.directSimuData.getEfficienciesPerRP()[rpId] = {file, object};
+  }
+
+  for (const auto &ps : ctppsDirectSimuData.getParameterSetVector("efficienciesPerPlane")) {
+    const auto rpId = ps.getParameter<unsigned int>("rpId");
+    const auto &file = ps.getParameter<std::string>("file");
+    const auto &object = ps.getParameter<std::string>("object");
+    pData.directSimuData.getEfficienciesPerPlane()[rpId] = {file, object};
+  }
 }
 
 //----------------------------------------------------------------------------------------------------

--- a/CondFormats/PPSObjects/interface/PPSDirectSimulationData.h
+++ b/CondFormats/PPSObjects/interface/PPSDirectSimulationData.h
@@ -1,6 +1,7 @@
 #ifndef CondFormats_PPSObjects_PPSDirectSimulationData_h
 #define CondFormats_PPSObjects_PPSDirectSimulationData_h
 
+#include <string>
 #include "CondFormats/Serialization/interface/Serializable.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "TH2F.h"
@@ -10,29 +11,28 @@ public:
   PPSDirectSimulationData();
   ~PPSDirectSimulationData();
 
+  typedef std::pair<std::string, std::string> FileObject;
+
   // Getters
-  bool getUseEmpiricalApertures() const;
   const std::string& getEmpiricalAperture45() const;
   const std::string& getEmpiricalAperture56() const;
+
   const std::string& getTimeResolutionDiamonds45() const;
   const std::string& getTimeResolutionDiamonds56() const;
-  bool getUseTimeEfficiencyCheck() const;
-  const std::string& getEffTimePath() const;
-  const std::string& getEffTimeObject45() const;
-  const std::string& getEffTimeObject56() const;
+
+  std::map<unsigned int, FileObject>& getEfficienciesPerRP();
+  std::map<unsigned int, FileObject>& getEfficienciesPerPlane();
 
   // Setters
-  void setUseEmpiricalApertures(bool b);
   void setEmpiricalAperture45(std::string s);
   void setEmpiricalAperture56(std::string s);
+
   void setTimeResolutionDiamonds45(std::string s);
   void setTimeResolutionDiamonds56(std::string s);
-  void setUseTimeEfficiencyCheck(bool b);
-  void setEffTimePath(std::string s);
-  void setEffTimeObject45(std::string s);
-  void setEffTimeObject56(std::string s);
 
-  void printInfo(std::stringstream& s);
+  // utility methods
+  std::map<unsigned int, std::unique_ptr<TH2F>> loadEffeciencyHistogramsPerRP() const;
+  std::map<unsigned int, std::unique_ptr<TH2F>> loadEffeciencyHistogramsPerPlane() const;
 
 private:
   std::string empiricalAperture45_;
@@ -41,13 +41,12 @@ private:
   std::string timeResolutionDiamonds45_;
   std::string timeResolutionDiamonds56_;
 
-  std::string effTimePath_;
-  std::string effTimeObject45_;
-  std::string effTimeObject56_;
+  std::map<unsigned int, FileObject> efficienciesPerRP_, efficienciesPerPlane_;
+
+  static std::unique_ptr<TH2F> loadObject(const std::string& file, const std::string& object);
+  static std::string replace(std::string input, const std::string& from, const std::string& to);
 
   COND_SERIALIZABLE
 };
-
-std::ostream& operator<<(std::ostream&, PPSDirectSimulationData);
 
 #endif

--- a/CondFormats/PPSObjects/src/PPSDirectSimulationData.cc
+++ b/CondFormats/PPSObjects/src/PPSDirectSimulationData.cc
@@ -1,31 +1,39 @@
 #include "CondFormats/PPSObjects/interface/PPSDirectSimulationData.h"
-#include <iostream>
 
-// Constructors
+#include "DataFormats/CTPPSDetId/interface/CTPPSDetId.h"
+#include "DataFormats/CTPPSDetId/interface/TotemRPDetId.h"
+#include "DataFormats/CTPPSDetId/interface/CTPPSPixelDetId.h"
+#include "DataFormats/CTPPSDetId/interface/CTPPSDiamondDetId.h"
+#include "FWCore/Utilities/interface/Exception.h"
+#include "FWCore/ParameterSet/interface/FileInPath.h"
+
+#include "TFile.h"
+
+#include <iostream>
+#include <string>
+
 PPSDirectSimulationData::PPSDirectSimulationData()
     : empiricalAperture45_(""),
       empiricalAperture56_(""),
 
       timeResolutionDiamonds45_(""),
-      timeResolutionDiamonds56_(""),
+      timeResolutionDiamonds56_("") {}
 
-      effTimePath_(""),
-      effTimeObject45_(""),
-      effTimeObject56_("") {}
-
-// Destructor
 PPSDirectSimulationData::~PPSDirectSimulationData() {}
 
 // Getters
-const std::string& PPSDirectSimulationData::getEmpiricalAperture45() const { return empiricalAperture45_; }
-const std::string& PPSDirectSimulationData::getEmpiricalAperture56() const { return empiricalAperture56_; }
+const std::string &PPSDirectSimulationData::getEmpiricalAperture45() const { return empiricalAperture45_; }
+const std::string &PPSDirectSimulationData::getEmpiricalAperture56() const { return empiricalAperture56_; }
 
-const std::string& PPSDirectSimulationData::getTimeResolutionDiamonds45() const { return timeResolutionDiamonds45_; }
-const std::string& PPSDirectSimulationData::getTimeResolutionDiamonds56() const { return timeResolutionDiamonds56_; }
+const std::string &PPSDirectSimulationData::getTimeResolutionDiamonds45() const { return timeResolutionDiamonds45_; }
+const std::string &PPSDirectSimulationData::getTimeResolutionDiamonds56() const { return timeResolutionDiamonds56_; }
 
-const std::string& PPSDirectSimulationData::getEffTimePath() const { return effTimePath_; }
-const std::string& PPSDirectSimulationData::getEffTimeObject45() const { return effTimeObject45_; }
-const std::string& PPSDirectSimulationData::getEffTimeObject56() const { return effTimeObject56_; }
+std::map<unsigned int, PPSDirectSimulationData::FileObject> &PPSDirectSimulationData::getEfficienciesPerRP() {
+  return efficienciesPerRP_;
+}
+std::map<unsigned int, PPSDirectSimulationData::FileObject> &PPSDirectSimulationData::getEfficienciesPerPlane() {
+  return efficienciesPerPlane_;
+};
 
 // Setters
 void PPSDirectSimulationData::setEmpiricalAperture45(std::string s) { empiricalAperture45_ = s; }
@@ -34,20 +42,69 @@ void PPSDirectSimulationData::setEmpiricalAperture56(std::string s) { empiricalA
 void PPSDirectSimulationData::setTimeResolutionDiamonds45(std::string s) { timeResolutionDiamonds45_ = s; }
 void PPSDirectSimulationData::setTimeResolutionDiamonds56(std::string s) { timeResolutionDiamonds56_ = s; }
 
-void PPSDirectSimulationData::setEffTimePath(std::string s) { effTimePath_ = s; }
-void PPSDirectSimulationData::setEffTimeObject45(std::string s) { effTimeObject45_ = s; }
-void PPSDirectSimulationData::setEffTimeObject56(std::string s) { effTimeObject56_ = s; }
+std::map<unsigned int, std::unique_ptr<TH2F>> PPSDirectSimulationData::loadEffeciencyHistogramsPerRP() const {
+  std::map<unsigned int, std::unique_ptr<TH2F>> result;
 
-void PPSDirectSimulationData::printInfo(std::stringstream& s) {
-  s << "\nempiricalAperture45 = " << empiricalAperture45_ << "\nempiricalAperture56 = " << empiricalAperture56_
-    << "\ntimeResolutionDiamonds45 = " << timeResolutionDiamonds45_
-    << "\ntimeResolutionDiamonds56 = " << timeResolutionDiamonds56_ << "\neffTimePath= " << effTimePath_
-    << "\neffTimeObject45= " << effTimeObject45_ << "\neffTimeObject56= " << effTimeObject56_ << std::endl;
+  for (const auto &it : efficienciesPerRP_)
+    result[it.first] = loadObject(it.second.first, it.second.second);
+
+  return result;
 }
 
-std::ostream& operator<<(std::ostream& os, PPSDirectSimulationData info) {
-  std::stringstream ss;
-  info.printInfo(ss);
-  os << ss.str();
-  return os;
+std::map<unsigned int, std::unique_ptr<TH2F>> PPSDirectSimulationData::loadEffeciencyHistogramsPerPlane() const {
+  std::map<unsigned int, std::unique_ptr<TH2F>> result;
+
+  for (const auto &it : efficienciesPerPlane_) {
+    CTPPSDetId rpId(it.first);
+
+    if (rpId.subdetId() == CTPPSDetId::sdTrackingStrip) {
+      for (unsigned int pl = 0; pl < 10; ++pl) {
+        TotemRPDetId plId(rpId.arm(), rpId.station(), rpId.rp(), pl);
+        result[plId] = loadObject(it.second.first, replace(it.second.second, "<detid>", std::to_string(pl)));
+      }
+    }
+
+    if (rpId.subdetId() == CTPPSDetId::sdTrackingPixel) {
+      for (unsigned int pl = 0; pl < 6; ++pl) {
+        CTPPSPixelDetId plId(rpId.arm(), rpId.station(), rpId.rp(), pl);
+        result[plId] = loadObject(it.second.first, replace(it.second.second, "<detid>", std::to_string(pl)));
+      }
+    }
+
+    if (rpId.subdetId() == CTPPSDetId::sdTimingDiamond) {
+      for (unsigned int pl = 0; pl < 4; ++pl) {
+        CTPPSDiamondDetId plId(rpId.arm(), rpId.station(), rpId.rp(), pl);
+        result[plId] = loadObject(it.second.first, replace(it.second.second, "<detid>", std::to_string(pl)));
+      }
+    }
+  }
+
+  return result;
+}
+
+std::unique_ptr<TH2F> PPSDirectSimulationData::loadObject(const std::string &file, const std::string &object) {
+  edm::FileInPath fip(file.c_str());
+  TFile *f_in = TFile::Open(fip.fullPath().c_str());
+  if (!f_in)
+    throw cms::Exception("PPS") << "Cannot open file '" << fip.fullPath() << "'.";
+
+  TH2F *o_in = (TH2F *)f_in->Get(object.c_str());
+  if (!o_in)
+    throw cms::Exception("PPS") << "Cannot load object '" << object << "' from file '" << fip.fullPath() << "'.";
+
+  // disassociate histogram from the file
+  o_in->SetDirectory(nullptr);
+
+  delete f_in;
+
+  return std::unique_ptr<TH2F>(o_in);
+}
+
+std::string PPSDirectSimulationData::replace(std::string input, const std::string &from, const std::string &to) {
+  size_t start_pos = 0;
+  while ((start_pos = input.find(from, start_pos)) != std::string::npos) {
+    input.replace(start_pos, from.length(), to);
+    start_pos += to.length();
+  }
+  return input;
 }

--- a/Validation/CTPPS/plugins/CTPPSDirectProtonSimulation.cc
+++ b/Validation/CTPPS/plugins/CTPPSDirectProtonSimulation.cc
@@ -14,6 +14,7 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 #include "FWCore/Utilities/interface/ESInputTag.h"
+#include "FWCore/Utilities/interface/Exception.h"
 #include "SimDataFormats/GeneratorProducts/interface/HepMCProduct.h"
 
 #include "DataFormats/CTPPSDetId/interface/CTPPSDetId.h"
@@ -112,11 +113,17 @@ private:
   std::unique_ptr<TF2> empiricalAperture45_;
   std::unique_ptr<TF2> empiricalAperture56_;
 
-  // timing-RP efficiency
-  bool useTimingRPEfficiency_;
-  std::unique_ptr<TH2F> effTimeMap45_;
-  std::unique_ptr<TH2F> effTimeMap56_;
+  // efficiency flags
+  bool useTrackingEfficiencyPerRP_;
+  bool useTimingEfficiencyPerRP_;
+  bool useTrackingEfficiencyPerPlane_;
+  bool useTimingEfficiencyPerPlane_;
 
+  // efficiency maps
+  std::map<unsigned int, std::unique_ptr<TH2F>> efficiencyMapsPerRP_;
+  std::map<unsigned int, std::unique_ptr<TH2F>> efficiencyMapsPerPlane_;
+
+  // other parameters
   bool produceHitsRelativeToBeam_;
   bool roundToPitch_;
   bool checkIsHit_;
@@ -152,7 +159,11 @@ CTPPSDirectProtonSimulation::CTPPSDirectProtonSimulation(const edm::ParameterSet
       produceRecHits_(iConfig.getParameter<bool>("produceRecHits")),
 
       useEmpiricalApertures_(iConfig.getParameter<bool>("useEmpiricalApertures")),
-      useTimingRPEfficiency_(iConfig.getParameter<bool>("useTimingRPEfficiency")),
+
+      useTrackingEfficiencyPerRP_(iConfig.getParameter<bool>("useTrackingEfficiencyPerRP")),
+      useTimingEfficiencyPerRP_(iConfig.getParameter<bool>("useTimingEfficiencyPerRP")),
+      useTrackingEfficiencyPerPlane_(iConfig.getParameter<bool>("useTrackingEfficiencyPerPlane")),
+      useTimingEfficiencyPerPlane_(iConfig.getParameter<bool>("useTimingEfficiencyPerPlane")),
 
       produceHitsRelativeToBeam_(iConfig.getParameter<bool>("produceHitsRelativeToBeam")),
       roundToPitch_(iConfig.getParameter<bool>("roundToPitch")),
@@ -178,6 +189,13 @@ CTPPSDirectProtonSimulation::CTPPSDirectProtonSimulation(const edm::ParameterSet
     produces<std::map<int, edm::DetSetVector<CTPPSPixelRecHit>>>();
   }
 
+  // check user input
+  if (useTrackingEfficiencyPerRP_ && useTrackingEfficiencyPerPlane_)
+    throw cms::Exception("PPS") << "useTrackingEfficiencyPerRP and useTrackingEfficiencyPerPlane should not be simultaneously set true.";
+
+  if (useTimingEfficiencyPerRP_ && useTimingEfficiencyPerPlane_)
+    throw cms::Exception("PPS") << "useTimingEfficiencyPerRP and useTimingEfficiencyPerPlane should not be simultaneously set true.";
+
   // v position of strip 0
   stripZeroPosition_ = RPTopology::last_strip_to_border_dist_ + (RPTopology::no_of_strips_ - 1) * RPTopology::pitch_ -
                        RPTopology::y_width_ / 2.;
@@ -198,7 +216,12 @@ void CTPPSDirectProtonSimulation::fillDescriptions(edm::ConfigurationDescription
   desc.add<bool>("produceRecHits", true);
 
   desc.add<bool>("useEmpiricalApertures", true);
-  desc.add<bool>("useTimingRPEfficiency", false);
+
+  desc.add<bool>("useTrackingEfficiencyPerRP", false);
+  desc.add<bool>("useTimingEfficiencyPerRP", false);
+  desc.add<bool>("useTrackingEfficiencyPerPlane", false);
+  desc.add<bool>("useTimingEfficiencyPerPlane", false);
+
   desc.add<bool>("produceHitsRelativeToBeam", true);
   desc.add<bool>("roundToPitch", true);
   desc.add<bool>("checkIsHit", true);
@@ -236,15 +259,11 @@ void CTPPSDirectProtonSimulation::produce(edm::Event &iEvent, const edm::EventSe
     empiricalAperture56_ =
         std::make_unique<TF2>(TF2("empiricalAperture56", directSimuData.getEmpiricalAperture56().c_str()));
 
-    if (useTimingRPEfficiency_) {
-      edm::FileInPath fip(directSimuData.getEffTimePath().c_str());
-      std::unique_ptr<TFile> f_in(TFile::Open(fip.fullPath().c_str()));
-      effTimeMap45_ = std::unique_ptr<TH2F>((TH2F *)f_in->Get(directSimuData.getEffTimeObject45().c_str()));
-      effTimeMap56_ = std::unique_ptr<TH2F>((TH2F *)f_in->Get(directSimuData.getEffTimeObject56().c_str()));
-      effTimeMap45_->SetDirectory(nullptr);
-      effTimeMap56_->SetDirectory(nullptr);
-      f_in->Close();
-    }
+    // load the efficiency maps
+    if (useTrackingEfficiencyPerRP_ || useTimingEfficiencyPerRP_)
+      efficiencyMapsPerRP_ = directSimuData.loadEffeciencyHistogramsPerRP();
+    if (useTimingEfficiencyPerRP_ || useTimingEfficiencyPerRP_)
+      efficiencyMapsPerPlane_ = directSimuData.loadEffeciencyHistogramsPerPlane();
   }
 
   // prepare outputs
@@ -439,6 +458,28 @@ void CTPPSDirectProtonSimulation::processProton(
             << " mm, b_y = " << b_y << " mm, z = " << z_scoringPlane << " mm" << std::endl;
     }
 
+    // RP type
+    const bool isTrackingRP = (rpId.subdetId() == CTPPSDetId::sdTrackingStrip || rpId.subdetId() == CTPPSDetId::sdTrackingPixel);
+    const bool isTimingRP = (rpId.subdetId() == CTPPSDetId::sdTimingDiamond);
+
+    // apply per-RP efficiency
+    if ((useTimingEfficiencyPerRP_ && isTimingRP) || (useTrackingEfficiencyPerRP_ && isTrackingRP)) {
+      const auto it = efficiencyMapsPerRP_.find(rpId);
+
+      if (it != efficiencyMapsPerRP_.end())
+      {
+        const double r = CLHEP::RandFlat::shoot(rndEngine, 0., 1.);
+        auto *effMap = it->second.get();
+        const double eff = effMap->GetBinContent(effMap->FindBin(b_x, b_y));
+        if (r > eff)
+        {
+          if (verbosity_)
+            ssLog << "    stop due to per-RP efficiency" << std::endl;
+          continue;
+        }
+      }
+    }
+
     // save scoring plane hit
     if (produceScoringPlaneHits_)
       out_tracks.emplace_back(
@@ -496,6 +537,24 @@ void CTPPSDirectProtonSimulation::processProton(
               << std::endl;
       }
 
+      // apply per-plane efficiency
+      if ((useTimingEfficiencyPerPlane_ && isTimingRP) || (useTrackingEfficiencyPerPlane_ && isTrackingRP)) {
+        const auto it = efficiencyMapsPerRP_.find(detId);
+
+        if (it != efficiencyMapsPerRP_.end())
+        {
+          const double r = CLHEP::RandFlat::shoot(rndEngine, 0., 1.);
+          auto *effMap = it->second.get();
+          const double eff = effMap->GetBinContent(effMap->FindBin(h_glo.x(), h_glo.y()));
+          if (r > eff)
+          {
+            if (verbosity_)
+              ssLog << "    stop due to per-plane efficiency" << std::endl;
+            continue;
+          }
+        }
+      }
+
       // strips
       if (detId.subdetId() == CTPPSDetId::sdTrackingStrip) {
         double u = h_loc.x();
@@ -538,13 +597,6 @@ void CTPPSDirectProtonSimulation::processProton(
       // diamonds
       if (detId.subdetId() == CTPPSDetId::sdTimingDiamond) {
         CTPPSDiamondDetId diamondDetId(detIdInt);
-
-        //efficiency
-        if (useTimingRPEfficiency_) {
-          TH2F *effMap = (diamondDetId.arm() == 0) ? effTimeMap45_.get() : effTimeMap56_.get();
-          if (CLHEP::RandFlat::shoot(rndEngine, 0., 1.) > effMap->GetBinContent(effMap->FindBin(h_glo.x(), h_glo.y())))
-            continue;
-        }
 
         // check acceptance
         const auto *dg = geometry.sensor(detIdInt);

--- a/Validation/CTPPS/plugins/CTPPSDirectProtonSimulation.cc
+++ b/Validation/CTPPS/plugins/CTPPSDirectProtonSimulation.cc
@@ -191,10 +191,12 @@ CTPPSDirectProtonSimulation::CTPPSDirectProtonSimulation(const edm::ParameterSet
 
   // check user input
   if (useTrackingEfficiencyPerRP_ && useTrackingEfficiencyPerPlane_)
-    throw cms::Exception("PPS") << "useTrackingEfficiencyPerRP and useTrackingEfficiencyPerPlane should not be simultaneously set true.";
+    throw cms::Exception("PPS")
+        << "useTrackingEfficiencyPerRP and useTrackingEfficiencyPerPlane should not be simultaneously set true.";
 
   if (useTimingEfficiencyPerRP_ && useTimingEfficiencyPerPlane_)
-    throw cms::Exception("PPS") << "useTimingEfficiencyPerRP and useTimingEfficiencyPerPlane should not be simultaneously set true.";
+    throw cms::Exception("PPS")
+        << "useTimingEfficiencyPerRP and useTimingEfficiencyPerPlane should not be simultaneously set true.";
 
   // v position of strip 0
   stripZeroPosition_ = RPTopology::last_strip_to_border_dist_ + (RPTopology::no_of_strips_ - 1) * RPTopology::pitch_ -
@@ -459,20 +461,19 @@ void CTPPSDirectProtonSimulation::processProton(
     }
 
     // RP type
-    const bool isTrackingRP = (rpId.subdetId() == CTPPSDetId::sdTrackingStrip || rpId.subdetId() == CTPPSDetId::sdTrackingPixel);
+    const bool isTrackingRP =
+        (rpId.subdetId() == CTPPSDetId::sdTrackingStrip || rpId.subdetId() == CTPPSDetId::sdTrackingPixel);
     const bool isTimingRP = (rpId.subdetId() == CTPPSDetId::sdTimingDiamond);
 
     // apply per-RP efficiency
     if ((useTimingEfficiencyPerRP_ && isTimingRP) || (useTrackingEfficiencyPerRP_ && isTrackingRP)) {
       const auto it = efficiencyMapsPerRP_.find(rpId);
 
-      if (it != efficiencyMapsPerRP_.end())
-      {
+      if (it != efficiencyMapsPerRP_.end()) {
         const double r = CLHEP::RandFlat::shoot(rndEngine, 0., 1.);
         auto *effMap = it->second.get();
         const double eff = effMap->GetBinContent(effMap->FindBin(b_x, b_y));
-        if (r > eff)
-        {
+        if (r > eff) {
           if (verbosity_)
             ssLog << "    stop due to per-RP efficiency" << std::endl;
           continue;
@@ -541,13 +542,11 @@ void CTPPSDirectProtonSimulation::processProton(
       if ((useTimingEfficiencyPerPlane_ && isTimingRP) || (useTrackingEfficiencyPerPlane_ && isTrackingRP)) {
         const auto it = efficiencyMapsPerPlane_.find(detId);
 
-        if (it != efficiencyMapsPerPlane_.end())
-        {
+        if (it != efficiencyMapsPerPlane_.end()) {
           const double r = CLHEP::RandFlat::shoot(rndEngine, 0., 1.);
           auto *effMap = it->second.get();
           const double eff = effMap->GetBinContent(effMap->FindBin(h_glo.x(), h_glo.y()));
-          if (r > eff)
-          {
+          if (r > eff) {
             if (verbosity_)
               ssLog << "    stop due to per-plane efficiency" << std::endl;
             continue;

--- a/Validation/CTPPS/plugins/CTPPSDirectProtonSimulation.cc
+++ b/Validation/CTPPS/plugins/CTPPSDirectProtonSimulation.cc
@@ -262,7 +262,7 @@ void CTPPSDirectProtonSimulation::produce(edm::Event &iEvent, const edm::EventSe
     // load the efficiency maps
     if (useTrackingEfficiencyPerRP_ || useTimingEfficiencyPerRP_)
       efficiencyMapsPerRP_ = directSimuData.loadEffeciencyHistogramsPerRP();
-    if (useTimingEfficiencyPerRP_ || useTimingEfficiencyPerRP_)
+    if (useTrackingEfficiencyPerPlane_ || useTimingEfficiencyPerPlane_)
       efficiencyMapsPerPlane_ = directSimuData.loadEffeciencyHistogramsPerPlane();
   }
 

--- a/Validation/CTPPS/plugins/CTPPSDirectProtonSimulation.cc
+++ b/Validation/CTPPS/plugins/CTPPSDirectProtonSimulation.cc
@@ -539,9 +539,9 @@ void CTPPSDirectProtonSimulation::processProton(
 
       // apply per-plane efficiency
       if ((useTimingEfficiencyPerPlane_ && isTimingRP) || (useTrackingEfficiencyPerPlane_ && isTrackingRP)) {
-        const auto it = efficiencyMapsPerRP_.find(detId);
+        const auto it = efficiencyMapsPerPlane_.find(detId);
 
-        if (it != efficiencyMapsPerRP_.end())
+        if (it != efficiencyMapsPerPlane_.end())
         {
           const double r = CLHEP::RandFlat::shoot(rndEngine, 0., 1.);
           auto *effMap = it->second.get();

--- a/Validation/CTPPS/python/simu_config/base_cff.py
+++ b/Validation/CTPPS/python/simu_config/base_cff.py
@@ -40,9 +40,8 @@ profile_base = cms.PSet(
     timeResolutionDiamonds45 = cms.string("999"),
     timeResolutionDiamonds56 = cms.string("999"),
 
-    effTimePath = cms.string(""),
-    effTimeObject45 = cms.string(""),
-    effTimeObject56 = cms.string("")
+    efficienciesPerRP = cms.VPSet(),
+    efficienciesPerPlane = cms.VPSet()
   )
 )
 
@@ -105,7 +104,6 @@ ctppsDirectProtonSimulation.pitchStrips = 66E-3 * 12 / 19 # effective value to r
 ctppsDirectProtonSimulation.pitchPixelsHor = 50E-3
 ctppsDirectProtonSimulation.pitchPixelsVer = 80E-3
 ctppsDirectProtonSimulation.useEmpiricalApertures = True
-ctppsDirectProtonSimulation.useTimingRPEfficiency = False
 ctppsDirectProtonSimulation.produceHitsRelativeToBeam = True
 ctppsDirectProtonSimulation.produceScoringPlaneHits = False
 ctppsDirectProtonSimulation.produceRecHits = True


### PR DESCRIPTION
#### PR description:

This PR extends the PPS direct simulation with an optional feature to simulate efficiency effects. Either per RP (~ local-track level) or per sensor plane (~ rec hit level). These features aim at facilitating various POG and DPG oriented studies, respectively. The efficiencies are applied to tracking and timing RPs in an uniform manner.

#### PR validation:

Technical validation - comparisons before-after this PR:
  * [reco_cmp.pdf](https://github.com/cms-sw/cmssw/files/5909831/reco_cmp.pdf): Run2 data reco workflows - no difference, as expected
  * [dirsim_cmp.pdf](https://github.com/cms-sw/cmssw/files/5909830/dirsim_cmp.pdf): direct simulation workflows - no difference, as expected - the new features are not enabled by default.

Functional validation kindly done by @AndreaBellora . The direct simulation is run with the following efficiency map (artificial):
![input](https://user-images.githubusercontent.com/17830858/106575315-3bc2d700-653c-11eb-9cb6-6e59e479aa3d.png)
The efficiency extracted from the simulation output:
![output](https://user-images.githubusercontent.com/17830858/106575318-3cf40400-653c-11eb-92fc-7a3341cf0a4a.png)
is well compatible with the input.





