### PR TITLE
PR 11_2_X L1t uGT Bugfix to UPT and DXY cuts following February MWGR #32984

### DIFF
--- a/L1Trigger/L1TGlobal/interface/ConditionEvaluation.h
+++ b/L1Trigger/L1TGlobal/interface/ConditionEvaluation.h
@@ -91,6 +91,17 @@ namespace l1t {
                               const Type2& value,
                               bool condGEqValue) const;
 
+    /// check if a value is greater than a threshold or
+    /// greater-or-equal depending on the value of the condGEqValue flag
+    /// Added by Rick Cavanaugh for Displaced Muons:
+    ///       Above checkThreshold fails when value overflows or threshold window is invalid
+    ///       Below checkUnconstrainedPt allows value to overflow and only evaluates cut if threshold window is valid
+    template <class Type1, class Type2>
+    const bool checkUnconstrainedPt(const Type1& thresholdL,
+				    const Type1& thresholdH,
+				    const Type2& value,
+				    bool condGEqValue) const;
+
     /// check if a index is in a given range
     template <class Type1>
     const bool checkIndex(const Type1& indexLo, const Type1& indexHi, const unsigned int index) const;
@@ -182,6 +193,47 @@ namespace l1t {
 
       return false;
     }
+  }
+
+  // check if a value is greater than a threshold or
+  // greater-or-equal depending on the value of the condGEqValue flag
+  /// Added by Rick Cavanaugh for Displaced Muons:
+  ///       Above checkThreshold fails when value overflows or threshold window is invalid
+  ///       Below checkUnconstrainedPt allows value to overflow and only evaluates cut if threshold window is valid
+  template <class Type1, class Type2>
+  const bool ConditionEvaluation::checkUnconstrainedPt(const Type1& thresholdL,
+						       const Type1& thresholdH,
+						       const Type2& value,
+						       const bool condGEqValue) const 
+  {
+    if( value > 0 ) 
+      {
+	LogTrace("L1GlobalTrigger") << "  checkUnconstrainedPt check for condGEqValue = " << condGEqValue
+				    << "\n    hex: " << std::hex << "threshold = " << thresholdL << " - " << thresholdH
+				    << " value = " << value << "\n    dec: " << std::dec << "threshold = " << thresholdL
+				    << " - " << thresholdH << " value = " << value << std::endl;
+      }
+    if( thresholdH > 0 ) // Only evaluate cut if threshold window is valid
+      {
+	if( condGEqValue ) 
+	  {
+	    if( value >= (Type2)thresholdL && (Type1)value <= thresholdH ) 
+	      {
+		return true;
+	      }
+	    return false;
+	  } 
+	else 
+	  {
+	    if (value == (Type2)thresholdL) 
+	      {
+		return true;
+	      }	
+	    return false;
+	  }
+      }
+    else  // If invalid threshold window, do not evaluate cut (ie. pass through)
+      return true;
   }
 
   // check if a index in a given range

--- a/L1Trigger/L1TGlobal/interface/ConditionEvaluation.h
+++ b/L1Trigger/L1TGlobal/interface/ConditionEvaluation.h
@@ -98,9 +98,9 @@ namespace l1t {
     ///       Below checkUnconstrainedPt allows value to overflow and only evaluates cut if threshold window is valid
     template <class Type1, class Type2>
     const bool checkUnconstrainedPt(const Type1& thresholdL,
-				    const Type1& thresholdH,
-				    const Type2& value,
-				    bool condGEqValue) const;
+                                    const Type1& thresholdH,
+                                    const Type2& value,
+                                    bool condGEqValue) const;
 
     /// check if a index is in a given range
     template <class Type1>
