### PR TITLE
Phase-2 Inner Tracker local reconstruction configuration updates

### DIFF
--- a/Configuration/AlCa/python/autoCondPhase2.py
+++ b/Configuration/AlCa/python/autoCondPhase2.py
@@ -52,15 +52,15 @@ allTags["SimLA"] = {
 }
 
 allTags["GenError"] = {
-    'T15' : ( ','.join( [ 'SiPixelGenErrorDBObject_phase2_IT_v6.1.5_25x100_v2_mc' ,SiPixelGenErrorRecord,connectionString, "", "2020-10-16 10:00:00"] ), ),  # cell is 25um (local-x) x 100um (local-y) , VBias=350V
-    'T21' : ( ','.join( [ 'SiPixelGenErrorDBObject_phase2_IT_v6.1.5_25x100_v2_mc',SiPixelGenErrorRecord,connectionString, "", "2020-10-16 10:00:00"] ), ),  # cell is 25um (local-x) x 100um (local-y) , VBias=350V
-    'T22' : ( ','.join( [ 'SiPixelGenErrorDBObject_phase2_IT_v6.1.5_50x50_v4_mc' ,SiPixelGenErrorRecord,connectionString, "", "2020-10-19 23:00:00"] ), ),  # cell is 50um (local-x) x 50um (local-y) , VBias=350V
+    'T15' : ( ','.join( [ 'SiPixelGenErrorDBObject_phase2_IT_v6.1.5_25x100_v3_mc',SiPixelGenErrorRecord,connectionString, "", "2021-01-27 10:00:00"] ), ),  # cell is 25um (local-x) x 100um (local-y) , VBias=350V
+    'T21' : ( ','.join( [ 'SiPixelGenErrorDBObject_phase2_IT_v6.1.5_25x100_v3_mc',SiPixelGenErrorRecord,connectionString, "", "2021-01-27 10:00:00"] ), ),  # cell is 25um (local-x) x 100um (local-y) , VBias=350V
+    'T22' : ( ','.join( [ 'SiPixelGenErrorDBObject_phase2_IT_v6.1.5_50x50_v5_mc' ,SiPixelGenErrorRecord,connectionString, "", "2021-01-27 10:00:00"] ), ),  # cell is 50um (local-x) x 50um (local-y) , VBias=350V
 }
 
 allTags["Template"] = {
-    'T15' : ( ','.join( [ 'SiPixelTemplateDBObject_phase2_IT_v6.1.5_25x100_v2_mc',SiPixelTemplatesRecord,connectionString, "", "2020-10-16 10:00:00"] ), ),  # cell is 25um (local-x) x 100um (local-y) , VBias=350V
-    'T21' : ( ','.join( [ 'SiPixelTemplateDBObject_phase2_IT_v6.1.5_25x100_v2_mc',SiPixelTemplatesRecord,connectionString, "", "2020-10-16 10:00:00"] ), ),  # cell is 25um (local-x) x 100um (local-y) , VBias=350V
-    'T22' : ( ','.join( [ 'SiPixelTemplateDBObject_phase2_IT_v6.1.5_50x50_v4_mc' ,SiPixelTemplatesRecord,connectionString, "", "2020-10-19 23:00:00"] ), ),  # cell is 50um (local-x) x 50um (local-y) , VBias=350V
+    'T15' : ( ','.join( [ 'SiPixelTemplateDBObject_phase2_IT_v6.1.5_25x100_v3_mc',SiPixelTemplatesRecord,connectionString, "", "2021-01-27 10:00:00"] ), ),  # cell is 25um (local-x) x 100um (local-y) , VBias=350V
+    'T21' : ( ','.join( [ 'SiPixelTemplateDBObject_phase2_IT_v6.1.5_25x100_v3_mc',SiPixelTemplatesRecord,connectionString, "", "2021-01-27 10:00:00"] ), ),  # cell is 25um (local-x) x 100um (local-y) , VBias=350V
+    'T22' : ( ','.join( [ 'SiPixelTemplateDBObject_phase2_IT_v6.1.5_50x50_v5_mc' ,SiPixelTemplatesRecord,connectionString, "", "2021-01-27 10:00:00"] ), ),  # cell is 50um (local-x) x 50um (local-y) , VBias=350V
 }
 
 ##

--- a/Configuration/Eras/python/Era_Phase2C11T22_cff.py
+++ b/Configuration/Eras/python/Era_Phase2C11T22_cff.py
@@ -1,0 +1,6 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Eras.Era_Phase2C11_cff import Phase2C11
+from Configuration.Eras.Modifier_phase2_squarePixels_cff import phase2_squarePixels
+
+Phase2C11T22 = cms.ModifierChain(Phase2C11, phase2_squarePixels)

