### PR TITLE
Move MessageLogger calls in DataFormat to source

### DIFF
--- a/DataFormats/GEMRecHit/interface/GEMCSCSegment.h
+++ b/DataFormats/GEMRecHit/interface/GEMCSCSegment.h
@@ -17,8 +17,6 @@
 #include "DataFormats/CSCRecHit/interface/CSCRecHit2DCollection.h"
 #include "DataFormats/CSCRecHit/interface/CSCSegmentCollection.h"
 
-#include "FWCore/MessageLogger/interface/MessageLogger.h"
-
 #include <iosfwd>
 
 class CSCDetId;
@@ -63,13 +61,7 @@ public:
 
   int degreesOfFreedom() const override { return 2 * nRecHits() - 4; }
 
-  int nRecHits() const {
-    return (theGEMRecHits.size() + theCSCSegment.specificRecHits().size());
-    edm::LogVerbatim("GEMCSCSegment") << "[GEMCSCSegment :: nRecHits] CSC RecHits: "
-                                      << theCSCSegment.specificRecHits().size()
-                                      << " + GEM RecHits: " << theGEMRecHits.size() << " = "
-                                      << (theGEMRecHits.size() + theCSCSegment.specificRecHits().size());
-  }
+  int nRecHits() const { return (theGEMRecHits.size() + theCSCSegment.specificRecHits().size()); }
 
   //--- Return the constituents in different ways
   const CSCSegment cscSegment() const { return theCSCSegment; }

