### PR TITLE
Fix an incorrect (D)CFEB number assignment in the CSC CLCT producer for Run-3 L1T (CCLUT-12)

### DIFF
--- a/L1Trigger/CSCTriggerPrimitives/interface/CSCCathodeLCTProcessor.h
+++ b/L1Trigger/CSCTriggerPrimitives/interface/CSCCathodeLCTProcessor.h
@@ -121,7 +121,6 @@ protected:
   // Multiple hits on the same strip are allowed.
   void readComparatorDigis(std::vector<int> halfstrip[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS_7CFEBS]);
   void pulseExtension(const std::vector<int> time[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS_7CFEBS],
-                      const int nStrips,
                       PulseArray pulse);
 
   //--------------- Functions for post-2007 version of the firmware -----------
@@ -133,7 +132,6 @@ protected:
 
   /* For a given clock cycle, check each half-strip if a pattern matches */
   bool patternFinding(const PulseArray pulse,
-                      const int nStrips,
                       const unsigned int bx_time,
                       std::map<int, std::map<int, CSCCLCTDigi::ComparatorContainer> >& hits_in_patterns);
 
@@ -150,8 +148,7 @@ protected:
   void dumpConfigParams() const;
 
   /** Dump half-strip digis */
-  void dumpDigis(const std::vector<int> strip[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS_7CFEBS],
-                 const int nStrips) const;
+  void dumpDigis(const std::vector<int> strip[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS_7CFEBS]) const;
 
   // --------Functions for the comparator code algorith for Run-3 ---------//
   //calculates the id based on location of hits
@@ -194,7 +191,9 @@ protected:
   };
 
   /* number of strips used in this processor */
-  int numStrips;
+  int numStrips_;
+  int numCFEBs_;
+  int numHalfStrips_;
 
   /* Is the layer in the chamber staggered? */
   int stagger[CSCConstants::NUM_LAYERS];

--- a/L1Trigger/CSCTriggerPrimitives/interface/CSCCathodeLCTProcessor.h
+++ b/L1Trigger/CSCTriggerPrimitives/interface/CSCCathodeLCTProcessor.h
@@ -155,7 +155,7 @@ protected:
   int calculateComparatorCode(const std::array<std::array<int, 3>, 6>& halfStripPattern) const;
 
   // sets the 1/4 and 1/8 strip bits given a floating point position offset
