### PR TITLE
Update GEM Offline DQM

### DIFF
--- a/DQMOffline/Configuration/python/DQMOfflineCosmics_SecondStep_cff.py
+++ b/DQMOffline/Configuration/python/DQMOfflineCosmics_SecondStep_cff.py
@@ -11,7 +11,7 @@ from DQM.SiPixelCommon.SiPixelOfflineDQM_client_cff import *
 from DQM.DTMonitorClient.dtDQMOfflineClients_Cosmics_cff import *
 from DQM.RPCMonitorClient.RPCTier0Client_cff import *
 from DQM.CSCMonitorModule.csc_dqm_offlineclient_cosmics_cff import *
-from DQMOffline.Muon.gem_dqm_offline_client_cff import *
+from DQMOffline.Muon.gem_dqm_offline_client_cosmics_cff import *
 from DQMServices.Components.DQMFEDIntegrityClient_cff import *
 
 DQMNone = cms.Sequence()
@@ -31,7 +31,7 @@ DQMOfflineCosmics_SecondStepMuonDPG = cms.Sequence( dtClientsCosmics *
 
 from Configuration.Eras.Modifier_run3_GEM_cff import run3_GEM
 _run3_GEM_DQMOfflineCosmics_SecondStepMuonDPG = DQMOfflineCosmics_SecondStepMuonDPG.copy()
-_run3_GEM_DQMOfflineCosmics_SecondStepMuonDPG += gemClients
+_run3_GEM_DQMOfflineCosmics_SecondStepMuonDPG += gemClientsCosmics
 run3_GEM.toReplaceWith(DQMOfflineCosmics_SecondStepMuonDPG, _run3_GEM_DQMOfflineCosmics_SecondStepMuonDPG)
 
 DQMOfflineCosmics_SecondStepFED = cms.Sequence( dqmFEDIntegrityClient )

--- a/DQMOffline/Configuration/python/DQMOfflineCosmics_cff.py
+++ b/DQMOffline/Configuration/python/DQMOfflineCosmics_cff.py
@@ -11,7 +11,7 @@ from DQM.SiPixelCommon.SiPixelOfflineDQM_source_cff import *
 from DQM.DTMonitorModule.dtDQMOfflineSources_Cosmics_cff import *
 from DQM.RPCMonitorClient.RPCTier0Source_cff import *
 from DQM.CSCMonitorModule.csc_dqm_sourceclient_offline_cff import *
-from DQMOffline.Muon.gem_dqm_offline_source_cff import *
+from DQMOffline.Muon.gem_dqm_offline_source_cosmics_cff import *
 from DQM.EcalPreshowerMonitorModule.es_dqm_source_offline_cosmic_cff import *
 from DQM.CastorMonitor.castor_dqm_sourceclient_offline_cff import *
 
@@ -36,7 +36,7 @@ DQMOfflineCosmicsMuonDPG = cms.Sequence( dtSourcesCosmics *
 
 from Configuration.Eras.Modifier_run3_GEM_cff import run3_GEM
 _run3_GEM_DQMOfflineCosmicsMuonDPG = DQMOfflineCosmicsMuonDPG.copy()
-_run3_GEM_DQMOfflineCosmicsMuonDPG += gemSources
+_run3_GEM_DQMOfflineCosmicsMuonDPG += gemSourcesCosmics
 run3_GEM.toReplaceWith(DQMOfflineCosmicsMuonDPG, _run3_GEM_DQMOfflineCosmicsMuonDPG)
 
 

--- a/DQMOffline/Muon/BuildFile.xml
+++ b/DQMOffline/Muon/BuildFile.xml
@@ -15,4 +15,6 @@
 <use name="CondFormats/DataRecord"/>
 <use name="EventFilter/CSCRawToDigi"/>
 <use name="CommonTools/TriggerUtils"/>
+<use name="Validation/MuonGEMHits"/>
+<use name="Validation/MuonHits"/>
 <flags EDM_PLUGIN="1"/>

--- a/DQMOffline/Muon/interface/GEMEfficiencyAnalyzer.h
+++ b/DQMOffline/Muon/interface/GEMEfficiencyAnalyzer.h
@@ -1,63 +1,124 @@
 #ifndef DQMOffline_Muon_GEMEfficiencyAnalyzer_h
 #define DQMOffline_Muon_GEMEfficiencyAnalyzer_h
 
+/** \class GEMEfficiencyAnalyzer
+ * 
+ * DQM monitoring source for GEM efficiency and resolution
+ * based on https://github.com/CPLUOS/MuonPerformance/blob/master/MuonAnalyser/plugins/SliceTestEfficiencyAnalysis.cc
+ *
+ * \author Seungjin Yang <seungjin.yang@cern.ch>
+ */
+
 #include "DQMOffline/Muon/interface/GEMOfflineDQMBase.h"
 #include "FWCore/Utilities/interface/EDGetToken.h"
 #include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "DataFormats/GEMRecHit/interface/GEMRecHitCollection.h"
 #include "DataFormats/PatCandidates/interface/Muon.h"
 #include "DataFormats/MuonReco/interface/MuonSelectors.h"
-#include "Geometry/GEMGeometry/interface/GEMGeometry.h"
 #include "RecoMuon/TrackingTools/interface/MuonServiceProxy.h"
+#include "TrackingTools/TransientTrack/interface/TransientTrack.h"
+
 
 class GEMEfficiencyAnalyzer : public GEMOfflineDQMBase {
 public:
   explicit GEMEfficiencyAnalyzer(const edm::ParameterSet &);
   ~GEMEfficiencyAnalyzer() override;
+  static void fillDescriptions(edm::ConfigurationDescriptions &);
 
 protected:
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
   void analyze(const edm::Event &event, const edm::EventSetup &eventSetup) override;
 
 private:
-  void bookDetectorOccupancy(
-      DQMStore::IBooker &, const GEMStation *, const MEMapKey1 &, const TString &, const TString &);
-  void bookOccupancy(DQMStore::IBooker &, const MEMapKey2 &, const TString &, const TString &);
-  void bookResolution(DQMStore::IBooker &, const MEMapKey3 &, const TString &, const TString &);
+  struct GEMLayerData {
+    GEMLayerData(Disk::DiskPointer surface,
+                 std::vector<const GEMChamber*> chambers,
+                 int region, int station, int layer)
+        : surface(surface), chambers(chambers), region(region),
+          station(station), layer(layer) {}
 
-  const GEMRecHit *findMatchedHit(const float, const GEMRecHitCollection::range &);
+    Disk::DiskPointer surface;
+    std::vector<const GEMChamber*> chambers;
+    int region, station, layer;
+  };
 
+  MonitorElement* bookNumerator1D(DQMStore::IBooker&, MonitorElement*);
+  MonitorElement* bookNumerator2D(DQMStore::IBooker&, MonitorElement*);
+
+  void bookEfficiencyMomentum(DQMStore::IBooker &, const edm::ESHandle<GEMGeometry>&);
+  void bookEfficiencyChamber(DQMStore::IBooker &, const edm::ESHandle<GEMGeometry>&);
+  void bookEfficiencyEtaPartition(DQMStore::IBooker &, const edm::ESHandle<GEMGeometry>&);
+  void bookResolution(DQMStore::IBooker &, const edm::ESHandle<GEMGeometry>&);
+  void bookMisc(DQMStore::IBooker &, const edm::ESHandle<GEMGeometry>&);
+
+  inline bool isInsideOut(const reco::Track&);
+
+  std::vector<GEMLayerData> buildGEMLayers(const edm::ESHandle<GEMGeometry>&);
+  const reco::Track* getTrack(const reco::Muon&);
+  std::pair<TrajectoryStateOnSurface, DetId> getStartingState(const reco::TransientTrack&, const GEMLayerData&, const edm::ESHandle<GlobalTrackingGeometry>&);
+  std::pair<TrajectoryStateOnSurface, DetId> findStartingState(const reco::TransientTrack&, const GEMLayerData&, const edm::ESHandle<GlobalTrackingGeometry>&);
+  bool isME11(const DetId&);
+  bool skipLayer(const reco::Track*, const GEMLayerData&);
+  bool checkBounds(const GlobalPoint&, const Plane&);
+  const GEMEtaPartition* findEtaPartition(const GlobalPoint&, const std::vector<const GEMChamber*>&);
+  std::pair<const GEMRecHit *, float> findClosetHit(const GlobalPoint&, const GEMRecHitCollection::range &, const GEMEtaPartition*);
+
+
+  // data members
+
+  // parameters
+  std::string name_;
+  std::string folder_;
   edm::EDGetTokenT<GEMRecHitCollection> rechit_token_;
   edm::EDGetTokenT<edm::View<reco::Muon> > muon_token_;
-
-  MuonServiceProxy *muon_service_;
-
+  bool is_cosmics_;
   bool use_global_muon_;
-  float residual_x_cut_;
-
-  std::vector<double> pt_binning_;
+  bool use_skip_layer_;
+  bool use_only_me11_;
+  float residual_rphi_cut_;
+  bool use_prop_r_error_cut_;
+  double prop_r_error_cut_;
+  bool use_prop_phi_error_cut_;
+  double prop_phi_error_cut_;
+  std::vector<double> pt_bins_;
   int eta_nbins_;
   double eta_low_;
   double eta_up_;
 
-  std::string folder_;
+  // data mebers derived from parameters
+  MuonServiceProxy *muon_service_;
+  double pt_clamp_max_;
+  double eta_clamp_max_;
 
-  TString title_;
-  TString matched_title_;
+  // MonitorElement
+  // efficiency
+  MEMap me_muon_pt_; // 1D, region-station
+  MEMap me_muon_pt_matched_;
+  MEMap me_muon_eta_; // 1D, region-station
+  MEMap me_muon_eta_matched_;
+  MEMap me_muon_phi_; // 1D, region-station
+  MEMap me_muon_phi_matched_;
+  MEMap me_chamber_; // 2D, region-station-layer
+  MEMap me_chamber_matched_;
+  MEMap me_detector_; // 2D, region-station
+  MEMap me_detector_matched_;
+  // resolution
+  MEMap me_residual_rphi_;    // global
+  MEMap me_residual_y_;    // local
+  MEMap me_pull_phi_;
+  MEMap me_pull_y_;
+  // MEs for optimizing cut values
+  MonitorElement* me_prop_r_err_; // clamped
+  MonitorElement* me_prop_phi_err_; // clamped
+  MonitorElement* me_all_abs_residual_rphi_;
 
-  MEMap1 me_detector_;
-  MEMap1 me_detector_matched_;
-
-  MEMap2 me_muon_pt_;
-  MEMap2 me_muon_eta_;
-  MEMap2 me_muon_pt_matched_;
-  MEMap2 me_muon_eta_matched_;
-
-  MEMap3 me_residual_x_;    // local
-  MEMap3 me_residual_y_;    // local
-  MEMap3 me_residual_phi_;  // global
-  MEMap3 me_pull_x_;
-  MEMap3 me_pull_y_;
+  // const
+  const std::string kLogCategory_ = "GEMEfficiencyAnalyzer";
 };
+
+inline bool GEMEfficiencyAnalyzer::isInsideOut(const reco::Track& track) {
+  return track.innerPosition().mag2() > track.outerPosition().mag2();
+}
 
 #endif  // DQMOffline_Muon_GEMEfficiencyAnalyzer_h

--- a/DQMOffline/Muon/interface/GEMEfficiencyAnalyzer.h
+++ b/DQMOffline/Muon/interface/GEMEfficiencyAnalyzer.h
@@ -1,4 +1,4 @@
-eifndef DQMOffline_Muon_GEMEfficiencyAnalyzer_h
+#ifndef DQMOffline_Muon_GEMEfficiencyAnalyzer_h;
 #define DQMOffline_Muon_GEMEfficiencyAnalyzer_h
 
 /** \class GEMEfficiencyAnalyzer

--- a/DQMOffline/Muon/interface/GEMEfficiencyAnalyzer.h
+++ b/DQMOffline/Muon/interface/GEMEfficiencyAnalyzer.h
@@ -1,4 +1,4 @@
-#ifndef DQMOffline_Muon_GEMEfficiencyAnalyzer_h
+eifndef DQMOffline_Muon_GEMEfficiencyAnalyzer_h
 #define DQMOffline_Muon_GEMEfficiencyAnalyzer_h
 
 /** \class GEMEfficiencyAnalyzer
@@ -107,7 +107,6 @@ private:
   // resolution
   MEMap me_residual_rphi_;  // global
   MEMap me_residual_y_;     // local
-  MEMap me_pull_phi_;
   MEMap me_pull_y_;
   // MEs for optimizing cut values
   MonitorElement *me_prop_r_err_;    // clamped

--- a/DQMOffline/Muon/interface/GEMEfficiencyAnalyzer.h
+++ b/DQMOffline/Muon/interface/GEMEfficiencyAnalyzer.h
@@ -112,6 +112,7 @@ private:
   MonitorElement *me_prop_r_err_;    // clamped
   MonitorElement *me_prop_phi_err_;  // clamped
   MonitorElement *me_all_abs_residual_rphi_;
+  MEMap me_prop_chamber_;
 
   // const
   const std::string kLogCategory_ = "GEMEfficiencyAnalyzer";

--- a/DQMOffline/Muon/interface/GEMEfficiencyAnalyzer.h
+++ b/DQMOffline/Muon/interface/GEMEfficiencyAnalyzer.h
@@ -1,4 +1,4 @@
-#ifndef DQMOffline_Muon_GEMEfficiencyAnalyzer_h;
+#ifndef DQMOffline_Muon_GEMEfficiencyAnalyzer_h
 #define DQMOffline_Muon_GEMEfficiencyAnalyzer_h
 
 /** \class GEMEfficiencyAnalyzer

--- a/DQMOffline/Muon/interface/GEMEfficiencyAnalyzer.h
+++ b/DQMOffline/Muon/interface/GEMEfficiencyAnalyzer.h
@@ -19,7 +19,6 @@
 #include "RecoMuon/TrackingTools/interface/MuonServiceProxy.h"
 #include "TrackingTools/TransientTrack/interface/TransientTrack.h"
 
-
 class GEMEfficiencyAnalyzer : public GEMOfflineDQMBase {
 public:
   explicit GEMEfficiencyAnalyzer(const edm::ParameterSet &);
@@ -32,38 +31,40 @@ protected:
 
 private:
   struct GEMLayerData {
-    GEMLayerData(Disk::DiskPointer surface,
-                 std::vector<const GEMChamber*> chambers,
-                 int region, int station, int layer)
-        : surface(surface), chambers(chambers), region(region),
-          station(station), layer(layer) {}
+    GEMLayerData(Disk::DiskPointer surface, std::vector<const GEMChamber *> chambers, int region, int station, int layer)
+        : surface(surface), chambers(chambers), region(region), station(station), layer(layer) {}
 
     Disk::DiskPointer surface;
-    std::vector<const GEMChamber*> chambers;
+    std::vector<const GEMChamber *> chambers;
     int region, station, layer;
   };
 
-  MonitorElement* bookNumerator1D(DQMStore::IBooker&, MonitorElement*);
-  MonitorElement* bookNumerator2D(DQMStore::IBooker&, MonitorElement*);
+  MonitorElement *bookNumerator1D(DQMStore::IBooker &, MonitorElement *);
+  MonitorElement *bookNumerator2D(DQMStore::IBooker &, MonitorElement *);
 
-  void bookEfficiencyMomentum(DQMStore::IBooker &, const edm::ESHandle<GEMGeometry>&);
-  void bookEfficiencyChamber(DQMStore::IBooker &, const edm::ESHandle<GEMGeometry>&);
-  void bookEfficiencyEtaPartition(DQMStore::IBooker &, const edm::ESHandle<GEMGeometry>&);
-  void bookResolution(DQMStore::IBooker &, const edm::ESHandle<GEMGeometry>&);
-  void bookMisc(DQMStore::IBooker &, const edm::ESHandle<GEMGeometry>&);
+  void bookEfficiencyMomentum(DQMStore::IBooker &, const edm::ESHandle<GEMGeometry> &);
+  void bookEfficiencyChamber(DQMStore::IBooker &, const edm::ESHandle<GEMGeometry> &);
+  void bookEfficiencyEtaPartition(DQMStore::IBooker &, const edm::ESHandle<GEMGeometry> &);
+  void bookResolution(DQMStore::IBooker &, const edm::ESHandle<GEMGeometry> &);
+  void bookMisc(DQMStore::IBooker &, const edm::ESHandle<GEMGeometry> &);
 
-  inline bool isInsideOut(const reco::Track&);
+  inline bool isInsideOut(const reco::Track &);
 
-  std::vector<GEMLayerData> buildGEMLayers(const edm::ESHandle<GEMGeometry>&);
-  const reco::Track* getTrack(const reco::Muon&);
-  std::pair<TrajectoryStateOnSurface, DetId> getStartingState(const reco::TransientTrack&, const GEMLayerData&, const edm::ESHandle<GlobalTrackingGeometry>&);
-  std::pair<TrajectoryStateOnSurface, DetId> findStartingState(const reco::TransientTrack&, const GEMLayerData&, const edm::ESHandle<GlobalTrackingGeometry>&);
-  bool isME11(const DetId&);
-  bool skipLayer(const reco::Track*, const GEMLayerData&);
-  bool checkBounds(const GlobalPoint&, const Plane&);
-  const GEMEtaPartition* findEtaPartition(const GlobalPoint&, const std::vector<const GEMChamber*>&);
-  std::pair<const GEMRecHit *, float> findClosetHit(const GlobalPoint&, const GEMRecHitCollection::range &, const GEMEtaPartition*);
-
+  std::vector<GEMLayerData> buildGEMLayers(const edm::ESHandle<GEMGeometry> &);
+  const reco::Track *getTrack(const reco::Muon &);
+  std::pair<TrajectoryStateOnSurface, DetId> getStartingState(const reco::TransientTrack &,
+                                                              const GEMLayerData &,
+                                                              const edm::ESHandle<GlobalTrackingGeometry> &);
+  std::pair<TrajectoryStateOnSurface, DetId> findStartingState(const reco::TransientTrack &,
+                                                               const GEMLayerData &,
+                                                               const edm::ESHandle<GlobalTrackingGeometry> &);
+  bool isME11(const DetId &);
+  bool skipLayer(const reco::Track *, const GEMLayerData &);
+  bool checkBounds(const GlobalPoint &, const Plane &);
+  const GEMEtaPartition *findEtaPartition(const GlobalPoint &, const std::vector<const GEMChamber *> &);
+  std::pair<const GEMRecHit *, float> findClosetHit(const GlobalPoint &,
+                                                    const GEMRecHitCollection::range &,
+                                                    const GEMEtaPartition *);
 
   // data members
 
@@ -93,31 +94,31 @@ private:
 
   // MonitorElement
   // efficiency
-  MEMap me_muon_pt_; // 1D, region-station
+  MEMap me_muon_pt_;  // 1D, region-station
   MEMap me_muon_pt_matched_;
-  MEMap me_muon_eta_; // 1D, region-station
+  MEMap me_muon_eta_;  // 1D, region-station
   MEMap me_muon_eta_matched_;
-  MEMap me_muon_phi_; // 1D, region-station
+  MEMap me_muon_phi_;  // 1D, region-station
   MEMap me_muon_phi_matched_;
-  MEMap me_chamber_; // 2D, region-station-layer
+  MEMap me_chamber_;  // 2D, region-station-layer
   MEMap me_chamber_matched_;
-  MEMap me_detector_; // 2D, region-station
+  MEMap me_detector_;  // 2D, region-station
   MEMap me_detector_matched_;
   // resolution
-  MEMap me_residual_rphi_;    // global
-  MEMap me_residual_y_;    // local
+  MEMap me_residual_rphi_;  // global
+  MEMap me_residual_y_;     // local
   MEMap me_pull_phi_;
   MEMap me_pull_y_;
   // MEs for optimizing cut values
-  MonitorElement* me_prop_r_err_; // clamped
-  MonitorElement* me_prop_phi_err_; // clamped
-  MonitorElement* me_all_abs_residual_rphi_;
+  MonitorElement *me_prop_r_err_;    // clamped
+  MonitorElement *me_prop_phi_err_;  // clamped
+  MonitorElement *me_all_abs_residual_rphi_;
 
   // const
   const std::string kLogCategory_ = "GEMEfficiencyAnalyzer";
 };
 
-inline bool GEMEfficiencyAnalyzer::isInsideOut(const reco::Track& track) {
+inline bool GEMEfficiencyAnalyzer::isInsideOut(const reco::Track &track) {
   return track.innerPosition().mag2() > track.outerPosition().mag2();
 }
 

--- a/DQMOffline/Muon/interface/GEMEfficiencyHarvester.h
+++ b/DQMOffline/Muon/interface/GEMEfficiencyHarvester.h
@@ -1,9 +1,18 @@
 #ifndef DQMOffline_Muon_GEMEfficiencyHarvester_h
 #define DQMOffline_Muon_GEMEfficiencyHarvester_h
 
+/** \class GEMEfficiencyAnalyzer
+ * 
+ * DQM monitoring client for GEM efficiency and resolution
+ * based on Validation/MuonGEMHits/MuonGEMBaseHarvestor
+ *
+ * \author Seungjin Yang <seungjin.yang@cern.ch>
+ */
+
 #include "DQMServices/Core/interface/DQMEDHarvester.h"
 #include "DQMServices/Core/interface/DQMStore.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 
 #include <vector>
 #include <string>
@@ -12,21 +21,30 @@ class GEMEfficiencyHarvester : public DQMEDHarvester {
 public:
   GEMEfficiencyHarvester(const edm::ParameterSet&);
   ~GEMEfficiencyHarvester() override;
+  static void fillDescriptions(edm::ConfigurationDescriptions &);
   void dqmEndJob(DQMStore::IBooker&, DQMStore::IGetter&) override;
 
 private:
   TProfile* computeEfficiency(const TH1F*, const TH1F*, const char*, const char*, const double confidence_level = 0.683);
-
   TH2F* computeEfficiency(const TH2F*, const TH2F*, const char*, const char*);
-
   std::vector<std::string> splitString(std::string, const std::string);
-  std::tuple<std::string, int, bool, int> parseResidualName(std::string, const std::string);
-
+  std::tuple<std::string, int, int> parseResidualName(std::string, const std::string);
   void doEfficiency(DQMStore::IBooker&, DQMStore::IGetter&);
   void doResolution(DQMStore::IBooker&, DQMStore::IGetter&, const std::string);
+
+  template <typename T>
+  int findResolutionBin(const T&, const std::vector<T>&);
 
   std::string folder_;
   std::string log_category_;
 };
+
+
+template<typename T>
+int GEMEfficiencyHarvester::findResolutionBin(const T& elem, const std::vector<T>& vec) {
+  auto iter = std::find(vec.begin(), vec.end(), elem);
+  int bin = (iter != vec.end()) ? std::distance(vec.begin(), iter) + 1 : -1;
+  return bin;
+}
 
 #endif  // DQMOffline_Muon_GEMEfficiencyHarvester_h

--- a/DQMOffline/Muon/interface/GEMEfficiencyHarvester.h
+++ b/DQMOffline/Muon/interface/GEMEfficiencyHarvester.h
@@ -21,7 +21,7 @@ class GEMEfficiencyHarvester : public DQMEDHarvester {
 public:
   GEMEfficiencyHarvester(const edm::ParameterSet&);
   ~GEMEfficiencyHarvester() override;
-  static void fillDescriptions(edm::ConfigurationDescriptions &);
+  static void fillDescriptions(edm::ConfigurationDescriptions&);
   void dqmEndJob(DQMStore::IBooker&, DQMStore::IGetter&) override;
 
 private:
@@ -39,8 +39,7 @@ private:
   std::string log_category_;
 };
 
-
-template<typename T>
+template <typename T>
 int GEMEfficiencyHarvester::findResolutionBin(const T& elem, const std::vector<T>& vec) {
   auto iter = std::find(vec.begin(), vec.end(), elem);
   int bin = (iter != vec.end()) ? std::distance(vec.begin(), iter) + 1 : -1;

--- a/DQMOffline/Muon/interface/GEMOfflineDQMBase.h
+++ b/DQMOffline/Muon/interface/GEMOfflineDQMBase.h
@@ -8,13 +8,12 @@
 #include "DataFormats/MuonDetId/interface/GEMDetId.h"
 #include "Geometry/GEMGeometry/interface/GEMGeometry.h"
 
-
 class GEMOfflineDQMBase : public DQMEDAnalyzer {
 public:
   using MEMap = std::map<GEMDetId, dqm::impl::MonitorElement*>;
 
   explicit GEMOfflineDQMBase(const edm::ParameterSet&);
- 
+
   inline int getVFATNumber(const int, const int, const int);
   inline int getVFATNumberByStrip(const int, const int, const int);
   inline int getMaxVFAT(const int);
@@ -26,19 +25,19 @@ public:
   inline GEMDetId getReStLaKey(const GEMDetId&);
   inline GEMDetId getReStEtKey(const GEMDetId&);
   inline GEMDetId getReStLaChKey(const GEMDetId&);
-  inline GEMDetId getKey(const GEMDetId&); // == getReStLaChEtKey
+  inline GEMDetId getKey(const GEMDetId&);  // == getReStLaChEtKey
 
   int getDetOccXBin(const GEMDetId&, const edm::ESHandle<GEMGeometry>&);
   void setDetLabelsVFAT(MonitorElement*, const GEMStation*);
   void setDetLabelsEta(MonitorElement*, const GEMStation*);
-  int getNumEtaPartitions(const GEMStation*); // the number of eta partitions per GEMChamber
+  int getNumEtaPartitions(const GEMStation*);  // the number of eta partitions per GEMChamber
   void fillME(MEMap& me_map, const GEMDetId& key, const float x);
   void fillME(MEMap& me_map, const GEMDetId& key, const float x, const float y);
 
   template <typename T>
   inline bool checkRefs(const std::vector<T*>&);
 
-  // 
+  //
   std::string log_category_;
 };
 
@@ -81,9 +80,7 @@ inline GEMDetId GEMOfflineDQMBase::getReStKey(const int region, const int statio
   return GEMDetId{region, 1, station, 0, 0, 0};
 }
 
-inline GEMDetId GEMOfflineDQMBase::getReStKey(const GEMDetId& id) {
-  return getReStKey(id.region(), id.station());
-}
+inline GEMDetId GEMOfflineDQMBase::getReStKey(const GEMDetId& id) { return getReStKey(id.region(), id.station()); }
 
 inline GEMDetId GEMOfflineDQMBase::getReStLaKey(const GEMDetId& id) {
   return GEMDetId{id.region(), 1, id.station(), id.layer(), 0, 0};

--- a/DQMOffline/Muon/interface/GEMOfflineDQMBase.h
+++ b/DQMOffline/Muon/interface/GEMOfflineDQMBase.h
@@ -8,100 +8,46 @@
 #include "DataFormats/MuonDetId/interface/GEMDetId.h"
 #include "Geometry/GEMGeometry/interface/GEMGeometry.h"
 
+
 class GEMOfflineDQMBase : public DQMEDAnalyzer {
 public:
+  using MEMap = std::map<GEMDetId, dqm::impl::MonitorElement*>;
+
   explicit GEMOfflineDQMBase(const edm::ParameterSet&);
-
-  typedef std::tuple<int, int> MEMapKey1;             // (region, station)
-  typedef std::tuple<int, int, bool> MEMapKey2;       // (region, station, is odd superchamber)
-  typedef std::tuple<int, int, bool, int> MEMapKey3;  // (region, station, is odd superchamber, ieta)
-  typedef std::map<MEMapKey1, MonitorElement*> MEMap1;
-  typedef std::map<MEMapKey2, MonitorElement*> MEMap2;
-  typedef std::map<MEMapKey3, MonitorElement*> MEMap3;
-
+ 
   inline int getVFATNumber(const int, const int, const int);
   inline int getVFATNumberByStrip(const int, const int, const int);
   inline int getMaxVFAT(const int);
   inline int getDetOccXBin(const int, const int, const int);
 
+  // Re: region / St: station, La: layer, Ch: chamber parity, Et: eta partition
+  inline GEMDetId getReStKey(const int, const int);
+  inline GEMDetId getReStKey(const GEMDetId&);
+  inline GEMDetId getReStLaKey(const GEMDetId&);
+  inline GEMDetId getReStEtKey(const GEMDetId&);
+  inline GEMDetId getReStLaChKey(const GEMDetId&);
+  inline GEMDetId getKey(const GEMDetId&); // == getReStLaChEtKey
+
   int getDetOccXBin(const GEMDetId&, const edm::ESHandle<GEMGeometry>&);
   void setDetLabelsVFAT(MonitorElement*, const GEMStation*);
   void setDetLabelsEta(MonitorElement*, const GEMStation*);
-  // the number of eta partitions per GEMChamber
-  int getNumEtaPartitions(const GEMStation*);
-
-  template <typename AnyKey>
-  TString convertKeyToStr(const AnyKey& key);
-
-  template <typename AnyKey>
-  void fillME(std::map<AnyKey, MonitorElement*>&, const AnyKey&, const float);
-
-  template <typename AnyKey>
-  void fillME(std::map<AnyKey, MonitorElement*>&, const AnyKey&, const float, const float y);
+  int getNumEtaPartitions(const GEMStation*); // the number of eta partitions per GEMChamber
+  void fillME(MEMap& me_map, const GEMDetId& key, const float x);
+  void fillME(MEMap& me_map, const GEMDetId& key, const float x, const float y);
 
   template <typename T>
   inline bool checkRefs(const std::vector<T*>&);
 
+  // 
   std::string log_category_;
-
-  class BookingHelper {
-  public:
-    BookingHelper(DQMStore::IBooker& ibooker, const TString& name_suffix, const TString& title_suffix)
-        : ibooker_(&ibooker), name_suffix_(name_suffix), title_suffix_(title_suffix) {}
-
-    ~BookingHelper() {}
-
-    MonitorElement* book1D(TString name,
-                           TString title,
-                           int nbinsx,
-                           double xlow,
-                           double xup,
-                           TString x_title = "",
-                           TString y_title = "Entries") {
-      name += name_suffix_;
-      title += title_suffix_ + ";" + x_title + ";" + y_title;
-      return ibooker_->book1D(name, title, nbinsx, xlow, xup);
-    }
-
-    MonitorElement* book1D(TString name,
-                           TString title,
-                           std::vector<double>& x_binning,
-                           TString x_title = "",
-                           TString y_title = "Entries") {
-      name += name_suffix_;
-      title += title_suffix_ + ";" + x_title + ";" + y_title;
-      TH1F* h_obj = new TH1F(name, title, x_binning.size() - 1, &x_binning[0]);
-      return ibooker_->book1D(name, h_obj);
-    }
-
-    MonitorElement* book2D(TString name,
-                           TString title,
-                           int nbinsx,
-                           double xlow,
-                           double xup,
-                           int nbinsy,
-                           double ylow,
-                           double yup,
-                           TString x_title = "",
-                           TString y_title = "") {
-      name += name_suffix_;
-      title += title_suffix_ + ";" + x_title + ";" + y_title;
-      return ibooker_->book2D(name, title, nbinsx, xlow, xup, nbinsy, ylow, yup);
-    }
-
-  private:
-    DQMStore::IBooker* ibooker_;
-    const TString name_suffix_;
-    const TString title_suffix_;
-  };  // BookingHelper
 };
 
 inline int GEMOfflineDQMBase::getMaxVFAT(const int station) {
-  if (GEMSubDetId::station(station) == GEMSubDetId::Station::GE0)
+  if (station == 0)
     return GEMeMap::maxVFatGE0_;
-  else if (GEMSubDetId::station(station) == GEMSubDetId::Station::GE11)
+  else if (station == 1)
     return GEMeMap::maxVFatGE11_;
-  else if (GEMSubDetId::station(station) == GEMSubDetId::Station::GE21)
+  else if (station == 2)
     return GEMeMap::maxVFatGE21_;
   else
     return -1;
@@ -115,7 +61,7 @@ inline int GEMOfflineDQMBase::getVFATNumber(const int station, const int ieta, c
 inline int GEMOfflineDQMBase::getVFATNumberByStrip(const int station, const int ieta, const int strip) {
   const int vfat_phi = (strip % GEMeMap::maxChan_) ? strip / GEMeMap::maxChan_ + 1 : strip / GEMeMap::maxChan_;
   return getVFATNumber(station, ieta, vfat_phi);
-};
+}
 
 inline int GEMOfflineDQMBase::getDetOccXBin(const int chamber, const int layer, const int n_chambers) {
   return n_chambers * (chamber - 1) + layer;
@@ -130,52 +76,29 @@ inline bool GEMOfflineDQMBase::checkRefs(const std::vector<T*>& refs) {
   return true;
 }
 
-template <typename AnyKey>
-TString GEMOfflineDQMBase::convertKeyToStr(const AnyKey& key) {
-  if constexpr (std::is_same_v<AnyKey, MEMapKey1>) {
-    return TString::Format("Region %d, Station %d.", std::get<0>(key), std::get<1>(key));
-
-  } else if constexpr (std::is_same_v<AnyKey, MEMapKey2>) {
-    const char* superchamber_type = std::get<2>(key) ? "Odd" : "Even";
-    return TString::Format(
-        "Region %d, Station %d, %s Superchamber", std::get<0>(key), std::get<1>(key), superchamber_type);
-
-  } else if constexpr (std::is_same_v<AnyKey, MEMapKey3>) {
-    const char* superchamber_type = std::get<2>(key) ? "Odd" : "Even";
-    return TString::Format("Region %d, Station %d, %s Superchamber, Roll %d",
-                           std::get<0>(key),
-                           std::get<1>(key),
-                           superchamber_type,
-                           std::get<3>(key));
-
-  } else {
-    return TString::Format("unknown key type: %s", typeid(key).name());
-  }
+inline GEMDetId GEMOfflineDQMBase::getReStKey(const int region, const int station) {
+  // region, ring, station, layer, chamber, roll
+  return GEMDetId{region, 1, station, 0, 0, 0};
 }
 
-template <typename AnyKey>
-void GEMOfflineDQMBase::fillME(std::map<AnyKey, MonitorElement*>& me_map, const AnyKey& key, const float x) {
-  if (me_map.find(key) == me_map.end()) {
-    const TString&& key_str = convertKeyToStr(key);
-    edm::LogError(log_category_) << "got invalid key: " << key_str << std::endl;
-
-  } else {
-    me_map[key]->Fill(x);
-  }
+inline GEMDetId GEMOfflineDQMBase::getReStKey(const GEMDetId& id) {
+  return getReStKey(id.region(), id.station());
 }
 
-template <typename AnyKey>
-void GEMOfflineDQMBase::fillME(std::map<AnyKey, MonitorElement*>& me_map,
-                               const AnyKey& key,
-                               const float x,
-                               const float y) {
-  if (me_map.find(key) == me_map.end()) {
-    const TString&& key_str = convertKeyToStr(key);
-    edm::LogError(log_category_) << "got invalid key: " << key_str << std::endl;
+inline GEMDetId GEMOfflineDQMBase::getReStLaKey(const GEMDetId& id) {
+  return GEMDetId{id.region(), 1, id.station(), id.layer(), 0, 0};
+}
 
-  } else {
-    me_map[key]->Fill(x, y);
-  }
+inline GEMDetId GEMOfflineDQMBase::getReStEtKey(const GEMDetId& id) {
+  return GEMDetId{id.region(), 1, id.station(), 0, 0, id.roll()};
+}
+
+inline GEMDetId GEMOfflineDQMBase::getReStLaChKey(const GEMDetId& id) {
+  return GEMDetId{id.region(), 1, id.station(), id.layer(), id.chamber() % 2, 0};
+}
+
+inline GEMDetId GEMOfflineDQMBase::getKey(const GEMDetId& id) {
+  return GEMDetId{id.region(), 1, id.station(), id.layer(), id.chamber() % 2, id.roll()};
 }
 
 #endif  // DQMOffline_Muon_GEMOfflineDQMBase_h

--- a/DQMOffline/Muon/interface/GEMOfflineMonitor.h
+++ b/DQMOffline/Muon/interface/GEMOfflineMonitor.h
@@ -9,7 +9,6 @@
 #include "DataFormats/GEMDigi/interface/GEMDigiCollection.h"
 #include "DataFormats/GEMRecHit/interface/GEMRecHitCollection.h"
 
-
 class GEMOfflineMonitor : public GEMOfflineDQMBase {
 public:
   explicit GEMOfflineMonitor(const edm::ParameterSet &);
@@ -21,11 +20,11 @@ protected:
   void analyze(const edm::Event &event, const edm::EventSetup &eventSetup) override;
 
 private:
-  void bookDigiOccupancy(DQMStore::IBooker &, const edm::ESHandle<GEMGeometry>&);
-  void bookHitOccupancy(DQMStore::IBooker &, const edm::ESHandle<GEMGeometry>&);
+  void bookDigiOccupancy(DQMStore::IBooker &, const edm::ESHandle<GEMGeometry> &);
+  void bookHitOccupancy(DQMStore::IBooker &, const edm::ESHandle<GEMGeometry> &);
 
-  void doDigiOccupancy(const edm::ESHandle<GEMGeometry>&, const edm::Handle<GEMDigiCollection>&);
-  void doHitOccupancy(const edm::ESHandle<GEMGeometry>&, const edm::Handle<GEMRecHitCollection>&);
+  void doDigiOccupancy(const edm::ESHandle<GEMGeometry> &, const edm::Handle<GEMDigiCollection> &);
+  void doHitOccupancy(const edm::ESHandle<GEMGeometry> &, const edm::Handle<GEMRecHitCollection> &);
 
   edm::EDGetTokenT<GEMDigiCollection> digi_token_;
   edm::EDGetTokenT<GEMRecHitCollection> rechit_token_;
@@ -33,8 +32,8 @@ private:
   bool do_digi_occupancy_;
   bool do_hit_occupancy_;
 
-  MEMap me_digi_det_; // TH2F, region-station
-  MEMap me_hit_det_; // TH2F, region-station
+  MEMap me_digi_det_;  // TH2F, region-station
+  MEMap me_hit_det_;   // TH2F, region-station
 };
 
 #endif  // DQMOffline_Muon_GEMOfflineMonitor_h

--- a/DQMOffline/Muon/interface/GEMOfflineMonitor.h
+++ b/DQMOffline/Muon/interface/GEMOfflineMonitor.h
@@ -2,11 +2,13 @@
 #define DQMOffline_Muon_GEMOfflineMonitor_h
 
 #include "DQMOffline/Muon/interface/GEMOfflineDQMBase.h"
+
 #include "FWCore/Utilities/interface/EDGetToken.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "DataFormats/GEMDigi/interface/GEMDigiCollection.h"
 #include "DataFormats/GEMRecHit/interface/GEMRecHitCollection.h"
+
 
 class GEMOfflineMonitor : public GEMOfflineDQMBase {
 public:
@@ -19,16 +21,20 @@ protected:
   void analyze(const edm::Event &event, const edm::EventSetup &eventSetup) override;
 
 private:
-  void bookDetectorOccupancy(
-      DQMStore::IBooker &, const GEMStation *, const MEMapKey1 &, const TString &, const TString &);
+  void bookDigiOccupancy(DQMStore::IBooker &, const edm::ESHandle<GEMGeometry>&);
+  void bookHitOccupancy(DQMStore::IBooker &, const edm::ESHandle<GEMGeometry>&);
+
+  void doDigiOccupancy(const edm::ESHandle<GEMGeometry>&, const edm::Handle<GEMDigiCollection>&);
+  void doHitOccupancy(const edm::ESHandle<GEMGeometry>&, const edm::Handle<GEMRecHitCollection>&);
 
   edm::EDGetTokenT<GEMDigiCollection> digi_token_;
   edm::EDGetTokenT<GEMRecHitCollection> rechit_token_;
 
-  std::string log_category_;
+  bool do_digi_occupancy_;
+  bool do_hit_occupancy_;
 
-  MEMap1 me_digi_det_;
-  MEMap1 me_hit_det_;
+  MEMap me_digi_det_; // TH2F, region-station
+  MEMap me_hit_det_; // TH2F, region-station
 };
 
 #endif  // DQMOffline_Muon_GEMOfflineMonitor_h

--- a/DQMOffline/Muon/python/gemEfficiencyAnalyzerCosmics_cfi.py
+++ b/DQMOffline/Muon/python/gemEfficiencyAnalyzerCosmics_cfi.py
@@ -20,8 +20,8 @@ gemEfficiencyAnalyzerCosmicsOneLeg = _gemEfficiencyAnalyzerCosmicsDefault.clone(
 from Configuration.Eras.Modifier_phase2_GEM_cff import phase2_GEM
 phase2_GEM.toModify(gemEfficiencyAnalyzerCosmics,
     etaNbins=cms.untracked.int32(15),
-    etaHigh=cms.untracked.double(3.0))
+    etaUp=cms.untracked.double(3.0))
 
 phase2_GEM.toModify(gemEfficiencyAnalyzerCosmicsOneLeg,
     etaNbins=cms.untracked.int32(15),
-    etaHigh=cms.untracked.double(3.0))
+    etaUp=cms.untracked.double(3.0))

--- a/DQMOffline/Muon/python/gemEfficiencyAnalyzerCosmics_cfi.py
+++ b/DQMOffline/Muon/python/gemEfficiencyAnalyzerCosmics_cfi.py
@@ -1,0 +1,27 @@
+import FWCore.ParameterSet.Config as cms
+from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
+from RecoMuon.TrackingTools.MuonServiceProxy_cff import MuonServiceProxy
+from DQMOffline.Muon.gemEfficiencyAnalyzerCosmicsDefault_cfi import gemEfficiencyAnalyzerCosmicsDefault as _gemEfficiencyAnalyzerCosmicsDefault
+
+gemEfficiencyAnalyzerCosmics = _gemEfficiencyAnalyzerCosmicsDefault.clone(
+    ServiceParameters = MuonServiceProxy.ServiceParameters.clone(),
+    muonTag = cms.InputTag('muons'),
+    name = cms.untracked.string('Cosmic 2-Leg STA Muon'),
+    folder = cms.untracked.string('GEM/Efficiency/type1'),
+)
+
+gemEfficiencyAnalyzerCosmicsOneLeg = _gemEfficiencyAnalyzerCosmicsDefault.clone(
+    ServiceParameters = MuonServiceProxy.ServiceParameters.clone(),
+    muonTag = cms.InputTag('muons1Leg'),
+    name = cms.untracked.string('Cosmic 1-Leg STA Muon'),
+    folder = cms.untracked.string('GEM/Efficiency/type2'),
+)
+
+from Configuration.Eras.Modifier_phase2_GEM_cff import phase2_GEM
+phase2_GEM.toModify(gemEfficiencyAnalyzerCosmics,
+    etaNbins=cms.untracked.int32(15),
+    etaHigh=cms.untracked.double(3.0))
+
+phase2_GEM.toModify(gemEfficiencyAnalyzerCosmicsOneLeg,
+    etaNbins=cms.untracked.int32(15),
+    etaHigh=cms.untracked.double(3.0))

--- a/DQMOffline/Muon/python/gemEfficiencyAnalyzer_cfi.py
+++ b/DQMOffline/Muon/python/gemEfficiencyAnalyzer_cfi.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
 from RecoMuon.TrackingTools.MuonServiceProxy_cff import MuonServiceProxy
-
+from DQMOffline.Muon.gemEfficiencyAnalyzerDefault_cfi import gemEfficiencyAnalyzerDefault as _gemEfficiencyAnalyzerDefault
 
 gemOfflineDQMTightGlbMuons = cms.EDFilter("MuonSelector",
     src = cms.InputTag('muons'),
@@ -14,7 +14,6 @@ gemOfflineDQMTightGlbMuons = cms.EDFilter("MuonSelector",
     filter = cms.bool(False)
 )
 
-
 gemOfflineDQMStaMuons = cms.EDFilter("MuonSelector",
     src = cms.InputTag('muons'),
     cut = cms.string(
@@ -25,38 +24,37 @@ gemOfflineDQMStaMuons = cms.EDFilter("MuonSelector",
     filter = cms.bool(False)
 )
 
-
-gemEfficiencyAnalyzerTight = DQMEDAnalyzer('GEMEfficiencyAnalyzer',
-    MuonServiceProxy,
+gemEfficiencyAnalyzerTightGlb = _gemEfficiencyAnalyzerDefault.clone(
+    ServiceParameters = MuonServiceProxy.ServiceParameters.clone(),
+    folder = cms.untracked.string('GEM/Efficiency/type1'),
     muonTag = cms.InputTag('gemOfflineDQMTightGlbMuons'),
-    recHitTag = cms.InputTag('gemRecHits'),
-    residualXCut = cms.double(5.0),
-    ptBinning = cms.untracked.vdouble(20. ,30., 40., 50., 60., 70., 80., 90., 100., 120., 140., 200.),
-    etaNbins = cms.untracked.int32(7),
-    etaLow = cms.untracked.double(1.5),
-    etaUp = cms.untracked.double(2.2),
+    name = cms.untracked.string('Tight GLB Muon'),
     useGlobalMuon = cms.untracked.bool(True),
-    folder = cms.untracked.string('GEM/GEMEfficiency/TightGlobalMuon'),
-    logCategory = cms.untracked.string('GEMEfficiencyAnalyzerTight'),
 )
 
-
-gemEfficiencyAnalyzerSTA = gemEfficiencyAnalyzerTight.clone()
-gemEfficiencyAnalyzerSTA.muonTag = cms.InputTag("gemOfflineDQMStaMuons")
-gemEfficiencyAnalyzerSTA.useGlobalMuon = cms.untracked.bool(False)
-gemEfficiencyAnalyzerSTA.folder = cms.untracked.string('GEM/GEMEfficiency/StandaloneMuon')
-gemEfficiencyAnalyzerSTA.logCategory = cms.untracked.string('GEMEfficiencyAnalyzerSTA')
-
+gemEfficiencyAnalyzerSta = _gemEfficiencyAnalyzerDefault.clone(
+    ServiceParameters = MuonServiceProxy.ServiceParameters.clone(),
+    muonTag = cms.InputTag("gemOfflineDQMStaMuons"),
+    folder = cms.untracked.string('GEM/Efficiency/type2'),
+    name = cms.untracked.string('STA Muon'),
+    useGlobalMuon = cms.untracked.bool(False),
+)
 
 from Configuration.Eras.Modifier_phase2_GEM_cff import phase2_GEM
-phase2_GEM.toModify(gemEfficiencyAnalyzerTight, etaNbins=cms.untracked.int32(15), etaHigh=cms.untracked.double(3.0))
-phase2_GEM.toModify(gemEfficiencyAnalyzerSTA, etaNbins=cms.untracked.int32(15), etaHigh=cms.untracked.double(3.0))
+phase2_GEM.toModify(
+    gemEfficiencyAnalyzerTightGlb,
+    etaNbins=cms.untracked.int32(15),
+    etaHigh=cms.untracked.double(3.0))
 
+phase2_GEM.toModify(
+    gemEfficiencyAnalyzerSta,
+    etaNbins=cms.untracked.int32(15),
+    etaHigh=cms.untracked.double(3.0))
 
-gemEfficiencyAnalyzerTightSeq = cms.Sequence(
+gemEfficiencyAnalyzerTightGlbSeq = cms.Sequence(
     cms.ignore(gemOfflineDQMTightGlbMuons) *
-    gemEfficiencyAnalyzerTight)
+    gemEfficiencyAnalyzerTightGlb)
 
-gemEfficiencyAnalyzerSTASeq = cms.Sequence(
+gemEfficiencyAnalyzerStaSeq = cms.Sequence(
     cms.ignore(gemOfflineDQMStaMuons) *
-    gemEfficiencyAnalyzerSTA)
+    gemEfficiencyAnalyzerSta)

--- a/DQMOffline/Muon/python/gemEfficiencyAnalyzer_cfi.py
+++ b/DQMOffline/Muon/python/gemEfficiencyAnalyzer_cfi.py
@@ -44,12 +44,12 @@ from Configuration.Eras.Modifier_phase2_GEM_cff import phase2_GEM
 phase2_GEM.toModify(
     gemEfficiencyAnalyzerTightGlb,
     etaNbins=cms.untracked.int32(15),
-    etaHigh=cms.untracked.double(3.0))
+    etaUp=cms.untracked.double(3.0))
 
 phase2_GEM.toModify(
     gemEfficiencyAnalyzerSta,
     etaNbins=cms.untracked.int32(15),
-    etaHigh=cms.untracked.double(3.0))
+    etaUp=cms.untracked.double(3.0))
 
 gemEfficiencyAnalyzerTightGlbSeq = cms.Sequence(
     cms.ignore(gemOfflineDQMTightGlbMuons) *

--- a/DQMOffline/Muon/python/gemEfficiencyHarvesterCosmics_cfi.py
+++ b/DQMOffline/Muon/python/gemEfficiencyHarvesterCosmics_cfi.py
@@ -1,0 +1,14 @@
+import FWCore.ParameterSet.Config as cms
+
+from DQMServices.Core.DQMEDHarvester import DQMEDHarvester
+from DQMOffline.Muon.gemEfficiencyHarvesterDefault_cfi import gemEfficiencyHarvesterDefault as _gemEfficiencyHarvesterDefault
+from DQMOffline.Muon.gemEfficiencyAnalyzerCosmics_cfi import gemEfficiencyAnalyzerCosmics as _gemEfficiencyAnalyzerCosmics
+from DQMOffline.Muon.gemEfficiencyAnalyzerCosmics_cfi import gemEfficiencyAnalyzerCosmicsOneLeg as _gemEfficiencyAnalyzerCosmicsOneLeg
+
+gemEfficiencyHarvesterCosmics = _gemEfficiencyHarvesterDefault.clone(
+    folder = cms.untracked.string(_gemEfficiencyAnalyzerCosmics.folder.value()),
+)
+
+gemEfficiencyHarvesterCosmicsOneLeg = _gemEfficiencyHarvesterDefault.clone(
+    folder = cms.untracked.string(_gemEfficiencyAnalyzerCosmicsOneLeg.folder.value()),
+)

--- a/DQMOffline/Muon/python/gemEfficiencyHarvester_cfi.py
+++ b/DQMOffline/Muon/python/gemEfficiencyHarvester_cfi.py
@@ -1,13 +1,14 @@
 import FWCore.ParameterSet.Config as cms
 
 from DQMServices.Core.DQMEDHarvester import DQMEDHarvester
+from DQMOffline.Muon.gemEfficiencyHarvesterDefault_cfi import gemEfficiencyHarvesterDefault as _gemEfficiencyHarvesterDefault
+from DQMOffline.Muon.gemEfficiencyAnalyzer_cfi import gemEfficiencyAnalyzerTightGlb as _gemEfficiencyAnalyzerTightGlb
+from DQMOffline.Muon.gemEfficiencyAnalyzer_cfi import gemEfficiencyAnalyzerSta as _gemEfficiencyAnalyzerSta
 
-gemEfficiencyHarvesterTight = DQMEDHarvester('GEMEfficiencyHarvester',
-    folder = cms.untracked.string('GEM/GEMEfficiency/TightGlobalMuon'),
-    logCategory = cms.untracked.string('GEMEfficiencyHarvesterTight')
+gemEfficiencyHarvesterTightGlb = _gemEfficiencyHarvesterDefault.clone(
+    folder = cms.untracked.string(_gemEfficiencyAnalyzerTightGlb.folder.value())
 )
 
-gemEfficiencyHarvesterSTA = DQMEDHarvester('GEMEfficiencyHarvester',
-    folder = cms.untracked.string('GEM/GEMEfficiency/StandaloneMuon'),
-    logCategory = cms.untracked.string('GEMEfficiencyHarvesterSTA')
+gemEfficiencyHarvesterSta = _gemEfficiencyHarvesterDefault.clone(
+    folder = cms.untracked.string(_gemEfficiencyAnalyzerSta.folder.value())
 )

--- a/DQMOffline/Muon/python/gem_dqm_offline_client_cff.py
+++ b/DQMOffline/Muon/python/gem_dqm_offline_client_cff.py
@@ -3,5 +3,5 @@ import FWCore.ParameterSet.Config as cms
 from DQMOffline.Muon.gemEfficiencyHarvester_cfi import *
 
 gemClients = cms.Sequence(
-    gemEfficiencyHarvesterTight *
-    gemEfficiencyHarvesterSTA)
+    gemEfficiencyHarvesterTightGlb *
+    gemEfficiencyHarvesterSta)

--- a/DQMOffline/Muon/python/gem_dqm_offline_client_cosmics_cff.py
+++ b/DQMOffline/Muon/python/gem_dqm_offline_client_cosmics_cff.py
@@ -1,0 +1,7 @@
+import FWCore.ParameterSet.Config as cms
+
+from DQMOffline.Muon.gemEfficiencyHarvesterCosmics_cfi import *
+
+gemClientsCosmics = cms.Sequence(
+    gemEfficiencyHarvesterCosmics *
+    gemEfficiencyHarvesterCosmicsOneLeg)

--- a/DQMOffline/Muon/python/gem_dqm_offline_source_cff.py
+++ b/DQMOffline/Muon/python/gem_dqm_offline_source_cff.py
@@ -1,9 +1,8 @@
 import FWCore.ParameterSet.Config as cms
 
-from DQMOffline.Muon.gemOfflineMonitor_cfi import *
 from DQMOffline.Muon.gemEfficiencyAnalyzer_cfi import *
 
 gemSources = cms.Sequence(
-    gemOfflineMonitor *
-    gemEfficiencyAnalyzerTightSeq *
-    gemEfficiencyAnalyzerSTASeq)
+    gemEfficiencyAnalyzerTightGlbSeq *
+    gemEfficiencyAnalyzerStaSeq
+)

--- a/DQMOffline/Muon/python/gem_dqm_offline_source_cosmics_cff.py
+++ b/DQMOffline/Muon/python/gem_dqm_offline_source_cosmics_cff.py
@@ -1,0 +1,7 @@
+import FWCore.ParameterSet.Config as cms
+
+from DQMOffline.Muon.gemEfficiencyAnalyzerCosmics_cfi import *
+
+gemSourcesCosmics = cms.Sequence(
+    gemEfficiencyAnalyzerCosmics *
+    gemEfficiencyAnalyzerCosmicsOneLeg)

--- a/DQMOffline/Muon/src/GEMEfficiencyAnalyzer.cc
+++ b/DQMOffline/Muon/src/GEMEfficiencyAnalyzer.cc
@@ -296,13 +296,12 @@ void GEMEfficiencyAnalyzer::bookMisc(DQMStore::IBooker& ibooker, const edm::ESHa
     const int num_ch = superchambers.size();
 
     const GEMDetId&& key = getReStKey(region_id, station_id);
-    const TString&& name_suffix = getSuffixName(region_id, station_id);
-    const TString&& title_suffix = getSuffixTitle(region_id, station_id);
+    const TString&& name_suffix = GEMUtils::getSuffixName(region_id, station_id);
+    const TString&& title_suffix = GEMUtils::getSuffixTitle(region_id, station_id);
     me_prop_chamber_[key] = ibooker.book1D("prop_chamber" + name_suffix, title_suffix, num_ch, 0.5, num_ch + 0.5);
     me_prop_chamber_[key]->setAxisTitle("Destination Chamber Id", 1);
     me_prop_chamber_[key]->setAxisTitle("Entries", 2);
   }  // station
-
 }
 
 void GEMEfficiencyAnalyzer::analyze(const edm::Event& event, const edm::EventSetup& setup) {

--- a/DQMOffline/Muon/src/GEMEfficiencyAnalyzer.cc
+++ b/DQMOffline/Muon/src/GEMEfficiencyAnalyzer.cc
@@ -12,7 +12,6 @@
 #include "Validation/MuonHits/interface/MuonHitHelper.h"
 #include "Validation/MuonGEMHits/interface/GEMValidationUtils.h"
 
-
 GEMEfficiencyAnalyzer::GEMEfficiencyAnalyzer(const edm::ParameterSet& pset) : GEMOfflineDQMBase(pset) {
   name_ = pset.getUntrackedParameter<std::string>("name");
   folder_ = pset.getUntrackedParameter<std::string>("folder");
@@ -57,12 +56,12 @@ void GEMEfficiencyAnalyzer::fillDescriptions(edm::ConfigurationDescriptions& des
     desc.addUntracked<bool>("useGlobalMuon", true);
     desc.add<bool>("useSkipLayer", true);
     desc.add<bool>("useOnlyME11", false);
-    desc.add<double>("residualRPhiCut", 2.0); // TODO need to be tuned
+    desc.add<double>("residualRPhiCut", 2.0);  // TODO need to be tuned
     desc.add<bool>("usePropRErrorCut", false);
     desc.add<double>("propRErrorCut", 1.0);
     desc.add<bool>("usePropPhiErrorCut", false);
     desc.add<double>("propPhiErrorCut", 0.01);
-    desc.addUntracked<std::vector<double> >("ptBins", {20. ,30., 40., 50., 60., 70., 80., 90., 100., 120.});
+    desc.addUntracked<std::vector<double> >("ptBins", {20., 30., 40., 50., 60., 70., 80., 90., 100., 120.});
     desc.addUntracked<int>("etaNbins", 9);
     desc.addUntracked<double>("etaLow", 1.4);
     desc.addUntracked<double>("etaUp", 2.3);
@@ -72,12 +71,12 @@ void GEMEfficiencyAnalyzer::fillDescriptions(edm::ConfigurationDescriptions& des
       desc.add<edm::ParameterSetDescription>("ServiceParameters", psd0);
     }
     descriptions.add("gemEfficiencyAnalyzerDefault", desc);
-  } // beam scenario
+  }  // beam scenario
 
   // cosmic scenario
   {
     edm::ParameterSetDescription desc;
-    desc.addUntracked<std::string>("name", "GlobalMuon"); // FIXME
+    desc.addUntracked<std::string>("name", "GlobalMuon");  // FIXME
     desc.addUntracked<std::string>("folder", "GEM/Efficiency/type0");
     desc.add<edm::InputTag>("recHitTag", edm::InputTag("gemRecHits"));
     desc.add<edm::InputTag>("muonTag", edm::InputTag("muons"));
@@ -85,12 +84,13 @@ void GEMEfficiencyAnalyzer::fillDescriptions(edm::ConfigurationDescriptions& des
     desc.addUntracked<bool>("useGlobalMuon", false);
     desc.add<bool>("useSkipLayer", false);
     desc.add<bool>("useOnlyME11", true);
-    desc.add<double>("residualRPhiCut", 5.0); // TODO need to be tuned
+    desc.add<double>("residualRPhiCut", 5.0);  // TODO need to be tuned
     desc.add<bool>("usePropRErrorCut", true);
     desc.add<double>("propRErrorCut", 1.0);
     desc.add<bool>("usePropPhiErrorCut", true);
     desc.add<double>("propPhiErrorCut", 0.001);
-    desc.addUntracked<std::vector<double> >("ptBins", {0., 10., 20., 30., 40., 50., 60., 70., 80., 90., 100., 120., 140., 160., 180., 200., 220.});
+    desc.addUntracked<std::vector<double> >(
+        "ptBins", {0., 10., 20., 30., 40., 50., 60., 70., 80., 90., 100., 120., 140., 160., 180., 200., 220.});
     desc.addUntracked<int>("etaNbins", 9);
     desc.addUntracked<double>("etaLow", 1.4);
     desc.addUntracked<double>("etaUp", 2.3);
@@ -100,7 +100,7 @@ void GEMEfficiencyAnalyzer::fillDescriptions(edm::ConfigurationDescriptions& des
       desc.add<edm::ParameterSetDescription>("ServiceParameters", psd0);
     }
     descriptions.add("gemEfficiencyAnalyzerCosmicsDefault", desc);
-  } // cosmics
+  }  // cosmics
 }
 
 void GEMEfficiencyAnalyzer::bookHistograms(DQMStore::IBooker& ibooker,
@@ -120,23 +120,19 @@ void GEMEfficiencyAnalyzer::bookHistograms(DQMStore::IBooker& ibooker,
   bookMisc(ibooker, gem);
 }
 
-dqm::impl::MonitorElement* GEMEfficiencyAnalyzer::bookNumerator1D(
-    DQMStore::IBooker& ibooker, MonitorElement* me) {
+dqm::impl::MonitorElement* GEMEfficiencyAnalyzer::bookNumerator1D(DQMStore::IBooker& ibooker, MonitorElement* me) {
   const std::string name = me->getName() + "_matched";
   TH1F* hist = dynamic_cast<TH1F*>(me->getTH1F()->Clone(name.c_str()));
   return ibooker.book1D(name, hist);
 }
 
-dqm::impl::MonitorElement* GEMEfficiencyAnalyzer::bookNumerator2D(
-    DQMStore::IBooker& ibooker, MonitorElement* me) {
+dqm::impl::MonitorElement* GEMEfficiencyAnalyzer::bookNumerator2D(DQMStore::IBooker& ibooker, MonitorElement* me) {
   const std::string name = me->getName() + "_matched";
   TH2F* hist = dynamic_cast<TH2F*>(me->getTH2F()->Clone(name.c_str()));
   return ibooker.book2D(name, hist);
 }
 
-void GEMEfficiencyAnalyzer::bookEfficiencyMomentum(
-    DQMStore::IBooker& ibooker,
-    const edm::ESHandle<GEMGeometry>& gem) {
+void GEMEfficiencyAnalyzer::bookEfficiencyMomentum(DQMStore::IBooker& ibooker, const edm::ESHandle<GEMGeometry>& gem) {
   // TODO Efficiency/Source
   ibooker.setCurrentFolder(folder_ + "/Efficiency");
 
@@ -171,10 +167,7 @@ void GEMEfficiencyAnalyzer::bookEfficiencyMomentum(
   }  // station
 }
 
-
-void GEMEfficiencyAnalyzer::bookEfficiencyChamber(
-    DQMStore::IBooker& ibooker,
-    const edm::ESHandle<GEMGeometry>& gem) {
+void GEMEfficiencyAnalyzer::bookEfficiencyChamber(DQMStore::IBooker& ibooker, const edm::ESHandle<GEMGeometry>& gem) {
   // TODO Efficiency/Source
   ibooker.setCurrentFolder(folder_ + "/Efficiency");
 
@@ -196,7 +189,8 @@ void GEMEfficiencyAnalyzer::bookEfficiencyChamber(
       const TString&& title_suffix = GEMUtils::getSuffixTitle(region_id, station_id, layer_id);
       const GEMDetId&& key = getReStLaKey(chamber->id());
 
-      me_chamber_[key] = ibooker.book1D("chamber" + name_suffix, name_.c_str() + title_suffix, num_chambers, 0.5, num_chambers + 0.5);
+      me_chamber_[key] =
+          ibooker.book1D("chamber" + name_suffix, name_.c_str() + title_suffix, num_chambers, 0.5, num_chambers + 0.5);
       me_chamber_[key]->setAxisTitle("Chamber");
       me_chamber_[key]->getTH1F()->SetNdivisions(-num_chambers, "Y");
       for (int binx = 1; binx <= num_chambers; binx++) {
@@ -204,13 +198,12 @@ void GEMEfficiencyAnalyzer::bookEfficiencyChamber(
       }
 
       me_chamber_matched_[key] = bookNumerator1D(ibooker, me_chamber_[key]);
-    } // layer
-  } // station
+    }  // layer
+  }    // station
 }
 
-void GEMEfficiencyAnalyzer::bookEfficiencyEtaPartition(
-    DQMStore::IBooker& ibooker,
-    const edm::ESHandle<GEMGeometry>& gem) {
+void GEMEfficiencyAnalyzer::bookEfficiencyEtaPartition(DQMStore::IBooker& ibooker,
+                                                       const edm::ESHandle<GEMGeometry>& gem) {
   // TODO Efficiency/Source
   ibooker.setCurrentFolder(folder_ + "/Efficiency");
 
@@ -231,16 +224,20 @@ void GEMEfficiencyAnalyzer::bookEfficiencyEtaPartition(
     const int num_ch = superchambers.size() * superchambers.front()->nChambers();
     const int num_etas = getNumEtaPartitions(station);
 
-    me_detector_[key] = ibooker.book2D("detector" + name_suffix, name_.c_str() + title_suffix, num_ch, 0.5, num_ch + 0.5, num_etas, 0.5, num_etas + 0.5);
+    me_detector_[key] = ibooker.book2D("detector" + name_suffix,
+                                       name_.c_str() + title_suffix,
+                                       num_ch,
+                                       0.5,
+                                       num_ch + 0.5,
+                                       num_etas,
+                                       0.5,
+                                       num_etas + 0.5);
     setDetLabelsEta(me_detector_[key], station);
     me_detector_matched_[key] = bookNumerator2D(ibooker, me_detector_[key]);
   }  // station
 }
 
-void GEMEfficiencyAnalyzer::bookResolution(
-    DQMStore::IBooker & ibooker,
-    const edm::ESHandle<GEMGeometry>& gem) {
-
+void GEMEfficiencyAnalyzer::bookResolution(DQMStore::IBooker& ibooker, const edm::ESHandle<GEMGeometry>& gem) {
   ibooker.setCurrentFolder(folder_ + "/Resolution");
   for (const GEMStation* station : gem->stations()) {
     const int region_id = station->region();
@@ -264,9 +261,11 @@ void GEMEfficiencyAnalyzer::bookResolution(
       const GEMDetId&& key = getReStEtKey(eta_partition->id());
       // TODO
       const TString&& name_suffix = TString::Format("_GE%+.2d_R%d", region_id * (station_id * 10 + 1), ieta);
-      const TString&& title = name_.c_str() + TString::Format(" : GE%+.2d Roll %d", region_id * (station_id * 10 + 1), ieta);
+      const TString&& title =
+          name_.c_str() + TString::Format(" : GE%+.2d Roll %d", region_id * (station_id * 10 + 1), ieta);
 
-      me_residual_rphi_[key] = ibooker.book1D("residual_rphi" + name_suffix, title, 50, -residual_rphi_cut_, residual_rphi_cut_);
+      me_residual_rphi_[key] =
+          ibooker.book1D("residual_rphi" + name_suffix, title, 50, -residual_rphi_cut_, residual_rphi_cut_);
       me_residual_rphi_[key]->setAxisTitle("Residual in R#phi [cm]");
 
       me_residual_y_[key] = ibooker.book1D("residual_y" + name_suffix, title, 60, -12.0, 12.0);
@@ -277,19 +276,16 @@ void GEMEfficiencyAnalyzer::bookResolution(
 
       me_pull_y_[key] = ibooker.book1D("pull_y" + name_suffix, title, 60, -3.0, 3.0);
       me_pull_y_[key]->setAxisTitle("Pull in Local Y");
-    } // ieta
-  } // station
+    }  // ieta
+  }    // station
 }
 
-void GEMEfficiencyAnalyzer::bookMisc(
-    DQMStore::IBooker & ibooker,
-    const edm::ESHandle<GEMGeometry>& gem) {
+void GEMEfficiencyAnalyzer::bookMisc(DQMStore::IBooker& ibooker, const edm::ESHandle<GEMGeometry>& gem) {
   ibooker.setCurrentFolder(folder_ + "/Misc");
   me_prop_r_err_ = ibooker.book1D("prop_r_err", ";Propagation Global R Error [cm];Entries", 20, 0.0, 20.0);
   me_prop_phi_err_ = ibooker.book1D("prop_phi_err", "Propagation Global Phi Error [rad];Entries", 20, 0.0, 0.5);
   me_all_abs_residual_rphi_ = ibooker.book1D("all_abs_residual_rphi", ";Residual in R#phi [cm];Entries", 20, 0.0, 20.0);
 }
-
 
 void GEMEfficiencyAnalyzer::analyze(const edm::Event& event, const edm::EventSetup& setup) {
   edm::Handle<GEMRecHitCollection> rechit_collection;
@@ -361,7 +357,7 @@ void GEMEfficiencyAnalyzer::analyze(const edm::Event& event, const edm::EventSet
 
     for (const GEMLayerData& layer : layer_vector) {
       if (use_skip_layer_ and skipLayer(track, layer)) {
-        edm::LogInfo(kLogCategory_) << "skip GEM Layer" << std::endl; 
+        edm::LogInfo(kLogCategory_) << "skip GEM Layer" << std::endl;
         continue;
       }
 
@@ -436,8 +432,7 @@ void GEMEfficiencyAnalyzer::analyze(const edm::Event& event, const edm::EventSet
       fillME(me_muon_phi_, rs_key, muon.phi());
       fillME(me_chamber_, rsl_key, gem_id.chamber());
 
-      const auto&& [hit, residual_rphi] = findClosetHit(
-          dest_global_pos, rechit_collection->get(gem_id), eta_partition);
+      const auto&& [hit, residual_rphi] = findClosetHit(dest_global_pos, rechit_collection->get(gem_id), eta_partition);
 
       if (hit == nullptr) {
         edm::LogInfo(kLogCategory_) << "failed to find a hit" << std::endl;
@@ -465,7 +460,8 @@ void GEMEfficiencyAnalyzer::analyze(const edm::Event& event, const edm::EventSet
 
       const float dphi = reco::deltaPhi(dest_global_pos.barePhi(), hit_global_pos.barePhi());
       const float residual_y = dest_local_pos.y() - hit_local_pos.y();
-      const float global_phi_err = std::sqrt(dest_global_err.phierr(dest_global_pos) + hit_global_err.phierr(hit_global_pos));
+      const float global_phi_err =
+          std::sqrt(dest_global_err.phierr(dest_global_pos) + hit_global_err.phierr(hit_global_pos));
       const float pull_phi = dphi / global_phi_err;
       const float pull_y = residual_y / std::sqrt(dest_local_err.yy() + hit_local_err.yy());
 
@@ -477,9 +473,8 @@ void GEMEfficiencyAnalyzer::analyze(const edm::Event& event, const edm::EventSet
   }    // Muon
 }
 
-
-std::vector<GEMEfficiencyAnalyzer::GEMLayerData>
-GEMEfficiencyAnalyzer::buildGEMLayers(const edm::ESHandle<GEMGeometry>& gem) {
+std::vector<GEMEfficiencyAnalyzer::GEMLayerData> GEMEfficiencyAnalyzer::buildGEMLayers(
+    const edm::ESHandle<GEMGeometry>& gem) {
   std::vector<GEMLayerData> layer_vector;
 
   for (const GEMStation* station : gem->stations()) {
@@ -487,7 +482,7 @@ GEMEfficiencyAnalyzer::buildGEMLayers(const edm::ESHandle<GEMGeometry>& gem) {
     const int station_id = station->station();
 
     // layer_id - chambers
-    std::map<int, std::vector<const GEMChamber*> > chambers_per_layer; // chambers per layer
+    std::map<int, std::vector<const GEMChamber*> > chambers_per_layer;  // chambers per layer
     for (const GEMSuperChamber* super_chamber : station->superChambers()) {
       for (const GEMChamber* chamber : super_chamber->chambers()) {
         const int layer_id = chamber->id().layer();
@@ -496,11 +491,10 @@ GEMEfficiencyAnalyzer::buildGEMLayers(const edm::ESHandle<GEMGeometry>& gem) {
           chambers_per_layer.insert({layer_id, std::vector<const GEMChamber*>()});
 
         chambers_per_layer[layer_id].push_back(chamber);
-      } // GEMChamber
-    } // GEMSuperChamber
+      }  // GEMChamber
+    }    // GEMSuperChamber
 
     for (auto [layer_id, chamber_vector] : chambers_per_layer) {
-
       auto [rmin, rmax] = chamber_vector[0]->surface().rSpan();
       auto [zmin, zmax] = chamber_vector[0]->surface().zSpan();
       for (const GEMChamber* chamber : chamber_vector) {
@@ -529,12 +523,11 @@ GEMEfficiencyAnalyzer::buildGEMLayers(const edm::ESHandle<GEMGeometry>& gem) {
 
       layer_vector.emplace_back(layer, chamber_vector, region_id, station_id, layer_id);
 
-    } // layer
-  } // GEMStation
+    }  // layer
+  }    // GEMStation
 
   return layer_vector;
 }
-
 
 const reco::Track* GEMEfficiencyAnalyzer::getTrack(const reco::Muon& muon) {
   const reco::Track* track = nullptr;
@@ -555,13 +548,10 @@ const reco::Track* GEMEfficiencyAnalyzer::getTrack(const reco::Muon& muon) {
   return track;
 }
 
-
-std::pair<TrajectoryStateOnSurface, DetId>
-GEMEfficiencyAnalyzer::getStartingState(
+std::pair<TrajectoryStateOnSurface, DetId> GEMEfficiencyAnalyzer::getStartingState(
     const reco::TransientTrack& transient_track,
     const GEMLayerData& layer,
     const edm::ESHandle<GlobalTrackingGeometry>& geometry) {
-
   TrajectoryStateOnSurface starting_state;
   DetId starting_id;
 
@@ -578,29 +568,26 @@ GEMEfficiencyAnalyzer::getStartingState(
       std::tie(starting_state, starting_id) = findStartingState(transient_track, layer, geometry);
 
     } else {
-      starting_id = std::move(inner_id);
+      starting_id = inner_id;
       if (is_insideout)
         starting_state = std::move(transient_track.outermostMeasurementState());
       else
         starting_state = std::move(transient_track.innermostMeasurementState());
     }
   }
- 
+
   return std::make_pair(starting_state, starting_id);
 }
 
-
-std::pair<TrajectoryStateOnSurface, DetId>
-GEMEfficiencyAnalyzer::findStartingState(
+std::pair<TrajectoryStateOnSurface, DetId> GEMEfficiencyAnalyzer::findStartingState(
     const reco::TransientTrack& transient_track,
     const GEMLayerData& layer,
     const edm::ESHandle<GlobalTrackingGeometry>& geometry) {
-
   GlobalPoint starting_point;
   DetId starting_id;
   float min_distance = 1e12;
   bool found = false;
- 
+
   // TODO optimize this loop because hits should be ordered..
   for (auto rechit = transient_track.recHitsBegin(); rechit != transient_track.recHitsEnd(); rechit++) {
     const DetId&& det_id = (*rechit)->geographicalId();
@@ -628,13 +615,13 @@ GEMEfficiencyAnalyzer::findStartingState(
 }
 
 bool GEMEfficiencyAnalyzer::isME11(const DetId& det_id) {
-  if (not MuonHitHelper::isCSC(det_id)) return false;
+  if (not MuonHitHelper::isCSC(det_id))
+    return false;
   const CSCDetId csc_id{det_id};
   return (csc_id.station() == 1) or ((csc_id.ring() == 1) or (csc_id.ring() == 4));
 }
 
-bool GEMEfficiencyAnalyzer::skipLayer(const reco::Track* track,
-                                      const GEMLayerData& layer) {
+bool GEMEfficiencyAnalyzer::skipLayer(const reco::Track* track, const GEMLayerData& layer) {
   const bool is_same_region = track->eta() * layer.region > 0;
 
   bool skip = false;
@@ -650,7 +637,6 @@ bool GEMEfficiencyAnalyzer::skipLayer(const reco::Track* track,
   } else {
     // beam scenario
     skip = not is_same_region;
-
   }
 
   return skip;
@@ -662,13 +648,11 @@ bool GEMEfficiencyAnalyzer::checkBounds(const GlobalPoint& global_point, const P
   return plane.bounds().inside(local_point_2d);
 }
 
-const GEMEtaPartition* GEMEfficiencyAnalyzer::findEtaPartition(
-    const GlobalPoint& global_point,
-    const std::vector<const GEMChamber*>& chamber_vector) {
-
+const GEMEtaPartition* GEMEfficiencyAnalyzer::findEtaPartition(const GlobalPoint& global_point,
+                                                               const std::vector<const GEMChamber*>& chamber_vector) {
   const GEMEtaPartition* bound = nullptr;
   for (const GEMChamber* chamber : chamber_vector) {
-    if (not checkBounds(global_point, chamber->surface())) 
+    if (not checkBounds(global_point, chamber->surface()))
       continue;
 
     for (const GEMEtaPartition* eta_partition : chamber->etaPartitions()) {
@@ -676,17 +660,15 @@ const GEMEtaPartition* GEMEfficiencyAnalyzer::findEtaPartition(
         bound = eta_partition;
         break;
       }
-    } // GEMEtaPartition
-  } // GEMChamber
+    }  // GEMEtaPartition
+  }    // GEMChamber
 
   return bound;
 }
 
-std::pair<const GEMRecHit*, float> GEMEfficiencyAnalyzer::findClosetHit(
-    const GlobalPoint& dest_global_pos,
-    const GEMRecHitCollection::range& range,
-    const GEMEtaPartition* eta_partition) {
-
+std::pair<const GEMRecHit*, float> GEMEfficiencyAnalyzer::findClosetHit(const GlobalPoint& dest_global_pos,
+                                                                        const GEMRecHitCollection::range& range,
+                                                                        const GEMEtaPartition* eta_partition) {
   const StripTopology& topology = eta_partition->specificTopology();
   const LocalPoint&& dest_local_pos = eta_partition->toLocal(dest_global_pos);
   const float dest_local_x = dest_local_pos.x();
@@ -698,7 +680,7 @@ std::pair<const GEMRecHit*, float> GEMEfficiencyAnalyzer::findClosetHit(
   for (auto hit = range.first; hit != range.second; ++hit) {
     const LocalPoint&& hit_local_pos = hit->localPosition();
     const float hit_local_phi = topology.stripAngle(eta_partition->strip(hit_local_pos));
- 
+
     const float residual_x = dest_local_x - hit_local_pos.x();
     const float residual_y = dest_local_y - hit_local_pos.y();
     const float residual_rphi = std::cos(hit_local_phi) * residual_x + std::sin(hit_local_phi) * residual_y;

--- a/DQMOffline/Muon/src/GEMEfficiencyAnalyzer.cc
+++ b/DQMOffline/Muon/src/GEMEfficiencyAnalyzer.cc
@@ -271,9 +271,6 @@ void GEMEfficiencyAnalyzer::bookResolution(DQMStore::IBooker& ibooker, const edm
       me_residual_y_[key] = ibooker.book1D("residual_y" + name_suffix, title, 60, -12.0, 12.0);
       me_residual_y_[key]->setAxisTitle("Residual in Local Y [cm]");
 
-      me_pull_phi_[key] = ibooker.book1D("pull_phi" + name_suffix, title, 60, -3.0, 3.0);
-      me_pull_phi_[key]->setAxisTitle("Pull in Global #phi");
-
       me_pull_y_[key] = ibooker.book1D("pull_y" + name_suffix, title, 60, -3.0, 3.0);
       me_pull_y_[key]->setAxisTitle("Pull in Local Y");
     }  // ieta
@@ -458,16 +455,11 @@ void GEMEfficiencyAnalyzer::analyze(const edm::Event& event, const edm::EventSet
       const LocalError&& hit_local_err = hit->localPositionError();
       const GlobalError& hit_global_err = ErrorFrameTransformer().transform(hit_local_err, surface);
 
-      const float dphi = reco::deltaPhi(dest_global_pos.barePhi(), hit_global_pos.barePhi());
       const float residual_y = dest_local_pos.y() - hit_local_pos.y();
-      const float global_phi_err =
-          std::sqrt(dest_global_err.phierr(dest_global_pos) + hit_global_err.phierr(hit_global_pos));
-      const float pull_phi = dphi / global_phi_err;
       const float pull_y = residual_y / std::sqrt(dest_local_err.yy() + hit_local_err.yy());
 
       fillME(me_residual_rphi_, rse_key, residual_rphi);
       fillME(me_residual_y_, rse_key, residual_y);
-      fillME(me_pull_phi_, rse_key, pull_phi);
       fillME(me_pull_y_, rse_key, pull_y);
     }  // layer
   }    // Muon

--- a/DQMOffline/Muon/src/GEMEfficiencyAnalyzer.cc
+++ b/DQMOffline/Muon/src/GEMEfficiencyAnalyzer.cc
@@ -580,9 +580,9 @@ std::pair<TrajectoryStateOnSurface, DetId> GEMEfficiencyAnalyzer::getStartingSta
     } else {
       starting_id = inner_id;
       if (is_insideout)
-        starting_state = std::move(transient_track.outermostMeasurementState());
+        starting_state = transient_track.outermostMeasurementState();
       else
-        starting_state = std::move(transient_track.innermostMeasurementState());
+        starting_state = transient_track.innermostMeasurementState();
     }
   }
 
@@ -619,7 +619,7 @@ std::pair<TrajectoryStateOnSurface, DetId> GEMEfficiencyAnalyzer::findStartingSt
 
   TrajectoryStateOnSurface starting_state;
   if (found) {
-    starting_state = std::move(transient_track.stateOnSurface(starting_point));
+    starting_state = transient_track.stateOnSurface(starting_point);
   }
   return std::make_pair(starting_state, starting_id);
 }

--- a/DQMOffline/Muon/src/GEMEfficiencyAnalyzer.cc
+++ b/DQMOffline/Muon/src/GEMEfficiencyAnalyzer.cc
@@ -1,33 +1,107 @@
 #include "DQMOffline/Muon/interface/GEMEfficiencyAnalyzer.h"
+
 #include "FWCore/Framework/interface/ConsumesCollector.h"
-#include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "TrackingTools/TransientTrack/interface/TransientTrackBuilder.h"
 #include "TrackingTools/Records/interface/TransientTrackRecord.h"
 #include "DataFormats/Math/interface/deltaPhi.h"
+#include "DataFormats/GeometryCommonDetAlgo/interface/ErrorFrameTransformer.h"
+#include "DataFormats/GeometrySurface/interface/SimpleDiskBounds.h"
+#include "Geometry/CommonTopologies/interface/GlobalTrackingGeometry.h"
+#include "Geometry/Records/interface/GlobalTrackingGeometryRecord.h"
+#include "Geometry/CommonTopologies/interface/StripTopology.h"
+#include "Validation/MuonHits/interface/MuonHitHelper.h"
+#include "Validation/MuonGEMHits/interface/GEMValidationUtils.h"
+
 
 GEMEfficiencyAnalyzer::GEMEfficiencyAnalyzer(const edm::ParameterSet& pset) : GEMOfflineDQMBase(pset) {
+  name_ = pset.getUntrackedParameter<std::string>("name");
+  folder_ = pset.getUntrackedParameter<std::string>("folder");
+
   rechit_token_ = consumes<GEMRecHitCollection>(pset.getParameter<edm::InputTag>("recHitTag"));
   muon_token_ = consumes<edm::View<reco::Muon> >(pset.getParameter<edm::InputTag>("muonTag"));
 
-  auto muon_service_parameter = pset.getParameter<edm::ParameterSet>("ServiceParameters");
-  muon_service_ = new MuonServiceProxy(muon_service_parameter, consumesCollector());
-
+  is_cosmics_ = pset.getUntrackedParameter<bool>("isCosmics");
   use_global_muon_ = pset.getUntrackedParameter<bool>("useGlobalMuon");
+  use_skip_layer_ = pset.getParameter<bool>("useSkipLayer");
+  use_only_me11_ = pset.getParameter<bool>("useOnlyME11");
+  residual_rphi_cut_ = static_cast<float>(pset.getParameter<double>("residualRPhiCut"));
+  use_prop_r_error_cut_ = pset.getParameter<bool>("usePropRErrorCut");
+  prop_r_error_cut_ = pset.getParameter<double>("propRErrorCut");
+  use_prop_phi_error_cut_ = pset.getParameter<bool>("usePropPhiErrorCut");
+  prop_phi_error_cut_ = pset.getParameter<double>("propPhiErrorCut");
 
-  residual_x_cut_ = static_cast<float>(pset.getParameter<double>("residualXCut"));
-
-  pt_binning_ = pset.getUntrackedParameter<std::vector<double> >("ptBinning");
+  pt_bins_ = pset.getUntrackedParameter<std::vector<double> >("ptBins");
   eta_nbins_ = pset.getUntrackedParameter<int>("etaNbins");
   eta_low_ = pset.getUntrackedParameter<double>("etaLow");
   eta_up_ = pset.getUntrackedParameter<double>("etaUp");
 
-  folder_ = pset.getUntrackedParameter<std::string>("folder");
+  const edm::ParameterSet&& muon_service_parameter = pset.getParameter<edm::ParameterSet>("ServiceParameters");
+  muon_service_ = new MuonServiceProxy(muon_service_parameter, consumesCollector());
 
-  title_ = (use_global_muon_ ? "Global Muon" : "Standalone Muon");
-  matched_title_ = title_ + TString::Format(" (|x_{Muon} - x_{Hit}| < %.1f)", residual_x_cut_);
+  const double eps = std::numeric_limits<double>::epsilon();
+  pt_clamp_max_ = pt_bins_.back() - eps;
+  eta_clamp_max_ = eta_up_ - eps;
 }
 
 GEMEfficiencyAnalyzer::~GEMEfficiencyAnalyzer() {}
+
+void GEMEfficiencyAnalyzer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  // beam scenario
+  {
+    edm::ParameterSetDescription desc;
+    desc.addUntracked<std::string>("name", "GlobalMuon");
+    desc.addUntracked<std::string>("folder", "GEM/Efficiency/type0");
+    desc.add<edm::InputTag>("recHitTag", edm::InputTag("gemRecHits"));
+    desc.add<edm::InputTag>("muonTag", edm::InputTag("muons"));
+    desc.addUntracked<bool>("isCosmics", false);
+    desc.addUntracked<bool>("useGlobalMuon", true);
+    desc.add<bool>("useSkipLayer", true);
+    desc.add<bool>("useOnlyME11", false);
+    desc.add<double>("residualRPhiCut", 2.0); // TODO need to be tuned
+    desc.add<bool>("usePropRErrorCut", false);
+    desc.add<double>("propRErrorCut", 1.0);
+    desc.add<bool>("usePropPhiErrorCut", false);
+    desc.add<double>("propPhiErrorCut", 0.01);
+    desc.addUntracked<std::vector<double> >("ptBins", {20. ,30., 40., 50., 60., 70., 80., 90., 100., 120.});
+    desc.addUntracked<int>("etaNbins", 9);
+    desc.addUntracked<double>("etaLow", 1.4);
+    desc.addUntracked<double>("etaUp", 2.3);
+    {
+      edm::ParameterSetDescription psd0;
+      psd0.setAllowAnything();
+      desc.add<edm::ParameterSetDescription>("ServiceParameters", psd0);
+    }
+    descriptions.add("gemEfficiencyAnalyzerDefault", desc);
+  } // beam scenario
+
+  // cosmic scenario
+  {
+    edm::ParameterSetDescription desc;
+    desc.addUntracked<std::string>("name", "GlobalMuon"); // FIXME
+    desc.addUntracked<std::string>("folder", "GEM/Efficiency/type0");
+    desc.add<edm::InputTag>("recHitTag", edm::InputTag("gemRecHits"));
+    desc.add<edm::InputTag>("muonTag", edm::InputTag("muons"));
+    desc.addUntracked<bool>("isCosmics", true);
+    desc.addUntracked<bool>("useGlobalMuon", false);
+    desc.add<bool>("useSkipLayer", false);
+    desc.add<bool>("useOnlyME11", true);
+    desc.add<double>("residualRPhiCut", 5.0); // TODO need to be tuned
+    desc.add<bool>("usePropRErrorCut", true);
+    desc.add<double>("propRErrorCut", 1.0);
+    desc.add<bool>("usePropPhiErrorCut", true);
+    desc.add<double>("propPhiErrorCut", 0.001);
+    desc.addUntracked<std::vector<double> >("ptBins", {0., 10., 20., 30., 40., 50., 60., 70., 80., 90., 100., 120., 140., 160., 180., 200., 220.});
+    desc.addUntracked<int>("etaNbins", 9);
+    desc.addUntracked<double>("etaLow", 1.4);
+    desc.addUntracked<double>("etaUp", 2.3);
+    {
+      edm::ParameterSetDescription psd0;
+      psd0.setAllowAnything();
+      desc.add<edm::ParameterSetDescription>("ServiceParameters", psd0);
+    }
+    descriptions.add("gemEfficiencyAnalyzerCosmicsDefault", desc);
+  } // cosmics
+}
 
 void GEMEfficiencyAnalyzer::bookHistograms(DQMStore::IBooker& ibooker,
                                            edm::Run const& run,
@@ -35,247 +109,605 @@ void GEMEfficiencyAnalyzer::bookHistograms(DQMStore::IBooker& ibooker,
   edm::ESHandle<GEMGeometry> gem;
   isetup.get<MuonGeometryRecord>().get(gem);
   if (not gem.isValid()) {
-    edm::LogError(log_category_) << "GEMGeometry is invalid" << std::endl;
+    edm::LogError(kLogCategory_) << "GEMGeometry is invalid" << std::endl;
     return;
   }
 
-  for (const GEMRegion* region : gem->regions()) {
-    const int region_number = region->region();
-    const char* region_sign = region_number > 0 ? "+" : "-";
+  bookEfficiencyMomentum(ibooker, gem);
+  bookEfficiencyChamber(ibooker, gem);
+  bookEfficiencyEtaPartition(ibooker, gem);
+  bookResolution(ibooker, gem);
+  bookMisc(ibooker, gem);
+}
 
-    for (const GEMStation* station : region->stations()) {
-      const int station_number = station->station();
+dqm::impl::MonitorElement* GEMEfficiencyAnalyzer::bookNumerator1D(
+    DQMStore::IBooker& ibooker, MonitorElement* me) {
+  const std::string name = me->getName() + "_matched";
+  TH1F* hist = dynamic_cast<TH1F*>(me->getTH1F()->Clone(name.c_str()));
+  return ibooker.book1D(name, hist);
+}
 
-      const MEMapKey1 key1{region_number, station_number};
-      const auto&& station_name_suffix = TString::Format("_ge%s%d1", region_sign, station_number);
-      const auto&& station_title_suffix = TString::Format(" : GE %s%d/1", region_sign, station_number);
-      bookDetectorOccupancy(ibooker, station, key1, station_name_suffix, station_title_suffix);
+dqm::impl::MonitorElement* GEMEfficiencyAnalyzer::bookNumerator2D(
+    DQMStore::IBooker& ibooker, MonitorElement* me) {
+  const std::string name = me->getName() + "_matched";
+  TH2F* hist = dynamic_cast<TH2F*>(me->getTH2F()->Clone(name.c_str()));
+  return ibooker.book2D(name, hist);
+}
 
-      const int num_etas = getNumEtaPartitions(station);
+void GEMEfficiencyAnalyzer::bookEfficiencyMomentum(
+    DQMStore::IBooker& ibooker,
+    const edm::ESHandle<GEMGeometry>& gem) {
+  // TODO Efficiency/Source
+  ibooker.setCurrentFolder(folder_ + "/Efficiency");
 
-      if (station_number == 1) {
-        for (const bool is_odd : {true, false}) {
-          std::tuple<int, int, bool> key2{region_number, station_number, is_odd};
-          const TString&& parity_name_suffix = station_name_suffix + (is_odd ? "_odd" : "_even");
-          const TString&& parity_title_suffix =
-              station_title_suffix + (is_odd ? ", Odd Superchamber" : ", Even Superchamber");
-          bookOccupancy(ibooker, key2, parity_name_suffix, parity_title_suffix);
+  const TString pt_x_title = "Muon p_{T} [GeV]";
+  const int pt_nbinsx = pt_bins_.size() - 1;
 
-          for (int ieta = 1; ieta <= num_etas; ieta++) {
-            const TString&& ieta_name_suffix = parity_name_suffix + Form("_ieta%d", ieta);
-            const TString&& ieta_title_suffix = parity_title_suffix + Form(", i#eta = %d", ieta);
-            const MEMapKey3 key3{region_number, station_number, is_odd, ieta};
-            bookResolution(ibooker, key3, ieta_name_suffix, ieta_title_suffix);
-          }  // ieta
-        }    // is_odd
+  const std::string eta_x_title = "Muon |#eta|";
+  const std::string phi_x_title = "Muon #phi [rad]";
 
-      } else {
-        std::tuple<int, int, bool> key2{region_number, station_number, false};
-        bookOccupancy(ibooker, key2, station_name_suffix, station_title_suffix);
+  for (const GEMStation* station : gem->stations()) {
+    const int region_id = station->region();
+    const int station_id = station->station();
 
-        for (int ieta = 1; ieta <= num_etas; ieta++) {
-          const MEMapKey3 key3{region_number, station_number, false, ieta};
-          const TString&& ieta_name_suffix = station_name_suffix + Form("_ieta%d", ieta);
-          const TString&& ieta_title_suffix = station_title_suffix + Form(", i#eta = %d", ieta);
-          bookResolution(ibooker, key3, ieta_name_suffix, ieta_title_suffix);
-        }  // ieta
+    const GEMDetId&& key = getReStKey(region_id, station_id);
+    const TString&& name_suffix = GEMUtils::getSuffixName(region_id, station_id);
+    const TString&& title_suffix = GEMUtils::getSuffixTitle(region_id, station_id);
+
+    const TString&& title = name_.c_str() + title_suffix;
+
+    TH1F* h_muon_pt = new TH1F("muon_pt" + name_suffix, title, pt_nbinsx, &pt_bins_[0]);
+    h_muon_pt->SetXTitle(pt_x_title);
+    me_muon_pt_[key] = ibooker.book1D(h_muon_pt->GetName(), h_muon_pt);
+    me_muon_pt_matched_[key] = bookNumerator1D(ibooker, me_muon_pt_[key]);
+
+    me_muon_eta_[key] = ibooker.book1D("muon_eta" + name_suffix, title, eta_nbins_, eta_low_, eta_up_);
+    me_muon_eta_[key]->setXTitle(eta_x_title);
+    me_muon_eta_matched_[key] = bookNumerator1D(ibooker, me_muon_eta_[key]);
+
+    me_muon_phi_[key] = ibooker.book1D("muon_phi" + name_suffix, title, 108, -M_PI, M_PI);
+    me_muon_phi_[key]->setAxisTitle(phi_x_title);
+    me_muon_phi_matched_[key] = bookNumerator1D(ibooker, me_muon_phi_[key]);
+  }  // station
+}
+
+
+void GEMEfficiencyAnalyzer::bookEfficiencyChamber(
+    DQMStore::IBooker& ibooker,
+    const edm::ESHandle<GEMGeometry>& gem) {
+  // TODO Efficiency/Source
+  ibooker.setCurrentFolder(folder_ + "/Efficiency");
+
+  for (const GEMStation* station : gem->stations()) {
+    const int region_id = station->region();
+    const int station_id = station->station();
+
+    const std::vector<const GEMSuperChamber*>&& superchambers = station->superChambers();
+    if (not checkRefs(superchambers)) {
+      edm::LogError(kLogCategory_) << "failed to get a valid vector of GEMSuperChamber ptrs" << std::endl;
+      return;
+    }
+
+    const int num_chambers = superchambers.size();
+    for (const GEMChamber* chamber : superchambers[0]->chambers()) {
+      const int layer_id = chamber->id().layer();
+
+      const TString&& name_suffix = GEMUtils::getSuffixName(region_id, station_id, layer_id);
+      const TString&& title_suffix = GEMUtils::getSuffixTitle(region_id, station_id, layer_id);
+      const GEMDetId&& key = getReStLaKey(chamber->id());
+
+      me_chamber_[key] = ibooker.book1D("chamber" + name_suffix, name_.c_str() + title_suffix, num_chambers, 0.5, num_chambers + 0.5);
+      me_chamber_[key]->setAxisTitle("Chamber");
+      me_chamber_[key]->getTH1F()->SetNdivisions(-num_chambers, "Y");
+      for (int binx = 1; binx <= num_chambers; binx++) {
+        me_chamber_[key]->setBinLabel(binx, std::to_string(binx));
       }
-    }  // station
-  }    // region
+
+      me_chamber_matched_[key] = bookNumerator1D(ibooker, me_chamber_[key]);
+    } // layer
+  } // station
 }
 
-void GEMEfficiencyAnalyzer::bookDetectorOccupancy(DQMStore::IBooker& ibooker,
-                                                  const GEMStation* station,
-                                                  const MEMapKey1& key,
-                                                  const TString& name_suffix,
-                                                  const TString& title_suffix) {
+void GEMEfficiencyAnalyzer::bookEfficiencyEtaPartition(
+    DQMStore::IBooker& ibooker,
+    const edm::ESHandle<GEMGeometry>& gem) {
+  // TODO Efficiency/Source
   ibooker.setCurrentFolder(folder_ + "/Efficiency");
-  BookingHelper helper(ibooker, name_suffix, title_suffix);
 
-  const auto&& superchambers = station->superChambers();
-  if (not checkRefs(superchambers)) {
-    edm::LogError(log_category_) << "failed to get a valid vector of GEMSuperChamber ptrs" << std::endl;
-    return;
-  }
+  for (const GEMStation* station : gem->stations()) {
+    const int region_id = station->region();
+    const int station_id = station->station();
 
-  // the number of GEMChambers per GEMStation
-  const int num_ch = superchambers.size() * superchambers.front()->nChambers();
-  // the number of eta partitions per GEMChamber
-  const int num_etas = getNumEtaPartitions(station);
+    const GEMDetId&& key = getReStKey(region_id, station_id);
+    const TString&& name_suffix = GEMUtils::getSuffixName(region_id, station_id);
+    const TString&& title_suffix = GEMUtils::getSuffixTitle(region_id, station_id);
 
-  me_detector_[key] = helper.book2D("detector", title_, num_ch, 0.5, num_ch + 0.5, num_etas, 0.5, num_etas + 0.5);
+    const std::vector<const GEMSuperChamber*>&& superchambers = station->superChambers();
+    if (not checkRefs(superchambers)) {
+      edm::LogError(kLogCategory_) << "failed to get a valid vector of GEMSuperChamber ptrs" << std::endl;
+      return;
+    }
 
-  me_detector_matched_[key] =
-      helper.book2D("detector_matched", matched_title_, num_ch, 0.5, num_ch + 0.5, num_etas, 0.5, num_etas + 0.5);
+    const int num_ch = superchambers.size() * superchambers.front()->nChambers();
+    const int num_etas = getNumEtaPartitions(station);
 
-  setDetLabelsEta(me_detector_[key], station);
-  setDetLabelsEta(me_detector_matched_[key], station);
+    me_detector_[key] = ibooker.book2D("detector" + name_suffix, name_.c_str() + title_suffix, num_ch, 0.5, num_ch + 0.5, num_etas, 0.5, num_etas + 0.5);
+    setDetLabelsEta(me_detector_[key], station);
+    me_detector_matched_[key] = bookNumerator2D(ibooker, me_detector_[key]);
+  }  // station
 }
 
-void GEMEfficiencyAnalyzer::bookOccupancy(DQMStore::IBooker& ibooker,
-                                          const MEMapKey2& key,
-                                          const TString& name_suffix,
-                                          const TString& title_suffix) {
-  ibooker.setCurrentFolder(folder_ + "/Efficiency");
-  BookingHelper helper(ibooker, name_suffix, title_suffix);
+void GEMEfficiencyAnalyzer::bookResolution(
+    DQMStore::IBooker & ibooker,
+    const edm::ESHandle<GEMGeometry>& gem) {
 
-  me_muon_pt_[key] = helper.book1D("muon_pt", title_, pt_binning_, "Muon p_{T} [GeV]");
-  me_muon_eta_[key] = helper.book1D("muon_eta", title_, eta_nbins_, eta_low_, eta_up_, "Muon |#eta|");
-
-  me_muon_pt_matched_[key] = helper.book1D("muon_pt_matched", matched_title_, pt_binning_, "Muon p_{T} [GeV]");
-  me_muon_eta_matched_[key] =
-      helper.book1D("muon_eta_matched", matched_title_, eta_nbins_, eta_low_, eta_up_, "Muon |#eta|");
-}
-
-void GEMEfficiencyAnalyzer::bookResolution(DQMStore::IBooker& ibooker,
-                                           const MEMapKey3& key,
-                                           const TString& name_suffix,
-                                           const TString& title_suffix) {
   ibooker.setCurrentFolder(folder_ + "/Resolution");
-  BookingHelper helper(ibooker, name_suffix, title_suffix);
+  for (const GEMStation* station : gem->stations()) {
+    const int region_id = station->region();
+    const int station_id = station->station();
 
-  // NOTE Residual & Pull
-  me_residual_x_[key] = helper.book1D("residual_x", title_, 50, -5.0, 5.0, "Residual in Local X [cm]");
-  me_residual_y_[key] = helper.book1D("residual_y", title_, 60, -12.0, 12.0, "Residual in Local Y [cm]");
-  me_residual_phi_[key] = helper.book1D("residual_phi", title_, 80, -0.008, 0.008, "Residual in Global #phi [rad]");
+    const std::vector<const GEMSuperChamber*>&& superchambers = station->superChambers();
+    if (not checkRefs(superchambers)) {
+      edm::LogError(kLogCategory_) << "failed to get a valid vector of GEMSuperChamber ptrs" << std::endl;
+      return;
+    }
 
-  me_pull_x_[key] = helper.book1D("pull_x", title_, 60, -3.0, 3.0, "Pull in Local X");
-  me_pull_y_[key] = helper.book1D("pull_y", title_, 60, -3.0, 3.0, "Pull in Local Y");
+    const std::vector<const GEMChamber*>& chambers = superchambers[0]->chambers();
+    if (not checkRefs(chambers)) {
+      edm::LogError(kLogCategory_) << "failed to get a valid vector of GEMChamber ptrs" << std::endl;
+      return;
+    }
+
+    for (const GEMEtaPartition* eta_partition : chambers[0]->etaPartitions()) {
+      const int ieta = eta_partition->id().roll();
+
+      const GEMDetId&& key = getReStEtKey(eta_partition->id());
+      // TODO
+      const TString&& name_suffix = TString::Format("_GE%+.2d_R%d", region_id * (station_id * 10 + 1), ieta);
+      const TString&& title = name_.c_str() + TString::Format(" : GE%+.2d Roll %d", region_id * (station_id * 10 + 1), ieta);
+
+      me_residual_rphi_[key] = ibooker.book1D("residual_rphi" + name_suffix, title, 50, -residual_rphi_cut_, residual_rphi_cut_);
+      me_residual_rphi_[key]->setAxisTitle("Residual in R#phi [cm]");
+
+      me_residual_y_[key] = ibooker.book1D("residual_y" + name_suffix, title, 60, -12.0, 12.0);
+      me_residual_y_[key]->setAxisTitle("Residual in Local Y [cm]");
+
+      me_pull_phi_[key] = ibooker.book1D("pull_phi" + name_suffix, title, 60, -3.0, 3.0);
+      me_pull_phi_[key]->setAxisTitle("Pull in Global #phi");
+
+      me_pull_y_[key] = ibooker.book1D("pull_y" + name_suffix, title, 60, -3.0, 3.0);
+      me_pull_y_[key]->setAxisTitle("Pull in Local Y");
+    } // ieta
+  } // station
 }
+
+void GEMEfficiencyAnalyzer::bookMisc(
+    DQMStore::IBooker & ibooker,
+    const edm::ESHandle<GEMGeometry>& gem) {
+  ibooker.setCurrentFolder(folder_ + "/Misc");
+  me_prop_r_err_ = ibooker.book1D("prop_r_err", ";Propagation Global R Error [cm];Entries", 20, 0.0, 20.0);
+  me_prop_phi_err_ = ibooker.book1D("prop_phi_err", "Propagation Global Phi Error [rad];Entries", 20, 0.0, 0.5);
+  me_all_abs_residual_rphi_ = ibooker.book1D("all_abs_residual_rphi", ";Residual in R#phi [cm];Entries", 20, 0.0, 20.0);
+}
+
 
 void GEMEfficiencyAnalyzer::analyze(const edm::Event& event, const edm::EventSetup& setup) {
   edm::Handle<GEMRecHitCollection> rechit_collection;
   event.getByToken(rechit_token_, rechit_collection);
   if (not rechit_collection.isValid()) {
-    edm::LogError(log_category_) << "GEMRecHitCollection is invalid" << std::endl;
+    edm::LogError(kLogCategory_) << "GEMRecHitCollection is invalid" << std::endl;
     return;
   }
 
   edm::Handle<edm::View<reco::Muon> > muon_view;
   event.getByToken(muon_token_, muon_view);
   if (not muon_view.isValid()) {
-    edm::LogError(log_category_) << "View<Muon> is invalid" << std::endl;
+    edm::LogError(kLogCategory_) << "View<Muon> is invalid" << std::endl;
+    return;
   }
 
   edm::ESHandle<GEMGeometry> gem;
   setup.get<MuonGeometryRecord>().get(gem);
   if (not gem.isValid()) {
-    edm::LogError(log_category_) << "GEMGeometry is invalid" << std::endl;
+    edm::LogError(kLogCategory_) << "GEMGeometry is invalid" << std::endl;
+    return;
+  }
+
+  edm::ESHandle<GlobalTrackingGeometry> global_tracking_geometry;
+  setup.get<GlobalTrackingGeometryRecord>().get(global_tracking_geometry);
+  if (not global_tracking_geometry.isValid()) {
+    edm::LogError(kLogCategory_) << "GlobalTrackingGeometry is invalid" << std::endl;
     return;
   }
 
   edm::ESHandle<TransientTrackBuilder> transient_track_builder;
   setup.get<TransientTrackRecord>().get("TransientTrackBuilder", transient_track_builder);
   if (not transient_track_builder.isValid()) {
-    edm::LogError(log_category_) << "TransientTrackRecord is invalid" << std::endl;
+    edm::LogError(kLogCategory_) << "TransientTrackRecord is invalid" << std::endl;
     return;
   }
 
   muon_service_->update(setup);
   edm::ESHandle<Propagator>&& propagator = muon_service_->propagator("SteppingHelixPropagatorAny");
   if (not propagator.isValid()) {
-    edm::LogError(log_category_) << "Propagator is invalid" << std::endl;
+    edm::LogError(kLogCategory_) << "Propagator is invalid" << std::endl;
     return;
   }
 
+  if (rechit_collection->size() < 1) {
+    edm::LogInfo(kLogCategory_) << "empty rechit collection" << std::endl;
+    return;
+  }
+
+  if (muon_view->empty()) {
+    edm::LogInfo(kLogCategory_) << "empty muon collection" << std::endl;
+    return;
+  }
+
+  const std::vector<GEMLayerData>&& layer_vector = buildGEMLayers(gem);
+
   for (const reco::Muon& muon : *muon_view) {
-    const reco::Track* track = nullptr;
-
-    if (use_global_muon_ and muon.globalTrack().isNonnull()) {
-      track = muon.globalTrack().get();
-
-    } else if ((not use_global_muon_) and muon.outerTrack().isNonnull()) {
-      track = muon.outerTrack().get();
-    }
-
+    const reco::Track* track = getTrack(muon);
     if (track == nullptr) {
-      edm::LogError(log_category_) << "failed to get muon track" << std::endl;
+      edm::LogError(kLogCategory_) << "failed to get a muon track" << std::endl;
       continue;
     }
 
     const reco::TransientTrack&& transient_track = transient_track_builder->build(track);
     if (not transient_track.isValid()) {
-      edm::LogInfo(log_category_) << "failed to build TransientTrack" << std::endl;
+      edm::LogError(kLogCategory_) << "failed to build TransientTrack" << std::endl;
       continue;
     }
 
-    for (const GEMEtaPartition* eta_partition : gem->etaPartitions()) {
-      // Skip propagation inn the opposite direction.
-      if (muon.eta() * eta_partition->id().region() < 0)
-        continue;
-
-      const BoundPlane& bound_plane = eta_partition->surface();
-
-      const TrajectoryStateOnSurface&& tsos =
-          propagator->propagate(transient_track.outermostMeasurementState(), bound_plane);
-      if (not tsos.isValid()) {
+    for (const GEMLayerData& layer : layer_vector) {
+      if (use_skip_layer_ and skipLayer(track, layer)) {
+        edm::LogInfo(kLogCategory_) << "skip GEM Layer" << std::endl; 
         continue;
       }
 
-      const LocalPoint&& tsos_local_pos = tsos.localPosition();
-      const LocalPoint tsos_local_pos_2d(tsos_local_pos.x(), tsos_local_pos.y(), 0.0f);
-      if (not bound_plane.bounds().inside(tsos_local_pos_2d)) {
+      const auto&& [start_state, start_id] = getStartingState(transient_track, layer, global_tracking_geometry);
+
+      if (not start_state.isValid()) {
+        edm::LogInfo(kLogCategory_) << "failed to get a starting state" << std::endl;
+        continue;
+      }
+
+      if (use_only_me11_ and (not isME11(start_id))) {
+        edm::LogInfo(kLogCategory_) << "skip" << std::endl;
+        continue;
+      }
+
+      // the trajectory state on the destination surface
+      const TrajectoryStateOnSurface&& dest_state = propagator->propagate(start_state, *(layer.surface));
+      if (not dest_state.isValid()) {
+        edm::LogInfo(kLogCategory_) << "failed to propagate a muon" << std::endl;
+        continue;
+      }
+
+      const GlobalPoint&& dest_global_pos = dest_state.globalPosition();
+
+      if (not checkBounds(dest_global_pos, (*layer.surface))) {
+        edm::LogInfo(kLogCategory_) << "failed to pass checkBounds" << std::endl;
+        continue;
+      }
+
+      const GEMEtaPartition* eta_partition = findEtaPartition(dest_global_pos, layer.chambers);
+      if (eta_partition == nullptr) {
+        edm::LogInfo(kLogCategory_) << "failed to find an eta partition" << std::endl;
+        continue;
+      }
+
+      const BoundPlane& surface = eta_partition->surface();
+
+      const LocalPoint&& dest_local_pos = eta_partition->toLocal(dest_global_pos);
+      const LocalError&& dest_local_err = dest_state.localError().positionError();
+      const GlobalError& dest_global_err = ErrorFrameTransformer().transform(dest_local_err, surface);
+
+      const double dest_global_r_err = std::sqrt(dest_global_err.rerr(dest_global_pos));
+      const double dest_global_phi_err = std::sqrt(dest_global_err.phierr(dest_global_pos));
+
+      me_prop_r_err_->Fill(std::min(dest_global_r_err, 19.999));
+      me_prop_phi_err_->Fill(std::min(dest_global_r_err, 0.4999));
+
+      // TODO monitor elements for debugging
+      if (use_prop_r_error_cut_ and (dest_global_r_err > prop_r_error_cut_)) {
+        edm::LogInfo(kLogCategory_) << "failed to pass a propagation global R error cut" << std::endl;
+        continue;
+      }
+
+      if (use_prop_phi_error_cut_ and (dest_global_phi_err > prop_phi_error_cut_)) {
+        edm::LogInfo(kLogCategory_) << "failed to pass a propagation global phi error cut" << std::endl;
         continue;
       }
 
       const GEMDetId&& gem_id = eta_partition->id();
 
-      bool is_odd = gem_id.station() == 1 ? (gem_id.chamber() % 2 == 1) : false;
-      const std::tuple<int, int> key1{gem_id.region(), gem_id.station()};
-      const std::tuple<int, int, bool> key2{gem_id.region(), gem_id.station(), is_odd};
-      const std::tuple<int, int, bool, int> key3{gem_id.region(), gem_id.station(), is_odd, gem_id.roll()};
+      const GEMDetId&& rs_key = getReStKey(gem_id);
+      const GEMDetId&& rsl_key = getReStLaKey(gem_id);
+      const GEMDetId&& rse_key = getReStEtKey(gem_id);
 
       const int chamber_bin = getDetOccXBin(gem_id, gem);
+      const double muon_pt = std::min(muon.pt(), pt_clamp_max_);
+      const double muon_eta = std::clamp(std::fabs(muon.eta()), eta_low_, eta_clamp_max_);
 
-      fillME(me_detector_, key1, chamber_bin, gem_id.roll());
-      fillME(me_muon_pt_, key2, muon.pt());
-      fillME(me_muon_eta_, key2, std::fabs(muon.eta()));
+      fillME(me_detector_, rs_key, chamber_bin, gem_id.roll());
+      fillME(me_muon_pt_, rs_key, muon_pt);
+      fillME(me_muon_eta_, rs_key, muon_eta);
+      fillME(me_muon_phi_, rs_key, muon.phi());
+      fillME(me_chamber_, rsl_key, gem_id.chamber());
 
-      const GEMRecHit* matched_hit = findMatchedHit(tsos_local_pos.x(), rechit_collection->get(gem_id));
-      if (matched_hit == nullptr) {
+      const auto&& [hit, residual_rphi] = findClosetHit(
+          dest_global_pos, rechit_collection->get(gem_id), eta_partition);
+
+      if (hit == nullptr) {
+        edm::LogInfo(kLogCategory_) << "failed to find a hit" << std::endl;
         continue;
       }
 
-      fillME(me_detector_matched_, key1, chamber_bin, gem_id.roll());
-      fillME(me_muon_pt_matched_, key2, muon.pt());
-      fillME(me_muon_eta_matched_, key2, std::fabs(muon.eta()));
+      me_all_abs_residual_rphi_->Fill(std::min(std::abs(residual_rphi), 19.999f));
 
-      const LocalPoint&& hit_local_pos = matched_hit->localPosition();
+      // TODO overall residual rphi for debugging
+      if (std::abs(residual_rphi) > residual_rphi_cut_) {
+        edm::LogInfo(kLogCategory_) << "failed to pass the residual rphi cut" << std::endl;
+        continue;
+      }
+
+      fillME(me_detector_matched_, rs_key, chamber_bin, gem_id.roll());
+      fillME(me_muon_pt_matched_, rs_key, muon_pt);
+      fillME(me_muon_eta_matched_, rs_key, muon_eta);
+      fillME(me_muon_phi_matched_, rs_key, muon.phi());
+      fillME(me_chamber_matched_, rsl_key, gem_id.chamber());
+
+      const LocalPoint&& hit_local_pos = hit->localPosition();
       const GlobalPoint&& hit_global_pos = eta_partition->toGlobal(hit_local_pos);
-      const GlobalPoint&& tsos_global_pos = tsos.globalPosition();
+      const LocalError&& hit_local_err = hit->localPositionError();
+      const GlobalError& hit_global_err = ErrorFrameTransformer().transform(hit_local_err, surface);
 
-      const float residual_x = tsos_local_pos.x() - hit_local_pos.x();
-      const float residual_y = tsos_local_pos.y() - hit_local_pos.y();
-      const float residual_phi = reco::deltaPhi(tsos_global_pos.barePhi(), hit_global_pos.barePhi());
+      const float dphi = reco::deltaPhi(dest_global_pos.barePhi(), hit_global_pos.barePhi());
+      const float residual_y = dest_local_pos.y() - hit_local_pos.y();
+      const float global_phi_err = std::sqrt(dest_global_err.phierr(dest_global_pos) + hit_global_err.phierr(hit_global_pos));
+      const float pull_phi = dphi / global_phi_err;
+      const float pull_y = residual_y / std::sqrt(dest_local_err.yy() + hit_local_err.yy());
 
-      const LocalError&& tsos_err = tsos.localError().positionError();
-      const LocalError&& hit_err = matched_hit->localPositionError();
-
-      const float pull_x = residual_x / std::sqrt(tsos_err.xx() + hit_err.xx());
-      const float pull_y = residual_y / std::sqrt(tsos_err.yy() + hit_err.yy());
-
-      fillME(me_residual_x_, key3, residual_x);
-      fillME(me_residual_y_, key3, residual_y);
-      fillME(me_residual_phi_, key3, residual_phi);
-
-      fillME(me_pull_x_, key3, pull_x);
-      fillME(me_pull_y_, key3, pull_y);
-    }  // GEMChamber
+      fillME(me_residual_rphi_, rse_key, residual_rphi);
+      fillME(me_residual_y_, rse_key, residual_y);
+      fillME(me_pull_phi_, rse_key, pull_phi);
+      fillME(me_pull_y_, rse_key, pull_y);
+    }  // layer
   }    // Muon
 }
 
-const GEMRecHit* GEMEfficiencyAnalyzer::findMatchedHit(const float track_local_x,
-                                                       const GEMRecHitCollection::range& range) {
-  float min_residual_x{residual_x_cut_};
+
+std::vector<GEMEfficiencyAnalyzer::GEMLayerData>
+GEMEfficiencyAnalyzer::buildGEMLayers(const edm::ESHandle<GEMGeometry>& gem) {
+  std::vector<GEMLayerData> layer_vector;
+
+  for (const GEMStation* station : gem->stations()) {
+    const int region_id = station->region();
+    const int station_id = station->station();
+
+    // layer_id - chambers
+    std::map<int, std::vector<const GEMChamber*> > chambers_per_layer; // chambers per layer
+    for (const GEMSuperChamber* super_chamber : station->superChambers()) {
+      for (const GEMChamber* chamber : super_chamber->chambers()) {
+        const int layer_id = chamber->id().layer();
+
+        if (chambers_per_layer.find(layer_id) == chambers_per_layer.end())
+          chambers_per_layer.insert({layer_id, std::vector<const GEMChamber*>()});
+
+        chambers_per_layer[layer_id].push_back(chamber);
+      } // GEMChamber
+    } // GEMSuperChamber
+
+    for (auto [layer_id, chamber_vector] : chambers_per_layer) {
+
+      auto [rmin, rmax] = chamber_vector[0]->surface().rSpan();
+      auto [zmin, zmax] = chamber_vector[0]->surface().zSpan();
+      for (const GEMChamber* chamber : chamber_vector) {
+        // the span of a bound surface in the global coordinates
+        const auto [chamber_rmin, chamber_rmax] = chamber->surface().rSpan();
+        const auto [chamber_zmin, chamber_zmax] = chamber->surface().zSpan();
+
+        rmin = std::min(rmin, chamber_rmin);
+        rmax = std::max(rmax, chamber_rmax);
+
+        zmin = std::min(zmin, chamber_zmin);
+        zmax = std::max(zmax, chamber_zmax);
+      }
+
+      // layer position and rotation
+      const float layer_z = chamber_vector[0]->position().z();
+      Surface::PositionType position(0.f, 0.f, layer_z);
+      Surface::RotationType rotation;
+
+      zmin -= layer_z;
+      zmax -= layer_z;
+
+      // the bounds from min and max R and Z in the local coordinates.
+      SimpleDiskBounds* bounds = new SimpleDiskBounds(rmin, rmax, zmin, zmax);
+      const Disk::DiskPointer&& layer = Disk::build(position, rotation, bounds);
+
+      layer_vector.emplace_back(layer, chamber_vector, region_id, station_id, layer_id);
+
+    } // layer
+  } // GEMStation
+
+  return layer_vector;
+}
+
+
+const reco::Track* GEMEfficiencyAnalyzer::getTrack(const reco::Muon& muon) {
+  const reco::Track* track = nullptr;
+
+  if (is_cosmics_) {
+    if (muon.outerTrack().isNonnull())
+      track = muon.outerTrack().get();
+
+  } else {
+    // beams, i.e. pp or heavy ions
+    if (use_global_muon_ and muon.globalTrack().isNonnull())
+      track = muon.globalTrack().get();
+
+    else if ((not use_global_muon_) and muon.outerTrack().isNonnull())
+      track = muon.outerTrack().get();
+  }
+
+  return track;
+}
+
+
+std::pair<TrajectoryStateOnSurface, DetId>
+GEMEfficiencyAnalyzer::getStartingState(
+    const reco::TransientTrack& transient_track,
+    const GEMLayerData& layer,
+    const edm::ESHandle<GlobalTrackingGeometry>& geometry) {
+
+  TrajectoryStateOnSurface starting_state;
+  DetId starting_id;
+
+  if (use_global_muon_) {
+    std::tie(starting_state, starting_id) = findStartingState(transient_track, layer, geometry);
+
+  } else {
+    // if outer track
+    const reco::Track& track = transient_track.track();
+    const bool is_insideout = isInsideOut(track);
+
+    const DetId inner_id{(is_insideout ? track.outerDetId() : track.innerDetId())};
+    if (MuonHitHelper::isGEM(inner_id.rawId())) {
+      std::tie(starting_state, starting_id) = findStartingState(transient_track, layer, geometry);
+
+    } else {
+      starting_id = std::move(inner_id);
+      if (is_insideout)
+        starting_state = std::move(transient_track.outermostMeasurementState());
+      else
+        starting_state = std::move(transient_track.innermostMeasurementState());
+    }
+  }
+ 
+  return std::make_pair(starting_state, starting_id);
+}
+
+
+std::pair<TrajectoryStateOnSurface, DetId>
+GEMEfficiencyAnalyzer::findStartingState(
+    const reco::TransientTrack& transient_track,
+    const GEMLayerData& layer,
+    const edm::ESHandle<GlobalTrackingGeometry>& geometry) {
+
+  GlobalPoint starting_point;
+  DetId starting_id;
+  float min_distance = 1e12;
+  bool found = false;
+ 
+  // TODO optimize this loop because hits should be ordered..
+  for (auto rechit = transient_track.recHitsBegin(); rechit != transient_track.recHitsEnd(); rechit++) {
+    const DetId&& det_id = (*rechit)->geographicalId();
+
+    if (MuonHitHelper::isGEM(det_id.rawId())) {
+      continue;
+    }
+
+    const GeomDet* det = geometry->idToDet(det_id);
+    const GlobalPoint&& global_position = det->toGlobal((*rechit)->localPosition());
+    const float distance = std::abs(layer.surface->localZclamped(global_position));
+    if (distance < min_distance) {
+      found = true;
+      min_distance = distance;
+      starting_point = global_position;
+      starting_id = det_id;
+    }
+  }
+
+  TrajectoryStateOnSurface starting_state;
+  if (found) {
+    starting_state = std::move(transient_track.stateOnSurface(starting_point));
+  }
+  return std::make_pair(starting_state, starting_id);
+}
+
+bool GEMEfficiencyAnalyzer::isME11(const DetId& det_id) {
+  if (not MuonHitHelper::isCSC(det_id)) return false;
+  const CSCDetId csc_id{det_id};
+  return (csc_id.station() == 1) or ((csc_id.ring() == 1) or (csc_id.ring() == 4));
+}
+
+bool GEMEfficiencyAnalyzer::skipLayer(const reco::Track* track,
+                                      const GEMLayerData& layer) {
+  const bool is_same_region = track->eta() * layer.region > 0;
+
+  bool skip = false;
+  if (is_cosmics_) {
+    float p2_in = track->innerMomentum().mag2();
+    float p2_out = track->outerMomentum().mag2();
+    if (isInsideOut(*track))
+      std::swap(p2_in, p2_out);
+    const bool is_outgoing = p2_in > p2_out;
+
+    skip = (is_outgoing xor is_same_region);
+
+  } else {
+    // beam scenario
+    skip = not is_same_region;
+
+  }
+
+  return skip;
+}
+
+bool GEMEfficiencyAnalyzer::checkBounds(const GlobalPoint& global_point, const Plane& plane) {
+  const LocalPoint&& local_point = plane.toLocal(global_point);
+  const LocalPoint local_point_2d(local_point.x(), local_point.y(), 0.0f);
+  return plane.bounds().inside(local_point_2d);
+}
+
+const GEMEtaPartition* GEMEfficiencyAnalyzer::findEtaPartition(
+    const GlobalPoint& global_point,
+    const std::vector<const GEMChamber*>& chamber_vector) {
+
+  const GEMEtaPartition* bound = nullptr;
+  for (const GEMChamber* chamber : chamber_vector) {
+    if (not checkBounds(global_point, chamber->surface())) 
+      continue;
+
+    for (const GEMEtaPartition* eta_partition : chamber->etaPartitions()) {
+      if (checkBounds(global_point, eta_partition->surface())) {
+        bound = eta_partition;
+        break;
+      }
+    } // GEMEtaPartition
+  } // GEMChamber
+
+  return bound;
+}
+
+std::pair<const GEMRecHit*, float> GEMEfficiencyAnalyzer::findClosetHit(
+    const GlobalPoint& dest_global_pos,
+    const GEMRecHitCollection::range& range,
+    const GEMEtaPartition* eta_partition) {
+
+  const StripTopology& topology = eta_partition->specificTopology();
+  const LocalPoint&& dest_local_pos = eta_partition->toLocal(dest_global_pos);
+  const float dest_local_x = dest_local_pos.x();
+  const float dest_local_y = dest_local_pos.y();
+
   const GEMRecHit* closest_hit = nullptr;
+  float min_residual_rphi = 1e6;
 
   for (auto hit = range.first; hit != range.second; ++hit) {
-    float residual_x = std::fabs(track_local_x - hit->localPosition().x());
-    if (residual_x <= min_residual_x) {
-      min_residual_x = residual_x;
+    const LocalPoint&& hit_local_pos = hit->localPosition();
+    const float hit_local_phi = topology.stripAngle(eta_partition->strip(hit_local_pos));
+ 
+    const float residual_x = dest_local_x - hit_local_pos.x();
+    const float residual_y = dest_local_y - hit_local_pos.y();
+    const float residual_rphi = std::cos(hit_local_phi) * residual_x + std::sin(hit_local_phi) * residual_y;
+
+    if (std::abs(residual_rphi) < std::abs(min_residual_rphi)) {
+      min_residual_rphi = residual_rphi;
       closest_hit = &(*hit);
     }
   }
 
-  return closest_hit;
+  return std::make_pair(closest_hit, min_residual_rphi);
 }

--- a/DQMOffline/Muon/src/GEMEfficiencyHarvester.cc
+++ b/DQMOffline/Muon/src/GEMEfficiencyHarvester.cc
@@ -28,7 +28,7 @@ TProfile* GEMEfficiencyHarvester::computeEfficiency(
 
   TProfile* eff_profile = new TProfile(name, title, total_x->GetNbins(), total_x->GetXmin(), total_x->GetXmax());
   eff_profile->GetXaxis()->SetTitle(total_x->GetTitle());
-  eff_profile->GetYaxis()->SetTitle("#epsilon");
+  eff_profile->GetYaxis()->SetTitle("Efficiency");
 
   for (int bin = 1; bin <= total->GetNbinsX(); bin++) {
     double num_passed = passed->GetBinContent(bin);

--- a/DQMOffline/Muon/src/GEMEfficiencyHarvester.cc
+++ b/DQMOffline/Muon/src/GEMEfficiencyHarvester.cc
@@ -364,7 +364,12 @@ void GEMEfficiencyHarvester::doResolution(DQMStore::IBooker& ibooker,
 
     h_mean->SetBinContent(xbin, ybin, hist->GetMean());
     h_stddev->SetBinContent(xbin, ybin, hist->GetStdDev());
-    h_skewness->SetBinContent(xbin, ybin, hist->GetSkewness());
+
+    // FIXME
+    // `GetSkewness` seems to returns nan when its histogram has no entry..
+    const double skewness = hist->GetSkewness();
+    if (not std::isnan(skewness))
+      h_skewness->SetBinContent(xbin, ybin, skewness);
 
     h_mean->SetBinError(xbin, ybin, hist->GetMeanError());
     h_stddev->SetBinError(xbin, ybin, hist->GetStdDevError());

--- a/DQMOffline/Muon/src/GEMEfficiencyHarvester.cc
+++ b/DQMOffline/Muon/src/GEMEfficiencyHarvester.cc
@@ -6,10 +6,16 @@
 
 GEMEfficiencyHarvester::GEMEfficiencyHarvester(const edm::ParameterSet& pset) {
   folder_ = pset.getUntrackedParameter<std::string>("folder");
-  log_category_ = pset.getUntrackedParameter<std::string>("logCategory");
+  log_category_ = "GEMEfficiencyHarvester";
 }
 
 GEMEfficiencyHarvester::~GEMEfficiencyHarvester() {}
+
+void GEMEfficiencyHarvester::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.addUntracked<std::string>("folder", "GEM/Efficiency/type0");
+  descriptions.add("gemEfficiencyHarvesterDefault", desc);
+}
 
 TProfile* GEMEfficiencyHarvester::computeEfficiency(
     const TH1F* passed, const TH1F* total, const char* name, const char* title, const double confidence_level) {
@@ -24,7 +30,7 @@ TProfile* GEMEfficiencyHarvester::computeEfficiency(
   eff_profile->GetXaxis()->SetTitle(total_x->GetTitle());
   eff_profile->GetYaxis()->SetTitle("#epsilon");
 
-  for (int bin = 1; bin < total->GetNbinsX(); bin++) {
+  for (int bin = 1; bin <= total->GetNbinsX(); bin++) {
     double num_passed = passed->GetBinContent(bin);
     double num_total = total->GetBinContent(bin);
 
@@ -119,6 +125,7 @@ void GEMEfficiencyHarvester::doEfficiency(DQMStore::IBooker& ibooker, DQMStore::
     const auto& [me_passed, me_total] = value;
     if (me_passed == nullptr) {
       edm::LogError(log_category_) << "numerator is missing. " << key << std::endl;
+      continue;
     }
 
     if (me_total == nullptr) {
@@ -199,45 +206,36 @@ std::vector<std::string> GEMEfficiencyHarvester::splitString(std::string name, c
   return tokens;
 }
 
-std::tuple<std::string, int, bool, int> GEMEfficiencyHarvester::parseResidualName(const std::string org_name,
+std::tuple<std::string, int, int> GEMEfficiencyHarvester::parseResidualName(const std::string org_name,
                                                                                   const std::string prefix) {
   std::string name = org_name;
 
-  // residual_x_ge-11_odd_ieta4 or residdual_x_ge+21_ieta3
-  // residual_x: prefix
+  // e.g. residual_rdphi_GE-11_R4 -> _GE-11_R4
   name.erase(name.find(prefix), prefix.length());
-  name.erase(name.find("_ge"), 3);
 
+  // _GE-11_R4 -> -11_R4
+  name.erase(name.find("_GE"), 3);
+
+  // -11_R4 -> (-11, R4)
   const std::vector<std::string>&& tokens = splitString(name, "_");
   const size_t num_tokens = tokens.size();
 
-  if ((num_tokens != 2) and (num_tokens != 3)) {
-    return std::make_tuple("", -1, false, -1);
+  if (num_tokens != 2) {
+    return std::make_tuple("", -1, -1);
   }
 
-  // station != 1
+  // '-'11
   std::string region_sign = tokens.front().substr(0, 1);
-
+  // -'1'1
   TString station_str = tokens.front().substr(1, 1);
-  TString ieta_str = tokens.back().substr(4, 1);
-  TString superchamber_str = (num_tokens == 3) ? tokens[1] : "";
 
-  int station = station_str.IsDigit() ? station_str.Atoi() : -1;
-  int ieta = ieta_str.IsDigit() ? ieta_str.Atoi() : -1;
+  // R'4' or R'16'
+  TString ieta_str = tokens.back().substr(1);
 
-  bool is_odd;
-  if (station == 1) {
-    if (superchamber_str.EqualTo("odd"))
-      is_odd = true;
-    else if (superchamber_str.EqualTo("even"))
-      is_odd = false;
-    else
-      return std::make_tuple("", -1, false, -1);
-  } else {
-    is_odd = false;
-  }
+  const int station = station_str.IsDigit() ? station_str.Atoi() : -1;
+  const int ieta = ieta_str.IsDigit() ? ieta_str.Atoi() : -1;
 
-  return std::make_tuple(region_sign, station, is_odd, ieta);
+  return std::make_tuple(region_sign, station, ieta);
 }
 
 void GEMEfficiencyHarvester::doResolution(DQMStore::IBooker& ibooker,
@@ -248,7 +246,12 @@ void GEMEfficiencyHarvester::doResolution(DQMStore::IBooker& ibooker,
   igetter.setCurrentFolder(resolution_folder);
   ibooker.setCurrentFolder(resolution_folder);
 
-  std::map<std::tuple<std::string, int, bool>, std::vector<std::pair<int, TH1F*> > > res_data;
+  // (histogram, (region_sign, station), ieta)
+  std::vector<std::tuple<const TH1F*, std::pair<std::string, int>, int> > hist_vector;
+  // (region_sign, station)
+  std::vector<std::pair<std::string, int> > re_st_vec;
+  // ieta
+  std::vector<int> ieta_vec;
 
   for (const std::string& name : igetter.getMEs()) {
     if (name.find(prefix) == std::string::npos)
@@ -261,73 +264,119 @@ void GEMEfficiencyHarvester::doResolution(DQMStore::IBooker& ibooker,
       continue;
     }
 
-    TH1F* hist = me->getTH1F();
+    const TH1F* hist = me->getTH1F();
     if (hist == nullptr) {
       edm::LogError(log_category_) << "failed to get TH1F" << std::endl;
       continue;
     }
 
-    auto&& [region_sign, station, is_odd, ieta] = parseResidualName(name, prefix);
+    auto&& [region_sign, station, ieta] = parseResidualName(name, prefix);
     if (region_sign.empty() or station < 0 or ieta < 0) {
       edm::LogError(log_category_) << "failed to parse the name of the residual histogram: " << name << std::endl;
       continue;
     }
+    std::pair<std::string, int> region_station(region_sign, station);
 
-    const std::tuple<std::string, int, bool> key{region_sign, station, is_odd};
-
-    if (res_data.find(key) == res_data.end()) {
-      res_data.insert({key, std::vector<std::pair<int, TH1F*> >()});
-    }
-    res_data[key].emplace_back(ieta, hist);
+    hist_vector.emplace_back(hist, region_station, ieta);
+    if (std::find(re_st_vec.begin(), re_st_vec.end(), region_station) == re_st_vec.end())
+      re_st_vec.push_back(region_station);
+    if (std::find(ieta_vec.begin(), ieta_vec.end(), ieta) == ieta_vec.end())
+      ieta_vec.push_back(ieta);
   }  // MonitorElement
 
-  //////////////////////////////////////////////////////////////////////////////
+  if (hist_vector.empty()) {
+    edm::LogError(log_category_) << "failed to find " << prefix << std::endl;
+    return;
+  }
+
   // NOTE
-  //////////////////////////////////////////////////////////////////////////////
-  for (auto [key, ieta_data] : res_data) {
-    if (ieta_data.empty()) {
+  // GE-2/1, GE-1/1, GE-0/1, GE+0/1, GE+1/1, GE+2/1
+  auto f_sort = [](const std::pair<std::string, int>& lhs, const std::pair<std::string, int>& rhs) -> bool {
+    if (lhs.first == rhs.first) {
+      if (lhs.first == "-")
+        return lhs.second > rhs.second;
+      else
+        return lhs.second < rhs.second;
+
+    } else {
+      return (lhs.first == "-");
+
+    }
+  };
+
+  std::sort(re_st_vec.begin(), re_st_vec.end(), f_sort);
+  std::sort(ieta_vec.begin(), ieta_vec.end());
+
+  const int num_st = re_st_vec.size();
+  const int num_ieta = ieta_vec.size();
+
+  // NOTE
+  TString tmp_title{std::get<0>(hist_vector.front())->GetTitle()};
+
+  const TObjArray* tokens = tmp_title.Tokenize(":");
+  const TString title_prefix = dynamic_cast<TObjString*>(tokens->At(0))->GetString();
+
+  const TString h_mean_name = prefix + "_mean";
+  const TString h_stddev_name = prefix + "_stddev";
+  const TString h_skewness_name = prefix + "_skewness";
+
+  const TString h_mean_title = title_prefix + " : Mean";
+  const TString h_stddev_title = title_prefix + " : Standard Deviation";
+  const TString h_skewness_title = title_prefix + " : Skewness";
+
+  TH2F* h_mean = new TH2F(h_mean_name, h_mean_title,
+                          num_ieta, 0.5, num_ieta + 0.5,
+                          num_st, 0.5, num_st + 0.5);
+  // x-axis
+  h_mean->GetXaxis()->SetTitle("i#eta");
+  for (unsigned int idx = 0; idx < ieta_vec.size(); idx++) {
+    const int xbin = idx + 1;
+    const char* label = Form("%d", ieta_vec[idx]);
+    h_mean->GetXaxis()->SetBinLabel(xbin, label);
+  }
+  // y-axis
+  for (unsigned int idx = 0; idx < re_st_vec.size(); idx++) {
+    auto [region_sign, station] = re_st_vec[idx];
+    const char* label = Form("GE%s%d/1", region_sign.c_str(), station);
+    const int ybin = idx + 1;
+    h_mean->GetYaxis()->SetBinLabel(ybin, label);
+  }
+
+  TH2F* h_stddev = dynamic_cast<TH2F*>(h_mean->Clone(h_stddev_name));
+  TH2F* h_skewness = dynamic_cast<TH2F*>(h_mean->Clone(h_skewness_name));
+
+  h_stddev->SetTitle(h_stddev_title);
+  h_skewness->SetTitle(h_skewness_title);
+
+  // NOTE
+  for (auto [hist, region_station, ieta] : hist_vector) {
+    const int xbin = findResolutionBin(ieta, ieta_vec);
+    if (xbin < 0) {
+      edm::LogError(log_category_) << "found a wrong x bin = " << xbin << std::endl;
       continue;
     }
 
-    TString tmp_title{ieta_data.front().second->GetTitle()};
-    const TObjArray* tokens = tmp_title.Tokenize(":");
-    TString title = dynamic_cast<TObjString*>(tokens->At(0))->GetString();
-
-    auto&& [region_sign, station, is_odd] = key;
-    TString&& name = TString::Format("%s_ge%s%d1", prefix.data(), region_sign.c_str(), station);
-    title += TString::Format("GE %s%d/1", region_sign.c_str(), station);
-    if (station == 1) {
-      name += (is_odd ? "_odd" : "_even");
-      title += (is_odd ? ", Odd Superchambers" : ", Even Superchambers");
+    const int ybin = findResolutionBin(region_station, re_st_vec);
+    if (ybin < 0) {
+      edm::LogError(log_category_) << "found a wrong y bin = " << ybin << std::endl;
+      continue;
     }
 
-    const int num_etas = ieta_data.size();
+    h_mean->SetBinContent(xbin, ybin, hist->GetMean());
+    h_stddev->SetBinContent(xbin, ybin, hist->GetStdDev());
+    h_skewness->SetBinContent(xbin, ybin, hist->GetSkewness());
 
-    TH2F* profile = new TH2F(name, title, num_etas, 0.5, num_etas + 0.5, 2, -0.5, 1.5);
-    auto x_axis = profile->GetXaxis();
+    h_mean->SetBinError(xbin, ybin, hist->GetMeanError());
+    h_stddev->SetBinError(xbin, ybin, hist->GetStdDevError());
+    h_skewness->SetBinError(xbin, ybin, hist->GetSkewness(11));
+  }
 
-    x_axis->SetTitle("i#eta");
-    for (int ieta = 1; ieta <= num_etas; ieta++) {
-      const std::string&& label = std::to_string(ieta);
-      x_axis->SetBinLabel(ieta, label.c_str());
-    }
-
-    profile->GetYaxis()->SetBinLabel(1, "Mean");
-    profile->GetYaxis()->SetBinLabel(2, "Std. Dev.");
-
-    for (auto [ieta, hist] : ieta_data) {
-      profile->SetBinContent(ieta, 1, hist->GetMean());
-      profile->SetBinContent(ieta, 2, hist->GetStdDev());
-
-      profile->SetBinError(ieta, 1, hist->GetMeanError());
-      profile->SetBinError(ieta, 2, hist->GetStdDevError());
-    }
-
-    ibooker.book2D(name, profile);
+  for (auto&& each : {h_mean, h_stddev, h_skewness}) {
+    ibooker.book2D(each->GetName(), each);
   }
 }
 
 void GEMEfficiencyHarvester::dqmEndJob(DQMStore::IBooker& ibooker, DQMStore::IGetter& igetter) {
   doEfficiency(ibooker, igetter);
-  doResolution(ibooker, igetter, "residual_phi");
+  doResolution(ibooker, igetter, "residual_rphi");
 }

--- a/DQMOffline/Muon/src/GEMEfficiencyHarvester.cc
+++ b/DQMOffline/Muon/src/GEMEfficiencyHarvester.cc
@@ -207,7 +207,7 @@ std::vector<std::string> GEMEfficiencyHarvester::splitString(std::string name, c
 }
 
 std::tuple<std::string, int, int> GEMEfficiencyHarvester::parseResidualName(const std::string org_name,
-                                                                                  const std::string prefix) {
+                                                                            const std::string prefix) {
   std::string name = org_name;
 
   // e.g. residual_rdphi_GE-11_R4 -> _GE-11_R4
@@ -300,7 +300,6 @@ void GEMEfficiencyHarvester::doResolution(DQMStore::IBooker& ibooker,
 
     } else {
       return (lhs.first == "-");
-
     }
   };
 
@@ -324,9 +323,7 @@ void GEMEfficiencyHarvester::doResolution(DQMStore::IBooker& ibooker,
   const TString h_stddev_title = title_prefix + " : Standard Deviation";
   const TString h_skewness_title = title_prefix + " : Skewness";
 
-  TH2F* h_mean = new TH2F(h_mean_name, h_mean_title,
-                          num_ieta, 0.5, num_ieta + 0.5,
-                          num_st, 0.5, num_st + 0.5);
+  TH2F* h_mean = new TH2F(h_mean_name, h_mean_title, num_ieta, 0.5, num_ieta + 0.5, num_st, 0.5, num_st + 0.5);
   // x-axis
   h_mean->GetXaxis()->SetTitle("i#eta");
   for (unsigned int idx = 0; idx < ieta_vec.size(); idx++) {

--- a/DQMOffline/Muon/src/GEMOfflineDQMBase.cc
+++ b/DQMOffline/Muon/src/GEMOfflineDQMBase.cc
@@ -1,8 +1,7 @@
 #include "DQMOffline/Muon/interface/GEMOfflineDQMBase.h"
 #include "FWCore/Utilities/interface/Likely.h"
 
-GEMOfflineDQMBase::GEMOfflineDQMBase(const edm::ParameterSet& pset) {
-}
+GEMOfflineDQMBase::GEMOfflineDQMBase(const edm::ParameterSet& pset) {}
 
 int GEMOfflineDQMBase::getDetOccXBin(const GEMDetId& gem_id, const edm::ESHandle<GEMGeometry>& gem) {
   const GEMSuperChamber* superchamber = gem->superChamber(gem_id);
@@ -91,22 +90,18 @@ int GEMOfflineDQMBase::getNumEtaPartitions(const GEMStation* station) {
 }
 
 void GEMOfflineDQMBase::fillME(MEMap& me_map, const GEMDetId& key, const float x) {
-  if UNLIKELY(me_map.find(key) == me_map.end()) {
-    const std::string hint = me_map.size() > 0 ? me_map.begin()->second->getName() : "empty";
+  if UNLIKELY (me_map.find(key) == me_map.end()) {
+    const std::string hint = !me_map.empty() ? me_map.begin()->second->getName() : "empty";
 
     edm::LogError(log_category_) << "got invalid key: " << key << ", hint=" << hint << std::endl;
 
   } else {
     me_map[key]->Fill(x);
-
   }
 }
 
-void GEMOfflineDQMBase::fillME(MEMap& me_map,
-                               const GEMDetId& key,
-                               const float x,
-                               const float y) {
-  if UNLIKELY(me_map.find(key) == me_map.end()) {
+void GEMOfflineDQMBase::fillME(MEMap& me_map, const GEMDetId& key, const float x, const float y) {
+  if UNLIKELY (me_map.find(key) == me_map.end()) {
     edm::LogError(log_category_) << "got invalid key: " << key << std::endl;
 
   } else {

--- a/DQMOffline/Muon/src/GEMOfflineDQMBase.cc
+++ b/DQMOffline/Muon/src/GEMOfflineDQMBase.cc
@@ -1,7 +1,7 @@
 #include "DQMOffline/Muon/interface/GEMOfflineDQMBase.h"
+#include "FWCore/Utilities/interface/Likely.h"
 
 GEMOfflineDQMBase::GEMOfflineDQMBase(const edm::ParameterSet& pset) {
-  log_category_ = pset.getUntrackedParameter<std::string>("logCategory");
 }
 
 int GEMOfflineDQMBase::getDetOccXBin(const GEMDetId& gem_id, const edm::ESHandle<GEMGeometry>& gem) {
@@ -88,4 +88,28 @@ int GEMOfflineDQMBase::getNumEtaPartitions(const GEMStation* station) {
   }
 
   return chambers.front()->nEtaPartitions();
+}
+
+void GEMOfflineDQMBase::fillME(MEMap& me_map, const GEMDetId& key, const float x) {
+  if UNLIKELY(me_map.find(key) == me_map.end()) {
+    const std::string hint = me_map.size() > 0 ? me_map.begin()->second->getName() : "empty";
+
+    edm::LogError(log_category_) << "got invalid key: " << key << ", hint=" << hint << std::endl;
+
+  } else {
+    me_map[key]->Fill(x);
+
+  }
+}
+
+void GEMOfflineDQMBase::fillME(MEMap& me_map,
+                               const GEMDetId& key,
+                               const float x,
+                               const float y) {
+  if UNLIKELY(me_map.find(key) == me_map.end()) {
+    edm::LogError(log_category_) << "got invalid key: " << key << std::endl;
+
+  } else {
+    me_map[key]->Fill(x, y);
+  }
 }

--- a/DQMOffline/Muon/src/GEMOfflineMonitor.cc
+++ b/DQMOffline/Muon/src/GEMOfflineMonitor.cc
@@ -1,14 +1,16 @@
 #include "DQMOffline/Muon/interface/GEMOfflineMonitor.h"
-
-#include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "Geometry/CommonTopologies/interface/StripTopology.h"
 #include "Geometry/Records/interface/MuonGeometryRecord.h"
-#include "DataFormats/Math/interface/deltaPhi.h"
+#include "Validation/MuonGEMHits/interface/GEMValidationUtils.h"
+
 
 GEMOfflineMonitor::GEMOfflineMonitor(const edm::ParameterSet& pset) : GEMOfflineDQMBase(pset) {
   digi_token_ = consumes<GEMDigiCollection>(pset.getParameter<edm::InputTag>("digiTag"));
   rechit_token_ = consumes<GEMRecHitCollection>(pset.getParameter<edm::InputTag>("recHitTag"));
+  do_digi_occupancy_ = pset.getUntrackedParameter<bool>("doDigiOccupancy");
+  do_hit_occupancy_ = pset.getUntrackedParameter<bool>("doHitOccupancy");
+  log_category_ = pset.getUntrackedParameter<std::string>("logCategory");
 }
 
 GEMOfflineMonitor::~GEMOfflineMonitor() {}
@@ -18,80 +20,110 @@ void GEMOfflineMonitor::fillDescriptions(edm::ConfigurationDescriptions& descrip
   desc.add<edm::InputTag>("digiTag", edm::InputTag("muonGEMDigis"));
   desc.add<edm::InputTag>("recHitTag", edm::InputTag("gemRecHits"));
   desc.addUntracked<std::string>("logCategory", "GEMOfflineMonitor");
-  descriptions.add("gemOfflineMonitor", desc);
+  desc.addUntracked<bool>("doDigiOccupancy", true);
+  desc.addUntracked<bool>("doHitOccupancy", true);
+  descriptions.add("gemOfflineMonitorDefault", desc);
 }
 
-void GEMOfflineMonitor::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const& run, edm::EventSetup const& isetup) {
+void GEMOfflineMonitor::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const& run, edm::EventSetup const& setup) {
   edm::ESHandle<GEMGeometry> gem;
-  isetup.get<MuonGeometryRecord>().get(gem);
+  setup.get<MuonGeometryRecord>().get(gem);
   if (not gem.isValid()) {
     edm::LogError(log_category_) << "GEMGeometry is invalid" << std::endl;
     return;
   }
 
-  for (const GEMRegion* region : gem->regions()) {
-    const int region_number = region->region();
-    const char* region_sign = region_number > 0 ? "+" : "-";
+  if (do_digi_occupancy_)
+    bookDigiOccupancy(ibooker, gem);
 
-    for (const GEMStation* station : region->stations()) {
-      const int station_number = station->station();
+  if (do_hit_occupancy_)
+    bookHitOccupancy(ibooker, gem);
 
-      const MEMapKey1 det_key{region_number, station_number};
-      const auto&& station_name = TString::Format("_ge%s%d1", region_sign, station_number);
-      const auto&& station_title = TString::Format(" : GE %s%d/1", region_sign, station_number);
-      bookDetectorOccupancy(ibooker, station, det_key, station_name, station_title);
-    }  // station
-  }    // region
 }
 
-void GEMOfflineMonitor::bookDetectorOccupancy(DQMStore::IBooker& ibooker,
-                                              const GEMStation* station,
-                                              const MEMapKey1& key,
-                                              const TString& name_suffix,
-                                              const TString& title_suffix) {
-  BookingHelper helper(ibooker, name_suffix, title_suffix);
-  const auto&& superchambers = station->superChambers();
-  if (not checkRefs(superchambers)) {
-    edm::LogError(log_category_) << "failed to get a valid vector of GEMSuperChamber ptrs" << std::endl;
-    return;
-  }
 
-  // per station
-  const int num_superchambers = superchambers.size();
-  const int num_chambers = num_superchambers * superchambers.front()->nChambers();
-  // the numer of VFATs per GEMEtaPartition
-  const int max_vfat = getMaxVFAT(station->station());
-  // the number of eta partitions per GEMChamber
-  const int num_etas = getNumEtaPartitions(station);
-  // the number of VFATs per GEMChamber
-  const int num_vfat = num_etas * max_vfat;
+void GEMOfflineMonitor::bookDigiOccupancy(DQMStore::IBooker& ibooker,
+                                         const edm::ESHandle<GEMGeometry>& gem) {
+  ibooker.setCurrentFolder("GEM/GEMOfflineMonitor/DigiOccupancy");
 
-  // NOTE Digi
-  ibooker.setCurrentFolder("GEM/GEMOfflineMonitor/Digi");
-  me_digi_det_[key] =
-      helper.book2D("digi_det", "Digi Occupancy", num_chambers, 0.5, num_chambers + 0.5, num_vfat, 0.5, num_vfat + 0.5);
-  setDetLabelsVFAT(me_digi_det_[key], station);
+  for (const GEMStation* station : gem->stations()) {
+    const int region_id = station->region();
+    const int station_id = station->station();
+    const GEMDetId&& key = getReStKey(region_id, station_id);
+    const auto&& name_suffix = GEMUtils::getSuffixName(region_id, station_id);
+    const auto&& title_suffix = GEMUtils::getSuffixTitle(region_id, station_id);
 
-  // NOTE RecHit
-  ibooker.setCurrentFolder("GEM/GEMOfflineMonitor/RecHit");
-  me_hit_det_[key] =
-      helper.book2D("hit_det", "Hit Occupancy", num_chambers, 0.5, num_chambers + 0.5, num_etas, 0.5, num_etas + 0.5);
-  setDetLabelsEta(me_hit_det_[key], station);
+    const auto&& superchambers = station->superChambers();
+    if (not checkRefs(superchambers)) {
+      edm::LogError(log_category_) << "failed to get a valid vector of GEMSuperChamber ptrs" << std::endl;
+      return;
+    }
+
+    // per station
+    const int num_superchambers = superchambers.size();
+    const int num_chambers = num_superchambers * superchambers.front()->nChambers();
+    // the numer of VFATs per GEMEtaPartition
+    const int max_vfat = getMaxVFAT(station->station());
+    // the number of eta partitions per GEMChamber
+    const int num_etas = getNumEtaPartitions(station);
+    // the number of VFATs per GEMChamber
+    const int num_vfat = num_etas * max_vfat;
+
+    me_digi_det_[key] = 
+        ibooker.book2D("digi_det" + name_suffix, "Digi Occupancy" + title_suffix, 
+                       num_chambers, 0.5, num_chambers + 0.5, num_vfat, 0.5, num_vfat + 0.5);
+    setDetLabelsVFAT(me_digi_det_[key], station);
+  }  // station
 }
+
+void GEMOfflineMonitor::bookHitOccupancy(DQMStore::IBooker& ibooker,
+                                         const edm::ESHandle<GEMGeometry>& gem) {
+  ibooker.setCurrentFolder("GEM/GEMOfflineMonitor/HitOccupancy");
+
+  for (const GEMStation* station : gem->stations()) {
+    const int region_id = station->region();
+    const int station_id = station->station();
+
+    const GEMDetId&& key = getReStKey(region_id, station_id);
+    const auto&& name_suffix = GEMUtils::getSuffixName(region_id, station_id);
+    const auto&& title_suffix = GEMUtils::getSuffixTitle(region_id, station_id);
+
+    const auto&& superchambers = station->superChambers();
+    if (not checkRefs(superchambers)) {
+      edm::LogError(log_category_) << "failed to get a valid vector of GEMSuperChamber ptrs" << std::endl;
+      return;
+    }
+
+    // per station
+    const int num_superchambers = superchambers.size();
+    const int num_chambers = num_superchambers * superchambers.front()->nChambers();
+    // the number of eta partitions per GEMChamber
+    const int num_etas = getNumEtaPartitions(station);
+
+    me_hit_det_[key] =
+        ibooker.book2D("hit_det" + name_suffix, "Hit Occupancy" + title_suffix, num_chambers, 0.5, num_chambers + 0.5, num_etas, 0.5, num_etas + 0.5);
+    setDetLabelsEta(me_hit_det_[key], station);
+  }  // station
+}
+
 
 void GEMOfflineMonitor::analyze(const edm::Event& event, const edm::EventSetup& setup) {
   edm::Handle<GEMDigiCollection> digi_collection;
-  event.getByToken(digi_token_, digi_collection);
-  if (not digi_collection.isValid()) {
-    edm::LogError(log_category_) << "GEMDigiCollection is invalid!" << std::endl;
-    return;
+  if (do_digi_occupancy_) {
+    event.getByToken(digi_token_, digi_collection);
+    if (not digi_collection.isValid()) {
+      edm::LogError(log_category_) << "GEMDigiCollection is invalid!" << std::endl;
+      return;
+    }
   }
 
   edm::Handle<GEMRecHitCollection> rechit_collection;
-  event.getByToken(rechit_token_, rechit_collection);
-  if (not rechit_collection.isValid()) {
-    edm::LogError(log_category_) << "GEMRecHitCollection is invalid" << std::endl;
-    return;
+  if (do_hit_occupancy_) {
+    event.getByToken(rechit_token_, rechit_collection);
+    if (not rechit_collection.isValid()) {
+      edm::LogError(log_category_) << "GEMRecHitCollection is invalid" << std::endl;
+      return;
+    }
   }
 
   edm::ESHandle<GEMGeometry> gem;
@@ -101,26 +133,39 @@ void GEMOfflineMonitor::analyze(const edm::Event& event, const edm::EventSetup& 
     return;
   }
 
-  // GEMDigi
+  if (do_digi_occupancy_)
+    doDigiOccupancy(gem, digi_collection);
+
+  if (do_hit_occupancy_)
+    doHitOccupancy(gem, rechit_collection);
+}
+
+
+void GEMOfflineMonitor::doDigiOccupancy(
+    const edm::ESHandle<GEMGeometry>& gem,
+    const edm::Handle<GEMDigiCollection>& digi_collection) {
   for (auto range_iter = digi_collection->begin(); range_iter != digi_collection->end(); range_iter++) {
     const GEMDetId& gem_id = (*range_iter).first;
     const GEMDigiCollection::Range& range = (*range_iter).second;
 
-    const MEMapKey1 det_key{gem_id.region(), gem_id.station()};
+    const GEMDetId&& rs_key = getReStKey(gem_id);
     for (auto digi = range.first; digi != range.second; ++digi) {
       const int chamber_bin = getDetOccXBin(gem_id, gem);
       const int vfat_number = getVFATNumberByStrip(gem_id.station(), gem_id.roll(), digi->strip());
 
-      fillME(me_digi_det_, det_key, chamber_bin, vfat_number);
-    }
-  }
+      fillME(me_digi_det_, rs_key, chamber_bin, vfat_number);
+    } // digi
+  } // range
+}
 
-  // GEMRecHit
+
+void GEMOfflineMonitor::doHitOccupancy(
+    const edm::ESHandle<GEMGeometry>& gem,
+    const edm::Handle<GEMRecHitCollection>& rechit_collection) {
   for (auto hit = rechit_collection->begin(); hit != rechit_collection->end(); hit++) {
     const GEMDetId&& gem_id = hit->gemId();
-    const MEMapKey1 det_key{gem_id.region(), gem_id.station()};
-
+    const GEMDetId&& rs_key = getReStKey(gem_id);
     const int chamber_bin = getDetOccXBin(gem_id, gem);
-    fillME(me_hit_det_, det_key, chamber_bin, gem_id.roll());
+    fillME(me_hit_det_, rs_key, chamber_bin, gem_id.roll());
   }
 }

--- a/DQMOffline/Muon/src/GEMOfflineMonitor.cc
+++ b/DQMOffline/Muon/src/GEMOfflineMonitor.cc
@@ -4,7 +4,6 @@
 #include "Geometry/Records/interface/MuonGeometryRecord.h"
 #include "Validation/MuonGEMHits/interface/GEMValidationUtils.h"
 
-
 GEMOfflineMonitor::GEMOfflineMonitor(const edm::ParameterSet& pset) : GEMOfflineDQMBase(pset) {
   digi_token_ = consumes<GEMDigiCollection>(pset.getParameter<edm::InputTag>("digiTag"));
   rechit_token_ = consumes<GEMRecHitCollection>(pset.getParameter<edm::InputTag>("recHitTag"));
@@ -38,12 +37,9 @@ void GEMOfflineMonitor::bookHistograms(DQMStore::IBooker& ibooker, edm::Run cons
 
   if (do_hit_occupancy_)
     bookHitOccupancy(ibooker, gem);
-
 }
 
-
-void GEMOfflineMonitor::bookDigiOccupancy(DQMStore::IBooker& ibooker,
-                                         const edm::ESHandle<GEMGeometry>& gem) {
+void GEMOfflineMonitor::bookDigiOccupancy(DQMStore::IBooker& ibooker, const edm::ESHandle<GEMGeometry>& gem) {
   ibooker.setCurrentFolder("GEM/GEMOfflineMonitor/DigiOccupancy");
 
   for (const GEMStation* station : gem->stations()) {
@@ -69,15 +65,19 @@ void GEMOfflineMonitor::bookDigiOccupancy(DQMStore::IBooker& ibooker,
     // the number of VFATs per GEMChamber
     const int num_vfat = num_etas * max_vfat;
 
-    me_digi_det_[key] = 
-        ibooker.book2D("digi_det" + name_suffix, "Digi Occupancy" + title_suffix, 
-                       num_chambers, 0.5, num_chambers + 0.5, num_vfat, 0.5, num_vfat + 0.5);
+    me_digi_det_[key] = ibooker.book2D("digi_det" + name_suffix,
+                                       "Digi Occupancy" + title_suffix,
+                                       num_chambers,
+                                       0.5,
+                                       num_chambers + 0.5,
+                                       num_vfat,
+                                       0.5,
+                                       num_vfat + 0.5);
     setDetLabelsVFAT(me_digi_det_[key], station);
   }  // station
 }
 
-void GEMOfflineMonitor::bookHitOccupancy(DQMStore::IBooker& ibooker,
-                                         const edm::ESHandle<GEMGeometry>& gem) {
+void GEMOfflineMonitor::bookHitOccupancy(DQMStore::IBooker& ibooker, const edm::ESHandle<GEMGeometry>& gem) {
   ibooker.setCurrentFolder("GEM/GEMOfflineMonitor/HitOccupancy");
 
   for (const GEMStation* station : gem->stations()) {
@@ -100,12 +100,17 @@ void GEMOfflineMonitor::bookHitOccupancy(DQMStore::IBooker& ibooker,
     // the number of eta partitions per GEMChamber
     const int num_etas = getNumEtaPartitions(station);
 
-    me_hit_det_[key] =
-        ibooker.book2D("hit_det" + name_suffix, "Hit Occupancy" + title_suffix, num_chambers, 0.5, num_chambers + 0.5, num_etas, 0.5, num_etas + 0.5);
+    me_hit_det_[key] = ibooker.book2D("hit_det" + name_suffix,
+                                      "Hit Occupancy" + title_suffix,
+                                      num_chambers,
+                                      0.5,
+                                      num_chambers + 0.5,
+                                      num_etas,
+                                      0.5,
+                                      num_etas + 0.5);
     setDetLabelsEta(me_hit_det_[key], station);
   }  // station
 }
-
 
 void GEMOfflineMonitor::analyze(const edm::Event& event, const edm::EventSetup& setup) {
   edm::Handle<GEMDigiCollection> digi_collection;
@@ -140,10 +145,8 @@ void GEMOfflineMonitor::analyze(const edm::Event& event, const edm::EventSetup& 
     doHitOccupancy(gem, rechit_collection);
 }
 
-
-void GEMOfflineMonitor::doDigiOccupancy(
-    const edm::ESHandle<GEMGeometry>& gem,
-    const edm::Handle<GEMDigiCollection>& digi_collection) {
+void GEMOfflineMonitor::doDigiOccupancy(const edm::ESHandle<GEMGeometry>& gem,
+                                        const edm::Handle<GEMDigiCollection>& digi_collection) {
   for (auto range_iter = digi_collection->begin(); range_iter != digi_collection->end(); range_iter++) {
     const GEMDetId& gem_id = (*range_iter).first;
     const GEMDigiCollection::Range& range = (*range_iter).second;
@@ -154,14 +157,12 @@ void GEMOfflineMonitor::doDigiOccupancy(
       const int vfat_number = getVFATNumberByStrip(gem_id.station(), gem_id.roll(), digi->strip());
 
       fillME(me_digi_det_, rs_key, chamber_bin, vfat_number);
-    } // digi
-  } // range
+    }  // digi
+  }    // range
 }
 
-
-void GEMOfflineMonitor::doHitOccupancy(
-    const edm::ESHandle<GEMGeometry>& gem,
-    const edm::Handle<GEMRecHitCollection>& rechit_collection) {
+void GEMOfflineMonitor::doHitOccupancy(const edm::ESHandle<GEMGeometry>& gem,
+                                       const edm::Handle<GEMRecHitCollection>& rechit_collection) {
   for (auto hit = rechit_collection->begin(); hit != rechit_collection->end(); hit++) {
     const GEMDetId&& gem_id = hit->gemId();
     const GEMDetId&& rs_key = getReStKey(gem_id);


### PR DESCRIPTION
#### PR description:
* Regarding `GEMEfficiencyAnalyzer`,
  * Update the way to propagate muons into GEM layers because the existing way is not decent to cosmics scenario. 
  * Combine plots for odd/even chambers into one for reducing memory usage.
  * Update the way to book `MonitorElement`s. Remove `BookingHelper`, which is the wrapper of `IBooker`. Use `GEMDetId` as a key of `MEMap` rather than tuple of int numbers.
  * Create cfi files for comics scenario.
* Exclude `GEMOfflineMonitor` from GEM offline DQM sequence. `GEMOfflineMonitor` creates only `GEMDigi` and `GEMRecHit` occupancy plots but these plots are moved to the online DQM. However, `GEMOfflineMonitor` is not removed because it will make more diverse plots (mainly `GEMSegment`) in the near future.

Here is a link to [slides](https://indico.cern.ch/event/1010727/contributions/4241619/attachments/2199578/3719850/200226-OfflineDQMUpdate.pdf)

#### PR validation:
The offline DQM GUI server is running at the local server. [Link to DQM GUI](http://offlinedqm.sscc.uos.ac.kr:50200/dqm/offline/session/oUsaUn).
Please check out the manual of GUI at the last page of the [slides](https://indico.cern.ch/event/1010727/contributions/4241619/attachments/2199578/3719850/200226-OfflineDQMUpdate.pdf)


This PR is tested with two workflows:
* For pp, `runTheMatrix.py -w upgrade -l 12411.0`, which is `TenMuExtendedE_0_200+2023`.
* For comics, I used custom [UndergroundCosmicMu_cfi without magnetic field](https://gist.github.com/seungjin-yang/307384bbf301391788abf2ac21c089fb), whose result is shown in GUI.

@jshlee, @szaleski
