### PR TITLE
HBHEgpu: add correlated noise

### DIFF
--- a/RecoLocalCalo/HcalRecProducers/src/DeclsForKernels.h
+++ b/RecoLocalCalo/HcalRecProducers/src/DeclsForKernels.h
@@ -99,7 +99,8 @@ namespace hcal {
     };
 
     struct ScratchDataGPU {
-      cms::cuda::device::unique_ptr<float[]> amplitudes, noiseTerms, electronicNoiseTerms, pulseMatrices, pulseMatricesM, pulseMatricesP;
+      cms::cuda::device::unique_ptr<float[]> amplitudes, noiseTerms, electronicNoiseTerms, pulseMatrices,
+          pulseMatricesM, pulseMatricesP;
       cms::cuda::device::unique_ptr<int8_t[]> soiSamples;
     };
 

--- a/RecoLocalCalo/HcalRecProducers/src/DeclsForKernels.h
+++ b/RecoLocalCalo/HcalRecProducers/src/DeclsForKernels.h
@@ -99,7 +99,7 @@ namespace hcal {
     };
 
     struct ScratchDataGPU {
-      cms::cuda::device::unique_ptr<float[]> amplitudes, noiseTerms, pulseMatrices, pulseMatricesM, pulseMatricesP;
+      cms::cuda::device::unique_ptr<float[]> amplitudes, noiseTerms, electronicNoiseTerms, pulseMatrices, pulseMatricesM, pulseMatricesP;
       cms::cuda::device::unique_ptr<int8_t[]> soiSamples;
     };
 

--- a/RecoLocalCalo/HcalRecProducers/src/HBHERecHitProducerGPU.cc
+++ b/RecoLocalCalo/HcalRecProducers/src/HBHERecHitProducerGPU.cc
@@ -214,6 +214,8 @@ void HBHERecHitProducerGPU::acquire(edm::Event const& event,
                                              ctx.stream()),
       cms::cuda::make_device_unique<float[]>(configParameters_.maxChannels * configParameters_.maxTimeSamples,
                                              ctx.stream()),
+      cms::cuda::make_device_unique<float[]>(configParameters_.maxChannels * configParameters_.maxTimeSamples,
+                                             ctx.stream()),
       cms::cuda::make_device_unique<float[]>(
           configParameters_.maxChannels * configParameters_.maxTimeSamples * configParameters_.maxTimeSamples,
           ctx.stream()),

