### PR TITLE
Migrate rest of RecoLocalTracker to esConsumes

### DIFF
--- a/RecoLocalTracker/Phase2TrackerRecHits/plugins/Phase2TrackerRecHits.cc
+++ b/RecoLocalTracker/Phase2TrackerRecHits/plugins/Phase2TrackerRecHits.cc
@@ -34,13 +34,16 @@ public:
   void produce(edm::StreamID sid, edm::Event& event, const edm::EventSetup& eventSetup) const final;
 
 private:
+  edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> const tTrackerGeom_;
+  edm::ESGetToken<ClusterParameterEstimator<Phase2TrackerCluster1D>, TkPhase2OTCPERecord> const tCPE_;
+
   edm::EDGetTokenT<Phase2TrackerCluster1DCollectionNew> token_;
-  edm::ESInputTag cpeTag_;
 };
 
 Phase2TrackerRecHits::Phase2TrackerRecHits(edm::ParameterSet const& conf)
-    : token_(consumes<Phase2TrackerCluster1DCollectionNew>(conf.getParameter<edm::InputTag>("src"))),
-      cpeTag_(conf.getParameter<edm::ESInputTag>("Phase2StripCPE")) {
+    : tTrackerGeom_(esConsumes<TrackerGeometry, TrackerDigiGeometryRecord>()),
+      tCPE_(esConsumes(conf.getParameter<edm::ESInputTag>("Phase2StripCPE"))),
+      token_(consumes<Phase2TrackerCluster1DCollectionNew>(conf.getParameter<edm::InputTag>("src"))) {
   produces<Phase2TrackerRecHit1DCollectionNew>();
 }
 
@@ -50,13 +53,10 @@ void Phase2TrackerRecHits::produce(edm::StreamID sid, edm::Event& event, const e
   event.getByToken(token_, clusters);
 
   // load the cpe via the eventsetup
-  edm::ESHandle<ClusterParameterEstimator<Phase2TrackerCluster1D> > cpe;
-  eventSetup.get<TkPhase2OTCPERecord>().get(cpeTag_, cpe);
+  const auto& cpe = &eventSetup.getData(tCPE_);
 
   // Get the geometry
-  edm::ESHandle<TrackerGeometry> geomHandle;
-  eventSetup.get<TrackerDigiGeometryRecord>().get(geomHandle);
-  const TrackerGeometry* tkGeom(&(*geomHandle));
+  const TrackerGeometry* tkGeom = &eventSetup.getData(tTrackerGeom_);
 
   // Global container for the RecHits of each module
   auto outputRecHits = std::make_unique<Phase2TrackerRecHit1DCollectionNew>();

--- a/RecoLocalTracker/SubCollectionProducers/interface/PixelClusterSelectorTopBottom.h
+++ b/RecoLocalTracker/SubCollectionProducers/interface/PixelClusterSelectorTopBottom.h
@@ -13,8 +13,6 @@
 #include "FWCore/Framework/interface/global/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "DataFormats/Common/interface/Handle.h"
-#include "FWCore/Framework/interface/ESHandle.h"
-
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 #include "DataFormats/SiPixelCluster/interface/SiPixelCluster.h"
@@ -28,7 +26,8 @@
 class PixelClusterSelectorTopBottom : public edm::global::EDProducer<> {
 public:
   explicit PixelClusterSelectorTopBottom(const edm::ParameterSet& cfg)
-      : token_(consumes<SiPixelClusterCollectionNew>(cfg.getParameter<edm::InputTag>("label"))),
+      : tTrackerGeom_(esConsumes<TrackerGeometry, TrackerDigiGeometryRecord>()),
+        token_(consumes<SiPixelClusterCollectionNew>(cfg.getParameter<edm::InputTag>("label"))),
         y_(cfg.getParameter<double>("y")) {
     produces<SiPixelClusterCollectionNew>();
   }
@@ -36,6 +35,7 @@ public:
   void produce(edm::StreamID, edm::Event& event, const edm::EventSetup& setup) const override;
 
 private:
+  edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> const tTrackerGeom_;
   edm::EDGetTokenT<SiPixelClusterCollectionNew> token_;
   double y_;
 };

--- a/RecoLocalTracker/SubCollectionProducers/interface/StripClusterSelectorTopBottom.h
+++ b/RecoLocalTracker/SubCollectionProducers/interface/StripClusterSelectorTopBottom.h
@@ -13,7 +13,6 @@
 #include "FWCore/Framework/interface/global/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "DataFormats/Common/interface/Handle.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
@@ -29,7 +28,8 @@
 class StripClusterSelectorTopBottom : public edm::global::EDProducer<> {
 public:
   explicit StripClusterSelectorTopBottom(const edm::ParameterSet& cfg)
-      : token_(consumes<edmNew::DetSetVector<SiStripCluster>>(cfg.getParameter<edm::InputTag>("label"))),
+      : tTrackerGeom_(esConsumes<TrackerGeometry, TrackerDigiGeometryRecord>()),
+        token_(consumes<edmNew::DetSetVector<SiStripCluster>>(cfg.getParameter<edm::InputTag>("label"))),
         y_(cfg.getParameter<double>("y")) {
     produces<edmNew::DetSetVector<SiStripCluster>>();
   }
@@ -37,6 +37,7 @@ public:
   void produce(edm::StreamID, edm::Event& event, const edm::EventSetup& setup) const override;
 
 private:
+  edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> const tTrackerGeom_;
   edm::EDGetTokenT<edmNew::DetSetVector<SiStripCluster>> token_;
   double y_;
 };

--- a/RecoLocalTracker/SubCollectionProducers/src/PixelClusterSelectorTopBottom.cc
+++ b/RecoLocalTracker/SubCollectionProducers/src/PixelClusterSelectorTopBottom.cc
@@ -5,9 +5,7 @@ void PixelClusterSelectorTopBottom::produce(edm::StreamID, edm::Event& event, co
   edm::Handle<SiPixelClusterCollectionNew> input;
   event.getByToken(token_, input);
 
-  edm::ESHandle<TrackerGeometry> geom;
-  setup.get<TrackerDigiGeometryRecord>().get(geom);
-  const TrackerGeometry& theTracker(*geom);
+  const TrackerGeometry& theTracker = setup.getData(tTrackerGeom_);
 
   auto output = std::make_unique<SiPixelClusterCollectionNew>();
 

--- a/RecoLocalTracker/SubCollectionProducers/src/SeedClusterRemover.cc
+++ b/RecoLocalTracker/SubCollectionProducers/src/SeedClusterRemover.cc
@@ -1,7 +1,6 @@
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 
@@ -39,6 +38,7 @@ public:
   void produce(edm::Event &iEvent, const edm::EventSetup &iSetup) override;
 
 private:
+  edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> const tTrackerGeom_;
   struct ParamBlock {
     ParamBlock() : isSet_(false), usesCharge_(false) {}
     ParamBlock(const edm::ParameterSet &iConfig)
@@ -111,7 +111,8 @@ void SeedClusterRemover::readPSet(
 }
 
 SeedClusterRemover::SeedClusterRemover(const ParameterSet &iConfig)
-    : doStrip_(iConfig.existsAs<bool>("doStrip") ? iConfig.getParameter<bool>("doStrip") : true),
+    : tTrackerGeom_(esConsumes<TrackerGeometry, TrackerDigiGeometryRecord>()),
+      doStrip_(iConfig.existsAs<bool>("doStrip") ? iConfig.getParameter<bool>("doStrip") : true),
       doPixel_(iConfig.existsAs<bool>("doPixel") ? iConfig.getParameter<bool>("doPixel") : true),
       mergeOld_(iConfig.exists("oldClusterRemovalInfo")) {
   fill(pblocks_, pblocks_ + NumberOfParamBlocks, ParamBlock());
@@ -235,8 +236,7 @@ void SeedClusterRemover::process(const TrackingRecHit *hit, float chi2, const Tr
 }
 
 void SeedClusterRemover::produce(Event &iEvent, const EventSetup &iSetup) {
-  edm::ESHandle<TrackerGeometry> tgh;
-  iSetup.get<TrackerDigiGeometryRecord>().get("", tgh);  //is it correct to use "" ?
+  const auto &tgh = &iSetup.getData(tTrackerGeom_);
 
   Handle<edmNew::DetSetVector<SiPixelCluster> > pixelClusters;
   if (doPixel_) {
@@ -283,7 +283,7 @@ void SeedClusterRemover::produce(Event &iEvent, const EventSetup &iSetup) {
     for (auto const &hit : seed.recHits()) {
       if (!hit.isValid())
         continue;
-      process(&hit, 0., tgh.product());
+      process(&hit, 0., tgh);
     }
   }
 

--- a/RecoLocalTracker/SubCollectionProducers/src/StripClusterSelectorTopBottom.cc
+++ b/RecoLocalTracker/SubCollectionProducers/src/StripClusterSelectorTopBottom.cc
@@ -5,9 +5,7 @@ void StripClusterSelectorTopBottom::produce(edm::StreamID, edm::Event& event, co
   edm::Handle<edmNew::DetSetVector<SiStripCluster>> input;
   event.getByToken(token_, input);
 
-  edm::ESHandle<TrackerGeometry> geom;
-  setup.get<TrackerDigiGeometryRecord>().get(geom);
-  const TrackerGeometry& theTracker(*geom);
+  const TrackerGeometry& theTracker = setup.getData(tTrackerGeom_);
 
   auto output = std::make_unique<edmNew::DetSetVector<SiStripCluster>>();
 


### PR DESCRIPTION
#### PR description:

Title says it all, follows the migrations done for Strips at PR https://github.com/cms-sw/cmssw/pull/31826 and for Pixels at PR https://github.com/cms-sw/cmssw/pull/32093.

#### PR validation:

It compiles.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Not a backport, no backport is needed.
