### PR TITLE
CSC RU builder widened roads and narrower anode time window switched to default

### DIFF
--- a/RecoLocalMuon/CSCRecHitD/python/cscRecHitD_cfi.py
+++ b/RecoLocalMuon/CSCRecHitD/python/cscRecHitD_cfi.py
@@ -28,9 +28,9 @@ csc2DRecHits = cms.EDProducer("CSCRecHitDProducer",
     CSCWireClusterDeltaT = cms.int32(1),
     #
     #    wire time window used for reconstruction
-    CSCUseReducedWireTimeWindow = cms.bool(False),
-    CSCWireTimeWindowLow = cms.int32(0),
-    CSCWireTimeWindowHigh = cms.int32(15),
+    CSCUseReducedWireTimeWindow = cms.bool(True),
+    CSCWireTimeWindowLow = cms.int32(5),
+    CSCWireTimeWindowHigh = cms.int32(11),
     #
     #    Calibration info:
     CSCUseCalibrations = cms.bool(True),

--- a/RecoLocalMuon/CSCRecHitD/python/customRecHitBuilder.py
+++ b/RecoLocalMuon/CSCRecHitD/python/customRecHitBuilder.py
@@ -1,8 +1,0 @@
-import FWCore.ParameterSet.Config as cms
-
-def tightenAnodeTimes(process):
-    if hasattr(process,'csc2DRecHits'):
-        process.csc2DRecHits.CSCUseReducedWireTimeWindow = True
-        process.csc2DRecHits.CSCWireTimeWindowLow = 5
-        process.csc2DRecHits.CSCWireTimeWindowHigh = 11
-        return process

--- a/RecoLocalMuon/CSCSegment/python/CSCSegmentAlgorithmRU_cfi.py
+++ b/RecoLocalMuon/CSCSegment/python/CSCSegmentAlgorithmRU_cfi.py
@@ -2,7 +2,6 @@ import FWCore.ParameterSet.Config as cms
 
 RU_ME1A = cms.PSet(
     doCollisions = cms.bool(True),
-    enlarge = cms.bool(False),
     chi2Norm_2D_ = cms.double(35),
     chi2_str = cms.double(50.0),
     chi2Max = cms.double(100.0),
@@ -15,7 +14,6 @@ RU_ME1A = cms.PSet(
 )
 RU_ME1B = cms.PSet(
     doCollisions = cms.bool(True),
-    enlarge = cms.bool(False),
     chi2Norm_2D_ = cms.double(35),
     chi2_str = cms.double(50.0),
     chi2Max = cms.double(100.0),
@@ -28,7 +26,6 @@ RU_ME1B = cms.PSet(
 )
 RU_ME12 = cms.PSet(
     doCollisions = cms.bool(True),
-    enlarge = cms.bool(False),
     chi2Norm_2D_ = cms.double(35),
     chi2_str = cms.double(50.0),
     chi2Max = cms.double(100.0),
@@ -41,7 +38,6 @@ RU_ME12 = cms.PSet(
 )
 RU_ME13 = cms.PSet(
     doCollisions = cms.bool(True),
-    enlarge = cms.bool(False),
     chi2Norm_2D_ = cms.double(20),
     chi2_str = cms.double(30.0),
     chi2Max = cms.double(60.0),
@@ -54,7 +50,6 @@ RU_ME13 = cms.PSet(
 )
 RU_MEX1 = cms.PSet(
     doCollisions = cms.bool(True),
-    enlarge = cms.bool(False),
     chi2Norm_2D_ = cms.double(60),
     chi2_str = cms.double(80.0),
     chi2Max = cms.double(180.0),
@@ -67,7 +62,6 @@ RU_MEX1 = cms.PSet(
 )
 RU_MEX2 = cms.PSet(
     doCollisions = cms.bool(True),
-    enlarge = cms.bool(False),
     chi2Norm_2D_ = cms.double(35),
     chi2_str = cms.double(50.0),
     chi2Max = cms.double(100.0),

--- a/RecoLocalMuon/CSCSegment/python/customSegmentBuilder.py
+++ b/RecoLocalMuon/CSCSegment/python/customSegmentBuilder.py
@@ -1,6 +1,0 @@
-import FWCore.ParameterSet.Config as cms
-
-def widenRoads(process):
-   if hasattr(process,'cscSegments'):
-      for ps in process.cscSegments.algo_psets[4].algo_psets: ps.enlarge = True   
-      return process

--- a/RecoLocalMuon/CSCSegment/src/CSCSegAlgoRU.cc
+++ b/RecoLocalMuon/CSCSegment/src/CSCSegAlgoRU.cc
@@ -21,7 +21,6 @@
 
 CSCSegAlgoRU::CSCSegAlgoRU(const edm::ParameterSet& ps) : CSCSegmentAlgorithm(ps), myName("CSCSegAlgoRU") {
   doCollisions = ps.getParameter<bool>("doCollisions");
-  enlarge = ps.getParameter<bool>("enlarge");
   chi2_str_ = ps.getParameter<double>("chi2_str");
   chi2Norm_2D_ = ps.getParameter<double>("chi2Norm_2D_");
   dRMax = ps.getParameter<double>("dRMax");
@@ -96,7 +95,6 @@ std::vector<CSCSegment> CSCSegAlgoRU::buildSegments(const CSCChamber* aChamber,
   AlgoState aState;
   aState.aChamber = aChamber;
   aState.doCollisions = doCollisions;
-  aState.enlarge = enlarge;
   aState.dRMax = dRMax;
   aState.dPhiMax = dPhiMax;
   aState.dRIntMax = dRIntMax;
@@ -104,10 +102,6 @@ std::vector<CSCSegment> CSCSegAlgoRU::buildSegments(const CSCChamber* aChamber,
   aState.chi2Norm_2D_ = chi2Norm_2D_;
   aState.chi2_str_ = chi2_str_;
   aState.chi2Max = chi2Max;
-
-  int scale_factor = 1;
-  if (aState.enlarge)
-    scale_factor = 2;
 
   // Define buffer for segments we build
   std::vector<CSCSegment> segments;
@@ -122,13 +116,11 @@ std::vector<CSCSegment> CSCSegAlgoRU::buildSegments(const CSCChamber* aChamber,
   for (int ipass = 0; ipass < npass; ++ipass) {
     if (aState.windowScale > 1.) {
       iadd = 1;
-      aState.strip_iadd = 2 * scale_factor;
-      aState.chi2D_iadd = 2 * scale_factor;
-      if (aState.enlarge) {
-        aState.chi2Max = 2 * chi2Max;
-        if (rechits.size() <= 12)
-          iadd = 0;  //allow 3 hit segments for low hit multiplicity chambers
-      }
+      aState.strip_iadd = 4;
+      aState.chi2D_iadd = 4;
+      aState.chi2Max = 2 * chi2Max;
+      if (rechits.size() <= 12)
+        iadd = 0;  //allow 3 hit segments for low hit multiplicity chambers
     }
 
     int used_rh = 0;
@@ -143,13 +135,13 @@ std::vector<CSCSegment> CSCSegAlgoRU::buildSegments(const CSCChamber* aChamber,
             2) {  //check if there are enough recHits left to build a segment from displaced vertices
       aState.doCollisions = false;
       aState.windowScale = 1.;  // scale factor for cuts
-      aState.dRMax = scale_factor * 2.0;
-      aState.dPhiMax = scale_factor * 2 * aState.dPhiMax;
-      aState.dRIntMax = scale_factor * 2 * aState.dRIntMax;
-      aState.dPhiIntMax = scale_factor * 2 * aState.dPhiIntMax;
-      aState.chi2Norm_2D_ = scale_factor * 5 * aState.chi2Norm_2D_;
-      aState.chi2_str_ = scale_factor * 100;
-      aState.chi2Max = scale_factor * 2 * aState.chi2Max;
+      aState.dRMax = 4.0;
+      aState.dPhiMax = 4 * aState.dPhiMax;
+      aState.dRIntMax = 4 * aState.dRIntMax;
+      aState.dPhiIntMax = 4 * aState.dPhiIntMax;
+      aState.chi2Norm_2D_ = 10 * aState.chi2Norm_2D_;
+      aState.chi2_str_ = 200;
+      aState.chi2Max = 4 * aState.chi2Max;
     } else {
       search_disp = false;  //make sure the flag is off
     }
@@ -284,11 +276,11 @@ std::vector<CSCSegment> CSCSegAlgoRU::buildSegments(const CSCChamber* aChamber,
       aState.doCollisions = true;
       aState.dRMax = 2.0;
       aState.chi2_str_ = 100;
-      aState.dPhiMax = 0.5 * aState.dPhiMax / scale_factor;
-      aState.dRIntMax = 0.5 * aState.dRIntMax / scale_factor;
-      aState.dPhiIntMax = 0.5 * aState.dPhiIntMax / scale_factor;
-      aState.chi2Norm_2D_ = 0.2 * aState.chi2Norm_2D_ / scale_factor;
-      aState.chi2Max = 0.5 * aState.chi2Max / scale_factor;
+      aState.dPhiMax = 0.25 * aState.dPhiMax;
+      aState.dRIntMax = 0.25 * aState.dRIntMax;
+      aState.dPhiIntMax = 0.25 * aState.dPhiIntMax;
+      aState.chi2Norm_2D_ = 0.1 * aState.chi2Norm_2D_;
+      aState.chi2Max = 0.25 * aState.chi2Max;
     }
 
     std::vector<CSCSegment>::iterator it = segments.begin();
@@ -426,19 +418,11 @@ bool CSCSegAlgoRU::areHitsCloseInR(const AlgoState& aState, const CSCRecHit2D* h
     h1z = 1;
     h2z = 1;
   }
-
-  if (aState.enlarge) {
-    return (gp2.perp() > ((gp1.perp() - aState.dRMax * aState.strip_iadd * maxWG_width[iStn]) * h2z) / h1z &&
+  
+  return (gp2.perp() > ((gp1.perp() - aState.dRMax * aState.strip_iadd * maxWG_width[iStn]) * h2z) / h1z &&
             gp2.perp() < ((gp1.perp() + aState.dRMax * aState.strip_iadd * maxWG_width[iStn]) * h2z) / h1z)
                ? true
                : false;
-
-  } else {
-    return (gp2.perp() > ((gp1.perp() - aState.dRMax * maxWG_width[iStn]) * h2z) / h1z &&
-            gp2.perp() < ((gp1.perp() + aState.dRMax * maxWG_width[iStn]) * h2z) / h1z)
-               ? true
-               : false;
-  }
 }
 
 bool CSCSegAlgoRU::areHitsCloseInGlobalPhi(const AlgoState& aState,
@@ -544,19 +528,10 @@ bool CSCSegAlgoRU::isHitNearSegment(const AlgoState& aState, const CSCRecHit2D* 
       maxWG_width[1] = 10.75;
     }
   }
-
-  if (aState.enlarge) {
-    return (fabs(phidif) < aState.dPhiIntMax * aState.strip_iadd * pos_str + dphi_incr &&
+  return (fabs(phidif) < aState.dPhiIntMax * aState.strip_iadd * pos_str + dphi_incr &&
             fabs(dr) < aState.dRIntMax * aState.strip_iadd * maxWG_width[iStn])
                ? true
                : false;
-
-  } else {
-    return (fabs(phidif) < aState.dPhiIntMax * aState.strip_iadd * pos_str + dphi_incr &&
-            fabs(dr) < aState.dRIntMax * maxWG_width[iStn])
-               ? true
-               : false;
-  }
 }
 
 float CSCSegAlgoRU::phiAtZ(const AlgoState& aState, float z) const {
@@ -583,7 +558,7 @@ bool CSCSegAlgoRU::isSegmentGood(const AlgoState& aState, const ChamberHitContai
   unsigned int iadd = (rechitsInChamber.size() > 20) ? 1 : 0;
   if (aState.windowScale > 1.) {
     iadd = 1;
-    if (rechitsInChamber.size() <= 12 && aState.enlarge)
+    if (rechitsInChamber.size() <= 12)
       iadd = 0;
   }
   if (aState.proto_segment.size() >= 3 + iadd)

--- a/RecoLocalMuon/CSCSegment/src/CSCSegAlgoRU.cc
+++ b/RecoLocalMuon/CSCSegment/src/CSCSegAlgoRU.cc
@@ -418,11 +418,10 @@ bool CSCSegAlgoRU::areHitsCloseInR(const AlgoState& aState, const CSCRecHit2D* h
     h1z = 1;
     h2z = 1;
   }
-  
   return (gp2.perp() > ((gp1.perp() - aState.dRMax * aState.strip_iadd * maxWG_width[iStn]) * h2z) / h1z &&
-            gp2.perp() < ((gp1.perp() + aState.dRMax * aState.strip_iadd * maxWG_width[iStn]) * h2z) / h1z)
-               ? true
-               : false;
+          gp2.perp() < ((gp1.perp() + aState.dRMax * aState.strip_iadd * maxWG_width[iStn]) * h2z) / h1z)
+             ? true
+             : false;
 }
 
 bool CSCSegAlgoRU::areHitsCloseInGlobalPhi(const AlgoState& aState,
@@ -529,9 +528,9 @@ bool CSCSegAlgoRU::isHitNearSegment(const AlgoState& aState, const CSCRecHit2D* 
     }
   }
   return (fabs(phidif) < aState.dPhiIntMax * aState.strip_iadd * pos_str + dphi_incr &&
-            fabs(dr) < aState.dRIntMax * aState.strip_iadd * maxWG_width[iStn])
-               ? true
-               : false;
+          fabs(dr) < aState.dRIntMax * aState.strip_iadd * maxWG_width[iStn])
+             ? true
+             : false;
 }
 
 float CSCSegAlgoRU::phiAtZ(const AlgoState& aState, float z) const {

--- a/RecoLocalMuon/CSCSegment/src/CSCSegAlgoRU.h
+++ b/RecoLocalMuon/CSCSegment/src/CSCSegAlgoRU.h
@@ -89,7 +89,6 @@ private:
 
     //adjustable configuration
     bool doCollisions;
-    bool enlarge;
     float dRMax;
     float dPhiMax;
     float dRIntMax;
@@ -162,7 +161,6 @@ private:
   float wideSeg;
   int minLayersApart;
   bool debugInfo;
-  bool enlarge;
 };
 
 #endif


### PR DESCRIPTION
#### PR description:
This is a PR that omitts the customisation files and confirable parameter used for validation of the proposed changes in https://github.com/cms-sw/cmssw/pull/25684 and https://github.com/cms-sw/cmssw/pull/17772

Related presentation can be found here https://indico.cern.ch/event/784929/contributions/3265299/attachments/1777781/2890942/19_01_11-Voytishin_Palichik-CSCSegBuilder_proposal_RECO_meeting.pdf
The results of the validation can be found here:
https://hypernews.cern.ch/HyperNews/CMS/get/muon-object-validation/1287/1.html


