### PR TITLE
drop type specification in RecoVertex

### DIFF
--- a/RecoVertex/AdaptiveVertexFinder/python/inclusiveVertexing_cff.py
+++ b/RecoVertex/AdaptiveVertexFinder/python/inclusiveVertexing_cff.py
@@ -43,7 +43,7 @@ candidateVertexMergerCvsL = candidateVertexMerger.clone(
 )
 
 candidateVertexArbitratorCvsL = candidateVertexArbitrator.clone(
-   secondaryVertices = cms.InputTag("candidateVertexMergerCvsL")
+   secondaryVertices = "candidateVertexMergerCvsL"
 )
 
 inclusiveCandidateSecondaryVerticesCvsL = candidateVertexMerger.clone(


### PR DESCRIPTION
#### PR description: 
Update the safer syntax for existing parameter :
- drop type specifications where the original parameter exists.
 (previous PRs for RecoVertex is [PR#31784](https://github.com/cms-sw/cmssw/pull/31784) )

In this PR, one file changed. 
RecoVertex/AdaptiveVertexFinder 1 file

#### PR validation:
Event Content comparison check was also done and there is no change with these updates.
Tested in CMSSW_11_2_X, the basic test all passed in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html).