### PR TITLE
PPS strings --> InputTag

### DIFF
--- a/RecoPPS/Local/plugins/CTPPSPixelClusterProducer.cc
+++ b/RecoPPS/Local/plugins/CTPPSPixelClusterProducer.cc
@@ -3,8 +3,7 @@
 #include "RecoPPS/Local/interface/CTPPSPixelClusterProducer.h"
 
 CTPPSPixelClusterProducer::CTPPSPixelClusterProducer(const edm::ParameterSet &conf)
-    : tokenCTPPSPixelDigi_(
-          consumes<edm::DetSetVector<CTPPSPixelDigi> >(conf.getParameter<edm::InputTag>("label"))),
+    : tokenCTPPSPixelDigi_(consumes<edm::DetSetVector<CTPPSPixelDigi> >(conf.getParameter<edm::InputTag>("label"))),
       tokenCTPPSPixelAnalysisMask_(esConsumes()),
       tokenGainCalib_(esConsumes()),
       verbosity_(conf.getUntrackedParameter<int>("RPixVerbosity")),

--- a/RecoPPS/Local/plugins/CTPPSPixelClusterProducer.cc
+++ b/RecoPPS/Local/plugins/CTPPSPixelClusterProducer.cc
@@ -3,7 +3,7 @@
 #include "RecoPPS/Local/interface/CTPPSPixelClusterProducer.h"
 
 CTPPSPixelClusterProducer::CTPPSPixelClusterProducer(const edm::ParameterSet &conf)
-    : tokenCTPPSPixelDigi_(consumes<edm::DetSetVector<CTPPSPixelDigi> >(conf.getParameter<edm::InputTag>("label"))),
+    : tokenCTPPSPixelDigi_(consumes<edm::DetSetVector<CTPPSPixelDigi> >(conf.getParameter<edm::InputTag>("tag"))),
       tokenCTPPSPixelAnalysisMask_(esConsumes()),
       tokenGainCalib_(esConsumes()),
       verbosity_(conf.getUntrackedParameter<int>("RPixVerbosity")),
@@ -16,7 +16,7 @@ CTPPSPixelClusterProducer::~CTPPSPixelClusterProducer() {}
 void CTPPSPixelClusterProducer::fillDescriptions(edm::ConfigurationDescriptions &descriptions) {
   edm::ParameterSetDescription desc;
   desc.addUntracked<int>("RPixVerbosity", 0);
-  desc.add<edm::InputTag>("label", edm::InputTag("ctppsPixelDigis"));
+  desc.add<edm::InputTag>("tag", edm::InputTag("ctppsPixelDigis"));
   desc.add<int>("SeedADCThreshold", 2);
   desc.add<int>("ADCThreshold", 2);
   desc.add<double>("ElectronADCGain", 135.0);

--- a/RecoPPS/Local/plugins/CTPPSPixelClusterProducer.cc
+++ b/RecoPPS/Local/plugins/CTPPSPixelClusterProducer.cc
@@ -4,7 +4,7 @@
 
 CTPPSPixelClusterProducer::CTPPSPixelClusterProducer(const edm::ParameterSet &conf)
     : tokenCTPPSPixelDigi_(
-          consumes<edm::DetSetVector<CTPPSPixelDigi> >(edm::InputTag(conf.getParameter<std::string>("label")))),
+          consumes<edm::DetSetVector<CTPPSPixelDigi> >(conf.getParameter<edm::InputTag>("label"))),
       tokenCTPPSPixelAnalysisMask_(esConsumes()),
       tokenGainCalib_(esConsumes()),
       verbosity_(conf.getUntrackedParameter<int>("RPixVerbosity")),
