### PR TITLE
Rename herwigpp tool to herwig7

### DIFF
--- a/GeneratorInterface/Herwig7Interface/BuildFile.xml
+++ b/GeneratorInterface/Herwig7Interface/BuildFile.xml
@@ -3,7 +3,7 @@
 <use name="boost"/>
 <use name="hepmc"/>
 <use name="thepeg"/>
-<use name="herwigpp"/>
+<use name="herwig7"/>
 <export>
 	<lib name="GeneratorInterfaceHerwig7Interface"/>
 </export>

--- a/GeneratorInterface/Herwig7Interface/plugins/BuildFile.xml
+++ b/GeneratorInterface/Herwig7Interface/plugins/BuildFile.xml
@@ -1,5 +1,5 @@
 <use name="SimDataFormats/GeneratorProducts"/>
-<use name="herwigpp"/>
+<use name="herwig7"/>
 <use name="GeneratorInterface/Herwig7Interface"/>
 <library name="GeneratorInterfaceHerwig7HadronizerPlugins" file="Herwig7Hadronizer.cc">
 	<use name="GeneratorInterface/Core"/>


### PR DESCRIPTION
#### PR description:

Rename external library herwigpp to herwig7 for consistency with pull request cms-sw/cmsdist#6709.

#### PR validation:

Tested with workflow 535 and matchbox test command command from Herwig twiki.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Backport of #32468 for use in UL production