### PR TITLE
backport: FastSim number of photoelectrons in HF simulation #33051

### DIFF
--- a/FastSimulation/Calorimetry/python/Calorimetry_cff.py
+++ b/FastSimulation/Calorimetry/python/Calorimetry_cff.py
@@ -262,7 +262,7 @@ FamosCalorimetryBlock = cms.PSet(
             timeShiftHF = cms.vdouble(50.7, 52.5, 52.9, 53.9, 54.5, 55.1, 55.1, 55.7, 55.9, 56.1, 56.1, 56.1, 56.5),
             ),
         HFShower           = cms.PSet(
-            ProbMax          = cms.double(0.5),
+            ProbMax          = cms.double(1.0),
             CFibre           = cms.double(0.5),
             OnlyLong          = cms.bool(True)
             ),
@@ -300,3 +300,5 @@ FamosCalorimetryBlock.Calorimetry.HCAL.Digitizer = True
 
 from Configuration.Eras.Modifier_run2_common_cff import run2_common
 run2_common.toModify(FamosCalorimetryBlock.Calorimetry.HFShowerLibrary, FileName = 'SimG4CMS/Calo/data/HFShowerLibrary_npmt_noatt_eta4_16en_v4.root' )
+
+run2_common.toModify(FamosCalorimetryBlock.Calorimetry.HFShower, ProbMax = 0.5 )

--- a/FastSimulation/Calorimetry/python/Calorimetry_cff.py
+++ b/FastSimulation/Calorimetry/python/Calorimetry_cff.py
@@ -262,7 +262,7 @@ FamosCalorimetryBlock = cms.PSet(
             timeShiftHF = cms.vdouble(50.7, 52.5, 52.9, 53.9, 54.5, 55.1, 55.1, 55.7, 55.9, 56.1, 56.1, 56.1, 56.5),
             ),
         HFShower           = cms.PSet(
-            ProbMax          = cms.double(1.0),
+            ProbMax          = cms.double(0.5),
             CFibre           = cms.double(0.5),
             OnlyLong          = cms.bool(True)
             ),


### PR DESCRIPTION
This is a backport of the update to the FastSim HF configuration 
https://github.com/cms-sw/cmssw/pull/33051

For the purpose of UL campaigns. The original PR links to plots validating the change in CMSSW_10_6. 