### PR TITLE
Get PhysicsTools/TensorFlow to compile with optimization off

### DIFF
--- a/PhysicsTools/TensorFlow/interface/TensorFlow.h
+++ b/PhysicsTools/TensorFlow/interface/TensorFlow.h
@@ -9,6 +9,8 @@
 #ifndef PHYSICSTOOLS_TENSORFLOW_TENSORFLOW_H
 #define PHYSICSTOOLS_TENSORFLOW_TENSORFLOW_H
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wsign-compare"
 #include "tensorflow/core/framework/tensor.h"
 #include "tensorflow/core/lib/core/threadpool.h"
 #include "tensorflow/core/lib/io/path.h"
@@ -18,6 +20,7 @@
 #include "tensorflow/cc/saved_model/loader.h"
 #include "tensorflow/cc/saved_model/constants.h"
 #include "tensorflow/cc/saved_model/tag_constants.h"
+#pragma GCC diagnostic pop
 
 #include "PhysicsTools/TensorFlow/interface/NoThreadPool.h"
 #include "PhysicsTools/TensorFlow/interface/TBBThreadPool.h"

--- a/PhysicsTools/TensorFlow/interface/TensorFlow.h
+++ b/PhysicsTools/TensorFlow/interface/TensorFlow.h
@@ -10,7 +10,7 @@
 #define PHYSICSTOOLS_TENSORFLOW_TENSORFLOW_H
 
 #pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wsign-compare"
+#pragma GCC diagnostic warning "-Wsign-compare"
 #include "tensorflow/core/framework/tensor.h"
 #include "tensorflow/core/lib/core/threadpool.h"
 #include "tensorflow/core/lib/io/path.h"

--- a/PhysicsTools/TensorFlow/test/testHelloWorld.cc
+++ b/PhysicsTools/TensorFlow/test/testHelloWorld.cc
@@ -9,8 +9,11 @@
 #include <stdexcept>
 #include <cppunit/extensions/HelperMacros.h>
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wsign-compare"
 #include "tensorflow/cc/saved_model/loader.h"
 #include "tensorflow/cc/saved_model/tag_constants.h"
+#pragma GCC diagnostic pop
 
 #include "testBase.h"
 

--- a/PhysicsTools/TensorFlow/test/testHelloWorld.cc
+++ b/PhysicsTools/TensorFlow/test/testHelloWorld.cc
@@ -10,7 +10,7 @@
 #include <cppunit/extensions/HelperMacros.h>
 
 #pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wsign-compare"
+#pragma GCC diagnostic warning "-Wsign-compare"
 #include "tensorflow/cc/saved_model/loader.h"
 #include "tensorflow/cc/saved_model/tag_constants.h"
 #pragma GCC diagnostic pop


### PR DESCRIPTION
#### PR description:

PhysicsTools/TensorFlow doesn't compile with optimization off.  Compiling with
```
USER_CXXFLAGS="-g -O0" scram b
```
results in many "integer expressions of different signedness" warnings that we promote to errors:
```
/cvmfs/cms.cern.ch/slc7_amd64_gcc900/external/tensorflow/2.3.1/include/tensorflow/core/platform/default/logging.h:370:29: error: comparison of integer expressions of different signedness: 'const size_t' {aka 'const long unsigned int'} and int' [-Werror=sign-compare]
  370 |     if (TF_PREDICT_FALSE(v2 >= std::numeric_limits<int>::max())) {        \
      |                          ~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/cvmfs/cms.cern.ch/slc7_amd64_gcc900/external/tensorflow/2.3.1/include/tensorflow/core/platform/macros.h:83:47: note: in definition of macro 'TF_PREDICT_FALSE'
   83 | #define TF_PREDICT_FALSE(x) (__builtin_expect(x, 0))
      |                                               ^
/cvmfs/cms.cern.ch/slc7_amd64_gcc900/external/tensorflow/2.3.1/include/tensorflow/core/platform/default/logging.h:381:1: note: in expansion of macro 'TF_DEFINE_CHECK_OP_IMPL'
  381 | TF_DEFINE_CHECK_OP_IMPL(Check_EQ,
      | ^~~~~~~~~~~~~~~~~~~~~~~
```
Apparently with the optimizer on these get optimized away and hence don't trigger the diagnostic.  This PR turns off the GCC sign-compare diagnostic for the TensorFlow include files.

#### PR validation:

Checked compilation following a "git cms-checkdeps -a".  Also checked that CLANG does not need any similar pragma (it doesn't issue a warning), and doesn't issue an error or warning for the GCC pragmas.  Since this is a purely technical change it shouldn't result in any performance changes.