### PR TITLE
Move ParticleFlow to a separate category in RelMon

### DIFF
--- a/Utilities/RelMon/python/definitions.py
+++ b/Utilities/RelMon/python/definitions.py
@@ -75,8 +75,10 @@ original=[\
 
 ('B Tagging' , ['Btag']),
 
+('Particle Flow', ['ParticleFlow']),
+
 ('Miscellanea: Simulation',['Generator','GlobalDigisV','GlobalHitsV','GlobalRecHitsV','MixingV','NoiseRatesV']),
-('Miscellanea',['Info','MessageLogger','ParticleFlow','Physics'])]
+('Miscellanea',['Info','MessageLogger','Physics'])]
 
 # designed for the Reconstruction
 reco_aggr=[\
@@ -100,12 +102,13 @@ reco_aggr=[\
 ('MET',['JetMET/MET','JetMET/METv','ParticleFlow/PFMETValidation']),
 ('B Tagging' , ['Btag']),
 ('Tau' , ['RecoTauV']),
+('Particle Flow', ['ParticleFlow']),
 
 # Other
 ('Castor Calorimeter', ['Castor']),
 ('Level 1 Trigger',['L1T', 'L1TEMU']),
 ('Miscellanea: Sim.',['Generator','GlobalDigisV','GlobalHitsV','GlobalRecHitsV','MixingV','NoiseRatesV']),
-('Miscellanea',['Info','MessageLogger','ParticleFlow','Physics'])]
+('Miscellanea',['Info','MessageLogger','Physics'])]
 
 # Designed for the HLT
 hlt_aggr=[\


### PR DESCRIPTION
#### PR description:

Move ParticleFlow from Miscellanea to it's own separate row in category table of RelMon report summary since the PF has joined the release validation.

#### PR validation:

Ran ValidationMatrix.py and compared results to output before changes.

#### If this PR is a backport please specify the original PR and why you need to backport that PR:

Not a backport.
