### PR TITLE
Changes for TensorFlow 2.4 support.

### DIFF
--- a/PhysicsTools/TensorFlow/test/testBase.h
+++ b/PhysicsTools/TensorFlow/test/testBase.h
@@ -29,7 +29,7 @@ void testBase::setUp() {
 
   // create the graph
   std::string testPath = cmsswPath("/src/PhysicsTools/TensorFlow/test");
-  std::string cmd = "python " + testPath + "/" + pyScript() + " " + dataPath_;
+  std::string cmd = "python3 " + testPath + "/" + pyScript() + " " + dataPath_;
   std::array<char, 128> buffer;
   std::string result;
   std::shared_ptr<FILE> pipe(popen(cmd.c_str(), "r"), pclose);


### PR DESCRIPTION
#### PR description

TensorFlow is going to be updated to version 2.4.1 in https://github.com/cms-sw/cmsdist/pull/6674 (superseding https://github.com/cms-sw/cmsdist/pull/6545), which drops Python 2 support.

_This_ PR updates the TF test cases to use Python 3 instead. Currently, no changes to the C++ interface are required.

#### PR validation

All existing TF test cases pass. https://github.com/cms-sw/cmsdist/pull/6674 is required to run validation builds.