### PR TITLE
Use CMS_USE_AVX2 instead of CMS_USE_AVX

### DIFF
--- a/DataFormats/Math/interface/SSEVec.h
+++ b/DataFormats/Math/interface/SSEVec.h
@@ -6,9 +6,9 @@
 #if defined(__GNUC__)
 #include <x86intrin.h>
 #define CMS_USE_SSE
-#ifdef __AVX__
-#define CMS_USE_AVX
-#endif /* __AVX__ */
+#ifdef __AVX2__
+#define CMS_USE_AVX2
+#endif /* __AVX2__ */
 #endif /* defined(__GNUC__) */
 #endif /* !defined(__arm__) && !defined(__aarch64__) && !defined(__MIC__) */
 
@@ -63,7 +63,7 @@ namespace mathSSE {
   }
 #endif  // CMS_USE_SSE
 
-#ifdef CMS_USE_AVX
+#ifdef CMS_USE_AVX2
   inline __m256d __attribute__((always_inline)) __attribute__((pure)) _mm256_dot_pd(__m256d v1, __m256d v2) {
     __m256d mul = _mm256_mul_pd(v1, v2);
     mul = _mm256_hadd_pd(mul, mul);
@@ -92,7 +92,7 @@ namespace mathSSE {
     return __m256d(_mm256_xor_si256(__m256i(ret), neg));
   }
 
-#endif  //  CMS_USE_AVX
+#endif  //  CMS_USE_AVX2
 
   template <typename T>
   struct OldVec {
@@ -101,7 +101,7 @@ namespace mathSSE {
     T theZ;
     T theW;
   } __attribute__((aligned(16)));
-#ifdef CMS_USE_AVX
+#ifdef CMS_USE_AVX2
   template <>
   struct OldVec<double> {
     double theX;
@@ -235,7 +235,7 @@ namespace mathSSE {
     }
   };
 
-#ifdef CMS_USE_AVX
+#ifdef CMS_USE_AVX2
   template <>
   union Mask4<double> {
     __m256d vec;
@@ -380,7 +380,7 @@ namespace mathSSE {
     double operator[](unsigned int n) const { return arr[n]; }
   };
 
-#ifdef CMS_USE_AVX
+#ifdef CMS_USE_AVX2
 }  // namespace mathSSE
 #include "private/AVXVec.h"
 
@@ -473,7 +473,7 @@ namespace mathSSE {
     __m128 v2 = _mm_cvtpd_ps(ivec.vec[1]);
     vec = _mm_shuffle_ps(vec, v2, _MM_SHUFFLE(1, 0, 1, 0));
   }
-#endif  // CMS_USE_AVX
+#endif  // CMS_USE_AVX2
 
 #endif  // CMS_USE_SSE
 
@@ -602,7 +602,7 @@ inline float cross(mathSSE::Vec2F a, mathSSE::Vec2F b) { return a.arr[0] * b.arr
 //
 
 inline mathSSE::Vec2D::Vec2(Vec4D v4) {
-#ifdef CMS_USE_AVX
+#ifdef CMS_USE_AVX2
   vec = _mm256_castpd256_pd128(v4.vec);
 #else
   vec = v4.vec[0];
@@ -671,7 +671,7 @@ inline double cross(mathSSE::Vec2D a, mathSSE::Vec2D b) {
   return s;
 }
 
-#ifndef CMS_USE_AVX
+#ifndef CMS_USE_AVX2
 // double op 3d
 
 #ifdef __SSE3__
@@ -781,7 +781,7 @@ inline double __attribute__((always_inline)) __attribute__((pure)) dotxy(mathSSE
   return dot(a.xy(), b.xy());
 }
 
-#endif  // CMS_USE_AVX
+#endif  // CMS_USE_AVX2
 
 // sqrt
 namespace mathSSE {
@@ -797,7 +797,7 @@ namespace mathSSE {
   inline Vec2D sqrt(Vec2D v) {
     return _mm_sqrt_pd(v.vec);
   }
-#ifdef CMS_USE_AVX
+#ifdef CMS_USE_AVX2
   template <>
   inline Vec4D sqrt(Vec4D v) {
     return _mm256_sqrt_pd(v.vec);

--- a/DataFormats/Math/test/ExtVec_t.cpp
+++ b/DataFormats/Math/test/ExtVec_t.cpp
@@ -5,9 +5,9 @@
 
 #include <iostream>
 
-#ifdef __AVX__
-#define CMS_USE_AVX
-#endif /* __AVX__ */
+#ifdef __AVX2__
+#define CMS_USE_AVX2
+#endif /* __AVX2__ */
 
 void addScaleddiff(Vec3F& res, float s, Vec3F const& a, Vec3F const& b) { res = res + s * (a - b); }
 
@@ -232,12 +232,12 @@ void go(bool dovec = true) {
 }
 
 int main() {
-#ifdef CMS_USE_AVX
+#ifdef CMS_USE_AVX2
   std::cout << "using AVX" << std::endl;
 #endif
   testBa();
   go<float>();
-#ifdef CMS_USE_AVX
+#ifdef CMS_USE_AVX2
   go<double>(false);
 #else
   go<double>();

--- a/DataFormats/Math/test/SSEVec_t.cpp
+++ b/DataFormats/Math/test/SSEVec_t.cpp
@@ -226,12 +226,12 @@ void go(bool dovect = true) {
 }
 
 int main() {
-#ifdef CMS_USE_AVX
-  std::cout << "using AVX" << std::endl;
+#ifdef CMS_USE_AVX2
+  std::cout << "using AVX2" << std::endl;
 #endif
   testBa();
   go<float>();
-#ifdef CMS_USE_AVX
+#ifdef CMS_USE_AVX2
   go<double>(false);
 #else
   go<double>();

--- a/TrackingTools/AnalyticalJacobians/src/AnalyticalCurvilinearJacobianSSE.icc
+++ b/TrackingTools/AnalyticalJacobians/src/AnalyticalCurvilinearJacobianSSE.icc
@@ -50,7 +50,7 @@ void AnalyticalCurvilinearJacobian::computeFullJacobian(const GlobalTrajectoryPa
   Vec4D tt = t * t;
   tt = mathSSE::sqrt(hadd(tt, tt));
 
-#ifdef CMS_USE_AVX
+#ifdef CMS_USE_AVX2
   const __m256d neg = _mm256_setr_pd(-0.0, 0.0, -0.0, 0.0);
   Vec4D res(_mm256_xor_pd(neg, _mm256_div_pd(_mm256_shuffle_pd(t.vec, t.vec, 5), tt.vec)));
   Vec2D u1(res.xy());


### PR DESCRIPTION
Fixes  https://github.com/cms-sw/cmssw/issues/33267

`SSEVec.h` has code for `AVX2` and does not work when build for `avx` e.g `sandybridge` ( see https://github.com/cms-sw/cmssw/issues/33267). This PR proposes to define `CMS_USE_AVX2` instead of `CMS_USE_AVX` when `__AVX2__` is available. 

This change should not have any effects of normal cmssw builds as we build with `-msse3` however this should fix the `SKYLAKEAVX512` IBs which are now build for `sandybridge,haswell,skylake-avx512`
