### PR TITLE
[L1TMuonBarrel] KMTF fixes on propagation coefficients (CMSSW_11_2_X)

### DIFF
--- a/L1Trigger/L1TMuonBarrel/BuildFile.xml
+++ b/L1Trigger/L1TMuonBarrel/BuildFile.xml
@@ -4,6 +4,7 @@
 <use name="CondFormats/L1TObjects"/>
 <use name="CondFormats/DataRecord"/>
 <use name="L1Trigger/L1TCommon"/>
+<use name="hls"/>
 <export>
   <lib name="1"/>
 </export>

--- a/L1Trigger/L1TMuonBarrel/interface/L1TMuonBarrelKalmanAlgo.h
+++ b/L1Trigger/L1TMuonBarrel/interface/L1TMuonBarrelKalmanAlgo.h
@@ -38,10 +38,10 @@ private:
   int correctedPhiB(const L1MuKBMTCombinedStubRef&);
   void propagate(L1MuKBMTrack&);
   void updateEta(L1MuKBMTrack&, const L1MuKBMTCombinedStubRef&);
-  bool update(L1MuKBMTrack&, const L1MuKBMTCombinedStubRef&, int);
+  bool update(L1MuKBMTrack&, const L1MuKBMTCombinedStubRef&, int, int);
   bool updateOffline(L1MuKBMTrack&, const L1MuKBMTCombinedStubRef&);
   bool updateOffline1D(L1MuKBMTrack&, const L1MuKBMTCombinedStubRef&);
-  bool updateLUT(L1MuKBMTrack&, const L1MuKBMTCombinedStubRef&, int);
+  bool updateLUT(L1MuKBMTrack&, const L1MuKBMTCombinedStubRef&, int, int);
   void vertexConstraint(L1MuKBMTrack&);
   void vertexConstraintOffline(L1MuKBMTrack&);
   void vertexConstraintLUT(L1MuKBMTrack&);
@@ -106,6 +106,26 @@ private:
   std::vector<int> combos2_;
   std::vector<int> combos1_;
 
+  //bits for fixed point precision
+  static const int BITSCURV = 14;
+  static const int BITSPHI = 12;
+  static const int BITSPHIB = 13;
+  static const int BITSPARAM = 14;
+  static const int GAIN_0 = 9;
+  static const int GAIN_0INT = 6;
+  static const int GAIN_4 = 9;
+  static const int GAIN_4INT = 4;
+  static const int GAIN_V0 = 9;
+  static const int GAIN_V0INT = 3;
+
+  static const int GAIN2_0 = 12;
+  static const int GAIN2_0INT = 8;
+  static const int GAIN2_1 = 12;
+  static const int GAIN2_1INT = 4;
+  static const int GAIN2_4 = 12;
+  static const int GAIN2_4INT = 4;
+  static const int GAIN2_5 = 12;
+  static const int GAIN2_5INT = 0;
   //STUFF NOT USED IN THE FIRMWARE BUT ONLY FOR DEBUGGING
   ///////////////////////////////////////////////////////
 
@@ -116,6 +136,9 @@ private:
   double pointResolutionPhi_;
   //point resolution for phiB
   double pointResolutionPhiB_;
+  std::vector<double> pointResolutionPhiBH_;
+  std::vector<double> pointResolutionPhiBL_;
+  //double pointResolutionPhiB_;
   //point resolution for vertex
   double pointResolutionVertex_;
 

--- a/L1Trigger/L1TMuonBarrel/interface/L1TMuonBarrelKalmanLUTs.h
+++ b/L1Trigger/L1TMuonBarrel/interface/L1TMuonBarrelKalmanLUTs.h
@@ -12,14 +12,17 @@ public:
   ~L1TMuonBarrelKalmanLUTs();
 
   std::vector<float> trackGain(uint, uint, uint);
-  std::vector<float> trackGain2(uint, uint, uint);
+  std::vector<float> trackGain2(uint, uint, uint, uint, uint);
   std::pair<float, float> vertexGain(uint, uint);
   uint coarseEta(uint, uint);
 
 private:
   TFile *lutFile_;
   std::map<uint, const TH1 *> lut_;
-  std::map<uint, const TH1 *> lut2_;
+  std::map<uint, const TH1 *> lut2HH_;
+  std::map<uint, const TH1 *> lut2LH_;
+  std::map<uint, const TH1 *> lut2HL_;
+  std::map<uint, const TH1 *> lut2LL_;
   std::map<uint, const TH1 *> coarseEta_;
 };
 

