### PR TITLE
Removing global variables from EcalDQMCommonUtils

### DIFF
--- a/DQM/EcalCommon/interface/DQWorker.h
+++ b/DQM/EcalCommon/interface/DQWorker.h
@@ -12,6 +12,11 @@
 
 #include "tbb/concurrent_unordered_map.h"
 
+#include "Geometry/CaloGeometry/interface/CaloGeometry.h"
+#include "Geometry/CaloTopology/interface/CaloTopology.h"
+#include "Geometry/CaloTopology/interface/EcalTrigTowerConstituentsMap.h"
+#include "Geometry/EcalMapping/interface/EcalElectronicsMapping.h"
+
 namespace edm {
   class Run;
   class LuminosityBlock;
@@ -63,6 +68,14 @@ namespace ecaldqm {
     virtual void bookMEs(DQMStore::IBooker &);
     virtual void releaseMEs();
 
+    // old ecaldqmGetSetupObjects (old global vars)
+    void setSetupObjects(edm::EventSetup const &);
+    EcalElectronicsMapping const *GetElectronicsMap();
+    EcalTrigTowerConstituentsMap const *GetTrigTowerMap();
+    CaloGeometry const *GetGeometry();
+    CaloTopology const *GetTopology();
+    EcalDQMSetupObjects const getEcalDQMSetupObjects();
+
     void setTime(time_t _t) { timestamp_.now = _t; }
     void setRunNumber(edm::RunNumber_t _r) { timestamp_.iRun = _r; }
     void setLumiNumber(edm::LuminosityBlockNumber_t _l) { timestamp_.iLumi = _l; }
@@ -84,6 +97,9 @@ namespace ecaldqm {
     // common parameters
     bool onlineMode_;
     bool willConvertToEDM_;
+
+  private:
+    EcalDQMSetupObjects edso_;
   };
 
   typedef DQWorker *(*WorkerFactory)();

--- a/DQM/EcalCommon/interface/DQWorker.h
+++ b/DQM/EcalCommon/interface/DQWorker.h
@@ -69,6 +69,19 @@ namespace ecaldqm {
     virtual void releaseMEs();
 
     // old ecaldqmGetSetupObjects (old global vars)
+    // These are objects obtained from EventSetup and stored
+    // inside each module (which inherit from DQWorker).
+    // Before, EcalCommon functions could access these through
+    // global functions, but now we need to pass them from the
+    // modules to functions in EcalCommon, such as in
+    // EcalDQMCommonUtils, MESetBinningUtils, all MESets, etc.
+    //
+    // The global variables were removed as they were against
+    // CMSSW rules, and potentially led to undefined behavior
+    // (data race) at IOV boundaries. They also relied on a mutex
+    // which leads to poor multi-threading performance.
+    // Original issue here:
+    // https://github.com/cms-sw/cmssw/issues/28858
     void setSetupObjects(edm::EventSetup const &);
     EcalElectronicsMapping const *GetElectronicsMap();
     EcalTrigTowerConstituentsMap const *GetTrigTowerMap();

--- a/DQM/EcalCommon/interface/EcalDQMCommonUtils.h
+++ b/DQM/EcalCommon/interface/EcalDQMCommonUtils.h
@@ -143,7 +143,7 @@ namespace ecaldqm {
 
   std::vector<DetId> scConstituents(EcalScDetId const &);
 
-  EcalPnDiodeDetId pnForCrystal(DetId const &, char, EcalElectronicsMapping const*);
+  EcalPnDiodeDetId pnForCrystal(DetId const &, char, EcalElectronicsMapping const *);
 
   unsigned dccId(std::string const &);
   std::string smName(unsigned);

--- a/DQM/EcalCommon/interface/EcalDQMCommonUtils.h
+++ b/DQM/EcalCommon/interface/EcalDQMCommonUtils.h
@@ -6,7 +6,6 @@
 #include <iomanip>
 
 #include "Geometry/CaloGeometry/interface/CaloGeometry.h"
-#include "Geometry/CaloTopology/interface/CaloTopology.h"
 #include "Geometry/CaloTopology/interface/EcalTrigTowerConstituentsMap.h"
 #include "Geometry/EcalMapping/interface/EcalElectronicsMapping.h"
 
@@ -120,39 +119,39 @@ namespace ecaldqm {
   extern double const etaBound;
 
   // returns DCC ID (1 - 54)
-  unsigned dccId(DetId const &);
+  unsigned dccId(DetId const &, EcalElectronicsMapping const *);
   unsigned dccId(EcalElectronicsId const &);
 
   unsigned memDCCId(unsigned);     // convert from dccId skipping DCCs without MEM
   unsigned memDCCIndex(unsigned);  // reverse conversion
 
   // returns TCC ID (1 - 108)
-  unsigned tccId(DetId const &);
-  unsigned tccId(EcalElectronicsId const &);
+  unsigned tccId(DetId const &, EcalElectronicsMapping const *);
+  unsigned tccId(EcalElectronicsId const &, EcalElectronicsMapping const *);
 
   // returns the data tower id - pass only
-  unsigned towerId(DetId const &);
+  unsigned towerId(DetId const &, EcalElectronicsMapping const *);
   unsigned towerId(EcalElectronicsId const &);
 
-  unsigned ttId(DetId const &);
-  unsigned ttId(EcalElectronicsId const &);
+  unsigned ttId(DetId const &, EcalElectronicsMapping const *);
+  unsigned ttId(EcalElectronicsId const &, EcalElectronicsMapping const *);
 
-  unsigned rtHalf(DetId const &);
+  unsigned rtHalf(DetId const &, EcalElectronicsMapping const *);
 
   std::pair<unsigned, unsigned> innerTCCs(unsigned);
   std::pair<unsigned, unsigned> outerTCCs(unsigned);
 
   std::vector<DetId> scConstituents(EcalScDetId const &);
 
-  EcalPnDiodeDetId pnForCrystal(DetId const &, char);
+  EcalPnDiodeDetId pnForCrystal(DetId const &, char, EcalElectronicsMapping const*);
 
   unsigned dccId(std::string const &);
   std::string smName(unsigned);
 
   int zside(DetId const &);
 
-  double eta(EBDetId const &);
-  double eta(EEDetId const &);
+  double eta(EBDetId const &, CaloGeometry const *);
+  double eta(EEDetId const &, CaloGeometry const *);
   double phi(EBDetId const &);
   double phi(EEDetId const &);
   double phi(EcalTrigTowerDetId const &);
@@ -169,22 +168,6 @@ namespace ecaldqm {
   unsigned nSuperCrystals(unsigned);
 
   bool ccuExists(unsigned, unsigned);
-
-  bool checkElectronicsMap(bool = true);
-  EcalElectronicsMapping const *getElectronicsMap();
-  void setElectronicsMap(EcalElectronicsMapping const *);
-
-  bool checkTrigTowerMap(bool = true);
-  EcalTrigTowerConstituentsMap const *getTrigTowerMap();
-  void setTrigTowerMap(EcalTrigTowerConstituentsMap const *);
-
-  bool checkGeometry(bool = true);
-  CaloGeometry const *getGeometry();
-  void setGeometry(CaloGeometry const *);
-
-  bool checkTopology(bool = true);
-  CaloTopology const *getTopology();
-  void setTopology(CaloTopology const *);
 }  // namespace ecaldqm
 
 #endif

--- a/DQM/EcalCommon/interface/EcalDQMonitor.h
+++ b/DQM/EcalCommon/interface/EcalDQMonitor.h
@@ -30,7 +30,6 @@ namespace ecaldqm {
     static void fillDescriptions(edm::ParameterSetDescription &);
 
   protected:
-    void ecaldqmGetSetupObjects(edm::EventSetup const &);
     void ecaldqmBeginRun(edm::Run const &, edm::EventSetup const &);
     void ecaldqmEndRun(edm::Run const &, edm::EventSetup const &);
     void ecaldqmBeginLuminosityBlock(edm::LuminosityBlock const &, edm::EventSetup const &) const;

--- a/DQM/EcalCommon/interface/MESet.h
+++ b/DQM/EcalCommon/interface/MESet.h
@@ -8,6 +8,11 @@
 #include "DataFormats/DetId/interface/DetId.h"
 #include "DataFormats/EcalDetId/interface/EcalElectronicsId.h"
 
+#include "Geometry/EcalMapping/interface/EcalElectronicsMapping.h"
+#include "Geometry/CaloTopology/interface/EcalTrigTowerConstituentsMap.h"
+#include "Geometry/CaloGeometry/interface/CaloGeometry.h"
+#include "Geometry/CaloTopology/interface/CaloTopology.h"
+
 #include "FWCore/Utilities/interface/Exception.h"
 
 #include <string>
@@ -21,6 +26,13 @@ namespace ecaldqm {
   Base class for MonitorElement wrappers
   Interface between ME bins and DetId
 */
+
+  struct EcalDQMSetupObjects {
+      EcalElectronicsMapping const *electronicsMap;
+      EcalTrigTowerConstituentsMap const *trigtowerMap;
+      CaloGeometry const *geometry;
+      CaloTopology const *topology;
+  };
 
   class StatusManager;
 
@@ -39,55 +51,55 @@ namespace ecaldqm {
 
     virtual MESet *clone(std::string const & = "") const;
 
-    virtual void book(DQMStore::IBooker &) {}
-    virtual bool retrieve(DQMStore::IGetter &, std::string * = nullptr) const { return false; }
+    virtual void book(DQMStore::IBooker &, EcalElectronicsMapping const *) {}
+    virtual bool retrieve(EcalElectronicsMapping const *, DQMStore::IGetter &, std::string * = nullptr) const { return false; }
     virtual void clear() const;
 
-    virtual void fill(DetId const &, double = 1., double = 1., double = 1.) {}
-    virtual void fill(EcalElectronicsId const &, double = 1., double = 1., double = 1.) {}
-    virtual void fill(int, double = 1., double = 1., double = 1.) {}
-    virtual void fill(double, double = 1., double = 1.) {}
+    virtual void fill(EcalDQMSetupObjects const, DetId const &, double = 1., double = 1., double = 1.) {}
+    virtual void fill(EcalDQMSetupObjects const, EcalElectronicsId const &, double = 1., double = 1., double = 1.) {}
+    virtual void fill(EcalDQMSetupObjects const, int, double = 1., double = 1., double = 1.) {}
+    virtual void fill(EcalDQMSetupObjects const, double, double = 1., double = 1.) {}
 
-    virtual void setBinContent(DetId const &, double) {}
-    virtual void setBinContent(EcalElectronicsId const &, double) {}
-    virtual void setBinContent(int, double) {}
-    virtual void setBinContent(DetId const &, int, double) {}
-    virtual void setBinContent(EcalElectronicsId const &, int, double) {}
-    virtual void setBinContent(int, int, double) {}
+    virtual void setBinContent(EcalDQMSetupObjects const, DetId const &, double) {}
+    virtual void setBinContent(EcalDQMSetupObjects const, EcalElectronicsId const &, double) {}
+    virtual void setBinContent(EcalDQMSetupObjects const, int, double) {}
+    virtual void setBinContent(EcalDQMSetupObjects const, DetId const &, int, double) {}
+    virtual void setBinContent(EcalDQMSetupObjects const, EcalElectronicsId const &, int, double) {}
+    virtual void setBinContent(EcalDQMSetupObjects const, int, int, double) {}
 
-    virtual void setBinError(DetId const &, double) {}
-    virtual void setBinError(EcalElectronicsId const &, double) {}
-    virtual void setBinError(int, double) {}
-    virtual void setBinError(DetId const &, int, double) {}
-    virtual void setBinError(EcalElectronicsId const &, int, double) {}
-    virtual void setBinError(int, int, double) {}
+    virtual void setBinError(EcalDQMSetupObjects const, DetId const &, double) {}
+    virtual void setBinError(EcalDQMSetupObjects const, EcalElectronicsId const &, double) {}
+    virtual void setBinError(EcalDQMSetupObjects const, int, double) {}
+    virtual void setBinError(EcalDQMSetupObjects const, DetId const &, int, double) {}
+    virtual void setBinError(EcalDQMSetupObjects const, EcalElectronicsId const &, int, double) {}
+    virtual void setBinError(EcalDQMSetupObjects const, int, int, double) {}
 
-    virtual void setBinEntries(DetId const &, double) {}
-    virtual void setBinEntries(EcalElectronicsId const &, double) {}
-    virtual void setBinEntries(int, double) {}
-    virtual void setBinEntries(DetId const &, int, double) {}
-    virtual void setBinEntries(EcalElectronicsId const &, int, double) {}
-    virtual void setBinEntries(int, int, double) {}
+    virtual void setBinEntries(EcalDQMSetupObjects const, DetId const &, double) {}
+    virtual void setBinEntries(EcalDQMSetupObjects const, EcalElectronicsId const &, double) {}
+    virtual void setBinEntries(EcalDQMSetupObjects const, int, double) {}
+    virtual void setBinEntries(EcalDQMSetupObjects const, DetId const &, int, double) {}
+    virtual void setBinEntries(EcalDQMSetupObjects const, EcalElectronicsId const &, int, double) {}
+    virtual void setBinEntries(EcalDQMSetupObjects const, int, int, double) {}
 
-    virtual double getBinContent(DetId const &, int = 0) const { return 0.; }
-    virtual double getBinContent(EcalElectronicsId const &, int = 0) const { return 0.; }
-    virtual double getBinContent(int, int = 0) const { return 0.; }
+    virtual double getBinContent(EcalDQMSetupObjects const, DetId const &, int = 0) const { return 0.; }
+    virtual double getBinContent(EcalDQMSetupObjects const, EcalElectronicsId const &, int = 0) const { return 0.; }
+    virtual double getBinContent(EcalDQMSetupObjects const, int, int = 0) const { return 0.; }
 
-    virtual double getBinError(DetId const &, int = 0) const { return 0.; }
-    virtual double getBinError(EcalElectronicsId const &, int = 0) const { return 0.; }
-    virtual double getBinError(int, int = 0) const { return 0.; }
+    virtual double getBinError(EcalDQMSetupObjects const, DetId const &, int = 0) const { return 0.; }
+    virtual double getBinError(EcalDQMSetupObjects const, EcalElectronicsId const &, int = 0) const { return 0.; }
+    virtual double getBinError(EcalDQMSetupObjects const, int, int = 0) const { return 0.; }
 
-    virtual double getBinEntries(DetId const &, int = 0) const { return 0.; }
-    virtual double getBinEntries(EcalElectronicsId const &, int = 0) const { return 0.; }
-    virtual double getBinEntries(int, int = 0) const { return 0.; }
+    virtual double getBinEntries(EcalDQMSetupObjects const, DetId const &, int = 0) const { return 0.; }
+    virtual double getBinEntries(EcalDQMSetupObjects const, EcalElectronicsId const &, int = 0) const { return 0.; }
+    virtual double getBinEntries(EcalDQMSetupObjects const, int, int = 0) const { return 0.; }
 
     // title, axis
     virtual void setAxisTitle(std::string const &, int = 1);
 
-    virtual void reset(double = 0., double = 0., double = 0.);
+    virtual void reset(EcalElectronicsMapping const *, double = 0., double = 0., double = 0.);
     virtual void resetAll(double = 0., double = 0., double = 0.);
 
-    virtual bool maskMatches(DetId const &, uint32_t, StatusManager const *) const;
+    virtual bool maskMatches(DetId const &, uint32_t, StatusManager const *, EcalTrigTowerConstituentsMap const *) const;
 
     virtual std::string const &getPath() const { return path_; }
     binning::ObjectType getObjType() const { return otype_; }
@@ -149,9 +161,9 @@ namespace ecaldqm {
       bool operator==(ConstBin const &_rhs) const {
         return meSet_ != nullptr && meSet_ == _rhs.meSet_ && iME == _rhs.iME && iBin == _rhs.iBin;
       }
-      bool isChannel() const {
+      bool isChannel(EcalElectronicsMapping const *electronicsMap) const {
         if (meSet_)
-          return binning::isValidIdBin(otype, meSet_->getBinType(), iME, iBin);
+          return binning::isValidIdBin(electronicsMap, otype, meSet_->getBinType(), iME, iBin);
         else
           return false;
       }
@@ -244,8 +256,8 @@ namespace ecaldqm {
   */
     struct const_iterator {
       const_iterator() : bin_() {}
-      const_iterator(MESet const &_meSet, unsigned _iME = 0, int _iBin = 1) : bin_(_meSet, _iME, _iBin) {}
-      const_iterator(MESet const &, DetId const &);
+      const_iterator(EcalElectronicsMapping const *, MESet const &_meSet, unsigned _iME = 0, int _iBin = 1) : bin_(_meSet, _iME, _iBin) {}
+      const_iterator(EcalElectronicsMapping const *, MESet const &, DetId const &);
       const_iterator(const_iterator const &_orig) : bin_(_orig.bin_) {}
       const_iterator &operator=(const_iterator const &_rhs) {
         bin_ = _rhs.bin_;
@@ -255,7 +267,7 @@ namespace ecaldqm {
       bool operator!=(const_iterator const &_rhs) const { return !(bin_ == _rhs.bin_); }
       ConstBin const *operator->() const { return &bin_; }
       const_iterator &operator++();
-      const_iterator &toNextChannel();
+      const_iterator &toNextChannel(EcalElectronicsMapping const *);
       bool up();
       bool down();
       bool left();
@@ -267,10 +279,10 @@ namespace ecaldqm {
 
     struct iterator : public const_iterator {
       iterator() : const_iterator(), bin_() {}
-      iterator(MESet &_meSet, unsigned _iME = 0, int _iBin = 1) : const_iterator(_meSet, _iME, _iBin), bin_(_meSet) {
+      iterator(EcalElectronicsMapping const *electronicsMap, MESet &_meSet, unsigned _iME = 0, int _iBin = 1) : const_iterator(electronicsMap, _meSet, _iME, _iBin), bin_(_meSet) {
         bin_.ConstBin::operator=(const_iterator::bin_);
       }
-      iterator(MESet &_meSet, DetId const &_id) : const_iterator(_meSet, _id), bin_(_meSet) {
+      iterator(EcalElectronicsMapping const *electronicsMap, MESet &_meSet, DetId const &_id) : const_iterator(electronicsMap, _meSet, _id), bin_(_meSet) {
         bin_.ConstBin::operator=(const_iterator::bin_);
       }
       iterator(iterator const &_orig) : const_iterator(_orig), bin_(_orig.bin_) {}
@@ -286,8 +298,8 @@ namespace ecaldqm {
         bin_.ConstBin::operator=(const_iterator::bin_);
         return *this;
       }
-      const_iterator &toNextChannel() {
-        const_iterator::toNextChannel();
+      const_iterator &toNextChannel(EcalElectronicsMapping const *electronicsMap) {
+        const_iterator::toNextChannel(electronicsMap);
         bin_.ConstBin::operator=(const_iterator::bin_);
         return *this;
       }
@@ -316,22 +328,22 @@ namespace ecaldqm {
       Bin bin_;
     };
 
-    virtual const_iterator begin() const { return const_iterator(*this); }
+    virtual const_iterator begin(EcalElectronicsMapping const *electronicsMap) const { return const_iterator(electronicsMap, *this); }
 
-    virtual const_iterator end() const { return const_iterator(*this, -1, -1); }
+    virtual const_iterator end(EcalElectronicsMapping const *electronicsMap) const { return const_iterator(electronicsMap, *this, -1, -1); }
 
-    virtual const_iterator beginChannel() const {
-      const_iterator itr(*this, 0, 0);
-      return itr.toNextChannel();
+    virtual const_iterator beginChannel(EcalElectronicsMapping const *electronicsMap) const {
+      const_iterator itr(electronicsMap, *this, 0, 0);
+      return itr.toNextChannel(electronicsMap);
     }
 
-    virtual iterator begin() { return iterator(*this); }
+    virtual iterator begin(EcalElectronicsMapping const *electronicsMap) { return iterator(electronicsMap, *this); }
 
-    virtual iterator end() { return iterator(*this, -1, -1); }
+    virtual iterator end(EcalElectronicsMapping const *electronicsMap) { return iterator(electronicsMap, *this, -1, -1); }
 
-    virtual iterator beginChannel() {
-      iterator itr(*this, 0, 0);
-      itr.toNextChannel();
+    virtual iterator beginChannel(EcalElectronicsMapping const *electronicsMap) {
+      iterator itr(electronicsMap, *this, 0, 0);
+      itr.toNextChannel(electronicsMap);
       return itr;
     }
   };

--- a/DQM/EcalCommon/interface/MESet.h
+++ b/DQM/EcalCommon/interface/MESet.h
@@ -27,6 +27,9 @@ namespace ecaldqm {
   Interface between ME bins and DetId
 */
 
+  // struct made to simplify passing multiple setup
+  // variables (see DQWorker.h for implementation)
+  // to MESet functions
   struct EcalDQMSetupObjects {
     EcalElectronicsMapping const *electronicsMap;
     EcalTrigTowerConstituentsMap const *trigtowerMap;
@@ -57,6 +60,17 @@ namespace ecaldqm {
     }
     virtual void clear() const;
 
+    // Overloaded functions deal with different ids or
+    // inputs to fill, setBinContent, etc and each determines
+    // the correct bin to fill based on what is passed.
+    //
+    // Note: not every fill, setBinContent, etc necessarily uses
+    // EcalDQMSetupObjects, but they are passed one anyway to
+    // avoid accidentally casting a DetId or a EcalElectronicsId
+    // to an int or a double and have it exercute the wrong function.
+    // This would be tricky to debug if this error is made, so it
+    // makes more sense for these functions to look consistent in
+    // terms of passing EcalDQMSetupObjects.
     virtual void fill(EcalDQMSetupObjects const, DetId const &, double = 1., double = 1., double = 1.) {}
     virtual void fill(EcalDQMSetupObjects const, EcalElectronicsId const &, double = 1., double = 1., double = 1.) {}
     virtual void fill(EcalDQMSetupObjects const, int, double = 1., double = 1., double = 1.) {}

--- a/DQM/EcalCommon/interface/MESet.h
+++ b/DQM/EcalCommon/interface/MESet.h
@@ -28,10 +28,10 @@ namespace ecaldqm {
 */
 
   struct EcalDQMSetupObjects {
-      EcalElectronicsMapping const *electronicsMap;
-      EcalTrigTowerConstituentsMap const *trigtowerMap;
-      CaloGeometry const *geometry;
-      CaloTopology const *topology;
+    EcalElectronicsMapping const *electronicsMap;
+    EcalTrigTowerConstituentsMap const *trigtowerMap;
+    CaloGeometry const *geometry;
+    CaloTopology const *topology;
   };
 
   class StatusManager;
@@ -52,7 +52,9 @@ namespace ecaldqm {
     virtual MESet *clone(std::string const & = "") const;
 
     virtual void book(DQMStore::IBooker &, EcalElectronicsMapping const *) {}
-    virtual bool retrieve(EcalElectronicsMapping const *, DQMStore::IGetter &, std::string * = nullptr) const { return false; }
+    virtual bool retrieve(EcalElectronicsMapping const *, DQMStore::IGetter &, std::string * = nullptr) const {
+      return false;
+    }
     virtual void clear() const;
 
     virtual void fill(EcalDQMSetupObjects const, DetId const &, double = 1., double = 1., double = 1.) {}
@@ -256,7 +258,8 @@ namespace ecaldqm {
   */
     struct const_iterator {
       const_iterator() : bin_() {}
-      const_iterator(EcalElectronicsMapping const *, MESet const &_meSet, unsigned _iME = 0, int _iBin = 1) : bin_(_meSet, _iME, _iBin) {}
+      const_iterator(EcalElectronicsMapping const *, MESet const &_meSet, unsigned _iME = 0, int _iBin = 1)
+          : bin_(_meSet, _iME, _iBin) {}
       const_iterator(EcalElectronicsMapping const *, MESet const &, DetId const &);
       const_iterator(const_iterator const &_orig) : bin_(_orig.bin_) {}
       const_iterator &operator=(const_iterator const &_rhs) {
@@ -279,10 +282,12 @@ namespace ecaldqm {
 
     struct iterator : public const_iterator {
       iterator() : const_iterator(), bin_() {}
-      iterator(EcalElectronicsMapping const *electronicsMap, MESet &_meSet, unsigned _iME = 0, int _iBin = 1) : const_iterator(electronicsMap, _meSet, _iME, _iBin), bin_(_meSet) {
+      iterator(EcalElectronicsMapping const *electronicsMap, MESet &_meSet, unsigned _iME = 0, int _iBin = 1)
+          : const_iterator(electronicsMap, _meSet, _iME, _iBin), bin_(_meSet) {
         bin_.ConstBin::operator=(const_iterator::bin_);
       }
-      iterator(EcalElectronicsMapping const *electronicsMap, MESet &_meSet, DetId const &_id) : const_iterator(electronicsMap, _meSet, _id), bin_(_meSet) {
+      iterator(EcalElectronicsMapping const *electronicsMap, MESet &_meSet, DetId const &_id)
+          : const_iterator(electronicsMap, _meSet, _id), bin_(_meSet) {
         bin_.ConstBin::operator=(const_iterator::bin_);
       }
       iterator(iterator const &_orig) : const_iterator(_orig), bin_(_orig.bin_) {}
@@ -328,9 +333,13 @@ namespace ecaldqm {
       Bin bin_;
     };
 
-    virtual const_iterator begin(EcalElectronicsMapping const *electronicsMap) const { return const_iterator(electronicsMap, *this); }
+    virtual const_iterator begin(EcalElectronicsMapping const *electronicsMap) const {
+      return const_iterator(electronicsMap, *this);
+    }
 
-    virtual const_iterator end(EcalElectronicsMapping const *electronicsMap) const { return const_iterator(electronicsMap, *this, -1, -1); }
+    virtual const_iterator end(EcalElectronicsMapping const *electronicsMap) const {
+      return const_iterator(electronicsMap, *this, -1, -1);
+    }
 
     virtual const_iterator beginChannel(EcalElectronicsMapping const *electronicsMap) const {
       const_iterator itr(electronicsMap, *this, 0, 0);
@@ -339,7 +348,9 @@ namespace ecaldqm {
 
     virtual iterator begin(EcalElectronicsMapping const *electronicsMap) { return iterator(electronicsMap, *this); }
 
-    virtual iterator end(EcalElectronicsMapping const *electronicsMap) { return iterator(electronicsMap, *this, -1, -1); }
+    virtual iterator end(EcalElectronicsMapping const *electronicsMap) {
+      return iterator(electronicsMap, *this, -1, -1);
+    }
 
     virtual iterator beginChannel(EcalElectronicsMapping const *electronicsMap) {
       iterator itr(electronicsMap, *this, 0, 0);

--- a/DQM/EcalCommon/interface/MESetBinningUtils.h
+++ b/DQM/EcalCommon/interface/MESetBinningUtils.h
@@ -2,6 +2,7 @@
 #define MESetBinningUtils_H
 
 #include "DQMServices/Core/interface/DQMStore.h"
+#include "Geometry/EcalMapping/interface/EcalElectronicsMapping.h"
 
 #include <string>
 
@@ -125,27 +126,27 @@ namespace ecaldqm {
       }
     };
 
-    AxisSpecs getBinning(ObjectType, BinningType, bool, int, unsigned);
+    AxisSpecs getBinning(EcalElectronicsMapping const *, ObjectType, BinningType, bool, int, unsigned);
 
-    int findBin1D(ObjectType, BinningType, DetId const &);
-    int findBin1D(ObjectType, BinningType, EcalElectronicsId const &);
-    int findBin1D(ObjectType, BinningType, int);
+    int findBin1D(EcalElectronicsMapping const *, ObjectType, BinningType, DetId const &);
+    int findBin1D(EcalElectronicsMapping const *, ObjectType, BinningType, EcalElectronicsId const &);
+    int findBin1D(EcalElectronicsMapping const *, ObjectType, BinningType, int);
 
-    int findBin2D(ObjectType, BinningType, DetId const &);
-    int findBin2D(ObjectType, BinningType, EcalElectronicsId const &);
-    int findBin2D(ObjectType, BinningType, int);
+    int findBin2D(EcalElectronicsMapping const *, ObjectType, BinningType, DetId const &);
+    int findBin2D(EcalElectronicsMapping const *, ObjectType, BinningType, EcalElectronicsId const &);
+    int findBin2D(EcalElectronicsMapping const *, ObjectType, BinningType, int);
 
-    unsigned findPlotIndex(ObjectType, DetId const &);
-    unsigned findPlotIndex(ObjectType, EcalElectronicsId const &);
-    unsigned findPlotIndex(ObjectType, int, BinningType _btype = kDCC);
+    unsigned findPlotIndex(EcalElectronicsMapping const *, ObjectType, DetId const &);
+    unsigned findPlotIndex(EcalElectronicsMapping const *, ObjectType, EcalElectronicsId const &);
+    unsigned findPlotIndex(EcalElectronicsMapping const *, ObjectType, int, BinningType _btype = kDCC);
 
     ObjectType getObject(ObjectType, unsigned);
 
     unsigned getNObjects(ObjectType);
 
-    bool isValidIdBin(ObjectType, BinningType, unsigned, int);
+    bool isValidIdBin(EcalElectronicsMapping const *, ObjectType, BinningType, unsigned, int);
 
-    std::string channelName(uint32_t, BinningType _btype = kDCC);
+    std::string channelName(EcalElectronicsMapping const *, uint32_t, BinningType _btype = kDCC);
 
     uint32_t idFromName(std::string const &);
     uint32_t idFromBin(ObjectType, BinningType, unsigned, int);
@@ -165,18 +166,18 @@ namespace ecaldqm {
 
     AxisSpecs getBinningEB_(BinningType, bool, int);
     AxisSpecs getBinningEE_(BinningType, bool, int, int);
-    AxisSpecs getBinningSM_(BinningType, bool, unsigned, int);
+    AxisSpecs getBinningSM_(BinningType, bool, unsigned, int, EcalElectronicsMapping const *);
     AxisSpecs getBinningSMMEM_(BinningType, bool, unsigned, int);
     AxisSpecs getBinningEcal_(BinningType, bool, int);
     AxisSpecs getBinningMEM_(BinningType, bool, int, int);
 
-    int findBinCrystal_(ObjectType, DetId const &, int = -1);
-    int findBinCrystal_(ObjectType, EcalElectronicsId const &);
-    int findBinTriggerTower_(ObjectType, DetId const &);
-    int findBinPseudoStrip_(ObjectType, DetId const &);
+    int findBinCrystal_(EcalElectronicsMapping const *, ObjectType, DetId const &, int = -1);
+    int findBinCrystal_(EcalElectronicsMapping const *, ObjectType, EcalElectronicsId const &);
+    int findBinTriggerTower_(EcalElectronicsMapping const *, ObjectType, DetId const &);
+    int findBinPseudoStrip_(EcalElectronicsMapping const *, ObjectType, DetId const &);
     int findBinRCT_(ObjectType, DetId const &);
-    int findBinSuperCrystal_(ObjectType, DetId const &, int = -1);
-    int findBinSuperCrystal_(ObjectType, EcalElectronicsId const &);
+    int findBinSuperCrystal_(EcalElectronicsMapping const *, ObjectType, DetId const &, int = -1);
+    int findBinSuperCrystal_(EcalElectronicsMapping const *, ObjectType, EcalElectronicsId const &);
   }  // namespace binning
 }  // namespace ecaldqm
 

--- a/DQM/EcalCommon/interface/MESetDet0D.h
+++ b/DQM/EcalCommon/interface/MESetDet0D.h
@@ -22,9 +22,15 @@ namespace ecaldqm {
     void fill(EcalDQMSetupObjects const, EcalElectronicsId const &, double, double = 0., double = 0.) override;
     void fill(EcalDQMSetupObjects const, int, double, double = 0., double = 0.) override;
 
-    void setBinContent(EcalDQMSetupObjects const edso, DetId const &_id, int, double _value) override { fill(edso, _id, _value); }
-    void setBinContent(EcalDQMSetupObjects const edso, EcalElectronicsId const &_id, int, double _value) override { fill(edso, _id, _value); }
-    void setBinContent(EcalDQMSetupObjects const edso, int _dcctccid, int, double _value) override { fill(edso, _dcctccid, _value); }
+    void setBinContent(EcalDQMSetupObjects const edso, DetId const &_id, int, double _value) override {
+      fill(edso, _id, _value);
+    }
+    void setBinContent(EcalDQMSetupObjects const edso, EcalElectronicsId const &_id, int, double _value) override {
+      fill(edso, _id, _value);
+    }
+    void setBinContent(EcalDQMSetupObjects const edso, int _dcctccid, int, double _value) override {
+      fill(edso, _dcctccid, _value);
+    }
 
     double getBinContent(EcalDQMSetupObjects const, DetId const &, int = 0) const override;
     double getBinContent(EcalDQMSetupObjects const, EcalElectronicsId const &, int = 0) const override;

--- a/DQM/EcalCommon/interface/MESetDet0D.h
+++ b/DQM/EcalCommon/interface/MESetDet0D.h
@@ -18,19 +18,19 @@ namespace ecaldqm {
 
     MESet *clone(std::string const & = "") const override;
 
-    void fill(DetId const &, double, double = 0., double = 0.) override;
-    void fill(EcalElectronicsId const &, double, double = 0., double = 0.) override;
-    void fill(int, double, double = 0., double = 0.) override;
+    void fill(EcalDQMSetupObjects const, DetId const &, double, double = 0., double = 0.) override;
+    void fill(EcalDQMSetupObjects const, EcalElectronicsId const &, double, double = 0., double = 0.) override;
+    void fill(EcalDQMSetupObjects const, int, double, double = 0., double = 0.) override;
 
-    void setBinContent(DetId const &_id, int, double _value) override { fill(_id, _value); }
-    void setBinContent(EcalElectronicsId const &_id, int, double _value) override { fill(_id, _value); }
-    void setBinContent(int _dcctccid, int, double _value) override { fill(_dcctccid, _value); }
+    void setBinContent(EcalDQMSetupObjects const edso, DetId const &_id, int, double _value) override { fill(edso, _id, _value); }
+    void setBinContent(EcalDQMSetupObjects const edso, EcalElectronicsId const &_id, int, double _value) override { fill(edso, _id, _value); }
+    void setBinContent(EcalDQMSetupObjects const edso, int _dcctccid, int, double _value) override { fill(edso, _dcctccid, _value); }
 
-    double getBinContent(DetId const &, int = 0) const override;
-    double getBinContent(EcalElectronicsId const &, int = 0) const override;
-    double getBinContent(int, int = 0) const override;
+    double getBinContent(EcalDQMSetupObjects const, DetId const &, int = 0) const override;
+    double getBinContent(EcalDQMSetupObjects const, EcalElectronicsId const &, int = 0) const override;
+    double getBinContent(EcalDQMSetupObjects const, int, int = 0) const override;
 
-    void reset(double = 0., double = 0., double = 0.) override;
+    void reset(EcalElectronicsMapping const *, double = 0., double = 0., double = 0.) override;
   };
 }  // namespace ecaldqm
 

--- a/DQM/EcalCommon/interface/MESetDet1D.h
+++ b/DQM/EcalCommon/interface/MESetDet1D.h
@@ -22,53 +22,53 @@ namespace ecaldqm {
 
     MESet *clone(std::string const & = "") const override;
 
-    void book(DQMStore::IBooker &) override;
+    void book(DQMStore::IBooker &, EcalElectronicsMapping const *) override;
 
-    void fill(DetId const &, double = 1., double = 1., double = 0.) override;
-    void fill(EcalElectronicsId const &, double = 1., double = 1., double = 0.) override;
-    void fill(int, double = 1., double = 1., double = 0.) override;
+    void fill(EcalDQMSetupObjects const, DetId const &, double = 1., double = 1., double = 0.) override;
+    void fill(EcalDQMSetupObjects const, EcalElectronicsId const &, double = 1., double = 1., double = 0.) override;
+    void fill(EcalDQMSetupObjects const, int, double = 1., double = 1., double = 0.) override;
 
-    void setBinContent(DetId const &, double) override;
-    void setBinContent(EcalElectronicsId const &, double) override;
-    void setBinContent(int, double) override;
-    void setBinContent(DetId const &, int, double) override;
-    void setBinContent(EcalElectronicsId const &, int, double) override;
-    void setBinContent(int, int, double) override;
+    void setBinContent(EcalDQMSetupObjects const, DetId const &, double) override;
+    void setBinContent(EcalDQMSetupObjects const, EcalElectronicsId const &, double) override;
+    void setBinContent(EcalDQMSetupObjects const, int, double) override;
+    void setBinContent(EcalDQMSetupObjects const, DetId const &, int, double) override;
+    void setBinContent(EcalDQMSetupObjects const, EcalElectronicsId const &, int, double) override;
+    void setBinContent(EcalDQMSetupObjects const, int, int, double) override;
 
-    void setBinError(DetId const &, double) override;
-    void setBinError(EcalElectronicsId const &, double) override;
-    void setBinError(int, double) override;
-    void setBinError(DetId const &, int, double) override;
-    void setBinError(EcalElectronicsId const &, int, double) override;
-    void setBinError(int, int, double) override;
+    void setBinError(EcalDQMSetupObjects const, DetId const &, double) override;
+    void setBinError(EcalDQMSetupObjects const, EcalElectronicsId const &, double) override;
+    void setBinError(EcalDQMSetupObjects const, int, double) override;
+    void setBinError(EcalDQMSetupObjects const, DetId const &, int, double) override;
+    void setBinError(EcalDQMSetupObjects const, EcalElectronicsId const &, int, double) override;
+    void setBinError(EcalDQMSetupObjects const, int, int, double) override;
 
-    void setBinEntries(DetId const &, double) override;
-    void setBinEntries(EcalElectronicsId const &, double) override;
-    void setBinEntries(int, double) override;
-    void setBinEntries(DetId const &, int, double) override;
-    void setBinEntries(EcalElectronicsId const &, int, double) override;
-    void setBinEntries(int, int, double) override;
+    void setBinEntries(EcalDQMSetupObjects const, DetId const &, double) override;
+    void setBinEntries(EcalDQMSetupObjects const, EcalElectronicsId const &, double) override;
+    void setBinEntries(EcalDQMSetupObjects const, int, double) override;
+    void setBinEntries(EcalDQMSetupObjects const, DetId const &, int, double) override;
+    void setBinEntries(EcalDQMSetupObjects const, EcalElectronicsId const &, int, double) override;
+    void setBinEntries(EcalDQMSetupObjects const, int, int, double) override;
 
-    double getBinContent(DetId const &, int = 0) const override;
-    double getBinContent(EcalElectronicsId const &, int = 0) const override;
-    double getBinContent(int, int = 0) const override;
+    double getBinContent(EcalDQMSetupObjects const, DetId const &, int = 0) const override;
+    double getBinContent(EcalDQMSetupObjects const, EcalElectronicsId const &, int = 0) const override;
+    double getBinContent(EcalDQMSetupObjects const, int, int = 0) const override;
 
-    double getBinError(DetId const &, int = 0) const override;
-    double getBinError(EcalElectronicsId const &, int = 0) const override;
-    double getBinError(int, int = 0) const override;
+    double getBinError(EcalDQMSetupObjects const, DetId const &, int = 0) const override;
+    double getBinError(EcalDQMSetupObjects const, EcalElectronicsId const &, int = 0) const override;
+    double getBinError(EcalDQMSetupObjects const, int, int = 0) const override;
 
-    double getBinEntries(DetId const &, int = 0) const override;
-    double getBinEntries(EcalElectronicsId const &, int = 0) const override;
-    double getBinEntries(int, int = 0) const override;
+    double getBinEntries(EcalDQMSetupObjects const, DetId const &, int = 0) const override;
+    double getBinEntries(EcalDQMSetupObjects const, EcalElectronicsId const &, int = 0) const override;
+    double getBinEntries(EcalDQMSetupObjects const, int, int = 0) const override;
 
-    int findBin(DetId const &) const;
-    int findBin(EcalElectronicsId const &) const;
-    int findBin(int) const;
-    int findBin(DetId const &, double, double = 0.) const override;
-    int findBin(EcalElectronicsId const &, double, double = 0.) const override;
-    int findBin(int, double, double = 0.) const override;
+    int findBin(EcalDQMSetupObjects const, DetId const &) const;
+    int findBin(EcalDQMSetupObjects const, EcalElectronicsId const &) const;
+    int findBin(EcalDQMSetupObjects const, int) const;
+    int findBin(EcalDQMSetupObjects const, DetId const &, double, double = 0.) const override;
+    int findBin(EcalDQMSetupObjects const, EcalElectronicsId const &, double, double = 0.) const override;
+    int findBin(EcalDQMSetupObjects const, int, double, double = 0.) const override;
 
-    void reset(double = 0., double = 0., double = 0.) override;
+    void reset(EcalElectronicsMapping const *, double = 0., double = 0., double = 0.) override;
   };
 }  // namespace ecaldqm
 

--- a/DQM/EcalCommon/interface/MESetDet2D.h
+++ b/DQM/EcalCommon/interface/MESetDet2D.h
@@ -20,47 +20,47 @@ namespace ecaldqm {
 
     MESet *clone(std::string const & = "") const override;
 
-    void book(DQMStore::IBooker &) override;
+    void book(DQMStore::IBooker &, EcalElectronicsMapping const *) override;
 
-    void fill(DetId const &, double = 1., double = 0., double = 0.) override;
-    void fill(EcalElectronicsId const &, double = 1., double = 0., double = 0.) override;
-    void fill(int, double = 1., double = 1., double = 1.) override;
+    void fill(EcalDQMSetupObjects const, DetId const &, double = 1., double = 0., double = 0.) override;
+    void fill(EcalDQMSetupObjects const, EcalElectronicsId const &, double = 1., double = 0., double = 0.) override;
+    void fill(EcalDQMSetupObjects const, int, double = 1., double = 1., double = 1.) override;
 
     using MESetEcal::setBinContent;
-    void setBinContent(DetId const &, double) override;
-    void setBinContent(EcalElectronicsId const &, double) override;
-    void setBinContent(int, double) override;
+    void setBinContent(EcalDQMSetupObjects const, DetId const &, double) override;
+    void setBinContent(EcalDQMSetupObjects const, EcalElectronicsId const &, double) override;
+    void setBinContent(EcalDQMSetupObjects const, int, double) override;
 
     using MESetEcal::setBinError;
-    void setBinError(DetId const &, double) override;
-    void setBinError(EcalElectronicsId const &, double) override;
-    void setBinError(int, double) override;
+    void setBinError(EcalDQMSetupObjects const, DetId const &, double) override;
+    void setBinError(EcalDQMSetupObjects const, EcalElectronicsId const &, double) override;
+    void setBinError(EcalDQMSetupObjects const, int, double) override;
 
     using MESetEcal::setBinEntries;
-    void setBinEntries(DetId const &, double) override;
-    void setBinEntries(EcalElectronicsId const &, double) override;
-    void setBinEntries(int, double) override;
+    void setBinEntries(EcalDQMSetupObjects const, DetId const &, double) override;
+    void setBinEntries(EcalDQMSetupObjects const, EcalElectronicsId const &, double) override;
+    void setBinEntries(EcalDQMSetupObjects const, int, double) override;
 
     using MESetEcal::getBinContent;
-    double getBinContent(DetId const &, int = 0) const override;
-    double getBinContent(EcalElectronicsId const &, int = 0) const override;
-    double getBinContent(int, int = 0) const override;
+    double getBinContent(EcalDQMSetupObjects const, DetId const &, int = 0) const override;
+    double getBinContent(EcalDQMSetupObjects const, EcalElectronicsId const &, int = 0) const override;
+    double getBinContent(EcalDQMSetupObjects const, int, int = 0) const override;
 
     using MESetEcal::getBinError;
-    double getBinError(DetId const &, int = 0) const override;
-    double getBinError(EcalElectronicsId const &, int = 0) const override;
-    double getBinError(int, int = 0) const override;
+    double getBinError(EcalDQMSetupObjects const, DetId const &, int = 0) const override;
+    double getBinError(EcalDQMSetupObjects const, EcalElectronicsId const &, int = 0) const override;
+    double getBinError(EcalDQMSetupObjects const, int, int = 0) const override;
 
     using MESetEcal::getBinEntries;
-    double getBinEntries(DetId const &, int = 0) const override;
-    double getBinEntries(EcalElectronicsId const &, int = 0) const override;
-    double getBinEntries(int, int) const override;
+    double getBinEntries(EcalDQMSetupObjects const, DetId const &, int = 0) const override;
+    double getBinEntries(EcalDQMSetupObjects const, EcalElectronicsId const &, int = 0) const override;
+    double getBinEntries(EcalDQMSetupObjects const, int, int) const override;
 
     using MESetEcal::findBin;
-    int findBin(DetId const &) const;
-    int findBin(EcalElectronicsId const &) const;
+    int findBin(EcalDQMSetupObjects const, DetId const &) const;
+    int findBin(EcalDQMSetupObjects const, EcalElectronicsId const &) const;
 
-    void reset(double = 0., double = 0., double = 0.) override;
+    void reset(EcalElectronicsMapping const *, double = 0., double = 0., double = 0.) override;
 
   protected:
     void fill_(unsigned, int, double) override;

--- a/DQM/EcalCommon/interface/MESetEcal.h
+++ b/DQM/EcalCommon/interface/MESetEcal.h
@@ -29,45 +29,45 @@ namespace ecaldqm {
 
     MESet *clone(std::string const & = "") const override;
 
-    void book(DQMStore::IBooker &) override;
-    bool retrieve(DQMStore::IGetter &, std::string * = nullptr) const override;
+    void book(DQMStore::IBooker &, EcalElectronicsMapping const *) override;
+    bool retrieve(EcalElectronicsMapping const *, DQMStore::IGetter &, std::string * = nullptr) const override;
 
-    void fill(DetId const &, double = 1., double = 1., double = 1.) override;
-    void fill(EcalElectronicsId const &, double = 1., double = 1., double = 1.) override;
-    void fill(int, double = 1., double = 1., double = 1.) override;
-    void fill(double, double = 1., double = 1.) override;
+    void fill(EcalDQMSetupObjects const, DetId const &, double = 1., double = 1., double = 1.) override;
+    void fill(EcalDQMSetupObjects const, EcalElectronicsId const &, double = 1., double = 1., double = 1.) override;
+    void fill(EcalDQMSetupObjects const, int, double = 1., double = 1., double = 1.) override;
+    void fill(EcalDQMSetupObjects const, double, double = 1., double = 1.) override;
 
-    void setBinContent(DetId const &, int, double) override;
-    void setBinContent(EcalElectronicsId const &, int, double) override;
-    void setBinContent(int, int, double) override;
+    void setBinContent(EcalDQMSetupObjects const, DetId const &, int, double) override;
+    void setBinContent(EcalDQMSetupObjects const, EcalElectronicsId const &, int, double) override;
+    void setBinContent(EcalDQMSetupObjects const, int, int, double) override;
 
-    void setBinError(DetId const &, int, double) override;
-    void setBinError(EcalElectronicsId const &, int, double) override;
-    void setBinError(int, int, double) override;
+    void setBinError(EcalDQMSetupObjects const, DetId const &, int, double) override;
+    void setBinError(EcalDQMSetupObjects const, EcalElectronicsId const &, int, double) override;
+    void setBinError(EcalDQMSetupObjects const, int, int, double) override;
 
-    void setBinEntries(DetId const &, int, double) override;
-    void setBinEntries(EcalElectronicsId const &, int, double) override;
-    void setBinEntries(int, int, double) override;
+    void setBinEntries(EcalDQMSetupObjects const, DetId const &, int, double) override;
+    void setBinEntries(EcalDQMSetupObjects const, EcalElectronicsId const &, int, double) override;
+    void setBinEntries(EcalDQMSetupObjects const, int, int, double) override;
 
-    double getBinContent(DetId const &, int) const override;
-    double getBinContent(EcalElectronicsId const &, int) const override;
-    double getBinContent(int, int) const override;
+    double getBinContent(EcalDQMSetupObjects const, DetId const &, int) const override;
+    double getBinContent(EcalDQMSetupObjects const, EcalElectronicsId const &, int) const override;
+    double getBinContent(EcalDQMSetupObjects const, int, int) const override;
 
-    double getBinError(DetId const &, int) const override;
-    double getBinError(EcalElectronicsId const &, int) const override;
-    double getBinError(int, int) const override;
+    double getBinError(EcalDQMSetupObjects const, DetId const &, int) const override;
+    double getBinError(EcalDQMSetupObjects const, EcalElectronicsId const &, int) const override;
+    double getBinError(EcalDQMSetupObjects const, int, int) const override;
 
-    double getBinEntries(DetId const &, int) const override;
-    double getBinEntries(EcalElectronicsId const &, int) const override;
-    double getBinEntries(int, int) const override;
+    double getBinEntries(EcalDQMSetupObjects const, DetId const &, int) const override;
+    double getBinEntries(EcalDQMSetupObjects const, EcalElectronicsId const &, int) const override;
+    double getBinEntries(EcalDQMSetupObjects const, int, int) const override;
 
-    virtual int findBin(DetId const &, double, double = 0.) const;
-    virtual int findBin(EcalElectronicsId const &, double, double = 0.) const;
-    virtual int findBin(int, double, double = 0.) const;
+    virtual int findBin(EcalDQMSetupObjects const, DetId const &, double, double = 0.) const;
+    virtual int findBin(EcalDQMSetupObjects const, EcalElectronicsId const &, double, double = 0.) const;
+    virtual int findBin(EcalDQMSetupObjects const, int, double, double = 0.) const;
 
     bool isVariableBinning() const override;
 
-    std::vector<std::string> generatePaths() const;
+    std::vector<std::string> generatePaths(EcalElectronicsMapping const *) const;
 
   protected:
     unsigned logicalDimensions_;

--- a/DQM/EcalCommon/interface/MESetMulti.h
+++ b/DQM/EcalCommon/interface/MESetMulti.h
@@ -22,89 +22,89 @@ namespace ecaldqm {
 
     MESet *clone(std::string const & = "") const override;
 
-    void book(DQMStore::IBooker &) override;
-    bool retrieve(DQMStore::IGetter &, std::string * = nullptr) const override;
+    void book(DQMStore::IBooker &, EcalElectronicsMapping const *) override;
+    bool retrieve(EcalElectronicsMapping const *, DQMStore::IGetter &, std::string * = nullptr) const override;
     void clear() const override;
 
-    void fill(DetId const &_id, double _xyw = 1., double _yw = 1., double _w = 1.) override {
-      current_->fill(_id, _xyw, _yw, _w);
+    void fill(EcalDQMSetupObjects const edso, DetId const &_id, double _xyw = 1., double _yw = 1., double _w = 1.) override {
+      current_->fill(edso, _id, _xyw, _yw, _w);
     }
-    void fill(EcalElectronicsId const &_id, double _xyw = 1., double _yw = 1., double _w = 1.) override {
-      current_->fill(_id, _xyw, _yw, _w);
+    void fill(EcalDQMSetupObjects const edso, EcalElectronicsId const &_id, double _xyw = 1., double _yw = 1., double _w = 1.) override {
+      current_->fill(edso, _id, _xyw, _yw, _w);
     }
-    void fill(int _dcctccid, double _xyw = 1., double _yw = 1., double _w = 1.) override {
-      current_->fill(_dcctccid, _xyw, _yw, _w);
+    void fill(EcalDQMSetupObjects const edso, int _dcctccid, double _xyw = 1., double _yw = 1., double _w = 1.) override {
+      current_->fill(edso, _dcctccid, _xyw, _yw, _w);
     }
-    void fill(double _x, double _yw = 1., double _w = 1.) override { current_->fill(_x, _yw, _w); }
+    void fill(EcalDQMSetupObjects const edso, double _x, double _yw = 1., double _w = 1.) override { current_->fill(edso, _x, _yw, _w); }
 
-    void setBinContent(DetId const &_id, double _content) override { current_->setBinContent(_id, _content); }
-    void setBinContent(EcalElectronicsId const &_id, double _content) override {
-      current_->setBinContent(_id, _content);
+    void setBinContent(EcalDQMSetupObjects const edso, DetId const &_id, double _content) override { current_->setBinContent(edso, _id, _content); }
+    void setBinContent(EcalDQMSetupObjects const edso, EcalElectronicsId const &_id, double _content) override {
+      current_->setBinContent(edso, _id, _content);
     }
-    void setBinContent(int _dcctccid, double _content) override { current_->setBinContent(_dcctccid, _content); }
-    void setBinContent(DetId const &_id, int _bin, double _content) override {
-      current_->setBinContent(_id, _bin, _content);
+    void setBinContent(EcalDQMSetupObjects const edso, int _dcctccid, double _content) override { current_->setBinContent(edso, _dcctccid, _content); }
+    void setBinContent(EcalDQMSetupObjects const edso, DetId const &_id, int _bin, double _content) override {
+      current_->setBinContent(edso, _id, _bin, _content);
     }
-    void setBinContent(EcalElectronicsId const &_id, int _bin, double _content) override {
-      current_->setBinContent(_id, _bin, _content);
+    void setBinContent(EcalDQMSetupObjects const edso, EcalElectronicsId const &_id, int _bin, double _content) override {
+      current_->setBinContent(edso, _id, _bin, _content);
     }
-    void setBinContent(int _dcctccid, int _bin, double _content) override {
-      current_->setBinContent(_dcctccid, _bin, _content);
-    }
-
-    void setBinError(DetId const &_id, double _error) override { current_->setBinError(_id, _error); }
-    void setBinError(EcalElectronicsId const &_id, double _error) override { current_->setBinError(_id, _error); }
-    void setBinError(int _dcctccid, double _error) override { current_->setBinError(_dcctccid, _error); }
-    void setBinError(DetId const &_id, int _bin, double _error) override { current_->setBinError(_id, _bin, _error); }
-    void setBinError(EcalElectronicsId const &_id, int _bin, double _error) override {
-      current_->setBinError(_id, _bin, _error);
-    }
-    void setBinError(int _dcctccid, int _bin, double _error) override {
-      current_->setBinError(_dcctccid, _bin, _error);
+    void setBinContent(EcalDQMSetupObjects const edso, int _dcctccid, int _bin, double _content) override {
+      current_->setBinContent(edso, _dcctccid, _bin, _content);
     }
 
-    void setBinEntries(DetId const &_id, double _entries) override { current_->setBinEntries(_id, _entries); }
-    void setBinEntries(EcalElectronicsId const &_id, double _entries) override {
-      current_->setBinEntries(_id, _entries);
+    void setBinError(EcalDQMSetupObjects const edso, DetId const &_id, double _error) override { current_->setBinError(edso, _id, _error); }
+    void setBinError(EcalDQMSetupObjects const edso, EcalElectronicsId const &_id, double _error) override { current_->setBinError(edso, _id, _error); }
+    void setBinError(EcalDQMSetupObjects const edso, int _dcctccid, double _error) override { current_->setBinError(edso, _dcctccid, _error); }
+    void setBinError(EcalDQMSetupObjects const edso, DetId const &_id, int _bin, double _error) override { current_->setBinError(edso, _id, _bin, _error); }
+    void setBinError(EcalDQMSetupObjects const edso, EcalElectronicsId const &_id, int _bin, double _error) override {
+      current_->setBinError(edso, _id, _bin, _error);
     }
-    void setBinEntries(int _dcctccid, double _entries) override { current_->setBinEntries(_dcctccid, _entries); }
-    void setBinEntries(DetId const &_id, int _bin, double _entries) override {
-      current_->setBinEntries(_id, _bin, _entries);
-    }
-    void setBinEntries(EcalElectronicsId const &_id, int _bin, double _entries) override {
-      current_->setBinEntries(_id, _bin, _entries);
-    }
-    void setBinEntries(int _dcctccid, int _bin, double _entries) override {
-      current_->setBinEntries(_dcctccid, _bin, _entries);
+    void setBinError(EcalDQMSetupObjects const edso, int _dcctccid, int _bin, double _error) override {
+      current_->setBinError(edso, _dcctccid, _bin, _error);
     }
 
-    double getBinContent(DetId const &_id, int _bin = 0) const override { return current_->getBinContent(_id, _bin); }
-    double getBinContent(EcalElectronicsId const &_id, int _bin = 0) const override {
-      return current_->getBinContent(_id, _bin);
+    void setBinEntries(EcalDQMSetupObjects const edso, DetId const &_id, double _entries) override { current_->setBinEntries(edso, _id, _entries); }
+    void setBinEntries(EcalDQMSetupObjects const edso, EcalElectronicsId const &_id, double _entries) override {
+      current_->setBinEntries(edso, _id, _entries);
     }
-    double getBinContent(int _dcctccid, int _bin = 0) const override {
-      return current_->getBinContent(_dcctccid, _bin);
+    void setBinEntries(EcalDQMSetupObjects const edso, int _dcctccid, double _entries) override { current_->setBinEntries(edso, _dcctccid, _entries); }
+    void setBinEntries(EcalDQMSetupObjects const edso, DetId const &_id, int _bin, double _entries) override {
+      current_->setBinEntries(edso, _id, _bin, _entries);
     }
-
-    double getBinError(DetId const &_id, int _bin = 0) const override { return current_->getBinError(_id, _bin); }
-    double getBinError(EcalElectronicsId const &_id, int _bin = 0) const override {
-      return current_->getBinError(_id, _bin);
+    void setBinEntries(EcalDQMSetupObjects const edso, EcalElectronicsId const &_id, int _bin, double _entries) override {
+      current_->setBinEntries(edso, _id, _bin, _entries);
     }
-    double getBinError(int _dcctccid, int _bin = 0) const override { return current_->getBinError(_dcctccid, _bin); }
-
-    double getBinEntries(DetId const &_id, int _bin = 0) const override { return current_->getBinEntries(_id, _bin); }
-    double getBinEntries(EcalElectronicsId const &_id, int _bin = 0) const override {
-      return current_->getBinEntries(_id, _bin);
-    }
-    double getBinEntries(int _dcctccid, int _bin = 0) const override {
-      return current_->getBinEntries(_dcctccid, _bin);
+    void setBinEntries(EcalDQMSetupObjects const edso, int _dcctccid, int _bin, double _entries) override {
+      current_->setBinEntries(edso, _dcctccid, _bin, _entries);
     }
 
-    void reset(double = 0., double = 0., double = 0.) override;
+    double getBinContent(EcalDQMSetupObjects const edso, DetId const &_id, int _bin = 0) const override { return current_->getBinContent(edso, _id, _bin); }
+    double getBinContent(EcalDQMSetupObjects const edso, EcalElectronicsId const &_id, int _bin = 0) const override {
+      return current_->getBinContent(edso, _id, _bin);
+    }
+    double getBinContent(EcalDQMSetupObjects const edso, int _dcctccid, int _bin = 0) const override {
+      return current_->getBinContent(edso, _dcctccid, _bin);
+    }
+
+    double getBinError(EcalDQMSetupObjects const edso, DetId const &_id, int _bin = 0) const override { return current_->getBinError(edso, _id, _bin); }
+    double getBinError(EcalDQMSetupObjects const edso, EcalElectronicsId const &_id, int _bin = 0) const override {
+      return current_->getBinError(edso, _id, _bin);
+    }
+    double getBinError(EcalDQMSetupObjects const edso, int _dcctccid, int _bin = 0) const override { return current_->getBinError(edso, _dcctccid, _bin); }
+
+    double getBinEntries(EcalDQMSetupObjects const edso, DetId const &_id, int _bin = 0) const override { return current_->getBinEntries(edso, _id, _bin); }
+    double getBinEntries(EcalDQMSetupObjects const edso, EcalElectronicsId const &_id, int _bin = 0) const override {
+      return current_->getBinEntries(edso, _id, _bin);
+    }
+    double getBinEntries(EcalDQMSetupObjects const edso, int _dcctccid, int _bin = 0) const override {
+      return current_->getBinEntries(edso, _dcctccid, _bin);
+    }
+
+    void reset(EcalElectronicsMapping const *, double = 0., double = 0., double = 0.) override;
     void resetAll(double = 0., double = 0., double = 0.) override;
 
-    bool maskMatches(DetId const &_id, uint32_t _mask, StatusManager const *_statusManager) const override {
-      return current_ && current_->maskMatches(_id, _mask, _statusManager);
+    bool maskMatches(DetId const &_id, uint32_t _mask, StatusManager const *_statusManager, EcalTrigTowerConstituentsMap const *trigTowerMap) const override {
+      return current_ && current_->maskMatches(_id, _mask, _statusManager, trigTowerMap);
     }
 
     bool isVariableBinning() const override { return current_->isVariableBinning(); }
@@ -118,12 +118,12 @@ namespace ecaldqm {
     unsigned getMultiplicity() const { return sets_.size(); }
     unsigned getIndex(PathReplacements const &) const;
 
-    const_iterator begin() const override { return const_iterator(*current_); }
-    const_iterator end() const override { return const_iterator(*current_, -1, -1); }
-    const_iterator beginChannel() const override { return current_->beginChannel(); }
-    iterator begin() override { return iterator(*current_); }
-    iterator end() override { return iterator(*current_, -1, -1); }
-    iterator beginChannel() override { return current_->beginChannel(); }
+    const_iterator begin(EcalElectronicsMapping const *electronicsMap) const override { return const_iterator(electronicsMap, *current_); }
+    const_iterator end(EcalElectronicsMapping const *electronicsMap) const override { return const_iterator(electronicsMap, *current_, -1, -1); }
+    const_iterator beginChannel(EcalElectronicsMapping const *electronicsMap) const override { return current_->beginChannel(electronicsMap); }
+    iterator begin(EcalElectronicsMapping const *electronicsMap) override { return iterator(electronicsMap, *current_); }
+    iterator end(EcalElectronicsMapping const *electronicsMap) override { return iterator(electronicsMap, *current_, -1, -1); }
+    iterator beginChannel(EcalElectronicsMapping const *electronicsMap) override { return current_->beginChannel(electronicsMap); }
 
   protected:
     mutable MESet *current_;

--- a/DQM/EcalCommon/interface/MESetMulti.h
+++ b/DQM/EcalCommon/interface/MESetMulti.h
@@ -26,36 +26,59 @@ namespace ecaldqm {
     bool retrieve(EcalElectronicsMapping const *, DQMStore::IGetter &, std::string * = nullptr) const override;
     void clear() const override;
 
-    void fill(EcalDQMSetupObjects const edso, DetId const &_id, double _xyw = 1., double _yw = 1., double _w = 1.) override {
+    void fill(
+        EcalDQMSetupObjects const edso, DetId const &_id, double _xyw = 1., double _yw = 1., double _w = 1.) override {
       current_->fill(edso, _id, _xyw, _yw, _w);
     }
-    void fill(EcalDQMSetupObjects const edso, EcalElectronicsId const &_id, double _xyw = 1., double _yw = 1., double _w = 1.) override {
+    void fill(EcalDQMSetupObjects const edso,
+              EcalElectronicsId const &_id,
+              double _xyw = 1.,
+              double _yw = 1.,
+              double _w = 1.) override {
       current_->fill(edso, _id, _xyw, _yw, _w);
     }
-    void fill(EcalDQMSetupObjects const edso, int _dcctccid, double _xyw = 1., double _yw = 1., double _w = 1.) override {
+    void fill(
+        EcalDQMSetupObjects const edso, int _dcctccid, double _xyw = 1., double _yw = 1., double _w = 1.) override {
       current_->fill(edso, _dcctccid, _xyw, _yw, _w);
     }
-    void fill(EcalDQMSetupObjects const edso, double _x, double _yw = 1., double _w = 1.) override { current_->fill(edso, _x, _yw, _w); }
+    void fill(EcalDQMSetupObjects const edso, double _x, double _yw = 1., double _w = 1.) override {
+      current_->fill(edso, _x, _yw, _w);
+    }
 
-    void setBinContent(EcalDQMSetupObjects const edso, DetId const &_id, double _content) override { current_->setBinContent(edso, _id, _content); }
+    void setBinContent(EcalDQMSetupObjects const edso, DetId const &_id, double _content) override {
+      current_->setBinContent(edso, _id, _content);
+    }
     void setBinContent(EcalDQMSetupObjects const edso, EcalElectronicsId const &_id, double _content) override {
       current_->setBinContent(edso, _id, _content);
     }
-    void setBinContent(EcalDQMSetupObjects const edso, int _dcctccid, double _content) override { current_->setBinContent(edso, _dcctccid, _content); }
+    void setBinContent(EcalDQMSetupObjects const edso, int _dcctccid, double _content) override {
+      current_->setBinContent(edso, _dcctccid, _content);
+    }
     void setBinContent(EcalDQMSetupObjects const edso, DetId const &_id, int _bin, double _content) override {
       current_->setBinContent(edso, _id, _bin, _content);
     }
-    void setBinContent(EcalDQMSetupObjects const edso, EcalElectronicsId const &_id, int _bin, double _content) override {
+    void setBinContent(EcalDQMSetupObjects const edso,
+                       EcalElectronicsId const &_id,
+                       int _bin,
+                       double _content) override {
       current_->setBinContent(edso, _id, _bin, _content);
     }
     void setBinContent(EcalDQMSetupObjects const edso, int _dcctccid, int _bin, double _content) override {
       current_->setBinContent(edso, _dcctccid, _bin, _content);
     }
 
-    void setBinError(EcalDQMSetupObjects const edso, DetId const &_id, double _error) override { current_->setBinError(edso, _id, _error); }
-    void setBinError(EcalDQMSetupObjects const edso, EcalElectronicsId const &_id, double _error) override { current_->setBinError(edso, _id, _error); }
-    void setBinError(EcalDQMSetupObjects const edso, int _dcctccid, double _error) override { current_->setBinError(edso, _dcctccid, _error); }
-    void setBinError(EcalDQMSetupObjects const edso, DetId const &_id, int _bin, double _error) override { current_->setBinError(edso, _id, _bin, _error); }
+    void setBinError(EcalDQMSetupObjects const edso, DetId const &_id, double _error) override {
+      current_->setBinError(edso, _id, _error);
+    }
+    void setBinError(EcalDQMSetupObjects const edso, EcalElectronicsId const &_id, double _error) override {
+      current_->setBinError(edso, _id, _error);
+    }
+    void setBinError(EcalDQMSetupObjects const edso, int _dcctccid, double _error) override {
+      current_->setBinError(edso, _dcctccid, _error);
+    }
+    void setBinError(EcalDQMSetupObjects const edso, DetId const &_id, int _bin, double _error) override {
+      current_->setBinError(edso, _id, _bin, _error);
+    }
     void setBinError(EcalDQMSetupObjects const edso, EcalElectronicsId const &_id, int _bin, double _error) override {
       current_->setBinError(edso, _id, _bin, _error);
     }
@@ -63,22 +86,31 @@ namespace ecaldqm {
       current_->setBinError(edso, _dcctccid, _bin, _error);
     }
 
-    void setBinEntries(EcalDQMSetupObjects const edso, DetId const &_id, double _entries) override { current_->setBinEntries(edso, _id, _entries); }
+    void setBinEntries(EcalDQMSetupObjects const edso, DetId const &_id, double _entries) override {
+      current_->setBinEntries(edso, _id, _entries);
+    }
     void setBinEntries(EcalDQMSetupObjects const edso, EcalElectronicsId const &_id, double _entries) override {
       current_->setBinEntries(edso, _id, _entries);
     }
-    void setBinEntries(EcalDQMSetupObjects const edso, int _dcctccid, double _entries) override { current_->setBinEntries(edso, _dcctccid, _entries); }
+    void setBinEntries(EcalDQMSetupObjects const edso, int _dcctccid, double _entries) override {
+      current_->setBinEntries(edso, _dcctccid, _entries);
+    }
     void setBinEntries(EcalDQMSetupObjects const edso, DetId const &_id, int _bin, double _entries) override {
       current_->setBinEntries(edso, _id, _bin, _entries);
     }
-    void setBinEntries(EcalDQMSetupObjects const edso, EcalElectronicsId const &_id, int _bin, double _entries) override {
+    void setBinEntries(EcalDQMSetupObjects const edso,
+                       EcalElectronicsId const &_id,
+                       int _bin,
+                       double _entries) override {
       current_->setBinEntries(edso, _id, _bin, _entries);
     }
     void setBinEntries(EcalDQMSetupObjects const edso, int _dcctccid, int _bin, double _entries) override {
       current_->setBinEntries(edso, _dcctccid, _bin, _entries);
     }
 
-    double getBinContent(EcalDQMSetupObjects const edso, DetId const &_id, int _bin = 0) const override { return current_->getBinContent(edso, _id, _bin); }
+    double getBinContent(EcalDQMSetupObjects const edso, DetId const &_id, int _bin = 0) const override {
+      return current_->getBinContent(edso, _id, _bin);
+    }
     double getBinContent(EcalDQMSetupObjects const edso, EcalElectronicsId const &_id, int _bin = 0) const override {
       return current_->getBinContent(edso, _id, _bin);
     }
@@ -86,13 +118,19 @@ namespace ecaldqm {
       return current_->getBinContent(edso, _dcctccid, _bin);
     }
 
-    double getBinError(EcalDQMSetupObjects const edso, DetId const &_id, int _bin = 0) const override { return current_->getBinError(edso, _id, _bin); }
+    double getBinError(EcalDQMSetupObjects const edso, DetId const &_id, int _bin = 0) const override {
+      return current_->getBinError(edso, _id, _bin);
+    }
     double getBinError(EcalDQMSetupObjects const edso, EcalElectronicsId const &_id, int _bin = 0) const override {
       return current_->getBinError(edso, _id, _bin);
     }
-    double getBinError(EcalDQMSetupObjects const edso, int _dcctccid, int _bin = 0) const override { return current_->getBinError(edso, _dcctccid, _bin); }
+    double getBinError(EcalDQMSetupObjects const edso, int _dcctccid, int _bin = 0) const override {
+      return current_->getBinError(edso, _dcctccid, _bin);
+    }
 
-    double getBinEntries(EcalDQMSetupObjects const edso, DetId const &_id, int _bin = 0) const override { return current_->getBinEntries(edso, _id, _bin); }
+    double getBinEntries(EcalDQMSetupObjects const edso, DetId const &_id, int _bin = 0) const override {
+      return current_->getBinEntries(edso, _id, _bin);
+    }
     double getBinEntries(EcalDQMSetupObjects const edso, EcalElectronicsId const &_id, int _bin = 0) const override {
       return current_->getBinEntries(edso, _id, _bin);
     }
@@ -103,7 +141,10 @@ namespace ecaldqm {
     void reset(EcalElectronicsMapping const *, double = 0., double = 0., double = 0.) override;
     void resetAll(double = 0., double = 0., double = 0.) override;
 
-    bool maskMatches(DetId const &_id, uint32_t _mask, StatusManager const *_statusManager, EcalTrigTowerConstituentsMap const *trigTowerMap) const override {
+    bool maskMatches(DetId const &_id,
+                     uint32_t _mask,
+                     StatusManager const *_statusManager,
+                     EcalTrigTowerConstituentsMap const *trigTowerMap) const override {
       return current_ && current_->maskMatches(_id, _mask, _statusManager, trigTowerMap);
     }
 
@@ -118,12 +159,24 @@ namespace ecaldqm {
     unsigned getMultiplicity() const { return sets_.size(); }
     unsigned getIndex(PathReplacements const &) const;
 
-    const_iterator begin(EcalElectronicsMapping const *electronicsMap) const override { return const_iterator(electronicsMap, *current_); }
-    const_iterator end(EcalElectronicsMapping const *electronicsMap) const override { return const_iterator(electronicsMap, *current_, -1, -1); }
-    const_iterator beginChannel(EcalElectronicsMapping const *electronicsMap) const override { return current_->beginChannel(electronicsMap); }
-    iterator begin(EcalElectronicsMapping const *electronicsMap) override { return iterator(electronicsMap, *current_); }
-    iterator end(EcalElectronicsMapping const *electronicsMap) override { return iterator(electronicsMap, *current_, -1, -1); }
-    iterator beginChannel(EcalElectronicsMapping const *electronicsMap) override { return current_->beginChannel(electronicsMap); }
+    const_iterator begin(EcalElectronicsMapping const *electronicsMap) const override {
+      return const_iterator(electronicsMap, *current_);
+    }
+    const_iterator end(EcalElectronicsMapping const *electronicsMap) const override {
+      return const_iterator(electronicsMap, *current_, -1, -1);
+    }
+    const_iterator beginChannel(EcalElectronicsMapping const *electronicsMap) const override {
+      return current_->beginChannel(electronicsMap);
+    }
+    iterator begin(EcalElectronicsMapping const *electronicsMap) override {
+      return iterator(electronicsMap, *current_);
+    }
+    iterator end(EcalElectronicsMapping const *electronicsMap) override {
+      return iterator(electronicsMap, *current_, -1, -1);
+    }
+    iterator beginChannel(EcalElectronicsMapping const *electronicsMap) override {
+      return current_->beginChannel(electronicsMap);
+    }
 
   protected:
     mutable MESet *current_;

--- a/DQM/EcalCommon/interface/MESetNonObject.h
+++ b/DQM/EcalCommon/interface/MESetNonObject.h
@@ -20,26 +20,26 @@ namespace ecaldqm {
 
     MESet *clone(std::string const & = "") const override;
 
-    void book(DQMStore::IBooker &) override;
-    bool retrieve(DQMStore::IGetter &, std::string * = nullptr) const override;
+    void book(DQMStore::IBooker &, EcalElectronicsMapping const *) override;
+    bool retrieve(EcalElectronicsMapping const *, DQMStore::IGetter &, std::string * = nullptr) const override;
 
-    void fill(double, double = 1., double = 1.) override;
+    void fill(EcalDQMSetupObjects const, double, double = 1., double = 1.) override;
 
-    void setBinContent(int, double) override;
+    void setBinContent(EcalDQMSetupObjects const, int, double) override;
 
-    void setBinError(int, double) override;
+    void setBinError(EcalDQMSetupObjects const, int, double) override;
 
-    void setBinEntries(int, double) override;
+    void setBinEntries(EcalDQMSetupObjects const, int, double) override;
 
-    double getBinContent(int, int = 0) const override;
+    double getBinContent(EcalDQMSetupObjects const, int, int = 0) const override;
 
     double getFloatValue() const;
 
-    double getBinError(int, int = 0) const override;
+    double getBinError(EcalDQMSetupObjects const, int, int = 0) const override;
 
-    double getBinEntries(int, int = 0) const override;
+    double getBinEntries(EcalDQMSetupObjects const, int, int = 0) const override;
 
-    int findBin(double, double = 0.) const;
+    int findBin(EcalDQMSetupObjects const, double, double = 0.) const;
 
     bool isVariableBinning() const override;
 

--- a/DQM/EcalCommon/interface/MESetProjection.h
+++ b/DQM/EcalCommon/interface/MESetProjection.h
@@ -21,27 +21,27 @@ namespace ecaldqm {
 
     MESet *clone(std::string const & = "") const override;
 
-    void fill(DetId const &, double = 1., double = 0., double = 0.) override;
-    void fill(int, double = 1., double = 1., double = 0.) override;
-    void fill(double, double = 1., double = 0.) override;
+    void fill(EcalDQMSetupObjects const, DetId const &, double = 1., double = 0., double = 0.) override;
+    void fill(EcalDQMSetupObjects const, int, double = 1., double = 1., double = 0.) override;
+    void fill(EcalDQMSetupObjects const, double, double = 1., double = 0.) override;
 
     using MESetEcal::setBinContent;
-    void setBinContent(DetId const &, double) override;
+    void setBinContent(EcalDQMSetupObjects const, DetId const &, double) override;
 
     using MESetEcal::setBinError;
-    void setBinError(DetId const &, double) override;
+    void setBinError(EcalDQMSetupObjects const, DetId const &, double) override;
 
     using MESetEcal::setBinEntries;
-    void setBinEntries(DetId const &, double) override;
+    void setBinEntries(EcalDQMSetupObjects const, DetId const &, double) override;
 
     using MESetEcal::getBinContent;
-    double getBinContent(DetId const &, int = 0) const override;
+    double getBinContent(EcalDQMSetupObjects const, DetId const &, int = 0) const override;
 
     using MESetEcal::getBinError;
-    double getBinError(DetId const &, int = 0) const override;
+    double getBinError(EcalDQMSetupObjects const, DetId const &, int = 0) const override;
 
     using MESetEcal::getBinEntries;
-    double getBinEntries(DetId const &, int = 0) const override;
+    double getBinEntries(EcalDQMSetupObjects const, DetId const &, int = 0) const override;
   };
 }  // namespace ecaldqm
 

--- a/DQM/EcalCommon/interface/MESetTrend.h
+++ b/DQM/EcalCommon/interface/MESetTrend.h
@@ -24,17 +24,17 @@ namespace ecaldqm {
 
     MESet *clone(std::string const & = "") const override;
 
-    void book(DQMStore::IBooker &) override;
+    void book(DQMStore::IBooker &, EcalElectronicsMapping const *) override;
 
-    void fill(DetId const &, double, double = 1., double = 1.) override;
-    void fill(EcalElectronicsId const &, double, double = 1., double = 1.) override;
-    void fill(int, double, double = 1., double = 1.) override;
-    void fill(double, double = 1., double = 1.) override;
+    void fill(EcalDQMSetupObjects const, DetId const &, double, double = 1., double = 1.) override;
+    void fill(EcalDQMSetupObjects const, EcalElectronicsId const &, double, double = 1., double = 1.) override;
+    void fill(EcalDQMSetupObjects const, int, double, double = 1., double = 1.) override;
+    void fill(EcalDQMSetupObjects const, double, double = 1., double = 1.) override;
 
-    int findBin(DetId const &, double, double = 0.) const override;
-    int findBin(EcalElectronicsId const &, double, double = 0.) const override;
-    int findBin(int, double, double = 0.) const override;
-    int findBin(double, double = 0.) const;
+    int findBin(EcalDQMSetupObjects const, DetId const &, double, double = 0.) const override;
+    int findBin(EcalDQMSetupObjects const, EcalElectronicsId const &, double, double = 0.) const override;
+    int findBin(EcalDQMSetupObjects const, int, double, double = 0.) const override;
+    int findBin(EcalDQMSetupObjects const, double, double = 0.) const;
 
     bool isVariableBinning() const override { return true; }
 

--- a/DQM/EcalCommon/interface/StatusManager.h
+++ b/DQM/EcalCommon/interface/StatusManager.h
@@ -9,6 +9,8 @@
 #include "CondFormats/EcalObjects/interface/EcalDQMChannelStatus.h"
 #include "CondFormats/EcalObjects/interface/EcalDQMTowerStatus.h"
 
+#include "Geometry/EcalMapping/interface/EcalElectronicsMapping.h"
+
 namespace ecaldqm {
 
   class StatusManager {
@@ -16,7 +18,7 @@ namespace ecaldqm {
     StatusManager();
     ~StatusManager() {}
 
-    void readFromStream(std::istream &);
+    void readFromStream(std::istream &, EcalElectronicsMapping const *);
     void readFromObj(EcalDQMChannelStatus const &, EcalDQMTowerStatus const &);
     void writeToStream(std::ostream &) const;
     void writeToObj(EcalDQMChannelStatus &, EcalDQMTowerStatus &) const;

--- a/DQM/EcalCommon/plugins/EcalMEFormatter.cc
+++ b/DQM/EcalCommon/plugins/EcalMEFormatter.cc
@@ -27,7 +27,8 @@ void EcalMEFormatter::fillDescriptions(edm::ConfigurationDescriptions &_descs) {
 void EcalMEFormatter::dqmEndLuminosityBlock(DQMStore::IBooker &,
                                             DQMStore::IGetter &_igetter,
                                             edm::LuminosityBlock const &,
-                                            edm::EventSetup const &) {
+                                            edm::EventSetup const &_es) {
+  setSetupObjects(_es);
   format_(_igetter, true);
 }
 
@@ -40,7 +41,7 @@ void EcalMEFormatter::format_(DQMStore::IGetter &_igetter, bool _checkLumi) {
     if (_checkLumi && !mItr.second->getLumiFlag())
       continue;
     mItr.second->clear();
-    if (!mItr.second->retrieve(_igetter, &failedPath)) {
+    if (!mItr.second->retrieve(GetElectronicsMap(), _igetter, &failedPath)) {
       if (verbosity_ > 0)
         edm::LogWarning("EcalDQM") << "Could not find ME " << mItr.first << "@" << failedPath;
       continue;

--- a/DQM/EcalCommon/src/DQWorker.cc
+++ b/DQM/EcalCommon/src/DQWorker.cc
@@ -9,9 +9,14 @@
 
 #include "DataFormats/Provenance/interface/EventID.h"
 
+#include "Geometry/EcalMapping/interface/EcalMappingRcd.h"
+#include "Geometry/Records/interface/CaloGeometryRecord.h"
+#include "Geometry/Records/interface/CaloTopologyRecord.h"
+#include "Geometry/Records/interface/IdealGeometryRecord.h"
+
 namespace ecaldqm {
   DQWorker::DQWorker()
-      : name_(""), MEs_(), booked_(false), timestamp_(), verbosity_(0), onlineMode_(false), willConvertToEDM_(true) {}
+      : name_(""), MEs_(), booked_(false), timestamp_(), verbosity_(0), onlineMode_(false), willConvertToEDM_(true), edso_() {}
 
   DQWorker::~DQWorker() noexcept(false) {}
 
@@ -67,8 +72,62 @@ namespace ecaldqm {
     if (booked_)
       return;
     for (MESetCollection::iterator mItr(MEs_.begin()); mItr != MEs_.end(); ++mItr)
-      mItr->second->book(_booker);
+      mItr->second->book(_booker, GetElectronicsMap());
     booked_ = true;
+  }
+
+  void DQWorker::setSetupObjects(edm::EventSetup const &_es) {
+     edm::ESHandle<EcalElectronicsMapping> elecMapHandle;
+    _es.get<EcalMappingRcd>().get(elecMapHandle);
+    edso_.electronicsMap = elecMapHandle.product();
+
+    edm::ESHandle<EcalTrigTowerConstituentsMap> ttMapHandle;
+    _es.get<IdealGeometryRecord>().get(ttMapHandle);
+    edso_.trigtowerMap = ttMapHandle.product();
+
+    edm::ESHandle<CaloGeometry> geomHandle;
+    _es.get<CaloGeometryRecord>().get(geomHandle);
+    edso_.geometry = geomHandle.product();
+
+    edm::ESHandle<CaloTopology> topoHandle;
+    _es.get<CaloTopologyRecord>().get(topoHandle);
+    edso_.topology = topoHandle.product();
+  }
+
+  EcalElectronicsMapping const * DQWorker::GetElectronicsMap() {
+    if (!edso_.electronicsMap)
+      throw cms::Exception("InvalidCall") << "Electronics Mapping not initialized";
+    return edso_.electronicsMap;
+  }
+
+  EcalTrigTowerConstituentsMap const * DQWorker::GetTrigTowerMap() {
+    if (!edso_.trigtowerMap)
+      throw cms::Exception("InvalidCall") << "TrigTowerConstituentsMap not initialized";
+    return edso_.trigtowerMap;
+  }
+
+  CaloGeometry const * DQWorker::GetGeometry() {
+    if (!edso_.geometry)
+      throw cms::Exception("InvalidCall") << "CaloGeometry not initialized";
+    return edso_.geometry;
+  }
+
+  CaloTopology const * DQWorker::GetTopology() {
+    if (!edso_.topology)
+      throw cms::Exception("InvalidCall") << "CaloTopology not initialized";
+    return edso_.topology;
+  }
+
+  EcalDQMSetupObjects const DQWorker::getEcalDQMSetupObjects() {
+      if (!edso_.electronicsMap)
+        throw cms::Exception("InvalidCall") << "Electronics Mapping not initialized";
+      if (!edso_.trigtowerMap)
+        throw cms::Exception("InvalidCall") << "TrigTowerConstituentsMap not initialized";
+      if (!edso_.geometry)
+        throw cms::Exception("InvalidCall") << "CaloGeometry not initialized";
+      if (!edso_.topology)
+        throw cms::Exception("InvalidCall") << "CaloTopology not initialized";
+      return edso_;
   }
 
   void DQWorker::print_(std::string const &_message, int _threshold /* = 0*/) const {

--- a/DQM/EcalCommon/src/DQWorker.cc
+++ b/DQM/EcalCommon/src/DQWorker.cc
@@ -16,7 +16,14 @@
 
 namespace ecaldqm {
   DQWorker::DQWorker()
-      : name_(""), MEs_(), booked_(false), timestamp_(), verbosity_(0), onlineMode_(false), willConvertToEDM_(true), edso_() {}
+      : name_(""),
+        MEs_(),
+        booked_(false),
+        timestamp_(),
+        verbosity_(0),
+        onlineMode_(false),
+        willConvertToEDM_(true),
+        edso_() {}
 
   DQWorker::~DQWorker() noexcept(false) {}
 
@@ -77,7 +84,7 @@ namespace ecaldqm {
   }
 
   void DQWorker::setSetupObjects(edm::EventSetup const &_es) {
-     edm::ESHandle<EcalElectronicsMapping> elecMapHandle;
+    edm::ESHandle<EcalElectronicsMapping> elecMapHandle;
     _es.get<EcalMappingRcd>().get(elecMapHandle);
     edso_.electronicsMap = elecMapHandle.product();
 
@@ -94,40 +101,40 @@ namespace ecaldqm {
     edso_.topology = topoHandle.product();
   }
 
-  EcalElectronicsMapping const * DQWorker::GetElectronicsMap() {
+  EcalElectronicsMapping const *DQWorker::GetElectronicsMap() {
     if (!edso_.electronicsMap)
       throw cms::Exception("InvalidCall") << "Electronics Mapping not initialized";
     return edso_.electronicsMap;
   }
 
-  EcalTrigTowerConstituentsMap const * DQWorker::GetTrigTowerMap() {
+  EcalTrigTowerConstituentsMap const *DQWorker::GetTrigTowerMap() {
     if (!edso_.trigtowerMap)
       throw cms::Exception("InvalidCall") << "TrigTowerConstituentsMap not initialized";
     return edso_.trigtowerMap;
   }
 
-  CaloGeometry const * DQWorker::GetGeometry() {
+  CaloGeometry const *DQWorker::GetGeometry() {
     if (!edso_.geometry)
       throw cms::Exception("InvalidCall") << "CaloGeometry not initialized";
     return edso_.geometry;
   }
 
-  CaloTopology const * DQWorker::GetTopology() {
+  CaloTopology const *DQWorker::GetTopology() {
     if (!edso_.topology)
       throw cms::Exception("InvalidCall") << "CaloTopology not initialized";
     return edso_.topology;
   }
 
   EcalDQMSetupObjects const DQWorker::getEcalDQMSetupObjects() {
-      if (!edso_.electronicsMap)
-        throw cms::Exception("InvalidCall") << "Electronics Mapping not initialized";
-      if (!edso_.trigtowerMap)
-        throw cms::Exception("InvalidCall") << "TrigTowerConstituentsMap not initialized";
-      if (!edso_.geometry)
-        throw cms::Exception("InvalidCall") << "CaloGeometry not initialized";
-      if (!edso_.topology)
-        throw cms::Exception("InvalidCall") << "CaloTopology not initialized";
-      return edso_;
+    if (!edso_.electronicsMap)
+      throw cms::Exception("InvalidCall") << "Electronics Mapping not initialized";
+    if (!edso_.trigtowerMap)
+      throw cms::Exception("InvalidCall") << "TrigTowerConstituentsMap not initialized";
+    if (!edso_.geometry)
+      throw cms::Exception("InvalidCall") << "CaloGeometry not initialized";
+    if (!edso_.topology)
+      throw cms::Exception("InvalidCall") << "CaloTopology not initialized";
+    return edso_;
   }
 
   void DQWorker::print_(std::string const &_message, int _threshold /* = 0*/) const {

--- a/DQM/EcalCommon/src/EcalDQMCommonUtils2.cc
+++ b/DQM/EcalCommon/src/EcalDQMCommonUtils2.cc
@@ -7,7 +7,7 @@
 #include "CalibCalorimetry/EcalLaserAnalyzer/interface/MEEEGeom.h"
 
 namespace ecaldqm {
-  EcalPnDiodeDetId pnForCrystal(DetId const &_id, char _ab) {
+  EcalPnDiodeDetId pnForCrystal(DetId const &_id, char _ab, const EcalElectronicsMapping *electronicsMap) {
     bool pnA(_ab == 'a' || _ab == 'A');
 
     if (!isCrystalId(_id))
@@ -17,7 +17,7 @@ namespace ecaldqm {
       EBDetId ebid(_id);
       int lmmod(MEEBGeom::lmmod(ebid.ieta(), ebid.iphi()));
 
-      switch (dccId(_id)) {
+      switch (dccId(_id, electronicsMap)) {
         case 10:
           switch (lmmod) {
             case 1:

--- a/DQM/EcalCommon/src/EcalDQMonitor.cc
+++ b/DQM/EcalCommon/src/EcalDQMonitor.cc
@@ -61,29 +61,6 @@ namespace ecaldqm {
     _desc.addUntracked("commonParameters", commonParameters);
   }
 
-  void EcalDQMonitor::ecaldqmGetSetupObjects(edm::EventSetup const &_es) {
-    // NB: a more minimal solution may rely on ESWatchers
-    //    but then here the cost is rather minimal
-    // set up electronicsMap in EcalDQMCommonUtils
-    edm::ESHandle<EcalElectronicsMapping> elecMapHandle;
-    _es.get<EcalMappingRcd>().get(elecMapHandle);
-    setElectronicsMap(elecMapHandle.product());
-
-    // set up trigTowerMap in EcalDQMCommonUtils
-    edm::ESHandle<EcalTrigTowerConstituentsMap> ttMapHandle;
-    _es.get<IdealGeometryRecord>().get(ttMapHandle);
-    setTrigTowerMap(ttMapHandle.product());
-
-    edm::ESHandle<CaloGeometry> geomHandle;
-    _es.get<CaloGeometryRecord>().get(geomHandle);
-    setGeometry(geomHandle.product());
-
-    // set up trigTowerMap in EcalDQMCommonUtils
-    edm::ESHandle<CaloTopology> topoHandle;
-    _es.get<CaloTopologyRecord>().get(topoHandle);
-    setTopology(topoHandle.product());
-  }
-
   void EcalDQMonitor::ecaldqmBeginRun(edm::Run const &_run, edm::EventSetup const &_es) {
     executeOnWorkers_(
         [&_run, &_es](DQWorker *worker) {

--- a/DQM/EcalCommon/src/MESet.cc
+++ b/DQM/EcalCommon/src/MESet.cc
@@ -95,7 +95,7 @@ namespace ecaldqm {
       mes_[iME]->setAxisTitle(_title, _axis);
   }
 
-  void MESet::reset(double _content /* = 0.*/, double _err /* = 0.*/, double _entries /* = 0.*/) {
+  void MESet::reset(EcalElectronicsMapping const *electronicsMap, double _content /* = 0.*/, double _err /* = 0.*/, double _entries /* = 0.*/) {
     if (!active_)
       return;
 
@@ -164,7 +164,7 @@ namespace ecaldqm {
     return path.Data();
   }
 
-  bool MESet::maskMatches(DetId const &_id, uint32_t _mask, StatusManager const *_statusManager) const {
+  bool MESet::maskMatches(DetId const &_id, uint32_t _mask, StatusManager const *_statusManager, EcalTrigTowerConstituentsMap const *trigTowerMap) const {
     if (!_statusManager)
       return false;
 
@@ -187,7 +187,7 @@ namespace ecaldqm {
           return true;
 
         if (searchNeighborsInTower) {
-          std::vector<DetId> ids(getTrigTowerMap()->constituentsOf(ttId));
+          std::vector<DetId> ids(trigTowerMap->constituentsOf(ttId));
           for (std::vector<DetId>::iterator idItr(ids.begin()); idItr != ids.end(); ++idItr)
             if ((_statusManager->getStatus(idItr->rawId()) & _mask) != 0)
               return true;
@@ -230,7 +230,7 @@ namespace ecaldqm {
 
       case EcalTriggerTower: {
         EcalTrigTowerDetId ttId(_id);
-        std::vector<DetId> ids(getTrigTowerMap()->constituentsOf(ttId));
+        std::vector<DetId> ids(trigTowerMap->constituentsOf(ttId));
         for (std::vector<DetId>::iterator idItr(ids.begin()); idItr != ids.end(); ++idItr)
           if ((_statusManager->getStatus(idItr->rawId()) & _mask) != 0)
             return true;
@@ -334,14 +334,14 @@ namespace ecaldqm {
     return *this;
   }
 
-  MESet::const_iterator::const_iterator(MESet const &_meSet, DetId const &_id) : bin_() {
+  MESet::const_iterator::const_iterator(EcalElectronicsMapping const *electronicsMap, MESet const &_meSet, DetId const &_id) : bin_() {
     binning::ObjectType otype(_meSet.getObjType());
-    unsigned iME(binning::findPlotIndex(otype, _id));
+    unsigned iME(binning::findPlotIndex(electronicsMap, otype, _id));
     if (iME == unsigned(-1))
       return;
 
     binning::BinningType btype(_meSet.getBinType());
-    int bin(binning::findBin2D(otype, btype, _id));
+    int bin(binning::findBin2D(electronicsMap, otype, btype, _id));
     if (bin == 0)
       return;
 
@@ -401,12 +401,12 @@ namespace ecaldqm {
     return *this;
   }
 
-  MESet::const_iterator &MESet::const_iterator::toNextChannel() {
+  MESet::const_iterator &MESet::const_iterator::toNextChannel(const EcalElectronicsMapping *electronicsMap) {
     if (!bin_.getMESet())
       return *this;
     do
       operator++();
-    while (bin_.iME != unsigned(-1) && !bin_.isChannel());
+    while (bin_.iME != unsigned(-1) && !bin_.isChannel(electronicsMap));
 
     return *this;
   }

--- a/DQM/EcalCommon/src/MESet.cc
+++ b/DQM/EcalCommon/src/MESet.cc
@@ -95,7 +95,10 @@ namespace ecaldqm {
       mes_[iME]->setAxisTitle(_title, _axis);
   }
 
-  void MESet::reset(EcalElectronicsMapping const *electronicsMap, double _content /* = 0.*/, double _err /* = 0.*/, double _entries /* = 0.*/) {
+  void MESet::reset(EcalElectronicsMapping const *electronicsMap,
+                    double _content /* = 0.*/,
+                    double _err /* = 0.*/,
+                    double _entries /* = 0.*/) {
     if (!active_)
       return;
 
@@ -164,7 +167,10 @@ namespace ecaldqm {
     return path.Data();
   }
 
-  bool MESet::maskMatches(DetId const &_id, uint32_t _mask, StatusManager const *_statusManager, EcalTrigTowerConstituentsMap const *trigTowerMap) const {
+  bool MESet::maskMatches(DetId const &_id,
+                          uint32_t _mask,
+                          StatusManager const *_statusManager,
+                          EcalTrigTowerConstituentsMap const *trigTowerMap) const {
     if (!_statusManager)
       return false;
 
@@ -334,7 +340,10 @@ namespace ecaldqm {
     return *this;
   }
 
-  MESet::const_iterator::const_iterator(EcalElectronicsMapping const *electronicsMap, MESet const &_meSet, DetId const &_id) : bin_() {
+  MESet::const_iterator::const_iterator(EcalElectronicsMapping const *electronicsMap,
+                                        MESet const &_meSet,
+                                        DetId const &_id)
+      : bin_() {
     binning::ObjectType otype(_meSet.getObjType());
     unsigned iME(binning::findPlotIndex(electronicsMap, otype, _id));
     if (iME == unsigned(-1))

--- a/DQM/EcalCommon/src/MESetBinningUtils.cc
+++ b/DQM/EcalCommon/src/MESetBinningUtils.cc
@@ -11,7 +11,7 @@
 
 namespace ecaldqm {
   namespace binning {
-    AxisSpecs getBinning(ObjectType _otype, BinningType _btype, bool _isMap, int _axis, unsigned _iME) {
+    AxisSpecs getBinning(EcalElectronicsMapping const *electronicsMap, ObjectType _otype, BinningType _btype, bool _isMap, int _axis, unsigned _iME) {
       if (_otype >= nObjType || _btype >= unsigned(nPresetBinnings))
         return AxisSpecs();  // you are on your own
 
@@ -25,14 +25,14 @@ namespace ecaldqm {
         case kEEp:
           return getBinningEE_(_btype, _isMap, 1, _axis);
         case kSM:
-          return getBinningSM_(_btype, _isMap, _iME, _axis);
+          return getBinningSM_(_btype, _isMap, _iME, _axis, electronicsMap);
         case kEBSM:
-          return getBinningSM_(_btype, _isMap, _iME + 9, _axis);
+          return getBinningSM_(_btype, _isMap, _iME + 9, _axis, electronicsMap);
         case kEESM:
           if (_iME <= kEEmHigh)
-            return getBinningSM_(_btype, _isMap, _iME, _axis);
+            return getBinningSM_(_btype, _isMap, _iME, _axis, electronicsMap);
           else
-            return getBinningSM_(_btype, _isMap, _iME + nEBDCC, _axis);
+            return getBinningSM_(_btype, _isMap, _iME + nEBDCC, _axis, electronicsMap);
         case kSMMEM:
           return getBinningSMMEM_(_btype, _isMap, _iME, _axis);
         case kEBSMMEM:
@@ -55,17 +55,17 @@ namespace ecaldqm {
       }
     }
 
-    int findBin1D(ObjectType _otype, BinningType _btype, const DetId &_id) {
+    int findBin1D(EcalElectronicsMapping const *electronicsMap, ObjectType _otype, BinningType _btype, const DetId &_id) {
       switch (_otype) {
         case kSM:
         case kEBSM:
         case kEESM:
           if (_btype == kSuperCrystal)
-            return towerId(_id);
+            return towerId(_id, electronicsMap);
           else if (_btype == kTriggerTower) {
-            unsigned tccid(tccId(_id));
+            unsigned tccid(tccId(_id, electronicsMap));
             if (tccid <= 36 || tccid >= 73) {  // EE
-              unsigned bin(ttId(_id));
+              unsigned bin(ttId(_id, electronicsMap));
               bool outer((tccid >= 19 && tccid <= 36) || (tccid >= 73 && tccid <= 90));
               // For the following, the constants nTTInner and nTTOuter are defined in
               // EcalDQMCommonUtils.h.
@@ -80,45 +80,45 @@ namespace ecaldqm {
               // outer2.
               return bin;
             } else
-              return ttId(_id);
+              return ttId(_id, electronicsMap);
           } else
             break;
         case kEcal:
           if (_btype == kDCC)
-            return dccId(_id);
+            return dccId(_id, electronicsMap);
           else if (_btype == kTCC)
-            return tccId(_id);
+            return tccId(_id, electronicsMap);
           else
             break;
         case kEB:
           if (_btype == kDCC)
-            return dccId(_id) - 9;
+            return dccId(_id, electronicsMap) - 9;
           else if (_btype == kTCC)
-            return tccId(_id) - 36;
+            return tccId(_id, electronicsMap) - 36;
           else
             break;
         case kEEm:
           if (_btype == kDCC)
-            return dccId(_id);
+            return dccId(_id, electronicsMap);
           else if (_btype == kTCC)
-            return tccId(_id);
+            return tccId(_id, electronicsMap);
           else
             break;
         case kEEp:
           if (_btype == kDCC)
-            return dccId(_id) - 45;
+            return dccId(_id, electronicsMap) - 45;
           else if (_btype == kTCC)
-            return tccId(_id) - 72;
+            return tccId(_id, electronicsMap) - 72;
           else
             break;
         case kEE:
           if (_btype == kDCC) {
-            int bin(dccId(_id));
+            int bin(dccId(_id, electronicsMap));
             if (bin >= 46)
               bin -= 36;
             return bin;
           } else if (_btype == kTCC) {
-            int bin(tccId(_id));
+            int bin(tccId(_id, electronicsMap));
             if (bin >= 72)
               bin -= 36;
             return bin;
@@ -138,7 +138,7 @@ namespace ecaldqm {
       return 0;
     }
 
-    int findBin1D(ObjectType _otype, BinningType _btype, const EcalElectronicsId &_id) {
+    int findBin1D(EcalElectronicsMapping const *electronicsMap, ObjectType _otype, BinningType _btype, const EcalElectronicsId &_id) {
       switch (_otype) {
         case kSM:
         case kEBSM:
@@ -146,9 +146,9 @@ namespace ecaldqm {
           if (_btype == kSuperCrystal)
             return towerId(_id);
           else if (_btype == kTriggerTower) {
-            unsigned tccid(tccId(_id));
+            unsigned tccid(tccId(_id, electronicsMap));
             if (tccid <= 36 || tccid >= 73) {  // EE
-              unsigned bin(ttId(_id));
+              unsigned bin(ttId(_id, electronicsMap));
               bool outer((tccid >= 19 && tccid <= 36) || (tccid >= 73 && tccid <= 90));
               // For the following, the constants nTTInner and nTTOuter are defined in
               // EcalDQMCommonUtils.h.
@@ -163,35 +163,35 @@ namespace ecaldqm {
               // outer2.
               return bin;
             } else
-              return ttId(_id);
+              return ttId(_id, electronicsMap);
           } else
             break;
         case kEcal:
           if (_btype == kDCC)
             return dccId(_id);
           else if (_btype == kTCC)
-            return tccId(_id);
+            return tccId(_id, electronicsMap);
           else
             break;
         case kEB:
           if (_btype == kDCC)
             return dccId(_id) - 9;
           else if (_btype == kTCC)
-            return tccId(_id) - 36;
+            return tccId(_id, electronicsMap) - 36;
           else
             break;
         case kEEm:
           if (_btype == kDCC)
             return dccId(_id);
           else if (_btype == kTCC)
-            return tccId(_id);
+            return tccId(_id, electronicsMap);
           else
             break;
         case kEEp:
           if (_btype == kDCC)
             return dccId(_id) - 45;
           else if (_btype == kTCC)
-            return tccId(_id) - 72;
+            return tccId(_id, electronicsMap) - 72;
           else
             break;
         case kEE:
@@ -201,7 +201,7 @@ namespace ecaldqm {
               bin -= 36;
             return bin;
           } else if (_btype == kTCC) {
-            int bin(tccId(_id));
+            int bin(tccId(_id, electronicsMap));
             if (bin >= 72)
               bin -= 36;
             return bin;
@@ -214,7 +214,7 @@ namespace ecaldqm {
       return 0;
     }
 
-    int findBin1D(ObjectType _otype, BinningType _btype, int _dcctccid) {
+    int findBin1D(EcalElectronicsMapping const *electronicsMap, ObjectType _otype, BinningType _btype, int _dcctccid) {
       if (_otype == kEcal && _btype == kDCC)
         return _dcctccid;
       else if (_otype == kEcal && _btype == kTCC)
@@ -239,22 +239,22 @@ namespace ecaldqm {
       return 0;
     }
 
-    int findBin2D(ObjectType _otype, BinningType _btype, const DetId &_id) {
+    int findBin2D(EcalElectronicsMapping const *electronicsMap, ObjectType _otype, BinningType _btype, const DetId &_id) {
       if (_otype >= nObjType || _btype >= unsigned(nPresetBinnings))
         return 0;
 
       switch (_btype) {
         case kCrystal:
-          return findBinCrystal_(_otype, _id);
+          return findBinCrystal_(electronicsMap, _otype, _id);
           break;
         case kTriggerTower:
-          return findBinTriggerTower_(_otype, _id);
+          return findBinTriggerTower_(electronicsMap, _otype, _id);
           break;
         case kSuperCrystal:
-          return findBinSuperCrystal_(_otype, _id);
+          return findBinSuperCrystal_(electronicsMap, _otype, _id);
           break;
         case kPseudoStrip:
-          return findBinPseudoStrip_(_otype, _id);
+          return findBinPseudoStrip_(electronicsMap, _otype, _id);
           break;
         case kRCT:
           return findBinRCT_(_otype, _id);
@@ -264,23 +264,23 @@ namespace ecaldqm {
       }
     }
 
-    int findBin2D(ObjectType _otype, BinningType _btype, const EcalElectronicsId &_id) {
+    int findBin2D(EcalElectronicsMapping const *electronicsMap, ObjectType _otype, BinningType _btype, const EcalElectronicsId &_id) {
       if (_otype >= nObjType || _btype >= unsigned(nPresetBinnings))
         return 0;
 
       switch (_btype) {
         case kCrystal:
-          return findBinCrystal_(_otype, _id);
+          return findBinCrystal_(electronicsMap, _otype, _id);
           break;
         case kSuperCrystal:
-          return findBinSuperCrystal_(_otype, _id);
+          return findBinSuperCrystal_(electronicsMap, _otype, _id);
           break;
         default:
           return 0;
       }
     }
 
-    int findBin2D(ObjectType _otype, BinningType _btype, int _dccid) {
+    int findBin2D(EcalElectronicsMapping const *electronicsMap, ObjectType _otype, BinningType _btype, int _dccid) {
       if (_otype != kEcal || _btype != kDCC)
         return 0;
 
@@ -296,7 +296,7 @@ namespace ecaldqm {
       return (nbinsX + 2) * ybin + xbin;
     }
 
-    unsigned findPlotIndex(ObjectType _otype, const DetId &_id) {
+    unsigned findPlotIndex(EcalElectronicsMapping const *electronicsMap, ObjectType _otype, const DetId &_id) {
       if (getNObjects(_otype) == 1)
         return 0;
 
@@ -334,7 +334,7 @@ namespace ecaldqm {
 
         case kMEM2P:
           if (_id.subdetId() == EcalLaserPnDiode) {
-            unsigned iDCC(dccId(_id) - 1);
+            unsigned iDCC(dccId(_id, electronicsMap) - 1);
             if (iDCC >= kEBmLow && iDCC <= kEBpHigh)
               return 1;
             else
@@ -343,18 +343,18 @@ namespace ecaldqm {
             return -1;
 
         default:
-          return findPlotIndex(_otype, dccId(_id));
+          return findPlotIndex(electronicsMap, _otype, dccId(_id, electronicsMap));
       }
     }
 
-    unsigned findPlotIndex(ObjectType _otype, const EcalElectronicsId &_id) {
+    unsigned findPlotIndex(EcalElectronicsMapping const *electronicsMap, ObjectType _otype, const EcalElectronicsId &_id) {
       if (getNObjects(_otype) == 1)
         return 0;
 
-      return findPlotIndex(_otype, _id.dccId());
+      return findPlotIndex(electronicsMap, _otype, _id.dccId());
     }
 
-    unsigned findPlotIndex(ObjectType _otype, int _dcctccid, BinningType _btype /* = kDCC*/) {
+    unsigned findPlotIndex(EcalElectronicsMapping const *electronicsMap, ObjectType _otype, int _dcctccid, BinningType _btype /* = kDCC*/) {
       if (getNObjects(_otype) == 1)
         return 0;
 
@@ -536,7 +536,7 @@ namespace ecaldqm {
       }
     }
 
-    bool isValidIdBin(ObjectType _otype, BinningType _btype, unsigned _iME, int _bin) {
+    bool isValidIdBin(EcalElectronicsMapping const *electronicsMap, ObjectType _otype, BinningType _btype, unsigned _iME, int _bin) {
       if (_otype == kEEm || _otype == kEEp) {
         if (_btype == kCrystal || _btype == kTriggerTower)
           return EEDetId::validDetId(_bin % 102, _bin / 102, 1);
@@ -571,7 +571,7 @@ namespace ecaldqm {
           int ix(_bin % (nX + 2) + xlow_(iSM));
           int iy(_bin / (nX + 2) + ylow_(iSM));
           int z(iSM <= kEEmHigh ? -1 : 1);
-          return EEDetId::validDetId(ix, iy, 1) && iSM == dccId(EEDetId(ix, iy, z)) - 1;
+          return EEDetId::validDetId(ix, iy, 1) && iSM == dccId(EEDetId(ix, iy, z), electronicsMap) - 1;
         } else if (_btype == kSuperCrystal) {
           int nX(nEESMX / 5);
           if (iSM == kEEm02 || iSM == kEEm08 || iSM == kEEp02 || iSM == kEEp08)
@@ -581,14 +581,14 @@ namespace ecaldqm {
           int ix(_bin % (nX + 2) + xlow_(iSM) / 5);
           int iy(_bin / (nX + 2) + ylow_(iSM) / 5);
           int z(iSM <= kEEmHigh ? -1 : 1);
-          return EcalScDetId::validDetId(ix, iy, z) && iSM == dccId(EcalScDetId(ix, iy, z)) - 1;
+          return EcalScDetId::validDetId(ix, iy, z) && iSM == dccId(EcalScDetId(ix, iy, z), electronicsMap) - 1;
         }
       }
 
       return true;
     }
 
-    std::string channelName(uint32_t _rawId, BinningType _btype /* = kDCC*/) {
+    std::string channelName(const EcalElectronicsMapping *electronicsMap, uint32_t _rawId, BinningType _btype /* = kDCC*/) {
       // assume the following IDs for respective binning types:
       // Crystal: EcalElectronicsId
       // TriggerTower: EcalTriggerElectronicsId (pstrip and channel ignored)
@@ -610,13 +610,13 @@ namespace ecaldqm {
                << eid.stripId() << " xtal " << eid.xtalId();
 
             if (eid.dccId() >= kEBmLow + 1 && eid.dccId() <= kEBpHigh + 1) {
-              EBDetId ebid(getElectronicsMap()->getDetId(eid));
+              EBDetId ebid(electronicsMap->getDetId(eid));
               ss << " (EB ieta " << std::showpos << ebid.ieta() << std::noshowpos << " iphi " << ebid.iphi() << ")";
             } else {
-              EEDetId eeid(getElectronicsMap()->getDetId(eid));
+              EEDetId eeid(electronicsMap->getDetId(eid));
               ss << " (EE ix " << eeid.ix() << " iy " << eeid.iy() << ")";
             }
-            EcalTriggerElectronicsId teid(getElectronicsMap()->getTriggerElectronicsId(eid));
+            EcalTriggerElectronicsId teid(electronicsMap->getTriggerElectronicsId(eid));
             ss << " (TCC " << teid.tccId() << " TT " << teid.ttId() << " pstrip " << teid.pseudoStripId() << " chan "
                << teid.channelId() << ")";
             break;
@@ -626,7 +626,7 @@ namespace ecaldqm {
         case kTriggerTower: {
           // EB-03 DCC 12 TCC 18 TT 3
           EcalTriggerElectronicsId teid(_rawId);
-          EcalElectronicsId eid(getElectronicsMap()->getElectronicsId(teid));
+          EcalElectronicsId eid(electronicsMap->getElectronicsId(teid));
           ss << smName(eid.dccId()) << " DCC " << eid.dccId() << " TCC " << teid.tccId() << " TT " << teid.ttId();
           break;
         }
@@ -635,10 +635,10 @@ namespace ecaldqm {
           EcalElectronicsId eid(_rawId);
           ss << smName(eid.dccId()) << " DCC " << eid.dccId() << " CCU " << eid.towerId();
           if (eid.dccId() >= kEBmLow + 1 && eid.dccId() <= kEBpHigh + 1) {
-            EcalTrigTowerDetId ttid(EBDetId(getElectronicsMap()->getDetId(eid)).tower());
+            EcalTrigTowerDetId ttid(EBDetId(electronicsMap->getDetId(eid)).tower());
             ss << " (EBTT ieta " << std::showpos << ttid.ieta() << std::noshowpos << " iphi " << ttid.iphi() << ")";
           } else {
-            EcalScDetId scid(EEDetId(getElectronicsMap()->getDetId(eid)).sc());
+            EcalScDetId scid(EEDetId(electronicsMap->getDetId(eid)).sc());
             ss << " (EESC ix " << scid.ix() << " iy " << scid.iy() << ")";
           }
           break;
@@ -646,7 +646,7 @@ namespace ecaldqm {
         case kTCC: {
           // EB-03 TCC 12
           int tccid(_rawId - nDCC);
-          int dccid(getElectronicsMap()->DCCid(getElectronicsMap()->getTrigTowerDetId(tccid, 1)));
+          int dccid(electronicsMap->DCCid(electronicsMap->getTrigTowerDetId(tccid, 1)));
           ss << smName(dccid) << " TCC " << (_rawId - nDCC);
           break;
         }

--- a/DQM/EcalCommon/src/MESetBinningUtils.cc
+++ b/DQM/EcalCommon/src/MESetBinningUtils.cc
@@ -11,7 +11,12 @@
 
 namespace ecaldqm {
   namespace binning {
-    AxisSpecs getBinning(EcalElectronicsMapping const *electronicsMap, ObjectType _otype, BinningType _btype, bool _isMap, int _axis, unsigned _iME) {
+    AxisSpecs getBinning(EcalElectronicsMapping const *electronicsMap,
+                         ObjectType _otype,
+                         BinningType _btype,
+                         bool _isMap,
+                         int _axis,
+                         unsigned _iME) {
       if (_otype >= nObjType || _btype >= unsigned(nPresetBinnings))
         return AxisSpecs();  // you are on your own
 
@@ -55,7 +60,10 @@ namespace ecaldqm {
       }
     }
 
-    int findBin1D(EcalElectronicsMapping const *electronicsMap, ObjectType _otype, BinningType _btype, const DetId &_id) {
+    int findBin1D(EcalElectronicsMapping const *electronicsMap,
+                  ObjectType _otype,
+                  BinningType _btype,
+                  const DetId &_id) {
       switch (_otype) {
         case kSM:
         case kEBSM:
@@ -138,7 +146,10 @@ namespace ecaldqm {
       return 0;
     }
 
-    int findBin1D(EcalElectronicsMapping const *electronicsMap, ObjectType _otype, BinningType _btype, const EcalElectronicsId &_id) {
+    int findBin1D(EcalElectronicsMapping const *electronicsMap,
+                  ObjectType _otype,
+                  BinningType _btype,
+                  const EcalElectronicsId &_id) {
       switch (_otype) {
         case kSM:
         case kEBSM:
@@ -239,7 +250,10 @@ namespace ecaldqm {
       return 0;
     }
 
-    int findBin2D(EcalElectronicsMapping const *electronicsMap, ObjectType _otype, BinningType _btype, const DetId &_id) {
+    int findBin2D(EcalElectronicsMapping const *electronicsMap,
+                  ObjectType _otype,
+                  BinningType _btype,
+                  const DetId &_id) {
       if (_otype >= nObjType || _btype >= unsigned(nPresetBinnings))
         return 0;
 
@@ -264,7 +278,10 @@ namespace ecaldqm {
       }
     }
 
-    int findBin2D(EcalElectronicsMapping const *electronicsMap, ObjectType _otype, BinningType _btype, const EcalElectronicsId &_id) {
+    int findBin2D(EcalElectronicsMapping const *electronicsMap,
+                  ObjectType _otype,
+                  BinningType _btype,
+                  const EcalElectronicsId &_id) {
       if (_otype >= nObjType || _btype >= unsigned(nPresetBinnings))
         return 0;
 
@@ -347,14 +364,19 @@ namespace ecaldqm {
       }
     }
 
-    unsigned findPlotIndex(EcalElectronicsMapping const *electronicsMap, ObjectType _otype, const EcalElectronicsId &_id) {
+    unsigned findPlotIndex(EcalElectronicsMapping const *electronicsMap,
+                           ObjectType _otype,
+                           const EcalElectronicsId &_id) {
       if (getNObjects(_otype) == 1)
         return 0;
 
       return findPlotIndex(electronicsMap, _otype, _id.dccId());
     }
 
-    unsigned findPlotIndex(EcalElectronicsMapping const *electronicsMap, ObjectType _otype, int _dcctccid, BinningType _btype /* = kDCC*/) {
+    unsigned findPlotIndex(EcalElectronicsMapping const *electronicsMap,
+                           ObjectType _otype,
+                           int _dcctccid,
+                           BinningType _btype /* = kDCC*/) {
       if (getNObjects(_otype) == 1)
         return 0;
 
@@ -536,7 +558,8 @@ namespace ecaldqm {
       }
     }
 
-    bool isValidIdBin(EcalElectronicsMapping const *electronicsMap, ObjectType _otype, BinningType _btype, unsigned _iME, int _bin) {
+    bool isValidIdBin(
+        EcalElectronicsMapping const *electronicsMap, ObjectType _otype, BinningType _btype, unsigned _iME, int _bin) {
       if (_otype == kEEm || _otype == kEEp) {
         if (_btype == kCrystal || _btype == kTriggerTower)
           return EEDetId::validDetId(_bin % 102, _bin / 102, 1);
@@ -588,7 +611,9 @@ namespace ecaldqm {
       return true;
     }
 
-    std::string channelName(const EcalElectronicsMapping *electronicsMap, uint32_t _rawId, BinningType _btype /* = kDCC*/) {
+    std::string channelName(const EcalElectronicsMapping *electronicsMap,
+                            uint32_t _rawId,
+                            BinningType _btype /* = kDCC*/) {
       // assume the following IDs for respective binning types:
       // Crystal: EcalElectronicsId
       // TriggerTower: EcalTriggerElectronicsId (pstrip and channel ignored)

--- a/DQM/EcalCommon/src/MESetBinningUtils.cc
+++ b/DQM/EcalCommon/src/MESetBinningUtils.cc
@@ -385,8 +385,9 @@ namespace ecaldqm {
       switch (_otype) {
         case kSM:
           if (_btype == kPseudoStrip) {
-            iSM = iSM <= kEEmTCCHigh ? (iSM + 1) % 18 / 2
-                                     : iSM >= kEEpTCCLow ? (iSM + 1 - 72) % 18 / 2 + 45 : (iSM + 1) - kEEmTCCHigh;
+            iSM = iSM <= kEEmTCCHigh  ? (iSM + 1) % 18 / 2
+                  : iSM >= kEEpTCCLow ? (iSM + 1 - 72) % 18 / 2 + 45
+                                      : (iSM + 1) - kEEmTCCHigh;
             return iSM;
           } else
             return iSM;

--- a/DQM/EcalCommon/src/MESetBinningUtils2.cc
+++ b/DQM/EcalCommon/src/MESetBinningUtils2.cc
@@ -222,7 +222,7 @@ namespace ecaldqm {
       return specs;
     }
 
-    AxisSpecs getBinningSM_(BinningType _btype, bool _isMap, unsigned _iObj, int _axis) {
+    AxisSpecs getBinningSM_(BinningType _btype, bool _isMap, unsigned _iObj, int _axis, const EcalElectronicsMapping *electronicsMap) {
       AxisSpecs specs;
 
       unsigned iSM(_iObj);
@@ -232,7 +232,7 @@ namespace ecaldqm {
       if (!_isMap) {
         switch (_btype) {
           case kCrystal:
-            specs.nbins = isBarrel ? 1700 : getElectronicsMap()->dccConstituents(iSM + 1).size();
+            specs.nbins = isBarrel ? 1700 : electronicsMap->dccConstituents(iSM + 1).size();
             specs.low = 0.;
             specs.high = specs.nbins;
             specs.title = "crystal";
@@ -426,7 +426,7 @@ namespace ecaldqm {
       return specs;
     }
 
-    int findBinCrystal_(ObjectType _otype, const DetId &_id, int _iSM /* = -1*/) {
+    int findBinCrystal_(const EcalElectronicsMapping *electronicsMap, ObjectType _otype, const DetId &_id, int _iSM /* = -1*/) {
       int xbin(0), ybin(0);
       int nbinsX(0);
       int subdet(_id.subdetId());
@@ -468,7 +468,7 @@ namespace ecaldqm {
             break;
           case kSM:
           case kEESM: {
-            int iSM(_iSM >= 0 ? _iSM : dccId(_id) - 1);
+            int iSM(_iSM >= 0 ? _iSM : dccId(_id, electronicsMap) - 1);
             xbin = ix - xlow_(iSM);
             ybin = iy - ylow_(iSM);
             if (iSM == kEEm02 || iSM == kEEm08 || iSM == kEEp02 || iSM == kEEp08)
@@ -492,17 +492,17 @@ namespace ecaldqm {
             nbinsX = 10;
             break;
           case kMEM:
-            xbin = memDCCIndex(dccId(_id)) + 1;
+            xbin = memDCCIndex(dccId(_id, electronicsMap)) + 1;
             ybin = pnid.iPnId();
             nbinsX = 44;
             break;
           case kEBMEM:
-            xbin = memDCCIndex(dccId(_id)) - 3;
+            xbin = memDCCIndex(dccId(_id, electronicsMap)) - 3;
             ybin = pnid.iPnId();
             nbinsX = 36;
             break;
           case kEEMEM:
-            xbin = memDCCIndex(dccId(_id)) + 1;
+            xbin = memDCCIndex(dccId(_id, electronicsMap)) + 1;
             if (xbin > kEEmHigh + 1)
               xbin -= 36;
             ybin = pnid.iPnId();
@@ -516,8 +516,8 @@ namespace ecaldqm {
       return (nbinsX + 2) * ybin + xbin;
     }
 
-    int findBinCrystal_(ObjectType _otype, EcalElectronicsId const &_id) {
-      return findBinCrystal_(_otype, getElectronicsMap()->getDetId(_id));
+    int findBinCrystal_(const EcalElectronicsMapping *electronicsMap, ObjectType _otype, EcalElectronicsId const &_id) {
+      return findBinCrystal_(electronicsMap, _otype, electronicsMap->getDetId(_id));
     }
 
     int findBinRCT_(ObjectType _otype, DetId const &_id) {
@@ -536,7 +536,7 @@ namespace ecaldqm {
       return (nbinsX + 2) * ybin + xbin;
     }
 
-    int findBinTriggerTower_(ObjectType _otype, DetId const &_id) {
+    int findBinTriggerTower_(const EcalElectronicsMapping *electronicsMap, ObjectType _otype, DetId const &_id) {
       int xbin(0);
       int ybin(0);
       int nbinsX(0);
@@ -571,32 +571,32 @@ namespace ecaldqm {
             break;
         }
       } else if (subdet == EcalEndcap) {
-        unsigned tccid(tccId(_id));
+        unsigned tccid(tccId(_id, electronicsMap));
         unsigned iSM(tccid <= 36 ? tccid % 18 / 2 : (tccid - 72) % 18 / 2);
-        return findBinCrystal_(_otype, _id, iSM);
+        return findBinCrystal_(electronicsMap, _otype, _id, iSM);
       }
 
       return (nbinsX + 2) * ybin + xbin;
     }
 
-    int findBinPseudoStrip_(ObjectType _otype, DetId const &_id) {
+    int findBinPseudoStrip_(const EcalElectronicsMapping *electronicsMap, ObjectType _otype, DetId const &_id) {
       int xbin(0);
       int ybin(0);
       int nbinsX(0);
       int subdet(_id.subdetId());
 
       if ((subdet == EcalTriggerTower && !isEndcapTTId(_id)) || subdet == EcalBarrel) {
-        return findBinTriggerTower_(_otype, _id);
+        return findBinTriggerTower_(electronicsMap, _otype, _id);
       } else if (subdet == EcalEndcap) {
-        unsigned tccid(tccId(_id));
+        unsigned tccid(tccId(_id, electronicsMap));
         unsigned iSM(tccid <= 36 ? tccid % 18 / 2 : (tccid - 72) % 18 / 2);
-        return findBinCrystal_(_otype, _id, iSM);
+        return findBinCrystal_(electronicsMap, _otype, _id, iSM);
       }
 
       return (nbinsX + 2) * ybin + xbin;
     }
 
-    int findBinSuperCrystal_(ObjectType _otype, const DetId &_id, int _iSM /* -1*/) {
+    int findBinSuperCrystal_(const EcalElectronicsMapping *electronicsMap, ObjectType _otype, const DetId &_id, int _iSM /* -1*/) {
       int xbin(0);
       int ybin(0);
       int nbinsX(0);
@@ -641,7 +641,7 @@ namespace ecaldqm {
               break;
             case kSM:
             case kEESM: {
-              int iSM(_iSM >= 0 ? _iSM : dccId(_id) - 1);
+              int iSM(_iSM >= 0 ? _iSM : dccId(_id, electronicsMap) - 1);
               xbin = ix - xlow_(iSM) / 5;
               ybin = iy - ylow_(iSM) / 5;
               if (iSM == kEEm02 || iSM == kEEm08 || iSM == kEEp02 || iSM == kEEp08)
@@ -673,7 +673,7 @@ namespace ecaldqm {
               break;
             case kSM:
             case kEESM: {
-              int iSM(_iSM >= 0 ? _iSM : dccId(_id) - 1);
+              int iSM(_iSM >= 0 ? _iSM : dccId(_id, electronicsMap) - 1);
               xbin = (ix - xlow_(iSM) - 1) / 5 + 1;
               ybin = (iy - ylow_(iSM) - 1) / 5 + 1;
               if (iSM == kEEm02 || iSM == kEEm08 || iSM == kEEp02 || iSM == kEEp08)
@@ -712,7 +712,7 @@ namespace ecaldqm {
       return (nbinsX + 2) * ybin + xbin;
     }
 
-    int findBinSuperCrystal_(ObjectType _otype, const EcalElectronicsId &_id) {
+    int findBinSuperCrystal_(const EcalElectronicsMapping *electronicsMap, ObjectType _otype, const EcalElectronicsId &_id) {
       int xbin(0);
       int ybin(0);
       int nbinsX(0);
@@ -739,7 +739,7 @@ namespace ecaldqm {
             break;
         }
       } else {
-        return findBinSuperCrystal_(_otype, EEDetId(getElectronicsMap()->getDetId(_id)).sc());
+        return findBinSuperCrystal_(electronicsMap, _otype, EEDetId(electronicsMap->getDetId(_id)).sc());
       }
 
       return (nbinsX + 2) * ybin + xbin;

--- a/DQM/EcalCommon/src/MESetBinningUtils2.cc
+++ b/DQM/EcalCommon/src/MESetBinningUtils2.cc
@@ -222,7 +222,8 @@ namespace ecaldqm {
       return specs;
     }
 
-    AxisSpecs getBinningSM_(BinningType _btype, bool _isMap, unsigned _iObj, int _axis, const EcalElectronicsMapping *electronicsMap) {
+    AxisSpecs getBinningSM_(
+        BinningType _btype, bool _isMap, unsigned _iObj, int _axis, const EcalElectronicsMapping *electronicsMap) {
       AxisSpecs specs;
 
       unsigned iSM(_iObj);
@@ -426,7 +427,10 @@ namespace ecaldqm {
       return specs;
     }
 
-    int findBinCrystal_(const EcalElectronicsMapping *electronicsMap, ObjectType _otype, const DetId &_id, int _iSM /* = -1*/) {
+    int findBinCrystal_(const EcalElectronicsMapping *electronicsMap,
+                        ObjectType _otype,
+                        const DetId &_id,
+                        int _iSM /* = -1*/) {
       int xbin(0), ybin(0);
       int nbinsX(0);
       int subdet(_id.subdetId());
@@ -596,7 +600,10 @@ namespace ecaldqm {
       return (nbinsX + 2) * ybin + xbin;
     }
 
-    int findBinSuperCrystal_(const EcalElectronicsMapping *electronicsMap, ObjectType _otype, const DetId &_id, int _iSM /* -1*/) {
+    int findBinSuperCrystal_(const EcalElectronicsMapping *electronicsMap,
+                             ObjectType _otype,
+                             const DetId &_id,
+                             int _iSM /* -1*/) {
       int xbin(0);
       int ybin(0);
       int nbinsX(0);
@@ -712,7 +719,9 @@ namespace ecaldqm {
       return (nbinsX + 2) * ybin + xbin;
     }
 
-    int findBinSuperCrystal_(const EcalElectronicsMapping *electronicsMap, ObjectType _otype, const EcalElectronicsId &_id) {
+    int findBinSuperCrystal_(const EcalElectronicsMapping *electronicsMap,
+                             ObjectType _otype,
+                             const EcalElectronicsId &_id) {
       int xbin(0);
       int ybin(0);
       int nbinsX(0);

--- a/DQM/EcalCommon/src/MESetDet0D.cc
+++ b/DQM/EcalCommon/src/MESetDet0D.cc
@@ -27,67 +27,67 @@ namespace ecaldqm {
     return copy;
   }
 
-  void MESetDet0D::fill(DetId const &_id, double _value, double, double) {
+  void MESetDet0D::fill(EcalDQMSetupObjects const edso, DetId const &_id, double _value, double, double) {
     if (!active_)
       return;
 
-    unsigned iME(binning::findPlotIndex(otype_, _id));
+    unsigned iME(binning::findPlotIndex(edso.electronicsMap, otype_, _id));
     checkME_(iME);
 
     mes_[iME]->Fill(_value);
   }
 
-  void MESetDet0D::fill(EcalElectronicsId const &_id, double _value, double, double) {
+  void MESetDet0D::fill(EcalDQMSetupObjects const edso, EcalElectronicsId const &_id, double _value, double, double) {
     if (!active_)
       return;
 
-    unsigned iME(binning::findPlotIndex(otype_, _id));
+    unsigned iME(binning::findPlotIndex(edso.electronicsMap, otype_, _id));
     checkME_(iME);
 
     mes_[iME]->Fill(_value);
   }
 
-  void MESetDet0D::fill(int _dcctccid, double _value, double, double) {
+  void MESetDet0D::fill(EcalDQMSetupObjects const edso, int _dcctccid, double _value, double, double) {
     if (!active_)
       return;
 
-    unsigned iME(binning::findPlotIndex(otype_, _dcctccid, btype_));
+    unsigned iME(binning::findPlotIndex(edso.electronicsMap, otype_, _dcctccid, btype_));
     checkME_(iME);
 
     mes_[iME]->Fill(_value);
   }
 
-  double MESetDet0D::getBinContent(DetId const &_id, int) const {
+  double MESetDet0D::getBinContent(EcalDQMSetupObjects const edso, DetId const &_id, int) const {
     if (!active_)
       return 0.;
 
-    unsigned iME(binning::findPlotIndex(otype_, _id));
+    unsigned iME(binning::findPlotIndex(edso.electronicsMap, otype_, _id));
     checkME_(iME);
 
     return mes_[iME]->getFloatValue();
   }
 
-  double MESetDet0D::getBinContent(EcalElectronicsId const &_id, int) const {
+  double MESetDet0D::getBinContent(EcalDQMSetupObjects const edso, EcalElectronicsId const &_id, int) const {
     if (!active_)
       return 0.;
 
-    unsigned iME(binning::findPlotIndex(otype_, _id));
+    unsigned iME(binning::findPlotIndex(edso.electronicsMap, otype_, _id));
     checkME_(iME);
 
     return mes_[iME]->getFloatValue();
   }
 
-  double MESetDet0D::getBinContent(int _dcctccid, int) const {
+  double MESetDet0D::getBinContent(EcalDQMSetupObjects const edso, int _dcctccid, int) const {
     if (!active_)
       return 0.;
 
-    unsigned iME(binning::findPlotIndex(otype_, _dcctccid, btype_));
+    unsigned iME(binning::findPlotIndex(edso.electronicsMap, otype_, _dcctccid, btype_));
     checkME_(iME);
 
     return mes_[iME]->getFloatValue();
   }
 
-  void MESetDet0D::reset(double _value /* = 0.*/, double, double) {
+  void MESetDet0D::reset(EcalElectronicsMapping const *electronicsMap, double _value /* = 0.*/, double, double) {
     unsigned nME(mes_.size());
     for (unsigned iME(0); iME < nME; iME++)
       mes_[iME]->Fill(_value);

--- a/DQM/EcalCommon/src/MESetDet1D.cc
+++ b/DQM/EcalCommon/src/MESetDet1D.cc
@@ -107,7 +107,8 @@ namespace ecaldqm {
     }
   }
 
-  void MESetDet1D::fill(EcalDQMSetupObjects const edso, DetId const &_id, double _wy /* = 1.*/, double _w /* = 1.*/, double) {
+  void MESetDet1D::fill(
+      EcalDQMSetupObjects const edso, DetId const &_id, double _wy /* = 1.*/, double _w /* = 1.*/, double) {
     if (!active_)
       return;
 
@@ -123,7 +124,8 @@ namespace ecaldqm {
       fill_(iME, xbin, _wy);
   }
 
-  void MESetDet1D::fill(EcalDQMSetupObjects const edso, EcalElectronicsId const &_id, double _wy /* = 1.*/, double _w /* = 1.*/, double) {
+  void MESetDet1D::fill(
+      EcalDQMSetupObjects const edso, EcalElectronicsId const &_id, double _wy /* = 1.*/, double _w /* = 1.*/, double) {
     if (!active_)
       return;
 
@@ -139,7 +141,8 @@ namespace ecaldqm {
       fill_(iME, xbin, _wy);
   }
 
-  void MESetDet1D::fill(EcalDQMSetupObjects const edso, int _dcctccid, double _wy /* = 1.*/, double _w /* = 1.*/, double) {
+  void MESetDet1D::fill(
+      EcalDQMSetupObjects const edso, int _dcctccid, double _wy /* = 1.*/, double _w /* = 1.*/, double) {
     if (!active_)
       return;
 
@@ -231,7 +234,10 @@ namespace ecaldqm {
     me->setBinContent(xbin, _ybin, _content);
   }
 
-  void MESetDet1D::setBinContent(EcalDQMSetupObjects const edso, EcalElectronicsId const &_id, int _ybin, double _content) {
+  void MESetDet1D::setBinContent(EcalDQMSetupObjects const edso,
+                                 EcalElectronicsId const &_id,
+                                 int _ybin,
+                                 double _content) {
     if (!active_)
       return;
     if (kind_ != MonitorElement::Kind::TH2F && kind_ != MonitorElement::Kind::TPROFILE2D)
@@ -457,7 +463,10 @@ namespace ecaldqm {
     me->setBinEntries((nbinsX + 2) * _ybin + xbin, _entries);
   }
 
-  void MESetDet1D::setBinEntries(EcalDQMSetupObjects const edso, EcalElectronicsId const &_id, int _ybin, double _entries) {
+  void MESetDet1D::setBinEntries(EcalDQMSetupObjects const edso,
+                                 EcalElectronicsId const &_id,
+                                 int _ybin,
+                                 double _entries) {
     if (!active_)
       return;
     if (kind_ != MonitorElement::Kind::TPROFILE2D)
@@ -507,7 +516,9 @@ namespace ecaldqm {
     return me->getBinContent((nbinsX + 2) * _ybin + xbin);
   }
 
-  double MESetDet1D::getBinContent(EcalDQMSetupObjects const edso, EcalElectronicsId const &_id, int _ybin /* = 0*/) const {
+  double MESetDet1D::getBinContent(EcalDQMSetupObjects const edso,
+                                   EcalElectronicsId const &_id,
+                                   int _ybin /* = 0*/) const {
     if (!active_)
       return 0.;
 
@@ -555,7 +566,9 @@ namespace ecaldqm {
     return me->getBinError((nbinsX + 2) * _ybin + xbin);
   }
 
-  double MESetDet1D::getBinError(EcalDQMSetupObjects const edso, EcalElectronicsId const &_id, int _ybin /* = 0*/) const {
+  double MESetDet1D::getBinError(EcalDQMSetupObjects const edso,
+                                 EcalElectronicsId const &_id,
+                                 int _ybin /* = 0*/) const {
     if (!active_)
       return 0.;
 
@@ -605,7 +618,9 @@ namespace ecaldqm {
     return me->getBinEntries((nbinsX + 2) * _ybin + xbin);
   }
 
-  double MESetDet1D::getBinEntries(EcalDQMSetupObjects const edso, EcalElectronicsId const &_id, int _ybin /* = 0*/) const {
+  double MESetDet1D::getBinEntries(EcalDQMSetupObjects const edso,
+                                   EcalElectronicsId const &_id,
+                                   int _ybin /* = 0*/) const {
     if (!active_)
       return 0.;
     if (kind_ != MonitorElement::Kind::TPROFILE && kind_ != MonitorElement::Kind::TPROFILE2D)
@@ -731,7 +746,10 @@ namespace ecaldqm {
     return xbin + (nbinsX + 2) * me->getTH1()->GetYaxis()->FindBin(_y);
   }
 
-  void MESetDet1D::reset(EcalElectronicsMapping const *, double _content /* = 0.*/, double _err /* = 0.*/, double _entries /* = 0.*/) {
+  void MESetDet1D::reset(EcalElectronicsMapping const *,
+                         double _content /* = 0.*/,
+                         double _err /* = 0.*/,
+                         double _entries /* = 0.*/) {
     unsigned nME(binning::getNObjects(otype_));
 
     bool isProfile(kind_ == MonitorElement::Kind::TPROFILE || kind_ == MonitorElement::Kind::TPROFILE2D);

--- a/DQM/EcalCommon/src/MESetDet1D.cc
+++ b/DQM/EcalCommon/src/MESetDet1D.cc
@@ -34,8 +34,8 @@ namespace ecaldqm {
     return copy;
   }
 
-  void MESetDet1D::book(DQMStore::IBooker &_ibooker) {
-    MESetEcal::book(_ibooker);
+  void MESetDet1D::book(DQMStore::IBooker &_ibooker, const EcalElectronicsMapping *electronicsMap) {
+    MESetEcal::book(_ibooker, electronicsMap);
 
     if (btype_ == binning::kDCC) {
       for (unsigned iME(0); iME < mes_.size(); iME++) {
@@ -44,18 +44,18 @@ namespace ecaldqm {
         binning::ObjectType actualObject(binning::getObject(otype_, iME));
         if (actualObject == binning::kEB) {
           for (int iBin(1); iBin <= me->getNbinsX(); iBin++)
-            me->setBinLabel(iBin, binning::channelName(iBin + kEBmLow));
+            me->setBinLabel(iBin, binning::channelName(electronicsMap, iBin + kEBmLow));
         } else if (actualObject == binning::kEE) {
           for (int iBin(1); iBin <= me->getNbinsX() / 2; iBin++) {
-            me->setBinLabel(iBin, binning::channelName(iBin));
-            me->setBinLabel(iBin + me->getNbinsX() / 2, binning::channelName(iBin + 45));
+            me->setBinLabel(iBin, binning::channelName(electronicsMap, iBin));
+            me->setBinLabel(iBin + me->getNbinsX() / 2, binning::channelName(electronicsMap, iBin + 45));
           }
         } else if (actualObject == binning::kEEm) {
           for (int iBin(1); iBin <= me->getNbinsX(); iBin++)
-            me->setBinLabel(iBin, binning::channelName(iBin));
+            me->setBinLabel(iBin, binning::channelName(electronicsMap, iBin));
         } else if (actualObject == binning::kEEp) {
           for (int iBin(1); iBin <= me->getNbinsX(); iBin++)
-            me->setBinLabel(iBin, binning::channelName(iBin + 45));
+            me->setBinLabel(iBin, binning::channelName(electronicsMap, iBin + 45));
         }
       }
     } else if (btype_ == binning::kTriggerTower) {
@@ -107,15 +107,15 @@ namespace ecaldqm {
     }
   }
 
-  void MESetDet1D::fill(DetId const &_id, double _wy /* = 1.*/, double _w /* = 1.*/, double) {
+  void MESetDet1D::fill(EcalDQMSetupObjects const edso, DetId const &_id, double _wy /* = 1.*/, double _w /* = 1.*/, double) {
     if (!active_)
       return;
 
-    unsigned iME(binning::findPlotIndex(otype_, _id));
+    unsigned iME(binning::findPlotIndex(edso.electronicsMap, otype_, _id));
     checkME_(iME);
 
     binning::ObjectType obj(binning::getObject(otype_, iME));
-    int xbin(binning::findBin1D(obj, btype_, _id));
+    int xbin(binning::findBin1D(edso.electronicsMap, obj, btype_, _id));
 
     if (kind_ == MonitorElement::Kind::TH2F || kind_ == MonitorElement::Kind::TPROFILE2D)
       fill_(iME, xbin, _wy, _w);
@@ -123,15 +123,15 @@ namespace ecaldqm {
       fill_(iME, xbin, _wy);
   }
 
-  void MESetDet1D::fill(EcalElectronicsId const &_id, double _wy /* = 1.*/, double _w /* = 1.*/, double) {
+  void MESetDet1D::fill(EcalDQMSetupObjects const edso, EcalElectronicsId const &_id, double _wy /* = 1.*/, double _w /* = 1.*/, double) {
     if (!active_)
       return;
 
-    unsigned iME(binning::findPlotIndex(otype_, _id));
+    unsigned iME(binning::findPlotIndex(edso.electronicsMap, otype_, _id));
     checkME_(iME);
 
     binning::ObjectType obj(binning::getObject(otype_, iME));
-    int xbin(binning::findBin1D(obj, btype_, _id));
+    int xbin(binning::findBin1D(edso.electronicsMap, obj, btype_, _id));
 
     if (kind_ == MonitorElement::Kind::TH2F || kind_ == MonitorElement::Kind::TPROFILE2D)
       fill_(iME, xbin, _wy, _w);
@@ -139,15 +139,15 @@ namespace ecaldqm {
       fill_(iME, xbin, _wy);
   }
 
-  void MESetDet1D::fill(int _dcctccid, double _wy /* = 1.*/, double _w /* = 1.*/, double) {
+  void MESetDet1D::fill(EcalDQMSetupObjects const edso, int _dcctccid, double _wy /* = 1.*/, double _w /* = 1.*/, double) {
     if (!active_)
       return;
 
-    unsigned iME(binning::findPlotIndex(otype_, _dcctccid, btype_));
+    unsigned iME(binning::findPlotIndex(edso.electronicsMap, otype_, _dcctccid, btype_));
     checkME_(iME);
 
     binning::ObjectType obj(binning::getObject(otype_, iME));
-    int xbin(binning::findBin1D(obj, btype_, _dcctccid));
+    int xbin(binning::findBin1D(edso.electronicsMap, obj, btype_, _dcctccid));
 
     if (kind_ == MonitorElement::Kind::TH2F || kind_ == MonitorElement::Kind::TPROFILE2D)
       fill_(iME, xbin, _wy, _w);
@@ -155,17 +155,17 @@ namespace ecaldqm {
       fill_(iME, xbin, _wy);
   }
 
-  void MESetDet1D::setBinContent(DetId const &_id, double _content) {
+  void MESetDet1D::setBinContent(EcalDQMSetupObjects const edso, DetId const &_id, double _content) {
     if (!active_)
       return;
 
-    unsigned iME(binning::findPlotIndex(otype_, _id));
+    unsigned iME(binning::findPlotIndex(edso.electronicsMap, otype_, _id));
     checkME_(iME);
 
     MonitorElement *me(mes_[iME]);
 
     binning::ObjectType obj(binning::getObject(otype_, iME));
-    int xbin(binning::findBin1D(obj, btype_, _id));
+    int xbin(binning::findBin1D(edso.electronicsMap, obj, btype_, _id));
 
     if (kind_ == MonitorElement::Kind::TH2F || kind_ == MonitorElement::Kind::TPROFILE2D) {
       int nbinsY(me->getTH1()->GetNbinsY());
@@ -175,17 +175,17 @@ namespace ecaldqm {
       me->setBinContent(xbin, _content);
   }
 
-  void MESetDet1D::setBinContent(EcalElectronicsId const &_id, double _content) {
+  void MESetDet1D::setBinContent(EcalDQMSetupObjects const edso, EcalElectronicsId const &_id, double _content) {
     if (!active_)
       return;
 
-    unsigned iME(binning::findPlotIndex(otype_, _id));
+    unsigned iME(binning::findPlotIndex(edso.electronicsMap, otype_, _id));
     checkME_(iME);
 
     MonitorElement *me(mes_[iME]);
 
     binning::ObjectType obj(binning::getObject(otype_, iME));
-    int xbin(binning::findBin1D(obj, btype_, _id));
+    int xbin(binning::findBin1D(edso.electronicsMap, obj, btype_, _id));
 
     if (kind_ == MonitorElement::Kind::TH2F || kind_ == MonitorElement::Kind::TPROFILE2D) {
       int nbinsY(me->getTH1()->GetNbinsY());
@@ -195,17 +195,17 @@ namespace ecaldqm {
       me->setBinContent(xbin, _content);
   }
 
-  void MESetDet1D::setBinContent(int _dcctccid, double _content) {
+  void MESetDet1D::setBinContent(EcalDQMSetupObjects const edso, int _dcctccid, double _content) {
     if (!active_)
       return;
 
-    unsigned iME(binning::findPlotIndex(otype_, _dcctccid, btype_));
+    unsigned iME(binning::findPlotIndex(edso.electronicsMap, otype_, _dcctccid, btype_));
     checkME_(iME);
 
     MonitorElement *me(mes_[iME]);
 
     binning::ObjectType obj(binning::getObject(otype_, iME));
-    int xbin(binning::findBin1D(obj, btype_, _dcctccid));
+    int xbin(binning::findBin1D(edso.electronicsMap, obj, btype_, _dcctccid));
 
     if (kind_ == MonitorElement::Kind::TH2F || kind_ == MonitorElement::Kind::TPROFILE2D) {
       int nbinsY(me->getTH1()->GetNbinsY());
@@ -215,65 +215,65 @@ namespace ecaldqm {
       me->setBinContent(xbin, _content);
   }
 
-  void MESetDet1D::setBinContent(DetId const &_id, int _ybin, double _content) {
+  void MESetDet1D::setBinContent(EcalDQMSetupObjects const edso, DetId const &_id, int _ybin, double _content) {
     if (!active_)
       return;
     if (kind_ != MonitorElement::Kind::TH2F && kind_ != MonitorElement::Kind::TPROFILE2D)
       return;
 
-    unsigned iME(binning::findPlotIndex(otype_, _id));
+    unsigned iME(binning::findPlotIndex(edso.electronicsMap, otype_, _id));
     checkME_(iME);
 
     MonitorElement *me(mes_[iME]);
 
     binning::ObjectType obj(binning::getObject(otype_, iME));
-    int xbin(binning::findBin1D(obj, btype_, _id));
+    int xbin(binning::findBin1D(edso.electronicsMap, obj, btype_, _id));
     me->setBinContent(xbin, _ybin, _content);
   }
 
-  void MESetDet1D::setBinContent(EcalElectronicsId const &_id, int _ybin, double _content) {
+  void MESetDet1D::setBinContent(EcalDQMSetupObjects const edso, EcalElectronicsId const &_id, int _ybin, double _content) {
     if (!active_)
       return;
     if (kind_ != MonitorElement::Kind::TH2F && kind_ != MonitorElement::Kind::TPROFILE2D)
       return;
 
-    unsigned iME(binning::findPlotIndex(otype_, _id));
+    unsigned iME(binning::findPlotIndex(edso.electronicsMap, otype_, _id));
     checkME_(iME);
 
     MonitorElement *me(mes_[iME]);
 
     binning::ObjectType obj(binning::getObject(otype_, iME));
-    int xbin(binning::findBin1D(obj, btype_, _id));
+    int xbin(binning::findBin1D(edso.electronicsMap, obj, btype_, _id));
     me->setBinContent(xbin, _ybin, _content);
   }
 
-  void MESetDet1D::setBinContent(int _dcctccid, int _ybin, double _content) {
+  void MESetDet1D::setBinContent(EcalDQMSetupObjects const edso, int _dcctccid, int _ybin, double _content) {
     if (!active_)
       return;
     if (kind_ != MonitorElement::Kind::TH2F && kind_ != MonitorElement::Kind::TPROFILE2D)
       return;
 
-    unsigned iME(binning::findPlotIndex(otype_, _dcctccid));
+    unsigned iME(binning::findPlotIndex(edso.electronicsMap, otype_, _dcctccid));
     checkME_(iME);
 
     MonitorElement *me(mes_[iME]);
 
     binning::ObjectType obj(binning::getObject(otype_, iME));
-    int xbin(binning::findBin1D(obj, btype_, _dcctccid));
+    int xbin(binning::findBin1D(edso.electronicsMap, obj, btype_, _dcctccid));
     me->setBinContent(xbin, _ybin, _content);
   }
 
-  void MESetDet1D::setBinError(DetId const &_id, double _error) {
+  void MESetDet1D::setBinError(EcalDQMSetupObjects const edso, DetId const &_id, double _error) {
     if (!active_)
       return;
 
-    unsigned iME(binning::findPlotIndex(otype_, _id));
+    unsigned iME(binning::findPlotIndex(edso.electronicsMap, otype_, _id));
     checkME_(iME);
 
     MonitorElement *me(mes_[iME]);
 
     binning::ObjectType obj(binning::getObject(otype_, iME));
-    int xbin(binning::findBin1D(obj, btype_, _id));
+    int xbin(binning::findBin1D(edso.electronicsMap, obj, btype_, _id));
 
     if (kind_ == MonitorElement::Kind::TH2F || kind_ == MonitorElement::Kind::TPROFILE2D) {
       int nbinsY(me->getTH1()->GetNbinsY());
@@ -283,17 +283,17 @@ namespace ecaldqm {
       me->setBinError(xbin, _error);
   }
 
-  void MESetDet1D::setBinError(EcalElectronicsId const &_id, double _error) {
+  void MESetDet1D::setBinError(EcalDQMSetupObjects const edso, EcalElectronicsId const &_id, double _error) {
     if (!active_)
       return;
 
-    unsigned iME(binning::findPlotIndex(otype_, _id));
+    unsigned iME(binning::findPlotIndex(edso.electronicsMap, otype_, _id));
     checkME_(iME);
 
     MonitorElement *me(mes_[iME]);
 
     binning::ObjectType obj(binning::getObject(otype_, iME));
-    int xbin(binning::findBin1D(obj, btype_, _id));
+    int xbin(binning::findBin1D(edso.electronicsMap, obj, btype_, _id));
 
     if (kind_ == MonitorElement::Kind::TH2F || kind_ == MonitorElement::Kind::TPROFILE2D) {
       int nbinsY(me->getTH1()->GetNbinsY());
@@ -303,17 +303,17 @@ namespace ecaldqm {
       me->setBinError(xbin, _error);
   }
 
-  void MESetDet1D::setBinError(int _dcctccid, double _error) {
+  void MESetDet1D::setBinError(EcalDQMSetupObjects const edso, int _dcctccid, double _error) {
     if (!active_)
       return;
 
-    unsigned iME(binning::findPlotIndex(otype_, _dcctccid, btype_));
+    unsigned iME(binning::findPlotIndex(edso.electronicsMap, otype_, _dcctccid, btype_));
     checkME_(iME);
 
     MonitorElement *me(mes_[iME]);
 
     binning::ObjectType obj(binning::getObject(otype_, iME));
-    int xbin(binning::findBin1D(obj, btype_, _dcctccid));
+    int xbin(binning::findBin1D(edso.electronicsMap, obj, btype_, _dcctccid));
 
     if (kind_ == MonitorElement::Kind::TH2F || kind_ == MonitorElement::Kind::TPROFILE2D) {
       int nbinsY(me->getTH1()->GetNbinsY());
@@ -323,67 +323,67 @@ namespace ecaldqm {
       me->setBinError(xbin, _error);
   }
 
-  void MESetDet1D::setBinError(DetId const &_id, int _ybin, double _error) {
+  void MESetDet1D::setBinError(EcalDQMSetupObjects const edso, DetId const &_id, int _ybin, double _error) {
     if (!active_)
       return;
     if (kind_ != MonitorElement::Kind::TH2F && kind_ != MonitorElement::Kind::TPROFILE2D)
       return;
 
-    unsigned iME(binning::findPlotIndex(otype_, _id));
+    unsigned iME(binning::findPlotIndex(edso.electronicsMap, otype_, _id));
     checkME_(iME);
 
     MonitorElement *me(mes_[iME]);
 
     binning::ObjectType obj(binning::getObject(otype_, iME));
-    int xbin(binning::findBin1D(obj, btype_, _id));
+    int xbin(binning::findBin1D(edso.electronicsMap, obj, btype_, _id));
     me->setBinError(xbin, _ybin, _error);
   }
 
-  void MESetDet1D::setBinError(EcalElectronicsId const &_id, int _ybin, double _error) {
+  void MESetDet1D::setBinError(EcalDQMSetupObjects const edso, EcalElectronicsId const &_id, int _ybin, double _error) {
     if (!active_)
       return;
     if (kind_ != MonitorElement::Kind::TH2F && kind_ != MonitorElement::Kind::TPROFILE2D)
       return;
 
-    unsigned iME(binning::findPlotIndex(otype_, _id));
+    unsigned iME(binning::findPlotIndex(edso.electronicsMap, otype_, _id));
     checkME_(iME);
 
     MonitorElement *me(mes_[iME]);
 
     binning::ObjectType obj(binning::getObject(otype_, iME));
-    int xbin(binning::findBin1D(obj, btype_, _id));
+    int xbin(binning::findBin1D(edso.electronicsMap, obj, btype_, _id));
     me->setBinError(xbin, _ybin, _error);
   }
 
-  void MESetDet1D::setBinError(int _dcctccid, int _ybin, double _error) {
+  void MESetDet1D::setBinError(EcalDQMSetupObjects const edso, int _dcctccid, int _ybin, double _error) {
     if (!active_)
       return;
     if (kind_ != MonitorElement::Kind::TH2F && kind_ != MonitorElement::Kind::TPROFILE2D)
       return;
 
-    unsigned iME(binning::findPlotIndex(otype_, _dcctccid));
+    unsigned iME(binning::findPlotIndex(edso.electronicsMap, otype_, _dcctccid));
     checkME_(iME);
 
     MonitorElement *me(mes_[iME]);
 
     binning::ObjectType obj(binning::getObject(otype_, iME));
-    int xbin(binning::findBin1D(obj, btype_, _dcctccid));
+    int xbin(binning::findBin1D(edso.electronicsMap, obj, btype_, _dcctccid));
     me->setBinError(xbin, _ybin, _error);
   }
 
-  void MESetDet1D::setBinEntries(DetId const &_id, double _entries) {
+  void MESetDet1D::setBinEntries(EcalDQMSetupObjects const edso, DetId const &_id, double _entries) {
     if (!active_)
       return;
     if (kind_ != MonitorElement::Kind::TPROFILE && kind_ != MonitorElement::Kind::TPROFILE2D)
       return;
 
-    unsigned iME(binning::findPlotIndex(otype_, _id));
+    unsigned iME(binning::findPlotIndex(edso.electronicsMap, otype_, _id));
     checkME_(iME);
 
     MonitorElement *me(mes_[iME]);
 
     binning::ObjectType obj(binning::getObject(otype_, iME));
-    int xbin(binning::findBin1D(obj, btype_, _id));
+    int xbin(binning::findBin1D(edso.electronicsMap, obj, btype_, _id));
 
     if (kind_ == MonitorElement::Kind::TPROFILE2D) {
       int nbinsX(me->getTH1()->GetNbinsX());
@@ -394,19 +394,19 @@ namespace ecaldqm {
       me->setBinEntries(xbin, _entries);
   }
 
-  void MESetDet1D::setBinEntries(EcalElectronicsId const &_id, double _entries) {
+  void MESetDet1D::setBinEntries(EcalDQMSetupObjects const edso, EcalElectronicsId const &_id, double _entries) {
     if (!active_)
       return;
     if (kind_ != MonitorElement::Kind::TPROFILE && kind_ != MonitorElement::Kind::TPROFILE2D)
       return;
 
-    unsigned iME(binning::findPlotIndex(otype_, _id));
+    unsigned iME(binning::findPlotIndex(edso.electronicsMap, otype_, _id));
     checkME_(iME);
 
     MonitorElement *me(mes_[iME]);
 
     binning::ObjectType obj(binning::getObject(otype_, iME));
-    int xbin(binning::findBin1D(obj, btype_, _id));
+    int xbin(binning::findBin1D(edso.electronicsMap, obj, btype_, _id));
 
     if (kind_ == MonitorElement::Kind::TPROFILE2D) {
       int nbinsX(me->getTH1()->GetNbinsX());
@@ -417,19 +417,19 @@ namespace ecaldqm {
       me->setBinEntries(xbin, _entries);
   }
 
-  void MESetDet1D::setBinEntries(int _dcctccid, double _entries) {
+  void MESetDet1D::setBinEntries(EcalDQMSetupObjects const edso, int _dcctccid, double _entries) {
     if (!active_)
       return;
     if (kind_ != MonitorElement::Kind::TPROFILE && kind_ != MonitorElement::Kind::TPROFILE2D)
       return;
 
-    unsigned iME(binning::findPlotIndex(otype_, _dcctccid, btype_));
+    unsigned iME(binning::findPlotIndex(edso.electronicsMap, otype_, _dcctccid, btype_));
     checkME_(iME);
 
     MonitorElement *me(mes_[iME]);
 
     binning::ObjectType obj(binning::getObject(otype_, iME));
-    int xbin(binning::findBin1D(obj, btype_, _dcctccid));
+    int xbin(binning::findBin1D(edso.electronicsMap, obj, btype_, _dcctccid));
 
     if (kind_ == MonitorElement::Kind::TPROFILE2D) {
       int nbinsX(me->getTH1()->GetNbinsX());
@@ -440,298 +440,298 @@ namespace ecaldqm {
       me->setBinEntries(xbin, _entries);
   }
 
-  void MESetDet1D::setBinEntries(DetId const &_id, int _ybin, double _entries) {
+  void MESetDet1D::setBinEntries(EcalDQMSetupObjects const edso, DetId const &_id, int _ybin, double _entries) {
     if (!active_)
       return;
     if (kind_ != MonitorElement::Kind::TPROFILE2D)
       return;
 
-    unsigned iME(binning::findPlotIndex(otype_, _id));
+    unsigned iME(binning::findPlotIndex(edso.electronicsMap, otype_, _id));
     checkME_(iME);
 
     MonitorElement *me(mes_[iME]);
 
     binning::ObjectType obj(binning::getObject(otype_, iME));
-    int xbin(binning::findBin1D(obj, btype_, _id));
+    int xbin(binning::findBin1D(edso.electronicsMap, obj, btype_, _id));
     int nbinsX(me->getTH1()->GetNbinsX());
     me->setBinEntries((nbinsX + 2) * _ybin + xbin, _entries);
   }
 
-  void MESetDet1D::setBinEntries(EcalElectronicsId const &_id, int _ybin, double _entries) {
+  void MESetDet1D::setBinEntries(EcalDQMSetupObjects const edso, EcalElectronicsId const &_id, int _ybin, double _entries) {
     if (!active_)
       return;
     if (kind_ != MonitorElement::Kind::TPROFILE2D)
       return;
 
-    unsigned iME(binning::findPlotIndex(otype_, _id));
+    unsigned iME(binning::findPlotIndex(edso.electronicsMap, otype_, _id));
     checkME_(iME);
 
     MonitorElement *me(mes_[iME]);
 
     binning::ObjectType obj(binning::getObject(otype_, iME));
-    int xbin(binning::findBin1D(obj, btype_, _id));
+    int xbin(binning::findBin1D(edso.electronicsMap, obj, btype_, _id));
     int nbinsX(me->getTH1()->GetNbinsX());
     me->setBinEntries((nbinsX + 2) * _ybin + xbin, _entries);
   }
 
-  void MESetDet1D::setBinEntries(int _dcctccid, int _ybin, double _entries) {
+  void MESetDet1D::setBinEntries(EcalDQMSetupObjects const edso, int _dcctccid, int _ybin, double _entries) {
     if (!active_)
       return;
     if (kind_ != MonitorElement::Kind::TPROFILE2D)
       return;
 
-    unsigned iME(binning::findPlotIndex(otype_, _dcctccid));
+    unsigned iME(binning::findPlotIndex(edso.electronicsMap, otype_, _dcctccid));
     checkME_(iME);
 
     MonitorElement *me(mes_[iME]);
 
     binning::ObjectType obj(binning::getObject(otype_, iME));
-    int xbin(binning::findBin1D(obj, btype_, _dcctccid));
+    int xbin(binning::findBin1D(edso.electronicsMap, obj, btype_, _dcctccid));
     int nbinsX(me->getTH1()->GetNbinsX());
     me->setBinEntries((nbinsX + 2) * _ybin + xbin, _entries);
   }
 
-  double MESetDet1D::getBinContent(DetId const &_id, int _ybin /* = 0*/) const {
+  double MESetDet1D::getBinContent(EcalDQMSetupObjects const edso, DetId const &_id, int _ybin /* = 0*/) const {
     if (!active_)
       return 0.;
 
-    unsigned iME(binning::findPlotIndex(otype_, _id));
+    unsigned iME(binning::findPlotIndex(edso.electronicsMap, otype_, _id));
     checkME_(iME);
 
     MonitorElement *me(mes_[iME]);
 
     binning::ObjectType obj(binning::getObject(otype_, iME));
-    int xbin(binning::findBin1D(obj, btype_, _id));
+    int xbin(binning::findBin1D(edso.electronicsMap, obj, btype_, _id));
     int nbinsX(me->getTH1()->GetNbinsX());
 
     return me->getBinContent((nbinsX + 2) * _ybin + xbin);
   }
 
-  double MESetDet1D::getBinContent(EcalElectronicsId const &_id, int _ybin /* = 0*/) const {
+  double MESetDet1D::getBinContent(EcalDQMSetupObjects const edso, EcalElectronicsId const &_id, int _ybin /* = 0*/) const {
     if (!active_)
       return 0.;
 
-    unsigned iME(binning::findPlotIndex(otype_, _id));
+    unsigned iME(binning::findPlotIndex(edso.electronicsMap, otype_, _id));
     checkME_(iME);
 
     MonitorElement *me(mes_[iME]);
 
     binning::ObjectType obj(binning::getObject(otype_, iME));
-    int xbin(binning::findBin1D(obj, btype_, _id));
+    int xbin(binning::findBin1D(edso.electronicsMap, obj, btype_, _id));
     int nbinsX(me->getTH1()->GetNbinsX());
 
     return me->getBinContent((nbinsX + 2) * _ybin + xbin);
   }
 
-  double MESetDet1D::getBinContent(int _dcctccid, int _ybin /* = 0*/) const {
+  double MESetDet1D::getBinContent(EcalDQMSetupObjects const edso, int _dcctccid, int _ybin /* = 0*/) const {
     if (!active_)
       return 0.;
 
-    unsigned iME(binning::findPlotIndex(otype_, _dcctccid, btype_));
+    unsigned iME(binning::findPlotIndex(edso.electronicsMap, otype_, _dcctccid, btype_));
     checkME_(iME);
 
     MonitorElement *me(mes_[iME]);
 
     binning::ObjectType obj(binning::getObject(otype_, iME));
-    int xbin(binning::findBin1D(obj, btype_, _dcctccid));
+    int xbin(binning::findBin1D(edso.electronicsMap, obj, btype_, _dcctccid));
     int nbinsX(me->getTH1()->GetNbinsX());
 
     return me->getBinContent((nbinsX + 2) * _ybin + xbin);
   }
 
-  double MESetDet1D::getBinError(DetId const &_id, int _ybin /* = 0*/) const {
+  double MESetDet1D::getBinError(EcalDQMSetupObjects const edso, DetId const &_id, int _ybin /* = 0*/) const {
     if (!active_)
       return 0.;
 
-    unsigned iME(binning::findPlotIndex(otype_, _id));
+    unsigned iME(binning::findPlotIndex(edso.electronicsMap, otype_, _id));
     checkME_(iME);
 
     MonitorElement *me(mes_[iME]);
 
     binning::ObjectType obj(binning::getObject(otype_, iME));
-    int xbin(binning::findBin1D(obj, btype_, _id));
+    int xbin(binning::findBin1D(edso.electronicsMap, obj, btype_, _id));
     int nbinsX(me->getTH1()->GetNbinsX());
 
     return me->getBinError((nbinsX + 2) * _ybin + xbin);
   }
 
-  double MESetDet1D::getBinError(EcalElectronicsId const &_id, int _ybin /* = 0*/) const {
+  double MESetDet1D::getBinError(EcalDQMSetupObjects const edso, EcalElectronicsId const &_id, int _ybin /* = 0*/) const {
     if (!active_)
       return 0.;
 
-    unsigned iME(binning::findPlotIndex(otype_, _id));
+    unsigned iME(binning::findPlotIndex(edso.electronicsMap, otype_, _id));
     checkME_(iME);
 
     MonitorElement *me(mes_[iME]);
 
     binning::ObjectType obj(binning::getObject(otype_, iME));
-    int xbin(binning::findBin1D(obj, btype_, _id));
+    int xbin(binning::findBin1D(edso.electronicsMap, obj, btype_, _id));
     int nbinsX(me->getTH1()->GetNbinsX());
 
     return me->getBinError((nbinsX + 2) * _ybin + xbin);
   }
 
-  double MESetDet1D::getBinError(int _dcctccid, int _ybin /* = 0*/) const {
+  double MESetDet1D::getBinError(EcalDQMSetupObjects const edso, int _dcctccid, int _ybin /* = 0*/) const {
     if (!active_)
       return 0.;
 
-    unsigned iME(binning::findPlotIndex(otype_, _dcctccid, btype_));
+    unsigned iME(binning::findPlotIndex(edso.electronicsMap, otype_, _dcctccid, btype_));
     checkME_(iME);
 
     MonitorElement *me(mes_[iME]);
 
     binning::ObjectType obj(binning::getObject(otype_, iME));
-    int xbin(binning::findBin1D(obj, btype_, _dcctccid));
+    int xbin(binning::findBin1D(edso.electronicsMap, obj, btype_, _dcctccid));
     int nbinsX(me->getTH1()->GetNbinsX());
 
     return me->getBinError((nbinsX + 2) * _ybin + xbin);
   }
 
-  double MESetDet1D::getBinEntries(DetId const &_id, int _ybin /* = 0*/) const {
+  double MESetDet1D::getBinEntries(EcalDQMSetupObjects const edso, DetId const &_id, int _ybin /* = 0*/) const {
     if (!active_)
       return 0.;
     if (kind_ != MonitorElement::Kind::TPROFILE && kind_ != MonitorElement::Kind::TPROFILE2D)
       return 0.;
 
-    unsigned iME(binning::findPlotIndex(otype_, _id));
+    unsigned iME(binning::findPlotIndex(edso.electronicsMap, otype_, _id));
     checkME_(iME);
 
     MonitorElement *me(mes_[iME]);
 
     binning::ObjectType obj(binning::getObject(otype_, iME));
-    int xbin(binning::findBin1D(obj, btype_, _id));
+    int xbin(binning::findBin1D(edso.electronicsMap, obj, btype_, _id));
     int nbinsX(me->getTH1()->GetNbinsX());
 
     return me->getBinEntries((nbinsX + 2) * _ybin + xbin);
   }
 
-  double MESetDet1D::getBinEntries(EcalElectronicsId const &_id, int _ybin /* = 0*/) const {
+  double MESetDet1D::getBinEntries(EcalDQMSetupObjects const edso, EcalElectronicsId const &_id, int _ybin /* = 0*/) const {
     if (!active_)
       return 0.;
     if (kind_ != MonitorElement::Kind::TPROFILE && kind_ != MonitorElement::Kind::TPROFILE2D)
       return 0.;
 
-    unsigned iME(binning::findPlotIndex(otype_, _id));
+    unsigned iME(binning::findPlotIndex(edso.electronicsMap, otype_, _id));
     checkME_(iME);
 
     MonitorElement *me(mes_[iME]);
 
     binning::ObjectType obj(binning::getObject(otype_, iME));
-    int xbin(binning::findBin1D(obj, btype_, _id));
+    int xbin(binning::findBin1D(edso.electronicsMap, obj, btype_, _id));
     int nbinsX(me->getTH1()->GetNbinsX());
 
     return me->getBinEntries((nbinsX + 2) * _ybin + xbin);
   }
 
-  double MESetDet1D::getBinEntries(int _dcctccid, int _ybin /* = 0*/) const {
+  double MESetDet1D::getBinEntries(EcalDQMSetupObjects const edso, int _dcctccid, int _ybin /* = 0*/) const {
     if (!active_)
       return 0.;
     if (kind_ != MonitorElement::Kind::TPROFILE && kind_ != MonitorElement::Kind::TPROFILE2D)
       return 0.;
 
-    unsigned iME(binning::findPlotIndex(otype_, _dcctccid, btype_));
+    unsigned iME(binning::findPlotIndex(edso.electronicsMap, otype_, _dcctccid, btype_));
     checkME_(iME);
 
     MonitorElement *me(mes_[iME]);
 
     binning::ObjectType obj(binning::getObject(otype_, iME));
-    int xbin(binning::findBin1D(obj, btype_, _dcctccid));
+    int xbin(binning::findBin1D(edso.electronicsMap, obj, btype_, _dcctccid));
     int nbinsX(me->getTH1()->GetNbinsX());
 
     return me->getBinEntries((nbinsX + 2) * _ybin + xbin);
   }
 
-  int MESetDet1D::findBin(DetId const &_id) const {
+  int MESetDet1D::findBin(EcalDQMSetupObjects const edso, DetId const &_id) const {
     if (!active_)
       return -1;
     if (kind_ == MonitorElement::Kind::TPROFILE || kind_ == MonitorElement::Kind::TPROFILE2D)
       return -1;
 
-    unsigned iME(binning::findPlotIndex(otype_, _id));
+    unsigned iME(binning::findPlotIndex(edso.electronicsMap, otype_, _id));
     checkME_(iME);
 
     binning::ObjectType obj(binning::getObject(otype_, iME));
-    return binning::findBin1D(obj, btype_, _id);
+    return binning::findBin1D(edso.electronicsMap, obj, btype_, _id);
   }
 
-  int MESetDet1D::findBin(EcalElectronicsId const &_id) const {
+  int MESetDet1D::findBin(EcalDQMSetupObjects const edso, EcalElectronicsId const &_id) const {
     if (!active_)
       return -1;
     if (kind_ == MonitorElement::Kind::TPROFILE || kind_ == MonitorElement::Kind::TPROFILE2D)
       return -1;
 
-    unsigned iME(binning::findPlotIndex(otype_, _id));
+    unsigned iME(binning::findPlotIndex(edso.electronicsMap, otype_, _id));
     checkME_(iME);
 
     binning::ObjectType obj(binning::getObject(otype_, iME));
-    return binning::findBin1D(obj, btype_, _id);
+    return binning::findBin1D(edso.electronicsMap, obj, btype_, _id);
   }
 
-  int MESetDet1D::findBin(int _dcctccid) const {
+  int MESetDet1D::findBin(EcalDQMSetupObjects const edso, int _dcctccid) const {
     if (!active_)
       return -1;
     if (kind_ == MonitorElement::Kind::TPROFILE || kind_ == MonitorElement::Kind::TPROFILE2D)
       return -1;
 
-    unsigned iME(binning::findPlotIndex(otype_, _dcctccid));
+    unsigned iME(binning::findPlotIndex(edso.electronicsMap, otype_, _dcctccid));
     checkME_(iME);
 
     binning::ObjectType obj(binning::getObject(otype_, iME));
-    return binning::findBin1D(obj, btype_, _dcctccid);
+    return binning::findBin1D(edso.electronicsMap, obj, btype_, _dcctccid);
   }
 
-  int MESetDet1D::findBin(DetId const &_id, double _y, double) const {
+  int MESetDet1D::findBin(EcalDQMSetupObjects const edso, DetId const &_id, double _y, double) const {
     if (!active_)
       return -1;
     if (kind_ != MonitorElement::Kind::TPROFILE && kind_ != MonitorElement::Kind::TPROFILE2D)
       return -1;
 
-    unsigned iME(binning::findPlotIndex(otype_, _id));
+    unsigned iME(binning::findPlotIndex(edso.electronicsMap, otype_, _id));
     checkME_(iME);
 
     MonitorElement *me(mes_[iME]);
 
     binning::ObjectType obj(binning::getObject(otype_, iME));
-    int xbin(binning::findBin1D(obj, btype_, _id));
+    int xbin(binning::findBin1D(edso.electronicsMap, obj, btype_, _id));
     int nbinsX(me->getTH1()->GetNbinsX());
     return xbin + (nbinsX + 2) * me->getTH1()->GetYaxis()->FindBin(_y);
   }
 
-  int MESetDet1D::findBin(EcalElectronicsId const &_id, double _y, double) const {
+  int MESetDet1D::findBin(EcalDQMSetupObjects const edso, EcalElectronicsId const &_id, double _y, double) const {
     if (!active_)
       return -1;
     if (kind_ != MonitorElement::Kind::TPROFILE && kind_ != MonitorElement::Kind::TPROFILE2D)
       return -1;
 
-    unsigned iME(binning::findPlotIndex(otype_, _id));
+    unsigned iME(binning::findPlotIndex(edso.electronicsMap, otype_, _id));
     checkME_(iME);
 
     MonitorElement *me(mes_[iME]);
 
     binning::ObjectType obj(binning::getObject(otype_, iME));
-    int xbin(binning::findBin1D(obj, btype_, _id));
+    int xbin(binning::findBin1D(edso.electronicsMap, obj, btype_, _id));
     int nbinsX(me->getTH1()->GetNbinsX());
     return xbin + (nbinsX + 2) * me->getTH1()->GetYaxis()->FindBin(_y);
   }
 
-  int MESetDet1D::findBin(int _dcctccid, double _y, double) const {
+  int MESetDet1D::findBin(EcalDQMSetupObjects const edso, int _dcctccid, double _y, double) const {
     if (!active_)
       return -1;
     if (kind_ != MonitorElement::Kind::TPROFILE && kind_ != MonitorElement::Kind::TPROFILE2D)
       return -1;
 
-    unsigned iME(binning::findPlotIndex(otype_, _dcctccid));
+    unsigned iME(binning::findPlotIndex(edso.electronicsMap, otype_, _dcctccid));
     checkME_(iME);
 
     MonitorElement *me(mes_[iME]);
 
     binning::ObjectType obj(binning::getObject(otype_, iME));
-    int xbin(binning::findBin1D(obj, btype_, _dcctccid));
+    int xbin(binning::findBin1D(edso.electronicsMap, obj, btype_, _dcctccid));
     int nbinsX(me->getTH1()->GetNbinsX());
     return xbin + (nbinsX + 2) * me->getTH1()->GetYaxis()->FindBin(_y);
   }
 
-  void MESetDet1D::reset(double _content /* = 0.*/, double _err /* = 0.*/, double _entries /* = 0.*/) {
+  void MESetDet1D::reset(EcalElectronicsMapping const *, double _content /* = 0.*/, double _err /* = 0.*/, double _entries /* = 0.*/) {
     unsigned nME(binning::getNObjects(otype_));
 
     bool isProfile(kind_ == MonitorElement::Kind::TPROFILE || kind_ == MonitorElement::Kind::TPROFILE2D);

--- a/DQM/EcalCommon/src/MESetDet2D.cc
+++ b/DQM/EcalCommon/src/MESetDet2D.cc
@@ -104,7 +104,8 @@ namespace ecaldqm {
     }
   }
 
-  void MESetDet2D::fill(EcalDQMSetupObjects const edso, EcalElectronicsId const &_id, double _w /* = 1.*/, double, double) {
+  void MESetDet2D::fill(
+      EcalDQMSetupObjects const edso, EcalElectronicsId const &_id, double _w /* = 1.*/, double, double) {
     if (!active_)
       return;
 
@@ -492,7 +493,10 @@ namespace ecaldqm {
     return binning::findBin2D(edso.electronicsMap, obj, btype_, _id);
   }
 
-  void MESetDet2D::reset(EcalElectronicsMapping const *electronicsMap, double _content /* = 0.*/, double _err /* = 0.*/, double _entries /* = 0.*/) {
+  void MESetDet2D::reset(EcalElectronicsMapping const *electronicsMap,
+                         double _content /* = 0.*/,
+                         double _err /* = 0.*/,
+                         double _entries /* = 0.*/) {
     unsigned nME(binning::getNObjects(otype_));
 
     bool isProfile(kind_ == MonitorElement::Kind::TPROFILE2D);

--- a/DQM/EcalCommon/src/MESetDet2D.cc
+++ b/DQM/EcalCommon/src/MESetDet2D.cc
@@ -31,8 +31,8 @@ namespace ecaldqm {
     return copy;
   }
 
-  void MESetDet2D::book(DQMStore::IBooker &_ibooker) {
-    MESetEcal::book(_ibooker);
+  void MESetDet2D::book(DQMStore::IBooker &_ibooker, const EcalElectronicsMapping *electronicsMap) {
+    MESetEcal::book(_ibooker, electronicsMap);
 
     if (btype_ == binning::kCrystal) {
       for (unsigned iME(0); iME < mes_.size(); iME++) {
@@ -41,16 +41,16 @@ namespace ecaldqm {
         binning::ObjectType actualObject(binning::getObject(otype_, iME));
         if (actualObject == binning::kMEM) {
           for (int iBin(1); iBin <= me->getNbinsX(); ++iBin)
-            me->setBinLabel(iBin, binning::channelName(memDCCId(iBin - 1)));
+            me->setBinLabel(iBin, binning::channelName(electronicsMap, memDCCId(iBin - 1)));
         }
         if (actualObject == binning::kEBMEM) {
           for (int iBin(1); iBin <= me->getNbinsX(); ++iBin)
-            me->setBinLabel(iBin, binning::channelName(iBin + kEBmLow));
+            me->setBinLabel(iBin, binning::channelName(electronicsMap, iBin + kEBmLow));
         }
         if (actualObject == binning::kEEMEM) {
           for (int iBin(1); iBin <= me->getNbinsX() / 2; ++iBin) {
-            me->setBinLabel(iBin, binning::channelName(memDCCId(iBin - 1)));
-            me->setBinLabel(iBin + me->getNbinsX() / 2, binning::channelName(memDCCId(iBin + 39)));
+            me->setBinLabel(iBin, binning::channelName(electronicsMap, memDCCId(iBin - 1)));
+            me->setBinLabel(iBin + me->getNbinsX() / 2, binning::channelName(electronicsMap, memDCCId(iBin + 39)));
           }
         }
       }
@@ -75,11 +75,11 @@ namespace ecaldqm {
       resetAll(0., 0., -1.);
   }
 
-  void MESetDet2D::fill(DetId const &_id, double _w /* = 1.*/, double, double) {
+  void MESetDet2D::fill(EcalDQMSetupObjects const edso, DetId const &_id, double _w /* = 1.*/, double, double) {
     if (!active_)
       return;
 
-    unsigned iME(binning::findPlotIndex(otype_, _id));
+    unsigned iME(binning::findPlotIndex(edso.electronicsMap, otype_, _id));
     checkME_(iME);
 
     binning::ObjectType obj(binning::getObject(otype_, iME));
@@ -87,32 +87,32 @@ namespace ecaldqm {
     int bin;
 
     if (btype_ == binning::kRCT) {
-      bin = binning::findBin2D(obj, btype_, _id);
+      bin = binning::findBin2D(edso.electronicsMap, obj, btype_, _id);
       fill_(iME, bin, _w);
     } else {
       if (isEndcapTTId(_id)) {
-        std::vector<DetId> ids(getTrigTowerMap()->constituentsOf(EcalTrigTowerDetId(_id)));
+        std::vector<DetId> ids(edso.trigtowerMap->constituentsOf(EcalTrigTowerDetId(_id)));
         unsigned nId(ids.size());
         for (unsigned iId(0); iId < nId; iId++) {
-          bin = binning::findBin2D(obj, binning::kTriggerTower, ids[iId]);
+          bin = binning::findBin2D(edso.electronicsMap, obj, binning::kTriggerTower, ids[iId]);
           fill_(iME, bin, _w);
         }
       } else {
-        bin = binning::findBin2D(obj, btype_, _id);
+        bin = binning::findBin2D(edso.electronicsMap, obj, btype_, _id);
         fill_(iME, bin, _w);
       }
     }
   }
 
-  void MESetDet2D::fill(EcalElectronicsId const &_id, double _w /* = 1.*/, double, double) {
+  void MESetDet2D::fill(EcalDQMSetupObjects const edso, EcalElectronicsId const &_id, double _w /* = 1.*/, double, double) {
     if (!active_)
       return;
 
     unsigned iME(0);
     if (btype_ == binning::kPseudoStrip)
-      iME = binning::findPlotIndex(otype_, _id.dccId(), binning::kPseudoStrip);
+      iME = binning::findPlotIndex(edso.electronicsMap, otype_, _id.dccId(), binning::kPseudoStrip);
     else
-      iME = binning::findPlotIndex(otype_, _id);
+      iME = binning::findPlotIndex(edso.electronicsMap, otype_, _id);
     checkME_(iME);
 
     binning::ObjectType obj(binning::getObject(otype_, iME));
@@ -122,36 +122,36 @@ namespace ecaldqm {
     if (btype_ == binning::kPseudoStrip) {
       EcalElectronicsId stid(_id);
       std::vector<DetId> ids(
-          getElectronicsMap()->pseudoStripConstituents(stid.dccId(), stid.towerId(), stid.stripId()));
+          edso.electronicsMap->pseudoStripConstituents(stid.dccId(), stid.towerId(), stid.stripId()));
       unsigned nId(ids.size());
       for (unsigned iId(0); iId < nId; iId++) {
-        bin = binning::findBin2D(obj, btype_, ids[iId]);
+        bin = binning::findBin2D(edso.electronicsMap, obj, btype_, ids[iId]);
         fill_(iME, bin, _w);
       }
     } else {
-      bin = binning::findBin2D(obj, btype_, _id);
+      bin = binning::findBin2D(edso.electronicsMap, obj, btype_, _id);
       fill_(iME, bin, _w);
     }
   }
 
-  void MESetDet2D::fill(int _dcctccid, double _w /* = 1.*/, double, double) {
+  void MESetDet2D::fill(EcalDQMSetupObjects const edso, int _dcctccid, double _w /* = 1.*/, double, double) {
     if (!active_)
       return;
 
-    unsigned iME(binning::findPlotIndex(otype_, _dcctccid));
+    unsigned iME(binning::findPlotIndex(edso.electronicsMap, otype_, _dcctccid));
     checkME_(iME);
 
     binning::ObjectType obj(binning::getObject(otype_, iME));
 
-    int bin(binning::findBin2D(obj, btype_, _dcctccid));
+    int bin(binning::findBin2D(edso.electronicsMap, obj, btype_, _dcctccid));
     fill_(iME, bin, _w);
   }
 
-  void MESetDet2D::setBinContent(DetId const &_id, double _content) {
+  void MESetDet2D::setBinContent(EcalDQMSetupObjects const edso, DetId const &_id, double _content) {
     if (!active_)
       return;
 
-    unsigned iME(binning::findPlotIndex(otype_, _id));
+    unsigned iME(binning::findPlotIndex(edso.electronicsMap, otype_, _id));
     checkME_(iME);
 
     binning::ObjectType obj(binning::getObject(otype_, iME));
@@ -159,49 +159,49 @@ namespace ecaldqm {
     int bin;
 
     if (isEndcapTTId(_id)) {
-      std::vector<DetId> ids(getTrigTowerMap()->constituentsOf(EcalTrigTowerDetId(_id)));
+      std::vector<DetId> ids(edso.trigtowerMap->constituentsOf(EcalTrigTowerDetId(_id)));
       unsigned nId(ids.size());
       for (unsigned iId(0); iId < nId; iId++) {
-        bin = binning::findBin2D(obj, binning::kTriggerTower, ids[iId]);
+        bin = binning::findBin2D(edso.electronicsMap, obj, binning::kTriggerTower, ids[iId]);
         mes_[iME]->setBinContent(bin, _content);
       }
     } else {
-      bin = binning::findBin2D(obj, btype_, _id);
+      bin = binning::findBin2D(edso.electronicsMap, obj, btype_, _id);
       mes_[iME]->setBinContent(bin, _content);
     }
   }
 
-  void MESetDet2D::setBinContent(EcalElectronicsId const &_id, double _content) {
+  void MESetDet2D::setBinContent(EcalDQMSetupObjects const edso, EcalElectronicsId const &_id, double _content) {
     if (!active_)
       return;
 
-    unsigned iME(binning::findPlotIndex(otype_, _id));
+    unsigned iME(binning::findPlotIndex(edso.electronicsMap, otype_, _id));
     checkME_(iME);
 
     binning::ObjectType obj(binning::getObject(otype_, iME));
 
-    int bin(binning::findBin2D(obj, btype_, _id));
+    int bin(binning::findBin2D(edso.electronicsMap, obj, btype_, _id));
     mes_[iME]->setBinContent(bin, _content);
   }
 
-  void MESetDet2D::setBinContent(int _dcctccid, double _content) {
+  void MESetDet2D::setBinContent(EcalDQMSetupObjects const edso, int _dcctccid, double _content) {
     if (!active_)
       return;
 
-    unsigned iME(binning::findPlotIndex(otype_, _dcctccid));
+    unsigned iME(binning::findPlotIndex(edso.electronicsMap, otype_, _dcctccid));
     checkME_(iME);
 
     binning::ObjectType obj(binning::getObject(otype_, iME));
 
-    int bin(binning::findBin2D(obj, btype_, _dcctccid));
+    int bin(binning::findBin2D(edso.electronicsMap, obj, btype_, _dcctccid));
     mes_[iME]->setBinContent(bin, _content);
   }
 
-  void MESetDet2D::setBinError(DetId const &_id, double _error) {
+  void MESetDet2D::setBinError(EcalDQMSetupObjects const edso, DetId const &_id, double _error) {
     if (!active_)
       return;
 
-    unsigned iME(binning::findPlotIndex(otype_, _id));
+    unsigned iME(binning::findPlotIndex(edso.electronicsMap, otype_, _id));
     checkME_(iME);
 
     binning::ObjectType obj(binning::getObject(otype_, iME));
@@ -209,51 +209,51 @@ namespace ecaldqm {
     int bin;
 
     if (isEndcapTTId(_id)) {
-      std::vector<DetId> ids(getTrigTowerMap()->constituentsOf(EcalTrigTowerDetId(_id)));
+      std::vector<DetId> ids(edso.trigtowerMap->constituentsOf(EcalTrigTowerDetId(_id)));
       unsigned nId(ids.size());
       for (unsigned iId(0); iId < nId; iId++) {
-        bin = binning::findBin2D(obj, binning::kTriggerTower, ids[iId]);
+        bin = binning::findBin2D(edso.electronicsMap, obj, binning::kTriggerTower, ids[iId]);
         mes_[iME]->setBinError(bin, _error);
       }
     } else {
-      bin = binning::findBin2D(obj, btype_, _id);
+      bin = binning::findBin2D(edso.electronicsMap, obj, btype_, _id);
       mes_[iME]->setBinError(bin, _error);
     }
   }
 
-  void MESetDet2D::setBinError(EcalElectronicsId const &_id, double _error) {
+  void MESetDet2D::setBinError(EcalDQMSetupObjects const edso, EcalElectronicsId const &_id, double _error) {
     if (!active_)
       return;
 
-    unsigned iME(binning::findPlotIndex(otype_, _id));
+    unsigned iME(binning::findPlotIndex(edso.electronicsMap, otype_, _id));
     checkME_(iME);
 
     binning::ObjectType obj(binning::getObject(otype_, iME));
 
-    int bin(binning::findBin2D(obj, btype_, _id));
+    int bin(binning::findBin2D(edso.electronicsMap, obj, btype_, _id));
     mes_[iME]->setBinError(bin, _error);
   }
 
-  void MESetDet2D::setBinError(int _dcctccid, double _error) {
+  void MESetDet2D::setBinError(EcalDQMSetupObjects const edso, int _dcctccid, double _error) {
     if (!active_)
       return;
 
-    unsigned iME(binning::findPlotIndex(otype_, _dcctccid));
+    unsigned iME(binning::findPlotIndex(edso.electronicsMap, otype_, _dcctccid));
     checkME_(iME);
 
     binning::ObjectType obj(binning::getObject(otype_, iME));
 
-    int bin(binning::findBin2D(obj, btype_, _dcctccid));
+    int bin(binning::findBin2D(edso.electronicsMap, obj, btype_, _dcctccid));
     mes_[iME]->setBinError(bin, _error);
   }
 
-  void MESetDet2D::setBinEntries(DetId const &_id, double _entries) {
+  void MESetDet2D::setBinEntries(EcalDQMSetupObjects const edso, DetId const &_id, double _entries) {
     if (!active_)
       return;
     if (kind_ != MonitorElement::Kind::TPROFILE2D)
       return;
 
-    unsigned iME(binning::findPlotIndex(otype_, _id));
+    unsigned iME(binning::findPlotIndex(edso.electronicsMap, otype_, _id));
     checkME_(iME);
 
     binning::ObjectType obj(binning::getObject(otype_, iME));
@@ -261,51 +261,51 @@ namespace ecaldqm {
     int bin;
 
     if (isEndcapTTId(_id)) {
-      std::vector<DetId> ids(getTrigTowerMap()->constituentsOf(EcalTrigTowerDetId(_id)));
+      std::vector<DetId> ids(edso.trigtowerMap->constituentsOf(EcalTrigTowerDetId(_id)));
       unsigned nId(ids.size());
       for (unsigned iId(0); iId < nId; iId++) {
-        bin = binning::findBin2D(obj, binning::kTriggerTower, ids[iId]);
+        bin = binning::findBin2D(edso.electronicsMap, obj, binning::kTriggerTower, ids[iId]);
         mes_[iME]->setBinEntries(bin, _entries);
       }
     } else {
-      bin = binning::findBin2D(obj, btype_, _id);
+      bin = binning::findBin2D(edso.electronicsMap, obj, btype_, _id);
       mes_[iME]->setBinEntries(bin, _entries);
     }
   }
 
-  void MESetDet2D::setBinEntries(EcalElectronicsId const &_id, double _entries) {
+  void MESetDet2D::setBinEntries(EcalDQMSetupObjects const edso, EcalElectronicsId const &_id, double _entries) {
     if (!active_)
       return;
     if (kind_ != MonitorElement::Kind::TPROFILE2D)
       return;
 
-    unsigned iME(binning::findPlotIndex(otype_, _id));
+    unsigned iME(binning::findPlotIndex(edso.electronicsMap, otype_, _id));
     checkME_(iME);
 
     binning::ObjectType obj(binning::getObject(otype_, iME));
 
-    int bin(binning::findBin2D(obj, btype_, _id));
+    int bin(binning::findBin2D(edso.electronicsMap, obj, btype_, _id));
     mes_[iME]->setBinEntries(bin, _entries);
   }
 
-  void MESetDet2D::setBinEntries(int _dcctccid, double _entries) {
+  void MESetDet2D::setBinEntries(EcalDQMSetupObjects const edso, int _dcctccid, double _entries) {
     if (!active_)
       return;
 
-    unsigned iME(binning::findPlotIndex(otype_, _dcctccid));
+    unsigned iME(binning::findPlotIndex(edso.electronicsMap, otype_, _dcctccid));
     checkME_(iME);
 
     binning::ObjectType obj(binning::getObject(otype_, iME));
 
-    int bin(binning::findBin2D(obj, btype_, _dcctccid));
+    int bin(binning::findBin2D(edso.electronicsMap, obj, btype_, _dcctccid));
     mes_[iME]->setBinEntries(bin, _entries);
   }
 
-  double MESetDet2D::getBinContent(DetId const &_id, int) const {
+  double MESetDet2D::getBinContent(EcalDQMSetupObjects const edso, DetId const &_id, int) const {
     if (!active_)
       return 0.;
 
-    unsigned iME(binning::findPlotIndex(otype_, _id));
+    unsigned iME(binning::findPlotIndex(edso.electronicsMap, otype_, _id));
     checkME_(iME);
 
     binning::ObjectType obj(binning::getObject(otype_, iME));
@@ -313,48 +313,48 @@ namespace ecaldqm {
     int bin;
 
     if (isEndcapTTId(_id)) {
-      std::vector<DetId> ids(getTrigTowerMap()->constituentsOf(EcalTrigTowerDetId(_id)));
-      bin = binning::findBin2D(obj, binning::kTriggerTower, ids[0]);
+      std::vector<DetId> ids(edso.trigtowerMap->constituentsOf(EcalTrigTowerDetId(_id)));
+      bin = binning::findBin2D(edso.electronicsMap, obj, binning::kTriggerTower, ids[0]);
     } else {
-      bin = binning::findBin2D(obj, btype_, _id);
+      bin = binning::findBin2D(edso.electronicsMap, obj, btype_, _id);
     }
 
     return mes_[iME]->getBinContent(bin);
   }
 
-  double MESetDet2D::getBinContent(EcalElectronicsId const &_id, int) const {
+  double MESetDet2D::getBinContent(EcalDQMSetupObjects const edso, EcalElectronicsId const &_id, int) const {
     if (!active_)
       return 0.;
 
-    unsigned iME(binning::findPlotIndex(otype_, _id));
+    unsigned iME(binning::findPlotIndex(edso.electronicsMap, otype_, _id));
     checkME_(iME);
 
     binning::ObjectType obj(binning::getObject(otype_, iME));
 
-    int bin(binning::findBin2D(obj, btype_, _id));
+    int bin(binning::findBin2D(edso.electronicsMap, obj, btype_, _id));
 
     return mes_[iME]->getBinContent(bin);
   }
 
-  double MESetDet2D::getBinContent(int _dcctccid, int) const {
+  double MESetDet2D::getBinContent(EcalDQMSetupObjects const edso, int _dcctccid, int) const {
     if (!active_)
       return 0.;
 
-    unsigned iME(binning::findPlotIndex(otype_, _dcctccid));
+    unsigned iME(binning::findPlotIndex(edso.electronicsMap, otype_, _dcctccid));
     checkME_(iME);
 
     binning::ObjectType obj(binning::getObject(otype_, iME));
 
-    int bin(binning::findBin2D(obj, btype_, _dcctccid));
+    int bin(binning::findBin2D(edso.electronicsMap, obj, btype_, _dcctccid));
 
     return mes_[iME]->getBinContent(bin);
   }
 
-  double MESetDet2D::getBinError(DetId const &_id, int) const {
+  double MESetDet2D::getBinError(EcalDQMSetupObjects const edso, DetId const &_id, int) const {
     if (!active_)
       return 0.;
 
-    unsigned iME(binning::findPlotIndex(otype_, _id));
+    unsigned iME(binning::findPlotIndex(edso.electronicsMap, otype_, _id));
     checkME_(iME);
 
     binning::ObjectType obj(binning::getObject(otype_, iME));
@@ -362,50 +362,50 @@ namespace ecaldqm {
     int bin;
 
     if (isEndcapTTId(_id)) {
-      std::vector<DetId> ids(getTrigTowerMap()->constituentsOf(EcalTrigTowerDetId(_id)));
-      bin = binning::findBin2D(obj, binning::kTriggerTower, ids[0]);
+      std::vector<DetId> ids(edso.trigtowerMap->constituentsOf(EcalTrigTowerDetId(_id)));
+      bin = binning::findBin2D(edso.electronicsMap, obj, binning::kTriggerTower, ids[0]);
     } else {
-      bin = binning::findBin2D(obj, btype_, _id);
+      bin = binning::findBin2D(edso.electronicsMap, obj, btype_, _id);
     }
 
     return mes_[iME]->getBinError(bin);
   }
 
-  double MESetDet2D::getBinError(EcalElectronicsId const &_id, int) const {
+  double MESetDet2D::getBinError(EcalDQMSetupObjects const edso, EcalElectronicsId const &_id, int) const {
     if (!active_)
       return 0.;
 
-    unsigned iME(binning::findPlotIndex(otype_, _id));
+    unsigned iME(binning::findPlotIndex(edso.electronicsMap, otype_, _id));
     checkME_(iME);
 
     binning::ObjectType obj(binning::getObject(otype_, iME));
 
-    int bin(binning::findBin2D(obj, btype_, _id));
+    int bin(binning::findBin2D(edso.electronicsMap, obj, btype_, _id));
 
     return mes_[iME]->getBinError(bin);
   }
 
-  double MESetDet2D::getBinError(int _dcctccid, int) const {
+  double MESetDet2D::getBinError(EcalDQMSetupObjects const edso, int _dcctccid, int) const {
     if (!active_)
       return 0.;
 
-    unsigned iME(binning::findPlotIndex(otype_, _dcctccid));
+    unsigned iME(binning::findPlotIndex(edso.electronicsMap, otype_, _dcctccid));
     checkME_(iME);
 
     binning::ObjectType obj(binning::getObject(otype_, iME));
 
-    int bin(binning::findBin2D(obj, btype_, _dcctccid));
+    int bin(binning::findBin2D(edso.electronicsMap, obj, btype_, _dcctccid));
 
     return mes_[iME]->getBinError(bin);
   }
 
-  double MESetDet2D::getBinEntries(DetId const &_id, int) const {
+  double MESetDet2D::getBinEntries(EcalDQMSetupObjects const edso, DetId const &_id, int) const {
     if (!active_)
       return 0.;
     if (kind_ != MonitorElement::Kind::TPROFILE2D)
       return 0.;
 
-    unsigned iME(binning::findPlotIndex(otype_, _id));
+    unsigned iME(binning::findPlotIndex(edso.electronicsMap, otype_, _id));
     checkME_(iME);
 
     binning::ObjectType obj(binning::getObject(otype_, iME));
@@ -413,10 +413,10 @@ namespace ecaldqm {
     int bin;
 
     if (isEndcapTTId(_id)) {
-      std::vector<DetId> ids(getTrigTowerMap()->constituentsOf(EcalTrigTowerDetId(_id)));
-      bin = binning::findBin2D(obj, binning::kTriggerTower, ids[0]);
+      std::vector<DetId> ids(edso.trigtowerMap->constituentsOf(EcalTrigTowerDetId(_id)));
+      bin = binning::findBin2D(edso.electronicsMap, obj, binning::kTriggerTower, ids[0]);
     } else {
-      bin = binning::findBin2D(obj, btype_, _id);
+      bin = binning::findBin2D(edso.electronicsMap, obj, btype_, _id);
     }
 
     double entries(mes_[iME]->getBinEntries(bin));
@@ -426,18 +426,18 @@ namespace ecaldqm {
       return entries;
   }
 
-  double MESetDet2D::getBinEntries(EcalElectronicsId const &_id, int) const {
+  double MESetDet2D::getBinEntries(EcalDQMSetupObjects const edso, EcalElectronicsId const &_id, int) const {
     if (!active_)
       return 0.;
     if (kind_ != MonitorElement::Kind::TPROFILE2D)
       return 0.;
 
-    unsigned iME(binning::findPlotIndex(otype_, _id));
+    unsigned iME(binning::findPlotIndex(edso.electronicsMap, otype_, _id));
     checkME_(iME);
 
     binning::ObjectType obj(binning::getObject(otype_, iME));
 
-    int bin(binning::findBin2D(obj, btype_, _id));
+    int bin(binning::findBin2D(edso.electronicsMap, obj, btype_, _id));
 
     double entries(mes_[iME]->getBinEntries(bin));
     if (entries < 0.)
@@ -446,16 +446,16 @@ namespace ecaldqm {
       return entries;
   }
 
-  double MESetDet2D::getBinEntries(int _dcctccid, int) const {
+  double MESetDet2D::getBinEntries(EcalDQMSetupObjects const edso, int _dcctccid, int) const {
     if (!active_)
       return 0.;
 
-    unsigned iME(binning::findPlotIndex(otype_, _dcctccid));
+    unsigned iME(binning::findPlotIndex(edso.electronicsMap, otype_, _dcctccid));
     checkME_(iME);
 
     binning::ObjectType obj(binning::getObject(otype_, iME));
 
-    int bin(binning::findBin2D(obj, btype_, _dcctccid));
+    int bin(binning::findBin2D(edso.electronicsMap, obj, btype_, _dcctccid));
 
     double entries(mes_[iME]->getBinEntries(bin));
     if (entries < 0.)
@@ -464,35 +464,35 @@ namespace ecaldqm {
       return entries;
   }
 
-  int MESetDet2D::findBin(DetId const &_id) const {
+  int MESetDet2D::findBin(EcalDQMSetupObjects const edso, DetId const &_id) const {
     if (!active_)
       return 0;
 
-    unsigned iME(binning::findPlotIndex(otype_, _id));
+    unsigned iME(binning::findPlotIndex(edso.electronicsMap, otype_, _id));
     checkME_(iME);
 
     binning::ObjectType obj(binning::getObject(otype_, iME));
 
     if (isEndcapTTId(_id)) {
-      std::vector<DetId> ids(getTrigTowerMap()->constituentsOf(EcalTrigTowerDetId(_id)));
-      return binning::findBin2D(obj, binning::kTriggerTower, ids[0]);
+      std::vector<DetId> ids(edso.trigtowerMap->constituentsOf(EcalTrigTowerDetId(_id)));
+      return binning::findBin2D(edso.electronicsMap, obj, binning::kTriggerTower, ids[0]);
     } else
-      return binning::findBin2D(obj, btype_, _id);
+      return binning::findBin2D(edso.electronicsMap, obj, btype_, _id);
   }
 
-  int MESetDet2D::findBin(EcalElectronicsId const &_id) const {
+  int MESetDet2D::findBin(EcalDQMSetupObjects const edso, EcalElectronicsId const &_id) const {
     if (!active_)
       return 0;
 
-    unsigned iME(binning::findPlotIndex(otype_, _id));
+    unsigned iME(binning::findPlotIndex(edso.electronicsMap, otype_, _id));
     checkME_(iME);
 
     binning::ObjectType obj(binning::getObject(otype_, iME));
 
-    return binning::findBin2D(obj, btype_, _id);
+    return binning::findBin2D(edso.electronicsMap, obj, btype_, _id);
   }
 
-  void MESetDet2D::reset(double _content /* = 0.*/, double _err /* = 0.*/, double _entries /* = 0.*/) {
+  void MESetDet2D::reset(EcalElectronicsMapping const *electronicsMap, double _content /* = 0.*/, double _err /* = 0.*/, double _entries /* = 0.*/) {
     unsigned nME(binning::getNObjects(otype_));
 
     bool isProfile(kind_ == MonitorElement::Kind::TPROFILE2D);
@@ -507,7 +507,7 @@ namespace ecaldqm {
       for (int ix(1); ix <= nbinsX; ix++) {
         for (int iy(1); iy <= nbinsY; iy++) {
           int bin((nbinsX + 2) * iy + ix);
-          if (!binning::isValidIdBin(obj, btype_, iME, bin))
+          if (!binning::isValidIdBin(electronicsMap, obj, btype_, iME, bin))
             continue;
           me->setBinContent(bin, _content);
           me->setBinError(bin, _err);

--- a/DQM/EcalCommon/src/MESetEcal.cc
+++ b/DQM/EcalCommon/src/MESetEcal.cc
@@ -277,7 +277,9 @@ namespace ecaldqm {
     active_ = true;
   }
 
-  bool MESetEcal::retrieve(EcalElectronicsMapping const *electronicsMap, DQMStore::IGetter &_igetter, std::string *_failedPath /* = 0*/) const {
+  bool MESetEcal::retrieve(EcalElectronicsMapping const *electronicsMap,
+                           DQMStore::IGetter &_igetter,
+                           std::string *_failedPath /* = 0*/) const {
     clear();
 
     std::vector<std::string> mePaths(generatePaths(electronicsMap));
@@ -307,7 +309,11 @@ namespace ecaldqm {
     return true;
   }
 
-  void MESetEcal::fill(EcalDQMSetupObjects const edso, DetId const &_id, double _x /* = 1.*/, double _wy /* = 1.*/, double _w /* = 1.*/) {
+  void MESetEcal::fill(EcalDQMSetupObjects const edso,
+                       DetId const &_id,
+                       double _x /* = 1.*/,
+                       double _wy /* = 1.*/,
+                       double _w /* = 1.*/) {
     if (!active_)
       return;
 
@@ -317,7 +323,11 @@ namespace ecaldqm {
     fill_(iME, _x, _wy, _w);
   }
 
-  void MESetEcal::fill(EcalDQMSetupObjects const edso, EcalElectronicsId const &_id, double _x /* = 1.*/, double _wy /* = 1.*/, double _w /* = 1.*/) {
+  void MESetEcal::fill(EcalDQMSetupObjects const edso,
+                       EcalElectronicsId const &_id,
+                       double _x /* = 1.*/,
+                       double _wy /* = 1.*/,
+                       double _w /* = 1.*/) {
     if (!active_)
       return;
 
@@ -327,7 +337,8 @@ namespace ecaldqm {
     fill_(iME, _x, _wy, _w);
   }
 
-  void MESetEcal::fill(EcalDQMSetupObjects const edso, int _dcctccid, double _x /* = 1.*/, double _wy /* = 1.*/, double _w /* = 1.*/) {
+  void MESetEcal::fill(
+      EcalDQMSetupObjects const edso, int _dcctccid, double _x /* = 1.*/, double _wy /* = 1.*/, double _w /* = 1.*/) {
     if (!active_)
       return;
 
@@ -357,7 +368,10 @@ namespace ecaldqm {
     mes_[iME]->setBinContent(_bin, _content);
   }
 
-  void MESetEcal::setBinContent(EcalDQMSetupObjects const edso, EcalElectronicsId const &_id, int _bin, double _content) {
+  void MESetEcal::setBinContent(EcalDQMSetupObjects const edso,
+                                EcalElectronicsId const &_id,
+                                int _bin,
+                                double _content) {
     if (!active_)
       return;
 
@@ -419,7 +433,10 @@ namespace ecaldqm {
     mes_[iME]->setBinEntries(_bin, _entries);
   }
 
-  void MESetEcal::setBinEntries(EcalDQMSetupObjects const edso, EcalElectronicsId const &_id, int _bin, double _entries) {
+  void MESetEcal::setBinEntries(EcalDQMSetupObjects const edso,
+                                EcalElectronicsId const &_id,
+                                int _bin,
+                                double _entries) {
     if (!active_)
       return;
     if (kind_ != MonitorElement::Kind::TPROFILE && kind_ != MonitorElement::Kind::TPROFILE2D)
@@ -549,7 +566,10 @@ namespace ecaldqm {
     return mes_[iME]->getTH1()->FindBin(_x, _y);
   }
 
-  int MESetEcal::findBin(EcalDQMSetupObjects const edso, EcalElectronicsId const &_id, double _x, double _y /* = 0.*/) const {
+  int MESetEcal::findBin(EcalDQMSetupObjects const edso,
+                         EcalElectronicsId const &_id,
+                         double _x,
+                         double _y /* = 0.*/) const {
     if (!active_)
       return -1;
 

--- a/DQM/EcalCommon/src/MESetEcal.cc
+++ b/DQM/EcalCommon/src/MESetEcal.cc
@@ -67,7 +67,7 @@ namespace ecaldqm {
     return copy;
   }
 
-  void MESetEcal::book(DQMStore::IBooker &_ibooker) {
+  void MESetEcal::book(DQMStore::IBooker &_ibooker, EcalElectronicsMapping const *electronicsMap) {
     using namespace std;
 
     auto oldscope = MonitorElementData::Scope::RUN;
@@ -76,7 +76,7 @@ namespace ecaldqm {
 
     clear();
 
-    vector<string> mePaths(generatePaths());
+    vector<string> mePaths(generatePaths(electronicsMap));
 
     for (unsigned iME(0); iME < mePaths.size(); iME++) {
       string &path(mePaths[iME]);
@@ -99,7 +99,7 @@ namespace ecaldqm {
           zaxis = *zaxis_;
 
         if (xaxis.nbins == 0) {  // uses preset
-          binning::AxisSpecs xdef(binning::getBinning(actualObject, btype_, isMap, 1, iME));
+          binning::AxisSpecs xdef(binning::getBinning(electronicsMap, actualObject, btype_, isMap, 1, iME));
           if (xaxis.labels || !xaxis.title.empty()) {  // PSet specifies title / label only
             std::string *labels(xaxis.labels);
             std::string title(xaxis.title);
@@ -112,7 +112,7 @@ namespace ecaldqm {
         }
 
         if (isMap && yaxis.nbins == 0) {
-          binning::AxisSpecs ydef(binning::getBinning(actualObject, btype_, isMap, 2, iME));
+          binning::AxisSpecs ydef(binning::getBinning(electronicsMap, actualObject, btype_, isMap, 2, iME));
           if (yaxis.labels || !yaxis.title.empty()) {  // PSet specifies title / label only
             std::string *labels(yaxis.labels);
             std::string title(yaxis.title);
@@ -277,10 +277,10 @@ namespace ecaldqm {
     active_ = true;
   }
 
-  bool MESetEcal::retrieve(DQMStore::IGetter &_igetter, std::string *_failedPath /* = 0*/) const {
+  bool MESetEcal::retrieve(EcalElectronicsMapping const *electronicsMap, DQMStore::IGetter &_igetter, std::string *_failedPath /* = 0*/) const {
     clear();
 
-    std::vector<std::string> mePaths(generatePaths());
+    std::vector<std::string> mePaths(generatePaths(electronicsMap));
     if (mePaths.empty()) {
       if (_failedPath)
         _failedPath->clear();
@@ -307,37 +307,37 @@ namespace ecaldqm {
     return true;
   }
 
-  void MESetEcal::fill(DetId const &_id, double _x /* = 1.*/, double _wy /* = 1.*/, double _w /* = 1.*/) {
+  void MESetEcal::fill(EcalDQMSetupObjects const edso, DetId const &_id, double _x /* = 1.*/, double _wy /* = 1.*/, double _w /* = 1.*/) {
     if (!active_)
       return;
 
-    unsigned iME(binning::findPlotIndex(otype_, _id));
+    unsigned iME(binning::findPlotIndex(edso.electronicsMap, otype_, _id));
     checkME_(iME);
 
     fill_(iME, _x, _wy, _w);
   }
 
-  void MESetEcal::fill(EcalElectronicsId const &_id, double _x /* = 1.*/, double _wy /* = 1.*/, double _w /* = 1.*/) {
+  void MESetEcal::fill(EcalDQMSetupObjects const edso, EcalElectronicsId const &_id, double _x /* = 1.*/, double _wy /* = 1.*/, double _w /* = 1.*/) {
     if (!active_)
       return;
 
-    unsigned iME(binning::findPlotIndex(otype_, _id));
+    unsigned iME(binning::findPlotIndex(edso.electronicsMap, otype_, _id));
     checkME_(iME);
 
     fill_(iME, _x, _wy, _w);
   }
 
-  void MESetEcal::fill(int _dcctccid, double _x /* = 1.*/, double _wy /* = 1.*/, double _w /* = 1.*/) {
+  void MESetEcal::fill(EcalDQMSetupObjects const edso, int _dcctccid, double _x /* = 1.*/, double _wy /* = 1.*/, double _w /* = 1.*/) {
     if (!active_)
       return;
 
-    unsigned iME(binning::findPlotIndex(otype_, _dcctccid, btype_));
+    unsigned iME(binning::findPlotIndex(edso.electronicsMap, otype_, _dcctccid, btype_));
     checkME_(iME);
 
     fill_(iME, _x, _wy, _w);
   }
 
-  void MESetEcal::fill(double _x, double _wy /* = 1.*/, double _w /* = 1.*/) {
+  void MESetEcal::fill(EcalDQMSetupObjects const edso, double _x, double _wy /* = 1.*/, double _w /* = 1.*/) {
     if (!active_)
       return;
 
@@ -347,223 +347,223 @@ namespace ecaldqm {
     fill_(0, _x, _wy, _w);
   }
 
-  void MESetEcal::setBinContent(DetId const &_id, int _bin, double _content) {
+  void MESetEcal::setBinContent(EcalDQMSetupObjects const edso, DetId const &_id, int _bin, double _content) {
     if (!active_)
       return;
 
-    unsigned iME(binning::findPlotIndex(otype_, _id));
+    unsigned iME(binning::findPlotIndex(edso.electronicsMap, otype_, _id));
     checkME_(iME);
 
     mes_[iME]->setBinContent(_bin, _content);
   }
 
-  void MESetEcal::setBinContent(EcalElectronicsId const &_id, int _bin, double _content) {
+  void MESetEcal::setBinContent(EcalDQMSetupObjects const edso, EcalElectronicsId const &_id, int _bin, double _content) {
     if (!active_)
       return;
 
-    unsigned iME(binning::findPlotIndex(otype_, _id));
+    unsigned iME(binning::findPlotIndex(edso.electronicsMap, otype_, _id));
     checkME_(iME);
 
     mes_[iME]->setBinContent(_bin, _content);
   }
 
-  void MESetEcal::setBinContent(int _dcctccid, int _bin, double _content) {
+  void MESetEcal::setBinContent(EcalDQMSetupObjects const edso, int _dcctccid, int _bin, double _content) {
     if (!active_)
       return;
 
-    unsigned iME(binning::findPlotIndex(otype_, _dcctccid, btype_));
+    unsigned iME(binning::findPlotIndex(edso.electronicsMap, otype_, _dcctccid, btype_));
     checkME_(iME);
 
     mes_[iME]->setBinContent(_bin, _content);
   }
 
-  void MESetEcal::setBinError(DetId const &_id, int _bin, double _error) {
+  void MESetEcal::setBinError(EcalDQMSetupObjects const edso, DetId const &_id, int _bin, double _error) {
     if (!active_)
       return;
 
-    unsigned iME(binning::findPlotIndex(otype_, _id));
+    unsigned iME(binning::findPlotIndex(edso.electronicsMap, otype_, _id));
     checkME_(iME);
 
     mes_[iME]->setBinError(_bin, _error);
   }
 
-  void MESetEcal::setBinError(EcalElectronicsId const &_id, int _bin, double _error) {
+  void MESetEcal::setBinError(EcalDQMSetupObjects const edso, EcalElectronicsId const &_id, int _bin, double _error) {
     if (!active_)
       return;
 
-    unsigned iME(binning::findPlotIndex(otype_, _id));
+    unsigned iME(binning::findPlotIndex(edso.electronicsMap, otype_, _id));
     checkME_(iME);
 
     mes_[iME]->setBinError(_bin, _error);
   }
 
-  void MESetEcal::setBinError(int _dcctccid, int _bin, double _error) {
+  void MESetEcal::setBinError(EcalDQMSetupObjects const edso, int _dcctccid, int _bin, double _error) {
     if (!active_)
       return;
 
-    unsigned iME(binning::findPlotIndex(otype_, _dcctccid, btype_));
+    unsigned iME(binning::findPlotIndex(edso.electronicsMap, otype_, _dcctccid, btype_));
     checkME_(iME);
 
     mes_[iME]->setBinError(_bin, _error);
   }
 
-  void MESetEcal::setBinEntries(DetId const &_id, int _bin, double _entries) {
+  void MESetEcal::setBinEntries(EcalDQMSetupObjects const edso, DetId const &_id, int _bin, double _entries) {
     if (!active_)
       return;
     if (kind_ != MonitorElement::Kind::TPROFILE && kind_ != MonitorElement::Kind::TPROFILE2D)
       return;
 
-    unsigned iME(binning::findPlotIndex(otype_, _id));
+    unsigned iME(binning::findPlotIndex(edso.electronicsMap, otype_, _id));
     checkME_(iME);
 
     mes_[iME]->setBinEntries(_bin, _entries);
   }
 
-  void MESetEcal::setBinEntries(EcalElectronicsId const &_id, int _bin, double _entries) {
+  void MESetEcal::setBinEntries(EcalDQMSetupObjects const edso, EcalElectronicsId const &_id, int _bin, double _entries) {
     if (!active_)
       return;
     if (kind_ != MonitorElement::Kind::TPROFILE && kind_ != MonitorElement::Kind::TPROFILE2D)
       return;
 
-    unsigned iME(binning::findPlotIndex(otype_, _id));
+    unsigned iME(binning::findPlotIndex(edso.electronicsMap, otype_, _id));
     checkME_(iME);
 
     mes_[iME]->setBinEntries(_bin, _entries);
   }
 
-  void MESetEcal::setBinEntries(int _dcctccid, int _bin, double _entries) {
+  void MESetEcal::setBinEntries(EcalDQMSetupObjects const edso, int _dcctccid, int _bin, double _entries) {
     if (!active_)
       return;
     if (kind_ != MonitorElement::Kind::TPROFILE && kind_ != MonitorElement::Kind::TPROFILE2D)
       return;
 
-    unsigned iME(binning::findPlotIndex(otype_, _dcctccid, btype_));
+    unsigned iME(binning::findPlotIndex(edso.electronicsMap, otype_, _dcctccid, btype_));
     checkME_(iME);
 
     mes_[iME]->setBinEntries(_bin, _entries);
   }
 
-  double MESetEcal::getBinContent(DetId const &_id, int _bin) const {
+  double MESetEcal::getBinContent(EcalDQMSetupObjects const edso, DetId const &_id, int _bin) const {
     if (!active_)
       return 0.;
 
-    unsigned iME(binning::findPlotIndex(otype_, _id));
+    unsigned iME(binning::findPlotIndex(edso.electronicsMap, otype_, _id));
     checkME_(iME);
 
     return mes_[iME]->getBinContent(_bin);
   }
 
-  double MESetEcal::getBinContent(EcalElectronicsId const &_id, int _bin) const {
+  double MESetEcal::getBinContent(EcalDQMSetupObjects const edso, EcalElectronicsId const &_id, int _bin) const {
     if (!active_)
       return 0.;
 
-    unsigned iME(binning::findPlotIndex(otype_, _id));
+    unsigned iME(binning::findPlotIndex(edso.electronicsMap, otype_, _id));
     checkME_(iME);
 
     return mes_[iME]->getBinContent(_bin);
   }
 
-  double MESetEcal::getBinContent(int _dcctccid, int _bin) const {
+  double MESetEcal::getBinContent(EcalDQMSetupObjects const edso, int _dcctccid, int _bin) const {
     if (!active_)
       return 0.;
 
-    unsigned iME(binning::findPlotIndex(otype_, _dcctccid, btype_));
+    unsigned iME(binning::findPlotIndex(edso.electronicsMap, otype_, _dcctccid, btype_));
     checkME_(iME);
 
     return mes_[iME]->getBinContent(_bin);
   }
 
-  double MESetEcal::getBinError(DetId const &_id, int _bin) const {
+  double MESetEcal::getBinError(EcalDQMSetupObjects const edso, DetId const &_id, int _bin) const {
     if (!active_)
       return 0.;
 
-    unsigned iME(binning::findPlotIndex(otype_, _id));
+    unsigned iME(binning::findPlotIndex(edso.electronicsMap, otype_, _id));
     checkME_(iME);
 
     return mes_[iME]->getBinError(_bin);
   }
 
-  double MESetEcal::getBinError(EcalElectronicsId const &_id, int _bin) const {
+  double MESetEcal::getBinError(EcalDQMSetupObjects const edso, EcalElectronicsId const &_id, int _bin) const {
     if (!active_)
       return 0.;
 
-    unsigned iME(binning::findPlotIndex(otype_, _id));
+    unsigned iME(binning::findPlotIndex(edso.electronicsMap, otype_, _id));
     checkME_(iME);
 
     return mes_[iME]->getBinError(_bin);
   }
 
-  double MESetEcal::getBinError(int _dcctccid, int _bin) const {
+  double MESetEcal::getBinError(EcalDQMSetupObjects const edso, int _dcctccid, int _bin) const {
     if (!active_)
       return 0.;
 
-    unsigned iME(binning::findPlotIndex(otype_, _dcctccid, btype_));
+    unsigned iME(binning::findPlotIndex(edso.electronicsMap, otype_, _dcctccid, btype_));
     checkME_(iME);
 
     return mes_[iME]->getBinError(_bin);
   }
 
-  double MESetEcal::getBinEntries(DetId const &_id, int _bin) const {
+  double MESetEcal::getBinEntries(EcalDQMSetupObjects const edso, DetId const &_id, int _bin) const {
     if (!active_)
       return 0.;
     if (kind_ != MonitorElement::Kind::TPROFILE && kind_ != MonitorElement::Kind::TPROFILE2D)
       return 0.;
 
-    unsigned iME(binning::findPlotIndex(otype_, _id));
+    unsigned iME(binning::findPlotIndex(edso.electronicsMap, otype_, _id));
     checkME_(iME);
 
     return mes_[iME]->getBinEntries(_bin);
   }
 
-  double MESetEcal::getBinEntries(EcalElectronicsId const &_id, int _bin) const {
+  double MESetEcal::getBinEntries(EcalDQMSetupObjects const edso, EcalElectronicsId const &_id, int _bin) const {
     if (!active_)
       return 0.;
     if (kind_ != MonitorElement::Kind::TPROFILE && kind_ != MonitorElement::Kind::TPROFILE2D)
       return 0.;
 
-    unsigned iME(binning::findPlotIndex(otype_, _id));
+    unsigned iME(binning::findPlotIndex(edso.electronicsMap, otype_, _id));
     checkME_(iME);
 
     return mes_[iME]->getBinEntries(_bin);
   }
 
-  double MESetEcal::getBinEntries(int _dcctccid, int _bin) const {
+  double MESetEcal::getBinEntries(EcalDQMSetupObjects const edso, int _dcctccid, int _bin) const {
     if (!active_)
       return 0.;
     if (kind_ != MonitorElement::Kind::TPROFILE && kind_ != MonitorElement::Kind::TPROFILE2D)
       return 0.;
 
-    unsigned iME(binning::findPlotIndex(otype_, _dcctccid, btype_));
+    unsigned iME(binning::findPlotIndex(edso.electronicsMap, otype_, _dcctccid, btype_));
     checkME_(iME);
 
     return mes_[iME]->getBinEntries(_bin);
   }
 
-  int MESetEcal::findBin(DetId const &_id, double _x, double _y /* = 0.*/) const {
+  int MESetEcal::findBin(EcalDQMSetupObjects const edso, DetId const &_id, double _x, double _y /* = 0.*/) const {
     if (!active_)
       return -1;
 
-    unsigned iME(binning::findPlotIndex(otype_, _id));
+    unsigned iME(binning::findPlotIndex(edso.electronicsMap, otype_, _id));
     checkME_(iME);
 
     return mes_[iME]->getTH1()->FindBin(_x, _y);
   }
 
-  int MESetEcal::findBin(EcalElectronicsId const &_id, double _x, double _y /* = 0.*/) const {
+  int MESetEcal::findBin(EcalDQMSetupObjects const edso, EcalElectronicsId const &_id, double _x, double _y /* = 0.*/) const {
     if (!active_)
       return -1;
 
-    unsigned iME(binning::findPlotIndex(otype_, _id));
+    unsigned iME(binning::findPlotIndex(edso.electronicsMap, otype_, _id));
     checkME_(iME);
 
     return mes_[iME]->getTH1()->FindBin(_x, _y);
   }
 
-  int MESetEcal::findBin(int _dcctccid, double _x, double _y /* = 0.*/) const {
+  int MESetEcal::findBin(EcalDQMSetupObjects const edso, int _dcctccid, double _x, double _y /* = 0.*/) const {
     if (!active_)
       return -1;
 
-    unsigned iME(binning::findPlotIndex(otype_, _dcctccid, btype_));
+    unsigned iME(binning::findPlotIndex(edso.electronicsMap, otype_, _dcctccid, btype_));
     checkME_(iME);
 
     return mes_[iME]->getTH1()->FindBin(_x, _y);
@@ -573,7 +573,7 @@ namespace ecaldqm {
     return (xaxis_ && xaxis_->edges) || (yaxis_ && yaxis_->edges) || (zaxis_ && zaxis_->edges);
   }
 
-  std::vector<std::string> MESetEcal::generatePaths() const {
+  std::vector<std::string> MESetEcal::generatePaths(EcalElectronicsMapping const *electronicsMap) const {
     using namespace std;
 
     vector<string> paths(0);
@@ -630,18 +630,18 @@ namespace ecaldqm {
             replacements["prefix"] = "EB";
             replacements["supercrystal"] = "trigger tower";
           }
-          replacements["sm"] = binning::channelName(iME + 1);
+          replacements["sm"] = binning::channelName(electronicsMap, iME + 1);
           break;
         case binning::kEBSM:
           replacements["subdet"] = "EcalBarrel";
           replacements["prefix"] = "EB";
-          replacements["sm"] = binning::channelName(iME + kEBmLow + 1);
+          replacements["sm"] = binning::channelName(electronicsMap, iME + kEBmLow + 1);
           replacements["supercrystal"] = "trigger tower";
           break;
         case binning::kEESM:
           replacements["subdet"] = "EcalEndcap";
           replacements["prefix"] = "EE";
-          replacements["sm"] = binning::channelName(iME <= kEEmHigh ? iME + 1 : iME + 37);
+          replacements["sm"] = binning::channelName(electronicsMap, iME <= kEEmHigh ? iME + 1 : iME + 37);
           replacements["supercrystal"] = "super crystal";
           break;
         case binning::kSMMEM: {
@@ -654,19 +654,19 @@ namespace ecaldqm {
             replacements["subdet"] = "EcalBarrel";
             replacements["prefix"] = "EB";
           }
-          replacements["sm"] = binning::channelName(iDCC + 1);
+          replacements["sm"] = binning::channelName(electronicsMap, iDCC + 1);
         } break;
         case binning::kEBSMMEM: {
           unsigned iDCC(memDCCId(iME + 4) - 1);
           replacements["subdet"] = "EcalBarrel";
           replacements["prefix"] = "EB";
-          replacements["sm"] = binning::channelName(iDCC + 1);
+          replacements["sm"] = binning::channelName(electronicsMap, iDCC + 1);
         } break;
         case binning::kEESMMEM: {
           unsigned iDCC(memDCCId(iME < 4 ? iME : iME + 36) - 1);
           replacements["subdet"] = "EcalEndcap";
           replacements["prefix"] = "EE";
-          replacements["sm"] = binning::channelName(iDCC + 1);
+          replacements["sm"] = binning::channelName(electronicsMap, iDCC + 1);
         }
         default:
           break;

--- a/DQM/EcalCommon/src/MESetMulti.cc
+++ b/DQM/EcalCommon/src/MESetMulti.cc
@@ -94,16 +94,16 @@ namespace ecaldqm {
     return copy;
   }
 
-  void MESetMulti::book(DQMStore::IBooker &_ibooker) {
+  void MESetMulti::book(DQMStore::IBooker &_ibooker, EcalElectronicsMapping const *electronicsMap) {
     for (unsigned iS(0); iS < sets_.size(); ++iS)
-      sets_[iS]->book(_ibooker);
+      sets_[iS]->book(_ibooker, electronicsMap);
 
     active_ = true;
   }
 
-  bool MESetMulti::retrieve(DQMStore::IGetter &_igetter, std::string *_failedPath /* = 0*/) const {
+  bool MESetMulti::retrieve(EcalElectronicsMapping const *electronicsMap, DQMStore::IGetter &_igetter, std::string *_failedPath /* = 0*/) const {
     for (unsigned iS(0); iS < sets_.size(); ++iS)
-      if (!sets_[iS]->retrieve(_igetter, _failedPath))
+      if (!sets_[iS]->retrieve(electronicsMap, _igetter, _failedPath))
         return false;
 
     active_ = true;
@@ -117,9 +117,9 @@ namespace ecaldqm {
     active_ = false;
   }
 
-  void MESetMulti::reset(double _content /* = 0*/, double _error /* = 0.*/, double _entries /* = 0.*/) {
+  void MESetMulti::reset(EcalElectronicsMapping const *electronicsMap, double _content /* = 0*/, double _error /* = 0.*/, double _entries /* = 0.*/) {
     for (unsigned iS(0); iS < sets_.size(); ++iS)
-      sets_[iS]->reset(_content, _error, _entries);
+      sets_[iS]->reset(electronicsMap, _content, _error, _entries);
   }
 
   void MESetMulti::resetAll(double _content /* = 0*/, double _error /* = 0.*/, double _entries /* = 0.*/) {

--- a/DQM/EcalCommon/src/MESetMulti.cc
+++ b/DQM/EcalCommon/src/MESetMulti.cc
@@ -101,7 +101,9 @@ namespace ecaldqm {
     active_ = true;
   }
 
-  bool MESetMulti::retrieve(EcalElectronicsMapping const *electronicsMap, DQMStore::IGetter &_igetter, std::string *_failedPath /* = 0*/) const {
+  bool MESetMulti::retrieve(EcalElectronicsMapping const *electronicsMap,
+                            DQMStore::IGetter &_igetter,
+                            std::string *_failedPath /* = 0*/) const {
     for (unsigned iS(0); iS < sets_.size(); ++iS)
       if (!sets_[iS]->retrieve(electronicsMap, _igetter, _failedPath))
         return false;
@@ -117,7 +119,10 @@ namespace ecaldqm {
     active_ = false;
   }
 
-  void MESetMulti::reset(EcalElectronicsMapping const *electronicsMap, double _content /* = 0*/, double _error /* = 0.*/, double _entries /* = 0.*/) {
+  void MESetMulti::reset(EcalElectronicsMapping const *electronicsMap,
+                         double _content /* = 0*/,
+                         double _error /* = 0.*/,
+                         double _entries /* = 0.*/) {
     for (unsigned iS(0); iS < sets_.size(); ++iS)
       sets_[iS]->reset(electronicsMap, _content, _error, _entries);
   }

--- a/DQM/EcalCommon/src/MESetNonObject.cc
+++ b/DQM/EcalCommon/src/MESetNonObject.cc
@@ -54,7 +54,7 @@ namespace ecaldqm {
     return copy;
   }
 
-  void MESetNonObject::book(DQMStore::IBooker &_ibooker) {
+  void MESetNonObject::book(DQMStore::IBooker &_ibooker, EcalElectronicsMapping const *electronicsMap) {
     using namespace std;
 
     clear();
@@ -182,7 +182,7 @@ namespace ecaldqm {
     active_ = true;
   }
 
-  bool MESetNonObject::retrieve(DQMStore::IGetter &_igetter, std::string *_failedPath /* = 0*/) const {
+  bool MESetNonObject::retrieve(EcalElectronicsMapping const *electronicsMap, DQMStore::IGetter &_igetter, std::string *_failedPath /* = 0*/) const {
     mes_.clear();
 
     MonitorElement *me(_igetter.get(path_));
@@ -198,7 +198,7 @@ namespace ecaldqm {
     return true;
   }
 
-  void MESetNonObject::fill(double _x, double _wy /* = 1.*/, double _w /* = 1.*/) {
+  void MESetNonObject::fill(EcalDQMSetupObjects const edso, double _x, double _wy /* = 1.*/, double _w /* = 1.*/) {
     if (!active_)
       return;
 
@@ -222,7 +222,7 @@ namespace ecaldqm {
     }
   }
 
-  void MESetNonObject::setBinContent(int _bin, double _content) {
+  void MESetNonObject::setBinContent(EcalDQMSetupObjects const edso, int _bin, double _content) {
     if (!active_)
       return;
     if (kind_ == MonitorElement::Kind::REAL)
@@ -234,7 +234,7 @@ namespace ecaldqm {
     mes_[0]->setBinContent(_bin, _content);
   }
 
-  void MESetNonObject::setBinError(int _bin, double _error) {
+  void MESetNonObject::setBinError(EcalDQMSetupObjects const edso, int _bin, double _error) {
     if (!active_)
       return;
     if (kind_ == MonitorElement::Kind::REAL)
@@ -246,7 +246,7 @@ namespace ecaldqm {
     mes_[0]->setBinError(_bin, _error);
   }
 
-  void MESetNonObject::setBinEntries(int _bin, double _entries) {
+  void MESetNonObject::setBinEntries(EcalDQMSetupObjects const edso, int _bin, double _entries) {
     if (!active_)
       return;
     if (kind_ != MonitorElement::Kind::TPROFILE && kind_ != MonitorElement::Kind::TPROFILE2D)
@@ -258,7 +258,7 @@ namespace ecaldqm {
     mes_[0]->setBinEntries(_bin, _entries);
   }
 
-  double MESetNonObject::getBinContent(int _bin, int) const {
+  double MESetNonObject::getBinContent(EcalDQMSetupObjects const edso, int _bin, int) const {
     if (!active_)
       return 0.;
     if (kind_ == MonitorElement::Kind::REAL)
@@ -277,7 +277,7 @@ namespace ecaldqm {
       return 0.;
   }
 
-  double MESetNonObject::getBinError(int _bin, int) const {
+  double MESetNonObject::getBinError(EcalDQMSetupObjects const edso, int _bin, int) const {
     if (!active_)
       return 0.;
     if (kind_ == MonitorElement::Kind::REAL)
@@ -289,7 +289,7 @@ namespace ecaldqm {
     return mes_[0]->getBinError(_bin);
   }
 
-  double MESetNonObject::getBinEntries(int _bin, int) const {
+  double MESetNonObject::getBinEntries(EcalDQMSetupObjects const edso, int _bin, int) const {
     if (!active_)
       return 0.;
     if (kind_ != MonitorElement::Kind::TPROFILE && kind_ != MonitorElement::Kind::TPROFILE2D)
@@ -301,7 +301,7 @@ namespace ecaldqm {
     return mes_[0]->getBinEntries(_bin);
   }
 
-  int MESetNonObject::findBin(double _x, double _y /* = 0.*/) const {
+  int MESetNonObject::findBin(EcalDQMSetupObjects const edso, double _x, double _y /* = 0.*/) const {
     if (!active_)
       return 0;
 

--- a/DQM/EcalCommon/src/MESetNonObject.cc
+++ b/DQM/EcalCommon/src/MESetNonObject.cc
@@ -182,7 +182,9 @@ namespace ecaldqm {
     active_ = true;
   }
 
-  bool MESetNonObject::retrieve(EcalElectronicsMapping const *electronicsMap, DQMStore::IGetter &_igetter, std::string *_failedPath /* = 0*/) const {
+  bool MESetNonObject::retrieve(EcalElectronicsMapping const *electronicsMap,
+                                DQMStore::IGetter &_igetter,
+                                std::string *_failedPath /* = 0*/) const {
     mes_.clear();
 
     MonitorElement *me(_igetter.get(path_));

--- a/DQM/EcalCommon/src/MESetProjection.cc
+++ b/DQM/EcalCommon/src/MESetProjection.cc
@@ -39,11 +39,11 @@ namespace ecaldqm {
     return copy;
   }
 
-  void MESetProjection::fill(DetId const &_id, double _w /* = 1.*/, double, double) {
+  void MESetProjection::fill(EcalDQMSetupObjects const edso, DetId const &_id, double _w /* = 1.*/, double, double) {
     if (!active_)
       return;
 
-    unsigned iME(binning::findPlotIndex(otype_, _id));
+    unsigned iME(binning::findPlotIndex(edso.electronicsMap, otype_, _id));
     checkME_(iME);
 
     int subdet(_id.subdetId());
@@ -51,23 +51,23 @@ namespace ecaldqm {
     if (subdet == EcalBarrel) {
       EBDetId ebid(_id);
       if (btype_ == binning::kProjEta)
-        fill_(iME, eta(ebid), _w, 0.);
+        fill_(iME, eta(ebid, edso.geometry), _w, 0.);
       else if (btype_ == binning::kProjPhi)
         fill_(iME, phi(ebid), _w, 0.);
     } else if (subdet == EcalEndcap) {
       EEDetId eeid(_id);
       if (btype_ == binning::kProjEta)
-        fill_(iME, eta(eeid), _w, 0.);
+        fill_(iME, eta(eeid, edso.geometry), _w, 0.);
       if (btype_ == binning::kProjPhi) {
         fill_(iME, phi(eeid), _w, 0.);
       }
     } else if (isEndcapTTId(_id)) {
       EcalTrigTowerDetId ttid(_id);
-      std::vector<DetId> ids(getTrigTowerMap()->constituentsOf(ttid));
+      std::vector<DetId> ids(edso.trigtowerMap->constituentsOf(ttid));
       unsigned nIds(ids.size());
       if (btype_ == binning::kProjEta) {
         for (unsigned iId(0); iId < nIds; iId++)
-          fill_(iME, eta(EEDetId(ids[iId])), _w / nIds, 0.);
+          fill_(iME, eta(EEDetId(ids[iId]), edso.geometry), _w / nIds, 0.);
       } else if (btype_ == binning::kProjPhi) {
         for (unsigned iId(0); iId < nIds; iId++)
           fill_(iME, phi(EEDetId(ids[iId])), _w / nIds, 0.);
@@ -85,11 +85,11 @@ namespace ecaldqm {
     }
   }
 
-  void MESetProjection::fill(int _subdet, double _x /* = 1.*/, double _w /* = 1.*/, double) {
+  void MESetProjection::fill(EcalDQMSetupObjects const edso, int _subdet, double _x /* = 1.*/, double _w /* = 1.*/, double) {
     if (!active_)
       return;
 
-    unsigned iME(binning::findPlotIndex(otype_, _subdet, btype_));
+    unsigned iME(binning::findPlotIndex(edso.electronicsMap, otype_, _subdet, btype_));
     checkME_(iME);
 
     if (btype_ == binning::kProjPhi)
@@ -98,7 +98,7 @@ namespace ecaldqm {
     mes_[iME]->Fill(_x, _w);
   }
 
-  void MESetProjection::fill(double _x, double _w /* = 1.*/, double) {
+  void MESetProjection::fill(EcalDQMSetupObjects const edso, double _x, double _w /* = 1.*/, double) {
     if (!active_)
       return;
     if (btype_ != binning::kProjEta)
@@ -120,23 +120,23 @@ namespace ecaldqm {
     mes_[iME]->Fill(_x, _w);
   }
 
-  void MESetProjection::setBinContent(DetId const &_id, double _content) {
+  void MESetProjection::setBinContent(EcalDQMSetupObjects const edso, DetId const &_id, double _content) {
     if (!active_)
       return;
 
-    unsigned iME(binning::findPlotIndex(otype_, _id));
+    unsigned iME(binning::findPlotIndex(edso.electronicsMap, otype_, _id));
     checkME_(iME);
 
     MonitorElement *me(mes_[iME]);
 
     if (isEndcapTTId(_id)) {
       EcalTrigTowerDetId ttid(_id);
-      std::vector<DetId> ids(getTrigTowerMap()->constituentsOf(ttid));
+      std::vector<DetId> ids(edso.trigtowerMap->constituentsOf(ttid));
       unsigned nIds(ids.size());
       std::set<int> bins;
       if (btype_ == binning::kProjEta) {
         for (unsigned iId(0); iId < nIds; iId++) {
-          int bin(me->getTH1()->FindBin(eta(EEDetId(ids[iId]))));
+          int bin(me->getTH1()->FindBin(eta(EEDetId(ids[iId]), edso.geometry)));
           if (bins.find(bin) != bins.end())
             continue;
           me->setBinContent(bin, _content);
@@ -157,12 +157,12 @@ namespace ecaldqm {
     if (subdet == EcalBarrel) {
       EBDetId ebid(_id);
       if (btype_ == binning::kProjEta)
-        x = eta(ebid);
+        x = eta(ebid, edso.geometry);
       else if (btype_ == binning::kProjPhi)
         x = phi(ebid);
     } else if (subdet == EcalEndcap) {
       if (btype_ == binning::kProjEta)
-        x = eta(EEDetId(_id));
+        x = eta(EEDetId(_id), edso.geometry);
       else if (btype_ == binning::kProjPhi)
         x = phi(EEDetId(_id));
     } else if (subdet == EcalTriggerTower) {
@@ -181,23 +181,23 @@ namespace ecaldqm {
     me->setBinContent(bin, _content);
   }
 
-  void MESetProjection::setBinError(DetId const &_id, double _error) {
+  void MESetProjection::setBinError(EcalDQMSetupObjects const edso, DetId const &_id, double _error) {
     if (!active_)
       return;
 
-    unsigned iME(binning::findPlotIndex(otype_, _id));
+    unsigned iME(binning::findPlotIndex(edso.electronicsMap, otype_, _id));
     checkME_(iME);
 
     MonitorElement *me(mes_[iME]);
 
     if (isEndcapTTId(_id)) {
       EcalTrigTowerDetId ttid(_id);
-      std::vector<DetId> ids(getTrigTowerMap()->constituentsOf(ttid));
+      std::vector<DetId> ids(edso.trigtowerMap->constituentsOf(ttid));
       unsigned nIds(ids.size());
       std::set<int> bins;
       if (btype_ == binning::kProjEta) {
         for (unsigned iId(0); iId < nIds; iId++) {
-          int bin(me->getTH1()->FindBin(eta(EEDetId(ids[iId]))));
+          int bin(me->getTH1()->FindBin(eta(EEDetId(ids[iId]), edso.geometry)));
           if (bins.find(bin) != bins.end())
             continue;
           me->setBinError(bin, _error);
@@ -218,12 +218,12 @@ namespace ecaldqm {
     if (subdet == EcalBarrel) {
       EBDetId ebid(_id);
       if (btype_ == binning::kProjEta)
-        x = eta(ebid);
+        x = eta(ebid, edso.geometry);
       else if (btype_ == binning::kProjPhi)
         x = phi(ebid);
     } else if (subdet == EcalEndcap) {
       if (btype_ == binning::kProjEta)
-        x = eta(EEDetId(_id));
+        x = eta(EEDetId(_id), edso.geometry);
       else if (btype_ == binning::kProjPhi)
         x = phi(EEDetId(_id));
     } else if (subdet == EcalTriggerTower) {
@@ -242,23 +242,23 @@ namespace ecaldqm {
     me->setBinError(bin, _error);
   }
 
-  void MESetProjection::setBinEntries(DetId const &_id, double _entries) {
+  void MESetProjection::setBinEntries(EcalDQMSetupObjects const edso, DetId const &_id, double _entries) {
     if (!active_)
       return;
 
-    unsigned iME(binning::findPlotIndex(otype_, _id));
+    unsigned iME(binning::findPlotIndex(edso.electronicsMap, otype_, _id));
     checkME_(iME);
 
     MonitorElement *me(mes_[iME]);
 
     if (isEndcapTTId(_id)) {
       EcalTrigTowerDetId ttid(_id);
-      std::vector<DetId> ids(getTrigTowerMap()->constituentsOf(ttid));
+      std::vector<DetId> ids(edso.trigtowerMap->constituentsOf(ttid));
       unsigned nIds(ids.size());
       std::set<int> bins;
       if (btype_ == binning::kProjEta) {
         for (unsigned iId(0); iId < nIds; iId++) {
-          int bin(me->getTH1()->FindBin(eta(EEDetId(ids[iId]))));
+          int bin(me->getTH1()->FindBin(eta(EEDetId(ids[iId]), edso.geometry)));
           if (bins.find(bin) != bins.end())
             continue;
           me->setBinEntries(bin, _entries);
@@ -279,12 +279,12 @@ namespace ecaldqm {
     if (subdet == EcalBarrel) {
       EBDetId ebid(_id);
       if (btype_ == binning::kProjEta)
-        x = eta(ebid);
+        x = eta(ebid, edso.geometry);
       else if (btype_ == binning::kProjPhi)
         x = phi(ebid);
     } else if (subdet == EcalEndcap) {
       if (btype_ == binning::kProjEta)
-        x = eta(EEDetId(_id));
+        x = eta(EEDetId(_id), edso.geometry);
       else if (btype_ == binning::kProjPhi)
         x = phi(EEDetId(_id));
     } else if (subdet == EcalTriggerTower) {
@@ -303,20 +303,20 @@ namespace ecaldqm {
     me->setBinEntries(bin, _entries);
   }
 
-  double MESetProjection::getBinContent(DetId const &_id, int) const {
+  double MESetProjection::getBinContent(EcalDQMSetupObjects const edso, DetId const &_id, int) const {
     if (!active_)
       return 0.;
 
-    unsigned iME(binning::findPlotIndex(otype_, _id));
+    unsigned iME(binning::findPlotIndex(edso.electronicsMap, otype_, _id));
     checkME_(iME);
 
     MonitorElement *me(mes_[iME]);
 
     if (isEndcapTTId(_id)) {
       EcalTrigTowerDetId ttid(_id);
-      std::vector<DetId> ids(getTrigTowerMap()->constituentsOf(ttid));
+      std::vector<DetId> ids(edso.trigtowerMap->constituentsOf(ttid));
       if (btype_ == binning::kProjEta) {
-        int bin(me->getTH1()->FindBin(eta(EEDetId(ids[0]))));
+        int bin(me->getTH1()->FindBin(eta(EEDetId(ids[0]), edso.geometry)));
         return me->getBinContent(bin);
       } else if (btype_ == binning::kProjPhi) {
         int bin(me->getTH1()->FindBin(phi(EEDetId(ids[0]))));
@@ -330,12 +330,12 @@ namespace ecaldqm {
     if (subdet == EcalBarrel) {
       EBDetId ebid(_id);
       if (btype_ == binning::kProjEta)
-        x = eta(ebid);
+        x = eta(ebid, edso.geometry);
       else if (btype_ == binning::kProjPhi)
         x = phi(ebid);
     } else if (subdet == EcalEndcap) {
       if (btype_ == binning::kProjEta)
-        x = eta(EEDetId(_id));
+        x = eta(EEDetId(_id), edso.geometry);
       else if (btype_ == binning::kProjPhi)
         x = phi(EEDetId(_id));
     } else if (subdet == EcalTriggerTower) {
@@ -354,20 +354,20 @@ namespace ecaldqm {
     return me->getBinContent(bin);
   }
 
-  double MESetProjection::getBinError(DetId const &_id, int) const {
+  double MESetProjection::getBinError(EcalDQMSetupObjects const edso, DetId const &_id, int) const {
     if (!active_)
       return 0.;
 
-    unsigned iME(binning::findPlotIndex(otype_, _id));
+    unsigned iME(binning::findPlotIndex(edso.electronicsMap, otype_, _id));
     checkME_(iME);
 
     MonitorElement *me(mes_[iME]);
 
     if (isEndcapTTId(_id)) {
       EcalTrigTowerDetId ttid(_id);
-      std::vector<DetId> ids(getTrigTowerMap()->constituentsOf(ttid));
+      std::vector<DetId> ids(edso.trigtowerMap->constituentsOf(ttid));
       if (btype_ == binning::kProjEta) {
-        int bin(me->getTH1()->FindBin(eta(EEDetId(ids[0]))));
+        int bin(me->getTH1()->FindBin(eta(EEDetId(ids[0]), edso.geometry)));
         return me->getBinError(bin);
       } else if (btype_ == binning::kProjPhi) {
         int bin(me->getTH1()->FindBin(phi(EEDetId(ids[0]))));
@@ -381,12 +381,12 @@ namespace ecaldqm {
     if (subdet == EcalBarrel) {
       EBDetId ebid(_id);
       if (btype_ == binning::kProjEta)
-        x = eta(ebid);
+        x = eta(ebid, edso.geometry);
       else if (btype_ == binning::kProjPhi)
         x = phi(ebid);
     } else if (subdet == EcalEndcap) {
       if (btype_ == binning::kProjEta)
-        x = eta(EEDetId(_id));
+        x = eta(EEDetId(_id), edso.geometry);
       else if (btype_ == binning::kProjPhi)
         x = phi(EEDetId(_id));
     } else if (subdet == EcalTriggerTower) {
@@ -405,20 +405,20 @@ namespace ecaldqm {
     return me->getBinError(bin);
   }
 
-  double MESetProjection::getBinEntries(DetId const &_id, int) const {
+  double MESetProjection::getBinEntries(EcalDQMSetupObjects const edso, DetId const &_id, int) const {
     if (!active_)
       return 0.;
 
-    unsigned iME(binning::findPlotIndex(otype_, _id));
+    unsigned iME(binning::findPlotIndex(edso.electronicsMap, otype_, _id));
     checkME_(iME);
 
     MonitorElement *me(mes_[iME]);
 
     if (isEndcapTTId(_id)) {
       EcalTrigTowerDetId ttid(_id);
-      std::vector<DetId> ids(getTrigTowerMap()->constituentsOf(ttid));
+      std::vector<DetId> ids(edso.trigtowerMap->constituentsOf(ttid));
       if (btype_ == binning::kProjEta) {
-        int bin(me->getTH1()->FindBin(eta(EEDetId(ids[0]))));
+        int bin(me->getTH1()->FindBin(eta(EEDetId(ids[0]), edso.geometry)));
         return me->getBinEntries(bin);
       } else if (btype_ == binning::kProjPhi) {
         int bin(me->getTH1()->FindBin(phi(EEDetId(ids[0]))));
@@ -432,12 +432,12 @@ namespace ecaldqm {
     if (subdet == EcalBarrel) {
       EBDetId ebid(_id);
       if (btype_ == binning::kProjEta)
-        x = eta(ebid);
+        x = eta(ebid, edso.geometry);
       else if (btype_ == binning::kProjPhi)
         x = phi(ebid);
     } else if (subdet == EcalEndcap) {
       if (btype_ == binning::kProjEta)
-        x = eta(EEDetId(_id));
+        x = eta(EEDetId(_id), edso.geometry);
       else if (btype_ == binning::kProjPhi)
         x = phi(EEDetId(_id));
     } else if (subdet == EcalTriggerTower) {

--- a/DQM/EcalCommon/src/MESetProjection.cc
+++ b/DQM/EcalCommon/src/MESetProjection.cc
@@ -85,7 +85,8 @@ namespace ecaldqm {
     }
   }
 
-  void MESetProjection::fill(EcalDQMSetupObjects const edso, int _subdet, double _x /* = 1.*/, double _w /* = 1.*/, double) {
+  void MESetProjection::fill(
+      EcalDQMSetupObjects const edso, int _subdet, double _x /* = 1.*/, double _w /* = 1.*/, double) {
     if (!active_)
       return;
 

--- a/DQM/EcalCommon/src/MESetTrend.cc
+++ b/DQM/EcalCommon/src/MESetTrend.cc
@@ -48,7 +48,7 @@ namespace ecaldqm {
     return copy;
   }
 
-  void MESetTrend::book(DQMStore::IBooker &_ibooker) {
+  void MESetTrend::book(DQMStore::IBooker &_ibooker, EcalElectronicsMapping const *electronicsMap) {
     binning::AxisSpecs xaxis;
     if (xaxis_)
       xaxis = *xaxis_;
@@ -74,7 +74,7 @@ namespace ecaldqm {
     binning::AxisSpecs const *xaxisTemp(xaxis_);
     xaxis_ = &xaxis;
 
-    MESetEcal::book(_ibooker);
+    MESetEcal::book(_ibooker, electronicsMap);
 
     xaxis_ = xaxisTemp;
 
@@ -86,40 +86,40 @@ namespace ecaldqm {
       setAxisTitle("LumiSections");
   }
 
-  void MESetTrend::fill(DetId const &_id, double _t, double _wy /* = 1.*/, double _w /* = 1.*/) {
+  void MESetTrend::fill(EcalDQMSetupObjects const edso, DetId const &_id, double _t, double _wy /* = 1.*/, double _w /* = 1.*/) {
     if (!active_)
       return;
 
-    unsigned iME(binning::findPlotIndex(otype_, _id));
+    unsigned iME(binning::findPlotIndex(edso.electronicsMap, otype_, _id));
     checkME_(iME);
 
     if (shift_(unsigned(_t)))
       fill_(iME, _t + 0.5, _wy, _w);
   }
 
-  void MESetTrend::fill(EcalElectronicsId const &_id, double _t, double _wy /* = 1.*/, double _w /* = 1.*/) {
+  void MESetTrend::fill(EcalDQMSetupObjects const edso, EcalElectronicsId const &_id, double _t, double _wy /* = 1.*/, double _w /* = 1.*/) {
     if (!active_)
       return;
 
-    unsigned iME(binning::findPlotIndex(otype_, _id));
+    unsigned iME(binning::findPlotIndex(edso.electronicsMap, otype_, _id));
     checkME_(iME);
 
     if (shift_(unsigned(_t)))
       fill_(iME, _t + 0.5, _wy, _w);
   }
 
-  void MESetTrend::fill(int _dcctccid, double _t, double _wy /* = 1.*/, double _w /* = 1.*/) {
+  void MESetTrend::fill(EcalDQMSetupObjects const edso, int _dcctccid, double _t, double _wy /* = 1.*/, double _w /* = 1.*/) {
     if (!active_)
       return;
 
-    unsigned iME(binning::findPlotIndex(otype_, _dcctccid, btype_));
+    unsigned iME(binning::findPlotIndex(edso.electronicsMap, otype_, _dcctccid, btype_));
     checkME_(iME);
 
     if (shift_(unsigned(_t)))
       fill_(iME, _t + 0.5, _wy, _w);
   }
 
-  void MESetTrend::fill(double _t, double _wy /* = 1.*/, double _w /* = 1.*/) {
+  void MESetTrend::fill(EcalDQMSetupObjects const edso, double _t, double _wy /* = 1.*/, double _w /* = 1.*/) {
     if (!active_)
       return;
     if (mes_.size() != 1)
@@ -129,37 +129,37 @@ namespace ecaldqm {
       fill_(0, _t + 0.5, _wy, _w);
   }
 
-  int MESetTrend::findBin(DetId const &_id, double _t, double _y /* = 0.*/) const {
+  int MESetTrend::findBin(EcalDQMSetupObjects const edso, DetId const &_id, double _t, double _y /* = 0.*/) const {
     if (!active_)
       return -1;
 
-    unsigned iME(binning::findPlotIndex(otype_, _id));
+    unsigned iME(binning::findPlotIndex(edso.electronicsMap, otype_, _id));
     checkME_(iME);
 
     return mes_[iME]->getTH1()->FindBin(_t + 0.5, _y);
   }
 
-  int MESetTrend::findBin(EcalElectronicsId const &_id, double _t, double _y /* = 0.*/) const {
+  int MESetTrend::findBin(EcalDQMSetupObjects const edso, EcalElectronicsId const &_id, double _t, double _y /* = 0.*/) const {
     if (!active_)
       return -1;
 
-    unsigned iME(binning::findPlotIndex(otype_, _id));
+    unsigned iME(binning::findPlotIndex(edso.electronicsMap, otype_, _id));
     checkME_(iME);
 
     return mes_[iME]->getTH1()->FindBin(_t + 0.5, _y);
   }
 
-  int MESetTrend::findBin(int _dcctccid, double _t, double _y /* = 0.*/) const {
+  int MESetTrend::findBin(EcalDQMSetupObjects const edso, int _dcctccid, double _t, double _y /* = 0.*/) const {
     if (!active_)
       return -1;
 
-    unsigned iME(binning::findPlotIndex(otype_, _dcctccid, btype_));
+    unsigned iME(binning::findPlotIndex(edso.electronicsMap, otype_, _dcctccid, btype_));
     checkME_(iME);
 
     return mes_[iME]->getTH1()->FindBin(_t + 0.5, _y);
   }
 
-  int MESetTrend::findBin(double _t, double _y /* = 0.*/) const {
+  int MESetTrend::findBin(EcalDQMSetupObjects const edso, double _t, double _y /* = 0.*/) const {
     if (!active_)
       return -1;
     if (mes_.size() != 1)

--- a/DQM/EcalCommon/src/MESetTrend.cc
+++ b/DQM/EcalCommon/src/MESetTrend.cc
@@ -86,7 +86,8 @@ namespace ecaldqm {
       setAxisTitle("LumiSections");
   }
 
-  void MESetTrend::fill(EcalDQMSetupObjects const edso, DetId const &_id, double _t, double _wy /* = 1.*/, double _w /* = 1.*/) {
+  void MESetTrend::fill(
+      EcalDQMSetupObjects const edso, DetId const &_id, double _t, double _wy /* = 1.*/, double _w /* = 1.*/) {
     if (!active_)
       return;
 
@@ -97,7 +98,11 @@ namespace ecaldqm {
       fill_(iME, _t + 0.5, _wy, _w);
   }
 
-  void MESetTrend::fill(EcalDQMSetupObjects const edso, EcalElectronicsId const &_id, double _t, double _wy /* = 1.*/, double _w /* = 1.*/) {
+  void MESetTrend::fill(EcalDQMSetupObjects const edso,
+                        EcalElectronicsId const &_id,
+                        double _t,
+                        double _wy /* = 1.*/,
+                        double _w /* = 1.*/) {
     if (!active_)
       return;
 
@@ -108,7 +113,8 @@ namespace ecaldqm {
       fill_(iME, _t + 0.5, _wy, _w);
   }
 
-  void MESetTrend::fill(EcalDQMSetupObjects const edso, int _dcctccid, double _t, double _wy /* = 1.*/, double _w /* = 1.*/) {
+  void MESetTrend::fill(
+      EcalDQMSetupObjects const edso, int _dcctccid, double _t, double _wy /* = 1.*/, double _w /* = 1.*/) {
     if (!active_)
       return;
 
@@ -139,7 +145,10 @@ namespace ecaldqm {
     return mes_[iME]->getTH1()->FindBin(_t + 0.5, _y);
   }
 
-  int MESetTrend::findBin(EcalDQMSetupObjects const edso, EcalElectronicsId const &_id, double _t, double _y /* = 0.*/) const {
+  int MESetTrend::findBin(EcalDQMSetupObjects const edso,
+                          EcalElectronicsId const &_id,
+                          double _t,
+                          double _y /* = 0.*/) const {
     if (!active_)
       return -1;
 

--- a/DQM/EcalCommon/src/StatusManager.cc
+++ b/DQM/EcalCommon/src/StatusManager.cc
@@ -121,7 +121,7 @@ namespace ecaldqm {
                                    0x1 << EcalDQMStatusHelper::PHYSICS_BAD_CHANNEL_ERROR;
   }
 
-  void StatusManager::readFromStream(std::istream &_input) {
+  void StatusManager::readFromStream(std::istream &_input, const EcalElectronicsMapping *electronicsMap) {
     TPRegexp linePat(
         "^[ ]*(Crystal|TT|PN)[ ]+(EB[0-9+-]*|EE[0-9+-]*|[0-9]+)[ "
         "]+([0-9]+)[ ]([a-zA-Z_]+)");
@@ -183,7 +183,7 @@ namespace ecaldqm {
           status_.insert(
               std::pair<uint32_t, uint32_t>(EcalTrigTowerDetId(zside, EcalBarrel, iEta, iPhi).rawId(), statusVal));
         } else if (module.Contains("EE")) {
-          std::vector<EcalScDetId> scIds(getElectronicsMap()->getEcalScDetId(dccId(module.Data()), channel, false));
+          std::vector<EcalScDetId> scIds(electronicsMap->getEcalScDetId(dccId(module.Data()), channel, false));
           for (unsigned iS(0); iS != scIds.size(); ++iS)
             status_.insert(std::pair<uint32_t, uint32_t>(scIds[iS].rawId(), statusVal));
         }

--- a/DQM/EcalMonitorClient/plugins/EcalDQMonitorClient.cc
+++ b/DQM/EcalMonitorClient/plugins/EcalDQMonitorClient.cc
@@ -62,7 +62,9 @@ void EcalDQMonitorClient::fillDescriptions(edm::ConfigurationDescriptions& _desc
 }
 
 void EcalDQMonitorClient::beginRun(edm::Run const& _run, edm::EventSetup const& _es) {
-  executeOnWorkers_([&_es](ecaldqm::DQWorker* worker) { worker->setSetupObjects(_es); }, "ecaldqmGetSetupObjects", "Getting EventSetup Objects");
+  executeOnWorkers_([&_es](ecaldqm::DQWorker* worker) { worker->setSetupObjects(_es); },
+                    "ecaldqmGetSetupObjects",
+                    "Getting EventSetup Objects");
 
   if (_es.find(edm::eventsetup::EventSetupRecordKey::makeKey<EcalDQMChannelStatusRcd>()) &&
       _es.find(edm::eventsetup::EventSetupRecordKey::makeKey<EcalDQMTowerStatusRcd>())) {

--- a/DQM/EcalMonitorClient/plugins/EcalDQMonitorClient.cc
+++ b/DQM/EcalMonitorClient/plugins/EcalDQMonitorClient.cc
@@ -35,6 +35,8 @@ EcalDQMonitorClient::EcalDQMonitorClient(edm::ParameterSet const& _ps)
       },
       "initialization");
 
+  // This is no longer used since run 2
+  //
   //if (_ps.existsAs<edm::FileInPath>("PNMaskFile", false)) {
   //  std::ifstream maskFile(_ps.getUntrackedParameter<edm::FileInPath>("PNMaskFile").fullPath());
   //  if (maskFile.is_open())

--- a/DQM/EcalMonitorClient/plugins/EcalDQMonitorClient.cc
+++ b/DQM/EcalMonitorClient/plugins/EcalDQMonitorClient.cc
@@ -35,11 +35,11 @@ EcalDQMonitorClient::EcalDQMonitorClient(edm::ParameterSet const& _ps)
       },
       "initialization");
 
-  if (_ps.existsAs<edm::FileInPath>("PNMaskFile", false)) {
-    std::ifstream maskFile(_ps.getUntrackedParameter<edm::FileInPath>("PNMaskFile").fullPath());
-    if (maskFile.is_open())
-      statusManager_.readFromStream(maskFile);
-  }
+  //if (_ps.existsAs<edm::FileInPath>("PNMaskFile", false)) {
+  //  std::ifstream maskFile(_ps.getUntrackedParameter<edm::FileInPath>("PNMaskFile").fullPath());
+  //  if (maskFile.is_open())
+  //    statusManager_.readFromStream(maskFile);
+  //}
 }
 
 EcalDQMonitorClient::~EcalDQMonitorClient() {}
@@ -62,7 +62,7 @@ void EcalDQMonitorClient::fillDescriptions(edm::ConfigurationDescriptions& _desc
 }
 
 void EcalDQMonitorClient::beginRun(edm::Run const& _run, edm::EventSetup const& _es) {
-  ecaldqmGetSetupObjects(_es);
+  executeOnWorkers_([&_es](ecaldqm::DQWorker* worker) { worker->setSetupObjects(_es); }, "ecaldqmGetSetupObjects", "Getting EventSetup Objects");
 
   if (_es.find(edm::eventsetup::EventSetupRecordKey::makeKey<EcalDQMChannelStatusRcd>()) &&
       _es.find(edm::eventsetup::EventSetupRecordKey::makeKey<EcalDQMTowerStatusRcd>())) {

--- a/DQM/EcalMonitorClient/src/CalibrationSummaryClient.cc
+++ b/DQM/EcalMonitorClient/src/CalibrationSummaryClient.cc
@@ -145,7 +145,8 @@ namespace ecaldqm {
     MESet const& sPNIntegrity(sources_.at("PNIntegrity"));
 
     MESet::iterator qEnd(meQualitySummary.end(GetElectronicsMap()));
-    for (MESet::iterator qItr(meQualitySummary.beginChannel(GetElectronicsMap())); qItr != qEnd; qItr.toNextChannel(GetElectronicsMap())) {
+    for (MESet::iterator qItr(meQualitySummary.beginChannel(GetElectronicsMap())); qItr != qEnd;
+         qItr.toNextChannel(GetElectronicsMap())) {
       DetId id(qItr->getId());
 
       int status(kGood);

--- a/DQM/EcalMonitorClient/src/CalibrationSummaryClient.cc
+++ b/DQM/EcalMonitorClient/src/CalibrationSummaryClient.cc
@@ -144,8 +144,8 @@ namespace ecaldqm {
                                                        : nullptr);
     MESet const& sPNIntegrity(sources_.at("PNIntegrity"));
 
-    MESet::iterator qEnd(meQualitySummary.end());
-    for (MESet::iterator qItr(meQualitySummary.beginChannel()); qItr != qEnd; qItr.toNextChannel()) {
+    MESet::iterator qEnd(meQualitySummary.end(GetElectronicsMap()));
+    for (MESet::iterator qItr(meQualitySummary.beginChannel(GetElectronicsMap())); qItr != qEnd; qItr.toNextChannel(GetElectronicsMap())) {
       DetId id(qItr->getId());
 
       int status(kGood);
@@ -153,7 +153,7 @@ namespace ecaldqm {
       if (status == kGood && sLaser) {
         for (map<int, unsigned>::iterator wlItr(laserWlToME_.begin()); wlItr != laserWlToME_.end(); ++wlItr) {
           sLaser->use(wlItr->second);
-          if (sLaser->getBinContent(id) == kBad) {
+          if (sLaser->getBinContent(getEcalDQMSetupObjects(), id) == kBad) {
             status = kBad;
             break;
           }
@@ -165,7 +165,7 @@ namespace ecaldqm {
         if (id.subdetId() == EcalEndcap) {
           for (map<int, unsigned>::iterator wlItr(ledWlToME_.begin()); wlItr != ledWlToME_.end(); ++wlItr) {
             sLed->use(wlItr->second);
-            if (sLed->getBinContent(id) == kBad) {
+            if (sLed->getBinContent(getEcalDQMSetupObjects(), id) == kBad) {
               status = kBad;
               break;
             }
@@ -176,7 +176,7 @@ namespace ecaldqm {
       if (status == kGood && sTestPulse) {
         for (map<int, unsigned>::iterator gainItr(tpGainToME_.begin()); gainItr != tpGainToME_.end(); ++gainItr) {
           sTestPulse->use(gainItr->second);
-          if (sTestPulse->getBinContent(id) == kBad) {
+          if (sTestPulse->getBinContent(getEcalDQMSetupObjects(), id) == kBad) {
             status = kBad;
             break;
           }
@@ -186,7 +186,7 @@ namespace ecaldqm {
       if (status == kGood && sPedestal) {
         for (map<int, unsigned>::iterator gainItr(pedGainToME_.begin()); gainItr != pedGainToME_.end(); ++gainItr) {
           sPedestal->use(gainItr->second);
-          if (sPedestal->getBinContent(id) == kBad) {
+          if (sPedestal->getBinContent(getEcalDQMSetupObjects(), id) == kBad) {
             status = kBad;
             break;
           }
@@ -210,13 +210,13 @@ namespace ecaldqm {
 
         int status(kGood);
 
-        if (sPNIntegrity.getBinContent(id) == kBad)
+        if (sPNIntegrity.getBinContent(getEcalDQMSetupObjects(), id) == kBad)
           status = kBad;
 
         if (status == kGood && sLaserPN) {
           for (map<int, unsigned>::iterator wlItr(laserWlToME_.begin()); wlItr != laserWlToME_.end(); ++wlItr) {
             sLaserPN->use(wlItr->second);
-            if (sLaserPN->getBinContent(id) == kBad) {
+            if (sLaserPN->getBinContent(getEcalDQMSetupObjects(), id) == kBad) {
               status = kBad;
               break;
             }
@@ -226,7 +226,7 @@ namespace ecaldqm {
         if (status == kGood && sLedPN) {
           for (map<int, unsigned>::iterator wlItr(ledWlToME_.begin()); wlItr != ledWlToME_.end(); ++wlItr) {
             sLedPN->use(wlItr->second);
-            if (sLedPN->getBinContent(id) == kBad) {
+            if (sLedPN->getBinContent(getEcalDQMSetupObjects(), id) == kBad) {
               status = kBad;
               break;
             }
@@ -236,7 +236,7 @@ namespace ecaldqm {
         if (status == kGood && sTestPulsePN) {
           for (map<int, unsigned>::iterator gainItr(tpPNGainToME_.begin()); gainItr != tpPNGainToME_.end(); ++gainItr) {
             sTestPulsePN->use(gainItr->second);
-            if (sTestPulsePN->getBinContent(id) == kBad) {
+            if (sTestPulsePN->getBinContent(getEcalDQMSetupObjects(), id) == kBad) {
               status = kBad;
               break;
             }
@@ -247,14 +247,14 @@ namespace ecaldqm {
           for (map<int, unsigned>::iterator gainItr(pedPNGainToME_.begin()); gainItr != pedPNGainToME_.end();
                ++gainItr) {
             sPedestalPN->use(gainItr->second);
-            if (sPedestalPN->getBinContent(id) == kBad) {
+            if (sPedestalPN->getBinContent(getEcalDQMSetupObjects(), id) == kBad) {
               status = kBad;
               break;
             }
           }
         }
 
-        mePNQualitySummary.setBinContent(id, status);
+        mePNQualitySummary.setBinContent(getEcalDQMSetupObjects(), id, status);
       }
     }
   }

--- a/DQM/EcalMonitorClient/src/CertificationClient.cc
+++ b/DQM/EcalMonitorClient/src/CertificationClient.cc
@@ -21,7 +21,9 @@ namespace ecaldqm {
 
     double meanValue(0.);
     for (int iDCC(0); iDCC < nDCC; ++iDCC) {
-      double certValue(sDAQ.getBinContent(getEcalDQMSetupObjects(), iDCC + 1) * sDCS.getBinContent(getEcalDQMSetupObjects(), iDCC + 1) * sDQM.getBinContent(getEcalDQMSetupObjects(), iDCC + 1));
+      double certValue(sDAQ.getBinContent(getEcalDQMSetupObjects(), iDCC + 1) *
+                       sDCS.getBinContent(getEcalDQMSetupObjects(), iDCC + 1) *
+                       sDQM.getBinContent(getEcalDQMSetupObjects(), iDCC + 1));
 
       meCertificationContents.fill(getEcalDQMSetupObjects(), iDCC + 1, certValue);
       meCertificationMap.setBinContent(getEcalDQMSetupObjects(), iDCC + 1, certValue);

--- a/DQM/EcalMonitorClient/src/CertificationClient.cc
+++ b/DQM/EcalMonitorClient/src/CertificationClient.cc
@@ -21,15 +21,15 @@ namespace ecaldqm {
 
     double meanValue(0.);
     for (int iDCC(0); iDCC < nDCC; ++iDCC) {
-      double certValue(sDAQ.getBinContent(iDCC + 1) * sDCS.getBinContent(iDCC + 1) * sDQM.getBinContent(iDCC + 1));
+      double certValue(sDAQ.getBinContent(getEcalDQMSetupObjects(), iDCC + 1) * sDCS.getBinContent(getEcalDQMSetupObjects(), iDCC + 1) * sDQM.getBinContent(getEcalDQMSetupObjects(), iDCC + 1));
 
-      meCertificationContents.fill(iDCC + 1, certValue);
-      meCertificationMap.setBinContent(iDCC + 1, certValue);
+      meCertificationContents.fill(getEcalDQMSetupObjects(), iDCC + 1, certValue);
+      meCertificationMap.setBinContent(getEcalDQMSetupObjects(), iDCC + 1, certValue);
 
       meanValue += certValue * nCrystals(iDCC + 1);
     }
 
-    meCertification.fill(meanValue / nChannels);
+    meCertification.fill(getEcalDQMSetupObjects(), meanValue / nChannels);
   }
 
   DEFINE_ECALDQM_WORKER(CertificationClient);

--- a/DQM/EcalMonitorClient/src/DQWorkerClient.cc
+++ b/DQM/EcalMonitorClient/src/DQWorkerClient.cc
@@ -100,7 +100,7 @@ namespace ecaldqm {
         continue;
       if (verbosity_ > 1)
         edm::LogInfo("EcalDQM") << name_ << ": Retrieving source " << sItr->first;
-      if (!sItr->second->retrieve(_igetter, &failedPath)) {
+      if (!sItr->second->retrieve(GetElectronicsMap(), _igetter, &failedPath)) {
         if (verbosity_ > 1)
           edm::LogWarning("EcalDQM") << name_ << ": Could not find source " << sItr->first << "@" << failedPath;
         return false;
@@ -126,19 +126,19 @@ namespace ecaldqm {
             multi->use(iS);
             if (multi->getKind() == MonitorElement::Kind::TH2F) {
               multi->resetAll(-1.);
-              multi->reset(kUnknown);
+              multi->reset(GetElectronicsMap(), kUnknown);
             } else
-              multi->reset(-1.);
+              multi->reset(GetElectronicsMap(), -1.);
           }
         } else {
           if (meset->getKind() == MonitorElement::Kind::TH2F) {
             meset->resetAll(-1.);
-            meset->reset(kUnknown);
+            meset->reset(GetElectronicsMap(), kUnknown);
           } else
-            meset->reset(-1.);
+            meset->reset(GetElectronicsMap(), -1.);
         }
       } else
-        meset->reset();
+        meset->reset(GetElectronicsMap());
     }
   }
 
@@ -159,13 +159,13 @@ namespace ecaldqm {
   void DQWorkerClient::towerAverage_(MESet& _target, MESet const& _source, float _threshold) {
     bool isQuality(_threshold > 0.);
 
-    MESet::iterator tEnd(_target.end());
-    for (MESet::iterator tItr(_target.beginChannel()); tItr != tEnd; tItr.toNextChannel()) {
+    MESet::iterator tEnd(_target.end(GetElectronicsMap()));
+    for (MESet::iterator tItr(_target.beginChannel(GetElectronicsMap())); tItr != tEnd; tItr.toNextChannel(GetElectronicsMap())) {
       DetId towerId(tItr->getId());
 
       std::vector<DetId> cryIds;
       if (towerId.subdetId() == EcalTriggerTower)
-        cryIds = getTrigTowerMap()->constituentsOf(EcalTrigTowerDetId(towerId));
+        cryIds = GetTrigTowerMap()->constituentsOf(EcalTrigTowerDetId(towerId));
       else {
         cryIds = scConstituents(EcalScDetId(towerId));
       }
@@ -177,7 +177,7 @@ namespace ecaldqm {
       float nValid(0.);
       bool masked(false);
       for (unsigned iId(0); iId < cryIds.size(); ++iId) {
-        float content(_source.getBinContent(cryIds[iId]));
+        float content(_source.getBinContent(getEcalDQMSetupObjects(), cryIds[iId]));
         if (isQuality) {
           if (content < 0. || content == 2.)
             continue;

--- a/DQM/EcalMonitorClient/src/DQWorkerClient.cc
+++ b/DQM/EcalMonitorClient/src/DQWorkerClient.cc
@@ -160,7 +160,8 @@ namespace ecaldqm {
     bool isQuality(_threshold > 0.);
 
     MESet::iterator tEnd(_target.end(GetElectronicsMap()));
-    for (MESet::iterator tItr(_target.beginChannel(GetElectronicsMap())); tItr != tEnd; tItr.toNextChannel(GetElectronicsMap())) {
+    for (MESet::iterator tItr(_target.beginChannel(GetElectronicsMap())); tItr != tEnd;
+         tItr.toNextChannel(GetElectronicsMap())) {
       DetId towerId(tItr->getId());
 
       std::vector<DetId> cryIds;

--- a/DQM/EcalMonitorClient/src/IntegrityClient.cc
+++ b/DQM/EcalMonitorClient/src/IntegrityClient.cc
@@ -44,8 +44,8 @@ namespace ecaldqm {
 
     // Fill Channel Status Map MEs
     // Record is checked for updates at every endLumi and filled here
-    MESet::iterator chSEnd(meChStatus.end());
-    for (MESet::iterator chSItr(meChStatus.beginChannel()); chSItr != chSEnd; chSItr.toNextChannel()) {
+    MESet::iterator chSEnd(meChStatus.end(GetElectronicsMap()));
+    for (MESet::iterator chSItr(meChStatus.beginChannel(GetElectronicsMap())); chSItr != chSEnd; chSItr.toNextChannel(GetElectronicsMap())) {
       DetId id(chSItr->getId());
 
       EcalChannelStatusMap::const_iterator chIt(nullptr);
@@ -67,27 +67,27 @@ namespace ecaldqm {
 
     }  // Channel Status Map
 
-    MESet::iterator qEnd(meQuality.end());
-    MESet::const_iterator occItr(sOccupancy);
-    for (MESet::iterator qItr(meQuality.beginChannel()); qItr != qEnd; qItr.toNextChannel()) {
+    MESet::iterator qEnd(meQuality.end(GetElectronicsMap()));
+    MESet::const_iterator occItr(GetElectronicsMap(), sOccupancy);
+    for (MESet::iterator qItr(meQuality.beginChannel(GetElectronicsMap())); qItr != qEnd; qItr.toNextChannel(GetElectronicsMap())) {
       occItr = qItr;
 
       DetId id(qItr->getId());
 
-      bool doMask(meQuality.maskMatches(id, mask, statusManager_));
+      bool doMask(meQuality.maskMatches(id, mask, statusManager_, GetTrigTowerMap()));
 
       float entries(occItr->getBinContent());
 
-      float gain(sGain.getBinContent(id));
-      float chid(sChId.getBinContent(id));
-      float gainswitch(sGainSwitch.getBinContent(id));
+      float gain(sGain.getBinContent(getEcalDQMSetupObjects(), id));
+      float chid(sChId.getBinContent(getEcalDQMSetupObjects(), id));
+      float gainswitch(sGainSwitch.getBinContent(getEcalDQMSetupObjects(), id));
 
-      float towerid(sTowerId.getBinContent(id));
-      float blocksize(sBlockSize.getBinContent(id));
+      float towerid(sTowerId.getBinContent(getEcalDQMSetupObjects(), id));
+      float blocksize(sBlockSize.getBinContent(getEcalDQMSetupObjects(), id));
 
       if (entries + gain + chid + gainswitch + towerid + blocksize < 1.) {
         qItr->setBinContent(doMask ? kMUnknown : kUnknown);
-        meQualitySummary.setBinContent(id, doMask ? kMUnknown : kUnknown);
+        meQualitySummary.setBinContent(getEcalDQMSetupObjects(), id, doMask ? kMUnknown : kUnknown);
         continue;
       }
 
@@ -96,10 +96,10 @@ namespace ecaldqm {
 
       if (chErr > errFractionThreshold_) {
         qItr->setBinContent(doMask ? kMBad : kBad);
-        meQualitySummary.setBinContent(id, doMask ? kMBad : kBad);
+        meQualitySummary.setBinContent(getEcalDQMSetupObjects(), id, doMask ? kMBad : kBad);
       } else {
         qItr->setBinContent(doMask ? kMGood : kGood);
-        meQualitySummary.setBinContent(id, doMask ? kMGood : kGood);
+        meQualitySummary.setBinContent(getEcalDQMSetupObjects(), id, doMask ? kMGood : kGood);
       }
     }
 
@@ -109,16 +109,16 @@ namespace ecaldqm {
     MESet const& sBXTCC(sources_.at("BXTCC"));
     std::vector<bool> hasMismatchDCC(nDCC, false);
     for (unsigned iDCC(0); iDCC < nDCC; ++iDCC) {
-      if (sBXSRP.getBinContent(iDCC + 1) > 50. || sBXTCC.getBinContent(iDCC + 1) > 50.)  // "any" => 50
+      if (sBXSRP.getBinContent(getEcalDQMSetupObjects(), iDCC + 1) > 50. || sBXTCC.getBinContent(getEcalDQMSetupObjects(), iDCC + 1) > 50.)  // "any" => 50
         hasMismatchDCC[iDCC] = true;
     }
     // Analyze mismatch statistics
-    for (MESet::iterator qsItr(meQualitySummary.beginChannel()); qsItr != meQualitySummary.end();
-         qsItr.toNextChannel()) {
+    for (MESet::iterator qsItr(meQualitySummary.beginChannel(GetElectronicsMap())); qsItr != meQualitySummary.end(GetElectronicsMap());
+         qsItr.toNextChannel(GetElectronicsMap())) {
       DetId id(qsItr->getId());
-      unsigned iDCC(dccId(id) - 1);
+      unsigned iDCC(dccId(id, GetElectronicsMap()) - 1);
       if (hasMismatchDCC[iDCC])
-        meQualitySummary.setBinContent(id, meQualitySummary.maskMatches(id, mask, statusManager_) ? kMBad : kBad);
+        meQualitySummary.setBinContent(getEcalDQMSetupObjects(), id, meQualitySummary.maskMatches(id, mask, statusManager_, GetTrigTowerMap()) ? kMBad : kBad);
     }
 
   }  // producePlots()

--- a/DQM/EcalMonitorClient/src/IntegrityClient.cc
+++ b/DQM/EcalMonitorClient/src/IntegrityClient.cc
@@ -45,7 +45,8 @@ namespace ecaldqm {
     // Fill Channel Status Map MEs
     // Record is checked for updates at every endLumi and filled here
     MESet::iterator chSEnd(meChStatus.end(GetElectronicsMap()));
-    for (MESet::iterator chSItr(meChStatus.beginChannel(GetElectronicsMap())); chSItr != chSEnd; chSItr.toNextChannel(GetElectronicsMap())) {
+    for (MESet::iterator chSItr(meChStatus.beginChannel(GetElectronicsMap())); chSItr != chSEnd;
+         chSItr.toNextChannel(GetElectronicsMap())) {
       DetId id(chSItr->getId());
 
       EcalChannelStatusMap::const_iterator chIt(nullptr);
@@ -69,7 +70,8 @@ namespace ecaldqm {
 
     MESet::iterator qEnd(meQuality.end(GetElectronicsMap()));
     MESet::const_iterator occItr(GetElectronicsMap(), sOccupancy);
-    for (MESet::iterator qItr(meQuality.beginChannel(GetElectronicsMap())); qItr != qEnd; qItr.toNextChannel(GetElectronicsMap())) {
+    for (MESet::iterator qItr(meQuality.beginChannel(GetElectronicsMap())); qItr != qEnd;
+         qItr.toNextChannel(GetElectronicsMap())) {
       occItr = qItr;
 
       DetId id(qItr->getId());
@@ -109,16 +111,21 @@ namespace ecaldqm {
     MESet const& sBXTCC(sources_.at("BXTCC"));
     std::vector<bool> hasMismatchDCC(nDCC, false);
     for (unsigned iDCC(0); iDCC < nDCC; ++iDCC) {
-      if (sBXSRP.getBinContent(getEcalDQMSetupObjects(), iDCC + 1) > 50. || sBXTCC.getBinContent(getEcalDQMSetupObjects(), iDCC + 1) > 50.)  // "any" => 50
+      if (sBXSRP.getBinContent(getEcalDQMSetupObjects(), iDCC + 1) > 50. ||
+          sBXTCC.getBinContent(getEcalDQMSetupObjects(), iDCC + 1) > 50.)  // "any" => 50
         hasMismatchDCC[iDCC] = true;
     }
     // Analyze mismatch statistics
-    for (MESet::iterator qsItr(meQualitySummary.beginChannel(GetElectronicsMap())); qsItr != meQualitySummary.end(GetElectronicsMap());
+    for (MESet::iterator qsItr(meQualitySummary.beginChannel(GetElectronicsMap()));
+         qsItr != meQualitySummary.end(GetElectronicsMap());
          qsItr.toNextChannel(GetElectronicsMap())) {
       DetId id(qsItr->getId());
       unsigned iDCC(dccId(id, GetElectronicsMap()) - 1);
       if (hasMismatchDCC[iDCC])
-        meQualitySummary.setBinContent(getEcalDQMSetupObjects(), id, meQualitySummary.maskMatches(id, mask, statusManager_, GetTrigTowerMap()) ? kMBad : kBad);
+        meQualitySummary.setBinContent(
+            getEcalDQMSetupObjects(),
+            id,
+            meQualitySummary.maskMatches(id, mask, statusManager_, GetTrigTowerMap()) ? kMBad : kBad);
     }
 
   }  // producePlots()

--- a/DQM/EcalMonitorClient/src/LaserClient.cc
+++ b/DQM/EcalMonitorClient/src/LaserClient.cc
@@ -111,17 +111,17 @@ namespace ecaldqm {
       sTiming.use(wlItr->second);
       sPNAmplitude.use(wlItr->second);
 
-      MESet::iterator qEnd(meQuality.end());
+      MESet::iterator qEnd(meQuality.end(GetElectronicsMap()));
 
-      MESet::const_iterator tItr(sTiming);
-      MESet::const_iterator aItr(sAmplitude);
+      MESet::const_iterator tItr(GetElectronicsMap(), sTiming);
+      MESet::const_iterator aItr(GetElectronicsMap(), sAmplitude);
 
       int wl(wlItr->first - 1);
-      bool enabled(wl < 0 ? false : sCalibStatus.getBinContent(wl) > 0 ? true : false);
-      for (MESet::iterator qItr(meQuality.beginChannel()); qItr != qEnd; qItr.toNextChannel()) {
+      bool enabled(wl < 0 ? false : sCalibStatus.getBinContent(getEcalDQMSetupObjects(), wl) > 0 ? true : false);
+      for (MESet::iterator qItr(meQuality.beginChannel(GetElectronicsMap())); qItr != qEnd; qItr.toNextChannel(GetElectronicsMap())) {
         DetId id(qItr->getId());
 
-        bool doMask(meQuality.maskMatches(id, mask, statusManager_));
+        bool doMask(meQuality.maskMatches(id, mask, statusManager_, GetTrigTowerMap()));
 
         aItr = qItr;
 
@@ -135,8 +135,8 @@ namespace ecaldqm {
         float aMean(aItr->getBinContent());
         float aRms(aItr->getBinError() * sqrt(aEntries));
 
-        meAmplitudeMean.fill(id, aMean);
-        meAmplitudeRMS.setBinContent(id, aRms);
+        meAmplitudeMean.fill(getEcalDQMSetupObjects(), id, aMean);
+        meAmplitudeRMS.setBinContent(getEcalDQMSetupObjects(), id, aRms);
 
         tItr = qItr;
 
@@ -148,9 +148,9 @@ namespace ecaldqm {
         float tMean(tItr->getBinContent());
         float tRms(tItr->getBinError() * sqrt(tEntries));
 
-        meTimingMean.fill(id, tMean);
-        meTimingRMS.fill(id, tRms);
-        meTimingRMSMap.setBinContent(id, tRms);
+        meTimingMean.fill(getEcalDQMSetupObjects(), id, tMean);
+        meTimingRMS.fill(getEcalDQMSetupObjects(), id, tRms);
+        meTimingRMSMap.setBinContent(getEcalDQMSetupObjects(), id, tRms);
 
         float intensity(aMean / expectedAmplitude_[wlItr->second]);
         if (isForward(id))
@@ -178,23 +178,23 @@ namespace ecaldqm {
         for (unsigned iPN(0); iPN < 10; ++iPN) {
           EcalPnDiodeDetId id(subdet, iDCC + 1, iPN + 1);
 
-          bool doMask(mePNQualitySummary.maskMatches(id, mask, statusManager_));
+          bool doMask(mePNQualitySummary.maskMatches(id, mask, statusManager_, GetTrigTowerMap()));
 
-          float pEntries(sPNAmplitude.getBinEntries(id));
+          float pEntries(sPNAmplitude.getBinEntries(getEcalDQMSetupObjects(), id));
 
           if (pEntries < minChannelEntries_) {
-            mePNQualitySummary.setBinContent(id, doMask ? kMUnknown : kUnknown);
+            mePNQualitySummary.setBinContent(getEcalDQMSetupObjects(), id, doMask ? kMUnknown : kUnknown);
             continue;
           }
 
-          float pMean(sPNAmplitude.getBinContent(id));
-          float pRms(sPNAmplitude.getBinError(id) * sqrt(pEntries));
+          float pMean(sPNAmplitude.getBinContent(getEcalDQMSetupObjects(), id));
+          float pRms(sPNAmplitude.getBinError(getEcalDQMSetupObjects(), id) * sqrt(pEntries));
           float intensity(pMean / expectedPNAmplitude_[wlItr->second]);
 
           if (intensity < tolerancePNAmp_ || pRms > pMean * tolerancePNRMSRatio_)
-            mePNQualitySummary.setBinContent(id, doMask ? kMBad : kBad);
+            mePNQualitySummary.setBinContent(getEcalDQMSetupObjects(), id, doMask ? kMBad : kBad);
           else
-            mePNQualitySummary.setBinContent(id, doMask ? kMGood : kGood);
+            mePNQualitySummary.setBinContent(getEcalDQMSetupObjects(), id, doMask ? kMGood : kGood);
         }
       }
     }

--- a/DQM/EcalMonitorClient/src/LaserClient.cc
+++ b/DQM/EcalMonitorClient/src/LaserClient.cc
@@ -118,7 +118,8 @@ namespace ecaldqm {
 
       int wl(wlItr->first - 1);
       bool enabled(wl < 0 ? false : sCalibStatus.getBinContent(getEcalDQMSetupObjects(), wl) > 0 ? true : false);
-      for (MESet::iterator qItr(meQuality.beginChannel(GetElectronicsMap())); qItr != qEnd; qItr.toNextChannel(GetElectronicsMap())) {
+      for (MESet::iterator qItr(meQuality.beginChannel(GetElectronicsMap())); qItr != qEnd;
+           qItr.toNextChannel(GetElectronicsMap())) {
         DetId id(qItr->getId());
 
         bool doMask(meQuality.maskMatches(id, mask, statusManager_, GetTrigTowerMap()));

--- a/DQM/EcalMonitorClient/src/LedClient.cc
+++ b/DQM/EcalMonitorClient/src/LedClient.cc
@@ -107,17 +107,17 @@ namespace ecaldqm {
       sTiming.use(wlItr->second);
       sPNAmplitude.use(wlItr->second);
 
-      MESet::iterator qEnd(meQuality.end());
+      MESet::iterator qEnd(meQuality.end(GetElectronicsMap()));
 
-      MESet::const_iterator tItr(sTiming);
-      MESet::const_iterator aItr(sAmplitude);
+      MESet::const_iterator tItr(GetElectronicsMap(), sTiming);
+      MESet::const_iterator aItr(GetElectronicsMap(), sAmplitude);
 
       int wl(wlItr->first + 3);
-      bool enabled(wl < 0 ? false : sCalibStatus.getBinContent(wl) > 0 ? true : false);
-      for (MESet::iterator qItr(meQuality.beginChannel()); qItr != qEnd; qItr.toNextChannel()) {
+      bool enabled(wl < 0 ? false : sCalibStatus.getBinContent(getEcalDQMSetupObjects(), wl) > 0 ? true : false);
+      for (MESet::iterator qItr(meQuality.beginChannel(GetElectronicsMap())); qItr != qEnd; qItr.toNextChannel(GetElectronicsMap())) {
         DetId id(qItr->getId());
 
-        bool doMask(meQuality.maskMatches(id, mask, statusManager_));
+        bool doMask(meQuality.maskMatches(id, mask, statusManager_, GetTrigTowerMap()));
 
         aItr = qItr;
 
@@ -131,8 +131,8 @@ namespace ecaldqm {
         float aMean(aItr->getBinContent());
         float aRms(aItr->getBinError() * sqrt(aEntries));
 
-        meAmplitudeMean.fill(id, aMean);
-        meAmplitudeRMS.setBinContent(id, aRms);
+        meAmplitudeMean.fill(getEcalDQMSetupObjects(), id, aMean);
+        meAmplitudeRMS.setBinContent(getEcalDQMSetupObjects(), id, aRms);
 
         tItr = qItr;
 
@@ -144,8 +144,8 @@ namespace ecaldqm {
         float tMean(tItr->getBinContent());
         float tRms(tItr->getBinError() * sqrt(tEntries));
 
-        meTimingMean.fill(id, tMean);
-        meTimingRMSMap.setBinContent(id, tRms);
+        meTimingMean.fill(getEcalDQMSetupObjects(), id, tMean);
+        meTimingRMSMap.setBinContent(getEcalDQMSetupObjects(), id, tRms);
 
         float intensity(aMean / expectedAmplitude_[wlItr->second]);
         if (isForward(id))
@@ -170,23 +170,23 @@ namespace ecaldqm {
         for (unsigned iPN(0); iPN < 10; ++iPN) {
           EcalPnDiodeDetId id(EcalEndcap, iDCC + 1, iPN + 1);
 
-          bool doMask(mePNQualitySummary.maskMatches(id, mask, statusManager_));
+          bool doMask(mePNQualitySummary.maskMatches(id, mask, statusManager_, GetTrigTowerMap()));
 
-          float pEntries(sPNAmplitude.getBinEntries(id));
+          float pEntries(sPNAmplitude.getBinEntries(getEcalDQMSetupObjects(), id));
 
           if (pEntries < minChannelEntries_) {
-            mePNQualitySummary.setBinContent(id, doMask ? kMUnknown : kUnknown);
+            mePNQualitySummary.setBinContent(getEcalDQMSetupObjects(), id, doMask ? kMUnknown : kUnknown);
             continue;
           }
 
-          float pMean(sPNAmplitude.getBinContent(id));
-          float pRms(sPNAmplitude.getBinError(id) * sqrt(pEntries));
+          float pMean(sPNAmplitude.getBinContent(getEcalDQMSetupObjects(), id));
+          float pRms(sPNAmplitude.getBinError(getEcalDQMSetupObjects(), id) * sqrt(pEntries));
           float intensity(pMean / expectedPNAmplitude_[wlItr->second]);
 
           if (intensity < tolerancePNAmp_ || pRms > pMean * tolerancePNRMSRatio_)
-            mePNQualitySummary.setBinContent(id, doMask ? kMBad : kBad);
+            mePNQualitySummary.setBinContent(getEcalDQMSetupObjects(), id, doMask ? kMBad : kBad);
           else
-            mePNQualitySummary.setBinContent(id, doMask ? kMGood : kGood);
+            mePNQualitySummary.setBinContent(getEcalDQMSetupObjects(), id, doMask ? kMGood : kGood);
         }
       }
     }

--- a/DQM/EcalMonitorClient/src/LedClient.cc
+++ b/DQM/EcalMonitorClient/src/LedClient.cc
@@ -114,7 +114,8 @@ namespace ecaldqm {
 
       int wl(wlItr->first + 3);
       bool enabled(wl < 0 ? false : sCalibStatus.getBinContent(getEcalDQMSetupObjects(), wl) > 0 ? true : false);
-      for (MESet::iterator qItr(meQuality.beginChannel(GetElectronicsMap())); qItr != qEnd; qItr.toNextChannel(GetElectronicsMap())) {
+      for (MESet::iterator qItr(meQuality.beginChannel(GetElectronicsMap())); qItr != qEnd;
+           qItr.toNextChannel(GetElectronicsMap())) {
         DetId id(qItr->getId());
 
         bool doMask(meQuality.maskMatches(id, mask, statusManager_, GetTrigTowerMap()));

--- a/DQM/EcalMonitorClient/src/OccupancyClient.cc
+++ b/DQM/EcalMonitorClient/src/OccupancyClient.cc
@@ -46,9 +46,9 @@ namespace ecaldqm {
     int numCrystals[nPhiRings];  // this is static, but is easier to count now
     std::fill_n(numCrystals, nPhiRings, 0);
 
-    MESet::const_iterator dEnd(sDigi.end());
-    MESet::const_iterator rItr(sRecHitThr);
-    for (MESet::const_iterator dItr(sDigi.beginChannel()); dItr != dEnd; dItr.toNextChannel()) {
+    MESet::const_iterator dEnd(sDigi.end(GetElectronicsMap()));
+    MESet::const_iterator rItr(GetElectronicsMap(), sRecHitThr);
+    for (MESet::const_iterator dItr(sDigi.beginChannel(GetElectronicsMap())); dItr != dEnd; dItr.toNextChannel(GetElectronicsMap())) {
       rItr = dItr;
 
       float entries(dItr->getBinContent());
@@ -62,7 +62,7 @@ namespace ecaldqm {
         std::vector<DetId> ids(scConstituents(EcalScDetId(id)));
         if (ids.empty())
           continue;
-        ieta = getTrigTowerMap()->towerOf(ids[0]).ieta();
+        ieta = GetTrigTowerMap()->towerOf(ids[0]).ieta();
       }
 
       unsigned index(ieta < 0 ? ieta + 28 : ieta + 27);
@@ -82,10 +82,10 @@ namespace ecaldqm {
     std::vector<float> Nrhentries(nDCC, 0.);  // (filtered) rechits
 
     // second round to find hot towers
-    for (MESet::const_iterator dItr(sDigi.beginChannel()); dItr != dEnd; dItr.toNextChannel()) {
+    for (MESet::const_iterator dItr(sDigi.beginChannel(GetElectronicsMap())); dItr != dEnd; dItr.toNextChannel(GetElectronicsMap())) {
       DetId id(dItr->getId());
 
-      bool doMask(meQualitySummary.maskMatches(id, mask, statusManager_));
+      bool doMask(meQualitySummary.maskMatches(id, mask, statusManager_, GetTrigTowerMap()));
 
       rItr = dItr;
 
@@ -99,7 +99,7 @@ namespace ecaldqm {
         std::vector<DetId> ids(scConstituents(EcalScDetId(id)));
         if (ids.empty())
           continue;
-        ieta = getTrigTowerMap()->towerOf(ids[0]).ieta();
+        ieta = GetTrigTowerMap()->towerOf(ids[0]).ieta();
       }
 
       unsigned index(ieta < 0 ? ieta + 28 : ieta + 27);
@@ -115,10 +115,10 @@ namespace ecaldqm {
         quality = doMask ? kMBad : kBad;
       }
 
-      meQualitySummary.setBinContent(id, double(quality));
+      meQualitySummary.setBinContent(getEcalDQMSetupObjects(), id, double(quality));
 
       // Keep count of digis & rechits for Occupancy analysis
-      unsigned iDCC(dccId(id) - 1);
+      unsigned iDCC(dccId(id, GetElectronicsMap()) - 1);
       if (entries > minHits_)
         Nentries[iDCC] += entries;
       if (rhentries > minHits_)
@@ -130,7 +130,7 @@ namespace ecaldqm {
 
     for (unsigned iTT(0); iTT < EcalTrigTowerDetId::kSizeForDenseIndexing; ++iTT) {
       EcalTrigTowerDetId ttid(EcalTrigTowerDetId::detIdFromDenseIndex(iTT));
-      float entries(sTPDigiThr.getBinContent(ttid));
+      float entries(sTPDigiThr.getBinContent(getEcalDQMSetupObjects(), ttid));
 
       unsigned index(ttid.ieta() < 0 ? ttid.ieta() + 28 : ttid.ieta() + 27);
 
@@ -150,7 +150,7 @@ namespace ecaldqm {
     for (unsigned iTT(0); iTT < EcalTrigTowerDetId::kSizeForDenseIndexing; ++iTT) {
       EcalTrigTowerDetId ttid(EcalTrigTowerDetId::detIdFromDenseIndex(iTT));
 
-      float entries(sTPDigiThr.getBinContent(ttid));
+      float entries(sTPDigiThr.getBinContent(getEcalDQMSetupObjects(), ttid));
 
       unsigned index(ttid.ieta() < 0 ? ttid.ieta() + 28 : ttid.ieta() + 27);
 
@@ -164,15 +164,15 @@ namespace ecaldqm {
       if (quality != kBad)
         continue;
 
-      std::vector<DetId> ids(getTrigTowerMap()->constituentsOf(ttid));
+      std::vector<DetId> ids(GetTrigTowerMap()->constituentsOf(ttid));
       for (unsigned iD(0); iD < ids.size(); ++iD) {
         DetId& id(ids[iD]);
 
-        int quality(meQualitySummary.getBinContent(id));
+        int quality(meQualitySummary.getBinContent(getEcalDQMSetupObjects(), id));
         if (quality == kMBad || quality == kBad)
           continue;
 
-        meQualitySummary.setBinContent(id, meQualitySummary.maskMatches(id, mask, statusManager_) ? kMBad : kBad);
+        meQualitySummary.setBinContent(getEcalDQMSetupObjects(), id, meQualitySummary.maskMatches(id, mask, statusManager_, GetTrigTowerMap()) ? kMBad : kBad);
       }
     }
 
@@ -199,10 +199,10 @@ namespace ecaldqm {
     rmsFEDEE = sqrt(abs(rmsFEDEE - meanFEDEE * meanFEDEE));
     // Analyze FED statistics
     float meanFED(0.), rmsFED(0.), nRMS(5.);
-    for (MESet::iterator qsItr(meQualitySummary.beginChannel()); qsItr != meQualitySummary.end();
-         qsItr.toNextChannel()) {
+    for (MESet::iterator qsItr(meQualitySummary.beginChannel(GetElectronicsMap())); qsItr != meQualitySummary.end(GetElectronicsMap());
+         qsItr.toNextChannel(GetElectronicsMap())) {
       DetId id(qsItr->getId());
-      unsigned iDCC(dccId(id) - 1);
+      unsigned iDCC(dccId(id, GetElectronicsMap()) - 1);
       if (iDCC >= kEBmLow && iDCC <= kEBpHigh) {
         meanFED = meanFEDEB;
         rmsFED = rmsFEDEB;
@@ -212,7 +212,7 @@ namespace ecaldqm {
       }
       float threshold(meanFED < nRMS * rmsFED ? minHits_ : meanFED - nRMS * rmsFED);
       if (meanFED > 1000. && Nrhentries[iDCC] < threshold)
-        meQualitySummary.setBinContent(id, meQualitySummary.maskMatches(id, mask, statusManager_) ? kMBad : kBad);
+        meQualitySummary.setBinContent(getEcalDQMSetupObjects(), id, meQualitySummary.maskMatches(id, mask, statusManager_, GetTrigTowerMap()) ? kMBad : kBad);
     }
 
   }  // producePlots()

--- a/DQM/EcalMonitorClient/src/OccupancyClient.cc
+++ b/DQM/EcalMonitorClient/src/OccupancyClient.cc
@@ -48,7 +48,8 @@ namespace ecaldqm {
 
     MESet::const_iterator dEnd(sDigi.end(GetElectronicsMap()));
     MESet::const_iterator rItr(GetElectronicsMap(), sRecHitThr);
-    for (MESet::const_iterator dItr(sDigi.beginChannel(GetElectronicsMap())); dItr != dEnd; dItr.toNextChannel(GetElectronicsMap())) {
+    for (MESet::const_iterator dItr(sDigi.beginChannel(GetElectronicsMap())); dItr != dEnd;
+         dItr.toNextChannel(GetElectronicsMap())) {
       rItr = dItr;
 
       float entries(dItr->getBinContent());
@@ -82,7 +83,8 @@ namespace ecaldqm {
     std::vector<float> Nrhentries(nDCC, 0.);  // (filtered) rechits
 
     // second round to find hot towers
-    for (MESet::const_iterator dItr(sDigi.beginChannel(GetElectronicsMap())); dItr != dEnd; dItr.toNextChannel(GetElectronicsMap())) {
+    for (MESet::const_iterator dItr(sDigi.beginChannel(GetElectronicsMap())); dItr != dEnd;
+         dItr.toNextChannel(GetElectronicsMap())) {
       DetId id(dItr->getId());
 
       bool doMask(meQualitySummary.maskMatches(id, mask, statusManager_, GetTrigTowerMap()));
@@ -172,7 +174,10 @@ namespace ecaldqm {
         if (quality == kMBad || quality == kBad)
           continue;
 
-        meQualitySummary.setBinContent(getEcalDQMSetupObjects(), id, meQualitySummary.maskMatches(id, mask, statusManager_, GetTrigTowerMap()) ? kMBad : kBad);
+        meQualitySummary.setBinContent(
+            getEcalDQMSetupObjects(),
+            id,
+            meQualitySummary.maskMatches(id, mask, statusManager_, GetTrigTowerMap()) ? kMBad : kBad);
       }
     }
 
@@ -199,7 +204,8 @@ namespace ecaldqm {
     rmsFEDEE = sqrt(abs(rmsFEDEE - meanFEDEE * meanFEDEE));
     // Analyze FED statistics
     float meanFED(0.), rmsFED(0.), nRMS(5.);
-    for (MESet::iterator qsItr(meQualitySummary.beginChannel(GetElectronicsMap())); qsItr != meQualitySummary.end(GetElectronicsMap());
+    for (MESet::iterator qsItr(meQualitySummary.beginChannel(GetElectronicsMap()));
+         qsItr != meQualitySummary.end(GetElectronicsMap());
          qsItr.toNextChannel(GetElectronicsMap())) {
       DetId id(qsItr->getId());
       unsigned iDCC(dccId(id, GetElectronicsMap()) - 1);
@@ -212,7 +218,10 @@ namespace ecaldqm {
       }
       float threshold(meanFED < nRMS * rmsFED ? minHits_ : meanFED - nRMS * rmsFED);
       if (meanFED > 1000. && Nrhentries[iDCC] < threshold)
-        meQualitySummary.setBinContent(getEcalDQMSetupObjects(), id, meQualitySummary.maskMatches(id, mask, statusManager_, GetTrigTowerMap()) ? kMBad : kBad);
+        meQualitySummary.setBinContent(
+            getEcalDQMSetupObjects(),
+            id,
+            meQualitySummary.maskMatches(id, mask, statusManager_, GetTrigTowerMap()) ? kMBad : kBad);
     }
 
   }  // producePlots()

--- a/DQM/EcalMonitorClient/src/PNIntegrityClient.cc
+++ b/DQM/EcalMonitorClient/src/PNIntegrityClient.cc
@@ -41,27 +41,27 @@ namespace ecaldqm {
 
         EcalPnDiodeDetId id(subdet, iDCC + 1, iPN + 1);
 
-        bool doMask(meQualitySummary.maskMatches(id, mask, statusManager_));
+        bool doMask(meQualitySummary.maskMatches(id, mask, statusManager_, GetTrigTowerMap()));
 
-        float entries(sOccupancy.getBinContent(id));
+        float entries(sOccupancy.getBinContent(getEcalDQMSetupObjects(), id));
 
-        float chid(sMEMChId.getBinContent(id));
-        float gain(sMEMGain.getBinContent(id));
+        float chid(sMEMChId.getBinContent(getEcalDQMSetupObjects(), id));
+        float gain(sMEMGain.getBinContent(getEcalDQMSetupObjects(), id));
 
-        float blocksize(sMEMBlockSize.getBinContent(id));
-        float towerid(sMEMTowerId.getBinContent(id));
+        float blocksize(sMEMBlockSize.getBinContent(getEcalDQMSetupObjects(), id));
+        float towerid(sMEMTowerId.getBinContent(getEcalDQMSetupObjects(), id));
 
         if (entries + gain + chid + blocksize + towerid < 1.) {
-          meQualitySummary.setBinContent(id, doMask ? kMUnknown : kUnknown);
+          meQualitySummary.setBinContent(getEcalDQMSetupObjects(), id, doMask ? kMUnknown : kUnknown);
           continue;
         }
 
         float chErr((gain + chid + blocksize + towerid) / (entries + gain + chid + blocksize + towerid));
 
         if (chErr > errFractionThreshold_)
-          meQualitySummary.setBinContent(id, doMask ? kMBad : kBad);
+          meQualitySummary.setBinContent(getEcalDQMSetupObjects(), id, doMask ? kMBad : kBad);
         else
-          meQualitySummary.setBinContent(id, doMask ? kMGood : kGood);
+          meQualitySummary.setBinContent(getEcalDQMSetupObjects(), id, doMask ? kMGood : kGood);
       }
     }
   }

--- a/DQM/EcalMonitorClient/src/PedestalClient.cc
+++ b/DQM/EcalMonitorClient/src/PedestalClient.cc
@@ -147,12 +147,12 @@ namespace ecaldqm {
           break;
       }
 
-      MESet::iterator qEnd(meQuality.end());
-      MESet::const_iterator pItr(sPedestal);
-      for (MESet::iterator qItr(meQuality.beginChannel()); qItr != qEnd; qItr.toNextChannel()) {
+      MESet::iterator qEnd(meQuality.end(GetElectronicsMap()));
+      MESet::const_iterator pItr(GetElectronicsMap(), sPedestal);
+      for (MESet::iterator qItr(meQuality.beginChannel(GetElectronicsMap())); qItr != qEnd; qItr.toNextChannel(GetElectronicsMap())) {
         DetId id(qItr->getId());
 
-        bool doMask(meQuality.maskMatches(id, mask, statusManager_));
+        bool doMask(meQuality.maskMatches(id, mask, statusManager_, GetTrigTowerMap()));
 
         pItr = qItr;
 
@@ -166,8 +166,8 @@ namespace ecaldqm {
         float mean(pItr->getBinContent());
         float rms(pItr->getBinError() * sqrt(entries));
 
-        meMean.fill(id, mean);
-        meRMS.fill(id, rms);
+        meMean.fill(getEcalDQMSetupObjects(), id, mean);
+        meRMS.fill(getEcalDQMSetupObjects(), id, rms);
 
         float toleranceRMS_ =
             (id.subdetId() == EcalBarrel) ? toleranceRMSEB_[gainItr->second] : toleranceRMSEE_[gainItr->second];
@@ -214,24 +214,24 @@ namespace ecaldqm {
 
           EcalPnDiodeDetId id(subdet, iDCC + 1, iPN + 1);
 
-          bool doMask(mePNQualitySummary.maskMatches(id, mask, statusManager_));
+          bool doMask(mePNQualitySummary.maskMatches(id, mask, statusManager_, GetTrigTowerMap()));
 
-          float entries(sPNPedestal.getBinEntries(id));
+          float entries(sPNPedestal.getBinEntries(getEcalDQMSetupObjects(), id));
 
           if (entries < minChannelEntries_) {
-            mePNQualitySummary.setBinContent(id, doMask ? kMUnknown : kUnknown);
+            mePNQualitySummary.setBinContent(getEcalDQMSetupObjects(), id, doMask ? kMUnknown : kUnknown);
             continue;
           }
 
-          float mean(sPNPedestal.getBinContent(id));
-          float rms(sPNPedestal.getBinError(id) * sqrt(entries));
+          float mean(sPNPedestal.getBinContent(getEcalDQMSetupObjects(), id));
+          float rms(sPNPedestal.getBinError(getEcalDQMSetupObjects(), id) * sqrt(entries));
 
-          mePNRMS.fill(id, rms);
+          mePNRMS.fill(getEcalDQMSetupObjects(), id, rms);
 
           if (abs(mean - expectedPNMean_) > tolerancePNMean_ || rms > tolerancePNRMS_[gainItr->second])
-            mePNQualitySummary.setBinContent(id, doMask ? kMBad : kBad);
+            mePNQualitySummary.setBinContent(getEcalDQMSetupObjects(), id, doMask ? kMBad : kBad);
           else
-            mePNQualitySummary.setBinContent(id, doMask ? kMGood : kGood);
+            mePNQualitySummary.setBinContent(getEcalDQMSetupObjects(), id, doMask ? kMGood : kGood);
         }
       }
     }

--- a/DQM/EcalMonitorClient/src/PedestalClient.cc
+++ b/DQM/EcalMonitorClient/src/PedestalClient.cc
@@ -149,7 +149,8 @@ namespace ecaldqm {
 
       MESet::iterator qEnd(meQuality.end(GetElectronicsMap()));
       MESet::const_iterator pItr(GetElectronicsMap(), sPedestal);
-      for (MESet::iterator qItr(meQuality.beginChannel(GetElectronicsMap())); qItr != qEnd; qItr.toNextChannel(GetElectronicsMap())) {
+      for (MESet::iterator qItr(meQuality.beginChannel(GetElectronicsMap())); qItr != qEnd;
+           qItr.toNextChannel(GetElectronicsMap())) {
         DetId id(qItr->getId());
 
         bool doMask(meQuality.maskMatches(id, mask, statusManager_, GetTrigTowerMap()));

--- a/DQM/EcalMonitorClient/src/PresampleClient.cc
+++ b/DQM/EcalMonitorClient/src/PresampleClient.cc
@@ -48,19 +48,19 @@ namespace ecaldqm {
     uint32_t mask(1 << EcalDQMStatusHelper::PEDESTAL_ONLINE_HIGH_GAIN_MEAN_ERROR |
                   1 << EcalDQMStatusHelper::PEDESTAL_ONLINE_HIGH_GAIN_RMS_ERROR);
 
-    MESet::iterator qEnd(meQuality.end());
+    MESet::iterator qEnd(meQuality.end(GetElectronicsMap()));
 
-    MESet::const_iterator pItr(sPedestal);
-    MESet::const_iterator pLSItr(sPedestalByLS);
+    MESet::const_iterator pItr(GetElectronicsMap(), sPedestal);
+    MESet::const_iterator pLSItr(GetElectronicsMap(), sPedestalByLS);
     double maxEB(0.), minEB(0.), maxEE(0.), minEE(0.);
     double rmsMaxEB(0.), rmsMaxEE(0.);
-    for (MESet::iterator qItr(meQuality.beginChannel()); qItr != qEnd; qItr.toNextChannel()) {
+    for (MESet::iterator qItr(meQuality.beginChannel(GetElectronicsMap())); qItr != qEnd; qItr.toNextChannel(GetElectronicsMap())) {
       pItr = qItr;
       pLSItr = qItr;
 
       DetId id(qItr->getId());
 
-      bool doMask(meQuality.maskMatches(id, mask, statusManager_));
+      bool doMask(meQuality.maskMatches(id, mask, statusManager_, GetTrigTowerMap()));
 
       double rmsThresh(toleranceRMS_);
 
@@ -72,8 +72,8 @@ namespace ecaldqm {
 
       if (entries < minChannelEntries_) {
         qItr->setBinContent(doMask ? kMUnknown : kUnknown);
-        meQualitySummary.setBinContent(id, doMask ? kMUnknown : kUnknown);
-        meRMSMap.setBinContent(id, -1.);
+        meQualitySummary.setBinContent(getEcalDQMSetupObjects(), id, doMask ? kMUnknown : kUnknown);
+        meRMSMap.setBinContent(getEcalDQMSetupObjects(), id, -1.);
         continue;
       }
 
@@ -82,26 +82,26 @@ namespace ecaldqm {
       double rms(pItr->getBinError() * std::sqrt(entries));
       double rmsLS(pLSItr->getBinError() * std::sqrt(entriesLS));
 
-      int dccid(dccId(id));
+      int dccid(dccId(id, GetElectronicsMap()));
 
-      meMean.fill(dccid, mean);
-      meRMS.fill(dccid, rms);
-      meRMSMap.setBinContent(id, rms);
-      meRMSMapAllByLumi.setBinContent(id, rmsLS);
+      meMean.fill(getEcalDQMSetupObjects(), dccid, mean);
+      meRMS.fill(getEcalDQMSetupObjects(), dccid, rms);
+      meRMSMap.setBinContent(getEcalDQMSetupObjects(), id, rms);
+      meRMSMapAllByLumi.setBinContent(getEcalDQMSetupObjects(), id, rmsLS);
 
       if (((mean > expectedMean_ + toleranceHigh_) || (mean < expectedMean_ - toleranceLow_)) || rms > rmsThresh) {
         qItr->setBinContent(doMask ? kMBad : kBad);
-        meQualitySummary.setBinContent(id, doMask ? kMBad : kBad);
+        meQualitySummary.setBinContent(getEcalDQMSetupObjects(), id, doMask ? kMBad : kBad);
         if (!doMask)
-          meErrorsSummary.fill(id);
+          meErrorsSummary.fill(getEcalDQMSetupObjects(), id);
       } else {
         qItr->setBinContent(doMask ? kMGood : kGood);
-        meQualitySummary.setBinContent(id, doMask ? kMGood : kGood);
+        meQualitySummary.setBinContent(getEcalDQMSetupObjects(), id, doMask ? kMGood : kGood);
       }
 
       // Fill Presample Trend plots:
       // Use PedestalByLS which only contains digis from "current" LS
-      float chStatus(sChStatus.getBinContent(id));
+      float chStatus(sChStatus.getBinContent(getEcalDQMSetupObjects(), id));
       if (entriesLS < minChannelEntries_)
         continue;
       if (chStatus != EcalChannelStatusCode::kOk)
@@ -131,10 +131,10 @@ namespace ecaldqm {
 
     MESet& meTrendMean(MEs_.at("TrendMean"));
     MESet& meTrendRMS(MEs_.at("TrendRMS"));
-    meTrendMean.fill(EcalBarrel, double(timestamp_.iLumi), maxEB - minEB);
-    meTrendMean.fill(EcalEndcap, double(timestamp_.iLumi), maxEE - minEE);
-    meTrendRMS.fill(EcalBarrel, double(timestamp_.iLumi), rmsMaxEB);
-    meTrendRMS.fill(EcalEndcap, double(timestamp_.iLumi), rmsMaxEE);
+    meTrendMean.fill(getEcalDQMSetupObjects(), EcalBarrel, double(timestamp_.iLumi), maxEB - minEB);
+    meTrendMean.fill(getEcalDQMSetupObjects(), EcalEndcap, double(timestamp_.iLumi), maxEE - minEE);
+    meTrendRMS.fill(getEcalDQMSetupObjects(), EcalBarrel, double(timestamp_.iLumi), rmsMaxEB);
+    meTrendRMS.fill(getEcalDQMSetupObjects(), EcalEndcap, double(timestamp_.iLumi), rmsMaxEE);
   }
 
   DEFINE_ECALDQM_WORKER(PresampleClient);

--- a/DQM/EcalMonitorClient/src/PresampleClient.cc
+++ b/DQM/EcalMonitorClient/src/PresampleClient.cc
@@ -54,7 +54,8 @@ namespace ecaldqm {
     MESet::const_iterator pLSItr(GetElectronicsMap(), sPedestalByLS);
     double maxEB(0.), minEB(0.), maxEE(0.), minEE(0.);
     double rmsMaxEB(0.), rmsMaxEE(0.);
-    for (MESet::iterator qItr(meQuality.beginChannel(GetElectronicsMap())); qItr != qEnd; qItr.toNextChannel(GetElectronicsMap())) {
+    for (MESet::iterator qItr(meQuality.beginChannel(GetElectronicsMap())); qItr != qEnd;
+         qItr.toNextChannel(GetElectronicsMap())) {
       pItr = qItr;
       pLSItr = qItr;
 

--- a/DQM/EcalMonitorClient/src/RawDataClient.cc
+++ b/DQM/EcalMonitorClient/src/RawDataClient.cc
@@ -33,13 +33,14 @@ namespace ecaldqm {
 
     for (unsigned iDCC(0); iDCC < nDCC; ++iDCC) {
       double entries(sEntries.getBinContent(getEcalDQMSetupObjects(), iDCC + 1));
-      if (entries > 1. &&
-          sL1ADCC.getBinContent(getEcalDQMSetupObjects(), iDCC + 1) > synchErrThresholdFactor_ * std::log(entries) / std::log(10.))
+      if (entries > 1. && sL1ADCC.getBinContent(getEcalDQMSetupObjects(), iDCC + 1) >
+                              synchErrThresholdFactor_ * std::log(entries) / std::log(10.))
         dccStatus[iDCC] = 0;
     }
 
     MESet::iterator meEnd(meQualitySummary.end(GetElectronicsMap()));
-    for (MESet::iterator meItr(meQualitySummary.beginChannel(GetElectronicsMap())); meItr != meEnd; meItr.toNextChannel(GetElectronicsMap())) {
+    for (MESet::iterator meItr(meQualitySummary.beginChannel(GetElectronicsMap())); meItr != meEnd;
+         meItr.toNextChannel(GetElectronicsMap())) {
       DetId id(meItr->getId());
 
       bool doMask(meQualitySummary.maskMatches(id, mask, statusManager_, GetTrigTowerMap()));

--- a/DQM/EcalMonitorClient/src/RawDataClient.cc
+++ b/DQM/EcalMonitorClient/src/RawDataClient.cc
@@ -32,19 +32,19 @@ namespace ecaldqm {
     std::vector<int> dccStatus(nDCC, 1);
 
     for (unsigned iDCC(0); iDCC < nDCC; ++iDCC) {
-      double entries(sEntries.getBinContent(iDCC + 1));
+      double entries(sEntries.getBinContent(getEcalDQMSetupObjects(), iDCC + 1));
       if (entries > 1. &&
-          sL1ADCC.getBinContent(iDCC + 1) > synchErrThresholdFactor_ * std::log(entries) / std::log(10.))
+          sL1ADCC.getBinContent(getEcalDQMSetupObjects(), iDCC + 1) > synchErrThresholdFactor_ * std::log(entries) / std::log(10.))
         dccStatus[iDCC] = 0;
     }
 
-    MESet::iterator meEnd(meQualitySummary.end());
-    for (MESet::iterator meItr(meQualitySummary.beginChannel()); meItr != meEnd; meItr.toNextChannel()) {
+    MESet::iterator meEnd(meQualitySummary.end(GetElectronicsMap()));
+    for (MESet::iterator meItr(meQualitySummary.beginChannel(GetElectronicsMap())); meItr != meEnd; meItr.toNextChannel(GetElectronicsMap())) {
       DetId id(meItr->getId());
 
-      bool doMask(meQualitySummary.maskMatches(id, mask, statusManager_));
+      bool doMask(meQualitySummary.maskMatches(id, mask, statusManager_, GetTrigTowerMap()));
 
-      int dccid(dccId(id));
+      int dccid(dccId(id, GetElectronicsMap()));
 
       if (dccStatus[dccid - 1] == 0) {
         meItr->setBinContent(doMask ? kMUnknown : kUnknown);
@@ -54,7 +54,7 @@ namespace ecaldqm {
       int towerStatus(doMask ? kMGood : kGood);
       float towerEntries(0.);
       for (unsigned iS(0); iS < nFEFlags; iS++) {
-        float entries(sFEStatus.getBinContent(id, iS + 1));
+        float entries(sFEStatus.getBinContent(getEcalDQMSetupObjects(), id, iS + 1));
         towerEntries += entries;
         if (entries > 0. && iS != Enabled && iS != Suppressed && iS != FIFOFull && iS != FIFOFullL1ADesync &&
             iS != ForcedZS)
@@ -66,7 +66,7 @@ namespace ecaldqm {
 
       meItr->setBinContent(towerStatus);
       if (towerStatus == kBad)
-        meErrorsSummary.fill(dccid);
+        meErrorsSummary.fill(getEcalDQMSetupObjects(), dccid);
     }
   }
 

--- a/DQM/EcalMonitorClient/src/SelectiveReadoutClient.cc
+++ b/DQM/EcalMonitorClient/src/SelectiveReadoutClient.cc
@@ -28,21 +28,21 @@ namespace ecaldqm {
     MESet const& sMedIntMap(sources_.at("MedIntMap"));
     MESet const& sLowIntMap(sources_.at("LowIntMap"));
 
-    MESet::const_iterator ruItr(sRUForcedMap);
-    MESet::const_iterator frItr(sFullReadoutMap);
-    MESet::const_iterator zs1Itr(sZS1Map);
-    MESet::const_iterator zsItr(sZSMap);
-    MESet::const_iterator zsfrItr(sZSFullReadoutMap);
-    MESet::const_iterator frdItr(sFRDroppedMap);
+    MESet::const_iterator ruItr(GetElectronicsMap(), sRUForcedMap);
+    MESet::const_iterator frItr(GetElectronicsMap(), sFullReadoutMap);
+    MESet::const_iterator zs1Itr(GetElectronicsMap(), sZS1Map);
+    MESet::const_iterator zsItr(GetElectronicsMap(), sZSMap);
+    MESet::const_iterator zsfrItr(GetElectronicsMap(), sZSFullReadoutMap);
+    MESet::const_iterator frdItr(GetElectronicsMap(), sFRDroppedMap);
 
-    MESet::iterator frdRateItr(meFRDropped);
-    MESet::iterator zsrRateItr(meZSReadout);
-    MESet::iterator frRateItr(meFR);
-    MESet::iterator ruRateItr(meRUForced);
-    MESet::iterator zs1RateItr(meZS1);
+    MESet::iterator frdRateItr(GetElectronicsMap(), meFRDropped);
+    MESet::iterator zsrRateItr(GetElectronicsMap(), meZSReadout);
+    MESet::iterator frRateItr(GetElectronicsMap(), meFR);
+    MESet::iterator ruRateItr(GetElectronicsMap(), meRUForced);
+    MESet::iterator zs1RateItr(GetElectronicsMap(), meZS1);
 
-    MESet::const_iterator cEnd(sFlagCounterMap.end());
-    for (MESet::const_iterator cItr(sFlagCounterMap.beginChannel()); cItr != cEnd; cItr.toNextChannel()) {
+    MESet::const_iterator cEnd(sFlagCounterMap.end(GetElectronicsMap()));
+    for (MESet::const_iterator cItr(sFlagCounterMap.beginChannel(GetElectronicsMap())); cItr != cEnd; cItr.toNextChannel(GetElectronicsMap())) {
       ruItr = cItr;
       frItr = cItr;
       zs1Itr = cItr;
@@ -75,15 +75,15 @@ namespace ecaldqm {
     for (unsigned iTT(0); iTT < EcalTrigTowerDetId::kSizeForDenseIndexing; ++iTT) {
       EcalTrigTowerDetId id(EcalTrigTowerDetId::detIdFromDenseIndex(iTT));
 
-      float nHigh(sHighIntMap.getBinContent(id));
-      float nMed(sMedIntMap.getBinContent(id));
-      float nLow(sLowIntMap.getBinContent(id));
+      float nHigh(sHighIntMap.getBinContent(getEcalDQMSetupObjects(), id));
+      float nMed(sMedIntMap.getBinContent(getEcalDQMSetupObjects(), id));
+      float nLow(sLowIntMap.getBinContent(getEcalDQMSetupObjects(), id));
       float total(nHigh + nMed + nLow);
 
       if (total > 0.) {
-        meHighInterest.setBinContent(id, nHigh / total);
-        meMedInterest.setBinContent(id, nMed / total);
-        meLowInterest.setBinContent(id, nLow / total);
+        meHighInterest.setBinContent(getEcalDQMSetupObjects(), id, nHigh / total);
+        meMedInterest.setBinContent(getEcalDQMSetupObjects(), id, nMed / total);
+        meLowInterest.setBinContent(getEcalDQMSetupObjects(), id, nLow / total);
       }
     }
   }

--- a/DQM/EcalMonitorClient/src/SelectiveReadoutClient.cc
+++ b/DQM/EcalMonitorClient/src/SelectiveReadoutClient.cc
@@ -42,7 +42,8 @@ namespace ecaldqm {
     MESet::iterator zs1RateItr(GetElectronicsMap(), meZS1);
 
     MESet::const_iterator cEnd(sFlagCounterMap.end(GetElectronicsMap()));
-    for (MESet::const_iterator cItr(sFlagCounterMap.beginChannel(GetElectronicsMap())); cItr != cEnd; cItr.toNextChannel(GetElectronicsMap())) {
+    for (MESet::const_iterator cItr(sFlagCounterMap.beginChannel(GetElectronicsMap())); cItr != cEnd;
+         cItr.toNextChannel(GetElectronicsMap())) {
       ruItr = cItr;
       frItr = cItr;
       zs1Itr = cItr;

--- a/DQM/EcalMonitorClient/src/SummaryClient.cc
+++ b/DQM/EcalMonitorClient/src/SummaryClient.cc
@@ -67,7 +67,8 @@ namespace ecaldqm {
     double rawDataByLumi[nDCC];
     for (unsigned iDCC(0); iDCC < nDCC; ++iDCC) {
       integrityByLumi[iDCC] = sIntegrityByLumi.getBinContent(getEcalDQMSetupObjects(), iDCC + 1);
-      rawDataByLumi[iDCC] = sDesyncByLumi.getBinContent(getEcalDQMSetupObjects(), iDCC + 1) + sFEByLumi.getBinContent(getEcalDQMSetupObjects(), iDCC + 1);
+      rawDataByLumi[iDCC] = sDesyncByLumi.getBinContent(getEcalDQMSetupObjects(), iDCC + 1) +
+                            sFEByLumi.getBinContent(getEcalDQMSetupObjects(), iDCC + 1);
     }
 
     MESet& meQualitySummary(MEs_.at("QualitySummary"));
@@ -97,7 +98,8 @@ namespace ecaldqm {
     MESet const& sBXTCC(sources_.at("BXTCC"));
     std::vector<bool> hasMismatchDCC(nDCC, false);
     for (unsigned iDCC(0); iDCC < nDCC; ++iDCC) {
-      if (sBXSRP.getBinContent(getEcalDQMSetupObjects(), iDCC + 1) > 50. || sBXTCC.getBinContent(getEcalDQMSetupObjects(), iDCC + 1) > 50.)  // "any" = 50
+      if (sBXSRP.getBinContent(getEcalDQMSetupObjects(), iDCC + 1) > 50. ||
+          sBXTCC.getBinContent(getEcalDQMSetupObjects(), iDCC + 1) > 50.)  // "any" = 50
         hasMismatchDCC[iDCC] = true;
     }
 
@@ -105,7 +107,8 @@ namespace ecaldqm {
     uint32_t mask(1 << EcalDQMStatusHelper::STATUS_FLAG_ERROR);
 
     MESet::iterator qEnd(meQualitySummary.end(GetElectronicsMap()));
-    for (MESet::iterator qItr(meQualitySummary.beginChannel(GetElectronicsMap())); qItr != qEnd; qItr.toNextChannel(GetElectronicsMap())) {
+    for (MESet::iterator qItr(meQualitySummary.beginChannel(GetElectronicsMap())); qItr != qEnd;
+         qItr.toNextChannel(GetElectronicsMap())) {
       DetId id(qItr->getId());
       unsigned iDCC(dccId(id, GetElectronicsMap()) - 1);
 
@@ -115,7 +118,8 @@ namespace ecaldqm {
       int presample(sPresample ? (int)sPresample->getBinContent(getEcalDQMSetupObjects(), id) : kUnknown);
       int hotcell(sHotCell ? (int)sHotCell->getBinContent(getEcalDQMSetupObjects(), id) : kUnknown);
       int timing(sTiming ? (int)sTiming->getBinContent(getEcalDQMSetupObjects(), id) : kUnknown);
-      int trigprim(sTriggerPrimitives ? (int)sTriggerPrimitives->getBinContent(getEcalDQMSetupObjects(), id) : kUnknown);
+      int trigprim(sTriggerPrimitives ? (int)sTriggerPrimitives->getBinContent(getEcalDQMSetupObjects(), id)
+                                      : kUnknown);
       int rawdata(sRawData.getBinContent(getEcalDQMSetupObjects(), id));
 
       double rawdataLS(sFEStatusErrMapByLumi.getBinContent(getEcalDQMSetupObjects(), id));  // Includes FE=Disabled

--- a/DQM/EcalMonitorClient/src/SummaryClient.cc
+++ b/DQM/EcalMonitorClient/src/SummaryClient.cc
@@ -40,12 +40,12 @@ namespace ecaldqm {
 
     for (unsigned iDCC(0); iDCC < nDCC; ++iDCC) {
       int dccid(iDCC + 1);
-      meReportSummaryContents.fill(dccid, -1.);
+      meReportSummaryContents.fill(getEcalDQMSetupObjects(), dccid, -1.);
     }
 
-    meReportSummary.fill(-1.);
+    meReportSummary.fill(getEcalDQMSetupObjects(), -1.);
 
-    meReportSummaryMap.reset(-1.);
+    meReportSummaryMap.reset(GetElectronicsMap(), -1.);
   }
 
   void SummaryClient::producePlots(ProcessType _pType) {
@@ -54,9 +54,9 @@ namespace ecaldqm {
 
     for (unsigned iDCC(0); iDCC < nDCC; ++iDCC) {
       int dccid(iDCC + 1);
-      meReportSummaryContents.fill(dccid, -1.);
+      meReportSummaryContents.fill(getEcalDQMSetupObjects(), dccid, -1.);
     }
-    meReportSummary.fill(-1.);
+    meReportSummary.fill(getEcalDQMSetupObjects(), -1.);
 
     MESet const& sIntegrityByLumi(sources_.at("IntegrityByLumi"));
     MESet const& sDesyncByLumi(sources_.at("DesyncByLumi"));
@@ -66,8 +66,8 @@ namespace ecaldqm {
     double integrityByLumi[nDCC];
     double rawDataByLumi[nDCC];
     for (unsigned iDCC(0); iDCC < nDCC; ++iDCC) {
-      integrityByLumi[iDCC] = sIntegrityByLumi.getBinContent(iDCC + 1);
-      rawDataByLumi[iDCC] = sDesyncByLumi.getBinContent(iDCC + 1) + sFEByLumi.getBinContent(iDCC + 1);
+      integrityByLumi[iDCC] = sIntegrityByLumi.getBinContent(getEcalDQMSetupObjects(), iDCC + 1);
+      rawDataByLumi[iDCC] = sDesyncByLumi.getBinContent(getEcalDQMSetupObjects(), iDCC + 1) + sFEByLumi.getBinContent(getEcalDQMSetupObjects(), iDCC + 1);
     }
 
     MESet& meQualitySummary(MEs_.at("QualitySummary"));
@@ -97,28 +97,28 @@ namespace ecaldqm {
     MESet const& sBXTCC(sources_.at("BXTCC"));
     std::vector<bool> hasMismatchDCC(nDCC, false);
     for (unsigned iDCC(0); iDCC < nDCC; ++iDCC) {
-      if (sBXSRP.getBinContent(iDCC + 1) > 50. || sBXTCC.getBinContent(iDCC + 1) > 50.)  // "any" = 50
+      if (sBXSRP.getBinContent(getEcalDQMSetupObjects(), iDCC + 1) > 50. || sBXTCC.getBinContent(getEcalDQMSetupObjects(), iDCC + 1) > 50.)  // "any" = 50
         hasMismatchDCC[iDCC] = true;
     }
 
     // Get RawData mask
     uint32_t mask(1 << EcalDQMStatusHelper::STATUS_FLAG_ERROR);
 
-    MESet::iterator qEnd(meQualitySummary.end());
-    for (MESet::iterator qItr(meQualitySummary.beginChannel()); qItr != qEnd; qItr.toNextChannel()) {
+    MESet::iterator qEnd(meQualitySummary.end(GetElectronicsMap()));
+    for (MESet::iterator qItr(meQualitySummary.beginChannel(GetElectronicsMap())); qItr != qEnd; qItr.toNextChannel(GetElectronicsMap())) {
       DetId id(qItr->getId());
-      unsigned iDCC(dccId(id) - 1);
+      unsigned iDCC(dccId(id, GetElectronicsMap()) - 1);
 
       // Initialize individual Quality Summaries
       // NOTE: These represent quality over *cumulative* statistics
-      int integrity(sIntegrity ? (int)sIntegrity->getBinContent(id) : kUnknown);
-      int presample(sPresample ? (int)sPresample->getBinContent(id) : kUnknown);
-      int hotcell(sHotCell ? (int)sHotCell->getBinContent(id) : kUnknown);
-      int timing(sTiming ? (int)sTiming->getBinContent(id) : kUnknown);
-      int trigprim(sTriggerPrimitives ? (int)sTriggerPrimitives->getBinContent(id) : kUnknown);
-      int rawdata(sRawData.getBinContent(id));
+      int integrity(sIntegrity ? (int)sIntegrity->getBinContent(getEcalDQMSetupObjects(), id) : kUnknown);
+      int presample(sPresample ? (int)sPresample->getBinContent(getEcalDQMSetupObjects(), id) : kUnknown);
+      int hotcell(sHotCell ? (int)sHotCell->getBinContent(getEcalDQMSetupObjects(), id) : kUnknown);
+      int timing(sTiming ? (int)sTiming->getBinContent(getEcalDQMSetupObjects(), id) : kUnknown);
+      int trigprim(sTriggerPrimitives ? (int)sTriggerPrimitives->getBinContent(getEcalDQMSetupObjects(), id) : kUnknown);
+      int rawdata(sRawData.getBinContent(getEcalDQMSetupObjects(), id));
 
-      double rawdataLS(sFEStatusErrMapByLumi.getBinContent(id));  // Includes FE=Disabled
+      double rawdataLS(sFEStatusErrMapByLumi.getBinContent(getEcalDQMSetupObjects(), id));  // Includes FE=Disabled
 
       // If there are no RawData or Integrity errors in this LS, set them back to GOOD
       //if(integrity == kBad && integrityByLumi[iDCC] == 0.) integrity = kGood;
@@ -161,7 +161,7 @@ namespace ecaldqm {
 
       // Keep running count of good channels in RawData only: Uses LS stats only.
       // LS-based reports only use RawData as input to save on having to run other workers
-      bool isMasked(meQualitySummary.maskMatches(id, mask, statusManager_));
+      bool isMasked(meQualitySummary.maskMatches(id, mask, statusManager_, GetTrigTowerMap()));
       if (rawdataLS == 0. || isMasked) {  // channel != kBad in rawdata
         dccGoodRaw[iDCC] += 1.;
         totalGoodRaw += 1.;
@@ -241,9 +241,9 @@ namespace ecaldqm {
       int dccid(iDCC + 1);
       float frac(dccGood[iDCC] / dccChannels[iDCC]);
       float fracRaw(dccGoodRaw[iDCC] / dccChannels[iDCC]);
-      meReportSummaryMap.setBinContent(dccid, frac);
+      meReportSummaryMap.setBinContent(getEcalDQMSetupObjects(), dccid, frac);
       float fracLS(onlineMode_ ? frac : fracRaw);
-      meReportSummaryContents.fill(dccid, fracLS);  // reported by LS
+      meReportSummaryContents.fill(getEcalDQMSetupObjects(), dccid, fracLS);  // reported by LS
 
       if (1. - frac > fedBadFraction_)
         nBad += 1.;
@@ -251,12 +251,12 @@ namespace ecaldqm {
 
     float totalGoodLS(onlineMode_ ? totalGood : totalGoodRaw);
     if (totalChannels > 0.)
-      meReportSummary.fill(totalGoodLS / totalChannels);  // reported by LS
+      meReportSummary.fill(getEcalDQMSetupObjects(), totalGoodLS / totalChannels);  // reported by LS
 
     if (onlineMode_) {
       if (totalChannels > 0.)
-        MEs_.at("GlobalSummary").setBinContent(1, totalGood / totalChannels);
-      MEs_.at("NBadFEDs").setBinContent(1, nBad);
+        MEs_.at("GlobalSummary").setBinContent(getEcalDQMSetupObjects(), 1, totalGood / totalChannels);
+      MEs_.at("NBadFEDs").setBinContent(getEcalDQMSetupObjects(), 1, nBad);
     }
 
   }  // producePlots()

--- a/DQM/EcalMonitorClient/src/TestPulseClient.cc
+++ b/DQM/EcalMonitorClient/src/TestPulseClient.cc
@@ -141,13 +141,13 @@ namespace ecaldqm {
           break;
       }
 
-      MESet::iterator qEnd(meQuality.end());
-      MESet::iterator rItr(meAmplitudeRMS);
-      MESet::const_iterator aItr(sAmplitude);
-      for (MESet::iterator qItr(meQuality.beginChannel()); qItr != qEnd; qItr.toNextChannel()) {
+      MESet::iterator qEnd(meQuality.end(GetElectronicsMap()));
+      MESet::iterator rItr(GetElectronicsMap(), meAmplitudeRMS);
+      MESet::const_iterator aItr(GetElectronicsMap(), sAmplitude);
+      for (MESet::iterator qItr(meQuality.beginChannel(GetElectronicsMap())); qItr != qEnd; qItr.toNextChannel(GetElectronicsMap())) {
         DetId id(qItr->getId());
 
-        bool doMask(meQuality.maskMatches(id, mask, statusManager_));
+        bool doMask(meQuality.maskMatches(id, mask, statusManager_, GetTrigTowerMap()));
 
         aItr = qItr;
         rItr = qItr;
@@ -205,21 +205,21 @@ namespace ecaldqm {
 
           EcalPnDiodeDetId id(subdet, iDCC + 1, iPN + 1);
 
-          bool doMask(mePNQualitySummary.maskMatches(id, mask, statusManager_));
+          bool doMask(mePNQualitySummary.maskMatches(id, mask, statusManager_, GetTrigTowerMap()));
 
-          float amp(sPNAmplitude.getBinContent(id));
-          float entries(sPNAmplitude.getBinEntries(id));
-          float rms(sPNAmplitude.getBinError(id) * sqrt(entries));
+          float amp(sPNAmplitude.getBinContent(getEcalDQMSetupObjects(), id));
+          float entries(sPNAmplitude.getBinEntries(getEcalDQMSetupObjects(), id));
+          float rms(sPNAmplitude.getBinError(getEcalDQMSetupObjects(), id) * sqrt(entries));
 
           if (entries < minChannelEntries_) {
-            mePNQualitySummary.setBinContent(id, doMask ? kMUnknown : kUnknown);
+            mePNQualitySummary.setBinContent(getEcalDQMSetupObjects(), id, doMask ? kMUnknown : kUnknown);
             continue;
           }
 
           if (amp < PNAmplitudeThreshold_[gainItr->second] || rms > tolerancePNRMS_[gainItr->second])
-            mePNQualitySummary.setBinContent(id, doMask ? kMBad : kBad);
+            mePNQualitySummary.setBinContent(getEcalDQMSetupObjects(), id, doMask ? kMBad : kBad);
           else
-            mePNQualitySummary.setBinContent(id, doMask ? kMGood : kGood);
+            mePNQualitySummary.setBinContent(getEcalDQMSetupObjects(), id, doMask ? kMGood : kGood);
         }
       }
     }

--- a/DQM/EcalMonitorClient/src/TestPulseClient.cc
+++ b/DQM/EcalMonitorClient/src/TestPulseClient.cc
@@ -144,7 +144,8 @@ namespace ecaldqm {
       MESet::iterator qEnd(meQuality.end(GetElectronicsMap()));
       MESet::iterator rItr(GetElectronicsMap(), meAmplitudeRMS);
       MESet::const_iterator aItr(GetElectronicsMap(), sAmplitude);
-      for (MESet::iterator qItr(meQuality.beginChannel(GetElectronicsMap())); qItr != qEnd; qItr.toNextChannel(GetElectronicsMap())) {
+      for (MESet::iterator qItr(meQuality.beginChannel(GetElectronicsMap())); qItr != qEnd;
+           qItr.toNextChannel(GetElectronicsMap())) {
         DetId id(qItr->getId());
 
         bool doMask(meQuality.maskMatches(id, mask, statusManager_, GetTrigTowerMap()));

--- a/DQM/EcalMonitorClient/src/TimingClient.cc
+++ b/DQM/EcalMonitorClient/src/TimingClient.cc
@@ -56,16 +56,16 @@ namespace ecaldqm {
 
     uint32_t mask(1 << EcalDQMStatusHelper::PHYSICS_BAD_CHANNEL_WARNING);
 
-    MESet::iterator qEnd(meQuality.end());
+    MESet::iterator qEnd(meQuality.end(GetElectronicsMap()));
 
-    MESet::iterator rItr(meRMSMap);
-    MESet::const_iterator tItr(sTimeMap);
-    MESet::const_iterator tLSItr(sTimeMapByLS);
+    MESet::iterator rItr(GetElectronicsMap(), meRMSMap);
+    MESet::const_iterator tItr(GetElectronicsMap(), sTimeMap);
+    MESet::const_iterator tLSItr(GetElectronicsMap(), sTimeMapByLS);
 
     float EBentries(0.), EEentries(0.);
     float EBmean(0.), EEmean(0.);
     float EBrms(0.), EErms(0.);
-    for (MESet::iterator qItr(meQuality.beginChannel()); qItr != qEnd; qItr.toNextChannel()) {
+    for (MESet::iterator qItr(meQuality.beginChannel(GetElectronicsMap())); qItr != qEnd; qItr.toNextChannel(GetElectronicsMap())) {
       tItr = qItr;
       rItr = qItr;
 
@@ -81,7 +81,7 @@ namespace ecaldqm {
         rmsThresh = toleranceRMSFwd_;
       }
 
-      bool doMask(meQuality.maskMatches(id, mask, statusManager_));
+      bool doMask(meQuality.maskMatches(id, mask, statusManager_, GetTrigTowerMap()));
 
       float entries(tItr->getBinEntries());
 
@@ -94,11 +94,11 @@ namespace ecaldqm {
       float mean(tItr->getBinContent());
       float rms(tItr->getBinError() * sqrt(entries));
 
-      meMeanSM.fill(id, mean);
-      meMeanAll.fill(id, mean);
-      meProjEta.fill(id, mean);
-      meProjPhi.fill(id, mean);
-      meRMSAll.fill(id, rms);
+      meMeanSM.fill(getEcalDQMSetupObjects(), id, mean);
+      meMeanAll.fill(getEcalDQMSetupObjects(), id, mean);
+      meProjEta.fill(getEcalDQMSetupObjects(), id, mean);
+      meProjPhi.fill(getEcalDQMSetupObjects(), id, mean);
+      meRMSAll.fill(getEcalDQMSetupObjects(), id, rms);
       rItr->setBinContent(rms);
 
       bool negative(false);
@@ -109,19 +109,19 @@ namespace ecaldqm {
         if (ebid.zside() < 0) {
           negative = true;
           EBDetId posId(EBDetId::switchZSide(ebid));
-          posTime = sTimeMap.getBinContent(posId);
+          posTime = sTimeMap.getBinContent(getEcalDQMSetupObjects(), posId);
         }
       } else {
         EEDetId eeid(id);
         if (eeid.zside() < 0) {
           negative = true;
           EEDetId posId(EEDetId::switchZSide(eeid));
-          posTime = sTimeMap.getBinContent(posId);
+          posTime = sTimeMap.getBinContent(getEcalDQMSetupObjects(), posId);
         }
       }
       if (negative) {
-        meFwdBkwdDiff.fill(id, posTime - mean);
-        meFwdvBkwd.fill(id, mean, posTime);
+        meFwdBkwdDiff.fill(getEcalDQMSetupObjects(), id, posTime - mean);
+        meFwdvBkwd.fill(getEcalDQMSetupObjects(), id, mean, posTime);
       }
 
       if (std::abs(mean) > meanThresh || rms > rmsThresh)
@@ -134,7 +134,7 @@ namespace ecaldqm {
       float entriesLS(tLSItr->getBinEntries());
       float meanLS(tLSItr->getBinContent());
       float rmsLS(tLSItr->getBinError() * sqrt(entriesLS));
-      float chStatus(sChStatus.getBinContent(id));
+      float chStatus(sChStatus.getBinContent(getEcalDQMSetupObjects(), id));
 
       if (entriesLS < minChannelEntries)
         continue;
@@ -159,26 +159,26 @@ namespace ecaldqm {
     MESet& meTrendRMS(MEs_.at("TrendRMS"));
     if (EBentries > 0.) {
       if (std::abs(EBmean) > 0.)
-        meTrendMean.fill(EcalBarrel, double(timestamp_.iLumi), EBmean / EBentries);
+        meTrendMean.fill(getEcalDQMSetupObjects(), EcalBarrel, double(timestamp_.iLumi), EBmean / EBentries);
       if (std::abs(EBrms) > 0.)
-        meTrendRMS.fill(EcalBarrel, double(timestamp_.iLumi), EBrms / EBentries);
+        meTrendRMS.fill(getEcalDQMSetupObjects(), EcalBarrel, double(timestamp_.iLumi), EBrms / EBentries);
     }
     if (EEentries > 0.) {
       if (std::abs(EEmean) > 0.)
-        meTrendMean.fill(EcalEndcap, double(timestamp_.iLumi), EEmean / EEentries);
+        meTrendMean.fill(getEcalDQMSetupObjects(), EcalEndcap, double(timestamp_.iLumi), EEmean / EEentries);
       if (std::abs(EErms) > 0.)
-        meTrendRMS.fill(EcalEndcap, double(timestamp_.iLumi), EErms / EEentries);
+        meTrendRMS.fill(getEcalDQMSetupObjects(), EcalEndcap, double(timestamp_.iLumi), EErms / EEentries);
     }
 
-    MESet::iterator qsEnd(meQualitySummary.end());
+    MESet::iterator qsEnd(meQualitySummary.end(GetElectronicsMap()));
 
-    for (MESet::iterator qsItr(meQualitySummary.beginChannel()); qsItr != qsEnd; qsItr.toNextChannel()) {
+    for (MESet::iterator qsItr(meQualitySummary.beginChannel(GetElectronicsMap())); qsItr != qsEnd; qsItr.toNextChannel(GetElectronicsMap())) {
       DetId tId(qsItr->getId());
 
       std::vector<DetId> ids;
 
       if (tId.subdetId() == EcalTriggerTower)
-        ids = getTrigTowerMap()->constituentsOf(EcalTrigTowerDetId(tId));
+        ids = GetTrigTowerMap()->constituentsOf(EcalTrigTowerDetId(tId));
       else
         ids = scConstituents(EcalScDetId(tId));
 
@@ -193,7 +193,7 @@ namespace ecaldqm {
       }
 
       // tower entries != sum(channel entries) because of the difference in timing cut at the source
-      float summaryEntries(sTimeAllMap.getBinEntries(tId));
+      float summaryEntries(sTimeAllMap.getBinEntries(getEcalDQMSetupObjects(), tId));
 
       float towerEntries(0.);
       float towerMean(0.);
@@ -204,9 +204,9 @@ namespace ecaldqm {
       for (std::vector<DetId>::iterator idItr(ids.begin()); idItr != ids.end(); ++idItr) {
         DetId& id(*idItr);
 
-        doMask |= meQuality.maskMatches(id, mask, statusManager_);
+        doMask |= meQuality.maskMatches(id, mask, statusManager_, GetTrigTowerMap());
 
-        MESet::const_iterator tmItr(sTimeMap, id);
+        MESet::const_iterator tmItr(GetElectronicsMap(), sTimeMap, id);
 
         float entries(tmItr->getBinEntries());
         if (entries < 0.)

--- a/DQM/EcalMonitorClient/src/TimingClient.cc
+++ b/DQM/EcalMonitorClient/src/TimingClient.cc
@@ -65,7 +65,8 @@ namespace ecaldqm {
     float EBentries(0.), EEentries(0.);
     float EBmean(0.), EEmean(0.);
     float EBrms(0.), EErms(0.);
-    for (MESet::iterator qItr(meQuality.beginChannel(GetElectronicsMap())); qItr != qEnd; qItr.toNextChannel(GetElectronicsMap())) {
+    for (MESet::iterator qItr(meQuality.beginChannel(GetElectronicsMap())); qItr != qEnd;
+         qItr.toNextChannel(GetElectronicsMap())) {
       tItr = qItr;
       rItr = qItr;
 
@@ -172,7 +173,8 @@ namespace ecaldqm {
 
     MESet::iterator qsEnd(meQualitySummary.end(GetElectronicsMap()));
 
-    for (MESet::iterator qsItr(meQualitySummary.beginChannel(GetElectronicsMap())); qsItr != qsEnd; qsItr.toNextChannel(GetElectronicsMap())) {
+    for (MESet::iterator qsItr(meQualitySummary.beginChannel(GetElectronicsMap())); qsItr != qsEnd;
+         qsItr.toNextChannel(GetElectronicsMap())) {
       DetId tId(qsItr->getId());
 
       std::vector<DetId> ids;

--- a/DQM/EcalMonitorClient/src/TowerStatusTask.cc
+++ b/DQM/EcalMonitorClient/src/TowerStatusTask.cc
@@ -50,13 +50,13 @@ namespace ecaldqm {
         for (unsigned id(0); id < EcalTrigTowerDetId::kEBTotalTowers; id++) {
           if (daqHndl->barrel(id).getStatusCode() != 0) {
             EcalTrigTowerDetId ttid(EcalTrigTowerDetId::detIdFromDenseIndex(id));
-            daqStatus_[dccId(ttid) - 1] -= 25. / 1700.;
+            daqStatus_[dccId(ttid, GetElectronicsMap()) - 1] -= 25. / 1700.;
           }
         }
         for (unsigned id(0); id < EcalScDetId::kSizeForDenseIndexing; id++) {
           if (daqHndl->endcap(id).getStatusCode() != 0) {
             EcalScDetId scid(EcalScDetId::unhashIndex(id));
-            unsigned dccid(dccId(scid));
+            unsigned dccid(dccId(scid, GetElectronicsMap()));
             daqStatus_[dccid - 1] -= double(scConstituents(scid).size()) / nCrystals(dccid);
           }
         }
@@ -73,13 +73,13 @@ namespace ecaldqm {
         for (unsigned id(0); id < EcalTrigTowerDetId::kEBTotalTowers; id++) {
           if (dcsHndl->barrel(id).getStatusCode() != 0) {
             EcalTrigTowerDetId ttid(EcalTrigTowerDetId::detIdFromDenseIndex(id));
-            dcsStatus_[dccId(ttid) - 1] -= 25. / 1700.;
+            dcsStatus_[dccId(ttid, GetElectronicsMap()) - 1] -= 25. / 1700.;
           }
         }
         for (unsigned id(0); id < EcalScDetId::kSizeForDenseIndexing; id++) {
           if (dcsHndl->endcap(id).getStatusCode() != 0) {
             EcalScDetId scid(EcalScDetId::unhashIndex(id));
-            unsigned dccid(dccId(scid));
+            unsigned dccid(dccId(scid, GetElectronicsMap()));
             dcsStatus_[dccid - 1] -= double(scConstituents(scid).size()) / nCrystals(dccid);
           }
         }
@@ -103,19 +103,19 @@ namespace ecaldqm {
     meSummaryMap = &MEs_.at(_type + "SummaryMap");
     meContents = &MEs_.at(_type + "Contents");
 
-    meSummary->reset(-1.);
+    meSummary->reset(GetElectronicsMap(), -1.);
     meSummaryMap->resetAll(-1.);
-    meSummaryMap->reset();
-    meContents->reset(-1.);
+    meSummaryMap->reset(GetElectronicsMap());
+    meContents->reset(GetElectronicsMap(), -1.);
 
     float totalFraction(0.);
     for (int iDCC(0); iDCC < nDCC; iDCC++) {
-      meSummaryMap->setBinContent(iDCC + 1, _status[iDCC]);
-      meContents->fill(iDCC + 1, _status[iDCC]);
+      meSummaryMap->setBinContent(getEcalDQMSetupObjects(), iDCC + 1, _status[iDCC]);
+      meContents->fill(getEcalDQMSetupObjects(), iDCC + 1, _status[iDCC]);
       totalFraction += _status[iDCC] / nCrystals(iDCC + 1);
     }
 
-    meSummary->fill(totalFraction);
+    meSummary->fill(getEcalDQMSetupObjects(), totalFraction);
   }
 
   DEFINE_ECALDQM_WORKER(TowerStatusTask);

--- a/DQM/EcalMonitorClient/src/TrigPrimClient.cc
+++ b/DQM/EcalMonitorClient/src/TrigPrimClient.cc
@@ -53,7 +53,7 @@ namespace ecaldqm {
     for (unsigned iTT(0); iTT < EcalTrigTowerDetId::kSizeForDenseIndexing; iTT++) {
       EcalTrigTowerDetId ttid(EcalTrigTowerDetId::detIdFromDenseIndex(iTT));
 
-      bool doMask(meEmulQualitySummary.maskMatches(ttid, mask, statusManager_));
+      bool doMask(meEmulQualitySummary.maskMatches(ttid, mask, statusManager_, GetTrigTowerMap()));
 
       if (sourceFromEmul_) {
         sEtEmulError = &sources_.at("EtEmulError");
@@ -64,7 +64,7 @@ namespace ecaldqm {
         float tMax(0.5);
         float nMax(0.);
         for (int iBin(0); iBin < 6; iBin++) {
-          float entries(sMatchedIndex->getBinContent(ttid, iBin + 1));
+          float entries(sMatchedIndex->getBinContent(getEcalDQMSetupObjects(), ttid, iBin + 1));
           towerEntries += entries;
 
           if (entries > nMax) {
@@ -72,28 +72,28 @@ namespace ecaldqm {
             tMax = iBin == 0 ? -0.5 : iBin + 0.5;  // historical reasons.. much clearer to say "no entry = -0.5"
           }
         }
-        meTimingSummary->setBinContent(ttid, tMax);
+        meTimingSummary->setBinContent(getEcalDQMSetupObjects(), ttid, tMax);
         if (towerEntries < minEntries_) {
-          meEmulQualitySummary.setBinContent(ttid, doMask ? kMUnknown : kUnknown);
+          meEmulQualitySummary.setBinContent(getEcalDQMSetupObjects(), ttid, doMask ? kMUnknown : kUnknown);
           continue;
         }
 
         float nonsingleFraction(1. - nMax / towerEntries);
 
         if (nonsingleFraction > 0.) {
-          meNonSingleSummary->setBinContent(ttid, nonsingleFraction);
+          meNonSingleSummary->setBinContent(getEcalDQMSetupObjects(), ttid, nonsingleFraction);
         }
 
-        if (sEtEmulError->getBinContent(ttid) / towerEntries > errorFractionThreshold_) {
-          meEmulQualitySummary.setBinContent(ttid, doMask ? kMBad : kBad);
+        if (sEtEmulError->getBinContent(getEcalDQMSetupObjects(), ttid) / towerEntries > errorFractionThreshold_) {
+          meEmulQualitySummary.setBinContent(getEcalDQMSetupObjects(), ttid, doMask ? kMBad : kBad);
         } else {
-          meEmulQualitySummary.setBinContent(ttid, doMask ? kMGood : kGood);
+          meEmulQualitySummary.setBinContent(getEcalDQMSetupObjects(), ttid, doMask ? kMGood : kGood);
         }
       }
 
       // Keep count for Occupancy analysis
-      unsigned iDCC(dccId(ttid) - 1);
-      Nentries[iDCC] += sTPDigiThrAll.getBinContent(ttid);
+      unsigned iDCC(dccId(ttid, GetElectronicsMap()) - 1);
+      Nentries[iDCC] += sTPDigiThrAll.getBinContent(getEcalDQMSetupObjects(), ttid);
     }
 
     // Fill TTF4 v Masking ME
@@ -112,10 +112,10 @@ namespace ecaldqm {
     // Loop over all TTs
     for (unsigned iTT(0); iTT < EcalTrigTowerDetId::kSizeForDenseIndexing; iTT++) {
       EcalTrigTowerDetId ttid(EcalTrigTowerDetId::detIdFromDenseIndex(iTT));
-      unsigned iDCC(dccId(ttid) - 1);
-      bool isMasked(sTTMaskMapAll.getBinContent(ttid) > 0.);
-      bool hasTTF4(sTTFlags4.getBinContent(ttid) > 0.);
-      bool hasTTF4InThisLumiSection(sTTFlags4ByLumi.getBinContent(ttid) > 0.);
+      unsigned iDCC(dccId(ttid, GetElectronicsMap()) - 1);
+      bool isMasked(sTTMaskMapAll.getBinContent(getEcalDQMSetupObjects(), ttid) > 0.);
+      bool hasTTF4(sTTFlags4.getBinContent(getEcalDQMSetupObjects(), ttid) > 0.);
+      bool hasTTF4InThisLumiSection(sTTFlags4ByLumi.getBinContent(getEcalDQMSetupObjects(), ttid) > 0.);
       if (hasTTF4InThisLumiSection) {
         nWithTTF4[iDCC]++;
         if (ttid.subDet() == EcalBarrel)
@@ -125,26 +125,26 @@ namespace ecaldqm {
       }
       if (isMasked) {
         if (hasTTF4) {
-          meTTF4vMask.setBinContent(ttid, 12);  // Masked, has TTF4
+          meTTF4vMask.setBinContent(getEcalDQMSetupObjects(), ttid, 12);  // Masked, has TTF4
         } else {
-          meTTF4vMask.setBinContent(ttid, 11);  // Masked, no TTF4
+          meTTF4vMask.setBinContent(getEcalDQMSetupObjects(), ttid, 11);  // Masked, no TTF4
         }
         if (hasTTF4InThisLumiSection) {
-          meTTF4vMaskByLumi.setBinContent(ttid, 12);  // Masked, has TTF4
+          meTTF4vMaskByLumi.setBinContent(getEcalDQMSetupObjects(), ttid, 12);  // Masked, has TTF4
         } else {
-          meTTF4vMaskByLumi.setBinContent(ttid, 11);  // Masked, no TTF4
+          meTTF4vMaskByLumi.setBinContent(getEcalDQMSetupObjects(), ttid, 11);  // Masked, no TTF4
         }
       } else {
         if (hasTTF4)
-          meTTF4vMask.setBinContent(ttid, 13);  // not Masked, has TTF4
+          meTTF4vMask.setBinContent(getEcalDQMSetupObjects(), ttid, 13);  // not Masked, has TTF4
         if (hasTTF4InThisLumiSection)
-          meTTF4vMaskByLumi.setBinContent(ttid, 13);  // not Masked, has TTF4
+          meTTF4vMaskByLumi.setBinContent(getEcalDQMSetupObjects(), ttid, 13);  // not Masked, has TTF4
       }
     }  // TT loop
 
     // Fill trend plots for number of TTs with TTF4 flag set
-    meTrendTTF4Flags.fill(EcalBarrel, double(timestamp_.iLumi), nWithTTF4_EB);
-    meTrendTTF4Flags.fill(EcalEndcap, double(timestamp_.iLumi), nWithTTF4_EE);
+    meTrendTTF4Flags.fill(getEcalDQMSetupObjects(), EcalBarrel, double(timestamp_.iLumi), nWithTTF4_EB);
+    meTrendTTF4Flags.fill(getEcalDQMSetupObjects(), EcalEndcap, double(timestamp_.iLumi), nWithTTF4_EE);
 
     // Quality check: set an entire FED to BAD if a more than 80% of the TTs in that FED show any DCC-SRP flag mismatch errors
     // Fill flag mismatch statistics
@@ -153,18 +153,18 @@ namespace ecaldqm {
     MESet const& sTTFMismatch(sources_.at("TTFMismatch"));
     for (unsigned iTT(0); iTT < EcalTrigTowerDetId::kSizeForDenseIndexing; iTT++) {
       EcalTrigTowerDetId ttid(EcalTrigTowerDetId::detIdFromDenseIndex(iTT));
-      unsigned iDCC(dccId(ttid) - 1);
-      if (sTTFMismatch.getBinContent(ttid) > 0.)
+      unsigned iDCC(dccId(ttid, GetElectronicsMap()) - 1);
+      if (sTTFMismatch.getBinContent(getEcalDQMSetupObjects(), ttid) > 0.)
         nTTFMismath[iDCC]++;
       nTTs[iDCC]++;
     }
     // Analyze flag mismatch statistics and TTF4 fraction statistics
     for (unsigned iTT(0); iTT < EcalTrigTowerDetId::kSizeForDenseIndexing; iTT++) {
       EcalTrigTowerDetId ttid(EcalTrigTowerDetId::detIdFromDenseIndex(iTT));
-      unsigned iDCC(dccId(ttid) - 1);
+      unsigned iDCC(dccId(ttid, GetElectronicsMap()) - 1);
       if (nTTFMismath[iDCC] > 0.8 * nTTs[iDCC] || nWithTTF4[iDCC] > TTF4MaskingAlarmThreshold_ * nTTs[iDCC]) {
-        meEmulQualitySummary.setBinContent(ttid,
-                                           meEmulQualitySummary.maskMatches(ttid, mask, statusManager_) ? kMBad : kBad);
+        meEmulQualitySummary.setBinContent(getEcalDQMSetupObjects(), ttid,
+                                           meEmulQualitySummary.maskMatches(ttid, mask, statusManager_, GetTrigTowerMap()) ? kMBad : kBad);
       }
     }
 
@@ -193,7 +193,7 @@ namespace ecaldqm {
     float meanFED(0.), rmsFED(0.), nRMS(5.);
     for (unsigned iTT(0); iTT < EcalTrigTowerDetId::kSizeForDenseIndexing; iTT++) {
       EcalTrigTowerDetId ttid(EcalTrigTowerDetId::detIdFromDenseIndex(iTT));
-      unsigned iDCC(dccId(ttid) - 1);
+      unsigned iDCC(dccId(ttid, GetElectronicsMap()) - 1);
       if (iDCC >= kEBmLow && iDCC <= kEBpHigh) {
         meanFED = meanFEDEB;
         rmsFED = rmsFEDEB;
@@ -203,8 +203,8 @@ namespace ecaldqm {
       }
       float threshold(meanFED < nRMS * rmsFED ? minEntries_ : meanFED - nRMS * rmsFED);
       if ((meanFED > 100. && Nentries[iDCC] < threshold) && statsCheckEnabled)
-        meEmulQualitySummary.setBinContent(ttid,
-                                           meEmulQualitySummary.maskMatches(ttid, mask, statusManager_) ? kMBad : kBad);
+        meEmulQualitySummary.setBinContent(getEcalDQMSetupObjects(), ttid,
+                                           meEmulQualitySummary.maskMatches(ttid, mask, statusManager_, GetTrigTowerMap()) ? kMBad : kBad);
     }
 
   }  // producePlots()

--- a/DQM/EcalMonitorClient/src/TrigPrimClient.cc
+++ b/DQM/EcalMonitorClient/src/TrigPrimClient.cc
@@ -163,8 +163,10 @@ namespace ecaldqm {
       EcalTrigTowerDetId ttid(EcalTrigTowerDetId::detIdFromDenseIndex(iTT));
       unsigned iDCC(dccId(ttid, GetElectronicsMap()) - 1);
       if (nTTFMismath[iDCC] > 0.8 * nTTs[iDCC] || nWithTTF4[iDCC] > TTF4MaskingAlarmThreshold_ * nTTs[iDCC]) {
-        meEmulQualitySummary.setBinContent(getEcalDQMSetupObjects(), ttid,
-                                           meEmulQualitySummary.maskMatches(ttid, mask, statusManager_, GetTrigTowerMap()) ? kMBad : kBad);
+        meEmulQualitySummary.setBinContent(
+            getEcalDQMSetupObjects(),
+            ttid,
+            meEmulQualitySummary.maskMatches(ttid, mask, statusManager_, GetTrigTowerMap()) ? kMBad : kBad);
       }
     }
 
@@ -203,8 +205,10 @@ namespace ecaldqm {
       }
       float threshold(meanFED < nRMS * rmsFED ? minEntries_ : meanFED - nRMS * rmsFED);
       if ((meanFED > 100. && Nentries[iDCC] < threshold) && statsCheckEnabled)
-        meEmulQualitySummary.setBinContent(getEcalDQMSetupObjects(), ttid,
-                                           meEmulQualitySummary.maskMatches(ttid, mask, statusManager_, GetTrigTowerMap()) ? kMBad : kBad);
+        meEmulQualitySummary.setBinContent(
+            getEcalDQMSetupObjects(),
+            ttid,
+            meEmulQualitySummary.maskMatches(ttid, mask, statusManager_, GetTrigTowerMap()) ? kMBad : kBad);
     }
 
   }  // producePlots()

--- a/DQM/EcalMonitorDbModule/interface/DBWriterWorkers.h
+++ b/DQM/EcalMonitorDbModule/interface/DBWriterWorkers.h
@@ -20,7 +20,7 @@ namespace ecaldqm {
     typedef dqm::legacy::DQMStore DQMStore;
     typedef dqm::legacy::MonitorElement MonitorElement;
     DBWriterWorker(std::string const &, edm::ParameterSet const &);
-    virtual ~DBWriterWorker() {}
+    ~DBWriterWorker() override {}
 
     void retrieveSource(DQMStore::IGetter &);
     virtual bool run(EcalCondDBInterface *, MonRunIOV &) = 0;

--- a/DQM/EcalMonitorDbModule/interface/DBWriterWorkers.h
+++ b/DQM/EcalMonitorDbModule/interface/DBWriterWorkers.h
@@ -9,11 +9,13 @@
 #include "OnlineDB/EcalCondDB/interface/EcalCondDBInterface.h"
 #include "OnlineDB/EcalCondDB/interface/MonRunDat.h"
 
+#include "DQM/EcalCommon/interface/DQWorker.h"
+
 #include <map>
 
 namespace ecaldqm {
 
-  class DBWriterWorker {
+  class DBWriterWorker : public DQWorker {
   public:
     typedef dqm::legacy::DQMStore DQMStore;
     typedef dqm::legacy::MonitorElement MonitorElement;

--- a/DQM/EcalMonitorDbModule/interface/EcalCondDBReader.h
+++ b/DQM/EcalMonitorDbModule/interface/EcalCondDBReader.h
@@ -12,7 +12,12 @@ public:
   ~EcalCondDBReader() override;
 
 private:
-  void dqmEndJob(DQMStore::IBooker &, DQMStore::IGetter &) override;
+  void dqmEndRun(DQMStore::IBooker &, DQMStore::IGetter &, edm::Run const &, edm::EventSetup const &) override;
+
+  EcalElectronicsMapping const *electronicsMap;
+  void setElectronicsMap(edm::EventSetup const &);
+  EcalElectronicsMapping const *GetElectronicsMap();
+  ecaldqm::EcalDQMSetupObjects const getEcalDQMSetupObjects();
 
   // DON'T CHANGE - ORDER MATTERS IN DB
   enum Tasks {

--- a/DQM/EcalMonitorDbModule/interface/EcalCondDBWriter.h
+++ b/DQM/EcalMonitorDbModule/interface/EcalCondDBWriter.h
@@ -13,6 +13,7 @@ public:
   ~EcalCondDBWriter() override;
 
 private:
+  void beginRun(edm::Run const &, edm::EventSetup const &) override;
   void dqmEndJob(DQMStore::IBooker &, DQMStore::IGetter &) override;
 
   // DON'T CHANGE - ORDER MATTERS IN DB

--- a/DQM/EcalMonitorDbModule/interface/EcalDQMStatusWriter.h
+++ b/DQM/EcalMonitorDbModule/interface/EcalDQMStatusWriter.h
@@ -18,7 +18,7 @@ public:
 
 private:
   void analyze(edm::Event const &, edm::EventSetup const &) override;
-  void beginRun(edm::Run const&, edm::EventSetup const&) override;
+  void beginRun(edm::Run const &, edm::EventSetup const &) override;
 
   EcalDQMChannelStatus channelStatus_;
   EcalDQMTowerStatus towerStatus_;

--- a/DQM/EcalMonitorDbModule/interface/EcalDQMStatusWriter.h
+++ b/DQM/EcalMonitorDbModule/interface/EcalDQMStatusWriter.h
@@ -6,6 +6,11 @@
 #include "CondFormats/EcalObjects/interface/EcalDQMChannelStatus.h"
 #include "CondFormats/EcalObjects/interface/EcalDQMTowerStatus.h"
 
+#include "Geometry/EcalMapping/interface/EcalElectronicsMapping.h"
+#include "Geometry/EcalMapping/interface/EcalMappingRcd.h"
+
+#include <fstream>
+
 class EcalDQMStatusWriter : public edm::EDAnalyzer {
 public:
   EcalDQMStatusWriter(edm::ParameterSet const &);
@@ -13,10 +18,16 @@ public:
 
 private:
   void analyze(edm::Event const &, edm::EventSetup const &) override;
+  void beginRun(edm::Run const&, edm::EventSetup const&) override;
 
   EcalDQMChannelStatus channelStatus_;
   EcalDQMTowerStatus towerStatus_;
   unsigned firstRun_;
+  std::ifstream inputFile_;
+
+  EcalElectronicsMapping const *electronicsMap;
+  void setElectronicsMap(edm::EventSetup const &);
+  EcalElectronicsMapping const *GetElectronicsMap();
 };
 
 #endif

--- a/DQM/EcalMonitorDbModule/interface/LogicIDTranslation.h
+++ b/DQM/EcalMonitorDbModule/interface/LogicIDTranslation.h
@@ -11,10 +11,12 @@
 #include "DataFormats/EcalDetId/interface/EcalSubdetector.h"
 #include "DataFormats/EcalDetId/interface/EcalTrigTowerDetId.h"
 
+#include "Geometry/EcalMapping/interface/EcalElectronicsMapping.h"
+
 namespace ecaldqm {
   EcalLogicID ecalID();
   EcalLogicID subdetID(EcalSubdetector);
-  EcalLogicID crystalID(DetId const &);
+  EcalLogicID crystalID(DetId const &, EcalElectronicsMapping const *);
   EcalLogicID towerID(EcalElectronicsId const &);
   EcalLogicID memChannelID(EcalPnDiodeDetId const &);
   EcalLogicID memTowerID(EcalElectronicsId const &);

--- a/DQM/EcalMonitorDbModule/plugins/EcalCondDBReader.cc
+++ b/DQM/EcalMonitorDbModule/plugins/EcalCondDBReader.cc
@@ -9,6 +9,8 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
 
+#include "Geometry/EcalMapping/interface/EcalMappingRcd.h"
+
 EcalCondDBReader::EcalCondDBReader(edm::ParameterSet const &_ps)
     : db_(nullptr),
       monIOV_(),
@@ -145,10 +147,30 @@ EcalCondDBReader::~EcalCondDBReader() {
   delete meSet_;
 }
 
-void EcalCondDBReader::dqmEndJob(DQMStore::IBooker &_ibooker, DQMStore::IGetter &) {
-  meSet_->book(_ibooker);
+void EcalCondDBReader::dqmEndRun(DQMStore::IBooker &_ibooker, DQMStore::IGetter &, edm::Run const &, edm::EventSetup const &_es) {
+  setElectronicsMap(_es);
+  meSet_->book(_ibooker, GetElectronicsMap());
 
   std::map<DetId, double> values(worker_->run(db_, monIOV_, formula_));
   for (std::map<DetId, double>::const_iterator vItr(values.begin()); vItr != values.end(); ++vItr)
-    meSet_->setBinContent(vItr->first, vItr->second);
+    meSet_->setBinContent(getEcalDQMSetupObjects(), vItr->first, vItr->second);
+}
+
+void EcalCondDBReader::setElectronicsMap(edm::EventSetup const &_es) {
+    edm::ESHandle<EcalElectronicsMapping> elecMapHandle;
+    _es.get<EcalMappingRcd>().get(elecMapHandle);
+    electronicsMap = elecMapHandle.product();
+}
+
+EcalElectronicsMapping const * EcalCondDBReader::GetElectronicsMap() {
+  if (!electronicsMap)
+    throw cms::Exception("InvalidCall") << "Electronics Mapping not initialized";
+  return electronicsMap;
+}
+
+ecaldqm::EcalDQMSetupObjects const EcalCondDBReader::getEcalDQMSetupObjects() {
+  if (!electronicsMap)
+    throw cms::Exception("InvalidCall") << "Electronics Mapping not initialized";
+  ecaldqm::EcalDQMSetupObjects edso = {electronicsMap, 0, 0, 0};
+  return edso;
 }

--- a/DQM/EcalMonitorDbModule/plugins/EcalCondDBReader.cc
+++ b/DQM/EcalMonitorDbModule/plugins/EcalCondDBReader.cc
@@ -147,7 +147,10 @@ EcalCondDBReader::~EcalCondDBReader() {
   delete meSet_;
 }
 
-void EcalCondDBReader::dqmEndRun(DQMStore::IBooker &_ibooker, DQMStore::IGetter &, edm::Run const &, edm::EventSetup const &_es) {
+void EcalCondDBReader::dqmEndRun(DQMStore::IBooker &_ibooker,
+                                 DQMStore::IGetter &,
+                                 edm::Run const &,
+                                 edm::EventSetup const &_es) {
   setElectronicsMap(_es);
   meSet_->book(_ibooker, GetElectronicsMap());
 
@@ -157,12 +160,12 @@ void EcalCondDBReader::dqmEndRun(DQMStore::IBooker &_ibooker, DQMStore::IGetter 
 }
 
 void EcalCondDBReader::setElectronicsMap(edm::EventSetup const &_es) {
-    edm::ESHandle<EcalElectronicsMapping> elecMapHandle;
-    _es.get<EcalMappingRcd>().get(elecMapHandle);
-    electronicsMap = elecMapHandle.product();
+  edm::ESHandle<EcalElectronicsMapping> elecMapHandle;
+  _es.get<EcalMappingRcd>().get(elecMapHandle);
+  electronicsMap = elecMapHandle.product();
 }
 
-EcalElectronicsMapping const * EcalCondDBReader::GetElectronicsMap() {
+EcalElectronicsMapping const *EcalCondDBReader::GetElectronicsMap() {
   if (!electronicsMap)
     throw cms::Exception("InvalidCall") << "Electronics Mapping not initialized";
   return electronicsMap;

--- a/DQM/EcalMonitorDbModule/plugins/EcalCondDBReader.cc
+++ b/DQM/EcalMonitorDbModule/plugins/EcalCondDBReader.cc
@@ -174,6 +174,6 @@ EcalElectronicsMapping const *EcalCondDBReader::GetElectronicsMap() {
 ecaldqm::EcalDQMSetupObjects const EcalCondDBReader::getEcalDQMSetupObjects() {
   if (!electronicsMap)
     throw cms::Exception("InvalidCall") << "Electronics Mapping not initialized";
-  ecaldqm::EcalDQMSetupObjects edso = {electronicsMap, 0, 0, 0};
+  ecaldqm::EcalDQMSetupObjects edso = {electronicsMap, nullptr, nullptr, nullptr};
   return edso;
 }

--- a/DQM/EcalMonitorDbModule/plugins/EcalCondDBWriter.cc
+++ b/DQM/EcalMonitorDbModule/plugins/EcalCondDBWriter.cc
@@ -120,9 +120,9 @@ EcalCondDBWriter::~EcalCondDBWriter() {
 }
 
 void EcalCondDBWriter::beginRun(edm::Run const &_run, edm::EventSetup const &_es) {
-    for (unsigned iC(0); iC < nTasks; ++iC)
-      if (workers_[iC])
-        workers_[iC]->setSetupObjects(_es);
+  for (unsigned iC(0); iC < nTasks; ++iC)
+    if (workers_[iC])
+      workers_[iC]->setSetupObjects(_es);
 }
 
 void EcalCondDBWriter::dqmEndJob(DQMStore::IBooker &, DQMStore::IGetter &_igetter) {

--- a/DQM/EcalMonitorDbModule/plugins/EcalCondDBWriter.cc
+++ b/DQM/EcalMonitorDbModule/plugins/EcalCondDBWriter.cc
@@ -119,6 +119,12 @@ EcalCondDBWriter::~EcalCondDBWriter() {
     delete workers_[iC];
 }
 
+void EcalCondDBWriter::beginRun(edm::Run const &_run, edm::EventSetup const &_es) {
+    for (unsigned iC(0); iC < nTasks; ++iC)
+      if (workers_[iC])
+        workers_[iC]->setSetupObjects(_es);
+}
+
 void EcalCondDBWriter::dqmEndJob(DQMStore::IBooker &, DQMStore::IGetter &_igetter) {
   if (executed_)
     return;

--- a/DQM/EcalMonitorDbModule/plugins/EcalDQMStatusWriter.cc
+++ b/DQM/EcalMonitorDbModule/plugins/EcalDQMStatusWriter.cc
@@ -12,15 +12,21 @@
 #include <fstream>
 
 EcalDQMStatusWriter::EcalDQMStatusWriter(edm::ParameterSet const &_ps)
-    : channelStatus_(), towerStatus_(), firstRun_(_ps.getUntrackedParameter<unsigned>("firstRun")) {
-  std::ifstream inputFile(_ps.getUntrackedParameter<std::string>("inputFile"));
-  if (!inputFile.is_open())
+    : channelStatus_(),
+      towerStatus_(),
+      firstRun_(_ps.getUntrackedParameter<unsigned>("firstRun")),
+      inputFile_(_ps.getUntrackedParameter<std::string>("inputFile")) {
+  if (!inputFile_.is_open())
     throw cms::Exception("Invalid input for EcalDQMStatusWriter");
+}
 
-  ecaldqm::StatusManager statusManager;
+void EcalDQMStatusWriter::beginRun(edm::Run const&_run, edm::EventSetup const&_es) {
+    setElectronicsMap(_es);
 
-  statusManager.readFromStream(inputFile);
-  statusManager.writeToObj(channelStatus_, towerStatus_);
+    ecaldqm::StatusManager statusManager;
+
+    statusManager.readFromStream(inputFile_, GetElectronicsMap());
+    statusManager.writeToObj(channelStatus_, towerStatus_);
 }
 
 void EcalDQMStatusWriter::analyze(edm::Event const &, edm::EventSetup const &_es) {
@@ -32,6 +38,18 @@ void EcalDQMStatusWriter::analyze(edm::Event const &, edm::EventSetup const &_es
   dbOutput.writeOne(&towerStatus_, firstRun_, "EcalDQMTowerStatusRcd");
 
   firstRun_ = dbOutput.endOfTime();  // avoid accidentally re-writing the conditions
+}
+
+void EcalDQMStatusWriter::setElectronicsMap(edm::EventSetup const &_es) {
+    edm::ESHandle<EcalElectronicsMapping> elecMapHandle;
+    _es.get<EcalMappingRcd>().get(elecMapHandle);
+    electronicsMap = elecMapHandle.product();
+}
+
+EcalElectronicsMapping const * EcalDQMStatusWriter::GetElectronicsMap() {
+  if (!electronicsMap)
+    throw cms::Exception("InvalidCall") << "Electronics Mapping not initialized";
+  return electronicsMap;
 }
 
 DEFINE_FWK_MODULE(EcalDQMStatusWriter);

--- a/DQM/EcalMonitorDbModule/plugins/EcalDQMStatusWriter.cc
+++ b/DQM/EcalMonitorDbModule/plugins/EcalDQMStatusWriter.cc
@@ -20,13 +20,13 @@ EcalDQMStatusWriter::EcalDQMStatusWriter(edm::ParameterSet const &_ps)
     throw cms::Exception("Invalid input for EcalDQMStatusWriter");
 }
 
-void EcalDQMStatusWriter::beginRun(edm::Run const&_run, edm::EventSetup const&_es) {
-    setElectronicsMap(_es);
+void EcalDQMStatusWriter::beginRun(edm::Run const &_run, edm::EventSetup const &_es) {
+  setElectronicsMap(_es);
 
-    ecaldqm::StatusManager statusManager;
+  ecaldqm::StatusManager statusManager;
 
-    statusManager.readFromStream(inputFile_, GetElectronicsMap());
-    statusManager.writeToObj(channelStatus_, towerStatus_);
+  statusManager.readFromStream(inputFile_, GetElectronicsMap());
+  statusManager.writeToObj(channelStatus_, towerStatus_);
 }
 
 void EcalDQMStatusWriter::analyze(edm::Event const &, edm::EventSetup const &_es) {
@@ -41,12 +41,12 @@ void EcalDQMStatusWriter::analyze(edm::Event const &, edm::EventSetup const &_es
 }
 
 void EcalDQMStatusWriter::setElectronicsMap(edm::EventSetup const &_es) {
-    edm::ESHandle<EcalElectronicsMapping> elecMapHandle;
-    _es.get<EcalMappingRcd>().get(elecMapHandle);
-    electronicsMap = elecMapHandle.product();
+  edm::ESHandle<EcalElectronicsMapping> elecMapHandle;
+  _es.get<EcalMappingRcd>().get(elecMapHandle);
+  electronicsMap = elecMapHandle.product();
 }
 
-EcalElectronicsMapping const * EcalDQMStatusWriter::GetElectronicsMap() {
+EcalElectronicsMapping const *EcalDQMStatusWriter::GetElectronicsMap() {
   if (!electronicsMap)
     throw cms::Exception("InvalidCall") << "Electronics Mapping not initialized";
   return electronicsMap;

--- a/DQM/EcalMonitorDbModule/src/DBWriterWorkers.cc
+++ b/DQM/EcalMonitorDbModule/src/DBWriterWorkers.cc
@@ -57,7 +57,7 @@ namespace ecaldqm {
   bool qualityOK(int _quality) { return (_quality != kBad && _quality != kUnknown); }
 
   DBWriterWorker::DBWriterWorker(std::string const &_name, edm::ParameterSet const &_ps)
-      : name_(_name), runTypes_(), source_(), active_(false) {
+      : DQWorker(), name_(_name), runTypes_(), source_(), active_(false) {
     edm::ParameterSet const &params(_ps.getUntrackedParameterSet(name_));
 
     std::vector<std::string> runTypes(params.getUntrackedParameter<std::vector<std::string>>("runTypes"));
@@ -79,7 +79,7 @@ namespace ecaldqm {
   void DBWriterWorker::retrieveSource(DQMStore::IGetter &_igetter) {
     std::string failedPath;
     for (MESetCollection::iterator sItr(this->source_.begin()); sItr != this->source_.end(); ++sItr) {
-      if (!sItr->second->retrieve(_igetter, &failedPath)) {
+      if (!sItr->second->retrieve(GetElectronicsMap(), _igetter, &failedPath)) {
         edm::LogError("EcalDQM") << name_ << ": MESet " << sItr->first << "@" << failedPath << " not found";
         this->active_ = false;
         return;
@@ -136,19 +136,19 @@ namespace ecaldqm {
     if (verbosity_ > 1)
       edm::LogInfo("EcalDQM") << " Looping over crystals";
 
-    MESet::const_iterator dEnd(digiME.end());
-    MESet::const_iterator qItr(qualityME);
-    for (MESet::const_iterator dItr(digiME.beginChannel()); dItr != dEnd; dItr.toNextChannel()) {
+    MESet::const_iterator dEnd(digiME.end(GetElectronicsMap()));
+    MESet::const_iterator qItr(GetElectronicsMap(), qualityME);
+    for (MESet::const_iterator dItr(digiME.beginChannel(GetElectronicsMap())); dItr != dEnd; dItr.toNextChannel(GetElectronicsMap())) {
       DetId id(dItr->getId());
 
       int nDigis(dItr->getBinContent());
-      int gain(gainME.getBinContent(id));
-      int chid(chidME.getBinContent(id));
-      int gainswitch(gainswitchME.getBinContent(id));
+      int gain(gainME.getBinContent(getEcalDQMSetupObjects(), id));
+      int chid(chidME.getBinContent(getEcalDQMSetupObjects(), id));
+      int gainswitch(gainswitchME.getBinContent(getEcalDQMSetupObjects(), id));
       qItr = dItr;
 
       if (gain > 0 || chid > 0 || gainswitch > 0) {
-        MonCrystalConsistencyDat &data(crystalConsistencies[crystalID(id)]);
+        MonCrystalConsistencyDat &data(crystalConsistencies[crystalID(id, GetElectronicsMap())]);
         data.setProcessedEvents(nDigis);
         data.setProblematicEvents(gain + chid + gainswitch);
         data.setProblemsGainZero(gain);
@@ -172,22 +172,22 @@ namespace ecaldqm {
           continue;
 
         EcalElectronicsId eid(iDCC + 1, iTower, 1, 1);
-        std::vector<DetId> channels(getElectronicsMap()->dccTowerConstituents(iDCC + 1, iTower));
+        std::vector<DetId> channels(GetElectronicsMap()->dccTowerConstituents(iDCC + 1, iTower));
         int nDigis(0);
         bool towerBad(false);
         for (unsigned iD(0); iD < channels.size(); ++iD) {
-          int n(digiME.getBinContent(channels[iD]));
+          int n(digiME.getBinContent(getEcalDQMSetupObjects(), channels[iD]));
           if (n > nDigis)
             nDigis = n;
-          int channelStatus(qualityME.getBinContent(channels[iD]));
+          int channelStatus(qualityME.getBinContent(getEcalDQMSetupObjects(), channels[iD]));
           if (channelStatus == kBad || channelStatus == kMBad)
             towerBad = true;
         }
 
-        int towerid(toweridME.getBinContent(eid));
-        int blocksize(blocksizeME.getBinContent(eid));
-        int l1a(l1aME.getBinContent(iDCC + 1, iTower));
-        int bx(bxME.getBinContent(iDCC + 1, iTower));
+        int towerid(toweridME.getBinContent(getEcalDQMSetupObjects(), eid));
+        int blocksize(blocksizeME.getBinContent(getEcalDQMSetupObjects(), eid));
+        int l1a(l1aME.getBinContent(getEcalDQMSetupObjects(), iDCC + 1, iTower));
+        int bx(bxME.getBinContent(getEcalDQMSetupObjects(), iDCC + 1, iTower));
 
         if (towerid > 0 || blocksize > 0 || l1a > 0 || bx > 0) {
           MonTTConsistencyDat &data(towerConsistencies[towerID(eid)]);
@@ -215,9 +215,9 @@ namespace ecaldqm {
       for (unsigned iPN(1); iPN <= 10; ++iPN) {
         EcalPnDiodeDetId pnid(subdet, iDCC + 1, iPN);
 
-        int nDigis(memdigiME.getBinContent(pnid));
-        int memchid(memchidME.getBinContent(pnid));
-        int memgain(memgainME.getBinContent(pnid));
+        int nDigis(memdigiME.getBinContent(getEcalDQMSetupObjects(), pnid));
+        int memchid(memchidME.getBinContent(getEcalDQMSetupObjects(), pnid));
+        int memgain(memgainME.getBinContent(getEcalDQMSetupObjects(), pnid));
 
         if (memchid > 0 || memgain > 0) {
           MonMemChConsistencyDat &data(memChannelConsistencies[memChannelID(pnid)]);
@@ -227,7 +227,7 @@ namespace ecaldqm {
           data.setProblemsID(memchid);
           data.setProblemsGainZero(memgain);
 
-          int channelStatus(pnqualityME.getBinContent(pnid));
+          int channelStatus(pnqualityME.getBinContent(getEcalDQMSetupObjects(), pnid));
           bool channelBad(channelStatus == kBad || channelStatus == kMBad);
           data.setTaskStatus(channelBad);
 
@@ -242,16 +242,16 @@ namespace ecaldqm {
         bool towerBad(false);
         for (unsigned iPN(1); iPN <= 10; ++iPN) {
           EcalPnDiodeDetId pnid(subdet, iDCC + 1, iPN);
-          int n(memdigiME.getBinContent(pnid));
+          int n(memdigiME.getBinContent(getEcalDQMSetupObjects(), pnid));
           if (n > nDigis)
             nDigis = n;
-          int channelStatus(pnqualityME.getBinContent(pnid));
+          int channelStatus(pnqualityME.getBinContent(getEcalDQMSetupObjects(), pnid));
           if (channelStatus == kBad || channelStatus == kMBad)
             towerBad = true;
         }
 
-        int towerid(memtoweridME.getBinContent(eid));
-        int blocksize(memblocksizeME.getBinContent(eid));
+        int towerid(memtoweridME.getBinContent(getEcalDQMSetupObjects(), eid));
+        int blocksize(memblocksizeME.getBinContent(getEcalDQMSetupObjects(), eid));
 
         if (towerid > 0 || blocksize > 0) {
           MonMemTTConsistencyDat &data(memTowerConsistencies[memTowerID(eid)]);
@@ -368,11 +368,11 @@ namespace ecaldqm {
       static_cast<MESetMulti const &>(pnME).use(iM);
       static_cast<MESetMulti const &>(pnQualityME).use(iM);
 
-      MESet::const_iterator aEnd(ampME.end());
-      MESet::const_iterator qItr(qualityME);
-      MESet::const_iterator oItr(aopME);
-      MESet::const_iterator tItr(timeME);
-      for (MESet::const_iterator aItr(ampME.beginChannel()); aItr != aEnd; aItr.toNextChannel()) {
+      MESet::const_iterator aEnd(ampME.end(GetElectronicsMap()));
+      MESet::const_iterator qItr(GetElectronicsMap(), qualityME);
+      MESet::const_iterator oItr(GetElectronicsMap(), aopME);
+      MESet::const_iterator tItr(GetElectronicsMap(), timeME);
+      for (MESet::const_iterator aItr(ampME.beginChannel(GetElectronicsMap())); aItr != aEnd; aItr.toNextChannel(GetElectronicsMap())) {
         float aEntries(aItr->getBinEntries());
         if (aEntries < 1.)
           continue;
@@ -397,7 +397,7 @@ namespace ecaldqm {
         int channelStatus(qItr->getBinContent());
         bool channelBad(channelStatus == kBad || channelStatus == kMBad);
 
-        EcalLogicID logicID(crystalID(id));
+        EcalLogicID logicID(crystalID(id, GetElectronicsMap()));
 
         switch (wl) {
           case 1: {
@@ -464,18 +464,18 @@ namespace ecaldqm {
         for (unsigned iPN(1); iPN <= 10; ++iPN) {
           EcalPnDiodeDetId pnid(subdet, iDCC + 1, iPN);
 
-          float entries(pnME.getBinEntries(pnid));
+          float entries(pnME.getBinEntries(getEcalDQMSetupObjects(), pnid));
           if (entries < 1.)
             continue;
 
-          float mean(pnME.getBinContent(pnid));
-          float rms(pnME.getBinError(pnid) * std::sqrt(entries));
+          float mean(pnME.getBinContent(getEcalDQMSetupObjects(), pnid));
+          float rms(pnME.getBinError(getEcalDQMSetupObjects(), pnid) * std::sqrt(entries));
 
-          float pedestalEntries(pnPedestalME.getBinEntries(pnid));
-          float pedestalMean(pnPedestalME.getBinContent(pnid));
-          float pedestalRms(pnPedestalME.getBinError(pnid) * std::sqrt(pedestalEntries));
+          float pedestalEntries(pnPedestalME.getBinEntries(getEcalDQMSetupObjects(), pnid));
+          float pedestalMean(pnPedestalME.getBinContent(getEcalDQMSetupObjects(), pnid));
+          float pedestalRms(pnPedestalME.getBinError(getEcalDQMSetupObjects(), pnid) * std::sqrt(pedestalEntries));
 
-          int channelStatus(pnQualityME.getBinContent(pnid));
+          int channelStatus(pnQualityME.getBinContent(getEcalDQMSetupObjects(), pnid));
           bool channelBad(channelStatus == kBad || channelStatus == kMBad);
 
           switch (wl) {
@@ -626,9 +626,9 @@ namespace ecaldqm {
       static_cast<MESetMulti const &>(pedestalME).use(iM);
       static_cast<MESetMulti const &>(qualityME).use(iM);
 
-      MESet::const_iterator pEnd(pedestalME.end());
-      MESet::const_iterator qItr(qualityME);
-      for (MESet::const_iterator pItr(pedestalME.beginChannel()); pItr != pEnd; pItr.toNextChannel()) {
+      MESet::const_iterator pEnd(pedestalME.end(GetElectronicsMap()));
+      MESet::const_iterator qItr(GetElectronicsMap(), qualityME);
+      for (MESet::const_iterator pItr(pedestalME.beginChannel(GetElectronicsMap())); pItr != pEnd; pItr.toNextChannel(GetElectronicsMap())) {
         float entries(pItr->getBinEntries());
         if (entries < 1.)
           continue;
@@ -638,7 +638,7 @@ namespace ecaldqm {
         float mean(pItr->getBinContent());
         float rms(pItr->getBinError() * std::sqrt(entries));
 
-        EcalLogicID logicID(crystalID(pItr->getId()));
+        EcalLogicID logicID(crystalID(pItr->getId(), GetElectronicsMap()));
         if (pedestals.find(logicID) == pedestals.end()) {
           MonPedestalsDat &insertion(pedestals[logicID]);
           insertion.setPedMeanG1(-1.);
@@ -690,12 +690,12 @@ namespace ecaldqm {
         for (unsigned iPN(1); iPN <= 10; ++iPN) {
           EcalPnDiodeDetId pnid(subdet, iDCC + 1, iPN);
 
-          float entries(pnPedestalME.getBinEntries(pnid));
+          float entries(pnPedestalME.getBinEntries(getEcalDQMSetupObjects(), pnid));
           if (entries < 1.)
             continue;
 
-          float mean(pnPedestalME.getBinContent(pnid));
-          float rms(pnPedestalME.getBinError(pnid) * std::sqrt(entries));
+          float mean(pnPedestalME.getBinContent(getEcalDQMSetupObjects(), pnid));
+          float rms(pnPedestalME.getBinError(getEcalDQMSetupObjects(), pnid) * std::sqrt(entries));
 
           EcalLogicID logicID(lmPNID(pnid));
           if (pnPedestals.find(logicID) == pnPedestals.end()) {
@@ -719,7 +719,7 @@ namespace ecaldqm {
               break;
           }
 
-          int channelStatus(pnQualityME.getBinContent(pnid));
+          int channelStatus(pnQualityME.getBinContent(getEcalDQMSetupObjects(), pnid));
           bool channelBad(channelStatus == kBad || channelStatus == kMBad);
           if (channelBad)
             data.setTaskStatus(true);
@@ -758,9 +758,9 @@ namespace ecaldqm {
     MESet const &pedestalME(source_.at("Pedestal"));
     MESet const &qualityME(source_.at("Quality"));
 
-    MESet::const_iterator pEnd(pedestalME.end());
-    MESet::const_iterator qItr(qualityME);
-    for (MESet::const_iterator pItr(pedestalME.beginChannel()); pItr != pEnd; pItr.toNextChannel()) {
+    MESet::const_iterator pEnd(pedestalME.end(GetElectronicsMap()));
+    MESet::const_iterator qItr(GetElectronicsMap(), qualityME);
+    for (MESet::const_iterator pItr(pedestalME.beginChannel(GetElectronicsMap())); pItr != pEnd; pItr.toNextChannel(GetElectronicsMap())) {
       float entries(pItr->getBinEntries());
       if (entries < 1.)
         continue;
@@ -770,7 +770,7 @@ namespace ecaldqm {
       float mean(pItr->getBinContent());
       float rms(pItr->getBinError() * std::sqrt(entries));
 
-      MonPedestalsOnlineDat &data(pedestals[crystalID(pItr->getId())]);
+      MonPedestalsOnlineDat &data(pedestals[crystalID(pItr->getId(), GetElectronicsMap())]);
       data.setADCMeanG12(mean);
       data.setADCRMSG12(rms);
 
@@ -857,9 +857,9 @@ namespace ecaldqm {
       static_cast<MESetMulti const &>(shapeME).use(iM);
       static_cast<MESetMulti const &>(qualityME).use(iM);
 
-      MESet::const_iterator aEnd(amplitudeME.end());
-      MESet::const_iterator qItr(qualityME);
-      for (MESet::const_iterator aItr(amplitudeME.beginChannel()); aItr != aEnd; aItr.toNextChannel()) {
+      MESet::const_iterator aEnd(amplitudeME.end(GetElectronicsMap()));
+      MESet::const_iterator qItr(GetElectronicsMap(), qualityME);
+      for (MESet::const_iterator aItr(amplitudeME.beginChannel(GetElectronicsMap())); aItr != aEnd; aItr.toNextChannel(GetElectronicsMap())) {
         float entries(aItr->getBinEntries());
         if (entries < 1.)
           continue;
@@ -869,7 +869,7 @@ namespace ecaldqm {
         float mean(aItr->getBinContent());
         float rms(aItr->getBinError() * std::sqrt(entries));
 
-        EcalLogicID logicID(crystalID(aItr->getId()));
+        EcalLogicID logicID(crystalID(aItr->getId(), GetElectronicsMap()));
         if (amplitude.find(logicID) == amplitude.end()) {
           MonTestPulseDat &insertion(amplitude[logicID]);
           insertion.setADCMeanG1(-1.);
@@ -907,7 +907,7 @@ namespace ecaldqm {
 
       for (unsigned iSM(0); iSM < 54; ++iSM) {
         std::vector<float> samples(10, 0.);
-        std::vector<DetId> ids(getElectronicsMap()->dccConstituents(iSM + 1));
+        std::vector<DetId> ids(GetElectronicsMap()->dccConstituents(iSM + 1));
         unsigned nId(ids.size());
         unsigned nChannels(0);
         EcalLogicID logicID;
@@ -915,15 +915,15 @@ namespace ecaldqm {
           DetId &id(ids[iD]);
 
           if (iD == 0)
-            logicID = crystalID(id);
+            logicID = crystalID(id, GetElectronicsMap());
 
-          if (shapeME.getBinEntries(id, 1) < 1.)
+          if (shapeME.getBinEntries(getEcalDQMSetupObjects(), id, 1) < 1.)
             continue;
 
           ++nChannels;
 
           for (int i(0); i < 10; ++i)
-            samples[i] += shapeME.getBinContent(id, i + 1);
+            samples[i] += shapeME.getBinContent(getEcalDQMSetupObjects(), id, i + 1);
         }
 
         if (nChannels == 0)
@@ -960,15 +960,15 @@ namespace ecaldqm {
         for (unsigned iPN(1); iPN <= 10; ++iPN) {
           EcalPnDiodeDetId pnid(subdet, iDCC + 1, iPN);
 
-          float entries(pnAmplitudeME.getBinEntries(pnid));
+          float entries(pnAmplitudeME.getBinEntries(getEcalDQMSetupObjects(), pnid));
           if (entries < 1.)
             continue;
 
-          float mean(pnAmplitudeME.getBinContent(pnid));
-          float rms(pnAmplitudeME.getBinError(pnid) * std::sqrt(entries));
-          float pedestalEntries(pnPedestalME.getBinEntries(pnid));
-          float pedestalMean(pnPedestalME.getBinContent(pnid));
-          float pedestalRms(pnPedestalME.getBinError(pnid) * std::sqrt(pedestalEntries));
+          float mean(pnAmplitudeME.getBinContent(getEcalDQMSetupObjects(), pnid));
+          float rms(pnAmplitudeME.getBinError(getEcalDQMSetupObjects(), pnid) * std::sqrt(entries));
+          float pedestalEntries(pnPedestalME.getBinEntries(getEcalDQMSetupObjects(), pnid));
+          float pedestalMean(pnPedestalME.getBinContent(getEcalDQMSetupObjects(), pnid));
+          float pedestalRms(pnPedestalME.getBinError(getEcalDQMSetupObjects(), pnid) * std::sqrt(pedestalEntries));
 
           EcalLogicID logicID(lmPNID(pnid));
           if (pnAmplitude.find(logicID) == pnAmplitude.end()) {
@@ -1001,7 +1001,7 @@ namespace ecaldqm {
               break;
           }
 
-          int channelStatus(pnQualityME.getBinContent(pnid));
+          int channelStatus(pnQualityME.getBinContent(getEcalDQMSetupObjects(), pnid));
           bool channelBad(channelStatus == kBad || channelStatus == kMBad);
           if (channelBad)
             data.setTaskStatus(true);
@@ -1042,9 +1042,9 @@ namespace ecaldqm {
     MESet const &timingME(source_.at("Timing"));
     MESet const &qualityME(source_.at("Quality"));
 
-    MESet::const_iterator tEnd(timingME.end());
-    MESet::const_iterator qItr(qualityME);
-    for (MESet::const_iterator tItr(timingME.beginChannel()); tItr != tEnd; tItr.toNextChannel()) {
+    MESet::const_iterator tEnd(timingME.end(GetElectronicsMap()));
+    MESet::const_iterator qItr(GetElectronicsMap(), qualityME);
+    for (MESet::const_iterator tItr(timingME.beginChannel(GetElectronicsMap())); tItr != tEnd; tItr.toNextChannel(GetElectronicsMap())) {
       float entries(tItr->getBinEntries());
       if (entries < 1.)
         continue;
@@ -1054,7 +1054,7 @@ namespace ecaldqm {
       float mean(tItr->getBinContent());
       float rms(tItr->getBinError() * std::sqrt(entries));
 
-      MonTimingCrystalDat &data(timing[crystalID(tItr->getId())]);
+      MonTimingCrystalDat &data(timing[crystalID(tItr->getId(), GetElectronicsMap())]);
       data.setTimingMean(mean);
       data.setTimingRMS(rms);
 
@@ -1139,11 +1139,11 @@ x      PNDiodeTask.Pedestal (i13, i14)
       //       static_cast<MESetMulti const&>(pnME).use(iM);
       //       static_cast<MESetMulti const&>(pnQualityME).use(iM);
 
-      MESet::const_iterator aEnd(ampME.end());
-      MESet::const_iterator qItr(qualityME);
-      MESet::const_iterator oItr(aopME);
-      MESet::const_iterator tItr(timeME);
-      for (MESet::const_iterator aItr(ampME.beginChannel()); aItr != aEnd; aItr.toNextChannel()) {
+      MESet::const_iterator aEnd(ampME.end(GetElectronicsMap()));
+      MESet::const_iterator qItr(GetElectronicsMap(), qualityME);
+      MESet::const_iterator oItr(GetElectronicsMap(), aopME);
+      MESet::const_iterator tItr(GetElectronicsMap(), timeME);
+      for (MESet::const_iterator aItr(ampME.beginChannel(GetElectronicsMap())); aItr != aEnd; aItr.toNextChannel(GetElectronicsMap())) {
         float aEntries(aItr->getBinEntries());
         if (aEntries < 1.)
           continue;
@@ -1168,7 +1168,7 @@ x      PNDiodeTask.Pedestal (i13, i14)
         int channelStatus(qItr->getBinContent());
         bool channelBad(channelStatus == kBad || channelStatus == kMBad);
 
-        EcalLogicID logicID(crystalID(id));
+        EcalLogicID logicID(crystalID(id, GetElectronicsMap()));
 
         switch (wl) {
           case 1: {
@@ -1295,9 +1295,9 @@ x      PNDiodeTask.Pedestal (i13, i14)
     MESet const &occupancyME(source_.at("Occupancy"));
     MESet const &energyME(source_.at("Energy"));
 
-    MESet::const_iterator oEnd(occupancyME.end());
-    MESet::const_iterator eItr(energyME);
-    for (MESet::const_iterator oItr(occupancyME.beginChannel()); oItr != oEnd; oItr.toNextChannel()) {
+    MESet::const_iterator oEnd(occupancyME.end(GetElectronicsMap()));
+    MESet::const_iterator eItr(GetElectronicsMap(), energyME);
+    for (MESet::const_iterator oItr(occupancyME.beginChannel(GetElectronicsMap())); oItr != oEnd; oItr.toNextChannel(GetElectronicsMap())) {
       if (oItr->getME()->getTH1()->GetEntries() < 1000.)
         continue;
 
@@ -1310,7 +1310,7 @@ x      PNDiodeTask.Pedestal (i13, i14)
       int eEntries(eItr->getBinEntries());
       float energy(eEntries > 10 ? eItr->getBinContent() : -1.);
 
-      MonOccupancyDat &data(occupancy[crystalID(oItr->getId())]);
+      MonOccupancyDat &data(occupancy[crystalID(oItr->getId(), GetElectronicsMap())]);
       data.setEventsOverLowThreshold(entries);
       data.setEventsOverHighThreshold(eEntries);
       data.setAvgEnergy(energy);

--- a/DQM/EcalMonitorDbModule/src/DBWriterWorkers.cc
+++ b/DQM/EcalMonitorDbModule/src/DBWriterWorkers.cc
@@ -138,7 +138,8 @@ namespace ecaldqm {
 
     MESet::const_iterator dEnd(digiME.end(GetElectronicsMap()));
     MESet::const_iterator qItr(GetElectronicsMap(), qualityME);
-    for (MESet::const_iterator dItr(digiME.beginChannel(GetElectronicsMap())); dItr != dEnd; dItr.toNextChannel(GetElectronicsMap())) {
+    for (MESet::const_iterator dItr(digiME.beginChannel(GetElectronicsMap())); dItr != dEnd;
+         dItr.toNextChannel(GetElectronicsMap())) {
       DetId id(dItr->getId());
 
       int nDigis(dItr->getBinContent());
@@ -372,7 +373,8 @@ namespace ecaldqm {
       MESet::const_iterator qItr(GetElectronicsMap(), qualityME);
       MESet::const_iterator oItr(GetElectronicsMap(), aopME);
       MESet::const_iterator tItr(GetElectronicsMap(), timeME);
-      for (MESet::const_iterator aItr(ampME.beginChannel(GetElectronicsMap())); aItr != aEnd; aItr.toNextChannel(GetElectronicsMap())) {
+      for (MESet::const_iterator aItr(ampME.beginChannel(GetElectronicsMap())); aItr != aEnd;
+           aItr.toNextChannel(GetElectronicsMap())) {
         float aEntries(aItr->getBinEntries());
         if (aEntries < 1.)
           continue;
@@ -628,7 +630,8 @@ namespace ecaldqm {
 
       MESet::const_iterator pEnd(pedestalME.end(GetElectronicsMap()));
       MESet::const_iterator qItr(GetElectronicsMap(), qualityME);
-      for (MESet::const_iterator pItr(pedestalME.beginChannel(GetElectronicsMap())); pItr != pEnd; pItr.toNextChannel(GetElectronicsMap())) {
+      for (MESet::const_iterator pItr(pedestalME.beginChannel(GetElectronicsMap())); pItr != pEnd;
+           pItr.toNextChannel(GetElectronicsMap())) {
         float entries(pItr->getBinEntries());
         if (entries < 1.)
           continue;
@@ -760,7 +763,8 @@ namespace ecaldqm {
 
     MESet::const_iterator pEnd(pedestalME.end(GetElectronicsMap()));
     MESet::const_iterator qItr(GetElectronicsMap(), qualityME);
-    for (MESet::const_iterator pItr(pedestalME.beginChannel(GetElectronicsMap())); pItr != pEnd; pItr.toNextChannel(GetElectronicsMap())) {
+    for (MESet::const_iterator pItr(pedestalME.beginChannel(GetElectronicsMap())); pItr != pEnd;
+         pItr.toNextChannel(GetElectronicsMap())) {
       float entries(pItr->getBinEntries());
       if (entries < 1.)
         continue;
@@ -859,7 +863,8 @@ namespace ecaldqm {
 
       MESet::const_iterator aEnd(amplitudeME.end(GetElectronicsMap()));
       MESet::const_iterator qItr(GetElectronicsMap(), qualityME);
-      for (MESet::const_iterator aItr(amplitudeME.beginChannel(GetElectronicsMap())); aItr != aEnd; aItr.toNextChannel(GetElectronicsMap())) {
+      for (MESet::const_iterator aItr(amplitudeME.beginChannel(GetElectronicsMap())); aItr != aEnd;
+           aItr.toNextChannel(GetElectronicsMap())) {
         float entries(aItr->getBinEntries());
         if (entries < 1.)
           continue;
@@ -1044,7 +1049,8 @@ namespace ecaldqm {
 
     MESet::const_iterator tEnd(timingME.end(GetElectronicsMap()));
     MESet::const_iterator qItr(GetElectronicsMap(), qualityME);
-    for (MESet::const_iterator tItr(timingME.beginChannel(GetElectronicsMap())); tItr != tEnd; tItr.toNextChannel(GetElectronicsMap())) {
+    for (MESet::const_iterator tItr(timingME.beginChannel(GetElectronicsMap())); tItr != tEnd;
+         tItr.toNextChannel(GetElectronicsMap())) {
       float entries(tItr->getBinEntries());
       if (entries < 1.)
         continue;
@@ -1143,7 +1149,8 @@ x      PNDiodeTask.Pedestal (i13, i14)
       MESet::const_iterator qItr(GetElectronicsMap(), qualityME);
       MESet::const_iterator oItr(GetElectronicsMap(), aopME);
       MESet::const_iterator tItr(GetElectronicsMap(), timeME);
-      for (MESet::const_iterator aItr(ampME.beginChannel(GetElectronicsMap())); aItr != aEnd; aItr.toNextChannel(GetElectronicsMap())) {
+      for (MESet::const_iterator aItr(ampME.beginChannel(GetElectronicsMap())); aItr != aEnd;
+           aItr.toNextChannel(GetElectronicsMap())) {
         float aEntries(aItr->getBinEntries());
         if (aEntries < 1.)
           continue;
@@ -1297,7 +1304,8 @@ x      PNDiodeTask.Pedestal (i13, i14)
 
     MESet::const_iterator oEnd(occupancyME.end(GetElectronicsMap()));
     MESet::const_iterator eItr(GetElectronicsMap(), energyME);
-    for (MESet::const_iterator oItr(occupancyME.beginChannel(GetElectronicsMap())); oItr != oEnd; oItr.toNextChannel(GetElectronicsMap())) {
+    for (MESet::const_iterator oItr(occupancyME.beginChannel(GetElectronicsMap())); oItr != oEnd;
+         oItr.toNextChannel(GetElectronicsMap())) {
       if (oItr->getME()->getTH1()->GetEntries() < 1000.)
         continue;
 

--- a/DQM/EcalMonitorDbModule/src/LogicIDTranslation.cc
+++ b/DQM/EcalMonitorDbModule/src/LogicIDTranslation.cc
@@ -18,7 +18,7 @@ namespace ecaldqm {
     }
   }
 
-  EcalLogicID crystalID(DetId const &_id, EcalElectronicsMapping const*electronicsMap) {
+  EcalLogicID crystalID(DetId const &_id, EcalElectronicsMapping const *electronicsMap) {
     unsigned iDCC(dccId(_id, electronicsMap) - 1);
     if (iDCC <= kEEmHigh || iDCC >= kEEpLow) {
       EEDetId eeid(_id);

--- a/DQM/EcalMonitorDbModule/src/LogicIDTranslation.cc
+++ b/DQM/EcalMonitorDbModule/src/LogicIDTranslation.cc
@@ -18,8 +18,8 @@ namespace ecaldqm {
     }
   }
 
-  EcalLogicID crystalID(DetId const &_id) {
-    unsigned iDCC(dccId(_id) - 1);
+  EcalLogicID crystalID(DetId const &_id, EcalElectronicsMapping const*electronicsMap) {
+    unsigned iDCC(dccId(_id, electronicsMap) - 1);
     if (iDCC <= kEEmHigh || iDCC >= kEEpLow) {
       EEDetId eeid(_id);
       return EcalLogicID("EE_crystal_number",

--- a/DQM/EcalMonitorTasks/interface/EcalFEDMonitor.h
+++ b/DQM/EcalMonitorTasks/interface/EcalFEDMonitor.h
@@ -21,6 +21,8 @@
 
 #include "DQM/EcalCommon/interface/EcalDQMCommonUtils.h"
 
+#include "Geometry/EcalMapping/interface/EcalElectronicsMapping.h"
+
 #include <iostream>
 
 // Making the class templated temporarily, until HLT sequence can be fixed (is using EBHltTask and EEHltTask currently)
@@ -37,6 +39,10 @@ private:
   void bookHistograms(DQMStore::IBooker&, edm::Run const&, edm::EventSetup const&) override;
 
   enum MEs { kEBOccupancy, kEBFatal, kEBNonFatal, kEEOccupancy, kEEFatal, kEENonFatal, nMEs };
+
+  EcalElectronicsMapping const *electronicsMap;
+  void setElectronicsMap(edm::EventSetup const &);
+  EcalElectronicsMapping const *GetElectronicsMap();
 
   std::string folderName_;
 

--- a/DQM/EcalMonitorTasks/interface/EcalFEDMonitor.h
+++ b/DQM/EcalMonitorTasks/interface/EcalFEDMonitor.h
@@ -29,14 +29,14 @@
 template <int SUBDET>
 class EcalFEDMonitorTemp : public DQMEDAnalyzer {
 public:
-  EcalFEDMonitorTemp(edm::ParameterSet const&);
+  EcalFEDMonitorTemp(edm::ParameterSet const &);
   ~EcalFEDMonitorTemp() override {}
 
 private:
-  void analyze(edm::Event const&, edm::EventSetup const&) override;
-  void dqmBeginRun(edm::Run const&, edm::EventSetup const&) override;
+  void analyze(edm::Event const &, edm::EventSetup const &) override;
+  void dqmBeginRun(edm::Run const &, edm::EventSetup const &) override;
 
-  void bookHistograms(DQMStore::IBooker&, edm::Run const&, edm::EventSetup const&) override;
+  void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
 
   enum MEs { kEBOccupancy, kEBFatal, kEBNonFatal, kEEOccupancy, kEEFatal, kEENonFatal, nMEs };
 
@@ -56,7 +56,7 @@ private:
   edm::EDGetTokenT<EcalElectronicsIdCollection> towerIdErrorsToken_;
   edm::EDGetTokenT<EcalElectronicsIdCollection> blockSizeErrorsToken_;
 
-  std::vector<MonitorElement*> MEs_;
+  std::vector<MonitorElement *> MEs_;
 };
 
 #endif

--- a/DQM/EcalMonitorTasks/plugins/EcalDQMonitorTask.cc
+++ b/DQM/EcalMonitorTasks/plugins/EcalDQMonitorTask.cc
@@ -99,7 +99,9 @@ void EcalDQMonitorTask::fillDescriptions(edm::ConfigurationDescriptions& _descs)
 }
 
 void EcalDQMonitorTask::bookHistograms(DQMStore::IBooker& _ibooker, edm::Run const&, edm::EventSetup const& _es) {
-  executeOnWorkers_([&_es](ecaldqm::DQWorker* worker) { worker->setSetupObjects(_es); }, "ecaldqmGetSetupObjects", "Getting EventSetup Objects");
+  executeOnWorkers_([&_es](ecaldqm::DQWorker* worker) { worker->setSetupObjects(_es); },
+                    "ecaldqmGetSetupObjects",
+                    "Getting EventSetup Objects");
 
   executeOnWorkers_([&_ibooker](ecaldqm::DQWorker* worker) { worker->bookMEs(_ibooker); }, "bookMEs", "Booking MEs");
 }

--- a/DQM/EcalMonitorTasks/plugins/EcalDQMonitorTask.cc
+++ b/DQM/EcalMonitorTasks/plugins/EcalDQMonitorTask.cc
@@ -99,7 +99,7 @@ void EcalDQMonitorTask::fillDescriptions(edm::ConfigurationDescriptions& _descs)
 }
 
 void EcalDQMonitorTask::bookHistograms(DQMStore::IBooker& _ibooker, edm::Run const&, edm::EventSetup const& _es) {
-  ecaldqmGetSetupObjects(_es);
+  executeOnWorkers_([&_es](ecaldqm::DQWorker* worker) { worker->setSetupObjects(_es); }, "ecaldqmGetSetupObjects", "Getting EventSetup Objects");
 
   executeOnWorkers_([&_ibooker](ecaldqm::DQWorker* worker) { worker->bookMEs(_ibooker); }, "bookMEs", "Booking MEs");
 }

--- a/DQM/EcalMonitorTasks/plugins/EcalFEDMonitor.cc
+++ b/DQM/EcalMonitorTasks/plugins/EcalFEDMonitor.cc
@@ -225,14 +225,14 @@ void EcalFEDMonitorTemp<SUBDET>::analyze(edm::Event const& _evt, edm::EventSetup
 }
 
 template <int SUBDET>
-void EcalFEDMonitorTemp<SUBDET>::setElectronicsMap(edm::EventSetup const &_es) {
-    edm::ESHandle<EcalElectronicsMapping> elecMapHandle;
-    _es.get<EcalMappingRcd>().get(elecMapHandle);
-    electronicsMap = elecMapHandle.product();
+void EcalFEDMonitorTemp<SUBDET>::setElectronicsMap(edm::EventSetup const& _es) {
+  edm::ESHandle<EcalElectronicsMapping> elecMapHandle;
+  _es.get<EcalMappingRcd>().get(elecMapHandle);
+  electronicsMap = elecMapHandle.product();
 }
 
 template <int SUBDET>
-EcalElectronicsMapping const * EcalFEDMonitorTemp<SUBDET>::GetElectronicsMap() {
+EcalElectronicsMapping const* EcalFEDMonitorTemp<SUBDET>::GetElectronicsMap() {
   if (!electronicsMap)
     throw cms::Exception("InvalidCall") << "Electronics Mapping not initialized";
   return electronicsMap;

--- a/DQM/EcalMonitorTasks/plugins/EcalFEDMonitor.cc
+++ b/DQM/EcalMonitorTasks/plugins/EcalFEDMonitor.cc
@@ -33,12 +33,7 @@ EcalFEDMonitorTemp<SUBDET>::EcalFEDMonitorTemp(edm::ParameterSet const& _ps)
 
 template <int SUBDET>
 void EcalFEDMonitorTemp<SUBDET>::dqmBeginRun(edm::Run const&, edm::EventSetup const& _es) {
-  if (!ecaldqm::checkElectronicsMap(false)) {
-    // set up ecaldqm::electronicsMap in EcalDQMCommonUtils
-    edm::ESHandle<EcalElectronicsMapping> elecMapHandle;
-    _es.get<EcalMappingRcd>().get(elecMapHandle);
-    ecaldqm::setElectronicsMap(elecMapHandle.product());
-  }
+  setElectronicsMap(_es);
 }
 
 template <int SUBDET>
@@ -114,7 +109,7 @@ void EcalFEDMonitorTemp<SUBDET>::analyze(edm::Event const& _evt, edm::EventSetup
   if ((SUBDET == EcalBarrel || SUBDET < 0) && _evt.getByToken(ebGainErrorsToken_, ebHndl)) {
     EBDetIdCollection::const_iterator ebEnd(ebHndl->end());
     for (EBDetIdCollection::const_iterator ebItr(ebHndl->begin()); ebItr != ebEnd; ++ebItr) {
-      unsigned iDCC(ecaldqm::dccId(*ebItr) - 1);
+      unsigned iDCC(ecaldqm::dccId(*ebItr, GetElectronicsMap()) - 1);
 
       double normalization(ecaldqm::nCrystals(iDCC + 1));
       if (normalization < 1.)
@@ -126,7 +121,7 @@ void EcalFEDMonitorTemp<SUBDET>::analyze(edm::Event const& _evt, edm::EventSetup
   if ((SUBDET == EcalEndcap || SUBDET < 0) && _evt.getByToken(eeGainErrorsToken_, eeHndl)) {
     EEDetIdCollection::const_iterator eeEnd(eeHndl->end());
     for (EEDetIdCollection::const_iterator eeItr(eeHndl->begin()); eeItr != eeEnd; ++eeItr) {
-      unsigned iDCC(ecaldqm::dccId(*eeItr) - 1);
+      unsigned iDCC(ecaldqm::dccId(*eeItr, GetElectronicsMap()) - 1);
 
       double normalization(ecaldqm::nCrystals(iDCC + 1));
       if (normalization < 1.)
@@ -139,7 +134,7 @@ void EcalFEDMonitorTemp<SUBDET>::analyze(edm::Event const& _evt, edm::EventSetup
   if ((SUBDET == EcalBarrel || SUBDET < 0) && _evt.getByToken(ebChIdErrorsToken_, ebHndl)) {
     EBDetIdCollection::const_iterator ebEnd(ebHndl->end());
     for (EBDetIdCollection::const_iterator ebItr(ebHndl->begin()); ebItr != ebEnd; ++ebItr) {
-      unsigned iDCC(ecaldqm::dccId(*ebItr) - 1);
+      unsigned iDCC(ecaldqm::dccId(*ebItr, GetElectronicsMap()) - 1);
 
       double normalization(ecaldqm::nCrystals(iDCC + 1));
       if (normalization < 1.)
@@ -151,7 +146,7 @@ void EcalFEDMonitorTemp<SUBDET>::analyze(edm::Event const& _evt, edm::EventSetup
   if ((SUBDET == EcalEndcap || SUBDET < 0) && _evt.getByToken(eeChIdErrorsToken_, eeHndl)) {
     EEDetIdCollection::const_iterator eeEnd(eeHndl->end());
     for (EEDetIdCollection::const_iterator eeItr(eeHndl->begin()); eeItr != eeEnd; ++eeItr) {
-      unsigned iDCC(ecaldqm::dccId(*eeItr) - 1);
+      unsigned iDCC(ecaldqm::dccId(*eeItr, GetElectronicsMap()) - 1);
 
       double normalization(ecaldqm::nCrystals(iDCC + 1));
       if (normalization < 1.)
@@ -164,7 +159,7 @@ void EcalFEDMonitorTemp<SUBDET>::analyze(edm::Event const& _evt, edm::EventSetup
   if ((SUBDET == EcalBarrel || SUBDET < 0) && _evt.getByToken(ebGainSwitchErrorsToken_, ebHndl)) {
     EBDetIdCollection::const_iterator ebEnd(ebHndl->end());
     for (EBDetIdCollection::const_iterator ebItr(ebHndl->begin()); ebItr != ebEnd; ++ebItr) {
-      unsigned iDCC(ecaldqm::dccId(*ebItr) - 1);
+      unsigned iDCC(ecaldqm::dccId(*ebItr, GetElectronicsMap()) - 1);
 
       double normalization(ecaldqm::nCrystals(iDCC + 1));
       if (normalization < 1.)
@@ -176,7 +171,7 @@ void EcalFEDMonitorTemp<SUBDET>::analyze(edm::Event const& _evt, edm::EventSetup
   if ((SUBDET == EcalEndcap || SUBDET < 0) && _evt.getByToken(eeGainSwitchErrorsToken_, eeHndl)) {
     EEDetIdCollection::const_iterator eeEnd(eeHndl->end());
     for (EEDetIdCollection::const_iterator eeItr(eeHndl->begin()); eeItr != eeEnd; ++eeItr) {
-      unsigned iDCC(ecaldqm::dccId(*eeItr) - 1);
+      unsigned iDCC(ecaldqm::dccId(*eeItr, GetElectronicsMap()) - 1);
 
       double normalization(ecaldqm::nCrystals(iDCC + 1));
       if (normalization < 1.)
@@ -227,6 +222,20 @@ void EcalFEDMonitorTemp<SUBDET>::analyze(edm::Event const& _evt, edm::EventSetup
       MEs_[nonfatal]->Fill(iDCC + 601.5, 25. / normalization);
     }
   }
+}
+
+template <int SUBDET>
+void EcalFEDMonitorTemp<SUBDET>::setElectronicsMap(edm::EventSetup const &_es) {
+    edm::ESHandle<EcalElectronicsMapping> elecMapHandle;
+    _es.get<EcalMappingRcd>().get(elecMapHandle);
+    electronicsMap = elecMapHandle.product();
+}
+
+template <int SUBDET>
+EcalElectronicsMapping const * EcalFEDMonitorTemp<SUBDET>::GetElectronicsMap() {
+  if (!electronicsMap)
+    throw cms::Exception("InvalidCall") << "Electronics Mapping not initialized";
+  return electronicsMap;
 }
 
 typedef EcalFEDMonitorTemp<EcalBarrel> EBHltTask;

--- a/DQM/EcalMonitorTasks/src/ClusterTask.cc
+++ b/DQM/EcalMonitorTasks/src/ClusterTask.cc
@@ -173,9 +173,9 @@ namespace ecaldqm {
     for (unsigned iT(0); iT != nTriggerTypes; ++iT) {
       if (!triggered_[iT])
         continue;
-      meTriggers.fill(iT + 0.5);
+      meTriggers.fill(getEcalDQMSetupObjects(), iT + 0.5);
       if (triggered_.count() == 1)
-        meExclusiveTriggers.fill(iT + 0.5);
+        meExclusiveTriggers.fill(getEcalDQMSetupObjects(), iT + 0.5);
     }
   }
 
@@ -248,7 +248,7 @@ namespace ecaldqm {
       if (id.null()) {
         GlobalPoint gp(position.x(), position.y(), position.z());
         CaloSubdetectorGeometry const* subgeom(
-            getGeometry()->getSubdetectorGeometry(DetId::Ecal, isBarrel ? EcalBarrel : EcalEndcap));
+            GetGeometry()->getSubdetectorGeometry(DetId::Ecal, isBarrel ? EcalBarrel : EcalEndcap));
 
         id = subgeom->getClosestCell(gp);
       }
@@ -264,26 +264,26 @@ namespace ecaldqm {
       if (subdet == EcalEndcap && position.z() < 0.)
         subdet = -EcalEndcap;
 
-      meBCE.fill(id, energy);
+      meBCE.fill(getEcalDQMSetupObjects(), id, energy);
 
-      meBCEMap.fill(id, energy);
-      meBCEMapProjEta.fill(posEta, energy);
-      meBCEMapProjPhi.fill(subdet, posPhi, energy);
-      meBCEtMapProjEta.fill(posEta, et);
-      meBCEtMapProjPhi.fill(subdet, posPhi, et);
+      meBCEMap.fill(getEcalDQMSetupObjects(), id, energy);
+      meBCEMapProjEta.fill(getEcalDQMSetupObjects(), posEta, energy);
+      meBCEMapProjPhi.fill(getEcalDQMSetupObjects(), subdet, posPhi, energy);
+      meBCEtMapProjEta.fill(getEcalDQMSetupObjects(), posEta, et);
+      meBCEtMapProjPhi.fill(getEcalDQMSetupObjects(), subdet, posPhi, et);
 
-      meBCOccupancy.fill(id);
-      meBCOccupancyProjEta.fill(posEta);
-      meBCOccupancyProjPhi.fill(subdet, posPhi);
+      meBCOccupancy.fill(getEcalDQMSetupObjects(), id);
+      meBCOccupancyProjEta.fill(getEcalDQMSetupObjects(), posEta);
+      meBCOccupancyProjPhi.fill(getEcalDQMSetupObjects(), subdet, posPhi);
 
       float size(bcItr->size());
 
-      meBCSize.fill(id, size);
-      meTrendBCSize.fill(id, double(timestamp_.iLumi), size);
+      meBCSize.fill(getEcalDQMSetupObjects(), id, size);
+      meTrendBCSize.fill(getEcalDQMSetupObjects(), id, double(timestamp_.iLumi), size);
 
-      meBCSizeMap.fill(id, size);
-      meBCSizeMapProjEta.fill(posEta, size);
-      meBCSizeMapProjPhi.fill(subdet, posPhi, size);
+      meBCSizeMap.fill(getEcalDQMSetupObjects(), id, size);
+      meBCSizeMapProjEta.fill(getEcalDQMSetupObjects(), posEta, size);
+      meBCSizeMapProjPhi.fill(getEcalDQMSetupObjects(), subdet, posPhi, size);
 
       int zside(position.z() > 0 ? 1 : 0);
       nBC[zside]++;
@@ -304,12 +304,12 @@ namespace ecaldqm {
     }
 
     if (isBarrel) {
-      meBCNum.fill(EcalBarrel, nBC[0] + nBC[1]);
-      meTrendNBC.fill(EcalBarrel, double(timestamp_.iLumi), nBC[0] + nBC[1]);
+      meBCNum.fill(getEcalDQMSetupObjects(), EcalBarrel, nBC[0] + nBC[1]);
+      meTrendNBC.fill(getEcalDQMSetupObjects(), EcalBarrel, double(timestamp_.iLumi), nBC[0] + nBC[1]);
     } else {
-      meBCNum.fill(-EcalEndcap, nBC[0]);
-      meBCNum.fill(EcalEndcap, nBC[1]);
-      meTrendNBC.fill(EcalEndcap, double(timestamp_.iLumi), nBC[0] + nBC[1]);
+      meBCNum.fill(getEcalDQMSetupObjects(), -EcalEndcap, nBC[0]);
+      meBCNum.fill(getEcalDQMSetupObjects(), EcalEndcap, nBC[1]);
+      meTrendNBC.fill(getEcalDQMSetupObjects(), EcalEndcap, double(timestamp_.iLumi), nBC[0] + nBC[1]);
     }
 
     //     if(ievt_ % massCalcPrescale_ != 0) return;
@@ -404,7 +404,7 @@ namespace ecaldqm {
         GlobalPoint gp(position.x(), position.y(), position.z());
 
         CaloSubdetectorGeometry const* subgeom(
-            getGeometry()->getSubdetectorGeometry(DetId::Ecal, isBarrel ? EcalBarrel : EcalEndcap));
+            GetGeometry()->getSubdetectorGeometry(DetId::Ecal, isBarrel ? EcalBarrel : EcalEndcap));
 
         seedId = subgeom->getClosestCell(gp);
       }
@@ -422,37 +422,37 @@ namespace ecaldqm {
       float rawEnergy(scItr->rawEnergy());
       float size(scItr->size());
 
-      meSCE.fill(seedId, energy);
-      meSCELow.fill(seedId, energy);
+      meSCE.fill(getEcalDQMSetupObjects(), seedId, energy);
+      meSCELow.fill(getEcalDQMSetupObjects(), seedId, energy);
 
-      meSCRawE.fill(seedId, rawEnergy);
-      meSCRawELow.fill(seedId, rawEnergy);
+      meSCRawE.fill(getEcalDQMSetupObjects(), seedId, rawEnergy);
+      meSCRawELow.fill(getEcalDQMSetupObjects(), seedId, rawEnergy);
 
-      meSCNBCs.fill(seedId, scItr->clustersSize());
-      meSCNcrystals.fill(seedId, size);
+      meSCNBCs.fill(getEcalDQMSetupObjects(), seedId, scItr->clustersSize());
+      meSCNcrystals.fill(getEcalDQMSetupObjects(), seedId, size);
 
       if (doExtra_)
-        meSCSizeVsEnergy->fill(subdet, energy, size);
+        meSCSizeVsEnergy->fill(getEcalDQMSetupObjects(), subdet, energy, size);
 
-      meTrendSCSize.fill(seedId, double(timestamp_.iLumi), size);
+      meTrendSCSize.fill(getEcalDQMSetupObjects(), seedId, double(timestamp_.iLumi), size);
 
-      meSCSeedEnergy.fill(seedId, seedItr->energy());
-      meSCClusterVsSeed.fill(seedId, seedItr->energy(), energy);
+      meSCSeedEnergy.fill(getEcalDQMSetupObjects(), seedId, seedItr->energy());
+      meSCClusterVsSeed.fill(getEcalDQMSetupObjects(), seedId, seedItr->energy(), energy);
 
-      meSCSeedOccupancy.fill(seedId);
+      meSCSeedOccupancy.fill(getEcalDQMSetupObjects(), seedId);
       if (doExtra_ && energy > energyThreshold_)
-        meSCSeedOccupancyHighE->fill(seedId);
+        meSCSeedOccupancyHighE->fill(getEcalDQMSetupObjects(), seedId);
 
       if (scItr->size() == 1)
-        meSingleCrystalCluster.fill(seedId);
+        meSingleCrystalCluster.fill(getEcalDQMSetupObjects(), seedId);
 
-      float e3x3(EcalClusterTools::e3x3(*scItr->seed(), hits, getTopology()));
-      float e3x3Full(noZS::EcalClusterTools::e3x3(*scItr->seed(), hits, getTopology()));
+      float e3x3(EcalClusterTools::e3x3(*scItr->seed(), hits, GetTopology()));
+      float e3x3Full(noZS::EcalClusterTools::e3x3(*scItr->seed(), hits, GetTopology()));
 
-      meSCR9.fill(seedId, e3x3 / energy);
-      meSCR9Raw.fill(seedId, e3x3 / rawEnergy);
-      meSCR9Full.fill(seedId, e3x3Full / energy);
-      meSCR9FullRaw.fill(seedId, e3x3Full / rawEnergy);
+      meSCR9.fill(getEcalDQMSetupObjects(), seedId, e3x3 / energy);
+      meSCR9Raw.fill(getEcalDQMSetupObjects(), seedId, e3x3 / rawEnergy);
+      meSCR9Full.fill(getEcalDQMSetupObjects(), seedId, e3x3Full / energy);
+      meSCR9FullRaw.fill(getEcalDQMSetupObjects(), seedId, e3x3Full / rawEnergy);
 
       if (doExtra_) {
         for (unsigned iT(0); iT != nTriggerTypes; ++iT) {
@@ -460,29 +460,29 @@ namespace ecaldqm {
             continue;
 
           static_cast<MESetMulti*>(meSCSeedOccupancyTrig)->use(trigTypeToME_[iT]);
-          meSCSeedOccupancyTrig->fill(seedId);
+          meSCSeedOccupancyTrig->fill(getEcalDQMSetupObjects(), seedId);
 
           // exclusive
           if (triggered_.count() == 1) {
             static_cast<MESetMulti*>(meSCSeedTimeTrigEx)->use(trigTypeToME_[iT]);
             static_cast<MESetMulti*>(meSCSeedTimeMapTrigEx)->use(trigTypeToME_[iT]);
-            meSCSeedTimeTrigEx->fill(subdet, seedItr->time());
-            meSCSeedTimeMapTrigEx->fill(seedId, seedItr->time());
+            meSCSeedTimeTrigEx->fill(getEcalDQMSetupObjects(), subdet, seedItr->time());
+            meSCSeedTimeMapTrigEx->fill(getEcalDQMSetupObjects(), seedId, seedItr->time());
           }
         }
 
-        meSCOccupancyProjEta->fill(subdet, scItr->eta());
-        meSCOccupancyProjPhi->fill(subdet, phi(scItr->phi()));
+        meSCOccupancyProjEta->fill(getEcalDQMSetupObjects(), subdet, scItr->eta());
+        meSCOccupancyProjPhi->fill(getEcalDQMSetupObjects(), subdet, phi(scItr->phi()));
 
         if (isBarrel) {
           float e1(EcalClusterTools::eMax(*scItr, ebHits_));
           if (e1 > swissCrossMaxThreshold_) {
-            float e4(EcalClusterTools::eTop(*scItr, ebHits_, getTopology()) +
-                     EcalClusterTools::eRight(*scItr, ebHits_, getTopology()) +
-                     EcalClusterTools::eBottom(*scItr, ebHits_, getTopology()) +
-                     EcalClusterTools::eLeft(*scItr, ebHits_, getTopology()));
+            float e4(EcalClusterTools::eTop(*scItr, ebHits_, GetTopology()) +
+                     EcalClusterTools::eRight(*scItr, ebHits_, GetTopology()) +
+                     EcalClusterTools::eBottom(*scItr, ebHits_, GetTopology()) +
+                     EcalClusterTools::eLeft(*scItr, ebHits_, GetTopology()));
 
-            meSCSwissCross->fill(1. - e4 / e1);
+            meSCSwissCross->fill(getEcalDQMSetupObjects(), 1. - e4 / e1);
           }
         }
       }
@@ -499,8 +499,8 @@ namespace ecaldqm {
       //       }
     }
 
-    MEs_.at("SCNum").fill(subdet, nSC);
-    MEs_.at("TrendNSC").fill(subdet, double(timestamp_.iLumi), nSC);
+    MEs_.at("SCNum").fill(getEcalDQMSetupObjects(), subdet, nSC);
+    MEs_.at("TrendNSC").fill(getEcalDQMSetupObjects(), subdet, double(timestamp_.iLumi), nSC);
 
     //     if(ievt_ % massCalcPrescale_ != 0) return;
 

--- a/DQM/EcalMonitorTasks/src/EnergyTask.cc
+++ b/DQM/EcalMonitorTasks/src/EnergyTask.cc
@@ -28,7 +28,7 @@ namespace ecaldqm {
 
   void EnergyTask::beginEvent(edm::Event const& _evt, edm::EventSetup const& _es, bool const& ByLumiResetSwitch, bool&) {
     if (ByLumiResetSwitch) {
-      MEs_.at("HitMapAllByLumi").reset();
+      MEs_.at("HitMapAllByLumi").reset(GetElectronicsMap());
     }
   }
 
@@ -55,11 +55,11 @@ namespace ecaldqm {
 
       DetId id(hitItr->id());
 
-      meHitMap.fill(id, energy);
-      meHitMapAll.fill(id, energy);
-      meHitMapAllByLumi.fill(id, energy);
-      meHit.fill(id, energy);
-      meHitAll.fill(id, energy);
+      meHitMap.fill(getEcalDQMSetupObjects(), id, energy);
+      meHitMapAll.fill(getEcalDQMSetupObjects(), id, energy);
+      meHitMapAllByLumi.fill(getEcalDQMSetupObjects(), id, energy);
+      meHit.fill(getEcalDQMSetupObjects(), id, energy);
+      meHitAll.fill(getEcalDQMSetupObjects(), id, energy);
 
       // look for the seeds
       //       float e3x3(energy);
@@ -67,7 +67,7 @@ namespace ecaldqm {
 
       //       EcalRecHitCollection::const_iterator neighborItr;
       //       float neighborE;
-      //       std::vector<DetId> window(getTopology()->getWindow(id, 3, 3));
+      //       std::vector<DetId> window(GetTopology()->getWindow(id, 3, 3));
       //       for(std::vector<DetId>::iterator idItr(window.begin()); idItr != window.end(); ++idItr){
       // 	if((neighborItr = _hits.find(*idItr)) == _hits.end()) continue;
       //         if(isPhysicsRun_ && neighborItr->checkFlagMask(notGood)) continue;

--- a/DQM/EcalMonitorTasks/src/IntegrityTask.cc
+++ b/DQM/EcalMonitorTasks/src/IntegrityTask.cc
@@ -11,8 +11,8 @@ namespace ecaldqm {
                                  bool const& ByLumiResetSwitch,
                                  bool&) {
     if (ByLumiResetSwitch) {
-      MEs_.at("MapByLumi").reset();
-      MEs_.at("ByLumi").reset();
+      MEs_.at("MapByLumi").reset(GetElectronicsMap());
+      MEs_.at("ByLumi").reset(GetElectronicsMap());
     }
   }
 
@@ -46,14 +46,14 @@ namespace ecaldqm {
     MESet& meTrendNErrors(MEs_.at("TrendNErrors"));
 
     std::for_each(_ids.begin(), _ids.end(), [&](typename IDCollection::value_type const& id) {
-      set->fill(id);
-      int dccid(dccId(id));
-      meByLumi.fill(dccid);
-      meTotal.fill(dccid);
+      set->fill(getEcalDQMSetupObjects(), id);
+      int dccid(dccId(id, GetElectronicsMap()));
+      meByLumi.fill(getEcalDQMSetupObjects(), dccid);
+      meTotal.fill(getEcalDQMSetupObjects(), dccid);
       // Fill Integrity Errors Map with channel errors for this lumi
-      meMapByLumi.fill(id);
+      meMapByLumi.fill(getEcalDQMSetupObjects(), id);
 
-      meTrendNErrors.fill(double(timestamp_.iLumi), 1.);
+      meTrendNErrors.fill(getEcalDQMSetupObjects(), double(timestamp_.iLumi), 1.);
     });
   }
 
@@ -80,23 +80,23 @@ namespace ecaldqm {
     MESet& meTrendNErrors(MEs_.at("TrendNErrors"));
 
     std::for_each(_ids.begin(), _ids.end(), [&](EcalElectronicsIdCollection::value_type const& id) {
-      set->fill(id);
+      set->fill(getEcalDQMSetupObjects(), id);
       int dccid(id.dccId());
       double nCrystals(0.);
-      std::vector<DetId> chIds(getElectronicsMap()->dccTowerConstituents(dccid, id.towerId()));
+      std::vector<DetId> chIds(GetElectronicsMap()->dccTowerConstituents(dccid, id.towerId()));
       if (dccid <= kEEmHigh + 1 || dccid >= kEEpLow + 1)
         nCrystals = chIds.size();
       else
         nCrystals = 25.;
-      meByLumi.fill(dccid, nCrystals);
-      meTotal.fill(dccid, nCrystals);
+      meByLumi.fill(getEcalDQMSetupObjects(), dccid, nCrystals);
+      meTotal.fill(getEcalDQMSetupObjects(), dccid, nCrystals);
       // Fill Integrity Errors Map with tower errors for this lumi
       // Since binned by crystal for compatibility with channel errors,
       // fill with constituent channels of tower
       for (std::vector<DetId>::iterator chItr(chIds.begin()); chItr != chIds.end(); ++chItr)
-        meMapByLumi.fill(*chItr);
+        meMapByLumi.fill(getEcalDQMSetupObjects(), *chItr);
 
-      meTrendNErrors.fill(double(timestamp_.iLumi), nCrystals);
+      meTrendNErrors.fill(getEcalDQMSetupObjects(), double(timestamp_.iLumi), nCrystals);
     });
   }
 

--- a/DQM/EcalMonitorTasks/src/LaserTask.cc
+++ b/DQM/EcalMonitorTasks/src/LaserTask.cc
@@ -101,7 +101,7 @@ namespace ecaldqm {
       }
     }
     for (unsigned iWL(0); iWL < nWavelength; iWL++) {
-      meCalibStatus.fill(double(iWL), LaserStatus[iWL] ? 1 : 0);
+      meCalibStatus.fill(getEcalDQMSetupObjects(), double(iWL), LaserStatus[iWL] ? 1 : 0);
     }
   }
 
@@ -126,16 +126,16 @@ namespace ecaldqm {
     for (typename DigiCollection::const_iterator digiItr(_digis.begin()); digiItr != _digis.end(); ++digiItr) {
       const DetId& id(digiItr->id());
 
-      unsigned iDCC(dccId(id) - 1);
+      unsigned iDCC(dccId(id, GetElectronicsMap()) - 1);
 
       inData[iDCC] = true;
 
       if (!enable_[iDCC])
         continue;
-      if (rtHalf(id) != rtHalf_[iDCC])
+      if (rtHalf(id, GetElectronicsMap()) != rtHalf_[iDCC])
         continue;
 
-      meOccupancy.fill(id);
+      meOccupancy.fill(getEcalDQMSetupObjects(), id);
 
       ++nReadouts[iDCC];
 
@@ -196,7 +196,7 @@ namespace ecaldqm {
         static_cast<MESetMulti&>(meSignalRate).use(iME);
       }
 
-      meSignalRate.fill(iDCC + 1, enable_[iDCC] ? 1 : 0);
+      meSignalRate.fill(getEcalDQMSetupObjects(), iDCC + 1, enable_[iDCC] ? 1 : 0);
     }
 
     if (enable)
@@ -209,11 +209,11 @@ namespace ecaldqm {
     for (typename DigiCollection::const_iterator digiItr(_digis.begin()); digiItr != _digis.end(); ++digiItr) {
       const DetId& id(digiItr->id());
 
-      unsigned iDCC(dccId(id) - 1);
+      unsigned iDCC(dccId(id, GetElectronicsMap()) - 1);
 
       if (!enable_[iDCC])
         continue;
-      if (rtHalf(id) != rtHalf_[iDCC])
+      if (rtHalf(id, GetElectronicsMap()) != rtHalf_[iDCC])
         continue;
 
       EcalDataFrame dataFrame(*digiItr);
@@ -224,10 +224,10 @@ namespace ecaldqm {
       }
 
       for (int iSample(0); iSample < EcalDataFrame::MAXSAMPLES; iSample++)
-        meShape.fill(id, iSample + 0.5, float(dataFrame.sample(iSample).adc()));
+        meShape.fill(getEcalDQMSetupObjects(), id, iSample + 0.5, float(dataFrame.sample(iSample).adc()));
 
-      EcalPnDiodeDetId pnidA(pnForCrystal(id, 'a'));
-      EcalPnDiodeDetId pnidB(pnForCrystal(id, 'b'));
+      EcalPnDiodeDetId pnidA(pnForCrystal(id, 'a', GetElectronicsMap()));
+      EcalPnDiodeDetId pnidB(pnForCrystal(id, 'b', GetElectronicsMap()));
       if (pnidA.null() || pnidB.null())
         continue;
       pnAmp_.insert(std::make_pair(pnidA.rawId(), 0.));
@@ -256,7 +256,7 @@ namespace ecaldqm {
       if (ampItr == pnAmp_.end())
         continue;
 
-      unsigned iDCC(dccId(id) - 1);
+      unsigned iDCC(dccId(id, GetElectronicsMap()) - 1);
 
       double pedestal(0.);
       for (int iSample(0); iSample < 4; iSample++)
@@ -275,7 +275,7 @@ namespace ecaldqm {
         static_cast<MESetMulti&>(mePNAmplitude).use(iME);
       }
 
-      mePNAmplitude.fill(id, max);
+      mePNAmplitude.fill(getEcalDQMSetupObjects(), id, max);
 
       ampItr->second = max;
     }
@@ -300,11 +300,11 @@ namespace ecaldqm {
     for (EcalUncalibratedRecHitCollection::const_iterator uhitItr(_uhits.begin()); uhitItr != _uhits.end(); ++uhitItr) {
       const DetId& id(uhitItr->id());
 
-      unsigned iDCC(dccId(id) - 1);
+      unsigned iDCC(dccId(id, GetElectronicsMap()) - 1);
 
       if (!enable_[iDCC])
         continue;
-      if (rtHalf(id) != rtHalf_[iDCC])
+      if (rtHalf(id, GetElectronicsMap()) != rtHalf_[iDCC])
         continue;
 
       if (iME != wlToME_[wavelength_[iDCC]]) {
@@ -318,14 +318,14 @@ namespace ecaldqm {
       float amp(max((double)uhitItr->amplitude(), 0.));
       float jitter(max((double)uhitItr->jitter() + 5.0, 0.));
 
-      meAmplitude.fill(id, amp);
-      meAmplitudeSummary.fill(id, amp);
-      meTiming.fill(id, jitter);
+      meAmplitude.fill(getEcalDQMSetupObjects(), id, amp);
+      meAmplitudeSummary.fill(getEcalDQMSetupObjects(), id, amp);
+      meTiming.fill(getEcalDQMSetupObjects(), id, jitter);
 
       float aop(0.);
 
-      map<uint32_t, float>::iterator ampItrA(pnAmp_.find(pnForCrystal(id, 'a')));
-      map<uint32_t, float>::iterator ampItrB(pnAmp_.find(pnForCrystal(id, 'b')));
+      map<uint32_t, float>::iterator ampItrA(pnAmp_.find(pnForCrystal(id, 'a', GetElectronicsMap())));
+      map<uint32_t, float>::iterator ampItrB(pnAmp_.find(pnForCrystal(id, 'b', GetElectronicsMap())));
       if (ampItrA == pnAmp_.end() && ampItrB == pnAmp_.end())
         continue;
       else if (ampItrB == pnAmp_.end())
@@ -335,7 +335,7 @@ namespace ecaldqm {
       else
         aop = amp / (ampItrA->second + ampItrB->second) * 2.;
 
-      meAOverP.fill(id, aop);
+      meAOverP.fill(getEcalDQMSetupObjects(), id, aop);
     }
   }
 

--- a/DQM/EcalMonitorTasks/src/LedTask.cc
+++ b/DQM/EcalMonitorTasks/src/LedTask.cc
@@ -186,7 +186,8 @@ namespace ecaldqm {
         static_cast<MESetMulti&>(meSignalRate).use(iME);
       }
 
-      meSignalRate.fill(getEcalDQMSetupObjects(), (index <= kEEmHigh ? index : index + nEBDCC) + 1, enable_[index] ? 1 : 0);
+      meSignalRate.fill(
+          getEcalDQMSetupObjects(), (index <= kEEmHigh ? index : index + nEBDCC) + 1, enable_[index] ? 1 : 0);
     }
 
     if (!enable && isemptyLS >= 0)

--- a/DQM/EcalMonitorTasks/src/LedTask.cc
+++ b/DQM/EcalMonitorTasks/src/LedTask.cc
@@ -105,7 +105,7 @@ namespace ecaldqm {
       }
     }
     for (unsigned iWL(0); iWL < 2; iWL++) {
-      meCalibStatus.fill(double(iWL + 3), LedStatus[iWL] ? 1 : 0);
+      meCalibStatus.fill(getEcalDQMSetupObjects(), double(iWL + 3), LedStatus[iWL] ? 1 : 0);
     }
   }
 
@@ -125,17 +125,17 @@ namespace ecaldqm {
     for (EEDigiCollection::const_iterator digiItr(_digis.begin()); digiItr != _digis.end(); ++digiItr) {
       const DetId& id(digiItr->id());
 
-      unsigned iDCC(dccId(id) - 1);
+      unsigned iDCC(dccId(id, GetElectronicsMap()) - 1);
       if (iDCC >= kEBmLow && iDCC <= kEBpHigh)
         continue;
       unsigned index(iDCC <= kEEmHigh ? iDCC : iDCC - nEBDCC);
 
       if (!enable_[index])
         continue;
-      if (rtHalf(id) != rtHalf_[index])
+      if (rtHalf(id, GetElectronicsMap()) != rtHalf_[index])
         continue;
 
-      meOccupancy.fill(id);
+      meOccupancy.fill(getEcalDQMSetupObjects(), id);
 
       ++nReadouts[index];
 
@@ -186,7 +186,7 @@ namespace ecaldqm {
         static_cast<MESetMulti&>(meSignalRate).use(iME);
       }
 
-      meSignalRate.fill((index <= kEEmHigh ? index : index + nEBDCC) + 1, enable_[index] ? 1 : 0);
+      meSignalRate.fill(getEcalDQMSetupObjects(), (index <= kEEmHigh ? index : index + nEBDCC) + 1, enable_[index] ? 1 : 0);
     }
 
     if (!enable && isemptyLS >= 0)
@@ -204,14 +204,14 @@ namespace ecaldqm {
     for (EEDigiCollection::const_iterator digiItr(_digis.begin()); digiItr != _digis.end(); ++digiItr) {
       const DetId& id(digiItr->id());
 
-      unsigned iDCC(dccId(id) - 1);
+      unsigned iDCC(dccId(id, GetElectronicsMap()) - 1);
       if (iDCC >= kEBmLow && iDCC <= kEBpHigh)
         continue;
       unsigned index(iDCC <= kEEmHigh ? iDCC : iDCC - nEBDCC);
 
       if (!enable_[index])
         continue;
-      if (rtHalf(id) != rtHalf_[index])
+      if (rtHalf(id, GetElectronicsMap()) != rtHalf_[index])
         continue;
 
       if (iME != wlToME_[wavelength_[index]]) {
@@ -223,10 +223,10 @@ namespace ecaldqm {
       EcalDataFrame dataFrame(*digiItr);
 
       for (int iSample(0); iSample < 10; iSample++)
-        meShape.fill(id, iSample + 0.5, float(dataFrame.sample(iSample).adc()));
+        meShape.fill(getEcalDQMSetupObjects(), id, iSample + 0.5, float(dataFrame.sample(iSample).adc()));
 
-      EcalPnDiodeDetId pnidA(pnForCrystal(id, 'a'));
-      EcalPnDiodeDetId pnidB(pnForCrystal(id, 'b'));
+      EcalPnDiodeDetId pnidA(pnForCrystal(id, 'a', GetElectronicsMap()));
+      EcalPnDiodeDetId pnidB(pnForCrystal(id, 'b', GetElectronicsMap()));
       if (pnidA.null() || pnidB.null())
         continue;
       pnAmp_.insert(std::make_pair(pnidA.rawId(), 0.));
@@ -249,7 +249,7 @@ namespace ecaldqm {
       if (ampItr == pnAmp_.end())
         continue;
 
-      unsigned iDCC(dccId(id) - 1);
+      unsigned iDCC(dccId(id, GetElectronicsMap()) - 1);
       if (iDCC >= kEBmLow && iDCC <= kEBpHigh)
         continue;
       unsigned index(iDCC <= kEEmHigh ? iDCC : iDCC - nEBDCC);
@@ -271,7 +271,7 @@ namespace ecaldqm {
         static_cast<MESetMulti&>(mePNAmplitude).use(iME);
       }
 
-      mePNAmplitude.fill(id, max);
+      mePNAmplitude.fill(getEcalDQMSetupObjects(), id, max);
 
       ampItr->second = max;
     }
@@ -290,14 +290,14 @@ namespace ecaldqm {
     for (EcalUncalibratedRecHitCollection::const_iterator uhitItr(_uhits.begin()); uhitItr != _uhits.end(); ++uhitItr) {
       EEDetId id(uhitItr->id());
 
-      unsigned iDCC(dccId(id) - 1);
+      unsigned iDCC(dccId(id, GetElectronicsMap()) - 1);
       if (iDCC >= kEBmLow && iDCC <= kEBpHigh)
         continue;
       unsigned index(iDCC <= kEEmHigh ? iDCC : iDCC - nEBDCC);
 
       if (!enable_[index])
         continue;
-      if (rtHalf(id) != rtHalf_[index])
+      if (rtHalf(id, GetElectronicsMap()) != rtHalf_[index])
         continue;
 
       if (iME != wlToME_[wavelength_[index]]) {
@@ -311,14 +311,14 @@ namespace ecaldqm {
       float amp(max((double)uhitItr->amplitude(), 0.));
       float jitter(max((double)uhitItr->jitter() + 5.0, 0.));
 
-      meAmplitude.fill(id, amp);
-      meAmplitudeSummary.fill(id, amp);
-      meTiming.fill(id, jitter);
+      meAmplitude.fill(getEcalDQMSetupObjects(), id, amp);
+      meAmplitudeSummary.fill(getEcalDQMSetupObjects(), id, amp);
+      meTiming.fill(getEcalDQMSetupObjects(), id, jitter);
 
       float aop(0.);
 
-      map<uint32_t, float>::iterator ampItrA(pnAmp_.find(pnForCrystal(id, 'a')));
-      map<uint32_t, float>::iterator ampItrB(pnAmp_.find(pnForCrystal(id, 'b')));
+      map<uint32_t, float>::iterator ampItrA(pnAmp_.find(pnForCrystal(id, 'a', GetElectronicsMap())));
+      map<uint32_t, float>::iterator ampItrB(pnAmp_.find(pnForCrystal(id, 'b', GetElectronicsMap())));
       if (ampItrA == pnAmp_.end() && ampItrB == pnAmp_.end())
         continue;
       else if (ampItrB == pnAmp_.end())
@@ -328,7 +328,7 @@ namespace ecaldqm {
       else
         aop = amp / (ampItrA->second + ampItrB->second) * 2.;
 
-      meAOverP.fill(id, aop);
+      meAOverP.fill(getEcalDQMSetupObjects(), id, aop);
     }
   }
 

--- a/DQM/EcalMonitorTasks/src/OccupancyTask.cc
+++ b/DQM/EcalMonitorTasks/src/OccupancyTask.cc
@@ -30,9 +30,9 @@ namespace ecaldqm {
                                  bool const& ByLumiResetSwitch,
                                  bool&) {
     if (ByLumiResetSwitch) {
-      MEs_.at("DigiAllByLumi").reset();
-      MEs_.at("TPDigiThrAllByLumi").reset();
-      MEs_.at("RecHitThrAllByLumi").reset();
+      MEs_.at("DigiAllByLumi").reset(GetElectronicsMap());
+      MEs_.at("TPDigiThrAllByLumi").reset(GetElectronicsMap());
+      MEs_.at("RecHitThrAllByLumi").reset(GetElectronicsMap());
     }
   }
 
@@ -40,7 +40,7 @@ namespace ecaldqm {
     MESet& meDCC(MEs_.at("DCC"));
 
     for (EcalRawDataCollection::const_iterator dcchItr(_dcchs.begin()); dcchItr != _dcchs.end(); ++dcchItr)
-      meDCC.fill(dcchItr->id());
+      meDCC.fill(getEcalDQMSetupObjects(), dcchItr->id());
   }
 
   template <typename DigiCollection>
@@ -56,17 +56,17 @@ namespace ecaldqm {
 
     std::for_each(_digis.begin(), _digis.end(), [&](typename DigiCollection::Digi const& digi) {
       DetId id(digi.id());
-      meDigi.fill(id);
-      meDigiProjEta.fill(id);
-      meDigiProjPhi.fill(id);
-      meDigiAll.fill(id);
-      meDigiAllByLumi.fill(id);
-      meDigiDCC.fill(id);
+      meDigi.fill(getEcalDQMSetupObjects(), id);
+      meDigiProjEta.fill(getEcalDQMSetupObjects(), id);
+      meDigiProjPhi.fill(getEcalDQMSetupObjects(), id);
+      meDigiAll.fill(getEcalDQMSetupObjects(), id);
+      meDigiAllByLumi.fill(getEcalDQMSetupObjects(), id);
+      meDigiDCC.fill(getEcalDQMSetupObjects(), id);
     });
 
     int iSubdet(_collection == kEBDigi ? EcalBarrel : EcalEndcap);
-    meDigi1D.fill(iSubdet, double(_digis.size()));
-    meTrendNDigi.fill(iSubdet, double(timestamp_.iLumi), double(_digis.size()));
+    meDigi1D.fill(getEcalDQMSetupObjects(), iSubdet, double(_digis.size()));
+    meTrendNDigi.fill(getEcalDQMSetupObjects(), iSubdet, double(timestamp_.iLumi), double(_digis.size()));
   }
 
   void OccupancyTask::runOnTPDigis(EcalTrigPrimDigiCollection const& _digis) {
@@ -89,11 +89,11 @@ namespace ecaldqm {
       //       meTPDigiProjPhi.fill(id);
       //       meTPDigiAll.fill(id);
       if (digi.compressedEt() > tpThreshold_) {
-        meTPDigiThrProjEta.fill(id);
-        meTPDigiThrProjPhi.fill(id);
-        meTPDigiThrAll.fill(id);
-        meTPDigiThrAllByLumi.fill(id);
-        meTPDigiRCT.fill(id);
+        meTPDigiThrProjEta.fill(getEcalDQMSetupObjects(), id);
+        meTPDigiThrProjPhi.fill(getEcalDQMSetupObjects(), id);
+        meTPDigiThrAll.fill(getEcalDQMSetupObjects(), id);
+        meTPDigiThrAllByLumi.fill(getEcalDQMSetupObjects(), id);
+        meTPDigiRCT.fill(getEcalDQMSetupObjects(), id);
         if (id.subDet() == EcalBarrel)
           nFilteredEB += 1.;
         else
@@ -101,8 +101,8 @@ namespace ecaldqm {
       }
     });
 
-    meTrendNTPDigi.fill(EcalBarrel, double(timestamp_.iLumi), nFilteredEB);
-    meTrendNTPDigi.fill(EcalEndcap, double(timestamp_.iLumi), nFilteredEE);
+    meTrendNTPDigi.fill(getEcalDQMSetupObjects(), EcalBarrel, double(timestamp_.iLumi), nFilteredEB);
+    meTrendNTPDigi.fill(getEcalDQMSetupObjects(), EcalEndcap, double(timestamp_.iLumi), nFilteredEE);
   }
 
   void OccupancyTask::runOnRecHits(EcalRecHitCollection const& _hits, Collections _collection) {
@@ -126,15 +126,15 @@ namespace ecaldqm {
     std::for_each(_hits.begin(), _hits.end(), [&](EcalRecHitCollection::value_type const& hit) {
       DetId id(hit.id());
 
-      meRecHitAll.fill(id);
-      meRecHitProjEta.fill(id);
-      meRecHitProjPhi.fill(id);
+      meRecHitAll.fill(getEcalDQMSetupObjects(), id);
+      meRecHitProjEta.fill(getEcalDQMSetupObjects(), id);
+      meRecHitProjPhi.fill(getEcalDQMSetupObjects(), id);
 
       if (!hit.checkFlagMask(mask) && hit.energy() > recHitThreshold_) {
-        meRecHitThrProjEta.fill(id);
-        meRecHitThrProjPhi.fill(id);
-        meRecHitThrAll.fill(id);
-        meRecHitThrAllByLumi.fill(id);
+        meRecHitThrProjEta.fill(getEcalDQMSetupObjects(), id);
+        meRecHitThrProjPhi.fill(getEcalDQMSetupObjects(), id);
+        meRecHitThrAll.fill(getEcalDQMSetupObjects(), id);
+        meRecHitThrAllByLumi.fill(getEcalDQMSetupObjects(), id);
         nFiltered += 1.;
         bool isPlusFar(iSubdet == EcalBarrel ? (EBDetId(id).iphi() > 100 && EBDetId(id).iphi() < 280) : zside(id) > 0);
         if (isPlusFar)
@@ -144,10 +144,10 @@ namespace ecaldqm {
       }
     });
 
-    meRecHitThr1D.fill(iSubdet, nFiltered);
-    meTrendNRecHitThr.fill(iSubdet, double(timestamp_.iLumi), nFiltered);
-    meRecHitThrmvp.fill(iSubdet, nRHThrp, nRHThrm);
-    meRecHitThrpm.fill(iSubdet, nRHThrp - nRHThrm);
+    meRecHitThr1D.fill(getEcalDQMSetupObjects(), iSubdet, nFiltered);
+    meTrendNRecHitThr.fill(getEcalDQMSetupObjects(), iSubdet, double(timestamp_.iLumi), nFiltered);
+    meRecHitThrmvp.fill(getEcalDQMSetupObjects(), iSubdet, nRHThrp, nRHThrm);
+    meRecHitThrpm.fill(getEcalDQMSetupObjects(), iSubdet, nRHThrp - nRHThrm);
   }
 
   DEFINE_ECALDQM_WORKER(OccupancyTask);

--- a/DQM/EcalMonitorTasks/src/PNDiodeTask.cc
+++ b/DQM/EcalMonitorTasks/src/PNDiodeTask.cc
@@ -62,9 +62,9 @@ namespace ecaldqm {
                   _ids.end(),
                   [&](EcalElectronicsIdCollection::value_type const& id) {
                     if (id.towerId() == 69)
-                      meMEMErrors->fill(id.dccId() + 0.0, errorType);
+                      meMEMErrors->fill(getEcalDQMSetupObjects(), id.dccId() + 0.0, errorType);
                     else if (id.towerId() == 70)
-                      meMEMErrors->fill(id.dccId() + 0.5, errorType);
+                      meMEMErrors->fill(getEcalDQMSetupObjects(), id.dccId() + 0.5, errorType);
                     else {
                       edm::LogWarning("EcalDQM")
                           << "PNDiodeTask::runOnErrors : one of the ids in the electronics ID collection does not "
@@ -82,16 +82,16 @@ namespace ecaldqm {
     std::for_each(_digis.begin(), _digis.end(), [&](EcalPnDiodeDigiCollection::value_type const& digi) {
       const EcalPnDiodeDetId& id(digi.id());
 
-      if (!enable_[dccId(id) - 1])
+      if (!enable_[dccId(id, GetElectronicsMap()) - 1])
         return;
 
-      meOccupancy.fill(id);
-      meOccupancySummary.fill(id);
+      meOccupancy.fill(getEcalDQMSetupObjects(), id);
+      meOccupancySummary.fill(getEcalDQMSetupObjects(), id);
 
       for (int iSample(0); iSample < 4; iSample++) {
         if (digi.sample(iSample).gainId() != 1)
           break;
-        mePedestal.fill(id, double(digi.sample(iSample).adc()));
+        mePedestal.fill(getEcalDQMSetupObjects(), id, double(digi.sample(iSample).adc()));
       }
     });
   }

--- a/DQM/EcalMonitorTasks/src/PedestalTask.cc
+++ b/DQM/EcalMonitorTasks/src/PedestalTask.cc
@@ -65,7 +65,7 @@ namespace ecaldqm {
     for (typename DigiCollection::const_iterator digiItr(_digis.begin()); digiItr != _digis.end(); ++digiItr) {
       DetId id(digiItr->id());
 
-      int iDCC(dccId(id) - 1);
+      int iDCC(dccId(id, GetElectronicsMap()) - 1);
 
       if (!enable_[iDCC])
         continue;
@@ -96,10 +96,10 @@ namespace ecaldqm {
         static_cast<MESetMulti&>(mePedestal).use(iME);
       }
 
-      meOccupancy.fill(id);
+      meOccupancy.fill(getEcalDQMSetupObjects(), id);
 
       for (int iSample(0); iSample < EcalDataFrame::MAXSAMPLES; iSample++)
-        mePedestal.fill(id, double(dataFrame.sample(iSample).adc()));
+        mePedestal.fill(getEcalDQMSetupObjects(), id, double(dataFrame.sample(iSample).adc()));
     }
   }
 
@@ -111,7 +111,7 @@ namespace ecaldqm {
     for (EcalPnDiodeDigiCollection::const_iterator digiItr(_digis.begin()); digiItr != _digis.end(); ++digiItr) {
       EcalPnDiodeDetId id(digiItr->id());
 
-      int iDCC(dccId(id) - 1);
+      int iDCC(dccId(id, GetElectronicsMap()) - 1);
 
       if (!enable_[iDCC])
         continue;
@@ -137,7 +137,7 @@ namespace ecaldqm {
       }
 
       for (int iSample(0); iSample < 50; iSample++)
-        mePNPedestal.fill(id, double(digiItr->sample(iSample).adc()));
+        mePNPedestal.fill(getEcalDQMSetupObjects(), id, double(digiItr->sample(iSample).adc()));
     }
   }
 

--- a/DQM/EcalMonitorTasks/src/PresampleTask.cc
+++ b/DQM/EcalMonitorTasks/src/PresampleTask.cc
@@ -38,7 +38,7 @@ namespace ecaldqm {
       // 1 pt:10 LS in Trend plots
       mePedestalByLS = &MEs_.at("PedestalByLS");
       if (timestamp_.iLumi % 10 == 0)
-        mePedestalByLS->reset();
+        mePedestalByLS->reset(GetElectronicsMap());
     }
   }
 
@@ -74,8 +74,8 @@ namespace ecaldqm {
       }  // PulseMaxCheck
 
       for (int iSample(0); iSample < nSamples_; ++iSample) {
-        mePedestal.fill(id, double(dataFrame.sample(iSample).adc()));
-        mePedestalByLS->fill(id, double(dataFrame.sample(iSample).adc()));
+        mePedestal.fill(getEcalDQMSetupObjects(), id, double(dataFrame.sample(iSample).adc()));
+        mePedestalByLS->fill(getEcalDQMSetupObjects(), id, double(dataFrame.sample(iSample).adc()));
       }
 
     }  // _digis loop

--- a/DQM/EcalMonitorTasks/src/RawDataTask.cc
+++ b/DQM/EcalMonitorTasks/src/RawDataTask.cc
@@ -27,9 +27,9 @@ namespace ecaldqm {
     l1A_ = 0;
     feL1Offset_ = _evt.isRealData() ? 1 : 0;
     if (ByLumiResetSwitch) {
-      MEs_.at("DesyncByLumi").reset();
-      MEs_.at("FEByLumi").reset();
-      MEs_.at("FEStatusErrMapByLumi").reset();
+      MEs_.at("DesyncByLumi").reset(GetElectronicsMap());
+      MEs_.at("FEByLumi").reset(GetElectronicsMap());
+      MEs_.at("FEStatusErrMapByLumi").reset(GetElectronicsMap());
     }
   }
 
@@ -49,7 +49,7 @@ namespace ecaldqm {
       if (length > 1) {  // FED header is one 64 bit word
         const uint64_t* pData(reinterpret_cast<uint64_t const*>(fedData.data()));
         if ((pData[length - 1] & 0x4) != 0)
-          meCRC.fill(iFED - 600);
+          meCRC.fill(getEcalDQMSetupObjects(), iFED - 600);
       }
     }
   }
@@ -105,21 +105,21 @@ namespace ecaldqm {
       short dccL1AShort(dccL1A & 0xfff);
       int dccBX(dcchItr->getBX());
 
-      meOrbitDiff.fill(dccId, dcchItr->getOrbit() - orbit_);
-      meBXDCCDiff.fill(dccId, dccBX - bx_);
+      meOrbitDiff.fill(getEcalDQMSetupObjects(), dccId, dcchItr->getOrbit() - orbit_);
+      meBXDCCDiff.fill(getEcalDQMSetupObjects(), dccId, dccBX - bx_);
       if (dccBX == -1)
-        meBXFEInvalid.fill(dccId, 68.5);
+        meBXFEInvalid.fill(getEcalDQMSetupObjects(), dccId, 68.5);
 
       if (dcchItr->getRunNumber() != int(runNumber_))
-        meRunNumber.fill(dccId);
+        meRunNumber.fill(getEcalDQMSetupObjects(), dccId);
       if (dcchItr->getOrbit() != orbit_)
-        meOrbit.fill(dccId);
+        meOrbit.fill(getEcalDQMSetupObjects(), dccId);
       if (dcchItr->getBasicTriggerType() != triggerType_)
-        meTriggerType.fill(dccId);
+        meTriggerType.fill(getEcalDQMSetupObjects(), dccId);
       if (dccL1A != l1A_)
-        meL1ADCC.fill(dccId);
+        meL1ADCC.fill(getEcalDQMSetupObjects(), dccId);
       if (dccBX != bx_)
-        meBXDCC.fill(dccId);
+        meBXDCC.fill(getEcalDQMSetupObjects(), dccId);
 
       const vector<short>& feStatus(dcchItr->getFEStatus());
       const vector<short>& feBxs(dcchItr->getFEBxs());
@@ -135,21 +135,21 @@ namespace ecaldqm {
         short status(feStatus[iFE]);
 
         if (feBxs[iFE] != -1 && dccBX != -1) {
-          meBXFEDiff.fill(dccId, feBxs[iFE] - dccBX);
+          meBXFEDiff.fill(getEcalDQMSetupObjects(), dccId, feBxs[iFE] - dccBX);
         }
         if (feBxs[iFE] == -1)
-          meBXFEInvalid.fill(dccId, iFE + 0.5);
+          meBXFEInvalid.fill(getEcalDQMSetupObjects(), dccId, iFE + 0.5);
 
         if (status != BXDesync && status != L1ABXDesync) {  // BX desync not detected in the DCC
           if (feBxs[iFE] != dccBX && feBxs[iFE] != -1 && dccBX != -1) {
-            meBXFE.fill(dccId, iFE + 0.5);
+            meBXFE.fill(getEcalDQMSetupObjects(), dccId, iFE + 0.5);
             feDesync += 1.;
           }
         }
 
         if (status != L1ADesync && status != L1ABXDesync) {
           if (feL1s[iFE] + feL1Offset_ != dccL1AShort && feL1s[iFE] != -1 && dccL1AShort != 0) {
-            meL1AFE.fill(dccId, iFE + 0.5);
+            meL1AFE.fill(getEcalDQMSetupObjects(), dccId, iFE + 0.5);
             feDesync += 1.;
           }
         }
@@ -160,18 +160,18 @@ namespace ecaldqm {
           // bins correspond to towerId 69 and half integer
           // number bins correspond to towerId 70.
           if (iFE + 1 == 69)
-            meFEStatusMEM.fill(dccId + 0.0, status);
+            meFEStatusMEM.fill(getEcalDQMSetupObjects(), dccId + 0.0, status);
           else if (iFE + 1 == 70)
-            meFEStatusMEM.fill(dccId + 0.5, status);
+            meFEStatusMEM.fill(getEcalDQMSetupObjects(), dccId + 0.5, status);
           continue;
         }
 
-        DetId id(getElectronicsMap()->dccTowerConstituents(dccId, iFE + 1).at(0));
-        meFEStatus.fill(id, status);
+        DetId id(GetElectronicsMap()->dccTowerConstituents(dccId, iFE + 1).at(0));
+        meFEStatus.fill(getEcalDQMSetupObjects(), id, status);
         // Fill FE Status Error Map with error states only
         if (status != Enabled && status != Suppressed && status != FIFOFull && status != FIFOFullL1ADesync &&
             status != ForcedZS)
-          meFEStatusErrMapByLumi.fill(id, status);
+          meFEStatusErrMapByLumi.fill(getEcalDQMSetupObjects(), id, status);
 
         switch (status) {
           case Timeout:
@@ -192,12 +192,12 @@ namespace ecaldqm {
       }
 
       if (feDesync > 0.) {
-        meDesyncByLumi.fill(dccId, feDesync);
-        meDesyncTotal.fill(dccId, feDesync);
-        meTrendNSyncErrors.fill(double(timestamp_.iLumi), feDesync);
+        meDesyncByLumi.fill(getEcalDQMSetupObjects(), dccId, feDesync);
+        meDesyncTotal.fill(getEcalDQMSetupObjects(), dccId, feDesync);
+        meTrendNSyncErrors.fill(getEcalDQMSetupObjects(), double(timestamp_.iLumi), feDesync);
       }
       if (statusError > 0.)
-        meFEByLumi.fill(dccId, statusError);
+        meFEByLumi.fill(getEcalDQMSetupObjects(), dccId, statusError);
 
       const vector<short>& tccBx(dcchItr->getTCCBx());
       const vector<short>& tccL1(dcchItr->getTCCLv1());
@@ -206,17 +206,17 @@ namespace ecaldqm {
         if (dccId <= kEEmHigh + 1 || dccId >= kEEpLow + 1) {
           for (int iTCC(0); iTCC < 4; iTCC++) {
             if (tccBx[iTCC] != dccBX && tccBx[iTCC] != -1 && dccBX != -1)
-              meBXTCC.fill(dccId);
+              meBXTCC.fill(getEcalDQMSetupObjects(), dccId);
 
             if (tccL1[iTCC] != dccL1AShort && tccL1[iTCC] != -1 && dccL1AShort != 0)
-              meL1ATCC.fill(dccId);
+              meL1ATCC.fill(getEcalDQMSetupObjects(), dccId);
           }
         } else {
           if (tccBx[0] != dccBX && tccBx[0] != -1 && dccBX != -1)
-            meBXTCC.fill(dccId);
+            meBXTCC.fill(getEcalDQMSetupObjects(), dccId);
 
           if (tccL1[0] != dccL1AShort && tccL1[0] != -1 && dccL1AShort != 0)
-            meL1ATCC.fill(dccId);
+            meL1ATCC.fill(getEcalDQMSetupObjects(), dccId);
         }
       }
 
@@ -224,10 +224,10 @@ namespace ecaldqm {
       short srpL1(dcchItr->getSRPLv1());
 
       if (srpBx != dccBX && srpBx != -1 && dccBX != -1)
-        meBXSRP.fill(dccId);
+        meBXSRP.fill(getEcalDQMSetupObjects(), dccId);
 
       if (srpL1 != dccL1AShort && srpL1 != -1 && dccL1AShort != 0)
-        meL1ASRP.fill(dccId);
+        meL1ASRP.fill(getEcalDQMSetupObjects(), dccId);
 
       const int calibBX(3490);
 
@@ -235,11 +235,11 @@ namespace ecaldqm {
       if (runType < 0 || runType > 22)
         runType = 0;
       if (dccBX < calibBX)
-        meEventTypePreCalib.fill(dccId, runType, 1. / 54.);
+        meEventTypePreCalib.fill(getEcalDQMSetupObjects(), dccId, runType, 1. / 54.);
       else if (dccBX == calibBX)
-        meEventTypeCalib.fill(dccId, runType, 1. / 54.);
+        meEventTypeCalib.fill(getEcalDQMSetupObjects(), dccId, runType, 1. / 54.);
       else
-        meEventTypePostCalib.fill(dccId, runType, 1. / 54.);
+        meEventTypePostCalib.fill(getEcalDQMSetupObjects(), dccId, runType, 1. / 54.);
     }
   }
 

--- a/DQM/EcalMonitorTasks/src/RecoSummaryTask.cc
+++ b/DQM/EcalMonitorTasks/src/RecoSummaryTask.cc
@@ -63,7 +63,7 @@ namespace ecaldqm {
     int subdet(isBarrel ? EcalBarrel : EcalEndcap);
 
     for (EcalRecHitCollection::const_iterator hitItr(_hits.begin()); hitItr != _hits.end(); ++hitItr) {
-      meRecoFlag.fill(subdet, hitItr->recoFlag());
+      meRecoFlag.fill(getEcalDQMSetupObjects(), subdet, hitItr->recoFlag());
       float energy(hitItr->energy());
 
       int signedSubdet;
@@ -76,7 +76,7 @@ namespace ecaldqm {
         if (energy > 3.) {
           EBDetId ebId(hitItr->id());
           if (ebId.ieta() != 85)
-            meSwissCross->fill(EcalTools::swissCross(ebId, _hits, 0.));
+            meSwissCross->fill(getEcalDQMSetupObjects(), EcalTools::swissCross(ebId, _hits, 0.));
         }
 
         if (energy > maxE[0])
@@ -97,18 +97,18 @@ namespace ecaldqm {
       }
 
       if (energy > rechitThreshold) {
-        meChi2.fill(signedSubdet, hitItr->chi2());
-        meTime.fill(signedSubdet, hitItr->time());
+        meChi2.fill(getEcalDQMSetupObjects(), signedSubdet, hitItr->chi2());
+        meTime.fill(getEcalDQMSetupObjects(), signedSubdet, hitItr->time());
       }
     }
 
     if (isBarrel) {
-      meEnergyMax.fill(EcalBarrel, maxE[0]);
+      meEnergyMax.fill(getEcalDQMSetupObjects(), EcalBarrel, maxE[0]);
 
       ebHits_ = &_hits;
     } else {
-      meEnergyMax.fill(-EcalEndcap, maxE[0]);
-      meEnergyMax.fill(EcalEndcap, maxE[1]);
+      meEnergyMax.fill(getEcalDQMSetupObjects(), -EcalEndcap, maxE[0]);
+      meEnergyMax.fill(getEcalDQMSetupObjects(), EcalEndcap, maxE[1]);
 
       eeHits_ = &_hits;
     }
@@ -120,7 +120,7 @@ namespace ecaldqm {
     int subdet(_collections == kEBReducedRecHit ? EcalBarrel : EcalEndcap);
 
     for (EcalRecHitCollection::const_iterator hitItr(_hits.begin()); hitItr != _hits.end(); ++hitItr)
-      meRecoFlag.fill(subdet, hitItr->recoFlag());
+      meRecoFlag.fill(getEcalDQMSetupObjects(), subdet, hitItr->recoFlag());
   }
 
   void RecoSummaryTask::runOnBasicClusters(edm::View<reco::CaloCluster> const& _bcs, Collections _collection) {
@@ -148,7 +148,7 @@ namespace ecaldqm {
         EcalRecHitCollection::const_iterator hItr(hitCol->find(haf[iH].first));
         if (hItr == hitCol->end())
           continue;
-        meRecoFlag.fill(subdet, hItr->recoFlag());
+        meRecoFlag.fill(getEcalDQMSetupObjects(), subdet, hItr->recoFlag());
       }
     }
   }

--- a/DQM/EcalMonitorTasks/src/SelectiveReadoutTask.cc
+++ b/DQM/EcalMonitorTasks/src/SelectiveReadoutTask.cc
@@ -240,7 +240,8 @@ namespace ecaldqm {
       meHighIntPayload.fill(getEcalDQMSetupObjects(), EcalBarrel, nHighInt[0] * bytesPerCrystal / 1024. / nEBDCC);
       meLowIntPayload.fill(getEcalDQMSetupObjects(), EcalBarrel, nLowInt[0] * bytesPerCrystal / 1024. / nEBDCC);
     } else {
-      meHighIntPayload.fill(getEcalDQMSetupObjects(), -EcalEndcap, nHighInt[0] * bytesPerCrystal / 1024. / (nEEDCC / 2));
+      meHighIntPayload.fill(
+          getEcalDQMSetupObjects(), -EcalEndcap, nHighInt[0] * bytesPerCrystal / 1024. / (nEEDCC / 2));
       meHighIntPayload.fill(getEcalDQMSetupObjects(), EcalEndcap, nHighInt[1] * bytesPerCrystal / 1024. / (nEEDCC / 2));
       meLowIntPayload.fill(getEcalDQMSetupObjects(), -EcalEndcap, nLowInt[0] * bytesPerCrystal / 1024. / (nEEDCC / 2));
       meLowIntPayload.fill(getEcalDQMSetupObjects(), EcalEndcap, nLowInt[1] * bytesPerCrystal / 1024. / (nEEDCC / 2));

--- a/DQM/EcalMonitorTasks/src/SelectiveReadoutTask.cc
+++ b/DQM/EcalMonitorTasks/src/SelectiveReadoutTask.cc
@@ -74,8 +74,8 @@ namespace ecaldqm {
     // DCC event size
     for (int iFED(601); iFED <= 654; iFED++) {
       float size(_fedRaw.FEDData(iFED).size() / 1024.);
-      meDCCSize.fill(iFED - 600, size);
-      meDCCSizeProf.fill(iFED - 600, size);
+      meDCCSize.fill(getEcalDQMSetupObjects(), iFED - 600, size);
+      meDCCSizeProf.fill(getEcalDQMSetupObjects(), iFED - 600, size);
       if (iFED - 601 <= kEEmHigh)
         eemSize += size;
       else if (iFED - 601 >= kEEpLow)
@@ -84,9 +84,9 @@ namespace ecaldqm {
         ebSize += size;
     }
 
-    meEventSize.fill(-EcalEndcap, eemSize / 9.);
-    meEventSize.fill(EcalEndcap, eepSize / 9.);
-    meEventSize.fill(EcalBarrel, ebSize / 36.);
+    meEventSize.fill(getEcalDQMSetupObjects(), -EcalEndcap, eemSize / 9.);
+    meEventSize.fill(getEcalDQMSetupObjects(), EcalEndcap, eepSize / 9.);
+    meEventSize.fill(getEcalDQMSetupObjects(), EcalBarrel, ebSize / 36.);
   }
 
   void SelectiveReadoutTask::runOnRawData(EcalRawDataCollection const& _dcchs) {
@@ -113,7 +113,7 @@ namespace ecaldqm {
       DetId const& id(srf.id());
       int flag(srf.value());
 
-      meFlagCounterMap.fill(id);
+      meFlagCounterMap.fill(getEcalDQMSetupObjects(), id);
 
       unsigned iRU(-1);
       if (id.subdetId() == EcalTriggerTower)
@@ -124,24 +124,24 @@ namespace ecaldqm {
 
       switch (flag & ~EcalSrFlag::SRF_FORCED_MASK) {
         case EcalSrFlag::SRF_FULL:
-          meFullReadoutMap.fill(id);
+          meFullReadoutMap.fill(getEcalDQMSetupObjects(), id);
           nFR += 1.;
           break;
         case EcalSrFlag::SRF_ZS1:
-          meZS1Map.fill(id);
+          meZS1Map.fill(getEcalDQMSetupObjects(), id);
           // fallthrough
         case EcalSrFlag::SRF_ZS2:
-          meZSMap.fill(id);
+          meZSMap.fill(getEcalDQMSetupObjects(), id);
           break;
         default:
           break;
       }
 
       if (flag & EcalSrFlag::SRF_FORCED_MASK)
-        meRUForcedMap.fill(id);
+        meRUForcedMap.fill(getEcalDQMSetupObjects(), id);
     });
 
-    MEs_.at("FullReadout").fill(_col == kEBSrFlag ? EcalBarrel : EcalEndcap, nFR);
+    MEs_.at("FullReadout").fill(getEcalDQMSetupObjects(), _col == kEBSrFlag ? EcalBarrel : EcalEndcap, nFR);
   }
 
   template <typename DigiCollection>
@@ -222,14 +222,14 @@ namespace ecaldqm {
       bool highInterest((flags_[iRU] & ~EcalSrFlag::SRF_FORCED_MASK) == EcalSrFlag::SRF_FULL);
 
       if (highInterest) {
-        meHighIntOutput.fill(id, ZSFIRValue);
-        if (isEB || dccId(id) - 1 <= kEEmHigh)
+        meHighIntOutput.fill(getEcalDQMSetupObjects(), id, ZSFIRValue);
+        if (isEB || dccId(id, GetElectronicsMap()) - 1 <= kEEmHigh)
           nHighInt[0] += 1;
         else
           nHighInt[1] += 1;
       } else {
-        meLowIntOutput.fill(id, ZSFIRValue);
-        if (isEB || dccId(id) - 1 <= kEEmHigh)
+        meLowIntOutput.fill(getEcalDQMSetupObjects(), id, ZSFIRValue);
+        if (isEB || dccId(id, GetElectronicsMap()) - 1 <= kEEmHigh)
           nLowInt[0] += 1;
         else
           nLowInt[1] += 1;
@@ -237,13 +237,13 @@ namespace ecaldqm {
     }
 
     if (isEB) {
-      meHighIntPayload.fill(EcalBarrel, nHighInt[0] * bytesPerCrystal / 1024. / nEBDCC);
-      meLowIntPayload.fill(EcalBarrel, nLowInt[0] * bytesPerCrystal / 1024. / nEBDCC);
+      meHighIntPayload.fill(getEcalDQMSetupObjects(), EcalBarrel, nHighInt[0] * bytesPerCrystal / 1024. / nEBDCC);
+      meLowIntPayload.fill(getEcalDQMSetupObjects(), EcalBarrel, nLowInt[0] * bytesPerCrystal / 1024. / nEBDCC);
     } else {
-      meHighIntPayload.fill(-EcalEndcap, nHighInt[0] * bytesPerCrystal / 1024. / (nEEDCC / 2));
-      meHighIntPayload.fill(EcalEndcap, nHighInt[1] * bytesPerCrystal / 1024. / (nEEDCC / 2));
-      meLowIntPayload.fill(-EcalEndcap, nLowInt[0] * bytesPerCrystal / 1024. / (nEEDCC / 2));
-      meLowIntPayload.fill(EcalEndcap, nLowInt[1] * bytesPerCrystal / 1024. / (nEEDCC / 2));
+      meHighIntPayload.fill(getEcalDQMSetupObjects(), -EcalEndcap, nHighInt[0] * bytesPerCrystal / 1024. / (nEEDCC / 2));
+      meHighIntPayload.fill(getEcalDQMSetupObjects(), EcalEndcap, nHighInt[1] * bytesPerCrystal / 1024. / (nEEDCC / 2));
+      meLowIntPayload.fill(getEcalDQMSetupObjects(), -EcalEndcap, nLowInt[0] * bytesPerCrystal / 1024. / (nEEDCC / 2));
+      meLowIntPayload.fill(getEcalDQMSetupObjects(), EcalEndcap, nLowInt[1] * bytesPerCrystal / 1024. / (nEEDCC / 2));
     }
 
     unsigned iRU(isEB ? 0 : EcalTrigTowerDetId::kEBTotalTowers);
@@ -256,29 +256,29 @@ namespace ecaldqm {
 
       double towerSize(sizes[iTower] * bytesPerCrystal);
 
-      meTowerSize.fill(id, towerSize);
+      meTowerSize.fill(getEcalDQMSetupObjects(), id, towerSize);
 
       if (flags_[iRU] < 0)
         continue;
 
-      int dccid(dccId(id));
-      int towerid(towerId(id));
+      int dccid(dccId(id, GetElectronicsMap()));
+      int towerid(towerId(id, GetElectronicsMap()));
 
       if (suppressed_.find(std::make_pair(dccid, towerid)) != suppressed_.end())
         continue;
 
       int flag(flags_[iRU] & ~EcalSrFlag::SRF_FORCED_MASK);
 
-      bool ruFullyReadout(sizes[iTower] == getElectronicsMap()->dccTowerConstituents(dccid, towerid).size());
+      bool ruFullyReadout(sizes[iTower] == GetElectronicsMap()->dccTowerConstituents(dccid, towerid).size());
 
       if (ruFullyReadout && (flag == EcalSrFlag::SRF_ZS1 || flag == EcalSrFlag::SRF_ZS2)) {
-        meZSFullReadoutMap.fill(id);
-        meZSFullReadout.fill(id);
+        meZSFullReadoutMap.fill(getEcalDQMSetupObjects(), id);
+        meZSFullReadout.fill(getEcalDQMSetupObjects(), id);
       }
 
       if (sizes[iTower] == 0 && flag == EcalSrFlag::SRF_FULL) {
-        meFRDroppedMap.fill(id);
-        meFRDropped.fill(id);
+        meFRDroppedMap.fill(getEcalDQMSetupObjects(), id);
+        meFRDropped.fill(getEcalDQMSetupObjects(), id);
       }
     }
   }

--- a/DQM/EcalMonitorTasks/src/TestPulseTask.cc
+++ b/DQM/EcalMonitorTasks/src/TestPulseTask.cc
@@ -102,9 +102,9 @@ namespace ecaldqm {
     for (typename DigiCollection::const_iterator digiItr(_digis.begin()); digiItr != _digis.end(); ++digiItr) {
       DetId id(digiItr->id());
 
-      meOccupancy.fill(id);
+      meOccupancy.fill(getEcalDQMSetupObjects(), id);
 
-      int iDCC(dccId(id) - 1);
+      int iDCC(dccId(id, GetElectronicsMap()) - 1);
 
       if (!enable_[iDCC])
         continue;
@@ -118,7 +118,7 @@ namespace ecaldqm {
       }
 
       for (int iSample(0); iSample < 10; iSample++)
-        meShape.fill(id, iSample + 0.5, float(dataFrame.sample(iSample).adc()));
+        meShape.fill(getEcalDQMSetupObjects(), id, iSample + 0.5, float(dataFrame.sample(iSample).adc()));
     }
   }
 
@@ -130,7 +130,7 @@ namespace ecaldqm {
     for (EcalPnDiodeDigiCollection::const_iterator digiItr(_digis.begin()); digiItr != _digis.end(); ++digiItr) {
       EcalPnDiodeDetId const& id(digiItr->id());
 
-      int iDCC(dccId(id) - 1);
+      int iDCC(dccId(id, GetElectronicsMap()) - 1);
 
       if (!enable_[iDCC])
         continue;
@@ -167,7 +167,7 @@ namespace ecaldqm {
 
       double amplitude(max - pedestal);
 
-      mePNAmplitude.fill(id, amplitude);
+      mePNAmplitude.fill(getEcalDQMSetupObjects(), id, amplitude);
     }
   }
 
@@ -179,7 +179,7 @@ namespace ecaldqm {
     for (EcalUncalibratedRecHitCollection::const_iterator uhitItr(_uhits.begin()); uhitItr != _uhits.end(); ++uhitItr) {
       DetId id(uhitItr->id());
 
-      int iDCC(dccId(id) - 1);
+      int iDCC(dccId(id, GetElectronicsMap()) - 1);
 
       if (!enable_[iDCC])
         continue;
@@ -189,7 +189,7 @@ namespace ecaldqm {
         static_cast<MESetMulti&>(meAmplitude).use(iME);
       }
 
-      meAmplitude.fill(id, uhitItr->amplitude());
+      meAmplitude.fill(getEcalDQMSetupObjects(), id, uhitItr->amplitude());
     }
   }
 

--- a/DQM/EcalMonitorTasks/src/TimingTask.cc
+++ b/DQM/EcalMonitorTasks/src/TimingTask.cc
@@ -54,7 +54,7 @@ namespace ecaldqm {
     if (ByLumiResetSwitch) {
       meTimeMapByLS = &MEs_.at("TimeMapByLS");
       if (timestamp_.iLumi % 10 == 0)
-        meTimeMapByLS->reset();
+        meTimeMapByLS->reset(GetElectronicsMap());
     }
   }
 
@@ -100,7 +100,7 @@ namespace ecaldqm {
       }
 
       if (energy > energyThreshold)
-        meChi2.fill(signedSubdet, hit.chi2());
+        meChi2.fill(getEcalDQMSetupObjects(), signedSubdet, hit.chi2());
 
       // Apply cut on chi2 of pulse shape fit
       if (hit.chi2() > chi2Threshold)
@@ -110,18 +110,18 @@ namespace ecaldqm {
       if (hit.timeError() > timeErrorThreshold_)
         return;
 
-      meTimeAmp.fill(id, energy, time);
-      meTimeAmpAll.fill(id, energy, time);
+      meTimeAmp.fill(getEcalDQMSetupObjects(), id, energy, time);
+      meTimeAmpAll.fill(getEcalDQMSetupObjects(), id, energy, time);
 
       if (energy > timingVsBXThreshold_ && signedSubdet == EcalBarrel)
-        meTimingVsBX.fill(bxBin_, time);
+        meTimingVsBX.fill(getEcalDQMSetupObjects(), bxBin_, time);
 
       if (energy > energyThreshold) {
-        meTimeAll.fill(id, time);
-        meTimeMap.fill(id, time);
-        meTimeMapByLS->fill(id, time);
-        meTime1D.fill(id, time);
-        meTimeAllMap.fill(id, time);
+        meTimeAll.fill(getEcalDQMSetupObjects(), id, time);
+        meTimeMap.fill(getEcalDQMSetupObjects(), id, time);
+        meTimeMapByLS->fill(getEcalDQMSetupObjects(), id, time);
+        meTime1D.fill(getEcalDQMSetupObjects(), id, time);
+        meTimeAllMap.fill(getEcalDQMSetupObjects(), id, time);
       }
     });
   }
@@ -163,8 +163,8 @@ namespace ecaldqm {
         continue;
 
       // Fill MEs
-      meTimeAmpBXm.fill(id, amp, uhitItr->outOfTimeAmplitude(4));  // BX-1
-      meTimeAmpBXp.fill(id, amp, uhitItr->outOfTimeAmplitude(6));  // BX+1
+      meTimeAmpBXm.fill(getEcalDQMSetupObjects(), id, amp, uhitItr->outOfTimeAmplitude(4));  // BX-1
+      meTimeAmpBXp.fill(getEcalDQMSetupObjects(), id, amp, uhitItr->outOfTimeAmplitude(6));  // BX+1
     }
   }
 

--- a/DQM/EcalMonitorTasks/src/TrigPrimTask.cc
+++ b/DQM/EcalMonitorTasks/src/TrigPrimTask.cc
@@ -62,9 +62,9 @@ namespace ecaldqm {
     towerReadouts_.clear();
 
     if (ByLumiResetSwitch) {
-      MEs_.at("EtSummaryByLumi").reset();
-      MEs_.at("TTFlags4ByLumi").reset();
-      MEs_.at("LHCStatusByLumi").reset(-1);
+      MEs_.at("EtSummaryByLumi").reset(GetElectronicsMap());
+      MEs_.at("TTFlags4ByLumi").reset(GetElectronicsMap());
+      MEs_.at("LHCStatusByLumi").reset(GetElectronicsMap(), -1);
     }
 
     if (!lhcStatusSet) {
@@ -73,7 +73,7 @@ namespace ecaldqm {
       edm::Handle<TCDSRecord> tcdsData;
       _evt.getByToken(lhcStatusInfoRecordToken_, tcdsData);
       if (tcdsData.isValid()) {
-        meLHCStatusByLumi.fill(double(tcdsData->getBST().getBeamMode()));
+        meLHCStatusByLumi.fill(getEcalDQMSetupObjects(), double(tcdsData->getBST().getBeamMode()));
         lhcStatusSet = true;
       }
     }
@@ -102,7 +102,7 @@ namespace ecaldqm {
       if ((*ttItr).second > 0) {
         const EcalTrigTowerDetId ttid((*ttItr).first);
         //if(ttid.subDet() == EcalBarrel)
-        meTTMaskMap.fill(ttid, 1);
+        meTTMaskMap.fill(getEcalDQMSetupObjects(), ttid, 1);
       }  //masked
     }    //loop on towers
 
@@ -110,7 +110,7 @@ namespace ecaldqm {
       if ((*stItr).second > 0) {
         const EcalElectronicsId stid((*stItr).first);
         //if(stid.subdet() == EcalEndcap);
-        meTTMaskMap.fill(stid, 1);
+        meTTMaskMap.fill(getEcalDQMSetupObjects(), stid, 1);
       }  //masked
     }    //loop on pseudo-strips
 
@@ -173,7 +173,7 @@ namespace ecaldqm {
   template <typename DigiCollection>
   void TrigPrimTask::runOnDigis(DigiCollection const& _digis) {
     for (typename DigiCollection::const_iterator digiItr(_digis.begin()); digiItr != _digis.end(); ++digiItr) {
-      EcalTrigTowerDetId ttid(getTrigTowerMap()->towerOf(digiItr->id()));
+      EcalTrigTowerDetId ttid(GetTrigTowerMap()->towerOf(digiItr->id()));
       towerReadouts_[ttid.rawId()]++;
     }
   }
@@ -213,25 +213,25 @@ namespace ecaldqm {
           nTP[1] += 1.;
         else
           nTP[2] += 2.;
-        meEtVsBx.fill(ttid, bxBin_, et);
+        meEtVsBx.fill(getEcalDQMSetupObjects(), ttid, bxBin_, et);
       }
 
-      meEtReal.fill(ttid, et);
-      meEtRealMap.fill(ttid, et);
-      meEtSummary.fill(ttid, et);
-      meEtSummaryByLumi.fill(ttid, et);
+      meEtReal.fill(getEcalDQMSetupObjects(), ttid, et);
+      meEtRealMap.fill(getEcalDQMSetupObjects(), ttid, et);
+      meEtSummary.fill(getEcalDQMSetupObjects(), ttid, et);
+      meEtSummaryByLumi.fill(getEcalDQMSetupObjects(), ttid, et);
 
       int interest(tpItr->ttFlag() & 0x3);
 
       switch (interest) {
         case 0:
-          meLowIntMap.fill(ttid);
+          meLowIntMap.fill(getEcalDQMSetupObjects(), ttid);
           break;
         case 1:
-          meMedIntMap.fill(ttid);
+          meMedIntMap.fill(getEcalDQMSetupObjects(), ttid);
           break;
         case 3:
-          meHighIntMap.fill(ttid);
+          meHighIntMap.fill(getEcalDQMSetupObjects(), ttid);
           break;
         default:
           break;
@@ -239,21 +239,21 @@ namespace ecaldqm {
 
       // Fill TT Flag MEs
       int ttF(tpItr->ttFlag());
-      meTTFlags.fill(ttid, 1.0 * ttF);
-      meTTFlagsVsEt.fill(ttid, et, 1.0 * ttF);
+      meTTFlags.fill(getEcalDQMSetupObjects(), ttid, 1.0 * ttF);
+      meTTFlagsVsEt.fill(getEcalDQMSetupObjects(), ttid, et, 1.0 * ttF);
       // Monitor occupancy of TTF=4
       // which contains info about TT auto-masking
       if (ttF >= 4) {
-        meTTFlags4.fill(ttid);
-        meTTFlags4ByLumi.fill(ttid);
+        meTTFlags4.fill(getEcalDQMSetupObjects(), ttid);
+        meTTFlags4ByLumi.fill(getEcalDQMSetupObjects(), ttid);
       }
-      if ((ttF == 1 || ttF == 3) && towerReadouts_[ttid.rawId()] != getTrigTowerMap()->constituentsOf(ttid).size())
-        meTTFMismatch.fill(ttid);
+      if ((ttF == 1 || ttF == 3) && towerReadouts_[ttid.rawId()] != GetTrigTowerMap()->constituentsOf(ttid).size())
+        meTTFMismatch.fill(getEcalDQMSetupObjects(), ttid);
     }
 
-    meOccVsBx.fill(EcalBarrel, bxBin_, nTP[0]);
-    meOccVsBx.fill(-EcalEndcap, bxBin_, nTP[1]);
-    meOccVsBx.fill(EcalEndcap, bxBin_, nTP[2]);
+    meOccVsBx.fill(getEcalDQMSetupObjects(), EcalBarrel, bxBin_, nTP[0]);
+    meOccVsBx.fill(getEcalDQMSetupObjects(), -EcalEndcap, bxBin_, nTP[1]);
+    meOccVsBx.fill(getEcalDQMSetupObjects(), EcalEndcap, bxBin_, nTP[2]);
 
     // Set TT/Strip Masking status in Ecal3P view
     // Status Records are read-in at beginRun() but filled here
@@ -266,7 +266,7 @@ namespace ecaldqm {
     for (EcalTPGTowerStatusMap::const_iterator ttItr(TTStatusMap.begin()); ttItr != TTStatusMap.end(); ++ttItr) {
       const EcalTrigTowerDetId ttid(ttItr->first);
       if (ttItr->second > 0)
-        meTTMaskMapAll.setBinContent(ttid, 1);  // TT is masked
+        meTTMaskMapAll.setBinContent(getEcalDQMSetupObjects(), ttid, 1);  // TT is masked
     }                                           // TTs
 
     // Fill from Strip Status Rcd
@@ -276,9 +276,9 @@ namespace ecaldqm {
       const EcalTriggerElectronicsId stid(stItr->first);
       // Since ME has kTriggerTower binning, convert to EcalTrigTowerDetId first
       // In principle, setBinContent() could be implemented for EcalTriggerElectronicsId class as well
-      const EcalTrigTowerDetId ttid(getElectronicsMap()->getTrigTowerDetId(stid.tccId(), stid.ttId()));
+      const EcalTrigTowerDetId ttid(GetElectronicsMap()->getTrigTowerDetId(stid.tccId(), stid.ttId()));
       if (stItr->second > 0)
-        meTTMaskMapAll.setBinContent(ttid, 1);  // PseudoStrip is masked
+        meTTMaskMapAll.setBinContent(getEcalDQMSetupObjects(), ttid, 1);  // PseudoStrip is masked
     }                                           // PseudoStrips
 
   }  // TrigPrimTask::runOnRealTPs()
@@ -307,9 +307,9 @@ namespace ecaldqm {
         }
       }
 
-      meEtMaxEmul.fill(ttid, maxEt);
+      meEtMaxEmul.fill(getEcalDQMSetupObjects(), ttid, maxEt);
       if (maxEt > 0.)
-        meEmulMaxIndex.fill(ttid, iMax);
+        meEmulMaxIndex.fill(getEcalDQMSetupObjects(), ttid, iMax);
 
       bool match(true);
       bool matchFG(true);
@@ -324,7 +324,7 @@ namespace ecaldqm {
         if (realEt > 0) {
           int ttF(realItr->ttFlag());
           if ((ttF == 1 || ttF == 3) &&
-              towerReadouts_[ttid.rawId()] == getTrigTowerMap()->constituentsOf(ttid).size()) {
+              towerReadouts_[ttid.rawId()] == GetTrigTowerMap()->constituentsOf(ttid).size()) {
             if (et != realEt)
               match = false;
             if (tpItr->fineGrain() != realItr->fineGrain())
@@ -354,12 +354,12 @@ namespace ecaldqm {
               matchedIndex.push_back(0);  // no Et match found => no emul
 
             // Fill Real vs Emulated TP Et
-            meRealvEmulEt.fill(ttid, realEt, (*tpItr)[2].compressedEt());  // iDigi=2:in-time BX
+            meRealvEmulEt.fill(getEcalDQMSetupObjects(), ttid, realEt, (*tpItr)[2].compressedEt());  // iDigi=2:in-time BX
 
             // Fill matchedIndex ME
             for (std::vector<int>::iterator matchItr(matchedIndex.begin()); matchItr != matchedIndex.end();
                  ++matchItr) {
-              meMatchedIndex.fill(ttid, *matchItr + 0.5);
+              meMatchedIndex.fill(getEcalDQMSetupObjects(), ttid, *matchItr + 0.5);
 
               // timing information is only within emulated TPs (real TPs have one time sample)
               //      if(HLTCaloBit_) MEs_[kTimingCalo].fill(ttid, float(*matchItr));
@@ -373,9 +373,9 @@ namespace ecaldqm {
       }
 
       if (!match)
-        meEtEmulError.fill(ttid);
+        meEtEmulError.fill(getEcalDQMSetupObjects(), ttid);
       if (!matchFG)
-        meFGEmulError.fill(ttid);
+        meFGEmulError.fill(getEcalDQMSetupObjects(), ttid);
     }
   }
 

--- a/DQM/EcalMonitorTasks/src/TrigPrimTask.cc
+++ b/DQM/EcalMonitorTasks/src/TrigPrimTask.cc
@@ -267,7 +267,7 @@ namespace ecaldqm {
       const EcalTrigTowerDetId ttid(ttItr->first);
       if (ttItr->second > 0)
         meTTMaskMapAll.setBinContent(getEcalDQMSetupObjects(), ttid, 1);  // TT is masked
-    }                                           // TTs
+    }                                                                     // TTs
 
     // Fill from Strip Status Rcd
     const EcalTPGStripStatus* StripStatus(StripStatusRcd.product());
@@ -279,7 +279,7 @@ namespace ecaldqm {
       const EcalTrigTowerDetId ttid(GetElectronicsMap()->getTrigTowerDetId(stid.tccId(), stid.ttId()));
       if (stItr->second > 0)
         meTTMaskMapAll.setBinContent(getEcalDQMSetupObjects(), ttid, 1);  // PseudoStrip is masked
-    }                                           // PseudoStrips
+    }                                                                     // PseudoStrips
 
   }  // TrigPrimTask::runOnRealTPs()
 
@@ -354,7 +354,8 @@ namespace ecaldqm {
               matchedIndex.push_back(0);  // no Et match found => no emul
 
             // Fill Real vs Emulated TP Et
-            meRealvEmulEt.fill(getEcalDQMSetupObjects(), ttid, realEt, (*tpItr)[2].compressedEt());  // iDigi=2:in-time BX
+            meRealvEmulEt.fill(
+                getEcalDQMSetupObjects(), ttid, realEt, (*tpItr)[2].compressedEt());  // iDigi=2:in-time BX
 
             // Fill matchedIndex ME
             for (std::vector<int>::iterator matchItr(matchedIndex.begin()); matchItr != matchedIndex.end();


### PR DESCRIPTION
#### PR description:

An issue with with the access and storage of database variables in the ECAL DQM code was brought up here: https://github.com/cms-sw/cmssw/issues/28858

Inside EcalDQMCommonUtils.cc, there were 4 variables defined globally that saved pointers from EventSetup and made these variables accessible through global functions. The code attempted to make this thread safe by implementing a mutex.

```
std::mutex mapMutex;
EcalElectronicsMapping const *electronicsMap(nullptr);
EcalTrigTowerConstituentsMap const *trigtowerMap(nullptr);
CaloGeometry const *geometry(nullptr);
CaloTopology const *topology(nullptr);
```

There were several issues with this:

1: Functions like getElectronicsMap() do not lock the mutex before accessing the global variable, leading to a potential data race with potentially undefined behavior.

2: CMSSW is moving to rely more on multi-threaded processing, and objects such as a mutex lead to blocking and poor multi-threading performance.

3: This approach does not support data that needs to be updated at IOV boundaries, which is a potential issue.

4: This violates rule 7-1 of CMS coding and style rules: “Do not use mutable global data (no globals).

5: This created dependencies between the modules that required them to be executed in a specific order that is not easy for developers to understand. 

This PR removes the global variables and instead makes them member variables of each module. Most of this is done by defining the variables inside DQWorker, a class that the majority of ECAL DQM modules inherit from. 

There are a few exceptions inside DQM/EcalMonitorDbModule, where some variables had to be defined separately for specific plugins that could not inherit easily from DQWorker. 

A side effect of this approach is that a large portion of DQM/EcalCommon needed to be modified. Most of (if not all) of the classes defined here heavily relied on the fact that these variables were accessible from global functions. Now, the variables have to passed to every function that needs them, as the classes and functions here no longer had free access to these values.

Many of the functions inside MESet and its derived classes required multiple variables in order to work. For neatness, a struct was created, EcalDQMSetupObjects, that can pass all the variables at once, rather than having to pass 2, 3, or 4 additional variables to a given function.

In addition, overloaded functions, such as fill() for each MESet, had some versions that used the old global setup variables and some that didn’t. To avoid the compiler choosing the incorrect function during overload resolutions, each fill function (and other overloaded functions) is now passed a copy of these variables. 

For example, these first two fill functions use the setup variables 
```
void fill(EcalDQMSetupObjects const, DetId const &, double = 1., double = 0., double = 0.) override;
void fill(EcalDQMSetupObjects const, EcalElectronicsId const &, double = 1., double = 0., double = 0.) override;
```

While this third one does not, but is passed to them anyway.
```
void fill(EcalDQMSetupObjects const, int, double = 1., double = 1., double = 1.) override;
```

This is to avoid the compiler type casting a DetId or and EcalElectronicsId into an int. Otherwise, a call such as fill(detid) would compile but lead to undefined behavior and a crash at runtime, with the error not easy to spot.

In the end, each module now contains a copy of the EventSetup pointers and passes them to the EcalCommon functions that require them. As a toy example,
```
meSet.fill(GetEcalDQMSetupObjects(), detid);
```

#### PR validation:

The fix was validated on both physics and calibration ECAL online DQM-like workflows using data from 2018 pp collisions in stable beams. The output was compared to the output of the old code to ensure that there were no changes to the plots. This was checked using a private Online DQM GUI, checking every ECAL layout and ensuring that every plot was identical before and after this fix was implemented.

The fix was also validated on a full offline DQM relval workflow 136.874 using the runTheMatrix script
```
runTheMatrix.py -l 136.874 --ibeos
```
The output was compared before and after the fix using a private Offline DQM GUI, again checking every layout and plot and seeing no changes.

The memory usage was also compared before and after using the dqmStoreStats utility https://github.com/cms-sw/cmssw/blob/master/DQMServices/Components/python/DQMStoreStats_cfi.py as well as the SimpleMemoryCheck service https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideEDMTimingAndMemory#SimpleMemoryCheck_service. The difference in peak memory usage increased by 40kb during processing, which we deemed to be negligible.