### PR TITLE
Fix logical error in HGCal module rotation class

### DIFF
--- a/Geometry/HGCalCommonData/src/HGCalGeomRotation.cc
+++ b/Geometry/HGCalCommonData/src/HGCalGeomRotation.cc
@@ -134,8 +134,7 @@ unsigned HGCalGeomRotation::uvMappingTo60DegreeSector0(WaferCentring waferCentri
     } else {
       sector = 1;
     }
-  }
-  else if (moduleU >= moduleV && moduleV < 0) {
+  } else if (moduleU >= moduleV && moduleV < 0) {
     if (moduleU >= 0) {
       sector = 5;
     } else {

--- a/Geometry/HGCalCommonData/src/HGCalGeomRotation.cc
+++ b/Geometry/HGCalCommonData/src/HGCalGeomRotation.cc
@@ -36,8 +36,7 @@ void HGCalGeomRotation::uvMappingFrom60DegreeSector0(WaferCentring waferCentring
   if (waferCentring != WaferCentring::WaferCentred) {
     edm::LogError("HGCalGeomRotation")
         << "HGCalGeomRotation: 60 degree sector defintion selected, but not WaferCentred centring. This is "
-           "incompatible, switching to WaferCentred centring";
-    waferCentring = WaferCentring::WaferCentred;
+           "incompatible, assuming WaferCentred centring";
   }
 
   if (sector > 5) {
@@ -125,7 +124,7 @@ unsigned HGCalGeomRotation::uvMappingTo60DegreeSector0(WaferCentring waferCentri
   if (waferCentring != WaferCentring::WaferCentred) {
     edm::LogError("HGCalGeomRotation")
         << "HGCalGeomRotation: 60 degree sector defintion selected, but not WaferCentred centring. This is "
-           "incompatible, switching to WaferCentred centring";
+           "incompatible, assuming WaferCentred centring";
     waferCentring = WaferCentring::WaferCentred;
   }
 
@@ -136,7 +135,7 @@ unsigned HGCalGeomRotation::uvMappingTo60DegreeSector0(WaferCentring waferCentri
       sector = 1;
     }
   }
-  if (moduleU >= moduleV && moduleV < 0) {
+  else if (moduleU >= moduleV && moduleV < 0) {
     if (moduleU >= 0) {
       sector = 5;
     } else {

--- a/Geometry/HGCalCommonData/src/HGCalGeomRotation.cc
+++ b/Geometry/HGCalCommonData/src/HGCalGeomRotation.cc
@@ -125,7 +125,6 @@ unsigned HGCalGeomRotation::uvMappingTo60DegreeSector0(WaferCentring waferCentri
     edm::LogError("HGCalGeomRotation")
         << "HGCalGeomRotation: 60 degree sector defintion selected, but not WaferCentred centring. This is "
            "incompatible, assuming WaferCentred centring";
-    waferCentring = WaferCentring::WaferCentred;
   }
 
   if (moduleU > 0 && moduleV >= 0) {


### PR DESCRIPTION
#### PR description:

Logical error found in `if` clause (see #33190 from @perrotta for report) in the module rotation class`HGCalGeomRotation`. This is fixed and additionally a logging message has been made clearer.

#### PR validation:

Code-checks and format applied successfully (this is a very small change).
