### PR TITLE
Remove MessageLoggerHeader from SimDataFormats headers

### DIFF
--- a/PhysicsTools/HepMCCandAlgos/plugins/GenParticleProducer.cc
+++ b/PhysicsTools/HepMCCandAlgos/plugins/GenParticleProducer.cc
@@ -10,6 +10,7 @@
 #include "FWCore/Framework/interface/global/EDProducer.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "FWCore/Utilities/interface/ESGetToken.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "DataFormats/Candidate/interface/CandidateFwd.h"
 #include "DataFormats/HepMCCandidate/interface/GenParticleFwd.h"
 #include "SimDataFormats/CrossingFrame/interface/CrossingFrame.h"

--- a/SimCalorimetry/EcalSimAlgos/interface/EBHitResponse.icc
+++ b/SimCalorimetry/EcalSimAlgos/interface/EBHitResponse.icc
@@ -10,6 +10,7 @@
 #include "CLHEP/Random/RandGaussQ.h"
 #include "DataFormats/EcalDetId/interface/EBDetId.h"
 #include "SimDataFormats/CaloHit/interface/PCaloHit.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/Utilities/interface/isFinite.h"
 #include "FWCore/Utilities/interface/Exception.h"
 

--- a/SimCalorimetry/EcalTestBeam/src/EcalTBDigiProducer.cc
+++ b/SimCalorimetry/EcalTestBeam/src/EcalTBDigiProducer.cc
@@ -5,6 +5,7 @@
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/Event.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "Geometry/CaloGeometry/interface/CaloGeometry.h"
 #include "Geometry/Records/interface/CaloGeometryRecord.h"
 #include "SimCalorimetry/EcalSimAlgos/interface/EBHitResponse.h"

--- a/SimDataFormats/CaloTest/interface/HcalTestHistoClass.h
+++ b/SimDataFormats/CaloTest/interface/HcalTestHistoClass.h
@@ -5,7 +5,6 @@
 // Histogram handling class for analysis in HcalTest
 ///////////////////////////////////////////////////////////////////////////////
 
-#include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "SimDataFormats/CaloHit/interface/CaloHit.h"
 
 #include <string>

--- a/SimDataFormats/CaloTest/src/HcalTestHistoClass.cc
+++ b/SimDataFormats/CaloTest/src/HcalTestHistoClass.cc
@@ -5,6 +5,7 @@
 
 #include "SimDataFormats/CaloTest/interface/HcalTestHistoClass.h"
 #include "DataFormats/HcalDetId/interface/HcalTestNumbering.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include <algorithm>
 #include <iostream>

--- a/SimDataFormats/CrossingFrame/interface/CrossingFrame.h
+++ b/SimDataFormats/CrossingFrame/interface/CrossingFrame.h
@@ -22,7 +22,6 @@
 #include "DataFormats/Provenance/interface/EventID.h"
 #include "DataFormats/Common/interface/Wrapper.h"
 #include "SimDataFormats/EncodedEventId/interface/EncodedEventId.h"
-#include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 template <class T>
 class PCrossingFrame;

--- a/SimDataFormats/CrossingFrame/interface/CrossingFramePlaybackInfoExtended.h
+++ b/SimDataFormats/CrossingFrame/interface/CrossingFramePlaybackInfoExtended.h
@@ -14,7 +14,6 @@
  ************************************************************/
 
 #include "DataFormats/Provenance/interface/EventID.h"
-#include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include <vector>
 #include <utility>
 

--- a/SimDataFormats/CrossingFrame/interface/CrossingFramePlaybackInfoNew.h
+++ b/SimDataFormats/CrossingFrame/interface/CrossingFramePlaybackInfoNew.h
@@ -15,7 +15,6 @@
 
 #include "DataFormats/Common/interface/SecondaryEventIDAndFileInfo.h"
 #include "DataFormats/Provenance/interface/EventID.h"
-#include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include <iterator>
 #include <vector>
 #include <utility>

--- a/SimDataFormats/CrossingFrame/interface/MixCollection.h
+++ b/SimDataFormats/CrossingFrame/interface/MixCollection.h
@@ -4,7 +4,6 @@
 #include <string>
 #include <vector>
 
-#include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "SimDataFormats/CrossingFrame/interface/CrossingFrame.h"
 
 template <class T>
