### PR TITLE
Fix Inactive DOHM carriers with DD4hep

### DIFF
--- a/Geometry/TrackerCommonData/plugins/dd4hep/DDTIBLayerAlgo.cc
+++ b/Geometry/TrackerCommonData/plugins/dd4hep/DDTIBLayerAlgo.cc
@@ -362,9 +362,12 @@ static long algorithm(Detector& /* description */, cms::DDParsingContext& contex
     int dohmCarrierReplica = 0;
     int placeDohm = 0;
 
+    Volume dohmCarrier;
+
     switch (j) {
       case 0:
         name = idName + "DOHMCarrierFW";
+        dohmCarrier = ns.addVolumeNS(Volume(name, solid, ns.material(dohmCarrierMaterial)));
         dohmList = dohmListFW;
         tran = Position(0., 0., dohmCarrierZ);
         rotstr = idName + "FwUp";
@@ -374,6 +377,7 @@ static long algorithm(Detector& /* description */, cms::DDParsingContext& contex
         break;
       case 1:
         name = idName + "DOHMCarrierFW";
+        dohmCarrier = ns.volume(name);  // Re-use internally stored DOHMCarrierFW Volume
         dohmList = dohmListFW;
         tran = Position(0., 0., dohmCarrierZ);
         rotstr = idName + "FwDown";
@@ -383,6 +387,7 @@ static long algorithm(Detector& /* description */, cms::DDParsingContext& contex
         break;
       case 2:
         name = idName + "DOHMCarrierBW";
+        dohmCarrier = ns.addVolumeNS(Volume(name, solid, ns.material(dohmCarrierMaterial)));
         dohmList = dohmListBW;
         tran = Position(0., 0., -dohmCarrierZ);
         rotstr = idName + "BwUp";
@@ -392,6 +397,7 @@ static long algorithm(Detector& /* description */, cms::DDParsingContext& contex
         break;
       case 3:
         name = idName + "DOHMCarrierBW";
+        dohmCarrier = ns.volume(name);  // Re-use internally stored DOHMCarrierBW Volume
         dohmList = dohmListBW;
         tran = Position(0., 0., -dohmCarrierZ);
         rotstr = idName + "BwDown";
@@ -401,7 +407,6 @@ static long algorithm(Detector& /* description */, cms::DDParsingContext& contex
         break;
     }
 
-    Volume dohmCarrier = ns.addVolumeNS(Volume(name, solid, ns.material(dohmCarrierMaterial)));
     int primReplica = 0;
     int auxReplica = 0;
 

--- a/SimG4Core/PrintGeomInfo/test/python/runDD4HEP_cfg.py
+++ b/SimG4Core/PrintGeomInfo/test/python/runDD4HEP_cfg.py
@@ -1,21 +1,13 @@
 import FWCore.ParameterSet.Config as cms
 
-process = cms.Process("G4PrintGeometry")
+from Configuration.Eras.Era_Run3_dd4hep_cff import Run3_dd4hep
+process = cms.Process("G4PrintGeometry",Run3_dd4hep)
 
-process.load('Configuration.ProcessModifiers.dd4hep_cff')
-#process.load('Configuration.Geometry.GeometryDD4hepExtended2021_cff')
-process.load('Geometry.CMSCommonData.cmsExtendedGeometry2021XML_cfi')
-process.load('Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cfi')
-process.load('Geometry.EcalCommonData.ecalSimulationParameters_cff')
-process.load('Geometry.HcalCommonData.hcalDDDSimConstants_cff')
-process.load('Geometry.HGCalCommonData.hgcalParametersInitialization_cfi')
-process.load('Geometry.HGCalCommonData.hgcalNumberingInitialization_cfi')
-process.load('Geometry.MTDNumberingBuilder.mtdNumberingGeometry_cfi')
-process.load("Geometry.MuonNumbering.muonGeometryConstants_cff")
+process.load('Configuration.Geometry.GeometryDD4hepExtended2021_cff')
 process.load('FWCore.MessageService.MessageLogger_cfi')
 
-from SimG4Core.PrintGeomInfo.g4PrintGeomInfo_cfi import *
 
+from SimG4Core.PrintGeomInfo.g4PrintGeomInfo_cfi import *
 process = printGeomInfo(process)
 
 if hasattr(process,'MessageLogger'):
@@ -56,12 +48,3 @@ process.g4SimHits.Watchers = cms.VPSet(cms.PSet(
     type             = cms.string('PrintGeomInfoAction')
 ))
 
-process.hcalParameters.fromDD4Hep = cms.bool(True)
-process.hcalSimulationParameters.fromDD4Hep = cms.bool(True)
-process.caloSimulationParameters.fromDD4Hep = cms.bool(True)
-process.ecalSimulationParametersEB.fromDD4Hep = cms.bool(True)
-process.ecalSimulationParametersEE.fromDD4Hep = cms.bool(True)
-process.ecalSimulationParametersES.fromDD4Hep = cms.bool(True)
-process.hgcalEEParametersInitialize.fromDD4Hep = cms.bool(True)
-process.hgcalHESiParametersInitialize.fromDD4Hep = cms.bool(True)
-process.hgcalHEScParametersInitialize.fromDD4Hep = cms.bool(True)

--- a/SimG4Core/PrintGeomInfo/test/python/runDD4HEP_cfg.py
+++ b/SimG4Core/PrintGeomInfo/test/python/runDD4HEP_cfg.py
@@ -1,13 +1,21 @@
 import FWCore.ParameterSet.Config as cms
 
-from Configuration.Eras.Era_Run3_dd4hep_cff import Run3_dd4hep
-process = cms.Process("G4PrintGeometry",Run3_dd4hep)
+process = cms.Process("G4PrintGeometry")
 
-process.load('Configuration.Geometry.GeometryDD4hepExtended2021_cff')
+process.load('Configuration.ProcessModifiers.dd4hep_cff')
+#process.load('Configuration.Geometry.GeometryDD4hepExtended2021_cff')
+process.load('Geometry.CMSCommonData.cmsExtendedGeometry2021XML_cfi')
+process.load('Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cfi')
+process.load('Geometry.EcalCommonData.ecalSimulationParameters_cff')
+process.load('Geometry.HcalCommonData.hcalDDDSimConstants_cff')
+process.load('Geometry.HGCalCommonData.hgcalParametersInitialization_cfi')
+process.load('Geometry.HGCalCommonData.hgcalNumberingInitialization_cfi')
+process.load('Geometry.MTDNumberingBuilder.mtdNumberingGeometry_cfi')
+process.load("Geometry.MuonNumbering.muonGeometryConstants_cff")
 process.load('FWCore.MessageService.MessageLogger_cfi')
 
-
 from SimG4Core.PrintGeomInfo.g4PrintGeomInfo_cfi import *
+
 process = printGeomInfo(process)
 
 if hasattr(process,'MessageLogger'):
@@ -48,3 +56,12 @@ process.g4SimHits.Watchers = cms.VPSet(cms.PSet(
     type             = cms.string('PrintGeomInfoAction')
 ))
 
+process.hcalParameters.fromDD4Hep = cms.bool(True)
+process.hcalSimulationParameters.fromDD4Hep = cms.bool(True)
+process.caloSimulationParameters.fromDD4Hep = cms.bool(True)
+process.ecalSimulationParametersEB.fromDD4Hep = cms.bool(True)
+process.ecalSimulationParametersEE.fromDD4Hep = cms.bool(True)
+process.ecalSimulationParametersES.fromDD4Hep = cms.bool(True)
+process.hgcalEEParametersInitialize.fromDD4Hep = cms.bool(True)
+process.hgcalHESiParametersInitialize.fromDD4Hep = cms.bool(True)
+process.hgcalHEScParametersInitialize.fromDD4Hep = cms.bool(True)


### PR DESCRIPTION
This is to smoothen the number of volumes between DDD and DD4hep.

This removes **unnecessary extra logical volumes (DOHM carriers)**, created with DD4hep for **TIB inactive materials parts**. 
This also fixes **the children physical volumes (DOHM prim / aux)**.

The extra logical volumes with DD4hep were stemming down from internal implementation of **DNamespace::addVolumeNS, which just returns the logical volume provided as argument** ( https://github.com/cms-sw/cmssw/blob/master/DetectorDescription/DDCMS/src/DDNamespace.cc#L161 ).
Instead, **DDNamespace::volume binds any duplicate logical volume to the already existing one** (https://github.com/cms-sw/cmssw/blob/master/DetectorDescription/DDCMS/src/DDNamespace.cc#L208 ). 
Hence, in DD4hep, whenever a logical volume already exists, **DDNamespace::volume should be used.**

Instead, the way duplicated logical volumes are avoided in DDD is as follows.
The logical volumes are always created once only, as nodes of a graph. Whenever any existing logical volume is used for a new placement: an extra edge to the already existing logical volumes nodes is simply added, containing the placement information: https://github.com/cms-sw/cmssw/blob/master/DetectorDescription/Core/src/DDCompactViewImpl.cc#L40

@civanch @cvuosalo @ianna
