### PR TITLE
Added EventSetup calls to ActivityRegistry

### DIFF
--- a/FWCore/Framework/interface/CallbackProxy.h
+++ b/FWCore/Framework/interface/CallbackProxy.h
@@ -58,9 +58,10 @@ namespace edm::eventsetup {
                            const EventSetupRecordImpl& iRecord,
                            const DataKey&,
                            EventSetupImpl const* iEventSetupImpl,
-                           ServiceToken const& iToken) final {
+                           ServiceToken const& iToken,
+                           edm::ESParentContext const& iParent) final {
       assert(iRecord.key() == RecordT::keyForClass());
-      callback_->prefetchAsync(iWaitTask, &iRecord, iEventSetupImpl, iToken);
+      callback_->prefetchAsync(iWaitTask, &iRecord, iEventSetupImpl, iToken, iParent);
     }
 
     void const* getAfterPrefetchImpl() const final { return smart_pointer_traits::getPointer(data_); }

--- a/FWCore/Framework/interface/DataProxy.h
+++ b/FWCore/Framework/interface/DataProxy.h
@@ -32,6 +32,7 @@ namespace edm {
   class ActivityRegistry;
   class EventSetupImpl;
   class ServiceToken;
+  class ESParentContext;
 
   namespace eventsetup {
     struct ComponentDescription;
@@ -52,13 +53,15 @@ namespace edm {
                          EventSetupRecordImpl const&,
                          DataKey const&,
                          EventSetupImpl const*,
-                         ServiceToken const&) const;
+                         ServiceToken const&,
+                         ESParentContext const&) const;
 
       void const* get(EventSetupRecordImpl const&,
                       DataKey const&,
                       bool iTransiently,
                       ActivityRegistry const*,
-                      EventSetupImpl const*) const;
+                      EventSetupImpl const*,
+                      ESParentContext const&) const;
       void const* getAfterPrefetch(const EventSetupRecordImpl& iRecord, const DataKey& iKey, bool iTransiently) const;
 
       ///returns the description of the DataProxyProvider which owns this Proxy
