### PR TITLE
Fixed backward propagator

### DIFF
--- a/SimG4Core/GeometryProducer/interface/GeometryProducer.h
+++ b/SimG4Core/GeometryProducer/interface/GeometryProducer.h
@@ -62,8 +62,8 @@ private:
   std::vector<SensitiveCaloDetector *> m_sensCaloDets;
   edm::ParameterSet m_p;
 
-  mutable const DDCompactView* m_pDD;
-  mutable const cms::DDCompactView* m_pDD4hep;
+  mutable const DDCompactView *m_pDD;
+  mutable const cms::DDCompactView *m_pDD4hep;
 
   bool m_firstRun;
   bool m_pUseMagneticField;

--- a/SimG4Core/GeometryProducer/interface/GeometryProducer.h
+++ b/SimG4Core/GeometryProducer/interface/GeometryProducer.h
@@ -21,11 +21,16 @@ namespace sim {
   class FieldBuilder;
 }
 
+namespace cms {
+  class DDCompactView;
+}
+
 class SimWatcher;
 class SimProducer;
 class DDDWorld;
 class G4RunManagerKernel;
 class SimTrackManager;
+class DDCompactView;
 
 class GeometryProducer : public edm::one::EDProducer<edm::one::SharedResources, edm::one::WatchRuns> {
 public:
@@ -46,9 +51,7 @@ private:
   void updateMagneticField(edm::EventSetup const &es);
 
   G4RunManagerKernel *m_kernel;
-  bool m_pUseMagneticField;
   edm::ParameterSet m_pField;
-  bool m_pUseSensitiveDetectors;
   SimActivityRegistry m_registry;
   std::vector<std::shared_ptr<SimWatcher>> m_watchers;
   std::vector<std::shared_ptr<SimProducer>> m_producers;
@@ -58,7 +61,14 @@ private:
   std::vector<SensitiveTkDetector *> m_sensTkDets;
   std::vector<SensitiveCaloDetector *> m_sensCaloDets;
   edm::ParameterSet m_p;
+
+  mutable const DDCompactView* m_pDD;
+  mutable const cms::DDCompactView* m_pDD4hep;
+
   bool m_firstRun;
+  bool m_pUseMagneticField;
+  bool m_pUseSensitiveDetectors;
+  bool m_pGeoFromDD4hep;
 };
 
 #endif

--- a/SimG4Core/GeometryProducer/src/GeometryProducer.cc
+++ b/SimG4Core/GeometryProducer/src/GeometryProducer.cc
@@ -23,6 +23,7 @@
 #include "Geometry/Records/interface/IdealGeometryRecord.h"
 
 #include "DetectorDescription/Core/interface/DDCompactView.h"
+#include "DetectorDescription/DDCMS/interface/DDCompactView.h"
 
 #include "G4RunManagerKernel.hh"
 #include "G4TransportationManager.hh"
