### PR TITLE
Annotate EventSetupImpl::taskArena() as thread safe

### DIFF
--- a/FWCore/Framework/interface/EventSetupImpl.h
+++ b/FWCore/Framework/interface/EventSetupImpl.h
@@ -71,7 +71,7 @@ namespace edm {
 
     bool validRecord(eventsetup::EventSetupRecordKey const& iKey) const;
 
-    tbb::task_arena* taskArena() const { return taskArena_; }
+    tbb::task_arena* taskArena CMS_THREAD_SAFE() const { return taskArena_; }
     ///Only EventSetupProvider allowed to create an EventSetupImpl
     friend class eventsetup::EventSetupProvider;
     friend class eventsetup::EventSetupRecordProvider;


### PR DESCRIPTION
#### PR description:

This should silence many static analyzer warnings that @jpata reported in https://mattermost.web.cern.ch/cms-o-and-c/pl/6efrf7q4s7yi8k3oaamjhwdr3a

Resolves https://github.com/makortel/framework/issues/85

#### PR validation:

Framework compiles.