### PR TITLE
Pilot PR for the GPU attributes in workflow injected by runTheMatrix

### DIFF
--- a/Configuration/PyReleaseValidation/python/MatrixInjector.py
+++ b/Configuration/PyReleaseValidation/python/MatrixInjector.py
@@ -64,6 +64,12 @@ class MatrixInjector(object):
         self.batchTime = str(int(time.time()))
         if(opt.batchName):
             self.batchName = '__'+opt.batchName+'-'+self.batchTime
+        #GPU tuff
+        self.gpuClass = opt.gpuClass
+        self.gpuDriverVersion = opt.gpuDriverVersion
+        self.gpuRuntime = opt.gpuRuntime
+        self.gpuMemory = opt.gpuMemory
+        self.gpuRuntimeVersion = opt.gpuRuntimeVersion
 
         # WMagent url
         if not self.wmagent:
@@ -132,6 +138,11 @@ class MatrixInjector(object):
             "Memory" : 3000,
             "SizePerEvent" : 1234,
             "TimePerEvent" : 10,
+            "GPUClass": None,
+            "GPUDriverVersion": None, 
+            "GPURuntime": None, 
+            "GPUMemory": None, 
+            "GPURuntimeVersion": None,
             "PrepID": os.getenv('CMSSW_VERSION')
             }
 
@@ -321,6 +332,16 @@ class MatrixInjector(object):
         for (n,dir) in directories.items():
             chainDict=copy.deepcopy(self.defaultChain)
             print("inspecting",dir)
+            if self.gpuClass:
+                chainDict['GPUClass'] = self.gpuClass
+            if self.gpuDriverVersion:
+                chainDict['GPUDriverVersion'] =self.gpuDriverVersion
+            if self.gpuRuntime:
+                chainDict['GPURuntime'] =self.gpuRuntime
+            if self.gpuMemory:
+                chainDict['GPUMemory'] =self.gpuMemory
+            if self.gpuRuntimeVersion:
+                chainDict['GPURuntimeVersion'] =self.gpuRuntimeVersion
             nextHasDSInput=None
             for (x,s) in mReader.workFlowSteps.items():
                 #x has the format (num, prefix)

--- a/Configuration/PyReleaseValidation/python/MatrixInjector.py
+++ b/Configuration/PyReleaseValidation/python/MatrixInjector.py
@@ -70,9 +70,12 @@ class MatrixInjector(object):
         ####################################
         # require
         self.RequiresGPU = opt.RequiresGPU
-        if self.RequiresGPU not in (0,1,2):
-            print('RequiresGPU should be 0,1,2. Now, reset to 0.')
-            self.RequiresGPU = 0 #reset if number is not 0,1,2 
+        if self.RequiresGPU not in ('forbidden','optional','required'):
+            print('RequiresGPU must be forbidden, optional, required. Now, set to forbidden.')
+            self.RequiresGPU = 'forbidden'
+        if self.RequiresGPU == 'optional':
+            print('Optional GPU is turned off for RelVals. Now, changing it to forbidden')
+            self.RequiresGPU = 'forbidden'
         self.GPUMemory = opt.GPUMemory
         self.CUDACapabilities = opt.CUDACapabilities.split(',')
         self.CUDARuntime = opt.CUDARuntime
@@ -171,7 +174,8 @@ class MatrixInjector(object):
             "nowmIO": {},
             "Multicore" : opt.nThreads,                  # this is the per-taskchain Multicore; it's the default assigned to a task if it has no value specified 
             "EventStreams": self.numberOfStreams,
