### PR TITLE
PPS: update of era modifiers

### DIFF
--- a/Configuration/Eras/python/Era_Run2_2016_cff.py
+++ b/Configuration/Eras/python/Era_Run2_2016_cff.py
@@ -3,6 +3,7 @@ import FWCore.ParameterSet.Config as cms
 from Configuration.Eras.Modifier_run2_common_cff import run2_common
 from Configuration.Eras.Modifier_run2_25ns_specific_cff import run2_25ns_specific
 from Configuration.Eras.Modifier_stage2L1Trigger_cff import stage2L1Trigger
+from Configuration.Eras.Modifier_ctpps_cff import ctpps
 from Configuration.Eras.Modifier_ctpps_2016_cff import ctpps_2016
 from Configuration.Eras.Modifier_run2_HLTconditions_2016_cff import run2_HLTconditions_2016
 from Configuration.Eras.Modifier_run2_muon_2016_cff import run2_muon_2016
@@ -14,5 +15,5 @@ from Configuration.Eras.Modifier_strips_vfp30_2016_cff import strips_vfp30_2016
 from Configuration.Eras.Modifier_run2_ECAL_2016_cff import run2_ECAL_2016
 
 Run2_2016 = cms.ModifierChain(run2_common, run2_25ns_specific,
- stage2L1Trigger, ctpps_2016, run2_HLTconditions_2016, run2_ECAL_2016, run2_muon_2016, run2_egamma_2016, run2_L1prefiring, pixel_2016, run2_jme_2016, strips_vfp30_2016)
+ stage2L1Trigger, ctpps, ctpps_2016, run2_HLTconditions_2016, run2_ECAL_2016, run2_muon_2016, run2_egamma_2016, run2_L1prefiring, pixel_2016, run2_jme_2016, strips_vfp30_2016)
 

--- a/Configuration/Eras/python/Era_Run2_2017_cff.py
+++ b/Configuration/Eras/python/Era_Run2_2017_cff.py
@@ -17,13 +17,14 @@ from Configuration.Eras.Modifier_run2_muon_2017_cff import run2_muon_2017
 from Configuration.Eras.Modifier_run2_muon_2016_cff import run2_muon_2016
 from Configuration.Eras.Modifier_run2_egamma_2017_cff import run2_egamma_2017
 from Configuration.Eras.Modifier_run2_egamma_2016_cff import run2_egamma_2016
+from Configuration.Eras.Modifier_ctpps_2016_cff import ctpps_2016
 from Configuration.Eras.Modifier_ctpps_2017_cff import ctpps_2017
 from Configuration.Eras.Modifier_pixel_2016_cff import pixel_2016
 from Configuration.Eras.Modifier_run2_jme_2017_cff import run2_jme_2017
 from Configuration.Eras.Modifier_run2_jme_2016_cff import run2_jme_2016
 from Configuration.Eras.Modifier_strips_vfp30_2016_cff import strips_vfp30_2016
 
