### PR TITLE
Update HLT common customisations to handle SwitchProducers

### DIFF
--- a/HLTrigger/Configuration/python/common.py
+++ b/HLTrigger/Configuration/python/common.py
@@ -1,11 +1,15 @@
 import itertools
-
-import FWCore.ParameterSet.Config as cms
 import six
+import FWCore.ParameterSet.Config as cms
 
 def producers_by_type(process, *types):
     "Find all EDProducers in the Process that are instances of the given C++ type."
-    return (module for module in process._Process__producers.values() if module._TypedParameterizable__type in types)
+    switches = (module for module in (getattr(switchproducer, case) \
+      for switchproducer in six.itervalues(process._Process__switchproducers) \
+      for case in switchproducer.parameterNames_()) \
+      if isinstance(module, cms.EDProducer))
+    return (module for module in itertools.chain(six.itervalues(process._Process__producers), switches) \
+      if module._TypedParameterizable__type in types)
 
 def filters_by_type(process, *types):
     "Find all EDFilters in the Process that are instances of the given C++ type."
@@ -21,7 +25,11 @@ def esproducers_by_type(process, *types):
 
 def modules_by_type(process, *types):
     "Find all modiles or other components in the Process that are instances of the given C++ type."
-    return (module for module in process.__dict__.values() if hasattr(module, '_TypedParameterizable__type') and module._TypedParameterizable__type in types)
+    switches = (module for module in (getattr(switchproducer, case) \
+      for switchproducer in six.itervalues(process._Process__switchproducers) \
+      for case in switchproducer.parameterNames_()))
+    return (module for module in itertools.chain(six.itervalues(process.__dict__), switches) \
+      if hasattr(module, '_TypedParameterizable__type') and module._TypedParameterizable__type in types)
 
 
 def insert_modules_before(process, target, *modules):


### PR DESCRIPTION
#### PR description:

Update the HLT common customisations to discover the `EDProducer`s nested within a `SwitchProducer`.

#### PR validation:

HLT customisations now apply the required changes also to nested `EDProducer`s.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Backport #33137 .