### PR TITLE
Small bugfix in  Configuration/DataProcessing/python/Impl/cosmics.py

### DIFF
--- a/Configuration/DataProcessing/python/Impl/cosmics.py
+++ b/Configuration/DataProcessing/python/Impl/cosmics.py
@@ -75,8 +75,6 @@ class cosmics(Reco):
             args['customs'].append('Configuration/DataProcessing/RecoTLR.customiseCosmicData')
         process = Reco.visualizationProcessing(self,globalTag, **args)
 
-        process.reconstructionCosmics.remove(process.lumiProducer)
-
         return process
 
     def alcaHarvesting(self, globalTag, datasetName, **args):


### PR DESCRIPTION
This PR solves https://github.com/cms-sw/cmssw/issues/33058

Since https://github.com/cms-sw/cmssw/pull/33024 has removed `lumiProducer` from `reconstructionCosmics`,
we have to remove the line `process.reconstructionCosmics.remove(process.lumiProducer)` in `Configuration/DataProcessing/python/Impl/cosmics.py`

Validation: `scram b runtests` in  `Configuration/DataProcessing`