### PR TITLE
Fix lostTracks producer not setting lostInnerHits

### DIFF
--- a/PhysicsTools/PatAlgos/plugins/PATLostTracks.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATLostTracks.cc
@@ -68,6 +68,7 @@ namespace pat {
     const double maxDxyForNotReconstructedPrimary_;
     const double maxDxySigForNotReconstructedPrimary_;
     const bool useLegacySetup_;
+    const bool fillLostInnerHits_;
   };
 }  // namespace pat
 
@@ -100,7 +101,8 @@ pat::PATLostTracks::PATLostTracks(const edm::ParameterSet& iConfig)
                                             .getParameter<double>("maxDxyForNotReconstructedPrimary")),
       maxDxySigForNotReconstructedPrimary_(iConfig.getParameter<edm::ParameterSet>("pvAssignment")
                                                .getParameter<double>("maxDxySigForNotReconstructedPrimary")),
-      useLegacySetup_(iConfig.getParameter<bool>("useLegacySetup")) {
+      useLegacySetup_(iConfig.getParameter<bool>("useLegacySetup")),
+      fillLostInnerHits_(iConfig.getParameter<bool>("fillLostInnerHits")) {
   std::vector<std::string> trkQuals(iConfig.getParameter<std::vector<std::string>>("qualsToAutoAccept"));
   std::transform(
       trkQuals.begin(), trkQuals.end(), std::back_inserter(qualsToAutoAccept_), reco::TrackBase::qualityByName);
@@ -273,23 +275,25 @@ void pat::PATLostTracks::addPackedCandidate(std::vector<pat::PackedCandidate>& c
     }
   }
 
-  pat::PackedCandidate::LostInnerHits lostHits = pat::PackedCandidate::noLostInnerHits;
-  int nlost = trk->hitPattern().numberOfLostHits(reco::HitPattern::MISSING_INNER_HITS);
-  if (nlost == 0) {
-    if (trk->hitPattern().hasValidHitInPixelLayer(PixelSubdetector::SubDetector::PixelBarrel, 1)) {
-      lostHits = pat::PackedCandidate::validHitInFirstPixelBarrelLayer;
-    }
-  } else {
-    lostHits = (nlost == 1 ? pat::PackedCandidate::oneLostInnerHit : pat::PackedCandidate::moreLostInnerHits);
-  }
-
   reco::Candidate::PolarLorentzVector p4(trk->pt(), trk->eta(), trk->phi(), mass);
   cands.emplace_back(
       pat::PackedCandidate(p4, trk->vertex(), trk->pt(), trk->eta(), trk->phi(), id, pvSlimmedColl, pvSlimmed.key()));
 
+  if (fillLostInnerHits_) {
+    pat::PackedCandidate::LostInnerHits lostHits = pat::PackedCandidate::noLostInnerHits;
+    int nlost = trk->hitPattern().numberOfLostHits(reco::HitPattern::MISSING_INNER_HITS);
+    if (nlost == 0) {
+      if (trk->hitPattern().hasValidHitInPixelLayer(PixelSubdetector::SubDetector::PixelBarrel, 1)) {
+        lostHits = pat::PackedCandidate::validHitInFirstPixelBarrelLayer;
+      }
+    } else {
+      lostHits = (nlost == 1 ? pat::PackedCandidate::oneLostInnerHit : pat::PackedCandidate::moreLostInnerHits);
+    }
+    cands.back().setLostInnerHits(lostHits);
+  }
+
   cands.back().setTrackHighPurity(trk->quality(reco::TrackBase::highPurity));
 
-  cands.back().setLostInnerHits(lostHits);
   if (trk->pt() > minPtToStoreProps_ || trkStatus == TrkStatus::VTX) {
     if (useLegacySetup_ || std::abs(id) == 11 || trkStatus == TrkStatus::VTX) {
       cands.back().setTrackProperties(*trk, covariancePackingSchemas_[4], covarianceVersion_);

--- a/PhysicsTools/PatAlgos/plugins/PATLostTracks.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATLostTracks.cc
@@ -273,12 +273,23 @@ void pat::PATLostTracks::addPackedCandidate(std::vector<pat::PackedCandidate>& c
     }
   }
 
+  pat::PackedCandidate::LostInnerHits lostHits = pat::PackedCandidate::noLostInnerHits;
+  int nlost = trk->hitPattern().numberOfLostHits(reco::HitPattern::MISSING_INNER_HITS);
+  if (nlost == 0) {
+    if (trk->hitPattern().hasValidHitInPixelLayer(PixelSubdetector::SubDetector::PixelBarrel, 1)) {
+      lostHits = pat::PackedCandidate::validHitInFirstPixelBarrelLayer;
+    }
+  } else {
+    lostHits = (nlost == 1 ? pat::PackedCandidate::oneLostInnerHit : pat::PackedCandidate::moreLostInnerHits);
+  }
+
   reco::Candidate::PolarLorentzVector p4(trk->pt(), trk->eta(), trk->phi(), mass);
   cands.emplace_back(
       pat::PackedCandidate(p4, trk->vertex(), trk->pt(), trk->eta(), trk->phi(), id, pvSlimmedColl, pvSlimmed.key()));
 
   cands.back().setTrackHighPurity(trk->quality(reco::TrackBase::highPurity));
 
+  cands.back().setLostInnerHits(lostHits);
   if (trk->pt() > minPtToStoreProps_ || trkStatus == TrkStatus::VTX) {
     if (useLegacySetup_ || std::abs(id) == 11 || trkStatus == TrkStatus::VTX) {
       cands.back().setTrackProperties(*trk, covariancePackingSchemas_[4], covarianceVersion_);

--- a/PhysicsTools/PatAlgos/python/slimming/lostTracks_cfi.py
+++ b/PhysicsTools/PatAlgos/python/slimming/lostTracks_cfi.py
@@ -22,11 +22,15 @@ lostTracks = cms.EDProducer("PATLostTracks",
     passThroughCut = cms.string("0"),
     allowMuonId = cms.bool(False),
     pvAssignment = primaryVertexAssociation.assignment,
-    useLegacySetup = cms.bool(True)
+    useLegacySetup = cms.bool(True),
+    fillLostInnerHits = cms.bool(False)
 )
 from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
 phase1Pixel.toModify(lostTracks, covarianceVersion =1 )
 
 from Configuration.ProcessModifiers.run2_miniAOD_UL_cff import run2_miniAOD_UL
 run2_miniAOD_UL.toModify(lostTracks, passThroughCut="pt>2", allowMuonId=True, useLegacySetup=False)
+
+from Configuration.Eras.Modifier_bParking_cff import bParking
+bParking.toModify(lostTracks, fillLostInnerHits = True)
 


### PR DESCRIPTION
#### PR description:

The lostTracks producer has a bug that leaves the `lostInnerHits` of the `PackedCandidate` unset (and thus at its default value of `validHitInFirstPixelBarrelLayer`). Other than in `lostInnerHits` the bug propagates in the number of valid pixel hits and the number of pixel and tracker layers with measurements in the `HitPattern` of the `bestTrack` of the candidate.

This PR fixes the bug by adding the call to `setLostInnerHits` as the code from the `packedPFCandidates` producer does. This fix has been checked running the workflow 136.8311 and the issue was solved (see attached figures in the PR on master).

#### PR validation:

This PR has been validated with `runTheMatrix.py -l limited -i all --ibeos` and all checks are ok.
The final output is
```
35 34 33 25 12 2 1 1 1 tests passed, 0 0 0 0 0 0 0 0 0 failed
```
In particular the DQM output of 136.8311 shows the differences which are expected: inside `Tracking/PackedCandidate/lostTracks`, in `diffLostInnerHits`, `diffHitPatternNumberOfLostPixelHits`, `diffHitPatternHasValidHitInFirstPixelBarrel`, `diffHitPatternNumberOfValidPixelHits`, `diffHitPatternPixelLayersWithMeasurement`, `diffHitPatternTrackerLayersWithMeasurement`, see the attached plots in the PR on master.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This PR is a backport of #32814, needed for BParking reprocessing.