@@ -156,8 +155,8 @@ MixCollection<T>::MixCollection(const CrossingFrame<T> *cf, const std::pair<int,
     crossingFrames_.push_back(cf);
     init(bunchRange);
   } else
-    edm::LogWarning("MixCollectionInvalidCtr") << "Could not construct MixCollection for " << typeid(T).name()
-                                               << ", pointer to CrossingFrame invalid!" << std::endl;
+    throw cms::Exception("InvalidPtr") << "Could not construct MixCollection for " << typeid(T).name()
+                                       << ", pointer to CrossingFrame invalid!";
 }
 
 template <class T>

--- a/SimDataFormats/SimHitMaker/interface/CaloSlaveSD.h
+++ b/SimDataFormats/SimHitMaker/interface/CaloSlaveSD.h
@@ -6,7 +6,6 @@
 #ifndef CaloSlaveSD_h
 #define CaloSlaveSD_h
 
-#include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "SimDataFormats/CaloHit/interface/PCaloHit.h"
 #include "SimDataFormats/CaloHit/interface/PCaloHitContainer.h"
 

--- a/SimDataFormats/SimHitMaker/src/CaloSlaveSD.cc
+++ b/SimDataFormats/SimHitMaker/src/CaloSlaveSD.cc
@@ -7,6 +7,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 
 #include "SimDataFormats/SimHitMaker/interface/CaloSlaveSD.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include <iostream>
 

--- a/SimG4CMS/Calo/src/HcalTestHistoManager.cc
+++ b/SimG4CMS/Calo/src/HcalTestHistoManager.cc
@@ -6,6 +6,7 @@
 #include "SimG4CMS/Calo/interface/HcalTestHistoManager.h"
 
 #include "FWCore/PluginManager/interface/PluginManager.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include <cmath>
 #include <iostream>

--- a/SimGeneral/PileupInformation/plugins/GenPUProtonProducer.cc
+++ b/SimGeneral/PileupInformation/plugins/GenPUProtonProducer.cc
@@ -17,6 +17,7 @@
 #include "SimGeneral/HepPDTRecord/interface/ParticleDataTable.h"
 #include "DataFormats/HepMCCandidate/interface/GenParticle.h"
 #include "FWCore/Utilities/interface/EDMException.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include <vector>
 #include <string>

--- a/SimMuon/GEMDigitizer/src/ME0SimpleModel.cc
+++ b/SimMuon/GEMDigitizer/src/ME0SimpleModel.cc
@@ -5,6 +5,7 @@
 #include "Geometry/GEMGeometry/interface/ME0EtaPartitionSpecs.h"
 #include "Geometry/CommonTopologies/interface/TrapezoidalStripTopology.h"
 #include "Geometry/GEMGeometry/interface/ME0Geometry.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/Utilities/interface/Exception.h"
 #include "CLHEP/Random/RandFlat.h"
 #include "CLHEP/Random/RandPoissonQ.h"

--- a/SimMuon/MCTruth/src/GEMHitAssociator.cc
+++ b/SimMuon/MCTruth/src/GEMHitAssociator.cc
@@ -1,4 +1,5 @@
 #include "SimMuon/MCTruth/interface/GEMHitAssociator.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 using namespace std;
 

--- a/SimMuon/MCTruth/src/PSimHitMap.cc
+++ b/SimMuon/MCTruth/src/PSimHitMap.cc
@@ -1,5 +1,6 @@
 #include "SimDataFormats/CrossingFrame/interface/MixCollection.h"
 #include "SimMuon/MCTruth/interface/PSimHitMap.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 void PSimHitMap::fill(const edm::Event &e) {
   theMap.clear();

--- a/SimMuon/MCTruth/src/RPCHitAssociator.cc
+++ b/SimMuon/MCTruth/src/RPCHitAssociator.cc
@@ -1,4 +1,5 @@
 #include "SimMuon/MCTruth/interface/RPCHitAssociator.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 using namespace std;
 


### PR DESCRIPTION
#### PR description:

Removed the use of FWCore/MessageLogger/interface/MessageLogger.h from SimDataFormats headers. Only one of the headers actually used MessageLogger and for that one it was actually more consistent to throw an exception instead.

#### PR validation:

The code and all of its dependencies compile.