### PR TITLE
Calo l1 last20 mismatches axis fix

### DIFF
--- a/DQM/L1TMonitor/interface/L1TStage2CaloLayer1.h
+++ b/DQM/L1TMonitor/interface/L1TStage2CaloLayer1.h
@@ -155,7 +155,7 @@ namespace CaloL1Information {
 
     dqm::reco::MonitorElement *last20Mismatches_;
 
-    std::vector<std::tuple<edm::RunID, edm::LuminosityBlockID, edm::EventID, int>> runMismatchList;
+    std::vector<std::tuple<edm::RunID, edm::LuminosityBlockID, edm::EventID, std::vector<int>>> runMismatchList;
   };
 
   struct perStreamMonitoringDataHolder {
@@ -166,7 +166,7 @@ namespace CaloL1Information {
     int streamNumMaxEvtMismatchECAL{0};
     int streamNumMaxEvtMismatchHCAL{0};
     int streamNumMaxEvtMismatch{0};
-    std::vector<std::tuple<edm::RunID, edm::LuminosityBlockID, edm::EventID, int>> streamMismatchList;
+    std::vector<std::tuple<edm::RunID, edm::LuminosityBlockID, edm::EventID, std::vector<int>>> streamMismatchList;
   };
 
   struct perLumiBlockMonitoringInformation {
@@ -178,11 +178,11 @@ namespace CaloL1Information {
     int lumiNumMaxEvtMismatchHCAL{0};
     int lumiNumMaxEvtMismatch{0};
 
-    std::vector<std::tuple<edm::RunID, edm::LuminosityBlockID, edm::EventID, int>> lumiMismatchList;
+    std::vector<std::tuple<edm::RunID, edm::LuminosityBlockID, edm::EventID, std::vector<int>>> lumiMismatchList;
   };
 
   struct perRunSummaryMonitoringInformation {
-    std::vector<std::tuple<edm::RunID, edm::LuminosityBlockID, edm::EventID, int>> runMismatchList;
+    std::vector<std::tuple<edm::RunID, edm::LuminosityBlockID, edm::EventID, std::vector<int>>> runMismatchList;
   };
 
 }  // namespace CaloL1Information
@@ -248,19 +248,21 @@ protected:
                            CaloL1Information::perRunSummaryMonitoringInformation *) const override;
 
 private:
-  void updateMismatch(
-      const edm::Event &e,
-      int mismatchType,
-      std::vector<std::tuple<edm::RunID, edm::LuminosityBlockID, edm::EventID, int>> &streamMismatches) const;
+  void updateMismatch(const edm::Event &e,
+                      int mismatchType,
+                      std::vector<std::tuple<edm::RunID, edm::LuminosityBlockID, edm::EventID, std::vector<int>>>
+                          &streamMismatches) const;
 
-  void mergeMismatchVectors(std::vector<std::tuple<edm::RunID, edm::LuminosityBlockID, edm::EventID, int>> &,
-                            std::vector<std::tuple<edm::RunID, edm::LuminosityBlockID, edm::EventID, int>> &) const;
+  void mergeMismatchVectors(
+      std::vector<std::tuple<edm::RunID, edm::LuminosityBlockID, edm::EventID, std::vector<int>>> &,
+      std::vector<std::tuple<edm::RunID, edm::LuminosityBlockID, edm::EventID, std::vector<int>>> &) const;
 
-  bool isLaterMismatch(std::tuple<edm::RunID, edm::LuminosityBlockID, edm::EventID, int> &candidateMismatch,
-                       std::tuple<edm::RunID, edm::LuminosityBlockID, edm::EventID, int> &comparisonMismatch) const;
+  bool isLaterMismatch(
+      std::tuple<edm::RunID, edm::LuminosityBlockID, edm::EventID, std::vector<int>> &candidateMismatch,
+      std::tuple<edm::RunID, edm::LuminosityBlockID, edm::EventID, std::vector<int>> &comparisonMismatch) const;
 
