### PR TITLE
If SecondaryEventProvider has no modules do not create a task

### DIFF
--- a/Mixing/Base/src/SecondaryEventProvider.cc
+++ b/Mixing/Base/src/SecondaryEventProvider.cc
@@ -17,9 +17,12 @@ namespace {
                             bool cleaningUpAfterException = false) {
     manager.resetAll();
 
+    if (manager.allWorkers().empty())
+      return;
+
+    auto token = edm::ServiceRegistry::instance().presentToken();
     std::exception_ptr exceptPtr = edm::syncWait([&](edm::WaitingTaskHolder&& iHolder) {
-      manager.processOneOccurrenceAsync<T, U>(
-          std::move(iHolder), info, edm::ServiceRegistry::instance().presentToken(), streamID, topContext, context);
+      manager.processOneOccurrenceAsync<T, U>(std::move(iHolder), info, token, streamID, topContext, context);
     });
 
     if (exceptPtr) {


### PR DESCRIPTION
#### PR description:

edm::syncWait is always required to create at least one TBB task and then wait on it (which can cause other modules to be run on top of the module using SecondaryEventProvider). To avoid that in the case where there are no modules in SecondaryEventProvider we first check that condition and if so immediately return from the member functions.

This fixes the problem where the Timing service and the MessageLogger were both failing.

#### PR validation:

The code compiles and running step 1 of workflow 250406.17 using 4 threads,  which was failing each time it was run, succeded 3 times in a row when run using the fix.