### PR TITLE
header check fix: include missing MessageLogger.h

### DIFF
--- a/SimTracker/TrackAssociation/interface/trackHitsToClusterRefs.h
+++ b/SimTracker/TrackAssociation/interface/trackHitsToClusterRefs.h
@@ -10,6 +10,7 @@
 #include "DataFormats/TrackerRecHit2D/interface/SiStripRecHit2D.h"
 #include "DataFormats/TrackerRecHit2D/interface/VectorHit.h"
 #include "DataFormats/TrackingRecHit/interface/TrackingRecHitFwd.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 namespace track_associator {
   const TrackingRecHit *getHitFromIter(trackingRecHit_iterator iter) { return &(**iter); }


### PR DESCRIPTION
This should fix the `header consistency` caused by https://github.com/cms-sw/cmssw/pull/32859