### PR TITLE
Move cms.Sequence to cms.Task in RecoPixelVertexing

### DIFF
--- a/RecoPixelVertexing/PixelLowPtUtilities/python/AllPixelTracks_cfi.py
+++ b/RecoPixelVertexing/PixelLowPtUtilities/python/AllPixelTracks_cfi.py
@@ -58,8 +58,9 @@ allPixelTracksFitter = trackFitter.clone(
     TTRHBuilder = 'TTRHBuilderWithoutAngle4PixelTriplets'
 )
 
-allPixelTracksSequence = cms.Sequence(
-    allPixelTracksFitter +
-    clusterShapeTrackFilter +
+allPixelTracksTask = cms.Task(
+    allPixelTracksFitter,
+    clusterShapeTrackFilter,
     allPixelTracks
 )
+allPixelTracksSequence = cms.Sequence(allPixelTracksTask)


### PR DESCRIPTION
#### PR description: 

Move cms.Sequence() to cms.Task() for python configurations in RecoPixelVertexing. 
(the previous task is [PR#25163](https://github.com/cms-sw/cmssw/pull/25163)).

In this PR, one file was changed.

RecoPixelVertexing/PixelLowPtUtilities 1 file

#### PR validation:
Event Content comparison check was also done and there is no change with these updates.
Tested in CMSSW_11_2_X, the basic test all passed in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html).