### PR TITLE
[HGCAL] Reorganizing layer cluster plots into subfolders

### DIFF
--- a/Validation/HGCalValidation/interface/HGVHistoProducerAlgo.h
+++ b/Validation/HGCalValidation/interface/HGVHistoProducerAlgo.h
@@ -213,14 +213,12 @@ public:
                                        std::vector<int> thicknesses);
 
   void bookClusterHistos_ClusterLevel(DQMStore::IBooker& ibook,
-                         Histograms& histograms,
-                         unsigned int layers,
-                         std::vector<int> thicknesses,
-                         std::string pathtomatbudfile);
+                                      Histograms& histograms,
+                                      unsigned int layers,
+                                      std::vector<int> thicknesses,
+                                      std::string pathtomatbudfile);
 
-  void bookClusterHistos_LCtoCP_association(DQMStore::IBooker& ibook,
-                                            Histograms& histograms,
-                                            unsigned int layers);
+  void bookClusterHistos_LCtoCP_association(DQMStore::IBooker& ibook, Histograms& histograms, unsigned int layers);
 
   void bookClusterHistos_CellLevel(DQMStore::IBooker& ibook,
                                    Histograms& histograms,

--- a/Validation/HGCalValidation/interface/HGVHistoProducerAlgo.h
+++ b/Validation/HGCalValidation/interface/HGVHistoProducerAlgo.h
@@ -217,7 +217,19 @@ public:
                          unsigned int layers,
                          std::vector<int> thicknesses,
                          std::string pathtomatbudfile);
+
+  void bookClusterHistos_LCtoCP_association(DQMStore::IBooker& ibook,
+                                            Histograms& histograms,
+                                            unsigned int layers,
+                                            std::vector<int> thicknesses);
+
+  void bookClusterHistos_CellLevel(DQMStore::IBooker& ibook, 
+                                   Histograms& histograms, 
+                                   unsigned int layers, 
+                                   std::vector<int> thicknesses);
+
   void bookMultiClusterHistos(DQMStore::IBooker& ibook, Histograms& histograms, unsigned int layers);
+
   void layerClusters_to_CaloParticles(const Histograms& histograms,
                                       edm::Handle<reco::CaloClusterCollection> clusterHandle,
                                       const reco::CaloClusterCollection& clusters,

--- a/Validation/HGCalValidation/interface/HGVHistoProducerAlgo.h
+++ b/Validation/HGCalValidation/interface/HGVHistoProducerAlgo.h
@@ -212,7 +212,7 @@ public:
                                        unsigned int layers,
                                        std::vector<int> thicknesses);
 