--- a/Configuration/Eras/python/Era_Phase2C11T23_cff.py
+++ b/Configuration/Eras/python/Era_Phase2C11T23_cff.py
@@ -1,0 +1,6 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Eras.Era_Phase2C11_cff import Phase2C11
+from Configuration.Eras.Modifier_phase2_3DPixels_cff import phase2_3DPixels
+
+Phase2C11T23 = cms.ModifierChain(Phase2C11, phase2_3DPixels)

--- a/Configuration/Eras/python/Modifier_phase2_3DPixels_cff.py
+++ b/Configuration/Eras/python/Modifier_phase2_3DPixels_cff.py
@@ -1,0 +1,3 @@
+import FWCore.ParameterSet.Config as cms
+
+phase2_3DPixels = cms.Modifier()

--- a/Configuration/Eras/python/Modifier_phase2_squarePixels_cff.py
+++ b/Configuration/Eras/python/Modifier_phase2_squarePixels_cff.py
@@ -1,0 +1,3 @@
+import FWCore.ParameterSet.Config as cms
+
+phase2_squarePixels = cms.Modifier()

--- a/Configuration/Geometry/python/dict2026Geometry.py
+++ b/Configuration/Geometry/python/dict2026Geometry.py
@@ -221,7 +221,7 @@ trackerDict = {
             'from Geometry.TrackerGeometryBuilder.idealForDigiTrackerGeometry_cff import *',
             'trackerGeometry.applyAlignment = cms.bool(False)',
         ],
-        "era" : "phase2_tracker, trackingPhase2PU140",
+        "era" : "phase2_tracker, phase2_squarePixels, trackingPhase2PU140",
     },
     "T23" : {
         1 : [
@@ -255,7 +255,7 @@ trackerDict = {
             'from Geometry.TrackerGeometryBuilder.idealForDigiTrackerGeometry_cff import *',
             'trackerGeometry.applyAlignment = cms.bool(False)',
         ],
-        "era" : "phase2_tracker, trackingPhase2PU140",
+        "era" : "phase2_tracker, phase2_3DPixels, trackingPhase2PU140",
     }
 }
 

--- a/Configuration/ProcessModifiers/python/PixelCPEGeneric_cff.py
+++ b/Configuration/ProcessModifiers/python/PixelCPEGeneric_cff.py
@@ -1,4 +1,4 @@
 import FWCore.ParameterSet.Config as cms
 
 # This modifier is to run the Pixel Generic CPE algorithm in Phase-2 workflows
-phase2_PixelCPEGeneric =  cms.Modifier()
+PixelCPEGeneric =  cms.Modifier()

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -1069,18 +1069,19 @@ upgradeProperties[2026] = {
         'ScenToRun' : ['GenSimHLBeamSpot','DigiTrigger','RecoGlobal', 'HARVESTGlobal'],
     },
     '2026D64' : {
-        'Geom' : 'Extended2026D64',                   # N.B.: Geometry with square 50x50 um2 pixels in the Inner Tracker.
+        'Geom' : 'Extended2026D64',             # N.B.: Geometry with square 50x50 um2 pixels in the Inner Tracker.
         'HLTmenu': '@fake2',
         'GT' : 'auto:phase2_realistic_T22',
-        'Era' : 'Phase2C11',
+        'ProcessModifier': 'PixelCPEGeneric',   # This swaps template reco CPE for generic reco CPE
+        'Era' : 'Phase2C11T22',       # customized for square pixels
         'ScenToRun' : ['GenSimHLBeamSpot','DigiTrigger','RecoGlobal', 'HARVESTGlobal'],
     },
     '2026D65' : {
-        'Geom' : 'Extended2026D65',                   # N.B.: Geometry with 3D pixels in the Inner Tracker.
+        'Geom' : 'Extended2026D65',             # N.B.: Geometry with 3D pixels in the Inner Tracker.
         'HLTmenu': '@fake2',
-        'GT' : 'auto:phase2_realistic_T23',           # This symbolic GT has no pixel template / GenError informations.
-        'ProcessModifier': 'phase2_PixelCPEGeneric',  # This modifier removes all need for IT template information. DO NOT USE for standard planar sensors.
-        'Era' : 'Phase2C11',
+        'GT' : 'auto:phase2_realistic_T23',     # This symbolic GT has no pixel template / GenError informations.
+        'ProcessModifier': 'PixelCPEGeneric',   # This swaps template reco CPE for generic reco CPE
+        'Era' : 'Phase2C11T23',           # customizes for 3D Pixels
         'ScenToRun' : ['GenSimHLBeamSpot','DigiTrigger','RecoGlobal', 'HARVESTGlobal'],
     },
     '2026D66' : {

--- a/Configuration/StandardSequences/python/Eras.py
+++ b/Configuration/StandardSequences/python/Eras.py
@@ -43,6 +43,8 @@ class Eras (object):
                  'Phase2C10_dd4hep',
                  'Phase2C11_dd4hep',
                  'Phase2C11_etlV4',
+                 'Phase2C11T22',
+                 'Phase2C11T23',
                  'Phase2C12_dd4hep',
                  'Phase2C11M9',
         ]
