### PR TITLE
Migrate DQMOffline/Alignment and CondTools/DQM to esConsumes

### DIFF
--- a/CondTools/DQM/plugins/DQMSummaryEventSetupAnalyzer.cc
+++ b/CondTools/DQM/plugins/DQMSummaryEventSetupAnalyzer.cc
@@ -1,52 +1,54 @@
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Utilities/interface/Exception.h"
 #include "CondFormats/DQMObjects/interface/DQMSummary.h"
 #include "CondFormats/DataRecord/interface/DQMSummaryRcd.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
-#include <iostream>
 
 namespace edmtest {
-  class DQMSummaryEventSetupAnalyzer : public edm::EDAnalyzer {
+  class DQMSummaryEventSetupAnalyzer : public edm::one::EDAnalyzer<> {
   public:
     explicit DQMSummaryEventSetupAnalyzer(const edm::ParameterSet& pset);
     explicit DQMSummaryEventSetupAnalyzer(int i);
     ~DQMSummaryEventSetupAnalyzer() override;
     void analyze(const edm::Event& event, const edm::EventSetup& setup) override;
+
+  private:
+    const edm::ESGetToken<DQMSummary, DQMSummaryRcd> dqmSummaryToken_;
   };
 
-  DQMSummaryEventSetupAnalyzer::DQMSummaryEventSetupAnalyzer(const edm::ParameterSet& pset) {
-    std::cout << "DQMSummaryEventSetupAnalyzer" << std::endl;
+  DQMSummaryEventSetupAnalyzer::DQMSummaryEventSetupAnalyzer(const edm::ParameterSet& pset)
+      : dqmSummaryToken_(esConsumes()) {
+    edm::LogPrint("DQMSummaryEventSetupAnalyzer") << "DQMSummaryEventSetupAnalyzer" << std::endl;
   }
 
-  DQMSummaryEventSetupAnalyzer::DQMSummaryEventSetupAnalyzer(int i) {
-    std::cout << "DQMSummaryEventSetupAnalyzer" << i << std::endl;
+  DQMSummaryEventSetupAnalyzer::DQMSummaryEventSetupAnalyzer(int i) : dqmSummaryToken_(esConsumes()) {
+    edm::LogPrint("DQMSummaryEventSetupAnalyzer") << "DQMSummaryEventSetupAnalyzer" << i << std::endl;
   }
 
   DQMSummaryEventSetupAnalyzer::~DQMSummaryEventSetupAnalyzer() {
-    std::cout << "~DQMSummaryEventSetupAnalyzer" << std::endl;
+    edm::LogPrint("DQMSummaryEventSetupAnalyzer") << "~DQMSummaryEventSetupAnalyzer" << std::endl;
   }
 
   void DQMSummaryEventSetupAnalyzer::analyze(const edm::Event& event, const edm::EventSetup& setup) {
-    std::cout << "### DQMSummaryEventSetupAnalyzer::analyze" << std::endl;
-    std::cout << "--- RUN NUMBER: " << event.id().run() << std::endl;
-    std::cout << "--- EVENT NUMBER: " << event.id().event() << std::endl;
+    edm::LogPrint("DQMSummaryEventSetupAnalyzer") << "### DQMSummaryEventSetupAnalyzer::analyze" << std::endl;
+    edm::LogPrint("DQMSummaryEventSetupAnalyzer") << "--- RUN NUMBER: " << event.id().run() << std::endl;
+    edm::LogPrint("DQMSummaryEventSetupAnalyzer") << "--- EVENT NUMBER: " << event.id().event() << std::endl;
     edm::eventsetup::EventSetupRecordKey recordKey(
         edm::eventsetup::EventSetupRecordKey::TypeTag::findType("DQMSummaryRcd"));
     if (recordKey.type() == edm::eventsetup::EventSetupRecordKey::TypeTag()) {
       throw cms::Exception("Record not found") << "Record \"DQMSummaryRcd"
                                                << "\" does not exist!" << std::endl;
     }
-    edm::ESHandle<DQMSummary> sum;
-    std::cout << "got EShandle" << std::endl;
-    setup.get<DQMSummaryRcd>().get(sum);
-    std::cout << "got the Event Setup" << std::endl;
+
+    edm::LogPrint("DQMSummaryEventSetupAnalyzer") << "got EShandle" << std::endl;
+    edm::ESHandle<DQMSummary> sum = setup.getHandle(dqmSummaryToken_);
+    edm::LogPrint("DQMSummaryEventSetupAnalyzer") << "got the Event Setup" << std::endl;
     const DQMSummary* summary = sum.product();
-    std::cout << "got DQMSummary* " << std::endl;
-    std::cout << "print result" << std::endl;
+    edm::LogPrint("DQMSummaryEventSetupAnalyzer") << "got DQMSummary* " << std::endl;
+    edm::LogPrint("DQMSummaryEventSetupAnalyzer") << "print result" << std::endl;
     summary->printAllValues();
   }
 

--- a/DQMOffline/Alignment/interface/TkAlCaRecoMonitor.h
+++ b/DQMOffline/Alignment/interface/TkAlCaRecoMonitor.h
@@ -42,6 +42,9 @@ private:
   void fillRawIdMap(const TrackerGeometry &geometry);
 
   // ----------member data ---------------------------
+  const edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> tkGeomToken_;
+  const edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> mfToken_;
+
   edm::ParameterSet conf_;
 
   double maxJetPt_;

--- a/DQMOffline/Alignment/src/TkAlCaRecoMonitor.cc
+++ b/DQMOffline/Alignment/src/TkAlCaRecoMonitor.cc
@@ -3,8 +3,6 @@
  *
  */
 
-#include "FWCore/Framework/interface/ESHandle.h"
-
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
 #include "Geometry/CommonDetUnit/interface/GeomDet.h"
@@ -24,7 +22,8 @@
 #include <string>
 #include "TLorentzVector.h"
 
-TkAlCaRecoMonitor::TkAlCaRecoMonitor(const edm::ParameterSet &iConfig) {
+TkAlCaRecoMonitor::TkAlCaRecoMonitor(const edm::ParameterSet &iConfig)
+    : tkGeomToken_(esConsumes()), mfToken_(esConsumes()) {
   conf_ = iConfig;
   trackProducer_ = consumes<reco::TrackCollection>(conf_.getParameter<edm::InputTag>("TrackProducer"));
   referenceTrackProducer_ =
@@ -206,14 +205,12 @@ void TkAlCaRecoMonitor::analyze(const edm::Event &iEvent, const edm::EventSetup 
     return;
   }
 
-  edm::ESHandle<TrackerGeometry> geometry;
-  iSetup.get<TrackerDigiGeometryRecord>().get(geometry);
+  const auto &geometry = iSetup.getHandle(tkGeomToken_);
   if (!geometry.isValid()) {
     edm::LogError("Alignment") << "invalid geometry found in event setup!";
   }
 
-  edm::ESHandle<MagneticField> magneticField;
-  iSetup.get<IdealMagneticFieldRecord>().get(magneticField);
+  const auto &magneticField = iSetup.getHandle(mfToken_);
   if (!magneticField.isValid()) {
     edm::LogError("Alignment") << "invalid magnetic field configuration encountered!";
     return;


### PR DESCRIPTION
#### PR description:

Title says it all.
   * migrated to `esConsumes`  subsystem `DQMOffline/Alignment` 
   * migrated to `esConsumes`  subsystem `CondTools/DQM`
   * analyzers in `CondTools/DQM` have been modernized

Part of https://github.com/cms-sw/cmssw/issues/31061

#### PR validation:

Compiles + run `scramv1 b runtests`

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Not a backport, no backport is needed.