-  int findIndex(std::tuple<edm::RunID, edm::LuminosityBlockID, edm::EventID, int>,
-                std::vector<std::tuple<edm::RunID, edm::LuminosityBlockID, edm::EventID, int>>,
+  int findIndex(std::tuple<edm::RunID, edm::LuminosityBlockID, edm::EventID, std::vector<int>>,
+                std::vector<std::tuple<edm::RunID, edm::LuminosityBlockID, edm::EventID, std::vector<int>>>,
                 int lowerIndexToSearch,
                 int upperIndexToSearch) const;
   // Input and config info

--- a/DQM/L1TMonitor/src/L1TStage2CaloLayer1.cc
+++ b/DQM/L1TMonitor/src/L1TStage2CaloLayer1.cc
@@ -348,7 +348,7 @@ void L1TStage2CaloLayer1::updateMismatch(
     int mismatchType,
     std::vector<std::tuple<edm::RunID, edm::LuminosityBlockID, edm::EventID, std::vector<int>>>& streamMismatches)
     const {
-  //check if this combination of Run/Lumi/Event already exists in the strem mismatch list
+  //check if this combination of Run/Lumi/Event already exists in the stream mismatch list
   //if it does, update that entry, otherwise insert a new one with this particular combination.
   for (auto mismatchIterator = streamMismatches.begin(); mismatchIterator != streamMismatches.end();
        ++mismatchIterator) {

--- a/DQM/L1TMonitor/src/L1TStage2CaloLayer1.cc
+++ b/DQM/L1TMonitor/src/L1TStage2CaloLayer1.cc
@@ -346,12 +346,38 @@ void L1TStage2CaloLayer1::dqmAnalyze(const edm::Event& event,
 void L1TStage2CaloLayer1::updateMismatch(
     const edm::Event& e,
     int mismatchType,
-    std::vector<std::tuple<edm::RunID, edm::LuminosityBlockID, edm::EventID, int>>& streamMismatches) const {
-  std::tuple<edm::RunID, edm::LuminosityBlockID, edm::EventID, int> mismatchToInsert = {
-      e.getRun().id(), e.getLuminosityBlock().id(), e.id(), mismatchType};
+    std::vector<std::tuple<edm::RunID, edm::LuminosityBlockID, edm::EventID, std::vector<int>>>& streamMismatches)
+    const {
+  //check if this combination of Run/Lumi/Event already exists in the strem mismatch list
+  //if it does, update that entry, otherwise insert a new one with this particular combination.
+  for (auto mismatchIterator = streamMismatches.begin(); mismatchIterator != streamMismatches.end();
+       ++mismatchIterator) {
+    if (e.getRun().id() == std::get<0>(*mismatchIterator) &&
+        e.getLuminosityBlock().id() == std::get<1>(*mismatchIterator) && e.id() == std::get<2>(*mismatchIterator)) {
+      //the run, lumi and event exist. Check if this kind of mismatch has been reported before
+      std::vector<int> mismatchTypeVector = std::get<3>(*mismatchIterator);
+      for (auto mismatchTypeIterator = mismatchTypeVector.begin(); mismatchTypeIterator != mismatchTypeVector.end();
+           ++mismatchTypeIterator) {
+        if (mismatchType == *mismatchTypeIterator) {
+          //this has already been reported
+          return;
+        }
+      }
+      //A mismatch exists, but it is not a type that has been previously reported.
+      //Insert it into the vector of types of mismatches reported
+      mismatchTypeVector.push_back(mismatchType);
+      return;
+    }
+  }
+
+  //The run/lumi/event does not exist in the list, construct an entry
+  std::vector<int> newMismatchTypeVector;
+  newMismatchTypeVector.push_back(mismatchType);
+  std::tuple<edm::RunID, edm::LuminosityBlockID, edm::EventID, std::vector<int>> mismatchToInsert = {
+      e.getRun().id(), e.getLuminosityBlock().id(), e.id(), newMismatchTypeVector};
   streamMismatches.push_back(mismatchToInsert);
-  //This 20 is potentially a non-obvious constant "magic number"
-  //this matches the mismatch detail histogram, but should be upgraded to not use the constant in this manner.
+
+  //maintain the mismatch vector size at 20.
   if (streamMismatches.size() > 20)
     streamMismatches.erase(streamMismatches.begin());
 }
@@ -607,8 +633,8 @@ void L1TStage2CaloLayer1::globalEndLuminosityBlockSummary(
 // based on Run, Lumisection, and event number
 //false otherwise
 bool L1TStage2CaloLayer1::isLaterMismatch(
-    std::tuple<edm::RunID, edm::LuminosityBlockID, edm::EventID, int>& candidateMismatch,
-    std::tuple<edm::RunID, edm::LuminosityBlockID, edm::EventID, int>& comparisonMismatch) const {
+    std::tuple<edm::RunID, edm::LuminosityBlockID, edm::EventID, std::vector<int>>& candidateMismatch,
+    std::tuple<edm::RunID, edm::LuminosityBlockID, edm::EventID, std::vector<int>>& comparisonMismatch) const {
   //check the run. If the run ID of the candidate mismatch is less than the run ID of the comparison mismatch, it is earlier,
   if (std::get<0>(candidateMismatch) < std::get<0>(comparisonMismatch))
     return false;
@@ -637,8 +663,8 @@ bool L1TStage2CaloLayer1::isLaterMismatch(
 //will find an interger we add to the iterator to get the proper location to find the insertion location
 //will return -1 if the mismatch should not be inserted into the list
 int L1TStage2CaloLayer1::findIndex(
-    std::tuple<edm::RunID, edm::LuminosityBlockID, edm::EventID, int> candidateMismatch,
-    std::vector<std::tuple<edm::RunID, edm::LuminosityBlockID, edm::EventID, int>> comparisonList,
+    std::tuple<edm::RunID, edm::LuminosityBlockID, edm::EventID, std::vector<int>> candidateMismatch,
+    std::vector<std::tuple<edm::RunID, edm::LuminosityBlockID, edm::EventID, std::vector<int>>> comparisonList,
     int lowerIndexToSearch,
     int upperIndexToSearch) const {
   //Start by getting the spot in the the vector to start searching
@@ -697,8 +723,9 @@ int L1TStage2CaloLayer1::findIndex(
 
 //will shuffle the candidate mismatch list into the comparison mismatch list.
 void L1TStage2CaloLayer1::mergeMismatchVectors(
-    std::vector<std::tuple<edm::RunID, edm::LuminosityBlockID, edm::EventID, int>>& candidateMismatchList,
-    std::vector<std::tuple<edm::RunID, edm::LuminosityBlockID, edm::EventID, int>>& comparisonMismatchList) const {
+    std::vector<std::tuple<edm::RunID, edm::LuminosityBlockID, edm::EventID, std::vector<int>>>& candidateMismatchList,
+    std::vector<std::tuple<edm::RunID, edm::LuminosityBlockID, edm::EventID, std::vector<int>>>& comparisonMismatchList)
+    const {
   //okay now we loop over our candidate mismatches
   for (auto candidateIterator = candidateMismatchList.begin(); candidateIterator != candidateMismatchList.end();
        ++candidateIterator) {
@@ -748,7 +775,13 @@ void L1TStage2CaloLayer1::globalEndRunSummary(
                            std::to_string(std::get<1>(*mismatchIterator).luminosityBlock()) + ":" +
                            std::to_string(std::get<2>(*mismatchIterator).event());
     theRunCache->last20Mismatches_->setBinLabel(ibin, binLabel, 2);
-    theRunCache->last20Mismatches_->setBinContent(std::get<3>(*mismatchIterator) + 1, ibin, 1);
+    //Get the vector of mismatches for this particular event and iterate through it.
+    //Set the bin content to 1 for each type of mismatch seen
+    std::vector<int> mismatchTypeVector = std::get<3>(*mismatchIterator);
+    for (auto mismatchTypeIterator = mismatchTypeVector.begin(); mismatchTypeIterator != mismatchTypeVector.end();
+         ++mismatchTypeIterator) {
+      theRunCache->last20Mismatches_->setBinContent(*mismatchTypeIterator + 1, ibin, 1);
+    }
     ++ibin;
   }
 }

--- a/DQM/L1TMonitor/src/L1TStage2CaloLayer1.cc
+++ b/DQM/L1TMonitor/src/L1TStage2CaloLayer1.cc
@@ -784,4 +784,8 @@ void L1TStage2CaloLayer1::globalEndRunSummary(
     }
     ++ibin;
   }
+  //remove the remaining empty string labels to prevent overlap
+  for (int emptyBinIndex = ibin; emptyBinIndex <= 20; ++emptyBinIndex) {
+    theRunCache->last20Mismatches_->setBinLabel(emptyBinIndex, std::to_string(emptyBinIndex), 2);
+  }
 }


### PR DESCRIPTION
#### PR description:

<!-- Please replace this text with a description of the feature proposed or problem addressed, specifying:
  - what changes are expected in the output if any, 
  - what other PRs or externals it depends upon if any,
  - link to any additional material useful to provide a documentation for this PR (slides, JIRA tickets, related pull requestes, hypernews, TWiki or Indico pages)  -->

This PR modifies the function of the last20Mismatches monitoring element to not include duplicate event mismatch reports on the Y-axis, instead just updating the types of mismatches seen for a given combination of Run, Lumi, and Event. As well, empty Y-axis labels are now simply given their corresponding bin number, to prevent empty string labels causing issues as seen before in #32250. This PR fixes the issue first spotted on this hypernews thread: https://hypernews.cern.ch/HyperNews/CMS/get/tier0-Ops/2192.html

#### PR validation:

<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->

All code compiles, and produces expected plots as seen when using `runTheMatrix.py`. Using @silviodonato 's method to test the DQM merging step, this code eliminates the merging error seen.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This PR is not a backport. However, it does need to be forward port-ed to 11_3_X and master.