-  void bookClusterHistos(DQMStore::IBooker& ibook,
+  void bookClusterHistos_ClusterLevel(DQMStore::IBooker& ibook,
                          Histograms& histograms,
                          unsigned int layers,
                          std::vector<int> thicknesses,
@@ -223,9 +223,9 @@ public:
                                             unsigned int layers,
                                             std::vector<int> thicknesses);
 
-  void bookClusterHistos_CellLevel(DQMStore::IBooker& ibook, 
-                                   Histograms& histograms, 
-                                   unsigned int layers, 
+  void bookClusterHistos_CellLevel(DQMStore::IBooker& ibook,
+                                   Histograms& histograms,
+                                   unsigned int layers,
                                    std::vector<int> thicknesses);
 
   void bookMultiClusterHistos(DQMStore::IBooker& ibook, Histograms& histograms, unsigned int layers);

--- a/Validation/HGCalValidation/interface/HGVHistoProducerAlgo.h
+++ b/Validation/HGCalValidation/interface/HGVHistoProducerAlgo.h
@@ -220,8 +220,7 @@ public:
 
   void bookClusterHistos_LCtoCP_association(DQMStore::IBooker& ibook,
                                             Histograms& histograms,
-                                            unsigned int layers,
-                                            std::vector<int> thicknesses);
+                                            unsigned int layers);
 
   void bookClusterHistos_CellLevel(DQMStore::IBooker& ibook,
                                    Histograms& histograms,

--- a/Validation/HGCalValidation/plugins/HGCalValidator.cc
+++ b/Validation/HGCalValidation/plugins/HGCalValidator.cc
@@ -158,16 +158,13 @@ void HGCalValidator::bookHistograms(DQMStore::IBooker& ibook,
                                                        cummatbudinxo_.fullPath());
     ibook.cd();
     ibook.setCurrentFolder(dirName_ + "hgcalLayerClusters/LCtoCP_association");
-    histoProducerAlgo_->bookClusterHistos_LCtoCP_association(ibook, 
-                                                             histograms.histoProducerAlgo, 
-                                                             totallayers_to_monitor_);
-                                                             
+    histoProducerAlgo_->bookClusterHistos_LCtoCP_association(
+        ibook, histograms.histoProducerAlgo, totallayers_to_monitor_);
+
     ibook.cd();
     ibook.setCurrentFolder(dirName_ + "hgcalLayerClusters/CellLevel");
-    histoProducerAlgo_->bookClusterHistos_CellLevel(ibook, 
-                                                    histograms.histoProducerAlgo, 
-                                                    totallayers_to_monitor_, 
-                                                    thicknesses_to_monitor_);
+    histoProducerAlgo_->bookClusterHistos_CellLevel(
+        ibook, histograms.histoProducerAlgo, totallayers_to_monitor_, thicknesses_to_monitor_);
   }
 
   //Booking histograms for multiclusters

--- a/Validation/HGCalValidation/plugins/HGCalValidator.cc
+++ b/Validation/HGCalValidation/plugins/HGCalValidator.cc
@@ -160,8 +160,8 @@ void HGCalValidator::bookHistograms(DQMStore::IBooker& ibook,
     ibook.setCurrentFolder(dirName_ + "hgcalLayerClusters/LCtoCP_association");
     histoProducerAlgo_->bookClusterHistos_LCtoCP_association(ibook, 
                                                              histograms.histoProducerAlgo, 
-                                                             totallayers_to_monitor_, 
-                                                             thicknesses_to_monitor_);
+                                                             totallayers_to_monitor_);
+                                                             
     ibook.cd();
     ibook.setCurrentFolder(dirName_ + "hgcalLayerClusters/CellLevel");
     histoProducerAlgo_->bookClusterHistos_CellLevel(ibook, 

--- a/Validation/HGCalValidation/plugins/HGCalValidator.cc
+++ b/Validation/HGCalValidation/plugins/HGCalValidator.cc
@@ -150,23 +150,23 @@ void HGCalValidator::bookHistograms(DQMStore::IBooker& ibook,
   //Booking histograms concerning with hgcal layer clusters
   if (dolayerclustersPlots_) {
     ibook.cd();
-    ibook.setCurrentFolder(dirName_ + "hgcalLayerClusters");
-    histoProducerAlgo_->bookClusterHistos(ibook,
-                                          histograms.histoProducerAlgo,
-                                          totallayers_to_monitor_,
-                                          thicknesses_to_monitor_,
-                                          cummatbudinxo_.fullPath());
+    ibook.setCurrentFolder(dirName_ + "hgcalLayerClusters/ClusterLevel");
+    histoProducerAlgo_->bookClusterHistos_ClusterLevel(ibook,
+                                                       histograms.histoProducerAlgo,
+                                                       totallayers_to_monitor_,
+                                                       thicknesses_to_monitor_,
+                                                       cummatbudinxo_.fullPath());
     ibook.cd();
-    ibook.setCurrentFolder(dirName_ + "hgcalLayerClusters/" + "LCtoCP_association");
-    histoProducerAlgo_->bookClusterHistos_LCtoCP_association(ibook,
-                                                              histograms.histoProducerAlgo,
-                                                              totallayers_to_monitor_,
-                                                              thicknesses_to_monitor_);
+    ibook.setCurrentFolder(dirName_ + "hgcalLayerClusters/LCtoCP_association");
+    histoProducerAlgo_->bookClusterHistos_LCtoCP_association(ibook, 
+                                                             histograms.histoProducerAlgo, 
+                                                             totallayers_to_monitor_, 
+                                                             thicknesses_to_monitor_);
     ibook.cd();
-    ibook.setCurrentFolder(dirName_ + "hgcalLayerClusters/" + "CellLevel");
-    histoProducerAlgo_->bookClusterHistos_CellLevel(ibook,
-                                                    histograms.histoProducerAlgo,
-                                                    totallayers_to_monitor_,
+    ibook.setCurrentFolder(dirName_ + "hgcalLayerClusters/CellLevel");
+    histoProducerAlgo_->bookClusterHistos_CellLevel(ibook, 
+                                                    histograms.histoProducerAlgo, 
+                                                    totallayers_to_monitor_, 
                                                     thicknesses_to_monitor_);
   }
 

--- a/Validation/HGCalValidation/plugins/HGCalValidator.cc
+++ b/Validation/HGCalValidation/plugins/HGCalValidator.cc
@@ -156,6 +156,18 @@ void HGCalValidator::bookHistograms(DQMStore::IBooker& ibook,
                                           totallayers_to_monitor_,
                                           thicknesses_to_monitor_,
                                           cummatbudinxo_.fullPath());
+    ibook.cd();
+    ibook.setCurrentFolder(dirName_ + "hgcalLayerClusters/" + "LCtoCP_association");
+    histoProducerAlgo_->bookClusterHistos_LCtoCP_association(ibook,
+                                                              histograms.histoProducerAlgo,
+                                                              totallayers_to_monitor_,
+                                                              thicknesses_to_monitor_);
+    ibook.cd();
+    ibook.setCurrentFolder(dirName_ + "hgcalLayerClusters/" + "CellLevel");
+    histoProducerAlgo_->bookClusterHistos_CellLevel(ibook,
+                                                    histograms.histoProducerAlgo,
+                                                    totallayers_to_monitor_,
+                                                    thicknesses_to_monitor_);
   }
 
   //Booking histograms for multiclusters

--- a/Validation/HGCalValidation/python/PostProcessorHGCAL_cfi.py
+++ b/Validation/HGCalValidation/python/PostProcessorHGCAL_cfi.py
@@ -15,7 +15,7 @@ eff_layers.extend(["merge_eta_layer{:02d} 'LayerCluster Merge Rate vs #eta Layer
 eff_layers.extend(["merge_phi_layer{:02d} 'LayerCluster Merge Rate vs #phi Layer{:02d} in z-' NumMerge_LayerCluster_Phi_perlayer{:02d} Denom_LayerCluster_Phi_perlayer{:02d}".format(i, i%maxlayerzm+1, i, i) if (i<maxlayerzm) else "merge_phi_layer{:02d} 'LayerCluster Merge Rate vs #phi Layer{:02d} in z+' NumMerge_LayerCluster_Phi_perlayer{:02d} Denom_LayerCluster_Phi_perlayer{:02d}".format(i, i%maxlayerzm+1, i, i) for i in range(maxlayerzp) ])
 
 postProcessorHGCALlayerclusters= DQMEDHarvester('DQMGenericClient',
-    subDirs = cms.untracked.vstring('HGCAL/HGCalValidator/hgcalLayerClusters/'),
+    subDirs = cms.untracked.vstring('HGCAL/HGCalValidator/hgcalLayerClusters/LCtoCP_association'),
     efficiency = cms.vstring(eff_layers),
     resolution = cms.vstring(),
     cumulativeDists = cms.untracked.vstring(),

--- a/Validation/HGCalValidation/python/hgcalPlots.py
+++ b/Validation/HGCalValidation/python/hgcalPlots.py
@@ -1984,9 +1984,7 @@ lc_general_clusterlevel = [
   _longdepthbarycentre,
   # calculated "energy density" for cells in a) 120um, b) 200um, c) 300um, d) scint
   # (one entry per rechit, in the appropriate histo)
-  _cellsenedens_thick,
-  # SelectedCaloParticles plots
-  _SelectedCaloParticles
+  _cellsenedens_thick
 ]
 
 lc_clusterlevel_zminus = [
@@ -1997,23 +1995,7 @@ lc_clusterlevel_zminus = [
   # Looking at the fraction of true energy that has been clustered; by layer and overall
   _energyclustered_perlayer_EE_zminus,
   _energyclustered_perlayer_FH_zminus,
-  _energyclustered_perlayer_BH_zminus,
-  # Efficiency Plots
-  _efficiencies_zminus,
-  _efficiencies_zminus_eta,
-  _efficiencies_zminus_phi,
-  # Duplicate Plots
-  _duplicates_zminus,
-  _duplicates_zminus_eta,
-  _duplicates_zminus_phi,
-  # Fake Rate Plots
-  _fakes_zminus,
-  _fakes_zminus_eta,
-  _fakes_zminus_phi,
-  # Merge Rate Plots
-  _merges_zminus,
-  _merges_zminus_eta,
-  _merges_zminus_phi
+  _energyclustered_perlayer_BH_zminus
 ]
 
 lc_cellevel_zminus = [
@@ -2038,6 +2020,22 @@ lc_cellevel_zminus = [
 ]
 
 lc_cp_association_zminus = [
+  # Efficiency Plots
+  _efficiencies_zminus,
+  _efficiencies_zminus_eta,
+  _efficiencies_zminus_phi,
+  # Duplicate Plots
+  _duplicates_zminus,
+  _duplicates_zminus_eta,
+  _duplicates_zminus_phi,
+  # Fake Rate Plots
+  _fakes_zminus,
+  _fakes_zminus_eta,
+  _fakes_zminus_phi,
+  # Merge Rate Plots
+  _merges_zminus,
+  _merges_zminus_eta,
+  _merges_zminus_phi,
   # Score of CaloParticles wrt Layer Clusters
   _score_caloparticle_to_layerclusters_zminus,
   # Score of LayerClusters wrt CaloParticles
@@ -2140,23 +2138,7 @@ lc_clusterlevel_zplus = [
   # Looking at the fraction of true energy that has been clustered; by layer and overall
   _energyclustered_perlayer_EE_zplus,
   _energyclustered_perlayer_FH_zplus,
-  _energyclustered_perlayer_BH_zplus,
-  # Efficiency Plots
-  _efficiencies_zplus,
-  _efficiencies_zplus_eta,
-  _efficiencies_zplus_phi,
-  # Duplicate Plots
-  _duplicates_zplus,
-  _duplicates_zplus_eta,
-  _duplicates_zplus_phi,
-  # Fake Rate Plots
-  _fakes_zplus,
-  _fakes_zplus_eta,
-  _fakes_zplus_phi,
-  # Merge Rate Plots
-  _merges_zplus,
-  _merges_zplus_eta,
-  _merges_zplus_phi  
+  _energyclustered_perlayer_BH_zplus
 ]
 
 lc_cellevel_zplus = [
@@ -2178,6 +2160,22 @@ lc_cellevel_zplus = [
 ]
 
 lc_cp_association_zplus = [
+  # Efficiency Plots
+  _efficiencies_zplus,
+  _efficiencies_zplus_eta,
+  _efficiencies_zplus_phi,
+  # Duplicate Plots
+  _duplicates_zplus,
+  _duplicates_zplus_eta,
+  _duplicates_zplus_phi,
+  # Fake Rate Plots
+  _fakes_zplus,
+  _fakes_zplus_eta,
+  _fakes_zplus_phi,
+  # Merge Rate Plots
+  _merges_zplus,
+  _merges_zplus_eta,
+  _merges_zplus_phi,  
   # Score of CaloParticles wrt Layer Clusters
   _score_caloparticle_to_layerclusters_zplus,
   # Score of LayerClusters wrt CaloParticles
@@ -2281,12 +2279,12 @@ def append_hgcalLayerClustersPlots(collection = "hgcalLayerClusters", name_colle
   plots_lc_cp_association_zplus  = lc_cp_association_zplus
 
   if extended :
-    plots_lc_clusterlevel_zminus   = lc_clusterlevel_zminus + lc_zminus_extended
-    plots_lc_clusterlevel_zplus    = lc_clusterlevel_zplus + lc_zplus_extended
+    #plots_lc_clusterlevel_zminus   = lc_clusterlevel_zminus 
+    #plots_lc_clusterlevel_zplus    = lc_clusterlevel_zplus 
     plots_lc_cellevel_zminus       = lc_cellevel_zminus + lc_zminus_extended
     plots_lc_cellevel_zplus        = lc_cellevel_zplus + lc_zplus_extended
-    plots_lc_cp_association_zminus = lc_cp_association_zminus + lc_zminus_extended
-    plots_lc_cp_association_zplus  = lc_cp_association_zplus + lc_zplus_extended
+    #plots_lc_cp_association_zminus = lc_cp_association_zminus 
+    #plots_lc_cp_association_zplus  = lc_cp_association_zplus 
 
   setPlots_ClusterLevel       = [plots_lc_general_clusterlevel, plots_lc_clusterlevel_zminus, plots_lc_clusterlevel_zplus]
   setPlots_CellLevel          = [plots_lc_cellevel_zminus, plots_lc_cellevel_zplus]

--- a/Validation/HGCalValidation/python/hgcalPlots.py
+++ b/Validation/HGCalValidation/python/hgcalPlots.py
@@ -1970,10 +1970,7 @@ _PhotonsFromMultiCl_Closest_EoverCPenergy = PlotGroup("PhotonsFromMultiCl", [
 hgcalLayerClustersPlotter = Plotter()
 layerClustersLabel = 'Layer Clusters'
 
-lc_general = [
-  # calculated "energy density" for cells in a) 120um, b) 200um, c) 300um, d) scint
-  # (one entry per rechit, in the appropriate histo)
-  _cellsenedens_thick,
+lc_general_clusterlevel = [
   # number of layer clusters per event in a) 120um, b) 200um, c) 300um, d) scint
   # (one entry per event in each of the four histos)
   _totclusternum_thick,
@@ -1985,14 +1982,49 @@ lc_general = [
   _energyclustered,
   _mixedhitsclusters,
   _longdepthbarycentre,
+  # calculated "energy density" for cells in a) 120um, b) 200um, c) 300um, d) scint
+  # (one entry per rechit, in the appropriate histo)
+  _cellsenedens_thick,
   # SelectedCaloParticles plots
-  _SelectedCaloParticles,
+  _SelectedCaloParticles
 ]
-lc_zminus = [
+
+"""
+lc_general_cellevel = [
+  # calculated "energy density" for cells in a) 120um, b) 200um, c) 300um, d) scint
+  # (one entry per rechit, in the appropriate histo)
+  _cellsenedens_thick
+]
+"""
+
+lc_clusterlevel_zminus = [
   # number of layer clusters per layer (one entry per event in each histo)
   _totclusternum_layer_EE_zminus,
   _totclusternum_layer_FH_zminus,
   _totclusternum_layer_BH_zminus,
+  # Looking at the fraction of true energy that has been clustered; by layer and overall
+  _energyclustered_perlayer_EE_zminus,
+  _energyclustered_perlayer_FH_zminus,
+  _energyclustered_perlayer_BH_zminus,
+  # Efficiency Plots
+  _efficiencies_zminus,
+  _efficiencies_zminus_eta,
+  _efficiencies_zminus_phi,
+  # Duplicate Plots
+  _duplicates_zminus,
+  _duplicates_zminus_eta,
+  _duplicates_zminus_phi,
+  # Fake Rate Plots
+  _fakes_zminus,
+  _fakes_zminus_eta,
+  _fakes_zminus_phi,
+  # Merge Rate Plots
+  _merges_zminus,
+  _merges_zminus_eta,
+  _merges_zminus_phi
+]
+
+lc_cellevel_zminus = [
   # For each layer cluster:
   # number of cells in layer cluster, by layer - separate histos in each layer for 120um Si, 200/300um Si, Scint
   # NB: not all combinations exist; e.g. no 120um Si in layers with scint.
@@ -2009,10 +2041,11 @@ lc_zminus = [
   _cellsnum_perthick_perlayer_scint_EE_zminus,
   _cellsnum_perthick_perlayer_scint_FH_zminus,
   _cellsnum_perthick_perlayer_scint_BH_zminus,
-  # Looking at the fraction of true energy that has been clustered; by layer and overall
-  _energyclustered_perlayer_EE_zminus,
-  _energyclustered_perlayer_FH_zminus,
-  _energyclustered_perlayer_BH_zminus,
+  # Cell Association per Layer
+  _cell_association_table_zminus
+]
+
+lc_cp_association_zminus = [
   # Score of CaloParticles wrt Layer Clusters
   _score_caloparticle_to_layerclusters_zminus,
   # Score of LayerClusters wrt CaloParticles
@@ -2021,29 +2054,12 @@ lc_zminus = [
   _sharedEnergy_caloparticle_to_layercluster_zminus,
   # Shared Energy between LayerClusters and CaloParticle
   _sharedEnergy_layercluster_to_caloparticle_zminus,
-  # Cell Association per Layer
-  _cell_association_table_zminus,
-  # Efficiency Plots
-  _efficiencies_zminus,
-  _efficiencies_zminus_eta,
-  _efficiencies_zminus_phi,
-  # Duplicate Plots
-  _duplicates_zminus,
-  _duplicates_zminus_eta,
-  _duplicates_zminus_phi,
-  # Fake Rate Plots
-  _fakes_zminus,
-  _fakes_zminus_eta,
-  _fakes_zminus_phi,
-  # Merge Rate Plots
-  _merges_zminus,
-  _merges_zminus_eta,
-  _merges_zminus_phi,
   # Energy vs Score 2D plots CP to LC
   _energyscore_cp2lc_zminus,
   # Energy vs Score 2D plots LC to CP
   _energyscore_lc2cp_zminus
 ]
+
 lc_zminus_extended = [
   # For each layer cluster:
   # distance of cells from a) seed cell, b) max cell; and c), d): same with entries weighted by cell energy
@@ -2121,40 +2137,18 @@ lc_zminus_extended = [
   _distancebetseedandmaxcellvsclusterenergy_perthickperlayer_300_BH_zminus,
   _distancebetseedandmaxcellvsclusterenergy_perthickperlayer_scint_EE_zminus,
   _distancebetseedandmaxcellvsclusterenergy_perthickperlayer_scint_FH_zminus,
-  _distancebetseedandmaxcellvsclusterenergy_perthickperlayer_scint_BH_zminus,
+  _distancebetseedandmaxcellvsclusterenergy_perthickperlayer_scint_BH_zminus
 ]
-lc_zplus = [
+
+lc_clusterlevel_zplus = [
   # number of layer clusters per layer (one entry per event in each histo)
   _totclusternum_layer_EE_zplus,
   _totclusternum_layer_FH_zplus,
   _totclusternum_layer_BH_zplus,
-  # number of cells in layer cluster, by layer - separate histos in each layer for 120um Si, 200/300um Si, Scint
-  _cellsnum_perthick_perlayer_120_EE_zplus,
-  _cellsnum_perthick_perlayer_120_FH_zplus,
-  _cellsnum_perthick_perlayer_120_BH_zplus,
-  _cellsnum_perthick_perlayer_200_EE_zplus,
-  _cellsnum_perthick_perlayer_200_FH_zplus,
-  _cellsnum_perthick_perlayer_200_BH_zplus,
-  _cellsnum_perthick_perlayer_300_EE_zplus,
-  _cellsnum_perthick_perlayer_300_FH_zplus,
-  _cellsnum_perthick_perlayer_300_BH_zplus,
-  _cellsnum_perthick_perlayer_scint_EE_zplus,
-  _cellsnum_perthick_perlayer_scint_FH_zplus,
-  _cellsnum_perthick_perlayer_scint_BH_zplus,
   # Looking at the fraction of true energy that has been clustered; by layer and overall
   _energyclustered_perlayer_EE_zplus,
   _energyclustered_perlayer_FH_zplus,
   _energyclustered_perlayer_BH_zplus,
-  # Score of CaloParticles wrt Layer Clusters
-  _score_caloparticle_to_layerclusters_zplus,
-  # Score of LayerClusters wrt CaloParticles
-  _score_layercluster_to_caloparticles_zplus,
-  # Shared Energy between CaloParticle and LayerClusters
-  _sharedEnergy_caloparticle_to_layercluster_zplus,
-  # Shared Energy between LayerClusters and CaloParticle
-  _sharedEnergy_layercluster_to_caloparticle_zplus,
-  # Cell Association per Layer
-  _cell_association_table_zplus,
   # Efficiency Plots
   _efficiencies_zplus,
   _efficiencies_zplus_eta,
@@ -2170,10 +2164,40 @@ lc_zplus = [
   # Merge Rate Plots
   _merges_zplus,
   _merges_zplus_eta,
-  _merges_zplus_phi,
+  _merges_zplus_phi  
+]
+
+lc_cellevel_zplus = [
+  # number of cells in layer cluster, by layer - separate histos in each layer for 120um Si, 200/300um Si, Scint
+  _cellsnum_perthick_perlayer_120_EE_zplus,
+  _cellsnum_perthick_perlayer_120_FH_zplus,
+  _cellsnum_perthick_perlayer_120_BH_zplus,
+  _cellsnum_perthick_perlayer_200_EE_zplus,
+  _cellsnum_perthick_perlayer_200_FH_zplus,
+  _cellsnum_perthick_perlayer_200_BH_zplus,
+  _cellsnum_perthick_perlayer_300_EE_zplus,
+  _cellsnum_perthick_perlayer_300_FH_zplus,
+  _cellsnum_perthick_perlayer_300_BH_zplus,
+  _cellsnum_perthick_perlayer_scint_EE_zplus,
+  _cellsnum_perthick_perlayer_scint_FH_zplus,
+  _cellsnum_perthick_perlayer_scint_BH_zplus,
+  # Cell Association per Layer
+  _cell_association_table_zplus
+]
+
+lc_cp_association_zplus = [
+  # Score of CaloParticles wrt Layer Clusters
+  _score_caloparticle_to_layerclusters_zplus,
+  # Score of LayerClusters wrt CaloParticles
+  _score_layercluster_to_caloparticles_zplus,
+  # Shared Energy between CaloParticle and LayerClusters
+  _sharedEnergy_caloparticle_to_layercluster_zplus,
+  # Shared Energy between LayerClusters and CaloParticle
+  _sharedEnergy_layercluster_to_caloparticle_zplus,
   _energyscore_cp2lc_zplus,
   _energyscore_lc2cp_zplus
 ]
+
 lc_zplus_extended = [
   # distance of cells from a) seed cell, b) max cell; and c), d): same with entries weighted by cell energy
   _distancetomaxcell_perthickperlayer_120_EE_zplus,
@@ -2247,22 +2271,52 @@ lc_zplus_extended = [
   _distancebetseedandmaxcellvsclusterenergy_perthickperlayer_300_BH_zplus,
   _distancebetseedandmaxcellvsclusterenergy_perthickperlayer_scint_EE_zplus,
   _distancebetseedandmaxcellvsclusterenergy_perthickperlayer_scint_FH_zplus,
-  _distancebetseedandmaxcellvsclusterenergy_perthickperlayer_scint_BH_zplus,
+  _distancebetseedandmaxcellvsclusterenergy_perthickperlayer_scint_BH_zplus
 ]
 
 def append_hgcalLayerClustersPlots(collection = "hgcalLayerClusters", name_collection = layerClustersLabel, extended = False):
   print('extended : ',extended)
-  regions = ["General", "zminus", "zplus"]
-  plots_lc_zminus  = lc_zminus
-  plots_lc_zplus   = lc_zplus 
-  plots_lc_general = lc_general
+  regions_ClusterLevel       = ["General: Cluster Level", "Z-minus: Cluster Level", "Z-plus: Cluster Level"]
+  regions_CellLevel          = ["Z-minus: Cell Level", "Z-plus: Cell Level"]
+  regions_LCtoCP_association = ["Z-minus: LC_CP association", "Z-plus: LC_CP association"]
+  
+  plots_lc_general_clusterlevel  = lc_general_clusterlevel
+  #plots_lc_general_cellevel      = lc_general_cellevel
+  plots_lc_clusterlevel_zminus   = lc_clusterlevel_zminus 
+  plots_lc_cellevel_zminus       = lc_cellevel_zminus 
+  plots_lc_clusterlevel_zplus    = lc_clusterlevel_zplus
+  plots_lc_cellevel_zplus        = lc_cellevel_zplus
+  plots_lc_cp_association_zminus = lc_cp_association_zminus
+  plots_lc_cp_association_zplus  = lc_cp_association_zplus
+
   if extended :
-    plots_lc_zminus = lc_zminus + lc_zminus_extended
-    plots_lc_zplus = lc_zplus + lc_zplus_extended
-  setPlots = [plots_lc_general, plots_lc_zminus, plots_lc_zplus]
-  for reg, setPlot in zip(regions, setPlots):
+    plots_lc_clusterlevel_zminus   = lc_clusterlevel_zminus + lc_zminus_extended
+    plots_lc_clusterlevel_zplus    = lc_clusterlevel_zplus + lc_zplus_extended
+    plots_lc_cellevel_zminus       = lc_cellevel_zminus + lc_zminus_extended
+    plots_lc_cellevel_zplus        = lc_cellevel_zplus + lc_zplus_extended
+    plots_lc_cp_association_zminus = lc_cp_association_zminus + lc_zminus_extended
+    plots_lc_cp_association_zplus  = lc_cp_association_zplus + lc_zplus_extended
+
+  setPlots_ClusterLevel       = [plots_lc_general_clusterlevel, plots_lc_clusterlevel_zminus, plots_lc_clusterlevel_zplus]
+  setPlots_CellLevel          = [plots_lc_cellevel_zminus, plots_lc_cellevel_zplus]
+  setPlots_LCtoCP_association = [plots_lc_cp_association_zminus, plots_lc_cp_association_zplus]
+  for reg, setPlot in zip(regions_ClusterLevel, setPlots_ClusterLevel):
     hgcalLayerClustersPlotter.append(collection+"_"+reg, [
-                _hgcalFolders(collection)
+                _hgcalFolders(collection + "/ClusterLevel")
+                ], PlotFolder(
+                *setPlot,
+                loopSubFolders=False,
+                purpose=PlotPurpose.Timing, page=layerClustersLabel, section=reg))
+  for reg, setPlot in zip(regions_CellLevel, setPlots_CellLevel):
+    hgcalLayerClustersPlotter.append(collection+"_"+reg, [
+                _hgcalFolders(collection + "/CellLevel")
+                ], PlotFolder(
+                *setPlot,
+                loopSubFolders=False,
+                purpose=PlotPurpose.Timing, page=layerClustersLabel, section=reg))
+  for reg, setPlot in zip(regions_LCtoCP_association, setPlots_LCtoCP_association):
+    hgcalLayerClustersPlotter.append(collection+"_"+reg, [
+                _hgcalFolders(collection + "/LCtoCP_association")
                 ], PlotFolder(
                 *setPlot,
                 loopSubFolders=False,

--- a/Validation/HGCalValidation/python/hgcalPlots.py
+++ b/Validation/HGCalValidation/python/hgcalPlots.py
@@ -1989,14 +1989,6 @@ lc_general_clusterlevel = [
   _SelectedCaloParticles
 ]
 
-"""
-lc_general_cellevel = [
-  # calculated "energy density" for cells in a) 120um, b) 200um, c) 300um, d) scint
-  # (one entry per rechit, in the appropriate histo)
-  _cellsenedens_thick
-]
-"""
-
 lc_clusterlevel_zminus = [
   # number of layer clusters per layer (one entry per event in each histo)
   _totclusternum_layer_EE_zminus,
@@ -2281,7 +2273,6 @@ def append_hgcalLayerClustersPlots(collection = "hgcalLayerClusters", name_colle
   regions_LCtoCP_association = ["Z-minus: LC_CP association", "Z-plus: LC_CP association"]
   
   plots_lc_general_clusterlevel  = lc_general_clusterlevel
-  #plots_lc_general_cellevel      = lc_general_cellevel
   plots_lc_clusterlevel_zminus   = lc_clusterlevel_zminus 
   plots_lc_cellevel_zminus       = lc_cellevel_zminus 
   plots_lc_clusterlevel_zplus    = lc_clusterlevel_zplus

--- a/Validation/HGCalValidation/src/HGVHistoProducerAlgo.cc
+++ b/Validation/HGCalValidation/src/HGVHistoProducerAlgo.cc
@@ -689,8 +689,8 @@ void HGVHistoProducerAlgo::bookClusterHistos_ClusterLevel(DQMStore::IBooker& ibo
 }
 
 void HGVHistoProducerAlgo::bookClusterHistos_LCtoCP_association(DQMStore::IBooker& ibook,
-                                                                      Histograms& histograms,
-                                                                      unsigned int layers) {
+                                                                Histograms& histograms,
+                                                                unsigned int layers) {
   //----------------------------------------------------------------------------------------------------------------------------
   for (unsigned ilayer = 0; ilayer < 2 * layers; ++ilayer) {
     auto istr1 = std::to_string(ilayer);
@@ -858,7 +858,7 @@ void HGVHistoProducerAlgo::bookClusterHistos_LCtoCP_association(DQMStore::IBooke
 void HGVHistoProducerAlgo::bookClusterHistos_CellLevel(DQMStore::IBooker& ibook,
                                                        Histograms& histograms,
                                                        unsigned int layers,
-                                                       std::vector<int> thicknesses){
+                                                       std::vector<int> thicknesses) {
   //----------------------------------------------------------------------------------------------------------------------------
   for (unsigned ilayer = 0; ilayer < 2 * layers; ++ilayer) {
     auto istr1 = std::to_string(ilayer);
@@ -960,7 +960,6 @@ void HGVHistoProducerAlgo::bookClusterHistos_CellLevel(DQMStore::IBooker& ibook,
           maxClEneperthickperlayer_);
     }
   }
-
 }
 //----------------------------------------------------------------------------------------------------------------------------
 

--- a/Validation/HGCalValidation/src/HGVHistoProducerAlgo.cc
+++ b/Validation/HGCalValidation/src/HGVHistoProducerAlgo.cc
@@ -674,6 +674,38 @@ void HGVHistoProducerAlgo::bookClusterHistos(DQMStore::IBooker& ibook,
                      nintEneClperlay_,
                      minEneClperlay_,
                      maxEneClperlay_);
+  }
+
+  //---------------------------------------------------------------------------------------------------------------------------
+  for (std::vector<int>::iterator it = thicknesses.begin(); it != thicknesses.end(); ++it) {
+    auto istr = std::to_string(*it);
+    histograms.h_clusternum_perthick[(*it)] = ibook.book1D("totclusternum_thick_" + istr,
+                                                           "total number of layer clusters for thickness " + istr,
+                                                           nintTotNClsperthick_,
+                                                           minTotNClsperthick_,
+                                                           maxTotNClsperthick_);
+  }
+  //---------------------------------------------------------------------------------------------------------------------------
+}
+
+void HGVHistoProducerAlgo::bookClusterHistos_LCtoCP_association(DQMStore::IBooker& ibook,
+                                                                Histograms& histograms,
+                                                                unsigned int layers,
+                                                                std::vector<int> thicknesses){
+  //----------------------------------------------------------------------------------------------------------------------------
+  for (unsigned ilayer = 0; ilayer < 2 * layers; ++ilayer) {
+    auto istr1 = std::to_string(ilayer);
+    while (istr1.size() < 2) {
+      istr1.insert(0, "0");
+    }
+    //We will make a mapping to the regural layer naming plus z- or z+ for convenience
+    std::string istr2 = "";
+    //First with the -z endcap
+    if (ilayer < layers) {
+      istr2 = std::to_string(ilayer + 1) + " in z-";
+    } else {  //Then for the +z
+      istr2 = std::to_string(ilayer - (layers - 1)) + " in z+";
+    }
     histograms.h_score_layercl2caloparticle_perlayer[ilayer] =
         ibook.book1D("Score_layercl2caloparticle_perlayer" + istr1,
                      "Score of Layer Cluster per CaloParticle for layer " + istr2,
@@ -766,6 +798,12 @@ void HGVHistoProducerAlgo::bookClusterHistos(DQMStore::IBooker& ibook,
                      nintEta_,
                      minEta_,
                      maxEta_);
+    histograms.h_denom_caloparticle_eta_perlayer[ilayer] =
+        ibook.book1D("Denom_CaloParticle_Eta_perlayer" + istr1,
+                     "Denom CaloParticle Eta per Layer Cluster for layer " + istr2,
+                     nintEta_,
+                     minEta_,
+                     maxEta_);
     histograms.h_num_caloparticle_phi_perlayer[ilayer] =
         ibook.book1D("Num_CaloParticle_Phi_perlayer" + istr1,
                      "Num CaloParticle Phi per Layer Cluster for layer " + istr2,
@@ -820,6 +858,28 @@ void HGVHistoProducerAlgo::bookClusterHistos(DQMStore::IBooker& ibook,
                      nintPhi_,
                      minPhi_,
                      maxPhi_);
+  }
+  //---------------------------------------------------------------------------------------------------------------------------
+}
+
+void HGVHistoProducerAlgo::bookClusterHistos_CellLevel(DQMStore::IBooker& ibook,
+                                                       Histograms& histograms,
+                                                       unsigned int layers,
+                                                       std::vector<int> thicknesses){
+  //----------------------------------------------------------------------------------------------------------------------------
+  for (unsigned ilayer = 0; ilayer < 2 * layers; ++ilayer) {
+    auto istr1 = std::to_string(ilayer);
+    while (istr1.size() < 2) {
+      istr1.insert(0, "0");
+    }
+    //We will make a mapping to the regural layer naming plus z- or z+ for convenience
+    std::string istr2 = "";
+    //First with the -z endcap
+    if (ilayer < layers) {
+      istr2 = std::to_string(ilayer + 1) + " in z-";
+    } else {  //Then for the +z
+      istr2 = std::to_string(ilayer - (layers - 1)) + " in z+";
+    }
     histograms.h_cellAssociation_perlayer[ilayer] =
         ibook.book1D("cellAssociation_perlayer" + istr1, "Cell Association for layer " + istr2, 5, -4., 1.);
     histograms.h_cellAssociation_perlayer[ilayer]->setBinLabel(2, "TN(purity)");
@@ -827,24 +887,16 @@ void HGVHistoProducerAlgo::bookClusterHistos(DQMStore::IBooker& ibook,
     histograms.h_cellAssociation_perlayer[ilayer]->setBinLabel(4, "FP(fake)");
     histograms.h_cellAssociation_perlayer[ilayer]->setBinLabel(5, "TP(eff.)");
   }
-
-  //---------------------------------------------------------------------------------------------------------------------------
+  //----------------------------------------------------------------------------------------------------------------------------
   for (std::vector<int>::iterator it = thicknesses.begin(); it != thicknesses.end(); ++it) {
     auto istr = std::to_string(*it);
-    histograms.h_clusternum_perthick[(*it)] = ibook.book1D("totclusternum_thick_" + istr,
-                                                           "total number of layer clusters for thickness " + istr,
-                                                           nintTotNClsperthick_,
-                                                           minTotNClsperthick_,
-                                                           maxTotNClsperthick_);
-    //---
     histograms.h_cellsenedens_perthick[(*it)] = ibook.book1D("cellsenedens_thick_" + istr,
                                                              "energy density of cluster cells for thickness " + istr,
                                                              nintCellsEneDensperthick_,
                                                              minCellsEneDensperthick_,
                                                              maxCellsEneDensperthick_);
   }
-
-  //---------------------------------------------------------------------------------------------------------------------------
+  //----------------------------------------------------------------------------------------------------------------------------
   //Not all combination exists but we should keep them all for cross checking reason.
   for (std::vector<int>::iterator it = thicknesses.begin(); it != thicknesses.end(); ++it) {
     for (unsigned ilayer = 0; ilayer < 2 * layers; ++ilayer) {
@@ -915,8 +967,9 @@ void HGVHistoProducerAlgo::bookClusterHistos(DQMStore::IBooker& ibook,
           maxClEneperthickperlayer_);
     }
   }
-  //---------------------------------------------------------------------------------------------------------------------------
+
 }
+//----------------------------------------------------------------------------------------------------------------------------
 
 void HGVHistoProducerAlgo::bookMultiClusterHistos(DQMStore::IBooker& ibook,
                                                   Histograms& histograms,

--- a/Validation/HGCalValidation/src/HGVHistoProducerAlgo.cc
+++ b/Validation/HGCalValidation/src/HGVHistoProducerAlgo.cc
@@ -591,11 +591,11 @@ void HGVHistoProducerAlgo::bookSimClusterAssociationHistos(DQMStore::IBooker& ib
   histograms.h_sharedenergy_simcluster2layercl_vs_phi_perlayer.push_back(
       std::move(sharedenergy_simcluster2layercl_vs_phi_perlayer));
 }
-void HGVHistoProducerAlgo::bookClusterHistos(DQMStore::IBooker& ibook,
-                                             Histograms& histograms,
-                                             unsigned int layers,
-                                             std::vector<int> thicknesses,
-                                             std::string pathtomatbudfile) {
+void HGVHistoProducerAlgo::bookClusterHistos_ClusterLevel(DQMStore::IBooker& ibook,
+                                                          Histograms& histograms,
+                                                          unsigned int layers,
+                                                          std::vector<int> thicknesses,
+                                                          std::string pathtomatbudfile) {
   //---------------------------------------------------------------------------------------------------------------------------
   histograms.h_cluster_eta.push_back(
       ibook.book1D("num_reco_cluster_eta", "N of reco clusters vs eta", nintEta_, minEta_, maxEta_));
@@ -689,9 +689,9 @@ void HGVHistoProducerAlgo::bookClusterHistos(DQMStore::IBooker& ibook,
 }
 
 void HGVHistoProducerAlgo::bookClusterHistos_LCtoCP_association(DQMStore::IBooker& ibook,
-                                                                Histograms& histograms,
-                                                                unsigned int layers,
-                                                                std::vector<int> thicknesses){
+                                                                      Histograms& histograms,
+                                                                      unsigned int layers,
+                                                                      std::vector<int> thicknesses) {
   //----------------------------------------------------------------------------------------------------------------------------
   for (unsigned ilayer = 0; ilayer < 2 * layers; ++ilayer) {
     auto istr1 = std::to_string(ilayer);
@@ -789,12 +789,6 @@ void HGVHistoProducerAlgo::bookClusterHistos_LCtoCP_association(DQMStore::IBooke
     histograms.h_numDup_caloparticle_eta_perlayer[ilayer] =
         ibook.book1D("NumDup_CaloParticle_Eta_perlayer" + istr1,
                      "Num Duplicate CaloParticle Eta per Layer Cluster for layer " + istr2,
-                     nintEta_,
-                     minEta_,
-                     maxEta_);
-    histograms.h_denom_caloparticle_eta_perlayer[ilayer] =
-        ibook.book1D("Denom_CaloParticle_Eta_perlayer" + istr1,
-                     "Denom CaloParticle Eta per Layer Cluster for layer " + istr2,
                      nintEta_,
                      minEta_,
                      maxEta_);

--- a/Validation/HGCalValidation/src/HGVHistoProducerAlgo.cc
+++ b/Validation/HGCalValidation/src/HGVHistoProducerAlgo.cc
@@ -690,8 +690,7 @@ void HGVHistoProducerAlgo::bookClusterHistos_ClusterLevel(DQMStore::IBooker& ibo
 
 void HGVHistoProducerAlgo::bookClusterHistos_LCtoCP_association(DQMStore::IBooker& ibook,
                                                                       Histograms& histograms,
-                                                                      unsigned int layers,
-                                                                      std::vector<int> thicknesses) {
+                                                                      unsigned int layers) {
   //----------------------------------------------------------------------------------------------------------------------------
   for (unsigned ilayer = 0; ilayer < 2 * layers; ++ilayer) {
     auto istr1 = std::to_string(ilayer);


### PR DESCRIPTION
#### PR description:

The plots in the plots folder contain layer cluster plots that cannot be load or viewed in DQM GUI due to the enormous number of plots in a single layer cluster plot folder. We reorganized the layer cluster folder into subfolders so that we can check the relevant plots in DQM GUI but also have a nicer structure of the output plots.

We expect there is no change in DQM files neither in size or memory as no new histograms are created or deleted.

#### PR validation:

We have check with a ttbar workflow and plots are visible. Here is our website testing result
https://xisu.web.cern.ch/xisu/HGCValid_hgcalLayerClusters_Plots/

@apsallid  @rovere @felicepantaleo @ebrondol @lecriste 

