### PR TITLE
add missing buildfile dependencies to HeterogeneousCore

### DIFF
--- a/HeterogeneousCore/CUDACore/BuildFile.xml
+++ b/HeterogeneousCore/CUDACore/BuildFile.xml
@@ -1,10 +1,13 @@
 <iftool name="cuda">
   <use name="FWCore/Concurrency"/>
   <use name="FWCore/Framework"/>
+  <use name="FWCore/MessageLogger"/>
   <use name="FWCore/ServiceRegistry"/>
   <use name="FWCore/ParameterSet"/>
+  <use name="FWCore/Utilities"/>
   <use name="CUDADataFormats/Common"/>
   <use name="HeterogeneousCore/CUDAServices"/>
+  <use name="HeterogeneousCore/CUDAUtilities"/>
   <use name="cuda"/>
   <export>
     <lib name="1"/>

--- a/HeterogeneousCore/CUDAServices/BuildFile.xml
+++ b/HeterogeneousCore/CUDAServices/BuildFile.xml
@@ -2,6 +2,7 @@
   <use name="FWCore/ServiceRegistry"/>
   <use name="FWCore/ParameterSet"/>
   <use name="FWCore/MessageLogger"/>
+  <use name="FWCore/Utilities"/>
   <use name="HeterogeneousCore/CUDAUtilities"/>
   <use name="cuda"/>
   <export>

--- a/HeterogeneousCore/CUDATest/BuildFile.xml
+++ b/HeterogeneousCore/CUDATest/BuildFile.xml
@@ -1,5 +1,6 @@
 <iftool name="cuda-gcc-support">
   <use name="DataFormats/Common"/>
   <use name="CUDADataFormats/Common"/>
+  <use name="HeterogeneousCore/CUDAUtilities"/>
   <use name="rootcore"/>
 </iftool>

--- a/HeterogeneousCore/SonicTriton/BuildFile.xml
+++ b/HeterogeneousCore/SonicTriton/BuildFile.xml
@@ -1,6 +1,8 @@
-<use name="FWCore/Utilities"/>
-<use name="FWCore/ParameterSet"/>
+<use name="DataFormats/Provenance"/>
+<use name="FWCore/ServiceRegistry"/>
 <use name="FWCore/MessageLogger"/>
+<use name="FWCore/ParameterSet"/>
+<use name="FWCore/Utilities"/>
 <use name="HeterogeneousCore/SonicCore"/>
 <use name="triton-inference-server"/>
 <use name="protobuf"/>


### PR DESCRIPTION
via usual automatic script (reordered to attempt to follow the existing groupings in the files)