### PR TITLE
Run4-hgx278X Avoid ASAN problem in HGCalGeomTools::radius

### DIFF
--- a/Geometry/HGCalCommonData/src/HGCalGeomTools.cc
+++ b/Geometry/HGCalCommonData/src/HGCalGeomTools.cc
@@ -37,7 +37,8 @@ void HGCalGeomTools::radius(double zf,
   if ((zb1 != zFront1.begin()) && (std::abs(*zb1 - zb) < tol_)) {
     --zb1;
     dz2 = -2 * tol_;
-  } else if (std::abs(*(zb1 + 1) - zb) < tol_) {
+  }
+  if (((zb1 + 1) != zFront1.end()) && (std::abs(*(zb1 + 1) - zb) < tol_)) {
     dz2 = -2 * tol_;
   }
   auto zb2 = std::lower_bound(zFront2.begin(), zFront2.end(), zb);


### PR DESCRIPTION
#### PR description:

Avoid ASAN problem in HGCalGeomTools::radius

#### PR validation:

Test using the workflow 34634.0 within CMSSW_11_3_ASAN_X_2021-03-15-2300

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Nothing special