### PR TITLE
Validation code update for MTD tracks and hits

### DIFF
--- a/Validation/Configuration/python/mtdSimValid_cff.py
+++ b/Validation/Configuration/python/mtdSimValid_cff.py
@@ -7,8 +7,8 @@ from Validation.MtdValidation.btlLocalReco_cfi import btlLocalReco
 from Validation.MtdValidation.etlLocalReco_cfi import etlLocalReco
 from Validation.MtdValidation.etlSimHits_cfi import etlSimHits
 from Validation.MtdValidation.etlDigiHits_cfi import etlDigiHits
-from Validation.MtdValidation.globalReco_cfi import globalReco
+from Validation.MtdValidation.mtdTracks_cfi import mtdTracks
 
 mtdSimValid  = cms.Sequence(btlSimHits  + etlSimHits )
 mtdDigiValid = cms.Sequence(btlDigiHits + etlDigiHits)
-mtdRecoValid = cms.Sequence(btlLocalReco  + etlLocalReco + globalReco)
+mtdRecoValid = cms.Sequence(btlLocalReco  + etlLocalReco + mtdTracks)

--- a/Validation/MtdValidation/plugins/BtlDigiHitsValidation.cc
+++ b/Validation/MtdValidation/plugins/BtlDigiHitsValidation.cc
@@ -50,6 +50,7 @@ private:
   // ------------ member data ------------
 
   const std::string folder_;
+  const bool LocalPosDebug_;
 
   edm::EDGetTokenT<BTLDigiCollection> btlDigiHitsToken_;
 
@@ -61,6 +62,12 @@ private:
   MonitorElement* meHitTime_[2];
 
   MonitorElement* meOccupancy_[2];
+
+  //local position monitoring
+  MonitorElement* meLocalOccupancy_[2];
+  MonitorElement* meHitXlocal_[2];
+  MonitorElement* meHitYlocal_[2];
+  MonitorElement* meHitZlocal_[2];
 
   MonitorElement* meHitX_[2];
   MonitorElement* meHitY_[2];
@@ -79,7 +86,8 @@ private:
 
 // ------------ constructor and destructor --------------
 BtlDigiHitsValidation::BtlDigiHitsValidation(const edm::ParameterSet& iConfig)
