### PR TITLE
DAQ: input source update and new output module for tests (11_3_X)

### DIFF
--- a/EventFilter/Utilities/interface/FastMonitoringService.h
+++ b/EventFilter/Utilities/interface/FastMonitoringService.h
@@ -80,7 +80,7 @@ namespace evf {
       MCOUNT
     };
 
-    enum InputState {
+    enum InputState : short {
       inIgnore = 0,
       inInit,
       inWaitInput,

--- a/EventFilter/Utilities/interface/FedRawDataInputSource.h
+++ b/EventFilter/Utilities/interface/FedRawDataInputSource.h
@@ -35,7 +35,7 @@ namespace evf {
   namespace FastMonState {
     enum InputState : short;
   }
-}
+}  // namespace evf
 
 class FedRawDataInputSource : public edm::RawInputSource {
   friend struct InputFile;

--- a/EventFilter/Utilities/interface/FedRawDataInputSource.h
+++ b/EventFilter/Utilities/interface/FedRawDataInputSource.h
@@ -32,6 +32,9 @@ struct InputChunk;
 
 namespace evf {
   class FastMonitoringService;
+  namespace FastMonState {
+    enum InputState : short;
+  }
 }
 
 class FedRawDataInputSource : public edm::RawInputSource {
@@ -48,6 +51,8 @@ public:
 protected:
   Next checkNext() override;
   void read(edm::EventPrincipal& eventPrincipal) override;
+  void setMonState(evf::FastMonState::InputState state);
+  void setMonStateSup(evf::FastMonState::InputState state);
 
 private:
   void rewind_() override;

--- a/EventFilter/Utilities/plugins/FRDOutputModule.cc
+++ b/EventFilter/Utilities/plugins/FRDOutputModule.cc
@@ -29,22 +29,18 @@ FRDOutputModule::FRDOutputModule(edm::ParameterSet const& ps)
       frdVersion_(ps.getUntrackedParameter<unsigned int>("frdVersion")),
       frdFileVersion_(ps.getUntrackedParameter<unsigned int>("frdFileVersion")),
       filePrefix_(ps.getUntrackedParameter<std::string>("filePrefix")),
-      fileName_(ps.getUntrackedParameter<std::string>("fileName"))
-      {}
+      fileName_(ps.getUntrackedParameter<std::string>("fileName")) {}
 
 FRDOutputModule::~FRDOutputModule() {}
-
 
 void FRDOutputModule::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
   desc.add<edm::InputTag>("source", edm::InputTag("rawDataCollector"));
-  desc.addUntracked<unsigned int>("frdFileVersion", 1),
-  desc.addUntracked<unsigned int>("frdVersion", 6);
+  desc.addUntracked<unsigned int>("frdFileVersion", 1), desc.addUntracked<unsigned int>("frdVersion", 6);
   desc.addUntracked<std::string>("filePrefix", "");
   desc.addUntracked<std::string>("fileName", "");
   descriptions.addWithDefaultLabel(desc);
 }
-
 
 void FRDOutputModule::write(edm::EventForOutput const& e) {
   // serialize the FEDRawDataCollection into the format that we expect for
@@ -135,27 +131,26 @@ void FRDOutputModule::write(edm::EventForOutput const& e) {
 }
 
 void FRDOutputModule::beginLuminosityBlock(edm::LuminosityBlockForOutput const& lumiBlock) {
-
   int ls = lumiBlock.id().luminosityBlock();
 
   if (outfd_ != -1)
     finishFileWrite(ls);
 
   if (fileWritten_)
-    throw cms::Exception("RawEventFileWriterForBU", "beginLuminosityBlock") << "Multiple lumisections not supported in the same FRD file!";
-
+    throw cms::Exception("RawEventFileWriterForBU", "beginLuminosityBlock")
+        << "Multiple lumisections not supported in the same FRD file!";
 
   std::string fileName;
   if (fileName_.empty()) {
     std::stringstream ss;
-    ss << (filePrefix_.empty() ? "" : filePrefix_ + "_") << "run" <<  std::setfill('0') << std::setw(6) << lumiBlock.run() << "_ls" << std::setfill('0') << std::setw(4) << ls << "_index000000.raw";
+    ss << (filePrefix_.empty() ? "" : filePrefix_ + "_") << "run" << std::setfill('0') << std::setw(6)
+       << lumiBlock.run() << "_ls" << std::setfill('0') << std::setw(4) << ls << "_index000000.raw";
     fileName = ss.str();
-  }
-  else {
+  } else {
     //use exact filename (will be overwritten by last LS content if input contains multiple lumisections)
     fileName = fileName_;
   }
- 
+
   outfd_ = open(fileName.c_str(), O_WRONLY | O_CREAT, S_IRWXU | S_IRWXG | S_IRWXO);
   ftruncate(outfd_, 0);
 
@@ -186,7 +181,6 @@ void FRDOutputModule::endLuminosityBlock(edm::LuminosityBlockForOutput const& lu
 }
 
 void FRDOutputModule::finishFileWrite(int ls) {
-
   if (outfd_ == -1)
     return;
 
@@ -200,8 +194,7 @@ void FRDOutputModule::finishFileWrite(int ls) {
   close(outfd_);
   outfd_ = -1;
   if (!fileName_.empty())
-      fileWritten_ = true;
+    fileWritten_ = true;
 
   edm::LogInfo("FRDOutputModule") << "closed RAW input file";
 }
-

--- a/EventFilter/Utilities/plugins/FRDOutputModule.cc
+++ b/EventFilter/Utilities/plugins/FRDOutputModule.cc
@@ -1,0 +1,202 @@
+#include "EventFilter/Utilities/plugins/FRDOutputModule.h"
+
+// system headers
+#include <unistd.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+
+// C++ headers
+#include <cstdio>
+#include <fstream>
+#include <memory>
+#include <vector>
+
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/Utilities/interface/EDGetToken.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/Utilities/interface/Adler32Calculator.h"
+#include "DataFormats/Common/interface/Handle.h"
+#include "DataFormats/FEDRawData/interface/FEDNumbering.h"
+#include "IOPool/Streamer/interface/FRDEventMessage.h"
+#include "IOPool/Streamer/interface/FRDFileHeader.h"
+#include "EventFilter/Utilities/interface/crc32c.h"
+
+FRDOutputModule::FRDOutputModule(edm::ParameterSet const& ps)
+    : edm::one::OutputModuleBase::OutputModuleBase(ps),
+      edm::one::OutputModule<edm::one::WatchLuminosityBlocks>(ps),
+      token_(consumes<FEDRawDataCollection>(ps.getParameter<edm::InputTag>("source"))),
+      frdVersion_(ps.getParameter<unsigned int>("frdVersion")),
+      frdFileVersion_(ps.getParameter<unsigned int>("frdFileVersion")),
+      filePrefix_(ps.getParameter<std::string>("filePrefix")),
+      fileName_(ps.getParameter<std::string>("fileName"))
+      {}
+
+FRDOutputModule::~FRDOutputModule() {}
+
+
+void FRDOutputModule::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.add<edm::InputTag>("source", edm::InputTag("rawDataCollector"));
+  desc.add<unsigned int>("numEventsPerFile", 100);
+  desc.add<unsigned int>("frdFileVersion",1),
+  desc.add<unsigned int>("frdVersion", 6);
+  desc.add<std::string>("filePrefix","rawdata");
+  desc.add<std::string>("fileName","");
+  descriptions.addWithDefaultLabel(desc);
+}
+
+
+void FRDOutputModule::write(edm::EventForOutput const& e) {
+  // serialize the FEDRawDataCollection into the format that we expect for
+  // FRDEventMsgView objects (may be better ways to do this)
+  edm::Handle<FEDRawDataCollection> fedBuffers;
+  e.getByToken(token_, fedBuffers);
+
+  // determine the expected size of the FRDEvent IN BYTES !!!!!
+  assert(frdVersion_ <= FRDHeaderMaxVersion);
+  int headerSize = FRDHeaderVersionSize[frdVersion_];
+  int expectedSize = headerSize;
+  int nFeds = frdVersion_ < 3 ? 1024 : FEDNumbering::lastFEDId() + 1;
+
+  for (int idx = 0; idx < nFeds; ++idx) {
+    FEDRawData singleFED = fedBuffers->FEDData(idx);
+    expectedSize += singleFED.size();
+  }
+
+  // build the FRDEvent into a temporary buffer
+  std::unique_ptr<std::vector<unsigned char>> workBuffer(
+      std::make_unique<std::vector<unsigned char>>(expectedSize + 256));
+  uint32* bufPtr = (uint32*)(workBuffer.get()->data());
+  if (frdVersion_ <= 5) {
+    *bufPtr++ = (uint32)frdVersion_;  // version number only
+  } else {
+    uint16 flags = 0;
+    if (!e.eventAuxiliary().isRealData())
+      flags |= FRDEVENT_MASK_ISGENDATA;
+    *(uint16*)bufPtr = (uint16)(frdVersion_ & 0xffff);
+    *((uint16*)bufPtr + 1) = flags;
+    bufPtr++;
+  }
+  *bufPtr++ = (uint32)e.id().run();
+  *bufPtr++ = (uint32)e.luminosityBlock();
+  *bufPtr++ = (uint32)e.id().event();
+  if (frdVersion_ == 4)
+    *bufPtr++ = 0;  //64-bit event id high part
+
+  if (frdVersion_ < 3) {
+    uint32 fedsize[1024];
+    for (int idx = 0; idx < 1024; ++idx) {
+      FEDRawData singleFED = fedBuffers->FEDData(idx);
+      fedsize[idx] = singleFED.size();
+      //std::cout << "fed size " << singleFED.size()<< std::endl;
+    }
+    memcpy(bufPtr, fedsize, 1024 * sizeof(uint32));
+    bufPtr += 1024;
+  } else {
+    *bufPtr++ = expectedSize - headerSize;
+    *bufPtr++ = 0;
+    if (frdVersion_ <= 4)
+      *bufPtr++ = 0;
+  }
+  uint32* payloadPtr = bufPtr;
+  for (int idx = 0; idx < nFeds; ++idx) {
+    FEDRawData singleFED = fedBuffers->FEDData(idx);
+    if (singleFED.size() > 0) {
+      memcpy(bufPtr, singleFED.data(), singleFED.size());
+      bufPtr += singleFED.size() / 4;
+    }
+  }
+  if (frdVersion_ > 4) {
+    //crc32c checksum
+    uint32_t crc = 0;
+    *(payloadPtr - 1) = crc32c(crc, (const unsigned char*)payloadPtr, expectedSize - headerSize);
+  } else if (frdVersion_ >= 3) {
+    //adler32 checksum
+    uint32 adlera = 1;
+    uint32 adlerb = 0;
+    cms::Adler32((const char*)payloadPtr, expectedSize - headerSize, adlera, adlerb);
+    *(payloadPtr - 1) = (adlerb << 16) | adlera;
+  }
+
+  // create the FRDEventMsgView and use the template consumer to write it out
+  FRDEventMsgView msg(workBuffer.get()->data());
+
+  //write
+  ssize_t retval = ::write(outfd_, (void*)msg.startAddress(), msg.size());
+
+  if ((unsigned)retval != msg.size()) {
+    throw cms::Exception("FRDOutputModule", "write")
+        << "Error writing FED Raw Data event data to " << fileName_ << ".  Possibly the output disk "
+        << "is full?" << std::endl;
+  }
+
+  perFileEventCount_++;
+  perFileSize_ += msg.size();
+}
+
+void FRDOutputModule::beginLuminosityBlock(edm::LuminosityBlockForOutput const& lumiBlock) {
+
+  int ls = lumiBlock.id().luminosityBlock();
+
+  if (outfd_ != -1)
+    finishFileWrite(ls);
+
+  std::string fileName;
+  if (fileName_.empty()) {
+    std::stringstream ss;
+    ss << filePrefix_ << "_ls" << std::setfill('0') << std::setw(4) << ls << ".raw";
+    fileName = ss.str();
+  }
+  else {
+    //use exact filename (will be overwritten by last LS content if input contains multiple lumisections)
+    fileName = fileName_;
+  }
+ 
+  outfd_ = open(fileName.c_str(), O_WRONLY | O_CREAT, S_IRWXU | S_IRWXG | S_IRWXO);
+  ftruncate(outfd_, 0);
+
+  if (outfd_ < 0) {  //attention here... it may happen that outfd_ is *not* set (e.g. missing initialize call...)
+    throw cms::Exception("RawEventFileWriterForBU", "beginLuminosityBlock")
+        << "Error opening FED Raw Data event output file: " << fileName << ": " << strerror(errno) << "\n";
+  }
+  edm::LogInfo("RawEventFileWriterForBU") << " Opened " << fileName;
+
+  perFileEventCount_ = 0;
+  perFileSize_ = 0;
+
+  adlera_ = 1;
+  adlerb_ = 0;
+
+  if (frdFileVersion_ > 0) {
+    assert(frdFileVersion_ == 1);
+    //reserve space for file header
+    ftruncate(outfd_, sizeof(FRDFileHeader_v1));
+    lseek(outfd_, sizeof(FRDFileHeader_v1), SEEK_SET);
+    perFileSize_ = sizeof(FRDFileHeader_v1);
+  }
+}
+
+void FRDOutputModule::endLuminosityBlock(edm::LuminosityBlockForOutput const& lumiBlock) {
+  int ls = lumiBlock.id().luminosityBlock();
+  finishFileWrite(ls);
+}
+
+void FRDOutputModule::finishFileWrite(int ls) {
+
+  if (outfd_ == -1)
+    return;
+
+  if (frdFileVersion_ > 0) {
+    //rewind
+    lseek(outfd_, 0, SEEK_SET);
+    FRDFileHeader_v1 frdFileHeader(perFileEventCount_, (uint32_t)ls, perFileSize_);
+    ::write(outfd_, (char*)&frdFileHeader, sizeof(FRDFileHeader_v1));
+  }
+
+  close(outfd_);
+  outfd_ = -1;
+
+  edm::LogInfo("FRDOutputModule") << "closed RAW input file";
+}
+

--- a/EventFilter/Utilities/plugins/FRDOutputModule.h
+++ b/EventFilter/Utilities/plugins/FRDOutputModule.h
@@ -47,6 +47,8 @@ private:
   uint32_t perFileEventCount_;
   uint64_t perFileSize_;
 
+  bool fileWritten_ = false;
+
 
 };
 

--- a/EventFilter/Utilities/plugins/FRDOutputModule.h
+++ b/EventFilter/Utilities/plugins/FRDOutputModule.h
@@ -13,7 +13,6 @@
 //#include "FWCore/ServiceRegistry/interface/ModuleCallingContext.h"
 
 class FRDOutputModule : public edm::one::OutputModule<edm::one::WatchLuminosityBlocks> {
-
 public:
   explicit FRDOutputModule(edm::ParameterSet const& ps);
   ~FRDOutputModule() override;
@@ -48,9 +47,6 @@ private:
   uint64_t perFileSize_;
 
   bool fileWritten_ = false;
-
-
 };
 
 #endif  // IOPool_Streamer_interface_FRDOutputModule_h
-

--- a/EventFilter/Utilities/plugins/FRDOutputModule.h
+++ b/EventFilter/Utilities/plugins/FRDOutputModule.h
@@ -1,0 +1,54 @@
+#ifndef IOPool_Streamer_interface_FRDOutputModule_h
+#define IOPool_Streamer_interface_FRDOutputModule_h
+
+// CMSSW headers
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+
+//#include "DataFormats/FEDRawData/interface/FEDRawData.h"
+#include "DataFormats/FEDRawData/interface/FEDRawDataCollection.h"
+#include "FWCore/Framework/interface/EventForOutput.h"
+#include "FWCore/Framework/interface/LuminosityBlockForOutput.h"
+#include "FWCore/Framework/interface/one/OutputModule.h"
+//#include "FWCore/ServiceRegistry/interface/ModuleCallingContext.h"
+
+class FRDOutputModule : public edm::one::OutputModule<edm::one::WatchLuminosityBlocks> {
+
+public:
+  explicit FRDOutputModule(edm::ParameterSet const& ps);
+  ~FRDOutputModule() override;
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+private:
+  void write(edm::EventForOutput const& e) override;
+  //void beginRun(edm::RunForOutput const&) override {}
+  //void endRun(edm::RunForOutput const&) override {}
+  void writeRun(const edm::RunForOutput&) override {}
+  void writeLuminosityBlock(const edm::LuminosityBlockForOutput&) override {}
+
+  void beginLuminosityBlock(edm::LuminosityBlockForOutput const&) override;
+  void endLuminosityBlock(edm::LuminosityBlockForOutput const&) override;
+
+  void finishFileWrite(int ls);
+  uint32_t adler32() const { return (adlerb_ << 16) | adlera_; }
+
+  const edm::EDGetTokenT<FEDRawDataCollection> token_;
+
+  const uint32_t frdVersion_;
+  const uint32_t frdFileVersion_;
+  std::string filePrefix_;
+  std::string fileName_;
+
+  int outfd_ = -1;
+  uint32_t adlera_;
+  uint32_t adlerb_;
+
+  uint32_t perFileEventCount_;
+  uint64_t perFileSize_;
+
+
+};
+
+#endif  // IOPool_Streamer_interface_FRDOutputModule_h
+

--- a/EventFilter/Utilities/plugins/RawEventFileWriterForBU.h
+++ b/EventFilter/Utilities/plugins/RawEventFileWriterForBU.h
@@ -32,7 +32,6 @@ public:
   void stop();
   void initialize(std::string const& destinationDir, std::string const& name, int ls);
   void endOfLS(int ls);
-  bool sharedMode() const { return false; }
   void makeRunPrefix(std::string const& destinationDir);
 
   static void extendDescription(edm::ParameterSetDescription& desc);

--- a/EventFilter/Utilities/plugins/RawEventOutputModuleForBU.h
+++ b/EventFilter/Utilities/plugins/RawEventOutputModuleForBU.h
@@ -159,8 +159,7 @@ void RawEventOutputModuleForBU<Consumer>::write(edm::EventForOutput const& e) {
   FRDEventMsgView msg(workBuffer.get()->data());
   writtensize += msg.size();
 
-  if (!templateConsumer_->sharedMode())
-    templateConsumer_->doOutputEvent(msg);
+  templateConsumer_->doOutputEvent(msg);
 }
 
 template <class Consumer>

--- a/EventFilter/Utilities/plugins/modules.cc
+++ b/EventFilter/Utilities/plugins/modules.cc
@@ -8,6 +8,7 @@
 #include "EventFilter/Utilities/plugins/ExceptionGenerator.h"
 #include "EventFilter/Utilities/plugins/RawEventFileWriterForBU.h"
 #include "EventFilter/Utilities/plugins/RawEventOutputModuleForBU.h"
+#include "EventFilter/Utilities/plugins/FRDOutputModule.h"
 #include "EventFilter/Utilities/plugins/RecoEventOutputModuleForFU.h"
 #include "EventFilter/Utilities/plugins/RecoEventWriterForFU.h"
 #include "FWCore/Framework/interface/InputSourceMacros.h"
@@ -22,6 +23,7 @@ DEFINE_FWK_SERVICE_MAKER(FastMonitoringService, FastMonitoringServiceMaker);
 
 typedef RawEventOutputModuleForBU<RawEventFileWriterForBU> RawStreamFileWriterForBU;
 DEFINE_FWK_MODULE(RawStreamFileWriterForBU);
+DEFINE_FWK_MODULE(FRDOutputModule);
 
 // legacy name for ConfDB compatibility
 typedef RecoEventOutputModuleForFU<RecoEventWriterForFU> ShmStreamConsumer;

--- a/EventFilter/Utilities/src/EvFDaqDirector.cc
+++ b/EventFilter/Utilities/src/EvFDaqDirector.cc
@@ -241,8 +241,14 @@ namespace evf {
                 << " Error creating bu run dir -: " << hltdir << " mkdir error:" << strerror(errno) << "\n";
 
           std::filesystem::copy_file(hltSourceDirectory_ + "/HltConfig.py", tmphltdir + "/HltConfig.py");
-
           std::filesystem::copy_file(hltSourceDirectory_ + "/fffParameters.jsn", tmphltdir + "/fffParameters.jsn");
+
+          std::string optfiles[3] = { "hltinfo", "blacklist", "whitelist" };
+          for (auto& optfile: optfiles) {
+            try {
+              std::filesystem::copy_file(hltSourceDirectory_ + "/" + optfile, tmphltdir + "/" + optfile);
+            } catch(...) {}
+          }
 
           std::filesystem::rename(tmphltdir, hltdir);
         } else

--- a/EventFilter/Utilities/src/EvFDaqDirector.cc
+++ b/EventFilter/Utilities/src/EvFDaqDirector.cc
@@ -243,11 +243,12 @@ namespace evf {
           std::filesystem::copy_file(hltSourceDirectory_ + "/HltConfig.py", tmphltdir + "/HltConfig.py");
           std::filesystem::copy_file(hltSourceDirectory_ + "/fffParameters.jsn", tmphltdir + "/fffParameters.jsn");
 
-          std::string optfiles[3] = { "hltinfo", "blacklist", "whitelist" };
-          for (auto& optfile: optfiles) {
+          std::string optfiles[3] = {"hltinfo", "blacklist", "whitelist"};
+          for (auto& optfile : optfiles) {
             try {
               std::filesystem::copy_file(hltSourceDirectory_ + "/" + optfile, tmphltdir + "/" + optfile);
-            } catch(...) {}
+            } catch (...) {
+            }
           }
 
           std::filesystem::rename(tmphltdir, hltdir);

--- a/EventFilter/Utilities/src/EvFOutputModule.cc
+++ b/EventFilter/Utilities/src/EvFOutputModule.cc
@@ -142,7 +142,7 @@ namespace evf {
     EvFOutputModuleType::fillDescription(desc);
     desc.addUntracked<edm::InputTag>("psetMap", {"hltPSetMap"})
         ->setComment("Optionally allow the map of ParameterSets to be calculated externally.");
-    descriptions.addDefault(desc);
+    descriptions.add("evfOutputModule", desc);
   }
 
   void EvFOutputModule::beginRun(edm::RunForOutput const& run) {

--- a/EventFilter/Utilities/src/FedRawDataInputSource.cc
+++ b/EventFilter/Utilities/src/FedRawDataInputSource.cc
@@ -561,7 +561,7 @@ inline evf::EvFDaqDirector::FileStatus FedRawDataInputSource::getNextEvent() {
         //rewind to header start position
         currentFile_->rewindChunk(FRDHeaderVersionSize[detectedFRDversion_]);
         //copy event to a chunk start and move pointers
-        
+
         setMonState(inWaitChunk);
 
         chunkEnd = currentFile_->advance(dataPosition, FRDHeaderVersionSize[detectedFRDversion_] + msgSize);
@@ -1354,9 +1354,7 @@ inline void FedRawDataInputSource::setMonStateSup(evf::FastMonState::InputState 
 inline bool InputFile::advance(unsigned char*& dataPosition, const size_t size) {
   //wait for chunk
 
-
   while (!waitForChunk(currentChunk_)) {
-
     parent_->setMonState(inWaitChunk);
     usleep(100000);
     parent_->setMonState(inChunkReceived);

--- a/EventFilter/Utilities/src/FedRawDataInputSource.cc
+++ b/EventFilter/Utilities/src/FedRawDataInputSource.cc
@@ -49,6 +49,8 @@
 
 #include <boost/lexical_cast.hpp>
 
+using namespace evf::FastMonState;
+
 FedRawDataInputSource::FedRawDataInputSource(edm::ParameterSet const& pset, edm::InputSourceDescription const& desc)
     : edm::RawInputSource(pset, desc),
       defPath_(pset.getUntrackedParameter<std::string>("buDefPath", "")),
@@ -146,8 +148,8 @@ FedRawDataInputSource::FedRawDataInputSource(edm::ParameterSet const& pset, edm:
   if (fms_) {
     daqDirector_->setFMS(fms_);
     fms_->setInputSource(this);
-    fms_->setInState(evf::FastMonState::inInit);
-    fms_->setInStateSup(evf::FastMonState::inInit);
+    fms_->setInState(inInit);
+    fms_->setInStateSup(inInit);
   }
   //should delete chunks when run stops
   for (unsigned int i = 0; i < numBuffers_; i++) {
@@ -239,8 +241,7 @@ edm::RawInputSource::Next FedRawDataInputSource::checkNext() {
   //signal hltd to start event accounting
   if (!currentLumiSection_)
     daqDirector_->createProcessingNotificationMaybe();
-  if (fms_)
-    fms_->setInState(evf::FastMonState::inWaitInput);
+  setMonState(inWaitInput);
   switch (nextEvent()) {
     case evf::EvFDaqDirector::runEnded: {
       //maybe create EoL file in working directory before ending run
@@ -354,8 +355,7 @@ inline evf::EvFDaqDirector::FileStatus FedRawDataInputSource::getNextEvent() {
     threadError();
   if (!currentFile_.get()) {
     evf::EvFDaqDirector::FileStatus status = evf::EvFDaqDirector::noFile;
-    if (fms_)
-      fms_->setInState(evf::FastMonState::inWaitInput);
+    setMonState(inWaitInput);
     if (!fileQueue_.try_pop(currentFile_)) {
       //sleep until wakeup (only in single-buffer mode) or timeout
       std::unique_lock<std::mutex> lkw(mWakeup_);
@@ -364,16 +364,14 @@ inline evf::EvFDaqDirector::FileStatus FedRawDataInputSource::getNextEvent() {
     }
     status = currentFile_->status_;
     if (status == evf::EvFDaqDirector::runEnded) {
-      if (fms_)
-        fms_->setInState(evf::FastMonState::inRunEnd);
+      setMonState(inRunEnd);
       currentFile_.reset();
       return status;
     } else if (status == evf::EvFDaqDirector::runAbort) {
       throw cms::Exception("FedRawDataInputSource::getNextEvent")
           << "Run has been aborted by the input source reader thread";
     } else if (status == evf::EvFDaqDirector::newLumi) {
-      if (fms_)
-        fms_->setInState(evf::FastMonState::inNewLumi);
+      setMonState(inNewLumi);
       if (getLSFromFilename_) {
         if (currentFile_->lumi_ > currentLumiSection_) {
           reportEventsThisLumiInSource(currentLumiSection_, eventsThisLumi_);
@@ -390,8 +388,7 @@ inline evf::EvFDaqDirector::FileStatus FedRawDataInputSource::getNextEvent() {
     } else
       assert(false);
   }
-  if (fms_)
-    fms_->setInState(evf::FastMonState::inProcessingFile);
+  setMonState(inProcessingFile);
 
   //file is empty
   if (!currentFile_->fileSize_) {
@@ -465,15 +462,13 @@ inline evf::EvFDaqDirector::FileStatus FedRawDataInputSource::getNextEvent() {
   }
   if (singleBufferMode_) {
     //should already be there
-    if (fms_)
-      fms_->setInState(evf::FastMonState::inWaitChunk);
+    setMonState(inWaitChunk);
     while (!currentFile_->waitForChunk(currentFile_->currentChunk_)) {
       usleep(10000);
       if (currentFile_->parent_->exceptionState() || setExceptionState_)
         currentFile_->parent_->threadError();
     }
-    if (fms_)
-      fms_->setInState(evf::FastMonState::inChunkReceived);
+    setMonState(inChunkReceived);
 
     unsigned char* dataPosition = currentFile_->chunks_[0]->buf_ + currentFile_->chunkPosition_;
 
@@ -526,15 +521,13 @@ inline evf::EvFDaqDirector::FileStatus FedRawDataInputSource::getNextEvent() {
   //multibuffer mode:
   else {
     //wait for the current chunk to become added to the vector
-    if (fms_)
-      fms_->setInState(evf::FastMonState::inWaitChunk);
+    setMonState(inWaitChunk);
     while (!currentFile_->waitForChunk(currentFile_->currentChunk_)) {
       usleep(10000);
       if (setExceptionState_)
         threadError();
     }
-    if (fms_)
-      fms_->setInState(evf::FastMonState::inChunkReceived);
+    setMonState(inChunkReceived);
 
     //check if header is at the boundary of two chunks
     chunkIsFree_ = false;
@@ -568,7 +561,13 @@ inline evf::EvFDaqDirector::FileStatus FedRawDataInputSource::getNextEvent() {
         //rewind to header start position
         currentFile_->rewindChunk(FRDHeaderVersionSize[detectedFRDversion_]);
         //copy event to a chunk start and move pointers
+        
+        setMonState(inWaitChunk);
+
         chunkEnd = currentFile_->advance(dataPosition, FRDHeaderVersionSize[detectedFRDversion_] + msgSize);
+
+        setMonState(inChunkReceived);
+
         assert(chunkEnd);
         chunkIsFree_ = true;
         //header is moved
@@ -581,8 +580,7 @@ inline evf::EvFDaqDirector::FileStatus FedRawDataInputSource::getNextEvent() {
       }
     }
   }  //end multibuffer mode
-  if (fms_)
-    fms_->setInState(evf::FastMonState::inChecksumEvent);
+  setMonState(inChecksumEvent);
 
   if (verifyChecksum_ && event_->version() >= 5) {
     uint32_t crc = 0;
@@ -606,8 +604,7 @@ inline evf::EvFDaqDirector::FileStatus FedRawDataInputSource::getNextEvent() {
           << adler;
     }
   }
-  if (fms_)
-    fms_->setInState(evf::FastMonState::inCachedEvent);
+  setMonState(inCachedEvent);
 
   currentFile_->nProcessed_++;
 
@@ -615,8 +612,7 @@ inline evf::EvFDaqDirector::FileStatus FedRawDataInputSource::getNextEvent() {
 }
 
 void FedRawDataInputSource::read(edm::EventPrincipal& eventPrincipal) {
-  if (fms_)
-    fms_->setInState(evf::FastMonState::inReadEvent);
+  setMonState(inReadEvent);
   std::unique_ptr<FEDRawDataCollection> rawData(new FEDRawDataCollection);
   edm::Timestamp tstamp = fillFEDRawDataCollection(*rawData);
 
@@ -654,8 +650,7 @@ void FedRawDataInputSource::read(edm::EventPrincipal& eventPrincipal) {
   eventPrincipal.put(daqProvenanceHelper_.branchDescription(), std::move(edp), daqProvenanceHelper_.dummyProvenance());
 
   eventsThisLumi_++;
-  if (fms_)
-    fms_->setInState(evf::FastMonState::inReadCleanup);
+  setMonState(inReadCleanup);
 
   //resize vector if needed
   while (streamFileTracker_.size() <= eventPrincipal.streamID())
@@ -686,8 +681,7 @@ void FedRawDataInputSource::read(edm::EventPrincipal& eventPrincipal) {
   if (chunkIsFree_)
     freeChunks_.push(currentFile_->chunks_[currentFile_->currentChunk_ - 1]);
   chunkIsFree_ = false;
-  if (fms_)
-    fms_->setInState(evf::FastMonState::inNoRequest);
+  setMonState(inNoRequest);
   return;
 }
 
@@ -777,17 +771,17 @@ void FedRawDataInputSource::readSupervisor() {
           if (j)
             copy_active = true;
         if (readingFilesCount_ >= maxBufferedFiles_)
-          fms_->setInStateSup(evf::FastMonState::inSupFileLimit);
+          setMonStateSup(inSupFileLimit);
         else if (freeChunks_.empty()) {
           if (copy_active)
-            fms_->setInStateSup(evf::FastMonState::inSupWaitFreeChunkCopying);
+            setMonStateSup(inSupWaitFreeChunkCopying);
           else
-            fms_->setInStateSup(evf::FastMonState::inSupWaitFreeChunk);
+            setMonStateSup(inSupWaitFreeChunk);
         } else {
           if (copy_active)
-            fms_->setInStateSup(evf::FastMonState::inSupWaitFreeThreadCopying);
+            setMonStateSup(inSupWaitFreeThreadCopying);
           else
-            fms_->setInStateSup(evf::FastMonState::inSupWaitFreeThread);
+            setMonStateSup(inSupWaitFreeThread);
         }
       }
       std::unique_lock<std::mutex> lkw(mWakeup_);
@@ -815,9 +809,9 @@ void FedRawDataInputSource::readSupervisor() {
     int64_t fileSizeFromMetadata;
 
     if (fms_) {
-      fms_->setInStateSup(evf::FastMonState::inSupBusy);
+      setMonStateSup(inSupBusy);
       fms_->startedLookingForFile();
-      fms_->setInStateSup(evf::FastMonState::inSupLockPolling);
+      setMonStateSup(inSupLockPolling);
     }
 
     evf::EvFDaqDirector::FileStatus status = evf::EvFDaqDirector::noFile;
@@ -872,8 +866,7 @@ void FedRawDataInputSource::readSupervisor() {
                                                      thisLockWaitTimeUs);
       }
 
-      if (fms_)
-        fms_->setInStateSup(evf::FastMonState::inSupBusy);
+      setMonStateSup(inSupBusy);
 
       //cycle through all remaining LS even if no files get assigned
       if (currentLumiSection != ls && status == evf::EvFDaqDirector::runEnded)
@@ -894,8 +887,7 @@ void FedRawDataInputSource::readSupervisor() {
 
       //check again for any remaining index/EoLS files after EoR file is seen
       if (status == evf::EvFDaqDirector::runEnded && !fileListMode_ && !useFileBroker_) {
-        if (fms_)
-          fms_->setInStateSup(evf::FastMonState::inRunEnd);
+        setMonStateSup(inRunEnd);
         usleep(100000);
         //now all files should have appeared in ramdisk, check again if any raw files were left behind
         status = daqDirector_->updateFuLock(
@@ -923,7 +915,7 @@ void FedRawDataInputSource::readSupervisor() {
         if (ls > currentLumiSection) {
           if (!useFileBroker_) {
             //file locking
-            //fms_->setInStateSup(evf::FastMonState::inSupNewLumi);
+            //setMonStateSup(inSupNewLumi);
             currentLumiSection = ls;
             std::unique_ptr<InputFile> inf(new InputFile(evf::EvFDaqDirector::newLumi, currentLumiSection));
             fileQueue_.push(std::move(inf));
@@ -970,8 +962,7 @@ void FedRawDataInputSource::readSupervisor() {
 
       int dbgcount = 0;
       if (status == evf::EvFDaqDirector::noFile) {
-        if (fms_)
-          fms_->setInStateSup(evf::FastMonState::inSupNoFile);
+        setMonStateSup(inSupNoFile);
         dbgcount++;
         if (!(dbgcount % 20))
           LogDebug("FedRawDataInputSource") << "No file for me... sleep and try again...";
@@ -989,8 +980,7 @@ void FedRawDataInputSource::readSupervisor() {
     }
     //end of file grab loop, parse result
     if (status == evf::EvFDaqDirector::newFile) {
-      if (fms_)
-        fms_->setInStateSup(evf::FastMonState::inSupNewFile);
+      setMonStateSup(inSupNewFile);
       LogDebug("FedRawDataInputSource") << "The director says to grab -: " << nextFile;
 
       std::string rawFile;
@@ -1012,9 +1002,9 @@ void FedRawDataInputSource::readSupervisor() {
       uint64_t fileSize = st.st_size;
 
       if (fms_) {
-        fms_->setInStateSup(evf::FastMonState::inSupBusy);
+        setMonStateSup(inSupBusy);
         fms_->stoppedLookingForFile(ls);
-        fms_->setInStateSup(evf::FastMonState::inSupNewFile);
+        setMonStateSup(inSupNewFile);
       }
       int eventsInNewFile;
       if (fileListMode_) {
@@ -1069,9 +1059,9 @@ void FedRawDataInputSource::readSupervisor() {
               if (j)
                 copy_active = true;
             if (copy_active)
-              fms_->setInStateSup(evf::FastMonState::inSupNewFileWaitThreadCopying);
+              setMonStateSup(inSupNewFileWaitThreadCopying);
             else
-              fms_->setInStateSup(evf::FastMonState::inSupNewFileWaitThread);
+              setMonStateSup(inSupNewFileWaitThread);
           }
           //get thread
           unsigned int newTid = 0xffffffff;
@@ -1089,9 +1079,9 @@ void FedRawDataInputSource::readSupervisor() {
               if (j)
                 copy_active = true;
             if (copy_active)
-              fms_->setInStateSup(evf::FastMonState::inSupNewFileWaitChunkCopying);
+              setMonStateSup(inSupNewFileWaitChunkCopying);
             else
-              fms_->setInStateSup(evf::FastMonState::inSupNewFileWaitChunk);
+              setMonStateSup(inSupNewFileWaitChunk);
           }
           InputChunk* newChunk = nullptr;
           while (!freeChunks_.try_pop(newChunk)) {
@@ -1111,8 +1101,7 @@ void FedRawDataInputSource::readSupervisor() {
           }
           if (stop)
             break;
-          if (fms_)
-            fms_->setInStateSup(evf::FastMonState::inSupNewFile);
+          setMonStateSup(inSupNewFile);
 
           std::unique_lock<std::mutex> lk(mReader_);
 
@@ -1186,8 +1175,7 @@ void FedRawDataInputSource::readSupervisor() {
       }
     }
   }
-  if (fms_)
-    fms_->setInStateSup(evf::FastMonState::inRunEnd);
+  setMonStateSup(inRunEnd);
   //make sure threads finish reading
   unsigned numFinishedThreads = 0;
   while (numFinishedThreads < workerThreads_.size()) {
@@ -1353,10 +1341,25 @@ void FedRawDataInputSource::threadError() {
   throw cms::Exception("FedRawDataInputSource:threadError") << " file reader thread error ";
 }
 
+inline void FedRawDataInputSource::setMonState(evf::FastMonState::InputState state) {
+  if (fms_)
+    fms_->setInState(state);
+}
+
+inline void FedRawDataInputSource::setMonStateSup(evf::FastMonState::InputState state) {
+  if (fms_)
+    fms_->setInStateSup(state);
+}
+
 inline bool InputFile::advance(unsigned char*& dataPosition, const size_t size) {
   //wait for chunk
+
+
   while (!waitForChunk(currentChunk_)) {
+
+    parent_->setMonState(inWaitChunk);
     usleep(100000);
+    parent_->setMonState(inChunkReceived);
     if (parent_->exceptionState())
       parent_->threadError();
   }
@@ -1367,7 +1370,9 @@ inline bool InputFile::advance(unsigned char*& dataPosition, const size_t size) 
   if (currentLeft < size) {
     //we need next chunk
     while (!waitForChunk(currentChunk_ + 1)) {
+      parent_->setMonState(inWaitChunk);
       usleep(100000);
+      parent_->setMonState(inChunkReceived);
       if (parent_->exceptionState())
         parent_->threadError();
     }

--- a/EventFilter/Utilities/test/frdOutput.py
+++ b/EventFilter/Utilities/test/frdOutput.py
@@ -1,0 +1,74 @@
+import FWCore.ParameterSet.Config as cms
+import FWCore.ParameterSet.VarParsing as VarParsing
+import os
+import math
+
+
+options = VarParsing.VarParsing ('analysis')
+
+options.register ('runNumber',
+                  100, # default value
+                  VarParsing.VarParsing.multiplicity.singleton,
+                  VarParsing.VarParsing.varType.int,          # string, int, or float
+                  "Run Number")
+
+options.register ('eventsPerLS',
+                  105,
+                  VarParsing.VarParsing.multiplicity.singleton,
+                  VarParsing.VarParsing.varType.int,          # string, int, or float
+                  "Max LS to generate (0 to disable limit)")
+
+options.register ('fedMeanSize',
+                  1024,
+                  VarParsing.VarParsing.multiplicity.singleton,
+                  VarParsing.VarParsing.varType.int,          # string, int, or float
+                  "Mean size of generated (fake) FED raw payload")
+
+options.register ('frdFileVersion',
+                  1,
+                  VarParsing.VarParsing.multiplicity.singleton,
+                  VarParsing.VarParsing.varType.int,          # string, int, or float
+                  "Generate raw files with FRD file header with version 1 or separate JSON files with 0")
+
+
+
+options.parseArguments()
+
+process = cms.Process("RRDOUTPUT")
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(options.eventsPerLS)
+)
+
+process.MessageLogger = cms.Service("MessageLogger",
+    cout = cms.untracked.PSet(threshold = cms.untracked.string( "INFO" )),
+    destinations = cms.untracked.vstring( 'cout' )
+)
+
+process.source = cms.Source("EmptySource",
+     firstRun= cms.untracked.uint32(options.runNumber),
+     numberEventsInLuminosityBlock = cms.untracked.uint32(options.eventsPerLS),
+     numberEventsInRun       = cms.untracked.uint32(0)
+)
+
+process.a = cms.EDAnalyzer("ExceptionGenerator",
+    defaultAction = cms.untracked.int32(0),
+    defaultQualifier = cms.untracked.int32(0))
+
+process.s = cms.EDProducer("DaqFakeReader",
+                           meanSize = cms.untracked.uint32(options.fedMeanSize),
+                           width = cms.untracked.uint32(int(math.ceil(options.fedMeanSize/2.))),
+                           tcdsFEDID = cms.untracked.uint32(1024),
+                           injectErrPpm = cms.untracked.uint32(0)
+                           )
+
+process.out = cms.OutputModule("FRDOutputModule",
+    source = cms.InputTag("s"),
+    frdVersion = cms.untracked.uint32(6),
+    frdFileVersion = cms.untracked.uint32(options.frdFileVersion),
+#    fileName = cms.untracked.string("frd_output.raw")
+    )
+
+process.p = cms.Path(process.s+process.a)
+
+process.ep = cms.EndPath(process.out)


### PR DESCRIPTION
#### PR description:

- using a helper function to set input source state for monitoring
- set correct input source monitoring state when sleeping in some locations
- additional HLT files copied when emulating DAQ input
- output module for raw (FRD) files which doesn't produce full HLT(F3) directory structure. Test script is also provided.
- fixed generation of cfi file for EvFOutputModule (for ConfDB)
- removing unused "shared mode" from RAW output module used for DAQ to HLT output emulation

<!-- Please replace this text with a description of the feature proposed or problem addressed, specifying:
  - what changes are expected in the output if any, 
  - what other PRs or externals it depends upon if any,
  - link to any additional material useful to provide a documentation for this PR (slides, JIRA tickets, related pull requestes, hypernews, TWiki or Indico pages)  -->

#### PR validation:

Tested in HLT validation test system (running a simple HLT appliance setup).
New output module tested manually to verify it produced valid output format.
