### PR TITLE
Improve the execution speed of the DA clusterizers for primary vertex finding

### DIFF
--- a/Alignment/OfflineValidation/plugins/PrimaryVertexValidation.cc
+++ b/Alignment/OfflineValidation/plugins/PrimaryVertexValidation.cc
@@ -3746,6 +3746,7 @@ void PrimaryVertexValidation::fillDescriptions(edm::ConfigurationDescriptions& d
       psd1.add<double>("coolingFactor", 0.6);
       psd1.add<double>("vertexSize", 0.006);
       psd1.add<double>("uniquetrkweight", 0.8);
+      psd1.add<double>("uniquetrkminp", 0.0);
       psd1.add<double>("zrange", 4.0);
       psd1.add<double>("tmerge", 0.01);           // 4D only
       psd1.add<double>("dtCutOff", 4.);           // 4D only

--- a/RecoVertex/PrimaryVertexProducer/interface/DAClusterizerInZT_vect.h
+++ b/RecoVertex/PrimaryVertexProducer/interface/DAClusterizerInZT_vect.h
@@ -35,6 +35,8 @@ public:
     std::vector<unsigned int> kmax;                // 1 + index of the last cluster within zrange
     std::vector<const reco::TransientTrack *> tt;  // a pointer to the Transient Track
 
+    double osumtkwt;  // 1. / (sum of all track weights)
+
     void addItem(double new_zpca,
                  double new_tpca,
                  double new_dz2,
@@ -302,6 +304,7 @@ private:
 
   double mintrkweight_;
   double uniquetrkweight_;
+  double uniquetrkminp_;
   double zmerge_;
   double tmerge_;
   double betapurge_;

--- a/RecoVertex/PrimaryVertexProducer/interface/DAClusterizerInZ_vect.h
+++ b/RecoVertex/PrimaryVertexProducer/interface/DAClusterizerInZ_vect.h
@@ -29,6 +29,8 @@ public:
     std::vector<unsigned int> kmax;                // 1 + index of the last cluster within zrange
     std::vector<const reco::TransientTrack *> tt;  // a pointer to the Transient Track
 
+    double osumtkwt;  // 1. / (sum of all track weights)
+
     void addItemSorted(double new_zpca, double new_dz2, const reco::TransientTrack *new_tt, double new_tkwt) {
       // sort tracks with decreasing resolution (note that dz2 = 1/sigma^2)
       unsigned int i = 0;
@@ -206,6 +208,7 @@ private:
 
   double mintrkweight_;
   double uniquetrkweight_;
+  double uniquetrkminp_;
   double zmerge_;
   double betapurge_;
 

--- a/RecoVertex/PrimaryVertexProducer/plugins/PrimaryVertexProducer.cc
+++ b/RecoVertex/PrimaryVertexProducer/plugins/PrimaryVertexProducer.cc
@@ -32,8 +32,7 @@ PrimaryVertexProducer::PrimaryVertexProducer(const edm::ParameterSet& conf) : th
   } else if (trackSelectionAlgorithm == "filterWithThreshold") {
     theTrackFilter = new HITrackFilterForPVFinding(conf.getParameter<edm::ParameterSet>("TkFilterParameters"));
   } else {
-    throw VertexException("PrimaryVertexProducer: unknown track selection algorithm: " +
-                          trackSelectionAlgorithm);
+    throw VertexException("PrimaryVertexProducer: unknown track selection algorithm: " + trackSelectionAlgorithm);
   }
 
   // select and configure the track clusterizer

--- a/RecoVertex/PrimaryVertexProducer/plugins/PrimaryVertexProducer.cc
+++ b/RecoVertex/PrimaryVertexProducer/plugins/PrimaryVertexProducer.cc
@@ -32,7 +32,7 @@ PrimaryVertexProducer::PrimaryVertexProducer(const edm::ParameterSet& conf) : th
   } else if (trackSelectionAlgorithm == "filterWithThreshold") {
     theTrackFilter = new HITrackFilterForPVFinding(conf.getParameter<edm::ParameterSet>("TkFilterParameters"));
   } else {
-    throw VertexException("PrimaryVertexProducerAlgorithm: unknown track selection algorithm: " +
+    throw VertexException("PrimaryVertexProducer: unknown track selection algorithm: " +
                           trackSelectionAlgorithm);
   }
 
@@ -57,7 +57,7 @@ PrimaryVertexProducer::PrimaryVertexProducer(const edm::ParameterSet& conf) : th
   }
 
   else {
-    throw VertexException("PrimaryVertexProducerAlgorithm: unknown clustering algorithm: " + clusteringAlgorithm);
+    throw VertexException("PrimaryVertexProducer: unknown clustering algorithm: " + clusteringAlgorithm);
   }
 
   if (f4D) {
@@ -80,7 +80,7 @@ PrimaryVertexProducer::PrimaryVertexProducer(const edm::ParameterSet& conf) : th
       } else if (fitterAlgorithm == "AdaptiveVertexFitter") {
         algorithm.fitter = new AdaptiveVertexFitter(GeometricAnnealing(algoconf->getParameter<double>("chi2cutoff")));
       } else {
-        throw VertexException("PrimaryVertexProducerAlgorithm: unknown algorithm: " + fitterAlgorithm);
+        throw VertexException("PrimaryVertexProducer: unknown algorithm: " + fitterAlgorithm);
       }
       algorithm.label = algoconf->getParameter<std::string>("label");
       algorithm.minNdof = algoconf->getParameter<double>("minNdof");
@@ -120,10 +120,10 @@ PrimaryVertexProducer::PrimaryVertexProducer(const edm::ParameterSet& conf) : th
   fRecoveryIteration = conf.getParameter<bool>("isRecoveryIteration");
   if (fRecoveryIteration) {
     if (algorithms.empty()) {
-      throw VertexException("PrimaryVertexProducerAlgorithm: No algorithm specified. ");
+      throw VertexException("PrimaryVertexProducer: No algorithm specified. ");
     } else if (algorithms.size() > 1) {
       throw VertexException(
-          "PrimaryVertexProducerAlgorithm: Running in Recovery mode and more than one algorithm specified.  Please "
+          "PrimaryVertexProducer: Running in Recovery mode and more than one algorithm specified.  Please "
           "only one algorithm.");
     }
     recoveryVtxToken = consumes<reco::VertexCollection>(conf.getParameter<edm::InputTag>("recoveryVtxCollection"));
@@ -144,7 +144,7 @@ PrimaryVertexProducer::~PrimaryVertexProducer() {
 }
 
 void PrimaryVertexProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
-  // get the BeamSpot, it will alwys be needed, even when not used as a constraint
+  // get the BeamSpot, it will always be needed, even when not used as a constraint
   reco::BeamSpot beamSpot;
   edm::Handle<reco::BeamSpot> recoBeamSpotHandle;
   iEvent.getByToken(bsToken, recoBeamSpotHandle);
@@ -251,8 +251,10 @@ void PrimaryVertexProducer::produce(edm::Event& iEvent, const edm::EventSetup& i
         if (f4D) {
           if (v.isValid()) {
             auto err = v.positionError().matrix4D();
+            auto trkweightMap3d = v.weightMap();  // copy the 3 fit weights
             err(3, 3) = vartime;
             v = TransientVertex(v.position(), meantime, err, v.originalTracks(), v.totalChiSquared());
+            v.weightMap(trkweightMap3d);
           }
         }
 
@@ -427,6 +429,7 @@ void PrimaryVertexProducer::fillDescriptions(edm::ConfigurationDescriptions& des
       psd1.add<double>("coolingFactor", 0.6);
       psd1.add<double>("vertexSize", 0.006);
       psd1.add<double>("uniquetrkweight", 0.8);
+      psd1.add<double>("uniquetrkminp", 0.0);
       psd1.add<double>("zrange", 4.0);
 
       psd1.add<double>("tmerge", 0.01);           // 4D only

--- a/RecoVertex/PrimaryVertexProducer/python/TkClusParameters_cff.py
+++ b/RecoVertex/PrimaryVertexProducer/python/TkClusParameters_cff.py
@@ -54,6 +54,7 @@ DA2D_vectParameters = cms.PSet(
         t0Max = cms.double(1.0),          # outlier rejection for use of timing information
         zmerge = cms.double(1e-2),        # merge intermediat clusters separated by less than zmerge and tmerge
         tmerge = cms.double(1e-1),        # merge intermediat clusters separated by less than zmerge and tmerge
-        uniquetrkweight = cms.double(0.8) # require at least two tracks with this weight at T=Tpurge
+        uniquetrkweight = cms.double(0.8),# require at least two tracks with this weight at T=Tpurge
+        uniquetrkminp = cms.double(0.0)   # minimal a priori track weight for counting unique tracks
         )
 )

--- a/RecoVertex/PrimaryVertexProducer/python/TkClusParameters_cff.py
+++ b/RecoVertex/PrimaryVertexProducer/python/TkClusParameters_cff.py
@@ -15,7 +15,8 @@ DA_vectParameters = cms.PSet(
         d0CutOff = cms.double(3.),        # downweight high IP tracks 
         dzCutOff = cms.double(3.),        # outlier rejection after freeze-out (T<Tmin)       
         zmerge = cms.double(1e-2),        # merge intermediat clusters separated by less than zmerge
-        uniquetrkweight = cms.double(0.8) # require at least two tracks with this weight at T=Tpurge
+        uniquetrkweight = cms.double(0.8),# require at least two tracks with this weight at T=Tpurge
+        uniquetrkminp = cms.double(0.0)   # minimal a priori track weight for counting unique tracks
         )
 )
 

--- a/RecoVertex/PrimaryVertexProducer/src/DAClusterizerInZT_vect.cc
+++ b/RecoVertex/PrimaryVertexProducer/src/DAClusterizerInZT_vect.cc
@@ -462,8 +462,8 @@ double DAClusterizerInZT_vect::update(
 
   // loop over tracks
   for (auto itrack = 0U; itrack < nt; ++itrack) {
-    unsigned int kmin = gtracks.kmin[itrack];
-    unsigned int kmax = gtracks.kmax[itrack];
+    const unsigned int kmin = gtracks.kmin[itrack];
+    const unsigned int kmax = gtracks.kmax[itrack];
 
 #ifdef DEBUG
     assert((kmin < kmax) && (kmax <= nv));

--- a/RecoVertex/PrimaryVertexProducer/src/DAClusterizerInZT_vect.cc
+++ b/RecoVertex/PrimaryVertexProducer/src/DAClusterizerInZT_vect.cc
@@ -40,6 +40,7 @@ DAClusterizerInZT_vect::DAClusterizerInZT_vect(const edm::ParameterSet& conf) {
   dtCutOff_ = conf.getParameter<double>("dtCutOff");
   t0Max_ = conf.getParameter<double>("t0Max");
   uniquetrkweight_ = conf.getParameter<double>("uniquetrkweight");
+  uniquetrkminp_ = conf.getParameter<double>("uniquetrkminp");
   zmerge_ = conf.getParameter<double>("zmerge");
   tmerge_ = conf.getParameter<double>("tmerge");
   sel_zrange_ = conf.getParameter<double>("zrange");
@@ -50,6 +51,7 @@ DAClusterizerInZT_vect::DAClusterizerInZT_vect(const edm::ParameterSet& conf) {
 #ifdef DEBUG
   std::cout << "DAClusterizerInZT_vect: mintrkweight = " << mintrkweight_ << std::endl;
   std::cout << "DAClusterizerInZT_vect: uniquetrkweight = " << uniquetrkweight_ << std::endl;
+  std::cout << "DAClusterizerInZT_vect: uniquetrkminp = " << uniquetrkminp_ << std::endl;
   std::cout << "DAClusterizerInZT_vect: zmerge = " << zmerge_ << std::endl;
   std::cout << "DAClusterizerInZT_vect: tmerge = " << tmerge_ << std::endl;
   std::cout << "DAClusterizerInZT_vect: Tmin = " << minT << std::endl;
@@ -208,6 +210,8 @@ void DAClusterizerInZT_vect::verify(const vertex_t& v, const track_t& tks, unsig
 DAClusterizerInZT_vect::track_t DAClusterizerInZT_vect::fill(const vector<reco::TransientTrack>& tracks) const {
   // prepare track data for clustering
   track_t tks;
+  double sumtkwt = 0.;
+
   for (const auto& tk : tracks) {
     if (!tk.isValid())
       continue;
@@ -259,8 +263,12 @@ DAClusterizerInZT_vect::track_t DAClusterizerInZT_vect::fill(const vector<reco::
     }
 
     tks.addItem(t_z, t_t, t_dz2, t_dt2, &tk, t_tkwt);
+    sumtkwt += t_tkwt;
   }
+
   tks.extractRaw();
+  tks.osumtkwt = sumtkwt > 0 ? 1. / sumtkwt : 0.;
+
 #ifdef DEBUG
   if (DEBUGLEVEL > 0) {
     std::cout << "Track count (ZT) filled " << tks.getSize() << " initial " << tracks.size() << std::endl;
@@ -350,16 +358,9 @@ double DAClusterizerInZT_vect::update(
 
   const unsigned int nt = gtracks.getSize();
   const unsigned int nv = gvertices.getSize();
+  auto osumtkwt = gtracks.osumtkwt;
 
-  //initialize sums
-  double sumtkwt = 0.;
-
-  // to return how much the prototype moved
-  double delta = 0.;
-
-  // intial value of a sum
   double Z_init = 0;
-  // independpent of loop
   if (rho0 > 0) {
     Z_init = rho0 * local_exp(-beta * dzCutOff_ * dzCutOff_);  // cut-off
   }
@@ -476,12 +477,10 @@ double DAClusterizerInZT_vect::update(
 
     kernel_calc_exp_arg_range(itrack, gtracks, gvertices, kmin, kmax);
     local_exp_list_range(gvertices.exp_arg, gvertices.exp, kmin, kmax);
-
     gtracks.sum_Z[itrack] = kernel_add_Z_range(gvertices, kmin, kmax);
+
     if (edm::isNotFinite(gtracks.sum_Z[itrack]))
       gtracks.sum_Z[itrack] = 0.0;
-    // used in the next major loop to follow
-    sumtkwt += gtracks.tkwt[itrack];
 
     if (gtracks.sum_Z[itrack] > 1.e-100) {
       kernel_calc_normalization_range(itrack, gtracks, gvertices, kmin, kmax);
@@ -489,7 +488,7 @@ double DAClusterizerInZT_vect::update(
   }
 
   // now update z, t, and rho
-  auto kernel_calc_zt = [sumtkwt, nv](vertex_t& vertices) -> double {
+  auto kernel_calc_zt = [osumtkwt, nv](vertex_t& vertices) -> double {
     double delta = 0;
 
     // does not vectorize
@@ -529,7 +528,6 @@ double DAClusterizerInZT_vect::update(
 #endif
     }
 
-    auto osumtkwt = 1. / sumtkwt;
     for (unsigned int ivertex = 0; ivertex < nv; ++ivertex) {
       vertices.rho[ivertex] = vertices.rho[ivertex] * vertices.se[ivertex] * osumtkwt;
     }
@@ -537,7 +535,7 @@ double DAClusterizerInZT_vect::update(
     return delta;
   };
 
-  delta += kernel_calc_zt(gvertices);
+  double delta = kernel_calc_zt(gvertices);
 
   if (zorder(gvertices)) {
     set_vtx_range(beta, gtracks, gvertices);
@@ -758,53 +756,59 @@ bool DAClusterizerInZT_vect::purge(vertex_t& y, track_t& tks, double& rho0, cons
   if (nv < 2)
     return false;
 
-  double sumpmin = nt;
-  unsigned int k0 = nv;
-
-  int nUnique = 0;
-  double sump = 0;
-
-  std::vector<double> inverse_zsums(nt), arg_cache(nt), eik_cache(nt), pcut_cache(nt);
-  double* __restrict__ pinverse_zsums;
+  std::vector<double> sump_v(nv), arg_cache_v(nv), exp_cache_v(nv), pcut_cache_v(nv);
+  std::vector<int> nUnique_v(nv);
   double* __restrict__ parg_cache;
-  double* __restrict__ peik_cache;
+  double* __restrict__ pexp_cache;
   double* __restrict__ ppcut_cache;
-  pinverse_zsums = inverse_zsums.data();
-  parg_cache = arg_cache.data();
-  peik_cache = eik_cache.data();
-  ppcut_cache = pcut_cache.data();
-  for (unsigned i = 0; i < nt; ++i) {
-    inverse_zsums[i] = tks.sum_Z[i] > eps ? 1. / tks.sum_Z[i] : 0.0;
-  }
+  double* __restrict__ psump;
+  int* __restrict__ pnUnique;
+  int constexpr nunique_min_ = 2;
+
+  zorder(y);
+  set_vtx_range(beta, tks, y);
+
+  parg_cache = arg_cache_v.data();
+  pexp_cache = exp_cache_v.data();
+  ppcut_cache = pcut_cache_v.data();
+  psump = sump_v.data();
+  pnUnique = nUnique_v.data();
+
   const auto rhoconst = rho0 * local_exp(-beta * dzCutOff_ * dzCutOff_);
   for (unsigned int k = 0; k < nv; ++k) {
     const double pmax = y.rho[k] / (y.rho[k] + rhoconst);
     ppcut_cache[k] = uniquetrkweight_ * pmax;
   }
 
-  for (unsigned int k = 0; k < nv; ++k) {
-    for (unsigned i = 0; i < nt; ++i) {
-      const auto track_z = tks.zpca[i];
-      const auto track_t = tks.tpca[i];
-      const auto botrack_dz2 = -beta * tks.dz2[i];
-      const auto botrack_dt2 = -beta * tks.dt2[i];  // FIXME usevtxdt2?
+  for (unsigned int i = 0; i < nt; i++) {
+    const auto invZ = ((tks.sum_Z[i] > eps) && (tks.tkwt[i] > uniquetrkminp_)) ? 1. / tks.sum_Z[i] : 0.;
+    const auto track_z = tks.zpca[i];
+    const auto track_t = tks.tpca[i];
+    const auto botrack_dz2 = -beta * tks.dz2[i];
+    const auto botrack_dt2 = -beta * tks.dt2[i];
+    const auto kmin = tks.kmin[i];
+    const auto kmax = tks.kmax[i];
 
+    for (unsigned int k = kmin; k < kmax; k++) {
       const auto mult_resz = track_z - y.zvtx[k];
       const auto mult_rest = track_t - y.tvtx[k];
-      parg_cache[i] = botrack_dz2 * (mult_resz * mult_resz) + botrack_dt2 * (mult_rest * mult_rest);
-    }
-    local_exp_list(parg_cache, peik_cache, nt);
-
-    nUnique = 0;
-    sump = 0;
-    for (unsigned int i = 0; i < nt; ++i) {
-      const auto p = y.rho[k] * peik_cache[i] * pinverse_zsums[i];
-      sump += p;
-      nUnique += ((p > ppcut_cache[k]) & (tks.tkwt[i] > 0)) ? 1 : 0;
+      parg_cache[k] = botrack_dz2 * (mult_resz * mult_resz) + botrack_dt2 * (mult_rest * mult_rest);
     }
 
-    if ((nUnique < 2) && (sump < sumpmin)) {
-      sumpmin = sump;
+    local_exp_list_range(parg_cache, pexp_cache, kmin, kmax);
+
+    for (unsigned int k = kmin; k < kmax; k++) {
+      const double p = y.rho[k] * pexp_cache[k] * invZ;
+      psump[k] += p;
+      pnUnique[k] += (p > ppcut_cache[k]) ? 1 : 0;
+    }
+  }
+
+  double sumpmin = nt;
+  unsigned int k0 = nv;
+  for (unsigned k = 0; k < nv; k++) {
+    if ((pnUnique[k] < nunique_min_) && (psump[k] < sumpmin)) {
+      sumpmin = psump[k];
       k0 = k;
     }
   }
@@ -1103,6 +1107,7 @@ bool DAClusterizerInZT_vect::split(const double beta, track_t& tks, vertex_t& y,
 #endif
     }
   }
+
   return split;
 }
 
@@ -1254,7 +1259,7 @@ vector<TransientVertex> DAClusterizerInZT_vect::vertices(const vector<reco::Tran
   }
 #endif
 
-  // eliminate insigificant vertices, this is more restrictive at higher T
+  // eliminate insignificant vertices, this is more restrictive at higher T
   while (purge(y, tks, rho0, beta)) {
     thermalize(beta, tks, y, delta_lowT_, rho0);
     if (zorder(y)) {
@@ -1296,9 +1301,8 @@ vector<TransientVertex> DAClusterizerInZT_vect::vertices(const vector<reco::Tran
     ;
 
   // select significant tracks and use a TransientVertex as a container
-  GlobalError dummyError(0.01, 0, 0.01, 0., 0., 0.01);
-
-  // ensure correct normalization of probabilities, should makes double assignment reasonably impossible
+  zorder(y);
+  set_vtx_range(beta, tks, y);
   const unsigned int nv = y.getSize();
   for (unsigned int k = 0; k < nv; k++)
     if (edm::isNotFinite(y.rho[k]) || edm::isNotFinite(y.zvtx[k])) {
@@ -1307,33 +1311,44 @@ vector<TransientVertex> DAClusterizerInZT_vect::vertices(const vector<reco::Tran
     }
 
   const auto z_sum_init = rho0 * local_exp(-beta * dzCutOff_ * dzCutOff_);
-  for (unsigned int i = 0; i < nt; i++)  // initialize
+  std::vector<std::vector<unsigned int> > vtx_track_indices(nv);
+  for (unsigned int i = 0; i < nt; i++) {
+    const auto kmin = tks.kmin[i];
+    const auto kmax = tks.kmax[i];
+    for (auto k = kmin; k < kmax; k++) {
+      y.exp_arg[k] = -beta * Eik(tks.zpca[i], y.zvtx[k], tks.dz2[i], tks.tpca[i], y.tvtx[k], tks.dt2[i]);
+    }
+
+    local_exp_list_range(y.exp_arg, y.exp, kmin, kmax);
+
     tks.sum_Z[i] = z_sum_init;
+    for (auto k = kmin; k < kmax; k++) {
+      tks.sum_Z[i] += y.rho[k] * y.exp[k];
+    }
+    const double invZ = tks.sum_Z[i] > 1e-100 ? 1. / tks.sum_Z[i] : 0.0;
 
-  // improve vectorization (does not require reduction ....)
-  for (unsigned int k = 0; k < nv; k++) {
-    for (unsigned int i = 0; i < nt; i++)
-      tks.sum_Z[i] +=
-          y.rho[k] * local_exp(-beta * Eik(tks.zpca[i], y.zvtx[k], tks.dz2[i], tks.tpca[i], y.tvtx[k], tks.dt2[i]));
-  }
-
-  for (unsigned int k = 0; k < nv; k++) {
-    GlobalPoint pos(0, 0, y.zvtx[k]);
-
-    vector<reco::TransientTrack> vertexTracks;
-    for (unsigned int i = 0; i < nt; i++) {
-      if (tks.sum_Z[i] > 1e-100) {
-        double p = y.rho[k] *
-                   local_exp(-beta * Eik(tks.zpca[i], y.zvtx[k], tks.dz2[i], tks.tpca[i], y.tvtx[k], tks.dt2[i])) /
-                   tks.sum_Z[i];
-        if ((tks.tkwt[i] > 0) && (p > mintrkweight_)) {
-          vertexTracks.push_back(*(tks.tt[i]));
-          tks.sum_Z[i] = 0;  // setting Z=0 excludes double assignment
-        }
+    for (auto k = kmin; k < kmax; k++) {
+      double p = y.rho[k] * y.exp[k] * invZ;
+      if (p > mintrkweight_) {
+        // assign  track i -> vertex k (hard, mintrkweight_ should be >= 0.5 here
+        vtx_track_indices[k].push_back(i);
+        break;
       }
     }
-    TransientVertex v(pos, y.tvtx[k], dummyError, vertexTracks, 0);
-    clusters.push_back(v);
+
+  }  // track loop
+
+  GlobalError dummyError(0.01, 0, 0.01, 0., 0., 0.01);
+  for (unsigned int k = 0; k < nv; k++) {
+    if (!vtx_track_indices[k].empty()) {
+      GlobalPoint pos(0, 0, y.zvtx[k]);
+      vector<reco::TransientTrack> vertexTracks;
+      for (auto i : vtx_track_indices[k]) {
+        vertexTracks.push_back(*(tks.tt[i]));
+      }
+      TransientVertex v(pos, dummyError, vertexTracks, 0);
+      clusters.push_back(v);
+    }
   }
 
   return clusters;

--- a/RecoVertex/PrimaryVertexProducer/src/DAClusterizerInZT_vect.cc
+++ b/RecoVertex/PrimaryVertexProducer/src/DAClusterizerInZT_vect.cc
@@ -102,11 +102,6 @@ DAClusterizerInZT_vect::DAClusterizerInZT_vect(const edm::ParameterSet& conf) {
 namespace {
   inline double local_exp(double const& inp) { return vdt::fast_exp(inp); }
 
-  inline void local_exp_list(double const* __restrict__ arg_inp, double* __restrict__ arg_out, const int arg_arr_size) {
-    for (auto i = 0; i != arg_arr_size; ++i)
-      arg_out[i] = vdt::fast_exp(arg_inp[i]);
-  }
-
   inline void local_exp_list_range(double const* __restrict__ arg_inp,
                                    double* __restrict__ arg_out,
                                    const int kmin,

--- a/RecoVertex/PrimaryVertexProducer/src/DAClusterizerInZ_vect.cc
+++ b/RecoVertex/PrimaryVertexProducer/src/DAClusterizerInZ_vect.cc
@@ -95,11 +95,6 @@ DAClusterizerInZ_vect::DAClusterizerInZ_vect(const edm::ParameterSet& conf) {
 namespace {
   inline double local_exp(double const& inp) { return vdt::fast_exp(inp); }
 
-  inline void local_exp_list(double const* __restrict__ arg_inp, double* __restrict__ arg_out, const int arg_arr_size) {
-    for (auto i = 0; i != arg_arr_size; ++i)
-      arg_out[i] = vdt::fast_exp(arg_inp[i]);
-  }
-
   inline void local_exp_list_range(double const* __restrict__ arg_inp,
                                    double* __restrict__ arg_out,
                                    const int kmin,

--- a/RecoVertex/PrimaryVertexProducer/src/DAClusterizerInZ_vect.cc
+++ b/RecoVertex/PrimaryVertexProducer/src/DAClusterizerInZ_vect.cc
@@ -10,8 +10,6 @@
 #include "FWCore/Utilities/interface/isFinite.h"
 #include "vdt/vdtMath.h"
 
-#include <Math/SMatrix.h>
-
 using namespace std;
 
 //#define DEBUG
@@ -24,7 +22,7 @@ DAClusterizerInZ_vect::DAClusterizerInZ_vect(const edm::ParameterSet& conf) {
   maxIterations_ = 1000;
   mintrkweight_ = 0.5;
 
-  // configurable debug outptut
+  // configurable debug output
 #ifdef DEBUG
   zdumpcenter_ = conf.getUntrackedParameter<double>("zdumpcenter", 0.);
   zdumpwidth_ = conf.getUntrackedParameter<double>("zdumpwidth", 20.);
@@ -39,6 +37,7 @@ DAClusterizerInZ_vect::DAClusterizerInZ_vect(const edm::ParameterSet& conf) {
   d0CutOff_ = conf.getParameter<double>("d0CutOff");
   dzCutOff_ = conf.getParameter<double>("dzCutOff");
   uniquetrkweight_ = conf.getParameter<double>("uniquetrkweight");
+  uniquetrkminp_ = conf.getParameter<double>("uniquetrkminp");
   zmerge_ = conf.getParameter<double>("zmerge");
   sel_zrange_ = conf.getParameter<double>("zrange");
   convergence_mode_ = conf.getParameter<int>("convergence_mode");
@@ -48,6 +47,7 @@ DAClusterizerInZ_vect::DAClusterizerInZ_vect(const edm::ParameterSet& conf) {
 #ifdef DEBUG
   std::cout << "DAClusterizerinZ_vect: mintrkweight = " << mintrkweight_ << std::endl;
   std::cout << "DAClusterizerinZ_vect: uniquetrkweight = " << uniquetrkweight_ << std::endl;
+  std::cout << "DAClusterizerInZ_vect: uniquetrkminp = " << uniquetrkminp_ << std::endl;
   std::cout << "DAClusterizerinZ_vect: zmerge = " << zmerge_ << std::endl;
   std::cout << "DAClusterizerinZ_vect: Tmin = " << Tmin << std::endl;
   std::cout << "DAClusterizerinZ_vect: Tpurge = " << Tpurge << std::endl;
@@ -175,6 +175,7 @@ void DAClusterizerInZ_vect::verify(const vertex_t& v, const track_t& tks, unsign
 DAClusterizerInZ_vect::track_t DAClusterizerInZ_vect::fill(const vector<reco::TransientTrack>& tracks) const {
   // prepare track data for clustering
   track_t tks;
+  double sumtkwt = 0.;
   for (auto it = tracks.begin(); it != tracks.end(); it++) {
     if (!(*it).isValid())
       continue;
@@ -202,9 +203,12 @@ DAClusterizerInZ_vect::track_t DAClusterizerInZ_vect::fill(const vector<reco::Tr
       }
     }
     tks.addItemSorted(t_z, t_dz2, &(*it), t_tkwt);
+    sumtkwt += t_tkwt;
   }
 
   tks.extractRaw();
+  tks.osumtkwt = sumtkwt > 0 ? 1. / sumtkwt : 0.;
+
 #ifdef DEBUG
   if (DEBUGLEVEL > 0) {
     std::cout << "Track count (Z) " << tks.getSize() << std::endl;
@@ -278,20 +282,14 @@ void DAClusterizerInZ_vect::clear_vtx_range(track_t& gtracks, vertex_t& gvertice
 
 double DAClusterizerInZ_vect::update(
     double beta, track_t& gtracks, vertex_t& gvertices, const double rho0, const bool updateTc) const {
-  // update weights and vertex positions and Tc input
-  // returns the squared sum of changes of vertex positions
+  // update weights and vertex positions
+  // returns the maximum of changes of vertex positions
   // sums needed for Tc are only updated if updateTC == true
 
   const unsigned int nt = gtracks.getSize();
   const unsigned int nv = gvertices.getSize();
+  auto osumtkwt = gtracks.osumtkwt;
 
-  //initialize sums
-  double sumtkwt = 0;
-
-  // to return how much the prototype moved
-  double delta = 0;
-
-  // independpent of loop
   double Z_init = 0;
   if (rho0 > 0) {
     Z_init = rho0 * local_exp(-beta * dzCutOff_ * dzCutOff_);  // cut-off
@@ -327,8 +325,9 @@ double DAClusterizerInZ_vect::update(
                                                     vertex_t& vertices,
                                                     const unsigned int kmin,
                                                     const unsigned int kmax) {
-    auto tmp_trk_tkwt = tracks.tkwt[track_num];
-    auto o_trk_sum_Z = 1. / tracks.sum_Z[track_num];
+    //auto tmp_trk_tkwt = tracks.tkwt[track_num];
+    //auto o_trk_sum_Z = 1. / tracks.sum_Z[track_num];
+    auto o_trk_sum_Z = tracks.tkwt[track_num] / tracks.sum_Z[track_num];
     auto o_trk_dz2 = tracks.dz2[track_num];
     auto tmp_trk_z = tracks.zpca[track_num];
 
@@ -336,8 +335,10 @@ double DAClusterizerInZ_vect::update(
     if (updateTc) {
 #pragma GCC ivdep
       for (unsigned int k = kmin; k < kmax; ++k) {
-        vertices.se[k] += vertices.exp[k] * (tmp_trk_tkwt * o_trk_sum_Z);
-        auto w = vertices.rho[k] * vertices.exp[k] * (tmp_trk_tkwt * o_trk_sum_Z * o_trk_dz2);
+        //vertices.se[k] += vertices.exp[k] * (tmp_trk_tkwt * o_trk_sum_Z);
+        //auto w = vertices.rho[k] * vertices.exp[k] * (tmp_trk_tkwt * o_trk_sum_Z * o_trk_dz2);
+        vertices.se[k] += vertices.exp[k] * o_trk_sum_Z;
+        auto w = vertices.rho[k] * vertices.exp[k] * (o_trk_sum_Z * o_trk_dz2);
         vertices.sw[k] += w;
         vertices.swz[k] += w * tmp_trk_z;
         vertices.swE[k] += w * vertices.exp_arg[k];
@@ -346,8 +347,10 @@ double DAClusterizerInZ_vect::update(
       // same loop but without updating sWE
 #pragma GCC ivdep
       for (unsigned int k = kmin; k < kmax; ++k) {
-        vertices.se[k] += vertices.exp[k] * (tmp_trk_tkwt * o_trk_sum_Z);
-        auto w = vertices.rho[k] * vertices.exp[k] * (tmp_trk_tkwt * o_trk_sum_Z * o_trk_dz2);
+        //vertices.se[k] += vertices.exp[k] * (tmp_trk_tkwt * o_trk_sum_Z);
+        //auto w = vertices.rho[k] * vertices.exp[k] * (tmp_trk_tkwt * o_trk_sum_Z * o_trk_dz2);
+        vertices.se[k] += vertices.exp[k] * o_trk_sum_Z;
+        auto w = vertices.rho[k] * vertices.exp[k] * (o_trk_sum_Z * o_trk_dz2);
         vertices.sw[k] += w;
         vertices.swz[k] += w * tmp_trk_z;
       }
@@ -371,8 +374,8 @@ double DAClusterizerInZ_vect::update(
 
   // loop over tracks
   for (auto itrack = 0U; itrack < nt; ++itrack) {
-    unsigned int kmin = gtracks.kmin[itrack];
-    unsigned int kmax = gtracks.kmax[itrack];
+    const unsigned int kmin = gtracks.kmin[itrack];
+    const unsigned int kmax = gtracks.kmax[itrack];
 
     kernel_calc_exp_arg_range(itrack, gtracks, gvertices, kmin, kmax);
     local_exp_list_range(gvertices.exp_arg, gvertices.exp, kmin, kmax);
@@ -380,8 +383,6 @@ double DAClusterizerInZ_vect::update(
 
     if (edm::isNotFinite(gtracks.sum_Z[itrack]))
       gtracks.sum_Z[itrack] = 0.0;
-    // used in the next major loop to follow
-    sumtkwt += gtracks.tkwt[itrack];
 
     if (gtracks.sum_Z[itrack] > 1.e-100) {
       kernel_calc_normalization_range(itrack, gtracks, gvertices, kmin, kmax);
@@ -397,7 +398,7 @@ double DAClusterizerInZ_vect::update(
   }
 
   // now update z and rho
-  auto kernel_calc_z = [sumtkwt, nv](vertex_t& vertices) -> double {
+  auto kernel_calc_z = [osumtkwt, nv](vertex_t& vertices) -> double {
     double delta = 0;
     // does not vectorize
     for (unsigned int ivertex = 0; ivertex < nv; ++ivertex) {
@@ -409,14 +410,13 @@ double DAClusterizerInZ_vect::update(
       }
     }
 
-    auto osumtkwt = 1. / sumtkwt;
     for (unsigned int ivertex = 0; ivertex < nv; ++ivertex)
       vertices.rho[ivertex] = vertices.rho[ivertex] * vertices.se[ivertex] * osumtkwt;
 
     return delta;
   };
 
-  delta = kernel_calc_z(gvertices);
+  double delta = kernel_calc_z(gvertices);
 
   // return how much the prototypes moved
   return delta;
@@ -533,46 +533,55 @@ bool DAClusterizerInZ_vect::purge(vertex_t& y, track_t& tks, double& rho0, const
   if (nv < 2)
     return false;
 
-  double sumpmin = nt;
-  unsigned int k0 = nv;
-
-  std::vector<double> inverse_zsums(nt), arg_cache(nt), eik_cache(nt), pcut_cache(nv);
-  double* __restrict__ pinverse_zsums;
+  std::vector<double> sump_v(nv), arg_cache_v(nv), exp_cache_v(nv), pcut_cache_v(nv);
+  std::vector<int> nUnique_v(nv);
   double* __restrict__ parg_cache;
-  double* __restrict__ peik_cache;
+  double* __restrict__ pexp_cache;
   double* __restrict__ ppcut_cache;
-  pinverse_zsums = inverse_zsums.data();
-  parg_cache = arg_cache.data();
-  peik_cache = eik_cache.data();
-  ppcut_cache = pcut_cache.data();
-  for (unsigned i = 0; i < nt; ++i) {
-    inverse_zsums[i] = tks.sum_Z[i] > eps ? 1. / tks.sum_Z[i] : 0.0;
-  }
+  double* __restrict__ psump;
+  int* __restrict__ pnUnique;
+  int constexpr nunique_min_ = 2;
+
+  set_vtx_range(beta, tks, y);
+
+  parg_cache = arg_cache_v.data();
+  pexp_cache = exp_cache_v.data();
+  ppcut_cache = pcut_cache_v.data();
+  psump = sump_v.data();
+  pnUnique = nUnique_v.data();
+
   const auto rhoconst = rho0 * local_exp(-beta * dzCutOff_ * dzCutOff_);
   for (unsigned int k = 0; k < nv; k++) {
     const double pmax = y.rho[k] / (y.rho[k] + rhoconst);
     ppcut_cache[k] = uniquetrkweight_ * pmax;
   }
 
-  for (unsigned int k = 0; k < nv; k++) {
-    for (unsigned int i = 0; i < nt; ++i) {
-      const auto track_z = tks.zpca[i];
-      const auto botrack_dz2 = -beta * tks.dz2[i];
+  for (unsigned int i = 0; i < nt; i++) {
+    const auto invZ = ((tks.sum_Z[i] > eps) && (tks.tkwt[i] > uniquetrkminp_)) ? 1. / tks.sum_Z[i] : 0.;
+    const auto track_z = tks.zpca[i];
+    const auto botrack_dz2 = -beta * tks.dz2[i];
+    const auto kmin = tks.kmin[i];
+    const auto kmax = tks.kmax[i];
+
+    for (unsigned int k = kmin; k < kmax; k++) {
       const auto mult_resz = track_z - y.zvtx[k];
-      parg_cache[i] = botrack_dz2 * (mult_resz * mult_resz);
-    }
-    local_exp_list(parg_cache, peik_cache, nt);
-
-    int nUnique = 0;
-    double sump = 0;
-    for (unsigned int i = 0; i < nt; ++i) {
-      const auto p = y.rho[k] * peik_cache[i] * pinverse_zsums[i];
-      sump += p;
-      nUnique += ((p > ppcut_cache[k]) & (tks.tkwt[i] > 0)) ? 1 : 0;
+      parg_cache[k] = botrack_dz2 * (mult_resz * mult_resz);
     }
 
-    if ((nUnique < 2) && (sump < sumpmin)) {
-      sumpmin = sump;
+    local_exp_list_range(parg_cache, pexp_cache, kmin, kmax);
+
+    for (unsigned int k = kmin; k < kmax; k++) {
+      const double p = y.rho[k] * pexp_cache[k] * invZ;
+      psump[k] += p;
+      pnUnique[k] += (p > ppcut_cache[k]) ? 1 : 0;
+    }
+  }
+
+  double sumpmin = nt;
+  unsigned int k0 = nv;
+  for (unsigned k = 0; k < nv; k++) {
+    if ((pnUnique[k] < nunique_min_) && (psump[k] < sumpmin)) {
+      sumpmin = psump[k];
       k0 = k;
     }
   }
@@ -803,7 +812,6 @@ vector<TransientVertex> DAClusterizerInZ_vect::vertices(const vector<reco::Trans
     split(beta, tks, y);
 
     beta = beta / coolingFactor_;
-    set_vtx_range(beta, tks, y);
     thermalize(beta, tks, y, delta_highT_);
   }
 
@@ -827,8 +835,7 @@ vector<TransientVertex> DAClusterizerInZ_vect::vertices(const vector<reco::Trans
   unsigned int ntry = 0;
   double threshold = 1.0;
   while (split(beta, tks, y, threshold) && (ntry++ < 10)) {
-    set_vtx_range(beta, tks, y);
-    thermalize(beta, tks, y, delta_highT_, 0.);
+    thermalize(beta, tks, y, delta_highT_, rho0);  // rho0 = 0. here
     update(beta, tks, y, rho0, true);
     while (merge(y, tks, beta)) {
       update(beta, tks, y, rho0, true);
@@ -848,7 +855,7 @@ vector<TransientVertex> DAClusterizerInZ_vect::vertices(const vector<reco::Trans
 
   // switch on outlier rejection at T=Tmin, doesn't do much at high PU
   if (dzCutOff_ > 0) {
-    rho0 = 1. / nt;  //1. / y.getSize();??
+    rho0 = 1. / nt;
     for (unsigned int a = 0; a < 5; a++) {
       update(beta, tks, y, a * rho0 / 5.);  // adiabatic turn-on
     }
@@ -886,7 +893,6 @@ vector<TransientVertex> DAClusterizerInZ_vect::vertices(const vector<reco::Trans
   // go down to the purging temperature (if it is lower than tmin)
   while (beta < betapurge_) {
     beta = min(beta / coolingFactor_, betapurge_);
-    set_vtx_range(beta, tks, y);
     thermalize(beta, tks, y, delta_lowT_, rho0);
   }
 
@@ -898,7 +904,7 @@ vector<TransientVertex> DAClusterizerInZ_vect::vertices(const vector<reco::Trans
   }
 #endif
 
-  // eliminate insigificant vertices, this is more restrictive at higher T
+  // eliminate insignificant vertices, this is more restrictive at higher T
   while (purge(y, tks, rho0, beta)) {
     thermalize(beta, tks, y, delta_lowT_, rho0);
   }
@@ -928,41 +934,55 @@ vector<TransientVertex> DAClusterizerInZ_vect::vertices(const vector<reco::Trans
 #endif
 
   // select significant tracks and use a TransientVertex as a container
-  GlobalError dummyError(0.01, 0, 0.01, 0., 0., 0.01);
 
-  // ensure correct normalization of probabilities, should makes double assignment reasonably impossible
+  set_vtx_range(beta, tks, y);
   const unsigned int nv = y.getSize();
-  for (unsigned int k = 0; k < nv; k++)
+  for (unsigned int k = 0; k < nv; k++) {
     if (edm::isNotFinite(y.rho[k]) || edm::isNotFinite(y.zvtx[k])) {
       y.rho[k] = 0;
       y.zvtx[k] = 0;
     }
-
-  const auto z_sum_init = rho0 * local_exp(-beta * dzCutOff_ * dzCutOff_);
-  for (unsigned int i = 0; i < nt; i++)  // initialize
-    tks.sum_Z[i] = z_sum_init;
-
-  // improve vectorization (does not require reduction ....)
-  for (unsigned int k = 0; k < nv; k++) {
-    for (unsigned int i = 0; i < nt; i++)
-      tks.sum_Z[i] += y.rho[k] * local_exp(-beta * Eik(tks.zpca[i], y.zvtx[k], tks.dz2[i]));
   }
 
-  for (unsigned int k = 0; k < nv; k++) {
-    GlobalPoint pos(0, 0, y.zvtx[k]);
+  const auto z_sum_init = rho0 * local_exp(-beta * dzCutOff_ * dzCutOff_);
+  std::vector<std::vector<unsigned int> > vtx_track_indices(nv);
+  for (unsigned int i = 0; i < nt; i++) {
+    const auto kmin = tks.kmin[i];
+    const auto kmax = tks.kmax[i];
+    for (auto k = kmin; k < kmax; k++) {
+      y.exp_arg[k] = -beta * Eik(tks.zpca[i], y.zvtx[k], tks.dz2[i]);
+    }
 
-    vector<reco::TransientTrack> vertexTracks;
-    for (unsigned int i = 0; i < nt; i++) {
-      if (tks.sum_Z[i] > 1e-100) {
-        double p = y.rho[k] * local_exp(-beta * Eik(tks.zpca[i], y.zvtx[k], tks.dz2[i])) / tks.sum_Z[i];
-        if ((tks.tkwt[i] > 0) && (p > mintrkweight_)) {
-          vertexTracks.push_back(*(tks.tt[i]));
-          tks.sum_Z[i] = 0;  // setting Z=0 excludes double assignment
-        }
+    local_exp_list_range(y.exp_arg, y.exp, kmin, kmax);
+
+    tks.sum_Z[i] = z_sum_init;
+    for (auto k = kmin; k < kmax; k++) {
+      tks.sum_Z[i] += y.rho[k] * y.exp[k];
+    }
+    const double invZ = tks.sum_Z[i] > 1e-100 ? 1. / tks.sum_Z[i] : 0.0;
+
+    for (auto k = kmin; k < kmax; k++) {
+      double p = y.rho[k] * y.exp[k] * invZ;
+      if (p > mintrkweight_) {
+        // assign  track i -> vertex k (hard, mintrkweight_ should be >= 0.5 here
+        vtx_track_indices[k].push_back(i);
+        break;
       }
     }
-    TransientVertex v(pos, dummyError, vertexTracks, 0);
-    clusters.push_back(v);
+
+  }  // track loop
+
+  GlobalError dummyError(0.01, 0, 0.01, 0., 0., 0.01);
+  for (unsigned int k = 0; k < nv; k++) {
+    if (!vtx_track_indices[k].empty()) {
+      GlobalPoint pos(0, 0, y.zvtx[k]);
+      vector<reco::TransientTrack> vertexTracks;
+      for (auto i : vtx_track_indices[k]) {
+        vertexTracks.push_back(*(tks.tt[i]));
+      }
+      TransientVertex v(pos, dummyError, vertexTracks, 0);
+      clusters.push_back(v);
+    }
   }
 
   return clusters;

--- a/RecoVertex/PrimaryVertexProducer/src/DAClusterizerInZ_vect.cc
+++ b/RecoVertex/PrimaryVertexProducer/src/DAClusterizerInZ_vect.cc
@@ -320,8 +320,6 @@ double DAClusterizerInZ_vect::update(
                                                     vertex_t& vertices,
                                                     const unsigned int kmin,
                                                     const unsigned int kmax) {
-    //auto tmp_trk_tkwt = tracks.tkwt[track_num];
-    //auto o_trk_sum_Z = 1. / tracks.sum_Z[track_num];
     auto o_trk_sum_Z = tracks.tkwt[track_num] / tracks.sum_Z[track_num];
     auto o_trk_dz2 = tracks.dz2[track_num];
     auto tmp_trk_z = tracks.zpca[track_num];
@@ -330,8 +328,6 @@ double DAClusterizerInZ_vect::update(
     if (updateTc) {
 #pragma GCC ivdep
       for (unsigned int k = kmin; k < kmax; ++k) {
-        //vertices.se[k] += vertices.exp[k] * (tmp_trk_tkwt * o_trk_sum_Z);
-        //auto w = vertices.rho[k] * vertices.exp[k] * (tmp_trk_tkwt * o_trk_sum_Z * o_trk_dz2);
         vertices.se[k] += vertices.exp[k] * o_trk_sum_Z;
         auto w = vertices.rho[k] * vertices.exp[k] * (o_trk_sum_Z * o_trk_dz2);
         vertices.sw[k] += w;
@@ -342,8 +338,6 @@ double DAClusterizerInZ_vect::update(
       // same loop but without updating sWE
 #pragma GCC ivdep
       for (unsigned int k = kmin; k < kmax; ++k) {
-        //vertices.se[k] += vertices.exp[k] * (tmp_trk_tkwt * o_trk_sum_Z);
-        //auto w = vertices.rho[k] * vertices.exp[k] * (tmp_trk_tkwt * o_trk_sum_Z * o_trk_dz2);
         vertices.se[k] += vertices.exp[k] * o_trk_sum_Z;
         auto w = vertices.rho[k] * vertices.exp[k] * (o_trk_sum_Z * o_trk_dz2);
         vertices.sw[k] += w;


### PR DESCRIPTION
Last year the execution time of  DAClusterizerInZ_vect and DAClusterizerInZT_vect  was improved significantly by reducing the list of clusters considered for a triack to within 4 sigma in the update() cycles.  Similar arithmetic is used in the purge() method and the final track assignment at the end of vertices().  This code is executed much less frequently than update but there is still some time to gain because they are executed at low Temperature when the cluster lists are long. 
In addition the code was streamlined to avoid repeating some computations. Only changes that are not expected to change the result have been implemented. The cluster list restriction represents an approximation (cutting off a gaussinan at 4 sigma) that can lead to very small changes.
 This PR reduces the clustering time by about 30 % with negligible changes of the results.

Small additional changes that don't change the behaviour are packaged with this PR
*  new configurable parameter (uniqutrkminp) was introduced for future use. When set to 0 (=current default) it restores the original behaviour
* the 4d vertices until now have no track weights. These are now copied from the 3d fit after the 4d clustering (in plugin/PrimaryVertexProducer.cc)

![clustering-time-offlinePrimaryVertices](https://user-images.githubusercontent.com/4669785/109121892-23fbfe80-7748-11eb-84e6-618e92574544.png)




#### PR validation:
the PR was tested with several RelVal samples from Run 3 and Phase2. Almost no differences in the results have been found.
runthematrix reports 37 36 35 26 17 4 1 1 1 tests passed, 0 0 0 0 0 0 0 0 0 failed

