### PR TITLE
remove boost/filesystem usage

### DIFF
--- a/CondCore/Utilities/src/CondDBTools.cc
+++ b/CondCore/Utilities/src/CondDBTools.cc
@@ -4,7 +4,6 @@
 //
 #include "CondCore/CondDB/src/DbCore.h"
 //
-#include <boost/filesystem.hpp>
 #include <boost/regex.hpp>
 #include <boost/bind.hpp>
 #include <memory>

--- a/DQMServices/FwkIO/plugins/BuildFile.xml
+++ b/DQMServices/FwkIO/plugins/BuildFile.xml
@@ -7,7 +7,6 @@
 <use name="FWCore/Utilities"/>
 <use name="FWCore/Catalog"/>
 <use name="roothistmatrix"/>
-<use name="boost_filesystem"/>
 <library file="*.cc" name="DQMServicesFwkIOPlugins">
   <flags EDM_PLUGIN="1"/>
 </library>

--- a/DQMServices/FwkIO/plugins/DQMRootOutputModule.cc
+++ b/DQMServices/FwkIO/plugins/DQMRootOutputModule.cc
@@ -20,7 +20,6 @@
 #include <string>
 #include <vector>
 
-#include <boost/filesystem.hpp>
 #include "TFile.h"
 #include "TTree.h"
 #include "TString.h"

