### PR TITLE
[PPS] Cloning of geometry definition objects prior to their usage/modification in validation tools

### DIFF
--- a/Geometry/VeryForwardGeometry/python/commons_cff.py
+++ b/Geometry/VeryForwardGeometry/python/commons_cff.py
@@ -1,0 +1,15 @@
+import FWCore.ParameterSet.Config as cms
+from importlib import import_module
+
+def cloneGeometry(mod_path):
+    _geom = import_module(mod_path)
+    totemGeomXMLFiles = _geom.totemGeomXMLFiles.clone()
+    ctppsDiamondGeomXMLFiles = _geom.ctppsDiamondGeomXMLFiles.clone()
+    ctppsUFSDGeomXMLFiles = _geom.ctppsUFSDGeomXMLFiles.clone()
+    ctppsPixelGeomXMLFiles = _geom.ctppsPixelGeomXMLFiles.clone()
+    XMLIdealGeometryESSource_CTPPS = _geom.XMLIdealGeometryESSource_CTPPS.clone(
+        geomXMLFiles = totemGeomXMLFiles + ctppsDiamondGeomXMLFiles + ctppsUFSDGeomXMLFiles + ctppsPixelGeomXMLFiles
+    )
+    ctppsGeometryESModule = _geom.ctppsGeometryESModule.clone()
+
+    return (XMLIdealGeometryESSource_CTPPS, ctppsGeometryESModule)

--- a/Geometry/VeryForwardGeometry/python/commons_cff.py
+++ b/Geometry/VeryForwardGeometry/python/commons_cff.py
@@ -4,13 +4,13 @@ from copy import copy
 
 def cloneGeometry(mod_path):
     _geom = import_module(mod_path)
+
     totemGeomXMLFiles = copy(_geom.totemGeomXMLFiles)
     ctppsDiamondGeomXMLFiles = copy(_geom.ctppsDiamondGeomXMLFiles)
     ctppsUFSDGeomXMLFiles = copy(_geom.ctppsUFSDGeomXMLFiles)
     ctppsPixelGeomXMLFiles = copy(_geom.ctppsPixelGeomXMLFiles)
-    XMLIdealGeometryESSource_CTPPS = _geom.XMLIdealGeometryESSource_CTPPS.clone(
-        geomXMLFiles = totemGeomXMLFiles + ctppsDiamondGeomXMLFiles + ctppsUFSDGeomXMLFiles + ctppsPixelGeomXMLFiles
-    )
+
+    XMLIdealGeometryESSource_CTPPS = _geom.XMLIdealGeometryESSource_CTPPS.clone()
     ctppsGeometryESModule = _geom.ctppsGeometryESModule.clone()
 
     return (XMLIdealGeometryESSource_CTPPS, ctppsGeometryESModule)

--- a/Geometry/VeryForwardGeometry/python/commons_cff.py
+++ b/Geometry/VeryForwardGeometry/python/commons_cff.py
@@ -1,12 +1,13 @@
 import FWCore.ParameterSet.Config as cms
 from importlib import import_module
+from copy import copy
 
 def cloneGeometry(mod_path):
     _geom = import_module(mod_path)
-    totemGeomXMLFiles = _geom.totemGeomXMLFiles.clone()
-    ctppsDiamondGeomXMLFiles = _geom.ctppsDiamondGeomXMLFiles.clone()
-    ctppsUFSDGeomXMLFiles = _geom.ctppsUFSDGeomXMLFiles.clone()
-    ctppsPixelGeomXMLFiles = _geom.ctppsPixelGeomXMLFiles.clone()
+    totemGeomXMLFiles = copy(_geom.totemGeomXMLFiles)
+    ctppsDiamondGeomXMLFiles = copy(_geom.ctppsDiamondGeomXMLFiles)
+    ctppsUFSDGeomXMLFiles = copy(_geom.ctppsUFSDGeomXMLFiles)
+    ctppsPixelGeomXMLFiles = copy(_geom.ctppsPixelGeomXMLFiles)
     XMLIdealGeometryESSource_CTPPS = _geom.XMLIdealGeometryESSource_CTPPS.clone(
         geomXMLFiles = totemGeomXMLFiles + ctppsDiamondGeomXMLFiles + ctppsUFSDGeomXMLFiles + ctppsPixelGeomXMLFiles
     )

