### PR TITLE
Fix crash when changing lumiblocks on crab

### DIFF
--- a/GeneratorInterface/Herwig7Interface/plugins/Herwig7Hadronizer.cc
+++ b/GeneratorInterface/Herwig7Interface/plugins/Herwig7Hadronizer.cc
@@ -94,12 +94,6 @@ bool Herwig7Hadronizer::initializeForInternalPartons()
 {
 	if (currentLumiBlock==firstLumiBlock)
 	{
-		initRepository(paramSettings);
-	}
-	if (!initGenerator())
-	{
-		edm::LogInfo("Generator|Herwig7Hadronizer") << "No run step for Herwig chosen. Program will be aborted.";
-		exit(0);
 		std::ifstream runFile(runFileName+".run");
 		if (runFile.fail()) //required for showering of LHE files
 		{


### PR DESCRIPTION
#### PR description:

Jobs on crab have been found to crash when starting a new lumiblock due to CMSSW trying to re-initialise Herwig each lumiblock. This was fixed for master in PR  #26905, but for some reason doesn't seem to be properly fixed for CMSSW_10_6.

#### PR validation:

Tested that Herwig no longer crashes when changing lumiblocks, and with standard unit tests of runTheMAtrix workflow 535, and Matchbox test code

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Backport of  #26905 for use in UL production.
