### PR TITLE
[DD4hep] Disable DT Geometry Builder unit test that can't work with new DD4hep

### DIFF
--- a/Geometry/DTGeometryBuilder/test/python/validateDTGeometry_cfg.py
+++ b/Geometry/DTGeometryBuilder/test/python/validateDTGeometry_cfg.py
@@ -1,3 +1,7 @@
+# This config does not work with the version of DD4hep that uses Geant4 units. This config performs a comparison
+# with a reference geometry which might use the ROOT units convention. This mismatch somehow triggers a ROOT exception.
+# We don't currently have a fix for this problem.
+
 import FWCore.ParameterSet.Config as cms
 
 process = cms.Process('VALID')

--- a/Geometry/DTGeometryBuilder/test/runTest.sh
+++ b/Geometry/DTGeometryBuilder/test/runTest.sh
@@ -21,8 +21,9 @@ FILE4=dtGeometryFiltered.log
 echo " testing Geometry/DTGeometryBuilder"
 
 export tmpdir=${LOCAL_TMP_DIR:-/tmp}
-echo "===== Test \"cmsRun validateDTGeometry_cfg.py\" ===="
-(cmsRun $F1) || die "Failure using cmsRun $F1" $?
+# The following test does not work with DD4hep with Geant4 units
+# echo "===== Test \"cmsRun validateDTGeometry_cfg.py\" ===="
+# (cmsRun $F1) || die "Failure using cmsRun $F1" $?
 echo "===== Test \"cmsRun testDTGeometry.py\" ===="
 (cmsRun $F2;
     grep -v 'Benchmark ' $FILE2 | grep -v '^ *[1-9]' | grep -v '%MSG-i' | grep -v '^Info '>& $FILE4;


### PR DESCRIPTION
The new version of DD4hep uses the Geant4 units convention. The `validateDTGeometry_cfg.py` unit test in the `Geometry/DTGeometryBuilder` package compares a reference geometry that may have the ROOT units convention with the current geometry that has the Geant4 units convention. This comparison somehow triggers a ROOT exception complaining about changing the units convention. Discussion with the DD4hep developers indicates there is no easy fix. Rather than block the new version of DD4hep, it was decided to disable this unit test. In the future, we may figure out a way to fix it, but it doesn't seem to be essential.

#### PR validation:

With the changes in this PR, the `Geometry/DTGeometryBuilder` unit tests were run successfully in a special build with the new version of DD4hep.

No backport is needed.