--- a/DataFormats/GEMRecHit/src/GEMCSCSegment.cc
+++ b/DataFormats/GEMRecHit/src/GEMCSCSegment.cc
@@ -5,6 +5,7 @@
  */
 
 #include "DataFormats/GEMRecHit/interface/GEMCSCSegment.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include <iostream>
 
 namespace {

--- a/DataFormats/L1TCalorimeterPhase2/interface/CaloCrystalCluster.h
+++ b/DataFormats/L1TCalorimeterPhase2/interface/CaloCrystalCluster.h
@@ -7,7 +7,6 @@
 #include <algorithm>
 #include "DataFormats/L1Trigger/interface/L1Candidate.h"
 #include "DataFormats/DetId/interface/DetId.h"
-#include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 namespace l1tp2 {
 
@@ -66,7 +65,7 @@ namespace l1tp2 {
           looseL1TkMatchWP_(looseL1TkMatchWP),
           stage2effMatch_(stage2effMatch){};
 
-    virtual ~CaloCrystalCluster(){};
+    ~CaloCrystalCluster() override{};
     inline float calibratedPt() const { return calibratedPt_; };
     inline float hovere() const { return hovere_; };
     inline float isolation() const { return iso_; };
@@ -80,12 +79,12 @@ namespace l1tp2 {
     };
     void setExperimentalParams(const std::map<std::string, float> &params) { experimentalParams_ = params; };
     const std::map<std::string, float> &getExperimentalParams() const { return experimentalParams_; };
-    inline float experimentalParam(std::string name) const {
+    inline float experimentalParam(const std::string &name) const {
       auto iter = experimentalParams_.find(name);
       if (iter != experimentalParams_.end()) {
         return iter->second;
       } else {
-        edm::LogWarning("CaloCrystalCluster") << "Error: no mapping for ExperimentalParam: " << name << std::endl;
+        warningNoMapping(name);
         return -99.;
       }
     };
@@ -106,6 +105,7 @@ namespace l1tp2 {
     inline float crystalPt(unsigned int index) const { return (index < crystalPt_.size()) ? crystalPt_[index] : 0.; };
 
   private:
+    static void warningNoMapping(const std::string &name);
     // pT calibrated to Stage-2 (Phase-I) L1EG Objects.  NOTE
     // all working points are defined with respect to cluster.pt(),
     // not cluster.calibratedPt()

--- a/DataFormats/L1TCalorimeterPhase2/interface/CaloJet.h
+++ b/DataFormats/L1TCalorimeterPhase2/interface/CaloJet.h
@@ -6,7 +6,6 @@
 #include <string>
 #include <algorithm>
 #include "DataFormats/L1Trigger/interface/L1Candidate.h"
-#include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 namespace l1tp2 {
 
@@ -33,12 +32,13 @@ namespace l1tp2 {
       if (iter != experimentalParams_.end()) {
         return iter->second;
       } else {
-        edm::LogWarning("CaloJet") << "Error: no mapping for ExperimentalParam: " << name << std::endl;
+        warningNoMapping(name);
         return -99.;
       }
     };
 
   private:
+    static void warningNoMapping(std::string const&);
     // pT calibrated to get
     float calibratedPt_;
     // HCal energy in region behind cluster (for size, look in producer) / ECal energy in cluster

--- a/DataFormats/L1TCalorimeterPhase2/src/CaloCrystalCluster.cc
+++ b/DataFormats/L1TCalorimeterPhase2/src/CaloCrystalCluster.cc
@@ -1,0 +1,6 @@
+#include "DataFormats/L1TCalorimeterPhase2/interface/CaloCrystalCluster.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+void l1tp2::CaloCrystalCluster::warningNoMapping(const std::string& name) {
+  edm::LogWarning("CaloCrystalCluster") << "Error: no mapping for ExperimentalParam: " << name << std::endl;
+}

--- a/DataFormats/L1TCalorimeterPhase2/src/CaloJet.cc
+++ b/DataFormats/L1TCalorimeterPhase2/src/CaloJet.cc
@@ -1,0 +1,6 @@
+#include "DataFormats/L1TCalorimeterPhase2/interface/CaloJet.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+void l1tp2::CaloJet::warningNoMapping(std::string const& name) {
+  edm::LogWarning("CaloJet") << "Error: no mapping for ExperimentalParam: " << name << std::endl;
+}

--- a/DataFormats/L1TrackTrigger/interface/TTTrack.h
+++ b/DataFormats/L1TrackTrigger/interface/TTTrack.h
@@ -16,11 +16,14 @@
 #include "CLHEP/Units/GlobalPhysicalConstants.h"
 #include "DataFormats/L1TrackTrigger/interface/TTStub.h"
 #include "DataFormats/L1TrackTrigger/interface/TTTrack_TrackWord.h"
-#include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "DataFormats/Common/interface/DetSetVectorNew.h"
 #include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
 #include "DataFormats/SiStripDetId/interface/StripSubdetector.h"
 #include "DataFormats/Phase2TrackerDigi/interface/Phase2TrackerDigi.h"
+
+namespace tttrack {
+  void errorSetTrackWordBits(unsigned int);
+}
 
 template <typename T>
 class TTTrack : public TTTrack_TrackWord {
@@ -402,8 +405,7 @@ void TTTrack<T>::setBField(double aBField) {
 template <typename T>
 void TTTrack<T>::setTrackWordBits() {
   if (!(theNumFitPars_ == Npars4 || theNumFitPars_ == Npars5)) {
-    edm::LogError("TTTrack") << " setTrackWordBits method is called with theNumFitPars_=" << theNumFitPars_
-                             << " only possible values are 4/5" << std::endl;
+    tttrack::errorSetTrackWordBits(theNumFitPars_);
     return;
   }
 

--- a/DataFormats/L1TrackTrigger/src/TTTrack.cc
+++ b/DataFormats/L1TrackTrigger/src/TTTrack.cc
@@ -1,0 +1,7 @@
+#include "DataFormats/L1TrackTrigger/interface/TTTrack.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+void tttrack::errorSetTrackWordBits(unsigned int theNumFitPars) {
+  edm::LogError("TTTrack") << " setTrackWordBits method is called with theNumFitPars_=" << theNumFitPars
+                           << " only possible values are 4/5" << std::endl;
+}

--- a/DataFormats/TrackerRecHit2D/src/SiPixelRecHitQuality.cc
+++ b/DataFormats/TrackerRecHit2D/src/SiPixelRecHitQuality.cc
@@ -52,3 +52,25 @@ SiPixelRecHitQuality::Packing::Packing() {
 
 //  Initialize the packing format singleton
 const SiPixelRecHitQuality::Packing SiPixelRecHitQuality::thePacking;
+
+void SiPixelRecHitQuality::warningObsolete() {
+  edm::LogWarning("ObsoleteVariable")
+      << "Since 39x, probabilityX and probabilityY have been replaced by probabilityXY and probabilityQ";
+}
+
+void SiPixelRecHitQuality::warningOutOfBoundQbin(int iValue, QualWordType const& iQualWord) {
+  edm::LogWarning("OutOfBounds") << "Qbin outside the bounds of the quality word. Defaulting to Qbin=0. Qbin = "
+                                 << iValue << " QualityWord = " << iQualWord;
+}
+
+void SiPixelRecHitQuality::warningOutOfBoundProb(const char* iName, float iProb, QualWordType const& iQualWord) {
+  edm::LogWarning("OutOfBounds") << "Prob " << iName
+                                 << " outside the bounds of the quality word. Defaulting to Prob=0. Prob = " << iProb
+                                 << " QualityWord = " << iQualWord;
+}
+
+void SiPixelRecHitQuality::warningOutOfBoundRaw(const char* iName, int iRaw, QualWordType const& iQualWord) {
+  edm::LogWarning("OutOfBounds") << "Probability " << iName
+                                 << " outside the bounds of the quality word. Defaulting to Prob=0. Raw = " << iRaw
+                                 << " QualityWord = " << iQualWord;
+}

--- a/HLTriggerOffline/Higgs/src/EVTColContainer.cc
+++ b/HLTriggerOffline/Higgs/src/EVTColContainer.cc
@@ -32,6 +32,7 @@
 #include "DataFormats/JetReco/interface/PFJet.h"
 #include "DataFormats/JetReco/interface/PFJetCollection.h"
 #include "DataFormats/BTauReco/interface/JetTag.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include <vector>
 #include <map>

--- a/L1Trigger/L1CaloTrigger/BuildFile.xml
+++ b/L1Trigger/L1CaloTrigger/BuildFile.xml
@@ -1,4 +1,5 @@
 <use name="FWCore/ParameterSet"/>
+<use name="DataFormats/L1TCalorimeterPhase2"/>
 <use   name="clhep"/>
 
 <export> 

--- a/L1Trigger/Phase2L1ParticleFlow/plugins/L1TPFProducer.cc
+++ b/L1Trigger/Phase2L1ParticleFlow/plugins/L1TPFProducer.cc
@@ -11,6 +11,7 @@
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSet/interface/FileInPath.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include "DataFormats/Common/interface/View.h"
 #include "DataFormats/L1TParticleFlow/interface/PFCandidate.h"

--- a/RecoLocalTracker/SubCollectionProducers/src/ClusterChargeMasker.cc
+++ b/RecoLocalTracker/SubCollectionProducers/src/ClusterChargeMasker.cc
@@ -2,6 +2,7 @@
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/InputTag.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include "DataFormats/SiStripCluster/interface/SiStripCluster.h"
 #include "DataFormats/SiPixelCluster/interface/SiPixelCluster.h"


### PR DESCRIPTION
#### PR description:

Moved all MessageLogger calls being made in the header files to be done in the source file. This meant creating new functions which hide the calls.

#### PR validation:

The code compiles and all `git cms-checkdeps -a` packages also compile.