### PR TITLE
Make auto:phase2_realistic key usable

### DIFF
--- a/Configuration/AlCa/python/GlobalTag.py
+++ b/Configuration/AlCa/python/GlobalTag.py
@@ -71,6 +71,13 @@ def GlobalTag(essource = None, globaltag = None, conditions = None):
                 raise Exception('no correspondence for '+globaltag+'\navailable keys are\n'+','.join(autoCond.keys()))
             if 'phase1_2017_design' == globaltag:
                 sys.stderr.write('Warning: %s now points to %s. This has reco-Beamspot centered to (0,0,0)\n'%(globaltag,autoCond[globaltag]))
+            if 'phase2_realistic' == globaltag:
+                sys.stderr.write('*'*120+'\n\t\t\t\t\t\t WARNING!\n The key %s now points to %s.'\
+                                 '\n Usage of this key is discretionary and users are cautioned to use it at their own risk!'\
+                                 '\n This Global Tag contains tags suited for an Inner Tracker layout with rectangular (25x100um2) pixel cells (T15,T21).'\
+                                 '\n If this is not the geometry you are expecting to use, please consult:' \
+                                 '\n https://github.com/cms-sw/cmssw/blob/master/Configuration/AlCa/python/autoCondPhase2.py' \
+                                 ' to retrieve the right key.\n'%(globaltag,autoCond[globaltag])+'*'*120+'\n')
             autoKey = autoCond[globaltag]
             if isinstance(autoKey, tuple) or isinstance(autoKey, list):
                 globaltag = autoKey[0]

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -83,7 +83,7 @@ autoCond = {
     # GlobalTag for MC production with realistic conditions for Phase1 2024
     'phase1_2024_realistic'    : '113X_mcRun3_2024_realistic_v5', # GT containing realistic conditions for Phase1 2024
     # GlobalTag for MC production with realistic conditions for Phase2
-    'phase2_realistic'         : '113X_mcRun4_realistic_v4'
+    'phase2_realistic'         : '113X_mcRun4_realistic_v5'
 }
 
 aliases = {


### PR DESCRIPTION
#### PR description:

Several users have by now complained about the fact that the autoCond key `phase2_realistic` is not usable.
This is caused by the fact that it contains a funny mix of Phase-1 and Phase-2 pixel tags:
```
$ conddb list 113X_mcRun4_realistic_v4 | grep SiPixel
[2021-03-02 16:19:07,970] INFO: Connecting to pro [frontier://PromptProd/CMS_CONDITIONS]
DQMXMLFileRcd                                           SiPixelDQMQTests                                                   DQMXMLFile_SiPixelDQM_v1_mc                                                  
SiPixelDetVOffRcd                                       -                                                                  SiPixelDetVOff_Ideal_RunBased_31X_v2_hlt                                     
SiPixelDynamicInefficiencyRcd                           -                                                                  SiPixelDynamicInefficiency_13TeV_v3_mc                                       
SiPixelFedCablingMapRcd                                 -                                                                  SiPixelFedCablingMap_mc                                                      
SiPixelGainCalibrationForHLTRcd                         -                                                                  SiPixelGainCalibrationForHLT_split_smeared_mc                                
SiPixelGainCalibrationOfflineRcd                        -                                                                  SiPixelGainCalibration_split_smeared_mc                                      
SiPixelGenErrorDBObjectRcd                              -                                                                  SiPixelGenErrorDBObject_phase1_38T_2017_rereco_v9                            
SiPixelLorentzAngleRcd                                  -                                                                  SiPixelLorentzAngle_phase2_T15_v0_mc                                         
SiPixelLorentzAngleRcd                                  forWidth                                                           SiPixelLorentzAngle_phase2_forWidth_T15_v0_mc                                
SiPixelLorentzAngleRcd                                  fromAlignment                                                      SiPixelLorentzAngle_fromAlignment_v1_mc[cms_orcon_prod/CMS_COND_31X_PIXEL]   
SiPixelLorentzAngleSimRcd                               -                                                                  SiPixelSimLorentzAngle_phase2_T15_v0_mc                                      
SiPixelQualityFromDbRcd                                 -                                                                  SiPixelQuality_phase2_ideal                                                  
SiPixelTemplateDBObjectRcd                              -                                                                  SiPixelTemplateDBObject_phase1_38T_2017_rereco_v9                            
SiPixelTemplateDBObjectRcd                              0T                                                                 SiPixelTemplateDBObject_0T_v3_mc                                             
SiPixelTemplateDBObjectRcd                              2T                                                                 SiPixelTemplateDBObject_2T_v3_mc                                             
SiPixelTemplateDBObjectRcd                              35T                                                                SiPixelTemplateDBObject_35T_v3_mc                                            
SiPixelTemplateDBObjectRcd                              3T                                                                 SiPixelTemplateDBObject_3T_v3_mc                                             
SiPixelTemplateDBObjectRcd                              4T                                                                 SiPixelTemplateDBObject_4T_v3_mc      
```
This per se is not a big issue as in a regular job (like relval or production jobs) it picks up the correct GT string from the upgrade matrix (`runTheMatrix.py`) or by imposing a physical GT by hand. 
On the other hand `auto:phase2_realistic` key is by now totally bogus and cannot be used as it is.
I propose to remedy this situation by:
-  make `auto:phase2_realistic` key to point to a GT which contains *only* phase-2 IT tags. As we support multiple geometries I have chosen the ones used in the more conservative baseline (25x100 um2 pixel cells in the inner Tracker), such as T15 - used in D49 (HLT TDR) or T21-used in D76 (which has to become the new baseline for RelVals after PR https://github.com/cms-sw/cmssw/pull/33007 is merged). 
   * A new GT has been created: `113X_mcRun4_realistic_v5`: as expected, it differs from the previous version (v4) only for the SiPixel tags ([link to DB Browser](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/113X_mcRun4_realistic_v4/113X_mcRun4_realistic_v5))

- make the framework emit a warning in case this "naked" key is used as one size cannot fit all. Users should be warned that if they are not expecting to use the baseline geometry they need to look up the correct key in the dictionary.

#### PR validation:

Changing one `runTheMatrix` workflow with:

` runTheMatrix.py --what upgrade -l 34606.0 --command='--conditions auto:phase2_realitic'`

runs fine and in the logs I find the following warning (as expected):

```
************************************************************************************************************************
						 WARNING!
 The key phase2_realistic now points to 113X_mcRun4_realistic_Candidate_2021_03_02_13_27_45.
 Usage of this key is discretionary and users are cautioned to use it at their own risk!
 This Global Tag contains tags suited for an Inner Tracker layout with rectangular (25x100um2) pixel cells (T15,T21).
 If this is not the geometry you are expecting to use, please consult:
 https://github.com/cms-sw/cmssw/blob/master/Configuration/AlCa/python/autoCondPhase2.py to retrieve the right key.
************************************************************************************************************************
```

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Not a backport, no backport needed.

cc:
@veszpv 