### PR TITLE
Update Migration to DD4Hep for CSC and RPC db Loader

### DIFF
--- a/CondTools/Geometry/test/writehelpers/geometryExtended2021_writer.py
+++ b/CondTools/Geometry/test/writehelpers/geometryExtended2021_writer.py
@@ -9,6 +9,8 @@ process.load('CondCore.CondDB.CondDB_cfi')
 # the reco part of the database need the DDCompactView.
 process.load('Configuration.Geometry.GeometryExtended2021_cff')
 process.load('Geometry.MuonNumbering.muonNumberingInitialization_cfi')
+process.load("Geometry.MuonNumbering.muonGeometryConstants_cff")
+process.load('Configuration.StandardSequences.DD4hep_GeometrySim_cff')
 process.load('Geometry.CaloEventSetup.CaloGeometryDBWriter_cfi')
 process.load('CondTools.Geometry.HcalParametersWriter_cff')
 
@@ -34,11 +36,11 @@ process.TrackerParametersWriter = cms.EDAnalyzer("PTrackerParametersDBBuilder",f
 
 process.CaloGeometryWriter = cms.EDAnalyzer("PCaloGeometryBuilder")
 
-process.CSCGeometryWriter = cms.EDAnalyzer("CSCRecoIdealDBLoader")
+process.CSCGeometryWriter = cms.EDAnalyzer("CSCRecoIdealDBLoader",fromDD4Hep = cms.untracked.bool(False))
 
 process.DTGeometryWriter = cms.EDAnalyzer("DTRecoIdealDBLoader")
 
-process.RPCGeometryWriter = cms.EDAnalyzer("RPCRecoIdealDBLoader")
+process.RPCGeometryWriter = cms.EDAnalyzer("RPCRecoIdealDBLoader",fromDD4Hep = cms.untracked.bool(False))
 
 process.GEMGeometryWriter = cms.EDAnalyzer("GEMRecoIdealDBLoader")
 

--- a/Geometry/CSCGeometryBuilder/plugins/CSCGeometryESModule.cc
+++ b/Geometry/CSCGeometryBuilder/plugins/CSCGeometryESModule.cc
@@ -205,6 +205,7 @@ std::shared_ptr<CSCGeometry> CSCGeometryESModule::produce(const MuonGeometryReco
 
 void CSCGeometryESModule::initCSCGeometry_(const MuonGeometryRecord& record, std::shared_ptr<HostType>& host) {
   if (fromDDD_) {
+    edm::LogVerbatim("CSCGeoemtryESModule") << "(0) CSCGeoemtryESModule  - DDD ";
     host->ifRecordChanges<IdealGeometryRecord>(record, [&host, &record, this](auto const& rec) {
       host->clear();
       edm::ESTransientHandle<DDCompactView> cpv = record.getTransientHandle(cpvToken_);
@@ -213,6 +214,7 @@ void CSCGeometryESModule::initCSCGeometry_(const MuonGeometryRecord& record, std
       builder.build(*host, cpv.product(), mdc);
     });
   } else if (fromDD4hep_) {
+    edm::LogVerbatim("CSCGeoemtryESModule") << "(0) CSCGeoemtryESModule  - DD4HEP ";
     host->ifRecordChanges<IdealGeometryRecord>(record, [&host, &record, this](auto const& rec) {
       host->clear();
       edm::ESTransientHandle<cms::DDCompactView> cpv = record.getTransientHandle(cpvTokendd4hep_);
@@ -228,8 +230,9 @@ void CSCGeometryESModule::initCSCGeometry_(const MuonGeometryRecord& record, std
 
     host->ifRecordChanges<CSCRecoDigiParametersRcd>(record,
                                                     [&recreateGeometry](auto const& rec) { recreateGeometry = true; });
-
+    edm::LogVerbatim("CSCGeoemtryESModule") << "(0) CSCGeoemtryESModule  - DB recreateGeometry=false ";
     if (recreateGeometry) {
+      edm::LogVerbatim("CSCGeoemtryESModule") << "(0) CSCGeoemtryESModule  - DB recreateGeometry=true ";
       host->clear();
       const auto& rig = record.get(rigToken_);
       const auto& rdp = record.get(rdpToken_);

--- a/Geometry/CSCGeometryBuilder/plugins/CSCGeometryESModule.cc
+++ b/Geometry/CSCGeometryBuilder/plugins/CSCGeometryESModule.cc
@@ -205,7 +205,7 @@ std::shared_ptr<CSCGeometry> CSCGeometryESModule::produce(const MuonGeometryReco
 
 void CSCGeometryESModule::initCSCGeometry_(const MuonGeometryRecord& record, std::shared_ptr<HostType>& host) {
   if (fromDDD_) {
-    edm::LogVerbatim("CSCGeoemtryESModule") << "(0) CSCGeoemtryESModule  - DDD ";
+    edm::LogVerbatim("CSCGeoemtryESModule") << "(0) CSCGeometryESModule  - DDD ";
     host->ifRecordChanges<IdealGeometryRecord>(record, [&host, &record, this](auto const& rec) {
       host->clear();
       edm::ESTransientHandle<DDCompactView> cpv = record.getTransientHandle(cpvToken_);
@@ -214,7 +214,7 @@ void CSCGeometryESModule::initCSCGeometry_(const MuonGeometryRecord& record, std
       builder.build(*host, cpv.product(), mdc);
     });
   } else if (fromDD4hep_) {
-    edm::LogVerbatim("CSCGeoemtryESModule") << "(0) CSCGeoemtryESModule  - DD4HEP ";
+    edm::LogVerbatim("CSCGeoemtryESModule") << "(0) CSCGeometryESModule  - DD4HEP ";
     host->ifRecordChanges<IdealGeometryRecord>(record, [&host, &record, this](auto const& rec) {
       host->clear();
       edm::ESTransientHandle<cms::DDCompactView> cpv = record.getTransientHandle(cpvTokendd4hep_);
@@ -230,9 +230,9 @@ void CSCGeometryESModule::initCSCGeometry_(const MuonGeometryRecord& record, std
 
     host->ifRecordChanges<CSCRecoDigiParametersRcd>(record,
                                                     [&recreateGeometry](auto const& rec) { recreateGeometry = true; });
-    edm::LogVerbatim("CSCGeoemtryESModule") << "(0) CSCGeoemtryESModule  - DB recreateGeometry=false ";
+    edm::LogVerbatim("CSCGeoemtryESModule") << "(0) CSCGeometryESModule  - DB recreateGeometry=false ";
     if (recreateGeometry) {
-      edm::LogVerbatim("CSCGeoemtryESModule") << "(0) CSCGeoemtryESModule  - DB recreateGeometry=true ";
+      edm::LogVerbatim("CSCGeoemtryESModule") << "(0) CSCGeometryESModule  - DB recreateGeometry=true ";
       host->clear();
       const auto& rig = record.get(rigToken_);
       const auto& rdp = record.get(rdpToken_);

--- a/Geometry/RPCGeometryBuilder/plugins/RPCGeometryESModule.cc
+++ b/Geometry/RPCGeometryBuilder/plugins/RPCGeometryESModule.cc
@@ -74,19 +74,19 @@ void RPCGeometryESModule::fillDescriptions(edm::ConfigurationDescriptions& descr
 
 std::unique_ptr<RPCGeometry> RPCGeometryESModule::produce(const MuonGeometryRecord& record) {
   if (fromDDD_) {
-    edm::LogVerbatim("RPCGeoemtryESModule") << "(0) RPCGeoemtryESModule  - DDD ";
+    edm::LogVerbatim("RPCGeoemtryESModule") << "(0) RPCGeometryESModule  - DDD ";
     edm::ESTransientHandle<DDCompactView> cpv = record.getTransientHandle(idealGeomToken_);
     auto const& mdc = record.get(dddConstantsToken_);
     RPCGeometryBuilder builder;
     return std::unique_ptr<RPCGeometry>(builder.build(&(*cpv), mdc));
   } else if (fromDD4hep_) {
-    edm::LogVerbatim("RPCGeoemtryESModule") << "(0) RPCGeoemtryESModule  - DD4HEP ";
+    edm::LogVerbatim("RPCGeoemtryESModule") << "(0) RPCGeometryESModule  - DD4HEP ";
     edm::ESTransientHandle<cms::DDCompactView> cpv = record.getTransientHandle(idealDD4hepGeomToken_);
     auto const& mdc = record.get(dddConstantsToken_);
     RPCGeometryBuilder builder;
     return std::unique_ptr<RPCGeometry>(builder.build(&(*cpv), mdc));
   } else {
-    edm::LogVerbatim("RPCGeoemtryESModule") << "(0) RPCGeoemtryESModule  - DB ";
+    edm::LogVerbatim("RPCGeoemtryESModule") << "(0) RPCGeometryESModule  - DB ";
     auto const& rigrpc = record.get(recoIdealToken_);
     RPCGeometryBuilderFromCondDB builder;
     return std::unique_ptr<RPCGeometry>(builder.build(rigrpc));

--- a/Geometry/RPCGeometryBuilder/plugins/RPCGeometryESModule.cc
+++ b/Geometry/RPCGeometryBuilder/plugins/RPCGeometryESModule.cc
@@ -74,16 +74,19 @@ void RPCGeometryESModule::fillDescriptions(edm::ConfigurationDescriptions& descr
 
 std::unique_ptr<RPCGeometry> RPCGeometryESModule::produce(const MuonGeometryRecord& record) {
   if (fromDDD_) {
+    edm::LogVerbatim("RPCGeoemtryESModule") << "(0) RPCGeoemtryESModule  - DDD ";
     edm::ESTransientHandle<DDCompactView> cpv = record.getTransientHandle(idealGeomToken_);
     auto const& mdc = record.get(dddConstantsToken_);
     RPCGeometryBuilder builder;
     return std::unique_ptr<RPCGeometry>(builder.build(&(*cpv), mdc));
   } else if (fromDD4hep_) {
+    edm::LogVerbatim("RPCGeoemtryESModule") << "(0) RPCGeoemtryESModule  - DD4HEP ";
     edm::ESTransientHandle<cms::DDCompactView> cpv = record.getTransientHandle(idealDD4hepGeomToken_);
     auto const& mdc = record.get(dddConstantsToken_);
     RPCGeometryBuilder builder;
     return std::unique_ptr<RPCGeometry>(builder.build(&(*cpv), mdc));
   } else {
+    edm::LogVerbatim("RPCGeoemtryESModule") << "(0) RPCGeoemtryESModule  - DB ";
     auto const& rigrpc = record.get(recoIdealToken_);
     RPCGeometryBuilderFromCondDB builder;
     return std::unique_ptr<RPCGeometry>(builder.build(rigrpc));


### PR DESCRIPTION
**PR description:**

This PR (only for CSC and RPC) is an update what I did in the PRs #32102 #32001. 

**PR validation:**

Validation by using a dump scripts (for DDD and DD4HEP) related to CSC and RPC, not included in this PR (because they use local .mb files). Details are present in [*] at the end of this PR description.

The command used is "cmsRun dumpCSCGeometry_DB_cfg.py" (the same for RPC).

// DDD (CSC)

(0) CSCGeometryESModule  - DB recreateGeometry=true 
CSCGeometry found with 612 chambers

Chamber 0:2:ME1/b: (E:1 S:1 R:1 C:1 L:0) with 6 layers 

Layer 0:CSC: (E:1 S:1 R:1 C:1 L:1)

Layer 1:CSC: (E:1 S:1 R:1 C:1 L:2)

Layer 2:CSC: (E:1 S:1 R:1 C:1 L:3)

Layer 3:CSC: (E:1 S:1 R:1 C:1 L:4)

Layer 4:CSC: (E:1 S:1 R:1 C:1 L:5)

Layer 5:CSC: (E:1 S:1 R:1 C:1 L:6)

and so on.

// DD4HEP (CSC)

(0) CSCGeometryESModule  - DB recreateGeometry=true 
CSCGeometry found with 612 chambers

Chamber 0:2:ME1/b: (E:1 S:1 R:1 C:1 L:0) with 6 layers 

Layer 0:CSC: (E:1 S:1 R:1 C:1 L:1)

Layer 1:CSC: (E:1 S:1 R:1 C:1 L:2)

Layer 2:CSC: (E:1 S:1 R:1 C:1 L:3)

Layer 3:CSC: (E:1 S:1 R:1 C:1 L:4)

Layer 4:CSC: (E:1 S:1 R:1 C:1 L:5)

Layer 5:CSC: (E:1 S:1 R:1 C:1 L:6)

and so on.

// DDD (RPC)

(0) RPCGeometryESModule  - DB 
RPCGeometry found with 1056 chambers

Chamber 0: Re -1 Ri 2 St 1 Se 1 La 1 Su 1 Ro 0 Tr 0  with 3 rolls

Roll 0: Re -1 Ri 2 St 1 Se 1 La 1 Su 1 Ro 1 Tr 0  Barrel|Endcap 0:1:0 with 32 of pitch 2.37878

Roll 1: Re -1 Ri 2 St 1 Se 1 La 1 Su 1 Ro 2 Tr 0  Barrel|Endcap 0:1:0 with 32 of pitch 2.09312

Roll 2: Re -1 Ri 2 St 1 Se 1 La 1 Su 1 Ro 3 Tr 0  Barrel|Endcap 0:1:0 with 32 of pitch 1.73672

and so on.

// DD4Hep (RPC)

(0) RPCGeometryESModule  - DB 
RPCGeometry found with 1056 chambers

Chamber 0: Re -1 Ri 2 St 1 Se 1 La 1 Su 1 Ro 0 Tr 0  with 3 rolls

Roll 0: Re -1 Ri 2 St 1 Se 1 La 1 Su 1 Ro 1 Tr 0  Barrel|Endcap 0:1:0 with 32 of pitch 2.37878

Roll 1: Re -1 Ri 2 St 1 Se 1 La 1 Su 1 Ro 2 Tr 0  Barrel|Endcap 0:1:0 with 32 of pitch 2.09312

Roll 2: Re -1 Ri 2 St 1 Se 1 La 1 Su 1 Ro 3 Tr 0  Barrel|Endcap 0:1:0 with 32 of pitch 1.73672

and so on.

**if this PR is a backport please specify the original PR and why you need to backport that PR:**

nothing special

[*]

In CMSSW_11_3_X_2021-02-15-1100 (for DDD) and CMSSW_11_3_X_2021-02-15-2300 (for DD4Hep)

a) In /condTools/Geom/test 
cp writehelp/* .

b) ./createExtended2021Payload.sh 113YV8 (for DDD and 113YV9 for DD4Hep)

Then I created a
script called "dumpCSCGeometry_DB_cfg.py" (the same for RPC) and the lines are:
+++++++
import FWCore.ParameterSet.Config as cms

process = cms.Process('DUMP')

process.load("CondCore.CondDB.CondDB_cfi")
process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
process.load("FWCore.MessageLogger.MessageLogger_cfi")
process.load("Geometry.MuonNumbering.muonGeometryConstants_cff")
process.load("Geometry.CSCGeometryBuilder.cscGeometryDB_cfi")
process.load("Geometry.CSCGeometryBuilder.cscGeometryDump_cfi")

process.MessageLogger = cms.Service("MessageLogger",
    destinations = cms.untracked.vstring('myLogCSC'),
    myLogCSC = cms.untracked.PSet(
        threshold = cms.untracked.string('INFO'),
    )
)

process.muonGeometryConstants.fromDD4Hep = True
process.CSCGeometryESModule.applyAlignment = False 

from Configuration.AlCa.autoCond import autoCond
process.GlobalTag.globaltag = autoCond['mc']
process.GlobalTag.toGet = cms.VPSet(cms.PSet(record = cms.string('CSCRecoGeometryRcd'),
tag = cms.string('CSCRECO_Geometry_113YV9'),
connect = cms.string("sqlite_file:/afs/cern.ch/user/s/slomeo/CMSSW_11_3_X_2021-02-15-1100/src/CondTools/Geometry/test/myfile.db")))

process.source = cms.Source('EmptySource')

process.maxEvents = cms.untracked.PSet(
    input = cms.untracked.int32(1)
)

process.p = cms.Path(process.gemGeometryDump)
++++++++++++
