### PR TITLE
HCAL  conditions dumping fix 

### DIFF
--- a/CondTools/Hcal/plugins/HcalDumpConditions.cc
+++ b/CondTools/Hcal/plugins/HcalDumpConditions.cc
@@ -235,22 +235,6 @@ namespace edmtest {
         mDumpRequest, e, context, "TPChannelParameters", topo, tok_TPChannelParameters);
     dumpIt<HcalTPParameters, HcalTPParametersRcd>(mDumpRequest, e, context, "TPParameters", tok_TPParameters);
 
-    /*
-
-    // Calibration...Set items 
-    const HcalDbService* pSetup = &context.getData(m_tokdb);
-    if (std::find(mDumpRequest.begin(), mDumpRequest.end(), std::string("CalibrationsSet")) != mDumpRequest.end() ||
-	std::find(mDumpRequest.begin(), mDumpRequest.end(), std::string("CalibrationWidthsSet")) !=
-	mDumpRequest.end()) {
-      if (std::find(mDumpRequest.begin(), mDumpRequest.end(), std::string("CalibrationsSet")) != mDumpRequest.end()) {
-	  writeToFile(*(pSetup->getHcalCalibrationsSet()), e, "CalibrationsSet");
-      }
-      if (std::find(mDumpRequest.begin(), mDumpRequest.end(), std::string("CalibrationWidthsSet")) !=
-	  mDumpRequest.end()) {
-	writeToFile(*pSetup->getHcalCalibrationWidthsSet(), e, "CalibrationWidthsSet");
-      }
-    }
-    */
   }
   DEFINE_FWK_MODULE(HcalDumpConditions);
 }  // namespace edmtest

--- a/CondTools/Hcal/plugins/HcalDumpConditions.cc
+++ b/CondTools/Hcal/plugins/HcalDumpConditions.cc
@@ -234,7 +234,6 @@ namespace edmtest {
     dumpIt<HcalTPChannelParameters, HcalTPChannelParametersRcd>(
         mDumpRequest, e, context, "TPChannelParameters", topo, tok_TPChannelParameters);
     dumpIt<HcalTPParameters, HcalTPParametersRcd>(mDumpRequest, e, context, "TPParameters", tok_TPParameters);
-
   }
   DEFINE_FWK_MODULE(HcalDumpConditions);
 }  // namespace edmtest

