### PR TITLE
Add EcalMustacheSCParameters and EcalSCDynamicDPhiParameters to GTs

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -10,31 +10,31 @@ autoCond = {
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run1
     'run1_mc_pa'        :   '113X_mcRun1_pA_v1',
     # GlobalTag for MC production with pessimistic alignment and calibrations for Run2
-    'run2_mc_50ns'      :   '113X_mcRun2_startup_v1',
+    'run2_mc_50ns'      :   '113X_mcRun2_startup_v2',
     # GlobalTag for MC production (2015 L1 Trigger Stage1) with startup-like alignment and calibrations for Run2, L1 trigger in Stage1 mode
-    'run2_mc_l1stage1'  :   '113X_mcRun2_asymptotic_l1stage1_v2',
+    'run2_mc_l1stage1'  :   '113X_mcRun2_asymptotic_l1stage1_v3',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run2
-    'run2_design'       :   '113X_mcRun2_design_v2',
+    'run2_design'       :   '113X_mcRun2_design_v3',
     #GlobalTag for MC production with optimistic alignment and calibrations for 2016, prior to VFP change
-    'run2_mc_pre_vfp'   :   '113X_mcRun2_asymptotic_preVFP_v2',
+    'run2_mc_pre_vfp'   :   '113X_mcRun2_asymptotic_preVFP_v3',
     #GlobalTag for MC production with optimistic alignment and calibrations for 2016, after VFP change
-    'run2_mc'           :   '113X_mcRun2_asymptotic_v2',
+    'run2_mc'           :   '113X_mcRun2_asymptotic_v3',
     # GlobalTag for MC production (cosmics) with starup-like alignment and calibrations for Run2, Strip tracker in peak mode
-    'run2_mc_cosmics'   :   '113X_mcRun2cosmics_asymptotic_deco_v2',
+    'run2_mc_cosmics'   :   '113X_mcRun2cosmics_asymptotic_deco_v3',
     # GlobalTag for MC production (Heavy Ions collisions) with optimistic alignment and calibrations for Run2
-    'run2_mc_hi'        :   '113X_mcRun2_HeavyIon_v2',
+    'run2_mc_hi'        :   '113X_mcRun2_HeavyIon_v3',
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2
-    'run2_mc_pa'        :   '113X_mcRun2_pA_v2',
+    'run2_mc_pa'        :   '113X_mcRun2_pA_v3',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   '113X_dataRun2_v3',
+    'run1_data'         :   '113X_dataRun2_v4',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   '113X_dataRun2_v3',
+    'run2_data'         :   '113X_dataRun2_v4',
     # GlobalTag for Run2 data 2018B relvals only: HEM-15-16 fail
-    'run2_data_HEfail'  :   '113X_dataRun2_HEfail_v3',
+    'run2_data_HEfail'  :   '113X_dataRun2_HEfail_v4',
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
-    'run2_data_relval'  :   '113X_dataRun2_relval_v3',
+    'run2_data_relval'  :   '113X_dataRun2_relval_v4',
     # GlobalTag for Run2 HI data
-    'run2_data_promptlike_hi' : '113X_dataRun2_PromptLike_HI_v3',
+    'run2_data_promptlike_hi' : '113X_dataRun2_PromptLike_HI_v4',
     # GlobalTag for Run1 HLT: it points to the online GT
     'run1_hlt'          :   '101X_dataRun2_HLT_frozen_v11',
     # GlobalTag for Run2 HLT: it points to the online GT
@@ -49,39 +49,39 @@ autoCond = {
     # GlobalTag for Run3 data relvals
     'run3_data_promptlike'     :   '112X_dataRun3_Prompt_v2',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,~0-centred beamspot)
-    'phase1_2017_design'       :  '113X_mc2017_design_v3',
+    'phase1_2017_design'       :  '113X_mc2017_design_v4',
     # GlobalTag for MC production with realistic conditions for Phase1 2017 detector
-    'phase1_2017_realistic'    :  '113X_mc2017_realistic_v3',
+    'phase1_2017_realistic'    :  '113X_mc2017_realistic_v4',
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in DECO mode
-    'phase1_2017_cosmics'      :  '113X_mc2017cosmics_realistic_deco_v3',
+    'phase1_2017_cosmics'      :  '113X_mc2017cosmics_realistic_deco_v4',
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in PEAK mode
-    'phase1_2017_cosmics_peak' :  '113X_mc2017cosmics_realistic_peak_v3',
+    'phase1_2017_cosmics_peak' :  '113X_mc2017cosmics_realistic_peak_v4',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for full Phase1 2018 (and 0,0,0-centred beamspot)
-    'phase1_2018_design'       :  '113X_upgrade2018_design_v3',
+    'phase1_2018_design'       :  '113X_upgrade2018_design_v4',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector
-    'phase1_2018_realistic'    :  '113X_upgrade2018_realistic_v3',
+    'phase1_2018_realistic'    :  '113X_upgrade2018_realistic_v4',
     # GlobalTag for MC production with realistic run-dependent (RD) conditions for full Phase1 2018 detector
-    'phase1_2018_realistic_rd' :  '113X_upgrade2018_realistic_RD_v1',
+    'phase1_2018_realistic_rd' :  '113X_upgrade2018_realistic_RD_v2',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector for Heavy Ion
-    'phase1_2018_realistic_hi' :  '113X_upgrade2018_realistic_HI_v3',
+    'phase1_2018_realistic_hi' :  '113X_upgrade2018_realistic_HI_v4',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector: HEM-15-16 fail
-    'phase1_2018_realistic_HEfail' :  '113X_upgrade2018_realistic_HEfail_v3',
+    'phase1_2018_realistic_HEfail' :  '113X_upgrade2018_realistic_HEfail_v4',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in DECO mode
-    'phase1_2018_cosmics'      :  '113X_upgrade2018cosmics_realistic_deco_v3',
+    'phase1_2018_cosmics'      :  '113X_upgrade2018cosmics_realistic_deco_v4',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in PEAK mode
-    'phase1_2018_cosmics_peak' :  '113X_upgrade2018cosmics_realistic_peak_v3',
+    'phase1_2018_cosmics_peak' :  '113X_upgrade2018cosmics_realistic_peak_v4',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2021
-    'phase1_2021_design'       : '113X_mcRun3_2021_design_v4', # GT containing design conditions for Phase1 2021
+    'phase1_2021_design'       : '113X_mcRun3_2021_design_v5', # GT containing design conditions for Phase1 2021
     # GlobalTag for MC production with realistic conditions for Phase1 2021
-    'phase1_2021_realistic'    : '113X_mcRun3_2021_realistic_v4', # GT containing realistic conditions for Phase1 2021
+    'phase1_2021_realistic'    : '113X_mcRun3_2021_realistic_v7', # GT containing realistic conditions for Phase1 2021
     # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2021,  Strip tracker in DECO mode
-    'phase1_2021_cosmics'      : '113X_mcRun3_2021cosmics_realistic_deco_v5',
+    'phase1_2021_cosmics'      : '113X_mcRun3_2021cosmics_realistic_deco_v6',
     # GlobalTag for MC production with realistic conditions for Phase1 2021 detector for Heavy Ion
-    'phase1_2021_realistic_hi' : '113X_mcRun3_2021_realistic_HI_v4',
+    'phase1_2021_realistic_hi' : '113X_mcRun3_2021_realistic_HI_v5',
     # GlobalTag for MC production with realistic conditions for Phase1 2023
-    'phase1_2023_realistic'    : '113X_mcRun3_2023_realistic_v4', # GT containing realistic conditions for Phase1 2023
+    'phase1_2023_realistic'    : '113X_mcRun3_2023_realistic_v5', # GT containing realistic conditions for Phase1 2023
     # GlobalTag for MC production with realistic conditions for Phase1 2024
-    'phase1_2024_realistic'    : '113X_mcRun3_2024_realistic_v4', # GT containing realistic conditions for Phase1 2024
+    'phase1_2024_realistic'    : '113X_mcRun3_2024_realistic_v5', # GT containing realistic conditions for Phase1 2024
     # GlobalTag for MC production with realistic conditions for Phase2
     'phase2_realistic'         : '113X_mcRun4_realistic_v3'
 }


