### PR TITLE
[BP to 106X] Add SV charge + small fixes

### DIFF
--- a/Configuration/StandardSequences/python/Eras.py
+++ b/Configuration/StandardSequences/python/Eras.py
@@ -62,7 +62,7 @@ class Eras (object):
                            'trackingLowPU', 'trackingPhase1', 'ctpps_2016', 'trackingPhase2PU140','highBetaStar_2018',
                            'tracker_apv_vfp30_2016', 'pf_badHcalMitigation', 'run2_miniAOD_80XLegacy','run2_miniAOD_94XFall17', 'run2_nanoAOD_92X',
                            'run2_nanoAOD_94XMiniAODv1', 'run2_nanoAOD_94XMiniAODv2', 'run2_nanoAOD_94X2016',
-                           'run2_miniAOD_devel', 'run2_nanoAOD_102Xv1', 'run2_nanoAOD_106Xv1', 'run2_nanoAOD_106Xv2',
+                           'run2_miniAOD_devel', 'run2_nanoAOD_102Xv1', 'run2_nanoAOD_106Xv1', 'run2_nanoAOD_106Xv2', 'run2_nanoAOD_devel', 
                            'run2_tau_ul_2016', 'run2_tau_ul_2018',
                            'hcalHardcodeConditions', 'hcalSkipPacker',
                            'run2_HLTconditions_2016','run2_HLTconditions_2017','run2_HLTconditions_2018',

--- a/PhysicsTools/NanoAOD/plugins/VertexTableProducer.cc
+++ b/PhysicsTools/NanoAOD/plugins/VertexTableProducer.cc
@@ -2,7 +2,7 @@
 //
 // Package:    PhysicsTools/NanoAOD
 // Class:      VertexTableProducer
