### PR TITLE
drop type specs and change deepcopy to clone in TrackingTools

### DIFF
--- a/TrackingTools/GsfTracking/python/BwdAnalyticalPropagator_cfi.py
+++ b/TrackingTools/GsfTracking/python/BwdAnalyticalPropagator_cfi.py
@@ -1,6 +1,5 @@
 import FWCore.ParameterSet.Config as cms
 
-#import copy
 from TrackingTools.GsfTracking.FwdAnalyticalPropagator_cfi import *
 #
 # "backward" propagator for electrons

--- a/TrackingTools/GsfTracking/python/BwdAnalyticalPropagator_cfi.py
+++ b/TrackingTools/GsfTracking/python/BwdAnalyticalPropagator_cfi.py
@@ -1,11 +1,11 @@
 import FWCore.ParameterSet.Config as cms
 
-import copy
+#import copy
 from TrackingTools.GsfTracking.FwdAnalyticalPropagator_cfi import *
 #
 # "backward" propagator for electrons
 #
-bwdAnalyticalPropagator = copy.deepcopy(fwdAnalyticalPropagator)
-bwdAnalyticalPropagator.ComponentName = 'bwdAnalyticalPropagator'
-bwdAnalyticalPropagator.PropagationDirection = 'oppositeToMomentum'
-
+bwdAnalyticalPropagator = fwdAnalyticalPropagator.clone(
+    ComponentName = 'bwdAnalyticalPropagator',
+    PropagationDirection = 'oppositeToMomentum'
+)

--- a/TrackingTools/GsfTracking/python/CkfElectronCandidates_cfi.py
+++ b/TrackingTools/GsfTracking/python/CkfElectronCandidates_cfi.py
@@ -1,7 +1,9 @@
 import FWCore.ParameterSet.Config as cms
 
-import copy
+#import copy
 from RecoTracker.CkfPattern.CkfTrackCandidates_cfi import *
-CkfElectronCandidates = copy.deepcopy(ckfTrackCandidates)
-CkfElectronCandidates.TrajectoryBuilderPSet.refToPSet_ = 'CkfElectronTrajectoryBuilder'
-
+CkfElectronCandidates = ckfTrackCandidates.clone(
+    TrajectoryBuilderPSet = dict(
+	refToPSet_ = 'CkfElectronTrajectoryBuilder'
+    )
+)

--- a/TrackingTools/GsfTracking/python/CkfElectronCandidates_cfi.py
+++ b/TrackingTools/GsfTracking/python/CkfElectronCandidates_cfi.py
@@ -1,6 +1,5 @@
 import FWCore.ParameterSet.Config as cms
 
-#import copy
 from RecoTracker.CkfPattern.CkfTrackCandidates_cfi import *
 CkfElectronCandidates = ckfTrackCandidates.clone(
     TrajectoryBuilderPSet = dict(

--- a/TrackingTools/GsfTracking/python/CkfElectronTrajectoryBuilder_cfi.py
+++ b/TrackingTools/GsfTracking/python/CkfElectronTrajectoryBuilder_cfi.py
@@ -1,6 +1,5 @@
 import FWCore.ParameterSet.Config as cms
 
-#import copy
 from RecoTracker.CkfPattern.CkfTrajectoryBuilder_cfi import *
 CkfElectronTrajectoryBuilder = CkfTrajectoryBuilder.clone(
     propagatorAlong = 'fwdElectronPropagator',

--- a/TrackingTools/GsfTracking/python/CkfElectronTrajectoryBuilder_cfi.py
+++ b/TrackingTools/GsfTracking/python/CkfElectronTrajectoryBuilder_cfi.py
@@ -1,9 +1,9 @@
 import FWCore.ParameterSet.Config as cms
 
-import copy
+#import copy
 from RecoTracker.CkfPattern.CkfTrajectoryBuilder_cfi import *
-CkfElectronTrajectoryBuilder = copy.deepcopy(CkfTrajectoryBuilder)
-CkfElectronTrajectoryBuilder.propagatorAlong = 'fwdElectronPropagator'
-CkfElectronTrajectoryBuilder.propagatorOpposite = 'bwdElectronPropagator'
-CkfElectronTrajectoryBuilder.estimator = 'electronChi2'
-
+CkfElectronTrajectoryBuilder = CkfTrajectoryBuilder.clone(
+    propagatorAlong = 'fwdElectronPropagator',
+    propagatorOpposite = 'bwdElectronPropagator',
+    estimator = 'electronChi2'
+)

--- a/TrackingTools/GsfTracking/python/GsfElectronTracking_cff.py
+++ b/TrackingTools/GsfTracking/python/GsfElectronTracking_cff.py
@@ -42,7 +42,7 @@ phase2_hgcal.toReplaceWith(
 )
 
 from SimTracker.TrackAssociation.trackTimeValueMapProducer_cfi import trackTimeValueMapProducer
-gsfTrackTimeValueMapProducer = trackTimeValueMapProducer.clone(trackSrc = cms.InputTag('electronGsfTracks'))
+gsfTrackTimeValueMapProducer = trackTimeValueMapProducer.clone(trackSrc = 'electronGsfTracks')
 
 electronGsfTrackingWithTimingTask = cms.Task(electronGsfTrackingTask.copy(),gsfTrackTimeValueMapProducer)
 electronGsfTrackingWithTiming = cms.Sequence(electronGsfTrackingWithTimingTask)


### PR DESCRIPTION
#### PR description: 
Update the safer syntax for existing parameter :
- drop type specifications where the original parameter exists. : 1 file
- change deepcopy() to clone() : 3 files

In this PR, 4 files changed.  (previous PRs for TrackingTools is [PR#32396](https://github.com/cms-sw/cmssw/pull/32396) )

TrackingTools/GsfTracking 4 file

#### PR validation:
Event Content comparison check was also done and there is no change with these updates.
Tested in CMSSW_11_2_X, the basic test all passed in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html).