-            "KeepOutput" : False
+            "KeepOutput" : False,
+            "GPUParams": None
             }
         self.defaultInput={
             "TaskName" : "DigiHLT",                                      #Task Name
@@ -183,7 +187,8 @@ class MatrixInjector(object):
             "nowmIO": {},
             "Multicore" : opt.nThreads,                       # this is the per-taskchain Multicore; it's the default assigned to a task if it has no value specified 
             "EventStreams": self.numberOfStreams,
-            "KeepOutput" : False
+            "KeepOutput" : False,
+            "GPUParams": None
             }
         self.defaultTask={
             "TaskName" : None,                                 #Task Name
@@ -197,8 +202,8 @@ class MatrixInjector(object):
             "Multicore" : opt.nThreads,                       # this is the per-taskchain Multicore; it's the default assigned to a task if it has no value specified 
             "EventStreams": self.numberOfStreams,
             "KeepOutput" : False,
-            "RequiresGPU" : 0,
-            "GPUParams": {None}
+            "RequiresGPU" : None,
+            "GPUParams": None
             }
         self.defaultGPUParams={
             "GPUMemory": self.GPUMemory,
@@ -404,7 +409,6 @@ class MatrixInjector(object):
                                     thisLabel+='_FastSim'
                                 if 'lhe' in s[2][index] in s[2][index]:
                                     chainDict['nowmTasklist'][-1]['LheInputFiles'] =True
-
                             elif nextHasDSInput:
                                 chainDict['nowmTasklist'].append(copy.deepcopy(self.defaultInput))
                                 try:
@@ -434,6 +438,9 @@ class MatrixInjector(object):
                                     if setPrimaryDs:
                                         chainDict['nowmTasklist'][-1]['PrimaryDataset']=setPrimaryDs
                                 nextHasDSInput=None
+                                if 'GPU' in step and self.RequiresGPU == 'required':
+                                    chainDict['nowmTasklist'][-1]['RequiresGPU'] = self.RequiresGPU
+                                    chainDict['nowmTasklist'][-1]['GPUParams']=self.defaultGPUParams
                             else:
                                 #not first step and no inputDS
                                 chainDict['nowmTasklist'].append(copy.deepcopy(self.defaultTask))
@@ -446,7 +453,7 @@ class MatrixInjector(object):
                                     chainDict['nowmTasklist'][-1]['LumisPerJob']=splitForThisWf
                                 if step in wmsplit:
                                     chainDict['nowmTasklist'][-1]['LumisPerJob']=wmsplit[step]
-                                if 'GPU' in step and (self.RequiresGPU == 1 or self.RequiresGPU == 2):
+                                if 'GPU' in step and self.RequiresGPU == 'required':
                                     chainDict['nowmTasklist'][-1]['RequiresGPU'] = self.RequiresGPU
                                     chainDict['nowmTasklist'][-1]['GPUParams']=self.defaultGPUParams 
 

--- a/Configuration/PyReleaseValidation/python/MatrixInjector.py
+++ b/Configuration/PyReleaseValidation/python/MatrixInjector.py
@@ -175,6 +175,7 @@ class MatrixInjector(object):
             "Multicore" : opt.nThreads,                  # this is the per-taskchain Multicore; it's the default assigned to a task if it has no value specified 
             "EventStreams": self.numberOfStreams,
             "KeepOutput" : False,
+            "RequiresGPU" : None,
             "GPUParams": None
             }
         self.defaultInput={
@@ -188,6 +189,7 @@ class MatrixInjector(object):
             "Multicore" : opt.nThreads,                       # this is the per-taskchain Multicore; it's the default assigned to a task if it has no value specified 
             "EventStreams": self.numberOfStreams,
             "KeepOutput" : False,
+            "RequiresGPU" : None,
             "GPUParams": None
             }
         self.defaultTask={

--- a/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
+++ b/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
@@ -333,22 +333,22 @@ if __name__ == '__main__':
                       action='store')
 
     parser.add_option('--RequiresGPU',
-                      help='if GPU is reuired or not: 0 = Not (default), 1 = can use if available, 2 = must use. Default = 0.',
+                      help='if GPU is reuired or not: forbidden (default, CPU-only), optional, required',
                       dest='RequiresGPU',
                       default=0)
 
     parser.add_option('--GPUMemory',
-                      help='to specify GPU memory. Default = 8000 MB (for RequiresGPU=2).',
+                      help='to specify GPU memory. Default = 8000 MB (for RequiresGPU = required).',
                       dest='GPUMemory',
                       default='8000')
 
     parser.add_option('--CUDACapabilities',
-                      help='to specify CUDA capabilities. Default = 7.5 (for RequiresGPU=2).',
+                      help='to specify CUDA capabilities. Default = 7.5 (for RequiresGPU = required).',
                       dest='CUDACapabilities',
                       default='7.5')
 
     parser.add_option('--CUDARuntime',
-                      help='to specify CUDA runtime. Default = 11.2 (for RequiresGPU=2).',
+                      help='to specify CUDA runtime. Default = 11.2 (for RequiresGPU= required).',
                       dest='CUDARuntime',
                       default='11.2')
 
