### PR TITLE
MTD local reconstruction: new parameterizations for the RecHits time uncertainty  

### DIFF
--- a/RecoLocalFastTime/FTLCommonAlgos/BuildFile.xml
+++ b/RecoLocalFastTime/FTLCommonAlgos/BuildFile.xml
@@ -4,6 +4,7 @@
 <use name="Geometry/MTDGeometryBuilder"/>
 <use name="DataFormats/FTLRecHit"/>
 <use name="clhep"/>
+<use name="CommonTools/Utils"/>
 <export>
   <lib name="1"/>
 </export>

--- a/RecoLocalFastTime/FTLCommonAlgos/plugins/BTLUncalibRecHitAlgo.cc
+++ b/RecoLocalFastTime/FTLCommonAlgos/plugins/BTLUncalibRecHitAlgo.cc
@@ -83,8 +83,8 @@ FTLUncalibratedRecHit BTLUncalibRecHitAlgo::makeRecHit(const BTLDataFrame& dataF
 
   // --- Calculate the error on the hit time using the provided parameterization
 
-  std::vector<double> amplitudeV = {(amplitude.first + amplitude.second) / nHits};
-  std::vector<double> emptyV;
+  const std::array<double, 1> amplitudeV = {{(amplitude.first + amplitude.second) / nHits}};
+  const std::array<double, 1> emptyV = {{0.}};
 
   double timeError = (nHits > 0. ? timeError_.evaluate(amplitudeV, emptyV) : -1.);
 

--- a/RecoLocalFastTime/FTLCommonAlgos/plugins/ETLUncalibRecHitAlgo.cc
+++ b/RecoLocalFastTime/FTLCommonAlgos/plugins/ETLUncalibRecHitAlgo.cc
@@ -1,6 +1,8 @@
 #include "RecoLocalFastTime/FTLCommonAlgos/interface/MTDUncalibratedRecHitAlgoBase.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
+#include "CommonTools/Utils/interface/FormulaEvaluator.h"
+
 class ETLUncalibRecHitAlgo : public ETLUncalibratedRecHitAlgoBase {
 public:
   /// Constructor
@@ -11,7 +13,7 @@ public:
         adcLSB_(adcSaturation_ / (1 << adcNBits_)),
         toaLSBToNS_(conf.getParameter<double>("toaLSB_ns")),
         tofDelay_(conf.getParameter<double>("tofDelay")),
-        timeError_(conf.getParameter<double>("timeResolutionInNs")) {}
+        timeError_(conf.getParameter<std::string>("timeResolutionInNs")) {}
 
   /// Destructor
   ~ETLUncalibRecHitAlgo() override {}
@@ -29,25 +31,37 @@ private:
   const double adcLSB_;
   const double toaLSBToNS_;
   const double tofDelay_;
-  const double timeError_;
+  const reco::FormulaEvaluator timeError_;
 };
 
 FTLUncalibratedRecHit ETLUncalibRecHitAlgo::makeRecHit(const ETLDataFrame& dataFrame) const {
   constexpr int iSample = 2;  //only in-time sample
   const auto& sample = dataFrame.sample(iSample);
 
-  double amplitude = double(sample.data()) * adcLSB_;
+  std::vector<double> amplitudeV = {double(sample.data()) * adcLSB_};
+  // NB: Here amplitudeV is defined as a vector in order to be used below
+  //     as an input to FormulaEvaluator::evaluate.
   double time = double(sample.toa()) * toaLSBToNS_ - tofDelay_;
   unsigned char flag = 0;
 
-  LogDebug("ETLUncalibRecHit") << "ADC+: set the charge to: " << amplitude << ' ' << sample.data() << ' ' << adcLSB_
+  LogDebug("ETLUncalibRecHit") << "ADC+: set the charge to: " << amplitudeV[0] << ' ' << sample.data() << ' ' << adcLSB_
                                << ' ' << std::endl;
   LogDebug("ETLUncalibRecHit") << "ADC+: set the time to: " << time << ' ' << sample.toa() << ' ' << toaLSBToNS_ << ' '
                                << std::endl;
-  LogDebug("ETLUncalibRecHit") << "Final uncalibrated amplitude : " << amplitude << std::endl;
+  LogDebug("ETLUncalibRecHit") << "Final uncalibrated amplitude : " << amplitudeV[0] << std::endl;
 
-  return FTLUncalibratedRecHit(
-      dataFrame.id(), dataFrame.row(), dataFrame.column(), {amplitude, 0.f}, {time, 0.f}, timeError_, -1.f, -1.f, flag);
+  std::vector<double> emptyV;
+  double timeError = timeError_.evaluate(amplitudeV, emptyV);
+
+  return FTLUncalibratedRecHit(dataFrame.id(),
+                               dataFrame.row(),
+                               dataFrame.column(),
+                               {amplitudeV[0], 0.f},
+                               {time, 0.f},
+                               timeError,
+                               -1.f,
+                               -1.f,
+                               flag);
 }
 
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/RecoLocalFastTime/FTLCommonAlgos/plugins/ETLUncalibRecHitAlgo.cc
+++ b/RecoLocalFastTime/FTLCommonAlgos/plugins/ETLUncalibRecHitAlgo.cc
@@ -38,9 +38,9 @@ FTLUncalibratedRecHit ETLUncalibRecHitAlgo::makeRecHit(const ETLDataFrame& dataF
   constexpr int iSample = 2;  //only in-time sample
   const auto& sample = dataFrame.sample(iSample);
 
-  std::vector<double> amplitudeV = {double(sample.data()) * adcLSB_};
-  // NB: Here amplitudeV is defined as a vector in order to be used below
-  //     as an input to FormulaEvaluator::evaluate.
+  const std::array<double, 1> amplitudeV = {{double(sample.data()) * adcLSB_}};
+  // NB: Here amplitudeV is defined as an array in order to be used
+  //     below as an input to FormulaEvaluator::evaluate.
   double time = double(sample.toa()) * toaLSBToNS_ - tofDelay_;
   unsigned char flag = 0;
 
@@ -50,7 +50,7 @@ FTLUncalibratedRecHit ETLUncalibRecHitAlgo::makeRecHit(const ETLDataFrame& dataF
                                << std::endl;
   LogDebug("ETLUncalibRecHit") << "Final uncalibrated amplitude : " << amplitudeV[0] << std::endl;
 
-  std::vector<double> emptyV;
+  const std::array<double, 1> emptyV = {{0.}};
   double timeError = timeError_.evaluate(amplitudeV, emptyV);
 
   return FTLUncalibratedRecHit(dataFrame.id(),

--- a/RecoLocalFastTime/FTLRecProducers/python/mtdUncalibratedRecHits_cfi.py
+++ b/RecoLocalFastTime/FTLRecProducers/python/mtdUncalibratedRecHits_cfi.py
@@ -8,7 +8,7 @@ _barrelAlgo = cms.PSet(
     adcNbits = mtdDigitizer.barrelDigitizer.ElectronicsSimulation.adcNbits,
     adcSaturation = mtdDigitizer.barrelDigitizer.ElectronicsSimulation.adcSaturation_MIP,
     toaLSB_ns = mtdDigitizer.barrelDigitizer.ElectronicsSimulation.toaLSB_ns,
-    timeResolutionInNs = cms.double(0.025),
+    timeResolutionInNs = cms.string("0.308*pow(x,-0.4175)"), # [ns]
     timeCorr_p0 = cms.double( 2.21103),
     timeCorr_p1 = cms.double(-0.933552),
     timeCorr_p2 = cms.double( 0.),
@@ -22,7 +22,7 @@ _endcapAlgo = cms.PSet(
     adcSaturation = mtdDigitizer.endcapDigitizer.ElectronicsSimulation.adcSaturation_MIP,
     toaLSB_ns     = mtdDigitizer.endcapDigitizer.ElectronicsSimulation.toaLSB_ns,
     tofDelay      = mtdDigitizer.endcapDigitizer.DeviceSimulation.tofDelay,
-    timeResolutionInNs = cms.double(0.025)
+    timeResolutionInNs = cms.string("0.039") # [ns]
 )
 
 


### PR DESCRIPTION
#### PR description:

The time uncertainties of the BTL and ETL RecHits are passed as parameters to the UncalibratedRecHits producers. Currently a constant resolution of 25 ps is used for both the BTL and the ETL. 
The code update proposed in this PR introduces more realistic parameterizations for the RecHit time uncertainties.

In the case of ETL, for the time being a constant value is used, but the framework has been setup for a more realistic function dependence.

Details are provided in [this](https://indico.cern.ch/event/1019342/contributions/4278150/attachments/2212249/3744576/casarsa_rechitTimeError.pdf) presentation at the MTD DPG Meeting on 19/03/2021.

#### PR validation:

The updated code has been tested with a TTBar sample (WF 34634) in the CMSSW release 11_3_0_pre4.
The values of the RecHits amplitudes and times match 1-to-1 and the RecHits time errors are consistent with the provided parameterizations.