--- a/Geometry/VeryForwardGeometry/python/commons_cff.py
+++ b/Geometry/VeryForwardGeometry/python/commons_cff.py
@@ -3,13 +3,14 @@ from importlib import import_module
 from copy import copy
 
 def cloneGeometry(mod_path):
+    # start by importing the actual module to be cloned
     _geom = import_module(mod_path)
-
+    # clone all geometry DDL files
     totemGeomXMLFiles = copy(_geom.totemGeomXMLFiles)
     ctppsDiamondGeomXMLFiles = copy(_geom.ctppsDiamondGeomXMLFiles)
     ctppsUFSDGeomXMLFiles = copy(_geom.ctppsUFSDGeomXMLFiles)
     ctppsPixelGeomXMLFiles = copy(_geom.ctppsPixelGeomXMLFiles)
-
+    # clone the ESSource and ESModule to be returned
     XMLIdealGeometryESSource_CTPPS = _geom.XMLIdealGeometryESSource_CTPPS.clone()
     ctppsGeometryESModule = _geom.ctppsGeometryESModule.clone()
 

--- a/Validation/CTPPS/python/simu_config/year_2016_cff.py
+++ b/Validation/CTPPS/python/simu_config/year_2016_cff.py
@@ -10,11 +10,14 @@ profile_base_2016 = profile_base.clone(
 )
 
 # geometry (using 2017 here is OK)
-from Geometry.VeryForwardGeometry.geometryRPFromDD_2017_cfi import totemGeomXMLFiles, ctppsDiamondGeomXMLFiles, ctppsUFSDGeomXMLFiles, ctppsPixelGeomXMLFiles
-from Geometry.VeryForwardGeometry.geometryRPFromDD_2017_cfi import XMLIdealGeometryESSource_CTPPS
+from Geometry.VeryForwardGeometry.geometryRPFromDD_2017_cfi import totemGeomXMLFiles as _strip, ctppsDiamondGeomXMLFiles as _diam, ctppsUFSDGeomXMLFiles as _ufsd, ctppsPixelGeomXMLFiles as _pix
+from Geometry.VeryForwardGeometry.geometryRPFromDD_2017_cfi import XMLIdealGeometryESSource_CTPPS as _es_source
 from Geometry.VeryForwardGeometry.geometryRPFromDD_2017_cfi import ctppsGeometryESModule as _geom
+
 ctppsCompositeESSource.compactViewTag = _geom.compactViewTag
 ctppsCompositeESSource.isRun2 = _geom.isRun2
+
+XMLIdealGeometryESSource_CTPPS = _es_source.clone()
 
 # local reconstruction
 ctppsLocalTrackLiteProducer.includeStrips = True

--- a/Validation/CTPPS/python/simu_config/year_2016_cff.py
+++ b/Validation/CTPPS/python/simu_config/year_2016_cff.py
@@ -10,14 +10,11 @@ profile_base_2016 = profile_base.clone(
 )
 
 # geometry (using 2017 here is OK)
-from Geometry.VeryForwardGeometry.geometryRPFromDD_2017_cfi import totemGeomXMLFiles as _strip, ctppsDiamondGeomXMLFiles as _diam, ctppsUFSDGeomXMLFiles as _ufsd, ctppsPixelGeomXMLFiles as _pix
-from Geometry.VeryForwardGeometry.geometryRPFromDD_2017_cfi import XMLIdealGeometryESSource_CTPPS as _es_source
-from Geometry.VeryForwardGeometry.geometryRPFromDD_2017_cfi import ctppsGeometryESModule as _geom
+from Geometry.VeryForwardGeometry.commons_cff import cloneGeometry
+XMLIdealGeometryESSource_CTPPS, _ctppsGeometryESModule = cloneGeometry('Geometry.VeryForwardGeometry.geometryRPFromDD_2017_cfi')
 
