### PR TITLE
Add more pixel payload inspections

### DIFF
--- a/CondCore/SiPixelPlugins/README.md
+++ b/CondCore/SiPixelPlugins/README.md
@@ -1,0 +1,20 @@
+# CondCore/SiPixelPlugins
+
+This package contains a series of `cmssw` plugins for inspecting SiPixel conditions.
+The available inspectors are:
+
+| Record                                | Object                          | Inspector                                         |
+| --------------------------------------|---------------------------------| --------------------------------------------------|
+| `SiPixelLorentzAngleRcd`              | `SiPixelLorentzAngle`           | [SiPixelLorentzAngle_PayloadInspector.cc](https://github.com/cms-sw/cmssw/blob/master/CondCore/SiPixelPlugins/plugins/SiPixelLorentzAngle_PayloadInspector.cc) |
+| `SiPixelGenErrorDBObjectRcd`          | `SiPixelGenErrorDBObject`       | [SiPixelGenErrorDBObject_PayloadInspector.cc](https://github.com/cms-sw/cmssw/blob/master/CondCore/SiPixelPlugins/plugins/SiPixelGenErrorDBObject_PayloadInspector.cc)       |
+| `SiPixelGainCalibrationOfflineRcd`    | `SiPixelGainCalibrationOffline` | [SiPixelGainCalibrationOffline_PayloadInspector.cc](https://github.com/cms-sw/cmssw/blob/master/CondCore/SiPixelPlugins/plugins/SiPixelGainCalibrationOffline_PayloadInspector.cc) |
+| `SiPixelGainCalibrationForHLTRcd`     | `SiPixelGainCalibrationForHLT`  | [SiPixelGainCalibrationForHLT_PayloadInspector.cc](https://github.com/cms-sw/cmssw/blob/master/CondCore/SiPixelPlugins/plugins/SiPixelGainCalibrationForHLT_PayloadInspector.cc)  |
+| NOT IMPLEMENTED                       | `SiPixelVCal`                   | [SiPixelVCal_PayloadInspector.cc](https://github.com/cms-sw/cmssw/blob/master/CondCore/SiPixelPlugins/plugins/SiPixelVCal_PayloadInspector.cc)                   |
+| `SiPixelTemplateDBObjectRcd`          | `SiPixelTemplateDBObject`       | [SiPixelTemplateDBObject_PayloadInspector.cc](https://github.com/cms-sw/cmssw/blob/master/CondCore/SiPixelPlugins/plugins/SiPixelTemplateDBObject_PayloadInspector.cc)       |
+| `SiPixel2DTemplateDBObjectRcd`        | `SiPixel2DTemplateDBObject`     | [SiPixel2DTemplateDBObject_PayloadInspector.cc](https://github.com/cms-sw/cmssw/blob/master/CondCore/SiPixelPlugins/plugins/SiPixel2DTemplateDBObject_PayloadInspector.cc)       |
+| `SiPixelQualityFromDbRcd`             | `SiPixelQuality`                | [SiPixelQuality_PayloadInspector.cc](https://github.com/cms-sw/cmssw/blob/master/CondCore/SiPixelPlugins/plugins/SiPixelQuality_PayloadInspector.cc)                |
+| `SiPixelStatusScenarioProbabilityRcd` | `SiPixelQualityProbabilities`   | [SiPixelQualityProbabilities_PayloadInspector.cc](https://github.com/cms-sw/cmssw/blob/master/CondCore/SiPixelPlugins/plugins/SiPixelQualityProbabilities_PayloadInspector.cc)   |
+| `SiPixelStatusScenariosRcd`           | `SiPixelFEDChannelContainer`    | [SiPixelFEDChannelContainer_PayloadInspector.cc](https://github.com/cms-sw/cmssw/blob/master/CondCore/SiPixelPlugins/plugins/SiPixelFEDChannelContainer_PayloadInspector.cc)    |
+
+Plots will be shown within the **cmsDbBrowser** [payload inspector](https://cms-conddb.cern.ch/cmsDbBrowser/payload_inspector/Prod) application.
+In the `CondCore/SiPixelPlugins/test` directory a few bash scripts to inspect conditions from command line are available.

--- a/CondCore/SiPixelPlugins/interface/SiPixelPayloadInspectorHelper.h
+++ b/CondCore/SiPixelPlugins/interface/SiPixelPayloadInspectorHelper.h
@@ -227,10 +227,13 @@ namespace SiPixelPI {
 
     if (lay > 0) {
       canv.cd(lay);
-      s_title = "Barrel Pixel Layer" + std::to_string(lay);
+      s_title = "Barrel Pixel Layer " + std::to_string(lay);
     } else {
       canv.cd(ring);
-      s_title = "Forward Pixel Ring" + std::to_string(ring);
+      if (ring > 4) {
+        ring = ring - 4;
+      }
+      s_title = "Forward Pixel Ring " + std::to_string(ring);
     }
 
     gStyle->SetPadRightMargin(0.125);

--- a/CondCore/SiPixelPlugins/interface/SiPixelTemplateHelper.h
+++ b/CondCore/SiPixelPlugins/interface/SiPixelTemplateHelper.h
@@ -98,8 +98,8 @@ namespace templateHelper {
           y_line.push_back(y - (pitch / 2.));
         }
 
-        const char* c_title = fmt::sprintf("%s titles", (isTemplate_ ? "Template" : "GenError")).c_str();
-        TCanvas canvas(c_title, c_title, 2000, std::max(y_x1.size(), y_x2.size()) * 40);
+        const auto& c_title = fmt::sprintf("%s titles", (isTemplate_ ? "Template" : "GenError"));
+        TCanvas canvas(c_title.c_str(), c_title.c_str(), 2000, std::max(y_x1.size(), y_x2.size()) * 40);
         TLatex l;
         // Draw the columns titles
         l.SetTextAlign(12);

--- a/CondCore/SiPixelPlugins/interface/SiPixelTemplateHelper.h
+++ b/CondCore/SiPixelPlugins/interface/SiPixelTemplateHelper.h
@@ -7,6 +7,7 @@
 #include "CondCore/SiPixelPlugins/interface/SiPixelPayloadInspectorHelper.h"
 #include "DataFormats/SiPixelDetId/interface/PixelSubdetector.h"
 #include "CondFormats/SiPixelObjects/interface/SiPixelTemplateDBObject.h"
+#include "CondFormats/SiPixelObjects/interface/SiPixelGenErrorDBObject.h"
 #include "CondFormats/SiPixelTransient/interface/SiPixelTemplate.h"
 
 #include <type_traits>
@@ -31,18 +32,18 @@ namespace templateHelper {
   using namespace cond::payloadInspector;
 
   //************************************************
-  // Display of Template Titles
+  // Display of Template/GenError Titles
   // *************************************************/
   template <class PayloadType, class StoreType, class TransientType>
   class SiPixelTitles_Display : public PlotImage<PayloadType, SINGLE_IOV> {
   public:
-    SiPixelTitles_Display() : PlotImage<PayloadType, SINGLE_IOV>("Table of Template titles") {
-      if constexpr (std::is_same_v<PayloadType, SiPixelTemplateDBObject>) {
-        isTemplate_ = true;
-        label_ = "SiPixelTemplateDBObject_PayloadInspector";
-      } else {
+    SiPixelTitles_Display() : PlotImage<PayloadType, SINGLE_IOV>("Table of SiPixelTemplate/GenError titles") {
+      if constexpr (std::is_same_v<PayloadType, SiPixelGenErrorDBObject>) {
         isTemplate_ = false;
         label_ = "SiPixelGenErrorDBObject_PayloadInspector";
+      } else {
+        isTemplate_ = true;
+        label_ = "SiPixelTemplateDBObject_PayloadInspector";
       }
     }
 
@@ -57,7 +58,9 @@ namespace templateHelper {
 
       if (payload.get()) {
         if (!TransientType::pushfile(*payload, thePixelTemp_)) {
-          throw cms::Exception(label_) << "\nERROR: Templates not filled correctly. Check the conditions. Using "
+          throw cms::Exception(label_) << "\nERROR:" << (isTemplate_ ? "Templates" : "GenErrors")
+                                       << " not filled correctly."
+                                       << " Check the conditions. Using "
                                        << (isTemplate_ ? "SiPixelTemplateDBObject" : "SiPixelGenErrorDBObject")
                                        << " version " << payload->version() << "\n\n";
         }
@@ -95,7 +98,8 @@ namespace templateHelper {
           y_line.push_back(y - (pitch / 2.));
         }
 
-        TCanvas canvas("Template Titles", "Template Titles", 2000, std::max(y_x1.size(), y_x2.size()) * 40);
+        const char* c_title = fmt::sprintf("%s titles", (isTemplate_ ? "Template" : "GenError")).c_str();
+        TCanvas canvas(c_title, c_title, 2000, std::max(y_x1.size(), y_x2.size()) * 40);
         TLatex l;
         // Draw the columns titles
         l.SetTextAlign(12);
@@ -144,13 +148,13 @@ namespace templateHelper {
   template <class PayloadType, class StoreType, class TransientType>
   class SiPixelHeaderTable : public PlotImage<PayloadType, SINGLE_IOV> {
   public:
-    SiPixelHeaderTable() : PlotImage<PayloadType, SINGLE_IOV>("SiPixelGenErrorDBObject Header summary") {
-      if constexpr (std::is_same_v<PayloadType, SiPixelTemplateDBObject>) {
-        isTemplate_ = true;
-        label_ = "SiPixelTemplateDBObject_PayloadInspector";
-      } else {
+    SiPixelHeaderTable() : PlotImage<PayloadType, SINGLE_IOV>("SiPixel CPE Header summary") {
+      if constexpr (std::is_same_v<PayloadType, SiPixelGenErrorDBObject>) {
         isTemplate_ = false;
         label_ = "SiPixelGenErrorDBObject_PayloadInspector";
+      } else {
+        isTemplate_ = true;
+        label_ = "SiPixelTemplateDBObject_PayloadInspector";
       }
     }
 
@@ -166,7 +170,9 @@ namespace templateHelper {
 
       if (payload.get()) {
         if (!TransientType::pushfile(*payload, thePixelTemp_)) {
-          throw cms::Exception(label_) << "\nERROR: GenErrors not filled correctly. Check the conditions. Using "
+          throw cms::Exception(label_) << "\nERROR:" << (isTemplate_ ? "Templates" : "GenErrors")
+                                       << " not filled correctly."
+                                       << " Check the conditions. Using "
                                        << (isTemplate_ ? "SiPixelTemplateDBObject" : "SiPixelGenErrorDBObject")
                                        << payload->version() << "\n\n";
         }
@@ -298,13 +304,13 @@ namespace templateHelper {
   template <class PayloadType, SiPixelPI::DetType myType>
   class SiPixelIDs : public PlotImage<PayloadType, SINGLE_IOV> {
   public:
-    SiPixelIDs() : PlotImage<PayloadType, SINGLE_IOV>("SiPixelMap of ID Values") {
-      if constexpr (std::is_same_v<PayloadType, SiPixelTemplateDBObject>) {
-        isTemplate_ = true;
-        label_ = "SiPixelTemplateDBObject_PayloadInspector";
-      } else {
+    SiPixelIDs() : PlotImage<PayloadType, SINGLE_IOV>("SiPixelMap of Template / GenError ID Values") {
+      if constexpr (std::is_same_v<PayloadType, SiPixelGenErrorDBObject>) {
         isTemplate_ = false;
         label_ = "SiPixelGenErrorDBObject_PayloadInspector";
+      } else {
+        isTemplate_ = true;
+        label_ = "SiPixelTemplateDBObject_PayloadInspector";
       }
     }
 
@@ -333,10 +339,10 @@ namespace templateHelper {
         }
 
         std::map<unsigned int, short> templMap;
-        if constexpr (std::is_same_v<PayloadType, SiPixelTemplateDBObject>) {
-          templMap = payload->getTemplateIDs();
-        } else {
+        if constexpr (std::is_same_v<PayloadType, SiPixelGenErrorDBObject>) {
           templMap = payload->getGenErrorIDs();
+        } else {
+          templMap = payload->getTemplateIDs();
         }
 
         if (templMap.size() == SiPixelPI::phase0size || templMap.size() > SiPixelPI::phase1size) {
@@ -365,7 +371,8 @@ namespace templateHelper {
 	*/
 
         for (auto const& entry : templMap) {
-          COUT << "DetID: " << entry.first << " generror ID: " << entry.second << std::endl;
+          COUT << "DetID: " << entry.first << fmt::sprintf("%s ID ", (isTemplate_ ? "Template" : "GenError"))
+               << entry.second << std::endl;
           auto detid = DetId(entry.first);
           if ((detid.subdetId() == PixelSubdetector::PixelBarrel) && (myType == SiPixelPI::t_barrel)) {
             theMaps.fillBarrelBin(barrelName_, entry.first, entry.second);

--- a/CondCore/SiPixelPlugins/plugins/BuildFile.xml
+++ b/CondCore/SiPixelPlugins/plugins/BuildFile.xml
@@ -49,17 +49,23 @@
   <use name="CalibTracker/StandaloneTrackerTopology"/>
 </library>
 
-<library file="plugin.cc" name="CondCoreSiPixelPluginsPlugin">
-  <flags EDM_PLUGIN="1"/>
-  <use name="CondCore/ESSources"/>
-  <use name="CondFormats/SiPixelObjects"/>
-  <use name="CondFormats/DataRecord"/>
-</library>
-
 <library file="SiPixelQualityProbabilities_PayloadInspector.cc" name="SiPixelQualityProbabilities_PayloadInspector">
   <use   name="CondCore/Utilities"/>
   <use   name="CondCore/CondDB"/>
   <use   name="CondFormats/Common"/>
   <use   name="CalibTracker/StandaloneTrackerTopology"/>
-  <use   name="boost_python"/>
+</library>
+
+<library file="SiPixelFEDChannelContainer_PayloadInspector.cc" name="SiPixelFEDChannelContainer_PayloadInspector">
+  <use   name="CondCore/Utilities"/>
+  <use   name="CondCore/CondDB"/>
+  <use   name="CondFormats/Common"/>
+  <use   name="CalibTracker/StandaloneTrackerTopology"/>
+</library>
+
+<library file="plugin.cc" name="CondCoreSiPixelPluginsPlugin">
+  <flags EDM_PLUGIN="1"/>
+  <use name="CondCore/ESSources"/>
+  <use name="CondFormats/SiPixelObjects"/>
+  <use name="CondFormats/DataRecord"/>
 </library>

--- a/CondCore/SiPixelPlugins/plugins/BuildFile.xml
+++ b/CondCore/SiPixelPlugins/plugins/BuildFile.xml
@@ -55,3 +55,11 @@
   <use name="CondFormats/SiPixelObjects"/>
   <use name="CondFormats/DataRecord"/>
 </library>
+
+<library file="SiPixelQualityProbabilities_PayloadInspector.cc" name="SiPixelQualityProbabilities_PayloadInspector">
+  <use   name="CondCore/Utilities"/>
+  <use   name="CondCore/CondDB"/>
+  <use   name="CondFormats/Common"/>
+  <use   name="CalibTracker/StandaloneTrackerTopology"/>
+  <use   name="boost_python"/>
+</library>

--- a/CondCore/SiPixelPlugins/plugins/BuildFile.xml
+++ b/CondCore/SiPixelPlugins/plugins/BuildFile.xml
@@ -34,6 +34,14 @@
   <use name="CalibTracker/StandaloneTrackerTopology"/>
 </library>
 
+<library file="SiPixel2DTemplateDBObject_PayloadInspector.cc" name="SiPixel2DTemplateDBObject_PayloadInspector">
+  <use name="CondCore/SiPixelPlugins"/>
+  <use name="CondCore/Utilities"/>
+  <use name="CondCore/CondDB"/>
+  <use name="CondFormats/SiPixelTransient"/>
+  <use name="CalibTracker/StandaloneTrackerTopology"/>
+</library>
+
 <library file="SiPixelVCal_PayloadInspector.cc" name="SiPixelVCal_PayloadInspector">
   <use name="CondCore/SiPixelPlugins"/>
   <use name="CondCore/Utilities"/>

--- a/CondCore/SiPixelPlugins/plugins/SiPixel2DTemplateDBObject_PayloadInspector.cc
+++ b/CondCore/SiPixelPlugins/plugins/SiPixel2DTemplateDBObject_PayloadInspector.cc
@@ -1,6 +1,6 @@
 /*!
   \file SiPixel2DTemplateDBObject_PayloadInspector
-  \Payload Inspector Plugin for SiPixelTemplateDBObject
+  \Payload Inspector Plugin for SiPixel2DTemplateDBObject
   \author M. Musich
   \version $Revision: 1.0 $
   \date $Date: 2020/04/16 18:00:00 $

--- a/CondCore/SiPixelPlugins/plugins/SiPixel2DTemplateDBObject_PayloadInspector.cc
+++ b/CondCore/SiPixelPlugins/plugins/SiPixel2DTemplateDBObject_PayloadInspector.cc
@@ -1,6 +1,6 @@
 /*!
-  \file SiPixelGenErrorDBObject_PayloadInspector
-  \Payload Inspector Plugin for SiPixelGenError
+  \file SiPixel2DTemplateDBObject_PayloadInspector
+  \Payload Inspector Plugin for SiPixelTemplateDBObject
   \author M. Musich
   \version $Revision: 1.0 $
   \date $Date: 2020/04/16 18:00:00 $
@@ -18,8 +18,8 @@
 #include "CalibTracker/StandaloneTrackerTopology/interface/StandaloneTrackerTopology.h"
 
 // the data format of the condition to be inspected
-#include "CondFormats/SiPixelObjects/interface/SiPixelGenErrorDBObject.h"
-#include "CondFormats/SiPixelTransient/interface/SiPixelGenError.h"
+#include "CondFormats/SiPixelObjects/interface/SiPixel2DTemplateDBObject.h"
+#include "CondFormats/SiPixelTransient/interface/SiPixelTemplate2D.h"
 #include "DataFormats/SiPixelDetId/interface/PixelSubdetector.h"
 #include "DataFormats/DetId/interface/DetId.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
@@ -53,26 +53,27 @@ namespace {
   // Display of Template Titles
   // **********************************************/
   using namespace templateHelper;
-  using SiPixelGenErrorTitles_Display =
-      SiPixelTitles_Display<SiPixelGenErrorDBObject, SiPixelGenErrorStore, SiPixelGenError>;
+  using SiPixel2DTemplateTitles_Display =
+      SiPixelTitles_Display<SiPixel2DTemplateDBObject, SiPixelTemplateStore2D, SiPixelTemplate2D>;
 
   //***********************************************
-  // Display of GenError Header
+  // Display of 2DTemplate Header
   // **********************************************/
-  using SiPixelGenErrorHeaderTable = SiPixelHeaderTable<SiPixelGenErrorDBObject, SiPixelGenErrorStore, SiPixelGenError>;
+  using SiPixel2DTemplateHeaderTable =
+      SiPixelHeaderTable<SiPixel2DTemplateDBObject, SiPixelTemplateStore2D, SiPixelTemplate2D>;
 
   //***********************************************
   // TH2Poly Map of IDs
   //***********************************************/
-  using SiPixelGenErrorIDsBPixMap = SiPixelIDs<SiPixelGenErrorDBObject, SiPixelPI::t_barrel>;
-  using SiPixelGenErrorIDsFPixMap = SiPixelIDs<SiPixelGenErrorDBObject, SiPixelPI::t_forward>;
+  using SiPixel2DTemplateIDsBPixMap = SiPixelIDs<SiPixel2DTemplateDBObject, SiPixelPI::t_barrel>;
+  using SiPixel2DTemplateIDsFPixMap = SiPixelIDs<SiPixel2DTemplateDBObject, SiPixelPI::t_forward>;
 
 }  // namespace
 
 // Register the classes as boost python plugin
-PAYLOAD_INSPECTOR_MODULE(SiPixelGenErrorDBObject) {
-  PAYLOAD_INSPECTOR_CLASS(SiPixelGenErrorTitles_Display);
-  PAYLOAD_INSPECTOR_CLASS(SiPixelGenErrorHeaderTable);
-  PAYLOAD_INSPECTOR_CLASS(SiPixelGenErrorIDsBPixMap);
-  PAYLOAD_INSPECTOR_CLASS(SiPixelGenErrorIDsFPixMap);
+PAYLOAD_INSPECTOR_MODULE(SiPixel2DTemplateDBObject) {
+  PAYLOAD_INSPECTOR_CLASS(SiPixel2DTemplateTitles_Display);
+  PAYLOAD_INSPECTOR_CLASS(SiPixel2DTemplateHeaderTable);
+  PAYLOAD_INSPECTOR_CLASS(SiPixel2DTemplateIDsBPixMap);
+  PAYLOAD_INSPECTOR_CLASS(SiPixel2DTemplateIDsFPixMap);
 }

--- a/CondCore/SiPixelPlugins/plugins/SiPixelFEDChannelContainer_PayloadInspector.cc
+++ b/CondCore/SiPixelPlugins/plugins/SiPixelFEDChannelContainer_PayloadInspector.cc
@@ -275,11 +275,13 @@ namespace {
             for (const auto& bin : rocsToMask) {
               double x = h_fpix_occ[ring - 1]->GetXaxis()->GetBinCenter(std::get<0>(bin));
               double y = h_fpix_occ[ring - 1]->GetYaxis()->GetBinCenter(std::get<1>(bin));
-              h_fpix_occ[ring - 1]->SetBinContent(x, y, 1);
-            }
-          }  // if it's endcap
-        }    // loop on the channels
-      }      // loop on the scenarios
+              h_fpix_occ[ring - 1]->Fill(x, y, 1);
+            }  // if it's endcap
+          } else {
+            throw cms::Exception("LogicError") << "Unknown Pixel SubDet ID " << std::endl;
+          }
+        }  // loop on the channels
+      }    // loop on the scenarios
 
       gStyle->SetOptStat(0);
       //=========================
@@ -414,7 +416,7 @@ namespace {
       for (const auto& scenario : scenarios) {
         scenarioIndex++;
         int badRocCount = 0;
-	LogDebug("SiPixelFEDChannelContainerScenarios") << scenario << std::endl;
+        LogDebug("SiPixelFEDChannelContainerScenarios") << scenario << std::endl;
         auto badChannelCollection = payload->getDetSetBadPixelFedChannels(scenario);
         for (const auto& disabledChannels : *badChannelCollection) {
           for (const auto& ch : disabledChannels) {
@@ -426,8 +428,8 @@ namespace {
         h1->SetBinContent(scenarioIndex, badRocCount);
       }  // loop on scenarios
 
-      TGaxis::SetExponentOffset(-0.1, 0.01, "y");  // Y offset
-      TGaxis::SetExponentOffset(-0.03, -0.10, "x"); // Y and Y offset for X axis
+      TGaxis::SetExponentOffset(-0.1, 0.01, "y");    // Y offset
+      TGaxis::SetExponentOffset(-0.03, -0.10, "x");  // Y and Y offset for X axis
 
       h1->SetTitle("");
       h1->GetYaxis()->SetRangeUser(0., h1->GetMaximum() * 1.30);
@@ -443,19 +445,20 @@ namespace {
       TLegend legend = TLegend(0.30, 0.88, 0.95, 0.94);
       //legend.SetHeader(("#splitline{Payload hash: #bf{" + (std::get<1>(iov)) + "}}{Total Scenarios:"+std::to_string(scenarioIndex)+"}").c_str(),"C");  // option "C" allows to center the header
 
-      legend.SetHeader(fmt::sprintf("Payload hash: #bf{%s}",std::get<1>(iov)).c_str(),"C");
-      legend.AddEntry(h1.get(),fmt::sprintf("total scenarios: #bf{%s}",std::to_string(scenarioIndex)).c_str(), "F");
+      legend.SetHeader(fmt::sprintf("Payload hash: #bf{%s}", std::get<1>(iov)).c_str(), "C");
+      legend.AddEntry(h1.get(), fmt::sprintf("total scenarios: #bf{%s}", std::to_string(scenarioIndex)).c_str(), "F");
       legend.SetTextSize(0.025);
       legend.Draw("same");
 
       auto ltx = TLatex();
       ltx.SetTextFont(62);
       //ltx.SetTextColor(kBlue);
-      ltx.SetTextSize(0.040);
       //ltx.SetTextAlign(11);
-      ltx.DrawLatexNDC(gPad->GetLeftMargin(),
-                       1 - gPad->GetTopMargin() + 0.01,
-                       fmt::sprintf("#color[4]{%s} IOV: #color[4]{%s}",tagname,std::to_string(std::get<0>(iov))).c_str());
+      ltx.SetTextSize(0.040);
+      ltx.DrawLatexNDC(
+          gPad->GetLeftMargin(),
+          1 - gPad->GetTopMargin() + 0.01,
+          fmt::sprintf("#color[4]{%s} IOV: #color[4]{%s}", tagname, std::to_string(std::get<0>(iov))).c_str());
 
       std::string fileName(m_imageFileName);
       canvas.SaveAs(fileName.c_str());

--- a/CondCore/SiPixelPlugins/plugins/SiPixelFEDChannelContainer_PayloadInspector.cc
+++ b/CondCore/SiPixelPlugins/plugins/SiPixelFEDChannelContainer_PayloadInspector.cc
@@ -1,0 +1,277 @@
+/*!
+  \file SiPixelFEDChannelContainer_PayloadInspector
+  \Payload Inspector Plugin for SiPixelFEDChannelContainer
+  \author M. Musich
+  \version $Revision: 1.0 $
+  \date $Date: 2020/02/22 10:00:00 $
+*/
+
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "CondCore/CondDB/interface/ConnectionPool.h"
+
+#include "CondCore/Utilities/interface/PayloadInspectorModule.h"
+#include "CondCore/Utilities/interface/PayloadInspector.h"
+#include "CondCore/CondDB/interface/Time.h"
+#include "CondCore/SiPixelPlugins/interface/SiPixelPayloadInspectorHelper.h"
+#include "FWCore/ParameterSet/interface/FileInPath.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "CalibTracker/StandaloneTrackerTopology/interface/StandaloneTrackerTopology.h"
+
+#include "CondFormats/SiPixelObjects/interface/CablingPathToDetUnit.h"
+#include "CondFormats/SiPixelObjects/interface/LocalPixel.h"
+#include "CondFormats/SiPixelObjects/interface/PixelIndices.h"
+#include "CondFormats/SiPixelObjects/interface/PixelROC.h"
+#include "CondFormats/SiPixelObjects/interface/SiPixelFedCabling.h"
+#include "CondFormats/SiPixelObjects/interface/SiPixelFedCablingMap.h"
+#include "CondFormats/SiPixelObjects/interface/SiPixelFedCablingTree.h"
+#include "CondFormats/SiPixelObjects/interface/SiPixelFrameConverter.h"
+
+// the data format of the condition to be inspected
+#include "CondFormats/SiPixelObjects/interface/SiPixelFEDChannelContainer.h"
+#include "DataFormats/SiPixelDetId/interface/PixelSubdetector.h"
+#include "DataFormats/DetId/interface/DetId.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+#include <memory>
+#include <sstream>
+#include <iostream>
+#include <fmt/printf.h>
+
+// include ROOT
+#include "TH2F.h"
+#include "TLegend.h"
+#include "TCanvas.h"
+#include "TLine.h"
+#include "TGraph.h"
+#include "TGaxis.h"
+#include "TStyle.h"
+#include "TLatex.h"
+#include "TPave.h"
+#include "TPaveStats.h"
+
+namespace {
+
+  using namespace cond::payloadInspector;
+
+  /************************************************
+  1d histogram of SiPixelFEDChannelContainer of 1 IOV 
+  *************************************************/
+
+  class SiPixelFEDChannelContainerTest : public PlotImage<SiPixelFEDChannelContainer, SINGLE_IOV> {
+  public:
+    SiPixelFEDChannelContainerTest()
+        : PlotImage<SiPixelFEDChannelContainer, SINGLE_IOV>("SiPixelFEDChannelContainer scenarios count"),
+          m_trackerTopo{StandaloneTrackerTopology::fromTrackerParametersXMLFile(
+              edm::FileInPath("Geometry/TrackerCommonData/data/PhaseI/trackerParameters.xml").fullPath())} {
+      // hardcoded connection to the MC cabling tag, though luck
+      m_condDbCabling = "frontier://FrontierProd/CMS_CONDITIONS";
+      m_CablingTagName = "SiPixelFedCablingMap_phase1_v7";
+
+      m_connectionPool.setParameters(m_connectionPset);
+      m_connectionPool.configure();
+    }
+
+    bool fill() override {
+      static const int n_layers = 4;
+      int nlad_list[n_layers] = {6, 14, 22, 32};
+      int divide_roc = 1;
+
+      // ---------------------    BOOK HISTOGRAMS
+      std::array<TH2D*, n_layers> h_bpix_occ;
+
+      for (unsigned int lay = 1; lay <= 4; lay++) {
+        int nlad = nlad_list[lay - 1];
+
+        std::string name = "occ_Layer_" + std::to_string(lay);
+        std::string title = "; Module # ; Ladder #";
+        h_bpix_occ[lay - 1] = new TH2D(name.c_str(),
+                                       title.c_str(),
+                                       72 * divide_roc,
+                                       -4.5,
+                                       4.5,
+                                       (nlad * 4 + 2) * divide_roc,
+                                       -nlad - 0.5,
+                                       nlad + 0.5);
+      }
+
+      auto tag = PlotBase::getTag<0>();
+      auto iov = tag.iovs.front();
+
+      // open db session for the cabling map
+      edm::LogPrint("SiPixelFEDChannelContainerTest") << "[SiPixelFEDChannelContainerTest::" << __func__ << "] "
+                                                      << "Query the condition database " << m_condDbCabling;
+
+      cond::persistency::Session condDbSession = m_connectionPool.createSession(m_condDbCabling);
+      condDbSession.transaction().start(true);
+
+      // query the database
+      edm::LogPrint("SiPixelFEDChannelContainerTest") << "[SiPixelFEDChannelContainerTest::" << __func__ << "] "
+                                                      << "Reading IOVs from tag " << m_CablingTagName;
+
+      const auto MIN_VAL = cond::timeTypeSpecs[cond::runnumber].beginValue;
+      const auto MAX_VAL = cond::timeTypeSpecs[cond::runnumber].endValue;
+
+      // get the list of payloads for the Cabling Map
+      std::vector<std::tuple<cond::Time_t, cond::Hash> > m_cabling_iovs;
+      condDbSession.readIov(m_CablingTagName).selectRange(MIN_VAL, MAX_VAL, m_cabling_iovs);
+
+      std::vector<unsigned int> listOfCablingIOVs;
+      std::transform(m_cabling_iovs.begin(),
+                     m_cabling_iovs.end(),
+                     std::back_inserter(listOfCablingIOVs),
+                     [](std::tuple<cond::Time_t, cond::Hash> myIOV2) -> unsigned int { return std::get<0>(myIOV2); });
+
+      edm::LogPrint("SiPixelFEDChannelContainerTest")
+          << " Number of SiPixelFedCablngMap payloads: " << listOfCablingIOVs.size() << std::endl;
+
+      auto it = std::find(
+          listOfCablingIOVs.begin(), listOfCablingIOVs.end(), closest_from_below(listOfCablingIOVs, std::get<0>(iov)));
+      int index = std::distance(listOfCablingIOVs.begin(), it);
+
+      edm::LogPrint("SiPixelFEDChannelContainerTest")
+          << " using the SiPixelFedCablingMap with hash: " << std::get<1>(m_cabling_iovs.at(index)) << std::endl;
+
+      auto theCablingMap = condDbSession.fetchPayload<SiPixelFedCablingMap>(std::get<1>(m_cabling_iovs.at(index)));
+      theCablingMap->initializeRocs();
+      // auto theCablingTree = (*theCablingMap).cablingTree();
+
+      //auto map = theCablingMap->det2fedMap();
+      //for (const auto &element : map){
+      //	std::cout << element.first << " " << element.second << std::endl;
+      //}
+
+      std::shared_ptr<SiPixelFEDChannelContainer> payload = fetchPayload(std::get<1>(iov));
+      const auto& scenarioMap = payload->getScenarioMap();
+
+      const int numColumns = 416;
+      const int numRows = 160;
+
+      auto pIndexConverter = PixelIndices(numColumns, numRows);
+
+      for (const auto& scenario : scenarioMap) {
+        std::string scenName = scenario.first;
+
+        //if (strcmp(scenName.c_str(),"320824_103") != 0) continue;
+
+        const auto& theDetSetBadPixelFedChannels = payload->getDetSetBadPixelFedChannels(scenName);
+        for (const auto& disabledChannels : *theDetSetBadPixelFedChannels) {
+          const auto t_detid = disabledChannels.detId();
+          int subid = DetId(t_detid).subdetId();
+          // std::cout << fmt::sprintf("DetId : %i \n", t_detid) << std::endl;
+
+          std::bitset<16> badRocsFromFEDChannels;
+
+          for (const auto& ch : disabledChannels) {
+            std::string toOut_ = fmt::sprintf("fed : %i | link : %2i | roc_first : %2i | roc_last: %2i \n",
+                                              ch.fed,
+                                              ch.link,
+                                              ch.roc_first,
+                                              ch.roc_last);
+
+            //std::cout << toOut_ << std::endl;
+            const std::vector<sipixelobjects::CablingPathToDetUnit>& path =
+                theCablingMap->pathToDetUnit(disabledChannels.detId());
+            for (unsigned int i_roc = ch.roc_first; i_roc <= ch.roc_last; ++i_roc) {
+              for (const auto p : path) {
+                const sipixelobjects::PixelROC* myroc = theCablingMap->findItem(p);
+                if (myroc->idInDetUnit() == static_cast<unsigned int>(i_roc)) {
+                  sipixelobjects::LocalPixel::RocRowCol local = {39, 25};  //corresponding to center of ROC row,col
+                  sipixelobjects::GlobalPixel global = myroc->toGlobal(sipixelobjects::LocalPixel(local));
+                  int chipIndex(0), colROC(0), rowROC(0);
+
+                  pIndexConverter.transformToROC(global.col, global.row, chipIndex, colROC, rowROC);
+
+                  //std::cout<<" => i_roc:" << i_roc << "  " << global.col << "-" << global.row << " | => " << chipIndex << " : (" << colROC << "," << rowROC << ")" << std::endl;
+
+                  badRocsFromFEDChannels[chipIndex] = true;
+                }
+              }
+            }
+
+            //std::cout << badRocsFromFEDChannels << std::endl;
+
+            if (subid == PixelSubdetector::PixelBarrel) {
+              auto layer = m_trackerTopo.pxbLayer(DetId(t_detid));
+              auto s_ladder = SiPixelPI::signed_ladder(DetId(t_detid), m_trackerTopo, true);
+              auto s_module = SiPixelPI::signed_module(DetId(t_detid), m_trackerTopo, true);
+
+              bool isFlipped = SiPixelPI::isBPixOuterLadder(DetId(t_detid), m_trackerTopo, false);
+              if ((layer > 1 && s_module < 0))
+                isFlipped = !isFlipped;
+
+              auto ladder = m_trackerTopo.pxbLadder(DetId(t_detid));
+              auto module = m_trackerTopo.pxbModule(DetId(t_detid));
+              //COUT << "layer:" << layer << " ladder:" << ladder << " module:" << module << " signed ladder: " << s_ladder
+              //   << " signed module: " << s_module << std::endl;
+
+              auto rocsToMask =
+                  SiPixelPI::maskedBarrelRocsToBins(layer, s_ladder, s_module, badRocsFromFEDChannels, isFlipped);
+              for (const auto& bin : rocsToMask) {
+                double x = h_bpix_occ[layer - 1]->GetXaxis()->GetBinCenter(std::get<0>(bin));
+                double y = h_bpix_occ[layer - 1]->GetYaxis()->GetBinCenter(std::get<1>(bin));
+                h_bpix_occ[layer - 1]->Fill(x, y, 1);
+              }
+            }
+          }
+        }
+      }
+
+      gStyle->SetOptStat(0);
+      //=========================
+      TCanvas canvas("Summary", "Summary", 1200, 1200);
+      canvas.Divide(2, 2);
+      canvas.SetBottomMargin(0.11);
+      canvas.SetLeftMargin(0.13);
+      canvas.SetRightMargin(0.05);
+      canvas.Modified();
+
+      for (unsigned int lay = 1; lay <= 4; lay++) {
+        SiPixelPI::dress_occup_plot(canvas, h_bpix_occ[lay - 1], lay, 0, 1);
+      }
+
+      auto unpacked = SiPixelPI::unpack(std::get<0>(iov));
+
+      for (unsigned int lay = 1; lay <= 4; lay++) {
+        canvas.cd(lay);
+        auto ltx = TLatex();
+        ltx.SetTextFont(62);
+        ltx.SetTextColor(kBlue);
+        ltx.SetTextSize(0.055);
+        ltx.SetTextAlign(11);
+        ltx.DrawLatexNDC(gPad->GetLeftMargin(),
+                         1 - gPad->GetTopMargin() + 0.01,
+                         unpacked.first == 0
+                             ? ("IOV:" + std::to_string(unpacked.second)).c_str()
+                             : (std::to_string(unpacked.first) + "," + std::to_string(unpacked.second)).c_str());
+      }
+
+      std::string fileName(m_imageFileName);
+      canvas.SaveAs(fileName.c_str());
+
+      condDbSession.transaction().commit();
+
+      return true;
+    }
+
+  public:
+    inline unsigned int closest_from_above(std::vector<unsigned int> const& vec, unsigned int value) {
+      auto const it = std::lower_bound(vec.begin(), vec.end(), value);
+      return vec.at(it - vec.begin() - 1);
+    }
+
+    inline unsigned int closest_from_below(std::vector<unsigned int> const& vec, unsigned int value) {
+      auto const it = std::upper_bound(vec.begin(), vec.end(), value);
+      return vec.at(it - vec.begin() - 1);
+    }
+
+  private:
+    TrackerTopology m_trackerTopo;
+    edm::ParameterSet m_connectionPset;
+    cond::persistency::ConnectionPool m_connectionPool;
+    std::string m_CablingTagName;
+    std::string m_condDbCabling;
+  };
+}  // namespace
+
+// Register the classes as boost python plugin
+PAYLOAD_INSPECTOR_MODULE(SiPixelFEDChannelContainer) { PAYLOAD_INSPECTOR_CLASS(SiPixelFEDChannelContainerTest); }

--- a/CondCore/SiPixelPlugins/plugins/SiPixelQualityProbabilities_PayloadInspector.cc
+++ b/CondCore/SiPixelPlugins/plugins/SiPixelQualityProbabilities_PayloadInspector.cc
@@ -39,21 +39,20 @@
 
 namespace {
 
+  using namespace cond::payloadInspector;
+
   /************************************************
   1d histogram of SiPixelQualityProbabilities of 1 IOV 
   *************************************************/
 
-  class SiPixelQualityProbabilitiesScenariosCount
-      : public cond::payloadInspector::PlotImage<SiPixelQualityProbabilities> {
+  class SiPixelQualityProbabilitiesScenariosCount : public PlotImage<SiPixelQualityProbabilities, SINGLE_IOV> {
   public:
     SiPixelQualityProbabilitiesScenariosCount()
-        : cond::payloadInspector::PlotImage<SiPixelQualityProbabilities>(
-              "SiPixelQualityProbabilities scenarios count") {
-      setSingleIov(true);
-    }
+        : PlotImage<SiPixelQualityProbabilities, SINGLE_IOV>("SiPixelQualityProbabilities scenarios count") {}
 
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash>> &iovs) override {
-      auto iov = iovs.front();
+    bool fill() override {
+      auto tag = PlotBase::getTag<0>();
+      auto iov = tag.iovs.front();
       std::shared_ptr<SiPixelQualityProbabilities> payload = fetchPayload(std::get<1>(iov));
       auto PUbins = payload->getPileUpBins();
       auto span = PUbins.back() - PUbins.front();

--- a/CondCore/SiPixelPlugins/plugins/SiPixelQualityProbabilities_PayloadInspector.cc
+++ b/CondCore/SiPixelPlugins/plugins/SiPixelQualityProbabilities_PayloadInspector.cc
@@ -1,0 +1,121 @@
+/*!
+  \file SiPixelQualityProbabilities_PayloadInspector
+  \Payload Inspector Plugin for SiPixelQualityProbabilities
+  \author M. Musich
+  \version $Revision: 1.0 $
+  \date $Date: 2019/10/22 19:16:00 $
+*/
+
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+#include "CondCore/Utilities/interface/PayloadInspectorModule.h"
+#include "CondCore/Utilities/interface/PayloadInspector.h"
+#include "CondCore/CondDB/interface/Time.h"
+#include "CondCore/SiPixelPlugins/interface/SiPixelPayloadInspectorHelper.h"
+#include "FWCore/ParameterSet/interface/FileInPath.h"
+#include "CalibTracker/StandaloneTrackerTopology/interface/StandaloneTrackerTopology.h"
+
+// the data format of the condition to be inspected
+#include "CondFormats/SiPixelObjects/interface/SiPixelQualityProbabilities.h"
+#include "DataFormats/SiPixelDetId/interface/PixelSubdetector.h"
+#include "DataFormats/DetId/interface/DetId.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+#include <memory>
+#include <sstream>
+#include <iostream>
+
+// include ROOT
+#include "TH2F.h"
+#include "TLegend.h"
+#include "TCanvas.h"
+#include "TLine.h"
+#include "TGraph.h"
+#include "TGaxis.h"
+#include "TStyle.h"
+#include "TLatex.h"
+#include "TPave.h"
+#include "TPaveStats.h"
+
+namespace {
+
+  /************************************************
+  1d histogram of SiPixelQualityProbabilities of 1 IOV 
+  *************************************************/
+
+  class SiPixelQualityProbabilitiesScenariosCount
+      : public cond::payloadInspector::PlotImage<SiPixelQualityProbabilities> {
+  public:
+    SiPixelQualityProbabilitiesScenariosCount()
+        : cond::payloadInspector::PlotImage<SiPixelQualityProbabilities>(
+              "SiPixelQualityProbabilities scenarios count") {
+      setSingleIov(true);
+    }
+
+    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash>> &iovs) override {
+      auto iov = iovs.front();
+      std::shared_ptr<SiPixelQualityProbabilities> payload = fetchPayload(std::get<1>(iov));
+      auto PUbins = payload->getPileUpBins();
+      auto span = PUbins.back() - PUbins.front();
+
+      TGaxis::SetMaxDigits(3);
+
+      TCanvas canvas("Canv", "Canv", 1200, 1000);
+      canvas.cd();
+      auto h1 = std::make_unique<TH1F>("Count",
+                                       "SiPixelQualityProbablities Scenarios count;PU bin;n. of scenarios",
+                                       span,
+                                       PUbins.front(),
+                                       PUbins.back());
+      h1->SetStats(false);
+
+      canvas.SetTopMargin(0.06);
+      canvas.SetBottomMargin(0.12);
+      canvas.SetLeftMargin(0.12);
+      canvas.SetRightMargin(0.05);
+      canvas.Modified();
+
+      for (const auto &bin : PUbins) {
+        h1->SetBinContent(bin + 1, payload->nelements(bin));
+      }
+
+      h1->SetTitle("");
+      h1->GetYaxis()->SetRangeUser(0., h1->GetMaximum() * 1.30);
+      h1->SetFillColor(kRed);
+      h1->SetMarkerStyle(20);
+      h1->SetMarkerSize(1);
+      h1->Draw("bar2");
+
+      SiPixelPI::makeNicePlotStyle(h1.get());
+
+      canvas.Update();
+
+      TLegend legend = TLegend(0.40, 0.88, 0.95, 0.94);
+      legend.SetHeader(("Payload hash: #bf{" + (std::get<1>(iov)) + "}").c_str(),
+                       "C");  // option "C" allows to center the header
+      //legend.AddEntry(h1.get(), ("IOV: " + std::to_string(std::get<0>(iov))).c_str(), "PL");
+      legend.SetTextSize(0.025);
+      legend.Draw("same");
+
+      auto ltx = TLatex();
+      ltx.SetTextFont(62);
+      //ltx.SetTextColor(kBlue);
+      ltx.SetTextSize(0.05);
+      ltx.SetTextAlign(11);
+      ltx.DrawLatexNDC(gPad->GetLeftMargin() + 0.1,
+                       1 - gPad->GetTopMargin() + 0.01,
+                       ("SiPixelQualityProbabilities IOV:" + std::to_string(std::get<0>(iov))).c_str());
+
+      std::string fileName(m_imageFileName);
+      canvas.SaveAs(fileName.c_str());
+
+      return true;
+    }
+  };
+
+}  // namespace
+
+// Register the classes as boost python plugin
+PAYLOAD_INSPECTOR_MODULE(SiPixelQualityProbabilities) {
+  PAYLOAD_INSPECTOR_CLASS(SiPixelQualityProbabilitiesScenariosCount);
+}

--- a/CondCore/SiPixelPlugins/test/test.sh
+++ b/CondCore/SiPixelPlugins/test/test.sh
@@ -20,13 +20,24 @@ getPayloadData.py \
 
 mv *.png $W_DIR/results/SiPixelTemplate2DHeader.png
 
- getPayloadData.py \
-     --plugin pluginSiPixelFEDChannelContainer_PayloadInspector \
-     --plot plot_SiPixelFEDChannelContainerTest \
-     --tag SiPixelStatusScenarios_UltraLegacy2018_v0_mc \
-     --time_type Run --iovs '{"start_iov": "1", "end_iov" : "1"}' \
-     --db Prod \
-     --input_params '{"Scenarios":"320824_103,316758_983,320934_254"}' \
-     --test ;
+getPayloadData.py \
+    --plugin pluginSiPixelFEDChannelContainer_PayloadInspector \
+    --plot plot_SiPixelFEDChannelContainerTest \
+    --tag SiPixelStatusScenarios_UltraLegacy2018_v0_mc \
+    --time_type Run --iovs '{"start_iov": "1", "end_iov" : "1"}' \
+    --db Prod \
+    --input_params '{"Scenarios":"320824_103,316758_983,320934_254"}' \
+    --test ;
 
 mv *.png $W_DIR/results/SiPixelFEDChannelContainer.png
+
+
+getPayloadData.py \
+    --plugin pluginSiPixelFEDChannelContainer_PayloadInspector \
+    --plot plot_SiPixelFEDChannelContainerScenarios \
+    --tag SiPixelStatusScenarios_UltraLegacy2018_v0_mc \
+    --time_type Run --iovs '{"start_iov": "1", "end_iov" : "1"}' \
+    --db Prod \
+    --test ;
+
+mv *.png $W_DIR/results/SiPixelFEDChannelScenarios.png

--- a/CondCore/SiPixelPlugins/test/test.sh
+++ b/CondCore/SiPixelPlugins/test/test.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# Save current working dir so img can be outputted there later
+W_DIR=$(pwd);
+# Set SCRAM architecture var
+SCRAM_ARCH=slc6_amd64_gcc630;
+export SCRAM_ARCH;
+source /afs/cern.ch/cms/cmsset_default.sh;
+eval `scram run -sh`;
+
+mkdir -p $W_DIR/results
+
+getPayloadData.py \
+    --plugin pluginSiPixel2DTemplateDBObject_PayloadInspector \
+    --plot plot_SiPixel2DTemplateHeaderTable \
+    --tag SiPixel2DTemplateDBObject_phase2_IT_v6.1.5_25x100_unirradiated_den_v2_mc \
+    --time_type Run \
+    --iovs '{"start_iov": "1", "end_iov": "1"}' \
+    --db Prod \
+    --test
+
+mv *.png $W_DIR/results/SiPixelTemplate2DHeader.png
+
+ getPayloadData.py \
+     --plugin pluginSiPixelFEDChannelContainer_PayloadInspector \
+     --plot plot_SiPixelFEDChannelContainerTest \
+     --tag SiPixelStatusScenarios_UltraLegacy2018_v0_mc \
+     --time_type Run --iovs '{"start_iov": "1", "end_iov" : "1"}' \
+     --db Prod \
+     --input_params '{"Scenarios":"320824_103,316758_983,320934_254"}' \
+     --test ;
+
+mv *.png $W_DIR/results/SiPixelFEDChannelContainer.png

--- a/CondCore/SiPixelPlugins/test/testSiPixelPayloadInspector.cpp
+++ b/CondCore/SiPixelPlugins/test/testSiPixelPayloadInspector.cpp
@@ -8,6 +8,7 @@
 #include "CondCore/SiPixelPlugins/plugins/SiPixelGenErrorDBObject_PayloadInspector.cc"
 #include "CondCore/SiPixelPlugins/plugins/SiPixelVCal_PayloadInspector.cc"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "CondCore/SiPixelPlugins/plugins/SiPixelQualityProbabilities_PayloadInspector.cc"
 #include "FWCore/PluginManager/interface/PluginManager.h"
 #include "FWCore/PluginManager/interface/standard.h"
 #include "FWCore/PluginManager/interface/SharedLibrary.h"
@@ -187,6 +188,18 @@ int main(int argc, char** argv) {
   SiPixelGenErrorIDsBPixMap histo24;
   histo24.process(connectionString, PI::mk_input(tag, end, end));
   edm::LogPrint("testSiPixelPayloadInspector") << histo24.data() << std::endl;
+
+  // SiPixelQualityProbabilities
+
+  tag = "SiPixelQualityProbabilities_UltraLegacy2018_v0_mc";
+  start = boost::lexical_cast<unsigned long long>(1);
+  end = boost::lexical_cast<unsigned long long>(1);
+
+  std::cout << "## Exercising SiPixelQualityProbabilities plots " << std::endl;
+
+  SiPixelQualityProbabilitiesScenariosCount histo25;
+  histo25.process(connectionString, PI::mk_input(tag, start, start));
+  std::cout << histo25.data() << std::endl;
 
   inputs.clear();
 #if PY_MAJOR_VERSION >= 3

--- a/CondCore/SiPixelPlugins/test/testSiPixelTemplateDBObject.sh
+++ b/CondCore/SiPixelPlugins/test/testSiPixelTemplateDBObject.sh
@@ -89,3 +89,14 @@ getPayloadData.py \
     --test ;
 
 mv *.png $W_DIR/plots_Template/HeaderTitles.png
+
+getPayloadData.py \
+    --plugin pluginSiPixel2DTemplateDBObject_PayloadInspector \
+    --plot plot_SiPixel2DTemplateHeaderTable \
+    --tag SiPixel2DTemplateDBObject_38T_v1_express \
+    --time_type Run \
+    --iovs '{"start_iov": "326083", "end_iov": "326083"}' \
+    --db Prod \
+    --test ;
+
+mv *.png $W_DIR/plots_Template/2DHeaderTable.png


### PR DESCRIPTION
#### PR description:

The goal of this PR is expand the set of Pixel conditions browsable with the Payload Inspector.
It adds inspectors for:
   * `SiPixelQualityProbabilities`
   * `SiPixelFEDChannelContainer`
   * `SiPixel2DTemplateDBObject`

I profit of this PR to add a `README` file for the package   
   
#### PR validation:

Run successfully the unit tests of this package as well as private testing of the added plots.
Example plot obtained with:
```bash
 getPayloadData.py \
     --plugin pluginSiPixelFEDChannelContainer_PayloadInspector \
     --plot plot_SiPixelFEDChannelContainerTest \
     --tag SiPixelStatusScenarios_UltraLegacy2018_v0_mc \
     --time_type Run --iovs '{"start_iov": "1", "end_iov" : "1"}' \
     --db Prod \
     --input_params '{"Scenarios":"320824_103,316758_983,320934_254"}' \
     --test ;
```
![001eb939-bb2a-4620-a569-480bdb2dc8f3](https://user-images.githubusercontent.com/5082376/110007003-8c377b00-7d1a-11eb-9a7e-47a43f519c9f.png)
and example plot obtained with: 
```bash
getPayloadData.py \
    --plugin pluginSiPixelFEDChannelContainer_PayloadInspector \
    --plot plot_SiPixelFEDChannelContainerScenarios \
    --tag SiPixelStatusScenarios_UltraLegacy2017_v0_mc \
    --time_type Run --iovs '{"start_iov": "1", "end_iov" : "1"}' \
    --db Prod \
    --test ;
```
![image](https://user-images.githubusercontent.com/5082376/109983963-a1ed7600-7d03-11eb-981f-99ab96d6f789.png)

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Not a backport, no backport needed.
