### PR TITLE
Fix Run-2 equivalent pattern assignment (CCLUT-11)

### DIFF
--- a/L1Trigger/CSCTriggerPrimitives/src/CSCCathodeLCTProcessor.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCCathodeLCTProcessor.cc
@@ -1400,7 +1400,7 @@ void CSCCathodeLCTProcessor::runCCLUT(CSCCLCTDigi& digi) const {
   // look-up the unsigned values
   const unsigned positionCC(lutpos_[pattern]->lookup(comparatorCode));
   const unsigned slopeCC(lutslope_[pattern]->lookup(comparatorCode));
-  unsigned run2PatternCC(lutpatconv_[pattern]->lookup(comparatorCode));
+  const unsigned run2PatternCC(convertSlopeToRun2Pattern(slopeCC));
 
   // if the slope is negative, set bending to 0
   const bool slopeCCSign((slopeCC >> 4) & 0x1);
@@ -1422,9 +1422,6 @@ void CSCCathodeLCTProcessor::runCCLUT(CSCCLCTDigi& digi) const {
   digi.setSlope(slopeCCValue);
 
   // set the quasi Run-2 pattern - to accommodate integration with EMTF/OMTF
-  if (run2PatternCC == 0) {
-    run2PatternCC = convertSlopeToRun2Pattern(slopeCC);
-  }
   digi.setPattern(run2PatternCC);
 
   // now print out the new CLCT for debugging
@@ -1443,7 +1440,7 @@ void CSCCathodeLCTProcessor::runCCLUT(CSCCLCTDigi& digi) const {
 }
 
 unsigned CSCCathodeLCTProcessor::convertSlopeToRun2Pattern(const unsigned slope) const {
-  const unsigned slopeList[32] = {2,  2,  2, 4, 4, 4, 6, 6, 6, 6, 8, 8, 8, 8, 10, 10,
-                                  10, 10, 9, 9, 9, 9, 7, 7, 7, 7, 5, 5, 5, 3, 3,  3};
+  const unsigned slopeList[32] = {10, 10, 8, 8, 8, 8, 6, 6, 6, 6, 4, 4, 4, 2, 2, 2,
+                                  10, 10, 9, 9, 9, 9, 7, 7, 7, 7, 5, 5, 5, 3, 3, 3};
   return slopeList[slope];
 }


### PR DESCRIPTION
#### PR description:

Small change in a LUT. Run-3 pattern no. 4 (straight) was incorrectly being mapped to Run-2 pattern no. 2 (left bending).

#### PR validation:

Tested with 1000 events of `/store/relval/CMSSW_11_2_0/RelValSingleMuPt10/GEN-SIM-DIGI-RAW/112X_mcRun3_2021_realistic_v13-v1/10000/6e3329de-3404-4624-8227-9e48ab268f20.root`

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A

@tahuang1991 @msd14