@@ -202,37 +202,29 @@ namespace l1t {
   ///       Below checkUnconstrainedPt allows value to overflow and only evaluates cut if threshold window is valid
   template <class Type1, class Type2>
   const bool ConditionEvaluation::checkUnconstrainedPt(const Type1& thresholdL,
-						       const Type1& thresholdH,
-						       const Type2& value,
-						       const bool condGEqValue) const 
-  {
-    if( value > 0 ) 
-      {
-	LogTrace("L1GlobalTrigger") << "  checkUnconstrainedPt check for condGEqValue = " << condGEqValue
-				    << "\n    hex: " << std::hex << "threshold = " << thresholdL << " - " << thresholdH
-				    << " value = " << value << "\n    dec: " << std::dec << "threshold = " << thresholdL
-				    << " - " << thresholdH << " value = " << value << std::endl;
+                                                       const Type1& thresholdH,
+                                                       const Type2& value,
+                                                       const bool condGEqValue) const {
+    if (value > 0) {
+      LogTrace("L1GlobalTrigger") << "  checkUnconstrainedPt check for condGEqValue = " << condGEqValue
+                                  << "\n    hex: " << std::hex << "threshold = " << thresholdL << " - " << thresholdH
+                                  << " value = " << value << "\n    dec: " << std::dec << "threshold = " << thresholdL
+                                  << " - " << thresholdH << " value = " << value << std::endl;
+    }
+    if (thresholdH > 0)  // Only evaluate cut if threshold window is valid
+    {
+      if (condGEqValue) {
+        if (value >= (Type2)thresholdL && (Type1)value <= thresholdH) {
+          return true;
+        }
+        return false;
+      } else {
+        if (value == (Type2)thresholdL) {
+          return true;
+        }
+        return false;
       }
-    if( thresholdH > 0 ) // Only evaluate cut if threshold window is valid
-      {
-	if( condGEqValue ) 
-	  {
-	    if( value >= (Type2)thresholdL && (Type1)value <= thresholdH ) 
-	      {
-		return true;
-	      }
-	    return false;
-	  } 
-	else 
-	  {
-	    if (value == (Type2)thresholdL) 
-	      {
-		return true;
-	      }	
-	    return false;
-	  }
-      }
-    else  // If invalid threshold window, do not evaluate cut (ie. pass through)
+    } else  // If invalid threshold window, do not evaluate cut (ie. pass through)
       return true;
   }
 

--- a/L1Trigger/L1TGlobal/src/MuCondition.cc
+++ b/L1Trigger/L1TGlobal/src/MuCondition.cc
@@ -382,28 +382,33 @@ const bool l1t::MuCondition::checkObjectParameter(const int iCondition,
                         << "\n\t hwQual     = 0x " << cand.hwQual() << "\n\t hwIso      = 0x " << cand.hwIso()
                         << std::dec << std::endl;
 
-  if (objPar.unconstrainedPtHigh > 0)  // Check if unconstrained pT cut-window is valid
+  if( objPar.unconstrainedPtHigh > 0 )  // Check if unconstrained pT cut-window is valid
   {
-    if (!checkThreshold(objPar.unconstrainedPtLow,
-                        objPar.unconstrainedPtHigh,
-                        cand.hwPtUnconstrained(),
-                        m_gtMuonTemplate->condGEq())) {
-      LogDebug("L1TGlobal") << "\t\t Muon Failed unconstrainedPt checkThreshold; iCondition = " << iCondition
-                            << std::endl;
-      return false;
-    }
-    // check impact parameter ( bit check ) with impact parameter LUT
-    // sanity check on candidate impact parameter
-    if (cand.hwDXY() > 3) {
-      LogDebug("L1TGlobal") << "\t\t l1t::Candidate has out of range hwDXY = " << cand.hwDXY() << std::endl;
-      return false;
-    }
-    bool passImpactParameterLUT = ((objPar.impactParameterLUT >> cand.hwDXY()) & 1);
-    if (!passImpactParameterLUT)  // POTENITAL PROBLEM RICK
-    {
-      LogDebug("L1TGlobal") << "\t\t l1t::Candidate failed impact parameter requirement" << std::endl;
-      return false;
-    }
+      if( !checkUnconstrainedPt(objPar.unconstrainedPtLow,
+				objPar.unconstrainedPtHigh,
+				cand.hwPtUnconstrained(),
+				m_gtMuonTemplate->condGEq()) ) 
+	    {
+	      LogDebug("L1TGlobal") << "\t\t Muon Failed unconstrainedPt checkThreshold; iCondition = " << iCondition
+				<< std::endl;
+	      return false;
+	    }
+  }
+
+  if( objPar.impactParameterLUT != 0 ) // Check if impact parameter LUT is valid.  0xF is default; 0x0 is invalid
+  { 
+      // check impact parameter ( bit check ) with impact parameter LUT
+      // sanity check on candidate impact parameter
+      if (cand.hwDXY() > 3) {
+	      LogDebug("L1TGlobal") << "\t\t l1t::Candidate has out of range hwDXY = " << cand.hwDXY() << std::endl;
+	      return false;
+      }
+      bool passImpactParameterLUT = ((objPar.impactParameterLUT >> cand.hwDXY()) & 1);
+      if (!passImpactParameterLUT) 
+	    {
+	      LogDebug("L1TGlobal") << "\t\t l1t::Candidate failed impact parameter requirement" << std::endl;
+	      return false;
+	    }
   }
 
   if (!checkThreshold(objPar.ptLowThreshold, objPar.ptHighThreshold, cand.hwPt(), m_gtMuonTemplate->condGEq())) {

--- a/L1Trigger/L1TGlobal/src/MuCondition.cc
+++ b/L1Trigger/L1TGlobal/src/MuCondition.cc
@@ -382,33 +382,31 @@ const bool l1t::MuCondition::checkObjectParameter(const int iCondition,
                         << "\n\t hwQual     = 0x " << cand.hwQual() << "\n\t hwIso      = 0x " << cand.hwIso()
                         << std::dec << std::endl;
 
-  if( objPar.unconstrainedPtHigh > 0 )  // Check if unconstrained pT cut-window is valid
+  if (objPar.unconstrainedPtHigh > 0)  // Check if unconstrained pT cut-window is valid
   {
-      if( !checkUnconstrainedPt(objPar.unconstrainedPtLow,
-				objPar.unconstrainedPtHigh,
-				cand.hwPtUnconstrained(),
-				m_gtMuonTemplate->condGEq()) ) 
-	    {
-	      LogDebug("L1TGlobal") << "\t\t Muon Failed unconstrainedPt checkThreshold; iCondition = " << iCondition
-				<< std::endl;
-	      return false;
-	    }
+    if (!checkUnconstrainedPt(objPar.unconstrainedPtLow,
+                              objPar.unconstrainedPtHigh,
+                              cand.hwPtUnconstrained(),
+                              m_gtMuonTemplate->condGEq())) {
+      LogDebug("L1TGlobal") << "\t\t Muon Failed unconstrainedPt checkThreshold; iCondition = " << iCondition
+                            << std::endl;
+      return false;
+    }
   }
 
-  if( objPar.impactParameterLUT != 0 ) // Check if impact parameter LUT is valid.  0xF is default; 0x0 is invalid
-  { 
-      // check impact parameter ( bit check ) with impact parameter LUT
-      // sanity check on candidate impact parameter
-      if (cand.hwDXY() > 3) {
-	      LogDebug("L1TGlobal") << "\t\t l1t::Candidate has out of range hwDXY = " << cand.hwDXY() << std::endl;
-	      return false;
-      }
-      bool passImpactParameterLUT = ((objPar.impactParameterLUT >> cand.hwDXY()) & 1);
-      if (!passImpactParameterLUT) 
-	    {
-	      LogDebug("L1TGlobal") << "\t\t l1t::Candidate failed impact parameter requirement" << std::endl;
-	      return false;
-	    }
+  if (objPar.impactParameterLUT != 0)  // Check if impact parameter LUT is valid.  0xF is default; 0x0 is invalid
+  {
+    // check impact parameter ( bit check ) with impact parameter LUT
+    // sanity check on candidate impact parameter
+    if (cand.hwDXY() > 3) {
+      LogDebug("L1TGlobal") << "\t\t l1t::Candidate has out of range hwDXY = " << cand.hwDXY() << std::endl;
+      return false;
+    }
+    bool passImpactParameterLUT = ((objPar.impactParameterLUT >> cand.hwDXY()) & 1);
+    if (!passImpactParameterLUT) {
+      LogDebug("L1TGlobal") << "\t\t l1t::Candidate failed impact parameter requirement" << std::endl;
+      return false;
+    }
   }
 
   if (!checkThreshold(objPar.ptLowThreshold, objPar.ptHighThreshold, cand.hwPt(), m_gtMuonTemplate->condGEq())) {


### PR DESCRIPTION
#### PR description:

backport of https://github.com/cms-sw/cmssw/pull/32984

This PR is needed to fix a discrepancy in the uGT emulator of unconstrainedPt muon conditions that was observed during the 2021 February MWGR.

The following changes to code are listed in the cms-l1t-offline#890

#### PR validation:

<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

<!-- Please replace this text with any link to  -->

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
