### PR TITLE
add missing Tc updates before cluster merging

### DIFF
--- a/RecoVertex/PrimaryVertexProducer/src/DAClusterizerInZ_vect.cc
+++ b/RecoVertex/PrimaryVertexProducer/src/DAClusterizerInZ_vect.cc
@@ -855,7 +855,7 @@ vector<TransientVertex> DAClusterizerInZ_vect::vertices(const vector<reco::Trans
   }
 
   thermalize(beta, tks, y, delta_lowT_, rho0);
-  //update(beta, tks, y, rho0, true);//to be introduced in a forthcoming PR
+  update(beta, tks, y, rho0, true);
 
 #ifdef DEBUG
   verify(y, tks);
@@ -870,7 +870,7 @@ vector<TransientVertex> DAClusterizerInZ_vect::vertices(const vector<reco::Trans
   // merge again  (some cluster split by outliers collapse here)
   while (merge(y, tks, beta)) {
     set_vtx_range(beta, tks, y);
-    update(beta, tks, y, rho0, false);  //change to "true" in a forthcoming PR
+    update(beta, tks, y, rho0, true);
   }
 
 #ifdef DEBUG


### PR DESCRIPTION
#### PR description:

implement the missing updates of Tc discussed in the context of PR #32764.
This is technically a bug-fix, it removes an unwanted behavior. It was intentionally not included in PR #32764 and scheduled for a separate PR (this one). 

#### PR validation:

Results already discussed in the context of the previous PR #32764 where a version equivalent to this code has been tested.
It was retested on relvals. Small differences observable in a fraction of the events.
