### PR TITLE
Adding HGCAL SuperCluster Regressions : 111X

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -79,7 +79,7 @@ autoCond = {
     # GlobalTag for MC production with realistic conditions for Phase1 2024
     'phase1_2024_realistic'    : '111X_mcRun3_2024_realistic_v7', # GT containing realistic conditions for Phase1 2024
     # GlobalTag for MC production with realistic conditions for Phase2
-    'phase2_realistic'         : '111X_mcRun4_realistic_T15_v4'
+    'phase2_realistic'         : '111X_mcRun4_realistic_T15_v5'
 }
 
 aliases = {

--- a/DataFormats/Common/src/classes_def.xml
+++ b/DataFormats/Common/src/classes_def.xml
@@ -147,12 +147,14 @@
  <class name="edm::ValueMap<float>" />
  <class name="edm::ValueMap<double>" />
  <class name="edm::ValueMap<std::pair<float, float>>" />
+ <class name="edm::ValueMap<std::vector<float>>" />
  <class name="edm::Wrapper<edm::ValueMap<int> >" splitLevel="0"/>
  <class name="edm::Wrapper<edm::ValueMap<bool> >" splitLevel="0"/>
  <class name="edm::Wrapper<edm::ValueMap<unsigned int> >" splitLevel="0"/>
  <class name="edm::Wrapper<edm::ValueMap<float> >" splitLevel="0"/>
  <class name="edm::Wrapper<edm::ValueMap<double> >" splitLevel="0"/>
  <class name="edm::Wrapper<edm::ValueMap<std::pair<float, float>> >" splitLevel="0"/>
+ <class name="edm::Wrapper<edm::ValueMap<std::vector<float>> >" splitLevel="0"/>
  <class name="std::vector<edm::EventAuxiliary>"/>
  <class name="edm::Wrapper<std::vector<edm::EventAuxiliary> >"/>
  <class name="edm::Wrapper<std::vector<edm::ErrorSummaryEntry> >"/>

--- a/DataFormats/WrappedStdDictionaries/src/classes_def.xml
+++ b/DataFormats/WrappedStdDictionaries/src/classes_def.xml
@@ -48,6 +48,7 @@
  <class name="edm::Wrapper<std::vector<unsigned short> >"/>
  <class name="edm::Wrapper<std::vector<std::pair<int,int>>>"/>
  <class name="edm::Wrapper<std::vector<std::pair<unsigned int,float>>>"/>
+ <class name="edm::Wrapper<std::vector<std::vector<float>>>"/>
  <class name="edm::Wrapper<unsigned char>"/>
  <class name="edm::Wrapper<unsigned int>"/>
  <class name="edm::Wrapper<unsigned long>"/>

--- a/DataFormats/WrappedStdDictionaries/src/classes_def.xml
+++ b/DataFormats/WrappedStdDictionaries/src/classes_def.xml
@@ -48,7 +48,6 @@
  <class name="edm::Wrapper<std::vector<unsigned short> >"/>
  <class name="edm::Wrapper<std::vector<std::pair<int,int>>>"/>
  <class name="edm::Wrapper<std::vector<std::pair<unsigned int,float>>>"/>
- <class name="edm::Wrapper<std::vector<std::vector<float>>>"/>
  <class name="edm::Wrapper<unsigned char>"/>
  <class name="edm::Wrapper<unsigned int>"/>
  <class name="edm::Wrapper<unsigned long>"/>

--- a/RecoEcal/EgammaClusterAlgos/BuildFile.xml
+++ b/RecoEcal/EgammaClusterAlgos/BuildFile.xml
@@ -3,12 +3,15 @@
 <use name="DataFormats/EcalRecHit"/>
 <use name="DataFormats/EgammaReco"/>
 <use name="DataFormats/Math"/>
+<use name="DataFormats/ParticleFlowReco"/>
+<use name="DataFormats/VertexReco"/>
 <use name="CondFormats/ESObjects"/>
 <use name="CondFormats/EgammaObjects"/>
 <use name="CondFormats/DataRecord"/>
 <use name="RecoEcal/EgammaCoreTools"/>
 <use name="Geometry/CaloGeometry"/>
 <use name="Geometry/CaloTopology"/>
+<use name="RecoEgamma/EgammaTools"/>
 <use name="RecoParticleFlow/PFClusterTools"/>
 <use name="clhep"/>
 <export>

--- a/RecoEcal/EgammaClusterAlgos/interface/SCEnergyCorrectorSemiParm.h
+++ b/RecoEcal/EgammaClusterAlgos/interface/SCEnergyCorrectorSemiParm.h
@@ -29,7 +29,7 @@
 #include "DataFormats/EcalDetId/interface/EcalSubdetector.h"
 #include "DataFormats/ParticleFlowReco/interface/PFRecHit.h"
 #include "DataFormats/VertexReco/interface/VertexFwd.h"
-#include "CondFormats/GBRForest/interface/GBRForestD.h"
+#include "CondFormats/EgammaObjects/interface/GBRForestD.h"
 #include "CondFormats/DataRecord/interface/GBRDWrapperRcd.h"
 #include "RecoEgamma/EgammaTools/interface/EgammaBDTOutputTransformer.h"
 #include "RecoEgamma/EgammaTools/interface/HGCalShowerShapeHelper.h"

--- a/RecoEcal/EgammaClusterAlgos/interface/SCEnergyCorrectorSemiParm.h
+++ b/RecoEcal/EgammaClusterAlgos/interface/SCEnergyCorrectorSemiParm.h
@@ -5,71 +5,183 @@
 //
 // Helper Class for applying regression-based energy corrections with optimized BDT implementation
 //
-// Authors: J.Bendavid
+// Original Author: J.Bendavid
+//
+// Refactored, modernised and extended to HGCAL by S. Harper (RAL/CERN)
+// with input from S. Bhattacharya (DESY)
 //--------------------------------------------------------------------------------------------------
 
 #ifndef RecoEcal_EgammaClusterAlgos_SCEnergyCorrectorSemiParm_h
 #define RecoEcal_EgammaClusterAlgos_SCEnergyCorrectorSemiParm_h
 
+#include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
-
-#include "DataFormats/VertexReco/interface/VertexFwd.h"
-#include "CondFormats/EgammaObjects/interface/GBRForestD.h"
-#include "DataFormats/EcalRecHit/interface/EcalRecHit.h"
-#include "DataFormats/EcalRecHit/interface/EcalRecHitCollections.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "Geometry/CaloEventSetup/interface/CaloTopologyRecord.h"
 #include "Geometry/CaloTopology/interface/CaloTopology.h"
 #include "Geometry/Records/interface/CaloGeometryRecord.h"
 #include "Geometry/CaloGeometry/interface/CaloGeometry.h"
-#include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "DataFormats/EgammaReco/interface/SuperCluster.h"
-#include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/ESHandle.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "DataFormats/EcalRecHit/interface/EcalRecHit.h"
+#include "DataFormats/EcalRecHit/interface/EcalRecHitCollections.h"
+#include "DataFormats/EcalDetId/interface/EcalSubdetector.h"
+#include "DataFormats/ParticleFlowReco/interface/PFRecHit.h"
+#include "DataFormats/VertexReco/interface/VertexFwd.h"
+#include "CondFormats/GBRForest/interface/GBRForestD.h"
+#include "CondFormats/DataRecord/interface/GBRDWrapperRcd.h"
+#include "RecoEgamma/EgammaTools/interface/EgammaBDTOutputTransformer.h"
+#include "RecoEgamma/EgammaTools/interface/HGCalShowerShapeHelper.h"
 
 class SCEnergyCorrectorSemiParm {
 public:
   SCEnergyCorrectorSemiParm();
-  ~SCEnergyCorrectorSemiParm();
+  //if you want override the default on where conditions are consumed, you need to use
+  //the other constructor and then call setTokens approprately
+  SCEnergyCorrectorSemiParm(const edm::ParameterSet& iConfig, edm::ConsumesCollector cc);
 
-  void setTokens(const edm::ParameterSet &iConfig, edm::ConsumesCollector &cc);
+  static void fillPSetDescription(edm::ParameterSetDescription& desc);
+  static edm::ParameterSetDescription makePSetDescription();
 
-  std::pair<double, double> getCorrections(const reco::SuperCluster &sc) const;
-  void modifyObject(reco::SuperCluster &sc);
+  template <edm::Transition tr = edm::Transition::BeginLuminosityBlock>
+  void setTokens(const edm::ParameterSet& iConfig, edm::ConsumesCollector cc);
 
-  void setEventSetup(const edm::EventSetup &es);
-  void setEvent(const edm::Event &e);
+  void setEventSetup(const edm::EventSetup& es);
+  void setEvent(const edm::Event& e);
+
+  std::pair<double, double> getCorrections(const reco::SuperCluster& sc) const;
+  void modifyObject(reco::SuperCluster& sc) const;
+
+  std::vector<float> getRegData(const reco::SuperCluster& sc) const;
 
 protected:
-  const GBRForestD *foresteb_;
-  const GBRForestD *forestee_;
-  const GBRForestD *forestsigmaeb_;
-  const GBRForestD *forestsigmaee_;
+  class RegParam {
+  public:
+    RegParam(std::string meanKey = "",
+             float meanLow = 0,
+             float meanHigh = 0,
+             std::string sigmaKey = "",
+             float sigmaLow = 0,
+             float sigmaHigh = 0)
+        : meanKey_(std::move(meanKey)),
+          sigmaKey_(std::move(sigmaKey)),
+          meanOutTrans_(meanLow, meanHigh),
+          sigmaOutTrans_(sigmaLow, sigmaHigh) {}
+    RegParam(edm::ConsumesCollector cc,
+             std::string meanKey = "",
+             float meanLow = 0,
+             float meanHigh = 0,
+             std::string sigmaKey = "",
+             float sigmaLow = 0,
+             float sigmaHigh = 0)
+        : RegParam(meanKey, meanLow, meanHigh, sigmaKey, sigmaLow, sigmaHigh) {
+      setTokens(cc);
+    }
+    template <edm::Transition esTransition = edm::Transition::BeginLuminosityBlock>
+    void setTokens(edm::ConsumesCollector cc);
+    void setForests(const edm::EventSetup& setup);
 
-  edm::ESHandle<CaloTopology> calotopo_;
-  edm::ESHandle<CaloGeometry> calogeom_;
+    double mean(const std::vector<float>& data) const;
+    double sigma(const std::vector<float>& data) const;
+
+  private:
+    std::string meanKey_;
+    std::string sigmaKey_;
+    EgammaBDTOutputTransformer meanOutTrans_;
+    EgammaBDTOutputTransformer sigmaOutTrans_;
+    edm::ESHandle<GBRForestD> meanForest_;
+    edm::ESHandle<GBRForestD> sigmaForest_;
+    edm::ESGetToken<GBRForestD, GBRDWrapperRcd> meanForestToken_;
+    edm::ESGetToken<GBRForestD, GBRDWrapperRcd> sigmaForestToken_;
+  };
+
+  //barrel = always ecal barrel, endcap may be ECAL or HGCAL
+  RegParam regParamBarrel_;
+  RegParam regParamEndcap_;
+
+  edm::ESHandle<CaloTopology> caloTopo_;
+  edm::ESHandle<CaloGeometry> caloGeom_;
+  edm::ESGetToken<CaloTopology, CaloTopologyRecord> caloTopoToken_;
+  edm::ESGetToken<CaloGeometry, CaloGeometryRecord> caloGeomToken_;
 
   edm::EDGetTokenT<EcalRecHitCollection> tokenEBRecHits_;
   edm::EDGetTokenT<EcalRecHitCollection> tokenEERecHits_;
+  edm::EDGetTokenT<reco::PFRecHitCollection> tokenHgcalRecHits_;
   edm::EDGetTokenT<reco::VertexCollection> tokenVertices_;
 
+  edm::Handle<EcalRecHitCollection> recHitsEB_;
+  edm::Handle<EcalRecHitCollection> recHitsEE_;
+  edm::Handle<reco::PFRecHitCollection> recHitsHgcal_;
   edm::Handle<reco::VertexCollection> vertices_;
-  edm::Handle<EcalRecHitCollection> rechitsEB_;
-  edm::Handle<EcalRecHitCollection> rechitsEE_;
 
   edm::InputTag ecalHitsEBInputTag_;
   edm::InputTag ecalHitsEEInputTag_;
+  edm::InputTag hgcalHitsInputTag_;
+
   edm::InputTag vertexInputTag_;
 
-  std::string regressionKeyEB_;
-  std::string uncertaintyKeyEB_;
-  std::string regressionKeyEE_;
-  std::string uncertaintyKeyEE_;
+  //returns barrel for ecal barrel, otherwise returns endcap
+  const RegParam& getRegParam(const DetId& detId) const {
+    return detId.det() == DetId::Ecal && detId.subdetId() == EcalBarrel ? regParamBarrel_ : regParamEndcap_;
+  }
 
 private:
+  float getInputEnergy(const reco::SuperCluster& sc) const;
+  std::vector<float> getRegDataECALV1(const reco::SuperCluster& sc) const;
+  std::vector<float> getRegDataECALHLTV1(const reco::SuperCluster& sc) const;
+  std::vector<float> getRegDataHGCALV1(const reco::SuperCluster& sc) const;
+  std::vector<float> getRegDataHGCALHLTV1(const reco::SuperCluster& sc) const;
+
   bool isHLT_;
+  bool isPhaseII_;
   bool applySigmaIetaIphiBug_;  //there was a bug in sigmaIetaIphi for the 74X application
-  int nHitsAboveThreshold_;
-  float eThreshold_;
+  int nHitsAboveThresholdEB_;
+  int nHitsAboveThresholdEE_;
+  int nHitsAboveThresholdHG_;
+  float hitsEnergyThreshold_;
+  float hgcalCylinderR_;
+  HGCalShowerShapeHelper hgcalShowerShapes_;
 };
+template <edm::Transition esTransition>
+void SCEnergyCorrectorSemiParm::RegParam::setTokens(edm::ConsumesCollector cc) {
+  meanForestToken_ = cc.esConsumes<GBRForestD, GBRDWrapperRcd, esTransition>(edm::ESInputTag("", meanKey_));
+  sigmaForestToken_ = cc.esConsumes<GBRForestD, GBRDWrapperRcd, esTransition>(edm::ESInputTag("", sigmaKey_));
+}
+
+template <edm::Transition esTransition>
+void SCEnergyCorrectorSemiParm::setTokens(const edm::ParameterSet& iConfig, edm::ConsumesCollector cc) {
+  isHLT_ = iConfig.getParameter<bool>("isHLT");
+  isPhaseII_ = iConfig.getParameter<bool>("isPhaseII");
+  applySigmaIetaIphiBug_ = iConfig.getParameter<bool>("applySigmaIetaIphiBug");
+  tokenEBRecHits_ = cc.consumes<EcalRecHitCollection>(iConfig.getParameter<edm::InputTag>("ecalRecHitsEB"));
+  if (not isPhaseII_) {
+    tokenEERecHits_ = cc.consumes<EcalRecHitCollection>(iConfig.getParameter<edm::InputTag>("ecalRecHitsEE"));
+  } else {
+    tokenHgcalRecHits_ = cc.consumes<reco::PFRecHitCollection>(iConfig.getParameter<edm::InputTag>("hgcalRecHits"));
+    hgcalCylinderR_ = iConfig.getParameter<double>("hgcalCylinderR");
+    hgcalShowerShapes_.setTokens<esTransition>(cc);
+  }
+  caloGeomToken_ = cc.esConsumes<CaloGeometry, CaloGeometryRecord, esTransition>();
+  caloTopoToken_ = cc.esConsumes<CaloTopology, CaloTopologyRecord, esTransition>();
+
+  regParamBarrel_ = RegParam(iConfig.getParameter<std::string>("regressionKeyEB"),
+                             iConfig.getParameter<double>("regressionMinEB"),
+                             iConfig.getParameter<double>("regressionMaxEB"),
+                             iConfig.getParameter<std::string>("uncertaintyKeyEB"),
+                             iConfig.getParameter<double>("uncertaintyMinEB"),
+                             iConfig.getParameter<double>("uncertaintyMaxEB"));
+  regParamBarrel_.setTokens<esTransition>(cc);
+  regParamEndcap_ = RegParam(iConfig.getParameter<std::string>("regressionKeyEE"),
+                             iConfig.getParameter<double>("regressionMinEE"),
+                             iConfig.getParameter<double>("regressionMaxEE"),
+                             iConfig.getParameter<std::string>("uncertaintyKeyEE"),
+                             iConfig.getParameter<double>("uncertaintyMinEE"),
+                             iConfig.getParameter<double>("uncertaintyMaxEE"));
+  regParamEndcap_.setTokens<esTransition>(cc);
+  hitsEnergyThreshold_ = iConfig.getParameter<double>("eRecHitThreshold");
+  if (not isHLT_) {
+    tokenVertices_ = cc.consumes<reco::VertexCollection>(iConfig.getParameter<edm::InputTag>("vertexCollection"));
+  }
+}
 #endif

--- a/RecoEcal/EgammaClusterAlgos/interface/SCEnergyCorrectorSemiParm.h
+++ b/RecoEcal/EgammaClusterAlgos/interface/SCEnergyCorrectorSemiParm.h
@@ -127,7 +127,6 @@ protected:
   }
 
 private:
