### PR TITLE
Hcal - packing HB TDC

### DIFF
--- a/EventFilter/HcalRawToDigi/plugins/HcalDigiToRawuHTR.cc
+++ b/EventFilter/HcalRawToDigi/plugins/HcalDigiToRawuHTR.cc
@@ -50,21 +50,20 @@ public:
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 private:
-  int _verbosity;
-  vector<int> tdc1_;
-  vector<int> tdc2_;
-  bool packHBTDC_;
+  const int _verbosity;
+  const vector<int> tdc1_;
+  const vector<int> tdc2_;
+  const bool packHBTDC_;
   static constexpr int tdcmax_ = 49;
-  std::string electronicsMapLabel_;
 
-  edm::EDGetTokenT<HcalDataFrameContainer<QIE10DataFrame>> tok_QIE10DigiCollection_;
-  edm::EDGetTokenT<HcalDataFrameContainer<QIE11DataFrame>> tok_QIE11DigiCollection_;
-  edm::EDGetTokenT<HBHEDigiCollection> tok_HBHEDigiCollection_;
-  edm::EDGetTokenT<HFDigiCollection> tok_HFDigiCollection_;
-  edm::EDGetTokenT<HcalTrigPrimDigiCollection> tok_TPDigiCollection_;
-  edm::ESGetToken<HcalElectronicsMap, HcalElectronicsMapRcd> tok_electronicsMap_;
+  const edm::EDGetTokenT<HcalDataFrameContainer<QIE10DataFrame>> tok_QIE10DigiCollection_;
+  const edm::EDGetTokenT<HcalDataFrameContainer<QIE11DataFrame>> tok_QIE11DigiCollection_;
+  const edm::EDGetTokenT<HBHEDigiCollection> tok_HBHEDigiCollection_;
+  const edm::EDGetTokenT<HFDigiCollection> tok_HFDigiCollection_;
+  const edm::EDGetTokenT<HcalTrigPrimDigiCollection> tok_TPDigiCollection_;
+  const edm::ESGetToken<HcalElectronicsMap, HcalElectronicsMapRcd> tok_electronicsMap_;
 
-  bool premix_;
+  const bool premix_;
 };
 
 HcalDigiToRawuHTR::HcalDigiToRawuHTR(const edm::ParameterSet& iConfig)
@@ -72,7 +71,6 @@ HcalDigiToRawuHTR::HcalDigiToRawuHTR(const edm::ParameterSet& iConfig)
       tdc1_(iConfig.getParameter<vector<int>>("tdc1")),
       tdc2_(iConfig.getParameter<vector<int>>("tdc2")),
       packHBTDC_(iConfig.getParameter<bool>("packHBTDC")),