@@ -60,12 +61,15 @@ static void createWatchers(const edm::ParameterSet &iP,
 
 GeometryProducer::GeometryProducer(edm::ParameterSet const &p)
     : m_kernel(nullptr),
-      m_pUseMagneticField(p.getParameter<bool>("UseMagneticField")),
       m_pField(p.getParameter<edm::ParameterSet>("MagneticField")),
-      m_pUseSensitiveDetectors(p.getParameter<bool>("UseSensitiveDetectors")),
       m_attach(nullptr),
       m_p(p),
-      m_firstRun(true) {
+      m_pDD(nullptr),
+      m_pDD4hep(nullptr),
+      m_firstRun(true),
+      m_pUseMagneticField(p.getParameter<bool>("UseMagneticField")),
+      m_pUseSensitiveDetectors(p.getParameter<bool>("UseSensitiveDetectors")),
+      m_pGeoFromDD4hep(false) {
   // Look for an outside SimActivityRegistry
   // this is used by the visualization code
   edm::Service<SimActivityRegistry> otherRegistry;
@@ -111,21 +115,34 @@ void GeometryProducer::produce(edm::Event &e, const edm::EventSetup &es) {
     return;
   m_firstRun = false;
 
-  edm::LogInfo("GeometryProducer") << "Producing G4 Geom";
+  edm::LogVerbatim("GeometryProducer") << "Producing G4 Geom";
 
   m_kernel = G4RunManagerKernel::GetRunManagerKernel();
   if (m_kernel == nullptr)
     m_kernel = new G4RunManagerKernel();
-  edm::LogInfo("GeometryProducer") << " GeometryProducer initializing ";
+  edm::LogVerbatim("GeometryProducer") << " GeometryProducer initializing ";
   // DDDWorld: get the DDCV from the ES and use it to build the World
-  edm::ESTransientHandle<DDCompactView> pDD;
-  es.get<IdealGeometryRecord>().get(pDD);
+  if (m_pGeoFromDD4hep) {
+    edm::ESTransientHandle<cms::DDCompactView> pDD;
+    es.get<IdealGeometryRecord>().get(pDD);
+    m_pDD4hep = pDD.product();
+  } else {
+    edm::ESTransientHandle<DDCompactView> pDD;
+    es.get<IdealGeometryRecord>().get(pDD);
+    m_pDD = pDD.product();
+  }
 
-  G4LogicalVolumeToDDLogicalPartMap map_;
-  SensitiveDetectorCatalog catalog_;
-  const DDDWorld *world = new DDDWorld(&(*pDD), map_, catalog_, false);
-  m_registry.dddWorldSignal_(world);
+  SensitiveDetectorCatalog catalog;
+  const DDDWorld *dddworld = new DDDWorld(m_pDD, m_pDD4hep, catalog, 1, false, false);
+  G4VPhysicalVolume* world = dddworld->GetWorldVolume();
+  if(nullptr != world)
+    edm::LogVerbatim("GeometryProducer") << " World Volume: " << world->GetName();
+  m_kernel->DefineWorldVolume(world, true);
 
+  m_registry.dddWorldSignal_(dddworld);
+
+
+  edm::LogVerbatim("GeometryProducer") << " Magnetic field initialisation";
   updateMagneticField(es);
 
   if (m_pUseSensitiveDetectors) {
@@ -136,7 +153,7 @@ void GeometryProducer::produce(edm::Event &e, const edm::EventSetup &es) {
       m_attach = new AttachSD;
     {
       std::pair<std::vector<SensitiveTkDetector *>, std::vector<SensitiveCaloDetector *>> sensDets =
-          m_attach->create(es, catalog_, m_p, m_trackManager.get(), m_registry);
+          m_attach->create(es, catalog, m_p, m_trackManager.get(), m_registry);
 
       m_sensTkDets.swap(sensDets.first);
       m_sensCaloDets.swap(sensDets.second);

--- a/SimG4Core/GeometryProducer/src/GeometryProducer.cc
+++ b/SimG4Core/GeometryProducer/src/GeometryProducer.cc
@@ -134,13 +134,12 @@ void GeometryProducer::produce(edm::Event &e, const edm::EventSetup &es) {
 
   SensitiveDetectorCatalog catalog;
   const DDDWorld *dddworld = new DDDWorld(m_pDD, m_pDD4hep, catalog, 1, false, false);
-  G4VPhysicalVolume* world = dddworld->GetWorldVolume();
-  if(nullptr != world)
+  G4VPhysicalVolume *world = dddworld->GetWorldVolume();
+  if (nullptr != world)
     edm::LogVerbatim("GeometryProducer") << " World Volume: " << world->GetName();
   m_kernel->DefineWorldVolume(world, true);
 
   m_registry.dddWorldSignal_(dddworld);
-
 
   edm::LogVerbatim("GeometryProducer") << " Magnetic field initialisation";
   updateMagneticField(es);

--- a/SimG4Core/Notification/interface/Signaler.h
+++ b/SimG4Core/Notification/interface/Signaler.h
@@ -57,11 +57,10 @@ namespace sim_act {
     ///does not take ownership of memory
     void connect(Observer<const T*>& iObs) { observers_.push_back(&iObs); }
 
-  private:
-    Signaler(const Signaler&) = delete;  // stop default
-
+    Signaler(const Signaler&) = delete;                   // stop default
     const Signaler& operator=(const Signaler&) = delete;  // stop default
 
+  private:
     void update(const T* iData) override { this->operator()(iData); }
     // ---------- member data --------------------------------
     std::vector<Observer<const T*>*> observers_;

--- a/SimG4Core/Notification/interface/SimActivityRegistry.h
+++ b/SimG4Core/Notification/interface/SimActivityRegistry.h
@@ -93,12 +93,9 @@ public:
   ///forwards our signals to slots connected to iOther
   void connect(SimActivityRegistry& iOther);
 
-private:
-  SimActivityRegistry(const SimActivityRegistry&) = delete;  // stop default
-
-  const SimActivityRegistry& operator=(const SimActivityRegistry&) = delete;  // stop default
-
-  // ---------- member data --------------------------------
+  // stop default
+  SimActivityRegistry(const SimActivityRegistry&) = delete;
+  const SimActivityRegistry& operator=(const SimActivityRegistry&) = delete;
 };
 
 #endif

--- a/SimG4Core/Notification/interface/SimActivityRegistryEnroller.h
+++ b/SimG4Core/Notification/interface/SimActivityRegistryEnroller.h
@@ -82,14 +82,10 @@ public:
   static void enroll(SimActivityRegistry& iReg, T* iObj) {
     enroller_helper::EnrollerHelper<T, Signals>::enroll(iReg, iObj);
   }
-  // ---------- member functions ---------------------------
 
-private:
-  SimActivityRegistryEnroller(const SimActivityRegistryEnroller&) = delete;  // stop default
-
-  const SimActivityRegistryEnroller& operator=(const SimActivityRegistryEnroller&) = delete;  // stop default
-
-  // ---------- member data --------------------------------
+  // stop default
+  SimActivityRegistryEnroller(const SimActivityRegistryEnroller&) = delete;
+  const SimActivityRegistryEnroller& operator=(const SimActivityRegistryEnroller&) = delete;
 };
 
 #endif

--- a/SimG4Core/Notification/interface/SimTrackManager.h
+++ b/SimG4Core/Notification/interface/SimTrackManager.h
@@ -127,11 +127,11 @@ public:
   }
   void setLHCTransportLink(const edm::LHCTransportLinkContainer* thisLHCTlink) { theLHCTlink = thisLHCTlink; }
 
-private:
   // stop default
   SimTrackManager(const SimTrackManager&) = delete;
   const SimTrackManager& operator=(const SimTrackManager&) = delete;
 
+private:
   void saveTrackAndItsBranch(TrackWithHistory*);
   int getOrCreateVertex(TrackWithHistory*, int, G4SimEvent* simEvent);
   void cleanVertexMap();

--- a/SimG4Core/Notification/src/CMSSteppingVerbose.cc
+++ b/SimG4Core/Notification/src/CMSSteppingVerbose.cc
@@ -293,7 +293,8 @@ void CMSSteppingVerbose::NextStep(const G4Step* step, const G4SteppingManager* s
     const G4RotationMatrix* rotm = pv1->GetFrameRotation();
     G4cout << "PreStepVolume: " << pv1->GetName() << G4endl;
     G4cout << "       Translation: " << pv1->GetObjectTranslation() << G4endl;
-    if(nullptr != rotm) G4cout << "       Rotation:    " << *rotm << G4endl;
+    if (nullptr != rotm)
+      G4cout << "       Rotation:    " << *rotm << G4endl;
     const G4VSolid* sv1 = pv1->GetLogicalVolume()->GetSolid();
     sv1->StreamInfo(G4cout);
     G4cout << G4endl;
@@ -301,7 +302,8 @@ void CMSSteppingVerbose::NextStep(const G4Step* step, const G4SteppingManager* s
       G4cout << "PostStepVolume: " << pv2->GetName() << G4endl;
       G4cout << "       Translation: " << pv2->GetObjectTranslation() << G4endl;
       rotm = pv2->GetFrameRotation();
-      if(nullptr != rotm) G4cout << "       Rotation:    " << *rotm << G4endl;
+      if (nullptr != rotm)
+        G4cout << "       Rotation:    " << *rotm << G4endl;
       const G4VSolid* sv2 = pv2->GetLogicalVolume()->GetSolid();
       sv2->StreamInfo(G4cout);
     }
@@ -315,8 +317,9 @@ void CMSSteppingVerbose::NextStep(const G4Step* step, const G4SteppingManager* s
           const G4VSolid* sol = pv->GetLogicalVolume()->GetSolid();
           G4cout << " Depth # " << k << "  PhysVolume " << pv->GetName() << G4endl;
           G4cout << "       Translation: " << pv->GetObjectTranslation() << G4endl;
-	  const G4RotationMatrix* rotm = pv->GetFrameRotation();
-          if(nullptr != rotm) G4cout << "       Rotation:    " << *rotm << G4endl;
+          const G4RotationMatrix* rotm = pv->GetFrameRotation();
+          if (nullptr != rotm)
+            G4cout << "       Rotation:    " << *rotm << G4endl;
           sol->StreamInfo(G4cout);
         }
       }

--- a/SimG4Core/Notification/src/CMSSteppingVerbose.cc
+++ b/SimG4Core/Notification/src/CMSSteppingVerbose.cc
@@ -290,16 +290,18 @@ void CMSSteppingVerbose::NextStep(const G4Step* step, const G4SteppingManager* s
            << G4endl;
     const G4VPhysicalVolume* pv1 = preStep->GetPhysicalVolume();
     const G4VPhysicalVolume* pv2 = postStep->GetPhysicalVolume();
+    const G4RotationMatrix* rotm = pv1->GetFrameRotation();
     G4cout << "PreStepVolume: " << pv1->GetName() << G4endl;
     G4cout << "       Translation: " << pv1->GetObjectTranslation() << G4endl;
-    G4cout << "       Rotation:    " << pv1->GetObjectRotationValue() << G4endl;
+    if(nullptr != rotm) G4cout << "       Rotation:    " << *rotm << G4endl;
     const G4VSolid* sv1 = pv1->GetLogicalVolume()->GetSolid();
     sv1->StreamInfo(G4cout);
     G4cout << G4endl;
-    if (pv2) {
+    if (pv2 && pv2 != pv1) {
       G4cout << "PostStepVolume: " << pv2->GetName() << G4endl;
       G4cout << "       Translation: " << pv2->GetObjectTranslation() << G4endl;
-      G4cout << "       Rotation:    " << pv2->GetObjectRotationValue() << G4endl;
+      rotm = pv2->GetFrameRotation();
+      if(nullptr != rotm) G4cout << "       Rotation:    " << *rotm << G4endl;
       const G4VSolid* sv2 = pv2->GetLogicalVolume()->GetSolid();
       sv2->StreamInfo(G4cout);
     }
@@ -313,7 +315,8 @@ void CMSSteppingVerbose::NextStep(const G4Step* step, const G4SteppingManager* s
           const G4VSolid* sol = pv->GetLogicalVolume()->GetSolid();
           G4cout << " Depth # " << k << "  PhysVolume " << pv->GetName() << G4endl;
           G4cout << "       Translation: " << pv->GetObjectTranslation() << G4endl;
-          G4cout << "       Rotation:    " << pv->GetObjectRotationValue() << G4endl;
+	  const G4RotationMatrix* rotm = pv->GetFrameRotation();
+          if(nullptr != rotm) G4cout << "       Rotation:    " << *rotm << G4endl;
           sol->StreamInfo(G4cout);
         }
       }


### PR DESCRIPTION
#### PR description:
GeometryProducer is used in order to prepare Geant4 geometry for use in backward propagation. The code is updated in order to take into account possible use of DDD and potentially DD4Hep. This addresses #31920 .

Also CMSSteppingVerbosity is improved, code-check warnings in Notification sub-library are fixed.

These modifications do not affect any WF used in validation. 

#### PR validation:
private

#### if this PR is a backport please specify the original PR and why you need to backport that PR:
May require backport to 11_2_0
