### PR TITLE
Refactor ProductResolvers

### DIFF
--- a/DataFormats/Provenance/interface/BranchDescription.h
+++ b/DataFormats/Provenance/interface/BranchDescription.h
@@ -84,6 +84,7 @@ namespace edm {
     bool present() const { return !transient_.dropped_; }
     bool dropped() const { return transient_.dropped_; }
     void setDropped(bool isDropped) { transient_.dropped_ = isDropped; }
+    //returns true if unscheduled (produced()==true) or using delayed reader (produced()==false)
     bool onDemand() const { return transient_.onDemand_; }
     void setOnDemand(bool isOnDemand) { transient_.onDemand_ = isOnDemand; }
     bool availableOnlyAtEndTransition() const { return transient_.availableOnlyAtEndTransition_; }

--- a/DataFormats/TestObjects/interface/Thing.h
+++ b/DataFormats/TestObjects/interface/Thing.h
@@ -8,6 +8,7 @@ namespace edmtest {
   struct Thing {
     ~Thing() {}
     Thing() : a() {}
+    explicit Thing(cms_int32_t v) : a{v} {}
     cms_int32_t a;
   };
 

--- a/DataFormats/TestObjects/interface/ThingWithIsEqual.h
+++ b/DataFormats/TestObjects/interface/ThingWithIsEqual.h
@@ -8,6 +8,7 @@ namespace edmtest {
   struct ThingWithIsEqual {
     ~ThingWithIsEqual() {}
     ThingWithIsEqual() : a() {}
+    explicit ThingWithIsEqual(cms_int32_t v) : a(v) {}
     bool isProductEqual(ThingWithIsEqual const& thingWithIsEqual) const;
     cms_int32_t a;
   };

--- a/DataFormats/TestObjects/interface/ThingWithMerge.h
+++ b/DataFormats/TestObjects/interface/ThingWithMerge.h
@@ -8,6 +8,7 @@ namespace edmtest {
   struct ThingWithMerge {
     ~ThingWithMerge() {}
     ThingWithMerge() : a() {}
+    explicit ThingWithMerge(cms_int32_t v) : a{v} {}
     bool mergeProduct(ThingWithMerge const& newThing);
     void swap(ThingWithMerge& iOther);
     cms_int32_t a;

--- a/FWCore/Framework/interface/Principal.h
+++ b/FWCore/Framework/interface/Principal.h
@@ -47,7 +47,6 @@ namespace edm {
   class ProductResolverIndexHelper;
   class EDConsumerBase;
   class SharedResourcesAcquirer;
-  class InputProductResolver;
   class UnscheduledConfigurator;
 
   struct FilledProductPtr {
@@ -209,7 +208,7 @@ namespace edm {
     ProductResolverBase const* getExistingProduct(BranchID const& branchID) const;
     ProductResolverBase const* getExistingProduct(ProductResolverBase const& phb) const;
 
-    void putOrMerge(BranchDescription const& bd, std::unique_ptr<WrapperBase> edp) const;
+    void put_(BranchDescription const& bd, std::unique_ptr<WrapperBase> edp) const;
 
     //F must take an argument of type ProductResolverBase*
     template <typename F>
@@ -225,7 +224,8 @@ namespace edm {
 
     void addScheduledProduct(std::shared_ptr<BranchDescription const> bd);
     void addSourceProduct(std::shared_ptr<BranchDescription const> bd);
-    void addInputProduct(std::shared_ptr<BranchDescription const> bd);
+    void addDelayedReaderInputProduct(std::shared_ptr<BranchDescription const> bd);
+    void addPutOnReadInputProduct(std::shared_ptr<BranchDescription const> bd);
     void addUnscheduledProduct(std::shared_ptr<BranchDescription const> bd);
     void addAliasedProduct(std::shared_ptr<BranchDescription const> bd);
     void addSwitchProducerProduct(std::shared_ptr<BranchDescription const> bd);
@@ -264,7 +264,7 @@ namespace edm {
                                           SharedResourcesAcquirer* sra,
                                           ModuleCallingContext const* mcc) const;
 
-    void putOrMerge(std::unique_ptr<WrapperBase> prod, ProductResolverBase const* productResolver) const;
+    void put_(std::unique_ptr<WrapperBase> prod, ProductResolverBase const* productResolver) const;
 
     std::shared_ptr<ProcessHistory const> processHistoryPtr_;
 

--- a/FWCore/Framework/interface/ProductResolverBase.h
+++ b/FWCore/Framework/interface/ProductResolverBase.h
@@ -159,15 +159,6 @@ namespace edm {
     // Retrieves the product ID of the product.
     ProductID const& productID() const { return provenance()->productID(); }
 
-    // Puts the product into the ProductResolver.
-    void putProduct(std::unique_ptr<WrapperBase> edp) const { putProduct_(std::move(edp)); }
-
-    // If the product already exists we merge, else will put
-    void putOrMergeProduct(std::unique_ptr<WrapperBase> edp,
-                           MergeableRunProductMetadata const* mergeableRunProductMetadata = nullptr) const {
-      putOrMergeProduct_(std::move(edp), mergeableRunProductMetadata);
-    }
-
     virtual void connectTo(ProductResolverBase const&, Principal const*) = 0;
     virtual void setupUnscheduled(UnscheduledConfigurator const&);
 
@@ -192,9 +183,6 @@ namespace edm {
     virtual bool productWasDeleted_() const = 0;
     virtual bool productWasFetchedAndIsValid_(bool iSkipCurrentProcess) const = 0;
 
-    virtual void putProduct_(std::unique_ptr<WrapperBase> edp) const = 0;
-    virtual void putOrMergeProduct_(std::unique_ptr<WrapperBase> edp,
-                                    MergeableRunProductMetadata const* mergeableRunProductMetadata) const = 0;
     virtual BranchDescription const& branchDescription_() const = 0;
     virtual void resetBranchDescription_(std::shared_ptr<BranchDescription const> bd) = 0;
     virtual Provenance const* provenance_() const = 0;

--- a/FWCore/Framework/interface/RunPrincipal.h
+++ b/FWCore/Framework/interface/RunPrincipal.h
@@ -76,6 +76,8 @@ namespace edm {
 
     void put(ProductResolverIndex index, std::unique_ptr<WrapperBase> edp) const;
 
+    void putOrMerge(BranchDescription const& bd, std::unique_ptr<WrapperBase> edp) const;
+
     MergeableRunProductMetadata* mergeableRunProductMetadata() { return mergeableRunProductMetadataPtr_.get(); }
 
     void preReadFile();

--- a/FWCore/Framework/src/Event.cc
+++ b/FWCore/Framework/src/Event.cc
@@ -8,6 +8,7 @@
 #include "FWCore/Framework/interface/EventPrincipal.h"
 #include "FWCore/Framework/interface/LuminosityBlock.h"
 #include "FWCore/Framework/src/TransitionInfoTypes.h"
+#include "FWCore/Framework/src/ProductPutterBase.h"
 #include "FWCore/ParameterSet/interface/Registry.h"
 #include "FWCore/Utilities/interface/Algorithms.h"
 #include "FWCore/Utilities/interface/InputTag.h"
@@ -169,7 +170,7 @@ namespace edm {
       for (auto index : iShouldPut) {
         auto resolver = p.getProductResolverByIndex(index);
         if (not resolver->productResolved()) {
-          resolver->putProduct(std::unique_ptr<WrapperBase>());
+          dynamic_cast<ProductPutterBase const*>(resolver)->putProduct(std::unique_ptr<WrapperBase>());
         }
       }
     }

--- a/FWCore/Framework/src/EventPrincipal.cc
+++ b/FWCore/Framework/src/EventPrincipal.cc
@@ -17,6 +17,7 @@
 #include "FWCore/Framework/interface/ProductResolverBase.h"
 #include "FWCore/Framework/interface/LuminosityBlockPrincipal.h"
 #include "FWCore/Framework/src/ProductDeletedException.h"
+#include "FWCore/Framework/src/ProductPutterBase.h"
 #include "FWCore/Framework/interface/SharedResourcesAcquirer.h"
 #include "FWCore/Utilities/interface/Algorithms.h"
 #include "FWCore/Utilities/interface/EDMException.h"
@@ -189,7 +190,7 @@ namespace edm {
     auto phb = getExistingProduct(bd.branchID());
     assert(phb);
     // ProductResolver assumes ownership
-    phb->putProduct(std::move(edp));
+    dynamic_cast<ProductPutterBase const*>(phb)->putProduct(std::move(edp));
   }
 
   void EventPrincipal::put(ProductResolverIndex index, std::unique_ptr<WrapperBase> edp, ParentageID parentage) const {
@@ -204,7 +205,7 @@ namespace edm {
 
     assert(phb);
     // ProductResolver assumes ownership
-    phb->putProduct(std::move(edp));
+    dynamic_cast<ProductPutterBase const*>(phb)->putProduct(std::move(edp));
   }
 
   void EventPrincipal::putOnRead(BranchDescription const& bd,
@@ -217,7 +218,7 @@ namespace edm {
     auto phb = getExistingProduct(bd.branchID());
     assert(phb);
     // ProductResolver assumes ownership
-    phb->putProduct(std::move(edp));
+    dynamic_cast<ProductPutterBase const*>(phb)->putProduct(std::move(edp));
   }
 
   BranchID EventPrincipal::pidToBid(ProductID const& pid) const {

--- a/FWCore/Framework/src/LuminosityBlock.cc
+++ b/FWCore/Framework/src/LuminosityBlock.cc
@@ -3,6 +3,7 @@
 #include "FWCore/Framework/interface/LuminosityBlockPrincipal.h"
 #include "FWCore/Framework/interface/Run.h"
 #include "FWCore/Framework/src/TransitionInfoTypes.h"
+#include "FWCore/Framework/src/ProductPutterBase.h"
 #include "FWCore/Utilities/interface/Algorithms.h"
 #include "FWCore/Utilities/interface/get_underlying_safe.h"
 
@@ -92,7 +93,7 @@ namespace edm {
         auto resolver = p.getProductResolverByIndex(index);
         if (not resolver->productResolved() and isEndTransition(provRecorder_.transition()) ==
                                                     resolver->branchDescription().availableOnlyAtEndTransition()) {
-          resolver->putProduct(std::unique_ptr<WrapperBase>());
+          dynamic_cast<ProductPutterBase const*>(resolver)->putProduct(std::unique_ptr<WrapperBase>());
         }
       }
     }

--- a/FWCore/Framework/src/LuminosityBlockPrincipal.cc
+++ b/FWCore/Framework/src/LuminosityBlockPrincipal.cc
@@ -1,5 +1,5 @@
 #include "FWCore/Framework/interface/LuminosityBlockPrincipal.h"
-
+#include "FWCore/Framework/src/ProductPutterBase.h"
 #include "DataFormats/Provenance/interface/ProductRegistry.h"
 
 namespace edm {
@@ -19,12 +19,12 @@ namespace edm {
   }
 
   void LuminosityBlockPrincipal::put(BranchDescription const& bd, std::unique_ptr<WrapperBase> edp) const {
-    putOrMerge(bd, std::move(edp));
+    put_(bd, std::move(edp));
   }
 
   void LuminosityBlockPrincipal::put(ProductResolverIndex index, std::unique_ptr<WrapperBase> edp) const {
     auto phb = getProductResolverByIndex(index);
-    phb->putOrMergeProduct(std::move(edp));
+    dynamic_cast<ProductPutterBase const*>(phb)->putProduct(std::move(edp));
   }
 
   unsigned int LuminosityBlockPrincipal::transitionIndex_() const { return index().value(); }

--- a/FWCore/Framework/src/ProcessBlock.cc
+++ b/FWCore/Framework/src/ProcessBlock.cc
@@ -1,5 +1,6 @@
 #include "FWCore/Framework/interface/ProcessBlock.h"
 #include "FWCore/Framework/interface/ProcessBlockPrincipal.h"
+#include "FWCore/Framework/src/ProductPutterBase.h"
 
 namespace edm {
 
@@ -42,7 +43,7 @@ namespace edm {
         auto resolver = principal.getProductResolverByIndex(index);
         if (not resolver->productResolved() and isEndTransition(provRecorder_.transition()) ==
                                                     resolver->branchDescription().availableOnlyAtEndTransition()) {
-          resolver->putProduct(std::unique_ptr<WrapperBase>());
+          dynamic_cast<ProductPutterBase const*>(resolver)->putProduct(std::unique_ptr<WrapperBase>());
         }
       }
     }

--- a/FWCore/Framework/src/ProcessBlockPrincipal.cc
+++ b/FWCore/Framework/src/ProcessBlockPrincipal.cc
@@ -1,4 +1,5 @@
 #include "FWCore/Framework/interface/ProcessBlockPrincipal.h"
+#include "FWCore/Framework/src/ProductPutterBase.h"
 
 #include "DataFormats/Provenance/interface/ProductRegistry.h"
 #include "DataFormats/Provenance/interface/BranchType.h"
@@ -19,7 +20,7 @@ namespace edm {
 
   void ProcessBlockPrincipal::put(ProductResolverIndex index, std::unique_ptr<WrapperBase> edp) const {
     auto phb = getProductResolverByIndex(index);
-    phb->putProduct(std::move(edp));
+    dynamic_cast<ProductPutterBase const*>(phb)->putProduct(std::move(edp));
   }
 
   unsigned int ProcessBlockPrincipal::transitionIndex_() const {

--- a/FWCore/Framework/src/ProductPutOrMergerBase.h
+++ b/FWCore/Framework/src/ProductPutOrMergerBase.h
@@ -1,0 +1,26 @@
+//
+//  ProductPutOrMergerBase.h
+//  CMSSW
+//
+//  Created by Chris Jones on 3/18/21.
+//
+
+#ifndef FWCore_Framework_ProductPutOrMergerBase_h
+#define FWCore_Framework_ProductPutOrMergerBase_h
+
+#include <memory>
+
+namespace edm {
+  class WrapperBase;
+  class MergeableRunProductMetadata;
+
+  class ProductPutOrMergerBase {
+  public:
+    ProductPutOrMergerBase() = default;
+    virtual ~ProductPutOrMergerBase() = default;
+
+    virtual void putOrMergeProduct(std::unique_ptr<WrapperBase> edp) const = 0;
+  };
+}  // namespace edm
+
+#endif /* ProductPutOrMergerBase_h */

--- a/FWCore/Framework/src/ProductPutterBase.h
+++ b/FWCore/Framework/src/ProductPutterBase.h
@@ -1,0 +1,26 @@
+//
+//  ProductPutterBase.h
+//  CMSSW
+//
+//  Created by Chris Jones on 3/18/21.
+//
+
+#ifndef FWCore_Framework_ProductPutterBase_h
+#define FWCore_Framework_ProductPutterBase_h
+
+#include <memory>
+
+namespace edm {
+  class WrapperBase;
+
+  class ProductPutterBase {
+  public:
+    ProductPutterBase() = default;
+    virtual ~ProductPutterBase() = default;
+
+    // Puts the product into the ProductResolver.
+    virtual void putProduct(std::unique_ptr<WrapperBase> edp) const = 0;
+  };
+}  // namespace edm
+
+#endif /* ProductPutterBase_h */

--- a/FWCore/Framework/src/ProductResolvers.cc
+++ b/FWCore/Framework/src/ProductResolvers.cc
@@ -77,7 +77,7 @@ namespace edm {
     return Resolution(nullptr);
   }
 
-  void DelayedReaderInputProductResolver::mergeProduct(
+  void MergeableInputProductResolver::mergeProduct(
       std::unique_ptr<WrapperBase> iFrom, MergeableRunProductMetadata const* mergeableRunProductMetadata) const {
     // if its not mergeable and the previous read failed, go ahead and use this one
     if (status() == ProductStatus::ResolveFailed) {
@@ -213,7 +213,7 @@ namespace edm {
         }
         if (status() == defaultStatus() || status() == ProductStatus::ProductSet ||
             (status() == ProductStatus::ResolveFailed && !branchDescription().isMergeable())) {
-          putOrMergeProduct_(std::move(edp), mergeableRunProductMetadata);
+          setOrMergeProduct(std::move(edp), mergeableRunProductMetadata);
         } else {  // status() == ResolveFailed && branchDescription().isMergeable()
           throw Exception(errors::MismatchedInputFiles)
               << "Merge of Run or Lumi product failed for branch " << branchDescription().branchName() << "\n"
@@ -237,7 +237,7 @@ namespace edm {
     }
   }
 
-  void DelayedReaderInputProductResolver::putOrMergeProduct_(
+  void MergeableInputProductResolver::setOrMergeProduct(
       std::unique_ptr<WrapperBase> prod, MergeableRunProductMetadata const* mergeableRunProductMetadata) const {
     if (status() == defaultStatus()) {
       //resolveProduct has not been called or it failed
@@ -347,6 +347,10 @@ namespace edm {
                                                      ServiceToken const& token,
                                                      SharedResourcesAcquirer* sra,
                                                      ModuleCallingContext const* mcc) const {}
+
+  void PutOnReadInputProductResolver::putOrMergeProduct(std::unique_ptr<WrapperBase> edp) const {
+    setOrMergeProduct(std::move(edp), nullptr);
+  }
 
   ProductResolverBase::Resolution PuttableProductResolver::resolveProduct_(Principal const&,
                                                                            bool skipCurrentProcess,

--- a/FWCore/Framework/src/ProductResolvers.h
+++ b/FWCore/Framework/src/ProductResolvers.h
@@ -8,6 +8,7 @@ a set of related EDProducts. This is the storage unit of such information.
 
 ----------------------------------------------------------------------*/
 #include "FWCore/Framework/interface/ProductResolverBase.h"
+#include "FWCore/Framework/src/ProductPutterBase.h"
 #include "DataFormats/Common/interface/WrapperBase.h"
 #include "DataFormats/Common/interface/ProductData.h"
 #include "DataFormats/Provenance/interface/BranchDescription.h"
@@ -71,15 +72,12 @@ namespace edm {
     ProductData const& getProductData() const final { return productData_; }
     void setMergeableRunProductMetadataInProductData(MergeableRunProductMetadata const*);
 
+    void checkType(WrapperBase const& prod) const;
+
   private:
     void throwProductDeletedException() const;
-    void checkType(WrapperBase const& prod) const;
     virtual bool isFromCurrentProcess() const = 0;
-    // merges the product with the pre-existing product
-    void mergeProduct(std::unique_ptr<WrapperBase> edp, MergeableRunProductMetadata const*) const;
 
-    void putOrMergeProduct_(std::unique_ptr<WrapperBase> prod,
-                            MergeableRunProductMetadata const* mergeableRunProductMetadata) const final;
     bool productUnavailable_() const final;
     bool productResolved_() const final;
     bool productWasDeleted_() const final;
@@ -102,10 +100,13 @@ namespace edm {
     ProductStatus const defaultStatus_;
   };
 
-  class InputProductResolver : public DataManagingProductResolver {
+  class DelayedReaderInputProductResolver : public DataManagingProductResolver {
   public:
-    explicit InputProductResolver(std::shared_ptr<BranchDescription const> bd)
-        : DataManagingProductResolver(bd, ProductStatus::ResolveNotRun), m_prefetchRequested{false}, aux_{nullptr} {}
+    explicit DelayedReaderInputProductResolver(std::shared_ptr<BranchDescription const> bd)
+        : DataManagingProductResolver(bd, ProductStatus::ResolveNotRun), m_prefetchRequested{false}, aux_{nullptr} {
+      assert(bd->onDemand());
+      assert(not bd->produced());
+    }
 
     void setupUnscheduled(UnscheduledConfigurator const&) final;
 
@@ -122,10 +123,14 @@ namespace edm {
                         ServiceToken const& token,
                         SharedResourcesAcquirer* sra,
                         ModuleCallingContext const* mcc) const override;
-    void putProduct_(std::unique_ptr<WrapperBase> edp) const override;
 
     void retrieveAndMerge_(Principal const& principal,
                            MergeableRunProductMetadata const* mergeableRunProductMetadata) const override;
+    void putOrMergeProduct_(std::unique_ptr<WrapperBase> prod,
+                            MergeableRunProductMetadata const* mergeableRunProductMetadata) const;
+
+    // merges the product with the pre-existing product
+    void mergeProduct(std::unique_ptr<WrapperBase> edp, MergeableRunProductMetadata const*) const;
 
     void setMergeableRunProductMetadata_(MergeableRunProductMetadata const*) override;
 
@@ -138,7 +143,34 @@ namespace edm {
     UnscheduledAuxiliary const* aux_;  //provides access to the delayedGet signals
   };
 
-  class ProducedProductResolver : public DataManagingProductResolver {
+  class PutOnReadInputProductResolver : public DataManagingProductResolver, public ProductPutterBase {
+  public:
+    PutOnReadInputProductResolver(std::shared_ptr<BranchDescription const> bd)
+        : DataManagingProductResolver(bd, ProductStatus::ResolveNotRun) {
+      assert(not bd->produced());
+      assert(not bd->onDemand());
+    }
+
+  protected:
+    void putProduct(std::unique_ptr<WrapperBase> edp) const override;
+
+    Resolution resolveProduct_(Principal const& principal,
+                               bool skipCurrentProcess,
+                               SharedResourcesAcquirer* sra,
+                               ModuleCallingContext const* mcc) const final;
+    void prefetchAsync_(WaitingTaskHolder waitTask,
+                        Principal const& principal,
+                        bool skipCurrentProcess,
+                        ServiceToken const& token,
+                        SharedResourcesAcquirer* sra,
+                        ModuleCallingContext const* mcc) const final;
+    bool unscheduledWasNotRun_() const final { return false; }
+
+  private:
+    bool isFromCurrentProcess() const final;
+  };
+
+  class ProducedProductResolver : public DataManagingProductResolver, public ProductPutterBase {
   public:
     ProducedProductResolver(std::shared_ptr<BranchDescription const> bd, ProductStatus iDefaultStatus)
         : DataManagingProductResolver(bd, iDefaultStatus) {
@@ -146,7 +178,7 @@ namespace edm {
     }
 
   protected:
-    void putProduct_(std::unique_ptr<WrapperBase> edp) const override;
+    void putProduct(std::unique_ptr<WrapperBase> edp) const override;
 
   private:
     bool isFromCurrentProcess() const final;
@@ -172,7 +204,7 @@ namespace edm {
                         ModuleCallingContext const* mcc) const override;
     bool unscheduledWasNotRun_() const override { return false; }
 
-    void putProduct_(std::unique_ptr<WrapperBase> edp) const override;
+    void putProduct(std::unique_ptr<WrapperBase> edp) const override;
     void resetProductData_(bool deleteEarly) override;
 
     CMS_THREAD_SAFE mutable WaitingTaskList m_waitingTasks;
@@ -242,9 +274,6 @@ namespace edm {
       return realProduct_.productWasFetchedAndIsValid(iSkipCurrentProcess);
     }
 
-    void putProduct_(std::unique_ptr<WrapperBase> edp) const override;
-    void putOrMergeProduct_(std::unique_ptr<WrapperBase> prod,
-                            MergeableRunProductMetadata const* mergeableRunProductMetadata) const final;
     BranchDescription const& branchDescription_() const override { return *bd_; }
     void resetBranchDescription_(std::shared_ptr<BranchDescription const> bd) override { bd_ = bd; }
     Provenance const* provenance_() const final { return realProduct_.provenance(); }
@@ -286,8 +315,6 @@ namespace edm {
     bool productWasFetchedAndIsValid_(bool iSkipCurrentProcess) const final {
       return realProduct_.productWasFetchedAndIsValid(iSkipCurrentProcess);
     }
-    void putOrMergeProduct_(std::unique_ptr<WrapperBase> edp,
-                            MergeableRunProductMetadata const* mergeableRunProductMetadata) const final;
     BranchDescription const& branchDescription_() const final {
       return *productData_.branchDescription();
       ;
@@ -315,7 +342,7 @@ namespace edm {
   };
 
   // For the case when SwitchProducer is on a Path
-  class SwitchProducerProductResolver : public SwitchBaseProductResolver {
+  class SwitchProducerProductResolver : public SwitchBaseProductResolver, public ProductPutterBase {
   public:
     SwitchProducerProductResolver(std::shared_ptr<BranchDescription const> bd,
                                   DataManagingOrAliasProductResolver& realProduct);
@@ -331,7 +358,7 @@ namespace edm {
                         ServiceToken const& token,
                         SharedResourcesAcquirer* sra,
                         ModuleCallingContext const* mcc) const final;
-    void putProduct_(std::unique_ptr<WrapperBase> edp) const final;
+    void putProduct(std::unique_ptr<WrapperBase> edp) const final;
     bool unscheduledWasNotRun_() const final { return false; }
     bool productUnavailable_() const final;
     void resetProductData_(bool deleteEarly) final;
@@ -362,7 +389,6 @@ namespace edm {
                         ServiceToken const& token,
                         SharedResourcesAcquirer* sra,
                         ModuleCallingContext const* mcc) const final;
-    void putProduct_(std::unique_ptr<WrapperBase> edp) const final;
     bool unscheduledWasNotRun_() const final { return realProduct().unscheduledWasNotRun(); }
     bool productUnavailable_() const final { return realProduct().productUnavailable(); }
   };
@@ -409,9 +435,6 @@ namespace edm {
       return realProduct_->productWasFetchedAndIsValid(iSkipCurrentProcess);
     }
 
-    void putProduct_(std::unique_ptr<WrapperBase> edp) const override;
-    void putOrMergeProduct_(std::unique_ptr<WrapperBase> prod,
-                            MergeableRunProductMetadata const* mergeableRunProductMetadata) const final;
     BranchDescription const& branchDescription_() const override { return *bd_; }
     void resetBranchDescription_(std::shared_ptr<BranchDescription const> bd) override { bd_ = bd; }
     Provenance const* provenance_() const final { return realProduct_->provenance(); }
@@ -473,9 +496,6 @@ namespace edm {
     bool productResolved_() const final;
     bool productWasFetchedAndIsValid_(bool iSkipCurrentProcess) const override;
 
-    void putProduct_(std::unique_ptr<WrapperBase> edp) const override;
-    void putOrMergeProduct_(std::unique_ptr<WrapperBase> prod,
-                            MergeableRunProductMetadata const* mergeableRunProductMetadata) const final;
     BranchDescription const& branchDescription_() const override;
     void resetBranchDescription_(std::shared_ptr<BranchDescription const> bd) override;
     Provenance const* provenance_() const override;
@@ -531,9 +551,6 @@ namespace edm {
     bool productResolved_() const final;
     bool productWasFetchedAndIsValid_(bool iSkipCurrentProcess) const override;
 
-    void putProduct_(std::unique_ptr<WrapperBase> edp) const override;
-    void putOrMergeProduct_(std::unique_ptr<WrapperBase> prod,
-                            MergeableRunProductMetadata const* mergeableRunProductMetadata) const final;
     BranchDescription const& branchDescription_() const override;
     void resetBranchDescription_(std::shared_ptr<BranchDescription const> bd) override;
     Provenance const* provenance_() const override;

--- a/FWCore/Framework/src/Run.cc
+++ b/FWCore/Framework/src/Run.cc
@@ -2,6 +2,7 @@
 
 #include "FWCore/Framework/interface/RunPrincipal.h"
 #include "FWCore/Framework/src/TransitionInfoTypes.h"
+#include "FWCore/Framework/src/ProductPutterBase.h"
 #include "FWCore/Utilities/interface/Algorithms.h"
 #include "FWCore/Utilities/interface/get_underlying_safe.h"
 
@@ -98,7 +99,7 @@ namespace edm {
         auto resolver = p.getProductResolverByIndex(index);
         if (not resolver->productResolved() and isEndTransition(provRecorder_.transition()) ==
                                                     resolver->branchDescription().availableOnlyAtEndTransition()) {
-          resolver->putProduct(std::unique_ptr<WrapperBase>());
+          dynamic_cast<ProductPutterBase const*>(resolver)->putProduct(std::unique_ptr<WrapperBase>());
         }
       }
     }

--- a/FWCore/Framework/src/RunPrincipal.cc
+++ b/FWCore/Framework/src/RunPrincipal.cc
@@ -5,6 +5,7 @@
 #include "FWCore/Framework/interface/ProductResolverBase.h"
 #include "FWCore/Framework/interface/MergeableRunProductMetadata.h"
 #include "FWCore/Framework/src/ProductPutterBase.h"
+#include "FWCore/Framework/src/ProductPutOrMergerBase.h"
 
 namespace edm {
   RunPrincipal::RunPrincipal(std::shared_ptr<RunAuxiliary> aux,
@@ -41,6 +42,17 @@ namespace edm {
   void RunPrincipal::put(ProductResolverIndex index, std::unique_ptr<WrapperBase> edp) const {
     auto phb = getProductResolverByIndex(index);
     dynamic_cast<ProductPutterBase const*>(phb)->putProduct(std::move(edp));
+  }
+
+  void RunPrincipal::putOrMerge(BranchDescription const& bd, std::unique_ptr<WrapperBase> prod) const {
+    if (prod.get() == nullptr) {
+      throw edm::Exception(edm::errors::InsertFailure, "Null Pointer")
+          << "putOrMerge: Cannot put because unique_ptr to product is null."
+          << "\n";
+    }
+    auto phb = getExistingProduct(bd.branchID());
+    assert(phb);
+    dynamic_cast<ProductPutOrMergerBase const*>(phb)->putOrMergeProduct(std::move(prod));
   }
 
   unsigned int RunPrincipal::transitionIndex_() const { return index().value(); }

--- a/FWCore/Framework/src/RunPrincipal.cc
+++ b/FWCore/Framework/src/RunPrincipal.cc
@@ -4,6 +4,7 @@
 #include "DataFormats/Provenance/interface/ProductRegistry.h"
 #include "FWCore/Framework/interface/ProductResolverBase.h"
 #include "FWCore/Framework/interface/MergeableRunProductMetadata.h"
+#include "FWCore/Framework/src/ProductPutterBase.h"
 
 namespace edm {
   RunPrincipal::RunPrincipal(std::shared_ptr<RunAuxiliary> aux,
@@ -34,12 +35,12 @@ namespace edm {
   }
 
   void RunPrincipal::put(BranchDescription const& bd, std::unique_ptr<WrapperBase> edp) const {
-    putOrMerge(bd, std::move(edp));
+    put_(bd, std::move(edp));
   }
 
   void RunPrincipal::put(ProductResolverIndex index, std::unique_ptr<WrapperBase> edp) const {
     auto phb = getProductResolverByIndex(index);
-    phb->putOrMergeProduct(std::move(edp));
+    dynamic_cast<ProductPutterBase const*>(phb)->putProduct(std::move(edp));
   }
 
   unsigned int RunPrincipal::transitionIndex_() const { return index().value(); }

--- a/FWCore/Integration/test/BuildFile.xml
+++ b/FWCore/Integration/test/BuildFile.xml
@@ -244,6 +244,12 @@
     <use name="FWCore/Sources"/>
   </library>
 
+  <library file="PutOrMergeTestSource.cc" name="PutOrMergeTestSource">
+    <flags EDM_PLUGIN="1"/>
+    <use name="FWCore/Sources"/>
+    <use name="DataFormats/TestObjects"/>
+  </library>
+
   <library file="OtherThingProducer.cc,OtherThingAlgorithm.cc" name="TestOtherThingProducer">
     <flags EDM_PLUGIN="1"/>
     <use name="DataFormats/Common"/>
@@ -431,4 +437,6 @@
   </bin>
 
   <test name="TestFWCoreIntegrationInterProcess" command="cmsRun ${LOCALTOP}/src/FWCore/Integration/test/test_TestInterProcessProd_cfg.py"/>
+
+  <test name="TestFWCoreIntegrationPutOrMerge" command="cmsRun ${LOCALTOP}/src/FWCore/Integration/test/putOrMergeTest_cfg.py"/>
 </environment>

--- a/FWCore/Integration/test/PutOrMergeTestSource.cc
+++ b/FWCore/Integration/test/PutOrMergeTestSource.cc
@@ -1,0 +1,151 @@
+//
+//  PutOrMergeTestSource.cc
+//  CMSSW
+//
+//  Created by Chris Jones on 3/23/21.
+//
+
+#include "FWCore/Framework/interface/InputSource.h"
+#include "FWCore/Framework/interface/InputSourceMacros.h"
+#include "FWCore/Framework/interface/FileBlock.h"
+#include "FWCore/Framework/interface/RunPrincipal.h"
+
+#include "DataFormats/Provenance/interface/ProductRegistry.h"
+#include "DataFormats/Provenance/interface/ProcessHistory.h"
+#include "DataFormats/Provenance/interface/ProcessHistoryRegistry.h"
+
+#include "DataFormats/TestObjects/interface/Thing.h"
+#include "DataFormats/TestObjects/interface/ThingWithMerge.h"
+#include "DataFormats/TestObjects/interface/ThingWithIsEqual.h"
+
+#include <cassert>
+using namespace edm;
+
+namespace edmtest {
+  class PutOrMergeTestSource : public InputSource {
+  public:
+    PutOrMergeTestSource(ParameterSet const&, InputSourceDescription const&);
+
+    /// Register any produced products
+    void registerProducts() final;
+
+  private:
+    ItemType getNextItemType() final;
+    std::shared_ptr<RunAuxiliary> readRunAuxiliary_() final;
+    std::shared_ptr<LuminosityBlockAuxiliary> readLuminosityBlockAuxiliary_() final;
+    std::unique_ptr<FileBlock> readFile_() final;
+    void readRun_(RunPrincipal& runPrincipal) final;
+    void readEvent_(EventPrincipal& eventPrincipal) final;
+
+    int stage_;
+    ParameterSet const dummyPSet_;
+    BranchDescription thingDesc_;
+    BranchDescription thingWithMergeDesc_;
+    BranchDescription thingWithEqualDesc_;
+    ProcessHistoryID historyID_;
+  };
+}  // namespace edmtest
+
+using namespace edmtest;
+
+PutOrMergeTestSource::PutOrMergeTestSource(ParameterSet const& iPS, InputSourceDescription const& iISD)
+    : InputSource(iPS, iISD),
+      stage_(0),
+      dummyPSet_([]() {
+        ParameterSet dummy;
+        dummy.registerIt();
+        return dummy;
+      }()),
+      thingDesc_(InRun,
+                 "thingWithMergeProducer",
+                 "PROD",
+                 "edmtest::Thing",
+                 "edmtestThing",
+                 "endRun",
+                 "PutOrMergeTestSource",
+                 dummyPSet_.id(),
+                 edm::TypeWithDict(typeid(edmtest::Thing)),
+                 false,
+                 true),
+      thingWithMergeDesc_(InRun,
+                          "thingWithMergeProducer",
+                          "PROD",
+                          "edmtest::ThingWithMerge",
+                          "edmtestThingWithMerge",
+                          "endRun",
+                          "PutOrMergeTestSource",
+                          dummyPSet_.id(),
+                          edm::TypeWithDict(typeid(edmtest::ThingWithMerge)),
+                          false,
+                          true),
+      thingWithEqualDesc_(InRun,
+                          "thingWithMergeProducer",
+                          "PROD",
+                          "edmtest::ThingWithIsEqual",
+                          "edmtestThingWithIsEqual",
+                          "endRun",
+                          "PutOrMergeTestSource",
+                          dummyPSet_.id(),
+                          edm::TypeWithDict(typeid(edmtest::ThingWithIsEqual)),
+                          false,
+                          true) {
+  edm::ParameterSet dummyPset;
+  dummyPset.registerIt();
+
+  ProcessHistory history;
+  history.emplace_back("PROD", dummyPset.id(), "RELVERSION", "PASSID");
+  processHistoryRegistry().registerProcessHistory(history);
+  historyID_ = history.id();
+}
+
+void PutOrMergeTestSource::registerProducts() {
+  edm::ParameterSet dummyPset;
+  dummyPset.registerIt();
+
+  thingDesc_.setIsProvenanceSetOnRead();
+  thingWithMergeDesc_.setIsProvenanceSetOnRead();
+  productRegistryUpdate().copyProduct(thingDesc_);
+  productRegistryUpdate().copyProduct(thingWithMergeDesc_);
+  productRegistryUpdate().copyProduct(thingWithEqualDesc_);
+}
+
+InputSource::ItemType PutOrMergeTestSource::getNextItemType() {
+  switch (stage_) {
+    case 0: {
+      return IsFile;
+    }
+    case 1: {
+      return IsRun;
+    }
+    case 2: {
+      return IsRun;
+    }
+    default:
+      return IsStop;
+  }
+  return IsInvalid;
+}
+
+std::shared_ptr<RunAuxiliary> PutOrMergeTestSource::readRunAuxiliary_() {
+  auto id = std::make_shared<RunAuxiliary>(1, Timestamp::beginOfTime(), Timestamp::endOfTime());
+  id->setProcessHistoryID(historyID_);
+  return id;
+}
+std::shared_ptr<LuminosityBlockAuxiliary> PutOrMergeTestSource::readLuminosityBlockAuxiliary_() { return {}; }
+std::unique_ptr<FileBlock> PutOrMergeTestSource::readFile_() {
+  ++stage_;
+  return std::make_unique<FileBlock>();
+}
+void PutOrMergeTestSource::readRun_(RunPrincipal& runPrincipal) {
+  runAuxiliary()->setProcessHistoryID(historyID_);
+  runPrincipal.fillRunPrincipal(processHistoryRegistry());
+  ++stage_;
+  runPrincipal.putOrMerge(thingDesc_, std::make_unique<Wrapper<edmtest::Thing>>(WrapperBase::Emplace{}, 100001));
+  runPrincipal.putOrMerge(thingWithMergeDesc_,
+                          std::make_unique<Wrapper<edmtest::ThingWithMerge>>(WrapperBase::Emplace{}, 100002));
+  runPrincipal.putOrMerge(thingWithEqualDesc_,
+                          std::make_unique<Wrapper<edmtest::ThingWithIsEqual>>(WrapperBase::Emplace{}, 100003));
+}
+void PutOrMergeTestSource::readEvent_(EventPrincipal& eventPrincipal) { assert(false); }
+
+DEFINE_FWK_INPUT_SOURCE(PutOrMergeTestSource);

--- a/FWCore/Integration/test/putOrMergeTest_cfg.py
+++ b/FWCore/Integration/test/putOrMergeTest_cfg.py
@@ -1,0 +1,35 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("TEST")
+
+process.source = cms.Source("PutOrMergeTestSource")
+
+
+process.test = cms.EDAnalyzer("TestMergeResults",
+
+    #   Check to see that the value we read matches what we know
+    #   was written. Expected values listed below come in sets of three
+    #      value expected in Thing
+    #      value expected in ThingWithMerge
+    #      value expected in ThingWithIsEqual
+    #   Each set of 3 is tested at endRun for the expected
+    #   run values or at endLuminosityBlock for the expected
+    #   lumi values. And then the next set of three values
+    #   is tested at the next endRun or endLuminosityBlock.
+    #   When the sequence of parameter values is exhausted it stops checking
+
+    expectedBeginRunProd = cms.untracked.vint32(
+    ),
+
+    expectedEndRunProd = cms.untracked.vint32(
+        100001,   200004,  100003,
+    ),
+
+    expectedEndRunProdImproperlyMerged = cms.untracked.vint32(
+    )
+)
+
+#process.dump = cms.EDAnalyzer("EventContentAnalyzer")
+process.end = cms.EndPath(process.test)
+
+#process.add_(cms.Service("Tracer"))

--- a/FWCore/TFWLiteSelector/src/TFWLiteSelectorBasic.cc
+++ b/FWCore/TFWLiteSelector/src/TFWLiteSelectorBasic.cc
@@ -477,6 +477,7 @@ void TFWLiteSelectorBasic::setupNewFile(TFile& iFile) {
       if (m_->tree_->GetBranch(prod.branchName().c_str()) == nullptr) {
         prod.setDropped(true);
       }
+      prod.setOnDemand(true);
 
       //std::cout << "id " << it->first << " branch " << it->second << std::endl;
       //m_->pointerToBranchBuffer_.push_back(&(*itB));

--- a/FWCore/TestProcessor/src/TestProcessor.cc
+++ b/FWCore/TestProcessor/src/TestProcessor.cc
@@ -29,6 +29,7 @@
 #include "FWCore/Framework/src/globalTransitionAsync.h"
 #include "FWCore/Framework/src/streamTransitionAsync.h"
 #include "FWCore/Framework/src/TransitionInfoTypes.h"
+#include "FWCore/Framework/src/ProductPutterBase.h"
 #include "FWCore/Framework/interface/DelayedReader.h"
 
 #include "FWCore/ServiceRegistry/interface/ServiceRegistry.h"
@@ -561,7 +562,7 @@ namespace edm {
           //The data product was not set so we need to
           // tell the ProductResolver not to wait
           auto r = pep->getProductResolver(p.first.branchID());
-          r->putProduct(std::unique_ptr<WrapperBase>());
+          dynamic_cast<ProductPutterBase const*>(r)->putProduct(std::unique_ptr<WrapperBase>());
         }
       }
 

--- a/GeneratorInterface/LHEInterface/plugins/LHESource.cc
+++ b/GeneratorInterface/LHEInterface/plugins/LHESource.cc
@@ -115,7 +115,7 @@ void LHESource::putRunInfoProduct(edm::RunPrincipal& iRunPrincipal) {
   if (runInfoProductLast_) {
     auto product = std::make_unique<LHERunInfoProduct>(*runInfoProductLast_);
     std::unique_ptr<edm::WrapperBase> rdp(new edm::Wrapper<LHERunInfoProduct>(std::move(product)));
-    iRunPrincipal.put(lheProvenanceHelper_.runProductBranchDescription_, std::move(rdp));
+    iRunPrincipal.putOrMerge(lheProvenanceHelper_.runProductBranchDescription_, std::move(rdp));
   }
 }
 

--- a/IOPool/Input/src/RootFile.cc
+++ b/IOPool/Input/src/RootFile.cc
@@ -546,6 +546,10 @@ namespace edm {
           setIsMergeable(product.second);
         }
       }
+      //inform system we want to use DelayedReader
+      for (auto& product : newReg->productListUpdator()) {
+        product.second.setOnDemand(true);
+      }
 
       // freeze the product registry
       newReg->setFrozen(inputType != InputType::Primary);


### PR DESCRIPTION
#### PR description:

- Removed put interfaces from base class and use ProductPutterBase abstract class instead
- Separated InputProductResolver into DelayedReader* and PutOnRead* variants
- BranchDescription::onDemand is also true for case of DelayedReader being used by source
- putOrMerge on ProductResolvers was not being used so was removed.

#### PR validation:

- code compiles
- framework related unit tests all pass.