### PR TITLE
Fix global position for ME1/a LCTs

### DIFF
--- a/Validation/MuonCSCDigis/src/CSCStubMatcher.cc
+++ b/Validation/MuonCSCDigis/src/CSCStubMatcher.cc
@@ -629,14 +629,19 @@ bool CSCStubMatcher::lctInChamber(const CSCDetId& id, const CSCCorrelatedLCTDigi
 
 GlobalPoint CSCStubMatcher::getGlobalPosition(unsigned int rawId, const CSCCorrelatedLCTDigi& lct) const {
   CSCDetId cscId(rawId);
-  CSCDetId key_id(cscId.endcap(), cscId.station(), cscId.ring(), cscId.chamber(), CSCConstants::KEY_CLCT_LAYER);
-  const auto& chamber = cscGeometry_->chamber(cscId);
+  CSCDetId keyId(cscId.endcap(), cscId.station(), cscId.ring(), cscId.chamber(), CSCConstants::KEY_CLCT_LAYER);
   float fractional_strip = lct.getFractionalStrip();
+  // case ME1/a
+  if (cscId.station() == 1 and cscId.ring() == 4 and lct.getStrip() > CSCConstants::MAX_HALF_STRIP_ME1B) {
+    fractional_strip -= CSCConstants::MAX_NUM_STRIPS_ME1B;
+  }
+  // regular cases
+  const auto& chamber = cscGeometry_->chamber(cscId);
   const auto& layer_geo = chamber->layer(CSCConstants::KEY_CLCT_LAYER)->geometry();
   // LCT::getKeyWG() also starts from 0
   float wire = layer_geo->middleWireOfGroup(lct.getKeyWG() + 1);
   const LocalPoint& csc_intersect = layer_geo->intersectionOfStripAndWire(fractional_strip, wire);
-  const GlobalPoint& csc_gp = cscGeometry_->idToDet(key_id)->surface().toGlobal(csc_intersect);
+  const GlobalPoint& csc_gp = cscGeometry_->idToDet(keyId)->surface().toGlobal(csc_intersect);
   return csc_gp;
 }
 


### PR DESCRIPTION
#### PR description:

Minor change to fix the ME1/a LCT global position. ME1/a LCTs have half-strip numbers 128 to 227, so 128 needs to be subtracted before the function `intersectionOfStripAndWire` can be used.

#### PR validation:

Code compiles and was tested on CMSSW_11_2_X relvals.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A

@rathjd