### PR TITLE
Updates to tauID python tool (10_6_X)

### DIFF
--- a/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
+++ b/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
@@ -381,16 +381,14 @@ def miniAOD_customizeCommon(process):
     import RecoTauTag.RecoTau.tools.runTauIdMVA as tauIdConfig
     tauIdEmbedder = tauIdConfig.TauIDEmbedder(
         process, cms, debug = False,
+        originalTauName = _noUpdatedTauName,
         updatedTauName = _updatedTauName,
         toKeep = ['deepTau2017v2']
     )
     tauIdEmbedder.runTauID()
     addToProcessAndTask(_noUpdatedTauName, process.slimmedTaus.clone(),process,task)
     delattr(process, 'slimmedTaus')
-    process.deepTau2017v2.taus = _noUpdatedTauName
-    process.slimmedTaus = getattr(process, _updatedTauName).clone(
-        src = _noUpdatedTauName
-    )
+    process.slimmedTaus = getattr(process, _updatedTauName).clone()
     process.deepTauIDTask = cms.Task(process.deepTau2017v2, process.slimmedTaus)
     task.add(process.deepTauIDTask)
 
@@ -398,18 +396,18 @@ def miniAOD_customizeCommon(process):
     _updatedTauNameNew = 'slimmedTausDeepIDsv2p1'
     tauIdEmbedderNew = tauIdConfig.TauIDEmbedder(
         process, cms, debug = False,
+        originalTauName = _noUpdatedTauName,
         updatedTauName = _updatedTauNameNew,
         toKeep = ['deepTau2017v2p1']
     )
     tauIdEmbedderNew.runTauID()
-    process.deepTau2017v2p1.taus = _noUpdatedTauName
     deepTauIDTaskNew_ = cms.Task(process.deepTau2017v2p1,process.slimmedTaus)
 
     from Configuration.Eras.Modifier_run2_tau_ul_2016_cff import run2_tau_ul_2016
     from Configuration.Eras.Modifier_run2_tau_ul_2018_cff import run2_tau_ul_2018
     for era in [run2_miniAOD_UL,run2_tau_ul_2016,run2_tau_ul_2018]:
         era.toReplaceWith(process.slimmedTaus,
-                          getattr(process, _updatedTauNameNew).clone(src = _noUpdatedTauName))
+                          getattr(process, _updatedTauNameNew))
         era.toReplaceWith(process.deepTauIDTask,
                           deepTauIDTaskNew_)
 

--- a/RecoTauTag/RecoTau/python/tools/runTauIdMVA.py
+++ b/RecoTauTag/RecoTau/python/tools/runTauIdMVA.py
@@ -188,18 +188,17 @@ class TauIDEmbedder(object):
 
             wp_to_eff_match = {
                 "VVLoose" : "WPEff95",
-                "VLoose" : "WPEff90",
                 "Loose" : "WPEff80",
                 "Medium" : "WPEff70",
                 "Tight" : "WPEff60",
                 "VTight" : "WPEff50",
                 "VVTight" : "WPEff40"
             }
-            for wp in ["VVLoose","Loose","Medium","Tight","VTight","VVTight"]:
+            for wp,wpEff in wp_to_eff_match.items():
                 _aWP = "rerunDiscriminationByIsolationOldDMMVArun2017v1"+wp+self.postfix
                 setattr(self.process,_aWP,_byIsolationOldDMMVArun2017v1VLooseProd.clone())
                 _aWPProd = getattr(self.process,_aWP)
-                _aWPProd.mapping[0].cut = self.cms.string("RecoTauTag_tauIdMVAIsoDBoldDMwLT2017v1_"+wp_to_eff_match[wp])
+                _aWPProd.mapping[0].cut = self.cms.string("RecoTauTag_tauIdMVAIsoDBoldDMwLT2017v1_"+wpEff)
                 _rerunIsolationOldDMMVArun2017v1Task.add(_aWPProd)
                 setattr(tauIDSources,"by"+wp+"IsolationMVArun2017v1DBoldDMwLT2017",self.cms.InputTag(_aWP))
 
@@ -265,18 +264,17 @@ class TauIDEmbedder(object):
 
             wp_to_eff_match = {
                 "VVLoose" : "WPEff95",
-                "VLoose" : "WPEff90",
                 "Loose" : "WPEff80",
                 "Medium" : "WPEff70",
                 "Tight" : "WPEff60",
                 "VTight" : "WPEff50",
                 "VVTight" : "WPEff40"
             }
-            for wp in ["VVLoose","Loose","Medium","Tight","VTight","VVTight"]:
+            for wp,wpEff in wp_to_eff_match.items():
                 _aWP = "rerunDiscriminationByIsolationOldDMMVArun2017v2"+wp+self.postfix
                 setattr(self.process,_aWP,_byIsolationOldDMMVArun2017v2VLooseProd.clone())
                 _aWPProd = getattr(self.process,_aWP)
-                _aWPProd.mapping[0].cut = self.cms.string("RecoTauTag_tauIdMVAIsoDBoldDMwLT2017v2_"+wp_to_eff_match[wp])
+                _aWPProd.mapping[0].cut = self.cms.string("RecoTauTag_tauIdMVAIsoDBoldDMwLT2017v2_"+wpEff)
                 _rerunIsolationOldDMMVArun2017v2Task.add(_aWPProd)
                 setattr(tauIDSources,"by"+wp+"IsolationMVArun2017v2DBoldDMwLT2017",self.cms.InputTag(_aWP))
 
@@ -342,18 +340,17 @@ class TauIDEmbedder(object):
 
             wp_to_eff_match = {
                 "VVLoose" : "WPEff95",
-                "VLoose" : "WPEff90",
                 "Loose" : "WPEff80",
                 "Medium" : "WPEff70",
                 "Tight" : "WPEff60",
                 "VTight" : "WPEff50",
                 "VVTight" : "WPEff40"
             }
-            for wp in ["VVLoose","Loose","Medium","Tight","VTight","VVTight"]:
+            for wp,wpEff in wp_to_eff_match.items():
                 _aWP = "rerunDiscriminationByIsolationNewDMMVArun2017v2"+wp+self.postfix
                 setattr(self.process,_aWP,_byIsolationNewDMMVArun2017v2VLooseProd.clone())
                 _aWPProd = getattr(self.process,_aWP)
-                _aWPProd.mapping[0].cut = self.cms.string("RecoTauTag_tauIdMVAIsoDBnewDMwLT2017v2_"+wp_to_eff_match[wp])
+                _aWPProd.mapping[0].cut = self.cms.string("RecoTauTag_tauIdMVAIsoDBnewDMwLT2017v2_"+wpEff)
                 _rerunIsolationNewDMMVArun2017v2Task.add(_aWPProd)
                 setattr(tauIDSources,"by"+wp+"IsolationMVArun2017v2DBnewDMwLT2017",self.cms.InputTag(_aWP))
 
@@ -423,18 +420,17 @@ class TauIDEmbedder(object):
 
             wp_to_eff_match = {
                 "VVLoose" : "WPEff95",
-                "VLoose" : "WPEff90",
                 "Loose" : "WPEff80",
                 "Medium" : "WPEff70",
                 "Tight" : "WPEff60",
                 "VTight" : "WPEff50",
                 "VVTight" : "WPEff40"
             }
-            for wp in ["VVLoose","Loose","Medium","Tight","VTight","VVTight"]:
+            for wp,wpEff in wp_to_eff_match.items():
                 _aWP = "rerunDiscriminationByIsolationOldDMdR0p3MVArun2017v2"+wp+self.postfix
                 setattr(self.process,_aWP,_byIsolationOldDMdR0p3MVArun2017v2VLooseProd.clone())
                 _aWPProd = getattr(self.process,_aWP)
-                _aWPProd.mapping[0].cut = self.cms.string("RecoTauTag_tauIdMVAIsoDBoldDMdR0p3wLT2017v2_"+wp_to_eff_match[wp])
+                _aWPProd.mapping[0].cut = self.cms.string("RecoTauTag_tauIdMVAIsoDBoldDMdR0p3wLT2017v2_"+wpEff)
                 _rerunIsolationOldDMdR0p3MVArun2017v2Task.add(_aWPProd)
                 setattr(tauIDSources,"by"+wp+"IsolationMVArun2017v2DBoldDMdR0p3wLT2017",self.cms.InputTag(_aWP))
 
@@ -505,19 +501,17 @@ class TauIDEmbedder(object):
             tauIDSources.byVLooseIsolationMVArun2v2DBoldDMwLT2016 = self.cms.InputTag(_byIsolationOldDMMVArun2016v1VLoose)
 
             wp_to_eff_match = {
-                "VVLoose" : "WPEff95",
-                "VLoose" : "WPEff90",
                 "Loose" : "WPEff80",
                 "Medium" : "WPEff70",
                 "Tight" : "WPEff60",
                 "VTight" : "WPEff50",
                 "VVTight" : "WPEff40"
             }
-            for wp in ["Loose","Medium","Tight","VTight","VVTight"]:
+            for wp,wpEff in wp_to_eff_match.items():
                 _aWP = "rerunDiscriminationByIsolationOldDMMVArun2v1"+wp+self.postfix
                 setattr(self.process,_aWP,_byIsolationOldDMMVArun2016v1VLooseProd.clone())
                 _aWPProd = getattr(self.process,_aWP)
-                _aWPProd.mapping[0].cut = self.cms.string("RecoTauTag_tauIdMVAIsoDBoldDMwLT2016v1_"+wp_to_eff_match[wp])
+                _aWPProd.mapping[0].cut = self.cms.string("RecoTauTag_tauIdMVAIsoDBoldDMwLT2016v1_"+wpEff)
                 _rerunIsolationOldDMMVArun2016v1Task.add(_aWPProd)
                 setattr(tauIDSources,"by"+wp+"IsolationMVArun2v1DBoldDMwLT2016",self.cms.InputTag(_aWP))
 
@@ -562,19 +556,17 @@ class TauIDEmbedder(object):
             tauIDSources.byVLooseIsolationMVArun2v2DBnewDMwLT2016 = self.cms.InputTag(_byIsolationNewDMMVArun2016v1VLoose)
 
             wp_to_eff_match = {
-                "VVLoose" : "WPEff95",
-                "VLoose" : "WPEff90",
                 "Loose" : "WPEff80",
                 "Medium" : "WPEff70",
                 "Tight" : "WPEff60",
                 "VTight" : "WPEff50",
                 "VVTight" : "WPEff40"
             }
-            for wp in ["Loose","Medium","Tight","VTight","VVTight"]:
+            for wp,wpEff in wp_to_eff_match.items():
                 _aWP = "rerunDiscriminationByIsolationNewDMMVArun2v1"+wp+self.postfix
                 setattr(self.process,_aWP,_byIsolationNewDMMVArun2016v1VLooseProd.clone())
                 _aWPProd = getattr(self.process,_aWP)
-                _aWPProd.mapping[0].cut = self.cms.string("RecoTauTag_tauIdMVAIsoDBnewDMwLT2016v1_"+wp_to_eff_match[wp])
+                _aWPProd.mapping[0].cut = self.cms.string("RecoTauTag_tauIdMVAIsoDBnewDMwLT2016v1_"+wpEff)
                 _rerunIsolationNewDMMVArun2016v1Task.add(_aWPProd)
                 setattr(tauIDSources,"by"+wp+"IsolationMVArun2v1DBnewDMwLT2016",self.cms.InputTag(_aWP))
 
@@ -901,54 +893,53 @@ class TauIDEmbedder(object):
             )
             # Other WPs
             wp_to_eff_match = {
-                "VLoose" : "WPeff98",
                 "Loose" : "WPeff90",
                 "Medium" : "WPeff80",
                 "Tight" : "WPeff70",
                 "VTight" : "WPeff60",
             }
