### PR TITLE
update dict map as TTTrackTruthPair is now part of Associations

### DIFF
--- a/Utilities/ReleaseScripts/scripts/duplicateReflexLibrarySearch.py
+++ b/Utilities/ReleaseScripts/scripts/duplicateReflexLibrarySearch.py
@@ -35,6 +35,7 @@ typedefsDict = \
 #Ordered List to search for matched packages
 equivDict = \
      [
+         {'Associations': ['TTTrackTruthPair']},
          {'TrajectoryState'         : ['TrajectoryStateOnSurface']},
          {'TrackTriggerAssociation' : ['(TTClusterAssociationMap|TTStubAssociationMap|TTTrackAssociationMap|TrackingParticle).*Phase2TrackerDigi',
                                        '(TTStub|TTCluster|TTTrack).*Phase2TrackerDigi.*TrackingParticle']},


### PR DESCRIPTION
https://github.com/cms-sw/cmssw/pull/33188 has moved `TTTrackTruthPair` in to `SimDataFormats/Associations`. This PR updates the duplicate dictionary rules to now assign `TTTrackTruthPair`  under `Associations`