### PR TITLE
Enable CMS custom clang-tidy checks 

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,6 +1,8 @@
 ---
 Checks: -*,
   ,boost-use-to-string,
+  ,cms-handle,
+  ,cms-esrget,
   ,misc-string-compare,
   ,misc-uniqueptr-reset-release,
   ,modernize-deprecated-headers,


### PR DESCRIPTION
Enables two CMS custom clang-tidy checks

EventSetupRecord::get called 
Event::getByToken called

Requires LLVM/Clang 11.x