--- a/L1Trigger/L1TMuonBarrel/python/simKBmtfDigis_cfi.py
+++ b/L1Trigger/L1TMuonBarrel/python/simKBmtfDigis_cfi.py
@@ -8,12 +8,12 @@ bmtfKalmanTrackingSettings = cms.PSet(
 #    eLoss = cms.vdouble(-2.85e-4,-6.21e-5,-1.26e-4,-1.23e-4), 
     eLoss = cms.vdouble(+0.000765,0,0,0), 
 
-    aPhi = cms.vdouble(1.942,0.03125,0.0273438,0.015625),
-    aPhiB = cms.vdouble(-1.508,-0.123047,-0.174805,-0.144531),
+    aPhi = cms.vdouble(1.942, .01511, .01476, .009799),
+    aPhiB = cms.vdouble(-1.508,-0.1237,-0.1496,-0.1333),
     aPhiBNLO = cms.vdouble(0.000331,0,0,0),
 
-    bPhi = cms.vdouble(-1,0.154297,0.173828,0.147461),
-    bPhiB = cms.vdouble(-1,1.15332,1.17285,1.14648),
+    bPhi = cms.vdouble(-1,.18245,.20898,.17286),
+    bPhiB = cms.vdouble(-1,1.18245,1.20898,1.17286),
     phiAt2 = cms.double(0.15918),
     etaLUT0 = cms.vdouble(8.946,7.508,6.279,6.399),
     etaLUT1 = cms.vdouble(0.159,0.116,0.088,0.128),
@@ -22,6 +22,7 @@ bmtfKalmanTrackingSettings = cms.PSet(
     chiSquareCutPattern = cms.vint32(7,11,13,14,15),
     chiSquareCutCurvMax = cms.vint32(2500,2500,2500,2500,2500),
     chiSquareCut = cms.vint32(126,126,126,126,126),
+
 
     #vertex cuts
     trackComp = cms.vdouble(1.75,1.25,0.625,0.250),   
@@ -43,6 +44,8 @@ bmtfKalmanTrackingSettings = cms.PSet(
     mScatteringPhiB = cms.vdouble(7.22e-3,3.461e-3,4.447e-3,4.12e-3),
     pointResolutionPhi = cms.double(1.),
     pointResolutionPhiB = cms.double(500.),
+    pointResolutionPhiBH = cms.vdouble(151., 173., 155., 153.),
+    pointResolutionPhiBL = cms.vdouble(17866., 19306., 23984., 23746.),
     pointResolutionVertex = cms.double(1.)
 )
 

--- a/L1Trigger/L1TMuonBarrel/src/L1TMuonBarrelKalmanLUTs.cc
+++ b/L1Trigger/L1TMuonBarrel/src/L1TMuonBarrelKalmanLUTs.cc
@@ -25,12 +25,33 @@ L1TMuonBarrelKalmanLUTs::L1TMuonBarrelKalmanLUTs(const std::string& filename) {
   lut_[14] = (TH1*)lutFile_->Get("gain_14_0");
   lut_[15] = (TH1*)lutFile_->Get("gain_15_0");
 
-  lut2_[3 * 64 + 8] = (TH1*)lutFile_->Get("gain2_8_3");
-  lut2_[2 * 64 + 8] = (TH1*)lutFile_->Get("gain2_8_2");
-  lut2_[2 * 64 + 4] = (TH1*)lutFile_->Get("gain2_4_2");
-  lut2_[1 * 64 + 8] = (TH1*)lutFile_->Get("gain2_8_1");
-  lut2_[1 * 64 + 4] = (TH1*)lutFile_->Get("gain2_4_1");
-  lut2_[1 * 64 + 2] = (TH1*)lutFile_->Get("gain2_2_1");
+  lut2HH_[3 * 64 + 8] = (TH1*)lutFile_->Get("gain2_8_3_HH");
+  lut2HH_[2 * 64 + 8] = (TH1*)lutFile_->Get("gain2_8_2_HH");
+  lut2HH_[2 * 64 + 4] = (TH1*)lutFile_->Get("gain2_4_2_HH");
+  lut2HH_[1 * 64 + 8] = (TH1*)lutFile_->Get("gain2_8_1_HH");
+  lut2HH_[1 * 64 + 4] = (TH1*)lutFile_->Get("gain2_4_1_HH");
+  lut2HH_[1 * 64 + 2] = (TH1*)lutFile_->Get("gain2_2_1_HH");
+
+  lut2LH_[3 * 64 + 8] = (TH1*)lutFile_->Get("gain2_8_3_LH");
+  lut2LH_[2 * 64 + 8] = (TH1*)lutFile_->Get("gain2_8_2_LH");
+  lut2LH_[2 * 64 + 4] = (TH1*)lutFile_->Get("gain2_4_2_LH");
+  lut2LH_[1 * 64 + 8] = (TH1*)lutFile_->Get("gain2_8_1_LH");
+  lut2LH_[1 * 64 + 4] = (TH1*)lutFile_->Get("gain2_4_1_LH");
+  lut2LH_[1 * 64 + 2] = (TH1*)lutFile_->Get("gain2_2_1_LH");
+
+  lut2HL_[3 * 64 + 8] = (TH1*)lutFile_->Get("gain2_8_3_HL");
+  lut2HL_[2 * 64 + 8] = (TH1*)lutFile_->Get("gain2_8_2_HL");
+  lut2HL_[2 * 64 + 4] = (TH1*)lutFile_->Get("gain2_4_2_HL");
+  lut2HL_[1 * 64 + 8] = (TH1*)lutFile_->Get("gain2_8_1_HL");
+  lut2HL_[1 * 64 + 4] = (TH1*)lutFile_->Get("gain2_4_1_HL");
+  lut2HL_[1 * 64 + 2] = (TH1*)lutFile_->Get("gain2_2_1_HL");
+
+  lut2LL_[3 * 64 + 8] = (TH1*)lutFile_->Get("gain2_8_3_LL");
+  lut2LL_[2 * 64 + 8] = (TH1*)lutFile_->Get("gain2_8_2_LL");
+  lut2LL_[2 * 64 + 4] = (TH1*)lutFile_->Get("gain2_4_2_LL");
+  lut2LL_[1 * 64 + 8] = (TH1*)lutFile_->Get("gain2_8_1_LL");
+  lut2LL_[1 * 64 + 4] = (TH1*)lutFile_->Get("gain2_4_1_LL");
+  lut2LL_[1 * 64 + 2] = (TH1*)lutFile_->Get("gain2_2_1_LL");
 
   coarseEta_[3] = (TH1*)lutFile_->Get("coarseEta_3");
   coarseEta_[5] = (TH1*)lutFile_->Get("coarseEta_5");
@@ -56,18 +77,29 @@ std::vector<float> L1TMuonBarrelKalmanLUTs::trackGain(uint step, uint bitmask, u
   std::vector<float> gain(4, 0.0);
   const TH1* h = lut_[64 * step + bitmask];
   gain[0] = h->GetBinContent(K + 1);
-  gain[2] = -h->GetBinContent(1024 + K + 1);
+  gain[2] = h->GetBinContent(1024 + K + 1);
   return gain;
 }
 
-std::vector<float> L1TMuonBarrelKalmanLUTs::trackGain2(uint step, uint bitmask, uint K) {
+std::vector<float> L1TMuonBarrelKalmanLUTs::trackGain2(uint step, uint bitmask, uint K, uint qual1, uint qual2) {
   std::vector<float> gain(4, 0.0);
 
   //  printf("Track gain %d %d %d\n",step,bitmask,K);
-  const TH1* h = lut2_[64 * step + bitmask];
+  const TH1* h;
+  if (qual1 < 4) {
+    if (qual2 < 4)
+      h = lut2LL_[64 * step + bitmask];
+    else
+      h = lut2LH_[64 * step + bitmask];
+  } else {
+    if (qual2 < 4)
+      h = lut2HL_[64 * step + bitmask];
+    else
+      h = lut2HH_[64 * step + bitmask];
+  }
   gain[0] = h->GetBinContent(K + 1);
   gain[1] = h->GetBinContent(512 + K + 1);
-  gain[2] = -h->GetBinContent(2 * 512 + K + 1);
+  gain[2] = h->GetBinContent(2 * 512 + K + 1);
   gain[3] = h->GetBinContent(3 * 512 + K + 1);
   return gain;
 }

--- a/L1Trigger/L1TMuonBarrel/src/L1TMuonBarrelKalmanRegionModule.cc
+++ b/L1Trigger/L1TMuonBarrel/src/L1TMuonBarrelKalmanRegionModule.cc
@@ -80,6 +80,11 @@ L1MuKBMTrackCollection L1TMuonBarrelKalmanRegionModule::process(L1TMuonBarrelKal
 
   for (const auto& seed : seeds) {
     std::pair<bool, L1MuKBMTrack> trackInfo = trackMaker->chain(seed, stubs);
+    //printf("Kalman Track %d valid=%d tag=%d rank=%d charge=%d pt=%f eta=%f phi=%f curvature=%d curvature STA =%d stubs=%d chi2=%d pts=%f %f pattern=%d\n",seed->stNum(),trackInfo.first, trackInfo.second.stubs()[0]->tag(),trackInfo.second.rank(),trackInfo.second.charge(),trackInfo.second.pt(),trackInfo.second.eta(),trackInfo.second.phi(),trackInfo.second.curvatureAtVertex(),trackInfo.second.curvatureAtMuon(),int(trackInfo.second.stubs().size()),trackInfo.second.approxChi2(),trackInfo.second.pt(),trackInfo.second.ptUnconstrained(),trackInfo.second.hitPattern());
+
+    L1MuKBMTrack nullTrack(seed, seed->phi(), 8 * seed->phiB());
+    nullTrack.setPtEtaPhi(0, 0, 0);
+    nullTrack.setRank(0);
     if (trackInfo.first) {
       if (seed->stNum() == 2)
         pretracks2.push_back(trackInfo.second);
@@ -87,18 +92,73 @@ L1MuKBMTrackCollection L1TMuonBarrelKalmanRegionModule::process(L1TMuonBarrelKal
         pretracks3.push_back(trackInfo.second);
       if (seed->stNum() == 4)
         pretracks4.push_back(trackInfo.second);
+    } else {
+      if (seed->stNum() == 2)
+        pretracks2.push_back(nullTrack);
+      if (seed->stNum() == 3)
+        pretracks3.push_back(nullTrack);
+      if (seed->stNum() == 4)
+        pretracks4.push_back(nullTrack);
     }
   }
-  //for (const auto& track1 :pretracks2)
-  //      printf("SEED=2 Kalman Track charge=%d pt=%f eta=%f phi=%f curvature=%d curvature STA =%d stubs=%d chi2=%d pts=%f %f pattern=%d\n",track1.charge(),track1.pt(),track1.eta(),track1.phi(),track1.curvatureAtVertex(),track1.curvatureAtMuon(),int(track1.stubs().size()),track1.approxChi2(),track1.pt(),track1.ptUnconstrained(),track1.hitPattern());
+  L1MuKBMTrack nullTrack;
+  nullTrack.setPtEtaPhi(0, 0, 0);
+  nullTrack.setRank(0);
+  // All pretracks must have trackL and trackH like firmware
+  // Swap trackH and trackL for seeds 2/3 to mimic firmware
+  if (pretracks2.size() < 2) {
+    if (pretracks2.empty()) {  // if no tracks, set trackH and trackL to null
+      pretracks2.push_back(nullTrack);
+      pretracks2.push_back(nullTrack);
+    } else {  // otherwise add nulltrack for trackH or trackL
+      if (pretracks2[0].stubs()[0]->tag() == 0)
+        pretracks2.push_back(nullTrack);
+      else
+        pretracks2.insert(pretracks2.begin(), nullTrack);
+    }
+  }
+  std::swap(pretracks2[0], pretracks2[1]);
 
-  //for (const auto& track1 :pretracks3)
-  //      printf("SEED=3 Kalman Track charge=%d pt=%f eta=%f phi=%f curvature=%d curvature STA =%d stubs=%d chi2=%d pts=%f %f pattern=%d\n",track1.charge(),track1.pt(),track1.eta(),track1.phi(),track1.curvatureAtVertex(),track1.curvatureAtMuon(),int(track1.stubs().size()),track1.approxChi2(),track1.pt(),track1.ptUnconstrained(),track1.hitPattern());
+  if (pretracks3.size() < 2) {
+    if (pretracks3.empty()) {
+      pretracks3.push_back(nullTrack);
+      pretracks3.push_back(nullTrack);
+    } else {
+      if (pretracks3[0].stubs()[0]->tag() == 0)
+        pretracks3.push_back(nullTrack);
+      else
+        pretracks3.insert(pretracks3.begin(), nullTrack);
+    }
+  }
+  std::swap(pretracks3[0], pretracks3[1]);
 
-  //for (const auto& track1 :pretracks4)
-  //  printf("SEED=4 Kalman Track charge=%d pt=%f eta=%f phi=%f curvature=%d curvature STA =%d stubs=%d chi2=%d pts=%f %f pattern=%d\n",track1.charge(),track1.pt(),track1.eta(),track1.phi(),track1.curvatureAtVertex(),track1.curvatureAtMuon(),int(track1.stubs().size()),track1.approxChi2(),track1.pt(),track1.ptUnconstrained(),track1.hitPattern());
+  if (pretracks4.size() < 2) {
+    if (pretracks4.empty()) {
+      pretracks4.push_back(nullTrack);
+      pretracks4.push_back(nullTrack);
+    } else {
+      if (pretracks4[0].stubs()[0]->tag() == 0)
+        pretracks4.push_back(nullTrack);
+      else
+        pretracks4.insert(pretracks4.begin(), nullTrack);
+    }
+  }
 
-  //  trackMaker->resolveEtaUnit(pretracks);
+  /*
+  printf("SEED 2\n");
+  for (const auto& track1 :pretracks2){
+    printf("   Kalman Track rank=%d charge=%d pt=%f eta=%f phi=%f curvature=%d curvature STA =%d stubs=%d chi2=%d pts=%f %f pattern=%d\n",track1.rank(),track1.charge(),track1.pt(),track1.eta(),track1.phi(),track1.curvatureAtVertex(),track1.curvatureAtMuon(),int(track1.stubs().size()),track1.approxChi2(),track1.pt(),track1.ptUnconstrained(),track1.hitPattern());
+  }
+  printf("SEED 3\n");
+  for (const auto& track1 :pretracks3){
+    printf("   Kalman Track rank=%d charge=%d pt=%f eta=%f phi=%f curvature=%d curvature STA =%d stubs=%d chi2=%d pts=%f %f pattern=%d\n",track1.rank(),track1.charge(),track1.pt(),track1.eta(),track1.phi(),track1.curvatureAtVertex(),track1.curvatureAtMuon(),int(track1.stubs().size()),track1.approxChi2(),track1.pt(),track1.ptUnconstrained(),track1.hitPattern());
+  }
+  printf("SEED 4\n");
+  for (const auto& track1 :pretracks4){
+    printf("   Kalman Track rank=%d charge=%d pt=%f eta=%f phi=%f curvature=%d curvature STA =%d stubs=%d chi2=%d pts=%f %f pattern=%d\n",track1.rank(),track1.charge(),track1.pt(),track1.eta(),track1.phi(),track1.curvatureAtVertex(),track1.curvatureAtMuon(),int(track1.stubs().size()),track1.approxChi2(),track1.pt(),track1.ptUnconstrained(),track1.hitPattern());
+  }
+  */
+
   L1MuKBMTrackCollection out = cleanRegion(pretracks2, pretracks3, pretracks4);
   if (verbose_) {
     printf(" -----Sector Processor Kalman Tracks-----\n");
@@ -123,24 +183,29 @@ L1MuKBMTrackCollection L1TMuonBarrelKalmanRegionModule::selfClean(const L1MuKBMT
   L1MuKBMTrackCollection out;
 
   for (uint i = 0; i < tracks.size(); ++i) {
-    bool keep = true;
-
+    //bool keep = true;
+    L1MuKBMTrack temp = tracks[i];
     for (uint j = 0; j < tracks.size(); ++j) {
       if (i == j)
         continue;
 
       if (tracks[i].overlapTrack(tracks[j])) {
         if (tracks[i].rank() < tracks[j].rank()) {
-          keep = false;
+          //keep = false;
+          temp.setPtEtaPhi(0, 0, 0);
+          temp.setRank(0);
         } else if (tracks[i].rank() == tracks[j].rank()) {  //if same rank prefer seed that is high
-          if (!tracks[j].stubs()[0]->tag())
-            keep = false;
+          if (!tracks[j].stubs()[0]->tag()) {
+            //keep = false;
+            temp.setPtEtaPhi(0, 0, 0);
+            temp.setRank(0);
+          }
         }
       }
     }
-
-    if (keep)
-      out.push_back(tracks[i]);
+    out.push_back(temp);
+    //if (keep)
+    //out.push_back(tracks[i]);
   }
 
   return out;
@@ -151,17 +216,20 @@ L1MuKBMTrackCollection L1TMuonBarrelKalmanRegionModule::cleanHigher(const L1MuKB
   L1MuKBMTrackCollection out;
 
   for (uint i = 0; i < tracks1.size(); ++i) {
-    bool keep = true;
-
+    //bool keep = true;
+    L1MuKBMTrack temp = tracks1[i];
     for (uint j = 0; j < tracks2.size(); ++j) {
       if (tracks1[i].overlapTrack(tracks2[j])) {
         if (tracks1[i].rank() <= tracks2[j].rank()) {
-          keep = false;
+          //keep = false;
+          temp.setPtEtaPhi(0, 0, 0);
+          temp.setRank(0);
         }
       }
     }
-    if (keep)
-      out.push_back(tracks1[i]);
+    out.push_back(temp);
+    //if (keep)
+    //  out.push_back(tracks1[i]);
   }
 
   return out;
@@ -172,17 +240,20 @@ L1MuKBMTrackCollection L1TMuonBarrelKalmanRegionModule::cleanLower(const L1MuKBM
   L1MuKBMTrackCollection out;
 
   for (uint i = 0; i < tracks1.size(); ++i) {
-    bool keep = true;
-
+    //bool keep = true;
+    L1MuKBMTrack temp = tracks1[i];
     for (uint j = 0; j < tracks2.size(); ++j) {
       if (tracks1[i].overlapTrack(tracks2[j])) {
         if (tracks1[i].rank() < tracks2[j].rank()) {
-          keep = false;
+          //keep = false;
+          temp.setPtEtaPhi(0, 0, 0);
+          temp.setRank(0);
         }
       }
     }
-    if (keep)
-      out.push_back(tracks1[i]);
+    out.push_back(temp);
+    //if (keep)
+    // out.push_back(tracks1[i]);
   }
 
   return out;
@@ -191,6 +262,7 @@ L1MuKBMTrackCollection L1TMuonBarrelKalmanRegionModule::cleanLower(const L1MuKBM
 L1MuKBMTrackCollection L1TMuonBarrelKalmanRegionModule::sort4(const L1MuKBMTrackCollection& in) {
   L1MuKBMTrackCollection out;
   //partial sort like in firmwarE (bitonic)
+
   if (in.size() <= 2)
     return in;
   else if (in.size() == 3) {
@@ -268,7 +340,6 @@ L1MuKBMTrackCollection L1TMuonBarrelKalmanRegionModule::sort4(const L1MuKBMTrack
     out.push_back(s3_1);
     out.push_back(s3_2);
   }
-
   return out;
 }
 
@@ -281,32 +352,24 @@ L1MuKBMTrackCollection L1TMuonBarrelKalmanRegionModule::cleanRegion(const L1MuKB
   L1MuKBMTrackCollection cleaned23 = cleanHigher(cleaned2, tracks3);
   L1MuKBMTrackCollection cleaned32 = cleanLower(cleaned3, tracks2);
 
-  //printf("Cleaned sizes = 2=%d 3=%d 23=%d 32=%d \n",int(cleaned2.size()),int(cleaned3.size()),int(cleaned23.size()),int(cleaned32.size()));
-
   //merge 2,3
   L1MuKBMTrackCollection step1;
-
-  if (!cleaned32.empty())
-    step1.insert(step1.end(), cleaned32.begin(), cleaned32.end());
   if (!cleaned23.empty())
     step1.insert(step1.end(), cleaned23.begin(), cleaned23.end());
+  if (!cleaned32.empty())
+    step1.insert(step1.end(), cleaned32.begin(), cleaned32.end());
 
   //take the best 2
   L1MuKBMTrackCollection sorted23 = sort4(step1);
-  //  printf("Sorted 23 =%d\n",int(sorted23.size()));
 
   //Now clean the tracks 4 between them
   L1MuKBMTrackCollection cleaned4 = selfClean(tracks4);
-  //  printf("Cleaned4 =%d\n",int(cleaned4.size()));
 
   //Now clean the 23 tracks from tracks4
   L1MuKBMTrackCollection cleanedSorted23 = cleanHigher(sorted23, tracks4);
 
-  //  printf("Cleaned23 from 4  =%d\n",int(cleanedSorted23.size()));
-
   //Now clean the  tracks4 from sorted 23
   L1MuKBMTrackCollection cleanedSorted4 = cleanLower(cleaned4, sorted23);
-  //  printf("Cleaned4 from 23  =%d\n",int(cleanedSorted4.size()));
 
   //Now merge all of those
   L1MuKBMTrackCollection step2;
@@ -317,5 +380,23 @@ L1MuKBMTrackCollection L1TMuonBarrelKalmanRegionModule::cleanRegion(const L1MuKB
     step2.insert(step2.end(), cleanedSorted23.begin(), cleanedSorted23.end());
 
   L1MuKBMTrackCollection out = sort4(step2);
+  // Verbose statements:
+  /*
+  printf("tracks 1-4\n");
+  for (const auto& track1 :step1)
+    printf("   rank=%d charge=%d pt=%f eta=%f phi=%f curvature=%d curvature STA =%d stubs=%d chi2=%d pts=%f %f pattern=%d\n",track1.rank(),track1.charge(),track1.pt(),track1.eta(),track1.phi(),track1.curvatureAtVertex(),track1.curvatureAtMuon(),int(track1.stubs().size()),track1.approxChi2(),track1.pt(),track1.ptUnconstrained(),track1.hitPattern());
+
+  printf("sorted1\n");
+  for (const auto& track1 :sorted23)
+    printf("   rank=%d charge=%d pt=%f eta=%f phi=%f curvature=%d curvature STA =%d stubs=%d chi2=%d pts=%f %f pattern=%d\n",track1.rank(),track1.charge(),track1.pt(),track1.eta(),track1.phi(),track1.curvatureAtVertex(),track1.curvatureAtMuon(),int(track1.stubs().size()),track1.approxChi2(),track1.pt(),track1.ptUnconstrained(),track1.hitPattern());
+
+  printf("track 5-8\n");
+  for (const auto& track1 :step2)
+    printf("   rank=%d charge=%d pt=%f eta=%f phi=%f curvature=%d curvature STA =%d stubs=%d chi2=%d pts=%f %f pattern=%d\n",track1.rank(),track1.charge(),track1.pt(),track1.eta(),track1.phi(),track1.curvatureAtVertex(),track1.curvatureAtMuon(),int(track1.stubs().size()),track1.approxChi2(),track1.pt(),track1.ptUnconstrained(),track1.hitPattern());
+  
+  printf("OUTPUT\n");
+  for (const auto& track1 :out)
+    printf("   rank=%d charge=%d pt=%f eta=%f phi=%f curvature=%d curvature STA =%d stubs=%d chi2=%d pts=%f %f pattern=%d\n",track1.rank(),track1.charge(),track1.pt(),track1.eta(),track1.phi(),track1.curvatureAtVertex(),track1.curvatureAtMuon(),int(track1.stubs().size()),track1.approxChi2(),track1.pt(),track1.ptUnconstrained(),track1.hitPattern());
+  */
   return out;
 }

--- a/L1Trigger/L1TMuonBarrel/src/L1TMuonBarrelKalmanSectorProcessor.cc
+++ b/L1Trigger/L1TMuonBarrel/src/L1TMuonBarrelKalmanSectorProcessor.cc
@@ -223,6 +223,7 @@ L1MuKBMTrackCollection L1TMuonBarrelKalmanSectorProcessor::cleanNeighbor(const L
   L1MuKBMTrackCollection out;
 
   for (const auto& track1 : coll1) {
+    /*
     if (verbose_)
       printf(
           "Pre Track charge=%d pt=%f eta=%f phi=%f curvature=%d curvature STA =%d stubs=%d bitmask=%d rank=%d chi=%d "
@@ -239,7 +240,7 @@ L1MuKBMTrackCollection L1TMuonBarrelKalmanSectorProcessor::cleanNeighbor(const L
           track1.approxChi2(),
           track1.pt(),
           track1.ptUnconstrained());
-
+    */
     bool keep = true;
     for (const auto& track2 : coll2) {
       if (!track1.overlapTrack(track2))
@@ -253,6 +254,12 @@ L1MuKBMTrackCollection L1TMuonBarrelKalmanSectorProcessor::cleanNeighbor(const L
     }
     if (keep)
       out.push_back(track1);
+    else {
+      L1MuKBMTrack temp = track1;
+      temp.setPtEtaPhi(0, 0, 0);
+      temp.setRank(0);
+      out.push_back(temp);
+    }
   }
 
   return out;
@@ -292,6 +299,12 @@ L1MuKBMTrackCollection L1TMuonBarrelKalmanSectorProcessor::cleanNeighbors(const 
 
     if (keep)
       out.push_back(track1);
+    else {
+      L1MuKBMTrack temp = track1;
+      temp.setPtEtaPhi(0, 0, 0);
+      temp.setRank(0);
+      out.push_back(temp);
+    }
   }
 
   return out;

--- a/L1Trigger/L1TMuonBarrel/src/L1TMuonBarrelKalmanStubProcessor.cc
+++ b/L1Trigger/L1TMuonBarrel/src/L1TMuonBarrelKalmanStubProcessor.cc
@@ -301,7 +301,8 @@ void L1TMuonBarrelKalmanStubProcessor::makeInputPattern(const L1MuDTChambPhConta
     } else {
       os << "-2048 0 0 0 15 ";
     }
-    const L1MuDTChambPhDigi* seg8 = phiContainer->chPhiSegm2(wheel, 4, previousSector, 1);
+    //const L1MuDTChambPhDigi* seg8 = phiContainer->chPhiSegm2(wheel, 4, previousSector, 1);
+    const L1MuDTChambPhDigi* seg8 = phiContainer->chPhiSegm2(wheel, 4, previousSector, -1);
     if (seg8 && seg8->phi() > 111) {
       os << seg8->phi() - 2144 << " " << seg8->phiB() << " " << seg8->code() << " 1 5 ";
     } else {

--- a/L1Trigger/L1TMuonBarrel/test/kalmanTools/createGains.py
+++ b/L1Trigger/L1TMuonBarrel/test/kalmanTools/createGains.py
@@ -20,8 +20,9 @@ def fetchKMTF(event,etaMax=0.83,chi2=800000,dxyCut=100000):
 
 ####Save the Kalman Gains for LUTs
 kalmanGain={}
+kalmanGain2H={}
+kalmanGain2L={}
 kalmanGain2={}
-
 for track in [3,5,6,7,9,10,11,12,13,14,15]:
     for station in [3,2,1]:
         if getBit(track,station-1)==0:
@@ -33,18 +34,27 @@ for track in [3,5,6,7,9,10,11,12,13,14,15]:
         if track in [3,5,6,9,10,12]:
             if not (partialMask in kalmanGain2.keys()):
                 kalmanGain2[partialMask] = {}
-            kalmanGain2[partialMask][station] = {}
+            if not (partialMask in kalmanGain2H.keys()):
+                kalmanGain2H[partialMask] = {}
+            if not (partialMask in kalmanGain2L.keys()):
+                kalmanGain2L[partialMask] = {}
+            kalmanGain2[partialMask][station]={}
+            for q1 in ['H', 'L']:
+                kalmanGain2[partialMask][station][q1]={}
+                for q2 in ['H', 'L']:
+                    kalmanGain2[partialMask][station][q1][q2]={}
 
-            kalmanGain2[partialMask][station][0]=ROOT.TH2D("gain2_{track}_{station}_0".format(track=partialMask,station=station),"h",64,0,512,128,-100,100)
-            kalmanGain2[partialMask][station][1]=ROOT.TH2D("gain2_{track}_{station}_1".format(track=partialMask,station=station),"h",64,0,512,128,-8,8)
-            kalmanGain2[partialMask][station][4]=ROOT.TH2D("gain2_{track}_{station}_4".format(track=partialMask,station=station),"h",64,0,512,128,-15,0)
-            kalmanGain2[partialMask][station][5]=ROOT.TH2D("gain2_{track}_{station}_5".format(track=partialMask,station=station),"h",64,0,512,128,0,1)
+                    kalmanGain2[partialMask][station][q1][q2][0]=ROOT.TH2D("gain2_{track}_{station}_0_{q1}{q2}".format(track=partialMask,station=station,q1=q1,q2=q2),"h",64,0,512,256*2,-100*2,100*2)
+                    kalmanGain2[partialMask][station][q1][q2][1]=ROOT.TH2D("gain2_{track}_{station}_1_{q1}{q2}".format(track=partialMask,station=station,q1=q1,q2=q2),"h",64,0,512,256*4,-8*4,8*4)
+                    kalmanGain2[partialMask][station][q1][q2][4]=ROOT.TH2D("gain2_{track}_{station}_4_{q1}{q2}".format(track=partialMask,station=station,q1=q1,q2=q2),"h",64,0,512,256*2,-15*2,0)
+                    kalmanGain2[partialMask][station][q1][q2][5]=ROOT.TH2D("gain2_{track}_{station}_5_{q1}{q2}".format(track=partialMask,station=station,q1=q1,q2=q2),"h",64,0,512,256*2,0,1*2)
+
         else:
             if not (partialMask in kalmanGain.keys()):
                 kalmanGain[partialMask] = {}
             kalmanGain[partialMask][station] = {}
-            kalmanGain[partialMask][station][0]=ROOT.TH2D("gain_{track}_{station}_0".format(track=partialMask,station=station),"h",64,0,1024,128,-100,100)
-            kalmanGain[partialMask][station][4]=ROOT.TH2D("gain_{track}_{station}_4".format(track=partialMask,station=station),"h",64,0,1024,128,-15,0)
+            kalmanGain[partialMask][station][0]=ROOT.TH2D("gain_{track}_{station}_0".format(track=partialMask,station=station),"h",64,0,1024,256,-100,100)
+            kalmanGain[partialMask][station][4]=ROOT.TH2D("gain_{track}_{station}_4".format(track=partialMask,station=station),"h",64,0,1024,256,-15,0)
 
 
     for station in [0]:
@@ -60,37 +70,44 @@ for track in [3,5,6,7,9,10,11,12,13,14,15]:
 
 
 
+for p in [3,5,6,7,9,10,11,12,13,14,15]:
+    events=Events(['singleMu0_{}.root'.format(p)]) # Run KBMTF with only 1 pattern at a time to increase statistics
+    counter=-1
+    for event in events:
+        counter=counter+1
+        #fetch stubs
+        kmtf=[]
+        kmtf = fetchKMTF(event,1.5,1000000,1000000)
+        ##Fill histograms and rates
+        for track in kmtf:
+            mask = track.hitPattern()
+            qual = {}
+            q1 = 'L'
+            for stub in track.stubs():
+                qual[stub.stNum()] = stub.quality()
+            if qual[max(qual)] >= 4:
+                q1='H'
+            for station in [3,2,1]:
+                if not getBit(mask,station-1):
+                    continue
+                gain = track.kalmanGain(station)
+                partialMask = mask & (15<<station)
+                if partialMask==0:
+                    continue
+                q2 = 'L'
+                if qual[station] >= 4:
+                    q2 = 'H'
+                if mask in [3,5,6,9,10,12]:
+                    for element in [0,1,4,5]:
+                        kalmanGain2[partialMask][station][q1][q2][element].Fill(gain[0]/8,gain[element+1])
+                else:        
+                    for element in [0,4]:
+                        kalmanGain[partialMask][station][element].Fill(gain[0]/4,gain[element+1])
 
-events=Events(['lutEvents.root'])
-counter=-1
-for event in events:
-    counter=counter+1
-    #fetch stubs
-    kmtf=[]
-    kmtf = fetchKMTF(event,1.5,1000000,1000000)
-    ##Fill histograms and rates
-    for track in kmtf:
-        mask = track.hitPattern()
-        for station in [3,2,1]:
-            if not getBit(mask,station-1):
-                continue
-            gain = track.kalmanGain(station)
-            partialMask = mask & (15<<station)
-            if partialMask==0:
-                continue
-            if mask in [3,5,6,9,10,12]:
-                for element in [0,1,4,5]:
-
-                    kalmanGain2[partialMask][station][element].Fill(gain[0]/8,gain[element+1])
-            else:        
-                for element in [0,4]:
-
-                    kalmanGain[partialMask][station][element].Fill(gain[0]/4,gain[element+1])
-
-        for station in [0]:
-            gain = track.kalmanGain(station)
-            kalmanGain[mask][station][0].Fill(gain[0]/2,gain[1])
-            kalmanGain[mask][station][1].Fill(gain[0]/2,gain[2])
+            for station in [0]:
+                gain = track.kalmanGain(station)
+                kalmanGain[mask][station][0].Fill(gain[0]/2,gain[1])
+                kalmanGain[mask][station][1].Fill(gain[0]/2,gain[2])
 
         
 f=ROOT.TFile("gains.root","RECREATE")
@@ -103,10 +120,10 @@ for k in kalmanGain.keys():
 
 for k in kalmanGain2.keys():
     for s in kalmanGain2[k].keys():
-        for e in kalmanGain2[k][s].keys():
-            kalmanGain2[k][s][e].Write()
-
-
+        for q1 in kalmanGain2[k][s].keys():
+            for q2 in kalmanGain2[k][s][q1].keys():
+                for e in kalmanGain2[k][s][q1][q2].keys():
+                    kalmanGain2[k][s][q1][q2][e].Write()
 
 f.Close()
 

--- a/L1Trigger/L1TMuonBarrel/test/kalmanTools/packGainsLUT.py
+++ b/L1Trigger/L1TMuonBarrel/test/kalmanTools/packGainsLUT.py
@@ -16,12 +16,14 @@ def pack(f,fout,station,code):
 
 def pack2(f,fout,station,code):
     fout.cd()        
-    newH=ROOT.TH1D("gain2_{code}_{station}".format(station=station,code=code),"h",4*512,0,4*512)
-    for N,i in enumerate([0,1,4,5]):
-        h=f.Get("G2_{code}_{station}_{i}".format(station=station,code=code,i=i))
-        for j in range(1,h.GetNbinsX()+1):
-            newH.SetBinContent(N*512+j,h.GetBinContent(j))
-    newH.Write()
+    for q1 in ['H', 'L']:
+        for q2 in ['H', 'L']:
+            newH=ROOT.TH1D("gain2_{code}_{station}_{q1}{q2}".format(station=station,code=code,q1=q1,q2=q2),"h",4*512,0,4*512)
+            for N,i in enumerate([0,1,4,5]):
+                h=f.Get("G2_{code}_{station}_{i}_{q1}{q2}".format(station=station,code=code,i=i,q1=q1,q2=q2))
+                for j in range(1,h.GetNbinsX()+1):
+                    newH.SetBinContent(N*512+j,h.GetBinContent(j))
+            newH.Write()
 
 
 def packV(f,fout,code):

--- a/L1Trigger/L1TMuonBarrel/test/kalmanTools/parseGainsLUT.py
+++ b/L1Trigger/L1TMuonBarrel/test/kalmanTools/parseGainsLUT.py
@@ -1,18 +1,20 @@
 import ROOT
+ROOT.gROOT.SetBatch(True)
 
 
 
-
-def generate(tfile,name,outname,bins,mini,maxi,zeroSup=False,constant=-1,absol=False,factor=1):
+def generate(tfile,name,outname,bins,mini,maxi,zeroSup=False,constant=-1,absol=False,factor=1,rebin=False):
     xaxis=ROOT.TAxis(512*factor,0,512*factor)
     axis=ROOT.TAxis(bins,mini,maxi)
     h=tfile.Get(name)
+    if rebin:
+        h.Rebin()
     histo = h.ProfileX().ProjectionX()
     for i in range(1,h.GetNbinsX()+1):
         proj = h.ProjectionY("q",i,i)
         mean=proj.GetMean()
         rms = proj.GetRMS()
-        if proj.Integral()>100:
+        if proj.Integral()>15:
             histo.SetBinContent(i,mean)
             histo.SetBinError(i,rms)
         else:    
@@ -34,11 +36,10 @@ def generate(tfile,name,outname,bins,mini,maxi,zeroSup=False,constant=-1,absol=F
             N=N+1
     else:
         g = ROOT.TGraphErrors(histo)
-        x1=ROOT.Double_t(0.0)
-        y1=ROOT.Double_t(0.0)
+        x1=ROOT.Double(0.0)
+        y1=ROOT.Double(0.0)
         g.GetPoint(g.GetN()-1,x1,y1)
         lastx=x1
-
     newH = ROOT.TH1D(outname,outname,512*factor,0,512*factor)    
     for i in range(1,xaxis.GetNbins()+1):
         x = xaxis.GetBinLowEdge(i)
@@ -51,37 +52,47 @@ def generate(tfile,name,outname,bins,mini,maxi,zeroSup=False,constant=-1,absol=F
         if absol:
             content=abs(content)
         intCont = axis.GetBinLowEdge(axis.FindBin(content))    
-        newH.SetBinContent(i,intCont)
-
+        newH.SetBinContent(i,round(content,5))
+    c1 = ROOT.TCanvas("temp", "", 600, 600)
+    newH.Draw("p")
+    histo.Draw("same")
+    newH.GetYaxis().SetRangeUser(min(newH.GetMinimum(), histo.GetMinimum())-.1, max(newH.GetMaximum(), histo.GetMaximum())+.1)
+    c1.SaveAs(outname+".png")
     return newH,h.ProfileX().ProjectionX(outname+'_orig')
-
+    
 
 def printLUT(h,f,name,N):
     typ = 'updateLUT'+name[-1]+'_t'
     arr=[]
     for i in range(1,h.GetNbinsX()+1):
-        arr.append(str(h.GetBinContent(i)))
+        arr.append("{}".format(h.GetBinContent(i)))
     st = "const "+typ+" "+name+"["+str(N)+"]={"+','.join(arr)+"};\n"
     f.write(st)
+
+def printLUT2(h,f,name,N):
+    typ = 'update2LUT'+name[-4]+"_t"
+    arr=[]
+    if name[-2]=="L":
+        st = "const "+typ+" "+name+"={}".format(h.GetBinContent(1))+";\n"
+        f.write(st)
+    else:
+        for i in range(1,h.GetNbinsX()+1):
+            arr.append("{}".format(h.GetBinContent(i)))
+        st = "const "+typ+" "+name+"["+str(N)+"]={"+','.join(arr)+"};\n"
+        f.write(st)
+
 def printLUTV(h,f,name,N):
     typ = 'updateLUTV'+name[-1]+'_t'
     arr=[]
     for i in range(1,h.GetNbinsX()+1):
-        arr.append(str(h.GetBinContent(i)))
+        arr.append("{}".format(h.GetBinContent(i)))
     st = "const "+typ+" "+name+"["+str(N)+"]={"+','.join(arr)+"};\n"
     f.write(st)
 
 
 
 fileio=open("gainLUTs.h","w")
-fileio.write('#include "ap_fixed.h"\n')
-fileio.write('typedef ap_ufixed<9,6> updateLUT0_t;\n')
-fileio.write('typedef ap_ufixed<9,4> updateLUT4_t;\n')
-fileio.write('typedef ap_fixed<9,4> updateLUT1_t;\n')
-fileio.write('typedef ap_ufixed<9,8> updateLUT5_t;\n')
-fileio.write('typedef ap_ufixed<9,2> updateLUTV0_t;\n')
-fileio.write('typedef ap_ufixed<9,2> updateLUTV1_t;\n');
-
+fileio.write('#include common.h\n')
 
 f=ROOT.TFile("gains.root")
 
@@ -89,46 +100,46 @@ fout = ROOT.TFile("gainLUTs.root","RECREATE")
 fout.cd()
 
 
-def parse(fileio,f,fout,ele,bins,mini,maxi,zeroSup=False,constant=-1,absol=False,factor=1):
+def parse(fileio,f,fout,ele,bins,mini,maxi,zeroSup=False,constant=-1,absol=False,factor=1,rebin=False):
     fout.cd()
     stele=str(ele)
-    h,hO=generate(f,"gain_8_3_"+stele,"G_8_3_"+stele,bins,mini,maxi,zeroSup,constant,absol,factor)
+    h,hO=generate(f,"gain_8_3_"+stele,"G_8_3_"+stele,bins,mini,maxi,zeroSup,constant,absol,factor,rebin)
     printLUT(h,fileio,"gain_1000_3_"+stele,1024)
     h.Write()
     hO.Write()
 
-    h,hO=generate(f,"gain_8_2_"+stele,"G_8_2_"+stele,bins,mini,maxi,zeroSup,constant,absol,factor)
+    h,hO=generate(f,"gain_8_2_"+stele,"G_8_2_"+stele,bins,mini,maxi,zeroSup,constant,absol,factor,rebin)
     printLUT(h,fileio,"gain_1000_2_"+stele,1024)
     h.Write()
     hO.Write()
 
 
-    h,hO=generate(f,"gain_12_2_"+stele,"G_12_2_"+stele,bins,mini,maxi,zeroSup,constant,absol,factor)
+    h,hO=generate(f,"gain_12_2_"+stele,"G_12_2_"+stele,bins,mini,maxi,zeroSup,constant,absol,factor,rebin)
     printLUT(h,fileio,"gain_1100_2_"+stele,1024)
     h.Write()
     hO.Write()
 
-    h,hO=generate(f,"gain_12_1_"+stele,"G_12_1_"+stele,bins,mini,maxi,zeroSup,constant,absol,factor)
+    h,hO=generate(f,"gain_12_1_"+stele,"G_12_1_"+stele,bins,mini,maxi,zeroSup,constant,absol,factor,rebin)
     printLUT(h,fileio,"gain_1100_1_"+stele,1024)
     h.Write()
     hO.Write()
 
-    h,hO=generate(f,"gain_4_2_"+stele,"G_4_2_"+stele,bins,mini,maxi,zeroSup,constant,absol,factor)
+    h,hO=generate(f,"gain_4_2_"+stele,"G_4_2_"+stele,bins,mini,maxi,zeroSup,constant,absol,factor,rebin)
     printLUT(h,fileio,"gain_0100_2_"+stele,1024)
     h.Write()
     hO.Write()
 
-    h,hO=generate(f,"gain_10_1_"+stele,"G_10_1_"+stele,bins,mini,maxi,zeroSup,constant,absol,factor)
+    h,hO=generate(f,"gain_10_1_"+stele,"G_10_1_"+stele,bins,mini,maxi,zeroSup,constant,absol,factor,rebin)
     printLUT(h,fileio,"gain_1010_1_"+stele,1024)
     h.Write()
     hO.Write()
 
-    h,hO=generate(f,"gain_6_1_"+stele,"G_6_1_"+stele,bins,mini,maxi,zeroSup,constant,absol,factor)
+    h,hO=generate(f,"gain_6_1_"+stele,"G_6_1_"+stele,bins,mini,maxi,zeroSup,constant,absol,factor,rebin)
     printLUT(h,fileio,"gain_0110_1_"+stele,1024)
     h.Write()
     hO.Write()
 
-    h,hO=generate(f,"gain_14_1_"+stele,"G_14_1_"+stele,bins,mini,maxi,zeroSup,constant,absol,factor)
+    h,hO=generate(f,"gain_14_1_"+stele,"G_14_1_"+stele,bins,mini,maxi,zeroSup,constant,absol,factor,rebin)
     printLUT(h,fileio,"gain_1110_1_"+stele,1024)
     h.Write()
     hO.Write()
@@ -138,100 +149,104 @@ def parse(fileio,f,fout,ele,bins,mini,maxi,zeroSup=False,constant=-1,absol=False
 def parse2(fileio,f,fout,ele,bins,mini,maxi,zeroSup=False,constant=-1,absol=False,factor=1):
     fout.cd()
     stele=str(ele)
-    h,hO=generate(f,"gain2_8_3_"+stele,"G2_8_3_"+stele,bins,mini,maxi,zeroSup,constant,absol,factor)
-    printLUT(h,fileio,"gain2_1000_3_"+stele,512)
-    h.Write()
-    hO.Write()
+    for q1 in ['H', 'L']:
+        for q2 in ['H', 'L']:
+            stele = str(ele)
+            stele = stele+"_"+q1+q2
+            h,hO=generate(f,"gain2_8_3_"+stele,"G2_8_3_"+stele,bins,mini,maxi,zeroSup,constant,absol,factor)
+            printLUT2(h,fileio,"gain2_1000_3_"+stele,512)
+            h.Write()
+            hO.Write()
 
-    h,hO=generate(f,"gain2_8_2_"+stele,"G2_8_2_"+stele,bins,mini,maxi,zeroSup,constant,absol,factor)
-    printLUT(h,fileio,"gain2_1000_2_"+stele,512)
-    h.Write()
-    hO.Write()
+            h,hO=generate(f,"gain2_8_2_"+stele,"G2_8_2_"+stele,bins,mini,maxi,zeroSup,constant,absol,factor)
+            printLUT2(h,fileio,"gain2_1000_2_"+stele,512)
+            h.Write()
+            hO.Write()
 
-    h,hO=generate(f,"gain2_8_1_"+stele,"G2_8_1_"+stele,bins,mini,maxi,zeroSup,constant,absol,factor)
-    printLUT(h,fileio,"gain2_1000_1_"+stele,512)
-    h.Write()
-    hO.Write()
+            h,hO=generate(f,"gain2_8_1_"+stele,"G2_8_1_"+stele,bins,mini,maxi,zeroSup,constant,absol,factor)
+            printLUT2(h,fileio,"gain2_1000_1_"+stele,512)
+            h.Write()
+            hO.Write()
 
-    h,hO=generate(f,"gain2_4_2_"+stele,"G2_4_2_"+stele,bins,mini,maxi,zeroSup,constant,absol,factor)
-    printLUT(h,fileio,"gain2_0100_2_"+stele,512)
-    h.Write()
-    hO.Write()
+            h,hO=generate(f,"gain2_4_2_"+stele,"G2_4_2_"+stele,bins,mini,maxi,zeroSup,constant,absol,factor)
+            printLUT2(h,fileio,"gain2_0100_2_"+stele,512)
+            h.Write()
+            hO.Write()
 
-    h,hO=generate(f,"gain2_4_1_"+stele,"G2_4_1_"+stele,bins,mini,maxi,zeroSup,constant,absol,factor)
-    printLUT(h,fileio,"gain2_0100_1_"+stele,512)
-    h.Write()
-    hO.Write()
+            h,hO=generate(f,"gain2_4_1_"+stele,"G2_4_1_"+stele,bins,mini,maxi,zeroSup,constant,absol,factor)
+            printLUT2(h,fileio,"gain2_0100_1_"+stele,512)
+            h.Write()
+            hO.Write()
 
-    h,hO=generate(f,"gain2_2_1_"+stele,"G2_2_1_"+stele,bins,mini,maxi,zeroSup,constant,absol,factor)
-    printLUT(h,fileio,"gain2_0010_1_"+stele,512)
-    h.Write()
-    hO.Write()
-
-
+            h,hO=generate(f,"gain2_2_1_"+stele,"G2_2_1_"+stele,bins,mini,maxi,zeroSup,constant,absol,factor)
+            printLUT2(h,fileio,"gain2_0010_1_"+stele,512)
+            h.Write()
+            hO.Write()
 
 
 
-def parseV(fileio,f,fout,ele,bins,mini,maxi,zeroSup=False,constant=-1,absol=False,factor=2):
+
+
+def parseV(fileio,f,fout,ele,bins,mini,maxi,zeroSup=False,constant=-1,absol=False,factor=2,rebin=False):
     fout.cd()
     stele=str(ele)
-    h,hO=generate(f,"gain_15_0_"+stele,"G_15_0_"+stele,bins,mini,maxi,zeroSup,constant,absol,factor)
+    h,hO=generate(f,"gain_15_0_"+stele,"G_15_0_"+stele,bins,mini,maxi,zeroSup,constant,absol,factor,rebin)
     printLUTV(h,fileio,"gain_1111_0_"+stele,1024)
     h.Write()
     hO.Write()
-    h,hO=generate(f,"gain_14_0_"+stele,"G_14_0_"+stele,bins,mini,maxi,zeroSup,constant,absol,factor)
+    h,hO=generate(f,"gain_14_0_"+stele,"G_14_0_"+stele,bins,mini,maxi,zeroSup,constant,absol,factor,rebin)
     printLUTV(h,fileio,"gain_1110_0_"+stele,1024)
     h.Write()
     hO.Write()
-    h,hO=generate(f,"gain_13_0_"+stele,"G_13_0_"+stele,bins,mini,maxi,zeroSup,constant,absol,factor)
+    h,hO=generate(f,"gain_13_0_"+stele,"G_13_0_"+stele,bins,mini,maxi,zeroSup,constant,absol,factor,rebin)
     printLUTV(h,fileio,"gain_1101_0_"+stele,1024)
     h.Write()
     hO.Write()
-    h,hO=generate(f,"gain_12_0_"+stele,"G_12_0_"+stele,bins,mini,maxi,zeroSup,constant,absol,factor)
+    h,hO=generate(f,"gain_12_0_"+stele,"G_12_0_"+stele,bins,mini,maxi,zeroSup,constant,absol,factor,rebin)
     printLUTV(h,fileio,"gain_1100_0_"+stele,1024)
     h.Write()
     hO.Write()
-    h,hO=generate(f,"gain_11_0_"+stele,"G_11_0_"+stele,bins,mini,maxi,zeroSup,constant,absol,factor)
+    h,hO=generate(f,"gain_11_0_"+stele,"G_11_0_"+stele,bins,mini,maxi,zeroSup,constant,absol,factor,rebin)
     printLUTV(h,fileio,"gain_1011_0_"+stele,1024)
     h.Write()
     hO.Write()
-    h,hO=generate(f,"gain_10_0_"+stele,"G_10_0_"+stele,bins,mini,maxi,zeroSup,constant,absol,factor)
+    h,hO=generate(f,"gain_10_0_"+stele,"G_10_0_"+stele,bins,mini,maxi,zeroSup,constant,absol,factor,rebin)
     printLUTV(h,fileio,"gain_1010_0_"+stele,1024)
     h.Write()
     hO.Write()
-    h,hO=generate(f,"gain_9_0_"+stele,"G_9_0_"+stele,bins,mini,maxi,zeroSup,constant,absol,factor)
+    h,hO=generate(f,"gain_9_0_"+stele,"G_9_0_"+stele,bins,mini,maxi,zeroSup,constant,absol,factor,rebin)
     printLUTV(h,fileio,"gain_1001_0_"+stele,1024)
     h.Write()
     hO.Write()
-    h,hO=generate(f,"gain_7_0_"+stele,"G_7_0_"+stele,bins,mini,maxi,zeroSup,constant,absol,factor)
+    h,hO=generate(f,"gain_7_0_"+stele,"G_7_0_"+stele,bins,mini,maxi,zeroSup,constant,absol,factor,rebin)
     printLUTV(h,fileio,"gain_0111_0_"+stele,1024)
     h.Write()
     hO.Write()
-    h,hO=generate(f,"gain_6_0_"+stele,"G_6_0_"+stele,bins,mini,maxi,zeroSup,constant,absol,factor)
+    h,hO=generate(f,"gain_6_0_"+stele,"G_6_0_"+stele,bins,mini,maxi,zeroSup,constant,absol,factor,rebin)
     printLUTV(h,fileio,"gain_0110_0_"+stele,1024)
     h.Write()
     hO.Write()
-    h,hO=generate(f,"gain_5_0_"+stele,"G_5_0_"+stele,bins,mini,maxi,zeroSup,constant,absol,factor)
+    h,hO=generate(f,"gain_5_0_"+stele,"G_5_0_"+stele,bins,mini,maxi,zeroSup,constant,absol,factor,rebin)
     printLUTV(h,fileio,"gain_0101_0_"+stele,1024)
     h.Write()
     hO.Write()
-    h,hO=generate(f,"gain_3_0_"+stele,"G_3_0_"+stele,bins,mini,maxi,zeroSup,constant,absol,factor)
+    h,hO=generate(f,"gain_3_0_"+stele,"G_3_0_"+stele,bins,mini,maxi,zeroSup,constant,absol,factor,rebin)
     printLUTV(h,fileio,"gain_0011_0_"+stele,1024)
     h.Write()
     hO.Write()
 
 
 
-parse(fileio,f,fout,0,512,0,64,True,-1,False,2)    
-parse(fileio,f,fout,4,512,0,16,True,-1,True,2)    
+parse(fileio,f,fout,0,512*2,0,64*2,True,-1,False,2,False)    
+parse(fileio,f,fout,4,512,0,16,True,-1,True,2,False)    
 
 parse2(fileio,f,fout,0,512,0,64,True,-1,False,1)    
-parse2(fileio,f,fout,1,512,-8,8,True,-1,False,1)    
+parse2(fileio,f,fout,1,512,-8,8,True,-1,True,1)    
 parse2(fileio,f,fout,4,512,0,16,True,-1,True,1)    
 parse2(fileio,f,fout,5,512,0,1,True,-1,False,1)    
 
-parseV(fileio,f,fout,0,512,0,4,True,700,True,2)    
-parseV(fileio,f,fout,1,512,0,4,True,700,True,2)    
+parseV(fileio,f,fout,0,512,0,4,True,-1,True,2,True)    
+parseV(fileio,f,fout,1,512,0,4,True,-1,True,2,True)    
 
 fout.Close()
 f.Close()


### PR DESCRIPTION
#### PR description:

New version of KMTF algorithm as discussed in https://indico.cern.ch/event/1012620/contributions/4250430/attachments/2200192/3721090/Run3_KMTF.pdf

#### PR validation:

Nominal tests with just KMTF algorithm. No core changes, just incremental changes to KMTF

#### if this PR is a backport please specify the original PR and why you need to backport that PR:
Backport of #33078 , requested by the L1 Trigger group

@rekovic copied from #33078 -  the LUTs in L1Trigger/L1TMuon/data/bmtf_luts/kalmanLUTs.root are usually in the https://github.com/cms-l1t-offline/L1Trigger-L1TMuon.git repository. They have to be moved but I do not have access