### PR TITLE
Add customisation to make sure that upgrade WFs will cross LS in the short matrix 

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -3286,6 +3286,7 @@ for year,k in [(year,k) for year in upgradeKeys for k in upgradeKeys[year]]:
     # setup baseline steps
     upgradeStepDict['GenSim'][k]= {'-s' : 'GEN,SIM',
                                        '-n' : 10,
+                                       '--customise_commands': '"process.source.numberEventsInLuminosityBlock=cms.untracked.uint32(5)"',
                                        '--conditions' : gt,
                                        '--beamspot' : 'Realistic25ns13TeVEarly2017Collision',
                                        '--datatier' : 'GEN-SIM',
@@ -3296,6 +3297,7 @@ for year,k in [(year,k) for year in upgradeKeys for k in upgradeKeys[year]]:
 
     upgradeStepDict['GenSimHLBeamSpot'][k]= {'-s' : 'GEN,SIM',
                                        '-n' : 10,
+                                       '--customise_commands': '"process.source.numberEventsInLuminosityBlock=cms.untracked.uint32(5)"',
                                        '--conditions' : gt,
                                        '--beamspot' : 'HLLHC',
                                        '--datatier' : 'GEN-SIM',
@@ -3305,6 +3307,7 @@ for year,k in [(year,k) for year in upgradeKeys for k in upgradeKeys[year]]:
 
     upgradeStepDict['GenSimHLBeamSpot14'][k]= {'-s' : 'GEN,SIM',
                                        '-n' : 10,
+                                       '--customise_commands': '"process.source.numberEventsInLuminosityBlock=cms.untracked.uint32(5)"',
                                        '--conditions' : gt,
                                        '--beamspot' : 'HLLHC14TeV',
                                        '--datatier' : 'GEN-SIM',


### PR DESCRIPTION
#### PR description:
This purpose of this PR is to add customisation on GEN-SIM step which will force all upgrade WFs to cross LS in the short matrix. It should not affect relvals submitted by PdmV. Crossing LS in the short matrix will help us to identify rare issues that can happen during crossing LS as we spotted lately in the past.

#### PR validation:
Config from the following command runs fine.
> runTheMatrix.py -w upgrade -l 34640.0 --wm init

#### if this PR is a backport please specify the original PR and why you need to backport that PR:
No backport is needed.
