### PR TITLE
Update GTs with Ecal supercluster parameters [11_2_X]

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -2,13 +2,13 @@ autoCond = {
 
     ### NEW KEYS ###
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run1
-    'run1_design'       :   '112X_mcRun1_design_v1',
+    'run1_design'       :   '112X_mcRun1_design_v2',
     # GlobalTag for MC production (pp collisions) with realistic alignment and calibrations for Run1
-    'run1_mc'           :   '112X_mcRun1_realistic_v1',
+    'run1_mc'           :   '112X_mcRun1_realistic_v2',
     # GlobalTag for MC production (Heavy Ions collisions) with realistic alignment and calibrations for Run1
-    'run1_mc_hi'        :   '112X_mcRun1_HeavyIon_v1',
+    'run1_mc_hi'        :   '112X_mcRun1_HeavyIon_v2',
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run1
-    'run1_mc_pa'        :   '112X_mcRun1_pA_v2',
+    'run1_mc_pa'        :   '112X_mcRun1_pA_v3',
     # GlobalTag for MC production with pessimistic alignment and calibrations for Run2
     'run2_mc_50ns'      :   '112X_mcRun2_startup_v1',
     # GlobalTag for MC production (L1 Trigger Stage1) with starup-like alignment and calibrations for Run2, L1 trigger in Stage1 mode
@@ -40,14 +40,14 @@ autoCond = {
     # GlobalTag for Run2 HLT: it points to the online GT
     'run2_hlt'          :   '101X_dataRun2_HLT_frozen_v10',
     # GlobalTag for Run2 HLT RelVals: customizations to run with fixed L1 Menu
-    'run2_hlt_relval'      :   '112X_dataRun2_HLT_relval_v3',
-    'run2_hlt_relval_hi'   :   '112X_dataRun2_HLT_relval_HI_v2',
+    'run2_hlt_relval'      :   '112X_dataRun2_HLT_relval_v4',
+    'run2_hlt_relval_hi'   :   '112X_dataRun2_HLT_relval_HI_v3',
     # GlobalTag for Run2 HLT for HI (not 2018 HI): it points to the online GT
     'run2_hlt_hi'       :   '101X_dataRun2_HLTHI_frozen_v10',
     # GlobalTag for Run3 data relvals (express GT)
-    'run3_data_express'        :   '112X_dataRun3_Express_v2',
+    'run3_data_express'        :   '112X_dataRun3_Express_v3',
     # GlobalTag for Run3 data relvals
-    'run3_data_promptlike'     :   '112X_dataRun3_Prompt_v2',
+    'run3_data_promptlike'     :   '112X_dataRun3_Prompt_v3',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,~0-centred beamspot)
     'phase1_2017_design'       :  '112X_mc2017_design_v4',
     # GlobalTag for MC production with realistic conditions for Phase1 2017 detector
@@ -81,7 +81,7 @@ autoCond = {
     # GlobalTag for MC production with realistic conditions for Phase1 2024
     'phase1_2024_realistic'    : '112X_mcRun3_2024_realistic_v17', # GT containing realistic conditions for Phase1 2024
     # GlobalTag for MC production with realistic conditions for Phase2
-    'phase2_realistic'         : '112X_mcRun4_realistic_v6'
+    'phase2_realistic'         : '112X_mcRun4_realistic_v7'
 }
 
 aliases = {


### PR DESCRIPTION
#### PR description:
This PR is the backport of #33142 to add the Ecal supercluster parameters to run1_mc GTs, data GTs and run4_mc GTs.

The GT diffs are as follow:
**Run 1 design**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/112X_mcRun1_design_v1/112X_mcRun1_design_v2

**Run 1 realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/112X_mcRun1_realistic_v1/112X_mcRun1_realistic_v2

**Run 1 heavy ion**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/112X_mcRun1_HeavyIon_v1/112X_mcRun1_HeavyIon_v2

**Run 1 proton-heavy ion**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/112X_mcRun1_pA_v2/112X_mcRun1_pA_v3

**Run 2 HLT RelVals**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/112X_dataRun2_HLT_relval_v3/112X_dataRun2_HLT_relval_v4

**Run 2 HI HLT RelVals**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/112X_dataRun2_HLT_relval_HI_v2/112X_dataRun2_HLT_relval_HI_v3

**Run 3 data (express)**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/112X_dataRun3_Express_v2/112X_dataRun3_Express_v3

**Run 3 data (prompt)**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/112X_dataRun3_Prompt_v2/112X_dataRun3_Prompt_v3

**Phase 2 realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/112X_mcRun4_realistic_v6/112X_mcRun4_realistic_v7



#### PR validation:
A technical test was performed:
`runTheMatrix.py -l limited,138.1,138.2,140.0 --ibeos -j 9`

#### if this PR is a backport please specify the original PR and why you need to backport that PR:
This PR is the backport of #33142 
