### PR TITLE
Added support of Authorization for Tag access (back-port)

### DIFF
--- a/CondCore/CondDB/interface/Auth.h
+++ b/CondCore/CondDB/interface/Auth.h
@@ -30,6 +30,16 @@ namespace cond {
     static constexpr unsigned int COND_AUTHENTICATION_KEY_SIZE = 30;
     static constexpr unsigned int COND_DB_KEY_SIZE = 30;
 
+    static constexpr size_t COND_SESSION_HASH_SIZE = 16;
+
+    static constexpr int COND_SESSION_HASH_CODE = 4;
+    static constexpr int COND_DBKEY_CREDENTIAL_CODE = 1;
+
+    static constexpr int COND_DBTAG_LOCK_ACCESS_CODE = 8;
+    static constexpr int COND_DBTAG_WRITE_ACCESS_CODE = 2;
+    static constexpr int COND_DBTAG_READ_ACCESS_CODE = 1;
+    static constexpr int COND_DBTAG_NO_PROTECTION_CODE = 0;
+
     static constexpr const char* const COND_AUTH_PATH_PROPERTY = "AuthenticationFile";
   }  // namespace auth
 

--- a/CondCore/CondDB/interface/ConnectionPool.h
+++ b/CondCore/CondDB/interface/ConnectionPool.h
@@ -63,6 +63,7 @@ namespace cond {
     private:
       std::string m_authPath = std::string("");
       int m_authSys = 0;
+      std::string m_authenticationService = std::string("");
       coral::MsgLevel m_messageLevel = coral::Error;
       CoralMsgReporter* m_msgReporter = nullptr;
       bool m_loggingEnabled = false;

--- a/CondCore/CondDB/interface/DecodingKey.h
+++ b/CondCore/CondDB/interface/DecodingKey.h
@@ -30,6 +30,7 @@ namespace cond {
 
     class DecodingKey {
     public:
+      static constexpr const char* const KEY_FMT_VERSION = "2.0";
       static constexpr const char* const FILE_NAME = "db.key";
       static constexpr const char* const FILE_PATH = ".cms_cond/db.key";
       static constexpr size_t DEFAULT_KEY_SIZE = 100;
@@ -48,6 +49,8 @@ namespace cond {
       void list(std::ostream& out);
 
       void flush();
+
+      const std::string& version() const;
 
       const std::string& principalName() const;
 
@@ -69,6 +72,8 @@ namespace cond {
     private:
       std::string m_fileName;
 
+      std::string m_version;
+
       bool m_mode;
 
       std::string m_pwd;
@@ -89,7 +94,16 @@ inline cond::auth::KeyGenerator::KeyGenerator() : m_iteration(0) {}
 inline cond::auth::ServiceCredentials::ServiceCredentials() : connectionString(""), userName(""), password("") {}
 
 inline cond::auth::DecodingKey::DecodingKey()
-    : m_fileName(""), m_mode(true), m_pwd(""), m_principalName(""), m_principalKey(""), m_owner(""), m_services() {}
+    : m_fileName(""),
+      m_version(""),
+      m_mode(true),
+      m_pwd(""),
+      m_principalName(""),
+      m_principalKey(""),
+      m_owner(""),
+      m_services() {}
+
+inline const std::string& cond::auth::DecodingKey::version() const { return m_version; }
 
 inline const std::string& cond::auth::DecodingKey::principalName() const { return m_principalName; }
 

--- a/CondCore/CondDB/interface/IOVEditor.h
+++ b/CondCore/CondDB/interface/IOVEditor.h
@@ -45,6 +45,9 @@ namespace cond {
       //
       IOVEditor& operator=(const IOVEditor& rhs);
 
+      //
+      ~IOVEditor();
+
       // loads to tag to edit
       void load(const std::string& tag);
 
@@ -66,9 +69,6 @@ namespace cond {
       cond::Time_t lastValidatedTime() const;
       void setLastValidatedTime(cond::Time_t time);
 
-      // flag (hack) for the validation
-      void setValidationMode();
-
       // register a new insertion.
       // if checkType==true, the payload corresponding to the specified id is verified to be the same type as the iov payloadObjectType
       void insert(cond::Time_t since, const cond::Hash& payloadHash, bool checkType = false);
@@ -85,6 +85,10 @@ namespace cond {
       bool flush(const boost::posix_time::ptime& operationTime);
       bool flush(const std::string& logText);
       bool flush(const std::string& logText, bool forceInsertion);
+
+      bool isLocked() const;
+      void lock();
+      void unlock();
 
     private:
       bool flush(const std::string& logText, const boost::posix_time::ptime& operationTime, bool forceInsertion);

--- a/CondCore/CondDB/plugins/RelationalAuthenticationService.cc
+++ b/CondCore/CondDB/plugins/RelationalAuthenticationService.cc
@@ -86,5 +86,9 @@ cond::RelationalAuthenticationService::RelationalAuthenticationService::credenti
   return *creds;
 }
 
+std::string cond::RelationalAuthenticationService::RelationalAuthenticationService::principalName() {
+  return m_db.keyPrincipalName();
+}
+
 DEFINE_CORALSERVICE(cond::RelationalAuthenticationService::RelationalAuthenticationService,
                     "COND/Services/RelationalAuthenticationService");

--- a/CondCore/CondDB/plugins/RelationalAuthenticationService.h
+++ b/CondCore/CondDB/plugins/RelationalAuthenticationService.h
@@ -2,6 +2,7 @@
 #define COND_XMLAUTHENTITACTIONSERVICE_H
 
 #include "CondCore/CondDB/interface/CredentialStore.h"
+#include "CondCore/CondDB/src/IDbAuthentication.h"
 //
 #include "RelationalAccess/IAuthenticationService.h"
 #include "CoralKernel/Service.h"
@@ -23,7 +24,9 @@ namespace cond {
 
     /**
      */
-    class RelationalAuthenticationService : public coral::Service, virtual public coral::IAuthenticationService {
+    class RelationalAuthenticationService : public coral::Service,
+                                            virtual public coral::IAuthenticationService,
+                                            virtual public persistency::IDbAuthentication {
     public:
       /// Standard Constructor
       explicit RelationalAuthenticationService(const std::string& name);
@@ -48,6 +51,8 @@ namespace cond {
        */
       const coral::IAuthenticationCredentials& credentials(const std::string& connectionString,
                                                            const std::string& role) const override;
+
+      std::string principalName() override;
 
     private:
       /// The input file with the data

--- a/CondCore/CondDB/src/ConnectionPool.cc
+++ b/CondCore/CondDB/src/ConnectionPool.cc
@@ -1,5 +1,6 @@
 #include "CondCore/CondDB/interface/ConnectionPool.h"
 #include "DbConnectionString.h"
+#include "IDbAuthentication.h"
 #include "SessionImpl.h"
 #include "IOVSchema.h"
 #include "CoralMsgReporter.h"
@@ -10,6 +11,7 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 // coral includes
 #include "RelationalAccess/ConnectionService.h"
+#include "RelationalAccess/IAuthenticationService.h"
 #include "RelationalAccess/IWebCacheControl.h"
 #include "RelationalAccess/ISessionProxy.h"
 #include "RelationalAccess/IConnectionServiceConfiguration.h"
@@ -78,7 +80,7 @@ namespace cond {
       m_msgReporter->setOutputLevel(m_messageLevel);
 
       // authentication
-      std::string authServiceName("CORAL/Services/EnvironmentAuthenticationService");
+      m_authenticationService = std::string("CORAL/Services/EnvironmentAuthenticationService");
       std::string authPath = m_authPath;
       // authentication
       if (authPath.empty()) {
@@ -114,12 +116,12 @@ namespace cond {
         servName = "COND/Services/XMLAuthenticationService";
       }
       if (!authPath.empty()) {
-        authServiceName = servName;
+        m_authenticationService = servName;
         coral::Context::instance().PropertyManager().property(cond::auth::COND_AUTH_PATH_PROPERTY)->set(authPath);
-        coral::Context::instance().loadComponent(authServiceName, m_pluginManager);
+        coral::Context::instance().loadComponent(m_authenticationService, m_pluginManager);
       }
 
-      coralConfig.setAuthenticationService(authServiceName);
+      coralConfig.setAuthenticationService(m_authenticationService);
     }
 
     void ConnectionPool::configure() {
@@ -152,7 +154,19 @@ namespace cond {
                                           bool writeCapable) {
       std::shared_ptr<coral::ISessionProxy> coralSession =
           createCoralSession(connectionString, transactionId, writeCapable);
-      return Session(std::make_shared<SessionImpl>(coralSession, connectionString));
+
+      std::string principalName("");
+      if (!m_authenticationService.empty()) {
+        // need to hard-code somewhere the target name...
+        if (m_authenticationService == "COND/Services/RelationalAuthenticationService") {
+          coral::IHandle<coral::IAuthenticationService> authSvc =
+              coral::Context::instance().query<coral::IAuthenticationService>(m_authenticationService);
+          IDbAuthentication* dbAuth = dynamic_cast<IDbAuthentication*>(authSvc.get());
+          principalName = dbAuth->principalName();
+        }
+      }
+
+      return Session(std::make_shared<SessionImpl>(coralSession, connectionString, principalName));
     }
 
     Session ConnectionPool::createSession(const std::string& connectionString, bool writeCapable) {

--- a/CondCore/CondDB/src/CredentialStore.cc
+++ b/CondCore/CondDB/src/CredentialStore.cc
@@ -35,10 +35,7 @@ coral_bridge::AuthenticationCredentialSet::AuthenticationCredentialSet() : m_dat
 coral_bridge::AuthenticationCredentialSet::~AuthenticationCredentialSet() { reset(); }
 
 void coral_bridge::AuthenticationCredentialSet::reset() {
-  for (std::map<std::pair<std::string, std::string>, coral::AuthenticationCredentials*>::iterator iData =
-           m_data.begin();
-       iData != m_data.end();
-       ++iData)
+  for (auto iData = m_data.begin(); iData != m_data.end(); ++iData)
     delete iData->second;
   m_data.clear();
 }
@@ -119,18 +116,20 @@ coral_bridge::AuthenticationCredentialSet::data() const {
   return m_data;
 }
 
-static const std::string SEQUENCE_TABLE_NAME("COND_CREDENTIAL_SEQUENCE");
+static const std::string TABLE_PREFIX("DB_");
+static const std::string LEGACY_TABLE_PREFIX("COND_");
+static const std::string SEQUENCE_TABLE("CREDENTIAL_SEQUENCE");
 static const std::string SEQUENCE_NAME_COL("NAME");
 static const std::string SEQUENCE_VALUE_COL("VALUE");
 
-static const std::string COND_AUTHENTICATION_TABLE("COND_AUTHENTICATION");
+static const std::string AUTHENTICATION_TABLE("AUTHENTICATION");
 static const std::string PRINCIPAL_ID_COL("P_ID");
 static const std::string PRINCIPAL_NAME_COL("P_NAME");
 static const std::string VERIFICATION_COL("CRED0");
 static const std::string PRINCIPAL_KEY_COL("CRED1");
 static const std::string ADMIN_KEY_COL("CRED2");
 
-static const std::string COND_AUTHORIZATION_TABLE("COND_AUTHORIZATION");
+static const std::string AUTHORIZATION_TABLE("AUTHORIZATION");
 static const std::string AUTH_ID_COL("AUTH_ID");
 static const std::string P_ID_COL("P_ID");
 static const std::string ROLE_COL("C_ROLE");
@@ -138,7 +137,7 @@ static const std::string SCHEMA_COL("C_SCHEMA");
 static const std::string AUTH_KEY_COL("CRED3");
 static const std::string C_ID_COL("C_ID");
 
-static const std::string COND_CREDENTIAL_TABLE("COND_CREDENTIAL");
+static const std::string CREDENTIAL_TABLE("CREDENTIAL");
 static const std::string CONNECTION_ID_COL("CONN_ID");
 static const std::string CONNECTION_LABEL_COL("CONN_LABEL");
 static const std::string USERNAME_COL("CRED4");
@@ -148,6 +147,20 @@ static const std::string CONNECTION_KEY_COL("CRED7");
 
 const std::string DEFAULT_DATA_SOURCE("Cond_Default_Authentication");
 
+std::string tname(const std::string& tableName, const std::string& schemaVersion) {
+  std::string prefix(TABLE_PREFIX);
+  if (schemaVersion.empty())
+    prefix = LEGACY_TABLE_PREFIX;
+  return prefix + tableName;
+}
+
+std::string to_lower(const std::string& s) {
+  std::string str(s);
+  for (auto& c : str)
+    c = tolower(c);
+  return str;
+}
+
 // implementation functions and helpers
 namespace cond {
 
@@ -155,6 +168,7 @@ namespace cond {
     std::string ret = userName;
     if (!serviceName.empty()) {
       ret += "@" + serviceName;
+      ret = to_lower(ret);
     }
     return ret;
   }
@@ -188,8 +202,11 @@ namespace cond {
     std::string adminKey;
     PrincipalData() : id(-1), verifKey(""), principalKey(""), adminKey("") {}
   };
-  bool selectPrincipal(coral::ISchema& schema, const std::string& principal, PrincipalData& destination) {
-    std::unique_ptr<coral::IQuery> query(schema.tableHandle(COND_AUTHENTICATION_TABLE).newQuery());
+  bool selectPrincipal(const std::string& schemaVersion,
+                       coral::ISchema& schema,
+                       const std::string& principal,
+                       PrincipalData& destination) {
+    std::unique_ptr<coral::IQuery> query(schema.tableHandle(tname(AUTHENTICATION_TABLE, schemaVersion)).newQuery());
     coral::AttributeList readBuff;
     readBuff.extend<int>(PRINCIPAL_ID_COL);
     readBuff.extend<std::string>(VERIFICATION_COL);
@@ -227,8 +244,11 @@ namespace cond {
     CredentialData() : id(-1), userName(""), password(""), connectionKey("") {}
   };
 
-  bool selectConnection(coral::ISchema& schema, const std::string& connectionLabel, CredentialData& destination) {
-    std::unique_ptr<coral::IQuery> query(schema.tableHandle(COND_CREDENTIAL_TABLE).newQuery());
+  bool selectConnection(const std::string& schemaVersion,
+                        coral::ISchema& schema,
+                        const std::string& connectionLabel,
+                        CredentialData& destination) {
+    std::unique_ptr<coral::IQuery> query(schema.tableHandle(tname(CREDENTIAL_TABLE, schemaVersion)).newQuery());
     coral::AttributeList readBuff;
     readBuff.extend<int>(CONNECTION_ID_COL);
     readBuff.extend<std::string>(USERNAME_COL);
@@ -267,12 +287,13 @@ namespace cond {
     AuthorizationData() : id(-1), connectionId(-1), key("") {}
   };
 
-  bool selectAuthorization(coral::ISchema& schema,
+  bool selectAuthorization(const std::string& schemaVersion,
+                           coral::ISchema& schema,
                            int principalId,
                            const std::string& role,
                            const std::string& connectionString,
                            AuthorizationData& destination) {
-    std::unique_ptr<coral::IQuery> query(schema.tableHandle(COND_AUTHORIZATION_TABLE).newQuery());
+    std::unique_ptr<coral::IQuery> query(schema.tableHandle(tname(AUTHORIZATION_TABLE, schemaVersion)).newQuery());
     coral::AttributeList readBuff;
     readBuff.extend<int>(AUTH_ID_COL);
     readBuff.extend<int>(C_ID_COL);
@@ -305,9 +326,12 @@ namespace cond {
     return found;
   }
 
-  bool getNextSequenceValue(coral::ISchema& schema, const std::string& sequenceName, int& value) {
+  bool getNextSequenceValue(const std::string& schemaVersion,
+                            coral::ISchema& schema,
+                            const std::string& sequenceName,
+                            int& value) {
     bool ret = false;
-    std::unique_ptr<coral::IQuery> query(schema.tableHandle(SEQUENCE_TABLE_NAME).newQuery());
+    std::unique_ptr<coral::IQuery> query(schema.tableHandle(tname(SEQUENCE_TABLE, schemaVersion)).newQuery());
     query->limitReturnedRows(1, 0);
     query->addToOutputList(SEQUENCE_VALUE_COL);
     query->defineOutputType(SEQUENCE_VALUE_COL, coral::AttributeSpecification::typeNameForType<int>());
@@ -334,18 +358,19 @@ namespace cond {
     iAttribute->data<std::string>() = sequenceName;
     ++iAttribute;
     iAttribute->data<int>() = value;
-    schema.tableHandle(SEQUENCE_TABLE_NAME).dataEditor().updateRows(setClause, whClause, updateData);
+    schema.tableHandle(tname(SEQUENCE_TABLE, schemaVersion)).dataEditor().updateRows(setClause, whClause, updateData);
     return ret;
   }
 
-  std::pair<int, std::string> updatePrincipalData(coral::ISchema& schema,
+  std::pair<int, std::string> updatePrincipalData(const std::string& schemaVersion,
+                                                  coral::ISchema& schema,
                                                   const std::string& authenticationKey,
                                                   const std::string& principalName,
                                                   const std::string& adminKey,
                                                   bool init /**= false **/,
                                                   std::stringstream& log) {
     PrincipalData princData;
-    bool found = selectPrincipal(schema, principalName, princData);
+    bool found = selectPrincipal(schemaVersion, schema, principalName, princData);
 
     auth::Cipher cipher0(authenticationKey);
     auth::Cipher cipher1(adminKey);
@@ -354,7 +379,9 @@ namespace cond {
     std::string principalKey("");
     int principalId = princData.id;
 
-    coral::ITableDataEditor& editor = schema.tableHandle(COND_AUTHENTICATION_TABLE).dataEditor();
+    std::string authentication_table_name = tname(AUTHENTICATION_TABLE, schemaVersion);
+
+    coral::ITableDataEditor& editor = schema.tableHandle(authentication_table_name).dataEditor();
     if (found) {
       log << "Updating existing principal " << principalName << " (id: " << principalId << " )" << std::endl;
       principalKey = cipher1.b64decrypt(princData.adminKey);
@@ -380,10 +407,10 @@ namespace cond {
         auth::KeyGenerator gen;
         principalKey = gen.make(auth::COND_DB_KEY_SIZE);
       }
-      coral::ITableDataEditor& editor0 = schema.tableHandle(COND_AUTHENTICATION_TABLE).dataEditor();
+      coral::ITableDataEditor& editor0 = schema.tableHandle(authentication_table_name).dataEditor();
 
-      if (!getNextSequenceValue(schema, COND_AUTHENTICATION_TABLE, principalId))
-        throwException("Can't find " + COND_AUTHENTICATION_TABLE + " sequence.", "CredentialStore::updatePrincipal");
+      if (!getNextSequenceValue(schemaVersion, schema, authentication_table_name, principalId))
+        throwException("Can't find " + authentication_table_name + " sequence.", "CredentialStore::updatePrincipal");
       log << "Creating new principal " << principalName << " (id: " << principalId << " )" << std::endl;
       coral::AttributeList authData;
       editor0.rowBuffer(authData);
@@ -398,7 +425,8 @@ namespace cond {
     return std::make_pair(principalId, principalKey);
   }
 
-  bool setPermissionData(coral::ISchema& schema,
+  bool setPermissionData(const std::string& schemaVersion,
+                         coral::ISchema& schema,
                          int principalId,
                          const std::string& principalKey,
                          const std::string& role,
@@ -412,9 +440,10 @@ namespace cond {
     auth::Cipher cipher(principalKey);
     std::string encryptedConnectionKey = cipher.b64encrypt(connectionKey);
     AuthorizationData authData;
-    bool found = selectAuthorization(schema, principalId, role, connectionString, authData);
+    bool found = selectAuthorization(schemaVersion, schema, principalId, role, connectionString, authData);
 
-    coral::ITableDataEditor& editor = schema.tableHandle(COND_AUTHORIZATION_TABLE).dataEditor();
+    std::string authorization_table_name = tname(AUTHORIZATION_TABLE, schemaVersion);
+    coral::ITableDataEditor& editor = schema.tableHandle(authorization_table_name).dataEditor();
     if (found) {
       log << "Updating permission for principal id " << principalId << " to access resource " << connectionString
           << " with role " << role << std::endl;
@@ -430,8 +459,8 @@ namespace cond {
       editor.updateRows(setCl, whereCl, updateData);
     } else {
       int next = -1;
-      if (!getNextSequenceValue(schema, COND_AUTHORIZATION_TABLE, next))
-        throwException("Can't find " + COND_AUTHORIZATION_TABLE + " sequence.", "CredentialStore::setPermission");
+      if (!getNextSequenceValue(schemaVersion, schema, authorization_table_name, next))
+        throwException("Can't find " + authorization_table_name + " sequence.", "CredentialStore::setPermission");
       log << "Setting permission for principal id " << principalId << " to access resource " << connectionString
           << " with role " << role << std::endl;
       coral::AttributeList insertData;
@@ -452,7 +481,8 @@ namespace cond {
     return true;
   }
 
-  std::pair<int, std::string> updateConnectionData(coral::ISchema& schema,
+  std::pair<int, std::string> updateConnectionData(const std::string& schemaVersion,
+                                                   coral::ISchema& schema,
                                                    const std::string& adminKey,
                                                    const std::string& connectionLabel,
                                                    const std::string& userName,
@@ -460,12 +490,13 @@ namespace cond {
                                                    bool forceUpdate,
                                                    std::stringstream& log) {
     CredentialData credsData;
-    bool found = selectConnection(schema, connectionLabel, credsData);
+    bool found = selectConnection(schemaVersion, schema, connectionLabel, credsData);
     int connId = credsData.id;
 
     auth::Cipher adminCipher(adminKey);
     std::string connectionKey("");
-    coral::ITableDataEditor& editor = schema.tableHandle(COND_CREDENTIAL_TABLE).dataEditor();
+    std::string credential_table_name = tname(CREDENTIAL_TABLE, schemaVersion);
+    coral::ITableDataEditor& editor = schema.tableHandle(credential_table_name).dataEditor();
     if (found) {
       connectionKey = adminCipher.b64decrypt(credsData.connectionKey);
       auth::Cipher cipher(connectionKey);
@@ -498,8 +529,8 @@ namespace cond {
       std::string encryptedPassword = cipher.b64encrypt(password);
       std::string encryptedLabel = cipher.b64encrypt(connectionLabel);
 
-      if (!getNextSequenceValue(schema, COND_CREDENTIAL_TABLE, connId))
-        throwException("Can't find " + COND_CREDENTIAL_TABLE + " sequence.", "CredentialStore::updateConnection");
+      if (!getNextSequenceValue(schemaVersion, schema, credential_table_name, connId))
+        throwException("Can't find " + credential_table_name + " sequence.", "CredentialStore::updateConnection");
       log << "Creating new connection " << connectionLabel << std::endl;
       coral::AttributeList insertData;
       insertData.extend<int>(CONNECTION_ID_COL);
@@ -592,8 +623,10 @@ void cond::CredentialStore::startSession(bool readMode) {
   openSession(connTokens.second, userName, password, true);
 
   coral::ISchema& schema = m_session->nominalSchema();
-  if (!schema.existsTable(COND_AUTHENTICATION_TABLE) || !schema.existsTable(COND_AUTHORIZATION_TABLE) ||
-      !schema.existsTable(COND_CREDENTIAL_TABLE)) {
+  const std::string& schemaVersion = m_key.version();
+  if (!schema.existsTable(tname(AUTHENTICATION_TABLE, schemaVersion)) ||
+      !schema.existsTable(tname(AUTHORIZATION_TABLE, schemaVersion)) ||
+      !schema.existsTable(tname(CREDENTIAL_TABLE, schemaVersion))) {
     throwException("Credential database does not exists in \"" + storeConnectionString + "\"",
                    "CredentialStore::startSession");
   }
@@ -601,7 +634,7 @@ void cond::CredentialStore::startSession(bool readMode) {
   const std::string& principalName = m_key.principalName();
   // now authenticate...
   PrincipalData princData;
-  if (!selectPrincipal(m_session->nominalSchema(), principalName, princData)) {
+  if (!selectPrincipal(schemaVersion, m_session->nominalSchema(), principalName, princData)) {
     throwException("Invalid credentials provided.(0)", "CredentialStore::startSession");
   }
   auth::Cipher cipher0(m_key.principalKey());
@@ -623,8 +656,8 @@ void cond::CredentialStore::startSession(bool readMode) {
 
     // first find the credentials for WRITING in the security tables
     std::unique_ptr<coral::IQuery> query(schema.newQuery());
-    query->addToTableList(COND_AUTHORIZATION_TABLE, "AUTHO");
-    query->addToTableList(COND_CREDENTIAL_TABLE, "CREDS");
+    query->addToTableList(tname(AUTHORIZATION_TABLE, schemaVersion), "AUTHO");
+    query->addToTableList(tname(CREDENTIAL_TABLE, schemaVersion), "CREDS");
     coral::AttributeList readBuff;
     readBuff.extend<std::string>("CREDS." + CONNECTION_LABEL_COL);
     readBuff.extend<std::string>("CREDS." + CONNECTION_KEY_COL);
@@ -662,8 +695,8 @@ void cond::CredentialStore::startSession(bool readMode) {
       auth::Cipher cipher1(connectionKey);
       const std::string& encryptedUserName = row["CREDS." + USERNAME_COL].data<std::string>();
       const std::string& encryptedPassword = row["CREDS." + PASSWORD_COL].data<std::string>();
-      const std::string& verificationKey = row["CREDS." + VERIFICATION_KEY_COL].data<std::string>();
-      if (cipher1.b64decrypt(verificationKey) != connLabel) {
+      std::string verificationKey = cipher1.b64decrypt(row["CREDS." + VERIFICATION_KEY_COL].data<std::string>());
+      if (verificationKey != connLabel) {
         throwException("Could not decrypt credentials.Provided key is invalid.", "CredentialStore::startSession");
       }
       writeUserName = cipher1.b64decrypt(encryptedUserName);
@@ -738,7 +771,7 @@ std::string cond::CredentialStore::setUpForConnectionString(const std::string& c
   return setUpForService(serviceName, authPath);
 }
 
-void addSequence(coral::ISchema& schema, const std::string& name) {
+void addSequence(const std::string& schemaVersion, coral::ISchema& schema, const std::string& name) {
   // Create the entry in the table
   coral::AttributeList insertData;
   insertData.extend<std::string>(SEQUENCE_NAME_COL);
@@ -747,7 +780,7 @@ void addSequence(coral::ISchema& schema, const std::string& name) {
   iAttribute->data<std::string>() = name;
   ++iAttribute;
   iAttribute->data<int>() = -1;
-  schema.tableHandle(SEQUENCE_TABLE_NAME).dataEditor().insertRow(insertData);
+  schema.tableHandle(tname(SEQUENCE_TABLE, schemaVersion)).dataEditor().insertRow(insertData);
 }
 
 bool cond::CredentialStore::createSchema(const std::string& connectionString,
@@ -757,14 +790,15 @@ bool cond::CredentialStore::createSchema(const std::string& connectionString,
   session.startSuper(connectionString, userName, password);
 
   coral::ISchema& schema = m_session->nominalSchema();
-  if (schema.existsTable(COND_AUTHENTICATION_TABLE)) {
+  std::string authentication_table_name = tname(AUTHENTICATION_TABLE, m_key.version());
+  if (schema.existsTable(authentication_table_name)) {
     throwException("Credential database, already exists.", "CredentialStore::create");
   }
 
   m_log << "Creating sequence table." << std::endl;
+  std::string sequence_table_name = tname(SEQUENCE_TABLE, m_key.version());
   coral::TableDescription dseq;
-  dseq.setName(SEQUENCE_TABLE_NAME);
-
+  dseq.setName(sequence_table_name);
   dseq.insertColumn(SEQUENCE_NAME_COL, coral::AttributeSpecification::typeNameForType<std::string>());
   dseq.setNotNullConstraint(SEQUENCE_NAME_COL);
   dseq.insertColumn(SEQUENCE_VALUE_COL, coral::AttributeSpecification::typeNameForType<int>());
@@ -776,9 +810,9 @@ bool cond::CredentialStore::createSchema(const std::string& connectionString,
 
   m_log << "Creating authentication table." << std::endl;
   // authentication table
-  addSequence(schema, COND_AUTHENTICATION_TABLE);
+  addSequence(m_key.version(), schema, authentication_table_name);
   coral::TableDescription descr0;
-  descr0.setName(COND_AUTHENTICATION_TABLE);
+  descr0.setName(authentication_table_name);
   descr0.insertColumn(PRINCIPAL_ID_COL, coral::AttributeSpecification::typeNameForType<int>());
   descr0.insertColumn(
       PRINCIPAL_NAME_COL, coral::AttributeSpecification::typeNameForType<std::string>(), columnSize, false);
@@ -801,10 +835,11 @@ bool cond::CredentialStore::createSchema(const std::string& connectionString,
   schema.createTable(descr0);
 
   m_log << "Creating authorization table." << std::endl;
+  std::string authorization_table_name = tname(AUTHORIZATION_TABLE, m_key.version());
   // authorization table
-  addSequence(schema, COND_AUTHORIZATION_TABLE);
+  addSequence(m_key.version(), schema, authorization_table_name);
   coral::TableDescription descr1;
-  descr1.setName(COND_AUTHORIZATION_TABLE);
+  descr1.setName(authorization_table_name);
   descr1.insertColumn(AUTH_ID_COL, coral::AttributeSpecification::typeNameForType<int>());
   descr1.insertColumn(P_ID_COL, coral::AttributeSpecification::typeNameForType<int>());
   descr1.insertColumn(ROLE_COL, coral::AttributeSpecification::typeNameForType<std::string>(), columnSize, false);
@@ -828,10 +863,11 @@ bool cond::CredentialStore::createSchema(const std::string& connectionString,
   schema.createTable(descr1);
 
   m_log << "Creating credential table." << std::endl;
+  std::string credential_table_name = tname(CREDENTIAL_TABLE, m_key.version());
   // credential table
-  addSequence(schema, COND_CREDENTIAL_TABLE);
+  addSequence(m_key.version(), schema, credential_table_name);
   coral::TableDescription descr2;
-  descr2.setName(COND_CREDENTIAL_TABLE);
+  descr2.setName(credential_table_name);
   descr2.insertColumn(CONNECTION_ID_COL, coral::AttributeSpecification::typeNameForType<int>());
   descr2.insertColumn(
       CONNECTION_LABEL_COL, coral::AttributeSpecification::typeNameForType<std::string>(), columnSize, false);
@@ -856,13 +892,13 @@ bool cond::CredentialStore::createSchema(const std::string& connectionString,
   schema.createTable(descr2);
 
   try {
-    schema.tableHandle(COND_AUTHENTICATION_TABLE)
+    schema.tableHandle(authentication_table_name)
         .privilegeManager()
         .grantToUser(m_serviceData->userName, coral::ITablePrivilegeManager::Select);
-    schema.tableHandle(COND_AUTHORIZATION_TABLE)
+    schema.tableHandle(authorization_table_name)
         .privilegeManager()
         .grantToUser(m_serviceData->userName, coral::ITablePrivilegeManager::Select);
-    schema.tableHandle(COND_CREDENTIAL_TABLE)
+    schema.tableHandle(credential_table_name)
         .privilegeManager()
         .grantToUser(m_serviceData->userName, coral::ITablePrivilegeManager::Select);
   } catch (const coral::Exception& e) {
@@ -872,12 +908,13 @@ bool cond::CredentialStore::createSchema(const std::string& connectionString,
   m_log << "Granting ADMIN access permission." << std::endl;
   auth::KeyGenerator gen;
   m_principalKey = gen.make(auth::COND_DB_KEY_SIZE);
-  auto princData =
-      updatePrincipalData(schema, m_key.principalKey(), m_key.principalName(), m_principalKey, true, m_log);
+  auto princData = updatePrincipalData(
+      m_key.version(), schema, m_key.principalKey(), m_key.principalName(), m_principalKey, true, m_log);
   std::string credentialAccessLabel = schemaLabel(m_serviceName, userName);
-  auto connParams =
-      updateConnectionData(schema, m_principalKey, credentialAccessLabel, userName, password, true, m_log);
-  bool ret = setPermissionData(schema,
+  auto connParams = updateConnectionData(
+      m_key.version(), schema, m_principalKey, credentialAccessLabel, userName, password, true, m_log);
+  bool ret = setPermissionData(m_key.version(),
+                               schema,
                                princData.first,
                                m_principalKey,
                                auth::COND_ADMIN_ROLE,
@@ -897,10 +934,10 @@ bool cond::CredentialStore::drop(const std::string& connectionString,
 
   m_log << "Dropping AUTHORIZATION, CREDENTIAL, AUTHENTICATION and SEQUENCE tables." << std::endl;
   coral::ISchema& schema = m_session->nominalSchema();
-  schema.dropIfExistsTable(COND_AUTHORIZATION_TABLE);
-  schema.dropIfExistsTable(COND_CREDENTIAL_TABLE);
-  schema.dropIfExistsTable(COND_AUTHENTICATION_TABLE);
-  schema.dropIfExistsTable(SEQUENCE_TABLE_NAME);
+  schema.dropIfExistsTable(tname(AUTHORIZATION_TABLE, m_key.version()));
+  schema.dropIfExistsTable(tname(CREDENTIAL_TABLE, m_key.version()));
+  schema.dropIfExistsTable(tname(AUTHENTICATION_TABLE, m_key.version()));
+  schema.dropIfExistsTable(tname(SEQUENCE_TABLE, m_key.version()));
   session.close();
   return true;
 }
@@ -918,7 +955,7 @@ bool cond::CredentialStore::resetAdmin(const std::string& userName, const std::s
   const std::string& principalName = m_key.principalName();
   const std::string& authenticationKey = m_key.principalKey();
   PrincipalData princData;
-  if (!selectPrincipal(schema, principalName, princData)) {
+  if (!selectPrincipal(m_key.version(), schema, principalName, princData)) {
     std::string msg("User \"");
     msg += principalName + "\" has not been found.";
     throwException(msg, "CredentialStore::resetAdmin");
@@ -926,11 +963,12 @@ bool cond::CredentialStore::resetAdmin(const std::string& userName, const std::s
   auth::Cipher cipher0(authenticationKey);
   m_principalKey = cipher0.b64decrypt(princData.principalKey);
 
-  auto p = updatePrincipalData(schema, authenticationKey, principalName, m_principalKey, false, m_log);
+  auto p = updatePrincipalData(m_key.version(), schema, authenticationKey, principalName, m_principalKey, false, m_log);
   std::string credentialAccessLabel = schemaLabel(m_serviceName, userName);
-  auto connParams =
-      updateConnectionData(schema, m_principalKey, credentialAccessLabel, userName, password, true, m_log);
-  bool ret = setPermissionData(schema,
+  auto connParams = updateConnectionData(
+      m_key.version(), schema, m_principalKey, credentialAccessLabel, userName, password, true, m_log);
+  bool ret = setPermissionData(m_key.version(),
+                               schema,
                                p.first,
                                m_principalKey,
                                auth::COND_ADMIN_ROLE,
@@ -948,7 +986,8 @@ bool cond::CredentialStore::updatePrincipal(const std::string& principalName,
   CSScopedSession session(*this);
   session.start(false);
   coral::ISchema& schema = m_session->nominalSchema();
-  auto princData = updatePrincipalData(schema, authenticationKey, principalName, m_principalKey, false, m_log);
+  auto princData =
+      updatePrincipalData(m_key.version(), schema, authenticationKey, principalName, m_principalKey, false, m_log);
   bool ret = false;
   if (setAdmin) {
     int princId = princData.first;
@@ -961,11 +1000,12 @@ bool cond::CredentialStore::updatePrincipal(const std::string& principalName,
     }
     std::string connLabel = permissions.front().connectionLabel;
     CredentialData credsData;
-    if (!selectConnection(schema, connLabel, credsData)) {
+    if (!selectConnection(m_key.version(), schema, connLabel, credsData)) {
       throwException("Credential Store connection has not been defined.", "CredentialStore::updatePrincipal");
     }
     auth::Cipher adminCipher(m_principalKey);
-    ret = setPermissionData(schema,
+    ret = setPermissionData(m_key.version(),
+                            schema,
                             princId,
                             princKey,
                             auth::COND_ADMIN_ROLE,
@@ -988,7 +1028,7 @@ bool cond::CredentialStore::setPermission(const std::string& principal,
   coral::ISchema& schema = m_session->nominalSchema();
 
   PrincipalData princData;
-  bool found = selectPrincipal(schema, principal, princData);
+  bool found = selectPrincipal(m_key.version(), schema, principal, princData);
 
   if (!found) {
     std::string msg = "Principal \"" + principal + "\" does not exist in the database.";
@@ -997,7 +1037,7 @@ bool cond::CredentialStore::setPermission(const std::string& principal,
 
   m_log << "Principal " << principal << " id: " << princData.id << std::endl;
   CredentialData credsData;
-  found = selectConnection(schema, connectionLabel, credsData);
+  found = selectConnection(m_key.version(), schema, connectionLabel, credsData);
 
   if (!found) {
     std::string msg = "Connection named \"" + connectionLabel + "\" does not exist in the database.";
@@ -1005,7 +1045,8 @@ bool cond::CredentialStore::setPermission(const std::string& principal,
   }
 
   auth::Cipher cipher(m_principalKey);
-  bool ret = setPermissionData(schema,
+  bool ret = setPermissionData(m_key.version(),
+                               schema,
                                princData.id,
                                cipher.b64decrypt(princData.adminKey),
                                role,
@@ -1028,7 +1069,7 @@ bool cond::CredentialStore::unsetPermission(const std::string& principal,
   coral::ISchema& schema = m_session->nominalSchema();
 
   PrincipalData princData;
-  bool found = selectPrincipal(schema, principal, princData);
+  bool found = selectPrincipal(m_key.version(), schema, principal, princData);
 
   if (!found) {
     std::string msg = "Principal \"" + principal + "\" does not exist in the database.";
@@ -1036,7 +1077,7 @@ bool cond::CredentialStore::unsetPermission(const std::string& principal,
   }
   m_log << "Removing permission for principal " << principal << " (id: " << princData.id << ") to access resource "
         << connectionString << " with role " << role << std::endl;
-  coral::ITableDataEditor& editor = schema.tableHandle(COND_AUTHORIZATION_TABLE).dataEditor();
+  coral::ITableDataEditor& editor = schema.tableHandle(tname(AUTHORIZATION_TABLE, m_key.version())).dataEditor();
   coral::AttributeList deleteData;
   deleteData.extend<int>(P_ID_COL);
   deleteData.extend<std::string>(ROLE_COL);
@@ -1061,7 +1102,8 @@ bool cond::CredentialStore::updateConnection(const std::string& connectionLabel,
 
   m_session->transaction().start();
   coral::ISchema& schema = m_session->nominalSchema();
-  updateConnectionData(schema, m_principalKey, connectionLabel, userName, password, true, m_log);
+  std::string connLabel = to_lower(connectionLabel);
+  updateConnectionData(m_key.version(), schema, m_principalKey, connLabel, userName, password, true, m_log);
 
   session.close();
   return true;
@@ -1073,7 +1115,7 @@ bool cond::CredentialStore::removePrincipal(const std::string& principal) {
   coral::ISchema& schema = m_session->nominalSchema();
 
   PrincipalData princData;
-  bool found = selectPrincipal(schema, principal, princData);
+  bool found = selectPrincipal(m_key.version(), schema, principal, princData);
 
   if (!found) {
     std::string msg = "Principal \"" + principal + "\" does not exist in the database.";
@@ -1082,7 +1124,7 @@ bool cond::CredentialStore::removePrincipal(const std::string& principal) {
 
   m_log << "Removing principal " << principal << " (id: " << princData.id << ")" << std::endl;
 
-  coral::ITableDataEditor& editor0 = schema.tableHandle(COND_AUTHORIZATION_TABLE).dataEditor();
+  coral::ITableDataEditor& editor0 = schema.tableHandle(tname(AUTHORIZATION_TABLE, m_key.version())).dataEditor();
 
   coral::AttributeList deleteData0;
   deleteData0.extend<int>(P_ID_COL);
@@ -1090,7 +1132,7 @@ bool cond::CredentialStore::removePrincipal(const std::string& principal) {
   std::string whereClause0 = P_ID_COL + " = :" + P_ID_COL;
   editor0.deleteRows(whereClause0, deleteData0);
 
-  coral::ITableDataEditor& editor1 = schema.tableHandle(COND_AUTHENTICATION_TABLE).dataEditor();
+  coral::ITableDataEditor& editor1 = schema.tableHandle(tname(AUTHENTICATION_TABLE, m_key.version())).dataEditor();
 
   coral::AttributeList deleteData1;
   deleteData1.extend<int>(PRINCIPAL_ID_COL);
@@ -1109,7 +1151,7 @@ bool cond::CredentialStore::removeConnection(const std::string& connectionLabel)
   coral::ISchema& schema = m_session->nominalSchema();
 
   CredentialData credsData;
-  bool found = selectConnection(schema, connectionLabel, credsData);
+  bool found = selectConnection(m_key.version(), schema, connectionLabel, credsData);
 
   if (!found) {
     std::string msg = "Connection named \"" + connectionLabel + "\" does not exist in the database.";
@@ -1117,7 +1159,7 @@ bool cond::CredentialStore::removeConnection(const std::string& connectionLabel)
   }
 
   m_log << "Removing connection " << connectionLabel << std::endl;
-  coral::ITableDataEditor& editor0 = schema.tableHandle(COND_AUTHORIZATION_TABLE).dataEditor();
+  coral::ITableDataEditor& editor0 = schema.tableHandle(tname(AUTHORIZATION_TABLE, m_key.version())).dataEditor();
 
   coral::AttributeList deleteData0;
   deleteData0.extend<int>(C_ID_COL);
@@ -1125,7 +1167,7 @@ bool cond::CredentialStore::removeConnection(const std::string& connectionLabel)
   std::string whereClause0 = C_ID_COL + " = :" + C_ID_COL;
   editor0.deleteRows(whereClause0, deleteData0);
 
-  coral::ITableDataEditor& editor1 = schema.tableHandle(COND_CREDENTIAL_TABLE).dataEditor();
+  coral::ITableDataEditor& editor1 = schema.tableHandle(tname(CREDENTIAL_TABLE, m_key.version())).dataEditor();
 
   coral::AttributeList deleteData1;
   deleteData1.extend<int>(CONNECTION_ID_COL);
@@ -1146,8 +1188,8 @@ bool cond::CredentialStore::selectForUser(coral_bridge::AuthenticationCredential
   auth::Cipher cipher(m_principalKey);
 
   std::unique_ptr<coral::IQuery> query(schema.newQuery());
-  query->addToTableList(COND_AUTHORIZATION_TABLE, "AUTHO");
-  query->addToTableList(COND_CREDENTIAL_TABLE, "CREDS");
+  query->addToTableList(tname(AUTHORIZATION_TABLE, m_key.version()), "AUTHO");
+  query->addToTableList(tname(CREDENTIAL_TABLE, m_key.version()), "CREDS");
   coral::AttributeList readBuff;
   readBuff.extend<std::string>("AUTHO." + ROLE_COL);
   readBuff.extend<std::string>("AUTHO." + SCHEMA_COL);
@@ -1182,10 +1224,10 @@ bool cond::CredentialStore::selectForUser(coral_bridge::AuthenticationCredential
     const std::string& connectionLabel = row["CREDS." + CONNECTION_LABEL_COL].data<std::string>();
     const std::string& encryptedUserName = row["CREDS." + USERNAME_COL].data<std::string>();
     const std::string& encryptedPassword = row["CREDS." + PASSWORD_COL].data<std::string>();
-    const std::string& encryptedLabel = row["CREDS." + VERIFICATION_KEY_COL].data<std::string>();
     std::string authKey = cipher.b64decrypt(encryptedAuthKey);
     auth::Cipher connCipher(authKey);
-    if (connCipher.b64decrypt(encryptedLabel) == connectionLabel) {
+    std::string verificationString = connCipher.b64decrypt(row["CREDS." + VERIFICATION_KEY_COL].data<std::string>());
+    if (verificationString == connectionLabel) {
       destinationData.registerCredentials(
           connectionString, role, connCipher.b64decrypt(encryptedUserName), connCipher.b64decrypt(encryptedPassword));
     }
@@ -1203,8 +1245,8 @@ std::pair<std::string, std::string> cond::CredentialStore::getUserCredentials(co
   auth::Cipher cipher(m_principalKey);
 
   std::unique_ptr<coral::IQuery> query(schema.newQuery());
-  query->addToTableList(COND_AUTHORIZATION_TABLE, "AUTHO");
-  query->addToTableList(COND_CREDENTIAL_TABLE, "CREDS");
+  query->addToTableList(tname(AUTHORIZATION_TABLE, m_key.version()), "AUTHO");
+  query->addToTableList(tname(CREDENTIAL_TABLE, m_key.version()), "CREDS");
   coral::AttributeList readBuff;
   readBuff.extend<std::string>("AUTHO." + AUTH_KEY_COL);
   readBuff.extend<std::string>("CREDS." + CONNECTION_LABEL_COL);
@@ -1242,10 +1284,10 @@ std::pair<std::string, std::string> cond::CredentialStore::getUserCredentials(co
     const std::string& connectionLabel = row["CREDS." + CONNECTION_LABEL_COL].data<std::string>();
     const std::string& encryptedUserName = row["CREDS." + USERNAME_COL].data<std::string>();
     const std::string& encryptedPassword = row["CREDS." + PASSWORD_COL].data<std::string>();
-    const std::string& encryptedLabel = row["CREDS." + VERIFICATION_KEY_COL].data<std::string>();
     std::string authKey = cipher.b64decrypt(encryptedAuthKey);
     auth::Cipher connCipher(authKey);
-    if (connCipher.b64decrypt(encryptedLabel) == connectionLabel) {
+    std::string verificationString = connCipher.b64decrypt(row["CREDS." + VERIFICATION_KEY_COL].data<std::string>());
+    if (verificationString == connectionLabel) {
       ret.first = connCipher.b64decrypt(encryptedUserName);
       ret.second = connCipher.b64decrypt(encryptedPassword);
     }
@@ -1262,7 +1304,7 @@ bool cond::CredentialStore::importForPrincipal(const std::string& principal,
   coral::ISchema& schema = m_session->nominalSchema();
 
   PrincipalData princData;
-  bool found = selectPrincipal(schema, principal, princData);
+  bool found = selectPrincipal(m_key.version(), schema, principal, princData);
 
   if (!found) {
     std::string msg = "Principal \"" + principal + "\" does not exist in the database.";
@@ -1286,11 +1328,18 @@ bool cond::CredentialStore::importForPrincipal(const std::string& principal,
     std::string userName = iConn->second->valueForItem(coral::IAuthenticationCredentials::userItem());
     std::string password = iConn->second->valueForItem(coral::IAuthenticationCredentials::passwordItem());
     // first import the connections
-    std::pair<int, std::string> conn = updateConnectionData(
-        schema, m_principalKey, schemaLabel(serviceName, userName), userName, password, forceUpdateConnection, m_log);
+    std::pair<int, std::string> conn = updateConnectionData(m_key.version(),
+                                                            schema,
+                                                            m_principalKey,
+                                                            schemaLabel(serviceName, userName),
+                                                            userName,
+                                                            password,
+                                                            forceUpdateConnection,
+                                                            m_log);
     auth::Cipher cipher(m_principalKey);
     // than set the permission for the specific role
-    setPermissionData(schema, princData.id, princKey, role, connectionString, conn.first, conn.second, m_log);
+    setPermissionData(
+        m_key.version(), schema, princData.id, princKey, role, connectionString, conn.first, conn.second, m_log);
     imported = true;
   }
   session.close();
@@ -1302,7 +1351,7 @@ bool cond::CredentialStore::listPrincipals(std::vector<std::string>& destination
   session.start(true);
   coral::ISchema& schema = m_session->nominalSchema();
 
-  std::unique_ptr<coral::IQuery> query(schema.tableHandle(COND_AUTHENTICATION_TABLE).newQuery());
+  std::unique_ptr<coral::IQuery> query(schema.tableHandle(tname(AUTHENTICATION_TABLE, m_key.version())).newQuery());
   coral::AttributeList readBuff;
   readBuff.extend<std::string>(PRINCIPAL_NAME_COL);
   query->defineOutput(readBuff);
@@ -1323,7 +1372,7 @@ bool cond::CredentialStore::listConnections(std::map<std::string, std::pair<std:
   session.start(true);
   coral::ISchema& schema = m_session->nominalSchema();
 
-  std::unique_ptr<coral::IQuery> query(schema.tableHandle(COND_CREDENTIAL_TABLE).newQuery());
+  std::unique_ptr<coral::IQuery> query(schema.tableHandle(tname(CREDENTIAL_TABLE, m_key.version())).newQuery());
   coral::AttributeList readBuff;
   readBuff.extend<std::string>(CONNECTION_LABEL_COL);
   readBuff.extend<std::string>(USERNAME_COL);
@@ -1370,9 +1419,9 @@ bool cond::CredentialStore::selectPermissions(const std::string& principalName,
   session.start(true);
   coral::ISchema& schema = m_session->nominalSchema();
   std::unique_ptr<coral::IQuery> query(schema.newQuery());
-  query->addToTableList(COND_AUTHENTICATION_TABLE, "AUTHE");
-  query->addToTableList(COND_AUTHORIZATION_TABLE, "AUTHO");
-  query->addToTableList(COND_CREDENTIAL_TABLE, "CREDS");
+  query->addToTableList(tname(AUTHENTICATION_TABLE, m_key.version()), "AUTHE");
+  query->addToTableList(tname(AUTHORIZATION_TABLE, m_key.version()), "AUTHO");
+  query->addToTableList(tname(CREDENTIAL_TABLE, m_key.version()), "CREDS");
   coral::AttributeList readBuff;
   readBuff.extend<std::string>("AUTHE." + PRINCIPAL_NAME_COL);
   readBuff.extend<std::string>("AUTHO." + ROLE_COL);
@@ -1429,8 +1478,8 @@ bool cond::CredentialStore::exportAll(coral_bridge::AuthenticationCredentialSet&
   session.start(true);
   coral::ISchema& schema = m_session->nominalSchema();
   std::unique_ptr<coral::IQuery> query(schema.newQuery());
-  query->addToTableList(COND_AUTHORIZATION_TABLE, "AUTHO");
-  query->addToTableList(COND_CREDENTIAL_TABLE, "CREDS");
+  query->addToTableList(tname(AUTHORIZATION_TABLE, m_key.version()), "AUTHO");
+  query->addToTableList(tname(CREDENTIAL_TABLE, m_key.version()), "CREDS");
   coral::AttributeList readBuff;
   readBuff.extend<std::string>("AUTHO." + ROLE_COL);
   readBuff.extend<std::string>("AUTHO." + SCHEMA_COL);

--- a/CondCore/CondDB/src/DbCore.h
+++ b/CondCore/CondDB/src/DbCore.h
@@ -29,6 +29,7 @@
 #include "RelationalAccess/IQuery.h"
 #include "RelationalAccess/TableDescription.h"
 #include "RelationalAccess/ITable.h"
+#include "RelationalAccess/IColumn.h"
 #include "RelationalAccess/ITableDataEditor.h"
 #include "RelationalAccess/IBulkOperation.h"
 #include "RelationalAccess/IBulkOperation.h"

--- a/CondCore/CondDB/src/IDbAuthentication.h
+++ b/CondCore/CondDB/src/IDbAuthentication.h
@@ -1,0 +1,17 @@
+#ifndef CondCore_CondDB_IDbAuthentication_h
+#define CondCore_CondDB_IDbAuthentication_h
+
+#include <string>
+
+namespace cond {
+
+  namespace persistency {
+
+    class IDbAuthentication {
+    public:
+      virtual ~IDbAuthentication() {}
+      virtual std::string principalName() = 0;
+    };
+  }  // namespace persistency
+}  // namespace cond
+#endif

--- a/CondCore/CondDB/src/IDbSchema.h
+++ b/CondCore/CondDB/src/IDbSchema.h
@@ -23,7 +23,8 @@ namespace cond {
                           std::string& objectType,
                           cond::SynchronizationType& synchronizationType,
                           cond::Time_t& endOfValidity,
-                          cond::Time_t& lastValidatedTime) = 0;
+                          cond::Time_t& lastValidatedTime,
+                          int& protectionCode) = 0;
       virtual bool getMetadata(const std::string& name,
                                std::string& description,
                                boost::posix_time::ptime& insertionTime,
@@ -47,7 +48,8 @@ namespace cond {
       virtual void updateValidity(const std::string& name,
                                   cond::Time_t lastValidatedTime,
                                   const boost::posix_time::ptime& updateTime) = 0;
-      virtual void setValidationMode() = 0;
+      virtual void setProtectionCode(const std::string& name, int code) = 0;
+      virtual void unsetProtectionCode(const std::string& name, int code) = 0;
     };
 
     class IPayloadTable {
@@ -103,39 +105,23 @@ namespace cond {
       virtual void erase(const std::string& tag) = 0;
     };
 
-    class ITagMigrationTable {
+    class ITagAccessPermissionTable {
     public:
-      virtual ~ITagMigrationTable() {}
+      virtual ~ITagAccessPermissionTable() {}
       virtual bool exists() = 0;
       virtual void create() = 0;
-      virtual bool select(const std::string& sourceAccount,
-                          const std::string& sourceTag,
-                          std::string& tagName,
-                          int& statusCode) = 0;
-      virtual void insert(const std::string& sourceAccount,
-                          const std::string& sourceTag,
-                          const std::string& tagName,
-                          int statusCode,
-                          const boost::posix_time::ptime& insertionTime) = 0;
-      virtual void updateValidationCode(const std::string& sourceAccount,
-                                        const std::string& sourceTag,
-                                        int statusCode) = 0;
-    };
-
-    class IPayloadMigrationTable {
-    public:
-      virtual ~IPayloadMigrationTable() {}
-      virtual bool exists() = 0;
-      virtual void create() = 0;
-      virtual bool select(const std::string& sourceAccount, const std::string& sourceToken, std::string& payloadId) = 0;
-      virtual void insert(const std::string& sourceAccount,
-                          const std::string& sourceToken,
-                          const std::string& payloadId,
-                          const boost::posix_time::ptime& insertionTime) = 0;
-      virtual void update(const std::string& sourceAccount,
-                          const std::string& sourceToken,
-                          const std::string& payloadId,
-                          const boost::posix_time::ptime& insertionTime) = 0;
+      virtual bool getAccessPermission(const std::string& tagName,
+                                       const std::string& credential,
+                                       int credentialType,
+                                       int accessType) = 0;
+      virtual void setAccessPermission(const std::string& tagName,
+                                       const std::string& credential,
+                                       int credentialType,
+                                       int accessType) = 0;
+      virtual void removeAccessPermission(const std::string& tagName,
+                                          const std::string& credential,
+                                          int credentialType) = 0;
+      virtual void removeEntriesForCredential(const std::string& credential, int credentialType) = 0;
     };
 
     class ITagLogTable {
@@ -161,6 +147,7 @@ namespace cond {
       virtual IIOVTable& iovTable() = 0;
       virtual IPayloadTable& payloadTable() = 0;
       virtual ITagLogTable& tagLogTable() = 0;
+      virtual ITagAccessPermissionTable& tagAccessPermissionTable() = 0;
     };
 
     class IGTTable {

--- a/CondCore/CondDB/src/IOVProxy.cc
+++ b/CondCore/CondDB/src/IOVProxy.cc
@@ -144,12 +144,14 @@ namespace cond {
 
       checkTransaction("IOVProxyNew::load");
 
+      int dummy;
       if (!m_session->iovSchema().tagTable().select(tagName,
                                                     m_data->tagInfo.timeType,
                                                     m_data->tagInfo.payloadType,
                                                     m_data->tagInfo.synchronizationType,
                                                     m_data->tagInfo.endOfValidity,
-                                                    m_data->tagInfo.lastValidatedTime)) {
+                                                    m_data->tagInfo.lastValidatedTime,
+                                                    dummy)) {
         throwException("Tag \"" + tagName + "\" has not been found in the database.", "IOVProxy::load");
       }
       m_data->tagInfo.name = tagName;

--- a/CondCore/CondDB/src/SessionImpl.h
+++ b/CondCore/CondDB/src/SessionImpl.h
@@ -43,7 +43,9 @@ namespace cond {
 
     public:
       SessionImpl();
-      SessionImpl(std::shared_ptr<coral::ISessionProxy>& session, const std::string& connectionString);
+      SessionImpl(std::shared_ptr<coral::ISessionProxy>& session,
+                  const std::string& connectionString,
+                  const std::string& principalName);
 
       ~SessionImpl();
 
@@ -65,14 +67,17 @@ namespace cond {
     public:
       // allows for session shared among more services. To be changed to unique_ptr when we stop needing this feature.
       std::shared_ptr<coral::ISessionProxy> coralSession;
-      // not really useful outside the ORA bridging...
+      std::string sessionHash;
       std::string connectionString;
+      std::string principalName;
+      std::set<std::string> lockedTags;
       std::unique_ptr<ITransaction> transaction;
       std::unique_ptr<IIOVSchema> iovSchemaHandle;
       std::unique_ptr<IGTSchema> gtSchemaHandle;
       std::unique_ptr<IRunInfoSchema> runInfoSchemaHandle;
 
     private:
+      void releaseTagLocks();
       std::recursive_mutex transactionMutex;
       std::unique_lock<std::recursive_mutex> transactionLock;
     };

--- a/CondCore/DBOutputService/interface/PoolDBOutputService.h
+++ b/CondCore/DBOutputService/interface/PoolDBOutputService.h
@@ -45,6 +45,12 @@ namespace cond {
       cond::persistency::Session session() const;
 
       //
+      void lockRecords();
+
+      //
+      void releaseLocks();
+
+      //
       void startTransaction();
       void commitTransaction();
 

--- a/CondCore/DBOutputService/src/PoolDBOutputService.cc
+++ b/CondCore/DBOutputService/src/PoolDBOutputService.cc
@@ -46,7 +46,6 @@ cond::service::PoolDBOutputService::PoolDBOutputService(const edm::ParameterSet&
   m_timetype = cond::time::timeTypeFromName(timetypestr);
   m_autoCommit = iConfig.getUntrackedParameter<bool>("autoCommit", false);
   m_writeTransactionDelay = iConfig.getUntrackedParameter<unsigned int>("writeTransactionDelay", 0);
-
   edm::ParameterSet connectionPset = iConfig.getParameter<edm::ParameterSet>("DBParameters");
   m_connection.setParameters(connectionPset);
   m_connection.setLogDestination(m_logger);
@@ -58,7 +57,6 @@ cond::service::PoolDBOutputService::PoolDBOutputService(const edm::ParameterSet&
     m_logger.setDbDestination(connectionString);
   // implicit start
   doStartTransaction();
-
   typedef std::vector<edm::ParameterSet> Parameters;
   Parameters toPut = iConfig.getParameter<Parameters>("toPut");
   for (Parameters::iterator itToPut = toPut.begin(); itToPut != toPut.end(); ++itToPut)
@@ -92,6 +90,36 @@ cond::persistency::Session cond::service::PoolDBOutputService::newReadOnlySessio
 }
 
 cond::persistency::Session cond::service::PoolDBOutputService::session() const { return m_session; }
+
+void cond::service::PoolDBOutputService::lockRecords() {
+  std::lock_guard<std::recursive_mutex> lock(m_mutex);
+  doStartTransaction();
+  cond::persistency::TransactionScope scope(m_session.transaction());
+  this->initDB();
+  for (auto& iR : m_records) {
+    if (iR.second.m_isNewTag == false) {
+      cond::persistency::IOVEditor editor = m_session.editIov(iR.second.m_tag);
+      editor.lock();
+    }
+  }
+  doCommitTransaction();
+  scope.close();
+}
+
+void cond::service::PoolDBOutputService::releaseLocks() {
+  std::lock_guard<std::recursive_mutex> lock(m_mutex);
+  doStartTransaction();
+  cond::persistency::TransactionScope scope(m_session.transaction());
+  this->initDB();
+  for (auto& iR : m_records) {
+    if (iR.second.m_isNewTag == false) {
+      cond::persistency::IOVEditor editor = m_session.editIov(iR.second.m_tag);
+      editor.unlock();
+    }
+  }
+  doCommitTransaction();
+  scope.close();
+}
 
 std::string cond::service::PoolDBOutputService::tag(const std::string& recordName) {
   return this->lookUpRecord(recordName).m_tag;

--- a/CondCore/DBOutputService/test/python/testIOVPayloadAnalyzer_cfg.py
+++ b/CondCore/DBOutputService/test/python/testIOVPayloadAnalyzer_cfg.py
@@ -10,7 +10,7 @@ process.source = cms.Source("EmptyIOVSource",
 
 process.PoolDBOutputService = cms.Service("PoolDBOutputService",
     DBParameters = cms.PSet(
-        messageLevel = cms.untracked.int32(0),
+        messageLevel = cms.untracked.int32(3),
         authenticationPath = cms.untracked.string('.')
     ),
     timetype = cms.untracked.string('runnumber'),

--- a/CondCore/DBOutputService/test/python/testLumiBasedUpdateAnalyzer_oracle.cfg.py
+++ b/CondCore/DBOutputService/test/python/testLumiBasedUpdateAnalyzer_oracle.cfg.py
@@ -30,17 +30,16 @@ process.MessageLogger = cms.Service("MessageLogger",
 process.OnlineDBOutputService = cms.Service("OnlineDBOutputService",
     DBParameters = cms.PSet(
         messageLevel = cms.untracked.int32(1),
-        authenticationPath = cms.untracked.string('/build/gg')
+        authenticationPath = cms.untracked.string('.')
     ),
     #timetype = cms.untracked.string('runnumber'),
     jobName = cms.untracked.string("TestLumiBasedUpdate"),
     connect = cms.string('oracle://cms_orcoff_prep/CMS_CONDITIONS'),
     preLoadConnectionString = cms.untracked.string('frontier://FrontierPrep/CMS_CONDITIONS'),
     runNumber = cms.untracked.uint64(options.runNumber),
-    #lastLumiFile = cms.untracked.string('/build/gg/last_lumi.txt'),
+    lastLumiFile = cms.untracked.string('last_lumi.txt'),
     writeTransactionDelay = cms.untracked.uint32(options.transDelay),
     autoCommit = cms.untracked.bool(True),
-    lastLumiFile = cms.untracked.string('lastLumi.txt'),
     saveLogsOnDB = cms.untracked.bool(True),
     toPut = cms.VPSet(cms.PSet(
         record = cms.string('PedestalsRcd'),
@@ -51,7 +50,7 @@ process.OnlineDBOutputService = cms.Service("OnlineDBOutputService",
 )
 
 process.mytest = cms.EDAnalyzer("LumiBasedUpdateAnalyzer",
-    lastLumiFile = cms.untracked.string('/build/gg/last_lumi.txt'),
+    lastLumiFile = cms.untracked.string('last_lumi.txt'),
     record = cms.string('PedestalsRcd')
 )
 

--- a/CondCore/DBOutputService/test/stubs/IOVPayloadAnalyzer.cc
+++ b/CondCore/DBOutputService/test/stubs/IOVPayloadAnalyzer.cc
@@ -41,5 +41,5 @@ void IOVPayloadAnalyzer::analyze(const edm::Event& evt, const edm::EventSetup& e
   //std::cout <<" tinfo name="<<tinfo.name<<" token="<<tinfo.lastPayloadToken<<std::endl;
   //}
 }
-void IOVPayloadAnalyzer::endJob() {}
+void IOVPayloadAnalyzer::endJob() { std::cout << "End of job..." << std::endl; }
 DEFINE_FWK_MODULE(IOVPayloadAnalyzer);

--- a/CondCore/DBOutputService/test/stubs/LumiBasedUpdateAnalyzer.h
+++ b/CondCore/DBOutputService/test/stubs/LumiBasedUpdateAnalyzer.h
@@ -26,6 +26,7 @@ private:
   cond::Time_t m_prevLumi;
   std::chrono::time_point<std::chrono::steady_clock> m_prevLumiTime;
   std::string m_omsServiceUrl;
+  bool m_tagLocks;
   // ----------member data ---------------------------
 };
 #endif


### PR DESCRIPTION
#### PR description:

Adding the ability to protect the DB-access on Tag:

for IOV updating.
for concurrent update (lock)
The support of the new feature will be connected with a new version of the DB key certificate.
No change is expected in the access of existing, not upgraded databases (central CMS servers or sqlite files ) . Also, the sqlite files produced with this change are fully forward compatible.

#### PR validation:

unit tests and integration tests

####  Backport of https://github.com/cms-sw/cmssw/pull/32732

The features are required in the 11_2 branch, for the operation of online workflows running at P5


