### PR TITLE
Boost 1.75 - Add missing headers (algorithm and memory) and update include locations

### DIFF
--- a/CalibCalorimetry/HcalAlgos/interface/HcalDbASCIIIO.h
+++ b/CalibCalorimetry/HcalAlgos/interface/HcalDbASCIIIO.h
@@ -5,7 +5,7 @@
 #define HcalDbASCIIIO_h
 
 #include <iostream>
-
+#include <memory>
 #include "DataFormats/HcalDetId/interface/HcalDetId.h"
 #include "CondFormats/HcalObjects/interface/AllObjects.h"
 #include "CalibFormats/HcalObjects/interface/HcalCalibrationsSet.h"

--- a/CaloOnlineTools/HcalOnlineDb/interface/LMap.h
+++ b/CaloOnlineTools/HcalOnlineDb/interface/LMap.h
@@ -23,7 +23,7 @@
 #include <vector>
 #include <cstring>
 #include <fstream>
-
+#include <memory>
 #include "CaloOnlineTools/HcalOnlineDb/interface/ConfigurationDatabase.hh"
 #include "DataFormats/HcalDetId/interface/HcalSubdetector.h"
 #include "CondFormats/HcalObjects/interface/HcalElectronicsMap.h"

--- a/CondFormats/EcalObjects/src/EcalMustacheSCParameters.cc
+++ b/CondFormats/EcalObjects/src/EcalMustacheSCParameters.cc
@@ -1,4 +1,5 @@
 #include "CondFormats/EcalObjects/interface/EcalMustacheSCParameters.h"
+#include <boost/range/algorithm/lower_bound.hpp>
 
 float EcalMustacheSCParameters::sqrtLogClustETuning() const { return sqrtLogClustETuning_; }
 

--- a/CondFormats/EcalObjects/src/EcalMustacheSCParameters.cc
+++ b/CondFormats/EcalObjects/src/EcalMustacheSCParameters.cc
@@ -1,5 +1,5 @@
 #include "CondFormats/EcalObjects/interface/EcalMustacheSCParameters.h"
-#include <boost/range/algorithm/lower_bound.hpp>
+#include <algorithm>
 
 float EcalMustacheSCParameters::sqrtLogClustETuning() const { return sqrtLogClustETuning_; }
 

--- a/CondFormats/EcalObjects/src/EcalSCDynamicDPhiParameters.cc
+++ b/CondFormats/EcalObjects/src/EcalSCDynamicDPhiParameters.cc
@@ -1,5 +1,5 @@
 #include "CondFormats/EcalObjects/interface/EcalSCDynamicDPhiParameters.h"
-#include <boost/range/algorithm/lower_bound.hpp>
+#include <algorithm>
 
 const EcalSCDynamicDPhiParameters::DynamicDPhiParameters* EcalSCDynamicDPhiParameters::dynamicDPhiParameters(
     double clustE, double absSeedEta) const {

--- a/CondFormats/EcalObjects/src/EcalSCDynamicDPhiParameters.cc
+++ b/CondFormats/EcalObjects/src/EcalSCDynamicDPhiParameters.cc
@@ -1,4 +1,5 @@
 #include "CondFormats/EcalObjects/interface/EcalSCDynamicDPhiParameters.h"
+#include <boost/range/algorithm/lower_bound.hpp>
 
 const EcalSCDynamicDPhiParameters::DynamicDPhiParameters* EcalSCDynamicDPhiParameters::dynamicDPhiParameters(
     double clustE, double absSeedEta) const {

--- a/CondTools/RPC/src/RPCLBLinkNameParser.cc
+++ b/CondTools/RPC/src/RPCLBLinkNameParser.cc
@@ -1,7 +1,7 @@
 #include "CondTools/RPC/interface/RPCLBLinkNameParser.h"
 
 #include <sstream>
-
+#include <algorithm>
 #include "FWCore/Utilities/interface/Exception.h"
 
 void RPCLBLinkNameParser::parse(std::string const& name, RPCLBLink& lb_link) {

--- a/EventFilter/L1TRawToDigi/interface/OmtfRpcPacker.h
+++ b/EventFilter/L1TRawToDigi/interface/OmtfRpcPacker.h
@@ -2,7 +2,7 @@
 #define EventFilter_L1TRawToDigi_Omtf_RpcPacker_H
 
 #include <string>
-
+#include <memory>
 #include "DataFormats/RPCDigi/interface/RPCDigiCollection.h"
 #include "DataFormats/L1TMuon/interface/OMTF/OmtfDataWord64.h"
 #include "EventFilter/L1TRawToDigi/interface/OmtfLinkMappingRpc.h"

--- a/EventFilter/RPCRawToDigi/src/RPCLBPacker.cc
+++ b/EventFilter/RPCRawToDigi/src/RPCLBPacker.cc
@@ -1,7 +1,7 @@
 #include "EventFilter/RPCRawToDigi/interface/RPCLBPacker.h"
 
 #include "FWCore/Utilities/interface/Exception.h"
-
+#include <algorithm>
 #include "CondFormats/RPCObjects/interface/RPCInverseLBLinkMap.h"
 #include "DataFormats/RPCDigi/interface/RPCDigi.h"
 

--- a/L1Trigger/RPCTechnicalTrigger/interface/TTUTrackingAlg.h
+++ b/L1Trigger/RPCTechnicalTrigger/interface/TTUTrackingAlg.h
@@ -2,6 +2,7 @@
 #define TTUTRACKINGALG_H 1
 
 // Include files
+#include <memory>
 #include "L1Trigger/RPCTechnicalTrigger/interface/TTULogic.h"
 #include "L1Trigger/RPCTechnicalTrigger/interface/TTUInput.h"
 

--- a/RecoParticleFlow/PFClusterProducer/plugins/Basic2DGenericPFlowPositionCalc.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/Basic2DGenericPFlowPositionCalc.cc
@@ -69,11 +69,10 @@ void Basic2DGenericPFlowPositionCalc::calculateAndSetPositionActual(reco::PFClus
     const auto rh_rawenergy = rhf.energy;
     const auto rh_energy = rh_rawenergy * rh_fraction;
 #ifdef PF_DEBUG
-    if
-      UNLIKELY(edm::isNotFinite(rh_energy)) {
-        throw cms::Exception("PFClusterAlgo") << "rechit " << refhit.detId() << " has a NaN energy... "
-                                              << "The input of the particle flow clustering seems to be corrupted.";
-      }
+    if UNLIKELY (edm::isNotFinite(rh_energy)) {
+      throw cms::Exception("PFClusterAlgo") << "rechit " << refhit.detId() << " has a NaN energy... "
+                                            << "The input of the particle flow clustering seems to be corrupted.";
+    }
 #endif
     cl_energy += rh_energy;
     // If time resolution is given, calculated weighted average

--- a/RecoParticleFlow/PFClusterProducer/plugins/Basic2DGenericPFlowPositionCalc.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/Basic2DGenericPFlowPositionCalc.cc
@@ -6,7 +6,7 @@
 #include <cmath>
 #include "CommonTools/Utils/interface/DynArray.h"
 #include <iterator>
-#include <boost/function_output_iterator.hpp>
+#include <boost/iterator/function_output_iterator.hpp>
 
 #include "vdt/vdtMath.h"
 


### PR DESCRIPTION
#### PR description:

This brings the header for the 4 argument lower_bound, coming from algorithm 
It fixes deprecated header warning. There might other warnings

#### PR validation:

CondFormats/EcalObjects builds with boost 1.75

