### PR TITLE
Some additions to the conddb command line interface

### DIFF
--- a/CondCore/Utilities/scripts/conddb
+++ b/CondCore/Utilities/scripts/conddb
@@ -21,6 +21,8 @@ import socket
 import calendar
 import sqlalchemy
 
+from prettytable import PrettyTable
+
 import CondCore.Utilities.conddblib as conddb
 import CondCore.Utilities.cond2xml as cond2xml
 import CondCore.Utilities.conddb_serialization_metadata as serialization_metadata
@@ -902,6 +904,273 @@ def listTags_(args):
     return 0
 
 
+
+def listParentTags_(args):
+    connection = connect(args)
+    session = connection.session()
+
+    IOV = session.get_dbtype(conddb.IOV)
+    Tag = session.get_dbtype(conddb.Tag)
+
+    query_result = session.query(IOV.tag_name).filter(IOV.payload_hash == args.hash_name).all()
+    tag_names = map(lambda entry : entry[0], query_result)
+
+    listOfOccur=[]
+
+    for tag in tag_names:
+        synchro = session.query(Tag.synchronization).filter(Tag.name == tag).all()
+        iovs = session.query(IOV.since).filter(IOV.tag_name == tag).filter(IOV.payload_hash == args.hash_name).all()
+        times = session.query(IOV.insertion_time).filter(IOV.tag_name == tag).filter(IOV.payload_hash == args.hash_name).all()
+
+        synchronization = [item[0] for item in synchro]
+        listOfIOVs  = [item[0] for item in iovs]
+        listOfTimes = [str(item[0]) for item in times]
+
+        for iEntry in range(0,len(listOfIOVs)):
+            listOfOccur.append({"tag": tag,
+                                "synchronization" : synchronization[0],
+                                "since" : listOfIOVs[iEntry] ,
+                                "insertion_time" : listOfTimes[iEntry] })
+
+    t = PrettyTable(['hash', 'since','tag','synch','insertion time'])
+    for element in listOfOccur:
+        t.add_row([args.hash_name,element['since'],element['tag'],element['synchronization'],element['insertion_time']])
+
+    print(t)
+
+
+
+
+def diffGlobalTagsAtRun_(args):
+    connection = connect(args)
+    session = connection.session()
+
+    IOV     = session.get_dbtype(conddb.IOV)
+    TAG     = session.get_dbtype(conddb.Tag)
+    GT      = session.get_dbtype(conddb.GlobalTag)
+    GTMAP   = session.get_dbtype(conddb.GlobalTagMap)
+    RUNINFO = session.get_dbtype(conddb.RunInfo)
+
+    ####################################
+    # Get the time info for the test run
+    ####################################
+
+    if(not args.lastIOV):
+
+        if(args.testRunNumber<0):
+            raise Exception("Run %s (default) can't be matched with an existing run in the database. \n\t\t Please specify a run with the option --run." % args.testRunNumber)
+
+        bestRun = session.query(RUNINFO.run_number, RUNINFO.start_time, RUNINFO.end_time).filter(RUNINFO.run_number == int(args.testRunNumber)).first()
+        if bestRun is None:
+            raise Exception("Run %s can't be matched with an existing run in the database." % args.testRunNumber)
+
+        print("Run",args.testRunNumber," |Start time",bestRun[1]," |End time",bestRun[2],".")
+
+    ####################################
+    # Get the Global Tag snapshots
+    ####################################
+
+    refSnap = session.query(GT.snapshot_time).\
+        filter(GT.name == args.refGT).all()[0][0]
+
+    tarSnap = session.query(GT.snapshot_time).\
+        filter(GT.name == args.tarGT).all()[0][0]
+
+    print("reference GT (",args.refGT ,") snapshot: ",refSnap," | target GT (",args.tarGT,") snapshot",tarSnap)
+
+    ####################################
+    # Get the Global Tag maps
+    ####################################
+
+    GTMap_ref = session.query(GTMAP.record, GTMAP.label, GTMAP.tag_name).\
+        filter(GTMAP.global_tag_name == args.refGT).\
+        order_by(GTMAP.record, GTMAP.label).\
+        all()
+
+    GTMap_tar = session.query(GTMAP.record, GTMAP.label, GTMAP.tag_name).\
+        filter(GTMAP.global_tag_name == args.tarGT).\
+        order_by(GTMAP.record, GTMAP.label).\
+        all()
+
+    text_file = open(("diff_%s_vs_%s.twiki") % (args.refGT,args.tarGT), "w")
+
+    differentTags = {}
+
+    for element in GTMap_ref:
+        RefRecord = element[0]
+        RefLabel  = element[1]
+        RefTag    = element[2]
+
+        for element2 in GTMap_tar:
+            if (RefRecord == element2[0] and RefLabel==element2[1]):
+                if RefTag != element2[2]:
+                    differentTags[(RefRecord,RefLabel)]=(RefTag,element2[2])
+
+    ####################################
+    ## Search for Records,Label not-found in the other list
+    ####################################
+
+    temp1 = [item for item in GTMap_ref if (item[0],item[1]) not in list(zip(list(zip(*GTMap_tar))[0],list(zip(*GTMap_tar))[1]))]
+    for elem in temp1:
+        differentTags[(elem[0],elem[1])]=(elem[2],"")
+
+    temp2 = [item for item in GTMap_tar if (item[0],item[1]) not in list(zip(list(zip(*GTMap_ref))[0],list(zip(*GTMap_ref))[1]))]
+    for elem in temp2:
+        differentTags[(elem[0],elem[1])]=("",elem[2])
+
+    text_file.write("| *Record* | *"+args.refGT+"* | *"+args.tarGT+"* | Remarks | \n")
+
+    t = PrettyTable()
+
+    if(args.isVerbose):
+        t.field_names = ['/','',args.refGT,args.tarGT,refSnap,tarSnap]
+    else:
+        t.field_names = ['/','',args.refGT,args.tarGT]
+
+    t.hrules=1
+
+    if(args.isVerbose):
+        t.add_row(['Record','label','Reference Tag','Target Tag','hash1:time1:since1','hash2:time2:since2'])
+    else:
+        t.add_row(['Record','label','Reference Tag','Target Tag'])
+
+    isDifferent=False
+
+    ####################################
+    # Loop on the difference
+    ####################################
+
+    for Rcd in sorted(differentTags):
+
+        # empty lists at the beginning
+        refTagIOVs=[]
+        tarTagIOVs=[]
+
+        if( differentTags[Rcd][0]!=""):
+            refTagIOVs = session.query(IOV.since,IOV.payload_hash,IOV.insertion_time).filter(IOV.tag_name == differentTags[Rcd][0]).all()
+            refTagInfo = session.query(TAG.synchronization,TAG.time_type).filter(TAG.name == differentTags[Rcd][0]).all()[0]
+        if( differentTags[Rcd][1]!=""):
+            tarTagIOVs = session.query(IOV.since,IOV.payload_hash,IOV.insertion_time).filter(IOV.tag_name == differentTags[Rcd][1]).all()
+            tarTagInfo = session.query(TAG.synchronization,TAG.time_type).filter(TAG.name == differentTags[Rcd][1]).all()[0]
+
+        if(differentTags[Rcd][0]!="" and differentTags[Rcd][1]!=""):
+            if(tarTagInfo[1] != refTagInfo[1]):
+                print(colors.bold_red+" *** Warning *** found mismatched time type for",Rcd,"entry. \n"+differentTags[Rcd][0],"has time type",refTagInfo[1],"while",differentTags[Rcd][1],"has time type",tarTagInfo[1]+". These need to be checked by hand. \n\n"+ colors.end)
+
+        if(args.lastIOV):
+
+            if(sorted(differentTags).index(Rcd)==0):
+                print("\n")
+                print(33 * "=")
+                print("|| COMPARING ONLY THE LAST IOV ||")
+                print(33 * "=")
+                print("\n")
+
+            lastSinceRef=-1
+            lastSinceTar=-1
+
+            hash_lastRefTagIOV = ""
+            time_lastRefTagIOV = ""
+
+            hash_lastTarTagIOV = ""
+            time_lastTarTagIOV = ""
+
+            for i in refTagIOVs:
+                if (i[0]>lastSinceRef):
+                    lastSinceRef = i[0]
+                    hash_lastRefTagIOV = i[1]
+                    time_lastRefTagIOV = str(i[2])
+
+            for j in tarTagIOVs:
+                if (j[0]>lastSinceTar):
+                    lastSinceTar = j[0]
+                    hash_lastTarTagIOV = j[1]
+                    time_lastTarTagIOV = str(j[2])
+
+            if(hash_lastRefTagIOV!=hash_lastTarTagIOV):
+                isDifferent=True
+                text_file.write("| ="+Rcd[0]+"= ("+Rcd[1]+") | =="+differentTags[Rcd][0]+"==  | =="+differentTags[Rcd][1]+"== | | \n")
+                text_file.write("|^|"+hash_lastRefTagIOV+" <br> ("+time_lastRefTagIOV+") "+ str(lastSinceRef) +" | "+hash_lastTarTagIOV+" <br> ("+time_lastTarTagIOV+") " + str(lastSinceTar)+" | ^| \n")
+
+                if(args.isVerbose):
+                    t.add_row([Rcd[0],Rcd[1],differentTags[Rcd][0],differentTags[Rcd][1],str(hash_lastRefTagIOV)+"\n"+str(time_lastRefTagIOV)+"\n"+str(lastSinceRef),str(hash_lastTarTagIOV)+"\n"+str(time_lastTarTagIOV)+"\n"+str(lastSinceTar)])
+                else:
+                    t.add_row([Rcd[0],Rcd[1],differentTags[Rcd][0]+"\n"+str(hash_lastRefTagIOV),differentTags[Rcd][1]+"\n"+str(hash_lastTarTagIOV)])
+
+        else:
+
+            ### reset all defaults
+
+            theGoodRefIOV=-1
+            theGoodTarIOV=-1
+            sinceRefTagIOV=0
+            sinceTarTagIOV=0
+
+            RefIOVtime = datetime.datetime(1970, 1, 1, 0, 0, 0)
+            TarIOVtime = datetime.datetime(1970, 1, 1, 0, 0, 0)
+
+            theRefPayload=""
+            theTarPayload=""
+            theRefTime=""
+            theTarTime=""
+
+            ### loop on the reference IOV list
+            for refIOV in refTagIOVs:
+
+                ## logic for retrieving the the last payload active on a given IOV
+                ## - the new IOV since is less than the run under consideration
+                ## - the payload insertion time is lower than the GT snapshot
+                ## - finall either:
+                ##   - the new IOV since is larger then the last saved
+                ##   - the new IOV since is equal to the last saved but it has a more recent insertion time
+
+                if ( (refIOV[0] <= int(args.testRunNumber)) and (refIOV[0]>sinceRefTagIOV) or ((refIOV[0]==sinceRefTagIOV) and (refIOV[2]>RefIOVtime)) and (refIOV[2]<=refSnap) ):
+                    sinceRefTagIOV = refIOV[0]
+                    RefIOVtime = refIOV[2]
+                    theGoodRefIOV=sinceRefTagIOV
+                    theRefPayload=refIOV[1]
+                    theRefTime=str(refIOV[2])
+
+            ### loop on the target IOV list
+            for tarIOV in tarTagIOVs:
+                if ( (tarIOV[0] <= int(args.testRunNumber)) and (tarIOV[0]>sinceTarTagIOV) or ((tarIOV[0]==sinceTarTagIOV) and (tarIOV[2]>=TarIOVtime)) and (tarIOV[2]<=tarSnap) ):
+                    sinceTarTagIOV = tarIOV[0]
+                    tarIOVtime = tarIOV[2]
+                    theGoodTarIOV=sinceTarTagIOV
+                    theTarPayload=tarIOV[1]
+                    theTarTime=str(tarIOV[2])
+
+            #print Rcd[0],theRefPayload,theTarPayload
+
+            if(theRefPayload!=theTarPayload):
+                isDifferent=True
+                text_file.write("| ="+Rcd[0]+"= ("+Rcd[1]+") | =="+differentTags[Rcd][0]+"==  | =="+differentTags[Rcd][1]+"== |\n")
+                text_file.write("|^|"+theRefPayload+" ("+theRefTime+") | "+theTarPayload+" ("+theTarTime+") |\n")
+
+                ### determinte if it is to be shown
+
+                isMatched=False
+                tokens=args.stringToMatch.split(",")
+                decisions = [bool(Rcd[0].find(x)!=-1) for x in tokens]
+                for decision in decisions:
+                    isMatched = (isMatched or decision)
+
+                if(args.isVerbose):
+                    if (args.stringToMatch=="" or isMatched):
+                        t.add_row([Rcd[0],Rcd[1],differentTags[Rcd][0],differentTags[Rcd][1],str(theRefPayload)+"\n"+str(theRefTime)+"\n"+str(theGoodRefIOV),str(theTarPayload)+"\n"+str(theTarTime)+"\n"+str(theGoodTarIOV)])
+                else:
+                    if (args.stringToMatch=="" or isMatched):
+                        t.add_row([Rcd[0],Rcd[1],differentTags[Rcd][0]+"\n"+str(theRefPayload),differentTags[Rcd][1]+"\n"+str(theTarPayload)])
+
+    if(not isDifferent):
+        if(args.isVerbose):
+            t.add_row(["None","None","None","None","None","None"])
+        else:
+            t.add_row(["None","None","None"])
+    print(t)
+
+
+
 def listGTsForTag_(args):
     connection = connect(args)
     session = connection.session()
