### PR TITLE
GPU pixel local reconstruction: make the pixel cluster thresholds configurable

### DIFF
--- a/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelClusterThresholds.h
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelClusterThresholds.h
@@ -1,0 +1,12 @@
+#ifndef RecoLocalTracker_SiPixelClusterizer_plugins_SiPixelClusterThresholds_h
+#define RecoLocalTracker_SiPixelClusterizer_plugins_SiPixelClusterThresholds_h
+
+struct SiPixelClusterThresholds {
+  inline constexpr int32_t getThresholdForLayerOnCondition(bool isLayer1) const noexcept {
+    return isLayer1 ? layer1 : otherLayers;
+  }
+  const int32_t layer1;
+  const int32_t otherLayers;
+};
+
+#endif  // RecoLocalTracker_SiPixelClusterizer_plugins_SiPixelClusterThresholds_h

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelClusterThresholds.h
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelClusterThresholds.h
@@ -9,4 +9,6 @@ struct SiPixelClusterThresholds {
   const int32_t otherLayers;
 };
 
+constexpr SiPixelClusterThresholds kSiPixelClusterThresholdsDefaultPhase1{.layer1 = 2000, .otherLayers = 4000};
+
 #endif  // RecoLocalTracker_SiPixelClusterizer_plugins_SiPixelClusterThresholds_h

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelDigisClustersFromSoA.cc
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelDigisClustersFromSoA.cc
@@ -15,7 +15,10 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "Geometry/Records/interface/TrackerTopologyRcd.h"
-#include "RecoLocalTracker/SiPixelClusterizer/plugins/PixelClusterizerBase.h"
+
+// local include(s)
+#include "PixelClusterizerBase.h"
+#include "SiPixelClusterThresholds.h"
 
 class SiPixelDigisClustersFromSoA : public edm::global::EDProducer<> {
 public:
@@ -33,17 +36,23 @@ private:
 
   edm::EDPutTokenT<edm::DetSetVector<PixelDigi>> digiPutToken_;
   edm::EDPutTokenT<SiPixelClusterCollectionNew> clusterPutToken_;
+
+  const SiPixelClusterThresholds clusterThresholds_;  // Cluster threshold in electrons
 };
 
 SiPixelDigisClustersFromSoA::SiPixelDigisClustersFromSoA(const edm::ParameterSet& iConfig)
     : topoToken_(esConsumes()),
       digiGetToken_(consumes<SiPixelDigisSoA>(iConfig.getParameter<edm::InputTag>("src"))),
       digiPutToken_(produces<edm::DetSetVector<PixelDigi>>()),
-      clusterPutToken_(produces<SiPixelClusterCollectionNew>()) {}
+      clusterPutToken_(produces<SiPixelClusterCollectionNew>()),
+      clusterThresholds_{iConfig.getParameter<int>("clusterThreshold_layer1"),
+                         iConfig.getParameter<int>("clusterThreshold_otherLayers")} {}
 
 void SiPixelDigisClustersFromSoA::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
   desc.add<edm::InputTag>("src", edm::InputTag("siPixelDigisSoA"));
+  desc.add<int>("clusterThreshold_layer1", 2000);
+  desc.add<int>("clusterThreshold_otherLayers", 4000);
   descriptions.addWithDefaultLabel(desc);
 }
 
