### PR TITLE
MTD geometry/reconstruction: update tests, invert order of forward DetLayers

### DIFF
--- a/Geometry/MTDGeometryBuilder/test/MTDDigiGeometryAnalyzer.cc
+++ b/Geometry/MTDGeometryBuilder/test/MTDDigiGeometryAnalyzer.cc
@@ -13,9 +13,10 @@
 #include "Geometry/CommonTopologies/interface/PixelTopology.h"
 #include "Geometry/MTDGeometryBuilder/interface/MTDGeomDetType.h"
 #include "Geometry/MTDGeometryBuilder/interface/RectangularMTDTopology.h"
-#include "Geometry/Records/interface/MTDTopologyRcd.h"
-#include "Geometry/MTDNumberingBuilder/interface/MTDTopology.h"
 
+#include "DataFormats/ForwardDetId/interface/MTDDetId.h"
+#include "DataFormats/ForwardDetId/interface/BTLDetId.h"
+#include "DataFormats/ForwardDetId/interface/ETLDetId.h"
 #include "Geometry/MTDGeometryBuilder/interface/MTDGeomDetUnit.h"
 #include "DataFormats/GeometrySurface/interface/MediumProperties.h"
 #include "DataFormats/GeometrySurface/interface/RectangularPlaneBounds.h"
@@ -47,9 +48,6 @@ using cms_rounding::roundIfNear0, cms_rounding::roundVecIfNear0;
 
 // ------------ method called to produce the data  ------------
 void MTDDigiGeometryAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
-  edm::ESHandle<MTDTopology> mtdTopo;
-  iSetup.get<MTDTopologyRcd>().get(mtdTopo);
-
   //
   // get the MTDGeometry
   //
@@ -67,10 +65,22 @@ void MTDDigiGeometryAnalyzer::analyze(const edm::Event& iEvent, const edm::Event
   for (auto const& it : pDD->detUnits()) {
     if (dynamic_cast<const MTDGeomDetUnit*>((it)) != nullptr) {
       const BoundPlane& p = (dynamic_cast<const MTDGeomDetUnit*>((it)))->specificSurface();
+      const MTDDetId mtdId(it->geographicalId());
+      std::stringstream moduleLabel;
+      if (mtdId.mtdSubDetector() == 1) {
+        moduleLabel << " BTL side " << mtdId.mtdSide() << " Rod " << mtdId.mtdRR() << " mod "
+                    << (static_cast<const BTLDetId>(mtdId)).module();
+      } else if (mtdId.mtdSubDetector() == 2) {
+        const ETLDetId etlId(it->geographicalId());
+        moduleLabel << " ETL side " << mtdId.mtdSide() << " Disc/Side/Sector " << etlId.nDisc() << " "
+                    << etlId.discSide() << " " << etlId.sector();
+      } else {
+        edm::LogWarning("MTDDigiGeometryanalyzer") << (it->geographicalId()).rawId() << " unknown MTD subdetector!";
+      }
       edm::LogVerbatim("MTDDigiGeometryAnalyzer")
           << "---------------------------------------------------------- \n"
-          << mtdTopo->print(it->geographicalId()) << " RadLeng Pixel " << p.mediumProperties().radLen() << " Xi Pixel "
-          << p.mediumProperties().xi();
+          << it->geographicalId().rawId() << moduleLabel.str() << " RadLeng Pixel " << p.mediumProperties().radLen()
+          << " Xi Pixel " << p.mediumProperties().xi();
 
       const GeomDetUnit theDet = *(dynamic_cast<const MTDGeomDetUnit*>(it));
       analyseRectangle(theDet);

--- a/RecoMTD/DetLayers/plugins/ETLDetLayerGeometryBuilder.cc
+++ b/RecoMTD/DetLayers/plugins/ETLDetLayerGeometryBuilder.cc
@@ -66,7 +66,10 @@ pair<vector<DetLayer*>, vector<DetLayer*> > ETLDetLayerGeometryBuilder::buildLay
       }
     }
   }
-  pair<vector<DetLayer*>, vector<DetLayer*> > res_pair(result[0], result[1]);
+  //
+  // the first entry is Z+ ( MTD side 1), the second is Z- (MTD side 0)
+  //
+  pair<vector<DetLayer*>, vector<DetLayer*> > res_pair(result[1], result[0]);
   return res_pair;
 }
 

--- a/RecoMTD/DetLayers/test/MTDRecoGeometryAnalyzer.cc
+++ b/RecoMTD/DetLayers/test/MTDRecoGeometryAnalyzer.cc
@@ -86,6 +86,20 @@ void MTDRecoGeometryAnalyzer::analyze(const Event& ev, const EventSetup& es) {
     LogVerbatim("MTDLayerDump") << "  " << static_cast<int>(dl - geo->allETLLayers().begin()) << " " << dumpLayer(*dl);
   }
 