@@ -87,7 +90,8 @@ namespace edm {
                                      EventSetupRecordImpl const&,
                                      DataKey const& iKey,
                                      EventSetupImpl const*,
-                                     ServiceToken const&) = 0;
+                                     ServiceToken const&,
+                                     ESParentContext const&) = 0;
 
       /** indicates that the Proxy should invalidate any cached information
           as that information has 'expired' (i.e. we have moved to a new IOV)

--- a/FWCore/Framework/interface/DataProxyTemplate.h
+++ b/FWCore/Framework/interface/DataProxyTemplate.h
@@ -34,6 +34,7 @@
 #include "FWCore/Framework/interface/DataProxy.h"
 #include "FWCore/Framework/interface/EventSetupRecord.h"
 #include "FWCore/ServiceRegistry/interface/ServiceRegistry.h"
+#include "FWCore/ServiceRegistry/interface/ESParentContext.h"
 #include "FWCore/Concurrency/interface/WaitingTaskList.h"
 #include "FWCore/Concurrency/interface/WaitingTaskHolder.h"
 #include <cassert>
@@ -60,7 +61,8 @@ namespace edm {
                              const EventSetupRecordImpl& iRecord,
                              const DataKey& iKey,
                              EventSetupImpl const* iEventSetupImpl,
-                             edm::ServiceToken const& iToken) override {
+                             edm::ServiceToken const& iToken,
+                             edm::ESParentContext const&) override {
         assert(iRecord.key() == RecordT::keyForClass());
         bool expected = false;
         bool doPrefetch = prefetching_.compare_exchange_strong(expected, true);
@@ -71,7 +73,8 @@ namespace edm {
               tbb::task::allocate_root(), [this, &iRecord, iKey, iEventSetupImpl, iToken](std::exception_ptr const*) {
                 try {
                   RecordT rec;
-                  rec.setImpl(&iRecord, std::numeric_limits<unsigned int>::max(), nullptr, iEventSetupImpl, true);
+                  ESParentContext pc;
+                  rec.setImpl(&iRecord, std::numeric_limits<unsigned int>::max(), nullptr, iEventSetupImpl, &pc, true);
                   ServiceRegistry::Operate operate(iToken);
                   this->make(rec, iKey);
                 } catch (...) {

--- a/FWCore/Framework/interface/DependentRecordImplementation.h
+++ b/FWCore/Framework/interface/DependentRecordImplementation.h
@@ -53,8 +53,11 @@ namespace edm {
             (list_type::template contains<DepRecordT>()),
             "Trying to get a Record from another Record where the second Record is not dependent on the first Record.");
         try {
-          EventSetup const eventSetupT{
-              this->eventSetup(), this->transitionID(), this->getTokenIndices(), this->requireTokens()};
+          EventSetup const eventSetupT{this->eventSetup(),
+                                       this->transitionID(),
+                                       this->getTokenIndices(),
+                                       *this->esParentContext(),
+                                       this->requireTokens()};
           return eventSetupT.get<DepRecordT>();
         } catch (cms::Exception& e) {
           std::ostringstream sstrm;
@@ -70,8 +73,11 @@ namespace edm {
         static_assert(
             (list_type::template contains<DepRecordT>()),
             "Trying to get a Record from another Record where the second Record is not dependent on the first Record.");
-        EventSetup const eventSetupT{
-            this->eventSetup(), this->transitionID(), this->getTokenIndices(), this->requireTokens()};
+        EventSetup const eventSetupT{this->eventSetup(),
+                                     this->transitionID(),
+                                     this->getTokenIndices(),
+                                     *this->esParentContext(),
+                                     this->requireTokens()};
         return eventSetupT.tryToGet<DepRecordT>();
       }
 

--- a/FWCore/Framework/interface/ESSourceDataProxyBase.h
+++ b/FWCore/Framework/interface/ESSourceDataProxyBase.h
@@ -58,7 +58,8 @@ namespace edm::eventsetup {
                            edm::eventsetup::EventSetupRecordImpl const&,
                            edm::eventsetup::DataKey const& iKey,
                            edm::EventSetupImpl const*,
-                           edm::ServiceToken const&) final;
+                           edm::ServiceToken const&,
+                           edm::ESParentContext const&) final;
 
     // ---------- member data --------------------------------
 

--- a/FWCore/Framework/interface/EventSetupImpl.h
+++ b/FWCore/Framework/interface/EventSetupImpl.h
@@ -58,7 +58,8 @@ namespace edm {
 
     std::optional<eventsetup::EventSetupRecordGeneric> find(const eventsetup::EventSetupRecordKey&,
                                                             unsigned int iTransitionID,
-                                                            ESProxyIndex const* getTokenIndices) const;
+                                                            ESProxyIndex const* getTokenIndices,
+                                                            ESParentContext const& iParent) const;
 
     ///clears the oToFill vector and then fills it with the keys for all available records
     void fillAvailableRecordKeys(std::vector<eventsetup::EventSetupRecordKey>& oToFill) const;

--- a/FWCore/Framework/interface/EventSetupRecord.h
+++ b/FWCore/Framework/interface/EventSetupRecord.h
@@ -97,11 +97,13 @@ namespace edm {
                    unsigned int transitionID,
                    ESProxyIndex const* getTokenIndices,
                    EventSetupImpl const* iEventSetupImpl,
+                   ESParentContext const* iContext,
                    bool requireTokens) {
         impl_ = iImpl;
         transitionID_ = transitionID;
         getTokenIndices_ = getTokenIndices;
         eventSetupImpl_ = iEventSetupImpl;
+        context_ = iContext;
         requireTokens_ = requireTokens;
       }
 
@@ -118,7 +120,8 @@ namespace edm {
         typename HolderT::value_type const* value = nullptr;
         ComponentDescription const* desc = nullptr;
         std::shared_ptr<ESHandleExceptionFactory> whyFailedFactory;
-        impl_->getImplementation(value, iName, desc, iHolder.transientAccessOnly, whyFailedFactory, eventSetupImpl_);
+        impl_->getImplementation(
+            value, iName, desc, iHolder.transientAccessOnly, whyFailedFactory, *context_, eventSetupImpl_);
 
         if (value) {
           iHolder = HolderT(value, desc);
@@ -143,7 +146,7 @@ namespace edm {
         ComponentDescription const* desc = nullptr;
         std::shared_ptr<ESHandleExceptionFactory> whyFailedFactory;
         impl_->getImplementation(
-            value, iTag.data().c_str(), desc, iHolder.transientAccessOnly, whyFailedFactory, eventSetupImpl_);
+            value, iTag.data().c_str(), desc, iHolder.transientAccessOnly, whyFailedFactory, *context_, eventSetupImpl_);
 
         if (value) {
           validate(desc, iTag);
@@ -235,9 +238,11 @@ namespace edm {
         return H<T>(value, desc);
       }
 
-      EventSetupImpl const& eventSetup() const { return *eventSetupImpl_; }
+      EventSetupImpl const& eventSetup() const noexcept { return *eventSetupImpl_; }
 
-      ESProxyIndex const* getTokenIndices() const { return getTokenIndices_; }
+      ESProxyIndex const* getTokenIndices() const noexcept { return getTokenIndices_; }
+
+      ESParentContext const* esParentContext() const noexcept { return context_; }
 
       void validate(ComponentDescription const*, ESInputTag const&) const;
 
@@ -283,6 +288,7 @@ namespace edm {
       EventSetupRecordImpl const* impl_ = nullptr;
       EventSetupImpl const* eventSetupImpl_ = nullptr;
       ESProxyIndex const* getTokenIndices_ = nullptr;
+      ESParentContext const* context_ = nullptr;
       unsigned int transitionID_ = std::numeric_limits<unsigned int>::max();
       bool requireTokens_ = false;
     };
@@ -293,8 +299,9 @@ namespace edm {
                               unsigned int iTransitionID,
                               ESProxyIndex const* getTokenIndices,
                               EventSetupImpl const* eventSetupImpl,
+                              ESParentContext const* context,
                               bool requireTokens = false) {
-        setImpl(iImpl, iTransitionID, getTokenIndices, eventSetupImpl, requireTokens);
+        setImpl(iImpl, iTransitionID, getTokenIndices, eventSetupImpl, context, requireTokens);
       }
 
       EventSetupRecordKey key() const final { return impl()->key(); }

--- a/FWCore/Framework/interface/EventSetupRecordImpl.h
+++ b/FWCore/Framework/interface/EventSetupRecordImpl.h
@@ -42,6 +42,7 @@ through the 'validityInterval' method.
 #include "FWCore/Framework/interface/EventSetupRecordKey.h"
 #include "FWCore/Concurrency/interface/WaitingTaskHolder.h"
 #include "FWCore/Utilities/interface/thread_safety_macros.h"
+#include "FWCore/ServiceRegistry/interface/ESParentContext.h"
 #include "FWCore/Utilities/interface/propagate_const.h"
 #include "FWCore/Utilities/interface/ESInputTag.h"
 #include "FWCore/Utilities/interface/ESIndices.h"
@@ -67,6 +68,7 @@ namespace edm {
   class ESInputTag;
   class EventSetupImpl;
   class ServiceToken;
+  class ESParentContext;
 
   namespace eventsetup {
     struct ComponentDescription;
@@ -88,7 +90,8 @@ namespace edm {
       void prefetchAsync(WaitingTaskHolder iTask,
                          ESProxyIndex iProxyIndex,
                          EventSetupImpl const*,
-                         ServiceToken const&) const;
+                         ServiceToken const&,
+                         ESParentContext) const;
 
       /**returns true only if someone has already requested data for this key
           and the data was retrieved
@@ -158,12 +161,14 @@ namespace edm {
       void const* getFromProxy(DataKey const& iKey,
                                ComponentDescription const*& iDesc,
                                bool iTransientAccessOnly,
+                               ESParentContext const&,
                                EventSetupImpl const* = nullptr) const;
 
       void const* getFromProxy(ESProxyIndex iProxyIndex,
                                bool iTransientAccessOnly,
                                ComponentDescription const*& iDesc,
                                DataKey const*& oGottenKey,
+                               ESParentContext const&,
                                EventSetupImpl const* = nullptr) const;
 
       void const* getFromProxyAfterPrefetch(ESProxyIndex iProxyIndex,
@@ -177,10 +182,11 @@ namespace edm {
                              ComponentDescription const*& iDesc,
                              bool iTransientAccessOnly,
                              std::shared_ptr<ESHandleExceptionFactory>& whyFailedFactory,
+                             ESParentContext const& iParent,
                              EventSetupImpl const* iEventSetupImpl) const {
         DataKey dataKey(DataKey::makeTypeTag<DataT>(), iName, DataKey::kDoNotCopyMemory);
 
-        void const* pValue = this->getFromProxy(dataKey, iDesc, iTransientAccessOnly, iEventSetupImpl);
+        void const* pValue = this->getFromProxy(dataKey, iDesc, iTransientAccessOnly, iParent, iEventSetupImpl);
         if (nullptr == pValue) {
           whyFailedFactory = makeESHandleExceptionFactory([=] {
             NoProxyException<DataT> ex(this->key(), dataKey);

--- a/FWCore/Framework/interface/EventSetupRecordImpl.h
+++ b/FWCore/Framework/interface/EventSetupRecordImpl.h
@@ -149,6 +149,8 @@ namespace edm {
 
       void validate(ComponentDescription const*, ESInputTag const&) const;
 
+      ActivityRegistry const* activityRegistry() const noexcept { return activityRegistry_; }
+
       void addTraceInfoToCmsException(cms::Exception& iException,
                                       char const* iName,
                                       ComponentDescription const*,

--- a/FWCore/Framework/interface/stream/EDAnalyzerAdaptor.h
+++ b/FWCore/Framework/interface/stream/EDAnalyzerAdaptor.h
@@ -33,6 +33,7 @@
 #include "FWCore/Framework/interface/stream/makeGlobal.h"
 #include "FWCore/Framework/src/MakeModuleHelper.h"
 #include "FWCore/Framework/src/TransitionInfoTypes.h"
+#include "FWCore/ServiceRegistry/interface/ESParentContext.h"
 
 // forward declarations
 
@@ -151,9 +152,11 @@ namespace edm {
           r.setConsumer(consumer());
           Run const& cnstR = r;
           RunIndex ri = rp.index();
+          ESParentContext pc{mcc};
           const EventSetup c{info,
                              static_cast<unsigned int>(Transition::BeginRun),
                              this->consumer()->esGetTokenIndices(Transition::BeginRun),
+                             pc,
                              false};
           MyGlobalRun::beginRun(cnstR, c, m_global.get(), m_runs[ri]);
           typename T::RunContext rc(m_runs[ri].get(), m_global.get());
@@ -168,9 +171,11 @@ namespace edm {
 
           RunIndex ri = rp.index();
           typename T::RunContext rc(m_runs[ri].get(), m_global.get());
+          ESParentContext pc{mcc};
           const EventSetup c{info,
                              static_cast<unsigned int>(Transition::EndRun),
                              this->consumer()->esGetTokenIndices(Transition::EndRun),
+                             pc,
                              false};
           MyGlobalRunSummary::globalEndRun(r, c, &rc, m_runSummaries[ri].get());
           MyGlobalRun::endRun(r, c, &rc);
@@ -186,9 +191,11 @@ namespace edm {
           LuminosityBlockIndex li = lbp.index();
           RunIndex ri = lbp.runPrincipal().index();
           typename T::RunContext rc(m_runs[ri].get(), m_global.get());
+          ESParentContext pc{mcc};
           const EventSetup c{info,
                              static_cast<unsigned int>(Transition::BeginLuminosityBlock),
                              this->consumer()->esGetTokenIndices(Transition::BeginLuminosityBlock),
+                             pc,
                              false};
           MyGlobalLuminosityBlock::beginLuminosityBlock(cnstLb, c, &rc, m_lumis[li]);
           typename T::LuminosityBlockContext lc(m_lumis[li].get(), m_runs[ri].get(), m_global.get());
@@ -204,9 +211,11 @@ namespace edm {
           LuminosityBlockIndex li = lbp.index();
           RunIndex ri = lbp.runPrincipal().index();
           typename T::LuminosityBlockContext lc(m_lumis[li].get(), m_runs[ri].get(), m_global.get());
+          ESParentContext pc{mcc};
           const EventSetup c{info,
                              static_cast<unsigned int>(Transition::EndLuminosityBlock),
                              this->consumer()->esGetTokenIndices(Transition::EndLuminosityBlock),
+                             pc,
                              false};
           MyGlobalLuminosityBlockSummary::globalEndLuminosityBlock(lb, c, &lc, m_lumiSummaries[li].get());
           MyGlobalLuminosityBlock::endLuminosityBlock(lb, c, &lc);

--- a/FWCore/Framework/interface/stream/ProducingModuleAdaptor.h
+++ b/FWCore/Framework/interface/stream/ProducingModuleAdaptor.h
@@ -31,6 +31,7 @@
 #include "FWCore/Framework/interface/stream/dummy_helpers.h"
 #include "FWCore/Framework/interface/stream/makeGlobal.h"
 #include "FWCore/Framework/src/TransitionInfoTypes.h"
+#include "FWCore/ServiceRegistry/interface/ESParentContext.h"
 // forward declarations
 
 namespace edm {
@@ -166,9 +167,11 @@ namespace edm {
           r.setProducer(this->producer());
           Run const& cnstR = r;
           RunIndex ri = rp.index();
+          ESParentContext parentC(mcc);
           const EventSetup c{info,
                              static_cast<unsigned int>(Transition::BeginRun),
                              this->consumer()->esGetTokenIndices(Transition::BeginRun),
+                             parentC,
                              false};
           MyGlobalRun::beginRun(cnstR, c, m_global.get(), m_runs[ri]);
           typename T::RunContext rc(m_runs[ri].get(), m_global.get());
@@ -189,9 +192,11 @@ namespace edm {
 
           RunIndex ri = rp.index();
           typename T::RunContext rc(m_runs[ri].get(), m_global.get());
+          ESParentContext parentC(mcc);
           const EventSetup c{info,
                              static_cast<unsigned int>(Transition::EndRun),
                              this->consumer()->esGetTokenIndices(Transition::EndRun),
+                             parentC,
                              false};
           MyGlobalRunSummary::globalEndRun(r, c, &rc, m_runSummaries[ri].get());
           if constexpr (T::HasAbility::kEndRunProducer) {
@@ -213,9 +218,11 @@ namespace edm {
           LuminosityBlockIndex li = lbp.index();
           RunIndex ri = lbp.runPrincipal().index();
           typename T::RunContext rc(m_runs[ri].get(), m_global.get());
+          ESParentContext parentC(mcc);
           const EventSetup c{info,
                              static_cast<unsigned int>(Transition::BeginLuminosityBlock),
                              this->consumer()->esGetTokenIndices(Transition::BeginLuminosityBlock),
+                             parentC,
                              false};
 
           MyGlobalLuminosityBlock::beginLuminosityBlock(cnstLb, c, &rc, m_lumis[li]);
@@ -238,9 +245,11 @@ namespace edm {
           LuminosityBlockIndex li = lbp.index();
           RunIndex ri = lbp.runPrincipal().index();
           typename T::LuminosityBlockContext lc(m_lumis[li].get(), m_runs[ri].get(), m_global.get());
+          ESParentContext parentC(mcc);
           const EventSetup c{info,
                              static_cast<unsigned int>(Transition::EndLuminosityBlock),
                              this->consumer()->esGetTokenIndices(Transition::EndLuminosityBlock),
+                             parentC,
                              false};
           MyGlobalLuminosityBlockSummary::globalEndLuminosityBlock(lb, c, &lc, m_lumiSummaries[li].get());
           if constexpr (T::HasAbility::kEndLuminosityBlockProducer) {

--- a/FWCore/Framework/src/EDAnalyzer.cc
+++ b/FWCore/Framework/src/EDAnalyzer.cc
@@ -21,6 +21,7 @@
 #include "DataFormats/Provenance/interface/ProductRegistry.h"
 
 #include "FWCore/ServiceRegistry/interface/Service.h"
+#include "FWCore/ServiceRegistry/interface/ESParentContext.h"
 
 namespace edm {
   EDAnalyzer::~EDAnalyzer() {}
@@ -33,7 +34,9 @@ namespace edm {
     e.setConsumer(this);
     e.setSharedResourcesAcquirer(&resourceAcquirer_);
     EventSignalsSentry sentry(act, mcc);
-    const EventSetup c{info, static_cast<unsigned int>(Transition::Event), esGetTokenIndices(Transition::Event), false};
+    ESParentContext parentC(mcc);
+    const EventSetup c{
+        info, static_cast<unsigned int>(Transition::Event), esGetTokenIndices(Transition::Event), parentC, false};
     this->analyze(e, c);
     return true;
   }
@@ -50,8 +53,9 @@ namespace edm {
   bool EDAnalyzer::doBeginRun(RunTransitionInfo const& info, ModuleCallingContext const* mcc) {
     Run r(info, moduleDescription_, mcc, false);
     r.setConsumer(this);
+    ESParentContext parentC(mcc);
     const EventSetup c{
-        info, static_cast<unsigned int>(Transition::BeginRun), esGetTokenIndices(Transition::BeginRun), false};
+        info, static_cast<unsigned int>(Transition::BeginRun), esGetTokenIndices(Transition::BeginRun), parentC, false};
     this->beginRun(r, c);
     return true;
   }
@@ -59,8 +63,9 @@ namespace edm {
   bool EDAnalyzer::doEndRun(RunTransitionInfo const& info, ModuleCallingContext const* mcc) {
     Run r(info, moduleDescription_, mcc, true);
     r.setConsumer(this);
+    ESParentContext parentC(mcc);
     const EventSetup c{
-        info, static_cast<unsigned int>(Transition::EndRun), esGetTokenIndices(Transition::EndRun), false};
+        info, static_cast<unsigned int>(Transition::EndRun), esGetTokenIndices(Transition::EndRun), parentC, false};
     this->endRun(r, c);
     return true;
   }
@@ -68,9 +73,11 @@ namespace edm {
   bool EDAnalyzer::doBeginLuminosityBlock(LumiTransitionInfo const& info, ModuleCallingContext const* mcc) {
     LuminosityBlock lb(info, moduleDescription_, mcc, false);
     lb.setConsumer(this);
+    ESParentContext parentC(mcc);
     const EventSetup c{info,
                        static_cast<unsigned int>(Transition::BeginLuminosityBlock),
                        esGetTokenIndices(Transition::BeginLuminosityBlock),
+                       parentC,
                        false};
     this->beginLuminosityBlock(lb, c);
     return true;
@@ -79,9 +86,11 @@ namespace edm {
   bool EDAnalyzer::doEndLuminosityBlock(LumiTransitionInfo const& info, ModuleCallingContext const* mcc) {
     LuminosityBlock lb(info, moduleDescription_, mcc, true);
     lb.setConsumer(this);
+    ESParentContext parentC(mcc);
     const EventSetup c{info,
                        static_cast<unsigned int>(Transition::EndLuminosityBlock),
                        esGetTokenIndices(Transition::EndLuminosityBlock),
+                       parentC,
                        false};
     this->endLuminosityBlock(lb, c);
     return true;

--- a/FWCore/Framework/src/EDFilter.cc
+++ b/FWCore/Framework/src/EDFilter.cc
@@ -11,6 +11,7 @@
 #include "FWCore/Framework/src/edmodule_mightGet_config.h"
 #include "FWCore/Framework/src/EventSignalsSentry.h"
 #include "FWCore/Framework/src/TransitionInfoTypes.h"
+#include "FWCore/ServiceRegistry/interface/ESParentContext.h"
 
 #include "SharedResourcesRegistry.h"
 
@@ -32,8 +33,11 @@ namespace edm {
     e.setProducer(this, &previousParentage_);
     e.setSharedResourcesAcquirer(&resourceAcquirer_);
     EventSignalsSentry sentry(act, mcc);
+    ESParentContext parentC(mcc);
     rc = this->filter(
-        e, EventSetup{info, static_cast<unsigned int>(Transition::Event), esGetTokenIndices(Transition::Event), false});
+        e,
+        EventSetup{
+            info, static_cast<unsigned int>(Transition::Event), esGetTokenIndices(Transition::Event), parentC, false});
     commit_(e, &previousParentageId_);
     return rc;
   }
@@ -51,10 +55,13 @@ namespace edm {
     Run r(info, moduleDescription_, mcc, false);
     r.setConsumer(this);
     Run const& cnstR = r;
-    this->beginRun(
-        cnstR,
-        EventSetup{
-            info, static_cast<unsigned int>(Transition::BeginRun), esGetTokenIndices(Transition::BeginRun), false});
+    ESParentContext parentC(mcc);
+    this->beginRun(cnstR,
+                   EventSetup{info,
+                              static_cast<unsigned int>(Transition::BeginRun),
+                              esGetTokenIndices(Transition::BeginRun),
+                              parentC,
+                              false});
     commit_(r);
     return;
   }
@@ -63,9 +70,11 @@ namespace edm {
     Run r(info, moduleDescription_, mcc, true);
     r.setConsumer(this);
     Run const& cnstR = r;
+    ESParentContext parentC(mcc);
     this->endRun(
         cnstR,
-        EventSetup{info, static_cast<unsigned int>(Transition::EndRun), esGetTokenIndices(Transition::EndRun), false});
+        EventSetup{
+            info, static_cast<unsigned int>(Transition::EndRun), esGetTokenIndices(Transition::EndRun), parentC, false});
     commit_(r);
     return;
   }
@@ -74,10 +83,12 @@ namespace edm {
     LuminosityBlock lb(info, moduleDescription_, mcc, false);
     lb.setConsumer(this);
     LuminosityBlock const& cnstLb = lb;
+    ESParentContext parentC(mcc);
     this->beginLuminosityBlock(cnstLb,
                                EventSetup{info,
                                           static_cast<unsigned int>(Transition::BeginLuminosityBlock),
                                           esGetTokenIndices(Transition::BeginLuminosityBlock),
+                                          parentC,
                                           false});
     commit_(lb);
   }
@@ -86,10 +97,12 @@ namespace edm {
     LuminosityBlock lb(info, moduleDescription_, mcc, true);
     lb.setConsumer(this);
     LuminosityBlock const& cnstLb = lb;
+    ESParentContext parentC(mcc);
     this->endLuminosityBlock(cnstLb,
                              EventSetup{info,
                                         static_cast<unsigned int>(Transition::EndLuminosityBlock),
                                         esGetTokenIndices(Transition::EndLuminosityBlock),
+                                        parentC,
                                         false});
     commit_(lb);
     return;

--- a/FWCore/Framework/src/EDLooperBase.cc
+++ b/FWCore/Framework/src/EDLooperBase.cc
@@ -26,6 +26,7 @@
 #include "FWCore/ServiceRegistry/interface/ModuleCallingContext.h"
 #include "FWCore/ServiceRegistry/interface/ParentContext.h"
 #include "FWCore/ServiceRegistry/interface/StreamContext.h"
+#include "FWCore/ServiceRegistry/interface/ESParentContext.h"
 
 namespace edm {
 
@@ -54,7 +55,8 @@ namespace edm {
 
     Status status = kContinue;
     try {
-      const EventSetup es{esi, static_cast<unsigned int>(Transition::Event), nullptr, false};
+      ESParentContext parentC(&moduleCallingContext_);
+      const EventSetup es{esi, static_cast<unsigned int>(Transition::Event), nullptr, parentC, false};
       status = duringLoop(event, es, ioController);
     } catch (cms::Exception& e) {
       e.addContext("Calling the 'duringLoop' method of a looper");
@@ -69,7 +71,8 @@ namespace edm {
   }
 
   EDLooperBase::Status EDLooperBase::doEndOfLoop(const edm::EventSetupImpl& esi) {
-    const EventSetup es{esi, static_cast<unsigned int>(Transition::EndRun), nullptr, false};
+    ESParentContext parentC(&moduleCallingContext_);
+    const EventSetup es{esi, static_cast<unsigned int>(Transition::EndRun), nullptr, parentC, false};
     return endOfLoop(es, iCounter_);
   }
 
@@ -82,7 +85,8 @@ namespace edm {
   }
 
   void EDLooperBase::beginOfJob(const edm::EventSetupImpl& iImpl) {
-    beginOfJob(EventSetup{iImpl, static_cast<unsigned int>(Transition::BeginRun), nullptr, false});
+    ESParentContext parentC(&moduleCallingContext_);
+    beginOfJob(EventSetup{iImpl, static_cast<unsigned int>(Transition::BeginRun), nullptr, parentC, false});
   }
   void EDLooperBase::beginOfJob(const edm::EventSetup&) { beginOfJob(); }
   void EDLooperBase::beginOfJob() {}
@@ -99,7 +103,8 @@ namespace edm {
     ParentContext parentContext(&globalContext);
     ModuleContextSentry moduleContextSentry(&moduleCallingContext_, parentContext);
     Run run(iRP, moduleDescription_, &moduleCallingContext_, false);
-    const EventSetup es{iES, static_cast<unsigned int>(Transition::BeginRun), nullptr, false};
+    ESParentContext parentC(&moduleCallingContext_);
+    const EventSetup es{iES, static_cast<unsigned int>(Transition::BeginRun), nullptr, parentC, false};
     beginRun(run, es);
   }
 
@@ -113,7 +118,8 @@ namespace edm {
     ParentContext parentContext(&globalContext);
     ModuleContextSentry moduleContextSentry(&moduleCallingContext_, parentContext);
     Run run(iRP, moduleDescription_, &moduleCallingContext_, true);
-    const EventSetup es{iES, static_cast<unsigned int>(Transition::EndRun), nullptr, false};
+    ESParentContext parentC(&moduleCallingContext_);
+    const EventSetup es{iES, static_cast<unsigned int>(Transition::EndRun), nullptr, parentC, false};
     endRun(run, es);
   }
   void EDLooperBase::doBeginLuminosityBlock(LuminosityBlockPrincipal& iLB,
@@ -128,7 +134,8 @@ namespace edm {
     ParentContext parentContext(&globalContext);
     ModuleContextSentry moduleContextSentry(&moduleCallingContext_, parentContext);
     LuminosityBlock luminosityBlock(iLB, moduleDescription_, &moduleCallingContext_, false);
-    const EventSetup es{iES, static_cast<unsigned int>(Transition::BeginLuminosityBlock), nullptr, false};
+    ESParentContext parentC(&moduleCallingContext_);
+    const EventSetup es{iES, static_cast<unsigned int>(Transition::BeginLuminosityBlock), nullptr, parentC, false};
     beginLuminosityBlock(luminosityBlock, es);
   }
   void EDLooperBase::doEndLuminosityBlock(LuminosityBlockPrincipal& iLB,
@@ -143,7 +150,8 @@ namespace edm {
     ParentContext parentContext(&globalContext);
     ModuleContextSentry moduleContextSentry(&moduleCallingContext_, parentContext);
     LuminosityBlock luminosityBlock(iLB, moduleDescription_, &moduleCallingContext_, true);
-    const EventSetup es{iES, static_cast<unsigned int>(Transition::EndLuminosityBlock), nullptr, false};
+    ESParentContext parentC(&moduleCallingContext_);
+    const EventSetup es{iES, static_cast<unsigned int>(Transition::EndLuminosityBlock), nullptr, parentC, false};
     endLuminosityBlock(luminosityBlock, es);
   }
 

--- a/FWCore/Framework/src/EDProducer.cc
+++ b/FWCore/Framework/src/EDProducer.cc
@@ -11,6 +11,7 @@
 #include "FWCore/Framework/src/edmodule_mightGet_config.h"
 #include "FWCore/Framework/src/EventSignalsSentry.h"
 #include "FWCore/Framework/src/TransitionInfoTypes.h"
+#include "FWCore/ServiceRegistry/interface/ESParentContext.h"
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 
@@ -29,7 +30,9 @@ namespace edm {
     e.setProducer(this, &previousParentage_);
     e.setSharedResourcesAcquirer(&resourceAcquirer_);
     EventSignalsSentry sentry(act, mcc);
-    const EventSetup c{info, static_cast<unsigned int>(Transition::Event), esGetTokenIndices(Transition::Event), false};
+    ESParentContext parentC(mcc);
+    const EventSetup c{
+        info, static_cast<unsigned int>(Transition::Event), esGetTokenIndices(Transition::Event), parentC, false};
     this->produce(e, c);
     commit_(e, &previousParentageId_);
     return true;
@@ -47,8 +50,9 @@ namespace edm {
     Run r(info, moduleDescription_, mcc, false);
     r.setConsumer(this);
     Run const& cnstR = r;
+    ESParentContext parentC(mcc);
     const EventSetup c{
-        info, static_cast<unsigned int>(Transition::BeginRun), esGetTokenIndices(Transition::BeginRun), false};
+        info, static_cast<unsigned int>(Transition::BeginRun), esGetTokenIndices(Transition::BeginRun), parentC, false};
     this->beginRun(cnstR, c);
     commit_(r);
   }
@@ -57,8 +61,9 @@ namespace edm {
     Run r(info, moduleDescription_, mcc, true);
     r.setConsumer(this);
     Run const& cnstR = r;
+    ESParentContext parentC(mcc);
     const EventSetup c{
-        info, static_cast<unsigned int>(Transition::EndRun), esGetTokenIndices(Transition::EndRun), false};
+        info, static_cast<unsigned int>(Transition::EndRun), esGetTokenIndices(Transition::EndRun), parentC, false};
     this->endRun(cnstR, c);
     commit_(r);
   }
@@ -67,9 +72,11 @@ namespace edm {
     LuminosityBlock lb(info, moduleDescription_, mcc, false);
     lb.setConsumer(this);
     LuminosityBlock const& cnstLb = lb;
+    ESParentContext parentC(mcc);
     const EventSetup c{info,
                        static_cast<unsigned int>(Transition::BeginLuminosityBlock),
                        esGetTokenIndices(Transition::BeginLuminosityBlock),
+                       parentC,
                        false};
     this->beginLuminosityBlock(cnstLb, c);
     commit_(lb);
@@ -78,9 +85,11 @@ namespace edm {
   void EDProducer::doEndLuminosityBlock(LumiTransitionInfo const& info, ModuleCallingContext const* mcc) {
     LuminosityBlock lb(info, moduleDescription_, mcc, true);
     lb.setConsumer(this);
+    ESParentContext parentC(mcc);
     const EventSetup c{info,
                        static_cast<unsigned int>(Transition::EndLuminosityBlock),
                        esGetTokenIndices(Transition::EndLuminosityBlock),
+                       parentC,
                        false};
     LuminosityBlock const& cnstLb = lb;
     this->endLuminosityBlock(cnstLb, c);

--- a/FWCore/Framework/src/ESSourceDataProxyBase.cc
+++ b/FWCore/Framework/src/ESSourceDataProxyBase.cc
@@ -24,7 +24,8 @@ void edm::eventsetup::ESSourceDataProxyBase::prefetchAsyncImpl(edm::WaitingTaskH
                                                                edm::eventsetup::EventSetupRecordImpl const& iRecord,
                                                                edm::eventsetup::DataKey const& iKey,
                                                                edm::EventSetupImpl const*,
-                                                               edm::ServiceToken const&) {
+                                                               edm::ServiceToken const&,
+                                                               edm::ESParentContext const&) {
   bool expected = false;
   auto doPrefetch = m_prefetching.compare_exchange_strong(expected, true);
   m_waitingList.add(iTask);

--- a/FWCore/Framework/src/ESSourceDataProxyBase.cc
+++ b/FWCore/Framework/src/ESSourceDataProxyBase.cc
@@ -15,6 +15,8 @@
 // user include files
 #include "FWCore/Framework/interface/ESSourceDataProxyBase.h"
 #include "FWCore/Framework/interface/DataKey.h"
+#include "FWCore/ServiceRegistry/interface/ESModuleCallingContext.h"
+#include "FWCore/ServiceRegistry/interface/ActivityRegistry.h"
 
 //
 // member functions
@@ -25,15 +27,24 @@ void edm::eventsetup::ESSourceDataProxyBase::prefetchAsyncImpl(edm::WaitingTaskH
                                                                edm::eventsetup::DataKey const& iKey,
                                                                edm::EventSetupImpl const*,
                                                                edm::ServiceToken const&,
-                                                               edm::ESParentContext const&) {
+                                                               edm::ESParentContext const& iParent) {
   bool expected = false;
   auto doPrefetch = m_prefetching.compare_exchange_strong(expected, true);
   m_waitingList.add(iTask);
   if (doPrefetch) {
-    m_queue->push([this, iKey, &iRecord]() {
+    m_queue->push([this, iKey, &iRecord, iParent]() {
       try {
         {
           std::lock_guard<std::mutex> guard(*m_mutex);
+          edm::ESModuleCallingContext context(providerDescription(), ESModuleCallingContext::State::kRunning, iParent);
+          iRecord.activityRegistry()->preESModuleSignal_.emit(iRecord.key(), context);
+          struct EndGuard {
+            EndGuard(EventSetupRecordImpl const& iRecord, ESModuleCallingContext const& iContext)
+                : record_{iRecord}, context_{iContext} {}
+            ~EndGuard() { record_.activityRegistry()->postESModuleSignal_.emit(record_.key(), context_); }
+            EventSetupRecordImpl const& record_;
+            ESModuleCallingContext const& context_;
+          } guardAR(iRecord, context);
           prefetch(iKey, EventSetupRecordDetails(&iRecord));
         }
         m_waitingList.doneWaiting(std::exception_ptr{});

--- a/FWCore/Framework/src/EventSetupImpl.cc
+++ b/FWCore/Framework/src/EventSetupImpl.cc
@@ -44,7 +44,8 @@ namespace edm {
 
   std::optional<eventsetup::EventSetupRecordGeneric> EventSetupImpl::find(const eventsetup::EventSetupRecordKey& iKey,
                                                                           unsigned int iTransitionID,
-                                                                          ESProxyIndex const* getTokenIndices) const {
+                                                                          ESProxyIndex const* getTokenIndices,
+                                                                          ESParentContext const& iParent) const {
     auto lb = std::lower_bound(keysBegin_, keysEnd_, iKey);
     if (lb == keysEnd_ || iKey != *lb) {
       return std::nullopt;
@@ -53,7 +54,7 @@ namespace edm {
     if (recordImpls_[index] == nullptr) {
       return std::nullopt;
     }
-    return eventsetup::EventSetupRecordGeneric(recordImpls_[index], iTransitionID, getTokenIndices, this);
+    return eventsetup::EventSetupRecordGeneric(recordImpls_[index], iTransitionID, getTokenIndices, this, &iParent);
   }
 
   eventsetup::EventSetupRecordImpl const* EventSetupImpl::findImpl(const eventsetup::EventSetupRecordKey& iKey) const {

--- a/FWCore/Framework/src/EventSetupRecordImpl.cc
+++ b/FWCore/Framework/src/EventSetupRecordImpl.cc
@@ -18,6 +18,7 @@
 #include "FWCore/Framework/interface/EventSetupRecordImpl.h"
 #include "FWCore/Framework/interface/DataProxy.h"
 #include "FWCore/Framework/interface/ComponentDescription.h"
+#include "FWCore/ServiceRegistry/interface/ESParentContext.h"
 
 #include "FWCore/Concurrency/interface/WaitingTaskHolder.h"
 #include "FWCore/Utilities/interface/ConvertException.h"
@@ -181,6 +182,7 @@ namespace edm {
     const void* EventSetupRecordImpl::getFromProxy(DataKey const& iKey,
                                                    const ComponentDescription*& iDesc,
                                                    bool iTransientAccessOnly,
+                                                   ESParentContext const& iParent,
                                                    EventSetupImpl const* iEventSetupImpl) const {
       const DataProxy* proxy = this->find(iKey);
 
@@ -189,7 +191,7 @@ namespace edm {
       if (nullptr != proxy) {
         try {
           convertException::wrap([&]() {
-            hold = proxy->get(*this, iKey, iTransientAccessOnly, activityRegistry_, iEventSetupImpl);
+            hold = proxy->get(*this, iKey, iTransientAccessOnly, activityRegistry_, iEventSetupImpl, iParent);
             iDesc = proxy->providerDescription();
           });
         } catch (cms::Exception& e) {
@@ -206,6 +208,7 @@ namespace edm {
                                                    bool iTransientAccessOnly,
                                                    const ComponentDescription*& iDesc,
                                                    DataKey const*& oGottenKey,
+                                                   ESParentContext const& iParent,
                                                    EventSetupImpl const* iEventSetupImpl) const {
       if (iProxyIndex.value() >= static_cast<ESProxyIndex::Value_t>(proxies_.size())) {
         return nullptr;
@@ -220,8 +223,9 @@ namespace edm {
       auto const& key = keysForProxies_[iProxyIndex.value()];
       oGottenKey = &key;
       try {
-        convertException::wrap(
-            [&]() { hold = proxy->get(*this, key, iTransientAccessOnly, activityRegistry_, iEventSetupImpl); });
+        convertException::wrap([&]() {
+          hold = proxy->get(*this, key, iTransientAccessOnly, activityRegistry_, iEventSetupImpl, iParent);
+        });
       } catch (cms::Exception& e) {
         addTraceInfoToCmsException(e, key.name().value(), proxy->providerDescription(), key);
         throw;
@@ -261,7 +265,8 @@ namespace edm {
     void EventSetupRecordImpl::prefetchAsync(WaitingTaskHolder iTask,
                                              ESProxyIndex iProxyIndex,
                                              EventSetupImpl const* iEventSetupImpl,
-                                             ServiceToken const& iToken) const {
+                                             ServiceToken const& iToken,
+                                             ESParentContext iParent) const {
       if UNLIKELY (iProxyIndex.value() == std::numeric_limits<int>::max()) {
         return;
       }
@@ -269,7 +274,7 @@ namespace edm {
       const DataProxy* proxy = proxies_[iProxyIndex.value()];
       if (nullptr != proxy) {
         auto const& key = keysForProxies_[iProxyIndex.value()];
-        proxy->prefetchAsync(iTask, *this, key, iEventSetupImpl, iToken);
+        proxy->prefetchAsync(iTask, *this, key, iEventSetupImpl, iToken, iParent);
       }
     }
 

--- a/FWCore/Framework/src/Worker.cc
+++ b/FWCore/Framework/src/Worker.cc
@@ -10,6 +10,7 @@
 #include "FWCore/Framework/interface/ProcessBlockPrincipal.h"
 #include "FWCore/Framework/interface/RunPrincipal.h"
 #include "FWCore/ServiceRegistry/interface/StreamContext.h"
+#include "FWCore/ServiceRegistry/interface/ESParentContext.h"
 #include "FWCore/Concurrency/interface/WaitingTask.h"
 #include "FWCore/Concurrency/interface/WaitingTaskHolder.h"
 #include "FWCore/Concurrency/interface/WaitingTaskWithArenaHolder.h"
@@ -282,7 +283,7 @@ namespace edm {
                   if (recs[i] != ESRecordIndex{}) {
                     auto rec = iImpl.findImpl(recs[i]);
                     if (rec) {
-                      rec->prefetchAsync(hWaitTask, items[i], &iImpl, iToken);
+                      rec->prefetchAsync(hWaitTask, items[i], &iImpl, iToken, ESParentContext(&moduleCallingContext_));
                     }
                   }
                 }
@@ -319,7 +320,7 @@ namespace edm {
           if (recs[i] != ESRecordIndex{}) {
             auto rec = iImpl.findImpl(recs[i]);
             if (rec) {
-              rec->prefetchAsync(tempH, items[i], &iImpl, iToken);
+              rec->prefetchAsync(tempH, items[i], &iImpl, iToken, ESParentContext(&moduleCallingContext_));
             }
           }
         }

--- a/FWCore/Framework/src/global/EDAnalyzerBase.cc
+++ b/FWCore/Framework/src/global/EDAnalyzerBase.cc
@@ -30,6 +30,7 @@
 #include "DataFormats/Provenance/interface/ProductRegistry.h"
 
 #include "FWCore/ServiceRegistry/interface/Service.h"
+#include "FWCore/ServiceRegistry/interface/ESParentContext.h"
 #include "FWCore/Framework/interface/ConstProductRegistry.h"
 
 //
@@ -54,8 +55,9 @@ namespace edm {
       Event e(info, moduleDescription_, mcc);
       e.setConsumer(this);
       EventSignalsSentry sentry(act, mcc);
+      ESParentContext parentC(mcc);
       const EventSetup c{
-          info, static_cast<unsigned int>(Transition::Event), esGetTokenIndices(Transition::Event), false};
+          info, static_cast<unsigned int>(Transition::Event), esGetTokenIndices(Transition::Event), parentC, false};
       this->analyze(e.streamID(), e, c);
       return true;
     }
@@ -96,8 +98,12 @@ namespace edm {
       Run r(info, moduleDescription_, mcc, false);
       r.setConsumer(this);
       Run const& cnstR = r;
-      const EventSetup c{
-          info, static_cast<unsigned int>(Transition::BeginRun), esGetTokenIndices(Transition::BeginRun), false};
+      ESParentContext parentC(mcc);
+      const EventSetup c{info,
+                         static_cast<unsigned int>(Transition::BeginRun),
+                         esGetTokenIndices(Transition::BeginRun),
+                         parentC,
+                         false};
       this->doBeginRun_(cnstR, c);
       this->doBeginRunSummary_(cnstR, c);
     }
@@ -106,8 +112,9 @@ namespace edm {
       Run r(info, moduleDescription_, mcc, true);
       r.setConsumer(this);
       Run const& cnstR = r;
+      ESParentContext parentC(mcc);
       const EventSetup c{
-          info, static_cast<unsigned int>(Transition::EndRun), esGetTokenIndices(Transition::EndRun), false};
+          info, static_cast<unsigned int>(Transition::EndRun), esGetTokenIndices(Transition::EndRun), parentC, false};
       this->doEndRunSummary_(r, c);
       this->doEndRun_(cnstR, c);
     }
@@ -116,9 +123,11 @@ namespace edm {
       LuminosityBlock lb(info, moduleDescription_, mcc, false);
       lb.setConsumer(this);
       LuminosityBlock const& cnstLb = lb;
+      ESParentContext parentC(mcc);
       const EventSetup c{info,
                          static_cast<unsigned int>(Transition::BeginLuminosityBlock),
                          esGetTokenIndices(Transition::BeginLuminosityBlock),
+                         parentC,
                          false};
       this->doBeginLuminosityBlock_(cnstLb, c);
       this->doBeginLuminosityBlockSummary_(cnstLb, c);
@@ -128,9 +137,11 @@ namespace edm {
       LuminosityBlock lb(info, moduleDescription_, mcc, true);
       lb.setConsumer(this);
       LuminosityBlock const& cnstLb = lb;
+      ESParentContext parentC(mcc);
       const EventSetup c{info,
                          static_cast<unsigned int>(Transition::EndLuminosityBlock),
                          esGetTokenIndices(Transition::EndLuminosityBlock),
+                         parentC,
                          false};
       this->doEndLuminosityBlockSummary_(cnstLb, c);
       this->doEndLuminosityBlock_(cnstLb, c);
@@ -141,15 +152,20 @@ namespace edm {
     void EDAnalyzerBase::doStreamBeginRun(StreamID id, RunTransitionInfo const& info, ModuleCallingContext const* mcc) {
       Run r(info, moduleDescription_, mcc, false);
       r.setConsumer(this);
-      const EventSetup c{
-          info, static_cast<unsigned int>(Transition::BeginRun), esGetTokenIndices(Transition::BeginRun), false};
+      ESParentContext parentC(mcc);
+      const EventSetup c{info,
+                         static_cast<unsigned int>(Transition::BeginRun),
+                         esGetTokenIndices(Transition::BeginRun),
+                         parentC,
+                         false};
       this->doStreamBeginRun_(id, r, c);
     }
     void EDAnalyzerBase::doStreamEndRun(StreamID id, RunTransitionInfo const& info, ModuleCallingContext const* mcc) {
       Run r(info, moduleDescription_, mcc, true);
       r.setConsumer(this);
+      ESParentContext parentC(mcc);
       const EventSetup c{
-          info, static_cast<unsigned int>(Transition::EndRun), esGetTokenIndices(Transition::EndRun), false};
+          info, static_cast<unsigned int>(Transition::EndRun), esGetTokenIndices(Transition::EndRun), parentC, false};
       this->doStreamEndRun_(id, r, c);
       this->doStreamEndRunSummary_(id, r, c);
     }
@@ -158,9 +174,11 @@ namespace edm {
                                                       ModuleCallingContext const* mcc) {
       LuminosityBlock lb(info, moduleDescription_, mcc, false);
       lb.setConsumer(this);
+      ESParentContext parentC(mcc);
       const EventSetup c{info,
                          static_cast<unsigned int>(Transition::BeginLuminosityBlock),
                          esGetTokenIndices(Transition::BeginLuminosityBlock),
+                         parentC,
                          false};
       this->doStreamBeginLuminosityBlock_(id, lb, c);
     }
@@ -170,9 +188,11 @@ namespace edm {
                                                     ModuleCallingContext const* mcc) {
       LuminosityBlock lb(info, moduleDescription_, mcc, true);
       lb.setConsumer(this);
+      ESParentContext parentC(mcc);
       const EventSetup c{info,
                          static_cast<unsigned int>(Transition::EndLuminosityBlock),
                          esGetTokenIndices(Transition::EndLuminosityBlock),
+                         parentC,
                          false};
       this->doStreamEndLuminosityBlock_(id, lb, c);
       this->doStreamEndLuminosityBlockSummary_(id, lb, c);

--- a/FWCore/Framework/src/global/EDFilterBase.cc
+++ b/FWCore/Framework/src/global/EDFilterBase.cc
@@ -26,6 +26,7 @@
 #include "FWCore/Framework/src/PreallocationConfiguration.h"
 #include "FWCore/Framework/src/edmodule_mightGet_config.h"
 #include "FWCore/Framework/src/TransitionInfoTypes.h"
+#include "FWCore/ServiceRegistry/interface/ESParentContext.h"
 
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
@@ -59,8 +60,9 @@ namespace edm {
       e.setProducer(
           this, &previousParentages_[streamIndex], hasAcquire() ? &gotBranchIDsFromAcquire_[streamIndex] : nullptr);
       EventSignalsSentry sentry(act, mcc);
+      ESParentContext parentC(mcc);
       const EventSetup c{
-          info, static_cast<unsigned int>(Transition::Event), esGetTokenIndices(Transition::Event), false};
+          info, static_cast<unsigned int>(Transition::Event), esGetTokenIndices(Transition::Event), parentC, false};
       bool returnValue = this->filter(e.streamID(), e, c);
       commit_(e, &previousParentageIds_[streamIndex]);
       return returnValue;
@@ -75,8 +77,9 @@ namespace edm {
       const auto streamIndex = e.streamID().value();
       e.setProducerForAcquire(this, nullptr, gotBranchIDsFromAcquire_[streamIndex]);
       EventAcquireSignalsSentry sentry(act, mcc);
+      ESParentContext parentC(mcc);
       const EventSetup c{
-          info, static_cast<unsigned int>(Transition::Event), esGetTokenIndices(Transition::Event), false};
+          info, static_cast<unsigned int>(Transition::Event), esGetTokenIndices(Transition::Event), parentC, false};
       this->doAcquire_(e.streamID(), e, c, holder);
     }
 
@@ -128,8 +131,12 @@ namespace edm {
       Run r(info, moduleDescription_, mcc, false);
       r.setConsumer(this);
       Run const& cnstR = r;
-      const EventSetup c{
-          info, static_cast<unsigned int>(Transition::BeginRun), esGetTokenIndices(Transition::BeginRun), false};
+      ESParentContext parentC(mcc);
+      const EventSetup c{info,
+                         static_cast<unsigned int>(Transition::BeginRun),
+                         esGetTokenIndices(Transition::BeginRun),
+                         parentC,
+                         false};
       this->doBeginRun_(cnstR, c);
       this->doBeginRunSummary_(cnstR, c);
       r.setProducer(this);
@@ -142,8 +149,9 @@ namespace edm {
       r.setConsumer(this);
       r.setProducer(this);
       Run const& cnstR = r;
+      ESParentContext parentC(mcc);
       const EventSetup c{
-          info, static_cast<unsigned int>(Transition::EndRun), esGetTokenIndices(Transition::EndRun), false};
+          info, static_cast<unsigned int>(Transition::EndRun), esGetTokenIndices(Transition::EndRun), parentC, false};
       this->doEndRunSummary_(r, c);
       this->doEndRunProduce_(r, c);
       this->doEndRun_(cnstR, c);
@@ -154,9 +162,11 @@ namespace edm {
       LuminosityBlock lb(info, moduleDescription_, mcc, false);
       lb.setConsumer(this);
       LuminosityBlock const& cnstLb = lb;
+      ESParentContext parentC(mcc);
       const EventSetup c{info,
                          static_cast<unsigned int>(Transition::BeginLuminosityBlock),
                          esGetTokenIndices(Transition::BeginLuminosityBlock),
+                         parentC,
                          false};
       this->doBeginLuminosityBlock_(cnstLb, c);
       this->doBeginLuminosityBlockSummary_(cnstLb, c);
@@ -170,9 +180,11 @@ namespace edm {
       lb.setConsumer(this);
       lb.setProducer(this);
       LuminosityBlock const& cnstLb = lb;
+      ESParentContext parentC(mcc);
       const EventSetup c{info,
                          static_cast<unsigned int>(Transition::EndLuminosityBlock),
                          esGetTokenIndices(Transition::EndLuminosityBlock),
+                         parentC,
                          false};
       this->doEndLuminosityBlockSummary_(cnstLb, c);
       this->doEndLuminosityBlockProduce_(lb, c);
@@ -185,15 +197,20 @@ namespace edm {
     void EDFilterBase::doStreamBeginRun(StreamID id, RunTransitionInfo const& info, ModuleCallingContext const* mcc) {
       Run r(info, moduleDescription_, mcc, false);
       r.setConsumer(this);
-      const EventSetup c{
-          info, static_cast<unsigned int>(Transition::BeginRun), esGetTokenIndices(Transition::BeginRun), false};
+      ESParentContext parentC(mcc);
+      const EventSetup c{info,
+                         static_cast<unsigned int>(Transition::BeginRun),
+                         esGetTokenIndices(Transition::BeginRun),
+                         parentC,
+                         false};
       this->doStreamBeginRun_(id, r, c);
     }
     void EDFilterBase::doStreamEndRun(StreamID id, RunTransitionInfo const& info, ModuleCallingContext const* mcc) {
       Run r(info, moduleDescription_, mcc, true);
       r.setConsumer(this);
+      ESParentContext parentC(mcc);
       const EventSetup c{
-          info, static_cast<unsigned int>(Transition::EndRun), esGetTokenIndices(Transition::EndRun), false};
+          info, static_cast<unsigned int>(Transition::EndRun), esGetTokenIndices(Transition::EndRun), parentC, false};
       this->doStreamEndRun_(id, r, c);
       this->doStreamEndRunSummary_(id, r, c);
     }
@@ -202,9 +219,11 @@ namespace edm {
                                                     ModuleCallingContext const* mcc) {
       LuminosityBlock lb(info, moduleDescription_, mcc, false);
       lb.setConsumer(this);
+      ESParentContext parentC(mcc);
       const EventSetup c{info,
                          static_cast<unsigned int>(Transition::BeginLuminosityBlock),
                          esGetTokenIndices(Transition::BeginLuminosityBlock),
+                         parentC,
                          false};
       this->doStreamBeginLuminosityBlock_(id, lb, c);
     }
@@ -214,9 +233,11 @@ namespace edm {
                                                   ModuleCallingContext const* mcc) {
       LuminosityBlock lb(info, moduleDescription_, mcc, true);
       lb.setConsumer(this);
+      ESParentContext parentC(mcc);
       const EventSetup c{info,
                          static_cast<unsigned int>(Transition::EndLuminosityBlock),
                          esGetTokenIndices(Transition::EndLuminosityBlock),
+                         parentC,
                          false};
       this->doStreamEndLuminosityBlock_(id, lb, c);
       this->doStreamEndLuminosityBlockSummary_(id, lb, c);

--- a/FWCore/Framework/src/global/EDProducerBase.cc
+++ b/FWCore/Framework/src/global/EDProducerBase.cc
@@ -26,6 +26,7 @@
 #include "FWCore/Framework/src/PreallocationConfiguration.h"
 #include "FWCore/Framework/src/edmodule_mightGet_config.h"
 #include "FWCore/Framework/src/TransitionInfoTypes.h"
+#include "FWCore/ServiceRegistry/interface/ESParentContext.h"
 
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
@@ -63,10 +64,12 @@ namespace edm {
       e.setProducer(
           this, &previousParentages_[streamIndex], hasAcquire() ? &gotBranchIDsFromAcquire_[streamIndex] : nullptr);
       EventSignalsSentry sentry(act, mcc);
+      ESParentContext parentC(mcc);
       this->produce(
           e.streamID(),
           e,
-          EventSetup{info, static_cast<unsigned int>(Transition::Event), esGetTokenIndices(Transition::Event), false});
+          EventSetup{
+              info, static_cast<unsigned int>(Transition::Event), esGetTokenIndices(Transition::Event), parentC, false});
       commit_(e, &previousParentageIds_[streamIndex]);
       return true;
     }
@@ -80,8 +83,9 @@ namespace edm {
       const auto streamIndex = e.streamID().value();
       e.setProducerForAcquire(this, nullptr, gotBranchIDsFromAcquire_[streamIndex]);
       EventAcquireSignalsSentry sentry(act, mcc);
+      ESParentContext parentC(mcc);
       const EventSetup c{
-          info, static_cast<unsigned int>(Transition::Event), esGetTokenIndices(Transition::Event), false};
+          info, static_cast<unsigned int>(Transition::Event), esGetTokenIndices(Transition::Event), parentC, false};
       this->doAcquire_(e.streamID(), e, c, holder);
     }
 
@@ -133,8 +137,12 @@ namespace edm {
       Run r(info, moduleDescription_, mcc, false);
       r.setConsumer(this);
       Run const& cnstR = r;
-      const EventSetup c{
-          info, static_cast<unsigned int>(Transition::BeginRun), esGetTokenIndices(Transition::BeginRun), false};
+      ESParentContext parentC(mcc);
+      const EventSetup c{info,
+                         static_cast<unsigned int>(Transition::BeginRun),
+                         esGetTokenIndices(Transition::BeginRun),
+                         parentC,
+                         false};
       this->doBeginRun_(cnstR, c);
       this->doBeginRunSummary_(cnstR, c);
       r.setProducer(this);
@@ -147,8 +155,9 @@ namespace edm {
       r.setConsumer(this);
       r.setProducer(this);
       Run const& cnstR = r;
+      ESParentContext parentC(mcc);
       const EventSetup c{
-          info, static_cast<unsigned int>(Transition::EndRun), esGetTokenIndices(Transition::EndRun), false};
+          info, static_cast<unsigned int>(Transition::EndRun), esGetTokenIndices(Transition::EndRun), parentC, false};
       this->doEndRunSummary_(r, c);
       this->doEndRunProduce_(r, c);
       this->doEndRun_(cnstR, c);
@@ -159,9 +168,11 @@ namespace edm {
       LuminosityBlock lb(info, moduleDescription_, mcc, false);
       lb.setConsumer(this);
       LuminosityBlock const& cnstLb = lb;
+      ESParentContext parentC(mcc);
       const EventSetup c{info,
                          static_cast<unsigned int>(Transition::BeginLuminosityBlock),
                          esGetTokenIndices(Transition::BeginLuminosityBlock),
+                         parentC,
                          false};
       this->doBeginLuminosityBlock_(cnstLb, c);
       this->doBeginLuminosityBlockSummary_(cnstLb, c);
@@ -175,9 +186,11 @@ namespace edm {
       lb.setConsumer(this);
       lb.setProducer(this);
       LuminosityBlock const& cnstLb = lb;
+      ESParentContext parentC(mcc);
       const EventSetup c{info,
                          static_cast<unsigned int>(Transition::EndLuminosityBlock),
                          esGetTokenIndices(Transition::EndLuminosityBlock),
+                         parentC,
                          false};
       this->doEndLuminosityBlockSummary_(cnstLb, c);
       this->doEndLuminosityBlockProduce_(lb, c);
@@ -190,17 +203,21 @@ namespace edm {
     void EDProducerBase::doStreamBeginRun(StreamID id, RunTransitionInfo const& info, ModuleCallingContext const* mcc) {
       Run r(info, moduleDescription_, mcc, false);
       r.setConsumer(this);
-      this->doStreamBeginRun_(
-          id,
-          r,
-          EventSetup{
-              info, static_cast<unsigned int>(Transition::BeginRun), esGetTokenIndices(Transition::BeginRun), false});
+      ESParentContext parentC(mcc);
+      this->doStreamBeginRun_(id,
+                              r,
+                              EventSetup{info,
+                                         static_cast<unsigned int>(Transition::BeginRun),
+                                         esGetTokenIndices(Transition::BeginRun),
+                                         parentC,
+                                         false});
     }
     void EDProducerBase::doStreamEndRun(StreamID id, RunTransitionInfo const& info, ModuleCallingContext const* mcc) {
       Run r(info, moduleDescription_, mcc, true);
       r.setConsumer(this);
+      ESParentContext parentC(mcc);
       const EventSetup c{
-          info, static_cast<unsigned int>(Transition::EndRun), esGetTokenIndices(Transition::EndRun), false};
+          info, static_cast<unsigned int>(Transition::EndRun), esGetTokenIndices(Transition::EndRun), parentC, false};
       this->doStreamEndRun_(id, r, c);
       this->doStreamEndRunSummary_(id, r, c);
     }
@@ -209,11 +226,14 @@ namespace edm {
                                                       ModuleCallingContext const* mcc) {
       LuminosityBlock lb(info, moduleDescription_, mcc, false);
       lb.setConsumer(this);
+      ESParentContext parentC(mcc);
+
       this->doStreamBeginLuminosityBlock_(id,
                                           lb,
                                           EventSetup{info,
                                                      static_cast<unsigned int>(Transition::BeginLuminosityBlock),
                                                      esGetTokenIndices(Transition::BeginLuminosityBlock),
+                                                     parentC,
                                                      false});
     }
 
@@ -222,9 +242,11 @@ namespace edm {
                                                     ModuleCallingContext const* mcc) {
       LuminosityBlock lb(info, moduleDescription_, mcc, true);
       lb.setConsumer(this);
+      ESParentContext parentC(mcc);
       const EventSetup c{info,
                          static_cast<unsigned int>(Transition::EndLuminosityBlock),
                          esGetTokenIndices(Transition::EndLuminosityBlock),
+                         parentC,
                          false};
       this->doStreamEndLuminosityBlock_(id, lb, c);
       this->doStreamEndLuminosityBlockSummary_(id, lb, c);

--- a/FWCore/Framework/src/limited/EDAnalyzerBase.cc
+++ b/FWCore/Framework/src/limited/EDAnalyzerBase.cc
@@ -30,6 +30,7 @@
 #include "DataFormats/Provenance/interface/ProductRegistry.h"
 
 #include "FWCore/ServiceRegistry/interface/Service.h"
+#include "FWCore/ServiceRegistry/interface/ESParentContext.h"
 #include "FWCore/Framework/interface/ConstProductRegistry.h"
 
 //
@@ -55,8 +56,9 @@ namespace edm {
       Event e(info, moduleDescription_, mcc);
       e.setConsumer(this);
       EventSignalsSentry sentry(act, mcc);
+      ESParentContext parentC(mcc);
       const EventSetup c{
-          info, static_cast<unsigned int>(Transition::Event), esGetTokenIndices(Transition::Event), false};
+          info, static_cast<unsigned int>(Transition::Event), esGetTokenIndices(Transition::Event), parentC, false};
       this->analyze(e.streamID(), e, c);
       return true;
     }
@@ -97,8 +99,12 @@ namespace edm {
       Run r(info, moduleDescription_, mcc, false);
       r.setConsumer(this);
       Run const& cnstR = r;
-      const EventSetup c{
-          info, static_cast<unsigned int>(Transition::BeginRun), esGetTokenIndices(Transition::BeginRun), false};
+      ESParentContext parentC(mcc);
+      const EventSetup c{info,
+                         static_cast<unsigned int>(Transition::BeginRun),
+                         esGetTokenIndices(Transition::BeginRun),
+                         parentC,
+                         false};
       this->doBeginRun_(cnstR, c);
       this->doBeginRunSummary_(cnstR, c);
     }
@@ -107,8 +113,9 @@ namespace edm {
       Run r(info, moduleDescription_, mcc, true);
       r.setConsumer(this);
       Run const& cnstR = r;
+      ESParentContext parentC(mcc);
       const EventSetup c{
-          info, static_cast<unsigned int>(Transition::EndRun), esGetTokenIndices(Transition::EndRun), false};
+          info, static_cast<unsigned int>(Transition::EndRun), esGetTokenIndices(Transition::EndRun), parentC, false};
       this->doEndRunSummary_(r, c);
       this->doEndRun_(cnstR, c);
     }
@@ -117,9 +124,11 @@ namespace edm {
       LuminosityBlock lb(info, moduleDescription_, mcc, false);
       lb.setConsumer(this);
       LuminosityBlock const& cnstLb = lb;
+      ESParentContext parentC(mcc);
       const EventSetup c{info,
                          static_cast<unsigned int>(Transition::BeginLuminosityBlock),
                          esGetTokenIndices(Transition::BeginLuminosityBlock),
+                         parentC,
                          false};
       this->doBeginLuminosityBlock_(cnstLb, c);
       this->doBeginLuminosityBlockSummary_(cnstLb, c);
@@ -129,9 +138,11 @@ namespace edm {
       LuminosityBlock lb(info, moduleDescription_, mcc, true);
       lb.setConsumer(this);
       LuminosityBlock const& cnstLb = lb;
+      ESParentContext parentC(mcc);
       const EventSetup c{info,
                          static_cast<unsigned int>(Transition::EndLuminosityBlock),
                          esGetTokenIndices(Transition::EndLuminosityBlock),
+                         parentC,
                          false};
       this->doEndLuminosityBlockSummary_(cnstLb, c);
       this->doEndLuminosityBlock_(cnstLb, c);
@@ -142,15 +153,20 @@ namespace edm {
     void EDAnalyzerBase::doStreamBeginRun(StreamID id, RunTransitionInfo const& info, ModuleCallingContext const* mcc) {
       Run r(info, moduleDescription_, mcc, false);
       r.setConsumer(this);
-      const EventSetup c{
-          info, static_cast<unsigned int>(Transition::BeginRun), esGetTokenIndices(Transition::BeginRun), false};
+      ESParentContext parentC(mcc);
+      const EventSetup c{info,
+                         static_cast<unsigned int>(Transition::BeginRun),
+                         esGetTokenIndices(Transition::BeginRun),
+                         parentC,
+                         false};
       this->doStreamBeginRun_(id, r, c);
     }
     void EDAnalyzerBase::doStreamEndRun(StreamID id, RunTransitionInfo const& info, ModuleCallingContext const* mcc) {
       Run r(info, moduleDescription_, mcc, true);
       r.setConsumer(this);
+      ESParentContext parentC(mcc);
       const EventSetup c{
-          info, static_cast<unsigned int>(Transition::EndRun), esGetTokenIndices(Transition::EndRun), false};
+          info, static_cast<unsigned int>(Transition::EndRun), esGetTokenIndices(Transition::EndRun), parentC, false};
       this->doStreamEndRun_(id, r, c);
       this->doStreamEndRunSummary_(id, r, c);
     }
@@ -159,9 +175,11 @@ namespace edm {
                                                       ModuleCallingContext const* mcc) {
       LuminosityBlock lb(info, moduleDescription_, mcc, false);
       lb.setConsumer(this);
+      ESParentContext parentC(mcc);
       const EventSetup c{info,
                          static_cast<unsigned int>(Transition::BeginLuminosityBlock),
                          esGetTokenIndices(Transition::BeginLuminosityBlock),
+                         parentC,
                          false};
       this->doStreamBeginLuminosityBlock_(id, lb, c);
     }
@@ -171,9 +189,11 @@ namespace edm {
                                                     ModuleCallingContext const* mcc) {
       LuminosityBlock lb(info, moduleDescription_, mcc, true);
       lb.setConsumer(this);
+      ESParentContext parentC(mcc);
       const EventSetup c{info,
                          static_cast<unsigned int>(Transition::EndLuminosityBlock),
                          esGetTokenIndices(Transition::EndLuminosityBlock),
+                         parentC,
                          false};
       this->doStreamEndLuminosityBlock_(id, lb, c);
       this->doStreamEndLuminosityBlockSummary_(id, lb, c);

--- a/FWCore/Framework/src/limited/EDFilterBase.cc
+++ b/FWCore/Framework/src/limited/EDFilterBase.cc
@@ -25,6 +25,7 @@
 #include "FWCore/Framework/src/PreallocationConfiguration.h"
 #include "FWCore/Framework/src/edmodule_mightGet_config.h"
 #include "FWCore/Framework/src/TransitionInfoTypes.h"
+#include "FWCore/ServiceRegistry/interface/ESParentContext.h"
 
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
@@ -57,8 +58,9 @@ namespace edm {
       e.setConsumer(this);
       const auto streamIndex = e.streamID().value();
       e.setProducer(this, &previousParentages_[streamIndex]);
+      ESParentContext parentC(mcc);
       const EventSetup c{
-          info, static_cast<unsigned int>(Transition::Event), esGetTokenIndices(Transition::Event), false};
+          info, static_cast<unsigned int>(Transition::Event), esGetTokenIndices(Transition::Event), parentC, false};
       EventSignalsSentry sentry(act, mcc);
       bool returnValue = this->filter(e.streamID(), e, c);
       commit_(e, &previousParentageIds_[streamIndex]);
@@ -110,8 +112,12 @@ namespace edm {
       Run r(info, moduleDescription_, mcc, false);
       r.setConsumer(this);
       Run const& cnstR = r;
-      const EventSetup c{
-          info, static_cast<unsigned int>(Transition::BeginRun), esGetTokenIndices(Transition::BeginRun), false};
+      ESParentContext parentC(mcc);
+      const EventSetup c{info,
+                         static_cast<unsigned int>(Transition::BeginRun),
+                         esGetTokenIndices(Transition::BeginRun),
+                         parentC,
+                         false};
       this->doBeginRun_(cnstR, c);
       this->doBeginRunSummary_(cnstR, c);
       r.setProducer(this);
@@ -124,8 +130,9 @@ namespace edm {
       r.setConsumer(this);
       r.setProducer(this);
       Run const& cnstR = r;
+      ESParentContext parentC(mcc);
       const EventSetup c{
-          info, static_cast<unsigned int>(Transition::EndRun), esGetTokenIndices(Transition::EndRun), false};
+          info, static_cast<unsigned int>(Transition::EndRun), esGetTokenIndices(Transition::EndRun), parentC, false};
       this->doEndRunSummary_(r, c);
       this->doEndRunProduce_(r, c);
       this->doEndRun_(cnstR, c);
@@ -136,9 +143,11 @@ namespace edm {
       LuminosityBlock lb(info, moduleDescription_, mcc, false);
       lb.setConsumer(this);
       LuminosityBlock const& cnstLb = lb;
+      ESParentContext parentC(mcc);
       const EventSetup c{info,
                          static_cast<unsigned int>(Transition::BeginLuminosityBlock),
                          esGetTokenIndices(Transition::BeginLuminosityBlock),
+                         parentC,
                          false};
       this->doBeginLuminosityBlock_(cnstLb, c);
       this->doBeginLuminosityBlockSummary_(cnstLb, c);
@@ -152,9 +161,11 @@ namespace edm {
       lb.setConsumer(this);
       lb.setProducer(this);
       LuminosityBlock const& cnstLb = lb;
+      ESParentContext parentC(mcc);
       const EventSetup c{info,
                          static_cast<unsigned int>(Transition::EndLuminosityBlock),
                          esGetTokenIndices(Transition::EndLuminosityBlock),
+                         parentC,
                          false};
       this->doEndLuminosityBlockSummary_(cnstLb, c);
       this->doEndLuminosityBlockProduce_(lb, c);
@@ -167,15 +178,20 @@ namespace edm {
     void EDFilterBase::doStreamBeginRun(StreamID id, RunTransitionInfo const& info, ModuleCallingContext const* mcc) {
       Run r(info, moduleDescription_, mcc, false);
       r.setConsumer(this);
-      const EventSetup c{
-          info, static_cast<unsigned int>(Transition::BeginRun), esGetTokenIndices(Transition::BeginRun), false};
+      ESParentContext parentC(mcc);
+      const EventSetup c{info,
+                         static_cast<unsigned int>(Transition::BeginRun),
+                         esGetTokenIndices(Transition::BeginRun),
+                         parentC,
+                         false};
       this->doStreamBeginRun_(id, r, c);
     }
     void EDFilterBase::doStreamEndRun(StreamID id, RunTransitionInfo const& info, ModuleCallingContext const* mcc) {
       Run r(info, moduleDescription_, mcc, true);
       r.setConsumer(this);
+      ESParentContext parentC(mcc);
       const EventSetup c{
-          info, static_cast<unsigned int>(Transition::EndRun), esGetTokenIndices(Transition::EndRun), false};
+          info, static_cast<unsigned int>(Transition::EndRun), esGetTokenIndices(Transition::EndRun), parentC, false};
       this->doStreamEndRun_(id, r, c);
       this->doStreamEndRunSummary_(id, r, c);
     }
@@ -183,9 +199,11 @@ namespace edm {
                                                     LumiTransitionInfo const& info,
                                                     ModuleCallingContext const* mcc) {
       LuminosityBlock lb(info, moduleDescription_, mcc, false);
+      ESParentContext parentC(mcc);
       const EventSetup c{info,
                          static_cast<unsigned int>(Transition::BeginLuminosityBlock),
                          esGetTokenIndices(Transition::BeginLuminosityBlock),
+                         parentC,
                          false};
       lb.setConsumer(this);
       this->doStreamBeginLuminosityBlock_(id, lb, c);
@@ -196,9 +214,11 @@ namespace edm {
                                                   ModuleCallingContext const* mcc) {
       LuminosityBlock lb(info, moduleDescription_, mcc, true);
       lb.setConsumer(this);
+      ESParentContext parentC(mcc);
       const EventSetup c{info,
                          static_cast<unsigned int>(Transition::EndLuminosityBlock),
                          esGetTokenIndices(Transition::EndLuminosityBlock),
+                         parentC,
                          false};
       this->doStreamEndLuminosityBlock_(id, lb, c);
       this->doStreamEndLuminosityBlockSummary_(id, lb, c);

--- a/FWCore/Framework/src/limited/EDProducerBase.cc
+++ b/FWCore/Framework/src/limited/EDProducerBase.cc
@@ -25,6 +25,7 @@
 #include "FWCore/Framework/src/PreallocationConfiguration.h"
 #include "FWCore/Framework/src/edmodule_mightGet_config.h"
 #include "FWCore/Framework/src/TransitionInfoTypes.h"
+#include "FWCore/ServiceRegistry/interface/ESParentContext.h"
 
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
@@ -58,8 +59,9 @@ namespace edm {
       const auto streamIndex = e.streamID().value();
       e.setProducer(this, &previousParentages_[streamIndex]);
       EventSignalsSentry sentry(act, mcc);
+      ESParentContext parentC(mcc);
       const EventSetup c{
-          info, static_cast<unsigned int>(Transition::Event), esGetTokenIndices(Transition::Event), false};
+          info, static_cast<unsigned int>(Transition::Event), esGetTokenIndices(Transition::Event), parentC, false};
       this->produce(e.streamID(), e, c);
       commit_(e, &previousParentageIds_[streamIndex]);
       return true;
@@ -110,8 +112,12 @@ namespace edm {
       Run r(info, moduleDescription_, mcc, false);
       r.setConsumer(this);
       Run const& cnstR = r;
-      const EventSetup c{
-          info, static_cast<unsigned int>(Transition::BeginRun), esGetTokenIndices(Transition::BeginRun), false};
+      ESParentContext parentC(mcc);
+      const EventSetup c{info,
+                         static_cast<unsigned int>(Transition::BeginRun),
+                         esGetTokenIndices(Transition::BeginRun),
+                         parentC,
+                         false};
       this->doBeginRun_(cnstR, c);
       this->doBeginRunSummary_(cnstR, c);
       r.setProducer(this);
@@ -124,8 +130,9 @@ namespace edm {
       r.setConsumer(this);
       r.setProducer(this);
       Run const& cnstR = r;
+      ESParentContext parentC(mcc);
       const EventSetup c{
-          info, static_cast<unsigned int>(Transition::EndRun), esGetTokenIndices(Transition::EndRun), false};
+          info, static_cast<unsigned int>(Transition::EndRun), esGetTokenIndices(Transition::EndRun), parentC, false};
       this->doEndRunSummary_(r, c);
       this->doEndRunProduce_(r, c);
       this->doEndRun_(cnstR, c);
@@ -136,9 +143,11 @@ namespace edm {
       LuminosityBlock lb(info, moduleDescription_, mcc, false);
       lb.setConsumer(this);
       LuminosityBlock const& cnstLb = lb;
+      ESParentContext parentC(mcc);
       const EventSetup c{info,
                          static_cast<unsigned int>(Transition::BeginLuminosityBlock),
                          esGetTokenIndices(Transition::BeginLuminosityBlock),
+                         parentC,
                          false};
       this->doBeginLuminosityBlock_(cnstLb, c);
       this->doBeginLuminosityBlockSummary_(cnstLb, c);
@@ -152,9 +161,11 @@ namespace edm {
       lb.setConsumer(this);
       lb.setProducer(this);
       LuminosityBlock const& cnstLb = lb;
+      ESParentContext parentC(mcc);
       const EventSetup c{info,
                          static_cast<unsigned int>(Transition::EndLuminosityBlock),
                          esGetTokenIndices(Transition::EndLuminosityBlock),
+                         parentC,
                          false};
       this->doEndLuminosityBlockSummary_(cnstLb, c);
       this->doEndLuminosityBlockProduce_(lb, c);
@@ -167,15 +178,20 @@ namespace edm {
     void EDProducerBase::doStreamBeginRun(StreamID id, RunTransitionInfo const& info, ModuleCallingContext const* mcc) {
       Run r(info, moduleDescription_, mcc, false);
       r.setConsumer(this);
-      const EventSetup c{
-          info, static_cast<unsigned int>(Transition::BeginRun), esGetTokenIndices(Transition::BeginRun), false};
+      ESParentContext parentC(mcc);
+      const EventSetup c{info,
+                         static_cast<unsigned int>(Transition::BeginRun),
+                         esGetTokenIndices(Transition::BeginRun),
+                         parentC,
+                         false};
       this->doStreamBeginRun_(id, r, c);
     }
     void EDProducerBase::doStreamEndRun(StreamID id, RunTransitionInfo const& info, ModuleCallingContext const* mcc) {
       Run r(info, moduleDescription_, mcc, true);
       r.setConsumer(this);
+      ESParentContext parentC(mcc);
       const EventSetup c{
-          info, static_cast<unsigned int>(Transition::EndRun), esGetTokenIndices(Transition::EndRun), false};
+          info, static_cast<unsigned int>(Transition::EndRun), esGetTokenIndices(Transition::EndRun), parentC, false};
       this->doStreamEndRun_(id, r, c);
       this->doStreamEndRunSummary_(id, r, c);
     }
@@ -184,9 +200,11 @@ namespace edm {
                                                       ModuleCallingContext const* mcc) {
       LuminosityBlock lb(info, moduleDescription_, mcc, false);
       lb.setConsumer(this);
+      ESParentContext parentC(mcc);
       const EventSetup c{info,
                          static_cast<unsigned int>(Transition::BeginLuminosityBlock),
                          esGetTokenIndices(Transition::BeginLuminosityBlock),
+                         parentC,
                          false};
       this->doStreamBeginLuminosityBlock_(id, lb, c);
     }
@@ -196,9 +214,11 @@ namespace edm {
                                                     ModuleCallingContext const* mcc) {
       LuminosityBlock lb(info, moduleDescription_, mcc, true);
       lb.setConsumer(this);
+      ESParentContext parentC(mcc);
       const EventSetup c{info,
                          static_cast<unsigned int>(Transition::EndLuminosityBlock),
                          esGetTokenIndices(Transition::EndLuminosityBlock),
+                         parentC,
                          false};
       this->doStreamEndLuminosityBlock_(id, lb, c);
       this->doStreamEndLuminosityBlockSummary_(id, lb, c);

--- a/FWCore/Framework/src/one/EDAnalyzerBase.cc
+++ b/FWCore/Framework/src/one/EDAnalyzerBase.cc
@@ -28,6 +28,7 @@
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 
 #include "FWCore/ServiceRegistry/interface/Service.h"
+#include "FWCore/ServiceRegistry/interface/ESParentContext.h"
 #include "FWCore/Framework/interface/ConstProductRegistry.h"
 
 //
@@ -57,8 +58,9 @@ namespace edm {
       e.setConsumer(this);
       e.setSharedResourcesAcquirer(&resourcesAcquirer_);
       EventSignalsSentry sentry(act, mcc);
+      ESParentContext parentC(mcc);
       const EventSetup c{
-          info, static_cast<unsigned int>(Transition::Event), esGetTokenIndices(Transition::Event), false};
+          info, static_cast<unsigned int>(Transition::Event), esGetTokenIndices(Transition::Event), parentC, false};
       this->analyze(e, c);
       return true;
     }
@@ -109,8 +111,12 @@ namespace edm {
       Run r(info, moduleDescription_, mcc, false);
       r.setConsumer(this);
       Run const& cnstR = r;
-      const EventSetup c{
-          info, static_cast<unsigned int>(Transition::BeginRun), esGetTokenIndices(Transition::BeginRun), false};
+      ESParentContext parentC(mcc);
+      const EventSetup c{info,
+                         static_cast<unsigned int>(Transition::BeginRun),
+                         esGetTokenIndices(Transition::BeginRun),
+                         parentC,
+                         false};
       this->doBeginRun_(cnstR, c);
     }
 
@@ -118,8 +124,9 @@ namespace edm {
       Run r(info, moduleDescription_, mcc, true);
       r.setConsumer(this);
       Run const& cnstR = r;
+      ESParentContext parentC(mcc);
       const EventSetup c{
-          info, static_cast<unsigned int>(Transition::EndRun), esGetTokenIndices(Transition::EndRun), false};
+          info, static_cast<unsigned int>(Transition::EndRun), esGetTokenIndices(Transition::EndRun), parentC, false};
       this->doEndRun_(cnstR, c);
     }
 
@@ -127,9 +134,11 @@ namespace edm {
       LuminosityBlock lb(info, moduleDescription_, mcc, false);
       lb.setConsumer(this);
       LuminosityBlock const& cnstLb = lb;
+      ESParentContext parentC(mcc);
       const EventSetup c{info,
                          static_cast<unsigned int>(Transition::BeginLuminosityBlock),
                          esGetTokenIndices(Transition::BeginLuminosityBlock),
+                         parentC,
                          false};
       this->doBeginLuminosityBlock_(cnstLb, c);
     }
@@ -138,9 +147,11 @@ namespace edm {
       LuminosityBlock lb(info, moduleDescription_, mcc, true);
       lb.setConsumer(this);
       LuminosityBlock const& cnstLb = lb;
+      ESParentContext parentC(mcc);
       const EventSetup c{info,
                          static_cast<unsigned int>(Transition::EndLuminosityBlock),
                          esGetTokenIndices(Transition::EndLuminosityBlock),
+                         parentC,
                          false};
       this->doEndLuminosityBlock_(cnstLb, c);
     }

--- a/FWCore/Framework/src/one/EDFilterBase.cc
+++ b/FWCore/Framework/src/one/EDFilterBase.cc
@@ -23,6 +23,7 @@
 #include "FWCore/Framework/src/PreallocationConfiguration.h"
 #include "FWCore/Framework/src/EventSignalsSentry.h"
 #include "FWCore/Framework/src/TransitionInfoTypes.h"
+#include "FWCore/ServiceRegistry/interface/ESParentContext.h"
 
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
@@ -54,8 +55,9 @@ namespace edm {
       bool returnValue = true;
       e.setSharedResourcesAcquirer(&resourcesAcquirer_);
       EventSignalsSentry sentry(act, mcc);
+      ESParentContext parentC(mcc);
       const EventSetup c{
-          info, static_cast<unsigned int>(Transition::Event), esGetTokenIndices(Transition::Event), false};
+          info, static_cast<unsigned int>(Transition::Event), esGetTokenIndices(Transition::Event), parentC, false};
       returnValue = this->filter(e, c);
       commit_(e, &previousParentageId_);
       return returnValue;
@@ -115,8 +117,12 @@ namespace edm {
       Run r(info, moduleDescription_, mcc, false);
       r.setConsumer(this);
       Run const& cnstR = r;
-      const EventSetup c{
-          info, static_cast<unsigned int>(Transition::BeginRun), esGetTokenIndices(Transition::BeginRun), false};
+      ESParentContext parentC(mcc);
+      const EventSetup c{info,
+                         static_cast<unsigned int>(Transition::BeginRun),
+                         esGetTokenIndices(Transition::BeginRun),
+                         parentC,
+                         false};
       this->doBeginRun_(cnstR, c);
       r.setProducer(this);
       this->doBeginRunProduce_(r, c);
@@ -127,8 +133,9 @@ namespace edm {
       Run r(info, moduleDescription_, mcc, true);
       r.setConsumer(this);
       Run const& cnstR = r;
+      ESParentContext parentC(mcc);
       const EventSetup c{
-          info, static_cast<unsigned int>(Transition::EndRun), esGetTokenIndices(Transition::EndRun), false};
+          info, static_cast<unsigned int>(Transition::EndRun), esGetTokenIndices(Transition::EndRun), parentC, false};
       this->doEndRun_(cnstR, c);
       r.setProducer(this);
       this->doEndRunProduce_(r, c);
@@ -139,9 +146,11 @@ namespace edm {
       LuminosityBlock lb(info, moduleDescription_, mcc, false);
       lb.setConsumer(this);
       LuminosityBlock const& cnstLb = lb;
+      ESParentContext parentC(mcc);
       const EventSetup c{info,
                          static_cast<unsigned int>(Transition::BeginLuminosityBlock),
                          esGetTokenIndices(Transition::BeginLuminosityBlock),
+                         parentC,
                          false};
       this->doBeginLuminosityBlock_(cnstLb, c);
       lb.setProducer(this);
@@ -153,9 +162,11 @@ namespace edm {
       LuminosityBlock lb(info, moduleDescription_, mcc, true);
       lb.setConsumer(this);
       LuminosityBlock const& cnstLb = lb;
+      ESParentContext parentC(mcc);
       const EventSetup c{info,
                          static_cast<unsigned int>(Transition::EndLuminosityBlock),
                          esGetTokenIndices(Transition::EndLuminosityBlock),
+                         parentC,
                          false};
       this->doEndLuminosityBlock_(cnstLb, c);
       lb.setProducer(this);

--- a/FWCore/Framework/src/one/EDProducerBase.cc
+++ b/FWCore/Framework/src/one/EDProducerBase.cc
@@ -23,6 +23,7 @@
 #include "FWCore/Framework/src/PreallocationConfiguration.h"
 #include "FWCore/Framework/src/EventSignalsSentry.h"
 #include "FWCore/Framework/src/TransitionInfoTypes.h"
+#include "FWCore/ServiceRegistry/interface/ESParentContext.h"
 
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
@@ -53,8 +54,9 @@ namespace edm {
       e.setProducer(this, &previousParentage_);
       e.setSharedResourcesAcquirer(&resourcesAcquirer_);
       EventSignalsSentry sentry(act, mcc);
+      ESParentContext parentC(mcc);
       const EventSetup c{
-          info, static_cast<unsigned int>(Transition::Event), esGetTokenIndices(Transition::Event), false};
+          info, static_cast<unsigned int>(Transition::Event), esGetTokenIndices(Transition::Event), parentC, false};
       this->produce(e, c);
       commit_(e, &previousParentageId_);
       return true;
@@ -115,8 +117,12 @@ namespace edm {
       Run r(info, moduleDescription_, mcc, false);
       r.setConsumer(this);
       Run const& cnstR = r;
-      const EventSetup c{
-          info, static_cast<unsigned int>(Transition::BeginRun), esGetTokenIndices(Transition::BeginRun), false};
+      ESParentContext parentC(mcc);
+      const EventSetup c{info,
+                         static_cast<unsigned int>(Transition::BeginRun),
+                         esGetTokenIndices(Transition::BeginRun),
+                         parentC,
+                         false};
       this->doBeginRun_(cnstR, c);
       r.setProducer(this);
       this->doBeginRunProduce_(r, c);
@@ -128,8 +134,9 @@ namespace edm {
       r.setConsumer(this);
       Run const& cnstR = r;
       r.setProducer(this);
+      ESParentContext parentC(mcc);
       const EventSetup c{
-          info, static_cast<unsigned int>(Transition::EndRun), esGetTokenIndices(Transition::EndRun), false};
+          info, static_cast<unsigned int>(Transition::EndRun), esGetTokenIndices(Transition::EndRun), parentC, false};
       this->doEndRunProduce_(r, c);
       this->doEndRun_(cnstR, c);
       commit_(r);
@@ -139,9 +146,11 @@ namespace edm {
       LuminosityBlock lb(info, moduleDescription_, mcc, false);
       lb.setConsumer(this);
       LuminosityBlock const& cnstLb = lb;
+      ESParentContext parentC(mcc);
       const EventSetup c{info,
                          static_cast<unsigned int>(Transition::BeginLuminosityBlock),
                          esGetTokenIndices(Transition::BeginLuminosityBlock),
+                         parentC,
                          false};
       this->doBeginLuminosityBlock_(cnstLb, c);
       lb.setProducer(this);
@@ -153,9 +162,11 @@ namespace edm {
       LuminosityBlock lb(info, moduleDescription_, mcc, true);
       lb.setConsumer(this);
       lb.setProducer(this);
+      ESParentContext parentC(mcc);
       const EventSetup c{info,
                          static_cast<unsigned int>(Transition::EndLuminosityBlock),
                          esGetTokenIndices(Transition::EndLuminosityBlock),
+                         parentC,
                          false};
       this->doEndLuminosityBlockProduce_(lb, c);
       LuminosityBlock const& cnstLb = lb;

--- a/FWCore/Framework/src/stream/EDAnalyzerAdaptorBase.cc
+++ b/FWCore/Framework/src/stream/EDAnalyzerAdaptorBase.cc
@@ -23,6 +23,7 @@
 #include "FWCore/Framework/interface/EventPrincipal.h"
 #include "FWCore/Framework/interface/LuminosityBlockPrincipal.h"
 #include "FWCore/Framework/interface/RunPrincipal.h"
+#include "FWCore/ServiceRegistry/interface/ESParentContext.h"
 
 #include "FWCore/Framework/src/PreallocationConfiguration.h"
 #include "FWCore/Framework/src/EventSignalsSentry.h"
@@ -151,8 +152,9 @@ bool EDAnalyzerAdaptorBase::doEvent(EventTransitionInfo const& info,
   auto mod = m_streamModules[ep.streamID()];
   Event e(ep, moduleDescription_, mcc);
   e.setConsumer(mod);
+  ESParentContext parentC(mcc);
   const EventSetup c{
-      info, static_cast<unsigned int>(Transition::Event), mod->esGetTokenIndices(Transition::Event), false};
+      info, static_cast<unsigned int>(Transition::Event), mod->esGetTokenIndices(Transition::Event), parentC, false};
   EventSignalsSentry sentry(act, mcc);
   mod->analyze(e, c);
   return true;
@@ -169,8 +171,12 @@ void EDAnalyzerAdaptorBase::doStreamBeginRun(StreamID id,
   setupRun(mod, rp.index());
 
   Run r(rp, moduleDescription_, mcc, false);
-  const EventSetup c{
-      info, static_cast<unsigned int>(Transition::BeginRun), mod->esGetTokenIndices(Transition::BeginRun), false};
+  ESParentContext parentC(mcc);
+  const EventSetup c{info,
+                     static_cast<unsigned int>(Transition::BeginRun),
+                     mod->esGetTokenIndices(Transition::BeginRun),
+                     parentC,
+                     false};
   r.setConsumer(mod);
   mod->beginRun(r, c);
 }
@@ -181,8 +187,9 @@ void EDAnalyzerAdaptorBase::doStreamEndRun(StreamID id,
   auto mod = m_streamModules[id];
   Run r(info, moduleDescription_, mcc, true);
   r.setConsumer(mod);
+  ESParentContext parentC(mcc);
   const EventSetup c{
-      info, static_cast<unsigned int>(Transition::EndRun), mod->esGetTokenIndices(Transition::EndRun), false};
+      info, static_cast<unsigned int>(Transition::EndRun), mod->esGetTokenIndices(Transition::EndRun), parentC, false};
   mod->endRun(r, c);
   streamEndRunSummary(mod, r, c);
 }
@@ -196,9 +203,11 @@ void EDAnalyzerAdaptorBase::doStreamBeginLuminosityBlock(StreamID id,
 
   LuminosityBlock lb(lbp, moduleDescription_, mcc, false);
   lb.setConsumer(mod);
+  ESParentContext parentC(mcc);
   const EventSetup c{info,
                      static_cast<unsigned int>(Transition::BeginLuminosityBlock),
                      mod->esGetTokenIndices(Transition::BeginLuminosityBlock),
+                     parentC,
                      false};
   mod->beginLuminosityBlock(lb, c);
 }
@@ -208,9 +217,11 @@ void EDAnalyzerAdaptorBase::doStreamEndLuminosityBlock(StreamID id,
   auto mod = m_streamModules[id];
   LuminosityBlock lb(info, moduleDescription_, mcc, true);
   lb.setConsumer(mod);
+  ESParentContext parentC(mcc);
   const EventSetup c{info,
                      static_cast<unsigned int>(Transition::EndLuminosityBlock),
                      mod->esGetTokenIndices(Transition::EndLuminosityBlock),
+                     parentC,
                      false};
   mod->endLuminosityBlock(lb, c);
   streamEndLuminosityBlockSummary(mod, lb, c);

--- a/FWCore/Framework/src/stream/EDFilterAdaptorBase.cc
+++ b/FWCore/Framework/src/stream/EDFilterAdaptorBase.cc
@@ -26,6 +26,7 @@
 #include "FWCore/Framework/src/EventSignalsSentry.h"
 #include "FWCore/Framework/src/stream/ProducingModuleAdaptorBase.cc"
 #include "FWCore/Framework/src/TransitionInfoTypes.h"
+#include "FWCore/ServiceRegistry/interface/ESParentContext.h"
 
 using namespace edm::stream;
 namespace edm {
@@ -54,8 +55,9 @@ namespace edm {
       e.setConsumer(mod);
       e.setProducer(mod, &mod->previousParentage_, &mod->gotBranchIDsFromAcquire_);
       EventSignalsSentry sentry(act, mcc);
+      ESParentContext parentC(mcc);
       const EventSetup c{
-          info, static_cast<unsigned int>(Transition::Event), mod->esGetTokenIndices(Transition::Event), false};
+          info, static_cast<unsigned int>(Transition::Event), mod->esGetTokenIndices(Transition::Event), parentC, false};
       bool result = mod->filter(e, c);
       commit(e, &mod->previousParentageId_);
       return result;
@@ -72,8 +74,9 @@ namespace edm {
       e.setConsumer(mod);
       e.setProducerForAcquire(mod, nullptr, mod->gotBranchIDsFromAcquire_);
       EventAcquireSignalsSentry sentry(act, mcc);
+      ESParentContext parentC(mcc);
       const EventSetup c{
-          info, static_cast<unsigned int>(Transition::Event), mod->esGetTokenIndices(Transition::Event), false};
+          info, static_cast<unsigned int>(Transition::Event), mod->esGetTokenIndices(Transition::Event), parentC, false};
       mod->doAcquire_(e, c, holder);
     }
 

--- a/FWCore/Framework/src/stream/EDProducerAdaptorBase.cc
+++ b/FWCore/Framework/src/stream/EDProducerAdaptorBase.cc
@@ -26,6 +26,7 @@
 #include "FWCore/Framework/src/EventSignalsSentry.h"
 #include "FWCore/Framework/src/stream/ProducingModuleAdaptorBase.cc"
 #include "FWCore/Framework/src/TransitionInfoTypes.h"
+#include "FWCore/ServiceRegistry/interface/ESParentContext.h"
 
 using namespace edm::stream;
 namespace edm {
@@ -54,8 +55,9 @@ namespace edm {
       e.setConsumer(mod);
       e.setProducer(mod, &mod->previousParentage_, &mod->gotBranchIDsFromAcquire_);
       EventSignalsSentry sentry(act, mcc);
+      ESParentContext parentC(mcc);
       const EventSetup c{
-          info, static_cast<unsigned int>(Transition::Event), mod->esGetTokenIndices(Transition::Event), false};
+          info, static_cast<unsigned int>(Transition::Event), mod->esGetTokenIndices(Transition::Event), parentC, false};
       mod->produce(e, c);
       commit(e, &mod->previousParentageId_);
       return true;
@@ -72,8 +74,9 @@ namespace edm {
       e.setConsumer(mod);
       e.setProducerForAcquire(mod, nullptr, mod->gotBranchIDsFromAcquire_);
       EventAcquireSignalsSentry sentry(act, mcc);
+      ESParentContext parentC(mcc);
       const EventSetup c{
-          info, static_cast<unsigned int>(Transition::Event), mod->esGetTokenIndices(Transition::Event), false};
+          info, static_cast<unsigned int>(Transition::Event), mod->esGetTokenIndices(Transition::Event), parentC, false};
       mod->doAcquire_(e, c, holder);
     }
 

--- a/FWCore/Framework/src/stream/ProducingModuleAdaptorBase.cc
+++ b/FWCore/Framework/src/stream/ProducingModuleAdaptorBase.cc
@@ -22,6 +22,7 @@
 #include "FWCore/Framework/interface/RunPrincipal.h"
 #include "FWCore/Framework/src/PreallocationConfiguration.h"
 #include "FWCore/Framework/src/TransitionInfoTypes.h"
+#include "FWCore/ServiceRegistry/interface/ESParentContext.h"
 
 //
 // constants, enums and typedefs
@@ -190,8 +191,12 @@ namespace edm {
 
       Run r(rp, moduleDescription_, mcc, false);
       r.setConsumer(mod);
-      const EventSetup c{
-          info, static_cast<unsigned int>(Transition::BeginRun), mod->esGetTokenIndices(Transition::BeginRun), false};
+      ESParentContext parentC(mcc);
+      const EventSetup c{info,
+                         static_cast<unsigned int>(Transition::BeginRun),
+                         mod->esGetTokenIndices(Transition::BeginRun),
+                         parentC,
+                         false};
       mod->beginRun(r, c);
     }
 
@@ -202,8 +207,12 @@ namespace edm {
       auto mod = m_streamModules[id];
       Run r(info, moduleDescription_, mcc, true);
       r.setConsumer(mod);
-      const EventSetup c{
-          info, static_cast<unsigned int>(Transition::EndRun), mod->esGetTokenIndices(Transition::EndRun), false};
+      ESParentContext parentC(mcc);
+      const EventSetup c{info,
+                         static_cast<unsigned int>(Transition::EndRun),
+                         mod->esGetTokenIndices(Transition::EndRun),
+                         parentC,
+                         false};
       mod->endRun(r, c);
       streamEndRunSummary(mod, r, c);
     }
@@ -218,9 +227,11 @@ namespace edm {
 
       LuminosityBlock lb(lbp, moduleDescription_, mcc, false);
       lb.setConsumer(mod);
+      ESParentContext parentC(mcc);
       const EventSetup c{info,
                          static_cast<unsigned int>(Transition::BeginLuminosityBlock),
                          mod->esGetTokenIndices(Transition::BeginLuminosityBlock),
+                         parentC,
                          false};
       mod->beginLuminosityBlock(lb, c);
     }
@@ -232,9 +243,11 @@ namespace edm {
       auto mod = m_streamModules[id];
       LuminosityBlock lb(info, moduleDescription_, mcc, true);
       lb.setConsumer(mod);
+      ESParentContext parentC(mcc);
       const EventSetup c{info,
                          static_cast<unsigned int>(Transition::EndLuminosityBlock),
                          mod->esGetTokenIndices(Transition::EndLuminosityBlock),
+                         parentC,
                          false};
       mod->endLuminosityBlock(lb, c);
       streamEndLuminosityBlockSummary(mod, lb, c);

--- a/FWCore/Framework/test/dependentrecord_t.cppunit.cc
+++ b/FWCore/Framework/test/dependentrecord_t.cppunit.cc
@@ -29,6 +29,7 @@
 #include "FWCore/Framework/test/print_eventsetup_record_dependencies.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ServiceRegistry/interface/ActivityRegistry.h"
+#include "FWCore/ServiceRegistry/interface/ESParentContext.h"
 #include "FWCore/Utilities/interface/propagate_const.h"
 #include "FWCore/Concurrency/interface/ThreadsController.h"
 
@@ -607,17 +608,18 @@ void testdependentrecord::timeAndRunTest() {
     provider.add(std::shared_ptr<edm::EventSetupRecordIntervalFinder>(dummy2Finder));
 
     {
+      edm::ESParentContext parentC;
       controller.eventSetupForInstance(edm::IOVSyncValue(edm::EventID(1, 1, 1), edm::Timestamp(1)));
-      const edm::EventSetup eventSetup1(provider.eventSetupImpl(), 0, nullptr, true);
+      const edm::EventSetup eventSetup1(provider.eventSetupImpl(), 0, nullptr, parentC, true);
       long long id1 = eventSetup1.get<DepOn2Record>().cacheIdentifier();
 
       controller.eventSetupForInstance(edm::IOVSyncValue(edm::EventID(1, 1, 1), edm::Timestamp(2)));
-      const edm::EventSetup eventSetup2(provider.eventSetupImpl(), 0, nullptr, true);
+      const edm::EventSetup eventSetup2(provider.eventSetupImpl(), 0, nullptr, parentC, true);
       long long id2 = eventSetup2.get<DepOn2Record>().cacheIdentifier();
       CPPUNIT_ASSERT(id1 == id2);
 
       controller.eventSetupForInstance(edm::IOVSyncValue(edm::EventID(1, 1, 2), edm::Timestamp(2)));
-      const edm::EventSetup eventSetup3(provider.eventSetupImpl(), 0, nullptr, true);
+      const edm::EventSetup eventSetup3(provider.eventSetupImpl(), 0, nullptr, parentC, true);
       long long id3 = eventSetup3.get<DepOn2Record>().cacheIdentifier();
       CPPUNIT_ASSERT(id1 == id3);
 
@@ -625,7 +627,7 @@ void testdependentrecord::timeAndRunTest() {
           edm::ValidityInterval(edm::IOVSyncValue(edm::Timestamp(6)), edm::IOVSyncValue(edm::Timestamp(10))));
 
       controller.eventSetupForInstance(edm::IOVSyncValue(edm::EventID(1, 1, 4), edm::Timestamp(7)));
-      const edm::EventSetup eventSetup4(provider.eventSetupImpl(), 0, nullptr, true);
+      const edm::EventSetup eventSetup4(provider.eventSetupImpl(), 0, nullptr, parentC, true);
       long long id4 = eventSetup4.get<DepOn2Record>().cacheIdentifier();
       CPPUNIT_ASSERT(id1 != id4);
 
@@ -633,7 +635,7 @@ void testdependentrecord::timeAndRunTest() {
           edm::ValidityInterval(edm::IOVSyncValue(edm::EventID(1, 1, 6)), edm::IOVSyncValue(edm::EventID(1, 1, 10))));
 
       controller.eventSetupForInstance(edm::IOVSyncValue(edm::EventID(1, 1, 7), edm::Timestamp(8)));
-      const edm::EventSetup eventSetup5(provider.eventSetupImpl(), 0, nullptr, true);
+      const edm::EventSetup eventSetup5(provider.eventSetupImpl(), 0, nullptr, parentC, true);
       long long id5 = eventSetup5.get<DepOn2Record>().cacheIdentifier();
       CPPUNIT_ASSERT(id4 != id5);
     }
@@ -661,31 +663,32 @@ void testdependentrecord::timeAndRunTest() {
         edm::ValidityInterval(edm::IOVSyncValue(edm::Timestamp(1)), edm::IOVSyncValue::invalidIOVSyncValue()));
     provider.add(std::shared_ptr<edm::EventSetupRecordIntervalFinder>(dummy2Finder));
     {
+      edm::ESParentContext parentC;
       controller.eventSetupForInstance(edm::IOVSyncValue(edm::EventID(1, 1, 1), edm::Timestamp(1)));
-      const edm::EventSetup eventSetup1(provider.eventSetupImpl(), 0, nullptr, true);
+      const edm::EventSetup eventSetup1(provider.eventSetupImpl(), 0, nullptr, parentC, true);
       long long id1 = eventSetup1.get<DepOn2Record>().cacheIdentifier();
 
       controller.eventSetupForInstance(edm::IOVSyncValue(edm::EventID(1, 1, 1), edm::Timestamp(2)));
-      const edm::EventSetup eventSetup2(provider.eventSetupImpl(), 0, nullptr, true);
+      const edm::EventSetup eventSetup2(provider.eventSetupImpl(), 0, nullptr, parentC, true);
       long long id2 = eventSetup2.get<DepOn2Record>().cacheIdentifier();
       CPPUNIT_ASSERT(id1 == id2);
 
       controller.eventSetupForInstance(edm::IOVSyncValue(edm::EventID(1, 1, 2), edm::Timestamp(2)));
-      const edm::EventSetup eventSetup3(provider.eventSetupImpl(), 0, nullptr, true);
+      const edm::EventSetup eventSetup3(provider.eventSetupImpl(), 0, nullptr, parentC, true);
       long long id3 = eventSetup3.get<DepOn2Record>().cacheIdentifier();
       CPPUNIT_ASSERT(id1 == id3);
 
       dummy2Finder->setInterval(
           edm::ValidityInterval(edm::IOVSyncValue(edm::Timestamp(6)), edm::IOVSyncValue::invalidIOVSyncValue()));
       controller.eventSetupForInstance(edm::IOVSyncValue(edm::EventID(1, 1, 4), edm::Timestamp(7)));
-      const edm::EventSetup eventSetup4(provider.eventSetupImpl(), 0, nullptr, true);
+      const edm::EventSetup eventSetup4(provider.eventSetupImpl(), 0, nullptr, parentC, true);
       long long id4 = eventSetup4.get<DepOn2Record>().cacheIdentifier();
       CPPUNIT_ASSERT(id1 != id4);
 
       dummyFinder->setInterval(
           edm::ValidityInterval(edm::IOVSyncValue(edm::EventID(1, 1, 6)), edm::IOVSyncValue::invalidIOVSyncValue()));
       controller.eventSetupForInstance(edm::IOVSyncValue(edm::EventID(1, 1, 7), edm::Timestamp(8)));
-      const edm::EventSetup eventSetup5(provider.eventSetupImpl(), 0, nullptr, true);
+      const edm::EventSetup eventSetup5(provider.eventSetupImpl(), 0, nullptr, parentC, true);
       long long id5 = eventSetup5.get<DepOn2Record>().cacheIdentifier();
       CPPUNIT_ASSERT(id4 != id5);
     }
@@ -724,9 +727,10 @@ void testdependentrecord::getTest() {
 
   std::shared_ptr<edm::eventsetup::DataProxyProvider> depProv = std::make_shared<DepRecordProxyProvider>();
   provider.add(depProv);
+  edm::ESParentContext parentC;
   {
     controller.eventSetupForInstance(edm::IOVSyncValue(edm::EventID(1, 1, 1)));
-    const edm::EventSetup eventSetup1(provider.eventSetupImpl(), 0, nullptr, true);
+    const edm::EventSetup eventSetup1(provider.eventSetupImpl(), 0, nullptr, parentC, true);
     const DepRecord& depRecord = eventSetup1.get<DepRecord>();
 
     depRecord.getRecord<DummyRecord>();
@@ -736,7 +740,7 @@ void testdependentrecord::getTest() {
   }
   {
     controller.eventSetupForInstance(edm::IOVSyncValue(edm::EventID(1, 1, 4)));
-    const edm::EventSetup eventSetup2(provider.eventSetupImpl(), 0, nullptr, true);
+    const edm::EventSetup eventSetup2(provider.eventSetupImpl(), 0, nullptr, parentC, true);
     CPPUNIT_ASSERT_THROW(eventSetup2.get<DepRecord>(), edm::eventsetup::NoRecordException<DepRecord>);
   }
 }
@@ -755,7 +759,8 @@ namespace {
         if (rec) {
           auto waitTask = edm::make_empty_waiting_task();
           waitTask->set_ref_count(2);
-          rec->prefetchAsync(edm::WaitingTaskHolder(waitTask.get()), proxies[i], &iImpl, edm::ServiceToken{});
+          rec->prefetchAsync(
+              edm::WaitingTaskHolder(waitTask.get()), proxies[i], &iImpl, edm::ServiceToken{}, edm::ESParentContext{});
           waitTask->decrement_ref_count();
           waitTask->wait_for_all();
           if (waitTask->exceptionPtr()) {
@@ -781,7 +786,8 @@ namespace {
         if (rec) {
           auto waitTask = edm::make_empty_waiting_task();
           waitTask->set_ref_count(2);
-          rec->prefetchAsync(edm::WaitingTaskHolder(waitTask.get()), proxies[i], &iImpl, edm::ServiceToken{});
+          rec->prefetchAsync(
+              edm::WaitingTaskHolder(waitTask.get()), proxies[i], &iImpl, edm::ServiceToken{}, edm::ESParentContext{});
           waitTask->decrement_ref_count();
           waitTask->wait_for_all();
           if (waitTask->exceptionPtr()) {
@@ -836,6 +842,7 @@ void testdependentrecord::getDataWithESGetTokenTest() {
     provider.add(std::shared_ptr<edm::EventSetupRecordIntervalFinder>(dummyFinder));
 
     controller.eventSetupForInstance(edm::IOVSyncValue(edm::EventID(1, 1, 1)));
+    edm::ESParentContext parentC;
     {
       DummyDataConsumer<DepRecord> consumer{edm::ESInputTag{"", "blah"}};
       consumer.updateLookup(provider.recordsToProxyIndices());
@@ -843,6 +850,7 @@ void testdependentrecord::getDataWithESGetTokenTest() {
       const edm::EventSetup eventSetup{provider.eventSetupImpl(),
                                        static_cast<unsigned int>(edm::Transition::Event),
                                        consumer.esGetTokenIndices(edm::Transition::Event),
+                                       parentC,
                                        true};
       auto const& data = eventSetup.getData(consumer.m_token);
       CPPUNIT_ASSERT(kGood.value_ == data.value_);
@@ -854,6 +862,7 @@ void testdependentrecord::getDataWithESGetTokenTest() {
       const edm::EventSetup eventSetup{provider.eventSetupImpl(),
                                        static_cast<unsigned int>(edm::Transition::Event),
                                        consumer.esGetTokenIndices(edm::Transition::Event),
+                                       parentC,
                                        true};
       auto const& data = eventSetup.getData(consumer.m_token);
       CPPUNIT_ASSERT(kBad.value_ == data.value_);
@@ -865,6 +874,7 @@ void testdependentrecord::getDataWithESGetTokenTest() {
       const edm::EventSetup eventSetup{provider.eventSetupImpl(),
                                        static_cast<unsigned int>(edm::Transition::Event),
                                        consumer.esGetTokenIndices(edm::Transition::Event),
+                                       parentC,
                                        true};
       auto const& depRecord = eventSetup.get<DepRecord>();
       auto const& data = depRecord.get(consumer.m_token);
@@ -877,6 +887,7 @@ void testdependentrecord::getDataWithESGetTokenTest() {
       const edm::EventSetup eventSetup{provider.eventSetupImpl(),
                                        static_cast<unsigned int>(edm::Transition::Event),
                                        consumer.esGetTokenIndices(edm::Transition::Event),
+                                       parentC,
                                        true};
       auto const& depRecord = eventSetup.get<DepRecord>();
 
@@ -890,6 +901,7 @@ void testdependentrecord::getDataWithESGetTokenTest() {
       const edm::EventSetup eventSetup{provider.eventSetupImpl(),
                                        static_cast<unsigned int>(edm::Transition::Event),
                                        consumer.esGetTokenIndices(edm::Transition::Event),
+                                       parentC,
                                        true};
       auto const& depRecord = eventSetup.get<DepRecord>();
 
@@ -903,6 +915,7 @@ void testdependentrecord::getDataWithESGetTokenTest() {
       const edm::EventSetup eventSetup{provider.eventSetupImpl(),
                                        static_cast<unsigned int>(edm::Transition::Event),
                                        consumer.esGetTokenIndices(edm::Transition::Event),
+                                       parentC,
                                        true};
       auto const& depRecord = eventSetup.get<DepRecord>();
 
@@ -919,6 +932,7 @@ void testdependentrecord::getDataWithESGetTokenTest() {
       const edm::EventSetup eventSetup{provider.eventSetupImpl(),
                                        static_cast<unsigned int>(edm::Transition::Event),
                                        consumer.esGetTokenIndices(edm::Transition::Event),
+                                       parentC,
                                        true};
       auto const& depRecord = eventSetup.get<DepRecord>();
 
@@ -931,6 +945,7 @@ void testdependentrecord::getDataWithESGetTokenTest() {
       const edm::EventSetup eventSetup{provider.eventSetupImpl(),
                                        static_cast<unsigned int>(edm::Transition::Event),
                                        consumer.esGetTokenIndices(edm::Transition::Event),
+                                       parentC,
                                        true};
       auto const& depRecord = eventSetup.get<DepRecord>();
 
@@ -982,6 +997,7 @@ void testdependentrecord::getHandleWithESGetTokenTest() {
 
     controller.eventSetupForInstance(edm::IOVSyncValue(edm::EventID(1, 1, 1)));
 
+    edm::ESParentContext parentC;
     {
       DummyDataConsumer<DepRecord> consumer{edm::ESInputTag{"", "blah"}};
       consumer.updateLookup(provider.recordsToProxyIndices());
@@ -989,6 +1005,7 @@ void testdependentrecord::getHandleWithESGetTokenTest() {
       const edm::EventSetup eventSetup{provider.eventSetupImpl(),
                                        static_cast<unsigned int>(edm::Transition::Event),
                                        consumer.esGetTokenIndices(edm::Transition::Event),
+                                       parentC,
                                        true};
       edm::ESHandle<DummyData> data = eventSetup.getHandle(consumer.m_token);
       CPPUNIT_ASSERT(kGood.value_ == data->value_);
@@ -1002,6 +1019,7 @@ void testdependentrecord::getHandleWithESGetTokenTest() {
       const edm::EventSetup eventSetup{provider.eventSetupImpl(),
                                        static_cast<unsigned int>(edm::Transition::Event),
                                        consumer.esGetTokenIndices(edm::Transition::Event),
+                                       parentC,
                                        true};
       edm::ESHandle<DummyData> data = eventSetup.getHandle(consumer.m_token);
       CPPUNIT_ASSERT(kBad.value_ == data->value_);
@@ -1015,6 +1033,7 @@ void testdependentrecord::getHandleWithESGetTokenTest() {
       const edm::EventSetup eventSetup{provider.eventSetupImpl(),
                                        static_cast<unsigned int>(edm::Transition::Event),
                                        consumer.esGetTokenIndices(edm::Transition::Event),
+                                       parentC,
                                        true};
       auto const& depRecord = eventSetup.get<DepRecord>();
 
@@ -1030,6 +1049,7 @@ void testdependentrecord::getHandleWithESGetTokenTest() {
       const edm::EventSetup eventSetup{provider.eventSetupImpl(),
                                        static_cast<unsigned int>(edm::Transition::Event),
                                        consumer.esGetTokenIndices(edm::Transition::Event),
+                                       parentC,
                                        true};
       auto const& depRecord = eventSetup.get<DepRecord>();
 
@@ -1045,6 +1065,7 @@ void testdependentrecord::getHandleWithESGetTokenTest() {
       const edm::EventSetup eventSetup{provider.eventSetupImpl(),
                                        static_cast<unsigned int>(edm::Transition::Event),
                                        consumer.esGetTokenIndices(edm::Transition::Event),
+                                       parentC,
                                        true};
       auto const& depRecord = eventSetup.get<DepRecord>();
 
@@ -1060,6 +1081,7 @@ void testdependentrecord::getHandleWithESGetTokenTest() {
       const edm::EventSetup eventSetup{provider.eventSetupImpl(),
                                        static_cast<unsigned int>(edm::Transition::Event),
                                        consumer.esGetTokenIndices(edm::Transition::Event),
+                                       parentC,
                                        true};
       auto const& depRecord = eventSetup.get<DepRecord>();
 
@@ -1080,6 +1102,7 @@ void testdependentrecord::getHandleWithESGetTokenTest() {
       const edm::EventSetup eventSetup{provider.eventSetupImpl(),
                                        static_cast<unsigned int>(edm::Transition::Event),
                                        consumer.esGetTokenIndices(edm::Transition::Event),
+                                       parentC,
                                        true};
       auto const& depRecord = eventSetup.get<DepRecord>();
 
@@ -1093,6 +1116,7 @@ void testdependentrecord::getHandleWithESGetTokenTest() {
       const edm::EventSetup eventSetup{provider.eventSetupImpl(),
                                        static_cast<unsigned int>(edm::Transition::Event),
                                        consumer.esGetTokenIndices(edm::Transition::Event),
+                                       parentC,
                                        true};
       auto const& depRecord = eventSetup.get<DepRecord>();
 
@@ -1144,6 +1168,7 @@ void testdependentrecord::getTransientHandleWithESGetTokenTest() {
     provider.add(std::shared_ptr<edm::EventSetupRecordIntervalFinder>(dummyFinder));
 
     controller.eventSetupForInstance(edm::IOVSyncValue(edm::EventID(1, 1, 1)));
+    edm::ESParentContext parentC;
     {
       DummyDataConsumer<DepRecord> consumer{edm::ESInputTag{"", "blah"}};
       consumer.updateLookup(provider.recordsToProxyIndices());
@@ -1151,6 +1176,7 @@ void testdependentrecord::getTransientHandleWithESGetTokenTest() {
       const edm::EventSetup eventSetup{provider.eventSetupImpl(),
                                        static_cast<unsigned int>(edm::Transition::Event),
                                        consumer.esGetTokenIndices(edm::Transition::Event),
+                                       parentC,
                                        true};
       edm::ESTransientHandle<DummyData> data = eventSetup.getTransientHandle(consumer.m_token);
       CPPUNIT_ASSERT(kGood.value_ == data->value_);
@@ -1164,6 +1190,7 @@ void testdependentrecord::getTransientHandleWithESGetTokenTest() {
       const edm::EventSetup eventSetup{provider.eventSetupImpl(),
                                        static_cast<unsigned int>(edm::Transition::Event),
                                        consumer.esGetTokenIndices(edm::Transition::Event),
+                                       parentC,
                                        true};
       edm::ESTransientHandle<DummyData> data = eventSetup.getTransientHandle(consumer.m_token);
       CPPUNIT_ASSERT(kBad.value_ == data->value_);
@@ -1177,6 +1204,7 @@ void testdependentrecord::getTransientHandleWithESGetTokenTest() {
       const edm::EventSetup eventSetup{provider.eventSetupImpl(),
                                        static_cast<unsigned int>(edm::Transition::Event),
                                        consumer.esGetTokenIndices(edm::Transition::Event),
+                                       parentC,
                                        true};
       auto const& depRecord = eventSetup.get<DepRecord>();
 
@@ -1192,6 +1220,7 @@ void testdependentrecord::getTransientHandleWithESGetTokenTest() {
       const edm::EventSetup eventSetup{provider.eventSetupImpl(),
                                        static_cast<unsigned int>(edm::Transition::Event),
                                        consumer.esGetTokenIndices(edm::Transition::Event),
+                                       parentC,
                                        true};
       auto const& depRecord = eventSetup.get<DepRecord>();
 
@@ -1207,6 +1236,7 @@ void testdependentrecord::getTransientHandleWithESGetTokenTest() {
       const edm::EventSetup eventSetup{provider.eventSetupImpl(),
                                        static_cast<unsigned int>(edm::Transition::Event),
                                        consumer.esGetTokenIndices(edm::Transition::Event),
+                                       parentC,
                                        true};
       auto const& depRecord = eventSetup.get<DepRecord>();
 
@@ -1222,6 +1252,7 @@ void testdependentrecord::getTransientHandleWithESGetTokenTest() {
       const edm::EventSetup eventSetup{provider.eventSetupImpl(),
                                        static_cast<unsigned int>(edm::Transition::Event),
                                        consumer.esGetTokenIndices(edm::Transition::Event),
+                                       parentC,
                                        true};
       auto const& depRecord = eventSetup.get<DepRecord>();
 
@@ -1242,6 +1273,7 @@ void testdependentrecord::getTransientHandleWithESGetTokenTest() {
       const edm::EventSetup eventSetup{provider.eventSetupImpl(),
                                        static_cast<unsigned int>(edm::Transition::Event),
                                        consumer.esGetTokenIndices(edm::Transition::Event),
+                                       parentC,
                                        true};
       auto const& depRecord = eventSetup.get<DepRecord>();
 
@@ -1256,6 +1288,7 @@ void testdependentrecord::getTransientHandleWithESGetTokenTest() {
       const edm::EventSetup eventSetup{provider.eventSetupImpl(),
                                        static_cast<unsigned int>(edm::Transition::Event),
                                        consumer.esGetTokenIndices(edm::Transition::Event),
+                                       parentC,
                                        true};
       auto const& depRecord = eventSetup.get<DepRecord>();
 
@@ -1285,8 +1318,9 @@ void testdependentrecord::oneOfTwoRecordTest() {
   std::shared_ptr<edm::eventsetup::DataProxyProvider> depProv = std::make_shared<DepOn2RecordProxyProvider>();
   provider.add(depProv);
   {
+    edm::ESParentContext parentC;
     controller.eventSetupForInstance(edm::IOVSyncValue(edm::EventID(1, 1, 1)));
-    const edm::EventSetup eventSetup1(provider.eventSetupImpl(), 0, nullptr, true);
+    const edm::EventSetup eventSetup1(provider.eventSetupImpl(), 0, nullptr, parentC, true);
     const DepOn2Record& depRecord = eventSetup1.get<DepOn2Record>();
 
     depRecord.getRecord<DummyRecord>();
@@ -1319,8 +1353,9 @@ void testdependentrecord::resetTest() {
   std::shared_ptr<edm::eventsetup::DataProxyProvider> depProv = std::make_shared<DepRecordProxyProvider>();
   provider.add(depProv);
   {
+    edm::ESParentContext parentC;
     controller.eventSetupForInstance(edm::IOVSyncValue(edm::EventID(1, 1, 1)));
-    const edm::EventSetup eventSetup1(provider.eventSetupImpl(), 0, nullptr, true);
+    const edm::EventSetup eventSetup1(provider.eventSetupImpl(), 0, nullptr, parentC, true);
     const DepRecord& depRecord = eventSetup1.get<DepRecord>();
     unsigned long long depCacheID = depRecord.cacheIdentifier();
     const DummyRecord& dummyRecord = depRecord.getRecord<DummyRecord>();
@@ -1464,19 +1499,20 @@ void testdependentrecord::extendIOVTest() {
   std::shared_ptr<edm::eventsetup::DataProxyProvider> depProv = std::make_shared<DepOn2RecordProxyProvider>();
   provider.add(depProv);
 
+  edm::ESParentContext parentC;
   std::shared_ptr<Dummy2RecordFinder> dummy2Finder = std::make_shared<Dummy2RecordFinder>();
   dummy2Finder->setInterval(edm::ValidityInterval{startSyncValue, edm::IOVSyncValue{edm::EventID{1, 1, 6}}});
   provider.add(std::shared_ptr<edm::EventSetupRecordIntervalFinder>(dummy2Finder));
   {
     controller.eventSetupForInstance(edm::IOVSyncValue(edm::EventID(1, 1, 1), edm::Timestamp(1)));
-    const edm::EventSetup eventSetup1(provider.eventSetupImpl(), 0, nullptr, true);
+    const edm::EventSetup eventSetup1(provider.eventSetupImpl(), 0, nullptr, parentC, true);
     unsigned long long id1 = eventSetup1.get<DepOn2Record>().cacheIdentifier();
     CPPUNIT_ASSERT(id1 == eventSetup1.get<DummyRecord>().cacheIdentifier());
     CPPUNIT_ASSERT(id1 == eventSetup1.get<Dummy2Record>().cacheIdentifier());
 
     {
       controller.eventSetupForInstance(edm::IOVSyncValue(edm::EventID(1, 1, 5), edm::Timestamp(2)));
-      const edm::EventSetup eventSetup(provider.eventSetupImpl(), 0, nullptr, true);
+      const edm::EventSetup eventSetup(provider.eventSetupImpl(), 0, nullptr, parentC, true);
       unsigned long long id = eventSetup.get<DepOn2Record>().cacheIdentifier();
       CPPUNIT_ASSERT(id1 == id);
       CPPUNIT_ASSERT(id1 == eventSetup.get<DummyRecord>().cacheIdentifier());
@@ -1486,7 +1522,7 @@ void testdependentrecord::extendIOVTest() {
     dummyFinder->setInterval(edm::ValidityInterval{startSyncValue, edm::IOVSyncValue{edm::EventID{1, 1, 7}}});
     {
       controller.eventSetupForInstance(edm::IOVSyncValue(edm::EventID(1, 1, 6), edm::Timestamp(7)));
-      const edm::EventSetup eventSetup(provider.eventSetupImpl(), 0, nullptr, true);
+      const edm::EventSetup eventSetup(provider.eventSetupImpl(), 0, nullptr, parentC, true);
       unsigned long long id = eventSetup.get<DepOn2Record>().cacheIdentifier();
       CPPUNIT_ASSERT(id1 == id);
       CPPUNIT_ASSERT(id1 == eventSetup.get<DummyRecord>().cacheIdentifier());
@@ -1498,7 +1534,7 @@ void testdependentrecord::extendIOVTest() {
 
     {
       controller.eventSetupForInstance(edm::IOVSyncValue(edm::EventID(1, 1, 7), edm::Timestamp(7)));
-      const edm::EventSetup eventSetup(provider.eventSetupImpl(), 0, nullptr, true);
+      const edm::EventSetup eventSetup(provider.eventSetupImpl(), 0, nullptr, parentC, true);
       unsigned long long id = eventSetup.get<DepOn2Record>().cacheIdentifier();
       CPPUNIT_ASSERT(id1 == id);
       CPPUNIT_ASSERT(id1 == eventSetup.get<DummyRecord>().cacheIdentifier());
@@ -1510,7 +1546,7 @@ void testdependentrecord::extendIOVTest() {
     dummyFinder->setInterval(edm::ValidityInterval{startSyncValue, edm::IOVSyncValue{edm::EventID{1, 1, 8}}});
     {
       controller.eventSetupForInstance(edm::IOVSyncValue(edm::EventID(1, 1, 8), edm::Timestamp(7)));
-      const edm::EventSetup eventSetup(provider.eventSetupImpl(), 0, nullptr, true);
+      const edm::EventSetup eventSetup(provider.eventSetupImpl(), 0, nullptr, parentC, true);
       unsigned long long id = eventSetup.get<DepOn2Record>().cacheIdentifier();
       CPPUNIT_ASSERT(id1 == id);
       CPPUNIT_ASSERT(id1 == eventSetup.get<DummyRecord>().cacheIdentifier());
@@ -1523,7 +1559,7 @@ void testdependentrecord::extendIOVTest() {
         edm::ValidityInterval{edm::IOVSyncValue{edm::EventID{1, 1, 9}}, edm::IOVSyncValue{edm::EventID{1, 1, 9}}});
     {
       controller.eventSetupForInstance(edm::IOVSyncValue(edm::EventID(1, 1, 9), edm::Timestamp(7)));
-      const edm::EventSetup eventSetup(provider.eventSetupImpl(), 0, nullptr, true);
+      const edm::EventSetup eventSetup(provider.eventSetupImpl(), 0, nullptr, parentC, true);
       unsigned long long id = eventSetup.get<DepOn2Record>().cacheIdentifier();
       CPPUNIT_ASSERT(id1 + 1 == id);
       CPPUNIT_ASSERT(id1 + 1 == eventSetup.get<DummyRecord>().cacheIdentifier());
@@ -1538,7 +1574,7 @@ void testdependentrecord::extendIOVTest() {
 
     {
       controller.eventSetupForInstance(edm::IOVSyncValue(edm::EventID(1, 1, 10), edm::Timestamp(7)));
-      const edm::EventSetup eventSetup(provider.eventSetupImpl(), 0, nullptr, true);
+      const edm::EventSetup eventSetup(provider.eventSetupImpl(), 0, nullptr, parentC, true);
       unsigned long long id = eventSetup.get<DepOn2Record>().cacheIdentifier();
       CPPUNIT_ASSERT(id1 + 2 == id);
       CPPUNIT_ASSERT(id1 + 1 == eventSetup.get<DummyRecord>().cacheIdentifier());

--- a/FWCore/Framework/test/esproducer_t.cppunit.cc
+++ b/FWCore/Framework/test/esproducer_t.cppunit.cc
@@ -206,11 +206,12 @@ void testEsproducer::getFromTest() {
   auto pFinder = std::make_shared<DummyFinder>();
   provider.add(std::shared_ptr<EventSetupRecordIntervalFinder>(pFinder));
 
+  edm::ESParentContext parentC;
   for (int iTime = 1; iTime != 6; ++iTime) {
     const edm::Timestamp time(iTime);
     pFinder->setInterval(edm::ValidityInterval(edm::IOVSyncValue(time), edm::IOVSyncValue(time)));
     controller.eventSetupForInstance(edm::IOVSyncValue(time));
-    const edm::EventSetup eventSetup(provider.eventSetupImpl(), 0, nullptr, false);
+    const edm::EventSetup eventSetup(provider.eventSetupImpl(), 0, nullptr, parentC, false);
     edm::ESHandle<DummyData> pDummy;
     eventSetup.get<DummyRecord>().get(pDummy);
     CPPUNIT_ASSERT(0 != pDummy.product());
@@ -229,11 +230,12 @@ void testEsproducer::getfromShareTest() {
   auto pFinder = std::make_shared<DummyFinder>();
   provider.add(std::shared_ptr<EventSetupRecordIntervalFinder>(pFinder));
 
+  edm::ESParentContext parentC;
   for (int iTime = 1; iTime != 6; ++iTime) {
     const edm::Timestamp time(iTime);
     pFinder->setInterval(edm::ValidityInterval(edm::IOVSyncValue(time), edm::IOVSyncValue(time)));
     controller.eventSetupForInstance(edm::IOVSyncValue(time));
-    const edm::EventSetup eventSetup(provider.eventSetupImpl(), 0, nullptr, false);
+    const edm::EventSetup eventSetup(provider.eventSetupImpl(), 0, nullptr, parentC, false);
     edm::ESHandle<DummyData> pDummy;
     eventSetup.get<DummyRecord>().get(pDummy);
     CPPUNIT_ASSERT(0 != pDummy.product());
@@ -252,11 +254,12 @@ void testEsproducer::getfromUniqueTest() {
   auto pFinder = std::make_shared<DummyFinder>();
   provider.add(std::shared_ptr<EventSetupRecordIntervalFinder>(pFinder));
 
+  edm::ESParentContext parentC;
   for (int iTime = 1; iTime != 6; ++iTime) {
     const edm::Timestamp time(iTime);
     pFinder->setInterval(edm::ValidityInterval(edm::IOVSyncValue(time), edm::IOVSyncValue(time)));
     controller.eventSetupForInstance(edm::IOVSyncValue(time));
-    const edm::EventSetup eventSetup(provider.eventSetupImpl(), 0, nullptr, false);
+    const edm::EventSetup eventSetup(provider.eventSetupImpl(), 0, nullptr, parentC, false);
     edm::ESHandle<DummyData> pDummy;
     eventSetup.get<DummyRecord>().get(pDummy);
     CPPUNIT_ASSERT(0 != pDummy.product());
@@ -274,11 +277,12 @@ void testEsproducer::getfromOptionalTest() {
   auto pFinder = std::make_shared<DummyFinder>();
   provider.add(std::shared_ptr<EventSetupRecordIntervalFinder>(pFinder));
 
+  edm::ESParentContext parentC;
   for (int iTime = 1; iTime != 6; ++iTime) {
     const edm::Timestamp time(iTime);
     pFinder->setInterval(edm::ValidityInterval(edm::IOVSyncValue(time), edm::IOVSyncValue(time)));
     controller.eventSetupForInstance(edm::IOVSyncValue(time));
-    const edm::EventSetup eventSetup(provider.eventSetupImpl(), 0, nullptr, false);
+    const edm::EventSetup eventSetup(provider.eventSetupImpl(), 0, nullptr, parentC, false);
     edm::ESHandle<DummyData> pDummy;
     eventSetup.get<DummyRecord>().get(pDummy);
     CPPUNIT_ASSERT(0 != pDummy.product());
@@ -298,11 +302,12 @@ void testEsproducer::labelTest() {
     auto pFinder = std::make_shared<DummyFinder>();
     provider.add(std::shared_ptr<EventSetupRecordIntervalFinder>(pFinder));
 
+    edm::ESParentContext parentC;
     for (int iTime = 1; iTime != 6; ++iTime) {
       const edm::Timestamp time(iTime);
       pFinder->setInterval(edm::ValidityInterval(edm::IOVSyncValue(time), edm::IOVSyncValue(time)));
       controller.eventSetupForInstance(edm::IOVSyncValue(time));
-      const edm::EventSetup eventSetup(provider.eventSetupImpl(), 0, nullptr, false);
+      const edm::EventSetup eventSetup(provider.eventSetupImpl(), 0, nullptr, parentC, false);
       edm::ESHandle<DummyData> pDummy;
       eventSetup.get<DummyRecord>().get("foo", pDummy);
       CPPUNIT_ASSERT(0 != pDummy.product());
@@ -356,11 +361,12 @@ void testEsproducer::decoratorTest() {
   auto pFinder = std::make_shared<DummyFinder>();
   provider.add(std::shared_ptr<EventSetupRecordIntervalFinder>(pFinder));
 
+  edm::ESParentContext parentC;
   for (int iTime = 1; iTime != 6; ++iTime) {
     const edm::Timestamp time(iTime);
     pFinder->setInterval(edm::ValidityInterval(edm::IOVSyncValue(time), edm::IOVSyncValue(time)));
     controller.eventSetupForInstance(edm::IOVSyncValue(time));
-    const edm::EventSetup eventSetup(provider.eventSetupImpl(), 0, nullptr, false);
+    const edm::EventSetup eventSetup(provider.eventSetupImpl(), 0, nullptr, parentC, false);
     edm::ESHandle<DummyData> pDummy;
 
     CPPUNIT_ASSERT(iTime - 1 == TestDecorator::s_pre);
@@ -400,11 +406,12 @@ void testEsproducer::dependsOnTest() {
   auto pFinder = std::make_shared<DummyFinder>();
   provider.add(std::shared_ptr<EventSetupRecordIntervalFinder>(pFinder));
 
+  edm::ESParentContext parentC;
   for (int iTime = 1; iTime != 6; ++iTime) {
     const edm::Timestamp time(iTime);
     pFinder->setInterval(edm::ValidityInterval(edm::IOVSyncValue(time), edm::IOVSyncValue(time)));
     controller.eventSetupForInstance(edm::IOVSyncValue(time));
-    const edm::EventSetup eventSetup(provider.eventSetupImpl(), 0, nullptr, false);
+    const edm::EventSetup eventSetup(provider.eventSetupImpl(), 0, nullptr, parentC, false);
     edm::ESHandle<DummyData> pDummy;
 
     eventSetup.get<DepRecord>().get(pDummy);
@@ -428,7 +435,8 @@ void testEsproducer::forceCacheClearTest() {
   const edm::Timestamp time(1);
   pFinder->setInterval(edm::ValidityInterval(edm::IOVSyncValue(time), edm::IOVSyncValue(time)));
   controller.eventSetupForInstance(edm::IOVSyncValue(time));
-  const edm::EventSetup eventSetup(provider.eventSetupImpl(), 0, nullptr, false);
+  edm::ESParentContext parentC;
+  const edm::EventSetup eventSetup(provider.eventSetupImpl(), 0, nullptr, parentC, false);
   {
     edm::ESHandle<DummyData> pDummy;
     eventSetup.get<DummyRecord>().get(pDummy);
@@ -438,7 +446,8 @@ void testEsproducer::forceCacheClearTest() {
   provider.forceCacheClear();
   controller.eventSetupForInstance(edm::IOVSyncValue(time));
   {
-    const edm::EventSetup eventSetup2(provider.eventSetupImpl(), 0, nullptr, false);
+    edm::ESParentContext parentC;
+    const edm::EventSetup eventSetup2(provider.eventSetupImpl(), 0, nullptr, parentC, false);
     edm::ESHandle<DummyData> pDummy;
     eventSetup2.get<DummyRecord>().get(pDummy);
     CPPUNIT_ASSERT(0 != pDummy.product());
@@ -457,7 +466,8 @@ namespace {
                              EventSetupRecordImpl const&,
                              DataKey const&,
                              edm::EventSetupImpl const*,
-                             edm::ServiceToken const&) override {}
+                             edm::ServiceToken const&,
+                             edm::ESParentContext const&) override {}
       void invalidateCache() override {}
       void const* getAfterPrefetchImpl() const override { return nullptr; }
     };

--- a/FWCore/Framework/test/eventsetup_t.cppunit.cc
+++ b/FWCore/Framework/test/eventsetup_t.cppunit.cc
@@ -157,7 +157,8 @@ void testEventsetup::constructTest() {
   bool newEventSetupImpl = false;
   auto eventSetupImpl = provider.eventSetupForInstance(timestamp, newEventSetupImpl);
   CPPUNIT_ASSERT(non_null(eventSetupImpl.get()));
-  const edm::EventSetup eventSetup(provider.eventSetupImpl(), 0, nullptr, true);
+  edm::ESParentContext pc;
+  const edm::EventSetup eventSetup(provider.eventSetupImpl(), 0, nullptr, pc, true);
 }
 
 // Note there is a similar test in dependentrecord_t.cppunit.cc
@@ -173,7 +174,8 @@ void testEventsetup::getTest() {
   eventSetupImpl.setKeyIters(keys.begin(), keys.end());
   EventSetupRecordImpl dummyRecordImpl{key, &activityRegistry};
   eventSetupImpl.addRecordImpl(dummyRecordImpl);
-  const edm::EventSetup eventSetup(eventSetupImpl, 0, nullptr, true);
+  edm::ESParentContext pc;
+  const edm::EventSetup eventSetup(eventSetupImpl, 0, nullptr, pc, true);
   const DummyRecord& gottenRecord = eventSetup.get<DummyRecord>();
   CPPUNIT_ASSERT(&dummyRecordImpl == gottenRecord.impl_);
 }
@@ -186,7 +188,8 @@ void testEventsetup::tryToGetTest() {
   eventSetupImpl.setKeyIters(keys.begin(), keys.end());
   EventSetupRecordImpl dummyRecordImpl{key, &activityRegistry};
   eventSetupImpl.addRecordImpl(dummyRecordImpl);
-  const edm::EventSetup eventSetup(eventSetupImpl, 0, nullptr, true);
+  edm::ESParentContext pc;
+  const edm::EventSetup eventSetup(eventSetupImpl, 0, nullptr, pc, true);
   std::optional<DummyRecord> gottenRecord = eventSetup.tryToGet<DummyRecord>();
   CPPUNIT_ASSERT(gottenRecord);
   CPPUNIT_ASSERT(&dummyRecordImpl == gottenRecord.value().impl_);
@@ -197,7 +200,8 @@ void testEventsetup::getExcTest() {
   edm::ParameterSet pset = createDummyPset();
   EventSetupProvider& provider = *controller.makeProvider(pset, &activityRegistry);
   controller.eventSetupForInstance(edm::IOVSyncValue(edm::EventID(1, 1, 1), edm::Timestamp(1)));
-  const edm::EventSetup eventSetup(provider.eventSetupImpl(), 0, nullptr, true);
+  edm::ESParentContext pc;
+  const edm::EventSetup eventSetup(provider.eventSetupImpl(), 0, nullptr, pc, true);
   eventSetup.get<DummyRecord>();
 }
 
@@ -236,27 +240,31 @@ void testEventsetup::recordValidityTest() {
 
   Timestamp time_1(1);
   controller.eventSetupForInstance(IOVSyncValue(time_1));
-  const edm::EventSetup eventSetup1(provider.eventSetupImpl(), 0, nullptr, false);
+  edm::ESParentContext pc;
+  const edm::EventSetup eventSetup1(provider.eventSetupImpl(), 0, nullptr, pc, false);
   CPPUNIT_ASSERT(!eventSetup1.tryToGet<DummyRecord>().has_value());
 
   const Timestamp time_2(2);
   dummyFinder->setInterval(ValidityInterval(IOVSyncValue(time_2), IOVSyncValue(Timestamp(3))));
   {
     controller.eventSetupForInstance(IOVSyncValue(time_2));
-    const edm::EventSetup eventSetup(provider.eventSetupImpl(), 0, nullptr, false);
+    edm::ESParentContext pc;
+    const edm::EventSetup eventSetup(provider.eventSetupImpl(), 0, nullptr, pc, false);
     eventSetup.get<DummyRecord>();
     CPPUNIT_ASSERT(eventSetup.tryToGet<DummyRecord>().has_value());
   }
 
   {
     controller.eventSetupForInstance(IOVSyncValue(Timestamp(3)));
-    const edm::EventSetup eventSetup(provider.eventSetupImpl(), 0, nullptr, false);
+    edm::ESParentContext pc;
+    const edm::EventSetup eventSetup(provider.eventSetupImpl(), 0, nullptr, pc, false);
     eventSetup.get<DummyRecord>();
     CPPUNIT_ASSERT(eventSetup.tryToGet<DummyRecord>().has_value());
   }
   {
     controller.eventSetupForInstance(IOVSyncValue(Timestamp(4)));
-    const edm::EventSetup eventSetup(provider.eventSetupImpl(), 0, nullptr, false);
+    edm::ESParentContext pc;
+    const edm::EventSetup eventSetup(provider.eventSetupImpl(), 0, nullptr, pc, false);
     CPPUNIT_ASSERT(!eventSetup.tryToGet<DummyRecord>().has_value());
   }
 }
@@ -275,7 +283,8 @@ void testEventsetup::recordValidityExcTest() {
 
   Timestamp time_1(1);
   controller.eventSetupForInstance(IOVSyncValue(time_1));
-  const edm::EventSetup eventSetup(provider.eventSetupImpl(), 0, nullptr, true);
+  edm::ESParentContext pc;
+  const edm::EventSetup eventSetup(provider.eventSetupImpl(), 0, nullptr, pc, true);
   eventSetup.get<DummyRecord>();
 }
 
@@ -286,7 +295,8 @@ void testEventsetup::recordValidityNoFinderTest() {
 
   Timestamp time_1(1);
   controller.eventSetupForInstance(IOVSyncValue(time_1));
-  const edm::EventSetup eventSetup(provider.eventSetupImpl(), 0, nullptr, false);
+  edm::ESParentContext pc;
+  const edm::EventSetup eventSetup(provider.eventSetupImpl(), 0, nullptr, pc, false);
   CPPUNIT_ASSERT(!eventSetup.tryToGet<DummyRecord>().has_value());
 }
 
@@ -297,7 +307,8 @@ void testEventsetup::recordValidityNoFinderExcTest() {
 
   Timestamp time_1(1);
   controller.eventSetupForInstance(IOVSyncValue(time_1));
-  const edm::EventSetup eventSetup(provider.eventSetupImpl(), 0, nullptr, false);
+  edm::ESParentContext pc;
+  const edm::EventSetup eventSetup(provider.eventSetupImpl(), 0, nullptr, pc, false);
   eventSetup.get<DummyRecord>();
 }
 
@@ -313,7 +324,8 @@ void testEventsetup::recordValidityProxyNoFinderTest() {
 
   Timestamp time_1(1);
   controller.eventSetupForInstance(IOVSyncValue(time_1));
-  const edm::EventSetup eventSetup(provider.eventSetupImpl(), 0, nullptr, true);
+  edm::ESParentContext pc;
+  const edm::EventSetup eventSetup(provider.eventSetupImpl(), 0, nullptr, pc, true);
   CPPUNIT_ASSERT(!eventSetup.tryToGet<DummyRecord>().has_value());
 }
 
@@ -326,7 +338,8 @@ void testEventsetup::recordValidityProxyNoFinderExcTest() {
 
   Timestamp time_1(1);
   controller.eventSetupForInstance(IOVSyncValue(time_1));
-  const edm::EventSetup eventSetup(provider.eventSetupImpl(), 0, nullptr, true);
+  edm::ESParentContext pc;
+  const edm::EventSetup eventSetup(provider.eventSetupImpl(), 0, nullptr, pc, true);
   eventSetup.get<DummyRecord>();
 }
 
@@ -393,12 +406,13 @@ void testEventsetup::twoSourceTest() {
     provider.add(finderPtr);
   }
   //checking for conflicts is delayed until first eventSetupForInstance
+  edm::ESParentContext pc;
   controller.eventSetupForInstance(IOVSyncValue::invalidIOVSyncValue());
-  const edm::EventSetup eventSetup3(provider.eventSetupImpl(), 0, nullptr, false);
+  const edm::EventSetup eventSetup3(provider.eventSetupImpl(), 0, nullptr, pc, false);
   CPPUNIT_ASSERT(!eventSetup3.tryToGet<DummyRecord>().has_value());
   CPPUNIT_ASSERT(!eventSetup3.tryToGet<DummyEventSetupRecord>().has_value());
   controller.eventSetupForInstance(IOVSyncValue(Timestamp(3)));
-  const edm::EventSetup eventSetup4(provider.eventSetupImpl(), 0, nullptr, false);
+  const edm::EventSetup eventSetup4(provider.eventSetupImpl(), 0, nullptr, pc, false);
   CPPUNIT_ASSERT(!eventSetup4.tryToGet<DummyRecord>().has_value());
   CPPUNIT_ASSERT(eventSetup4.tryToGet<DummyEventSetupRecord>().has_value());
   eventSetup4.get<DummyEventSetupRecord>();
@@ -435,7 +449,8 @@ void testEventsetup::provenanceTest() {
       provider.add(dummyProv);
     }
     controller.eventSetupForInstance(IOVSyncValue(Timestamp(2)));
-    const edm::EventSetup eventSetup(provider.eventSetupImpl(), 0, nullptr, false);
+    edm::ESParentContext pc;
+    const edm::EventSetup eventSetup(provider.eventSetupImpl(), 0, nullptr, pc, false);
     edm::ESHandle<DummyData> data;
     eventSetup.getData(data);
     CPPUNIT_ASSERT(kGood.value_ == data->value_);
@@ -480,7 +495,8 @@ void testEventsetup::getDataWithLabelTest() {
       provider.add(dummyProv);
     }
     controller.eventSetupForInstance(IOVSyncValue(Timestamp(2)));
-    const edm::EventSetup eventSetup(provider.eventSetupImpl(), 0, nullptr, false);
+    edm::ESParentContext pc;
+    const edm::EventSetup eventSetup(provider.eventSetupImpl(), 0, nullptr, pc, false);
     edm::ESHandle<DummyData> data;
     eventSetup.getData("blah", data);
     CPPUNIT_ASSERT(kGood.value_ == data->value_);
@@ -525,7 +541,8 @@ void testEventsetup::getDataWithESInputTagTest() {
       provider.add(dummyProv);
     }
     controller.eventSetupForInstance(IOVSyncValue(Timestamp(2)));
-    const edm::EventSetup eventSetup(provider.eventSetupImpl(), 0, nullptr, false);
+    edm::ESParentContext pc;
+    const edm::EventSetup eventSetup(provider.eventSetupImpl(), 0, nullptr, pc, false);
     {
       edm::ESHandle<DummyData> data;
       edm::ESInputTag blahTag("", "blah");
@@ -577,7 +594,8 @@ namespace {
         if (rec) {
           auto waitTask = edm::make_empty_waiting_task();
           waitTask->set_ref_count(2);
-          rec->prefetchAsync(WaitingTaskHolder(waitTask.get()), proxies[i], &iImpl, edm::ServiceToken{});
+          rec->prefetchAsync(
+              WaitingTaskHolder(waitTask.get()), proxies[i], &iImpl, edm::ServiceToken{}, edm::ESParentContext{});
           waitTask->decrement_ref_count();
           waitTask->wait_for_all();
           if (waitTask->exceptionPtr()) {
@@ -798,6 +816,7 @@ void testEventsetup::getDataWithESGetTokenTest() {
       provider.add(dummyProv);
     }
 
+    edm::ESParentContext pc;
     controller.eventSetupForInstance(IOVSyncValue(Timestamp(2)));
     {
       DummyDataConsumer consumer{edm::ESInputTag("", "blah")};
@@ -806,6 +825,7 @@ void testEventsetup::getDataWithESGetTokenTest() {
       EventSetup eventSetup{provider.eventSetupImpl(),
                             static_cast<unsigned int>(edm::Transition::Event),
                             consumer.esGetTokenIndices(edm::Transition::Event),
+                            pc,
                             true};
       auto const& data = eventSetup.getData(consumer.m_token);
       CPPUNIT_ASSERT(kGood.value_ == data.value_);
@@ -826,6 +846,7 @@ void testEventsetup::getDataWithESGetTokenTest() {
       EventSetup eventSetup{provider.eventSetupImpl(),
                             static_cast<unsigned int>(edm::Transition::Event),
                             consumer.esGetTokenIndices(edm::Transition::Event),
+                            pc,
                             true};
       const DummyData& data = eventSetup.getData(consumer.m_token);
       CPPUNIT_ASSERT(kBad.value_ == data.value_);
@@ -838,6 +859,7 @@ void testEventsetup::getDataWithESGetTokenTest() {
       EventSetup eventSetup{provider.eventSetupImpl(),
                             static_cast<unsigned int>(edm::Transition::Event),
                             consumer.esGetTokenIndices(edm::Transition::Event),
+                            pc,
                             true};
       auto const& data = eventSetup.getData(consumer.m_token);
       CPPUNIT_ASSERT(kGood.value_ == data.value_);
@@ -850,6 +872,7 @@ void testEventsetup::getDataWithESGetTokenTest() {
       EventSetup eventSetup{provider.eventSetupImpl(),
                             static_cast<unsigned int>(edm::Transition::Event),
                             consumer.esGetTokenIndices(edm::Transition::Event),
+                            pc,
                             true};
       CPPUNIT_ASSERT_THROW(eventSetup.getData(consumer.m_token), cms::Exception);
     }
@@ -861,6 +884,7 @@ void testEventsetup::getDataWithESGetTokenTest() {
       EventSetup eventSetup{provider.eventSetupImpl(),
                             static_cast<unsigned int>(edm::Transition::Event),
                             consumer.esGetTokenIndices(edm::Transition::Event),
+                            pc,
                             true};
       const DummyData& data = eventSetup.getData(consumer.m_token);
       CPPUNIT_ASSERT(kBad.value_ == data.value_);
@@ -872,6 +896,7 @@ void testEventsetup::getDataWithESGetTokenTest() {
       EventSetup eventSetup{provider.eventSetupImpl(),
                             static_cast<unsigned int>(edm::Transition::Event),
                             consumer.esGetTokenIndices(edm::Transition::Event),
+                            pc,
                             true};
       const DummyData& data = eventSetup.getData(consumer.m_token);
       CPPUNIT_ASSERT(kBad.value_ == data.value_);
@@ -883,6 +908,7 @@ void testEventsetup::getDataWithESGetTokenTest() {
       EventSetup eventSetup{provider.eventSetupImpl(),
                             static_cast<unsigned int>(edm::Transition::Event),
                             consumer.esGetTokenIndices(edm::Transition::Event),
+                            pc,
                             true};
       CPPUNIT_ASSERT_THROW(eventSetup.getData(consumer.m_token), edm::eventsetup::MakeDataException);
     }
@@ -893,6 +919,7 @@ void testEventsetup::getDataWithESGetTokenTest() {
       EventSetup eventSetup{provider.eventSetupImpl(),
                             static_cast<unsigned int>(edm::Transition::Event),
                             consumer.esGetTokenIndices(edm::Transition::Event),
+                            pc,
                             true};
       const DummyData& data = eventSetup.getData(consumer.m_token);
       CPPUNIT_ASSERT(kBad.value_ == data.value_);
@@ -913,6 +940,7 @@ void testEventsetup::getHandleWithESGetTokenTest() {
   dummyFinder->setInterval(ValidityInterval(IOVSyncValue(Timestamp(2)), IOVSyncValue(Timestamp(3))));
   provider.add(std::shared_ptr<edm::EventSetupRecordIntervalFinder>(dummyFinder));
 
+  edm::ESParentContext pc;
   try {
     {
       edm::eventsetup::ComponentDescription description("DummyProxyProvider", "testOne", true);
@@ -945,6 +973,7 @@ void testEventsetup::getHandleWithESGetTokenTest() {
       EventSetup eventSetup{provider.eventSetupImpl(),
                             static_cast<unsigned int>(edm::Transition::Event),
                             consumer.esGetTokenIndices(edm::Transition::Event),
+                            pc,
                             true};
       edm::ESHandle<DummyData> data = eventSetup.getHandle(consumer.m_token);
       CPPUNIT_ASSERT(kGood.value_ == data->value_);
@@ -959,6 +988,7 @@ void testEventsetup::getHandleWithESGetTokenTest() {
       EventSetup eventSetup{provider.eventSetupImpl(),
                             static_cast<unsigned int>(edm::Transition::Event),
                             consumer.esGetTokenIndices(edm::Transition::Event),
+                            pc,
                             true};
       edm::ESHandle<DummyData> data = eventSetup.getHandle(consumer.m_token);
       CPPUNIT_ASSERT(kBad.value_ == data->value_);
@@ -973,6 +1003,7 @@ void testEventsetup::getHandleWithESGetTokenTest() {
       EventSetup eventSetup{provider.eventSetupImpl(),
                             static_cast<unsigned int>(edm::Transition::Event),
                             consumer.esGetTokenIndices(edm::Transition::Event),
+                            pc,
                             true};
       edm::ESHandle<DummyData> data = eventSetup.getHandle(consumer.m_token);
       CPPUNIT_ASSERT(kGood.value_ == data->value_);
@@ -987,6 +1018,7 @@ void testEventsetup::getHandleWithESGetTokenTest() {
       EventSetup eventSetup{provider.eventSetupImpl(),
                             static_cast<unsigned int>(edm::Transition::Event),
                             consumer.esGetTokenIndices(edm::Transition::Event),
+                            pc,
                             true};
       CPPUNIT_ASSERT(not eventSetup.getHandle(consumer.m_token));
       CPPUNIT_ASSERT_THROW(*eventSetup.getHandle(consumer.m_token), cms::Exception);
@@ -1008,6 +1040,7 @@ void testEventsetup::getTransientHandleWithESGetTokenTest() {
   edm::ParameterSet pset = createDummyPset();
   EventSetupProvider& provider = *controller.makeProvider(pset, &activityRegistry);
 
+  edm::ESParentContext pc;
   try {
     {
       edm::eventsetup::ComponentDescription description("DummyProxyProvider", "testOne", true);
@@ -1044,6 +1077,7 @@ void testEventsetup::getTransientHandleWithESGetTokenTest() {
       const edm::EventSetup eventSetup{provider.eventSetupImpl(),
                                        static_cast<unsigned int>(edm::Transition::Event),
                                        consumer.esGetTokenIndices(edm::Transition::Event),
+                                       pc,
                                        true};
       edm::ESTransientHandle<DummyData> data = eventSetup.getTransientHandle(consumer.m_token);
       CPPUNIT_ASSERT(kGood.value_ == data->value_);
@@ -1058,6 +1092,7 @@ void testEventsetup::getTransientHandleWithESGetTokenTest() {
       const edm::EventSetup eventSetup{provider.eventSetupImpl(),
                                        static_cast<unsigned int>(edm::Transition::Event),
                                        consumer.esGetTokenIndices(edm::Transition::Event),
+                                       pc,
                                        true};
       edm::ESTransientHandle<DummyData> data = eventSetup.getTransientHandle(consumer.m_token);
       CPPUNIT_ASSERT(kBad.value_ == data->value_);
@@ -1072,6 +1107,7 @@ void testEventsetup::getTransientHandleWithESGetTokenTest() {
       const edm::EventSetup eventSetup{provider.eventSetupImpl(),
                                        static_cast<unsigned int>(edm::Transition::Event),
                                        consumer.esGetTokenIndices(edm::Transition::Event),
+                                       pc,
                                        true};
       edm::ESTransientHandle<DummyData> data = eventSetup.getTransientHandle(consumer.m_token);
       CPPUNIT_ASSERT(kGood.value_ == data->value_);
@@ -1086,6 +1122,7 @@ void testEventsetup::getTransientHandleWithESGetTokenTest() {
       const edm::EventSetup eventSetup{provider.eventSetupImpl(),
                                        static_cast<unsigned int>(edm::Transition::Event),
                                        consumer.esGetTokenIndices(edm::Transition::Event),
+                                       pc,
                                        true};
       edm::ESTransientHandle<DummyData> data = eventSetup.getTransientHandle(consumer.m_token);
       CPPUNIT_ASSERT(not data);
@@ -1108,6 +1145,7 @@ void testEventsetup::sourceProducerResolutionTest() {
     dummyFinder->setInterval(ValidityInterval(IOVSyncValue(Timestamp(2)), IOVSyncValue(Timestamp(3))));
     provider.add(std::shared_ptr<edm::EventSetupRecordIntervalFinder>(dummyFinder));
 
+    edm::ESParentContext pc;
     {
       edm::eventsetup::ComponentDescription description("DummyProxyProvider", "", true);
       auto dummyProv = std::make_shared<DummyProxyProvider>(kBad);
@@ -1121,7 +1159,7 @@ void testEventsetup::sourceProducerResolutionTest() {
       provider.add(dummyProv);
     }
     controller.eventSetupForInstance(IOVSyncValue(Timestamp(2)));
-    const EventSetup eventSetup{provider.eventSetupImpl(), 0, nullptr, false};
+    const EventSetup eventSetup{provider.eventSetupImpl(), 0, nullptr, pc, false};
     edm::ESHandle<DummyData> data;
     eventSetup.getData(data);
     CPPUNIT_ASSERT(kGood.value_ == data->value_);
@@ -1149,7 +1187,8 @@ void testEventsetup::sourceProducerResolutionTest() {
       provider.add(dummyProv);
     }
     controller.eventSetupForInstance(IOVSyncValue(Timestamp(2)));
-    EventSetup eventSetup{provider.eventSetupImpl(), 0, nullptr, false};
+    ESParentContext pc;
+    EventSetup eventSetup{provider.eventSetupImpl(), 0, nullptr, pc, false};
     edm::ESHandle<DummyData> data;
     eventSetup.getData(data);
     CPPUNIT_ASSERT(kGood.value_ == data->value_);
@@ -1162,6 +1201,7 @@ void testEventsetup::preferTest() {
   std::shared_ptr<DummyFinder> dummyFinder = std::make_shared<DummyFinder>();
   dummyFinder->setInterval(ValidityInterval(IOVSyncValue(Timestamp(2)), IOVSyncValue(Timestamp(3))));
 
+  edm::ESParentContext pc;
   try {
     {
       EventSetupsController controller;
@@ -1186,7 +1226,7 @@ void testEventsetup::preferTest() {
         provider.add(dummyProv);
       }
       controller.eventSetupForInstance(IOVSyncValue(Timestamp(2)));
-      EventSetup eventSetup{provider.eventSetupImpl(), 0, nullptr, false};
+      EventSetup eventSetup{provider.eventSetupImpl(), 0, nullptr, pc, false};
       edm::ESHandle<DummyData> data;
       eventSetup.getData(data);
       CPPUNIT_ASSERT(kGood.value_ == data->value_);
@@ -1216,7 +1256,7 @@ void testEventsetup::preferTest() {
         provider.add(dummyProv);
       }
       controller.eventSetupForInstance(IOVSyncValue(Timestamp(2)));
-      EventSetup eventSetup{provider.eventSetupImpl(), 0, nullptr, false};
+      EventSetup eventSetup{provider.eventSetupImpl(), 0, nullptr, pc, false};
       edm::ESHandle<DummyData> data;
       eventSetup.getData(data);
       CPPUNIT_ASSERT(kGood.value_ == data->value_);
@@ -1247,7 +1287,7 @@ void testEventsetup::preferTest() {
         provider.add(dummyProv);
       }
       controller.eventSetupForInstance(IOVSyncValue(Timestamp(2)));
-      EventSetup eventSetup{provider.eventSetupImpl(), 0, nullptr, false};
+      EventSetup eventSetup{provider.eventSetupImpl(), 0, nullptr, pc, false};
       edm::ESHandle<DummyData> data;
       eventSetup.getData(data);
       CPPUNIT_ASSERT(kGood.value_ == data->value_);
@@ -1268,6 +1308,7 @@ void testEventsetup::introspectionTest() {
   dummyFinder->setInterval(ValidityInterval(IOVSyncValue(Timestamp(2)), IOVSyncValue(Timestamp(3))));
   provider.add(std::shared_ptr<edm::EventSetupRecordIntervalFinder>(dummyFinder));
 
+  edm::ESParentContext pc;
   try {
     {
       edm::eventsetup::ComponentDescription description("DummyProxyProvider", "", true);
@@ -1292,7 +1333,7 @@ void testEventsetup::introspectionTest() {
     EventSetupRecordKey dummyRecordKey = EventSetupRecordKey::makeKey<DummyRecord>();
     controller.eventSetupForInstance(IOVSyncValue(Timestamp(2)));
     {
-      EventSetup eventSetup{provider.eventSetupImpl(), 0, nullptr, true};
+      EventSetup eventSetup{provider.eventSetupImpl(), 0, nullptr, pc, true};
 
       CPPUNIT_ASSERT(eventSetup.recordIsProvidedByAModule(dummyRecordKey));
       std::vector<edm::eventsetup::EventSetupRecordKey> recordKeys;
@@ -1307,7 +1348,7 @@ void testEventsetup::introspectionTest() {
     // EventSetupImpl but has a null pointer.
     controller.eventSetupForInstance(IOVSyncValue(Timestamp(4)));
     {
-      EventSetup eventSetup{provider.eventSetupImpl(), 0, nullptr, true};
+      EventSetup eventSetup{provider.eventSetupImpl(), 0, nullptr, pc, true};
 
       CPPUNIT_ASSERT(eventSetup.recordIsProvidedByAModule(dummyRecordKey));
       std::vector<edm::eventsetup::EventSetupRecordKey> recordKeys;
@@ -1337,14 +1378,15 @@ void testEventsetup::iovExtensionTest() {
   finder->setInterval(ValidityInterval(IOVSyncValue(Timestamp(2)), IOVSyncValue(Timestamp(3))));
   provider.add(std::shared_ptr<edm::EventSetupRecordIntervalFinder>(finder));
 
+  edm::ESParentContext pc;
   {
     controller.eventSetupForInstance(IOVSyncValue{Timestamp(2)});
-    EventSetup eventSetup{provider.eventSetupImpl(), 0, nullptr, true};
+    EventSetup eventSetup{provider.eventSetupImpl(), 0, nullptr, pc, true};
     CPPUNIT_ASSERT(2 == eventSetup.get<DummyRecord>().cacheIdentifier());
   }
   {
     controller.eventSetupForInstance(IOVSyncValue{Timestamp(3)});
-    EventSetup eventSetup{provider.eventSetupImpl(), 0, nullptr, true};
+    EventSetup eventSetup{provider.eventSetupImpl(), 0, nullptr, pc, true};
     eventSetup.get<DummyRecord>();
     CPPUNIT_ASSERT(2 == eventSetup.get<DummyRecord>().cacheIdentifier());
   }
@@ -1352,7 +1394,7 @@ void testEventsetup::iovExtensionTest() {
   finder->setInterval(ValidityInterval(IOVSyncValue{Timestamp{2}}, IOVSyncValue{Timestamp{4}}));
   {
     controller.eventSetupForInstance(IOVSyncValue{Timestamp(4)});
-    EventSetup eventSetup{provider.eventSetupImpl(), 0, nullptr, true};
+    EventSetup eventSetup{provider.eventSetupImpl(), 0, nullptr, pc, true};
     CPPUNIT_ASSERT(2 == eventSetup.get<DummyRecord>().cacheIdentifier());
   }
 
@@ -1360,7 +1402,7 @@ void testEventsetup::iovExtensionTest() {
   finder->setInterval(ValidityInterval(IOVSyncValue{Timestamp{5}}, IOVSyncValue{Timestamp{6}}));
   {
     controller.eventSetupForInstance(IOVSyncValue{Timestamp(5)});
-    EventSetup eventSetup{provider.eventSetupImpl(), 0, nullptr, true};
+    EventSetup eventSetup{provider.eventSetupImpl(), 0, nullptr, pc, true};
     CPPUNIT_ASSERT(3 == eventSetup.get<DummyRecord>().cacheIdentifier());
   }
 }
@@ -1384,9 +1426,10 @@ void testEventsetup::resetProxiesTest() {
   dummyProv->setDescription(description);
   provider.add(dummyProv);
 
+  edm::ESParentContext pc;
   {
     controller.eventSetupForInstance(IOVSyncValue{Timestamp(2)});
-    EventSetup eventSetup{provider.eventSetupImpl(), 0, nullptr, false};
+    EventSetup eventSetup{provider.eventSetupImpl(), 0, nullptr, pc, false};
     CPPUNIT_ASSERT(2 == eventSetup.get<DummyRecord>().cacheIdentifier());
     edm::ESHandle<DummyData> data;
     eventSetup.getData(data);
@@ -1395,7 +1438,7 @@ void testEventsetup::resetProxiesTest() {
   provider.forceCacheClear();
   {
     controller.eventSetupForInstance(IOVSyncValue{Timestamp(2)});
-    EventSetup eventSetup{provider.eventSetupImpl(), 0, nullptr, false};
+    EventSetup eventSetup{provider.eventSetupImpl(), 0, nullptr, pc, false};
     eventSetup.get<DummyRecord>();
     CPPUNIT_ASSERT(3 == eventSetup.get<DummyRecord>().cacheIdentifier());
     dummyProv->incrementData();

--- a/FWCore/Framework/test/eventsetuprecord_t.cppunit.cc
+++ b/FWCore/Framework/test/eventsetuprecord_t.cppunit.cc
@@ -29,6 +29,7 @@
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ServiceRegistry/interface/ActivityRegistry.h"
+#include "FWCore/ServiceRegistry/interface/ESParentContext.h"
 
 #include <memory>
 
@@ -185,7 +186,8 @@ void testEventsetupRecord::getTest() {
   const DataKey dummyDataKey(DataKey::makeTypeTag<FailingDummyProxy::value_type>(), "");
 
   DummyRecord dummyRecord;
-  dummyRecord.setImpl(&dummyRecordImpl, 0, nullptr, nullptr, false);
+  ESParentContext pc;
+  dummyRecord.setImpl(&dummyRecordImpl, 0, nullptr, nullptr, &pc, false);
   ESHandle<Dummy> dummyPtr;
   CPPUNIT_ASSERT(not dummyRecord.get(dummyPtr));
   CPPUNIT_ASSERT(not dummyPtr.isValid());
@@ -254,7 +256,8 @@ namespace {
       for (size_t i = 0; i != proxies.size(); ++i) {
         auto waitTask = edm::make_empty_waiting_task();
         waitTask->set_ref_count(2);
-        iRec.prefetchAsync(WaitingTaskHolder(waitTask.get()), proxies[i], nullptr, edm::ServiceToken{});
+        iRec.prefetchAsync(
+            WaitingTaskHolder(waitTask.get()), proxies[i], nullptr, edm::ServiceToken{}, edm::ESParentContext{});
         waitTask->decrement_ref_count();
         waitTask->wait_for_all();
         if (waitTask->exceptionPtr()) {
@@ -275,7 +278,8 @@ namespace {
       for (size_t i = 0; i != proxies.size(); ++i) {
         auto waitTask = edm::make_empty_waiting_task();
         waitTask->set_ref_count(2);
-        iRec.prefetchAsync(WaitingTaskHolder(waitTask.get()), proxies[i], nullptr, edm::ServiceToken{});
+        iRec.prefetchAsync(
+            WaitingTaskHolder(waitTask.get()), proxies[i], nullptr, edm::ServiceToken{}, edm::ESParentContext{});
         waitTask->decrement_ref_count();
         waitTask->wait_for_all();
         if (waitTask->exceptionPtr()) {
@@ -318,7 +322,8 @@ namespace {
 
     DummyRecord makeRecord() {
       DummyRecord ret;
-      ret.setImpl(&dummyRecordImpl, 0, consumer.esGetTokenIndices(edm::Transition::Event), nullptr, false);
+      ESParentContext pc;
+      ret.setImpl(&dummyRecordImpl, 0, consumer.esGetTokenIndices(edm::Transition::Event), nullptr, &pc, false);
       return ret;
     }
   };
@@ -503,7 +508,8 @@ void testEventsetupRecord::getWithTokenTest() {
 void testEventsetupRecord::getNodataExpTest() {
   EventSetupRecordImpl recImpl(DummyRecord::keyForClass(), &activityRegistry);
   DummyRecord dummyRecord;
-  dummyRecord.setImpl(&recImpl, 0, nullptr, nullptr, false);
+  ESParentContext pc;
+  dummyRecord.setImpl(&recImpl, 0, nullptr, nullptr, &pc, false);
   FailingDummyProxy dummyProxy;
 
   const DataKey dummyDataKey(DataKey::makeTypeTag<FailingDummyProxy::value_type>(), "");
@@ -523,7 +529,8 @@ void testEventsetupRecord::getExepTest() {
   dummyRecordImpl.add(dummyDataKey, &dummyProxy);
 
   DummyRecord dummyRecord;
-  dummyRecord.setImpl(&dummyRecordImpl, 0, nullptr, nullptr, false);
+  ESParentContext pc;
+  dummyRecord.setImpl(&dummyRecordImpl, 0, nullptr, nullptr, &pc, false);
   dummyRecord.get(dummyPtr);
   //CPPUNIT_ASSERT_THROW(dummyRecord.get(dummyPtr), ExceptionType);
 }
@@ -593,7 +600,8 @@ void testEventsetupRecord::introspectionTest() {
   CPPUNIT_ASSERT(keys.empty());
 
   DummyRecord dummyRecord;
-  dummyRecord.setImpl(&dummyRecordImpl, 0, nullptr, nullptr, false);
+  ESParentContext pc;
+  dummyRecord.setImpl(&dummyRecordImpl, 0, nullptr, nullptr, &pc, false);
 
   std::vector<ComponentDescription const*> esproducers;
   dummyRecordImpl.getESProducers(esproducers);
@@ -732,7 +740,8 @@ void testEventsetupRecord::proxyResetTest() {
   EventSetupRecordProvider const* constRecordProvider = dummyProvider.get();
 
   DummyRecord dummyRecord;
-  dummyRecord.setImpl(&constRecordProvider->firstRecordImpl(), 0, nullptr, nullptr, false);
+  ESParentContext pc;
+  dummyRecord.setImpl(&constRecordProvider->firstRecordImpl(), 0, nullptr, nullptr, &pc, false);
 
   Dummy myDummy;
   std::shared_ptr<WorkingDummyProxy> workingProxy = std::make_shared<WorkingDummyProxy>(&myDummy);
@@ -780,7 +789,8 @@ void testEventsetupRecord::transientTest() {
   auto dummyProvider = std::make_unique<EventSetupRecordProvider>(DummyRecord::keyForClass(), &activityRegistry);
 
   DummyRecord dummyRecordNoConst;
-  dummyRecordNoConst.setImpl(&dummyProvider->firstRecordImpl(), 0, nullptr, nullptr, false);
+  ESParentContext pc;
+  dummyRecordNoConst.setImpl(&dummyProvider->firstRecordImpl(), 0, nullptr, nullptr, &pc, false);
   EventSetupRecord const& dummyRecord = dummyRecordNoConst;
 
   eventsetup::EventSetupRecordImpl& nonConstDummyRecordImpl = *const_cast<EventSetupRecordImpl*>(dummyRecord.impl_);

--- a/FWCore/Framework/test/fullchain_t.cppunit.cc
+++ b/FWCore/Framework/test/fullchain_t.cppunit.cc
@@ -78,10 +78,11 @@ void testfullChain::getfromDataproxyproviderTest() {
   auto proxyProvider = std::make_shared<DummyProxyProvider>();
   provider.add(proxyProvider);
 
+  edm::ESParentContext pc;
   for (unsigned int iTime = 1; iTime != 6; ++iTime) {
     const Timestamp time(iTime);
     controller.eventSetupForInstance(IOVSyncValue(time));
-    EventSetup eventSetup(provider.eventSetupImpl(), 0, nullptr, false);
+    EventSetup eventSetup(provider.eventSetupImpl(), 0, nullptr, pc, false);
     ESHandle<DummyData> pDummy;
     eventSetup.get<DummyRecord>().get(pDummy);
     CPPUNIT_ASSERT(0 != pDummy.product());

--- a/FWCore/Integration/test/unit_test_outputs/testSubProcess.grep.txt
+++ b/FWCore/Integration/test/unit_test_outputs/testSubProcess.grep.txt
@@ -1,6 +1,14 @@
 Sharing ESSource: class=DoodadESSource label=''
 Sharing ESSource: class=DoodadESSource label=''
 Sharing ESSource: class=DoodadESSource label=''
+++++++++ starting: prefetching for esmodule: label = '' type = DoodadESSource in record = GadgetRcd
+++++++++ finished: prefetching for esmodule: label = '' type = DoodadESSource in record = GadgetRcd
+++++++++ starting: processing esmodule: label = '' type = DoodadESSource in record = GadgetRcd
+++++++++ finished: processing esmodule: label = '' type = DoodadESSource in record = GadgetRcd
 got data of type "edmtest::Doodad" with name "abcd" in record GadgetRcd
+++++++++ starting: prefetching for esmodule: label = '' type = DoodadESSource in record = GadgetRcd
+++++++++ finished: prefetching for esmodule: label = '' type = DoodadESSource in record = GadgetRcd
+++++++++ starting: processing esmodule: label = '' type = DoodadESSource in record = GadgetRcd
+++++++++ finished: processing esmodule: label = '' type = DoodadESSource in record = GadgetRcd
 got data of type "edmtest::Doodad" with name "abc" in record GadgetRcd
 got data of type "edmtest::Doodad" with name "abc" in record GadgetRcd

--- a/FWCore/Integration/test/unit_test_outputs/testSubProcess.grep2.txt
+++ b/FWCore/Integration/test/unit_test_outputs/testSubProcess.grep2.txt
@@ -257,6 +257,10 @@
 ++++ starting: global begin run 1 : time = 1
 ++++++ starting: global begin run for module: label = 'thingWithMergeProducer' id = 5
 ++++++ finished: global begin run for module: label = 'thingWithMergeProducer' id = 5
+++++++++ starting: prefetching for esmodule: label = '' type = DoodadESSource in record = GadgetRcd
+++++++++ finished: prefetching for esmodule: label = '' type = DoodadESSource in record = GadgetRcd
+++++++++ starting: processing esmodule: label = '' type = DoodadESSource in record = GadgetRcd
+++++++++ finished: processing esmodule: label = '' type = DoodadESSource in record = GadgetRcd
 ++++++ starting: global begin run for module: label = 'get' id = 6
 ++++++ finished: global begin run for module: label = 'get' id = 6
 ++++++ starting: global begin run for module: label = 'getInt' id = 10
@@ -274,6 +278,10 @@
 ++++++ finished: global begin run for module: label = 'test' id = 32
 ++++++ starting: global begin run for module: label = 'testmerge' id = 33
 ++++++ finished: global begin run for module: label = 'testmerge' id = 33
+++++++++ starting: prefetching for esmodule: label = '' type = DoodadESSource in record = GadgetRcd
+++++++++ finished: prefetching for esmodule: label = '' type = DoodadESSource in record = GadgetRcd
+++++++++ starting: processing esmodule: label = '' type = DoodadESSource in record = GadgetRcd
+++++++++ finished: processing esmodule: label = '' type = DoodadESSource in record = GadgetRcd
 ++++++ starting: global begin run for module: label = 'get' id = 34
 ++++++ finished: global begin run for module: label = 'get' id = 34
 ++++++ starting: global begin run for module: label = 'getInt' id = 35

--- a/FWCore/ServiceRegistry/interface/ActivityRegistry.h
+++ b/FWCore/ServiceRegistry/interface/ActivityRegistry.h
@@ -100,6 +100,7 @@ namespace edm {
   class ProcessContext;
   class ModuleCallingContext;
   class PathsAndConsumesOfModulesBase;
+  class ESModuleCallingContext;
   namespace eventsetup {
     struct ComponentDescription;
     class DataKey;
@@ -501,6 +502,36 @@ namespace edm {
       preSourceEarlyTerminationSignal_.connect(iSlot);
     }
     AR_WATCH_USING_METHOD_1(watchPreSourceEarlyTermination)
+
+    /// signal is emitted before the esmodule starts processing and before prefetching has started
+    typedef signalslot::Signal<void(eventsetup::EventSetupRecordKey const&, ESModuleCallingContext const&)>
+        PreESModulePrefetching;
+    PreESModulePrefetching preESModulePrefetchingSignal_;
+    void watchPreESModulePrefetching(PreESModulePrefetching::slot_type const& iSlot) {
+      preESModulePrefetchingSignal_.connect(iSlot);
+    }
+    AR_WATCH_USING_METHOD_2(watchPreESModulePrefetching)
+
+    /// signal is emitted before the esmodule starts processing  and after prefetching has finished
+    typedef signalslot::Signal<void(eventsetup::EventSetupRecordKey const&, ESModuleCallingContext const&)>
+        PostESModulePrefetching;
+    PostESModulePrefetching postESModulePrefetchingSignal_;
+    void watchPostESModulePrefetching(PostESModulePrefetching::slot_type const& iSlot) {
+      postESModulePrefetchingSignal_.connect_front(iSlot);
+    }
+    AR_WATCH_USING_METHOD_2(watchPostESModulePrefetching)
+
+    /// signal is emitted before the esmodule starts processing
+    typedef signalslot::Signal<void(eventsetup::EventSetupRecordKey const&, ESModuleCallingContext const&)> PreESModule;
+    PreESModule preESModuleSignal_;
+    void watchPreESModule(PreESModule::slot_type const& iSlot) { preESModuleSignal_.connect(iSlot); }
+    AR_WATCH_USING_METHOD_2(watchPreESModule)
+
+    /// signal is emitted after the esmodule finished processing
+    typedef signalslot::Signal<void(eventsetup::EventSetupRecordKey const&, ESModuleCallingContext const&)> PostESModule;
+    PostESModule postESModuleSignal_;
+    void watchPostESModule(PostESModule::slot_type const& iSlot) { postESModuleSignal_.connect_front(iSlot); }
+    AR_WATCH_USING_METHOD_2(watchPostESModule)
 
     // OLD DELETE THIS
     typedef signalslot::ObsoleteSignal<void(EventID const&, Timestamp const&)> PreProcessEvent;

--- a/FWCore/ServiceRegistry/interface/ESModuleCallingContext.h
+++ b/FWCore/ServiceRegistry/interface/ESModuleCallingContext.h
@@ -1,0 +1,68 @@
+#ifndef FWCore_ServiceRegistry_ESModuleCallingContext_h
+#define FWCore_ServiceRegistry_ESModuleCallingContext_h
+
+/**\class edm::ESModuleCallingContext
+
+ Description: This is intended primarily to be passed to
+Services as an argument to their callback functions.
+
+ Usage:
+
+
+*/
+//
+// Original Author: W. David Dagenhart
+//         Created: 7/11/2013
+
+#include "FWCore/ServiceRegistry/interface/ESParentContext.h"
+
+#include <iosfwd>
+
+namespace edm {
+
+  namespace eventsetup {
+    class ComponentDescription;
+  }
+  class ModuleCallingContext;
+  class ESModuleCallingContext {
+  public:
+    using Type = ESParentContext::Type;
+
+    enum class State {
+      kPrefetching,  // prefetching products before starting to run
+      kRunning,      // module actually running
+      kInvalid
+    };
+
+    ESModuleCallingContext(edm::eventsetup::ComponentDescription const* moduleDescription);
+
+    ESModuleCallingContext(edm::eventsetup::ComponentDescription const* moduleDescription,
+                           State state,
+                           ESParentContext const& parent);
+
+    void setContext(State state, ESParentContext const& parent);
+
+    void setState(State state) { state_ = state; }
+
+    edm::eventsetup::ComponentDescription const* componentDescription() const { return componentDescription_; }
+    State state() const { return state_; }
+    Type type() const { return parent_.type(); }
+    ESParentContext const& parent() const { return parent_; }
+    ModuleCallingContext const* moduleCallingContext() const { return parent_.moduleCallingContext(); }
+    ESModuleCallingContext const* esmoduleCallingContext() const { return parent_.esmoduleCallingContext(); }
+
+    // This function will iterate up a series of linked context objects to
+    // find the highest level ModuleCallingContext.
+    ModuleCallingContext const* getTopModuleCallingContext() const;
+
+    // Returns the number of ESModuleCallingContexts above this ESModuleCallingContext
+    // in the series of linked context objects.
+    unsigned depth() const;
+
+  private:
+    edm::eventsetup::ComponentDescription const* componentDescription_;
+    ESParentContext parent_;
+    State state_;
+  };
+}  // namespace edm
+#endif

