### PR TITLE
Add additional capability (filtering by decay R/Z) to MCMultiParticle…

### DIFF
--- a/GeneratorInterface/GenFilters/interface/MCMultiParticleFilter.h
+++ b/GeneratorInterface/GenFilters/interface/MCMultiParticleFilter.h
@@ -62,6 +62,10 @@ class MCMultiParticleFilter : public edm::EDFilter {
   std::vector<double> ptMin_;      // minimum Pt of particles
   std::vector<double> etaMax_;     // maximum fabs(eta) of particles
   std::vector<int> status_;        // status of particles
+  std::vector<double> decayRadiusMin;
+  std::vector<double> decayRadiusMax;
+  std::vector<double> decayZMin;
+  std::vector<double> decayZMax;
   int totalEvents_;                // counters
   int passedEvents_;
 };

--- a/GeneratorInterface/GenFilters/src/MCSmartSingleParticleFilter.cc
+++ b/GeneratorInterface/GenFilters/src/MCSmartSingleParticleFilter.cc
@@ -66,60 +66,42 @@ betaBoost(iConfig.getUntrackedParameter("BetaBoost",0.))
 
     // if pMin size smaller than particleID , fill up further with defaults
     if (particleID.size() > pMin.size() ){
-       vector<double> defpmin2 ;
-       for (unsigned int i = 0; i < particleID.size(); i++){ defpmin2.push_back(0.);}
-       pMin = defpmin2;   
+       for (unsigned int i = pMin.size(); i < particleID.size(); i++){ pMin.push_back(0.);}
     } 
     // if ptMin size smaller than particleID , fill up further with defaults
     if (particleID.size() > ptMin.size() ){
-       vector<double> defptmin2 ;
-       for (unsigned int i = 0; i < particleID.size(); i++){ defptmin2.push_back(0.);}
-       ptMin = defptmin2;   
+       for (unsigned int i = ptMin.size(); i < particleID.size(); i++){ ptMin.push_back(0.);}
     } 
     // if etaMin size smaller than particleID , fill up further with defaults
     if (particleID.size() > etaMin.size() ){
-       vector<double> defetamin2 ;
-       for (unsigned int i = 0; i < particleID.size(); i++){ defetamin2.push_back(-10.);}
-       etaMin = defetamin2;   
+       for (unsigned int i = etaMin.size(); i < particleID.size(); i++){ etaMin.push_back(-10.);}
     } 
     // if etaMax size smaller than particleID , fill up further with defaults
     if (particleID.size() > etaMax.size() ){
-       vector<double> defetamax2 ;
-       for (unsigned int i = 0; i < particleID.size(); i++){ defetamax2.push_back(10.);}
-       etaMax = defetamax2;   
-    }     
+       for (unsigned int i = etaMax.size(); i < particleID.size(); i++){ etaMax.push_back(10.);}
+    }
     // if status size smaller than particleID , fill up further with defaults
     if (particleID.size() > status.size() ){
-       vector<int> defstat2 ;
-       for (unsigned int i = 0; i < particleID.size(); i++){ defstat2.push_back(0);}
-       status = defstat2;   
-    } 
+       for (unsigned int i = status.size(); i < particleID.size(); i++){ status.push_back(0);}
+    }
 
     // if decayRadiusMin size smaller than particleID , fill up further with defaults
     if (particleID.size() > decayRadiusMin.size() ){
-       vector<double> decayRadiusmin2 ;
-       for (unsigned int i = 0; i < particleID.size(); i++){ decayRadiusmin2.push_back(-10.);}
-       decayRadiusMin = decayRadiusmin2;   
-    } 
+       for (unsigned int i = decayRadiusMin.size(); i < particleID.size(); i++){ decayRadiusMin.push_back(-10.);}
+    }
     // if decayRadiusMax size smaller than particleID , fill up further with defaults
     if (particleID.size() > decayRadiusMax.size() ){
-       vector<double> decayRadiusmax2 ;
-       for (unsigned int i = 0; i < particleID.size(); i++){ decayRadiusmax2.push_back(1.e5);}
-       decayRadiusMax = decayRadiusmax2;   
-    }     
+       for (unsigned int i = decayRadiusMax.size(); i < particleID.size(); i++){ decayRadiusMax.push_back(1.e5);}
+    }
 
     // if decayZMin size smaller than particleID , fill up further with defaults
     if (particleID.size() > decayZMin.size() ){
-       vector<double> decayZmin2 ;
-       for (unsigned int i = 0; i < particleID.size(); i++){ decayZmin2.push_back(-1.e5);}
-       decayZMin = decayZmin2;   
-    } 
+       for (unsigned int i = decayZMin.size(); i < particleID.size(); i++){ decayZMin.push_back(-1.e5);}
+    }
     // if decayZMax size smaller than particleID , fill up further with defaults
     if (particleID.size() > decayZMax.size() ){
-       vector<double> decayZmax2 ;
-       for (unsigned int i = 0; i < particleID.size(); i++){ decayZmax2.push_back(1.e5);}
-       decayZMax = decayZmax2;   
-    }     
+       for (unsigned int i = decayZMax.size(); i < particleID.size(); i++){ decayZMax.push_back(1.e5);}
+    }
 
     // check if beta is smaller than 1
     if (std::abs(betaBoost) >= 1 ){


### PR DESCRIPTION
…Filter; fill up vectors with defaults if necessary for MCSmartSingleParticleFilter

#### PR description:

- Additional capability (filtering according to the decay region, the same functionality which has been already implemented in the MCSmartSingleParticleFilter) is added to the MCMultiParticleFilter. A small typo (bug, but no real effect) for loading motherID_ in the original filter has been fixed.

- Fill up vectors with defaults if necessary, fix both MCMultiParticleFilter and MCSmartSingleParticleFilter filters.

#### PR validation:

Managed to filter the B(s,d) -> hh -> mumu events by adding such a filter (requiring two muon decaying from K/pi, and within the detector volume) to the process:
mugenfilter = cms.EDFilter(
"MCMultiParticleFilter",
ParticleID = cms.vint32(-13, 13, -13, 13),
MotherID = cms.untracked.vint32(321, -321, 211, -211),
MaxDecayRadius = cms.untracked.vdouble(2000.0, 2000.0, 2000.0, 2000.0),
MaxDecayZ = cms.untracked.vdouble(4000.0, 4000.0, 4000.0, 4000.0),
MinDecayZ = cms.untracked.vdouble(-4000.0, -4000.0, -4000.0, -4000.0),
EtaMax = cms.vdouble(2.5, 2.5, 2.5, 2.5),
PtMin = cms.vdouble(3.5, 3.5, 3.5, 3.5),
Status = cms.vint32(1,1,1,1),
NumRequired = cms.int32(2),
AcceptMore = cms.bool(True)
)

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Backport from PR #32999, in order to enable the generation for Run-2 UL


