### PR TITLE
use non-static lambda in DeepTauId::CellGrid::tryGetCellIndex

### DIFF
--- a/RecoTauTag/RecoTau/plugins/DeepTauId.cc
+++ b/RecoTauTag/RecoTau/plugins/DeepTauId.cc
@@ -1039,7 +1039,7 @@ namespace {
     int getPhiTensorIndex(const CellIndex& cellIndex) const { return cellIndex.phi + maxPhiIndex(); }
 
     bool tryGetCellIndex(double deltaEta, double deltaPhi, CellIndex& cellIndex) const {
-      static auto getCellIndex = [this](double x, double maxX, double size, int& index) {
+      const auto getCellIndex = [this](double x, double maxX, double size, int& index) {
         const double absX = std::abs(x);
         if (absX > maxX)
           return false;


### PR DESCRIPTION
this apparently fixes #32837

tested in CMSSW_11_3_ASAN_X_2021-02-05-2300 on wf 4.17; also checked that the single-thread execution time is unchanged