### PR TITLE
Add additional capability (filter by decay R/Z) to MCMultiParticleFilter

### DIFF
--- a/GeneratorInterface/GenFilters/plugins/MCMultiParticleFilter.cc
+++ b/GeneratorInterface/GenFilters/plugins/MCMultiParticleFilter.cc
@@ -124,36 +124,28 @@ MCMultiParticleFilter::MCMultiParticleFilter(const edm::ParameterSet& iConfig)
 
   // if decayRadiusMin size smaller than particleID , fill up further with defaults
   if (particleID_.size() > decayRadiusMin.size()) {
-    std::vector<double> decayRadiusmin2;
-    for (unsigned int i = 0; i < particleID_.size(); i++) {
-      decayRadiusmin2.push_back(-10.);
+    for (unsigned int i = decayRadiusMin.size(); i < particleID_.size(); i++) {
+      decayRadiusMin.push_back(-10.);
     }
-    decayRadiusMin = decayRadiusmin2;
   }
   // if decayRadiusMax size smaller than particleID , fill up further with defaults
   if (particleID_.size() > decayRadiusMax.size()) {
-    std::vector<double> decayRadiusmax2;
-    for (unsigned int i = 0; i < particleID_.size(); i++) {
-      decayRadiusmax2.push_back(1.e5);
+    for (unsigned int i = decayRadiusMax.size(); i < particleID_.size(); i++) {
+      decayRadiusMax.push_back(1.e5);
     }
-    decayRadiusMax = decayRadiusmax2;
   }
 
   // if decayZMin size smaller than particleID , fill up further with defaults
   if (particleID_.size() > decayZMin.size()) {
-    std::vector<double> decayZmin2;
-    for (unsigned int i = 0; i < particleID_.size(); i++) {
-      decayZmin2.push_back(-1.e5);
+    for (unsigned int i = decayZMin.size(); i < particleID_.size(); i++) {
+      decayZMin.push_back(-1.e5);
     }
-    decayZMin = decayZmin2;
   }
   // if decayZMax size smaller than particleID , fill up further with defaults
   if (particleID_.size() > decayZMax.size()) {
-    std::vector<double> decayZmax2;
-    for (unsigned int i = 0; i < particleID_.size(); i++) {
-      decayZmax2.push_back(1.e5);
+    for (unsigned int i = decayZMax.size(); i < particleID_.size(); i++) {
+      decayZMax.push_back(1.e5);
     }
-    decayZMax = decayZmax2;
   }
 }
 

--- a/GeneratorInterface/GenFilters/plugins/MCMultiParticleFilter.cc
+++ b/GeneratorInterface/GenFilters/plugins/MCMultiParticleFilter.cc
@@ -80,7 +80,7 @@ MCMultiParticleFilter::MCMultiParticleFilter(const edm::ParameterSet& iConfig)
   std::vector<int> defmother;
   defmother.push_back(0);
   motherID_ = iConfig.getUntrackedParameter<std::vector<int> >("MotherID", defmother);
-          
+
   std::vector<double> defDecayRadiusmin;
   defDecayRadiusmin.push_back(-1.);
   decayRadiusMin = iConfig.getUntrackedParameter<std::vector<double> >("MinDecayRadius", defDecayRadiusmin);
@@ -106,7 +106,8 @@ MCMultiParticleFilter::MCMultiParticleFilter(const edm::ParameterSet& iConfig)
       (decayRadiusMax.size() > 1 && particleID_.size() != decayRadiusMax.size()) ||
       (decayZMin.size() > 1 && particleID_.size() != decayZMin.size()) ||
       (decayZMax.size() > 1 && particleID_.size() != decayZMax.size())) {
-    edm::LogWarning("MCMultiParticleFilter") << "WARNING: MCMultiParticleFilter: size of PtMin, EtaMax, motherID, decayRadiusMin, decayRadiusMax, decayZMin, decayZMax"
+    edm::LogWarning("MCMultiParticleFilter") << "WARNING: MCMultiParticleFilter: size of PtMin, EtaMax, motherID, "
+                                                "decayRadiusMin, decayRadiusMax, decayZMin, decayZMax"
                                                 "and/or Status does not match ParticleID size!"
                                              << std::endl;
   }
@@ -120,7 +121,7 @@ MCMultiParticleFilter::MCMultiParticleFilter(const edm::ParameterSet& iConfig)
     status_.push_back(defstat[0]);
   while (motherID_.size() < particleID_.size())
     motherID_.push_back(defmother[0]);
-          
+
   // if decayRadiusMin size smaller than particleID , fill up further with defaults
   if (particleID_.size() > decayRadiusMin.size()) {
     std::vector<double> decayRadiusmin2;
@@ -171,24 +172,23 @@ bool MCMultiParticleFilter::filter(edm::StreamID, edm::Event& iEvent, const edm:
       if ((particleID_[i] == 0 || std::abs(particleID_[i]) == std::abs((*p)->pdg_id())) &&
           (*p)->momentum().perp() > ptMin_[i] && std::fabs((*p)->momentum().eta()) < etaMax_[i] &&
           (status_[i] == 0 || (*p)->status() == status_[i])) {
-          
-          if (!((*p)->production_vertex()))
-            continue;
+        if (!((*p)->production_vertex()))
+          continue;
 
-          double decx = (*p)->production_vertex()->position().x();
-          double decy = (*p)->production_vertex()->position().y();
-          double decrad = sqrt(decx * decx + decy * decy);
-          if (decrad < decayRadiusMin[i])
-            continue;
-          if (decrad > decayRadiusMax[i])
-            continue;
+        double decx = (*p)->production_vertex()->position().x();
+        double decy = (*p)->production_vertex()->position().y();
+        double decrad = sqrt(decx * decx + decy * decy);
+        if (decrad < decayRadiusMin[i])
+          continue;
+        if (decrad > decayRadiusMax[i])
+          continue;
 
-          double decz = (*p)->production_vertex()->position().z();
-          if (decz < decayZMin[i])
-            continue;
-          if (decz > decayZMax[i])
-            continue;
-          
+        double decz = (*p)->production_vertex()->position().z();
+        if (decz < decayZMin[i])
+          continue;
+        if (decz > decayZMax[i])
+          continue;
+
         if (motherID_[i] == 0) {  // do not check for mother ID if not sepcified
           nFound++;
           break;  // only match a given particle once!

--- a/GeneratorInterface/GenFilters/plugins/MCSmartSingleParticleFilter.cc
+++ b/GeneratorInterface/GenFilters/plugins/MCSmartSingleParticleFilter.cc
@@ -111,77 +111,59 @@ MCSmartSingleParticleFilter::MCSmartSingleParticleFilter(const edm::ParameterSet
 
   // if pMin size smaller than particleID , fill up further with defaults
   if (particleID.size() > pMin.size()) {
-    vector<double> defpmin2;
-    for (unsigned int i = 0; i < particleID.size(); i++) {
-      defpmin2.push_back(0.);
+    for (unsigned int i = pMin.size(); i < particleID.size(); i++) {
+      pMin.push_back(0.);
     }
-    pMin = defpmin2;
   }
   // if ptMin size smaller than particleID , fill up further with defaults
   if (particleID.size() > ptMin.size()) {
-    vector<double> defptmin2;
-    for (unsigned int i = 0; i < particleID.size(); i++) {
-      defptmin2.push_back(0.);
+    for (unsigned int i = ptMin.size(); i < particleID.size(); i++) {
+      ptMin.push_back(0.);
     }
-    ptMin = defptmin2;
   }
   // if etaMin size smaller than particleID , fill up further with defaults
   if (particleID.size() > etaMin.size()) {
-    vector<double> defetamin2;
-    for (unsigned int i = 0; i < particleID.size(); i++) {
-      defetamin2.push_back(-10.);
+    for (unsigned int i = etaMin.size(); i < particleID.size(); i++) {
+      etaMin.push_back(-10.);
     }
-    etaMin = defetamin2;
   }
   // if etaMax size smaller than particleID , fill up further with defaults
   if (particleID.size() > etaMax.size()) {
-    vector<double> defetamax2;
-    for (unsigned int i = 0; i < particleID.size(); i++) {
-      defetamax2.push_back(10.);
+    for (unsigned int i = etaMax.size(); i < particleID.size(); i++) {
+      etaMax.push_back(10.);
     }
-    etaMax = defetamax2;
   }
   // if status size smaller than particleID , fill up further with defaults
   if (particleID.size() > status.size()) {
-    vector<int> defstat2;
-    for (unsigned int i = 0; i < particleID.size(); i++) {
-      defstat2.push_back(0);
+    for (unsigned int i = status.size(); i < particleID.size(); i++) {
+      status.push_back(0);
     }
-    status = defstat2;
   }
 
   // if decayRadiusMin size smaller than particleID , fill up further with defaults
   if (particleID.size() > decayRadiusMin.size()) {
-    vector<double> decayRadiusmin2;
-    for (unsigned int i = 0; i < particleID.size(); i++) {
-      decayRadiusmin2.push_back(-10.);
+    for (unsigned int i = decayRadiusMin.size(); i < particleID.size(); i++) {
+      decayRadiusMin.push_back(-10.);
     }
-    decayRadiusMin = decayRadiusmin2;
   }
   // if decayRadiusMax size smaller than particleID , fill up further with defaults
   if (particleID.size() > decayRadiusMax.size()) {
-    vector<double> decayRadiusmax2;
-    for (unsigned int i = 0; i < particleID.size(); i++) {
-      decayRadiusmax2.push_back(1.e5);
+    for (unsigned int i = decayRadiusMax.size(); i < particleID.size(); i++) {
+      decayRadiusMax.push_back(1.e5);
     }
-    decayRadiusMax = decayRadiusmax2;
   }
 
   // if decayZMin size smaller than particleID , fill up further with defaults
   if (particleID.size() > decayZMin.size()) {
-    vector<double> decayZmin2;
-    for (unsigned int i = 0; i < particleID.size(); i++) {
-      decayZmin2.push_back(-1.e5);
+    for (unsigned int i = decayZMin.size(); i < particleID.size(); i++) {
+      decayZMin.push_back(-1.e5);
     }
-    decayZMin = decayZmin2;
   }
   // if decayZMax size smaller than particleID , fill up further with defaults
   if (particleID.size() > decayZMax.size()) {
-    vector<double> decayZmax2;
-    for (unsigned int i = 0; i < particleID.size(); i++) {
-      decayZmax2.push_back(1.e5);
+    for (unsigned int i = decayZMax.size(); i < particleID.size(); i++) {
+      decayZMax.push_back(1.e5);
     }
-    decayZMax = decayZmax2;
   }
 
   // check if beta is smaller than 1


### PR DESCRIPTION
#### PR description:

For the B->mumu analysis, we would like to generate a special MC which has a full decay chain of B(s,d) -> hh(=k,pi) -> mumu, with the hadrons decaying to the muon within the detector volume. We have identified such a MC can be produced if an additional capability (filtering according to the decay region, the same functionality which has been already implemented in the MCSmartSingleParticleFilter) can be added to the MCMultiParticleFilter. Hence this PR is proposed, with no change to the original filter, but just adding new capabilities.  

A small typo (bug, but no real effect) for loading motherID_  in the original filter has been fixed as well.

#### PR validation:

Managed to filter the B(s,d) -> hh -> mumu events by adding such a filter (requiring two muon decaying from K/pi, and within the detector volume) to the process:
mugenfilter = cms.EDFilter(
    "MCMultiParticleFilter",
    ParticleID = cms.vint32(-13, 13, -13, 13),
    MotherID = cms.untracked.vint32(321, -321, 211, -211),
    MaxDecayRadius = cms.untracked.vdouble(2000.0, 2000.0, 2000.0, 2000.0),
    MaxDecayZ = cms.untracked.vdouble(4000.0, 4000.0, 4000.0, 4000.0),
    MinDecayZ = cms.untracked.vdouble(-4000.0, -4000.0, -4000.0, -4000.0),
    EtaMax = cms.vdouble(2.5, 2.5, 2.5, 2.5),
    PtMin = cms.vdouble(3.5, 3.5, 3.5, 3.5),
    Status = cms.vint32(1,1,1,1),
    NumRequired = cms.int32(2),
    AcceptMore = cms.bool(True)
)

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Not a backport PR.

