### PR TITLE
FileInPath: replace boost::filesystem by std::filesystem 

### DIFF
--- a/DQMServices/Components/src/fillJson.cc
+++ b/DQMServices/Components/src/fillJson.cc
@@ -13,11 +13,11 @@
 // system include files
 #include <boost/property_tree/json_parser.hpp>
 #include <boost/property_tree/ptree.hpp>
-#include <boost/filesystem.hpp>
 #include <boost/format.hpp>
 
 #include <string>
 #include <sstream>
+#include <filesystem>
 
 // user include files
 #include "FWCore/ServiceRegistry/interface/Service.h"
@@ -33,7 +33,6 @@ boost::property_tree::ptree dqmfilesaver::fillJson(int run,
                                                    const std::string& mergeTypeStr,
                                                    evf::FastMonitoringService* fms) {
   namespace bpt = boost::property_tree;
-  namespace bfs = boost::filesystem;
 
   bpt::ptree pt;
 
@@ -57,7 +56,7 @@ boost::property_tree::ptree dqmfilesaver::fillJson(int run,
     if (stat(dataFilePathName.c_str(), &dataFileStat) != 0)
       throw cms::Exception("fillJson") << "Internal error, cannot get data file: " << dataFilePathName;
     // Extract only the data file name from the full path
-    dataFileName = bfs::path(dataFilePathName).filename().string();
+    dataFileName = std::filesystem::path(dataFilePathName).filename().string();
   }
   // The availability test of the FastMonitoringService was done in the ctor.
   bpt::ptree data;
@@ -95,7 +94,7 @@ boost::property_tree::ptree dqmfilesaver::fillJson(int run,
     pt.put("definition", "/fakeDefinition.jsn");
   } else {
     // The availability test of the EvFDaqDirector Service was done in the ctor.
-    bfs::path outJsonDefName{
+    std::filesystem::path outJsonDefName{
         edm::Service<evf::EvFDaqDirector>()->baseRunDir()};  //we assume this file is written bu the EvF Output module
     outJsonDefName /= (std::string("output_") + oss_pid.str() + std::string(".jsd"));
     pt.put("definition", outJsonDefName.string());

--- a/FWCore/Catalog/test/FileLocator_t.cpp
+++ b/FWCore/Catalog/test/FileLocator_t.cpp
@@ -2,7 +2,7 @@
 #include "FWCore/Catalog/interface/SiteLocalConfig.h"
 #include "FWCore/Utilities/interface/Exception.h"
 #include "FWCore/ServiceRegistry/interface/ServiceRegistry.h"
-#include <boost/filesystem.hpp>
+#include <filesystem>
 
 #include <string>
 
@@ -46,7 +46,7 @@ TEST_CASE("FileLocator", "[filelocator]") {
   std::string CMSSW_BASE(std::getenv("CMSSW_BASE"));
   std::string CMSSW_RELEASE_BASE(std::getenv("CMSSW_RELEASE_BASE"));
   std::string file_name("/src/FWCore/Catalog/test/simple_catalog.xml");
-  std::string full_file_name = boost::filesystem::exists((CMSSW_BASE + file_name).c_str())
+  std::string full_file_name = std::filesystem::exists((CMSSW_BASE + file_name).c_str())
                                    ? CMSSW_BASE + file_name
                                    : CMSSW_RELEASE_BASE + file_name;
 
@@ -84,7 +84,7 @@ TEST_CASE("FileLocator", "[filelocator]") {
     edm::ServiceRegistry::Operate operate(tempToken);
 
     std::string override_file_name("/src/FWCore/Catalog/test/override_catalog.xml");
-    std::string override_full_file_name = boost::filesystem::exists((CMSSW_BASE + override_file_name).c_str())
+    std::string override_full_file_name = std::filesystem::exists((CMSSW_BASE + override_file_name).c_str())
                                               ? CMSSW_BASE + override_file_name
                                               : CMSSW_RELEASE_BASE + override_file_name;
 

--- a/FWCore/ParameterSet/BuildFile.xml
+++ b/FWCore/ParameterSet/BuildFile.xml
@@ -4,7 +4,6 @@
 <use name="FWCore/Utilities"/>
 <use name="tbb"/>
 <use name="boost"/>
-<use name="boost_filesystem"/>
 <export>
   <lib name="1"/>
 </export>

--- a/FWCore/ParameterSet/bin/edmPluginHelp.cpp
+++ b/FWCore/ParameterSet/bin/edmPluginHelp.cpp
@@ -23,7 +23,6 @@
 #include "FWCore/PluginManager/interface/standard.h"
 #include "FWCore/Utilities/interface/Algorithms.h"
 
-#include <boost/filesystem/path.hpp>
 #include <boost/program_options.hpp>
 
 #include <vector>

--- a/FWCore/ParameterSet/bin/edmWriteConfigs.cpp
+++ b/FWCore/ParameterSet/bin/edmWriteConfigs.cpp
@@ -40,8 +40,6 @@
 #include "FWCore/PluginManager/interface/PluginFactoryManager.h"
 
 #include <boost/program_options.hpp>
-#include <boost/filesystem/path.hpp>
-#include <boost/filesystem/operations.hpp>
 
 #include <set>
 #include <string>

--- a/FWCore/ParameterSet/src/FileInPath.cc
+++ b/FWCore/ParameterSet/src/FileInPath.cc
@@ -376,7 +376,7 @@ namespace edm {
       // something goofy.
       if (locateFile(pathPrefix, relativePath_)) {
         // Convert relative path to canonical form, and save it.
-        relativePath_ = std::filesystem::weakly_canonical(std::filesystem::path(relativePath_)).string();
+        relativePath_ = std::filesystem::path(relativePath_).lexically_normal().string();
         //std::filesystem::path(relativePath_).normalize().string();
 
         // Save the absolute path.

--- a/FWCore/ParameterSet/src/FileInPath.cc
+++ b/FWCore/ParameterSet/src/FileInPath.cc
@@ -377,7 +377,7 @@ namespace edm {
       if (locateFile(pathPrefix, relativePath_)) {
         // Convert relative path to canonical form, and save it.
         relativePath_ = std::filesystem::weakly_canonical(std::filesystem::path(relativePath_)).string();
-							  //std::filesystem::path(relativePath_).normalize().string();
+        //std::filesystem::path(relativePath_).normalize().string();
 
         // Save the absolute path.
         canonicalFilename_ = std::filesystem::absolute(pathPrefix / relativePath_).string();
@@ -389,7 +389,9 @@ namespace edm {
 
         // From the current path element, find the branch path (basically the path minus the
         // last directory, e.g. /src or /share):
-        for (std::filesystem::path br = pathPrefix.parent_path(); !std::filesystem::weakly_canonical(br).string().empty(); br = br.parent_path()) {
+        for (std::filesystem::path br = pathPrefix.parent_path();
+             !std::filesystem::weakly_canonical(br).string().empty();
+             br = br.parent_path()) {
           if (!localTop_.empty()) {
             // Create a path object for our local path LOCALTOP:
             std::filesystem::path local_(localTop_);

--- a/FWCore/ParameterSet/src/FileInPath.cc
+++ b/FWCore/ParameterSet/src/FileInPath.cc
@@ -4,15 +4,13 @@
 #include <atomic>
 #include <cstdlib>
 #include <vector>
-#include "boost/filesystem/path.hpp"
-#include "boost/filesystem/operations.hpp"
+#include <cassert>
+#include <filesystem>
 
 #include "FWCore/ParameterSet/interface/FileInPath.h"
 #include "FWCore/Utilities/interface/EDMException.h"
 #include "FWCore/Utilities/interface/Parse.h"
 #include "FWCore/Utilities/interface/resolveSymbolicLinks.h"
-
-namespace bf = boost::filesystem;
 
 namespace {
 
@@ -83,17 +81,17 @@ namespace {
   // Return false is *nothing* is found
   // Throw an exception if either a directory or symbolic link is found.
   // If true is returned, then put the
-  bool locateFile(bf::path p, std::string const& relative) {
+  bool locateFile(std::filesystem::path p, std::string const& relative) {
     p /= relative;
 
-    if (!bf::exists(p))
+    if (!std::filesystem::exists(p))
       return false;
 
-    if (bf::is_directory(p)) {
+    if (std::filesystem::is_directory(p)) {
       throw edm::Exception(edm::errors::FileInPathError) << "Path " << p.string() << " is a directory, not a file\n";
     }
 
-    if (bf::is_symlink(bf::symlink_status(p))) {
+    if (std::filesystem::is_symlink(std::filesystem::symlink_status(p))) {
       throw edm::Exception(edm::errors::FileInPathError)
           << "Path " << p.string() << " is a symbolic link, not a file\n";
     }
@@ -372,16 +370,17 @@ namespace edm {
     for (auto const& element : pathElements) {
       // Set the boost::fs path to the current element of
       // CMSSW_SEARCH_PATH:
-      bf::path pathPrefix(element);
+      std::filesystem::path pathPrefix(element);
 
       // Does the a file exist? locateFile throws is it finds
       // something goofy.
       if (locateFile(pathPrefix, relativePath_)) {
         // Convert relative path to canonical form, and save it.
-        relativePath_ = bf::path(relativePath_).normalize().string();
+        relativePath_ = std::filesystem::weakly_canonical(std::filesystem::path(relativePath_)).string();
+							  //std::filesystem::path(relativePath_).normalize().string();
 
         // Save the absolute path.
-        canonicalFilename_ = bf::absolute(relativePath_, pathPrefix).string();
+        canonicalFilename_ = std::filesystem::absolute(pathPrefix / relativePath_).string();
         if (canonicalFilename_.empty()) {
           throw edm::Exception(edm::errors::FileInPathError)
               << "fullPath is empty"
@@ -390,10 +389,10 @@ namespace edm {
 
         // From the current path element, find the branch path (basically the path minus the
         // last directory, e.g. /src or /share):
-        for (bf::path br = pathPrefix.branch_path(); !br.normalize().string().empty(); br = br.branch_path()) {
+        for (std::filesystem::path br = pathPrefix.parent_path(); !std::filesystem::weakly_canonical(br).string().empty(); br = br.parent_path()) {
           if (!localTop_.empty()) {
             // Create a path object for our local path LOCALTOP:
-            bf::path local_(localTop_);
+            std::filesystem::path local_(localTop_);
             // If the branch path matches the local path, the file was found locally:
             if (br == local_) {
               location_ = Local;
@@ -403,7 +402,7 @@ namespace edm {
 
           if (!releaseTop_.empty()) {
             // Create a path object for our release path RELEASETOP:
-            bf::path release_(releaseTop_);
+            std::filesystem::path release_(releaseTop_);
             // If the branch path matches the release path, the file was found in the release:
             if (br == release_) {
               location_ = Release;
@@ -413,7 +412,7 @@ namespace edm {
 
           if (!dataTop_.empty()) {
             // Create a path object for our data path DATATOP:
-            bf::path data_(dataTop_);
+            std::filesystem::path data_(dataTop_);
             // If the branch path matches the data path, the file was found in the data area:
             if (br == data_) {
               location_ = Data;
@@ -430,7 +429,7 @@ namespace edm {
         << "edm::FileInPath unable to find file " << relativePath_ << " anywhere in the search path."
         << "\nThe search path is defined by: " << PathVariableName << "\n${" << PathVariableName
         << "} is: " << std::getenv(PathVariableName.c_str())
-        << "\nCurrent directory is: " << bf::initial_path().string() << "\n";
+        << "\nCurrent directory is: " << std::filesystem::current_path().string() << "\n";
   }
 
   void FileInPath::disableFileLookup() { s_fileLookupDisabled = true; }

--- a/FWCore/PyDevParameterSet/test/makepset_t.cppunit.cc
+++ b/FWCore/PyDevParameterSet/test/makepset_t.cppunit.cc
@@ -21,7 +21,7 @@
 #include <stdlib.h>  // for setenv; <cstdlib> is likely to fail
 #include <string>
 #include <unistd.h>
-#include <boost/filesystem.hpp>
+#include <filesystem>
 
 class testmakepset : public CppUnit::TestFixture {
   CPPUNIT_TEST_SUITE(testmakepset);
@@ -240,7 +240,7 @@ void testmakepset::fileinpathAux() {
       std::string const src("/src");
       std::string local = localBase + src;
       std::string localFile = local + "/Geometry/TrackerSimData/data/trackersens.xml";
-      if (!boost::filesystem::exists(localFile))
+      if (!std::filesystem::exists(localFile))
         CPPUNIT_ASSERT(topo.location() != edm::FileInPath::Local);
       else
         std::cerr << "Disabling test against local path for trackersens.xml as package is checked out in this test"

--- a/FWCore/PythonParameterSet/test/makepset_t.cppunit.cc
+++ b/FWCore/PythonParameterSet/test/makepset_t.cppunit.cc
@@ -21,7 +21,7 @@
 #include <stdlib.h>  // for setenv; <cstdlib> is likely to fail
 #include <string>
 #include <unistd.h>
-#include <boost/filesystem.hpp>
+#include <filesystem>
 
 class testmakepset : public CppUnit::TestFixture {
   CPPUNIT_TEST_SUITE(testmakepset);
@@ -240,7 +240,7 @@ void testmakepset::fileinpathAux() {
       std::string const src("/src");
       std::string local = localBase + src;
       std::string localFile = local + "/Geometry/TrackerSimData/data/trackersens.xml";
-      if (!boost::filesystem::exists(localFile))
+      if (!std::filesystem::exists(localFile))
         CPPUNIT_ASSERT(topo.location() != edm::FileInPath::Local);
       else
         std::cerr << "Disabling test against local path for trackersens.xml as package is checked out in this test"

--- a/GeneratorInterface/Herwig7Interface/src/Herwig7Interface.cc
+++ b/GeneratorInterface/Herwig7Interface/src/Herwig7Interface.cc
@@ -14,8 +14,6 @@
 
 #include <algorithm>
 
-#include <boost/filesystem.hpp>
-
 #include <HepMC/GenEvent.h>
 #include <HepMC/PdfInfo.h>
 #include <HepMC/IO_GenEvent.h>

--- a/GeneratorInterface/Pythia6Interface/src/Pythia6Service.cc
+++ b/GeneratorInterface/Pythia6Interface/src/Pythia6Service.cc
@@ -389,7 +389,6 @@ void Pythia6Service::setSLHAFromHeader(const std::vector<std::string>& lines) {
   write(fd, f_info.str().c_str(), f_info.str().size());
   close(fd);
 
-
   if (blocks.count("SMINPUTS"))
     pydat1_.paru[102 - 1] =
         0.5 - std::sqrt(0.25 - pydat1_.paru[0] * M_SQRT1_2 * pydat1_.paru[103 - 1] / pydat1_.paru[105 - 1] /

--- a/GeneratorInterface/Pythia6Interface/src/Pythia6Service.cc
+++ b/GeneratorInterface/Pythia6Interface/src/Pythia6Service.cc
@@ -10,7 +10,7 @@
 #include <boost/bind.hpp>
 #include <boost/algorithm/string/classification.hpp>
 #include <boost/algorithm/string/split.hpp>
-#include <boost/filesystem.hpp>
+#include <filesystem>
 
 #include "CLHEP/Random/RandomEngine.h"
 
@@ -324,13 +324,13 @@ void Pythia6Service::setPYUPDAParams(bool afterPyinit) {
 void Pythia6Service::setSLHAFromHeader(const std::vector<std::string>& lines) {
   std::set<std::string> blocks;
   unsigned int model = 0, subModel = 0;
+  char tempslhaname[] = "pythia6slhaXXXXXX";
+  int fd = mkstemp(tempslhaname);
 
-  std::string fnamest = boost::filesystem::unique_path().string();
-  const char* fname = fnamest.c_str();
-  std::ofstream file(fname, std::fstream::out | std::fstream::trunc);
   std::string block;
+  std::stringstream f_info;
   for (std::vector<std::string>::const_iterator iter = lines.begin(); iter != lines.end(); ++iter) {
-    file << *iter;
+    f_info << *iter;
 
     std::string line = *iter;
     std::transform(line.begin(), line.end(), line.begin(), (int (*)(int))std::toupper);
@@ -386,7 +386,9 @@ void Pythia6Service::setSLHAFromHeader(const std::vector<std::string>& lines) {
       }
     }
   }
-  file.close();
+  write(fd, f_info.str().c_str(), f_info.str().size());
+  close(fd);
+
 
   if (blocks.count("SMINPUTS"))
     pydat1_.paru[102 - 1] =
@@ -402,8 +404,8 @@ void Pythia6Service::setSLHAFromHeader(const std::vector<std::string>& lines) {
 	call_pygive("IMSS(22)=24");
 */
 
-  openSLHA(fname);
-  std::remove(fname);
+  openSLHA(tempslhaname);
+  std::remove(tempslhaname);
 
   if (model || blocks.count("HIGMIX") || blocks.count("SBOTMIX") || blocks.count("STOPMIX") ||
       blocks.count("STAUMIX") || blocks.count("AMIX") || blocks.count("NMIX") || blocks.count("UMIX") ||

--- a/GeneratorInterface/Pythia8Interface/src/Py8InterfaceBase.cc
+++ b/GeneratorInterface/Pythia8Interface/src/Py8InterfaceBase.cc
@@ -6,9 +6,7 @@
 
 #include "FWCore/Utilities/interface/Exception.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
-
-#include "boost/filesystem.hpp"
-#include "boost/filesystem/path.hpp"
+#include <filesystem>
 
 // EvtGen plugin
 //
@@ -58,23 +56,15 @@ namespace gen {
       if (ps.exists("evtgenUserFileEmbedded")) {
         std::vector<std::string> user_decay_lines =
             ps.getParameter<std::vector<std::string> >("evtgenUserFileEmbedded");
-        auto tmp_dir = boost::filesystem::temp_directory_path();
-        tmp_dir += "/%%%%-%%%%-%%%%-%%%%";
-        auto tmp_path = boost::filesystem::unique_path(tmp_dir);
-        std::string user_decay_tmp = std::string(tmp_path.c_str());
-        FILE* tmpf = std::fopen(user_decay_tmp.c_str(), "w");
-        if (!tmpf) {
-          edm::LogError("Py8InterfaceBase::~Py8InterfaceBase")
-              << "Py8InterfaceBase::Py8InterfaceBase fails when trying to open a temporary file for embedded user.dec "
-                 "for EvtGenPlugin. Terminating program ";
-          exit(0);
-        }
+	char tempslhaname[] = "pythia8evtgenXXXXXX";
+	int fd = mkstemp(tempslhaname);
+
         for (unsigned int i = 0; i < user_decay_lines.size(); i++) {
           user_decay_lines.at(i) += "\n";
-          std::fputs(user_decay_lines.at(i).c_str(), tmpf);
+	  write(fd,user_decay_lines.at(i).c_str(),user_decay_lines.at(i).size());
         }
-        std::fclose(tmpf);
-        evtgenUserFiles.push_back(user_decay_tmp);
+	close(fd);
+        evtgenUserFiles.push_back(std::string(tempslhaname));
       }
     }
   }

--- a/GeneratorInterface/Pythia8Interface/src/Py8InterfaceBase.cc
+++ b/GeneratorInterface/Pythia8Interface/src/Py8InterfaceBase.cc
@@ -56,14 +56,14 @@ namespace gen {
       if (ps.exists("evtgenUserFileEmbedded")) {
         std::vector<std::string> user_decay_lines =
             ps.getParameter<std::vector<std::string> >("evtgenUserFileEmbedded");
-	char tempslhaname[] = "pythia8evtgenXXXXXX";
-	int fd = mkstemp(tempslhaname);
+        char tempslhaname[] = "pythia8evtgenXXXXXX";
+        int fd = mkstemp(tempslhaname);
 
         for (unsigned int i = 0; i < user_decay_lines.size(); i++) {
           user_decay_lines.at(i) += "\n";
-	  write(fd,user_decay_lines.at(i).c_str(),user_decay_lines.at(i).size());
+          write(fd, user_decay_lines.at(i).c_str(), user_decay_lines.at(i).size());
         }
-	close(fd);
+        close(fd);
         evtgenUserFiles.push_back(std::string(tempslhaname));
       }
     }


### PR DESCRIPTION
To possibly address aarch64 build issues seen when using boost1.75 across different machines- More discussion in cms-sw/cmsdist#6698