@@ -77,7 +86,7 @@ void SiPixelDigisClustersFromSoA::produce(edm::StreamID, edm::Event& iEvent, con
       return;  // this in reality should never happen
     edmNew::DetSetVector<SiPixelCluster>::FastFiller spc(*outputClusters, detId);
     auto layer = (DetId(detId).subdetId() == 1) ? ttopo.pxbLayer(detId) : 0;
-    auto clusterThreshold = (layer == 1) ? 2000 : 4000;
+    auto clusterThreshold = clusterThresholds_.getThresholdForLayerOnCondition(layer == 1);
     for (int32_t ic = 0; ic < nclus + 1; ++ic) {
       auto const& acluster = aclusters[ic];
       // in any case we cannot  go out of sync with gpu...

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelDigisClustersFromSoA.cc
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelDigisClustersFromSoA.cc
@@ -51,8 +51,8 @@ SiPixelDigisClustersFromSoA::SiPixelDigisClustersFromSoA(const edm::ParameterSet
 void SiPixelDigisClustersFromSoA::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
   desc.add<edm::InputTag>("src", edm::InputTag("siPixelDigisSoA"));
-  desc.add<int>("clusterThreshold_layer1", 2000);
-  desc.add<int>("clusterThreshold_otherLayers", 4000);
+  desc.add<int>("clusterThreshold_layer1", kSiPixelClusterThresholdsDefaultPhase1.layer1);
+  desc.add<int>("clusterThreshold_otherLayers", kSiPixelClusterThresholdsDefaultPhase1.otherLayers);
   descriptions.addWithDefaultLabel(desc);
 }
 

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelRawToClusterCUDA.cc
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelRawToClusterCUDA.cc
@@ -114,8 +114,8 @@ void SiPixelRawToClusterCUDA::fillDescriptions(edm::ConfigurationDescriptions& d
   desc.add<bool>("isRun2", true);
   desc.add<bool>("IncludeErrors", true);
   desc.add<bool>("UseQualityInfo", false);
-  desc.add<int32_t>("clusterThreshold_layer1", 2000);
-  desc.add<int32_t>("clusterThreshold_otherLayers", 4000);
+  desc.add<int32_t>("clusterThreshold_layer1", kSiPixelClusterThresholdsDefaultPhase1.layer1);
+  desc.add<int32_t>("clusterThreshold_otherLayers", kSiPixelClusterThresholdsDefaultPhase1.otherLayers);
   desc.add<edm::InputTag>("InputLabel", edm::InputTag("rawDataCollector"));
   {
     edm::ParameterSetDescription psd0;

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelRawToClusterCUDA.cc
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelRawToClusterCUDA.cc
@@ -37,6 +37,7 @@
 #include "RecoTracker/Record/interface/CkfComponentsRecord.h"
 
 // local includes
+#include "SiPixelClusterThresholds.h"
 #include "SiPixelRawToClusterGPUKernel.h"
 
 class SiPixelRawToClusterCUDA : public edm::stream::EDProducer<edm::ExternalWork> {
@@ -77,6 +78,7 @@ private:
   const bool isRun2_;
   const bool includeErrors_;
   const bool useQuality_;
+  const SiPixelClusterThresholds clusterThresholds_;
 };
 
 SiPixelRawToClusterCUDA::SiPixelRawToClusterCUDA(const edm::ParameterSet& iConfig)
@@ -89,7 +91,9 @@ SiPixelRawToClusterCUDA::SiPixelRawToClusterCUDA(const edm::ParameterSet& iConfi
           edm::ESInputTag("", iConfig.getParameter<std::string>("CablingMapLabel")))),
       isRun2_(iConfig.getParameter<bool>("isRun2")),
       includeErrors_(iConfig.getParameter<bool>("IncludeErrors")),
-      useQuality_(iConfig.getParameter<bool>("UseQualityInfo")) {
+      useQuality_(iConfig.getParameter<bool>("UseQualityInfo")),
+      clusterThresholds_{iConfig.getParameter<int32_t>("clusterThreshold_layer1"),
+                         iConfig.getParameter<int32_t>("clusterThreshold_otherLayers")} {
   if (includeErrors_) {
     digiErrorPutToken_ = produces<cms::cuda::Product<SiPixelDigiErrorsCUDA>>();
   }
@@ -110,6 +114,8 @@ void SiPixelRawToClusterCUDA::fillDescriptions(edm::ConfigurationDescriptions& d
   desc.add<bool>("isRun2", true);
   desc.add<bool>("IncludeErrors", true);
   desc.add<bool>("UseQualityInfo", false);
+  desc.add<int32_t>("clusterThreshold_layer1", 2000);
+  desc.add<int32_t>("clusterThreshold_otherLayers", 4000);
   desc.add<edm::InputTag>("InputLabel", edm::InputTag("rawDataCollector"));
   {
     edm::ParameterSetDescription psd0;
@@ -231,6 +237,7 @@ void SiPixelRawToClusterCUDA::acquire(const edm::Event& iEvent,
   }  // end of for loop
 
   gpuAlgo_.makeClustersAsync(isRun2_,
+                             clusterThresholds_,
                              gpuMap,
                              gpuModulesToUnpack,
                              gpuGains,

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelRawToClusterGPUKernel.cu
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelRawToClusterGPUKernel.cu
@@ -510,6 +510,7 @@ namespace pixelgpudetails {
 
   // Interface to outside
   void SiPixelRawToClusterGPUKernel::makeClustersAsync(bool isRun2,
+                                                       const SiPixelClusterThresholds clusterThresholds,
                                                        const SiPixelROCsStatusAndMapping *cablingMap,
                                                        const unsigned char *modToUnp,
                                                        const SiPixelGainForHLTonGPU *gains,
@@ -635,7 +636,8 @@ namespace pixelgpudetails {
 #endif
 
       // apply charge cut
-      clusterChargeCut<<<blocks, threadsPerBlock, 0, stream>>>(digis_d.moduleInd(),
+      clusterChargeCut<<<blocks, threadsPerBlock, 0, stream>>>(clusterThresholds,
+                                                               digis_d.moduleInd(),
                                                                digis_d.adc(),
                                                                clusters_d.moduleStart(),
                                                                clusters_d.clusInModule(),

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelRawToClusterGPUKernel.h
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelRawToClusterGPUKernel.h
@@ -14,6 +14,9 @@
 #include "DataFormats/SiPixelRawData/interface/SiPixelErrorCompact.h"
 #include "DataFormats/SiPixelRawData/interface/SiPixelFormatterErrors.h"
 
+// local include(s)
+#include "SiPixelClusterThresholds.h"
+
 struct SiPixelROCsStatusAndMapping;
 class SiPixelGainForHLTonGPU;
 
@@ -170,6 +173,7 @@ namespace pixelgpudetails {
     SiPixelRawToClusterGPUKernel& operator=(SiPixelRawToClusterGPUKernel&&) = delete;
 
     void makeClustersAsync(bool isRun2,
+                           const SiPixelClusterThresholds clusterThresholds,
                            const SiPixelROCsStatusAndMapping* cablingMap,
                            const unsigned char* modToUnp,
                            const SiPixelGainForHLTonGPU* gains,

--- a/RecoLocalTracker/SiPixelClusterizer/test/gpuClustering_t.h
+++ b/RecoLocalTracker/SiPixelClusterizer/test/gpuClustering_t.h
@@ -18,6 +18,7 @@
 
 #include "RecoLocalTracker/SiPixelClusterizer/plugins/gpuClustering.h"
 #include "RecoLocalTracker/SiPixelClusterizer/plugins/gpuClusterChargeCut.h"
+#include "RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelClusterThresholds.h"
 
 int main(void) {
 #ifdef __CUDACC__
@@ -27,6 +28,7 @@ int main(void) {
   using namespace gpuClustering;
 
   constexpr int numElements = 256 * maxNumModules;
+  constexpr SiPixelClusterThresholds clusterThresholds{2000,4000};
 
   // these in reality are already on GPU
   auto h_id = std::make_unique<uint16_t[]>(numElements);
@@ -288,6 +290,7 @@ int main(void) {
 
     cms::cuda::launch(clusterChargeCut,
                       {blocksPerGrid, threadsPerBlock},
+                      clusterThresholds,
                       d_id.get(),
                       d_adc.get(),
                       d_moduleStart.get(),
@@ -317,8 +320,14 @@ int main(void) {
     if (ncl != std::accumulate(nclus, nclus + maxNumModules, 0))
       std::cout << "ERROR!!!!! wrong number of cluster found" << std::endl;
 
-    clusterChargeCut(
-        h_id.get(), h_adc.get(), h_moduleStart.get(), h_clusInModule.get(), h_moduleId.get(), h_clus.get(), n);
+    clusterChargeCut(clusterThresholds,
+                     h_id.get(),
+                     h_adc.get(),
+                     h_moduleStart.get(),
+                     h_clusInModule.get(),
+                     h_moduleId.get(),
+                     h_clus.get(),
+                     n);
 #endif  // __CUDACC__
 
     std::cout << "found " << nModules << " Modules active" << std::endl;

--- a/RecoLocalTracker/SiPixelClusterizer/test/gpuClustering_t.h
+++ b/RecoLocalTracker/SiPixelClusterizer/test/gpuClustering_t.h
@@ -28,7 +28,7 @@ int main(void) {
   using namespace gpuClustering;
 
   constexpr int numElements = 256 * maxNumModules;
-  constexpr SiPixelClusterThresholds clusterThresholds{2000,4000};
+  constexpr SiPixelClusterThresholds clusterThresholds(kSiPixelClusterThresholdsDefaultPhase1);
 
   // these in reality are already on GPU
   auto h_id = std::make_unique<uint16_t[]>(numElements);


### PR DESCRIPTION
#### PR description:

This is an effort towards solving [one of the issues](https://github.com/cms-sw/cmssw/issues/32483#issuecomment-745388762) in #32483.

Hardcoded charge cuts on pixel clusters were used in:  
`RecoLocalTracker/SiPixelClusterizer/plugins/gpuClusterChargeCut.h` and  
`RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelDigisClustersFromSoA.cc`

Since the GPU version uses these thresholds in the free function `gpuClusterChargeCut` nested in the `gpuClustering` namespace, they are propagated through function parameters, passing them by value. They are initially set in the `SiPixelRawToClusterCUDA` class.

The `SiPixelDigisClustersFromSoA` has these parameters as private members (as does the legacy version).

#### PR validation:

These changes should not affect validation results.  
Performance should not be affected.

<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->

#### if this PR is a backport please specify the original PR and why you need to backport that PR: