### PR TITLE
DAQ: generate cfi file for output module (11_2_X)

### DIFF
--- a/EventFilter/Utilities/src/EvFOutputModule.cc
+++ b/EventFilter/Utilities/src/EvFOutputModule.cc
@@ -142,7 +142,7 @@ namespace evf {
     EvFOutputModuleType::fillDescription(desc);
     desc.addUntracked<edm::InputTag>("psetMap", {"hltPSetMap"})
         ->setComment("Optionally allow the map of ParameterSets to be calculated externally.");
-    descriptions.addDefault(desc);
+    descriptions.add("evfOutputModule", desc);
   }
 
   void EvFOutputModule::beginRun(edm::RunForOutput const& run) {


### PR DESCRIPTION
#### PR description:

Modification to generate cfi file for EvFOutputModule.

#### PR validation:

At compile time it generates cfi file as intended:
`cfipython/slc7_amd64_gcc900/EventFilter/Utilities/evfOutputModule_cfi.py`
```
evfOutputModule = cms.OutputModule('EvFOutputModule',
  max_event_size = cms.untracked.int32(7000000),
  use_compression = cms.untracked.bool(True),
  compression_algorithm = cms.untracked.string('ZLIB'),
  compression_level = cms.untracked.int32(1),
  lumiSection_interval = cms.untracked.int32(0),
  outputCommands = cms.untracked.vstring('keep *'),
  SelectEvents = cms.untracked.PSet(
    SelectEvents = cms.optional.vstring
  ),
  psetMap = cms.untracked.InputTag('hltPSetMap')
)
```

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Backport of a commit https://github.com/cms-sw/cmssw/pull/33198/commits/c8aa48b610226888f7c74789114c1f7f50575a1f 
from #33198

Backporting to allow work on changing the output module name in HLT ConfDB.