@@ -61,6 +63,7 @@ class Eras (object):
                            'phase2_hgcal', 'phase2_timing', 'phase2_hfnose', 'phase2_hgcalV10', 'phase2_hgcalV11', 'phase2_hgcalV12',
                            'phase2_timing_layer', 'phase2_hcal', 'phase2_ecal','phase2_ecal_devel',
                            'phase2_trigger',
+                           'phase2_squarePixels', 'phase2_3DPixels',
                            'trackingLowPU', 'trackingPhase1', 'ctpps_2016', 'ctpps_2017', 'ctpps_2018', 'ctpps_2021', 'trackingPhase2PU140','highBetaStar_2018',
                            'tracker_apv_vfp30_2016', 'pf_badHcalMitigation', 'run2_miniAOD_80XLegacy','run2_miniAOD_94XFall17', 'run2_nanoAOD_92X',
                            'run2_nanoAOD_94XMiniAODv1', 'run2_nanoAOD_94XMiniAODv2', 'run2_nanoAOD_94X2016',

--- a/RecoLocalTracker/SiPixelRecHits/python/PixelCPEGeneric_cfi.py
+++ b/RecoLocalTracker/SiPixelRecHits/python/PixelCPEGeneric_cfi.py
@@ -8,7 +8,6 @@ PixelCPEGenericESProducer = _generic_default.clone()
 from Configuration.Eras.Modifier_run3_common_cff import run3_common
 run3_common.toModify(PixelCPEGenericESProducer, IrradiationBiasCorrection = True)
 
