### PR TITLE
Implement skipBadFiles in RootEmbeddedFileSequence::readOneRandom

### DIFF
--- a/IOPool/Input/src/RootEmbeddedFileSequence.cc
+++ b/IOPool/Input/src/RootEmbeddedFileSequence.cc
@@ -271,7 +271,7 @@ namespace edm {
           }
         }
       }
-      if (not rootFile()) {
+      if (not opened) {
         throw Exception(errors::FileOpenError) << "RootEmbeddedFileSequence::readOneRandom(): "
                                                << " input file retries exhausted.\n";
       }

--- a/IOPool/Input/src/RootEmbeddedFileSequence.cc
+++ b/IOPool/Input/src/RootEmbeddedFileSequence.cc
@@ -24,7 +24,7 @@
 #include <atomic>
 
 namespace {
-  static std::atomic<unsigned int> badFilesSkipped_{0};
+  std::atomic<unsigned int> badFilesSkipped_{0};
   auto operator"" _uz(unsigned long long i) -> std::size_t { return std::size_t{i}; }  // uz will be in C++23
 }  // namespace
 

--- a/IOPool/Input/src/RootEmbeddedFileSequence.h
+++ b/IOPool/Input/src/RootEmbeddedFileSequence.h
@@ -71,6 +71,7 @@ namespace edm {
     unsigned int treeCacheSize_;
     bool enablePrefetching_;
     bool enforceGUIDInFileName_;
+    unsigned int fileOpenAttempts_;
   };  // class RootEmbeddedFileSequence
 }  // namespace edm
 #endif

--- a/IOPool/Input/src/RootEmbeddedFileSequence.h
+++ b/IOPool/Input/src/RootEmbeddedFileSequence.h
@@ -71,7 +71,7 @@ namespace edm {
     unsigned int treeCacheSize_;
     bool enablePrefetching_;
     bool enforceGUIDInFileName_;
-    unsigned int fileOpenAttempts_;
+    unsigned int maxFileSkips_;
   };  // class RootEmbeddedFileSequence
 }  // namespace edm
 #endif

--- a/IOPool/Input/src/RootInputFileSequence.cc
+++ b/IOPool/Input/src/RootInputFileSequence.cc
@@ -253,10 +253,10 @@ namespace edm {
     if (filePtr) {
       size_t currentIndexIntoFile = fileIter_ - fileIterBegin_;
       rootFile_ = makeRootFile(filePtr);
+      assert(rootFile_);
       if (input) {
         rootFile_->setSignals(&(input->preEventReadFromSourceSignal_), &(input->postEventReadFromSourceSignal_));
       }
-      assert(rootFile_);
       fileIterLastOpened_ = fileIter_;
       setIndexIntoFile(currentIndexIntoFile);
       rootFile_->reportOpened(inputTypeName);

--- a/IOPool/Input/src/RootInputFileSequence.h
+++ b/IOPool/Input/src/RootInputFileSequence.h
@@ -3,7 +3,10 @@
 
 /*----------------------------------------------------------------------
 
-RootInputFileSequence: This is an InputSource. initTheFile tries to open a file using a list of PFN names constructed from multiple data catalogs in site-local-config.xml. These are accessed via FileCatalogItem iterator fileIter_.  
+RootInputFileSequence: This is an InputSource. initTheFile tries to open
+a file using a list of PFN names constructed from multiple data catalogs
+in site-local-config.xml. These are accessed via FileCatalogItem iterator
+fileIter_.
 
 ----------------------------------------------------------------------*/
 

--- a/IOPool/SecondaryInput/test/SecondaryInputTestSkip_cfg.py
+++ b/IOPool/SecondaryInput/test/SecondaryInputTestSkip_cfg.py
@@ -24,7 +24,7 @@ process.source = cms.Source("PoolSource",
 process.Thing = cms.EDProducer("SecondaryProducer",
     input = cms.SecSource("EmbeddedRootSource",
         skipBadFiles = cms.untracked.bool(True),
-        fileOpenAttempts = cms.untracked.uint32(100),
+        maxFileSkips = cms.untracked.uint32(100),
         fileNames = cms.untracked.vstring(
             'file:SecondaryInputTest2.root',
             'file:missing.root',

--- a/IOPool/SecondaryInput/test/SecondaryInputTestSkip_cfg.py
+++ b/IOPool/SecondaryInput/test/SecondaryInputTestSkip_cfg.py
@@ -1,0 +1,42 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("PROD")
+process.load("FWCore.Framework.test.cmsExceptionsFatal_cff")
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(75)
+)
+process.RandomNumberGeneratorService = cms.Service("RandomNumberGeneratorService",
+    Thing = cms.PSet(
+        initialSeed = cms.untracked.uint32(12345)
+    )
+)
+
+process.source = cms.Source("PoolSource",
+    skipBadFiles = cms.untracked.bool(True),
+    fileNames = cms.untracked.vstring(
+        'file:SecondaryInputTest.root',
+        'file:SecondaryInputTest.root',
+        'file:SecondaryInputTest.root'
+    )
+)
+
+process.Thing = cms.EDProducer("SecondaryProducer",
+    input = cms.SecSource("EmbeddedRootSource",
+        skipBadFiles = cms.untracked.bool(True),
+        fileOpenAttempts = cms.untracked.uint32(100),
+        fileNames = cms.untracked.vstring(
+            'file:SecondaryInputTest2.root',
+            'file:missing.root',
+            'file:SecondaryInputTest2.root'
+        )
+    )
+)
+
+process.Analysis = cms.EDAnalyzer("EventContentAnalyzer",
+    verbose = cms.untracked.bool(False)
+)
+
+process.p = cms.Path(process.Thing*process.Analysis)
+
+


### PR DESCRIPTION
#### PR description:

Under heavy loads, we can see high failure rates in premixing jobs due to file open failures for the secondary input files.  The `skipBadFiles` parameter is supposed to allow skipping over file open failures; however, it is only partially implemented in the `EmbeddedRootSource` used for the secondary input files.  This PR implements `skipBadFiles` for the `RootEmbeddedFileSequence::readOneRandom()` routine and adds a `fileOpenAttempts` parameter to control how many file open attempts are made in case of failures.

`skipBadFiles` is still ignored for the (less often used) sequential read cases.

This PR resolves issue #15653 (from 4.5 years ago), which has links to the HN thread that motivated it.

#### PR validation:

A test config was created in `SecondaryInput/test/SecondaryInputTestSkip_cfg.py` (and it found some bugs).  However, it has a small probability of causing false positives so it has not been added to the standard unit test run by 'runtests'.  Standard tests were also run.