### PR TITLE
[DD4hep] Correct name of material for PixelBarrelLayerNCoolTubeHalf volumes

### DIFF
--- a/Geometry/TrackerCommonData/plugins/dd4hep/DDPixBarLayerUpgradeAlgo.cc
+++ b/Geometry/TrackerCommonData/plugins/dd4hep/DDPixBarLayerUpgradeAlgo.cc
@@ -22,7 +22,7 @@ static long algorithm(dd4hep::Detector&, cms::DDParsingContext& ctxt, xml_h e) {
   std::string coolMat = args.value<std::string>("CoolMaterial");
   std::string tubeMat = args.value<std::string>("CoolTubeMaterial");
   std::string coolMatHalf = args.value<std::string>("CoolMaterialHalf");
-  std::string tubeMatHalf = args.value<std::string>("CoolTubeMaterial");
+  std::string tubeMatHalf = args.value<std::string>("CoolTubeMaterialHalf");
   double phiFineTune = args.value<double>("PitchFineTune");
   double rOuterFineTune = args.value<double>("OuterOffsetFineTune");
   double rInnerFineTune = args.value<double>("InnerOffsetFineTune");


### PR DESCRIPTION
In old DD, `PixelBarrelLayerNCoolTubeHalf` (where N = 0 to 3) volumes are composed of `Bpix_Pipe_Steel_Half`. However, with DD4hep, these volumes were composed of `Bpix_Pipe_Steel`. One way this difference appeared was that the `Bpix_Pipe_Steel_Half` material cut couple was missing with DD4hep.

Looking in the code, one can see that the `tubeMatHalf` variable, which sets the material for these volumes, is set to `CoolTubeMaterialHalf` in the old DD code, while it was set to `CoolTubeMaterial` in the DD4hep code, which looks like a simple typo.

#### PR validation:
With this fix, with DD4hep the `PixelBarrelLayerNCoolTubeHalf` volumes are now properly composed of `Bpix_Pipe_Steel_Half`, and the corresponding material cut couple also appears, just as in the old DD.
These two configs were used for validation:
```
SimG4Core/PrintGeomInfo/test/python/g4OverlapCheck_cfg.py
SimG4Core/PrintGeomInfo/test/python/g4OverlapCheckDD4Hep_cfg.py
```

No backport is needed.