### PR TITLE
Make units dd4hep-dependent in Run3 Tracker algo

### DIFF
--- a/Geometry/TrackerCommonData/plugins/dd4hep/DDTECModuleAlgo.cc
+++ b/Geometry/TrackerCommonData/plugins/dd4hep/DDTECModuleAlgo.cc
@@ -1,4 +1,5 @@
 #include "DD4hep/DetFactoryHelper.h"
+#include <DD4hep/DD4hepUnits.h>
 #include "DataFormats/Math/interface/angle_units.h"
 #include "DetectorDescription/DDCMS/interface/DDPlugins.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"

--- a/Geometry/TrackerCommonData/plugins/dd4hep/DDTECModuleAlgo.cc
+++ b/Geometry/TrackerCommonData/plugins/dd4hep/DDTECModuleAlgo.cc
@@ -1,12 +1,12 @@
 #include "DD4hep/DetFactoryHelper.h"
-#include "DataFormats/Math/interface/CMSUnits.h"
+#include "DataFormats/Math/interface/angle_units.h"
 #include "DetectorDescription/DDCMS/interface/DDPlugins.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 using namespace std;
 using namespace dd4hep;
 using namespace cms;
-using namespace cms_units::operators;
+using namespace angle_units::operators;
 
 static long algorithm(Detector& /* description */, cms::DDParsingContext& ctxt, xml_h e) {
   cms::DDNamespace ns(ctxt, e, true);
@@ -216,7 +216,7 @@ static long algorithm(Detector& /* description */, cms::DDParsingContext& ctxt, 
     xpos = -0.5 * topFrameBotWidth + bl2 * cos(detTilt) + dz * sin(fabs(thet) + detTilt) / cos(fabs(thet));
     xpos = -xpos;
     zpos = topFrameEndZ - topFrame2LHeight - 0.5 * sin(detTilt) * (topFrameBotWidth - topFrame2Width) -
-           dz * cos(detTilt + fabs(thet)) / cos(fabs(thet)) + bl2 * sin(detTilt) - 0.1_mm;
+           dz * cos(detTilt + fabs(thet)) / cos(fabs(thet)) + bl2 * sin(detTilt) - 0.1 * dd4hep::mm;
   }
   //position
   mother.placeVolume(
@@ -252,7 +252,7 @@ static long algorithm(Detector& /* description */, cms::DDParsingContext& ctxt, 
     xpos = 0.5 * topFrameBotWidth - bl2 * cos(detTilt) - dz * sin(fabs(detTilt - fabs(thet))) / cos(fabs(thet));
     xpos = -xpos;
     zpos = topFrameEndZ - topFrame2RHeight + 0.5 * sin(detTilt) * (topFrameBotWidth - topFrame2Width) -
-           dz * cos(detTilt - fabs(thet)) / cos(fabs(thet)) - bl2 * sin(detTilt) - 0.1_mm;
+           dz * cos(detTilt - fabs(thet)) / cos(fabs(thet)) - bl2 * sin(detTilt) - 0.1 * dd4hep::mm;
   }
   //position it
   mother.placeVolume(

--- a/Geometry/TrackerCommonData/plugins/dd4hep/DDTIBLayerAlgo.cc
+++ b/Geometry/TrackerCommonData/plugins/dd4hep/DDTIBLayerAlgo.cc
@@ -1,12 +1,12 @@
 #include "DD4hep/DetFactoryHelper.h"
-#include "DataFormats/Math/interface/CMSUnits.h"
+#include "DataFormats/Math/interface/angle_units.h"
 #include "DetectorDescription/DDCMS/interface/DDPlugins.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 using namespace std;
 using namespace dd4hep;
 using namespace cms;
-using namespace cms_units::operators;
+using namespace angle_units::operators;
 
 static long algorithm(Detector& /* description */, cms::DDParsingContext& context, xml_h element) {
   using VecDouble = vector<double>;
@@ -249,12 +249,12 @@ static long algorithm(Detector& /* description */, cms::DDParsingContext& contex
     name = idName + "Rib" + std::to_string(i);
     double width = 2. * ribW[i] / (rin + rout);
     double dz = 0.5 * layerL - 2. * fillerDz;
-    double _rmi = std::min(rin + 0.5_mm, rout - 0.5_mm);
-    double _rma = std::max(rin + 0.5_mm, rout - 0.5_mm);
+    double _rmi = std::min(rin + 0.5 * dd4hep::mm, rout - 0.5 * dd4hep::mm);
+    double _rma = std::max(rin + 0.5 * dd4hep::mm, rout - 0.5 * dd4hep::mm);
     solid = ns.addSolidNS(name, Tube(_rmi, _rma, dz, -0.5 * width, width));
     LogDebug("TIBGeom") << solid.name() << " Tubs made of " << ribMat << " from " << -0.5 * convertRadToDeg(width)
-                        << " to " << 0.5 * convertRadToDeg(width) << " with Rin " << rin + 0.5_mm << " Rout "
-                        << rout - 0.5_mm << " ZHalf " << dz;
+                        << " to " << 0.5 * convertRadToDeg(width) << " with Rin " << rin + 0.5 * dd4hep::mm << " Rout "
+                        << rout - 0.5 * dd4hep::mm << " ZHalf " << dz;
     Volume cylinderRib = ns.addVolumeNS(Volume(name, solid, matrib));
     double phix = ribPhi[i];
     double theta = 90_deg;

--- a/Geometry/TrackerCommonData/plugins/dd4hep/DDTIBLayerAlgo.cc
+++ b/Geometry/TrackerCommonData/plugins/dd4hep/DDTIBLayerAlgo.cc
@@ -1,4 +1,5 @@
 #include "DD4hep/DetFactoryHelper.h"
+#include <DD4hep/DD4hepUnits.h>
 #include "DataFormats/Math/interface/angle_units.h"
 #include "DetectorDescription/DDCMS/interface/DDPlugins.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"

--- a/Geometry/TrackerNumberingBuilder/plugins/DDDCmsTrackerContruction.cc
+++ b/Geometry/TrackerNumberingBuilder/plugins/DDDCmsTrackerContruction.cc
@@ -44,7 +44,7 @@ std::unique_ptr<GeometricDet> DDDCmsTrackerContruction::construct(const DDCompac
   theCmsTrackerDetIdBuilder.buildId(*tracker);
 
   if (DEBUG) {
-    printAllTrackerGeometricDetsBeforeDetIDBuilding(tracker.get());
+    printAllTrackerGeometricDets(tracker.get());
   }
 
   fv.parent();
@@ -88,7 +88,7 @@ std::unique_ptr<GeometricDet> DDDCmsTrackerContruction::construct(const cms::DDC
   theCmsTrackerDetIdBuilder.buildId(*tracker);
 
   if (DEBUG) {
-    printAllTrackerGeometricDetsBeforeDetIDBuilding(tracker.get());
+    printAllTrackerGeometricDets(tracker.get());
   }
 
   return tracker;
@@ -100,7 +100,7 @@ std::unique_ptr<GeometricDet> DDDCmsTrackerContruction::construct(const cms::DDC
  * and all GeometricDets are sorted according to their geometric position.
  * This allows a convenient debugging, as the DetIds will be later assigned according to this information.
  */
-void DDDCmsTrackerContruction::printAllTrackerGeometricDetsBeforeDetIDBuilding(const GeometricDet* tracker) {
+void DDDCmsTrackerContruction::printAllTrackerGeometricDets(const GeometricDet* tracker) {
   std::ofstream outputFile("All_Tracker_GeometricDets_before_DetId_building.log", std::ios::out);
 
   // Tree navigation: queue for BFS (we want to see same hierarchy level together).

--- a/Geometry/TrackerNumberingBuilder/plugins/DDDCmsTrackerContruction.h
+++ b/Geometry/TrackerNumberingBuilder/plugins/DDDCmsTrackerContruction.h
@@ -22,7 +22,7 @@ namespace cms {
 namespace DDDCmsTrackerContruction {
   std::unique_ptr<GeometricDet> construct(DDCompactView const& cpv, std::vector<int> const& detidShifts);
   std::unique_ptr<GeometricDet> construct(cms::DDCompactView const& cpv, std::vector<int> const& detidShifts);
-  void printAllTrackerGeometricDetsBeforeDetIDBuilding(const GeometricDet* tracker);
+  void printAllTrackerGeometricDets(const GeometricDet* tracker);
 };  // namespace DDDCmsTrackerContruction
 
 #endif


### PR DESCRIPTION
Make units dd4hep-dependent.
This is in preparation of DD4hep unit change.

@cvuosalo @civanch @ianna 

Tested against all regressions: compared all coordinates.