### PR TITLE
initialize variables to fix compiler warnings

### DIFF
--- a/CondTools/Ecal/src/EcalTPGWeightIdMapHandler.cc
+++ b/CondTools/Ecal/src/EcalTPGWeightIdMapHandler.cc
@@ -281,7 +281,7 @@ void popcon::EcalTPGWeightIdMapHandler::readxmlFile() {
   unsigned int wloc[5];
   EcalTPGWeights w;
   EcalTPGWeightIdMap* weightMap = new EcalTPGWeightIdMap;
-  int ngroups, igroups;
+  int ngroups, igroups = 0;
   edm::LogInfo("EcalTPGWeightIdMapHandler") << "found " << igroups << "Weight groups";
   for (int i = 0; i < 5; i++)
     std::getline(fxml, dummyLine);  // skip first lines

--- a/L1Trigger/TrackFindingTracklet/src/PurgeDuplicate.cc
+++ b/L1Trigger/TrackFindingTracklet/src/PurgeDuplicate.cc
@@ -241,7 +241,7 @@ void PurgeDuplicate::execute(std::vector<Track*>& outputtracks_) {
             int i = stubsTrk2[stcount].first;
             int reg = (i > 0 && i < 10) * (i - 1) + (i > 10) * (i - 5) - (i < 0) * i;
             double nres = getPhiRes(inputtracklets_[jtrk], fullStubslistsTrk2[stcount]);
-            double ores;
+            double ores = 0;
             if (URStubidsTrk2[reg] != -1)
               ores = getPhiRes(inputtracklets_[jtrk], fullStubslistsTrk2[URStubidsTrk2[reg]]);
             if (URStubidsTrk2[reg] == -1 || nres < ores) {


### PR DESCRIPTION
UBSAN and LLVM 11 build show new build warnings about uninitialized variables. This PR show fix those warnings.