### PR TITLE
FastSim number of photoelectrons in HF simulation

### DIFF
--- a/FastSimulation/Calorimetry/python/Calorimetry_cff.py
+++ b/FastSimulation/Calorimetry/python/Calorimetry_cff.py
@@ -262,7 +262,7 @@ FamosCalorimetryBlock = cms.PSet(
             timeShiftHF = cms.vdouble(50.7, 52.5, 52.9, 53.9, 54.5, 55.1, 55.1, 55.7, 55.9, 56.1, 56.1, 56.1, 56.5),
             ),
         HFShower           = cms.PSet(
-            ProbMax          = cms.double(0.5),
+            ProbMax          = cms.double(1.0),
             CFibre           = cms.double(0.5),
             OnlyLong          = cms.bool(True)
             ),
@@ -300,3 +300,5 @@ FamosCalorimetryBlock.Calorimetry.HCAL.Digitizer = True
 
 from Configuration.Eras.Modifier_run2_common_cff import run2_common
 run2_common.toModify(FamosCalorimetryBlock.Calorimetry.HFShowerLibrary, FileName = 'SimG4CMS/Calo/data/HFShowerLibrary_npmt_noatt_eta4_16en_v4.root' )
+
+run2_common.toModify(FamosCalorimetryBlock.Calorimetry.HFShower, ProbMax = 0.5 )

--- a/FastSimulation/Calorimetry/python/Calorimetry_cff.py
+++ b/FastSimulation/Calorimetry/python/Calorimetry_cff.py
@@ -262,7 +262,7 @@ FamosCalorimetryBlock = cms.PSet(
             timeShiftHF = cms.vdouble(50.7, 52.5, 52.9, 53.9, 54.5, 55.1, 55.1, 55.7, 55.9, 56.1, 56.1, 56.1, 56.5),
             ),
         HFShower           = cms.PSet(
-            ProbMax          = cms.double(1.0),
+            ProbMax          = cms.double(0.5),
             CFibre           = cms.double(0.5),
             OnlyLong          = cms.bool(True)
             ),


### PR DESCRIPTION
The parameter ProbMax in FastSim HF simulation is updated to be consistent with the change made in FullSim:

https://github.com/cms-sw/cmssw/pull/25155

This fixes an issue related to the HF jet response discussed in the Feb 4 simulation meeting:

https://indico.cern.ch/event/1007716/contributions/4231234/attachments/2189371/3700030/FastSimBugsFeb2021b.pdf

This also fixes a discrepancy in the ttbar MET distribution introduced in CMSSW_10_4_0_pre3. 
#### PR validation:

the update has been tested in the head release of C11 and also in the UL release CMSSW_10_6_20 (plots of jet response and MET attached). This change needs to be backported to CMSSW_10_6. 

[fastvsfull_forwardJetResponse_CMSSW_10_6_20_fix.pdf](https://github.com/cms-sw/cmssw/files/6074744/fastvsfull_forwardJetResponse_CMSSW_10_6_20_fix.pdf)
[fastvsfull_forwardJetResponse_CMSSW_11_X.pdf](https://github.com/cms-sw/cmssw/files/6074745/fastvsfull_forwardJetResponse_CMSSW_11_X.pdf)
[fastvsfull_MET_CMSSW_10_6_20_fix.pdf](https://github.com/cms-sw/cmssw/files/6074746/fastvsfull_MET_CMSSW_10_6_20_fix.pdf)
[fastvsfull_MET_CMSSW_11_X.pdf](https://github.com/cms-sw/cmssw/files/6074747/fastvsfull_MET_CMSSW_11_X.pdf)




