### PR TITLE
restrict FastTimerService to default arena

### DIFF
--- a/HLTrigger/Timer/plugins/FastTimerService.cc
+++ b/HLTrigger/Timer/plugins/FastTimerService.cc
@@ -766,7 +766,8 @@ void FastTimerService::PlotsPerJob::fill_lumi(AtomicResources const& data, unsig
 ///////////////////////////////////////////////////////////////////////////////
 
 FastTimerService::FastTimerService(const edm::ParameterSet& config, edm::ActivityRegistry& registry)
-    :  // configuration
+    : tbb::task_scheduler_observer(true),
+      // configuration
       callgraph_(),
       // job configuration
       concurrent_lumis_(0),


### PR DESCRIPTION
#### PR description:

This makes the FastTimerService tbb::task_scheduler_observer local to the primary arena.  This fixes the problem with crashes at the end of the job following #32804 and covered in issue #33107.

#### PR validation:

It compiles, and running step 3 of 136.885501, which was failing 20-50% of the time depending on platform, has run without crashes in dozens of test runs.