### PR TITLE
[Backport to 11_2_X] Change DBS url to cmsweb-prod in MatrixInjector

### DIFF
--- a/Configuration/PyReleaseValidation/python/MatrixInjector.py
+++ b/Configuration/PyReleaseValidation/python/MatrixInjector.py
@@ -71,7 +71,7 @@ class MatrixInjector(object):
         if not self.wmagent:
             if not opt.testbed :
                 self.wmagent = 'cmsweb.cern.ch'
-                self.DbsUrl = "https://"+self.wmagent+"/dbs/prod/global/DBSReader"
+                self.DbsUrl = "https://cmsweb-prod.cern.ch/dbs/prod/global/DBSReader"
             else :
                 self.wmagent = 'cmsweb-testbed.cern.ch'
                 self.DbsUrl = "https://"+self.wmagent+"/dbs/int/global/DBSReader"

--- a/Configuration/PyReleaseValidation/python/MatrixInjector.py
+++ b/Configuration/PyReleaseValidation/python/MatrixInjector.py
@@ -65,16 +65,29 @@ class MatrixInjector(object):
         if(opt.batchName):
             self.batchName = '__'+opt.batchName+'-'+self.batchTime
 
-        #wagemt stuff
+        # WMagent url
         if not self.wmagent:
-            self.wmagent=os.getenv('WMAGENT_REQMGR')
+            # Overwrite with env variable
+            self.wmagent = os.getenv('WMAGENT_REQMGR')
+
         if not self.wmagent:
-            if not opt.testbed :
+            # Default values
+            if not opt.testbed:
                 self.wmagent = 'cmsweb.cern.ch'
-                self.DbsUrl = "https://cmsweb-prod.cern.ch/dbs/prod/global/DBSReader"
-            else :
+            else:
                 self.wmagent = 'cmsweb-testbed.cern.ch'
-                self.DbsUrl = "https://"+self.wmagent+"/dbs/int/global/DBSReader"
+
+        # DBSReader url
+        if opt.dbsUrl is not None:
+            self.DbsUrl = opt.dbsUrl
+        elif os.getenv('CMS_DBSREADER_URL') is not None:
+            self.DbsUrl = os.getenv('CMS_DBSREADER_URL')
+        else:
+            # Default values
+            if not opt.testbed:
+                self.DbsUrl = "https://cmsweb-prod.cern.ch/dbs/prod/global/DBSReader"
+            else:
+                self.DbsUrl = "https://cmsweb-testbed.cern.ch/dbs/int/global/DBSReader"
 
         if not self.dqmgui:
             self.dqmgui="https://cmsweb.cern.ch/dqm/relval"

--- a/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
+++ b/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
@@ -288,6 +288,12 @@ if __name__ == '__main__':
                       default='T2_CH_CERN',
                       action='store')
 
+    parser.add_option('--dbs-url',
+                      help='Overwrite DbsUrl value in JSON submitted to ReqMgr2',
+                      dest='dbsUrl',
+                      default=None,
+                      action='store')
+
     opt,args = parser.parse_args()
     os.environ["CMSSW_DAS_QUERY_SITES"]=opt.dasSites
     if opt.IBEos:


### PR DESCRIPTION
#### PR description:

Use cmsweb-prod.cern.ch for "DbsUrl" attribute in the dictionary that is submitted to ReqMgr2 by MatrixInjector.

Relevant ticket on gitlab: https://gitlab.cern.ch/cms-http-group/doc/-/issues/256 

#### PR validation:

None.

#### If this PR is a backport please specify the original PR and why you need to backport that PR:

https://github.com/cms-sw/cmssw/pull/33209
Backport because 11_2_X is still used in production.