### PR TITLE
Devirtualize PFBlockElement daughter classes

### DIFF
--- a/DataFormats/ParticleFlowReco/interface/PFBlockElementBrem.h
+++ b/DataFormats/ParticleFlowReco/interface/PFBlockElementBrem.h
@@ -14,7 +14,7 @@ namespace reco {
   /// \brief Track Element.
   ///
   /// this class contains a reference to a PFRecTrack
-  class PFBlockElementBrem : public PFBlockElement {
+  class PFBlockElementBrem final : public PFBlockElement {
   public:
     PFBlockElementBrem() {}
 

--- a/DataFormats/ParticleFlowReco/interface/PFBlockElementCluster.h
+++ b/DataFormats/ParticleFlowReco/interface/PFBlockElementCluster.h
@@ -13,7 +13,7 @@ namespace reco {
   /// \brief Cluster Element.
   ///
   /// this class contains a reference to a PFCluster
-  class PFBlockElementCluster : public PFBlockElement {
+  class PFBlockElementCluster final : public PFBlockElement {
   public:
     PFBlockElementCluster() {}
 

--- a/DataFormats/ParticleFlowReco/interface/PFBlockElementGsfTrack.h
+++ b/DataFormats/ParticleFlowReco/interface/PFBlockElementGsfTrack.h
@@ -15,7 +15,7 @@ namespace reco {
   /// \brief Track Element.
   ///
   /// this class contains a reference to a PFRecTrack
-  class PFBlockElementGsfTrack : public PFBlockElement {
+  class PFBlockElementGsfTrack final : public PFBlockElement {
   public:
     PFBlockElementGsfTrack() {}
 
@@ -38,7 +38,9 @@ namespace reco {
         trackType_ = trackType_ ^ (1 << trType);
     }
 
-    bool isSecondary() const override { return trackType(T_FROM_GAMMACONV); }
+    static constexpr unsigned int kSecondaryMask = 1 << T_FROM_GAMMACONV;
+
+    bool isSecondary() const override { return trackType_ & kSecondaryMask; }
 
     /// \return reference to the corresponding PFGsfRecTrack
     const GsfPFRecTrackRef& GsftrackRefPF() const { return GsftrackRefPF_; }

--- a/DataFormats/ParticleFlowReco/interface/PFBlockElementSuperCluster.h
+++ b/DataFormats/ParticleFlowReco/interface/PFBlockElementSuperCluster.h
@@ -12,7 +12,7 @@ namespace reco {
   /// \brief Cluster Element.
   ///
   /// this class contains a reference to a PFCluster
-  class PFBlockElementSuperCluster : public PFBlockElement {
+  class PFBlockElementSuperCluster final : public PFBlockElement {
   public:
     PFBlockElementSuperCluster() {}
 

--- a/DataFormats/ParticleFlowReco/interface/PFBlockElementTrack.h
+++ b/DataFormats/ParticleFlowReco/interface/PFBlockElementTrack.h
@@ -48,14 +48,18 @@ namespace reco {
     /// \return reference to the corresponding Track
     const reco::TrackRef& trackRef() const override { return trackRef_; }
 
+    static constexpr unsigned int kPrimaryMask = 1 << T_TO_DISP;
+
+    static constexpr unsigned int kSecondaryMask = (1 << T_FROM_DISP) | (1 << T_FROM_GAMMACONV) | (1 << T_FROM_V0);
+
+    static constexpr unsigned int kLinkedToDisplacedVertexMask = kPrimaryMask | kSecondaryMask;
+
     /// check if the track is secondary
-    bool isSecondary() const override {
-      return trackType(T_FROM_DISP) | trackType(T_FROM_GAMMACONV) | trackType(T_FROM_V0);
-    }
+    bool isSecondary() const override { return trackType_ & kSecondaryMask; }
 
-    bool isPrimary() const override { return trackType(T_TO_DISP); }
+    bool isPrimary() const override { return trackType_ & kPrimaryMask; }
 
-    bool isLinkedToDisplacedVertex() const override { return isSecondary() | isPrimary(); }
+    bool isLinkedToDisplacedVertex() const override { return trackType_ & kLinkedToDisplacedVertexMask; }
 
     /// \return the displaced vertex associated
     const PFDisplacedTrackerVertexRef& displacedVertexRef(TrackType trType) const override {

--- a/DataFormats/ParticleFlowReco/interface/PFBlockElementTrack.h
+++ b/DataFormats/ParticleFlowReco/interface/PFBlockElementTrack.h
@@ -14,7 +14,7 @@ namespace reco {
   /// \brief Track Element.
   ///
   /// this class contains a reference to a PFRecTrack
-  class PFBlockElementTrack : public PFBlockElement {
+  class PFBlockElementTrack final : public PFBlockElement {
   public:
     PFBlockElementTrack() {}
 
@@ -50,12 +50,12 @@ namespace reco {
 
     /// check if the track is secondary
     bool isSecondary() const override {
-      return trackType(T_FROM_DISP) || trackType(T_FROM_GAMMACONV) || trackType(T_FROM_V0);
+      return trackType(T_FROM_DISP) | trackType(T_FROM_GAMMACONV) | trackType(T_FROM_V0);
     }
 
     bool isPrimary() const override { return trackType(T_TO_DISP); }
 
-    bool isLinkedToDisplacedVertex() const override { return isSecondary() || isPrimary(); }
+    bool isLinkedToDisplacedVertex() const override { return isSecondary() | isPrimary(); }
 
     /// \return the displaced vertex associated
     const PFDisplacedTrackerVertexRef& displacedVertexRef(TrackType trType) const override {


### PR DESCRIPTION
**PR description:**

This PR addresses the performance issues discussed in issue #33083. The `PFBlockElementTrack`, `PFBlockElementBrem`,  `PFBlockElementCluster`, `PFBlockElementSuperCluster`, and `PFBlockElementGsfTrack` daughter classes of `PFBlockElement` are devirtualized. Bitmasks are now used for `PFBlockElementGsfTrack::isSecondary` and in place of the logical operators used for `PFBlockElementTrack::isLinkedToDisplacedVertex`.


**PR validation:**

The performance was profiled with igprof using step 3 of matrix test 23434.21:

Base: https://msaunder.web.cern.ch/msaunder/cgi-bin/igprof-navigator/gitIssues/33083/step3_23434_21_base/1728
Final: https://msaunder.web.cern.ch/msaunder/cgi-bin/igprof-navigator/gitIssues/33083/step3_23434_21_final/3332

This is not a backport.

@hatakeyamak @bendavid @rappoccio @laurenhay 