### PR TITLE
[HGCAL] Updates on the RelVal campaign scripts

### DIFF
--- a/Validation/HGCalValidation/python/html.py
+++ b/Validation/HGCalValidation/python/html.py
@@ -99,6 +99,7 @@ _pageNameMap = {
     "hitCalibration": "Reconstructed hits calibration",
     "hitValidation" : "Simulated hits, digis, reconstructed hits validation" , 
     "hgcalLayerClusters": "Layer clusters",
+    "allTiclMultiClusters":"TICL multiclusters", 
     "ticlMultiClustersFromTrackstersEM": "Electromagnetic multiclusters",
     "ticlMultiClustersFromTrackstersHAD": "Hadronic multiclusters",
     "hgcalMultiClusters" : "Old multiclusters",
@@ -114,6 +115,7 @@ _sectionNameMapOrder = collections.OrderedDict([
     ("ticlMultiClustersFromTrackstersEM","Electromagnetic multiclusters"),
     # ticlMultiClustersFromTrackstersHAD
     ("ticlMultiClustersFromTrackstersHAD","Hadronic multiclusters"),
+    ("allTiclMultiClusters","TICL multiclusters"),
     # hgcalMultiClusters
     ("hgcalMultiClusters","Old multiclusters"),
 ])
@@ -122,34 +124,35 @@ _sectionNameMapOrder = collections.OrderedDict([
 _summary = {}
 
 #Objects to keep in summary
-_summobj = ['hitCalibration','hitValidation', 'hgcalLayerClusters','ticlMultiClustersFromTrackstersEM','ticlMultiClustersFromTrackstersHAD']
+#_summobj = ['hitCalibration','hitValidation', 'hgcalLayerClusters','ticlMultiClustersFromTrackstersEM','ticlMultiClustersFromTrackstersHAD']
+_summobj = ['hitCalibration','hitValidation', 'hgcalLayerClusters','allTiclMultiClusters']
 #_summobj = ['hitCalibration','hitValidation', 'hgcalLayerClusters']
 
 #Plots to keep in summary from hitCalibration
 summhitcalib=[
-    'Layer_Occupancy/LayerOccupancy_LayerOccupancy.png',
-    'ReconstructableEnergyOverCPenergy/ReconstructableEnergyOverCPenergy_h_EoP_CPene_300_calib_fraction.png',
-    'ReconstructableEnergyOverCPenergy/ReconstructableEnergyOverCPenergy_h_EoP_CPene_200_calib_fraction.png',
-    'ReconstructableEnergyOverCPenergy/ReconstructableEnergyOverCPenergy_h_EoP_CPene_100_calib_fraction.png',
-    'ReconstructableEnergyOverCPenergy/ReconstructableEnergyOverCPenergy_h_EoP_CPene_scint_calib_fraction.png'
+    'Layer_Occupancy/LayerOccupancy/LayerOccupancy.png',
+    'ReconstructableEnergyOverCPenergy/ReconstructableEnergyOverCPenergy/h_EoP_CPene_300_calib_fraction.png',
+    'ReconstructableEnergyOverCPenergy/ReconstructableEnergyOverCPenergy/h_EoP_CPene_200_calib_fraction.png',
+    'ReconstructableEnergyOverCPenergy/ReconstructableEnergyOverCPenergy/h_EoP_CPene_100_calib_fraction.png',
+    'ReconstructableEnergyOverCPenergy/ReconstructableEnergyOverCPenergy/h_EoP_CPene_scint_calib_fraction.png'
     ]
 
 #Plots to keep in summary from hitValidation
 summhitvalid = [
-    'SimHits_Validation/HitValidation_heeEnSim.png',
-    'SimHits_Validation/HitValidation_hebEnSim.png',
-    'SimHits_Validation/HitValidation_hefEnSim.png']
+    'SimHits_Validation/HitValidation/heeEnSim.png',
+    'SimHits_Validation/HitValidation/hebEnSim.png',
+    'SimHits_Validation/HitValidation/hefEnSim.png']
                           
 #Plots to keep in summary from layer clusters
 summlc = [
-    'Efficiencies_zminus/Efficiencies_zminus_globalEfficiencies.png' ,
-    'Efficiencies_zplus/Efficiencies_zplus_globalEfficiencies.png' ,
-    'Duplicates_zminus/Duplicates_zminus_globalEfficiencies.png' ,
-    'Duplicates_zplus/Duplicates_zplus_globalEfficiencies.png' ,
-    'FakeRate_zminus/FakeRate_zminus_globalEfficiencies.png' ,
-    'FakeRate_zplus/FakeRate_zplus_globalEfficiencies.png' ,
-    'MergeRate_zminus/MergeRate_zminus_globalEfficiencies.png' ,
-    'MergeRate_zplus/MergeRate_zplus_globalEfficiencies.png',
+    'hgcalLayerClusters_zminus/Efficiencies_vs_layer/globalEfficiencies.png' ,
+    'hgcalLayerClusters_zplus/Efficiencies_vs_layer/globalEfficiencies.png' ,
+    'hgcalLayerClusters_zminus/Duplicates_vs_layer/globalEfficiencies.png' ,
+    'hgcalLayerClusters_zplus/Duplicates_vs_layer/globalEfficiencies.png' ,
+    'hgcalLayerClusters_zminus/FakeRate_vs_layer/globalEfficiencies.png' ,
+    'hgcalLayerClusters_zplus/FakeRate_vs_layer/globalEfficiencies.png' ,
+    'hgcalLayerClusters_zminus/MergeRate_vs_layer/globalEfficiencies.png' ,
+    'hgcalLayerClusters_zplus/MergeRate_vs_layer/globalEfficiencies.png',
     'SelectedCaloParticles_Photons/SelectedCaloParticles_num_caloparticle_eta.png',
     'SelectedCaloParticles_Photons/SelectedCaloParticles_caloparticle_pt.png',
     'SelectedCaloParticles_Photons/SelectedCaloParticles_caloparticle_phi.png',
@@ -160,14 +163,21 @@ summlc = [
 
 #Plots to keep in summary from ticlMultiClustersFromTrackstersEM
 summmcEM = [
-    'Efficiencies/Efficiencies_globalEfficiencies.png' ,
-    'Duplicates/Duplicates_globalEfficiencies.png' ,
-    'FakeRate/FakeRate_globalEfficiencies.png' ,
-    'MergeRate/MergeRate_globalEfficiencies.png'
+    'ticlMultiClustersFromTrackstersEM/Efficiencies/globalEfficiencies.png' ,
+    'ticlMultiClustersFromTrackstersEM/Duplicates/globalEfficiencies.png' ,
+    'ticlMultiClustersFromTrackstersEM/FakeRate/globalEfficiencies.png' ,
+    'ticlMultiClustersFromTrackstersEM/MergeRate/globalEfficiencies.png'
 ]
 
 #Plots to keep in summary from ticlMultiClustersFromTrackstersHAD
-summmcHAD = summmcEM
+summmcHAD = [
+    'ticlMultiClustersFromTrackstersHAD/Efficiencies/globalEfficiencies.png' ,
+    'ticlMultiClustersFromTrackstersHAD/Duplicates/globalEfficiencies.png' ,
+    'ticlMultiClustersFromTrackstersHAD/FakeRate/globalEfficiencies.png' ,
+    'ticlMultiClustersFromTrackstersHAD/MergeRate/globalEfficiencies.png'
+]
+
+summmcTICL = summmcEM + summmcHAD
 
 #Plots to keep in summary from standalone analysis
 summstandalone = [
@@ -180,8 +190,105 @@ for obj in _summobj:
 _summary['hitCalibration'] = summhitcalib
 _summary['hitValidation'] = summhitvalid
 _summary['hgcalLayerClusters'] = summlc
-_summary['ticlMultiClustersFromTrackstersEM'] = summmcEM
-_summary['ticlMultiClustersFromTrackstersHAD'] = summmcHAD                          
+_summary['allTiclMultiClusters'] = summmcTICL
+#_summary['ticlMultiClustersFromTrackstersEM'] = summmcEM
+#_summary['ticlMultiClustersFromTrackstersHAD'] = summmcHAD                          
+
+#Entering the geometry section 
+#_MatBudSections = ["allhgcal","zminus","zplus","indimat","fromvertex"]
+_MatBudSections = ["allhgcal","indimat","fromvertex"]
+
+_geoPageNameMap = {
+ "allhgcal": "All materials",
+# "zminus" : "Zminus",
+# "zplus"  : "Zplus",
+ "indimat" : "Individual materials",
+ "fromvertex": "From vertex up to in front of muon stations"    
+}
+
+_individualmaterials =['Air','Aluminium','Cables','Copper','Epoxy','HGC_G10-FR4','Kapton','Lead','Other','Scintillator','Silicon','Stainless_Steel','WCu']
+
+_matPageNameMap = {
+ 'Air': 'Air',
+ 'Aluminium': 'Aluminium',
+ 'Cables': 'Cables',
+ 'Copper': 'Copper',
+ 'Epoxy': 'Epoxy',
+ 'HGC_G10-FR4': 'HGC_G10-FR4',
+ 'Kapton': 'Kapton',
+ 'Lead': 'Lead',
+ 'Other': 'Other',
+ 'Scintillator': 'Scintillator',
+ 'Silicon': 'Silicon',
+ 'Stainless_Steel': 'Stainless Steel',
+ 'WCu': 'WCu'
+}
+
+_individualmatplots = {"HGCal_x_vs_z_vs_Rsum","HGCal_l_vs_z_vs_Rsum","HGCal_x_vs_z_vs_Rsumcos","HGCal_l_vs_z_vs_Rsumcos","HGCal_x_vs_z_vs_Rloc","HGCal_l_vs_z_vs_Rloc"}
+
+_allmaterialsplots = {"HGCal_x_vs_eta","HGCal_l_vs_eta","HGCal_x_vs_phi","HGCal_l_vs_phi","HGCal_x_vs_R","HGCal_l_vs_R","HGCal_x_vs_eta_vs_phi","HGCal_l_vs_eta_vs_phi","HGCal_x_vs_z_vs_Rsum","HGCal_l_vs_z_vs_Rsum","HGCal_x_vs_z_vs_Rsumcos","HGCal_l_vs_z_vs_Rsumcos","HGCal_x_vs_z_vs_Rloc","HGCal_l_vs_z_vs_Rloc"}
+
+_fromvertexplots = {"HGCal_l_vs_eta","HGCal_l_vs_z_vs_Rsum","HGCal_l_vs_z_vs_Rsum_Zpluszoom"}
+
+_individualMatPlotsDesc = {
+"HGCal_x_vs_z_vs_Rsum" : "The plots below shows the 2D profile histogram for THEMAT in all HGCAL that displays the mean value of the material budget in units of radiation length in each R-z cell. R-z cell is 1 cm x 1 mm. The plots depict the accumulated material budget as seen by the track, as the track travels throughout the detector.",
+"HGCal_l_vs_z_vs_Rsum" : "The plots below shows the 2D profile histogram for THEMAT in all HGCAL that displays the mean value of the material budget in units of interaction length in each R-z cell. R-z cell is 1 cm x 1 mm. The plots depict the accumulated material budget as seen by the track, as the track travels throughout the detector.",
+"HGCal_x_vs_z_vs_Rsumcos" : "The plots below shows the 2D profile histogram for THEMAT in all HGCAL that displays the mean value of the material budget in units of radiation length in each R-z cell. R-z cell is 1 cm x 1 mm. The plots depict the orthogonal accumulated material budget, that is cos(theta) what the track sees. ",
+"HGCal_l_vs_z_vs_Rsumcos" : "The plots below shows the 2D profile histogram for THEMAT in all HGCAL that displays the mean value of the material budget in units of interaction length in each R-z cell. R-z cell is 1 cm x 1 mm. The plots depict the orthogonal accumulated material budget, that is cos(theta) what the track sees. ",
+"HGCal_x_vs_z_vs_Rloc" : "The plots below shows the 2D profile histogram for THEMAT in all HGCAL that displays the local mean value of the material budget in units of radiation length in each R-z cell. R-z cell is 1 cm x 1 mm. The plots depict the local material budget as seen by the track, as the track travels throughout the detector. ",
+"HGCal_l_vs_z_vs_Rloc" : "The plots below shows the 2D profile histogram for THEMAT in all HGCAL that displays the local mean value of the material budget in units of interaction length in each R-z cell. R-z cell is 1 cm x 1 mm. The plots depict the local material budget as seen by the track, as the track travels throughout the detector. "
+}
+
+_allmaterialsPlotsDesc= {
+    "HGCal_x_vs_eta" : "The plot on the left shows the stacked profile histograms of all materials in HGCal geometry. These profile histograms display the mean value of the material budget in units of radiation length in each eta bin. 250 bins in eta (-5,5), so eta is divided in 0.04 width bins. ",
+
+    "HGCal_l_vs_eta" : "The plot on the left shows the stacked profile histograms of all materials in HGCal geometry. These profile histograms display the mean value of the material budget in units of interaction length in each eta bin. 250 bins in eta (-5,5), so eta is divided in 0.04 width bins. ",
+
+    "HGCal_x_vs_phi" : "The plot on the left shows the stacked profile histograms of all materials in HGCal geometry. These profile histograms display the mean value of the material budget in units of radiation length in each phi bin. 180 bins in phi (-3.2,3.2), so phi is divided in 0.036 rad width bins or 2.038 degrees width bins. ",
+
+    "HGCal_l_vs_phi" : "The plot on the left shows the stacked profile histograms of all materials in HGCal geometry. These profile histograms display the mean value of the material budget in units of interaction length in each phi bin. 180 bins in phi -3.2,3.2), so phi is divided in 0.036 rad width bins or 2.038 degrees width bins. ",
+
+    "HGCal_x_vs_R" : "The plot on the left shows the stacked profile histograms of all materials in HGCal geometry. These profile histograms display the mean value of the material budget in units of radiation length in each radius bin. 300 bins in radius (0,3000 mm), so radius is defined in 1 cm width bins. Both endcaps are in this histogram. Entries are huge since the radius is filled for each step of the track. Statistics in the HEB part above 1565 mm is smaller (although non visible, error is small), since in most part nothing is infront to keep account of the step. ",
+
+    "HGCal_l_vs_R" : "The plot on the left shows the stacked profile histograms of all materials in HGCal geometry. These profile histograms display the mean value of the material budget in units of interaction length in each radius bin. 300 bins in radius (0,3000 mm), so radius is defined in 1 cm width bins. Both endcaps are in this histogram. Entries are huge since the radius is filled for each step of the track. Statistics in the HEB part above 1565 mm is smaller (although non visible, error is small), since in most part nothing is in front to keep account of the step. ", 
+
+    "HGCal_x_vs_eta_vs_phi" : "The plot on the left shows the 2D profile histogram that displays the mean value of the material budget in units of radiation length in each eta-phi cell. 180 bins in phi (-3.2,3.2), so phi is divided in 0.036 rad width bins or 2.038 degrees width bins. 250 bins in eta -5., 5., so eta is divided in 0.04 width bins. Therefore, eta-phi cell is 2.038 degrees x 0.04 . ",
+
+    "HGCal_l_vs_eta_vs_phi" : "The plot on the left shows the 2D profile histogram that displays the mean value of the material budget in units of interaction length in each eta-phi cell. 180 bins in phi (-3.2,3.2), so phi is divided in 0.036 rad width bins or 2.038 degrees width bins. 250 bins in eta -5., 5., so eta is divided in 0.04 width bins. Therefore, eta-phi cell is 2.038 degrees x 0.04 . ",
+    
+    "HGCal_x_vs_z_vs_Rsum" : "The plots below shows the 2D profile histogram that displays the mean value of the material budget in units of radiation length in each R-z cell. R-z cell is 1 cm x 1 mm. The plots depict the accumulated material budget as seen by the track, as the track travels throughout the detector.",
+    
+    "HGCal_l_vs_z_vs_Rsum" : "The plots below shows the 2D profile histogram that displays the mean value of the material budget in units of interaction length in each R-z cell. R-z cell is 1 cm x 1 mm. The plots depict the accumulated material budget as seen by the track, as the track travels throughout the detector.",
+    
+    "HGCal_x_vs_z_vs_Rsumcos" : "The plots below shows the 2D profile histogram that displays the mean value of the material budget in units of radiation length in each R-z cell. R-z cell is 1 cm x 1 mm. The plots depict the orthogonal accumulated material budget, that is cos(theta) what the track sees. ",
+    
+    "HGCal_l_vs_z_vs_Rsumcos" : "The plots below shows the 2D profile histogram that displays the mean value of the material budget in units of interaction length in each R-z cell. R-z cell is 1 cm x 1 mm. The plots depict the orthogonal accumulated material budget, that is cos(theta) what the track sees. " ,   
+    
+    "HGCal_x_vs_z_vs_Rloc" : "The plots below shows the 2D profile histogram that displays the local mean value of the material budget in units of radiation length in each R-z cell. R-z cell is 1 cm x 1 mm. The plots depict the local material budget as seen by the track, as the track travels throughout the detector. ",
+    
+    "HGCal_l_vs_z_vs_Rloc" : "The plots below shows the 2D profile histogram that displays the local mean value of the material budget in units of interaction length in each R-z cell. R-z cell is 1 cm x 1 mm. The plots depict the local material budget as seen by the track, as the track travels throughout the detector. "
+
+
+}
+
+_fromVertexPlotsDesc = {
+   "HGCal_x_vs_eta" : "The plot below shows the stacked profile histogram of all sub detectors in front of muon stations. This profile histogram displays the mean value of the material budget in units of radiation length in each eta bin. 250 bins in eta (-5,5), so eta is divided in 0.04 width bins. ",
+   
+   "HGCal_l_vs_eta" : "The plots below shows the stacked profile histogram of all sub detectors in front of muon stations. This profile histogram displays the mean value of the material budget in units of interaction length in each eta bin. 250 bins in eta (-5,5), so eta is divided in 0.04 width bins. ",
+
+   "HGCal_l_vs_z_vs_Rsum" : "The plots below shows the detectors that are taken into account in the calculation of the material budget. Keep in mind that coloured regions that depicts each sub-detector area may contain Air as material.",
+
+   "HGCal_l_vs_z_vs_Rsum_Zpluszoom" : "The zoomed plots below shows the detectors that are taken into account in the calculation of the material budget. Keep in mind that coloured regions that depicts each sub-detector area may contain Air as material."
+   
+
+
+}
+
+_hideShowFun = { 
+     "thestyle" : "<meta name=\"viewport\" content=\"width=device-width, initial-scale=1\"> \n <style> \n body {font-family: Arial;} \n.tab { \n  overflow: hidden; \n  border: 1px solid #ccc; \n  background-color: #f1f1f1;} \n .tab button {  background-color: inherit; \n  float: left; \n  border: none; \n  outline: none; \n  cursor: pointer; \n  padding: 14px 16px; \n  transition: 0.3s; \n  font-size: 17px; } \n .tab button:hover {  background-color: #ddd; } \n .tab button.active {  background-color: #ccc; } \n .tabcontent {  display: none; \n  padding: 6px 12px; \n  border: 1px solid #ccc; \n  border-top: none; \n} \n </style>",
+     "buttonandFunction" : "<script> \n function openRegion(evt, regionName) { \n  var i, tabcontent, tablinks;\n  tabcontent = document.getElementsByClassName(\"tabcontent\"); \n  for (i = 0; i < tabcontent.length; i++) {\n    tabcontent[i].style.display = \"none\";\n  }\n  tablinks = document.getElementsByClassName(\"tablinks\"); \n  for (i = 0; i < tablinks.length; i++) {\n    tablinks[i].className = tablinks[i].className.replace(\" active\", \"\"); \n  }\n  document.getElementById(regionName).style.display = \"block\";\n  evt.currentTarget.className += \" active\"; \n}\n</script>\n",
+     "divTabs" : "<div class=\"tab\">\n   <button class=\"tablinks\" onclick=\"openRegion(event, \'_AllHGCAL\')\">All HGCAL</button>\n   <button class=\"tablinks\" onclick=\"openRegion(event, \'_ZminusZoom\')\">Zminus</button>\n   <button class=\"tablinks\" onclick=\"openRegion(event, \'_ZplusZoom\')\">Zplus</button>\n </div>\n "
+} 
 
 
 

--- a/Validation/HGCalValidation/scripts/hgcalPerformanceValidation.py
+++ b/Validation/HGCalValidation/scripts/hgcalPerformanceValidation.py
@@ -17,8 +17,10 @@ import commands
 import optparse
 import pandas as pd
 
+from collections import OrderedDict
+
 from Validation.RecoTrack.plotting.validation import Sample, Validation
-from Validation.HGCalValidation.html import _sampleName,_pageNameMap,_summary,_summobj
+from Validation.HGCalValidation.html import _sampleName,_pageNameMap,_summary,_summobj,_MatBudSections,_geoPageNameMap,_individualmaterials,_matPageNameMap,_individualmatplots,_individualMatPlotsDesc,_hideShowFun,_allmaterialsplots,_allmaterialsPlotsDesc, _fromvertexplots, _fromVertexPlotsDesc
 
 #------------------------------------------------------------------------------------------
 #Parsing input options
@@ -35,6 +37,8 @@ def parseOptions():
     parser.add_option('-w', '--wwwarea', dest='WWWAREA',  type='string', default='/eos/project/h/hgcaldpg/www', help='Objects to gather: hitValidation, hitCalibration, hgcalLayerClusters, hgcalMultiClusters, ticlMultiClustersFromTrackstersEM, ticlMultiClustersFromTrackstersHAD')
     parser.add_option('-y', '--dry-run', action='store_true', dest='DRYRUN', default=False, help='perform a dry run (nothing is lauched).')
     parser.add_option('-i', '--inputeosarea', dest='INPUT',  type='string', default='/eos/cms/store/group/dpg_hgcal/comm_hgcal/apsallid/RelVals', help='Eos area where we will place all DQM files of the new and reference release campaign')
+    parser.add_option('', '--geometry', action='store_true', dest='GEOMETRY', default=False, help='Geometry validation section')
+    parser.add_option('', '--copyhtml', action='store_true', dest='COPYHTML', default=False, help='If used the main index.html file will be copied to the www area. Useful in case of experimenting to avoid surprises.')
 
     # store options and arguments as global variables
     global opt, args
@@ -78,7 +82,19 @@ def putype(t):
 #                                             will be placed.
 #------------------------------------------------------------------------------------------
 #thereleases = { "CMSSW 11_1_X" : ["CMSSW_11_1_0_pre4_GEANT4","CMSSW_11_1_0_pre3","CMSSW_11_1_0_pre2"] }
-thereleases = { "CMSSW 11_2_X" : [
+thereleases = OrderedDict()
+thereleases = { "CMSSW 11_3_X" : [
+    "CMSSW_11_3_0_pre3_G4VECGEOM_vs_CMSSW_11_3_0_pre3",
+    "CMSSW_11_3_0_pre3_D76_vs_CMSSW_11_3_0_pre3",
+    "CMSSW_11_3_0_pre3_vs_CMSSW_11_3_0_pre2",
+    "CMSSW_11_3_0_pre2_vs_CMSSW_11_3_0_pre1",
+    "CMSSW_11_3_0_pre1_vs_CMSSW_11_2_0_pre10",
+     		],
+		"CMSSW 11_2_X" : [
+    "CMSSW_11_2_0_vs_CMSSW_11_2_0_pre10",
+    "CMSSW_11_2_0_pre10_vs_CMSSW_11_2_0_pre9",
+    "CMSSW_11_2_0_pre9_vs_CMSSW_11_2_0_pre8",
+    "CMSSW_11_2_0_pre8_vs_CMSSW_11_2_0_pre7",
     "CMSSW_11_2_0_pre7_vs_CMSSW_11_2_0_pre6",
     "CMSSW_11_2_0_pre6_ROOT622_vs_CMSSW_11_2_0_pre6",
     "CMSSW_11_2_0_pre6_vs_CMSSW_11_2_0_pre5",
@@ -106,11 +122,20 @@ thereleases = { "CMSSW 11_2_X" : [
                ] 
 }
 
-RefRelease='CMSSW_11_2_0_pre7'
+geometryTests = OrderedDict()
+geometryTests = { "Material budget" : [
+                #"Extended2026D49_vs_Extended2026D71",
+                "Extended2026D49_vs_Extended2026D76"
+                ]
+}
 
-NewRelease='CMSSW_11_2_0_pre7'
+GeoScenario = "Extended2026D49_vs_Extended2026D76"
 
-NotNormalRelease = "raw"
+RefRelease='CMSSW_11_3_0_pre3'
+
+NewRelease='CMSSW_11_3_0_pre3_G4VECGEOM'
+
+NotNormalRelease = "normal"
 NotNormalRefRelease = "normal"
 
 if ( os.path.isdir('%s/%s' %(opt.WWWAREA, NewRelease))) : 
@@ -121,7 +146,8 @@ if ( os.path.isdir('%s/%s' %(opt.WWWAREA, NewRelease))) :
 if "raw" in NotNormalRelease: 
 #   appendglobaltag = "_2026D49noPU_raw1100_rsb"
 #   appendglobaltag = "_2026D49noPU_raw1100"
-   appendglobaltag = "_2026D49noPU_gcc900"
+#   appendglobaltag = "_2026D49noPU_gcc900"
+   appendglobaltag = "_2026D76noPU"
 else: 
    appendglobaltag = "_2026D49noPU"
 
@@ -173,6 +199,8 @@ phase2samples_noPU_oldnaming = [
 #Main workflow RelVals
 phase2samples_noPU = [
 
+    #------------------------------
+    #version v2 campaign
     #Sample("RelValZpTT_1500", midfix="14", scenario="2026D49", appendGlobalTag=appendglobaltag, version="v2" ),
     ##Sample("RelValZpTT_1500", midfix="14TeV", scenario="2026D49", appendGlobalTag=appendglobaltag, version="v2" ),
     #Sample("RelValZTT", midfix="14TeV", scenario="2026D49", appendGlobalTag=appendglobaltag, version="v2" ),
@@ -188,7 +216,8 @@ phase2samples_noPU = [
     #Sample("RelValMinBias", midfix="14TeV", scenario="2026D49", appendGlobalTag=appendglobaltag, version="v2" ),
     #Sample("RelValH125GGgluonfusion", midfix="14", scenario="2026D49", appendGlobalTag=appendglobaltag, version="v2" )
 
-
+    #------------------------------
+    #NORMAL version v1 campaign
     Sample("RelValZpTT_1500", midfix="14", scenario="2026D49", appendGlobalTag=appendglobaltag ),
     #Sample("RelValZpTT_1500", midfix="14TeV", scenario="2026D49", appendGlobalTag=appendglobaltag ),
     Sample("RelValZTT", midfix="14TeV", scenario="2026D49", appendGlobalTag=appendglobaltag ),
@@ -203,6 +232,7 @@ phase2samples_noPU = [
     #Sample("RelValMinBias", midfix="14", scenario="2026D49", appendGlobalTag=appendglobaltag ),
     Sample("RelValMinBias", midfix="14TeV", scenario="2026D49", appendGlobalTag=appendglobaltag ),
     Sample("RelValH125GGgluonfusion", midfix="14", scenario="2026D49", appendGlobalTag=appendglobaltag )
+    #------------------------------
 
 
 ]
@@ -228,33 +258,36 @@ phase2samples_noPU_extend = [
 #For the moment I cannot find these in pre7.
 phase2samples_noPU_extend_more = [
 
-    #Sample("RelValCloseByPGun_CE_H_Fine_300um", scenario="2026D49", appendGlobalTag=appendglobaltag, version="v2" ),
-    #Sample("RelValCloseByPGun_CE_H_Fine_200um", scenario="2026D49", appendGlobalTag=appendglobaltag, version="v2" ),
-    #Sample("RelValCloseByPGun_CE_H_Fine_120um", scenario="2026D49", appendGlobalTag=appendglobaltag, version="v2" ),
-    #Sample("RelValCloseByPGun_CE_H_Coarse_Scint", scenario="2026D49", appendGlobalTag=appendglobaltag, version="v2" ),
-    #Sample("RelValCloseByPGun_CE_H_Coarse_300um", scenario="2026D49", appendGlobalTag=appendglobaltag, version="v2" ),
-    #Sample("RelValCloseByPGun_CE_E_Front_300um", scenario="2026D49", appendGlobalTag=appendglobaltag, version="v2" ),
-    #Sample("RelValCloseByPGun_CE_E_Front_200um", scenario="2026D49", appendGlobalTag=appendglobaltag, version="v2" ),
-    #Sample("RelValCloseByPGun_CE_E_Front_120um", scenario="2026D49", appendGlobalTag=appendglobaltag, version="v2" ),
-    #Sample("RelValSingleGammaFlatPt8To150", scenario="2026D49", appendGlobalTag=appendglobaltag, version="v2" ),
-    #Sample("RelValSingleEFlatPt2To100", scenario="2026D49", appendGlobalTag=appendglobaltag, version="v2" ),
-    #Sample("RelValSinglePiFlatPt0p7To10", scenario="2026D49", appendGlobalTag=appendglobaltag, version="v2" )
+    #------------------------------
+    #version v2 campaign
+    Sample("RelValCloseByPGun_CE_H_Fine_300um", scenario="2026D49", appendGlobalTag=appendglobaltag, version="v2" ),
+    Sample("RelValCloseByPGun_CE_H_Fine_200um", scenario="2026D49", appendGlobalTag=appendglobaltag, version="v2" ),
+    Sample("RelValCloseByPGun_CE_H_Fine_120um", scenario="2026D49", appendGlobalTag=appendglobaltag, version="v2" ),
+    Sample("RelValCloseByPGun_CE_H_Coarse_Scint", scenario="2026D49", appendGlobalTag=appendglobaltag, version="v2" ),
+    Sample("RelValCloseByPGun_CE_H_Coarse_300um", scenario="2026D49", appendGlobalTag=appendglobaltag, version="v2" ),
+    Sample("RelValCloseByPGun_CE_E_Front_300um", scenario="2026D49", appendGlobalTag=appendglobaltag, version="v2" ),
+    Sample("RelValCloseByPGun_CE_E_Front_200um", scenario="2026D49", appendGlobalTag=appendglobaltag, version="v2" ),
+    Sample("RelValCloseByPGun_CE_E_Front_120um", scenario="2026D49", appendGlobalTag=appendglobaltag, version="v2" ),
+    Sample("RelValSingleGammaFlatPt8To150", scenario="2026D49", appendGlobalTag=appendglobaltag, version="v2" ),
+    Sample("RelValSingleEFlatPt2To100", scenario="2026D49", appendGlobalTag=appendglobaltag, version="v2" ),
+    Sample("RelValSinglePiFlatPt0p7To10", scenario="2026D49", appendGlobalTag=appendglobaltag, version="v2" )
 
 
-
-
-    Sample("RelValCloseByPGun_CE_H_Fine_300um", scenario="2026D49", appendGlobalTag=appendglobaltag ),
-    Sample("RelValCloseByPGun_CE_H_Fine_200um", scenario="2026D49", appendGlobalTag=appendglobaltag ),
-    Sample("RelValCloseByPGun_CE_H_Fine_120um", scenario="2026D49", appendGlobalTag=appendglobaltag ),
-    Sample("RelValCloseByPGun_CE_H_Coarse_Scint", scenario="2026D49", appendGlobalTag=appendglobaltag ),
-    Sample("RelValCloseByPGun_CE_H_Coarse_300um", scenario="2026D49", appendGlobalTag=appendglobaltag ),
-    Sample("RelValCloseByPGun_CE_E_Front_300um", scenario="2026D49", appendGlobalTag=appendglobaltag ),
-    Sample("RelValCloseByPGun_CE_E_Front_200um", scenario="2026D49", appendGlobalTag=appendglobaltag ),
-    Sample("RelValCloseByPGun_CE_E_Front_120um", scenario="2026D49", appendGlobalTag=appendglobaltag ),
-    Sample("RelValSingleGammaFlatPt8To150", scenario="2026D49", appendGlobalTag=appendglobaltag ),
-    Sample("RelValSingleEFlatPt2To100", scenario="2026D49", appendGlobalTag=appendglobaltag ),
-    Sample("RelValSinglePiFlatPt0p7To10", scenario="2026D49", appendGlobalTag=appendglobaltag )
-
+    
+    #------------------------------
+    #NORMAL version v1 campaign
+    #Sample("RelValCloseByPGun_CE_H_Fine_300um", scenario="2026D49", appendGlobalTag=appendglobaltag ),
+    #Sample("RelValCloseByPGun_CE_H_Fine_200um", scenario="2026D49", appendGlobalTag=appendglobaltag ),
+    #Sample("RelValCloseByPGun_CE_H_Fine_120um", scenario="2026D49", appendGlobalTag=appendglobaltag ),
+    #Sample("RelValCloseByPGun_CE_H_Coarse_Scint", scenario="2026D49", appendGlobalTag=appendglobaltag ),
+    #Sample("RelValCloseByPGun_CE_H_Coarse_300um", scenario="2026D49", appendGlobalTag=appendglobaltag ),
+    #Sample("RelValCloseByPGun_CE_E_Front_300um", scenario="2026D49", appendGlobalTag=appendglobaltag ),
+    #Sample("RelValCloseByPGun_CE_E_Front_200um", scenario="2026D49", appendGlobalTag=appendglobaltag ),
+    #Sample("RelValCloseByPGun_CE_E_Front_120um", scenario="2026D49", appendGlobalTag=appendglobaltag ),
+    #Sample("RelValSingleGammaFlatPt8To150", scenario="2026D49", appendGlobalTag=appendglobaltag ),
+    #Sample("RelValSingleEFlatPt2To100", scenario="2026D49", appendGlobalTag=appendglobaltag ),
+    #Sample("RelValSinglePiFlatPt0p7To10", scenario="2026D49", appendGlobalTag=appendglobaltag )
+    #------------------------------
 
     #Sample("RelValCloseByPGun_CE_H_Fine_300um", scenario="2026D49", appendGlobalTag=appendglobaltag + "_HGCal" ),
     #Sample("RelValCloseByPGun_CE_H_Fine_200um", scenario="2026D49", appendGlobalTag=appendglobaltag + "_HGCal" ),
@@ -288,6 +321,13 @@ phase2samples_noPU_extend_more = [
 phase2samples_noPU.extend(phase2samples_noPU_extend)
 phase2samples_noPU.extend(phase2samples_noPU_extend_more)
 #phase2samples_noPU.extend(phase2samples_noPU_oldnaming)
+
+phase2samples_noPU = phase2samples_noPU_extend_more
+
+#phase2samples_noPU = [
+#    Sample("RelValCloseByPGun_CE_E_Front_300um", scenario="2026D49", appendGlobalTag=appendglobaltag ),
+#    Sample("RelValCloseByPGun_CE_E_Front_200um", scenario="2026D49", appendGlobalTag=appendglobaltag )
+#]
 
 #For the PU samples 
 phase2samples_PU = [
@@ -334,7 +374,7 @@ if(opt.DOWNLOAD):
 #------------------------------------------------------------------------------------------
 
 #This is the hgcalLayerClusters, ticlMultiClustersFromTrackstersEM, ticlMultiClustersFromTrackstersHAD, and hitCalibration part
-if (opt.OBJ == 'hgcalLayerClusters' or opt.OBJ == 'hitCalibration' or opt.OBJ == 'ticlMultiClustersFromTrackstersEM' or opt.OBJ == 'ticlMultiClustersFromTrackstersHAD'):
+if (opt.OBJ == 'hgcalLayerClusters' or opt.OBJ == 'hitCalibration' or opt.OBJ == 'ticlMultiClustersFromTrackstersEM' or opt.OBJ == 'ticlMultiClustersFromTrackstersHAD' or opt.OBJ == 'allTiclMultiClusters'):
     fragments = []
     #Now  that we have them in eos lets produce plots
     #Let's loop through RelVals
@@ -358,30 +398,44 @@ if (opt.OBJ == 'hgcalLayerClusters' or opt.OBJ == 'hitCalibration' or opt.OBJ ==
         if RefRelease == None:
             cmd = 'python Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py ' +  inputpathNew + infi.filename(NewRelease) + ' --outputDir HGCValid_%s_Plots --no-ratio --png --separate --html-sample "%s" ' %(opt.HTMLVALNAME, _sampleName[infi.name()] ) + ' --html-validation-name %s --subdirprefix ' %(opt.HTMLVALNAME) + ' plots_%s' % (samplename)+ ' --collection %s' %(opt.HTMLVALNAME)
         elif "raw" in NotNormalRelease and "normal" in NotNormalRefRelease:
-            cmd = 'python Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py ' +  inputpathRef + infi.filename(RefRelease).replace("mcRun4_realistic_v2_2026D49noPU_gcc900-v1","mcRun4_realistic_v2_2026D49noPU-v1") + ' ' +  inputpathNew + infi.filename(NewRelease) + ' --outputDir HGCValid_%s_Plots --no-ratio --png --separate --html-sample "%s" ' %(opt.HTMLVALNAME, _sampleName[infi.name()] ) + ' --html-validation-name %s --subdirprefix ' %(opt.HTMLVALNAME) + ' plots_%s' % (samplename) + ' --collection %s' %(opt.HTMLVALNAME)
+            cmd = 'python Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py ' +  inputpathRef + infi.filename(RefRelease).replace("mcRun4_realistic_v3_2026D76noPU-v1","mcRun4_realistic_v3_2026D49noPU-v1") + ' ' +  inputpathNew + infi.filename(NewRelease) + ' --outputDir HGCValid_%s_Plots --no-ratio --png --separate --html-sample "%s" ' %(opt.HTMLVALNAME, _sampleName[infi.name()] ) + ' --html-validation-name %s --subdirprefix ' %(opt.HTMLVALNAME) + ' plots_%s' % (samplename) + ' --collection %s' %(opt.HTMLVALNAME)
             #cmd = 'python Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py ' +  inputpathRef + infi.filename(RefRelease).replace("mcRun4_realistic_v3_2026D49noPU_raw1100_rsb-v1","mcRun4_realistic_v3_2026D49noPU-v1") + ' ' +  inputpathNew + infi.filename(NewRelease) + ' --outputDir HGCValid_%s_Plots --no-ratio --png --separate --html-sample "%s" ' %(opt.HTMLVALNAME, _sampleName[infi.name()] ) + ' --html-validation-name %s --subdirprefix ' %(opt.HTMLVALNAME) + ' plots_%s' % (samplename) + ' --collection %s' %(opt.HTMLVALNAME)
         elif "raw" in NotNormalRelease and "raw" in NotNormalRefRelease:
             #cmd = 'python Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py ' +  inputpathRef + infi.filename(RefRelease) + ' ' +  inputpathNew + infi.filename(NewRelease) + ' --outputDir HGCValid_%s_Plots --no-ratio --png --separate --html-sample "%s" ' %(opt.HTMLVALNAME, _sampleName[infi.name()] ) + ' --html-validation-name %s --subdirprefix ' %(opt.HTMLVALNAME) + ' plots_%s' % (samplename) + ' --collection %s' %(opt.HTMLVALNAME)
             cmd = 'python Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py ' +  inputpathRef + infi.filename(RefRelease).replace("_raw1100","_raw1100_rsb") + ' ' +  inputpathNew + infi.filename(NewRelease) + ' --outputDir HGCValid_%s_Plots --no-ratio --png --separate --html-sample "%s" ' %(opt.HTMLVALNAME, _sampleName[infi.name()] ) + ' --html-validation-name %s --subdirprefix ' %(opt.HTMLVALNAME) + ' plots_%s' % (samplename) + ' --collection %s' %(opt.HTMLVALNAME)
         elif "normal" in NotNormalRelease and "normal" in NotNormalRefRelease:
-            cmd = 'python Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py ' +  inputpathRef + infi.filename(RefRelease) + ' ' +  inputpathNew + infi.filename(NewRelease) + ' --outputDir HGCValid_%s_Plots --no-ratio --png --separate --html-sample "%s" ' %(opt.HTMLVALNAME, _sampleName[infi.name()] ) + ' --html-validation-name %s --subdirprefix ' %(opt.HTMLVALNAME) + ' plots_%s' % (samplename) + ' --collection %s' %(opt.HTMLVALNAME)
+            #cmd = 'python Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py ' +  inputpathRef + infi.filename(RefRelease) + ' ' +  inputpathNew + infi.filename(NewRelease) + ' --outputDir HGCValid_%s_Plots --no-ratio --png --separate --html-sample "%s" ' %(opt.HTMLVALNAME, _sampleName[infi.name()] ) + ' --html-validation-name %s --subdirprefix ' %(opt.HTMLVALNAME) + ' plots_%s' % (samplename) + ' --collection %s' %(opt.HTMLVALNAME)
+            cmd = 'python Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py ' +  inputpathRef + infi.filename(RefRelease).replace("2026D49noPU-v2","2026D49noPU-v1") + ' ' +  inputpathNew + infi.filename(NewRelease) + ' --outputDir HGCValid_%s_Plots --no-ratio --png --separate --html-sample "%s" ' %(opt.HTMLVALNAME, _sampleName[infi.name()] ) + ' --html-validation-name %s --subdirprefix ' %(opt.HTMLVALNAME) + ' plots_%s' % (samplename) + ' --collection %s' %(opt.HTMLVALNAME)
         else: 
             #print inputpathRef, infi.filename(RefRelease).replace("D49","D41")
             #YOU SHOULD INSPECT EACH TIME THIS COMMAND AND THE REPLACE
             #cmd = 'python Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py ' +  inputpathRef + infi.filename(RefRelease).replace("D49","D41").replace("200-v2","200-v1") + ' ' +  inputpathNew + infi.filename(NewRelease) + ' --outputDir HGCValid_%s_Plots --no-ratio --png --separate --html-sample "%s" ' %(opt.HTMLVALNAME, _sampleName[infi.name()] ) + ' --html-validation-name %s --subdirprefix ' %(opt.HTMLVALNAME) + ' plots_%s' % (samplename) + ' --collection %s' %(opt.HTMLVALNAME) .replace("v2__", "v1__")
             cmd = 'python Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py ' +  inputpathRef + infi.filename(RefRelease).replace("mcRun4_realistic_v2-v1", "mcRun4_realistic_v2_2026D49noPU-v1") + ' ' +  inputpathNew + infi.filename(NewRelease) + ' --outputDir HGCValid_%s_Plots --no-ratio --png --separate --html-sample "%s" ' %(opt.HTMLVALNAME, _sampleName[infi.name()] ) + ' --html-validation-name %s --subdirprefix ' %(opt.HTMLVALNAME) + ' plots_%s' % (samplename) + ' --collection %s' %(opt.HTMLVALNAME) 
-            #print cmd
+            print cmd
 
         if(opt.DRYRUN):
             print 'Dry-run: ['+cmd+']'
         else:
             output = processCmd(cmd)
             if opt.OBJ == 'hgcalLayerClusters':
-                processCmd('awk \'NR>=6&&NR<=44\' HGCValid_%s_Plots/index.html > HGCValid_%s_Plots/index_%s.html '% (opt.HTMLVALNAME,opt.HTMLVALNAME, samplename))
+                processCmd('mv HGCValid_%s_Plots/plots_%s_Layer\ Clusters.html HGCValid_%s_Plots/index.html'%(opt.HTMLVALNAME,samplename,opt.HTMLVALNAME))
+                processCmd('awk \'NR>=6&&NR<=589\' HGCValid_%s_Plots/index.html > HGCValid_%s_Plots/index_%s.html '% (opt.HTMLVALNAME,opt.HTMLVALNAME, samplename))
+                processCmd('echo "  <br/>" >> HGCValid_%s_Plots/index_%s.html '%(opt.HTMLVALNAME, samplename) )
+                processCmd('echo "  <hr>" >> HGCValid_%s_Plots/index_%s.html '%(opt.HTMLVALNAME, samplename) )
+
             if opt.OBJ == 'hitCalibration':
-                processCmd('awk \'NR>=6&&NR<=15\' HGCValid_%s_Plots/index.html > HGCValid_%s_Plots/index_%s.html '% (opt.HTMLVALNAME,opt.HTMLVALNAME, samplename))
-            if opt.OBJ == 'ticlMultiClustersFromTrackstersEM' or opt.OBJ == 'ticlMultiClustersFromTrackstersHAD':
-                processCmd('awk \'NR>=6&&NR<=25\' HGCValid_%s_Plots/index.html > HGCValid_%s_Plots/index_%s.html '% (opt.HTMLVALNAME,opt.HTMLVALNAME, samplename))
+                #processCmd('indexname=`ls HGCValid_%s_Plots/plots_*.html`; mv ${indexname} HGCValid_%s_Plots/index.html;'%(opt.HTMLVALNAME,opt.HTMLVALNAME))
+                processCmd('mv HGCValid_%s_Plots/plots_%s_Calibrated\ RecHits.html HGCValid_%s_Plots/index.html'%(opt.HTMLVALNAME,samplename,opt.HTMLVALNAME))
+                processCmd('sed -i \'s/Calibrated\ RecHits//g\' HGCValid_%s_Plots/index.html'%(opt.HTMLVALNAME) )
+                processCmd('awk \'NR>=6&&NR<=27\' HGCValid_%s_Plots/index.html > HGCValid_%s_Plots/index_%s.html '% (opt.HTMLVALNAME,opt.HTMLVALNAME, samplename))
+                processCmd('echo "  <br/>" >> HGCValid_%s_Plots/index_%s.html '%(opt.HTMLVALNAME, samplename) )
+                processCmd('echo "  <hr>" >> HGCValid_%s_Plots/index_%s.html '%(opt.HTMLVALNAME, samplename) )
+
+            if opt.OBJ == 'ticlMultiClustersFromTrackstersEM' or opt.OBJ == 'ticlMultiClustersFromTrackstersHAD' or opt.OBJ == 'allTiclMultiClusters':
+                processCmd('mv HGCValid_%s_Plots/plots_%s_MultiClusters.html HGCValid_%s_Plots/index.html'%(opt.HTMLVALNAME,samplename,opt.HTMLVALNAME))
+                processCmd('awk \'NR>=6&&NR<=141\' HGCValid_%s_Plots/index.html > HGCValid_%s_Plots/index_%s.html '% (opt.HTMLVALNAME,opt.HTMLVALNAME, samplename))
+                processCmd('echo "  <br/>" >> HGCValid_%s_Plots/index_%s.html '%(opt.HTMLVALNAME, samplename) )
+                processCmd('echo "  <hr>" >> HGCValid_%s_Plots/index_%s.html '%(opt.HTMLVALNAME, samplename) )
 
     
         fragments.append( 'HGCValid_%s_Plots/index_%s.html'% (opt.HTMLVALNAME, samplename) )
@@ -452,13 +506,14 @@ if (opt.OBJ == 'hitValidation'):
         if RefRelease == None:
             cmd = 'python Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py ' +  inputpathNew + infi.filename(NewRelease) + ' --outputDir HGCValid_%s_Plots --no-ratio --png --separate --html-sample "%s" ' %(opt.HTMLVALNAME, _sampleName[infi.name()] ) + ' --html-validation-name %s --subdirprefix ' %(opt.HTMLVALNAME) + ' plots_%s' % (samplename)+ ' --collection %s' %(opt.HTMLVALNAME)
         elif "raw" in NotNormalRelease and "normal" in NotNormalRefRelease:
-            cmd = 'python Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py ' +  inputpathRef + infi.filename(RefRelease).replace("mcRun4_realistic_v2_2026D49noPU_gcc900-v1","mcRun4_realistic_v2_2026D49noPU-v1") + ' ' +  inputpathNew + infi.filename(NewRelease) + ' --outputDir HGCValid_%s_Plots --no-ratio --png --separate --html-sample "%s" ' %(opt.HTMLVALNAME, _sampleName[infi.name()] ) + ' --html-validation-name %s --subdirprefix ' %(opt.HTMLVALNAME) + ' plots_%s' % (samplename) + ' --collection %s' %(opt.HTMLVALNAME)
+            cmd = 'python Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py ' +  inputpathRef + infi.filename(RefRelease).replace("mcRun4_realistic_v3_2026D76noPU-v1","mcRun4_realistic_v3_2026D49noPU-v1") + ' ' +  inputpathNew + infi.filename(NewRelease) + ' --outputDir HGCValid_%s_Plots --no-ratio --png --separate --html-sample "%s" ' %(opt.HTMLVALNAME, _sampleName[infi.name()] ) + ' --html-validation-name %s --subdirprefix ' %(opt.HTMLVALNAME) + ' plots_%s' % (samplename) + ' --collection %s' %(opt.HTMLVALNAME)
             #cmd = 'python Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py ' +  inputpathRef + infi.filename(RefRelease).replace("mcRun4_realistic_v3_2026D49noPU_raw1100_rsb-v1","mcRun4_realistic_v3_2026D49noPU-v1") + ' ' +  inputpathNew + infi.filename(NewRelease) + ' --outputDir HGCValid_%s_Plots --no-ratio --png --separate --html-sample "%s" ' %(opt.HTMLVALNAME, _sampleName[infi.name()] ) + ' --html-validation-name %s --subdirprefix ' %(opt.HTMLVALNAME) + ' plots_%s' % (samplename) + ' --collection %s' %(opt.HTMLVALNAME)
         elif "raw" in NotNormalRelease and "raw" in NotNormalRefRelease:
             #cmd = 'python Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py ' +  inputpathRef + infi.filename(RefRelease) + ' ' +  inputpathNew + infi.filename(NewRelease) + ' --outputDir HGCValid_%s_Plots --no-ratio --png --separate --html-sample "%s" ' %(opt.HTMLVALNAME, _sampleName[infi.name()] ) + ' --html-validation-name %s --subdirprefix ' %(opt.HTMLVALNAME) + ' plots_%s' % (samplename) + ' --collection %s' %(opt.HTMLVALNAME)
             cmd = 'python Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py ' +  inputpathRef + infi.filename(RefRelease).replace("_raw1100","_raw1100_rsb") + ' ' +  inputpathNew + infi.filename(NewRelease) + ' --outputDir HGCValid_%s_Plots --no-ratio --png --separate --html-sample "%s" ' %(opt.HTMLVALNAME, _sampleName[infi.name()] ) + ' --html-validation-name %s --subdirprefix ' %(opt.HTMLVALNAME) + ' plots_%s' % (samplename) + ' --collection %s' %(opt.HTMLVALNAME)
         elif "normal" in NotNormalRelease and "normal" in NotNormalRefRelease:
-            cmd = 'python Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py ' +  inputpathRef + infi.filename(RefRelease) + ' ' +  inputpathNew + infi.filename(NewRelease) + ' --outputDir HGCValid_%s_Plots --no-ratio --png --separate --html-sample "%s" ' %(opt.HTMLVALNAME, _sampleName[infi.name()] ) + ' --html-validation-name %s --subdirprefix ' %(opt.HTMLVALNAME) + ' plots_%s' % (samplename) + ' --collection %s' %(opt.HTMLVALNAME)
+            #cmd = 'python Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py ' +  inputpathRef + infi.filename(RefRelease) + ' ' +  inputpathNew + infi.filename(NewRelease) + ' --outputDir HGCValid_%s_Plots --no-ratio --png --separate --html-sample "%s" ' %(opt.HTMLVALNAME, _sampleName[infi.name()] ) + ' --html-validation-name %s --subdirprefix ' %(opt.HTMLVALNAME) + ' plots_%s' % (samplename) + ' --collection %s' %(opt.HTMLVALNAME)
+            cmd = 'python Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py ' +  inputpathRef + infi.filename(RefRelease).replace("2026D49noPU-v2","2026D49noPU-v1") + ' ' +  inputpathNew + infi.filename(NewRelease) + ' --outputDir HGCValid_%s_Plots --no-ratio --png --separate --html-sample "%s" ' %(opt.HTMLVALNAME, _sampleName[infi.name()] ) + ' --html-validation-name %s --subdirprefix ' %(opt.HTMLVALNAME) + ' plots_%s' % (samplename) + ' --collection %s' %(opt.HTMLVALNAME)
         else: 
             #cmd = 'python Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py ' +  inputpathRef + infi.filename(RefRelease).replace("D49","D41").replace("200-v2","200-v1") + ' ' +  inputpathNew + infi.filename(NewRelease) + ' --outputDir HGCValid_%s_Plots --no-ratio --png --separate --html-sample "%s" ' %(opt.HTMLVALNAME, _sampleName[infi.name()] ) + ' --html-validation-name %s --subdirprefix ' %(opt.HTMLVALNAME) + ' plots_%s' % (samplename) + ' --collection %s' %(opt.HTMLVALNAME) 
             cmd = 'python Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py ' +  inputpathRef + infi.filename(RefRelease).replace("mcRun4_realistic_v2-v1", "mcRun4_realistic_v2_2026D49noPU-v1") + ' ' +  inputpathNew + infi.filename(NewRelease) + ' --outputDir HGCValid_%s_Plots --no-ratio --png --separate --html-sample "%s" ' %(opt.HTMLVALNAME, _sampleName[infi.name()] ) + ' --html-validation-name %s --subdirprefix ' %(opt.HTMLVALNAME) + ' plots_%s' % (samplename) + ' --collection %s' %(opt.HTMLVALNAME)
@@ -469,7 +524,10 @@ if (opt.OBJ == 'hitValidation'):
             print 'Dry-run: ['+cmd+']'
         else:
             output = processCmd(cmd)
-            processCmd('awk \'NR>=6&&NR<=28\' HGCValid_%s_Plots/index.html > HGCValid_%s_Plots/index_%s.html '% (opt.HTMLVALNAME,opt.HTMLVALNAME, samplename))
+            processCmd('mv HGCValid_%s_Plots/plots_%s_Hits.html HGCValid_%s_Plots/index.html'%(opt.HTMLVALNAME,samplename,opt.HTMLVALNAME))
+            processCmd('awk \'NR>=6&&NR<=184\' HGCValid_%s_Plots/index.html > HGCValid_%s_Plots/index_%s.html '% (opt.HTMLVALNAME,opt.HTMLVALNAME, samplename))
+            processCmd('echo "  <br/>" >> HGCValid_%s_Plots/index_%s.html '%(opt.HTMLVALNAME, samplename) )  
+            processCmd('echo "  <hr>" >> HGCValid_%s_Plots/index_%s.html '%(opt.HTMLVALNAME, samplename) )
     
         fragments.append( 'HGCValid_%s_Plots/index_%s.html'% (opt.HTMLVALNAME, samplename) )
             
@@ -610,6 +668,10 @@ if (opt.GATHER != None) :
     index_file.write(' <h1>\n')
     index_file.write(' HGCAL Validation Results \n'  )
     index_file.write(' </h1>\n')
+    index_file.write(' <hr/>\n' )
+    index_file.write(' <h2>\n')
+    index_file.write(' Release Validation Campaigns \n'  )
+    index_file.write(' </h2>\n')
     index_file.write('  <ul>\n' )
 
     for trel in thereleases.keys():
@@ -623,14 +685,47 @@ if (opt.GATHER != None) :
         index_file.write('  <br>\n' )
         index_file.write('  <br>\n' )
         index_file.write('  <br>\n' )
-       
-    #Writing postamble"
+
     index_file.write('  </ul>\n' )
+    index_file.write(' <hr/>\n' )
+
+    #New section : Geometry Validation
+    #Regardless of the release validation, the top html menu should contain the geometry section.
+    #we put this in the "gather" step.
+    index_file.write(' <h2>\n')
+    index_file.write(' Geometry Validation \n'  )
+    index_file.write(' </h2>\n')
+    index_file.write('  <ul>\n' )
+
+    for tgeo in geometryTests.keys():
+        index_file.write('   <li>\n' )
+        index_file.write('   %s\n' %(tgeo) )
+        for geo in geometryTests[tgeo]:
+            #We need the directory for the geometry related results 
+            if (not os.path.isdir(geo)):
+                processCmd('mkdir -p %s/%s' %(opt.WWWAREA,geo) )
+                processCmd('mkdir -p %s' %(geo) )
+                for mats in _individualmaterials:
+                    processCmd('mkdir -p %s/%s/indimat/%s' %(opt.WWWAREA,geo,mats) )
+                    processCmd('mkdir -p %s/indimat/%s' %(geo,mats) )
+                     
+            index_file.write('  <ul>\n' )
+            index_file.write('   <li><a href="%s/index.html">%s</a></li>\n' %(geo, geo ) )
+            index_file.write('  </ul>\n' )
+        index_file.write('   </li>\n' )
+        index_file.write('  <br>\n' )
+        index_file.write('  <br>\n' )
+        index_file.write('  <br>\n' )
+
+    #Writing postamble"
     index_file.write(' </body>\n')
     index_file.write('</html>\n')
     index_file.close()
 
-    processCmd('cp index.html %s/.' %(opt.WWWAREA) )
+    #This is the main html file for the validation webpage. In order to avoid 
+    #surprises when experimenting, in order to copy it automatically to the 
+    #www area you should have activated the relevant flag:  
+    if (opt.COPYHTML) : processCmd('cp index.html %s/.' %(opt.WWWAREA) )
  
     #Let's make also the summary folder
     if (not os.path.isdir("HGCValid_summary_Plots")):  
@@ -675,7 +770,10 @@ if (opt.GATHER != None) :
                    #print(df[obj][ind])          
                    print(j)
                    #index_file.write(' <li><a href="plots_%s_%s">%s</a></li>   \n' %(samplename, df[obj][ind], df[obj][ind].partition("/")[2] ))
-                   index_file.write(' <li><a href="../HGCValid_%s_Plots/plots_%s_%s">%s</a></li>   \n' %(j, samplename, column, column.partition("/")[2] ))
+                   if "Ticl" in j: 
+                       index_file.write(' <li><a href="../HGCValid_%s_Plots/plots_%s_%s">%s</a></li>   \n' %(j, samplename, column, column.replace("ticlMultiClustersFromTracksters","") ))
+                   else: 
+                       index_file.write(' <li><a href="../HGCValid_%s_Plots/plots_%s_%s">%s</a></li>   \n' %(j, samplename, column, column.partition("/")[2] ))
 
                 index_file.write('    </ul>\n')                        
                 index_file.write('    </td>\n')
@@ -698,7 +796,8 @@ if (opt.GATHER != None) :
     if "raw" in NotNormalRelease and "raw" in NotNormalRefRelease: 
        localoutputdir = NewRelease + "_raw1100" + "_vs_" + RefRelease + "_raw1100"
     elif "raw" in NotNormalRelease and "normal" in NotNormalRefRelease: 
-       localoutputdir = NewRelease + "_raw1100" + "_vs_" + RefRelease
+       #localoutputdir = NewRelease + "_raw1100" + "_vs_" + RefRelease
+       localoutputdir = NewRelease + "_D76" + "_vs_" + RefRelease
     elif "normal" in NotNormalRelease and "normal" in NotNormalRefRelease: 
        localoutputdir = NewRelease + "_vs_" + RefRelease
     else: 
@@ -729,6 +828,7 @@ if (opt.GATHER != None) :
                 else: processCmd('cp -r %s/HGCValid_%s_Plots/plots_%s_%s %s/HGCValid_summary_Plots ' %(NewRelease, obj, samplename, df[obj][ind].partition("/")[0], NewRelease ) )
     '''
 
+    #html file of the relval campaign we are validating
     index_file = open('%s/index.html'%(localoutputdir),'w')            
     #Write preamble
     index_file.write('<html>\n')
@@ -736,7 +836,7 @@ if (opt.GATHER != None) :
     index_file.write('  <title> <h2> HGCal validation results for %s </h2> </title>\n' %(localoutputdir) )
     index_file.write(' </head>\n')
     index_file.write(' <body>\n')
-    index_file.write(' HGCal validation results for %s \n' %(localoutputdir) )
+    index_file.write(' <h2> HGCal validation results for %s </h2> \n' %(localoutputdir) )
 
     for obj in objects:
         print(obj)
@@ -758,7 +858,7 @@ if (opt.GATHER != None) :
     index_file.write(' </body>\n')
     index_file.write('</html>\n')
     index_file.close()
-
+    
     #We choose to zip in uncompressed form all the files for two reasons:
     #1. Copying to eos so many files is really slow. It is faster to
     #   create one uncompressed file, copy that and unzip there.
@@ -768,12 +868,236 @@ if (opt.GATHER != None) :
     #   the directory content, leaving inside only the zip file.
 
     # This will take some time. 
-    processCmd('zip -0 -r %s.zip %s' %(localoutputdir,localoutputdir) )
-    processCmd('cp %s.zip %s/.' %(localoutputdir,opt.WWWAREA) )
-    processCmd('cd %s' %(opt.WWWAREA) )
-    processCmd('unzip %s.zip' %(localoutputdir) )
-    processCmd('mv %s.zip %s/.' %(localoutputdir,localoutputdir) )
-    processCmd('cd -')
+#    processCmd('zip -0 -r %s.zip %s' %(localoutputdir,localoutputdir) )
+#    processCmd('cp %s.zip %s/.' %(localoutputdir,opt.WWWAREA) )
+#    processCmd('cd %s' %(opt.WWWAREA) )
+#    processCmd('unzip -q %s.zip' %(localoutputdir) )
+#    processCmd('mv %s.zip %s/.' %(localoutputdir,localoutputdir) )
+#    processCmd('cd -')
 
 
+#------------------------------------------------------------------------------------------
+#Geometry section: Here we gather results from geometry related validation packages.
+#-------------------------------------------------------------------------------------------
+#Keep in mind that the gne
+if (opt.GEOMETRY) :
+    #html file of the geometry scenario we are estimating the material budget
+    index_file = open('%s/index.html'%(GeoScenario),'w')
+    #Write preamble
+    index_file.write('<html>\n')
+    index_file.write(' <head>\n')
+    index_file.write('  <title> <h2> HGCAL material budget results for %s </h2> </title>\n' %(GeoScenario) )
+    index_file.write(' </head>\n')
+    index_file.write(' <body>\n')
+    index_file.write(' <h2> HGCAL material budget results for %s </h2> \n' %(GeoScenario) )
 
+    for obj in _MatBudSections:
+        print(obj)
+        #We need the directory for the geometry related results 
+        if (not os.path.isdir('%s/%s/%s' %(opt.WWWAREA,GeoScenario,obj))):
+            processCmd('mkdir -p %s/%s/%s' %(opt.WWWAREA,GeoScenario,obj) )
+        index_file.write('  <br/>\n' )
+        index_file.write('  <ul>\n' )
+        index_file.write('   <li><a href="%s/index.html">%s</a></li>\n' %(obj, _geoPageNameMap[obj] ) )
+        index_file.write('  </ul>\n' )
+        index_file.write('  <br/>\n' )
+
+    #Writing postamble
+    index_file.write(' </body>\n')
+    index_file.write('</html>\n')
+    index_file.close()
+
+    #Copy the material budget menu file in the current geometry scenario
+    processCmd('cp %s/index.html %s/%s/.' %(GeoScenario, opt.WWWAREA,GeoScenario) )
+
+    #html file for the menu of the individual materials
+    index_file = open('%s/indimat/index.html'%(GeoScenario),'w')
+    #Write preamble
+    index_file.write('<html>\n')
+    index_file.write(' <head>\n')
+    index_file.write('  <title> <h2> HGCAL material budget results for individual materials for  %s </h2> </title>\n' %(GeoScenario) )
+    index_file.write(' </head>\n')
+    index_file.write(' <body>\n')
+    index_file.write(' <h2> HGCAL material budget results for individual materials for %s </h2> \n' %(GeoScenario) )
+    for mats in _individualmaterials:
+        print(mats)
+        #index_file.write('  <br/>\n' )
+        index_file.write('  <ul>\n' )
+        index_file.write('   <li><a href="%s/index.html">%s</a></li>\n' %(mats, _matPageNameMap[mats] ) )
+        index_file.write('  </ul>\n' )
+        #index_file.write('  <br/>\n' )
+
+    #Writing postamble
+    index_file.write(' </body>\n')
+    index_file.write('</html>\n')
+    index_file.close()
+
+    #Copy the menu html file for the individual materials
+    processCmd('cp %s/indimat/index.html %s/%s/indimat/.' %(GeoScenario, opt.WWWAREA,GeoScenario) )
+
+    #html file for all HGCal stack plots materials
+    index_file = open('%s/allhgcal/index.html'%(GeoScenario),'w')
+    #Write preamble
+    index_file.write('<html>\n')
+    index_file.write(' <head>\n')
+
+    index_file.write(' <style>img.Reference{margin: 20px auto 20px auto; border: 10px solid green; border-radius: 10px;}img.New{margin: 20px auto 20px auto; border: 10px solid red; border-radius: 10px;} </style> \n')
+
+    index_file.write(_hideShowFun["thestyle"])
+
+    index_file.write('  <title> <h2> HGCAL material budget results for all materials for  %s </h2> </title>\n' %(GeoScenario) )
+    index_file.write(' </head>\n')
+    index_file.write(' <body>\n')
+
+    index_file.write(' <h2> HGCAL material budget results for : <span style="color:red;font-size:120%%" >All Materials </span></h2> \n' )
+
+    index_file.write('<p> %s plots have a green border followed by the %s plots which features a red border. </p>\n' % (GeoScenario.split("_")[0], GeoScenario.split("_")[2]) )
+
+    index_file.write('<h2> Geometry: <span style="color:green;" > %s</span>_vs_<span style="color:red;" >%s </span> </h2>\n' % (GeoScenario.split("_")[0], GeoScenario.split("_")[2]) )
+
+    index_file.write('<hr/>\n')
+
+    index_file.write(_hideShowFun["divTabs"])
+
+    for region in ["_AllHGCAL", "_ZminusZoom", "_ZplusZoom"]:
+  
+        index_file.write('<div id="%s" class="tabcontent"> \n' %(region))
+        pngnamestring = ""
+        if region == "_AllHGCAL": pngnamestring = ""
+        else: pngnamestring = region
+	
+        for allmatplot in _allmaterialsplots:
+            if region == "_AllHGCAL":
+                index_file.write('<p> %s <a href="../%s/%s%s.pdf" class="TMLlink">Click to enlarge %s plot</a></p>\n' %(_allmaterialsPlotsDesc[allmatplot], GeoScenario.split("_")[2],allmatplot,pngnamestring,GeoScenario.split("_")[2]))
+		index_file.write('<img class="Reference" src="../%s/%s%s.png" width="375"/> \n' %(GeoScenario.split("_")[0],allmatplot,pngnamestring) )
+		index_file.write('<img class="New" src="../%s/%s%s.png" width="375"/> \n' %(GeoScenario.split("_")[2],allmatplot,pngnamestring))
+		index_file.write('<hr/>\n')
+            elif region != "_AllHGCAL" and "HGCal_l_vs_z_vs_R" in allmatplot:
+                index_file.write('<p> %s <a href="../%s/%s/%s%s.pdf" class="TMLlink">Click to enlarge %s plot</a></p>\n' %(_allmaterialsPlotsDesc[allmatplot], GeoScenario.split("_")[2],region.replace("_Zminus","ZMinus").replace("_Zplus","ZPlus"),allmatplot,pngnamestring,GeoScenario.split("_")[2]))
+                index_file.write('<img class="Reference" src="../%s/%s/%s%s.png" width="375"/> \n' %(GeoScenario.split("_")[0],region.replace("_Zminus","ZMinus").replace("_Zplus","ZPlus"),allmatplot,pngnamestring) )
+                index_file.write('<img class="New" src="../%s/%s/%s%s.png" width="375"/> \n' %(GeoScenario.split("_")[2],region.replace("_Zminus","ZMinus").replace("_Zplus","ZPlus"),allmatplot,pngnamestring))
+                index_file.write('<hr/>\n')
+
+
+        index_file.write('</div>\n')
+
+    index_file.write(_hideShowFun["buttonandFunction"])
+    index_file.write(' </body>\n')
+    index_file.write('</html>\n')
+    index_file.close()
+
+    #Copy all materials budget file
+    processCmd('cp %s/allhgcal/index.html %s/%s/allhgcal/.' %(GeoScenario, opt.WWWAREA,GeoScenario) )
+
+    #html file of the individual materials for the material budget analysis
+    for mats in _individualmaterials:
+        index_file = open('%s/indimat/%s/index.html'%(GeoScenario,mats),'w')
+        #Write preamble
+        index_file.write('<html>\n')
+        index_file.write(' <head>\n')
+
+        index_file.write(' <style>img.Reference{margin: 20px auto 20px auto; border: 10px solid green; border-radius: 10px;}img.New{margin: 20px auto 20px auto; border: 10px solid red; border-radius: 10px;} </style> \n')
+
+        index_file.write(_hideShowFun["thestyle"])
+
+        index_file.write('  <title> <h2> HGCAL material budget results for individual materials for  %s </h2> </title>\n' %(GeoScenario) )
+        index_file.write(' </head>\n')
+        index_file.write(' <body>\n')
+        index_file.write(' <h2> HGCAL material budget results for : <span style="color:red;font-size:120%%" >%s </span></h2> \n' %(_matPageNameMap[mats]) )
+
+        index_file.write('<p> %s plots have a green border followed by the %s plots which features a red border. </p>\n' % (GeoScenario.split("_")[0], GeoScenario.split("_")[2]) )
+
+        index_file.write('<h2> Geometry: <span style="color:green;" > %s</span>_vs_<span style="color:red;" >%s </span> </h2>\n' % (GeoScenario.split("_")[0], GeoScenario.split("_")[2]) )
+
+        index_file.write('<hr/>\n')
+
+        #--------------------------------------------------------------
+        #This one below is a solution using a table with 3 columns: 
+        #Two for the plots and the third for the text. 
+
+        #index_file.write('<table style=\'font-size:120%%\' border="1" cellspacing="1" cellpadding="0">\n')
+        #index_file.write('<tbody>\n')
+
+        #for indiplots in _individualmatplots:
+        #    index_file.write('<tr>\n')
+        #    index_file.write('<td> <img class="Reference" src="../../%s/%s/%s%s.png" width="375"/> </td>\n' %(GeoScenario.split("_")[0],mats,indiplots,mats) )
+        #    index_file.write('<td> <img class="New" src="../../%s/%s/%s%s.png" width="375"/> </td>\n' %(GeoScenario.split("_")[2],mats,indiplots,mats))
+        #    index_file.write('<td> %s <a href="../../%s/%s/%s%s.pdf" class="TMLlink">Click to enlarge %s plot</a></td>\n' %(_individualMatPlotsDesc[indiplots].replace("THEMAT",_matPageNameMap[mats]), GeoScenario.split("_")[2],mats,indiplots,mats,GeoScenario.split("_")[2]))
+        #    index_file.write('</tr>\n')
+        
+        #Writing postamble
+        #index_file.write('</tbody>\n')
+        #index_file.write('</table>\n')
+        #--------------------------------------------------------------
+        index_file.write(_hideShowFun["divTabs"])
+
+	#Individual material here for: All HGCAL, Zminus, Zplus
+        for region in ["_AllHGCAL", "_ZminusZoom", "_ZplusZoom"]:
+            #The hide/show button
+            #index_file.write(_hideShowFun["buttonandFunction%s"%(region)])
+
+            index_file.write('<div id="%s" class="tabcontent"> \n' %(region))
+            pngnamestring = ""
+            if region == "_AllHGCAL": pngnamestring = ""
+	    else: pngnamestring = region 
+            for indiplots in _individualmatplots: 
+                if region == "_AllHGCAL":
+                    index_file.write('<p> %s <a href="../../%s/%s/%s%s%s.pdf" class="TMLlink">Click to enlarge %s plot</a></p>\n' %(_individualMatPlotsDesc[indiplots].replace("THEMAT",_matPageNameMap[mats]), GeoScenario.split("_")[2],mats,indiplots,mats,pngnamestring,GeoScenario.split("_")[2]))
+                    index_file.write('<img class="Reference" src="../../%s/%s/%s%s%s.png" width="375"/> \n' %(GeoScenario.split("_")[0],mats,indiplots,mats,pngnamestring) )
+                    index_file.write('<img class="New" src="../../%s/%s/%s%s%s.png" width="375"/> \n' %(GeoScenario.split("_")[2],mats,indiplots,mats,pngnamestring))
+                    index_file.write('<hr/>\n')
+                else: 
+                    index_file.write('<p> %s <a href="../../%s/%s/%s/%s%s%s.pdf" class="TMLlink">Click to enlarge %s plot</a></p>\n' %(_individualMatPlotsDesc[indiplots].replace("THEMAT",_matPageNameMap[mats]), GeoScenario.split("_")[2],mats,region.replace("_Zminus","ZMinus").replace("_Zplus","ZPlus"),indiplots,mats,pngnamestring,GeoScenario.split("_")[2]))
+                    index_file.write('<img class="Reference" src="../../%s/%s/%s/%s%s%s.png" width="375"/> \n' %(GeoScenario.split("_")[0],mats,region.replace("_Zminus","ZMinus").replace("_Zplus","ZPlus"),indiplots,mats,pngnamestring) )
+                    index_file.write('<img class="New" src="../../%s/%s/%s/%s%s%s.png" width="375"/> \n' %(GeoScenario.split("_")[2],mats,region.replace("_Zminus","ZMinus").replace("_Zplus","ZPlus"),indiplots,mats,pngnamestring))
+                    index_file.write('<hr/>\n')
+             
+
+            index_file.write('</div>\n')          
+
+        index_file.write(_hideShowFun["buttonandFunction"]) 
+        index_file.write(' </body>\n')
+        index_file.write('</html>\n')
+        index_file.close()
+
+        #Copy the individual materials budget file
+        processCmd('cp %s/indimat/%s/index.html %s/%s/indimat/%s/.' %(GeoScenario, mats, opt.WWWAREA,GeoScenario,mats) )
+
+    #html file for from vertex up to muon stations
+    index_file = open('%s/fromvertex/index.html'%(GeoScenario),'w')
+    #Write preamble
+    index_file.write('<html>\n')
+    index_file.write(' <head>\n')
+
+    index_file.write(' <style>img.Reference{margin: 20px auto 20px auto; border: 10px solid green; border-radius: 10px;}img.New{margin: 20px auto 20px auto; border: 10px solid red; border-radius: 10px;} </style> \n')
+
+    index_file.write(_hideShowFun["thestyle"])
+
+    index_file.write('  <title> <h2> HGCAL material budget results from vertex up to in front of muon stations for  %s </h2> </title>\n' %(GeoScenario) )
+    index_file.write(' </head>\n')
+    index_file.write(' <body>\n')
+
+    index_file.write(' <h2> HGCAL material budget results from vertex up to in front of muon stations: <span style="color:red;font-size:120%%" >All detectors </span></h2> \n' )
+
+    index_file.write('<p> %s plots have a green border followed by the %s plots which features a red border. </p>\n' % (GeoScenario.split("_")[0], GeoScenario.split("_")[2]) )
+
+    index_file.write('<h2> Geometry: <span style="color:green;" > %s</span>_vs_<span style="color:red;" >%s </span> </h2>\n' % (GeoScenario.split("_")[0], GeoScenario.split("_")[2]) )
+
+    index_file.write('<hr/>\n')
+
+    #index_file.write(_hideShowFun["divTabs"])
+
+    for vertexplots in _fromvertexplots:
+        index_file.write('<p> %s </p>\n' %(_fromVertexPlotsDesc[vertexplots]))
+        index_file.write('<img class="Reference" src="%s/Figures/MaterialBdg_FromVertexToBackOf%s.png" width="375"/> \n' %(GeoScenario.split("_")[0],vertexplots) )
+        index_file.write('<img class="New" src="%s/Figures/MaterialBdg_FromVertexToBackOf%s.png" width="375"/> \n' %(GeoScenario.split("_")[2],vertexplots) )
+        index_file.write('<hr/>\n')
+
+    #index_file.write(_hideShowFun["buttonandFunction"])
+    index_file.write(' </body>\n')
+    index_file.write('</html>\n')
+    index_file.close()
+
+    #Copy all materials budget file
+    processCmd('cp %s/fromvertex/index.html %s/%s/fromvertex/.' %(GeoScenario, opt.WWWAREA,GeoScenario) )
+ 

--- a/Validation/HGCalValidation/scripts/hgcalPerformanceValidation.py
+++ b/Validation/HGCalValidation/scripts/hgcalPerformanceValidation.py
@@ -322,8 +322,6 @@ phase2samples_noPU.extend(phase2samples_noPU_extend)
 phase2samples_noPU.extend(phase2samples_noPU_extend_more)
 #phase2samples_noPU.extend(phase2samples_noPU_oldnaming)
 
-phase2samples_noPU = phase2samples_noPU_extend_more
-
 #phase2samples_noPU = [
 #    Sample("RelValCloseByPGun_CE_E_Front_300um", scenario="2026D49", appendGlobalTag=appendglobaltag ),
 #    Sample("RelValCloseByPGun_CE_E_Front_200um", scenario="2026D49", appendGlobalTag=appendglobaltag )


### PR DESCRIPTION
#### PR description:

This PR updates the HGCAL scripts used for the regular validation campaigns. Specifically, 
1. Corrects the links in the summary webpage for the layercluster efficiency/merge rate/fake rate/duplicates, which are broken due to updates in `hgcalPlots.py` . 
2. Adds a geometry section containing material budget plots for HGCAL as well as from the vertex up to in front of muon stations. 
3. Updates the `html.py` to use the `allticlmulticluster` option among other updates for a nicer webpage environment regarding the material budget comparison plots. 
4. A flag is added in the main script to avoid overwriting the main index.html file of the webpage when experimenting or using it for other studies.  

#### PR validation:

We have used these scripts to create the most recent campaign validation reports including the D76 phase 2 campaign for which we studied also material budget plots. 

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This is not a backport. 

@rovere @felicepantaleo @lecriste @ebrondol 