### PR TITLE
Migration to DD4hep for ME0 db Loader

### DIFF
--- a/CondTools/Geometry/plugins/ME0RecoIdealDBLoader.cc
+++ b/CondTools/Geometry/plugins/ME0RecoIdealDBLoader.cc
@@ -3,23 +3,36 @@
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
-
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "CondCore/DBOutputService/interface/PoolDBOutputService.h"
 #include "CondFormats/GeometryObjects/interface/RecoIdealGeometry.h"
+#include "Geometry/Records/interface/IdealGeometryRecord.h"
 #include "DetectorDescription/Core/interface/DDCompactView.h"
+#include "DetectorDescription/DDCMS/interface/DDCompactView.h"
 #include "Geometry/GEMGeometryBuilder/src/ME0GeometryParsFromDD.h"
 #include "Geometry/MuonNumbering/interface/MuonGeometryConstants.h"
 #include "Geometry/Records/interface/ME0RecoGeometryRcd.h"
 #include "Geometry/Records/interface/MuonNumberingRecord.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "Geometry/Records/interface/MuonGeometryRecord.h"
 
 class ME0RecoIdealDBLoader : public edm::one::EDAnalyzer<edm::one::WatchRuns> {
 public:
-  ME0RecoIdealDBLoader(const edm::ParameterSet&) {}
+  ME0RecoIdealDBLoader(const edm::ParameterSet&);
 
   void beginRun(edm::Run const& iEvent, edm::EventSetup const&) override;
   void analyze(edm::Event const& iEvent, edm::EventSetup const&) override {}
   void endRun(edm::Run const& iEvent, edm::EventSetup const&) override {}
+
+private:
+  bool fromDD4Hep_;
 };
+
+ME0RecoIdealDBLoader::ME0RecoIdealDBLoader(const edm::ParameterSet& iC) {
+  fromDD4Hep_ = iC.getUntrackedParameter<bool>("fromDD4Hep", false);  // set true for DD4HEP
+}
 
 void ME0RecoIdealDBLoader::beginRun(const edm::Run&, edm::EventSetup const& es) {
   edm::LogInfo("ME0RecoIdealDBLoader") << "ME0RecoIdealDBLoader::beginRun";
@@ -31,17 +44,24 @@ void ME0RecoIdealDBLoader::beginRun(const edm::Run&, edm::EventSetup const& es) 
   }
 
   if (mydbservice->isNewTagRequest("ME0RecoGeometryRcd")) {
-    edm::ESTransientHandle<DDCompactView> pDD;
     edm::ESHandle<MuonGeometryConstants> pMNDC;
+    ME0GeometryParsFromDD me0pd;
+    RecoIdealGeometry* rig = new RecoIdealGeometry;
+    if (fromDD4Hep_) {
+      edm::LogVerbatim("ME0RecoIdealDBLoader") << "(0) ME0RecoIdealDBLoader - DD4HEP ";
+      edm::ESTransientHandle<cms::DDCompactView> pDD;
+      es.get<IdealGeometryRecord>().get(pDD);
+      es.get<IdealGeometryRecord>().get(pMNDC);
+      const cms::DDCompactView& cpv = *pDD;
+      // me0pd.build(&cpv, *pMNDC, *rig);
+   } else {
+      edm::LogVerbatim("ME0RecoIdealDBLoader") << "(0) ME0RecoIdealDBLoader - DDD ";
+    edm::ESTransientHandle<DDCompactView> pDD;
     es.get<IdealGeometryRecord>().get(pDD);
     es.get<IdealGeometryRecord>().get(pMNDC);
-
     const DDCompactView& cpv = *pDD;
-    ME0GeometryParsFromDD me0pd;
-
-    RecoIdealGeometry* rig = new RecoIdealGeometry;
     me0pd.build(&cpv, *pMNDC, *rig);
-
+    }
     mydbservice->createNewIOV<RecoIdealGeometry>(
         rig, mydbservice->beginOfTime(), mydbservice->endOfTime(), "ME0RecoGeometryRcd");
   } else {

--- a/CondTools/Geometry/plugins/ME0RecoIdealDBLoader.cc
+++ b/CondTools/Geometry/plugins/ME0RecoIdealDBLoader.cc
@@ -53,14 +53,14 @@ void ME0RecoIdealDBLoader::beginRun(const edm::Run&, edm::EventSetup const& es) 
       es.get<IdealGeometryRecord>().get(pDD);
       es.get<IdealGeometryRecord>().get(pMNDC);
       const cms::DDCompactView& cpv = *pDD;
-      // me0pd.build(&cpv, *pMNDC, *rig);
-   } else {
+      me0pd.build(&cpv, *pMNDC, *rig);
+    } else {
       edm::LogVerbatim("ME0RecoIdealDBLoader") << "(0) ME0RecoIdealDBLoader - DDD ";
-    edm::ESTransientHandle<DDCompactView> pDD;
-    es.get<IdealGeometryRecord>().get(pDD);
-    es.get<IdealGeometryRecord>().get(pMNDC);
-    const DDCompactView& cpv = *pDD;
-    me0pd.build(&cpv, *pMNDC, *rig);
+      edm::ESTransientHandle<DDCompactView> pDD;
+      es.get<IdealGeometryRecord>().get(pDD);
+      es.get<IdealGeometryRecord>().get(pMNDC);
+      const DDCompactView& cpv = *pDD;
+      me0pd.build(&cpv, *pMNDC, *rig);
     }
     mydbservice->createNewIOV<RecoIdealGeometry>(
         rig, mydbservice->beginOfTime(), mydbservice->endOfTime(), "ME0RecoGeometryRcd");

