### PR TITLE
modernize DQMDaqInfo 

### DIFF
--- a/DQMServices/Components/plugins/DQMDaqInfo.cc
+++ b/DQMServices/Components/plugins/DQMDaqInfo.cc
@@ -1,49 +1,48 @@
 #include "DQMDaqInfo.h"
 #include "DataFormats/FEDRawData/interface/FEDNumbering.h"
 
-DQMDaqInfo::DQMDaqInfo(const edm::ParameterSet& iConfig) {}
+DQMDaqInfo::DQMDaqInfo(const edm::ParameterSet& iConfig)
+    : runInfoToken_{esConsumes<edm::Transition::BeginLuminosityBlock>()} {}
 
 DQMDaqInfo::~DQMDaqInfo() = default;
 
 void DQMDaqInfo::beginLuminosityBlock(const edm::LuminosityBlock& lumiBlock, const edm::EventSetup& iSetup) {
   edm::eventsetup::EventSetupRecordKey recordKey(edm::eventsetup::EventSetupRecordKey::TypeTag::findType("RunInfoRcd"));
 
-  if (auto runInfoRec = iSetup.tryToGet<RunInfoRcd>()) {
-    edm::ESHandle<RunInfo> sumFED;
-    runInfoRec->get(sumFED);
+  if (iSetup.tryToGet<RunInfoRcd>()) {
+    if (auto sumFED = iSetup.getHandle(runInfoToken_)) {
+      //const RunInfo* summaryFED=sumFED.product();
 
-    //const RunInfo* summaryFED=sumFED.product();
+      std::vector<int> FedsInIds = sumFED->m_fed_in;
 
-    std::vector<int> FedsInIds = sumFED->m_fed_in;
+      float FedCount[9] = {0., 0., 0., 0., 0., 0., 0., 0., 0.};
 
-    float FedCount[9] = {0., 0., 0., 0., 0., 0., 0., 0., 0.};
+      for (int fedID : FedsInIds) {
+        if (fedID >= PixelRange.first && fedID <= PixelRange.second)
+          ++FedCount[Pixel];
+        if (fedID >= TrackerRange.first && fedID <= TrackerRange.second)
+          ++FedCount[SiStrip];
+        if (fedID >= CSCRange.first && fedID <= CSCRange.second)
+          ++FedCount[CSC];
+        if (fedID >= RPCRange.first && fedID <= RPCRange.second)
+          ++FedCount[RPC];
+        if (fedID >= DTRange.first && fedID <= DTRange.second)
+          ++FedCount[DT];
+        if (fedID >= HcalRange.first && fedID <= HcalRange.second)
+          ++FedCount[Hcal];
+        if (fedID >= ECALBarrRange.first && fedID <= ECALBarrRange.second)
+          ++FedCount[EcalBarrel];
+        if ((fedID >= ECALEndcapRangeLow.first && fedID <= ECALEndcapRangeLow.second) ||
+            (fedID >= ECALEndcapRangeHigh.first && fedID <= ECALEndcapRangeHigh.second))
+          ++FedCount[EcalEndcap];
+        if (fedID >= L1TRange.first && fedID <= L1TRange.second)
+          ++FedCount[L1T];
+      }
 
-    for (int fedID : FedsInIds) {
-      if (fedID >= PixelRange.first && fedID <= PixelRange.second)
-        ++FedCount[Pixel];
-      if (fedID >= TrackerRange.first && fedID <= TrackerRange.second)
-        ++FedCount[SiStrip];
-      if (fedID >= CSCRange.first && fedID <= CSCRange.second)
-        ++FedCount[CSC];
-      if (fedID >= RPCRange.first && fedID <= RPCRange.second)
-        ++FedCount[RPC];
-      if (fedID >= DTRange.first && fedID <= DTRange.second)
-        ++FedCount[DT];
-      if (fedID >= HcalRange.first && fedID <= HcalRange.second)
-        ++FedCount[Hcal];
-      if (fedID >= ECALBarrRange.first && fedID <= ECALBarrRange.second)
-        ++FedCount[EcalBarrel];
-      if ((fedID >= ECALEndcapRangeLow.first && fedID <= ECALEndcapRangeLow.second) ||
-          (fedID >= ECALEndcapRangeHigh.first && fedID <= ECALEndcapRangeHigh.second))
-        ++FedCount[EcalEndcap];
-      if (fedID >= L1TRange.first && fedID <= L1TRange.second)
-        ++FedCount[L1T];
+      for (int detIndex = 0; detIndex < 9; ++detIndex) {
+        DaqFraction[detIndex]->Fill(FedCount[detIndex] / NumberOfFeds[detIndex]);
+      }
     }
-
-    for (int detIndex = 0; detIndex < 9; ++detIndex) {
-      DaqFraction[detIndex]->Fill(FedCount[detIndex] / NumberOfFeds[detIndex]);
-    }
-
   } else {
     for (auto& detIndex : DaqFraction)
       detIndex->Fill(-1);

--- a/DQMServices/Components/plugins/DQMDaqInfo.h
+++ b/DQMServices/Components/plugins/DQMDaqInfo.h
@@ -26,7 +26,7 @@
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/LuminosityBlock.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -42,7 +42,7 @@
 #include "DQMServices/Core/interface/DQMStore.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
 
-class DQMDaqInfo : public edm::EDAnalyzer {
+class DQMDaqInfo : public edm::one::EDAnalyzer<> {
 public:
   typedef dqm::legacy::DQMStore DQMStore;
   typedef dqm::legacy::MonitorElement MonitorElement;
@@ -51,9 +51,10 @@ public:
 
 private:
   void beginJob() override;
-  void beginLuminosityBlock(const edm::LuminosityBlock&, const edm::EventSetup&) override;
+  void beginLuminosityBlock(const edm::LuminosityBlock&, const edm::EventSetup&);
   void analyze(const edm::Event&, const edm::EventSetup&) override;
 
+  edm::ESGetToken<RunInfo, RunInfoRcd> runInfoToken_;
   DQMStore* dbe_;
 
   enum subDetList { Pixel, SiStrip, EcalBarrel, EcalEndcap, Hcal, DT, CSC, RPC, L1T };


### PR DESCRIPTION
#### PR description:

Part of https://github.com/cms-sw/cmssw/issues/31061
Migrated `DQMDaqInfo` to `esCosumes`. 
Profited of the PR to make it an `edm::one` `EDmodule` instead of a legacy one.

#### PR validation:

`runTheMatrix.py -l limited --ibeos` runs without errors.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Not a backport, no backport needed.
