### PR TITLE
Replace roll to ieta in GEM

### DIFF
--- a/DataFormats/MuonDetId/interface/GEMDetId.h
+++ b/DataFormats/MuonDetId/interface/GEMDetId.h
@@ -32,6 +32,8 @@ public:
   static constexpr int32_t maxLayerId = 2;  // GE1/GE2 has 2 layers
   static constexpr int32_t minEtaPartitionId = 0;
   static constexpr int32_t maxEtaPartitionId = 16;
+  static constexpr int32_t minRollId = minEtaPartitionId;
+  static constexpr int32_t maxRollId = maxEtaPartitionId;
 
 private:
   static constexpr uint32_t RegionNumBits = 2;

--- a/DataFormats/MuonDetId/interface/GEMDetId.h
+++ b/DataFormats/MuonDetId/interface/GEMDetId.h
@@ -108,7 +108,8 @@ public:
 
     id_ |= ((regionInBits & RegionMask) << RegionStartBit | (ringInBits & RingMask) << RingStartBit |
             (stationInBits & StationMask) << StationStartBit | (layerInBits & LayerMask) << LayerStartBit |
-            (chamberInBits & ChamberMask) << ChamberStartBit | (ietaInBits & EtaPartitionMask) << EtaPartitionStartBit | kGEMIdFormat);
+            (chamberInBits & ChamberMask) << ChamberStartBit | (ietaInBits & EtaPartitionMask) << EtaPartitionStartBit |
+            kGEMIdFormat);
   }
 
   /** Assignment from a generic cell id */
@@ -191,7 +192,7 @@ public:
   constexpr int roll() const {
     return (static_cast<int>((id_ >> EtaPartitionStartBit) & EtaPartitionMask));  // value 0 is used as wild card
   }
-  
+
   /** Return the corresponding EtaPartition id (same as roll) */
   constexpr int ieta() const {
     return (static_cast<int>((id_ >> EtaPartitionStartBit) & EtaPartitionMask));  // value 0 is used as wild card
@@ -228,8 +229,8 @@ public:
                ((MuonSubdetId::GEM & DetId::kSubdetMask) << DetId::kSubdetOffset) |
                ((regionInBits & RegionMask) << RegionStartBit) | ((ringInBits & RingMask) << RingStartBit) |
                ((stationInBits & StationMask) << StationStartBit) | ((layerInBits & LayerMask) << LayerStartBit) |
-               ((chamberInBits & ChamberMask) << ChamberStartBit) | ((ietaInBits & EtaPartitionMask) << EtaPartitionStartBit) |
-               kGEMIdFormat);
+               ((chamberInBits & ChamberMask) << ChamberStartBit) |
+               ((ietaInBits & EtaPartitionMask) << EtaPartitionStartBit) | kGEMIdFormat);
     }
     return rawid;
   }

--- a/DataFormats/MuonDetId/interface/GEMDetId.h
+++ b/DataFormats/MuonDetId/interface/GEMDetId.h
@@ -30,8 +30,8 @@ public:
   static constexpr int32_t minLayerId = 0;  // LayerId = 0 is superChamber
   static constexpr int32_t maxLayerId0 = 6;
   static constexpr int32_t maxLayerId = 2;  // GE1/GE2 has 2 layers
-  static constexpr int32_t minRollId = 0;
-  static constexpr int32_t maxRollId = 16;
+  static constexpr int32_t minEtaPartitionId = 0;
+  static constexpr int32_t maxEtaPartitionId = 16;
 
 private:
   static constexpr uint32_t RegionNumBits = 2;
@@ -53,19 +53,19 @@ private:
   static constexpr uint32_t LayerStartBitM = ChamberStartBitM + ChamberNumBits;
   static constexpr uint32_t LayerMask = 0x1F;
   static constexpr uint32_t LayerMaskP = 0x3;
-  static constexpr uint32_t RollNumBits = 5;
-  static constexpr uint32_t RollStartBit = LayerStartBit + LayerNumBits;
-  static constexpr uint32_t RollStartBitP = LayerStartBit + LayerNumBitsP;
-  static constexpr uint32_t RollStartBitM = LayerStartBitM + LayerNumBits;
-  static constexpr uint32_t RollMask = 0x1F;
+  static constexpr uint32_t EtaPartitionNumBits = 5;
+  static constexpr uint32_t EtaPartitionStartBit = LayerStartBit + LayerNumBits;
+  static constexpr uint32_t EtaPartitionStartBitP = LayerStartBit + LayerNumBitsP;
+  static constexpr uint32_t EtaPartitionStartBitM = LayerStartBitM + LayerNumBits;
+  static constexpr uint32_t EtaPartitionMask = 0x1F;
   static constexpr uint32_t FormatNumBits = 1;