--- a/CondTools/Geometry/test/me0geometrywriter.py
+++ b/CondTools/Geometry/test/me0geometrywriter.py
@@ -24,9 +24,6 @@ process.source = cms.Source("EmptyIOVSource",
 
 process.ME0GeometryWriter = cms.EDAnalyzer("ME0RecoIdealDBLoader")
 
-#process.ME0GeometryWriter = cms.EDAnalyzer("ME0RecoIdealDBLoader",
-#                                           fromDD4Hep = cms.untracked.bool(False))
-
 process.CondDB.timetype = cms.untracked.string('runnumber')
 process.CondDB.connect = cms.string('sqlite_file:myfile.db')
 process.PoolDBOutputService = cms.Service("PoolDBOutputService",

--- a/CondTools/Geometry/test/me0geometrywriter.py
+++ b/CondTools/Geometry/test/me0geometrywriter.py
@@ -2,8 +2,18 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("ME0GeometryWriter")
 process.load('CondCore.CondDB.CondDB_cfi')
-process.load('Configuration.Geometry.GeometryExtended2026D41_cff')
+process.load('Configuration.Geometry.GeometryExtended2026D49_cff')
 process.load('Geometry.MuonNumbering.muonNumberingInitialization_cfi')
+process.load("Geometry.MuonNumbering.muonGeometryConstants_cff")
+process.load('Configuration.StandardSequences.DD4hep_GeometrySimPhase2_cff')
+process.load('FWCore.MessageService.MessageLogger_cfi')
+
+process.MessageLogger = cms.Service("MessageLogger",
+    destinations = cms.untracked.vstring('myLog'),
+    myLog = cms.untracked.PSet(
+        threshold = cms.untracked.string('INFO'),
+    )
+)
 
 process.source = cms.Source("EmptyIOVSource",
                             lastValue = cms.uint64(1),
@@ -13,6 +23,9 @@ process.source = cms.Source("EmptyIOVSource",
                             )
 
 process.ME0GeometryWriter = cms.EDAnalyzer("ME0RecoIdealDBLoader")
+
+#process.ME0GeometryWriter = cms.EDAnalyzer("ME0RecoIdealDBLoader",
+#                                           fromDD4Hep = cms.untracked.bool(False))
 
 process.CondDB.timetype = cms.untracked.string('runnumber')
 process.CondDB.connect = cms.string('sqlite_file:myfile.db')

--- a/CondTools/Geometry/test/writehelpers/geometryExtended2026_writer.py
+++ b/CondTools/Geometry/test/writehelpers/geometryExtended2026_writer.py
@@ -50,7 +50,7 @@ process.RPCGeometryWriter = cms.EDAnalyzer("RPCRecoIdealDBLoader",fromDD4Hep = c
 
 process.GEMGeometryWriter = cms.EDAnalyzer("GEMRecoIdealDBLoader")
 
-process.GEMGeometryWriter = cms.EDAnalyzer("ME0RecoIdealDBLoader")
+process.ME0GeometryWriter = cms.EDAnalyzer("ME0RecoIdealDBLoader")
 
 process.CondDB.timetype = cms.untracked.string('runnumber')
 process.CondDB.connect = cms.string('sqlite_file:myfile.db')
@@ -80,4 +80,4 @@ process.maxEvents = cms.untracked.PSet(
     input = cms.untracked.int32(1)
     )
 
-process.p1 = cms.Path(process.XMLGeometryWriter+process.TrackerGeometryWriter+process.TrackerParametersWriter+process.CaloGeometryWriter+process.HcalParametersWriter+process.CSCGeometryWriter+process.DTGeometryWriter+process.RPCGeometryWriter+process.GEMGeometryWriter)+process.ME0GeometryWriter)
+process.p1 = cms.Path(process.XMLGeometryWriter+process.TrackerGeometryWriter+process.TrackerParametersWriter+process.CaloGeometryWriter+process.HcalParametersWriter+process.CSCGeometryWriter+process.DTGeometryWriter+process.RPCGeometryWriter+process.GEMGeometryWriter+process.ME0GeometryWriter)

--- a/CondTools/Geometry/test/writehelpers/geometryExtended2026_writer.py
+++ b/CondTools/Geometry/test/writehelpers/geometryExtended2026_writer.py
@@ -3,14 +3,15 @@ import FWCore.ParameterSet.Config as cms
 process = cms.Process("GeometryWriter")
 
 process.load('CondCore.CondDB.CondDB_cfi')
-
-# This will read all the little XML files and from
-# that fill the DDCompactView. The modules that fill
-# the reco part of the database need the DDCompactView.
+#
+# FIXME: the command "./createExtended2026Payloads.sh 113YV12" (i.e 113YV12 is a tag just for test) creates a problem related to:  
+# 1) Tracker if Configuration.Geometry.GeometryExtended2026D49_cff is used (Scenario2026D49 has to be set in DD4hep_GeometrySimPhase2_cff)  
+# 2) GEM if Configuration.Geometry.GeometryExtended2026D77_cff is used (Scenario2026D77 has to be set inDD4hep_GeometrySimPhase2_cff)  
+#
 process.load('Configuration.Geometry.GeometryExtended2026D49_cff')
 process.load('Geometry.MuonNumbering.muonNumberingInitialization_cfi')
 process.load("Geometry.MuonNumbering.muonGeometryConstants_cff")
-process.load('Configuration.StandardSequences.DD4hep_GeometrySim_cff')
+process.load('Configuration.StandardSequences.DD4hep_GeometrySimPhase2_cff')
 process.load('Geometry.CaloEventSetup.CaloGeometry2026DBWriter_cfi')
 process.load('CondTools.Geometry.HcalParametersWriter_cff')
 
@@ -21,11 +22,6 @@ process.source = cms.Source("EmptyIOVSource",
                             interval = cms.uint64(1)
                             )
 
-# This reads the big XML file and the only way to fill the
-# nonreco part of the database is to read this file.  It
-# somewhat duplicates the information read from the little
-# XML files, but there is no way to directly build the
-# DDCompactView from this.
 process.XMLGeometryWriter = cms.EDAnalyzer("XMLGeometryBuilder",
                                            XMLFileName = cms.untracked.string("./geD49SingleBigFile.xml"),
                                            ZIP = cms.untracked.bool(True)

--- a/CondTools/Geometry/test/writehelpers/geometryExtended2026_writer.py
+++ b/CondTools/Geometry/test/writehelpers/geometryExtended2026_writer.py
@@ -7,8 +7,10 @@ process.load('CondCore.CondDB.CondDB_cfi')
 # This will read all the little XML files and from
 # that fill the DDCompactView. The modules that fill
 # the reco part of the database need the DDCompactView.
-process.load('Configuration.Geometry.GeometryExtended2026D41_cff')
+process.load('Configuration.Geometry.GeometryExtended2026D49_cff')
 process.load('Geometry.MuonNumbering.muonNumberingInitialization_cfi')
+process.load("Geometry.MuonNumbering.muonGeometryConstants_cff")
+process.load('Configuration.StandardSequences.DD4hep_GeometrySim_cff')
 process.load('Geometry.CaloEventSetup.CaloGeometry2026DBWriter_cfi')
 process.load('CondTools.Geometry.HcalParametersWriter_cff')
 
@@ -25,7 +27,7 @@ process.source = cms.Source("EmptyIOVSource",
 # XML files, but there is no way to directly build the
 # DDCompactView from this.
 process.XMLGeometryWriter = cms.EDAnalyzer("XMLGeometryBuilder",
-                                           XMLFileName = cms.untracked.string("./geD17SingleBigFile.xml"),
+                                           XMLFileName = cms.untracked.string("./geD49SingleBigFile.xml"),
                                            ZIP = cms.untracked.bool(True)
                                            )
 process.TrackerGeometricDetESModule = cms.ESProducer( "TrackerGeometricDetESModule",
@@ -40,13 +42,15 @@ process.CaloGeometryWriter = cms.EDAnalyzer("PCaloGeometryBuilder",
                                             EcalP = cms.untracked.bool(False),
                                             HGCal = cms.untracked.bool(False))
 
-process.CSCGeometryWriter = cms.EDAnalyzer("CSCRecoIdealDBLoader")
+process.CSCGeometryWriter = cms.EDAnalyzer("CSCRecoIdealDBLoader",fromDD4Hep = cms.untracked.bool(False))
 
-process.DTGeometryWriter = cms.EDAnalyzer("DTRecoIdealDBLoader")
+process.DTGeometryWriter = cms.EDAnalyzer("DTRecoIdealDBLoader",fromDD4Hep = cms.untracked.bool(False))
 
-process.RPCGeometryWriter = cms.EDAnalyzer("RPCRecoIdealDBLoader")
+process.RPCGeometryWriter = cms.EDAnalyzer("RPCRecoIdealDBLoader",fromDD4Hep = cms.untracked.bool(False))
 
 process.GEMGeometryWriter = cms.EDAnalyzer("GEMRecoIdealDBLoader")
+
+process.GEMGeometryWriter = cms.EDAnalyzer("ME0RecoIdealDBLoader")
 
 process.CondDB.timetype = cms.untracked.string('runnumber')
 process.CondDB.connect = cms.string('sqlite_file:myfile.db')
@@ -76,4 +80,4 @@ process.maxEvents = cms.untracked.PSet(
     input = cms.untracked.int32(1)
     )
 
-process.p1 = cms.Path(process.XMLGeometryWriter+process.TrackerGeometryWriter+process.TrackerParametersWriter+process.CaloGeometryWriter+process.HcalParametersWriter+process.CSCGeometryWriter+process.DTGeometryWriter+process.RPCGeometryWriter+process.GEMGeometryWriter)
+process.p1 = cms.Path(process.XMLGeometryWriter+process.TrackerGeometryWriter+process.TrackerParametersWriter+process.CaloGeometryWriter+process.HcalParametersWriter+process.CSCGeometryWriter+process.DTGeometryWriter+process.RPCGeometryWriter+process.GEMGeometryWriter)+process.ME0GeometryWriter)

--- a/CondTools/Geometry/test/writehelpers/geometryExtended2026_writer.py
+++ b/CondTools/Geometry/test/writehelpers/geometryExtended2026_writer.py
@@ -30,9 +30,6 @@ process.XMLGeometryWriter = cms.EDAnalyzer("XMLGeometryBuilder",
                                            XMLFileName = cms.untracked.string("./geD49SingleBigFile.xml"),
                                            ZIP = cms.untracked.bool(True)
                                            )
-process.TrackerGeometricDetESModule = cms.ESProducer( "TrackerGeometricDetESModule",
-                                                      fromDDD = cms.bool( True )
-                                                     )
 
 process.TrackerGeometryWriter = cms.EDAnalyzer("PGeometricDetBuilder",fromDD4hep=cms.bool(False))
 process.TrackerParametersWriter = cms.EDAnalyzer("PTrackerParametersDBBuilder",fromDD4hep=cms.bool(False))

--- a/CondTools/Geometry/test/writehelpers/geometryExtended2026_writer.py
+++ b/CondTools/Geometry/test/writehelpers/geometryExtended2026_writer.py
@@ -5,8 +5,9 @@ process = cms.Process("GeometryWriter")
 process.load('CondCore.CondDB.CondDB_cfi')
 #
 # FIXME: the command "./createExtended2026Payloads.sh 113YV12" (i.e 113YV12 is a tag just for test) creates a problem related to:  
-# 1) Tracker if Configuration.Geometry.GeometryExtended2026D49_cff is used (Scenario2026D49 has to be set in DD4hep_GeometrySimPhase2_cff)  
-# 2) GEM if Configuration.Geometry.GeometryExtended2026D77_cff is used (Scenario2026D77 has to be set inDD4hep_GeometrySimPhase2_cff)  
+# 1) Tracker, if Configuration.Geometry.GeometryExtended2026D49_cff is used (Scenario2026D49 has to be set in DD4hep_GeometrySimPhase2_cff)  
+# 2) GEM, if Configuration.Geometry.GeometryExtended2026D77_cff is used (Scenario2026D77 has to be set in DD4hep_GeometrySimPhase2_cff)  
+# Please add the right Scenario (D49 or D77 or ..) also in geometryExtended2026_xmlwriter.py and in splitExtended2026Database.sh 
 #
 process.load('Configuration.Geometry.GeometryExtended2026D49_cff')
 process.load('Geometry.MuonNumbering.muonNumberingInitialization_cfi')

--- a/CondTools/Geometry/test/writehelpers/geometryExtended2026_xmlwriter.py
+++ b/CondTools/Geometry/test/writehelpers/geometryExtended2026_xmlwriter.py
@@ -2,7 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("GeometryXMLWriter")
 
-process.load('Configuration.Geometry.GeometryExtended2026D41_cff')
+process.load('Configuration.Geometry.GeometryExtended2026D49_cff')
 
 process.source = cms.Source("EmptyIOVSource",
                             lastValue = cms.uint64(1),
@@ -13,7 +13,7 @@ process.source = cms.Source("EmptyIOVSource",
 
 process.BigXMLWriter = cms.EDAnalyzer("OutputDDToDDL",
                               rotNumSeed = cms.int32(0),
-                              fileName = cms.untracked.string("./geD41SingleBigFile.xml")
+                              fileName = cms.untracked.string("./geD49SingleBigFile.xml")
                               )
 
 

--- a/CondTools/Geometry/test/writehelpers/splitExtended2026Database.sh
+++ b/CondTools/Geometry/test/writehelpers/splitExtended2026Database.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-conddb_import -f sqlite_file:myfile.db -c sqlite_file:GeometryFileExtended2026D41.db -t XMLFILE_Geometry_TagXX_Extended2026D41_mc -i XMLFILE_Geometry_TagXX_Extended2026D41_mc
+conddb_import -f sqlite_file:myfile.db -c sqlite_file:GeometryFileExtended2026D49.db -t XMLFILE_Geometry_TagXX_Extended2026D49_mc -i XMLFILE_Geometry_TagXX_Extended2026D49_mc
 conddb_import -f sqlite_file:myfile.db -c sqlite_file:TKRECO_Geometry.db -t TKRECO_Geometry_TagXX -i TKRECO_Geometry_TagXX
 conddb_import -f sqlite_file:myfile.db -c sqlite_file:TKParameters_Geometry.db -t TKParameters_Geometry_TagXX -i TKParameters_Geometry_TagXX
 conddb_import -f sqlite_file:myfile.db -c sqlite_file:EBRECO_Geometry.db -t EBRECO_Geometry_TagXX -i EBRECO_Geometry_TagXX

--- a/CondTools/Geometry/test/writehelpers/splitExtended2026Database.sh
+++ b/CondTools/Geometry/test/writehelpers/splitExtended2026Database.sh
@@ -1,19 +1,19 @@
 #!/bin/sh
 
-conddb_import -f sqlite_file:myfile.db -c sqlite_file:GeometryFileExtended2026D49.db -t XMLFILE_Geometry_TagXX_Extended2026D49_mc -i XMLFILE_Geometry_TagXX_Extended2026D49_mc
-conddb_import -f sqlite_file:myfile.db -c sqlite_file:TKRECO_Geometry.db -t TKRECO_Geometry_TagXX -i TKRECO_Geometry_TagXX
-conddb_import -f sqlite_file:myfile.db -c sqlite_file:TKParameters_Geometry.db -t TKParameters_Geometry_TagXX -i TKParameters_Geometry_TagXX
-conddb_import -f sqlite_file:myfile.db -c sqlite_file:EBRECO_Geometry.db -t EBRECO_Geometry_TagXX -i EBRECO_Geometry_TagXX
-conddb_import -f sqlite_file:myfile.db -c sqlite_file:HCALRECO_Geometry.db -t HCALRECO_Geometry_TagXX -i HCALRECO_Geometry_TagXX
-conddb_import -f sqlite_file:myfile.db -c sqlite_file:HCALParameters_Geometry.db -t HCALParameters_Geometry_TagXX -i HCALParameters_Geometry_TagXX
-conddb_import -f sqlite_file:myfile.db -c sqlite_file:HGCALRECO_Geometry.db -t HGCALRECO_Geometry_TagXX -i HGCALRECO_Geometry_TagXX
-conddb_import -f sqlite_file:myfile.db -c sqlite_file:HGCALParameters_Geometry.db -t HGCALParameters_Geometry_TagXX -i HGCALParameters_Geometry_TagXX
-conddb_import -f sqlite_file:myfile.db -c sqlite_file:CTRECO_Geometry.db -t CTRECO_Geometry_TagXX -i CTRECO_Geometry_TagXX
-conddb_import -f sqlite_file:myfile.db -c sqlite_file:ZDCRECO_Geometry.db -t ZDCRECO_Geometry_TagXX -i ZDCRECO_Geometry_TagXX
-conddb_import -f sqlite_file:myfile.db -c sqlite_file:CASTORRECO_Geometry.db -t CASTORRECO_Geometry_TagXX -i CASTORRECO_Geometry_TagXX
-conddb_import -f sqlite_file:myfile.db -c sqlite_file:CSCRECO_Geometry.db -t CSCRECO_Geometry_TagXX -i CSCRECO_Geometry_TagXX
-conddb_import -f sqlite_file:myfile.db -c sqlite_file:CSCRECODIGI_Geometry.db -t CSCRECODIGI_Geometry_TagXX -i CSCRECODIGI_Geometry_TagXX
-conddb_import -f sqlite_file:myfile.db -c sqlite_file:DTRECO_Geometry.db -t DTRECO_Geometry_TagXX -i DTRECO_Geometry_TagXX
-conddb_import -f sqlite_file:myfile.db -c sqlite_file:RPCRECO_Geometry.db -t RPCRECO_Geometry_TagXX -i RPCRECO_Geometry_TagXX
-conddb_import -f sqlite_file:myfile.db -c sqlite_file:GEMRECO_Geometry.db -t GEMRECO_Geometry_TagXX -i GEMRECO_Geometry_TagXX
-conddb_import -f sqlite_file:myfile.db -c sqlite_file:ME0RECO_Geometry.db -t ME0RECO_Geometry_TagXX -i ME0RECO_Geometry_TagXX
+conddb -f sqlite_file:myfile.db -c sqlite_file:GeometryFileExtended2026D49.db -t XMLFILE_Geometry_TagXX_Extended2026D49_mc -i XMLFILE_Geometry_TagXX_Extended2026D49_mc
+conddb -f sqlite_file:myfile.db -c sqlite_file:TKRECO_Geometry.db -t TKRECO_Geometry_TagXX -i TKRECO_Geometry_TagXX
+conddb -f sqlite_file:myfile.db -c sqlite_file:TKParameters_Geometry.db -t TKParameters_Geometry_TagXX -i TKParameters_Geometry_TagXX
+conddb -f sqlite_file:myfile.db -c sqlite_file:EBRECO_Geometry.db -t EBRECO_Geometry_TagXX -i EBRECO_Geometry_TagXX
+conddb -f sqlite_file:myfile.db -c sqlite_file:HCALRECO_Geometry.db -t HCALRECO_Geometry_TagXX -i HCALRECO_Geometry_TagXX
+conddb -f sqlite_file:myfile.db -c sqlite_file:HCALParameters_Geometry.db -t HCALParameters_Geometry_TagXX -i HCALParameters_Geometry_TagXX
+conddb -f sqlite_file:myfile.db -c sqlite_file:HGCALRECO_Geometry.db -t HGCALRECO_Geometry_TagXX -i HGCALRECO_Geometry_TagXX
+conddb -f sqlite_file:myfile.db -c sqlite_file:HGCALParameters_Geometry.db -t HGCALParameters_Geometry_TagXX -i HGCALParameters_Geometry_TagXX
+conddb -f sqlite_file:myfile.db -c sqlite_file:CTRECO_Geometry.db -t CTRECO_Geometry_TagXX -i CTRECO_Geometry_TagXX
+conddb -f sqlite_file:myfile.db -c sqlite_file:ZDCRECO_Geometry.db -t ZDCRECO_Geometry_TagXX -i ZDCRECO_Geometry_TagXX
+conddb -f sqlite_file:myfile.db -c sqlite_file:CASTORRECO_Geometry.db -t CASTORRECO_Geometry_TagXX -i CASTORRECO_Geometry_TagXX
+conddb -f sqlite_file:myfile.db -c sqlite_file:CSCRECO_Geometry.db -t CSCRECO_Geometry_TagXX -i CSCRECO_Geometry_TagXX
+conddb -f sqlite_file:myfile.db -c sqlite_file:CSCRECODIGI_Geometry.db -t CSCRECODIGI_Geometry_TagXX -i CSCRECODIGI_Geometry_TagXX
+conddb -f sqlite_file:myfile.db -c sqlite_file:DTRECO_Geometry.db -t DTRECO_Geometry_TagXX -i DTRECO_Geometry_TagXX
+conddb -f sqlite_file:myfile.db -c sqlite_file:RPCRECO_Geometry.db -t RPCRECO_Geometry_TagXX -i RPCRECO_Geometry_TagXX
+conddb -f sqlite_file:myfile.db -c sqlite_file:GEMRECO_Geometry.db -t GEMRECO_Geometry_TagXX -i GEMRECO_Geometry_TagXX
+conddb -f sqlite_file:myfile.db -c sqlite_file:ME0RECO_Geometry.db -t ME0RECO_Geometry_TagXX -i ME0RECO_Geometry_TagXX

--- a/Geometry/GEMGeometryBuilder/plugins/ME0GeometryESModule.cc
+++ b/Geometry/GEMGeometryBuilder/plugins/ME0GeometryESModule.cc
@@ -76,18 +76,21 @@ std::unique_ptr<ME0Geometry> ME0GeometryESModule::produce(const MuonGeometryReco
   edm::LogVerbatim("GEMGeometry") << "ME0GeometryESModule::produce with fromDDD = " << fromDDD_ << " fromDD4hep "
                                   << fromDD4hep_;
   if (fromDDD_) {
+    edm::LogVerbatim("ME0GeometryESModule") << "(0) ME0GeometryESModule - DDD ";
     edm::LogVerbatim("GEMGeometry") << "ME0GeometryESModule::produce :: ME0GeometryBuilder builder";
     auto cpv = record.getTransientHandle(cpvToken_);
     const auto& mdc = record.get(mdcToken_);
     ME0GeometryBuilder builder;
     return std::unique_ptr<ME0Geometry>(builder.build(cpv.product(), mdc));
   } else if (fromDD4hep_) {
+    edm::LogVerbatim("ME0GeometryESModule") << "(0) ME0GeometryESModule - DD4HEP ";
     edm::LogVerbatim("GEMGeometry") << "ME0GeometryESModule::produce :: ME0GeometryBuilder builder DD4hep";
     auto cpv = record.getTransientHandle(dd4hepcpvToken_);
     const auto& mdc = record.get(mdcToken_);
     ME0GeometryBuilder builder;
     return std::unique_ptr<ME0Geometry>(builder.build(cpv.product(), mdc));
   } else {
+    edm::LogVerbatim("ME0GeometryESModule") << "(0) ME0GeometryESModule - DB ";
     edm::LogVerbatim("GEMGeometry") << "ME0GeometryESModule::produce :: ME0GeometryBuilderFromCondDB builder";
     const auto& rigme0 = record.get(rigme0Token_);
     ME0GeometryBuilderFromCondDB builder;

--- a/Geometry/GEMGeometryBuilder/src/ME0GeometryParsFromDD.cc
+++ b/Geometry/GEMGeometryBuilder/src/ME0GeometryParsFromDD.cc
@@ -24,6 +24,8 @@
 #include <iostream>
 #include <algorithm>
 
+// DD
+
 void ME0GeometryParsFromDD::build(const DDCompactView* cview,
                                   const MuonGeometryConstants& muonConstants,
                                   RecoIdealGeometry& rgeo) {
@@ -47,7 +49,7 @@ void ME0GeometryParsFromDD::buildGeometry(DDFilteredView& fv,
   edm::LogVerbatim("ME0GeometryParsFromDD") << "(0) ME0GeometryParsFromDD - DDD ";
   MuonGeometryNumbering muonDDDNumbering(muonConstants);
   ME0NumberingScheme me0Numbering(muonConstants);
- 
+
   bool doChambers = fv.firstChild();
   LogDebug("ME0GeometryParsFromDD") << "doChamber = " << doChambers;
   // loop over superchambers
@@ -99,8 +101,8 @@ void ME0GeometryParsFromDD::buildChamber(DDFilteredView& fv, ME0DetId detId, Rec
   std::vector<double> vtra = getTranslation(fv);
   std::vector<double> vrot = getRotation(fv);
   edm::LogVerbatim("ME0GeometryParsFromDD")
-    << "(4) DDD, Chamber DetID " << detId.chamberId().rawId() << " Name " << fv.logicalPart().name().name();
-     
+      << "(4) DDD, Chamber DetID " << detId.chamberId().rawId() << " Name " << fv.logicalPart().name().name();
+
   rgeo.insert(detId.chamberId().rawId(), vtra, vrot, pars, {fv.logicalPart().name().name()});
 }
 
@@ -112,7 +114,7 @@ void ME0GeometryParsFromDD::buildLayer(DDFilteredView& fv, ME0DetId detId, RecoI
   std::vector<double> vrot = getRotation(fv);
 
   edm::LogVerbatim("ME0GeometryParsFromDD")
-    << "(5) DDD, Layer DetID " << detId.layerId().rawId() << " Name " << fv.logicalPart().name().name();
+      << "(5) DDD, Layer DetID " << detId.layerId().rawId() << " Name " << fv.logicalPart().name().name();
   rgeo.insert(detId.layerId().rawId(), vtra, vrot, pars, {fv.logicalPart().name().name()});
 }
 
@@ -143,8 +145,9 @@ void ME0GeometryParsFromDD::buildEtaPartition(DDFilteredView& fv, ME0DetId detId
   std::vector<double> vrot = getRotation(fv);
 
   edm::LogVerbatim("ME0GeometryParsFromDD")
-    << "(6) DDD, Eta Partion DetID " << detId.rawId() << " Name " << fv.logicalPart().name().name() <<  " nStrips " << nStrips << " nPads " << nPads;
-     
+      << "(6) DDD, Eta Partion DetID " << detId.rawId() << " Name " << fv.logicalPart().name().name() << " nStrips "
+      << nStrips << " nPads " << nPads;
+
   rgeo.insert(detId.rawId(), vtra, vrot, pars, {fv.logicalPart().name().name()});
 }
 
@@ -157,7 +160,7 @@ std::vector<double> ME0GeometryParsFromDD::getDimension(DDFilteredView& fv) {
   LogDebug("ME0GeometryParsFromDD") << "dimension dx1 " << dpar[4] << ", dx2 " << dpar[8] << ", dy " << dpar[0]
                                     << ", dz " << dpar[3];
   edm::LogVerbatim("ME0GeometryParsFromDD")
-      << "(1) DDD, dimension dx1 " << dpar[4] << ", dx2 " << dpar[8] << ", dy " << dpar[0]<< ", dz " << dpar[3];
+      << "(1) DDD, dimension dx1 " << dpar[4] << ", dx2 " << dpar[8] << ", dy " << dpar[0] << ", dz " << dpar[3];
   return {dpar[4], dpar[8], dpar[0], dpar[3]};
 }
 
@@ -172,8 +175,120 @@ std::vector<double> ME0GeometryParsFromDD::getRotation(DDFilteredView& fv) {
   const DDRotationMatrix& rota = fv.rotation();  //.Inverse();
   DD3Vector x, y, z;
   rota.GetComponents(x, y, z);
- edm::LogVerbatim("ME0GeometryParsFromDD")
-   << "(3) DDD, rot matrix " << x.X() << "  " << x.Y() << "  " << x.Z() << " " << y.X() << "  " << y.Y() << "  "
+  edm::LogVerbatim("ME0GeometryParsFromDD")
+      << "(3) DDD, rot matrix " << x.X() << "  " << x.Y() << "  " << x.Z() << " " << y.X() << "  " << y.Y() << "  "
       << y.Z() << " " << z.X() << "  " << z.Y() << "  " << z.Z();
   return {x.X(), x.Y(), x.Z(), y.X(), y.Y(), y.Z(), z.X(), z.Y(), z.Z()};
+}
+
+// DD4HEP
+
+void ME0GeometryParsFromDD::build(const cms::DDCompactView* cview,
+                                  const MuonGeometryConstants& muonConstants,
+                                  RecoIdealGeometry& rgeo) {
+  std::string attribute = "MuStructure";
+  std::string value = "MuonEndCapME0";
+  const cms::DDFilter filter(attribute, value);
+  cms::DDFilteredView fview(*cview, filter);
+  this->buildGeometry(fview, muonConstants, rgeo);
+}
+
+void ME0GeometryParsFromDD::buildGeometry(cms::DDFilteredView& fv,
+                                          const MuonGeometryConstants& muonConstants,
+                                          RecoIdealGeometry& rgeo) {
+  edm::LogVerbatim("ME0GeometryParsFromDD") << "(0) ME0GeometryParsFromDD - DD4HEP ";
+
+  MuonGeometryNumbering mdddnum(muonConstants);
+  ME0NumberingScheme me0Num(muonConstants);
+
+  static constexpr uint32_t levelChamber = 7;
+  static constexpr uint32_t levelLayer = 8;
+  uint32_t theLevelPart = muonConstants.getValue("level");
+  uint32_t theSectorLevel = muonConstants.getValue("m0_sector") / theLevelPart;
+
+  while (fv.firstChild()) {
+    const auto& history = fv.history();
+    MuonBaseNumber num(mdddnum.geoHistoryToBaseNumber(history));
+    ME0DetId detId(me0Num.baseNumberToUnitNumber(num));
+
+    if (fv.level() == levelChamber) {
+      buildChamber(fv, detId, rgeo);
+    } else if (fv.level() == levelLayer) {
+      buildLayer(fv, detId, rgeo);
+    } else if (history.tags.size() > theSectorLevel) {
+      buildEtaPartition(fv, detId, rgeo);
+    }
+  }  // end while
+}  // end buildGeometry
+
+void ME0GeometryParsFromDD::buildChamber(cms::DDFilteredView& fv, ME0DetId detId, RecoIdealGeometry& rgeo) {
+  std::string_view name = fv.name();
+  std::vector<double> pars = getDimension(fv);
+  std::vector<double> vtra = getTranslation(fv);
+  std::vector<double> vrot = getRotation(fv);
+
+  edm::LogVerbatim("ME0GeometryParsFromDD")
+      << "(4) DD4HEP, Chamber DetID " << detId.chamberId().rawId() << " Name " << std::string(name);
+
+  rgeo.insert(detId.chamberId().rawId(), vtra, vrot, pars, {std::string(name)});
+}
+
+void ME0GeometryParsFromDD::buildLayer(cms::DDFilteredView& fv, ME0DetId detId, RecoIdealGeometry& rgeo) {
+  std::string_view name = fv.name();
+  std::vector<double> pars = getDimension(fv);
+  std::vector<double> vtra = getTranslation(fv);
+  std::vector<double> vrot = getRotation(fv);
+
+  edm::LogVerbatim("ME0GeometryParsFromDD")
+      << "(5) DD4HEP, Layer DetID " << detId.layerId().rawId() << " Name " << std::string(name);
+  rgeo.insert(detId.layerId().rawId(), vtra, vrot, pars, {std::string(name)});
+}
+
+void ME0GeometryParsFromDD::buildEtaPartition(cms::DDFilteredView& fv, ME0DetId detId, RecoIdealGeometry& rgeo) {
+  auto nStrips = fv.get<double>("nStrips");
+  auto nPads = fv.get<double>("nPads");
+  std::string_view name = fv.name();
+  std::vector<double> pars = getDimension(fv);
+  pars.emplace_back(nStrips);
+  pars.emplace_back(nPads);
+  std::vector<double> vtra = getTranslation(fv);
+  std::vector<double> vrot = getRotation(fv);
+
+  edm::LogVerbatim("ME0GeometryParsFromDD") << "(6) DD4HEP, Eta Partion DetID " << detId.rawId() << " Name "
+                                            << std::string(name) << " nStrips " << nStrips << " nPads " << nPads;
+
+  rgeo.insert(detId.rawId(), vtra, vrot, pars, {std::string(name)});
+}
+
+std::vector<double> ME0GeometryParsFromDD::getDimension(cms::DDFilteredView& fv) {
+  std::vector<double> dpar = fv.parameters();
+
+  edm::LogVerbatim("ME0GeometryParsFromDD")
+      << "(1) DD4HEP, dimension dx1 " << dpar[0] / dd4hep::mm << ", dx2 " << dpar[1] / dd4hep::mm << ", dy "
+      << dpar[3] / dd4hep::mm << ", dz " << dpar[2] / dd4hep::mm;
+
+  return {dpar[0] / dd4hep::mm, dpar[1] / dd4hep::mm, dpar[3] / dd4hep::mm, dpar[2] / dd4hep::mm};
+}
+
+std::vector<double> ME0GeometryParsFromDD::getTranslation(cms::DDFilteredView& fv) {
+  std::vector<double> tran(3);
+  tran[0] = static_cast<double>(fv.translation().X()) / dd4hep::mm;
+  tran[1] = static_cast<double>(fv.translation().Y()) / dd4hep::mm;
+  tran[2] = static_cast<double>(fv.translation().Z()) / dd4hep::mm;
+
+  edm::LogVerbatim("ME0GeometryParsFromDD")
+      << "(2) DD4HEP, tran vector " << tran[0] << "  " << tran[1] << "  " << tran[2];
+  return {tran[0], tran[1], tran[2]};
+}
+
+std::vector<double> ME0GeometryParsFromDD::getRotation(cms::DDFilteredView& fv) {
+  DDRotationMatrix rota;
+  fv.rot(rota);
+  DD3Vector x, y, z;
+  rota.GetComponents(x, y, z);
+  const std::vector<double> rot = {x.X(), x.Y(), x.Z(), y.X(), y.Y(), y.Z(), z.X(), z.Y(), z.Z()};
+  edm::LogVerbatim("ME0GeometryParsFromDD")
+      << "(3) DD4HEP, rot matrix " << rot[0] << "  " << rot[1] << "  " << rot[2] << " " << rot[3] << "  " << rot[4]
+      << "  " << rot[5] << " " << rot[6] << "  " << rot[7] << "  " << rot[8];
+  return {rot[0], rot[1], rot[2], rot[3], rot[4], rot[5], rot[6], rot[7], rot[8]};
 }

--- a/Geometry/GEMGeometryBuilder/src/ME0GeometryParsFromDD.cc
+++ b/Geometry/GEMGeometryBuilder/src/ME0GeometryParsFromDD.cc
@@ -1,3 +1,11 @@
+/* Implementation of the  ME0GeometryParsFromDD Class
+ *  Build the ME0Geometry from the DDD and DD4Hep description
+ *  
+ *  DD4hep part added to the original old file (DD version) made by M. Maggi (INFN Bari)
+ *  Author:  Sergio Lo Meo (sergio.lo.meo@cern.ch) 
+ *  Created:  Thu, 25 Feb 2021 
+ *
+ */
 #include "Geometry/GEMGeometryBuilder/src/ME0GeometryParsFromDD.h"
 #include "DataFormats/MuonDetId/interface/ME0DetId.h"
 #include "CondFormats/GeometryObjects/interface/RecoIdealGeometry.h"
@@ -7,7 +15,14 @@
 #include "Geometry/MuonNumbering/interface/MuonGeometryNumbering.h"
 #include "Geometry/MuonNumbering/interface/MuonBaseNumber.h"
 #include "Geometry/MuonNumbering/interface/ME0NumberingScheme.h"
+#include "Geometry/MuonNumbering/interface/MuonGeometryConstants.h"
 #include "DataFormats/GeometryVector/interface/Basic3DVector.h"
+#include "DetectorDescription/DDCMS/interface/DDFilteredView.h"
+#include "DetectorDescription/DDCMS/interface/DDCompactView.h"
+#include "DetectorDescription/DDCMS/interface/DDSpecParRegistry.h"
+
+#include <iostream>
+#include <algorithm>
 
 void ME0GeometryParsFromDD::build(const DDCompactView* cview,
                                   const MuonGeometryConstants& muonConstants,
@@ -29,9 +44,10 @@ void ME0GeometryParsFromDD::buildGeometry(DDFilteredView& fv,
   LogDebug("ME0GeometryParsFromDD") << "About to run through the ME0 structure\n"
                                     << " First logical part " << fv.logicalPart().name().name();
 
+  edm::LogVerbatim("ME0GeometryParsFromDD") << "(0) ME0GeometryParsFromDD - DDD ";
   MuonGeometryNumbering muonDDDNumbering(muonConstants);
   ME0NumberingScheme me0Numbering(muonConstants);
-
+ 
   bool doChambers = fv.firstChild();
   LogDebug("ME0GeometryParsFromDD") << "doChamber = " << doChambers;
   // loop over superchambers
@@ -82,7 +98,9 @@ void ME0GeometryParsFromDD::buildChamber(DDFilteredView& fv, ME0DetId detId, Rec
   std::vector<double> pars = getDimension(fv);
   std::vector<double> vtra = getTranslation(fv);
   std::vector<double> vrot = getRotation(fv);
-
+  edm::LogVerbatim("ME0GeometryParsFromDD")
+    << "(4) DDD, Chamber DetID " << detId.chamberId().rawId() << " Name " << fv.logicalPart().name().name();
+     
   rgeo.insert(detId.chamberId().rawId(), vtra, vrot, pars, {fv.logicalPart().name().name()});
 }
 
@@ -93,6 +111,8 @@ void ME0GeometryParsFromDD::buildLayer(DDFilteredView& fv, ME0DetId detId, RecoI
   std::vector<double> vtra = getTranslation(fv);
   std::vector<double> vrot = getRotation(fv);
 
+  edm::LogVerbatim("ME0GeometryParsFromDD")
+    << "(5) DDD, Layer DetID " << detId.layerId().rawId() << " Name " << fv.logicalPart().name().name();
   rgeo.insert(detId.layerId().rawId(), vtra, vrot, pars, {fv.logicalPart().name().name()});
 }
 
@@ -122,6 +142,9 @@ void ME0GeometryParsFromDD::buildEtaPartition(DDFilteredView& fv, ME0DetId detId
   std::vector<double> vtra = getTranslation(fv);
   std::vector<double> vrot = getRotation(fv);
 
+  edm::LogVerbatim("ME0GeometryParsFromDD")
+    << "(6) DDD, Eta Partion DetID " << detId.rawId() << " Name " << fv.logicalPart().name().name() <<  " nStrips " << nStrips << " nPads " << nPads;
+     
   rgeo.insert(detId.rawId(), vtra, vrot, pars, {fv.logicalPart().name().name()});
 }
 
@@ -133,11 +156,15 @@ std::vector<double> ME0GeometryParsFromDD::getDimension(DDFilteredView& fv) {
   //dpar[0] length is along local Y
   LogDebug("ME0GeometryParsFromDD") << "dimension dx1 " << dpar[4] << ", dx2 " << dpar[8] << ", dy " << dpar[0]
                                     << ", dz " << dpar[3];
+  edm::LogVerbatim("ME0GeometryParsFromDD")
+      << "(1) DDD, dimension dx1 " << dpar[4] << ", dx2 " << dpar[8] << ", dy " << dpar[0]<< ", dz " << dpar[3];
   return {dpar[4], dpar[8], dpar[0], dpar[3]};
 }
 
 std::vector<double> ME0GeometryParsFromDD::getTranslation(DDFilteredView& fv) {
   const DDTranslation& tran = fv.translation();
+  edm::LogVerbatim("ME0GeometryParsFromDD")
+      << "(2) DDD, tran vector " << tran.x() << "  " << tran.y() << "  " << tran.z();
   return {tran.x(), tran.y(), tran.z()};
 }
 
@@ -145,5 +172,8 @@ std::vector<double> ME0GeometryParsFromDD::getRotation(DDFilteredView& fv) {
   const DDRotationMatrix& rota = fv.rotation();  //.Inverse();
   DD3Vector x, y, z;
   rota.GetComponents(x, y, z);
+ edm::LogVerbatim("ME0GeometryParsFromDD")
+   << "(3) DDD, rot matrix " << x.X() << "  " << x.Y() << "  " << x.Z() << " " << y.X() << "  " << y.Y() << "  "
+      << y.Z() << " " << z.X() << "  " << z.Y() << "  " << z.Z();
   return {x.X(), x.Y(), x.Z(), y.X(), y.Y(), y.Z(), z.X(), z.Y(), z.Z()};
 }

--- a/Geometry/GEMGeometryBuilder/src/ME0GeometryParsFromDD.h
+++ b/Geometry/GEMGeometryBuilder/src/ME0GeometryParsFromDD.h
@@ -43,7 +43,7 @@ private:
   std::vector<double> getDimension(DDFilteredView& fv);
   std::vector<double> getTranslation(DDFilteredView& fv);
   std::vector<double> getRotation(DDFilteredView& fv);
-  
+
   //DD4HEP
 
   void buildGeometry(cms::DDFilteredView&, const MuonGeometryConstants&, RecoIdealGeometry&);

--- a/Geometry/GEMGeometryBuilder/src/ME0GeometryParsFromDD.h
+++ b/Geometry/GEMGeometryBuilder/src/ME0GeometryParsFromDD.h
@@ -1,10 +1,23 @@
 #ifndef Geometry_GEMGeometry_ME0GeometryParsFromDD_H
 #define Geometry_GEMGeometry_ME0GeometryParsFromDD_H
 
+/* Implementation of the  ME0GeometryParsFromDD Class
+ *  Build the ME0Geometry from the DDD and DD4Hep description
+ *  
+ *  DD4hep part added to the original old file (DD version) made by M. Maggi (INFN Bari)
+ *  Author:  Sergio Lo Meo (sergio.lo.meo@cern.ch) 
+ *  Created:  Thu, 25 Feb 2021 
+ *
+ */
+
 #include <vector>
 
 class DDCompactView;
 class DDFilteredView;
+namespace cms {  // DD4Hep
+  class DDFilteredView;
+  class DDCompactView;
+}  // namespace cms
 class MuonGeometryConstants;
 class RecoIdealGeometry;
 class ME0DetId;
@@ -14,10 +27,13 @@ public:
   ME0GeometryParsFromDD(void) {}
 
   ~ME0GeometryParsFromDD(void) {}
-
+  // DD
   void build(const DDCompactView*, const MuonGeometryConstants&, RecoIdealGeometry&);
+  // DD4HEP
+  void build(const cms::DDCompactView*, const MuonGeometryConstants&, RecoIdealGeometry&);
 
 private:
+  // DD
   void buildGeometry(DDFilteredView&, const MuonGeometryConstants&, RecoIdealGeometry&);
 
   void buildChamber(DDFilteredView& fv, ME0DetId detId, RecoIdealGeometry& rgeo);
@@ -27,5 +43,17 @@ private:
   std::vector<double> getDimension(DDFilteredView& fv);
   std::vector<double> getTranslation(DDFilteredView& fv);
   std::vector<double> getRotation(DDFilteredView& fv);
+  
+  //DD4HEP
+
+  void buildGeometry(cms::DDFilteredView&, const MuonGeometryConstants&, RecoIdealGeometry&);
+
+  void buildChamber(cms::DDFilteredView& fv, ME0DetId detId, RecoIdealGeometry& rgeo);
+  void buildLayer(cms::DDFilteredView& fv, ME0DetId detId, RecoIdealGeometry& rgeo);
+  void buildEtaPartition(cms::DDFilteredView& fv, ME0DetId detId, RecoIdealGeometry& rgeo);
+
+  std::vector<double> getDimension(cms::DDFilteredView& fv);
+  std::vector<double> getTranslation(cms::DDFilteredView& fv);
+  std::vector<double> getRotation(cms::DDFilteredView& fv);
 };
 #endif


### PR DESCRIPTION
**PR description:**

This PR (only for ME0) followed what I did for GEM in the PR #32982  . 

**PR validation:**

1) Validation by using "cmsRun CondTools/Geometry/test/me0geometrywriter.py" (with DDD and DD4hep):
by checking printouts for both DD & DD4Hep build methods within the ME0GeometryParsFromDD Class in order to compare some DetId parameters (see below):

//DDD

(0) ME0GeometryParsFromDD - DDD 
(1) DDD, dimension dx1 109.951, dx2 263.652, dy 435.84, dz 147.5
(2) DDD, tran vector 1059.4  -2.37076e-12  5393.5
(3) DDD, rot matrix 2.44929e-16  -1  2.44929e-16 4.89859e-16  3.67394e-16  -1 1  -3.67394e-16  -1.22465e-16
(4) DDD, Chamber DetID 704643078 Name ME0Box
(1) DDD, dimension dx1 109.951, dx2 263.652, dy 435.84, dz 2.9875
(2) DDD, tran vector 1059.4  -2.32539e-12  5270
(3) DDD, rot matrix 2.44929e-16  -1  2.44929e-16 4.89859e-16  3.67394e-16  -1 1  -3.67394e-16  -1.22465e-16
(5) DDD, Layer DetID 704643334 Name ME0L
(1) DDD, dimension dx1 237.625, dx2 263.652, dy 73.803, dz 2.9875
(2) DDD, tran vector 1421.44  -2.4584e-12  5270
(3) DDD, rot matrix 2.44929e-16  -1  2.44929e-16 4.89859e-16  3.67394e-16  -1 1  -3.67394e-16  -1.22465e-16
(6) DDD, Eta Partion DetID 704651526 Name GHA001 nStrips 384 nPads 192

and so on...

//DD4Hep 

(0) ME0GeometryParsFromDD - DD4HEP 
(1) DD4HEP, dimension dx1 109.951, dx2 263.652, dy 435.84, dz 147.5
(2) DD4HEP, tran vector 1059.4  0  5393.5
(3) DD4HEP, rot matrix -6.12323e-17  -1  -6.12323e-17 0  -1.22465e-16  -1 1  1.22465e-16  1.83697e-16
(4) DD4HEP, Chamber DetID 704643078 Name ME0Box
(1) DD4HEP, dimension dx1 109.951, dx2 263.652, dy 435.84, dz 2.9875
(2) DD4HEP, tran vector 1059.4  -1.51244e-14  5270
(3) DD4HEP, rot matrix -6.12323e-17  -1  -6.12323e-17 0  -1.22465e-16  -1 1  1.22465e-16  1.83697e-16
(5) DD4HEP, Layer DetID 704643334 Name ME0L
(1) DD4HEP, dimension dx1 237.625, dx2 263.652, dy 73.803, dz 2.9875
(2) DD4HEP, tran vector 1421.44  2.92124e-14  5270
(3) DD4HEP, rot matrix -6.12323e-17  -1  -6.12323e-17 0  -1.22465e-16  -1 1  1.22465e-16  1.83697e-16
(6) DD4HEP, Eta Partion DetID 704651526 Name GHA001 nStrips 384 nPads 192

and so on..

The DD part of the code has not been touched by this PR (except for the printouts). Added "/ dd4hep::mm;", where it was necessary, in the DD4Hep part of the code.

2) Validation by using a dump script, as I did for the PRs (#32992  #32982  #32781 ), that reads  a local .mb file produced by Payload scripts has been not performed because some problems are present. Please read the FIXME comment in CondTools/Geometry/test/writehelpers/geometryExtended2026_writer.py

This second validation step will be perfomed when all the problems with Payloads will be fixed.

**if this PR is a backport please specify the original PR and why you need to backport that PR:**

nothing special