@@ -436,7 +436,6 @@ if __name__ == '__main__':
     if opt.numberEventsInLuminosityBlock: opt.numberEventsInLuminosityBlock=int(opt.numberEventsInLuminosityBlock)
     if opt.memoryOffset: opt.memoryOffset=int(opt.memoryOffset)
     if opt.memPerCore: opt.memPerCore=int(opt.memPerCore)
-    if opt.RequiresGPU: opt.RequiresGPU=int(opt.RequiresGPU)
 
     if opt.wmcontrol:
         performInjectionOptionTest(opt)

--- a/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
+++ b/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
@@ -303,6 +303,22 @@ if __name__ == '__main__':
                       default=None,
                       action='store')
 
+    parser.add_option('--gpuClass',
+                      help='to specify GPU class',
+                      default='')
+    parser.add_option('--gpuDriverVersion',
+                      help='to specify GPU driver version',
+                      default='')
+    parser.add_option('--gpuRuntime',
+                      help='to specify GPU runtime',
+                      default='')
+    parser.add_option('--gpuMemory',
+                      help='to specify GPU memory',
+                      default='')
+    parser.add_option('--gpuRuntimeVersion',
+                      help='to specify GPU runtime version',
+                      default='')
+
     opt,args = parser.parse_args()
     os.environ["CMSSW_DAS_QUERY_SITES"]=opt.dasSites
     if opt.IBEos:

--- a/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
+++ b/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
@@ -172,7 +172,7 @@ if __name__ == '__main__':
                       )
 
     parser.add_option('-l','--list',
-                      help='Coma separated list of workflow to be shown or ran. Possible keys are also '+str(predefinedSet.keys())+'. and wild card like muon, or mc',
+                      help='Comma separated list of workflow to be shown or ran. Possible keys are also '+str(predefinedSet.keys())+'. and wild card like muon, or mc',
                       dest='testList',
                       default=None
                      )
@@ -183,7 +183,7 @@ if __name__ == '__main__':
                       )
 
     parser.add_option('-i','--useInput',
-                      help='Use recyling where available. Either all, or a coma separated list of wf number.',
+                      help='Use recyling where available. Either all, or a comma separated list of wf number.',
                       dest='useInput',
                       default=None
                       )
@@ -208,7 +208,7 @@ if __name__ == '__main__':
                       )
 
     parser.add_option('--fromScratch',
-                      help='Coma separated list of wf to be run without recycling. all is not supported as default.',
+                      help='Comma separated list of wf to be run without recycling. all is not supported as default.',
                       dest='fromScratch',
                       default=None
                        )
@@ -239,7 +239,7 @@ if __name__ == '__main__':
                       dest='wmoptions')
 
     parser.add_option('--keep',
-                      help='allow to specify for which coma separated steps the output is needed',
+                      help='allow to specify for which comma separated steps the output is needed',
                       default=None)
 
     parser.add_option('--label',
@@ -253,7 +253,7 @@ if __name__ == '__main__':
                       )
 
     parser.add_option('--apply',
-                      help='allow to use the --command only for 1 coma separeated',
+                      help='allow to use the --command only for 1 comma separeated',
                       dest='apply',
                       default=None)
 
@@ -343,7 +343,7 @@ if __name__ == '__main__':
                       default='8000')
 
     parser.add_option('--CUDACapabilities',
-                      help='to specify CUDA capabilities. Default = 7.5 (for RequiresGPU = required).',
+                      help='to specify CUDA capabilities. Default = 7.5 (for RequiresGPU = required). Use comma to identify various CUDACapabilities',
                       dest='CUDACapabilities',
                       default='7.5')
 

--- a/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
+++ b/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
@@ -119,26 +119,31 @@ if __name__ == '__main__':
                       dest='memoryOffset',
                       default=3000
                      )
+
     parser.add_option('--addMemPerCore',
                       help='increase of memory per each n > 1 core:  memory(n_core) = memoryOffset + (n_core-1) * memPerCore',
                       dest='memPerCore',
                       default=1500
                      )
+
     parser.add_option('-j','--nproc',
                       help='number of processes. 0 Will use 4 processes, not execute anything but create the wfs',
                       dest='nProcs',
                       default=4
                      )
+
     parser.add_option('-t','--nThreads',
                       help='number of threads per process to use in cmsRun.',
                       dest='nThreads',
                       default=1
                      )
+
     parser.add_option('--nStreams',
                       help='number of streams to use in cmsRun.',
                       dest='nStreams',
                       default=0
                      )
