### PR TITLE
Utilities/StaticAnalyzer: Add check for func name in DiGraph before calling has_path.

### DIFF
--- a/Utilities/StaticAnalyzers/scripts/callgraph.py
+++ b/Utilities/StaticAnalyzers/scripts/callgraph.py
@@ -43,7 +43,7 @@ print()
 callstacks=set()
 for tfunc in sorted(toplevelfuncs):
         for epfunc in sorted(epfuncs):
-		if tfunc in G and epfunc in G and nx.has_path(G,tfunc,epfunc) : 
+		if G.has_node(tfunc) and G.has_node(epfunc) and nx.has_path(G,tfunc,epfunc) : 
 			path = nx.shortest_path(G,tfunc,epfunc)
 			cs=""
                         previous=str("")

--- a/Utilities/StaticAnalyzers/scripts/callgraph.py
+++ b/Utilities/StaticAnalyzers/scripts/callgraph.py
@@ -43,7 +43,7 @@ print()
 callstacks=set()
 for tfunc in sorted(toplevelfuncs):
         for epfunc in sorted(epfuncs):
-		if nx.has_path(G,tfunc,epfunc) : 
+		if tfunc in G and epfunc in G and nx.has_path(G,tfunc,epfunc) : 
 			path = nx.shortest_path(G,tfunc,epfunc)
 			cs=""
                         previous=str("")

--- a/Utilities/StaticAnalyzers/scripts/create_statics_esd_reports.sh
+++ b/Utilities/StaticAnalyzers/scripts/create_statics_esd_reports.sh
@@ -50,6 +50,7 @@ if [ ! -f ./callgraph.py ]
    cp -pv ${CMSSW_BASE}/src/Utilities/StaticAnalyzers/scripts/callgraph.py .
    cp -pv ${CMSSW_BASE}/src/Utilities/StaticAnalyzers/scripts/modules_in_ib.txt .
 fi
+touch eventsetuprecord-get-all.txt eventsetuprecord-get.txt
 ./callgraph.py 2>&1 > eventsetuprecord-get-all.txt
 grep -f modules_in_ib.txt eventsetuprecord-get-all.txt | awk '{print $0"\n"}' > eventsetuprecord-get.txt
 

--- a/Utilities/StaticAnalyzers/scripts/data-class-funcs.py
+++ b/Utilities/StaticAnalyzers/scripts/data-class-funcs.py
@@ -150,7 +150,7 @@ print()
 
 for badclass in sorted(badclasses):
 	for dataclass in sorted(dataclasses):
-		if  tfunc in H and dataclassfunc in H and H.has_node(badclass) and H.has_node(dataclass):
+		if H.has_node(badclass) and H.has_node(dataclass):
 			if nx.has_path(H,dataclass, badclass) :
 				print("Event setup data class '"+dataclass+"' contains or inherits from flagged class '"+badclass+"'.")
 				flaggedclasses.add(dataclass)
@@ -160,7 +160,7 @@ print()
 
 for dataclassfunc in sorted(dataclassfuncs):
 	for tfunc in sorted(toplevelfuncs):
-		if tfunc in G and dataclassfunc in G and nx.has_path(G,tfunc,dataclassfunc):
+		if G.has_node(tfunc) and G.has_node(dataclassfunc) and nx.has_path(G,tfunc,dataclassfunc):
 			m = getfunc.match(dataclassfunc)
 			n = handle.match(m.group(1))
 			if n : o = n.group(3)

