### PR TITLE
For Tensorflow tests, use python3

### DIFF
--- a/PhysicsTools/TensorFlow/test/createconstantgraph.py
+++ b/PhysicsTools/TensorFlow/test/createconstantgraph.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 # coding: utf-8
 
 """

--- a/PhysicsTools/TensorFlow/test/creategraph.py
+++ b/PhysicsTools/TensorFlow/test/creategraph.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 # coding: utf-8
 
 """

--- a/PhysicsTools/TensorFlow/test/readconstantgraph.py
+++ b/PhysicsTools/TensorFlow/test/readconstantgraph.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 # coding: utf-8
 
 """

--- a/PhysicsTools/TensorFlow/test/testBase.h
+++ b/PhysicsTools/TensorFlow/test/testBase.h
@@ -29,7 +29,7 @@ void testBase::setUp() {
 
   // create the graph
   std::string testPath = cmsswPath("/src/PhysicsTools/TensorFlow/test");
-  std::string cmd = "python " + testPath + "/" + pyScript() + " " + dataPath_;
+  std::string cmd = testPath + "/" + pyScript() + " " + dataPath_;
   std::array<char, 128> buffer;
   std::string result;
   std::shared_ptr<FILE> pipe(popen(cmd.c_str(), "r"), pclose);


### PR DESCRIPTION
Just like many python packages, Tensorflow has deprecated python2. This PR suggest to use python3 for tensorflow tests.