### PR TITLE
address high-pt efficiency drop in EB EG objects - fix hardcoding

### DIFF
--- a/L1Trigger/L1CaloTrigger/plugins/L1EGammaCrystalsEmulatorProducer.cc
+++ b/L1Trigger/L1CaloTrigger/plugins/L1EGammaCrystalsEmulatorProducer.cc
@@ -1177,12 +1177,13 @@ void L1EGCrystalClusterEmulatorProducer::produce(edm::Event& iEvent, const edm::
 }
 
 bool L1EGCrystalClusterEmulatorProducer::passes_iso(float pt, float iso) {
+  bool is_iso = true;
   if (pt < slideIsoPtThreshold) {
     if (!((a0_80 - a1_80 * pt) > iso))
-      return false;
+      is_iso = false;
   } else {
     if (iso > a0)
-      return false;
+      is_iso = false;
   }
   if (pt > plateau_ss)
     is_iso = true;

--- a/L1Trigger/L1CaloTrigger/plugins/L1EGammaCrystalsEmulatorProducer.cc
+++ b/L1Trigger/L1CaloTrigger/plugins/L1EGammaCrystalsEmulatorProducer.cc
@@ -78,6 +78,7 @@ static constexpr int n_GCTcards = 3;
 static constexpr float ECAL_eta_range = 1.4841;
 static constexpr float half_crystal_size = 0.00873;
 static constexpr float slideIsoPtThreshold = 80;
+static constexpr float plateau_ss = 130.0;
 static constexpr float a0_80 = 0.85, a1_80 = 0.0080, a0 = 0.21;                        // passes_iso
 static constexpr float b0 = 0.38, b1 = 1.9, b2 = 0.05;                                 //passes_looseTkiso
 static constexpr float c0_ss = 0.94, c1_ss = 0.052, c2_ss = 0.044;                     //passes_ss
@@ -1183,21 +1184,37 @@ bool L1EGCrystalClusterEmulatorProducer::passes_iso(float pt, float iso) {
     if (iso > a0)
       return false;
   }
-  return true;
+  if (pt > plateau_ss)
+    is_iso = true;
+  return is_iso;
 }
 
 bool L1EGCrystalClusterEmulatorProducer::passes_looseTkiso(float pt, float iso) {
-  return (b0 + b1 * std::exp(-b2 * pt) > iso);
+  bool is_iso = (b0 + b1 * std::exp(-b2 * pt) > iso);
+  if (pt > plateau_ss)
+    is_iso = true;
+  return is_iso;
 }
 
 bool L1EGCrystalClusterEmulatorProducer::passes_ss(float pt, float ss) {
-  return ((c0_ss + c1_ss * std::exp(-c2_ss * pt)) <= ss);
+  bool is_ss = ((c0_ss + c1_ss * std::exp(-c2_ss * pt)) <= ss);
+  if (pt > plateau_ss)
+    is_ss = true;
+  return is_ss;
 }
 
-bool L1EGCrystalClusterEmulatorProducer::passes_photon(float pt, float pss) { return (pss > d0 - d1 * pt); }
+bool L1EGCrystalClusterEmulatorProducer::passes_photon(float pt, float pss) {
+  bool is_ss = (pss > d0 - d1 * pt);
+  if (pt > plateau_ss)
+    is_ss = true;
+  return is_ss;
+}
 
 bool L1EGCrystalClusterEmulatorProducer::passes_looseTkss(float pt, float ss) {
-  return ((e0_looseTkss - e1_looseTkss * std::exp(-e2_looseTkss * pt)) <= ss);
+  bool is_ss = ((e0_looseTkss - e1_looseTkss * std::exp(-e2_looseTkss * pt)) <= ss);
+  if (pt > plateau_ss)
+    is_ss = true;
+  return is_ss;
 }
 
 //define this as a plug-in


### PR DESCRIPTION
#### PR description:

Backport from 11_3_X to fix the efficiency drop in the L1 EGamma reconstruction phase-2, caused by hit saturation.

#### PR validation:

This PR was already validated for 11_3_X and does not interfere with other files.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

https://github.com/cms-sw/cmssw/pull/32697/
Backport needed by EGamma group @Sam-Harper 
