### PR TITLE
CSCShowerDigi format and producer (HST-I)

### DIFF
--- a/DataFormats/CSCDigi/interface/CSCShowerDigi.h
+++ b/DataFormats/CSCDigi/interface/CSCShowerDigi.h
@@ -1,0 +1,43 @@
+#ifndef CSCDigi_CSCShowerDigi_h
+#define CSCDigi_CSCShowerDigi_h
+
+#include <cstdint>
+#include <iosfwd>
+#include <limits>
+#include <vector>
+
+class CSCShowerDigi {
+public:
+  // Run-3 definitions as provided in DN-20-033
+  enum Run3Shower { kInvalid = 0, kLoose = 1, kNominal = 2, kTight = 3 };
+
+  /// Constructors
+  CSCShowerDigi(const uint8_t bits, const uint16_t cscID);
+
+  /// default
+  CSCShowerDigi();
+
+  // any loose shower is valid
+  bool isValid() const;
+
+  /// data
+  uint16_t bits() const { return bits_; }
+  bool isLoose() const;
+  bool isNominal() const;
+  bool isTight() const;
+
+  // trigger chamber
+  uint16_t getCSCID() const { return cscID_; }
+
+  /// set trigger chamber
+  void setCSCID(const uint16_t c) { cscID_ = c; }
+
+private:
+  // 4 bits hit counter
+  uint8_t bits_;
+  // 4-bit CSC chamber identifier
+  uint8_t cscID_;
+};
+
+std::ostream& operator<<(std::ostream& o, const CSCShowerDigi& digi);
+#endif

--- a/DataFormats/CSCDigi/interface/CSCShowerDigiCollection.h
+++ b/DataFormats/CSCDigi/interface/CSCShowerDigiCollection.h
@@ -1,0 +1,10 @@
+#ifndef DataFormats_CSCDigi_CSCShowerDigiCollection_h
+#define DataFormats_CSCDigi_CSCShowerDigiCollection_h
+
+#include "DataFormats/MuonDetId/interface/CSCDetId.h"
+#include "DataFormats/CSCDigi/interface/CSCShowerDigi.h"
+#include "DataFormats/MuonData/interface/MuonDigiCollection.h"
+
+typedef MuonDigiCollection<CSCDetId, CSCShowerDigi> CSCShowerDigiCollection;
+
+#endif

--- a/DataFormats/CSCDigi/src/CSCShowerDigi.cc
+++ b/DataFormats/CSCDigi/src/CSCShowerDigi.cc
@@ -1,0 +1,24 @@
+#include "DataFormats/CSCDigi/interface/CSCShowerDigi.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include <iomanip>
+#include <iostream>
+
+using namespace std;
+
+/// Constructors
+CSCShowerDigi::CSCShowerDigi(const uint8_t bits, const uint16_t cscID) : bits_(bits), cscID_(cscID) {}
+
+/// Default
+CSCShowerDigi::CSCShowerDigi() : bits_(0), cscID_(0) {}
+
+bool CSCShowerDigi::isValid() const {
+  return isLoose();
+}
+
+bool CSCShowerDigi::isLoose() const { return bits_ >= kLoose; }
+
+bool CSCShowerDigi::isNominal() const { return bits_ >= kNominal; }
+
+bool CSCShowerDigi::isTight() const { return bits_ >= kTight; }
+
+std::ostream& operator<<(std::ostream& o, const CSCShowerDigi& digi) { return o << "CSC Shower: " << digi.bits(); }

