### PR TITLE
Update HLT/HLT relval/Express/Prompt GTs

### DIFF
--- a/Alignment/OfflineValidation/test/testPVValidation.ini
+++ b/Alignment/OfflineValidation/test/testPVValidation.ini
@@ -24,7 +24,7 @@ ttrhtype: WithAngleAndTemplate
 
 [Conditions:PromptGT]
 jobname: testingPromptGT
-gt: auto:run3_data_promptlike
+gt: auto:run3_data_prompt
 allFromGT: True
 applyextracond: False
 alignmentdb: frontier://FrontierProd/CMS_CONDITIONS

--- a/CondTools/DQM/test/DQMXMLFileEventSetupAnalyzer_cfg.py
+++ b/CondTools/DQM/test/DQMXMLFileEventSetupAnalyzer_cfg.py
@@ -22,7 +22,7 @@ options.parseArguments()
 ####################################################################
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
 from Configuration.AlCa.GlobalTag import GlobalTag
-process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:run3_data_promptlike', '')
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:run3_data_prompt', '')
 #process.GlobalTag.DumpStat = cms.untracked.bool(True)  # optional if you want it to be verbose
 
 # import of standard configurations

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -25,8 +25,6 @@ autoCond = {
     'run2_mc_hi'        :   '113X_mcRun2_HeavyIon_v3',
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2
     'run2_mc_pa'        :   '113X_mcRun2_pA_v3',
-    # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   '113X_dataRun2_v4',
     # GlobalTag for Run2 data reprocessing
     'run2_data'         :   '113X_dataRun2_v4',
     # GlobalTag for Run2 data 2018B relvals only: HEM-15-16 fail
@@ -37,8 +35,6 @@ autoCond = {
     'run2_data_promptlike_hi' : '113X_dataRun2_PromptLike_HI_v4',
     # GlobalTag for Run3 HLT: it points to the online GT
     'run3_hlt'          :   '112X_dataRun3_HLT_v2',
-    # GlobalTag with fixed snapshot time for Run1 HLT RelVals: customizations to run with fixed L1 Menu
-    'run1_hlt_relval'   :   '112X_dataRun2_HLT_relval_v5',
     # GlobalTag with fixed snapshot time for Run2 HLT RelVals: customizations to run with fixed L1 Menu
     'run2_hlt_relval'   :   '112X_dataRun2_HLT_relval_v5',
     # GlobalTag for Run3 data relvals (express GT)
@@ -87,6 +83,12 @@ aliases = {
     'MAINGT' : 'FT_P_V42D|AN_V4',
     'BASEGT' : 'BASE1_V1|BASE2_V1'
 }
+
+### Run 1 data GTs ###
+    # GlobalTag with fixed snapshot time for Run1 HLT RelVals: customizations to run with fixed L1 Menu
+autoCond['run1_hlt_relval']  = autoCond['run2_hlt_relval']
+    # GlobalTag for Run1 data reprocessing
+autoCond['run1_data']        = autoCond['run2_data']
 
 # dedicated GlobalTags for HLT
 from Configuration.HLT.autoCondHLT import autoCondHLT

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -42,9 +42,9 @@ autoCond = {
     # GlobalTag with fixed snapshot time for Run2 HLT RelVals: customizations to run with fixed L1 Menu
     'run2_hlt_relval'   :   '112X_dataRun2_HLT_relval_v5',
     # GlobalTag for Run3 data relvals (express GT)
-    'run3_data_express'        :   '112X_dataRun3_Express_v3',
+    'run3_data_express'        :   '112X_dataRun3_Express_v4',
     # GlobalTag for Run3 data relvals
-    'run3_data_promptlike'     :   '112X_dataRun3_Prompt_v3',
+    'run3_data_promptlike'     :   '112X_dataRun3_Prompt_v4',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,~0-centred beamspot)
     'phase1_2017_design'       :  '113X_mc2017_design_v4',
     # GlobalTag for MC production with realistic conditions for Phase1 2017 detector

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -35,15 +35,12 @@ autoCond = {
     'run2_data_relval'  :   '113X_dataRun2_relval_v4',
     # GlobalTag for Run2 HI data
     'run2_data_promptlike_hi' : '113X_dataRun2_PromptLike_HI_v4',
-    # GlobalTag for Run1 HLT: it points to the online GT
-    'run1_hlt'          :   '101X_dataRun2_HLT_frozen_v11',
-    # GlobalTag for Run2 HLT: it points to the online GT
-    'run2_hlt'          :   '101X_dataRun2_HLT_frozen_v11',
-    # GlobalTag for Run2 HLT RelVals: customizations to run with fixed L1 Menu
-    'run2_hlt_relval'      :   '112X_dataRun2_HLT_relval_v4',
-    'run2_hlt_relval_hi'   :   '112X_dataRun2_HLT_relval_HI_v3',
-    # GlobalTag for Run2 HLT for HI (not 2018 HI): it points to the online GT
-    'run2_hlt_hi'       :   '101X_dataRun2_HLTHI_frozen_v11',
+    # GlobalTag for Run3 HLT: it points to the online GT
+    'run3_hlt'          :   '112X_dataRun3_HLT_v2',
+    # GlobalTag with fixed snapshot time for Run1 HLT RelVals: customizations to run with fixed L1 Menu
+    'run1_hlt_relval'   :   '112X_dataRun2_HLT_relval_v5',
+    # GlobalTag with fixed snapshot time for Run2 HLT RelVals: customizations to run with fixed L1 Menu
+    'run2_hlt_relval'   :   '112X_dataRun2_HLT_relval_v5',
     # GlobalTag for Run3 data relvals (express GT)
     'run3_data_express'        :   '112X_dataRun3_Express_v3',
     # GlobalTag for Run3 data relvals
@@ -103,6 +100,10 @@ autoCond = autoCondPhase2(autoCond)
 from Configuration.AlCa.autoCondModifiers import autoCond0T
 autoCond = autoCond0T(autoCond)
 
+# special GT for 2015 HLT HI run
+from Configuration.AlCa.autoCondModifiers import autoCondHLTHI
+autoCond = autoCondHLTHI(autoCond)
+
 ### OLD KEYS ### kept for backward compatibility
     # GlobalTag for MC production with perfectly aligned and calibrated detector
 autoCond['mc']               = ( autoCond['run1_design'] )
@@ -115,7 +116,7 @@ autoCond['startpa']          = ( autoCond['run1_mc_pa'] )
     # GlobalTag for data reprocessing
 autoCond['com10']            = ( autoCond['run1_data'] )
     # GlobalTag for running HLT on recent data: it points to the online GT (remove the snapshot!)
-autoCond['hltonline']        = ( autoCond['run1_hlt'] )
+autoCond['hltonline']        = ( autoCond['run3_hlt'] )
     # GlobalTag for POSTLS1 upgrade studies:
 autoCond['upgradePLS1']      = ( autoCond['run2_mc'] )
 autoCond['upgradePLS150ns']  = ( autoCond['run2_mc_50ns'] )

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -40,7 +40,7 @@ autoCond = {
     # GlobalTag for Run3 data relvals (express GT)
     'run3_data_express'        :   '112X_dataRun3_Express_v4',
     # GlobalTag for Run3 data relvals
-    'run3_data_promptlike'     :   '112X_dataRun3_Prompt_v4',
+    'run3_data_prompt'         :   '112X_dataRun3_Prompt_v4',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,~0-centred beamspot)
     'phase1_2017_design'       :  '113X_mc2017_design_v4',
     # GlobalTag for MC production with realistic conditions for Phase1 2017 detector

--- a/Configuration/AlCa/python/autoCondModifiers.py
+++ b/Configuration/AlCa/python/autoCondModifiers.py
@@ -11,8 +11,23 @@ def autoCond0T(autoCond):
     ConditionsFor0T =  ','.join( ['RunInfo_0T_v1_mc', "RunInfoRcd", connectionString, "", "2020-07-01 12:00:00.000"] )
     GlobalTags0T = {}
     for key,val in six.iteritems(autoCond):
-        if "phase" in key:    # restric to phase1 upgrade GTs
+        if "phase" in key:    # restrict to phase1 upgrade GTs
             GlobalTags0T[key+"_0T"] = (autoCond[key], ConditionsFor0T)
 
     autoCond.update(GlobalTags0T)
+    return autoCond
+
+def autoCondHLTHI(autoCond):
+
+    GlobalTagsHLTHI = {}
+
+    # emulate hybrid ZeroSuppression on the VirginRaw data of 2015
+    FullPedestalsForHLTHI =  ','.join( ['SiStripFullPedestals_GR10_v1_hlt', "SiStripPedestalsRcd", connectionString, "", "2021-03-11 12:00:00.000"] )
+    MenuForHLTHI =  ','.join( ['L1Menu_CollisionsHeavyIons2015_v5_uGT_xml', "L1TUtmTriggerMenuRcd", connectionString, "", "2021-03-11 12:00:00.000"] )
+
+    for key,val in six.iteritems(autoCond):
+        if key == 'run2_hlt_relval':    # modification of HLT relval GT
+            GlobalTagsHLTHI['run2_hlt_hi'] = (autoCond[key], FullPedestalsForHLTHI, MenuForHLTHI)
+
+    autoCond.update(GlobalTagsHLTHI)
     return autoCond

--- a/Configuration/HLT/python/autoCondHLT.py
+++ b/Configuration/HLT/python/autoCondHLT.py
@@ -45,7 +45,7 @@ hltGTs = {
     'run2_hlt_Fake2'         : ('run2_hlt_relval'         ,l1Menus['Fake2']),
     'run3_hlt_FULL'          : ('run2_hlt_relval'         ,l1Menus['FULL']),
     'run3_hlt_GRun'          : ('run2_hlt_relval'         ,l1Menus['GRun']),
-    'run3_hlt_HIon'          : ('run2_hlt_relval_hi'      ,l1Menus['HIon']),
+    'run3_hlt_HIon'          : ('run2_hlt_relval'         ,l1Menus['HIon']),
     'run3_hlt_PIon'          : ('run2_hlt_relval'         ,l1Menus['PIon']),
     'run3_hlt_PRef'          : ('run2_hlt_relval'         ,l1Menus['PRef']),
 

--- a/Configuration/HLT/python/autoCondHLT.py
+++ b/Configuration/HLT/python/autoCondHLT.py
@@ -39,7 +39,7 @@ hltGTs = {
     'run3_mc_PIon'           : ('phase1_2021_realistic'   ,l1Menus['PIon']),
     'run3_mc_PRef'           : ('phase1_2021_realistic'   ,l1Menus['PRef']),
 
-    'run1_hlt_Fake'          : ('run1_hlt'                ,l1Menus['Fake']),
+    'run1_hlt_Fake'          : ('run1_hlt_relval'         ,l1Menus['Fake']),
     'run2_hlt_Fake'          : ('run2_hlt_relval'         ,l1Menus['Fake']),
     'run2_hlt_Fake1'         : ('run2_hlt_relval'         ,l1Menus['Fake1']),
     'run2_hlt_Fake2'         : ('run2_hlt_relval'         ,l1Menus['Fake2']),

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -2129,7 +2129,7 @@ steps['RECOCOSD']=merge([{'--scenario':'cosmics',
                           },dataReco])
 
 steps['RECOCOSDRUN2']=merge([{'--conditions':'auto:run2_data','--era':'Run2_2016'},steps['RECOCOSD']])
-steps['RECOCOSDRUN3']=merge([{'--conditions':'auto:run3_data_promptlike','--era':'Run3'},steps['RECOCOSD']])
+steps['RECOCOSDRUN3']=merge([{'--conditions':'auto:run3_data_prompt','--era':'Run3'},steps['RECOCOSD']])
 steps['RECOCOSDEXPRUN3']=merge([{'--conditions':'auto:run3_data_express','--era':'Run3'},steps['RECOCOSD']])
 
 # step1 gensim for HI mixing
@@ -2539,7 +2539,7 @@ steps['ALCACOSD']={'--conditions':'auto:run1_data',
 
 steps['ALCACOSDRUN2']=merge([{'--conditions':'auto:run2_data','--era':'Run2_2016','-s':'ALCA:SiPixelCalCosmics+TkAlCosmics0T+SiStripCalCosmics+MuAlGlobalCosmics+HcalCalHOCosmics+DQM'},steps['ALCACOSD']])
 
-steps['ALCACOSDRUN3']=merge([{'--conditions':'auto:run3_data_promptlike','--era':'Run3','-s':'ALCA:SiPixelCalCosmics+TkAlCosmics0T+SiStripCalCosmics+MuAlGlobalCosmics+HcalCalHOCosmics+DQM'},steps['ALCACOSD']])
+steps['ALCACOSDRUN3']=merge([{'--conditions':'auto:run3_data_prompt','--era':'Run3','-s':'ALCA:SiPixelCalCosmics+TkAlCosmics0T+SiStripCalCosmics+MuAlGlobalCosmics+HcalCalHOCosmics+DQM'},steps['ALCACOSD']])
 steps['ALCACOSDEXPRUN3']=merge([{'--conditions':'auto:run3_data_express','--era':'Run3','-s':'ALCA:SiPixelCalCosmics+TkAlCosmics0T+SiStripCalCosmics+MuAlGlobalCosmics+HcalCalHOCosmics+DQM'},steps['ALCACOSD']])
 
 steps['ALCAPROMPT']={'-s':'ALCA:PromptCalibProd',
@@ -2761,7 +2761,7 @@ steps['HARVESTDC']={'-s':'HARVESTING:dqmHarvestingFakeHLT',
 
 steps['HARVESTDCRUN2']=merge([{'--conditions':'auto:run2_data','--era':'Run2_2016'},steps['HARVESTDC']])
 
-steps['HARVESTDCRUN3']=merge([{'--conditions':'auto:run3_data_promptlike','--era':'Run3'},steps['HARVESTDC']])
+steps['HARVESTDCRUN3']=merge([{'--conditions':'auto:run3_data_prompt','--era':'Run3'},steps['HARVESTDC']])
 steps['HARVESTDCEXPRUN3']=merge([{'--conditions':'auto:run3_data_express','--era':'Run3'},steps['HARVESTDC']])
 
 steps['HARVESTDR2_REMINIAOD_data2016']=merge([{'--data':'', '-s':'HARVESTING:@miniAODDQM','--era':'Run2_2016,run2_miniAOD_80XLegacy'},steps['HARVESTDR2']])

--- a/DQM/Integration/python/config/FrontierCondition_GT_autoExpress_cfi.py
+++ b/DQM/Integration/python/config/FrontierCondition_GT_autoExpress_cfi.py
@@ -1,13 +1,14 @@
 from __future__ import print_function
 import FWCore.ParameterSet.Config as cms
 from Configuration.StandardSequences.FrontierConditions_GlobalTag_cff import *
+from Configuration.AlCa.autoCond import autoCond
 
 # Default Express GT: it is the GT that will be used in case we are not able
 # to retrieve the one used at Tier0.
 # It should be kept in synch with Express processing at Tier0: what the url
 # https://cmsweb.cern.ch/t0wmadatasvc/prod/express_config
 # would tell you.
-GlobalTag.globaltag = "112X_dataRun3_Express_v2"
+GlobalTag.globaltag = autoCond['run3_data_express']
 
 # ===== auto -> Automatically get the GT string from current Tier0 configuration via a Tier0Das call.
 #       This needs a valid proxy to access the cern.ch network from the .cms one.

--- a/DQM/Integration/python/config/FrontierCondition_GT_cfi.py
+++ b/DQM/Integration/python/config/FrontierCondition_GT_cfi.py
@@ -1,3 +1,4 @@
 import FWCore.ParameterSet.Config as cms
 from Configuration.StandardSequences.FrontierConditions_GlobalTag_cff import *
-GlobalTag.globaltag = "112X_dataRun3_HLT_v1"
+from Configuration.AlCa.autoCond import autoCond
+GlobalTag.globaltag = autoCond['run3_hlt']


### PR DESCRIPTION
#### PR description:

This PR makes several changes to the online GTs to bring several up-to-date and simplify maintenance.

- The `run1_hlt` key is replaced by a `run1_hlt_relval` key as the only usage of this key is in Run 1 addOnTests in which the L1T menu is intended to be fixed, as in relvals
- The `run2_hlt` key has been removed, as it is not used anywhere in CMSSW
- A new HLT autoCond key, `run3_hlt` has been introduced and is intended to be kept up-to-date with the actual HLT GT. This key is used by the `DQM/Integration` package and is also used in the legacy `autoCond['hltonline']` key (intended to represent the online HLT). There are no other uses of this key in CMSSW.
- The GT represented by the value of key `run2_hlt_relval` has been brought up-to-date with respect to the current online GT. It now is equivalent to the online HLT key, aside from a fixed snapshot time and L1T trigger menu
- The `run2_hlt_relval_hi` key was superfluous. It differs from the `run2_hlt_relval` key only by the L1 trigger menu. Since only usage was in `autoCondHLT`, which overrides the trigger menu, I have modified the relevant entry to use the `run2_hlt_relval` key and removed the `run2_hlt_relval_hi` key.
- `run2_hlt_hi` is used only by workflow 140.55, representing 2015 HI data and requires a special tag `SiStripFullPedestals_GR10_v1_hlt` and a special L1T menu. Since this is a very special scenario, this GT has been represented by a symbolic GT that implements these changes on top of the `run2_hlt_relval` key.

During the course of preparing this PR, I discovered that an the `PFCalibrationRcd` with label "HLT" was incorrect in the HLT, Express and Prompt GTs. The corrected tag is now used.

The GT diffs are as follows:

**Run 2 HLT RelVals**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/112X_dataRun2_HLT_relval_v4/112X_dataRun2_HLT_relval_v5

**Run 3 data (express)**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/112X_dataRun3_Express_v3/112X_dataRun3_Express_v4

**Run 3 data (prompt)**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/112X_dataRun3_Prompt_v3/112X_dataRun3_Prompt_v4

The large number of EGM calibration records that are present in old Run 2 HLT relvals are not consumed (or else a crash would result in various tests).

Attn: @mmusich @Martin-Grunewald 

#### PR validation:

This PR is mainly technical and has been validated with:

- runTheMatrix.py -l 138.1,138.2,140.55 --ibeos
- addOnTests.py -j 8
- scram b runtests

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

<!-- Please replace this text with any link to  -->

Since this PR affects GTs in the 112X release, a backport to 11_2_X is intended.