@@ -925,6 +1194,7 @@ def listGTs_(args):
             all(),
         ['GT_name', 'Description', 'Release', 'Snapshot_time', 'Insertion_time'],
     )
+
 
 def listRuns_(args):
     connection = connect(args)
@@ -2153,6 +2423,19 @@ def main():
 
     parser_listTags = parser_subparsers.add_parser('listTags', description='Lists all the Tags available in the DB.')
     parser_listTags.set_defaults(func=listTags_)
+
+    parser_listParentTags = parser_subparsers.add_parser('listParentTags', description='Lists all the Tags available in the DB, containing the matched payload hash.')
+    parser_listParentTags.add_argument('hash_name', help="Payload hash to match.")
+    parser_listParentTags.set_defaults(func=listParentTags_)
+
+    parser_diffGlobalTagsAtRun = parser_subparsers.add_parser('diffGlobalTagsAtRun', description='Diffs two global tags, but showing only the differences relevant for a given run number.')
+    parser_diffGlobalTagsAtRun.add_argument('--last', '-L', dest='lastIOV', action='store_true', default=False, help='Diff the Global tags at the last open IOV.')
+    parser_diffGlobalTagsAtRun.add_argument('--reference', '-R', dest='refGT', help="Reference Global Tag")
+    parser_diffGlobalTagsAtRun.add_argument('--target', '-T', dest='tarGT', help="Target Global Tag")
+    parser_diffGlobalTagsAtRun.add_argument('--run', '-r', dest='testRunNumber', help="target run to compare",default=-1)
+    parser_diffGlobalTagsAtRun.add_argument('--verbose','-v',help='returns more info', dest='isVerbose',action='store_true',default=False)
+    parser_diffGlobalTagsAtRun.add_argument('--match','-m',help='print only matching',dest='stringToMatch',action='store',default='')
+    parser_diffGlobalTagsAtRun.set_defaults(func=diffGlobalTagsAtRun_)
 
     parser_listGTsForTag = parser_subparsers.add_parser('listGTsForTag', description='Lists the GTs which contain a given tag.')
     parser_listGTsForTag.add_argument('name', help="Name of the tag.")