-Run2_2017 = cms.ModifierChain(Run2_2016.copyAndExclude([run2_muon_2016, run2_HLTconditions_2016, run2_ECAL_2016, run2_egamma_2016,pixel_2016,run2_jme_2016, strips_vfp30_2016]),
+Run2_2017 = cms.ModifierChain(Run2_2016.copyAndExclude([run2_muon_2016, run2_HLTconditions_2016, run2_ECAL_2016, run2_egamma_2016,pixel_2016,run2_jme_2016, strips_vfp30_2016, ctpps_2016]),
                               phase1Pixel, run2_ECAL_2017, run2_HF_2017, run2_HCAL_2017, run2_HE_2017, run2_HEPlan1_2017, 
                               trackingPhase1, run2_GEM_2017, stage2L1Trigger_2017, run2_HLTconditions_2017, run2_muon_2017,run2_egamma_2017, ctpps_2017, run2_jme_2017)
 

--- a/Configuration/Eras/python/Modifier_ctpps_cff.py
+++ b/Configuration/Eras/python/Modifier_ctpps_cff.py
@@ -1,0 +1,4 @@
+import FWCore.ParameterSet.Config as cms
+
+ctpps =  cms.Modifier()
+

--- a/Configuration/EventContent/python/EventContent_cff.py
+++ b/Configuration/EventContent/python/EventContent_cff.py
@@ -212,7 +212,7 @@ RECOEventContent.outputCommands.extend(TcdsEventContent.outputCommands)
 RECOEventContent.outputCommands.extend(CommonEventContent.outputCommands)
 RECOEventContent.outputCommands.extend(EITopPAGEventContent.outputCommands)
 
-from Configuration.Eras.Modifier_ctpps_2016_cff import ctpps_2016
+from Configuration.Eras.Modifier_ctpps_cff import ctpps
 from Configuration.Eras.Modifier_phase2_hgcal_cff import phase2_hgcal
 from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
 from Configuration.Eras.Modifier_phase2_muon_cff import phase2_muon
@@ -223,7 +223,7 @@ from Configuration.ProcessModifiers.pp_on_AA_cff import pp_on_AA
 from RecoLocalFastTime.Configuration.RecoLocalFastTime_EventContent_cff import *
 from RecoMTD.Configuration.RecoMTD_EventContent_cff import *
 
-ctpps_2016.toModify(RECOEventContent, 
+ctpps.toModify(RECOEventContent, 
     outputCommands = RECOEventContent.outputCommands + RecoCTPPSRECO.outputCommands)
 phase2_hgcal.toModify(RECOEventContent,
     outputCommands = RECOEventContent.outputCommands + TICL_RECO.outputCommands)
@@ -276,7 +276,7 @@ AODEventContent.outputCommands.extend(OnlineMetaDataContent.outputCommands)
 AODEventContent.outputCommands.extend(TcdsEventContent.outputCommands)
 AODEventContent.outputCommands.extend(CommonEventContent.outputCommands)
 
-ctpps_2016.toModify(AODEventContent, 
+ctpps.toModify(AODEventContent, 
     outputCommands = AODEventContent.outputCommands + RecoCTPPSAOD.outputCommands)
 phase2_hgcal.toModify(AODEventContent,
     outputCommands = AODEventContent.outputCommands + TICL_AOD.outputCommands)
@@ -486,7 +486,7 @@ FEVTEventContent.outputCommands.extend(TcdsEventContent.outputCommands)
 FEVTEventContent.outputCommands.extend(CommonEventContent.outputCommands)
 FEVTEventContent.outputCommands.extend(EITopPAGEventContent.outputCommands)
 
-ctpps_2016.toModify(FEVTEventContent, 
+ctpps.toModify(FEVTEventContent, 
     outputCommands = FEVTEventContent.outputCommands + RecoCTPPSFEVT.outputCommands)
 phase2_hgcal.toModify(FEVTEventContent,
     outputCommands = FEVTEventContent.outputCommands + TICL_FEVT.outputCommands)

--- a/Configuration/StandardSequences/python/Eras.py
+++ b/Configuration/StandardSequences/python/Eras.py
@@ -66,7 +66,7 @@ class Eras (object):
                            'phase2_timing_layer', 'phase2_hcal', 'phase2_ecal','phase2_ecal_devel',
                            'phase2_trigger',
                            'phase2_squarePixels', 'phase2_3DPixels',
-                           'trackingLowPU', 'trackingPhase1', 'ctpps_2016', 'ctpps_2017', 'ctpps_2018', 'ctpps_2021', 'trackingPhase2PU140','highBetaStar_2018',
+                           'trackingLowPU', 'trackingPhase1', 'ctpps', 'ctpps_2016', 'ctpps_2017', 'ctpps_2018', 'ctpps_2021', 'trackingPhase2PU140','highBetaStar_2018',
                            'tracker_apv_vfp30_2016', 'pf_badHcalMitigation', 'run2_miniAOD_80XLegacy','run2_miniAOD_94XFall17', 'run2_nanoAOD_92X',
                            'run2_nanoAOD_94XMiniAODv1', 'run2_nanoAOD_94XMiniAODv2', 'run2_nanoAOD_94X2016',
                            'run2_miniAOD_devel', 'run2_nanoAOD_102Xv1', 'run2_nanoAOD_106Xv1', 'run2_nanoAOD_106Xv2',

--- a/Configuration/StandardSequences/python/RawToDigi_cff.py
+++ b/Configuration/StandardSequences/python/RawToDigi_cff.py
@@ -92,15 +92,15 @@ phase2_tracker.toReplaceWith(RawToDigiTask, RawToDigiTask.copyAndExclude([siPixe
 
 
 # add CTPPS 2016 raw-to-digi modules
-from Configuration.Eras.Modifier_ctpps_2016_cff import ctpps_2016
+from Configuration.Eras.Modifier_ctpps_cff import ctpps
 
-_ctpps_2016_RawToDigiTask = RawToDigiTask.copy()
-_ctpps_2016_RawToDigiTask.add(ctppsRawToDigiTask)
-ctpps_2016.toReplaceWith(RawToDigiTask, _ctpps_2016_RawToDigiTask)
+_ctpps_RawToDigiTask = RawToDigiTask.copy()
+_ctpps_RawToDigiTask.add(ctppsRawToDigiTask)
+ctpps.toReplaceWith(RawToDigiTask, _ctpps_RawToDigiTask)
 
-_ctpps_2016_RawToDigiTask_noTk = RawToDigiTask_noTk.copy()
-_ctpps_2016_RawToDigiTask_noTk.add(ctppsRawToDigiTask)
-ctpps_2016.toReplaceWith(RawToDigiTask_noTk, _ctpps_2016_RawToDigiTask_noTk)
+_ctpps_RawToDigiTask_noTk = RawToDigiTask_noTk.copy()
+_ctpps_RawToDigiTask_noTk.add(ctppsRawToDigiTask)
+ctpps.toReplaceWith(RawToDigiTask_noTk, _ctpps_RawToDigiTask_noTk)
 
 # GEM settings
 _gem_RawToDigiTask = RawToDigiTask.copy()

--- a/Configuration/StandardSequences/python/Reconstruction_cff.py
+++ b/Configuration/StandardSequences/python/Reconstruction_cff.py
@@ -75,14 +75,15 @@ _phase2_timing_layer_localreco_HcalNZSTask.add(fastTimingLocalRecoTask)
 phase2_timing_layer.toReplaceWith(localrecoTask,_phase2_timing_layer_localrecoTask)
 phase2_timing_layer.toReplaceWith(localreco_HcalNZSTask,_phase2_timing_layer_localreco_HcalNZSTask)
 
-_ctpps_2016_localrecoTask = localrecoTask.copy()
-_ctpps_2016_localrecoTask.add(recoCTPPSTask)
-from Configuration.Eras.Modifier_ctpps_2016_cff import ctpps_2016
-ctpps_2016.toReplaceWith(localrecoTask, _ctpps_2016_localrecoTask)
+from Configuration.Eras.Modifier_ctpps_cff import ctpps
 
-_ctpps_2016_localreco_HcalNZSTask = localreco_HcalNZSTask.copy()
-_ctpps_2016_localreco_HcalNZSTask.add(recoCTPPSTask)
-ctpps_2016.toReplaceWith(localreco_HcalNZSTask, _ctpps_2016_localreco_HcalNZSTask)
+_ctpps_localrecoTask = localrecoTask.copy()
+_ctpps_localrecoTask.add(recoCTPPSTask)
+ctpps.toReplaceWith(localrecoTask, _ctpps_localrecoTask)
+
+_ctpps_localreco_HcalNZSTask = localreco_HcalNZSTask.copy()
+_ctpps_localreco_HcalNZSTask.add(recoCTPPSTask)
+ctpps.toReplaceWith(localreco_HcalNZSTask, _ctpps_localreco_HcalNZSTask)
 
 ###########################################
 # no castor, zdc, Totem/CTPPS RP in FastSim

--- a/DQM/CTPPS/python/ctppsDQM_cff.py
+++ b/DQM/CTPPS/python/ctppsDQM_cff.py
@@ -60,19 +60,19 @@ _ctppsDQMOfflineHarvest = cms.Sequence(
 )
 
 # the actually used sequences must be empty for pre-PPS data
-from Configuration.Eras.Modifier_ctpps_2016_cff import ctpps_2016
+from Configuration.Eras.Modifier_ctpps_cff import ctpps
 
 ctppsDQMOnlineSource = cms.Sequence()
 ctppsDQMOnlineHarvest = cms.Sequence()
-ctpps_2016.toReplaceWith(ctppsDQMOnlineSource, _ctppsDQMOnlineSource)
-ctpps_2016.toReplaceWith(ctppsDQMOnlineHarvest, _ctppsDQMOnlineHarvest)
+ctpps.toReplaceWith(ctppsDQMOnlineSource, _ctppsDQMOnlineSource)
+ctpps.toReplaceWith(ctppsDQMOnlineHarvest, _ctppsDQMOnlineHarvest)
 
 ctppsDQMCalibrationSource = cms.Sequence()
 ctppsDQMCalibrationHarvest = cms.Sequence()
-ctpps_2016.toReplaceWith(ctppsDQMCalibrationSource, _ctppsDQMCalibrationSource)
-ctpps_2016.toReplaceWith(ctppsDQMCalibrationHarvest, _ctppsDQMCalibrationHarvest)
+ctpps.toReplaceWith(ctppsDQMCalibrationSource, _ctppsDQMCalibrationSource)
+ctpps.toReplaceWith(ctppsDQMCalibrationHarvest, _ctppsDQMCalibrationHarvest)
 
 ctppsDQMOfflineSource = cms.Sequence()
 ctppsDQMOfflineHarvest = cms.Sequence()
-ctpps_2016.toReplaceWith(ctppsDQMOfflineSource, _ctppsDQMOfflineSource)
-ctpps_2016.toReplaceWith(ctppsDQMOfflineHarvest, _ctppsDQMOfflineHarvest)
+ctpps.toReplaceWith(ctppsDQMOfflineSource, _ctppsDQMOfflineSource)
+ctpps.toReplaceWith(ctppsDQMOfflineHarvest, _ctppsDQMOfflineHarvest)

--- a/DQM/CTPPS/test/all_ctpps_dqm_test_from_aod_cfg.py
+++ b/DQM/CTPPS/test/all_ctpps_dqm_test_from_aod_cfg.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
-from Configuration.Eras.Modifier_ctpps_2016_cff import ctpps_2016
-process = cms.Process('ctppsDQMfromAOD', ctpps_2016)
+from Configuration.Eras.Modifier_ctpps_cff import ctpps
+process = cms.Process('ctppsDQMfromAOD', ctpps)
 
 # minimum of logs
 process.MessageLogger = cms.Service("MessageLogger",

--- a/DQM/CTPPS/test/all_ctpps_dqm_test_from_dat_cfg.py
+++ b/DQM/CTPPS/test/all_ctpps_dqm_test_from_dat_cfg.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
-from Configuration.Eras.Modifier_ctpps_2016_cff import ctpps_2016
-process = cms.Process('ctppsDQMfromRAW', ctpps_2016)
+from Configuration.Eras.Modifier_ctpps_cff import ctpps
+process = cms.Process('ctppsDQMfromRAW', ctpps)
 
 # minimum of logs
 process.MessageLogger = cms.Service("MessageLogger",

--- a/DQM/CTPPS/test/all_ctpps_dqm_test_from_raw_cfg.py
+++ b/DQM/CTPPS/test/all_ctpps_dqm_test_from_raw_cfg.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
-from Configuration.Eras.Modifier_ctpps_2016_cff import ctpps_2016
-process = cms.Process('ctppsDQMfromRAW', ctpps_2016)
+from Configuration.Eras.Modifier_ctpps_cff import ctpps
+process = cms.Process('ctppsDQMfromRAW', ctpps)
 
 # minimum of logs
 process.MessageLogger = cms.Service("MessageLogger",

--- a/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
+++ b/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
@@ -628,9 +628,9 @@ def miniAOD_customizeData(process):
     process.load("Geometry.VeryForwardGeometry.geometryRPFromDB_cfi")
     process.load('L1Trigger.L1TGlobal.simGtExtFakeProd_cfi')
     task = getPatAlgosToolsTask(process)
-    from Configuration.Eras.Modifier_ctpps_2016_cff import ctpps_2016
-    ctpps_2016.toModify(task, func=lambda t: t.add(process.ctppsLocalTrackLiteProducer))
-    ctpps_2016.toModify(task, func=lambda t: t.add(process.ctppsProtons))
+    from Configuration.Eras.Modifier_ctpps_cff import ctpps
+    ctpps.toModify(task, func=lambda t: t.add(process.ctppsLocalTrackLiteProducer))
+    ctpps.toModify(task, func=lambda t: t.add(process.ctppsProtons))
     from Configuration.ProcessModifiers.run2_miniAOD_UL_cff import run2_miniAOD_UL
     run2_miniAOD_UL.toModify(task, func=lambda t: t.add(process.simGtExtUnprefireable))
 

--- a/RecoPPS/Configuration/test/raw_data_test.py
+++ b/RecoPPS/Configuration/test/raw_data_test.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
-from Configuration.Eras.Modifier_ctpps_2016_cff import ctpps_2016
-process = cms.Process("CTPPSReconstructionChainTest", ctpps_2016)
+from Configuration.Eras.Modifier_ctpps_cff import ctpps
+process = cms.Process("CTPPSReconstructionChainTest", ctpps)
 
 # minimum of logs
 process.MessageLogger = cms.Service("MessageLogger",

--- a/RecoPPS/Local/plugins/CTPPSLocalTrackLiteProducer.cc
+++ b/RecoPPS/Local/plugins/CTPPSLocalTrackLiteProducer.cc
@@ -238,7 +238,7 @@ void CTPPSLocalTrackLiteProducer::fillDescriptions(edm::ConfigurationDescription
   edm::ParameterSetDescription desc;
 
   // By default: all includeXYZ flags set to false.
-  // The includeXYZ are switched on when the "ctpps_2016" era is declared in
+  // The includeXYZ are switched on when the "ctpps" era modifier is declared in
   // python config, see:
   // RecoPPS/Local/python/ctppsLocalTrackLiteProducer_cff.py
 

--- a/RecoPPS/Local/python/ctppsLocalTrackLiteProducer_cff.py
+++ b/RecoPPS/Local/python/ctppsLocalTrackLiteProducer_cff.py
@@ -5,8 +5,8 @@ from RecoPPS.Local.ctppsLocalTrackLiteDefaultProducer_cfi import ctppsLocalTrack
 ctppsLocalTrackLiteProducer = ctppsLocalTrackLiteDefaultProducer.clone()
 
 # enable the module for CTPPS era(s)
-from Configuration.Eras.Modifier_ctpps_2016_cff import ctpps_2016
-ctpps_2016.toModify(
+from Configuration.Eras.Modifier_ctpps_cff import ctpps
+ctpps.toModify(
     ctppsLocalTrackLiteProducer,
     includeStrips = True,
     includeDiamonds = True,

--- a/RecoPPS/ProtonReconstruction/python/ctppsProtons_cff.py
+++ b/RecoPPS/ProtonReconstruction/python/ctppsProtons_cff.py
@@ -10,7 +10,7 @@ from CalibPPS.ESProducers.ctppsOpticalFunctions_cff import *
 from RecoPPS.ProtonReconstruction.ctppsProtons_cfi import *
 ctppsProtons.lhcInfoLabel = ctppsLHCInfoLabel
 
-from Configuration.Eras.Modifier_ctpps_2016_cff import ctpps_2016
+from Configuration.Eras.Modifier_ctpps_cff import ctpps
 from Configuration.Eras.Modifier_ctpps_2017_cff import ctpps_2017
 from Configuration.Eras.Modifier_ctpps_2018_cff import ctpps_2018
 
@@ -34,7 +34,7 @@ def applyDefaultSettings(ctppsProtons):
   ctppsProtons.pixelDiscardBXShiftedTracks = True
   ctppsProtons.default_time = -999.
 
-ctpps_2016.toModify(ctppsProtons, applyDefaultSettings) # applied for all Run2 years (2016, 2017 and 2018)
+ctpps.toModify(ctppsProtons, applyDefaultSettings)
 
 def apply2017Settings(ctppsProtons):
   ctppsProtons.association_cuts_45.x_cut_apply = False


### PR DESCRIPTION
#### PR description:

This PR proposes a tiny reorganisation of (CT)PPS era modifiers in order to avoid mistakes and provide flexibility needed for Run 3. The motivation and the selected solution are described in https://github.com/cms-sw/cmssw/issues/33080 and [PPS SW meeting presentation on 10 Mar 2021](https://indico.cern.ch/event/1016318/contributions/4265132/attachments/2205339/3731168/kaspar_PPS_SW_meeting.pdf). In brief, the changes include:
  * new era modifier `ctpps` introduced - turned on for all eras where PPS was/is active
  * the meaning of `ctpps_2016` is restricted to 2016 only

This update shall be transparent whenever `Run2_20XY` or `Run3` modifier chains are used.

This is a technical update, no change in test results expected.

No backport is foreseen.

#### PR validation:

Below, two comparisons before this PR (blue) vs. after the PR (red dashed) are attached:
  * direct simulation: [dirsim_cmp.pdf](https://github.com/cms-sw/cmssw/files/6187897/dirsim_cmp.pdf)
  * reconstruction: [reco_cmp.pdf](https://github.com/cms-sw/cmssw/files/6187898/reco_cmp.pdf)
 
No change observed, as expected.
