### PR TITLE
Remove not needed RooFit dependencies from BuildFiles

### DIFF
--- a/CalibMuon/DTCalibration/BuildFile.xml
+++ b/CalibMuon/DTCalibration/BuildFile.xml
@@ -11,12 +11,9 @@
 <use name="root"/>
 <use name="rootmath"/>
 <use name="rootcore"/>
-<use name="roofit"/>
 <export>
   <lib name="1"/>
   <use name="root"/>
   <use name="rootmath"/>
   <use name="rootcore"/>
-  <use name="rootroofit"/>
-  <use name="roofit"/>
 </export>

--- a/CalibMuon/DTCalibration/plugins/BuildFile.xml
+++ b/CalibMuon/DTCalibration/plugins/BuildFile.xml
@@ -12,7 +12,7 @@
 <use name="root"/>
 <use name="rootmath"/>
 <use name="rootcore"/>
-<use name="roofit"/>
+<use name="rootfitcore"/>
 <use name="rootgraphics"/>
 <lib name="Spectrum"/>
 <library file="*.cc" name="CalibMuonDTCalibrationPlugins">

--- a/DQM/MuonMonitor/plugins/BuildFile.xml
+++ b/DQM/MuonMonitor/plugins/BuildFile.xml
@@ -9,6 +9,5 @@
   <use name="FWCore/PluginManager"/>
   <use name="FWCore/ServiceRegistry"/>
   <use name="FWCore/Utilities"/>
-  <use name="roofitcore"/>
   <flags EDM_PLUGIN="1"/>
 </library>

--- a/HeavyFlavorAnalysis/Onia2MuMu/BuildFile.xml
+++ b/HeavyFlavorAnalysis/Onia2MuMu/BuildFile.xml
@@ -4,7 +4,6 @@
 <use name="root"/>
 <use name="rootmath"/>
 <use name="rootcore"/>
-<use name="roofit"/>
 <use name="hepmc"/>
 <use name="DataFormats/HepMCCandidate"/>
 <use name="DataFormats/Candidate"/>

--- a/L1Trigger/DTTriggerPhase2/BuildFile.xml
+++ b/L1Trigger/DTTriggerPhase2/BuildFile.xml
@@ -9,7 +9,6 @@
 <use name="Geometry/DTGeometry"/>
 <use name="Geometry/RPCGeometry"/>
 <use name="Geometry/Records"/>
-<use name="roofitcore"/>
 <use name="vdt"/>
 <export>
   <lib name="1"/>

--- a/PhysicsTools/FWLite/test/BuildFile.xml
+++ b/PhysicsTools/FWLite/test/BuildFile.xml
@@ -8,7 +8,7 @@
   <bin name="testScanner.exe" file="testScanner.cc">
     <flags NO_TESTRUN="1"/>
     <use name="root"/>
-    <use name="roofit"/>
+    <use name="roofitcore"/>
     <use name="rootgraphics"/>
     <use name="FWCore/FWLite"/>
     <use name="DataFormats/TrackReco"/>

--- a/PhysicsTools/TagAndProbe/BuildFile.xml
+++ b/PhysicsTools/TagAndProbe/BuildFile.xml
@@ -1,4 +1,4 @@
-<use name="roofit"/>
+<use name="roofitcore"/>
 <use name="FWCore/MessageLogger"/>
 <use name="FWCore/ParameterSet"/>
 <use name="DataFormats/METReco"/>

--- a/PhysicsTools/TagAndProbe/plugins/BuildFile.xml
+++ b/PhysicsTools/TagAndProbe/plugins/BuildFile.xml
@@ -2,7 +2,6 @@
 </export>
 <library name="PhysicsToolsTagAndProbe_plugins" file="*.cc">
   <flags EDM_PLUGIN="1"/>
-  <use name="roofit"/>
   <use name="FWCore/Framework"/>
   <use name="FWCore/MessageLogger"/>
   <use name="FWCore/ParameterSet"/>

--- a/PhysicsTools/Utilities/BuildFile.xml
+++ b/PhysicsTools/Utilities/BuildFile.xml
@@ -3,7 +3,7 @@
 <use name="FWCore/Utilities"/>
 <use name="FWCore/Common"/>
 <use name="SimDataFormats/PileupSummaryInfo"/>
-<use name="roofit"/>
+<use name="roofitcore"/>
 <use name="rootcore"/>
 <use name="root"/>
 <use name="boost"/>

--- a/PhysicsTools/Utilities/test/BuildFile.xml
+++ b/PhysicsTools/Utilities/test/BuildFile.xml
@@ -34,7 +34,7 @@
 
 <bin file="testRooFitFunction.cpp" name="testRooFitFunction">
   <use name="PhysicsTools/Utilities"/>
-  <use name="roofit"/>
+  <use name="roofitcore"/>
 </bin>
 
 <bin file="testIntegralTiming.cpp" name="testIntegralTiming">


### PR DESCRIPTION
#### PR description:

Another quick BuildFile cleaning PR in the style of many before (for example https://github.com/cms-sw/cmssw/pull/32762).

This one targets all the `roofit` and `roofitcore` dependencies so we can better keep track where RooFit is used.

#### PR validation:

CMSSW compiles.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

No backport intended.