### PR TITLE
fix to KineParticleFilter::acceptParticle

### DIFF
--- a/FastSimulation/Event/src/KineParticleFilter.cc
+++ b/FastSimulation/Event/src/KineParticleFilter.cc
@@ -34,7 +34,7 @@ bool KineParticleFilter::acceptParticle(const RawParticle& particle) const {
 
   // keep all high-energy protons
   else if (pId == 2212 && particle.E() >= protonEMin) {
-    return true;
+    return acceptVertex(particle.vertex());
   }
 
   // cut on the energy


### PR DESCRIPTION
#### PR description:

This PR is meant to fix a problem in a Jet/MET analysis workflow.

The current procedure to derive the so-called PF-Hadron Calibrations (for Offline and HLT) relies on the `PFSimParticleProducer`, which in turn makes use of `PFSimBaseEvent` and related utilities.

For a non-negligible amount of events, `PFSimParticleProducer` crashes with the following error message
```
----- Begin Fatal Exception [...]-----------------------
An exception of category 'FastSim' occurred while
   [0] Processing  Event run: 1 lumi: 2757 event: 2756952 stream: 0
   [1] Running path 'pfSimParticlePath'
   [2] Calling method for module PFSimParticleProducer/'particleFlowSimParticle'
Exception Message:
Index for FSimVertex out of range, please contact FastSim developers
----- End Fatal Exception ------------------------------
```

This error was already reported in previous years, apparently without a clear solution:
https://indico.cern.ch/event/673246/contributions/2757878/attachments/1541980/2418599/JMEHLTX-POG.pdf
https://hypernews.cern.ch/HyperNews/CMS/get/eflow/1011/1/1.html
https://hypernews.cern.ch/HyperNews/CMS/get/famos/687.html

Some debugging [*] led to the update in this PR, which fixes the issue.

FYI: @lathomas @kirschen @hatakeyamak @bendavid @pallabidas

------------

[*] More debugging information.

The crash occurs in `FBaseSimEvent`, and was caused by instances where

 * `KineParticleFilter::acceptVertex` would fail (return `false`)
   https://github.com/cms-sw/cmssw/blob/03dd22b632c7c8b384a515c5fc1937de77470afe/FastSimulation/Event/src/KineParticleFilter.cc#L59
   and this would cause the vertex-id in
   https://github.com/cms-sw/cmssw/blob/03dd22b632c7c8b384a515c5fc1937de77470afe/FastSimulation/Event/src/FBaseSimEvent.cc#L178
   to be `-1`
   https://github.com/cms-sw/cmssw/blob/03dd22b632c7c8b384a515c5fc1937de77470afe/FastSimulation/Event/src/FBaseSimEvent.cc#L529

 * in the ensuing call to `FBaseSimEvent::addSimTrack`
   https://github.com/cms-sw/cmssw/blob/03dd22b632c7c8b384a515c5fc1937de77470afe/FastSimulation/Event/src/FBaseSimEvent.cc#L199
   `KineParticleFilter::acceptParticle` would return `true`
   https://github.com/cms-sw/cmssw/blob/03dd22b632c7c8b384a515c5fc1937de77470afe/FastSimulation/Event/src/FBaseSimEvent.cc#L487
   because of
   https://github.com/cms-sw/cmssw/blob/03dd22b632c7c8b384a515c5fc1937de77470afe/FastSimulation/Event/src/KineParticleFilter.cc#L37

 * and, ultimately, the crash would occur here, because of `iv` being `-1`
   https://github.com/cms-sw/cmssw/blob/03dd22b632c7c8b384a515c5fc1937de77470afe/FastSimulation/Event/src/FBaseSimEvent.cc#L498

In summary, it seems that, when `KineParticleFilter::acceptVertex` returns `false`, then `KineParticleFilter::acceptParticle` should also return `false` for particles associated to that vertex. When this is not the case (i.e. without the suggested fix), the logic in `FBaseSimEvent` starts to break.

------------

#### PR validation:

Private tests on the affected JME workflow.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A (no backport planned)
