### PR TITLE
Move cms.Sequence to cms.Task for RecoMET

### DIFF
--- a/RecoMET/METPUSubtraction/python/mitigatedMETSequence_cff.py
+++ b/RecoMET/METPUSubtraction/python/mitigatedMETSequence_cff.py
@@ -72,25 +72,25 @@ pfMVAMEt = cms.EDProducer("PFMETProducerMVA",
     verbosity = cms.int32(0)
 )
 
-pfMVAMEtSequence  = cms.Sequence(
-    kt6PFJets*
-    calibratedAK4PFJetsForPFMVAMEt*
+pfMVAMEtTask  = cms.Task(
+    kt6PFJets,
+    calibratedAK4PFJetsForPFMVAMEt,
     pfMVAMEt
 )
-
+pfMVAMEtSequence  = cms.Sequence(pfMVAMEtTask)
 
 ##================================================
 ## Pf No Pileup MET sequence
 ##================================================
-pfNoPUMEtSequence = cms.Sequence()
+pfNoPUMEtTask = cms.Task()
 
 from JetMETCorrections.Configuration.JetCorrectionServices_cff import *
 calibratedAK4PFJetsForPFNoPUMEt = cms.EDProducer('PFJetCorrectionProducer',
     src = cms.InputTag('ak4PFJets'),
     correctors = cms.vstring('ak4PFL1FastL2L3Residual') # NOTE: use "ak4PFL1FastL2L3" for MC / "ak4PFL1FastL2L3Residual" for Data
 )
-ak4PFJetSequenceForPFNoPUMEt = cms.Sequence(calibratedAK4PFJetsForPFNoPUMEt)
-pfNoPUMEtSequence += ak4PFJetSequenceForPFNoPUMEt
+ak4PFJetTaskForPFNoPUMEt = cms.Task(calibratedAK4PFJetsForPFNoPUMEt)
+pfNoPUMEtTask.add(ak4PFJetTaskForPFNoPUMEt)
 
 from RecoJets.JetProducers.PileupJetID_cfi import *
 puJetIdForPFNoPUMEt = pileupJetId.clone(
@@ -99,28 +99,28 @@ puJetIdForPFNoPUMEt = pileupJetId.clone(
         cutbased,
         PhilV1
         ),
-#    label = cms.string("fullId"), #MM does not work for weird reasons, cannot be cloned properly
+#    label = "fullId", #MM does not work for weird reasons, cannot be cloned properly
     produceJetIds    = True,
     runMvas          = True,
     jets             = "calibratedAK4PFJetsForPFNoPUMEt",
     applyJec         = False,
     inputIsCorrected = True,
     )
-pfNoPUMEtSequence += puJetIdForPFNoPUMEt
+pfNoPUMEtTask.add(puJetIdForPFNoPUMEt)
 
 from JetMETCorrections.Type1MET.pfMETCorrectionType0_cfi import *
-pfNoPUMEtSequence += type0PFMEtCorrection
+pfNoPUMEtTask.add(type0PFMEtCorrection)
 pfCandidateToVertexAssociationForPFNoPUMEt = pfCandidateToVertexAssociation.clone(
     MaxNumberOfAssociations = 1,	
     doReassociation         = False,
     FinalAssociation        = 1,			    
     nTrackWeight            = 0.
 )
-pfNoPUMEtSequence += pfCandidateToVertexAssociationForPFNoPUMEt
+pfNoPUMEtTask.add(pfCandidateToVertexAssociationForPFNoPUMEt)
 pfMETcorrType0ForPFNoPUMEt = pfMETcorrType0.clone(
     srcPFCandidateToVertexAssociations = 'pfCandidateToVertexAssociationForPFNoPUMEt'
 )
-pfNoPUMEtSequence += pfMETcorrType0ForPFNoPUMEt
+pfNoPUMEtTask.add(pfMETcorrType0ForPFNoPUMEt)
 
 jvfJetIdForPFNoPUMEt = cms.EDProducer("JVFJetIdProducer",
     srcJets = cms.InputTag('calibratedAK4PFJetsForPFNoPUMEt'),
@@ -132,7 +132,7 @@ jvfJetIdForPFNoPUMEt = cms.EDProducer("JVFJetIdProducer",
     JVFcut = cms.double(0.75),
     neutralJetOption = cms.string("noPU")
 )
-pfNoPUMEtSequence += jvfJetIdForPFNoPUMEt
+pfNoPUMEtTask.add(jvfJetIdForPFNoPUMEt)
 
 import RecoMET.METProducers.METSigParams_cfi as met_config
 pfNoPUMEtData = cms.EDProducer("NoPileUpPFMEtDataProducer",
@@ -151,7 +151,7 @@ pfNoPUMEtData = cms.EDProducer("NoPileUpPFMEtDataProducer",
     resolution = met_config.METSignificance_params,
     verbosity = cms.int32(0)     
 )
-pfNoPUMEtSequence += pfNoPUMEtData
+pfNoPUMEtTask.add(pfNoPUMEtData)
 
 pfNoPUMEt = cms.EDProducer("NoPileUpPFMEtProducer",
     srcMEt = cms.InputTag('pfMet'),
@@ -180,11 +180,12 @@ pfNoPUMEt = cms.EDProducer("NoPileUpPFMEtProducer",
     saveInputs = cms.bool(True),
     verbosity = cms.int32(0)                               
 )
-pfNoPUMEtSequence += pfNoPUMEt
+pfNoPUMEtTask.add(pfNoPUMEt)
+pfNoPUMEtSequence = cms.Sequence(pfNoPUMEtTask)
 
-
-mitigatedMETSequence = cms.Sequence(
-selectionSequenceForMVANoPUMET+
-pfMVAMEtSequence+
-pfNoPUMEtSequence
+mitigatedMETTask = cms.Task(
+selectionSequenceForMVANoPUMETTask,
+pfMVAMEtTask,
+pfNoPUMEtTask
 )
+mitigatedMETSequence = cms.Sequence(mitigatedMETTask)

--- a/RecoMET/METPUSubtraction/python/mvaPFMET_Data_cff.py
+++ b/RecoMET/METPUSubtraction/python/mvaPFMET_Data_cff.py
@@ -61,8 +61,9 @@ pfMEtMVA = cms.EDProducer("PFMETProducerMVA",
     verbosity = cms.int32(0)
 )
 
-pfMEtMVAsequence  = cms.Sequence(
-    #(isomuonseq+isotauseq+isoelectronseq)*
-    calibratedAK4PFJetsForPFMEtMVA*
+pfMEtMVATask  = cms.Task(
+    #isomuonTask, isotauTask, isoelectronTask,
+    calibratedAK4PFJetsForPFMEtMVA,
     pfMEtMVA
 )
+pfMEtMVAsequence  = cms.Sequence(pfMEtMVATask)

--- a/RecoMET/METPUSubtraction/python/mvaPFMET_cff.py
+++ b/RecoMET/METPUSubtraction/python/mvaPFMET_cff.py
@@ -91,7 +91,7 @@ pfMVAMEt = cms.EDProducer("PFMETProducerMVA",
 )
 
 pfMVAMEtTask  = cms.Task(
-    #(isomuonseq+isotauseq+isoelectronseq)*
+    #isomuonTask,isotauTask,isoelectronTask,
     jetCorrectorsTask,
     calibratedAK4PFJetsForPFMVAMEt,
     puJetIdForPFMVAMEt,

--- a/RecoMET/METPUSubtraction/python/mvaPFMET_leptons_cff.py
+++ b/RecoMET/METPUSubtraction/python/mvaPFMET_leptons_cff.py
@@ -63,9 +63,12 @@ pfMEtMVA = cms.EDProducer("PFMETProducerMVA",
     verbosity = cms.int32(0)
 )
 
-pfMEtMVAsequence  = cms.Sequence(
-    (isomuonseq+isotauseq+isoelectronseq)*
-    calibratedAK4PFJetsForPFMEtMVA*
+pfMEtMVATask  = cms.Task(
+    isomuonTask,
+    isotauTask,
+    isoelectronTask,
+    calibratedAK4PFJetsForPFMEtMVA,
     pfMEtMVA
     )
+pfMEtMVAsequence  = cms.Sequence(pfMEtMVATask)
 

--- a/RecoMET/METPUSubtraction/python/mvaPFMET_leptons_cfi.py
+++ b/RecoMET/METPUSubtraction/python/mvaPFMET_leptons_cfi.py
@@ -99,21 +99,24 @@ isotaus = cms.EDFilter(
     filter = cms.bool(False)
     )
 
-isomuonseq     = cms.Sequence(isomuons)
-isoelectronseq = cms.Sequence(isoelectrons)
-isotauseq      = cms.Sequence(
-    hpsPFTauDiscriminationByLooseCombinedIsolationDBSumPtCorr3Hits*
-     #kt6PFJetsForRhoComputationVoronoiMet*
-     #hpsPFTauDiscriminationByMVAIsolation*
-     hpsPFTauDiscriminationAgainstMuon2*
+isomuonTask     = cms.Task(isomuons)
+isomuonseq      = cms.Sequence(isomuonsTask)
+isoelectronTask = cms.Task(isoelectrons)
+isoelectronseq  = cms.Sequence(isoelectronsTask)
+isotauTask      = cms.Task(
+     hpsPFTauDiscriminationByLooseCombinedIsolationDBSumPtCorr3Hits,
+     #kt6PFJetsForRhoComputationVoronoiMet,
+     #hpsPFTauDiscriminationByMVAIsolation,
+     hpsPFTauDiscriminationAgainstMuon2,
      isotaus
     )
+isotauseq      = cms.Sequence(isotauTask)
 
 leptonSelection = cms.PSet(
     SelectEvents = cms.PSet(
-    SelectEvents = cms.vstring(
-    'isomuonseq',
-    'isoelectronseq',
-    'isotauseq')
+       SelectEvents = cms.vstring(
+       'isomuonseq',
+       'isoelectronseq',
+       'isotauseq')
     )
-    )
+)

--- a/RecoMET/METPUSubtraction/python/mvaPFMET_leptons_data_cff.py
+++ b/RecoMET/METPUSubtraction/python/mvaPFMET_leptons_data_cff.py
@@ -60,9 +60,11 @@ pfMEtMVA = cms.EDProducer("PFMETProducerMVA",
     verbosity = cms.int32(0)
 )
 
-pfMEtMVAsequence  = cms.Sequence(
-    (isomuonseq+isotauseq+isoelectronseq)*
-    calibratedAK4PFJetsForPFMEtMVA*
+pfMEtMVATask  = cms.Task(
+    isomuonTask,
+    isotauTask,
+    isoelectronTask,
+    calibratedAK4PFJetsForPFMEtMVA,
     pfMEtMVA
     )
-
+pfMEtMVAsequence  = cms.Sequence(pfMEtMVATask)

--- a/RecoMET/METPUSubtraction/python/pfNoPUMET_cff.py
+++ b/RecoMET/METPUSubtraction/python/pfNoPUMET_cff.py
@@ -1,14 +1,14 @@
 import FWCore.ParameterSet.Config as cms
 
-pfNoPUMEtSequence = cms.Sequence()
+pfNoPUMEtTask = cms.Task()
 
 from JetMETCorrections.Configuration.JetCorrectionServices_cff import *
 calibratedAK4PFJetsForPFNoPUMEt = cms.EDProducer('PFJetCorrectionProducer',
     src = cms.InputTag('ak4PFJets'),
     correctors = cms.vstring('ak4PFL1FastL2L3') # NOTE: use "ak4PFL1FastL2L3" for MC / "ak4PFL1FastL2L3Residual" for Data
 )
-ak4PFJetSequenceForPFNoPUMEt = cms.Sequence(calibratedAK4PFJetsForPFNoPUMEt)
-pfNoPUMEtSequence += ak4PFJetSequenceForPFNoPUMEt
+ak4PFJetTaskForPFNoPUMEt = cms.Task(calibratedAK4PFJetsForPFNoPUMEt)
+pfNoPUMEtTask.add(ak4PFJetTaskForPFNoPUMEt)
 
 from RecoJets.JetProducers.PileupJetID_cfi import *
 puJetIdForPFNoPUMEt = pileupJetId.clone(
@@ -17,28 +17,28 @@ puJetIdForPFNoPUMEt = pileupJetId.clone(
         cutbased,
         PhilV1
         ),
-#    label = cms.string("fullId"), #MM does not work for weird reasons, cannot be cloned properly
+#    label = "fullId", #MM does not work for weird reasons, cannot be cloned properly
     produceJetIds    = True,
     runMvas          = True,
     jets             = "calibratedAK4PFJetsForPFNoPUMEt",
     applyJec         = False,
     inputIsCorrected = True,
     )
-pfNoPUMEtSequence += puJetIdForPFNoPUMEt
+pfNoPUMEtTask.add(puJetIdForPFNoPUMEt)
 
 from JetMETCorrections.Type1MET.pfMETCorrectionType0_cfi import *
-pfNoPUMEtSequence += type0PFMEtCorrection
+pfNoPUMEtTask.add(type0PFMEtCorrection)
 pfCandidateToVertexAssociationForPFNoPUMEt = pfCandidateToVertexAssociation.clone(
     MaxNumberOfAssociations = 1,	
     doReassociation         = False,
     FinalAssociation        = 1,			    
     nTrackWeight            = 0.
 )
-pfNoPUMEtSequence += pfCandidateToVertexAssociationForPFNoPUMEt
+pfNoPUMEtTask.add(pfCandidateToVertexAssociationForPFNoPUMEt)
 pfMETcorrType0ForPFNoPUMEt = pfMETcorrType0.clone(
     srcPFCandidateToVertexAssociations = 'pfCandidateToVertexAssociationForPFNoPUMEt'
 )
-pfNoPUMEtSequence += pfMETcorrType0ForPFNoPUMEt
+pfNoPUMEtTask.add(pfMETcorrType0ForPFNoPUMEt)
 
 jvfJetIdForPFNoPUMEt = cms.EDProducer("JVFJetIdProducer",
     srcJets = cms.InputTag('calibratedAK4PFJetsForPFNoPUMEt'),
@@ -50,7 +50,7 @@ jvfJetIdForPFNoPUMEt = cms.EDProducer("JVFJetIdProducer",
     JVFcut = cms.double(0.75),
     neutralJetOption = cms.string("noPU")
 )
-pfNoPUMEtSequence += jvfJetIdForPFNoPUMEt
+pfNoPUMEtTask.add(jvfJetIdForPFNoPUMEt)
 
 import RecoMET.METProducers.METSigParams_cfi as met_config
 pfNoPUMEtData = cms.EDProducer("NoPileUpPFMEtDataProducer",
@@ -70,7 +70,7 @@ pfNoPUMEtData = cms.EDProducer("NoPileUpPFMEtDataProducer",
     resolution = met_config.METSignificance_params,
     verbosity = cms.int32(0)     
 )
-pfNoPUMEtSequence += pfNoPUMEtData
+pfNoPUMEtTask.add(pfNoPUMEtData)
 
 pfNoPUMEt = cms.EDProducer("NoPileUpPFMEtProducer",
     srcMEt = cms.InputTag('pfMet'),
@@ -96,4 +96,5 @@ pfNoPUMEt = cms.EDProducer("NoPileUpPFMEtProducer",
     saveInputs = cms.bool(True),
     verbosity = cms.int32(0)                               
 )
-pfNoPUMEtSequence += pfNoPUMEt
+pfNoPUMEtTask.add(pfNoPUMEt)
+pfNoPUMEtSequence = cms.Sequence(pfNoPUMEtTask)

--- a/RecoMET/METPUSubtraction/python/pfNoPUchsMET_cff.py
+++ b/RecoMET/METPUSubtraction/python/pfNoPUchsMET_cff.py
@@ -1,17 +1,17 @@
 import FWCore.ParameterSet.Config as cms
 
-pfNoPUchsMEtSequence = cms.Sequence()
+pfNoPUchsMEtTask = cms.Task()
 
 from JetMETCorrections.Type1MET.ak4PFchsJets_cff import *
-pfNoPUchsMEtSequence += ak4PFchsJetsSequence
+pfNoPUchsMEtTask.add(ak4PFchsJetsTask)
 
 from JetMETCorrections.Configuration.JetCorrectionServices_cff import *
 calibratedAK4PFchsJetsForPFNoPUchsMEt = cms.EDProducer('PFJetCorrectionProducer',
     src = cms.InputTag('ak4PFchsJets'),
     correctors = cms.vstring('ak4PFchsL1FastL2L3Residual') # NOTE: use "ak4PFchsL1FastL2L3" for MC / "ak4PFchsL1FastL2L3Residual" for Data
 )
-ak4PFJetSequenceForPFNoPUchsMEt = cms.Sequence(calibratedAK4PFchsJetsForPFNoPUchsMEt)
-pfNoPUchsMEtSequence += ak4PFJetSequenceForPFNoPUchsMEt
+ak4PFJetTaskForPFNoPUchsMEt = cms.Task(calibratedAK4PFchsJetsForPFNoPUchsMEt)
+pfNoPUchsMEtTask.add(ak4PFJetTaskForPFNoPUchsMEt)
 
 from RecoJets.JetProducers.PileupJetID_cfi import *
 puJetIdForPFNoPUchsMEt = pileupJetId.clone(
@@ -26,28 +26,28 @@ puJetIdForPFNoPUchsMEt = pileupJetId.clone(
     applyJec         = False,
     inputIsCorrected = True,                                     
 )
-pfNoPUchsMEtSequence += puJetIdForPFNoPUchsMEt
+pfNoPUchsMEtTask.add(puJetIdForPFNoPUchsMEt)
 
 from JetMETCorrections.Type1MET.pfMETCorrectionType0_cfi import *
-pfNoPUchsMEtSequence += type0PFMEtCorrection
+pfNoPUchsMEtTask.add(type0PFMEtCorrection)
 pfCandidateToVertexAssociationForPFNoPUchsMEt = pfCandidateToVertexAssociation.clone(
     MaxNumberOfAssociations = 1,	
     doReassociation         = False,
     FinalAssociation        = 1,			    
     nTrackWeight            = 0.
 )
-pfNoPUchsMEtSequence += pfCandidateToVertexAssociationForPFNoPUchsMEt
+pfNoPUchsMEtTask.add(pfCandidateToVertexAssociationForPFNoPUchsMEt)
 pfMETcorrType0ForPFNoPUchsMEt = pfMETcorrType0.clone(
-    srcPFCandidateToVertexAssociations = cms.InputTag('pfCandidateToVertexAssociationForPFNoPUchsMEt')
+    srcPFCandidateToVertexAssociations = 'pfCandidateToVertexAssociationForPFNoPUchsMEt'
 )
-pfNoPUchsMEtSequence += pfMETcorrType0ForPFNoPUchsMEt
+pfNoPUchsMEtTask.add(pfMETcorrType0ForPFNoPUchsMEt)
 
 ##from CommonTools.RecoUtils.pfcand_assomap_cfi import PFCandAssoMap
 ##pfPileUpToVertexAssociation = PFCandAssoMap.clone(
 ##    VertexTrackAssociationMap = cms.InputTag('trackToVertexAssociation'),
-##    PFCandidateCollection = cms.InputTag('pfPileUpForAK4PFchsJets')
+##    PFCandidateCollection = 'pfPileUpForAK4PFchsJets'
 ##)
-##pfNoPUchsMEtSequence += pfPileUpToVertexAssociation
+##pfNoPUchsMEtTask.add(pfPileUpToVertexAssociation)
 
 jvfJetIdForPFNoPUchsMEt = cms.EDProducer("JVFJetIdProducer",
     srcJets = cms.InputTag('calibratedAK4PFchsJetsForPFNoPUchsMEt'),                                      
@@ -59,7 +59,7 @@ jvfJetIdForPFNoPUchsMEt = cms.EDProducer("JVFJetIdProducer",
     JVFcut = cms.double(0.75),
     neutralJetOption = cms.string("noPU")
 )
-pfNoPUchsMEtSequence += jvfJetIdForPFNoPUchsMEt
+pfNoPUchsMEtTask.add(jvfJetIdForPFNoPUchsMEt)
 
 import RecoMET.METProducers.METSigParams_cfi as met_config
 pfNoPUchsMEtData = cms.EDProducer("PFNoPUMEtDataProducer",
@@ -80,7 +80,7 @@ pfNoPUchsMEtData = cms.EDProducer("PFNoPUMEtDataProducer",
     resolution = met_config.METSignificance_params,
     verbosity = cms.int32(0)     
 )
-pfNoPUchsMEtSequence += pfNoPUchsMEtData
+pfNoPUchsMEtTask.add(pfNoPUchsMEtData)
 
 pfNoPUchsMEt = cms.EDProducer("PFNoPUMEtProducer",
     srcMEt = cms.InputTag('pfMet'),
@@ -104,4 +104,5 @@ pfNoPUchsMEt = cms.EDProducer("PFNoPUMEtProducer",
     saveInputs = cms.bool(True),
     verbosity = cms.int32(0)                               
 )
-pfNoPUchsMEtSequence += pfNoPUchsMEt
+pfNoPUchsMEtTask.add(pfNoPUchsMEt)
+pfNoPUchsMEtSequence = cms.Sequence(pfNoPUchsMEtTask)

--- a/RecoMET/METProducers/python/METSignificanceObjects_cfi.py
+++ b/RecoMET/METProducers/python/METSignificanceObjects_cfi.py
@@ -66,8 +66,10 @@ selectedPhotons = cms.EDFilter("PhotonSelector",
       )
 
 
-selectionSequenceForMETSig = cms.Sequence(
-      selectedMuons+
-      selectedElectrons+
+selectionTaskForMETSig = cms.Task(
+      selectedMuons,
+      selectedElectrons,
       selectedPhotons
       )
+selectionSequenceForMETSig = cms.Sequence(selectionTaskForMETSig)
+


### PR DESCRIPTION
#### PR description: 

Move cms.Sequence() to cms.Task() for python configurations in RecoMET. (the previous task is [PR#27887](https://github.com/cms-sw/cmssw/pull/27887)).

In this PR, a total of 9 files were changed.

RecoMET/METPUSubtraction  8 files
RecoMET/METProducers 1 file

#### PR validation:
Event Content comparison check was also done and there is no change with these updates.
Tested in CMSSW_11_2_X, the basic test all passed in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html).