### PR TITLE
Change binning of TP occupancy vs BX plot and update BX plot descriptions

### DIFF
--- a/DQM/EcalMonitorTasks/interface/TrigPrimTask.h
+++ b/DQM/EcalMonitorTasks/interface/TrigPrimTask.h
@@ -49,8 +49,10 @@ namespace ecaldqm {
     /*     bool HLTCaloBit_; */
     /*     bool HLTMuonBit_; */
 
-    std::array<int, nBXBins + 1> bxBinEdges_;
+    std::vector<int> bxBinEdges_;
+    std::vector<int> bxBinEdgesFine_;
     double bxBin_;
+    double bxBinFine_;
 
     std::map<uint32_t, unsigned> towerReadouts_;
 

--- a/DQM/EcalMonitorTasks/python/TimingTask_cfi.py
+++ b/DQM/EcalMonitorTasks/python/TimingTask_cfi.py
@@ -140,14 +140,14 @@ ecalTimingTask = cms.untracked.PSet(
                 high = cms.untracked.double(1.0*nBXBins),
                 nbins = cms.untracked.int32(nBXBins),
                 low = cms.untracked.double(0.0),
-                title = cms.untracked.string('bunch crossing'),
+                title = cms.untracked.string('BX Id'),
                 labels = cms.untracked.vstring(bxBinLabels)
             ),
             yaxis = cms.untracked.PSet(
                 title = cms.untracked.string('Timing (ns)')
             ),
             btype = cms.untracked.string('User'),
-            description = cms.untracked.string('Average hit timing in the barrel as a function of BX number.')
+            description = cms.untracked.string('Average hit timing in EB as a function of BX number. BX ids start at 1. Only events with energy above 2.02 GeV and chi2 less than 16 are used.')
         ),
         BarrelTimingVsBXFineBinned = cms.untracked.PSet(
             path = cms.untracked.string('EcalBarrel/EBTimingTask/EBTMT Timing vs Finely Binned BX'),
@@ -157,14 +157,14 @@ ecalTimingTask = cms.untracked.PSet(
                 high = cms.untracked.double(1.0*nBXBinsFine),
                 nbins = cms.untracked.int32(nBXBinsFine),
                 low = cms.untracked.double(0.0),
-                title = cms.untracked.string('bunch crossing'),
+                title = cms.untracked.string('BX Id'),
                 labels = cms.untracked.vstring(bxBinLabelsFine)
             ),
             yaxis = cms.untracked.PSet(
                 title = cms.untracked.string('Timing (ns)')
             ),
             btype = cms.untracked.string('User'),
-            description = cms.untracked.string('Average hit timing in the barrel as a finely-binned function of BX number.')
+            description = cms.untracked.string('Average hit timing in EB as a finely binned function of BX number. BX ids start at 1. Only events with energy above 2.02 GeV and chi2 less than 16 are used. The Customize button can be used to zoom in.')
         ),
         TimeAmpBXm = cms.untracked.PSet(
             kind = cms.untracked.string('TH2F'),

--- a/DQM/EcalMonitorTasks/python/TrigPrimTask_cfi.py
+++ b/DQM/EcalMonitorTasks/python/TrigPrimTask_cfi.py
@@ -1,28 +1,35 @@
 import FWCore.ParameterSet.Config as cms
 
 bxBins = [
-    "1",
-    "271",
-    "541",
-    "892",
-    "1162",
-    "1432",
-    "1783",
-    "2053",
-    "2323",
-    "2674",
-    "2944",
-    "3214",
-    "3446",
-    "3490",
-    "3491",
-    "3565"
+    1,
+    271,
+    541,
+    892,
+    1162,
+    1432,
+    1783,
+    2053,
+    2323,
+    2674,
+    2944,
+    3214,
+    3446,
+    3490,
+    3491,
+    3565
 ]
+bxBinLabels = [str(i) for i in bxBins]
+
+bxBinsFine = [i for i in range(1, 3601)]
+bxBinLabelsFine = [str(i) for i in bxBinsFine]
+nBXBinsFine = len(bxBinsFine)
 
 ecalTrigPrimTask = cms.untracked.PSet(
     params = cms.untracked.PSet(
         #    HLTMuonPath = cms.untracked.string('HLT_Mu5_v*'),
         #    HLTCaloPath = cms.untracked.string('HLT_SingleJet*'),
+        bxBins = cms.untracked.vint32(bxBins),
+        bxBinsFine = cms.untracked.vint32(bxBinsFine),
         runOnEmul = cms.untracked.bool(True),
         lhcStatusInfoCollectionTag = cms.untracked.InputTag("tcdsDigis","tcdsRecord")
     ),
@@ -60,14 +67,14 @@ ecalTrigPrimTask = cms.untracked.PSet(
             kind = cms.untracked.string('TProfile'),
             otype = cms.untracked.string('Ecal3P'),
             xaxis = cms.untracked.PSet(
-                high = cms.untracked.double(16.0),
-                nbins = cms.untracked.int32(16),
+                high = cms.untracked.double(1.0*nBXBinsFine),
+                nbins = cms.untracked.int32(nBXBinsFine),
                 low = cms.untracked.double(0.0),
-                title = cms.untracked.string('bunch crossing'),
-                labels = cms.untracked.vstring(bxBins)
+                title = cms.untracked.string('BX Id'),
+                labels = cms.untracked.vstring(bxBinLabelsFine)
             ),
             btype = cms.untracked.string('User'),
-            description = cms.untracked.string('TP occupancy in different bunch crossing intervals. This plot is filled by data from physics data stream. It is normal to have very little entries in BX >= 3490.')
+            description = cms.untracked.string('TP occupancy in different bunch crossing intervals. This plot is filled by data from physics data stream. BX ids start at 1. It is normal to have very little entries in BX >= 3490. The Customize button can be used to zoom in.')
         ),
         HighIntMap = cms.untracked.PSet(
             path = cms.untracked.string('%(subdet)s/%(prefix)sSelectiveReadoutTask/Counters/%(prefix)sSRT tower high interest counter%(suffix)s'),
@@ -85,13 +92,13 @@ ecalTrigPrimTask = cms.untracked.PSet(
                 high = cms.untracked.double(16.0),
                 nbins = cms.untracked.int32(16),
                 low = cms.untracked.double(0.0),
-                title = cms.untracked.string('bunch crossing'),
-                labels = cms.untracked.vstring(bxBins)
+                title = cms.untracked.string('BX Id'),
+                labels = cms.untracked.vstring(bxBinLabels)
             ),
             yaxis = cms.untracked.PSet(
                 title = cms.untracked.string('TP Et')
             ),
-            description = cms.untracked.string('Mean TP Et in different bunch crossing intervals. This plot is filled by data from physics data stream. It is normal to have very little entries in BX >= 3490.')
+            description = cms.untracked.string('Mean TP Et in different bunch crossing intervals. This plot is filled by data from physics data stream. BX ids start at 1. It is normal to have very little entries in BX >= 3490.')
         ),
         EtEmulError = cms.untracked.PSet(
 #            path = cms.untracked.string('Ecal/Errors/TriggerPrimitives/EtEmulation/'),

--- a/DQM/EcalMonitorTasks/src/TrigPrimTask.cc
+++ b/DQM/EcalMonitorTasks/src/TrigPrimTask.cc
@@ -21,8 +21,10 @@ namespace ecaldqm {
         //     HLTMuonPath_(""),
         //     HLTCaloBit_(false),
         //     HLTMuonBit_(false),
-        bxBinEdges_{{1, 271, 541, 892, 1162, 1432, 1783, 2053, 2323, 2674, 2944, 3214, 3446, 3490, 3491, 3565}},
+        bxBinEdges_(),
+        bxBinEdgesFine_(),
         bxBin_(0.),
+        bxBinFine_(0.),
         towerReadouts_(),
         lhcStatusInfoCollectionTag_() {}
 
@@ -38,6 +40,8 @@ namespace ecaldqm {
     }
     lhcStatusInfoCollectionTag_ = _params.getUntrackedParameter<edm::InputTag>(
         "lhcStatusInfoCollectionTag", edm::InputTag("tcdsDigis", "tcdsRecord"));
+    bxBinEdges_ = _params.getUntrackedParameter<std::vector<int> >("bxBins");
+    bxBinEdgesFine_ = _params.getUntrackedParameter<std::vector<int> >("bxBinsFine");
   }
 
   void TrigPrimTask::addDependencies(DependencySet& _dependencies) {
@@ -83,8 +87,11 @@ namespace ecaldqm {
     //     HLTCaloBit_ = false;
     //     HLTMuonBit_ = false;
 
-    int* pBin(std::upper_bound(bxBinEdges_.begin(), bxBinEdges_.end(), _evt.bunchCrossing()));
+    std::vector<int>::iterator pBin(std::upper_bound(bxBinEdges_.begin(), bxBinEdges_.end(), _evt.bunchCrossing()));
     bxBin_ = static_cast<int>(pBin - bxBinEdges_.begin()) - 0.5;
+    // fine binning for TP Occ vs BX plot as requested by DAQ in March 2021
+    std::vector<int>::iterator pBinFine(std::upper_bound(bxBinEdgesFine_.begin(), bxBinEdgesFine_.end(), _evt.bunchCrossing()));
+    bxBinFine_ = static_cast<int>(pBinFine - bxBinEdgesFine_.begin()) - 0.5;
 
     edm::ESHandle<EcalTPGTowerStatus> TTStatusRcd_;
     _es.get<EcalTPGTowerStatusRcd>().get(TTStatusRcd_);
@@ -251,9 +258,9 @@ namespace ecaldqm {
         meTTFMismatch.fill(getEcalDQMSetupObjects(), ttid);
     }
 
-    meOccVsBx.fill(getEcalDQMSetupObjects(), EcalBarrel, bxBin_, nTP[0]);
-    meOccVsBx.fill(getEcalDQMSetupObjects(), -EcalEndcap, bxBin_, nTP[1]);
-    meOccVsBx.fill(getEcalDQMSetupObjects(), EcalEndcap, bxBin_, nTP[2]);
+    meOccVsBx.fill(getEcalDQMSetupObjects(), EcalBarrel, bxBinFine_, nTP[0]);
+    meOccVsBx.fill(getEcalDQMSetupObjects(), -EcalEndcap, bxBinFine_, nTP[1]);
+    meOccVsBx.fill(getEcalDQMSetupObjects(), EcalEndcap, bxBinFine_, nTP[2]);
 
     // Set TT/Strip Masking status in Ecal3P view
     // Status Records are read-in at beginRun() but filled here

--- a/DQM/EcalMonitorTasks/src/TrigPrimTask.cc
+++ b/DQM/EcalMonitorTasks/src/TrigPrimTask.cc
@@ -90,7 +90,8 @@ namespace ecaldqm {
     std::vector<int>::iterator pBin(std::upper_bound(bxBinEdges_.begin(), bxBinEdges_.end(), _evt.bunchCrossing()));
     bxBin_ = static_cast<int>(pBin - bxBinEdges_.begin()) - 0.5;
     // fine binning for TP Occ vs BX plot as requested by DAQ in March 2021
-    std::vector<int>::iterator pBinFine(std::upper_bound(bxBinEdgesFine_.begin(), bxBinEdgesFine_.end(), _evt.bunchCrossing()));
+    std::vector<int>::iterator pBinFine(
+        std::upper_bound(bxBinEdgesFine_.begin(), bxBinEdgesFine_.end(), _evt.bunchCrossing()));
     bxBinFine_ = static_cast<int>(pBinFine - bxBinEdgesFine_.begin()) - 0.5;
 
     edm::ESHandle<EcalTPGTowerStatus> TTStatusRcd_;


### PR DESCRIPTION
#### PR description:

This PR is fulfilling a request from ECAL DAQ to change the binning in the TP occupancy vs BX plot to have finer BX bins. The new binning is by BX rather than by groups of BXs, similar to the Timing vs BX finely binned plot used in Offline DQM. This leads to the new plot to be quite busy with many bins, but the expectation is that DAQ experts will zoom in on the x-axis using the Customize button on the DQM GUI to study their region of interest.

Slight modifications were made to the TrigPrimTask module so the way the BX binning is done more closely matches what is done in the TimingTask module, which also contain some “vs BX” plots. Some plot descriptions were also updated to mention relevant information for these plots, such as the BX ids starting at 1, as well as a minor relabelling of the x-axis. 

#### PR validation:

An Online DQM-like workflow was run and the plots were uploaded to a private DQM GUI. We verified with ECAL DAQ that the new binning was to their liking. We also verified that the new BX binning changes did not affect any other plot binned by BX.

#### Backport:

A backport of this PR to CMSSW_11_2_X has been submitted here: https://github.com/cms-sw/cmssw/pull/33275