-
 # customize the Pixel CPE generic producer for phase2
 from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
 phase2_tracker.toModify(PixelCPEGenericESProducer,
@@ -21,10 +20,19 @@ phase2_tracker.toModify(PixelCPEGenericESProducer,
   Upgrade = True                     # use 'upgrade' version of hardcoded CPE errors
 )
 
+# customize the Pixel CPE generic producer for phase2 3D pixels
+# Will remove any usage of template / genError payloads from the reconstruction
+from Configuration.Eras.Modifier_phase2_3DPixels_cff import phase2_3DPixels
+(phase2_tracker & phase2_3DPixels).toModify(PixelCPEGenericESProducer,
+                                            UseErrorsFromTemplates = False,    # no GenErrors
+                                            LoadTemplatesFromDB = False,       # do not load templates
+                                            )
 
-# customize the Pixel CPE generic producer in order not to use any  template information
-from Configuration.ProcessModifiers.phase2_PixelCPEGeneric_cff import phase2_PixelCPEGeneric
-phase2_PixelCPEGeneric.toModify(PixelCPEGenericESProducer,
-  UseErrorsFromTemplates = False,    # no GenErrors
-  LoadTemplatesFromDB = False,       # do not load templates
-)
+# customize the Pixel CPE generic producer for phase2 square pixels
+# Do use Template errors for square pixels even in the first tracking step
+# This is needed because hardcoded errors in https://github.com/cms-sw/cmssw/blob/master/RecoLocalTracker/SiPixelRecHits/src/PixelCPEGeneric.cc#L113
+# have been optimized for rectangular 25x100 pixels, and in the current generic reco setup we use hardcoded errors for the first tracking pass
+from Configuration.Eras.Modifier_phase2_squarePixels_cff import phase2_squarePixels
+(phase2_tracker & phase2_squarePixels).toModify(PixelCPEGenericESProducer,
+                                                NoTemplateErrorsWhenNoTrkAngles = False # use genErrors in the seeding step (when no track angles are available)
+                                                )

--- a/RecoTracker/TransientTrackingRecHit/python/TTRHBuilderWithTemplate_cfi.py
+++ b/RecoTracker/TransientTrackingRecHit/python/TTRHBuilderWithTemplate_cfi.py
@@ -16,5 +16,5 @@ from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
 phase1Pixel.toModify(TTRHBuilderAngleAndTemplate, PixelCPE = 'PixelCPEClusterRepair')
 
 # Turn off template reco for phase 2 (when not supported)
-from Configuration.ProcessModifiers.phase2_PixelCPEGeneric_cff import phase2_PixelCPEGeneric
-phase2_PixelCPEGeneric.toModify(TTRHBuilderAngleAndTemplate, PixelCPE = 'PixelCPEGeneric')
+from Configuration.ProcessModifiers.PixelCPEGeneric_cff import PixelCPEGeneric
+PixelCPEGeneric.toModify(TTRHBuilderAngleAndTemplate, PixelCPE = 'PixelCPEGeneric')

--- a/SimTracker/SiPhase2Digitizer/test/PixelTestBeamValidator_cfg.py
+++ b/SimTracker/SiPhase2Digitizer/test/PixelTestBeamValidator_cfg.py
@@ -1,9 +1,9 @@
 import FWCore.ParameterSet.Config as cms
 
 from Configuration.Eras.Era_Phase2C9_cff import Phase2C9
-from Configuration.ProcessModifiers.phase2_PixelCPEGeneric_cff import phase2_PixelCPEGeneric
+from Configuration.ProcessModifiers.PixelCPEGeneric_cff import PixelCPEGeneric
 
-process = cms.Process('digiTest',Phase2C9,phase2_PixelCPEGeneric)
+process = cms.Process('digiTest',Phase2C9,PixelCPEGeneric)
 
 import FWCore.ParameterSet.VarParsing as VarParsing 
 options = VarParsing.VarParsing ("analysis") 


### PR DESCRIPTION
#### PR description:

The purpose of this PR is to update the conditions and customizations used to deal with the Phase-2 Inner tracker local reconstruction.
With respect to last update (PR https://github.com/cms-sw/cmssw/pull/32220) it has been found that:
   1) a later version of pixel templates and GenError payloads was produced with enhanced angular span in cotα and cotβ, 
   2) the template reconstruction for the square pixels (geometry T22) is sub-optimal at the physical edges of modules and at very high rapidity (|η|>2.5) (see more details [here](https://indico.cern.ch/event/988835/contributions/4196673/attachments/2176549/3675455/2021_01_22_SimulationPlanarSensorResolution.pdf)). These effects are due to some limitation to the pixel template reconstruction code in presence of 50um long cells in the longitudinal direction. As it seems - at this point - unlikely to instrument the phase-2 inner tracker with 50x50 pixels especially at high rapidity due to low resilience to radiation damage, it has been instead preferred to avoid changing the reconstruction code and use the generic reconstruction instead, within the limited scope of producing reference resolution results in the not-irradiated simulation case.
   
The first point is addressed in commit 5e2562c  by updating the `autoCondPhase2.py` file, while the second is addressed by introducing two `Era`s be used on top of the `PixelCPEGeneric` process modifier (**N.B. its name has been changed since now is generic enough not to entail only phase2**):
   * `Phase2C11T23` (targeting geometry T23, and 3D pixels in general) removes any usage of template / genError payloads from the reconstruction, as those are not yet available for 3D pixels
   * `Phase2C11T22` (targeting geometry T22 and square pixels in general) allows to use genErrors in the seeding step (when no track angles are available). This is needed because hardcoded errors in https://github.com/cms-sw/cmssw/blob/master/RecoLocalTracker/SiPixelRecHits/src/PixelCPEGeneric.cc#L113 have been optimized for rectangular 25x100 pixels, and in the current generic reco setup we use hardcoded errors for the first tracking pass (see PR https://github.com/cms-sw/cmssw/pull/29783)

#### PR validation:

Run successfully `runTheMatrix.py --what upgrade -l 29806.0,30606.0,30206.0` to test technical soundness of the code changes.
Private internal validation of the new setup is available here: https://dinardo.web.cern.ch/dinardo/TMPshare/
In particular the pulls for the track parameters for T22 have changed from:

| Before this PR  | With this PR |
| ------------- | ------------- |
| ![image](https://user-images.githubusercontent.com/5082376/106575142-04ecc100-653c-11eb-8b3f-0cd9d2e73729.png) | ![image](https://user-images.githubusercontent.com/5082376/106575235-2352bc80-653c-11eb-8b59-a706c4020409.png) |

In blue is T22 (with generic CPE) while in red is T21 (with template CPE, baseline).

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This PR is not a backport and no backport is needed.
cc:
@emiglior @tsusa @OzAmram @tvami @gennai @dinardo 

