### PR TITLE
Add displaced muon info from EMTF to RegionalMuonCand (un)packing and to uGMT DQM

### DIFF
--- a/DQM/L1TMonitor/interface/L1TStage2RegionalMuonCandComp.h
+++ b/DQM/L1TMonitor/interface/L1TStage2RegionalMuonCandComp.h
@@ -63,6 +63,10 @@ private:
     RPT2
   };
   enum tfs { BMTFBIN = 1, OMTFNEGBIN, OMTFPOSBIN, EMTFNEGBIN, EMTFPOSBIN };
+  int numSummaryBins_{
+      TRACKADDRBAD};  // In Run-2 we didn't have the last two bins. This is incremented in source file if we configure for Run-3.
+  int numErrBins_{
+      RTRACKADDR};  // In Run-2 we didn't have the last two bins. This is incremented in source file if we configure for Run-3.
   bool incBin[RPT2 + 1];
 
   edm::EDGetTokenT<l1t::RegionalMuonCandBxCollection> muonToken1;

--- a/DQM/L1TMonitor/interface/L1TStage2RegionalMuonCandComp.h
+++ b/DQM/L1TMonitor/interface/L1TStage2RegionalMuonCandComp.h
@@ -74,7 +74,7 @@ private:
   bool ignoreBadTrkAddr;
   std::vector<int> ignoreBin;
   bool verbose;
-  bool isBmtf;
+  bool hasDisplacementInfo;
 
   MonitorElement* summary;
   MonitorElement* errorSummaryNum;

--- a/DQM/L1TMonitor/interface/L1TStage2uGMT.h
+++ b/DQM/L1TMonitor/interface/L1TStage2uGMT.h
@@ -77,6 +77,8 @@ private:
   MonitorElement* ugmtEMTFBX;
   MonitorElement* ugmtEMTFnMuons;
   MonitorElement* ugmtEMTFhwPt;
+  MonitorElement* ugmtEMTFhwPtUnconstrained;
+  MonitorElement* ugmtEMTFhwDXY;
   MonitorElement* ugmtEMTFhwEta;
   MonitorElement* ugmtEMTFhwPhiPos;
   MonitorElement* ugmtEMTFhwPhiNeg;

--- a/DQM/L1TMonitor/python/L1TStage2BMTF_cff.py
+++ b/DQM/L1TMonitor/python/L1TStage2BMTF_cff.py
@@ -39,7 +39,7 @@ l1tStage2BmtfSecond = l1tStage2Bmtf.clone()
 l1tStage2BmtfSecond.bmtfSource = cms.InputTag("bmtfDigis","BMTF2")
 l1tStage2BmtfSecond.monitorDir = cms.untracked.string("L1T/L1TStage2BMTF/L1TStage2BMTF-Secondary")
 l1tStage2BmtfSecond.verbose = cms.untracked.bool(False)
