### PR TITLE
Better destructor behavior for SiPixelTemplateStore2D

### DIFF
--- a/CondFormats/SiPixelTransient/interface/SiPixelTemplate2D.h
+++ b/CondFormats/SiPixelTransient/interface/SiPixelTemplate2D.h
@@ -101,13 +101,7 @@ struct SiPixelTemplateHeader2D {  //!< template header structure
 
 struct SiPixelTemplateStore2D {  //!< template storage structure
   SiPixelTemplateHeader2D head;
-  SiPixelTemplateEntry2D** entry = nullptr;  //!< use 2d entry to store BPix and FPix entries [dynamically allocated]
-  void destroy() {                           // deletes arrays created by pushfile method of SiPixelTemplate
-    if (entry != nullptr) {
-      delete[] entry[0];
-      delete[] entry;
-    }
-  }
+  std::vector<std::vector<SiPixelTemplateEntry2D>> entry;  //!< use 2d entry to store BPix and FPix entries [dynamically allocated]
 };
 
 // ******************************************************************************************

--- a/CondFormats/SiPixelTransient/interface/SiPixelTemplate2D.h
+++ b/CondFormats/SiPixelTransient/interface/SiPixelTemplate2D.h
@@ -101,7 +101,8 @@ struct SiPixelTemplateHeader2D {  //!< template header structure
 
 struct SiPixelTemplateStore2D {  //!< template storage structure
   SiPixelTemplateHeader2D head;
-  std::vector<std::vector<SiPixelTemplateEntry2D>> entry;  //!< use 2d entry to store BPix and FPix entries [dynamically allocated]
+  std::vector<std::vector<SiPixelTemplateEntry2D>>
+      entry;  //!< use 2d entry to store BPix and FPix entries [dynamically allocated]
 };
 
 // ******************************************************************************************

--- a/CondFormats/SiPixelTransient/interface/SiPixelTemplate2D.h
+++ b/CondFormats/SiPixelTransient/interface/SiPixelTemplate2D.h
@@ -100,9 +100,10 @@ struct SiPixelTemplateHeader2D {  //!< template header structure
 };
 
 struct SiPixelTemplateStore2D {  //!< template storage structure
-  SiPixelTemplateHeader2D head;
-  std::vector<std::vector<SiPixelTemplateEntry2D>>
-      entry;  //!< use 2d entry to store BPix and FPix entries [dynamically allocated]
+  SiPixelTemplateHeader2D head;  //!< Header information
+
+  //!< use 2d entry to store BPix and FPix entries [dynamically allocated]
+  std::vector<std::vector<SiPixelTemplateEntry2D>> entry;
 };
 
 // ******************************************************************************************

--- a/CondFormats/SiPixelTransient/src/SiPixelTemplate2D.cc
+++ b/CondFormats/SiPixelTransient/src/SiPixelTemplate2D.cc
@@ -166,10 +166,10 @@ bool SiPixelTemplate2D::pushfile(int filenum, std::vector<SiPixelTemplateStore2D
 
     // next, layout the 2-d structure needed to store template
 
-    theCurrentTemp.entry = new SiPixelTemplateEntry2D*[theCurrentTemp.head.NTyx];
-    theCurrentTemp.entry[0] = new SiPixelTemplateEntry2D[theCurrentTemp.head.NTyx * theCurrentTemp.head.NTxx];
-    for (int i = 1; i < theCurrentTemp.head.NTyx; ++i)
-      theCurrentTemp.entry[i] = theCurrentTemp.entry[i - 1] + theCurrentTemp.head.NTxx;
+
+    theCurrentTemp.entry.resize(theCurrentTemp.head.NTyx);
+    for (int iy = 0; iy < theCurrentTemp.head.NTyx; ++iy)
+        theCurrentTemp.entry[iy].resize(theCurrentTemp.head.NTxx);
 
     // Read in the file info
 
@@ -181,8 +181,6 @@ bool SiPixelTemplate2D::pushfile(int filenum, std::vector<SiPixelTemplateStore2D
         if (in_file.fail()) {
           LOGERROR("SiPixelTemplate2D") << "Error reading file 1, no template load, run # "
                                         << theCurrentTemp.entry[iy][jx].runnum << ENDL;
-          delete[] theCurrentTemp.entry[0];
-          delete[] theCurrentTemp.entry;
           return false;
         }
 
@@ -202,8 +200,6 @@ bool SiPixelTemplate2D::pushfile(int filenum, std::vector<SiPixelTemplateStore2D
         if (in_file.fail()) {
           LOGERROR("SiPixelTemplate2D") << "Error reading file 2, no template load, run # "
                                         << theCurrentTemp.entry[iy][jx].runnum << ENDL;
-          delete[] theCurrentTemp.entry[0];
-          delete[] theCurrentTemp.entry;
           return false;
         }
 
@@ -215,8 +211,6 @@ bool SiPixelTemplate2D::pushfile(int filenum, std::vector<SiPixelTemplateStore2D
           if (in_file.fail()) {
             LOGERROR("SiPixelTemplate2D")
                 << "Error reading file 3, no template load, run # " << theCurrentTemp.entry[iy][jx].runnum << ENDL;
-            delete[] theCurrentTemp.entry[0];
-            delete[] theCurrentTemp.entry;
             return false;
           }
         }
@@ -229,8 +223,6 @@ bool SiPixelTemplate2D::pushfile(int filenum, std::vector<SiPixelTemplateStore2D
           if (in_file.fail()) {
             LOGERROR("SiPixelTemplate2D")
                 << "Error reading file 4, no template load, run # " << theCurrentTemp.entry[iy][jx].runnum << ENDL;
-            delete[] theCurrentTemp.entry[0];
-            delete[] theCurrentTemp.entry;
             return false;
           }
         }
@@ -247,8 +239,6 @@ bool SiPixelTemplate2D::pushfile(int filenum, std::vector<SiPixelTemplateStore2D
               if (in_file.fail()) {
                 LOGERROR("SiPixelTemplate2D")
                     << "Error reading file 5, no template load, run # " << theCurrentTemp.entry[iy][jx].runnum << ENDL;
-                delete[] theCurrentTemp.entry[0];
-                delete[] theCurrentTemp.entry;
                 return false;
               }
               for (int i = 0; i < T2YSIZE; ++i) {
@@ -267,8 +257,6 @@ bool SiPixelTemplate2D::pushfile(int filenum, std::vector<SiPixelTemplateStore2D
         if (in_file.fail()) {
           LOGERROR("SiPixelTemplate2D") << "Error reading file 6, no template load, run # "
                                         << theCurrentTemp.entry[iy][jx].runnum << ENDL;
-          delete[] theCurrentTemp.entry[0];
-          delete[] theCurrentTemp.entry;
           return false;
         }
 
@@ -281,8 +269,6 @@ bool SiPixelTemplate2D::pushfile(int filenum, std::vector<SiPixelTemplateStore2D
         if (in_file.fail()) {
           LOGERROR("SiPixelTemplate2D") << "Error reading file 7, no template load, run # "
                                         << theCurrentTemp.entry[iy][jx].runnum << ENDL;
-          delete[] theCurrentTemp.entry[0];
-          delete[] theCurrentTemp.entry;
           return false;
         }
 
@@ -295,8 +281,6 @@ bool SiPixelTemplate2D::pushfile(int filenum, std::vector<SiPixelTemplateStore2D
         if (in_file.fail()) {
           LOGERROR("SiPixelTemplate2D") << "Error reading file 8, no template load, run # "
                                         << theCurrentTemp.entry[iy][jx].runnum << ENDL;
-          delete[] theCurrentTemp.entry[0];
-          delete[] theCurrentTemp.entry;
           return false;
         }
       }
@@ -419,10 +403,9 @@ bool SiPixelTemplate2D::pushfile(const SiPixel2DTemplateDBObject& dbobject,
 
     // next, layout the 2-d structure needed to store template
 
-    theCurrentTemp.entry = new SiPixelTemplateEntry2D*[theCurrentTemp.head.NTyx];
-    theCurrentTemp.entry[0] = new SiPixelTemplateEntry2D[theCurrentTemp.head.NTyx * theCurrentTemp.head.NTxx];
-    for (int i = 1; i < theCurrentTemp.head.NTyx; ++i)
-      theCurrentTemp.entry[i] = theCurrentTemp.entry[i - 1] + theCurrentTemp.head.NTxx;
+    theCurrentTemp.entry.resize(theCurrentTemp.head.NTyx);
+    for (int iy = 0; iy < theCurrentTemp.head.NTyx; ++iy)
+        theCurrentTemp.entry[iy].resize(theCurrentTemp.head.NTxx);
 
     // Read in the file info
 
@@ -434,8 +417,6 @@ bool SiPixelTemplate2D::pushfile(const SiPixel2DTemplateDBObject& dbobject,
         if (db.fail()) {
           LOGERROR("SiPixelTemplate2D") << "Error reading file 1, no template load, run # "
                                         << theCurrentTemp.entry[iy][jx].runnum << ENDL;
-          delete[] theCurrentTemp.entry[0];
-          delete[] theCurrentTemp.entry;
           return false;
         }
 
@@ -455,8 +436,6 @@ bool SiPixelTemplate2D::pushfile(const SiPixel2DTemplateDBObject& dbobject,
         if (db.fail()) {
           LOGERROR("SiPixelTemplate2D") << "Error reading file 2, no template load, run # "
                                         << theCurrentTemp.entry[iy][jx].runnum << ENDL;
-          delete[] theCurrentTemp.entry[0];
-          delete[] theCurrentTemp.entry;
           return false;
         }
 
@@ -468,8 +447,6 @@ bool SiPixelTemplate2D::pushfile(const SiPixel2DTemplateDBObject& dbobject,
           if (db.fail()) {
             LOGERROR("SiPixelTemplate2D")
                 << "Error reading file 3, no template load, run # " << theCurrentTemp.entry[iy][jx].runnum << ENDL;
-            delete[] theCurrentTemp.entry[0];
-            delete[] theCurrentTemp.entry;
             return false;
           }
         }
@@ -482,8 +459,6 @@ bool SiPixelTemplate2D::pushfile(const SiPixel2DTemplateDBObject& dbobject,
           if (db.fail()) {
             LOGERROR("SiPixelTemplate2D")
                 << "Error reading file 4, no template load, run # " << theCurrentTemp.entry[iy][jx].runnum << ENDL;
-            delete[] theCurrentTemp.entry[0];
-            delete[] theCurrentTemp.entry;
             return false;
           }
         }
@@ -500,8 +475,6 @@ bool SiPixelTemplate2D::pushfile(const SiPixel2DTemplateDBObject& dbobject,
               if (db.fail()) {
                 LOGERROR("SiPixelTemplate2D")
                     << "Error reading file 5, no template load, run # " << theCurrentTemp.entry[iy][jx].runnum << ENDL;
-                delete[] theCurrentTemp.entry[0];
-                delete[] theCurrentTemp.entry;
                 return false;
               }
               for (int i = 0; i < T2YSIZE; ++i) {
@@ -520,8 +493,6 @@ bool SiPixelTemplate2D::pushfile(const SiPixel2DTemplateDBObject& dbobject,
         if (db.fail()) {
           LOGERROR("SiPixelTemplate2D") << "Error reading file 6, no template load, run # "
                                         << theCurrentTemp.entry[iy][jx].runnum << ENDL;
-          delete[] theCurrentTemp.entry[0];
-          delete[] theCurrentTemp.entry;
           return false;
         }
 
@@ -534,8 +505,6 @@ bool SiPixelTemplate2D::pushfile(const SiPixel2DTemplateDBObject& dbobject,
         if (db.fail()) {
           LOGERROR("SiPixelTemplate2D") << "Error reading file 7, no template load, run # "
                                         << theCurrentTemp.entry[iy][jx].runnum << ENDL;
-          delete[] theCurrentTemp.entry[0];
-          delete[] theCurrentTemp.entry;
           return false;
         }
 
@@ -548,8 +517,6 @@ bool SiPixelTemplate2D::pushfile(const SiPixel2DTemplateDBObject& dbobject,
         if (db.fail()) {
           LOGERROR("SiPixelTemplate2D") << "Error reading file 8, no template load, run # "
                                         << theCurrentTemp.entry[iy][jx].runnum << ENDL;
-          delete[] theCurrentTemp.entry[0];
-          delete[] theCurrentTemp.entry;
           return false;
         }
       }

--- a/CondFormats/SiPixelTransient/src/SiPixelTemplate2D.cc
+++ b/CondFormats/SiPixelTransient/src/SiPixelTemplate2D.cc
@@ -166,10 +166,9 @@ bool SiPixelTemplate2D::pushfile(int filenum, std::vector<SiPixelTemplateStore2D
 
     // next, layout the 2-d structure needed to store template
 
-
     theCurrentTemp.entry.resize(theCurrentTemp.head.NTyx);
     for (int iy = 0; iy < theCurrentTemp.head.NTyx; ++iy)
-        theCurrentTemp.entry[iy].resize(theCurrentTemp.head.NTxx);
+      theCurrentTemp.entry[iy].resize(theCurrentTemp.head.NTxx);
 
     // Read in the file info
 
@@ -405,7 +404,7 @@ bool SiPixelTemplate2D::pushfile(const SiPixel2DTemplateDBObject& dbobject,
 
     theCurrentTemp.entry.resize(theCurrentTemp.head.NTyx);
     for (int iy = 0; iy < theCurrentTemp.head.NTyx; ++iy)
-        theCurrentTemp.entry[iy].resize(theCurrentTemp.head.NTxx);
+      theCurrentTemp.entry[iy].resize(theCurrentTemp.head.NTxx);
 
     // Read in the file info
 

--- a/CondFormats/SiPixelTransient/src/SiPixelTemplate2D.cc
+++ b/CondFormats/SiPixelTransient/src/SiPixelTemplate2D.cc
@@ -167,8 +167,8 @@ bool SiPixelTemplate2D::pushfile(int filenum, std::vector<SiPixelTemplateStore2D
     // next, layout the 2-d structure needed to store template
 
     theCurrentTemp.entry.resize(theCurrentTemp.head.NTyx);
-    for (int iy = 0; iy < theCurrentTemp.head.NTyx; ++iy)
-      theCurrentTemp.entry[iy].resize(theCurrentTemp.head.NTxx);
+    for (auto& item : theCurrentTemp.entry)
+      item.resize(theCurrentTemp.head.NTxx);
 
     // Read in the file info
 
@@ -403,8 +403,8 @@ bool SiPixelTemplate2D::pushfile(const SiPixel2DTemplateDBObject& dbobject,
     // next, layout the 2-d structure needed to store template
 
     theCurrentTemp.entry.resize(theCurrentTemp.head.NTyx);
-    for (int iy = 0; iy < theCurrentTemp.head.NTyx; ++iy)
-      theCurrentTemp.entry[iy].resize(theCurrentTemp.head.NTxx);
+    for (auto& item : theCurrentTemp.entry)
+      item.resize(theCurrentTemp.head.NTxx);
 
     // Read in the file info
 

--- a/RecoLocalTracker/SiPixelRecHits/src/PixelCPEClusterRepair.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/PixelCPEClusterRepair.cc
@@ -155,10 +155,7 @@ void PixelCPEClusterRepair::fill2DTemplIDs() {
 //-----------------------------------------------------------------------------
 //  Clean up.
 //-----------------------------------------------------------------------------
-PixelCPEClusterRepair::~PixelCPEClusterRepair() {
-  for (auto x : thePixelTemp2D_)
-    x.destroy();
-}
+PixelCPEClusterRepair::~PixelCPEClusterRepair() {}
 
 std::unique_ptr<PixelCPEBase::ClusterParam> PixelCPEClusterRepair::createClusterParam(const SiPixelCluster& cl) const {
   return std::make_unique<ClusterParamTemplate>(cl);


### PR DESCRIPTION
This PR updates the SiPixelTemplate2D objects to use std::vectors rather than arrays allocated directly on the heap. This removes the need for the destroy() function. We expect no changes in output. 

This addresses issue #32567 that was raised in PR #32494, which had a similar change for the 1D template. 

@mmusich @tvami @pmaksim1 @tsusa 