-  void assignPositionCC(const unsigned offset, std::tuple<uint16_t, bool, bool>& returnValue) const;
+  void assignPositionCC(const unsigned offset, std::tuple<int16_t, bool, bool>& returnValue) const;
 
   // runs the CCLUT procedure
   void runCCLUT(CSCCLCTDigi& digi) const;

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCCathodeLCTProcessor.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCCathodeLCTProcessor.cc
@@ -1416,11 +1416,11 @@ void CSCCathodeLCTProcessor::runCCLUT(CSCCLCTDigi& digi) const {
   int newCFEB = digi.getCFEB();
 
   // case where key half-strip is on the lower edge of the CFEB
-  if (digi.getStrip() == 0 and halfstripoffset == -1 and digi.getCFEB() > 0) {
+  if (digi.getStrip() == 0 and halfstripoffset <= -1 and digi.getCFEB() > 0) {
     newCFEB = digi.getCFEB() - 1;
   }
   // case where key half-strip is on the upper edge of the CFEB
-  if (digi.getStrip() == CSCConstants::NUM_HALF_STRIPS_PER_CFEB - 1 and halfstripoffset == 1 and
+  if (digi.getStrip() == CSCConstants::NUM_HALF_STRIPS_PER_CFEB - 1 and halfstripoffset >= 1 and
       digi.getCFEB() < numCFEBs_) {
     newCFEB = digi.getCFEB() + 1;
   }

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCCathodeLCTProcessor.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCCathodeLCTProcessor.cc
@@ -70,7 +70,7 @@ CSCCathodeLCTProcessor::CSCCathodeLCTProcessor(unsigned endcap,
     config_dumped = true;
   }
 
-  numStrips = 0;  // Will be set later.
+  numStrips_ = 0;  // Will be set later.
   // Provisional, but should be OK for all stations except ME1.
   for (int i_layer = 0; i_layer < CSCConstants::NUM_LAYERS; i_layer++) {
     if ((i_layer + 1) % 2 == 0)
@@ -123,7 +123,7 @@ CSCCathodeLCTProcessor::CSCCathodeLCTProcessor() : CSCBaseboard() {
     config_dumped = true;
   }
 
-  numStrips = CSCConstants::MAX_NUM_STRIPS;
+  numStrips_ = CSCConstants::MAX_NUM_STRIPS;
   // Should be OK for all stations except ME1.
   for (int i_layer = 0; i_layer < CSCConstants::NUM_LAYERS; i_layer++) {
     if ((i_layer + 1) % 2 == 0)
@@ -221,9 +221,10 @@ std::vector<CSCCLCTDigi> CSCCathodeLCTProcessor::run(const CSCComparatorDigiColl
 
   // Get the number of strips and stagger of layers for the given chamber.
   // Do it only once per chamber.
-  if (numStrips <= 0 or numStrips > CSCConstants::MAX_NUM_STRIPS_7CFEBS) {
+  if (numStrips_ <= 0 or numStrips_ > CSCConstants::MAX_NUM_STRIPS_7CFEBS) {
     if (cscChamber_) {
-      numStrips = cscChamber_->layer(1)->geometry()->numberOfStrips();
+      numStrips_ = cscChamber_->layer(1)->geometry()->numberOfStrips();
+
       // ME1/a is known to the readout hardware as strips 65-80 of ME1/1.
       // Still need to decide whether we do any special adjustments to
       // reconstruct LCTs in this region (3:1 ganged strips); for now, we
@@ -238,20 +239,25 @@ std::vector<CSCCLCTDigi> CSCCathodeLCTProcessor::run(const CSCComparatorDigiColl
               << "+++ CSC geometry looks garbled; no emulation possible +++\n";
         }
         if (!disableME1a_ && theRing == 1 && !gangedME1a_)
-          numStrips = CSCConstants::MAX_NUM_STRIPS_7CFEBS;
+          numStrips_ = CSCConstants::MAX_NUM_STRIPS_7CFEBS;
         if (!disableME1a_ && theRing == 1 && gangedME1a_)
-          numStrips = CSCConstants::MAX_NUM_STRIPS;
+          numStrips_ = CSCConstants::MAX_NUM_STRIPS;
         if (disableME1a_ && theRing == 1)
-          numStrips = CSCConstants::MAX_NUM_STRIPS_ME1B;
+          numStrips_ = CSCConstants::MAX_NUM_STRIPS_ME1B;
       }
 
-      if (numStrips > CSCConstants::MAX_NUM_STRIPS_7CFEBS) {
+      numHalfStrips_ = 2 * numStrips_ + 1;
+      numCFEBs_ = numStrips_ / CSCConstants::NUM_STRIPS_PER_CFEB;
+
+      if (numStrips_ > CSCConstants::MAX_NUM_STRIPS_7CFEBS) {
         edm::LogError("CSCCathodeLCTProcessor|SetupError")
-            << "+++ Number of strips, " << numStrips << " found in " << theCSCName_ << " (sector " << theSector
+            << "+++ Number of strips, " << numStrips_ << " found in " << theCSCName_ << " (sector " << theSector
             << " subsector " << theSubsector << " trig id. " << theTrigChamber << ")"
             << " exceeds max expected, " << CSCConstants::MAX_NUM_STRIPS_7CFEBS << " +++\n"
             << "+++ CSC geometry looks garbled; no emulation possible +++\n";
-        numStrips = -1;
+        numStrips_ = -1;
+        numHalfStrips_ = -1;
+        numCFEBs_ = -1;
       }
       // The strips for a given layer may be offset from the adjacent layers.
       // This was done in order to improve resolution.  We need to find the
@@ -275,15 +281,17 @@ std::vector<CSCCLCTDigi> CSCCathodeLCTProcessor::run(const CSCComparatorDigiColl
           << theTrigChamber << ")"
           << " is not defined in current geometry! +++\n"
           << "+++ CSC geometry looks garbled; no emulation possible +++\n";
-      numStrips = -1;
+      numStrips_ = -1;
+      numHalfStrips_ = -1;
+      numCFEBs_ = -1;
     }
   }
 
-  if (numStrips <= 0 or 2 * (unsigned)numStrips > qualityControl_->get_csc_max_halfstrip(theStation, theRing)) {
+  if (numStrips_ <= 0 or 2 * (unsigned)numStrips_ > qualityControl_->get_csc_max_halfstrip(theStation, theRing)) {
     edm::LogError("CSCCathodeLCTProcessor|ConfigError")
         << " " << theCSCName_ << " (sector " << theSector << " subsector " << theSubsector << " trig id. "
         << theTrigChamber << "):"
-        << " numStrips = " << numStrips << "; CLCT emulation skipped! +++";
+        << " numStrips_ = " << numStrips_ << "; CLCT emulation skipped! +++";
     std::vector<CSCCLCTDigi> emptyV;
     return emptyV;
   }
@@ -474,11 +482,11 @@ void CSCCathodeLCTProcessor::readComparatorDigis(
 
       // Get strip number.
       int thisStrip = pld->getStrip() - 1;  // count from 0
-      if (thisStrip < 0 || thisStrip >= numStrips) {
+      if (thisStrip < 0 || thisStrip >= numStrips_) {
         if (infoV >= 0)
           edm::LogWarning("L1CSCTPEmulatorWrongInput")
               << "+++ station " << theStation << " ring " << theRing << " chamber " << theChamber
-              << " Found comparator digi with wrong strip number = " << thisStrip << " (max strips = " << numStrips
+              << " Found comparator digi with wrong strip number = " << thisStrip << " (max strips = " << numStrips_
               << "); skipping it... +++\n";
         continue;
       }
@@ -486,7 +494,7 @@ void CSCCathodeLCTProcessor::readComparatorDigis(
       // comp   : comparator output
       // stagger: stagger for this layer
       int thisHalfstrip = 2 * thisStrip + thisComparator + stagger[i_layer];
-      if (thisHalfstrip >= 2 * numStrips + 1) {
+      if (thisHalfstrip >= numHalfStrips_) {
         if (infoV >= 0)
           edm::LogWarning("L1CSCTPEmulatorWrongInput")
               << "+++ station " << theStation << " ring " << theRing << " chamber " << theChamber
@@ -540,18 +548,15 @@ std::vector<CSCCLCTDigi> CSCCathodeLCTProcessor::findLCTs(
     const std::vector<int> halfstrip[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS_7CFEBS]) {
   std::vector<CSCCLCTDigi> lctList;
 
-  // Max. number of half-strips for this chamber.
-  const int maxHalfStrips = 2 * numStrips + 1;
-
   if (infoV > 1)
-    dumpDigis(halfstrip, maxHalfStrips);
+    dumpDigis(halfstrip);
 
   // 2 possible LCTs per CSC x 7 LCT quantities
   int keystrip_data[CSCConstants::MAX_CLCTS_PER_PROCESSOR][CLCT_NUM_QUANTITIES] = {{0}};
   PulseArray pulse;
 
   // Fire half-strip one-shots for hit_persist bx's (4 bx's by default).
-  pulseExtension(halfstrip, maxHalfStrips, pulse);
+  pulseExtension(halfstrip, pulse);
 
   unsigned int start_bx = start_bx_shift;
   // Stop drift_delay bx's short of fifo_tbins since at later bx's we will
@@ -585,10 +590,10 @@ std::vector<CSCCLCTDigi> CSCCathodeLCTProcessor::findLCTs(
 
       // We check if there is at least one key half strip for which at least
       // one pattern id has at least the minimum number of hits
-      bool hits_in_time = patternFinding(pulse, maxHalfStrips, latch_bx, hits_in_patterns);
+      bool hits_in_time = patternFinding(pulse, latch_bx, hits_in_patterns);
       if (infoV > 1) {
         if (hits_in_time) {
-          for (int hstrip = stagger[CSCConstants::KEY_CLCT_LAYER - 1]; hstrip < maxHalfStrips; hstrip++) {
+          for (int hstrip = stagger[CSCConstants::KEY_CLCT_LAYER - 1]; hstrip < numHalfStrips_; hstrip++) {
             if (nhits[hstrip] > 0) {
               LogTrace("CSCCathodeLCTProcessor")
                   << " bx = " << std::setw(2) << latch_bx << " --->"
@@ -618,7 +623,7 @@ std::vector<CSCCLCTDigi> CSCCathodeLCTProcessor::findLCTs(
       // Calculate quality from pattern id and number of hits, and
       // simultaneously select best-quality LCT.
       if (hits_in_time) {
-        for (int hstrip = stagger[CSCConstants::KEY_CLCT_LAYER - 1]; hstrip < maxHalfStrips; hstrip++) {
+        for (int hstrip = stagger[CSCConstants::KEY_CLCT_LAYER - 1]; hstrip < numHalfStrips_; hstrip++) {
           // The bend-direction bit pid[0] is ignored (left and right
           // bends have equal quality).
           quality[hstrip] = (best_pid[hstrip] & 14) | (nhits[hstrip] << 5);
@@ -642,7 +647,7 @@ std::vector<CSCCLCTDigi> CSCCathodeLCTProcessor::findLCTs(
         // zero, and repeat the search.
         markBusyKeys(best_halfstrip[0], best_pid[best_halfstrip[0]], quality);
 
-        for (int hstrip = stagger[CSCConstants::KEY_CLCT_LAYER - 1]; hstrip < maxHalfStrips; hstrip++) {
+        for (int hstrip = stagger[CSCConstants::KEY_CLCT_LAYER - 1]; hstrip < numHalfStrips_; hstrip++) {
           if (quality[hstrip] > best_quality[1]) {
             best_halfstrip[1] = hstrip;
             best_quality[1] = quality[hstrip];
@@ -730,9 +735,9 @@ std::vector<CSCCLCTDigi> CSCCathodeLCTProcessor::findLCTs(
       unsigned int stop_time = fifo_tbins - drift_delay;
       for (unsigned int bx = latch_bx + 1; bx < stop_time; bx++) {
         bool return_to_idle = true;
-        bool hits_in_time = patternFinding(pulse, maxHalfStrips, bx, hits_in_patterns);
+        bool hits_in_time = patternFinding(pulse, bx, hits_in_patterns);
         if (hits_in_time) {
-          for (int hstrip = stagger[CSCConstants::KEY_CLCT_LAYER - 1]; hstrip < maxHalfStrips; hstrip++) {
+          for (int hstrip = stagger[CSCConstants::KEY_CLCT_LAYER - 1]; hstrip < numHalfStrips_; hstrip++) {
             // the dead-time is done at the pre-trigger, not at the trigger
             if (nhits[hstrip] >= nplanes_hit_pretrig) {
               if (infoV > 1)
@@ -760,9 +765,7 @@ std::vector<CSCCLCTDigi> CSCCathodeLCTProcessor::findLCTs(
 
 // Common to all versions.
 void CSCCathodeLCTProcessor::pulseExtension(
-    const std::vector<int> time[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS_7CFEBS],
-    const int nStrips,
-    PulseArray pulse) {
+    const std::vector<int> time[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS_7CFEBS], PulseArray pulse) {
   static const unsigned int bits_in_pulse = 8 * sizeof(pulse[0][0]);
 
   // Clear pulse array.  This array will be used as a bit representation of
@@ -774,12 +777,12 @@ void CSCCathodeLCTProcessor::pulseExtension(
   // of 3 would look like 0000000000111000.  This is similating the digital
   // one-shot in the TMB.
   for (int i_layer = 0; i_layer < CSCConstants::NUM_LAYERS; i_layer++)
-    for (int i_strip = 0; i_strip < nStrips; i_strip++)
+    for (int i_strip = 0; i_strip < numHalfStrips_; i_strip++)
       pulse[i_layer][i_strip] = 0;
 
   // Loop over all layers and halfstrips.
   for (int i_layer = 0; i_layer < CSCConstants::NUM_LAYERS; i_layer++) {
-    for (int i_strip = 0; i_strip < nStrips; i_strip++) {
+    for (int i_strip = 0; i_strip < numHalfStrips_; i_strip++) {
       // If there is a hit, simulate digital one-shot persistence starting
       // in the bx of the initial hit.  Fill this into pulse[][].
       if (!time[i_layer][i_strip].empty()) {
@@ -809,9 +812,6 @@ bool CSCCathodeLCTProcessor::preTrigger(const PulseArray pulse, const int start_
   if (infoV > 1)
     LogTrace("CSCCathodeLCTProcessor") << "....................PreTrigger...........................";
 
-  // Max. number of half-strips for this chamber.
-  const int nStrips = 2 * numStrips + 1;
-
   int nPreTriggers = 0;
 
   bool pre_trig = false;
@@ -826,9 +826,9 @@ bool CSCCathodeLCTProcessor::preTrigger(const PulseArray pulse, const int start_
     std::map<int, std::map<int, CSCCLCTDigi::ComparatorContainer>> hits_in_patterns;
     hits_in_patterns.clear();
 
-    bool hits_in_time = patternFinding(pulse, nStrips, bx_time, hits_in_patterns);
+    bool hits_in_time = patternFinding(pulse, bx_time, hits_in_patterns);
     if (hits_in_time) {
-      for (int hstrip = stagger[CSCConstants::KEY_CLCT_LAYER - 1]; hstrip < nStrips; hstrip++) {
+      for (int hstrip = stagger[CSCConstants::KEY_CLCT_LAYER - 1]; hstrip < numHalfStrips_; hstrip++) {
         if (infoV > 1) {
           if (nhits[hstrip] > 0) {
             LogTrace("CSCCathodeLCTProcessor")
@@ -869,7 +869,6 @@ bool CSCCathodeLCTProcessor::preTrigger(const PulseArray pulse, const int start_
 // TMB-07 version.
 bool CSCCathodeLCTProcessor::patternFinding(
     const PulseArray pulse,
-    const int nStrips,
     const unsigned int bx_time,
     std::map<int, std::map<int, CSCCLCTDigi::ComparatorContainer>>& hits_in_patterns) {
   if (bx_time >= fifo_tbins)
@@ -880,7 +879,7 @@ bool CSCCathodeLCTProcessor::patternFinding(
   // substantially.
   unsigned int layers_hit = 0;
   for (int i_layer = 0; i_layer < CSCConstants::NUM_LAYERS; i_layer++) {
-    for (int i_hstrip = 0; i_hstrip < nStrips; i_hstrip++) {
+    for (int i_hstrip = 0; i_hstrip < numHalfStrips_; i_hstrip++) {
       if (((pulse[i_layer][i_hstrip] >> bx_time) & 1) == 1) {
         layers_hit++;
         break;
@@ -890,7 +889,7 @@ bool CSCCathodeLCTProcessor::patternFinding(
   if (layers_hit < nplanes_hit_pretrig)
     return false;
 
-  for (int key_hstrip = 0; key_hstrip < nStrips; key_hstrip++) {
+  for (int key_hstrip = 0; key_hstrip < numHalfStrips_; key_hstrip++) {
     best_pid[key_hstrip] = 0;
     nhits[key_hstrip] = 0;
     first_bx_corrected[key_hstrip] = -999;
@@ -899,7 +898,7 @@ bool CSCCathodeLCTProcessor::patternFinding(
   bool hit_layer[CSCConstants::NUM_LAYERS];
 
   // Loop over candidate key strips.
-  for (int key_hstrip = stagger[CSCConstants::KEY_CLCT_LAYER - 1]; key_hstrip < nStrips; key_hstrip++) {
+  for (int key_hstrip = stagger[CSCConstants::KEY_CLCT_LAYER - 1]; key_hstrip < numHalfStrips_; key_hstrip++) {
     // Loop over patterns and look for hits matching each pattern.
     for (unsigned int pid = clct_pattern_.size() - 1; pid >= pid_thresh_pretrig and pid < clct_pattern_.size(); pid--) {
       layers_hit = 0;
@@ -932,7 +931,7 @@ bool CSCCathodeLCTProcessor::patternFinding(
           int this_strip = CSCPatternBank::clct_pattern_offset_[strip_num] + key_hstrip;
 
           // current strip should be valid of course
-          if (this_strip >= 0 && this_strip < nStrips) {
+          if (this_strip >= 0 && this_strip < numHalfStrips_) {
             if (infoV > 3) {
               LogTrace("CSCCathodeLCTProcessor") << " In patternFinding: key_strip = " << key_hstrip << " pid = " << pid
                                                  << " layer = " << this_layer << " strip = " << this_strip << std::endl;
@@ -1061,12 +1060,11 @@ void CSCCathodeLCTProcessor::dumpConfigParams() const {
 
 // Reasonably nice dump of digis on half-strips.
 void CSCCathodeLCTProcessor::dumpDigis(
-    const std::vector<int> strip[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS_7CFEBS],
-    const int nStrips) const {
-  LogDebug("CSCCathodeLCTProcessor") << theCSCName_ << " strip type: half-strip,  nStrips " << nStrips;
+    const std::vector<int> strip[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS_7CFEBS]) const {
+  LogDebug("CSCCathodeLCTProcessor") << theCSCName_ << " strip type: half-strip,  numHalfStrips " << numHalfStrips_;
 
   std::ostringstream strstrm;
-  for (int i_strip = 0; i_strip < nStrips; i_strip++) {
+  for (int i_strip = 0; i_strip < numHalfStrips_; i_strip++) {
     if (i_strip % 10 == 0) {
       if (i_strip < 100)
         strstrm << i_strip / 10;
@@ -1078,14 +1076,14 @@ void CSCCathodeLCTProcessor::dumpDigis(
       strstrm << " ";
   }
   strstrm << "\n";
-  for (int i_strip = 0; i_strip < nStrips; i_strip++) {
+  for (int i_strip = 0; i_strip < numHalfStrips_; i_strip++) {
     strstrm << i_strip % 10;
     if ((i_strip + 1) % CSCConstants::NUM_HALF_STRIPS_PER_CFEB == 0)
       strstrm << " ";
   }
   for (int i_layer = 0; i_layer < CSCConstants::NUM_LAYERS; i_layer++) {
     strstrm << "\n";
-    for (int i_strip = 0; i_strip < nStrips; i_strip++) {
+    for (int i_strip = 0; i_strip < numHalfStrips_; i_strip++) {
       if (!strip[i_layer][i_strip].empty()) {
         std::vector<int> bx_times = strip[i_layer][i_strip];
         // Dump only the first in time.

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCCathodeLCTProcessor.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCCathodeLCTProcessor.cc
@@ -297,9 +297,9 @@ std::vector<CSCCLCTDigi> CSCCathodeLCTProcessor::run(const CSCComparatorDigiColl
   }
 
   // Get comparator digis in this chamber.
-  bool noDigis = getDigis(compdc);
+  bool hasDigis = getDigis(compdc);
 
-  if (!noDigis) {
+  if (hasDigis) {
     // Get halfstrip times from comparator digis.
     std::vector<int> halfstrip[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS_7CFEBS];
     readComparatorDigis(halfstrip);
@@ -404,7 +404,7 @@ void CSCCathodeLCTProcessor::run(
 }
 
 bool CSCCathodeLCTProcessor::getDigis(const CSCComparatorDigiCollection* compdc) {
-  bool noDigis = true;
+  bool hasDigis = false;
 
   // Loop over layers and save comparator digis on each one into digiV[layer].
   for (int i_layer = 0; i_layer < CSCConstants::NUM_LAYERS; i_layer++) {
@@ -419,7 +419,7 @@ bool CSCCathodeLCTProcessor::getDigis(const CSCComparatorDigiCollection* compdc)
     }
 
     if (!digiV[i_layer].empty()) {
-      noDigis = false;
+      hasDigis = true;
       if (infoV > 1) {
         LogTrace("CSCCathodeLCTProcessor") << "found " << digiV[i_layer].size() << " comparator digi(s) in layer "
                                            << i_layer << " of " << detid.chamberName() << " (trig. sector " << theSector
@@ -428,7 +428,7 @@ bool CSCCathodeLCTProcessor::getDigis(const CSCComparatorDigiCollection* compdc)
     }
   }
 
-  return noDigis;
+  return hasDigis;
 }
 
 void CSCCathodeLCTProcessor::getDigis(const CSCComparatorDigiCollection* compdc, const CSCDetId& id) {

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCUpgradeCathodeLCTProcessor.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCUpgradeCathodeLCTProcessor.cc
@@ -45,9 +45,6 @@ bool CSCUpgradeCathodeLCTProcessor::preTrigger(const PulseArray pulse, const int
     LogTrace("CSCUpgradeCathodeLCTProcessor")
         << "....................PreTrigger, Phase2 version with localized dead time zone...........................";
 
-  // Max. number of half-strips for this chamber.
-  const int nStrips = 2 * numStrips + 1;
-
   int nPreTriggers = 0;
 
   bool pre_trig = false;
@@ -63,9 +60,9 @@ bool CSCUpgradeCathodeLCTProcessor::preTrigger(const PulseArray pulse, const int
     std::map<int, std::map<int, CSCCLCTDigi::ComparatorContainer> > hits_in_patterns;
     hits_in_patterns.clear();
 
-    bool hits_in_time = patternFinding(pulse, nStrips, bx_time, hits_in_patterns);
+    bool hits_in_time = patternFinding(pulse, bx_time, hits_in_patterns);
     if (hits_in_time) {
-      for (int hstrip = stagger[CSCConstants::KEY_CLCT_LAYER - 1]; hstrip < nStrips; hstrip++) {
+      for (int hstrip = stagger[CSCConstants::KEY_CLCT_LAYER - 1]; hstrip < numHalfStrips_; hstrip++) {
         if (infoV > 1) {
           if (nhits[hstrip] > 0) {
             LogTrace("CSCUpgradeCathodeLCTProcessor")
@@ -102,14 +99,14 @@ bool CSCUpgradeCathodeLCTProcessor::preTrigger(const PulseArray pulse, const int
       }  // find all pretriggers
 
       //update dead zone
-      for (int hstrip = stagger[CSCConstants::KEY_CLCT_LAYER - 1]; hstrip < nStrips; hstrip++) {
+      for (int hstrip = stagger[CSCConstants::KEY_CLCT_LAYER - 1]; hstrip < numHalfStrips_; hstrip++) {
         if (ispretrig[hstrip]) {
           int min_hstrip = hstrip - delta_hs;  //only fixed localized dead time zone is implemented
           int max_hstrip = hstrip + delta_hs;
           if (min_hstrip < stagger[CSCConstants::KEY_CLCT_LAYER - 1])
             min_hstrip = stagger[CSCConstants::KEY_CLCT_LAYER - 1];
-          if (max_hstrip >= nStrips)
-            max_hstrip = nStrips - 1;
+          if (max_hstrip >= numHalfStrips_)
+            max_hstrip = numHalfStrips_ - 1;
           for (int hs = min_hstrip; hs <= max_hstrip; hs++)
             busyMap[hs][bx_time + 1] = true;
           if (infoV > 1)
@@ -123,7 +120,7 @@ bool CSCUpgradeCathodeLCTProcessor::preTrigger(const PulseArray pulse, const int
         return true;
       }
     } else  //no pattern found, remove all dead time zone
-      for (int hstrip = stagger[CSCConstants::KEY_CLCT_LAYER - 1]; hstrip < nStrips; hstrip++) {
+      for (int hstrip = stagger[CSCConstants::KEY_CLCT_LAYER - 1]; hstrip < numHalfStrips_; hstrip++) {
         if (ispretrig[hstrip])
           ispretrig[hstrip] = false;  //dead zone is gone by default
       }
@@ -146,16 +143,13 @@ std::vector<CSCCLCTDigi> CSCUpgradeCathodeLCTProcessor::findLCTs(
 
   std::vector<CSCCLCTDigi> lctList;
 
-  // Max. number of half-strips for this chamber.
-  const int maxHalfStrips = 2 * numStrips + 1;
-
   // initialize the ispretrig before doing pretriggering
-  for (int hstrip = stagger[CSCConstants::KEY_CLCT_LAYER - 1]; hstrip < maxHalfStrips; hstrip++) {
+  for (int hstrip = stagger[CSCConstants::KEY_CLCT_LAYER - 1]; hstrip < numHalfStrips_; hstrip++) {
     ispretrig[hstrip] = false;
   }
 
   if (infoV > 1)
-    dumpDigis(halfstrip, maxHalfStrips);
+    dumpDigis(halfstrip);
 
   // keeps dead-time zones around key halfstrips of triggered CLCTs
   for (int i = 0; i < CSCConstants::NUM_HALF_STRIPS_7CFEBS; i++) {
@@ -169,7 +163,7 @@ std::vector<CSCCLCTDigi> CSCUpgradeCathodeLCTProcessor::findLCTs(
   unsigned int pulse[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS_7CFEBS];
 
   // Fire half-strip one-shots for hit_persist bx's (4 bx's by default).
-  pulseExtension(halfstrip, maxHalfStrips, pulse);
+  pulseExtension(halfstrip, pulse);
 
   unsigned int start_bx = start_bx_shift;
   // Stop drift_delay bx's short of fifo_tbins since at later bx's we will
@@ -198,10 +192,10 @@ std::vector<CSCCLCTDigi> CSCUpgradeCathodeLCTProcessor::findLCTs(
       std::map<int, std::map<int, CSCCLCTDigi::ComparatorContainer> > hits_in_patterns;
       hits_in_patterns.clear();
 
-      bool hits_in_time = patternFinding(pulse, maxHalfStrips, latch_bx, hits_in_patterns);
+      bool hits_in_time = patternFinding(pulse, latch_bx, hits_in_patterns);
       if (infoV > 1) {
         if (hits_in_time) {
-          for (int hstrip = stagger[CSCConstants::KEY_CLCT_LAYER - 1]; hstrip < maxHalfStrips; hstrip++) {
+          for (int hstrip = stagger[CSCConstants::KEY_CLCT_LAYER - 1]; hstrip < numHalfStrips_; hstrip++) {
             if (nhits[hstrip] > 0) {
               LogTrace("CSCUpgradeCathodeLCTProcessor")
                   << " bx = " << std::setw(2) << latch_bx << " --->"
@@ -248,7 +242,7 @@ std::vector<CSCCLCTDigi> CSCUpgradeCathodeLCTProcessor::findLCTs(
           }
         }
 
-        for (int hstrip = stagger[CSCConstants::KEY_CLCT_LAYER - 1]; hstrip < maxHalfStrips; hstrip++) {
+        for (int hstrip = stagger[CSCConstants::KEY_CLCT_LAYER - 1]; hstrip < numHalfStrips_; hstrip++) {
           // The bend-direction bit pid[0] is ignored (left and right bends have equal quality).
           quality[hstrip] = (best_pid[hstrip] & 14) | (nhits[hstrip] << 5);
           // do not consider halfstrips:
@@ -274,7 +268,7 @@ std::vector<CSCCLCTDigi> CSCUpgradeCathodeLCTProcessor::findLCTs(
         // Mark keys near best CLCT as busy by setting their quality to zero, and repeat the search.
         markBusyKeys(best_halfstrip[0], best_pid[best_halfstrip[0]], quality);
 
-        for (int hstrip = stagger[CSCConstants::KEY_CLCT_LAYER - 1]; hstrip < maxHalfStrips; hstrip++) {
+        for (int hstrip = stagger[CSCConstants::KEY_CLCT_LAYER - 1]; hstrip < numHalfStrips_; hstrip++) {
           if (quality[hstrip] > best_quality[1] && pretrig_zone[hstrip] && !busyMap[hstrip][first_bx])
           //!busyMap[hstrip][latch_bx] )
           {


### PR DESCRIPTION
#### PR description:

* It was reported that the Run-3 CCLUT trigger primitive algorithm shows weird behavior for CSC CLCTs when the key half-strip is on the edge of a (D)CFEB (key half-strip is 0 or 31). This PR fixes that. If a CLCT is on the edge, the (D)CFEB number is changed when the CCLUT-corrected half-strip crosses the (D)CFEB boundary.
* In addition, 3 class members are added to store the number of strips, half-strips and (D)CFEBs for a chamber.
* I also changed `bool noDigis` (which is used as a double-negative)  to `bool hasDigis`. 

#### PR validation:

Tested on a 10 GeV prompt muon sample produced with 11_0_X.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)

@tahuang1991 @msd14