### PR TITLE
warn when no data is available for CalibTracker/SiStripChannelGain unit test

### DIFF
--- a/CalibTracker/SiStripChannelGain/test/testSSTGain_PCL_FromRECO_cfg.py
+++ b/CalibTracker/SiStripChannelGain/test/testSSTGain_PCL_FromRECO_cfg.py
@@ -1,6 +1,7 @@
 from __future__ import print_function
 # Auto generated configuration file
 # with command line options: stepALCA --datatier ALCARECO --conditions auto:run2_data -s ALCA:PromptCalibProdSiStripGains --eventcontent ALCARECO -n 1000 --dasquery=file dataset=/ZeroBias/Run2016C-SiStripCalMinBias-18Apr2017-v1/ALCARECO run=276243 --no_exec
+import warnings
 import FWCore.ParameterSet.Config as cms
 from FWCore.ParameterSet.VarParsing import VarParsing
 
@@ -22,7 +23,7 @@ def getFileNames_das_client(era_name):
     jsondict = das_client.get_data(query)
     status = jsondict['status']
     if status != 'ok':
-        print("DAS query status: %s"%(status))
+        warnings.warn("DAS query status: %s"%(status))
         return files
 
     data =  jsondict['data']
@@ -36,7 +37,7 @@ def getFileNames_das_client(era_name):
     jsondict = das_client.get_data(query)
     status = jsondict['status']
     if status != 'ok':
-        print("DAS query status: %s"%(status))
+        warnings.warn("DAS query status: %s"%(status))
         return files
 
     mongo_query = jsondict['mongo_query']
@@ -89,8 +90,9 @@ process.maxEvents = cms.untracked.PSet(
 INPUTFILES=getFileNames_das_client(options.era)
 
 if len(INPUTFILES)==0: 
-    print("** WARNING: ** According to a DAS query no suitable data for test is available. Skipping test")
-    os._exit(0)
+    warnings.warn("** WARNING: ** According to a DAS query no suitable data for test is available. Skipping test!")
+    ### since there are tests depending on this one, if the query fails, let's exit with an error
+    os._exit(1)
 
 myFiles = cms.untracked.vstring()
 myFiles.extend([INPUTFILES[0][0].replace("\"","")])


### PR DESCRIPTION
fixes https://github.com/cms-sw/cmssw/issues/33055

#### PR description:

As pointed out in https://github.com/cms-sw/cmssw/issues/33055#issuecomment-789928341 when the first `cmsRun` instance of  `testSSTGainPCL_fromRECO`

https://github.com/cms-sw/cmssw/blob/837e8e8ffe2363c63e40f761907fc50508ecf79a/CalibTracker/SiStripChannelGain/test/testSSTGain_PCL_FromRECO.sh#L4

 (silently) failed because of lack of suitable input data coming from the dedicate DAS query, the subsequent harvesting step `cmsRun`

https://github.com/cms-sw/cmssw/blob/837e8e8ffe2363c63e40f761907fc50508ecf79a/CalibTracker/SiStripChannelGain/test/testSSTGain_PCL_FromRECO.sh#L6

might fail with somewhat confusing errors about a missing (local) file, see https://github.com/cms-sw/cmssw/issues/33055#issue-821218552.
By using a python `warning` it should be now clear from the logs that the initial DAS query failed.

#### PR validation:

Run the unit tests in a local check-out area, by using `scramv1 b runtests` - **without having set valid GRID credentials** (to force the test to fail) and got back:

```bash
cmsRun:26: UserWarning: DAS query status: error
cmsRun:93: UserWarning: ** WARNING: ** According to a DAS query no suitable data for test is available. Skipping test
Failure running cmsRun testSSTGain_PCL_FromRECO_cfg.py era=A: status 1
status = 256

---> test testSSTGainPCL_fromRECO had ERRORS
```

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Not a backport, no backport needed.