### PR TITLE
Caloparticle debugger improvements

### DIFF
--- a/SimGeneral/Debugging/plugins/CaloParticleDebugger.cc
+++ b/SimGeneral/Debugging/plugins/CaloParticleDebugger.cc
@@ -181,51 +181,52 @@ void CaloParticleDebugger::analyze(const edm::Event& iEvent, const edm::EventSet
   int idx = 0;
 
   std::map<int, int> trackid_to_track_index;
-  std::cout << "\n\n**Printing SimTracks information **" << std::endl;
-  std::cout << "IDX\tTrackId\tPDGID\tMOMENTUM(x,y,z,E)\tVertexIdx\tGenPartIdx" << std::endl;
+  LogVerbatim("CaloParticleDebuggerSimTracks") << "\n\n**Printing SimTracks information **" ;
+  LogVerbatim("CaloParticleDebuggerSimTracks") << "IDX\tTrackId\tPDGID\tMOMENTUM(x,y,z,E)\tVertexIdx\tGenPartIdx" ;
   for (auto i : sorted_tracks_idx) {
     auto const& t = tracks[i];
-    std::cout << idx << "\t" << t.trackId() << "\t" << t << std::endl;
-    std::cout << "Crossed  Boundary: " << t.crossedBoundary()
+    LogVerbatim("CaloParticleDebuggerSimTracks") << idx << "\t" << t.trackId() << "\t" << t ;
+    LogVerbatim("CaloParticleDebuggerSimTracks") << "Crossed  Boundary: " << t.crossedBoundary()
               << "  Position Boundary: " << t.getPositionAtBoundary()
               << "  Momentum Boundary: " << t.getMomentumAtBoundary()
               << "  Vtx:               " << t.vertIndex()
               << "  Momemtum Origin:   " << t.momentum()
-              << std::endl;
+              ;
     trackid_to_track_index[t.trackId()] = idx;
     idx++;
   }
 
-  std::cout << "\n\n**Printing GenParticles information **" << std::endl;
-  std::cout << "IDX\tPDGID\tMOMENTUM(x,y,z)\tVertex(x,y,z)" << std::endl;
+  LogVerbatim("CaloParticleDebuggerGenParticles") << "\n\n**Printing GenParticles information **" ;
+  LogVerbatim("CaloParticleDebuggerGenParticles") << "IDX\tPDGID\tMOMENTUM(x,y,z)\tVertex(x,y,z)" ;
   for (auto i : sorted_genParticles_idx) {
     auto const& gp = genParticles[i];
-    std::cout << i << "\t" << gp.pdgId() << "\t" << gp.momentum() << "\t" << gp.vertex() << std::endl;
+    LogVerbatim("CaloParticleDebuggerGenParticles") << i << "\t" << gp.pdgId() << "\t" << gp.momentum() << "\t" << gp.vertex() ;
   }
 
-  std::cout << "\n\n**Printing SimVertex information **" << std::endl;
-  std::cout << "IDX\tPOSITION(x,y,z)\tPARENT_INDEX\tVERTEX_ID" << std::endl;
+  LogVerbatim("CaloParticleDebuggerSimVertices") << "\n\n**Printing SimVertex information **" ;
+  LogVerbatim("CaloParticleDebuggerSimVertices") << "IDX\tPOSITION(x,y,z)\tPARENT_INDEX\tVERTEX_ID" ;
   for (auto i : sorted_vertices_idx) {
     auto const& v = vertices[i];
-    std::cout << i << "\t" << v << std::endl;
-  }
-  std::cout << "\n\n**Printing TrackingParticles information **" << std::endl;
-  for (auto i : sorted_tp_idx) {
-    auto const& tp = trackingpart[i];
-    std::cout << i << "\t" << tp << std::endl;
+    LogVerbatim("CaloParticleDebuggerSimVertices") << i << "\t" << v ;
   }
 
-  std::cout << "\n\n**Printing CaloParticles information **" << std::endl;
+  LogVerbatim("CaloParticleDebuggerTrackingParticles") << "\n\n**Printing TrackingParticles information **" ;
+  for (auto i : sorted_tp_idx) {
+    auto const& tp = trackingpart[i];
+    LogVerbatim("CaloParticleDebuggerTrackingParticles") << i << "\t" << tp ;
+  }
+
+  LogVerbatim("CaloParticleDebuggerCaloParticles") << "\n\n**Printing CaloParticles information **" ;
   idx = 0;
   for (auto i : sorted_cp_idx) {
     auto const& cp = calopart[i];
-    std::cout << "\n\n"
+    LogVerbatim("CaloParticleDebuggerCaloParticles") << "\n\n"
               << idx++ << " |Eta|: " << std::abs(cp.momentum().eta()) << "\tType: " << cp.pdgId()
               << "\tEnergy: " << cp.energy() << "\tIdx: " << cp.g4Tracks()[0].trackId()
-              << std::endl;  // << cp << std::endl;
+              ;  // << cp ;
     double total_sim_energy = 0.;
     double total_cp_energy = 0.;
-    std::cout << "--> Overall simclusters in CP: " << cp.simClusters().size() << std::endl;
+    LogVerbatim("CaloParticleDebuggerCaloParticles") << "--> Overall simclusters in CP: " << cp.simClusters().size() ;
     // All the next mess just to print the simClusters ordered
     auto const& simcs = cp.simClusters();
     std::vector<int> sorted_sc_idx(simcs.size());
@@ -234,7 +235,7 @@ void CaloParticleDebugger::analyze(const edm::Event& iEvent, const edm::EventSet
       return simcs[i]->momentum().eta() < simcs[j]->momentum().eta();
     });
     for (auto i : sorted_sc_idx) {
-      std::cout << *(simcs[i]);
+      LogVerbatim("CaloParticleDebuggerCaloParticles") << *(simcs[i]);
     }
 
     for (auto const& sc : cp.simClusters()) {
@@ -243,28 +244,28 @@ void CaloParticleDebugger::analyze(const edm::Event& iEvent, const edm::EventSet
         total_cp_energy += cp.energy() * cl.second;
       }
     }
-    std::cout << "--> Overall SC energy (sum using sim energies): " << total_sim_energy << std::endl;
-    std::cout << "--> Overall SC energy (sum using CaloP energies): " << total_cp_energy << std::endl;
+    LogVerbatim("CaloParticleDebuggerCaloParticles") << "--> Overall SC energy (sum using sim energies): " << total_sim_energy ;
+    LogVerbatim("CaloParticleDebuggerCaloParticles") << "--> Overall SC energy (sum using CaloP energies): " << total_cp_energy ;
   }
 
   idx = 0;
