### PR TITLE
MTD reconstruction: combine the time fro two ETL discs in TrackExtenderWithMTD

### DIFF
--- a/RecoMTD/TrackExtender/plugins/TrackExtenderWithMTD.cc
+++ b/RecoMTD/TrackExtender/plugins/TrackExtenderWithMTD.cc
@@ -1012,15 +1012,13 @@ reco::Track TrackExtenderWithMTDT<TrackCollection>::buildTrack(const reco::Track
       }
     }
 
+    auto ihit1 = trajWithMtd.measurements().cbegin() + ifirst - 1;
     if (ihitcount == 1) {
-      //if (ihitcount >= 1) {
-      auto ihit = trajWithMtd.measurements().cbegin() + ifirst - 1;
-      const MTDTrackingRecHit* mtdhit = static_cast<const MTDTrackingRecHit*>((*ihit).recHit()->hit());
+      const MTDTrackingRecHit* mtdhit = static_cast<const MTDTrackingRecHit*>((*ihit1).recHit()->hit());
       thit = mtdhit->time();
       thiterror = mtdhit->timeError();
       validmtd = true;
     } else if (ihitcount == 2 && ietlcount == 2) {
-      auto ihit1 = trajWithMtd.measurements().cbegin() + ifirst - 1;
       const MTDTrackingRecHit* mtdhit1 = static_cast<const MTDTrackingRecHit*>((*ihit1).recHit()->hit());
       const MTDTrackingRecHit* mtdhit2 = static_cast<const MTDTrackingRecHit*>((*(ihit1 + 1)).recHit()->hit());
       const auto& propresult =

--- a/RecoMTD/TrackExtender/plugins/TrackExtenderWithMTD.cc
+++ b/RecoMTD/TrackExtender/plugins/TrackExtenderWithMTD.cc
@@ -1003,9 +1003,6 @@ reco::Track TrackExtenderWithMTDT<TrackCollection>::buildTrack(const reco::Track
         if (ihitcount == 1 && ifirst == 0) {
           ifirst = ihitcount;
         }
-        MTDDetId thisId = MTDDetId(hit.recHit()->geographicalId());
-        edm::LogWarning("TrackExtenderWithMTD") << "MTD hit #" << ihitcount << " sub/RR = " << thisId.mtdSubDetector()
-                                                << " " << thisId.mtdRR() << " First = " << ifirst;
         if (MTDDetId(hit.recHit()->geographicalId()).mtdSubDetector() == 2) {
           ietlcount++;
         }
@@ -1024,9 +1021,6 @@ reco::Track TrackExtenderWithMTDT<TrackCollection>::buildTrack(const reco::Track
       const auto& propresult =
           thePropagator->propagateWithPath(ihit1->updatedState(), (ihit1 + 1)->updatedState().surface());
       double etlpathlength = std::abs(propresult.second);
-      edm::LogWarning("TrackExtenderWithMTD")
-          << "Total path = " << pathlength << " ETL path = " << etlpathlength
-          << " hit1 z = " << mtdhit1->globalPosition().z() << " hit2 z = " << mtdhit2->globalPosition().z();
       //
       // The information of the two ETL hits is combined and attributed to the innermost hit
       //
@@ -1034,7 +1028,6 @@ reco::Track TrackExtenderWithMTDT<TrackCollection>::buildTrack(const reco::Track
         validpropagation = false;
       } else {
         pathlength -= etlpathlength;
-        edm::LogWarning("TrackExtenderWithMTD") << "New total path = " << pathlength << " p = " << p.mag();
         TrackTofPidInfo tofInfo =
             computeTrackTofPidInfo(p.mag2(), etlpathlength, mtdhit1->time(), mtdhit1->timeError(), 0., 0., true);
         //
@@ -1051,15 +1044,15 @@ reco::Track TrackExtenderWithMTDT<TrackCollection>::buildTrack(const reco::Track
                   mtdhit2->time() / (mtdhit2->timeError() * mtdhit2->timeError())) /
                  thiterror;
           thiterror = 1. / std::sqrt(thiterror);
-          edm::LogWarning("TrackExtenderWithMTD")
-              << "ETL hits times/errors: " << mtdhit1->time() << " +/- " << mtdhit1->timeError() << " , "
-              << mtdhit2->time() << " +/- " << mtdhit2->timeError() << " extrapolated time1: " << tofInfo.dt << " +/- "
-              << tofInfo.dterror << " average = " << thit << " +/- " << thiterror;
+          LogDebug("TrackExtenderWithMTD") << "p trk = " << p.mag() << " ETL hits times/errors: " << mtdhit1->time()
+                                           << " +/- " << mtdhit1->timeError() << " , " << mtdhit2->time() << " +/- "
+                                           << mtdhit2->timeError() << " extrapolated time1: " << tofInfo.dt << " +/- "
+                                           << tofInfo.dterror << " average = " << thit << " +/- " << thiterror;
           validmtd = true;
         }
       }
     } else {
-      edm::LogWarning("TrackExtenderWithMTD")
+      edm::LogInfo("TrackExtenderWithMTD")
           << "MTD hits #" << ihitcount << "ETL hits #" << ietlcount << " anomalous pattern, skipping...";
     }
 

--- a/RecoMTD/TrackExtender/plugins/TrackExtenderWithMTD.cc
+++ b/RecoMTD/TrackExtender/plugins/TrackExtenderWithMTD.cc
@@ -1043,7 +1043,7 @@ reco::Track TrackExtenderWithMTDT<TrackCollection>::buildTrack(const reco::Track
         // Protect against incompatible times
         //
         if ((tofInfo.dt - mtdhit2->time()) * (tofInfo.dt - mtdhit2->time()) <
-            ((tofInfo.dt * tofInfo.dt) + (mtdhit2->timeError() * mtdhit2->timeError())) * etlTimeChi2Cut_) {
+            ((tofInfo.dterror * tofInfo.dterror) + (mtdhit2->timeError() * mtdhit2->timeError())) * etlTimeChi2Cut_) {
           //
           // Subtract the ETL time of flight from the outermost measurement, and combine it in a weighted average with the innermost
           // the mass ambiguity related uncertainty on the time of flight is added as an additional uncertainty


### PR DESCRIPTION
#### PR description:

The D76 geometry scenario has two discs for each ETL side, and they are used by the ```TrackExtenderWithMTD``` while adding hits to the track for refit, but so far only the time of the first hit was used as timing information, because the code was originally developed for the one-hit disc scenario. This PR combines the time fro the hits associated to a track in two discs by extrapolating the outermost to the innermost, and computing a weighted average. The uncertainty in the subtracted time-of-flight between the two discs induced by the mass hypothesis (pion is used for the extrapolation) is added in the form of the difference between the pion and proton estimated tof. This has very small effect but for very soft tracks.

#### PR validation:

Code compiles and runs, debugging printouts show the desired behaviour on wf 34634.0.