+
     parser.add_option('--numberEventsInLuminosityBlock',
                       help='number of events in a luminosity block',
                       dest='numberEventsInLuminosityBlock',
@@ -151,118 +156,141 @@ if __name__ == '__main__':
                       default=False,
                       action='store_true'
                       )
+
     parser.add_option('-e','--extended',
                       help='Show details of workflows, used with --show',
                       dest='extended',
                       default=False,
                       action='store_true'
                       )
+
     parser.add_option('-s','--selected',
                       help='Run a pre-defined selected matrix of wf. Deprecated, please use -l limited',
                       dest='restricted',
                       default=False,
                       action='store_true'
                       )
+
     parser.add_option('-l','--list',
-                     help='Coma separated list of workflow to be shown or ran. Possible keys are also '+str(predefinedSet.keys())+'. and wild card like muon, or mc',
-                     dest='testList',
-                     default=None
+                      help='Coma separated list of workflow to be shown or ran. Possible keys are also '+str(predefinedSet.keys())+'. and wild card like muon, or mc',
+                      dest='testList',
+                      default=None
                      )
+
     parser.add_option('-r','--raw',
                       help='Temporary dump the .txt needed for prodAgent interface. To be discontinued soon. Argument must be the name of the set (standard, pileup,...)',
                       dest='raw'
                       )
+
     parser.add_option('-i','--useInput',
                       help='Use recyling where available. Either all, or a coma separated list of wf number.',
                       dest='useInput',
                       default=None
                       )
+
     parser.add_option('-w','--what',
                       help='Specify the set to be used. Argument must be the name of a set (standard, pileup,...) or multiple sets separated by commas (--what standard,pileup )',
                       dest='what',
                       default='all'
                       )
+
     parser.add_option('--step1',
                       help='Used with --raw. Limit the production to step1',
                       dest='step1Only',
                       default=False
                       )
+
     parser.add_option('--maxSteps',
                       help='Only run maximum on maxSteps. Used when we are only interested in first n steps.',
                       dest='maxSteps',
                       default=9999,
                       type="int"
                       )
+
     parser.add_option('--fromScratch',
                       help='Coma separated list of wf to be run without recycling. all is not supported as default.',
                       dest='fromScratch',
                       default=None
                        )
+
     parser.add_option('--refRelease',
                       help='Allow to modify the recycling dataset version',
                       dest='refRel',
                       default=None
                       )
+
     parser.add_option('--wmcontrol',
                       help='Create the workflows for injection to WMAgent. In the WORKING. -wmcontrol init will create the the workflows, -wmcontrol test will dryRun a test, -wmcontrol submit will submit to wmagent',
                       choices=['init','test','submit','force'],
                       dest='wmcontrol',
                       default=None,
                       )
+
     parser.add_option('--revertDqmio',
                       help='When submitting workflows to wmcontrol, force DQM outout to use pool and not DQMIO',
                       choices=['yes','no'],
                       dest='revertDqmio',
                       default='no',
                       )
+
     parser.add_option('--optionswm',
                       help='Specify a few things for wm injection',
                       default='',
                       dest='wmoptions')
+
     parser.add_option('--keep',
                       help='allow to specify for which coma separated steps the output is needed',
                       default=None)
+
     parser.add_option('--label',
                       help='allow to give a special label to the output dataset name',
                       default='')
+
     parser.add_option('--command',
                       help='provide a way to add additional command to all of the cmsDriver commands in the matrix',
                       dest='command',
                       default=None
                       )
+
     parser.add_option('--apply',
                       help='allow to use the --command only for 1 coma separeated',
                       dest='apply',
                       default=None)
+
     parser.add_option('--workflow',
                       help='define a workflow to be created or altered from the matrix',
                       action='append',
                       dest='workflow',
                       default=None
                       )
+
     parser.add_option('--dryRun',
                       help='do not run the wf at all',
                       action='store_true',
                       dest='dryRun',
                       default=False
                       )
+
     parser.add_option('--testbed',
                       help='workflow injection to cmswebtest (you need dedicated rqmgr account)',
                       dest='testbed',
                       default=False,
                       action='store_true'
                       )
+
     parser.add_option('--noCafVeto',
                       help='Run from any source, ignoring the CAF label',
                       dest='cafVeto',
                       default=True,
                       action='store_false'
                       )
+
     parser.add_option('--overWrite',
                       help='Change the content of a step for another. List of pairs.',
                       dest='overWrite',
                       default=None
                       )
