### PR TITLE
Clean BuildFiles, fix typo and add source_only flags to fix warnings

### DIFF
--- a/CalibMuon/DTCalibration/plugins/BuildFile.xml
+++ b/CalibMuon/DTCalibration/plugins/BuildFile.xml
@@ -12,7 +12,7 @@
 <use name="root"/>
 <use name="rootmath"/>
 <use name="rootcore"/>
-<use name="rootfitcore"/>
+<use name="roofitcore"/>
 <use name="rootgraphics"/>
 <lib name="Spectrum"/>
 <library file="*.cc" name="CalibMuonDTCalibrationPlugins">

--- a/DQM/GEM/BuildFile.xml
+++ b/DQM/GEM/BuildFile.xml
@@ -4,7 +4,6 @@
 <use name="FWCore/Utilities"/>
 <use name="DQMServices/Core"/>
 <use name="DataFormats/GEMDigi"/>
-<use name="DataFormats/GEMRecHit"/>
 <use name="Geometry/Records"/>
 <use name="Geometry/GEMGeometry"/>
 <use name="Validation/MuonGEMHits"/>

--- a/DQM/GEM/plugins/BuildFile.xml
+++ b/DQM/GEM/plugins/BuildFile.xml
@@ -7,7 +7,5 @@
   <use name="DQMServices/Core"/>
   <use name="DataFormats/GEMDigi"/>
   <use name="DataFormats/GEMRecHit"/>
-  <use name="Geometry/Records"/>
-  <use name="Geometry/GEMGeometry"/>
   <use name="Validation/MuonGEMHits"/>
 </library>

--- a/DQM/SiStripMonitorSummary/plugins/BuildFile.xml
+++ b/DQM/SiStripMonitorSummary/plugins/BuildFile.xml
@@ -8,9 +8,7 @@
 <use name="DataFormats/SiStripDetId"/>
 <use name="CalibTracker/Records"/>
 <use name="CommonTools/TrackerMap"/>
-<use name="DQM/SiStripCommon"/>
 <use name="DQM/SiStripMonitorSummary"/>
-<use name="DQMServices/Core"/>
 <library file="*.cc" name="DQMSiStripMonitorSummaryplugins">
   <flags EDM_PLUGIN="1"/>
 </library>

--- a/DataFormats/DTDigi/BuildFile.xml
+++ b/DataFormats/DTDigi/BuildFile.xml
@@ -1,7 +1,7 @@
 <use name="DataFormats/Common"/>
 <use name="DataFormats/MuonDetId"/>
 <use name="DataFormats/FEDRawData"/>
-<use name="DataFormats/MuonData"/>
+<use name="DataFormats/MuonData" source_only="1"/>
 <use name="FWCore/Utilities"/>
 <export>
   <lib name="1"/>

--- a/DataFormats/HLTReco/BuildFile.xml
+++ b/DataFormats/HLTReco/BuildFile.xml
@@ -11,7 +11,6 @@
 <use name="DataFormats/TauReco"/>
 <use name="DataFormats/L1TParticleFlow"/>
 <use name="DataFormats/L1TCorrelator"/>
-<use name="FWCore/MessageLogger"/>
 <use name="DataFormats/GsfTrackReco"/>
 <export>
   <lib name="1"/>

--- a/GeneratorInterface/LHEInterface/plugins/BuildFile.xml
+++ b/GeneratorInterface/LHEInterface/plugins/BuildFile.xml
@@ -6,7 +6,6 @@
 <use name="stdcxx-fs"/>
 <library name="GeneratorInterfaceLHEProducer" file="LHEFilter.cc LHE2HepMCConverter.cc ExternalLHEProducer.cc ExternalLHEAsciiDumper.cc">
   <use name="FWCore/Framework"/>
-  <use name="FWCore/Concurrency"/>
   <use name="SimDataFormats/GeneratorProducts"/>
   <flags EDM_PLUGIN="1"/>
 </library>

--- a/Geometry/VeryForwardGeometry/BuildFile.xml
+++ b/Geometry/VeryForwardGeometry/BuildFile.xml
@@ -1,6 +1,5 @@
 <export>
   <lib name="1"/>
 </export>
-<use name="CondFormats/PPSObjects"/>
 <use name="hepmc"/>
 <use name="heppdt"/>

--- a/L1Trigger/L1CaloTrigger/BuildFile.xml
+++ b/L1Trigger/L1CaloTrigger/BuildFile.xml
@@ -1,5 +1,4 @@
 <use name="FWCore/ParameterSet"/>
