### PR TITLE
Add weight to HCAL output LUT and add all input tags to trigger key

### DIFF
--- a/CalibCalorimetry/HcalTPGAlgos/interface/LutXml.h
+++ b/CalibCalorimetry/HcalTPGAlgos/interface/LutXml.h
@@ -35,6 +35,7 @@ public:
     std::string formatrevision;
     std::string targetfirmware;
     int generalizedindex;
+    int weight;
     std::vector<unsigned int> lut;
     std::vector<uint64_t> mask;
   } Config;

--- a/CalibCalorimetry/HcalTPGAlgos/src/LutXml.cc
+++ b/CalibCalorimetry/HcalTPGAlgos/src/LutXml.cc
@@ -49,6 +49,7 @@ LutXml::Config::_Config() {
   formatrevision = "default_revision";
   targetfirmware = "default_revision";
   generalizedindex = -1;
+  weight = -1;
 }
 
 LutXml::LutXml() : XMLDOMBlock("CFGBrickSet", 1) { init(); }
@@ -111,6 +112,7 @@ void LutXml::addLut(LutXml::Config &_config, XMLDOMBlock *checksums_xml) {
     addParameter("LUT_TYPE", "int", _config.lut_type);
     addParameter("SLB", "int", _config.fiber);
     addParameter("SLBCHAN", "int", _config.fiberchan);
+    addParameter("WEIGHT", "int", _config.weight);
     addData(to_string(_config.lut.size()), "hex", _config.lut);
   } else if (_config.lut_type == 5) {  // channel masks
     addParameter("MASK_TYPE", "string", "TRIGGERCHANMASK");

--- a/CalibFormats/HcalObjects/interface/HcalDbService.h
+++ b/CalibFormats/HcalObjects/interface/HcalDbService.h
@@ -57,7 +57,7 @@ public:
   const HcalQIEType* getHcalQIEType(const HcalGenericDetId& fId) const;
   const HcalSiPMParameter* getHcalSiPMParameter(const HcalGenericDetId& fId) const;
   const HcalSiPMCharacteristics* getHcalSiPMCharacteristics() const;
-  const HcalTPChannelParameter* getHcalTPChannelParameter(const HcalGenericDetId& fId) const;
+  const HcalTPChannelParameter* getHcalTPChannelParameter(const HcalGenericDetId& fId, bool throwOnFail = true) const;
   const HcalTPParameters* getHcalTPParameters() const;
   const HcalMCParam* getHcalMCParam(const HcalGenericDetId& fId) const;
   const HcalRecoParam* getHcalRecoParam(const HcalGenericDetId& fId) const;

--- a/CalibFormats/HcalObjects/src/HcalDbService.cc
+++ b/CalibFormats/HcalObjects/src/HcalDbService.cc
@@ -388,9 +388,9 @@ const HcalSiPMParameter* HcalDbService::getHcalSiPMParameter(const HcalGenericDe
 
 const HcalSiPMCharacteristics* HcalDbService::getHcalSiPMCharacteristics() const { return mSiPMCharacteristics; }
 
-const HcalTPChannelParameter* HcalDbService::getHcalTPChannelParameter(const HcalGenericDetId& fId) const {
+const HcalTPChannelParameter* HcalDbService::getHcalTPChannelParameter(const HcalGenericDetId& fId, bool throwOnFail) const {
   if (mTPChannelParameters) {
-    return mTPChannelParameters->getValues(fId);
+    return mTPChannelParameters->getValues(fId, throwOnFail);
   }
   return nullptr;
 }

--- a/CalibFormats/HcalObjects/src/HcalDbService.cc
+++ b/CalibFormats/HcalObjects/src/HcalDbService.cc
@@ -388,7 +388,8 @@ const HcalSiPMParameter* HcalDbService::getHcalSiPMParameter(const HcalGenericDe
 
 const HcalSiPMCharacteristics* HcalDbService::getHcalSiPMCharacteristics() const { return mSiPMCharacteristics; }
 
-const HcalTPChannelParameter* HcalDbService::getHcalTPChannelParameter(const HcalGenericDetId& fId, bool throwOnFail) const {
+const HcalTPChannelParameter* HcalDbService::getHcalTPChannelParameter(const HcalGenericDetId& fId,
+                                                                       bool throwOnFail) const {
   if (mTPChannelParameters) {
     return mTPChannelParameters->getValues(fId, throwOnFail);
   }

--- a/CaloOnlineTools/HcalOnlineDb/src/HcalLutManager.cc
+++ b/CaloOnlineTools/HcalOnlineDb/src/HcalLutManager.cc
@@ -978,6 +978,8 @@ std::map<int, std::shared_ptr<LutXml>> HcalLutManager::getCompressionLutXmlFromC
     _cfg.generalizedindex = _cfg.iphi * 10000 + (row->ieta > 0) * 100 + abs(row->ieta);  //is this used for anything?
 
     _cfg.lut = _coder.getCompressionLUT(_detid);
+    auto pWeight = conditions->getHcalTPChannelParameter(_detid, false);
+    if (pWeight) _cfg.weight = pWeight->getauxi1();
 
     int crot = 100 * row->crate + row->slot;
     unsigned int size = _cfg.lut.size();

--- a/CaloOnlineTools/HcalOnlineDb/src/HcalLutManager.cc
+++ b/CaloOnlineTools/HcalOnlineDb/src/HcalLutManager.cc
@@ -979,7 +979,8 @@ std::map<int, std::shared_ptr<LutXml>> HcalLutManager::getCompressionLutXmlFromC
 
     _cfg.lut = _coder.getCompressionLUT(_detid);
     auto pWeight = conditions->getHcalTPChannelParameter(_detid, false);
-    if (pWeight) _cfg.weight = pWeight->getauxi1();
+    if (pWeight)
+      _cfg.weight = pWeight->getauxi1();
 
     int crot = 100 * row->crate + row->slot;
     unsigned int size = _cfg.lut.size();

--- a/CaloOnlineTools/HcalOnlineDb/test/genLUT.sh
+++ b/CaloOnlineTools/HcalOnlineDb/test/genLUT.sh
@@ -170,17 +170,23 @@ then
     echo "Creating Trigger Key..."
     echo 
 
-    dd=$(date +"%Y-%m-%d %H:%M:%S")
+    HcalInput=( "${inputConditions[@]/#/Hcal}" )
+    declare -A tagMap
+    eval $(conddb list $GlobalTag | grep -E "$(export IFS="|"; echo "${HcalInput[*]}")" | \
+	awk '{if($2=="-" || $2=="effective") if(!($1~/^HcalPed/ && $2=="-")) print "tagMap["$1"]="$3}')
+
     individualInputTags=""
     for i in ${inputConditions[@]}; do
 	t=$i
 	v=${!t}
-	if [[ -n $v ]]; then
-           individualInputTags="""$individualInputTags
+	if [[ -z $v ]]; then
+	    v=${tagMap[Hcal${i}Rcd]}
+	fi
+	individualInputTags="""$individualInputTags
     <Parameter type=\"string\" name=\"$t\">$v</Parameter>"""
-	fi 
     done
 
+    dd=$(date +"%Y-%m-%d %H:%M:%S")
     echo """<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\" ?>
 <CFGBrickSet>
 <CFGBrick>

--- a/CondTools/Hcal/test/runDumpHcalCond_cfg.py
+++ b/CondTools/Hcal/test/runDumpHcalCond_cfg.py
@@ -79,7 +79,7 @@ if options.era:
     from Configuration.StandardSequences.Eras import eras
     process = cms.Process("DUMP",getattr(eras,options.era))
 
-process.load("CondCore.DBCommon.CondDBSetup_cfi")
+process.load("CondCore.CondDB.CondDB_cfi")
 process.load('Configuration.StandardSequences.Services_cff')
 
 if options.globaltag:


### PR DESCRIPTION
#### PR description:

  -  add a WEIGHT in the output LUT to be loaded in uHTRs, as discussed with @JHiltbrand and @jmmans 
  -  add all input tags used for TPG LUT generation explicitly in the corresponding trigger key to aid O2O
  - The changes should not affect any offline workflow
  

#### PR validation:

  - New test LUT and trigger key have been generated successfully


