### PR TITLE
Fix in header protection of RecoJets/JetAlgorithms/interface/CATopJetHelper.h

### DIFF
--- a/RecoJets/JetAlgorithms/interface/CATopJetHelper.h
+++ b/RecoJets/JetAlgorithms/interface/CATopJetHelper.h
@@ -1,5 +1,5 @@
-#ifndef TopQuarkAnalysis_TopPairBSM_interface_CATopJetHelper_h
-#define TopQuarkAnalysis_TopPairBSM_interface_CATopJetHelper_h
+#ifndef RecoJets_JetAlgorithms_interface_CATopJetHelper_h
+#define RecoJets_JetAlgorithms_interface_CATopJetHelper_h
 
 // \class CATopJetHelper
 //


### PR DESCRIPTION
While I was checking the dependencies of `TopQuarkAnalysis/TopPairBSM`, I've realized this trivial mistake. This is a dummy bug-fix.

This PR is related to the cleaning of the Analysis packages (#32917)