### PR TITLE
#ifdef debug stringstream operations in SimMuon/RPCDigitizer

### DIFF
--- a/SimMuon/RPCDigitizer/src/RPCSimAsymmetricCls.cc
+++ b/SimMuon/RPCDigitizer/src/RPCSimAsymmetricCls.cc
@@ -156,6 +156,7 @@ void RPCSimAsymmetricCls::simulate(const RPCRoll* roll,
 
     std::vector<float> veff = (getRPCSimSetUp())->getEff(rpcId.rawId());
 
+#ifdef EDM_ML_DEBUG
     std::stringstream veffstream;
     veffstream << "[";
     for (std::vector<float>::iterator veffIt = veff.begin(); veffIt != veff.end(); ++veffIt) {
@@ -164,6 +165,7 @@ void RPCSimAsymmetricCls::simulate(const RPCRoll* roll,
     veffstream << "]";
     std::string veffstr = veffstream.str();
     LogDebug("RPCSimAsymmetricCls") << "Get Eff from RPCSimSetup for detId = " << rpcId.rawId() << " :: " << veffstr;
+#endif
 
     // Efficiency
     int centralStrip = topology.channel(entr) + 1;
@@ -322,6 +324,7 @@ void RPCSimAsymmetricCls::simulateNoise(const RPCRoll* roll, CLHEP::HepRandomEng
   LogDebug("RPCSimAsymmetricCls") << "[RPCSimAsymmetricCls::simulateNoise] Treating DetId :: " << rpcId << " = "
                                   << rpcId.rawId() << " which has " << roll->nstrips() << " strips";
 
+#ifdef EDM_ML_DEBUG
   std::stringstream vnoisestream;
   vnoisestream << "[";
   for (std::vector<float>::iterator vnoiseIt = vnoise.begin(); vnoiseIt != vnoise.end(); ++vnoiseIt) {
@@ -331,6 +334,7 @@ void RPCSimAsymmetricCls::simulateNoise(const RPCRoll* roll, CLHEP::HepRandomEng
   std::string vnoisestr = vnoisestream.str();
   LogDebug("RPCSimAsymmetricCls") << "Get Noise from RPCSimSetup for detId = " << rpcId.rawId() << " :: vector with "
                                   << vnoise.size() << "entries :: " << vnoisestr;
+#endif
 
   unsigned int nstrips = roll->nstrips();
   double area = 0.0;

--- a/SimMuon/RPCDigitizer/src/RPCSimSetUp.cc
+++ b/SimMuon/RPCDigitizer/src/RPCSimSetUp.cc
@@ -103,25 +103,29 @@ void RPCSimSetUp::setRPCSetUp(const std::vector<RPCStripNoises::NoiseItem>& vnoi
   unsigned int current_nStrips;
 
   LogDebug("RPCSimSetup") << "RPCSimSetUp::setRPCSetUp :: ClusterSizeItem :: begin" << std::endl;
+#ifdef EDM_ML_DEBUG
   std::stringstream sslogclsitem;
+#endif
   // ### ClusterSizeItem #######################################################
   std::vector<RPCClusterSize::ClusterSizeItem>::const_iterator itCls;
   int clsCounter(1);
   std::vector<double> clsVect;
   // ### loop for New Format (120 entries)
   for (itCls = vClusterSize.begin(); itCls != vClusterSize.end(); ++itCls) {
-    sslogclsitem << " Push back clustersize = " << itCls->clusterSize << std::endl;
     clsVect.push_back(((double)(itCls->clusterSize)));
+#ifdef EDM_ML_DEBUG
+    sslogclsitem << " Push back clustersize = " << itCls->clusterSize << std::endl;
     sslogclsitem << "Filling cls in _mapDetCls[detId,clsVect] :: detId = " << detId;
     sslogclsitem << " --> will it be accepted? clsCounter = " << clsCounter << " accepted?";
     sslogclsitem << " New Format ::" << ((!(clsCounter % 120)) && (clsCounter != 0));  // <<std::endl;
     sslogclsitem << " Old Format ::" << ((!(clsCounter % 100)) && (clsCounter != 0));  // <<std::endl;
     sslogclsitem << std::endl;
-
+#endif
     // New Format :: loop until 120
     if ((!(clsCounter % 120)) && (clsCounter != 0)) {
       detId = itCls->dpid;
       _mapDetClsMap[detId] = clsVect;
+#ifdef EDM_ML_DEBUG
       std::stringstream LogDebugClsVectString;
       LogDebugClsVectString << "[";
       for (std::vector<double>::iterator itClsVect = clsVect.begin(); itClsVect != clsVect.end(); ++itClsVect) {
@@ -137,27 +141,32 @@ void RPCSimSetUp::setRPCSetUp(const std::vector<RPCStripNoises::NoiseItem>& vnoi
       sslogclsitem << "Filling cls in _mapDetClsMap[detId,clsVect] :: detId = " << detId;
       sslogclsitem << " --> will it be accepted? clsCounter = " << clsCounter << " accepted? "
                    << ((!(clsCounter % 120)) && (clsCounter != 0)) << std::endl;
+#endif
       clsVect.clear();
       clsCounter = 0;
     } else {
+#ifdef EDM_ML_DEBUG
       sslogclsitem << " --> not saved in map " << std::endl;
+#endif
     }
     ++clsCounter;
   }
   // ### loop for Old Format (100 entries)
   for (itCls = vClusterSize.begin(); itCls != vClusterSize.end(); ++itCls) {
-    sslogclsitem << " Push back clustersize = " << itCls->clusterSize << std::endl;
     clsVect.push_back(((double)(itCls->clusterSize)));
+#ifdef EDM_ML_DEBUG
+    sslogclsitem << " Push back clustersize = " << itCls->clusterSize << std::endl;
     sslogclsitem << "Filling cls in _mapDetClsMapLegacy[detId,clsVect] :: detId = " << detId;
     sslogclsitem << " --> will it be accepted? clsCounter = " << clsCounter << " accepted?";
     sslogclsitem << " New Format ::" << ((!(clsCounter % 120)) && (clsCounter != 0));  // <<std::endl;
     sslogclsitem << " Old Format ::" << ((!(clsCounter % 100)) && (clsCounter != 0));  // <<std::endl;
     sslogclsitem << std::endl;
-
+#endif
     // Old Format :: same until 100
     if ((!(clsCounter % 100)) && (clsCounter != 0)) {
       detId = itCls->dpid;
       _mapDetClsMapLegacy[detId] = clsVect;
+#ifdef EDM_ML_DEBUG
       std::stringstream LogDebugClsVectString;
       LogDebugClsVectString << "[";
       for (std::vector<double>::iterator itClsVect = clsVect.begin(); itClsVect != clsVect.end(); ++itClsVect) {
@@ -173,14 +182,18 @@ void RPCSimSetUp::setRPCSetUp(const std::vector<RPCStripNoises::NoiseItem>& vnoi
       sslogclsitem << "Filling cls in _mapDetClsMapLegacy[detId,clsVect] :: detId = " << detId;
       sslogclsitem << " --> will it be accepted? clsCounter = " << clsCounter << " accepted? "
                    << ((!(clsCounter % 120)) && (clsCounter != 0)) << std::endl;
+#endif
       clsVect.clear();
       clsCounter = 0;
     } else {
+#ifdef EDM_ML_DEBUG
       sslogclsitem << " --> not saved in map " << std::endl;
+#endif
     }
     ++clsCounter;
   }
   // ###########################################################################
+#ifdef EDM_ML_DEBUG
   std::string logclsitem = sslogclsitem.str();
   sslogclsitem.clear();
   LogDebug("RPCSimSetupClsLoopDetails") << logclsitem << std::endl;
@@ -188,6 +201,7 @@ void RPCSimSetUp::setRPCSetUp(const std::vector<RPCStripNoises::NoiseItem>& vnoi
 
   LogDebug("RPCSimSetup") << "RPCSimSetUp::setRPCSetUp :: NoiseItem :: begin" << std::endl;
   std::stringstream sslognoiseitem;
+#endif
   // ### NoiseItem #############################################################
   unsigned int count_strips = 1;
   unsigned int count_all = 1;
@@ -207,26 +221,32 @@ void RPCSimSetUp::setRPCSetUp(const std::vector<RPCStripNoises::NoiseItem>& vnoi
     // Test whether this roll (picked up from the conditions) is inside the RPC Geometry
     const RPCRoll* roll = theGeometry->roll(current_rpcId);
     if (roll == nullptr) {
+#ifdef EDM_ML_DEBUG
       sslognoiseitem << "Searching for first valid detid :: current_detId = " << current_detId;
       sslognoiseitem << " aka " << current_rpcId << " is not in current Geometry --> Skip " << std::endl;
+#endif
       continue;
     } else {
+#ifdef EDM_ML_DEBUG
       sslognoiseitem << "Searching for first valid detid :: current_detId = " << current_detId;
       sslognoiseitem << " aka " << current_rpcId
                      << " is the first (valid) roll in the current Geometry --> Accept, Assign & Quit Loop"
                      << std::endl;
+#endif
       current_roll = theGeometry->roll(current_rpcId);
       current_nStrips = current_roll->nstrips();
       quitLoop = true;
     }
   }
 
+#ifdef EDM_ML_DEBUG
   sslognoiseitem << "Start Position ::            current_detId = " << current_detId << " aka " << current_rpcId;
   sslognoiseitem << " is a valid roll with pointer " << current_roll << " and has "
                  << (current_roll ? current_roll->nstrips() : 0) << " strips" << std::endl;
   sslognoiseitem << " -------------------------------------------------------------------------------------------------"
                     "------------------------------------ "
                  << std::endl;
+#endif
   for (std::vector<RPCStripNoises::NoiseItem>::const_iterator it = vnoise.begin(); it != vnoise.end(); ++it) {
     // roll associated to the conditions of this strip (iterator)
     this_detId = it->dpid;
@@ -234,31 +254,35 @@ void RPCSimSetUp::setRPCSetUp(const std::vector<RPCStripNoises::NoiseItem>& vnoi
     // Test whether this roll (picked up from the conditions) is inside the RPC Geometry
     const RPCRoll* roll = theGeometry->roll(this_rpcId);
     if (roll == nullptr) {
+#ifdef EDM_ML_DEBUG
       sslognoiseitem << "Inside Loop :: [" << std::setw(6) << count_all << "][" << std::setw(3) << count_strips
                      << "] :: this_detId = " << this_detId << " aka " << this_rpcId
                      << " which is not in current Geometry --> Skip " << std::endl;
+#endif
       continue;
     }
 
     // Case 1 :: FIRST ENTRY
     // ---------------------
     if (this_detId == current_detId && count_strips == 1) {
-      sslognoiseitem << "RPCSimSetUp::setRPCSetUp :: NoiseItem :: case 1" << std::endl;
-      sslognoiseitem << this_detId << " = " << this_rpcId << " with " << roll->nstrips() << " strips" << std::endl;
       // fill bx in map
       _bxmap[current_detId] = it->time;
-      sslognoiseitem << "[NoiseItem :: n = " << count_all
-                     << "] Filling time in _bxmap[detId] :: detId = " << RPCDetId(it->dpid) << " time = " << it->time
-                     << std::endl;
       // clear vectors
       vveff.clear();
       vvnoise.clear();
       // fill the vectors
       vvnoise.push_back((it->noise));
       vveff.push_back((it->eff));
+#ifdef EDM_ML_DEBUG
+      sslognoiseitem << "RPCSimSetUp::setRPCSetUp :: NoiseItem :: case 1" << std::endl;
+      sslognoiseitem << this_detId << " = " << this_rpcId << " with " << roll->nstrips() << " strips" << std::endl;
+      sslognoiseitem << "[NoiseItem :: n = " << count_all
+                     << "] Filling time in _bxmap[detId] :: detId = " << RPCDetId(it->dpid) << " time = " << it->time
+                     << std::endl;
       sslognoiseitem << "First Value :: [" << std::setw(6) << count_all << "][" << std::setw(3) << count_strips
                      << "] :: this_detId = " << this_detId << " aka " << this_rpcId;
       sslognoiseitem << " Strip " << std::setw(3) << count_strips << " Noise = " << it->noise << " Hz/cm2" << std::endl;
+#endif
       // update counter
       ++count_strips;
       ++count_all;
@@ -266,10 +290,12 @@ void RPCSimSetUp::setRPCSetUp(const std::vector<RPCStripNoises::NoiseItem>& vnoi
     // Case 2 :: 2ND ENTRY --> LAST-1 ENTRY
     // ------------------------------------
     else if (this_detId == current_detId && count_strips > 1 && count_strips < current_nStrips) {
+#ifdef EDM_ML_DEBUG
       sslognoiseitem << "RPCSimSetUp::setRPCSetUp :: NoiseItem :: case 2" << std::endl;
       sslognoiseitem << "Inside Loop :: [" << std::setw(6) << count_all << "][" << std::setw(3) << count_strips
                      << "] :: this_detId = " << this_detId << " aka " << this_rpcId;
       sslognoiseitem << " Strip " << std::setw(3) << count_strips << " Noise = " << it->noise << " Hz/cm2" << std::endl;
+#endif
       // fill the vectors
       vvnoise.push_back((it->noise));
       vveff.push_back((it->eff));
@@ -281,21 +307,24 @@ void RPCSimSetUp::setRPCSetUp(const std::vector<RPCStripNoises::NoiseItem>& vnoi
     // Case 3 :: LAST ENTRY
     // --------------------
     else if (this_detId == current_detId && count_strips == current_nStrips) {
+#ifdef EDM_ML_DEBUG
       sslognoiseitem << "RPCSimSetUp::setRPCSetUp :: NoiseItem :: case 3" << std::endl;
-      // fill last value in the vector
       sslognoiseitem << "Last Value ::  [" << std::setw(6) << count_all << "][" << std::setw(3) << count_strips
                      << "] :: this_detId = " << this_detId << " aka " << this_rpcId;
       sslognoiseitem << " Strip " << std::setw(3) << count_strips << " Noise = " << it->noise << " Hz/cm2" << std::endl;
+#endif
+      // fill last value in the vector
       vvnoise.push_back((it->noise));
       vveff.push_back((it->eff));
       // update counter
       ++count_strips;
       ++count_all;
       // fill vectors into map
-      sslognoiseitem << " fill vectors into map" << std::endl;
       _mapDetIdNoise[current_detId] = vvnoise;
       _mapDetIdEff[current_detId] = vveff;
 
+#ifdef EDM_ML_DEBUG
+      sslognoiseitem << " fill vectors into map" << std::endl;
       std::stringstream LogDebugNoiVectString, LogDebugEffVectString;
       LogDebugNoiVectString << "[";
       for (std::vector<float>::iterator itNoiVect = vvnoise.begin(); itNoiVect != vvnoise.end(); ++itNoiVect) {
@@ -313,12 +342,14 @@ void RPCSimSetUp::setRPCSetUp(const std::vector<RPCStripNoises::NoiseItem>& vnoi
                               << (RPCDetId(it->dpid)).rawId() << " vvnoise = " << LogDebugNoiVectStr;
       LogDebug("RPCSimSetup") << "Filling veff    in _mapDetIdEff[detId]   :: detId = " << RPCDetId(it->dpid) << " = "
                               << (RPCDetId(it->dpid)).rawId() << " veff    = " << LogDebugEffVectStr;
-
+#endif
       // look for next different detId and rename it to the current_detId
       // at this point we skip all the conditions for the strips that are not in this roll
       // and we will go to the conditions for the first strip of the next roll
       bool next_detId_found = false;
+#ifdef EDM_ML_DEBUG
       sslognoiseitem << "look for next different detId" << std::endl;
+#endif
       while (next_detId_found == 0 && it != vnoise.end() - 1) {
         ++it;
         this_detId = it->dpid;
@@ -326,21 +357,27 @@ void RPCSimSetUp::setRPCSetUp(const std::vector<RPCStripNoises::NoiseItem>& vnoi
         this_roll = theGeometry->roll(this_rpcId);
         if (!this_roll)
           continue;
+#ifdef EDM_ML_DEBUG
         sslognoiseitem << "Inside While:: [" << std::setw(6) << count_all << "][" << std::setw(3) << count_strips
                        << "] :: this_detId = " << this_detId << " aka " << this_rpcId << " Noise = " << it->noise
                        << " Hz/cm2" << std::endl;
+#endif
         ++count_strips;
         // ++count_all;
         if (this_detId != current_detId) {
+#ifdef EDM_ML_DEBUG
           sslognoiseitem << "Different detId is found ::                  " << this_detId << " aka " << this_rpcId
                          << " Noise = " << it->noise << " Hz/cm2";
+#endif
           // next roll is found. update current_detId to this newly found detId
           // and update also the number of strips
           current_detId = this_detId;
           current_rpcId = RPCDetId(current_detId);
           next_detId_found = true;
           current_nStrips = (theGeometry->roll(current_rpcId))->nstrips();
+#ifdef EDM_ML_DEBUG
           sslognoiseitem << " with " << current_nStrips << " strips" << std::endl;
+#endif
           --it;  // subtract one, because at the end of the loop the iterator will be increased with one
                  // in fact the treatment for roll N stops when we find the first occurence of roll N+1
                  // however we want to start the treatment for roll N+1 with the first occurence of roll N+1
@@ -357,12 +394,14 @@ void RPCSimSetUp::setRPCSetUp(const std::vector<RPCStripNoises::NoiseItem>& vnoi
     }
   }
   // ###########################################################################
+#ifdef EDM_ML_DEBUG
   std::string lognoiseitem = sslognoiseitem.str();
   sslognoiseitem.clear();
   LogDebug("RPCSimSetupNoiseLoopDetails") << lognoiseitem << std::endl;
   LogDebug("RPCSimSetup") << "RPCSimSetUp::setRPCSetUp :: NoiseItem :: end" << std::endl;
 
   LogDebug("RPCSimSetup") << "RPCSimSetUp::setRPCSetUp :: end" << std::endl;
+#endif
 }
 
 const std::vector<float>& RPCSimSetUp::getNoise(uint32_t id) {


### PR DESCRIPTION
#### PR description:

As noted in https://github.com/cms-sw/cmssw/issues/31123#issuecomment-672881007 a few routines in SimMuon/RPCDigitizer do a lot of relatively expensive stringstream formatting that is never seen unless LogDebug is enabled.  These operations also cause occasional crashes on aarch64 that are not understood.  This PR uses (ugly) `#ifdef EDM_ML_DEBUG` to elide the stringstream operations unless LogDebug is enabled.

#### PR validation:

It compiles.  This is a small technical change that should not result in any physics changes.

