### PR TITLE
add an option to leave an interactive gdb session on crash

### DIFF
--- a/FWCore/Services/plugins/InitRootHandlers.cc
+++ b/FWCore/Services/plugins/InitRootHandlers.cc
@@ -124,6 +124,7 @@ namespace edm {
       bool resetErrHandler_;
       bool loadAllDictionaries_;
       bool autoLibraryLoader_;
+      bool interactiveDebug_;
       std::shared_ptr<const void> sigBusHandler_;
       std::shared_ptr<const void> sigSegvHandler_;
       std::shared_ptr<const void> sigIllHandler_;
@@ -750,7 +751,8 @@ namespace edm {
           unloadSigHandler_(pset.getUntrackedParameter<bool>("UnloadRootSigHandler")),
           resetErrHandler_(pset.getUntrackedParameter<bool>("ResetRootErrHandler")),
           loadAllDictionaries_(pset.getUntrackedParameter<bool>("LoadAllDictionaries")),
-          autoLibraryLoader_(loadAllDictionaries_ or pset.getUntrackedParameter<bool>("AutoLibraryLoader")) {
+          autoLibraryLoader_(loadAllDictionaries_ or pset.getUntrackedParameter<bool>("AutoLibraryLoader")),
+          interactiveDebug_(pset.getUntrackedParameter<bool>("InteractiveDebug")) {
       stackTracePause_ = pset.getUntrackedParameter<int>("StackTracePauseTime");
 
       if (unloadSigHandler_) {
@@ -870,6 +872,8 @@ namespace edm {
           ->setComment(
               "If True, do an abort when a signal occurs that causes a crash. If False, ROOT will do an exit which "
               "attempts to do a clean shutdown.");
+      desc.addUntracked<bool>("InteractiveDebug", false)->setComment("If True, leave gdb attached to cmsRun after a crash; "
+              "if False, attach gdb, print a stack trace, and quit gdb");
       desc.addUntracked<int>("DebugLevel", 0)->setComment("Sets ROOT's gDebug value.");
       desc.addUntracked<int>("StackTracePauseTime", 300)
           ->setComment("Seconds to pause other threads during stack trace.");
@@ -889,15 +893,19 @@ namespace edm {
         //In that case, we are already all setup
         return;
       }
-      if (snprintf(pidString_,
-                   pidStringLength_ - 1,
-                   "date; gdb -quiet -p %d 2>&1 <<EOF |\n"
+      std::string gdbcmd{"date; gdb -quiet -p %d"};
+      if (!interactiveDebug_) {
+        gdbcmd += " 2>&1 <<EOF |\n"
                    "set width 0\n"
                    "set height 0\n"
                    "set pagination no\n"
                    "thread apply all bt\n"
                    "EOF\n"
-                   "/bin/sed -n -e 's/^\\((gdb) \\)*//' -e '/^#/p' -e '/^Thread/p'",
+                   "/bin/sed -n -e 's/^\\((gdb) \\)*//' -e '/^#/p' -e '/^Thread/p'";
+      }
+      if (snprintf(pidString_,
+                   pidStringLength_ - 1,
+                   gdbcmd.c_str(),
                    getpid()) >= pidStringLength_) {
         std::ostringstream sstr;
         sstr << "Unable to pre-allocate stacktrace handler information";

--- a/FWCore/Services/plugins/InitRootHandlers.cc
+++ b/FWCore/Services/plugins/InitRootHandlers.cc
@@ -872,7 +872,9 @@ namespace edm {
           ->setComment(
               "If True, do an abort when a signal occurs that causes a crash. If False, ROOT will do an exit which "
               "attempts to do a clean shutdown.");
-      desc.addUntracked<bool>("InteractiveDebug", false)->setComment("If True, leave gdb attached to cmsRun after a crash; "
+      desc.addUntracked<bool>("InteractiveDebug", false)
+          ->setComment(
+              "If True, leave gdb attached to cmsRun after a crash; "
               "if False, attach gdb, print a stack trace, and quit gdb");
       desc.addUntracked<int>("DebugLevel", 0)->setComment("Sets ROOT's gDebug value.");
       desc.addUntracked<int>("StackTracePauseTime", 300)
@@ -895,18 +897,16 @@ namespace edm {
       }
       std::string gdbcmd{"date; gdb -quiet -p %d"};
       if (!interactiveDebug_) {
-        gdbcmd += " 2>&1 <<EOF |\n"
-                   "set width 0\n"
-                   "set height 0\n"
-                   "set pagination no\n"
-                   "thread apply all bt\n"
-                   "EOF\n"
-                   "/bin/sed -n -e 's/^\\((gdb) \\)*//' -e '/^#/p' -e '/^Thread/p'";
+        gdbcmd +=
+            " 2>&1 <<EOF |\n"
+            "set width 0\n"
+            "set height 0\n"
+            "set pagination no\n"
+            "thread apply all bt\n"
+            "EOF\n"
+            "/bin/sed -n -e 's/^\\((gdb) \\)*//' -e '/^#/p' -e '/^Thread/p'";
       }
-      if (snprintf(pidString_,
-                   pidStringLength_ - 1,
-                   gdbcmd.c_str(),
-                   getpid()) >= pidStringLength_) {
+      if (snprintf(pidString_, pidStringLength_ - 1, gdbcmd.c_str(), getpid()) >= pidStringLength_) {
         std::ostringstream sstr;
         sstr << "Unable to pre-allocate stacktrace handler information";
         edm::Exception except(edm::errors::OtherCMS, sstr.str());


### PR DESCRIPTION
#### PR description:

This PR adds an option for the stack trace handler to attach to gdb and leave an interactive session, instead of printing a backtrace and detaching.  This allows for interactive investigation of bugs (particularly threading bugs) that don't manifest when run under gdb.

#### PR validation:

Tested (via `kill -SIGBUS`) that the default behavior is still the same, but with
```
process.InitRootHandlers = cms.Service('InitRootHandlers',
    InteractiveDebug = cms.untracked.bool(True)
)
```
the bus error signal leaves the terminal at an interactive `(gdb)` prompt attached to cmsRun.