### PR TITLE
Fix on the indexing of VFATs in GEM onlineDQM, backport to CMSSW_11_2_X

### DIFF
--- a/DQM/GEM/interface/GEMDQMBase.h
+++ b/DQM/GEM/interface/GEMDQMBase.h
@@ -446,7 +446,7 @@ inline int GEMDQMBase::getVFATNumberGE11(const int station, const int ieta, cons
 }
 
 inline int GEMDQMBase::getVFATNumberByStrip(const int station, const int ieta, const int strip) {
-  const int vfat_phi = (strip % GEMeMap::maxChan_) ? strip / GEMeMap::maxChan_ + 1 : strip / GEMeMap::maxChan_;
+  const int vfat_phi = (strip % GEMeMap::maxChan_) ? strip / GEMeMap::maxChan_ : strip / GEMeMap::maxChan_ - 1;
   return getVFATNumber(station, ieta, vfat_phi);
 }
 

--- a/DQM/GEM/plugins/GEMDAQStatusSource.cc
+++ b/DQM/GEM/plugins/GEMDAQStatusSource.cc
@@ -393,7 +393,7 @@ void GEMDAQStatusSource::analyze(edm::Event const &event, edm::EventSetup const 
         mapChamberStatus[key4Ch] = false;
       }
 
-      Int_t nIdxVFAT = getVFATNumber(gid.station(), gid.roll(), vfatStat->phi() + 1);
+      Int_t nIdxVFAT = getVFATNumber(gid.station(), gid.roll(), vfatStat->phi());
       mapStatusVFAT_.FillBits(key3, nIdxVFAT, unQFVFAT);
       mapStatusVFATPerCh_.FillBits(key4Ch, nIdxVFAT, unQFVFAT);
     }

--- a/DQM/GEM/plugins/GEMDigiSource.cc
+++ b/DQM/GEM/plugins/GEMDigiSource.cc
@@ -16,6 +16,8 @@
 
 #include "DataFormats/GEMDigi/interface/GEMDigiCollection.h"
 
+#include "DataFormats/Scalers/interface/LumiScalers.h"
+
 #include "DQM/GEM/interface/GEMDQMBase.h"
 
 #include <string>
@@ -39,6 +41,8 @@ private:
 
   edm::EDGetToken tagDigi_;
 
+  edm::EDGetTokenT<LumiScalersCollection> lumiScalers_;
+
   MEMap3Inf mapTotalDigi_layer_;
   MEMap3Inf mapStripOcc_ieta_;
   MEMap3Inf mapStripOcc_phi_;
@@ -58,6 +62,8 @@ using namespace edm;
 
 GEMDigiSource::GEMDigiSource(const edm::ParameterSet& cfg) : GEMDQMBase(cfg) {
   tagDigi_ = consumes<GEMDigiCollection>(cfg.getParameter<edm::InputTag>("digisInputLabel"));
+  lumiScalers_ = consumes<LumiScalersCollection>(
+      cfg.getUntrackedParameter<edm::InputTag>("lumiCollection", edm::InputTag("scalersRawToDigi")));
 }
 
 void GEMDigiSource::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
@@ -161,6 +167,9 @@ int GEMDigiSource::ProcessWithMEMap3WithChamber(BookingHelper& bh, ME4IdsKey key
 void GEMDigiSource::analyze(edm::Event const& event, edm::EventSetup const& eventSetup) {
   edm::Handle<GEMDigiCollection> gemDigis;
   event.getByToken(this->tagDigi_, gemDigis);
+  edm::Handle<LumiScalersCollection> lumiScalers;
+  event.getByToken(lumiScalers_, lumiScalers);
+
   std::map<ME3IdsKey, Int_t> total_strip_layer;
   for (const auto& ch : gemChambers_) {
     GEMDetId gid = ch.id();


### PR DESCRIPTION
#### PR description:
We modified the structure of GEM onlineDQM in the last time (#32791, #32792), and this is a fix for an issue on the indexing of VFATs. No fix on DQM GUI is necessary for this.

This is for the backport to CMSSW_11_2_X.

#### PR validation:
Test are done and one can check again by `runTheMatrix` workflows

@jshlee @watson-ij @hyunyong 