+
     parser.add_option('--noRun',
                       help='Remove all run list selection from wfs',
                       dest='noRun',
@@ -292,6 +320,7 @@ if __name__ == '__main__':
                       dest='dasSites',
                       default='T2_CH_CERN',
                       action='store')
+
     parser.add_option('--interactive',
                       help="Open the Matrix interactive shell",
                       action='store_true',
@@ -303,20 +332,39 @@ if __name__ == '__main__':
                       default=None,
                       action='store')
 
-    parser.add_option('--gpuClass',
+    parser.add_option('--RequiresGPU',
+                      help='if GPU is reuired or not: 0 = Not (default), 1 = can use if available, 2 = must use. Default = 0.',
+                      dest='RequiresGPU',
+                      default=0)
+
+    parser.add_option('--GPUMemory',
+                      help='to specify GPU memory. Default = 8000 MB (for RequiresGPU=2).',
+                      dest='GPUMemory',
+                      default='8000')
+
+    parser.add_option('--CUDACapabilities',
+                      help='to specify CUDA capabilities. Default = 7.5 (for RequiresGPU=2).',
+                      dest='CUDACapabilities',
+                      default='7.5')
+
+    parser.add_option('--CUDARuntime',
+                      help='to specify CUDA runtime. Default = 11.2 (for RequiresGPU=2).',
+                      dest='CUDARuntime',
+                      default='11.2')
+
+    parser.add_option('--GPUName',
                       help='to specify GPU class',
+                      dest='GPUName',
                       default='')
-    parser.add_option('--gpuDriverVersion',
-                      help='to specify GPU driver version',
+
+    parser.add_option('--CUDADriverVersion',
+                      help='to specify CUDA driver version',
+                      dest='CUDADriverVersion',
                       default='')
-    parser.add_option('--gpuRuntime',
-                      help='to specify GPU runtime',
-                      default='')
-    parser.add_option('--gpuMemory',
-                      help='to specify GPU memory',
-                      default='')
-    parser.add_option('--gpuRuntimeVersion',
-                      help='to specify GPU runtime version',
+
+    parser.add_option('--CUDARuntimeVersion',
+                      help='to specify CUDA runtime version',
+                      dest='CUDARuntimeVersion',
                       default='')
 
     opt,args = parser.parse_args()
@@ -385,9 +433,10 @@ if __name__ == '__main__':
     if opt.nProcs: opt.nProcs=int(opt.nProcs)
     if opt.nThreads: opt.nThreads=int(opt.nThreads)
     if opt.nStreams: opt.nStreams=int(opt.nStreams)
-    if (opt.numberEventsInLuminosityBlock): opt.numberEventsInLuminosityBlock=int(opt.numberEventsInLuminosityBlock)
-    if (opt.memoryOffset): opt.memoryOffset=int(opt.memoryOffset)
-    if (opt.memPerCore): opt.memPerCore=int(opt.memPerCore)
+    if opt.numberEventsInLuminosityBlock: opt.numberEventsInLuminosityBlock=int(opt.numberEventsInLuminosityBlock)
+    if opt.memoryOffset: opt.memoryOffset=int(opt.memoryOffset)
+    if opt.memPerCore: opt.memPerCore=int(opt.memPerCore)
+    if opt.RequiresGPU: opt.RequiresGPU=int(opt.RequiresGPU)
 
     if opt.wmcontrol:
         performInjectionOptionTest(opt)


### PR DESCRIPTION
#### PR description:

Backport of https://github.com/cms-sw/cmssw/pull/33538
(But this is original PR with discussions on how the workflow will look like)

This PR is to converge on how the workflow with GPU attributes will look like. This follows https://docs.google.com/document/d/150k_VBbja1EK9HlxhXs544T0uhenbad8dnMadyNKlpg/edit?usp=sharing
https://docs.google.com/document/d/1shJAEaPDIWF0S3odHm3SSMERhvlTozyTKP8cgfFcOto/edit?usp=sharing
and on WM side:
https://github.com/dmwm/WMCore/issues/10388

Default attributes when GPU is required are:
```
'GPUParams': {'CUDACapabilities': ['7.5'],
                         'CUDADriverVersion': '',
                         'CUDARuntime': '11.2',
                         'CUDARuntimeVersion': '',
                         'GPUMemory': '8000',
                         'GPUName': ''},
```

#### PR validation:
Please ignore the workflow name I use, we can use anything we want, this is to test the output only.

`runTheMatrix.py --what upgrade -l 11650.502 --RequiresGPU required --wm init`

give me the following workflow (*). However, uploading is not success yet, as we need to update wmcore to accept new attributes. 

(*)
```
Only viewing request 11650.502
{'AcquisitionEra': 'CMSSW_11_3_X_2021-04-26-2300',
 'CMSSWVersion': 'CMSSW_11_3_X_2021-04-26-2300',
 'Campaign': 'CMSSW_11_3_X_2021-04-26-2300',
 'ConfigCacheUrl': 'https://cmsweb.cern.ch/couchdb',
 'DQMConfigCacheID': 1041,
 'DQMUploadUrl': 'https://cmsweb.cern.ch/dqm/relval',
 'DbsUrl': 'https://cmsweb-prod.cern.ch/dbs/prod/global/DBSReader',
 'EnableHarvesting': 'True',
 'GlobalTag': u'113X_mcRun3_2021_realistic_v10',
 'Group': 'ppd',
 'Memory': 3000,
 'Multicore': 1,
 'PrepID': 'CMSSW_11_3_X_2021-04-26-2300__1619513550-ZMM_14',
 'ProcessingString': u'113X_mcRun3_2021_realistic_v10',
 'ProcessingVersion': 1,
 'RequestPriority': 500000,
 'RequestString': 'RVCMSSW_11_3_X_2021-04-26-2300ZMM_14',
 'RequestType': 'TaskChain',
 'Requestor': 'srimanob',
 'ScramArch': 'slc7_amd64_gcc900',
 'SizePerEvent': 1234,
 'SubRequestType': 'RelVal',
 'Task1': {'AcquisitionEra': 'CMSSW_11_3_X_2021-04-26-2300',
           'ConfigCacheID': 1043,
           'EventStreams': 0,
           'EventsPerJob': 100,
           'EventsPerLumi': 100,
           'GPUParams': None,
           'GlobalTag': u'113X_mcRun3_2021_realistic_v10',
           'KeepOutput': True,
           'Memory': 3000,
           'Multicore': 1,
           'PrimaryDataset': 'RelValZMM_14',
           'ProcessingString': u'113X_mcRun3_2021_realistic_v10',
           'RequestNumEvents': 18000,
           'RequiresGPU': None,
           'Seeding': 'AutomaticSeeding',
           'SplittingAlgo': 'EventBased',
           'TaskName': 'ZMM_14TeV_TuneCP5_2021_GenSim'},
 'Task2': {'AcquisitionEra': 'CMSSW_11_3_X_2021-04-26-2300',
           'ConfigCacheID': 1044,
           'EventStreams': 0,
           'GPUParams': None,
           'GlobalTag': u'113X_mcRun3_2021_realistic_v10',
           'InputFromOutputModule': u'FEVTDEBUGoutput',
           'InputTask': 'ZMM_14TeV_TuneCP5_2021_GenSim',
           'KeepOutput': True,
           'LumisPerJob': 10,
           'Memory': 3000,
           'Multicore': 1,
           'ProcessingString': u'113X_mcRun3_2021_realistic_v10',
           'RequiresGPU': None,
           'SplittingAlgo': 'LumiBased',
           'TaskName': 'Digi_2021'},
 'Task3': {'AcquisitionEra': 'CMSSW_11_3_X_2021-04-26-2300',
           'ConfigCacheID': 1042,
           'EventStreams': 0,
           'GPUParams': {'CUDACapabilities': ['7.5'],
                         'CUDADriverVersion': '',
                         'CUDARuntime': '11.2',
                         'CUDARuntimeVersion': '',
                         'GPUMemory': '8000',
                         'GPUName': ''},
           'GlobalTag': u'113X_mcRun3_2021_realistic_v10',
           'InputFromOutputModule': u'FEVTDEBUGHLToutput',
           'InputTask': 'Digi_2021',
           'KeepOutput': True,
           'LumisPerJob': 10,
           'Memory': 3000,
           'Multicore': 1,
           'ProcessingString': u'113X_mcRun3_2021_realistic_v10',
           'RequiresGPU': 'required',
           'SplittingAlgo': 'LumiBased',
           'TaskName': 'Reco_Patatrack_PixelOnlyGPU_2021'},
 'TaskChain': 3,
 'TimePerEvent': 10}
```

#### if this PR is a backport please specify the original PR and why you need to backport that PR:
This is a backport of https://github.com/cms-sw/cmssw/pull/33538
