### PR TITLE
treat a predicted state too far as invalid in CosmicMuonSmoother (backport of #33168)

### DIFF
--- a/RecoMuon/CosmicMuonProducer/src/CosmicMuonSmoother.cc
+++ b/RecoMuon/CosmicMuonProducer/src/CosmicMuonSmoother.cc
@@ -196,8 +196,8 @@ vector<Trajectory> CosmicMuonSmoother::fit(const TrajectorySeed& seed,
     } else {
       LogTrace(category_) << "predicted state invalid";
     }
-    if (!predTsos.isValid()) {
-      LogTrace(category_) << "Error: predTsos is still invalid forward fit.";
+    if (!predTsos.isValid() || predTsos.globalPosition().mag2() > 1.e12) {
+      LogTrace(category_) << "Error: predTsos is still invalid or too far in forward fit.";
       //      return vector<Trajectory>();
       continue;
     } else if ((**ihit).isValid()) {


### PR DESCRIPTION
(copy-paste from the 11_3_X)

this is a follow-up to the origins of the issue reported in https://hypernews.cern.ch/HyperNews/CMS/get/recoDevelopment/1706.html
in processing of date in Run: 340323, which has a seg fault.

This is a case of runaway fit leading to running over numerical precision limits with a final result as NaN. Some later code using this can crash (fixed separately in  #33157).

I propose to have this backport to avoid possible (rare) crashes in MWGR data (re)processing.
This PR is expected to affect/fix only cases that are going to lead to a crash or are very close to that state; this should be OK in the no-change policy.