### PR TITLE
Annotate cms::cuda::HostAllocator::allocate() as thread safe

### DIFF
--- a/HeterogeneousCore/CUDAUtilities/interface/HostAllocator.h
+++ b/HeterogeneousCore/CUDAUtilities/interface/HostAllocator.h
@@ -30,7 +30,7 @@ namespace cms {
         using other = HostAllocator<U, FLAGS>;
       };
 
-      T* allocate CMS_THREAD_SAFE(std::size_t n) const __attribute__((warn_unused_result)) __attribute__((malloc))
+      CMS_THREAD_SAFE T* allocate(std::size_t n) const __attribute__((warn_unused_result)) __attribute__((malloc))
       __attribute__((returns_nonnull)) {
         void* ptr = nullptr;
         cudaError_t status = cudaMallocHost(&ptr, n * sizeof(T), FLAGS);

--- a/HeterogeneousCore/CUDAUtilities/interface/HostAllocator.h
+++ b/HeterogeneousCore/CUDAUtilities/interface/HostAllocator.h
@@ -5,6 +5,8 @@
 #include <new>
 #include <cuda_runtime.h>
 
+#include "FWCore/Utilities/interface/thread_safety_macros.h"
+
 namespace cms {
   namespace cuda {
 
@@ -28,7 +30,7 @@ namespace cms {
         using other = HostAllocator<U, FLAGS>;
       };
 
-      T* allocate(std::size_t n) const __attribute__((warn_unused_result)) __attribute__((malloc))
+      T* allocate CMS_THREAD_SAFE(std::size_t n) const __attribute__((warn_unused_result)) __attribute__((malloc))
       __attribute__((returns_nonnull)) {
         void* ptr = nullptr;
         cudaError_t status = cudaMallocHost(&ptr, n * sizeof(T), FLAGS);


### PR DESCRIPTION
#### PR description:

This should silence 80 static analyzer warnings that @jpata reported in https://mattermost.web.cern.ch/cms-o-and-c/pl/6efrf7q4s7yi8k3oaamjhwdr3a

#### PR validation:

Code compiles.