### PR TITLE
Change ROOT::TF1 class def version from 10 to 12*

### DIFF
--- a/DQMServices/Components/test/testSchemaEvolution.cpp
+++ b/DQMServices/Components/test/testSchemaEvolution.cpp
@@ -41,7 +41,7 @@ CPPUNIT_TEST_SUITE_REGISTRATION(TestSchemaEvolution);
 
 void TestSchemaEvolution::fillBaseline() {
   unique_classes_current_.insert(std::make_pair("vector<double>", 6));
-  unique_classes_current_.insert(std::make_pair("TF1", 10));
+  unique_classes_current_.insert(std::make_pair("TF1", 11));
   unique_classes_current_.insert(std::make_pair("TH3S", 4));
   unique_classes_current_.insert(std::make_pair("TAtt3D", 1));
   unique_classes_current_.insert(std::make_pair("TH3", 6));

--- a/DQMServices/Components/test/testSchemaEvolution.cpp
+++ b/DQMServices/Components/test/testSchemaEvolution.cpp
@@ -41,7 +41,7 @@ CPPUNIT_TEST_SUITE_REGISTRATION(TestSchemaEvolution);
 
 void TestSchemaEvolution::fillBaseline() {
   unique_classes_current_.insert(std::make_pair("vector<double>", 6));
-  unique_classes_current_.insert(std::make_pair("TF1", 11));
+  unique_classes_current_.insert(std::make_pair("TF1", 12));
   unique_classes_current_.insert(std::make_pair("TH3S", 4));
   unique_classes_current_.insert(std::make_pair("TAtt3D", 1));
   unique_classes_current_.insert(std::make_pair("TH3", 6));


### PR DESCRIPTION
#### PR description:

ROOT has changed their class version for TF1 in master from 10 to 11 in :
https://github.com/root-project/root/pull/7035
I've requested a backport for the change to 6-22 https://github.com/root-project/root/pull/7193
so we can have them consistent and
https://github.com/cms-sw/cmsdist/pull/6631 integrated
Note that there is another such class version change in the same PR for TFormula from 12 to 13
and please let me know if anything else follows from the proposed changes (like should we change TFormula version somewhere)

in the meanwhile root updated TF1 to version 12 (in master)
https://github.com/root-project/root/pull/7274

#### PR validation:

the test testSchemaEvolution is running 

Resolves: #33053 