-  std::cout << "\n\n**Printing SimClusters information **" << std::endl;
+  LogVerbatim("CaloParticleDebuggerSimClusters") << "\n\n**Printing SimClusters information **" ;
   for (auto i : sorted_simcl_idx) {
     auto const& simcl = simclusters[i];
-    std::cout << "\n\n"
+    LogVerbatim("CaloParticleDebuggerSimClusters") << "\n\n"
               << idx++ << " |Eta|: " << std::abs(simcl.momentum().eta()) << "\tType: " << simcl.pdgId()
-              << "\tEnergy: " << simcl.energy() << "\tKey: " << i << std::endl;  // << simcl << std::endl;
+              << "\tEnergy: " << simcl.energy() << "\tKey: " << i ;  // << simcl ;
     auto const & simtrack = simcl.g4Tracks()[0];
-    std::cout << "  Crossed  Boundary: " << simtrack.crossedBoundary()
+    LogVerbatim("CaloParticleDebuggerSimClusters") << "  Crossed  Boundary: " << simtrack.crossedBoundary()
               << "  Position Boundary: " << simtrack.getPositionAtBoundary()
-              << "  Momentum Boundary: " << simtrack.getMomentumAtBoundary() << std::endl;
+              << "  Momentum Boundary: " << simtrack.getMomentumAtBoundary() ;
     double total_sim_energy = 0.;
-    std::cout << "--> Overall simclusters's size: " << simcl.numberOfRecHits() << std::endl;
+    LogVerbatim("CaloParticleDebuggerSimClusters") << "--> Overall simclusters's size: " << simcl.numberOfRecHits() ;
     for (auto const& cl : simcl.hits_and_fractions()) {
       total_sim_energy += detIdToTotalSimEnergy[cl.first] * cl.second;
     }
-    std::cout << simcl << std::endl;
-    std::cout << "--> Overall SimCluster energy (sum using sim energies): " << total_sim_energy << std::endl;
+    LogVerbatim("CaloParticleDebuggerSimClusters") << simcl ;
+    LogVerbatim("CaloParticleDebuggerSimClusters") << "--> Overall SimCluster energy (sum using sim energies): " << total_sim_energy ;
   }
 }
 

