### PR TITLE
improving PixelVertexCollectionTrimmer

### DIFF
--- a/RecoPixelVertexing/PixelVertexFinding/plugins/PixelVertexCollectionTrimmer.cc
+++ b/RecoPixelVertexing/PixelVertexFinding/plugins/PixelVertexCollectionTrimmer.cc
@@ -1,128 +1,102 @@
-// -*- C++ -*-
-//
-// Package: RecoPixelVertexing/PixelVertexFinding
-// Class: PixelVertexCollectionTrimmer
-//
-/**\class PixelVertexCollectionTrimmer PixelVertexCollectionTrimmer.cc RecoPixelVertexing/PixelVertexFinding/src/PixelVertexCollectionTrimmer.cc
-
-Description: [one line class summary]
-
-Implementation:
-[Notes on implementation]
-*/
-//
 // Original Author: Riccardo Manzoni
-// Created: Tue, 01 Apr 2014 10:11:16 GMT
-//
-//
-
-// system include files
 #include <memory>
 
-// user include files
+#include <vector>
+#include <memory>
+#include <numeric>
+#include <algorithm>
+
+#include "DataFormats/VertexReco/interface/Vertex.h"
+#include "DataFormats/VertexReco/interface/VertexFwd.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
-
-#include "DataFormats/VertexReco/interface/Vertex.h"
-#include "DataFormats/VertexReco/interface/VertexFwd.h"
-#include "FWCore/Utilities/interface/InputTag.h"
-#include "RecoPixelVertexing/PixelVertexFinding/interface/PVClusterComparer.h"
-
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "RecoPixelVertexing/PixelVertexFinding/interface/PVClusterComparer.h"
 
 class PixelVertexCollectionTrimmer : public edm::stream::EDProducer<> {
 public:
   explicit PixelVertexCollectionTrimmer(const edm::ParameterSet&);
-  ~PixelVertexCollectionTrimmer() override;
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 private:
   void produce(edm::Event&, const edm::EventSetup&) override;
 
-  edm::EDGetTokenT<reco::VertexCollection> vtxToken_;
-  unsigned int maxVtx_;
-  double fractionSumPt2_;
-  double minSumPt2_;
+  edm::EDGetTokenT<reco::VertexCollection> const vtxToken_;
+  uint const maxVtx_;
+  double const fractionSumPt2_;
+  double const minSumPt2_;
 
-  PVClusterComparer* pvComparer_;
+  std::unique_ptr<PVClusterComparer> pvComparer_;
 };
 
