### PR TITLE
Clean BuildFiles and add source_only flags to fix warnings

### DIFF
--- a/CondCore/SiPixelPlugins/plugins/BuildFile.xml
+++ b/CondCore/SiPixelPlugins/plugins/BuildFile.xml
@@ -60,14 +60,12 @@
 <library file="SiPixelQualityProbabilities_PayloadInspector.cc" name="SiPixelQualityProbabilities_PayloadInspector">
   <use   name="CondCore/Utilities"/>
   <use   name="CondCore/CondDB"/>
-  <use   name="CondFormats/Common"/>
   <use   name="CalibTracker/StandaloneTrackerTopology"/>
 </library>
 
 <library file="SiPixelFEDChannelContainer_PayloadInspector.cc" name="SiPixelFEDChannelContainer_PayloadInspector">
   <use   name="CondCore/Utilities"/>
   <use   name="CondCore/CondDB"/>
-  <use   name="CondFormats/Common"/>
   <use   name="CalibTracker/StandaloneTrackerTopology"/>
 </library>
 

--- a/DataFormats/CSCDigi/BuildFile.xml
+++ b/DataFormats/CSCDigi/BuildFile.xml
@@ -1,7 +1,7 @@
 <use name="DataFormats/Common"/>
 <use name="DataFormats/MuonDetId"/>
 <use name="DataFormats/GEMDigi"/>
-<use name="DataFormats/MuonData"/>
+<use name="DataFormats/MuonData" source_only="1"/>
 <use name="FWCore/MessageLogger"/>
 <export>
   <lib name="1"/>

--- a/DataFormats/GEMDigi/BuildFile.xml
+++ b/DataFormats/GEMDigi/BuildFile.xml
@@ -1,7 +1,7 @@
 <use name="DataFormats/Common"/>
 <use name="DataFormats/MuonDetId"/>
 <use name="DataFormats/GEMRecHit"/>
-<use name="DataFormats/MuonData"/>
+<use name="DataFormats/MuonData" source_only="1"/>
 <use name="FWCore/MessageLogger"/>
 <export>
   <lib name="1"/>

--- a/DataFormats/RPCDigi/BuildFile.xml
+++ b/DataFormats/RPCDigi/BuildFile.xml
@@ -1,7 +1,7 @@
 <use name="DataFormats/Common"/>
 <use name="DataFormats/MuonDetId"/>
 <use name="CondFormats/RPCObjects"/>
-<use name="DataFormats/MuonData"/>
+<use name="DataFormats/MuonData" source_only="1"/>
 <use name="FWCore/MessageLogger"/>
 <use name="FWCore/Utilities"/>
 <export>

--- a/Geometry/MTDGeometryBuilder/test/BuildFile.xml
+++ b/Geometry/MTDGeometryBuilder/test/BuildFile.xml
@@ -5,7 +5,6 @@
   <use name="FWCore/ParameterSet"/>
   <use name="Geometry/CommonTopologies"/>
   <use name="Geometry/MTDGeometryBuilder"/>
-  <use name="Geometry/MTDNumberingBuilder"/>
   <use name="Geometry/Records"/>
   <use name="boost_system"/>
   <use name="rootcling"/>

--- a/HLTrigger/Egamma/plugins/BuildFile.xml
+++ b/HLTrigger/Egamma/plugins/BuildFile.xml
@@ -1,5 +1,3 @@
-<use name="CondFormats/DataRecord"/>
-<use name="CondFormats/L1TObjects"/>
 <use name="DataFormats/Candidate"/>
 <use name="DataFormats/Common"/>
 <use name="DataFormats/EgammaCandidates"/>

--- a/HLTrigger/HLTcore/BuildFile.xml
+++ b/HLTrigger/HLTcore/BuildFile.xml
@@ -3,6 +3,7 @@
 <use name="DataFormats/Common"/>
 <use name="FWCore/Framework"/>
 <use name="FWCore/ParameterSet"/>
+<use name="FWCore/PrescaleService"/>
 <use name="FWCore/ServiceRegistry"/>
 <use name="FWCore/MessageLogger"/>
 <use name="L1Trigger/GlobalTriggerAnalyzer"/>

