### PR TITLE
migrate RecoPixelVertexing/PixelLowPtUtilities to esConsumes

### DIFF
--- a/RecoPixelVertexing/PixelLowPtUtilities/BuildFile.xml
+++ b/RecoPixelVertexing/PixelLowPtUtilities/BuildFile.xml
@@ -1,17 +1,19 @@
+<use name="CondFormats/DataRecord"/>
 <use name="CondFormats/SiPixelObjects"/>
+<use name="CondFormats/SiStripObjects"/>
+<use name="DataFormats/TrackerCommon"/>
 <use name="FWCore/Framework"/>
 <use name="FWCore/ParameterSet"/>
 <use name="FWCore/PluginManager"/>
 <use name="FWCore/Utilities"/>
 <use name="Geometry/Records"/>
 <use name="Geometry/TrackerGeometryBuilder"/>
-<use name="TrackingTools/PatternTools"/>
-<use name="RecoPixelVertexing/PixelTriplets"/>
-<use name="RecoPixelVertexing/PixelTrackFitting"/>
-<use name="TrackingTools/TrajectoryFiltering"/>
-<use name="TrackingTools/Records"/>
 <use name="MagneticField/Records"/>
-<use name="DataFormats/TrackerCommon"/>
+<use name="RecoPixelVertexing/PixelTrackFitting"/>
+<use name="RecoPixelVertexing/PixelTriplets"/>
+<use name="TrackingTools/PatternTools"/>
+<use name="TrackingTools/Records"/>
+<use name="TrackingTools/TrajectoryFiltering"/>
 <export>
   <lib name="1"/>
 </export>

--- a/RecoPixelVertexing/PixelLowPtUtilities/bin/PixelClusterShapeExtractor.cc
+++ b/RecoPixelVertexing/PixelLowPtUtilities/bin/PixelClusterShapeExtractor.cc
@@ -91,6 +91,10 @@ private:
   void analyzeSimHits(const edm::Event& ev, const edm::EventSetup& es) const;
   void analyzeRecTracks(const edm::Event& ev, const edm::EventSetup& es) const;
 
+  /// Tokens for ESconsumes
+  const edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> topoToken_;
+  const edm::ESGetToken<ClusterShapeHitFilter, CkfComponentsRecord> csfToken_;
+
   TFile* file;
 
   const bool hasSimHits;
