### PR TITLE
Seed TICL by L1 e/gamma + other timing considerations for e/gamma HLT

### DIFF
--- a/RecoEgamma/EgammaHLTProducers/plugins/HLTCaloObjInRegionsProducer.cc
+++ b/RecoEgamma/EgammaHLTProducers/plugins/HLTCaloObjInRegionsProducer.cc
@@ -331,3 +331,16 @@ DEFINE_FWK_MODULE(HLTEcalRecHitsInRegionsProducer);
 #include "DataFormats/EcalRecHit/interface/EcalUncalibratedRecHit.h"
 using HLTEcalUnCalibRecHitsInRegionsProducer = HLTCaloObjInRegionsProducer<EcalUncalibratedRecHit>;
 DEFINE_FWK_MODULE(HLTEcalUnCalibRecHitsInRegionsProducer);
+
+// HGCAL Digis
+#include "DataFormats/HGCDigi/interface/HGCDigiCollections.h"
+using HLTHGCalDigisInRegionsProducer = HLTCaloObjInRegionsProducer<HGCalDataFrame,HGCalDigiCollection>;
+DEFINE_FWK_MODULE(HLTHGCalDigisInRegionsProducer);
+
+// HGCAL RecHits
+#include "DataFormats/HGCRecHit/interface/HGCRecHit.h"
+using HLTHGCalRecHitsInRegionsProducer = HLTCaloObjInRegionsProducer<HGCRecHit>;
+DEFINE_FWK_MODULE(HLTHGCalRecHitsInRegionsProducer);
+#include "DataFormats/HGCRecHit/interface/HGCUncalibratedRecHit.h"
+using HLTHGCalUncalibratedRecHitsInRegionsProducer = HLTCaloObjInRegionsProducer<HGCUncalibratedRecHit>;
+DEFINE_FWK_MODULE(HLTHGCalUncalibratedRecHitsInRegionsProducer);

--- a/RecoEgamma/EgammaHLTProducers/plugins/HLTCaloObjInRegionsProducer.cc
+++ b/RecoEgamma/EgammaHLTProducers/plugins/HLTCaloObjInRegionsProducer.cc
@@ -334,7 +334,7 @@ DEFINE_FWK_MODULE(HLTEcalUnCalibRecHitsInRegionsProducer);
 
 // HGCAL Digis
 #include "DataFormats/HGCDigi/interface/HGCDigiCollections.h"
-using HLTHGCalDigisInRegionsProducer = HLTCaloObjInRegionsProducer<HGCalDataFrame,HGCalDigiCollection>;
+using HLTHGCalDigisInRegionsProducer = HLTCaloObjInRegionsProducer<HGCalDataFrame, HGCalDigiCollection>;
 DEFINE_FWK_MODULE(HLTHGCalDigisInRegionsProducer);
 
 // HGCAL RecHits

--- a/RecoEgamma/EgammaHLTProducers/plugins/L1TEGammaFilteredCollectionProducer.cc
+++ b/RecoEgamma/EgammaHLTProducers/plugins/L1TEGammaFilteredCollectionProducer.cc
@@ -40,8 +40,7 @@ public:
   explicit L1TEGammaFilteredCollectionProducer(const edm::ParameterSet&);
   ~L1TEGammaFilteredCollectionProducer() override;
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
-  void produce(edm::StreamID sid, edm::Event& iEvent,
-               const edm::EventSetup& iSetup) const override;
+  void produce(edm::StreamID sid, edm::Event& iEvent, const edm::EventSetup& iSetup) const override;
 
 private:
   edm::InputTag l1EgTag_;
@@ -56,10 +55,8 @@ private:
   double getOfflineEt(double et) const;
 };
 