--- a/HLTrigger/HLTcore/plugins/BuildFile.xml
+++ b/HLTrigger/HLTcore/plugins/BuildFile.xml
@@ -10,7 +10,6 @@
   <use name="DataFormats/RecoCandidate"/>
   <use name="DataFormats/TauReco"/>
   <use name="HLTrigger/HLTcore"/>
-  <use name="FWCore/PrescaleService"/>
   <use name="FWCore/ServiceRegistry"/>
   <use name="FWCore/Utilities"/>
   <flags EDM_PLUGIN="1"/>

--- a/HeterogeneousCore/SonicTriton/test/BuildFile.xml
+++ b/HeterogeneousCore/SonicTriton/test/BuildFile.xml
@@ -4,7 +4,6 @@
     <flags EDM_PLUGIN="1"/>
     <use name="FWCore/ParameterSet"/>
     <use name="FWCore/Framework"/>
-    <use name="HeterogeneousCore/SonicCore"/>
     <use name="HeterogeneousCore/SonicTriton"/>
   </library>
 </environment>

--- a/L1Trigger/L1TNtuples/BuildFile.xml
+++ b/L1Trigger/L1TNtuples/BuildFile.xml
@@ -17,7 +17,6 @@
 <use name="DataFormats/VertexReco"/>
 <use name="DataFormats/MuonReco"/>
 <use name="DataFormats/TrackReco"/>
-<use name="EventFilter/L1TRawToDigi"/>
 <use name="RecoLocalCalo/EcalRecAlgos"/>
 <use name="TrackingTools/TrajectoryState"/>
 <use name="L1Trigger/CSCTrackFinder"/>

--- a/L1Trigger/L1TNtuples/plugins/BuildFile.xml
+++ b/L1Trigger/L1TNtuples/plugins/BuildFile.xml
@@ -21,6 +21,7 @@
 <use name="DataFormats/VertexReco"/>
 <use name="DataFormats/MuonReco"/>
 <use name="DataFormats/TrackReco"/>
+<use name="EventFilter/L1TRawToDigi"/>
 <use name="Geometry/DTGeometry"/>
 <use name="Geometry/CSCGeometry"/>
 <use name="Geometry/RPCGeometry"/>

--- a/PhysicsTools/JetExamples/test/BuildFile.xml
+++ b/PhysicsTools/JetExamples/test/BuildFile.xml
@@ -2,24 +2,24 @@
 <library file="printJetFlavourInfo.cc">
   <flags EDM_PLUGIN="1"/>
   <use name="FWCore/Framework"/>
-  <use name="SimDataFormats/JetMatching"/>
   <use name="DataFormats/Candidate"/>
+  <use name="DataFormats/JetMatching"/>
   <use name="DataFormats/JetReco"/>
 </library>
 
 <library file="printJetFlavour.cc">
   <flags EDM_PLUGIN="1"/>
   <use name="FWCore/Framework"/>
-  <use name="SimDataFormats/JetMatching"/>
   <use name="DataFormats/Candidate"/>
+  <use name="DataFormats/JetMatching"/>
   <use name="DataFormats/JetReco"/>
 </library>
 
 <library file="printGenJetRatio.cc">
   <flags EDM_PLUGIN="1"/>
   <use name="FWCore/Framework"/>
-  <use name="SimDataFormats/JetMatching"/>
   <use name="DataFormats/Candidate"/>
+  <use name="DataFormats/JetMatching"/>
   <use name="DataFormats/JetReco"/>
 </library>
 

--- a/PhysicsTools/JetMCAlgos/plugins/BuildFile.xml
+++ b/PhysicsTools/JetMCAlgos/plugins/BuildFile.xml
@@ -4,13 +4,13 @@
 <use name="PhysicsTools/JetMCAlgos"/>
 <use name="PhysicsTools/JetMCUtils"/>
 <use name="PhysicsTools/HepMCCandAlgos"/>
