### PR TITLE
Migrate to esConsumes some more vertexing-related packages

### DIFF
--- a/RecoVertex/KalmanVertexFit/plugins/KVFTest.cc
+++ b/RecoVertex/KalmanVertexFit/plugins/KVFTest.cc
@@ -6,16 +6,9 @@
 #include "DataFormats/Common/interface/Handle.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
-#include "FWCore/Framework/interface/ESHandle.h"
-
-#include "TrackingTools/TransientTrack/interface/TransientTrackBuilder.h"
-#include "TrackingTools/Records/interface/TransientTrackRecord.h"
 #include "TrackingTools/TransientTrack/interface/TransientTrack.h"
 #include "RecoVertex/VertexPrimitives/interface/TransientVertex.h"
 #include "RecoVertex/KalmanVertexFit/interface/KalmanVertexFitter.h"
-#include "MagneticField/Engine/interface/MagneticField.h"
-#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
-
 #include <iostream>
 #include <memory>
 
@@ -23,7 +16,10 @@ using namespace reco;
 using namespace edm;
 using namespace std;
 
-KVFTest::KVFTest(const edm::ParameterSet& iConfig) : theConfig(iConfig) {
+KVFTest::KVFTest(const edm::ParameterSet& iConfig)
+    : estoken_MF(esConsumes()),
+      estoken_TTB(esConsumes(edm::ESInputTag("", "TransientTrackBuilder"))),
+      theConfig(iConfig) {
   token_tracks = consumes<TrackCollection>(iConfig.getParameter<string>("TrackLabel"));
   outputFile_ = iConfig.getUntrackedParameter<std::string>("outputFile");
   kvfPSet = iConfig.getParameter<edm::ParameterSet>("KVFParameters");
@@ -51,9 +47,7 @@ void KVFTest::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
   iEvent.getByToken(token_associatorForParamAtPca, associatorForParamAtPca);
 
   if (not tree) {
-    edm::ESHandle<MagneticField> magField;
-    iSetup.get<IdealMagneticFieldRecord>().get(magField);
-    tree = std::make_unique<SimpleVertexTree>("VertexFitter", magField.product());
+    tree = std::make_unique<SimpleVertexTree>("VertexFitter", &iSetup.getData(estoken_MF));
   }
 
   edm::LogInfo("RecoVertex/KVFTest") << "Reconstructing event number: " << iEvent.id() << "\n";
@@ -67,15 +61,14 @@ void KVFTest::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
   } else {
     edm::LogInfo("RecoVertex/KVFTest") << "Found: " << (*tks).size() << " reconstructed tracks"
                                        << "\n";
-    std::cout << "got " << (*tks).size() << " tracks " << std::endl;
+    edm::LogPrint("RecoVertex/KVFTest") << "got " << (*tks).size() << " tracks " << std::endl;
 
     // Transform Track to TransientTrack
 
     //get the builder:
-    edm::ESHandle<TransientTrackBuilder> theB;
-    iSetup.get<TransientTrackRecord>().get("TransientTrackBuilder", theB);
+    const auto& theB = &iSetup.getData(estoken_TTB);
     //do the conversion:
-    std::vector<TransientTrack> t_tks = (*theB).build(tks);
+    std::vector<TransientTrack> t_tks = theB->build(tks);
 
     edm::LogInfo("RecoVertex/KVFTest") << "Found: " << t_tks.size() << " reconstructed tracks"
                                        << "\n";
@@ -86,7 +79,7 @@ void KVFTest::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
       KalmanVertexFitter kvf(true);
       TransientVertex tv = kvf.vertex(t_tks);
 
-      std::cout << "Position: " << Vertex::Point(tv.position()) << "\n";
+      edm::LogPrint("RecoVertex/KVFTest") << "Position: " << Vertex::Point(tv.position()) << "\n";
 
       // For the analysis: compare to your SimVertex
       TrackingVertex sv = getSimVertex(iEvent);

--- a/RecoVertex/KalmanVertexFit/plugins/KVFTest.h
+++ b/RecoVertex/KalmanVertexFit/plugins/KVFTest.h
@@ -15,25 +15,27 @@
 #include <memory>
 
 // user include files
-#include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
-
+#include "DataFormats/TrackReco/interface/TrackFwd.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
-
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "SimDataFormats/Vertex/interface/SimVertex.h"
-#include "SimDataFormats/TrackingAnalysis/interface/TrackingVertexContainer.h"
-#include "SimDataFormats/Associations/interface/TrackToTrackingParticleAssociator.h"
+#include "MagneticField/Engine/interface/MagneticField.h"
+#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
 #include "RecoVertex/KalmanVertexFit/interface/SimpleVertexTree.h"
-#include "DataFormats/TrackReco/interface/TrackFwd.h"
+#include "SimDataFormats/Associations/interface/TrackToTrackingParticleAssociator.h"
+#include "SimDataFormats/TrackingAnalysis/interface/TrackingVertexContainer.h"
+#include "SimDataFormats/Vertex/interface/SimVertex.h"
+#include "TrackingTools/Records/interface/TransientTrackRecord.h"
+#include "TrackingTools/TransientTrack/interface/TransientTrackBuilder.h"
 #include <TFile.h>
 
 /**
    * This is a very simple test analyzer mean to test the KalmanVertexFitter
    */
 
-class KVFTest : public edm::EDAnalyzer {
+class KVFTest : public edm::one::EDAnalyzer<> {
 public:
   explicit KVFTest(const edm::ParameterSet&);
   ~KVFTest() override;
@@ -45,6 +47,9 @@ public:
 
 private:
   TrackingVertex getSimVertex(const edm::Event& iEvent) const;
+
+  const edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> estoken_MF;
+  const edm::ESGetToken<TransientTrackBuilder, TransientTrackRecord> estoken_TTB;
 
   edm::ParameterSet theConfig;
   edm::ParameterSet kvfPSet;

--- a/RecoVertex/KalmanVertexFit/plugins/KVFTrackUpdate.cc
+++ b/RecoVertex/KalmanVertexFit/plugins/KVFTrackUpdate.cc
@@ -6,10 +6,6 @@
 #include "DataFormats/Common/interface/Handle.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
-#include "FWCore/Framework/interface/ESHandle.h"
-
-#include "TrackingTools/TransientTrack/interface/TransientTrackBuilder.h"
-#include "TrackingTools/Records/interface/TransientTrackRecord.h"
 #include "TrackingTools/TransientTrack/interface/TransientTrack.h"
 #include "RecoVertex/VertexPrimitives/interface/TransientVertex.h"
 #include "RecoVertex/KalmanVertexFit/interface/KalmanVertexFitter.h"
@@ -23,7 +19,8 @@ using namespace reco;
 using namespace edm;
 using namespace std;
 
-KVFTrackUpdate::KVFTrackUpdate(const edm::ParameterSet& iConfig) {
+KVFTrackUpdate::KVFTrackUpdate(const edm::ParameterSet& iConfig)
+    : estoken_TTB(esConsumes(edm::ESInputTag("", "TransientTrackBuilder"))) {
   token_tracks = consumes<TrackCollection>(iConfig.getParameter<InputTag>("TrackLabel"));
   token_beamSpot = consumes<BeamSpot>(iConfig.getParameter<InputTag>("beamSpotLabel"));
 }
@@ -49,15 +46,14 @@ void KVFTrackUpdate::analyze(const edm::Event& iEvent, const edm::EventSetup& iS
 
     edm::LogInfo("RecoVertex/KVFTrackUpdate") << "Found: " << (*tks).size() << " reconstructed tracks"
                                               << "\n";
-    std::cout << "got " << (*tks).size() << " tracks " << std::endl;
+    edm::LogPrint("RecoVertex/KVFTrackUpdate") << "got " << (*tks).size() << " tracks " << std::endl;
 
     // Transform Track to TransientTrack
 
     //get the builder:
-    edm::ESHandle<TransientTrackBuilder> theB;
-    iSetup.get<TransientTrackRecord>().get("TransientTrackBuilder", theB);
+    const auto& theB = &iSetup.getData(estoken_TTB);
     //do the conversion:
-    std::vector<TransientTrack> t_tks = (*theB).build(tks);
+    std::vector<TransientTrack> t_tks = theB->build(tks);
 
     edm::LogInfo("RecoVertex/KVFTrackUpdate") << "Found: " << t_tks.size() << " reconstructed tracks"
                                               << "\n";
@@ -77,10 +73,10 @@ void KVFTrackUpdate::analyze(const edm::Event& iEvent, const edm::EventSetup& iS
     SingleTrackVertexConstraint stvc;
     for (unsigned int i = 0; i < t_tks.size(); i++) {
       SingleTrackVertexConstraint::BTFtuple a = stvc.constrain(t_tks[i], glbPos, glbErrPos);
-      std::cout << "Chi2: " << std::get<2>(a) << std::endl;
+      edm::LogPrint("RecoVertex/KVFTrackUpdate") << "Chi2: " << std::get<2>(a) << std::endl;
       if (recoBeamSpotHandle.isValid()) {
         SingleTrackVertexConstraint::BTFtuple b = stvc.constrain(t_tks[i], *recoBeamSpotHandle);
-        std::cout << "Chi2: " << std::get<2>(b) << std::endl;
+        edm::LogPrint("RecoVertex/KVFTrackUpdate") << "Chi2: " << std::get<2>(b) << std::endl;
       }
     }
   }

--- a/RecoVertex/KalmanVertexFit/plugins/KVFTrackUpdate.h
+++ b/RecoVertex/KalmanVertexFit/plugins/KVFTrackUpdate.h
@@ -3,7 +3,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
@@ -11,13 +11,15 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
 #include "DataFormats/BeamSpot/interface/BeamSpot.h"
+#include "TrackingTools/TransientTrack/interface/TransientTrackBuilder.h"
+#include "TrackingTools/Records/interface/TransientTrackRecord.h"
 
 /**
    * This is a very simple test analyzer to test the update of a track with
    * a vertex constraint with the Kalman filter.
    */
 
-class KVFTrackUpdate : public edm::EDAnalyzer {
+class KVFTrackUpdate : public edm::one::EDAnalyzer<> {
 public:
   explicit KVFTrackUpdate(const edm::ParameterSet&);
   ~KVFTrackUpdate() override;
@@ -28,6 +30,7 @@ public:
   void endJob() override;
 
 private:
+  const edm::ESGetToken<TransientTrackBuilder, TransientTrackRecord> estoken_TTB;
   edm::EDGetTokenT<reco::TrackCollection> token_tracks;
   edm::EDGetTokenT<reco::BeamSpot> token_beamSpot;
 };

--- a/RecoVertex/V0Producer/src/V0Fitter.cc
+++ b/RecoVertex/V0Producer/src/V0Fitter.cc
@@ -46,7 +46,7 @@ namespace {
 typedef ROOT::Math::SMatrix<double, 3, 3, ROOT::Math::MatRepSym<double, 3>> SMatrixSym3D;
 typedef ROOT::Math::SVector<double, 3> SVector3;
 
-V0Fitter::V0Fitter(const edm::ParameterSet& theParameters, edm::ConsumesCollector&& iC) {
+V0Fitter::V0Fitter(const edm::ParameterSet& theParameters, edm::ConsumesCollector&& iC) : esTokenMF_(iC.esConsumes()) {
   token_beamSpot = iC.consumes<reco::BeamSpot>(theParameters.getParameter<edm::InputTag>("beamSpot"));
   useVertex_ = theParameters.getParameter<bool>("useVertex");
   token_vertices = iC.consumes<std::vector<reco::Vertex>>(theParameters.getParameter<edm::InputTag>("vertices"));
@@ -108,9 +108,7 @@ void V0Fitter::fitAll(const edm::Event& iEvent,
     referencePos = referenceVtx.position();
   }
 
-  edm::ESHandle<MagneticField> theMagneticFieldHandle;
-  iSetup.get<IdealMagneticFieldRecord>().get(theMagneticFieldHandle);
-  const MagneticField* theMagneticField = theMagneticFieldHandle.product();
+  const MagneticField* theMagneticField = &iSetup.getData(esTokenMF_);
 
   std::vector<reco::TrackRef> theTrackRefs;
   std::vector<reco::TransientTrack> theTransTracks;

--- a/RecoVertex/V0Producer/src/V0Fitter.h
+++ b/RecoVertex/V0Producer/src/V0Fitter.h
@@ -46,6 +46,8 @@ public:
               reco::VertexCompositeCandidateCollection& l);
 
 private:
+  const edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> esTokenMF_;
+
   bool vertexFitter_;
   bool useRefTracks_;
   bool doKShorts_;

--- a/RecoVertex/V0Producer/test/V0Analyzer.cc
+++ b/RecoVertex/V0Producer/test/V0Analyzer.cc
@@ -23,18 +23,12 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
-
-#include "FWCore/Framework/interface/ESHandle.h"
-
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-
-#include "FWCore/Framework/interface/ESHandle.h"
-
 #include "TrackingTools/TransientTrack/interface/TransientTrack.h"
 
 //#include "DataFormats/TrackReco/interface/Track.h"
@@ -72,7 +66,7 @@
 // class declaration
 //
 
-class V0Analyzer : public edm::EDAnalyzer {
+class V0Analyzer : public edm::one::EDAnalyzer<edm::one::SharedResources> {
 public:
   explicit V0Analyzer(const edm::ParameterSet&);
   ~V0Analyzer();
@@ -82,6 +76,9 @@ private:
   virtual void beginJob();
   virtual void analyze(const edm::Event&, const edm::EventSetup&);
   virtual void endJob();
+
+  const edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> m_mfToken;
+  const edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> m_geomToken;
 
   std::string algoLabel;
   std::string recoAlgoLabel;
@@ -154,9 +151,11 @@ const double piMassSq = 0.019479101;
 
 //
 // constructors and destructor
-//
+
 V0Analyzer::V0Analyzer(const edm::ParameterSet& iConfig)
-    : algoLabel(iConfig.getUntrackedParameter("recoAlgorithm", std::string("ctfV0Prod"))),
+    : m_mfToken(esConsumes()),
+      m_geomToken(esConsumes()),
+      algoLabel(iConfig.getUntrackedParameter("recoAlgorithm", std::string("ctfV0Prod"))),
       recoAlgoLabel(iConfig.getUntrackedParameter("trackingAlgo", std::string("ctfWithMaterialTracks"))),
       SimTkLabel(iConfig.getUntrackedParameter("moduleLabelTk", std::string("g4SimHits"))),
       SimVtxLabel(iConfig.getUntrackedParameter("moduleLabelVtx", std::string("g4SimHits"))),
@@ -165,6 +164,8 @@ V0Analyzer::V0Analyzer(const edm::ParameterSet& iConfig)
       cmsswVersion(iConfig.getUntrackedParameter("cmsswVersion", std::string("200"))) {
   //now do what ever initialization is needed
   //theHistoFile = 0;
+
+  usesResource(TFileService::kSharedResource);
 
   numDiff1 = numDiff2 = 0;
 }
@@ -370,11 +371,8 @@ void V0Analyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup
   Handle<SimVertexContainer> SimVtx;
   Handle<reco::TrackCollection> RecoTk;
 
-  ESHandle<MagneticField> bFieldHandle;
-  iSetup.get<IdealMagneticFieldRecord>().get(bFieldHandle);
-
-  ESHandle<TrackerGeometry> trackerGeomHandle;
-  iSetup.get<TrackerDigiGeometryRecord>().get(trackerGeomHandle);
+  ESHandle<MagneticField> bFieldHandle = iSetup.getHandle(m_mfToken);
+  ESHandle<TrackerGeometry> trackerGeomHandle = iSetup.getHandle(m_geomToken);
 
   //const TrackerGeometry* trackerGeom = trackerGeomHandle.product();
 


### PR DESCRIPTION
#### PR description:

Part of #31061.
Migrated to esConsumes the following pakages:
  * `RecoPixelVertexing/PixelVertexFinding`
  * `RecoVertex/V0Producer`
  * `RecoVertex/KalmanVertexFit`

Profited to transform also some legacy `EDAnalyzer`s to `one::EDAnalyzer`. 

#### PR validation:

It builds

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Not a backport.