### PR TITLE
Increase precision of gen particles

### DIFF
--- a/PhysicsTools/NanoAOD/python/nano_cff.py
+++ b/PhysicsTools/NanoAOD/python/nano_cff.py
@@ -385,6 +385,18 @@ def nanoAOD_customizeMC(process):
         modifier.toModify(process, lambda p: nanoAOD_runMETfixEE2017(p,isData=False))
     return process
 
+###increasing the precision of selected GenParticles.                                                                                                 
+def nanoWmassGenCustomize(process):
+    pdgSelection="?(abs(pdgId) == 11|| abs(pdgId)==13 || abs(pdgId)==15 ||abs(pdgId)== 12 || abs(pdgId)== 14 || abs(pdgId)== 16|| abs(pdgId)== 24|| pdgId== 23)"
+    # Keep precision same as default RECO for selected particles                                                                                       
+    ptPrecision="{}?{}:{}".format(pdgSelection, CandVars.pt.precision.value(),genParticleTable.variables.pt.precision.value())
+    process.genParticleTable.variables.pt.precision=cms.string(ptPrecision)
+    phiPrecision="{} ? {} : {}".format(pdgSelection, CandVars.phi.precision.value(), genParticleTable.variables.phi.precision.value())
+    process.genParticleTable.variables.phi.precision=cms.string(phiPrecision)
+    etaPrecision="{} ? {} : {}".format(pdgSelection, CandVars.eta.precision.value(), genParticleTable.variables.eta.precision.value())
+    process.genParticleTable.variables.eta.precision=cms.string(etaPrecision)
+    return process
+
 ### Era dependent customization
 _80x_sequence = nanoSequenceCommon.copy()
 #remove stuff


### PR DESCRIPTION
#### PR description:
As discussed during the Cross-POG [meeting](https://indico.cern.ch/event/994591/), this PR adds the customization function to increase the precision of GenParticle pt, eta and phi information for leptons, neutrinos and W, and Z.  To enforce these changes, the process needs to be customized with the function:-
  PhysicsTools/NanoAOD/nano_cff.nanoWmassGenCustomize

#### PR validation:
Checks were done with the following

- cmsDriver.py default --eventcontent NANOAODSIM --datatier NANOAODSIM --conditions auto:run2_mc --step NANO --filein mini.root --nThreads 8 --mc -n 5000 --era Run2_2016,run2_nanoAOD_106Xv1
- msDriver.py wmassgen --eventcontent NANOAODSIM --datatier NANOAODSIM --conditions auto:run2_mc --step NANO --filein mini --nThreads 8 --mc -n 5000 --era Run2_2016,run2_nanoAOD_106Xv1  --customise PhysicsTools/NanoAOD/nano_cff.nanoWmassGenCustomize

#### if this PR is a backport please specify the original PR and why you need to backport that PR:
Backport to 106X will be needed.