### PR TITLE
Modifier for v8nano

### DIFF
--- a/Configuration/Eras/python/Modifier_run2_nanoAOD_devel_cff.py
+++ b/Configuration/Eras/python/Modifier_run2_nanoAOD_devel_cff.py
@@ -1,0 +1,3 @@
+import FWCore.ParameterSet.Config as cms
+
+run2_nanoAOD_devel = cms.Modifier()

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -450,8 +450,7 @@ steps['RunNoBPTX2018C']={'INPUT':InputInfo(dataSet='/NoBPTX/Run2018C-v1/RAW',lab
 steps['RunDisplacedJet2018C']={'INPUT':InputInfo(dataSet='/DisplacedJet/Run2018C-v1/RAW',label='2018C',events=100000,location='STD', ls=Run2018C)}
 steps['RunCharmonium2018C']={'INPUT':InputInfo(dataSet='/Charmonium/Run2018C-v1/RAW',label='2018C',events=100000,location='STD', ls=Run2018C)}
 
-Run2018Cpilot={319348: [[1, 100]]}
-steps['RunJetHT2018C_nanoULremini']={'INPUT':InputInfo(dataSet='/JetHT/Run2018C-UL2018_MiniAODv2_pilot1-v1/MINIAOD',label='2018C',events=100000,location='STD', ls=Run2018Cpilot)}
+steps['RunJetHT2018C_nanoULremini']={'INPUT':InputInfo(dataSet='/JetHT/Run2018C-UL2018_MiniAODv2-v1/MINIAOD',label='2018C',events=100000,location='STD', ls=Run2018C)}
 
 #### run2 2018D ####
 Run2018D={320822: [[1, 100]]}

--- a/PhysicsTools/NanoAOD/python/nano_cff.py
+++ b/PhysicsTools/NanoAOD/python/nano_cff.py
@@ -121,7 +121,7 @@ nanoSequenceFS = cms.Sequence(genParticleSequence + genVertexTables + particleLe
 
 (run2_nanoAOD_92X | run2_miniAOD_80XLegacy | run2_nanoAOD_94X2016 | run2_nanoAOD_94X2016 | \
     run2_nanoAOD_94XMiniAODv1 | run2_nanoAOD_94XMiniAODv2 | \
-    run2_nanoAOD_102Xv1).toReplaceWith(nanoSequenceFS, nanoSequenceFS.copyAndExclude([genVertexTable, genVertexT0Table]))
+    run2_nanoAOD_102Xv1 | ( run2_nanoAOD_106Xv1 and ~run2_nanoAOD_devel) ).toReplaceWith(nanoSequenceFS, nanoSequenceFS.copyAndExclude([genVertexTable, genVertexT0Table]))
 
 # GenVertex only stored in newer MiniAOD
 nanoSequenceMC = nanoSequenceFS.copy()

--- a/PhysicsTools/NanoAOD/python/nano_cff.py
+++ b/PhysicsTools/NanoAOD/python/nano_cff.py
@@ -117,11 +117,13 @@ nanoSequenceOnlyData = cms.Sequence(protonTables + lhcInfoTable)
 
 nanoSequence = cms.Sequence(nanoSequenceCommon + nanoSequenceOnlyData + nanoSequenceOnlyFullSim)
 
+( run2_nanoAOD_106Xv1 and ~run2_nanoAOD_devel).toReplaceWith(nanoSequence, nanoSequence.copyAndExclude([nanoSequenceOnlyData]))
+
 nanoSequenceFS = cms.Sequence(genParticleSequence + genVertexTables + particleLevelSequence + nanoSequenceCommon + jetMC + muonMC + electronMC + photonMC + tauMC + metMC + ttbarCatMCProducers +  globalTablesMC + btagWeightTable + genWeightsTable + genVertexTable + genParticleTables + particleLevelTables + lheInfoTable  + ttbarCategoryTable )
 
 (run2_nanoAOD_92X | run2_miniAOD_80XLegacy | run2_nanoAOD_94X2016 | run2_nanoAOD_94X2016 | \
     run2_nanoAOD_94XMiniAODv1 | run2_nanoAOD_94XMiniAODv2 | \
-    run2_nanoAOD_102Xv1 | ( run2_nanoAOD_106Xv1 and ~run2_nanoAOD_devel) ).toReplaceWith(nanoSequenceFS, nanoSequenceFS.copyAndExclude([genVertexTable, genVertexT0Table]))
+    run2_nanoAOD_102Xv1 ).toReplaceWith(nanoSequenceFS, nanoSequenceFS.copyAndExclude([genVertexTable, genVertexT0Table]))
 
 # GenVertex only stored in newer MiniAOD
 nanoSequenceMC = nanoSequenceFS.copy()

--- a/PhysicsTools/NanoAOD/python/nano_eras_cff.py
+++ b/PhysicsTools/NanoAOD/python/nano_eras_cff.py
@@ -17,4 +17,6 @@ from Configuration.Eras.Modifier_run2_nanoAOD_102Xv1_cff import run2_nanoAOD_102
 from Configuration.Eras.Modifier_run2_nanoAOD_106Xv1_cff import run2_nanoAOD_106Xv1
 from Configuration.Eras.Modifier_run2_nanoAOD_106Xv2_cff import run2_nanoAOD_106Xv2
 
+from Configuration.Eras.Modifier_run2_nanoAOD_devel_cff import run2_nanoAOD_devel
+
 from Configuration.Eras.Modifier_run2_miniAOD_devel_cff import run2_miniAOD_devel

--- a/PhysicsTools/NanoAOD/python/protons_cff.py
+++ b/PhysicsTools/NanoAOD/python/protons_cff.py
@@ -65,5 +65,6 @@ protonTables = cms.Sequence(
 
 if singleRPProtons: protonTables.insert(protonTables.index(multiRPTable),singleRPTable)
 
-for modifier in run2_miniAOD_80XLegacy, run2_nanoAOD_94XMiniAODv1, run2_nanoAOD_94XMiniAODv2, run2_nanoAOD_94X2016, run2_nanoAOD_102Xv1:
-    modifier.toReplaceWith(protonTables, cms.Sequence())
+(run2_nanoAOD_92X | run2_miniAOD_80XLegacy | run2_nanoAOD_94X2016 | run2_nanoAOD_94X2016 | \
+    run2_nanoAOD_94XMiniAODv1 | run2_nanoAOD_94XMiniAODv2 | \
+    run2_nanoAOD_102Xv1 | ( run2_nanoAOD_106Xv1 and ~run2_nanoAOD_devel) ).toReplaceWith(protonTables, cms.Sequence())


### PR DESCRIPTION
this modifier run2_nanoAOD_devel can be used to protect ongoing production.
i.e. the one using the run2_nanoAOD_106Xv1 
in this PR I correct the PPS recently added

All new nano features in 10_6 can be added like:
(run2_nanoAOD_106Xv1 and ~run2_nanoAOD_devel).toModify(xyzTable , xyxVariable = None)

+ replace pilot as already done in 11_2 and 11_3