### PR TITLE
Data vs emulator plots in CSC DQM [11_3_X]

### DIFF
--- a/DQM/Integration/python/clients/l1tstage2emulator_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/l1tstage2emulator_dqm_sourceclient-live_cfg.py
@@ -51,13 +51,12 @@ process.dqmEndPath = cms.EndPath(
 #--------------------------------------------------
 # Standard Unpacking Path
 
-process.load("Configuration.StandardSequences.RawToDigi_Data_cff")    
+process.load("Configuration.StandardSequences.RawToDigi_Data_cff")
 
 # remove unneeded unpackers
 process.RawToDigi.remove(process.ecalDigis)
 process.RawToDigi.remove(process.ecalPreshowerDigis)
 process.RawToDigi.remove(process.hcalDigis)
-process.RawToDigi.remove(process.muonCSCDigis)
 process.RawToDigi.remove(process.muonDTDigis)
 process.RawToDigi.remove(process.siPixelDigis)
 process.RawToDigi.remove(process.siStripDigis)
@@ -168,7 +167,7 @@ if (process.runType.getRunType() == process.runType.hi_run):
 #--------------------------------------------------
 # L1T Emulator Online DQM Schedule
 
-process.schedule = cms.Schedule( 
+process.schedule = cms.Schedule(
     process.rawToDigiPath,
     process.l1tEmulatorMonitorPath,
     process.l1tStage2EmulatorMonitorClientPath,

--- a/DQM/Integration/test/runtest.sh
+++ b/DQM/Integration/test/runtest.sh
@@ -3,7 +3,7 @@ set -e
 set -x
 
 if [[ $# -eq 0 ]]; then
-    echo "Please provide a name of the clinet"
+    echo "Please provide a name of the client"
     exit 1
 fi
 

--- a/DQM/L1TMonitor/interface/L1TdeCSCTPG.h
+++ b/DQM/L1TMonitor/interface/L1TdeCSCTPG.h
@@ -1,0 +1,55 @@
+#ifndef DQM_L1TMonitor_L1TdeCSCTPG_h
+#define DQM_L1TMonitor_L1TdeCSCTPG_h
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "DQMServices/Core/interface/DQMEDAnalyzer.h"
+#include "DQMServices/Core/interface/DQMStore.h"
+
+#include "DataFormats/CSCDigi/interface/CSCALCTDigiCollection.h"
+#include "DataFormats/CSCDigi/interface/CSCCLCTDigiCollection.h"
+#include "DataFormats/CSCDigi/interface/CSCCorrelatedLCTDigiCollection.h"
+
+class L1TdeCSCTPG : public DQMEDAnalyzer {
+public:
+  L1TdeCSCTPG(const edm::ParameterSet& ps);
+  ~L1TdeCSCTPG() override;
+
+protected:
+  void bookHistograms(DQMStore::IBooker&, const edm::Run&, const edm::EventSetup&) override;
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
+
+private:
+  edm::EDGetTokenT<CSCALCTDigiCollection> dataALCT_token_;
+  edm::EDGetTokenT<CSCALCTDigiCollection> emulALCT_token_;
+  edm::EDGetTokenT<CSCCLCTDigiCollection> dataCLCT_token_;
+  edm::EDGetTokenT<CSCCLCTDigiCollection> emulCLCT_token_;
+  edm::EDGetTokenT<CSCCorrelatedLCTDigiCollection> dataLCT_token_;
+  edm::EDGetTokenT<CSCCorrelatedLCTDigiCollection> emulLCT_token_;
+  std::string monitorDir_;
+
+  std::vector<std::string> chambers_;
+  std::vector<std::string> dataEmul_;
+
+  std::vector<std::string> alctVars_;
+  std::vector<std::string> clctVars_;
+  std::vector<std::string> lctVars_;
+
+  std::vector<unsigned> alctNBin_;
+  std::vector<unsigned> clctNBin_;
+  std::vector<unsigned> lctNBin_;
+  std::vector<double> alctMinBin_;
+  std::vector<double> clctMinBin_;
+  std::vector<double> lctMinBin_;
+  std::vector<double> alctMaxBin_;
+  std::vector<double> clctMaxBin_;
+  std::vector<double> lctMaxBin_;
+
+  // first key is the chamber number
+  // second key is the variable
+  std::map<uint32_t, std::map<std::string, MonitorElement*> > chamberHistos;
+};
+
+#endif

--- a/DQM/L1TMonitor/plugins/SealModule.cc
+++ b/DQM/L1TMonitor/plugins/SealModule.cc
@@ -98,6 +98,9 @@ DEFINE_FWK_MODULE(L1TdeStage2CaloLayer1);
 #include "DQM/L1TMonitor/interface/L1TdeGEMTPG.h"
 DEFINE_FWK_MODULE(L1TdeGEMTPG);
 
+#include "DQM/L1TMonitor/interface/L1TdeCSCTPG.h"
+DEFINE_FWK_MODULE(L1TdeCSCTPG);
+
 #include "DQM/L1TMonitor/interface/L1TdeCSCTF.h"
 DEFINE_FWK_MODULE(L1TdeCSCTF);
 

--- a/DQM/L1TMonitor/python/L1TEmulatorMonitor_cff.py
+++ b/DQM/L1TMonitor/python/L1TEmulatorMonitor_cff.py
@@ -46,6 +46,8 @@ l1TdeRCTfromRCT = l1TdeRCT.clone()
 l1TdeRCTfromRCT.rctSourceData = 'rctDigis'
 l1TdeRCTfromRCT.HistFolder = cms.untracked.string('L1TEMU/L1TdeRCT_FromRCT')
 
+from DQM.L1TMonitor.L1TdeCSCTPG_cfi import *
+
 from DQM.L1TMonitor.L1TdeCSCTF_cfi import *
 
 from DQM.L1TMonitor.L1GtHwValidation_cff import *
@@ -67,7 +69,7 @@ from L1Trigger.L1TCalorimeter.caloStage1LegacyFormatDigis_cfi import *
 
 ############################################################
 
-# GMT unpack from Fed813 in legacy stage1 parallel running                                                               
+# GMT unpack from Fed813 in legacy stage1 parallel running
 from EventFilter.L1GlobalTriggerRawToDigi.l1GtUnpack_cfi import *
 l1GtUnpack.DaqGtInputTag = 'rawDataCollector'
 
@@ -78,11 +80,12 @@ l1TdeRCTSeq = cms.Sequence(
                     )
 
 l1ExpertDataVsEmulator = cms.Sequence(
-                                l1TdeGCT + 
-                                l1TdeCSCTF + 
-                                l1GtHwValidation + 
-                                l1TdeRCTRun1
-                                )
+    l1TdeGCT +
+    l1tdeCSCTPG +
+    l1TdeCSCTF +
+    l1GtHwValidation +
+    l1TdeRCTRun1
+)
 
 
 l1EmulatorMonitorTask = cms.Task(
@@ -116,7 +119,7 @@ l1ExpertDataVsEmulatorStage1 = cms.Sequence(
 
 l1EmulatorMonitorStage1 = cms.Sequence(
     #caloStage1Digis*
-    #caloStage1LegacyFormatDigis*    
+    #caloStage1LegacyFormatDigis*
     l1demonstage1+
     l1ExpertDataVsEmulatorStage1
     )

--- a/DQM/L1TMonitor/python/L1TStage2Emulator_cff.py
+++ b/DQM/L1TMonitor/python/L1TStage2Emulator_cff.py
@@ -7,89 +7,102 @@ import FWCore.ParameterSet.Config as cms
 from L1Trigger.L1TCalorimeter.simDigis_cff import *
 # CaloLayer1
 from L1Trigger.L1TCaloLayer1.simCaloStage2Layer1Digis_cfi import simCaloStage2Layer1Digis
-valCaloStage2Layer1Digis = simCaloStage2Layer1Digis.clone()
-valCaloStage2Layer1Digis.ecalToken = cms.InputTag("caloLayer1Digis")
-valCaloStage2Layer1Digis.hcalToken = cms.InputTag("caloLayer1Digis")
-valCaloStage2Layer1Digis.unpackEcalMask = cms.bool(True)
-valCaloStage2Layer1Digis.unpackHcalMask = cms.bool(True)
+valCaloStage2Layer1Digis = simCaloStage2Layer1Digis.clone(
+    ecalToken = "caloLayer1Digis",
+    hcalToken = "caloLayer1Digis",
+    unpackEcalMask = True,
+    unpackHcalMask = True
+)
 
 # CaloLayer2
 from L1Trigger.L1TCalorimeter.simCaloStage2Digis_cfi import simCaloStage2Digis
-valCaloStage2Layer2Digis = simCaloStage2Digis.clone()
-valCaloStage2Layer2Digis.towerToken = cms.InputTag("caloStage2Digis", "CaloTower")
+valCaloStage2Layer2Digis = simCaloStage2Digis.clone(towerToken = "caloStage2Digis:CaloTower")
 
 # BMTF-Legacy
 from L1Trigger.L1TMuonBarrel.simBmtfDigis_cfi import *
-valBmtfDigis = simBmtfDigis.clone()
-valBmtfDigis.DTDigi_Source = cms.InputTag("bmtfDigis")
-valBmtfDigis.DTDigi_Theta_Source = cms.InputTag("bmtfDigis")
+valBmtfDigis = simBmtfDigis.clone(
+    DTDigi_Source = "bmtfDigis",
+    DTDigi_Theta_Source = "bmtfDigis"
+)
 
 # BMTF-Kalman
 from L1Trigger.L1TMuonBarrel.simKBmtfDigis_cfi import *
 from L1Trigger.L1TMuonBarrel.simKBmtfStubs_cfi import *
-valKBmtfStubs = simKBmtfStubs.clone()
-valKBmtfStubs.srcPhi = cms.InputTag("bmtfDigis")
-valKBmtfStubs.srcTheta = cms.InputTag("bmtfDigis")
-valKBmtfDigis = simKBmtfDigis.clone()
-valKBmtfDigis.src = cms.InputTag("valKBmtfStubs")
+valKBmtfStubs = simKBmtfStubs.clone(
+    srcPhi = "bmtfDigis",
+    srcTheta = "bmtfDigis"
+)
+valKBmtfDigis = simKBmtfDigis.clone(src = "valKBmtfStubs")
 
 # BMTF-AlgoTriggerSelector
 from DQM.L1TMonitor.L1TBMTFAlgoSelector_cfi import *
-valBmtfAlgoSel = l1tBmtfAlgoSelector.clone()
-valBmtfAlgoSel.bmtfKalman = cms.InputTag("valKBmtfDigis:BMTF")
-valBmtfAlgoSel.bmtfLegacy = cms.InputTag("valBmtfDigis:BMTF")
+valBmtfAlgoSel = l1tBmtfAlgoSelector.clone(
+    bmtfKalman = "valKBmtfDigis:BMTF",
+    bmtfLegacy = "valBmtfDigis:BMTF"
+)
 
 # OMTF
 from L1Trigger.L1TMuonOverlap.simOmtfDigis_cfi import *
-valOmtfDigis = simOmtfDigis.clone()
-valOmtfDigis.srcDTPh = cms.InputTag('omtfStage2Digis')
-valOmtfDigis.srcDTTh = cms.InputTag('omtfStage2Digis')
-valOmtfDigis.srcCSC = cms.InputTag('omtfStage2Digis')
-valOmtfDigis.srcRPC = cms.InputTag('omtfStage2Digis')
+valOmtfDigis = simOmtfDigis.clone(
+    srcDTPh = "omtfStage2Digis",
+    srcDTTh = "omtfStage2Digis",
+    srcCSC = "omtfStage2Digis",
+    srcRPC = "omtfStage2Digis"
+)
 
 # GEM TPG
 from L1Trigger.L1TGEM.simGEMDigis_cff import *
-valMuonGEMPadDigis = simMuonGEMPadDigis.clone()
-valMuonGEMPadDigis.InputCollection = cms.InputTag('muonGEMDigis')
-valMuonGEMPadDigiClusters = simMuonGEMPadDigiClusters.clone()
-valMuonGEMPadDigiClusters.InputCollection = cms.InputTag('valMuonGEMPadDigis')
+valMuonGEMPadDigis = simMuonGEMPadDigis.clone(InputCollection = "muonGEMDigis")
+valMuonGEMPadDigiClusters = simMuonGEMPadDigiClusters.clone(InputCollection = "valMuonGEMPadDigis")
+
+# CSC TPG
+from L1Trigger.CSCTriggerPrimitives.cscTriggerPrimitiveDigis_cfi import *
+valCscStage2Digis = cscTriggerPrimitiveDigis.clone(
+    CSCComparatorDigiProducer = "muonCSCDigis:MuonCSCComparatorDigi",
+    CSCWireDigiProducer = "muonCSCDigis:MuonCSCWireDigi"
+)
+
+from Configuration.Eras.Modifier_run3_GEM_cff import run3_GEM
+run3_GEM.toModify( valCscStage2Digis, GEMPadDigiClusterProducer = "valMuonGEMPadDigiClusters" )
 
 # EMTF
 from L1Trigger.L1TMuonEndCap.simEmtfDigis_cfi import *
-valEmtfStage2Digis = simEmtfDigis.clone()
-valEmtfStage2Digis.CSCInput = "emtfStage2Digis"
-valEmtfStage2Digis.RPCInput = "muonRPCDigis"
+valEmtfStage2Digis = simEmtfDigis.clone(
+    CSCInput = "emtfStage2Digis",
+    RPCInput = "muonRPCDigis"
+)
 
 # uGMT
 from L1Trigger.L1TMuon.simGmtStage2Digis_cfi import *
-valGmtCaloSumDigis = simGmtCaloSumDigis.clone()
-valGmtCaloSumDigis.caloStage2Layer2Label = cms.InputTag("valCaloStage2Layer1Digis")
-valGmtStage2Digis = simGmtStage2Digis.clone()
-valGmtStage2Digis.barrelTFInput = cms.InputTag("gmtStage2Digis", "BMTF")
-valGmtStage2Digis.overlapTFInput = cms.InputTag("gmtStage2Digis", "OMTF")
-valGmtStage2Digis.forwardTFInput = cms.InputTag("gmtStage2Digis", "EMTF")
-valGmtStage2Digis.triggerTowerInput = cms.InputTag("valGmtCaloSumDigis", "TriggerTowerSums")
+valGmtCaloSumDigis = simGmtCaloSumDigis.clone(caloStage2Layer2Label = "valCaloStage2Layer1Digis")
+valGmtStage2Digis = simGmtStage2Digis.clone(
+    barrelTFInput = "gmtStage2Digis:BMTF",
+    overlapTFInput = "gmtStage2Digis:OMTF",
+    forwardTFInput = "gmtStage2Digis:EMTF",
+    triggerTowerInput = "valGmtCaloSumDigis:TriggerTowerSums"
+)
 
 # uGT
 from L1Trigger.L1TGlobal.simGtStage2Digis_cfi import simGtStage2Digis
 from L1Trigger.L1TGlobal.simGtExtFakeProd_cfi import simGtExtFakeProd
 
-valGtStage2Digis = simGtStage2Digis.clone()
-valGtStage2Digis.ExtInputTag = cms.InputTag("gtStage2Digis")
-valGtStage2Digis.MuonInputTag = cms.InputTag("gtStage2Digis", "Muon")
-valGtStage2Digis.EGammaInputTag = cms.InputTag("gtStage2Digis", "EGamma")
-valGtStage2Digis.TauInputTag = cms.InputTag("gtStage2Digis", "Tau")
-valGtStage2Digis.JetInputTag = cms.InputTag("gtStage2Digis", "Jet")
-valGtStage2Digis.EtSumInputTag = cms.InputTag("gtStage2Digis", "EtSum")
-valGtStage2Digis.AlgorithmTriggersUnmasked = cms.bool(False)
-valGtStage2Digis.AlgorithmTriggersUnprescaled = cms.bool(False)
-valGtStage2Digis.EmulateBxInEvent = cms.int32(5)
-valGtStage2Digis.PrescaleSet = cms.uint32(7)
-valGtStage2Digis.GetPrescaleColumnFromData = cms.bool(True)
-valGtStage2Digis.AlgoBlkInputTag = cms.InputTag("gtStage2Digis")
-
+valGtStage2Digis = simGtStage2Digis.clone(
+    ExtInputTag = "gtStage2Digis",
+    MuonInputTag = "gtStage2Digis:Muon",
+    EGammaInputTag = "gtStage2Digis:EGamma",
+    TauInputTag = "gtStage2Digis:Tau",
+    JetInputTag = "gtStage2Digis:Jet",
+    EtSumInputTag = "gtStage2Digis:EtSum",
+    AlgorithmTriggersUnmasked = False,
+    AlgorithmTriggersUnprescaled = False,
+    EmulateBxInEvent = cms.int32(5),
+    PrescaleSet = cms.uint32(7),
+    GetPrescaleColumnFromData = True,
+    AlgoBlkInputTag = "gtStage2Digis"
+)
 Stage2L1HardwareValidation = cms.Sequence(
     valCaloStage2Layer1Digis +
+    valCscStage2Digis +
     valBmtfDigis +
     valKBmtfStubs +
     valKBmtfDigis +
@@ -122,6 +135,9 @@ from DQM.L1TMonitor.L1TStage2CaloLayer2Emul_cfi import *
 # GEM TPG
 from DQM.L1TMonitor.L1TdeGEMTPG_cfi import *
 
+# CSC TPG
+from DQM.L1TMonitor.L1TdeCSCTPG_cfi import *
+
 # BMTF
 from DQM.L1TMonitor.L1TdeStage2BMTF_cfi import *
 from DQM.L1TMonitor.L1TdeStage2BMTFSecond_cff import *
@@ -147,6 +163,7 @@ l1tStage2EmulatorOnlineDQM = cms.Sequence(
     l1tdeStage2Bmtf +
     l1tdeStage2BmtfSecond +
     l1tdeStage2Omtf +
+    l1tdeCSCTPG +
     l1tdeStage2EmtfOnlineDQMSeq +
     l1tStage2uGMTEmulatorOnlineDQMSeq +
     l1tdeStage2uGT +

--- a/DQM/L1TMonitor/python/L1TdeCSCTPG_cfi.py
+++ b/DQM/L1TMonitor/python/L1TdeCSCTPG_cfi.py
@@ -1,0 +1,34 @@
+import FWCore.ParameterSet.Config as cms
+from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
+
+l1tdeCSCTPGCommon = cms.PSet(
+    monitorDir = cms.string('L1TEMU/L1TdeCSCTPG'),
+    chambers = cms.vstring("ME1a", "ME1b", "ME12", "ME13", "ME21", "ME22",
+                           "ME31", "ME32", "ME41", "ME42"),
+    alctVars = cms.vstring("quality", "wiregroup", "bx"),
+    alctNBin = cms.vuint32(6, 116, 20),
+    alctMinBin = cms.vdouble(0, 0, 0),
+    alctMaxBin = cms.vdouble(6, 116, 20),
+    clctVars = cms.vstring("quality", "halfstrip", "bx",
+                           "pattern", "bend", "quartstrip","eightstrip"),
+    clctNBin = cms.vuint32(16, 240, 20, 16, 2, 2, 2),
+    clctMinBin = cms.vdouble(0, 0, 0, 0, 0, 0, 0),
+    clctMaxBin = cms.vdouble(16, 240, 20, 16, 2, 2, 2),
+    lctVars = cms.vstring( "quality", "wiregroup", "halfstrip",
+                          "bx", "pattern", "bend", "quartstrip","eightstrip"),
+    lctNBin = cms.vuint32(16, 116, 240, 20, 16, 2, 2, 2),
+    lctMinBin = cms.vdouble(0, 0, 0, 0, 0, 0, 0, 0),
+    lctMaxBin = cms.vdouble(16, 116, 240, 20, 16, 2, 2, 2),
+)
+
+l1tdeCSCTPG = DQMEDAnalyzer(
+    "L1TdeCSCTPG",
+    l1tdeCSCTPGCommon,
+    dataALCT = cms.InputTag("muonCSCDigis","MuonCSCALCTDigi"),
+    emulALCT = cms.InputTag("valCscStage2Digis"),
+    dataCLCT = cms.InputTag("muonCSCDigis","MuonCSCCLCTDigi"),
+    emulCLCT = cms.InputTag("valCscStage2Digis"),
+    dataLCT = cms.InputTag("muonCSCDigis","MuonCSCCorrelatedLCTDigi"),
+    emulLCT = cms.InputTag("valCscStage2Digis", "MPCSORTED"),
+    dataEmul = cms.vstring("data","emul"),
+)

--- a/DQM/L1TMonitor/src/L1TdeCSCTPG.cc
+++ b/DQM/L1TMonitor/src/L1TdeCSCTPG.cc
@@ -1,0 +1,157 @@
+#include <string>
+
+#include "DQM/L1TMonitor/interface/L1TdeCSCTPG.h"
+
+L1TdeCSCTPG::L1TdeCSCTPG(const edm::ParameterSet& ps)
+    : dataALCT_token_(consumes<CSCALCTDigiCollection>(ps.getParameter<edm::InputTag>("dataALCT"))),
+      emulALCT_token_(consumes<CSCALCTDigiCollection>(ps.getParameter<edm::InputTag>("emulALCT"))),
+      dataCLCT_token_(consumes<CSCCLCTDigiCollection>(ps.getParameter<edm::InputTag>("dataCLCT"))),
+      emulCLCT_token_(consumes<CSCCLCTDigiCollection>(ps.getParameter<edm::InputTag>("emulCLCT"))),
+      dataLCT_token_(consumes<CSCCorrelatedLCTDigiCollection>(ps.getParameter<edm::InputTag>("dataLCT"))),
+      emulLCT_token_(consumes<CSCCorrelatedLCTDigiCollection>(ps.getParameter<edm::InputTag>("emulLCT"))),
+      monitorDir_(ps.getParameter<std::string>("monitorDir")),
+
+      chambers_(ps.getParameter<std::vector<std::string>>("chambers")),
+      dataEmul_(ps.getParameter<std::vector<std::string>>("dataEmul")),
+
+      // variables
+      alctVars_(ps.getParameter<std::vector<std::string>>("alctVars")),
+      clctVars_(ps.getParameter<std::vector<std::string>>("lctVars")),
+      lctVars_(ps.getParameter<std::vector<std::string>>("lctVars")),
+
+      // binning
+      alctNBin_(ps.getParameter<std::vector<unsigned>>("alctNBin")),
+      clctNBin_(ps.getParameter<std::vector<unsigned>>("lctNBin")),
+      lctNBin_(ps.getParameter<std::vector<unsigned>>("lctNBin")),
+      alctMinBin_(ps.getParameter<std::vector<double>>("alctMinBin")),
+      clctMinBin_(ps.getParameter<std::vector<double>>("lctMinBin")),
+      lctMinBin_(ps.getParameter<std::vector<double>>("lctMinBin")),
+      alctMaxBin_(ps.getParameter<std::vector<double>>("alctMaxBin")),
+      clctMaxBin_(ps.getParameter<std::vector<double>>("lctMaxBin")),
+      lctMaxBin_(ps.getParameter<std::vector<double>>("lctMaxBin")) {}
+
+L1TdeCSCTPG::~L1TdeCSCTPG() {}
+
+void L1TdeCSCTPG::bookHistograms(DQMStore::IBooker& iBooker, const edm::Run&, const edm::EventSetup&) {
+  iBooker.setCurrentFolder(monitorDir_);
+
+  // chamber type
+  for (unsigned iType = 0; iType < chambers_.size(); iType++) {
+    // data vs emulator
+    for (unsigned iData = 0; iData < dataEmul_.size(); iData++) {
+      // alct variable
+      for (unsigned iVar = 0; iVar < alctVars_.size(); iVar++) {
+        const std::string key("alct_" + alctVars_[iVar] + "_" + dataEmul_[iData]);
+        const std::string histName(key + "_" + chambers_[iType]);
+        const std::string histTitle(chambers_[iType] + " ALCT " + alctVars_[iVar] + " (" + dataEmul_[iData] + ") ");
+        chamberHistos[iType][key] =
+            iBooker.book1D(histName, histTitle, alctNBin_[iVar], alctMinBin_[iVar], alctMaxBin_[iVar]);
+      }
+
+      // clct variable
+      for (unsigned iVar = 0; iVar < clctVars_.size(); iVar++) {
+        const std::string key("clct_" + clctVars_[iVar] + "_" + dataEmul_[iData]);
+        const std::string histName(key + "_" + chambers_[iType]);
+        const std::string histTitle(chambers_[iType] + " CLCT " + clctVars_[iVar] + " (" + dataEmul_[iData] + ") ");
+        chamberHistos[iType][key] =
+            iBooker.book1D(histName, histTitle, clctNBin_[iVar], clctMinBin_[iVar], clctMaxBin_[iVar]);
+      }
+
+      // lct variable
+      for (unsigned iVar = 0; iVar < lctVars_.size(); iVar++) {
+        const std::string key("lct_" + lctVars_[iVar] + "_" + dataEmul_[iData]);
+        const std::string histName(key + "_" + chambers_[iType]);
+        const std::string histTitle(chambers_[iType] + " LCT " + lctVars_[iVar] + " (" + dataEmul_[iData] + ") ");
+        chamberHistos[iType][key] =
+            iBooker.book1D(histName, histTitle, lctNBin_[iVar], lctMinBin_[iVar], lctMaxBin_[iVar]);
+      }
+    }
+  }
+}
+
+void L1TdeCSCTPG::analyze(const edm::Event& e, const edm::EventSetup& c) {
+  // handles
+  edm::Handle<CSCALCTDigiCollection> dataALCTs;
+  edm::Handle<CSCALCTDigiCollection> emulALCTs;
+  edm::Handle<CSCCLCTDigiCollection> dataCLCTs;
+  edm::Handle<CSCCLCTDigiCollection> emulCLCTs;
+  edm::Handle<CSCCorrelatedLCTDigiCollection> dataLCTs;
+  edm::Handle<CSCCorrelatedLCTDigiCollection> emulLCTs;
+
+  e.getByToken(dataALCT_token_, dataALCTs);
+  e.getByToken(emulALCT_token_, emulALCTs);
+  e.getByToken(dataCLCT_token_, dataCLCTs);
+  e.getByToken(emulCLCT_token_, emulCLCTs);
+  e.getByToken(dataLCT_token_, dataLCTs);
+  e.getByToken(emulLCT_token_, emulLCTs);
+
+  for (auto it = dataALCTs->begin(); it != dataALCTs->end(); it++) {
+    auto range = dataALCTs->get((*it).first);
+    const int type = ((*it).first).iChamberType() - 1;
+    for (auto alct = range.first; alct != range.second; alct++) {
+      chamberHistos[type]["alct_quality_data"]->Fill(alct->getQuality());
+      chamberHistos[type]["alct_wiregroup_data"]->Fill(alct->getKeyWG());
+      chamberHistos[type]["alct_bx_data"]->Fill(alct->getBX());
+    }
+  }
+
+  for (auto it = emulALCTs->begin(); it != emulALCTs->end(); it++) {
+    auto range = emulALCTs->get((*it).first);
+    const int type = ((*it).first).iChamberType() - 1;
+    for (auto alct = range.first; alct != range.second; alct++) {
+      chamberHistos[type]["alct_quality_emul"]->Fill(alct->getQuality());
+      chamberHistos[type]["alct_wiregroup_emul"]->Fill(alct->getKeyWG());
+      chamberHistos[type]["alct_bx_emul"]->Fill(alct->getBX());
+    }
+  }
+
+  for (auto it = dataCLCTs->begin(); it != dataCLCTs->end(); it++) {
+    auto range = dataCLCTs->get((*it).first);
+    const int type = ((*it).first).iChamberType() - 1;
+    for (auto clct = range.first; clct != range.second; clct++) {
+      chamberHistos[type]["clct_pattern_data"]->Fill(clct->getPattern());
+      chamberHistos[type]["clct_quality_data"]->Fill(clct->getQuality());
+      chamberHistos[type]["clct_halfstrip_data"]->Fill(clct->getKeyStrip());
+      chamberHistos[type]["clct_bend_data"]->Fill(clct->getBend());
+      chamberHistos[type]["clct_bx_data"]->Fill(clct->getBX());
+    }
+  }
+
+  for (auto it = emulCLCTs->begin(); it != emulCLCTs->end(); it++) {
+    auto range = emulCLCTs->get((*it).first);
+    const int type = ((*it).first).iChamberType() - 1;
+    for (auto clct = range.first; clct != range.second; clct++) {
+      chamberHistos[type]["clct_pattern_emul"]->Fill(clct->getPattern());
+      chamberHistos[type]["clct_quality_emul"]->Fill(clct->getQuality());
+      chamberHistos[type]["clct_halfstrip_emul"]->Fill(clct->getKeyStrip());
+      chamberHistos[type]["clct_bend_emul"]->Fill(clct->getBend());
+      chamberHistos[type]["clct_bx_emul"]->Fill(clct->getBX());
+    }
+  }
+
+  for (auto it = dataLCTs->begin(); it != dataLCTs->end(); it++) {
+    auto range = dataLCTs->get((*it).first);
+    const int type = ((*it).first).iChamberType() - 1;
+    for (auto lct = range.first; lct != range.second; lct++) {
+      chamberHistos[type]["lct_pattern_data"]->Fill(lct->getCLCTPattern());
+      chamberHistos[type]["lct_quality_data"]->Fill(lct->getQuality());
+      chamberHistos[type]["lct_wiregroup_data"]->Fill(lct->getKeyWG());
+      chamberHistos[type]["lct_halfstrip_data"]->Fill(lct->getStrip());
+      chamberHistos[type]["lct_bend_data"]->Fill(lct->getBend());
+      chamberHistos[type]["lct_bx_data"]->Fill(lct->getBX());
+    }
+  }
+
+  for (auto it = emulLCTs->begin(); it != emulLCTs->end(); it++) {
+    auto range = emulLCTs->get((*it).first);
+    const int type = ((*it).first).iChamberType() - 1;
+    for (auto lct = range.first; lct != range.second; lct++) {
+      chamberHistos[type]["lct_pattern_emul"]->Fill(lct->getCLCTPattern());
+      chamberHistos[type]["lct_quality_emul"]->Fill(lct->getQuality());
+      chamberHistos[type]["lct_wiregroup_emul"]->Fill(lct->getKeyWG());
+      chamberHistos[type]["lct_halfstrip_emul"]->Fill(lct->getStrip());
+      chamberHistos[type]["lct_bend_emul"]->Fill(lct->getBend());
+      chamberHistos[type]["lct_bx_emul"]->Fill(lct->getBX());
+    }
+  }
+}

--- a/DQM/L1TMonitorClient/interface/L1TdeCSCTPGClient.h
+++ b/DQM/L1TMonitorClient/interface/L1TdeCSCTPGClient.h
@@ -1,0 +1,55 @@
+#ifndef DQM_L1TMONITORCLIENT_L1TdeCSCTPGCLIENT_H
+#define DQM_L1TMONITORCLIENT_L1TdeCSCTPGCLIENT_H
+
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "DQMServices/Core/interface/DQMStore.h"
+#include "DQMServices/Core/interface/DQMEDHarvester.h"
+
+#include <string>
+
+class L1TdeCSCTPGClient : public DQMEDHarvester {
+public:
+  /// Constructor
+  L1TdeCSCTPGClient(const edm::ParameterSet &ps);
+
+  /// Destructor
+  ~L1TdeCSCTPGClient() override;
+
+protected:
+  void dqmEndLuminosityBlock(DQMStore::IBooker &,
+                             DQMStore::IGetter &,
+                             edm::LuminosityBlock const &,
+                             edm::EventSetup const &) override;
+  void dqmEndJob(DQMStore::IBooker &, DQMStore::IGetter &) override;
+
+private:
+  void book(DQMStore::IBooker &ibooker);
+  void processHistograms(DQMStore::IGetter &);
+
+  std::string monitorDir_;
+
+  std::vector<std::string> chambers_;
+
+  std::vector<std::string> alctVars_;
+  std::vector<std::string> clctVars_;
+  std::vector<std::string> lctVars_;
+
+  std::vector<unsigned> alctNBin_;
+  std::vector<unsigned> clctNBin_;
+  std::vector<unsigned> lctNBin_;
+  std::vector<double> alctMinBin_;
+  std::vector<double> clctMinBin_;
+  std::vector<double> lctMinBin_;
+  std::vector<double> alctMaxBin_;
+  std::vector<double> clctMaxBin_;
+  std::vector<double> lctMaxBin_;
+
+  // first key is the chamber number
+  // second key is the variable
+  std::map<uint32_t, std::map<std::string, MonitorElement *> > chamberHistos_;
+};
+
+#endif

--- a/DQM/L1TMonitorClient/python/L1TMonitorClient_cff.py
+++ b/DQM/L1TMonitorClient/python/L1TMonitorClient_cff.py
@@ -4,16 +4,16 @@ import FWCore.ParameterSet.Config as cms
 #
 # used by DQM GUI: DQM/Integration/python/test/l1t_dqm_sourceclient-*_cfg.py
 #
-# standard RawToDigi sequence must be run before the L1T module, labels 
+# standard RawToDigi sequence must be run before the L1T module, labels
 # from the standard sequence are used as default for the L1 DQM modules
 # any configuration change in the unpacking must be done in l1t_dqm_sourceclient-*_cfg.py
 #
 # see CVS for previous authors
 #
 # V.M. Ghete 2011-05-26 revised version of L1 Trigger client DQM
-#                       
+#
 
-# DQM quality tests 
+# DQM quality tests
 from DQM.L1TMonitorClient.L1TriggerQualityTests_cff import *
 
 #
@@ -27,38 +27,38 @@ from DQM.L1TMonitorClient.L1TriggerQualityTests_cff import *
 # ECAL TPG client DQM module
 # not run in L1T - do we need it? FIXME
 
-# HCAL TPG DQM module 
+# HCAL TPG DQM module
 # not run in L1T - do we need it? FIXME
 
 # RCT DQM client module - not available
 #from DQM.L1TMonitorClient.L1TRCTClient_cfi import *
 
-# GCT DQM client module 
+# GCT DQM client module
 from DQM.L1TMonitorClient.L1TGCTClient_cfi import *
 from DQM.L1TMonitorClient.L1TStage1Layer2Client_cfi import *
 
-# DTTPG DQM module 
+# DTTPG DQM module
 # not run in L1T - do we need it? FIXME
 
-# DTTF DQM client module 
+# DTTF DQM client module
 from DQM.L1TMonitorClient.L1TDTTFClient_cfi import *
 
-# CSCTPG DQM module 
-# not run in L1T - do we need it? FIXME
+# CSCTPG DQM module
+from DQM.L1TMonitorClient.L1TdeCSCTPGClient_cfi import *
 
-# CSCTF DQM client module 
-from DQM.L1TMonitorClient.L1TCSCTFClient_cfi import * 
+# CSCTF DQM client module
+from DQM.L1TMonitorClient.L1TCSCTFClient_cfi import *
 
 # RPC DQM client module - non-standard name of the module
 from DQM.L1TMonitorClient.L1TRPCTFClient_cfi import *
 
-# GMT DQM module 
+# GMT DQM module
 from DQM.L1TMonitorClient.L1TGMTClient_cfi import *
 
-# GT DQM client module - not available 
+# GT DQM client module - not available
 #from DQM.L1TMonitorClient.L1TGTClient_cfi import *
 
-# L1Extra DQM client module - not available 
+# L1Extra DQM client module - not available
 
 # L1 rates DQM client module
 # L1 synchronization DQM client module
@@ -66,7 +66,7 @@ from DQM.L1TMonitorClient.L1TGMTClient_cfi import *
 from DQM.L1TMonitorClient.L1TOccupancyClient_cff import *
 from DQM.L1TMonitorClient.L1TTestsSummary_cff import *
 
-# L1 event info DQM client 
+# L1 event info DQM client
 from DQM.L1TMonitorClient.L1TEventInfoClient_cfi import *
 
 #
@@ -80,49 +80,49 @@ l1tsClient.dqmFolder = cms.untracked.string("L1T/L1Scalers_SM")
 
 
 #
-# define sequences 
+# define sequences
 #
 
 # L1T monitor client sequence (system clients and quality tests)
 l1TriggerClients = cms.Sequence(
-                        l1tGctClient +
-                        l1tDttfClient +
-                        l1tCsctfClient + 
-                        l1tRpctfClient +
-                        l1tGmtClient +
-                        l1tOccupancyClient +
-                        l1tTestsSummary +
-                        l1tEventInfoClient
-                        )
+    l1tGctClient +
+    l1tDttfClient +
+    l1tdeCSCTPGClient +
+    l1tCsctfClient +
+    l1tRpctfClient +
+    l1tGmtClient +
+    l1tOccupancyClient +
+    l1tTestsSummary +
+    l1tEventInfoClient
+)
 
 l1TriggerStage1Clients = cms.Sequence(
-                        l1tStage1Layer2Client +
-                        l1tDttfClient +
-                        l1tCsctfClient + 
-                        l1tRpctfClient +
-                        l1tGmtClient +
-                        l1tOccupancyClient +
-                        l1tTestsSummary +
-                        l1tEventInfoClient
-                        )
+    l1tStage1Layer2Client +
+    l1tDttfClient +
+    l1tdeCSCTPGClient +
+    l1tCsctfClient +
+    l1tRpctfClient +
+    l1tGmtClient +
+    l1tOccupancyClient +
+    l1tTestsSummary +
+    l1tEventInfoClient
+)
 
 
 l1tMonitorClient = cms.Sequence(
-                        l1TriggerQualityTests +
-                        l1TriggerClients
-                        )
+    l1TriggerQualityTests +
+    l1TriggerClients
+)
 
 l1tMonitorStage1Client = cms.Sequence(
-                        l1TriggerQualityTests +
-                        l1TriggerStage1Clients
-                        )
+    l1TriggerQualityTests +
+    l1TriggerStage1Clients
+)
 
 
-# sequence for L1 Trigger DQM client modules on EndPath 
+# sequence for L1 Trigger DQM client modules on EndPath
 # FIXME clarify why needed on EndPath
 
 l1tMonitorClientEndPathSeq = cms.Sequence(
-                                l1tsClient
-                                )
-
-
+    l1tsClient
+)

--- a/DQM/L1TMonitorClient/python/L1TStage2EmulatorMonitorClient_cff.py
+++ b/DQM/L1TMonitorClient/python/L1TStage2EmulatorMonitorClient_cff.py
@@ -34,6 +34,9 @@ from DQM.L1TMonitorClient.L1TStage2OMTFEmulatorClient_cff import *
 # GEM TPG emulator client
 from DQM.L1TMonitorClient.L1TdeGEMTPGClient_cfi import *
 
+# CSC TPG emulator client
+from DQM.L1TMonitorClient.L1TdeCSCTPGClient_cfi import *
+
 # EMTF emulator client
 from DQM.L1TMonitorClient.L1TStage2EMTFEmulatorClient_cff import *
 
@@ -54,6 +57,7 @@ l1TStage2EmulatorClients = cms.Sequence(
     + l1tStage2BMTFEmulatorClient
     + l1tStage2BMTFEmulatorSecondClient
     + l1tStage2OMTFEmulatorClient
+    + l1tdeCSCTPGClient
     + l1tStage2EMTFEmulatorClient
     + l1tStage2EmulatorEventInfoClient
     + l1tStage2uGTEmulatorClient

--- a/DQM/L1TMonitorClient/python/L1TdeCSCTPGClient_cfi.py
+++ b/DQM/L1TMonitorClient/python/L1TdeCSCTPGClient_cfi.py
@@ -1,0 +1,8 @@
+import FWCore.ParameterSet.Config as cms
+from DQMServices.Core.DQMEDHarvester import DQMEDHarvester
+from DQM.L1TMonitor.L1TdeCSCTPG_cfi import l1tdeCSCTPGCommon
+
+l1tdeCSCTPGClient = DQMEDHarvester(
+    "L1TdeCSCTPGClient",
+    l1tdeCSCTPGCommon
+)

--- a/DQM/L1TMonitorClient/src/L1TdeCSCTPGClient.cc
+++ b/DQM/L1TMonitorClient/src/L1TdeCSCTPGClient.cc
@@ -1,0 +1,150 @@
+#include "DQM/L1TMonitorClient/interface/L1TdeCSCTPGClient.h"
+
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "DQMServices/Core/interface/DQMStore.h"
+#include "TRandom.h"
+using namespace edm;
+using namespace std;
+
+L1TdeCSCTPGClient::L1TdeCSCTPGClient(const edm::ParameterSet &ps)
+    : monitorDir_(ps.getParameter<string>("monitorDir")),
+      chambers_(ps.getParameter<std::vector<std::string>>("chambers")),
+      // variables
+      alctVars_(ps.getParameter<std::vector<std::string>>("alctVars")),
+      clctVars_(ps.getParameter<std::vector<std::string>>("clctVars")),
+      lctVars_(ps.getParameter<std::vector<std::string>>("lctVars")),
+      // binning
+      alctNBin_(ps.getParameter<std::vector<unsigned>>("alctNBin")),
+      clctNBin_(ps.getParameter<std::vector<unsigned>>("clctNBin")),
+      lctNBin_(ps.getParameter<std::vector<unsigned>>("lctNBin")),
+      alctMinBin_(ps.getParameter<std::vector<double>>("alctMinBin")),
+      clctMinBin_(ps.getParameter<std::vector<double>>("clctMinBin")),
+      lctMinBin_(ps.getParameter<std::vector<double>>("lctMinBin")),
+      alctMaxBin_(ps.getParameter<std::vector<double>>("alctMaxBin")),
+      clctMaxBin_(ps.getParameter<std::vector<double>>("clctMaxBin")),
+      lctMaxBin_(ps.getParameter<std::vector<double>>("lctMaxBin")) {}
+
+L1TdeCSCTPGClient::~L1TdeCSCTPGClient() {}
+
+void L1TdeCSCTPGClient::dqmEndLuminosityBlock(DQMStore::IBooker &ibooker,
+                                              DQMStore::IGetter &igetter,
+                                              const edm::LuminosityBlock &lumiSeg,
+                                              const edm::EventSetup &c) {
+  book(ibooker);
+  processHistograms(igetter);
+}
+
+//--------------------------------------------------------
+void L1TdeCSCTPGClient::dqmEndJob(DQMStore::IBooker &ibooker, DQMStore::IGetter &igetter) {
+  book(ibooker);
+  processHistograms(igetter);
+}
+
+void L1TdeCSCTPGClient::book(DQMStore::IBooker &iBooker) {
+  iBooker.setCurrentFolder(monitorDir_);
+
+  // chamber type
+  for (unsigned iType = 0; iType < chambers_.size(); iType++) {
+    // alct variable
+    for (unsigned iVar = 0; iVar < alctVars_.size(); iVar++) {
+      const std::string key("alct_" + alctVars_[iVar] + "_diff");
+      const std::string histName(key + "_" + chambers_[iType]);
+      const std::string histTitle(chambers_[iType] + " ALCT " + alctVars_[iVar] + " (Emul - Data)");
+      if (chamberHistos_[iType][key] == nullptr)
+        chamberHistos_[iType][key] =
+            iBooker.book1D(histName, histTitle, alctNBin_[iVar], alctMinBin_[iVar], alctMaxBin_[iVar]);
+      else
+        chamberHistos_[iType][key]->Reset();
+    }
+
+    // clct variable
+    for (unsigned iVar = 0; iVar < clctVars_.size(); iVar++) {
+      const std::string key("clct_" + clctVars_[iVar] + "_diff");
+      const std::string histName(key + "_" + chambers_[iType]);
+      const std::string histTitle(chambers_[iType] + " CLCT " + clctVars_[iVar] + " (Emul - Data)");
+      if (chamberHistos_[iType][key] == nullptr)
+        chamberHistos_[iType][key] =
+            iBooker.book1D(histName, histTitle, clctNBin_[iVar], clctMinBin_[iVar], clctMaxBin_[iVar]);
+      else
+        chamberHistos_[iType][key]->Reset();
+    }
+
+    // lct variable
+    for (unsigned iVar = 0; iVar < lctVars_.size(); iVar++) {
+      const std::string key("lct_" + lctVars_[iVar] + "_diff");
+      const std::string histName(key + "_" + chambers_[iType]);
+      const std::string histTitle(chambers_[iType] + " LCT " + lctVars_[iVar] + " (Emul - Data)");
+      if (chamberHistos_[iType][key] == nullptr)
+        chamberHistos_[iType][key] =
+            iBooker.book1D(histName, histTitle, lctNBin_[iVar], lctMinBin_[iVar], lctMaxBin_[iVar]);
+      else
+        chamberHistos_[iType][key]->Reset();
+    }
+  }
+}
+
+void L1TdeCSCTPGClient::processHistograms(DQMStore::IGetter &igetter) {
+  MonitorElement *dataMon;
+  MonitorElement *emulMon;
+
+  // chamber type
+  for (unsigned iType = 0; iType < chambers_.size(); iType++) {
+    // alct variable
+    for (unsigned iVar = 0; iVar < alctVars_.size(); iVar++) {
+      const std::string key("alct_" + alctVars_[iVar]);
+      const std::string histData(key + "_data_" + chambers_[iType]);
+      const std::string histEmul(key + "_emul_" + chambers_[iType]);
+
+      dataMon = igetter.get(monitorDir_ + "/" + histData);
+      emulMon = igetter.get(monitorDir_ + "/" + histEmul);
+
+      TH1F *hDiff = chamberHistos_[iType][key + "_diff"]->getTH1F();
+
+      if (dataMon && emulMon) {
+        TH1F *hData = dataMon->getTH1F();
+        TH1F *hEmul = emulMon->getTH1F();
+        hDiff->Add(hEmul, hData, 1, -1);
+      }
+    }
+
+    // clct variable
+    for (unsigned iVar = 0; iVar < clctVars_.size(); iVar++) {
+      const std::string key("clct_" + clctVars_[iVar]);
+      const std::string histData(key + "_data_" + chambers_[iType]);
+      const std::string histEmul(key + "_emul_" + chambers_[iType]);
+
+      dataMon = igetter.get(monitorDir_ + "/" + histData);
+      emulMon = igetter.get(monitorDir_ + "/" + histEmul);
+
+      TH1F *hDiff = chamberHistos_[iType][key + "_diff"]->getTH1F();
+
+      if (dataMon && emulMon) {
+        TH1F *hData = dataMon->getTH1F();
+        TH1F *hEmul = emulMon->getTH1F();
+        hDiff->Add(hEmul, hData, 1, -1);
+      }
+    }
+
+    // lct variable
+    for (unsigned iVar = 0; iVar < lctVars_.size(); iVar++) {
+      const std::string key("lct_" + lctVars_[iVar]);
+      const std::string histData(key + "_data_" + chambers_[iType]);
+      const std::string histEmul(key + "_emul_" + chambers_[iType]);
+
+      dataMon = igetter.get(monitorDir_ + "/" + histData);
+      emulMon = igetter.get(monitorDir_ + "/" + histEmul);
+
+      TH1F *hDiff = chamberHistos_[iType][key + "_diff"]->getTH1F();
+
+      if (dataMon && emulMon) {
+        TH1F *hData = dataMon->getTH1F();
+        TH1F *hEmul = emulMon->getTH1F();
+        hDiff->Add(hEmul, hData, 1, -1);
+      }
+    }
+  }
+}

--- a/DQM/L1TMonitorClient/src/SealModule.cc
+++ b/DQM/L1TMonitorClient/src/SealModule.cc
@@ -12,6 +12,9 @@ DEFINE_FWK_MODULE(L1TRPCTFClient);
 #include "DQM/L1TMonitorClient/interface/L1TdeGEMTPGClient.h"
 DEFINE_FWK_MODULE(L1TdeGEMTPGClient);
 
+#include "DQM/L1TMonitorClient/interface/L1TdeCSCTPGClient.h"
+DEFINE_FWK_MODULE(L1TdeCSCTPGClient);
+
 #include "DQM/L1TMonitorClient/interface/L1TCSCTFClient.h"
 DEFINE_FWK_MODULE(L1TCSCTFClient);
 


### PR DESCRIPTION
#### PR description:

With this PR we add histograms for CSC trigger primitives (ALCT, CLCT, LCT) data vs emulator comparisons. There are 1D histograms for each TP property and "data-emulator" plots - which ideally are empty. 

It would be great to have this up and running for the next MWGR.

#### PR validation:

Tested by @akhter-towsifa with a DQM private server (on an lxplus machine) using MWGR#5(2020) data. See also https://indico.cern.ch/event/1012264/contributions/4249723/attachments/2197001/3714846/Akhter_02252021_GEM_CSC_DQM_GUI_lxplus711.pdf

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

May need to backport to 11_2 for MWGR.

FYI @akhter-towsifa @ptcox @tahuang1991 