--- a/DataFormats/CSCDigi/src/CSCShowerDigi.cc
+++ b/DataFormats/CSCDigi/src/CSCShowerDigi.cc
@@ -11,9 +11,7 @@ CSCShowerDigi::CSCShowerDigi(const uint8_t bits, const uint16_t cscID) : bits_(b
 /// Default
 CSCShowerDigi::CSCShowerDigi() : bits_(0), cscID_(0) {}
 
-bool CSCShowerDigi::isValid() const {
-  return isLoose();
-}
+bool CSCShowerDigi::isValid() const { return isLoose(); }
 
 bool CSCShowerDigi::isLoose() const { return bits_ >= kLoose; }
 

--- a/DataFormats/CSCDigi/src/classes.h
+++ b/DataFormats/CSCDigi/src/classes.h
@@ -31,6 +31,8 @@
 #include "DataFormats/CSCDigi/interface/CSCCLCTPreTriggerDigiCollection.h"
 #include "DataFormats/CSCDigi/interface/CSCALCTPreTriggerDigi.h"
 #include "DataFormats/CSCDigi/interface/CSCALCTPreTriggerDigiCollection.h"
+#include "DataFormats/CSCDigi/interface/CSCShowerDigi.h"
+#include "DataFormats/CSCDigi/interface/CSCShowerDigiCollection.h"
 
 // dummy structs to ensure backward compatibility
 struct GEMCSCLCTDigi {};

--- a/DataFormats/CSCDigi/src/classes_def.xml
+++ b/DataFormats/CSCDigi/src/classes_def.xml
@@ -37,6 +37,9 @@
    <class name="CSCALCTPreTriggerDigi" ClassVersion="10">
     <version ClassVersion="10" checksum="2925979693"/>
    </class>
+   <class name="CSCShowerDigi" ClassVersion="10">
+    <version ClassVersion="10" checksum="1800768760"/>
+   </class>
    <class name="CSCCFEBStatusDigi" ClassVersion="10">
     <version ClassVersion="10" checksum="3752412263"/>
    </class>
@@ -76,6 +79,7 @@
    <class name="std::vector<CSCDDUStatusDigi>"/>
    <class name="std::vector<CSCDCCStatusDigi>"/>
    <class name="std::vector<CSCALCTStatusDigi>"/>
+   <class name="std::vector<CSCShowerDigi>"/>
 
    <class name="std::map<CSCDetId,std::vector<CSCWireDigi> >"/>
    <class name="std::map<CSCDetId,std::vector<CSCRPCDigi> >"/>
@@ -95,6 +99,7 @@
    <class name="std::map<CSCDetId,std::vector<CSCDCCStatusDigi> >"/>
    <class name="std::map<CSCDetId,std::vector<CSCALCTStatusDigi> >"/>
    <class name="std::map<CSCDetId,std::vector<CSCCLCTPreTrigger> >"/>
+   <class name="std::map<CSCDetId,std::vector<CSCShowerDigi> >"/>
 
    <class name="std::pair<CSCDetId,std::vector<CSCWireDigi> >"/>
    <class name="std::pair<CSCDetId,std::vector<CSCRPCDigi> >"/>
@@ -114,6 +119,7 @@
    <class name="std::pair<CSCDetId,std::vector<CSCDCCStatusDigi> >"/>
    <class name="std::pair<CSCDetId,std::vector<CSCALCTStatusDigi> >"/>
    <class name="std::pair<CSCDetId,std::vector<CSCCLCTPreTrigger> >"/>
+   <class name="std::pair<CSCDetId,std::vector<CSCShowerDigi> >"/>
 
 
    <class name="MuonDigiCollection<CSCDetId,CSCWireDigi>"/>
@@ -134,6 +140,7 @@
    <class name="MuonDigiCollection<CSCDetId,CSCDDUStatusDigi>"/>
    <class name="MuonDigiCollection<CSCDetId,CSCALCTStatusDigi>"/>
    <class name="MuonDigiCollection<CSCDetId,CSCCLCTPreTrigger>"/>
+   <class name="MuonDigiCollection<CSCDetId,CSCShowerDigi>"/>
 
    <class name="edm::Wrapper<MuonDigiCollection<CSCDetId,CSCWireDigi>>"  splitLevel="0"/>
    <class name="edm::Wrapper<MuonDigiCollection<CSCDetId,CSCRPCDigi>>" splitLevel="0"/>
@@ -153,5 +160,6 @@
    <class name="edm::Wrapper<MuonDigiCollection<CSCDetId,CSCDDUStatusDigi> >" splitLevel="0"/>
    <class name="edm::Wrapper<MuonDigiCollection<CSCDetId,CSCALCTStatusDigi> >" splitLevel="0"/>
    <class name="edm::Wrapper<MuonDigiCollection<CSCDetId,CSCCLCTPreTrigger> >" splitLevel="0"/>
+   <class name="edm::Wrapper<MuonDigiCollection<CSCDetId,CSCShowerDigi> >" splitLevel="0"/>
 
 </lcgdict>

--- a/L1Trigger/CSCTriggerPrimitives/interface/CSCAnodeLCTProcessor.h
+++ b/L1Trigger/CSCTriggerPrimitives/interface/CSCAnodeLCTProcessor.h
@@ -88,7 +88,7 @@ public:
   CSCALCTDigi getBestALCT(int bx) const;
   CSCALCTDigi getSecondALCT(int bx) const;
 
-  /* encode special bits for high multiplicity triggers */
+  /* get special bits for high multiplicity triggers */
   unsigned getHighMultiplictyBits() const { return highMultiplicityBits_; }
 
 protected:
@@ -123,8 +123,9 @@ protected:
   std::vector<CSCALCTPreTriggerDigi> thePreTriggerDigis;
 
   /* data members for high multiplicity triggers */
-  void encodeHighMultiplicityBits();
+  void encodeHighMultiplicityBits(const std::vector<int> wire[CSCConstants::NUM_LAYERS][CSCConstants::MAX_NUM_WIRES]);
   unsigned int highMultiplicityBits_;
+  std::vector<unsigned> thresholds_;
 
   /** Configuration parameters. */
   unsigned int fifo_tbins, fifo_pretrig, drift_delay;

--- a/L1Trigger/CSCTriggerPrimitives/interface/CSCCathodeLCTProcessor.h
+++ b/L1Trigger/CSCTriggerPrimitives/interface/CSCCathodeLCTProcessor.h
@@ -91,6 +91,9 @@ public:
   std::vector<CSCCLCTPreTriggerDigi> preTriggerDigisME1a() const;
   std::vector<CSCCLCTPreTriggerDigi> preTriggerDigisME1b() const;
 
+  /* get special bits for high multiplicity triggers */
+  unsigned getHighMultiplicityBits() const { return highMultiplicityBits_; }
+
 protected:
   /** Best LCT in this chamber, as found by the processor. */
   CSCCLCTDigi bestCLCT[CSCConstants::MAX_CLCT_TBINS];
@@ -202,6 +205,12 @@ protected:
   std::vector<CSCComparatorDigi> digiV[CSCConstants::NUM_LAYERS];
   std::vector<int> thePreTriggerBXs;
   std::vector<CSCCLCTPreTriggerDigi> thePreTriggerDigis;
+
+  /* data members for high multiplicity triggers */
+  void encodeHighMultiplicityBits(
+      const std::vector<int> halfstrip[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS_7CFEBS]);
+  unsigned highMultiplicityBits_;
+  std::vector<unsigned> thresholds_;
 
   /** Configuration parameters. */
   unsigned int fifo_tbins, fifo_pretrig;  // only for test beam mode.

--- a/L1Trigger/CSCTriggerPrimitives/interface/CSCMotherboard.h
+++ b/L1Trigger/CSCTriggerPrimitives/interface/CSCMotherboard.h
@@ -37,6 +37,7 @@
 #include "L1Trigger/CSCTriggerPrimitives/interface/CSCAnodeLCTProcessor.h"
 #include "L1Trigger/CSCTriggerPrimitives/interface/CSCCathodeLCTProcessor.h"
 #include "DataFormats/CSCDigi/interface/CSCCorrelatedLCTDigi.h"
+#include "DataFormats/CSCDigi/interface/CSCShowerDigi.h"
 
 class CSCMotherboard : public CSCBaseboard {
 public:
@@ -63,6 +64,9 @@ public:
 
   /** Returns vector of all found correlated LCTs, if any. */
   std::vector<CSCCorrelatedLCTDigi> getLCTs() const;
+
+  /** Returns shower bits */
+  CSCShowerDigi readoutShower() const;
 
   /** Clears correlated LCT and passes clear signal on to cathode and anode
       LCT processors. */

--- a/L1Trigger/CSCTriggerPrimitives/interface/CSCTriggerPrimitivesBuilder.h
+++ b/L1Trigger/CSCTriggerPrimitives/interface/CSCTriggerPrimitivesBuilder.h
@@ -27,6 +27,7 @@
 #include "DataFormats/CSCDigi/interface/CSCCLCTPreTriggerDigiCollection.h"
 #include "DataFormats/CSCDigi/interface/CSCCorrelatedLCTDigiCollection.h"
 #include "DataFormats/CSCDigi/interface/CSCCLCTPreTriggerCollection.h"
+#include "DataFormats/CSCDigi/interface/CSCShowerDigiCollection.h"
 #include "DataFormats/GEMDigi/interface/GEMPadDigiClusterCollection.h"
 #include "DataFormats/GEMDigi/interface/GEMCoPadDigiCollection.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -76,6 +77,7 @@ public:
              CSCCLCTPreTriggerCollection& oc_pretrig,
              CSCCorrelatedLCTDigiCollection& oc_lct,
              CSCCorrelatedLCTDigiCollection& oc_sorted_lct,
+             CSCShowerDigiCollection& oc_shower,
              GEMCoPadDigiCollection& oc_gemcopad);
 
   /** Max values of trigger labels for all CSCs; used to construct TMB

--- a/L1Trigger/CSCTriggerPrimitives/plugins/CSCTriggerPrimitivesProducer.cc
+++ b/L1Trigger/CSCTriggerPrimitives/plugins/CSCTriggerPrimitivesProducer.cc
@@ -46,6 +46,7 @@ CSCTriggerPrimitivesProducer::CSCTriggerPrimitivesProducer(const edm::ParameterS
   writeOutAllCLCTs_ = conf.getParameter<bool>("writeOutAllCLCTs");
   writeOutAllALCTs_ = conf.getParameter<bool>("writeOutAllALCTs");
   savePreTriggers_ = conf.getParameter<bool>("savePreTriggers");
+  writeOutShowers_ = conf.getParameter<bool>("writeOutShowers");
 
   // check whether you need to run the integrated local triggers
   const edm::ParameterSet commonParam(conf.getParameter<edm::ParameterSet>("commonParam"));
@@ -77,7 +78,9 @@ CSCTriggerPrimitivesProducer::CSCTriggerPrimitivesProducer(const edm::ParameterS
   }
   produces<CSCCorrelatedLCTDigiCollection>();
   produces<CSCCorrelatedLCTDigiCollection>("MPCSORTED");
-  produces<CSCShowerDigiCollection>();
+  if (writeOutShowers_) {
+    produces<CSCShowerDigiCollection>();
+  }
   if (runME11ILT_ or runME21ILT_)
     produces<GEMCoPadDigiCollection>();
 
@@ -195,7 +198,9 @@ void CSCTriggerPrimitivesProducer::produce(edm::Event& ev, const edm::EventSetup
   ev.put(std::move(oc_pretrig));
   ev.put(std::move(oc_lct));
   ev.put(std::move(oc_sorted_lct), "MPCSORTED");
-  ev.put(std::move(oc_shower));
+  if (writeOutShowers_) {
+    ev.put(std::move(oc_shower));
+  }
   // only put GEM copad collections in the event when the
   // integrated local triggers are running
   if (runME11ILT_ or runME21ILT_)

--- a/L1Trigger/CSCTriggerPrimitives/plugins/CSCTriggerPrimitivesProducer.cc
+++ b/L1Trigger/CSCTriggerPrimitives/plugins/CSCTriggerPrimitivesProducer.cc
@@ -23,6 +23,8 @@
 #include "DataFormats/CSCDigi/interface/CSCCorrelatedLCTDigiCollection.h"
 #include "DataFormats/CSCDigi/interface/CSCALCTPreTriggerDigiCollection.h"
 #include "DataFormats/CSCDigi/interface/CSCCLCTPreTriggerDigiCollection.h"
+#include "DataFormats/CSCDigi/interface/CSCCorrelatedLCTDigiCollection.h"
+#include "DataFormats/CSCDigi/interface/CSCShowerDigiCollection.h"
 #include "DataFormats/GEMDigi/interface/GEMCoPadDigiCollection.h"
 
 // Configuration via EventSetup
@@ -75,6 +77,7 @@ CSCTriggerPrimitivesProducer::CSCTriggerPrimitivesProducer(const edm::ParameterS
   }
   produces<CSCCorrelatedLCTDigiCollection>();
   produces<CSCCorrelatedLCTDigiCollection>("MPCSORTED");
+  produces<CSCShowerDigiCollection>();
   if (runME11ILT_ or runME21ILT_)
     produces<GEMCoPadDigiCollection>();
 
@@ -139,6 +142,7 @@ void CSCTriggerPrimitivesProducer::produce(edm::Event& ev, const edm::EventSetup
   std::unique_ptr<CSCCLCTPreTriggerCollection> oc_pretrig(new CSCCLCTPreTriggerCollection);
   std::unique_ptr<CSCCorrelatedLCTDigiCollection> oc_lct(new CSCCorrelatedLCTDigiCollection);
   std::unique_ptr<CSCCorrelatedLCTDigiCollection> oc_sorted_lct(new CSCCorrelatedLCTDigiCollection);
+  std::unique_ptr<CSCShowerDigiCollection> oc_shower(new CSCShowerDigiCollection);
   std::unique_ptr<GEMCoPadDigiCollection> oc_gemcopad(new GEMCoPadDigiCollection);
 
   if (!wireDigis.isValid()) {
@@ -169,6 +173,7 @@ void CSCTriggerPrimitivesProducer::produce(edm::Event& ev, const edm::EventSetup
                     *oc_pretrig,
                     *oc_lct,
                     *oc_sorted_lct,
+                    *oc_shower,
                     *oc_gemcopad);
     if (!checkBadChambers_)
       delete temp;
@@ -190,6 +195,7 @@ void CSCTriggerPrimitivesProducer::produce(edm::Event& ev, const edm::EventSetup
   ev.put(std::move(oc_pretrig));
   ev.put(std::move(oc_lct));
   ev.put(std::move(oc_sorted_lct), "MPCSORTED");
+  ev.put(std::move(oc_shower));
   // only put GEM copad collections in the event when the
   // integrated local triggers are running
   if (runME11ILT_ or runME21ILT_)

--- a/L1Trigger/CSCTriggerPrimitives/plugins/CSCTriggerPrimitivesProducer.h
+++ b/L1Trigger/CSCTriggerPrimitives/plugins/CSCTriggerPrimitivesProducer.h
@@ -89,6 +89,9 @@ private:
   // Write out pre-triggers
   bool savePreTriggers_;
 
+  // write out showers
+  bool writeOutShowers_;
+
   // switch to enable the integrated local triggers in ME11 and ME21
   bool runME11ILT_;
   bool runME21ILT_;

--- a/L1Trigger/CSCTriggerPrimitives/python/cscTriggerPrimitiveDigis_cfi.py
+++ b/L1Trigger/CSCTriggerPrimitives/python/cscTriggerPrimitiveDigis_cfi.py
@@ -39,6 +39,7 @@ cscTriggerPrimitiveDigis = cms.EDProducer(
     writeOutAllCLCTs = cms.bool(False),
     writeOutAllALCTs = cms.bool(False),
     savePreTriggers = cms.bool(False),
+    writeOutShowers = cms.bool(False),
 
     commonParam = auxPSets.commonParam.clone(),
     mpcParam = auxPSets.mpcParamRun1.clone()

--- a/L1Trigger/CSCTriggerPrimitives/python/params/alctParams.py
+++ b/L1Trigger/CSCTriggerPrimitives/python/params/alctParams.py
@@ -38,7 +38,29 @@ alctPhase1 = cms.PSet(
     # whether to store the "corrected" ALCT stub time
     # (currently it is median time of particular hits in a pattern) into the CSCCLCTDigi bx,
     # and temporary store the regular "key layer hit" time into the CSCCLCTDigi fullBX:
-    alctUseCorrectedBx = cms.bool(False)
+    alctUseCorrectedBx = cms.bool(False),
+
+    ## {loose, nominal, tight} thresholds for hit counters
+    shower_thresholds = cms.vuint32(
+        # ME1/1
+        104, 105, 107,
+        # ME1/2
+        92, 100, 102,
+        # ME1/3
+        32, 33, 48,
+        # ME2/1
+        133, 134, 136,
+        # ME2/2
+        83, 84, 86,
+        # ME3/1
+        130, 131, 133,
+        # ME3/2
+        74, 80, 87,
+        # ME4/1
+        127, 128, 130,
+        # ME4/2
+        88, 89, 94
+    )
 )
 
 # Parameters for upgrade ALCT processors

--- a/L1Trigger/CSCTriggerPrimitives/python/params/clctParams.py
+++ b/L1Trigger/CSCTriggerPrimitives/python/params/clctParams.py
@@ -15,6 +15,28 @@ clctPhase1 = cms.PSet(
 
     # BX to start CLCT finding (poor man's dead-time shortening):
     clctStartBxShift  = cms.int32(0),
+
+    ## {loose, nominal, tight} thresholds for hit counters
+    shower_thresholds = cms.vuint32(
+        # ME1/1
+        98, 99, 101,
+        # ME1/2
+        56, 62, 73,
+        # ME1/3
+        30, 31, 33,
+        # ME2/1
+        49, 53, 55,
+        # ME2/2
+        42, 43, 46,
+        # ME3/1
+        49, 50, 52,
+        # ME3/2
+        35, 36, 38,
+        # ME4/1
+        42, 49, 51,
+        # ME4/2
+        31, 34, 36
+    )
 )
 
 # Parameters for upgrade CLCT processors

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCCathodeLCTProcessor.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCCathodeLCTProcessor.cc
@@ -98,6 +98,8 @@ CSCCathodeLCTProcessor::CSCCathodeLCTProcessor(unsigned endcap,
     }
   }
 
+  thresholds_ = clctParams_.getParameter<std::vector<unsigned>>("shower_thresholds");
+
   thePreTriggerDigis.clear();
 
   // quality control of stubs
@@ -206,6 +208,7 @@ void CSCCathodeLCTProcessor::clear() {
     bestCLCT[bx].clear();
     secondCLCT[bx].clear();
   }
+  highMultiplicityBits_ = 0;
 }
 
 std::vector<CSCCLCTDigi> CSCCathodeLCTProcessor::run(const CSCComparatorDigiCollection* compdc) {
@@ -289,12 +292,15 @@ std::vector<CSCCLCTDigi> CSCCathodeLCTProcessor::run(const CSCComparatorDigiColl
   }
 
   // Get comparator digis in this chamber.
-  bool noDigis = getDigis(compdc);
+  bool hasDigis = getDigis(compdc);
 
-  if (!noDigis) {
+  if (hasDigis) {
     // Get halfstrip times from comparator digis.
     std::vector<int> halfstrip[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS_7CFEBS];
     readComparatorDigis(halfstrip);
+
+    // Get the high multiplicity bits in this chamber
+    encodeHighMultiplicityBits(halfstrip);
 
     // Pass arrays of halfstrips on to another run() doing the
     // LCT search.
@@ -396,7 +402,7 @@ void CSCCathodeLCTProcessor::run(
 }
 
 bool CSCCathodeLCTProcessor::getDigis(const CSCComparatorDigiCollection* compdc) {
-  bool noDigis = true;
+  bool hasDigis = false;
 
   // Loop over layers and save comparator digis on each one into digiV[layer].
   for (int i_layer = 0; i_layer < CSCConstants::NUM_LAYERS; i_layer++) {
@@ -411,7 +417,7 @@ bool CSCCathodeLCTProcessor::getDigis(const CSCComparatorDigiCollection* compdc)
     }
 
     if (!digiV[i_layer].empty()) {
-      noDigis = false;
+      hasDigis = true;
       if (infoV > 1) {
         LogTrace("CSCCathodeLCTProcessor") << "found " << digiV[i_layer].size() << " comparator digi(s) in layer "
                                            << i_layer << " of " << detid.chamberName() << " (trig. sector " << theSector
@@ -420,7 +426,7 @@ bool CSCCathodeLCTProcessor::getDigis(const CSCComparatorDigiCollection* compdc)
     }
   }
 
-  return noDigis;
+  return hasDigis;
 }
 
 void CSCCathodeLCTProcessor::getDigis(const CSCComparatorDigiCollection* compdc, const CSCDetId& id) {
@@ -1446,4 +1452,30 @@ unsigned CSCCathodeLCTProcessor::convertSlopeToRun2Pattern(const unsigned slope)
   const unsigned slopeList[32] = {2,  2,  2, 4, 4, 4, 6, 6, 6, 6, 8, 8, 8, 8, 10, 10,
                                   10, 10, 9, 9, 9, 9, 7, 7, 7, 7, 5, 5, 5, 3, 3,  3};
   return slopeList[slope];
+}
+
+void CSCCathodeLCTProcessor::encodeHighMultiplicityBits(
+    const std::vector<int> halfstrip[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS_7CFEBS]) {
+  highMultiplicityBits_ = 0;
+
+  unsigned hits = 0;
+  for (int i_layer = 0; i_layer < CSCConstants::NUM_LAYERS; i_layer++) {
+    for (int i_hstrip = 0; i_hstrip < CSCConstants::NUM_HALF_STRIPS_7CFEBS; i_hstrip++) {
+      hits += halfstrip[i_layer][i_hstrip].size();
+    }
+  }
+
+  // convert station and ring number to index
+  // index runs from 2 to 10, subtract 2
+  unsigned csc_idx = CSCDetId::iChamberType(theStation, theRing) - 2;
+
+  // loose, nominal and tight
+  std::vector<unsigned> station_thresholds = {
+      thresholds_[csc_idx * 3], thresholds_[csc_idx * 3 + 1], thresholds_[csc_idx * 3 + 2]};
+
+  for (unsigned i = 0; i < station_thresholds.size(); i++) {
+    if (hits >= station_thresholds[i]) {
+      highMultiplicityBits_ = i + 1;
+    }
+  }
 }

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCGEMMotherboard.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCGEMMotherboard.cc
@@ -273,9 +273,6 @@ CSCCorrelatedLCTDigi CSCGEMMotherboard::constructLCTsGEM(const CSCALCTDigi& alct
   // Not used in Run-2. Will not be assigned in Run-3
   thisLCT.setSyncErr(0);
   thisLCT.setCSCID(theTrigChamber);
-  // in Run-3 we plan to denote the presence of exotic signatures in the chamber
-  if (useHighMultiplicityBits_)
-    thisLCT.setHMT(highMultiplicityBits_);
 
   // future work: add a section that produces LCTs according
   // to the new LCT dataformat (not yet defined)

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboard.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboard.cc
@@ -102,6 +102,9 @@ void CSCMotherboard::clear() {
     firstLCT[bx].clear();
     secondLCT[bx].clear();
   }
+
+  // reset the shower trigger
+  highMultiplicityBits_ = 0;
 }
 
 // Set configuration parameters obtained via EventSetup mechanism.
@@ -150,8 +153,8 @@ void CSCMotherboard::run(const CSCWireDigiCollection* wiredc, const CSCComparato
     return;
 
   // encode high multiplicity bits
-  unsigned alctBits = alctProc->getHighMultiplictyBits();
-  encodeHighMultiplicityBits(alctBits);
+  unsigned clctBits = clctProc->getHighMultiplicityBits();
+  encodeHighMultiplicityBits(clctBits);
 
   // CLCT-centric matching
   if (clct_to_alct) {
@@ -428,6 +431,10 @@ std::vector<CSCCorrelatedLCTDigi> CSCMotherboard::getLCTs() const {
   return tmpV;
 }
 
+CSCShowerDigi CSCMotherboard::readoutShower() const {
+  return CSCShowerDigi(highMultiplicityBits_, theTrigChamber);
+}
+
 void CSCMotherboard::correlateLCTs(
     const CSCALCTDigi& bALCT, const CSCALCTDigi& sALCT, const CSCCLCTDigi& bCLCT, const CSCCLCTDigi& sCLCT, int type) {
   CSCALCTDigi bestALCT = bALCT;
@@ -527,10 +534,6 @@ CSCCorrelatedLCTDigi CSCMotherboard::constructLCTs(const CSCALCTDigi& aLCT,
     thisLCT.setEightStrip(cLCT.getEightStrip());
     thisLCT.setRun3Pattern(cLCT.getRun3Pattern());
   }
-
-  // in Run-3 we plan to denote the presence of exotic signatures in the chamber
-  if (useHighMultiplicityBits_)
-    thisLCT.setHMT(highMultiplicityBits_);
 
   // make sure to shift the ALCT BX from 8 to 3 and the CLCT BX from 8 to 7!
   thisLCT.setALCT(getBXShiftedALCT(aLCT));
@@ -708,11 +711,10 @@ CSCCLCTDigi CSCMotherboard::getBXShiftedCLCT(const CSCCLCTDigi& cLCT) const {
   return cLCT_shifted;
 }
 
-void CSCMotherboard::encodeHighMultiplicityBits(unsigned alctBits) {
+void CSCMotherboard::encodeHighMultiplicityBits(unsigned clctBits) {
   // encode the high multiplicity bits in the (O)TMB based on
-  // the high multiplicity bits from the ALCT processor
-  // draft version: simply rellay the ALCT bits.
-  // future versions may involve also bits from the CLCT processor
-  // this depends on memory constraints in the TMB FPGA
-  highMultiplicityBits_ = alctBits;
+  // the high multiplicity bits from the ALCT processor and the CLCT processor
+  // current version: relay the CLCT bits
+  // future versions may involve also bits from the ALCT processor
+  highMultiplicityBits_ = clctBits;
 }

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboard.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboard.cc
@@ -431,9 +431,7 @@ std::vector<CSCCorrelatedLCTDigi> CSCMotherboard::getLCTs() const {
   return tmpV;
 }
 
-CSCShowerDigi CSCMotherboard::readoutShower() const {
-  return CSCShowerDigi(highMultiplicityBits_, theTrigChamber);
-}
+CSCShowerDigi CSCMotherboard::readoutShower() const { return CSCShowerDigi(highMultiplicityBits_, theTrigChamber); }
 
 void CSCMotherboard::correlateLCTs(
     const CSCALCTDigi& bALCT, const CSCALCTDigi& sALCT, const CSCCLCTDigi& bCLCT, const CSCCLCTDigi& sCLCT, int type) {

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCTriggerPrimitivesBuilder.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCTriggerPrimitivesBuilder.cc
@@ -119,6 +119,7 @@ void CSCTriggerPrimitivesBuilder::build(const CSCBadChambers* badChambers,
                                         CSCCLCTPreTriggerCollection& oc_pretrig,
                                         CSCCorrelatedLCTDigiCollection& oc_lct,
                                         CSCCorrelatedLCTDigiCollection& oc_sorted_lct,
+                                        CSCShowerDigiCollection& oc_shower,
                                         GEMCoPadDigiCollection& oc_gemcopad) {
   // CSC geometry.
   for (int endc = min_endcap; endc <= max_endcap; endc++) {
@@ -178,6 +179,7 @@ void CSCTriggerPrimitivesBuilder::build(const CSCBadChambers* badChambers,
               const std::vector<CSCCLCTDigi>& clctV1a = tmb11->clctProc->readoutCLCTsME1a();
               const std::vector<CSCCLCTPreTriggerDigi>& pretriggerV1a = tmb11->clctProc->preTriggerDigisME1a();
               const std::vector<CSCALCTPreTriggerDigi>& alctpretriggerV = tmb11->alctProc->preTriggerDigis();
+              const CSCShowerDigi& shower = tmb11->readoutShower();
 
               if (infoV > 1)
                 LogTrace("CSCTriggerPrimitivesBuilder")
@@ -198,6 +200,8 @@ void CSCTriggerPrimitivesBuilder::build(const CSCBadChambers* badChambers,
               put(pretriggerV, oc_pretrigger, detid, " ME1b CLCT pre-trigger digi");
               put(preTriggerBXs, oc_pretrig, detid, " ME1b CLCT pre-trigger BX");
               put(alctpretriggerV, oc_alctpretrigger, detid, " ME1b ALCT pre-trigger digi");
+              if (shower.isValid())
+                oc_shower.insertDigi(detid, shower);
 
               // ME1/a
 
@@ -246,6 +250,7 @@ void CSCTriggerPrimitivesBuilder::build(const CSCBadChambers* badChambers,
               const std::vector<CSCCLCTPreTriggerDigi>& pretriggerV1a = tmb11GEM->clctProc->preTriggerDigisME1a();
               const std::vector<GEMCoPadDigi>& copads = tmb11GEM->coPadProcessor->readoutCoPads();
               const std::vector<CSCALCTPreTriggerDigi>& alctpretriggerV = tmb11GEM->alctProc->preTriggerDigis();
+              const CSCShowerDigi& shower = tmb11GEM->readoutShower();
 
               // ME1/b
               if (!(lctV.empty() && alctV.empty() && clctV.empty()) and infoV > 1) {
@@ -262,6 +267,8 @@ void CSCTriggerPrimitivesBuilder::build(const CSCBadChambers* badChambers,
               put(preTriggerBXs, oc_pretrig, detid, " ME1b CLCT pre-trigger BX");
               put(copads, oc_gemcopad, gemId, " GEM coincidence pad");
               put(alctpretriggerV, oc_alctpretrigger, detid, " ME1b ALCT pre-trigger digi");
+              if (shower.isValid())
+                oc_shower.insertDigi(detid, shower);
 
               // ME1/a
               if (disableME1a_)
@@ -303,6 +310,7 @@ void CSCTriggerPrimitivesBuilder::build(const CSCBadChambers* badChambers,
               const std::vector<CSCCLCTPreTriggerDigi>& pretriggerV = tmb21GEM->clctProc->preTriggerDigis();
               const std::vector<GEMCoPadDigi>& copads = tmb21GEM->coPadProcessor->readoutCoPads();
               const std::vector<CSCALCTPreTriggerDigi>& alctpretriggerV = tmb21GEM->alctProc->preTriggerDigis();
+              const CSCShowerDigi& shower = tmb21GEM->readoutShower();
 
               if (!(alctV.empty() && clctV.empty() && lctV.empty()) and infoV > 1) {
                 LogTrace("L1CSCTrigger") << "CSCTriggerPrimitivesBuilder got results in " << detid;
@@ -318,6 +326,8 @@ void CSCTriggerPrimitivesBuilder::build(const CSCBadChambers* badChambers,
               put(preTriggerBXs, oc_pretrig, detid, " ME21 CLCT pre-trigger BX");
               put(copads, oc_gemcopad, gemId, " GEM coincidence pad");
               put(alctpretriggerV, oc_alctpretrigger, detid, " ME21 ALCT pre-trigger digi");
+              if (shower.isValid())
+                oc_shower.insertDigi(detid, shower);
             }
             // running upgraded ME2/1-ME3/1-ME4/1 TMBs (without GEMs or RPCs)
             else if (runPhase2_ and ring == 1 and
@@ -339,6 +349,7 @@ void CSCTriggerPrimitivesBuilder::build(const CSCBadChambers* badChambers,
               const std::vector<int>& preTriggerBXs = utmb->clctProc->preTriggerBXs();
               const std::vector<CSCCLCTPreTriggerDigi>& pretriggerV = utmb->clctProc->preTriggerDigis();
               const std::vector<CSCALCTPreTriggerDigi>& alctpretriggerV = utmb->alctProc->preTriggerDigis();
+              const CSCShowerDigi& shower = utmb->readoutShower();
 
               if (!(alctV.empty() && clctV.empty() && lctV.empty()) and infoV > 1) {
                 LogTrace("L1CSCTrigger") << "CSCTriggerPrimitivesBuilder got results in " << detid;
@@ -353,6 +364,8 @@ void CSCTriggerPrimitivesBuilder::build(const CSCBadChambers* badChambers,
               put(pretriggerV, oc_pretrigger, detid, " CLCT pre-trigger digi");
               put(preTriggerBXs, oc_pretrig, detid, " CLCT pre-trigger BX");
               put(alctpretriggerV, oc_alctpretrigger, detid, " ALCT pre-trigger digi");
+              if (shower.isValid())
+                oc_shower.insertDigi(detid, shower);
             }
 
             // running non-upgraded TMB
@@ -371,6 +384,7 @@ void CSCTriggerPrimitivesBuilder::build(const CSCBadChambers* badChambers,
               const std::vector<int>& preTriggerBXs = tmb->clctProc->preTriggerBXs();
               const std::vector<CSCCLCTPreTriggerDigi>& pretriggerV = tmb->clctProc->preTriggerDigis();
               const std::vector<CSCALCTPreTriggerDigi>& alctpretriggerV = tmb->alctProc->preTriggerDigis();
+              const CSCShowerDigi& shower = tmb->readoutShower();
 
               if (!(alctV.empty() && clctV.empty() && lctV.empty()) and infoV > 1) {
                 LogTrace("L1CSCTrigger") << "CSCTriggerPrimitivesBuilder got results in " << detid;
@@ -385,6 +399,8 @@ void CSCTriggerPrimitivesBuilder::build(const CSCBadChambers* badChambers,
               put(pretriggerV, oc_pretrigger, detid, tmb->getCSCName() + " CLCT pre-trigger digi");
               put(preTriggerBXs, oc_pretrig, detid, tmb->getCSCName() + " CLCT pre-trigger BX");
               put(alctpretriggerV, oc_alctpretrigger, detid, tmb->getCSCName() + " ALCT pre-trigger digi");
+              if (shower.isValid())
+                oc_shower.insertDigi(detid, shower);
             }  // non-upgraded TMB
           }
         }

--- a/Validation/MuonGEMDigis/src/GEMDigiMatcher.cc
+++ b/Validation/MuonGEMDigis/src/GEMDigiMatcher.cc
@@ -63,7 +63,6 @@ void GEMDigiMatcher::match(const SimTrack& t, const SimVertex& v) {
   muonSimHitMatcher_->match(t, v);
 
   // get the digi collections
-  const edm::DetSetVector<GEMDigiSimLink>& gemDigisSL = *gemDigisSLH_.product();
   const GEMDigiCollection& gemDigis = *gemDigisH_.product();
   const GEMPadDigiCollection& gemPads = *gemPadsH_.product();
   const GEMPadDigiClusterCollection& gemClusters = *gemClustersH_.product();
@@ -76,8 +75,10 @@ void GEMDigiMatcher::match(const SimTrack& t, const SimVertex& v) {
     return;
 
   // now match the digis
-  if (matchToSimLink_)
+  if (matchToSimLink_) {
+    const edm::DetSetVector<GEMDigiSimLink>& gemDigisSL = *gemDigisSLH_.product();
     matchDigisSLToSimTrack(gemDigisSL);
+  }
   matchDigisToSimTrack(gemDigis);
   matchPadsToSimTrack(gemPads);
   matchClustersToSimTrack(gemClusters);


### PR DESCRIPTION
#### PR description:

In Run-3 we would like to include a counter in the CSC trigger sensitive to hadronic showers. They can indicate the decay of a long-lived particle in the muon endcap system and have the potential of increasing sensitivity in physics searches by a factor 20. 

This PR introduces `CSCShowerDigi` object and producer in the trigger. They can either be "loose", "nominal", or "tight", depending on how many hits were recorded in a chamber. The `CSCShowerDigi` are produced in addition to the regular CSC trigger primitives and are sent to the EMTF. They are therefore of type `CSCDetIdCSCShowerDigiMuonDigiCollection_simCscTriggerPrimitiveDigis__`. The trigger data has already been upgraded to include additional bits for hadronic showers (see [DN-20-016](https://gitlab.cern.ch/tdr/notes/DN-20-016/blob/master/temp/DN-20-016_temp.pdf)). For the CSC->MPC->EMTF path, 4 `HMT` bits per chamber per BX have been allocated. In the EMTF sector processors we're planning a simple logic block that checks the presence of a shower (e.g. one nominal shower, or two loose showers).  For the EMTF->uGMT 3x2 bits are available per BX per trigger sector. In our current design we would use 1 or 2 bits. That will be done in future PRs.

Additional documentation in [DN-20-033](https://gitlab.cern.ch/tdr/notes/DN-20-033/blob/master/temp/DN-20-033_temp.pdf) and in [this presentation](https://indico.cern.ch/event/1006558/contributions/4227898/attachments/2187396/3696178/HadronicShowerTrigger_20210204.pdf).

#### PR validation:

Tested with H->2s->4b/4d samples  below
https://cmsweb.cern.ch/das/request?view=list&limit=50&instance=prod%2Fglobal&input=%2FHTo2LongLivedTo4b*%2FRun3Winter20DRPremixMiniAOD-110X_mcRun3_2021_realistic_v6-v2%2FGEN-SIM-RAW

Also tested with WF 11634.0.

```
11634.0_TTbar_14TeV+2021+TTbar_14TeV_TuneCP5_GenSim+Digi+Reco+HARVEST+ALCA Step0-PASSED Step1-PASSED Step2-PASSED Step3-PASSED Step4-PASSED  - time date Thu Feb 11 11:30:07 2021-date Thu Feb 11 10:42:32 2021; exit: 0 0 0 0 0
1 1 1 1 1 tests passed, 0 0 0 0 0 failed
```

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A

@tahuang1991 