### PR TITLE
Add SV charge [112X]

### DIFF
--- a/PhysicsTools/NanoAOD/plugins/VertexTableProducer.cc
+++ b/PhysicsTools/NanoAOD/plugins/VertexTableProducer.cc
@@ -143,6 +143,7 @@ void VertexTableProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSe
   iEvent.getByToken(svs_, svsIn);
   auto selCandSv = std::make_unique<PtrVector<reco::Candidate>>();
   std::vector<float> dlen, dlenSig, pAngle, dxy, dxySig;
+  std::vector<int> charge;
   VertexDistance3D vdist;
   VertexDistanceXY vdistXY;
 
@@ -164,6 +165,13 @@ void VertexTableProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSe
             PV0, VertexState(RecoVertex::convertPos(sv.position()), RecoVertex::convertError(sv.error())));
         dxy.push_back(d2d.value());
         dxySig.push_back(d2d.significance());
+
+	int sum_charge = 0;
+        for (unsigned int id = 0; id < sv.numberOfDaughters(); ++id) {
+          const reco::Candidate* daughter = sv.daughter(id);
+          sum_charge += daughter->charge();
+        }
+        charge.push_back(sum_charge);
       }
     }
     i++;
@@ -176,6 +184,7 @@ void VertexTableProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSe
   svsTable->addColumn<float>("dxy", dxy, "2D decay length in cm", 10);
   svsTable->addColumn<float>("dxySig", dxySig, "2D decay length significance", 10);
   svsTable->addColumn<float>("pAngle", pAngle, "pointing angle, i.e. acos(p_SV * (SV - PV)) ", 10);
+  svsTable->addColumn<int>("charge", charge, "sum of the charge of the SV tracks", 10);
 
   iEvent.put(std::move(pvTable), "pv");
   iEvent.put(std::move(otherPVsTable), "otherPVs");

--- a/PhysicsTools/NanoAOD/python/nanoDQM_cfi.py
+++ b/PhysicsTools/NanoAOD/python/nanoDQM_cfi.py
@@ -634,6 +634,7 @@ nanoDQM = DQMEDAnalyzer("NanoAODDQM",
                 Plot1D('y', 'y', 20, -0.5, 0.5, 'secondary vertex Y position, in cm'),
                 Plot1D('z', 'z', 20, -10, 10, 'secondary vertex Z position, in cm'),
                 Plot1D('ntracks', 'ntracks', 11, -0.5, 10.5, 'number of tracks'),
+                Plot1D('charge', 'charge', 11 , -0.5, 10.5, 'sum of the charge of the SV tracks'),
             )
         ),
         SoftActivityJet = cms.PSet(


### PR DESCRIPTION
**PR description:**
Add the sum of the charge of the tracks associated to each SV.
Needed for BTV, Charm tagging calibration in the W+c channel, and analyses

Backport of https://github.com/cms-sw/cmssw/pull/32874