-      electronicsMapLabel_(iConfig.getParameter<std::string>("ElectronicsMap")),
       tok_QIE10DigiCollection_(
           consumes<HcalDataFrameContainer<QIE10DataFrame>>(iConfig.getParameter<edm::InputTag>("QIE10"))),
       tok_QIE11DigiCollection_(
@@ -80,8 +78,8 @@ HcalDigiToRawuHTR::HcalDigiToRawuHTR(const edm::ParameterSet& iConfig)
       tok_HBHEDigiCollection_(consumes<HBHEDigiCollection>(iConfig.getParameter<edm::InputTag>("HBHEqie8"))),
       tok_HFDigiCollection_(consumes<HFDigiCollection>(iConfig.getParameter<edm::InputTag>("HFqie8"))),
       tok_TPDigiCollection_(consumes<HcalTrigPrimDigiCollection>(iConfig.getParameter<edm::InputTag>("TP"))),
-      tok_electronicsMap_(
-          esConsumes<HcalElectronicsMap, HcalElectronicsMapRcd>(edm::ESInputTag("", electronicsMapLabel_))),
+      tok_electronicsMap_(esConsumes<HcalElectronicsMap, HcalElectronicsMapRcd>(
+          edm::ESInputTag("", iConfig.getParameter<std::string>("ElectronicsMap")))),
       premix_(iConfig.getParameter<bool>("premix")) {
   produces<FEDRawDataCollection>("");
   for (size_t i = 0; i < tdc1_.size(); i++) {

--- a/EventFilter/HcalRawToDigi/plugins/HcalDigiToRawuHTR.cc
+++ b/EventFilter/HcalRawToDigi/plugins/HcalDigiToRawuHTR.cc
@@ -51,14 +51,14 @@ public:
 
 private:
   int _verbosity;
-  int tdc1_;
-  int tdc2_;
+  vector<int> tdc1_;
+  vector<int> tdc2_;
   bool packHBTDC_;
   static constexpr int tdcmax_ = 49;
   std::string electronicsMapLabel_;
 
-  edm::EDGetTokenT<HcalDataFrameContainer<QIE10DataFrame> > tok_QIE10DigiCollection_;
-  edm::EDGetTokenT<HcalDataFrameContainer<QIE11DataFrame> > tok_QIE11DigiCollection_;
+  edm::EDGetTokenT<HcalDataFrameContainer<QIE10DataFrame>> tok_QIE10DigiCollection_;
+  edm::EDGetTokenT<HcalDataFrameContainer<QIE11DataFrame>> tok_QIE11DigiCollection_;
   edm::EDGetTokenT<HBHEDigiCollection> tok_HBHEDigiCollection_;
   edm::EDGetTokenT<HFDigiCollection> tok_HFDigiCollection_;
   edm::EDGetTokenT<HcalTrigPrimDigiCollection> tok_TPDigiCollection_;
@@ -69,14 +69,14 @@ private:
 
 HcalDigiToRawuHTR::HcalDigiToRawuHTR(const edm::ParameterSet& iConfig)
     : _verbosity(iConfig.getUntrackedParameter<int>("Verbosity", 0)),
-      tdc1_(iConfig.getParameter<int>("tdc1")),
-      tdc2_(iConfig.getParameter<int>("tdc2")),
+      tdc1_(iConfig.getParameter<vector<int>>("tdc1")),
+      tdc2_(iConfig.getParameter<vector<int>>("tdc2")),
       packHBTDC_(iConfig.getParameter<bool>("packHBTDC")),
       electronicsMapLabel_(iConfig.getParameter<std::string>("ElectronicsMap")),
       tok_QIE10DigiCollection_(
-          consumes<HcalDataFrameContainer<QIE10DataFrame> >(iConfig.getParameter<edm::InputTag>("QIE10"))),
+          consumes<HcalDataFrameContainer<QIE10DataFrame>>(iConfig.getParameter<edm::InputTag>("QIE10"))),
       tok_QIE11DigiCollection_(
-          consumes<HcalDataFrameContainer<QIE11DataFrame> >(iConfig.getParameter<edm::InputTag>("QIE11"))),
+          consumes<HcalDataFrameContainer<QIE11DataFrame>>(iConfig.getParameter<edm::InputTag>("QIE11"))),
       tok_HBHEDigiCollection_(consumes<HBHEDigiCollection>(iConfig.getParameter<edm::InputTag>("HBHEqie8"))),
       tok_HFDigiCollection_(consumes<HFDigiCollection>(iConfig.getParameter<edm::InputTag>("HFqie8"))),
       tok_TPDigiCollection_(consumes<HcalTrigPrimDigiCollection>(iConfig.getParameter<edm::InputTag>("TP"))),
@@ -84,8 +84,11 @@ HcalDigiToRawuHTR::HcalDigiToRawuHTR(const edm::ParameterSet& iConfig)
           esConsumes<HcalElectronicsMap, HcalElectronicsMapRcd>(edm::ESInputTag("", electronicsMapLabel_))),
       premix_(iConfig.getParameter<bool>("premix")) {
   produces<FEDRawDataCollection>("");
-  if (!(tdc1_ >= 0 && tdc1_ <= tdc2_ && tdc2_ <= tdcmax_))
-    edm::LogWarning("HcalDigiToRawuHTR") << " incorrect TDC ranges " << tdc1_ << ", " << tdc2_ << ", " << tdcmax_;
+  for (size_t i = 0; i < tdc1_.size(); i++) {
+    if (!(tdc1_.at(i) >= 0 && tdc1_.at(i) <= tdc2_.at(i) && tdc2_.at(i) <= tdcmax_))
+      edm::LogWarning("HcalDigiToRawuHTR")
+          << " incorrect TDC ranges " << i << "-th element: " << tdc1_.at(i) << ", " << tdc2_.at(i) << ", " << tdcmax_;
+  }
 }
 
 HcalDigiToRawuHTR::~HcalDigiToRawuHTR() {}
