### PR TITLE
Consume records for mustache SC only if the mustache algo is used - 112x backport

### DIFF
--- a/RecoEcal/EgammaClusterAlgos/src/PFECALSuperClusterAlgo.cc
+++ b/RecoEcal/EgammaClusterAlgos/src/PFECALSuperClusterAlgo.cc
@@ -122,8 +122,13 @@ void PFECALSuperClusterAlgo::setTokens(const edm::ParameterSet& iConfig, edm::Co
   esEEInterCalibToken_ =
       cc.esConsumes<ESEEIntercalibConstants, ESEEIntercalibConstantsRcd, edm::Transition::BeginLuminosityBlock>();
   esChannelStatusToken_ = cc.esConsumes<ESChannelStatus, ESChannelStatusRcd, edm::Transition::BeginLuminosityBlock>();
-  ecalMustacheSCParametersToken_ = cc.esConsumes<EcalMustacheSCParameters, EcalMustacheSCParametersRcd>();
-  ecalSCDynamicDPhiParametersToken_ = cc.esConsumes<EcalSCDynamicDPhiParameters, EcalSCDynamicDPhiParametersRcd>();
+
+  if (_clustype == PFECALSuperClusterAlgo::kMustache) {
+    ecalMustacheSCParametersToken_ = cc.esConsumes<EcalMustacheSCParameters, EcalMustacheSCParametersRcd>();
+  }
+  if (useDynamicDPhi_) {
+    ecalSCDynamicDPhiParametersToken_ = cc.esConsumes<EcalSCDynamicDPhiParameters, EcalSCDynamicDPhiParametersRcd>();
+  }
 
   if (useRegression_) {
     const edm::ParameterSet& regconf = iConfig.getParameter<edm::ParameterSet>("regressionConfig");
@@ -151,8 +156,12 @@ void PFECALSuperClusterAlgo::update(const edm::EventSetup& setup) {
 }
 
 void PFECALSuperClusterAlgo::updateSCParams(const edm::EventSetup& setup) {
-  mustacheSCParams_ = &setup.getData(ecalMustacheSCParametersToken_);
-  scDynamicDPhiParams_ = &setup.getData(ecalSCDynamicDPhiParametersToken_);
+  if (_clustype == PFECALSuperClusterAlgo::kMustache) {
+    mustacheSCParams_ = &setup.getData(ecalMustacheSCParametersToken_);
+  }
+  if (useDynamicDPhi_) {
+    scDynamicDPhiParams_ = &setup.getData(ecalSCDynamicDPhiParametersToken_);
+  }
 }
 
 void PFECALSuperClusterAlgo::loadAndSortPFClusters(const edm::Event& iEvent) {

--- a/RecoEcal/EgammaClusterProducers/src/PFECALSuperClusterProducer.cc
+++ b/RecoEcal/EgammaClusterProducers/src/PFECALSuperClusterProducer.cc
@@ -51,8 +51,6 @@ PFECALSuperClusterProducer::PFECALSuperClusterProducer(const edm::ParameterSet& 
   isOOTCollection_ = iConfig.getParameter<bool>("isOOTCollection");
   superClusterAlgo_.setIsOOTCollection(isOOTCollection_);
 
-  superClusterAlgo_.setTokens(iConfig, consumesCollector());
-
   std::string _typename = iConfig.getParameter<std::string>("ClusteringType");
   if (_typename == ClusterType__BOX) {
     _theclusteringtype = PFECALSuperClusterAlgo::kBOX;
@@ -62,6 +60,10 @@ PFECALSuperClusterProducer::PFECALSuperClusterProducer(const edm::ParameterSet& 
     throw cms::Exception("InvalidClusteringType") << "You have not chosen a valid clustering type,"
                                                   << " please choose from \"Box\" or \"Mustache\"!";
   }
+  superClusterAlgo_.setClusteringType(_theclusteringtype);
+  superClusterAlgo_.setUseDynamicDPhi(iConfig.getParameter<bool>("useDynamicDPhiWindow"));
+  // clusteringType and useDynamicDPhi need to be defined before setting the tokens in order to esConsume only the necessary records
+  superClusterAlgo_.setTokens(iConfig, consumesCollector());
 
   std::string _weightname = iConfig.getParameter<std::string>("EnergyWeight");
   if (_weightname == EnergyWeight__Raw) {
@@ -78,8 +80,6 @@ PFECALSuperClusterProducer::PFECALSuperClusterProducer(const edm::ParameterSet& 
 
   // parameters for clustering
   bool seedThresholdIsET = iConfig.getParameter<bool>("seedThresholdIsET");
-
-  bool useDynamicDPhi = iConfig.getParameter<bool>("useDynamicDPhiWindow");
 
   double threshPFClusterSeedBarrel = iConfig.getParameter<double>("thresh_PFClusterSeedBarrel");
   double threshPFClusterBarrel = iConfig.getParameter<double>("thresh_PFClusterBarrel");
@@ -102,10 +102,8 @@ PFECALSuperClusterProducer::PFECALSuperClusterProducer(const edm::ParameterSet& 
   bool dropUnseedable = iConfig.getParameter<bool>("dropUnseedable");
 
   superClusterAlgo_.setVerbosityLevel(verbose_);
-  superClusterAlgo_.setClusteringType(_theclusteringtype);
   superClusterAlgo_.setEnergyWeighting(_theenergyweight);
   superClusterAlgo_.setUseETForSeeding(seedThresholdIsET);
-  superClusterAlgo_.setUseDynamicDPhi(useDynamicDPhi);
 
   superClusterAlgo_.setThreshSuperClusterEt(iConfig.getParameter<double>("thresh_SCEt"));
 


### PR DESCRIPTION
#### PR description:

Use the records for EcalMustacheSCParameters and EcalSCDynamicDPhiParameters only if the SC algorithm is configured to run the mustache and/or the dynamic dPhi. This should avoid exceptions if the records are not in the GT. No changes to the outputs are expected.
The ESProducers for the records are still kept in the default configuration since not all necessary GTs contain the records already.
Backport to 112x since the new records are also consumed in the 11_2_X release.

#### PR validation:

Passes limited matrix tests.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Backport of #32997 