### PR TITLE
fix ipython and pylint unit tests

### DIFF
--- a/PhysicsTools/PythonAnalysis/test/BuildFile.xml
+++ b/PhysicsTools/PythonAnalysis/test/BuildFile.xml
@@ -157,5 +157,5 @@
 <test name="run-ipython2" command="ipython2 -h"/>
 <test name="run-ipython3" command="ipython3 -h"/>
 <test name="run-pylint" command="pylint -h"/>
-<test name="run-pylint2" command="pylint2 -h"/
+<test name="run-pylint2" command="pylint2 -h"/>
 <test name="run-pylint3" command="pylint3 -h"/>

--- a/PhysicsTools/PythonAnalysis/test/BuildFile.xml
+++ b/PhysicsTools/PythonAnalysis/test/BuildFile.xml
@@ -157,5 +157,4 @@
 <test name="run-ipython2" command="ipython2 -h"/>
 <test name="run-ipython3" command="ipython3 -h"/>
 <test name="run-pylint" command="pylint -h"/>
-<test name="run-pylint2" command="pylint2 -h"/>
 <test name="run-pylint3" command="pylint3 -h"/>

--- a/PhysicsTools/PythonAnalysis/test/BuildFile.xml
+++ b/PhysicsTools/PythonAnalysis/test/BuildFile.xml
@@ -153,7 +153,9 @@
 <test name="import-lxml" command="python -c 'import lxml'"/>
 <test name="import-bs4" command="python -c 'import bs4'"/>
 <test name="run-flawfinder" command="flawfinder -h"/>
-<test name="run-ipython" command="python2 $(shell which ipython) -h"/>
-<test name="run-ipython3" command="python3 $(shell which ipython3) -h"/>
-<test name="run-pylint" command="python2 $(shell which pylint) -h"/>
-<test name="run-pylint3" command="python3 $(shell which pylint3) -h"/>
+<test name="run-ipython" command="ipython -h"/>
+<test name="run-ipython2" command="ipython2 -h"/>
+<test name="run-ipython3" command="ipython3 -h"/>
+<test name="run-pylint" command="pylint -h"/>
+<test name="run-pylint2" command="pylint2 -h"/
+<test name="run-pylint3" command="pylint3 -h"/>


### PR DESCRIPTION
With new py3 version of ipython and pylint, the executables are bash scripts [a] which run itself under python. Running it with `python3 $(shell which ipython3) -h` works as in this case python3 correctly runs the tool but running it with ` ipython3 -h` fails due to relocation issues. https://github.com/cms-sw/cmsdist/pull/6673 should fix the relocation issue and we should be able to directly run `ipython3`.

[a]
```
#!/bin/sh
'''exec' /data/cmsbld/jenkins/workspace/auto-builds/CMSSW_11_3_0_pre3-slc7_amd64_gcc900/build/CMSSW_11_3_0_pre3-build/slc7_amd64_gcc900/external/python3/3.8.2-bcolbf/bin/python3 "$0" "$@"
' '''
# -*- coding: utf-8 -*-
import re
import sys
from IPython import start_ipython
if __name__ == '__main__':
    sys.argv[0] = re.sub(r'(-script\.pyw|\.exe)?$', '', sys.argv[0])
    sys.exit(start_ipython())
```