### PR TITLE
Migration to DD4hep for GEM DB loader

### DIFF
--- a/CondTools/Geometry/plugins/GEMRecoIdealDBLoader.cc
+++ b/CondTools/Geometry/plugins/GEMRecoIdealDBLoader.cc
@@ -20,10 +20,9 @@
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "Geometry/Records/interface/MuonGeometryRecord.h"
 
-
 class GEMRecoIdealDBLoader : public edm::one::EDAnalyzer<edm::one::WatchRuns> {
 public:
-  GEMRecoIdealDBLoader(const edm::ParameterSet&); 
+  GEMRecoIdealDBLoader(const edm::ParameterSet&);
 
   void beginRun(edm::Run const& iEvent, edm::EventSetup const&) override;
   void analyze(edm::Event const& iEvent, edm::EventSetup const&) override {}
@@ -34,7 +33,7 @@ private:
 };
 
 GEMRecoIdealDBLoader::GEMRecoIdealDBLoader(const edm::ParameterSet& iC) {
-  fromDD4Hep_ = iC.getUntrackedParameter<bool>("fromDD4Hep", false); // set true for DD4HEP
+  fromDD4Hep_ = iC.getUntrackedParameter<bool>("fromDD4Hep", false);  // set true for DD4HEP
 }
 
 void GEMRecoIdealDBLoader::beginRun(const edm::Run&, edm::EventSetup const& es) {
@@ -47,20 +46,19 @@ void GEMRecoIdealDBLoader::beginRun(const edm::Run&, edm::EventSetup const& es) 
   }
 
   if (mydbservice->isNewTagRequest("GEMRecoGeometryRcd")) {
-   
     edm::ESHandle<MuonGeometryConstants> pMNDC;
     GEMGeometryParsFromDD rpcpd;
     RecoIdealGeometry* rig = new RecoIdealGeometry;
 
     if (fromDD4Hep_) {
-      edm::LogVerbatim("GEMRecoIdealDBLoader")<< "(0) GEMRecoIdealDBLoader - DD4HEP ";
+      edm::LogVerbatim("GEMRecoIdealDBLoader") << "(0) GEMRecoIdealDBLoader - DD4HEP ";
       edm::ESTransientHandle<cms::DDCompactView> pDD;
       es.get<IdealGeometryRecord>().get(pDD);
       es.get<IdealGeometryRecord>().get(pMNDC);
       const cms::DDCompactView& cpv = *pDD;
-      rpcpd.build(&cpv, *pMNDC, *rig); 
+      rpcpd.build(&cpv, *pMNDC, *rig);
     } else {
-      edm::LogVerbatim("GEMRecoIdealDBLoader")<< "(0) GEMRecoIdealDBLoader - DDD ";
+      edm::LogVerbatim("GEMRecoIdealDBLoader") << "(0) GEMRecoIdealDBLoader - DDD ";
       edm::ESTransientHandle<DDCompactView> pDD;
       es.get<IdealGeometryRecord>().get(pDD);
       es.get<IdealGeometryRecord>().get(pMNDC);

--- a/CondTools/Geometry/plugins/GEMRecoIdealDBLoader.cc
+++ b/CondTools/Geometry/plugins/GEMRecoIdealDBLoader.cc
@@ -15,6 +15,10 @@
 #include "Geometry/Records/interface/GEMRecoGeometryRcd.h"
 #include "Geometry/Records/interface/MuonNumberingRecord.h"
 #include "Geometry/Records/interface/IdealGeometryRecord.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "CondCore/DBOutputService/interface/PoolDBOutputService.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "Geometry/Records/interface/MuonGeometryRecord.h"
 
 
 class GEMRecoIdealDBLoader : public edm::one::EDAnalyzer<edm::one::WatchRuns> {
@@ -55,6 +59,7 @@ void GEMRecoIdealDBLoader::beginRun(const edm::Run&, edm::EventSetup const& es) 
       const cms::DDCompactView& cpv = *pDD;
       // rpcpd.build(&cpv, *pMNDC, *rig); // to be fixed
     } else {
+      edm::LogVerbatim("GEMRecoIdealDBLoader")<< "(0) GEMRecoIdealDBLoader - DDD ";
       edm::ESTransientHandle<DDCompactView> pDD;
       es.get<IdealGeometryRecord>().get(pDD);
       es.get<IdealGeometryRecord>().get(pMNDC);

--- a/CondTools/Geometry/plugins/GEMRecoIdealDBLoader.cc
+++ b/CondTools/Geometry/plugins/GEMRecoIdealDBLoader.cc
@@ -34,7 +34,7 @@ private:
 };
 
 GEMRecoIdealDBLoader::GEMRecoIdealDBLoader(const edm::ParameterSet& iC) {
-  fromDD4Hep_ = iC.getUntrackedParameter<bool>("fromDD4Hep", false);
+  fromDD4Hep_ = iC.getUntrackedParameter<bool>("fromDD4Hep", false); // set true for DD4HEP
 }
 
 void GEMRecoIdealDBLoader::beginRun(const edm::Run&, edm::EventSetup const& es) {
@@ -53,11 +53,12 @@ void GEMRecoIdealDBLoader::beginRun(const edm::Run&, edm::EventSetup const& es) 
     RecoIdealGeometry* rig = new RecoIdealGeometry;
 
     if (fromDD4Hep_) {
+      edm::LogVerbatim("GEMRecoIdealDBLoader")<< "(0) GEMRecoIdealDBLoader - DD4HEP ";
       edm::ESTransientHandle<cms::DDCompactView> pDD;
       es.get<IdealGeometryRecord>().get(pDD);
       es.get<IdealGeometryRecord>().get(pMNDC);
       const cms::DDCompactView& cpv = *pDD;
-      // rpcpd.build(&cpv, *pMNDC, *rig); // to be fixed
+      rpcpd.build(&cpv, *pMNDC, *rig); 
     } else {
       edm::LogVerbatim("GEMRecoIdealDBLoader")<< "(0) GEMRecoIdealDBLoader - DDD ";
       edm::ESTransientHandle<DDCompactView> pDD;

--- a/CondTools/Geometry/test/gemgeometrywriter.py
+++ b/CondTools/Geometry/test/gemgeometrywriter.py
@@ -2,8 +2,19 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("GEMGeometryWriter")
 process.load('CondCore.CondDB.CondDB_cfi')
-process.load('Configuration.Geometry.GeometryExtended2019_cff')
+process.load('Configuration.StandardSequences.GeometryExtended_cff')
 process.load('Geometry.MuonNumbering.muonNumberingInitialization_cfi')
+process.load("Geometry.MuonNumbering.muonGeometryConstants_cff")
+process.load('Configuration.StandardSequences.DD4hep_GeometrySim_cff')
+process.load('FWCore.MessageService.MessageLogger_cfi')
+
+
+process.MessageLogger = cms.Service("MessageLogger",
+    destinations = cms.untracked.vstring('myLog'),
+    myLog = cms.untracked.PSet(
+        threshold = cms.untracked.string('INFO'),
+    )
+)
 
 process.source = cms.Source("EmptyIOVSource",
                             lastValue = cms.uint64(1),
@@ -11,6 +22,9 @@ process.source = cms.Source("EmptyIOVSource",
                             firstValue = cms.uint64(1),
                             interval = cms.uint64(1)
                             )
+
+process.RPCGeometryWriter = cms.EDAnalyzer("RPCRecoIdealDBLoader",
+                                           fromDD4Hep = cms.untracked.bool(False))
 
 process.GEMGeometryWriter = cms.EDAnalyzer("GEMRecoIdealDBLoader")
 

--- a/CondTools/Geometry/test/gemgeometrywriter.py
+++ b/CondTools/Geometry/test/gemgeometrywriter.py
@@ -8,7 +8,6 @@ process.load("Geometry.MuonNumbering.muonGeometryConstants_cff")
 process.load('Configuration.StandardSequences.DD4hep_GeometrySim_cff')
 process.load('FWCore.MessageService.MessageLogger_cfi')
 
-
 process.MessageLogger = cms.Service("MessageLogger",
     destinations = cms.untracked.vstring('myLog'),
     myLog = cms.untracked.PSet(

--- a/CondTools/Geometry/test/gemgeometrywriter.py
+++ b/CondTools/Geometry/test/gemgeometrywriter.py
@@ -22,9 +22,6 @@ process.source = cms.Source("EmptyIOVSource",
                             interval = cms.uint64(1)
                             )
 
-process.GEMGeometryWriter = cms.EDAnalyzer("GEMRecoIdealDBLoader",
-                                           fromDD4Hep = cms.untracked.bool(False))
-
 process.GEMGeometryWriter = cms.EDAnalyzer("GEMRecoIdealDBLoader")
 
 process.CondDB.timetype = cms.untracked.string('runnumber')

--- a/CondTools/Geometry/test/gemgeometrywriter.py
+++ b/CondTools/Geometry/test/gemgeometrywriter.py
@@ -2,7 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("GEMGeometryWriter")
 process.load('CondCore.CondDB.CondDB_cfi')
-process.load('Configuration.StandardSequences.GeometryExtended_cff')
+process.load('Configuration.Geometry.GeometryExtended2021_cff')
 process.load('Geometry.MuonNumbering.muonNumberingInitialization_cfi')
 process.load("Geometry.MuonNumbering.muonGeometryConstants_cff")
 process.load('Configuration.StandardSequences.DD4hep_GeometrySim_cff')
@@ -23,7 +23,7 @@ process.source = cms.Source("EmptyIOVSource",
                             interval = cms.uint64(1)
                             )
 
-process.RPCGeometryWriter = cms.EDAnalyzer("RPCRecoIdealDBLoader",
+process.GEMGeometryWriter = cms.EDAnalyzer("GEMRecoIdealDBLoader",
                                            fromDD4Hep = cms.untracked.bool(False))
 
 process.GEMGeometryWriter = cms.EDAnalyzer("GEMRecoIdealDBLoader")

--- a/Geometry/GEMGeometryBuilder/src/GEMGeometryParsFromDD.cc
+++ b/Geometry/GEMGeometryBuilder/src/GEMGeometryParsFromDD.cc
@@ -17,8 +17,13 @@
 #include "Geometry/MuonNumbering/interface/MuonGeometryNumbering.h"
 #include "Geometry/MuonNumbering/interface/MuonBaseNumber.h"
 #include "Geometry/MuonNumbering/interface/GEMNumberingScheme.h"
+#include "Geometry/MuonNumbering/interface/MuonGeometryConstants.h"
 
 #include "DataFormats/GeometryVector/interface/Basic3DVector.h"
+
+#include "DetectorDescription/DDCMS/interface/DDFilteredView.h"
+#include "DetectorDescription/DDCMS/interface/DDCompactView.h"
+#include "DetectorDescription/DDCMS/interface/DDSpecParRegistry.h"
 
 #include <iostream>
 #include <algorithm>
@@ -105,24 +110,25 @@ void GEMGeometryParsFromDD::buildSuperChamber(DDFilteredView& fv, GEMDetId detId
   DDBooleanSolid solid = (DDBooleanSolid)(fv.logicalPart().solid());
   std::vector<double> dpar = solid.solidA().parameters();
 
+  GEMDetId gemid = detId.superChamberId();
+
   double dy = dpar[0];   //length is along local Y
   double dz = dpar[3];   // thickness is long local Z
   double dx1 = dpar[4];  // bottom width is along local X
   double dx2 = dpar[8];  // top width is along local X
   dpar = solid.solidB().parameters();
+  
   dz += dpar[3];  // chamber thickness
   dz *= 2;        // 2 chambers in superchamber
   dz += 2.105;    // gap between chambers
-
-  GEMDetId gemid = detId.superChamberId();
-
+  
   std::vector<double> pars{dx1, dx2, dy, dz};
   std::vector<double> vtra = getTranslation(fv);
   std::vector<double> vrot = getRotation(fv);
 
   LogDebug("GEMGeometryParsFromDD") << "dimension dx1 " << dx1 << ", dx2 " << dx2 << ", dy " << dy << ", dz " << dz;
   edm::LogVerbatim("GEMGeometryParsFromDD")
-    << "(1) DDD, SuperChamber DetID " << gemid.rawId() <<" Name "<<fv.logicalPart().name().name()<<" dx1 " << dx1 << " dx2 " << dx2 << " dy " << dy << " dz " << dz; 
+    << "(3) DDD, SuperChamber DetID " << gemid.rawId() <<" Name "<<fv.logicalPart().name().name()<<" dx1 " << dx1 << " dx2 " << dx2 << " dy " << dy << " dz " << dz; 
   rgeo.insert(gemid.rawId(), vtra, vrot, pars, {fv.logicalPart().name().name()});
 }
 
@@ -147,7 +153,7 @@ void GEMGeometryParsFromDD::buildChamber(DDFilteredView& fv, GEMDetId detId, Rec
 
   LogDebug("GEMGeometryParsFromDD") << "dimension dx1 " << dx1 << ", dx2 " << dx2 << ", dy " << dy << ", dz " << dz;
  edm::LogVerbatim("GEMGeometryParsFromDD")
-    << "(2) DDD, Chamber DetID " << gemid.rawId() <<" Name "<<fv.logicalPart().name().name()<<" dx1 " << dx1 << " dx2 " << dx2 << " dy " << dy << " dz " << dz; 
+    << "(4) DDD, Chamber DetID " << gemid.rawId() <<" Name "<<fv.logicalPart().name().name()<<" dx1 " << dx1 << " dx2 " << dx2 << " dy " << dy << " dz " << dz; 
   rgeo.insert(gemid.rawId(), vtra, vrot, pars, {fv.logicalPart().name().name()});
 }
 
@@ -189,14 +195,14 @@ void GEMGeometryParsFromDD::buildEtaPartition(DDFilteredView& fv, GEMDetId detId
   LogDebug("GEMGeometryParsFromDD") << " dx1 " << dx1 << " dx2 " << dx2 << " dy " << dy << " dz " << dz <<" nStrips "<<nStrips<<" nPads "<<nPads<<" dPhi "<<dPhi;
  
  edm::LogVerbatim("GEMGeometryParsFromDD")
-    << "(3) DDD, Eta Partion DetID " << detId.rawId() <<" Name "<<fv.logicalPart().name().name()<<" dx1 " << dx1 << " dx2 " << dx2 << " dy " << dy << " dz " << dz; 
+    << "(5) DDD, Eta Partion DetID " << detId.rawId() <<" Name "<<fv.logicalPart().name().name()<<" dx1 " << dx1 << " dx2 " << dx2 << " dy " << dy << " dz " << dz<<" nStrips "<<nStrips<<" nPads "<<nPads<<" dPhi "<<dPhi; 
   rgeo.insert(detId.rawId(), vtra, vrot, pars, {fv.logicalPart().name().name()});
 }
 
 std::vector<double> GEMGeometryParsFromDD::getTranslation(DDFilteredView& fv) {
   const DDTranslation& tran = fv.translation();
 edm::LogVerbatim("GEMGeometryParsFromDD")
-    << "(4) DDD, tran vector " << tran.x() << "  " << tran.y() << "  " << tran.z();
+    << "(1) DDD, tran vector " << tran.x() << "  " << tran.y() << "  " << tran.z();
   return {tran.x(), tran.y(), tran.z()};
 }
 
@@ -205,9 +211,176 @@ std::vector<double> GEMGeometryParsFromDD::getRotation(DDFilteredView& fv) {
   DD3Vector x, y, z;
   rota.GetComponents(x, y, z);
   edm::LogVerbatim("GEMGeometryParsFromDD")
-    << "(5) DDD, rot matrix " << x.X() << "  " << x.Y() << "  " << x.Z()<<" "<< y.X() << "  " << y.Y() << "  " << y.Z()<<" "<< z.X() << "  " << z.Y() << "  " << z.Z();
+  << "(2) DDD, rot matrix " << x.X() << "  " << x.Y() << "  " << x.Z()<<" "<< y.X() << "  " << y.Y() << "  " << y.Z()<<" "<< z.X() << "  " << z.Y() << "  " << z.Z();
   return {x.X(), x.Y(), x.Z(), y.X(), y.Y(), y.Z(), z.X(), z.Y(), z.Z()};
 }
 
 // DD4Hep
+
+void GEMGeometryParsFromDD::build(const cms::DDCompactView* cview,
+                                  const MuonGeometryConstants& muonConstants,
+                                  RecoIdealGeometry& rgeo) {
+  std::string attribute = "MuStructure";
+  std::string value = "MuonEndCapGEM";
+
+  const cms::DDFilter filter(attribute, value);
+  cms::DDFilteredView fv(*cview, filter);
+
+  this->buildGeometry(fv, muonConstants, rgeo);
+}
+
+void GEMGeometryParsFromDD::buildGeometry(cms::DDFilteredView& fv,
+                                          const MuonGeometryConstants& muonConstants,
+                                          RecoIdealGeometry& rgeo) {
+  
+  edm::LogVerbatim("GEMGeometryParsFromDD")<< "(0) GEMGeometryParsFromDD - DD4HEP ";  
+  
+  MuonGeometryNumbering mdddnum(muonConstants);
+  GEMNumberingScheme gemNum(muonConstants);
+  static constexpr uint32_t levelChamb = 7;
+  int chamb(0), region(0);
+  int theLevelPart = muonConstants.getValue("level");
+  int theRingLevel = muonConstants.getValue("mg_ring") / theLevelPart;
+  int theSectorLevel = muonConstants.getValue("mg_sector") / theLevelPart; 
+  
+  while (fv.firstChild()) {
+    const auto& history = fv.history();
+    MuonBaseNumber num(mdddnum.geoHistoryToBaseNumber(history));
+    GEMDetId detId(gemNum.baseNumberToUnitNumber(num));
+    
+    if (detId.station() == GEMDetId::minStationId0) {
+      if (num.getLevels() == theRingLevel) {
+        if (detId.region() != region) {
+          region = detId.region();
+          chamb = 0;
+        }
+        ++chamb;
+        detId = GEMDetId(detId.region(), detId.ring(), detId.station(), detId.layer(), chamb, 0);
+	buildSuperChamber(fv, detId, rgeo); 
+      } else if (num.getLevels() == theSectorLevel) {
+	buildChamber(fv, detId, rgeo); 
+      } else {
+	buildEtaPartition(fv, detId, rgeo);
+      }
+    } else {
+      if (fv.level() == levelChamb) {
+        if (detId.layer() == 1) {
+	  buildSuperChamber(fv, detId, rgeo);
+	}
+	 buildChamber(fv, detId, rgeo); 
+      } else if (num.getLevels() > theSectorLevel) {
+	buildEtaPartition(fv, detId, rgeo);
+      }
+    }
+  }
+}
+
+void GEMGeometryParsFromDD::buildSuperChamber(cms::DDFilteredView& fv, GEMDetId detId, RecoIdealGeometry& rgeo) {
+  cms::DDSolid solid(fv.solid());
+  auto solidA = solid.solidA();
+  std::vector<double> dpar = solidA.dimensions();
+
+  double dy = dpar[3] / dd4hep::mm;   //length is along local Y
+  double dz = dpar[2] /dd4hep::mm;   // thickness is long local Z
+  double dx1 = dpar[0] /dd4hep::mm;  // bottom width is along local X
+  double dx2 = dpar[1] /dd4hep::mm;  // top width is along loc
+
+  auto solidB = solid.solidB();
+  dpar = solidB.dimensions();
+  const int nch = 2;
+  const double chgap = 2.105;
+
+  GEMDetId gemid = detId.superChamberId();
+  std::string_view name = fv.name();
+
+  dz += (dpar[2]/dd4hep::mm);  // chamber thickness
+  dz *= nch;                            // 2 chambers in superchamber
+  dz += chgap;                          // gap between chambers
+  
+  std::vector<double> pars{dx1, dx2, dy, dz};
+  std::vector<double> vtra = getTranslation(fv);
+  std::vector<double> vrot = getRotation(fv);
+
+  edm::LogVerbatim("GEMGeometryParsFromDD")
+    << "(3) DD4HEP, SuperChamber DetID " << gemid.rawId() <<" Name "<<std::string(name)<<" dx1 " << dx1 << " dx2 " << dx2 << " dy " << dy << " dz " << dz; 
+  rgeo.insert(gemid.rawId(), vtra, vrot, pars, {std::string(name)});
+ 
+}
+
+void GEMGeometryParsFromDD::buildChamber(cms::DDFilteredView& fv, GEMDetId detId, RecoIdealGeometry& rgeo) {
+  
+  cms::DDSolid solid(fv.solid());
+  auto solidA = solid.solidA();
+  std::vector<double> dpar = solidA.dimensions();
+
+  double dy = dpar[3] / dd4hep::mm ;   //length is along local Y
+  double dz = dpar[2] / dd4hep::mm;   // thickness is long local Z
+  double dx1 = dpar[0] / dd4hep::mm;  // bottom width is along local X
+  double dx2 = dpar[1] / dd4hep::mm;  // top width is along local X
+
+  auto solidB = solid.solidB();
+  dpar = solidB.dimensions();
+
+  dz += (dpar[2] / dd4hep::mm);  // chamber thickness
+
+  GEMDetId gemid = detId.chamberId();
+  std::string_view name = fv.name();
+
+  std::vector<double> pars{dx1, dx2, dy, dz};
+  std::vector<double> vtra = getTranslation(fv);
+  std::vector<double> vrot = getRotation(fv);
+  
+  edm::LogVerbatim("GEMGeometryParsFromDD")
+    << "(4) DD4HEP, Chamber DetID " << gemid.rawId() <<" Name "<<std::string(name)<<" dx1 " << dx1 << " dx2 " << dx2 << " dy " << dy << " dz " << dz; 
+  rgeo.insert(gemid.rawId(), vtra, vrot, pars, {std::string(name)});
+}
+
+void GEMGeometryParsFromDD::buildEtaPartition(cms::DDFilteredView& fv, GEMDetId detId, RecoIdealGeometry& rgeo) {
+
+  auto nStrips = fv.get<double>("nStrips");
+  auto nPads = fv.get<double>("nPads");
+  auto dPhi = fv.get<double>("dPhi");
+  
+  std::vector<double> dpar = fv.parameters();
+  std::string_view name = fv.name();
+
+  double dx1 = dpar[0] / dd4hep::mm;
+  double dx2 = dpar[1]/ dd4hep::mm;
+  double dy = dpar[3]/ dd4hep::mm;
+  double dz = dpar[2]/ dd4hep::mm;
+      
+  std::vector<double> pars{dx1, dx2, dy, dz, nStrips, nPads, dPhi};
+  std::vector<double> vtra = getTranslation(fv);
+  std::vector<double> vrot = getRotation(fv);
+  
+  edm::LogVerbatim("GEMGeometryParsFromDD")
+   << "(5) DD4HEP, Eta Partion DetID " << detId.rawId() <<" Name "<<std::string(name)<<" dx1 " << dx1 << " dx2 " << dx2 << " dy " << dy << " dz " << dz<<" nStrips "<<nStrips<<" nPads "<<nPads<<" dPhi "<<dPhi; 
+  rgeo.insert(detId.rawId(), vtra, vrot, pars, {std::string(name)});
+}
+
+
+std::vector<double> GEMGeometryParsFromDD::getTranslation(cms::DDFilteredView& fv) {
+
+ std::vector<double> tran(3);
+ tran[0] = static_cast<double>(fv.translation().X()) / dd4hep::mm;
+ tran[1] = static_cast<double>(fv.translation().Y()) / dd4hep::mm;
+ tran[2] = static_cast<double>(fv.translation().Z()) / dd4hep::mm;
+ 
+edm::LogVerbatim("GEMGeometryParsFromDD")
+    << "(1) DD4HEP, tran vector " << tran[0] << "  " << tran[1] << "  " << tran[2];
+  return {tran[0], tran[1], tran[2]};
+}
+
+std::vector<double> GEMGeometryParsFromDD::getRotation(cms::DDFilteredView& fv) {
+ 
+  DDRotationMatrix rota;
+  fv.rot(rota);
+  DD3Vector x, y, z;
+  rota.GetComponents(x, y, z);
+  const std::vector<double> rot = {x.X(), x.Y(), x.Z(), y.X(), y.Y(), y.Z(), z.X(), z.Y(), z.Z()};
+  edm::LogVerbatim("GEMGeometryParsFromDD")
+    << "(2) DD4HEP, rot matrix " << rot[0] << "  " << rot[1] << "  " << rot[2]<<" "<< rot[3] << "  " << rot[4] << "  " << rot[5]<<" "<< rot[6] << "  " << rot[7] << "  " << rot[8];
+  return {rot[0], rot[1], rot[2], rot[3], rot[4], rot[5], rot[6], rot[7], rot[8]};
+}
+
 

--- a/Geometry/GEMGeometryBuilder/src/GEMGeometryParsFromDD.cc
+++ b/Geometry/GEMGeometryBuilder/src/GEMGeometryParsFromDD.cc
@@ -54,17 +54,15 @@ void GEMGeometryParsFromDD::buildGeometry(DDFilteredView& fv,
   LogDebug("GEMGeometryParsFromDD") << "About to run through the GEM structure\n"
                                     << " First logical part " << fv.logicalPart().name().name();
 
- edm::LogVerbatim("GEMGeometryParsFromDD")
-   << "(0) GEMGeometryParsFromDD - DDD ";  
+  edm::LogVerbatim("GEMGeometryParsFromDD") << "(0) GEMGeometryParsFromDD - DDD ";
   MuonGeometryNumbering muonDDDNumbering(muonConstants);
   GEMNumberingScheme gemNumbering(muonConstants);
 
   bool doSuper = fv.firstChild();
- 
+
   LogDebug("GEMGeometryParsFromDD") << "doSuperChamber = " << doSuper;
   // loop over superchambers
   while (doSuper) {
-
     // getting chamber id from eta partitions
     fv.firstChild();
     fv.firstChild();
@@ -117,18 +115,19 @@ void GEMGeometryParsFromDD::buildSuperChamber(DDFilteredView& fv, GEMDetId detId
   double dx1 = dpar[4];  // bottom width is along local X
   double dx2 = dpar[8];  // top width is along local X
   dpar = solid.solidB().parameters();
-  
+
   dz += dpar[3];  // chamber thickness
   dz *= 2;        // 2 chambers in superchamber
   dz += 2.105;    // gap between chambers
-  
+
   std::vector<double> pars{dx1, dx2, dy, dz};
   std::vector<double> vtra = getTranslation(fv);
   std::vector<double> vrot = getRotation(fv);
 
   LogDebug("GEMGeometryParsFromDD") << "dimension dx1 " << dx1 << ", dx2 " << dx2 << ", dy " << dy << ", dz " << dz;
   edm::LogVerbatim("GEMGeometryParsFromDD")
-    << "(3) DDD, SuperChamber DetID " << gemid.rawId() <<" Name "<<fv.logicalPart().name().name()<<" dx1 " << dx1 << " dx2 " << dx2 << " dy " << dy << " dz " << dz; 
+      << "(3) DDD, SuperChamber DetID " << gemid.rawId() << " Name " << fv.logicalPart().name().name() << " dx1 " << dx1
+      << " dx2 " << dx2 << " dy " << dy << " dz " << dz;
   rgeo.insert(gemid.rawId(), vtra, vrot, pars, {fv.logicalPart().name().name()});
 }
 
@@ -152,8 +151,9 @@ void GEMGeometryParsFromDD::buildChamber(DDFilteredView& fv, GEMDetId detId, Rec
   std::vector<double> vrot = getRotation(fv);
 
   LogDebug("GEMGeometryParsFromDD") << "dimension dx1 " << dx1 << ", dx2 " << dx2 << ", dy " << dy << ", dz " << dz;
- edm::LogVerbatim("GEMGeometryParsFromDD")
-    << "(4) DDD, Chamber DetID " << gemid.rawId() <<" Name "<<fv.logicalPart().name().name()<<" dx1 " << dx1 << " dx2 " << dx2 << " dy " << dy << " dz " << dz; 
+  edm::LogVerbatim("GEMGeometryParsFromDD")
+      << "(4) DDD, Chamber DetID " << gemid.rawId() << " Name " << fv.logicalPart().name().name() << " dx1 " << dx1
+      << " dx2 " << dx2 << " dy " << dy << " dz " << dz;
   rgeo.insert(gemid.rawId(), vtra, vrot, pars, {fv.logicalPart().name().name()});
 }
 
@@ -192,17 +192,20 @@ void GEMGeometryParsFromDD::buildEtaPartition(DDFilteredView& fv, GEMDetId detId
   std::vector<double> vtra = getTranslation(fv);
   std::vector<double> vrot = getRotation(fv);
 
-  LogDebug("GEMGeometryParsFromDD") << " dx1 " << dx1 << " dx2 " << dx2 << " dy " << dy << " dz " << dz <<" nStrips "<<nStrips<<" nPads "<<nPads<<" dPhi "<<dPhi;
- 
- edm::LogVerbatim("GEMGeometryParsFromDD")
-    << "(5) DDD, Eta Partion DetID " << detId.rawId() <<" Name "<<fv.logicalPart().name().name()<<" dx1 " << dx1 << " dx2 " << dx2 << " dy " << dy << " dz " << dz<<" nStrips "<<nStrips<<" nPads "<<nPads<<" dPhi "<<dPhi; 
+  LogDebug("GEMGeometryParsFromDD") << " dx1 " << dx1 << " dx2 " << dx2 << " dy " << dy << " dz " << dz << " nStrips "
+                                    << nStrips << " nPads " << nPads << " dPhi " << dPhi;
+
+  edm::LogVerbatim("GEMGeometryParsFromDD")
+      << "(5) DDD, Eta Partion DetID " << detId.rawId() << " Name " << fv.logicalPart().name().name() << " dx1 " << dx1
+      << " dx2 " << dx2 << " dy " << dy << " dz " << dz << " nStrips " << nStrips << " nPads " << nPads << " dPhi "
+      << dPhi;
   rgeo.insert(detId.rawId(), vtra, vrot, pars, {fv.logicalPart().name().name()});
 }
 
 std::vector<double> GEMGeometryParsFromDD::getTranslation(DDFilteredView& fv) {
   const DDTranslation& tran = fv.translation();
-edm::LogVerbatim("GEMGeometryParsFromDD")
-    << "(1) DDD, tran vector " << tran.x() << "  " << tran.y() << "  " << tran.z();
+  edm::LogVerbatim("GEMGeometryParsFromDD")
+      << "(1) DDD, tran vector " << tran.x() << "  " << tran.y() << "  " << tran.z();
   return {tran.x(), tran.y(), tran.z()};
 }
 
@@ -211,7 +214,8 @@ std::vector<double> GEMGeometryParsFromDD::getRotation(DDFilteredView& fv) {
   DD3Vector x, y, z;
   rota.GetComponents(x, y, z);
   edm::LogVerbatim("GEMGeometryParsFromDD")
-  << "(2) DDD, rot matrix " << x.X() << "  " << x.Y() << "  " << x.Z()<<" "<< y.X() << "  " << y.Y() << "  " << y.Z()<<" "<< z.X() << "  " << z.Y() << "  " << z.Z();
+      << "(2) DDD, rot matrix " << x.X() << "  " << x.Y() << "  " << x.Z() << " " << y.X() << "  " << y.Y() << "  "
+      << y.Z() << " " << z.X() << "  " << z.Y() << "  " << z.Z();
   return {x.X(), x.Y(), x.Z(), y.X(), y.Y(), y.Z(), z.X(), z.Y(), z.Z()};
 }
 
@@ -232,22 +236,21 @@ void GEMGeometryParsFromDD::build(const cms::DDCompactView* cview,
 void GEMGeometryParsFromDD::buildGeometry(cms::DDFilteredView& fv,
                                           const MuonGeometryConstants& muonConstants,
                                           RecoIdealGeometry& rgeo) {
-  
-  edm::LogVerbatim("GEMGeometryParsFromDD")<< "(0) GEMGeometryParsFromDD - DD4HEP ";  
-  
+  edm::LogVerbatim("GEMGeometryParsFromDD") << "(0) GEMGeometryParsFromDD - DD4HEP ";
+
   MuonGeometryNumbering mdddnum(muonConstants);
   GEMNumberingScheme gemNum(muonConstants);
   static constexpr uint32_t levelChamb = 7;
   int chamb(0), region(0);
   int theLevelPart = muonConstants.getValue("level");
   int theRingLevel = muonConstants.getValue("mg_ring") / theLevelPart;
-  int theSectorLevel = muonConstants.getValue("mg_sector") / theLevelPart; 
-  
+  int theSectorLevel = muonConstants.getValue("mg_sector") / theLevelPart;
+
   while (fv.firstChild()) {
     const auto& history = fv.history();
     MuonBaseNumber num(mdddnum.geoHistoryToBaseNumber(history));
     GEMDetId detId(gemNum.baseNumberToUnitNumber(num));
-    
+
     if (detId.station() == GEMDetId::minStationId0) {
       if (num.getLevels() == theRingLevel) {
         if (detId.region() != region) {
@@ -256,20 +259,20 @@ void GEMGeometryParsFromDD::buildGeometry(cms::DDFilteredView& fv,
         }
         ++chamb;
         detId = GEMDetId(detId.region(), detId.ring(), detId.station(), detId.layer(), chamb, 0);
-	buildSuperChamber(fv, detId, rgeo); 
+        buildSuperChamber(fv, detId, rgeo);
       } else if (num.getLevels() == theSectorLevel) {
-	buildChamber(fv, detId, rgeo); 
+        buildChamber(fv, detId, rgeo);
       } else {
-	buildEtaPartition(fv, detId, rgeo);
+        buildEtaPartition(fv, detId, rgeo);
       }
     } else {
       if (fv.level() == levelChamb) {
         if (detId.layer() == 1) {
-	  buildSuperChamber(fv, detId, rgeo);
-	}
-	 buildChamber(fv, detId, rgeo); 
+          buildSuperChamber(fv, detId, rgeo);
+        }
+        buildChamber(fv, detId, rgeo);
       } else if (num.getLevels() > theSectorLevel) {
-	buildEtaPartition(fv, detId, rgeo);
+        buildEtaPartition(fv, detId, rgeo);
       }
     }
   }
@@ -281,9 +284,9 @@ void GEMGeometryParsFromDD::buildSuperChamber(cms::DDFilteredView& fv, GEMDetId 
   std::vector<double> dpar = solidA.dimensions();
 
   double dy = dpar[3] / dd4hep::mm;   //length is along local Y
-  double dz = dpar[2] /dd4hep::mm;   // thickness is long local Z
-  double dx1 = dpar[0] /dd4hep::mm;  // bottom width is along local X
-  double dx2 = dpar[1] /dd4hep::mm;  // top width is along loc
+  double dz = dpar[2] / dd4hep::mm;   // thickness is long local Z
+  double dx1 = dpar[0] / dd4hep::mm;  // bottom width is along local X
+  double dx2 = dpar[1] / dd4hep::mm;  // top width is along loc
 
   auto solidB = solid.solidB();
   dpar = solidB.dimensions();
@@ -293,27 +296,26 @@ void GEMGeometryParsFromDD::buildSuperChamber(cms::DDFilteredView& fv, GEMDetId 
   GEMDetId gemid = detId.superChamberId();
   std::string_view name = fv.name();
 
-  dz += (dpar[2]/dd4hep::mm);  // chamber thickness
-  dz *= nch;                            // 2 chambers in superchamber
-  dz += chgap;                          // gap between chambers
-  
+  dz += (dpar[2] / dd4hep::mm);  // chamber thickness
+  dz *= nch;                     // 2 chambers in superchamber
+  dz += chgap;                   // gap between chambers
+
   std::vector<double> pars{dx1, dx2, dy, dz};
   std::vector<double> vtra = getTranslation(fv);
   std::vector<double> vrot = getRotation(fv);
 
   edm::LogVerbatim("GEMGeometryParsFromDD")
-    << "(3) DD4HEP, SuperChamber DetID " << gemid.rawId() <<" Name "<<std::string(name)<<" dx1 " << dx1 << " dx2 " << dx2 << " dy " << dy << " dz " << dz; 
+      << "(3) DD4HEP, SuperChamber DetID " << gemid.rawId() << " Name " << std::string(name) << " dx1 " << dx1
+      << " dx2 " << dx2 << " dy " << dy << " dz " << dz;
   rgeo.insert(gemid.rawId(), vtra, vrot, pars, {std::string(name)});
- 
 }
 
 void GEMGeometryParsFromDD::buildChamber(cms::DDFilteredView& fv, GEMDetId detId, RecoIdealGeometry& rgeo) {
-  
   cms::DDSolid solid(fv.solid());
   auto solidA = solid.solidA();
   std::vector<double> dpar = solidA.dimensions();
 
-  double dy = dpar[3] / dd4hep::mm ;   //length is along local Y
+  double dy = dpar[3] / dd4hep::mm;   //length is along local Y
   double dz = dpar[2] / dd4hep::mm;   // thickness is long local Z
   double dx1 = dpar[0] / dd4hep::mm;  // bottom width is along local X
   double dx2 = dpar[1] / dd4hep::mm;  // top width is along local X
@@ -329,58 +331,55 @@ void GEMGeometryParsFromDD::buildChamber(cms::DDFilteredView& fv, GEMDetId detId
   std::vector<double> pars{dx1, dx2, dy, dz};
   std::vector<double> vtra = getTranslation(fv);
   std::vector<double> vrot = getRotation(fv);
-  
+
   edm::LogVerbatim("GEMGeometryParsFromDD")
-    << "(4) DD4HEP, Chamber DetID " << gemid.rawId() <<" Name "<<std::string(name)<<" dx1 " << dx1 << " dx2 " << dx2 << " dy " << dy << " dz " << dz; 
+      << "(4) DD4HEP, Chamber DetID " << gemid.rawId() << " Name " << std::string(name) << " dx1 " << dx1 << " dx2 "
+      << dx2 << " dy " << dy << " dz " << dz;
   rgeo.insert(gemid.rawId(), vtra, vrot, pars, {std::string(name)});
 }
 
 void GEMGeometryParsFromDD::buildEtaPartition(cms::DDFilteredView& fv, GEMDetId detId, RecoIdealGeometry& rgeo) {
-
   auto nStrips = fv.get<double>("nStrips");
   auto nPads = fv.get<double>("nPads");
   auto dPhi = fv.get<double>("dPhi");
-  
+
   std::vector<double> dpar = fv.parameters();
   std::string_view name = fv.name();
 
   double dx1 = dpar[0] / dd4hep::mm;
-  double dx2 = dpar[1]/ dd4hep::mm;
-  double dy = dpar[3]/ dd4hep::mm;
-  double dz = dpar[2]/ dd4hep::mm;
-      
+  double dx2 = dpar[1] / dd4hep::mm;
+  double dy = dpar[3] / dd4hep::mm;
+  double dz = dpar[2] / dd4hep::mm;
+
   std::vector<double> pars{dx1, dx2, dy, dz, nStrips, nPads, dPhi};
   std::vector<double> vtra = getTranslation(fv);
   std::vector<double> vrot = getRotation(fv);
-  
+
   edm::LogVerbatim("GEMGeometryParsFromDD")
-   << "(5) DD4HEP, Eta Partion DetID " << detId.rawId() <<" Name "<<std::string(name)<<" dx1 " << dx1 << " dx2 " << dx2 << " dy " << dy << " dz " << dz<<" nStrips "<<nStrips<<" nPads "<<nPads<<" dPhi "<<dPhi; 
+      << "(5) DD4HEP, Eta Partion DetID " << detId.rawId() << " Name " << std::string(name) << " dx1 " << dx1 << " dx2 "
+      << dx2 << " dy " << dy << " dz " << dz << " nStrips " << nStrips << " nPads " << nPads << " dPhi " << dPhi;
   rgeo.insert(detId.rawId(), vtra, vrot, pars, {std::string(name)});
 }
 
-
 std::vector<double> GEMGeometryParsFromDD::getTranslation(cms::DDFilteredView& fv) {
+  std::vector<double> tran(3);
+  tran[0] = static_cast<double>(fv.translation().X()) / dd4hep::mm;
+  tran[1] = static_cast<double>(fv.translation().Y()) / dd4hep::mm;
+  tran[2] = static_cast<double>(fv.translation().Z()) / dd4hep::mm;
 
- std::vector<double> tran(3);
- tran[0] = static_cast<double>(fv.translation().X()) / dd4hep::mm;
- tran[1] = static_cast<double>(fv.translation().Y()) / dd4hep::mm;
- tran[2] = static_cast<double>(fv.translation().Z()) / dd4hep::mm;
- 
-edm::LogVerbatim("GEMGeometryParsFromDD")
-    << "(1) DD4HEP, tran vector " << tran[0] << "  " << tran[1] << "  " << tran[2];
+  edm::LogVerbatim("GEMGeometryParsFromDD")
+      << "(1) DD4HEP, tran vector " << tran[0] << "  " << tran[1] << "  " << tran[2];
   return {tran[0], tran[1], tran[2]};
 }
 
 std::vector<double> GEMGeometryParsFromDD::getRotation(cms::DDFilteredView& fv) {
- 
   DDRotationMatrix rota;
   fv.rot(rota);
   DD3Vector x, y, z;
   rota.GetComponents(x, y, z);
   const std::vector<double> rot = {x.X(), x.Y(), x.Z(), y.X(), y.Y(), y.Z(), z.X(), z.Y(), z.Z()};
   edm::LogVerbatim("GEMGeometryParsFromDD")
-    << "(2) DD4HEP, rot matrix " << rot[0] << "  " << rot[1] << "  " << rot[2]<<" "<< rot[3] << "  " << rot[4] << "  " << rot[5]<<" "<< rot[6] << "  " << rot[7] << "  " << rot[8];
+      << "(2) DD4HEP, rot matrix " << rot[0] << "  " << rot[1] << "  " << rot[2] << " " << rot[3] << "  " << rot[4]
+      << "  " << rot[5] << " " << rot[6] << "  " << rot[7] << "  " << rot[8];
   return {rot[0], rot[1], rot[2], rot[3], rot[4], rot[5], rot[6], rot[7], rot[8]};
 }
-
-

--- a/Geometry/GEMGeometryBuilder/src/GEMGeometryParsFromDD.cc
+++ b/Geometry/GEMGeometryBuilder/src/GEMGeometryParsFromDD.cc
@@ -1,6 +1,10 @@
-/** Implementation of the GEM Geometry Builder from DDD
+/* Implementation of the  GEMGeometryParsFromDD Class
+ *  Build the GEMGeometry from the DDD and DD4Hep description
+ *  
+ *  DD4hep part added to the original old file (DD version) made by M. Maggi (INFN Bari)
+ *  Author:  Sergio Lo Meo (sergio.lo.meo@cern.ch) 
+ *  Created:  Mon, 25 Jan 2021 
  *
- *  \author M. Maggi - INFN Bari
  */
 #include "Geometry/GEMGeometryBuilder/src/GEMGeometryParsFromDD.h"
 #include "DataFormats/MuonDetId/interface/GEMDetId.h"

--- a/Geometry/GEMGeometryBuilder/src/GEMGeometryParsFromDD.cc
+++ b/Geometry/GEMGeometryBuilder/src/GEMGeometryParsFromDD.cc
@@ -27,6 +27,8 @@ GEMGeometryParsFromDD::GEMGeometryParsFromDD() {}
 
 GEMGeometryParsFromDD::~GEMGeometryParsFromDD() {}
 
+// DDD
+
 void GEMGeometryParsFromDD::build(const DDCompactView* cview,
                                   const MuonGeometryConstants& muonConstants,
                                   RecoIdealGeometry& rgeo) {
@@ -47,13 +49,17 @@ void GEMGeometryParsFromDD::buildGeometry(DDFilteredView& fv,
   LogDebug("GEMGeometryParsFromDD") << "About to run through the GEM structure\n"
                                     << " First logical part " << fv.logicalPart().name().name();
 
+ edm::LogVerbatim("GEMGeometryParsFromDD")
+   << "(0) GEMGeometryParsFromDD - DDD ";  
   MuonGeometryNumbering muonDDDNumbering(muonConstants);
   GEMNumberingScheme gemNumbering(muonConstants);
 
   bool doSuper = fv.firstChild();
+ 
   LogDebug("GEMGeometryParsFromDD") << "doSuperChamber = " << doSuper;
   // loop over superchambers
   while (doSuper) {
+
     // getting chamber id from eta partitions
     fv.firstChild();
     fv.firstChild();
@@ -115,6 +121,8 @@ void GEMGeometryParsFromDD::buildSuperChamber(DDFilteredView& fv, GEMDetId detId
   std::vector<double> vrot = getRotation(fv);
 
   LogDebug("GEMGeometryParsFromDD") << "dimension dx1 " << dx1 << ", dx2 " << dx2 << ", dy " << dy << ", dz " << dz;
+  edm::LogVerbatim("GEMGeometryParsFromDD")
+    << "(1) DDD, Chamber DetID " << gemid.rawId() <<" Name "<<fv.logicalPart().name().name()<<" dx1 " << dx1 << ", dx2 " << dx2 << ", dy " << dy << ", dz " << dz; 
   rgeo.insert(gemid.rawId(), vtra, vrot, pars, {fv.logicalPart().name().name()});
 }
 

--- a/Geometry/GEMGeometryBuilder/src/GEMGeometryParsFromDD.cc
+++ b/Geometry/GEMGeometryBuilder/src/GEMGeometryParsFromDD.cc
@@ -122,7 +122,7 @@ void GEMGeometryParsFromDD::buildSuperChamber(DDFilteredView& fv, GEMDetId detId
 
   LogDebug("GEMGeometryParsFromDD") << "dimension dx1 " << dx1 << ", dx2 " << dx2 << ", dy " << dy << ", dz " << dz;
   edm::LogVerbatim("GEMGeometryParsFromDD")
-    << "(1) DDD, Chamber DetID " << gemid.rawId() <<" Name "<<fv.logicalPart().name().name()<<" dx1 " << dx1 << ", dx2 " << dx2 << ", dy " << dy << ", dz " << dz; 
+    << "(1) DDD, SuperChamber DetID " << gemid.rawId() <<" Name "<<fv.logicalPart().name().name()<<" dx1 " << dx1 << " dx2 " << dx2 << " dy " << dy << " dz " << dz; 
   rgeo.insert(gemid.rawId(), vtra, vrot, pars, {fv.logicalPart().name().name()});
 }
 
@@ -146,6 +146,8 @@ void GEMGeometryParsFromDD::buildChamber(DDFilteredView& fv, GEMDetId detId, Rec
   std::vector<double> vrot = getRotation(fv);
 
   LogDebug("GEMGeometryParsFromDD") << "dimension dx1 " << dx1 << ", dx2 " << dx2 << ", dy " << dy << ", dz " << dz;
+ edm::LogVerbatim("GEMGeometryParsFromDD")
+    << "(2) DDD, Chamber DetID " << gemid.rawId() <<" Name "<<fv.logicalPart().name().name()<<" dx1 " << dx1 << " dx2 " << dx2 << " dy " << dy << " dz " << dz; 
   rgeo.insert(gemid.rawId(), vtra, vrot, pars, {fv.logicalPart().name().name()});
 }
 
@@ -184,12 +186,17 @@ void GEMGeometryParsFromDD::buildEtaPartition(DDFilteredView& fv, GEMDetId detId
   std::vector<double> vtra = getTranslation(fv);
   std::vector<double> vrot = getRotation(fv);
 
-  LogDebug("GEMGeometryParsFromDD") << "dimension dx1 " << dx1 << ", dx2 " << dx2 << ", dy " << dy << ", dz " << dz;
+  LogDebug("GEMGeometryParsFromDD") << " dx1 " << dx1 << " dx2 " << dx2 << " dy " << dy << " dz " << dz <<" nStrips "<<nStrips<<" nPads "<<nPads<<" dPhi "<<dPhi;
+ 
+ edm::LogVerbatim("GEMGeometryParsFromDD")
+    << "(3) DDD, Eta Partion DetID " << detId.rawId() <<" Name "<<fv.logicalPart().name().name()<<" dx1 " << dx1 << " dx2 " << dx2 << " dy " << dy << " dz " << dz; 
   rgeo.insert(detId.rawId(), vtra, vrot, pars, {fv.logicalPart().name().name()});
 }
 
 std::vector<double> GEMGeometryParsFromDD::getTranslation(DDFilteredView& fv) {
   const DDTranslation& tran = fv.translation();
+edm::LogVerbatim("GEMGeometryParsFromDD")
+    << "(4) DDD, tran vector " << tran.x() << "  " << tran.y() << "  " << tran.z();
   return {tran.x(), tran.y(), tran.z()};
 }
 
@@ -197,5 +204,10 @@ std::vector<double> GEMGeometryParsFromDD::getRotation(DDFilteredView& fv) {
   const DDRotationMatrix& rota = fv.rotation();  //.Inverse();
   DD3Vector x, y, z;
   rota.GetComponents(x, y, z);
+  edm::LogVerbatim("GEMGeometryParsFromDD")
+    << "(5) DDD, rot matrix " << x.X() << "  " << x.Y() << "  " << x.Z()<<" "<< y.X() << "  " << y.Y() << "  " << y.Z()<<" "<< z.X() << "  " << z.Y() << "  " << z.Z();
   return {x.X(), x.Y(), x.Z(), y.X(), y.Y(), y.Z(), z.X(), z.Y(), z.Z()};
 }
+
+// DD4Hep
+

--- a/Geometry/GEMGeometryBuilder/src/GEMGeometryParsFromDD.cc
+++ b/Geometry/GEMGeometryBuilder/src/GEMGeometryParsFromDD.cc
@@ -3,7 +3,7 @@
  *  
  *  DD4hep part added to the original old file (DD version) made by M. Maggi (INFN Bari)
  *  Author:  Sergio Lo Meo (sergio.lo.meo@cern.ch) 
- *  Created:  Mon, 25 Jan 2021 
+ *  Created:  Mon, 15 Feb 2021 
  *
  */
 #include "Geometry/GEMGeometryBuilder/src/GEMGeometryParsFromDD.h"

--- a/Geometry/GEMGeometryBuilder/src/GEMGeometryParsFromDD.h
+++ b/Geometry/GEMGeometryBuilder/src/GEMGeometryParsFromDD.h
@@ -55,6 +55,5 @@ private:
 
   std::vector<double> getTranslation(cms::DDFilteredView& fv);
   std::vector<double> getRotation(cms::DDFilteredView& fv);
-
 };
 #endif

--- a/Geometry/GEMGeometryBuilder/src/GEMGeometryParsFromDD.h
+++ b/Geometry/GEMGeometryBuilder/src/GEMGeometryParsFromDD.h
@@ -6,7 +6,7 @@
  *  
  *  DD4hep part added to the original old file (DD version) made by M. Maggi (INFN Bari)
  *  Author:  Sergio Lo Meo (sergio.lo.meo@cern.ch) 
- *  Created:  Mon, 25 Jan 2021 
+ *  Created:  Mon, 15 Feb 2021 
  *
  */
 

--- a/Geometry/GEMGeometryBuilder/src/GEMGeometryParsFromDD.h
+++ b/Geometry/GEMGeometryBuilder/src/GEMGeometryParsFromDD.h
@@ -48,6 +48,13 @@ private:
 
   // DD4Hep
 
+  void buildGeometry(cms::DDFilteredView& fview, const MuonGeometryConstants& muonConstants, RecoIdealGeometry& rgeo);
+  void buildSuperChamber(cms::DDFilteredView& fv, GEMDetId detId, RecoIdealGeometry& rgeo);
+  void buildChamber(cms::DDFilteredView& fv, GEMDetId detId, RecoIdealGeometry& rgeo);
+  void buildEtaPartition(cms::DDFilteredView& fv, GEMDetId detId, RecoIdealGeometry& rgeo);
+
+  std::vector<double> getTranslation(cms::DDFilteredView& fv);
+  std::vector<double> getRotation(cms::DDFilteredView& fv);
 
 };
 #endif

--- a/Geometry/GEMGeometryBuilder/src/GEMGeometryParsFromDD.h
+++ b/Geometry/GEMGeometryBuilder/src/GEMGeometryParsFromDD.h
@@ -1,10 +1,12 @@
 #ifndef Geometry_GEMGeometry_GEMGeometryParsFromDD_H
 #define Geometry_GEMGeometry_GEMGeometryParsFromDD_H
 
-/** \class  GEMGeometryParsFromDD
- *  Build the GEMGeometry ftom the DDD description
- *
- *  \author M. Maggi - INFN Bari
+/* Implementation of the  GEMGeometryParsFromDD Class
+ *  Build the GEMGeometry from the DDD and DD4Hep description
+ *  
+ *  DD4hep part added to the original old file (DD version) made by M. Maggi (INFN Bari)
+ *  Author:  Sergio Lo Meo (sergio.lo.meo@cern.ch) 
+ *  Created:  Mon, 25 Jan 2021 
  *
  */
 
@@ -15,6 +17,10 @@
 
 class DDCompactView;
 class DDFilteredView;
+namespace cms {  // DD4Hep
+  class DDFilteredView;
+  class DDCompactView;
+}  // namespace cms
 class MuonGeometryConstants;
 class RecoIdealGeometry;
 class GEMDetId;
@@ -25,16 +31,23 @@ public:
 
   ~GEMGeometryParsFromDD();
 
+  // DD
   void build(const DDCompactView* cview, const MuonGeometryConstants& muonConstants, RecoIdealGeometry& rgeo);
+  // DD4Hep
+  void build(const cms::DDCompactView* cview, const MuonGeometryConstants& muonConstants, RecoIdealGeometry& rgeo);
 
 private:
+  // DD
   void buildGeometry(DDFilteredView& fview, const MuonGeometryConstants& muonConstants, RecoIdealGeometry& rgeo);
-
   void buildSuperChamber(DDFilteredView& fv, GEMDetId detId, RecoIdealGeometry& rgeo);
   void buildChamber(DDFilteredView& fv, GEMDetId detId, RecoIdealGeometry& rgeo);
   void buildEtaPartition(DDFilteredView& fv, GEMDetId detId, RecoIdealGeometry& rgeo);
 
   std::vector<double> getTranslation(DDFilteredView& fv);
   std::vector<double> getRotation(DDFilteredView& fv);
+
+  // DD4Hep
+
+
 };
 #endif


### PR DESCRIPTION
**PR description:**

This PR (only for GEM) followed what I did for DT in the PR #32781 (to be signed and merged)  . 

**PR validation:**

1) Validation by using "cmsRun CondTools/Geometry/test/gemgeometrywriter.py" (with DDD and DD4hep):
by checking printouts for both DD & DD4Hep build methods within the GEMGeometryParsFromDD Class in order to compare some DetId parameters (see below):

//DDD

(0) GEMGeometryParsFromDD - DDD 
(1) DDD, tran vector 1877.54  331.06  5695.5
(4) DDD, Chamber DetID 687898914 Name GEMBox11L dx1 141.087 dx2 254.993 dy 641.5 dz 17.35
(1) DDD, tran vector 2377.3  419.183  5692.09
(5) DDD, Eta Partion DetID 688423202 Name GHA101 dx1 205.701 dx2 222.929 dy 97.025 dz 1.4875 nStrips 384 nPads 192 dPhi 0.177151

and so on...

//DD4Hep 

(0) GEMGeometryParsFromDD - DD4HEP 
(1) DD4HEP, tran vector 1877.54  331.06  5695.5
(4) DD4HEP, Chamber DetID 687898914 Name GEMBox11L dx1 141.087 dx2 254.993 dy 641.5 dz 17.35
(1) DD4HEP, tran vector 2377.3  419.183  5692.09
(5) DD4HEP, Eta Partion DetID 688423202 Name GHA101 dx1 205.701 dx2 222.929 dy 97.025 dz 1.4875 nStrips 384 nPads 192 dPhi 0.177151

and so on..

The DD part of the code has not been touched by this PR (except for the printouts). Added "/ dd4hep::mm;", where it was necessary, in the DD4Hep part of the code.

2) Validation by using a dump script, not included in this PR (because it uses a local .mb file). 
Details are present in [*] at the end of this PR description.

// DDD

GEMGeometryESModule::produce :: GEMGeometryBuilder builder db
GEMGeometry found with 2 regions

Region 0:-1 with 1 staions

Station 0:1:GE-1/1 with 1 rings

Ring 0:1 with 36 superChambers

SuperChamber 0: Re -1 Ri 1 St 1 La 0 Ch 35 Ro 0  with 2 chambers

Chamber 0: Re -1 Ri 1 St 1 La 1 Ch 35 Ro 0  with 8 etaPartitions

EtaPartition 0: Re -1 Ri 1 St 1 La 1 Ch 35 Ro 1 GHA111 with 384 strips of pitch 0.10517 and 192 pads of pitch 0.21034

EtaPartition 1: Re -1 Ri 1 St 1 La 1 Ch 35 Ro 2 GHA112 with 384 strips of pitch 0.0974638 and 192 pads of pitch 0.194927

EtaPartition 2: Re -1 Ri 1 St 1 La 1 Ch 35 Ro 3 GHA113 with 384 strips of pitch 0.0903565 and 192 pads of pitch 0.180713

EtaPartition 3: Re -1 Ri 1 St 1 La 1 Ch 35 Ro 4 GHA114 with 384 strips of pitch 0.0838485 and 192 pads of pitch 0.167697

EtaPartition 4: Re -1 Ri 1 St 1 La 1 Ch 35 Ro 5 GHA115 with 384 strips of pitch 0.077825 and 192 pads of pitch 0.15565

EtaPartition 5: Re -1 Ri 1 St 1 La 1 Ch 35 Ro 6 GHA116 with 384 strips of pitch 0.0722858 and 192 pads of pitch 0.144572

EtaPartition 6: Re -1 Ri 1 St 1 La 1 Ch 35 Ro 7 GHA117 with 384 strips of pitch 0.0671505 and 192 pads of pitch 0.134301

EtaPartition 7: Re -1 Ri 1 St 1 La 1 Ch 35 Ro 8 GHA118 with 384 strips of pitch 0.0624191 and 192 pads of pitch 0.124838

and so on

// DD4Hep

GEMGeometryESModule::produce :: GEMGeometryBuilder builder db
GEMGeometry found with 2 regions

Region 0:-1 with 1 staions

Station 0:1:GE-1/1 with 1 rings

Ring 0:1 with 36 superChambers

SuperChamber 0: Re -1 Ri 1 St 1 La 0 Ch 35 Ro 0  with 2 chambers

Chamber 0: Re -1 Ri 1 St 1 La 1 Ch 35 Ro 0  with 8 etaPartitions

EtaPartition 0: Re -1 Ri 1 St 1 La 1 Ch 35 Ro 1 GHA111 with 384 strips of pitch 0.10517 and 192 pads of pitch 0.21034

EtaPartition 1: Re -1 Ri 1 St 1 La 1 Ch 35 Ro 2 GHA112 with 384 strips of pitch 0.0974638 and 192 pads of pitch 0.194927

EtaPartition 2: Re -1 Ri 1 St 1 La 1 Ch 35 Ro 3 GHA113 with 384 strips of pitch 0.0903565 and 192 pads of pitch 0.180713

EtaPartition 3: Re -1 Ri 1 St 1 La 1 Ch 35 Ro 4 GHA114 with 384 strips of pitch 0.0838485 and 192 pads of pitch 0.167697

EtaPartition 4: Re -1 Ri 1 St 1 La 1 Ch 35 Ro 5 GHA115 with 384 strips of pitch 0.077825 and 192 pads of pitch 0.15565

EtaPartition 5: Re -1 Ri 1 St 1 La 1 Ch 35 Ro 6 GHA116 with 384 strips of pitch 0.0722858 and 192 pads of pitch 0.144572

EtaPartition 6: Re -1 Ri 1 St 1 La 1 Ch 35 Ro 7 GHA117 with 384 strips of pitch 0.0671505 and 192 pads of pitch 0.134301

EtaPartition 7: Re -1 Ri 1 St 1 La 1 Ch 35 Ro 8 GHA118 with 384 strips of pitch 0.0624191 and 192 pads of pitch 0.124838

and so on

The conclusion is that the validation of the GEM DB Loader Migration to DD4Hep is fine.

**if this PR is a backport please specify the original PR and why you need to backport that PR:**

nothing special

[*]

In CMSSW_11_3_X_2021-02-21-0000 (for DDD) and CMSSW_11_3_X_2021-02-21-2300 (for DD4Hep)

a) In /condTools/Geom/test 
cp writehelp/* .

b) ./createExtended2021Payload.sh 113YV10 (for DDD and 113YV11 for DD4Hep)

Then I created a
script called "dumpGEMGeometry_DB_cfg.py" and the lines are:
+++++++
import FWCore.ParameterSet.Config as cms

process = cms.Process('DUMP')

process.load("CondCore.CondDB.CondDB_cfi")
process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
process.load('Geometry.MuonCommonData.testGE0XML_cfi')
process.load("FWCore.MessageLogger.MessageLogger_cfi")
process.load("Geometry.MuonNumbering.muonGeometryConstants_cff")
process.load("Geometry.GEMGeometryBuilder.gemGeometryDB_cfi")
process.load("Geometry.GEMGeometryBuilder.gemGeometryDump_cfi")

process.MessageLogger = cms.Service("MessageLogger",
    destinations = cms.untracked.vstring('myLogGEM'),
    myLogGEM = cms.untracked.PSet(
        threshold = cms.untracked.string('INFO'),
    )
)

process.muonGeometryConstants.fromDD4Hep = True

from Configuration.AlCa.autoCond import autoCond
process.GlobalTag.globaltag = autoCond['mc']
process.GlobalTag.toGet = cms.VPSet(cms.PSet(record = cms.string('GEMRecoGeometryRcd'),
tag = cms.string('GEMRECO_Geometry_113YV10'),
connect = cms.string("sqlite_file:/afs/cern.ch/user/s/slomeo/CMSSW_11_3_X_2021-02-21-0000/src/CondTools/Geometry/test/myfile.db")))

process.source = cms.Source('EmptySource')

process.maxEvents = cms.untracked.PSet(
    input = cms.untracked.int32(1)
)

process.p = cms.Path(process.gemGeometryDump)
++++++++++++

This script (not included in this PR) is located in https://cmssdt.cern.ch/lxr/source/Geometry/GEMGeometryBuilder/test/python/
and calls GEMGeometryDump Class (already present) by using "cmsRun dumpGEMGeometry_DB_cfg.py"