-            for wp in ["Loose", "Medium", "Tight", "VTight"]:
+            for wp,wpEff in wp_to_eff_match.items():
                 _aWP = "patTauDiscriminationBy"+wp+"ElectronRejectionMVA62018"+self.postfix
                 setattr(self.process,_aWP,_byElectronRejectionMVA62018VLooseProd.clone(
                     mapping = self.cms.VPSet(
                         self.cms.PSet(
                             category = self.cms.uint32(0),
-                            cut = self.cms.string('RecoTauTag_antiElectron'+antiElectronDiscrMVA6_version+'_gbr_NoEleMatch_woGwoGSF_BL_'+wp_to_eff_match[wp]),
+                            cut = self.cms.string('RecoTauTag_antiElectron'+antiElectronDiscrMVA6_version+'_gbr_NoEleMatch_woGwoGSF_BL_'+wpEff),
                             variable = self.cms.string('pt')
                         ),
                         self.cms.PSet(
                             category = self.cms.uint32(2),
-                            cut = self.cms.string('RecoTauTag_antiElectron'+antiElectronDiscrMVA6_version+'_gbr_NoEleMatch_wGwoGSF_BL_'+wp_to_eff_match[wp]),
+                            cut = self.cms.string('RecoTauTag_antiElectron'+antiElectronDiscrMVA6_version+'_gbr_NoEleMatch_wGwoGSF_BL_'+wpEff),
                             variable = self.cms.string('pt')
                         ),
                         self.cms.PSet(
                             category = self.cms.uint32(5),
-                            cut = self.cms.string('RecoTauTag_antiElectron'+antiElectronDiscrMVA6_version+'_gbr_woGwGSF_BL_'+wp_to_eff_match[wp]),
+                            cut = self.cms.string('RecoTauTag_antiElectron'+antiElectronDiscrMVA6_version+'_gbr_woGwGSF_BL_'+wpEff),
                             variable = self.cms.string('pt')
                         ),
                         self.cms.PSet(
                             category = self.cms.uint32(7),
-                            cut = self.cms.string('RecoTauTag_antiElectron'+antiElectronDiscrMVA6_version+'_gbr_wGwGSF_BL_'+wp_to_eff_match[wp]),
+                            cut = self.cms.string('RecoTauTag_antiElectron'+antiElectronDiscrMVA6_version+'_gbr_wGwGSF_BL_'+wpEff),
                             variable = self.cms.string('pt')
                         ),
                         self.cms.PSet(
                             category = self.cms.uint32(8),
-                            cut = self.cms.string('RecoTauTag_antiElectron'+antiElectronDiscrMVA6_version+'_gbr_NoEleMatch_woGwoGSF_EC_'+wp_to_eff_match[wp]),
+                            cut = self.cms.string('RecoTauTag_antiElectron'+antiElectronDiscrMVA6_version+'_gbr_NoEleMatch_woGwoGSF_EC_'+wpEff),
                             variable = self.cms.string('pt')
                         ),
                         self.cms.PSet(
                             category = self.cms.uint32(10),
-                            cut = self.cms.string('RecoTauTag_antiElectron'+antiElectronDiscrMVA6_version+'_gbr_NoEleMatch_wGwoGSF_EC_'+wp_to_eff_match[wp]),
+                            cut = self.cms.string('RecoTauTag_antiElectron'+antiElectronDiscrMVA6_version+'_gbr_NoEleMatch_wGwoGSF_EC_'+wpEff),
                             variable = self.cms.string('pt')
                         ),
                         self.cms.PSet(
                             category = self.cms.uint32(13),
-                            cut = self.cms.string('RecoTauTag_antiElectron'+antiElectronDiscrMVA6_version+'_gbr_woGwGSF_EC_'+wp_to_eff_match[wp]),
+                            cut = self.cms.string('RecoTauTag_antiElectron'+antiElectronDiscrMVA6_version+'_gbr_woGwGSF_EC_'+wpEff),
                             variable = self.cms.string('pt')
                         ),
                         self.cms.PSet(
                             category = self.cms.uint32(15),
-                            cut = self.cms.string('RecoTauTag_antiElectron'+antiElectronDiscrMVA6_version+'_gbr_wGwGSF_EC_'+wp_to_eff_match[wp]),
+                            cut = self.cms.string('RecoTauTag_antiElectron'+antiElectronDiscrMVA6_version+'_gbr_wGwGSF_EC_'+wpEff),
                             variable = self.cms.string('pt')
                         )
                     )

--- a/RecoTauTag/RecoTau/python/tools/runTauIdMVA.py
+++ b/RecoTauTag/RecoTau/python/tools/runTauIdMVA.py
@@ -15,7 +15,9 @@ class TauIDEmbedder(object):
     ]
 
     def __init__(self, process, cms, debug = False,
+                 originalTauName = "slimmedTaus",
                  updatedTauName = "slimmedTausNewID",
+                 postfix = "",
                  toKeep =  ["deepTau2017v2p1"],
                  tauIdDiscrMVA_trainings_run2_2017 = { 'tauIdMVAIsoDBoldDMwLT2017' : "tauIdMVAIsoDBoldDMwLT2017", },
                  tauIdDiscrMVA_WPs_run2_2017 = {
@@ -36,7 +38,9 @@ class TauIDEmbedder(object):
         self.process = process
         self.cms = cms
         self.debug = debug
+        self.originalTauName = originalTauName
         self.updatedTauName = updatedTauName
+        self.postfix = postfix
         self.process.load('RecoTauTag.Configuration.loadRecoTauTagMVAsFromPrepDB_cfi')
         if len(conditionDB) != 0:
             self.process.CondDBTauConnection.connect = cms.string(conditionDB)
@@ -121,8 +125,8 @@ class TauIDEmbedder(object):
             )
 
     def runTauID(self):
-        self.process.rerunMvaIsolationTask = self.cms.Task()
-        self.process.rerunMvaIsolationSequence = self.cms.Sequence()
+        setattr(self.process,"rerunMvaIsolationTask"+self.postfix,self.cms.Task())
+        setattr(self.process,"rerunMvaIsolationSequence"+self.postfix,self.cms.Sequence())
         tauIDSources = self.cms.PSet()
 
         # rerun the seq to obtain the 2017 nom training with 0.5 iso cone, old DM, ptph>1, trained on 2017MCv1
@@ -147,20 +151,20 @@ class TauIDEmbedder(object):
                 if self.debug: print ("runTauID: not is_above_cmssw_version(9, 4, 4). Will update the list of available in DB samples to access 2017v1")
                 self.loadMVA_WPs_run2_2017()
 
-            self.process.rerunDiscriminationByIsolationOldDMMVArun2017v1raw = patDiscriminationByIsolationMVArun2v1raw.clone(
-                PATTauProducer = self.cms.InputTag('slimmedTaus'),
+            setattr(self.process,"rerunDiscriminationByIsolationOldDMMVArun2017v1raw"+self.postfix,patDiscriminationByIsolationMVArun2v1raw.clone(
+                PATTauProducer = self.cms.InputTag(self.originalTauName),
                 Prediscriminants = noPrediscriminants,
                 loadMVAfromDB = self.cms.bool(True),
                 mvaName = self.cms.string("RecoTauTag_tauIdMVAIsoDBoldDMwLT2017v1"),#RecoTauTag_tauIdMVAIsoDBoldDMwLT2016v1 writeTauIdDiscrMVAs
                 mvaOpt = self.cms.string("DBoldDMwLTwGJ"),
                 verbosity = self.cms.int32(0)
-            )
+            ))
 
-            self.process.rerunDiscriminationByIsolationOldDMMVArun2017v1VLoose = patDiscriminationByIsolationMVArun2v1VLoose.clone(
-                PATTauProducer = self.cms.InputTag('slimmedTaus'),
+            setattr(self.process,"rerunDiscriminationByIsolationOldDMMVArun2017v1VLoose"+self.postfix,patDiscriminationByIsolationMVArun2v1VLoose.clone(
+                PATTauProducer = self.cms.InputTag(self.originalTauName),
                 Prediscriminants = noPrediscriminants,
-                toMultiplex = self.cms.InputTag('rerunDiscriminationByIsolationOldDMMVArun2017v1raw'),
-                key = self.cms.InputTag('rerunDiscriminationByIsolationOldDMMVArun2017v1raw:category'),#?
+                toMultiplex = self.cms.InputTag('rerunDiscriminationByIsolationOldDMMVArun2017v1raw'+self.postfix),
+                key = self.cms.InputTag('rerunDiscriminationByIsolationOldDMMVArun2017v1raw'+self.postfix+':category'),#?
                 loadMVAfromDB = self.cms.bool(True),
                 mvaOutput_normalization = self.cms.string("RecoTauTag_tauIdMVAIsoDBoldDMwLT2017v1_mvaOutput_normalization"), #writeTauIdDiscrMVAoutputNormalizations
                 mapping = self.cms.VPSet(
@@ -170,42 +174,37 @@ class TauIDEmbedder(object):
                         variable = self.cms.string("pt"),
                     )
                 )
+            ))
+
+            wp_to_eff_match = {
+                "VVLoose" : "WPEff95",
+                "VLoose" : "WPEff90",
+                "Loose" : "WPEff80",
+                "Medium" : "WPEff70",
+                "Tight" : "WPEff60",
+                "VTight" : "WPEff50",
+                "VVTight" : "WPEff40"
+            }
+            self.rerunIsolationOldDMMVArun2017v1Task = self.cms.Task(
+                getattr(self.process,"rerunDiscriminationByIsolationOldDMMVArun2017v1raw"+self.postfix),
+                getattr(self.process,"rerunDiscriminationByIsolationOldDMMVArun2017v1VLoose"+self.postfix)
             )
+            for wp in ["VVLoose","Loose","Medium","Tight","VTight","VVTight"]:
+                setattr(self.process,"rerunDiscriminationByIsolationOldDMMVArun2017v1"+wp+self.postfix,getattr(self.process,"rerunDiscriminationByIsolationOldDMMVArun2017v1VLoose"+self.postfix).clone())
+                getattr(self.process,"rerunDiscriminationByIsolationOldDMMVArun2017v1"+wp+self.postfix).mapping[0].cut = self.cms.string("RecoTauTag_tauIdMVAIsoDBoldDMwLT2017v1_"+wp_to_eff_match[wp])
+                self.rerunIsolationOldDMMVArun2017v1Task.add(getattr(self.process,"rerunDiscriminationByIsolationOldDMMVArun2017v1"+wp+self.postfix))
+            getattr(self.process,"rerunMvaIsolationTask"+self.postfix).add(self.rerunIsolationOldDMMVArun2017v1Task)
+            tmpSeq = self.cms.Sequence(getattr(self.process,"rerunMvaIsolationSequence"+self.postfix) + self.cms.Sequence(self.rerunIsolationOldDMMVArun2017v1Task))
+            setattr(self.process,"rerunMvaIsolationSequence"+self.postfix,tmpSeq)
 
-            self.process.rerunDiscriminationByIsolationOldDMMVArun2017v1VVLoose = self.process.rerunDiscriminationByIsolationOldDMMVArun2017v1VLoose.clone()
-            self.process.rerunDiscriminationByIsolationOldDMMVArun2017v1VVLoose.mapping[0].cut = self.cms.string("RecoTauTag_tauIdMVAIsoDBoldDMwLT2017v1_WPEff95")
-            self.process.rerunDiscriminationByIsolationOldDMMVArun2017v1Loose = self.process.rerunDiscriminationByIsolationOldDMMVArun2017v1VLoose.clone()
-            self.process.rerunDiscriminationByIsolationOldDMMVArun2017v1Loose.mapping[0].cut = self.cms.string("RecoTauTag_tauIdMVAIsoDBoldDMwLT2017v1_WPEff80")
-            self.process.rerunDiscriminationByIsolationOldDMMVArun2017v1Medium = self.process.rerunDiscriminationByIsolationOldDMMVArun2017v1VLoose.clone()
-            self.process.rerunDiscriminationByIsolationOldDMMVArun2017v1Medium.mapping[0].cut = self.cms.string("RecoTauTag_tauIdMVAIsoDBoldDMwLT2017v1_WPEff70")
-            self.process.rerunDiscriminationByIsolationOldDMMVArun2017v1Tight = self.process.rerunDiscriminationByIsolationOldDMMVArun2017v1VLoose.clone()
-            self.process.rerunDiscriminationByIsolationOldDMMVArun2017v1Tight.mapping[0].cut = self.cms.string("RecoTauTag_tauIdMVAIsoDBoldDMwLT2017v1_WPEff60")
-            self.process.rerunDiscriminationByIsolationOldDMMVArun2017v1VTight = self.process.rerunDiscriminationByIsolationOldDMMVArun2017v1VLoose.clone()
-            self.process.rerunDiscriminationByIsolationOldDMMVArun2017v1VTight.mapping[0].cut = self.cms.string("RecoTauTag_tauIdMVAIsoDBoldDMwLT2017v1_WPEff50")
-            self.process.rerunDiscriminationByIsolationOldDMMVArun2017v1VVTight = self.process.rerunDiscriminationByIsolationOldDMMVArun2017v1VLoose.clone()
-            self.process.rerunDiscriminationByIsolationOldDMMVArun2017v1VVTight.mapping[0].cut = self.cms.string("RecoTauTag_tauIdMVAIsoDBoldDMwLT2017v1_WPEff40")
-
-            self.rerunIsolationOldDMMVArun2017v1Task =  self.cms.Task(
-                self.process.rerunDiscriminationByIsolationOldDMMVArun2017v1raw,
-                self.process.rerunDiscriminationByIsolationOldDMMVArun2017v1VLoose,
-                self.process.rerunDiscriminationByIsolationOldDMMVArun2017v1VVLoose,
-                self.process.rerunDiscriminationByIsolationOldDMMVArun2017v1Loose,
-                self.process.rerunDiscriminationByIsolationOldDMMVArun2017v1Medium,
-                self.process.rerunDiscriminationByIsolationOldDMMVArun2017v1Tight,
-                self.process.rerunDiscriminationByIsolationOldDMMVArun2017v1VTight,
-                self.process.rerunDiscriminationByIsolationOldDMMVArun2017v1VVTight
-            )
-            self.process.rerunMvaIsolationTask.add(self.rerunIsolationOldDMMVArun2017v1Task)
-            self.process.rerunMvaIsolationSequence += self.cms.Sequence(self.rerunIsolationOldDMMVArun2017v1Task)
-
-            tauIDSources.byIsolationMVArun2017v1DBoldDMwLTraw2017 = self.cms.InputTag('rerunDiscriminationByIsolationOldDMMVArun2017v1raw')
-            tauIDSources.byVVLooseIsolationMVArun2017v1DBoldDMwLT2017 = self.cms.InputTag('rerunDiscriminationByIsolationOldDMMVArun2017v1VVLoose')
-            tauIDSources.byVLooseIsolationMVArun2017v1DBoldDMwLT2017 = self.cms.InputTag('rerunDiscriminationByIsolationOldDMMVArun2017v1VLoose')
-            tauIDSources.byLooseIsolationMVArun2017v1DBoldDMwLT2017 = self.cms.InputTag('rerunDiscriminationByIsolationOldDMMVArun2017v1Loose')
-            tauIDSources.byMediumIsolationMVArun2017v1DBoldDMwLT2017 = self.cms.InputTag('rerunDiscriminationByIsolationOldDMMVArun2017v1Medium')
-            tauIDSources.byTightIsolationMVArun2017v1DBoldDMwLT2017 = self.cms.InputTag('rerunDiscriminationByIsolationOldDMMVArun2017v1Tight')
-            tauIDSources.byVTightIsolationMVArun2017v1DBoldDMwLT2017 = self.cms.InputTag('rerunDiscriminationByIsolationOldDMMVArun2017v1VTight')
-            tauIDSources.byVVTightIsolationMVArun2017v1DBoldDMwLT2017 = self.cms.InputTag('rerunDiscriminationByIsolationOldDMMVArun2017v1VVTight')
+            tauIDSources.byIsolationMVArun2017v1DBoldDMwLTraw2017 = self.cms.InputTag('rerunDiscriminationByIsolationOldDMMVArun2017v1raw'+self.postfix)
+            tauIDSources.byVVLooseIsolationMVArun2017v1DBoldDMwLT2017 = self.cms.InputTag('rerunDiscriminationByIsolationOldDMMVArun2017v1VVLoose'+self.postfix)
+            tauIDSources.byVLooseIsolationMVArun2017v1DBoldDMwLT2017 = self.cms.InputTag('rerunDiscriminationByIsolationOldDMMVArun2017v1VLoose'+self.postfix)
+            tauIDSources.byLooseIsolationMVArun2017v1DBoldDMwLT2017 = self.cms.InputTag('rerunDiscriminationByIsolationOldDMMVArun2017v1Loose'+self.postfix)
+            tauIDSources.byMediumIsolationMVArun2017v1DBoldDMwLT2017 = self.cms.InputTag('rerunDiscriminationByIsolationOldDMMVArun2017v1Medium'+self.postfix)
+            tauIDSources.byTightIsolationMVArun2017v1DBoldDMwLT2017 = self.cms.InputTag('rerunDiscriminationByIsolationOldDMMVArun2017v1Tight'+self.postfix)
+            tauIDSources.byVTightIsolationMVArun2017v1DBoldDMwLT2017 = self.cms.InputTag('rerunDiscriminationByIsolationOldDMMVArun2017v1VTight'+self.postfix)
+            tauIDSources.byVVTightIsolationMVArun2017v1DBoldDMwLT2017 = self.cms.InputTag('rerunDiscriminationByIsolationOldDMMVArun2017v1VVTight'+self.postfix)
 
 
         if "2017v2" in self.toKeep:
@@ -229,20 +228,20 @@ class TauIDEmbedder(object):
                 if self.debug: print ("runTauID: not is_above_cmssw_version(9, 4, 5). Will update the list of available in DB samples to access 2017v2")
                 self.loadMVA_WPs_run2_2017()
 
-            self.process.rerunDiscriminationByIsolationOldDMMVArun2017v2raw = patDiscriminationByIsolationMVArun2v1raw.clone(
-                PATTauProducer = self.cms.InputTag('slimmedTaus'),
+            setattr(self.process,"rerunDiscriminationByIsolationOldDMMVArun2017v2raw"+self.postfix,patDiscriminationByIsolationMVArun2v1raw.clone(
+                PATTauProducer = self.cms.InputTag(self.originalTauName),
                 Prediscriminants = noPrediscriminants,
                 loadMVAfromDB = self.cms.bool(True),
                 mvaName = self.cms.string("RecoTauTag_tauIdMVAIsoDBoldDMwLT2017v2"),#RecoTauTag_tauIdMVAIsoDBoldDMwLT2016v1 writeTauIdDiscrMVAs
                 mvaOpt = self.cms.string("DBoldDMwLTwGJ"),
                 verbosity = self.cms.int32(0)
-            )
+            ))
 
-            self.process.rerunDiscriminationByIsolationOldDMMVArun2017v2VLoose = patDiscriminationByIsolationMVArun2v1VLoose.clone(
-                PATTauProducer = self.cms.InputTag('slimmedTaus'),
+            setattr(self.process,"rerunDiscriminationByIsolationOldDMMVArun2017v2VLoose"+self.postfix,patDiscriminationByIsolationMVArun2v1VLoose.clone(
+                PATTauProducer = self.cms.InputTag(self.originalTauName),
                 Prediscriminants = noPrediscriminants,
-                toMultiplex = self.cms.InputTag('rerunDiscriminationByIsolationOldDMMVArun2017v2raw'),
-                key = self.cms.InputTag('rerunDiscriminationByIsolationOldDMMVArun2017v2raw:category'),#?
+                toMultiplex = self.cms.InputTag('rerunDiscriminationByIsolationOldDMMVArun2017v2raw'+self.postfix),
+                key = self.cms.InputTag('rerunDiscriminationByIsolationOldDMMVArun2017v2raw'+self.postfix+':category'),#?
                 loadMVAfromDB = self.cms.bool(True),
                 mvaOutput_normalization = self.cms.string("RecoTauTag_tauIdMVAIsoDBoldDMwLT2017v2_mvaOutput_normalization"), #writeTauIdDiscrMVAoutputNormalizations
                 mapping = self.cms.VPSet(
@@ -253,42 +252,37 @@ class TauIDEmbedder(object):
                     )
                 ),
                 verbosity = self.cms.int32(0)
-            )
+            ))
 
-            self.process.rerunDiscriminationByIsolationOldDMMVArun2017v2VVLoose = self.process.rerunDiscriminationByIsolationOldDMMVArun2017v2VLoose.clone()
-            self.process.rerunDiscriminationByIsolationOldDMMVArun2017v2VVLoose.mapping[0].cut = self.cms.string("RecoTauTag_tauIdMVAIsoDBoldDMwLT2017v2_WPEff95")
-            self.process.rerunDiscriminationByIsolationOldDMMVArun2017v2Loose = self.process.rerunDiscriminationByIsolationOldDMMVArun2017v2VLoose.clone()
-            self.process.rerunDiscriminationByIsolationOldDMMVArun2017v2Loose.mapping[0].cut = self.cms.string("RecoTauTag_tauIdMVAIsoDBoldDMwLT2017v2_WPEff80")
-            self.process.rerunDiscriminationByIsolationOldDMMVArun2017v2Medium = self.process.rerunDiscriminationByIsolationOldDMMVArun2017v2VLoose.clone()
-            self.process.rerunDiscriminationByIsolationOldDMMVArun2017v2Medium.mapping[0].cut = self.cms.string("RecoTauTag_tauIdMVAIsoDBoldDMwLT2017v2_WPEff70")
-            self.process.rerunDiscriminationByIsolationOldDMMVArun2017v2Tight = self.process.rerunDiscriminationByIsolationOldDMMVArun2017v2VLoose.clone()
-            self.process.rerunDiscriminationByIsolationOldDMMVArun2017v2Tight.mapping[0].cut = self.cms.string("RecoTauTag_tauIdMVAIsoDBoldDMwLT2017v2_WPEff60")
-            self.process.rerunDiscriminationByIsolationOldDMMVArun2017v2VTight = self.process.rerunDiscriminationByIsolationOldDMMVArun2017v2VLoose.clone()
-            self.process.rerunDiscriminationByIsolationOldDMMVArun2017v2VTight.mapping[0].cut = self.cms.string("RecoTauTag_tauIdMVAIsoDBoldDMwLT2017v2_WPEff50")
-            self.process.rerunDiscriminationByIsolationOldDMMVArun2017v2VVTight = self.process.rerunDiscriminationByIsolationOldDMMVArun2017v2VLoose.clone()
-            self.process.rerunDiscriminationByIsolationOldDMMVArun2017v2VVTight.mapping[0].cut = self.cms.string("RecoTauTag_tauIdMVAIsoDBoldDMwLT2017v2_WPEff40")
-
+            wp_to_eff_match = {
+                "VVLoose" : "WPEff95",
+                "VLoose" : "WPEff90",
+                "Loose" : "WPEff80",
+                "Medium" : "WPEff70",
+                "Tight" : "WPEff60",
+                "VTight" : "WPEff50",
+                "VVTight" : "WPEff40"
+            }
             self.rerunIsolationOldDMMVArun2017v2Task = self.cms.Task(
-                self.process.rerunDiscriminationByIsolationOldDMMVArun2017v2raw,
-                self.process.rerunDiscriminationByIsolationOldDMMVArun2017v2VLoose,
-                self.process.rerunDiscriminationByIsolationOldDMMVArun2017v2VVLoose,
-                self.process.rerunDiscriminationByIsolationOldDMMVArun2017v2Loose,
-                self.process.rerunDiscriminationByIsolationOldDMMVArun2017v2Medium,
-                self.process.rerunDiscriminationByIsolationOldDMMVArun2017v2Tight,
-                self.process.rerunDiscriminationByIsolationOldDMMVArun2017v2VTight,
-                self.process.rerunDiscriminationByIsolationOldDMMVArun2017v2VVTight
+                getattr(self.process,"rerunDiscriminationByIsolationOldDMMVArun2017v2raw"+self.postfix),
+                getattr(self.process,"rerunDiscriminationByIsolationOldDMMVArun2017v2VLoose"+self.postfix)
             )
-            self.process.rerunMvaIsolationTask.add(self.rerunIsolationOldDMMVArun2017v2Task)
-            self.process.rerunMvaIsolationSequence += self.cms.Sequence(self.rerunIsolationOldDMMVArun2017v2Task)
+            for wp in ["VVLoose","Loose","Medium","Tight","VTight","VVTight"]:
+                setattr(self.process,"rerunDiscriminationByIsolationOldDMMVArun2017v2"+wp+self.postfix,getattr(self.process,"rerunDiscriminationByIsolationOldDMMVArun2017v2VLoose"+self.postfix).clone())
+                getattr(self.process,"rerunDiscriminationByIsolationOldDMMVArun2017v2"+wp+self.postfix).mapping[0].cut = self.cms.string("RecoTauTag_tauIdMVAIsoDBoldDMwLT2017v2_"+wp_to_eff_match[wp])
+                self.rerunIsolationOldDMMVArun2017v2Task.add(getattr(self.process,"rerunDiscriminationByIsolationOldDMMVArun2017v2"+wp+self.postfix))
+            getattr(self.process,"rerunMvaIsolationTask"+self.postfix).add(self.rerunIsolationOldDMMVArun2017v2Task)
+            tmpSeq = self.cms.Sequence(getattr(self.process,"rerunMvaIsolationSequence"+self.postfix) + self.cms.Sequence(self.rerunIsolationOldDMMVArun2017v2Task))
+            setattr(self.process,"rerunMvaIsolationSequence"+self.postfix,tmpSeq)
 
-            tauIDSources.byIsolationMVArun2017v2DBoldDMwLTraw2017 = self.cms.InputTag('rerunDiscriminationByIsolationOldDMMVArun2017v2raw')
-            tauIDSources.byVVLooseIsolationMVArun2017v2DBoldDMwLT2017 = self.cms.InputTag('rerunDiscriminationByIsolationOldDMMVArun2017v2VVLoose')
-            tauIDSources.byVLooseIsolationMVArun2017v2DBoldDMwLT2017 = self.cms.InputTag('rerunDiscriminationByIsolationOldDMMVArun2017v2VLoose')
-            tauIDSources.byLooseIsolationMVArun2017v2DBoldDMwLT2017 = self.cms.InputTag('rerunDiscriminationByIsolationOldDMMVArun2017v2Loose')
-            tauIDSources.byMediumIsolationMVArun2017v2DBoldDMwLT2017 = self.cms.InputTag('rerunDiscriminationByIsolationOldDMMVArun2017v2Medium')
-            tauIDSources.byTightIsolationMVArun2017v2DBoldDMwLT2017 = self.cms.InputTag('rerunDiscriminationByIsolationOldDMMVArun2017v2Tight')
-            tauIDSources.byVTightIsolationMVArun2017v2DBoldDMwLT2017 = self.cms.InputTag('rerunDiscriminationByIsolationOldDMMVArun2017v2VTight')
-            tauIDSources.byVVTightIsolationMVArun2017v2DBoldDMwLT2017 = self.cms.InputTag('rerunDiscriminationByIsolationOldDMMVArun2017v2VVTight')
+            tauIDSources.byIsolationMVArun2017v2DBoldDMwLTraw2017 = self.cms.InputTag('rerunDiscriminationByIsolationOldDMMVArun2017v2raw'+self.postfix)
+            tauIDSources.byVVLooseIsolationMVArun2017v2DBoldDMwLT2017 = self.cms.InputTag('rerunDiscriminationByIsolationOldDMMVArun2017v2VVLoose'+self.postfix)
+            tauIDSources.byVLooseIsolationMVArun2017v2DBoldDMwLT2017 = self.cms.InputTag('rerunDiscriminationByIsolationOldDMMVArun2017v2VLoose'+self.postfix)
+            tauIDSources.byLooseIsolationMVArun2017v2DBoldDMwLT2017 = self.cms.InputTag('rerunDiscriminationByIsolationOldDMMVArun2017v2Loose'+self.postfix)
+            tauIDSources.byMediumIsolationMVArun2017v2DBoldDMwLT2017 = self.cms.InputTag('rerunDiscriminationByIsolationOldDMMVArun2017v2Medium'+self.postfix)
+            tauIDSources.byTightIsolationMVArun2017v2DBoldDMwLT2017 = self.cms.InputTag('rerunDiscriminationByIsolationOldDMMVArun2017v2Tight'+self.postfix)
+            tauIDSources.byVTightIsolationMVArun2017v2DBoldDMwLT2017 = self.cms.InputTag('rerunDiscriminationByIsolationOldDMMVArun2017v2VTight'+self.postfix)
+            tauIDSources.byVVTightIsolationMVArun2017v2DBoldDMwLT2017 = self.cms.InputTag('rerunDiscriminationByIsolationOldDMMVArun2017v2VVTight'+self.postfix)
 
         if "newDM2017v2" in self.toKeep:
             self.tauIdDiscrMVA_2017_version = "v2"
@@ -311,20 +305,20 @@ class TauIDEmbedder(object):
                 if self.debug: print ("runTauID: not is_above_cmssw_version(9, 4, 5). Will update the list of available in DB samples to access newDM2017v2")
                 self.loadMVA_WPs_run2_2017()
 
-            self.process.rerunDiscriminationByIsolationNewDMMVArun2017v2raw = patDiscriminationByIsolationMVArun2v1raw.clone(
-                PATTauProducer = self.cms.InputTag('slimmedTaus'),
+            setattr(self.process,"rerunDiscriminationByIsolationNewDMMVArun2017v2raw"+self.postfix,patDiscriminationByIsolationMVArun2v1raw.clone(
+                PATTauProducer = self.cms.InputTag(self.originalTauName),
                 Prediscriminants = noPrediscriminants,
                 loadMVAfromDB = self.cms.bool(True),
                 mvaName = self.cms.string("RecoTauTag_tauIdMVAIsoDBnewDMwLT2017v2"),#RecoTauTag_tauIdMVAIsoDBoldDMwLT2016v1 writeTauIdDiscrMVAs
                 mvaOpt = self.cms.string("DBnewDMwLTwGJ"),
                 verbosity = self.cms.int32(0)
-            )
+            ))
 
-            self.process.rerunDiscriminationByIsolationNewDMMVArun2017v2VLoose = patDiscriminationByIsolationMVArun2v1VLoose.clone(
-                PATTauProducer = self.cms.InputTag('slimmedTaus'),
+            setattr(self.process,"rerunDiscriminationByIsolationNewDMMVArun2017v2VLoose"+self.postfix,patDiscriminationByIsolationMVArun2v1VLoose.clone(
+                PATTauProducer = self.cms.InputTag(self.originalTauName),
                 Prediscriminants = noPrediscriminants,
-                toMultiplex = self.cms.InputTag('rerunDiscriminationByIsolationNewDMMVArun2017v2raw'),
-                key = self.cms.InputTag('rerunDiscriminationByIsolationNewDMMVArun2017v2raw:category'),#?
+                toMultiplex = self.cms.InputTag('rerunDiscriminationByIsolationNewDMMVArun2017v2raw'+self.postfix),
+                key = self.cms.InputTag('rerunDiscriminationByIsolationNewDMMVArun2017v2raw'+self.postfix+':category'),#?
                 loadMVAfromDB = self.cms.bool(True),
                 mvaOutput_normalization = self.cms.string("RecoTauTag_tauIdMVAIsoDBnewDMwLT2017v2_mvaOutput_normalization"), #writeTauIdDiscrMVAoutputNormalizations
                 mapping = self.cms.VPSet(
@@ -335,42 +329,37 @@ class TauIDEmbedder(object):
                     )
                 ),
                 verbosity = self.cms.int32(0)
-            )
+            ))
 