--- a/DQMServices/StreamerIO/plugins/DQMFileIterator.cc
+++ b/DQMServices/StreamerIO/plugins/DQMFileIterator.cc
@@ -94,7 +94,7 @@ namespace dqmservices {
     std::vector<std::string> tokens;
     boost::split(tokens, runInputDir_, boost::is_any_of(":"));
 
-    for (auto token : tokens) {
+    for (const auto& token : tokens) {
       runPath_.push_back(fmt::sprintf("%s/run%06d", token, runNumber_));
     }
 
@@ -182,7 +182,7 @@ namespace dqmservices {
   unsigned DQMFileIterator::mtimeHash() const {
     unsigned mtime_now = 0;
 
-    for (auto path : runPath_) {
+    for (const auto& path : runPath_) {
       if (!std::filesystem::exists(path))
         continue;
 
@@ -224,7 +224,7 @@ namespace dqmservices {
 
     std::string fn_eor;
 
-    for (auto runPath : runPath_) {
+    for (const auto& runPath : runPath_) {
       if (!std::filesystem::exists(runPath)) {
         logFileAction("Directory does not exist: ", runPath);
 

--- a/DQMServices/StreamerIO/plugins/DQMFileIterator.cc
+++ b/DQMServices/StreamerIO/plugins/DQMFileIterator.cc
@@ -5,7 +5,6 @@
 
 #include <boost/algorithm/string.hpp>
 #include <boost/algorithm/string/predicate.hpp>
-#include <boost/filesystem.hpp>
 #include <boost/property_tree/json_parser.hpp>
 #include <boost/property_tree/ptree.hpp>
 #include <boost/range.hpp>

--- a/DQMServices/StreamerIO/plugins/RamdiskMonitor.cc
+++ b/DQMServices/StreamerIO/plugins/RamdiskMonitor.cc
@@ -5,7 +5,6 @@
 
 #include <fmt/printf.h>
 #include <boost/algorithm/string/predicate.hpp>
-#include <boost/filesystem.hpp>
 #include <boost/range.hpp>
 #include <boost/regex.hpp>
 

--- a/EventFilter/Utilities/plugins/RawEventFileWriterForBU.cc
+++ b/EventFilter/Utilities/plugins/RawEventFileWriterForBU.cc
@@ -4,7 +4,6 @@
 #include <cstring>
 #include <iostream>
 #include <sstream>
-//#include <boost/filesystem/fstream.hpp>
 
 // CMSSW headers
 #include "EventFilter/Utilities/interface/EvFDaqDirector.h"

--- a/EventFilter/Utilities/src/EvFDaqDirector.cc
+++ b/EventFilter/Utilities/src/EvFDaqDirector.cc
@@ -1275,7 +1275,7 @@ namespace evf {
           std::ifstream ij(jsonDestPath);
           ss << ij.rdbuf();
         } catch (std::filesystem::filesystem_error const& ex) {
-          edm::LogError("EvFDaqDirector") << "grabNextJsonFile - BOOST FILESYSTEM ERROR CAUGHT -: " << ex.what();
+          edm::LogError("EvFDaqDirector") << "grabNextJsonFile - FILESYSTEM ERROR CAUGHT -: " << ex.what();
           return -1;
         }
         result = reader.parse(ss.str(), deserializeRoot);

--- a/EventFilter/Utilities/src/EvFDaqDirector.cc
+++ b/EventFilter/Utilities/src/EvFDaqDirector.cc
@@ -17,13 +17,12 @@
 #include "IOPool/Streamer/interface/FRDFileHeader.h"
 
 #include <iostream>
-//#include <istream>
+#include <fstream>
 #include <sstream>
 #include <sys/time.h>
 #include <unistd.h>
 #include <cstdio>
 #include <boost/lexical_cast.hpp>
-#include <boost/filesystem/fstream.hpp>
 #include <boost/algorithm/string.hpp>
 
 //using boost::asio::ip::tcp;

--- a/EventFilter/Utilities/src/FastMonitor.cc
+++ b/EventFilter/Utilities/src/FastMonitor.cc
@@ -16,7 +16,6 @@
 #include <cassert>
 #include <sys/types.h>
 #include <unistd.h>
-#include <boost/filesystem/fstream.hpp>
 
 using namespace jsoncollector;
 

--- a/EventFilter/Utilities/src/FedRawDataInputSource.cc
+++ b/EventFilter/Utilities/src/FedRawDataInputSource.cc
@@ -14,7 +14,6 @@
 #include <chrono>
 
 #include <boost/algorithm/string.hpp>
-#include <boost/filesystem/fstream.hpp>
 
 #include "DataFormats/FEDRawData/interface/FEDHeader.h"
 #include "DataFormats/FEDRawData/interface/FEDTrailer.h"

--- a/HLTrigger/Tools/bin/BuildFile.xml
+++ b/HLTrigger/Tools/bin/BuildFile.xml
@@ -13,7 +13,6 @@
 <bin name="hltDiff" file="hltDiff.cc">
   <use name="jemalloc"/>
   <use name="boost"/>
-  <use name="boost_filesystem"/>
   <use name="FWCore/Common"/>
   <use name="FWCore/Utilities"/>
   <use name="DataFormats/Common"/>

--- a/HLTrigger/Tools/bin/hltDiff.cc
+++ b/HLTrigger/Tools/bin/hltDiff.cc
@@ -22,7 +22,6 @@
 #include <cmath>
 
 #include <boost/algorithm/string.hpp>
-#include <boost/filesystem.hpp>
 
 #include <TFile.h>
 #include <TCanvas.h>

--- a/PhysicsTools/MXNet/test/BuildFile.xml
+++ b/PhysicsTools/MXNet/test/BuildFile.xml
@@ -2,7 +2,6 @@
   <use name="mxnet-predict"/>
 </test>
 <bin name="testMXNetCppPredictor" file="testRunner.cpp, testMXNetCppPredictor.cc">
-  <use name="boost_filesystem"/>
   <use name="cppunit"/>
   <use name="PhysicsTools/MXNet"/>
   <use name="FWCore/ParameterSet"/>

--- a/PhysicsTools/ONNXRuntime/test/BuildFile.xml
+++ b/PhysicsTools/ONNXRuntime/test/BuildFile.xml
@@ -2,7 +2,6 @@
   <use name="onnxruntime"/>
 </test>
 <bin name="testONNXRuntime" file="testRunner.cpp, testONNXRuntime.cc">
-  <use name="boost_filesystem"/>
   <use name="cppunit"/>
   <use name="PhysicsTools/ONNXRuntime"/>
   <use name="FWCore/ParameterSet"/>

--- a/PhysicsTools/TensorFlow/test/testBase.h
+++ b/PhysicsTools/TensorFlow/test/testBase.h
@@ -8,6 +8,7 @@
 #define PHYSICSTOOLS_TENSORFLOW_TEST_TESTBASE_H
 
 #include <boost/filesystem.hpp>
+#include <filesystem>
 #include <cppunit/extensions/HelperMacros.h>
 #include <stdexcept>
 
@@ -45,8 +46,8 @@ void testBase::setUp() {
 }
 
 void testBase::tearDown() {
-  if (boost::filesystem::exists(dataPath_)) {
-    boost::filesystem::remove_all(dataPath_);
+  if (std::filesystem::exists(dataPath_)) {
+    std::filesystem::remove_all(dataPath_);
   }
 }
 
@@ -58,7 +59,7 @@ std::string testBase::cmsswPath(std::string path) {
   std::string base = std::string(std::getenv("CMSSW_BASE"));
   std::string releaseBase = std::string(std::getenv("CMSSW_RELEASE_BASE"));
 
-  return (boost::filesystem::exists(base.c_str()) ? base : releaseBase) + path;
+  return (std::filesystem::exists(base.c_str()) ? base : releaseBase) + path;
 }
 
 #endif  // PHYSICSTOOLS_TENSORFLOW_TEST_TESTBASE_H

--- a/RecoLuminosity/LumiProducer/plugins/DIPLumiProducer.cc
+++ b/RecoLuminosity/LumiProducer/plugins/DIPLumiProducer.cc
@@ -56,8 +56,6 @@ Description: A essource/esproducer for lumi values from DIP via runtime logger D
 #include "Utilities/Xerces/interface/Xerces.h"
 #include <xercesc/util/XMLString.hpp>
 
-#include "boost/filesystem/path.hpp"
-#include "boost/filesystem/operations.hpp"
 
 DIPLumiProducer::DIPLumiProducer(const edm::ParameterSet& iConfig)
     : m_connectStr(""), m_summarycachedrun(0), m_detailcachedrun(0), m_cachesize(0) {

--- a/RecoLuminosity/LumiProducer/plugins/DIPLumiProducer.cc
+++ b/RecoLuminosity/LumiProducer/plugins/DIPLumiProducer.cc
@@ -56,7 +56,6 @@ Description: A essource/esproducer for lumi values from DIP via runtime logger D
 #include "Utilities/Xerces/interface/Xerces.h"
 #include <xercesc/util/XMLString.hpp>
 
-
 DIPLumiProducer::DIPLumiProducer(const edm::ParameterSet& iConfig)
     : m_connectStr(""), m_summarycachedrun(0), m_detailcachedrun(0), m_cachesize(0) {
   setWhatProduced(this, &DIPLumiProducer::produceSummary);

--- a/Utilities/LStoreAdaptor/BuildFile.xml
+++ b/Utilities/LStoreAdaptor/BuildFile.xml
@@ -6,6 +6,5 @@
 <use name="FWCore/Utilities"/>
 <use name="FWCore/MessageLogger"/>
 <use name="boost"/>
-<use name="boost_filesystem"/>
 <use name="boost_regex"/>
 <flags CPPDEFINES="_FILE_OFFSET_BITS=64"/>


### PR DESCRIPTION
Cleanup boost/filesystem usage. With new boost version 1.75 , boost filesystem makes use of statx (if available on the build machine) and fails if run on a machine without it. The PR proposes to drop boost filesystem usage and replace it with std::filesystem 