### PR TITLE
drop type specifications in RecoParticleFlow

### DIFF
--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowCluster_cff.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowCluster_cff.py
@@ -84,4 +84,4 @@ from Configuration.Eras.Modifier_phase2_timing_cff import phase2_timing
 phase2_timing.toReplaceWith(particleFlowClusterECALTask,
                                   _phase2_timing_particleFlowClusterECALTask)
 phase2_timing.toModify(particleFlowClusterECAL,
-                            inputECAL = cms.InputTag('particleFlowTimeAssignerECAL'))
+                            inputECAL = 'particleFlowTimeAssignerECAL')

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowRealisticSimClusterHGCCalibrations_cfi.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowRealisticSimClusterHGCCalibrations_cfi.py
@@ -5,8 +5,8 @@ maxEtaCorrection = cms.double(3.0)
 hadronCorrections = cms.PSet(value = cms.vdouble(1.24, 1.24, 1.24, 1.23, 1.24, 1.25, 1.29, 1.29))
 egammaCorrections = cms.PSet(value = cms.vdouble(1.00, 1.00, 1.01, 1.01, 1.02, 1.03, 1.04, 1.04))
 
-hadronCorrections_hgcalV10 = cms.vdouble(1.28, 1.28, 1.24, 1.19, 1.17, 1.17, 1.17, 1.17)
-egammaCorrections_hgcalV10 = cms.vdouble(1.00, 1.00, 1.01, 1.01, 1.02, 1.01, 1.01, 1.01)
+hadronCorrections_hgcalV10 = [1.28, 1.28, 1.24, 1.19, 1.17, 1.17, 1.17, 1.17]
+egammaCorrections_hgcalV10 = [1.00, 1.00, 1.01, 1.01, 1.02, 1.01, 1.01, 1.01]
 
 from Configuration.Eras.Modifier_phase2_hgcalV10_cff import phase2_hgcalV10
 phase2_hgcalV10.toModify(hadronCorrections, value = hadronCorrections_hgcalV10)

--- a/RecoParticleFlow/PFProducer/python/electronPFIsolationDeposits_cff.py
+++ b/RecoParticleFlow/PFProducer/python/electronPFIsolationDeposits_cff.py
@@ -24,10 +24,10 @@ elPFIsoDepositGamma= cms.EDProducer("CandIsoDepositProducer",
                                             DepositLabel = cms.untracked.string('')
                                             )
                                     )
-elPFIsoDepositCharged.ExtractorPSet.DR_Veto = cms.double(0)
-elPFIsoDepositChargedAll.ExtractorPSet.DR_Veto = cms.double(0)
-elPFIsoDepositNeutral.ExtractorPSet.DR_Veto = cms.double(0)
-elPFIsoDepositPU.ExtractorPSet.DR_Veto = cms.double(0)
+elPFIsoDepositCharged.ExtractorPSet.DR_Veto    = 0
+elPFIsoDepositChargedAll.ExtractorPSet.DR_Veto = 0
+elPFIsoDepositNeutral.ExtractorPSet.DR_Veto    = 0
+elPFIsoDepositPU.ExtractorPSet.DR_Veto         = 0
 
 
 electronPFIsolationDepositsTask = cms.Task(

--- a/RecoParticleFlow/PFProducer/python/pfGsfElectronMVASelector_cff.py
+++ b/RecoParticleFlow/PFProducer/python/pfGsfElectronMVASelector_cff.py
@@ -7,7 +7,7 @@ electronsWithPresel = cms.EDFilter("GsfElectronSelector",
                                    cut = cms.string("pt > 5 && ecalDrivenSeed && passingCutBasedPreselection"),
                                    )
 
-mvaElectrons.electronTag = cms.InputTag('electronsWithPresel')
+mvaElectrons.electronTag = 'electronsWithPresel'
 
 pfGsfElectronMVASelectionTask = cms.Task(
                electronsWithPresel,

--- a/RecoParticleFlow/PFProducer/python/photonPFIsolationDeposits_cff.py
+++ b/RecoParticleFlow/PFProducer/python/photonPFIsolationDeposits_cff.py
@@ -25,10 +25,10 @@ phPFIsoDepositGamma= cms.EDProducer("CandIsoDepositProducer",
                                         )
                             )
 
-phPFIsoDepositCharged.ExtractorPSet.DR_Veto = cms.double(0)
-phPFIsoDepositChargedAll.ExtractorPSet.DR_Veto = cms.double(0)
-phPFIsoDepositNeutral.ExtractorPSet.DR_Veto = cms.double(0)
-phPFIsoDepositPU.ExtractorPSet.DR_Veto = cms.double(0)
+phPFIsoDepositCharged.ExtractorPSet.DR_Veto    = 0
+phPFIsoDepositChargedAll.ExtractorPSet.DR_Veto = 0
+phPFIsoDepositNeutral.ExtractorPSet.DR_Veto    = 0
+phPFIsoDepositPU.ExtractorPSet.DR_Veto         = 0
 
 photonPFIsolationDepositsTask = cms.Task(
     phPFIsoDepositCharged,


### PR DESCRIPTION
#### PR description: 
Update the safer syntax for existing parameter :
- drop type specifications where the original parameter exists.

Instead of modifying parameters with full type specs, which can be interpreted as an insertion of a new parameter, it is a safer way to protect from parameter name mistakes and will also help in possible parameter migrations.
(previous PRs for RecoParticleFlow is [PR#31389](https://github.com/cms-sw/cmssw/pull/31389) )

In this PR, a total of 5 files changed. 

RecoParticleFlow/PFClusterProducer 2 files
RecoParticleFlow/PFProducer 3 files

#### PR validation:
Event Content comparison check was also done and there is no change with these updates.
Tested in CMSSW_11_2_X, the basic test all passed in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html).