### PR TITLE
fix potential crash in Sonic

### DIFF
--- a/HeterogeneousCore/SonicCore/src/SonicClientBase.cc
+++ b/HeterogeneousCore/SonicCore/src/SonicClientBase.cc
@@ -24,7 +24,7 @@ SonicClientBase::SonicClientBase(const edm::ParameterSet& params,
 }
 
 void SonicClientBase::setMode(SonicMode mode) {
-  if (mode_ == mode)
+  if (dispatcher_ and mode_ == mode)
     return;
   mode_ = mode;
 


### PR DESCRIPTION
#### PR description:

The SonicTriton unit test had a segmentation violation in the `CMSSW_11_3_X_2021-02-15-2300` IB. The resulting trace included:
```
Thread 1 (Thread 0x2ad4959a1c80 (LWP 4250)):
#0  0x00002ad493d98c3d in poll () from /lib64/libc.so.6
#1  0x00002ad4996dc407 in full_read.constprop () from /cvmfs/cms-ib.cern.ch/nweek-02668/slc7_amd64_gcc900/cms/cmssw/CMSSW_11_3_X_2021-02-14-0000/lib/slc7_amd64_gcc900/pluginFWCoreServicesPlugins.so
#2  0x00002ad4996dcb1c in edm::service::InitRootHandlers::stacktraceFromThread() () from /cvmfs/cms-ib.cern.ch/nweek-02668/slc7_amd64_gcc900/cms/cmssw/CMSSW_11_3_X_2021-02-14-0000/lib/slc7_amd64_gcc900/pluginFWCoreServicesPlugins.so
#3  0x00002ad4996dd954 in sig_dostack_then_abort () from /cvmfs/cms-ib.cern.ch/nweek-02668/slc7_amd64_gcc900/cms/cmssw/CMSSW_11_3_X_2021-02-14-0000/lib/slc7_amd64_gcc900/pluginFWCoreServicesPlugins.so
#4  <signal handler called>
#5  0x00002ad499f34044 in SonicClientBase::dispatch() () from /cvmfs/cms-ib.cern.ch/nweek-02668/slc7_amd64_gcc900/cms/cmssw/CMSSW_11_3_X_2021-02-14-0000/lib/slc7_amd64_gcc900/libHeterogeneousCoreSonicTriton.so
#6  0x00002ad4b28e22d0 in virtual thunk to SonicOneEDAnalyzer<TritonClient>::analyze(edm::Event const&, edm::EventSetup const&) () from /cvmfs/cms-ib.cern.ch/nweek-02668/slc7_amd64_gcc900/cms/cmssw/CMSSW_11_3_X_2021-02-14-0000/lib/slc7_amd64_gcc900/plugintestHeterogenousCoreSonicTriton.so
#7  0x00002ad491581857 in edm::one::EDAnalyzerBase::doEvent(edm::EventTransitionInfo const&, edm::ActivityRegistry*, edm::ModuleCallingContext const*) () from /cvmfs/cms-ib.cern.ch/nweek-02668/slc7_amd64_gcc900/cms/cmssw/CMSSW_11_3_X_2021-02-14-0000/lib/slc7_amd64_gcc900/libFWCoreFramework.so
#8  0x00002ad4915683cd in edm::WorkerT<edm::one::EDAnalyzerBase>::implDo(edm::EventTransitionInfo const&, edm::ModuleCallingContext const*) () from /cvmfs/cms-ib.cern.ch/nweek-02668/slc7_amd64_gcc900/cms/cmssw/CMSSW_11_3_X_2021-02-14-0000/lib/slc7_amd64_gcc900/libFWCoreFramework.so
```

This behavior should not occur. I tracked it down to https://github.com/cms-sw/cmssw/blob/2d254221bb90d80d7c28faac149f1820d3c11ea1/HeterogeneousCore/SonicCore/src/SonicClientBase.cc#L27, which does a comparison with an uninitialized member variable when called in the constructor. In the rare case that this uninitialized member variable has the same value as the comparison argument, the dispatcher will not be created. I confirmed this diagnosis with Valgrind, which, as expected, reported "Conditional jump or move depends on uninitialised value(s)" from that line.

#### PR validation:

Confirmed with Valgrind that the "Conditional jump or move depends on uninitialised value(s)" message goes away. The unit test runs successfully.