### PR TITLE
(Backport for 11_2_X) Correct muon unconstrained pT scale

### DIFF
--- a/L1Trigger/L1TMuon/plugins/L1TMuonProducer.cc
+++ b/L1Trigger/L1TMuon/plugins/L1TMuonProducer.cc
@@ -355,8 +355,10 @@ void L1TMuonProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
 
         // Set displacement information
         int hwPtUnconstrained{mu->hwPtUnconstrained()};
-        outMu.setPtUnconstrained(hwPtUnconstrained == 0 ? 0
-                                                        : (hwPtUnconstrained - 1) * 0.5);  // Don't want negative pT.
+        outMu.setPtUnconstrained(
+            hwPtUnconstrained == 0
+                ? 0
+                : (hwPtUnconstrained - 1));  // Don't want negative pT, unconstr. pT has LSB of 1 GeV.
         outMu.setHwPtUnconstrained(hwPtUnconstrained);
         outMu.setHwDXY(mu->hwDXY());
 
@@ -454,7 +456,9 @@ void L1TMuonProducer::addMuonsToCollections(MicroGMTConfiguration::InterMuonList
                mu->hwRank()};
 
     int hwPtUnconstrained{mu->hwPtUnconstrained()};
-    outMu.setPtUnconstrained(hwPtUnconstrained == 0 ? 0 : (hwPtUnconstrained - 1) * 0.5);  // Don't want negative pT.
+    outMu.setPtUnconstrained(hwPtUnconstrained == 0
+                                 ? 0
+                                 : (hwPtUnconstrained - 1));  // Don't want negative pT, unconstr. pT has LSB of 1 GeV.
     outMu.setHwPtUnconstrained(hwPtUnconstrained);
     outMu.setHwDXY(mu->hwDXY());
 

--- a/L1Trigger/L1TMuon/src/MuonRawDigiTranslator.cc
+++ b/L1Trigger/L1TMuon/src/MuonRawDigiTranslator.cc
@@ -76,7 +76,8 @@ void l1t::MuonRawDigiTranslator::fillMuonStableQuantities(Muon& mu, uint32_t raw
   mu.setPhiAtVtx(muAtVtx.phi());
 
   int hwPtUnconstrained{mu.hwPtUnconstrained()};
-  mu.setPtUnconstrained(hwPtUnconstrained == 0 ? 0 : (hwPtUnconstrained - 1) * 0.5);  // Don't want negative pT.
+  mu.setPtUnconstrained(
+      hwPtUnconstrained == 0 ? 0 : (hwPtUnconstrained - 1));  // Don't want negative pT, unconstr. pT has LSB of 1 GeV.
 }
 
 void l1t::MuonRawDigiTranslator::fillMuon(


### PR DESCRIPTION
#### PR description:
During the MWGR it was noticed that unconstrained pT in the DQM maxed out at 125 GeV. The reason for this is that in the Muon unpacker and uGMT emulator the step size for unconstrained pT was 0.5 GeV (as it is for standard pT), however in firmware it is actually 1 GeV. This PR fixes the discrepancy in both the unpacker and emulator.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:
bp of #32906
We would like this fix in for the next MWGR.
