### PR TITLE
Update Pixel DQM modules prohibiting concurrent lumis

### DIFF
--- a/DQM/SiPixelMonitorDigi/interface/SiPixelDigiSource.h
+++ b/DQM/SiPixelMonitorDigi/interface/SiPixelDigiSource.h
@@ -25,12 +25,11 @@
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 #include "Geometry/CommonTopologies/interface/PixelTopology.h"
 #include "Geometry/Records/interface/TrackerTopologyRcd.h"
-#include "DQMServices/Core/interface/DQMOneEDAnalyzer.h"
 #include "DQM/SiPixelMonitorDigi/interface/SiPixelDigiModule.h"
-
+#include <DQMServices/Core/interface/DQMOneEDAnalyzer.h>
 #include <cstdint>
 
-class SiPixelDigiSource : public DQMOneLumiEDAnalyzer<> {
+class SiPixelDigiSource : public DQMOneEDAnalyzer<edm::LuminosityBlockCache<bool>> {
 public:
   explicit SiPixelDigiSource(const edm::ParameterSet& conf);
   ~SiPixelDigiSource() override;
@@ -40,9 +39,9 @@ public:
   void analyze(const edm::Event&, const edm::EventSetup&) override;
   void dqmBeginRun(const edm::Run&, edm::EventSetup const&) override;
   void bookHistograms(DQMStore::IBooker&, edm::Run const&, edm::EventSetup const&) override;
-
-  void dqmBeginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
-  void dqmEndLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
+  std::shared_ptr<bool> globalBeginLuminosityBlock(const edm::LuminosityBlock& lumi,
+                                                   const edm::EventSetup& iSetup) const override;
+  void globalEndLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
 
   virtual void buildStructure(edm::EventSetup const&);
   virtual void bookMEs(DQMStore::IBooker&, const edm::EventSetup& iSetup);
@@ -226,7 +225,7 @@ private:
   int nDigisB;
 
   //define Token(-s)
-  edm::EDGetTokenT<edm::DetSetVector<PixelDigi> > srcToken_;
+  edm::EDGetTokenT<edm::DetSetVector<PixelDigi>> srcToken_;
   edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> trackerTopoToken_;
   edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> trackerTopoTokenBeginRun_;
   edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> trackerGeomTokenBeginRun_;

--- a/DQM/SiPixelMonitorDigi/src/SiPixelDigiSource.cc
+++ b/DQM/SiPixelMonitorDigi/src/SiPixelDigiSource.cc
@@ -101,67 +101,16 @@ SiPixelDigiSource::~SiPixelDigiSource() {
   LogInfo("PixelDQM") << "SiPixelDigiSource::~SiPixelDigiSource: Destructor" << endl;
 }
 
-void SiPixelDigiSource::dqmBeginLuminosityBlock(const edm::LuminosityBlock& lb, edm::EventSetup const&) {
-  int thisls = lb.id().luminosityBlock();
-
-  if (modOn && thisls % 10 == 0 && averageDigiOccupancy) {
-    nBPIXDigis = 0;
-    nFPIXDigis = 0;
-    for (int i = 0; i != 40; i++)
-      nDigisPerFed[i] = 0;
-  }
-  if (!modOn && averageDigiOccupancy) {
-    nBPIXDigis = 0;
-    nFPIXDigis = 0;
-    for (int i = 0; i != 40; i++)
-      nDigisPerFed[i] = 0;
-  }
-
-  if (modOn && thisls % 10 == 0) {
-    ROCMapToReset = true;  //the ROC map is reset each 10 lumisections
-
-    for (int i = 0; i < 2; i++)
-      NzeroROCs[i] = 0;
-    for (int i = 0; i < 2; i++)
-      NloEffROCs[i] = 0;  //resetting also Zero and low eff. ROC counters
-
-    NzeroROCs[1] = -672;
-    NloEffROCs[1] =
-        -672;  //this magic number derives by the way the endcap occupancy is filled, there are always 672 empty bins by construction
-
-    //these bools are needed to count zero occupancy plots in the substructure only once each 10 LS
-    DoZeroRocsBMO1 = true;
-    DoZeroRocsBMO2 = true;
-    DoZeroRocsBMO3 = true;
-
-    DoZeroRocsBMI1 = true;
-    DoZeroRocsBMI2 = true;
-    DoZeroRocsBMI3 = true;
-
-    DoZeroRocsBPO1 = true;
-    DoZeroRocsBPO2 = true;
-    DoZeroRocsBPO3 = true;
-
-    DoZeroRocsBPI1 = true;
-    DoZeroRocsBPI2 = true;
-    DoZeroRocsBPI3 = true;
-
-    DoZeroRocsFPO1 = true;
-    DoZeroRocsFPO2 = true;
-
-    DoZeroRocsFMO1 = true;
-    DoZeroRocsFMO2 = true;
-
-    DoZeroRocsFPI1 = true;
-    DoZeroRocsFPI2 = true;
-
-    DoZeroRocsFMI1 = true;
-    DoZeroRocsFMI2 = true;
-  }
+std::shared_ptr<bool> SiPixelDigiSource::globalBeginLuminosityBlock(const edm::LuminosityBlock& lumi,
+                                                                    const edm::EventSetup& iSetup) const {
+  unsigned int currentLS = lumi.id().luminosityBlock();
+  bool resetCounters = (currentLS % 10 == 0) ? true : false;
+  return std::make_shared<bool>(resetCounters);
 }
 
-void SiPixelDigiSource::dqmEndLuminosityBlock(const edm::LuminosityBlock& lb, edm::EventSetup const&) {
+void SiPixelDigiSource::globalEndLuminosityBlock(const edm::LuminosityBlock& lb, edm::EventSetup const&) {
   int thisls = lb.id().luminosityBlock();
+  const bool resetCounters = luminosityBlockCache(lb.index());
 
   float averageBPIXFed = float(nBPIXDigis) / 32.;
   float averageFPIXFed = float(nFPIXDigis) / 8.;
@@ -201,6 +150,64 @@ void SiPixelDigiSource::dqmEndLuminosityBlock(const edm::LuminosityBlock& lb, ed
       avgEndcapFedOccvsLumi->setBinContent(
           int(thisls / 10), averageFPIXFed);  //<NDigis> vs lumisection for endcap, filled every 10 lumi sections
     }
+  }
+
+  //reset counters
+
+  if (modOn && resetCounters && averageDigiOccupancy) {
+    nBPIXDigis = 0;
+    nFPIXDigis = 0;
+    for (int i = 0; i != 40; i++)
+      nDigisPerFed[i] = 0;
+  }
+
+  if (!modOn && averageDigiOccupancy) {
+    nBPIXDigis = 0;
+    nFPIXDigis = 0;
+    for (int i = 0; i != 40; i++)
+      nDigisPerFed[i] = 0;
+  }
+
+  if (modOn && resetCounters) {
+    ROCMapToReset = true;  //the ROC map is reset each 10 lumisections
+
+    for (int i = 0; i < 2; i++)
+      NzeroROCs[i] = 0;
+    for (int i = 0; i < 2; i++)
+      NloEffROCs[i] = 0;  //resetting also Zero and low eff. ROC counters
+
+    NzeroROCs[1] = -672;
+    NloEffROCs[1] =
+        -672;  //this magic number derives by the way the endcap occupancy is filled, there are always 672 empty bins by construction
+
+    //these bools are needed to count zero occupancy plots in the substructure only once each 10 LS
+    DoZeroRocsBMO1 = true;
+    DoZeroRocsBMO2 = true;
+    DoZeroRocsBMO3 = true;
+
+    DoZeroRocsBMI1 = true;
+    DoZeroRocsBMI2 = true;
+    DoZeroRocsBMI3 = true;
+
+    DoZeroRocsBPO1 = true;
+    DoZeroRocsBPO2 = true;
+    DoZeroRocsBPO3 = true;
+
+    DoZeroRocsBPI1 = true;
+    DoZeroRocsBPI2 = true;
+    DoZeroRocsBPI3 = true;
+
+    DoZeroRocsFPO1 = true;
+    DoZeroRocsFPO2 = true;
+
+    DoZeroRocsFMO1 = true;
+    DoZeroRocsFMO2 = true;
+
+    DoZeroRocsFPI1 = true;
+    DoZeroRocsFPI2 = true;
+
+    DoZeroRocsFMI1 = true;
+    DoZeroRocsFMI2 = true;
   }
 }
 

--- a/DQM/SiPixelMonitorRawData/interface/SiPixelRawDataErrorSource.h
+++ b/DQM/SiPixelMonitorRawData/interface/SiPixelRawDataErrorSource.h
@@ -28,7 +28,7 @@
 #include <memory>
 
 // user include files
-#include "DQMServices/Core/interface/DQMOneEDAnalyzer.h"
+#include "DQMServices/Core/interface/DQMEDAnalyzer.h"
 #include "DQM/SiPixelMonitorRawData/interface/SiPixelRawDataErrorModule.h"
 #include "DataFormats/Common/interface/DetSetVector.h"
 #include "DataFormats/FEDRawData/interface/FEDRawDataCollection.h"
@@ -38,7 +38,7 @@
 #include "Geometry/Records/interface/TrackerTopologyRcd.h"
 #include <cstdint>
 
-class SiPixelRawDataErrorSource : public DQMOneLumiEDAnalyzer<> {
+class SiPixelRawDataErrorSource : public DQMEDAnalyzer {
 public:
   explicit SiPixelRawDataErrorSource(const edm::ParameterSet &conf);
   ~SiPixelRawDataErrorSource() override;


### PR DESCRIPTION
#### PR description:
In this PR, SiPixelRawDataErrorSource & SiPixelDigiSource modules are updated to allow concurrent LS. 

#### PR validation:

Test with : runTheMatrix.py -t 4 -l 4.53

No differences observed when comparing the harvested DQM output files with dqmMemoryStats.py script. 

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

No backport is needed.
