### PR TITLE
Switch FastTimerService to using a local thread observer

### DIFF
--- a/HLTrigger/Timer/plugins/FastTimerService.cc
+++ b/HLTrigger/Timer/plugins/FastTimerService.cc
@@ -766,7 +766,8 @@ void FastTimerService::PlotsPerJob::fill_lumi(AtomicResources const& data, unsig
 ///////////////////////////////////////////////////////////////////////////////
 
 FastTimerService::FastTimerService(const edm::ParameterSet& config, edm::ActivityRegistry& registry)
-    :  // configuration
+    : tbb::task_scheduler_observer(true),
+      // configuration
       callgraph_(),
       // job configuration
       concurrent_lumis_(0),
@@ -1099,6 +1100,9 @@ void FastTimerService::postSourceLumi(edm::LuminosityBlockIndex index) {
 }
 
 void FastTimerService::postEndJob() {
+  for (auto& thread : threads_) {
+    thread.measure_and_accumulate(overhead_);
+  }
   if (print_job_summary_) {
     edm::LogVerbatim out("FastReport");
     printSummary(out, job_summary_, "Job");
@@ -1662,14 +1666,45 @@ void FastTimerService::postModuleStreamEndLumi(edm::StreamContext const& sc, edm
   thread().measure_and_accumulate(lumi_transition_[index]);
 }
 
+pthread_key_t FastTimerService::ThreadGuard::key;
+pthread_once_t FastTimerService::ThreadGuard::key_once = PTHREAD_ONCE_INIT;
+
+FastTimerService::ThreadGuard::ThreadGuard() {
+  auto err = ::pthread_key_create(&key, reset_thread);
+  if (err) {
+    edm::LogWarning("FastTimerService") << "ThreadGuard key creation failed: " << ::strerror(err);
+  }
+}
+
+bool FastTimerService::ThreadGuard::register_thread(FastTimerService::Measurement& m, FastTimerService::AtomicResources& r) {
+  auto ptr = ::pthread_getspecific(key);
+
+  if (not ptr) {
+    auto p = new specific_t(m, r);
+    auto err = ::pthread_setspecific(key, p);
+    if (err) {
+      edm::LogWarning("FastTimerService") << "ThreadGuard pthread_setspecific failed: " << ::strerror(err);
+    }
+    return true;
+  }
+  return false;
+}
+
+void FastTimerService::ThreadGuard::reset_thread(void* ptr) {
+  auto p = static_cast<specific_t*>(ptr);
+  // account any resources used or freed by the thread before leaving the TBB pool
+  p->first.measure_and_accumulate(p->second);
+  delete p;
+}
+
 void FastTimerService::on_scheduler_entry(bool worker) {
-  // initialise the measurement point for a thread that has newly joining the TBB pool
-  thread().measure();
+  if (guard_.register_thread(thread(), overhead_)) {
+    // initialise the measurement point for a thread that has newly joined the TBB pool
+    thread().measure();
+  }
 }
 
 void FastTimerService::on_scheduler_exit(bool worker) {
-  // account any resources used or freed by the thread before leaving the TBB pool
-  thread().measure_and_accumulate(overhead_);
 }
 
 FastTimerService::Measurement& FastTimerService::thread() { return threads_.local(); }

--- a/HLTrigger/Timer/plugins/FastTimerService.cc
+++ b/HLTrigger/Timer/plugins/FastTimerService.cc
@@ -1717,12 +1717,9 @@ void FastTimerService::on_scheduler_entry(bool worker) {
   }
 }
 
-void FastTimerService::on_scheduler_exit(bool worker) {
-}
+void FastTimerService::on_scheduler_exit(bool worker) {}
 
-FastTimerService::Measurement& FastTimerService::thread() {
-  return guard_.thread();
-}
+FastTimerService::Measurement& FastTimerService::thread() { return guard_.thread(); }
 
 // describe the module's configuration
 void FastTimerService::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {

--- a/HLTrigger/Timer/plugins/FastTimerService.h
+++ b/HLTrigger/Timer/plugins/FastTimerService.h
@@ -464,19 +464,20 @@ private:
 
       Measurement measurement_;
       AtomicResources& resource_;
-      bool live_;
+      std::atomic<bool> live_;
     };
 
     ThreadGuard();
     ~ThreadGuard() = default;
 
     static void retire_thread(void* t);
+    static std::shared_ptr<specific_t>* ptr(void* p);
 
     bool register_thread(FastTimerService::AtomicResources& r);
     Measurement& thread();
     void finalize();
 
-    tbb::concurrent_vector<std::unique_ptr<specific_t>> thread_resources_;
+    tbb::concurrent_vector<std::shared_ptr<specific_t>> thread_resources_;
     pthread_key_t key_;
   };
 


### PR DESCRIPTION
#### PR description:

With the new task_group interfaces, global thread observers cause crashes at the end of the job, and the interface for global thread observers is being removed in the latest versions of TBB.  This PR modifies the FastTimerService to use a local thread observer on the primary framework arena to register threads, and then tracks individual threads using lower level pthreads interfaces instead of the TBB enumerable_thread_specific (which, under the hood, uses the same pthread mechanisms).  In the normal case, this should reproduce the results of the FastTimerService with a global observer and account for any threads that are added to the arena.

#### PR validation:

Tested on one workflow (136.885501) that it produces results consistent with the results with the global thread observer, and doesn't crash on exit.