### PR TITLE
Add additional checks for seed candidate masking to deal with HCAL geometry complications

### DIFF
--- a/RecoParticleFlow/PFClusterProducer/plugins/LocalMaximumSeedFinder.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/LocalMaximumSeedFinder.cc
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <queue>
 #include <cfloat>
+#include "DataFormats/Math/interface/deltaPhi.h"
 #include "CommonTools/Utils/interface/DynArray.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
@@ -155,8 +156,8 @@ void LocalMaximumSeedFinder::findSeeds(const edm::Handle<reco::PFRecHitCollectio
             auto const& nei = (*input)[neighbour];
             if (maybeseed.depth() != nei.depth())
               continue;  // masking is done only if the neighbor is on the same depth layer as the seed
-            if ((abs(deltaPhi(maybeseed.positionREP().phi(), nei.positionREP().phi())) > dphicut) &&
-                (abs(maybeseed.positionREP().eta() - nei.positionREP().eta()) > detacut))
+            if (std::abs(deltaPhi(maybeseed.positionREP().phi(), nei.positionREP().phi())) > dphicut &&
+                std::abs(maybeseed.positionREP().eta() - nei.positionREP().eta()) > detacut)
               continue;  // masking is done only if the neighbor is on the swiss-cross w.r.t. the seed
             break;
         }

--- a/RecoParticleFlow/PFClusterProducer/plugins/LocalMaximumSeedFinder.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/LocalMaximumSeedFinder.cc
@@ -140,8 +140,30 @@ void LocalMaximumSeedFinder::findSeeds(const edm::Handle<reco::PFRecHitCollectio
     }
     if (seedable[idx]) {
       for (auto neighbour : myNeighbours) {
+        //
+        // For HCAL,
+        // even if channel a is a neighbor of channel b, channel b may not be a neighbor of channel a.
+        // So, perform additional checks to ensure making a hit unusable for seeding is safe.
+        int seedlayer = (int)maybeseed.layer();
+        switch (seedlayer) {
+          case PFLayer::HCAL_BARREL1:
+          case PFLayer::HCAL_ENDCAP:
+          case PFLayer::HF_EM:   // with the current HF setting, we won't see this case
+                                 // but this can come in if we change _nNeighbours for HF.
+          case PFLayer::HF_HAD:  // same as above
+            // HO has only one depth and eta-phi segmentation is regular, so no need to make this check
+            auto const& nei = (*input)[neighbour];
+            if (maybeseed.depth() != nei.depth())
+              continue;  // masking is done only if the neighbor is on the same depth layer as the seed
+            if ((abs(deltaPhi(maybeseed.positionREP().phi(), nei.positionREP().phi())) > dphicut) &&
+                (abs(maybeseed.positionREP().eta() - nei.positionREP().eta()) > detacut))
+              continue;  // masking is done only if the neighbor is on the swiss-cross w.r.t. the seed
+            break;
+        }
+
         usable[neighbour] = false;
-      }
+
+      }  // for-loop
     }
   }
 

--- a/RecoParticleFlow/PFClusterProducer/plugins/LocalMaximumSeedFinder.h
+++ b/RecoParticleFlow/PFClusterProducer/plugins/LocalMaximumSeedFinder.h
@@ -1,6 +1,7 @@
 #ifndef __LocalMaximumSeedFinder_H__
 #define __LocalMaximumSeedFinder_H__
 
+#include "DataFormats/Math/interface/deltaPhi.h"
 #include "RecoParticleFlow/PFClusterProducer/interface/SeedFinderBase.h"
 
 #include <unordered_map>
@@ -25,6 +26,9 @@ private:
 
   std::array<I3tuple, 35> _thresholds;
   static constexpr int layerOffset = 15;
+
+  static constexpr double detacut = 0.01;
+  static constexpr double dphicut = 0.01;
 };
 
 DEFINE_EDM_PLUGIN(SeedFinderFactory, LocalMaximumSeedFinder, "LocalMaximumSeedFinder");

--- a/RecoParticleFlow/PFClusterProducer/plugins/LocalMaximumSeedFinder.h
+++ b/RecoParticleFlow/PFClusterProducer/plugins/LocalMaximumSeedFinder.h
@@ -1,7 +1,6 @@
 #ifndef __LocalMaximumSeedFinder_H__
 #define __LocalMaximumSeedFinder_H__
 
-#include "DataFormats/Math/interface/deltaPhi.h"
 #include "RecoParticleFlow/PFClusterProducer/interface/SeedFinderBase.h"
 
 #include <unordered_map>


### PR DESCRIPTION
Add additional checks for seed candidate masking to deal with HCAL geometry complications (phi segmentation and depth segmentation change versus eta).

#### PR description:

This PR will fix some logical flaw in channel masking used for PF clustering seed finder. When we look for a clustering seed, for HCAL, we usually look at 4 neighbors along swiss-cross, and if the seed-candidate has higher energy than the 4 neighbors, the seed-candidate becomes seed, and neighbors get masked from becoming seed candidates. However, in HCAL, this logic causes complications (1) when the depth segmentation changes from one ieta to another ieta, (2) when the phi segmentation changes from one ieta to another ieta. In such boundary area, even if a channel A is one of four neighbors of channel B, the channel B may not be one of four neighbors of channel A.

Now, this channel masking will be done, in the case of HB/HE/HF, only when the neighbors are strictly on the same depth layer and has the same eta or phi. Then, the seed finder channel masking will happen only when two channels are neighbors for each other.

This change will make the seed finder of this CPU code and the seed finder of the GPU code (under development) consistent and address issues reported on page-15 of:
https://indico.cern.ch/event/986788/contributions/4155121/attachments/2165561/3654817/PFClusterGPUV4.pdf

#### PR validation:

The usual PF validation plots from **Mark Saunders**: @zeratul87 without and with this PR.
http://hep.baylor.edu/msaunder/PFval/HCAL_validation_plots
There are some differences in the endcap, but don't look significant.

In addition, 
![deltaSumSeed](https://user-images.githubusercontent.com/5814980/107591258-d58b2380-6bcf-11eb-8320-01bdffd7765c.png)
shows that, with this PR, we can get a perfect agreement between CPU and GPU seed finders (thx M. Saunders)

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This is not backport.

@bendavid @jsalfeld @zeratul87