@@ -143,7 +147,9 @@ void PixelClusterShapeExtractor::init() {
 
 /*****************************************************************************/
 PixelClusterShapeExtractor::PixelClusterShapeExtractor(const edm::ParameterSet& pset)
-    : hasSimHits(pset.getParameter<bool>("hasSimHits")),
+    : topoToken_(esConsumes()),
+      csfToken_(esConsumes(edm::ESInputTag("", "ClusterShapeHitFilter"))),
+      hasSimHits(pset.getParameter<bool>("hasSimHits")),
       hasRecTracks(pset.getParameter<bool>("hasRecTracks")),
       noBPIX1(pset.getParameter<bool>("noBPIX1")),
       tracks_token(hasRecTracks ? consumes<reco::TrackCollection>(pset.getParameter<edm::InputTag>("tracks"))
@@ -300,13 +306,8 @@ void PixelClusterShapeExtractor::processPixelRecHits(const SiPixelRecHitCollecti
 
 /*****************************************************************************/
 void PixelClusterShapeExtractor::analyzeSimHits(const edm::Event& ev, const edm::EventSetup& es) const {
-  edm::ESHandle<ClusterShapeHitFilter> shape;
-  es.get<CkfComponentsRecord>().get("ClusterShapeHitFilter", shape);
-  auto const& theClusterShape = *shape.product();
-
-  edm::ESHandle<TrackerTopology> tTopoHandle;
-  es.get<TrackerTopologyRcd>().get(tTopoHandle);
-  auto const& tkTpl = *tTopoHandle;
+  auto const& theClusterShape = es.getData(csfToken_);
+  auto const& tkTpl = es.getData(topoToken_);
 
   edm::Handle<SiPixelClusterShapeCache> clusterShapeCache;
   ev.getByToken(clusterShapeCache_token, clusterShapeCache);
@@ -329,13 +330,8 @@ void PixelClusterShapeExtractor::analyzeSimHits(const edm::Event& ev, const edm:
 
 /*****************************************************************************/
 void PixelClusterShapeExtractor::analyzeRecTracks(const edm::Event& ev, const edm::EventSetup& es) const {
-  edm::ESHandle<ClusterShapeHitFilter> shape;
-  es.get<CkfComponentsRecord>().get("ClusterShapeHitFilter", shape);
-  auto const& theClusterShape = *shape.product();
-
-  edm::ESHandle<TrackerTopology> tTopoHandle;
-  es.get<TrackerTopologyRcd>().get(tTopoHandle);
-  auto const& tkTpl = *tTopoHandle;
+  auto const& theClusterShape = es.getData(csfToken_);
+  auto const& tkTpl = es.getData(topoToken_);
 
   // Get tracks
   edm::Handle<reco::TrackCollection> tracks;

--- a/RecoPixelVertexing/PixelLowPtUtilities/interface/PixelTripletLowPtGenerator.h
+++ b/RecoPixelVertexing/PixelLowPtUtilities/interface/PixelTripletLowPtGenerator.h
@@ -7,6 +7,11 @@
     provided Layers
  */
 
+#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
+#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+#include "Geometry/Records/interface/TrackerTopologyRcd.h"
+
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/EDGetToken.h"
@@ -41,6 +46,9 @@ public:
                    const int nThirdLayers) override;
 
 private:
+  edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> m_geomToken;
+  edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> m_topoToken;
+
   void getTracker(const edm::EventSetup& es);
   GlobalPoint getGlobalPosition(const TrackingRecHit* recHit);
 

--- a/RecoPixelVertexing/PixelLowPtUtilities/interface/StripSubClusterShapeTrajectoryFilter.h
+++ b/RecoPixelVertexing/PixelLowPtUtilities/interface/StripSubClusterShapeTrajectoryFilter.h
@@ -9,6 +9,8 @@
 #include "FWCore/Utilities/interface/EDGetToken.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "RecoTracker/TkSeedingLayers/interface/SeedComparitor.h"
+#include "CondFormats/SiStripObjects/interface/SiStripNoises.h"
+#include "CondFormats/DataRecord/interface/SiStripNoisesRcd.h"
 
 class ClusterShapeHitFilter;
 class TrackerTopology;
@@ -39,6 +41,12 @@ protected:
                    const GlobalPoint &gpos,
                    const GlobalVector &gdir,
                    bool mustProject = false) const;
+
+  // esConsumes tokens
+  edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> topoToken_;
+  edm::ESGetToken<ClusterShapeHitFilter, CkfComponentsRecord> csfToken_;
+  edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> geomToken_;
+  edm::ESGetToken<SiStripNoises, SiStripNoisesRcd> stripNoiseToken_;
 
   // who am i
   std::string label_;

--- a/RecoPixelVertexing/PixelLowPtUtilities/plugins/PixelVertexProducerClusters.cc
+++ b/RecoPixelVertexing/PixelLowPtUtilities/plugins/PixelVertexProducerClusters.cc
@@ -11,14 +11,11 @@
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 #include "Geometry/CommonDetUnit/interface/PixelGeomDetUnit.h"
 #include "Geometry/CommonTopologies/interface/PixelTopology.h"
-#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
+
 #include "Geometry/CommonDetUnit/interface/GeomDet.h"
 
 #include "DataFormats/GeometryVector/interface/LocalPoint.h"
 #include "DataFormats/GeometryVector/interface/GlobalPoint.h"
-
-#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
-#include "Geometry/Records/interface/TrackerTopologyRcd.h"
 
 #include "SimDataFormats/Vertex/interface/SimVertexContainer.h"
 
@@ -56,7 +53,7 @@ namespace {
 
 /*****************************************************************************/
 PixelVertexProducerClusters::PixelVertexProducerClusters(const edm::ParameterSet& ps)
-    : pixelToken_(consumes<SiPixelRecHitCollection>(edm::InputTag("siPixelRecHits"))) {
+    : geomToken_(esConsumes()), pixelToken_(consumes<SiPixelRecHitCollection>(edm::InputTag("siPixelRecHits"))) {
   // Product
   produces<reco::VertexCollection>();
 }
@@ -66,14 +63,8 @@ PixelVertexProducerClusters::~PixelVertexProducerClusters() {}
 
 /*****************************************************************************/
 void PixelVertexProducerClusters::produce(edm::StreamID, edm::Event& ev, const edm::EventSetup& es) const {
-  //Retrieve tracker topology from geometry
-  edm::ESHandle<TrackerTopology> tTopo;
-  es.get<TrackerTopologyRcd>().get(tTopo);
-
   // Get tracker geometry
-  edm::ESHandle<TrackerGeometry> trackerHandle;
-  es.get<TrackerDigiGeometryRecord>().get(trackerHandle);
-  const TrackerGeometry* theTracker = trackerHandle.product();
+  const TrackerGeometry* theTracker = &es.getData(geomToken_);
 
   // Get pixel hit collections
   edm::Handle<SiPixelRecHitCollection> pixelColl;

--- a/RecoPixelVertexing/PixelLowPtUtilities/plugins/PixelVertexProducerClusters.h
+++ b/RecoPixelVertexing/PixelLowPtUtilities/plugins/PixelVertexProducerClusters.h
@@ -1,9 +1,10 @@
 #ifndef PixelVertexProducerClusters_H
 #define PixelVertexProducerClusters_H
 
+#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
+#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 #include "FWCore/Framework/interface/global/EDProducer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-
 #include "DataFormats/TrackerRecHit2D/interface/SiPixelRecHitCollection.h"
 
 namespace edm {
@@ -21,6 +22,7 @@ public:
   void produce(edm::StreamID, edm::Event& ev, const edm::EventSetup& es) const override;
 
 private:
+  const edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> geomToken_;
   edm::EDGetTokenT<SiPixelRecHitCollection> pixelToken_;
 };
 #endif

--- a/RecoPixelVertexing/PixelLowPtUtilities/plugins/PixelVertexProducerMedian.cc
+++ b/RecoPixelVertexing/PixelLowPtUtilities/plugins/PixelVertexProducerMedian.cc
@@ -27,6 +27,7 @@ struct ComparePairs {
 
 /*****************************************************************************/
 PixelVertexProducerMedian::PixelVertexProducerMedian(const edm::ParameterSet& ps) : theConfig(ps) {
+  thePtMin = theConfig.getParameter<double>("PtMin");
   produces<reco::VertexCollection>();
 }
 
@@ -34,14 +35,12 @@ PixelVertexProducerMedian::PixelVertexProducerMedian(const edm::ParameterSet& ps
 PixelVertexProducerMedian::~PixelVertexProducerMedian() {}
 
 /*****************************************************************************/
-void PixelVertexProducerMedian::produce(edm::Event& ev, const edm::EventSetup& es) {
+void PixelVertexProducerMedian::produce(edm::StreamID, edm::Event& ev, const edm::EventSetup& es) const {
   // Get pixel tracks
   edm::Handle<reco::TrackCollection> trackCollection;
   std::string trackCollectionName = theConfig.getParameter<std::string>("TrackCollection");
   ev.getByLabel(trackCollectionName, trackCollection);
   const reco::TrackCollection tracks_ = *(trackCollection.product());
-
-  thePtMin = theConfig.getParameter<double>("PtMin");
 
   // Select tracks
   std::vector<const reco::Track*> tracks;

--- a/RecoPixelVertexing/PixelLowPtUtilities/plugins/PixelVertexProducerMedian.h
+++ b/RecoPixelVertexing/PixelLowPtUtilities/plugins/PixelVertexProducerMedian.h
@@ -1,7 +1,7 @@
 #ifndef PixelVertexProducerMedian_H
 #define PixelVertexProducerMedian_H
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 namespace edm {
@@ -9,11 +9,11 @@ namespace edm {
   class EventSetup;
 }  // namespace edm
 
-class PixelVertexProducerMedian : public edm::EDProducer {
+class PixelVertexProducerMedian : public edm::global::EDProducer<> {
 public:
   explicit PixelVertexProducerMedian(const edm::ParameterSet& ps);
   ~PixelVertexProducerMedian() override;
-  void produce(edm::Event& ev, const edm::EventSetup& es) override;
+  void produce(edm::StreamID, edm::Event& ev, const edm::EventSetup& es) const override;
 
 private:
   edm::ParameterSet theConfig;

--- a/RecoPixelVertexing/PixelLowPtUtilities/plugins/SiPixelClusterShapeCacheProducer.cc
+++ b/RecoPixelVertexing/PixelLowPtUtilities/plugins/SiPixelClusterShapeCacheProducer.cc
@@ -36,10 +36,11 @@ private:
   using InputCollection = edmNew::DetSetVector<SiPixelCluster>;
 
   const edm::EDGetTokenT<InputCollection> token_;
+  const edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> geomToken_;
 };
 
 SiPixelClusterShapeCacheProducer::SiPixelClusterShapeCacheProducer(const edm::ParameterSet& iConfig)
-    : token_(consumes<InputCollection>(iConfig.getParameter<edm::InputTag>("src"))) {
+    : token_(consumes<InputCollection>(iConfig.getParameter<edm::InputTag>("src"))), geomToken_(esConsumes()) {
   if (iConfig.getParameter<bool>("onDemand")) {
     throw cms::Exception("OnDemandNotAllowed")
         << "Use of the `onDemand` feature of SiPixelClusterShapeCacheProducer is no longer supported";
@@ -60,8 +61,7 @@ void SiPixelClusterShapeCacheProducer::produce(edm::StreamID, edm::Event& iEvent
   edm::Handle<InputCollection> input;
   iEvent.getByToken(token_, input);
 
-  edm::ESHandle<TrackerGeometry> geom;
-  iSetup.get<TrackerDigiGeometryRecord>().get(geom);
+  const auto& geom = &iSetup.getData(geomToken_);
 
   auto output = std::make_unique<SiPixelClusterShapeCache>(input);
   output->resize(input->data().size());


### PR DESCRIPTION
#### PR description:

Title says it all. 
Part of #31061.
I migrated only the "easy" ones.  Classes inheriting from base classes needing modifications outside of this package will have to be dealt with at a later time.

#### PR validation:

Run standard limited matrix validation:
```
runTheMatrix.py -l limited -j 8 --ibeos
```

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Not a backport, no backport needed