+  LogVerbatim("MTDLayerDump") << "\n*** allForwardLayers(): " << std::fixed << std::setw(14)
+                              << geo->allForwardLayers().size();
+  for (auto dl = geo->allForwardLayers().begin(); dl != geo->allForwardLayers().end(); ++dl) {
+    LogVerbatim("MTDLayerDump") << "  " << static_cast<int>(dl - geo->allForwardLayers().begin()) << " "
+                                << dumpLayer(*dl);
+  }
+
+  LogVerbatim("MTDLayerDump") << "\n*** allBackwardLayers(): " << std::fixed << std::setw(14)
+                              << geo->allBackwardLayers().size();
+  for (auto dl = geo->allBackwardLayers().begin(); dl != geo->allBackwardLayers().end(); ++dl) {
+    LogVerbatim("MTDLayerDump") << "  " << static_cast<int>(dl - geo->allBackwardLayers().begin()) << " "
+                                << dumpLayer(*dl);
+  }
+
   LogVerbatim("MTDLayerDump") << "\n*** allLayers(): " << std::fixed << std::setw(14) << geo->allLayers().size();
   for (auto dl = geo->allLayers().begin(); dl != geo->allLayers().end(); ++dl) {
     LogVerbatim("MTDLayerDump") << "  " << static_cast<int>(dl - geo->allLayers().begin()) << " " << dumpLayer(*dl);
@@ -108,6 +122,21 @@ void MTDRecoGeometryAnalyzer::testBTLLayers(const MTDDetLayerGeometry* geo, cons
     LogVerbatim("MTDLayerDump") << std::fixed << "\nBTL layer " << std::setw(4) << layer->subDetector()
                                 << " rods = " << std::setw(14) << layer->rods().size() << " dets = " << std::setw(14)
                                 << layer->basicComponents().size();
+
+    unsigned int irodInd(0);
+    for (const auto& irod : layer->rods()) {
+      irodInd++;
+      LogVerbatim("MTDLayerDump") << std::fixed << "\nRod " << irodInd << " dets = " << irod->basicComponents().size()
+                                  << "\n";
+      for (const auto& imod : irod->basicComponents()) {
+        BTLDetId modId(imod->geographicalId().rawId());
+        LogVerbatim("MTDLayerDump") << std::fixed << "BTLDetId " << modId.rawId() << " side = " << std::setw(4)
+                                    << modId.mtdSide() << " rod = " << modId.mtdRR() << " mod = " << std::setw(4)
+                                    << modId.module() << std::setw(14) << " R = " << imod->position().perp()
+                                    << std::setw(14) << " phi = " << imod->position().phi() << std::setw(14)
+                                    << " Z = " << imod->position().z();
+      }
+    }
 
     const BoundCylinder& cyl = layer->specificSurface();
 

--- a/RecoMTD/TrackExtender/plugins/TrackExtenderWithMTD.cc
+++ b/RecoMTD/TrackExtender/plugins/TrackExtenderWithMTD.cc
@@ -875,6 +875,14 @@ TransientTrackingRecHit::ConstRecHitContainer TrackExtenderWithMTDT<TrackCollect
 
     fillMatchingHits(ilay, tsos, traj, pmag2, pathlength0, hits, prop, bs, vtxTime, matchVertex, output, bestHit);
   }
+
+  // the ETL hits order must be from the innermost to the outermost
+
+  if (output.size() == 2) {
+    if (std::abs(output[0]->globalPosition().z()) > std::abs(output[1]->globalPosition().z())) {
+      std::reverse(output.begin(), output.end());
+    }
+  }
   return output;
 }
 


### PR DESCRIPTION
#### PR description:

This PR addresses an issue reported by @parbol while validating the rebase of the addition of MTD to tracker navigation. As a default the order of the forward DetLayers looks inverted compared to what expected as default ordering (from negative to positive). This PR simply swaps the order, ~~so far it should be irrelevant for the use of the MTD code inside the reconstruction~~, but matters when adding MTD to the layers navigation.

At present the layers order matters only in the selection of ETL hits and their use for track building inside the ```TrackExtenderWithMTD```, where it was not properly managed, as the code was developed in a single-ETL disc content. 
In order to 1) get the correct behaviour that 2) makes the algorithm independent on the input ordering, a corresponding update of the ETL hits search is made (please note that the track build code still needs an update to properly use the timing information of both disks if present, work to follow and be based on this PR).

At the same time geometry tests are updated, also in order to become independent from ```MTDTopology```, whose real usefulness is under scrutiny and will be likely dropped or seriously revised in next future. 

#### PR validation:

Code compiles and run, the local test shows a change in the ordering of DetLayers:

```
*** allBTLLayers():              1
  0  subdet = Phase2TimingBarrel Barrel = 1 Forward = 0  Cylinder of radius:     117.629585

*** allETLLayers():              4
  0  subdet = Phase2TimingEndcap Barrel = 0 Forward = 1  Disk at:    -303.154999
  1  subdet = Phase2TimingEndcap Barrel = 0 Forward = 1  Disk at:    -300.265015
  2  subdet = Phase2TimingEndcap Barrel = 0 Forward = 1  Disk at:     300.265015
  3  subdet = Phase2TimingEndcap Barrel = 0 Forward = 1  Disk at:     303.154999

*** allForwardLayers():              2
  0  subdet = Phase2TimingEndcap Barrel = 0 Forward = 1  Disk at:     300.265015
  1  subdet = Phase2TimingEndcap Barrel = 0 Forward = 1  Disk at:     303.154999

*** allBackwardLayers():              2
  0  subdet = Phase2TimingEndcap Barrel = 0 Forward = 1  Disk at:    -300.265015
  1  subdet = Phase2TimingEndcap Barrel = 0 Forward = 1  Disk at:    -303.154999

*** allLayers():              5
  0  subdet = Phase2TimingEndcap Barrel = 0 Forward = 1  Disk at:    -303.154999
  1  subdet = Phase2TimingEndcap Barrel = 0 Forward = 1  Disk at:    -300.265015
  2  subdet = Phase2TimingBarrel Barrel = 1 Forward = 0  Cylinder of radius:     117.629585
  3  subdet = Phase2TimingEndcap Barrel = 0 Forward = 1  Disk at:     300.265015
  4  subdet = Phase2TimingEndcap Barrel = 0 Forward = 1  Disk at:     303.154999

```