### PR TITLE
small fixes to hltDiff

### DIFF
--- a/HLTrigger/Tools/bin/hltDiff.cc
+++ b/HLTrigger/Tools/bin/hltDiff.cc
@@ -1490,7 +1490,7 @@ public:
       std::cout << "\n" << std::endl;
     }
     // Printing the summary of affected triggers with affected-event counts
-    if (!quiet) {
+    if (!quiet and old_config) {
       bool summaryHeaderPrinted = false;
       for (size_t p = 0; p < old_config->size(); ++p) {
         if (differences.at(p).total() < 1)
@@ -1560,7 +1560,7 @@ usage: hltDiff -o|--old-files FILE1.ROOT [FILE2.ROOT ...] [-O|--old-process LABE
       safer if files are run for the first time, but can cause a substantial delay\n\
 \n\
   -d|--debug\n\
-      display messages about missing events and collectiions\n\
+      display messages about missing events and collections\n\
 \n\
   -q|--quiet\n\
       don't display summary printout with the list of affected trigger paths\n\

--- a/HLTrigger/Tools/bin/hltDiff.cc
+++ b/HLTrigger/Tools/bin/hltDiff.cc
@@ -747,47 +747,45 @@ public:
         // Writing the output to a JSON file
         std::string output_name = output_filename_base(run) += ".json";
         out_file.open(output_name, std::ofstream::out);
-        if(out_file.good()){
-        out_file << '{';  // line open
-        out_file << configuration.serialise(1) << ',';
-        out_file << vars.serialise(1) << ',';
-        // writing block for each event
-        out_file << indent(1) << key("events") << '[';  // line open
-        for (auto it = v_events.begin(); it != v_events.end(); ++it) {
-          out_file << (*it).serialise(2);
-          if (it != --v_events.end())
-            out_file << ',';
-        }
-        out_file << indent(1) << ']';  // line close
-        out_file << indent(0) << "}";  // line close
-        out_file.close();
-        // Adding file name to the list of created files
-        filesCreated.insert(output_name);
-        }
-        else
+        if (out_file.good()) {
+          out_file << '{';  // line open
+          out_file << configuration.serialise(1) << ',';
+          out_file << vars.serialise(1) << ',';
+          // writing block for each event
+          out_file << indent(1) << key("events") << '[';  // line open
+          for (auto it = v_events.begin(); it != v_events.end(); ++it) {
+            out_file << (*it).serialise(2);
+            if (it != --v_events.end())
+              out_file << ',';
+          }
+          out_file << indent(1) << ']';  // line close
+          out_file << indent(0) << "}";  // line close
+          out_file.close();
+          // Adding file name to the list of created files
+          filesCreated.insert(output_name);
+        } else
           filesNotCreated.insert(output_name);
       }
     } else {
       // Creating a single file containing with only configuration part
       std::string output_name = output_filename_base(0) += ".json";
       out_file.open(output_name, std::ofstream::out);
-      if(out_file.good()){
-      out_file << '{';  // line open
-      out_file << configuration.serialise(1) << ',';
-      out_file << vars.serialise(1) << ',';
-      // writing block for each event
-      out_file << indent(1) << key("events") << '[';  // line open
-      // for (std::vector<JsonEvent>::const_iterator it = v_events.begin(); it != v_events.end(); ++it) {
-      //   out_file << (*it).serialise(2);
-      //   if (it != --v_events.end()) out_file << ',';
-      // }
-      out_file << indent(1) << ']';  // line close
-      out_file << indent(0) << "}";  // line close
-      out_file.close();
-      // Adding file name to the list of created files
-      filesCreated.insert(output_name);
-      }
-      else
+      if (out_file.good()) {
+        out_file << '{';  // line open
+        out_file << configuration.serialise(1) << ',';
+        out_file << vars.serialise(1) << ',';
+        // writing block for each event
+        out_file << indent(1) << key("events") << '[';  // line open
+        // for (std::vector<JsonEvent>::const_iterator it = v_events.begin(); it != v_events.end(); ++it) {
+        //   out_file << (*it).serialise(2);
+        //   if (it != --v_events.end()) out_file << ',';
+        // }
+        out_file << indent(1) << ']';  // line close
+        out_file << indent(0) << "}";  // line close
+        out_file.close();
+        // Adding file name to the list of created files
+        filesCreated.insert(output_name);
+      } else
         filesNotCreated.insert(output_name);
     }
 
@@ -798,7 +796,8 @@ public:
     }
 
     if (!filesNotCreated.empty()) {
-      std::cout << "Failed to create the following JSON files (check output directory and its permissions):" << std::endl;
+      std::cout << "Failed to create the following JSON files (check output directory and its permissions):"
+                << std::endl;
       for (const std::string& filename : filesNotCreated)
         std::cout << " " << filename << std::endl;
     }
@@ -960,7 +959,7 @@ private:
     // Storing histograms to a ROOT file
     file_name = json.output_filename_base(this->run) += ".root";
     auto out_file = new TFile(file_name.c_str(), "RECREATE");
-    if(not out_file or out_file->IsZombie()){
+    if (not out_file or out_file->IsZombie()) {
       out_file->Close();
       return false;
     }
@@ -1111,26 +1110,26 @@ private:
     file_name = json.output_filename_base(this->run) += "_trigger.csv";
     FILE* out_file = fopen(file_name.c_str(), "w");
 
-    if(out_file){
-    fprintf(out_file,
-            "Total,Accepted OLD,Accepted NEW,Gained,Lost,|G|/A_N + "
-            "|L|/AO,sigma(AN)+sigma(AO),Changed,C/(T-AO),sigma(T-AO),trigger\n");
-    for (const auto& idSummary : m_triggerSummary) {
-      const SummaryOutputProducer::TriggerSummary& S = idSummary.second;
+    if (out_file) {
       fprintf(out_file,
-              "%d,%d,%d,%+.f,%+.f,%.2f%%,%.2f%%,~%.f,~%.2f%%,%.2f%%,%s\n",
-              this->json.configuration.events,
-              S.accepted_o,
-              S.accepted_n,
-              S.gained().v,
-              -1.0 * S.lost().v,
-              (S.gained(1).v + S.lost(1).v) * 100.0,
-              (S.gained(1).e + S.lost(1).e) * 100.0,
-              S.changed().v,
-              S.changed(1).v * 100.0,
-              S.changed(1).e * 100.0,
-              S.name.c_str());
-    }
+              "Total,Accepted OLD,Accepted NEW,Gained,Lost,|G|/A_N + "
+              "|L|/AO,sigma(AN)+sigma(AO),Changed,C/(T-AO),sigma(T-AO),trigger\n");
+      for (const auto& idSummary : m_triggerSummary) {
+        const SummaryOutputProducer::TriggerSummary& S = idSummary.second;
+        fprintf(out_file,
+                "%d,%d,%d,%+.f,%+.f,%.2f%%,%.2f%%,~%.f,~%.2f%%,%.2f%%,%s\n",
+                this->json.configuration.events,
+                S.accepted_o,
+                S.accepted_n,
+                S.gained().v,
+                -1.0 * S.lost().v,
+                (S.gained(1).v + S.lost(1).v) * 100.0,
+                (S.gained(1).e + S.lost(1).e) * 100.0,
+                S.changed().v,
+                S.changed(1).v * 100.0,
+                S.changed(1).e * 100.0,
+                S.name.c_str());
+      }
       fclose(out_file);
       ret = true;
     }
@@ -1144,18 +1143,18 @@ private:
     file_name = json.output_filename_base(this->run) += "_module.csv";
     FILE* out_file = fopen(file_name.c_str(), "w");
 
-    if(out_file){
-    fprintf(out_file, "Total,Gained,Lost,Changed,module\n");
-    for (const auto& idSummary : m_moduleSummary) {
-      const SummaryOutputProducer::GenericSummary& S = idSummary.second;
-      fprintf(out_file,
-              "%d,+%.f,-%.f,~%.f,%s\n",
-              this->json.configuration.events,
-              S.gained().v,
-              S.lost().v,
-              S.changed().v,
-              S.name.c_str());
-    }
+    if (out_file) {
+      fprintf(out_file, "Total,Gained,Lost,Changed,module\n");
+      for (const auto& idSummary : m_moduleSummary) {
+        const SummaryOutputProducer::GenericSummary& S = idSummary.second;
+        fprintf(out_file,
+                "%d,+%.f,-%.f,~%.f,%s\n",
+                this->json.configuration.events,
+                S.gained().v,
+                S.lost().v,
+                S.changed().v,
+                S.name.c_str());
+      }
       fclose(out_file);
       ret = true;
     }
@@ -1177,7 +1176,7 @@ public:
       for (const auto& runEvents : json.m_run_events) {
         prepareSummaries(runEvents.first, runEvents.second);
         if (storeROOT) {
-	  std::string fName;
+          std::string fName;
           auto& fNameVec = writeHistograms(fName) ? filesCreated : filesNotCreated;
           fNameVec.push_back(fName);
         }
@@ -1215,7 +1214,8 @@ public:
     }
 
     if (!filesNotCreated.empty()) {
-      std::cout << "Failed to create the following summary files (check output directory and its permissions):" << std::endl;
+      std::cout << "Failed to create the following summary files (check output directory and its permissions):"
+                << std::endl;
       for (const std::string& filename : filesNotCreated)
         std::cout << " " << filename << std::endl;
     }


### PR DESCRIPTION
#### PR description:

A few small fixes to `hltDiff`, to better handle incorrect command-line arguments:

* added a check on the content of `old_config` (otherwise, an invalid process name, via `-N` or `-O`, can lead to a seg-fault);

* improved checks on validity of output `.root`/`.csv`/`.json` files (if one specifies as output `-F foo/bar`, and the output folder `foo` does not exist already, the outputs will not be created; in such cases, the executable was giving a seg-fault (`csv` outputs), or erroneously stating that the output was created (`json` files)).

The final diff is rather confusing due to code-format; it might be easier to review these few commits individually.

#### PR validation:

Validated with private tests.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A