### PR TITLE
[DD4Hep] Use Placement instead of TGeoCombiTrans

### DIFF
--- a/Geometry/EcalCommonData/plugins/dd4hep/DDEcalBarrelNewAlgo.cc
+++ b/Geometry/EcalCommonData/plugins/dd4hep/DDEcalBarrelNewAlgo.cc
@@ -461,17 +461,6 @@ namespace {
         nam, t.dz(), t.theta(), t.phi(), t.h1(), t.bl1(), t.tl1(), t.alp1(), t.h2(), t.bl2(), t.tl2(), t.alp2());
   }
 
-  TGeoCombiTrans* createPlacement(const Rotation3D& iRot, const Position& iTrans) {
-    double elements[9];
-    iRot.GetComponents(elements);
-    TGeoRotation r;
-    r.SetMatrix(elements);
-
-    TGeoTranslation t(iTrans.x(), iTrans.y(), iTrans.z());
-
-    return new TGeoCombiTrans(t, r);
-  }
-
   string_view mynamespace(string_view input) {
     string_view v = input;
     auto trim_pos = v.find(':');
@@ -1453,7 +1442,7 @@ static long algorithm(dd4hep::Detector& /* description */, cms::DDParsingContext
                           vFAW[2] + Pt3D(2 * hawBoxClr, -5 * dd4hep::mm, 0),
                           vFAW[1] + Pt3D(-2 * hawBoxClr, -5 * dd4hep::mm, 0),
                           Pt3D(vFAW[1].x() - 2 * hawBoxClr, vFAW[1].y() - trapFAW.h(), vFAW[1].z() - zDel));
-    // FIXME: EFAW extruded by: EFAW/EHAWR_2 ovlp=0.209316 cm
+
     Solid fawSolid = SubtractionSolid(fawSolid1,
                                       fawCutBox,
                                       Transform3D(myrot(ns, fawCutName + "R", fawCutForm.getRotation()),
@@ -1488,13 +1477,11 @@ static long algorithm(dd4hep::Detector& /* description */, cms::DDParsingContext
                                 << cms::convert2mm(hawRform.getTranslation().z()) << ") with rotation";
 #endif
 
-    // FIXME: extrusion when using placeVolume,
-    // use TGeoCombiTrans instead
-    fawLog->AddNode(  //.placeVolume(
+    fawLog.placeVolume(
         hawRLog,
         copyTwo,
-        createPlacement(
-            Rotation3D(1., 0., 0., 0., 1., 0., 0., 0., -1.) * RotationY(-M_PI),  // rotate about Y after refl thru Z
+        Transform3D(
+            Rotation3D(1., 0., 0., 0., 1., 0., 0., 0., -1.) * RotationY(M_PI),  // rotate about Y after refl thru Z
             Position(-hawRform.getTranslation().x(), -hawRform.getTranslation().y(), -hawRform.getTranslation().z())));
 #ifdef EDM_ML_DEBUG
     edm::LogVerbatim("EBGeomX") << hawRLog.name() << ":" << copyTwo << " positioned in " << fawLog.name() << " at ("


### PR DESCRIPTION
#### PR description:

The PR should fix the sign discrepancy observed by @bsunanda in rotations

**DD**: 37 overlaps are displayed in `cm`
<img width="1135" alt="Screenshot 2021-03-15 at 11 10 57" src="https://user-images.githubusercontent.com/1390682/111139025-ea692700-8580-11eb-8df3-e15f108c56a2.png">
**DD4hep**: 36 identical overlaps displayed in `mm`
<img width="1134" alt="Screenshot 2021-03-15 at 11 11 15" src="https://user-images.githubusercontent.com/1390682/111139039-ed641780-8580-11eb-8333-ab124117234a.png">

Shapes:
**DD** (in `cm`):

```
*** Shape eregalgo:EBAR: TGeoPcon ***
    Nz    = 4
    phi1  =     0.00000
    dphi  =   360.00000
     plane 0: z= -304.50000 Rmin=  145.52200 Rmax=  177.50000
     plane 1: z= -268.67000 Rmin=  123.80000 Rmax=  177.50000
     plane 2: z=  268.67000 Rmin=  123.80000 Rmax=  177.50000
     plane 3: z=  304.50000 Rmin=  145.52200 Rmax=  177.50000
 Bounding box:
*** Shape eregalgo:EBAR: TGeoBBox ***
    dX =   177.50000
    dY =   177.50000
    dZ =   304.50000
    origin: x=    0.00000 y=    0.00000 z=    0.00000
*** TGeoCompositeShape : ebalgo:ESPM = 
 Bounding box:
*** Shape ebalgo:ESPM: TGeoBBox ***
    dX =    27.87442
    dY =    32.80927
    dZ =   152.20000
    origin: x=  148.02558 y=    0.75404 z=  152.20000
```

**DD4hep** (in `mm`):
```
*** Shape eregalgo:EBAR_shape_0x7f18b1503500: TGeoPcon ***
    Nz    = 4
    phi1  =     0.00000
    dphi  =   360.00000
     plane 0: z=-3045.00000 Rmin= 1455.22000 Rmax= 1775.00000
     plane 1: z=-2686.70000 Rmin= 1238.00000 Rmax= 1775.00000
     plane 2: z= 2686.70000 Rmin= 1238.00000 Rmax= 1775.00000
     plane 3: z= 3045.00000 Rmin= 1455.22000 Rmax= 1775.00000
 Bounding box:
*** Shape eregalgo:EBAR_shape_0x7f18b1503500: TGeoBBox ***
    dX =  1775.00000
    dY =  1775.00000
    dZ =  3045.00000
    origin: x=    0.00000 y=    0.00000 z=    0.00000
*** TGeoCompositeShape : ebalgo:ESPM_shape_0x7f18bbc17100 = Subtraction
 Bounding box:
*** Shape ebalgo:ESPM_shape_0x7f18bbc17100: TGeoBBox ***
    dX =   278.74416
    dY =   328.09266
    dZ =  1522.00000
    origin: x= 1480.25584 y=    7.54037 z= 1522.00000
```

Overlaps in DD and DD4hep at a prescission level:
<img width="1214" alt="Screenshot 2021-03-15 at 11 36 09" src="https://user-images.githubusercontent.com/1390682/111140567-c27ac300-8582-11eb-969a-6f82eb3ef2cd.png">

```
 = Overlap ov00036: eregalgo:EFAW extruded by: eregalgo:EFAW/eregalgo:EHAWR_2 ovlp=1.00141e-06
 - first volume: eregalgo:EFAW at position:
matrix Identity - tr=0  rot=0  refl=0  scl=0 shr=0 reg=1 own=0
  1.000000    0.000000    0.000000    Tx =   0.000000
  0.000000    1.000000    0.000000    Ty =   0.000000
  0.000000    0.000000    1.000000    Tz =   0.000000
*** TGeoCompositeShape : eregalgo:EFAW = 
 Bounding box:
*** Shape eregalgo:EFAW: TGeoBBox ***
    dX =     2.72562
    dY =    14.75000
    dZ =   152.20000
    origin: x=   -0.00000 y=    2.75000 z=    0.00000
 - second volume: eregalgo:EHAWR at position:
matrix  - tr=1  rot=1  refl=1  scl=0 shr=0 reg=0 own=0
 -1.000000    0.000000   -0.000000    Tx =  -1.210159
  0.000000    1.000000    0.000000    Ty =  -0.000000
 -0.000000   -0.000000    1.000000    Tz =  -0.000000
*** TGeoCompositeShape : eregalgo:EHAWR = 
 Bounding box:
*** Shape eregalgo:EHAWR: TGeoBBox ***
    dX =     1.36281
    dY =    14.75000
    dZ =   152.20000
    origin: x=    0.15265 y=    2.75000 z=    0.00000

```
#### PR validation:

<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

<!-- Please replace this text with any link to  -->

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