-            self.process.rerunDiscriminationByIsolationNewDMMVArun2017v2VVLoose = self.process.rerunDiscriminationByIsolationNewDMMVArun2017v2VLoose.clone()
-            self.process.rerunDiscriminationByIsolationNewDMMVArun2017v2VVLoose.mapping[0].cut = self.cms.string("RecoTauTag_tauIdMVAIsoDBnewDMwLT2017v2_WPEff95")
-            self.process.rerunDiscriminationByIsolationNewDMMVArun2017v2Loose = self.process.rerunDiscriminationByIsolationNewDMMVArun2017v2VLoose.clone()
-            self.process.rerunDiscriminationByIsolationNewDMMVArun2017v2Loose.mapping[0].cut = self.cms.string("RecoTauTag_tauIdMVAIsoDBnewDMwLT2017v2_WPEff80")
-            self.process.rerunDiscriminationByIsolationNewDMMVArun2017v2Medium = self.process.rerunDiscriminationByIsolationNewDMMVArun2017v2VLoose.clone()
-            self.process.rerunDiscriminationByIsolationNewDMMVArun2017v2Medium.mapping[0].cut = self.cms.string("RecoTauTag_tauIdMVAIsoDBnewDMwLT2017v2_WPEff70")
-            self.process.rerunDiscriminationByIsolationNewDMMVArun2017v2Tight = self.process.rerunDiscriminationByIsolationNewDMMVArun2017v2VLoose.clone()
-            self.process.rerunDiscriminationByIsolationNewDMMVArun2017v2Tight.mapping[0].cut = self.cms.string("RecoTauTag_tauIdMVAIsoDBnewDMwLT2017v2_WPEff60")
-            self.process.rerunDiscriminationByIsolationNewDMMVArun2017v2VTight = self.process.rerunDiscriminationByIsolationNewDMMVArun2017v2VLoose.clone()
-            self.process.rerunDiscriminationByIsolationNewDMMVArun2017v2VTight.mapping[0].cut = self.cms.string("RecoTauTag_tauIdMVAIsoDBnewDMwLT2017v2_WPEff50")
-            self.process.rerunDiscriminationByIsolationNewDMMVArun2017v2VVTight = self.process.rerunDiscriminationByIsolationNewDMMVArun2017v2VLoose.clone()
-            self.process.rerunDiscriminationByIsolationNewDMMVArun2017v2VVTight.mapping[0].cut = self.cms.string("RecoTauTag_tauIdMVAIsoDBnewDMwLT2017v2_WPEff40")
-
+            wp_to_eff_match = {
+                "VVLoose" : "WPEff95",
+                "VLoose" : "WPEff90",
+                "Loose" : "WPEff80",
+                "Medium" : "WPEff70",
+                "Tight" : "WPEff60",
+                "VTight" : "WPEff50",
+                "VVTight" : "WPEff40"
+            }
             self.rerunIsolationNewDMMVArun2017v2Task = self.cms.Task(
-                self.process.rerunDiscriminationByIsolationNewDMMVArun2017v2raw,
-                self.process.rerunDiscriminationByIsolationNewDMMVArun2017v2VLoose,
-                self.process.rerunDiscriminationByIsolationNewDMMVArun2017v2VVLoose,
-                self.process.rerunDiscriminationByIsolationNewDMMVArun2017v2Loose,
-                self.process.rerunDiscriminationByIsolationNewDMMVArun2017v2Medium,
-                self.process.rerunDiscriminationByIsolationNewDMMVArun2017v2Tight,
-                self.process.rerunDiscriminationByIsolationNewDMMVArun2017v2VTight,
-                self.process.rerunDiscriminationByIsolationNewDMMVArun2017v2VVTight
+                getattr(self.process,"rerunDiscriminationByIsolationNewDMMVArun2017v2raw"+self.postfix),
+                getattr(self.process,"rerunDiscriminationByIsolationNewDMMVArun2017v2VLoose"+self.postfix)
             )