-// 
+//
 /**\class VertexTableProducer VertexTableProducer.cc PhysicsTools/VertexTableProducer/plugins/VertexTableProducer.cc
 
  Description: [one line class summary]
@@ -15,7 +15,6 @@
 //         Created:  Mon, 28 Aug 2017 09:26:39 GMT
 //
 //
-
 
 // system include files
 #include <memory>
@@ -47,72 +46,65 @@
 //
 
 class VertexTableProducer : public edm::stream::EDProducer<> {
-   public:
-      explicit VertexTableProducer(const edm::ParameterSet&);
-      ~VertexTableProducer() override;
+public:
+  explicit VertexTableProducer(const edm::ParameterSet&);
+  ~VertexTableProducer() override;
 
-      static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
-   private:
-      void beginStream(edm::StreamID) override;
-      void produce(edm::Event&, const edm::EventSetup&) override;
-      void endStream() override;
+private:
+  void beginStream(edm::StreamID) override;
+  void produce(edm::Event&, const edm::EventSetup&) override;
+  void endStream() override;
 
-      //virtual void beginRun(edm::Run const&, edm::EventSetup const&) override;
-      //virtual void endRun(edm::Run const&, edm::EventSetup const&) override;
-      //virtual void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
-      //virtual void endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
+  //virtual void beginRun(edm::Run const&, edm::EventSetup const&) override;
+  //virtual void endRun(edm::Run const&, edm::EventSetup const&) override;
+  //virtual void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
+  //virtual void endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
 
-      // ----------member data ---------------------------
+  // ----------member data ---------------------------
 
-      const edm::EDGetTokenT<std::vector<reco::Vertex>> pvs_;
-      const edm::EDGetTokenT<edm::ValueMap<float>> pvsScore_;
-      const edm::EDGetTokenT<edm::View<reco::VertexCompositePtrCandidate> > svs_;
-      const StringCutObjectSelector<reco::Candidate> svCut_;
-      const StringCutObjectSelector<reco::Vertex> goodPvCut_;
-      const std::string goodPvCutString_;
-      const std::string  pvName_;
-      const std::string  svName_;
-      const std::string svDoc_;
-      const double dlenMin_,dlenSigMin_;
-
+  const edm::EDGetTokenT<std::vector<reco::Vertex>> pvs_;
+  const edm::EDGetTokenT<edm::ValueMap<float>> pvsScore_;
+  const edm::EDGetTokenT<edm::View<reco::VertexCompositePtrCandidate>> svs_;
+  const StringCutObjectSelector<reco::Candidate> svCut_;
+  const StringCutObjectSelector<reco::Vertex> goodPvCut_;
+  const std::string goodPvCutString_;
+  const std::string pvName_;
+  const std::string svName_;
+  const std::string svDoc_;
+  const double dlenMin_, dlenSigMin_;
+  const bool storeCharge_;
 };
-
-
 
 //
 // constructors and destructor
 //
-VertexTableProducer::VertexTableProducer(const edm::ParameterSet& params):
-    pvs_(consumes<std::vector<reco::Vertex>>( params.getParameter<edm::InputTag>("pvSrc") )),
-    pvsScore_(consumes<edm::ValueMap<float>>( params.getParameter<edm::InputTag>("pvSrc") )),
-    svs_(consumes<edm::View<reco::VertexCompositePtrCandidate> >( params.getParameter<edm::InputTag>("svSrc") )),
-    svCut_(params.getParameter<std::string>("svCut") , true),
-    goodPvCut_(params.getParameter<std::string>("goodPvCut") , true),
-    goodPvCutString_(params.getParameter<std::string>("goodPvCut") ),
-    pvName_(params.getParameter<std::string>("pvName") ),
-    svName_(params.getParameter<std::string>("svName") ),
-    svDoc_(params.getParameter<std::string>("svDoc") ),
-    dlenMin_(params.getParameter<double>("dlenMin") ),
-    dlenSigMin_(params.getParameter<double>("dlenSigMin") )
-   
+VertexTableProducer::VertexTableProducer(const edm::ParameterSet& params)
+    : pvs_(consumes<std::vector<reco::Vertex>>(params.getParameter<edm::InputTag>("pvSrc"))),
+      pvsScore_(consumes<edm::ValueMap<float>>(params.getParameter<edm::InputTag>("pvSrc"))),
+      svs_(consumes<edm::View<reco::VertexCompositePtrCandidate>>(params.getParameter<edm::InputTag>("svSrc"))),
+      svCut_(params.getParameter<std::string>("svCut"), true),
+      goodPvCut_(params.getParameter<std::string>("goodPvCut"), true),
+      goodPvCutString_(params.getParameter<std::string>("goodPvCut")),
+      pvName_(params.getParameter<std::string>("pvName")),
+      svName_(params.getParameter<std::string>("svName")),
+      svDoc_(params.getParameter<std::string>("svDoc")),
+      dlenMin_(params.getParameter<double>("dlenMin")),
+      dlenSigMin_(params.getParameter<double>("dlenSigMin")),
+      storeCharge_(params.getParameter<bool>("storeCharge"))
+
 {
-   produces<nanoaod::FlatTable>("pv");
-   produces<nanoaod::FlatTable>("otherPVs");
-   produces<nanoaod::FlatTable>("svs");
-   produces<edm::PtrVector<reco::Candidate> >();
- 
+  produces<nanoaod::FlatTable>("pv");
+  produces<nanoaod::FlatTable>("otherPVs");
+  produces<nanoaod::FlatTable>("svs");
+  produces<edm::PtrVector<reco::Candidate>>();
 }
 
-
-VertexTableProducer::~VertexTableProducer()
-{
- 
-   // do anything here that needs to be done at destruction time
-   // (e.g. close files, deallocate resources etc.)
-
+VertexTableProducer::~VertexTableProducer() {
+  // do anything here that needs to be done at destruction time
+  // (e.g. close files, deallocate resources etc.)
 }
-
 
 //
 // member functions
@@ -120,91 +112,113 @@ VertexTableProducer::~VertexTableProducer()
 
 // ------------ method called to produce the data  ------------
 
+void VertexTableProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  using namespace edm;
+  edm::Handle<edm::ValueMap<float>> pvsScoreIn;
+  edm::Handle<std::vector<reco::Vertex>> pvsIn;
+  iEvent.getByToken(pvs_, pvsIn);
+  iEvent.getByToken(pvsScore_, pvsScoreIn);
+  auto pvTable = std::make_unique<nanoaod::FlatTable>(1, pvName_, true);
+  pvTable->addColumnValue<float>(
+      "ndof", (*pvsIn)[0].ndof(), "main primary vertex number of degree of freedom", nanoaod::FlatTable::FloatColumn, 8);
+  pvTable->addColumnValue<float>(
+      "x", (*pvsIn)[0].position().x(), "main primary vertex position x coordinate", nanoaod::FlatTable::FloatColumn, 10);
+  pvTable->addColumnValue<float>(
+      "y", (*pvsIn)[0].position().y(), "main primary vertex position y coordinate", nanoaod::FlatTable::FloatColumn, 10);
+  pvTable->addColumnValue<float>(
+      "z", (*pvsIn)[0].position().z(), "main primary vertex position z coordinate", nanoaod::FlatTable::FloatColumn, 16);
+  pvTable->addColumnValue<float>(
+      "chi2", (*pvsIn)[0].normalizedChi2(), "main primary vertex reduced chi2", nanoaod::FlatTable::FloatColumn, 8);
+  int goodPVs = 0;
+  for (const auto& pv : *pvsIn)
+    if (goodPvCut_(pv))
+      goodPVs++;
+  pvTable->addColumnValue<int>(
+      "npvs", (*pvsIn).size(), "total number of reconstructed primary vertices", nanoaod::FlatTable::IntColumn);
+  pvTable->addColumnValue<int>("npvsGood",
+                               goodPVs,
+                               "number of good reconstructed primary vertices. selection:" + goodPvCutString_,
+                               nanoaod::FlatTable::IntColumn);
+  pvTable->addColumnValue<float>("score",
+                                 (*pvsScoreIn).get(pvsIn.id(), 0),
+                                 "main primary vertex score, i.e. sum pt2 of clustered objects",
+                                 nanoaod::FlatTable::FloatColumn,
+                                 8);
 
-void
-VertexTableProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
-{
-    using namespace edm;
-    edm::Handle<edm::ValueMap<float>> pvsScoreIn;
-    edm::Handle<std::vector<reco::Vertex>> pvsIn;
-    iEvent.getByToken(pvs_, pvsIn);
-    iEvent.getByToken(pvsScore_, pvsScoreIn);
-    auto pvTable = std::make_unique<nanoaod::FlatTable>(1,pvName_,true);
-    pvTable->addColumnValue<float>("ndof",(*pvsIn)[0].ndof(),"main primary vertex number of degree of freedom",nanoaod::FlatTable::FloatColumn,8);
-    pvTable->addColumnValue<float>("x",(*pvsIn)[0].position().x(),"main primary vertex position x coordinate",nanoaod::FlatTable::FloatColumn,10);
-    pvTable->addColumnValue<float>("y",(*pvsIn)[0].position().y(),"main primary vertex position y coordinate",nanoaod::FlatTable::FloatColumn,10);
-    pvTable->addColumnValue<float>("z",(*pvsIn)[0].position().z(),"main primary vertex position z coordinate",nanoaod::FlatTable::FloatColumn,16);
-    pvTable->addColumnValue<float>("chi2",(*pvsIn)[0].normalizedChi2(),"main primary vertex reduced chi2",nanoaod::FlatTable::FloatColumn,8);
-    int goodPVs=0;
-    for (const auto & pv : *pvsIn) if (goodPvCut_(pv)) goodPVs++;
-    pvTable->addColumnValue<int>("npvs",(*pvsIn).size(),"total number of reconstructed primary vertices",nanoaod::FlatTable::IntColumn);
-    pvTable->addColumnValue<int>("npvsGood",goodPVs,"number of good reconstructed primary vertices. selection:"+goodPvCutString_,nanoaod::FlatTable::IntColumn);
-    pvTable->addColumnValue<float>("score",(*pvsScoreIn).get(pvsIn.id(),0),"main primary vertex score, i.e. sum pt2 of clustered objects",nanoaod::FlatTable::FloatColumn,8);
+  auto otherPVsTable =
+      std::make_unique<nanoaod::FlatTable>((*pvsIn).size() > 4 ? 3 : (*pvsIn).size() - 1, "Other" + pvName_, false);
+  std::vector<float> pvsz;
+  for (size_t i = 1; i < (*pvsIn).size() && i < 4; i++)
+    pvsz.push_back((*pvsIn)[i - 1].position().z());
+  otherPVsTable->addColumn<float>(
+      "z", pvsz, "Z position of other primary vertices, excluding the main PV", nanoaod::FlatTable::FloatColumn, 8);
 
-    auto otherPVsTable = std::make_unique<nanoaod::FlatTable>((*pvsIn).size() >4?3:(*pvsIn).size()-1,"Other"+pvName_,false);
-    std::vector<float> pvsz;
-    for(size_t i=1;i < (*pvsIn).size() && i < 4; i++) pvsz.push_back((*pvsIn)[i-1].position().z());
-    otherPVsTable->addColumn<float>("z",pvsz,"Z position of other primary vertices, excluding the main PV",nanoaod::FlatTable::FloatColumn,8);
+  edm::Handle<edm::View<reco::VertexCompositePtrCandidate>> svsIn;
+  iEvent.getByToken(svs_, svsIn);
+  auto selCandSv = std::make_unique<PtrVector<reco::Candidate>>();
+  std::vector<float> dlen, dlenSig, pAngle, dxy, dxySig;
+  std::vector<int> charge;
+  VertexDistance3D vdist;
+  VertexDistanceXY vdistXY;
 
+  size_t i = 0;
+  const auto& PV0 = pvsIn->front();
+  for (const auto& sv : *svsIn) {
+    if (svCut_(sv)) {
+      Measurement1D dl =
+          vdist.distance(PV0, VertexState(RecoVertex::convertPos(sv.position()), RecoVertex::convertError(sv.error())));
+      if (dl.value() > dlenMin_ and dl.significance() > dlenSigMin_) {
+        dlen.push_back(dl.value());
+        dlenSig.push_back(dl.significance());
+        edm::Ptr<reco::Candidate> c = svsIn->ptrAt(i);
+        selCandSv->push_back(c);
+        double dx = (PV0.x() - sv.vx()), dy = (PV0.y() - sv.vy()), dz = (PV0.z() - sv.vz());
+        double pdotv = (dx * sv.px() + dy * sv.py() + dz * sv.pz()) / sv.p() / sqrt(dx * dx + dy * dy + dz * dz);
+        pAngle.push_back(std::acos(pdotv));
+        Measurement1D d2d = vdistXY.distance(
+            PV0, VertexState(RecoVertex::convertPos(sv.position()), RecoVertex::convertError(sv.error())));
+        dxy.push_back(d2d.value());
+        dxySig.push_back(d2d.significance());
 
-    edm::Handle<edm::View<reco::VertexCompositePtrCandidate> > svsIn;
-    iEvent.getByToken(svs_, svsIn);
-    auto selCandSv = std::make_unique<PtrVector<reco::Candidate>>();
-    std::vector<float> dlen,dlenSig,pAngle,dxy,dxySig;
-    VertexDistance3D vdist;
-    VertexDistanceXY vdistXY;
-
-    size_t i=0;
-    const auto & PV0 = pvsIn->front();
-    for (const auto & sv : *svsIn) {
-       if (svCut_(sv)) {
-           Measurement1D dl= vdist.distance(PV0,VertexState(RecoVertex::convertPos(sv.position()),RecoVertex::convertError(sv.error())));
-           if(dl.value() > dlenMin_ and dl.significance() > dlenSigMin_){
-               dlen.push_back(dl.value());
-               dlenSig.push_back(dl.significance());
-               edm::Ptr<reco::Candidate> c =  svsIn->ptrAt(i);
-               selCandSv->push_back(c);
-               double dx = (PV0.x() - sv.vx()), dy = (PV0.y() - sv.vy()), dz = (PV0.z() - sv.vz());
-               double pdotv = (dx * sv.px() + dy*sv.py() + dz*sv.pz())/sv.p()/sqrt(dx*dx + dy*dy + dz*dz);
-               pAngle.push_back(std::acos(pdotv));
-	       Measurement1D d2d = vdistXY.distance(PV0, VertexState(RecoVertex::convertPos(sv.position()), RecoVertex::convertError(sv.error())));
-	       dxy.push_back(d2d.value());
-	       dxySig.push_back(d2d.significance());
-           }
-       }
-       i++;
+        if (storeCharge_) {
+          int sum_charge = 0;
+          for (unsigned int id = 0; id < sv.numberOfDaughters(); ++id) {
+            const reco::Candidate* daughter = sv.daughter(id);
+            sum_charge += daughter->charge();
+          }
+          charge.push_back(sum_charge);
+        }
+      }
     }
+    i++;
+  }
 
+  auto svsTable = std::make_unique<nanoaod::FlatTable>(selCandSv->size(), svName_, false);
+  // For SV we fill from here only stuff that cannot be created with the SimpleFlatTableProducer
+  svsTable->addColumn<float>("dlen", dlen, "decay length in cm", nanoaod::FlatTable::FloatColumn, 10);
+  svsTable->addColumn<float>("dlenSig", dlenSig, "decay length significance", nanoaod::FlatTable::FloatColumn, 10);
+  svsTable->addColumn<float>("dxy", dxy, "2D decay length in cm", nanoaod::FlatTable::FloatColumn, 10);
+  svsTable->addColumn<float>("dxySig", dxySig, "2D decay length significance", nanoaod::FlatTable::FloatColumn, 10);
+  svsTable->addColumn<float>(
+      "pAngle", pAngle, "pointing angle, i.e. acos(p_SV * (SV - PV)) ", nanoaod::FlatTable::FloatColumn, 10);
+  if (storeCharge_) {
+    svsTable->addColumn<int>("charge", charge, "sum of the charge of the SV tracks", nanoaod::FlatTable::IntColumn, 10);
+  }
 
-    auto svsTable = std::make_unique<nanoaod::FlatTable>(selCandSv->size(),svName_,false);
-    // For SV we fill from here only stuff that cannot be created with the SimpleFlatTableProducer 
-    svsTable->addColumn<float>("dlen",dlen,"decay length in cm",nanoaod::FlatTable::FloatColumn,10);
-    svsTable->addColumn<float>("dlenSig",dlenSig,"decay length significance",nanoaod::FlatTable::FloatColumn, 10);
-    svsTable->addColumn<float>("dxy", dxy, "2D decay length in cm", nanoaod::FlatTable::FloatColumn, 10);
-    svsTable->addColumn<float>("dxySig", dxySig, "2D decay length significance", nanoaod::FlatTable::FloatColumn, 10);
-    svsTable->addColumn<float>("pAngle",pAngle,"pointing angle, i.e. acos(p_SV * (SV - PV)) ",nanoaod::FlatTable::FloatColumn,10);
- 
-
-    iEvent.put(std::move(pvTable),"pv");
-    iEvent.put(std::move(otherPVsTable),"otherPVs");
-    iEvent.put(std::move(svsTable),"svs");
-    iEvent.put(std::move(selCandSv));
+  iEvent.put(std::move(pvTable), "pv");
+  iEvent.put(std::move(otherPVsTable), "otherPVs");
+  iEvent.put(std::move(svsTable), "svs");
+  iEvent.put(std::move(selCandSv));
 }
 
 // ------------ method called once each stream before processing any runs, lumis or events  ------------
-void
-VertexTableProducer::beginStream(edm::StreamID)
-{
-}
+void VertexTableProducer::beginStream(edm::StreamID) {}
 
 // ------------ method called once each stream after processing all runs, lumis and events  ------------
-void
-VertexTableProducer::endStream() {
-}
+void VertexTableProducer::endStream() {}
 
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
-void
-VertexTableProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+void VertexTableProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   //The following says we do not know what parameters are allowed so do no validation
   // Please change this to state exactly what you do use, even if it is no parameters
   edm::ParameterSetDescription desc;

--- a/PhysicsTools/NanoAOD/python/nanoDQM_cff.py
+++ b/PhysicsTools/NanoAOD/python/nanoDQM_cff.py
@@ -67,9 +67,15 @@ run2_miniAOD_80XLegacy.toModify(nanoDQM.vplots.Flag, plots = _Flag_plots_80x)
 run2_miniAOD_80XLegacy.toModify(nanoDQM.vplots, IsoTrack = None)
 
 
+## no-change policy in run2_nanoAOD_106Xv1 (nanoAOD-v8)
+_sv_plots_nom = copy.deepcopy(nanoDQM.vplots.SV.plots)
+_sv_plots_106Xv1 = cms.VPSet()
+for plot in _sv_plots_nom:
+    if (plot.name.value() != "charge"):
+        _sv_plots_106Xv1.append(plot)
 from Configuration.Eras.Modifier_run2_nanoAOD_106Xv1_cff import run2_nanoAOD_106Xv1
 from Configuration.Eras.Modifier_run2_nanoAOD_devel_cff import run2_nanoAOD_devel
-(run2_nanoAOD_106Xv1 and ~run2_nanoAOD_devel).toModify(nanoDQM.vplots.SV , charge = None)
+(run2_nanoAOD_106Xv1 and ~run2_nanoAOD_devel).toModify(nanoDQM.vplots.SV, plots = _sv_plots_106Xv1 )
 
 
 ## MC

--- a/PhysicsTools/NanoAOD/python/nanoDQM_cff.py
+++ b/PhysicsTools/NanoAOD/python/nanoDQM_cff.py
@@ -66,6 +66,12 @@ run2_miniAOD_80XLegacy.toModify(nanoDQM.vplots.Flag, plots = _Flag_plots_80x)
 
 run2_miniAOD_80XLegacy.toModify(nanoDQM.vplots, IsoTrack = None)
 
+
+from Configuration.Eras.Modifier_run2_nanoAOD_106Xv1_cff import run2_nanoAOD_106Xv1
+from Configuration.Eras.Modifier_run2_nanoAOD_devel_cff import run2_nanoAOD_devel
+(run2_nanoAOD_106Xv1 and ~run2_nanoAOD_devel).toModify(nanoDQM.vplots.SV , charge = None)
+
+
 ## MC
 nanoDQMMC = nanoDQM.clone()
 nanoDQMMC.vplots.Electron.sels.Prompt = cms.string("genPartFlav == 1")

--- a/PhysicsTools/NanoAOD/python/nanoDQM_cff.py
+++ b/PhysicsTools/NanoAOD/python/nanoDQM_cff.py
@@ -75,7 +75,7 @@ for plot in _sv_plots_nom:
         _sv_plots_106Xv1.append(plot)
 from Configuration.Eras.Modifier_run2_nanoAOD_106Xv1_cff import run2_nanoAOD_106Xv1
 from Configuration.Eras.Modifier_run2_nanoAOD_devel_cff import run2_nanoAOD_devel
-(run2_nanoAOD_106Xv1 and ~run2_nanoAOD_devel).toModify(nanoDQM.vplots.SV, plots = _sv_plots_106Xv1 )
+(run2_nanoAOD_106Xv1 & ~run2_nanoAOD_devel).toModify(nanoDQM.vplots.SV, plots = _sv_plots_106Xv1 )
 
 
 ## MC

--- a/PhysicsTools/NanoAOD/python/nanoDQM_cfi.py
+++ b/PhysicsTools/NanoAOD/python/nanoDQM_cfi.py
@@ -669,6 +669,7 @@ nanoDQM = DQMEDAnalyzer("NanoAODDQM",
                 Plot1D('y', 'y', 20, -0.5, 0.5, 'secondary vertex Y position, in cm'),
                 Plot1D('z', 'z', 20, -10, 10, 'secondary vertex Z position, in cm'),
                 Plot1D('ntracks', 'ntracks', 11, -0.5, 10.5, 'number of tracks'),
+                Plot1D('charge', 'charge', 11 , -0.5, 10.5, 'sum of the charge of the SV tracks'),
             )
         ),
         SoftActivityJet = cms.PSet(

--- a/PhysicsTools/NanoAOD/python/nano_cff.py
+++ b/PhysicsTools/NanoAOD/python/nano_cff.py
@@ -117,7 +117,7 @@ nanoSequenceOnlyData = cms.Sequence(protonTables + lhcInfoTable)
 
 nanoSequence = cms.Sequence(nanoSequenceCommon + nanoSequenceOnlyData + nanoSequenceOnlyFullSim)
 
-( run2_nanoAOD_106Xv1 and ~run2_nanoAOD_devel).toReplaceWith(nanoSequence, nanoSequence.copyAndExclude([nanoSequenceOnlyData]))
+( run2_nanoAOD_106Xv1 & ~run2_nanoAOD_devel).toReplaceWith(nanoSequence, nanoSequence.copyAndExclude([nanoSequenceOnlyData]))
 
 nanoSequenceFS = cms.Sequence(genParticleSequence + genVertexTables + particleLevelSequence + nanoSequenceCommon + jetMC + muonMC + electronMC + photonMC + tauMC + metMC + ttbarCatMCProducers +  globalTablesMC + btagWeightTable + genWeightsTable + genVertexTable + genParticleTables + particleLevelTables + lheInfoTable  + ttbarCategoryTable )
 

--- a/PhysicsTools/NanoAOD/python/protons_cff.py
+++ b/PhysicsTools/NanoAOD/python/protons_cff.py
@@ -67,4 +67,4 @@ if singleRPProtons: protonTables.insert(protonTables.index(multiRPTable),singleR
 
 (run2_nanoAOD_92X | run2_miniAOD_80XLegacy | run2_nanoAOD_94X2016 | run2_nanoAOD_94X2016 | \
     run2_nanoAOD_94XMiniAODv1 | run2_nanoAOD_94XMiniAODv2 | \
-    run2_nanoAOD_102Xv1 | ( run2_nanoAOD_106Xv1 and ~run2_nanoAOD_devel) ).toReplaceWith(protonTables, cms.Sequence())
+    run2_nanoAOD_102Xv1 | ( run2_nanoAOD_106Xv1 & ~run2_nanoAOD_devel) ).toReplaceWith(protonTables, cms.Sequence())

--- a/PhysicsTools/NanoAOD/python/vertices_cff.py
+++ b/PhysicsTools/NanoAOD/python/vertices_cff.py
@@ -37,8 +37,6 @@ svCandidateTable =  cms.EDProducer("SimpleCandidateFlatTableProducer",
 )
 
 ## do not add SV_charge in nanoAODv8
-from Configuration.Eras.Modifier_run2_nanoAOD_106Xv1_cff import run2_nanoAOD_106Xv1
-from Configuration.Eras.Modifier_run2_nanoAOD_devel_cff import run2_nanoAOD_devel
 (run2_nanoAOD_106Xv1 and ~run2_nanoAOD_devel).toModify(vertexTable , storeCharge = False)
 
 

--- a/PhysicsTools/NanoAOD/python/vertices_cff.py
+++ b/PhysicsTools/NanoAOD/python/vertices_cff.py
@@ -37,7 +37,7 @@ svCandidateTable =  cms.EDProducer("SimpleCandidateFlatTableProducer",
 )
 
 ## do not add SV_charge in nanoAODv8
-(run2_nanoAOD_106Xv1 and ~run2_nanoAOD_devel).toModify(vertexTable , storeCharge = False)
+(run2_nanoAOD_106Xv1 & ~run2_nanoAOD_devel).toModify(vertexTable , storeCharge = False)
 
 
 

--- a/PhysicsTools/NanoAOD/python/vertices_cff.py
+++ b/PhysicsTools/NanoAOD/python/vertices_cff.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 from  PhysicsTools.NanoAOD.common_cff import *
-
+from  PhysicsTools.NanoAOD.nano_eras_cff import *
 
 
 ##################### User floats producers, selectors ##########################
@@ -14,6 +14,7 @@ vertexTable = cms.EDProducer("VertexTableProducer",
     svCut = cms.string(""),
     dlenMin = cms.double(0),
     dlenSigMin = cms.double(3),
+    storeCharge = cms.bool(True),
     pvName = cms.string("PV"),
     svName = cms.string("SV"),
     svDoc  = cms.string("secondary vertices from IVF algorithm"),
@@ -34,6 +35,14 @@ svCandidateTable =  cms.EDProducer("SimpleCandidateFlatTableProducer",
         ntracks = Var("numberOfDaughters()", "uint8", doc = "number of tracks"),
     ),
 )
+
+## do not add SV_charge in nanoAODv8
+from Configuration.Eras.Modifier_run2_nanoAOD_106Xv1_cff import run2_nanoAOD_106Xv1
+from Configuration.Eras.Modifier_run2_nanoAOD_devel_cff import run2_nanoAOD_devel
+(run2_nanoAOD_106Xv1 and ~run2_nanoAOD_devel).toModify(vertexTable , storeCharge = False)
+
+
+
 svCandidateTable.variables.pt.precision=10
 svCandidateTable.variables.phi.precision=12
 


### PR DESCRIPTION
#### PR description:

Add the sum of the charge of the tracks associated to each SV.
Needed for BTV, Charm tagging calibration in the W+c channel, and analyses

In addition this PR:
- adds the run2_nanoAOD_devel era that was accidentally missed in Configuration/StandardSequences/python/Eras.py
- fixes the no-change policy condition for nanoaod-v8 added in the [PR32960](#32960) for PPS

Backport of #32874

#### PR validation:

This BP will not change the content of the current nanoAOD-v8 production. Validated with:
`cmsDriver.py test_nanoTuples_mc2017 -n 10 --mc --eventcontent NANOAODSIM --datatier NANOAODSIM --conditions auto:phase1_2017_realistic --step NANO --nThreads 1 --era Run2_2017,run2_nanoAOD_106Xv1 --filein /store/mc/RunIISummer19UL17MiniAOD/TTToSemiLeptonic_TuneCP5CR2_13TeV-powheg-pythia8/MINIAODSIM/106X_mc2017_realistic_v6-v1/10000/466694A9-3806-624C-87A0-97C8379FAD23.root --fileout file:nano_mc2017.root`

Will change the upcoming nanoAOD-v9 and validated with:
`cmsDriver.py test_nanoTuples_mc2018 -n 10 --mc --eventcontent NANOAODSIM --datatier NANOAODSIM --conditions auto:phase1_2018_realistic --step NANO --nThreads 1 --era Run2_2018,run2_nanoAOD_devel --filein file:/eos/cms/store/mc/RunIISummer20UL18MiniAODv2/DYJetsToLL_M-50_TuneCP5_13TeV-madgraphMLM-pythia8/MINIAODSIM/106X_upgrade2018_realistic_v16_L1v1_ext1-v1/40000/FC5EE12D-1060-0A47-B8D7-288DE478BC6F.root --fileout file:nano_mc2018.root`


#### Comment:
The majority of the modifications in `PhysicsTools/NanoAOD/plugins/VertexTableProducer.cc` are after running: scram build code-format following [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)