### PR TITLE
Re-enable ctppsProtons from recoCTPPSTask (Run-3 only)

### DIFF
--- a/RecoPPS/Configuration/python/recoCTPPS_cff.py
+++ b/RecoPPS/Configuration/python/recoCTPPS_cff.py
@@ -20,10 +20,4 @@ recoCTPPSTask = cms.Task(
     ctppsLocalTrackLiteProducer ,
     ctppsProtons
 )
-
-#temporarily remove ctppsProtons in Run-3 (see issue #32340)
-from Configuration.Eras.Modifier_ctpps_2021_cff import ctpps_2021
-_ctpps_2021_recoCTPPSTask = recoCTPPSTask.copyAndExclude([ctppsProtons])
-ctpps_2021.toReplaceWith(recoCTPPSTask, _ctpps_2021_recoCTPPSTask)
-
 recoCTPPS = cms.Sequence(recoCTPPSTask)


### PR DESCRIPTION
After #33090, we are finally testing `GluGluTo2Jets_M_300_2000_14TeV_Exhume` (`11725.0,11925.0`) in the IB tests (#32969). This workflow was added specifically to test the PPS reco (#32765).

Brief summary of the history:
- #32003 has integrated the PPS digi in CMSSW
- this caused the error `No 'LHCInfoRcd' record found in the EventSetup.n` (#32340)
- so we temporary removed ctppsProtons from recoCTPPSTask (Run-3 only) #32352
- if I understand correctly from #32356, the `LHCInfoRcd` has been added in the GT. 
- the new "dynamic conditions" (#32207) will not be used for the time being.

Reverts cms-sw/cmssw#32352

@mundim @fabferro @jan-kaspar @cms-sw/alca-l2 @cms-sw/reconstruction-l2 

PS. The last open pre-release of 11_3_X is scheduled on April 13.