### PR TITLE
[RFC] Possible fixes for HGCalGeomRotation

### DIFF
--- a/Geometry/HGCalCommonData/src/HGCalGeomRotation.cc
+++ b/Geometry/HGCalCommonData/src/HGCalGeomRotation.cc
@@ -37,7 +37,7 @@ void HGCalGeomRotation::uvMappingFrom60DegreeSector0(WaferCentring waferCentring
     edm::LogError("HGCalGeomRotation")
         << "HGCalGeomRotation: 60 degree sector defintion selected, but not WaferCentred centring. This is "
            "incompatible, switching to WaferCentred centring";
-    waferCentring = WaferCentring::WaferCentred;
+    //    waferCentring = WaferCentring::WaferCentred;
   }
 
   if (sector > 5) {
@@ -126,14 +126,15 @@ unsigned HGCalGeomRotation::uvMappingTo60DegreeSector0(WaferCentring waferCentri
     edm::LogError("HGCalGeomRotation")
         << "HGCalGeomRotation: 60 degree sector defintion selected, but not WaferCentred centring. This is "
            "incompatible, switching to WaferCentred centring";
-    waferCentring = WaferCentring::WaferCentred;
+    //    waferCentring = WaferCentring::WaferCentred;
   }
 
   if (moduleU > 0 && moduleV >= 0) {
     if (moduleV <= moduleU) {
       return sector;
-    } else {
-      sector = 1;
+      // This is going to be overwritten below, i.e. sector will never be "1"
+      //    } else {
+      //      sector = 1;
     }
   }
   if (moduleU >= moduleV && moduleV < 0) {


### PR DESCRIPTION
#### PR description:

I hit some dead assignment reports from the newly merged HGCal silicon module rotation class, see #32684 

Those dead assignments could be easily removed, by removing the corresponding lines of dead code

Before doing so, I would like to check with the author of #32684 , @snwebb, whether those dead lines were just slipped in, or maybe if they witness some logical error in the code instead. For example:
- `sector` as set at [L137](https://github.com/cms-sw/cmssw/pull/33190/files#diff-4c6e8d4ad292197cb415977ad32373f43b902ff5696bdb7e628c74d976a4aa61R137) can never remain = 1: is this what you intended
- before [L40](https://github.com/cms-sw/cmssw/pull/33190/files#diff-4c6e8d4ad292197cb415977ad32373f43b902ff5696bdb7e628c74d976a4aa61R40) and [L129](https://github.com/cms-sw/cmssw/pull/33190/files#diff-4c6e8d4ad292197cb415977ad32373f43b902ff5696bdb7e628c74d976a4aa61R129) you write in the Log messages that you are "switching to WaferCentred centring": but since `waferCentring` is not passed to the method by reference it cannot happen: was this intended? (In that case, at least the Log messages should be fixed...)

#### PR validation:

Code builds (well, up to now only a few lines have been commented out)