-<use name="SimDataFormats/JetMatching"/>
 <use name="SimDataFormats/GeneratorProducts"/>
 <use name="DataFormats/HepMCCandidate"/>
 <use name="CommonTools/CandUtils"/>
 <use name="CommonTools/UtilAlgos"/>
 <use name="DataFormats/Candidate"/>
 <use name="DataFormats/Common"/>
+<use name="DataFormats/JetMatching"/>
 <use name="DataFormats/JetReco"/>
 <use name="DataFormats/Math"/>
 <use name="DataFormats/ParticleFlowCandidate"/>

--- a/PhysicsTools/PatAlgos/plugins/BuildFile.xml
+++ b/PhysicsTools/PatAlgos/plugins/BuildFile.xml
@@ -10,6 +10,7 @@
   <use name="DataFormats/PatCandidates"/>
   <use name="DataFormats/BTauReco"/>
   <use name="DataFormats/Common"/>
+  <use name="DataFormats/JetMatching"/>
   <use name="DataFormats/JetReco"/>
   <use name="DataFormats/MuonReco"/>
   <use name="DataFormats/TrackReco"/>
@@ -27,7 +28,6 @@
   <use name="RecoEgamma/EgammaTools"/>
   <use name="SimDataFormats/Track"/>
   <use name="SimDataFormats/Vertex"/>
-  <use name="SimDataFormats/JetMatching"/>
   <use name="SimDataFormats/PileupSummaryInfo"/>
   <use name="SimGeneral/HepPDTRecord"/>
   <use name="RecoMET/METAlgorithms"/>

--- a/RecoEgamma/PhotonIdentification/BuildFile.xml
+++ b/RecoEgamma/PhotonIdentification/BuildFile.xml
@@ -1,8 +1,6 @@
 <use name="FWCore/Framework"/>
 <use name="FWCore/MessageLogger"/>
 <use name="FWCore/ParameterSet"/>
-<use name="CommonTools/Utils"/>
-<use name="CondFormats/DataRecord"/>
 <use name="CondFormats/EcalObjects"/>
 <use name="DataFormats/BeamSpot"/>
 <use name="DataFormats/Common"/>

--- a/RecoEgamma/PhotonIdentification/plugins/BuildFile.xml
+++ b/RecoEgamma/PhotonIdentification/plugins/BuildFile.xml
@@ -7,6 +7,7 @@
 <use name="CommonTools/Egamma"/>
 <use name="CommonTools/MVAUtils"/>
 <use name="CommonTools/UtilAlgos"/>
+<use name="CommonTools/Utils"/>
 <library name="RecoEgammaPhotonIdentificationPlugins" file="*.cc">
   <use name="RecoEgamma/PhotonIdentification"/>
   <use name="RecoEgamma/EgammaTools"/>

--- a/RecoHGCal/TICL/plugins/BuildFile.xml
+++ b/RecoHGCal/TICL/plugins/BuildFile.xml
@@ -5,8 +5,6 @@
 <use name="FWCore/ParameterSet"/>
 <use name="FWCore/PluginManager"/>
 <use name="DataFormats/CaloRecHit"/>
-<use name="DataFormats/L1Trigger"/>
-<use name="DataFormats/Candidate"/>
 <use name="DataFormats/ParticleFlowCandidate"/>
 <use name="DataFormats/HGCalReco"/>
 <use name="FWCore/MessageLogger"/>

--- a/RecoHGCal/TICL/test/BuildFile.xml
+++ b/RecoHGCal/TICL/test/BuildFile.xml
@@ -4,9 +4,6 @@
 <use name="DataFormats/TrackReco"/>
 <use name="DataFormats/Math"/>
 <use name="SimDataFormats/CaloAnalysis"/>
-<use name="Geometry/HcalTowerAlgo"/>
-<use name="Geometry/HGCalGeometry"/>
-<use name="Geometry/Records"/>
 <use name="RecoLocalCalo/HGCalRecAlgos"/>
 <flags EDM_PLUGIN="1"/>
 <library   file="*.cc" name="testRecoHGCalTICL"> </library>

