### PR TITLE
[RPC] Bug fix DQM/RPCMonitorClient crash due to type conversion -1 to unsigned int

### DIFF
--- a/DQM/RPCMonitorClient/interface/RPCDcsInfoClient.h
+++ b/DQM/RPCMonitorClient/interface/RPCDcsInfoClient.h
@@ -8,18 +8,16 @@
 class RPCDcsInfoClient : public DQMEDHarvester {
 public:
   RPCDcsInfoClient(const edm::ParameterSet &ps);
-  ~RPCDcsInfoClient() override;
+  ~RPCDcsInfoClient() override = default;
 
 protected:
-  void beginJob() override;
   void dqmEndJob(DQMStore::IBooker &, DQMStore::IGetter &) override;  //performed in the endJob
 
 private:
-  std::string dcsinfofolder_;
-  std::string eventinfofolder_;
-  std::string dqmprovinfofolder_;
+  const std::string dcsinfofolder_;
+  const std::string eventinfofolder_;
+  const std::string dqmprovinfofolder_;
 
-  std::vector<int> DCS;
 };
 
 #endif

--- a/DQM/RPCMonitorClient/python/RPCDcsInfoClient_cfi.py
+++ b/DQM/RPCMonitorClient/python/RPCDcsInfoClient_cfi.py
@@ -3,6 +3,5 @@ from DQMServices.Core.DQMEDHarvester import DQMEDHarvester
 
 rpcDcsInfoClient = DQMEDHarvester("RPCDcsInfoClient",
                                   dcsInfoFolder = cms.untracked.string("RPC/DCSInfo"),
-                                  eventInfoFolder = cms.untracked.string("RPC/EventInfo"),
                                   dqmProvInfoFolder = cms.untracked.string("Info/EventInfo")
                                   )

--- a/DQM/RPCMonitorClient/src/RPCDcsInfoClient.cc
+++ b/DQM/RPCMonitorClient/src/RPCDcsInfoClient.cc
@@ -1,68 +1,67 @@
 #include "DQM/RPCMonitorClient/interface/RPCDcsInfoClient.h"
 #include "FWCore/Framework/interface/LuminosityBlock.h"
 
