### PR TITLE
fix issue with trend-plotting in payload inspector

### DIFF
--- a/CondCore/Utilities/interface/PayloadInspector.h
+++ b/CondCore/Utilities/interface/PayloadInspector.h
@@ -76,7 +76,9 @@ namespace cond {
           ss << "\"" << entryLabel << "\":" << value.second;
         }
       } else if constexpr (std::is_same_v<V, double>) {
-        ss.precision(0);
+        if ((value - int(value)) == 0) {
+          ss.precision(0);
+        }
         ss << "\"" << entryLabel << "\":" << std::fixed << value;
       } else {
         ss << "\"" << entryLabel << "\":" << value;


### PR DESCRIPTION
#### PR description:

In PR https://github.com/cms-sw/cmssw/pull/32404 I introduced a modification to `CondCore/Utilities/interface/PayloadInspector.h ` in order to be able retrieve the list of dead modules in JSON format from the `SiStripDetVOff` DB record.
The setting of  `precision(0)` was meant to strip off the decimal place from the `DetId` number (stored as double), but it turns out that applying this change indiscriminately kills all the trend plotting for quantities stored as `double` and with non vanishing decimal parts. See e.g.  [this example](https://cms-conddb.cern.ch/cmsDbBrowser/payload_inspector/Prod/CMSSW_11_3_0_pre1/eyJwbG90cyI6MSwicGxvdDEiOnsidGFnIjoiQmVhbVNwb3RPYmplY3RzXzIwMDlfTHVtaUJhc2VkX1NpZ21hWl92MzBfb2ZmbGluZSIsInBsb3QiOiJwbG90X0JlYW1TcG90X0hpc3RvcnlYIiwicGx1Z2luIjoicGx1Z2luQmVhbVNwb3RfUGF5bG9hZEluc3BlY3RvciIsInR5cGUiOiJIaXN0b3J5IiwiaW5wdXRfcGFyYW1zIjp7fSwiaW92cyI6eyJzdGFydF9pb3YiOiI0Mjk0OTY3Mjk3IiwiZW5kX2lvdiI6IjU2OTUwNDA3MzUxNTA1NCJ9fX0=):

![image](https://user-images.githubusercontent.com/5082376/107805211-516aa480-6d65-11eb-834a-5ffe5f9d4901.png)

I fix the issue by imposing that the setting of the precision is applied only when the number to display has no decimal part to start with.

#### PR validation:

Run the following command:
```python
getPayloadData.py --plugin pluginBeamSpotOnline_PayloadInspector --plot plot_BeamSpotOnline_HistoryX --tag BeamSpotOnlineTestHLT --time_type Lumi --iovs '{"start_iov": "1458480699408457", "end_iov": "1458480699408459"}' --db Prod --test ;
```
with this branch and got:

```json
{
    "version": "1.0", 
    "data": [
        {
            "y": -0.070925, 
            "x": 1458480699408457, 
            "y_err": 0
        }, 
        {
            "y": 0.140151, 
            "x": 1458480699408458, 
            "y_err": 0
        }, 
        {
            "y": -0.04356, 
            "x": 1458480699408459, 
            "y_err": 0
        }
    ], 
    "annotations": {
        "x_label": "iov_since", 
        "y_label": "X", 
        "type": "History", 
        "payload_type": "BeamSpotOnlineObjects", 
        "title": "X vs run number"
    }
}
```

while in vanila `CMSSW_11_3_X_2021-02-12-1100` I get 

```json
{
    "version": "1.0", 
    "data": [
        {
            "y": 0, 
            "x": 1458480699408457, 
            "y_err": 0
        }, 
        {
            "y": 0, 
            "x": 1458480699408458, 
            "y_err": 0
        }, 
        {
            "y": 0, 
            "x": 1458480699408459, 
            "y_err": 0
        }
    ], 
    "annotations": {
        "x_label": "iov_since", 
        "y_label": "X", 
        "type": "History", 
        "payload_type": "BeamSpotOnlineObjects", 
        "title": "X vs run number"
    }
}
```

#### if this PR is a backport please specify the original PR and why you need to backport that PR:


