### PR TITLE
Pr112x L1T Bug fix : uGT emulator of displaced muons - step2

### DIFF
--- a/L1Trigger/L1TGlobal/src/MuCondition.cc
+++ b/L1Trigger/L1TGlobal/src/MuCondition.cc
@@ -470,18 +470,6 @@ const bool l1t::MuCondition::checkObjectParameter(const int iCondition,
     return false;
   }
 
-  // check impact parameter ( bit check ) with impact parameter LUT
-  // sanity check on candidate impact parameter
-  if (cand.hwDXY() > 3) {
-    LogDebug("L1TGlobal") << "\t\t l1t::Candidate has out of range hwDXY = " << cand.hwDXY() << std::endl;
-    return false;
-  }
-  bool passImpactParameterLUT = ((objPar.impactParameterLUT >> cand.hwDXY()) & 1);
-  if (!passImpactParameterLUT) {
-    LogDebug("L1TGlobal") << "\t\t l1t::Candidate failed impact parameter requirement" << std::endl;
-    return false;
-  }
-
   // A number of values is required to trigger (at least one).
   // "Don’t care" means that all values are allowed.
   // Qual = 000 means then NO MUON (GTL module)


### PR DESCRIPTION
#### PR description:

Pr112x L1T: :  needed for MWGR

Fix uGT emulator of displaced muons (step2) - remove 2ndary check for impact paramete

#### PR validation:

<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

<!-- Please replace this text with any link to  -->

Backport of https://github.com/cms-sw/cmssw/pull/32818
