### PR TITLE
Change/add scripts to write PPS RECO geometry payloads to a DB file

### DIFF
--- a/CondTools/Geometry/test/writehelpers/createPPS2017RECOPayloads.sh
+++ b/CondTools/Geometry/test/writehelpers/createPPS2017RECOPayloads.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+
+if [ $# -ne 1 ]
+then
+  echo Error: createPPS2017RECOPayloads.sh requires exactly one argument which is the tag
+  exit 1
+fi
+mytag=$1
+echo ${mytag}
+
+# Set the tag in all the scripts and the metadata text files
+sed -i {s/TagXX/${mytag}/g} geometryCTPPS2017_writer.py
+sed -i {s/TagXX/${mytag}/g} geometryCTPPS2017*.txt
+sed -i {s/TagXX/${mytag}/g} splitPPS2017Database.sh
+
+# First read in the little XML files and create the
+# Input cff                                             Output file
+# geometryRPFromDD_2017_cfi                 ge2017SingleBigFile.xml
+cmsRun geometryCTPPS2017_xmlwriter.py
+
+# Now convert the content of the large XML file into
+# a "blob" and write it to the database.
+# Also reads in the little XML files again and fills
+# the DDCompactView. From the DDCompactView the
+# reco parts of the database are also filled.
+cmsRun geometryCTPPS2017_writer.py
+
+# All the database objects were written into one database
+# (myfile.db) in the steps above.  Extract the different
+# pieces into separate database files.  These are the payloads
+# that get uploaded to the dropbox.  There is one for each tag
+./splitPPS2017Database.sh

--- a/CondTools/Geometry/test/writehelpers/createPPS2018RECOPayloads.sh
+++ b/CondTools/Geometry/test/writehelpers/createPPS2018RECOPayloads.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+
+if [ $# -ne 1 ]
+then
+  echo Error: createPPS2018RECOPayloads.sh requires exactly one argument which is the tag
+  exit 1
+fi
+mytag=$1
+echo ${mytag}
+
+# Set the tag in all the scripts and the metadata text files
+sed -i {s/TagXX/${mytag}/g} geometryCTPPS2018_writer.py
+sed -i {s/TagXX/${mytag}/g} geometryCTPPS2018*.txt
+sed -i {s/TagXX/${mytag}/g} splitPPS2018Database.sh
+
+# First read in the little XML files and create the
+# Input cff                                             Output file
+# geometryRPFromDD_2018_cfi                 ge2018SingleBigFile.xml
+cmsRun geometryCTPPS2018_xmlwriter.py
+
+# Now convert the content of the large XML file into
+# a "blob" and write it to the database.
+# Also reads in the little XML files again and fills
+# the DDCompactView. From the DDCompactView the
+# reco parts of the database are also filled.
+cmsRun geometryCTPPS2018_writer.py
+
+# All the database objects were written into one database
+# (myfile.db) in the steps above.  Extract the different
+# pieces into separate database files.  These are the payloads
+# that get uploaded to the dropbox.  There is one for each tag
+./splitPPS2018Database.sh

--- a/CondTools/Geometry/test/writehelpers/geometryCTPPS2017_writer.py
+++ b/CondTools/Geometry/test/writehelpers/geometryCTPPS2017_writer.py
@@ -4,6 +4,9 @@ process = cms.Process("GeometryWriter")
 
 process.load('CondCore.CondDB.CondDB_cfi')
 
+# geometry
+process.load("Geometry.VeryForwardGeometry.dd4hep.geometryRPFromDD_2017_cfi")
+
 process.source = cms.Source("EmptyIOVSource",
                             lastValue = cms.uint64(1),
                             timetype = cms.string('runnumber'),
@@ -21,12 +24,21 @@ process.XMLGeometryWriter = cms.EDAnalyzer("XMLGeometryBuilder",
                                            ZIP = cms.untracked.bool(True)
                                            )
 
+# DB writer
+process.ppsGeometryBuilder = cms.EDAnalyzer("PPSGeometryBuilder",
+                                            fromDD4hep = cms.untracked.bool(True),
+                                            isRun2 = cms.untracked.bool(True),
+                                            compactViewTag = cms.untracked.string('XMLIdealGeometryESSource_CTPPS')
+)
+
 process.CondDB.timetype = cms.untracked.string('runnumber')
 process.CondDB.connect = cms.string('sqlite_file:myfile.db')
 process.PoolDBOutputService = cms.Service("PoolDBOutputService",
                                           process.CondDB,
                                           toPut = cms.VPSet(cms.PSet(record = cms.string('GeometryFileRcd'),
-                                                                     tag = cms.string('XMLFILE_CTPPS_Geometry_2017_TagXX'))
+                                                                     tag = cms.string('XMLFILE_CTPPS_Geometry_2017_TagXX')),
+                                                            cms.PSet(record = cms.string('VeryForwardIdealGeometryRecord'),
+                                                                     tag = cms.string('PPSRECO_Geometry_2017_TagXX'))
                                                             )
                                           )
 
@@ -34,5 +46,5 @@ process.maxEvents = cms.untracked.PSet(
     input = cms.untracked.int32(1)
     )
 
-process.p1 = cms.Path(process.XMLGeometryWriter)
+process.p1 = cms.Path(process.XMLGeometryWriter+process.ppsGeometryBuilder)
 

--- a/CondTools/Geometry/test/writehelpers/geometryCTPPS2018_writer.py
+++ b/CondTools/Geometry/test/writehelpers/geometryCTPPS2018_writer.py
@@ -4,6 +4,9 @@ process = cms.Process("GeometryWriter")
 
 process.load('CondCore.CondDB.CondDB_cfi')
 
+# geometry
+process.load("Geometry.VeryForwardGeometry.dd4hep.geometryRPFromDD_2018_cfi")
+
 process.source = cms.Source("EmptyIOVSource",
                             lastValue = cms.uint64(1),
                             timetype = cms.string('runnumber'),
@@ -21,12 +24,21 @@ process.XMLGeometryWriter = cms.EDAnalyzer("XMLGeometryBuilder",
                                            ZIP = cms.untracked.bool(True)
                                            )
 
+# DB writer
+process.ppsGeometryBuilder = cms.EDAnalyzer("PPSGeometryBuilder",
+                                            fromDD4hep = cms.untracked.bool(True),
+                                            isRun2 = cms.untracked.bool(True),
+                                            compactViewTag = cms.untracked.string('XMLIdealGeometryESSource_CTPPS')
+)
+
 process.CondDB.timetype = cms.untracked.string('runnumber')
 process.CondDB.connect = cms.string('sqlite_file:myfile.db')
 process.PoolDBOutputService = cms.Service("PoolDBOutputService",
                                           process.CondDB,
                                           toPut = cms.VPSet(cms.PSet(record = cms.string('GeometryFileRcd'),
-                                                                     tag = cms.string('XMLFILE_CTPPS_Geometry_2018_101YV1'))
+                                                                     tag = cms.string('XMLFILE_CTPPS_Geometry_2018_TagXX')),
+                                                            cms.PSet(record = cms.string('VeryForwardIdealGeometryRecord'),
+                                                                     tag = cms.string('PPSRECO_Geometry_2018_TagXX'))
                                                             )
                                           )
 
@@ -34,5 +46,5 @@ process.maxEvents = cms.untracked.PSet(
     input = cms.untracked.int32(1)
     )
 
-process.p1 = cms.Path(process.XMLGeometryWriter)
+process.p1 = cms.Path(process.XMLGeometryWriter+process.ppsGeometryBuilder)
 

--- a/CondTools/Geometry/test/writehelpers/splitPPS2017Database.sh
+++ b/CondTools/Geometry/test/writehelpers/splitPPS2017Database.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+conddb --yes --db myfile.db copy       PPSRECO_Geometry_2017_TagXX --destdb       PPSRECO_Geometry.db
+conddb --yes --db myfile.db copy XMLFILE_CTPPS_Geometry_2017_TagXX --destdb XMLFILE_CTPPS_Geometry.db

--- a/CondTools/Geometry/test/writehelpers/splitPPS2018Database.sh
+++ b/CondTools/Geometry/test/writehelpers/splitPPS2018Database.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+conddb --yes --db myfile.db copy       PPSRECO_Geometry_2018_TagXX --destdb       PPSRECO_Geometry.db
+conddb --yes --db myfile.db copy XMLFILE_CTPPS_Geometry_2018_TagXX --destdb XMLFILE_CTPPS_Geometry.db


### PR DESCRIPTION
#### PR description:

- Add a few scripts and change a couple of config files to create DB files for PPS RECO geometry. This is a new feature and it is not expected to change the output of any existing workflow.

- In the near future, we plan to use this feature to create and upload PPS RECO geometry payloads to the offline DB, to be used in Run 2 proton reconstruction workflows. 

- No dependence on other PR's.

#### PR validation:

The validation was performed by comparing the positions of the geometry elements (PPS pot and sensors) obtained from the DB file with those obtained from the corresponding XML geometry files. Perfect agreement is observed. Text print out files can be made available if needed, although they are some hundred lines long.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Not a backport.