-            self.process.rerunMvaIsolationTask.add(self.rerunIsolationNewDMMVArun2017v2Task)
-            self.process.rerunMvaIsolationSequence += self.cms.Sequence(self.rerunIsolationNewDMMVArun2017v2Task)
+            for wp in ["VVLoose","Loose","Medium","Tight","VTight","VVTight"]:
+                setattr(self.process,"rerunDiscriminationByIsolationNewDMMVArun2017v2"+wp+self.postfix,getattr(self.process,"rerunDiscriminationByIsolationNewDMMVArun2017v2VLoose"+self.postfix).clone())
+                getattr(self.process,"rerunDiscriminationByIsolationNewDMMVArun2017v2"+wp+self.postfix).mapping[0].cut = self.cms.string("RecoTauTag_tauIdMVAIsoDBnewDMwLT2017v2_"+wp_to_eff_match[wp])
+                self.rerunIsolationNewDMMVArun2017v2Task.add(getattr(self.process,"rerunDiscriminationByIsolationNewDMMVArun2017v2"+wp+self.postfix))
+            getattr(self.process,"rerunMvaIsolationTask"+self.postfix).add(self.rerunIsolationNewDMMVArun2017v2Task)
+            tmpSeq = self.cms.Sequence(getattr(self.process,"rerunMvaIsolationSequence"+self.postfix) + self.cms.Sequence(self.rerunIsolationNewDMMVArun2017v2Task))
+            setattr(self.process,"rerunMvaIsolationSequence"+self.postfix,tmpSeq)
 
-            tauIDSources.byIsolationMVArun2017v2DBnewDMwLTraw2017 = self.cms.InputTag('rerunDiscriminationByIsolationNewDMMVArun2017v2raw')
-            tauIDSources.byVVLooseIsolationMVArun2017v2DBnewDMwLT2017 = self.cms.InputTag('rerunDiscriminationByIsolationNewDMMVArun2017v2VVLoose')
-            tauIDSources.byVLooseIsolationMVArun2017v2DBnewDMwLT2017 = self.cms.InputTag('rerunDiscriminationByIsolationNewDMMVArun2017v2VLoose')
-            tauIDSources.byLooseIsolationMVArun2017v2DBnewDMwLT2017 = self.cms.InputTag('rerunDiscriminationByIsolationNewDMMVArun2017v2Loose')
-            tauIDSources.byMediumIsolationMVArun2017v2DBnewDMwLT2017 = self.cms.InputTag('rerunDiscriminationByIsolationNewDMMVArun2017v2Medium')
-            tauIDSources.byTightIsolationMVArun2017v2DBnewDMwLT2017 = self.cms.InputTag('rerunDiscriminationByIsolationNewDMMVArun2017v2Tight')
-            tauIDSources.byVTightIsolationMVArun2017v2DBnewDMwLT2017 = self.cms.InputTag('rerunDiscriminationByIsolationNewDMMVArun2017v2VTight')
-            tauIDSources.byVVTightIsolationMVArun2017v2DBnewDMwLT2017 = self.cms.InputTag('rerunDiscriminationByIsolationNewDMMVArun2017v2VVTight')
+            tauIDSources.byIsolationMVArun2017v2DBnewDMwLTraw2017 = self.cms.InputTag('rerunDiscriminationByIsolationNewDMMVArun2017v2raw'+self.postfix)
+            tauIDSources.byVVLooseIsolationMVArun2017v2DBnewDMwLT2017 = self.cms.InputTag('rerunDiscriminationByIsolationNewDMMVArun2017v2VVLoose'+self.postfix)
+            tauIDSources.byVLooseIsolationMVArun2017v2DBnewDMwLT2017 = self.cms.InputTag('rerunDiscriminationByIsolationNewDMMVArun2017v2VLoose'+self.postfix)
+            tauIDSources.byLooseIsolationMVArun2017v2DBnewDMwLT2017 = self.cms.InputTag('rerunDiscriminationByIsolationNewDMMVArun2017v2Loose'+self.postfix)
+            tauIDSources.byMediumIsolationMVArun2017v2DBnewDMwLT2017 = self.cms.InputTag('rerunDiscriminationByIsolationNewDMMVArun2017v2Medium'+self.postfix)
+            tauIDSources.byTightIsolationMVArun2017v2DBnewDMwLT2017 = self.cms.InputTag('rerunDiscriminationByIsolationNewDMMVArun2017v2Tight'+self.postfix)
+            tauIDSources.byVTightIsolationMVArun2017v2DBnewDMwLT2017 = self.cms.InputTag('rerunDiscriminationByIsolationNewDMMVArun2017v2VTight'+self.postfix)
+            tauIDSources.byVVTightIsolationMVArun2017v2DBnewDMwLT2017 = self.cms.InputTag('rerunDiscriminationByIsolationNewDMMVArun2017v2VVTight'+self.postfix)
 
         if "dR0p32017v2" in self.toKeep:
             self.tauIdDiscrMVA_2017_version = "v2"
@@ -393,8 +382,8 @@ class TauIDEmbedder(object):
                 if self.debug: print ("runTauID: not is_above_cmssw_version(9, 4, 5). Will update the list of available in DB samples to access dR0p32017v2")
                 self.loadMVA_WPs_run2_2017()
 
-            self.process.rerunDiscriminationByIsolationOldDMdR0p3MVArun2017v2raw = patDiscriminationByIsolationMVArun2v1raw.clone(
-                PATTauProducer = self.cms.InputTag('slimmedTaus'),
+            setattr(self.process,"rerunDiscriminationByIsolationOldDMdR0p3MVArun2017v2raw"+self.postfix,patDiscriminationByIsolationMVArun2v1raw.clone(
+                PATTauProducer = self.cms.InputTag(self.originalTauName),
                 Prediscriminants = noPrediscriminants,
                 loadMVAfromDB = self.cms.bool(True),
                 mvaName = self.cms.string("RecoTauTag_tauIdMVAIsoDBoldDMdR0p3wLT2017v2"),
@@ -404,13 +393,13 @@ class TauIDEmbedder(object):
                 srcNeutralIsoPtSum = self.cms.string('neutralIsoPtSumdR03'),
                 srcPhotonPtSumOutsideSignalCone = self.cms.string('photonPtSumOutsideSignalConedR03'),
                 verbosity = self.cms.int32(0)
-            )
+            ))
 
-            self.process.rerunDiscriminationByIsolationOldDMdR0p3MVArun2017v2VLoose = patDiscriminationByIsolationMVArun2v1VLoose.clone(
-                PATTauProducer = self.cms.InputTag('slimmedTaus'),
+            setattr(self.process,"rerunDiscriminationByIsolationOldDMdR0p3MVArun2017v2VLoose"+self.postfix,patDiscriminationByIsolationMVArun2v1VLoose.clone(
+                PATTauProducer = self.cms.InputTag(self.originalTauName),
                 Prediscriminants = noPrediscriminants,
-                toMultiplex = self.cms.InputTag('rerunDiscriminationByIsolationOldDMdR0p3MVArun2017v2raw'),
-                key = self.cms.InputTag('rerunDiscriminationByIsolationOldDMdR0p3MVArun2017v2raw:category'),#?
+                toMultiplex = self.cms.InputTag('rerunDiscriminationByIsolationOldDMdR0p3MVArun2017v2raw'+self.postfix),
+                key = self.cms.InputTag('rerunDiscriminationByIsolationOldDMdR0p3MVArun2017v2raw'+self.postfix+':category'),#?
                 loadMVAfromDB = self.cms.bool(True),
                 mvaOutput_normalization = self.cms.string("RecoTauTag_tauIdMVAIsoDBoldDMdR0p3wLT2017v2_mvaOutput_normalization"), #writeTauIdDiscrMVAoutputNormalizations
                 mapping = self.cms.VPSet(
@@ -421,46 +410,41 @@ class TauIDEmbedder(object):
                     )
                 ),
                 verbosity = self.cms.int32(0)
-            )
+            ))
 
-            self.process.rerunDiscriminationByIsolationOldDMdR0p3MVArun2017v2VVLoose = self.process.rerunDiscriminationByIsolationOldDMdR0p3MVArun2017v2VLoose.clone()
-            self.process.rerunDiscriminationByIsolationOldDMdR0p3MVArun2017v2VVLoose.mapping[0].cut = self.cms.string("RecoTauTag_tauIdMVAIsoDBoldDMdR0p3wLT2017v2_WPEff95")
-            self.process.rerunDiscriminationByIsolationOldDMdR0p3MVArun2017v2Loose = self.process.rerunDiscriminationByIsolationOldDMdR0p3MVArun2017v2VLoose.clone()
-            self.process.rerunDiscriminationByIsolationOldDMdR0p3MVArun2017v2Loose.mapping[0].cut = self.cms.string("RecoTauTag_tauIdMVAIsoDBoldDMdR0p3wLT2017v2_WPEff80")
-            self.process.rerunDiscriminationByIsolationOldDMdR0p3MVArun2017v2Medium = self.process.rerunDiscriminationByIsolationOldDMdR0p3MVArun2017v2VLoose.clone()
-            self.process.rerunDiscriminationByIsolationOldDMdR0p3MVArun2017v2Medium.mapping[0].cut = self.cms.string("RecoTauTag_tauIdMVAIsoDBoldDMdR0p3wLT2017v2_WPEff70")
-            self.process.rerunDiscriminationByIsolationOldDMdR0p3MVArun2017v2Tight = self.process.rerunDiscriminationByIsolationOldDMdR0p3MVArun2017v2VLoose.clone()
-            self.process.rerunDiscriminationByIsolationOldDMdR0p3MVArun2017v2Tight.mapping[0].cut = self.cms.string("RecoTauTag_tauIdMVAIsoDBoldDMdR0p3wLT2017v2_WPEff60")
-            self.process.rerunDiscriminationByIsolationOldDMdR0p3MVArun2017v2VTight = self.process.rerunDiscriminationByIsolationOldDMdR0p3MVArun2017v2VLoose.clone()
-            self.process.rerunDiscriminationByIsolationOldDMdR0p3MVArun2017v2VTight.mapping[0].cut = self.cms.string("RecoTauTag_tauIdMVAIsoDBoldDMdR0p3wLT2017v2_WPEff50")
-            self.process.rerunDiscriminationByIsolationOldDMdR0p3MVArun2017v2VVTight = self.process.rerunDiscriminationByIsolationOldDMdR0p3MVArun2017v2VLoose.clone()
-            self.process.rerunDiscriminationByIsolationOldDMdR0p3MVArun2017v2VVTight.mapping[0].cut = self.cms.string("RecoTauTag_tauIdMVAIsoDBoldDMdR0p3wLT2017v2_WPEff40")
-
+            wp_to_eff_match = {
+                "VVLoose" : "WPEff95",
+                "VLoose" : "WPEff90",
+                "Loose" : "WPEff80",
+                "Medium" : "WPEff70",
+                "Tight" : "WPEff60",
+                "VTight" : "WPEff50",
+                "VVTight" : "WPEff40"
+            }
             self.rerunIsolationOldDMdR0p3MVArun2017v2Task = self.cms.Task(
-                self.process.rerunDiscriminationByIsolationOldDMdR0p3MVArun2017v2raw,
-                self.process.rerunDiscriminationByIsolationOldDMdR0p3MVArun2017v2VLoose,
-                self.process.rerunDiscriminationByIsolationOldDMdR0p3MVArun2017v2VVLoose,
-                self.process.rerunDiscriminationByIsolationOldDMdR0p3MVArun2017v2Loose,
-                self.process.rerunDiscriminationByIsolationOldDMdR0p3MVArun2017v2Medium,
-                self.process.rerunDiscriminationByIsolationOldDMdR0p3MVArun2017v2Tight,
-                self.process.rerunDiscriminationByIsolationOldDMdR0p3MVArun2017v2VTight,
-                self.process.rerunDiscriminationByIsolationOldDMdR0p3MVArun2017v2VVTight
+                getattr(self.process,"rerunDiscriminationByIsolationOldDMdR0p3MVArun2017v2raw"+self.postfix),
+                getattr(self.process,"rerunDiscriminationByIsolationOldDMdR0p3MVArun2017v2VLoose"+self.postfix)
             )
-            self.process.rerunMvaIsolationTask.add(self.rerunIsolationOldDMdR0p3MVArun2017v2Task)
-            self.process.rerunMvaIsolationSequence += self.cms.Sequence(self.rerunIsolationOldDMdR0p3MVArun2017v2Task)
+            for wp in ["VVLoose","Loose","Medium","Tight","VTight","VVTight"]:
+                setattr(self.process,"rerunDiscriminationByIsolationOldDMdR0p3MVArun2017v2"+wp+self.postfix,getattr(self.process,"rerunDiscriminationByIsolationOldDMdR0p3MVArun2017v2VLoose"+self.postfix).clone())
+                getattr(self.process,"rerunDiscriminationByIsolationOldDMdR0p3MVArun2017v2"+wp+self.postfix).mapping[0].cut = self.cms.string("RecoTauTag_tauIdMVAIsoDBoldDMdR0p3wLT2017v2_"+wp_to_eff_match[wp])
+                self.rerunIsolationOldDMdR0p3MVArun2017v2Task.add(getattr(self.process,"rerunDiscriminationByIsolationOldDMdR0p3MVArun2017v2"+wp+self.postfix))
+            getattr(self.process,"rerunMvaIsolationTask"+self.postfix).add(self.rerunIsolationOldDMdR0p3MVArun2017v2Task)
+            tmpSeq = self.cms.Sequence(getattr(self.process,"rerunMvaIsolationSequence"+self.postfix) + self.cms.Sequence(self.rerunIsolationOldDMdR0p3MVArun2017v2Task))
+            setattr(self.process,"rerunMvaIsolationSequence"+self.postfix,tmpSeq)
 
