### PR TITLE
Update DD4Hep workflow to accept all Run-3 and Phase-2 wfs. Add README.md to runTheMatrix

### DIFF
--- a/Configuration/PyReleaseValidation/README.md
+++ b/Configuration/PyReleaseValidation/README.md
@@ -1,0 +1,39 @@
+# runTheMatrix.py
+
+## Upgrade workflows
+To list the upgrade workflows,
+```
+runTheMatrix.py --what upgrade -n
+``` 
+
+### offset:
+* 0.1: Tracking-only validation and DQM
+* 0.2: Tracking Run-2 era, `Run2_2017_trackingRun2`
+* 0.3: 0.1 + 0.2
+* 0.4: LowPU tracking era, `Run2_2017_trackingLowPU`
+* 0.5: Pixel tracking only + 0.1
+* 0.6: HE Collapse, HEM in 2018
+* 0.7: trackingMkFit modifier
+* 0.8: BPH Parking (Run-2)
+* 0.9: Vector hits
+* 0.12: Neutron background
+* 0.13: MLPF algorithm
+* 0.15: JME NanoAOD
+* 0.17: Run-3 deep core seeding for JetCore iteration
+* 0.21: Production-like sequence
+* 0.24: 0 Tesla (Run-2, Run-3)
+* 0.61: `phase2_ecal_devel` era
+* 0.91: Track DNN modifier
+* 0.97, 0.98, 0.99: Premixing stage1, stage2, stage1+stage2
+* 0.999: 0.99 with Phase-2 premixing with PU50
+* 0.911: DD4Hep
+* 0.101: Phase-2 aging, 1000fb-1
+* 0.103: Phase-2 aging, 3000fb-1
+* 0.501: Patatrack, pixel only CPU
+* 0.502: Patatrack, pixel only GPU
+* 0.511: Patatrack, ECAL only CPU
+* 0.512: Patatrack, ECAL only GPU
+* 0.521: Patatrack, HCAL only CPU
+* 0.522: Patatrack, HCAL only GPU
+* 0.9001: Sonic Triton
+

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -974,8 +974,7 @@ class UpgradeWorkflow_DD4hep(UpgradeWorkflow):
             dd4hepGeom+=stepDict[step][k]['--geometry']
             stepDict[stepName][k] = merge([{'--geometry' : dd4hepGeom, '--procModifiers': 'dd4hep'}, stepDict[step][k]])
     def condition(self, fragment, stepList, key, hasHarvest):
-        return ((fragment=='TTbar_14TeV' or fragment=='ZMM_14' or fragment=='SingleMuPt10') and '2021' in key) \
-            or ((fragment=='TTbar_14TeV' or fragment=='ZMM_14' or fragment=='SingleMuPt10') and '2026' in key)
+        return '2021' in key or '2026' in key
 upgradeWFs['DD4hep'] = UpgradeWorkflow_DD4hep(
     steps = [
         'GenSim',


### PR DESCRIPTION
#### PR description:
Currently, DD4Hep upgrade workflows accept only TTbar, ZMM, SingleMu gun. This PR is to enable it for all Run-3, Phase-2 workflows for future validation purpose.

In addition, README is added, to document runTheMatrix. The first version is to list all offset we use for upgrade workflows.

#### PR validation:
`runTheMatrix.py --what upgrade -l 11635.911 --wm init` dump properly.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:
Not a backport, and no need of backport.
