### PR TITLE
Update hlt customisations 11.2.x

### DIFF
--- a/HLTrigger/Configuration/python/Tools/confdb.py
+++ b/HLTrigger/Configuration/python/Tools/confdb.py
@@ -86,7 +86,9 @@ class HLTProcess(object):
       args = ['--runNumber', self.config.menu.run]
     else:
       args = ['--configName', self.config.menu.name ]
-    args.append('--noedsources')
+    if not self.config.hilton:
+        # keep the original Source when running on Hilton
+        args.append('--noedsources')
     for key, vals in six.iteritems(self.options):
       if vals:
         args.extend(('--'+key, ','.join(vals)))
@@ -181,6 +183,9 @@ class HLTProcess(object):
 from HLTrigger.Configuration.customizeHLTforALL import customizeHLTforAll
 fragment = customizeHLTforAll(fragment,"%s")
 """ % (self.config.type)
+    elif self.config.hilton:
+      # do not apply the STORM-specific customisation
+      pass
     else:
       if self.config.type=="Fake":
         prefix = "run1"
@@ -232,6 +237,7 @@ modifyHLTforEras(%(process)s)
             self.data += "from "+customiseValues[0]+" import "+customiseValues[1]+"\n"
             self.data += "process = "+customiseValues[1]+"(process)\n"
 
+
   # customize the configuration according to the options
   def customize(self):
 
@@ -268,7 +274,7 @@ modifyHLTforEras(%(process)s)
 
     if self.config.fragment:
       self.data += """
-# dummyfy hltGetConditions in cff's
+# dummify hltGetConditions in cff's
 if 'hltGetConditions' in %(dict)s and 'HLTriggerFirstPath' in %(dict)s :
     %(process)s.hltDummyConditions = cms.EDFilter( "HLTBool",
         result = cms.bool( True )
@@ -326,7 +332,6 @@ if 'hltGetConditions' in %(dict)s and 'HLTriggerFirstPath' in %(dict)s :
     wantSummary = cms.untracked.bool( True ),
     numberOfThreads = cms.untracked.uint32( 4 ),
     numberOfStreams = cms.untracked.uint32( 0 ),
-    sizeOfStackForThreadsInKB = cms.untracked.uint32( 10*1024 )
 )
 """
 
@@ -460,12 +465,13 @@ from HLTrigger.Configuration.CustomConfigs import L1REPACK
       self.data += text
 
   def overrideOutput(self):
-    # override the "online" ShmStreamConsumer output modules with "offline" PoolOutputModule's
-    self.data = re.sub(
-      r'\b(process\.)?hltOutput(\w+) *= *cms\.OutputModule\( *"ShmStreamConsumer" *,',
-      r'%(process)s.hltOutput\2 = cms.OutputModule( "PoolOutputModule",\n    fileName = cms.untracked.string( "output\2.root" ),\n    fastCloning = cms.untracked.bool( False ),\n    dataset = cms.untracked.PSet(\n        filterName = cms.untracked.string( "" ),\n        dataTier = cms.untracked.string( "RAW" )\n    ),',
-      self.data
-    )
+    # if not runnign on Hilton, override the "online" ShmStreamConsumer output modules with "offline" PoolOutputModule's
+    if not self.config.hilton:
+      self.data = re.sub(
+        r'\b(process\.)?hltOutput(\w+) *= *cms\.OutputModule\( *"ShmStreamConsumer" *,',
+        r'%(process)s.hltOutput\2 = cms.OutputModule( "PoolOutputModule",\n    fileName = cms.untracked.string( "output\2.root" ),\n    fastCloning = cms.untracked.bool( False ),\n    dataset = cms.untracked.PSet(\n        filterName = cms.untracked.string( "" ),\n        dataTier = cms.untracked.string( "RAW" )\n    ),',
+        self.data
+      )
 
     if not self.config.fragment and self.config.output == 'minimal':
       # add a single output to keep the TriggerResults and TriggerEvent
@@ -546,6 +552,7 @@ if 'MessageLogger' in %(dict)s:
     %(process)s.MessageLogger.categories.append('L1TGlobalSummary')
     %(process)s.MessageLogger.categories.append('HLTrigReport')
     %(process)s.MessageLogger.categories.append('FastReport')
+    %(process)s.MessageLogger.categories.append('ThroughputService')
 """
 
 
@@ -852,6 +859,10 @@ if 'GlobalTag' in %%(dict)s:
     return files
 
   def build_source(self):
+    if self.config.hilton:
+      # use the DAQ source
+      return
+
     if self.config.input:
       # if a dataset or a list of input files was given, use it
       self.source = self.expand_filenames(self.config.input)

--- a/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
+++ b/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
@@ -202,6 +202,8 @@ def customiseFor2018Input(process):
     process = customisePixelGainForRun2Input(process)
     process = synchronizeHCALHLTofflineRun3on2018data(process)
 
+    return process
+
 
 # CMSSW version specific customizations
 def customizeHLTforCMSSW(process, menuType="GRun"):


### PR DESCRIPTION
#### PR description:

Extend the functionality of the `hltGetConfiguration --hilton` option:
  - use the DAQ source and output modules
  - do not apply the STORM-specific customisation

#### PR validation:

None.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Backport #32961 to the CMSSW 11.2.x stable branch.