--- a/RecoLocalCalo/HcalRecProducers/src/MahiGPU.cu
+++ b/RecoLocalCalo/HcalRecProducers/src/MahiGPU.cu
@@ -826,7 +826,8 @@ namespace hcal {
       // map views
       Eigen::Map<const calo::multifit::ColumnVector<NSAMPLES>> inputAmplitudesView{inputAmplitudes + gch * NSAMPLES};
       Eigen::Map<const calo::multifit::ColumnVector<NSAMPLES>> noiseTermsView{noiseTerms + gch * NSAMPLES};
-      Eigen::Map<const calo::multifit::ColumnVector<NSAMPLES>> noiseElectronicView{electronicNoiseTerms + gch * NSAMPLES};
+      Eigen::Map<const calo::multifit::ColumnVector<NSAMPLES>> noiseElectronicView{electronicNoiseTerms +
+                                                                                   gch * NSAMPLES};
       Eigen::Map<const calo::multifit::ColMajorMatrix<NSAMPLES, NPULSES>> glbPulseMatrixMView{pulseMatricesM +
                                                                                               gch * NSAMPLES * NPULSES};
       Eigen::Map<const calo::multifit::ColMajorMatrix<NSAMPLES, NPULSES>> glbPulseMatrixPView{pulseMatricesP +
@@ -867,11 +868,13 @@ namespace hcal {
         calo::multifit::MapSymM<float, NSAMPLES> covarianceMatrix{covarianceMatrixStorage};
         CMS_UNROLL_LOOP
         for (int counter = 0; counter < calo::multifit::MapSymM<float, NSAMPLES>::total; counter++)
-          covarianceMatrixStorage[counter] = (noisecorr != 0.f) ? 0.f: averagePedestalWidth2;
+          covarianceMatrixStorage[counter] = (noisecorr != 0.f) ? 0.f : averagePedestalWidth2;
         CMS_UNROLL_LOOP
         for (unsigned int counter = 0; counter < calo::multifit::MapSymM<float, NSAMPLES>::stride; counter++) {
           covarianceMatrix(counter, counter) += noiseTermsView.coeffRef(counter);
-          if(counter!=0) covarianceMatrix(counter, counter-1) += noisecorr * __ldg(&noiseElectronicView.coeffRef(counter-1)) * __ldg(&noiseElectronicView.coeffRef(counter));
+          if (counter != 0)
+            covarianceMatrix(counter, counter - 1) += noisecorr * __ldg(&noiseElectronicView.coeffRef(counter - 1)) *
+                                                      __ldg(&noiseElectronicView.coeffRef(counter));
         }
 
         // update covariance matrix

--- a/RecoLocalCalo/HcalRecProducers/src/MahiGPU.cu
+++ b/RecoLocalCalo/HcalRecProducers/src/MahiGPU.cu
@@ -69,6 +69,7 @@ namespace hcal {
     // TODO: add/validate restrict (will increase #registers in use by the kernel)
     __global__ void kernel_prep1d_sameNumberOfSamples(float* amplitudes,
                                                       float* noiseTerms,
+                                                      float* electronicNoiseTerms,
                                                       float* outputEnergy,
                                                       float* outputChi2,
                                                       uint16_t const* dataf01HE,
@@ -166,6 +167,7 @@ namespace hcal {
       // offset output
       auto* amplitudesForChannel = amplitudes + nsamplesForCompute * gch;
       auto* noiseTermsForChannel = noiseTerms + nsamplesForCompute * gch;
+      auto* electronicNoiseTermsForChannel = electronicNoiseTerms + nsamplesForCompute * gch;
       auto const nchannelsf015 = nchannelsf01HE + nchannelsf5HB;
 
       // get event input quantities
@@ -182,6 +184,7 @@ namespace hcal {
                           ? idsf01HE[gch]
                           : (gch < nchannelsf015 ? idsf5HB[gch - nchannelsf01HE] : idsf3HB[gch - nchannelsf015]);
       auto const did = HcalDetId{id};
+
       auto const adc =
           gch < nchannelsf01HE
               ? adc_for_sample<Flavor1>(dataf01HE + stride * gch, sample)
@@ -216,6 +219,7 @@ namespace hcal {
       auto const* pedestalWidthsForChannel = useEffectivePedestals && (gch < nchannelsf01HE || gch >= nchannelsf015)
                                                  ? effectivePedestalWidths + hashedId * 4
                                                  : pedestalWidths + hashedId * 4;
+
       auto const* gains = gainValues + hashedId * 4;
       auto const gain = gains[capid];
       auto const gain0 = gains[0];
@@ -433,6 +437,7 @@ namespace hcal {
       // store to global memory
       amplitudesForChannel[sampleWithinWindow] = amplitude;
       noiseTermsForChannel[sampleWithinWindow] = noiseTerm;
+      electronicNoiseTermsForChannel[sampleWithinWindow] = pedestalWidth;
     }
 
     // TODO: need to add an array of offsets for pulses (a la activeBXs...)
@@ -728,7 +733,9 @@ namespace hcal {
                                     float const* __restrict__ pulseMatricesP,
                                     int const* __restrict__ pulseOffsetValues,
                                     float const* __restrict__ noiseTerms,
+                                    float const* __restrict__ electronicNoiseTerms,
                                     int8_t const* __restrict__ soiSamples,
+                                    float const* __restrict__ noiseCorrelationValues,
                                     float const* __restrict__ pedestalWidths,
                                     float const* __restrict__ effectivePedestalWidths,
                                     bool const useEffectivePedestals,
@@ -788,10 +795,13 @@ namespace hcal {
                                                  pedestalWidthsForChannel[1] * pedestalWidthsForChannel[1] +
                                                  pedestalWidthsForChannel[2] * pedestalWidthsForChannel[2] +
                                                  pedestalWidthsForChannel[3] * pedestalWidthsForChannel[3]);
+
       auto const* gains = gainValues + hashedId * 4;
       // FIXME on cpu ts 0 capid was used - does it make any difference
       auto const gain = gains[0];
       auto const respCorrection = respCorrectionValues[hashedId];
+
+      auto const noisecorr = noiseCorrelationValues[hashedId];
 
 #ifdef HCAL_MAHI_GPUDEBUG
 #ifdef HCAL_MAHI_GPUDEBUG_FILTERDETID
@@ -816,6 +826,7 @@ namespace hcal {
       // map views
       Eigen::Map<const calo::multifit::ColumnVector<NSAMPLES>> inputAmplitudesView{inputAmplitudes + gch * NSAMPLES};
       Eigen::Map<const calo::multifit::ColumnVector<NSAMPLES>> noiseTermsView{noiseTerms + gch * NSAMPLES};
+      Eigen::Map<const calo::multifit::ColumnVector<NSAMPLES>> noiseElectronicView{electronicNoiseTerms + gch * NSAMPLES};
       Eigen::Map<const calo::multifit::ColMajorMatrix<NSAMPLES, NPULSES>> glbPulseMatrixMView{pulseMatricesM +
                                                                                               gch * NSAMPLES * NPULSES};
       Eigen::Map<const calo::multifit::ColMajorMatrix<NSAMPLES, NPULSES>> glbPulseMatrixPView{pulseMatricesP +
@@ -856,10 +867,12 @@ namespace hcal {
         calo::multifit::MapSymM<float, NSAMPLES> covarianceMatrix{covarianceMatrixStorage};
         CMS_UNROLL_LOOP
         for (int counter = 0; counter < calo::multifit::MapSymM<float, NSAMPLES>::total; counter++)
-          covarianceMatrixStorage[counter] = averagePedestalWidth2;
+          covarianceMatrixStorage[counter] = (noisecorr != 0.f) ? 0.f: averagePedestalWidth2;
         CMS_UNROLL_LOOP
-        for (int counter = 0; counter < calo::multifit::MapSymM<float, NSAMPLES>::stride; counter++)
-          covarianceMatrix(counter, counter) += __ldg(&noiseTermsView.coeffRef(counter));
+        for (unsigned int counter = 0; counter < calo::multifit::MapSymM<float, NSAMPLES>::stride; counter++) {
+          covarianceMatrix(counter, counter) += noiseTermsView.coeffRef(counter);
+          if(counter!=0) covarianceMatrix(counter, counter-1) += noisecorr * __ldg(&noiseElectronicView.coeffRef(counter-1)) * __ldg(&noiseElectronicView.coeffRef(counter));
+        }
 
         // update covariance matrix
         update_covariance(
@@ -1060,6 +1073,7 @@ namespace hcal {
       hcal::mahi::kernel_prep1d_sameNumberOfSamples<<<blocks, threadsPerBlock, nbytesShared, cudaStream>>>(
           scratch.amplitudes.get(),
           scratch.noiseTerms.get(),
+          scratch.electronicNoiseTerms.get(),
           outputGPU.recHits.energy.get(),
           outputGPU.recHits.chi2.get(),
           inputGPU.f01HEDigis.data.get(),
@@ -1187,7 +1201,9 @@ namespace hcal {
             scratch.pulseMatricesP.get(),
             conditions.pulseOffsets.values,
             scratch.noiseTerms.get(),
+            scratch.electronicNoiseTerms.get(),
             scratch.soiSamples.get(),
+            conditions.sipmParameters.auxi2,
             conditions.pedestalWidths.values,
             conditions.effectivePedestalWidths.values,
             configParameters.useEffectivePedestals,


### PR DESCRIPTION
Resynchronise gpu and cpu with recent modification of the non diagonal noise
see notes here under
`implement the modification to follow up on recent noise correlation that are important in view of the Run3 ageing`
https://github.com/cms-sw/cmssw/issues/32413

Changes expected in gpu-Run3 only.

@fwyzard @vkhristenko
