### PR TITLE
Add support for configuration validation to EDLooper

### DIFF
--- a/FWCore/Framework/interface/LooperFactory.h
+++ b/FWCore/Framework/interface/LooperFactory.h
@@ -25,6 +25,7 @@
 // user include files
 #include "FWCore/Framework/interface/ComponentFactory.h"
 #include "FWCore/Framework/interface/EventSetupProvider.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescriptionFillerPluginFactory.h"
 
 // forward declarations
 namespace edm {
@@ -104,7 +105,8 @@ namespace edm {
   }  // namespace eventsetup
 }  // namespace edm
 
-#define DEFINE_FWK_LOOPER(type) \
-  DEFINE_EDM_PLUGIN(edm::eventsetup::LooperPluginFactory, edm::eventsetup::LooperMaker<type>, #type)
+#define DEFINE_FWK_LOOPER(type)                                                                       \
+  DEFINE_EDM_PLUGIN(edm::eventsetup::LooperPluginFactory, edm::eventsetup::LooperMaker<type>, #type); \
+  DEFINE_DESC_FILLER_FOR_EDLOOPERS(type)
 
 #endif

--- a/FWCore/ParameterSet/interface/ParameterSetDescriptionFiller.h
+++ b/FWCore/ParameterSet/interface/ParameterSetDescriptionFiller.h
@@ -198,5 +198,33 @@ namespace edm {
 
     const std::string& extendedBaseType() const override { return kEmpty; }
   };
+
+  template <typename T>
+  class DescriptionFillerForEDLoopers : public ParameterSetDescriptionFillerBase {
+  public:
+    DescriptionFillerForEDLoopers() {}
+    DescriptionFillerForEDLoopers(const DescriptionFillerForEDLoopers&) = delete;                   // stop default
+    const DescriptionFillerForEDLoopers& operator=(const DescriptionFillerForEDLoopers&) = delete;  // stop default
+
+    // If T has a fillDescriptions function then just call that, otherwise
+    // put in an "unknown description" as a default.
+    void fill(ConfigurationDescriptions& descriptions) const override {
+      std::conditional_t<edm::fillDetails::has_fillDescriptions_function<T>::value,
+                         edm::fillDetails::DoFillDescriptions<T>,
+                         edm::fillDetails::DoFillAsUnknown<T>>
+          fill_descriptions;
+      fill_descriptions(descriptions);
+
+      std::conditional_t<edm::fillDetails::has_prevalidate_function<T>::value,
+                         edm::fillDetails::DoPrevalidate<T>,
+                         edm::fillDetails::DoNothing<T>>
+          prevalidate;
+      prevalidate(descriptions);
+    }
+
+    const std::string& baseType() const override { return kBaseForEDLooper; }
+
+    const std::string& extendedBaseType() const override { return kEmpty; }
+  };
 }  // namespace edm
 #endif

--- a/FWCore/ParameterSet/interface/ParameterSetDescriptionFillerBase.h
+++ b/FWCore/ParameterSet/interface/ParameterSetDescriptionFillerBase.h
@@ -83,6 +83,7 @@ namespace edm {
     static const std::string kBaseForService;
     static const std::string kBaseForESSource;
     static const std::string kBaseForESProducer;
+    static const std::string kBaseForEDLooper;
     static const std::string kExtendedBaseForEDAnalyzer;
     static const std::string kExtendedBaseForEDProducer;
     static const std::string kExtendedBaseForEDFilter;

--- a/FWCore/ParameterSet/interface/ParameterSetDescriptionFillerPluginFactory.h
+++ b/FWCore/ParameterSet/interface/ParameterSetDescriptionFillerPluginFactory.h
@@ -50,4 +50,8 @@ namespace edm {
   static const edm::ParameterSetDescriptionFillerPluginFactory::PMaker<edm::DescriptionFillerForESProducers<type> > \
       EDM_PLUGIN_SYM(s_filler, __LINE__)(#type)
 
+#define DEFINE_DESC_FILLER_FOR_EDLOOPERS(type)                                                                    \
+  static const edm::ParameterSetDescriptionFillerPluginFactory::PMaker<edm::DescriptionFillerForEDLoopers<type> > \
+      EDM_PLUGIN_SYM(s_filler, __LINE__)(#type)
+
 #endif

--- a/FWCore/ParameterSet/src/ParameterSetDescriptionFillerBase.cc
+++ b/FWCore/ParameterSet/src/ParameterSetDescriptionFillerBase.cc
@@ -22,6 +22,7 @@ const std::string edm::ParameterSetDescriptionFillerBase::kEmpty("");
 const std::string edm::ParameterSetDescriptionFillerBase::kBaseForService("Service");
 const std::string edm::ParameterSetDescriptionFillerBase::kBaseForESSource("ESSource");
 const std::string edm::ParameterSetDescriptionFillerBase::kBaseForESProducer("ESProducer");
+const std::string edm::ParameterSetDescriptionFillerBase::kBaseForEDLooper("EDLooper");
 const std::string edm::ParameterSetDescriptionFillerBase::kExtendedBaseForEDAnalyzer("EDAnalyzer");
 const std::string edm::ParameterSetDescriptionFillerBase::kExtendedBaseForEDProducer("EDProducer");
 const std::string edm::ParameterSetDescriptionFillerBase::kExtendedBaseForEDFilter("EDFilter");


### PR DESCRIPTION
#### PR description:

While working on something else, I noticed that configuration validation is not used for EDLoopers. This PR adds that support.

Resolves https://github.com/makortel/framework/issues/82

#### PR validation:

Framework unit tests run. Test with EDLooper using the functionality (not included in this PR though, will come later) can generate a `cfi` file, and configuration parameters specified in `fillDescriptions()` but absent in python configuration are being automatically added before the constructor.