### PR TITLE
Remove ESProducers for ECAL Mustache parameters from configuration

### DIFF
--- a/RecoEcal/EgammaClusterProducers/python/particleFlowSuperClusterECAL_cfi.py
+++ b/RecoEcal/EgammaClusterProducers/python/particleFlowSuperClusterECAL_cfi.py
@@ -2,11 +2,6 @@ import FWCore.ParameterSet.Config as cms
 
 from RecoEcal.EgammaClusterProducers.particleFlowSuperClusterECALMustache_cfi import particleFlowSuperClusterECALMustache as _particleFlowSuperClusterECALMustache
 
-# create the EcalMustacheSCParameters record on the fly
-from RecoEcal.EgammaCoreTools.EcalMustacheSCParametersESProducer_cff import *
-# create the EcalSCDynamicDPhiParameters record on the fly
-from RecoEcal.EgammaCoreTools.EcalSCDynamicDPhiParametersESProducer_cff import *
-
 # define the default ECAL clustering (Mustache or Box)
 particleFlowSuperClusterECAL = _particleFlowSuperClusterECALMustache.clone()
 


### PR DESCRIPTION
#### PR description:

Since the records should now be provided with the GT this PR removes the ESSource and ESProducers for EcalMustacheSCParameters and EcalSCDynamicDPhiParameters from the default configuration.

#### PR validation:

Passes the limited matrix tests.