### PR TITLE
return valid only finite pathLength in plane crossings algorithms in TrackingTools

### DIFF
--- a/RecoTracker/TkDetLayers/src/TECLayer.cc
+++ b/RecoTracker/TkDetLayers/src/TECLayer.cc
@@ -144,7 +144,7 @@ SubLayerCrossings TECLayer::computeCrossings(const TrajectoryStateOnSurface& sta
 
   pair<bool, double> frontPath = crossing.pathLength(*theFrontDisk);
   if (!frontPath.first)
-    SubLayerCrossings();
+    return SubLayerCrossings();
 
   GlobalPoint gFrontPoint(crossing.position(frontPath.second));
 
@@ -156,7 +156,7 @@ SubLayerCrossings TECLayer::computeCrossings(const TrajectoryStateOnSurface& sta
 
   pair<bool, double> backPath = crossing.pathLength(*theBackDisk);
   if (!backPath.first)
-    SubLayerCrossings();
+    return SubLayerCrossings();
 
   GlobalPoint gBackPoint(crossing.position(backPath.second));
   LogDebug("TkDetLayers") << "in TECLayer,back crossing point: r,z,phi: (" << gBackPoint.perp() << ","

--- a/TrackingTools/GeomPropagators/interface/HelixForwardPlaneCrossing.h
+++ b/TrackingTools/GeomPropagators/interface/HelixForwardPlaneCrossing.h
@@ -4,6 +4,7 @@
 #include "DataFormats/TrajectorySeed/interface/PropagationDirection.h"
 #include "TrackingTools/GeomPropagators/interface/HelixPlaneCrossing.h"
 #include "DataFormats/GeometrySurface/interface/Plane.h"
+#include "FWCore/Utilities/interface/isFinite.h"
 #include "FWCore/Utilities/interface/Likely.h"
 #include <limits>
 
@@ -28,14 +29,15 @@ public:
     //
     // Protect against p_z=0 and calculate path length
     //
-    if
-      UNLIKELY(std::abs(theCosTheta) < std::numeric_limits<float>::min()) return std::pair<bool, double>(false, 0);
+    if UNLIKELY (std::abs(theCosTheta) < std::numeric_limits<float>::min())
+      return std::pair<bool, double>(false, 0);
 
     double dS = (plane.position().z() - theZ0) / theCosTheta;
 
     // negative logic to avoid checking for anyDirection...
-    return std::make_pair(
-        !(((thePropDir == alongMomentum) & (dS < 0.)) | ((thePropDir == oppositeToMomentum) & (dS > 0.))), dS);
+    return std::make_pair(!(((thePropDir == alongMomentum) & (dS < 0.)) |
+                            ((thePropDir == oppositeToMomentum) & (dS > 0.)) | edm::isNotFinite(dS)),
+                          dS);
   }
 
   /** Position at pathlength s from the starting point.

--- a/TrackingTools/GeomPropagators/src/StraightLinePlaneCrossing.cc
+++ b/TrackingTools/GeomPropagators/src/StraightLinePlaneCrossing.cc
@@ -1,6 +1,7 @@
 #include "TrackingTools/GeomPropagators/interface/StraightLinePlaneCrossing.h"
 
 #include "DataFormats/GeometrySurface/interface/Plane.h"
+#include "FWCore/Utilities/interface/isFinite.h"
 
 //
 // Propagation status  and path length to intersection
@@ -14,8 +15,8 @@ std::pair<bool, double> StraightLinePlaneCrossing::pathLength(const Plane& plane
   auto pz = planeNormal.dot(theP0);
   auto dS = -planeNormal.dot(theX0 - planePosition) / pz;
   // check direction
-  auto opposite2Track =
-      ((thePropDir == alongMomentum) & (dS < 0.f)) | ((thePropDir == oppositeToMomentum) & (dS > 0.f));
+  auto opposite2Track = ((thePropDir == alongMomentum) & (dS < 0.f)) |
+                        ((thePropDir == oppositeToMomentum) & (dS > 0.f)) | edm::isNotFinite(dS);
   //
   // Return result
   //


### PR DESCRIPTION
- [first commit 5247666] properly return on failing crossing in `TECLayer::computeCrossings` 
    - a bug from 2007 https://github.com/cms-sw/cmssw/commit/8198b00b0e5f66def9d5fe8cba9c167c5901f713#diff-f972dac0360a5d1ded73517ea4daa1e9370257d7b5235d6a2619c69a6fdeeeb6R165
    - all differences in jenkins comparisons are from this commit
- [second commit 8a51ab2] add check for finite result in the return flag of `HelixForwardPlaneCrossing` and `StraightLinePlaneCrossing` (a check already exists in a more complex case in `HelixArbitraryPlaneCrossing2Order`, which is subsequently used in `HelixArbitraryPlaneCrossing`)
    - this specifically targets inifinite/NaN values observed in the issue reported in https://hypernews.cern.ch/HyperNews/CMS/get/recoDevelopment/1706.html
    - the first commit is still required though to exit properly on failed helix-plane crossing

@mtosi @vmariani 
please cross-check