@@ -17,7 +17,7 @@ CTPPSPixelClusterProducer::~CTPPSPixelClusterProducer() {}
 void CTPPSPixelClusterProducer::fillDescriptions(edm::ConfigurationDescriptions &descriptions) {
   edm::ParameterSetDescription desc;
   desc.addUntracked<int>("RPixVerbosity", 0);
-  desc.add<std::string>("label", "ctppsPixelDigis");
+  desc.add<edm::InputTag>("label", edm::InputTag("ctppsPixelDigis"));
   desc.add<int>("SeedADCThreshold", 2);
   desc.add<int>("ADCThreshold", 2);
   desc.add<double>("ElectronADCGain", 135.0);

--- a/RecoPPS/Local/plugins/CTPPSPixelLocalTrackProducer.cc
+++ b/RecoPPS/Local/plugins/CTPPSPixelLocalTrackProducer.cc
@@ -70,7 +70,7 @@ private:
 //------------------------------------------------------------------------------------------------//
 
 CTPPSPixelLocalTrackProducer::CTPPSPixelLocalTrackProducer(const edm::ParameterSet &parameterSet) {
-  inputTag_ = parameterSet.getParameter<edm::InputTag>("label");
+  inputTag_ = parameterSet.getParameter<edm::InputTag>("tag");
   verbosity_ = parameterSet.getUntrackedParameter<int>("verbosity");
   maxHitPerRomanPot_ = parameterSet.getParameter<int>("maxHitPerRomanPot");
   maxHitPerPlane_ = parameterSet.getParameter<int>("maxHitPerPlane");
@@ -119,8 +119,8 @@ CTPPSPixelLocalTrackProducer::~CTPPSPixelLocalTrackProducer() {}
 void CTPPSPixelLocalTrackProducer::fillDescriptions(edm::ConfigurationDescriptions &descriptions) {
   edm::ParameterSetDescription desc;
 
-  desc.add<edm::InputTag>("label", edm::InputTag("ctppsPixelRecHits"))
-      ->setComment("label of the RecHits input for the tracking algorithm");
+  desc.add<edm::InputTag>("tag", edm::InputTag("ctppsPixelRecHits"))
+      ->setComment("inputTag of the RecHits input for the tracking algorithm");
   desc.add<std::string>("patternFinderAlgorithm", "RPixRoadFinder")->setComment("algorithm type for pattern finder");
   desc.add<std::string>("trackFinderAlgorithm", "RPixPlaneCombinatoryTracking")
       ->setComment("algorithm type for track finder");

--- a/RecoPPS/Local/plugins/CTPPSPixelLocalTrackProducer.cc
+++ b/RecoPPS/Local/plugins/CTPPSPixelLocalTrackProducer.cc
@@ -70,7 +70,7 @@ private:
 //------------------------------------------------------------------------------------------------//
 
 CTPPSPixelLocalTrackProducer::CTPPSPixelLocalTrackProducer(const edm::ParameterSet &parameterSet) {
-  inputTag_ = parameterSet.getParameter<std::string>("label");
+  inputTag_ = parameterSet.getParameter<edm::InputTag>("label");
   verbosity_ = parameterSet.getUntrackedParameter<int>("verbosity");
   maxHitPerRomanPot_ = parameterSet.getParameter<int>("maxHitPerRomanPot");
   maxHitPerPlane_ = parameterSet.getParameter<int>("maxHitPerPlane");
@@ -104,7 +104,7 @@ CTPPSPixelLocalTrackProducer::CTPPSPixelLocalTrackProducer(const edm::ParameterS
   trackFinder_->setListOfPlanes(listOfAllPlanes_);
   trackFinder_->initialize();
 
-  tokenCTPPSPixelRecHit_ = consumes<edm::DetSetVector<CTPPSPixelRecHit>>(edm::InputTag(inputTag_));
+  tokenCTPPSPixelRecHit_ = consumes<edm::DetSetVector<CTPPSPixelRecHit>>(inputTag_);
   tokenCTPPSGeometry_ = esConsumes<CTPPSGeometry, VeryForwardRealGeometryRecord>();
 
   produces<edm::DetSetVector<CTPPSPixelLocalTrack>>();
@@ -119,7 +119,7 @@ CTPPSPixelLocalTrackProducer::~CTPPSPixelLocalTrackProducer() {}
 void CTPPSPixelLocalTrackProducer::fillDescriptions(edm::ConfigurationDescriptions &descriptions) {
   edm::ParameterSetDescription desc;
 
-  desc.add<std::string>("label", "ctppsPixelRecHits")
+  desc.add<edm::InputTag>("label", edm::InputTag("ctppsPixelRecHits"))
       ->setComment("label of the RecHits input for the tracking algorithm");
   desc.add<std::string>("patternFinderAlgorithm", "RPixRoadFinder")->setComment("algorithm type for pattern finder");
   desc.add<std::string>("trackFinderAlgorithm", "RPixPlaneCombinatoryTracking")


### PR DESCRIPTION
This PR is only to make the input variables of the producers consistent across the board and get the flexibility provided by InputTags. It has been tested both with the reco and PPS direct simulation workflows. 