--- a/CondTools/Hcal/plugins/HcalDumpConditions.cc
+++ b/CondTools/Hcal/plugins/HcalDumpConditions.cc
@@ -42,6 +42,39 @@ namespace edmtest {
       mDumpRequest = p.getUntrackedParameter<std::vector<std::string> >("dump", std::vector<std::string>());
       m_toktopo = esConsumes<HcalTopology, HcalRecNumberingRecord>();
       m_tokdb = esConsumes<HcalDbService, HcalDbRecord>();
+
+      tok_ElectronicsMap = esConsumes<HcalElectronicsMap, HcalElectronicsMapRcd>();
+      tok_FrontEndMap = esConsumes<HcalFrontEndMap, HcalFrontEndMapRcd>();
+      tok_QIEData = esConsumes<HcalQIEData, HcalQIEDataRcd>();
+      tok_QIETypes = esConsumes<HcalQIETypes, HcalQIETypesRcd>();
+      tok_Pedestals = esConsumes<HcalPedestals, HcalPedestalsRcd>();
+      tok_PedestalWidths = esConsumes<HcalPedestalWidths, HcalPedestalWidthsRcd>();
+      tok_Pedestals_effective = esConsumes<HcalPedestals, HcalPedestalsRcd>(edm::ESInputTag("", "effective"));
+      tok_PedestalWidths_effective =
+          esConsumes<HcalPedestalWidths, HcalPedestalWidthsRcd>(edm::ESInputTag("", "effective"));
+      tok_Gains = esConsumes<HcalGains, HcalGainsRcd>();
+      tok_GainWidths = esConsumes<HcalGainWidths, HcalGainWidthsRcd>();
+      tok_ChannelQuality = esConsumes<HcalChannelQuality, HcalChannelQualityRcd>();
+      tok_RespCorrs = esConsumes<HcalRespCorrs, HcalRespCorrsRcd>();
+      tok_ZSThresholds = esConsumes<HcalZSThresholds, HcalZSThresholdsRcd>();
+      tok_L1TriggerObjects = esConsumes<HcalL1TriggerObjects, HcalL1TriggerObjectsRcd>();
+      tok_TimeCorrs = esConsumes<HcalTimeCorrs, HcalTimeCorrsRcd>();
+      tok_LUTCorrs = esConsumes<HcalLUTCorrs, HcalLUTCorrsRcd>();
+      tok_PFCorrs = esConsumes<HcalPFCorrs, HcalPFCorrsRcd>();
+      tok_ValidationCorrs = esConsumes<HcalValidationCorrs, HcalValidationCorrsRcd>();
+      tok_LutMetadata = esConsumes<HcalLutMetadata, HcalLutMetadataRcd>();
+      tok_DcsValues = esConsumes<HcalDcsValues, HcalDcsRcd>();
+      tok_DcsMap = esConsumes<HcalDcsMap, HcalDcsMapRcd>();
+      tok_RecoParams = esConsumes<HcalRecoParams, HcalRecoParamsRcd>();
+      tok_TimingParams = esConsumes<HcalTimingParams, HcalTimingParamsRcd>();
+      tok_LongRecoParams = esConsumes<HcalLongRecoParams, HcalLongRecoParamsRcd>();
+      tok_ZDCLowGainFractions = esConsumes<HcalZDCLowGainFractions, HcalZDCLowGainFractionsRcd>();
+      tok_MCParams = esConsumes<HcalMCParams, HcalMCParamsRcd>();
+      tok_FlagHFDigiTimeParams = esConsumes<HcalFlagHFDigiTimeParams, HcalFlagHFDigiTimeParamsRcd>();
+      tok_SiPMParameters = esConsumes<HcalSiPMParameters, HcalSiPMParametersRcd>();
+      tok_SiPMCharacteristics = esConsumes<HcalSiPMCharacteristics, HcalSiPMCharacteristicsRcd>();
+      tok_TPChannelParameters = esConsumes<HcalTPChannelParameters, HcalTPChannelParametersRcd>();
+      tok_TPParameters = esConsumes<HcalTPParameters, HcalTPParametersRcd>();
     }
 
     explicit HcalDumpConditions(int i) {}
@@ -53,13 +86,14 @@ namespace edmtest {
                 const edm::Event& e,
                 const edm::EventSetup& context,
                 const std::string name,
-                const HcalTopology* topo,
-                const std::string label = "");
+                const edm::ESGetToken<S, SRcd> tok);
     template <class S, class SRcd>
     void dumpIt(const std::vector<std::string>& mDumpRequest,
                 const edm::Event& e,
                 const edm::EventSetup& context,
-                const std::string name);
+                const std::string name,
+                const HcalTopology* topo,
+                const edm::ESGetToken<S, SRcd> tok);
     template <class S>
     void writeToFile(const S& myS, const edm::Event& e, const std::string name);
 
