### PR TITLE
Production cuts: DD4hep needs to reproduce same behavior as DDD.

### DIFF
--- a/SimG4Core/Geometry/src/DDG4ProductionCuts.cc
+++ b/SimG4Core/Geometry/src/DDG4ProductionCuts.cc
@@ -112,7 +112,10 @@ void DDG4ProductionCuts::dd4hepInitialize() {
   dd4hep::SpecParRefs specs;
   specPars_->filter(specs, keywordRegion_);
 
+  // LOOP ON ALL LOGICAL VOLUMES
   for (auto const& it : *dd4hepMap_) {
+    bool foundMatch = false;  // Same behavior as in DDD: when matching SpecPar is found, stop search!
+    // SEARCH ON ALL SPECPARS
     for (auto const& fit : specs) {
       for (auto const& pit : fit.second->paths) {
         const std::string_view selection = dd4hep::dd::noNamespace(dd4hep::dd::realTopName(pit));
@@ -121,10 +124,15 @@ void DDG4ProductionCuts::dd4hepInitialize() {
                 ? dd4hep::dd::compareEqual(name, selection)
                 : std::regex_match(name.begin(), name.end(), std::regex(selection.begin(), selection.end()))) {
           dd4hepVec_.emplace_back(std::make_pair<G4LogicalVolume*, const dd4hep::SpecPar*>(&*it.second, &*fit.second));
+          foundMatch = true;
+          break;
         }
       }
-    }
-  }
+      if (foundMatch)
+        break;
+    }  // Search on all SpecPars
+  }    // Loop on all logical volumes
+
   // sort all root volumes - to get the same sequence at every run of the application.
   sort(begin(dd4hepVec_), end(dd4hepVec_), &sortByName);
 


### PR DESCRIPTION
DDD: The matching of a DDLogicalPart with a production cut SpecPar happens here: 
https://github.com/cms-sw/cmssw/blob/master/SimG4Core/Geometry/src/DDG4ProductionCuts.cc#L85
Which itself calls:
https://github.com/cms-sw/cmssw/blob/master/DetectorDescription/Core/interface/DDMapper.h#L170 
**The DDD search stops when a first match is found.**

**DD4hep: Instead, for each volume, all SpecPars are looped on**:
https://github.com/cms-sw/cmssw/blob/master/SimG4Core/Geometry/src/DDG4ProductionCuts.cc#L116
For each search, expensive regex-match can be called: https://github.com/cms-sw/cmssw/blob/master/SimG4Core/Geometry/src/DDG4ProductionCuts.cc#L122

To reproduce the same results between DDD and DD4hep, it is necessary that the searches have same behavior.
- This PR fixes the production cuts for the `hcalouteralgo:MBBT_R1P` volume. 
More generally, order-dependent results, and extra occurrences of production cuts with DD4hep are now fixed.

NB: To avoid having order-dependent production cuts, the regex in the XMLs could be fixed, but this would only solve specific occurrences of this more general problem.

- Additionally, this should results in perf improvements with DD4hep. 

NB: This search pattern over SpecPars appears often in CMSSW-DD4hep. 
It would be interesting to see whether there are other situations (outside of production cuts), where the default DDD behavior was also to stop search after first match. In that case, similar fixes could allow significant perf improvements with DD4hep, while additionally providing the same search behavior with DD4hep as DDD, hence reducing the risks of discrepancies.

@ianna @cvuosalo @civanch @bsunanda 