### PR TITLE
drop type specification in RecoTauTag

### DIFF
--- a/RecoTauTag/Configuration/python/HPSPFTaus_cff.py
+++ b/RecoTauTag/Configuration/python/HPSPFTaus_cff.py
@@ -295,7 +295,7 @@ hpsPFTauDiscriminationByMVA6ElectronRejection = recoTauDiscriminantCutMultiplexe
 )
 
 # Define the HPS selection discriminator used in cleaning
-hpsSelectionDiscriminator.PFTauProducer = cms.InputTag("combinatoricRecoTaus")
+hpsSelectionDiscriminator.PFTauProducer = "combinatoricRecoTaus"
 #----------------------------------------------------------------------------
 # CV: disable 3Prong1Pi0 decay mode
 hpsSelectionDiscriminator.decayModes = cms.VPSet(


### PR DESCRIPTION
#### PR description: 
Update the safer syntax for existing parameter :
- drop type specifications where the original parameter exists.
(previous PR for RecoTauTag is [PR#31748](https://github.com/cms-sw/cmssw/pull/31748) )

In this PR, one file changed. 
RecoTauTag/Configuration

#### PR validation:
Event Content comparison check was also done and there is no change with these updates.
Tested in CMSSW_11_2_X, the basic test all passed in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html).