### PR DESCRIPTION
#### PR description:
This PR add to the GTs the `EcalMustacheSCParameters` and `EcalSCDynamicDPhiParameters` that were originally presented in https://indico.cern.ch/event/977708/contributions/4117978/attachments/2148136/3621264/alcadb_ecal_sc_params_pr32066_20201123.pdf
Note that only the MC and offilne GTs are updated, while the HLT/Express/Prompt GTs are not updated due to the presence of an ESProducer (see [these lines](https://github.com/cms-sw/cmssw/pull/32066/files#diff-1a9d4815ade228733027bce4262323f74a4e150052e3d94a5ac6b4b94e0d24deR5-R9) ) that would override the contents of the GTs.

EDIT: as @christopheralanwest pointed out the ESProducer would override these two records for **all** GTs. So no changes are expected in comparison tests for any workflow and a follow-up PR by ECAL experts will disable the relevant ESProducers.


The GT diffs are as follows:

**Run 2 startup**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/113X_mcRun2_startup_v1/113X_mcRun2_startup_v2

**Run 2 (L1 trigger stage 1)**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/113X_mcRun2_asymptotic_l1stage1_v2/113X_mcRun2_asymptotic_l1stage1_v3

**2016 design**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/113X_mcRun2_design_v2/113X_mcRun2_design_v3

**2016 realistic pre-VFP era**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/113X_mcRun2_asymptotic_preVFP_v2/113X_mcRun2_asymptotic_preVFP_v3

**2016 realistic post-VFP era**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/113X_mcRun2_asymptotic_v2/113X_mcRun2_asymptotic_v3

**2016 cosmics (asymptotic conditions)**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/113X_mcRun2cosmics_asymptotic_deco_v2/113X_mcRun2cosmics_asymptotic_deco_v3

**Run 2 heavy ion**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/113X_mcRun2_HeavyIon_v2/113X_mcRun2_HeavyIon_v3

**Run 2 proton-lead**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/113X_mcRun2_pA_v2/113X_mcRun2_pA_v3

**Offline data**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/113X_dataRun2_v3/113X_dataRun2_v4

**Offline data (HEM failure)**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/113X_dataRun2_HEfail_v3/113X_dataRun2_HEfail_v4

**Offline data relval**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/113X_dataRun2_relval_v3/113X_dataRun2_relval_v4

**Prompt-like HI data**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/113X_dataRun2_PromptLike_HI_v3/113X_dataRun2_PromptLike_HI_v4

**2017 design**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/113X_mc2017_design_v3/113X_mc2017_design_v4

**2017 realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/113X_mc2017_realistic_v3/113X_mc2017_realistic_v4

**2017 realistic cosmics (tracker deco mode)**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/113X_mc2017cosmics_realistic_deco_v3/113X_mc2017cosmics_realistic_deco_v4

**2017 realistic cosmics (tracker peak mode)**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/113X_mc2017cosmics_realistic_peak_v3/113X_mc2017cosmics_realistic_peak_v4

**2018 design**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/113X_upgrade2018_design_v3/113X_upgrade2018_design_v4

**2018 realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/113X_upgrade2018_realistic_v3/113X_upgrade2018_realistic_v4

**2018 Run-dependent MC**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/113X_upgrade2018_realistic_RD_v1/113X_upgrade2018_realistic_RD_v2

**2018 heavy ion**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/113X_upgrade2018_realistic_HI_v3/113X_upgrade2018_realistic_HI_v4

**2018 realistic (HEM15/16 failure)**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/113X_upgrade2018_realistic_HEfail_v3/113X_upgrade2018_realistic_HEfail_v4

**2018 cosmics (tracker deco mode)**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/113X_upgrade2018cosmics_realistic_deco_v3/113X_upgrade2018cosmics_realistic_deco_v4

**2018 cosmics (tracker peak mode)**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/113X_upgrade2018cosmics_realistic_peak_v3/113X_upgrade2018cosmics_realistic_peak_v4

**2021 design**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/113X_mcRun3_2021_design_v4/113X_mcRun3_2021_design_v5

**2021 realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/113X_mcRun3_2021_realistic_v4/113X_mcRun3_2021_realistic_v7

**2021 cosmics**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/113X_mcRun3_2021cosmics_realistic_deco_v5/113X_mcRun3_2021cosmics_realistic_deco_v6

**2021 heavy ion**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/113X_mcRun3_2021_realistic_HI_v4/113X_mcRun3_2021_realistic_HI_v5

**2023 realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/113X_mcRun3_2023_realistic_v4/113X_mcRun3_2023_realistic_v5

**2024 realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/113X_mcRun3_2024_realistic_v4/113X_mcRun3_2024_realistic_v5


#### PR validation:
A technical test was performed:
`runTheMatrix.py -l limited,12024.0,7.23,159.0,12834.0,7.4,11024.2,11224.0,7.21,7.24,10424.0,136.8642,7.22,1325.516 --ibeos -j 9`

#### if this PR is a backport please specify the original PR and why you need to backport that PR:
This PR is not a backport, but it will be backported to 112X.
