### PR TITLE
Correct muon unconstrained pT scale

### DIFF
--- a/L1Trigger/L1TMuon/plugins/L1TMuonProducer.cc
+++ b/L1Trigger/L1TMuon/plugins/L1TMuonProducer.cc
@@ -355,8 +355,10 @@ void L1TMuonProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
 
         // Set displacement information
         int hwPtUnconstrained{mu->hwPtUnconstrained()};
-        outMu.setPtUnconstrained(hwPtUnconstrained == 0 ? 0
-                                                        : (hwPtUnconstrained - 1) * 0.5);  // Don't want negative pT.
+        outMu.setPtUnconstrained(
+            hwPtUnconstrained == 0
+                ? 0
+                : (hwPtUnconstrained - 1));  // Don't want negative pT, unconstr. pT has LSB of 1 GeV.
         outMu.setHwPtUnconstrained(hwPtUnconstrained);
         outMu.setHwDXY(mu->hwDXY());
 
@@ -454,7 +456,9 @@ void L1TMuonProducer::addMuonsToCollections(MicroGMTConfiguration::InterMuonList
                mu->hwRank()};
 
     int hwPtUnconstrained{mu->hwPtUnconstrained()};
-    outMu.setPtUnconstrained(hwPtUnconstrained == 0 ? 0 : (hwPtUnconstrained - 1) * 0.5);  // Don't want negative pT.
+    outMu.setPtUnconstrained(hwPtUnconstrained == 0
+                                 ? 0
+                                 : (hwPtUnconstrained - 1));  // Don't want negative pT, unconstr. pT has LSB of 1 GeV.
     outMu.setHwPtUnconstrained(hwPtUnconstrained);
     outMu.setHwDXY(mu->hwDXY());
 

--- a/L1Trigger/L1TMuon/src/MuonRawDigiTranslator.cc
+++ b/L1Trigger/L1TMuon/src/MuonRawDigiTranslator.cc
@@ -76,7 +76,8 @@ void l1t::MuonRawDigiTranslator::fillMuonStableQuantities(Muon& mu, uint32_t raw
   mu.setPhiAtVtx(muAtVtx.phi());
 
   int hwPtUnconstrained{mu.hwPtUnconstrained()};
-  mu.setPtUnconstrained(hwPtUnconstrained == 0 ? 0 : (hwPtUnconstrained - 1) * 0.5);  // Don't want negative pT.
+  mu.setPtUnconstrained(
+      hwPtUnconstrained == 0 ? 0 : (hwPtUnconstrained - 1));  // Don't want negative pT, unconstr. pT has LSB of 1 GeV.
 }
 
 void l1t::MuonRawDigiTranslator::fillMuon(


### PR DESCRIPTION
#### PR description:

During the MWGR it was noticed that unconstrained pT in the DQM maxed out at 125 GeV. The reason for this is that in the Muon unpacker and uGMT emulator the step size for unconstrained pT was 0.5 GeV (as it is for standard pT), however in firmware it is actually 1 GeV. This PR fixes the discrepancy in both the unpacker and emulator.

This should also go in for the next MWGR in March and therefore assume I should make a backport, but please confirm. (attn @rekovic)

#### PR validation:

I have locally run the DQM on a streamer file taken last week and verified correctness.

Backport 11_2_X: https://github.com/cms-sw/cmssw/pull/32913