### PR TITLE
Removed unnecessary temporary variable in Callback

### DIFF
--- a/FWCore/Framework/interface/Callback.h
+++ b/FWCore/Framework/interface/Callback.h
@@ -146,7 +146,6 @@ namespace edm {
                                    EventSetupImpl const* iImpl,
                                    ESProxyIndex const* proxies,
                                    edm::ServiceToken const& token) const {
-        WaitingTaskHolder h(task);
         auto recs = producer_->getTokenRecordIndices(id_);
         auto n = producer_->numberOfTokenIndices(id_);
         for (size_t i = 0; i != n; ++i) {


### PR DESCRIPTION

#### PR description:

The unused variable was flagged by the code checker in clang 11.

#### PR validation:

Code compiles and all framework unit tests pass.