### PR TITLE
fix lostTracks producer not setting lostInnerHits

### DIFF
--- a/PhysicsTools/PatAlgos/plugins/PATLostTracks.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATLostTracks.cc
@@ -251,6 +251,16 @@ void pat::PATLostTracks::addPackedCandidate(std::vector<pat::PackedCandidate>& c
     }
   }
 
+  pat::PackedCandidate::LostInnerHits lostHits = pat::PackedCandidate::noLostInnerHits;
+  int nlost = trk->hitPattern().numberOfLostHits(reco::HitPattern::MISSING_INNER_HITS);
+  if (nlost == 0) {
+    if (trk->hitPattern().hasValidHitInPixelLayer(PixelSubdetector::SubDetector::PixelBarrel, 1)) {
+      lostHits = pat::PackedCandidate::validHitInFirstPixelBarrelLayer;
+    }
+  } else {
+    lostHits = (nlost == 1 ? pat::PackedCandidate::oneLostInnerHit : pat::PackedCandidate::moreLostInnerHits);
+  }
+
   reco::Candidate::PolarLorentzVector p4(trk->pt(), trk->eta(), trk->phi(), mass);
   cands.emplace_back(
       pat::PackedCandidate(p4, trk->vertex(), trk->pt(), trk->eta(), trk->phi(), id, pvSlimmedColl, pvSlimmed.key()));
@@ -260,6 +270,7 @@ void pat::PATLostTracks::addPackedCandidate(std::vector<pat::PackedCandidate>& c
   else
     cands.back().setTrackHighPurity(false);
 
+  cands.back().setLostInnerHits(lostHits);
   if (trk->pt() > minPtToStoreProps_ || trkStatus == TrkStatus::VTX)
     cands.back().setTrackProperties(*trk, covarianceSchema_, covarianceVersion_);
   if (pvOrig.trackWeight(trk) > 0.5) {


### PR DESCRIPTION
#### PR description:

The lostTracks producer has a bug that leaves the `lostInnerHits` of the `PackedCandidate` unset (and thus at its default value of `validHitInFirstPixelBarrelLayer`). Other than in `lostInnerHits` the bug propagates in the number of valid pixel hits and the number of pixel and tracker layers with measurements in the `HitPattern` of the `bestTrack` of the candidate.

As agreed with xPOG and TAU POG ( @mariadalfonso  , @gouskos  , @mbluj  ), this PR fixes the bug by adding the call to `setLostInnerHits` as the code from the packedPFCandidates producer does. This fix has been checked running the workflow 136.8311 and the issue was solved (see attached figures in the PR on master).

#### PR validation:

This PR has been validated with `runTheMatrix.py -l limited -i all --ibeos` and all checks are ok.
The final output is
35 34 33 25 16 4 1 1 1 tests passed, 0 0 0 0 0 0 0 0 0 failed
In particular the DQM output of 136.8311 shows the differences which are expected: inside `Tracking/PackedCandidate/lostTracks`, in `diffLostInnerHits`, `diffHitPatternNumberOfLostPixelHits`, `diffHitPatternHasValidHitInFirstPixelBarrel`, `diffHitPatternNumberOfValidPixelHits`, `diffHitPatternPixelLayersWithMeasurement`, `diffHitPatternTrackerLayersWithMeasurement`, see the attached plots in the PR on master

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This PR is a backport of #32814, needed for the reminiAOD for HeavyIon.
