### PR TITLE
fix trackdnn TfGraphDefWrapper memory leak

### DIFF
--- a/RecoTracker/FinalTrackSelectors/interface/TfGraphDefWrapper.h
+++ b/RecoTracker/FinalTrackSelectors/interface/TfGraphDefWrapper.h
@@ -15,7 +15,7 @@ public:
 
 private:
   tensorflow::Session* session_;
-  tensorflow::GraphDef* graph_;
+  std::unique_ptr<tensorflow::GraphDef> graph_;
 };
 
 #endif

--- a/RecoTracker/FinalTrackSelectors/interface/TfGraphDefWrapper.h
+++ b/RecoTracker/FinalTrackSelectors/interface/TfGraphDefWrapper.h
@@ -5,8 +5,8 @@
 
 class TfGraphDefWrapper {
 public:
-  TfGraphDefWrapper(tensorflow::Session*);
-  ~TfGraphDefWrapper() { tensorflow::closeSession(session_); };
+  TfGraphDefWrapper(tensorflow::Session*, tensorflow::GraphDef*);
+  ~TfGraphDefWrapper();
   TfGraphDefWrapper(const TfGraphDefWrapper&) = delete;
   TfGraphDefWrapper& operator=(const TfGraphDefWrapper&) = delete;
   TfGraphDefWrapper(TfGraphDefWrapper&&) = delete;
@@ -15,6 +15,7 @@ public:
 
 private:
   tensorflow::Session* session_;
+  tensorflow::GraphDef* graph_;
 };
 
 #endif

--- a/RecoTracker/FinalTrackSelectors/plugins/TfGraphDefProducer.cc
+++ b/RecoTracker/FinalTrackSelectors/plugins/TfGraphDefProducer.cc
@@ -46,8 +46,9 @@ TfGraphDefProducer::TfGraphDefProducer(const edm::ParameterSet& iConfig)
 }
 
 // ------------ method called to produce the data  ------------
-std::unique_ptr<TfGraphDefWrapper> TfGraphDefProducer::produce(const TfGraphRecord& iRecord) {
-  return std::make_unique<TfGraphDefWrapper>(tensorflow::createSession(tensorflow::loadGraphDef(filename_), 1));
+TfGraphDefProducer::ReturnType TfGraphDefProducer::produce(const TfGraphRecord& iRecord) {
+  auto* graph = tensorflow::loadGraphDef(filename_);
+  return std::make_unique<TfGraphDefWrapper>(tensorflow::createSession(graph, 1), graph);
 }
 
 void TfGraphDefProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {

--- a/RecoTracker/FinalTrackSelectors/src/TfGraphDefWrapper.cc
+++ b/RecoTracker/FinalTrackSelectors/src/TfGraphDefWrapper.cc
@@ -1,6 +1,12 @@
 #include "RecoTracker/FinalTrackSelectors/interface/TfGraphDefWrapper.h"
 
-TfGraphDefWrapper::TfGraphDefWrapper(tensorflow::Session* session) : session_(session) {}
+TfGraphDefWrapper::TfGraphDefWrapper(tensorflow::Session* session, tensorflow::GraphDef* graph)
+    : session_(session), graph_(graph) {}
 const tensorflow::Session* TfGraphDefWrapper::getSession() const {
   return const_cast<const tensorflow::Session*>(session_);
 }
+
+TfGraphDefWrapper::~TfGraphDefWrapper() {
+  tensorflow::closeSession(session_);
+  delete graph_;
+};

--- a/RecoTracker/FinalTrackSelectors/src/TfGraphDefWrapper.cc
+++ b/RecoTracker/FinalTrackSelectors/src/TfGraphDefWrapper.cc
@@ -2,11 +2,6 @@
 
 TfGraphDefWrapper::TfGraphDefWrapper(tensorflow::Session* session, tensorflow::GraphDef* graph)
     : session_(session), graph_(graph) {}
-const tensorflow::Session* TfGraphDefWrapper::getSession() const {
-  return const_cast<const tensorflow::Session*>(session_);
-}
+const tensorflow::Session* TfGraphDefWrapper::getSession() const { return session_; }
 
-TfGraphDefWrapper::~TfGraphDefWrapper() {
-  tensorflow::closeSession(session_);
-  delete graph_;
-};
+TfGraphDefWrapper::~TfGraphDefWrapper() { tensorflow::closeSession(session_); };


### PR DESCRIPTION
#### PR description:
Fixed the GraphDef memory leak pointed out by @makortel in https://github.com/cms-sw/cmssw/pull/32128#discussion_r577735043.

`tensorflow::Session` gets closed by the destructor, but the `tensorflow::GraphDef` does not get automatically collected, so I'm storing it in a `unique_ptr` in the `TfGraphDefWrapper` to ensure it gets collected.

cc @minxiyang @JanFSchulte @riga 

#### PR validation:

This is a technical PR.
Ran the trackdnn workflow 11634.91 before and after this change, no significant RSS differences observed. 