### PR TITLE
Protect against concurrent access of DD4Hep Detector

### DIFF
--- a/DetectorDescription/DDCMS/plugins/DDDetectorESProducer.cc
+++ b/DetectorDescription/DDCMS/plugins/DDDetectorESProducer.cc
@@ -22,6 +22,7 @@
 #include "FWCore/Framework/interface/SourceFactory.h"
 #include "FWCore/Framework/interface/ESProducer.h"
 #include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Concurrency/interface/SharedResourceNames.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "CondFormats/Common/interface/FileBlob.h"
 #include "CondFormats/DataRecord/interface/MFGeometryFileRcd.h"
@@ -68,6 +69,7 @@ DDDetectorESProducer::DDDetectorESProducer(const ParameterSet& iConfig)
       confGeomXMLFiles_(iConfig.getParameter<FileInPath>("confGeomXMLFiles").fullPath()),
       rootDDName_(iConfig.getParameter<string>("rootDDName")),
       label_(iConfig.getParameter<string>("label")) {
+  usesResources({edm::ESSharedResourceNames::kDD4Hep});
   if (rootDDName_ == "MagneticFieldVolumes:MAGF" || rootDDName_ == "cmsMagneticField:MAGF") {
     auto c = setWhatProduced(this,
                              &DDDetectorESProducer::produceMagField,

--- a/DetectorDescription/DDCMS/src/DDDetector.cc
+++ b/DetectorDescription/DDCMS/src/DDDetector.cc
@@ -11,6 +11,12 @@
 namespace cms {
 
   DDDetector::DDDetector(const std::string& tag, const std::string& fileName, bool bigXML) : m_tag(tag) {
+    //We do not want to use any previously created TGeoManager but we do want to reset after we are done.
+    auto oldGeoManager = gGeoManager;
+    gGeoManager = nullptr;
+    auto resetManager = [oldGeoManager](TGeoManager*) { gGeoManager = oldGeoManager; };
+    std::unique_ptr<TGeoManager, decltype(resetManager)> sentry(oldGeoManager, resetManager);
+
     m_description = &dd4hep::Detector::getInstance(tag);
     m_description->addExtension<cms::DDVectorsMap>(&m_vectors);
     m_description->addExtension<dd4hep::PartSelectionMap>(&m_partsels);

--- a/FWCore/Concurrency/interface/SharedResourceNames.h
+++ b/FWCore/Concurrency/interface/SharedResourceNames.h
@@ -35,6 +35,7 @@ namespace edm {
   class ESSharedResourceNames {
   public:
     static const std::string kDDGeometry;
+    static const std::string kDD4Hep;
   };
 
   // Each time the following function is called, it returns a different

--- a/FWCore/Concurrency/src/SharedResourceNames.cc
+++ b/FWCore/Concurrency/src/SharedResourceNames.cc
@@ -13,6 +13,7 @@ const std::string edm::SharedResourceNames::kEvtGen = "EvtGen";
 const std::string edm::SharedResourceNames::kHerwig6 = "Herwig6";
 
 const std::string edm::ESSharedResourceNames::kDDGeometry = "es_DDGeometry";
+const std::string edm::ESSharedResourceNames::kDD4Hep = "es_DD4Hep";
 
 static std::atomic<unsigned int> counter;
 

--- a/MagneticField/GeomBuilder/plugins/dd4hep/DD4hep_VolumeBasedMagneticFieldESProducerFromDB.cc
+++ b/MagneticField/GeomBuilder/plugins/dd4hep/DD4hep_VolumeBasedMagneticFieldESProducerFromDB.cc
@@ -7,6 +7,7 @@
 
 #include "FWCore/Framework/interface/EventSetupRecordIntervalFinder.h"
 #include "FWCore/Framework/interface/ESProducer.h"
+#include "FWCore/Concurrency/interface/SharedResourceNames.h"
 
 #include "CondFormats/RunInfo/interface/RunInfo.h"
 #include "CondFormats/DataRecord/interface/RunSummaryRcd.h"
@@ -80,6 +81,7 @@ DD4hep_VolumeBasedMagneticFieldESProducerFromDB::DD4hep_VolumeBasedMagneticField
     const edm::ParameterSet& iConfig)
     : debug_(iConfig.getUntrackedParameter<bool>("debugBuilder")) {
   std::string const myConfigLabel = "VBMFESChoice";
+  usesResources({edm::ESSharedResourceNames::kDD4Hep});
 
   //Based on configuration, pick algorithm to produce the proper MagFieldConfig with a specific label
   const int current = iConfig.getParameter<int>("valueOverride");


### PR DESCRIPTION
#### PR description:

Under the hood, DD4Hep uses ROOT's global gGeoManager and therefore
can not support concurrent changes.
- usesResources declaration avoids ES modules from running at same time
- Make sure to reset gGeoManager pointer to avoid accidental reuse.

#### PR validation:

- Code compiles
- Ran step 3 of workflow 11650.911 using 6 threads and 4 streams. Without this change it failed (either exception of seg fault) 4 out of 6 times. After this change, it never failed after trying 6 times.