### PR TITLE
Migrated Validation/*Tracker* to esConsumes

### DIFF
--- a/Validation/SiOuterTrackerV/plugins/OuterTrackerMonitorTrackingParticles.cc
+++ b/Validation/SiOuterTrackerV/plugins/OuterTrackerMonitorTrackingParticles.cc
@@ -38,7 +38,7 @@
 // constructors and destructor
 //
 OuterTrackerMonitorTrackingParticles::OuterTrackerMonitorTrackingParticles(const edm::ParameterSet &iConfig)
-    : conf_(iConfig) {
+    : m_topoToken(esConsumes()), conf_(iConfig) {
   topFolderName_ = conf_.getParameter<std::string>("TopFolderName");
   trackingParticleToken_ =
       consumes<std::vector<TrackingParticle>>(conf_.getParameter<edm::InputTag>("trackingParticleToken"));
@@ -80,9 +80,7 @@ void OuterTrackerMonitorTrackingParticles::analyze(const edm::Event &iEvent, con
   iEvent.getByToken(ttStubMCTruthToken_, MCTruthTTStubHandle);
 
   // Geometries
-  edm::ESHandle<TrackerTopology> tTopoHandle;
-  iSetup.get<TrackerTopologyRcd>().get(tTopoHandle);
-  const TrackerTopology *const tTopo = tTopoHandle.product();
+  const TrackerTopology *const tTopo = &iSetup.getData(m_topoToken);
 
   // Loop over tracking particles
   int this_tp = 0;

--- a/Validation/SiOuterTrackerV/plugins/OuterTrackerMonitorTrackingParticles.h
+++ b/Validation/SiOuterTrackerV/plugins/OuterTrackerMonitorTrackingParticles.h
@@ -97,6 +97,7 @@ public:
   MonitorElement *resd0_eta2to2p4 = nullptr;
 
 private:
+  const edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> m_topoToken;
   edm::ParameterSet conf_;
   edm::EDGetTokenT<std::vector<TrackingParticle>> trackingParticleToken_;
   edm::EDGetTokenT<TTClusterAssociationMap<Ref_Phase2TrackerDigi_>>

--- a/Validation/TrackerDigis/plugins/SiPixelDigiValid.h
+++ b/Validation/TrackerDigis/plugins/SiPixelDigiValid.h
@@ -5,6 +5,7 @@
 #include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 #include "RecoTracker/Record/interface/TrackerRecoGeometryRecord.h"
 #include "RecoTracker/TkDetLayers/interface/GeometricSearchTracker.h"
 #include "DQMServices/Core/interface/DQMStore.h"
@@ -27,6 +28,9 @@ protected:
   void bookHistograms(DQMStore::IBooker &ibooker, const edm::Run &run, const edm::EventSetup &es) override;
 
 private:
+  const edm::ESGetToken<GeometricSearchTracker, TrackerRecoGeometryRecord> m_geomToken;
+  const edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> m_topoToken;
+
   std::string outputFile_;
   bool runStandalone;
 
@@ -259,6 +263,6 @@ private:
 
   DQMStore *dbe_;
   edm::EDGetTokenT<edm::DetSetVector<PixelDigi>> edmDetSetVector_PixelDigi_Token_;
-  edm::ESHandle<GeometricSearchTracker> tracker;
+  const GeometricSearchTracker *tracker;
 };
 #endif

--- a/Validation/TrackerDigis/plugins/SiStripDigiValid.cc
+++ b/Validation/TrackerDigis/plugins/SiStripDigiValid.cc
@@ -21,7 +21,8 @@
 #include "SiStripDigiValid.h"
 
 SiStripDigiValid::SiStripDigiValid(const edm::ParameterSet &ps)
-    : dbe_(nullptr),
+    : m_topoToken(esConsumes()),
+      dbe_(nullptr),
       runStandalone(ps.getParameter<bool>("runStandalone")),
       outputFile_(ps.getUntrackedParameter<std::string>("outputFile", "stripdigihisto.root")),
       edmDetSetVector_SiStripDigi_Token_(
@@ -325,9 +326,7 @@ void SiStripDigiValid::bookHistograms(DQMStore::IBooker &ibooker, const edm::Run
 
 void SiStripDigiValid::analyze(const edm::Event &e, const edm::EventSetup &c) {
   // Retrieve tracker topology from geometry
-  edm::ESHandle<TrackerTopology> tTopoHandle;
-  c.get<TrackerTopologyRcd>().get(tTopoHandle);
-  const TrackerTopology *const tTopo = tTopoHandle.product();
+  const TrackerTopology *const tTopo = &c.getData(m_topoToken);
 
   int ndigilayertibzp[4];
   int ndigilayertibzm[4];
@@ -363,8 +362,6 @@ void SiStripDigiValid::analyze(const edm::Event &e, const edm::EventSetup &c) {
 
   // LogInfo("EventInfo") << " Run = " << e.id().run() << " Event = " <<
   // e.id().event();
-  edm::ESHandle<TrackerGeometry> tracker;
-  c.get<TrackerDigiGeometryRecord>().get(tracker);
 
   std::string digiProducer = "siStripDigis";
   edm::Handle<edm::DetSetVector<SiStripDigi>> stripDigis;

--- a/Validation/TrackerDigis/plugins/SiStripDigiValid.h
+++ b/Validation/TrackerDigis/plugins/SiStripDigiValid.h
@@ -24,6 +24,7 @@ protected:
   void bookHistograms(DQMStore::IBooker &ibooker, const edm::Run &run, const edm::EventSetup &es) override;
 
 private:
+  const edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> m_topoToken;
   // TIB  ADC
   MonitorElement *meAdcTIBLayer1Extzp_[3];
   MonitorElement *meAdcTIBLayer2Extzp_[3];

--- a/Validation/TrackerHits/interface/TrackerHitAnalyzer.h
+++ b/Validation/TrackerHits/interface/TrackerHitAnalyzer.h
@@ -11,11 +11,14 @@
 #include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include <DQMServices/Core/interface/DQMEDAnalyzer.h>
+#include "DQMServices/Core/interface/DQMEDAnalyzer.h"
 
 #include "SimDataFormats/Track/interface/SimTrackContainer.h"
 #include "SimDataFormats/TrackingHit/interface/PSimHitContainer.h"
 #include "DQMServices/Core/interface/DQMStore.h"
+
+#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
+#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 
 #include <string>
 
@@ -36,6 +39,7 @@ protected:
   // void BookTestHistos(Char_t sname, int nbin, float *xmin, float *xmax);
 
 private:
+  const edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> tGeomEsToken_;
   bool verbose_;
 
   edm::EDGetTokenT<edm::PSimHitContainer> edmPSimHitContainer_pxlBrlLow_Token_, edmPSimHitContainer_pxlBrlHigh_Token_;

--- a/Validation/TrackerHits/interface/TrackerHitProducer.h
+++ b/Validation/TrackerHits/interface/TrackerHitProducer.h
@@ -2,7 +2,7 @@
 #define TrackerHitProducer_h
 
 // framework & common header files
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/one/EDProducer.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
@@ -18,7 +18,7 @@ namespace edm {
 }
 class PTrackerSimHit;
 
-class TrackerHitProducer : public edm::EDProducer {
+class TrackerHitProducer : public edm::one::EDProducer<> {
 public:
   typedef std::vector<float> FloatVector;
   typedef std::vector<int> IntegerVector;

--- a/Validation/TrackerHits/src/TrackerHitAnalyzer.cc
+++ b/Validation/TrackerHits/src/TrackerHitAnalyzer.cc
@@ -17,8 +17,6 @@
 #include "DataFormats/SiStripDetId/interface/StripSubdetector.h"
 #include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "Geometry/CommonDetUnit/interface/TrackingGeometry.h"
-#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
-#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 
 // data in edm::event
 #include "SimDataFormats/GeneratorProducts/interface/HepMCProduct.h"
@@ -38,7 +36,8 @@
 #include <vector>
 
 TrackerHitAnalyzer::TrackerHitAnalyzer(const edm::ParameterSet &ps)
-    : verbose_(ps.getUntrackedParameter<bool>("Verbosity", false)),
+    : tGeomEsToken_(esConsumes()),
+      verbose_(ps.getUntrackedParameter<bool>("Verbosity", false)),
       edmPSimHitContainer_pxlBrlLow_Token_(
           consumes<edm::PSimHitContainer>(ps.getParameter<edm::InputTag>("PxlBrlLowSrc"))),
       edmPSimHitContainer_pxlBrlHigh_Token_(
@@ -457,9 +456,7 @@ void TrackerHitAnalyzer::analyze(const edm::Event &e, const edm::EventSetup &c) 
   }
 
   // Get geometry information
-
-  edm::ESHandle<TrackerGeometry> tracker;
-  c.get<TrackerDigiGeometryRecord>().get(tracker);
+  const auto &tracker = &c.getData(tGeomEsToken_);
 
   int ir = -100;
   edm::SimTrackContainer::const_iterator itTrk;

--- a/Validation/TrackerRecHits/interface/SiPixelRecHitsValid.h
+++ b/Validation/TrackerRecHits/interface/SiPixelRecHitsValid.h
@@ -15,6 +15,8 @@
 #include "DQMServices/Core/interface/DQMEDAnalyzer.h"
 #include "SimTracker/TrackerHitAssociation/interface/TrackerHitAssociator.h"
 #include "DQMServices/Core/interface/DQMStore.h"
+#include "Geometry/Records/interface/TrackerTopologyRcd.h"
+#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 
 #include <string>
 
@@ -23,6 +25,7 @@ class PSimHit;
 class PixelGeomDetUnit;
 class SiPixelRecHit;
 class TrackerTopology;
+class TrackerGeometry;
 
 class SiPixelRecHitsValid : public DQMEDAnalyzer {
 public:
@@ -39,6 +42,10 @@ protected:
 private:
   void fillBarrel(const SiPixelRecHit&, const PSimHit&, DetId, const PixelGeomDetUnit*, const TrackerTopology* tTopo);
   void fillForward(const SiPixelRecHit&, const PSimHit&, DetId, const PixelGeomDetUnit*, const TrackerTopology* tTopo);
+
+  // Es Tokens
+  const edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> tTopoEsToken;
+  const edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> tGeomEsToken;
 
   //Clusters BPIX
   MonitorElement* clustYSizeModule[8];

--- a/Validation/TrackerRecHits/interface/SiStripRecHitsValid.h
+++ b/Validation/TrackerRecHits/interface/SiStripRecHitsValid.h
@@ -7,6 +7,7 @@
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Utilities/interface/EDGetToken.h"
+#include "FWCore/Framework/interface/ESWatcher.h"
 //only mine
 #include "DataFormats/Common/interface/Handle.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -33,6 +34,12 @@
 #include "Geometry/TrackerNumberingBuilder/interface/GeometricDet.h"
 #include "Geometry/CommonDetUnit/interface/PixelGeomDetType.h"
 #include "Geometry/TrackerGeometryBuilder/interface/StripGeomDetType.h"
+
+// -- for es tokens
+#include "CalibTracker/Records/interface/SiStripDetCablingRcd.h"
+#include "CalibFormats/SiStripObjects/interface/SiStripDetCabling.h"
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+#include "Geometry/Records/interface/TrackerTopologyRcd.h"
 
 #include <string>
 #include <DQMServices/Core/interface/DQMEDAnalyzer.h>
@@ -123,6 +130,12 @@ protected:
   void bookHistograms(DQMStore::IBooker& ibooker, const edm::Run& run, const edm::EventSetup& es) override;
 
 private:
+  const edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> m_geomToken;
+  const edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> m_topoToken, m_topoTokenBR;
+  const edm::ESGetToken<SiStripDetCabling, SiStripDetCablingRcd> m_SiStripDetCablingToken;
+
+  edm::ESWatcher<SiStripDetCablingRcd> watchSiStripDetCablingRcd_;
+
   TotalMEs totalMEs;
 
   bool switchNumTotrphi;
@@ -210,7 +223,6 @@ private:
 
   edm::ParameterSet conf_;
   TrackerHitAssociator::Config trackerHitAssociatorConfig_;
-  unsigned long long m_cacheID_;
   //const StripTopology* topol;
 
   /* static const int MAXHIT = 1000; */