-L1TEGammaFilteredCollectionProducer::L1TEGammaFilteredCollectionProducer(
-	     const edm::ParameterSet& iConfig)
-  : l1EgTag_(iConfig.getParameter<edm::InputTag>("inputTag")),
-    l1EgToken_(consumes<BXVector<l1t::EGamma>>(l1EgTag_)) {
+L1TEGammaFilteredCollectionProducer::L1TEGammaFilteredCollectionProducer(const edm::ParameterSet& iConfig)
+    : l1EgTag_(iConfig.getParameter<edm::InputTag>("inputTag")), l1EgToken_(consumes<BXVector<l1t::EGamma>>(l1EgTag_)) {
   quality_ = iConfig.getParameter<int>("quality");
   qualIsMask_ = iConfig.getParameter<bool>("qualIsMask");
   applyQual_ = iConfig.getParameter<bool>("applyQual");
@@ -71,14 +68,11 @@ L1TEGammaFilteredCollectionProducer::L1TEGammaFilteredCollectionProducer(
   produces<BXVector<l1t::EGamma>>();
 }
 
-L1TEGammaFilteredCollectionProducer::~L1TEGammaFilteredCollectionProducer() =
- default;
+L1TEGammaFilteredCollectionProducer::~L1TEGammaFilteredCollectionProducer() = default;
 
-void L1TEGammaFilteredCollectionProducer::fillDescriptions(
-       edm::ConfigurationDescriptions& descriptions) {
+void L1TEGammaFilteredCollectionProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
-  desc.add<edm::InputTag>("inputTag",
-                          edm::InputTag("L1EGammaClusterEmuProducer"));
+  desc.add<edm::InputTag>("inputTag", edm::InputTag("L1EGammaClusterEmuProducer"));
   desc.add<int>("quality", 0x2);
   desc.add<bool>("qualIsMask", true);
   desc.add<bool>("applyQual", true);
@@ -89,9 +83,9 @@ void L1TEGammaFilteredCollectionProducer::fillDescriptions(
   descriptions.add("L1TEGammaFilteredCollectionProducer", desc);
 }
 
-void L1TEGammaFilteredCollectionProducer::produce(
-      edm::StreamID sid, edm::Event& iEvent,
-      const edm::EventSetup& iSetup) const {
+void L1TEGammaFilteredCollectionProducer::produce(edm::StreamID sid,
+                                                  edm::Event& iEvent,
+                                                  const edm::EventSetup& iSetup) const {
   auto outEgs = std::make_unique<BXVector<l1t::EGamma>>();
   auto l1Egs = iEvent.getHandle(l1EgToken_);
 
@@ -100,8 +94,7 @@ void L1TEGammaFilteredCollectionProducer::produce(
 
   for (int bx = startBX; bx <= endBX; bx++) {
     // Loop over all L1 e/gamma objects
-    for (BXVector<l1t::EGamma>::const_iterator iEg = (*l1Egs).begin(bx);
-         iEg != (*l1Egs).end(bx); iEg++) {
+    for (BXVector<l1t::EGamma>::const_iterator iEg = (*l1Egs).begin(bx); iEg != (*l1Egs).end(bx); iEg++) {
       double offlineEt = this->getOfflineEt((*iEg).pt());
       bool passQuality(false);
       if (applyQual_) {

--- a/RecoEgamma/EgammaHLTProducers/plugins/L1TEGammaFilteredCollectionProducer.cc
+++ b/RecoEgamma/EgammaHLTProducers/plugins/L1TEGammaFilteredCollectionProducer.cc
@@ -1,0 +1,128 @@
+/*
+  Author: Swagata Mukherjee
+
+  Date: Feb 2021
+
+  At the time of writing this new module, it is intended to be used mainly for
+  phase-2. Before feeding in the L1 e/g collection to
+  HLTEcalRecHitInAllL1RegionsProducer, it can pass through this module which
+  will filter the collection based on hardware quality and pT.
+
+  The most generic L1 e/g phase-2 collections are:
+  TkEm, which is std::vector<l1t::TkEm>
+  &
+  StaEG, which is BXVector<l1t::EGamma>
+
+  Despite this technical difference, the objects are almost identical, for all
+  practical purposes. So any of these two collections could have been used.
+  Currently, BXVector<l1t::EGamma> is recognised by the next step
+  HLTEcalRecHitInAllL1RegionsProducer, while std::vector<l1t::TkEm> is not. So
+  using BXVector<l1t::EGamma> is straightforward. If for some reason one need to
+  use std::vector<l1t::TkEm>, changes in HLTEcalRecHitInAllL1RegionsProducer
+  would also be necesary.
+*/
+
+#include "DataFormats/L1TCorrelator/interface/TkEm.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/EventSetupRecord.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+
+class L1TEGammaFilteredCollectionProducer : public edm::global::EDProducer<> {
+public:
+  explicit L1TEGammaFilteredCollectionProducer(const edm::ParameterSet&);
+  ~L1TEGammaFilteredCollectionProducer() override;
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+  void produce(edm::StreamID sid, edm::Event& iEvent,
+               const edm::EventSetup& iSetup) const override;
+
+private:
+  edm::InputTag l1EgTag_;
+  edm::EDGetTokenT<BXVector<l1t::EGamma>> l1EgToken_;
+  int quality_;
+  bool qualIsMask_;
+  bool applyQual_;
+  int minBX_;
+  int maxBX_;
+  double minPt_;
+  std::vector<double> scalings_;  // pT scaling factors
+  double getOfflineEt(double et) const;
+};
+
+L1TEGammaFilteredCollectionProducer::L1TEGammaFilteredCollectionProducer(
+	     const edm::ParameterSet& iConfig)
+  : l1EgTag_(iConfig.getParameter<edm::InputTag>("inputTag")),
+    l1EgToken_(consumes<BXVector<l1t::EGamma>>(l1EgTag_)) {
+  quality_ = iConfig.getParameter<int>("quality");
+  qualIsMask_ = iConfig.getParameter<bool>("qualIsMask");
+  applyQual_ = iConfig.getParameter<bool>("applyQual");
+  minBX_ = iConfig.getParameter<int>("minBX");
+  maxBX_ = iConfig.getParameter<int>("maxBX");
+  minPt_ = iConfig.getParameter<double>("minPt");
+  scalings_ = iConfig.getParameter<std::vector<double>>("scalings");
+
+  produces<BXVector<l1t::EGamma>>();
+}
+
+L1TEGammaFilteredCollectionProducer::~L1TEGammaFilteredCollectionProducer() =
+ default;
+
+void L1TEGammaFilteredCollectionProducer::fillDescriptions(
+       edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.add<edm::InputTag>("inputTag",
+                          edm::InputTag("L1EGammaClusterEmuProducer"));
+  desc.add<int>("quality", 0x2);
+  desc.add<bool>("qualIsMask", true);
+  desc.add<bool>("applyQual", true);
+  desc.add<int>("minBX", -1);
+  desc.add<int>("maxBX", 1);
+  desc.add<double>("minPt", 5.0);
+  desc.add<std::vector<double>>("scalings", {2.6604, 1.06077, 0.0});
+  descriptions.add("L1TEGammaFilteredCollectionProducer", desc);
+}
+
+void L1TEGammaFilteredCollectionProducer::produce(
+      edm::StreamID sid, edm::Event& iEvent,
+      const edm::EventSetup& iSetup) const {
+  auto outEgs = std::make_unique<BXVector<l1t::EGamma>>();
+  auto l1Egs = iEvent.getHandle(l1EgToken_);
+
+  int startBX = std::max((*l1Egs).getFirstBX(), minBX_);
+  int endBX = std::min((*l1Egs).getLastBX(), maxBX_);
+
+  for (int bx = startBX; bx <= endBX; bx++) {
+    // Loop over all L1 e/gamma objects
+    for (BXVector<l1t::EGamma>::const_iterator iEg = (*l1Egs).begin(bx);
+         iEg != (*l1Egs).end(bx); iEg++) {
+      double offlineEt = this->getOfflineEt((*iEg).pt());
+      bool passQuality(false);
+      if (applyQual_) {
+        if (qualIsMask_)
+          passQuality = ((*iEg).hwQual() & quality_);
+        else
+          passQuality = ((*iEg).hwQual() == quality_);
+      } else
+        passQuality = true;
+
+      // if quality is passed, put the object in filtered collection
+      if (passQuality && (offlineEt > minPt_)) {
+        outEgs->push_back(bx, *iEg);
+      }
+    }  // l1EG loop ends
+  }    // BX loop ends
+  iEvent.put(std::move(outEgs));
+}
+
+double L1TEGammaFilteredCollectionProducer::getOfflineEt(double et) const {
+  return (scalings_.at(0) + et * scalings_.at(1) + et * et * scalings_.at(2));
+}
+
+DEFINE_FWK_MODULE(L1TEGammaFilteredCollectionProducer);

--- a/RecoHGCal/TICL/plugins/BuildFile.xml
+++ b/RecoHGCal/TICL/plugins/BuildFile.xml
@@ -5,6 +5,8 @@
 <use name="FWCore/ParameterSet"/>
 <use name="FWCore/PluginManager"/>
 <use name="DataFormats/CaloRecHit"/>
+<use name="DataFormats/L1Trigger"/>
+<use name="DataFormats/Candidate"/>
 <use name="DataFormats/ParticleFlowCandidate"/>
 <use name="DataFormats/HGCalReco"/>
 <use name="FWCore/MessageLogger"/>

--- a/RecoHGCal/TICL/plugins/SeedingRegionAlgoBase.h
+++ b/RecoHGCal/TICL/plugins/SeedingRegionAlgoBase.h
@@ -9,6 +9,7 @@
 #include <vector>
 #include "DataFormats/HGCalReco/interface/Common.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "DataFormats/HGCalReco/interface/TICLSeedingRegion.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 
@@ -29,6 +30,8 @@ namespace ticl {
     virtual void makeRegions(const edm::Event& ev,
                              const edm::EventSetup& es,
                              std::vector<TICLSeedingRegion>& result) = 0;
+
+    static void fillPSetDescription(edm::ParameterSetDescription& desc) { desc.add<int>("algo_verbosity", 0); }
 
     enum VerbosityLevel { None = 0, Basic, Advanced, Expert, Guru };
 

--- a/RecoHGCal/TICL/plugins/SeedingRegionAlgoFactory.cc
+++ b/RecoHGCal/TICL/plugins/SeedingRegionAlgoFactory.cc
@@ -1,0 +1,13 @@
+#include "FWCore/ParameterSet/interface/ValidatedPluginFactoryMacros.h"
+#include "FWCore/ParameterSet/interface/ValidatedPluginMacros.h"
+#include "SeedingRegionAlgoFactory.h"
+#include "SeedingRegionByTracks.h"
+#include "SeedingRegionGlobal.h"
+#include "SeedingRegionByL1.h"
+
+EDM_REGISTER_VALIDATED_PLUGINFACTORY(SeedingRegionAlgoFactory, "SeedingRegionAlgoFactory");
+
+DEFINE_EDM_VALIDATED_PLUGIN(SeedingRegionAlgoFactory,ticl::SeedingRegionByTracks,"SeedingRegionByTracks");
+DEFINE_EDM_VALIDATED_PLUGIN(SeedingRegionAlgoFactory,ticl::SeedingRegionGlobal,"SeedingRegionGlobal");
+DEFINE_EDM_VALIDATED_PLUGIN(SeedingRegionAlgoFactory,ticl::SeedingRegionByL1,"SeedingRegionByL1");
+ 

--- a/RecoHGCal/TICL/plugins/SeedingRegionAlgoFactory.cc
+++ b/RecoHGCal/TICL/plugins/SeedingRegionAlgoFactory.cc
@@ -7,7 +7,6 @@
 
 EDM_REGISTER_VALIDATED_PLUGINFACTORY(SeedingRegionAlgoFactory, "SeedingRegionAlgoFactory");
 
-DEFINE_EDM_VALIDATED_PLUGIN(SeedingRegionAlgoFactory,ticl::SeedingRegionByTracks,"SeedingRegionByTracks");
-DEFINE_EDM_VALIDATED_PLUGIN(SeedingRegionAlgoFactory,ticl::SeedingRegionGlobal,"SeedingRegionGlobal");
-DEFINE_EDM_VALIDATED_PLUGIN(SeedingRegionAlgoFactory,ticl::SeedingRegionByL1,"SeedingRegionByL1");
- 
+DEFINE_EDM_VALIDATED_PLUGIN(SeedingRegionAlgoFactory, ticl::SeedingRegionByTracks, "SeedingRegionByTracks");
+DEFINE_EDM_VALIDATED_PLUGIN(SeedingRegionAlgoFactory, ticl::SeedingRegionGlobal, "SeedingRegionGlobal");
+DEFINE_EDM_VALIDATED_PLUGIN(SeedingRegionAlgoFactory, ticl::SeedingRegionByL1, "SeedingRegionByL1");

--- a/RecoHGCal/TICL/plugins/SeedingRegionAlgoFactory.h
+++ b/RecoHGCal/TICL/plugins/SeedingRegionAlgoFactory.h
@@ -1,0 +1,10 @@
+#ifndef RecoHGCAL_TICL_SeedingRegionAlgoFactory_h
+#define RecoHGCAL_TICL_SeedingRegionAlgoFactory_h
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/PluginManager/interface/PluginFactory.h"
+#include "SeedingRegionAlgoBase.h"
+
+using SeedingRegionAlgoFactory = edmplugin::PluginFactory<ticl::SeedingRegionAlgoBase*(const edm::ParameterSet&, edm::ConsumesCollector&)>;
+
+#endif

--- a/RecoHGCal/TICL/plugins/SeedingRegionAlgoFactory.h
+++ b/RecoHGCal/TICL/plugins/SeedingRegionAlgoFactory.h
@@ -5,6 +5,7 @@
 #include "FWCore/PluginManager/interface/PluginFactory.h"
 #include "SeedingRegionAlgoBase.h"
 
-using SeedingRegionAlgoFactory = edmplugin::PluginFactory<ticl::SeedingRegionAlgoBase*(const edm::ParameterSet&, edm::ConsumesCollector&)>;
+using SeedingRegionAlgoFactory =
+    edmplugin::PluginFactory<ticl::SeedingRegionAlgoBase*(const edm::ParameterSet&, edm::ConsumesCollector&)>;
 
 #endif

--- a/RecoHGCal/TICL/plugins/SeedingRegionByL1.cc
+++ b/RecoHGCal/TICL/plugins/SeedingRegionByL1.cc
@@ -34,7 +34,7 @@ void ticl::SeedingRegionByL1::makeRegions(const edm::Event &ev,
 
   for (size_t indx = 0; indx < (*l1TrkEms).size(); indx++) {
     const auto &l1TrkEm = (*l1TrkEms)[indx];
-    double offlinePt = this->TkEmOfflineEt(l1TrkEm.pt());
+    double offlinePt = this->tkEmOfflineEt(l1TrkEm.pt());
     if ((offlinePt < minPt_) || (std::abs(l1TrkEm.eta()) < minAbsEta_) || (std::abs(l1TrkEm.eta()) > maxAbsEta_) ||
         (l1TrkEm.EGRef()->hwQual() != quality_)) {
       continue;
@@ -53,8 +53,8 @@ void ticl::SeedingRegionByL1::makeRegions(const edm::Event &ev,
   });
 }
 
-double ticl::SeedingRegionByL1::TkEmOfflineEt(double Et) const {
-  return (endcapScalings_.at(0) + Et * endcapScalings_.at(1) + Et * Et * endcapScalings_.at(2));
+double ticl::SeedingRegionByL1::tkEmOfflineEt(double et) const {
+  return (endcapScalings_.at(0) + et * endcapScalings_.at(1) + et * et * endcapScalings_.at(2));
 }
 
 void ticl::SeedingRegionByL1::fillPSetDescription(edm::ParameterSetDescription &desc) {

--- a/RecoHGCal/TICL/plugins/SeedingRegionByL1.cc
+++ b/RecoHGCal/TICL/plugins/SeedingRegionByL1.cc
@@ -46,7 +46,6 @@ void ticl::SeedingRegionByL1::makeRegions(const edm::Event &ev,
                         iSide,
                         indx,
                         l1tkemsId);
-    indx++;
   }
 
   std::sort(result.begin(), result.end(), [](const TICLSeedingRegion &a, const TICLSeedingRegion &b) {

--- a/RecoHGCal/TICL/plugins/SeedingRegionByL1.cc
+++ b/RecoHGCal/TICL/plugins/SeedingRegionByL1.cc
@@ -1,0 +1,80 @@
+/*
+   Author: Swagata Mukherjee
+
+   Date: Feb 2021
+
+   TICL is currently seeded by tracks, or just globally.
+   Here, adding option to seed TICL by L1 e/gamma objects (L1 TkEm).
+   This is expected to be useful for CPU timing at the HLT.
+*/
+
+#include "SeedingRegionByL1.h"
+
+#include <algorithm>
+#include <set>
+#include <vector>
+
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+ticl::SeedingRegionByL1::SeedingRegionByL1(const edm::ParameterSet &conf,
+                                           edm::ConsumesCollector &sumes)
+  : SeedingRegionAlgoBase(conf, sumes),
+    l1TkEmsToken_(sumes.consumes<std::vector<l1t::TkEm>>(
+							 conf.getParameter<edm::InputTag>("l1TkEmColl"))),
+    algoVerbosity_(conf.getParameter<int>("algo_verbosity")),
+    minPt_(conf.getParameter<double>("minPt")),
+    minAbsEta_(conf.getParameter<double>("minAbsEta")),
+    maxAbsEta_(conf.getParameter<double>("maxAbsEta")),
+    endcapScalings_(conf.getParameter<std::vector<double>>("endcapScalings")),
+    quality_(conf.getParameter<int>("quality")) {}
+
+void ticl::SeedingRegionByL1::makeRegions(
+					  const edm::Event &ev, const edm::EventSetup &es,
+					  std::vector<TICLSeedingRegion> &result) {
+  auto l1TrkEms = ev.getHandle(l1TkEmsToken_);
+  edm::ProductID l1tkemsId = l1TrkEms.id();
+
+  for (size_t indx = 0; indx < (*l1TrkEms).size(); indx++) {
+    const auto &l1TrkEm = (*l1TrkEms)[indx];
+    double offlinePt = this->TkEmOfflineEt(l1TrkEm.pt());
+    if ((offlinePt < minPt_) || (std::abs(l1TrkEm.eta()) < minAbsEta_) ||
+        (std::abs(l1TrkEm.eta()) > maxAbsEta_) ||
+        (l1TrkEm.EGRef()->hwQual() != quality_)) {
+      continue;
+    }
+
+    int iSide = int(l1TrkEm.eta() > 0);
+    result.emplace_back(
+			GlobalPoint(l1TrkEm.p4().X(), l1TrkEm.p4().Y(), l1TrkEm.p4().Z()),
+			GlobalVector(l1TrkEm.px(), l1TrkEm.py(), l1TrkEm.pz()), iSide, indx,
+			l1tkemsId);
+    indx++;
+  }
+
+  std::sort(result.begin(), result.end(),
+            [](const TICLSeedingRegion &a, const TICLSeedingRegion &b) {
+              return a.directionAtOrigin.perp2() > b.directionAtOrigin.perp2();
+            });
+}
+
+double ticl::SeedingRegionByL1::TkEmOfflineEt(double Et) const {
+  return (endcapScalings_.at(0) + Et * endcapScalings_.at(1) +
+          Et * Et * endcapScalings_.at(2));
+}
+
+void ticl::SeedingRegionByL1::fillPSetDescription(
+						  edm::ParameterSetDescription &desc) {
+  desc.add<edm::InputTag>("l1TkEmColl", edm::InputTag("L1TkPhotonsHGC", "EG"));
+  desc.add<int>("algo_verbosity", 0);
+  desc.add<double>("minPt", 10);
+  desc.add<double>("minAbsEta", 1.479);
+  desc.add<double>("maxAbsEta", 4.0);
+  desc.add<std::vector<double>>("endcapScalings", {3.17445, 1.13219, 0.0});
+  desc.add<int>("quality", 5);
+}
+
+edm::ParameterSetDescription ticl::SeedingRegionByL1::makePSetDescription() {
+  edm::ParameterSetDescription desc;
+  fillPSetDescription(desc);
+  return desc;
+}

--- a/RecoHGCal/TICL/plugins/SeedingRegionByL1.cc
+++ b/RecoHGCal/TICL/plugins/SeedingRegionByL1.cc
@@ -16,54 +16,49 @@
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
-ticl::SeedingRegionByL1::SeedingRegionByL1(const edm::ParameterSet &conf,
-                                           edm::ConsumesCollector &sumes)
-  : SeedingRegionAlgoBase(conf, sumes),
-    l1TkEmsToken_(sumes.consumes<std::vector<l1t::TkEm>>(
-							 conf.getParameter<edm::InputTag>("l1TkEmColl"))),
-    algoVerbosity_(conf.getParameter<int>("algo_verbosity")),
-    minPt_(conf.getParameter<double>("minPt")),
-    minAbsEta_(conf.getParameter<double>("minAbsEta")),
-    maxAbsEta_(conf.getParameter<double>("maxAbsEta")),
-    endcapScalings_(conf.getParameter<std::vector<double>>("endcapScalings")),
-    quality_(conf.getParameter<int>("quality")) {}
+ticl::SeedingRegionByL1::SeedingRegionByL1(const edm::ParameterSet &conf, edm::ConsumesCollector &sumes)
+    : SeedingRegionAlgoBase(conf, sumes),
+      l1TkEmsToken_(sumes.consumes<std::vector<l1t::TkEm>>(conf.getParameter<edm::InputTag>("l1TkEmColl"))),
+      algoVerbosity_(conf.getParameter<int>("algo_verbosity")),
+      minPt_(conf.getParameter<double>("minPt")),
+      minAbsEta_(conf.getParameter<double>("minAbsEta")),
+      maxAbsEta_(conf.getParameter<double>("maxAbsEta")),
+      endcapScalings_(conf.getParameter<std::vector<double>>("endcapScalings")),
+      quality_(conf.getParameter<int>("quality")) {}
 
-void ticl::SeedingRegionByL1::makeRegions(
-					  const edm::Event &ev, const edm::EventSetup &es,
-					  std::vector<TICLSeedingRegion> &result) {
+void ticl::SeedingRegionByL1::makeRegions(const edm::Event &ev,
+                                          const edm::EventSetup &es,
+                                          std::vector<TICLSeedingRegion> &result) {
   auto l1TrkEms = ev.getHandle(l1TkEmsToken_);
   edm::ProductID l1tkemsId = l1TrkEms.id();
 
   for (size_t indx = 0; indx < (*l1TrkEms).size(); indx++) {
     const auto &l1TrkEm = (*l1TrkEms)[indx];
     double offlinePt = this->TkEmOfflineEt(l1TrkEm.pt());
-    if ((offlinePt < minPt_) || (std::abs(l1TrkEm.eta()) < minAbsEta_) ||
-        (std::abs(l1TrkEm.eta()) > maxAbsEta_) ||
+    if ((offlinePt < minPt_) || (std::abs(l1TrkEm.eta()) < minAbsEta_) || (std::abs(l1TrkEm.eta()) > maxAbsEta_) ||
         (l1TrkEm.EGRef()->hwQual() != quality_)) {
       continue;
     }
 
     int iSide = int(l1TrkEm.eta() > 0);
-    result.emplace_back(
-			GlobalPoint(l1TrkEm.p4().X(), l1TrkEm.p4().Y(), l1TrkEm.p4().Z()),
-			GlobalVector(l1TrkEm.px(), l1TrkEm.py(), l1TrkEm.pz()), iSide, indx,
-			l1tkemsId);
+    result.emplace_back(GlobalPoint(l1TrkEm.p4().X(), l1TrkEm.p4().Y(), l1TrkEm.p4().Z()),
+                        GlobalVector(l1TrkEm.px(), l1TrkEm.py(), l1TrkEm.pz()),
+                        iSide,
+                        indx,
+                        l1tkemsId);
     indx++;
   }
 
-  std::sort(result.begin(), result.end(),
-            [](const TICLSeedingRegion &a, const TICLSeedingRegion &b) {
-              return a.directionAtOrigin.perp2() > b.directionAtOrigin.perp2();
-            });
+  std::sort(result.begin(), result.end(), [](const TICLSeedingRegion &a, const TICLSeedingRegion &b) {
+    return a.directionAtOrigin.perp2() > b.directionAtOrigin.perp2();
+  });
 }
 
 double ticl::SeedingRegionByL1::TkEmOfflineEt(double Et) const {
-  return (endcapScalings_.at(0) + Et * endcapScalings_.at(1) +
-          Et * Et * endcapScalings_.at(2));
+  return (endcapScalings_.at(0) + Et * endcapScalings_.at(1) + Et * Et * endcapScalings_.at(2));
 }
 
-void ticl::SeedingRegionByL1::fillPSetDescription(
-						  edm::ParameterSetDescription &desc) {
+void ticl::SeedingRegionByL1::fillPSetDescription(edm::ParameterSetDescription &desc) {
   desc.add<edm::InputTag>("l1TkEmColl", edm::InputTag("L1TkPhotonsHGC", "EG"));
   desc.add<int>("algo_verbosity", 0);
   desc.add<double>("minPt", 10);

--- a/RecoHGCal/TICL/plugins/SeedingRegionByL1.cc
+++ b/RecoHGCal/TICL/plugins/SeedingRegionByL1.cc
@@ -66,9 +66,3 @@ void ticl::SeedingRegionByL1::fillPSetDescription(edm::ParameterSetDescription &
   desc.add<int>("quality", 5);
   SeedingRegionAlgoBase::fillPSetDescription(desc);
 }
-
-edm::ParameterSetDescription ticl::SeedingRegionByL1::makePSetDescription() {
-  edm::ParameterSetDescription desc;
-  fillPSetDescription(desc);
-  return desc;
-}

--- a/RecoHGCal/TICL/plugins/SeedingRegionByL1.cc
+++ b/RecoHGCal/TICL/plugins/SeedingRegionByL1.cc
@@ -59,12 +59,12 @@ double ticl::SeedingRegionByL1::tkEmOfflineEt(double et) const {
 
 void ticl::SeedingRegionByL1::fillPSetDescription(edm::ParameterSetDescription &desc) {
   desc.add<edm::InputTag>("l1TkEmColl", edm::InputTag("L1TkPhotonsHGC", "EG"));
-  desc.add<int>("algo_verbosity", 0);
   desc.add<double>("minPt", 10);
   desc.add<double>("minAbsEta", 1.479);
   desc.add<double>("maxAbsEta", 4.0);
   desc.add<std::vector<double>>("endcapScalings", {3.17445, 1.13219, 0.0});
   desc.add<int>("quality", 5);
+  SeedingRegionAlgoBase::fillPSetDescription(desc);
 }
 
 edm::ParameterSetDescription ticl::SeedingRegionByL1::makePSetDescription() {

--- a/RecoHGCal/TICL/plugins/SeedingRegionByL1.h
+++ b/RecoHGCal/TICL/plugins/SeedingRegionByL1.h
@@ -21,12 +21,10 @@
 namespace ticl {
   class SeedingRegionByL1 final : public SeedingRegionAlgoBase {
   public:
-    SeedingRegionByL1(const edm::ParameterSet& conf,
-		      edm::ConsumesCollector& sumes);
+    SeedingRegionByL1(const edm::ParameterSet& conf, edm::ConsumesCollector& sumes);
 
     void initialize(const edm::EventSetup& es) override{};
-    void makeRegions(const edm::Event& ev, const edm::EventSetup& es,
-		     std::vector<TICLSeedingRegion>& result) override;
+    void makeRegions(const edm::Event& ev, const edm::EventSetup& es, std::vector<TICLSeedingRegion>& result) override;
     static void fillPSetDescription(edm::ParameterSetDescription& desc);
     static edm::ParameterSetDescription makePSetDescription();
 

--- a/RecoHGCal/TICL/plugins/SeedingRegionByL1.h
+++ b/RecoHGCal/TICL/plugins/SeedingRegionByL1.h
@@ -1,0 +1,45 @@
+// Author: Swagata Mukherjee
+
+#ifndef RecoHGCal_TICL_SeedingRegionByL1_h
+#define RecoHGCal_TICL_SeedingRegionByL1_h
+#include <memory>
+#include <string>
+
+#include "DataFormats/L1TCorrelator/interface/TkEm.h"
+#include "DataFormats/L1TCorrelator/interface/TkEmFwd.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/Utilities/interface/ESGetToken.h"
+#include "RecoHGCal/TICL/plugins/SeedingRegionAlgoBase.h"
+
+namespace ticl {
+  class SeedingRegionByL1 final : public SeedingRegionAlgoBase {
+  public:
+    SeedingRegionByL1(const edm::ParameterSet& conf,
+		      edm::ConsumesCollector& sumes);
+
+    void initialize(const edm::EventSetup& es) override{};
+    void makeRegions(const edm::Event& ev, const edm::EventSetup& es,
+		     std::vector<TICLSeedingRegion>& result) override;
+    static void fillPSetDescription(edm::ParameterSetDescription& desc);
+    static edm::ParameterSetDescription makePSetDescription();
+
+  private:
+    edm::EDGetTokenT<std::vector<l1t::TkEm>> l1TkEmsToken_;
+    int algoVerbosity_ = 0;
+    double minPt_;                        // minimum pT of L1 TkEm objects
+    double minAbsEta_;                    // minimum |eta| of L1 TkEm objects
+    double maxAbsEta_;                    // maximum |eta| of L1 TkEm objects
+    std::vector<double> endcapScalings_;  // pT scaling factors for endcap
+    int quality_;                         // hwQual
+
+    double TkEmOfflineEt(double Et) const;
+  };
+}  // namespace ticl
+#endif

--- a/RecoHGCal/TICL/plugins/SeedingRegionByL1.h
+++ b/RecoHGCal/TICL/plugins/SeedingRegionByL1.h
@@ -26,7 +26,6 @@ namespace ticl {
     void initialize(const edm::EventSetup& es) override{};
     void makeRegions(const edm::Event& ev, const edm::EventSetup& es, std::vector<TICLSeedingRegion>& result) override;
     static void fillPSetDescription(edm::ParameterSetDescription& desc);
-    static edm::ParameterSetDescription makePSetDescription();
 
   private:
     edm::EDGetTokenT<std::vector<l1t::TkEm>> l1TkEmsToken_;

--- a/RecoHGCal/TICL/plugins/SeedingRegionByL1.h
+++ b/RecoHGCal/TICL/plugins/SeedingRegionByL1.h
@@ -37,7 +37,7 @@ namespace ticl {
     std::vector<double> endcapScalings_;  // pT scaling factors for endcap
     int quality_;                         // hwQual
 
-    double TkEmOfflineEt(double Et) const;
+    double tkEmOfflineEt(double et) const;
   };
 }  // namespace ticl
 #endif

--- a/RecoHGCal/TICL/plugins/SeedingRegionByTracks.cc
+++ b/RecoHGCal/TICL/plugins/SeedingRegionByTracks.cc
@@ -65,6 +65,15 @@ void SeedingRegionByTracks::makeRegions(const edm::Event &ev,
   });
 }
 
+void SeedingRegionByTracks::fillPSetDescription(edm::ParameterSetDescription &desc) {
+  desc.add<edm::InputTag>("tracks", edm::InputTag("generalTracks"));
+  desc.add<std::string>("cutTk",
+                        "1.48 < abs(eta) < 3.0 && pt > 1. && quality(\"highPurity\") && "
+                        "hitPattern().numberOfLostHits(\"MISSING_OUTER_HITS\") < 5");
+  desc.add<std::string>("propagator", "PropagatorWithMaterial");
+  SeedingRegionAlgoBase::fillPSetDescription(desc);
+}
+
 void SeedingRegionByTracks::buildFirstLayers() {
   float zVal = hgcons_->waferZ(1, true);
   std::pair<double, double> rMinMax = hgcons_->rangeR(zVal, true);

--- a/RecoHGCal/TICL/plugins/SeedingRegionByTracks.h
+++ b/RecoHGCal/TICL/plugins/SeedingRegionByTracks.h
@@ -37,6 +37,8 @@ namespace ticl {
 
     void makeRegions(const edm::Event& ev, const edm::EventSetup& es, std::vector<TICLSeedingRegion>& result) override;
 
+    static void fillPSetDescription(edm::ParameterSetDescription& desc);
+
   private:
     void buildFirstLayers();
 

--- a/RecoHGCal/TICL/plugins/SeedingRegionGlobal.cc
+++ b/RecoHGCal/TICL/plugins/SeedingRegionGlobal.cc
@@ -26,3 +26,7 @@ void SeedingRegionGlobal::makeRegions(const edm::Event &ev,
     result.emplace_back(GlobalPoint(0., 0., 0.), GlobalVector(0., 0., 0.), i, -1, edm::ProductID());
   }
 }
+
+void SeedingRegionGlobal::fillPSetDescription(edm::ParameterSetDescription &desc) {
+  SeedingRegionAlgoBase::fillPSetDescription(desc);
+}

--- a/RecoHGCal/TICL/plugins/SeedingRegionGlobal.h
+++ b/RecoHGCal/TICL/plugins/SeedingRegionGlobal.h
@@ -25,6 +25,8 @@ namespace ticl {
     void initialize(const edm::EventSetup& es) override{};
 
     void makeRegions(const edm::Event& ev, const edm::EventSetup& es, std::vector<TICLSeedingRegion>& result) override;
+
+    static void fillPSetDescription(edm::ParameterSetDescription& desc);
   };
 }  // namespace ticl
 #endif

--- a/RecoHGCal/TICL/plugins/TICLSeedingRegionProducer.cc
+++ b/RecoHGCal/TICL/plugins/TICLSeedingRegionProducer.cc
@@ -14,6 +14,7 @@
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "RecoHGCal/TICL/plugins/SeedingRegionAlgoBase.h"
+#include "SeedingRegionByL1.h"
 #include "SeedingRegionByTracks.h"
 #include "SeedingRegionGlobal.h"
 
@@ -47,6 +48,10 @@ TICLSeedingRegionProducer::TICLSeedingRegionProducer(const edm::ParameterSet& ps
     case 2:
       myAlgo_ = std::make_unique<SeedingRegionGlobal>(ps, sumes);
       break;
+  case 3:
+    myAlgo_ = std::make_unique<SeedingRegionByL1>(
+	 ps.getParameterSet("seedTiclByL1Config"), sumes);  // needed for HLT
+    break;
     default:
       break;
   }
@@ -62,6 +67,8 @@ void TICLSeedingRegionProducer::fillDescriptions(edm::ConfigurationDescriptions&
                         "hitPattern().numberOfLostHits(\"MISSING_OUTER_HITS\") < 5");
   desc.add<std::string>("propagator", "PropagatorWithMaterial");
   desc.add<int>("algoId", 1);
+  desc.add<edm::ParameterSetDescription>(
+       "seedTiclByL1Config", SeedingRegionByL1::makePSetDescription());
   descriptions.add("ticlSeedingRegionProducer", desc);
 }
 

--- a/RecoHGCal/TICL/plugins/TICLSeedingRegionProducer.cc
+++ b/RecoHGCal/TICL/plugins/TICLSeedingRegionProducer.cc
@@ -48,10 +48,9 @@ TICLSeedingRegionProducer::TICLSeedingRegionProducer(const edm::ParameterSet& ps
     case 2:
       myAlgo_ = std::make_unique<SeedingRegionGlobal>(ps, sumes);
       break;
-  case 3:
-    myAlgo_ = std::make_unique<SeedingRegionByL1>(
-	 ps.getParameterSet("seedTiclByL1Config"), sumes);  // needed for HLT
-    break;
+    case 3:
+      myAlgo_ = std::make_unique<SeedingRegionByL1>(ps.getParameterSet("seedTiclByL1Config"), sumes);  // needed for HLT
+      break;
     default:
       break;
   }
@@ -67,8 +66,7 @@ void TICLSeedingRegionProducer::fillDescriptions(edm::ConfigurationDescriptions&
                         "hitPattern().numberOfLostHits(\"MISSING_OUTER_HITS\") < 5");
   desc.add<std::string>("propagator", "PropagatorWithMaterial");
   desc.add<int>("algoId", 1);
-  desc.add<edm::ParameterSetDescription>(
-       "seedTiclByL1Config", SeedingRegionByL1::makePSetDescription());
+  desc.add<edm::ParameterSetDescription>("seedTiclByL1Config", SeedingRegionByL1::makePSetDescription());
   descriptions.add("ticlSeedingRegionProducer", desc);
 }
 

--- a/RecoHGCal/TICL/python/TICLSeedingRegions_cff.py
+++ b/RecoHGCal/TICL/python/TICLSeedingRegions_cff.py
@@ -5,13 +5,13 @@ from RecoHGCal.TICL.ticlSeedingRegionProducer_cfi import ticlSeedingRegionProduc
 # SEEDING REGION
 
 ticlSeedingGlobal = _ticlSeedingRegionProducer.clone(
-  seedingPSet = _ticlSeedingRegionProducer.seedingPSet.clone(type=cms.string("SeedingRegionGlobal"))
+  seedingPSet = _ticlSeedingRegionProducer.seedingPSet.clone(type="SeedingRegionGlobal")
 )
 
 ticlSeedingTrk = _ticlSeedingRegionProducer.clone(
-  seedingPSet = _ticlSeedingRegionProducer.seedingPSet.clone(type=cms.string("SeedingRegionByTracks"))
+  seedingPSet = _ticlSeedingRegionProducer.seedingPSet.clone(type="SeedingRegionByTracks")
 )
 
 ticlSeedingGlobalHFNose = _ticlSeedingRegionProducer.clone(
-  seedingPSet = _ticlSeedingRegionProducer.seedingPSet.clone(type=cms.string("SeedingRegionGlobal"))
+  seedingPSet = _ticlSeedingRegionProducer.seedingPSet.clone(type="SeedingRegionGlobal")
 )

--- a/RecoHGCal/TICL/python/TICLSeedingRegions_cff.py
+++ b/RecoHGCal/TICL/python/TICLSeedingRegions_cff.py
@@ -5,13 +5,13 @@ from RecoHGCal.TICL.ticlSeedingRegionProducer_cfi import ticlSeedingRegionProduc
 # SEEDING REGION
 
 ticlSeedingGlobal = _ticlSeedingRegionProducer.clone(
-  algoId = 2
+  seedingPSet = _ticlSeedingRegionProducer.seedingPSet.clone(type=cms.string("SeedingRegionGlobal"))
 )
 
 ticlSeedingTrk = _ticlSeedingRegionProducer.clone(
-  algoId = 1
+  seedingPSet = _ticlSeedingRegionProducer.seedingPSet.clone(type=cms.string("SeedingRegionByTracks"))
 )
 
 ticlSeedingGlobalHFNose = _ticlSeedingRegionProducer.clone(
-  algoId = 2
+  seedingPSet = _ticlSeedingRegionProducer.seedingPSet.clone(type=cms.string("SeedingRegionGlobal"))
 )


### PR DESCRIPTION
#### PR description:

This PR introduces 

1) an option to seed TICL by L1 e/gamma objects. Currently TICL can be seeded by general tracks, which is fine for offline reco but too slow for EGM HLT, hence we are not using it. We use globally seeded TICL EM iteration. It was found in preliminary studies that the trackster production step runs faster if we replace global seeding by L1 seeding. 

2) options to produce reduced recHit and reduced digi collections for HGCAL. Currently the layercluster production step at EGM HLT takes some time to run, as it runs on all HGCAL recHits. We want to run the layercluster production step on a reduced recHit collection, ie, only the recHits around L1 e/gamma objects. The reduced digi is not being used currently, but can be used later if needed.

3) a producer code to filter phase2 L1 collection based on hardware quality. The reduced recHit producer will take the filtered L1 collection with good quality L1 objects, and will keep the recHits around them. 

[with thanks to @Sam-Harper]


#### PR validation:
runTheMatrix.py -l 23234.0 #2026D49 ttbar (HLT TDR baseline w/ HGCal v11)
runTheMatrix.py -l 11634.0 #2021 ttbar


A backport to 11_1_X will be needed for HLT TDR. 