@@ -113,7 +116,7 @@ void HcalDigiToRawuHTR::produce(edm::StreamID id, edm::Event& iEvent, const edm:
   iEvent.getByToken(tok_TPDigiCollection_, tpDigiCollection);
 
   // first argument is the fedid (minFEDID+crateId)
-  map<int, unique_ptr<HCalFED> > fedMap;
+  map<int, unique_ptr<HCalFED>> fedMap;
 
   // - - - - - - - - - - - - - - - - - - - - - - - - - - -
   // QIE10 precision data
@@ -262,7 +265,7 @@ void HcalDigiToRawuHTR::produce(edm::StreamID id, edm::Event& iEvent, const edm:
            putting together the FEDRawDataCollection
      ------------------------------------------------------
      ------------------------------------------------------ */
-  for (map<int, unique_ptr<HCalFED> >::iterator fed = fedMap.begin(); fed != fedMap.end(); ++fed) {
+  for (map<int, unique_ptr<HCalFED>>::iterator fed = fedMap.begin(); fed != fedMap.end(); ++fed) {
     int fedId = fed->first;
 
     auto& rawData = fed_buffers->FEDData(fedId);
@@ -288,9 +291,13 @@ void HcalDigiToRawuHTR::fillDescriptions(edm::ConfigurationDescriptions& descrip
   // Please change this to state exactly what you do use, even if it is no parameters
   edm::ParameterSetDescription desc;
   desc.addUntracked<int>("Verbosity", 0);
-  desc.add<int>("tdc1", 4);
-  desc.add<int>("tdc2", 20);
-  desc.add<bool>("packHBTDC", false);
+  desc.add<vector<int>>("tdc1", {8,  14, 15, 17, 8,  14, 15, 17, 8,  14, 14, 17, 8,  14, 14, 17, 8,  13, 14, 16, 8,  13,
+                                 14, 16, 8,  12, 14, 15, 8,  12, 14, 15, 7,  12, 13, 15, 7,  12, 13, 15, 7,  12, 13, 15,
+                                 7,  12, 13, 15, 7,  11, 12, 14, 7,  11, 12, 14, 7,  11, 12, 14, 7,  11, 12, 7});
+  desc.add<vector<int>>("tdc2", {10, 16, 17, 19, 10, 16, 17, 19, 10, 16, 16, 19, 10, 16, 16, 19, 10, 15, 16, 18, 10, 15,
+                                 16, 18, 10, 14, 16, 17, 10, 14, 16, 17, 9,  14, 15, 17, 9,  14, 15, 17, 9,  14, 15, 17,
+                                 9,  14, 15, 17, 9,  13, 14, 16, 9,  13, 14, 16, 9,  13, 14, 16, 9,  13, 14, 9});
+  desc.add<bool>("packHBTDC", true);
   desc.add<std::string>("ElectronicsMap", "");
   desc.add<edm::InputTag>("QIE10", edm::InputTag("simHcalDigis", "HFQIE10DigiCollection"));
   desc.add<edm::InputTag>("QIE11", edm::InputTag("simHcalDigis", "HBHEQIE11DigiCollection"));

--- a/EventFilter/HcalRawToDigi/plugins/PackerHelp.h
+++ b/EventFilter/HcalRawToDigi/plugins/PackerHelp.h
@@ -625,7 +625,7 @@ QIE11DataFrame convertHB(QIE11DataFrame qiehe,
   int adc, tdc;
   bool soi;
   int is = 0;
-
+  int capid = qiehe[0].capid();
   //  flavor for HB digies is hardcoded here
   static const int hbflavor = 3;
   //  maximum HB depth
@@ -658,7 +658,6 @@ QIE11DataFrame convertHB(QIE11DataFrame qiehe,
 
   // puting flavor is safe here because flavor is stored in the same bits for all flavors
   qiehb.setFlavor(hbflavor);
-  int capid = qiehe[0].capid();
   qiehb.setCapid0(capid);
 
   return qiehb;

--- a/EventFilter/HcalRawToDigi/plugins/PackerHelp.h
+++ b/EventFilter/HcalRawToDigi/plugins/PackerHelp.h
@@ -636,12 +636,12 @@ QIE11DataFrame convertHB(QIE11DataFrame qiehe, std::vector<int> tdc1, std::vecto
     tdc = qiehe[is].tdc();
     soi = qiehe[is].soi();
 
-    if (tdc >= 0 && tdc <= tdc1.at(abs(did.ieta() - 1) * maxHBdepth + (did.depth() - 1)))
+    if (tdc >= 0 && tdc <= tdc1.at((abs(did.ieta()) - 1) * maxHBdepth + (did.depth() - 1)))
       tdc = 0;
-    else if (tdc > tdc1.at(abs(did.ieta() - 1) * maxHBdepth + (did.depth() - 1)) &&
-             tdc <= tdc2.at(abs(did.ieta() - 1) * maxHBdepth + (did.depth() - 1)))
+    else if (tdc > tdc1.at((abs(did.ieta()) - 1) * maxHBdepth + (did.depth() - 1)) &&
+             tdc <= tdc2.at((abs(did.ieta()) - 1) * maxHBdepth + (did.depth() - 1)))
       tdc = 1;
-    else if (tdc > tdc2.at(abs(did.ieta() - 1) * maxHBdepth + (did.depth() - 1)) && tdc <= tdcmax)
+    else if (tdc > tdc2.at((abs(did.ieta()) - 1) * maxHBdepth + (did.depth() - 1)) && tdc <= tdcmax)
       tdc = 2;
     else
       tdc = 3;

--- a/EventFilter/HcalRawToDigi/plugins/PackerHelp.h
+++ b/EventFilter/HcalRawToDigi/plugins/PackerHelp.h
@@ -628,6 +628,10 @@ QIE11DataFrame convertHB(QIE11DataFrame qiehe, std::vector<int> tdc1, std::vecto
   //  maximum HB depth
   static const int maxHBdepth = 4;
 
+  int entry = (abs(did.ieta()) - 1) * maxHBdepth + did.depth() - 1;
+  int first = tdc1.at(entry);
+  int second = tdc2.at(entry);
+
   //  iterator over samples
   for (edm::DataFrame::const_iterator it = qiehe.begin(); it != qiehe.end(); ++it) {
     if (it == qiehe.begin())
@@ -636,12 +640,11 @@ QIE11DataFrame convertHB(QIE11DataFrame qiehe, std::vector<int> tdc1, std::vecto
     tdc = qiehe[is].tdc();
     soi = qiehe[is].soi();
 
-    if (tdc >= 0 && tdc <= tdc1.at((abs(did.ieta()) - 1) * maxHBdepth + (did.depth() - 1)))
+    if (tdc >= 0 && tdc <= first)
       tdc = 0;
-    else if (tdc > tdc1.at((abs(did.ieta()) - 1) * maxHBdepth + (did.depth() - 1)) &&
-             tdc <= tdc2.at((abs(did.ieta()) - 1) * maxHBdepth + (did.depth() - 1)))
+    else if (tdc > first && tdc <= second)
       tdc = 1;
-    else if (tdc > tdc2.at((abs(did.ieta()) - 1) * maxHBdepth + (did.depth() - 1)) && tdc <= tdcmax)
+    else if (tdc > second && tdc <= tdcmax)
       tdc = 2;
     else
       tdc = 3;

--- a/EventFilter/HcalRawToDigi/plugins/PackerHelp.h
+++ b/EventFilter/HcalRawToDigi/plugins/PackerHelp.h
@@ -8,6 +8,7 @@
 #include "DataFormats/FEDRawData/interface/FEDHeader.h"
 #include "CondFormats/HcalObjects/interface/HcalElectronicsMap.h"
 #include "DataFormats/HcalDigi/interface/QIE10DataFrame.h"
+#include "DataFormats/HcalDigi/interface/QIE11DataFrame.h"
 
 #include <iostream>
 #include <cstdio>

--- a/EventFilter/HcalRawToDigi/plugins/PackerHelp.h
+++ b/EventFilter/HcalRawToDigi/plugins/PackerHelp.h
@@ -616,7 +616,10 @@ public:
 
 // converts HE QIE digies to HB data format
 
-QIE11DataFrame convertHB(QIE11DataFrame qiehe, std::vector<int> tdc1, std::vector<int> tdc2, int tdcmax) {
+QIE11DataFrame convertHB(QIE11DataFrame qiehe,
+                         std::vector<int> const& tdc1,
+                         std::vector<int> const& tdc2,
+                         const int tdcmax) {
   QIE11DataFrame qiehb = qiehe;
   HcalDetId did = HcalDetId(qiehb.detid());
   int adc, tdc;
@@ -628,9 +631,9 @@ QIE11DataFrame convertHB(QIE11DataFrame qiehe, std::vector<int> tdc1, std::vecto
   //  maximum HB depth
   static const int maxHBdepth = 4;
 
-  int entry = (abs(did.ieta()) - 1) * maxHBdepth + did.depth() - 1;
-  int first = tdc1.at(entry);
-  int second = tdc2.at(entry);
+  const int entry = (abs(did.ieta()) - 1) * maxHBdepth + did.depth() - 1;
+  const int first = tdc1.at(entry);
+  const int second = tdc2.at(entry);
 
   //  iterator over samples
   for (edm::DataFrame::const_iterator it = qiehe.begin(); it != qiehe.end(); ++it) {

--- a/EventFilter/HcalRawToDigi/plugins/PackerHelp.h
+++ b/EventFilter/HcalRawToDigi/plugins/PackerHelp.h
@@ -625,6 +625,8 @@ QIE11DataFrame convertHB(QIE11DataFrame qiehe, std::vector<int> tdc1, std::vecto
 
   //  flavor for HB digies is hardcoded here
   static const int hbflavor = 3;
+  //  maximum HB depth
+  static const int maxHBdepth = 4;
 
   //  iterator over samples
   for (edm::DataFrame::const_iterator it = qiehe.begin(); it != qiehe.end(); ++it) {
@@ -634,12 +636,12 @@ QIE11DataFrame convertHB(QIE11DataFrame qiehe, std::vector<int> tdc1, std::vecto
     tdc = qiehe[is].tdc();
     soi = qiehe[is].soi();
 
-    if (tdc >= 0 && tdc <= tdc1.at(abs(did.ieta() - 1) * 4 + (did.depth() - 1)))
+    if (tdc >= 0 && tdc <= tdc1.at(abs(did.ieta() - 1) * maxHBdepth + (did.depth() - 1)))
       tdc = 0;
-    else if (tdc > tdc1.at(abs(did.ieta() - 1) * 4 + (did.depth() - 1)) &&
-             tdc <= tdc2.at(abs(did.ieta() - 1) * 4 + (did.depth() - 1)))
+    else if (tdc > tdc1.at(abs(did.ieta() - 1) * maxHBdepth + (did.depth() - 1)) &&
+             tdc <= tdc2.at(abs(did.ieta() - 1) * maxHBdepth + (did.depth() - 1)))
       tdc = 1;
-    else if (tdc > tdc2.at(abs(did.ieta() - 1) * 4 + (did.depth() - 1)) && tdc <= tdcmax)
+    else if (tdc > tdc2.at(abs(did.ieta() - 1) * maxHBdepth + (did.depth() - 1)) && tdc <= tdcmax)
       tdc = 2;
     else
       tdc = 3;

--- a/EventFilter/HcalRawToDigi/plugins/PackerHelp.h
+++ b/EventFilter/HcalRawToDigi/plugins/PackerHelp.h
@@ -616,8 +616,9 @@ public:
 
 // converts HE QIE digies to HB data format
 
-QIE11DataFrame convertHB(QIE11DataFrame qiehe, int tdc1, int tdc2, int tdcmax) {
+QIE11DataFrame convertHB(QIE11DataFrame qiehe, std::vector<int> tdc1, std::vector<int> tdc2, int tdcmax) {
   QIE11DataFrame qiehb = qiehe;
+  HcalDetId did = HcalDetId(qiehb.detid());
   int adc, tdc;
   bool soi;
   int is = 0;
@@ -633,11 +634,12 @@ QIE11DataFrame convertHB(QIE11DataFrame qiehe, int tdc1, int tdc2, int tdcmax) {
     tdc = qiehe[is].tdc();
     soi = qiehe[is].soi();
 
-    if (tdc >= 0 && tdc <= tdc1)
+    if (tdc >= 0 && tdc <= tdc1.at(abs(did.ieta() - 1) * 4 + (did.depth() - 1)))
       tdc = 0;
-    else if (tdc > tdc1 && tdc <= tdc2)
+    else if (tdc > tdc1.at(abs(did.ieta() - 1) * 4 + (did.depth() - 1)) &&
+             tdc <= tdc2.at(abs(did.ieta() - 1) * 4 + (did.depth() - 1)))
       tdc = 1;
-    else if (tdc > tdc2 && tdc <= tdcmax)
+    else if (tdc > tdc2.at(abs(did.ieta() - 1) * 4 + (did.depth() - 1)) && tdc <= tdcmax)
       tdc = 2;
     else
       tdc = 3;


### PR DESCRIPTION
Applying prompt - delayed range for HB TDC packing, a solution for issue #33002. Expect to see HB TDC changes from a range of 0-63 to a range of 0-3.

In case of need (special/private MC production etc.) the packing of TDC for HB can be removed by including:
(1) following line into a job config: process.hcalDigiToRawuHTR.packHBTDC = cms.bool(False)
(2) customization into a cmsDriver command: --customise_command 'process.hcalDigiToRawuHTR.packHBTDC = cms.bool(False)\n'