-  static constexpr uint32_t FormatStartBit = RollStartBit + RollNumBits;
+  static constexpr uint32_t FormatStartBit = EtaPartitionStartBit + EtaPartitionNumBits;
   static constexpr uint32_t FormatMask = 0x1;
   static constexpr uint32_t kGEMIdFormat = 0x1000000;
   static constexpr uint32_t kMuonIdMask = 0xF0000000;
 
 public:
-  static constexpr uint32_t chamberIdMask = ~(RollMask << RollStartBit);
+  static constexpr uint32_t chamberIdMask = ~(EtaPartitionMask << EtaPartitionStartBit);
   static constexpr uint32_t superChamberIdMask = chamberIdMask + ~(LayerMask << LayerStartBit);
 
 public:
@@ -90,25 +90,25 @@ public:
       id_ = v12Form(id.rawId());
   }
   /// Construct from fully qualified identifier.
-  constexpr GEMDetId(int region, int ring, int station, int layer, int chamber, int roll)
+  constexpr GEMDetId(int region, int ring, int station, int layer, int chamber, int ieta)
       : DetId(DetId::Muon, MuonSubdetId::GEM) {
     if (region < minRegionId || region > maxRegionId || ring < minRingId || ring > maxRingId ||
         station < minStationId0 || station > maxStationId || layer < minLayerId || layer > maxLayerId0 ||
-        chamber < minChamberId || chamber > maxChamberId || roll < minRollId || roll > maxRollId)
+        chamber < minChamberId || chamber > maxChamberId || ieta < minEtaPartitionId || ieta > maxEtaPartitionId)
       throw cms::Exception("InvalidDetId")
           << "GEMDetId ctor: Invalid parameters:  region " << region << " ring " << ring << " station " << station
-          << " layer " << layer << " chamber " << chamber << " roll " << roll << std::endl;
+          << " layer " << layer << " chamber " << chamber << " ieta " << ieta << std::endl;
 
     int regionInBits = region - minRegionId;
     int ringInBits = ring - minRingId;
     int stationInBits = station - minStationId0;
     int layerInBits = layer - minLayerId;
     int chamberInBits = chamber - (minChamberId + 1);
-    int rollInBits = roll;
+    int ietaInBits = ieta;
 
     id_ |= ((regionInBits & RegionMask) << RegionStartBit | (ringInBits & RingMask) << RingStartBit |
             (stationInBits & StationMask) << StationStartBit | (layerInBits & LayerMask) << LayerStartBit |
-            (chamberInBits & ChamberMask) << ChamberStartBit | (rollInBits & RollMask) << RollStartBit | kGEMIdFormat);
+            (chamberInBits & ChamberMask) << ChamberStartBit | (ietaInBits & EtaPartitionMask) << EtaPartitionStartBit | kGEMIdFormat);
   }
 
   /** Assignment from a generic cell id */
@@ -133,19 +133,19 @@ public:
     uint32_t rawid = gen.rawId();
     if (rawid == id_)
       return true;
-    int reg(0), ri(0), stn(-1), lay(0), chamb(0), rol(0);
-    unpackId(rawid, reg, ri, stn, lay, chamb, rol);
+    int reg(0), ri(0), stn(-1), lay(0), chamb(0), iet(0);
+    unpackId(rawid, reg, ri, stn, lay, chamb, iet);
     return (((id_ & kMuonIdMask) == (rawid & kMuonIdMask)) && (reg == region()) && (ri == ring()) &&
-            (stn == station()) && (lay == layer()) && (chamb == chamber()) && (rol == roll()));
+            (stn == station()) && (lay == layer()) && (chamb == chamber()) && (iet == ieta()));
   }
   constexpr bool operator!=(const GEMDetId& gen) const {
     uint32_t rawid = gen.rawId();
     if (rawid == id_)
       return false;
-    int reg(0), ri(0), stn(-1), lay(0), chamb(0), rol(0);
-    unpackId(rawid, reg, ri, stn, lay, chamb, rol);
+    int reg(0), ri(0), stn(-1), lay(0), chamb(0), iet(0);
+    unpackId(rawid, reg, ri, stn, lay, chamb, iet);
     return (((id_ & kMuonIdMask) != (rawid & kMuonIdMask)) || (reg != region()) || (ri != ring()) ||
-            (stn != station()) || (lay != layer()) || (chamb != chamber()) || (rol != roll()));
+            (stn != station()) || (lay != layer()) || (chamb != chamber()) || (iet != ieta()));
   }
 
   /** Sort Operator based on the raw detector id */
@@ -186,10 +186,15 @@ public:
       For ME0 there are 6 layers of chambers */
   constexpr int layer() const { return (static_cast<int>((id_ >> LayerStartBit) & LayerMask) + minLayerId); }
 
