### PR TITLE
Update unit tests for LLVM 11

### DIFF
--- a/PhysicsTools/PythonAnalysis/test/BuildFile.xml
+++ b/PhysicsTools/PythonAnalysis/test/BuildFile.xml
@@ -25,7 +25,7 @@
   <test name="testNumba" command="testNumba.py"/>
 </iftool>
 <iftool name="py2-llvmlite">
-  <test name="testLLVMLite" command="python -c 'import llvmlite'"/>
+  <test name="testLLVMLite" command="python3 -c 'import llvmlite'"/>
 </iftool>
 <iftool name="py2-numpy">
   <test name="testNumPy" command="python -c 'import numpy'"/>

--- a/Utilities/ReleaseScripts/test/test-clang-tidy.cc.yaml
+++ b/Utilities/ReleaseScripts/test/test-clang-tidy.cc.yaml
@@ -11,7 +11,6 @@ Diagnostics:
           Offset:          69
           Length:          1
           ReplacementText: nullptr
-    Level:           Warning
   - DiagnosticName:  modernize-use-nullptr
     DiagnosticMessage:
       Message:         use nullptr
@@ -22,7 +21,6 @@ Diagnostics:
           Offset:          206
           Length:          1
           ReplacementText: nullptr
-    Level:           Warning
   - DiagnosticName:  modernize-use-nullptr
     DiagnosticMessage:
       Message:         use nullptr
@@ -33,7 +31,6 @@ Diagnostics:
           Offset:          235
           Length:          1
           ReplacementText: nullptr
-    Level:           Warning
   - DiagnosticName:  modernize-use-override
     DiagnosticMessage:
       Message:         'prefer using ''override'' or (rarely) ''final'' instead of ''virtual'''
@@ -48,7 +45,6 @@ Diagnostics:
           Offset:          399
           Length:          0
           ReplacementText: ' override'
-    Level:           Warning
   - DiagnosticName:  modernize-use-override
     DiagnosticMessage:
       Message:         'prefer using ''override'' or (rarely) ''final'' instead of ''virtual'''
@@ -63,5 +59,4 @@ Diagnostics:
           Offset:          427
           Length:          0
           ReplacementText: ' override'
-    Level:           Warning
 ...

--- a/Utilities/ReleaseScripts/test/test-clang-tidy.cc.yaml
+++ b/Utilities/ReleaseScripts/test/test-clang-tidy.cc.yaml
@@ -11,6 +11,7 @@ Diagnostics:
           Offset:          69
           Length:          1
           ReplacementText: nullptr
+    Level:           Warning
   - DiagnosticName:  modernize-use-nullptr
     DiagnosticMessage:
       Message:         use nullptr
@@ -21,6 +22,7 @@ Diagnostics:
           Offset:          206
           Length:          1
           ReplacementText: nullptr
+    Level:           Warning
   - DiagnosticName:  modernize-use-nullptr
     DiagnosticMessage:
       Message:         use nullptr
@@ -31,6 +33,7 @@ Diagnostics:
           Offset:          235
           Length:          1
           ReplacementText: nullptr
+    Level:           Warning
   - DiagnosticName:  modernize-use-override
     DiagnosticMessage:
       Message:         'prefer using ''override'' or (rarely) ''final'' instead of ''virtual'''
@@ -45,6 +48,7 @@ Diagnostics:
           Offset:          399
           Length:          0
           ReplacementText: ' override'
+    Level:           Warning
   - DiagnosticName:  modernize-use-override
     DiagnosticMessage:
       Message:         'prefer using ''override'' or (rarely) ''final'' instead of ''virtual'''
@@ -59,4 +63,5 @@ Diagnostics:
           Offset:          427
           Length:          0
           ReplacementText: ' override'
+    Level:           Warning
 ...

--- a/Utilities/ReleaseScripts/test/test-clang-tidy.sh
+++ b/Utilities/ReleaseScripts/test/test-clang-tidy.sh
@@ -1,5 +1,6 @@
 #!/bin/bash -ex
 clang-tidy -export-fixes $CMSSW_BASE/test-clang-tidy.cc.yaml -header-filter "$CMSSW_BASE/src/.*" $CMSSW_BASE/src/Utilities/ReleaseScripts/test/test-clang-tidy.cc
 sed -i -e "s|$CMSSW_BASE/src/||" $CMSSW_BASE/test-clang-tidy.cc.yaml
+sed -i -e '/^    BuildDirectory/d' $CMSSW_BASE/test-clang-tidy.cc.yaml
 diff -u $CMSSW_BASE/test-clang-tidy.cc.yaml $CMSSW_BASE/src/Utilities/ReleaseScripts/test/test-clang-tidy.cc.yaml
 rm -f $CMSSW_BASE/test-clang-tidy.cc.yaml

--- a/Utilities/ReleaseScripts/test/test-clang-tidy.sh
+++ b/Utilities/ReleaseScripts/test/test-clang-tidy.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -ex
 clang-tidy -export-fixes $CMSSW_BASE/test-clang-tidy.cc.yaml -header-filter "$CMSSW_BASE/src/.*" $CMSSW_BASE/src/Utilities/ReleaseScripts/test/test-clang-tidy.cc
 sed -i -e "s|$CMSSW_BASE/src/||" $CMSSW_BASE/test-clang-tidy.cc.yaml
-sed -i -e '/^    BuildDirectory/d' $CMSSW_BASE/test-clang-tidy.cc.yaml
+sed -i -e '/^\s\s*BuildDirectory/d;/^\s\s*Level:/d' $CMSSW_BASE/test-clang-tidy.cc.yaml
 diff -u $CMSSW_BASE/test-clang-tidy.cc.yaml $CMSSW_BASE/src/Utilities/ReleaseScripts/test/test-clang-tidy.cc.yaml
 rm -f $CMSSW_BASE/test-clang-tidy.cc.yaml


### PR DESCRIPTION
#### PR description:

This is adjusting existing tests to LLVM 11. llvmlite support for py2 is removed so testLLVMlite is run with python3 only.
The clang tidy test is adding two new lines in the generated yaml, one is 'BuildDirectory' which is better not assumed what it should be.

 #### PR validation:

The tests are running