--- a/Validation/TrackerRecHits/src/SiStripRecHitsValid.cc
+++ b/Validation/TrackerRecHits/src/SiStripRecHitsValid.cc
@@ -1,17 +1,13 @@
 #include "Validation/TrackerRecHits/interface/SiStripRecHitsValid.h"
 
 //needed for the geometry:
-#include "CalibTracker/Records/interface/SiStripDetCablingRcd.h"
-#include "CalibFormats/SiStripObjects/interface/SiStripDetCabling.h"
 #include "DataFormats/DetId/interface/DetId.h"
 #include "DataFormats/SiStripDetId/interface/StripSubdetector.h"
 #include "DataFormats/TrackerCommon/interface/SiStripSubStructure.h"
 #include "DQM/SiStripCommon/interface/SiStripFolderOrganizer.h"
-#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
 #include "DataFormats/GeometryVector/interface/LocalPoint.h"
 #include "DataFormats/GeometryVector/interface/GlobalPoint.h"
 #include "DQM/SiStripCommon/interface/SiStripHistoId.h"
-#include "Geometry/Records/interface/TrackerTopologyRcd.h"
 
 //--- for RecHit
 #include "DataFormats/SiStripCluster/interface/SiStripCluster.h"
@@ -26,9 +22,12 @@ using namespace edm;
 
 //Constructor
 SiStripRecHitsValid::SiStripRecHitsValid(const ParameterSet& ps)
