### PR TITLE
disable LumiProducer in reco sequences

### DIFF
--- a/Configuration/StandardSequences/python/ReconstructionCosmics_cff.py
+++ b/Configuration/StandardSequences/python/ReconstructionCosmics_cff.py
@@ -2,7 +2,6 @@ import FWCore.ParameterSet.Config as cms
 #
 # luminosity
 #
-from RecoLuminosity.LumiProducer.lumiProducer_cff import *
 from RecoLuminosity.LumiProducer.bunchSpacingProducer_cfi import *
 # no bunchspacing in cosmics
 bunchSpacingProducer.overrideBunchSpacing= cms.bool(True)
@@ -53,9 +52,9 @@ caloCosmics_HcalNZS = cms.Sequence(caloCosmics_HcalNZSTask)
 muonsLocalRecoCosmicsTask = cms.Task(muonlocalrecoTask,muonlocalrecoT0SegTask)
 muonsLocalRecoCosmics = cms.Sequence(muonsLocalRecoCosmicsTask)
 
-localReconstructionCosmicsTask         = cms.Task(bunchSpacingProducer,trackerCosmicsTask,caloCosmicsTask,muonsLocalRecoCosmicsTask,vertexrecoCosmicsTask,lumiProducer)
+localReconstructionCosmicsTask         = cms.Task(bunchSpacingProducer,trackerCosmicsTask,caloCosmicsTask,muonsLocalRecoCosmicsTask,vertexrecoCosmicsTask)
 localReconstructionCosmics         = cms.Sequence(localReconstructionCosmicsTask)
-localReconstructionCosmics_HcalNZSTask = cms.Task(bunchSpacingProducer,trackerCosmicsTask,caloCosmics_HcalNZSTask,muonsLocalRecoCosmicsTask,vertexrecoCosmicsTask,lumiProducer)
+localReconstructionCosmics_HcalNZSTask = cms.Task(bunchSpacingProducer,trackerCosmicsTask,caloCosmics_HcalNZSTask,muonsLocalRecoCosmicsTask,vertexrecoCosmicsTask)
 localReconstructionCosmics_HcalNZS = cms.Sequence(localReconstructionCosmics_HcalNZSTask)
 
 

--- a/Configuration/StandardSequences/python/ReconstructionHeavyIons_cff.py
+++ b/Configuration/StandardSequences/python/ReconstructionHeavyIons_cff.py
@@ -31,7 +31,6 @@ from RecoHI.Configuration.Reconstruction_HI_cff import *
 from RecoHI.Configuration.Reconstruction_hiPF_cff import *
 from RecoLocalCalo.Castor.Castor_cff import *
 from RecoHI.HiEgammaAlgos.HiElectronSequence_cff import *
-from RecoLuminosity.LumiProducer.lumiProducer_cff import *
 #--------------------------------------------------------------------------
 
 from RecoPixelVertexing.PixelLowPtUtilities.siPixelClusterShapeCache_cfi import *

--- a/Configuration/StandardSequences/python/Reconstruction_cff.py
+++ b/Configuration/StandardSequences/python/Reconstruction_cff.py
@@ -1,6 +1,5 @@
 import FWCore.ParameterSet.Config as cms
 
-from RecoLuminosity.LumiProducer.lumiProducer_cff import *
 from RecoLuminosity.LumiProducer.bunchSpacingProducer_cfi import *
 from RecoLocalMuon.Configuration.RecoLocalMuon_cff import *
 from RecoLocalCalo.Configuration.RecoLocalCalo_cff import *


### PR DESCRIPTION
#### PR description:

Removes LumiProducer from reco sequences to move towards concurrent lumi processing from reco side.
Previous reco-related discussions are in https://github.com/cms-sw/cmssw/issues/32518.
The comment that initiated this is here: https://github.com/cms-sw/cmssw/issues/25090#issuecomment-746418195

#### PR validation:

I'm running the following on cmsdev20:
`runTheMatrix.py --command="--customise_commands=\"process.options.wantSummary=True\"" -j 12`
I expect to find no references to lumiProducer in the logfile summaries.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:
No backport is intended.
