### PR TITLE
Improve CSC digi print-out

### DIFF
--- a/DataFormats/CSCDigi/src/CSCComparatorDigi.cc
+++ b/DataFormats/CSCDigi/src/CSCComparatorDigi.cc
@@ -95,14 +95,13 @@ void CSCComparatorDigi::print() const {
   std::ostringstream ost;
   ost << "CSCComparatorDigi | strip " << getStrip() << " | comparator " << getComparator() << " | first time bin "
       << getTimeBin() << " | time bins on ";
-  std::vector<int> tbins = getTimeBinsOn();
-  for (unsigned int i = 0; i < tbins.size(); i++) {
-    ost << tbins[i] << " ";
-  }
+  std::copy(getTimeBinsOn().begin(), getTimeBinsOn().end(), std::ostream_iterator<int>(ost, " "));
   edm::LogVerbatim("CSCDigi") << ost.str();
 }
 
-//@@ Doesn't print all time bins
 std::ostream& operator<<(std::ostream& o, const CSCComparatorDigi& digi) {
-  return o << " " << digi.getStrip() << " " << digi.getComparator() << " " << digi.getTimeBin();
+  o << "CSCComparatorDigi Strip:" << digi.getStrip() << ", Comparator: " << digi.getComparator()
+    << ", First Time Bin On: " << digi.getTimeBin() << ", Time Bins On: ";
+  std::copy(digi.getTimeBinsOn().begin(), digi.getTimeBinsOn().end(), std::ostream_iterator<int>(o, " "));
+  return o;
 }

--- a/DataFormats/CSCDigi/src/CSCWireDigi.cc
+++ b/DataFormats/CSCDigi/src/CSCWireDigi.cc
@@ -67,18 +67,12 @@ void CSCWireDigi::print() const {
       << " BX # " << getWireGroupBX() << " | "
       << " BX + Wire " << std::hex << getBXandWireGroup() << " | " << std::dec << " First Time Bin On " << getTimeBin()
       << " | Time Bins On ";
-  std::vector<int> tbins = getTimeBinsOn();
-  for (unsigned int i = 0; i < tbins.size(); i++) {
-    ost << tbins[i] << " ";
-  }
+  std::copy(getTimeBinsOn().begin(), getTimeBinsOn().end(), std::ostream_iterator<int>(ost, " "));
   edm::LogVerbatim("CSCDigi") << ost.str();
 }
 
 std::ostream& operator<<(std::ostream& o, const CSCWireDigi& digi) {
-  o << " CSC Wire " << digi.getWireGroup() << " CSC Wire First Time Bin On " << digi.getTimeBin()
-    << " CSC Time Bins On ";
-  for (unsigned int i = 0; i < digi.getTimeBinsOn().size(); ++i) {
-    o << " " << digi.getTimeBinsOn()[i];
-  }
+  o << " CSCWireDigi wg: " << digi.getWireGroup() << ", First Time Bin On: " << digi.getTimeBin() << ", Time Bins On: ";
+  std::copy(digi.getTimeBinsOn().begin(), digi.getTimeBinsOn().end(), std::ostream_iterator<int>(o, " "));
   return o;
 }


### PR DESCRIPTION
#### PR description:

Improve CSC digi print-out. 

#### PR validation:

Code compiles. Tested with 11634.0.

```
11634.0_TTbar_14TeV+2021+TTbar_14TeV_TuneCP5_GenSim+Digi+Reco+HARVEST+ALCA Step0-PASSED Step1-PASSED Step2-PASSED Step3-PASSED Step4-PASSED  - time date Fri Feb 26 12:39:02 2021-date Fri Feb 26 11:57:24 2021; exit: 0 0 0 0 0
1 1 1 1 1 tests passed, 0 0 0 0 0 failed
```

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A