### PR TITLE
Pr113x L1T Bug fix:  uGT emulator of displaced muons

### DIFF
--- a/L1Trigger/L1TGlobal/src/MuCondition.cc
+++ b/L1Trigger/L1TGlobal/src/MuCondition.cc
@@ -382,7 +382,7 @@ const bool l1t::MuCondition::checkObjectParameter(const int iCondition,
                         << "\n\t hwQual     = 0x " << cand.hwQual() << "\n\t hwIso      = 0x " << cand.hwIso()
                         << std::dec << std::endl;
 
-  if( objPar.unconstrainedPtHigh > 0 ) // POTENTIAL FIX (HACK) RICK
+  if( objPar.unconstrainedPtHigh > 0 ) // Check if unconstrained pT cut-window is valid
   {
     if (!checkThreshold(objPar.unconstrainedPtLow, objPar.unconstrainedPtHigh, cand.hwPtUnconstrained(), m_gtMuonTemplate->condGEq())) 
     {
@@ -400,9 +400,6 @@ const bool l1t::MuCondition::checkObjectParameter(const int iCondition,
     if (!passImpactParameterLUT) // POTENITAL PROBLEM RICK
       {
 	LogDebug("L1TGlobal") << "\t\t l1t::Candidate failed impact parameter requirement" << std::endl;
-	std::cout << "\t\t l1t::Candidate failed impact parameter requirement" << std::endl;
-	std::cout << "\t\t l1t::Candidate impactParameterLUT = " << objPar.impactParameterLUT << std::endl;
-	std::cout << "\t\t l1t::Candidate cand.hwDXY()       = " << cand.hwDXY() << std::endl;
 	return false;
       }
   }

--- a/L1Trigger/L1TGlobal/src/MuCondition.cc
+++ b/L1Trigger/L1TGlobal/src/MuCondition.cc
@@ -388,8 +388,8 @@ const bool l1t::MuCondition::checkObjectParameter(const int iCondition,
                         objPar.unconstrainedPtHigh,
                         cand.hwPtUnconstrained(),
                         m_gtMuonTemplate->condGEq())) {
-      LogDebug("L1TGlobal") << "\t\t Muon Failed unconstrainedPt checkThreshold " << std::endl;
-      std::cout << "\t\t Muon Failed unconstrainedPt checkThreshold; iCondition = " << iCondition << std::endl;
+      LogDebug("L1TGlobal") << "\t\t Muon Failed unconstrainedPt checkThreshold; iCondition = " << iCondition
+                            << std::endl;
       return false;
     }
     // check impact parameter ( bit check ) with impact parameter LUT

--- a/L1Trigger/L1TGlobal/src/MuCondition.cc
+++ b/L1Trigger/L1TGlobal/src/MuCondition.cc
@@ -382,26 +382,28 @@ const bool l1t::MuCondition::checkObjectParameter(const int iCondition,
                         << "\n\t hwQual     = 0x " << cand.hwQual() << "\n\t hwIso      = 0x " << cand.hwIso()
                         << std::dec << std::endl;
 
-  if( objPar.unconstrainedPtHigh > 0 ) // Check if unconstrained pT cut-window is valid
+  if (objPar.unconstrainedPtHigh > 0)  // Check if unconstrained pT cut-window is valid
   {
-    if (!checkThreshold(objPar.unconstrainedPtLow, objPar.unconstrainedPtHigh, cand.hwPtUnconstrained(), m_gtMuonTemplate->condGEq())) 
-    {
-	LogDebug("L1TGlobal") << "\t\t Muon Failed unconstrainedPt checkThreshold " << std::endl;
-	std::cout << "\t\t Muon Failed unconstrainedPt checkThreshold; iCondition = " << iCondition << std::endl;
-	return false;
+    if (!checkThreshold(objPar.unconstrainedPtLow,
+                        objPar.unconstrainedPtHigh,
+                        cand.hwPtUnconstrained(),
+                        m_gtMuonTemplate->condGEq())) {
+      LogDebug("L1TGlobal") << "\t\t Muon Failed unconstrainedPt checkThreshold " << std::endl;
+      std::cout << "\t\t Muon Failed unconstrainedPt checkThreshold; iCondition = " << iCondition << std::endl;
+      return false;
     }
-      // check impact parameter ( bit check ) with impact parameter LUT
+    // check impact parameter ( bit check ) with impact parameter LUT
     // sanity check on candidate impact parameter
     if (cand.hwDXY() > 3) {
       LogDebug("L1TGlobal") << "\t\t l1t::Candidate has out of range hwDXY = " << cand.hwDXY() << std::endl;
       return false;
     }
     bool passImpactParameterLUT = ((objPar.impactParameterLUT >> cand.hwDXY()) & 1);
-    if (!passImpactParameterLUT) // POTENITAL PROBLEM RICK
-      {
-	LogDebug("L1TGlobal") << "\t\t l1t::Candidate failed impact parameter requirement" << std::endl;
-	return false;
-      }
+    if (!passImpactParameterLUT)  // POTENITAL PROBLEM RICK
+    {
+      LogDebug("L1TGlobal") << "\t\t l1t::Candidate failed impact parameter requirement" << std::endl;
+      return false;
+    }
   }
 
   if (!checkThreshold(objPar.ptLowThreshold, objPar.ptHighThreshold, cand.hwPt(), m_gtMuonTemplate->condGEq())) {

--- a/L1Trigger/L1TGlobal/src/MuCondition.cc
+++ b/L1Trigger/L1TGlobal/src/MuCondition.cc
@@ -9,7 +9,7 @@
  *
  * \author: Vasile Mihai Ghete   - HEPHY Vienna
  *          Vladimir Rekovic - extend for indexing
- *
+ *          Rick Cavanaugh - include displaced muons
  *
  */
 

--- a/L1Trigger/L1TGlobal/src/MuCondition.cc
+++ b/L1Trigger/L1TGlobal/src/MuCondition.cc
@@ -382,12 +382,29 @@ const bool l1t::MuCondition::checkObjectParameter(const int iCondition,
                         << "\n\t hwQual     = 0x " << cand.hwQual() << "\n\t hwIso      = 0x " << cand.hwIso()
                         << std::dec << std::endl;
 
-  if (!checkThreshold(objPar.unconstrainedPtLow,
-                      objPar.unconstrainedPtHigh,
-                      cand.hwPtUnconstrained(),
-                      m_gtMuonTemplate->condGEq())) {
-    LogDebug("L1TGlobal") << "\t\t Muon Failed unconstrainedPt checkThreshold " << std::endl;
-    return false;
+  if( objPar.unconstrainedPtHigh > 0 ) // POTENTIAL FIX (HACK) RICK
+  {
+    if (!checkThreshold(objPar.unconstrainedPtLow, objPar.unconstrainedPtHigh, cand.hwPtUnconstrained(), m_gtMuonTemplate->condGEq())) 
+    {
+	LogDebug("L1TGlobal") << "\t\t Muon Failed unconstrainedPt checkThreshold " << std::endl;
+	std::cout << "\t\t Muon Failed unconstrainedPt checkThreshold; iCondition = " << iCondition << std::endl;
+	return false;
+    }
+      // check impact parameter ( bit check ) with impact parameter LUT
+    // sanity check on candidate impact parameter
+    if (cand.hwDXY() > 3) {
+      LogDebug("L1TGlobal") << "\t\t l1t::Candidate has out of range hwDXY = " << cand.hwDXY() << std::endl;
+      return false;
+    }
+    bool passImpactParameterLUT = ((objPar.impactParameterLUT >> cand.hwDXY()) & 1);
+    if (!passImpactParameterLUT) // POTENITAL PROBLEM RICK
+      {
+	LogDebug("L1TGlobal") << "\t\t l1t::Candidate failed impact parameter requirement" << std::endl;
+	std::cout << "\t\t l1t::Candidate failed impact parameter requirement" << std::endl;
+	std::cout << "\t\t l1t::Candidate impactParameterLUT = " << objPar.impactParameterLUT << std::endl;
+	std::cout << "\t\t l1t::Candidate cand.hwDXY()       = " << cand.hwDXY() << std::endl;
+	return false;
+      }
   }
 
   if (!checkThreshold(objPar.ptLowThreshold, objPar.ptHighThreshold, cand.hwPt(), m_gtMuonTemplate->condGEq())) {


### PR DESCRIPTION
#### PR description:
PR 11_3_X 
This is a bug fix needed for MWGR: first check if the high value of the unconstrained pT cut-window is valid (i.e. greater than 0), before proceeding to evaluate the cut on unconstrained pT, otherwise the emulation of triggers without unconstrained pT cuts specified will be affected.
There are no changes to output.
This PR does not depend on any externals.

#### PR validation:

<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

<!-- Please replace this text with any link to  -->

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
