### PR TITLE
[ASAN] Fix AddressSanitizer heap-buffer-overflow

### DIFF
--- a/L1Trigger/TrackTrigger/src/TrackQuality.cc
+++ b/L1Trigger/TrackTrigger/src/TrackQuality.cc
@@ -90,13 +90,13 @@ std::vector<float> TrackQuality::featureTransform(TTTrack<Ref_Phase2TrackerDigi_
   int eta_size = static_cast<int>(eta_bins.size());
   // First iterate through eta bins
 
-  for (int j = 0; j < eta_size; j++) {
-    if (eta >= eta_bins[j] && eta < eta_bins[j + 1])  // if track in eta bin
+  for (int j = 1; j < eta_size; j++) {
+    if (eta < eta_bins[j] && eta >= eta_bins[j - 1])  // if track in eta bin
     {
       // Iterate through hitpattern binary
       for (int k = 0; k <= 6; k++)
         // Fill expanded binary entries using the expected hitmap table positions
-        hitpattern_expanded_binary[hitmap[j][k]] = hitpattern_binary[k];
+        hitpattern_expanded_binary[hitmap[j-1][k]] = hitpattern_binary[k];
     }
   }
 

--- a/L1Trigger/TrackTrigger/src/TrackQuality.cc
+++ b/L1Trigger/TrackTrigger/src/TrackQuality.cc
@@ -96,7 +96,8 @@ std::vector<float> TrackQuality::featureTransform(TTTrack<Ref_Phase2TrackerDigi_
       // Iterate through hitpattern binary
       for (int k = 0; k <= 6; k++)
         // Fill expanded binary entries using the expected hitmap table positions
-        hitpattern_expanded_binary[hitmap[j-1][k]] = hitpattern_binary[k];
+        hitpattern_expanded_binary[hitmap[j - 1][k]] = hitpattern_binary[k];
+      break;
     }
   }
 


### PR DESCRIPTION
This fixes the head buffer overflow issue seen in ASAN IBs https://cmssdt.cern.ch/SDT/cgi-bin/logreader/slc7_amd64_gcc900/CMSSW_11_3_ASAN_X_2021-02-15-2300/pyRelValMatrixLogs/run/29834.0_TTbar_14TeV+2026D64+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTrigger+RecoGlobal+HARVESTGlobal/step2_TTbar_14TeV+2026D64+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTrigger+RecoGlobal+HARVESTGlobal.log#/

Fixes https://github.com/cms-sw/cmssw/issues/32896

[a] In ASAN IB , after the fix
```
29834.0_TTbar_14TeV+2026D64+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTrigger+RecoGlobal+HARVESTGlobal Step0-PASSED Step1-PASSED Step2-PASSED Step3-PASSED  - time date Tue Feb 16 21:41:44 2021-date Tue Feb 16 21:05:48 2021; exit: 0 0 0 0
1 1 1 1 tests passed, 0 0 0 0 failed

```