### PR TITLE
L1TkMuon Filter: adding duplicate removal and implementing L1 quality cuts 11

### DIFF
--- a/HLTrigger/HLTfilters/plugins/L1TTkMuonFilter.h
+++ b/HLTrigger/HLTfilters/plugins/L1TTkMuonFilter.h
@@ -31,6 +31,17 @@ public:
                  trigger::TriggerFilterObjectWithRefs& filterproduct) const override;
 
 private:
+  class MuonQualityCut {
+  public:
+    MuonQualityCut(const edm::ParameterSet&);
+    bool operator()(const l1t::TkMuon&) const;
+    static void fillPSetDescription(edm::ParameterSetDescription& desc);
+    static edm::ParameterSetDescription makePSetDescription();
+
+  private:
+    std::unordered_map<int, std::vector<int>> allowedQualities_;
+  };
+
   edm::InputTag l1TkMuonTag_;  //input tag for L1 Tk Muon product
   typedef std::vector<l1t::TkMuon> TkMuonCollection;
   edm::EDGetTokenT<TkMuonCollection> tkMuonToken_;  // token identifying product containing L1 TkMuons
@@ -40,11 +51,13 @@ private:
   double min_Eta_;                       // min eta cut
   double max_Eta_;                       // max eta cut
   bool applyQuality_;                    // apply quaility cuts
-  bool doDupRemoval_;                    // do dup removal
+  bool applyDuplicateRemoval_;           // apply duplicate removal
   edm::ParameterSet scalings_;           // all scalings. An indirection level allows extra flexibility
   std::vector<double> barrelScalings_;   // barrel scalings
   std::vector<double> overlapScalings_;  // overlap scalings
   std::vector<double> endcapScalings_;   // endcap scalings
+
+  MuonQualityCut qualityCut_;
 
   double TkMuonOfflineEt(double Et, double Eta) const;
 };

--- a/HLTrigger/HLTfilters/plugins/L1TTkMuonFilter.h
+++ b/HLTrigger/HLTfilters/plugins/L1TTkMuonFilter.h
@@ -39,6 +39,8 @@ private:
   int min_N_;                            // min number of candidates above pT cut
   double min_Eta_;                       // min eta cut
   double max_Eta_;                       // max eta cut
+  bool applyQuality_;                    // apply quaility cuts
+  bool doDupRemoval_;                    // do dup removal
   edm::ParameterSet scalings_;           // all scalings. An indirection level allows extra flexibility
   std::vector<double> barrelScalings_;   // barrel scalings
   std::vector<double> overlapScalings_;  // overlap scalings


### PR DESCRIPTION
#### PR description:

This PR adds the l1 muon quality selection and l1 muon duplicate removal

#### PR validation:

On 10000 MB events rate goes from 87+/-16kHz to 24kHz +/-8kHz for tripple mu 7_5_5 which now matches the L1 reference (https://twiki.cern.ch/twiki/bin/view/CMS/PhaseIIL1TriggerMenuTools)

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

backport of https://github.com/cms-sw/cmssw/pull/33026