### PR TITLE
Update GTs with Ecal supercluster parameters

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -2,13 +2,13 @@ autoCond = {
 
     ### NEW KEYS ###
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run1
-    'run1_design'       :   '113X_mcRun1_design_v1',
+    'run1_design'       :   '113X_mcRun1_design_v2',
     # GlobalTag for MC production (pp collisions) with realistic alignment and calibrations for Run1
-    'run1_mc'           :   '113X_mcRun1_realistic_v1',
+    'run1_mc'           :   '113X_mcRun1_realistic_v2',
     # GlobalTag for MC production (Heavy Ions collisions) with realistic alignment and calibrations for Run1
-    'run1_mc_hi'        :   '113X_mcRun1_HeavyIon_v1',
+    'run1_mc_hi'        :   '113X_mcRun1_HeavyIon_v2',
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run1
-    'run1_mc_pa'        :   '113X_mcRun1_pA_v1',
+    'run1_mc_pa'        :   '113X_mcRun1_pA_v2',
     # GlobalTag for MC production with pessimistic alignment and calibrations for Run2
     'run2_mc_50ns'      :   '113X_mcRun2_startup_v2',
     # GlobalTag for MC production (2015 L1 Trigger Stage1) with startup-like alignment and calibrations for Run2, L1 trigger in Stage1 mode
@@ -40,14 +40,14 @@ autoCond = {
     # GlobalTag for Run2 HLT: it points to the online GT
     'run2_hlt'          :   '101X_dataRun2_HLT_frozen_v11',
     # GlobalTag for Run2 HLT RelVals: customizations to run with fixed L1 Menu
-    'run2_hlt_relval'      :   '112X_dataRun2_HLT_relval_v3',
-    'run2_hlt_relval_hi'   :   '112X_dataRun2_HLT_relval_HI_v2',
+    'run2_hlt_relval'      :   '112X_dataRun2_HLT_relval_v4',
+    'run2_hlt_relval_hi'   :   '112X_dataRun2_HLT_relval_HI_v3',
     # GlobalTag for Run2 HLT for HI (not 2018 HI): it points to the online GT
     'run2_hlt_hi'       :   '101X_dataRun2_HLTHI_frozen_v11',
     # GlobalTag for Run3 data relvals (express GT)
-    'run3_data_express'        :   '112X_dataRun3_Express_v2',
+    'run3_data_express'        :   '112X_dataRun3_Express_v3',
     # GlobalTag for Run3 data relvals
-    'run3_data_promptlike'     :   '112X_dataRun3_Prompt_v2',
+    'run3_data_promptlike'     :   '112X_dataRun3_Prompt_v3',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,~0-centred beamspot)
     'phase1_2017_design'       :  '113X_mc2017_design_v4',
     # GlobalTag for MC production with realistic conditions for Phase1 2017 detector
@@ -83,7 +83,7 @@ autoCond = {
     # GlobalTag for MC production with realistic conditions for Phase1 2024
     'phase1_2024_realistic'    : '113X_mcRun3_2024_realistic_v5', # GT containing realistic conditions for Phase1 2024
     # GlobalTag for MC production with realistic conditions for Phase2
-    'phase2_realistic'         : '113X_mcRun4_realistic_v5'
+    'phase2_realistic'         : '113X_mcRun4_realistic_v6'
 }
 
 aliases = {


### PR DESCRIPTION
#### PR description:
This PR adds the Ecal supercluster parameters (`EcalMustacheSCParameters` and `EcalSCDynamicDPhiParameters`) to run1_mc GTs, data GTs and the run4_mc GT, as presented in https://indico.cern.ch/event/1015582/contributions/4262669/attachments/2203720/3728503/cipriani_08Mar2021_EcalSCtags.pdf and reported also in [this HN entry](https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/4363/1/1/1.html).

The GT diffs are as follows:
**Run 1 design**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/113X_mcRun1_design_v1/113X_mcRun1_design_v2

**Run 1 realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/113X_mcRun1_realistic_v1/113X_mcRun1_realistic_v2

**Run 1 heavy ion**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/113X_mcRun1_HeavyIon_v1/113X_mcRun1_HeavyIon_v2

**Run 1 proton-heavy ion**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/113X_mcRun1_pA_v1/113X_mcRun1_pA_v2

**Run 2 HLT RelVals**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/112X_dataRun2_HLT_relval_v3/112X_dataRun2_HLT_relval_v4

**Run 2 HI HLT RelVals**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/112X_dataRun2_HLT_relval_HI_v2/112X_dataRun2_HLT_relval_HI_v3

**Run 3 data (express)**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/112X_dataRun3_Express_v2/112X_dataRun3_Express_v3

**Run 3 data (prompt)**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/112X_dataRun3_Prompt_v2/112X_dataRun3_Prompt_v3

**Phase 2 realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/113X_mcRun4_realistic_v5/113X_mcRun4_realistic_v6


#### PR validation:
A technical test was performed:
`runTheMatrix.py -l limited,138.1,138.2,140.0 --ibeos`

#### if this PR is a backport please specify the original PR and why you need to backport that PR:
This PR is not a backport, but a backport will be done for 11_2_X once this is merged
