### PR TITLE
Remove GEM StripDigiSimLinks, only use GEMDigiSimLink

### DIFF
--- a/SimMuon/GEMDigitizer/plugins/GEMDigiProducer.cc
+++ b/SimMuon/GEMDigitizer/plugins/GEMDigiProducer.cc
@@ -21,7 +21,6 @@
 #include "SimDataFormats/CrossingFrame/interface/CrossingFrame.h"
 #include "SimDataFormats/CrossingFrame/interface/MixCollection.h"
 #include "SimDataFormats/TrackingHit/interface/PSimHitContainer.h"
-#include "SimDataFormats/TrackerDigiSimLink/interface/StripDigiSimLink.h"
 #include "SimDataFormats/GEMDigiSimLink/interface/GEMDigiSimLink.h"
 
 #include "Geometry/Records/interface/MuonGeometryRecord.h"
@@ -38,8 +37,6 @@ namespace CLHEP {
 
 class GEMDigiProducer : public edm::stream::EDProducer<> {
 public:
-  typedef edm::DetSetVector<StripDigiSimLink> StripDigiSimLinks;
-
   typedef edm::DetSetVector<GEMDigiSimLink> GEMDigiSimLinks;
 
   explicit GEMDigiProducer(const edm::ParameterSet& ps);
@@ -64,7 +61,6 @@ private:
 
 GEMDigiProducer::GEMDigiProducer(const edm::ParameterSet& ps) : gemDigiModule_(std::make_unique<GEMDigiModule>(ps)) {
   produces<GEMDigiCollection>();
-  produces<StripDigiSimLinks>("GEM");
   produces<GEMDigiSimLinks>("GEM");
 
   edm::Service<edm::RandomNumberGenerator> rng;
@@ -156,7 +152,6 @@ void GEMDigiProducer::produce(edm::Event& e, const edm::EventSetup& eventSetup) 
 
   // Create empty output
   auto digis = std::make_unique<GEMDigiCollection>();
-  auto stripDigiSimLinks = std::make_unique<StripDigiSimLinks>();
   auto gemDigiSimLinks = std::make_unique<GEMDigiSimLinks>();
 
   // arrange the hits by eta partition
@@ -177,13 +172,11 @@ void GEMDigiProducer::produce(edm::Event& e, const edm::EventSetup& eventSetup) 
 
     gemDigiModule_->simulate(roll, simHits, engine);
     gemDigiModule_->fillDigis(rawId, *digis);
-    (*stripDigiSimLinks).insert(gemDigiModule_->stripDigiSimLinks());
     (*gemDigiSimLinks).insert(gemDigiModule_->gemDigiSimLinks());
   }
 
   // store them in the event
   e.put(std::move(digis));
-  e.put(std::move(stripDigiSimLinks), "GEM");
   e.put(std::move(gemDigiSimLinks), "GEM");
 }
 

--- a/SimMuon/GEMDigitizer/plugins/ME0DigiProducer.cc
+++ b/SimMuon/GEMDigitizer/plugins/ME0DigiProducer.cc
@@ -20,7 +20,6 @@
 #include "SimDataFormats/CrossingFrame/interface/CrossingFrame.h"
 #include "SimDataFormats/CrossingFrame/interface/MixCollection.h"
 #include "SimDataFormats/TrackingHit/interface/PSimHitContainer.h"
-#include "SimDataFormats/TrackerDigiSimLink/interface/StripDigiSimLink.h"
 #include "SimDataFormats/GEMDigiSimLink/interface/ME0DigiSimLink.h"
 
 #include "SimMuon/GEMDigitizer/interface/ME0DigiModelFactory.h"
@@ -40,8 +39,6 @@ namespace CLHEP {
 
 class ME0DigiProducer : public edm::stream::EDProducer<> {
 public:
-  typedef edm::DetSetVector<StripDigiSimLink> StripDigiSimLinks;
-
   typedef edm::DetSetVector<ME0DigiSimLink> ME0DigiSimLinks;
 
   explicit ME0DigiProducer(const edm::ParameterSet& ps);
@@ -64,7 +61,6 @@ ME0DigiProducer::ME0DigiProducer(const edm::ParameterSet& ps)
     : ME0DigiModel_{
           ME0DigiModelFactory::get()->create("ME0" + ps.getParameter<std::string>("digiModelString") + "Model", ps)} {
   produces<ME0DigiCollection>();
-  produces<StripDigiSimLinks>("ME0");
   produces<ME0DigiSimLinks>("ME0");
 
   edm::Service<edm::RandomNumberGenerator> rng;
@@ -102,7 +98,6 @@ void ME0DigiProducer::produce(edm::Event& e, const edm::EventSetup& eventSetup) 
 
   // Create empty output
   auto digis = std::make_unique<ME0DigiCollection>();
-  auto stripDigiSimLinks = std::make_unique<StripDigiSimLinks>();
   auto me0DigiSimLinks = std::make_unique<ME0DigiSimLinks>();
 
   // arrange the hits by eta partition
@@ -124,13 +119,11 @@ void ME0DigiProducer::produce(edm::Event& e, const edm::EventSetup& eventSetup) 
     ME0DigiModel_->simulateSignal(roll, simHits, engine);
     ME0DigiModel_->simulateNoise(roll, engine);
     ME0DigiModel_->fillDigis(rawId, *digis);
-    (*stripDigiSimLinks).insert(ME0DigiModel_->stripDigiSimLinks());
     (*me0DigiSimLinks).insert(ME0DigiModel_->me0DigiSimLinks());
   }
 
   // store them in the event
   e.put(std::move(digis));
-  e.put(std::move(stripDigiSimLinks), "ME0");
   e.put(std::move(me0DigiSimLinks), "ME0");
 }
 

--- a/SimMuon/MCTruth/interface/GEMHitAssociator.h
+++ b/SimMuon/MCTruth/interface/GEMHitAssociator.h
@@ -9,7 +9,7 @@
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "SimDataFormats/EncodedEventId/interface/EncodedEventId.h"
-#include "SimDataFormats/TrackerDigiSimLink/interface/StripDigiSimLink.h"
+#include "SimDataFormats/GEMDigiSimLink/interface/GEMDigiSimLink.h"
 #include "SimDataFormats/TrackingHit/interface/PSimHit.h"
 #include "SimDataFormats/TrackingHit/interface/PSimHitContainer.h"
 
@@ -32,8 +32,8 @@
 
 class GEMHitAssociator {
 public:
-  typedef edm::DetSetVector<StripDigiSimLink> DigiSimLinks;
-  typedef edm::DetSet<StripDigiSimLink> LayerLinks;
+  typedef edm::DetSetVector<GEMDigiSimLink> DigiSimLinks;
+  typedef edm::DetSet<GEMDigiSimLink> LayerLinks;
   typedef std::pair<uint32_t, EncodedEventId> SimHitIdpr;
 
   // Constructor with configurable parameters
@@ -58,7 +58,7 @@ private:
 
   edm::EDGetTokenT<CrossingFrame<PSimHit>> GEMsimhitsXFToken_;
   edm::EDGetTokenT<edm::PSimHitContainer> GEMsimhitsToken_;
-  edm::EDGetTokenT<edm::DetSetVector<StripDigiSimLink>> GEMdigisimlinkToken_;
+  edm::EDGetTokenT<edm::DetSetVector<GEMDigiSimLink>> GEMdigisimlinkToken_;
 
   std::map<unsigned int, edm::PSimHitContainer> _SimHitMap;
 };

--- a/SimMuon/MCTruth/src/GEMHitAssociator.cc
+++ b/SimMuon/MCTruth/src/GEMHitAssociator.cc
@@ -16,7 +16,7 @@ GEMHitAssociator::GEMHitAssociator(const edm::ParameterSet &conf, edm::ConsumesC
     GEMsimhitsToken_ = iC.consumes<edm::PSimHitContainer>(GEMsimhitsTag);
   }
 
-  GEMdigisimlinkToken_ = iC.consumes<edm::DetSetVector<StripDigiSimLink>>(GEMdigisimlinkTag);
+  GEMdigisimlinkToken_ = iC.consumes<edm::DetSetVector<GEMDigiSimLink>>(GEMdigisimlinkTag);
 }
 
 GEMHitAssociator::GEMHitAssociator(const edm::Event &e,
@@ -82,11 +82,11 @@ std::vector<GEMHitAssociator::SimHitIdpr> GEMHitAssociator::associateRecHit(cons
       if (layerLinks != theDigiSimLinks->end()) {
         for (int i = fstrip; i < (fstrip + cls); ++i) {
           for (LayerLinks::const_iterator itlink = layerLinks->begin(); itlink != layerLinks->end(); ++itlink) {
-            int ch = static_cast<int>(itlink->channel());
+            int ch = static_cast<int>(itlink->getStrip());
             if (ch != i)
               continue;
 
-            SimHitIdpr currentId(itlink->SimTrackId(), itlink->eventId());
+            SimHitIdpr currentId(itlink->getTrackId(), itlink->getEventId());
             if (find(matched.begin(), matched.end(), currentId) == matched.end())
               matched.push_back(currentId);
           }


### PR DESCRIPTION
#### PR description:

Currently, there are two collections of SimLinks for GEM, GEMStripDigiSimLink and GEMDigiSimLink, which as far as I can see simply duplicate functionality. GEMStripDigiSimLink was only used in the GEMHitAssociator, but is easily replaced by GEMDigiSimLink which is used elsewhere in the codebase.

@jshlee @dildick 

<!-- Please replace this text with a description of the feature proposed or problem addressed, specifying:
  - what changes are expected in the output if any, 
  - what other PRs or externals it depends upon if any,
  - link to any additional material useful to provide a documentation for this PR (slides, JIRA tickets, related pull requestes, hypernews, TWiki or Indico pages)  -->

#### PR validation:

Checked the a phase 2 workflow runs to completion with no errors.

<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

<!-- Please replace this text with any link to  -->

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
