### PR TITLE
Adding D76 to the short matrix for PR test, disable ME0 when phase2_GE0 modifier is used

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_2026.py
+++ b/Configuration/PyReleaseValidation/python/relval_2026.py
@@ -33,6 +33,7 @@ numWFIB.extend([33034.0]) #2026D72
 numWFIB.extend([33834.0]) #2026D74
 numWFIB.extend([34234.0]) #2026D75
 numWFIB.extend([34634.0]) #2026D76
+numWFIB.extend([34834.999]) #2026D76 premixing combined stage1+stage2 (ttbar+PU50 for PR test)
 numWFIB.extend([35034.0]) #2026D77
 numWFIB.extend([35434.0]) #2026D78
 numWFIB.extend([35834.0]) #2026D79

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -3230,6 +3230,7 @@ defaultDataSets['2021Design']='CMSSW_11_2_0_pre8-112X_mcRun3_2021_design_v10-v'
 defaultDataSets['2023']='CMSSW_11_2_0_pre8-112X_mcRun3_2023_realistic_v10-v'
 defaultDataSets['2024']='CMSSW_11_2_0_pre8-112X_mcRun3_2024_realistic_v10-v'
 defaultDataSets['2026D49']='CMSSW_11_2_0_pre8-112X_mcRun4_realistic_v3_2026D49noPU-v'
+defaultDataSets['2026D76']='CMSSW_11_3_0_pre3-113X_mcRun4_realistic_v3_2026D76noPU-v'
 
 puDataSets = {}
 for key, value in defaultDataSets.items(): puDataSets[key+'PU'] = value

--- a/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
+++ b/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
@@ -90,6 +90,8 @@ if __name__ == '__main__':
                      23234.0, #2026D49 ttbar (HLT TDR baseline w/ HGCal v11)
                      23434.999, #2026D49 ttbar premixing stage1+stage2, PU50
                      28234.0, #2026D60 (exercise HF nose)
+                     34634.0, #2026D76 ttbar (2021 new baseline)
+                     34834.999, #2026D76 ttbar premixing stage1+stage2, PU50
                      25202.0, #2016 ttbar UP15 PU
                      250202.181, #2018 ttbar stage1 + stage2 premix
                      ],

--- a/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
+++ b/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
@@ -87,6 +87,7 @@ if __name__ == '__main__':
                      11634.911, #2021 DD4hep ttbar
                      11634.0, #2021 ttbar
                      12434.0, #2023 ttbar
+                     23234.0, #2026D49 ttbar (HLT TDR baseline w/ HGCal v11)
                      28234.0, #2026D60 (exercise HF nose)
                      34634.0, #2026D76 ttbar (2021 new baseline)
                      34834.999, #2026D76 ttbar premixing stage1+stage2, PU50

--- a/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
+++ b/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
@@ -87,8 +87,6 @@ if __name__ == '__main__':
                      11634.911, #2021 DD4hep ttbar
                      11634.0, #2021 ttbar
                      12434.0, #2023 ttbar
-                     23234.0, #2026D49 ttbar (HLT TDR baseline w/ HGCal v11)
-                     23434.999, #2026D49 ttbar premixing stage1+stage2, PU50
                      28234.0, #2026D60 (exercise HF nose)
                      34634.0, #2026D76 ttbar (2021 new baseline)
                      34834.999, #2026D76 ttbar premixing stage1+stage2, PU50

--- a/SimGeneral/PreMixingModule/python/mixOne_premix_on_sim_cfi.py
+++ b/SimGeneral/PreMixingModule/python/mixOne_premix_on_sim_cfi.py
@@ -302,7 +302,6 @@ phase2_hfnose.toModify(mixData,
     )
 )
 
-
 # Muon
 phase2_muon.toModify(mixData,
     workers = dict(
@@ -313,4 +312,12 @@ phase2_muon.toModify(mixData,
             collectionDM = cms.string("g4SimHitsMuonME0Hits"),
         ),
     )
+)
+
+# Disable GE0 (as introduced in #31309)
+from Configuration.Eras.Modifier_phase2_GE0_cff import phase2_GE0
+phase2_GE0.toModify(mixData,
+    workers = dict(
+        me0 = None,
+    ),
 )

--- a/SimGeneral/PreMixingModule/python/mixOne_premix_on_sim_cfi.py
+++ b/SimGeneral/PreMixingModule/python/mixOne_premix_on_sim_cfi.py
@@ -207,6 +207,7 @@ from Configuration.Eras.Modifier_phase2_hcal_cff import phase2_hcal
 from Configuration.Eras.Modifier_phase2_hgcal_cff import phase2_hgcal
 from Configuration.Eras.Modifier_phase2_hfnose_cff import phase2_hfnose
 from Configuration.Eras.Modifier_phase2_muon_cff import phase2_muon
+from Configuration.Eras.Modifier_phase2_GE0_cff import phase2_GE0
 phase2_common.toModify(mixData, input = dict(producers = [])) # we use digis directly, no need for raw2digi producers
 
 # Tracker
@@ -303,7 +304,7 @@ phase2_hfnose.toModify(mixData,
 )
 
 # Muon
-phase2_muon.toModify(mixData,
+(phase2_muon & ~phase2_GE0).toModify(mixData,
     workers = dict(
         me0 = cms.PSet(
             workerType = cms.string("PreMixingCrossingFramePSimHitWorker"),
@@ -314,10 +315,3 @@ phase2_muon.toModify(mixData,
     )
 )
 
-# Disable GE0 (as introduced in #31309)
-from Configuration.Eras.Modifier_phase2_GE0_cff import phase2_GE0
-phase2_GE0.toModify(mixData,
-    workers = dict(
-        me0 = None,
-    ),
-)

--- a/SimGeneral/TrackingAnalysis/python/TrackingParticleSelection_cfi.py
+++ b/SimGeneral/TrackingAnalysis/python/TrackingParticleSelection_cfi.py
@@ -68,5 +68,6 @@ run3_GEM.toModify(trackingParticleSelection, simHitCollections = dict(
         muon = trackingParticleSelection.simHitCollections.muon+["g4SimHitsMuonGEMHits"]))
 
 from Configuration.Eras.Modifier_phase2_muon_cff import phase2_muon
-phase2_muon.toModify( trackingParticleSelection, simHitCollections = dict(
+from Configuration.Eras.Modifier_phase2_GE0_cff import phase2_GE0
+(phase2_muon & ~phase2_GE0).toModify( trackingParticleSelection, simHitCollections = dict(
         muon = trackingParticleSelection.simHitCollections.muon+["g4SimHitsMuonME0Hits"]))


### PR DESCRIPTION
#### PR description:
This PR is to add D76 (NoPU, premixing) to the short matrix for the IB test, as a new baseline geometry. In addition, the PR also disable using ME0 when phase2_GE0 is used (as it is part of the GEM container already).

#### PR validation:
`runTheMatrix.py -w upgrade -l 34634.0,34834.999 --wm init`

#### if this PR is a backport please specify the original PR and why you need to backport that PR:
Not a backport, and backport is not needed.