--- a/Utilities/StaticAnalyzers/scripts/data-class-funcs.py
+++ b/Utilities/StaticAnalyzers/scripts/data-class-funcs.py
@@ -92,7 +92,7 @@ for line in fileinput.input(files =('function-statics-db.txt','function-calls-db
 		statics.add(fields[3])
 fileinput.close()
 
-for n,nbrdict in G.adjacency_iter():
+for n,nbrdict in G.adjacency():
 	for nbr,eattr in nbrdict.items():
 		if n in badfuncs or nbr in badfuncs :
 			if 'kind' in eattr and eattr['kind'] == ' overrides function '  :
@@ -100,13 +100,13 @@ for n,nbrdict in G.adjacency_iter():
 				virtfuncs.add(nbr)
 print()
 
-for n,nbrdict in H.adjacency_iter():
+for n,nbrdict in H.adjacency():
 	for nbr,eattr in nbrdict.items():
 		if n in badclasses and 'kind' in eattr and eattr['kind'] == ' base class '  :
 			virtclasses.add(nbr)
 
 
-for n,nbrdict in H.adjacency_iter():
+for n,nbrdict in H.adjacency():
 	for nbr,eattr in nbrdict.items():
 		if nbr in dclasses and 'kind' in eattr and eattr['kind'] == ' base class '  :
 			dclasses.add(n)

--- a/Utilities/StaticAnalyzers/scripts/data-class-funcs.py
+++ b/Utilities/StaticAnalyzers/scripts/data-class-funcs.py
@@ -150,7 +150,7 @@ print()
 
 for badclass in sorted(badclasses):
 	for dataclass in sorted(dataclasses):
-		if H.has_node(badclass) and H.has_node(dataclass):
+		if  tfunc in H and dataclassfunc in H and H.has_node(badclass) and H.has_node(dataclass):
 			if nx.has_path(H,dataclass, badclass) :
 				print("Event setup data class '"+dataclass+"' contains or inherits from flagged class '"+badclass+"'.")
 				flaggedclasses.add(dataclass)
@@ -160,7 +160,7 @@ print()
 
 for dataclassfunc in sorted(dataclassfuncs):
 	for tfunc in sorted(toplevelfuncs):
-		if nx.has_path(G,tfunc,dataclassfunc):
+		if tfunc in G and dataclassfunc in G and nx.has_path(G,tfunc,dataclassfunc):
 			m = getfunc.match(dataclassfunc)
 			n = handle.match(m.group(1))
 			if n : o = n.group(3)

--- a/Utilities/StaticAnalyzers/scripts/edm-global-class.py
+++ b/Utilities/StaticAnalyzers/scripts/edm-global-class.py
@@ -96,7 +96,7 @@ fileinput.close()
 
 
 
-for n,nbrdict in G.adjacency_iter():
+for n,nbrdict in G.adjacency():
 	for nbr,eattr in nbrdict.items():
 		if n in badfuncs or nbr in badfuncs :
 			if 'kind' in eattr and eattr['kind'] == ' overrides function '  :

--- a/Utilities/StaticAnalyzers/scripts/statics.py
+++ b/Utilities/StaticAnalyzers/scripts/statics.py
@@ -40,7 +40,7 @@ fileinput.close()
 
 for tfunc in sorted(toplevelfuncs):
 	for static in sorted(statics):
-		if nx.has_path(G,tfunc,static): 
+		if tfunc in G and static in G and nx.has_path(G,tfunc,static): 
 			path = nx.shortest_path(G,tfunc,static)
 
 			print("Non-const static variable \'"+re.sub(farg,"()",static)+"' is accessed in call stack '", end=' ')

--- a/Utilities/StaticAnalyzers/scripts/statics.py
+++ b/Utilities/StaticAnalyzers/scripts/statics.py
@@ -40,7 +40,7 @@ fileinput.close()
 
 for tfunc in sorted(toplevelfuncs):
 	for static in sorted(statics):
-		if tfunc in G and static in G and nx.has_path(G,tfunc,static): 
+		if G.has_node(tfunc) and G.has_node(static) and nx.has_path(G,tfunc,static): 
 			path = nx.shortest_path(G,tfunc,static)
 
 			print("Non-const static variable \'"+re.sub(farg,"()",static)+"' is accessed in call stack '", end=' ')


### PR DESCRIPTION
Resolves https://github.com/makortel/framework/issues/56

Fix for error in generating report from static analyzers:
```
+ ./create_statics_esd_reports.sh
Traceback (most recent call last):
  File "./data-class-funcs.py", line 95, in <module>
    for n,nbrdict in G.adjacency_iter():
AttributeError: 'DiGraph' object has no attribute 'adjacency_iter'
Traceback (most recent call last):
  File "./statics.py", line 43, in <module>
    if nx.has_path(G,tfunc,static): 
  File "/cvmfs/cms-ib.cern.ch/nweek-02669/slc7_amd64_gcc900/external/py2-networkx/2.2-ljfedo/lib/python2.7/site-packages/networkx/algorithms/shortest_paths/generic.py", line 40, in has_path
    nx.shortest_path(G, source, target)
  File "/cvmfs/cms-ib.cern.ch/nweek-02669/slc7_amd64_gcc900/external/py2-networkx/2.2-ljfedo/lib/python2.7/site-packages/networkx/algorithms/shortest_paths/generic.py", line 170, in shortest_path
    paths = nx.bidirectional_shortest_path(G, source, target)
  File "/cvmfs/cms-ib.cern.ch/nweek-02669/slc7_amd64_gcc900/external/py2-networkx/2.2-ljfedo/lib/python2.7/site-packages/networkx/algorithms/shortest_paths/unweighted.py", line 223, in bidirectional_shortest_path
    raise nx.NodeNotFound(msg.format(source, target))
networkx.exception.NodeNotFound: Either source edm::EventProcessor::beginRun(const edm::ProcessHistoryID &, edm::RunNumber_t, _Bool &, _Bool &) or target (anonymous namespace)::ChannelStatus is not in G
Traceback (most recent call last):
  File "/pool/condor/dir_27113/jenkins/workspace/ib-run-static-checks/CMSSW_11_3_X_2021-02-27-1100/bin/slc7_amd64_gcc900/edm-global-class.py", line 99, in <module>
    for n,nbrdict in G.adjacency_iter():
AttributeError: 'DiGraph' object has no attribute 'adjacency_iter'
 ```
