### PR TITLE
add Phase2C11T22M9 and Phase2C11T23M9 to Eras.py

### DIFF
--- a/Configuration/StandardSequences/python/Eras.py
+++ b/Configuration/StandardSequences/python/Eras.py
@@ -47,6 +47,8 @@ class Eras (object):
                  'Phase2C11T23',
                  'Phase2C12_dd4hep',
                  'Phase2C11M9',
+                 'Phase2C11T22M9',
+                 'Phase2C11T23M9'
         ]
 
         internalUseMods = ['run2_common', 'run2_25ns_specific',


### PR DESCRIPTION
fixes https://github.com/cms-sw/cmssw/issues/32986

#### PR description:

Title says it all, missed in #32952

#### PR validation:

run successfully

```
runTheMatrix.py -l 35434.0, 35834.0 -j 0
```

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This is not a backport, no backport is needed.
