### PR TITLE
[DD4hep] Enable DD4hep workflows to use DD4hep for the magnetic field

### DIFF
--- a/Configuration/StandardSequences/python/MagneticField_cff.py
+++ b/Configuration/StandardSequences/python/MagneticField_cff.py
@@ -5,6 +5,11 @@
 import FWCore.ParameterSet.Config as cms
 from MagneticField.Engine.volumeBasedMagneticFieldFromDB_cfi import *
 
+from MagneticField.Engine.volumeBasedMagneticFieldFromDB_dd4hep_cfi import VolumeBasedMagneticFieldESProducer as _VolumeBasedMagneticFieldESProducer_dd4hep
+
+from Configuration.ProcessModifiers.dd4hep_cff import dd4hep
+dd4hep.toReplaceWith(VolumeBasedMagneticFieldESProducer, _VolumeBasedMagneticFieldESProducer_dd4hep)
+
 # Parabolic parametrized magnetic field used for track building (scaled to nominal map closest to current from runInfo)
 from MagneticField.ParametrizedEngine.autoParabolicParametrizedField_cfi import ParametrizedMagneticFieldProducer as ParabolicParametrizedMagneticFieldProducer
 ParabolicParametrizedMagneticFieldProducer.label = "ParabolicMf"

--- a/MagneticField/Engine/python/volumeBasedMagneticFieldFromDB_cfi.py
+++ b/MagneticField/Engine/python/volumeBasedMagneticFieldFromDB_cfi.py
@@ -11,3 +11,11 @@ VolumeBasedMagneticFieldESProducer = cms.ESProducer("VolumeBasedMagneticFieldESP
     valueOverride = cms.int32(-1), # Force value of current (in A); take the value from DB if < 0.
 )
 
+_VolumeBasedMagneticFieldESProducer_dd4hep = cms.ESProducer("DD4hep_VolumeBasedMagneticFieldESProducerFromDB",
+    label = cms.untracked.string(''),
+    debugBuilder = cms.untracked.bool(False),
+    valueOverride = cms.int32(-1), # Force value of current (in A); take the value from DB if < 0.
+)
+
+from Configuration.ProcessModifiers.dd4hep_cff import dd4hep
+dd4hep.toReplaceWith(VolumeBasedMagneticFieldESProducer, _VolumeBasedMagneticFieldESProducer_dd4hep)

--- a/MagneticField/Engine/python/volumeBasedMagneticFieldFromDB_cfi.py
+++ b/MagneticField/Engine/python/volumeBasedMagneticFieldFromDB_cfi.py
@@ -11,11 +11,3 @@ VolumeBasedMagneticFieldESProducer = cms.ESProducer("VolumeBasedMagneticFieldESP
     valueOverride = cms.int32(-1), # Force value of current (in A); take the value from DB if < 0.
 )
 
-_VolumeBasedMagneticFieldESProducer_dd4hep = cms.ESProducer("DD4hep_VolumeBasedMagneticFieldESProducerFromDB",
-    label = cms.untracked.string(''),
-    debugBuilder = cms.untracked.bool(False),
-    valueOverride = cms.int32(-1), # Force value of current (in A); take the value from DB if < 0.
-)
-
-from Configuration.ProcessModifiers.dd4hep_cff import dd4hep
-dd4hep.toReplaceWith(VolumeBasedMagneticFieldESProducer, _VolumeBasedMagneticFieldESProducer_dd4hep)

--- a/MagneticField/GeomBuilder/plugins/dd4hep/DD4hep_VolumeBasedMagneticFieldESProducerFromDB.cc
+++ b/MagneticField/GeomBuilder/plugins/dd4hep/DD4hep_VolumeBasedMagneticFieldESProducerFromDB.cc
@@ -150,7 +150,8 @@ std::unique_ptr<MagneticField> DD4hep_VolumeBasedMagneticFieldESProducerFromDB::
   std::unique_ptr<MagneticField> paramField =
       ParametrizedMagneticFieldFactory::get(conf->slaveFieldVersion, conf->slaveFieldParameters);
 
-  edm::LogInfo("MagneticField") << "Version: " << conf->version << " geometryVersion: " << conf->geometryVersion
+  edm::LogInfo("MagneticField") << "(DD4hep) Version: " << conf->version
+                                << " geometryVersion: " << conf->geometryVersion
                                 << " slaveFieldVersion: " << conf->slaveFieldVersion;
 
   if (conf->version == "parametrizedMagneticField") {
@@ -182,7 +183,7 @@ std::unique_ptr<MagneticField> DD4hep_VolumeBasedMagneticFieldESProducerFromDB::
       "<MaterialSection label=\"materials.xml\"><ElementaryMaterial name=\"materials:Vacuum\" density=\"1e-13*mg/cm3\" "
       "symbol=\" \" atomicWeight=\"1*g/mole\" atomicNumber=\"1\"/></MaterialSection>");
 
-  auto ddet = make_unique<cms::DDDetector>("", sblob, true);
+  auto ddet = make_unique<cms::DDDetector>("cmsMagneticField:MAGF", sblob, true);
 
   builder.build(ddet.get());
 


### PR DESCRIPTION
Up to now, DD4hep workflows were using old DD for the magnetic field. The DD4hep magnetic field producer was already in place, but it wasn't called. This PR uses the dd4hep modifier to call the DD4hep producer for DD4hep workflows, and the old DD producer for old DD workflows.

Creating a new DD4hep detector for the magnetic field with the same name as the one used for the CMS detector caused a conflict, so a new, unique name has been provided for the magnetic field `cms::DDDetector`. 

#### PR validation:

Debug output from the old DD 11634.0 and DD4hep 11634.911 workflows were checked to see that either old DD or DD4hep was being used as appropriate.

No backport is needed.