-    : folder_(iConfig.getParameter<std::string>("folder")) {
+    : folder_(iConfig.getParameter<std::string>("folder")),
+      LocalPosDebug_(iConfig.getParameter<bool>("LocalPositionDebug")) {
   btlDigiHitsToken_ = consumes<BTLDigiCollection>(iConfig.getParameter<edm::InputTag>("inputTag"));
 }
 
@@ -132,6 +140,13 @@ void BtlDigiHitsValidation::analyze(const edm::Event& iEvent, const edm::EventSe
 
       meOccupancy_[iside]->Fill(global_point.z(), global_point.phi());
 
+      if (LocalPosDebug_) {
+        meLocalOccupancy_[iside]->Fill(local_point.x(), local_point.y());
+        meHitXlocal_[iside]->Fill(local_point.x());
+        meHitYlocal_[iside]->Fill(local_point.y());
+        meHitZlocal_[iside]->Fill(local_point.z());
+      }
+
       meHitX_[iside]->Fill(global_point.x());
       meHitY_[iside]->Fill(global_point.y());
       meHitZ_[iside]->Fill(global_point.z());
@@ -163,7 +178,6 @@ void BtlDigiHitsValidation::bookHistograms(DQMStore::IBooker& ibook,
                                            edm::Run const& run,
                                            edm::EventSetup const& iSetup) {
   ibook.setCurrentFolder(folder_);
-
   // --- histograms booking
 
   meNhits_[0] = ibook.book1D("BtlNhitsL", "Number of BTL DIGI hits (L);log_{10}(N_{DIGI})", 100, 0., 5.25);
@@ -173,7 +187,6 @@ void BtlDigiHitsValidation::bookHistograms(DQMStore::IBooker& ibook,
   meHitCharge_[1] = ibook.book1D("BtlHitChargeR", "BTL DIGI hits charge (R);Q_{DIGI} [ADC counts]", 100, 0., 1024.);
   meHitTime_[0] = ibook.book1D("BtlHitTimeL", "BTL DIGI hits ToA (L);ToA_{DIGI} [TDC counts]", 100, 0., 1024.);
   meHitTime_[1] = ibook.book1D("BtlHitTimeR", "BTL DIGI hits ToA (R);ToA_{DIGI} [TDC counts]", 100, 0., 1024.);
-
   meOccupancy_[0] = ibook.book2D("BtlOccupancyL",
                                  "BTL DIGI hits occupancy (L);Z_{DIGI} [cm]; #phi_{DIGI} [rad]",
                                  65,
@@ -190,6 +203,24 @@ void BtlDigiHitsValidation::bookHistograms(DQMStore::IBooker& ibook,
                                  126,
                                  -3.15,
                                  3.15);
+  if (LocalPosDebug_) {
+    meLocalOccupancy_[0] = ibook.book2D("BtlLocalOccupancyL",
+                                        "BTL DIGI hits local occupancy (L);X_{DIGI} [cm]; Y_{DIGI} [cm]",
+                                        100,
+                                        -10.,
+                                        10,
+                                        60,
+                                        -3.,
+                                        3.);
+    meLocalOccupancy_[1] = ibook.book2D(
+        "BtlLocalOccupancyR", "BTL DIGI hits occupancy (R);X_{DIGI} [cm]; Y_{DIGI} [cm]", 100, -10., 10., 60, -3., 3.);
+    meHitXlocal_[0] = ibook.book1D("BtlHitXlocalL", "BTL DIGI local X (L);X_{DIGI}^{LOC} [cm]", 100, -10., 10.);
+    meHitXlocal_[1] = ibook.book1D("BtlHitXlocalR", "BTL DIGI local X (R);X_{DIGI}^{LOC} [cm]", 100, -10., 10.);
+    meHitYlocal_[0] = ibook.book1D("BtlHitYlocalL", "BTL DIGI local Y (L);Y_{DIGI}^{LOC} [cm]", 60, -3., 3.);
+    meHitYlocal_[1] = ibook.book1D("BtlHitYlocalR", "BTL DIGI local Y (R);Y_{DIGI}^{LOC} [cm]", 60, -3., 3.);
+    meHitZlocal_[0] = ibook.book1D("BtlHitZlocalL", "BTL DIGI local z (L);z_{DIGI}^{LOC} [cm]", 10, -1, 1);
+    meHitZlocal_[1] = ibook.book1D("BtlHitZlocalR", "BTL DIGI local z (R);z_{DIGI}^{LOC} [cm]", 10, -1, 1);
+  }
 
   meHitX_[0] = ibook.book1D("BtlHitXL", "BTL DIGI hits X (L);X_{DIGI} [cm]", 60, -120., 120.);
   meHitX_[1] = ibook.book1D("BtlHitXR", "BTL DIGI hits X (R);X_{DIGI} [cm]", 60, -120., 120.);
@@ -258,6 +289,7 @@ void BtlDigiHitsValidation::fillDescriptions(edm::ConfigurationDescriptions& des
 
   desc.add<std::string>("folder", "MTD/BTL/DigiHits");
   desc.add<edm::InputTag>("inputTag", edm::InputTag("mix", "FTLBarrel"));
+  desc.add<bool>("LocalPositionDebug", false);
 
   descriptions.add("btlDigiHitsDefault", desc);
 }

--- a/Validation/MtdValidation/plugins/BtlLocalRecoValidation.cc
+++ b/Validation/MtdValidation/plugins/BtlLocalRecoValidation.cc
@@ -199,7 +199,7 @@ void BtlLocalRecoValidation::analyze(const edm::Event& iEvent, const edm::EventS
     meOccupancy_->Fill(global_point.z(), global_point.phi());
 
     if (LocalPosDebug_) {
-      meLocalOccupancy_->Fill(local_point.x(), local_point.y());
+      meLocalOccupancy_->Fill(local_point.x() + recHit.position(), local_point.y());
       meHitXlocal_->Fill(local_point.x());
       meHitYlocal_->Fill(local_point.y());
       meHitZlocal_->Fill(local_point.z());

--- a/Validation/MtdValidation/plugins/BtlLocalRecoValidation.cc
+++ b/Validation/MtdValidation/plugins/BtlLocalRecoValidation.cc
@@ -381,7 +381,7 @@ void BtlLocalRecoValidation::fillDescriptions(edm::ConfigurationDescriptions& de
   desc.add<edm::InputTag>("simHitsTag", edm::InputTag("mix", "g4SimHitsFastTimerHitsBarrel"));
   desc.add<edm::InputTag>("recCluTag", edm::InputTag("mtdClusters", "FTLBarrel"));
   desc.add<double>("hitMinimumEnergy", 1.);  // [MeV]
-  desc.add<bool>("LocalPositionDebug", true);
+  desc.add<bool>("LocalPositionDebug", false);
 
   descriptions.add("btlLocalReco", desc);
 }

--- a/Validation/MtdValidation/plugins/BtlLocalRecoValidation.cc
+++ b/Validation/MtdValidation/plugins/BtlLocalRecoValidation.cc
@@ -114,6 +114,7 @@ private:
   MonitorElement* meTPullvsEta_;
 
   MonitorElement* meCluTime_;
+  MonitorElement* meCluTimeError_;
   MonitorElement* meCluEnergy_;
   MonitorElement* meCluPhi_;
   MonitorElement* meCluEta_;
@@ -236,8 +237,8 @@ void BtlLocalRecoValidation::analyze(const edm::Event& iEvent, const edm::EventS
           topo.pixelToModuleLocalPoint(local_point_sim, detId.row(topo.nrows()), detId.column(topo.nrows()));
       const auto& global_point_sim = thedet->toGlobal(local_point_sim);
 
-      meTimeRes_->Fill(time_res / m_btlSimHits[detId.rawId()].time);
-      meEnergyRes_->Fill(energy_res / m_btlSimHits[detId.rawId()].energy);
+      meTimeRes_->Fill(time_res);
+      meEnergyRes_->Fill(energy_res);
 
       meLongPosPull_->Fill(longpos_res / recHit.positionError());
       meLongPosPullvsEta_->Fill(std::abs(global_point_sim.eta()), longpos_res / recHit.positionError());
@@ -276,6 +277,7 @@ void BtlLocalRecoValidation::analyze(const edm::Event& iEvent, const edm::EventS
 
       meCluEnergy_->Fill(cluster.energy());
       meCluTime_->Fill(cluster.time());
+      meCluTimeError_->Fill(cluster.timeError());
       meCluPhi_->Fill(global_point.phi());
       meCluEta_->Fill(global_point.eta());
       meCluZvsPhi_->Fill(global_point.z(), global_point.phi());
@@ -328,8 +330,8 @@ void BtlLocalRecoValidation::bookHistograms(DQMStore::IBooker& ibook,
   meHitLongPos_ = ibook.book1D("BtlLongPos", "BTL RECO hits longitudinal position;long. pos._{RECO}", 100, -10, 10);
   meHitLongPosErr_ =
       ibook.book1D("BtlLongPosErr", "BTL RECO hits longitudinal position error; long. pos. error_{RECO}", 100, -1, 1);
-  meTimeRes_ = ibook.book1D("BtlTimeRes", "BTL time resolution;T_{RECO}-T_{SIM}/T_{SIM}", 100, -0.5, 0.5);
-  meEnergyRes_ = ibook.book1D("BtlEnergyRes", "BTL energy resolution;E_{RECO}-E_{SIM}/E_{SIM}", 100, -0.5, 0.5);
+  meTimeRes_ = ibook.book1D("BtlTimeRes", "BTL time resolution;T_{RECO}-T_{SIM}", 100, -0.5, 0.5);
+  meEnergyRes_ = ibook.book1D("BtlEnergyRes", "BTL energy resolution;E_{RECO}-E_{SIM}", 100, -0.5, 0.5);
   meLongPosPull_ = ibook.book1D("BtlLongPosPull",
                                 "BTL longitudinal position pull;X^{loc}_{RECO}-X^{loc}_{SIM}/#sigma_{xloc_{RECO}}",
                                 100,
@@ -364,6 +366,7 @@ void BtlLocalRecoValidation::bookHistograms(DQMStore::IBooker& ibook,
                                     0.8,
                                     "S");
   meCluTime_ = ibook.book1D("BtlCluTime", "BTL cluster time ToA;ToA [ns]", 250, 0, 25);
+  meCluTimeError_ = ibook.book1D("BtlCluTimeError", "BTL cluster time error;#sigma_{t} [ns]", 100, 0, 0.1);
   meCluEnergy_ = ibook.book1D("BtlCluEnergy", "BTL cluster energy;E_{RECO} [MeV]", 100, 0, 20);
   meCluPhi_ = ibook.book1D("BtlCluPhi", "BTL cluster #phi;#phi_{RECO} [rad]", 144, -3.2, 3.2);
   meCluEta_ = ibook.book1D("BtlCluEta", "BTL cluster #eta;#eta_{RECO}", 100, -1.55, 1.55);

--- a/Validation/MtdValidation/plugins/BtlLocalRecoValidation.cc
+++ b/Validation/MtdValidation/plugins/BtlLocalRecoValidation.cc
@@ -240,10 +240,10 @@ void BtlLocalRecoValidation::analyze(const edm::Event& iEvent, const edm::EventS
       meEnergyRes_->Fill(energy_res / m_btlSimHits[detId.rawId()].energy);
 
       meLongPosPull_->Fill(longpos_res / recHit.positionError());
-      meLongPosPullvsEta_->Fill(fabs(global_point_sim.eta()), longpos_res / recHit.positionError());
+      meLongPosPullvsEta_->Fill(std::abs(global_point_sim.eta()), longpos_res / recHit.positionError());
       meLongPosPullvsE_->Fill(m_btlSimHits[detId.rawId()].energy, longpos_res / recHit.positionError());
 
-      meTPullvsEta_->Fill(fabs(global_point_sim.eta()), time_res / recHit.timeError());
+      meTPullvsEta_->Fill(std::abs(global_point_sim.eta()), time_res / recHit.timeError());
       meTPullvsE_->Fill(m_btlSimHits[detId.rawId()].energy, time_res / recHit.timeError());
     }
 

--- a/Validation/MtdValidation/plugins/EtlDigiHitsValidation.cc
+++ b/Validation/MtdValidation/plugins/EtlDigiHitsValidation.cc
@@ -46,6 +46,7 @@ private:
   // ------------ member data ------------
 
   const std::string folder_;
+  const bool LocalPosDebug_;
 
   edm::EDGetTokenT<ETLDigiCollection> etlDigiHitsToken_;
 
@@ -57,6 +58,10 @@ private:
   MonitorElement* meHitTime_[4];
 
   MonitorElement* meOccupancy_[4];
+
+  MonitorElement* meLocalOccupancy_[2];  //folding the two ETL discs
+  MonitorElement* meHitXlocal_[2];
+  MonitorElement* meHitYlocal_[2];
 
   MonitorElement* meHitX_[4];
   MonitorElement* meHitY_[4];
@@ -73,7 +78,8 @@ private:
 
 // ------------ constructor and destructor --------------
 EtlDigiHitsValidation::EtlDigiHitsValidation(const edm::ParameterSet& iConfig)
-    : folder_(iConfig.getParameter<std::string>("folder")) {
+    : folder_(iConfig.getParameter<std::string>("folder")),
+      LocalPosDebug_(iConfig.getParameter<bool>("LocalPositionDebug")) {
   etlDigiHitsToken_ = consumes<ETLDigiCollection>(iConfig.getParameter<edm::InputTag>("inputTag"));
 }
 
@@ -157,6 +163,19 @@ void EtlDigiHitsValidation::analyze(const edm::Event& iEvent, const edm::EventSe
     meHitCharge_[idet]->Fill(sample.data());
     meHitTime_[idet]->Fill(sample.toa());
     meOccupancy_[idet]->Fill(global_point.x(), global_point.y(), weight);
+
+    if (LocalPosDebug_) {
+      if ((idet == 0) || (idet == 1)) {
+        meLocalOccupancy_[0]->Fill(local_point.x(), local_point.y());
+        meHitXlocal_[0]->Fill(local_point.x());
+        meHitYlocal_[0]->Fill(local_point.y());
+
+      } else if ((idet == 2) || (idet == 3)) {
+        meLocalOccupancy_[1]->Fill(local_point.x(), local_point.y());
+        meHitXlocal_[1]->Fill(local_point.x());
+        meHitYlocal_[1]->Fill(local_point.y());
+      }
+    }
 
     meHitX_[idet]->Fill(global_point.x());
     meHitY_[idet]->Fill(global_point.y());
@@ -272,7 +291,28 @@ void EtlDigiHitsValidation::bookHistograms(DQMStore::IBooker& ibook,
                                  135,
                                  -135.,
                                  135.);
-
+  if (LocalPosDebug_) {
+    meLocalOccupancy_[0] = ibook.book2D("EtlLocalOccupancyZneg",
+                                        "ETL DIGI hits local occupancy (-Z);X_{DIGI} [cm];Y_{DIGI} [cm]",
+                                        100,
+                                        -2.2,
+                                        2.2,
+                                        50,
+                                        -1.1,
+                                        1.1);
+    meLocalOccupancy_[1] = ibook.book2D("EtlLocalOccupancyZpos",
+                                        "ETL DIGI hits local occupancy (+Z);X_{DIGI} [cm];Y_{DIGI} [cm]",
+                                        100,
+                                        -2.2,
+                                        2.2,
+                                        50,
+                                        -1.1,
+                                        1.1);
+    meHitXlocal_[0] = ibook.book1D("EtlHitXlocalZneg", "ETL DIGI local X (-Z);X_{DIGI}^{LOC} [cm]", 100, -2.2, 2.2);
+    meHitXlocal_[1] = ibook.book1D("EtlHitXlocalZpos", "ETL DIGI local X (+Z);X_{DIGI}^{LOC} [cm]", 100, -2.2, 2.2);
+    meHitYlocal_[0] = ibook.book1D("EtlHitYlocalZneg", "ETL DIGI local Y (-Z);Y_{DIGI}^{LOC} [cm]", 50, -1.1, 1.1);
+    meHitYlocal_[1] = ibook.book1D("EtlHitYlocalZpos", "ETL DIGI local Y (-Z);Y_{DIGI}^{LOC} [cm]", 50, -1.1, 1.1);
+  }
   meHitX_[0] = ibook.book1D(
       "EtlHitXZnegD1", "ETL DIGI hits X (-Z, Single(topo1D)/First(topo2D) disk);X_{DIGI} [cm]", 100, -130., 130.);
   meHitX_[1] = ibook.book1D("EtlHitXZnegD2", "ETL DIGI hits X (-Z, Second disk);X_{DIGI} [cm]", 100, -130., 130.);
@@ -312,7 +352,6 @@ void EtlDigiHitsValidation::bookHistograms(DQMStore::IBooker& ibook,
   meHitEta_[2] = ibook.book1D(
       "EtlHitEtaZposD1", "ETL DIGI hits #eta (+Z, Single(topo1D)/First(topo2D) disk);#eta_{DIGI}", 100, 1.56, 3.2);
   meHitEta_[3] = ibook.book1D("EtlHitEtaZposD2", "ETL DIGI hits #eta (+Z, Second disk);#eta_{DIGI}", 100, 1.56, 3.2);
-
   meHitTvsQ_[0] = ibook.bookProfile(
       "EtlHitTvsQZnegD1",
       "ETL DIGI ToA vs charge (-Z, Single(topo1D)/First(topo2D) disk);Q_{DIGI} [ADC counts];ToA_{DIGI} [TDC counts]",
@@ -477,6 +516,7 @@ void EtlDigiHitsValidation::fillDescriptions(edm::ConfigurationDescriptions& des
 
   desc.add<std::string>("folder", "MTD/ETL/DigiHits");
   desc.add<edm::InputTag>("inputTag", edm::InputTag("mix", "FTLEndcap"));
+  desc.add<bool>("LocalPositionDebug", false);
 
   descriptions.add("etlDigiHitsDefault", desc);
 }

--- a/Validation/MtdValidation/plugins/EtlLocalRecoValidation.cc
+++ b/Validation/MtdValidation/plugins/EtlLocalRecoValidation.cc
@@ -22,15 +22,28 @@
 #include "DQMServices/Core/interface/DQMStore.h"
 
 #include "DataFormats/Common/interface/ValidHandle.h"
+#include "DataFormats/Math/interface/GeantUnits.h"
 #include "DataFormats/ForwardDetId/interface/ETLDetId.h"
 #include "DataFormats/FTLRecHit/interface/FTLRecHitCollections.h"
 #include "DataFormats/FTLRecHit/interface/FTLClusterCollections.h"
+
+#include "SimDataFormats/CrossingFrame/interface/CrossingFrame.h"
+#include "SimDataFormats/CrossingFrame/interface/MixCollection.h"
+#include "SimDataFormats/TrackingHit/interface/PSimHit.h"
 
 #include "Geometry/Records/interface/MTDDigiGeometryRecord.h"
 #include "Geometry/MTDGeometryBuilder/interface/MTDGeometry.h"
 #include "Geometry/CommonTopologies/interface/PixelTopology.h"
 #include "Geometry/MTDNumberingBuilder/interface/MTDTopology.h"
 #include "Geometry/MTDCommonData/interface/MTDTopologyMode.h"
+
+struct MTDHit {
+  float energy;
+  float time;
+  float x_local;
+  float y_local;
+  float z_local;
+};
 
 class EtlLocalRecoValidation : public DQMEDAnalyzer {
 public:
@@ -49,8 +62,10 @@ private:
   const std::string folder_;
   const float hitMinEnergy1Dis_;
   const float hitMinEnergy2Dis_;
+  const bool LocalPosDebug_;
 
   edm::EDGetTokenT<FTLRecHitCollection> etlRecHitsToken_;
+  edm::EDGetTokenT<CrossingFrame<PSimHit> > etlSimHitsToken_;
   edm::EDGetTokenT<FTLClusterCollection> etlRecCluToken_;
 
   // --- histograms declaration
@@ -58,8 +73,13 @@ private:
   MonitorElement* meNhits_[4];
   MonitorElement* meHitEnergy_[4];
   MonitorElement* meHitTime_[4];
+  MonitorElement* meHitTimeError_[4];
 
   MonitorElement* meOccupancy_[4];
+
+  MonitorElement* meLocalOccupancy_[2];
+  MonitorElement* meHitXlocal_[2];
+  MonitorElement* meHitYlocal_[2];
 
   MonitorElement* meHitX_[4];
   MonitorElement* meHitY_[4];
@@ -79,14 +99,21 @@ private:
   MonitorElement* meCluEta_[4];
   MonitorElement* meCluHits_[4];
   MonitorElement* meCluOccupancy_[4];
+
+  MonitorElement* meTimeRes_;
+  MonitorElement* meEnergyRes_;
+  MonitorElement* meTPullvsE_;
+  MonitorElement* meTPullvsEta_;
 };
 
 // ------------ constructor and destructor --------------
 EtlLocalRecoValidation::EtlLocalRecoValidation(const edm::ParameterSet& iConfig)
     : folder_(iConfig.getParameter<std::string>("folder")),
       hitMinEnergy1Dis_(iConfig.getParameter<double>("hitMinimumEnergy1Dis")),
-      hitMinEnergy2Dis_(iConfig.getParameter<double>("hitMinimumEnergy2Dis")) {
+      hitMinEnergy2Dis_(iConfig.getParameter<double>("hitMinimumEnergy2Dis")),
+      LocalPosDebug_(iConfig.getParameter<bool>("LocalPositionDebug")) {
   etlRecHitsToken_ = consumes<FTLRecHitCollection>(iConfig.getParameter<edm::InputTag>("recHitsTag"));
+  etlSimHitsToken_ = consumes<CrossingFrame<PSimHit> >(iConfig.getParameter<edm::InputTag>("simHitsTag"));
   etlRecCluToken_ = consumes<FTLClusterCollection>(iConfig.getParameter<edm::InputTag>("recCluTag"));
 }
 
@@ -96,6 +123,8 @@ EtlLocalRecoValidation::~EtlLocalRecoValidation() {}
 void EtlLocalRecoValidation::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
   using namespace edm;
   using namespace std;
+  using namespace geant_units::operators;
+
   edm::ESHandle<MTDTopology> topologyHandle;
   iSetup.get<MTDTopologyRcd>().get(topologyHandle);
   const MTDTopology* topology = topologyHandle.product();
@@ -114,10 +143,50 @@ void EtlLocalRecoValidation::analyze(const edm::Event& iEvent, const edm::EventS
   const MTDGeometry* geom = geometryHandle.product();
 
   auto etlRecHitsHandle = makeValid(iEvent.getHandle(etlRecHitsToken_));
+  auto etlSimHitsHandle = makeValid(iEvent.getHandle(etlSimHitsToken_));
   auto etlRecCluHandle = makeValid(iEvent.getHandle(etlRecCluToken_));
+  MixCollection<PSimHit> etlSimHits(etlSimHitsHandle.product());
+
+  // --- Loop over the ETL SIM hits
+  std::unordered_map<uint32_t, MTDHit> m_etlSimHits[4];
+  for (auto const& simHit : etlSimHits) {
+    // --- Use only hits compatible with the in-time bunch-crossing
+    if (simHit.tof() < 0 || simHit.tof() > 25.)
+      continue;
+
+    ETLDetId id = simHit.detUnitId();
+
+    int idet = -1;
+
+    if ((id.zside() == -1) && (id.nDisc() == 1))
+      idet = 0;
+    else if ((id.zside() == -1) && (id.nDisc() == 2))
+      idet = 1;
+    else if ((id.zside() == 1) && (id.nDisc() == 1))
+      idet = 2;
+    else if ((id.zside() == 1) && (id.nDisc() == 2))
+      idet = 3;
+    else
+      continue;
+
+    auto simHitIt = m_etlSimHits[idet].emplace(id.rawId(), MTDHit()).first;
+
+    // --- Accumulate the energy (in MeV) of SIM hits in the same detector cell
+    (simHitIt->second).energy += convertUnitsTo(0.001_MeV, simHit.energyLoss());
+
+    // --- Get the time of the first SIM hit in the cell
+    if ((simHitIt->second).time == 0 || simHit.tof() < (simHitIt->second).time) {
+      (simHitIt->second).time = simHit.tof();
+
+      auto hit_pos = simHit.entryPoint();
+      (simHitIt->second).x_local = hit_pos.x();
+      (simHitIt->second).y_local = hit_pos.y();
+      (simHitIt->second).z_local = hit_pos.z();
+    }
+
+  }  // simHit loop
 
   // --- Loop over the ELT RECO hits
-
   unsigned int n_reco_etl[4] = {0, 0, 0, 0};
   for (const auto& recHit : *etlRecHitsHandle) {
     double weight = 1.0;
@@ -165,8 +234,22 @@ void EtlLocalRecoValidation::analyze(const edm::Event& iEvent, const edm::EventS
 
     meHitEnergy_[idet]->Fill(recHit.energy());
     meHitTime_[idet]->Fill(recHit.time());
+    meHitTimeError_[idet]->Fill(recHit.timeError());
 
     meOccupancy_[idet]->Fill(global_point.x(), global_point.y(), weight);
+
+    if (LocalPosDebug_) {
+      if ((idet == 0) || (idet == 1)) {
+        meLocalOccupancy_[0]->Fill(local_point.x(), local_point.y());
+        meHitXlocal_[0]->Fill(local_point.x());
+        meHitYlocal_[0]->Fill(local_point.y());
+      }
+      if ((idet == 2) || (idet == 3)) {
+        meLocalOccupancy_[1]->Fill(local_point.x(), local_point.y());
+        meHitXlocal_[1]->Fill(local_point.x());
+        meHitYlocal_[1]->Fill(local_point.y());
+      }
+    }
     meHitX_[idet]->Fill(global_point.x());
     meHitY_[idet]->Fill(global_point.y());
     meHitZ_[idet]->Fill(global_point.z());
@@ -177,6 +260,21 @@ void EtlLocalRecoValidation::analyze(const edm::Event& iEvent, const edm::EventS
     meHitEvsEta_[idet]->Fill(global_point.eta(), recHit.energy());
     meHitTvsPhi_[idet]->Fill(global_point.phi(), recHit.time());
     meHitTvsEta_[idet]->Fill(global_point.eta(), recHit.time());
+
+    // Resolution histograms
+    if (m_etlSimHits[idet].count(detId.rawId()) == 1) {
+      if ((topo1Dis && m_etlSimHits[idet][detId.rawId()].energy > hitMinEnergy1Dis_) ||
+          (topo2Dis && m_etlSimHits[idet][detId.rawId()].energy > hitMinEnergy2Dis_)) {
+        float time_res = recHit.time() - m_etlSimHits[idet][detId.rawId()].time;
+        float energy_res = recHit.energy() - m_etlSimHits[idet][detId.rawId()].energy;
+
+        meTimeRes_->Fill(time_res / m_etlSimHits[idet][detId.rawId()].time);
+        meEnergyRes_->Fill(energy_res / m_etlSimHits[idet][detId.rawId()].energy);
+
+        meTPullvsEta_->Fill(fabs(global_point.eta()), time_res / recHit.timeError());
+        meTPullvsE_->Fill(m_etlSimHits[idet][detId.rawId()].energy, time_res / recHit.timeError());
+      }
+    }
 
     n_reco_etl[idet]++;
   }  // recHit loop
@@ -284,6 +382,22 @@ void EtlLocalRecoValidation::bookHistograms(DQMStore::IBooker& ibook,
   meHitTime_[2] = ibook.book1D(
       "EtlHitTimeZposD1", "ETL RECO hits ToA (+Z, Single(topo1D)/First(topo2D) disk);ToA_{RECO} [ns]", 100, 0., 25.);
   meHitTime_[3] = ibook.book1D("EtlHitTimeZposD2", "ETL RECO hits ToA (+Z, Second disk);ToA_{RECO} [ns]", 100, 0., 25.);
+  meHitTimeError_[0] =
+      ibook.book1D("EtlHitTimeErrorZnegD1",
+                   "ETL RECO hits ToA error (-Z, Single(topo1D)/First(topo2D) disk);#sigma^{ToA}_{RECO} [ns]",
+                   50,
+                   0.,
+                   0.1);
+  meHitTimeError_[1] = ibook.book1D(
+      "EtlHitTimeErrorZnegD2", "ETL RECO hits ToA error(-Z, Second disk);#sigma^{ToA}_{RECO} [ns]", 50, 0., 0.1);
+  meHitTimeError_[2] =
+      ibook.book1D("EtlHitTimeErrorZposD1",
+                   "ETL RECO hits ToA error (+Z, Single(topo1D)/First(topo2D) disk);#sigma^{ToA}_{RECO} [ns]",
+                   50,
+                   0.,
+                   0.1);
+  meHitTimeError_[3] = ibook.book1D(
+      "EtlHitTimeErrorZposD2", "ETL RECO hits ToA error(+Z, Second disk);#sigma^{ToA}_{RECO} [ns]", 50, 0., 0.1);
 
   meOccupancy_[0] =
       ibook.book2D("EtlOccupancyZnegD1",
@@ -319,7 +433,28 @@ void EtlLocalRecoValidation::bookHistograms(DQMStore::IBooker& ibook,
                                  135,
                                  -135.,
                                  135.);
-
+  if (LocalPosDebug_) {
+    meLocalOccupancy_[0] = ibook.book2D("EtlLocalOccupancyZneg",
+                                        "ETL RECO hits local occupancy (-Z);X_{RECO} [cm];Y_{RECO} [cm]",
+                                        100,
+                                        -2.2,
+                                        2.2,
+                                        50,
+                                        -1.1,
+                                        1.1);
+    meLocalOccupancy_[1] = ibook.book2D("EtlLocalOccupancyZpos",
+                                        "ETL RECO hits local occupancy (+Z);X_{RECO} [cm];Y_{RECO} [cm]",
+                                        100,
+                                        -2.2,
+                                        2.2,
+                                        50,
+                                        -1.1,
+                                        1.1);
+    meHitXlocal_[0] = ibook.book1D("EtlHitXlocalZneg", "ETL RECO local X (-Z);X_{RECO}^{LOC} [cm]", 100, -2.2, 2.2);
+    meHitXlocal_[1] = ibook.book1D("EtlHitXlocalZpos", "ETL RECO local X (+Z);X_{RECO}^{LOC} [cm]", 100, -2.2, 2.2);
+    meHitYlocal_[0] = ibook.book1D("EtlHitYlocalZneg", "ETL RECO local Y (-Z);Y_{RECO}^{LOC} [cm]", 50, -1.1, 1.1);
+    meHitYlocal_[1] = ibook.book1D("EtlHitYlocalZpos", "ETL RECO local Y (-Z);Y_{RECO}^{LOC} [cm]", 50, -1.1, 1.1);
+  }
   meHitX_[0] = ibook.book1D(
       "EtlHitXZnegD1", "ETL RECO hits X (-Z, Single(topo1D)/First(topo2D) Disk);X_{RECO} [cm]", 100, -130., 130.);
   meHitX_[1] = ibook.book1D("EtlHitXZnegD2", "ETL RECO hits X (-Z, Second Disk);X_{RECO} [cm]", 100, -130., 130.);
@@ -352,7 +487,8 @@ void EtlLocalRecoValidation::bookHistograms(DQMStore::IBooker& ibook,
   meHitEta_[2] = ibook.book1D(
       "EtlHitEtaZposD1", "ETL RECO hits #eta (+Z, Single(topo1D)/First(topo2D) Disk);#eta_{RECO}", 100, 1.56, 3.2);
   meHitEta_[3] = ibook.book1D("EtlHitEtaZposD2", "ETL RECO hits #eta (+Z, Second Disk);#eta_{RECO}", 100, 1.56, 3.2);
-
+  meTimeRes_ = ibook.book1D("EtlTimeRes", "ETL time resolution;T_{RECO}-T_{SIM}/T_{SIM} [ns]", 100, -0.5, 0.5);
+  meEnergyRes_ = ibook.book1D("EtlEnergyRes", "ETL energy resolution;E_{RECO}-E_{SIM}/E_{SIM} [MeV]", 100, -0.5, 0.5);
   meHitTvsE_[0] = ibook.bookProfile(
       "EtlHitTvsEZnegD1",
       "ETL RECO time vs energy (-Z, Single(topo1D)/First(topo2D) Disk);E_{RECO} [MeV];ToA_{RECO} [ns]",
@@ -503,6 +639,22 @@ void EtlLocalRecoValidation::bookHistograms(DQMStore::IBooker& ibook,
                                       3.2,
                                       0.,
                                       100.);
+  meTPullvsE_ = ibook.bookProfile("EtlTPullvsE",
+                                  "ETL time pull vs E;E_{SIM} [MeV];T_{RECO}-T_{SIM}/#sigma_T_{RECO} [ns]",
+                                  20,
+                                  0.,
+                                  2.,
+                                  -0.8,
+                                  0.8,
+                                  "S");
+  meTPullvsEta_ = ibook.bookProfile("EtlTPullvsEta",
+                                    "ETL time pull vs #eta;|#eta_{RECO}|;T_{RECO}-T_{SIM}/#sigma_T_{RECO} [ns]",
+                                    26,
+                                    1.65,
+                                    3.0,
+                                    -0.8,
+                                    0.8,
+                                    "S");
   meCluTime_[0] =
       ibook.book1D("EtlCluTimeZnegD1", "ETL cluster ToA (-Z, Single(topo1D)/First(topo2D) Disk);ToA [ns]", 250, 0, 25);
   meCluTime_[1] = ibook.book1D("EtlCluTimeZnegD2", "ETL cluster ToA (-Z, Second Disk);ToA [ns]", 250, 0, 25);
@@ -581,9 +733,11 @@ void EtlLocalRecoValidation::fillDescriptions(edm::ConfigurationDescriptions& de
 
   desc.add<std::string>("folder", "MTD/ETL/LocalReco");
   desc.add<edm::InputTag>("recHitsTag", edm::InputTag("mtdRecHits", "FTLEndcap"));
+  desc.add<edm::InputTag>("simHitsTag", edm::InputTag("mix", "g4SimHitsFastTimerHitsEndcap"));
   desc.add<edm::InputTag>("recCluTag", edm::InputTag("mtdClusters", "FTLEndcap"));
   desc.add<double>("hitMinimumEnergy1Dis", 1.);     // [MeV]
   desc.add<double>("hitMinimumEnergy2Dis", 0.001);  // [MeV]
+  desc.add<bool>("LocalPositionDebug", false);
 
   descriptions.add("etlLocalReco", desc);
 }

--- a/Validation/MtdValidation/plugins/EtlLocalRecoValidation.cc
+++ b/Validation/MtdValidation/plugins/EtlLocalRecoValidation.cc
@@ -94,6 +94,7 @@ private:
   MonitorElement* meHitTvsEta_[4];
 
   MonitorElement* meCluTime_[4];
+  MonitorElement* meCluTimeError_[4];
   MonitorElement* meCluEnergy_[4];
   MonitorElement* meCluPhi_[4];
   MonitorElement* meCluEta_[4];
@@ -268,8 +269,8 @@ void EtlLocalRecoValidation::analyze(const edm::Event& iEvent, const edm::EventS
         float time_res = recHit.time() - m_etlSimHits[idet][detId.rawId()].time;
         float energy_res = recHit.energy() - m_etlSimHits[idet][detId.rawId()].energy;
 
-        meTimeRes_->Fill(time_res / m_etlSimHits[idet][detId.rawId()].time);
-        meEnergyRes_->Fill(energy_res / m_etlSimHits[idet][detId.rawId()].energy);
+        meTimeRes_->Fill(time_res);
+        meEnergyRes_->Fill(energy_res);
 
         meTPullvsEta_->Fill(std::abs(global_point.eta()), time_res / recHit.timeError());
         meTPullvsE_->Fill(m_etlSimHits[idet][detId.rawId()].energy, time_res / recHit.timeError());
@@ -346,6 +347,7 @@ void EtlLocalRecoValidation::analyze(const edm::Event& iEvent, const edm::EventS
 
       meCluEnergy_[idet]->Fill(cluster.energy());
       meCluTime_[idet]->Fill(cluster.time());
+      meCluTimeError_[idet]->Fill(cluster.timeError());
       meCluPhi_[idet]->Fill(global_point.phi());
       meCluEta_[idet]->Fill(global_point.eta());
       meCluOccupancy_[idet]->Fill(global_point.x(), global_point.y(), weight);
@@ -487,8 +489,8 @@ void EtlLocalRecoValidation::bookHistograms(DQMStore::IBooker& ibook,
   meHitEta_[2] = ibook.book1D(
       "EtlHitEtaZposD1", "ETL RECO hits #eta (+Z, Single(topo1D)/First(topo2D) Disk);#eta_{RECO}", 100, 1.56, 3.2);
   meHitEta_[3] = ibook.book1D("EtlHitEtaZposD2", "ETL RECO hits #eta (+Z, Second Disk);#eta_{RECO}", 100, 1.56, 3.2);
-  meTimeRes_ = ibook.book1D("EtlTimeRes", "ETL time resolution;T_{RECO}-T_{SIM}/T_{SIM}", 100, -0.5, 0.5);
-  meEnergyRes_ = ibook.book1D("EtlEnergyRes", "ETL energy resolution;E_{RECO}-E_{SIM}/E_{SIM}", 100, -0.5, 0.5);
+  meTimeRes_ = ibook.book1D("EtlTimeRes", "ETL time resolution;T_{RECO}-T_{SIM}", 100, -0.5, 0.5);
+  meEnergyRes_ = ibook.book1D("EtlEnergyRes", "ETL energy resolution;E_{RECO}-E_{SIM}", 100, -0.5, 0.5);
   meHitTvsE_[0] = ibook.bookProfile(
       "EtlHitTvsEZnegD1",
       "ETL RECO time vs energy (-Z, Single(topo1D)/First(topo2D) Disk);E_{RECO} [MeV];ToA_{RECO} [ns]",
@@ -655,6 +657,20 @@ void EtlLocalRecoValidation::bookHistograms(DQMStore::IBooker& ibook,
   meCluTime_[2] =
       ibook.book1D("EtlCluTimeZposD1", "ETL cluster ToA (+Z, Single(topo1D)/First(topo2D) Disk);ToA [ns]", 250, 0, 25);
   meCluTime_[3] = ibook.book1D("EtlCluTimeZposD2", "ETL cluster ToA (+Z, Second Disk);ToA [ns]", 250, 0, 25);
+  meCluTimeError_[0] = ibook.book1D("EtlCluTimeErrosZnegD1",
+                                    "ETL cluster time error (-Z, Single(topo1D)/First(topo2D) Disk);#sigma_{t} [ns]",
+                                    100,
+                                    0,
+                                    0.1);
+  meCluTimeError_[1] =
+      ibook.book1D("EtlCluTimeErrorZnegD2", "ETL cluster time error (-Z, Second Disk);#sigma_{t} [ns]", 100, 0, 0.1);
+  meCluTimeError_[2] = ibook.book1D("EtlCluTimeErrorZposD1",
+                                    "ETL cluster time error (+Z, Single(topo1D)/First(topo2D) Disk);#sigma_{t} [ns]",
+                                    100,
+                                    0,
+                                    0.1);
+  meCluTimeError_[3] =
+      ibook.book1D("EtlCluTimeErrorZposD2", "ETL cluster time error (+Z, Second Disk);#sigma_{t} [ns]", 100, 0, 0.1);
   meCluEnergy_[0] = ibook.book1D(
       "EtlCluEnergyZnegD1", "ETL cluster energy (-Z, Single(topo1D)/First(topo2D) Disk);E_{RECO} [MeV]", 100, 0, 10);
   meCluEnergy_[1] =

--- a/Validation/MtdValidation/plugins/EtlLocalRecoValidation.cc
+++ b/Validation/MtdValidation/plugins/EtlLocalRecoValidation.cc
@@ -271,7 +271,7 @@ void EtlLocalRecoValidation::analyze(const edm::Event& iEvent, const edm::EventS
         meTimeRes_->Fill(time_res / m_etlSimHits[idet][detId.rawId()].time);
         meEnergyRes_->Fill(energy_res / m_etlSimHits[idet][detId.rawId()].energy);
 
-        meTPullvsEta_->Fill(fabs(global_point.eta()), time_res / recHit.timeError());
+        meTPullvsEta_->Fill(std::abs(global_point.eta()), time_res / recHit.timeError());
         meTPullvsE_->Fill(m_etlSimHits[idet][detId.rawId()].energy, time_res / recHit.timeError());
       }
     }

--- a/Validation/MtdValidation/plugins/EtlLocalRecoValidation.cc
+++ b/Validation/MtdValidation/plugins/EtlLocalRecoValidation.cc
@@ -487,8 +487,8 @@ void EtlLocalRecoValidation::bookHistograms(DQMStore::IBooker& ibook,
   meHitEta_[2] = ibook.book1D(
       "EtlHitEtaZposD1", "ETL RECO hits #eta (+Z, Single(topo1D)/First(topo2D) Disk);#eta_{RECO}", 100, 1.56, 3.2);
   meHitEta_[3] = ibook.book1D("EtlHitEtaZposD2", "ETL RECO hits #eta (+Z, Second Disk);#eta_{RECO}", 100, 1.56, 3.2);
-  meTimeRes_ = ibook.book1D("EtlTimeRes", "ETL time resolution;T_{RECO}-T_{SIM}/T_{SIM} [ns]", 100, -0.5, 0.5);
-  meEnergyRes_ = ibook.book1D("EtlEnergyRes", "ETL energy resolution;E_{RECO}-E_{SIM}/E_{SIM} [MeV]", 100, -0.5, 0.5);
+  meTimeRes_ = ibook.book1D("EtlTimeRes", "ETL time resolution;T_{RECO}-T_{SIM}/T_{SIM}", 100, -0.5, 0.5);
+  meEnergyRes_ = ibook.book1D("EtlEnergyRes", "ETL energy resolution;E_{RECO}-E_{SIM}/E_{SIM}", 100, -0.5, 0.5);
   meHitTvsE_[0] = ibook.bookProfile(
       "EtlHitTvsEZnegD1",
       "ETL RECO time vs energy (-Z, Single(topo1D)/First(topo2D) Disk);E_{RECO} [MeV];ToA_{RECO} [ns]",
@@ -639,16 +639,10 @@ void EtlLocalRecoValidation::bookHistograms(DQMStore::IBooker& ibook,
                                       3.2,
                                       0.,
                                       100.);
-  meTPullvsE_ = ibook.bookProfile("EtlTPullvsE",
-                                  "ETL time pull vs E;E_{SIM} [MeV];T_{RECO}-T_{SIM}/#sigma_T_{RECO} [ns]",
-                                  20,
-                                  0.,
-                                  2.,
-                                  -0.8,
-                                  0.8,
-                                  "S");
+  meTPullvsE_ = ibook.bookProfile(
+      "EtlTPullvsE", "ETL time pull vs E;E_{SIM} [MeV];T_{RECO}-T_{SIM}/#sigma_{T_{RECO}}", 20, 0., 2., -0.8, 0.8, "S");
   meTPullvsEta_ = ibook.bookProfile("EtlTPullvsEta",
-                                    "ETL time pull vs #eta;|#eta_{RECO}|;T_{RECO}-T_{SIM}/#sigma_T_{RECO} [ns]",
+                                    "ETL time pull vs #eta;|#eta_{RECO}|;T_{RECO}-T_{SIM}/#sigma_{T_{RECO}}",
                                     26,
                                     1.65,
                                     3.0,

--- a/Validation/MtdValidation/plugins/MtdGlobalRecoValidation.cc
+++ b/Validation/MtdValidation/plugins/MtdGlobalRecoValidation.cc
@@ -4,6 +4,7 @@
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "DataFormats/Common/interface/ValueMap.h"
 
 #include "DQMServices/Core/interface/DQMEDAnalyzer.h"
 #include "DQMServices/Core/interface/DQMStore.h"
@@ -21,6 +22,7 @@
 
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "DataFormats/VertexReco/interface/Vertex.h"
+#include "DataFormats/TrackReco/interface/TrackFwd.h"
 
 #include "Geometry/Records/interface/MTDDigiGeometryRecord.h"
 #include "Geometry/Records/interface/MTDTopologyRcd.h"
@@ -49,8 +51,15 @@ private:
   const float trackMinEta_;
   const float trackMaxEta_;
 
+  edm::EDGetTokenT<reco::TrackCollection> GenRecTrackToken_;
   edm::EDGetTokenT<reco::TrackCollection> RecTrackToken_;
   edm::EDGetTokenT<std::vector<reco::Vertex>> RecVertexToken_;
+
+  edm::EDGetTokenT<edm::ValueMap<float>> pathLengthToken_;
+
+  edm::EDGetTokenT<edm::ValueMap<float>> t0SafePidToken_;
+  edm::EDGetTokenT<edm::ValueMap<float>> Sigmat0SafePidToken_;
+  edm::EDGetTokenT<edm::ValueMap<float>> trackMVAQualToken_;
 
   MonitorElement* meBTLTrackRPTime_;
   MonitorElement* meBTLTrackEffEtaTot_;
@@ -59,17 +68,22 @@ private:
   MonitorElement* meBTLTrackEffEtaMtd_;
   MonitorElement* meBTLTrackEffPhiMtd_;
   MonitorElement* meBTLTrackEffPtMtd_;
+  MonitorElement* meBTLTrackPtRes_;
 
-  MonitorElement* meETLTrackRPTime_[4];
-  MonitorElement* meETLTrackNumHits_[4];
+  MonitorElement* meETLTrackRPTime_;
   MonitorElement* meETLTrackEffEtaTot_[2];
   MonitorElement* meETLTrackEffPhiTot_[2];
   MonitorElement* meETLTrackEffPtTot_[2];
   MonitorElement* meETLTrackEffEtaMtd_[2];
   MonitorElement* meETLTrackEffPhiMtd_[2];
   MonitorElement* meETLTrackEffPtMtd_[2];
+  MonitorElement* meETLTrackPtRes_;
 
+  MonitorElement* meTrackt0SafePid_;
+  MonitorElement* meTrackSigmat0SafePid_;
   MonitorElement* meTrackNumHits_;
+  MonitorElement* meTrackMVAQual_;
+  MonitorElement* meTrackPathLenghtvsEta_;
 
   MonitorElement* meVerNumber_;
   MonitorElement* meVerZ_;
@@ -82,8 +96,13 @@ MtdGlobalRecoValidation::MtdGlobalRecoValidation(const edm::ParameterSet& iConfi
       trackMinEnergy_(iConfig.getParameter<double>("trackMinimumEnergy")),
       trackMinEta_(iConfig.getParameter<double>("trackMinimumEta")),
       trackMaxEta_(iConfig.getParameter<double>("trackMaximumEta")) {
+  GenRecTrackToken_ = consumes<reco::TrackCollection>(iConfig.getParameter<edm::InputTag>("inputTagG"));
   RecTrackToken_ = consumes<reco::TrackCollection>(iConfig.getParameter<edm::InputTag>("inputTagT"));
   RecVertexToken_ = consumes<std::vector<reco::Vertex>>(iConfig.getParameter<edm::InputTag>("inputTagV"));
+  pathLengthToken_ = consumes<edm::ValueMap<float>>(iConfig.getParameter<edm::InputTag>("pathLengthSrc"));
+  t0SafePidToken_ = consumes<edm::ValueMap<float>>(iConfig.getParameter<edm::InputTag>("t0SafePID"));
+  Sigmat0SafePidToken_ = consumes<edm::ValueMap<float>>(iConfig.getParameter<edm::InputTag>("sigmat0SafePID"));
+  trackMVAQualToken_ = consumes<edm::ValueMap<float>>(iConfig.getParameter<edm::InputTag>("trackMVAQual"));
 }
 
 MtdGlobalRecoValidation::~MtdGlobalRecoValidation() {}
@@ -107,124 +126,155 @@ void MtdGlobalRecoValidation::analyze(const edm::Event& iEvent, const edm::Event
     topo2Dis = true;
   }
 
+  auto GenRecTrackHandle = makeValid(iEvent.getHandle(GenRecTrackToken_));
   auto RecTrackHandle = makeValid(iEvent.getHandle(RecTrackToken_));
   auto RecVertexHandle = makeValid(iEvent.getHandle(RecVertexToken_));
 
+  const auto& t0Safe = iEvent.get(t0SafePidToken_);
+  const auto& Sigmat0Safe = iEvent.get(Sigmat0SafePidToken_);
+  const auto& mtdQualMVA = iEvent.get(trackMVAQualToken_);
+  const auto& pathLength = iEvent.get(pathLengthToken_);
+
+  unsigned int index = 0;
   // --- Loop over all RECO tracks ---
-  for (const auto& track : *RecTrackHandle) {
-    if (track.pt() < trackMinEnergy_)
-      continue;
+  for (const auto& trackGen : *GenRecTrackHandle) {
+    const reco::TrackRef trackref(iEvent.getHandle(GenRecTrackToken_), index);
+    index++;
 
-    if (fabs(track.eta()) < trackMinEta_) {
-      // --- all BTL tracks (with and without hit in MTD) ---
-      meBTLTrackEffEtaTot_->Fill(track.eta());
-      meBTLTrackEffPhiTot_->Fill(track.phi());
-      meBTLTrackEffPtTot_->Fill(track.pt());
+    unsigned int MTDindex = 0;
+    for (const auto& track : *RecTrackHandle) {
+      const reco::TrackRef mtdTrackref = reco::TrackRef(iEvent.getHandle(RecTrackToken_), MTDindex);
+      MTDindex++;
 
-      bool MTDBtl = false;
-      int numMTDBtlvalidhits = 0;
-      for (const auto hit : track.recHits()) {
-        if (hit->isValid() == false)
-          continue;
-        MTDDetId Hit = hit->geographicalId();
-        if ((Hit.det() == 6) && (Hit.subdetId() == 1) && (Hit.mtdSubDetector() == 1)) {
-          MTDBtl = true;
-          numMTDBtlvalidhits++;
-        }
-      }
-      meTrackNumHits_->Fill(numMTDBtlvalidhits);
+      if (track.pt() < trackMinEnergy_)
+        continue;
 
-      // --- keeping only tracks with last hit in MTD ---
-      if (MTDBtl == true) {
-        meBTLTrackEffEtaMtd_->Fill(track.eta());
-        meBTLTrackEffPhiMtd_->Fill(track.phi());
-        meBTLTrackEffPtMtd_->Fill(track.pt());
-        meBTLTrackRPTime_->Fill(track.t0());
-      }
-    }
-
-    else {
-      // --- all ETL tracks (with and without hit in MTD) ---
-      if ((track.eta() < -trackMinEta_) && (track.eta() > -trackMaxEta_)) {
-        meETLTrackEffEtaTot_[0]->Fill(track.eta());
-        meETLTrackEffPhiTot_[0]->Fill(track.phi());
-        meETLTrackEffPtTot_[0]->Fill(track.pt());
+      if (mtdQualMVA[trackref] == -1) {
+        continue;
       }
 
-      if ((track.eta() > trackMinEta_) && (track.eta() < trackMaxEta_)) {
-        meETLTrackEffEtaTot_[1]->Fill(track.eta());
-        meETLTrackEffPhiTot_[1]->Fill(track.phi());
-        meETLTrackEffPtTot_[1]->Fill(track.pt());
-      }
+      meTrackt0SafePid_->Fill(t0Safe[trackref]);
+      meTrackSigmat0SafePid_->Fill(Sigmat0Safe[trackref]);
+      meTrackMVAQual_->Fill(mtdQualMVA[trackref]);
 
-      bool MTDEtlZnegD1 = false;
-      bool MTDEtlZnegD2 = false;
-      bool MTDEtlZposD1 = false;
-      bool MTDEtlZposD2 = false;
-      int numMTDEtlvalidhits = 0;
-      for (const auto hit : track.recHits()) {
-        if (hit->isValid() == false)
-          continue;
-        MTDDetId Hit = hit->geographicalId();
-        if ((Hit.det() == 6) && (Hit.subdetId() == 1) && (Hit.mtdSubDetector() == 2)) {
-          ETLDetId ETLHit = hit->geographicalId();
+      meTrackPathLenghtvsEta_->Fill(std::fabs(track.eta()), pathLength[mtdTrackref]);
 
-          if (topo2Dis) {
-            if ((ETLHit.zside() == -1) && (ETLHit.nDisc() == 1)) {
-              MTDEtlZnegD1 = true;
-              meETLTrackRPTime_[0]->Fill(track.t0());
-              numMTDEtlvalidhits++;
-            }
-            if ((ETLHit.zside() == -1) && (ETLHit.nDisc() == 2)) {
-              MTDEtlZnegD2 = true;
-              meETLTrackRPTime_[1]->Fill(track.t0());
-              numMTDEtlvalidhits++;
-            }
-            if ((ETLHit.zside() == 1) && (ETLHit.nDisc() == 1)) {
-              MTDEtlZposD1 = true;
-              meETLTrackRPTime_[2]->Fill(track.t0());
-              numMTDEtlvalidhits++;
-            }
-            if ((ETLHit.zside() == 1) && (ETLHit.nDisc() == 2)) {
-              MTDEtlZposD2 = true;
-              meETLTrackRPTime_[3]->Fill(track.t0());
-              numMTDEtlvalidhits++;
-            }
-          }
+      if (fabs(track.eta()) < trackMinEta_) {
+        // --- all BTL tracks (with and without hit in MTD) ---
+        meBTLTrackEffEtaTot_->Fill(track.eta());
+        meBTLTrackEffPhiTot_->Fill(track.phi());
+        meBTLTrackEffPtTot_->Fill(track.pt());
 
-          if (topo1Dis) {
-            if (ETLHit.zside() == -1) {
-              MTDEtlZnegD1 = true;
-              meETLTrackRPTime_[0]->Fill(track.t0());
-              numMTDEtlvalidhits++;
-            }
-            if (ETLHit.zside() == 1) {
-              MTDEtlZposD1 = true;
-              meETLTrackRPTime_[2]->Fill(track.t0());
-              numMTDEtlvalidhits++;
-            }
+        bool MTDBtl = false;
+        int numMTDBtlvalidhits = 0;
+        for (const auto hit : track.recHits()) {
+          if (hit->isValid() == false)
+            continue;
+          MTDDetId Hit = hit->geographicalId();
+          if ((Hit.det() == 6) && (Hit.subdetId() == 1) && (Hit.mtdSubDetector() == 1)) {
+            MTDBtl = true;
+            numMTDBtlvalidhits++;
           }
         }
-      }
-      meTrackNumHits_->Fill(-numMTDEtlvalidhits);
+        meTrackNumHits_->Fill(numMTDBtlvalidhits);
 
-      // --- keeping only tracks with last hit in MTD ---
-      if ((track.eta() < -trackMinEta_) && (track.eta() > -trackMaxEta_)) {
-        if ((MTDEtlZnegD1 == true) || (MTDEtlZnegD2 == true)) {
-          meETLTrackEffEtaMtd_[0]->Fill(track.eta());
-          meETLTrackEffPhiMtd_[0]->Fill(track.phi());
-          meETLTrackEffPtMtd_[0]->Fill(track.pt());
+        // --- keeping only tracks with last hit in MTD ---
+        if (MTDBtl == true) {
+          meBTLTrackEffEtaMtd_->Fill(track.eta());
+          meBTLTrackEffPhiMtd_->Fill(track.phi());
+          meBTLTrackEffPtMtd_->Fill(track.pt());
+          meBTLTrackRPTime_->Fill(track.t0());
+          meBTLTrackPtRes_->Fill((trackGen.pt() - track.pt()) / trackGen.pt());
+        }
+      }  //loop over (geometrical) BTL tracks
+
+      else {
+        // --- all ETL tracks (with and without hit in MTD) ---
+        if ((track.eta() < -trackMinEta_) && (track.eta() > -trackMaxEta_)) {
+          meETLTrackEffEtaTot_[0]->Fill(track.eta());
+          meETLTrackEffPhiTot_[0]->Fill(track.phi());
+          meETLTrackEffPtTot_[0]->Fill(track.pt());
+        }
+
+        if ((track.eta() > trackMinEta_) && (track.eta() < trackMaxEta_)) {
+          meETLTrackEffEtaTot_[1]->Fill(track.eta());
+          meETLTrackEffPhiTot_[1]->Fill(track.phi());
+          meETLTrackEffPtTot_[1]->Fill(track.pt());
+        }
+
+        bool MTDEtlZnegD1 = false;
+        bool MTDEtlZnegD2 = false;
+        bool MTDEtlZposD1 = false;
+        bool MTDEtlZposD2 = false;
+        int numMTDEtlvalidhits = 0;
+        for (const auto hit : track.recHits()) {
+          if (hit->isValid() == false)
+            continue;
+          MTDDetId Hit = hit->geographicalId();
+          if ((Hit.det() == 6) && (Hit.subdetId() == 1) && (Hit.mtdSubDetector() == 2)) {
+            ETLDetId ETLHit = hit->geographicalId();
+
+            if (topo2Dis) {
+              if ((ETLHit.zside() == -1) && (ETLHit.nDisc() == 1)) {
+                MTDEtlZnegD1 = true;
+                meETLTrackRPTime_->Fill(track.t0());
+                meETLTrackPtRes_->Fill((trackGen.pt() - track.pt()) / trackGen.pt());
+                numMTDEtlvalidhits++;
+              }
+              if ((ETLHit.zside() == -1) && (ETLHit.nDisc() == 2)) {
+                MTDEtlZnegD2 = true;
+                meETLTrackRPTime_->Fill(track.t0());
+                meETLTrackPtRes_->Fill((trackGen.pt() - track.pt()) / trackGen.pt());
+                numMTDEtlvalidhits++;
+              }
+              if ((ETLHit.zside() == 1) && (ETLHit.nDisc() == 1)) {
+                MTDEtlZposD1 = true;
+                meETLTrackRPTime_->Fill(track.t0());
+                meETLTrackPtRes_->Fill((trackGen.pt() - track.pt()) / trackGen.pt());
+                numMTDEtlvalidhits++;
+              }
+              if ((ETLHit.zside() == 1) && (ETLHit.nDisc() == 2)) {
+                MTDEtlZposD2 = true;
+                meETLTrackRPTime_->Fill(track.t0());
+                meETLTrackPtRes_->Fill((trackGen.pt() - track.pt()) / trackGen.pt());
+                numMTDEtlvalidhits++;
+              }
+            }
+
+            if (topo1Dis) {
+              if (ETLHit.zside() == -1) {
+                MTDEtlZnegD1 = true;
+                meETLTrackRPTime_->Fill(track.t0());
+                numMTDEtlvalidhits++;
+              }
+              if (ETLHit.zside() == 1) {
+                MTDEtlZposD1 = true;
+                meETLTrackRPTime_->Fill(track.t0());
+                numMTDEtlvalidhits++;
+              }
+            }
+          }
+        }
+        meTrackNumHits_->Fill(-numMTDEtlvalidhits);
+
+        // --- keeping only tracks with last hit in MTD ---
+        if ((track.eta() < -trackMinEta_) && (track.eta() > -trackMaxEta_)) {
+          if ((MTDEtlZnegD1 == true) || (MTDEtlZnegD2 == true)) {
+            meETLTrackEffEtaMtd_[0]->Fill(track.eta());
+            meETLTrackEffPhiMtd_[0]->Fill(track.phi());
+            meETLTrackEffPtMtd_[0]->Fill(track.pt());
+          }
+        }
+        if ((track.eta() > trackMinEta_) && (track.eta() < trackMaxEta_)) {
+          if ((MTDEtlZposD1 == true) || (MTDEtlZposD2 == true)) {
+            meETLTrackEffEtaMtd_[1]->Fill(track.eta());
+            meETLTrackEffPhiMtd_[1]->Fill(track.phi());
+            meETLTrackEffPtMtd_[1]->Fill(track.pt());
+          }
         }
       }
-      if ((track.eta() > trackMinEta_) && (track.eta() < trackMaxEta_)) {
-        if ((MTDEtlZposD1 == true) || (MTDEtlZposD2 == true)) {
-          meETLTrackEffEtaMtd_[1]->Fill(track.eta());
-          meETLTrackEffPhiMtd_[1]->Fill(track.phi());
-          meETLTrackEffPtMtd_[1]->Fill(track.pt());
-        }
-      }
-    }
-  }  //RECO tracks loop
+    }  //RECO MTD tracks
+  }    //RECO GEN tracks loop
 
   // --- Loop over the RECO vertices ---
   int nv = 0;
@@ -247,6 +297,9 @@ void MtdGlobalRecoValidation::bookHistograms(DQMStore::IBooker& ibook,
 
   // histogram booking
   meBTLTrackRPTime_ = ibook.book1D("TrackBTLRPTime", "Track t0 with respect to R.P.;t0 [ns]", 100, -1, 3);
+  meTrackt0SafePid_ = ibook.book1D("Trackt0SafePID", "Track t0 Safe as stored in TofPid;t0 [ns]", 100, -1, 1);
+  meTrackSigmat0SafePid_ =
+      ibook.book1D("TrackSigmat0SafePID", "Sigmat0 Safe as stored in TofPid; #sigma_{t0} [ns]", 100, -0.02, 0.06);
   meBTLTrackEffEtaTot_ = ibook.book1D("TrackBTLEffEtaTot", "Track efficiency vs eta (Tot);#eta_{RECO}", 100, -1.6, 1.6);
   meBTLTrackEffPhiTot_ =
       ibook.book1D("TrackBTLEffPhiTot", "Track efficiency vs phi (Tot);#phi_{RECO} [rad]", 100, -3.2, 3.2);
@@ -255,14 +308,9 @@ void MtdGlobalRecoValidation::bookHistograms(DQMStore::IBooker& ibook,
   meBTLTrackEffPhiMtd_ =
       ibook.book1D("TrackBTLEffPhiMtd", "Track efficiency vs phi (Mtd);#phi_{RECO} [rad]", 100, -3.2, 3.2);
   meBTLTrackEffPtMtd_ = ibook.book1D("TrackBTLEffPtMtd", "Track efficiency vs pt (Mtd);pt_{RECO} [GeV]", 50, 0, 10);
-  meETLTrackRPTime_[0] =
-      ibook.book1D("TrackETLRPTimeZnegD1", "Track t0 with respect to R.P. (-Z, First Disk);t0 [ns]", 100, -1, 3);
-  meETLTrackRPTime_[1] =
-      ibook.book1D("TrackETLRPTimeZnegD2", "Track t0 with respect to R.P. (-Z, Second Disk);t0 [ns]", 100, -1, 3);
-  meETLTrackRPTime_[2] =
-      ibook.book1D("TrackETLRPTimeZposD1", "Track t0 with respect to R.P. (+Z, First Disk);t0 [ns]", 100, -1, 3);
-  meETLTrackRPTime_[3] =
-      ibook.book1D("TrackETLRPTimeZposD2", "Track t0 with respect to R.P. (+Z, Second Disk);t0 [ns]", 100, -1, 3);
+  meBTLTrackPtRes_ =
+      ibook.book1D("TrackBTLPtRes", "Track pT resolution  ;pT_{Gentrack}-pT_{MTDtrack}/pT_{Gentrack} ", 100, -0.1, 0.1);
+  meETLTrackRPTime_ = ibook.book1D("TrackETLRPTime", "Track t0 with respect to R.P.;t0 [ns]", 100, -1, 3);
   meETLTrackEffEtaTot_[0] =
       ibook.book1D("TrackETLEffEtaTotZneg", "Track efficiency vs eta (Tot) (-Z);#eta_{RECO}", 100, -3.2, -1.4);
   meETLTrackEffEtaTot_[1] =
@@ -287,7 +335,12 @@ void MtdGlobalRecoValidation::bookHistograms(DQMStore::IBooker& ibook,
       ibook.book1D("TrackETLEffPtMtdZneg", "Track efficiency vs pt (Mtd) (-Z);pt_{RECO} [GeV]", 50, 0, 10);
   meETLTrackEffPtMtd_[1] =
       ibook.book1D("TrackETLEffPtMtdZpos", "Track efficiency vs pt (Mtd) (+Z);pt_{RECO} [GeV]", 50, 0, 10);
+  meETLTrackPtRes_ =
+      ibook.book1D("TrackETLPtRes", "Track pT resolution;pT_{Gentrack}-pT_{MTDtrack}/pT_{Gentrack} ", 100, -0.1, 0.1);
   meTrackNumHits_ = ibook.book1D("TrackNumHits", "Number of valid MTD hits per track ; Number of hits", 10, -5, 5);
+  meTrackMVAQual_ = ibook.book1D("TrackMVAQual", "Track MVA Quality as stored in Value Map ; MVAQual", 100, 0, 1);
+  meTrackPathLenghtvsEta_ = ibook.bookProfile(
+      "TrackPathLenghtvsEta", "MTD Track pathlength vs MTD track Eta;|#eta|;Pathlength", 100, 0, 3.2, 100.0, 400.0, "S");
   meVerZ_ = ibook.book1D("VerZ", "RECO Vertex Z;Z_{RECO} [cm]", 180, -18, 18);
   meVerTime_ = ibook.book1D("VerTime", "RECO Vertex Time;t0 [ns]", 100, -1, 1);
   meVerNumber_ = ibook.book1D("VerNumber", "RECO Vertex Number: Number of vertices", 100, 0, 500);
@@ -299,8 +352,15 @@ void MtdGlobalRecoValidation::fillDescriptions(edm::ConfigurationDescriptions& d
   edm::ParameterSetDescription desc;
 
   desc.add<std::string>("folder", "MTD/GlobalReco");
+  desc.add<edm::InputTag>("inputTagG", edm::InputTag("generalTracks", ""));
   desc.add<edm::InputTag>("inputTagT", edm::InputTag("trackExtenderWithMTD", ""));
   desc.add<edm::InputTag>("inputTagV", edm::InputTag("offlinePrimaryVertices4D", ""));
+  desc.add<edm::InputTag>("t0Src", edm::InputTag("trackExtenderWithMTD:generalTrackt0", ""));
+  desc.add<edm::InputTag>("sigmat0Src", edm::InputTag("trackExtenderWithMTD:generalTracksigmat0", ""));
+  desc.add<edm::InputTag>("pathLengthSrc", edm::InputTag("trackExtenderWithMTD", "pathLength"));
+  desc.add<edm::InputTag>("t0SafePID", edm::InputTag("tofPID:t0safe", ""));
+  desc.add<edm::InputTag>("sigmat0SafePID", edm::InputTag("tofPID:sigmat0safe", ""));
+  desc.add<edm::InputTag>("trackMVAQual", edm::InputTag("mtdTrackQualityMVA:mtdQualMVA", ""));
   desc.add<double>("trackMinimumEnergy", 1.0);  // [GeV]
   desc.add<double>("trackMinimumEta", 1.5);
   desc.add<double>("trackMaximumEta", 3.2);

--- a/Validation/MtdValidation/plugins/MtdTracksHarvester.cc
+++ b/Validation/MtdValidation/plugins/MtdTracksHarvester.cc
@@ -10,10 +10,10 @@
 
 #include "DataFormats/ForwardDetId/interface/ETLDetId.h"
 
-class MtdGlobalRecoHarvester : public DQMEDHarvester {
+class MtdTracksHarvester : public DQMEDHarvester {
 public:
-  explicit MtdGlobalRecoHarvester(const edm::ParameterSet& iConfig);
-  ~MtdGlobalRecoHarvester() override;
+  explicit MtdTracksHarvester(const edm::ParameterSet& iConfig);
+  ~MtdTracksHarvester() override;
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
@@ -33,13 +33,13 @@ private:
 };
 
 // ------------ constructor and destructor --------------
-MtdGlobalRecoHarvester::MtdGlobalRecoHarvester(const edm::ParameterSet& iConfig)
+MtdTracksHarvester::MtdTracksHarvester(const edm::ParameterSet& iConfig)
     : folder_(iConfig.getParameter<std::string>("folder")) {}
 
-MtdGlobalRecoHarvester::~MtdGlobalRecoHarvester() {}
+MtdTracksHarvester::~MtdTracksHarvester() {}
 
 // ------------ endjob tasks ----------------------------
-void MtdGlobalRecoHarvester::dqmEndJob(DQMStore::IBooker& ibook, DQMStore::IGetter& igetter) {
+void MtdTracksHarvester::dqmEndJob(DQMStore::IBooker& ibook, DQMStore::IGetter& igetter) {
   // --- Get the monitoring histograms
   MonitorElement* meBTLTrackEffEtaTot = igetter.get(folder_ + "TrackBTLEffEtaTot");
   MonitorElement* meBTLTrackEffPhiTot = igetter.get(folder_ + "TrackBTLEffPhiTot");
@@ -65,7 +65,7 @@ void MtdGlobalRecoHarvester::dqmEndJob(DQMStore::IBooker& ibook, DQMStore::IGett
       !meETLTrackEffPtTotZneg || !meETLTrackEffEtaMtdZneg || !meETLTrackEffPhiMtdZneg || !meETLTrackEffPtMtdZneg ||
       !meETLTrackEffEtaTotZpos || !meETLTrackEffPhiTotZpos || !meETLTrackEffPtTotZpos || !meETLTrackEffEtaMtdZpos ||
       !meETLTrackEffPhiMtdZpos || !meETLTrackEffPtMtdZpos) {
-    edm::LogError("MtdGlobalRecoHarvester") << "Monitoring histograms not found!" << std::endl;
+    edm::LogError("MtdTracksHarvester") << "Monitoring histograms not found!" << std::endl;
     return;
   }
 
@@ -250,12 +250,12 @@ void MtdGlobalRecoHarvester::dqmEndJob(DQMStore::IBooker& ibook, DQMStore::IGett
 }
 
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ----------
-void MtdGlobalRecoHarvester::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+void MtdTracksHarvester::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
 
-  desc.add<std::string>("folder", "MTD/GlobalReco/");
+  desc.add<std::string>("folder", "MTD/Tracks/");
 
-  descriptions.add("MtdGlobalRecoPostProcessor", desc);
+  descriptions.add("MtdTracksPostProcessor", desc);
 }
 
-DEFINE_FWK_MODULE(MtdGlobalRecoHarvester);
+DEFINE_FWK_MODULE(MtdTracksHarvester);

--- a/Validation/MtdValidation/plugins/MtdTracksValidation.cc
+++ b/Validation/MtdValidation/plugins/MtdTracksValidation.cc
@@ -94,10 +94,6 @@ private:
   MonitorElement* meTrackMVAQual_;
   MonitorElement* meTrackPathLenghtvsEta_;
 
-  MonitorElement* meFailMVAEta_;
-  MonitorElement* meFailMVAPhi_;
-  MonitorElement* meFailMVAPt_;
-
   MonitorElement* meVerNumber_;
   MonitorElement* meVerZ_;
   MonitorElement* meVerTime_;
@@ -173,12 +169,6 @@ void MtdTracksValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
 
     if (track.pt() < trackMinEnergy_)
       continue;
-
-    if (mtdQualMVA[trackref] == -1) {
-      meFailMVAEta_->Fill(std::fabs(trackGen.eta()));
-      meFailMVAPhi_->Fill(trackGen.phi());
-      meFailMVAPt_->Fill(trackGen.pt());
-    }
 
     meTracktmtd_->Fill(tMtd[trackref]);
     meTrackSigmatmtd_->Fill(SigmatMtd[trackref]);
@@ -375,9 +365,6 @@ void MtdTracksValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
   meTrackMVAQual_ = ibook.book1D("TrackMVAQual", "Track MVA Quality as stored in Value Map ; MVAQual", 100, 0, 1);
   meTrackPathLenghtvsEta_ = ibook.bookProfile(
       "TrackPathLenghtvsEta", "MTD Track pathlength vs MTD track Eta;|#eta|;Pathlength", 100, 0, 3.2, 100.0, 400.0, "S");
-  meFailMVAEta_ = ibook.book1D("TrackFailingMVAEta", "Failing MVA track #eta;|#eta| ", 100, 0, 3.2);
-  meFailMVAPhi_ = ibook.book1D("TrackFailingMVAPhi", "Failing MVA track #phi;#phi [rad] ", 100, -3.2, 3.2);
-  meFailMVAPt_ = ibook.book1D("TrackFailingMVAPt", "Failing MVA track pT;pT [GeV]", 50, 0, 10);
   meVerZ_ = ibook.book1D("VerZ", "RECO Vertex Z;Z_{RECO} [cm]", 180, -18, 18);
   meVerTime_ = ibook.book1D("VerTime", "RECO Vertex Time;t0 [ns]", 100, -1, 1);
   meVerNumber_ = ibook.book1D("VerNumber", "RECO Vertex Number: Number of vertices", 100, 0, 500);

--- a/Validation/MtdValidation/plugins/MtdTracksValidation.cc
+++ b/Validation/MtdValidation/plugins/MtdTracksValidation.cc
@@ -32,10 +32,10 @@
 #include "Geometry/MTDGeometryBuilder/interface/ProxyMTDTopology.h"
 #include "Geometry/MTDGeometryBuilder/interface/RectangularMTDTopology.h"
 
-class MtdGlobalRecoValidation : public DQMEDAnalyzer {
+class MtdTracksValidation : public DQMEDAnalyzer {
 public:
-  explicit MtdGlobalRecoValidation(const edm::ParameterSet&);
-  ~MtdGlobalRecoValidation() override;
+  explicit MtdTracksValidation(const edm::ParameterSet&);
+  ~MtdTracksValidation() override;
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
@@ -55,10 +55,11 @@ private:
   edm::EDGetTokenT<reco::TrackCollection> RecTrackToken_;
   edm::EDGetTokenT<std::vector<reco::Vertex>> RecVertexToken_;
 
+  edm::EDGetTokenT<edm::ValueMap<int>> trackAssocToken_;
   edm::EDGetTokenT<edm::ValueMap<float>> pathLengthToken_;
 
-  edm::EDGetTokenT<edm::ValueMap<float>> t0SafePidToken_;
-  edm::EDGetTokenT<edm::ValueMap<float>> Sigmat0SafePidToken_;
+  edm::EDGetTokenT<edm::ValueMap<float>> t0SafePidToken_; 
+  edm::EDGetTokenT<edm::ValueMap<float>> Sigmat0SafePidToken_; 
   edm::EDGetTokenT<edm::ValueMap<float>> trackMVAQualToken_;
 
   MonitorElement* meBTLTrackRPTime_;
@@ -85,30 +86,35 @@ private:
   MonitorElement* meTrackMVAQual_;
   MonitorElement* meTrackPathLenghtvsEta_;
 
+  MonitorElement* meFailMVAEta_;
+  MonitorElement* meFailMVAPhi_;
+  MonitorElement* meFailMVAPt_;
+
   MonitorElement* meVerNumber_;
   MonitorElement* meVerZ_;
   MonitorElement* meVerTime_;
 };
 
 // ------------ constructor and destructor --------------
-MtdGlobalRecoValidation::MtdGlobalRecoValidation(const edm::ParameterSet& iConfig)
+MtdTracksValidation::MtdTracksValidation(const edm::ParameterSet& iConfig)
     : folder_(iConfig.getParameter<std::string>("folder")),
-      trackMinEnergy_(iConfig.getParameter<double>("trackMinimumEnergy")),
+      trackMinEnergy_(iConfig.getParameter<double>("trackMinimumPt")),
       trackMinEta_(iConfig.getParameter<double>("trackMinimumEta")),
       trackMaxEta_(iConfig.getParameter<double>("trackMaximumEta")) {
   GenRecTrackToken_ = consumes<reco::TrackCollection>(iConfig.getParameter<edm::InputTag>("inputTagG"));
   RecTrackToken_ = consumes<reco::TrackCollection>(iConfig.getParameter<edm::InputTag>("inputTagT"));
   RecVertexToken_ = consumes<std::vector<reco::Vertex>>(iConfig.getParameter<edm::InputTag>("inputTagV"));
+  trackAssocToken_ = consumes<edm::ValueMap<int>>(iConfig.getParameter<edm::InputTag>("trackAssocSrc"));
   pathLengthToken_ = consumes<edm::ValueMap<float>>(iConfig.getParameter<edm::InputTag>("pathLengthSrc"));
   t0SafePidToken_ = consumes<edm::ValueMap<float>>(iConfig.getParameter<edm::InputTag>("t0SafePID"));
   Sigmat0SafePidToken_ = consumes<edm::ValueMap<float>>(iConfig.getParameter<edm::InputTag>("sigmat0SafePID"));
   trackMVAQualToken_ = consumes<edm::ValueMap<float>>(iConfig.getParameter<edm::InputTag>("trackMVAQual"));
 }
 
-MtdGlobalRecoValidation::~MtdGlobalRecoValidation() {}
+MtdTracksValidation::~MtdTracksValidation() {}
 
 // ------------ method called for each event  ------------
-void MtdGlobalRecoValidation::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
+void MtdTracksValidation::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
   using namespace edm;
   using namespace geant_units::operators;
   using namespace std;
@@ -127,154 +133,162 @@ void MtdGlobalRecoValidation::analyze(const edm::Event& iEvent, const edm::Event
   }
 
   auto GenRecTrackHandle = makeValid(iEvent.getHandle(GenRecTrackToken_));
-  auto RecTrackHandle = makeValid(iEvent.getHandle(RecTrackToken_));
   auto RecVertexHandle = makeValid(iEvent.getHandle(RecVertexToken_));
 
   const auto& t0Safe = iEvent.get(t0SafePidToken_);
   const auto& Sigmat0Safe = iEvent.get(Sigmat0SafePidToken_);
   const auto& mtdQualMVA = iEvent.get(trackMVAQualToken_);
+  const auto& trackAssoc = iEvent.get(trackAssocToken_);
   const auto& pathLength = iEvent.get(pathLengthToken_);
 
   unsigned int index = 0;
   // --- Loop over all RECO tracks ---
   for (const auto& trackGen : *GenRecTrackHandle) {
+
     const reco::TrackRef trackref(iEvent.getHandle(GenRecTrackToken_), index);
     index++;
 
-    unsigned int MTDindex = 0;
-    for (const auto& track : *RecTrackHandle) {
-      const reco::TrackRef mtdTrackref = reco::TrackRef(iEvent.getHandle(RecTrackToken_), MTDindex);
-      MTDindex++;
+    if (trackAssoc[trackref] == -1) {
+      LogWarning("mtdTracks") << "Extended track not associated";
+      continue;
+    }
 
-      if (track.pt() < trackMinEnergy_)
-        continue;
+    const reco::TrackRef mtdTrackref = reco::TrackRef(iEvent.getHandle(RecTrackToken_), trackAssoc[trackref]);
+    const reco::Track track = *mtdTrackref;
 
-      if (mtdQualMVA[trackref] == -1) {
-        continue;
+    if (track.pt() < trackMinEnergy_)
+      continue;
+
+    if (mtdQualMVA[trackref] == -1) {
+      meFailMVAEta_->Fill(std::fabs(trackGen.eta()));
+      meFailMVAPhi_->Fill(trackGen.phi());
+      meFailMVAPt_->Fill(trackGen.pt());
+    }
+
+    meTrackt0SafePid_->Fill(t0Safe[trackref]);
+    meTrackSigmat0SafePid_->Fill(Sigmat0Safe[trackref]);
+    meTrackMVAQual_->Fill(mtdQualMVA[trackref]);
+
+    meTrackPathLenghtvsEta_->Fill(std::fabs(track.eta()), pathLength[mtdTrackref]);
+
+    if (fabs(track.eta()) < trackMinEta_) {
+      // --- all BTL tracks (with and without hit in MTD) ---
+      meBTLTrackEffEtaTot_->Fill(track.eta());
+      meBTLTrackEffPhiTot_->Fill(track.phi());
+      meBTLTrackEffPtTot_->Fill(track.pt());
+
+      bool MTDBtl = false;
+      int numMTDBtlvalidhits = 0;
+      for (const auto hit : track.recHits()) {
+        if (hit->isValid() == false)
+          continue;
+        MTDDetId Hit = hit->geographicalId();
+        if ((Hit.det() == 6) && (Hit.subdetId() == 1) && (Hit.mtdSubDetector() == 1)) {
+          MTDBtl = true;
+          numMTDBtlvalidhits++;
+        }
+      }
+      meTrackNumHits_->Fill(numMTDBtlvalidhits);
+
+      // --- keeping only tracks with last hit in MTD ---
+      if (MTDBtl == true) {
+
+        meBTLTrackEffEtaMtd_->Fill(track.eta());
+        meBTLTrackEffPhiMtd_->Fill(track.phi());
+        meBTLTrackEffPtMtd_->Fill(track.pt());
+        meBTLTrackRPTime_->Fill(track.t0());
+        meBTLTrackPtRes_->Fill((trackGen.pt() - track.pt())/trackGen.pt());
+      } 
+    } //loop over (geometrical) BTL tracks 
+
+    else {
+      // --- all ETL tracks (with and without hit in MTD) ---
+      if ((track.eta() < -trackMinEta_) && (track.eta() > -trackMaxEta_)) {
+        meETLTrackEffEtaTot_[0]->Fill(track.eta());
+        meETLTrackEffPhiTot_[0]->Fill(track.phi());
+        meETLTrackEffPtTot_[0]->Fill(track.pt());
       }
 
-      meTrackt0SafePid_->Fill(t0Safe[trackref]);
-      meTrackSigmat0SafePid_->Fill(Sigmat0Safe[trackref]);
-      meTrackMVAQual_->Fill(mtdQualMVA[trackref]);
+      if ((track.eta() > trackMinEta_) && (track.eta() < trackMaxEta_)) {
+        meETLTrackEffEtaTot_[1]->Fill(track.eta());
+        meETLTrackEffPhiTot_[1]->Fill(track.phi());
+        meETLTrackEffPtTot_[1]->Fill(track.pt());
+      }
 
-      meTrackPathLenghtvsEta_->Fill(std::fabs(track.eta()), pathLength[mtdTrackref]);
+      bool MTDEtlZnegD1 = false;
+      bool MTDEtlZnegD2 = false;
+      bool MTDEtlZposD1 = false;
+      bool MTDEtlZposD2 = false;
+      int numMTDEtlvalidhits = 0;
+      for (const auto hit : track.recHits()) {
+        if (hit->isValid() == false)
+          continue;
+        MTDDetId Hit = hit->geographicalId();
+        if ((Hit.det() == 6) && (Hit.subdetId() == 1) && (Hit.mtdSubDetector() == 2)) {
+          ETLDetId ETLHit = hit->geographicalId();
 
-      if (fabs(track.eta()) < trackMinEta_) {
-        // --- all BTL tracks (with and without hit in MTD) ---
-        meBTLTrackEffEtaTot_->Fill(track.eta());
-        meBTLTrackEffPhiTot_->Fill(track.phi());
-        meBTLTrackEffPtTot_->Fill(track.pt());
-
-        bool MTDBtl = false;
-        int numMTDBtlvalidhits = 0;
-        for (const auto hit : track.recHits()) {
-          if (hit->isValid() == false)
-            continue;
-          MTDDetId Hit = hit->geographicalId();
-          if ((Hit.det() == 6) && (Hit.subdetId() == 1) && (Hit.mtdSubDetector() == 1)) {
-            MTDBtl = true;
-            numMTDBtlvalidhits++;
-          }
-        }
-        meTrackNumHits_->Fill(numMTDBtlvalidhits);
-
-        // --- keeping only tracks with last hit in MTD ---
-        if (MTDBtl == true) {
-          meBTLTrackEffEtaMtd_->Fill(track.eta());
-          meBTLTrackEffPhiMtd_->Fill(track.phi());
-          meBTLTrackEffPtMtd_->Fill(track.pt());
-          meBTLTrackRPTime_->Fill(track.t0());
-          meBTLTrackPtRes_->Fill((trackGen.pt() - track.pt()) / trackGen.pt());
-        }
-      }  //loop over (geometrical) BTL tracks
-
-      else {
-        // --- all ETL tracks (with and without hit in MTD) ---
-        if ((track.eta() < -trackMinEta_) && (track.eta() > -trackMaxEta_)) {
-          meETLTrackEffEtaTot_[0]->Fill(track.eta());
-          meETLTrackEffPhiTot_[0]->Fill(track.phi());
-          meETLTrackEffPtTot_[0]->Fill(track.pt());
-        }
-
-        if ((track.eta() > trackMinEta_) && (track.eta() < trackMaxEta_)) {
-          meETLTrackEffEtaTot_[1]->Fill(track.eta());
-          meETLTrackEffPhiTot_[1]->Fill(track.phi());
-          meETLTrackEffPtTot_[1]->Fill(track.pt());
-        }
-
-        bool MTDEtlZnegD1 = false;
-        bool MTDEtlZnegD2 = false;
-        bool MTDEtlZposD1 = false;
-        bool MTDEtlZposD2 = false;
-        int numMTDEtlvalidhits = 0;
-        for (const auto hit : track.recHits()) {
-          if (hit->isValid() == false)
-            continue;
-          MTDDetId Hit = hit->geographicalId();
-          if ((Hit.det() == 6) && (Hit.subdetId() == 1) && (Hit.mtdSubDetector() == 2)) {
-            ETLDetId ETLHit = hit->geographicalId();
-
-            if (topo2Dis) {
-              if ((ETLHit.zside() == -1) && (ETLHit.nDisc() == 1)) {
-                MTDEtlZnegD1 = true;
-                meETLTrackRPTime_->Fill(track.t0());
-                meETLTrackPtRes_->Fill((trackGen.pt() - track.pt()) / trackGen.pt());
-                numMTDEtlvalidhits++;
-              }
-              if ((ETLHit.zside() == -1) && (ETLHit.nDisc() == 2)) {
-                MTDEtlZnegD2 = true;
-                meETLTrackRPTime_->Fill(track.t0());
-                meETLTrackPtRes_->Fill((trackGen.pt() - track.pt()) / trackGen.pt());
-                numMTDEtlvalidhits++;
-              }
-              if ((ETLHit.zside() == 1) && (ETLHit.nDisc() == 1)) {
-                MTDEtlZposD1 = true;
-                meETLTrackRPTime_->Fill(track.t0());
-                meETLTrackPtRes_->Fill((trackGen.pt() - track.pt()) / trackGen.pt());
-                numMTDEtlvalidhits++;
-              }
-              if ((ETLHit.zside() == 1) && (ETLHit.nDisc() == 2)) {
-                MTDEtlZposD2 = true;
-                meETLTrackRPTime_->Fill(track.t0());
-                meETLTrackPtRes_->Fill((trackGen.pt() - track.pt()) / trackGen.pt());
-                numMTDEtlvalidhits++;
-              }
+          if (topo2Dis) {
+            if ((ETLHit.zside() == -1) && (ETLHit.nDisc() == 1)) {
+              MTDEtlZnegD1 = true;
+              meETLTrackRPTime_->Fill(track.t0());
+              meETLTrackPtRes_->Fill((trackGen.pt() - track.pt())/trackGen.pt());
+              numMTDEtlvalidhits++;
             }
-
-            if (topo1Dis) {
-              if (ETLHit.zside() == -1) {
-                MTDEtlZnegD1 = true;
-                meETLTrackRPTime_->Fill(track.t0());
-                numMTDEtlvalidhits++;
-              }
-              if (ETLHit.zside() == 1) {
-                MTDEtlZposD1 = true;
-                meETLTrackRPTime_->Fill(track.t0());
-                numMTDEtlvalidhits++;
-              }
+            if ((ETLHit.zside() == -1) && (ETLHit.nDisc() == 2)) {
+              MTDEtlZnegD2 = true;
+              meETLTrackRPTime_->Fill(track.t0());
+              meETLTrackPtRes_->Fill((trackGen.pt() - track.pt())/trackGen.pt());
+              numMTDEtlvalidhits++;
+            }
+            if ((ETLHit.zside() == 1) && (ETLHit.nDisc() == 1)) {
+              MTDEtlZposD1 = true;
+              meETLTrackRPTime_->Fill(track.t0());
+              meETLTrackPtRes_->Fill((trackGen.pt() - track.pt())/trackGen.pt());
+              numMTDEtlvalidhits++;
+            }
+            if ((ETLHit.zside() == 1) && (ETLHit.nDisc() == 2)) {
+              MTDEtlZposD2 = true;
+              meETLTrackRPTime_->Fill(track.t0());
+              meETLTrackPtRes_->Fill((trackGen.pt() - track.pt())/trackGen.pt());
+              numMTDEtlvalidhits++;
             }
           }
-        }
-        meTrackNumHits_->Fill(-numMTDEtlvalidhits);
 
-        // --- keeping only tracks with last hit in MTD ---
-        if ((track.eta() < -trackMinEta_) && (track.eta() > -trackMaxEta_)) {
-          if ((MTDEtlZnegD1 == true) || (MTDEtlZnegD2 == true)) {
-            meETLTrackEffEtaMtd_[0]->Fill(track.eta());
-            meETLTrackEffPhiMtd_[0]->Fill(track.phi());
-            meETLTrackEffPtMtd_[0]->Fill(track.pt());
-          }
-        }
-        if ((track.eta() > trackMinEta_) && (track.eta() < trackMaxEta_)) {
-          if ((MTDEtlZposD1 == true) || (MTDEtlZposD2 == true)) {
-            meETLTrackEffEtaMtd_[1]->Fill(track.eta());
-            meETLTrackEffPhiMtd_[1]->Fill(track.phi());
-            meETLTrackEffPtMtd_[1]->Fill(track.pt());
+          if (topo1Dis) {
+            if (ETLHit.zside() == -1) {
+              MTDEtlZnegD1 = true;
+              meETLTrackRPTime_->Fill(track.t0());
+              numMTDEtlvalidhits++;
+            }
+            if (ETLHit.zside() == 1) {
+              MTDEtlZposD1 = true;
+              meETLTrackRPTime_->Fill(track.t0());
+              numMTDEtlvalidhits++;
+            }
           }
         }
       }
-    }  //RECO MTD tracks
-  }    //RECO GEN tracks loop
+      meTrackNumHits_->Fill(-numMTDEtlvalidhits);
+
+      // --- keeping only tracks with last hit in MTD ---
+      if ((track.eta() < -trackMinEta_) && (track.eta() > -trackMaxEta_)) {
+        if ((MTDEtlZnegD1 == true) || (MTDEtlZnegD2 == true)) {
+
+          meETLTrackEffEtaMtd_[0]->Fill(track.eta());
+          meETLTrackEffPhiMtd_[0]->Fill(track.phi());
+          meETLTrackEffPtMtd_[0]->Fill(track.pt());
+        }
+      }
+      if ((track.eta() > trackMinEta_) && (track.eta() < trackMaxEta_)) {
+
+        if ((MTDEtlZposD1 == true) || (MTDEtlZposD2 == true)) {
+          meETLTrackEffEtaMtd_[1]->Fill(track.eta());
+          meETLTrackEffPhiMtd_[1]->Fill(track.phi());
+          meETLTrackEffPtMtd_[1]->Fill(track.pt());
+        }
+      }
+    }
+  }  //RECO tracks loop
 
   // --- Loop over the RECO vertices ---
   int nv = 0;
@@ -290,7 +304,7 @@ void MtdGlobalRecoValidation::analyze(const edm::Event& iEvent, const edm::Event
 }
 
 // ------------ method for histogram booking ------------
-void MtdGlobalRecoValidation::bookHistograms(DQMStore::IBooker& ibook,
+void MtdTracksValidation::bookHistograms(DQMStore::IBooker& ibook,
                                              edm::Run const& run,
                                              edm::EventSetup const& iSetup) {
   ibook.setCurrentFolder(folder_);
@@ -298,8 +312,7 @@ void MtdGlobalRecoValidation::bookHistograms(DQMStore::IBooker& ibook,
   // histogram booking
   meBTLTrackRPTime_ = ibook.book1D("TrackBTLRPTime", "Track t0 with respect to R.P.;t0 [ns]", 100, -1, 3);
   meTrackt0SafePid_ = ibook.book1D("Trackt0SafePID", "Track t0 Safe as stored in TofPid;t0 [ns]", 100, -1, 1);
-  meTrackSigmat0SafePid_ =
-      ibook.book1D("TrackSigmat0SafePID", "Sigmat0 Safe as stored in TofPid; #sigma_{t0} [ns]", 100, -0.02, 0.06);
+  meTrackSigmat0SafePid_ = ibook.book1D("TrackSigmat0SafePID", "Sigmat0 Safe as stored in TofPid; #sigma_{t0} [ns]", 100, -0.02, 0.06);
   meBTLTrackEffEtaTot_ = ibook.book1D("TrackBTLEffEtaTot", "Track efficiency vs eta (Tot);#eta_{RECO}", 100, -1.6, 1.6);
   meBTLTrackEffPhiTot_ =
       ibook.book1D("TrackBTLEffPhiTot", "Track efficiency vs phi (Tot);#phi_{RECO} [rad]", 100, -3.2, 3.2);
@@ -308,9 +321,9 @@ void MtdGlobalRecoValidation::bookHistograms(DQMStore::IBooker& ibook,
   meBTLTrackEffPhiMtd_ =
       ibook.book1D("TrackBTLEffPhiMtd", "Track efficiency vs phi (Mtd);#phi_{RECO} [rad]", 100, -3.2, 3.2);
   meBTLTrackEffPtMtd_ = ibook.book1D("TrackBTLEffPtMtd", "Track efficiency vs pt (Mtd);pt_{RECO} [GeV]", 50, 0, 10);
-  meBTLTrackPtRes_ =
-      ibook.book1D("TrackBTLPtRes", "Track pT resolution  ;pT_{Gentrack}-pT_{MTDtrack}/pT_{Gentrack} ", 100, -0.1, 0.1);
-  meETLTrackRPTime_ = ibook.book1D("TrackETLRPTime", "Track t0 with respect to R.P.;t0 [ns]", 100, -1, 3);
+  meBTLTrackPtRes_ = ibook.book1D("TrackBTLPtRes", "Track pT resolution  ;pT_{Gentrack}-pT_{MTDtrack}/pT_{Gentrack} ", 100, -0.1, 0.1);
+  meETLTrackRPTime_ =
+      ibook.book1D("TrackETLRPTime", "Track t0 with respect to R.P.;t0 [ns]", 100, -1, 3);
   meETLTrackEffEtaTot_[0] =
       ibook.book1D("TrackETLEffEtaTotZneg", "Track efficiency vs eta (Tot) (-Z);#eta_{RECO}", 100, -3.2, -1.4);
   meETLTrackEffEtaTot_[1] =
@@ -335,12 +348,13 @@ void MtdGlobalRecoValidation::bookHistograms(DQMStore::IBooker& ibook,
       ibook.book1D("TrackETLEffPtMtdZneg", "Track efficiency vs pt (Mtd) (-Z);pt_{RECO} [GeV]", 50, 0, 10);
   meETLTrackEffPtMtd_[1] =
       ibook.book1D("TrackETLEffPtMtdZpos", "Track efficiency vs pt (Mtd) (+Z);pt_{RECO} [GeV]", 50, 0, 10);
-  meETLTrackPtRes_ =
-      ibook.book1D("TrackETLPtRes", "Track pT resolution;pT_{Gentrack}-pT_{MTDtrack}/pT_{Gentrack} ", 100, -0.1, 0.1);
+  meETLTrackPtRes_ = ibook.book1D("TrackETLPtRes", "Track pT resolution;pT_{Gentrack}-pT_{MTDtrack}/pT_{Gentrack} ", 100, -0.1, 0.1);
   meTrackNumHits_ = ibook.book1D("TrackNumHits", "Number of valid MTD hits per track ; Number of hits", 10, -5, 5);
   meTrackMVAQual_ = ibook.book1D("TrackMVAQual", "Track MVA Quality as stored in Value Map ; MVAQual", 100, 0, 1);
-  meTrackPathLenghtvsEta_ = ibook.bookProfile(
-      "TrackPathLenghtvsEta", "MTD Track pathlength vs MTD track Eta;|#eta|;Pathlength", 100, 0, 3.2, 100.0, 400.0, "S");
+  meTrackPathLenghtvsEta_ = ibook.bookProfile("TrackPathLenghtvsEta", "MTD Track pathlength vs MTD track Eta;|#eta|;Pathlength", 100, 0, 3.2, 100.0, 400.0, "S");
+  meFailMVAEta_ = ibook.book1D("TrackFailingMVAEta", "Failing MVA track #eta;|#eta| ", 100, 0, 3.2);
+  meFailMVAPhi_ = ibook.book1D("TrackFailingMVAPhi", "Failing MVA track #phi;#phi [rad] ", 100, -3.2, 3.2);
+  meFailMVAPt_ = ibook.book1D("TrackFailingMVAPt", "Failing MVA track pT;pT [GeV]", 50, 0, 10);
   meVerZ_ = ibook.book1D("VerZ", "RECO Vertex Z;Z_{RECO} [cm]", 180, -18, 18);
   meVerTime_ = ibook.book1D("VerTime", "RECO Vertex Time;t0 [ns]", 100, -1, 1);
   meVerNumber_ = ibook.book1D("VerNumber", "RECO Vertex Number: Number of vertices", 100, 0, 500);
@@ -348,24 +362,26 @@ void MtdGlobalRecoValidation::bookHistograms(DQMStore::IBooker& ibook,
 
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
 
-void MtdGlobalRecoValidation::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+void MtdTracksValidation::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
 
-  desc.add<std::string>("folder", "MTD/GlobalReco");
+  desc.add<std::string>("folder", "MTD/Tracks");
   desc.add<edm::InputTag>("inputTagG", edm::InputTag("generalTracks", ""));
   desc.add<edm::InputTag>("inputTagT", edm::InputTag("trackExtenderWithMTD", ""));
   desc.add<edm::InputTag>("inputTagV", edm::InputTag("offlinePrimaryVertices4D", ""));
-  desc.add<edm::InputTag>("t0Src", edm::InputTag("trackExtenderWithMTD:generalTrackt0", ""));
-  desc.add<edm::InputTag>("sigmat0Src", edm::InputTag("trackExtenderWithMTD:generalTracksigmat0", ""));
-  desc.add<edm::InputTag>("pathLengthSrc", edm::InputTag("trackExtenderWithMTD", "pathLength"));
-  desc.add<edm::InputTag>("t0SafePID", edm::InputTag("tofPID:t0safe", ""));
+  desc.add<edm::InputTag>("t0Src", edm::InputTag("trackExtenderWithMTD:generalTrackt0", "")); 
+  desc.add<edm::InputTag>("sigmat0Src", edm::InputTag("trackExtenderWithMTD:generalTracksigmat0", "")); 
+  desc.add<edm::InputTag>("trackAssocSrc", edm::InputTag("trackExtenderWithMTD", "generalTrackassoc"))
+      ->setComment("Association between General and MTD Extended tracks");
+  desc.add<edm::InputTag>("pathLengthSrc", edm::InputTag("trackExtenderWithMTD", "pathLength")); 
+  desc.add<edm::InputTag>("t0SafePID", edm::InputTag("tofPID:t0safe", "")); 
   desc.add<edm::InputTag>("sigmat0SafePID", edm::InputTag("tofPID:sigmat0safe", ""));
   desc.add<edm::InputTag>("trackMVAQual", edm::InputTag("mtdTrackQualityMVA:mtdQualMVA", ""));
-  desc.add<double>("trackMinimumEnergy", 1.0);  // [GeV]
+  desc.add<double>("trackMinimumPt", 1.0);  // [GeV]
   desc.add<double>("trackMinimumEta", 1.5);
   desc.add<double>("trackMaximumEta", 3.2);
 
-  descriptions.add("globalReco", desc);
+  descriptions.add("mtdTracks", desc);
 }
 
-DEFINE_FWK_MODULE(MtdGlobalRecoValidation);
+DEFINE_FWK_MODULE(MtdTracksValidation);

--- a/Validation/MtdValidation/plugins/MtdTracksValidation.cc
+++ b/Validation/MtdValidation/plugins/MtdTracksValidation.cc
@@ -178,9 +178,9 @@ void MtdTracksValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
     meTrackSigmat0SafePid_->Fill(Sigmat0Safe[trackref]);
     meTrackMVAQual_->Fill(mtdQualMVA[trackref]);
 
-    meTrackPathLenghtvsEta_->Fill(std::fabs(track.eta()), pathLength[mtdTrackref]);
+    meTrackPathLenghtvsEta_->Fill(std::abs(track.eta()), pathLength[mtdTrackref]);
 
-    if (fabs(track.eta()) < trackMinEta_) {
+    if (std::abs(track.eta()) < trackMinEta_) {
       // --- all BTL tracks (with and without hit in MTD) ---
       meBTLTrackEffEtaTot_->Fill(track.eta());
       meBTLTrackEffPhiTot_->Fill(track.phi());

--- a/Validation/MtdValidation/python/MtdPostProcessor_cff.py
+++ b/Validation/MtdValidation/python/MtdPostProcessor_cff.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
 from Validation.MtdValidation.btlSimHitsPostProcessor_cfi import btlSimHitsPostProcessor
-from Validation.MtdValidation.MtdGlobalRecoPostProcessor_cfi import MtdGlobalRecoPostProcessor
+from Validation.MtdValidation.MtdTracksPostProcessor_cfi import MtdTracksPostProcessor
 
-mtdValidationPostProcessor = cms.Sequence(btlSimHitsPostProcessor + MtdGlobalRecoPostProcessor)
+mtdValidationPostProcessor = cms.Sequence(btlSimHitsPostProcessor + MtdTracksPostProcessor)

--- a/Validation/MtdValidation/test/mtdValidation_cfg.py
+++ b/Validation/MtdValidation/test/mtdValidation_cfg.py
@@ -51,7 +51,7 @@ process.load("Validation.MtdValidation.etlLocalReco_cfi")
 etlValidation = cms.Sequence(process.etlSimHits + process.etlDigiHits + process.etlLocalReco)
 
 # --- Global Validation
-process.load("Validation.MtdValidation.globalReco_cfi")
+process.load("Validation.MtdValidation.mtdTracks_cfi")
 
 process.DQMStore = cms.Service("DQMStore")
 


### PR DESCRIPTION
#### PR description:

This PR expands the validation code for tracks, including monitoring for the following quantities:
-Time and time error of tracks at the different steps of the MTD track reconstruction 
-MVA and pathlenght of MTD tracks
-pT resolution wrt General tracks

The validation code for ETL and BTL Reco Hits has also been expanded, adding time and energy resolution MEs and implementing an optional set of histograms for the monitoring of the hits local position, that can be used for dedicated studies.

#### PR validation:

The new code has been tested in the release CMSSW_11_3_X_2021-03-19-1100

