### PR TITLE
Technical optimisation of e/gamma (local)covariances function (11_3_X)

### DIFF
--- a/DQMOffline/Ecal/plugins/EcalPileUpDepMonitor.cc
+++ b/DQMOffline/Ecal/plugins/EcalPileUpDepMonitor.cc
@@ -340,7 +340,7 @@ void EcalPileUpDepMonitor::analyze(const edm::Event &e, const edm::EventSetup &)
     const EcalRecHitCollection *eeRecHits = RecHitsEE.product();
 
     reco::BasicCluster const &seedCluster(*itSC->seed());
-    std::vector<float> cov = EcalClusterTools::localCovariances(seedCluster, eeRecHits, p_topology);
+    std::array<float,3> cov = EcalClusterTools::localCovariances(seedCluster, eeRecHits, p_topology);
     float sigmaIetaIeta = std::sqrt(cov[0]);
     float sigmaIetaIphi = cov[1];
 
@@ -383,7 +383,7 @@ void EcalPileUpDepMonitor::analyze(const edm::Event &e, const edm::EventSetup &)
     const EcalRecHitCollection *ebRecHits = RecHitsEB.product();
 
     reco::BasicCluster const &seedCluster(*itSC->seed());
-    std::vector<float> cov = EcalClusterTools::localCovariances(seedCluster, ebRecHits, p_topology);
+    std::array<float,3> cov = EcalClusterTools::localCovariances(seedCluster, ebRecHits, p_topology);
     float sigmaIetaIeta = std::sqrt(cov[0]);
     float sigmaIetaIphi = cov[1];
 

--- a/DQMOffline/Ecal/plugins/EcalPileUpDepMonitor.cc
+++ b/DQMOffline/Ecal/plugins/EcalPileUpDepMonitor.cc
@@ -340,7 +340,7 @@ void EcalPileUpDepMonitor::analyze(const edm::Event &e, const edm::EventSetup &)
     const EcalRecHitCollection *eeRecHits = RecHitsEE.product();
 
     reco::BasicCluster const &seedCluster(*itSC->seed());
-    const auto& cov = EcalClusterTools::localCovariances(seedCluster, eeRecHits, p_topology);
+    const auto &cov = EcalClusterTools::localCovariances(seedCluster, eeRecHits, p_topology);
     float sigmaIetaIeta = std::sqrt(cov[0]);
     float sigmaIetaIphi = cov[1];
 
@@ -383,7 +383,7 @@ void EcalPileUpDepMonitor::analyze(const edm::Event &e, const edm::EventSetup &)
     const EcalRecHitCollection *ebRecHits = RecHitsEB.product();
 
     reco::BasicCluster const &seedCluster(*itSC->seed());
-    const auto& cov = EcalClusterTools::localCovariances(seedCluster, ebRecHits, p_topology);
+    const auto &cov = EcalClusterTools::localCovariances(seedCluster, ebRecHits, p_topology);
     float sigmaIetaIeta = std::sqrt(cov[0]);
     float sigmaIetaIphi = cov[1];
 

--- a/DQMOffline/Ecal/plugins/EcalPileUpDepMonitor.cc
+++ b/DQMOffline/Ecal/plugins/EcalPileUpDepMonitor.cc
@@ -340,7 +340,7 @@ void EcalPileUpDepMonitor::analyze(const edm::Event &e, const edm::EventSetup &)
     const EcalRecHitCollection *eeRecHits = RecHitsEE.product();
 
     reco::BasicCluster const &seedCluster(*itSC->seed());
-    std::array<float, 3> cov = EcalClusterTools::localCovariances(seedCluster, eeRecHits, p_topology);
+    const auto& cov = EcalClusterTools::localCovariances(seedCluster, eeRecHits, p_topology);
     float sigmaIetaIeta = std::sqrt(cov[0]);
     float sigmaIetaIphi = cov[1];
 
@@ -383,7 +383,7 @@ void EcalPileUpDepMonitor::analyze(const edm::Event &e, const edm::EventSetup &)
     const EcalRecHitCollection *ebRecHits = RecHitsEB.product();
 
     reco::BasicCluster const &seedCluster(*itSC->seed());
-    std::array<float, 3> cov = EcalClusterTools::localCovariances(seedCluster, ebRecHits, p_topology);
+    const auto& cov = EcalClusterTools::localCovariances(seedCluster, ebRecHits, p_topology);
     float sigmaIetaIeta = std::sqrt(cov[0]);
     float sigmaIetaIphi = cov[1];
 

--- a/DQMOffline/Ecal/plugins/EcalPileUpDepMonitor.cc
+++ b/DQMOffline/Ecal/plugins/EcalPileUpDepMonitor.cc
@@ -340,7 +340,7 @@ void EcalPileUpDepMonitor::analyze(const edm::Event &e, const edm::EventSetup &)
     const EcalRecHitCollection *eeRecHits = RecHitsEE.product();
 
     reco::BasicCluster const &seedCluster(*itSC->seed());
-    std::array<float,3> cov = EcalClusterTools::localCovariances(seedCluster, eeRecHits, p_topology);
+    std::array<float, 3> cov = EcalClusterTools::localCovariances(seedCluster, eeRecHits, p_topology);
     float sigmaIetaIeta = std::sqrt(cov[0]);
     float sigmaIetaIphi = cov[1];
 
@@ -383,7 +383,7 @@ void EcalPileUpDepMonitor::analyze(const edm::Event &e, const edm::EventSetup &)
     const EcalRecHitCollection *ebRecHits = RecHitsEB.product();
 
     reco::BasicCluster const &seedCluster(*itSC->seed());
-    std::array<float,3> cov = EcalClusterTools::localCovariances(seedCluster, ebRecHits, p_topology);
+    std::array<float, 3> cov = EcalClusterTools::localCovariances(seedCluster, ebRecHits, p_topology);
     float sigmaIetaIeta = std::sqrt(cov[0]);
     float sigmaIetaIphi = cov[1];
 