-            tauIDSources.byIsolationMVArun2017v2DBoldDMdR0p3wLTraw2017 = self.cms.InputTag('rerunDiscriminationByIsolationOldDMdR0p3MVArun2017v2raw')
-            tauIDSources.byVVLooseIsolationMVArun2017v2DBoldDMdR0p3wLT2017 = self.cms.InputTag('rerunDiscriminationByIsolationOldDMdR0p3MVArun2017v2VVLoose')
-            tauIDSources.byVLooseIsolationMVArun2017v2DBoldDMdR0p3wLT2017 = self.cms.InputTag('rerunDiscriminationByIsolationOldDMdR0p3MVArun2017v2VLoose')
-            tauIDSources.byLooseIsolationMVArun2017v2DBoldDMdR0p3wLT2017 = self.cms.InputTag('rerunDiscriminationByIsolationOldDMdR0p3MVArun2017v2Loose')
-            tauIDSources.byMediumIsolationMVArun2017v2DBoldDMdR0p3wLT2017 = self.cms.InputTag('rerunDiscriminationByIsolationOldDMdR0p3MVArun2017v2Medium')
-            tauIDSources.byTightIsolationMVArun2017v2DBoldDMdR0p3wLT2017 = self.cms.InputTag('rerunDiscriminationByIsolationOldDMdR0p3MVArun2017v2Tight')
-            tauIDSources.byVTightIsolationMVArun2017v2DBoldDMdR0p3wLT2017 = self.cms.InputTag('rerunDiscriminationByIsolationOldDMdR0p3MVArun2017v2VTight')
-            tauIDSources.byVVTightIsolationMVArun2017v2DBoldDMdR0p3wLT2017 = self.cms.InputTag('rerunDiscriminationByIsolationOldDMdR0p3MVArun2017v2VVTight')
+            tauIDSources.byIsolationMVArun2017v2DBoldDMdR0p3wLTraw2017 = self.cms.InputTag('rerunDiscriminationByIsolationOldDMdR0p3MVArun2017v2raw'+self.postfix)
+            tauIDSources.byVVLooseIsolationMVArun2017v2DBoldDMdR0p3wLT2017 = self.cms.InputTag('rerunDiscriminationByIsolationOldDMdR0p3MVArun2017v2VVLoose'+self.postfix)
+            tauIDSources.byVLooseIsolationMVArun2017v2DBoldDMdR0p3wLT2017 = self.cms.InputTag('rerunDiscriminationByIsolationOldDMdR0p3MVArun2017v2VLoose'+self.postfix)
+            tauIDSources.byLooseIsolationMVArun2017v2DBoldDMdR0p3wLT2017 = self.cms.InputTag('rerunDiscriminationByIsolationOldDMdR0p3MVArun2017v2Loose'+self.postfix)
+            tauIDSources.byMediumIsolationMVArun2017v2DBoldDMdR0p3wLT2017 = self.cms.InputTag('rerunDiscriminationByIsolationOldDMdR0p3MVArun2017v2Medium'+self.postfix)
+            tauIDSources.byTightIsolationMVArun2017v2DBoldDMdR0p3wLT2017 = self.cms.InputTag('rerunDiscriminationByIsolationOldDMdR0p3MVArun2017v2Tight'+self.postfix)
+            tauIDSources.byVTightIsolationMVArun2017v2DBoldDMdR0p3wLT2017 = self.cms.InputTag('rerunDiscriminationByIsolationOldDMdR0p3MVArun2017v2VTight'+self.postfix)
+            tauIDSources.byVVTightIsolationMVArun2017v2DBoldDMdR0p3wLT2017 = self.cms.InputTag('rerunDiscriminationByIsolationOldDMdR0p3MVArun2017v2VVTight'+self.postfix)
 
         # 2016 training strategy(v2) - essentially the same as 2017 training strategy (v1), trained on 2016MC, old DM - currently not implemented in the tau sequence of any release
         # self.process.rerunDiscriminationByIsolationOldDMMVArun2v2raw = patDiscriminationByIsolationMVArun2v1raw.clone(
-        #     PATTauProducer = self.cms.InputTag('slimmedTaus'),
+        #     PATTauProducer = self.cms.InputTag(self.originalTauName),
         #     Prediscriminants = noPrediscriminants,
         #     loadMVAfromDB = self.cms.bool(True),
         #     mvaName = self.cms.string("RecoTauTag_tauIdMVAIsoDBoldDMwLT2016v2"),#RecoTauTag_tauIdMVAIsoDBoldDMwLT2016v1 writeTauIdDiscrMVAs
@@ -469,7 +453,7 @@ class TauIDEmbedder(object):
         # )
         # #
         # self.process.rerunDiscriminationByIsolationOldDMMVArun2v2VLoose = patDiscriminationByIsolationMVArun2v1VLoose.clone(
-        #     PATTauProducer = self.cms.InputTag('slimmedTaus'),
+        #     PATTauProducer = self.cms.InputTag(self.originalTauName),
         #     Prediscriminants = noPrediscriminants,
         #     toMultiplex = self.cms.InputTag('rerunDiscriminationByIsolationOldDMMVArun2v2raw'),
         #     key = self.cms.InputTag('rerunDiscriminationByIsolationOldDMMVArun2v2raw:category'),#?
@@ -486,20 +470,20 @@ class TauIDEmbedder(object):
 
         # 2016 training strategy(v1), trained on 2016MC, old DM
         if "2016v1" in self.toKeep:
-            self.process.rerunDiscriminationByIsolationOldDMMVArun2v1raw = patDiscriminationByIsolationMVArun2v1raw.clone(
-                PATTauProducer = self.cms.InputTag('slimmedTaus'),
+            setattr(self.process,"rerunDiscriminationByIsolationOldDMMVArun2v1raw"+self.postfix,patDiscriminationByIsolationMVArun2v1raw.clone(
+                PATTauProducer = self.cms.InputTag(self.originalTauName),
                 Prediscriminants = noPrediscriminants,
                 loadMVAfromDB = self.cms.bool(True),
                 mvaName = self.cms.string("RecoTauTag_tauIdMVAIsoDBoldDMwLT2016v1"),
                 mvaOpt = self.cms.string("DBoldDMwLT"),
                 verbosity = self.cms.int32(0)
-            )
+            ))
 
-            self.process.rerunDiscriminationByIsolationOldDMMVArun2v1VLoose = patDiscriminationByIsolationMVArun2v1VLoose.clone(
-                    PATTauProducer = self.cms.InputTag('slimmedTaus'),
+            setattr(self.process,"rerunDiscriminationByIsolationOldDMMVArun2v1VLoose"+self.postfix,patDiscriminationByIsolationMVArun2v1VLoose.clone(
+                    PATTauProducer = self.cms.InputTag(self.originalTauName),
                     Prediscriminants = noPrediscriminants,
-                    toMultiplex = self.cms.InputTag('rerunDiscriminationByIsolationOldDMMVArun2v1raw'),
-                    key = self.cms.InputTag('rerunDiscriminationByIsolationOldDMMVArun2v1raw:category'),
+                    toMultiplex = self.cms.InputTag('rerunDiscriminationByIsolationOldDMMVArun2v1raw'+self.postfix),
+                    key = self.cms.InputTag('rerunDiscriminationByIsolationOldDMMVArun2v1raw'+self.postfix+':category'),
                     loadMVAfromDB = self.cms.bool(True),
                     mvaOutput_normalization = self.cms.string("RecoTauTag_tauIdMVAIsoDBoldDMwLT2016v1_mvaOutput_normalization"),
                     mapping = self.cms.VPSet(
@@ -509,55 +493,53 @@ class TauIDEmbedder(object):
                             variable = self.cms.string("pt"),
                         )
                     )
-                )
+                ))
 
-            self.process.rerunDiscriminationByIsolationOldDMMVArun2v1Loose = self.process.rerunDiscriminationByIsolationOldDMMVArun2v1VLoose.clone()
-            self.process.rerunDiscriminationByIsolationOldDMMVArun2v1Loose.mapping[0].cut = self.cms.string("RecoTauTag_tauIdMVAIsoDBoldDMwLT2016v1_WPEff80")
-            self.process.rerunDiscriminationByIsolationOldDMMVArun2v1Medium = self.process.rerunDiscriminationByIsolationOldDMMVArun2v1VLoose.clone()
-            self.process.rerunDiscriminationByIsolationOldDMMVArun2v1Medium.mapping[0].cut = self.cms.string("RecoTauTag_tauIdMVAIsoDBoldDMwLT2016v1_WPEff70")
-            self.process.rerunDiscriminationByIsolationOldDMMVArun2v1Tight = self.process.rerunDiscriminationByIsolationOldDMMVArun2v1VLoose.clone()
-            self.process.rerunDiscriminationByIsolationOldDMMVArun2v1Tight.mapping[0].cut = self.cms.string("RecoTauTag_tauIdMVAIsoDBoldDMwLT2016v1_WPEff60")
-            self.process.rerunDiscriminationByIsolationOldDMMVArun2v1VTight = self.process.rerunDiscriminationByIsolationOldDMMVArun2v1VLoose.clone()
-            self.process.rerunDiscriminationByIsolationOldDMMVArun2v1VTight.mapping[0].cut = self.cms.string("RecoTauTag_tauIdMVAIsoDBoldDMwLT2016v1_WPEff50")
-            self.process.rerunDiscriminationByIsolationOldDMMVArun2v1VVTight = self.process.rerunDiscriminationByIsolationOldDMMVArun2v1VLoose.clone()
-            self.process.rerunDiscriminationByIsolationOldDMMVArun2v1VVTight.mapping[0].cut = self.cms.string("RecoTauTag_tauIdMVAIsoDBoldDMwLT2016v1_WPEff40")
-
+            wp_to_eff_match = {
+                "VVLoose" : "WPEff95",
+                "VLoose" : "WPEff90",
+                "Loose" : "WPEff80",
+                "Medium" : "WPEff70",
+                "Tight" : "WPEff60",
+                "VTight" : "WPEff50",
+                "VVTight" : "WPEff40"
+            }
             self.rerunIsolationOldDMMVArun2016v1Task = self.cms.Task(
-                self.process.rerunDiscriminationByIsolationOldDMMVArun2v1raw,
-                self.process.rerunDiscriminationByIsolationOldDMMVArun2v1VLoose,
-                self.process.rerunDiscriminationByIsolationOldDMMVArun2v1Loose,
-                self.process.rerunDiscriminationByIsolationOldDMMVArun2v1Medium,
-                self.process.rerunDiscriminationByIsolationOldDMMVArun2v1Tight,
-                self.process.rerunDiscriminationByIsolationOldDMMVArun2v1VTight,
-                self.process.rerunDiscriminationByIsolationOldDMMVArun2v1VVTight
+                getattr(self.process,"rerunDiscriminationByIsolationOldDMMVArun2v1raw"+self.postfix),
+                getattr(self.process,"rerunDiscriminationByIsolationOldDMMVArun2v1VLoose"+self.postfix)
             )
-            self.process.rerunMvaIsolationTask.add(self.rerunIsolationOldDMMVArun2016v1Task)
-            self.process.rerunMvaIsolationSequence += self.cms.Sequence(self.rerunIsolationOldDMMVArun2016v1Task)
+            for wp in ["Loose","Medium","Tight","VTight","VVTight"]:
+                setattr(self.process,"rerunDiscriminationByIsolationOldDMMVArun2v1"+wp+self.postfix,getattr(self.process,"rerunDiscriminationByIsolationOldDMMVArun2v1VLoose"+self.postfix).clone())
+                getattr(self.process,"rerunDiscriminationByIsolationOldDMMVArun2v1"+wp+self.postfix).mapping[0].cut = self.cms.string("RecoTauTag_tauIdMVAIsoDBoldDMwLT2016v1_"+wp_to_eff_match[wp])
+                self.rerunIsolationOldDMMVArun2016v1Task.add(getattr(self.process,"rerunDiscriminationByIsolationOldDMMVArun2v1"+wp+self.postfix))
+            getattr(self.process,"rerunMvaIsolationTask"+self.postfix).add(self.rerunIsolationOldDMMVArun2016v1Task)
+            tmpSeq = self.cms.Sequence(getattr(self.process,"rerunMvaIsolationSequence"+self.postfix) + self.cms.Sequence(self.rerunIsolationOldDMMVArun2016v1Task))
+            setattr(self.process,"rerunMvaIsolationSequence"+self.postfix,tmpSeq)
 
-            tauIDSources.byIsolationMVArun2v1DBoldDMwLTraw2016 = self.cms.InputTag('rerunDiscriminationByIsolationOldDMMVArun2v1raw')
-            tauIDSources.byVLooseIsolationMVArun2v1DBoldDMwLT2016 = self.cms.InputTag('rerunDiscriminationByIsolationOldDMMVArun2v1VLoose')
-            tauIDSources.byLooseIsolationMVArun2v1DBoldDMwLT2016 = self.cms.InputTag('rerunDiscriminationByIsolationOldDMMVArun2v1Loose')
-            tauIDSources.byMediumIsolationMVArun2v1DBoldDMwLT2016 = self.cms.InputTag('rerunDiscriminationByIsolationOldDMMVArun2v1Medium')
-            tauIDSources.byTightIsolationMVArun2v1DBoldDMwLT2016 = self.cms.InputTag('rerunDiscriminationByIsolationOldDMMVArun2v1Tight')
-            tauIDSources.byVTightIsolationMVArun2v1DBoldDMwLT2016 = self.cms.InputTag('rerunDiscriminationByIsolationOldDMMVArun2v1VTight')
-            tauIDSources.byVVTightIsolationMVArun2v1DBoldDMwLT2016 = self.cms.InputTag('rerunDiscriminationByIsolationOldDMMVArun2v1VVTight')
+            tauIDSources.byIsolationMVArun2v1DBoldDMwLTraw2016 = self.cms.InputTag('rerunDiscriminationByIsolationOldDMMVArun2v1raw'+self.postfix)
+            tauIDSources.byVLooseIsolationMVArun2v1DBoldDMwLT2016 = self.cms.InputTag('rerunDiscriminationByIsolationOldDMMVArun2v1VLoose'+self.postfix)
+            tauIDSources.byLooseIsolationMVArun2v1DBoldDMwLT2016 = self.cms.InputTag('rerunDiscriminationByIsolationOldDMMVArun2v1Loose'+self.postfix)
+            tauIDSources.byMediumIsolationMVArun2v1DBoldDMwLT2016 = self.cms.InputTag('rerunDiscriminationByIsolationOldDMMVArun2v1Medium'+self.postfix)
+            tauIDSources.byTightIsolationMVArun2v1DBoldDMwLT2016 = self.cms.InputTag('rerunDiscriminationByIsolationOldDMMVArun2v1Tight'+self.postfix)
+            tauIDSources.byVTightIsolationMVArun2v1DBoldDMwLT2016 = self.cms.InputTag('rerunDiscriminationByIsolationOldDMMVArun2v1VTight'+self.postfix)
+            tauIDSources.byVVTightIsolationMVArun2v1DBoldDMwLT2016 = self.cms.InputTag('rerunDiscriminationByIsolationOldDMMVArun2v1VVTight'+self.postfix)
 
         # 2016 training strategy(v1), trained on 2016MC, new DM
         if "newDM2016v1" in self.toKeep:
