### PR TITLE
Fix G4 logical volumes assignments to production cuts regions with DD4hep

### DIFF
--- a/SimG4Core/Geometry/src/DDG4ProductionCuts.cc
+++ b/SimG4Core/Geometry/src/DDG4ProductionCuts.cc
@@ -11,6 +11,7 @@
 #include "G4RegionStore.hh"
 #include "G4Region.hh"
 #include "G4LogicalVolume.hh"
+#include "G4LogicalVolumeStore.hh"
 
 #include <algorithm>
 

--- a/SimG4Core/Geometry/src/DDG4ProductionCuts.cc
+++ b/SimG4Core/Geometry/src/DDG4ProductionCuts.cc
@@ -141,7 +141,7 @@ void DDG4ProductionCuts::dd4hepInitialize() {
   for (auto const& it : dd4hepVec_) {
     auto regName = it.second->strValue(keywordRegion_);
     G4Region* region = G4RegionStore::GetInstance()->FindOrCreateRegion({regName.data(), regName.size()});
-    
+
     region->AddRootLogicalVolume(it.first);
     edm::LogVerbatim("Geometry") << it.first->GetName() << ": " << regName;
     edm::LogVerbatim("Geometry") << " MakeRegions: added " << it.first->GetName() << " to region " << region->GetName();
@@ -150,13 +150,15 @@ void DDG4ProductionCuts::dd4hepInitialize() {
     const G4String& nonReflectedG4Name = it.first->GetName();
     const G4String& reflectedG4Name = nonReflectedG4Name + "_refl";
     const G4LogicalVolumeStore* const allG4LogicalVolumes = G4LogicalVolumeStore::GetInstance();
-    const auto reflectedG4LogicalVolumeIt = std::find_if(allG4LogicalVolumes->begin(), allG4LogicalVolumes->end(), [&](const G4LogicalVolume* const aG4LogicalVolume) {
-	return (aG4LogicalVolume->GetName() == reflectedG4Name);
-      });
+    const auto reflectedG4LogicalVolumeIt = std::find_if(
+        allG4LogicalVolumes->begin(), allG4LogicalVolumes->end(), [&](const G4LogicalVolume* const aG4LogicalVolume) {
+          return (aG4LogicalVolume->GetName() == reflectedG4Name);
+        });
     // If G4 Logical volume has a reflected volume, add it to the region as well.
     if (reflectedG4LogicalVolumeIt != allG4LogicalVolumes->end()) {
       region->AddRootLogicalVolume(*reflectedG4LogicalVolumeIt);
-      edm::LogVerbatim("Geometry") << " MakeRegions: added " << (*reflectedG4LogicalVolumeIt)->GetName() << " to region " << region->GetName();
+      edm::LogVerbatim("Geometry") << " MakeRegions: added " << (*reflectedG4LogicalVolumeIt)->GetName()
+                                   << " to region " << region->GetName();
     }
 
     edm::LogVerbatim("Geometry").log([&](auto& log) {

--- a/SimG4Core/Geometry/src/DDG4ProductionCuts.cc
+++ b/SimG4Core/Geometry/src/DDG4ProductionCuts.cc
@@ -140,9 +140,24 @@ void DDG4ProductionCuts::dd4hepInitialize() {
   for (auto const& it : dd4hepVec_) {
     auto regName = it.second->strValue(keywordRegion_);
     G4Region* region = G4RegionStore::GetInstance()->FindOrCreateRegion({regName.data(), regName.size()});
+    
     region->AddRootLogicalVolume(it.first);
-    edm::LogVerbatim("Geometry") << it.first->GetName() << ": " << it.second->strValue(keywordRegion_);
+    edm::LogVerbatim("Geometry") << it.first->GetName() << ": " << regName;
     edm::LogVerbatim("Geometry") << " MakeRegions: added " << it.first->GetName() << " to region " << region->GetName();
+
+    // Also treat reflected volumes
+    const G4String& nonReflectedG4Name = it.first->GetName();
+    const G4String& reflectedG4Name = nonReflectedG4Name + "_refl";
+    const G4LogicalVolumeStore* const allG4LogicalVolumes = G4LogicalVolumeStore::GetInstance();
+    const auto reflectedG4LogicalVolumeIt = std::find_if(allG4LogicalVolumes->begin(), allG4LogicalVolumes->end(), [&](const G4LogicalVolume* const aG4LogicalVolume) {
+	return (aG4LogicalVolume->GetName() == reflectedG4Name);
+      });
+    // If G4 Logical volume has a reflected volume, add it to the region as well.
+    if (reflectedG4LogicalVolumeIt != allG4LogicalVolumes->end()) {
+      region->AddRootLogicalVolume(*reflectedG4LogicalVolumeIt);
+      edm::LogVerbatim("Geometry") << " MakeRegions: added " << (*reflectedG4LogicalVolumeIt)->GetName() << " to region " << region->GetName();
+    }
+
     edm::LogVerbatim("Geometry").log([&](auto& log) {
       for (auto const& sit : it.second->spars) {
         log << sit.first << " =  " << sit.second[0] << "\n";


### PR DESCRIPTION
Fix the remaining discrepancies in G4 logical volumes assignments to production cuts regions with DD4hep.
These discrepancies were stemming from reflected volumes.
Reflected volumes need to benefit from a special treatment in DD4hep.

This is now addressed, and together with https://github.com/cms-sw/cmssw/pull/33101:
**The production cuts assignments are not absolutely identical between DDD and DD4hep: 839 roots are assigned to production cuts regions.**

NB: I also had a branch where a container already containing the G4 reflected volumes is passed to the production cuts constructor. This complicates the interface though, and has absolutely no impact on perf (less than ~0.01 s in initialization loop), hence did not go for that option.

@civanch @cvuosalo @ianna 