### PR TITLE
Separate Algorithms for GE0 and GE1/1 GE2/1 Segments

### DIFF
--- a/RecoLocalMuon/GEMSegment/plugins/GEMSegmentBuilder.cc
+++ b/RecoLocalMuon/GEMSegment/plugins/GEMSegmentBuilder.cc
@@ -14,7 +14,8 @@ GEMSegmentBuilder::GEMSegmentBuilder(const edm::ParameterSet& ps) : geom_(nullpt
   segAlgoName = ps.getParameter<std::string>("algo_name");
   ge0AlgoName = ps.getParameter<std::string>("ge0_name");
 
-  edm::LogVerbatim("GEMSegmentBuilder") << "GEMSegmentBuilder algorithm : ge0 name : " << ge0AlgoName << " name: " << segAlgoName;
+  edm::LogVerbatim("GEMSegmentBuilder") << "GEMSegmentBuilder algorithm : ge0 name : " << ge0AlgoName
+                                        << " name: " << segAlgoName;
 
   // SegAlgo parameter set
   segAlgoPSet = ps.getParameter<edm::ParameterSet>("algo_pset");

--- a/RecoLocalMuon/GEMSegment/plugins/GEMSegmentBuilder.cc
+++ b/RecoLocalMuon/GEMSegment/plugins/GEMSegmentBuilder.cc
@@ -21,9 +21,8 @@ GEMSegmentBuilder::GEMSegmentBuilder(const edm::ParameterSet& ps) : geom_(nullpt
   segAlgoPSet = ps.getParameter<edm::ParameterSet>("algo_pset");
   ge0AlgoPSet = ps.getParameter<edm::ParameterSet>("ge0_pset");
 
-  // Ask factory to build this algorithm, giving it appropriate ParameterSet
+  // Ask factory to build these algorithms, giving it appropriate ParameterSets
   segAlgo = GEMSegmentBuilderPluginFactory::get()->create(segAlgoName, segAlgoPSet);
-  // Ask factory to build this algorithm, giving it appropriate ParameterSet
   ge0Algo = GEMSegmentBuilderPluginFactory::get()->create(ge0AlgoName, ge0AlgoPSet);
 }
 GEMSegmentBuilder::~GEMSegmentBuilder() {}

--- a/RecoLocalMuon/GEMSegment/plugins/GEMSegmentBuilder.cc
+++ b/RecoLocalMuon/GEMSegment/plugins/GEMSegmentBuilder.cc
@@ -11,19 +11,19 @@
 
 GEMSegmentBuilder::GEMSegmentBuilder(const edm::ParameterSet& ps) : geom_(nullptr) {
   // Algo name
-  segName = ps.getParameter<std::string>("algo_name");
-  ge0Name = ps.getParameter<std::string>("ge0_name");
+  segAlgoName = ps.getParameter<std::string>("algo_name");
+  ge0AlgoName = ps.getParameter<std::string>("ge0_name");
 
-  edm::LogVerbatim("GEMSegmentBuilder") << "GEMSegmentBuilder algorithm : ge0 name : " << ge0Name << " name: " << algoName;
+  edm::LogVerbatim("GEMSegmentBuilder") << "GEMSegmentBuilder algorithm : ge0 name : " << ge0AlgoName << " name: " << segAlgoName;
 
   // SegAlgo parameter set
   segAlgoPSet = ps.getParameter<edm::ParameterSet>("algo_pset");
   ge0AlgoPSet = ps.getParameter<edm::ParameterSet>("ge0_pset");
 
   // Ask factory to build this algorithm, giving it appropriate ParameterSet
-  seg_algo = GEMSegmentBuilderPluginFactory::get()->create(segName, segAlgoPSet);
+  segAlgo = GEMSegmentBuilderPluginFactory::get()->create(segAlgoName, segAlgoPSet);
   // Ask factory to build this algorithm, giving it appropriate ParameterSet
-  ge0_algo = GEMSegmentBuilderPluginFactory::get()->create(ge0Name, ge0AlgoPSet);
+  ge0Algo = GEMSegmentBuilderPluginFactory::get()->create(ge0AlgoName, ge0AlgoPSet);
 }
 GEMSegmentBuilder::~GEMSegmentBuilder() {}
 
@@ -93,7 +93,7 @@ void GEMSegmentBuilder::build(const GEMRecHitCollection* recHits, GEMSegmentColl
 
     // given the superchamber select the appropriate algo... and run it
     std::vector<GEMSegment> segv;
-    if (chamber->station() == 0)
+    if (chamber->id().station() == 0)
       segv = ge0Algo->run(ensemble, gemRecHits);
     else
       segv = segAlgo->run(ensemble, gemRecHits);

--- a/RecoLocalMuon/GEMSegment/plugins/GEMSegmentBuilder.cc
+++ b/RecoLocalMuon/GEMSegment/plugins/GEMSegmentBuilder.cc
@@ -11,15 +11,19 @@
 
 GEMSegmentBuilder::GEMSegmentBuilder(const edm::ParameterSet& ps) : geom_(nullptr) {
   // Algo name
-  algoName = ps.getParameter<std::string>("algo_name");
+  segName = ps.getParameter<std::string>("algo_name");
+  ge0Name = ps.getParameter<std::string>("ge0_name");
 
-  edm::LogVerbatim("GEMSegmentBuilder") << "GEMSegmentBuilder algorithm name: " << algoName;
+  edm::LogVerbatim("GEMSegmentBuilder") << "GEMSegmentBuilder algorithm : ge0 name : " << ge0Name << " name: " << algoName;
 
   // SegAlgo parameter set
   segAlgoPSet = ps.getParameter<edm::ParameterSet>("algo_pset");
+  ge0AlgoPSet = ps.getParameter<edm::ParameterSet>("ge0_pset");
 
   // Ask factory to build this algorithm, giving it appropriate ParameterSet
-  algo = GEMSegmentBuilderPluginFactory::get()->create(algoName, segAlgoPSet);
+  seg_algo = GEMSegmentBuilderPluginFactory::get()->create(segName, segAlgoPSet);
+  // Ask factory to build this algorithm, giving it appropriate ParameterSet
+  ge0_algo = GEMSegmentBuilderPluginFactory::get()->create(ge0Name, ge0AlgoPSet);
 }
 GEMSegmentBuilder::~GEMSegmentBuilder() {}
 
@@ -88,7 +92,11 @@ void GEMSegmentBuilder::build(const GEMRecHitCollection* recHits, GEMSegmentColl
 #endif
 
     // given the superchamber select the appropriate algo... and run it
-    std::vector<GEMSegment> segv = algo->run(ensemble, gemRecHits);
+    std::vector<GEMSegment> segv;
+    if (chamber->station() == 0)
+      segv = ge0Algo->run(ensemble, gemRecHits);
+    else
+      segv = segAlgo->run(ensemble, gemRecHits);
 #ifdef EDM_ML_DEBUG  // have lines below only compiled when in debug mode
     LogTrace("GEMSegmentBuilder") << "[GEMSegmentBuilder::build] found " << segv.size();
 #endif

--- a/RecoLocalMuon/GEMSegment/plugins/GEMSegmentBuilder.cc
+++ b/RecoLocalMuon/GEMSegment/plugins/GEMSegmentBuilder.cc
@@ -21,7 +21,7 @@ GEMSegmentBuilder::GEMSegmentBuilder(const edm::ParameterSet& ps) : geom_(nullpt
   segAlgoPSet = ps.getParameter<edm::ParameterSet>("algo_pset");
   ge0AlgoPSet = ps.getParameter<edm::ParameterSet>("ge0_pset");
 
-  // Ask factory to build these algorithms, giving it appropriate ParameterSets
+  // Ask factory to build these algorithms, giving them the appropriate ParameterSets
   segAlgo = GEMSegmentBuilderPluginFactory::get()->create(segAlgoName, segAlgoPSet);
   ge0Algo = GEMSegmentBuilderPluginFactory::get()->create(ge0AlgoName, ge0AlgoPSet);
 }

--- a/RecoLocalMuon/GEMSegment/plugins/GEMSegmentBuilder.h
+++ b/RecoLocalMuon/GEMSegment/plugins/GEMSegmentBuilder.h
@@ -40,9 +40,12 @@ public:
   void setGeometry(const GEMGeometry* g);
 
 private:
-  std::string algoName;
+  std::string segAlgoName;
+  std::string ge0AlgoName;
   edm::ParameterSet segAlgoPSet;
-  std::unique_ptr<GEMSegmentAlgorithmBase> algo;
+  edm::ParameterSet ge0AlgoPSet;
+  std::unique_ptr<GEMSegmentAlgorithmBase> segAlgo;
+  std::unique_ptr<GEMSegmentAlgorithmBase> ge0Algo;
   const GEMGeometry* geom_;
 };
 

--- a/RecoLocalMuon/GEMSegment/python/gemSegments_cfi.py
+++ b/RecoLocalMuon/GEMSegment/python/gemSegments_cfi.py
@@ -1,25 +1,24 @@
 import FWCore.ParameterSet.Config as cms
 
-# defaults for GE0SegAlgoRU
-RU_GE0 = cms.PSet(
-    allowWideSegments = cms.bool(True),
-    doCollisions = cms.bool(True),
-    maxChi2Additional = cms.double(100.0),
-    maxChi2Prune = cms.double(50),
-    maxChi2GoodSeg = cms.double(50),
-    maxPhiSeeds = cms.double(0.001096605744), #Assuming 384 strips
-    maxPhiAdditional = cms.double(0.001096605744), #Assuming 384 strips
-    maxETASeeds = cms.double(0.1), #Assuming 8 eta partitions
-    maxTOFDiff = cms.double(25),
-    requireCentralBX = cms.bool(True), #require that a majority of hits come from central BX
-    minNumberOfHits = cms.uint32(4),
-    maxNumberOfHits = cms.uint32(300),
-    maxNumberOfHitsPerLayer = cms.uint32(100),
-)
-
 gemSegments = cms.EDProducer("GEMSegmentProducer",
     gemRecHitLabel = cms.InputTag("gemRecHits"),
+    ge0_name = cms.string("GE0SegAlgoRU"),
     algo_name = cms.string("GEMSegmentAlgorithm"),
+    ge0_pset = cms.PSet(
+        allowWideSegments = cms.bool(True),
+        doCollisions = cms.bool(True),
+        maxChi2Additional = cms.double(100.0),
+        maxChi2Prune = cms.double(50),
+        maxChi2GoodSeg = cms.double(50),
+        maxPhiSeeds = cms.double(0.001096605744), #Assuming 384 strips
+        maxPhiAdditional = cms.double(0.001096605744), #Assuming 384 strips
+        maxETASeeds = cms.double(0.1), #Assuming 8 eta partitions
+        maxTOFDiff = cms.double(25),
+        requireCentralBX = cms.bool(True), #require that a majority of hits come from central BX
+        minNumberOfHits = cms.uint32(4),
+        maxNumberOfHits = cms.uint32(300),
+        maxNumberOfHitsPerLayer = cms.uint32(100),
+    ),
     algo_pset = cms.PSet(
         minHitsPerSegment = cms.uint32(2),
         preClustering = cms.bool(True),            # False => all hits in chamber are given to the fitter 


### PR DESCRIPTION
#### PR description:

For ME0, the RU segment builder was default while GEMSegmentAlgorithm is used for the other GEM stations. This PR allows separate GE0 and other GEM algorithms, and defaults GE0 to use the RU algorithm, and GE1/1 / GE2/1 to use the GEMSegmentAlgorithm, as is the default for the ME0/GEM setup.

@jshlee

<!-- Please replace this text with a description of the feature proposed or problem addressed, specifying:
  - what changes are expected in the output if any, 
  - what other PRs or externals it depends upon if any,
  - link to any additional material useful to provide a documentation for this PR (slides, JIRA tickets, related pull requestes, hypernews, TWiki or Indico pages)  -->

#### PR validation:

We checked the performance of the GE0 RU algorithm and found it to work as for ME0. I also ran runTheMatrix with workflow 34621.0 and confirmed that both station 0 and 1/2 segments are being created properly.

<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

<!-- Please replace this text with any link to  -->

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
