### PR TITLE
Mark dependence on FWCore/SOA as source-only in DataFormats/TestObjects/BuildFile.xml

### DIFF
--- a/DataFormats/TestObjects/BuildFile.xml
+++ b/DataFormats/TestObjects/BuildFile.xml
@@ -1,6 +1,6 @@
 <use name="DataFormats/Common"/>
 <use name="DataFormats/Provenance"/>
-<use name="FWCore/SOA"/>
+<use name="FWCore/SOA" source_only="1"/>
 <use name="FWCore/Utilities"/>
 <export>
   <lib name="1"/>


### PR DESCRIPTION
#### PR description:

To silence the following warning by `scram b`
```
****WARNING: Invalid tool FWCore/SOA. Please fix src/DataFormats/TestObjects/BuildFile.xml file
```

Resolves https://github.com/makortel/framework/issues/86

#### PR validation:

The warning by `scram b` disappears.