### PR TITLE
Use run-dependent bad channels for CSC, HCAL and strips

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -61,7 +61,7 @@ autoCond = {
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector
     'phase1_2018_realistic'    :  '113X_upgrade2018_realistic_v4',
     # GlobalTag for MC production with realistic run-dependent (RD) conditions for full Phase1 2018 detector
-    'phase1_2018_realistic_rd' :  '113X_upgrade2018_realistic_RD_v2',
+    'phase1_2018_realistic_rd' :  '113X_upgrade2018_realistic_RD_v3',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector for Heavy Ion
     'phase1_2018_realistic_hi' :  '113X_upgrade2018_realistic_HI_v4',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector: HEM-15-16 fail


### PR DESCRIPTION
#### PR description:

This PR adds run dependent tags to the 2018 run-dependent MC queue that represent bad channels for CSC, HCAL and strips. This GT will be used in an upcoming test of the run-dependent MC procedure.

At this point, a simplified IOV structure with equally weighted IOVs is being used and so the HCAL tag only approximately represents the appropriate luminosity weighting of the HEM15/HEM16 failure and non-failure periods. Both the CSC and strips tags have minor technical changes that represent small deviations from 2018 for the purpose of validating the run-dependent machinery. All three will require updates once a more realistic 2018 IOV weighting is supported.

The GT diff is as follows:

**2018 realistic (run-dependent)**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/113X_upgrade2018_realistic_RD_v2/113X_upgrade2018_realistic_RD_v3

#### PR validation:

See the presentations at the [22 Feb 2021 AlCaDB meeting](https://indico.cern.ch/event/1010099/) for details.

In addition, a technical test was performed: `runTheMatrix.py -l 250202.183 --ibeos`

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This PR is not a backport and should not be backported.
