### PR TITLE
Minor improvement to TritonService

### DIFF
--- a/HeterogeneousCore/SonicTriton/README.md
+++ b/HeterogeneousCore/SonicTriton/README.md
@@ -94,7 +94,7 @@ The script has two operations (`start` and `stop`) and the following options:
 * `-m [dir]`: specific model directory (can be given more than one)
 * `-n [name]`: name of container instance, also used for hidden temporary dir (default: triton_server_instance)
 * `-P [port]`: base port number for services (-1: automatically find an unused port range) (default: 8000)
-* `-p`: automatically shut down server when parent process ends
+* `-p [pid]`: automatically shut down server when process w/ specified PID ends (-1: use parent process PID)
 * `-r [num]`: number of retries when starting container (default: 3)
 * `-s [dir]`: Singularity sandbox directory (default: /cvmfs/unpacked.cern.ch/registry.hub.docker.com/fastml/triton-torchgeo:20.09-py3-geometric)
 * `-t [dir]`: non-default hidden temporary dir

--- a/HeterogeneousCore/SonicTriton/scripts/cmsTriton
+++ b/HeterogeneousCore/SonicTriton/scripts/cmsTriton
@@ -36,7 +36,7 @@ usage() {
 	$ECHO "-m [dir]    \t specific model directory (can be given more than one)"
 	$ECHO "-n [name]   \t name of container instance, also used for default hidden temporary dir (default: ${SERVER})"
 	$ECHO "-P [port]   \t base port number for services (-1: automatically find an unused port range) (default: ${BASEPORT})"
-	$ECHO "-p          \t automatically shut down server when parent process ends"
+	$ECHO "-p [pid]    \t automatically shut down server when process w/ specified PID ends (-1: use parent process PID)"
 	$ECHO "-r [num]    \t number of retries when starting container (default: ${RETRIES})"
 	$ECHO "-s [dir]    \t Singularity sandbox directory (default: ${SANDBOX})"
 	$ECHO "-t [dir]    \t non-default hidden temporary dir"
@@ -56,7 +56,7 @@ if [ -e /run/shm ]; then
 	SHM=/run/shm
 fi
 
-while getopts "cDdfgi:M:m:n:P:pr:s:t:vw:h" opt; do
+while getopts "cDdfgi:M:m:n:P:p:r:s:t:vw:h" opt; do
 	case "$opt" in
 		c) CLEANUP=""
 		;;
@@ -78,7 +78,7 @@ while getopts "cDdfgi:M:m:n:P:pr:s:t:vw:h" opt; do
 		;;
 		P) if [ "$OPTARG" -eq -1 ]; then AUTOPORT=true; else BASEPORT="$OPTARG"; fi
 		;;
-		p) PARENTPID="$PPID"
+		p) if [ "$OPTARG" -eq -1 ]; then PARENTPID="$PPID"; else PARENTPID="$OPTARG"; fi
 		;;
 		r) RETRIES="$OPTARG"
 		;;
@@ -297,13 +297,25 @@ auto_stop(){
 	PARENTPID="$2"
 
 	if [ -n "$PARENTPID" ]; then
+		if [ -n "$VERBOSE" ]; then
+			echo "watching PID $PARENTPID"
+			ps
+		fi
 		PCOUNTER=0
 		PMAX=5
 		while [ "$PCOUNTER" -le "$PMAX" ]; do
 			if ! kill -0 $PARENTPID >& /dev/null; then
 				PCOUNTER=$((PCOUNTER+1))
+				if [ -n "$VERBOSE" ]; then
+					echo "trigger $PCOUNTER:"
+					ps
+				fi
 			else
-				# must get 5 in a row, otherwise reset
+				# must get N in a row, otherwise reset
+				if [ "$PCOUNTER" -gt 0 ] && [ -n "$VERBOSE" ]; then
+					echo "reset:"
+					ps
+				fi
 				PCOUNTER=0
 			fi
 			sleep 1

--- a/HeterogeneousCore/SonicTriton/src/TritonService.cc
+++ b/HeterogeneousCore/SonicTriton/src/TritonService.cc
@@ -18,6 +18,7 @@
 #include <filesystem>
 #include <utility>
 #include <tuple>
+#include <unistd.h>
 
 namespace ni = nvidia::inferenceserver;
 namespace nic = ni::client;
@@ -207,7 +208,7 @@ void TritonService::preBeginJob(edm::PathsAndConsumesOfModulesBase const&, edm::
   }
 
   //assemble server start command
-  std::string command("cmsTriton -p -P -1");
+  std::string command("cmsTriton -P -1 -p " + std::to_string(::getpid()));
   if (fallbackOpts_.debug)
     command += " -c";
   if (fallbackOpts_.verbose)


### PR DESCRIPTION
#### PR description:

While testing an algorithm with a significantly longer inference time than the one used for the SonicTriton unit test, I re-encountered the issue with the fallback server shutting down too early.

Adding some debugging info to `auto_stop`, I found that using `$PPID` for the fallback server did not actually get the PID of the `cmsRun` process, but rather the `sh` process spawned by the `popen` call. Apparently, this `sh` process hangs around long enough for the unit test to complete, if `auto_stop` is delayed by a few seconds (in the case of Singularity reading from cvmfs, which is slightly slower than a local read). However, this is not reliable or general.

Instead, I now pass the `cmsRun` PID directly when starting the fallback server. This works to avoid the previous failure (tested by setting `PMAX=1` in `cmsTriton`). I've retained the value `PMAX=5` in this PR just in case some other instability might arise.

#### PR validation:

Reran stress tests from #32576.

@makortel @silviodonato @qliphy it would be nice to get this into pre3 if the deadline has not passed (it's really just a minor bug fix).