### PR TITLE
Fix LogDebug(...); not compiling

### DIFF
--- a/FWCore/MessageLogger/interface/MessageLogger.h
+++ b/FWCore/MessageLogger/interface/MessageLogger.h
@@ -141,6 +141,10 @@ namespace edm {
     explicit LogDebug_(std::string_view id, std::string_view file, int line);
     //Needed for the LogDebug macro
     LogDebug_(Log<level::Debug, false> const& iOther) : Log<level::Debug, false>(nullptr, iOther) {}
+    LogDebug_(LogDebug_ const&) = delete;
+    LogDebug_(LogDebug_&&) = default;
+    LogDebug_& operator=(LogDebug_ const&) = delete;
+    LogDebug_& operator=(LogDebug_&&) = default;
 
   private:
     std::string_view stripLeadingDirectoryTree(std::string_view file) const;
@@ -152,6 +156,10 @@ namespace edm {
     explicit LogTrace_(std::string_view id) : Log<level::Debug, true>(id) {}
     //Needed for the LogTrace macro
     LogTrace_(Log<level::Debug, true> const& iOther) : Log<level::Debug, true>(nullptr, iOther) {}
+    LogTrace_(LogTrace_ const&) = delete;
+    LogTrace_(LogTrace_&&) = default;
+    LogTrace_& operator=(LogTrace_ const&) = delete;
+    LogTrace_& operator=(LogTrace_&&) = default;
   };
 
   namespace impl {
@@ -161,6 +169,8 @@ namespace edm {
       //Need an operator with lower precendence than operator<<
       LogDebug_ operator|(Log<level::Debug, false>& iOther) { return LogDebug_(iOther); }
       LogTrace_ operator|(Log<level::Debug, true>& iOther) { return LogTrace_(iOther); }
+      LogDebug_ operator|(Log<level::Debug, false>&& iOther) { return LogDebug_(iOther); }
+      LogTrace_ operator|(Log<level::Debug, true>&& iOther) { return LogTrace_(iOther); }
     };
   }  // namespace impl
 

--- a/FWCore/MessageService/test/standAloneTest.cpp
+++ b/FWCore/MessageService/test/standAloneTest.cpp
@@ -4,6 +4,8 @@
 namespace edmtest {
 
   void sampleStandAlone() {
+    LogDebug("cat_A");  //test stand alone declaration
+    LogDebug("cat_A").log([](auto&& iLog) { iLog << " LogDebug.log was called"; });
     LogDebug("cat_A") << "LogDebug    was used to send cat_A";
     LogDebug("cat_B") << "LogDebug    was used to send cat_B";
     LogTrace("cat_A") << "LogTrace    was used to send cat_A";

--- a/FWCore/MessageService/test/unit_test_outputs/standAloneWithMessageLogger.cerr
+++ b/FWCore/MessageService/test/unit_test_outputs/standAloneWithMessageLogger.cerr
@@ -18,10 +18,18 @@ LogProblem  was used to send cat_B
 threshold DEBUG
 %MSG-d cat_A: 
  standAloneTest.cpp:7
+
+%MSG
+%MSG-d cat_A: 
+ standAloneTest.cpp:8
+ LogDebug.log was called
+%MSG
+%MSG-d cat_A: 
+ standAloneTest.cpp:9
 LogDebug    was used to send cat_A
 %MSG
 %MSG-d cat_B: 
- standAloneTest.cpp:8
+ standAloneTest.cpp:10
 LogDebug    was used to send cat_B
 %MSG
 LogTrace    was used to send cat_A


### PR DESCRIPTION
#### PR description:

Fixed bug where using EDM_ML_DEBUG would cause LogDebug(...) with no trailing '<<' to not compile.
Extended a unit test to make sure it keeps compiling.

#### PR validation:

Code compiles and all framework unit tests pass.