### PR TITLE
[HGCAL] TiclDebugger Analyzer

### DIFF
--- a/RecoHGCal/TICL/test/BuildFile.xml
+++ b/RecoHGCal/TICL/test/BuildFile.xml
@@ -1,0 +1,14 @@
+<use name="FWCore/Framework"/>
+<use name="FWCore/ParameterSet"/>
+<use name="DataFormats/HGCalReco"/>
+<use name="SimDataFormats/Track"/>
+<use name="SimDataFormats/Vertex"/>
+<use name="SimDataFormats/TrackingAnalysis"/>
+<use name="SimDataFormats/CaloAnalysis"/>
+<use name="SimDataFormats/CaloHit"/>
+<use name="SimDataFormats/CaloTest"/>
+<use name="Geometry/HcalTowerAlgo"/>
+<use name="Geometry/HGCalGeometry"/>
+<use name="Geometry/Records"/>
+<flags EDM_PLUGIN="1"/>
+<library   file="*.cc" name="testRecoHGCalTICL"> </library>

--- a/RecoHGCal/TICL/test/BuildFile.xml
+++ b/RecoHGCal/TICL/test/BuildFile.xml
@@ -7,5 +7,6 @@
 <use name="Geometry/HcalTowerAlgo"/>
 <use name="Geometry/HGCalGeometry"/>
 <use name="Geometry/Records"/>
+<use name="RecoLocalCalo/HGCalRecAlgos"/>
 <flags EDM_PLUGIN="1"/>
 <library   file="*.cc" name="testRecoHGCalTICL"> </library>

--- a/RecoHGCal/TICL/test/BuildFile.xml
+++ b/RecoHGCal/TICL/test/BuildFile.xml
@@ -1,12 +1,7 @@
 <use name="FWCore/Framework"/>
 <use name="FWCore/ParameterSet"/>
 <use name="DataFormats/HGCalReco"/>
-<use name="SimDataFormats/Track"/>
-<use name="SimDataFormats/Vertex"/>
-<use name="SimDataFormats/TrackingAnalysis"/>
-<use name="SimDataFormats/CaloAnalysis"/>
-<use name="SimDataFormats/CaloHit"/>
-<use name="SimDataFormats/CaloTest"/>
+<use name="DataFormats/TrackReco"/>
 <use name="Geometry/HcalTowerAlgo"/>
 <use name="Geometry/HGCalGeometry"/>
 <use name="Geometry/Records"/>

--- a/RecoHGCal/TICL/test/BuildFile.xml
+++ b/RecoHGCal/TICL/test/BuildFile.xml
@@ -2,6 +2,8 @@
 <use name="FWCore/ParameterSet"/>
 <use name="DataFormats/HGCalReco"/>
 <use name="DataFormats/TrackReco"/>
+<use name="DataFormats/Math"/>
+<use name="SimDataFormats/CaloAnalysis"/>
 <use name="Geometry/HcalTowerAlgo"/>
 <use name="Geometry/HGCalGeometry"/>
 <use name="Geometry/Records"/>

--- a/RecoHGCal/TICL/test/TiclDebugger.cc
+++ b/RecoHGCal/TICL/test/TiclDebugger.cc
@@ -46,7 +46,7 @@ private:
   void beginJob() override;
   void beginRun(const edm::Run&, const edm::EventSetup&) override;
   void analyze(const edm::Event&, const edm::EventSetup&) override;
-  void endRun(edm::Run const& iEvent, edm::EventSetup const&) override {};
+  void endRun(edm::Run const& iEvent, edm::EventSetup const&) override{};
   void endJob() override;
 
   const edm::InputTag trackstersMerge_;
