### PR TITLE
Utilities/StaticAnalyzer: EventSetupRecord::get static check: Add calls to get made in non-member functions

### DIFF
--- a/Utilities/StaticAnalyzers/src/ESRecordGetChecker.h
+++ b/Utilities/StaticAnalyzers/src/ESRecordGetChecker.h
@@ -21,13 +21,18 @@
 namespace clangcms {
 
   class ESRGetChecker : public clang::ento::Checker<clang::ento::check::ASTDecl<clang::CXXMethodDecl>,
-                                                    clang::ento::check::ASTDecl<clang::FunctionTemplateDecl> > {
+                                                    clang::ento::check::ASTDecl<clang::FunctionTemplateDecl>,
+                                                    clang::ento::check::ASTDecl<clang::FunctionDecl> > {
   public:
     void checkASTDecl(const clang::CXXMethodDecl *CMD,
                       clang::ento::AnalysisManager &mgr,
                       clang::ento::BugReporter &BR) const;
 
     void checkASTDecl(const clang::FunctionTemplateDecl *TD,
+                      clang::ento::AnalysisManager &mgr,
+                      clang::ento::BugReporter &BR) const;
+
+    void checkASTDecl(const clang::FunctionDecl *CMD,
                       clang::ento::AnalysisManager &mgr,
                       clang::ento::BugReporter &BR) const;
 


### PR DESCRIPTION
This update the EventSetpupRecord::get static analyzer check to find calls to ::get in non member functions. 
Missing warnings found using clang-tidy checker that does the same thing.

