### PR TITLE
Remove 11634.911 (DD4HEP) from the limited matrix

### DIFF
--- a/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
+++ b/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
@@ -84,7 +84,7 @@ if __name__ == '__main__':
                      10024.0, #2017 ttbar
                      10224.0, #2017 ttbar PU
                      10824.0, #2018 ttbar
-                     11634.911, #2021 DD4hep ttbar
+#temporarly remove DD4HEP from the short matrix 11634.911, #2021 DD4hep ttbar
                      11634.0, #2021 ttbar
                      12434.0, #2023 ttbar
                      23234.0, #2026D49 ttbar (HLT TDR baseline w/ HGCal v11)


### PR DESCRIPTION
#### PR description:

This PR temporarily removes 11634.911 (DD4HEP workflow) from the limited matrix to avoid problems with the PR tests.
See https://github.com/cms-sw/cmssw/issues/32963.
@cvuosalo agreed on Mattermost to remove it if creates too much confusion

#### PR validation:
`runTheMatrix.py  -l limited --showMatrix`

#### if this PR is a backport please specify the original PR and why you need to backport that 
PR:
No backport