### PR TITLE
Move FFTJet to JetMETCorrections/FFTJetObjects

### DIFF
--- a/JetMETCorrections/FFTJetModules/plugins/FFTJetSealModule.cc
+++ b/JetMETCorrections/FFTJetModules/plugins/FFTJetSealModule.cc
@@ -4,8 +4,7 @@
 #include "JetMETCorrections/FFTJetObjects/interface/FFTJetCorrectorSequenceRcdTypes.h"
 #include "JetMETCorrections/FFTJetObjects/interface/FFTJetLookupTableRcdTypes.h"
 #include "JetMETCorrections/FFTJetObjects/interface/FFTJetLookupTableSequence.h"
-
-#include "CondFormats/JetMETObjects/interface/FFTJet.h"
+#include "JetMETCorrections/FFTJetObjects/interface/FFTJet.h"
 
 REGISTER_PLUGIN(FFTBasicJetCorrectorSequenceRcd, FFTBasicJetCorrectorSequence);
 REGISTER_PLUGIN(FFTGenJetCorrectorSequenceRcd, FFTGenJetCorrectorSequence);

--- a/JetMETCorrections/FFTJetObjects/interface/FFTJet.h
+++ b/JetMETCorrections/FFTJetObjects/interface/FFTJet.h
@@ -1,5 +1,5 @@
-#ifndef CondFormats_JetMETObjects_FFTJET_H
-#define CondFormats_JetMETObjects_FFTJET_H
+#ifndef JetMETCorrections_FFTJetObjects_FFTJET_H
+#define JetMETCorrections_FFTJetObjects_FFTJET_H
 
 #include <boost/serialization/base_object.hpp>
 #include <boost/serialization/nvp.hpp>


### PR DESCRIPTION
Break part of the circular dependency between CondFormats/(DataRecord,JetMETObjects) and JetMETCorrections/FFTJetObjects. I believe this undoes part of the changes made in my previous (and apparently unsuccessful) attempt. This file appears to be unused..