### PR TITLE
Cleaning of ElectroWeakAnalysis in CMSSWReleaseDependency.rules

### DIFF
--- a/Utilities/ReleaseScripts/scripts/CMSSWReleaseDependency.rules
+++ b/Utilities/ReleaseScripts/scripts/CMSSWReleaseDependency.rules
@@ -129,7 +129,6 @@ TauAnalysis/MCEmbeddingTools/.* : GeneratorInterface/.*
 
 #f77compiler exception
 Generator.*                      : f77compiler
-ElectroWeakAnalysis/Utilities/.* : f77compiler
 
 #FastSim exception
 FastSimulation/.*                : FastSimulation/.*


### PR DESCRIPTION
#### PR description:

Cleaning of ElectroWeakAnalysis in CMSSWReleaseDependency.rules 

Follow-up of https://github.com/cms-sw/cmssw/pull/32917#issuecomment-781390708 by @smuzaffar :

>  Yes, cleanup Utilities/ReleaseScripts/scripts/CMSSWReleaseDependency.rules too but that can be done in e separate PR (once this PR is merged)

cc @cms-sw/core-l2 


#### PR validation:

`scram b runtests`

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

No backport expected