-            self.process.rerunDiscriminationByIsolationNewDMMVArun2v1raw = patDiscriminationByIsolationMVArun2v1raw.clone(
-                PATTauProducer = self.cms.InputTag('slimmedTaus'),
+            setattr(self.process,"rerunDiscriminationByIsolationNewDMMVArun2v1raw"+self.postfix,patDiscriminationByIsolationMVArun2v1raw.clone(
+                PATTauProducer = self.cms.InputTag(self.originalTauName),
                 Prediscriminants = noPrediscriminants,
                 loadMVAfromDB = self.cms.bool(True),
                 mvaName = self.cms.string("RecoTauTag_tauIdMVAIsoDBnewDMwLT2016v1"),
                 mvaOpt = self.cms.string("DBnewDMwLT"),
                 verbosity = self.cms.int32(0)
-            )
+            ))
 
-            self.process.rerunDiscriminationByIsolationNewDMMVArun2v1VLoose = patDiscriminationByIsolationMVArun2v1VLoose.clone(
-                PATTauProducer = self.cms.InputTag('slimmedTaus'),
+            setattr(self.process,"rerunDiscriminationByIsolationNewDMMVArun2v1VLoose"+self.postfix,patDiscriminationByIsolationMVArun2v1VLoose.clone(
+                PATTauProducer = self.cms.InputTag(self.originalTauName),
                 Prediscriminants = noPrediscriminants,
-                toMultiplex = self.cms.InputTag('rerunDiscriminationByIsolationNewDMMVArun2v1raw'),
-                key = self.cms.InputTag('rerunDiscriminationByIsolationNewDMMVArun2v1raw:category'),
+                toMultiplex = self.cms.InputTag('rerunDiscriminationByIsolationNewDMMVArun2v1raw'+self.postfix),
+                key = self.cms.InputTag('rerunDiscriminationByIsolationNewDMMVArun2v1raw'+self.postfix+':category'),
                 loadMVAfromDB = self.cms.bool(True),
                 mvaOutput_normalization = self.cms.string("RecoTauTag_tauIdMVAIsoDBnewDMwLT2016v1_mvaOutput_normalization"),
                 mapping = self.cms.VPSet(
@@ -567,38 +549,36 @@ class TauIDEmbedder(object):
                         variable = self.cms.string("pt"),
                     )
                 )
-            )
+            ))
 
-            self.process.rerunDiscriminationByIsolationNewDMMVArun2v1Loose = self.process.rerunDiscriminationByIsolationNewDMMVArun2v1VLoose.clone()
-            self.process.rerunDiscriminationByIsolationNewDMMVArun2v1Loose.mapping[0].cut = self.cms.string("RecoTauTag_tauIdMVAIsoDBnewDMwLT2016v1_WPEff80")
-            self.process.rerunDiscriminationByIsolationNewDMMVArun2v1Medium = self.process.rerunDiscriminationByIsolationNewDMMVArun2v1VLoose.clone()
-            self.process.rerunDiscriminationByIsolationNewDMMVArun2v1Medium.mapping[0].cut = self.cms.string("RecoTauTag_tauIdMVAIsoDBnewDMwLT2016v1_WPEff70")
-            self.process.rerunDiscriminationByIsolationNewDMMVArun2v1Tight = self.process.rerunDiscriminationByIsolationNewDMMVArun2v1VLoose.clone()
-            self.process.rerunDiscriminationByIsolationNewDMMVArun2v1Tight.mapping[0].cut = self.cms.string("RecoTauTag_tauIdMVAIsoDBnewDMwLT2016v1_WPEff60")
-            self.process.rerunDiscriminationByIsolationNewDMMVArun2v1VTight = self.process.rerunDiscriminationByIsolationNewDMMVArun2v1VLoose.clone()
-            self.process.rerunDiscriminationByIsolationNewDMMVArun2v1VTight.mapping[0].cut = self.cms.string("RecoTauTag_tauIdMVAIsoDBnewDMwLT2016v1_WPEff50")
-            self.process.rerunDiscriminationByIsolationNewDMMVArun2v1VVTight = self.process.rerunDiscriminationByIsolationNewDMMVArun2v1VLoose.clone()
-            self.process.rerunDiscriminationByIsolationNewDMMVArun2v1VVTight.mapping[0].cut = self.cms.string("RecoTauTag_tauIdMVAIsoDBnewDMwLT2016v1_WPEff40")
-
+            wp_to_eff_match = {
+                "VVLoose" : "WPEff95",
+                "VLoose" : "WPEff90",
+                "Loose" : "WPEff80",
+                "Medium" : "WPEff70",
+                "Tight" : "WPEff60",
+                "VTight" : "WPEff50",
+                "VVTight" : "WPEff40"
+            }
             self.rerunIsolationNewDMMVArun2016v1Task = self.cms.Task(
-                self.process.rerunDiscriminationByIsolationNewDMMVArun2v1raw,
-                self.process.rerunDiscriminationByIsolationNewDMMVArun2v1VLoose,
-                self.process.rerunDiscriminationByIsolationNewDMMVArun2v1Loose,
-                self.process.rerunDiscriminationByIsolationNewDMMVArun2v1Medium,
-                self.process.rerunDiscriminationByIsolationNewDMMVArun2v1Tight,
-                self.process.rerunDiscriminationByIsolationNewDMMVArun2v1VTight,
-                self.process.rerunDiscriminationByIsolationNewDMMVArun2v1VVTight
+                getattr(self.process,"rerunDiscriminationByIsolationNewDMMVArun2v1raw"+self.postfix),
+                getattr(self.process,"rerunDiscriminationByIsolationNewDMMVArun2v1VLoose"+self.postfix)
             )
-            self.process.rerunMvaIsolationTask.add(self.rerunIsolationNewDMMVArun2016v1Task)
-            self.process.rerunMvaIsolationSequence += self.cms.Sequence(self.rerunIsolationNewDMMVArun2016v1Task)
+            for wp in ["Loose","Medium","Tight","VTight","VVTight"]:
+                setattr(self.process,"rerunDiscriminationByIsolationNewDMMVArun2v1"+wp+self.postfix,getattr(self.process,"rerunDiscriminationByIsolationNewDMMVArun2v1VLoose"+self.postfix).clone())
+                getattr(self.process,"rerunDiscriminationByIsolationNewDMMVArun2v1"+wp+self.postfix).mapping[0].cut = self.cms.string("RecoTauTag_tauIdMVAIsoDBnewDMwLT2016v1_"+wp_to_eff_match[wp])
+                self.rerunIsolationNewDMMVArun2016v1Task.add(getattr(self.process,"rerunDiscriminationByIsolationNewDMMVArun2v1"+wp+self.postfix))
+            getattr(self.process,"rerunMvaIsolationTask"+self.postfix).add(self.rerunIsolationNewDMMVArun2016v1Task)
+            tmpSeq = self.cms.Sequence(getattr(self.process,"rerunMvaIsolationSequence"+self.postfix) + self.cms.Sequence(self.rerunIsolationNewDMMVArun2016v1Task))
+            setattr(self.process,"rerunMvaIsolationSequence"+self.postfix,tmpSeq)
 
-            tauIDSources.byIsolationMVArun2v1DBnewDMwLTraw2016 = self.cms.InputTag('rerunDiscriminationByIsolationNewDMMVArun2v1raw')
-            tauIDSources.byVLooseIsolationMVArun2v1DBnewDMwLT2016 = self.cms.InputTag('rerunDiscriminationByIsolationNewDMMVArun2v1VLoose')
-            tauIDSources.byLooseIsolationMVArun2v1DBnewDMwLT2016 = self.cms.InputTag('rerunDiscriminationByIsolationNewDMMVArun2v1Loose')
-            tauIDSources.byMediumIsolationMVArun2v1DBnewDMwLT2016 = self.cms.InputTag('rerunDiscriminationByIsolationNewDMMVArun2v1Medium')
-            tauIDSources.byTightIsolationMVArun2v1DBnewDMwLT2016 = self.cms.InputTag('rerunDiscriminationByIsolationNewDMMVArun2v1Tight')
-            tauIDSources.byVTightIsolationMVArun2v1DBnewDMwLT2016 = self.cms.InputTag('rerunDiscriminationByIsolationNewDMMVArun2v1VTight')
-            tauIDSources.byVVTightIsolationMVArun2v1DBnewDMwLT2016 = self.cms.InputTag('rerunDiscriminationByIsolationNewDMMVArun2v1VVTight')
+            tauIDSources.byIsolationMVArun2v1DBoldDMwLTraw2016 = self.cms.InputTag('rerunDiscriminationByIsolationNewDMMVArun2v1raw'+self.postfix)
+            tauIDSources.byVLooseIsolationMVArun2v1DBoldDMwLT2016 = self.cms.InputTag('rerunDiscriminationByIsolationNewDMMVArun2v1VLoose'+self.postfix)
+            tauIDSources.byLooseIsolationMVArun2v1DBoldDMwLT2016 = self.cms.InputTag('rerunDiscriminationByIsolationNewDMMVArun2v1Loose'+self.postfix)
+            tauIDSources.byMediumIsolationMVArun2v1DBoldDMwLT2016 = self.cms.InputTag('rerunDiscriminationByIsolationNewDMMVArun2v1Medium'+self.postfix)
+            tauIDSources.byTightIsolationMVArun2v1DBoldDMwLT2016 = self.cms.InputTag('rerunDiscriminationByIsolationNewDMMVArun2v1Tight'+self.postfix)
+            tauIDSources.byVTightIsolationMVArun2v1DBoldDMwLT2016 = self.cms.InputTag('rerunDiscriminationByIsolationNewDMMVArun2v1VTight'+self.postfix)
+            tauIDSources.byVVTightIsolationMVArun2v1DBoldDMwLT2016 = self.cms.InputTag('rerunDiscriminationByIsolationNewDMMVArun2v1VVTight'+self.postfix)
 
         if "deepTau2017v1" in self.toKeep:
             if self.debug: print ("Adding DeepTau IDs")
@@ -637,10 +617,10 @@ class TauIDEmbedder(object):
                 }
             }
             file_names = ['RecoTauTag/TrainingFiles/data/DeepTauId/deepTau_2017v1_20L1024N_quantized.pb']
-            self.process.deepTau2017v1 = self.cms.EDProducer("DeepTauId",
+            setattr(self.process,"deepTau2017v1"+self.postfix,self.cms.EDProducer("DeepTauId",
                 electrons              = self.cms.InputTag('slimmedElectrons'),
                 muons                  = self.cms.InputTag('slimmedMuons'),
-                taus                   = self.cms.InputTag('slimmedTaus'),
+                taus                   = self.cms.InputTag(self.originalTauName),
                 pfcands                = self.cms.InputTag('packedPFCandidates'),
                 vertices               = self.cms.InputTag('offlineSlimmedPrimaryVertices'),
                 rho                    = self.cms.InputTag('fixedGridRhoAll'),
@@ -650,12 +630,13 @@ class TauIDEmbedder(object):
                 debug_level            = self.cms.int32(0),
                 disable_dxy_pca        = self.cms.bool(False)
 
-            )
+            ))
 
             self.processDeepProducer('deepTau2017v1', tauIDSources, workingPoints_)
 
-            self.process.rerunMvaIsolationTask.add(self.process.deepTau2017v1)
-            self.process.rerunMvaIsolationSequence += self.process.deepTau2017v1
+            getattr(self.process,"rerunMvaIsolationTask"+self.postfix).add(getattr(self.process,"deepTau2017v1"+self.postfix))
+            tmpSeq = self.cms.Sequence(getattr(self.process,"rerunMvaIsolationSequence"+self.postfix) + getattr(self.process,"deepTau2017v1"+self.postfix))
+            setattr(self.process,"rerunMvaIsolationSequence"+self.postfix,tmpSeq)
 
         if "deepTau2017v2" in self.toKeep:
             if self.debug: print ("Adding DeepTau IDs")
@@ -694,10 +675,10 @@ class TauIDEmbedder(object):
                 'inner:RecoTauTag/TrainingFiles/data/DeepTauId/deepTau_2017v2p6_e6_inner.pb',
                 'outer:RecoTauTag/TrainingFiles/data/DeepTauId/deepTau_2017v2p6_e6_outer.pb',
             ]
-            self.process.deepTau2017v2 = self.cms.EDProducer("DeepTauId",
+            setattr(self.process,"deepTau2017v2"+self.postfix,self.cms.EDProducer("DeepTauId",
                 electrons              = self.cms.InputTag('slimmedElectrons'),
                 muons                  = self.cms.InputTag('slimmedMuons'),
-                taus                   = self.cms.InputTag('slimmedTaus'),
+                taus                   = self.cms.InputTag(self.originalTauName),
                 pfcands                = self.cms.InputTag('packedPFCandidates'),
                 vertices               = self.cms.InputTag('offlineSlimmedPrimaryVertices'),
                 rho                    = self.cms.InputTag('fixedGridRhoAll'),
@@ -707,12 +688,12 @@ class TauIDEmbedder(object):
                 debug_level            = self.cms.int32(0),
                 disable_dxy_pca        = self.cms.bool(False)
 
-            )
+            ))
 
             self.processDeepProducer('deepTau2017v2', tauIDSources, workingPoints_)
-
-            self.process.rerunMvaIsolationTask.add(self.process.deepTau2017v2)
-            self.process.rerunMvaIsolationSequence += self.process.deepTau2017v2
+            getattr(self.process,"rerunMvaIsolationTask"+self.postfix).add(getattr(self.process,"deepTau2017v2"+self.postfix))
+            tmpSeq = self.cms.Sequence(getattr(self.process,"rerunMvaIsolationSequence"+self.postfix) + getattr(self.process,"deepTau2017v2"+self.postfix))
+            setattr(self.process,"rerunMvaIsolationSequence"+self.postfix,tmpSeq)
 
         if "deepTau2017v2p1" in self.toKeep:
             if self.debug: print ("Adding DeepTau IDs")
@@ -751,10 +732,10 @@ class TauIDEmbedder(object):
                 'inner:RecoTauTag/TrainingFiles/data/DeepTauId/deepTau_2017v2p6_e6_inner.pb',
                 'outer:RecoTauTag/TrainingFiles/data/DeepTauId/deepTau_2017v2p6_e6_outer.pb',
             ]