@@ -68,6 +102,37 @@ namespace edmtest {
     std::vector<std::string> mDumpRequest;
     edm::ESGetToken<HcalTopology, HcalRecNumberingRecord> m_toktopo;
     edm::ESGetToken<HcalDbService, HcalDbRecord> m_tokdb;
+    edm::ESGetToken<HcalElectronicsMap, HcalElectronicsMapRcd> tok_ElectronicsMap;
+    edm::ESGetToken<HcalFrontEndMap, HcalFrontEndMapRcd> tok_FrontEndMap;
+    edm::ESGetToken<HcalQIEData, HcalQIEDataRcd> tok_QIEData;
+    edm::ESGetToken<HcalQIETypes, HcalQIETypesRcd> tok_QIETypes;
+    edm::ESGetToken<HcalPedestals, HcalPedestalsRcd> tok_Pedestals;
+    edm::ESGetToken<HcalPedestalWidths, HcalPedestalWidthsRcd> tok_PedestalWidths;
+    edm::ESGetToken<HcalPedestals, HcalPedestalsRcd> tok_Pedestals_effective;
+    edm::ESGetToken<HcalPedestalWidths, HcalPedestalWidthsRcd> tok_PedestalWidths_effective;
+    edm::ESGetToken<HcalGains, HcalGainsRcd> tok_Gains;
+    edm::ESGetToken<HcalGainWidths, HcalGainWidthsRcd> tok_GainWidths;
+    edm::ESGetToken<HcalChannelQuality, HcalChannelQualityRcd> tok_ChannelQuality;
+    edm::ESGetToken<HcalRespCorrs, HcalRespCorrsRcd> tok_RespCorrs;
+    edm::ESGetToken<HcalZSThresholds, HcalZSThresholdsRcd> tok_ZSThresholds;
+    edm::ESGetToken<HcalL1TriggerObjects, HcalL1TriggerObjectsRcd> tok_L1TriggerObjects;
+    edm::ESGetToken<HcalTimeCorrs, HcalTimeCorrsRcd> tok_TimeCorrs;
+    edm::ESGetToken<HcalLUTCorrs, HcalLUTCorrsRcd> tok_LUTCorrs;
+    edm::ESGetToken<HcalPFCorrs, HcalPFCorrsRcd> tok_PFCorrs;
+    edm::ESGetToken<HcalValidationCorrs, HcalValidationCorrsRcd> tok_ValidationCorrs;
+    edm::ESGetToken<HcalLutMetadata, HcalLutMetadataRcd> tok_LutMetadata;
+    edm::ESGetToken<HcalDcsValues, HcalDcsRcd> tok_DcsValues;
+    edm::ESGetToken<HcalDcsMap, HcalDcsMapRcd> tok_DcsMap;
+    edm::ESGetToken<HcalRecoParams, HcalRecoParamsRcd> tok_RecoParams;
+    edm::ESGetToken<HcalTimingParams, HcalTimingParamsRcd> tok_TimingParams;
+    edm::ESGetToken<HcalLongRecoParams, HcalLongRecoParamsRcd> tok_LongRecoParams;
+    edm::ESGetToken<HcalZDCLowGainFractions, HcalZDCLowGainFractionsRcd> tok_ZDCLowGainFractions;
+    edm::ESGetToken<HcalMCParams, HcalMCParamsRcd> tok_MCParams;
+    edm::ESGetToken<HcalFlagHFDigiTimeParams, HcalFlagHFDigiTimeParamsRcd> tok_FlagHFDigiTimeParams;
+    edm::ESGetToken<HcalSiPMParameters, HcalSiPMParametersRcd> tok_SiPMParameters;
+    edm::ESGetToken<HcalSiPMCharacteristics, HcalSiPMCharacteristicsRcd> tok_SiPMCharacteristics;
+    edm::ESGetToken<HcalTPChannelParameters, HcalTPChannelParametersRcd> tok_TPChannelParameters;
+    edm::ESGetToken<HcalTPParameters, HcalTPParametersRcd> tok_TPParameters;
   };
 
   template <class S, class SRcd>
