### PR TITLE
Add per-file fillPsetDescription in RecoVertex/PrimaryVertexProducer

### DIFF
--- a/Alignment/OfflineValidation/plugins/PrimaryVertexValidation.cc
+++ b/Alignment/OfflineValidation/plugins/PrimaryVertexValidation.cc
@@ -53,6 +53,7 @@
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 #include "Geometry/Records/interface/TrackerTopologyRcd.h"
+#include "RecoVertex/PrimaryVertexProducer/interface/TrackFilterForPVFinding.h"
 #include "RecoVertex/PrimaryVertexProducer/interface/DAClusterizerInZ_vect.h"
 #include "RecoVertex/PrimaryVertexProducer/interface/DAClusterizerInZ.h"
 #include "RecoVertex/PrimaryVertexProducer/interface/GapClusterizerInZ.h"
@@ -3710,18 +3711,8 @@ void PrimaryVertexValidation::fillDescriptions(edm::ConfigurationDescriptions& d
   desc.add<edm::InputTag>("BeamSpotTag", edm::InputTag("offlineBeamSpot"));
 
   // track filtering
-
   edm::ParameterSetDescription psd0;
-  psd0.add<double>("maxNormalizedChi2", 5.0);
-  psd0.add<double>("minPt", 0.0);
-  psd0.add<std::string>("algorithm", "filter");
-  psd0.add<double>("maxEta", 5.0);
-  psd0.add<double>("maxD0Significance", 5.0);
-  psd0.add<double>("maxD0Error", 1.0);
-  psd0.add<double>("maxDzError", 1.0);
-  psd0.add<std::string>("trackQuality", "any");
-  psd0.add<int>("minPixelLayersWithHits", 2);
-  psd0.add<int>("minSiliconLayersWithHits", 5);
+  TrackFilterForPVFinding::fillPSetDescription(psd0);
   psd0.add<int>("numTracksThreshold", 0);  // HI only
   desc.add<edm::ParameterSetDescription>("TkFilterParameters", psd0);
 
@@ -3730,31 +3721,11 @@ void PrimaryVertexValidation::fillDescriptions(edm::ConfigurationDescriptions& d
     edm::ParameterSetDescription psd0;
     {
       edm::ParameterSetDescription psd1;
-      psd1.addUntracked<bool>("verbose", false);
-      psd1.addUntracked<double>("zdumpcenter", 0.);
-      psd1.addUntracked<double>("zdumpwidth", 20.);
-      psd1.addUntracked<bool>("use_vdt", false);  // obsolete, appears in HLT configs
-      psd1.add<double>("d0CutOff", 3.0);
-      psd1.add<double>("Tmin", 2.0);
-      psd1.add<double>("delta_lowT", 0.001);
-      psd1.add<double>("zmerge", 0.01);
-      psd1.add<double>("dzCutOff", 3.0);
-      psd1.add<double>("Tpurge", 2.0);
-      psd1.add<int>("convergence_mode", 0);
-      psd1.add<double>("delta_highT", 0.01);
-      psd1.add<double>("Tstop", 0.5);
-      psd1.add<double>("coolingFactor", 0.6);
-      psd1.add<double>("vertexSize", 0.006);
-      psd1.add<double>("uniquetrkweight", 0.8);
-      psd1.add<double>("uniquetrkminp", 0.0);
-      psd1.add<double>("zrange", 4.0);
-      psd1.add<double>("tmerge", 0.01);           // 4D only
-      psd1.add<double>("dtCutOff", 4.);           // 4D only
-      psd1.add<double>("t0Max", 1.0);             // 4D only
-      psd1.add<double>("vertexSizeTime", 0.008);  // 4D only
+      DAClusterizerInZ_vect::fillPSetDescription(psd1);
       psd0.add<edm::ParameterSetDescription>("TkDAClusParameters", psd1);
+
       edm::ParameterSetDescription psd2;
-      psd2.add<double>("zSeparation", 1.0);
+      GapClusterizerInZ::fillPSetDescription(psd2);
       psd0.add<edm::ParameterSetDescription>("TkGapClusParameters", psd2);
     }
     psd0.add<std::string>("algorithm", "DA_vect");

--- a/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
+++ b/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
@@ -204,11 +204,23 @@ def customiseFor2018Input(process):
 
     return process
 
+def customiseFor33104(process):
+    """Customise the HLT menu to remove the unused use_vdt parameters"""
+    for producer in producers_by_type(process, "PrimaryVertexProducer"):
+        if hasattr(producer, "TkClusParameters"):
+            pset = getattr(producer, "TkClusParameters")
+            if hasattr(pset, "TkDAClusParameters"):
+                if hasattr(getattr(pset, "TkDAClusParameters"),"use_vdt"):
+                    del producer.TkClusParameters.TkDAClusParameters.use_vdt
+
+    return process
 
 # CMSSW version specific customizations
 def customizeHLTforCMSSW(process, menuType="GRun"):
 
     # add call to action function in proper order: newest last!
     # process = customiseFor12718(process)
+
+    process = customiseFor33104(process)
 
     return process

--- a/RecoVertex/PrimaryVertexProducer/interface/DAClusterizerInZT_vect.h
+++ b/RecoVertex/PrimaryVertexProducer/interface/DAClusterizerInZT_vect.h
@@ -12,6 +12,7 @@
 #include "RecoVertex/PrimaryVertexProducer/interface/TrackClusterizerInZ.h"
 #include "TrackingTools/TransientTrack/interface/TransientTrack.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include <vector>
 #include "DataFormats/Math/interface/Error.h"
 #include "RecoVertex/VertexTools/interface/VertexDistanceXY.h"
@@ -257,6 +258,8 @@ public:
   };
 
   DAClusterizerInZT_vect(const edm::ParameterSet &conf);
+
+  static void fillPSetDescription(edm::ParameterSetDescription &desc);
 
   std::vector<std::vector<reco::TransientTrack> > clusterize(
       const std::vector<reco::TransientTrack> &tracks) const override;

--- a/RecoVertex/PrimaryVertexProducer/interface/DAClusterizerInZ_vect.h
+++ b/RecoVertex/PrimaryVertexProducer/interface/DAClusterizerInZ_vect.h
@@ -11,6 +11,7 @@
 
 #include "RecoVertex/PrimaryVertexProducer/interface/TrackClusterizerInZ.h"
 #include "TrackingTools/TransientTrack/interface/TransientTrack.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include <vector>
 #include "DataFormats/Math/interface/Error.h"
@@ -19,6 +20,8 @@
 
 class DAClusterizerInZ_vect final : public TrackClusterizerInZ {
 public:
+  static void fillPSetDescription(edm::ParameterSetDescription &desc);
+
   // internal data structure for tracks
   struct track_t {
     std::vector<double> zpca_vec;                  // z-coordinate at point of closest approach to the beamline

--- a/RecoVertex/PrimaryVertexProducer/interface/GapClusterizerInZ.h
+++ b/RecoVertex/PrimaryVertexProducer/interface/GapClusterizerInZ.h
@@ -10,10 +10,13 @@
 #include "TrackingTools/TransientTrack/interface/TransientTrack.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "RecoVertex/VertexPrimitives/interface/TransientVertex.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 
 class GapClusterizerInZ : public TrackClusterizerInZ {
 public:
   GapClusterizerInZ(const edm::ParameterSet& conf);
+
+  static void fillPSetDescription(edm::ParameterSetDescription& desc);
 
   std::vector<std::vector<reco::TransientTrack> > clusterize(
       const std::vector<reco::TransientTrack>& tracks) const override;

--- a/RecoVertex/PrimaryVertexProducer/interface/HITrackFilterForPVFinding.h
+++ b/RecoVertex/PrimaryVertexProducer/interface/HITrackFilterForPVFinding.h
@@ -29,6 +29,11 @@ public:
       return seltks;
     }
   }
+
+  static void fillPSetDescription(edm::ParameterSetDescription& desc) {
+    TrackFilterForPVFinding::fillPSetDescription(desc);
+    desc.add<int>("numTracksThreshold", 0);  // HI only
+  }
 };
 
 #endif

--- a/RecoVertex/PrimaryVertexProducer/interface/PrimaryVertexProducer.h
+++ b/RecoVertex/PrimaryVertexProducer/interface/PrimaryVertexProducer.h
@@ -30,6 +30,8 @@
 
 //#include "RecoVertex/PrimaryVertexProducer/interface/PrimaryVertexProducerAlgorithm.h"
 #include "TrackingTools/TransientTrack/interface/TransientTrack.h"
+#include "TrackingTools/TransientTrack/interface/TransientTrackBuilder.h"
+#include "TrackingTools/Records/interface/TransientTrackRecord.h"
 #include "RecoVertex/PrimaryVertexProducer/interface/TrackFilterForPVFindingBase.h"
 #include "RecoVertex/PrimaryVertexProducer/interface/TrackClusterizerInZ.h"
 #include "RecoVertex/PrimaryVertexProducer/interface/DAClusterizerInZ_vect.h"
@@ -65,6 +67,8 @@ public:
 
 private:
   // ----------member data ---------------------------
+  const edm::ESGetToken<TransientTrackBuilder, TransientTrackRecord> theTTBToken;
+
   TrackFilterForPVFindingBase* theTrackFilter;
   TrackClusterizerInZ* theTrackClusterizer;
 

--- a/RecoVertex/PrimaryVertexProducer/interface/TrackFilterForPVFinding.h
+++ b/RecoVertex/PrimaryVertexProducer/interface/TrackFilterForPVFinding.h
@@ -9,11 +9,15 @@
 #include "RecoVertex/PrimaryVertexProducer/interface/TrackFilterForPVFindingBase.h"
 #include "TrackingTools/TransientTrack/interface/TransientTrack.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include <vector>
 
 class TrackFilterForPVFinding : public TrackFilterForPVFindingBase {
 public:
   TrackFilterForPVFinding(const edm::ParameterSet& conf);
+
+  static void fillPSetDescription(edm::ParameterSetDescription& desc);
+
   bool operator()(const reco::TransientTrack& tracks) const;
   std::vector<reco::TransientTrack> select(const std::vector<reco::TransientTrack>& tracks) const override;
 

--- a/RecoVertex/PrimaryVertexProducer/plugins/PrimaryVertexProducer.cc
+++ b/RecoVertex/PrimaryVertexProducer/plugins/PrimaryVertexProducer.cc
@@ -391,16 +391,7 @@ void PrimaryVertexProducer::fillDescriptions(edm::ConfigurationDescriptions& des
   desc.addUntracked<bool>("verbose", false);
   {
     edm::ParameterSetDescription psd0;
-    psd0.add<double>("maxNormalizedChi2", 10.0);
-    psd0.add<double>("minPt", 0.0);
-    psd0.add<std::string>("algorithm", "filter");
-    psd0.add<double>("maxEta", 2.4);
-    psd0.add<double>("maxD0Significance", 4.0);
-    psd0.add<double>("maxD0Error", 1.0);
-    psd0.add<double>("maxDzError", 1.0);
-    psd0.add<std::string>("trackQuality", "any");
-    psd0.add<int>("minPixelLayersWithHits", 2);
-    psd0.add<int>("minSiliconLayersWithHits", 5);
+    TrackFilterForPVFinding::fillPSetDescription(psd0);
     psd0.add<int>("numTracksThreshold", 0);  // HI only
     desc.add<edm::ParameterSetDescription>("TkFilterParameters", psd0);
   }
@@ -408,43 +399,22 @@ void PrimaryVertexProducer::fillDescriptions(edm::ConfigurationDescriptions& des
   desc.add<edm::InputTag>("TrackLabel", edm::InputTag("generalTracks"));
   desc.add<edm::InputTag>("TrackTimeResosLabel", edm::InputTag("dummy_default"));  // 4D only
   desc.add<edm::InputTag>("TrackTimesLabel", edm::InputTag("dummy_default"));      // 4D only
+
   {
     edm::ParameterSetDescription psd0;
     {
       edm::ParameterSetDescription psd1;
-      psd1.addUntracked<bool>("verbose", false);
-      psd1.addUntracked<double>("zdumpcenter", 0.);
-      psd1.addUntracked<double>("zdumpwidth", 20.);
-      psd1.addUntracked<bool>("use_vdt", false);  // obsolete, appears in HLT configs
-      psd1.add<double>("d0CutOff", 3.0);
-      psd1.add<double>("Tmin", 2.0);
-      psd1.add<double>("delta_lowT", 0.001);
-      psd1.add<double>("zmerge", 0.01);
-      psd1.add<double>("dzCutOff", 3.0);
-      psd1.add<double>("Tpurge", 2.0);
-      psd1.add<int>("convergence_mode", 0);
-      psd1.add<double>("delta_highT", 0.01);
-      psd1.add<double>("Tstop", 0.5);
-      psd1.add<double>("coolingFactor", 0.6);
-      psd1.add<double>("vertexSize", 0.006);
-      psd1.add<double>("uniquetrkweight", 0.8);
-      psd1.add<double>("uniquetrkminp", 0.0);
-      psd1.add<double>("zrange", 4.0);
-
-      psd1.add<double>("tmerge", 0.01);           // 4D only
-      psd1.add<double>("dtCutOff", 4.);           // 4D only
-      psd1.add<double>("t0Max", 1.0);             // 4D only
-      psd1.add<double>("vertexSizeTime", 0.008);  // 4D only
-
+      DAClusterizerInZT_vect::fillPSetDescription(psd1);
       psd0.add<edm::ParameterSetDescription>("TkDAClusParameters", psd1);
 
       edm::ParameterSetDescription psd2;
-      psd2.add<double>("zSeparation", 1.0);
+      GapClusterizerInZ::fillPSetDescription(psd2);
       psd0.add<edm::ParameterSetDescription>("TkGapClusParameters", psd2);
     }
     psd0.add<std::string>("algorithm", "DA_vect");
     desc.add<edm::ParameterSetDescription>("TkClusParameters", psd0);
   }
+
   desc.add<bool>("isRecoveryIteration", false);
   desc.add<edm::InputTag>("recoveryVtxCollection", {""});
 

--- a/RecoVertex/PrimaryVertexProducer/plugins/PrimaryVertexProducer.cc
+++ b/RecoVertex/PrimaryVertexProducer/plugins/PrimaryVertexProducer.cc
@@ -11,13 +11,12 @@
 #include "RecoVertex/VertexTools/interface/VertexDistanceXY.h"
 
 #include "FWCore/Framework/interface/ESHandle.h"
-#include "TrackingTools/TransientTrack/interface/TransientTrackBuilder.h"
-#include "TrackingTools/Records/interface/TransientTrackRecord.h"
 #include "DataFormats/BeamSpot/interface/BeamSpot.h"
 
 #include "RecoVertex/VertexTools/interface/GeometricAnnealing.h"
 
-PrimaryVertexProducer::PrimaryVertexProducer(const edm::ParameterSet& conf) : theConfig(conf) {
+PrimaryVertexProducer::PrimaryVertexProducer(const edm::ParameterSet& conf)
+    : theTTBToken(esConsumes(edm::ESInputTag("", "TransientTrackBuilder"))), theConfig(conf) {
   fVerbose = conf.getUntrackedParameter<bool>("verbose", false);
 
   trkToken = consumes<reco::TrackCollection>(conf.getParameter<edm::InputTag>("TrackLabel"));
@@ -183,8 +182,7 @@ void PrimaryVertexProducer::produce(edm::Event& iEvent, const edm::EventSetup& i
   iEvent.getByToken(trkToken, tks);
 
   // interface RECO tracks to vertex reconstruction
-  edm::ESHandle<TransientTrackBuilder> theB;
-  iSetup.get<TransientTrackRecord>().get("TransientTrackBuilder", theB);
+  const auto& theB = &iSetup.getData(theTTBToken);
   std::vector<reco::TransientTrack> t_tks;
 
   if (f4D) {

--- a/RecoVertex/PrimaryVertexProducer/python/TkClusParameters_cff.py
+++ b/RecoVertex/PrimaryVertexProducer/python/TkClusParameters_cff.py
@@ -37,7 +37,6 @@ highBetaStar_2018.toModify(DA_vectParameters,
 DA2D_vectParameters = cms.PSet(
     algorithm   = cms.string("DA2D_vect"),
     TkDAClusParameters = cms.PSet(
-        verbose = cms.untracked.bool(False),
         coolingFactor = cms.double(0.6),  # moderate annealing speed
         zrange = cms.double(4.),          # consider only clusters within 4 sigma*sqrt(T) of a track
         delta_highT = cms.double(1.e-2),  # convergence requirement at high T

--- a/RecoVertex/PrimaryVertexProducer/src/DAClusterizerInZT_vect.cc
+++ b/RecoVertex/PrimaryVertexProducer/src/DAClusterizerInZT_vect.cc
@@ -1556,3 +1556,27 @@ void DAClusterizerInZT_vect::dump(const double beta, const vertex_t& y, const tr
   }
 #endif
 }
+
+void DAClusterizerInZT_vect::fillPSetDescription(edm::ParameterSetDescription& desc) {
+  desc.addUntracked<double>("zdumpcenter", 0.);
+  desc.addUntracked<double>("zdumpwidth", 20.);
+  desc.addUntracked<bool>("use_vdt", false);  // obsolete, appears in HLT configs
+  desc.add<double>("d0CutOff", 3.0);
+  desc.add<double>("Tmin", 2.0);
+  desc.add<double>("delta_lowT", 0.001);
+  desc.add<double>("zmerge", 0.01);
+  desc.add<double>("dzCutOff", 3.0);
+  desc.add<double>("Tpurge", 2.0);
+  desc.add<int>("convergence_mode", 0);
+  desc.add<double>("delta_highT", 0.01);
+  desc.add<double>("Tstop", 0.5);
+  desc.add<double>("coolingFactor", 0.6);
+  desc.add<double>("vertexSize", 0.006);
+  desc.add<double>("uniquetrkweight", 0.8);
+  desc.add<double>("uniquetrkminp", 0.0);
+  desc.add<double>("zrange", 4.0);
+  desc.add<double>("tmerge", 0.01);           // 4D only
+  desc.add<double>("dtCutOff", 4.);           // 4D only
+  desc.add<double>("t0Max", 1.0);             // 4D only
+  desc.add<double>("vertexSizeTime", 0.008);  // 4D only
+}

--- a/RecoVertex/PrimaryVertexProducer/src/DAClusterizerInZT_vect.cc
+++ b/RecoVertex/PrimaryVertexProducer/src/DAClusterizerInZT_vect.cc
@@ -1,4 +1,5 @@
 #include "RecoVertex/PrimaryVertexProducer/interface/DAClusterizerInZT_vect.h"
+#include "RecoVertex/PrimaryVertexProducer/interface/DAClusterizerInZ_vect.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "DataFormats/GeometryCommonDetAlgo/interface/Measurement1D.h"
 #include "RecoVertex/VertexPrimitives/interface/VertexException.h"
@@ -1558,23 +1559,7 @@ void DAClusterizerInZT_vect::dump(const double beta, const vertex_t& y, const tr
 }
 
 void DAClusterizerInZT_vect::fillPSetDescription(edm::ParameterSetDescription& desc) {
-  desc.addUntracked<double>("zdumpcenter", 0.);
-  desc.addUntracked<double>("zdumpwidth", 20.);
-  desc.addUntracked<bool>("use_vdt", false);  // obsolete, appears in HLT configs
-  desc.add<double>("d0CutOff", 3.0);
-  desc.add<double>("Tmin", 2.0);
-  desc.add<double>("delta_lowT", 0.001);
-  desc.add<double>("zmerge", 0.01);
-  desc.add<double>("dzCutOff", 3.0);
-  desc.add<double>("Tpurge", 2.0);
-  desc.add<int>("convergence_mode", 0);
-  desc.add<double>("delta_highT", 0.01);
-  desc.add<double>("Tstop", 0.5);
-  desc.add<double>("coolingFactor", 0.6);
-  desc.add<double>("vertexSize", 0.006);
-  desc.add<double>("uniquetrkweight", 0.8);
-  desc.add<double>("uniquetrkminp", 0.0);
-  desc.add<double>("zrange", 4.0);
+  DAClusterizerInZ_vect::fillPSetDescription(desc);
   desc.add<double>("tmerge", 0.01);           // 4D only
   desc.add<double>("dtCutOff", 4.);           // 4D only
   desc.add<double>("t0Max", 1.0);             // 4D only

--- a/RecoVertex/PrimaryVertexProducer/src/DAClusterizerInZ_vect.cc
+++ b/RecoVertex/PrimaryVertexProducer/src/DAClusterizerInZ_vect.cc
@@ -1167,3 +1167,23 @@ void DAClusterizerInZ_vect::dump(const double beta, const vertex_t& y, const tra
   }
 #endif
 }
+
+void DAClusterizerInZ_vect::fillPSetDescription(edm::ParameterSetDescription& desc) {
+  desc.addUntracked<double>("zdumpcenter", 0.);
+  desc.addUntracked<double>("zdumpwidth", 20.);
+  desc.addUntracked<bool>("use_vdt", false);  // obsolete, appears in HLT configs
+  desc.add<double>("d0CutOff", 3.0);
+  desc.add<double>("Tmin", 2.0);
+  desc.add<double>("delta_lowT", 0.001);
+  desc.add<double>("zmerge", 0.01);
+  desc.add<double>("dzCutOff", 3.0);
+  desc.add<double>("Tpurge", 2.0);
+  desc.add<int>("convergence_mode", 0);
+  desc.add<double>("delta_highT", 0.01);
+  desc.add<double>("Tstop", 0.5);
+  desc.add<double>("coolingFactor", 0.6);
+  desc.add<double>("vertexSize", 0.006);
+  desc.add<double>("uniquetrkweight", 0.8);
+  desc.add<double>("uniquetrkminp", 0.0);
+  desc.add<double>("zrange", 4.0);
+}

--- a/RecoVertex/PrimaryVertexProducer/src/DAClusterizerInZ_vect.cc
+++ b/RecoVertex/PrimaryVertexProducer/src/DAClusterizerInZ_vect.cc
@@ -1171,7 +1171,6 @@ void DAClusterizerInZ_vect::dump(const double beta, const vertex_t& y, const tra
 void DAClusterizerInZ_vect::fillPSetDescription(edm::ParameterSetDescription& desc) {
   desc.addUntracked<double>("zdumpcenter", 0.);
   desc.addUntracked<double>("zdumpwidth", 20.);
-  desc.addUntracked<bool>("use_vdt", false);  // obsolete, appears in HLT configs
   desc.add<double>("d0CutOff", 3.0);
   desc.add<double>("Tmin", 2.0);
   desc.add<double>("delta_lowT", 0.001);

--- a/RecoVertex/PrimaryVertexProducer/src/GapClusterizerInZ.cc
+++ b/RecoVertex/PrimaryVertexProducer/src/GapClusterizerInZ.cc
@@ -60,3 +60,8 @@ vector<vector<reco::TransientTrack> > GapClusterizerInZ::clusterize(const vector
 
   return clusters;
 }
+
+void GapClusterizerInZ::fillPSetDescription(edm::ParameterSetDescription& desc) {
+  desc.add<double>("zSeparation", 1.0);
+  desc.addUntracked<bool>("verbose", false);
+}

--- a/RecoVertex/PrimaryVertexProducer/src/TrackFilterForPVFinding.cc
+++ b/RecoVertex/PrimaryVertexProducer/src/TrackFilterForPVFinding.cc
@@ -47,3 +47,16 @@ std::vector<reco::TransientTrack> TrackFilterForPVFinding::select(
   }
   return seltks;
 }
+
+void TrackFilterForPVFinding::fillPSetDescription(edm::ParameterSetDescription& desc) {
+  desc.add<double>("maxNormalizedChi2", 10.0);
+  desc.add<double>("minPt", 0.0);
+  desc.add<std::string>("algorithm", "filter");
+  desc.add<double>("maxEta", 2.4);
+  desc.add<double>("maxD0Significance", 4.0);
+  desc.add<double>("maxD0Error", 1.0);
+  desc.add<double>("maxDzError", 1.0);
+  desc.add<std::string>("trackQuality", "any");
+  desc.add<int>("minPixelLayersWithHits", 2);
+  desc.add<int>("minSiliconLayersWithHits", 5);
+}


### PR DESCRIPTION
#### PR description:

The main goal of this PR is to integrate per-file `fillPsetDescription`s method in the `RecoVertex/PrimaryVertexProducer` package. This is done at commit https://github.com/cms-sw/cmssw/commit/03514c136c07e61917926820407f77ce2a56f002  in order to avoid having to update the `fillDescriptions` method of `PrimaryVertexValidation` each time there is the need to update `PrimaryVertexProducer`. 
With distributed  `fillPsetDescription`s method in the various classes, now the consumers can just call the defaults which can be - hopefully - centrally mainained.
This has been suggested by @perrotta here https://github.com/cms-sw/cmssw/pull/32994#issuecomment-788965863
I profit of this PR to address also this comment https://github.com/cms-sw/cmssw/pull/32994#issuecomment-790904061 about missing `esConsumes` migration of the `RecoVertex/PrimaryVertexProducer` package (done in commit 16ed3c5)

#### PR validation:

Compiled and run unit tests with `scram b runtests`

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This PR is not a backport and no backport is needed.
cc:
@werdmann 