-            self.process.deepTau2017v2p1 = self.cms.EDProducer("DeepTauId",
+            setattr(self.process,"deepTau2017v2p1"+self.postfix,self.cms.EDProducer("DeepTauId",
                 electrons                = self.cms.InputTag('slimmedElectrons'),
                 muons                    = self.cms.InputTag('slimmedMuons'),
-                taus                     = self.cms.InputTag('slimmedTaus'),
+                taus                     = self.cms.InputTag(self.originalTauName),
                 pfcands                  = self.cms.InputTag('packedPFCandidates'),
                 vertices                 = self.cms.InputTag('offlineSlimmedPrimaryVertices'),
                 rho                      = self.cms.InputTag('fixedGridRhoAll'),
@@ -764,12 +745,13 @@ class TauIDEmbedder(object):
                 debug_level              = self.cms.int32(0),
                 disable_dxy_pca          = self.cms.bool(True)
 
-            )
+            ))
 
             self.processDeepProducer('deepTau2017v2p1', tauIDSources, workingPoints_)
 
-            self.process.rerunMvaIsolationTask.add(self.process.deepTau2017v2p1)
-            self.process.rerunMvaIsolationSequence += self.process.deepTau2017v2p1
+            getattr(self.process,"rerunMvaIsolationTask"+self.postfix).add(getattr(self.process,"deepTau2017v2p1"+self.postfix))
+            tmpSeq = self.cms.Sequence(getattr(self.process,"rerunMvaIsolationSequence"+self.postfix) + getattr(self.process,"deepTau2017v2p1"+self.postfix))
+            setattr(self.process,"rerunMvaIsolationSequence"+self.postfix,tmpSeq)
 
         if "DPFTau_2016_v0" in self.toKeep:
             if self.debug: print ("Adding DPFTau isolation (v0)")
@@ -789,20 +771,20 @@ class TauIDEmbedder(object):
                 }
             }
             file_names = [ 'RecoTauTag/TrainingFiles/data/DPFTauId/DPFIsolation_2017v0_quantized.pb' ]
-            self.process.dpfTau2016v0 = self.cms.EDProducer("DPFIsolation",
+            setattr(self.process,"dpfTau2016v0"+self.postfix,self.cms.EDProducer("DPFIsolation",
                 pfcands     = self.cms.InputTag('packedPFCandidates'),
-                taus        = self.cms.InputTag('slimmedTaus'),
+                taus        = self.cms.InputTag(self.originalTauName),
                 vertices    = self.cms.InputTag('offlineSlimmedPrimaryVertices'),
                 graph_file  = self.cms.vstring(file_names),
                 version     = self.cms.uint32(self.getDpfTauVersion(file_names[0])),
                 mem_mapped  = self.cms.bool(False)
-            )
+            ))
 
             self.processDeepProducer('dpfTau2016v0', tauIDSources, workingPoints_)
 
-            self.process.rerunMvaIsolationTask.add(self.process.dpfTau2016v0)
-            self.process.rerunMvaIsolationSequence += self.process.dpfTau2016v0
-
+            getattr(self.process,"rerunMvaIsolationTask"+self.postfix).add(getattr(self.process,"dpfTau2016v0"+self.postfix))
+            tmpSeq = self.cms.Sequence(getattr(self.process,"rerunMvaIsolationSequence"+self.postfix) + getattr(self.process,"dpfTau2016v0"+self.postfix))
+            setattr(self.process,"rerunMvaIsolationSequence"+self.postfix,tmpSeq)
 
         if "DPFTau_2016_v1" in self.toKeep:
             print ("Adding DPFTau isolation (v1)")
@@ -814,26 +796,27 @@ class TauIDEmbedder(object):
             }
 
             file_names = [ 'RecoTauTag/TrainingFiles/data/DPFTauId/DPFIsolation_2017v1_quantized.pb' ]
-            self.process.dpfTau2016v1 = self.cms.EDProducer("DPFIsolation",
+            setattr(self.process,"dpfTau2016v1"+self.postfix,self.cms.EDProducer("DPFIsolation",
                 pfcands     = self.cms.InputTag('packedPFCandidates'),
-                taus        = self.cms.InputTag('slimmedTaus'),
+                taus        = self.cms.InputTag(self.originalTauName),
                 vertices    = self.cms.InputTag('offlineSlimmedPrimaryVertices'),
                 graph_file  = self.cms.vstring(file_names),
                 version     = self.cms.uint32(self.getDpfTauVersion(file_names[0])),
                 mem_mapped  = self.cms.bool(False)
-            )
+            ))
 
             self.processDeepProducer('dpfTau2016v1', tauIDSources, workingPoints_)
 
-            self.process.rerunMvaIsolationTask.add(self.process.dpfTau2016v1)
-            self.process.rerunMvaIsolationSequence += self.process.dpfTau2016v1
+            getattr(self.process,"rerunMvaIsolationTask"+self.postfix).add(getattr(self.process,"dpfTau2016v1"+self.postfix))
+            tmpSeq = self.cms.Sequence(getattr(self.process,"rerunMvaIsolationSequence"+self.postfix) + getattr(self.process,"dpfTau2016v1"+self.postfix))
+            setattr(self.process,"rerunMvaIsolationSequence"+self.postfix,tmpSeq)
 
         if "againstEle2018" in self.toKeep:
             antiElectronDiscrMVA6_version = "MVA6v3_noeveto"
             ### Define new anti-e discriminants
             ## Raw
             from RecoTauTag.RecoTau.PATTauDiscriminationAgainstElectronMVA6_cfi import patTauDiscriminationAgainstElectronMVA6
-            self.process.patTauDiscriminationByElectronRejectionMVA62018Raw = patTauDiscriminationAgainstElectronMVA6.clone(
+            setattr(self.process,"patTauDiscriminationByElectronRejectionMVA62018Raw"+self.postfix,patTauDiscriminationAgainstElectronMVA6.clone(
                 Prediscriminants = noPrediscriminants, #already selected for MiniAOD
                 vetoEcalCracks = self.cms.bool(False), #keep taus in EB-EE cracks
                 mvaName_NoEleMatch_wGwoGSF_BL = 'RecoTauTag_antiElectron'+antiElectronDiscrMVA6_version+'_gbr_NoEleMatch_wGwoGSF_BL',
@@ -844,15 +827,15 @@ class TauIDEmbedder(object):
                 mvaName_wGwGSF_EC = 'RecoTauTag_antiElectron'+antiElectronDiscrMVA6_version+'_gbr_wGwGSF_EC',
                 mvaName_woGwGSF_BL = 'RecoTauTag_antiElectron'+antiElectronDiscrMVA6_version+'_gbr_woGwGSF_BL',
                 mvaName_woGwGSF_EC = 'RecoTauTag_antiElectron'+antiElectronDiscrMVA6_version+'_gbr_woGwGSF_EC'
-            )
+            ))
             ## WPs
             from RecoTauTag.RecoTau.PATTauDiscriminantCutMultiplexer_cfi import patTauDiscriminantCutMultiplexer
             # VLoose
