### PR TITLE
Add SV charge

### DIFF
--- a/PhysicsTools/NanoAOD/plugins/VertexTableProducer.cc
+++ b/PhysicsTools/NanoAOD/plugins/VertexTableProducer.cc
@@ -172,18 +172,17 @@ void VertexTableProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSe
         dxy.push_back(d2d.value());
         dxySig.push_back(d2d.significance());
 
-	int sum_charge = 0;
-	for (unsigned int id=0; id<sv.numberOfDaughters(); ++id) {
-	  const reco::Candidate* daughter = sv.daughter(id);
-	  sum_charge += daughter->charge(); 
-	}
-	charge.push_back(sum_charge);
+        int sum_charge = 0;
+        for (unsigned int id = 0; id < sv.numberOfDaughters(); ++id) {
+          const reco::Candidate* daughter = sv.daughter(id);
+          sum_charge += daughter->charge();
+        }
+        charge.push_back(sum_charge);
       }
     }
     i++;
   }
 
-    
   auto svsTable = std::make_unique<nanoaod::FlatTable>(selCandSv->size(), svName_, false);
   // For SV we fill from here only stuff that cannot be created with the SimpleFlatTableProducer
   svsTable->addColumn<float>("dlen", dlen, "decay length in cm", 10);
@@ -192,7 +191,7 @@ void VertexTableProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSe
   svsTable->addColumn<float>("dxySig", dxySig, "2D decay length significance", 10);
   svsTable->addColumn<float>("pAngle", pAngle, "pointing angle, i.e. acos(p_SV * (SV - PV)) ", 10);
   svsTable->addColumn<int>("charge", charge, "sum of the charge of the SV tracks", 10);
-  
+
   iEvent.put(std::move(pvTable), "pv");
   iEvent.put(std::move(otherPVsTable), "otherPVs");
   iEvent.put(std::move(svsTable), "svs");

--- a/PhysicsTools/NanoAOD/plugins/VertexTableProducer.cc
+++ b/PhysicsTools/NanoAOD/plugins/VertexTableProducer.cc
@@ -171,18 +171,19 @@ void VertexTableProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSe
             PV0, VertexState(RecoVertex::convertPos(sv.position()), RecoVertex::convertError(sv.error())));
         dxy.push_back(d2d.value());
         dxySig.push_back(d2d.significance());
-      }
 
-      int sum_charge = 0;
-      for (unsigned int id=0; id<sv.numberOfDaughters(); ++id) {
-	const reco::Candidate* daughter = sv.daughter(id);
-	sum_charge += daughter->charge(); 
+	int sum_charge = 0;
+	for (unsigned int id=0; id<sv.numberOfDaughters(); ++id) {
+	  const reco::Candidate* daughter = sv.daughter(id);
+	  sum_charge += daughter->charge(); 
+	}
+	charge.push_back(sum_charge);
       }
-      charge.push_back(sum_charge);
     }
     i++;
   }
 
+    
   auto svsTable = std::make_unique<nanoaod::FlatTable>(selCandSv->size(), svName_, false);
   // For SV we fill from here only stuff that cannot be created with the SimpleFlatTableProducer
   svsTable->addColumn<float>("dlen", dlen, "decay length in cm", 10);
@@ -190,7 +191,7 @@ void VertexTableProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSe
   svsTable->addColumn<float>("dxy", dxy, "2D decay length in cm", 10);
   svsTable->addColumn<float>("dxySig", dxySig, "2D decay length significance", 10);
   svsTable->addColumn<float>("pAngle", pAngle, "pointing angle, i.e. acos(p_SV * (SV - PV)) ", 10);
-  svsTable->addColumn<float>("charge", charge, "sum of the charge of the SV tracks", 10);
+  svsTable->addColumn<int>("charge", charge, "sum of the charge of the SV tracks", 10);
   
   iEvent.put(std::move(pvTable), "pv");
   iEvent.put(std::move(otherPVsTable), "otherPVs");

--- a/PhysicsTools/NanoAOD/plugins/VertexTableProducer.cc
+++ b/PhysicsTools/NanoAOD/plugins/VertexTableProducer.cc
@@ -41,12 +41,6 @@
 #include "RecoVertex/VertexPrimitives/interface/VertexState.h"
 #include "DataFormats/Common/interface/ValueMap.h"
 
-#include "DataFormats/Candidate/interface/LeafCandidate.h"
-#include "DataFormats/Candidate/interface/CompositePtrCandidate.h"
-#include "DataFormats/Candidate/interface/CandidateFwd.h"
-#include "DataFormats/Candidate/interface/VertexCompositePtrCandidate.h"
-#include "DataFormats/PatCandidates/interface/PackedCandidate.h"
-
 //
 // class declaration
 //

--- a/PhysicsTools/NanoAOD/python/nanoDQM_cfi.py
+++ b/PhysicsTools/NanoAOD/python/nanoDQM_cfi.py
@@ -669,6 +669,7 @@ nanoDQM = DQMEDAnalyzer("NanoAODDQM",
                 Plot1D('y', 'y', 20, -0.5, 0.5, 'secondary vertex Y position, in cm'),
                 Plot1D('z', 'z', 20, -10, 10, 'secondary vertex Z position, in cm'),
                 Plot1D('ntracks', 'ntracks', 11, -0.5, 10.5, 'number of tracks'),
+                Plot1D('charge', 'charge',11 , -0.5, 10.5, 'sum of the charge of the SV tracks'),
             )
         ),
         SoftActivityJet = cms.PSet(

--- a/PhysicsTools/NanoAOD/python/nanoDQM_cfi.py
+++ b/PhysicsTools/NanoAOD/python/nanoDQM_cfi.py
@@ -669,7 +669,7 @@ nanoDQM = DQMEDAnalyzer("NanoAODDQM",
                 Plot1D('y', 'y', 20, -0.5, 0.5, 'secondary vertex Y position, in cm'),
                 Plot1D('z', 'z', 20, -10, 10, 'secondary vertex Z position, in cm'),
                 Plot1D('ntracks', 'ntracks', 11, -0.5, 10.5, 'number of tracks'),
-                Plot1D('charge', 'charge',11 , -0.5, 10.5, 'sum of the charge of the SV tracks'),
+                Plot1D('charge', 'charge', 11 , -0.5, 10.5, 'sum of the charge of the SV tracks'),
             )
         ),
         SoftActivityJet = cms.PSet(


### PR DESCRIPTION
#### PR description:
Add the sum of the charge of the tracks associated to each SV.
Needed for BTV, Charm tagging calibration in the W+c channel.

#### PR validation:
Inspected output after running:
cmsDriver.py test_nanoTuples_mc2017 -n 10 --mc --eventcontent NANOAODSIM --datatier NANOAODSIM --conditions auto:phase1_2017_realistic --step NANO --nThreads 1 --era Run2_2017,run2_nanoAOD_106Xv1 --filein /store/mc/RunIISummer19UL17MiniAOD/TTToSemiLeptonic_TuneCP5CR2_13TeV-powheg-pythia8/MINIAODSIM/106X_mc2017_realistic_v6-v1/10000/466694A9-3806-624C-87A0-97C8379FAD23.root --fileout file:nano_mc2017.root --customise_commands "process.options.wantSummary = cms.untracked.bool(True)"

Increase on the nanoAOD size/evt and time/evt negligible.