@@ -131,54 +131,54 @@ void TiclDebugger::analyze(const edm::Event& iEvent, const edm::EventSetup& iSet
     std::vector<int> sorted_edges_idx(trackster.edges().size());
     iota(begin(sorted_edges_idx), end(sorted_edges_idx), 0);
     sort(begin(sorted_edges_idx), end(sorted_edges_idx), [&](int i, int j) {
-        int layers = rhtools_.lastLayer();
-        auto const & ed_i = trackster.edges()[i];
-        auto const & ed_j = trackster.edges()[j];
-        auto const & cl_i_in = layerClusters[ed_i[0]].hitsAndFractions()[0].first;
-        auto const & cl_i_out = layerClusters[ed_i[1]].hitsAndFractions()[0].first;
-        auto const & cl_j_in = layerClusters[ed_j[0]].hitsAndFractions()[0].first;
-        auto const & cl_j_out = layerClusters[ed_j[1]].hitsAndFractions()[0].first;
-        auto const layer_i_in = rhtools_.getLayerWithOffset(cl_i_in) + layers * ((rhtools_.zside(cl_i_in) + 1) >> 1) - 1;
-        auto const layer_i_out = rhtools_.getLayerWithOffset(cl_i_out) + layers * ((rhtools_.zside(cl_i_out) + 1) >> 1) - 1;
-        auto const layer_j_in = rhtools_.getLayerWithOffset(cl_j_in) + layers * ((rhtools_.zside(cl_j_in) + 1) >> 1) - 1;
-        auto const layer_j_out = rhtools_.getLayerWithOffset(cl_j_out) + layers * ((rhtools_.zside(cl_j_out) + 1) >> 1) - 1;
-        if (layer_i_in != layer_j_in)
-          return layer_i_in < layer_j_in;
-        else
-          return layer_i_out < layer_j_out;
+      int layers = rhtools_.lastLayer();
+      auto const& ed_i = trackster.edges()[i];
+      auto const& ed_j = trackster.edges()[j];
+      auto const& cl_i_in = layerClusters[ed_i[0]].hitsAndFractions()[0].first;
+      auto const& cl_i_out = layerClusters[ed_i[1]].hitsAndFractions()[0].first;
+      auto const& cl_j_in = layerClusters[ed_j[0]].hitsAndFractions()[0].first;
+      auto const& cl_j_out = layerClusters[ed_j[1]].hitsAndFractions()[0].first;
+      auto const layer_i_in = rhtools_.getLayerWithOffset(cl_i_in) + layers * ((rhtools_.zside(cl_i_in) + 1) >> 1) - 1;
+      auto const layer_i_out =
+          rhtools_.getLayerWithOffset(cl_i_out) + layers * ((rhtools_.zside(cl_i_out) + 1) >> 1) - 1;
+      auto const layer_j_in = rhtools_.getLayerWithOffset(cl_j_in) + layers * ((rhtools_.zside(cl_j_in) + 1) >> 1) - 1;
+      auto const layer_j_out =
+          rhtools_.getLayerWithOffset(cl_j_out) + layers * ((rhtools_.zside(cl_j_out) + 1) >> 1) - 1;
+      if (layer_i_in != layer_j_in)
+        return layer_i_in < layer_j_in;
+      else
+        return layer_i_out < layer_j_out;
     });
 
     for (auto p_idx : sorted_probs_idx) {
-      prob_id_str << "(" << particle_kind[p_idx] << "):" << std::fixed << std::setprecision(4) << probs[p_idx] << " "; 
+      prob_id_str << "(" << particle_kind[p_idx] << "):" << std::fixed << std::setprecision(4) << probs[p_idx] << " ";
     }
-    LogVerbatim("TICLDebugger")
-              << "\nTrksIdx: " << t << "\n bary: " << trackster.barycenter()
-              << " baryEta: " << trackster.barycenter().eta() << " baryPhi: " << trackster.barycenter().phi()
-              << "\n raw_energy: " << trackster.raw_energy() << " raw_em_energy: " << trackster.raw_em_energy()
-              << "\n raw_pt: " << trackster.raw_pt() << " raw_em_pt: " << trackster.raw_em_pt()
-              << "\n seedIdx: " << trackster.seedIndex() << "\n Probs: " << prob_id_str.str();
+    LogVerbatim("TICLDebugger") << "\nTrksIdx: " << t << "\n bary: " << trackster.barycenter()
+                                << " baryEta: " << trackster.barycenter().eta()
+                                << " baryPhi: " << trackster.barycenter().phi()
+                                << "\n raw_energy: " << trackster.raw_energy()
+                                << " raw_em_energy: " << trackster.raw_em_energy()
+                                << "\n raw_pt: " << trackster.raw_pt() << " raw_em_pt: " << trackster.raw_em_pt()
+                                << "\n seedIdx: " << trackster.seedIndex() << "\n Probs: " << prob_id_str.str();
     prob_id_str.str("");
     prob_id_str.clear();
     LogVerbatim("TICLDebugger") << "\n time: " << trackster.time() << "+/-" << trackster.timeError() << std::endl
-              << " vertices: " << trackster.vertices().size() << " average usage: "
-              << std::accumulate(
-                     std::begin(trackster.vertex_multiplicity()), std::end(trackster.vertex_multiplicity()), 0.) /
-                     trackster.vertex_multiplicity().size()
-              << std::endl;
+                                << " vertices: " << trackster.vertices().size() << " average usage: "
+                                << std::accumulate(std::begin(trackster.vertex_multiplicity()),
+                                                   std::end(trackster.vertex_multiplicity()),
+                                                   0.) /
+                                       trackster.vertex_multiplicity().size()
+                                << std::endl;
     LogVerbatim("TICLDebugger") << " link connections: " << trackster.edges().size() << std::endl;
-    auto dumpLayerCluster = [&layerClusters](hgcal::RecHitTools const & rhtools, int cluster_idx) {
-      auto const & cluster = layerClusters[cluster_idx];
+    auto dumpLayerCluster = [&layerClusters](hgcal::RecHitTools const& rhtools, int cluster_idx) {
+      auto const& cluster = layerClusters[cluster_idx];
       const auto firstHitDetId = cluster.hitsAndFractions()[0].first;
       int layers = rhtools.lastLayer();
       int lcLayerId =
-        rhtools.getLayerWithOffset(firstHitDetId) + layers * ((rhtools.zside(firstHitDetId) + 1) >> 1) - 1;
+          rhtools.getLayerWithOffset(firstHitDetId) + layers * ((rhtools.zside(firstHitDetId) + 1) >> 1) - 1;
 
-      LogVerbatim("TICLDebugger") << "Idx: " << cluster_idx
-        << "("
-        << lcLayerId << ", "
-        << cluster.hitsAndFractions().size() << ", "
-        << cluster.position()
-        << ") ";
+      LogVerbatim("TICLDebugger") << "Idx: " << cluster_idx << "(" << lcLayerId << ", "
+                                  << cluster.hitsAndFractions().size() << ", " << cluster.position() << ") ";
     };
     for (auto link : sorted_edges_idx) {
       LogVerbatim("TICLDebugger") << "(" << trackster.edges()[link][0] << ", " << trackster.edges()[link][1] << ")  ";
@@ -189,21 +189,19 @@ void TiclDebugger::analyze(const edm::Event& iEvent, const edm::EventSetup& iSet
     if (trackster.seedID().id() != 0) {
       auto const& track = tracks[trackster.seedIndex()];
       LogVerbatim("TICLDebugger") << " Seeding Track:" << std::endl;
-      LogVerbatim("TICLDebugger") << "   p: " << track.p() << " pt: " << track.pt()
-                << " charge: " << track.charge() << " eta: " << track.eta()
-                << " outerEta: " << track.outerEta() << " phi: " << track.phi() 
-                << " outerPhi: " << track.outerPhi()
-                << std::endl;
+      LogVerbatim("TICLDebugger") << "   p: " << track.p() << " pt: " << track.pt() << " charge: " << track.charge()
+                                  << " eta: " << track.eta() << " outerEta: " << track.outerEta()
+                                  << " phi: " << track.phi() << " outerPhi: " << track.outerPhi() << std::endl;
     }
     bestCaloParticleMatches(trackster);
     if (!bestCPMatches.empty()) {
-      LogVerbatim("TICLDebugger") << " Best CaloParticles Matches:" << std::endl;;
+      LogVerbatim("TICLDebugger") << " Best CaloParticles Matches:" << std::endl;
+      ;
       for (auto const& i : bestCPMatches) {
-        auto const & cp = caloParticles[i.first];
-        LogVerbatim("TICLDebugger") << "   " << i.first << "(" << i.second << "):" << cp.pdgId() 
-                  << " simCl size:" << cp.simClusters().size()
-                  << " energy:" << cp.energy() << " pt:" << cp.pt() 
-                  << " momentum:" << cp.momentum() << std::endl;
+        auto const& cp = caloParticles[i.first];
+        LogVerbatim("TICLDebugger") << "   " << i.first << "(" << i.second << "):" << cp.pdgId()
+                                    << " simCl size:" << cp.simClusters().size() << " energy:" << cp.energy()
+                                    << " pt:" << cp.pt() << " momentum:" << cp.momentum() << std::endl;
       }
       LogVerbatim("TICLDebugger") << std::endl;
     }
@@ -211,7 +209,9 @@ void TiclDebugger::analyze(const edm::Event& iEvent, const edm::EventSetup& iSet
 }
 
 void TiclDebugger::beginRun(edm::Run const&, edm::EventSetup const& es) {
-    edm::ESHandle<CaloGeometry> geom; es.get<CaloGeometryRecord>().get(geom); rhtools_.setGeometry(*geom);
+  edm::ESHandle<CaloGeometry> geom;
+  es.get<CaloGeometryRecord>().get(geom);
+  rhtools_.setGeometry(*geom);
 }
 
 void TiclDebugger::beginJob() {}

--- a/RecoHGCal/TICL/test/TiclDebugger.cc
+++ b/RecoHGCal/TICL/test/TiclDebugger.cc
@@ -204,7 +204,9 @@ void TiclDebugger::analyze(const edm::Event& iEvent, const edm::EventSetup& iSet
   }
 }
 
-void TiclDebugger::beginRun(edm::Run const&, edm::EventSetup const& es) { rhtools_.getEventSetup(es); }
+void TiclDebugger::beginRun(edm::Run const&, edm::EventSetup const& es) {
+    edm::ESHandle<CaloGeometry> geom; es.get<CaloGeometryRecord>().get(geom); rhtools_.setGeometry(*geom);
+}
 
 void TiclDebugger::beginJob() {}
 

--- a/RecoHGCal/TICL/test/TiclDebugger.cc
+++ b/RecoHGCal/TICL/test/TiclDebugger.cc
@@ -11,7 +11,6 @@
 #include <algorithm>
 
 // user include files
-#include "DataFormats/CaloRecHit/interface/CaloCluster.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
@@ -23,6 +22,7 @@
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
+#include "DataFormats/CaloRecHit/interface/CaloCluster.h"
 #include "DataFormats/ForwardDetId/interface/HGCalDetId.h"
 #include "DataFormats/HepMCCandidate/interface/GenParticle.h"
 #include "DataFormats/HGCalReco/interface/Trackster.h"
@@ -187,7 +187,8 @@ void TiclDebugger::analyze(const edm::Event& iEvent, const edm::EventSetup& iSet
       std::cout << " Seeding Track:" << std::endl;
       std::cout << "   p: " << track.p() << " pt: " << track.pt()
                 << " charge: " << track.charge() << " eta: " << track.eta()
-                << " outerEta: " << track.outerEta() << " phi: " << track.phi() << " outerPhi: " << track.outerPhi()
+                << " outerEta: " << track.outerEta() << " phi: " << track.phi() 
+                << " outerPhi: " << track.outerPhi()
                 << std::endl;
     }
     bestCaloParticleMatches(trackster);
@@ -195,9 +196,10 @@ void TiclDebugger::analyze(const edm::Event& iEvent, const edm::EventSetup& iSet
       std::cout << " Best CaloParticles Matches:" << std::endl;;
       for (auto const& i : bestCPMatches) {
         auto const & cp = caloParticles[i.first];
-        std::cout << "   " << i.first << "(" << i.second << "):" << cp.pdgId() << "|"
-                  << cp.simClusters().size() << "|"
-                  << cp.energy() << "|" << cp.pt() << "  " << std::endl;
+        std::cout << "   " << i.first << "(" << i.second << "):" << cp.pdgId() 
+                  << " simCl size:" << cp.simClusters().size()
+                  << " energy:" << cp.energy() << " pt:" << cp.pt() 
+                  << " momentum:" << cp.momentum() << std::endl;
       }
       std::cout << std::endl;
     }

--- a/RecoHGCal/TICL/test/TiclDebugger.cc
+++ b/RecoHGCal/TICL/test/TiclDebugger.cc
@@ -1,0 +1,130 @@
+//
+// Original Author:  Marco Rovere
+//         Created:  Fri May  1 07:21:02 CEST 2020
+//
+//
+//
+// system include files
+#include <memory>
+#include <iostream>
+#include <numeric>
+#include <algorithm>
+
+// user include files
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "DataFormats/ForwardDetId/interface/HGCalDetId.h"
+#include "DataFormats/HepMCCandidate/interface/GenParticle.h"
+#include "DataFormats/HGCalReco/interface/Trackster.h"
+#include "SimDataFormats/Track/interface/SimTrack.h"
+#include "SimDataFormats/Vertex/interface/SimVertex.h"
+#include "SimDataFormats/TrackingAnalysis/interface/TrackingParticle.h"
+#include "SimDataFormats/CaloAnalysis/interface/CaloParticle.h"
+#include "SimDataFormats/CaloHit/interface/PCaloHit.h"
+#include "SimDataFormats/CaloAnalysis/interface/SimCluster.h"
+
+#include "Geometry/HcalTowerAlgo/interface/HcalGeometry.h"
+#include "Geometry/HGCalGeometry/interface/HGCalGeometry.h"
+#include "Geometry/HGCalCommonData/interface/HGCalDDDConstants.h"
+#include "SimDataFormats/CaloTest/interface/HGCalTestNumbering.h"
+#include "Geometry/CaloTopology/interface/HGCalTopology.h"
+#include "Geometry/CaloGeometry/interface/CaloGeometry.h"
+#include "Geometry/Records/interface/CaloGeometryRecord.h"
+#include "Geometry/HcalCommonData/interface/HcalHitRelabeller.h"
+
+//
+// class declaration
+//
+
+class TiclDebugger : public edm::one::EDAnalyzer<> {
+public:
+  explicit TiclDebugger(const edm::ParameterSet&);
+  ~TiclDebugger() override;
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+private:
+  void beginJob() override;
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
+  void endJob() override;
+
+  edm::InputTag trackstersMerge_;
+  edm::EDGetTokenT<std::vector<ticl::Trackster>> trackstersMergeToken_;
+};
+
+TiclDebugger::TiclDebugger(const edm::ParameterSet& iConfig)
+    : trackstersMerge_(iConfig.getParameter<edm::InputTag>("trackstersMerge")) {
+  edm::ConsumesCollector&& iC = consumesCollector();
+  trackstersMergeToken_ = iC.consumes<std::vector<ticl::Trackster>>(trackstersMerge_);
+}
+
+TiclDebugger::~TiclDebugger() {}
+
+void TiclDebugger::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  static const char* particle_kind[] = {"gam", "e", "mu", "pi0", "h", "h0", "?", "!"};
+  using namespace edm;
+  using std::begin;
+  using std::end;
+  using std::iota;
+  using std::sort;
+
+  edm::Handle<std::vector<ticl::Trackster>> trackstersMergeH;
+
+  iEvent.getByToken(trackstersMergeToken_, trackstersMergeH);
+  auto const& tracksters = *trackstersMergeH.product();
+  std::vector<int> sorted_tracksters_idx(tracksters.size());
+  iota(begin(sorted_tracksters_idx), end(sorted_tracksters_idx), 0);
+  sort(begin(sorted_tracksters_idx), end(sorted_tracksters_idx), [&tracksters](int i, int j) {
+    return tracksters[i].raw_energy() > tracksters[j].raw_energy();
+  });
+
+  for (auto const & t : sorted_tracksters_idx) {
+    auto const & trackster = tracksters[t];
+    auto const & probs = trackster.id_probabilities();
+    // Sort probs in descending order
+    std::vector<int> sorted_probs_idx(probs.size());
+    iota(begin(sorted_probs_idx), end(sorted_probs_idx), 0);
+    sort(begin(sorted_probs_idx), end(sorted_probs_idx), [&probs](int i, int j) {
+      return probs[i] > probs[j];
+    });
+
+    std::cout << "TrksIdx: " << t << "\n bary: " << trackster.barycenter()
+      << " baryEta: " << trackster.barycenter().eta()
+      << " baryPhi: " << trackster.barycenter().phi()
+      << "\n raw_energy: " << trackster.raw_energy()
+      << " raw_em_energy: " << trackster.raw_em_energy()
+      << "\n raw_pt: " << trackster.raw_pt()
+      << " raw_em_pt: " << trackster.raw_em_pt()
+      << "\n seedIdx: " << trackster.seedIndex()
+      << "\n Probs: ";
+    for (auto p_idx : sorted_probs_idx) {
+      std::cout << "(" << particle_kind[p_idx] << "):" << probs[p_idx] << " ";
+    }
+    std::cout << "\n time: " << trackster.time() << "+/-" << trackster.timeError()
+      << std::endl;
+  }
+}
+
+void TiclDebugger::beginJob() {}
+
+void TiclDebugger::endJob() {}
+
+// ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
+void TiclDebugger::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.add<edm::InputTag>("trackstersMerge", edm::InputTag("ticlTrackstersMerge"));
+  desc.add<edm::InputTag>("tracks", edm::InputTag("generalTracks"));
+  descriptions.add("ticlDebugger", desc);
+}
+
+// define this as a plug-in
+DEFINE_FWK_MODULE(TiclDebugger);

--- a/RecoHGCal/TICL/test/ticlDebugger_cfg.py
+++ b/RecoHGCal/TICL/test/ticlDebugger_cfg.py
@@ -8,7 +8,7 @@ process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 from Configuration.AlCa.GlobalTag import GlobalTag
 process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase2_realistic_T15', '')
 
-process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(-1) )
+process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(1) )
 
 process.source = cms.Source("PoolSource",
     # replace 'myfile.root' with the source file you want to use
@@ -18,6 +18,7 @@ process.source = cms.Source("PoolSource",
 )
 
 process.load("RecoHGCal.TICL.ticlDebugger_cfi")
+process.load("SimGeneral.Debugging.caloParticleDebugger_cfi")
 
-process.p = cms.Path(process.ticlDebugger)
+process.p = cms.Path(process.ticlDebugger+process.caloParticleDebugger)
 

--- a/RecoHGCal/TICL/test/ticlDebugger_cfg.py
+++ b/RecoHGCal/TICL/test/ticlDebugger_cfg.py
@@ -20,5 +20,22 @@ process.source = cms.Source("PoolSource",
 process.load("RecoHGCal.TICL.ticlDebugger_cfi")
 process.load("SimGeneral.Debugging.caloParticleDebugger_cfi")
 
+# MessageLogger customizations
+process.MessageLogger.cerr.enable = False
+process.MessageLogger.cout.enable = False
+label = 'TICLDebugger'
+messageLogger = dict()
+main_key = '%sMessageLogger'%(label)
+messageLogger[main_key] = dict(
+        filename = '%s.log' % (label),
+        threshold = 'INFO',
+        default = dict(limit=0)
+        )
+messageLogger[main_key][label] = dict(limit=-1)
+# First create defaults
+setattr(process.MessageLogger.files, label, dict())
+# Then modify them
+setattr(process.MessageLogger.files, label, messageLogger[main_key])
+
 process.p = cms.Path(process.ticlDebugger+process.caloParticleDebugger)
 

--- a/RecoHGCal/TICL/test/ticlDebugger_cfg.py
+++ b/RecoHGCal/TICL/test/ticlDebugger_cfg.py
@@ -19,8 +19,6 @@ process.source = cms.Source("PoolSource",
 
 process.load("RecoHGCal.TICL.ticlDebugger_cfi")
 process.load("SimGeneral.Debugging.caloParticleDebugger_cfi")
-process.caloParticleDebugger.printTrackingP = True
-process.caloParticleDebugger.printSimTracks = True
 
 process.p = cms.Path(process.ticlDebugger+process.caloParticleDebugger)
 

--- a/RecoHGCal/TICL/test/ticlDebugger_cfg.py
+++ b/RecoHGCal/TICL/test/ticlDebugger_cfg.py
@@ -1,0 +1,23 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("TICLDEBUG")
+
+process.load("FWCore.MessageService.MessageLogger_cfi")
+process.load('Configuration.Geometry.GeometryExtended2026D49Reco_cff')
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase2_realistic_T15', '')
+
+process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(-1) )
+
+process.source = cms.Source("PoolSource",
+    # replace 'myfile.root' with the source file you want to use
+    fileNames = cms.untracked.vstring(
+        'file:step3.root'
+    )
+)
+
+process.load("RecoHGCal.TICL.ticlDebugger_cfi")
+
+process.p = cms.Path(process.ticlDebugger)
+

--- a/RecoHGCal/TICL/test/ticlDebugger_cfg.py
+++ b/RecoHGCal/TICL/test/ticlDebugger_cfg.py
@@ -19,6 +19,8 @@ process.source = cms.Source("PoolSource",
 
 process.load("RecoHGCal.TICL.ticlDebugger_cfi")
 process.load("SimGeneral.Debugging.caloParticleDebugger_cfi")
+process.caloParticleDebugger.printTrackingP = True
+process.caloParticleDebugger.printSimTracks = True
 
 process.p = cms.Path(process.ticlDebugger+process.caloParticleDebugger)
 


### PR DESCRIPTION
#### PR description:

This PR introduce the TiclDebugger which prints out information about HGCal Tracksters and their matching with the best CaloParticle. Compile with `scram b -v USER_CXXFLAGS="-D=EDM_ML_DEBUG"` to obtain `TICLDebugger.log`.
Example of printout here: https://cernbox.cern.ch/index.php/s/vjJ3ig5RZOIYz7n

#### PR validation:

No impact on workflows expected.

@rovere @lecriste @felicepantaleo 