### PR TITLE
small technical fix in PixelVertexCollectionTrimmer

### DIFF
--- a/RecoPixelVertexing/PixelVertexFinding/plugins/PixelVertexCollectionTrimmer.cc
+++ b/RecoPixelVertexing/PixelVertexFinding/plugins/PixelVertexCollectionTrimmer.cc
@@ -22,10 +22,9 @@ Implementation:
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/stream/EDProducer.h"
-
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
-
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 #include "DataFormats/VertexReco/interface/Vertex.h"
@@ -82,6 +81,12 @@ void PixelVertexCollectionTrimmer::produce(edm::Event& iEvent, const edm::EventS
 
   edm::Handle<reco::VertexCollection> vtxs;
   iEvent.getByToken(vtxToken_, vtxs);
+
+  if (vtxs->empty()) {
+    edm::LogWarning("Input") << "Input collection of vertices is empty. Output collection will be empty.";
+    iEvent.put(std::move(vtxs_trim));
+    return;
+  }
 
   double sumpt2;
   //double sumpt2previous = -99. ;


### PR DESCRIPTION
#### PR description:

A test of mine with an incorrectly-configured path ended with a segmentation violation from `PixelVertexCollectionTrimmer`.
This can occur because the latter producer assumes that the input collection of vertices is non-empty (see [here](https://github.com/cms-sw/cmssw/blob/188ed7abcf7bac9cf0b09471061a7ee2ba87373e/RecoPixelVertexing/PixelVertexFinding/plugins/PixelVertexCollectionTrimmer.cc#L99)).
The PR implements a simple way to avoid the segfault.

#### PR validation:

Update works as expected in the user test where the crash occurred.