--- a/FWCore/ServiceRegistry/interface/ESModuleCallingContext.h
+++ b/FWCore/ServiceRegistry/interface/ESModuleCallingContext.h
@@ -21,7 +21,7 @@ Services as an argument to their callback functions.
 namespace edm {
 
   namespace eventsetup {
-    class ComponentDescription;
+    struct ComponentDescription;
   }
   class ModuleCallingContext;
   class ESModuleCallingContext {

--- a/FWCore/ServiceRegistry/interface/ESParentContext.h
+++ b/FWCore/ServiceRegistry/interface/ESParentContext.h
@@ -1,0 +1,43 @@
+#ifndef FWCore_ServiceRegistry_ESParentContext_h
+#define FWCore_ServiceRegistry_ESParentContext_h
+
+/**\class edm::ESParentContext
+
+ Description: This is intended to be used as a member of ESModuleCallingContext.
+
+ Usage:
+
+
+*/
+//
+// Original Author: C. Jones
+//         Created: 2/07/2021
+
+namespace edm {
+
+  class ModuleCallingContext;
+  class ESModuleCallingContext;
+
+  class ESParentContext {
+  public:
+    enum class Type { kModule, kESModule, kInvalid };
+
+    ESParentContext();
+    explicit ESParentContext(ModuleCallingContext const*) noexcept;
+    explicit ESParentContext(ESModuleCallingContext const*) noexcept;
+
+    Type type() const noexcept { return type_; }
+
+    ModuleCallingContext const* moduleCallingContext() const;
+    ESModuleCallingContext const* esmoduleCallingContext() const;
+
+  private:
+    Type type_;
+
+    union Parent {
+      ModuleCallingContext const* module;
+      ESModuleCallingContext const* esmodule;
+    } parent_;
+  };
+}  // namespace edm
+#endif

--- a/FWCore/ServiceRegistry/src/ActivityRegistry.cc
+++ b/FWCore/ServiceRegistry/src/ActivityRegistry.cc
@@ -494,12 +494,6 @@ namespace edm {
 
     copySlotsToFrom(preESModuleSignal_, iOther.preESModuleSignal_);
     copySlotsToFromReverse(postESModuleSignal_, iOther.postESModuleSignal_);
-
-    copySlotsToFrom(preModuleEventAcquireSignal_, iOther.preModuleEventAcquireSignal_);
-    copySlotsToFromReverse(postModuleEventAcquireSignal_, iOther.postModuleEventAcquireSignal_);
-
-    copySlotsToFrom(preModuleEventDelayedGetSignal_, iOther.preModuleEventDelayedGetSignal_);
-    copySlotsToFromReverse(postModuleEventDelayedGetSignal_, iOther.postModuleEventDelayedGetSignal_);
     /*
     copySlotsToFrom(preModuleSignal_, iOther.preModuleSignal_);
     copySlotsToFromReverse(postModuleSignal_, iOther.postModuleSignal_);

--- a/FWCore/ServiceRegistry/src/ActivityRegistry.cc
+++ b/FWCore/ServiceRegistry/src/ActivityRegistry.cc
@@ -275,6 +275,12 @@ namespace edm {
     preModuleWriteLumiSignal_.connect(std::cref(iOther.preModuleWriteLumiSignal_));
     postModuleWriteLumiSignal_.connect(std::cref(iOther.postModuleWriteLumiSignal_));
 
+    preESModulePrefetchingSignal_.connect(std::cref(iOther.preESModulePrefetchingSignal_));
+    postESModulePrefetchingSignal_.connect(std::cref(iOther.postESModulePrefetchingSignal_));
+
+    preESModuleSignal_.connect(std::cref(iOther.preESModuleSignal_));
+    postESModuleSignal_.connect(std::cref(iOther.postESModuleSignal_));
+
     //preModuleSignal_.connect(std::cref(iOther.preModuleSignal_));
     //postModuleSignal_.connect(std::cref(iOther.postModuleSignal_));
 
@@ -483,6 +489,17 @@ namespace edm {
     copySlotsToFrom(preModuleWriteLumiSignal_, iOther.preModuleWriteLumiSignal_);
     copySlotsToFromReverse(postModuleWriteLumiSignal_, iOther.postModuleWriteLumiSignal_);
 
+    copySlotsToFrom(preESModulePrefetchingSignal_, iOther.preESModulePrefetchingSignal_);
+    copySlotsToFromReverse(postESModulePrefetchingSignal_, iOther.postESModulePrefetchingSignal_);
+
+    copySlotsToFrom(preESModuleSignal_, iOther.preESModuleSignal_);
+    copySlotsToFromReverse(postESModuleSignal_, iOther.postESModuleSignal_);
+
+    copySlotsToFrom(preModuleEventAcquireSignal_, iOther.preModuleEventAcquireSignal_);
+    copySlotsToFromReverse(postModuleEventAcquireSignal_, iOther.postModuleEventAcquireSignal_);
+
+    copySlotsToFrom(preModuleEventDelayedGetSignal_, iOther.preModuleEventDelayedGetSignal_);
+    copySlotsToFromReverse(postModuleEventDelayedGetSignal_, iOther.postModuleEventDelayedGetSignal_);
     /*
     copySlotsToFrom(preModuleSignal_, iOther.preModuleSignal_);
     copySlotsToFromReverse(postModuleSignal_, iOther.postModuleSignal_);

--- a/FWCore/ServiceRegistry/src/ESModuleCallingContext.cc
+++ b/FWCore/ServiceRegistry/src/ESModuleCallingContext.cc
@@ -1,0 +1,44 @@
+#include "FWCore/ServiceRegistry/interface/ESModuleCallingContext.h"
+#include "FWCore/ServiceRegistry/interface/ParentContext.h"
+#include "FWCore/ServiceRegistry/interface/ModuleCallingContext.h"
+#include "FWCore/Utilities/interface/EDMException.h"
+
+#include <ostream>
+
+namespace edm {
+
+  ESModuleCallingContext::ESModuleCallingContext(edm::eventsetup::ComponentDescription const* componentDescription)
+      : componentDescription_(componentDescription), parent_(), state_(State::kInvalid) {}
+
+  ESModuleCallingContext::ESModuleCallingContext(edm::eventsetup::ComponentDescription const* componentDescription,
+                                             State state,
+                                             ESParentContext const& parent)
+      : componentDescription_(componentDescription),
+        parent_(parent),
+        state_(state) {}
+
+  void ESModuleCallingContext::setContext(State state,
+                                          ESParentContext const& parent) {
+    state_ = state;
+    parent_ = parent;
+  }
+
+  ModuleCallingContext const* ESModuleCallingContext::getTopModuleCallingContext() const {
+    ESModuleCallingContext const* mcc = this;
+    while (mcc->type() == ESParentContext::Type::kESModule) {
+      mcc = mcc->esmoduleCallingContext();
+    }
+    return mcc->moduleCallingContext()->getTopModuleCallingContext();
+  }
+
+  unsigned ESModuleCallingContext::depth() const {
+    unsigned depth = 0;
+    ESModuleCallingContext const* mcc = this;
+    while (mcc->type() == ESParentContext::Type::kESModule) {
+      ++depth;
+      mcc = mcc->esmoduleCallingContext();
+    }
+    return depth + mcc->moduleCallingContext()->depth();
+  }
+
+}  // namespace edm

--- a/FWCore/ServiceRegistry/src/ESModuleCallingContext.cc
+++ b/FWCore/ServiceRegistry/src/ESModuleCallingContext.cc
@@ -11,14 +11,11 @@ namespace edm {
       : componentDescription_(componentDescription), parent_(), state_(State::kInvalid) {}
 
   ESModuleCallingContext::ESModuleCallingContext(edm::eventsetup::ComponentDescription const* componentDescription,
-                                             State state,
-                                             ESParentContext const& parent)
-      : componentDescription_(componentDescription),
-        parent_(parent),
-        state_(state) {}
+                                                 State state,
+                                                 ESParentContext const& parent)
+      : componentDescription_(componentDescription), parent_(parent), state_(state) {}
 
-  void ESModuleCallingContext::setContext(State state,
-                                          ESParentContext const& parent) {
+  void ESModuleCallingContext::setContext(State state, ESParentContext const& parent) {
     state_ = state;
     parent_ = parent;
   }

--- a/FWCore/ServiceRegistry/src/ESParentContext.cc
+++ b/FWCore/ServiceRegistry/src/ESParentContext.cc
@@ -1,0 +1,30 @@
+#include "FWCore/ServiceRegistry/interface/ESParentContext.h"
+#include "FWCore/ServiceRegistry/interface/ModuleCallingContext.h"
+#include "FWCore/ServiceRegistry/interface/ESModuleCallingContext.h"
+
+#include "FWCore/Utilities/interface/EDMException.h"
+
+#include <ostream>
+
+namespace edm {
+
+  ESParentContext::ESParentContext() : type_(Type::kInvalid) { parent_.esmodule = nullptr; }
+
+  ESParentContext::ESParentContext(ModuleCallingContext const* module) noexcept : type_(Type::kModule) { parent_.module = module; }
+
+  ESParentContext::ESParentContext(ESModuleCallingContext const* module) noexcept : type_(Type::kESModule) { parent_.esmodule = module; }
+
+  ModuleCallingContext const* ESParentContext::moduleCallingContext() const {
+    if (type_ != Type::kModule) {
+      throw Exception(errors::LogicError) << "ESParentContext::moduleCallingContext called for incorrect type of context";
+    }
+    return parent_.module;
+  }
+
+  ESModuleCallingContext const* ESParentContext::esmoduleCallingContext() const {
+    if (type_ != Type::kESModule) {
+      throw Exception(errors::LogicError) << "ESParentContext::esmoduleCallingContext called for incorrect type of context";
+    }
+    return parent_.esmodule;
+  }
+}  // namespace edm

--- a/FWCore/ServiceRegistry/src/ESParentContext.cc
+++ b/FWCore/ServiceRegistry/src/ESParentContext.cc
@@ -10,20 +10,26 @@ namespace edm {
 
   ESParentContext::ESParentContext() : type_(Type::kInvalid) { parent_.esmodule = nullptr; }
 
-  ESParentContext::ESParentContext(ModuleCallingContext const* module) noexcept : type_(Type::kModule) { parent_.module = module; }
+  ESParentContext::ESParentContext(ModuleCallingContext const* module) noexcept : type_(Type::kModule) {
+    parent_.module = module;
+  }
 
-  ESParentContext::ESParentContext(ESModuleCallingContext const* module) noexcept : type_(Type::kESModule) { parent_.esmodule = module; }
+  ESParentContext::ESParentContext(ESModuleCallingContext const* module) noexcept : type_(Type::kESModule) {
+    parent_.esmodule = module;
+  }
 
   ModuleCallingContext const* ESParentContext::moduleCallingContext() const {
     if (type_ != Type::kModule) {
-      throw Exception(errors::LogicError) << "ESParentContext::moduleCallingContext called for incorrect type of context";
+      throw Exception(errors::LogicError)
+          << "ESParentContext::moduleCallingContext called for incorrect type of context";
     }
     return parent_.module;
   }
 
   ESModuleCallingContext const* ESParentContext::esmoduleCallingContext() const {
     if (type_ != Type::kESModule) {
-      throw Exception(errors::LogicError) << "ESParentContext::esmoduleCallingContext called for incorrect type of context";
+      throw Exception(errors::LogicError)
+          << "ESParentContext::esmoduleCallingContext called for incorrect type of context";
     }
     return parent_.esmodule;
   }

--- a/FWCore/Services/plugins/Tracer.cc
+++ b/FWCore/Services/plugins/Tracer.cc
@@ -38,6 +38,7 @@
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "FWCore/ServiceRegistry/interface/GlobalContext.h"
 #include "FWCore/ServiceRegistry/interface/ModuleCallingContext.h"
+#include "FWCore/ServiceRegistry/interface/ESModuleCallingContext.h"
 #include "FWCore/ServiceRegistry/interface/PathContext.h"
 #include "FWCore/ServiceRegistry/interface/ProcessContext.h"
 #include "FWCore/ServiceRegistry/interface/StreamContext.h"
@@ -205,6 +206,11 @@ namespace edm {
 
       void preSourceConstruction(ModuleDescription const& md);
       void postSourceConstruction(ModuleDescription const& md);
+
+      void preESModulePrefetching(eventsetup::EventSetupRecordKey const&, ESModuleCallingContext const&);
+      void postESModulePrefetching(eventsetup::EventSetupRecordKey const&, ESModuleCallingContext const&);
+      void preESModule(eventsetup::EventSetupRecordKey const&, ESModuleCallingContext const&);
+      void postESModule(eventsetup::EventSetupRecordKey const&, ESModuleCallingContext const&);
 
     private:
       std::string indention_;
@@ -383,6 +389,11 @@ Tracer::Tracer(ParameterSet const& iPS, ActivityRegistry& iRegistry)
 
   iRegistry.watchPreSourceConstruction(this, &Tracer::preSourceConstruction);
   iRegistry.watchPostSourceConstruction(this, &Tracer::postSourceConstruction);
+
+  iRegistry.watchPreESModulePrefetching(this, &Tracer::preESModulePrefetching);
+  iRegistry.watchPostESModulePrefetching(this, &Tracer::postESModulePrefetching);
+  iRegistry.watchPreESModule(this, &Tracer::preESModule);
+  iRegistry.watchPostESModule(this, &Tracer::postESModule);
 
   iRegistry.preSourceEarlyTerminationSignal_.connect([this](edm::TerminationOrigin iOrigin) {
     LogAbsolute out("Tracer");
@@ -1610,6 +1621,50 @@ void Tracer::postSourceConstruction(ModuleDescription const& desc) {
   if (dumpNonModuleContext_) {
     out << "\n" << desc;
   }
+}
+
+void Tracer::preESModulePrefetching(eventsetup::EventSetupRecordKey const& iKey, ESModuleCallingContext const& mcc) {
+  LogAbsolute out("Tracer");
+  out << TimeStamper(printTimestamps_);
+  unsigned int nIndents = mcc.depth() + 4;
+  for (unsigned int i = 0; i < nIndents; ++i) {
+    out << indention_;
+  }
+  out << " starting: prefetching for esmodule: label = '" << mcc.componentDescription()->label_
+      << "' type = " << mcc.componentDescription()->type_ << " in record = " << iKey.name();
+}
+
+void Tracer::postESModulePrefetching(eventsetup::EventSetupRecordKey const& iKey, ESModuleCallingContext const& mcc) {
+  LogAbsolute out("Tracer");
+  out << TimeStamper(printTimestamps_);
+  unsigned int nIndents = mcc.depth() + 4;
+  for (unsigned int i = 0; i < nIndents; ++i) {
+    out << indention_;
+  }
+  out << " finished: prefetching for esmodule: label = '" << mcc.componentDescription()->label_
+      << "' type = " << mcc.componentDescription()->type_ << " in record = " << iKey.name();
+}
+
+void Tracer::preESModule(eventsetup::EventSetupRecordKey const& iKey, ESModuleCallingContext const& mcc) {
+  LogAbsolute out("Tracer");
+  out << TimeStamper(printTimestamps_);
+  unsigned int nIndents = mcc.depth() + 4;
+  for (unsigned int i = 0; i < nIndents; ++i) {
+    out << indention_;
+  }
+  out << " starting: processing esmodule: label = '" << mcc.componentDescription()->label_
+      << "' type = " << mcc.componentDescription()->type_ << " in record = " << iKey.name();
+}
+
+void Tracer::postESModule(eventsetup::EventSetupRecordKey const& iKey, ESModuleCallingContext const& mcc) {
+  LogAbsolute out("Tracer");
+  out << TimeStamper(printTimestamps_);
+  unsigned int nIndents = mcc.depth() + 4;
+  for (unsigned int i = 0; i < nIndents; ++i) {
+    out << indention_;
+  }
+  out << " finished: processing esmodule: label = '" << mcc.componentDescription()->label_
+      << "' type = " << mcc.componentDescription()->type_ << " in record = " << iKey.name();
 }
 
 using edm::service::Tracer;

--- a/FWCore/TestProcessor/interface/TestDataProxy.h
+++ b/FWCore/TestProcessor/interface/TestDataProxy.h
@@ -41,7 +41,8 @@ namespace edm {
                              eventsetup::EventSetupRecordImpl const&,
                              eventsetup::DataKey const&,
                              EventSetupImpl const*,
-                             ServiceToken const&) final {
+                             ServiceToken const&,
+                             ESParentContext const&) final {
         return;
       }
 

--- a/PhysicsTools/CondLiteIO/plugins/FWLiteESRecordWriterAnalyzer.cc
+++ b/PhysicsTools/CondLiteIO/plugins/FWLiteESRecordWriterAnalyzer.cc
@@ -75,10 +75,11 @@ namespace edm {
         const ComponentDescription*& iDesc,
         bool iTransientAccessOnly,
         std::shared_ptr<ESHandleExceptionFactory>& whyFailedFactory,
+        ESParentContext const& iParent,
         edm::EventSetupImpl const*) const {
       DataKey dataKey(*(iData->m_tag), iName, DataKey::kDoNotCopyMemory);
 
-      const void* pValue = this->getFromProxy(dataKey, iDesc, iTransientAccessOnly);
+      const void* pValue = this->getFromProxy(dataKey, iDesc, iTransientAccessOnly, iParent);
       if (nullptr == pValue) {
         throw cms::Exception("NoProxyException") << "No data of type \"" << iData->m_tag->name() << "\" with label \""
                                                  << iName << "\" in record \"" << this->key().name() << "\"";
@@ -94,7 +95,7 @@ namespace edm {
       const fwliteeswriter::DummyType* value = &t;
       const ComponentDescription* desc = nullptr;
       std::shared_ptr<ESHandleExceptionFactory> dummy;
-      impl_->getImplementation(value, iName.c_str(), desc, true, dummy, nullptr);
+      impl_->getImplementation(value, iName.c_str(), desc, true, dummy, *context_, nullptr);
       iHolder.m_data = t.m_data;
       iHolder.m_desc = desc;
       return true;


### PR DESCRIPTION
#### PR description:

The ActivityRegistry can now track prefetching and calls the ES Modules.
The Tracer Service has been modified to report the new callbacks.

#### PR validation:

Code compiles and a tests of the TracerService work.