-PixelVertexCollectionTrimmer::PixelVertexCollectionTrimmer(const edm::ParameterSet& iConfig) {
-  edm::InputTag vtxInputTag = iConfig.getParameter<edm::InputTag>("src");
-  vtxToken_ = consumes<reco::VertexCollection>(vtxInputTag);
-  maxVtx_ = iConfig.getParameter<unsigned int>("maxVtx");
-  fractionSumPt2_ = iConfig.getParameter<double>("fractionSumPt2");
-  minSumPt2_ = iConfig.getParameter<double>("minSumPt2");
+PixelVertexCollectionTrimmer::PixelVertexCollectionTrimmer(const edm::ParameterSet& iConfig)
+    : vtxToken_(consumes<reco::VertexCollection>(iConfig.getParameter<edm::InputTag>("src"))),
+      maxVtx_(iConfig.getParameter<uint>("maxVtx")),
+      fractionSumPt2_(iConfig.getParameter<double>("fractionSumPt2")),
+      minSumPt2_(iConfig.getParameter<double>("minSumPt2")) {
+  if (fractionSumPt2_ < 0)
+    edm::LogWarning("Configuration") << "value of \"fractionSumPt2\" is negative.";
+  else if (fractionSumPt2_ > 1)
+    edm::LogWarning("Configuration") << "value of \"fractionSumPt2\" is larger than 1.";
 
-  edm::ParameterSet PVcomparerPSet = iConfig.getParameter<edm::ParameterSet>("PVcomparer");
-  double track_pt_min = PVcomparerPSet.getParameter<double>("track_pt_min");
-  double track_pt_max = PVcomparerPSet.getParameter<double>("track_pt_max");
-  double track_chi2_max = PVcomparerPSet.getParameter<double>("track_chi2_max");
-  double track_prob_min = PVcomparerPSet.getParameter<double>("track_prob_min");
+  auto const PVcomparerPSet = iConfig.getParameter<edm::ParameterSet>("PVcomparer");
+  auto const track_pt_min = PVcomparerPSet.getParameter<double>("track_pt_min");
+  auto const track_pt_max = PVcomparerPSet.getParameter<double>("track_pt_max");
+  auto const track_chi2_max = PVcomparerPSet.getParameter<double>("track_chi2_max");
+  auto const track_prob_min = PVcomparerPSet.getParameter<double>("track_prob_min");
 
-  pvComparer_ = new PVClusterComparer(track_pt_min, track_pt_max, track_chi2_max, track_prob_min);
+  if (track_pt_min >= track_pt_max)
+    edm::LogWarning("Configuration") << "PVcomparer.track_pt_min (" << track_pt_min << ") >= PVcomparer.track_pt_max ("
+                                     << track_pt_max << ") : PVClusterComparer will use pT=" << track_pt_max
+                                     << " for all selected tracks.";
+
+  pvComparer_ = std::make_unique<PVClusterComparer>(track_pt_min, track_pt_max, track_chi2_max, track_prob_min);
 
   produces<reco::VertexCollection>();
 }
 
-PixelVertexCollectionTrimmer::~PixelVertexCollectionTrimmer() {}
-
-// ------------ method called to produce the data ------------
 void PixelVertexCollectionTrimmer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
-  using namespace edm;
-
   auto vtxs_trim = std::make_unique<reco::VertexCollection>();
 
-  edm::Handle<reco::VertexCollection> vtxs;
-  iEvent.getByToken(vtxToken_, vtxs);
+  auto const& vtxs = iEvent.get(vtxToken_);
 
-  if (vtxs->empty()) {
+  if (vtxs.empty())
     edm::LogWarning("Input") << "Input collection of vertices is empty. Output collection will be empty.";
-    iEvent.put(std::move(vtxs_trim));
-    return;
+  else {
+    std::vector<double> foms(vtxs.size());
+    for (size_t idx = 0; idx < vtxs.size(); ++idx)
+      foms.at(idx) = pvComparer_->pTSquaredSum(vtxs.at(idx));
+
+    std::vector<size_t> sortIdxs(vtxs.size());
+    std::iota(sortIdxs.begin(), sortIdxs.end(), 0);
+    std::sort(sortIdxs.begin(), sortIdxs.end(), [&](size_t const i1, size_t const i2) { return foms[i1] > foms[i2]; });
+
+    auto const min_fom = std::max(foms.at(sortIdxs.at(0)) * fractionSumPt2_, minSumPt2_);
+
+    vtxs_trim->reserve(maxVtx_ < vtxs.size() ? maxVtx_ : vtxs.size());
+    for (auto const idx : sortIdxs) {
+      if (vtxs_trim->size() >= maxVtx_)
+        break;
+      if (foms.at(idx) >= min_fom)
+        vtxs_trim->emplace_back(vtxs.at(idx));
+    }
+
+    if (vtxs_trim->empty())
+      edm::LogWarning("Output") << "Output collection is empty.";
   }
 
-  double sumpt2;
-  //double sumpt2previous = -99. ;
-
-  // this is not the logic we want, at least for now
-  // if requires the sumpt2 for vtx_n to be > threshold * sumpt2 vtx_n-1
-  // for (reco::VertexCollection::const_iterator vtx = vtxs->begin(); vtx != vtxs->end(); ++vtx, ++counter){
-  // if (counter > maxVtx_) break ;
-  // sumpt2 = PVCluster.pTSquaredSum(*vtx) ;
-  // if (sumpt2 > sumpt2previous*fractionSumPt2_ && sumpt2 > minSumPt2_ ) vtxs_trim->push_back(*vtx) ;
-  // else if (counter == 0 ) vtxs_trim->push_back(*vtx) ;
-  // sumpt2previous = sumpt2 ;
-  // }
-
-  double sumpt2first = pvComparer_->pTSquaredSum(*(vtxs->begin()));
-
-  for (reco::VertexCollection::const_iterator vtx = vtxs->begin(), evtx = vtxs->end(); vtx != evtx; ++vtx) {
-    if (vtxs_trim->size() >= maxVtx_)
-      break;
-    sumpt2 = pvComparer_->pTSquaredSum(*vtx);
-    //    std::cout << "sumpt2: " << sumpt2 << "[" << sumpt2first << "]" << std::endl;
-    //    if (sumpt2 >= sumpt2first*fractionSumPt2_ && sumpt2 > minSumPt2_ ) vtxs_trim->push_back(*vtx) ;
-    if (sumpt2 >= sumpt2first * fractionSumPt2_ && sumpt2 > minSumPt2_)
-      vtxs_trim->push_back(*vtx);
-  }
-  //  std::cout << " ==> # vertices: " << vtxs_trim->size() << std::endl;
   iEvent.put(std::move(vtxs_trim));
 }
 
-// ------------ method fills 'descriptions' with the allowed parameters for the module ------------
 void PixelVertexCollectionTrimmer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
-  //The following says we do not know what parameters are allowed so do no validation
-  // Please change this to state exactly what you do use, even if it is no parameters
   edm::ParameterSetDescription desc;
   desc.add<edm::InputTag>("src", edm::InputTag(""))->setComment("input (pixel) vertex collection");
-  desc.add<unsigned int>("maxVtx", 100)->setComment("max output collection size (number of accepted vertices)");
+  desc.add<uint>("maxVtx", 100)->setComment("max output collection size (number of accepted vertices)");
   desc.add<double>("fractionSumPt2", 0.3)->setComment("threshold on sumPt2 fraction of the leading vertex");
   desc.add<double>("minSumPt2", 0.)->setComment("min sumPt2");
   edm::ParameterSetDescription PVcomparerPSet;
@@ -135,5 +109,4 @@ void PixelVertexCollectionTrimmer::fillDescriptions(edm::ConfigurationDescriptio
   descriptions.add("hltPixelVertexCollectionTrimmer", desc);
 }
 
-//define this as a plug-in
 DEFINE_FWK_MODULE(PixelVertexCollectionTrimmer);

--- a/RecoPixelVertexing/PixelVertexFinding/plugins/PixelVertexCollectionTrimmer.cc
+++ b/RecoPixelVertexing/PixelVertexFinding/plugins/PixelVertexCollectionTrimmer.cc
@@ -76,13 +76,13 @@ void PixelVertexCollectionTrimmer::produce(edm::Event& iEvent, const edm::EventS
     std::iota(sortIdxs.begin(), sortIdxs.end(), 0);
     std::sort(sortIdxs.begin(), sortIdxs.end(), [&](size_t const i1, size_t const i2) { return foms[i1] > foms[i2]; });
 
-    auto const min_fom = std::max(foms.at(sortIdxs.at(0)) * fractionSumPt2_, minSumPt2_);
+    auto const minFOM_fromFrac = foms.at(sortIdxs.at(0)) * fractionSumPt2_;
 
     vtxs_trim->reserve(maxVtx_ < vtxs.size() ? maxVtx_ : vtxs.size());
     for (auto const idx : sortIdxs) {
       if (vtxs_trim->size() >= maxVtx_)
         break;
-      if (foms.at(idx) >= min_fom)
+      if (foms.at(idx) >= minFOM_fromFrac and foms.at(idx) > minSumPt2_)
         vtxs_trim->emplace_back(vtxs.at(idx));
     }
 

--- a/RecoPixelVertexing/PixelVertexFinding/plugins/PixelVertexCollectionTrimmer.cc
+++ b/RecoPixelVertexing/PixelVertexFinding/plugins/PixelVertexCollectionTrimmer.cc
@@ -1,6 +1,4 @@
 // Original Author: Riccardo Manzoni
-#include <memory>
-
 #include <vector>
 #include <memory>
 #include <numeric>

--- a/RecoPixelVertexing/PixelVertexFinding/plugins/PixelVertexCollectionTrimmer.cc
+++ b/RecoPixelVertexing/PixelVertexFinding/plugins/PixelVertexCollectionTrimmer.cc
@@ -85,7 +85,7 @@ void PixelVertexCollectionTrimmer::produce(edm::Event& iEvent, const edm::EventS
     }
 
     if (vtxs_trim->empty())
-      edm::LogWarning("Output") << "Output collection is empty.";
+      edm::LogInfo("Output") << "Output collection is empty.";
   }
 
   iEvent.put(std::move(vtxs_trim));


### PR DESCRIPTION
#### PR description:

This PR is meant to improve the implementation of the plugin `PixelVertexCollectionTrimmer`.

This plugin is used at HLT to select a subset of pixel vertices, based on their Sum-Pt2 score.

In its current form, the plugin implicitly assumes that the input collection of vertices is already sorted according to the same sorting criterion used in `PixelVertexCollectionTrimmer` itself ([the 1st entry of the input collection is assumed to have the highest f.o.m.](https://github.com/cms-sw/cmssw/blob/4adab384c347d9ba6d86978f905bb65c0e4743ab/RecoPixelVertexing/PixelVertexFinding/plugins/PixelVertexCollectionTrimmer.cc#L104)).

The main update in this PR is to remove this assumption on the ordering of the inputs.

While said assumption was valid in the past (e.g. Run-2 HLT), it might not be valid in the future; for example, the pixel vertices in the Patatrack workflow use a sorting criterion which is slightly different from the "legacy" pixel vertices (the trimmer still uses the same sorting criterion as the legacy pixel vertices).

More details can be found in https://github.com/cms-patatrack/cmssw/issues/605.

As suggested by @AdrianoDee (TRK POG), I'm opening a PR here, so that experts can review it.

----

On a technical level, these updates would introduce two small changes in the producer:

* in the PR, the output collection is sorted according to the sorter in `PixelVertexCollectionTrimmer` (currently, the trimming is applied, but there is no re-sorting, and the ordering of the outputs is the same as the inputs);

* the current impl uses [`sumpt2 > minSumPt2_`](https://github.com/cms-sw/cmssw/blob/4adab384c347d9ba6d86978f905bb65c0e4743ab/RecoPixelVertexing/PixelVertexFinding/plugins/PixelVertexCollectionTrimmer.cc#L112); in the impl in the PR, this is effectively changed to `sumpt2 >= minSumPt2_`.

----

Here are 3 (possibly alternative) ways to maybe improve things further, for experts to consider:

* adding a data member to `reco::Vertex` to save the Sum-Pt2 score, such that it would not have to be recomputed a posteriori in other modules (having to make sure different modules use the same sorting criterion);

* generalizing the implementation of `PVClusterComparer` (the legacy sorter, used in the trimmer) such that it can be configured to give the legacy sorting, or the Patatrack sorting, depending on what is needed;

* making `PixelVertexCollectionTrimmer` capable of using different sorting functions, rather than just `PVClusterComparer`.

---

#### PR validation:

Private tests to verify that the changes work as intended.

Running the updated plugin on 100 events (Run-3 DY MC with PU) suggests that its timing remains very small (<0.1ms).

#### If this PR is a backport, please specify the original PR and why you need to backport that PR:

N/A (no backport planned)