### PR TITLE
remove LumiProducer from RecoTLR

### DIFF
--- a/Configuration/DataProcessing/python/RecoTLR.py
+++ b/Configuration/DataProcessing/python/RecoTLR.py
@@ -9,17 +9,6 @@ def _swapOfflineBSwithOnline(process):
     process.offlineBeamSpot = onlineBeamSpotProducer.clone()
     return process
 
-def _addLumiProducer(process):
-    if not hasattr(process,'lumiProducer'):
-        #unscheduled.. 
-        from RecoLuminosity.LumiProducer.lumiProducer_cff import lumiProducer,LumiDBService
-        process.lumiProducer=lumiProducer
-    #if it's scheduled
-    if hasattr(process, 'reconstruction_step'):
-        process.reconstruction_step+=process.lumiProducer
-
-    return process
-
 def _overridesFor50ns(process):
     process.bunchSpacingProducer.bunchSpacingOverride = cms.uint32(50)
     process.bunchSpacingProducer.overrideBunchSpacing = cms.bool(True)
@@ -150,7 +139,6 @@ def customiseExpress(process):
 ##############################################################################
 def customisePrompt(process):
     process= customisePPData(process)
-    process = _addLumiProducer(process)
 
     return process
 
@@ -171,8 +159,6 @@ def customiseExpressHI(process):
 ##############################################################################
 def customisePromptHI(process):
     process = customiseCommonHI(process)
-
-    process = _addLumiProducer(process)
 
     return process
 


### PR DESCRIPTION
#### PR description:

As pointed out in https://github.com/cms-sw/cmssw/issues/25090#issuecomment-804434335, the outdated LumiProducer that prevents concurrent lumi processing was not completely disabled in https://github.com/cms-sw/cmssw/pull/33024. I removed it now also from the RecoTLR config, and a grep does not reveal any other reco sequences where `lumiProducer_cff` is used.

#### PR validation:

The workflow 1000.0 no longer runs the LumiProducer.

FYI @gkrintir @makortel