-    : conf_(ps),
-      trackerHitAssociatorConfig_(ps, consumesCollector()),
-      m_cacheID_(0)
+    : m_geomToken(esConsumes()),
+      m_topoToken(esConsumes()),
+      m_topoTokenBR(esConsumes<edm::Transition::BeginRun>()),
+      m_SiStripDetCablingToken(esConsumes<edm::Transition::BeginRun>()),
+      conf_(ps),
+      trackerHitAssociatorConfig_(ps, consumesCollector())
 // matchedRecHits_( ps.getParameter<edm::InputTag>("matchedRecHits") ),
 // rphiRecHits_( ps.getParameter<edm::InputTag>("rphiRecHits") ),
 // stereoRecHits_( ps.getParameter<edm::InputTag>("stereoRecHits") )
@@ -162,9 +161,7 @@ SiStripRecHitsValid::~SiStripRecHitsValid() {}
 
 //--------------------------------------------------------------------------------------------
 void SiStripRecHitsValid::bookHistograms(DQMStore::IBooker& ibooker, const edm::Run& run, const edm::EventSetup& es) {
-  unsigned long long cacheID = es.get<SiStripDetCablingRcd>().cacheIdentifier();
-  if (m_cacheID_ != cacheID) {
-    m_cacheID_ = cacheID;
+  if (watchSiStripDetCablingRcd_.check(es)) {
     edm::LogInfo("SiStripRecHitsValid") << "SiStripRecHitsValid::beginRun: "
                                         << " Creating MEs for new Cabling ";
 
@@ -176,9 +173,7 @@ void SiStripRecHitsValid::analyze(const edm::Event& e, const edm::EventSetup& es
   LogInfo("EventInfo") << " Run = " << e.id().run() << " Event = " << e.id().event();
 
   //Retrieve tracker topology from geometry
-  edm::ESHandle<TrackerTopology> tTopoHandle;
-  es.get<TrackerTopologyRcd>().get(tTopoHandle);
-  const TrackerTopology* const tTopo = tTopoHandle.product();
+  const TrackerTopology* const tTopo = &es.getData(m_topoToken);
 
   // Step A: Get Inputs
   edm::Handle<SiStripMatchedRecHit2DCollection> rechitsmatched;
@@ -198,9 +193,7 @@ void SiStripRecHitsValid::analyze(const edm::Event& e, const edm::EventSetup& es
 
   TrackerHitAssociator associate(e, trackerHitAssociatorConfig_);
 
-  edm::ESHandle<TrackerGeometry> pDD;
-  es.get<TrackerDigiGeometryRecord>().get(pDD);
-  const TrackerGeometry& tracker(*pDD);
+  const TrackerGeometry& tracker = es.getData(m_geomToken);
 
   SiStripHistoId hidmanager;
   SiStripFolderOrganizer fold_organ;
@@ -406,6 +399,10 @@ void SiStripRecHitsValid::rechitanalysis(SiStripRecHit2D const rechit,
         closest = &m;
       }
     }
+    
+    if(!closest) 
+      return;
+
     rechitpro.bunch = closest->eventId().bunchCrossing();
     rechitpro.event = closest->eventId().event();
     rechitpro.resx = rechitpro.x - closest->localPosition().x();
@@ -516,12 +513,10 @@ void SiStripRecHitsValid::rechitanalysis_matched(SiStripMatchedRecHit2D const re
 //--------------------------------------------------------------------------------------------
 void SiStripRecHitsValid::createMEs(DQMStore::IBooker& ibooker, const edm::EventSetup& es) {
   //Retrieve tracker topology from geometry
-  edm::ESHandle<TrackerTopology> tTopoHandle;
-  es.get<TrackerTopologyRcd>().get(tTopoHandle);
-  const TrackerTopology* const tTopo = tTopoHandle.product();
+  const TrackerTopology* const tTopo = &es.getData(m_topoTokenBR);
 
   // take from eventSetup the SiStripDetCabling object - here will use SiStripDetControl later on
-  es.get<SiStripDetCablingRcd>().get(SiStripDetCabling_);
+  const auto& SiStripDetCabling_ = &es.getData(m_SiStripDetCablingToken);
 
   // get list of active detectors from SiStripDetCabling
   std::vector<uint32_t> activeDets;

--- a/Validation/TrackerRecHits/src/SiStripRecHitsValid.cc
+++ b/Validation/TrackerRecHits/src/SiStripRecHitsValid.cc
@@ -399,8 +399,8 @@ void SiStripRecHitsValid::rechitanalysis(SiStripRecHit2D const rechit,
         closest = &m;
       }
     }
-    
-    if(!closest) 
+
+    if (!closest)
       return;
 
     rechitpro.bunch = closest->eventId().bunchCrossing();


### PR DESCRIPTION
#### PR description:

Part of #31061.
Migrated to esConsumes the following pakages
   * `Validation/TrackerDigis`
   * `Validation/TrackerHits`
   * `Validaiton/TrackerRecHits`
   * `Validation/SiOuterTrackerV`
   
Profited also to fix some static analyzer warnings.   
   
#### PR validation:

It builds.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Not a backport, no backport needed.
