### PR TITLE
add ECAL supercluster parameters to run2_mc_50ns GT

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -10,7 +10,7 @@ autoCond = {
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run1
     'run1_mc_pa'        :   '112X_mcRun1_pA_v3',
     # GlobalTag for MC production with pessimistic alignment and calibrations for Run2
-    'run2_mc_50ns'      :   '112X_mcRun2_startup_v1',
+    'run2_mc_50ns'      :   '112X_mcRun2_startup_v2',
     # GlobalTag for MC production (L1 Trigger Stage1) with starup-like alignment and calibrations for Run2, L1 trigger in Stage1 mode
     'run2_mc_l1stage1'  :   '112X_mcRun2_asymptotic_l1stage1_v3',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run2


### PR DESCRIPTION
#### PR description:
Adding Ecal supercluster paramaters to the `run2_mc_50ns` GT in order to align 11_2_X release with master.
Addressing issue #33237.

The GT diff is:
**Run 2 startup**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/112X_mcRun2_startup_v1/112X_mcRun2_startup_v2

#### PR validation:
Tested with: `runTheMatrix.py -l 50200.0 --ibeos`

#### if this PR is a backport please specify the original PR and why you need to backport that PR:
Not a backport, no backport needed.