### PR TITLE
[UBSAN] Added missing deps to fix UBSAN build errors

### DIFF
--- a/DQM/DataScouting/BuildFile.xml
+++ b/DQM/DataScouting/BuildFile.xml
@@ -4,6 +4,7 @@
 <use name="FWCore/ParameterSet"/>
 <use name="DataFormats/Math"/>
 <use name="DQMServices/Core"/>
+<use name="DataFormats/JetReco"/>
 <export>
   <use name="FWCore/Framework"/>
   <use name="FWCore/ParameterSet"/>

--- a/GeneratorInterface/TauolaInterface/plugins/BuildFile.xml
+++ b/GeneratorInterface/TauolaInterface/plugins/BuildFile.xml
@@ -14,6 +14,7 @@
 </library>
 
 <library file="TauSpinner/*.cc" name="TauSpinnerInterface">
+  <use name="GeneratorInterface/TauolaInterface"/>
   <use name="FWCore/Framework"/>
   <use name="FWCore/ServiceRegistry"/>
   <use name="SimDataFormats/GeneratorProducts"/>


### PR DESCRIPTION
Added missing dependencies to fix UBSAN build errors [a]

[a]
```
TauSpinnerCMS.cc.o:(.data.rel+0x4c18): undefined reference to `typeinfo for reco::LeafCandidate'
AlphaTVarProducer.cc.o:(.data.rel+0xb58): undefined reference to `typeinfo for reco::LeafCandidate'
DiJetVarProducer.cc.o:(.data.rel+0x3ed8): undefined reference to `typeinfo for reco::LeafCandidate'
```