### PR TITLE
[PPS] Fix of validation script

### DIFF
--- a/Validation/CTPPS/python/simu_config/base_cff.py
+++ b/Validation/CTPPS/python/simu_config/base_cff.py
@@ -117,7 +117,7 @@ from RecoPPS.Local.ctppsDiamondLocalReconstruction_cff import *
 from RecoPPS.Local.ctppsLocalTrackLiteProducer_cff import *
 
 totemRPUVPatternFinder.tagRecHit = cms.InputTag('ctppsDirectProtonSimulation')
-ctppsPixelLocalTracks.label = "ctppsDirectProtonSimulation"
+ctppsPixelLocalTracks.tag = cms.InputTag('ctppsDirectProtonSimulation')
 ctppsDiamondLocalTracks.recHitsTag = cms.InputTag('ctppsDirectProtonSimulation')
 
 ctppsLocalTrackLiteProducer.includeDiamonds = False


### PR DESCRIPTION
#### PR description:

This PR fixes the failure observed in `CMSSW_11_3_X_2021-02-25-1100` IB for the TestCTPPSDirectProtonSimulation unit test after the merge of #32971 (a leftover `(std::string)label` → `(edm::InputTag)tag` was not modified in base configuration). This was reported in #32996.
Curiously this did not trigger any failure in the review process of this latter...

#### PR validation:

Previously failing unit test passes.

#### if this PR is a backport please specify the original PR and why you need to backport that PR: N/A

<!-- Please replace this text with any link to  -->

Before submitting your pull requests, make sure you followed this checklist:
- [x] verify that the PR is really intended for the chosen branch
- [x] verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- [x] verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