-RPCDcsInfoClient::RPCDcsInfoClient(const edm::ParameterSet& ps) {
-  dcsinfofolder_ = ps.getUntrackedParameter<std::string>("dcsInfoFolder", "RPC/DCSInfo");
-  eventinfofolder_ = ps.getUntrackedParameter<std::string>("eventInfoFolder", "RPC/EventInfo");
-  dqmprovinfofolder_ = ps.getUntrackedParameter<std::string>("dqmProvInfoFolder", "Info/EventInfo");
-
-  DCS.clear();
+RPCDcsInfoClient::RPCDcsInfoClient(const edm::ParameterSet& ps):
+  dcsinfofolder_(ps.getUntrackedParameter<std::string>("dcsInfoFolder", "RPC/DCSInfo")),
+  eventinfofolder_(ps.getUntrackedParameter<std::string>("eventInfoFolder", "RPC/EventInfo")),
+  dqmprovinfofolder_(ps.getUntrackedParameter<std::string>("dqmProvInfoFolder", "Info/EventInfo"))
+{
 }
-
-RPCDcsInfoClient::~RPCDcsInfoClient() {}
-
-void RPCDcsInfoClient::beginJob() {}
 
 void RPCDcsInfoClient::dqmEndJob(DQMStore::IBooker& ibooker, DQMStore::IGetter& igetter) {
   // book
   ibooker.cd();
   ibooker.setCurrentFolder(dcsinfofolder_);
 
-  MonitorElement* reportSummaryMap_ = igetter.get(dqmprovinfofolder_ + "/reportSummaryMap");
+  MonitorElement* reportSummaryMap = igetter.get(dqmprovinfofolder_ + "/reportSummaryMap");
+  MonitorElement* eventInfoLumi = igetter.get(eventinfofolder_+"/iLumiSection");
 
-  if (!reportSummaryMap_)
+  if (!reportSummaryMap)
     return;
 
-  if (TH2F* h2 = reportSummaryMap_->getTH2F()) {
-    int hvStatus = 0;
-    const char* label_name = "RPC";
-    unsigned int rpc_num = 0;
-    const int nlsmax = h2->GetXaxis()->GetNbins();
+  TH2F* h2 = reportSummaryMap->getTH2F();
+  if ( !h2 ) return;
+  const int maxLS = reportSummaryMap->getNbinsX();
 
-    for (int ybin = 0; ybin < h2->GetNbinsY(); ++ybin) {
-      if (strcmp(h2->GetYaxis()->GetBinLabel(ybin + 1), label_name) == 0)
-        rpc_num = ybin + 1;
-    }
-
-    for (int nlumi = 0; nlumi < nlsmax; ++nlumi) {
-      int rpc_dcsbit = h2->GetBinContent(nlumi + 1, rpc_num);
-      if (rpc_dcsbit != -1) {
-        hvStatus = 1;  // set to 1 because HV was on (!)
-      } else {
-        hvStatus = 0;  // set to 0 because HV was off (!)
-      }
-      DCS.push_back(hvStatus);
+  int nLS = eventInfoLumi->getIntValue();
+  if ( nLS <= 0 or nLS > maxLS ) {
+    // If the nLS from the event info is not valid, we take the value from the
+    // reportSummaryMap. The histogram is initialized with -1 value then filled
+    // with non-negative value for valid LSs.
+    // Note that we start from the first bin, since many runs have small nLS.
+    for ( nLS=1; nLS<=maxLS; ++nLS ) {
+      const double dcsBit = h2->GetBinContent(nLS, 1);
+      if ( dcsBit == -1 ) break;
     }
   }
-
-  std::string meName = dcsinfofolder_ + "/rpcHVStatus";
-  unsigned int dcssize = DCS.size();
-  MonitorElement* rpcHVStatus = ibooker.book2D("rpcHVStatus", "RPC HV Status", dcssize, 1., dcssize + 1, 1, 0.5, 1.5);
+  
+  MonitorElement* rpcHVStatus = ibooker.book2D("rpcHVStatus", "RPC HV Status", nLS, 1., nLS+1, 1, 0.5, 1.5);
   rpcHVStatus->setAxisTitle("Luminosity Section", 1);
   rpcHVStatus->setBinLabel(1, "", 2);
 
-  const unsigned int nlsmax = DCS.size();
-  int lsCounter = 0;
-  // fill
-  for (unsigned int i = 0; i < nlsmax; i++) {
-    rpcHVStatus->setBinContent(i + 1, 1, DCS[i]);
-    lsCounter += DCS[i];
+  // Find bin number of RPC from the EventInfo's reportSummaryMap
+  int binRPC = 0;
+  for ( int i=1, nbinsY=reportSummaryMap->getNbinsY(); i<=nbinsY; ++i ) {
+    const std::string binLabel = h2->GetYaxis()->GetBinLabel(i);
+    if ( binLabel == "RPC" ) {
+      binRPC = i;
+      break;
+    }
+  }
+  if ( binRPC == 0 ) return;
+
+  // Take bin contents from the reportSummaryMap and fill into the RPC DCSInfo
+  int nLSRPC = 0;
+  for ( int i=1; i<=nLS; ++i ) {
+    const double dcsBit = h2->GetBinContent(i, binRPC);
+    const int hvStatus = (dcsBit != -1) ? 1 : 0;
+    if ( hvStatus != 0 ) {
+      ++nLSRPC;
+      rpcHVStatus->setBinContent(i, 1, hvStatus);
+    }
   }
 
-  meName = dcsinfofolder_ + "/rpcHV";
   MonitorElement* rpcHV = ibooker.bookInt("rpcHV");
+  rpcHV->Fill(nLSRPC);
 
-  rpcHV->Fill(lsCounter);
-
-  return;
 }


### PR DESCRIPTION
#### PR description:
From #31056,  the maximum luminosity section number(nlsmax) is taken from the iLumiSection which is saved in RPC/EventInfo.
Then this value is used in for loop for filling the RPC DCS histogram with unsigned int counter variable.
Commonly, it does not make a crash, but it makes a crash when the luminosity section is -1(default value).

Therefore, to avoid this crash, the counter variable is set as the integer and the nlsmax is taken from the report summary map histogram.

This solution comes from Junghwan Goh(@jhgoh).

#### PR validation:
Tested by the following recipe.
    1.tar xzf /afs/cern.ch/user/c/cmst0/public/PausedJobs/Tarballs/job_75141/a75a3540-ffc0-47d7-a47e-09affc7202a8-EndOfRun-Harvest-1-3-logArchive.tar.gz
    2. cd job/WMTaskSpace/cmsRun1/
    3.cmsRun PSet.py
Also, tested by runTheMatrix.py -l 7.23 and 7.24 with single-thread.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

@andresib @jhgoh @jfernan2
I make the new PR about the DQM/RPCMonitorClient bug fix.

Backport of:  #33115