### PR TITLE
More esConsumes migration in the Alignment area

### DIFF
--- a/Alignment/HIPAlignmentAlgorithm/interface/LhcTrackAnalyzer.h
+++ b/Alignment/HIPAlignmentAlgorithm/interface/LhcTrackAnalyzer.h
@@ -2,9 +2,8 @@
 #define LhcTrackAnalyzer_h
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -51,7 +50,7 @@
 // class decleration
 //
 
-class LhcTrackAnalyzer : public edm::EDAnalyzer {
+class LhcTrackAnalyzer : public edm::one::EDAnalyzer<> {
 public:
   explicit LhcTrackAnalyzer(const edm::ParameterSet&);
   ~LhcTrackAnalyzer() override;

--- a/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeDQMModule.cc
+++ b/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeDQMModule.cc
@@ -13,29 +13,24 @@
 #include "TH1F.h"
 
 /*** Core framework functionality ***/
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
-
-/*** Geometry ***/
-#include "CondFormats/GeometryObjects/interface/PTrackerParameters.h"
-#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
-#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeomBuilderFromGeometricDet.h"
 
 /*** Alignment ***/
 #include "Alignment/MillePedeAlignmentAlgorithm/interface/PedeLabelerBase.h"
 #include "Alignment/MillePedeAlignmentAlgorithm/interface/PedeLabelerPluginFactory.h"
 #include "Alignment/TrackerAlignment/interface/AlignableTracker.h"
 
-/*** Thresholds from DB ***/
-#include "CondFormats/DataRecord/interface/AlignPCLThresholdsRcd.h"
-
 /*** Necessary Framework infrastructure ***/
 #include "FWCore/Framework/interface/ProcessBlock.h"
 #include "DataFormats/Alignment/interface/AlignmentToken.h"
 
 MillePedeDQMModule ::MillePedeDQMModule(const edm::ParameterSet& config)
-    : mpReaderConfig_(config.getParameter<edm::ParameterSet>("MillePedeFileReader")) {
+    : tTopoToken_(esConsumes<edm::Transition::BeginRun>()),
+      gDetToken_(esConsumes<edm::Transition::BeginRun>()),
+      ptpToken_(esConsumes<edm::Transition::BeginRun>()),
+      aliThrToken_(esConsumes<edm::Transition::BeginRun>()),
+      mpReaderConfig_(config.getParameter<edm::ParameterSet>("MillePedeFileReader")) {
   consumes<AlignmentToken, edm::InProcess>(config.getParameter<edm::InputTag>("alignmentTokenSrc"));
 }
 
@@ -89,25 +84,20 @@ void MillePedeDQMModule ::beginRun(const edm::Run&, const edm::EventSetup& setup
   if (!setupChanged(setup))
     return;
 
-  edm::ESHandle<TrackerTopology> tTopo;
-  setup.get<TrackerTopologyRcd>().get(tTopo);
-  edm::ESHandle<GeometricDet> geometricDet;
-  setup.get<IdealGeometryRecord>().get(geometricDet);
-  edm::ESHandle<PTrackerParameters> ptp;
-  setup.get<PTrackerParametersRcd>().get(ptp);
+  const TrackerTopology* const tTopo = &setup.getData(tTopoToken_);
+  const GeometricDet* geometricDet = &setup.getData(gDetToken_);
+  const PTrackerParameters* ptp = &setup.getData(ptpToken_);
 
   // take the thresholds from DB
-  edm::ESHandle<AlignPCLThresholds> thresholdHandle;
-  setup.get<AlignPCLThresholdsRcd>().get(thresholdHandle);
-  auto thresholds_ = thresholdHandle.product();
+  const auto& thresholds_ = &setup.getData(aliThrToken_);
 
   auto myThresholds = std::make_shared<AlignPCLThresholds>();
   myThresholds->setAlignPCLThresholds(thresholds_->getNrecords(), thresholds_->getThreshold_Map());
 
   TrackerGeomBuilderFromGeometricDet builder;
 
-  const auto trackerGeometry = builder.build(&(*geometricDet), *ptp, &(*tTopo));
-  tracker_ = std::make_unique<AlignableTracker>(trackerGeometry, &(*tTopo));
+  const auto trackerGeometry = builder.build(geometricDet, *ptp, tTopo);
+  tracker_ = std::make_unique<AlignableTracker>(trackerGeometry, tTopo);
 
   const std::string labelerPlugin{"PedeLabeler"};
   edm::ParameterSet labelerConfig{};

--- a/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeDQMModule.h
+++ b/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeDQMModule.h
@@ -24,6 +24,14 @@
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
+/*** Geometry ***/
+#include "CondFormats/GeometryObjects/interface/PTrackerParameters.h"
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeomBuilderFromGeometricDet.h"
+
+/*** Thresholds from DB ***/
+#include "CondFormats/DataRecord/interface/AlignPCLThresholdsRcd.h"
+
 /*** DQM ***/
 #include "DQMServices/Core/interface/DQMEDHarvester.h"
 #include "DQMServices/Core/interface/DQMStore.h"
@@ -67,6 +75,12 @@ private:  //===================================================================
 
   //========================== PRIVATE DATA ====================================
   //============================================================================
+
+  // esConsumes
+  const edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> tTopoToken_;
+  const edm::ESGetToken<GeometricDet, IdealGeometryRecord> gDetToken_;
+  const edm::ESGetToken<PTrackerParameters, PTrackerParametersRcd> ptpToken_;
+  const edm::ESGetToken<AlignPCLThresholds, AlignPCLThresholdsRcd> aliThrToken_;
 
   const edm::ParameterSet mpReaderConfig_;
   std::unique_ptr<AlignableTracker> tracker_;


### PR DESCRIPTION
#### PR description:

Part of https://github.com/cms-sw/cmssw/issues/31061

Packages migrated to esConsumes:
   * `Alignment/CommonAlignment`
   
Packages partially migrated:
   * `Alignment/HIPAlignmentAlgorithm`
   *  `Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeDQMModule.cc ` 

#### PR validation:

Compilation + `scramv1 b run tests` + `runTheMatrix.py -l 1001.0 -t 4`

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This PR is not a backport, no backport is needed.


