### PR TITLE
Further preparations of deep tau ID for hlt phase2 (backport to CMSSW_11_2_X)

### DIFF
--- a/RecoTauTag/RecoTau/interface/DeepTauBase.h
+++ b/RecoTauTag/RecoTau/interface/DeepTauBase.h
@@ -84,7 +84,7 @@ namespace deep_tau {
 
       std::unique_ptr<TauDiscriminator> get_value(const edm::Handle<TauCollection>& taus,
                                                   const tensorflow::Tensor& pred,
-                                                  const WPList& working_points,
+                                                  const WPList* working_points,
                                                   bool is_online) const;
     };
 

--- a/RecoTauTag/RecoTau/plugins/DeepTauId.cc
+++ b/RecoTauTag/RecoTau/plugins/DeepTauId.cc
@@ -1039,7 +1039,7 @@ namespace {
     int getPhiTensorIndex(const CellIndex& cellIndex) const { return cellIndex.phi + maxPhiIndex(); }
 
     bool tryGetCellIndex(double deltaEta, double deltaPhi, CellIndex& cellIndex) const {
-      static auto getCellIndex = [this](double x, double maxX, double size, int& index) {
+      const auto getCellIndex = [this](double x, double maxX, double size, int& index) {
         const double absX = std::abs(x);
         if (absX > maxX)
           return false;

--- a/RecoTauTag/RecoTau/plugins/DeepTauId.cc
+++ b/RecoTauTag/RecoTau/plugins/DeepTauId.cc
@@ -1051,9 +1051,12 @@ namespace {
           return false;
         double absIndex;
         if ( disable_CellIndex_workaround_ ) {
-          absIndex = std::floor(std::abs(absX / size - 0.5));
-        } else {
+          // CV: use consistent definition for CellIndex
+          //     in DeepTauId.cc code and new DeepTau trainings
           absIndex = std::floor(absX / size + 0.5);
+        } else {
+          // CV: backwards compatibility with DeepTau training v2p1 used during Run 2
+          absIndex = std::floor(std::abs(absX / size - 0.5));
         }
         index = static_cast<int>(std::copysign(absIndex, x));
         return true;
@@ -1161,7 +1164,7 @@ public:
     desc.add<int>("debug_level", 0);
     desc.add<bool>("disable_dxy_pca", false);
     desc.add<bool>("disable_hcalFraction_workaround", false);
-    desc.add<bool>("disable_CellIndex_workaround", true);
+    desc.add<bool>("disable_CellIndex_workaround", false);
     desc.add<bool>("save_inputs", false);
     desc.add<bool>("is_online", false);
 

--- a/RecoTauTag/RecoTau/plugins/DeepTauId.cc
+++ b/RecoTauTag/RecoTau/plugins/DeepTauId.cc
@@ -1160,7 +1160,7 @@ public:
     desc.add<unsigned>("version", 2);
     desc.add<int>("debug_level", 0);
     desc.add<bool>("disable_dxy_pca", false);
-    desc.add<bool>("disable_hcalFraction_workaround", true);
+    desc.add<bool>("disable_hcalFraction_workaround", false);
     desc.add<bool>("disable_CellIndex_workaround", true);
     desc.add<bool>("save_inputs", false);
     desc.add<bool>("is_online", false);

--- a/RecoTauTag/RecoTau/plugins/DeepTauId.cc
+++ b/RecoTauTag/RecoTau/plugins/DeepTauId.cc
@@ -4,11 +4,18 @@
  * Tau identification using Deep NN.
  *
  * \author Konstantin Androsov, INFN Pisa
+ *         Christian Veelken, Tallinn
  */
 
 #include "RecoTauTag/RecoTau/interface/DeepTauBase.h"
 #include "FWCore/Utilities/interface/isFinite.h"
 #include "DataFormats/TauReco/interface/PFTauTransverseImpactParameterAssociation.h"
+
+#include <TString.h> // Form
+
+#include <iostream>
+#include <iomanip>
+#include <fstream>
 
 namespace deep_tau {
   constexpr int NumberOfOutputs = 4;
@@ -415,6 +422,26 @@ namespace {
     }
   }  // namespace dnn_inputs_2017_v2
 
+  float getTauID(const pat::Tau& tau, const std::string& tauID, float default_value = -999.)
+  {
+    static std::set<std::string> isFirstWarning;
+    float retVal = default_value;
+    if ( tau.isTauIDAvailable(tauID) )
+    {
+      retVal = tau.tauID(tauID);
+    }
+    else
+    {
+      if ( isFirstWarning.find(tauID) == isFirstWarning.end() )
+      {
+        std::cout << "Warning in <getTauID>: No tauID '" << tauID << "' available in pat::Tau given as function argument."
+                  << " Using default_value = " << default_value << " instead." << std::endl;
+        isFirstWarning.insert(tauID);
+      }
+    }
+    return retVal;
+  }
+
   struct TauFunc {
     const reco::TauDiscriminatorContainer* basicTauDiscriminatorCollection;
     const reco::TauDiscriminatorContainer* basicTauDiscriminatordR03Collection;
@@ -429,38 +456,38 @@ namespace {
       return (*basicTauDiscriminatorCollection)[tau_ref].rawValues.at(indexMap.at(BasicDiscr::ChargedIsoPtSum));
     }
     const float getChargedIsoPtSum(const pat::Tau& tau, const edm::RefToBase<reco::BaseTau> tau_ref) const {
-      return tau.tauID("chargedIsoPtSum");
+      return getTauID(tau, "chargedIsoPtSum");
     }
     const float getChargedIsoPtSumdR03(const reco::PFTau& tau, const edm::RefToBase<reco::BaseTau> tau_ref) const {
       return (*basicTauDiscriminatordR03Collection)[tau_ref].rawValues.at(indexMapdR03.at(BasicDiscr::ChargedIsoPtSum));
     }
     const float getChargedIsoPtSumdR03(const pat::Tau& tau, const edm::RefToBase<reco::BaseTau> tau_ref) const {
-      return tau.tauID("chargedIsoPtSumdR03");
+      return getTauID(tau, "chargedIsoPtSumdR03");
     }
     const float getFootprintCorrectiondR03(const reco::PFTau& tau, const edm::RefToBase<reco::BaseTau> tau_ref) const {
       return (*basicTauDiscriminatordR03Collection)[tau_ref].rawValues.at(
           indexMapdR03.at(BasicDiscr::FootprintCorrection));
     }
     const float getFootprintCorrectiondR03(const pat::Tau& tau, const edm::RefToBase<reco::BaseTau> tau_ref) const {
-      return tau.tauID("footprintCorrectiondR03");
+      return getTauID(tau, "footprintCorrectiondR03");
     }
     const float getNeutralIsoPtSum(const reco::PFTau& tau, const edm::RefToBase<reco::BaseTau> tau_ref) const {
       return (*basicTauDiscriminatorCollection)[tau_ref].rawValues.at(indexMap.at(BasicDiscr::NeutralIsoPtSum));
     }
     const float getNeutralIsoPtSum(const pat::Tau& tau, const edm::RefToBase<reco::BaseTau> tau_ref) const {
-      return tau.tauID("neutralIsoPtSum");
+      return getTauID(tau, "neutralIsoPtSum");
     }
     const float getNeutralIsoPtSumdR03(const reco::PFTau& tau, const edm::RefToBase<reco::BaseTau> tau_ref) const {
       return (*basicTauDiscriminatordR03Collection)[tau_ref].rawValues.at(indexMapdR03.at(BasicDiscr::NeutralIsoPtSum));
     }
     const float getNeutralIsoPtSumdR03(const pat::Tau& tau, const edm::RefToBase<reco::BaseTau> tau_ref) const {
-      return tau.tauID("neutralIsoPtSumdR03");
+      return getTauID(tau, "neutralIsoPtSumdR03");
     }
     const float getNeutralIsoPtSumWeight(const reco::PFTau& tau, const edm::RefToBase<reco::BaseTau> tau_ref) const {
       return (*basicTauDiscriminatorCollection)[tau_ref].rawValues.at(indexMap.at(BasicDiscr::NeutralIsoPtSumWeight));
     }
     const float getNeutralIsoPtSumWeight(const pat::Tau& tau, const edm::RefToBase<reco::BaseTau> tau_ref) const {
-      return tau.tauID("neutralIsoPtSumWeight");
+      return getTauID(tau, "neutralIsoPtSumWeight");
     }
     const float getNeutralIsoPtSumdR03Weight(const reco::PFTau& tau,
                                              const edm::RefToBase<reco::BaseTau> tau_ref) const {
@@ -468,7 +495,7 @@ namespace {
           indexMapdR03.at(BasicDiscr::NeutralIsoPtSumWeight));
     }
     const float getNeutralIsoPtSumdR03Weight(const pat::Tau& tau, const edm::RefToBase<reco::BaseTau> tau_ref) const {
-      return tau.tauID("neutralIsoPtSumWeightdR03");
+      return getTauID(tau, "neutralIsoPtSumWeightdR03");
     }
     const float getPhotonPtSumOutsideSignalCone(const reco::PFTau& tau,
                                                 const edm::RefToBase<reco::BaseTau> tau_ref) const {
@@ -477,7 +504,7 @@ namespace {
     }
     const float getPhotonPtSumOutsideSignalCone(const pat::Tau& tau,
                                                 const edm::RefToBase<reco::BaseTau> tau_ref) const {
-      return tau.tauID("photonPtSumOutsideSignalCone");
+      return getTauID(tau, "photonPtSumOutsideSignalCone");
     }
     const float getPhotonPtSumOutsideSignalConedR03(const reco::PFTau& tau,
                                                     const edm::RefToBase<reco::BaseTau> tau_ref) const {
@@ -486,13 +513,13 @@ namespace {
     }
     const float getPhotonPtSumOutsideSignalConedR03(const pat::Tau& tau,
                                                     const edm::RefToBase<reco::BaseTau> tau_ref) const {
-      return tau.tauID("photonPtSumOutsideSignalConedR03");
+      return getTauID(tau, "photonPtSumOutsideSignalConedR03");
     }
     const float getPuCorrPtSum(const reco::PFTau& tau, const edm::RefToBase<reco::BaseTau> tau_ref) const {
       return (*basicTauDiscriminatorCollection)[tau_ref].rawValues.at(indexMap.at(BasicDiscr::PUcorrPtSum));
     }
     const float getPuCorrPtSum(const pat::Tau& tau, const edm::RefToBase<reco::BaseTau> tau_ref) const {
-      return tau.tauID("puCorrPtSum");
+      return getTauID(tau, "puCorrPtSum");
     }
 
     auto getdxyPCA(const reco::PFTau& tau, const size_t tau_index) const {
@@ -634,15 +661,22 @@ namespace {
     auto getPseudoTrack(const pat::PackedCandidate& cand) { return cand.pseudoTrack(); }
     auto getFromPV(const reco::PFCandidate& cand) { return 0.9994f; }
     auto getFromPV(const pat::PackedCandidate& cand) { return cand.fromPV(); }
-    auto getHCalFraction(const reco::PFCandidate& cand) {
+    auto getHCalFraction(const reco::PFCandidate& cand, bool disable_hcalFraction_workaround) {
       return cand.rawHcalEnergy() / (cand.rawHcalEnergy() + cand.rawEcalEnergy());
     }
-    auto getHCalFraction(const pat::PackedCandidate& cand) {
+    auto getHCalFraction(const pat::PackedCandidate& cand, bool disable_hcalFraction_workaround) {
       float hcal_fraction = 0.;
-      if (cand.pdgId() == 1 || cand.pdgId() == 130) {
+      if ( disable_hcalFraction_workaround ) {
+        // CV: use consistent definition for pfCand_chHad_hcalFraction 
+        //     in DeepTauId.cc code and in TauMLTools/Production/plugins/TauTupleProducer.cc
         hcal_fraction = cand.hcalFraction();
-      } else if (cand.isIsolatedChargedHadron()) {
-        hcal_fraction = cand.rawHcalFraction();
+      } else {
+        // CV: backwards compatibility with DeepTau training v2p1 used during Run 2
+        if (cand.pdgId() == 1 || cand.pdgId() == 130) {
+          hcal_fraction = cand.hcalFraction();
+        } else if (cand.isIsolatedChargedHadron()) {
+          hcal_fraction = cand.rawHcalFraction();
+        }
       }
       return hcal_fraction;
     }
@@ -1017,7 +1051,8 @@ namespace {
         const double absX = std::abs(x);
         if (absX > maxX)
           return false;
-        const double absIndex = std::floor(std::abs(absX / size - 0.5));
+        //const double absIndex = std::floor(std::abs(absX / size - 0.5));
+        const double absIndex = std::floor(absX / size + 0.5);
         index = static_cast<int>(std::copysign(absIndex, x));
         return true;
       };
@@ -1041,7 +1076,6 @@ namespace {
   private:
     std::map<CellIndex, Cell> cells;
   };
-
 }  // anonymous namespace
 
 using bd = deep_tau::DeepTauBase::BasicDiscriminator;
@@ -1123,6 +1157,8 @@ public:
     desc.add<unsigned>("version", 2);
     desc.add<int>("debug_level", 0);
     desc.add<bool>("disable_dxy_pca", false);
+    desc.add<bool>("disable_hcalFraction_workaround", false);
+    desc.add<bool>("save_inputs", false);
     desc.add<bool>("is_online", false);
 
     desc.add<std::vector<std::string>>("VSeWP");
@@ -1151,6 +1187,7 @@ public:
 public:
   explicit DeepTauId(const edm::ParameterSet& cfg, const deep_tau::DeepTauCache* cache)
       : DeepTauBase(cfg, GetOutputs(), cache),
+        moduleLabel_(cfg.getParameter<std::string>("@module_label")),
         electrons_token_(consumes<std::vector<pat::Electron>>(cfg.getParameter<edm::InputTag>("electrons"))),
         muons_token_(consumes<std::vector<pat::Muon>>(cfg.getParameter<edm::InputTag>("muons"))),
         rho_token_(consumes<double>(cfg.getParameter<edm::InputTag>("rho"))),
@@ -1163,7 +1200,13 @@ public:
                 cfg.getParameter<edm::InputTag>("pfTauTransverseImpactParameters"))),
         version_(cfg.getParameter<unsigned>("version")),
         debug_level(cfg.getParameter<int>("debug_level")),
-        disable_dxy_pca_(cfg.getParameter<bool>("disable_dxy_pca")) {
+        disable_dxy_pca_(cfg.getParameter<bool>("disable_dxy_pca")),
+        disable_hcalFraction_workaround_(cfg.getParameter<bool>("disable_hcalFraction_workaround")),
+        inner_grid(nullptr),
+        outer_grid(nullptr),
+        save_inputs(cfg.getParameter<bool>("save_inputs")),
+        json_file(nullptr),
+        file_counter(0) {
     if (version_ == 1) {
       input_layer_ = cache_->getGraph().node(0).name();
       output_layer_ = cache_->getGraph().node(cache_->getGraph().node_size() - 1).name();
@@ -1204,6 +1247,11 @@ public:
     }
   }
 
+  ~DeepTauId() {
+    delete inner_grid;
+    delete outer_grid;  
+  }
+
   static std::unique_ptr<deep_tau::DeepTauCache> initializeGlobalCache(const edm::ParameterSet& cfg) {
     return DeepTauBase::initializeGlobalCache(cfg);
   }
@@ -1212,6 +1260,8 @@ public:
 
 private:
   static constexpr float pi = M_PI;
+
+  std::string moduleLabel_;
 
   template <typename T>
   static float getValue(T value) {
@@ -1260,25 +1310,104 @@ private:
       return false;
   }
 
-  inline void checkInputs(
-      const tensorflow::Tensor& inputs, const char* block_name, int n_inputs, int n_eta = 1, int n_phi = 1) const {
+  inline void checkInputs(const tensorflow::Tensor& inputs, const std::string& block_name, int n_inputs, const CellGrid* grid = nullptr) const {
     if (debug_level >= 1) {
-      for (int eta = 0; eta < n_eta; ++eta) {
-        for (int phi = 0; phi < n_phi; phi++) {
-          for (int k = 0; k < n_inputs; ++k) {
-            const float input =
-                n_eta == 1 && n_phi == 1 ? inputs.matrix<float>()(0, k) : inputs.tensor<float, 4>()(0, eta, phi, k);
-            if (edm::isNotFinite(input))
-              throw cms::Exception("DeepTauId")
-                  << "in the " << block_name << ", input is not finite, i.e. infinite or NaN, for eta_index = " << n_eta
-                  << ", phi_index = " << n_phi << ", input_index = " << k;
-            if (debug_level >= 2)
-              std::cout << block_name << "," << eta << "," << phi << "," << k << "," << std::setprecision(5)
-                        << std::fixed << input << '\n';
+      std::cout << "<checkInputs>: block_name = " << block_name << std::endl;
+      if ( block_name == "input_tau" ) {
+        for (int input_index = 0; input_index < n_inputs; ++input_index) {
+          float input = inputs.matrix<float>()(0, input_index);
+          if (edm::isNotFinite(input)) {
+            throw cms::Exception("DeepTauId")
+              << "in the " << block_name << ", input is not finite, i.e. infinite or NaN, for input_index = " << input_index;
+          }
+          if (debug_level >= 2) {
+            std::cout << block_name << "[var = " << input_index << "] = " << std::setprecision(5) << std::fixed << input << std::endl;
+          }
+        }
+      } else {
+        assert(grid);
+        int n_eta, n_phi;
+        if ( block_name.find("input_inner") != std::string::npos ) {
+          n_eta =  5;
+          n_phi =  5;
+        } else if ( block_name.find("input_outer") != std::string::npos ) {  
+          n_eta = 10;
+          n_phi = 10;
+        } else assert(0);
+        int eta_phi_index = 0;
+        for (int eta = -n_eta; eta <= n_eta; ++eta) {
+          for (int phi = -n_phi; phi <= n_phi; ++phi) {
+            const CellIndex cell_index{eta, phi};
+            const auto cell_iter = grid->find(cell_index);
+            if (cell_iter != grid->end()) {
+              for (int input_index = 0; input_index < n_inputs; ++input_index) {
+                float input = inputs.tensor<float, 4>()(eta_phi_index, 0, 0, input_index);
+                if (edm::isNotFinite(input)) {
+                  throw cms::Exception("DeepTauId")
+                    << "in the " << block_name << ", input is not finite, i.e. infinite or NaN, for eta = " << eta
+                    << ", phi = " << phi << ", input_index = " << input_index;
+                }
+                if (debug_level >= 2) {
+                  std::cout << block_name << "[eta = " << eta << "][phi = " << phi << "][var = " << input_index << "] = " << std::setprecision(5) << std::fixed << input << std::endl;
+                }
+              }
+              eta_phi_index += 1;
+            }
           }
         }
       }
     }
+  }
+
+  inline void saveInputs(const tensorflow::Tensor& inputs, const std::string& block_name, int n_inputs, const CellGrid* grid = nullptr) const {
+    if (debug_level >= 1) {
+      std::cout << "<saveInputs>: block_name = " << block_name << std::endl;
+    }
+    if ( !is_first_block ) (*json_file) << ", ";
+    (*json_file) << "\"" << block_name << "\": [";
+    if ( block_name == "input_tau" ) {
+      for (int input_index = 0; input_index < n_inputs; ++input_index) {
+        float input = inputs.matrix<float>()(0, input_index);
+        if ( input_index != 0 ) (*json_file) << ", ";
+        (*json_file) << input;
+      }
+    } else {
+      assert(grid);
+      int n_eta, n_phi;
+      if ( block_name.find("input_inner") != std::string::npos ) {
+        n_eta =  5;
+        n_phi =  5;
+      } else if ( block_name.find("input_outer") != std::string::npos ) {  
+        n_eta = 10;
+        n_phi = 10;
+      } else assert(0);
+      int eta_phi_index = 0;
+      for (int eta = -n_eta; eta <= n_eta; ++eta) {
+        if ( eta != -n_eta ) (*json_file) << ", ";
+        (*json_file) << "[";
+        for (int phi = -n_phi; phi <= n_phi; ++phi) {
+          if ( phi != -n_phi ) (*json_file) << ", ";
+          (*json_file) << "[";
+          const CellIndex cell_index{eta, phi};
+          const auto cell_iter = grid->find(cell_index);
+          for (int input_index = 0; input_index < n_inputs; ++input_index) {
+            float input = 0.;
+            if (cell_iter != grid->end()) {
+              input = inputs.tensor<float, 4>()(eta_phi_index, 0, 0, input_index);
+            }
+            if ( input_index != 0 ) (*json_file) << ", ";
+            (*json_file) << input;
+          }
+          if (cell_iter != grid->end()) {
+            eta_phi_index += 1;
+          } 
+          (*json_file) << "]";
+        }
+        (*json_file) << "]";
+      }
+    }
+    (*json_file) << "]";
+    is_first_block = false;
   }
 
 private:
@@ -1423,36 +1552,82 @@ private:
                         double rho,
                         std::vector<tensorflow::Tensor>& pred_vector,
                         TauFunc tau_funcs) {
-    CellGrid inner_grid(dnn_inputs_2017_v2::number_of_inner_cell, dnn_inputs_2017_v2::number_of_inner_cell, 0.02, 0.02);
-    CellGrid outer_grid(dnn_inputs_2017_v2::number_of_outer_cell, dnn_inputs_2017_v2::number_of_outer_cell, 0.05, 0.05);
-    fillGrids(dynamic_cast<const TauCastType&>(tau), *electrons, inner_grid, outer_grid);
-    fillGrids(dynamic_cast<const TauCastType&>(tau), *muons, inner_grid, outer_grid);
-    fillGrids(dynamic_cast<const TauCastType&>(tau), pfCands, inner_grid, outer_grid);
+    if (debug_level >= 2) {
+      std::cout << "<DeepTauId::getPredictionsV2 (moduleLabel = " << moduleLabel_ << ")>:" << std::endl;
+      std::cout << " tau: pT = " << tau.pt() << ", eta = " << tau.eta() << ", phi = " << tau.phi() << std::endl;
+    }
+    delete inner_grid;
+    inner_grid = new CellGrid(dnn_inputs_2017_v2::number_of_inner_cell, dnn_inputs_2017_v2::number_of_inner_cell, 0.02, 0.02);
+    delete outer_grid;
+    outer_grid = new CellGrid(dnn_inputs_2017_v2::number_of_outer_cell, dnn_inputs_2017_v2::number_of_outer_cell, 0.05, 0.05);
+    fillGrids(dynamic_cast<const TauCastType&>(tau), *electrons, *inner_grid, *outer_grid);
+    fillGrids(dynamic_cast<const TauCastType&>(tau), *muons, *inner_grid, *outer_grid);
+    fillGrids(dynamic_cast<const TauCastType&>(tau), pfCands, *inner_grid, *outer_grid);
+
+    if ( save_inputs ) {
+      std::string json_file_name = Form("DeepTauId_%i.json", file_counter);
+      json_file = new std::ofstream(json_file_name.data());
+      is_first_block = true;
+    }
 
     createTauBlockInputs<CandidateCastType>(
-        dynamic_cast<const TauCastType&>(tau), tau_index, tau_ref, pv, rho, tau_funcs);
-    createConvFeatures<CandidateCastType>(dynamic_cast<const TauCastType&>(tau),
-                                          tau_index,
-                                          tau_ref,
-                                          pv,
-                                          rho,
-                                          electrons,
-                                          muons,
-                                          pfCands,
-                                          inner_grid,
-                                          tau_funcs,
-                                          true);
-    createConvFeatures<CandidateCastType>(dynamic_cast<const TauCastType&>(tau),
-                                          tau_index,
-                                          tau_ref,
-                                          pv,
-                                          rho,
-                                          electrons,
-                                          muons,
-                                          pfCands,
-                                          outer_grid,
-                                          tau_funcs,
-                                          false);
+      dynamic_cast<const TauCastType&>(tau), 
+      tau_index, 
+      tau_ref, 
+      pv, 
+      rho, 
+      tau_funcs
+    );
+    checkInputs(*tauBlockTensor_, "input_tau", dnn_inputs_2017_v2::TauBlockInputs::NumberOfInputs);
+    createConvFeatures<CandidateCastType>(
+      dynamic_cast<const TauCastType&>(tau),
+      tau_index,
+      tau_ref,
+      pv,
+      rho,
+      electrons,
+      muons,
+      pfCands,
+      *inner_grid,
+      tau_funcs,
+      true
+    );
+    checkInputs(*eGammaTensor_[true], "input_inner_egamma", dnn_inputs_2017_v2::EgammaBlockInputs::NumberOfInputs, inner_grid);
+    checkInputs(*muonTensor_[true], "input_inner_muon", dnn_inputs_2017_v2::MuonBlockInputs::NumberOfInputs, inner_grid);
+    checkInputs(*hadronsTensor_[true], "input_inner_hadrons", dnn_inputs_2017_v2::HadronBlockInputs::NumberOfInputs, inner_grid);
+    createConvFeatures<CandidateCastType>(
+      dynamic_cast<const TauCastType&>(tau),
+      tau_index,
+      tau_ref,
+      pv,
+      rho,
+      electrons,
+      muons,
+      pfCands,
+      *outer_grid,
+      tau_funcs,
+      false
+    );
+    checkInputs(*eGammaTensor_[false], "input_outer_egamma", dnn_inputs_2017_v2::EgammaBlockInputs::NumberOfInputs, outer_grid);
+    checkInputs(*muonTensor_[false], "input_outer_muon", dnn_inputs_2017_v2::MuonBlockInputs::NumberOfInputs, outer_grid);
+    checkInputs(*hadronsTensor_[false], "input_outer_hadrons", dnn_inputs_2017_v2::HadronBlockInputs::NumberOfInputs, outer_grid);
+
+    if ( save_inputs ) {
+      std::string json_file_name = Form("DeepTauId_%i.json", file_counter);
+      json_file = new std::ofstream(json_file_name.data());
+      is_first_block = true;
+      (*json_file) << "{";
+      saveInputs(*tauBlockTensor_, "input_tau", dnn_inputs_2017_v2::TauBlockInputs::NumberOfInputs);
+      saveInputs(*eGammaTensor_[true], "input_inner_egamma", dnn_inputs_2017_v2::EgammaBlockInputs::NumberOfInputs, inner_grid);
+      saveInputs(*muonTensor_[true], "input_inner_muon", dnn_inputs_2017_v2::MuonBlockInputs::NumberOfInputs, inner_grid);
+      saveInputs(*hadronsTensor_[true], "input_inner_hadrons", dnn_inputs_2017_v2::HadronBlockInputs::NumberOfInputs, inner_grid);
+      saveInputs(*eGammaTensor_[false], "input_outer_egamma", dnn_inputs_2017_v2::EgammaBlockInputs::NumberOfInputs, outer_grid);
+      saveInputs(*muonTensor_[false], "input_outer_muon", dnn_inputs_2017_v2::MuonBlockInputs::NumberOfInputs, outer_grid);
+      saveInputs(*hadronsTensor_[false], "input_outer_hadrons", dnn_inputs_2017_v2::HadronBlockInputs::NumberOfInputs, outer_grid);
+      (*json_file) << "}";
+      delete json_file;
+      ++file_counter;
+    }
 
     tensorflow::run(&(cache_->getSession("core")),
                     {{"input_tau", *tauBlockTensor_},
@@ -1460,6 +1635,20 @@ private:
                      {"input_outer", *convTensor_.at(false)}},
                     {"main_output/Softmax"},
                     &pred_vector);
+    if ( debug_level >= 1 ) {
+      std::cout << "output = { ";
+      for ( int idx = 0; idx < deep_tau::NumberOfOutputs; ++idx ) { 
+        if ( idx > 0 ) std::cout << ", ";
+        std::string label;
+        if      ( idx == 0 ) label = "e";
+        else if ( idx == 1 ) label = "mu";
+        else if ( idx == 2 ) label = "tau";
+        else if ( idx == 3 ) label = "jet";
+        else assert(0);
+        std::cout << label << " = " << pred_vector[0].flat<float>()(idx);
+      }
+      std::cout << " }" << std::endl;
+    } 
   }
 
   template <typename Collection, typename TauCastType>
@@ -1535,6 +1724,9 @@ private:
                           const CellGrid& grid,
                           TauFunc tau_funcs,
                           bool is_inner) {
+    if (debug_level >= 2) {
+      std::cout << "<DeepTauId::createConvFeatures (is_inner = " << is_inner << ")>:" << std::endl;
+    }
     tensorflow::Tensor& convTensor = *convTensor_.at(is_inner);
     eGammaTensor_[is_inner] = std::make_unique<tensorflow::Tensor>(
         tensorflow::DT_FLOAT,
@@ -1556,9 +1748,15 @@ private:
     unsigned idx = 0;
     for (int eta = -grid.maxEtaIndex(); eta <= grid.maxEtaIndex(); ++eta) {
       for (int phi = -grid.maxPhiIndex(); phi <= grid.maxPhiIndex(); ++phi) {
+        if (debug_level >= 2) {
+          std::cout << "processing ( eta = " << eta << ", phi = " << phi << " )" << std::endl;
+        }
         const CellIndex cell_index{eta, phi};
         const auto cell_iter = grid.find(cell_index);
         if (cell_iter != grid.end()) {
+          if (debug_level >= 2) {
+            std::cout << " creating inputs for ( eta = " << eta << ", phi = " << phi << " ): idx = " << idx << std::endl;
+          }
           const Cell& cell = cell_iter->second;
           createEgammaBlockInputs<CandidateCastType>(
               idx, tau, tau_index, tau_ref, pv, rho, electrons, pfCands, cell, tau_funcs, is_inner);
@@ -1567,6 +1765,10 @@ private:
           createHadronsBlockInputs<CandidateCastType>(
               idx, tau, tau_index, tau_ref, pv, rho, pfCands, cell, tau_funcs, is_inner);
           idx += 1;
+        } else {
+          if (debug_level >= 2) {
+            std::cout << " skipping creation of inputs, because ( eta = " << eta << ", phi = " << phi << " ) is not in the grid !!" << std::endl;
+          }
         }
       }
     }
@@ -1595,8 +1797,9 @@ private:
                            unsigned batch_idx,
                            int eta_index,
                            int phi_index) {
-    for (int n = 0; n < dnn_inputs_2017_v2::number_of_conv_features; ++n)
+    for (int n = 0; n < dnn_inputs_2017_v2::number_of_conv_features; ++n) {
       convTensor.tensor<float, 4>()(0, eta_index, phi_index, n) = features.tensor<float, 4>()(batch_idx, 0, 0, n);
+    }
   }
 
   template <typename CandidateCastType, typename TauCastType>
@@ -1702,7 +1905,6 @@ private:
     get(dnn::tau_inside_ecal_crack) = getValue(isInEcalCrack(tau.p4().eta()));
     get(dnn::leadChargedCand_etaAtEcalEntrance_minus_tau_eta) =
         getValueNorm(tau_funcs.getEtaAtEcalEntrance(tau) - tau.p4().eta(), 0.0042f, 0.0323f);
-    checkInputs(inputs, "tau_block", dnn::NumberOfInputs);
   }
 
   template <typename CandidateCastType, typename TauCastType>
@@ -1942,8 +2144,6 @@ private:
             getValueNorm(closestCtfTrack->numberOfValidHits(), 15.16f, 5.26f);
       }
     }
-    if (valid_index_ele or valid_index_pf_ele or valid_index_pf_gamma)
-      checkInputs(inputs, is_inner ? "egamma_inner_block" : "egamma_outer_block", dnn::NumberOfInputs);
   }
 
   template <typename CandidateCastType, typename TauCastType>
@@ -2096,7 +2296,6 @@ private:
         }
       }
     }
-    checkInputs(inputs, is_inner ? "muon_inner_block" : "muon_outer_block", dnn::NumberOfInputs);
   }
 
   template <typename CandidateCastType, typename TauCastType>
@@ -2193,7 +2392,7 @@ private:
                 ? getValueNorm(candFunc::getPseudoTrack(chH_cand).ndof(), 13.92f, 6.581f)
                 : 0;
       }
-      float hcal_fraction = candFunc::getHCalFraction(chH_cand);
+      float hcal_fraction = candFunc::getHCalFraction(chH_cand, disable_hcalFraction_workaround_);
       get(dnn::pfCand_chHad_hcalFraction) = getValue(hcal_fraction);
       get(dnn::pfCand_chHad_rawCaloFraction) = getValueLinear(candFunc::getRawCaloFraction(chH_cand), 0.f, 2.6f, true);
     }
@@ -2213,10 +2412,9 @@ private:
           dPhi(tau.polarP4(), pfCands.at(index_nH).polarP4()), is_inner ? -0.1f : -0.5f, is_inner ? 0.1f : 0.5f, false);
       get(dnn::pfCand_nHad_puppiWeight) = getValue(candFunc::getPuppiWeight(nH_cand));
       get(dnn::pfCand_nHad_puppiWeightNoLep) = getValue(candFunc::getPuppiWeightNoLep(nH_cand));
-      float hcal_fraction = candFunc::getHCalFraction(nH_cand);
+      float hcal_fraction = candFunc::getHCalFraction(nH_cand, disable_hcalFraction_workaround_);
       get(dnn::pfCand_nHad_hcalFraction) = getValue(hcal_fraction);
     }
-    checkInputs(inputs, is_inner ? "hadron_inner_block" : "hadron_outer_block", dnn::NumberOfInputs);
   }
 
   template <typename dnn, typename CandidateCastType, typename TauCastType>