-            self.process.patTauDiscriminationByVLooseElectronRejectionMVA62018 = patTauDiscriminantCutMultiplexer.clone(
-                PATTauProducer = self.process.patTauDiscriminationByElectronRejectionMVA62018Raw.PATTauProducer,
-                Prediscriminants = self.process.patTauDiscriminationByElectronRejectionMVA62018Raw.Prediscriminants,
-                toMultiplex = self.cms.InputTag("patTauDiscriminationByElectronRejectionMVA62018Raw"),
-                key = self.cms.InputTag("patTauDiscriminationByElectronRejectionMVA62018Raw","category"),
+            setattr(self.process,"patTauDiscriminationByVLooseElectronRejectionMVA62018"+self.postfix,patTauDiscriminantCutMultiplexer.clone(
+                PATTauProducer = getattr(self.process,"patTauDiscriminationByElectronRejectionMVA62018Raw"+self.postfix).PATTauProducer,
+                Prediscriminants = getattr(self.process,"patTauDiscriminationByElectronRejectionMVA62018Raw"+self.postfix).Prediscriminants,
+                toMultiplex = self.cms.InputTag("patTauDiscriminationByElectronRejectionMVA62018Raw"+self.postfix),
+                key = self.cms.InputTag("patTauDiscriminationByElectronRejectionMVA62018Raw"+self.postfix,"category"),
                 mapping = self.cms.VPSet(
                     self.cms.PSet(
                         category = self.cms.uint32(0),
@@ -895,208 +878,82 @@ class TauIDEmbedder(object):
                         variable = self.cms.string('pt')
                     )
                 )
-            )
-            # Loose
-            self.process.patTauDiscriminationByLooseElectronRejectionMVA62018 = self.process.patTauDiscriminationByVLooseElectronRejectionMVA62018.clone(
-                mapping = self.cms.VPSet(
-                    self.cms.PSet(
-                        category = self.cms.uint32(0),
-                        cut = self.cms.string('RecoTauTag_antiElectron'+antiElectronDiscrMVA6_version+'_gbr_NoEleMatch_woGwoGSF_BL_WPeff90'),
-                        variable = self.cms.string('pt')
-                    ),
-                    self.cms.PSet(
-                        category = self.cms.uint32(2),
-                        cut = self.cms.string('RecoTauTag_antiElectron'+antiElectronDiscrMVA6_version+'_gbr_NoEleMatch_wGwoGSF_BL_WPeff90'),
-                        variable = self.cms.string('pt')
-                    ),
-                    self.cms.PSet(
-                        category = self.cms.uint32(5),
-                        cut = self.cms.string('RecoTauTag_antiElectron'+antiElectronDiscrMVA6_version+'_gbr_woGwGSF_BL_WPeff90'),
-                        variable = self.cms.string('pt')
-                    ),
-                    self.cms.PSet(
-                        category = self.cms.uint32(7),
-                        cut = self.cms.string('RecoTauTag_antiElectron'+antiElectronDiscrMVA6_version+'_gbr_wGwGSF_BL_WPeff90'),
-                        variable = self.cms.string('pt')
-                    ),
-                    self.cms.PSet(
-                        category = self.cms.uint32(8),
-                        cut = self.cms.string('RecoTauTag_antiElectron'+antiElectronDiscrMVA6_version+'_gbr_NoEleMatch_woGwoGSF_EC_WPeff90'),
-                        variable = self.cms.string('pt')
-                    ),
-                    self.cms.PSet(
-                        category = self.cms.uint32(10),
-                        cut = self.cms.string('RecoTauTag_antiElectron'+antiElectronDiscrMVA6_version+'_gbr_NoEleMatch_wGwoGSF_EC_WPeff90'),
-                        variable = self.cms.string('pt')
-                    ),
-                    self.cms.PSet(
-                        category = self.cms.uint32(13),
-                        cut = self.cms.string('RecoTauTag_antiElectron'+antiElectronDiscrMVA6_version+'_gbr_woGwGSF_EC_WPeff90'),
-                        variable = self.cms.string('pt')
-                    ),
-                    self.cms.PSet(
-                        category = self.cms.uint32(15),
-                        cut = self.cms.string('RecoTauTag_antiElectron'+antiElectronDiscrMVA6_version+'_gbr_wGwGSF_EC_WPeff90'),
-                        variable = self.cms.string('pt')
+            ))
+            # Other WPs
+            wp_to_eff_match = {
+                "VLoose" : "WPeff98",
+                "Loose" : "WPeff90",
+                "Medium" : "WPeff80",
+                "Tight" : "WPeff70",
+                "VTight" : "WPeff60",
+            }
+            for wp in ["Loose", "Medium", "Tight", "VTight"]:
+                setattr(self.process,"patTauDiscriminationBy"+wp+"ElectronRejectionMVA62018"+self.postfix,getattr(self.process,"patTauDiscriminationByVLooseElectronRejectionMVA62018"+self.postfix).clone(
+                    mapping = self.cms.VPSet(
+                        self.cms.PSet(
+                            category = self.cms.uint32(0),
+                            cut = self.cms.string('RecoTauTag_antiElectron'+antiElectronDiscrMVA6_version+'_gbr_NoEleMatch_woGwoGSF_BL_'+wp_to_eff_match[wp]),
+                            variable = self.cms.string('pt')
+                        ),
+                        self.cms.PSet(
+                            category = self.cms.uint32(2),
+                            cut = self.cms.string('RecoTauTag_antiElectron'+antiElectronDiscrMVA6_version+'_gbr_NoEleMatch_wGwoGSF_BL_'+wp_to_eff_match[wp]),
+                            variable = self.cms.string('pt')
+                        ),
+                        self.cms.PSet(
+                            category = self.cms.uint32(5),
+                            cut = self.cms.string('RecoTauTag_antiElectron'+antiElectronDiscrMVA6_version+'_gbr_woGwGSF_BL_'+wp_to_eff_match[wp]),
+                            variable = self.cms.string('pt')
+                        ),
+                        self.cms.PSet(
+                            category = self.cms.uint32(7),
+                            cut = self.cms.string('RecoTauTag_antiElectron'+antiElectronDiscrMVA6_version+'_gbr_wGwGSF_BL_'+wp_to_eff_match[wp]),
+                            variable = self.cms.string('pt')
+                        ),
+                        self.cms.PSet(
+                            category = self.cms.uint32(8),
+                            cut = self.cms.string('RecoTauTag_antiElectron'+antiElectronDiscrMVA6_version+'_gbr_NoEleMatch_woGwoGSF_EC_'+wp_to_eff_match[wp]),
+                            variable = self.cms.string('pt')
+                        ),
+                        self.cms.PSet(
+                            category = self.cms.uint32(10),
+                            cut = self.cms.string('RecoTauTag_antiElectron'+antiElectronDiscrMVA6_version+'_gbr_NoEleMatch_wGwoGSF_EC_'+wp_to_eff_match[wp]),
+                            variable = self.cms.string('pt')
+                        ),
+                        self.cms.PSet(
+                            category = self.cms.uint32(13),
+                            cut = self.cms.string('RecoTauTag_antiElectron'+antiElectronDiscrMVA6_version+'_gbr_woGwGSF_EC_'+wp_to_eff_match[wp]),
+                            variable = self.cms.string('pt')
+                        ),
+                        self.cms.PSet(
+                            category = self.cms.uint32(15),
+                            cut = self.cms.string('RecoTauTag_antiElectron'+antiElectronDiscrMVA6_version+'_gbr_wGwGSF_EC_'+wp_to_eff_match[wp]),
+                            variable = self.cms.string('pt')
+                        )
                     )
-                )
-            )
-            # Medium
-            self.process.patTauDiscriminationByMediumElectronRejectionMVA62018 = self.process.patTauDiscriminationByVLooseElectronRejectionMVA62018.clone(
-                mapping = self.cms.VPSet(
-                    self.cms.PSet(
-                        category = self.cms.uint32(0),
-                        cut = self.cms.string('RecoTauTag_antiElectron'+antiElectronDiscrMVA6_version+'_gbr_NoEleMatch_woGwoGSF_BL_WPeff80'),
-                        variable = self.cms.string('pt')
-                     ),
-                    self.cms.PSet(
-                        category = self.cms.uint32(2),
-                        cut = self.cms.string('RecoTauTag_antiElectron'+antiElectronDiscrMVA6_version+'_gbr_NoEleMatch_wGwoGSF_BL_WPeff80'),
-                        variable = self.cms.string('pt')
-                    ),
-                    self.cms.PSet(
-                        category = self.cms.uint32(5),
-                        cut = self.cms.string('RecoTauTag_antiElectron'+antiElectronDiscrMVA6_version+'_gbr_woGwGSF_BL_WPeff80'),
-                        variable = self.cms.string('pt')
-                    ),
-                    self.cms.PSet(
-                        category = self.cms.uint32(7),
-                        cut = self.cms.string('RecoTauTag_antiElectron'+antiElectronDiscrMVA6_version+'_gbr_wGwGSF_BL_WPeff80'),
-                        variable = self.cms.string('pt')
-                    ),
-                    self.cms.PSet(
-                        category = self.cms.uint32(8),
-                        cut = self.cms.string('RecoTauTag_antiElectron'+antiElectronDiscrMVA6_version+'_gbr_NoEleMatch_woGwoGSF_EC_WPeff80'),
-                        variable = self.cms.string('pt')
-                    ),
-                    self.cms.PSet(
-                        category = self.cms.uint32(10),
-                        cut = self.cms.string('RecoTauTag_antiElectron'+antiElectronDiscrMVA6_version+'_gbr_NoEleMatch_wGwoGSF_EC_WPeff80'),
-                        variable = self.cms.string('pt')
-                    ),
-                    self.cms.PSet(
-                        category = self.cms.uint32(13),
-                        cut = self.cms.string('RecoTauTag_antiElectron'+antiElectronDiscrMVA6_version+'_gbr_woGwGSF_EC_WPeff80'),
-                        variable = self.cms.string('pt')
-                    ),
-                    self.cms.PSet(
-                        category = self.cms.uint32(15),
-                        cut = self.cms.string('RecoTauTag_antiElectron'+antiElectronDiscrMVA6_version+'_gbr_wGwGSF_EC_WPeff80'),
-                        variable = self.cms.string('pt')
-                    )
-                )
-            )
-            # Tight
-            self.process.patTauDiscriminationByTightElectronRejectionMVA62018 = self.process.patTauDiscriminationByVLooseElectronRejectionMVA62018.clone(
-                mapping = self.cms.VPSet(
-                    self.cms.PSet(
-                        category = self.cms.uint32(0),
-                        cut = self.cms.string('RecoTauTag_antiElectron'+antiElectronDiscrMVA6_version+'_gbr_NoEleMatch_woGwoGSF_BL_WPeff70'),
-                        variable = self.cms.string('pt')
-                    ),
-                    self.cms.PSet(
-                        category = self.cms.uint32(2),
-                        cut = self.cms.string('RecoTauTag_antiElectron'+antiElectronDiscrMVA6_version+'_gbr_NoEleMatch_wGwoGSF_BL_WPeff70'),
-                        variable = self.cms.string('pt')
-                    ),
-                    self.cms.PSet(
-                        category = self.cms.uint32(5),
-                        cut = self.cms.string('RecoTauTag_antiElectron'+antiElectronDiscrMVA6_version+'_gbr_woGwGSF_BL_WPeff70'),
-                        variable = self.cms.string('pt')
-                    ),
-                    self.cms.PSet(
-                        category = self.cms.uint32(7),
-                        cut = self.cms.string('RecoTauTag_antiElectron'+antiElectronDiscrMVA6_version+'_gbr_wGwGSF_BL_WPeff70'),
-                        variable = self.cms.string('pt')
-                    ),
-                    self.cms.PSet(
-                        category = self.cms.uint32(8),
-                        cut = self.cms.string('RecoTauTag_antiElectron'+antiElectronDiscrMVA6_version+'_gbr_NoEleMatch_woGwoGSF_EC_WPeff70'),
-                        variable = self.cms.string('pt')
-                    ),
-                    self.cms.PSet(
-                        category = self.cms.uint32(10),
-                        cut = self.cms.string('RecoTauTag_antiElectron'+antiElectronDiscrMVA6_version+'_gbr_NoEleMatch_wGwoGSF_EC_WPeff70'),
-                        variable = self.cms.string('pt')
-                    ),
-                    self.cms.PSet(
-                        category = self.cms.uint32(13),
-                        cut = self.cms.string('RecoTauTag_antiElectron'+antiElectronDiscrMVA6_version+'_gbr_woGwGSF_EC_WPeff70'),
-                        variable = self.cms.string('pt')
-                    ),
-                    self.cms.PSet(
-                        category = self.cms.uint32(15),
-                        cut = self.cms.string('RecoTauTag_antiElectron'+antiElectronDiscrMVA6_version+'_gbr_wGwGSF_EC_WPeff70'),
-                        variable = self.cms.string('pt')
-                    )
-                )
-            )
-            # VTight
-            self.process.patTauDiscriminationByVTightElectronRejectionMVA62018 = self.process.patTauDiscriminationByVLooseElectronRejectionMVA62018.clone(
-                mapping = self.cms.VPSet(
-                    self.cms.PSet(
-                        category = self.cms.uint32(0),
-                        cut = self.cms.string('RecoTauTag_antiElectron'+antiElectronDiscrMVA6_version+'_gbr_NoEleMatch_woGwoGSF_BL_WPeff60'),
-                        variable = self.cms.string('pt')
-                    ),
-                    self.cms.PSet(
-                        category = self.cms.uint32(2),
-                        cut = self.cms.string('RecoTauTag_antiElectron'+antiElectronDiscrMVA6_version+'_gbr_NoEleMatch_wGwoGSF_BL_WPeff60'),
-                        variable = self.cms.string('pt')
-                    ),
-                    self.cms.PSet(
-                        category = self.cms.uint32(5),
-                        cut = self.cms.string('RecoTauTag_antiElectron'+antiElectronDiscrMVA6_version+'_gbr_woGwGSF_BL_WPeff60'),
-                        variable = self.cms.string('pt')
-                    ),
-                    self.cms.PSet(
-                        category = self.cms.uint32(7),
-                        cut = self.cms.string('RecoTauTag_antiElectron'+antiElectronDiscrMVA6_version+'_gbr_wGwGSF_BL_WPeff60'),
-                        variable = self.cms.string('pt')
-                    ),
-                    self.cms.PSet(
-                        category = self.cms.uint32(8),
-                        cut = self.cms.string('RecoTauTag_antiElectron'+antiElectronDiscrMVA6_version+'_gbr_NoEleMatch_woGwoGSF_EC_WPeff60'),
-                        variable = self.cms.string('pt')
-                    ),
-                    self.cms.PSet(
-                        category = self.cms.uint32(10),
-                        cut = self.cms.string('RecoTauTag_antiElectron'+antiElectronDiscrMVA6_version+'_gbr_NoEleMatch_wGwoGSF_EC_WPeff60'),
-                        variable = self.cms.string('pt')
-                    ),
-                    self.cms.PSet(
-                        category = self.cms.uint32(13),
-                        cut = self.cms.string('RecoTauTag_antiElectron'+antiElectronDiscrMVA6_version+'_gbr_woGwGSF_EC_WPeff60'),
-                        variable = self.cms.string('pt')
-                    ),
-                    self.cms.PSet(
-                        category = self.cms.uint32(15),
-                        cut = self.cms.string('RecoTauTag_antiElectron'+antiElectronDiscrMVA6_version+'_gbr_wGwGSF_EC_WPeff60'),
-                        variable = self.cms.string('pt')
-                    )
-                )
-            )
+                ))
             ### Put all new anti-e discrminats to a sequence
-            self.process.patTauDiscriminationByElectronRejectionMVA62018Task = self.cms.Task(
-                self.process.patTauDiscriminationByElectronRejectionMVA62018Raw,
-                self.process.patTauDiscriminationByVLooseElectronRejectionMVA62018,
-                self.process.patTauDiscriminationByLooseElectronRejectionMVA62018,
-                self.process.patTauDiscriminationByMediumElectronRejectionMVA62018,
-                self.process.patTauDiscriminationByTightElectronRejectionMVA62018,
-                self.process.patTauDiscriminationByVTightElectronRejectionMVA62018
+            patTauDiscriminationByElectronRejectionMVA62018Task = self.cms.Task(
+                getattr(self.process,"patTauDiscriminationByElectronRejectionMVA62018Raw"+self.postfix),
+                getattr(self.process,"patTauDiscriminationByVLooseElectronRejectionMVA62018"+self.postfix),
+                getattr(self.process,"patTauDiscriminationByLooseElectronRejectionMVA62018"+self.postfix),
+                getattr(self.process,"patTauDiscriminationByMediumElectronRejectionMVA62018"+self.postfix),
+                getattr(self.process,"patTauDiscriminationByTightElectronRejectionMVA62018"+self.postfix),
+                getattr(self.process,"patTauDiscriminationByVTightElectronRejectionMVA62018"+self.postfix)
             )
-            self.process.patTauDiscriminationByElectronRejectionMVA62018Seq = self.cms.Sequence(self.process.patTauDiscriminationByElectronRejectionMVA62018Task)
-            self.process.rerunMvaIsolationTask.add(self.process.patTauDiscriminationByElectronRejectionMVA62018Task)
-            self.process.rerunMvaIsolationSequence += self.process.patTauDiscriminationByElectronRejectionMVA62018Seq
+            patTauDiscriminationByElectronRejectionMVA62018Seq = self.cms.Sequence(patTauDiscriminationByElectronRejectionMVA62018Task)
+            getattr(self.process,"rerunMvaIsolationTask"+self.postfix).add(patTauDiscriminationByElectronRejectionMVA62018Task)
+            tmpSeq = self.cms.Sequence(getattr(self.process,"rerunMvaIsolationSequence"+self.postfix) + patTauDiscriminationByElectronRejectionMVA62018Seq)
+            setattr(self.process,"rerunMvaIsolationSequence"+self.postfix,tmpSeq)
 
             _againstElectronTauIDSources = self.cms.PSet(
-                againstElectronMVA6Raw2018 = self.cms.InputTag("patTauDiscriminationByElectronRejectionMVA62018Raw"),
-                againstElectronMVA6category2018 = self.cms.InputTag("patTauDiscriminationByElectronRejectionMVA62018Raw","category"),
-                againstElectronVLooseMVA62018 = self.cms.InputTag("patTauDiscriminationByVLooseElectronRejectionMVA62018"),
-                againstElectronLooseMVA62018 = self.cms.InputTag("patTauDiscriminationByLooseElectronRejectionMVA62018"),
-                againstElectronMediumMVA62018 = self.cms.InputTag("patTauDiscriminationByMediumElectronRejectionMVA62018"),
-                againstElectronTightMVA62018 = self.cms.InputTag("patTauDiscriminationByTightElectronRejectionMVA62018"),
-                againstElectronVTightMVA62018 = self.cms.InputTag("patTauDiscriminationByVTightElectronRejectionMVA62018")
+                againstElectronMVA6Raw2018 = self.cms.InputTag("patTauDiscriminationByElectronRejectionMVA62018Raw"+self.postfix),
+                againstElectronMVA6category2018 = self.cms.InputTag("patTauDiscriminationByElectronRejectionMVA62018Raw"+self.postfix,"category"),
+                againstElectronVLooseMVA62018 = self.cms.InputTag("patTauDiscriminationByVLooseElectronRejectionMVA62018"+self.postfix),
+                againstElectronLooseMVA62018 = self.cms.InputTag("patTauDiscriminationByLooseElectronRejectionMVA62018"+self.postfix),
+                againstElectronMediumMVA62018 = self.cms.InputTag("patTauDiscriminationByMediumElectronRejectionMVA62018"+self.postfix),
+                againstElectronTightMVA62018 = self.cms.InputTag("patTauDiscriminationByTightElectronRejectionMVA62018"+self.postfix),
+                againstElectronVTightMVA62018 = self.cms.InputTag("patTauDiscriminationByVTightElectronRejectionMVA62018"+self.postfix)
             )
             _tauIDSourcesWithAgainistEle = self.cms.PSet(
                 tauIDSources.clone(),
@@ -1108,7 +965,7 @@ class TauIDEmbedder(object):
         if self.debug: print('Embedding new TauIDs into \"'+self.updatedTauName+'\"')
         if not hasattr(self.process, self.updatedTauName):
             embedID = self.cms.EDProducer("PATTauIDEmbedder",
-               src = self.cms.InputTag('slimmedTaus'),
+               src = self.cms.InputTag(self.originalTauName),
                tauIDSources = tauIDSources
             )
             setattr(self.process, self.updatedTauName, embedID)
@@ -1123,14 +980,14 @@ class TauIDEmbedder(object):
         for target,points in six.iteritems(workingPoints_):
             cuts = self.cms.PSet()
             setattr(tauIDSources, 'by{}VS{}raw'.format(producer_name[0].upper()+producer_name[1:], target),
-                        self.cms.InputTag(producer_name, 'VS{}'.format(target)))
+                        self.cms.InputTag(producer_name+self.postfix, 'VS{}'.format(target)))
             for point,cut in six.iteritems(points):
                 setattr(cuts, point, self.cms.string(str(cut)))
 
                 setattr(tauIDSources, 'by{}{}VS{}'.format(point, producer_name[0].upper()+producer_name[1:], target),
-                        self.cms.InputTag(producer_name, 'VS{}{}'.format(target, point)))
+                        self.cms.InputTag(producer_name+self.postfix, 'VS{}{}'.format(target, point)))
 
-            setattr(getattr(self.process, producer_name), 'VS{}WP'.format(target), cuts)
+            setattr(getattr(self.process, producer_name+self.postfix), 'VS{}WP'.format(target), cuts)
 
 
     def getDpfTauVersion(self, file_name):

--- a/RecoTauTag/RecoTau/test/runDeepTauIDsOnMiniAOD.py
+++ b/RecoTauTag/RecoTau/test/runDeepTauIDsOnMiniAOD.py
@@ -22,8 +22,8 @@ process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase1_2018_realistic', '
 
 # Input source
 process.source = cms.Source('PoolSource', fileNames = cms.untracked.vstring(
-    # File from dataset DY1JetsToLL_M-50_TuneCP5_13TeV-madgraphMLM-pythia8
-    ' /store/mc/RunIIFall17MiniAODv2/TTToHadronic_TuneCP5_13TeV-powheg-pythia8/MINIAODSIM/PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/40000/A256C80D-0943-E811-998E-7CD30AB0522C.root'
+    # File from dataset TTToSemiLeptonic_TuneCP5_13TeV-powheg-pythia8
+    '/store/mc/RunIISummer20UL18MiniAOD/TTToSemiLeptonic_TuneCP5_13TeV-powheg-pythia8/MINIAODSIM/106X_upgrade2018_realistic_v11_L1v1-v2/00000/009636D7-07B2-DB49-882D-C251FD62CCE7.root'
 ))
 
 process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(eventsToProcess) )


### PR DESCRIPTION
#### PR description:

This PR updates a tool to run and then embed tauIDs to pat::Tau (RecoTauTag/RecoTau/python/tools/runTauIdMVA.py). The update enables possibility to run the tool for more than one pat::Tau collection in one job through specifying name of input collection and postix added to created modules and sequences. The new functionality does not affect any official workflows.

#### PR validation:

Unit and  (limited) matrix tests successful.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Backport of #33150 to be used on top on UL miniAOD.