-l1tStage2BmtfSecond.isBmtf = cms.untracked.bool(True)
+l1tStage2BmtfSecond.hasDisplacementInfo = cms.untracked.bool(True)
 
 # sequences
 l1tStage2BmtfOnlineDQMSeq = cms.Sequence(

--- a/DQM/L1TMonitor/python/L1TStage2uGMT_cff.py
+++ b/DQM/L1TMonitor/python/L1TStage2uGMT_cff.py
@@ -54,6 +54,10 @@ l1tStage2uGMTIntermediateEMTFPos = DQMEDAnalyzer(
     displacedQuantities = cms.untracked.bool(False)
 )
 
+## Era: Run3_2021; Displaced muons from EMTF used in uGMT from Run-3
+stage2L1Trigger_2021.toModify(l1tStage2uGMTIntermediateEMTFNeg, displacedQuantities = cms.untracked.bool(True))
+stage2L1Trigger_2021.toModify(l1tStage2uGMTIntermediateEMTFPos, displacedQuantities = cms.untracked.bool(True))
+
 # zero suppression DQM
 l1tStage2uGMTZeroSupp = DQMEDAnalyzer(
     "L1TMP7ZeroSupp",
@@ -129,7 +133,7 @@ l1tStage2BmtfOutVsuGMTIn = DQMEDAnalyzer(
 
 ## Era: Run3_2021; Displaced muons from BMTF used in uGMT from Run-3
 from Configuration.Eras.Modifier_stage2L1Trigger_2021_cff import stage2L1Trigger_2021
-stage2L1Trigger_2021.toModify(l1tStage2BmtfOutVsuGMTIn, isBmtf = cms.untracked.bool(True))
+stage2L1Trigger_2021.toModify(l1tStage2BmtfOutVsuGMTIn, hasDisplacementInfo = cms.untracked.bool(True))
 
 # compares the unpacked OMTF output regional muon collection with the unpacked uGMT input regional muon collection from OMTF
 # only muons that do not match are filled in the histograms
@@ -158,6 +162,9 @@ l1tStage2EmtfOutVsuGMTIn = DQMEDAnalyzer(
     ignoreBin = cms.untracked.vint32(ignoreBins['Emtf']),
     verbose = cms.untracked.bool(False),
 )
+
+## Era: Run3_2021; Displaced muons from EMTF used in uGMT from Run-3
+stage2L1Trigger_2021.toModify(l1tStage2EmtfOutVsuGMTIn, hasDisplacementInfo = cms.untracked.bool(True))
 
 # The five modules below compare the primary unpacked uGMT muon collection to goes to uGT board 0
 # to the unpacked uGMT muon collections that are sent to uGT boards 1 to 5.

--- a/DQM/L1TMonitor/python/L1TdeStage2BMTFSecond_cff.py
+++ b/DQM/L1TMonitor/python/L1TdeStage2BMTFSecond_cff.py
@@ -14,7 +14,7 @@ l1tdeStage2BmtfSecond.regionalMuonCollection2Title = cms.untracked.string("BMTF2
 l1tdeStage2BmtfSecond.summaryTitle = cms.untracked.string("Summary of comparison between BMTF2 muons and BMTF2 emulator muons")
 l1tdeStage2BmtfSecond.ignoreBin = cms.untracked.vint32(ignoreBinsDeStage2Bmtf)
 l1tdeStage2BmtfSecond.verbose = cms.untracked.bool(False)
-l1tdeStage2BmtfSecond.isBmtf = cms.untracked.bool(True)
+l1tdeStage2BmtfSecond.hasDisplacementInfo = cms.untracked.bool(True)
 
 
 

--- a/DQM/L1TMonitor/python/L1TdeStage2BMTF_cfi.py
+++ b/DQM/L1TMonitor/python/L1TdeStage2BMTF_cfi.py
@@ -17,6 +17,6 @@ l1tdeStage2Bmtf = DQMEDAnalyzer(
     summaryTitle = cms.untracked.string("Summary of comparison between BMTF muons and BMTF emulator muons"),
     ignoreBin = cms.untracked.vint32(ignoreBinsDeStage2Bmtf),
     verbose = cms.untracked.bool(False),
-    isBmtf = cms.untracked.bool(True)
+    hasDisplacementInfo = cms.untracked.bool(True)
 )
 

--- a/DQM/L1TMonitor/python/L1TdeStage2uGMT_cff.py
+++ b/DQM/L1TMonitor/python/L1TdeStage2uGMT_cff.py
@@ -66,6 +66,10 @@ l1tStage2uGMTIntermediateEMTFPosEmul = DQMEDAnalyzer(
     verbose = cms.untracked.bool(False),
 )
 
+## Era: Run3_2021; Displaced muons from EMTF used in uGMT from Run-3
+stage2L1Trigger_2021.toModify(l1tStage2uGMTIntermediateEMTFNegEmul, displacedQuantities = cms.untracked.bool(True))
+stage2L1Trigger_2021.toModify(l1tStage2uGMTIntermediateEMTFPosEmul, displacedQuantities = cms.untracked.bool(True))
+
 # compares the unpacked uGMT muon collection to the emulated uGMT muon collection
 # only muons that do not match are filled in the histograms
 l1tdeStage2uGMT = DQMEDAnalyzer(

--- a/DQM/L1TMonitor/src/L1TStage2MuonComp.cc
+++ b/DQM/L1TMonitor/src/L1TStage2MuonComp.cc
@@ -12,8 +12,11 @@ L1TStage2MuonComp::L1TStage2MuonComp(const edm::ParameterSet& ps)
       enable2DComp(
           ps.getUntrackedParameter<bool>("enable2DComp")),  // When true eta-phi comparison plots are also produced
       displacedQuantities_(ps.getUntrackedParameter<bool>("displacedQuantities")) {
+  if (displacedQuantities_) {
+    numErrBins_ += 2;
+  }
   // First include all bins
-  for (unsigned int i = 1; i <= RIDX; i++) {
+  for (int i = 1; i <= numErrBins_; i++) {
     incBin[i] = true;
   }
   // Then check the list of bins to ignore
@@ -74,9 +77,6 @@ void L1TStage2MuonComp::bookHistograms(DQMStore::IBooker& ibooker, const edm::Ru
     summary->setBinLabel(DXYBAD, "dXY mismatch", 1);
   }
 
-  if (displacedQuantities_) {
-    numErrBins_ += 2;
-  }
   errorSummaryNum = ibooker.book1D(
       "errorSummaryNum", summaryTitle.c_str(), numErrBins_, 1, numErrBins_ + 1);  // range to match bin numbering
   errorSummaryNum->setBinLabel(RBXRANGE, "BX range mismatch", 1);

--- a/DQM/L1TMonitor/src/L1TStage2RegionalMuonCandComp.cc
+++ b/DQM/L1TMonitor/src/L1TStage2RegionalMuonCandComp.cc
@@ -12,7 +12,7 @@ L1TStage2RegionalMuonCandComp::L1TStage2RegionalMuonCandComp(const edm::Paramete
       ignoreBadTrkAddr(ps.getUntrackedParameter<bool>("ignoreBadTrackAddress")),
       ignoreBin(ps.getUntrackedParameter<std::vector<int>>("ignoreBin")),
       verbose(ps.getUntrackedParameter<bool>("verbose")),
-      isBmtf(ps.getUntrackedParameter<bool>("isBmtf")) {
+      hasDisplacementInfo(ps.getUntrackedParameter<bool>("hasDisplacementInfo")) {
   // First include all bins
   for (unsigned int i = 1; i <= RPT2; i++) {
     incBin[i] = true;
@@ -41,7 +41,7 @@ void L1TStage2RegionalMuonCandComp::fillDescriptions(edm::ConfigurationDescripti
   desc.addUntracked<bool>("ignoreBadTrackAddress", false)->setComment("Ignore muon track address mismatches.");
   desc.addUntracked<std::vector<int>>("ignoreBin", std::vector<int>())->setComment("List of bins to ignore");
   desc.addUntracked<bool>("verbose", false);
-  desc.addUntracked<bool>("isBmtf", false);
+  desc.addUntracked<bool>("hasDisplacementInfo", false);
   descriptions.add("l1tStage2RegionalMuonCandComp", desc);
 }
 
@@ -54,7 +54,7 @@ void L1TStage2RegionalMuonCandComp::bookHistograms(DQMStore::IBooker& ibooker,
   }
 
   int nbins = 17;
-  if (isBmtf) {
+  if (hasDisplacementInfo) {
     nbins += 2;
   }
 
@@ -80,13 +80,13 @@ void L1TStage2RegionalMuonCandComp::bookHistograms(DQMStore::IBooker& ibooker,
   summary->setBinLabel(PROCBAD, "processor mismatch", 1);
   summary->setBinLabel(TFBAD, "track finder type mismatch", 1);
   summary->setBinLabel(TRACKADDRBAD, "track address mismatch", 1);
-  if (isBmtf) {
+  if (hasDisplacementInfo) {
     summary->setBinLabel(DXYBAD, "DXY mismatch", 1);
     summary->setBinLabel(PT2BAD, "P_{T} unconstrained mismatch", 1);
   }
 
   int nbinsNum = 14;
-  if (isBmtf) {
+  if (hasDisplacementInfo) {
     nbinsNum += 2;
   }
 
@@ -109,7 +109,7 @@ void L1TStage2RegionalMuonCandComp::bookHistograms(DQMStore::IBooker& ibooker,
   errorSummaryNum->setBinLabel(RPROC, "processor mismatch", 1);
   errorSummaryNum->setBinLabel(RTF, "track finder type mismatch", 1);
   errorSummaryNum->setBinLabel(RTRACKADDR, "track address mismatch", 1);
-  if (isBmtf) {
+  if (hasDisplacementInfo) {
     errorSummaryNum->setBinLabel(RDXY, "DXY mismatch", 1);
     errorSummaryNum->setBinLabel(RPT2, "P_{T} unconstrained mismatch", 1);
   }
@@ -195,7 +195,7 @@ void L1TStage2RegionalMuonCandComp::bookHistograms(DQMStore::IBooker& ibooker,
                                   15.5);
   muColl1TrkAddr->setAxisTitle("key", 1);
   muColl1TrkAddr->setAxisTitle("value", 2);
-  if (isBmtf) {
+  if (hasDisplacementInfo) {
     muColl1hwDXY = ibooker.book1D("muhwDXYColl1", (muonColl1Title + " HW DXY" + trkAddrIgnoreText).c_str(), 4, 0, 4);
     muColl1hwDXY->setAxisTitle("Hardware DXY", 1);
     muColl1hwPtUnconstrained = ibooker.book1D("muhwPtUnconstrainedColl1",
@@ -266,7 +266,7 @@ void L1TStage2RegionalMuonCandComp::bookHistograms(DQMStore::IBooker& ibooker,
                                   15.5);
   muColl2TrkAddr->setAxisTitle("key", 1);
   muColl2TrkAddr->setAxisTitle("value", 2);
-  if (isBmtf) {
+  if (hasDisplacementInfo) {
     muColl2hwDXY = ibooker.book1D("muhwDXYColl2", (muonColl2Title + " HW DXY" + trkAddrIgnoreText).c_str(), 4, 0, 4);
     muColl2hwDXY->setAxisTitle("Hardware DXY", 1);
     muColl2hwPtUnconstrained = ibooker.book1D("muhwPtUnconstrainedColl2",
@@ -337,7 +337,7 @@ void L1TStage2RegionalMuonCandComp::analyze(const edm::Event& e, const edm::Even
           muColl1trackFinderType->Fill(muonIt1->trackFinderType());
           muColl1hwHF->Fill(muonIt1->hwHF());
           muColl1TrkAddrSize->Fill(muon1TrackAddr.size());
-          if (isBmtf) {
+          if (hasDisplacementInfo) {
             muColl1hwDXY->Fill(muonIt1->hwDXY());
             muColl1hwPtUnconstrained->Fill(muonIt1->hwPtUnconstrained());
           }
@@ -361,7 +361,7 @@ void L1TStage2RegionalMuonCandComp::analyze(const edm::Event& e, const edm::Even
           muColl2trackFinderType->Fill(muonIt2->trackFinderType());
           muColl2hwHF->Fill(muonIt2->hwHF());
           muColl2TrkAddrSize->Fill(muon2TrackAddr.size());
-          if (isBmtf) {
+          if (hasDisplacementInfo) {
             muColl2hwDXY->Fill(muonIt2->hwDXY());
             muColl2hwPtUnconstrained->Fill(muonIt2->hwPtUnconstrained());
           }
@@ -503,7 +503,7 @@ void L1TStage2RegionalMuonCandComp::analyze(const edm::Event& e, const edm::Even
           errorSummaryNum->Fill(RTRACKADDR);
       }
 
-      if (isBmtf) {
+      if (hasDisplacementInfo) {
         if (muonIt1->hwDXY() != muonIt2->hwDXY()) {
           muonMismatch = true;
           summary->Fill(DXYBAD);
@@ -538,7 +538,7 @@ void L1TStage2RegionalMuonCandComp::analyze(const edm::Event& e, const edm::Even
         muColl1trackFinderType->Fill(muonIt1->trackFinderType());
         muColl1hwHF->Fill(muonIt1->hwHF());
         muColl1TrkAddrSize->Fill(muon1TrackAddr.size());
-        if (isBmtf) {
+        if (hasDisplacementInfo) {
           muColl1hwDXY->Fill(muonIt1->hwDXY());
           muColl1hwPtUnconstrained->Fill(muonIt1->hwPtUnconstrained());
         }
@@ -558,7 +558,7 @@ void L1TStage2RegionalMuonCandComp::analyze(const edm::Event& e, const edm::Even
         muColl2trackFinderType->Fill(muonIt2->trackFinderType());
         muColl2hwHF->Fill(muonIt2->hwHF());
         muColl2TrkAddrSize->Fill(muon2TrackAddr.size());
-        if (isBmtf) {
+        if (hasDisplacementInfo) {
           muColl2hwDXY->Fill(muonIt2->hwDXY());
           muColl2hwPtUnconstrained->Fill(muonIt2->hwPtUnconstrained());
         }

--- a/DQM/L1TMonitor/src/L1TStage2uGMT.cc
+++ b/DQM/L1TMonitor/src/L1TStage2uGMT.cc
@@ -176,6 +176,15 @@ void L1TStage2uGMT::bookHistograms(DQMStore::IBooker& ibooker, const edm::Run&, 
     ugmtEMTFhwPt = ibooker.book1D("ugmtEMTFhwPt", "uGMT EMTF HW p_{T}", 512, -0.5, 511.5);
     ugmtEMTFhwPt->setAxisTitle("Hardware p_{T}", 1);
 
+    if (displacedQuantities_) {
+      ugmtEMTFhwPtUnconstrained =
+          ibooker.book1D("ugmtEMTFhwPtUnconstrained", "uGMT EMTF Input HW p_{T} unconstrained", 256, -0.5, 255.5);
+      ugmtEMTFhwPtUnconstrained->setAxisTitle("Hardware p_{T} unconstrained", 1);
+
+      ugmtEMTFhwDXY = ibooker.book1D("ugmtEMTFhwDXY", "uGMT EMTF Input HW impact parameter", 4, -0.5, 3.5);
+      ugmtEMTFhwDXY->setAxisTitle("Hardware dXY", 1);
+    }
+
     ugmtEMTFhwEta = ibooker.book1D("ugmtEMTFhwEta", "uGMT EMTF HW #eta", 461, -230.5, 230.5);
     ugmtEMTFhwEta->setAxisTitle("Hardware #eta", 1);
 
@@ -790,6 +799,10 @@ void L1TStage2uGMT::analyze(const edm::Event& e, const edm::EventSetup& c) {
            ++EMTF) {
         ugmtEMTFBX->Fill(itBX);
         ugmtEMTFhwPt->Fill(EMTF->hwPt());
+        if (displacedQuantities_) {
+          ugmtEMTFhwPtUnconstrained->Fill(EMTF->hwPtUnconstrained());
+          ugmtEMTFhwDXY->Fill(EMTF->hwDXY());
+        }
         ugmtEMTFhwEta->Fill(EMTF->hwEta());
         ugmtEMTFhwSign->Fill(EMTF->hwSign());
         ugmtEMTFhwSignValid->Fill(EMTF->hwSignValid());

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/GMTSetup.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/GMTSetup.cc
@@ -44,7 +44,7 @@ namespace l1t {
         auto gmt_in_packer = static_pointer_cast<l1t::stage2::RegionalMuonGMTPacker>(
             PackerFactory::get()->make("stage2::RegionalMuonGMTPacker"));
         if (fw >= 0x6000000) {
-          gmt_in_packer->setKalmanAlgoTrue();
+          gmt_in_packer->setIsRun3();
         }
         auto gmt_out_packer =
             static_pointer_cast<l1t::stage2::GMTMuonPacker>(PackerFactory::get()->make("stage2::GMTMuonPacker"));

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/GMTSetup.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/GMTSetup.cc
@@ -87,7 +87,7 @@ namespace l1t {
       auto gmt_in_unp = static_pointer_cast<l1t::stage2::RegionalMuonGMTUnpacker>(
           UnpackerFactory::get()->make("stage2::RegionalMuonGMTUnpacker"));
       if (fw >= 0x6000000) {
-        gmt_in_unp->setKalmanAlgoTrue();
+        gmt_in_unp->setIsRun3();
       }
 
       for (int iLink = 72; iLink < 144; iLink += 2) {

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/RegionalMuonGMTPacker.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/RegionalMuonGMTPacker.cc
@@ -54,7 +54,7 @@ namespace l1t {
           uint32_t msw = 0;
           uint32_t lsw = 0;
 
-          RegionalMuonRawDigiTranslator::generatePackedDataWords(*mu, lsw, msw, isKalman_);
+          RegionalMuonRawDigiTranslator::generatePackedDataWords(*mu, lsw, msw, isRun3_);
 
           payloadMap[linkTimes2].push_back(lsw);
           payloadMap[linkTimes2].push_back(msw);

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/RegionalMuonGMTPacker.h
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/RegionalMuonGMTPacker.h
@@ -13,13 +13,13 @@ namespace l1t {
     class RegionalMuonGMTPacker : public Packer {
     public:
       Blocks pack(const edm::Event&, const PackerTokens*) override;
-      void setKalmanAlgoTrue() { isKalman_ = true; };
+      void setIsRun3() { isRun3_ = true; };
 
     private:
       typedef std::map<unsigned int, std::vector<uint32_t>> PayloadMap;
       void packTF(const edm::Event&, const edm::EDGetTokenT<RegionalMuonCandBxCollection>&, Blocks&);
 
-      bool isKalman_{false};
+      bool isRun3_{false};
     };
   }  // namespace stage2
 }  // namespace l1t

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/RegionalMuonGMTUnpacker.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/RegionalMuonGMTUnpacker.cc
@@ -102,7 +102,7 @@ namespace l1t {
             RegionalMuonCand mu;
 
             RegionalMuonRawDigiTranslator::fillRegionalMuonCand(
-                mu, raw_data_00_31, raw_data_32_63, processor, trackFinder, isKalman_);
+                mu, raw_data_00_31, raw_data_32_63, processor, trackFinder, isRun3_);
 
             LogDebug("L1T") << "Mu" << nWord / 2 << ": eta " << mu.hwEta() << " phi " << mu.hwPhi() << " pT "
                             << mu.hwPt() << " qual " << mu.hwQual() << " sign " << mu.hwSign() << " sign valid "

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/RegionalMuonGMTUnpacker.h
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/RegionalMuonGMTUnpacker.h
@@ -10,13 +10,13 @@ namespace l1t {
     class RegionalMuonGMTUnpacker : public Unpacker {
     public:
       bool unpack(const Block& block, UnpackerCollections* coll) override;
-      void setKalmanAlgoTrue() { isKalman_ = true; }
+      void setIsRun3() { isRun3_ = true; }
 
     private:
       static constexpr unsigned nWords_ = 6;  // every link transmits 6 words (3 muons) per bx
       static constexpr unsigned bxzs_enable_shift_ = 1;
 
-      bool isKalman_{false};
+      bool isRun3_{false};
     };
   }  // namespace stage2
 }  // namespace l1t

--- a/L1Trigger/L1TMuon/interface/RegionalMuonRawDigiTranslator.h
+++ b/L1Trigger/L1TMuon/interface/RegionalMuonRawDigiTranslator.h
@@ -7,13 +7,13 @@ namespace l1t {
   class RegionalMuonRawDigiTranslator {
   public:
     static void fillRegionalMuonCand(
-        RegionalMuonCand& mu, uint32_t raw_data_00_31, uint32_t raw_data_32_63, int proc, tftype tf, bool isKalman);
-    static void fillRegionalMuonCand(RegionalMuonCand& mu, uint64_t dataword, int proc, tftype tf, bool isKalman);
+        RegionalMuonCand& mu, uint32_t raw_data_00_31, uint32_t raw_data_32_63, int proc, tftype tf, bool isRun3);
+    static void fillRegionalMuonCand(RegionalMuonCand& mu, uint64_t dataword, int proc, tftype tf, bool isRun3);
     static void generatePackedDataWords(const RegionalMuonCand& mu,
                                         uint32_t& raw_data_00_31,
                                         uint32_t& raw_data_32_63,
-                                        bool isKalman);
-    static uint64_t generate64bitDataWord(const RegionalMuonCand& mu, bool isKalman);
+                                        bool isRun3);
+    static uint64_t generate64bitDataWord(const RegionalMuonCand& mu, bool isRun3);
     static int generateRawTrkAddress(const RegionalMuonCand&, bool isKalman);
 
     static constexpr unsigned ptMask_ = 0x1FF;
@@ -31,9 +31,11 @@ namespace l1t {
     static constexpr unsigned signShift_ = 0;
     static constexpr unsigned signValidShift_ = 1;
     static constexpr unsigned dxyMask_ = 0x3;
-    static constexpr unsigned dxyShift_ = 2;
+    static constexpr unsigned bmtfDxyShift_ = 2;
+    static constexpr unsigned emtfDxyShift_ = 29;
     static constexpr unsigned ptUnconstrainedMask_ = 0xFF;
-    static constexpr unsigned ptUnconstrainedShift_ = 23;
+    static constexpr unsigned bmtfPtUnconstrainedShift_ = 23;
+    static constexpr unsigned emtfPtUnconstrainedShift_ = 20;
     static constexpr unsigned trackAddressMask_ = 0x1FFFFFFF;
     static constexpr unsigned trackAddressShift_ = 2;
     // relative shifts within track address


### PR DESCRIPTION
#### PR description:
This PR adds awareness of displaced muon information from EMTF to the RegionalMuonCand (un)packers. It also adds plots for these data to the uGMT DQM.

#### PR validation:
I ran `runTheMatrix.py -l limited -i all --ibeos` and `scram b runtests` without errors. I also checked that the plots in the DQM appeared as expected.

@eyigitba please check if this makes sense to you too. I think you may need to update the EMTF (un)packers accordingly if this hasn't been done already.
attn @rekovic, please let me know if you'd like me to backport this.