### PR TITLE
cleanup includes in SimDataFormats/GeneratorProducts

### DIFF
--- a/SimDataFormats/GeneratorProducts/interface/HepMCProduct.h
+++ b/SimDataFormats/GeneratorProducts/interface/HepMCProduct.h
@@ -6,13 +6,16 @@
  *  \author Joanna Weng, Filip Moortgat
  */
 
-#include <TMatrixD.h>
-
-#include <cstddef>
-#include <HepMC/GenEvent.h>
-#include <HepMC/SimpleVector.h>
-
 #include "DataFormats/Common/interface/Ref.h"
+#include <TMatrixD.h>
+#include <HepMC/GenEvent.h>
+#include <cstddef>
+
+namespace HepMC {
+  class FourVector;
+  class GenParticle;
+  class GenVertex;
+}
 
 namespace edm {
   class HepMCProduct {

--- a/SimDataFormats/GeneratorProducts/interface/HepMCProduct.h
+++ b/SimDataFormats/GeneratorProducts/interface/HepMCProduct.h
@@ -15,7 +15,7 @@ namespace HepMC {
   class FourVector;
   class GenParticle;
   class GenVertex;
-}
+}  // namespace HepMC
 
 namespace edm {
   class HepMCProduct {

--- a/SimDataFormats/GeneratorProducts/src/HepMCProduct.cc
+++ b/SimDataFormats/GeneratorProducts/src/HepMCProduct.cc
@@ -7,8 +7,8 @@
 #include <iostream>
 #include <algorithm>  // because we use std::swap
 
-//#include "CLHEP/Vector/ThreeVector.h"
-
+#include <HepMC/GenEvent.h>
+#include <HepMC/SimpleVector.h>
 #include "SimDataFormats/GeneratorProducts/interface/HepMCProduct.h"
 
 using namespace edm;


### PR DESCRIPTION
Specifically moves any hepmc includes that can be replaced by forward declarations into the implementation