-  float getInputEnergy(const reco::SuperCluster& sc) const;
   std::vector<float> getRegDataECALV1(const reco::SuperCluster& sc) const;
   std::vector<float> getRegDataECALHLTV1(const reco::SuperCluster& sc) const;
   std::vector<float> getRegDataHGCALV1(const reco::SuperCluster& sc) const;

--- a/RecoEcal/EgammaClusterAlgos/src/SCEnergyCorrectorSemiParm.cc
+++ b/RecoEcal/EgammaClusterAlgos/src/SCEnergyCorrectorSemiParm.cc
@@ -1,320 +1,390 @@
 #include "RecoEcal/EgammaClusterAlgos/interface/SCEnergyCorrectorSemiParm.h"
 
-#include "CondFormats/DataRecord/interface/GBRDWrapperRcd.h"
 #include "RecoEcal/EgammaCoreTools/interface/EcalClusterTools.h"
 #include "DataFormats/EcalDetId/interface/EcalSubdetector.h"
 #include "DataFormats/VertexReco/interface/Vertex.h"
 #include "RecoEcal/EgammaCoreTools/interface/EcalTools.h"
 
 #include "FWCore/Utilities/interface/isFinite.h"
+#include "FWCore/Utilities/interface/Transition.h"
 #include "DataFormats/Math/interface/deltaPhi.h"
 
 #include <vdt/vdtMath.h>
 
 using namespace reco;
 
-//--------------------------------------------------------------------------------------------------
+namespace {
+  std::pair<edm::Ptr<reco::CaloCluster>, float> getMaxDRNonSeedCluster(const reco::SuperCluster& sc) {
+    float maxDR2 = 0.;
+    edm::Ptr<reco::CaloCluster> maxDRClus;
+    const edm::Ptr<reco::CaloCluster>& seedClus = sc.seed();
+
+    for (const auto& clus : sc.clusters()) {
+      if (clus == seedClus) {
+        continue;
+      }
+
+      // find cluster with max dR
+      const double dr2 = reco::deltaR2(*clus, *seedClus);
+      if (dr2 > maxDR2) {
+        maxDR2 = dr2;
+      }
+    }
+    return {maxDRClus, maxDR2 != 0. ? std::sqrt(maxDR2) : 999.};
+  }
+  template <typename T>
+  int countRecHits(const T& recHitHandle, float threshold) {
+    int count = 0;
+    if (recHitHandle.isValid()) {
+      for (const auto& recHit : *recHitHandle) {
+        if (recHit.energy() > threshold) {
+          count++;
+        }
+      }
+    }
+    return count;
+  }
+}  // namespace
+
 SCEnergyCorrectorSemiParm::SCEnergyCorrectorSemiParm()
-    : foresteb_(nullptr),
-      forestee_(nullptr),
-      forestsigmaeb_(nullptr),
-      forestsigmaee_(nullptr),
-      calotopo_(nullptr),
-      calogeom_(nullptr) {}
+    : caloTopo_(nullptr),
+      caloGeom_(nullptr),
+      isHLT_(false),
+      isPhaseII_(false),
+      applySigmaIetaIphiBug_(false),
+      nHitsAboveThresholdEB_(0),
+      nHitsAboveThresholdEE_(0),
+      nHitsAboveThresholdHG_(0),
+      hitsEnergyThreshold_(-1.),
+      hgcalCylinderR_(0.) {}
 
-//--------------------------------------------------------------------------------------------------
-SCEnergyCorrectorSemiParm::~SCEnergyCorrectorSemiParm() {}
+SCEnergyCorrectorSemiParm::SCEnergyCorrectorSemiParm(const edm::ParameterSet& iConfig, edm::ConsumesCollector cc)
+    : SCEnergyCorrectorSemiParm() {
+  setTokens(iConfig, cc);
+}
 