### PR DESCRIPTION
#### PR description:

The purpose of this PR is to add few useful functionalities to the `conddb` command line interface I used over the years and IMHO are missing from the current tool. 
They used to live as separate scripts in this repo (https://github.com/cms-AlCaDB/AlCaTools), but I think it would be more beneficial to distribute them via `cmssw` for wider usage.

Two new commands are added:
   -  `conddb listParentTags`: allows to list all tags that contain a given payload hash. Takes the payload hash as argument;
   -  `conddb diffGlobalTagsAtRun` : allows to compile the difference in terms of payloads for a pair of Global Tags, but comparing it **at a given run-number** (so eliminating all the spurious difference due to different tag names, but having actual same palyoads on a given IoV, etc.). This in my opinion is particularly useful when performing release validation and / or data certification, because the end-user - very frequently -would like to know what are the differences in terms of conditions between two Global Tags in data, but only for the run which is currently under examination.
  
#### PR validation:

After compiling and `env`-ing the environment, I've run successfully the new commands, e.g.:

```
$ conddb listParentTags 475738753d337409cc87e5f1cbf93b2f21be59f3
[2021-02-02 18:50:40,952] INFO: Connecting to pro [frontier://PromptProd/CMS_CONDITIONS]
+------------------------------------------+--------+-----------------------------------------------+------------+---------------------+
|                   hash                   | since  |                      tag                      |   synch    |    insertion time   |
+------------------------------------------+--------+-----------------------------------------------+------------+---------------------+
| 475738753d337409cc87e5f1cbf93b2f21be59f3 | 324063 |    SiStripApvGain_FromParticles_GR10_v1_hlt   |    hlt     | 2018-10-04 15:35:47 |
| 475738753d337409cc87e5f1cbf93b2f21be59f3 | 324063 |  SiStripApvGain_FromParticles_GR10_v1_express |  express   | 2018-10-04 15:35:47 |
| 475738753d337409cc87e5f1cbf93b2f21be59f3 |   1    |        SiStripApvGain2_v1_hltvalidation       | validation | 2018-10-04 12:00:20 |
| 475738753d337409cc87e5f1cbf93b2f21be59f3 | 323790 | SiStripApvGain_FromParticles_GR10_v11_offline |  offline   | 2019-09-19 12:44:10 |
| 475738753d337409cc87e5f1cbf93b2f21be59f3 | 323790 | SiStripApvGain_FromParticles_GR10_v12_offline |  offline   | 2019-10-25 16:37:43 |
+------------------------------------------+--------+-----------------------------------------------+------------+---------------------+
```

```
$ conddb diffGlobalTagsAtRun -R 106X_dataRun2_v24 -T 106X_dataRun2_v26 --run 324077
[2021-02-02 14:18:12,466] INFO: Connecting to pro [frontier://PromptProd/CMS_CONDITIONS]
Run 324077  |Start time 2018-10-04 21:59:31.619000  |End time 2018-10-05 02:56:29.293000 .
reference GT ( 106X_dataRun2_v24 ) snapshot:  2019-09-23 13:27:29  | target GT ( 106X_dataRun2_v26 ) snapshot 2020-01-13 16:24:57
+---------------------------+--------+----------------------------------------------+------------------------------------------+
|             /             |        |              106X_dataRun2_v24               |            106X_dataRun2_v26             |
+---------------------------+--------+----------------------------------------------+------------------------------------------+
|           Record          | label  |                Reference Tag                 |                Target Tag                |
+---------------------------+--------+----------------------------------------------+------------------------------------------+
| EcalTimeCalibConstantsRcd |   -    | EcalTimeCalibConstants_Run1_Run2_v02_offline |  EcalTimeCalibConstants_UL_Run1_Run2_v1  |
|                           |        |   3b4a9f66b6f04a012f1a05a936d2b7f3fde55e7a   | 2b2757b28dc60c778cd2ccb493f5caf65a74a392 |
+---------------------------+--------+----------------------------------------------+------------------------------------------+
|      HcalRespCorrsRcd     | bugged |          HcalRespCorrs_v6.3_offline          |                                          |
|                           |        |   04fb1bac77722d2b1a7d9761796854dfbc36877d   |                                          |
+---------------------------+--------+----------------------------------------------+------------------------------------------+
```

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Not a backport, no backport needed.

I am tagging also AlCa conveners as these tools might (or might not) be useful in their everyday work (especially when compiling differences of Global Tags for Relvals for PdmV):
cc:
@christopheralanwest @tlampen @francescobrivio 
