### PR TITLE
DQM GT to 112X in view of MWGR CMSSW 113X 

### DIFF
--- a/DQM/Integration/python/config/FrontierCondition_GT_autoExpress_cfi.py
+++ b/DQM/Integration/python/config/FrontierCondition_GT_autoExpress_cfi.py
@@ -7,7 +7,7 @@ from Configuration.StandardSequences.FrontierConditions_GlobalTag_cff import *
 # It should be kept in synch with Express processing at Tier0: what the url
 # https://cmsweb.cern.ch/t0wmadatasvc/prod/express_config
 # would tell you.
-GlobalTag.globaltag = "111X_dataRun3_Express_v4"
+GlobalTag.globaltag = "112X_dataRun3_Express_v2"
 
 # ===== auto -> Automatically get the GT string from current Tier0 configuration via a Tier0Das call.
 #       This needs a valid proxy to access the cern.ch network from the .cms one.

--- a/DQM/Integration/python/config/FrontierCondition_GT_cfi.py
+++ b/DQM/Integration/python/config/FrontierCondition_GT_cfi.py
@@ -1,3 +1,3 @@
 import FWCore.ParameterSet.Config as cms
 from Configuration.StandardSequences.FrontierConditions_GlobalTag_cff import *
-GlobalTag.globaltag = "111X_dataRun3_HLT_v3"
+GlobalTag.globaltag = "112X_dataRun3_HLT_v1"


### PR DESCRIPTION
#### PR description:

Forward port of https://github.com/cms-sw/cmssw/pull/32800

Using GT "112X_dataRun3_HLT_v1" for the moment to solve IB crashes in https://github.com/cms-sw/cmssw/issues/32796

Tested that the issue above is solved