@@ -2580,9 +2778,16 @@ private:
   const unsigned version_;
   const int debug_level;
   const bool disable_dxy_pca_;
+  const bool disable_hcalFraction_workaround_;
   std::unique_ptr<tensorflow::Tensor> tauBlockTensor_;
   std::array<std::unique_ptr<tensorflow::Tensor>, 2> eGammaTensor_, muonTensor_, hadronsTensor_, convTensor_,
       zeroOutputTensor_;
+  CellGrid* inner_grid;
+  CellGrid* outer_grid;
+  const bool save_inputs;
+  std::ofstream* json_file;
+  mutable bool is_first_block;
+  int file_counter;
 
   //boolean to check if discriminator indices are already mapped
   bool discrIndicesMapped_ = false;

--- a/RecoTauTag/RecoTau/plugins/DeepTauId.cc
+++ b/RecoTauTag/RecoTau/plugins/DeepTauId.cc
@@ -1045,12 +1045,12 @@ namespace {
     int getPhiTensorIndex(const CellIndex& cellIndex) const { return cellIndex.phi + maxPhiIndex(); }
 
     bool tryGetCellIndex(double deltaEta, double deltaPhi, CellIndex& cellIndex) const {
-      static auto getCellIndex = [](double x, double maxX, double size, bool disable_CellIndex_workaround, int& index) {
+      static auto getCellIndex = [this](double x, double maxX, double size, int& index) {
         const double absX = std::abs(x);
         if (absX > maxX)
           return false;
         double absIndex;
-        if ( disable_CellIndex_workaround ) {
+        if ( disable_CellIndex_workaround_ ) {
           absIndex = std::floor(std::abs(absX / size - 0.5));
         } else {
           absIndex = std::floor(absX / size + 0.5);
@@ -1059,8 +1059,8 @@ namespace {
         return true;
       };
 
-      return getCellIndex(deltaEta, maxDeltaEta(), cellSizeEta, disable_CellIndex_workaround_, cellIndex.eta) &&
-             getCellIndex(deltaPhi, maxDeltaPhi(), cellSizePhi, disable_CellIndex_workaround_, cellIndex.phi);
+      return getCellIndex(deltaEta, maxDeltaEta(), cellSizeEta, cellIndex.eta) &&
+             getCellIndex(deltaPhi, maxDeltaPhi(), cellSizePhi, cellIndex.phi);
     }
 
     size_t num_valid_cells() const { return cells.size(); }

--- a/RecoTauTag/RecoTau/plugins/DeepTauId.cc
+++ b/RecoTauTag/RecoTau/plugins/DeepTauId.cc
@@ -11,7 +11,7 @@
 #include "FWCore/Utilities/interface/isFinite.h"
 #include "DataFormats/TauReco/interface/PFTauTransverseImpactParameterAssociation.h"
 
-#include <TString.h> // Form
+#include <TString.h>  // Form
 
 #include <fstream>
 
@@ -420,18 +420,14 @@ namespace {
     }
   }  // namespace dnn_inputs_2017_v2
 
-  float getTauID(const pat::Tau& tau, const std::string& tauID, float default_value = -999.)
-  {
+  float getTauID(const pat::Tau& tau, const std::string& tauID, float default_value = -999.) {
     static std::set<std::string> isFirstWarning;
-    if ( tau.isTauIDAvailable(tauID) )
-    {
+    if (tau.isTauIDAvailable(tauID)) {
       return tau.tauID(tauID);
-    }
-    else
-    {
-      if ( isFirstWarning.find(tauID) == isFirstWarning.end() )
-      {
-        std::cout << "Warning in <getTauID>: No tauID '" << tauID << "' available in pat::Tau given as function argument."
+    } else {
+      if (isFirstWarning.find(tauID) == isFirstWarning.end()) {
+        std::cout << "Warning in <getTauID>: No tauID '" << tauID
+                  << "' available in pat::Tau given as function argument."
                   << " Using default_value = " << default_value << " instead." << std::endl;
         isFirstWarning.insert(tauID);
       }
@@ -663,8 +659,8 @@ namespace {
     }
     auto getHCalFraction(const pat::PackedCandidate& cand, bool disable_hcalFraction_workaround) {
       float hcal_fraction = 0.;
-      if ( disable_hcalFraction_workaround ) {
-        // CV: use consistent definition for pfCand_chHad_hcalFraction 
+      if (disable_hcalFraction_workaround) {
+        // CV: use consistent definition for pfCand_chHad_hcalFraction
         //     in DeepTauId.cc code and in TauMLTools/Production/plugins/TauTupleProducer.cc
         hcal_fraction = cand.hcalFraction();
       } else {
@@ -1022,7 +1018,11 @@ namespace {
     using Map = std::map<CellIndex, Cell>;
     using const_iterator = Map::const_iterator;
 
-    CellGrid(unsigned n_cells_eta, unsigned n_cells_phi, double cell_size_eta, double cell_size_phi, bool disable_CellIndex_workaround)
+    CellGrid(unsigned n_cells_eta,
+             unsigned n_cells_phi,
+             double cell_size_eta,
+             double cell_size_phi,
+             bool disable_CellIndex_workaround)
         : nCellsEta(n_cells_eta),
           nCellsPhi(n_cells_phi),
           nTotal(nCellsEta * nCellsPhi),
@@ -1050,7 +1050,7 @@ namespace {
         if (absX > maxX)
           return false;
         double absIndex;
-        if ( disable_CellIndex_workaround_ ) {
+        if (disable_CellIndex_workaround_) {
           // CV: use consistent definition for CellIndex
           //     in DeepTauId.cc code and new DeepTau trainings
           absIndex = std::floor(absX / size + 0.5);
@@ -1255,9 +1255,9 @@ public:
     }
   }
 
-  ~DeepTauId() {
+  ~DeepTauId() override {
     delete inner_grid_;
-    delete outer_grid_;  
+    delete outer_grid_;
   }
 
   static std::unique_ptr<deep_tau::DeepTauCache> initializeGlobalCache(const edm::ParameterSet& cfg) {
@@ -1318,30 +1318,36 @@ private:
       return false;
   }
 
-  inline void checkInputs(const tensorflow::Tensor& inputs, const std::string& block_name, int n_inputs, const CellGrid* grid = nullptr) const {
+  inline void checkInputs(const tensorflow::Tensor& inputs,
+                          const std::string& block_name,
+                          int n_inputs,
+                          const CellGrid* grid = nullptr) const {
     if (debug_level >= 1) {
       std::cout << "<checkInputs>: block_name = " << block_name << std::endl;
-      if ( block_name == "input_tau" ) {
+      if (block_name == "input_tau") {
         for (int input_index = 0; input_index < n_inputs; ++input_index) {
           float input = inputs.matrix<float>()(0, input_index);
           if (edm::isNotFinite(input)) {
             throw cms::Exception("DeepTauId")
-              << "in the " << block_name << ", input is not finite, i.e. infinite or NaN, for input_index = " << input_index;
+                << "in the " << block_name
+                << ", input is not finite, i.e. infinite or NaN, for input_index = " << input_index;
           }
           if (debug_level >= 2) {
-            std::cout << block_name << "[var = " << input_index << "] = " << std::setprecision(5) << std::fixed << input << std::endl;
+            std::cout << block_name << "[var = " << input_index << "] = " << std::setprecision(5) << std::fixed << input
+                      << std::endl;
           }
         }
       } else {
         assert(grid);
         int n_eta, n_phi;
-        if ( block_name.find("input_inner") != std::string::npos ) {
-          n_eta =  5;
-          n_phi =  5;
-        } else if ( block_name.find("input_outer") != std::string::npos ) {  
+        if (block_name.find("input_inner") != std::string::npos) {
+          n_eta = 5;
+          n_phi = 5;
+        } else if (block_name.find("input_outer") != std::string::npos) {
           n_eta = 10;
           n_phi = 10;
-        } else assert(0);
+        } else
+          assert(0);
         int eta_phi_index = 0;
         for (int eta = -n_eta; eta <= n_eta; ++eta) {
           for (int phi = -n_phi; phi <= n_phi; ++phi) {
@@ -1352,11 +1358,12 @@ private:
                 float input = inputs.tensor<float, 4>()(eta_phi_index, 0, 0, input_index);
                 if (edm::isNotFinite(input)) {
                   throw cms::Exception("DeepTauId")
-                    << "in the " << block_name << ", input is not finite, i.e. infinite or NaN, for eta = " << eta
-                    << ", phi = " << phi << ", input_index = " << input_index;
+                      << "in the " << block_name << ", input is not finite, i.e. infinite or NaN, for eta = " << eta
+                      << ", phi = " << phi << ", input_index = " << input_index;
                 }
                 if (debug_level >= 2) {
-                  std::cout << block_name << "[eta = " << eta << "][phi = " << phi << "][var = " << input_index << "] = " << std::setprecision(5) << std::fixed << input << std::endl;
+                  std::cout << block_name << "[eta = " << eta << "][phi = " << phi << "][var = " << input_index
+                            << "] = " << std::setprecision(5) << std::fixed << input << std::endl;
                 }
               }
               eta_phi_index += 1;
@@ -1367,34 +1374,42 @@ private:
     }
   }
 
-  inline void saveInputs(const tensorflow::Tensor& inputs, const std::string& block_name, int n_inputs, const CellGrid* grid = nullptr) const {
+  inline void saveInputs(const tensorflow::Tensor& inputs,
+                         const std::string& block_name,
+                         int n_inputs,
+                         const CellGrid* grid = nullptr) const {
     if (debug_level >= 1) {
       std::cout << "<saveInputs>: block_name = " << block_name << std::endl;
     }
-    if ( !is_first_block_ ) (*json_file_) << ", ";
+    if (!is_first_block_)
+      (*json_file_) << ", ";
     (*json_file_) << "\"" << block_name << "\": [";
-    if ( block_name == "input_tau" ) {
+    if (block_name == "input_tau") {
       for (int input_index = 0; input_index < n_inputs; ++input_index) {
         float input = inputs.matrix<float>()(0, input_index);
-        if ( input_index != 0 ) (*json_file_) << ", ";
+        if (input_index != 0)
+          (*json_file_) << ", ";
         (*json_file_) << input;
       }
     } else {
       assert(grid);
       int n_eta, n_phi;
-      if ( block_name.find("input_inner") != std::string::npos ) {
-        n_eta =  5;
-        n_phi =  5;
-      } else if ( block_name.find("input_outer") != std::string::npos ) {  
+      if (block_name.find("input_inner") != std::string::npos) {
+        n_eta = 5;
+        n_phi = 5;
+      } else if (block_name.find("input_outer") != std::string::npos) {
         n_eta = 10;
         n_phi = 10;
-      } else assert(0);
+      } else
+        assert(0);
       int eta_phi_index = 0;
       for (int eta = -n_eta; eta <= n_eta; ++eta) {
-        if ( eta != -n_eta ) (*json_file_) << ", ";
+        if (eta != -n_eta)
+          (*json_file_) << ", ";
         (*json_file_) << "[";
         for (int phi = -n_phi; phi <= n_phi; ++phi) {
-          if ( phi != -n_phi ) (*json_file_) << ", ";
+          if (phi != -n_phi)
+            (*json_file_) << ", ";
           (*json_file_) << "[";
           const CellIndex cell_index{eta, phi};
           const auto cell_iter = grid->find(cell_index);
@@ -1403,12 +1418,13 @@ private:
             if (cell_iter != grid->end()) {
               input = inputs.tensor<float, 4>()(eta_phi_index, 0, 0, input_index);
             }
-            if ( input_index != 0 ) (*json_file_) << ", ";
+            if (input_index != 0)
+              (*json_file_) << ", ";
             (*json_file_) << input;
           }
           if (cell_iter != grid->end()) {
             eta_phi_index += 1;
-          } 
+          }
           (*json_file_) << "]";
         }
         (*json_file_) << "]";
@@ -1565,67 +1581,91 @@ private:
       std::cout << " tau: pT = " << tau.pt() << ", eta = " << tau.eta() << ", phi = " << tau.phi() << std::endl;
     }
     delete inner_grid_;
-    inner_grid_ = new CellGrid(dnn_inputs_2017_v2::number_of_inner_cell, dnn_inputs_2017_v2::number_of_inner_cell, 0.02, 0.02, disable_CellIndex_workaround_);
+    inner_grid_ = new CellGrid(dnn_inputs_2017_v2::number_of_inner_cell,
+                               dnn_inputs_2017_v2::number_of_inner_cell,
+                               0.02,
+                               0.02,
+                               disable_CellIndex_workaround_);
     delete outer_grid_;
-    outer_grid_ = new CellGrid(dnn_inputs_2017_v2::number_of_outer_cell, dnn_inputs_2017_v2::number_of_outer_cell, 0.05, 0.05, disable_CellIndex_workaround_);
+    outer_grid_ = new CellGrid(dnn_inputs_2017_v2::number_of_outer_cell,
+                               dnn_inputs_2017_v2::number_of_outer_cell,
+                               0.05,
+                               0.05,
+                               disable_CellIndex_workaround_);
     fillGrids(dynamic_cast<const TauCastType&>(tau), *electrons, *inner_grid_, *outer_grid_);
     fillGrids(dynamic_cast<const TauCastType&>(tau), *muons, *inner_grid_, *outer_grid_);
     fillGrids(dynamic_cast<const TauCastType&>(tau), pfCands, *inner_grid_, *outer_grid_);
 
     createTauBlockInputs<CandidateCastType>(
-      dynamic_cast<const TauCastType&>(tau), 
-      tau_index, 
-      tau_ref, 
-      pv, 
-      rho, 
-      tau_funcs
-    );
+        dynamic_cast<const TauCastType&>(tau), tau_index, tau_ref, pv, rho, tau_funcs);
     checkInputs(*tauBlockTensor_, "input_tau", dnn_inputs_2017_v2::TauBlockInputs::NumberOfInputs);
-    createConvFeatures<CandidateCastType>(
-      dynamic_cast<const TauCastType&>(tau),
-      tau_index,
-      tau_ref,
-      pv,
-      rho,
-      electrons,
-      muons,
-      pfCands,
-      *inner_grid_,
-      tau_funcs,
-      true
-    );
-    checkInputs(*eGammaTensor_[true], "input_inner_egamma", dnn_inputs_2017_v2::EgammaBlockInputs::NumberOfInputs, inner_grid_);
-    checkInputs(*muonTensor_[true], "input_inner_muon", dnn_inputs_2017_v2::MuonBlockInputs::NumberOfInputs, inner_grid_);
-    checkInputs(*hadronsTensor_[true], "input_inner_hadrons", dnn_inputs_2017_v2::HadronBlockInputs::NumberOfInputs, inner_grid_);
-    createConvFeatures<CandidateCastType>(
-      dynamic_cast<const TauCastType&>(tau),
-      tau_index,
-      tau_ref,
-      pv,
-      rho,
-      electrons,
-      muons,
-      pfCands,
-      *outer_grid_,
-      tau_funcs,
-      false
-    );
-    checkInputs(*eGammaTensor_[false], "input_outer_egamma", dnn_inputs_2017_v2::EgammaBlockInputs::NumberOfInputs, outer_grid_);
-    checkInputs(*muonTensor_[false], "input_outer_muon", dnn_inputs_2017_v2::MuonBlockInputs::NumberOfInputs, outer_grid_);
-    checkInputs(*hadronsTensor_[false], "input_outer_hadrons", dnn_inputs_2017_v2::HadronBlockInputs::NumberOfInputs, outer_grid_);
+    createConvFeatures<CandidateCastType>(dynamic_cast<const TauCastType&>(tau),
+                                          tau_index,
+                                          tau_ref,
+                                          pv,
+                                          rho,
+                                          electrons,
+                                          muons,
+                                          pfCands,
+                                          *inner_grid_,
+                                          tau_funcs,
+                                          true);
+    checkInputs(
+        *eGammaTensor_[true], "input_inner_egamma", dnn_inputs_2017_v2::EgammaBlockInputs::NumberOfInputs, inner_grid_);
+    checkInputs(
+        *muonTensor_[true], "input_inner_muon", dnn_inputs_2017_v2::MuonBlockInputs::NumberOfInputs, inner_grid_);
+    checkInputs(*hadronsTensor_[true],
+                "input_inner_hadrons",
+                dnn_inputs_2017_v2::HadronBlockInputs::NumberOfInputs,
+                inner_grid_);
+    createConvFeatures<CandidateCastType>(dynamic_cast<const TauCastType&>(tau),
+                                          tau_index,
+                                          tau_ref,
+                                          pv,
+                                          rho,
+                                          electrons,
+                                          muons,
+                                          pfCands,
+                                          *outer_grid_,
+                                          tau_funcs,
+                                          false);
+    checkInputs(*eGammaTensor_[false],
+                "input_outer_egamma",
+                dnn_inputs_2017_v2::EgammaBlockInputs::NumberOfInputs,
+                outer_grid_);
+    checkInputs(
+        *muonTensor_[false], "input_outer_muon", dnn_inputs_2017_v2::MuonBlockInputs::NumberOfInputs, outer_grid_);
+    checkInputs(*hadronsTensor_[false],
+                "input_outer_hadrons",
+                dnn_inputs_2017_v2::HadronBlockInputs::NumberOfInputs,
+                outer_grid_);
 
-    if ( save_inputs_ ) {
+    if (save_inputs_) {
       std::string json_file_name = Form("DeepTauId_%i.json", file_counter_);
       json_file_ = new std::ofstream(json_file_name.data());
       is_first_block_ = true;
       (*json_file_) << "{";
       saveInputs(*tauBlockTensor_, "input_tau", dnn_inputs_2017_v2::TauBlockInputs::NumberOfInputs);
-      saveInputs(*eGammaTensor_[true], "input_inner_egamma", dnn_inputs_2017_v2::EgammaBlockInputs::NumberOfInputs, inner_grid_);
-      saveInputs(*muonTensor_[true], "input_inner_muon", dnn_inputs_2017_v2::MuonBlockInputs::NumberOfInputs, inner_grid_);
-      saveInputs(*hadronsTensor_[true], "input_inner_hadrons", dnn_inputs_2017_v2::HadronBlockInputs::NumberOfInputs, inner_grid_);
-      saveInputs(*eGammaTensor_[false], "input_outer_egamma", dnn_inputs_2017_v2::EgammaBlockInputs::NumberOfInputs, outer_grid_);
-      saveInputs(*muonTensor_[false], "input_outer_muon", dnn_inputs_2017_v2::MuonBlockInputs::NumberOfInputs, outer_grid_);
-      saveInputs(*hadronsTensor_[false], "input_outer_hadrons", dnn_inputs_2017_v2::HadronBlockInputs::NumberOfInputs, outer_grid_);
+      saveInputs(*eGammaTensor_[true],
+                 "input_inner_egamma",
+                 dnn_inputs_2017_v2::EgammaBlockInputs::NumberOfInputs,
+                 inner_grid_);
+      saveInputs(
+          *muonTensor_[true], "input_inner_muon", dnn_inputs_2017_v2::MuonBlockInputs::NumberOfInputs, inner_grid_);
+      saveInputs(*hadronsTensor_[true],
+                 "input_inner_hadrons",
+                 dnn_inputs_2017_v2::HadronBlockInputs::NumberOfInputs,
+                 inner_grid_);
+      saveInputs(*eGammaTensor_[false],
+                 "input_outer_egamma",
+                 dnn_inputs_2017_v2::EgammaBlockInputs::NumberOfInputs,
+                 outer_grid_);
+      saveInputs(
+          *muonTensor_[false], "input_outer_muon", dnn_inputs_2017_v2::MuonBlockInputs::NumberOfInputs, outer_grid_);
+      saveInputs(*hadronsTensor_[false],
+                 "input_outer_hadrons",
+                 dnn_inputs_2017_v2::HadronBlockInputs::NumberOfInputs,
+                 outer_grid_);
       (*json_file_) << "}";
       delete json_file_;
       ++file_counter_;
@@ -1637,20 +1677,26 @@ private:
                      {"input_outer", *convTensor_.at(false)}},
                     {"main_output/Softmax"},
                     &pred_vector);
-    if ( debug_level >= 1 ) {
+    if (debug_level >= 1) {
       std::cout << "output = { ";
-      for ( int idx = 0; idx < deep_tau::NumberOfOutputs; ++idx ) { 
-        if ( idx > 0 ) std::cout << ", ";
+      for (int idx = 0; idx < deep_tau::NumberOfOutputs; ++idx) {
+        if (idx > 0)
+          std::cout << ", ";
         std::string label;
-        if      ( idx == 0 ) label = "e";
-        else if ( idx == 1 ) label = "mu";
-        else if ( idx == 2 ) label = "tau";
-        else if ( idx == 3 ) label = "jet";
-        else assert(0);
+        if (idx == 0)
+          label = "e";
+        else if (idx == 1)
+          label = "mu";
+        else if (idx == 2)
+          label = "tau";
+        else if (idx == 3)
+          label = "jet";
+        else
+          assert(0);
         std::cout << label << " = " << pred_vector[0].flat<float>()(idx);
       }
       std::cout << " }" << std::endl;
-    } 
+    }
   }
 
   template <typename Collection, typename TauCastType>
@@ -1757,7 +1803,8 @@ private:
         const auto cell_iter = grid.find(cell_index);
         if (cell_iter != grid.end()) {
           if (debug_level >= 2) {
-            std::cout << " creating inputs for ( eta = " << eta << ", phi = " << phi << " ): idx = " << idx << std::endl;
+            std::cout << " creating inputs for ( eta = " << eta << ", phi = " << phi << " ): idx = " << idx
+                      << std::endl;
           }
           const Cell& cell = cell_iter->second;
           createEgammaBlockInputs<CandidateCastType>(
@@ -1769,7 +1816,8 @@ private:
           idx += 1;
         } else {
           if (debug_level >= 2) {
-            std::cout << " skipping creation of inputs, because ( eta = " << eta << ", phi = " << phi << " ) is not in the grid !!" << std::endl;
+            std::cout << " skipping creation of inputs, because ( eta = " << eta << ", phi = " << phi
+                      << " ) is not in the grid !!" << std::endl;
           }
         }
       }

--- a/RecoTauTag/RecoTau/plugins/DeepTauId.cc
+++ b/RecoTauTag/RecoTau/plugins/DeepTauId.cc
@@ -14,6 +14,9 @@
 #include <TString.h>  // Form
 
 #include <fstream>
+#include <mutex>
+
+std::mutex g_mutex;
 
 namespace deep_tau {
   constexpr int NumberOfOutputs = 4;
@@ -421,6 +424,7 @@ namespace {
   }  // namespace dnn_inputs_2017_v2
 
   float getTauID(const pat::Tau& tau, const std::string& tauID, float default_value = -999.) {
+    std::lock_guard<std::mutex> guard(g_mutex);
     static std::set<std::string> isFirstWarning;
     if (tau.isTauIDAvailable(tauID)) {
       return tau.tauID(tauID);

--- a/RecoTauTag/RecoTau/plugins/DeepTauId.cc
+++ b/RecoTauTag/RecoTau/plugins/DeepTauId.cc
@@ -1163,8 +1163,8 @@ public:
     desc.add<unsigned>("version", 2);
     desc.add<int>("debug_level", 0);
     desc.add<bool>("disable_dxy_pca", false);
-    desc.add<bool>("disable_hcalFraction_workaround", false);
-    desc.add<bool>("disable_CellIndex_workaround", false);
+    desc.add<bool>("disable_hcalFraction_workaround", true);
+    desc.add<bool>("disable_CellIndex_workaround", true);
     desc.add<bool>("save_inputs", false);
     desc.add<bool>("is_online", false);
 

--- a/RecoTauTag/RecoTau/plugins/DeepTauId.cc
+++ b/RecoTauTag/RecoTau/plugins/DeepTauId.cc
@@ -16,8 +16,6 @@
 #include <fstream>
 #include <mutex>
 
-std::mutex g_mutex;
-
 namespace deep_tau {
   constexpr int NumberOfOutputs = 4;
 }
@@ -424,11 +422,12 @@ namespace {
   }  // namespace dnn_inputs_2017_v2
 
   float getTauID(const pat::Tau& tau, const std::string& tauID, float default_value = -999.) {
-    std::lock_guard<std::mutex> guard(g_mutex);
+    static std::mutex g_mutex;
     static std::set<std::string> isFirstWarning;
     if (tau.isTauIDAvailable(tauID)) {
       return tau.tauID(tauID);
     } else {
+      std::lock_guard<std::mutex> guard(g_mutex);
       if (isFirstWarning.find(tauID) == isFirstWarning.end()) {
         std::cout << "Warning in <getTauID>: No tauID '" << tauID
                   << "' available in pat::Tau given as function argument."

--- a/RecoTauTag/RecoTau/plugins/DeepTauId.cc
+++ b/RecoTauTag/RecoTau/plugins/DeepTauId.cc
@@ -2036,8 +2036,8 @@ private:
       get(dnn::pfCand_gamma_puppiWeight) = is_inner ? getValue(candFunc::getPuppiWeight(gamma_cand, 0.9084110f))
                                                     : getValue(candFunc::getPuppiWeight(gamma_cand, 0.4211567f));
       get(dnn::pfCand_gamma_puppiWeightNoLep) =
-          is_inner ? getValue(candFunc::getPuppiWeightNoLep(gamma_cand, 0.8857715703446466))
-                   : getValue(candFunc::getPuppiWeightNoLep(gamma_cand, 0.38226042182344516));
+          is_inner ? getValue(candFunc::getPuppiWeightNoLep(gamma_cand, 0.8857716f))
+                   : getValue(candFunc::getPuppiWeightNoLep(gamma_cand, 0.3822604f));
       get(dnn::pfCand_gamma_lostInnerHits) = getValue<int>(candFunc::getLostInnerHits(gamma_cand, 0));
       get(dnn::pfCand_gamma_numberOfPixelHits) =
           getValueLinear(candFunc::getNumberOfPixelHits(gamma_cand, 0), 0, 7, true);
@@ -2810,7 +2810,7 @@ private:
       zeroOutputTensor_;
   const bool save_inputs_;
   std::ofstream* json_file_;
-  mutable bool is_first_block_;
+  bool is_first_block_;
   int file_counter_;
 
   //boolean to check if discriminator indices are already mapped

--- a/RecoTauTag/RecoTau/plugins/DeepTauId.cc
+++ b/RecoTauTag/RecoTau/plugins/DeepTauId.cc
@@ -2035,9 +2035,9 @@ private:
       get(dnn::pfCand_gamma_fromPV) = getValueLinear<int>(candFunc::getFromPV(gamma_cand), 0, 3, true);
       get(dnn::pfCand_gamma_puppiWeight) = is_inner ? getValue(candFunc::getPuppiWeight(gamma_cand, 0.9084110f))
                                                     : getValue(candFunc::getPuppiWeight(gamma_cand, 0.4211567f));
-      get(dnn::pfCand_gamma_puppiWeightNoLep) =
-          is_inner ? getValue(candFunc::getPuppiWeightNoLep(gamma_cand, 0.8857716f))
-                   : getValue(candFunc::getPuppiWeightNoLep(gamma_cand, 0.3822604f));
+      get(dnn::pfCand_gamma_puppiWeightNoLep) = is_inner
+                                                    ? getValue(candFunc::getPuppiWeightNoLep(gamma_cand, 0.8857716f))
+                                                    : getValue(candFunc::getPuppiWeightNoLep(gamma_cand, 0.3822604f));
       get(dnn::pfCand_gamma_lostInnerHits) = getValue<int>(candFunc::getLostInnerHits(gamma_cand, 0));
       get(dnn::pfCand_gamma_numberOfPixelHits) =
           getValueLinear(candFunc::getNumberOfPixelHits(gamma_cand, 0), 0, 7, true);

--- a/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationByIsolation.cc
+++ b/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationByIsolation.cc
@@ -38,6 +38,8 @@ public:
 
     calculateWeights_ = pset.getParameter<bool>("ApplyDiscriminationByWeightedECALIsolation");
 
+    enableHGCalWorkaround_ = pset.getParameter<bool>("enableHGCalWorkaround");
+
     // RIC: multiply neutral isolation by a flat factor.
     //      Useful, for instance, to combine charged and neutral isolations
     //      with different relative weights
@@ -201,6 +203,7 @@ private:
   bool includeTracks_;
   bool includeGammas_;
   bool calculateWeights_;
+  bool enableHGCalWorkaround_;
   double weightGammas_;
   bool applyOccupancyCut_;
   uint32_t maximumOccupancy_;
@@ -500,7 +503,22 @@ double PFRecoTauDiscriminationByIsolation::discriminate(const PFTauRef& pfTau) c
     double neutralPt = 0.;
     double weightedNeutralPt = 0.;
     for (auto const& isoObject : isoCharged_) {
-      chargedPt += isoObject->pt();
+      //-------------------------------------------------------------------------
+      // CV: fix for Phase-2 HLT tau trigger studies
+      //    (pT of PFCandidates within HGCal acceptance is significantly higher than track pT !!)
+      if ( enableHGCalWorkaround_ ) {
+        double trackPt  = ( isoObject->bestTrack() ) ? isoObject->bestTrack()->pt() : 0.;
+        double pfCandPt = isoObject->pt();
+        if ( pfCandPt > trackPt ) {
+          chargedPt += trackPt;
+          neutralPt += std::max(0., pfCandPt - trackPt);
+        } else {
+          chargedPt += isoObject->pt();
+        }
+      } else { 
+        chargedPt += isoObject->pt();
+      }
+      //-------------------------------------------------------------------------
     }
     if (!calculateWeights_) {
       for (auto const& isoObject : isoNeutral_) {
@@ -616,6 +634,7 @@ void PFRecoTauDiscriminationByIsolation::fillDescriptions(edm::ConfigurationDesc
   desc.add<bool>("ApplyDiscriminationByTrackerIsolation", true);
   desc.add<bool>("storeRawPhotonSumPt_outsideSignalCone", false);
   desc.add<edm::InputTag>("rhoProducer", edm::InputTag("fixedGridRhoFastjetAll"));
+  desc.add<bool>("enableHGCalWorkaround", false);
 
   {
     edm::ParameterSetDescription vpsd1;

--- a/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationByIsolation.cc
+++ b/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationByIsolation.cc
@@ -506,16 +506,16 @@ double PFRecoTauDiscriminationByIsolation::discriminate(const PFTauRef& pfTau) c
       //-------------------------------------------------------------------------
       // CV: fix for Phase-2 HLT tau trigger studies
       //    (pT of PFCandidates within HGCal acceptance is significantly higher than track pT !!)
-      if ( enableHGCalWorkaround_ ) {
-        double trackPt  = ( isoObject->bestTrack() ) ? isoObject->bestTrack()->pt() : 0.;
+      if (enableHGCalWorkaround_) {
+        double trackPt = (isoObject->bestTrack()) ? isoObject->bestTrack()->pt() : 0.;
         double pfCandPt = isoObject->pt();
-        if ( pfCandPt > trackPt ) {
+        if (pfCandPt > trackPt) {
           chargedPt += trackPt;
           neutralPt += std::max(0., pfCandPt - trackPt);
         } else {
           chargedPt += isoObject->pt();
         }
-      } else { 
+      } else {
         chargedPt += isoObject->pt();
       }
       //-------------------------------------------------------------------------

--- a/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationByIsolation.cc
+++ b/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationByIsolation.cc
@@ -511,7 +511,7 @@ double PFRecoTauDiscriminationByIsolation::discriminate(const PFTauRef& pfTau) c
         double pfCandPt = isoObject->pt();
         if (pfCandPt > trackPt) {
           chargedPt += trackPt;
-          neutralPt += std::max(0., pfCandPt - trackPt);
+          neutralPt += pfCandPt - trackPt;
         } else {
           chargedPt += isoObject->pt();
         }

--- a/RecoTauTag/RecoTau/src/DeepTauBase.cc
+++ b/RecoTauTag/RecoTau/src/DeepTauBase.cc
@@ -69,7 +69,7 @@ namespace deep_tau {
         x = den_val != 0 ? x / den_val : std::numeric_limits<float>::max();
       }
       outputbuffer[tau_index].rawValues.push_back(x);
-      if ( working_points ) {
+      if (working_points) {
         for (const auto& wp : *working_points) {
           const bool pass = x > (*wp)(taus->at(tau_index), is_online);
           outputbuffer[tau_index].workingPoints.push_back(pass);
@@ -177,7 +177,7 @@ namespace deep_tau {
   void DeepTauBase::createOutputs(edm::Event& event, const tensorflow::Tensor& pred, edm::Handle<TauCollection> taus) {
     for (const auto& output_desc : outputs_) {
       const WPList* working_points = nullptr;
-      if ( workingPoints_.find(output_desc.first) != workingPoints_.end() ) {
+      if (workingPoints_.find(output_desc.first) != workingPoints_.end()) {
         working_points = &workingPoints_.at(output_desc.first);
       }
       auto result = output_desc.second.get_value(taus, pred, working_points, is_online_);

--- a/RecoTauTag/RecoTau/src/DeepTauBase.cc
+++ b/RecoTauTag/RecoTau/src/DeepTauBase.cc
@@ -54,7 +54,7 @@ namespace deep_tau {
 
   std::unique_ptr<DeepTauBase::TauDiscriminator> DeepTauBase::Output::get_value(const edm::Handle<TauCollection>& taus,
                                                                                 const tensorflow::Tensor& pred,
-                                                                                const WPList& working_points,
+                                                                                const WPList* working_points,
                                                                                 bool is_online) const {
     std::vector<reco::SingleTauDiscriminatorContainer> outputbuffer(taus->size());
 
@@ -69,9 +69,11 @@ namespace deep_tau {
         x = den_val != 0 ? x / den_val : std::numeric_limits<float>::max();
       }
       outputbuffer[tau_index].rawValues.push_back(x);
-      for (const auto& wp : working_points) {
-        const bool pass = x > (*wp)(taus->at(tau_index), is_online);
-        outputbuffer[tau_index].workingPoints.push_back(pass);
+      if ( working_points ) {
+        for (const auto& wp : *working_points) {
+          const bool pass = x > (*wp)(taus->at(tau_index), is_online);
+          outputbuffer[tau_index].workingPoints.push_back(pass);
+        }
       }
     }
     std::unique_ptr<TauDiscriminator> output = std::make_unique<TauDiscriminator>();
@@ -174,7 +176,11 @@ namespace deep_tau {
 
   void DeepTauBase::createOutputs(edm::Event& event, const tensorflow::Tensor& pred, edm::Handle<TauCollection> taus) {
     for (const auto& output_desc : outputs_) {
-      auto result = output_desc.second.get_value(taus, pred, workingPoints_.at(output_desc.first), is_online_);
+      const WPList* working_points = nullptr;
+      if ( workingPoints_.find(output_desc.first) != workingPoints_.end() ) {
+        working_points = &workingPoints_.at(output_desc.first);
+      }
+      auto result = output_desc.second.get_value(taus, pred, working_points, is_online_);
       event.put(std::move(result), output_desc.first);
     }
   }


### PR DESCRIPTION
#### PR description:

Backports #32676 and #32838 in order to have a consistent setup for phase2 HLT DeepTauID developments from CMSSW_11_1_X on (together with another backport #32831 to 11_1_X).

#### PR validation:

Automatically cherry-picked commits from original PR. No particular validation done again.