--- a/RecoTracker/FinalTrackSelectors/BuildFile.xml
+++ b/RecoTracker/FinalTrackSelectors/BuildFile.xml
@@ -5,10 +5,10 @@
 <use name="FWCore/MessageLogger"/>
 <use name="FWCore/ParameterSet"/>
 <use name="CondFormats/GBRForest"/>
+<use name="PhysicsTools/TensorFlow"/>
+<use name="TrackingTools/PatternTools"/>
 <use name="roottmva"/>
 <use name="lwtnn"/>
-<use name="TrackingTools/Records"/>
-<use name="PhysicsTools/TensorFlow"/>
 <export>
   <lib name="1"/>
 </export>

--- a/RecoTracker/FinalTrackSelectors/plugins/BuildFile.xml
+++ b/RecoTracker/FinalTrackSelectors/plugins/BuildFile.xml
@@ -27,6 +27,7 @@
 <use name="TrackingTools/TransientTrack"/>
 <use name="TrackingTools/GeomPropagators"/>
 <use name="TrackingTools/KalmanUpdators"/>
+<use name="TrackingTools/Records"/>
 <use name="CondFormats/GBRForest"/>
 <use name="CommonTools/Utils"/>
 <use name="CommonTools/Statistics"/>

--- a/RecoVertex/PrimaryVertexProducer/BuildFile.xml
+++ b/RecoVertex/PrimaryVertexProducer/BuildFile.xml
@@ -8,6 +8,7 @@
 <use name="RecoVertex/KalmanVertexFit"/>
 <use name="RecoVertex/VertexPrimitives"/>
 <use name="RecoVertex/VertexTools"/>
+<use name="TrackingTools/Records"/>
 <use name="TrackingTools/TransientTrack"/>
 <use name="vdt_headers"/>
 <export>

--- a/RecoVertex/PrimaryVertexProducer/plugins/BuildFile.xml
+++ b/RecoVertex/PrimaryVertexProducer/plugins/BuildFile.xml
@@ -1,7 +1,6 @@
 <use name="FWCore/Framework"/>
 <use name="clhep"/>
 <use name="RecoVertex/PrimaryVertexProducer"/>
-<use name="TrackingTools/Records"/>
 <library file="*.cc" name="RecoVertexPrimaryVertexProducerPlugins">
   <flags EDM_PLUGIN="1"/>
 </library>

--- a/Validation/CSCRecHits/BuildFile.xml
+++ b/Validation/CSCRecHits/BuildFile.xml
@@ -2,10 +2,8 @@
 <use name="DQMServices/Core"/>
 <use name="FWCore/Framework"/>
 <use name="FWCore/ParameterSet"/>
-<use name="FWCore/ServiceRegistry"/>
 <use name="Geometry/CSCGeometry"/>
 <use name="Geometry/Records"/>
-<use name="SimMuon/MCTruth"/>
 <use name="Validation/MuonCSCDigis"/>
 <export>
   <lib name="1"/>

--- a/Validation/CSCRecHits/plugins/BuildFile.xml
+++ b/Validation/CSCRecHits/plugins/BuildFile.xml
@@ -1,6 +1,8 @@
 <library file="*.cc" name="ValidationCSCRecHitsPlugin">
   <use name="FWCore/Framework"/>
+  <use name="FWCore/ServiceRegistry"/>
   <use name="Validation/CSCRecHits"/>
+  <use name="SimMuon/MCTruth"/>
   <use name="clhep"/>
   <flags EDM_PLUGIN="1"/>
 </library>


### PR DESCRIPTION
#### PR description:

Another quick BuildFile cleaning PR in the style of many before (for example https://github.com/cms-sw/cmssw/pull/33143).

This PR cleans unnecessary includes from CMSSW BuildFiles that were recently added.

More importantly, it also adds the `source_only="1"` flag when there are dependencies on source-only packages that have no BuildFiles themselves. Otherwise, we get a warning with `scram b`. This was already done in https://github.com/cms-sw/cmssw/pull/33143, but in the meantime a few new `<use name="DataFormats/MuonData"/>` were introduced in CMSSW that needed to be fixed.

#### PR validation:

CMSSW compiles.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

No backport intended.