--- a/SimGeneral/Debugging/plugins/CaloParticleDebugger.cc
+++ b/SimGeneral/Debugging/plugins/CaloParticleDebugger.cc
@@ -181,35 +181,41 @@ void CaloParticleDebugger::analyze(const edm::Event& iEvent, const edm::EventSet
   int idx = 0;
 
   std::map<int, int> trackid_to_track_index;
-  std::cout << "Printing SimTracks information" << std::endl;
+  std::cout << "\n\n**Printing SimTracks information **" << std::endl;
   std::cout << "IDX\tTrackId\tPDGID\tMOMENTUM(x,y,z,E)\tVertexIdx\tGenPartIdx" << std::endl;
   for (auto i : sorted_tracks_idx) {
     auto const& t = tracks[i];
     std::cout << idx << "\t" << t.trackId() << "\t" << t << std::endl;
+    std::cout << "Crossed  Boundary: " << t.crossedBoundary()
+              << "  Position Boundary: " << t.getPositionAtBoundary()
+              << "  Momentum Boundary: " << t.getMomentumAtBoundary()
+              << "  Vtx:               " << t.vertIndex()
+              << "  Momemtum Origin:   " << t.momentum()
+              << std::endl;
     trackid_to_track_index[t.trackId()] = idx;
     idx++;
   }
 
-  std::cout << "Printing GenParticles information" << std::endl;
+  std::cout << "\n\n**Printing GenParticles information **" << std::endl;
   std::cout << "IDX\tPDGID\tMOMENTUM(x,y,z)\tVertex(x,y,z)" << std::endl;
   for (auto i : sorted_genParticles_idx) {
     auto const& gp = genParticles[i];
     std::cout << i << "\t" << gp.pdgId() << "\t" << gp.momentum() << "\t" << gp.vertex() << std::endl;
   }
 
-  std::cout << "Printing SimVertex information" << std::endl;
+  std::cout << "\n\n**Printing SimVertex information **" << std::endl;
   std::cout << "IDX\tPOSITION(x,y,z)\tPARENT_INDEX\tVERTEX_ID" << std::endl;
   for (auto i : sorted_vertices_idx) {
     auto const& v = vertices[i];
     std::cout << i << "\t" << v << std::endl;
   }
-  std::cout << "Printing TrackingParticles information" << std::endl;
+  std::cout << "\n\n**Printing TrackingParticles information **" << std::endl;
   for (auto i : sorted_tp_idx) {
     auto const& tp = trackingpart[i];
     std::cout << i << "\t" << tp << std::endl;
   }
 
-  std::cout << "Printing CaloParticles information" << std::endl;
+  std::cout << "\n\n**Printing CaloParticles information **" << std::endl;
   idx = 0;
   for (auto i : sorted_cp_idx) {
     auto const& cp = calopart[i];
@@ -219,7 +225,7 @@ void CaloParticleDebugger::analyze(const edm::Event& iEvent, const edm::EventSet
               << std::endl;  // << cp << std::endl;
     double total_sim_energy = 0.;
     double total_cp_energy = 0.;
-    std::cout << "--> Overall simclusters's size: " << cp.simClusters().size() << std::endl;
+    std::cout << "--> Overall simclusters in CP: " << cp.simClusters().size() << std::endl;
     // All the next mess just to print the simClusters ordered
     auto const& simcs = cp.simClusters();
     std::vector<int> sorted_sc_idx(simcs.size());
@@ -242,12 +248,16 @@ void CaloParticleDebugger::analyze(const edm::Event& iEvent, const edm::EventSet
   }
 
   idx = 0;
-  std::cout << "Printing SimClusters information" << std::endl;
+  std::cout << "\n\n**Printing SimClusters information **" << std::endl;
   for (auto i : sorted_simcl_idx) {
     auto const& simcl = simclusters[i];
     std::cout << "\n\n"
               << idx++ << " |Eta|: " << std::abs(simcl.momentum().eta()) << "\tType: " << simcl.pdgId()
               << "\tEnergy: " << simcl.energy() << "\tKey: " << i << std::endl;  // << simcl << std::endl;
+    auto const & simtrack = simcl.g4Tracks()[0];
+    std::cout << "  Crossed  Boundary: " << simtrack.crossedBoundary()
+              << "  Position Boundary: " << simtrack.getPositionAtBoundary()
+              << "  Momentum Boundary: " << simtrack.getMomentumAtBoundary() << std::endl;
     double total_sim_energy = 0.;
     std::cout << "--> Overall simclusters's size: " << simcl.numberOfRecHits() << std::endl;
     for (auto const& cl : simcl.hits_and_fractions()) {

--- a/SimGeneral/Debugging/plugins/CaloParticleDebugger.cc
+++ b/SimGeneral/Debugging/plugins/CaloParticleDebugger.cc
@@ -181,52 +181,51 @@ void CaloParticleDebugger::analyze(const edm::Event& iEvent, const edm::EventSet
   int idx = 0;
 
   std::map<int, int> trackid_to_track_index;
-  LogVerbatim("CaloParticleDebuggerSimTracks") << "\n\n**Printing SimTracks information **" ;
-  LogVerbatim("CaloParticleDebuggerSimTracks") << "IDX\tTrackId\tPDGID\tMOMENTUM(x,y,z,E)\tVertexIdx\tGenPartIdx" ;
+  LogVerbatim("CaloParticleDebuggerSimTracks") << "\n\n**Printing SimTracks information **";
+  LogVerbatim("CaloParticleDebuggerSimTracks") << "IDX\tTrackId\tPDGID\tMOMENTUM(x,y,z,E)\tVertexIdx\tGenPartIdx";
   for (auto i : sorted_tracks_idx) {
     auto const& t = tracks[i];
-    LogVerbatim("CaloParticleDebuggerSimTracks") << idx << "\t" << t.trackId() << "\t" << t ;
-    LogVerbatim("CaloParticleDebuggerSimTracks") << "Crossed  Boundary: " << t.crossedBoundary()
-              << "  Position Boundary: " << t.getPositionAtBoundary()
-              << "  Momentum Boundary: " << t.getMomentumAtBoundary()
-              << "  Vtx:               " << t.vertIndex()
-              << "  Momemtum Origin:   " << t.momentum()
-              ;
+    LogVerbatim("CaloParticleDebuggerSimTracks") << idx << "\t" << t.trackId() << "\t" << t;
+    LogVerbatim("CaloParticleDebuggerSimTracks")
+        << "Crossed  Boundary: " << t.crossedBoundary() << "  Position Boundary: " << t.getPositionAtBoundary()
+        << "  Momentum Boundary: " << t.getMomentumAtBoundary() << "  Vtx:               " << t.vertIndex()
+        << "  Momemtum Origin:   " << t.momentum();
     trackid_to_track_index[t.trackId()] = idx;
     idx++;
   }
 
-  LogVerbatim("CaloParticleDebuggerGenParticles") << "\n\n**Printing GenParticles information **" ;
-  LogVerbatim("CaloParticleDebuggerGenParticles") << "IDX\tPDGID\tMOMENTUM(x,y,z)\tVertex(x,y,z)" ;
+  LogVerbatim("CaloParticleDebuggerGenParticles") << "\n\n**Printing GenParticles information **";
+  LogVerbatim("CaloParticleDebuggerGenParticles") << "IDX\tPDGID\tMOMENTUM(x,y,z)\tVertex(x,y,z)";
   for (auto i : sorted_genParticles_idx) {
     auto const& gp = genParticles[i];
-    LogVerbatim("CaloParticleDebuggerGenParticles") << i << "\t" << gp.pdgId() << "\t" << gp.momentum() << "\t" << gp.vertex() ;
+    LogVerbatim("CaloParticleDebuggerGenParticles")
+        << i << "\t" << gp.pdgId() << "\t" << gp.momentum() << "\t" << gp.vertex();
   }
 
-  LogVerbatim("CaloParticleDebuggerSimVertices") << "\n\n**Printing SimVertex information **" ;
-  LogVerbatim("CaloParticleDebuggerSimVertices") << "IDX\tPOSITION(x,y,z)\tPARENT_INDEX\tVERTEX_ID" ;
+  LogVerbatim("CaloParticleDebuggerSimVertices") << "\n\n**Printing SimVertex information **";
+  LogVerbatim("CaloParticleDebuggerSimVertices") << "IDX\tPOSITION(x,y,z)\tPARENT_INDEX\tVERTEX_ID";
   for (auto i : sorted_vertices_idx) {
     auto const& v = vertices[i];
-    LogVerbatim("CaloParticleDebuggerSimVertices") << i << "\t" << v ;
+    LogVerbatim("CaloParticleDebuggerSimVertices") << i << "\t" << v;
   }
 
-  LogVerbatim("CaloParticleDebuggerTrackingParticles") << "\n\n**Printing TrackingParticles information **" ;
+  LogVerbatim("CaloParticleDebuggerTrackingParticles") << "\n\n**Printing TrackingParticles information **";
   for (auto i : sorted_tp_idx) {
     auto const& tp = trackingpart[i];
-    LogVerbatim("CaloParticleDebuggerTrackingParticles") << i << "\t" << tp ;
+    LogVerbatim("CaloParticleDebuggerTrackingParticles") << i << "\t" << tp;
   }
 
-  LogVerbatim("CaloParticleDebuggerCaloParticles") << "\n\n**Printing CaloParticles information **" ;
+  LogVerbatim("CaloParticleDebuggerCaloParticles") << "\n\n**Printing CaloParticles information **";
   idx = 0;
   for (auto i : sorted_cp_idx) {
     auto const& cp = calopart[i];
-    LogVerbatim("CaloParticleDebuggerCaloParticles") << "\n\n"
-              << idx++ << " |Eta|: " << std::abs(cp.momentum().eta()) << "\tType: " << cp.pdgId()
-              << "\tEnergy: " << cp.energy() << "\tIdx: " << cp.g4Tracks()[0].trackId()
-              ;  // << cp ;
+    LogVerbatim("CaloParticleDebuggerCaloParticles")
+        << "\n\n"
+        << idx++ << " |Eta|: " << std::abs(cp.momentum().eta()) << "\tType: " << cp.pdgId()
+        << "\tEnergy: " << cp.energy() << "\tIdx: " << cp.g4Tracks()[0].trackId();  // << cp ;
     double total_sim_energy = 0.;
     double total_cp_energy = 0.;
-    LogVerbatim("CaloParticleDebuggerCaloParticles") << "--> Overall simclusters in CP: " << cp.simClusters().size() ;
+    LogVerbatim("CaloParticleDebuggerCaloParticles") << "--> Overall simclusters in CP: " << cp.simClusters().size();
     // All the next mess just to print the simClusters ordered
     auto const& simcs = cp.simClusters();
     std::vector<int> sorted_sc_idx(simcs.size());
@@ -244,28 +243,32 @@ void CaloParticleDebugger::analyze(const edm::Event& iEvent, const edm::EventSet
         total_cp_energy += cp.energy() * cl.second;
       }
     }
-    LogVerbatim("CaloParticleDebuggerCaloParticles") << "--> Overall SC energy (sum using sim energies): " << total_sim_energy ;
-    LogVerbatim("CaloParticleDebuggerCaloParticles") << "--> Overall SC energy (sum using CaloP energies): " << total_cp_energy ;
+    LogVerbatim("CaloParticleDebuggerCaloParticles")
+        << "--> Overall SC energy (sum using sim energies): " << total_sim_energy;
+    LogVerbatim("CaloParticleDebuggerCaloParticles")
+        << "--> Overall SC energy (sum using CaloP energies): " << total_cp_energy;
   }
 
   idx = 0;
-  LogVerbatim("CaloParticleDebuggerSimClusters") << "\n\n**Printing SimClusters information **" ;
+  LogVerbatim("CaloParticleDebuggerSimClusters") << "\n\n**Printing SimClusters information **";
   for (auto i : sorted_simcl_idx) {
     auto const& simcl = simclusters[i];
-    LogVerbatim("CaloParticleDebuggerSimClusters") << "\n\n"
-              << idx++ << " |Eta|: " << std::abs(simcl.momentum().eta()) << "\tType: " << simcl.pdgId()
-              << "\tEnergy: " << simcl.energy() << "\tKey: " << i ;  // << simcl ;
-    auto const & simtrack = simcl.g4Tracks()[0];
+    LogVerbatim("CaloParticleDebuggerSimClusters")
+        << "\n\n"
+        << idx++ << " |Eta|: " << std::abs(simcl.momentum().eta()) << "\tType: " << simcl.pdgId()
+        << "\tEnergy: " << simcl.energy() << "\tKey: " << i;  // << simcl ;
+    auto const& simtrack = simcl.g4Tracks()[0];
     LogVerbatim("CaloParticleDebuggerSimClusters") << "  Crossed  Boundary: " << simtrack.crossedBoundary()
-              << "  Position Boundary: " << simtrack.getPositionAtBoundary()
-              << "  Momentum Boundary: " << simtrack.getMomentumAtBoundary() ;
+                                                   << "  Position Boundary: " << simtrack.getPositionAtBoundary()
+                                                   << "  Momentum Boundary: " << simtrack.getMomentumAtBoundary();
     double total_sim_energy = 0.;
-    LogVerbatim("CaloParticleDebuggerSimClusters") << "--> Overall simclusters's size: " << simcl.numberOfRecHits() ;
+    LogVerbatim("CaloParticleDebuggerSimClusters") << "--> Overall simclusters's size: " << simcl.numberOfRecHits();
     for (auto const& cl : simcl.hits_and_fractions()) {
       total_sim_energy += detIdToTotalSimEnergy[cl.first] * cl.second;
     }
-    LogVerbatim("CaloParticleDebuggerSimClusters") << simcl ;
-    LogVerbatim("CaloParticleDebuggerSimClusters") << "--> Overall SimCluster energy (sum using sim energies): " << total_sim_energy ;
+    LogVerbatim("CaloParticleDebuggerSimClusters") << simcl;
+    LogVerbatim("CaloParticleDebuggerSimClusters")
+        << "--> Overall SimCluster energy (sum using sim energies): " << total_sim_energy;
   }
 }
 

--- a/SimGeneral/Debugging/python/caloParticleDebugger_cfg.py
+++ b/SimGeneral/Debugging/python/caloParticleDebugger_cfg.py
@@ -1,5 +1,10 @@
 import FWCore.ParameterSet.Config as cms
 
+# The line below always has to be included to make VarParsing work
+from FWCore.ParameterSet.VarParsing import VarParsing
+options = VarParsing ('analysis')
+options.parseArguments()
+
 process = cms.Process("Demo")
 
 process.load("FWCore.MessageService.MessageLogger_cfi")
@@ -8,10 +13,11 @@ process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 from Configuration.AlCa.GlobalTag import GlobalTag
 process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase2_realistic', '')
 
-process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(1) )
+process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(-1) )
 
 
-input_filename='step2SingleElectronPt15Eta1p7_2p7_SimTracksters.root'
+input_filename = 'default.root' if len(options.inputFiles) == 0 else options.inputFiles[0]
+#input_filename='step2SingleElectronPt15Eta1p7_2p7_SimTracksters.root'
 #input_filename='step2FineCaloSingleElectronPt15Eta1p7_2p7_SimTracksters.root'
 #input_filename='step2SingleElectronPt15Eta1p7_2p7_CBWEAndSimTracksters.root'
 #input_filename='step2FineCaloSingleElectronPt15Eta1p7_2p7_CBWEAndSimTracksters.root'

--- a/SimGeneral/Debugging/python/caloParticleDebugger_cfg.py
+++ b/SimGeneral/Debugging/python/caloParticleDebugger_cfg.py
@@ -3,7 +3,7 @@ import FWCore.ParameterSet.Config as cms
 process = cms.Process("Demo")
 
 process.load("FWCore.MessageService.MessageLogger_cfi")
-process.load('Configuration.Geometry.GeometryExtended2023D17Reco_cff')
+process.load('Configuration.Geometry.GeometryExtended2026D49Reco_cff')
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 from Configuration.AlCa.GlobalTag import GlobalTag
 process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase2_realistic', '')

--- a/SimGeneral/Debugging/python/caloParticleDebugger_cfg.py
+++ b/SimGeneral/Debugging/python/caloParticleDebugger_cfg.py
@@ -8,7 +8,13 @@ process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 from Configuration.AlCa.GlobalTag import GlobalTag
 process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase2_realistic', '')
 
-process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(-1) )
+process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(1) )
+
+
+input_filename='step2SingleElectronPt15Eta1p7_2p7_SimTracksters.root'
+#input_filename='step2FineCaloSingleElectronPt15Eta1p7_2p7_SimTracksters.root'
+#input_filename='step2SingleElectronPt15Eta1p7_2p7_CBWEAndSimTracksters.root'
+#input_filename='step2FineCaloSingleElectronPt15Eta1p7_2p7_CBWEAndSimTracksters.root'
 
 process.source = cms.Source("PoolSource",
     inputCommands = cms.untracked.vstring(['keep *',
@@ -23,10 +29,31 @@ process.source = cms.Source("PoolSource",
 #        'file:/data/rovere/HGCAL/study/CMSSW_9_4_0/src/SimGeneral/Debugging/test/20824.0_TTbar_13+TTbar_13TeV_TuneCUETP8M1_2023D20_GenSimHLBeamSpotFull+DigiFull_2023D20+RecoFullGlobal_2023D20+HARVESTFullGlobal_2023D20/step2.root'
 #        'file:/data/rovere/HGCAL/study/CMSSW_9_4_0/src/SimGeneral/Debugging/test/20002.0_SingleElectronPt35+SingleElectronPt35_pythia8_2023D17_GenSimHLBeamSpotFull+DigiFullTrigger_2023D17+RecoFullGlobal_2023D17+HARVESTFullGlobal_2023D17/step2.root'
 #        'file:/data/rovere/HGCAL/study/CMSSW_9_4_0/src/SimGeneral/Debugging/test/20016.0_SingleGammaPt35Extended+DoubleGammaPt35Extended_pythia8_2023D17_GenSimHLBeamSpotFull+DigiFullTrigger_2023D17+RecoFullGlobal_2023D17+HARVESTFullGlobal_2023D17/step2.root'
-        'file:/data/rovere/HGCAL/study/CMSSW_9_4_0/src/SimGeneral/Debugging/test/20088.0_SinglePiPt25Eta1p7_2p7+SinglePiPt25Eta1p7_2p7_2023D17_GenSimHLBeamSpotFull+DigiFullTrigger_2023D17+RecoFullGlobal_2023D17+HARVESTFullGlobal_2023D17/step2.root'
+#        'file:/data/rovere/HGCAL/study/CMSSW_9_4_0/src/SimGeneral/Debugging/test/20088.0_SinglePiPt25Eta1p7_2p7+SinglePiPt25Eta1p7_2p7_2023D17_GenSimHLBeamSpotFull+DigiFullTrigger_2023D17+RecoFullGlobal_2023D17+HARVESTFullGlobal_2023D17/step2.root'
+         'file:%s'%input_filename
+
     )
 )
 
 process.load("SimGeneral.Debugging.caloParticleDebugger_cfi")
+
+# MessageLogger customizations
+process.MessageLogger.cerr.enable = False
+process.MessageLogger.cout.enable = False
+labels = ['SimTracks', 'SimVertices', 'GenParticles', 'TrackingParticles', 'CaloParticles', 'SimClusters']
+messageLogger = dict()
+for category in labels:
+    main_key = '%sMessageLogger'%(category)
+    category_key = 'CaloParticleDebugger%s'%(category)
+    messageLogger[main_key] = dict(
+            filename = '%s_%s.log' % (input_filename.replace('.root',''), category),
+            threshold = 'INFO',
+            default = dict(limit=0)
+            )
+    messageLogger[main_key][category_key] = dict(limit=-1)
+    # First create defaults
+    setattr(process.MessageLogger.files, category, dict())
+    # Then modify them
+    setattr(process.MessageLogger.files, category, messageLogger[main_key])
 
 process.p = cms.Path(process.caloParticleDebugger)


### PR DESCRIPTION
#### PR description:

Improve the `CaloParticleDebugger` module by:

* Add information on crossedBoundary for the `SimTracks` collection
* sending output via `LogVerbatim` and not directly to `std::cout`
* Exploit the improved `MessageLogger` configuration capabilities to have the output of each monitored collection saved into a separate file
* Add argument parsing to the python script.

#### PR validation:

Private tests, since this debugging module is not used in any workflow.

