### PR TITLE
move TBB_PREVIEW_RESUMABLE_TASKS macro in tbb tool definition

### DIFF
--- a/FWCore/Concurrency/interface/include_first_syncWait.h
+++ b/FWCore/Concurrency/interface/include_first_syncWait.h
@@ -7,7 +7,6 @@
 //
 //  Created by Chris Jones on 2/24/21.
 //
-#define TBB_PREVIEW_RESUMABLE_TASKS 1
 #include "FWCore/Concurrency/interface/WaitingTaskHolder.h"
 #include "tbb/task_group.h"
 #include "tbb/task.h"

--- a/FWCore/Concurrency/src/SerialTaskQueue.cc
+++ b/FWCore/Concurrency/src/SerialTaskQueue.cc
@@ -12,7 +12,6 @@
 //
 
 // system include files
-#define TBB_PREVIEW_RESUMABLE_TASKS 1
 #include "tbb/task.h"
 
 // user include files


### PR DESCRIPTION
As suggested https://github.com/cms-sw/cmssw/pull/32804#discussion_r590440324 , the TBB_PREVIEW_RESUMABLE_TASKS macro should now be defined by tbb toolfile ( https://github.com/cms-sw/cmsdist/pull/6713 ). This PR should be tested with https://github.com/cms-sw/cmsdist/pull/6713