### PR TITLE
 Bump of CLHEP::Hep3Vector ClassVersion needed for GEANT4 10.7.1

### DIFF
--- a/DataFormats/CLHEP/src/classes_def.xml
+++ b/DataFormats/CLHEP/src/classes_def.xml
@@ -1,5 +1,6 @@
 <lcgdict>
-  <class name="CLHEP::Hep3Vector" ClassVersion="10">
+  <class name="CLHEP::Hep3Vector" ClassVersion="11">
+   <version ClassVersion="11" checksum="3438801427"/>
    <version ClassVersion="10" checksum="3040806103"/>
   </class>
   <class name="CLHEP::HepEulerAngles" ClassVersion="10">


### PR DESCRIPTION
(see #33231)
#### PR description:

Bump of CLHEP::Hep3Vector ClassVersion in `DataFormats/CLHEP/src/classes_def.xml`
needed for the update of GEANT4 ( https://github.com/cms-sw/cmsdist/pull/6742 )

#### PR validation:

`CMSSW_11_3_0_pre3_G4VECGEOM` fully validated by PdmV 