--- a/DQMOffline/Trigger/src/EgHLTOffHelper.cc
+++ b/DQMOffline/Trigger/src/EgHLTOffHelper.cc
@@ -325,9 +325,9 @@ void OffHelper::fillClusShapeData(const reco::GsfElectron& ele, OffEle::ClusShap
       seedClus.hitsAndFractions()[0]
           .first;  //note this may not actually be the seed hit but it doesnt matter because all hits will be in the barrel OR endcap
   if (seedDetId.subdetId() == EcalBarrel) {
-    std::vector<float> stdCov =
+    std::array<float,3> stdCov =
         EcalClusterTools::covariances(seedClus, ebRecHits_.product(), caloTopology_.product(), caloGeom_.product());
-    std::vector<float> crysCov =
+    std::array<float,3> crysCov =
         EcalClusterTools::localCovariances(seedClus, ebRecHits_.product(), caloTopology_.product());
     clusShapeData.sigmaPhiPhi = sqrt(stdCov[2]);
     clusShapeData.sigmaIPhiIPhi = sqrt(crysCov[2]);
@@ -338,9 +338,9 @@ void OffHelper::fillClusShapeData(const reco::GsfElectron& ele, OffEle::ClusShap
       clusShapeData.r9 = -1.;
 
   } else {
-    std::vector<float> stdCov =
+    std::array<float,3> stdCov =
         EcalClusterTools::covariances(seedClus, eeRecHits_.product(), caloTopology_.product(), caloGeom_.product());
-    std::vector<float> crysCov =
+    std::array<float,3> crysCov =
         EcalClusterTools::localCovariances(seedClus, eeRecHits_.product(), caloTopology_.product());
     clusShapeData.sigmaPhiPhi = sqrt(stdCov[2]);
     clusShapeData.sigmaIPhiIPhi = sqrt(crysCov[2]);
@@ -496,16 +496,16 @@ void OffHelper::fillClusShapeData(const reco::Photon& pho, OffPho::ClusShapeData
       seedClus.hitsAndFractions()[0]
           .first;  //note this may not actually be the seed hit but it doesnt matter because all hits will be in the barrel OR endcap (it is also incredably inefficient as it getHitsByDetId passes the vector by value not reference
   if (seedDetId.subdetId() == EcalBarrel) {
-    std::vector<float> stdCov =
+    std::array<float,3> stdCov =
         EcalClusterTools::covariances(seedClus, ebRecHits_.product(), caloTopology_.product(), caloGeom_.product());
-    std::vector<float> crysCov =
+    std::array<float,3> crysCov =
         EcalClusterTools::localCovariances(seedClus, ebRecHits_.product(), caloTopology_.product());
     clusShapeData.sigmaPhiPhi = sqrt(stdCov[2]);
     clusShapeData.sigmaIPhiIPhi = sqrt(crysCov[2]);
   } else {
-    std::vector<float> stdCov =
+    std::array<float,3> stdCov =
         EcalClusterTools::covariances(seedClus, eeRecHits_.product(), caloTopology_.product(), caloGeom_.product());
-    std::vector<float> crysCov =
+    std::array<float,3> crysCov =
         EcalClusterTools::localCovariances(seedClus, eeRecHits_.product(), caloTopology_.product());
 
     clusShapeData.sigmaPhiPhi = sqrt(stdCov[2]);

--- a/DQMOffline/Trigger/src/EgHLTOffHelper.cc
+++ b/DQMOffline/Trigger/src/EgHLTOffHelper.cc
@@ -327,8 +327,7 @@ void OffHelper::fillClusShapeData(const reco::GsfElectron& ele, OffEle::ClusShap
   if (seedDetId.subdetId() == EcalBarrel) {
     const auto& stdCov =
         EcalClusterTools::covariances(seedClus, ebRecHits_.product(), caloTopology_.product(), caloGeom_.product());
-    const auto& crysCov =
-        EcalClusterTools::localCovariances(seedClus, ebRecHits_.product(), caloTopology_.product());
+    const auto& crysCov = EcalClusterTools::localCovariances(seedClus, ebRecHits_.product(), caloTopology_.product());
     clusShapeData.sigmaPhiPhi = sqrt(stdCov[2]);
     clusShapeData.sigmaIPhiIPhi = sqrt(crysCov[2]);
     if (ele.superCluster()->rawEnergy() != 0.) {
@@ -340,8 +339,7 @@ void OffHelper::fillClusShapeData(const reco::GsfElectron& ele, OffEle::ClusShap
   } else {
     const auto& stdCov =
         EcalClusterTools::covariances(seedClus, eeRecHits_.product(), caloTopology_.product(), caloGeom_.product());
-    const auto& crysCov =
-        EcalClusterTools::localCovariances(seedClus, eeRecHits_.product(), caloTopology_.product());
+    const auto& crysCov = EcalClusterTools::localCovariances(seedClus, eeRecHits_.product(), caloTopology_.product());
     clusShapeData.sigmaPhiPhi = sqrt(stdCov[2]);
     clusShapeData.sigmaIPhiIPhi = sqrt(crysCov[2]);
     if (ele.superCluster()->rawEnergy() != 0.) {
@@ -498,15 +496,13 @@ void OffHelper::fillClusShapeData(const reco::Photon& pho, OffPho::ClusShapeData
   if (seedDetId.subdetId() == EcalBarrel) {
     const auto& stdCov =
         EcalClusterTools::covariances(seedClus, ebRecHits_.product(), caloTopology_.product(), caloGeom_.product());
-    const auto& crysCov =
-        EcalClusterTools::localCovariances(seedClus, ebRecHits_.product(), caloTopology_.product());
+    const auto& crysCov = EcalClusterTools::localCovariances(seedClus, ebRecHits_.product(), caloTopology_.product());
     clusShapeData.sigmaPhiPhi = sqrt(stdCov[2]);
     clusShapeData.sigmaIPhiIPhi = sqrt(crysCov[2]);
   } else {
     const auto& stdCov =
         EcalClusterTools::covariances(seedClus, eeRecHits_.product(), caloTopology_.product(), caloGeom_.product());
-    const auto& crysCov =
-        EcalClusterTools::localCovariances(seedClus, eeRecHits_.product(), caloTopology_.product());
+    const auto& crysCov = EcalClusterTools::localCovariances(seedClus, eeRecHits_.product(), caloTopology_.product());
 
     clusShapeData.sigmaPhiPhi = sqrt(stdCov[2]);
     clusShapeData.sigmaIPhiIPhi = sqrt(crysCov[2]);

--- a/DQMOffline/Trigger/src/EgHLTOffHelper.cc
+++ b/DQMOffline/Trigger/src/EgHLTOffHelper.cc
@@ -325,9 +325,9 @@ void OffHelper::fillClusShapeData(const reco::GsfElectron& ele, OffEle::ClusShap
       seedClus.hitsAndFractions()[0]
           .first;  //note this may not actually be the seed hit but it doesnt matter because all hits will be in the barrel OR endcap
   if (seedDetId.subdetId() == EcalBarrel) {
-    std::array<float,3> stdCov =
+    std::array<float, 3> stdCov =
         EcalClusterTools::covariances(seedClus, ebRecHits_.product(), caloTopology_.product(), caloGeom_.product());
-    std::array<float,3> crysCov =
+    std::array<float, 3> crysCov =
         EcalClusterTools::localCovariances(seedClus, ebRecHits_.product(), caloTopology_.product());
     clusShapeData.sigmaPhiPhi = sqrt(stdCov[2]);
     clusShapeData.sigmaIPhiIPhi = sqrt(crysCov[2]);
@@ -338,9 +338,9 @@ void OffHelper::fillClusShapeData(const reco::GsfElectron& ele, OffEle::ClusShap
       clusShapeData.r9 = -1.;
 
   } else {
-    std::array<float,3> stdCov =
+    std::array<float, 3> stdCov =
         EcalClusterTools::covariances(seedClus, eeRecHits_.product(), caloTopology_.product(), caloGeom_.product());
-    std::array<float,3> crysCov =
+    std::array<float, 3> crysCov =
         EcalClusterTools::localCovariances(seedClus, eeRecHits_.product(), caloTopology_.product());
     clusShapeData.sigmaPhiPhi = sqrt(stdCov[2]);
     clusShapeData.sigmaIPhiIPhi = sqrt(crysCov[2]);
@@ -496,16 +496,16 @@ void OffHelper::fillClusShapeData(const reco::Photon& pho, OffPho::ClusShapeData
       seedClus.hitsAndFractions()[0]
           .first;  //note this may not actually be the seed hit but it doesnt matter because all hits will be in the barrel OR endcap (it is also incredably inefficient as it getHitsByDetId passes the vector by value not reference
   if (seedDetId.subdetId() == EcalBarrel) {
-    std::array<float,3> stdCov =
+    std::array<float, 3> stdCov =
         EcalClusterTools::covariances(seedClus, ebRecHits_.product(), caloTopology_.product(), caloGeom_.product());
-    std::array<float,3> crysCov =
+    std::array<float, 3> crysCov =
         EcalClusterTools::localCovariances(seedClus, ebRecHits_.product(), caloTopology_.product());
     clusShapeData.sigmaPhiPhi = sqrt(stdCov[2]);
     clusShapeData.sigmaIPhiIPhi = sqrt(crysCov[2]);
   } else {
-    std::array<float,3> stdCov =
+    std::array<float, 3> stdCov =
         EcalClusterTools::covariances(seedClus, eeRecHits_.product(), caloTopology_.product(), caloGeom_.product());
-    std::array<float,3> crysCov =
+    std::array<float, 3> crysCov =
         EcalClusterTools::localCovariances(seedClus, eeRecHits_.product(), caloTopology_.product());
 
     clusShapeData.sigmaPhiPhi = sqrt(stdCov[2]);

--- a/DQMOffline/Trigger/src/EgHLTOffHelper.cc
+++ b/DQMOffline/Trigger/src/EgHLTOffHelper.cc
@@ -325,9 +325,9 @@ void OffHelper::fillClusShapeData(const reco::GsfElectron& ele, OffEle::ClusShap
       seedClus.hitsAndFractions()[0]
           .first;  //note this may not actually be the seed hit but it doesnt matter because all hits will be in the barrel OR endcap
   if (seedDetId.subdetId() == EcalBarrel) {
-    std::array<float, 3> stdCov =
+    const auto& stdCov =
         EcalClusterTools::covariances(seedClus, ebRecHits_.product(), caloTopology_.product(), caloGeom_.product());
-    std::array<float, 3> crysCov =
+    const auto& crysCov =
         EcalClusterTools::localCovariances(seedClus, ebRecHits_.product(), caloTopology_.product());
     clusShapeData.sigmaPhiPhi = sqrt(stdCov[2]);
     clusShapeData.sigmaIPhiIPhi = sqrt(crysCov[2]);
@@ -338,9 +338,9 @@ void OffHelper::fillClusShapeData(const reco::GsfElectron& ele, OffEle::ClusShap
       clusShapeData.r9 = -1.;
 
   } else {
-    std::array<float, 3> stdCov =
+    const auto& stdCov =
         EcalClusterTools::covariances(seedClus, eeRecHits_.product(), caloTopology_.product(), caloGeom_.product());
-    std::array<float, 3> crysCov =
+    const auto& crysCov =
         EcalClusterTools::localCovariances(seedClus, eeRecHits_.product(), caloTopology_.product());
     clusShapeData.sigmaPhiPhi = sqrt(stdCov[2]);
     clusShapeData.sigmaIPhiIPhi = sqrt(crysCov[2]);
@@ -496,16 +496,16 @@ void OffHelper::fillClusShapeData(const reco::Photon& pho, OffPho::ClusShapeData
       seedClus.hitsAndFractions()[0]
           .first;  //note this may not actually be the seed hit but it doesnt matter because all hits will be in the barrel OR endcap (it is also incredably inefficient as it getHitsByDetId passes the vector by value not reference
   if (seedDetId.subdetId() == EcalBarrel) {
-    std::array<float, 3> stdCov =
+    const auto& stdCov =
         EcalClusterTools::covariances(seedClus, ebRecHits_.product(), caloTopology_.product(), caloGeom_.product());
-    std::array<float, 3> crysCov =
+    const auto& crysCov =
         EcalClusterTools::localCovariances(seedClus, ebRecHits_.product(), caloTopology_.product());
     clusShapeData.sigmaPhiPhi = sqrt(stdCov[2]);
     clusShapeData.sigmaIPhiIPhi = sqrt(crysCov[2]);
   } else {
-    std::array<float, 3> stdCov =
+    const auto& stdCov =
         EcalClusterTools::covariances(seedClus, eeRecHits_.product(), caloTopology_.product(), caloGeom_.product());
-    std::array<float, 3> crysCov =
+    const auto& crysCov =
         EcalClusterTools::localCovariances(seedClus, eeRecHits_.product(), caloTopology_.product());
 
     clusShapeData.sigmaPhiPhi = sqrt(stdCov[2]);

--- a/EgammaAnalysis/ElectronTools/interface/SuperClusterHelper.h
+++ b/EgammaAnalysis/ElectronTools/interface/SuperClusterHelper.h
@@ -107,7 +107,6 @@ private:
   /// cached variables
   /// covariance matrix
   bool covComputed_;
-  std::array<float, 3> vCov_;
   float spp_;
   float sep_;
   /// local coordinates

--- a/EgammaAnalysis/ElectronTools/interface/SuperClusterHelper.h
+++ b/EgammaAnalysis/ElectronTools/interface/SuperClusterHelper.h
@@ -107,7 +107,7 @@ private:
   /// cached variables
   /// covariance matrix
   bool covComputed_;
-  std::array<float,3> vCov_;
+  std::array<float, 3> vCov_;
   float spp_;
   float sep_;
   /// local coordinates

--- a/EgammaAnalysis/ElectronTools/interface/SuperClusterHelper.h
+++ b/EgammaAnalysis/ElectronTools/interface/SuperClusterHelper.h
@@ -107,7 +107,7 @@ private:
   /// cached variables
   /// covariance matrix
   bool covComputed_;
-  std::vector<float> vCov_;
+  std::array<float,3> vCov_;
   float spp_;
   float sep_;
   /// local coordinates

--- a/EgammaAnalysis/ElectronTools/src/EGammaMvaEleEstimator.cc
+++ b/EgammaAnalysis/ElectronTools/src/EGammaMvaEleEstimator.cc
@@ -986,7 +986,7 @@ Double_t EGammaMvaEleEstimator::mvaValue(const reco::GsfElectron& ele,
 
   // Pure ECAL -> shower shapes
   fMVAVar_see = ele.sigmaIetaIeta();  //EleSigmaIEtaIEta
-  std::array<float, 3> vCov = myEcalCluster.localCovariances(*(ele.superCluster()->seed()));
+  const auto& vCov = myEcalCluster.localCovariances(*(ele.superCluster()->seed()));
   if (edm::isFinite(vCov[2]))
     fMVAVar_spp = sqrt(vCov[2]);  //EleSigmaIPhiIPhi
   else
@@ -1096,7 +1096,7 @@ Double_t EGammaMvaEleEstimator::mvaValue(const reco::GsfElectron& ele,
 
   // Pure ECAL -> shower shapes
   fMVAVar_see = ele.sigmaIetaIeta();  //EleSigmaIEtaIEta
-  std::array<float, 3> vCov = myEcalCluster.localCovariances(*(ele.superCluster()->seed()));
+  const auto& vCov = myEcalCluster.localCovariances(*(ele.superCluster()->seed()));
   if (edm::isFinite(vCov[2]))
     fMVAVar_spp = sqrt(vCov[2]);  //EleSigmaIPhiIPhi
   else
@@ -1654,7 +1654,7 @@ Double_t EGammaMvaEleEstimator::IDIsoCombinedMvaValue(const reco::GsfElectron& e
 
   // Pure ECAL -> shower shapes
   fMVAVar_see = ele.sigmaIetaIeta();  //EleSigmaIEtaIEta
-  std::array<float, 3> vCov = myEcalCluster.localCovariances(*(ele.superCluster()->seed()));
+  const auto& vCov = myEcalCluster.localCovariances(*(ele.superCluster()->seed()));
   if (edm::isFinite(vCov[2]))
     fMVAVar_spp = sqrt(vCov[2]);  //EleSigmaIPhiIPhi
   else

--- a/EgammaAnalysis/ElectronTools/src/EGammaMvaEleEstimator.cc
+++ b/EgammaAnalysis/ElectronTools/src/EGammaMvaEleEstimator.cc
@@ -986,7 +986,7 @@ Double_t EGammaMvaEleEstimator::mvaValue(const reco::GsfElectron& ele,
 
   // Pure ECAL -> shower shapes
   fMVAVar_see = ele.sigmaIetaIeta();  //EleSigmaIEtaIEta
-  std::array<float,3> vCov = myEcalCluster.localCovariances(*(ele.superCluster()->seed()));
+  std::array<float, 3> vCov = myEcalCluster.localCovariances(*(ele.superCluster()->seed()));
   if (edm::isFinite(vCov[2]))
     fMVAVar_spp = sqrt(vCov[2]);  //EleSigmaIPhiIPhi
   else
@@ -1096,7 +1096,7 @@ Double_t EGammaMvaEleEstimator::mvaValue(const reco::GsfElectron& ele,
 
   // Pure ECAL -> shower shapes
   fMVAVar_see = ele.sigmaIetaIeta();  //EleSigmaIEtaIEta
-  std::array<float,3> vCov = myEcalCluster.localCovariances(*(ele.superCluster()->seed()));
+  std::array<float, 3> vCov = myEcalCluster.localCovariances(*(ele.superCluster()->seed()));
   if (edm::isFinite(vCov[2]))
     fMVAVar_spp = sqrt(vCov[2]);  //EleSigmaIPhiIPhi
   else
@@ -1654,7 +1654,7 @@ Double_t EGammaMvaEleEstimator::IDIsoCombinedMvaValue(const reco::GsfElectron& e
 
   // Pure ECAL -> shower shapes
   fMVAVar_see = ele.sigmaIetaIeta();  //EleSigmaIEtaIEta
-  std::array<float,3> vCov = myEcalCluster.localCovariances(*(ele.superCluster()->seed()));
+  std::array<float, 3> vCov = myEcalCluster.localCovariances(*(ele.superCluster()->seed()));
   if (edm::isFinite(vCov[2]))
     fMVAVar_spp = sqrt(vCov[2]);  //EleSigmaIPhiIPhi
   else

--- a/EgammaAnalysis/ElectronTools/src/EGammaMvaEleEstimator.cc
+++ b/EgammaAnalysis/ElectronTools/src/EGammaMvaEleEstimator.cc
@@ -986,7 +986,7 @@ Double_t EGammaMvaEleEstimator::mvaValue(const reco::GsfElectron& ele,
 
   // Pure ECAL -> shower shapes
   fMVAVar_see = ele.sigmaIetaIeta();  //EleSigmaIEtaIEta
-  std::vector<float> vCov = myEcalCluster.localCovariances(*(ele.superCluster()->seed()));
+  std::array<float,3> vCov = myEcalCluster.localCovariances(*(ele.superCluster()->seed()));
   if (edm::isFinite(vCov[2]))
     fMVAVar_spp = sqrt(vCov[2]);  //EleSigmaIPhiIPhi
   else
@@ -1096,7 +1096,7 @@ Double_t EGammaMvaEleEstimator::mvaValue(const reco::GsfElectron& ele,
 
   // Pure ECAL -> shower shapes
   fMVAVar_see = ele.sigmaIetaIeta();  //EleSigmaIEtaIEta
-  std::vector<float> vCov = myEcalCluster.localCovariances(*(ele.superCluster()->seed()));
+  std::array<float,3> vCov = myEcalCluster.localCovariances(*(ele.superCluster()->seed()));
   if (edm::isFinite(vCov[2]))
     fMVAVar_spp = sqrt(vCov[2]);  //EleSigmaIPhiIPhi
   else
@@ -1654,7 +1654,7 @@ Double_t EGammaMvaEleEstimator::IDIsoCombinedMvaValue(const reco::GsfElectron& e
 
   // Pure ECAL -> shower shapes
   fMVAVar_see = ele.sigmaIetaIeta();  //EleSigmaIEtaIEta
-  std::vector<float> vCov = myEcalCluster.localCovariances(*(ele.superCluster()->seed()));
+  std::array<float,3> vCov = myEcalCluster.localCovariances(*(ele.superCluster()->seed()));
   if (edm::isFinite(vCov[2]))
     fMVAVar_spp = sqrt(vCov[2]);  //EleSigmaIPhiIPhi
   else

--- a/EgammaAnalysis/ElectronTools/src/EGammaMvaEleEstimatorCSA14.cc
+++ b/EgammaAnalysis/ElectronTools/src/EGammaMvaEleEstimatorCSA14.cc
@@ -283,7 +283,7 @@ Double_t EGammaMvaEleEstimatorCSA14::mvaValue(const reco::GsfElectron &ele,
   fMVAVar_detacalo = ele.deltaEtaSeedClusterTrackAtCalo();
 
   // Pure ECAL -> shower shapes
-  std::array<float, 3> vCov = myEcalCluster.localCovariances(*(ele.superCluster()->seed()));
+  const auto& vCov = myEcalCluster.localCovariances(*(ele.superCluster()->seed()));
   if (edm::isFinite(vCov[0]))
     fMVAVar_see = sqrt(vCov[0]);  //EleSigmaIEtaIEta
   else

--- a/EgammaAnalysis/ElectronTools/src/EGammaMvaEleEstimatorCSA14.cc
+++ b/EgammaAnalysis/ElectronTools/src/EGammaMvaEleEstimatorCSA14.cc
@@ -283,7 +283,7 @@ Double_t EGammaMvaEleEstimatorCSA14::mvaValue(const reco::GsfElectron &ele,
   fMVAVar_detacalo = ele.deltaEtaSeedClusterTrackAtCalo();
 
   // Pure ECAL -> shower shapes
-  const auto& vCov = myEcalCluster.localCovariances(*(ele.superCluster()->seed()));
+  const auto &vCov = myEcalCluster.localCovariances(*(ele.superCluster()->seed()));
   if (edm::isFinite(vCov[0]))
     fMVAVar_see = sqrt(vCov[0]);  //EleSigmaIEtaIEta
   else

--- a/EgammaAnalysis/ElectronTools/src/EGammaMvaEleEstimatorCSA14.cc
+++ b/EgammaAnalysis/ElectronTools/src/EGammaMvaEleEstimatorCSA14.cc
@@ -283,7 +283,7 @@ Double_t EGammaMvaEleEstimatorCSA14::mvaValue(const reco::GsfElectron &ele,
   fMVAVar_detacalo = ele.deltaEtaSeedClusterTrackAtCalo();
 
   // Pure ECAL -> shower shapes
-  std::vector<float> vCov = myEcalCluster.localCovariances(*(ele.superCluster()->seed()));
+  std::array<float,3> vCov = myEcalCluster.localCovariances(*(ele.superCluster()->seed()));
   if (edm::isFinite(vCov[0]))
     fMVAVar_see = sqrt(vCov[0]);  //EleSigmaIEtaIEta
   else

--- a/EgammaAnalysis/ElectronTools/src/EGammaMvaEleEstimatorCSA14.cc
+++ b/EgammaAnalysis/ElectronTools/src/EGammaMvaEleEstimatorCSA14.cc
@@ -283,7 +283,7 @@ Double_t EGammaMvaEleEstimatorCSA14::mvaValue(const reco::GsfElectron &ele,
   fMVAVar_detacalo = ele.deltaEtaSeedClusterTrackAtCalo();
 
   // Pure ECAL -> shower shapes
-  std::array<float,3> vCov = myEcalCluster.localCovariances(*(ele.superCluster()->seed()));
+  std::array<float, 3> vCov = myEcalCluster.localCovariances(*(ele.superCluster()->seed()));
   if (edm::isFinite(vCov[0]))
     fMVAVar_see = sqrt(vCov[0]);  //EleSigmaIEtaIEta
   else

--- a/EgammaAnalysis/ElectronTools/src/SuperClusterHelper.cc
+++ b/EgammaAnalysis/ElectronTools/src/SuperClusterHelper.cc
@@ -104,7 +104,7 @@ SuperClusterHelper::SuperClusterHelper(const pat::Electron* electron,
 
 void SuperClusterHelper::computeLocalCovariances() {
   if (!covComputed_) {
-    vCov_ = EcalClusterTools::localCovariances(*seedCluster_, rechits_, topology_, 4.7);
+    const auto& vCov_ = EcalClusterTools::localCovariances(*seedCluster_, rechits_, topology_, 4.7);
     covComputed_ = true;
 
     spp_ = 0;

--- a/EgammaAnalysis/ElectronTools/test/ElectronTestAnalyzer.cc
+++ b/EgammaAnalysis/ElectronTools/test/ElectronTestAnalyzer.cc
@@ -468,7 +468,7 @@ void ElectronTestAnalyzer::myVar(const reco::GsfElectron& ele,
   myMVAVar_dphicalo = ele.deltaPhiSeedClusterTrackAtCalo();
 
   myMVAVar_see = ele.sigmaIetaIeta();  //EleSigmaIEtaIEta
-  std::array<float,3> vCov = myEcalCluster.localCovariances(*(ele.superCluster()->seed()));
+  std::array<float, 3> vCov = myEcalCluster.localCovariances(*(ele.superCluster()->seed()));
   if (edm::isFinite(vCov[2]))
     myMVAVar_spp = sqrt(vCov[2]);  //EleSigmaIPhiIPhi
   else

--- a/EgammaAnalysis/ElectronTools/test/ElectronTestAnalyzer.cc
+++ b/EgammaAnalysis/ElectronTools/test/ElectronTestAnalyzer.cc
@@ -468,7 +468,7 @@ void ElectronTestAnalyzer::myVar(const reco::GsfElectron& ele,
   myMVAVar_dphicalo = ele.deltaPhiSeedClusterTrackAtCalo();
 
   myMVAVar_see = ele.sigmaIetaIeta();  //EleSigmaIEtaIEta
-  std::vector<float> vCov = myEcalCluster.localCovariances(*(ele.superCluster()->seed()));
+  std::array<float,3> vCov = myEcalCluster.localCovariances(*(ele.superCluster()->seed()));
   if (edm::isFinite(vCov[2]))
     myMVAVar_spp = sqrt(vCov[2]);  //EleSigmaIPhiIPhi
   else

--- a/EgammaAnalysis/ElectronTools/test/ElectronTestAnalyzer.cc
+++ b/EgammaAnalysis/ElectronTools/test/ElectronTestAnalyzer.cc
@@ -468,7 +468,7 @@ void ElectronTestAnalyzer::myVar(const reco::GsfElectron& ele,
   myMVAVar_dphicalo = ele.deltaPhiSeedClusterTrackAtCalo();
 
   myMVAVar_see = ele.sigmaIetaIeta();  //EleSigmaIEtaIEta
-  std::array<float, 3> vCov = myEcalCluster.localCovariances(*(ele.superCluster()->seed()));
+  const auto& vCov = myEcalCluster.localCovariances(*(ele.superCluster()->seed()));
   if (edm::isFinite(vCov[2]))
     myMVAVar_spp = sqrt(vCov[2]);  //EleSigmaIPhiIPhi
   else

--- a/PhysicsTools/PatAlgos/plugins/PATElectronProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATElectronProducer.cc
@@ -450,7 +450,7 @@ void PATElectronProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSe
 
           if (addMVAVariables_) {
             // add missing mva variables
-            std::array<float,3> vCov = lazyTools.localCovariances(*(itElectron->superCluster()->seed()));
+            std::array<float, 3> vCov = lazyTools.localCovariances(*(itElectron->superCluster()->seed()));
             anElectron.setMvaVariables(vCov[1], ip3d);
           }
           // PFClusterIso
@@ -681,7 +681,7 @@ void PATElectronProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSe
 
       if (addMVAVariables_) {
         // add mva variables
-        std::array<float,3> vCov = lazyTools.localCovariances(*(itElectron->superCluster()->seed()));
+        std::array<float, 3> vCov = lazyTools.localCovariances(*(itElectron->superCluster()->seed()));
         anElectron.setMvaVariables(vCov[1], ip3d);
       }
 

--- a/PhysicsTools/PatAlgos/plugins/PATElectronProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATElectronProducer.cc
@@ -450,7 +450,7 @@ void PATElectronProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSe
 
           if (addMVAVariables_) {
             // add missing mva variables
-            std::vector<float> vCov = lazyTools.localCovariances(*(itElectron->superCluster()->seed()));
+            std::array<float,3> vCov = lazyTools.localCovariances(*(itElectron->superCluster()->seed()));
             anElectron.setMvaVariables(vCov[1], ip3d);
           }
           // PFClusterIso
@@ -681,7 +681,7 @@ void PATElectronProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSe
 
       if (addMVAVariables_) {
         // add mva variables
-        std::vector<float> vCov = lazyTools.localCovariances(*(itElectron->superCluster()->seed()));
+        std::array<float,3> vCov = lazyTools.localCovariances(*(itElectron->superCluster()->seed()));
         anElectron.setMvaVariables(vCov[1], ip3d);
       }
 

--- a/PhysicsTools/PatAlgos/plugins/PATElectronProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATElectronProducer.cc
@@ -450,7 +450,7 @@ void PATElectronProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSe
 
           if (addMVAVariables_) {
             // add missing mva variables
-            std::array<float, 3> vCov = lazyTools.localCovariances(*(itElectron->superCluster()->seed()));
+            const auto& vCov = lazyTools.localCovariances(*(itElectron->superCluster()->seed()));
             anElectron.setMvaVariables(vCov[1], ip3d);
           }
           // PFClusterIso
@@ -681,7 +681,7 @@ void PATElectronProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSe
 
       if (addMVAVariables_) {
         // add mva variables
-        std::array<float, 3> vCov = lazyTools.localCovariances(*(itElectron->superCluster()->seed()));
+        const auto& vCov = lazyTools.localCovariances(*(itElectron->superCluster()->seed()));
         anElectron.setMvaVariables(vCov[1], ip3d);
       }
 

--- a/PhysicsTools/PatAlgos/plugins/PATElectronSlimmer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATElectronSlimmer.cc
@@ -199,7 +199,7 @@ void pat::PATElectronSlimmer::produce(edm::Event& iEvent, const edm::EventSetup&
       }
     }
     if (saveNonZSClusterShapes_(electron)) {
-      std::array<float, 3> vCov = lazyToolsNoZS.localCovariances(*(electron.superCluster()->seed()));
+      const auto& vCov = lazyToolsNoZS.localCovariances(*(electron.superCluster()->seed()));
       electron.full5x5_setSigmaIetaIphi(vCov[1]);
     }
   }

--- a/PhysicsTools/PatAlgos/plugins/PATElectronSlimmer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATElectronSlimmer.cc
@@ -199,7 +199,7 @@ void pat::PATElectronSlimmer::produce(edm::Event& iEvent, const edm::EventSetup&
       }
     }
     if (saveNonZSClusterShapes_(electron)) {
-      std::vector<float> vCov = lazyToolsNoZS.localCovariances(*(electron.superCluster()->seed()));
+      std::array<float,3> vCov = lazyToolsNoZS.localCovariances(*(electron.superCluster()->seed()));
       electron.full5x5_setSigmaIetaIphi(vCov[1]);
     }
   }

--- a/PhysicsTools/PatAlgos/plugins/PATElectronSlimmer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATElectronSlimmer.cc
@@ -199,7 +199,7 @@ void pat::PATElectronSlimmer::produce(edm::Event& iEvent, const edm::EventSetup&
       }
     }
     if (saveNonZSClusterShapes_(electron)) {
-      std::array<float,3> vCov = lazyToolsNoZS.localCovariances(*(electron.superCluster()->seed()));
+      std::array<float, 3> vCov = lazyToolsNoZS.localCovariances(*(electron.superCluster()->seed()));
       electron.full5x5_setSigmaIetaIphi(vCov[1]);
     }
   }

--- a/PhysicsTools/PatAlgos/plugins/PATPhotonSlimmer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATPhotonSlimmer.cc
@@ -196,7 +196,7 @@ void pat::PATPhotonSlimmer::produce(edm::Event& iEvent, const edm::EventSetup& i
       }
     }
     if (saveNonZSClusterShapes_(photon)) {
-      std::array<float, 3> vCov = lazyToolsNoZS.localCovariances(*(photon.superCluster()->seed()));
+      const auto& vCov = lazyToolsNoZS.localCovariances(*(photon.superCluster()->seed()));
       float r9 = lazyToolsNoZS.e3x3(*(photon.superCluster()->seed())) / photon.superCluster()->rawEnergy();
       float sigmaIetaIeta = (!edm::isNotFinite(vCov[0])) ? sqrt(vCov[0]) : 0;
       float sigmaIetaIphi = vCov[1];

--- a/PhysicsTools/PatAlgos/plugins/PATPhotonSlimmer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATPhotonSlimmer.cc
@@ -196,7 +196,7 @@ void pat::PATPhotonSlimmer::produce(edm::Event& iEvent, const edm::EventSetup& i
       }
     }
     if (saveNonZSClusterShapes_(photon)) {
-      std::array<float,3> vCov = lazyToolsNoZS.localCovariances(*(photon.superCluster()->seed()));
+      std::array<float, 3> vCov = lazyToolsNoZS.localCovariances(*(photon.superCluster()->seed()));
       float r9 = lazyToolsNoZS.e3x3(*(photon.superCluster()->seed())) / photon.superCluster()->rawEnergy();
       float sigmaIetaIeta = (!edm::isNotFinite(vCov[0])) ? sqrt(vCov[0]) : 0;
       float sigmaIetaIphi = vCov[1];

--- a/PhysicsTools/PatAlgos/plugins/PATPhotonSlimmer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATPhotonSlimmer.cc
@@ -196,7 +196,7 @@ void pat::PATPhotonSlimmer::produce(edm::Event& iEvent, const edm::EventSetup& i
       }
     }
     if (saveNonZSClusterShapes_(photon)) {
-      std::vector<float> vCov = lazyToolsNoZS.localCovariances(*(photon.superCluster()->seed()));
+      std::array<float,3> vCov = lazyToolsNoZS.localCovariances(*(photon.superCluster()->seed()));
       float r9 = lazyToolsNoZS.e3x3(*(photon.superCluster()->seed())) / photon.superCluster()->rawEnergy();
       float sigmaIetaIeta = (!edm::isNotFinite(vCov[0])) ? sqrt(vCov[0]) : 0;
       float sigmaIetaIphi = vCov[1];

--- a/RecoEcal/EgammaClusterAlgos/src/SCEnergyCorrectorSemiParm.cc
+++ b/RecoEcal/EgammaClusterAlgos/src/SCEnergyCorrectorSemiParm.cc
@@ -206,7 +206,7 @@ std::vector<float> SCEnergyCorrectorSemiParm::getRegDataECALV1(const reco::Super
   const double raw_energy = sc.rawEnergy();
   const int numberOfClusters = sc.clusters().size();
 
-  std::array<float,3> localCovariances = EcalClusterTools::localCovariances(seedCluster, recHits, caloTopo_);
+  std::array<float, 3> localCovariances = EcalClusterTools::localCovariances(seedCluster, recHits, caloTopo_);
 
   const float eLeft = EcalClusterTools::eLeft(seedCluster, recHits, caloTopo_);
   const float eRight = EcalClusterTools::eRight(seedCluster, recHits, caloTopo_);

--- a/RecoEcal/EgammaClusterAlgos/src/SCEnergyCorrectorSemiParm.cc
+++ b/RecoEcal/EgammaClusterAlgos/src/SCEnergyCorrectorSemiParm.cc
@@ -206,7 +206,7 @@ std::vector<float> SCEnergyCorrectorSemiParm::getRegDataECALV1(const reco::Super
   const double raw_energy = sc.rawEnergy();
   const int numberOfClusters = sc.clusters().size();
 
-  std::vector<float> localCovariances = EcalClusterTools::localCovariances(seedCluster, recHits, caloTopo_);
+  std::array<float,3> localCovariances = EcalClusterTools::localCovariances(seedCluster, recHits, caloTopo_);
 
   const float eLeft = EcalClusterTools::eLeft(seedCluster, recHits, caloTopo_);
   const float eRight = EcalClusterTools::eRight(seedCluster, recHits, caloTopo_);

--- a/RecoEcal/EgammaClusterAlgos/src/SCEnergyCorrectorSemiParm.cc
+++ b/RecoEcal/EgammaClusterAlgos/src/SCEnergyCorrectorSemiParm.cc
@@ -206,7 +206,7 @@ std::vector<float> SCEnergyCorrectorSemiParm::getRegDataECALV1(const reco::Super
   const double raw_energy = sc.rawEnergy();
   const int numberOfClusters = sc.clusters().size();
 
-  std::array<float, 3> localCovariances = EcalClusterTools::localCovariances(seedCluster, recHits, caloTopo_);
+  const auto& localCovariances = EcalClusterTools::localCovariances(seedCluster, recHits, caloTopo_);
 
   const float eLeft = EcalClusterTools::eLeft(seedCluster, recHits, caloTopo_);
   const float eRight = EcalClusterTools::eRight(seedCluster, recHits, caloTopo_);

--- a/RecoEcal/EgammaCoreTools/interface/EcalClusterLazyTools.h
+++ b/RecoEcal/EgammaCoreTools/interface/EcalClusterLazyTools.h
@@ -267,12 +267,12 @@ public:
     return ClusterTools::lat(cluster, getEcalRecHitCollection(cluster), geometry_, logW, w0);
   }
 
-  // return a vector v with v[0] = covEtaEta, v[1] = covEtaPhi, v[2] = covPhiPhi
+  // return an array v with v[0] = covEtaEta, v[1] = covEtaPhi, v[2] = covPhiPhi
   std::array<float, 3> covariances(const reco::BasicCluster &cluster, float w0 = 4.7) const {
     return ClusterTools::covariances(cluster, getEcalRecHitCollection(cluster), topology_, geometry_, w0);
   }
 
-  // return a vector v with v[0] = covIEtaIEta, v[1] = covIEtaIPhi, v[2] = covIPhiIPhi
+  // return an array v with v[0] = covIEtaIEta, v[1] = covIEtaIPhi, v[2] = covIPhiIPhi
   // this function calculates differences in eta/phi in units of crystals not
   // global eta/phi this is gives better performance in the crack regions of
   // the calorimeter but gives otherwise identical results to covariances

--- a/RecoEcal/EgammaCoreTools/interface/EcalClusterLazyTools.h
+++ b/RecoEcal/EgammaCoreTools/interface/EcalClusterLazyTools.h
@@ -268,7 +268,7 @@ public:
   }
 
   // return a vector v with v[0] = covEtaEta, v[1] = covEtaPhi, v[2] = covPhiPhi
-  std::vector<float> covariances(const reco::BasicCluster &cluster, float w0 = 4.7) const {
+  std::array<float,3> covariances(const reco::BasicCluster &cluster, float w0 = 4.7) const {
     return ClusterTools::covariances(cluster, getEcalRecHitCollection(cluster), topology_, geometry_, w0);
   }
 
@@ -281,7 +281,7 @@ public:
   // egamma, but so far covIPhiIPhi hasnt been studied extensively so there
   // could be a bug in the covIPhiIEta or covIPhiIPhi calculations. I dont
   // think there is but as it hasnt been heavily used, there might be one
-  std::vector<float> localCovariances(const reco::BasicCluster &cluster,
+  std::array<float,3> localCovariances(const reco::BasicCluster &cluster,
                                       float w0 = EgammaLocalCovParamDefaults::kRelEnCut,
                                       const EcalPFRecHitThresholds *rhthresholds = nullptr,
                                       float multEB = 0.0,
@@ -289,7 +289,7 @@ public:
     return ClusterTools::localCovariances(
         cluster, getEcalRecHitCollection(cluster), topology_, w0, rhthresholds, multEB, multEE);
   }
-  std::vector<float> scLocalCovariances(const reco::SuperCluster &cluster, float w0 = 4.7) const {
+  std::array<float,3> scLocalCovariances(const reco::SuperCluster &cluster, float w0 = 4.7) const {
     return ClusterTools::scLocalCovariances(cluster, getEcalRecHitCollection(cluster), topology_, w0);
   }
   double zernike20(const reco::BasicCluster &cluster, double R0 = 6.6, bool logW = true, float w0 = 4.7) const {

--- a/RecoEcal/EgammaCoreTools/interface/EcalClusterLazyTools.h
+++ b/RecoEcal/EgammaCoreTools/interface/EcalClusterLazyTools.h
@@ -268,7 +268,7 @@ public:
   }
 
   // return a vector v with v[0] = covEtaEta, v[1] = covEtaPhi, v[2] = covPhiPhi
-  std::array<float,3> covariances(const reco::BasicCluster &cluster, float w0 = 4.7) const {
+  std::array<float, 3> covariances(const reco::BasicCluster &cluster, float w0 = 4.7) const {
     return ClusterTools::covariances(cluster, getEcalRecHitCollection(cluster), topology_, geometry_, w0);
   }
 
@@ -281,15 +281,15 @@ public:
   // egamma, but so far covIPhiIPhi hasnt been studied extensively so there
   // could be a bug in the covIPhiIEta or covIPhiIPhi calculations. I dont
   // think there is but as it hasnt been heavily used, there might be one
-  std::array<float,3> localCovariances(const reco::BasicCluster &cluster,
-                                      float w0 = EgammaLocalCovParamDefaults::kRelEnCut,
-                                      const EcalPFRecHitThresholds *rhthresholds = nullptr,
-                                      float multEB = 0.0,
-                                      float multEE = 0.0) const {
+  std::array<float, 3> localCovariances(const reco::BasicCluster &cluster,
+                                        float w0 = EgammaLocalCovParamDefaults::kRelEnCut,
+                                        const EcalPFRecHitThresholds *rhthresholds = nullptr,
+                                        float multEB = 0.0,
+                                        float multEE = 0.0) const {
     return ClusterTools::localCovariances(
         cluster, getEcalRecHitCollection(cluster), topology_, w0, rhthresholds, multEB, multEE);
   }
-  std::array<float,3> scLocalCovariances(const reco::SuperCluster &cluster, float w0 = 4.7) const {
+  std::array<float, 3> scLocalCovariances(const reco::SuperCluster &cluster, float w0 = 4.7) const {
     return ClusterTools::scLocalCovariances(cluster, getEcalRecHitCollection(cluster), topology_, w0);
   }
   double zernike20(const reco::BasicCluster &cluster, double R0 = 6.6, bool logW = true, float w0 = 4.7) const {

--- a/RecoEcal/EgammaCoreTools/interface/EcalClusterTools.h
+++ b/RecoEcal/EgammaCoreTools/interface/EcalClusterTools.h
@@ -183,15 +183,14 @@ public:
                                 bool logW = true,
                                 float w0 = 4.7);
 
-  // return a vector v with v[0] = covEtaEta, v[1] = covEtaPhi, v[2] = covPhiPhi
-
+  // return an array v with v[0] = covEtaEta, v[1] = covEtaPhi, v[2] = covPhiPhi
   static std::array<float, 3> covariances(const reco::BasicCluster &cluster,
                                           const EcalRecHitCollection *recHits,
                                           const CaloTopology *topology,
                                           const CaloGeometry *geometry,
                                           float w0 = 4.7);
 
-  // return a vector v with v[0] = covIEtaIEta, v[1] = covIEtaIPhi, v[2] = covIPhiIPhi
+  // return an array v with v[0] = covIEtaIEta, v[1] = covIEtaIPhi, v[2] = covIPhiIPhi
   //this function calculates differences in eta/phi in units of crystals not global eta/phi
   //this is gives better performance in the crack regions of the calorimeter but gives otherwise identical results to covariances function
   //   except that it doesnt need an eta based correction funtion in the endcap
@@ -1025,10 +1024,7 @@ std::array<float, 3> EcalClusterToolsT<noZS>::covariances(const reco::BasicClust
     covEtaPhi = 0;
     covPhiPhi = 0;
   }
-  std::array<float, 3> v;
-  v[0] = covEtaEta;
-  v[1] = covEtaPhi;
-  v[2] = covPhiPhi;
+  std::array<float, 3> v{{covEtaEta, covEtaPhi, covPhiPhi}};
   return v;
 }
 
@@ -1125,10 +1121,7 @@ std::array<float, 3> EcalClusterToolsT<noZS>::localCovariances(const reco::Basic
     covEtaPhi = 0;
     covPhiPhi = 0;
   }
-  std::array<float, 3> v;
-  v[0] = covEtaEta;
-  v[1] = covEtaPhi;
-  v[2] = covPhiPhi;
+  std::array<float, 3> v{{covEtaEta, covEtaPhi, covPhiPhi}};
   return v;
 }
 
@@ -1453,11 +1446,7 @@ std::array<float, 3> EcalClusterToolsT<noZS>::scLocalCovariances(const reco::Sup
     covPhiPhi = 0;
   }
 
-  std::array<float, 3> v;
-  v[0] = covEtaEta;
-  v[1] = covEtaPhi;
-  v[2] = covPhiPhi;
-
+  std::array<float, 3> v{{covEtaEta, covEtaPhi, covPhiPhi}};
   return v;
 }
 

--- a/RecoEcal/EgammaCoreTools/interface/EcalClusterTools.h
+++ b/RecoEcal/EgammaCoreTools/interface/EcalClusterTools.h
@@ -185,11 +185,11 @@ public:
 
   // return a vector v with v[0] = covEtaEta, v[1] = covEtaPhi, v[2] = covPhiPhi
 
-  static std::array<float,3> covariances(const reco::BasicCluster &cluster,
-                                        const EcalRecHitCollection *recHits,
-                                        const CaloTopology *topology,
-                                        const CaloGeometry *geometry,
-                                        float w0 = 4.7);
+  static std::array<float, 3> covariances(const reco::BasicCluster &cluster,
+                                          const EcalRecHitCollection *recHits,
+                                          const CaloTopology *topology,
+                                          const CaloGeometry *geometry,
+                                          float w0 = 4.7);
 
   // return a vector v with v[0] = covIEtaIEta, v[1] = covIEtaIPhi, v[2] = covIPhiIPhi
   //this function calculates differences in eta/phi in units of crystals not global eta/phi
@@ -199,18 +199,18 @@ public:
   //
   //Warning: covIEtaIEta has been studied by egamma, but so far covIPhiIPhi hasnt been studied extensively so there could be a bug in
   //         the covIPhiIEta or covIPhiIPhi calculations. I dont think there is but as it hasnt been heavily used, there might be one
-  static std::array<float,3> localCovariances(const reco::BasicCluster &cluster,
-                                             const EcalRecHitCollection *recHits,
-                                             const CaloTopology *topology,
-                                             float w0 = EgammaLocalCovParamDefaults::kRelEnCut,
-                                             const EcalPFRecHitThresholds *thresholds = nullptr,
-                                             float multEB = 0.0,
-                                             float multEE = 0.0);
-
-  static std::array<float,3> scLocalCovariances(const reco::SuperCluster &cluster,
+  static std::array<float, 3> localCovariances(const reco::BasicCluster &cluster,
                                                const EcalRecHitCollection *recHits,
                                                const CaloTopology *topology,
-                                               float w0 = 4.7);
+                                               float w0 = EgammaLocalCovParamDefaults::kRelEnCut,
+                                               const EcalPFRecHitThresholds *thresholds = nullptr,
+                                               float multEB = 0.0,
+                                               float multEE = 0.0);
+
+  static std::array<float, 3> scLocalCovariances(const reco::SuperCluster &cluster,
+                                                 const EcalRecHitCollection *recHits,
+                                                 const CaloTopology *topology,
+                                                 float w0 = 4.7);
 
   // cluster second moments with respect to principal axes:
   static Cluster2ndMoments cluster2ndMoments(const reco::BasicCluster &basicCluster,
@@ -960,11 +960,11 @@ std::pair<float, float> EcalClusterToolsT<noZS>::mean5x5PositionInXY(const reco:
 }
 
 template <bool noZS>
-std::array<float,3> EcalClusterToolsT<noZS>::covariances(const reco::BasicCluster &cluster,
-                                                        const EcalRecHitCollection *recHits,
-                                                        const CaloTopology *topology,
-                                                        const CaloGeometry *geometry,
-                                                        float w0) {
+std::array<float, 3> EcalClusterToolsT<noZS>::covariances(const reco::BasicCluster &cluster,
+                                                          const EcalRecHitCollection *recHits,
+                                                          const CaloTopology *topology,
+                                                          const CaloGeometry *geometry,
+                                                          float w0) {
   float e_5x5 = e5x5(cluster, recHits, topology);
   float covEtaEta, covEtaPhi, covPhiPhi;
   if (e_5x5 >= 0.) {
@@ -1025,10 +1025,10 @@ std::array<float,3> EcalClusterToolsT<noZS>::covariances(const reco::BasicCluste
     covEtaPhi = 0;
     covPhiPhi = 0;
   }
-  std::array<float,3> v;
-  v[0]=covEtaEta;
-  v[1]=covEtaPhi;
-  v[2]=covPhiPhi;
+  std::array<float, 3> v;
+  v[0] = covEtaEta;
+  v[1] = covEtaPhi;
+  v[2] = covPhiPhi;
   return v;
 }
 
@@ -1037,13 +1037,13 @@ std::array<float,3> EcalClusterToolsT<noZS>::covariances(const reco::BasicCluste
 //it also does not require any eta correction function in the endcap
 //it is multipled by an approprate crystal size to ensure it gives similar values to covariances(...)
 template <bool noZS>
-std::array<float,3> EcalClusterToolsT<noZS>::localCovariances(const reco::BasicCluster &cluster,
-                                                             const EcalRecHitCollection *recHits,
-                                                             const CaloTopology *topology,
-                                                             float w0,
-                                                             const EcalPFRecHitThresholds *thresholds,
-                                                             float multEB,
-                                                             float multEE) {
+std::array<float, 3> EcalClusterToolsT<noZS>::localCovariances(const reco::BasicCluster &cluster,
+                                                               const EcalRecHitCollection *recHits,
+                                                               const CaloTopology *topology,
+                                                               float w0,
+                                                               const EcalPFRecHitThresholds *thresholds,
+                                                               float multEB,
+                                                               float multEE) {
   float e_5x5 = e5x5(cluster, recHits, topology);
   float covEtaEta, covEtaPhi, covPhiPhi;
 
@@ -1125,10 +1125,10 @@ std::array<float,3> EcalClusterToolsT<noZS>::localCovariances(const reco::BasicC
     covEtaPhi = 0;
     covPhiPhi = 0;
   }
-  std::array<float,3> v;
-  v[0]=covEtaEta;
-  v[1]=covEtaPhi;
-  v[2]=covPhiPhi;
+  std::array<float, 3> v;
+  v[0] = covEtaEta;
+  v[1] = covEtaPhi;
+  v[2] = covPhiPhi;
   return v;
 }
 
@@ -1384,10 +1384,10 @@ float EcalClusterToolsT<noZS>::getDPhiEndcap(const DetId &crysId, float meanX, f
 }
 
 template <bool noZS>
-std::array<float,3> EcalClusterToolsT<noZS>::scLocalCovariances(const reco::SuperCluster &cluster,
-                                                               const EcalRecHitCollection *recHits,
-                                                               const CaloTopology *topology,
-                                                               float w0) {
+std::array<float, 3> EcalClusterToolsT<noZS>::scLocalCovariances(const reco::SuperCluster &cluster,
+                                                                 const EcalRecHitCollection *recHits,
+                                                                 const CaloTopology *topology,
+                                                                 float w0) {
   const reco::BasicCluster bcluster = *(cluster.seed());
 
   float e_5x5 = e5x5(bcluster, recHits, topology);
@@ -1453,10 +1453,10 @@ std::array<float,3> EcalClusterToolsT<noZS>::scLocalCovariances(const reco::Supe
     covPhiPhi = 0;
   }
 
-  std::array<float,3> v;
-  v[0]=covEtaEta;
-  v[1]=covEtaPhi;
-  v[2]=covPhiPhi;
+  std::array<float, 3> v;
+  v[0] = covEtaEta;
+  v[1] = covEtaPhi;
+  v[2] = covPhiPhi;
 
   return v;
 }

--- a/RecoEcal/EgammaCoreTools/interface/EcalClusterTools.h
+++ b/RecoEcal/EgammaCoreTools/interface/EcalClusterTools.h
@@ -185,7 +185,7 @@ public:
 
   // return a vector v with v[0] = covEtaEta, v[1] = covEtaPhi, v[2] = covPhiPhi
 
-  static std::vector<float> covariances(const reco::BasicCluster &cluster,
+  static std::array<float,3> covariances(const reco::BasicCluster &cluster,
                                         const EcalRecHitCollection *recHits,
                                         const CaloTopology *topology,
                                         const CaloGeometry *geometry,
@@ -199,7 +199,7 @@ public:
   //
   //Warning: covIEtaIEta has been studied by egamma, but so far covIPhiIPhi hasnt been studied extensively so there could be a bug in
   //         the covIPhiIEta or covIPhiIPhi calculations. I dont think there is but as it hasnt been heavily used, there might be one
-  static std::vector<float> localCovariances(const reco::BasicCluster &cluster,
+  static std::array<float,3> localCovariances(const reco::BasicCluster &cluster,
                                              const EcalRecHitCollection *recHits,
                                              const CaloTopology *topology,
                                              float w0 = EgammaLocalCovParamDefaults::kRelEnCut,
@@ -207,7 +207,7 @@ public:
                                              float multEB = 0.0,
                                              float multEE = 0.0);
 
-  static std::vector<float> scLocalCovariances(const reco::SuperCluster &cluster,
+  static std::array<float,3> scLocalCovariances(const reco::SuperCluster &cluster,
                                                const EcalRecHitCollection *recHits,
                                                const CaloTopology *topology,
                                                float w0 = 4.7);
@@ -960,7 +960,7 @@ std::pair<float, float> EcalClusterToolsT<noZS>::mean5x5PositionInXY(const reco:
 }
 
 template <bool noZS>
-std::vector<float> EcalClusterToolsT<noZS>::covariances(const reco::BasicCluster &cluster,
+std::array<float,3> EcalClusterToolsT<noZS>::covariances(const reco::BasicCluster &cluster,
                                                         const EcalRecHitCollection *recHits,
                                                         const CaloTopology *topology,
                                                         const CaloGeometry *geometry,
@@ -1025,10 +1025,10 @@ std::vector<float> EcalClusterToolsT<noZS>::covariances(const reco::BasicCluster
     covEtaPhi = 0;
     covPhiPhi = 0;
   }
-  std::vector<float> v;
-  v.push_back(covEtaEta);
-  v.push_back(covEtaPhi);
-  v.push_back(covPhiPhi);
+  std::array<float,3> v;
+  v[0]=covEtaEta;
+  v[1]=covEtaPhi;
+  v[2]=covPhiPhi;
   return v;
 }
 
@@ -1037,7 +1037,7 @@ std::vector<float> EcalClusterToolsT<noZS>::covariances(const reco::BasicCluster
 //it also does not require any eta correction function in the endcap
 //it is multipled by an approprate crystal size to ensure it gives similar values to covariances(...)
 template <bool noZS>
-std::vector<float> EcalClusterToolsT<noZS>::localCovariances(const reco::BasicCluster &cluster,
+std::array<float,3> EcalClusterToolsT<noZS>::localCovariances(const reco::BasicCluster &cluster,
                                                              const EcalRecHitCollection *recHits,
                                                              const CaloTopology *topology,
                                                              float w0,
@@ -1125,10 +1125,10 @@ std::vector<float> EcalClusterToolsT<noZS>::localCovariances(const reco::BasicCl
     covEtaPhi = 0;
     covPhiPhi = 0;
   }
-  std::vector<float> v;
-  v.push_back(covEtaEta);
-  v.push_back(covEtaPhi);
-  v.push_back(covPhiPhi);
+  std::array<float,3> v;
+  v[0]=covEtaEta;
+  v[1]=covEtaPhi;
+  v[2]=covPhiPhi;
   return v;
 }
 
@@ -1384,7 +1384,7 @@ float EcalClusterToolsT<noZS>::getDPhiEndcap(const DetId &crysId, float meanX, f
 }
 
 template <bool noZS>
-std::vector<float> EcalClusterToolsT<noZS>::scLocalCovariances(const reco::SuperCluster &cluster,
+std::array<float,3> EcalClusterToolsT<noZS>::scLocalCovariances(const reco::SuperCluster &cluster,
                                                                const EcalRecHitCollection *recHits,
                                                                const CaloTopology *topology,
                                                                float w0) {
@@ -1453,10 +1453,10 @@ std::vector<float> EcalClusterToolsT<noZS>::scLocalCovariances(const reco::Super
     covPhiPhi = 0;
   }
 
-  std::vector<float> v;
-  v.push_back(covEtaEta);
-  v.push_back(covEtaPhi);
-  v.push_back(covPhiPhi);
+  std::array<float,3> v;
+  v[0]=covEtaEta;
+  v[1]=covEtaPhi;
+  v[2]=covPhiPhi;
 
   return v;
 }

--- a/RecoEcal/EgammaCoreTools/test/testEcalClusterLazyTools.cc
+++ b/RecoEcal/EgammaCoreTools/test/testEcalClusterLazyTools.cc
@@ -102,9 +102,9 @@ void testEcalClusterLazyTools::analyze(const edm::Event& ev, const edm::EventSet
     std::cout << std::endl;
     std::vector<float> vLat = lazyTools.lat(clus);
     std::cout << "lat...................... " << vLat[0] << " " << vLat[1] << " " << vLat[2] << std::endl;
-    std::vector<float> vCov = lazyTools.covariances(clus);
+    std::array<float,3> vCov = lazyTools.covariances(clus);
     std::cout << "covariances.............. " << vCov[0] << " " << vCov[1] << " " << vCov[2] << std::endl;
-    std::vector<float> vLocCov = lazyTools.localCovariances(clus);
+    std::array<float,3> vLocCov = lazyTools.localCovariances(clus);
     std::cout << "local covariances........ " << vLocCov[0] << " " << vLocCov[1] << " " << vLocCov[2] << std::endl;
     std::cout << "zernike20................ " << lazyTools.zernike20(clus) << std::endl;
     std::cout << "zernike42................ " << lazyTools.zernike42(clus) << std::endl;
@@ -132,9 +132,9 @@ void testEcalClusterLazyTools::analyze(const edm::Event& ev, const edm::EventSet
     std::cout << "e2nd..................... " << lazyTools.e2nd(clus) << std::endl;
     std::vector<float> vLat = lazyTools.lat(clus);
     std::cout << "lat...................... " << vLat[0] << " " << vLat[1] << " " << vLat[2] << std::endl;
-    std::vector<float> vCov = lazyTools.covariances(clus);
+    std::array<float,3> vCov = lazyTools.covariances(clus);
     std::cout << "covariances.............. " << vCov[0] << " " << vCov[1] << " " << vCov[2] << std::endl;
-    std::vector<float> vLocCov = lazyTools.localCovariances(clus);
+    std::array<float,3> vLocCov = lazyTools.localCovariances(clus);
     std::cout << "local covariances........ " << vLocCov[0] << " " << vLocCov[1] << " " << vLocCov[2] << std::endl;
     std::cout << "zernike20................ " << lazyTools.zernike20(clus) << std::endl;
     std::cout << "zernike42................ " << lazyTools.zernike42(clus) << std::endl;

--- a/RecoEcal/EgammaCoreTools/test/testEcalClusterLazyTools.cc
+++ b/RecoEcal/EgammaCoreTools/test/testEcalClusterLazyTools.cc
@@ -104,7 +104,7 @@ void testEcalClusterLazyTools::analyze(const edm::Event& ev, const edm::EventSet
     std::cout << "lat...................... " << vLat[0] << " " << vLat[1] << " " << vLat[2] << std::endl;
     const auto& vCov = lazyTools.covariances(clus);
     std::cout << "covariances.............. " << vCov[0] << " " << vCov[1] << " " << vCov[2] << std::endl;
-    std::array<float, 3> vLocCov = lazyTools.localCovariances(clus);
+    const auto& vLocCov = lazyTools.localCovariances(clus);
     std::cout << "local covariances........ " << vLocCov[0] << " " << vLocCov[1] << " " << vLocCov[2] << std::endl;
     std::cout << "zernike20................ " << lazyTools.zernike20(clus) << std::endl;
     std::cout << "zernike42................ " << lazyTools.zernike42(clus) << std::endl;
@@ -132,9 +132,9 @@ void testEcalClusterLazyTools::analyze(const edm::Event& ev, const edm::EventSet
     std::cout << "e2nd..................... " << lazyTools.e2nd(clus) << std::endl;
     std::vector<float> vLat = lazyTools.lat(clus);
     std::cout << "lat...................... " << vLat[0] << " " << vLat[1] << " " << vLat[2] << std::endl;
-    std::array<float, 3> vCov = lazyTools.covariances(clus);
+    const auto& vCov = lazyTools.covariances(clus);
     std::cout << "covariances.............. " << vCov[0] << " " << vCov[1] << " " << vCov[2] << std::endl;
-    std::array<float, 3> vLocCov = lazyTools.localCovariances(clus);
+    const auto& vLocCov = lazyTools.localCovariances(clus);
     std::cout << "local covariances........ " << vLocCov[0] << " " << vLocCov[1] << " " << vLocCov[2] << std::endl;
     std::cout << "zernike20................ " << lazyTools.zernike20(clus) << std::endl;
     std::cout << "zernike42................ " << lazyTools.zernike42(clus) << std::endl;

--- a/RecoEcal/EgammaCoreTools/test/testEcalClusterLazyTools.cc
+++ b/RecoEcal/EgammaCoreTools/test/testEcalClusterLazyTools.cc
@@ -102,9 +102,9 @@ void testEcalClusterLazyTools::analyze(const edm::Event& ev, const edm::EventSet
     std::cout << std::endl;
     std::vector<float> vLat = lazyTools.lat(clus);
     std::cout << "lat...................... " << vLat[0] << " " << vLat[1] << " " << vLat[2] << std::endl;
-    std::array<float,3> vCov = lazyTools.covariances(clus);
+    std::array<float, 3> vCov = lazyTools.covariances(clus);
     std::cout << "covariances.............. " << vCov[0] << " " << vCov[1] << " " << vCov[2] << std::endl;
-    std::array<float,3> vLocCov = lazyTools.localCovariances(clus);
+    std::array<float, 3> vLocCov = lazyTools.localCovariances(clus);
     std::cout << "local covariances........ " << vLocCov[0] << " " << vLocCov[1] << " " << vLocCov[2] << std::endl;
     std::cout << "zernike20................ " << lazyTools.zernike20(clus) << std::endl;
     std::cout << "zernike42................ " << lazyTools.zernike42(clus) << std::endl;
@@ -132,9 +132,9 @@ void testEcalClusterLazyTools::analyze(const edm::Event& ev, const edm::EventSet
     std::cout << "e2nd..................... " << lazyTools.e2nd(clus) << std::endl;
     std::vector<float> vLat = lazyTools.lat(clus);
     std::cout << "lat...................... " << vLat[0] << " " << vLat[1] << " " << vLat[2] << std::endl;
-    std::array<float,3> vCov = lazyTools.covariances(clus);
+    std::array<float, 3> vCov = lazyTools.covariances(clus);
     std::cout << "covariances.............. " << vCov[0] << " " << vCov[1] << " " << vCov[2] << std::endl;
-    std::array<float,3> vLocCov = lazyTools.localCovariances(clus);
+    std::array<float, 3> vLocCov = lazyTools.localCovariances(clus);
     std::cout << "local covariances........ " << vLocCov[0] << " " << vLocCov[1] << " " << vLocCov[2] << std::endl;
     std::cout << "zernike20................ " << lazyTools.zernike20(clus) << std::endl;
     std::cout << "zernike42................ " << lazyTools.zernike42(clus) << std::endl;

--- a/RecoEcal/EgammaCoreTools/test/testEcalClusterLazyTools.cc
+++ b/RecoEcal/EgammaCoreTools/test/testEcalClusterLazyTools.cc
@@ -102,7 +102,7 @@ void testEcalClusterLazyTools::analyze(const edm::Event& ev, const edm::EventSet
     std::cout << std::endl;
     std::vector<float> vLat = lazyTools.lat(clus);
     std::cout << "lat...................... " << vLat[0] << " " << vLat[1] << " " << vLat[2] << std::endl;
-    std::array<float, 3> vCov = lazyTools.covariances(clus);
+    const auto& vCov = lazyTools.covariances(clus);
     std::cout << "covariances.............. " << vCov[0] << " " << vCov[1] << " " << vCov[2] << std::endl;
     std::array<float, 3> vLocCov = lazyTools.localCovariances(clus);
     std::cout << "local covariances........ " << vLocCov[0] << " " << vLocCov[1] << " " << vLocCov[2] << std::endl;

--- a/RecoEcal/EgammaCoreTools/test/testEcalClusterTools.cc
+++ b/RecoEcal/EgammaCoreTools/test/testEcalClusterTools.cc
@@ -116,9 +116,9 @@ void testEcalClusterTools::analyze(const edm::Event& ev, const edm::EventSetup& 
     std::cout << std::endl;
     std::vector<float> vLat = ClusterTools::lat(clus, ebRecHits, geometry);
     std::cout << "lat...................... " << vLat[0] << " " << vLat[1] << " " << vLat[2] << std::endl;
-    std::vector<float> vCov = ClusterTools::covariances(clus, ebRecHits, topology, geometry);
+    std::array<float,3> vCov = ClusterTools::covariances(clus, ebRecHits, topology, geometry);
     std::cout << "covariances.............. " << vCov[0] << " " << vCov[1] << " " << vCov[2] << std::endl;
-    std::vector<float> vLocCov = ClusterTools::localCovariances(clus, ebRecHits, topology);
+    std::array<float,3> vLocCov = ClusterTools::localCovariances(clus, ebRecHits, topology);
     std::cout << "local covariances........ " << vLocCov[0] << " " << vLocCov[1] << " " << vLocCov[2] << std::endl;
     std::cout << "zernike20................ " << ClusterTools::zernike20(clus, ebRecHits, geometry) << std::endl;
     std::cout << "zernike42................ " << ClusterTools::zernike42(clus, ebRecHits, geometry) << std::endl;
@@ -150,9 +150,9 @@ void testEcalClusterTools::analyze(const edm::Event& ev, const edm::EventSetup& 
     std::cout << "e2nd..................... " << ClusterTools::e2nd(clus, eeRecHits) << std::endl;
     std::vector<float> vLat = ClusterTools::lat(clus, eeRecHits, geometry);
     std::cout << "lat...................... " << vLat[0] << " " << vLat[1] << " " << vLat[2] << std::endl;
-    std::vector<float> vCov = ClusterTools::covariances(clus, eeRecHits, topology, geometry);
+    std::array<float,3> vCov = ClusterTools::covariances(clus, eeRecHits, topology, geometry);
     std::cout << "covariances.............. " << vCov[0] << " " << vCov[1] << " " << vCov[2] << std::endl;
-    std::vector<float> vLocCov = ClusterTools::localCovariances(clus, eeRecHits, topology);
+    std::array<float,3> vLocCov = ClusterTools::localCovariances(clus, eeRecHits, topology);
     std::cout << "local covariances........ " << vLocCov[0] << " " << vLocCov[1] << " " << vLocCov[2] << std::endl;
     std::cout << "zernike20................ " << ClusterTools::zernike20(clus, eeRecHits, geometry) << std::endl;
     std::cout << "zernike42................ " << ClusterTools::zernike42(clus, eeRecHits, geometry) << std::endl;

--- a/RecoEcal/EgammaCoreTools/test/testEcalClusterTools.cc
+++ b/RecoEcal/EgammaCoreTools/test/testEcalClusterTools.cc
@@ -116,9 +116,9 @@ void testEcalClusterTools::analyze(const edm::Event& ev, const edm::EventSetup& 
     std::cout << std::endl;
     std::vector<float> vLat = ClusterTools::lat(clus, ebRecHits, geometry);
     std::cout << "lat...................... " << vLat[0] << " " << vLat[1] << " " << vLat[2] << std::endl;
-    std::array<float, 3> vCov = ClusterTools::covariances(clus, ebRecHits, topology, geometry);
+    const auto& vCov = ClusterTools::covariances(clus, ebRecHits, topology, geometry);
     std::cout << "covariances.............. " << vCov[0] << " " << vCov[1] << " " << vCov[2] << std::endl;
-    std::array<float, 3> vLocCov = ClusterTools::localCovariances(clus, ebRecHits, topology);
+    const auto& vLocCov = ClusterTools::localCovariances(clus, ebRecHits, topology);
     std::cout << "local covariances........ " << vLocCov[0] << " " << vLocCov[1] << " " << vLocCov[2] << std::endl;
     std::cout << "zernike20................ " << ClusterTools::zernike20(clus, ebRecHits, geometry) << std::endl;
     std::cout << "zernike42................ " << ClusterTools::zernike42(clus, ebRecHits, geometry) << std::endl;
@@ -150,9 +150,9 @@ void testEcalClusterTools::analyze(const edm::Event& ev, const edm::EventSetup& 
     std::cout << "e2nd..................... " << ClusterTools::e2nd(clus, eeRecHits) << std::endl;
     std::vector<float> vLat = ClusterTools::lat(clus, eeRecHits, geometry);
     std::cout << "lat...................... " << vLat[0] << " " << vLat[1] << " " << vLat[2] << std::endl;
-    std::array<float, 3> vCov = ClusterTools::covariances(clus, eeRecHits, topology, geometry);
+    const auto& vCov = ClusterTools::covariances(clus, eeRecHits, topology, geometry);
     std::cout << "covariances.............. " << vCov[0] << " " << vCov[1] << " " << vCov[2] << std::endl;
-    std::array<float, 3> vLocCov = ClusterTools::localCovariances(clus, eeRecHits, topology);
+    const auto& vLocCov = ClusterTools::localCovariances(clus, eeRecHits, topology);
     std::cout << "local covariances........ " << vLocCov[0] << " " << vLocCov[1] << " " << vLocCov[2] << std::endl;
     std::cout << "zernike20................ " << ClusterTools::zernike20(clus, eeRecHits, geometry) << std::endl;
     std::cout << "zernike42................ " << ClusterTools::zernike42(clus, eeRecHits, geometry) << std::endl;

--- a/RecoEcal/EgammaCoreTools/test/testEcalClusterTools.cc
+++ b/RecoEcal/EgammaCoreTools/test/testEcalClusterTools.cc
@@ -116,9 +116,9 @@ void testEcalClusterTools::analyze(const edm::Event& ev, const edm::EventSetup& 
     std::cout << std::endl;
     std::vector<float> vLat = ClusterTools::lat(clus, ebRecHits, geometry);
     std::cout << "lat...................... " << vLat[0] << " " << vLat[1] << " " << vLat[2] << std::endl;
-    std::array<float,3> vCov = ClusterTools::covariances(clus, ebRecHits, topology, geometry);
+    std::array<float, 3> vCov = ClusterTools::covariances(clus, ebRecHits, topology, geometry);
     std::cout << "covariances.............. " << vCov[0] << " " << vCov[1] << " " << vCov[2] << std::endl;
-    std::array<float,3> vLocCov = ClusterTools::localCovariances(clus, ebRecHits, topology);
+    std::array<float, 3> vLocCov = ClusterTools::localCovariances(clus, ebRecHits, topology);
     std::cout << "local covariances........ " << vLocCov[0] << " " << vLocCov[1] << " " << vLocCov[2] << std::endl;
     std::cout << "zernike20................ " << ClusterTools::zernike20(clus, ebRecHits, geometry) << std::endl;
     std::cout << "zernike42................ " << ClusterTools::zernike42(clus, ebRecHits, geometry) << std::endl;
@@ -150,9 +150,9 @@ void testEcalClusterTools::analyze(const edm::Event& ev, const edm::EventSetup& 
     std::cout << "e2nd..................... " << ClusterTools::e2nd(clus, eeRecHits) << std::endl;
     std::vector<float> vLat = ClusterTools::lat(clus, eeRecHits, geometry);
     std::cout << "lat...................... " << vLat[0] << " " << vLat[1] << " " << vLat[2] << std::endl;
-    std::array<float,3> vCov = ClusterTools::covariances(clus, eeRecHits, topology, geometry);
+    std::array<float, 3> vCov = ClusterTools::covariances(clus, eeRecHits, topology, geometry);
     std::cout << "covariances.............. " << vCov[0] << " " << vCov[1] << " " << vCov[2] << std::endl;
-    std::array<float,3> vLocCov = ClusterTools::localCovariances(clus, eeRecHits, topology);
+    std::array<float, 3> vLocCov = ClusterTools::localCovariances(clus, eeRecHits, topology);
     std::cout << "local covariances........ " << vLocCov[0] << " " << vLocCov[1] << " " << vLocCov[2] << std::endl;
     std::cout << "zernike20................ " << ClusterTools::zernike20(clus, eeRecHits, geometry) << std::endl;
     std::cout << "zernike42................ " << ClusterTools::zernike42(clus, eeRecHits, geometry) << std::endl;

--- a/RecoEgamma/EgammaElectronAlgos/src/GsfElectronAlgo.cc
+++ b/RecoEgamma/EgammaElectronAlgos/src/GsfElectronAlgo.cc
@@ -316,18 +316,19 @@ reco::GsfElectron::ShowerShape GsfElectronAlgo::calculateShowerShape(const reco:
     recHitSeverityToBeExcluded = cfg_.recHits.recHitSeverityToBeExcludedEndcaps;
   }
 
-  std::array<float,3> covariances = ClusterTools::covariances(seedCluster, recHits, &topology, &geometry);
+  std::array<float, 3> covariances = ClusterTools::covariances(seedCluster, recHits, &topology, &geometry);
 
   // do noise-cleaning for full5x5, by passing per crystal PF recHit thresholds and mult values
   // mult values for EB and EE were obtained by dedicated studies
-  std::array<float,3> localCovariances = full5x5 ? ClusterTools::localCovariances(seedCluster,
-                                                                                 recHits,
-                                                                                 &topology,
-                                                                                 EgammaLocalCovParamDefaults::kRelEnCut,
-                                                                                 &thresholds,
-                                                                                 cfg_.cuts.multThresEB,
-                                                                                 cfg_.cuts.multThresEE)
-                                                : ClusterTools::localCovariances(seedCluster, recHits, &topology);
+  std::array<float, 3> localCovariances = full5x5
+                                              ? ClusterTools::localCovariances(seedCluster,
+                                                                               recHits,
+                                                                               &topology,
+                                                                               EgammaLocalCovParamDefaults::kRelEnCut,
+                                                                               &thresholds,
+                                                                               cfg_.cuts.multThresEB,
+                                                                               cfg_.cuts.multThresEE)
+                                              : ClusterTools::localCovariances(seedCluster, recHits, &topology);
 
   showerShape.sigmaEtaEta = sqrt(covariances[0]);
   showerShape.sigmaIetaIeta = sqrt(localCovariances[0]);

--- a/RecoEgamma/EgammaElectronAlgos/src/GsfElectronAlgo.cc
+++ b/RecoEgamma/EgammaElectronAlgos/src/GsfElectronAlgo.cc
@@ -316,19 +316,18 @@ reco::GsfElectron::ShowerShape GsfElectronAlgo::calculateShowerShape(const reco:
     recHitSeverityToBeExcluded = cfg_.recHits.recHitSeverityToBeExcludedEndcaps;
   }
 
-  std::array<float, 3> covariances = ClusterTools::covariances(seedCluster, recHits, &topology, &geometry);
+  const auto& covariances = ClusterTools::covariances(seedCluster, recHits, &topology, &geometry);
 
   // do noise-cleaning for full5x5, by passing per crystal PF recHit thresholds and mult values
   // mult values for EB and EE were obtained by dedicated studies
-  std::array<float, 3> localCovariances = full5x5
-                                              ? ClusterTools::localCovariances(seedCluster,
-                                                                               recHits,
-                                                                               &topology,
-                                                                               EgammaLocalCovParamDefaults::kRelEnCut,
-                                                                               &thresholds,
-                                                                               cfg_.cuts.multThresEB,
-                                                                               cfg_.cuts.multThresEE)
-                                              : ClusterTools::localCovariances(seedCluster, recHits, &topology);
+  const auto& localCovariances = full5x5 ? ClusterTools::localCovariances(seedCluster,
+									  recHits,
+									  &topology,
+									  EgammaLocalCovParamDefaults::kRelEnCut,
+									  &thresholds,
+									  cfg_.cuts.multThresEB,
+									  cfg_.cuts.multThresEE)
+                                         : ClusterTools::localCovariances(seedCluster, recHits, &topology);
 
   showerShape.sigmaEtaEta = sqrt(covariances[0]);
   showerShape.sigmaIetaIeta = sqrt(localCovariances[0]);

--- a/RecoEgamma/EgammaElectronAlgos/src/GsfElectronAlgo.cc
+++ b/RecoEgamma/EgammaElectronAlgos/src/GsfElectronAlgo.cc
@@ -316,11 +316,11 @@ reco::GsfElectron::ShowerShape GsfElectronAlgo::calculateShowerShape(const reco:
     recHitSeverityToBeExcluded = cfg_.recHits.recHitSeverityToBeExcludedEndcaps;
   }
 
-  std::vector<float> covariances = ClusterTools::covariances(seedCluster, recHits, &topology, &geometry);
+  std::array<float,3> covariances = ClusterTools::covariances(seedCluster, recHits, &topology, &geometry);
 
   // do noise-cleaning for full5x5, by passing per crystal PF recHit thresholds and mult values
   // mult values for EB and EE were obtained by dedicated studies
-  std::vector<float> localCovariances = full5x5 ? ClusterTools::localCovariances(seedCluster,
+  std::array<float,3> localCovariances = full5x5 ? ClusterTools::localCovariances(seedCluster,
                                                                                  recHits,
                                                                                  &topology,
                                                                                  EgammaLocalCovParamDefaults::kRelEnCut,

--- a/RecoEgamma/EgammaElectronAlgos/src/GsfElectronAlgo.cc
+++ b/RecoEgamma/EgammaElectronAlgos/src/GsfElectronAlgo.cc
@@ -321,12 +321,12 @@ reco::GsfElectron::ShowerShape GsfElectronAlgo::calculateShowerShape(const reco:
   // do noise-cleaning for full5x5, by passing per crystal PF recHit thresholds and mult values
   // mult values for EB and EE were obtained by dedicated studies
   const auto& localCovariances = full5x5 ? ClusterTools::localCovariances(seedCluster,
-									  recHits,
-									  &topology,
-									  EgammaLocalCovParamDefaults::kRelEnCut,
-									  &thresholds,
-									  cfg_.cuts.multThresEB,
-									  cfg_.cuts.multThresEE)
+                                                                          recHits,
+                                                                          &topology,
+                                                                          EgammaLocalCovParamDefaults::kRelEnCut,
+                                                                          &thresholds,
+                                                                          cfg_.cuts.multThresEB,
+                                                                          cfg_.cuts.multThresEE)
                                          : ClusterTools::localCovariances(seedCluster, recHits, &topology);
 
   showerShape.sigmaEtaEta = sqrt(covariances[0]);

--- a/RecoEgamma/EgammaHLTProducers/plugins/EgammaHLTClusterShapeProducer.cc
+++ b/RecoEgamma/EgammaHLTProducers/plugins/EgammaHLTClusterShapeProducer.cc
@@ -100,13 +100,12 @@ void EgammaHLTClusterShapeProducer::produce(edm::StreamID sid,
       continue;
     }
 
-    std::array<float, 3> vCov;
     double sigmaee;
     if (EtaOrIeta_) {
-      vCov = lazyTools.localCovariances(*(recoecalcandref->superCluster()->seed()));
+      const auto& vCov = lazyTools.localCovariances(*(recoecalcandref->superCluster()->seed()));
       sigmaee = sqrt(vCov[0]);
     } else {
-      vCov = lazyTools.covariances(*(recoecalcandref->superCluster()->seed()));
+      const auto& vCov = lazyTools.covariances(*(recoecalcandref->superCluster()->seed()));
       sigmaee = sqrt(vCov[0]);
       double EtaSC = recoecalcandref->eta();
       if (EtaSC > 1.479)

--- a/RecoEgamma/EgammaHLTProducers/plugins/EgammaHLTClusterShapeProducer.cc
+++ b/RecoEgamma/EgammaHLTProducers/plugins/EgammaHLTClusterShapeProducer.cc
@@ -100,7 +100,7 @@ void EgammaHLTClusterShapeProducer::produce(edm::StreamID sid,
       continue;
     }
 
-    std::vector<float> vCov;
+    std::array<float,3> vCov;
     double sigmaee;
     if (EtaOrIeta_) {
       vCov = lazyTools.localCovariances(*(recoecalcandref->superCluster()->seed()));

--- a/RecoEgamma/EgammaHLTProducers/plugins/EgammaHLTClusterShapeProducer.cc
+++ b/RecoEgamma/EgammaHLTProducers/plugins/EgammaHLTClusterShapeProducer.cc
@@ -100,7 +100,7 @@ void EgammaHLTClusterShapeProducer::produce(edm::StreamID sid,
       continue;
     }
 
-    std::array<float,3> vCov;
+    std::array<float, 3> vCov;
     double sigmaee;
     if (EtaOrIeta_) {
       vCov = lazyTools.localCovariances(*(recoecalcandref->superCluster()->seed()));

--- a/RecoEgamma/EgammaPhotonProducers/src/GEDPhotonProducer.cc
+++ b/RecoEgamma/EgammaPhotonProducers/src/GEDPhotonProducer.cc
@@ -596,12 +596,13 @@ void GEDPhotonProducer::fillPhotonCollection(edm::Event& evt,
     float e2x5 = (hits != nullptr ? EcalClusterTools::e2x5Max(*(scRef->seed()), hits, topology) : 0.f);
     float e3x3 = (hits != nullptr ? EcalClusterTools::e3x3(*(scRef->seed()), hits, topology) : 0.f);
     float e5x5 = (hits != nullptr ? EcalClusterTools::e5x5(*(scRef->seed()), hits, topology) : 0.f);
-    std::array<float,3> cov =
+    std::array<float, 3> cov =
         (hits != nullptr ? EcalClusterTools::covariances(*(scRef->seed()), hits, topology, caloGeom_)
-	 : std::array<float,3>({{0.f, 0.f, 0.f}}));
+                         : std::array<float, 3>({{0.f, 0.f, 0.f}}));
     // fractional local covariances
-    std::array<float,3> locCov = (hits != nullptr ? EcalClusterTools::localCovariances(*(scRef->seed()), hits, topology)
-				  : std::array<float,3>({{0.f, 0.f, 0.f}}));
+    std::array<float, 3> locCov =
+        (hits != nullptr ? EcalClusterTools::localCovariances(*(scRef->seed()), hits, topology)
+                         : std::array<float, 3>({{0.f, 0.f, 0.f}}));
 
     float sigmaEtaEta = std::sqrt(cov[0]);
     float sigmaIetaIeta = std::sqrt(locCov[0]);
@@ -613,13 +614,13 @@ void GEDPhotonProducer::fillPhotonCollection(edm::Event& evt,
     float full5x5_e2x5 = (hits != nullptr ? noZS::EcalClusterTools::e2x5Max(*(scRef->seed()), hits, topology) : 0.f);
     float full5x5_e3x3 = (hits != nullptr ? noZS::EcalClusterTools::e3x3(*(scRef->seed()), hits, topology) : 0.f);
     float full5x5_e5x5 = (hits != nullptr ? noZS::EcalClusterTools::e5x5(*(scRef->seed()), hits, topology) : 0.f);
-    std::array<float,3> full5x5_cov =
+    std::array<float, 3> full5x5_cov =
         (hits != nullptr ? noZS::EcalClusterTools::covariances(*(scRef->seed()), hits, topology, caloGeom_)
-	 : std::array<float,3>({{0.f, 0.f, 0.f}}));
+                         : std::array<float, 3>({{0.f, 0.f, 0.f}}));
     // for full5x5 local covariances, do noise-cleaning
     // by passing per crystal PF recHit thresholds and mult values.
     // mult values for EB and EE were obtained by dedicated studies.
-    std::array<float,3> full5x5_locCov =
+    std::array<float, 3> full5x5_locCov =
         (hits != nullptr ? noZS::EcalClusterTools::localCovariances(*(scRef->seed()),
                                                                     hits,
                                                                     topology,
@@ -627,7 +628,7 @@ void GEDPhotonProducer::fillPhotonCollection(edm::Event& evt,
                                                                     &thresholds,
                                                                     multThresEB_,
                                                                     multThresEE_)
-	 : std::array<float,3>({{0.f, 0.f, 0.f}}));
+                         : std::array<float, 3>({{0.f, 0.f, 0.f}}));
 
     float full5x5_sigmaEtaEta = sqrt(full5x5_cov[0]);
     float full5x5_sigmaIetaIeta = sqrt(full5x5_locCov[0]);

--- a/RecoEgamma/EgammaPhotonProducers/src/GEDPhotonProducer.cc
+++ b/RecoEgamma/EgammaPhotonProducers/src/GEDPhotonProducer.cc
@@ -596,11 +596,11 @@ void GEDPhotonProducer::fillPhotonCollection(edm::Event& evt,
     float e2x5 = (hits != nullptr ? EcalClusterTools::e2x5Max(*(scRef->seed()), hits, topology) : 0.f);
     float e3x3 = (hits != nullptr ? EcalClusterTools::e3x3(*(scRef->seed()), hits, topology) : 0.f);
     float e5x5 = (hits != nullptr ? EcalClusterTools::e5x5(*(scRef->seed()), hits, topology) : 0.f);
-    std::array<float, 3> cov =
+    const auto& cov =
         (hits != nullptr ? EcalClusterTools::covariances(*(scRef->seed()), hits, topology, caloGeom_)
                          : std::array<float, 3>({{0.f, 0.f, 0.f}}));
     // fractional local covariances
-    std::array<float, 3> locCov =
+    const auto& locCov =
         (hits != nullptr ? EcalClusterTools::localCovariances(*(scRef->seed()), hits, topology)
                          : std::array<float, 3>({{0.f, 0.f, 0.f}}));
 
@@ -614,13 +614,13 @@ void GEDPhotonProducer::fillPhotonCollection(edm::Event& evt,
     float full5x5_e2x5 = (hits != nullptr ? noZS::EcalClusterTools::e2x5Max(*(scRef->seed()), hits, topology) : 0.f);
     float full5x5_e3x3 = (hits != nullptr ? noZS::EcalClusterTools::e3x3(*(scRef->seed()), hits, topology) : 0.f);
     float full5x5_e5x5 = (hits != nullptr ? noZS::EcalClusterTools::e5x5(*(scRef->seed()), hits, topology) : 0.f);
-    std::array<float, 3> full5x5_cov =
+    const auto& full5x5_cov =
         (hits != nullptr ? noZS::EcalClusterTools::covariances(*(scRef->seed()), hits, topology, caloGeom_)
                          : std::array<float, 3>({{0.f, 0.f, 0.f}}));
     // for full5x5 local covariances, do noise-cleaning
     // by passing per crystal PF recHit thresholds and mult values.
     // mult values for EB and EE were obtained by dedicated studies.
-    std::array<float, 3> full5x5_locCov =
+    const auto& full5x5_locCov =
         (hits != nullptr ? noZS::EcalClusterTools::localCovariances(*(scRef->seed()),
                                                                     hits,
                                                                     topology,

--- a/RecoEgamma/EgammaPhotonProducers/src/GEDPhotonProducer.cc
+++ b/RecoEgamma/EgammaPhotonProducers/src/GEDPhotonProducer.cc
@@ -596,13 +596,11 @@ void GEDPhotonProducer::fillPhotonCollection(edm::Event& evt,
     float e2x5 = (hits != nullptr ? EcalClusterTools::e2x5Max(*(scRef->seed()), hits, topology) : 0.f);
     float e3x3 = (hits != nullptr ? EcalClusterTools::e3x3(*(scRef->seed()), hits, topology) : 0.f);
     float e5x5 = (hits != nullptr ? EcalClusterTools::e5x5(*(scRef->seed()), hits, topology) : 0.f);
-    const auto& cov =
-        (hits != nullptr ? EcalClusterTools::covariances(*(scRef->seed()), hits, topology, caloGeom_)
-                         : std::array<float, 3>({{0.f, 0.f, 0.f}}));
+    const auto& cov = (hits != nullptr ? EcalClusterTools::covariances(*(scRef->seed()), hits, topology, caloGeom_)
+                                       : std::array<float, 3>({{0.f, 0.f, 0.f}}));
     // fractional local covariances
-    const auto& locCov =
-        (hits != nullptr ? EcalClusterTools::localCovariances(*(scRef->seed()), hits, topology)
-                         : std::array<float, 3>({{0.f, 0.f, 0.f}}));
+    const auto& locCov = (hits != nullptr ? EcalClusterTools::localCovariances(*(scRef->seed()), hits, topology)
+                                          : std::array<float, 3>({{0.f, 0.f, 0.f}}));
 
     float sigmaEtaEta = std::sqrt(cov[0]);
     float sigmaIetaIeta = std::sqrt(locCov[0]);

--- a/RecoEgamma/EgammaPhotonProducers/src/GEDPhotonProducer.cc
+++ b/RecoEgamma/EgammaPhotonProducers/src/GEDPhotonProducer.cc
@@ -596,12 +596,12 @@ void GEDPhotonProducer::fillPhotonCollection(edm::Event& evt,
     float e2x5 = (hits != nullptr ? EcalClusterTools::e2x5Max(*(scRef->seed()), hits, topology) : 0.f);
     float e3x3 = (hits != nullptr ? EcalClusterTools::e3x3(*(scRef->seed()), hits, topology) : 0.f);
     float e5x5 = (hits != nullptr ? EcalClusterTools::e5x5(*(scRef->seed()), hits, topology) : 0.f);
-    std::vector<float> cov =
+    std::array<float,3> cov =
         (hits != nullptr ? EcalClusterTools::covariances(*(scRef->seed()), hits, topology, caloGeom_)
-                         : std::vector<float>({0.f, 0.f, 0.f}));
+	 : std::array<float,3>({{0.f, 0.f, 0.f}}));
     // fractional local covariances
-    std::vector<float> locCov = (hits != nullptr ? EcalClusterTools::localCovariances(*(scRef->seed()), hits, topology)
-                                                 : std::vector<float>({0.f, 0.f, 0.f}));
+    std::array<float,3> locCov = (hits != nullptr ? EcalClusterTools::localCovariances(*(scRef->seed()), hits, topology)
+				  : std::array<float,3>({{0.f, 0.f, 0.f}}));
 
     float sigmaEtaEta = std::sqrt(cov[0]);
     float sigmaIetaIeta = std::sqrt(locCov[0]);
@@ -613,13 +613,13 @@ void GEDPhotonProducer::fillPhotonCollection(edm::Event& evt,
     float full5x5_e2x5 = (hits != nullptr ? noZS::EcalClusterTools::e2x5Max(*(scRef->seed()), hits, topology) : 0.f);
     float full5x5_e3x3 = (hits != nullptr ? noZS::EcalClusterTools::e3x3(*(scRef->seed()), hits, topology) : 0.f);
     float full5x5_e5x5 = (hits != nullptr ? noZS::EcalClusterTools::e5x5(*(scRef->seed()), hits, topology) : 0.f);
-    std::vector<float> full5x5_cov =
+    std::array<float,3> full5x5_cov =
         (hits != nullptr ? noZS::EcalClusterTools::covariances(*(scRef->seed()), hits, topology, caloGeom_)
-                         : std::vector<float>({0.f, 0.f, 0.f}));
+	 : std::array<float,3>({{0.f, 0.f, 0.f}}));
     // for full5x5 local covariances, do noise-cleaning
     // by passing per crystal PF recHit thresholds and mult values.
     // mult values for EB and EE were obtained by dedicated studies.
-    std::vector<float> full5x5_locCov =
+    std::array<float,3> full5x5_locCov =
         (hits != nullptr ? noZS::EcalClusterTools::localCovariances(*(scRef->seed()),
                                                                     hits,
                                                                     topology,
@@ -627,7 +627,7 @@ void GEDPhotonProducer::fillPhotonCollection(edm::Event& evt,
                                                                     &thresholds,
                                                                     multThresEB_,
                                                                     multThresEE_)
-                         : std::vector<float>({0.f, 0.f, 0.f}));
+	 : std::array<float,3>({{0.f, 0.f, 0.f}}));
 
     float full5x5_sigmaEtaEta = sqrt(full5x5_cov[0]);
     float full5x5_sigmaIetaIeta = sqrt(full5x5_locCov[0]);

--- a/RecoEgamma/EgammaPhotonProducers/src/PhotonProducer.cc
+++ b/RecoEgamma/EgammaPhotonProducers/src/PhotonProducer.cc
@@ -368,8 +368,8 @@ void PhotonProducer::fillPhotonCollection(edm::Event& evt,
     float e2x5 = EcalClusterTools::e2x5Max(*(scRef->seed()), &(*hits), &(*topology));
     float e3x3 = EcalClusterTools::e3x3(*(scRef->seed()), &(*hits), &(*topology));
     float e5x5 = EcalClusterTools::e5x5(*(scRef->seed()), &(*hits), &(*topology));
-    std::array<float, 3> cov = EcalClusterTools::covariances(*(scRef->seed()), &(*hits), &(*topology), geometry);
-    std::array<float, 3> locCov = EcalClusterTools::localCovariances(*(scRef->seed()), &(*hits), &(*topology));
+    const auto& cov = EcalClusterTools::covariances(*(scRef->seed()), &(*hits), &(*topology), geometry);
+    const auto& locCov = EcalClusterTools::localCovariances(*(scRef->seed()), &(*hits), &(*topology));
 
     float sigmaEtaEta = sqrt(cov[0]);
     float sigmaIetaIeta = sqrt(locCov[0]);
@@ -382,9 +382,9 @@ void PhotonProducer::fillPhotonCollection(edm::Event& evt,
     float full5x5_e2x5 = noZS::EcalClusterTools::e2x5Max(*(scRef->seed()), &(*hits), &(*topology));
     float full5x5_e3x3 = noZS::EcalClusterTools::e3x3(*(scRef->seed()), &(*hits), &(*topology));
     float full5x5_e5x5 = noZS::EcalClusterTools::e5x5(*(scRef->seed()), &(*hits), &(*topology));
-    std::array<float, 3> full5x5_cov =
+    const auto& full5x5_cov =
         noZS::EcalClusterTools::covariances(*(scRef->seed()), &(*hits), &(*topology), geometry);
-    std::array<float, 3> full5x5_locCov =
+    const auto& full5x5_locCov =
         noZS::EcalClusterTools::localCovariances(*(scRef->seed()), &(*hits), &(*topology));
 
     float full5x5_sigmaEtaEta = sqrt(full5x5_cov[0]);

--- a/RecoEgamma/EgammaPhotonProducers/src/PhotonProducer.cc
+++ b/RecoEgamma/EgammaPhotonProducers/src/PhotonProducer.cc
@@ -368,8 +368,8 @@ void PhotonProducer::fillPhotonCollection(edm::Event& evt,
     float e2x5 = EcalClusterTools::e2x5Max(*(scRef->seed()), &(*hits), &(*topology));
     float e3x3 = EcalClusterTools::e3x3(*(scRef->seed()), &(*hits), &(*topology));
     float e5x5 = EcalClusterTools::e5x5(*(scRef->seed()), &(*hits), &(*topology));
-    std::array<float,3> cov = EcalClusterTools::covariances(*(scRef->seed()), &(*hits), &(*topology), geometry);
-    std::array<float,3> locCov = EcalClusterTools::localCovariances(*(scRef->seed()), &(*hits), &(*topology));
+    std::array<float, 3> cov = EcalClusterTools::covariances(*(scRef->seed()), &(*hits), &(*topology), geometry);
+    std::array<float, 3> locCov = EcalClusterTools::localCovariances(*(scRef->seed()), &(*hits), &(*topology));
 
     float sigmaEtaEta = sqrt(cov[0]);
     float sigmaIetaIeta = sqrt(locCov[0]);
@@ -382,9 +382,9 @@ void PhotonProducer::fillPhotonCollection(edm::Event& evt,
     float full5x5_e2x5 = noZS::EcalClusterTools::e2x5Max(*(scRef->seed()), &(*hits), &(*topology));
     float full5x5_e3x3 = noZS::EcalClusterTools::e3x3(*(scRef->seed()), &(*hits), &(*topology));
     float full5x5_e5x5 = noZS::EcalClusterTools::e5x5(*(scRef->seed()), &(*hits), &(*topology));
-    std::array<float,3> full5x5_cov =
+    std::array<float, 3> full5x5_cov =
         noZS::EcalClusterTools::covariances(*(scRef->seed()), &(*hits), &(*topology), geometry);
-    std::array<float,3> full5x5_locCov =
+    std::array<float, 3> full5x5_locCov =
         noZS::EcalClusterTools::localCovariances(*(scRef->seed()), &(*hits), &(*topology));
 
     float full5x5_sigmaEtaEta = sqrt(full5x5_cov[0]);

--- a/RecoEgamma/EgammaPhotonProducers/src/PhotonProducer.cc
+++ b/RecoEgamma/EgammaPhotonProducers/src/PhotonProducer.cc
@@ -382,10 +382,8 @@ void PhotonProducer::fillPhotonCollection(edm::Event& evt,
     float full5x5_e2x5 = noZS::EcalClusterTools::e2x5Max(*(scRef->seed()), &(*hits), &(*topology));
     float full5x5_e3x3 = noZS::EcalClusterTools::e3x3(*(scRef->seed()), &(*hits), &(*topology));
     float full5x5_e5x5 = noZS::EcalClusterTools::e5x5(*(scRef->seed()), &(*hits), &(*topology));
-    const auto& full5x5_cov =
-        noZS::EcalClusterTools::covariances(*(scRef->seed()), &(*hits), &(*topology), geometry);
-    const auto& full5x5_locCov =
-        noZS::EcalClusterTools::localCovariances(*(scRef->seed()), &(*hits), &(*topology));
+    const auto& full5x5_cov = noZS::EcalClusterTools::covariances(*(scRef->seed()), &(*hits), &(*topology), geometry);
+    const auto& full5x5_locCov = noZS::EcalClusterTools::localCovariances(*(scRef->seed()), &(*hits), &(*topology));
 
     float full5x5_sigmaEtaEta = sqrt(full5x5_cov[0]);
     float full5x5_sigmaIetaIeta = sqrt(full5x5_locCov[0]);

--- a/RecoEgamma/EgammaPhotonProducers/src/PhotonProducer.cc
+++ b/RecoEgamma/EgammaPhotonProducers/src/PhotonProducer.cc
@@ -368,8 +368,8 @@ void PhotonProducer::fillPhotonCollection(edm::Event& evt,
     float e2x5 = EcalClusterTools::e2x5Max(*(scRef->seed()), &(*hits), &(*topology));
     float e3x3 = EcalClusterTools::e3x3(*(scRef->seed()), &(*hits), &(*topology));
     float e5x5 = EcalClusterTools::e5x5(*(scRef->seed()), &(*hits), &(*topology));
-    std::vector<float> cov = EcalClusterTools::covariances(*(scRef->seed()), &(*hits), &(*topology), geometry);
-    std::vector<float> locCov = EcalClusterTools::localCovariances(*(scRef->seed()), &(*hits), &(*topology));
+    std::array<float,3> cov = EcalClusterTools::covariances(*(scRef->seed()), &(*hits), &(*topology), geometry);
+    std::array<float,3> locCov = EcalClusterTools::localCovariances(*(scRef->seed()), &(*hits), &(*topology));
 
     float sigmaEtaEta = sqrt(cov[0]);
     float sigmaIetaIeta = sqrt(locCov[0]);
@@ -382,9 +382,9 @@ void PhotonProducer::fillPhotonCollection(edm::Event& evt,
     float full5x5_e2x5 = noZS::EcalClusterTools::e2x5Max(*(scRef->seed()), &(*hits), &(*topology));
     float full5x5_e3x3 = noZS::EcalClusterTools::e3x3(*(scRef->seed()), &(*hits), &(*topology));
     float full5x5_e5x5 = noZS::EcalClusterTools::e5x5(*(scRef->seed()), &(*hits), &(*topology));
-    std::vector<float> full5x5_cov =
+    std::array<float,3> full5x5_cov =
         noZS::EcalClusterTools::covariances(*(scRef->seed()), &(*hits), &(*topology), geometry);
-    std::vector<float> full5x5_locCov =
+    std::array<float,3> full5x5_locCov =
         noZS::EcalClusterTools::localCovariances(*(scRef->seed()), &(*hits), &(*topology));
 
     float full5x5_sigmaEtaEta = sqrt(full5x5_cov[0]);

--- a/RecoEgamma/EgammaTools/src/EcalRegressionData.cc
+++ b/RecoEgamma/EgammaTools/src/EcalRegressionData.cc
@@ -80,7 +80,7 @@ void EcalRegressionData::fill(const reco::SuperCluster& superClus,
   eBottom_ = EcalClusterTools::eBottom(*superClus.seed(), recHits, topology);
   eLeft_ = EcalClusterTools::eLeft(*superClus.seed(), recHits, topology);
   eRight_ = EcalClusterTools::eRight(*superClus.seed(), recHits, topology);
-  std::array<float,3> localCovs = EcalClusterTools::localCovariances(*superClus.seed(), recHits, topology);
+  std::array<float, 3> localCovs = EcalClusterTools::localCovariances(*superClus.seed(), recHits, topology);
   sigmaIEtaIEta_ = edm::isNotFinite(localCovs[0]) ? 0. : std::sqrt(localCovs[0]);
   sigmaIPhiIPhi_ = edm::isNotFinite(localCovs[2]) ? 0. : std::sqrt(localCovs[2]);
 

--- a/RecoEgamma/EgammaTools/src/EcalRegressionData.cc
+++ b/RecoEgamma/EgammaTools/src/EcalRegressionData.cc
@@ -80,7 +80,7 @@ void EcalRegressionData::fill(const reco::SuperCluster& superClus,
   eBottom_ = EcalClusterTools::eBottom(*superClus.seed(), recHits, topology);
   eLeft_ = EcalClusterTools::eLeft(*superClus.seed(), recHits, topology);
   eRight_ = EcalClusterTools::eRight(*superClus.seed(), recHits, topology);
-  std::array<float, 3> localCovs = EcalClusterTools::localCovariances(*superClus.seed(), recHits, topology);
+  const auto& localCovs = EcalClusterTools::localCovariances(*superClus.seed(), recHits, topology);
   sigmaIEtaIEta_ = edm::isNotFinite(localCovs[0]) ? 0. : std::sqrt(localCovs[0]);
   sigmaIPhiIPhi_ = edm::isNotFinite(localCovs[2]) ? 0. : std::sqrt(localCovs[2]);
 

--- a/RecoEgamma/EgammaTools/src/EcalRegressionData.cc
+++ b/RecoEgamma/EgammaTools/src/EcalRegressionData.cc
@@ -80,7 +80,7 @@ void EcalRegressionData::fill(const reco::SuperCluster& superClus,
   eBottom_ = EcalClusterTools::eBottom(*superClus.seed(), recHits, topology);
   eLeft_ = EcalClusterTools::eLeft(*superClus.seed(), recHits, topology);
   eRight_ = EcalClusterTools::eRight(*superClus.seed(), recHits, topology);
-  std::vector<float> localCovs = EcalClusterTools::localCovariances(*superClus.seed(), recHits, topology);
+  std::array<float,3> localCovs = EcalClusterTools::localCovariances(*superClus.seed(), recHits, topology);
   sigmaIEtaIEta_ = edm::isNotFinite(localCovs[0]) ? 0. : std::sqrt(localCovs[0]);
   sigmaIPhiIPhi_ = edm::isNotFinite(localCovs[2]) ? 0. : std::sqrt(localCovs[2]);
 

--- a/RecoEgamma/PhotonIdentification/plugins/PhotonIDValueMapProducer.cc
+++ b/RecoEgamma/PhotonIdentification/plugins/PhotonIDValueMapProducer.cc
@@ -216,7 +216,7 @@ void PhotonIDValueMapProducer::produce(edm::StreamID, edm::Event& iEvent, const 
     // and userFloats or lazy tools for miniAOD. From some point in 72X and on, one can
     // retrieve the full5x5 directly from the object with ->full5x5_sigmaIetaIeta()
     // for both formats.
-    std::array<float,3> vCov = lazyToolnoZS.localCovariances(seed);
+    std::array<float, 3> vCov = lazyToolnoZS.localCovariances(seed);
     vars[0].push_back(edm::isNotFinite(vCov[0]) ? 0. : sqrt(vCov[0]));
     vars[1].push_back(vCov[1]);
     vars[2].push_back(lazyToolnoZS.e1x3(seed));

--- a/RecoEgamma/PhotonIdentification/plugins/PhotonIDValueMapProducer.cc
+++ b/RecoEgamma/PhotonIdentification/plugins/PhotonIDValueMapProducer.cc
@@ -216,7 +216,7 @@ void PhotonIDValueMapProducer::produce(edm::StreamID, edm::Event& iEvent, const 
     // and userFloats or lazy tools for miniAOD. From some point in 72X and on, one can
     // retrieve the full5x5 directly from the object with ->full5x5_sigmaIetaIeta()
     // for both formats.
-    std::array<float, 3> vCov = lazyToolnoZS.localCovariances(seed);
+    const auto& vCov = lazyToolnoZS.localCovariances(seed);
     vars[0].push_back(edm::isNotFinite(vCov[0]) ? 0. : sqrt(vCov[0]));
     vars[1].push_back(vCov[1]);
     vars[2].push_back(lazyToolnoZS.e1x3(seed));

--- a/RecoEgamma/PhotonIdentification/plugins/PhotonIDValueMapProducer.cc
+++ b/RecoEgamma/PhotonIdentification/plugins/PhotonIDValueMapProducer.cc
@@ -216,7 +216,7 @@ void PhotonIDValueMapProducer::produce(edm::StreamID, edm::Event& iEvent, const 
     // and userFloats or lazy tools for miniAOD. From some point in 72X and on, one can
     // retrieve the full5x5 directly from the object with ->full5x5_sigmaIetaIeta()
     // for both formats.
-    std::vector<float> vCov = lazyToolnoZS.localCovariances(seed);
+    std::array<float,3> vCov = lazyToolnoZS.localCovariances(seed);
     vars[0].push_back(edm::isNotFinite(vCov[0]) ? 0. : sqrt(vCov[0]));
     vars[1].push_back(vCov[1]);
     vars[2].push_back(lazyToolnoZS.e1x3(seed));


### PR DESCRIPTION
#### PR description:

This PR is a follow-up of my previous PR https://github.com/cms-sw/cmssw/pull/33148, which was merged recently. In particular, I'm addressing [this comment](https://github.com/cms-sw/cmssw/pull/33148#discussion_r597789981) which was raised in the last RECO meeting. So, as requested by @VinInn, this PR changes the return type of `localCovariances`, `scLocalCovariances`, and `covariances` functions from `std::vector<float>` to `std::array<float,3>`. As only 3 floats are returned, array is a better and more memory-efficient choice. 

This is a purely technical PR, and no change in physics is expected.

#### PR validation:

runTheMatrix.py successfully ran with 23234.0, 140.53, and 11634.0

This PR is not a backport.
No backport is needed.