@@ -75,14 +140,9 @@ namespace edmtest {
                                   const edm::Event& e,
                                   const edm::EventSetup& context,
                                   const std::string name,
-                                  const HcalTopology* topo,
-                                  const std::string label) {
+                                  const edm::ESGetToken<S, SRcd> tok) {
     if (std::find(mDumpRequest.begin(), mDumpRequest.end(), name) != mDumpRequest.end()) {
-      edm::ESGetToken<S, SRcd> tok =
-          ((!label.empty()) ? esConsumes<S, SRcd>(edm::ESInputTag("", label)) : esConsumes<S, SRcd>());
-      S myobject = context.getData(tok);
-      if (topo)
-        myobject.setTopo(topo);
+      const S& myobject = context.getData(tok);
 
       writeToFile(myobject, e, name);
 
@@ -95,10 +155,13 @@ namespace edmtest {
   void HcalDumpConditions::dumpIt(const std::vector<std::string>& mDumpRequest,
                                   const edm::Event& e,
                                   const edm::EventSetup& context,
-                                  const std::string name) {
+                                  const std::string name,
+                                  const HcalTopology* topo,
+                                  const edm::ESGetToken<S, SRcd> tok) {
     if (std::find(mDumpRequest.begin(), mDumpRequest.end(), name) != mDumpRequest.end()) {
-      edm::ESGetToken<S, SRcd> tok = esConsumes<S, SRcd>();
-      const S& myobject = context.getData(tok);
+      S myobject = context.getData(tok);
+      if (topo)
+        myobject.setTopo(topo);
 
       writeToFile(myobject, e, name);
 
@@ -127,52 +190,67 @@ namespace edmtest {
       return;
 
     // dumpIt called for all possible ValueMaps. The function checks if the dump is actually requested.
-    dumpIt<HcalElectronicsMap, HcalElectronicsMapRcd>(mDumpRequest, e, context, "ElectronicsMap");
-    dumpIt<HcalFrontEndMap, HcalFrontEndMapRcd>(mDumpRequest, e, context, "FrontEndMap");
-    dumpIt<HcalQIEData, HcalQIEDataRcd>(mDumpRequest, e, context, "QIEData", topo);
-    dumpIt<HcalQIETypes, HcalQIETypesRcd>(mDumpRequest, e, context, "QIETypes", topo);
-    dumpIt<HcalPedestals, HcalPedestalsRcd>(mDumpRequest, e, context, "Pedestals", topo);
-    dumpIt<HcalPedestalWidths, HcalPedestalWidthsRcd>(mDumpRequest, e, context, "PedestalWidths", topo);
-    dumpIt<HcalPedestals, HcalPedestalsRcd>(mDumpRequest, e, context, "EffectivePedestals", topo, "effective");
-    dumpIt<HcalPedestalWidths, HcalPedestalWidthsRcd>(
-        mDumpRequest, e, context, "EffectivePedestalWidths", topo, "effective");
-    dumpIt<HcalGains, HcalGainsRcd>(mDumpRequest, e, context, "Gains", topo);
-    dumpIt<HcalGainWidths, HcalGainWidthsRcd>(mDumpRequest, e, context, "GainWidths", topo);
-    dumpIt<HcalChannelQuality, HcalChannelQualityRcd>(mDumpRequest, e, context, "ChannelQuality", topo, "withTopo");
-    dumpIt<HcalRespCorrs, HcalRespCorrsRcd>(mDumpRequest, e, context, "RespCorrs", topo);
-    dumpIt<HcalZSThresholds, HcalZSThresholdsRcd>(mDumpRequest, e, context, "ZSThresholds", topo);
-    dumpIt<HcalL1TriggerObjects, HcalL1TriggerObjectsRcd>(mDumpRequest, e, context, "L1TriggerObjects", topo);
-    dumpIt<HcalTimeCorrs, HcalTimeCorrsRcd>(mDumpRequest, e, context, "TimeCorrs", topo);
-    dumpIt<HcalLUTCorrs, HcalLUTCorrsRcd>(mDumpRequest, e, context, "LUTCorrs", topo);
-    dumpIt<HcalPFCorrs, HcalPFCorrsRcd>(mDumpRequest, e, context, "PFCorrs", topo);
-    dumpIt<HcalValidationCorrs, HcalValidationCorrsRcd>(mDumpRequest, e, context, "ValidationCorrs", topo);
-    dumpIt<HcalLutMetadata, HcalLutMetadataRcd>(mDumpRequest, e, context, "LutMetadata", topo);
-    dumpIt<HcalDcsValues, HcalDcsRcd>(mDumpRequest, e, context, "DcsValues");
-    dumpIt<HcalDcsMap, HcalDcsMapRcd>(mDumpRequest, e, context, "DcsMap");
-    dumpIt<HcalRecoParams, HcalRecoParamsRcd>(mDumpRequest, e, context, "RecoParams", topo);
-    dumpIt<HcalTimingParams, HcalTimingParamsRcd>(mDumpRequest, e, context, "TimingParams", topo);
-    dumpIt<HcalLongRecoParams, HcalLongRecoParamsRcd>(mDumpRequest, e, context, "LongRecoParams", topo);
-    dumpIt<HcalZDCLowGainFractions, HcalZDCLowGainFractionsRcd>(mDumpRequest, e, context, "ZDCLowGainFractions", topo);
-    dumpIt<HcalMCParams, HcalMCParamsRcd>(mDumpRequest, e, context, "MCParams", topo);
-    dumpIt<HcalFlagHFDigiTimeParams, HcalFlagHFDigiTimeParamsRcd>(
-        mDumpRequest, e, context, "FlagHFDigiTimeParams", topo);
-    dumpIt<HcalSiPMParameters, HcalSiPMParametersRcd>(mDumpRequest, e, context, "SiPMParameters", topo);
-    dumpIt<HcalSiPMCharacteristics, HcalSiPMCharacteristicsRcd>(mDumpRequest, e, context, "SiPMCharacteristics");
-    dumpIt<HcalTPChannelParameters, HcalTPChannelParametersRcd>(mDumpRequest, e, context, "TPChannelParameters", topo);
-    dumpIt<HcalTPParameters, HcalTPParametersRcd>(mDumpRequest, e, context, "TPParameters");
 
+    dumpIt<HcalElectronicsMap, HcalElectronicsMapRcd>(mDumpRequest, e, context, "ElectronicsMap", tok_ElectronicsMap);
+    dumpIt<HcalFrontEndMap, HcalFrontEndMapRcd>(mDumpRequest, e, context, "FrontEndMap", tok_FrontEndMap);
+    dumpIt<HcalQIEData, HcalQIEDataRcd>(mDumpRequest, e, context, "QIEData", topo, tok_QIEData);
+    dumpIt<HcalQIETypes, HcalQIETypesRcd>(mDumpRequest, e, context, "QIETypes", topo, tok_QIETypes);
+    dumpIt<HcalPedestals, HcalPedestalsRcd>(mDumpRequest, e, context, "Pedestals", topo, tok_Pedestals);
+    dumpIt<HcalPedestalWidths, HcalPedestalWidthsRcd>(
+        mDumpRequest, e, context, "PedestalWidths", topo, tok_PedestalWidths);
+    dumpIt<HcalPedestals, HcalPedestalsRcd>(
+        mDumpRequest, e, context, "EffectivePedestals", topo, tok_Pedestals_effective);
+    dumpIt<HcalPedestalWidths, HcalPedestalWidthsRcd>(
+        mDumpRequest, e, context, "EffectivePedestalWidths", topo, tok_PedestalWidths_effective);
+    dumpIt<HcalGains, HcalGainsRcd>(mDumpRequest, e, context, "Gains", topo, tok_Gains);
+    dumpIt<HcalGainWidths, HcalGainWidthsRcd>(mDumpRequest, e, context, "GainWidths", topo, tok_GainWidths);
+    dumpIt<HcalChannelQuality, HcalChannelQualityRcd>(
+        mDumpRequest, e, context, "ChannelQuality", topo, tok_ChannelQuality);
+    dumpIt<HcalRespCorrs, HcalRespCorrsRcd>(mDumpRequest, e, context, "RespCorrs", topo, tok_RespCorrs);
+    dumpIt<HcalZSThresholds, HcalZSThresholdsRcd>(mDumpRequest, e, context, "ZSThresholds", topo, tok_ZSThresholds);
+    dumpIt<HcalL1TriggerObjects, HcalL1TriggerObjectsRcd>(
+        mDumpRequest, e, context, "L1TriggerObjects", topo, tok_L1TriggerObjects);
+    dumpIt<HcalTimeCorrs, HcalTimeCorrsRcd>(mDumpRequest, e, context, "TimeCorrs", topo, tok_TimeCorrs);
+    dumpIt<HcalLUTCorrs, HcalLUTCorrsRcd>(mDumpRequest, e, context, "LUTCorrs", topo, tok_LUTCorrs);
+    dumpIt<HcalPFCorrs, HcalPFCorrsRcd>(mDumpRequest, e, context, "PFCorrs", topo, tok_PFCorrs);
+    dumpIt<HcalValidationCorrs, HcalValidationCorrsRcd>(
+        mDumpRequest, e, context, "ValidationCorrs", topo, tok_ValidationCorrs);
+    dumpIt<HcalLutMetadata, HcalLutMetadataRcd>(mDumpRequest, e, context, "LutMetadata", topo, tok_LutMetadata);
+    dumpIt<HcalDcsValues, HcalDcsRcd>(mDumpRequest, e, context, "DcsValues", tok_DcsValues);
+    dumpIt<HcalDcsMap, HcalDcsMapRcd>(mDumpRequest, e, context, "DcsMap", tok_DcsMap);
+    dumpIt<HcalRecoParams, HcalRecoParamsRcd>(mDumpRequest, e, context, "RecoParams", topo, tok_RecoParams);
+    dumpIt<HcalTimingParams, HcalTimingParamsRcd>(mDumpRequest, e, context, "TimingParams", topo, tok_TimingParams);
+    dumpIt<HcalLongRecoParams, HcalLongRecoParamsRcd>(
+        mDumpRequest, e, context, "LongRecoParams", topo, tok_LongRecoParams);
+    dumpIt<HcalZDCLowGainFractions, HcalZDCLowGainFractionsRcd>(
+        mDumpRequest, e, context, "ZDCLowGainFractions", topo, tok_ZDCLowGainFractions);
+    dumpIt<HcalMCParams, HcalMCParamsRcd>(mDumpRequest, e, context, "MCParams", topo, tok_MCParams);
+    dumpIt<HcalFlagHFDigiTimeParams, HcalFlagHFDigiTimeParamsRcd>(
+        mDumpRequest, e, context, "FlagHFDigiTimeParams", topo, tok_FlagHFDigiTimeParams);
+    dumpIt<HcalSiPMParameters, HcalSiPMParametersRcd>(
+        mDumpRequest, e, context, "SiPMParameters", topo, tok_SiPMParameters);
+    dumpIt<HcalSiPMCharacteristics, HcalSiPMCharacteristicsRcd>(
+        mDumpRequest, e, context, "SiPMCharacteristics", tok_SiPMCharacteristics);
+    dumpIt<HcalTPChannelParameters, HcalTPChannelParametersRcd>(
+        mDumpRequest, e, context, "TPChannelParameters", topo, tok_TPChannelParameters);
+    dumpIt<HcalTPParameters, HcalTPParametersRcd>(mDumpRequest, e, context, "TPParameters", tok_TPParameters);
+
+    /*
+
+    // Calibration...Set items 
     const HcalDbService* pSetup = &context.getData(m_tokdb);
     if (std::find(mDumpRequest.begin(), mDumpRequest.end(), std::string("CalibrationsSet")) != mDumpRequest.end() ||
-        std::find(mDumpRequest.begin(), mDumpRequest.end(), std::string("CalibrationWidthsSet")) !=
-            mDumpRequest.end()) {
+	std::find(mDumpRequest.begin(), mDumpRequest.end(), std::string("CalibrationWidthsSet")) !=
+	mDumpRequest.end()) {
       if (std::find(mDumpRequest.begin(), mDumpRequest.end(), std::string("CalibrationsSet")) != mDumpRequest.end()) {
-        writeToFile(*(pSetup->getHcalCalibrationsSet()), e, "CalibrationsSet");
+	  writeToFile(*(pSetup->getHcalCalibrationsSet()), e, "CalibrationsSet");
       }
       if (std::find(mDumpRequest.begin(), mDumpRequest.end(), std::string("CalibrationWidthsSet")) !=
-          mDumpRequest.end()) {
-        writeToFile(*pSetup->getHcalCalibrationWidthsSet(), e, "CalibrationWidthsSet");
+	  mDumpRequest.end()) {
+	writeToFile(*pSetup->getHcalCalibrationWidthsSet(), e, "CalibrationWidthsSet");
       }
     }
+    */
   }
   DEFINE_FWK_MODULE(HcalDumpConditions);
 }  // namespace edmtest

--- a/CondTools/Hcal/test/makeDump_Run3.csh
+++ b/CondTools/Hcal/test/makeDump_Run3.csh
@@ -32,11 +32,6 @@ process.source = cms.Source("EmptySource",
     firstRun = cms.untracked.uint32($3)
 )
 
-#process.hcal_db_producer = cms.ESProducer("HcalDbProducer",
-#    dump = cms.untracked.vstring(''),
-#    file = cms.untracked.string('')
-#)
-
 process.load("CondCore.CondDB.CondDB_cfi")
 process.CondDB.connect = '$connectstring'
 

--- a/CondTools/Hcal/test/makeDump_Run3.csh
+++ b/CondTools/Hcal/test/makeDump_Run3.csh
@@ -1,0 +1,60 @@
+#!/bin/csh
+cmsenv
+
+if ("$4" == "test") then
+     echo "connectstring = sqlite_file:test.db"
+     set connectstring = sqlite_file:test.db
+else  if ( $#argv == 3 ) then
+    echo "connectstring = frontier://FrontierProd/CMS_CONDITIONS"
+    set connectstring = frontier://FrontierProd/CMS_CONDITIONS
+else
+    echo "connectstring = $4"
+    set connectstring = $4
+endif
+
+cat >! temp_dump_cfg.py <<%
+
+# Usage example:   
+# ./makeDump_Run3.csh ElectronicsMap HcalElectronicsMap_v9.0_hlt 309055 frontier://FrontierProd/CMS_CONDITIONS
+import FWCore.ParameterSet.Config as cms
+from Configuration.StandardSequences.Eras import eras
+process = cms.Process("DUMP",eras.Run3)
+
+process.load("Configuration.Geometry.GeometryExtended2021_cff")
+process.load("Configuration.Geometry.GeometryExtended2021Reco_cff")
+  
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(1)
+)
+
+process.source = cms.Source("EmptySource",
+    numberEventsInRun = cms.untracked.uint32(1),
+    firstRun = cms.untracked.uint32($3)
+)
+
+#process.hcal_db_producer = cms.ESProducer("HcalDbProducer",
+#    dump = cms.untracked.vstring(''),
+#    file = cms.untracked.string('')
+#)
+
+process.load("CondCore.CondDB.CondDB_cfi")
+process.CondDB.connect = '$connectstring'
+
+process.PoolDBESSource = cms.ESSource("PoolDBESSource",
+        process.CondDB,
+        toGet = cms.VPSet(cms.PSet(record = cms.string("Hcal$1Rcd"),
+                                   tag = cms.string("$2")
+                                  )                        
+                         )
+)
+
+process.dumpcond = cms.EDAnalyzer("HcalDumpConditions",
+                                  dump = cms.untracked.vstring("$1")
+                                  )
+
+process.p = cms.Path(process.dumpcond)
+
+%
+cmsRun temp_dump_cfg.py
+rm temp_dump_cfg.py
+


### PR DESCRIPTION
#### PR description:

Fix of HCAL conditions dumping ananlyser after it has been unwantedly broken in massive ESGetToken-ization of  CondTools/Hcal in  https://github.com/cms-sw/cmssw/pull/32672

#### PR validation:

runTheMatrix.py -l limited   is OK

Often used dumping config works again now:    
cmsRun $CMSSW_RELEASE_BASE/src/CondTools/Hcal/test/runDumpHcalCond_cfg.py geometry=DB prefix="" dumplist=ElectronicsMap run=1 globaltag=111X_dataRun3_Prompt_v3