-ctppsCompositeESSource.compactViewTag = _geom.compactViewTag
-ctppsCompositeESSource.isRun2 = _geom.isRun2
-
-XMLIdealGeometryESSource_CTPPS = _es_source.clone()
+ctppsCompositeESSource.compactViewTag = _ctppsGeometryESModule.compactViewTag
+ctppsCompositeESSource.isRun2 = _ctppsGeometryESModule.isRun2
 
 # local reconstruction
 ctppsLocalTrackLiteProducer.includeStrips = True

--- a/Validation/CTPPS/python/simu_config/year_2017_cff.py
+++ b/Validation/CTPPS/python/simu_config/year_2017_cff.py
@@ -29,11 +29,10 @@ profile_base_2017 = profile_base.clone(
 )
 
 # geometry
-from Geometry.VeryForwardGeometry.geometryRPFromDD_2017_cfi import totemGeomXMLFiles, ctppsDiamondGeomXMLFiles, ctppsUFSDGeomXMLFiles, ctppsPixelGeomXMLFiles
-from Geometry.VeryForwardGeometry.geometryRPFromDD_2017_cfi import XMLIdealGeometryESSource_CTPPS
-from Geometry.VeryForwardGeometry.geometryRPFromDD_2017_cfi import ctppsGeometryESModule as _geom
-ctppsCompositeESSource.compactViewTag = _geom.compactViewTag
-ctppsCompositeESSource.isRun2 = _geom.isRun2
+from Geometry.VeryForwardGeometry.commons_cff import cloneGeometry
+XMLIdealGeometryESSource_CTPPS, _ctppsGeometryESModule = cloneGeometry('Geometry.VeryForwardGeometry.geometryRPFromDD_2017_cfi')
+ctppsCompositeESSource.compactViewTag = _ctppsGeometryESModule.compactViewTag
+ctppsCompositeESSource.isRun2 = _ctppsGeometryESModule.isRun2
 
 # local reconstruction
 ctppsLocalTrackLiteProducer.includeStrips = True

--- a/Validation/CTPPS/python/simu_config/year_2018_cff.py
+++ b/Validation/CTPPS/python/simu_config/year_2018_cff.py
@@ -34,11 +34,10 @@ profile_base_2018 = profile_base.clone(
 )
 
 # geometry
-from Geometry.VeryForwardGeometry.geometryRPFromDD_2018_cfi import totemGeomXMLFiles, ctppsDiamondGeomXMLFiles, ctppsUFSDGeomXMLFiles, ctppsPixelGeomXMLFiles
-from Geometry.VeryForwardGeometry.geometryRPFromDD_2018_cfi import XMLIdealGeometryESSource_CTPPS
-from Geometry.VeryForwardGeometry.geometryRPFromDD_2018_cfi import ctppsGeometryESModule as _geom
-ctppsCompositeESSource.compactViewTag = _geom.compactViewTag
-ctppsCompositeESSource.isRun2 = _geom.isRun2
+from Geometry.VeryForwardGeometry.commons_cff import cloneGeometry
+XMLIdealGeometryESSource_CTPPS, _ctppsGeometryESModule = cloneGeometry('Geometry.VeryForwardGeometry.geometryRPFromDD_2018_cfi')
+ctppsCompositeESSource.compactViewTag = _ctppsGeometryESModule.compactViewTag
+ctppsCompositeESSource.isRun2 = _ctppsGeometryESModule.isRun2
 
 # local reconstruction
 ctppsLocalTrackLiteProducer.includeStrips = False


### PR DESCRIPTION
#### PR description:

As raised in #32448 some configuration files are loaded and used without any cloning. Thus a risk exists that a configuration script using these without precaution can induce competing behaviours/steerings of the ESProducer/ESSource.
For now, as the PPS validation suite is orthogonal to the data reconstruction flow it is not affecting anything. Nevertheless this PR defines a function to automate the cloning of all critical objects prior to their use.

#### PR validation:

PPS-related unit tests pass successfully. No effect expected on standard reconstruction chain.

#### if this PR is a backport please specify the original PR and why you need to backport that PR: N/A

<!-- Please replace this text with any link to  -->

Before submitting your pull requests, make sure you followed this checklist:
- [x] verify that the PR is really intended for the chosen branch
- [x] verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- [x] verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)

@fabferro @jan-kaspar @silviodonato 