-  /** Roll id  (also known as eta partition): each chamber is divided along
-      the strip direction in  several parts  (rolls) GEM up to 12 */
+  /** EtaPartition id  (also known as eta partition): each chamber is divided along
+      the strip direction in  several parts  (ietas) GEM up to 12 */
   constexpr int roll() const {
-    return (static_cast<int>((id_ >> RollStartBit) & RollMask));  // value 0 is used as wild card
+    return (static_cast<int>((id_ >> EtaPartitionStartBit) & EtaPartitionMask));  // value 0 is used as wild card
+  }
+  
+  /** Return the corresponding EtaPartition id (same as roll) */
+  constexpr int ieta() const {
+    return (static_cast<int>((id_ >> EtaPartitionStartBit) & EtaPartitionMask));  // value 0 is used as wild card
   }
 
   /** Return the corresponding ChamberId */
@@ -211,19 +216,19 @@ public:
   constexpr static uint32_t v12Form(const uint32_t& inpid) {
     uint32_t rawid(inpid);
     if ((rawid & kGEMIdFormat) == 0) {
-      int region(0), ring(0), station(-1), layer(0), chamber(0), roll(0);
-      unpackId(rawid, region, ring, station, layer, chamber, roll);
+      int region(0), ring(0), station(-1), layer(0), chamber(0), ieta(0);
+      unpackId(rawid, region, ring, station, layer, chamber, ieta);
       int regionInBits = region - minRegionId;
       int ringInBits = ring - minRingId;
       int stationInBits = station - minStationId0;
       int layerInBits = layer - minLayerId;
       int chamberInBits = chamber - (minChamberId + 1);
-      int rollInBits = roll;
+      int ietaInBits = ieta;
       rawid = (((DetId::Muon & DetId::kDetMask) << DetId::kDetOffset) |
                ((MuonSubdetId::GEM & DetId::kSubdetMask) << DetId::kSubdetOffset) |
                ((regionInBits & RegionMask) << RegionStartBit) | ((ringInBits & RingMask) << RingStartBit) |
                ((stationInBits & StationMask) << StationStartBit) | ((layerInBits & LayerMask) << LayerStartBit) |
-               ((chamberInBits & ChamberMask) << ChamberStartBit) | ((rollInBits & RollMask) << RollStartBit) |
+               ((chamberInBits & ChamberMask) << ChamberStartBit) | ((ietaInBits & EtaPartitionMask) << EtaPartitionStartBit) |
                kGEMIdFormat);
     }
     return rawid;
@@ -239,7 +244,7 @@ private:
   constexpr void v12FromV11(const uint32_t& rawid) { id_ = v12Form(rawid); }
 
   constexpr static void unpackId(
-      const uint32_t& rawid, int& region, int& ring, int& station, int& layer, int& chamber, int& roll) {
+      const uint32_t& rawid, int& region, int& ring, int& station, int& layer, int& chamber, int& ieta) {
     if (((rawid >> DetId::kDetOffset) & DetId::kDetMask) == DetId::Muon) {
       int subdet = ((rawid >> DetId::kSubdetOffset) & DetId::kSubdetMask);
       if (subdet == MuonSubdetId::GEM) {
@@ -249,11 +254,11 @@ private:
         if ((rawid & kGEMIdFormat) == 0) {
           station = (static_cast<int>((rawid >> StationStartBit) & StationMask) + minStationId);
           layer = (static_cast<int>((rawid >> LayerStartBit) & LayerMaskP) + minLayerId);
-          roll = (static_cast<int>((rawid >> RollStartBitP) & RollMask));
+          ieta = (static_cast<int>((rawid >> EtaPartitionStartBitP) & EtaPartitionMask));
         } else {
           station = (static_cast<int>((rawid >> StationStartBit) & StationMask) + minStationId0);
           layer = (static_cast<int>((rawid >> LayerStartBit) & LayerMask) + minLayerId);
-          roll = (static_cast<int>((rawid >> RollStartBit) & RollMask));
+          ieta = (static_cast<int>((rawid >> EtaPartitionStartBit) & EtaPartitionMask));
         }
       } else if (subdet == MuonSubdetId::ME0) {
         region = static_cast<int>(((rawid >> RegionStartBit) & RegionMask) + minRegionId);
@@ -261,7 +266,7 @@ private:
         station = 0;
         chamber = (static_cast<int>((rawid >> ChamberStartBitM) & ChamberMask) + (minChamberId));
         layer = (static_cast<int>((rawid >> LayerStartBitM) & LayerMask) + minLayerId);
-        roll = (static_cast<int>((rawid >> RollStartBitM) & RollMask));
+        ieta = (static_cast<int>((rawid >> EtaPartitionStartBitM) & EtaPartitionMask));
       }
     }
   }

--- a/DataFormats/MuonDetId/src/GEMDetId.cc
+++ b/DataFormats/MuonDetId/src/GEMDetId.cc
@@ -14,7 +14,7 @@ bool GEMDetId::isME0() const { return subsystem() == GEMSubDetId::Station::ME0; 
 
 std::ostream& operator<<(std::ostream& os, const GEMDetId& id) {
   os << " Re " << id.region() << " Ri " << id.ring() << " St " << id.station() << " La " << id.layer() << " Ch "
-     << id.chamber() << " Ro " << id.roll() << " ";
+     << id.chamber() << " Et " << id.roll() << " ";
 
   return os;
 }

--- a/DataFormats/MuonDetId/test/testGEMDetId.cc
+++ b/DataFormats/MuonDetId/test/testGEMDetId.cc
@@ -11,7 +11,7 @@ int testCell() {
         for (int st = GEMDetId::minStationId; st <= GEMDetId::maxStationId; ++st) {
           for (int la = GEMDetId::minLayerId; la <= GEMDetId::maxLayerId; ++la) {
             for (int ch = 1 + GEMDetId::minChamberId; ch <= GEMDetId::maxChamberId; ++ch) {
-              for (int ro = GEMDetId::minRollId; ro <= GEMDetId::maxRollId; ++ro) {
+              for (int ro = GEMDetId::minEtaPartitionId; ro <= GEMDetId::maxEtaPartitionId; ++ro) {
                 GEMDetId id(re, ri, st, la, ch, ro);
                 if ((id.region() != re) || (id.ring() != ri) || (id.station() != st) || (id.layer() != la) ||
                     (id.chamber() != ch) || (id.roll() != ro)) {

--- a/Validation/MuonGEMDigis/plugins/GEMPadDigiClusterValidation.cc
+++ b/Validation/MuonGEMDigis/plugins/GEMPadDigiClusterValidation.cc
@@ -197,7 +197,7 @@ void GEMPadDigiClusterValidation::analyze(const edm::Event& event, const edm::Ev
     Int_t station_id = gemid.station();
     Int_t layer_id = gemid.layer();
     Int_t chamber_id = gemid.chamber();
-    Int_t roll_id = gemid.roll();
+    Int_t ieta = gemid.ieta();
     Int_t num_layers = gemid.nlayers();
 
     ME2IdsKey key2(region_id, station_id);
@@ -235,7 +235,7 @@ void GEMPadDigiClusterValidation::analyze(const edm::Event& event, const edm::Ev
       me_cls_->Fill(cls);
       if (detail_plot_) {
         me_detail_occ_zr_[region_id]->Fill(g_abs_z, g_r);
-        me_detail_occ_det_[key2]->Fill(bin_x, roll_id);
+        me_detail_occ_det_[key2]->Fill(bin_x, ieta);
         me_detail_occ_xy_[key3]->Fill(g_x, g_y);
         me_detail_occ_phi_pad_[key3]->Fill(g_phi, pad);
         me_detail_occ_pad_[key3]->Fill(pad);
@@ -283,7 +283,7 @@ void GEMPadDigiClusterValidation::analyze(const edm::Event& event, const edm::Ev
     Int_t station_id = simhit_gemid.station();
     Int_t layer_id = simhit_gemid.layer();
     Int_t chamber_id = simhit_gemid.chamber();
-    Int_t roll_id = simhit_gemid.roll();
+    Int_t ieta = simhit_gemid.ieta();
     Int_t num_layers = simhit_gemid.nlayers();
 
     ME2IdsKey key2{region_id, station_id};
@@ -319,7 +319,7 @@ void GEMPadDigiClusterValidation::analyze(const edm::Event& event, const edm::Ev
         me_pad_cluster_occ_eta_[key3]->Fill(simhit_g_eta);
         me_pad_cluster_occ_phi_[key3]->Fill(simhit_g_phi);
         if (detail_plot_) {
-          me_detail_pad_cluster_occ_det_[key2]->Fill(bin_x, roll_id);
+          me_detail_pad_cluster_occ_det_[key2]->Fill(bin_x, ieta);
         }
         break;
       }

--- a/Validation/MuonGEMDigis/plugins/GEMPadDigiValidation.cc
+++ b/Validation/MuonGEMDigis/plugins/GEMPadDigiValidation.cc
@@ -179,7 +179,7 @@ void GEMPadDigiValidation::analyze(const edm::Event& event, const edm::EventSetu
     Int_t station_id = gemid.station();
     Int_t layer_id = gemid.layer();
     Int_t chamber_id = gemid.chamber();
-    Int_t roll_id = gemid.roll();
+    Int_t ieta = gemid.ieta();
     Int_t num_layers = gemid.nlayers();
 
     ME2IdsKey key2(region_id, station_id);
@@ -211,7 +211,7 @@ void GEMPadDigiValidation::analyze(const edm::Event& event, const edm::EventSetu
         me_detail_occ_xy_[key3]->Fill(g_x, g_y);
         me_detail_occ_phi_pad_[key3]->Fill(g_phi, pad);
         me_detail_occ_pad_[key3]->Fill(pad);
-        me_detail_occ_det_[key2]->Fill(bin_x, roll_id);
+        me_detail_occ_det_[key2]->Fill(bin_x, ieta);
         me_detail_bx_[key3]->Fill(bx);
       }  // if detail_plot
     }    // digi loop
@@ -256,7 +256,7 @@ void GEMPadDigiValidation::analyze(const edm::Event& event, const edm::EventSetu
     Int_t station_id = simhit_gemid.station();
     Int_t layer_id = simhit_gemid.layer();
     Int_t chamber_id = simhit_gemid.chamber();
-    Int_t roll_id = simhit_gemid.roll();
+    Int_t ieta = simhit_gemid.ieta();
     Int_t num_layers = simhit_gemid.nlayers();
 
     ME2IdsKey key2{region_id, station_id};
@@ -292,7 +292,7 @@ void GEMPadDigiValidation::analyze(const edm::Event& event, const edm::EventSetu
         me_pad_occ_eta_[key3]->Fill(simhit_g_eta);
         me_pad_occ_phi_[key3]->Fill(simhit_g_phi);
         if (detail_plot_) {
-          me_detail_pad_occ_det_[key2]->Fill(bin_x, roll_id);
+          me_detail_pad_occ_det_[key2]->Fill(bin_x, ieta);
         }
         break;
       }

--- a/Validation/MuonGEMDigis/plugins/GEMStripDigiValidation.cc
+++ b/Validation/MuonGEMDigis/plugins/GEMStripDigiValidation.cc
@@ -193,7 +193,7 @@ void GEMStripDigiValidation::analyze(const edm::Event& event, const edm::EventSe
     Int_t layer_id = id.layer();
     Int_t station_id = id.station();
     Int_t chamber_id = id.chamber();
-    Int_t roll_id = id.roll();
+    Int_t ieta = id.ieta();
     Int_t num_layers = id.nlayers();
 
     ME2IdsKey key2{region_id, station_id};
@@ -228,7 +228,7 @@ void GEMStripDigiValidation::analyze(const edm::Event& event, const edm::EventSe
 
       if (detail_plot_) {
         me_detail_occ_zr_[region_id]->Fill(digi_g_abs_z, digi_g_r);
-        me_detail_occ_det_[key2]->Fill(bin_x, roll_id);
+        me_detail_occ_det_[key2]->Fill(bin_x, ieta);
         me_detail_occ_xy_[key3]->Fill(digi_g_x, digi_g_y);
         me_detail_occ_strip_[key3]->Fill(strip);
       }
@@ -259,7 +259,7 @@ void GEMStripDigiValidation::analyze(const edm::Event& event, const edm::EventSe
     Int_t station_id = simhit_gemid.station();
     Int_t layer_id = simhit_gemid.layer();
     Int_t chamber_id = simhit_gemid.chamber();
-    Int_t roll_id = simhit_gemid.roll();
+    Int_t ieta = simhit_gemid.ieta();
     Int_t num_layers = simhit_gemid.nlayers();
 
     ME2IdsKey key2{region_id, station_id};
@@ -292,7 +292,7 @@ void GEMStripDigiValidation::analyze(const edm::Event& event, const edm::EventSe
           if (isMuonSimHit(simhit)) {
             me_detail_strip_occ_eta_[key3]->Fill(simhit_g_eta);
             me_detail_strip_occ_phi_[key3]->Fill(simhit_g_phi);
-            me_detail_strip_occ_det_[key2]->Fill(bin_x, roll_id);
+            me_detail_strip_occ_det_[key2]->Fill(bin_x, ieta);
           }
         }
         break;

--- a/Validation/MuonGEMHits/plugins/GEMSimHitValidation.cc
+++ b/Validation/MuonGEMHits/plugins/GEMSimHitValidation.cc
@@ -205,7 +205,7 @@ void GEMSimHitValidation::analyze(const edm::Event& event, const edm::EventSetup
     Int_t station_id = gemid.station();
     Int_t layer_id = gemid.layer();
     Int_t chamber_id = gemid.chamber();
-    Int_t roll_id = gemid.roll();
+    Int_t ieta = gemid.ieta();
     Int_t num_layers = gemid.nlayers();
 
     ME2IdsKey key2{region_id, station_id};
@@ -247,13 +247,13 @@ void GEMSimHitValidation::analyze(const edm::Event& event, const edm::EventSetup
       me_detail_eloss_[key3]->Fill(energy_loss);
 
       me_detail_occ_zr_[region_id]->Fill(simhit_g_abs_z, simhit_g_r);
-      me_detail_occ_det_[key2]->Fill(bin_x, roll_id);
+      me_detail_occ_det_[key2]->Fill(bin_x, ieta);
       me_detail_occ_xy_[key3]->Fill(simhit_g_x, simhit_g_y);
 
       if (is_muon_simhit) {
         me_detail_tof_mu_[key3]->Fill(tof);
         me_detail_eloss_mu_[key3]->Fill(energy_loss);
-        me_detail_occ_det_mu_[key2]->Fill(bin_x, roll_id);
+        me_detail_occ_det_mu_[key2]->Fill(bin_x, ieta);
       }
 
     }  // detail_plot

--- a/Validation/MuonGEMHits/src/GEMValidationUtils.cc
+++ b/Validation/MuonGEMHits/src/GEMValidationUtils.cc
@@ -13,7 +13,7 @@ TString GEMUtils::getSuffixName(Int_t region_id, Int_t station_id, Int_t layer_i
 }
 
 TString GEMUtils::getSuffixName(Int_t region_id, Int_t station_id, Int_t layer_id, Int_t roll_id) {
-  return TString::Format("_GE%+.2d_L%d_R%d", region_id * (station_id * 10 + 1), layer_id, roll_id);
+  return TString::Format("_GE%+.2d_L%d_iEta%d", region_id * (station_id * 10 + 1), layer_id, roll_id);
 }
 
 TString GEMUtils::getSuffixName(const ME2IdsKey& key) {
@@ -42,7 +42,7 @@ TString GEMUtils::getSuffixTitle(Int_t region_id, Int_t station_id, Int_t layer_
 }
 
 TString GEMUtils::getSuffixTitle(Int_t region_id, Int_t station_id, Int_t layer_id, Int_t roll_id) {
-  return TString::Format(" GE%+.2d Layer %d Roll %d", region_id * (station_id * 10 + 1), layer_id, roll_id);
+  return TString::Format(" GE%+.2d Layer %d iEta %d", region_id * (station_id * 10 + 1), layer_id, roll_id);
 }
 
 TString GEMUtils::getSuffixTitle(const ME2IdsKey& key) {

--- a/Validation/MuonGEMRecHits/plugins/GEMRecHitValidation.cc
+++ b/Validation/MuonGEMRecHits/plugins/GEMRecHitValidation.cc
@@ -82,19 +82,17 @@ void GEMRecHitValidation::bookHistograms(DQMStore::IBooker& booker, edm::Run con
       Int_t ieta = roll->id().ieta();
       ME2IdsKey key{station_id, ieta};
 
-      me_residual_x_[key] =
-          booker.book1D(Form("residual_x_GE%d1_R%d", station_id, ieta),
-                        Form("Residual in X : GE%d1 iEta %d; Residual in X [cm]", station_id, ieta),
-                        60,
-                        -2,
-                        2);
+      me_residual_x_[key] = booker.book1D(Form("residual_x_GE%d1_R%d", station_id, ieta),
+                                          Form("Residual in X : GE%d1 iEta %d; Residual in X [cm]", station_id, ieta),
+                                          60,
+                                          -2,
+                                          2);
 
-      me_residual_y_[key] =
-          booker.book1D(Form("residual_y_GE%d1_iEta%d", station_id, ieta),
-                        Form("Residual in Y : GE%d1 iEta %d; Residual in Y [cm]", station_id, ieta),
-                        60,
-                        -15,
-                        15);
+      me_residual_y_[key] = booker.book1D(Form("residual_y_GE%d1_iEta%d", station_id, ieta),
+                                          Form("Residual in Y : GE%d1 iEta %d; Residual in Y [cm]", station_id, ieta),
+                                          60,
+                                          -15,
+                                          15);
 
       me_residual_rphi_[key] = booker.book1D(
           Form("residual_rphi_GE%d1_iEta%d", station_id, ieta),

--- a/Validation/MuonGEMRecHits/plugins/GEMRecHitValidation.cc
+++ b/Validation/MuonGEMRecHits/plugins/GEMRecHitValidation.cc
@@ -36,10 +36,10 @@ void GEMRecHitValidation::bookHistograms(DQMStore::IBooker& booker, edm::Run con
   for (const auto& station : gem->regions()[0]->stations()) {
     Int_t station_id = station->station();
     for (const auto& roll : station->superChambers()[0]->chambers()[0]->etaPartitions()) {
-      Int_t roll_id = roll->id().roll();
-      ME2IdsKey key{station_id, roll_id};
-      me_cls_roll_[key] = booker.book1D(Form("cls_GE%d1_R%d", station_id, roll_id),
-                                        Form("Cluster Size Distribution : GE%d1 Roll %d", station_id, roll_id),
+      Int_t ieta = roll->id().ieta();
+      ME2IdsKey key{station_id, ieta};
+      me_cls_roll_[key] = booker.book1D(Form("cls_GE%d1_iEta%d", station_id, ieta),
+                                        Form("Cluster Size Distribution : GE%d1 iEta %d", station_id, ieta),
                                         10,
                                         0.5,
                                         10.5);
@@ -62,8 +62,8 @@ void GEMRecHitValidation::bookHistograms(DQMStore::IBooker& booker, edm::Run con
             Int_t layer_id = chamber->id().layer();
 
             for (const auto& roll : chamber->etaPartitions()) {
-              Int_t roll_id = roll->id().roll();
-              ME4IdsKey key4{region_id, station_id, layer_id, roll_id};
+              Int_t ieta = roll->id().ieta();
+              ME4IdsKey key4{region_id, station_id, layer_id, ieta};
 
               me_detail_cls_[key4] = bookHist1D(booker, key4, "cls", "Cluster Size Distribution", 11, -0.5, 10.5);
             }  // roll loop
@@ -79,26 +79,26 @@ void GEMRecHitValidation::bookHistograms(DQMStore::IBooker& booker, edm::Run con
   for (const auto& station : gem->regions()[0]->stations()) {
     Int_t station_id = station->station();
     for (const auto& roll : station->superChambers()[0]->chambers()[0]->etaPartitions()) {
-      Int_t roll_id = roll->id().roll();
-      ME2IdsKey key{station_id, roll_id};
+      Int_t ieta = roll->id().ieta();
+      ME2IdsKey key{station_id, ieta};
 
       me_residual_x_[key] =
-          booker.book1D(Form("residual_x_GE%d1_R%d", station_id, roll_id),
-                        Form("Residual in X : GE%d1 Roll %d; Residual in X [cm]", station_id, roll_id),
+          booker.book1D(Form("residual_x_GE%d1_R%d", station_id, ieta),
+                        Form("Residual in X : GE%d1 iEta %d; Residual in X [cm]", station_id, ieta),
                         60,
                         -2,
                         2);
 
       me_residual_y_[key] =
-          booker.book1D(Form("residual_y_GE%d1_R%d", station_id, roll_id),
-                        Form("Residual in Y : GE%d1 Roll %d; Residual in Y [cm]", station_id, roll_id),
+          booker.book1D(Form("residual_y_GE%d1_iEta%d", station_id, ieta),
+                        Form("Residual in Y : GE%d1 iEta %d; Residual in Y [cm]", station_id, ieta),
                         60,
                         -15,
                         15);
 
       me_residual_rphi_[key] = booker.book1D(
-          Form("residual_rphi_GE%d1_R%d", station_id, roll_id),
-          Form("Residual in R #times #phi : GE%d1 Roll %d; Residual in r #times #phi [cm]", station_id, roll_id),
+          Form("residual_rphi_GE%d1_iEta%d", station_id, ieta),
+          Form("Residual in R #times #phi : GE%d1 iEta %d; Residual in r #times #phi [cm]", station_id, ieta),
           60,
           -15,
           15);
@@ -118,8 +118,8 @@ void GEMRecHitValidation::bookHistograms(DQMStore::IBooker& booker, edm::Run con
             Int_t layer_id = chamber->id().layer();
 
             for (const auto& roll : chamber->etaPartitions()) {
-              Int_t roll_id = roll->id().roll();
-              ME4IdsKey key4{region_id, station_id, layer_id, roll_id};
+              Int_t ieta = roll->id().ieta();
+              ME4IdsKey key4{region_id, station_id, layer_id, ieta};
 
               me_detail_residual_x_[key4] =
                   bookHist1D(booker, key4, "residual_x", "Residual in x", 60, -2, 2, "Residual in x [cm]");
@@ -149,17 +149,17 @@ void GEMRecHitValidation::bookHistograms(DQMStore::IBooker& booker, edm::Run con
     for (const auto& station : gem->regions()[0]->stations()) {
       Int_t station_id = station->station();
       for (const auto& roll : station->superChambers()[0]->chambers()[0]->etaPartitions()) {
-        Int_t roll_id = roll->id().roll();
-        ME2IdsKey key{station_id, roll_id};
+        Int_t ieta = roll->id().ieta();
+        ME2IdsKey key{station_id, ieta};
 
-        me_detail_pull_x_[key] = booker.book1D(Form("pull_x_GE%d1_R%d", station_id, roll_id),
-                                               Form("Pull in X : GE%d1 Roll %d", station_id, roll_id),
+        me_detail_pull_x_[key] = booker.book1D(Form("pull_x_GE%d1_iEta%d", station_id, ieta),
+                                               Form("Pull in X : GE%d1 iEta %d", station_id, ieta),
                                                60,
                                                -3,
                                                3);
 
-        me_detail_pull_y_[key] = booker.book1D(Form("pull_y_GE%d1_R%d", station_id, roll_id),
-                                               Form("Pull in Y : GE%d1 Roll %d", station_id, roll_id),
+        me_detail_pull_y_[key] = booker.book1D(Form("pull_y_GE%d1_iEta%d", station_id, ieta),
+                                               Form("Pull in Y : GE%d1 iEta %d", station_id, ieta),
                                                60,
                                                -3,
                                                3);
@@ -178,8 +178,8 @@ void GEMRecHitValidation::bookHistograms(DQMStore::IBooker& booker, edm::Run con
             Int_t layer_id = chamber->id().layer();
 
             for (const auto& roll : chamber->etaPartitions()) {
-              Int_t roll_id = roll->id().roll();
-              ME4IdsKey key4{region_id, station_id, layer_id, roll_id};
+              Int_t ieta = roll->id().ieta();
+              ME4IdsKey key4{region_id, station_id, layer_id, ieta};
 
               me_detail_pull_x_la_[key4] = bookHist1D(booker, key4, "pull_x", "Pull in x", 60, -3, 3);
 
@@ -295,10 +295,10 @@ void GEMRecHitValidation::analyze(const edm::Event& event, const edm::EventSetup
     Int_t region_id = gem_id.region();
     Int_t station_id = gem_id.station();
     Int_t layer_id = gem_id.layer();
-    Int_t roll_id = gem_id.roll();
-    ME4IdsKey key4{region_id, station_id, layer_id, roll_id};
+    Int_t ieta = gem_id.ieta();
+    ME4IdsKey key4{region_id, station_id, layer_id, ieta};
 
-    ME2IdsKey key{station_id, roll_id};
+    ME2IdsKey key{station_id, ieta};
     ME2IdsKey key2{region_id, station_id};
     ME3IdsKey key3{region_id, station_id, layer_id};
 
@@ -316,7 +316,7 @@ void GEMRecHitValidation::analyze(const edm::Event& event, const edm::EventSetup
     cls = cls > 10 ? 10 : cls;
 
     me_cls_roll_[key]->Fill(cls);
-    me_occ_ieta_[key3]->Fill(roll_id);
+    me_occ_ieta_[key3]->Fill(ieta);
     me_occ_phi_[key3]->Fill(rechit_g_phi);
     total_rechit[key3]++;
 
@@ -375,13 +375,13 @@ void GEMRecHitValidation::analyze(const edm::Event& event, const edm::EventSetup
     Int_t station_id = simhit_gemid.station();
     Int_t layer_id = simhit_gemid.layer();
     Int_t chamber_id = simhit_gemid.chamber();
-    Int_t roll_id = simhit_gemid.roll();
+    Int_t ieta = simhit_gemid.ieta();
     Int_t num_layers = simhit_gemid.nlayers();
 
-    ME2IdsKey key{station_id, roll_id};
+    ME2IdsKey key{station_id, ieta};
     ME2IdsKey key2{region_id, station_id};
     ME3IdsKey key3{region_id, station_id, layer_id};
-    ME4IdsKey key4{region_id, station_id, layer_id, roll_id};
+    ME4IdsKey key4{region_id, station_id, layer_id, ieta};
 
     const LocalPoint& simhit_local_pos = simhit.localPosition();
     const GlobalPoint& simhit_global_pos = surface.toGlobal(simhit_local_pos);
@@ -438,7 +438,7 @@ void GEMRecHitValidation::analyze(const edm::Event& event, const edm::EventSetup
         me_rechit_occ_phi_[key3]->Fill(simhit_g_phi);
 
         if (detail_plot_) {
-          me_detail_rechit_occ_det_[key2]->Fill(det_occ_bin_x, roll_id);
+          me_detail_rechit_occ_det_[key2]->Fill(det_occ_bin_x, ieta);
 
           me_detail_residual_x_[key4]->Fill(residual_x);
           me_detail_residual_y_[key4]->Fill(residual_y);


### PR DESCRIPTION
#### PR description:

* Replace roll to ieta in GEMDetId for consistency between software and hardware words.
* But we keep the roll() to backward compatible.

#### PR validation:

* The branch has tested with following commands to check if it works in 2 different geometry versions.
`runTheMatrix.py -w upgrade -l 31011.0`
`runTheMatrix.py -w upgrade -l 23211.0`
* The code format has applied with `scram build code-format`