-<use name="DataFormats/L1TCalorimeterPhase2"/>
 <use   name="clhep"/>
 
 <export> 

--- a/L1Trigger/L1CaloTrigger/plugins/BuildFile.xml
+++ b/L1Trigger/L1CaloTrigger/plugins/BuildFile.xml
@@ -2,6 +2,7 @@
 <use   name="Geometry/CaloGeometry"/>
 <use   name="Geometry/HcalTowerAlgo"/>
 <use   name="Geometry/EcalAlgo"/>
+<use   name="DataFormats/L1TCalorimeterPhase2"/>
 <use   name="DataFormats/L1Trigger"/>
 <use   name="DataFormats/HcalDetId"/>
 <use   name="DataFormats/EcalDigi"/>

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/BuildFile.xml
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/BuildFile.xml
@@ -9,7 +9,6 @@
 <use name="FWCore/ParameterSet"/>
 <use name="FWCore/Utilities"/>
 <use name="HeterogeneousCore/CUDACore"/>
-<use name="RecoLocalTracker/SiPixelClusterizer"/>
 <use name="RecoTracker/Record"/>
 <library file="*.cc *.cu" name="RecoLocalTrackerSiPixelClusterizerPlugins">
   <flags EDM_PLUGIN="1"/>

--- a/RecoTracker/TkSeedGenerator/plugins/BuildFile.xml
+++ b/RecoTracker/TkSeedGenerator/plugins/BuildFile.xml
@@ -31,7 +31,7 @@
 <use name="MagneticField/UniformEngine"/>
 <use name="RecoTracker/MeasurementDet"/>
 <use name="RecoTracker/Record"/>
-<use name="RecoTracker/SpecialSeedGenerators"/>
+<use name="RecoTracker/SpecialSeedGenerators" source_only="1"/>
 <use name="RecoTracker/TkHitPairs"/>
 <use name="RecoTracker/TkSeedingLayers"/>
 <use name="RecoTracker/TransientTrackingRecHit"/>

--- a/SimDataFormats/CrossingFrame/BuildFile.xml
+++ b/SimDataFormats/CrossingFrame/BuildFile.xml
@@ -1,6 +1,5 @@
 <use name="DataFormats/Common"/>
 <use name="DataFormats/Provenance"/>
-<use name="FWCore/MessageLogger"/>
 <use name="FWCore/Utilities"/>
 <use name="SimDataFormats/CaloHit"/>
 <use name="SimDataFormats/EncodedEventId"/>

--- a/SimDataFormats/DigiSimLinks/BuildFile.xml
+++ b/SimDataFormats/DigiSimLinks/BuildFile.xml
@@ -1,7 +1,7 @@
 <use name="DataFormats/Common"/>
 <use name="SimDataFormats/EncodedEventId"/>
 <use name="DataFormats/MuonDetId"/>
-<use name="DataFormats/MuonData"/>
+<use name="DataFormats/MuonData" source_only="1"/>
 <use name="boost"/>
 <export>
   <lib name="1"/>

--- a/SimPPS/PPSPixelDigiProducer/BuildFile.xml
+++ b/SimPPS/PPSPixelDigiProducer/BuildFile.xml
@@ -1,7 +1,6 @@
 <use name="CondFormats/PPSObjects"/>
 <use name="DataFormats/CTPPSDigi"/>
 <use name="FWCore/ParameterSet"/>
-<use name="Geometry/VeryForwardGeometry"/>
 <use name="SimTracker/Common"/>
 <export>
   <lib name="1"/>


### PR DESCRIPTION
#### PR description:

Another quick BuildFile cleaning PR in the style of many before (for example https://github.com/cms-sw/cmssw/pull/33019).

This PR cleans unnecessary includes from CMSSW BuildFiles that were recently added.

More importantly, it also adds the `source_only="1"` flag when there are dependencies on source-only packages that have no BuildFiles themselves. Otherwise, we get a warning. We had the same situation with [FWCore/SOA](https://github.com/cms-sw/cmssw/blob/master/CommonTools/Utils/BuildFile.xml#L5) (see https://github.com/cms-sw/cmssw/pull/31459#issuecomment-692737732). I just noticed it because even thought missing this flag results in only a warning with scram, it causes my [experimental CMSSW Arch linux package](https://github.com/guitargeek/PKGBUILDs/tree/master/cmssw) to not compile.

This PR further fixes a typo I made in the previous PR https://github.com/cms-sw/cmssw/pull/33019.

#### PR validation:

CMSSW compiles.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

No backport intended.