-//--------------------------------------------------------------------------------------------------
-void SCEnergyCorrectorSemiParm::setTokens(const edm::ParameterSet &iConfig, edm::ConsumesCollector &cc) {
-  isHLT_ = iConfig.getParameter<bool>("isHLT");
-  applySigmaIetaIphiBug_ = iConfig.getParameter<bool>("applySigmaIetaIphiBug");
-  tokenEBRecHits_ = cc.consumes<EcalRecHitCollection>(iConfig.getParameter<edm::InputTag>("ecalRecHitsEB"));
-  tokenEERecHits_ = cc.consumes<EcalRecHitCollection>(iConfig.getParameter<edm::InputTag>("ecalRecHitsEE"));
+void SCEnergyCorrectorSemiParm::fillPSetDescription(edm::ParameterSetDescription& desc) {
+  desc.add<bool>("isHLT", false);
+  desc.add<bool>("isPhaseII", false);
+  desc.add<bool>("applySigmaIetaIphiBug", false);
+  desc.add<edm::InputTag>("ecalRecHitsEE", edm::InputTag("ecalRecHit", "EcalRecHitsEE"));
+  desc.add<edm::InputTag>("ecalRecHitsEB", edm::InputTag("ecalRecHit", "EcalRecHitsEB"));
+  desc.add<std::string>("regressionKeyEB", "pfscecal_EBCorrection_offline_v2");
+  desc.add<std::string>("regressionKeyEE", "pfscecal_EECorrection_offline_v2");
+  desc.add<std::string>("uncertaintyKeyEB", "pfscecal_EBUncertainty_offline_v2");
+  desc.add<std::string>("uncertaintyKeyEE", "pfscecal_EEUncertainty_offline_v2");
+  desc.add<double>("regressionMinEB", 0.2);
+  desc.add<double>("regressionMaxEB", 2.0);
+  desc.add<double>("regressionMinEE", 0.2);
+  desc.add<double>("regressionMaxEE", 2.0);
+  desc.add<double>("uncertaintyMinEB", 0.0002);
+  desc.add<double>("uncertaintyMaxEB", 0.5);
+  desc.add<double>("uncertaintyMinEE", 0.0002);
+  desc.add<double>("uncertaintyMaxEE", 0.5);
+  desc.add<edm::InputTag>("vertexCollection", edm::InputTag("offlinePrimaryVertices"));
+  desc.add<double>("eRecHitThreshold", 1.);
+  desc.add<edm::InputTag>("hgcalRecHits", edm::InputTag());
+  desc.add<double>("hgcalCylinderR", 2.8);
+}
 
-  regressionKeyEB_ = iConfig.getParameter<std::string>("regressionKeyEB");
-  uncertaintyKeyEB_ = iConfig.getParameter<std::string>("uncertaintyKeyEB");
-  regressionKeyEE_ = iConfig.getParameter<std::string>("regressionKeyEE");
-  uncertaintyKeyEE_ = iConfig.getParameter<std::string>("uncertaintyKeyEE");
+edm::ParameterSetDescription SCEnergyCorrectorSemiParm::makePSetDescription() {
+  edm::ParameterSetDescription desc;
+  fillPSetDescription(desc);
+  return desc;
+}
 
-  if (not isHLT_) {
-    tokenVertices_ = cc.consumes<reco::VertexCollection>(iConfig.getParameter<edm::InputTag>("vertexCollection"));
+void SCEnergyCorrectorSemiParm::setEventSetup(const edm::EventSetup& es) {
+  caloTopo_ = es.getHandle(caloTopoToken_);
+  caloGeom_ = es.getHandle(caloGeomToken_);
+
+  regParamBarrel_.setForests(es);
+  regParamEndcap_.setForests(es);
+
+  if (isPhaseII_) {
+    hgcalShowerShapes_.initPerSetup(es);
+  }
+}
+
+void SCEnergyCorrectorSemiParm::setEvent(const edm::Event& event) {
+  event.getByToken(tokenEBRecHits_, recHitsEB_);
+  if (!isPhaseII_) {
+    event.getByToken(tokenEERecHits_, recHitsEE_);
   } else {
-    eThreshold_ = iConfig.getParameter<double>("eRecHitThreshold");
+    event.getByToken(tokenHgcalRecHits_, recHitsHgcal_);
+    hgcalShowerShapes_.initPerEvent(*recHitsHgcal_);
+  }
+  if (isHLT_ || isPhaseII_) {
+    //note countRecHits checks the validity of the handle and returns 0
+    //if invalid so its okay to call on all rec-hit collections here
+    nHitsAboveThresholdEB_ = countRecHits(recHitsEB_, hitsEnergyThreshold_);
+    nHitsAboveThresholdEE_ = countRecHits(recHitsEE_, hitsEnergyThreshold_);
+    nHitsAboveThresholdHG_ = countRecHits(recHitsHgcal_, hitsEnergyThreshold_);
+  }
+  if (!isHLT_) {
+    event.getByToken(tokenVertices_, vertices_);
   }
 }
 
-//--------------------------------------------------------------------------------------------------
-void SCEnergyCorrectorSemiParm::setEventSetup(const edm::EventSetup &es) {
-  es.get<CaloTopologyRecord>().get(calotopo_);
-  es.get<CaloGeometryRecord>().get(calogeom_);
+std::pair<double, double> SCEnergyCorrectorSemiParm::getCorrections(const reco::SuperCluster& sc) const {
+  std::pair<double, double> corrEnergyAndRes = {-1, -1};
 
-  edm::ESHandle<GBRForestD> readereb;
-  edm::ESHandle<GBRForestD> readerebvar;
-  edm::ESHandle<GBRForestD> readeree;
-  edm::ESHandle<GBRForestD> readereevar;
+  const auto regData = getRegData(sc);
+  if (regData.empty()) {
+    //supercluster has no valid regression, return default values
+    return corrEnergyAndRes;
+  }
+  const auto& regParam = getRegParam(sc.seed()->seed());
 
-  es.get<GBRDWrapperRcd>().get(regressionKeyEB_, readereb);
-  es.get<GBRDWrapperRcd>().get(uncertaintyKeyEB_, readerebvar);
-  es.get<GBRDWrapperRcd>().get(regressionKeyEE_, readeree);
-  es.get<GBRDWrapperRcd>().get(uncertaintyKeyEE_, readereevar);
+  double mean = regParam.mean(regData);
+  double sigma = regParam.sigma(regData);
 
-  foresteb_ = readereb.product();
-  forestsigmaeb_ = readerebvar.product();
-  forestee_ = readeree.product();
-  forestsigmaee_ = readereevar.product();
+  const double energyCorr = mean * getInputEnergy(sc);
+  const double resolutionEst = sigma * energyCorr;
+
+  corrEnergyAndRes.first = energyCorr;
+  corrEnergyAndRes.second = resolutionEst;
+
+  return corrEnergyAndRes;
 }
 
-//--------------------------------------------------------------------------------------------------
-void SCEnergyCorrectorSemiParm::setEvent(const edm::Event &e) {
-  e.getByToken(tokenEBRecHits_, rechitsEB_);
-  e.getByToken(tokenEERecHits_, rechitsEE_);
-
-  if (not isHLT_)
-    e.getByToken(tokenVertices_, vertices_);
-  else {
-    nHitsAboveThreshold_ = 0;
-    const EcalRecHitCollection *recHitsEB = (rechitsEB_.isValid() ? rechitsEB_.product() : nullptr);
-    const EcalRecHitCollection *recHitsEE = (rechitsEE_.isValid() ? rechitsEE_.product() : nullptr);
-
-    if (nullptr != recHitsEB) {
-      for (EcalRecHitCollection::const_iterator it = recHitsEB->begin(); it != recHitsEB->end(); ++it) {
-        if (it->energy() > eThreshold_)
-          nHitsAboveThreshold_++;
-      }
-    }
-
-    if (nullptr != recHitsEE) {
-      for (EcalRecHitCollection::const_iterator it = recHitsEE->begin(); it != recHitsEE->end(); ++it) {
-        if (it->energy() > eThreshold_)
-          nHitsAboveThreshold_++;
-      }
-    }
+void SCEnergyCorrectorSemiParm::modifyObject(reco::SuperCluster& sc) const {
+  std::pair<double, double> cor = getCorrections(sc);
+  if (cor.first < 0)
+    return;
+  sc.setEnergy(cor.first);
+  sc.setCorrectedEnergy(cor.first);
+  if (cor.second >= 0) {
+    sc.setCorrectedEnergyUncertainty(cor.second);
   }
 }
 
-//--------------------------------------------------------------------------------------------------
-std::pair<double, double> SCEnergyCorrectorSemiParm::getCorrections(const reco::SuperCluster &sc) const {
-  std::pair<double, double> p;
-  p.first = -1;
-  p.second = -1;
+std::vector<float> SCEnergyCorrectorSemiParm::getRegData(const reco::SuperCluster& sc) const {
+  switch (sc.seed()->seed().det()) {
+    case DetId::Ecal:
+      if (isPhaseII_ && sc.seed()->seed().subdetId() == EcalEndcap) {
+        throw cms::Exception("ConfigError") << " Error in SCEnergyCorrectorSemiParm: "
+                                            << " running over events with EcalEndcap clusters while enabling "
+                                               "isPhaseII, please set isPhaseII = False in regression config";
+      }
+      return isHLT_ ? getRegDataECALHLTV1(sc) : getRegDataECALV1(sc);
+    case DetId::HGCalEE:
+      if (!isPhaseII_) {
+        throw cms::Exception("ConfigError") << " Error in SCEnergyCorrectorSemiParm: "
+                                            << " running over PhaseII events without enabling isPhaseII, please set "
+                                               "isPhaseII = True in regression config";
+      }
+      return isHLT_ ? getRegDataHGCALHLTV1(sc) : getRegDataHGCALV1(sc);
+    default:
+      return std::vector<float>();
+  }
+}
 
-  // protect against HGCal, don't mod the object
-  if (EcalTools::isHGCalDet(sc.seed()->seed().det()))
-    return p;
+void SCEnergyCorrectorSemiParm::RegParam::setForests(const edm::EventSetup& setup) {
+  meanForest_ = setup.getHandle(meanForestToken_);
+  sigmaForest_ = setup.getHandle(sigmaForestToken_);
+}
 
-  const reco::CaloCluster &seedCluster = *(sc.seed());
+double SCEnergyCorrectorSemiParm::RegParam::mean(const std::vector<float>& data) const {
+  return meanForest_ ? meanOutTrans_(meanForest_->GetResponse(data.data())) : -1;
+}
+
+double SCEnergyCorrectorSemiParm::RegParam::sigma(const std::vector<float>& data) const {
+  return sigmaForest_ ? sigmaOutTrans_(sigmaForest_->GetResponse(data.data())) : -1;
+}
+
+float SCEnergyCorrectorSemiParm::getInputEnergy(const reco::SuperCluster& sc) const {
+  const DetId& seedId = sc.seed()->seed();
+  //preshower is only used for HLT Ecal Endcap
+  //for reco, the mustache is mainly used to calibrate the ECAL hence no preshower
+  if (isHLT_ && seedId.det() == DetId::Ecal && seedId.subdetId() == EcalEndcap) {
+    return sc.rawEnergy() + sc.preshowerEnergy();
+  } else {
+    return sc.rawEnergy();
+  }
+}
+
+std::vector<float> SCEnergyCorrectorSemiParm::getRegDataECALV1(const reco::SuperCluster& sc) const {
+  std::vector<float> eval(30, 0.);
+
+  const reco::CaloCluster& seedCluster = *(sc.seed());
   const bool iseb = seedCluster.hitsAndFractions()[0].first.subdetId() == EcalBarrel;
-  const EcalRecHitCollection *recHits = iseb ? rechitsEB_.product() : rechitsEE_.product();
+  const EcalRecHitCollection* recHits = iseb ? recHitsEB_.product() : recHitsEE_.product();
 
-  const CaloTopology *topo = calotopo_.product();
+  const CaloTopology* topo = caloTopo_.product();
 
   const double raw_energy = sc.rawEnergy();
   const int numberOfClusters = sc.clusters().size();
 
   std::vector<float> localCovariances = EcalClusterTools::localCovariances(seedCluster, recHits, topo);
 
-  if (not isHLT_) {
-    std::array<float, 30> eval;
+  const float eLeft = EcalClusterTools::eLeft(seedCluster, recHits, topo);
+  const float eRight = EcalClusterTools::eRight(seedCluster, recHits, topo);
+  const float eTop = EcalClusterTools::eTop(seedCluster, recHits, topo);
+  const float eBottom = EcalClusterTools::eBottom(seedCluster, recHits, topo);
 
-    const float eLeft = EcalClusterTools::eLeft(seedCluster, recHits, topo);
-    const float eRight = EcalClusterTools::eRight(seedCluster, recHits, topo);
-    const float eTop = EcalClusterTools::eTop(seedCluster, recHits, topo);
-    const float eBottom = EcalClusterTools::eBottom(seedCluster, recHits, topo);
+  float sigmaIetaIeta = sqrt(localCovariances[0]);
+  float sigmaIetaIphi = std::numeric_limits<float>::max();
+  float sigmaIphiIphi = std::numeric_limits<float>::max();
 
-    float sigmaIetaIeta = sqrt(localCovariances[0]);
-    float sigmaIetaIphi = std::numeric_limits<float>::max();
-    float sigmaIphiIphi = std::numeric_limits<float>::max();
+  if (!edm::isNotFinite(localCovariances[2]))
+    sigmaIphiIphi = sqrt(localCovariances[2]);
 
-    if (!edm::isNotFinite(localCovariances[2]))
-      sigmaIphiIphi = sqrt(localCovariances[2]);
-
-    // extra shower shapes
-    const float see_by_spp =
-        sigmaIetaIeta * (applySigmaIetaIphiBug_ ? std::numeric_limits<float>::max() : sigmaIphiIphi);
-    if (see_by_spp > 0) {
-      sigmaIetaIphi = localCovariances[1] / see_by_spp;
-    } else if (localCovariances[1] > 0) {
-      sigmaIetaIphi = 1.f;
-    } else {
-      sigmaIetaIphi = -1.f;
-    }
-
-    // calculate sub-cluster variables
-    std::vector<float> clusterRawEnergy;
-    clusterRawEnergy.resize(std::max(3, numberOfClusters), 0);
-    std::vector<float> clusterDEtaToSeed;
-    clusterDEtaToSeed.resize(std::max(3, numberOfClusters), 0);
-    std::vector<float> clusterDPhiToSeed;
-    clusterDPhiToSeed.resize(std::max(3, numberOfClusters), 0);
-    float clusterMaxDR = 999.;
-    float clusterMaxDRDPhi = 999.;
-    float clusterMaxDRDEta = 999.;
-    float clusterMaxDRRawEnergy = 0.;
-
-    size_t iclus = 0;
-    float maxDR = 0;
-    edm::Ptr<reco::CaloCluster> pclus;
-    const edm::Ptr<reco::CaloCluster> &theseed = sc.seed();
-    // loop over all clusters that aren't the seed
-    auto clusend = sc.clustersEnd();
-    for (auto clus = sc.clustersBegin(); clus != clusend; ++clus) {
-      pclus = *clus;
-
-      if (theseed == pclus)
-        continue;
-      clusterRawEnergy[iclus] = pclus->energy();
-      clusterDPhiToSeed[iclus] = reco::deltaPhi(pclus->phi(), theseed->phi());
-      clusterDEtaToSeed[iclus] = pclus->eta() - theseed->eta();
-
-      // find cluster with max dR
-      const auto the_dr = reco::deltaR(*pclus, *theseed);
-      if (the_dr > maxDR) {
-        maxDR = the_dr;
-        clusterMaxDR = maxDR;
-        clusterMaxDRDPhi = clusterDPhiToSeed[iclus];
-        clusterMaxDRDEta = clusterDEtaToSeed[iclus];
-        clusterMaxDRRawEnergy = clusterRawEnergy[iclus];
-      }
-      ++iclus;
-    }
-
-    // SET INPUTS
-    eval[0] = vertices_->size();
-    eval[1] = raw_energy;
-    eval[2] = sc.etaWidth();
-    eval[3] = sc.phiWidth();
-    eval[4] = EcalClusterTools::e3x3(seedCluster, recHits, topo) / raw_energy;
-    eval[5] = seedCluster.energy() / raw_energy;
-    eval[6] = EcalClusterTools::eMax(seedCluster, recHits) / raw_energy;
-    eval[7] = EcalClusterTools::e2nd(seedCluster, recHits) / raw_energy;
-    eval[8] = (eLeft + eRight != 0.f ? (eLeft - eRight) / (eLeft + eRight) : 0.f);
-    eval[9] = (eTop + eBottom != 0.f ? (eTop - eBottom) / (eTop + eBottom) : 0.f);
-    eval[10] = sigmaIetaIeta;
-    eval[11] = sigmaIetaIphi;
-    eval[12] = sigmaIphiIphi;
-    eval[13] = std::max(0, numberOfClusters - 1);
-    eval[14] = clusterMaxDR;
-    eval[15] = clusterMaxDRDPhi;
-    eval[16] = clusterMaxDRDEta;
-    eval[17] = clusterMaxDRRawEnergy / raw_energy;
-    eval[18] = clusterRawEnergy[0] / raw_energy;
-    eval[19] = clusterRawEnergy[1] / raw_energy;
-    eval[20] = clusterRawEnergy[2] / raw_energy;
-    eval[21] = clusterDPhiToSeed[0];
-    eval[22] = clusterDPhiToSeed[1];
-    eval[23] = clusterDPhiToSeed[2];
-    eval[24] = clusterDEtaToSeed[0];
-    eval[25] = clusterDEtaToSeed[1];
-    eval[26] = clusterDEtaToSeed[2];
-    if (iseb) {
-      EBDetId ebseedid(seedCluster.seed());
-      eval[27] = ebseedid.ieta();
-      eval[28] = ebseedid.iphi();
-    } else {
-      EEDetId eeseedid(seedCluster.seed());
-      eval[27] = eeseedid.ix();
-      eval[28] = eeseedid.iy();
-      //seed cluster eta is only needed for the 106X Ultra Legacy regressions
-      //and was not used in the 74X regression however as its just an extra varaible
-      //at the end, its harmless to add for the 74X regression
-      eval[29] = seedCluster.eta();
-    }
-
-    //magic numbers for MINUIT-like transformation of BDT output onto limited range
-    //(These should be stored inside the conditions object in the future as well)
-    constexpr double meanlimlow = 0.2;
-    constexpr double meanlimhigh = 2.0;
-    constexpr double meanoffset = meanlimlow + 0.5 * (meanlimhigh - meanlimlow);
-    constexpr double meanscale = 0.5 * (meanlimhigh - meanlimlow);
-
-    constexpr double sigmalimlow = 0.0002;
-    constexpr double sigmalimhigh = 0.5;
-    constexpr double sigmaoffset = sigmalimlow + 0.5 * (sigmalimhigh - sigmalimlow);
-    constexpr double sigmascale = 0.5 * (sigmalimhigh - sigmalimlow);
-
-    const GBRForestD *forestmean = iseb ? foresteb_ : forestee_;
-    const GBRForestD *forestsigma = iseb ? forestsigmaeb_ : forestsigmaee_;
-
-    //these are the actual BDT responses
-    double rawmean = forestmean->GetResponse(eval.data());
-    double rawsigma = forestsigma->GetResponse(eval.data());
-
-    //apply transformation to limited output range (matching the training)
-    double mean = meanoffset + meanscale * vdt::fast_sin(rawmean);
-    double sigma = sigmaoffset + sigmascale * vdt::fast_sin(rawsigma);
-
-    double ecor = mean * (eval[1]);
-    const double sigmacor = sigma * ecor;
-
-    p.first = ecor;
-    p.second = sigmacor;
-
+  // extra shower shapes
+  const float see_by_spp = sigmaIetaIeta * (applySigmaIetaIphiBug_ ? std::numeric_limits<float>::max() : sigmaIphiIphi);
+  if (see_by_spp > 0) {
+    sigmaIetaIphi = localCovariances[1] / see_by_spp;
+  } else if (localCovariances[1] > 0) {
+    sigmaIetaIphi = 1.f;
   } else {
-    std::array<float, 7> eval;
-    float clusterMaxDR = 999.;
-
-    size_t iclus = 0;
-    float maxDR = 0;
-    edm::Ptr<reco::CaloCluster> pclus;
-    const edm::Ptr<reco::CaloCluster> &theseed = sc.seed();
-
-    // loop over all clusters that aren't the seed
-    auto clusend = sc.clustersEnd();
-    for (auto clus = sc.clustersBegin(); clus != clusend; ++clus) {
-      pclus = *clus;
-
-      if (theseed == pclus)
-        continue;
-
-      // find cluster with max dR
-      const auto the_dr = reco::deltaR(*pclus, *theseed);
-      if (the_dr > maxDR) {
-        maxDR = the_dr;
-        clusterMaxDR = maxDR;
-      }
-      ++iclus;
-    }
-
-    // SET INPUTS
-    eval[0] = nHitsAboveThreshold_;
-    eval[1] = sc.eta();
-    eval[2] = sc.phiWidth();
-    eval[3] = EcalClusterTools::e3x3(seedCluster, recHits, topo) / raw_energy;
-    eval[4] = std::max(0, numberOfClusters - 1);
-    eval[5] = clusterMaxDR;
-    eval[6] = raw_energy;
-
-    //magic numbers for MINUIT-like transformation of BDT output onto limited range
-    //(These should be stored inside the conditions object in the future as well)
-    constexpr double meanlimlow = 0.2;
-    constexpr double meanlimhigh = 2.0;
-    constexpr double meanoffset = meanlimlow + 0.5 * (meanlimhigh - meanlimlow);
-    constexpr double meanscale = 0.5 * (meanlimhigh - meanlimlow);
-
-    const GBRForestD *forestmean = iseb ? foresteb_ : forestee_;
-
-    double rawmean = forestmean->GetResponse(eval.data());
-    double mean = meanoffset + meanscale * vdt::fast_sin(rawmean);
-
-    double ecor = mean * eval[6];
-    if (!iseb)
-      ecor = mean * eval[6] + sc.preshowerEnergy();
-
-    p.first = ecor;
-    //p.second unchanged
+    sigmaIetaIphi = -1.f;
   }
 
-  return p;
+  // calculate sub-cluster variables
+  std::vector<float> clusterRawEnergy;
+  clusterRawEnergy.resize(std::max(3, numberOfClusters), 0);
+  std::vector<float> clusterDEtaToSeed;
+  clusterDEtaToSeed.resize(std::max(3, numberOfClusters), 0);
+  std::vector<float> clusterDPhiToSeed;
+  clusterDPhiToSeed.resize(std::max(3, numberOfClusters), 0);
+  float clusterMaxDR = 999.;
+  float clusterMaxDRDPhi = 999.;
+  float clusterMaxDRDEta = 999.;
+  float clusterMaxDRRawEnergy = 0.;
+
+  size_t iclus = 0;
+  float maxDR = 0;
+  edm::Ptr<reco::CaloCluster> pclus;
+  const edm::Ptr<reco::CaloCluster>& theseed = sc.seed();
+  // loop over all clusters that aren't the seed
+  auto clusend = sc.clustersEnd();
+  for (auto clus = sc.clustersBegin(); clus != clusend; ++clus) {
+    pclus = *clus;
+
+    if (theseed == pclus)
+      continue;
+    clusterRawEnergy[iclus] = pclus->energy();
+    clusterDPhiToSeed[iclus] = reco::deltaPhi(pclus->phi(), theseed->phi());
+    clusterDEtaToSeed[iclus] = pclus->eta() - theseed->eta();
+
+    // find cluster with max dR
+    const auto the_dr = reco::deltaR(*pclus, *theseed);
+    if (the_dr > maxDR) {
+      maxDR = the_dr;
+      clusterMaxDR = maxDR;
+      clusterMaxDRDPhi = clusterDPhiToSeed[iclus];
+      clusterMaxDRDEta = clusterDEtaToSeed[iclus];
+      clusterMaxDRRawEnergy = clusterRawEnergy[iclus];
+    }
+    ++iclus;
+  }
+
+  eval[0] = vertices_->size();
+  eval[1] = raw_energy;
+  eval[2] = sc.etaWidth();
+  eval[3] = sc.phiWidth();
+  eval[4] = EcalClusterTools::e3x3(seedCluster, recHits, topo) / raw_energy;
+  eval[5] = seedCluster.energy() / raw_energy;
+  eval[6] = EcalClusterTools::eMax(seedCluster, recHits) / raw_energy;
+  eval[7] = EcalClusterTools::e2nd(seedCluster, recHits) / raw_energy;
+  eval[8] = (eLeft + eRight != 0.f ? (eLeft - eRight) / (eLeft + eRight) : 0.f);
+  eval[9] = (eTop + eBottom != 0.f ? (eTop - eBottom) / (eTop + eBottom) : 0.f);
+  eval[10] = sigmaIetaIeta;
+  eval[11] = sigmaIetaIphi;
+  eval[12] = sigmaIphiIphi;
+  eval[13] = std::max(0, numberOfClusters - 1);
+  eval[14] = clusterMaxDR;
+  eval[15] = clusterMaxDRDPhi;
+  eval[16] = clusterMaxDRDEta;
+  eval[17] = clusterMaxDRRawEnergy / raw_energy;
+  eval[18] = clusterRawEnergy[0] / raw_energy;
+  eval[19] = clusterRawEnergy[1] / raw_energy;
+  eval[20] = clusterRawEnergy[2] / raw_energy;
+  eval[21] = clusterDPhiToSeed[0];
+  eval[22] = clusterDPhiToSeed[1];
+  eval[23] = clusterDPhiToSeed[2];
+  eval[24] = clusterDEtaToSeed[0];
+  eval[25] = clusterDEtaToSeed[1];
+  eval[26] = clusterDEtaToSeed[2];
+  if (iseb) {
+    EBDetId ebseedid(seedCluster.seed());
+    eval[27] = ebseedid.ieta();
+    eval[28] = ebseedid.iphi();
+  } else {
+    EEDetId eeseedid(seedCluster.seed());
+    eval[27] = eeseedid.ix();
+    eval[28] = eeseedid.iy();
+    //seed cluster eta is only needed for the 106X Ultra Legacy regressions
+    //and was not used in the 74X regression however as its just an extra varaible
+    //at the end, its harmless to add for the 74X regression
+    eval[29] = seedCluster.eta();
+  }
+  return eval;
 }
 
-//--------------------------------------------------------------------------------------------------
-void SCEnergyCorrectorSemiParm::modifyObject(reco::SuperCluster &sc) {
-  std::pair<double, double> cor = getCorrections(sc);
-  if (cor.first < 0)
-    return;
-  sc.setEnergy(cor.first);
-  sc.setCorrectedEnergy(cor.first);
-  if (!isHLT_ && cor.second >= 0.)
-    sc.setCorrectedEnergyUncertainty(cor.second);
+std::vector<float> SCEnergyCorrectorSemiParm::getRegDataECALHLTV1(const reco::SuperCluster& sc) const {
+  std::vector<float> eval(7, 0.);
+  auto maxDRNonSeedClus = getMaxDRNonSeedCluster(sc);
+  const float clusterMaxDR = maxDRNonSeedClus.first.isNonnull() ? maxDRNonSeedClus.second : 999.;
+
+  const reco::CaloCluster& seedCluster = *(sc.seed());
+  const bool iseb = seedCluster.hitsAndFractions()[0].first.subdetId() == EcalBarrel;
+  const EcalRecHitCollection* recHits = iseb ? recHitsEB_.product() : recHitsEE_.product();
+
+  eval[0] = nHitsAboveThresholdEB_ + nHitsAboveThresholdEE_;
+  eval[1] = sc.eta();
+  eval[2] = sc.phiWidth();
+  eval[3] = EcalClusterTools::e3x3(seedCluster, recHits, caloTopo_.product()) / sc.rawEnergy();
+  eval[4] = std::max(0, static_cast<int>(sc.clusters().size()) - 1);
+  eval[5] = clusterMaxDR;
+  eval[6] = sc.rawEnergy();
+
+  return eval;
+}
+
+std::vector<float> SCEnergyCorrectorSemiParm::getRegDataHGCALV1(const reco::SuperCluster& sc) const {
+  std::vector<float> eval(17, 0.);
+
+  auto ssCalc = hgcalShowerShapes_.createCalc(sc);
+  auto pcaWidths = ssCalc.getPCAWidths(hgcalCylinderR_);
+  auto energyHighestHits = ssCalc.getEnergyHighestHits(2);
+
+  auto maxDRNonSeedClus = getMaxDRNonSeedCluster(sc);
+  const float clusterMaxDR = maxDRNonSeedClus.first.isNonnull() ? maxDRNonSeedClus.second : 999.;
+
+  eval[0] = sc.rawEnergy();
+  eval[1] = sc.eta();
+  eval[2] = sc.etaWidth();
+  eval[3] = sc.phiWidth();
+  eval[4] = sc.clusters().size();
+  eval[5] = sc.hitsAndFractions().size();
+  eval[6] = clusterMaxDR;
+  eval[7] = sc.eta() - sc.seed()->eta();
+  eval[8] = reco::deltaPhi(sc.phi(), sc.seed()->phi());
+  eval[9] = energyHighestHits[0] / sc.rawEnergy();
+  eval[10] = energyHighestHits[1] / sc.rawEnergy();
+  eval[11] = std::sqrt(pcaWidths.sigma2uu);
+  eval[12] = std::sqrt(pcaWidths.sigma2vv);
+  eval[13] = std::sqrt(pcaWidths.sigma2ww);
+  eval[14] = ssCalc.getRvar(hgcalCylinderR_, sc.rawEnergy());
+  eval[15] = sc.seed()->energy() / sc.rawEnergy();
+  eval[16] = nHitsAboveThresholdEB_ + nHitsAboveThresholdHG_;
+
+  return eval;
+}
+
+std::vector<float> SCEnergyCorrectorSemiParm::getRegDataHGCALHLTV1(const reco::SuperCluster& sc) const {
+  std::vector<float> eval(7, 0.);
+  const float clusterMaxDR = getMaxDRNonSeedCluster(sc).second;
+
+  auto ssCalc = hgcalShowerShapes_.createCalc(sc);
+
+  eval[0] = sc.rawEnergy();
+  eval[1] = sc.eta();
+  eval[2] = sc.phiWidth();
+  eval[3] = std::max(0, static_cast<int>(sc.clusters().size()) - 1);
+  eval[4] = ssCalc.getRvar(hgcalCylinderR_);
+  eval[5] = clusterMaxDR;
+  eval[6] = nHitsAboveThresholdEB_ + nHitsAboveThresholdHG_;
+
+  return eval;
 }

--- a/RecoEcal/EgammaClusterProducers/python/particleFlowSuperClusteringSequence_cff.py
+++ b/RecoEcal/EgammaClusterProducers/python/particleFlowSuperClusteringSequence_cff.py
@@ -15,20 +15,23 @@ particleFlowSuperClusterHGCal = particleFlowSuperClusterECAL.clone()
 from Configuration.Eras.Modifier_phase2_hgcal_cff import phase2_hgcal
 phase2_hgcal.toModify(
     particleFlowSuperClusterHGCal,
-    PFClusters = cms.InputTag('particleFlowClusterHGCal'),
-    useRegression = cms.bool(False), #no HGCal regression yet
-    use_preshower = cms.bool(False),
-    PFBasicClusterCollectionEndcap = cms.string(""),
-    PFSuperClusterCollectionEndcap = cms.string(""),
-    PFSuperClusterCollectionEndcapWithPreshower = cms.string(""),
-    thresh_PFClusterEndcap = cms.double(1.5e-1), # 150 MeV threshold
-    dropUnseedable = cms.bool(True),
+    PFClusters                     = 'particleFlowClusterHGCal',
+    useRegression                  = False, #no HGCal regression yet
+    use_preshower                  = False,
+    PFBasicClusterCollectionEndcap = "",
+    PFSuperClusterCollectionEndcap = "",
+    PFSuperClusterCollectionEndcapWithPreshower = "",
+    thresh_PFClusterEndcap         = 1.5e-1, # 150 MeV threshold
+    dropUnseedable                 = True,
 )
 
 particleFlowSuperClusterHGCalFromMultiCl = particleFlowSuperClusterHGCal.clone()
 phase2_hgcal.toModify(
     particleFlowSuperClusterHGCalFromMultiCl,
-    PFClusters = cms.InputTag('particleFlowClusterHGCalFromMultiCl')
+    PFClusters = 'particleFlowClusterHGCalFromMultiCl',
+    useRegression  = cms.bool(True),
+    regressionKeyEE = cms.string("superclus_hgcal_mean_offline"),
+    uncertaintyKeyEE = cms.string("superclus_hgcal_sigma_offline"),
 )
 _phase2_hgcal_particleFlowSuperClusteringTask = particleFlowSuperClusteringTask.copy()
 _phase2_hgcal_particleFlowSuperClusteringTask.add(particleFlowSuperClusterHGCal)

--- a/RecoEcal/EgammaClusterProducers/python/particleFlowSuperClusteringSequence_cff.py
+++ b/RecoEcal/EgammaClusterProducers/python/particleFlowSuperClusteringSequence_cff.py
@@ -29,9 +29,14 @@ particleFlowSuperClusterHGCalFromMultiCl = particleFlowSuperClusterHGCal.clone()
 phase2_hgcal.toModify(
     particleFlowSuperClusterHGCalFromMultiCl,
     PFClusters = 'particleFlowClusterHGCalFromMultiCl',
-    useRegression  = cms.bool(True),
-    regressionKeyEE = cms.string("superclus_hgcal_mean_offline"),
-    uncertaintyKeyEE = cms.string("superclus_hgcal_sigma_offline"),
+    useRegression  = True,
+)
+phase2_hgcal.toModify( particleFlowSuperClusterHGCalFromMultiCl.regressionConfig,
+    regressionKeyEE = "superclus_hgcal_mean_offline",
+    uncertaintyKeyEE = "superclus_hgcal_sigma_offline",
+    isPhaseII = True,
+    hgcalRecHits = "particleFlowRecHitHGC"
+            
 )
 _phase2_hgcal_particleFlowSuperClusteringTask = particleFlowSuperClusteringTask.copy()
 _phase2_hgcal_particleFlowSuperClusteringTask.add(particleFlowSuperClusterHGCal)

--- a/RecoEcal/EgammaClusterProducers/src/PFECALSuperClusterProducer.cc
+++ b/RecoEcal/EgammaClusterProducers/src/PFECALSuperClusterProducer.cc
@@ -3,6 +3,7 @@
 #include <memory>
 
 #include "RecoEcal/EgammaClusterAlgos/interface/PFECALSuperClusterAlgo.h"
+#include "RecoEcal/EgammaClusterAlgos/interface/SCEnergyCorrectorSemiParm.h"
 
 #include "DataFormats/ParticleFlowReco/interface/PFRecHit.h"
 
@@ -304,20 +305,7 @@ void PFECALSuperClusterProducer::fillDescriptions(edm::ConfigurationDescriptions
   desc.add<double>("phiwidth_SuperClusterEndcap", 0.6);
   desc.add<bool>("useDynamicDPhiWindow", true);
   desc.add<std::string>("PFSuperClusterCollectionBarrel", "particleFlowSuperClusterECALBarrel");
-  {
-    edm::ParameterSetDescription psd0;
-    psd0.add<bool>("isHLT", false);
-    psd0.add<bool>("applySigmaIetaIphiBug", false);
-    psd0.add<edm::InputTag>("ecalRecHitsEE", edm::InputTag("ecalRecHit", "EcalRecHitsEE"));
-    psd0.add<edm::InputTag>("ecalRecHitsEB", edm::InputTag("ecalRecHit", "EcalRecHitsEB"));
-    psd0.add<std::string>("regressionKeyEB", "pfscecal_EBCorrection_offline_v2");
-    psd0.add<std::string>("regressionKeyEE", "pfscecal_EECorrection_offline_v2");
-    psd0.add<std::string>("uncertaintyKeyEB", "pfscecal_EBUncertainty_offline_v2");
-    psd0.add<std::string>("uncertaintyKeyEE", "pfscecal_EEUncertainty_offline_v2");
-    psd0.add<edm::InputTag>("vertexCollection", edm::InputTag("offlinePrimaryVertices"));
-    psd0.add<double>("eRecHitThreshold", 1.);
-    desc.add<edm::ParameterSetDescription>("regressionConfig", psd0);
-  }
+  desc.add<edm::ParameterSetDescription>("regressionConfig", SCEnergyCorrectorSemiParm::makePSetDescription());
   desc.add<bool>("applyCrackCorrections", false);
   desc.add<double>("satelliteClusterSeedThreshold", 50.0);
   desc.add<double>("etawidth_SuperClusterBarrel", 0.04);

--- a/RecoEcal/EgammaClusterProducers/src/SCEnergyCorrectorProducer.cc
+++ b/RecoEcal/EgammaClusterProducers/src/SCEnergyCorrectorProducer.cc
@@ -1,0 +1,69 @@
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "DataFormats/EgammaReco/interface/SuperCluster.h"
+#include "RecoEcal/EgammaClusterAlgos/interface/SCEnergyCorrectorSemiParm.h"
+
+#include <vector>
+
+//A simple producer which produces a set of corrected superclusters
+//Note this is more for testing and development and is not really meant for production
+//although its perfectly possible somebody could use it in some prod workflow
+//author S. Harper (RAL/CERN)
+
+class SCEnergyCorrectorProducer : public edm::stream::EDProducer<> {
+public:
+  explicit SCEnergyCorrectorProducer(const edm::ParameterSet& iConfig);
+
+  void beginLuminosityBlock(const edm::LuminosityBlock& iLumi, const edm::EventSetup& iSetup) override;
+  void produce(edm::Event& iEvent, const edm::EventSetup& iSetup) override;
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+private:
+  SCEnergyCorrectorSemiParm energyCorrector_;
+  edm::EDGetTokenT<reco::SuperClusterCollection> inputSCToken_;
+  bool writeFeatures_;
+};
+
+SCEnergyCorrectorProducer::SCEnergyCorrectorProducer(const edm::ParameterSet& iConfig)
+    : energyCorrector_(iConfig.getParameterSet("correctorCfg"), consumesCollector()),
+      inputSCToken_(consumes<reco::SuperClusterCollection>(iConfig.getParameter<edm::InputTag>("inputSCs"))),
+      writeFeatures_(iConfig.getParameter<bool>("writeFeatures")) {
+  produces<reco::SuperClusterCollection>();
+  if (writeFeatures_) {
+    produces<std::vector<std::vector<float>>>("features");
+  }
+}
+
+void SCEnergyCorrectorProducer::beginLuminosityBlock(const edm::LuminosityBlock& iLumi, const edm::EventSetup& iSetup) {
+  energyCorrector_.setEventSetup(iSetup);
+}
+
+void SCEnergyCorrectorProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  energyCorrector_.setEvent(iEvent);
+
+  auto inputSCHandle = iEvent.getHandle(inputSCToken_);
+  auto corrSCs = std::make_unique<reco::SuperClusterCollection>();
+  auto scFeatures = std::make_unique<std::vector<std::vector<float>>>();
+  for (const auto& inputSC : *inputSCHandle) {
+    corrSCs->push_back(inputSC);
+    energyCorrector_.modifyObject(corrSCs->back());
+    if (writeFeatures_) {
+      scFeatures->emplace_back(energyCorrector_.getRegData(corrSCs->back()));
+    }
+  }
+  iEvent.put(std::move(corrSCs));
+  iEvent.put(std::move(scFeatures), "features");
+}
+void SCEnergyCorrectorProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.add<edm::ParameterSetDescription>("correctorCfg", SCEnergyCorrectorSemiParm::makePSetDescription());
+  desc.add<bool>("writeFeatures", false);
+  desc.add<edm::InputTag>("inputSCs", edm::InputTag("particleFlowSuperClusterECAL"));
+  descriptions.add("scEnergyCorrectorProducer", desc);
+}
+
+DEFINE_FWK_MODULE(SCEnergyCorrectorProducer);

--- a/RecoEcal/EgammaClusterProducers/src/SCEnergyCorrectorProducer.cc
+++ b/RecoEcal/EgammaClusterProducers/src/SCEnergyCorrectorProducer.cc
@@ -4,6 +4,7 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 #include "DataFormats/EgammaReco/interface/SuperCluster.h"
+#include "DataFormats/Common/interface/ValueMap.h"
 #include "RecoEcal/EgammaClusterAlgos/interface/SCEnergyCorrectorSemiParm.h"
 
 #include <vector>
@@ -24,8 +25,8 @@ public:
 
 private:
   SCEnergyCorrectorSemiParm energyCorrector_;
-  edm::EDGetTokenT<reco::SuperClusterCollection> inputSCToken_;
-  bool writeFeatures_;
+  const edm::EDGetTokenT<reco::SuperClusterCollection> inputSCToken_;
+  const bool writeFeatures_;
 };
 
 SCEnergyCorrectorProducer::SCEnergyCorrectorProducer(const edm::ParameterSet& iConfig)
@@ -34,7 +35,7 @@ SCEnergyCorrectorProducer::SCEnergyCorrectorProducer(const edm::ParameterSet& iC
       writeFeatures_(iConfig.getParameter<bool>("writeFeatures")) {
   produces<reco::SuperClusterCollection>();
   if (writeFeatures_) {
-    produces<std::vector<std::vector<float>>>("features");
+    produces<edm::ValueMap<std::vector<float>>>("features");
   }
 }
 
@@ -45,19 +46,28 @@ void SCEnergyCorrectorProducer::beginLuminosityBlock(const edm::LuminosityBlock&
 void SCEnergyCorrectorProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   energyCorrector_.setEvent(iEvent);
 
-  auto inputSCHandle = iEvent.getHandle(inputSCToken_);
+  auto inputSCs = iEvent.get(inputSCToken_);
   auto corrSCs = std::make_unique<reco::SuperClusterCollection>();
-  auto scFeatures = std::make_unique<std::vector<std::vector<float>>>();
-  for (const auto& inputSC : *inputSCHandle) {
+  std::vector<std::vector<float>> scFeatures;
+  for (const auto& inputSC : inputSCs) {
     corrSCs->push_back(inputSC);
     energyCorrector_.modifyObject(corrSCs->back());
     if (writeFeatures_) {
-      scFeatures->emplace_back(energyCorrector_.getRegData(corrSCs->back()));
+      scFeatures.emplace_back(energyCorrector_.getRegData(corrSCs->back()));
     }
   }
-  iEvent.put(std::move(corrSCs));
-  iEvent.put(std::move(scFeatures), "features");
+
+  auto scHandle = iEvent.put(std::move(corrSCs));
+
+  if (writeFeatures_) {
+    auto valMap = std::make_unique<edm::ValueMap<std::vector<float>>>();
+    edm::ValueMap<std::vector<float>>::Filler filler(*valMap);
+    filler.insert(scHandle, scFeatures.begin(), scFeatures.end());
+    filler.fill();
+    iEvent.put(std::move(valMap), "features");
+  }
 }
+
 void SCEnergyCorrectorProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
   desc.add<edm::ParameterSetDescription>("correctorCfg", SCEnergyCorrectorSemiParm::makePSetDescription());

--- a/RecoEgamma/EgammaHLTProducers/plugins/EgammaHLTHGCalIDVarProducer.cc
+++ b/RecoEgamma/EgammaHLTProducers/plugins/EgammaHLTHGCalIDVarProducer.cc
@@ -54,7 +54,7 @@ private:
   const edm::EDGetTokenT<reco::RecoEcalCandidateCollection> recoEcalCandidateToken_;
   const edm::EDGetTokenT<reco::PFRecHitCollection> hgcalRecHitToken_;
   const edm::EDGetTokenT<reco::CaloClusterCollection> layerClusterToken_;
-  HGCalShowerShapeHelper ssCalc_;
+  HGCalShowerShapeHelper ssHelper_;
 };
 
 EgammaHLTHGCalIDVarProducer::EgammaHLTHGCalIDVarProducer(const edm::ParameterSet& config)
@@ -64,7 +64,7 @@ EgammaHLTHGCalIDVarProducer::EgammaHLTHGCalIDVarProducer(const edm::ParameterSet
           consumes<reco::RecoEcalCandidateCollection>(config.getParameter<edm::InputTag>("recoEcalCandidateProducer"))),
       hgcalRecHitToken_(consumes<reco::PFRecHitCollection>(config.getParameter<edm::InputTag>("hgcalRecHits"))),
       layerClusterToken_(consumes<reco::CaloClusterCollection>(config.getParameter<edm::InputTag>("layerClusters"))),
-      ssCalc_(consumesCollector()) {
+      ssHelper_(consumesCollector()) {
   pcaAssocMaps_.emplace_back(PCAAssocMap(&HGCalShowerShapeHelper::ShowerWidths::sigma2xx, "sigma2xx"));
   pcaAssocMaps_.emplace_back(PCAAssocMap(&HGCalShowerShapeHelper::ShowerWidths::sigma2yy, "sigma2yy"));
   pcaAssocMaps_.emplace_back(PCAAssocMap(&HGCalShowerShapeHelper::ShowerWidths::sigma2zz, "sigma2zz"));
@@ -99,7 +99,7 @@ void EgammaHLTHGCalIDVarProducer::produce(edm::Event& iEvent, const edm::EventSe
   const auto& hgcalRecHits = iEvent.get(hgcalRecHitToken_);
   const auto& layerClusters = iEvent.get(layerClusterToken_);
 
-  ssCalc_.initPerEvent(iSetup, hgcalRecHits);
+  ssHelper_.initPerEvent(iSetup, hgcalRecHits);
 
   auto rVarMap = std::make_unique<reco::RecoEcalCandidateIsolationMap>(recoEcalCandHandle);
   auto hForHoverEMap = std::make_unique<reco::RecoEcalCandidateIsolationMap>(recoEcalCandHandle);
@@ -109,13 +109,13 @@ void EgammaHLTHGCalIDVarProducer::produce(edm::Event& iEvent, const edm::EventSe
 
   for (size_t candNr = 0; candNr < recoEcalCandHandle->size(); candNr++) {
     reco::RecoEcalCandidateRef candRef(recoEcalCandHandle, candNr);
-    ssCalc_.initPerObject(candRef->superCluster()->hitsAndFractions());
-    rVarMap->insert(candRef, ssCalc_.getRvar(rCylinder_, candRef->superCluster()->energy()));
+    auto ssCalc = ssHelper_.createCalc(*candRef->superCluster());
+    rVarMap->insert(candRef, ssCalc.getRvar(rCylinder_));
 
     float hForHoverE = HGCalClusterTools::hadEnergyInCone(
         candRef->superCluster()->eta(), candRef->superCluster()->phi(), layerClusters, 0., hOverECone_, 0., 0.);
     hForHoverEMap->insert(candRef, hForHoverE);
-    auto pcaWidths = ssCalc_.getPCAWidths(rCylinder_);
+    auto pcaWidths = ssCalc.getPCAWidths(rCylinder_);
     for (auto& pcaMap : pcaAssocMaps_) {
       pcaMap.insert(candRef, pcaWidths);
     }

--- a/RecoEgamma/EgammaHLTProducers/plugins/EgammaHLTHGCalIDVarProducer.cc
+++ b/RecoEgamma/EgammaHLTProducers/plugins/EgammaHLTHGCalIDVarProducer.cc
@@ -16,6 +16,7 @@
 #include "DataFormats/ParticleFlowReco/interface/PFRecHit.h"
 #include "RecoEgamma/EgammaTools/interface/HGCalShowerShapeHelper.h"
 #include "RecoEgamma/EgammaTools/interface/HGCalClusterTools.h"
+#include "RecoEgamma/EgammaTools/interface/EgammaHGCALIDParamDefaults.h"
 
 class EgammaHLTHGCalIDVarProducer : public edm::stream::EDProducer<> {
 public:
@@ -89,7 +90,7 @@ void EgammaHLTHGCalIDVarProducer::fillDescriptions(edm::ConfigurationDescription
   desc.add<edm::InputTag>("recoEcalCandidateProducer", edm::InputTag("hltL1SeededRecoEcalCandidate"));
   desc.add<edm::InputTag>("hgcalRecHits", edm::InputTag("hgcalRecHits"));
   desc.add<edm::InputTag>("layerClusters", edm::InputTag("layerClusters"));
-  desc.add<double>("rCylinder", 2.8);
+  desc.add<double>("rCylinder", EgammaHGCALIDParamDefaults::kRCylinder);
   desc.add<double>("hOverECone", 0.15);
   descriptions.add(("hltEgammaHLTHGCalIDVarProducer"), desc);
 }

--- a/RecoEgamma/EgammaTools/interface/EgammaBDTOutputTransformer.h
+++ b/RecoEgamma/EgammaTools/interface/EgammaBDTOutputTransformer.h
@@ -16,8 +16,8 @@ public:
   double operator()(const double rawVal) const { return offset_ + scale_ * vdt::fast_sin(rawVal); }
 
 private:
-  const double offset_;
-  const double scale_;
+  double offset_;
+  double scale_;
 };
 
 #endif

--- a/RecoEgamma/EgammaTools/interface/EgammaHGCALIDParamDefaults.h
+++ b/RecoEgamma/EgammaTools/interface/EgammaHGCALIDParamDefaults.h
@@ -1,0 +1,8 @@
+#ifndef RecoEgamma_EgammaTools_interface_EgammaHGCALIDParamDefaults_h
+#define RecoEgamma_EgammaTools_interface_EgammaHGCALIDParamDefaults_h
+
+struct EgammaHGCALIDParamDefaults {
+  static constexpr float kRCylinder = 2.8;
+};
+
+#endif

--- a/RecoEgamma/EgammaTools/interface/HGCalShowerShapeHelper.h
+++ b/RecoEgamma/EgammaTools/interface/HGCalShowerShapeHelper.h
@@ -38,6 +38,7 @@
 #include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/StreamID.h"
+#include "FWCore/Utilities/interface/Transition.h"
 #include "Geometry/CaloTopology/interface/HGCalTopology.h"
 #include "Geometry/Records/interface/IdealGeometryRecord.h"
 #include "RecoLocalCalo/HGCalRecAlgos/interface/RecHitTools.h"
@@ -47,7 +48,9 @@ class HGCalShowerShapeHelper {
   // Good to filter/compute/store this stuff beforehand as they are common to the shower shape variables.
   // No point in filtering, computing layer-wise centroids, etc. for each variable again and again.
   // Once intitialized, one can the calculate different variables one after another for a given object.
-  // If a different set of preselections (E, ET, etc.) is required for a given object, then reinitialize using initPerObject(...).
+  // This is all handled by ShowerShapeCalc class which caches the layer-wise centroids and other
+  // heavy variables for an object + set of cuts
+  // It was changed to this approach so that we could use this in constant functions
 
   // In principle should consider the HGCalHSi and HGCalHSc hits (leakage) also.
   // Can have subdetector dependent thresholds and layer selection.
@@ -56,8 +59,6 @@ class HGCalShowerShapeHelper {
 public:
   static const double kLDWaferCellSize_;
   static const double kHDWaferCellSize_;
-
-  void setLayerWiseInfo();
 
   struct ShowerWidths {
     double sigma2xx;
@@ -84,48 +85,92 @@ public:
           sigma2ww(0.0) {}
   };
 
-  HGCalShowerShapeHelper(edm::ConsumesCollector &&sumes);
+  class ShowerShapeCalc {
+  public:
+    ShowerShapeCalc(std::shared_ptr<const hgcal::RecHitTools> recHitTools,
+                    std::shared_ptr<const std::unordered_map<uint32_t, const reco::PFRecHit *> > pfRecHitPtrMap,
+                    const std::vector<std::pair<DetId, float> > &hitsAndFracs,
+                    const double rawEnergy,
+                    const double minHitE = 0,
+                    const double minHitET = 0,
+                    const int minLayer = 1,
+                    const int maxLayer = -1,
+                    DetId::Detector subDet = DetId::HGCalEE);
 
+    double getCellSize(DetId detId) const;
+
+    // Compute Rvar in a cylinder around the layer centroids
+    double getRvar(double cylinderR, bool useFractions = true, bool useCellSize = true) const;
+
+    // Compute PCA widths around the layer centroids
+    ShowerWidths getPCAWidths(double cylinderR, bool useFractions = false) const;
+
+    std::vector<double> getEnergyHighestHits(unsigned int nrHits, bool useFractions = true) const;
+
+  private:
+    void setFilteredHitsAndFractions(const std::vector<std::pair<DetId, float> > &hitsAndFracs);
+    void setLayerWiseInfo();
+
+    std::shared_ptr<const hgcal::RecHitTools> recHitTools_;
+    std::shared_ptr<const std::unordered_map<uint32_t, const reco::PFRecHit *> > pfRecHitPtrMap_;
+    double rawEnergy_;
+
+    double minHitE_;
+    double minHitET_;
+    double minHitET2_;
+    int minLayer_;
+    int maxLayer_;
+    int nLayer_;
+    DetId::Detector subDet_;
+
+    std::vector<std::pair<DetId, float> > hitsAndFracs_;
+    std::vector<double> hitEnergies_;
+    std::vector<double> hitEnergiesWithFracs_;
+
+    ROOT::Math::XYZVector centroid_;
+    std::vector<double> layerEnergies_;
+    std::vector<ROOT::Math::XYZVector> layerCentroids_;
+  };
+
+  HGCalShowerShapeHelper();
+  HGCalShowerShapeHelper(edm::ConsumesCollector &&sumes);
+  ~HGCalShowerShapeHelper() = default;
+  HGCalShowerShapeHelper(const HGCalShowerShapeHelper &rhs) = delete;
+  HGCalShowerShapeHelper(const HGCalShowerShapeHelper &&rhs) = delete;
+  HGCalShowerShapeHelper &operator=(const HGCalShowerShapeHelper &rhs) = delete;
+  HGCalShowerShapeHelper &operator=(const HGCalShowerShapeHelper &&rhs) = delete;
+
+  template <edm::Transition tr = edm::Transition::Event>
+  void setTokens(edm::ConsumesCollector consumesCollector) {
+    caloGeometryToken_ = consumesCollector.esConsumes<CaloGeometry, CaloGeometryRecord, tr>();
+  }
+
+  void initPerSetup(const edm::EventSetup &iSetup);
+  void initPerEvent(const std::vector<reco::PFRecHit> &recHits);
   void initPerEvent(const edm::EventSetup &iSetup, const std::vector<reco::PFRecHit> &recHits);
 
-  void initPerObject(const std::vector<std::pair<DetId, float> > &hitsAndFracs,
-                     double minHitE = 0,
-                     double minHitET = 0,
-                     int minLayer = 1,
-                     int maxLayer = -1,
-                     DetId::Detector subDet = DetId::HGCalEE);
-
-  const double getCellSize(DetId detId);
-
-  // Compute Rvar in a cylinder around the layer centroids
-  const double getRvar(double cylinderR, double energyNorm, bool useFractions = true, bool useCellSize = true);
-
-  // Compute PCA widths around the layer centroids
-  const ShowerWidths getPCAWidths(double cylinderR, bool useFractions = false);
+  HGCalShowerShapeHelper::ShowerShapeCalc createCalc(const std::vector<std::pair<DetId, float> > &hitsAndFracs,
+                                                     double rawEnergy,
+                                                     double minHitE = 0,
+                                                     double minHitET = 0,
+                                                     int minLayer = 1,
+                                                     int maxLayer = -1,
+                                                     DetId::Detector subDet = DetId::HGCalEE) const;
+  HGCalShowerShapeHelper::ShowerShapeCalc createCalc(const reco::SuperCluster &sc,
+                                                     double minHitE = 0,
+                                                     double minHitET = 0,
+                                                     int minLayer = 1,
+                                                     int maxLayer = -1,
+                                                     DetId::Detector subDet = DetId::HGCalEE) const {
+    return createCalc(sc.hitsAndFractions(), sc.rawEnergy(), minHitE, minHitET, minLayer, maxLayer, subDet);
+  }
 
 private:
   void setPFRecHitPtrMap(const std::vector<reco::PFRecHit> &recHits);
-  void setFilteredHitsAndFractions(const std::vector<std::pair<DetId, float> > &hitsAndFracs);
-
-  double minHitE_;
-  double minHitET_;
-  double minHitET2_;
-  int minLayer_;
-  int maxLayer_;
-  int nLayer_;
-  DetId::Detector subDet_;
 
   edm::ESGetToken<CaloGeometry, CaloGeometryRecord> caloGeometryToken_;
-  hgcal::RecHitTools recHitTools_;
-
-  std::unordered_map<uint32_t, const reco::PFRecHit *> pfRecHitPtrMap_;
-  std::vector<std::pair<DetId, float> > hitsAndFracs_;
-  std::vector<double> hitEnergies_;
-  std::vector<double> hitEnergiesWithFracs_;
-
-  ROOT::Math::XYZVector centroid_;
-  std::vector<double> layerEnergies_;
-  std::vector<ROOT::Math::XYZVector> layerCentroids_;
+  std::shared_ptr<hgcal::RecHitTools> recHitTools_;
+  std::shared_ptr<std::unordered_map<uint32_t, const reco::PFRecHit *> > pfRecHitPtrMap_;
 };
 
 #endif

--- a/RecoEgamma/EgammaTools/src/HGCalShowerShapeHelper.cc
+++ b/RecoEgamma/EgammaTools/src/HGCalShowerShapeHelper.cc
@@ -3,145 +3,43 @@
 const double HGCalShowerShapeHelper::kLDWaferCellSize_ = 0.698;
 const double HGCalShowerShapeHelper::kHDWaferCellSize_ = 0.465;
 
-HGCalShowerShapeHelper::HGCalShowerShapeHelper(edm::ConsumesCollector &&sumes)
-    : caloGeometryToken_{sumes.esConsumes<CaloGeometry, CaloGeometryRecord>()} {}
-
-void HGCalShowerShapeHelper::initPerEvent(const edm::EventSetup &iSetup, const std::vector<reco::PFRecHit> &pfRecHits) {
-  recHitTools_.setGeometry(iSetup.getData(caloGeometryToken_));
-  setPFRecHitPtrMap(pfRecHits);
-}
-
-void HGCalShowerShapeHelper::initPerObject(const std::vector<std::pair<DetId, float> > &hitsAndFracs,
-                                           double minHitE,
-                                           double minHitET,
-                                           int minLayer,
-                                           int maxLayer,
-                                           DetId::Detector subDet) {
-  maxLayer = maxLayer <= 0 ? recHitTools_.lastLayerEE() : maxLayer;
-
-  // Safety checks
-  nLayer_ = maxLayer - minLayer + 1;
+HGCalShowerShapeHelper::ShowerShapeCalc::ShowerShapeCalc(
+    std::shared_ptr<const hgcal::RecHitTools> recHitTools,
+    std::shared_ptr<const std::unordered_map<uint32_t, const reco::PFRecHit *>> pfRecHitPtrMap,
+    const std::vector<std::pair<DetId, float>> &hitsAndFracs,
+    const double rawEnergy,
+    const double minHitE,
+    const double minHitET,
+    const int minLayer,
+    const int maxLayer,
+    const DetId::Detector subDet)
+    : recHitTools_(recHitTools),
+      pfRecHitPtrMap_(pfRecHitPtrMap),
+      rawEnergy_(rawEnergy),
+      minHitE_(minHitE),
+      minHitET_(minHitET),
+      minHitET2_(minHitET * minHitET),
+      minLayer_(minLayer),
+      maxLayer_(maxLayer <= 0 ? recHitTools_->lastLayerEE() : maxLayer),
+      nLayer_(maxLayer_ - minLayer_ + 1),
+      subDet_(subDet) {
   assert(nLayer_ > 0);
-
-  minHitE_ = minHitE;
-  minHitET_ = minHitET;
-  minHitET2_ = minHitET * minHitET;
-  minLayer_ = minLayer;
-  maxLayer_ = maxLayer;
-  subDet_ = subDet;
-
   setFilteredHitsAndFractions(hitsAndFracs);
-
   setLayerWiseInfo();
 }
 
-void HGCalShowerShapeHelper::setPFRecHitPtrMap(const std::vector<reco::PFRecHit> &recHits) {
-  pfRecHitPtrMap_.clear();
-
-  for (const auto &recHit : recHits) {
-    pfRecHitPtrMap_[recHit.detId()] = &recHit;
-  }
+double HGCalShowerShapeHelper::ShowerShapeCalc::getCellSize(DetId detId) const {
+  return recHitTools_->getSiThickIndex(detId) == 0 ? kHDWaferCellSize_ : kLDWaferCellSize_;
 }
 
-void HGCalShowerShapeHelper::setFilteredHitsAndFractions(const std::vector<std::pair<DetId, float> > &hitsAndFracs) {
-  hitsAndFracs_.clear();
-  hitEnergies_.clear();
-  hitEnergiesWithFracs_.clear();
-
-  for (const auto &hnf : hitsAndFracs) {
-    DetId hitId = hnf.first;
-    float hitEfrac = hnf.second;
-
-    int hitLayer = recHitTools_.getLayer(hitId);
-
-    if (hitLayer > nLayer_) {
-      continue;
-    }
-
-    if (hitId.det() != subDet_) {
-      continue;
-    }
-
-    if (pfRecHitPtrMap_.find(hitId.rawId()) == pfRecHitPtrMap_.end()) {
-      continue;
-    }
-
-    const reco::PFRecHit &recHit = *pfRecHitPtrMap_[hitId.rawId()];
-
-    if (recHit.energy() < minHitE_) {
-      continue;
-    }
-
-    if (recHit.pt2() < minHitET2_) {
-      continue;
-    }
-
-    // Fill the vectors
-    hitsAndFracs_.push_back(hnf);
-    hitEnergies_.push_back(recHit.energy());
-    hitEnergiesWithFracs_.push_back(recHit.energy() * hitEfrac);
-  }
-}
-
-void HGCalShowerShapeHelper::setLayerWiseInfo() {
-  layerEnergies_.clear();
-  layerEnergies_.resize(nLayer_);
-
-  layerCentroids_.clear();
-  layerCentroids_.resize(nLayer_);
-
-  centroid_.SetXYZ(0, 0, 0);
-
-  int iHit = -1;
-  double totalW = 0.0;
-
-  // Compute the centroid per layer
-  for (const auto &hnf : hitsAndFracs_) {
-    iHit++;
-
-    DetId hitId = hnf.first;
-
-    double weight = hitEnergies_[iHit];
-    totalW += weight;
-
-    const auto &hitPos = recHitTools_.getPosition(hitId);
-    ROOT::Math::XYZVector hitXYZ(hitPos.x(), hitPos.y(), hitPos.z());
-
-    centroid_ += weight * hitXYZ;
-
-    int hitLayer = recHitTools_.getLayer(hitId) - 1;
-
-    layerEnergies_[hitLayer] += weight;
-    layerCentroids_[hitLayer] += weight * hitXYZ;
-  }
-
-  int iLayer = -1;
-
-  for (auto &centroid : layerCentroids_) {
-    iLayer++;
-
-    if (layerEnergies_[iLayer]) {
-      centroid /= layerEnergies_[iLayer];
-    }
-  }
-
-  if (totalW) {
-    centroid_ /= totalW;
-  }
-}
-
-const double HGCalShowerShapeHelper::getCellSize(DetId detId) {
-  return recHitTools_.getSiThickIndex(detId) == 0 ? kHDWaferCellSize_ : kLDWaferCellSize_;
-}
-
-const double HGCalShowerShapeHelper::getRvar(double cylinderR, double energyNorm, bool useFractions, bool useCellSize) {
+double HGCalShowerShapeHelper::ShowerShapeCalc::getRvar(double cylinderR, bool useFractions, bool useCellSize) const {
   if (hitsAndFracs_.empty()) {
     return 0.0;
   }
 
-  if (energyNorm <= 0.0) {
+  if (rawEnergy_ <= 0.0) {
     edm::LogWarning("HGCalShowerShapeHelper")
-        << "Encountered negative or zero energy for HGCal R-variable denominator: " << energyNorm << std::endl;
+        << "Encountered negative or zero energy for HGCal R-variable denominator: " << rawEnergy_ << std::endl;
   }
 
   double cylinderR2 = cylinderR * cylinderR;
@@ -157,9 +55,9 @@ const double HGCalShowerShapeHelper::getRvar(double cylinderR, double energyNorm
 
     DetId hitId = hnf.first;
 
-    int hitLayer = recHitTools_.getLayer(hitId) - 1;
+    int hitLayer = recHitTools_->getLayer(hitId) - 1;
 
-    const auto &hitPos = recHitTools_.getPosition(hitId);
+    const auto &hitPos = recHitTools_->getPosition(hitId);
     ROOT::Math::XYZVector hitXYZ(hitPos.x(), hitPos.y(), hitPos.z());
 
     auto distXYZ = hitXYZ - layerCentroids_[hitLayer];
@@ -180,12 +78,13 @@ const double HGCalShowerShapeHelper::getRvar(double cylinderR, double energyNorm
     rVar += *hitEnergyIter;
   }
 
-  rVar /= energyNorm;
+  rVar /= rawEnergy_;
 
   return rVar;
 }
 
-const HGCalShowerShapeHelper::ShowerWidths HGCalShowerShapeHelper::getPCAWidths(double cylinderR, bool useFractions) {
+HGCalShowerShapeHelper::ShowerWidths HGCalShowerShapeHelper::ShowerShapeCalc::getPCAWidths(double cylinderR,
+                                                                                           bool useFractions) const {
   if (hitsAndFracs_.empty()) {
     return ShowerWidths();
   }
@@ -214,10 +113,10 @@ const HGCalShowerShapeHelper::ShowerWidths HGCalShowerShapeHelper::getPCAWidths(
 
     DetId hitId = hnf.first;
 
-    const auto &hitPos = recHitTools_.getPosition(hitId);
+    const auto &hitPos = recHitTools_->getPosition(hitId);
     ROOT::Math::XYZVector hitXYZ(hitPos.x(), hitPos.y(), hitPos.z());
 
-    int hitLayer = recHitTools_.getLayer(hitId) - 1;
+    int hitLayer = recHitTools_->getLayer(hitId) - 1;
 
     ROOT::Math::XYZVector radXYZ = hitXYZ - layerCentroids_[hitLayer];
 
@@ -288,4 +187,144 @@ const HGCalShowerShapeHelper::ShowerWidths HGCalShowerShapeHelper::getPCAWidths(
   returnWidths.sigma2ww = eigVals(0);
 
   return returnWidths;
+}
+
+std::vector<double> HGCalShowerShapeHelper::ShowerShapeCalc::getEnergyHighestHits(unsigned int nrHits,
+                                                                                  bool useFractions) const {
+  std::vector<double> sortedEnergies(nrHits, 0.);
+  const auto &hits = useFractions ? hitEnergiesWithFracs_ : hitEnergies_;
+  std::partial_sort_copy(
+      hits.begin(), hits.end(), sortedEnergies.begin(), sortedEnergies.end(), std::greater<double>());
+  return sortedEnergies;
+}
+
+void HGCalShowerShapeHelper::ShowerShapeCalc::setFilteredHitsAndFractions(
+    const std::vector<std::pair<DetId, float>> &hitsAndFracs) {
+  hitsAndFracs_.clear();
+  hitEnergies_.clear();
+  hitEnergiesWithFracs_.clear();
+
+  for (const auto &hnf : hitsAndFracs) {
+    DetId hitId = hnf.first;
+    float hitEfrac = hnf.second;
+
+    int hitLayer = recHitTools_->getLayer(hitId);
+
+    if (hitLayer > nLayer_) {
+      continue;
+    }
+
+    if (hitId.det() != subDet_) {
+      continue;
+    }
+    auto hitIt = pfRecHitPtrMap_->find(hitId.rawId());
+    if (hitIt == pfRecHitPtrMap_->end()) {
+      continue;
+    }
+
+    const reco::PFRecHit &recHit = *hitIt->second;
+
+    if (recHit.energy() < minHitE_) {
+      continue;
+    }
+
+    if (recHit.pt2() < minHitET2_) {
+      continue;
+    }
+
+    // Fill the vectors
+    hitsAndFracs_.push_back(hnf);
+    hitEnergies_.push_back(recHit.energy());
+    hitEnergiesWithFracs_.push_back(recHit.energy() * hitEfrac);
+  }
+}
+
+void HGCalShowerShapeHelper::ShowerShapeCalc::setLayerWiseInfo() {
+  layerEnergies_.clear();
+  layerEnergies_.resize(nLayer_);
+
+  layerCentroids_.clear();
+  layerCentroids_.resize(nLayer_);
+
+  centroid_.SetXYZ(0, 0, 0);
+
+  int iHit = -1;
+  double totalW = 0.0;
+
+  // Compute the centroid per layer
+  for (const auto &hnf : hitsAndFracs_) {
+    iHit++;
+
+    DetId hitId = hnf.first;
+
+    double weight = hitEnergies_[iHit];
+    totalW += weight;
+
+    const auto &hitPos = recHitTools_->getPosition(hitId);
+    ROOT::Math::XYZVector hitXYZ(hitPos.x(), hitPos.y(), hitPos.z());
+
+    centroid_ += weight * hitXYZ;
+
+    int hitLayer = recHitTools_->getLayer(hitId) - 1;
+
+    layerEnergies_[hitLayer] += weight;
+    layerCentroids_[hitLayer] += weight * hitXYZ;
+  }
+
+  int iLayer = -1;
+
+  for (auto &centroid : layerCentroids_) {
+    iLayer++;
+
+    if (layerEnergies_[iLayer]) {
+      centroid /= layerEnergies_[iLayer];
+    }
+  }
+
+  if (totalW) {
+    centroid_ /= totalW;
+  }
+}
+
+HGCalShowerShapeHelper::HGCalShowerShapeHelper()
+    : recHitTools_(std::make_shared<hgcal::RecHitTools>()),
+      pfRecHitPtrMap_(std::make_shared<std::unordered_map<uint32_t, const reco::PFRecHit *>>()) {}
+
+HGCalShowerShapeHelper::HGCalShowerShapeHelper(edm::ConsumesCollector &&sumes)
+    : recHitTools_(std::make_shared<hgcal::RecHitTools>()),
+      pfRecHitPtrMap_(std::make_shared<std::unordered_map<uint32_t, const reco::PFRecHit *>>()) {
+  setTokens(sumes);
+}
+
+void HGCalShowerShapeHelper::initPerSetup(const edm::EventSetup &iSetup) {
+  recHitTools_->setGeometry(iSetup.getData(caloGeometryToken_));
+}
+
+void HGCalShowerShapeHelper::initPerEvent(const std::vector<reco::PFRecHit> &pfRecHits) {
+  setPFRecHitPtrMap(pfRecHits);
+}
+
+void HGCalShowerShapeHelper::initPerEvent(const edm::EventSetup &iSetup, const std::vector<reco::PFRecHit> &pfRecHits) {
+  initPerSetup(iSetup);
+  initPerEvent(pfRecHits);
+}
+
+HGCalShowerShapeHelper::ShowerShapeCalc HGCalShowerShapeHelper::createCalc(
+    const std::vector<std::pair<DetId, float>> &hitsAndFracs,
+    double rawEnergy,
+    double minHitE,
+    double minHitET,
+    int minLayer,
+    int maxLayer,
+    DetId::Detector subDet) const {
+  return ShowerShapeCalc(
+      recHitTools_, pfRecHitPtrMap_, hitsAndFracs, rawEnergy, minHitE, minHitET, minLayer, maxLayer, subDet);
+}
+
+void HGCalShowerShapeHelper::setPFRecHitPtrMap(const std::vector<reco::PFRecHit> &recHits) {
+  pfRecHitPtrMap_->clear();
+
+  for (const auto &recHit : recHits) {
+    (*pfRecHitPtrMap_)[recHit.detId()] = &recHit;
+  }
 }


### PR DESCRIPTION
#### PR description:

This PR enables the HGCAL regressions for phase-II and is needed for the HLT TDR. It also modernises the class while doing so.   RECO results will change in both phase-II and Run2/3, with the later just coming from a numerical precision effect. While there is a no change policy for RECO in non-phase-II, I would argue this is exempt  as it is arguably a bug fix as it no longer needlessly casts the supercluster energy to a float and thus should go in as is


#### PR validation:

Tested in HLT TDR setup. 

#### if this PR is a backport please specify the original PR and why you need to backport that PR:
backport of https://github.com/cms-sw/cmssw/pull/32901
