### PR TITLE
GEM cluster data vs emulator plots in L1T DQM [11_3_X]

### DIFF
--- a/DQM/L1TMonitor/interface/L1TdeGEMTPG.h
+++ b/DQM/L1TMonitor/interface/L1TdeGEMTPG.h
@@ -1,0 +1,41 @@
+#ifndef DQM_L1TMonitor_L1TdeGEMTPG_h
+#define DQM_L1TMonitor_L1TdeGEMTPG_h
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "DQMServices/Core/interface/DQMEDAnalyzer.h"
+#include "DQMServices/Core/interface/DQMStore.h"
+
+#include "DataFormats/GEMDigi/interface/GEMPadDigiClusterCollection.h"
+
+class L1TdeGEMTPG : public DQMEDAnalyzer {
+public:
+  L1TdeGEMTPG(const edm::ParameterSet& ps);
+  ~L1TdeGEMTPG() override;
+
+protected:
+  void bookHistograms(DQMStore::IBooker&, const edm::Run&, const edm::EventSetup&) override;
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
+
+private:
+  edm::EDGetTokenT<GEMPadDigiClusterCollection> data_token_;
+  edm::EDGetTokenT<GEMPadDigiClusterCollection> emul_token_;
+  std::string monitorDir_;
+  bool verbose_;
+
+  std::vector<std::string> chambers_;
+  std::vector<std::string> dataEmul_;
+
+  std::vector<std::string> clusterVars_;
+  std::vector<unsigned> clusterNBin_;
+  std::vector<double> clusterMinBin_;
+  std::vector<double> clusterMaxBin_;
+
+  // first key is the chamber number
+  // second key is the variable
+  std::map<uint32_t, std::map<std::string, MonitorElement*> > chamberHistos;
+};
+
+#endif

--- a/DQM/L1TMonitor/plugins/SealModule.cc
+++ b/DQM/L1TMonitor/plugins/SealModule.cc
@@ -1,81 +1,81 @@
 #include "FWCore/PluginManager/interface/ModuleDef.h"
 
-#include <DQM/L1TMonitor/interface/L1TFED.h>
+#include "DQM/L1TMonitor/interface/L1TFED.h"
 DEFINE_FWK_MODULE(L1TFED);
 
-#include <DQM/L1TMonitor/interface/L1TCSCTPG.h>
+#include "DQM/L1TMonitor/interface/L1TCSCTPG.h"
 DEFINE_FWK_MODULE(L1TCSCTPG);
 
-#include <DQM/L1TMonitor/interface/L1TCSCTF.h>
+#include "DQM/L1TMonitor/interface/L1TCSCTF.h"
 DEFINE_FWK_MODULE(L1TCSCTF);
 
-#include <DQM/L1TMonitor/interface/L1TDTTPG.h>
+#include "DQM/L1TMonitor/interface/L1TDTTPG.h"
 DEFINE_FWK_MODULE(L1TDTTPG);
 
-#include <DQM/L1TMonitor/interface/L1TDTTF.h>
+#include "DQM/L1TMonitor/interface/L1TDTTF.h"
 DEFINE_FWK_MODULE(L1TDTTF);
 
-#include <DQM/L1TMonitor/interface/L1TRPCTPG.h>
+#include "DQM/L1TMonitor/interface/L1TRPCTPG.h"
 DEFINE_FWK_MODULE(L1TRPCTPG);
 
-#include <DQM/L1TMonitor/interface/L1TRPCTF.h>
+#include "DQM/L1TMonitor/interface/L1TRPCTF.h"
 DEFINE_FWK_MODULE(L1TRPCTF);
 
-#include <DQM/L1TMonitor/interface/L1TGMT.h>
+#include "DQM/L1TMonitor/interface/L1TGMT.h"
 DEFINE_FWK_MODULE(L1TGMT);
 
-#include <DQM/L1TMonitor/interface/L1TStage2CaloLayer1.h>
+#include "DQM/L1TMonitor/interface/L1TStage2CaloLayer1.h"
 DEFINE_FWK_MODULE(L1TStage2CaloLayer1);
 
-#include <DQM/L1TMonitor/interface/L1TStage2CaloLayer2.h>
+#include "DQM/L1TMonitor/interface/L1TStage2CaloLayer2.h"
 DEFINE_FWK_MODULE(L1TStage2CaloLayer2);
 
-#include <DQM/L1TMonitor/interface/L1TStage2uGMT.h>
+#include "DQM/L1TMonitor/interface/L1TStage2uGMT.h"
 DEFINE_FWK_MODULE(L1TStage2uGMT);
 
-#include <DQM/L1TMonitor/interface/L1TObjectsTiming.h>
+#include "DQM/L1TMonitor/interface/L1TObjectsTiming.h"
 DEFINE_FWK_MODULE(L1TObjectsTiming);
 
-#include <DQM/L1TMonitor/interface/L1TStage2uGMTMuon.h>
+#include "DQM/L1TMonitor/interface/L1TStage2uGMTMuon.h"
 DEFINE_FWK_MODULE(L1TStage2uGMTMuon);
 
-#include <DQM/L1TMonitor/interface/L1TStage2MuonComp.h>
+#include "DQM/L1TMonitor/interface/L1TStage2MuonComp.h"
 DEFINE_FWK_MODULE(L1TStage2MuonComp);
 
-#include <DQM/L1TMonitor/interface/L1TStage2RegionalMuonCandComp.h>
+#include "DQM/L1TMonitor/interface/L1TStage2RegionalMuonCandComp.h"
 DEFINE_FWK_MODULE(L1TStage2RegionalMuonCandComp);
 
-#include <DQM/L1TMonitor/interface/L1TStage2uGT.h>
+#include "DQM/L1TMonitor/interface/L1TStage2uGT.h"
 DEFINE_FWK_MODULE(L1TStage2uGT);
 
-#include <DQM/L1TMonitor/interface/L1TStage2uGTTiming.h>
+#include "DQM/L1TMonitor/interface/L1TStage2uGTTiming.h"
 DEFINE_FWK_MODULE(L1TStage2uGTTiming);
 
-#include <DQM/L1TMonitor/interface/L1TStage2BMTF.h>
+#include "DQM/L1TMonitor/interface/L1TStage2BMTF.h"
 DEFINE_FWK_MODULE(L1TStage2BMTF);
 
-#include <DQM/L1TMonitor/interface/L1TStage2OMTF.h>
+#include "DQM/L1TMonitor/interface/L1TStage2OMTF.h"
 DEFINE_FWK_MODULE(L1TStage2OMTF);
 
-#include <DQM/L1TMonitor/interface/L1TStage2EMTF.h>
+#include "DQM/L1TMonitor/interface/L1TStage2EMTF.h"
 DEFINE_FWK_MODULE(L1TStage2EMTF);
 
-#include <DQM/L1TMonitor/interface/L1TMP7ZeroSupp.h>
+#include "DQM/L1TMonitor/interface/L1TMP7ZeroSupp.h"
 DEFINE_FWK_MODULE(L1TMP7ZeroSupp);
 
-#include <DQM/L1TMonitor/interface/L1TGCT.h>
+#include "DQM/L1TMonitor/interface/L1TGCT.h"
 DEFINE_FWK_MODULE(L1TGCT);
 
-#include <DQM/L1TMonitor/interface/L1TRCT.h>
+#include "DQM/L1TMonitor/interface/L1TRCT.h"
 DEFINE_FWK_MODULE(L1TRCT);
 
 #include "DQM/L1TMonitor/interface/L1TPUM.h"
 DEFINE_FWK_MODULE(L1TPUM);
 
-#include <DQM/L1TMonitor/interface/L1TGT.h>
+#include "DQM/L1TMonitor/interface/L1TGT.h"
 DEFINE_FWK_MODULE(L1TGT);
 
-#include <DQM/L1TMonitor/interface/L1TCompare.h>
+#include "DQM/L1TMonitor/interface/L1TCompare.h"
 DEFINE_FWK_MODULE(L1TCompare);
 
 #include "DQM/L1TMonitor/interface/BxTiming.h"
@@ -92,13 +92,16 @@ DEFINE_FWK_MODULE(L1TdeGCT);
 #include "DQM/L1TMonitor/interface/L1TdeRCT.h"
 DEFINE_FWK_MODULE(L1TdeRCT);
 
-#include <DQM/L1TMonitor/interface/L1TdeStage2CaloLayer1.h>
+#include "DQM/L1TMonitor/interface/L1TdeStage2CaloLayer1.h"
 DEFINE_FWK_MODULE(L1TdeStage2CaloLayer1);
+
+#include "DQM/L1TMonitor/interface/L1TdeGEMTPG.h"
+DEFINE_FWK_MODULE(L1TdeGEMTPG);
 
 #include "DQM/L1TMonitor/interface/L1TdeCSCTF.h"
 DEFINE_FWK_MODULE(L1TdeCSCTF);
 
-#include <DQM/L1TMonitor/interface/L1TdeStage2EMTF.h>
+#include "DQM/L1TMonitor/interface/L1TdeStage2EMTF.h"
 DEFINE_FWK_MODULE(L1TdeStage2EMTF);
 
 //#include "DQM/L1TMonitor/interface/L1GtHwValidation.h"
@@ -125,5 +128,5 @@ DEFINE_FWK_MODULE(L1TStage2uGTCaloLayer2Comp);
 #include "DQM/L1TMonitor/interface/L1TdeStage2CaloLayer2.h"
 DEFINE_FWK_MODULE(L1TdeStage2CaloLayer2);
 
-#include <DQM/L1TMonitor/interface/L1TdeStage2uGT.h>
+#include "DQM/L1TMonitor/interface/L1TdeStage2uGT.h"
 DEFINE_FWK_MODULE(L1TdeStage2uGT);

--- a/DQM/L1TMonitor/python/L1TStage2Emulator_cff.py
+++ b/DQM/L1TMonitor/python/L1TStage2Emulator_cff.py
@@ -47,6 +47,13 @@ valOmtfDigis.srcDTTh = cms.InputTag('omtfStage2Digis')
 valOmtfDigis.srcCSC = cms.InputTag('omtfStage2Digis')
 valOmtfDigis.srcRPC = cms.InputTag('omtfStage2Digis')
 
+# GEM TPG
+from L1Trigger.L1TGEM.simGEMDigis_cff import *
+valMuonGEMPadDigis = simMuonGEMPadDigis.clone()
+valMuonGEMPadDigis.InputCollection = cms.InputTag('muonGEMDigis')
+valMuonGEMPadDigiClusters = simMuonGEMPadDigiClusters.clone()
+valMuonGEMPadDigiClusters.InputCollection = cms.InputTag('valMuonGEMPadDigis')
+
 # EMTF
 from L1Trigger.L1TMuonEndCap.simEmtfDigis_cfi import *
 valEmtfStage2Digis = simEmtfDigis.clone()
@@ -94,6 +101,12 @@ Stage2L1HardwareValidation = cms.Sequence(
     valGtStage2Digis
 )
 
+from Configuration.Eras.Modifier_run3_GEM_cff import run3_GEM
+_run3_Stage2L1HardwareValidation = Stage2L1HardwareValidation.copy()
+_run3_Stage2L1HardwareValidation += valMuonGEMPadDigis
+_run3_Stage2L1HardwareValidation += valMuonGEMPadDigiClusters
+run3_GEM.toReplaceWith( Stage2L1HardwareValidation, _run3_Stage2L1HardwareValidation )
+
 Stage2L1HardwareValidationForValidationEvents = cms.Sequence(
     valCaloStage2Layer2Digis
 )
@@ -107,6 +120,9 @@ from DQM.L1TMonitor.L1TdeStage2CaloLayer1_cfi import *
 # CaloLayer2
 from DQM.L1TMonitor.L1TdeStage2CaloLayer2_cfi import *
 from DQM.L1TMonitor.L1TStage2CaloLayer2Emul_cfi import *
+
+# GEM TPG
+from DQM.L1TMonitor.L1TdeGEMTPG_cfi import *
 
 # BMTF
 from DQM.L1TMonitor.L1TdeStage2BMTF_cfi import *
@@ -138,6 +154,12 @@ l1tStage2EmulatorOnlineDQM = cms.Sequence(
     l1tdeStage2uGT +
     l1tStage2uGtEmul
 )
+
+_run3_l1tStage2EmulatorOnlineDQM = l1tStage2EmulatorOnlineDQM.copy()
+_run3_l1tStage2EmulatorOnlineDQM += l1tdeGEMTPG
+
+from Configuration.Eras.Modifier_run3_GEM_cff import run3_GEM
+run3_GEM.toReplaceWith( l1tStage2EmulatorOnlineDQM, _run3_l1tStage2EmulatorOnlineDQM )
 
 # sequence to run only for validation events
 l1tStage2EmulatorOnlineDQMValidationEvents = cms.Sequence(

--- a/DQM/L1TMonitor/python/L1TStage2Emulator_cff.py
+++ b/DQM/L1TMonitor/python/L1TStage2Emulator_cff.py
@@ -103,9 +103,7 @@ Stage2L1HardwareValidation = cms.Sequence(
 
 from Configuration.Eras.Modifier_run3_GEM_cff import run3_GEM
 _run3_Stage2L1HardwareValidation = Stage2L1HardwareValidation.copy()
-_run3_Stage2L1HardwareValidation += valMuonGEMPadDigis
-_run3_Stage2L1HardwareValidation += valMuonGEMPadDigiClusters
-run3_GEM.toReplaceWith( Stage2L1HardwareValidation, _run3_Stage2L1HardwareValidation )
+run3_GEM.toReplaceWith( Stage2L1HardwareValidation, cms.Sequence( valMuonGEMPadDigis + valMuonGEMPadDigiClusters + _run3_Stage2L1HardwareValidation) )
 
 Stage2L1HardwareValidationForValidationEvents = cms.Sequence(
     valCaloStage2Layer2Digis

--- a/DQM/L1TMonitor/python/L1TdeGEMTPG_cfi.py
+++ b/DQM/L1TMonitor/python/L1TdeGEMTPG_cfi.py
@@ -1,0 +1,16 @@
+import FWCore.ParameterSet.Config as cms
+
+from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
+l1tdeGEMTPG = DQMEDAnalyzer(
+    "L1TdeGEMTPG",
+    data = cms.InputTag("valMuonGEMPadDigiClusters"),
+    emul = cms.InputTag("valMuonGEMPadDigiClusters"),
+    monitorDir = cms.string("L1TEMU/L1TdeGEMTPG"),
+    verbose = cms.bool(False),
+    chambers = cms.vstring("GE11"),
+    dataEmul = cms.vstring("data","emul"),
+    clusterVars = cms.vstring("size", "pad", "bx"),
+    clusterNBin = cms.vuint32(20,384,10),
+    clusterMinBin = cms.vdouble(-0.5,-0.5,-4.5),
+    clusterMaxBin = cms.vdouble(19.5,383.5,5.5),
+)

--- a/DQM/L1TMonitor/python/L1TdeGEMTPG_cfi.py
+++ b/DQM/L1TMonitor/python/L1TdeGEMTPG_cfi.py
@@ -7,6 +7,7 @@ l1tdeGEMTPG = DQMEDAnalyzer(
     emul = cms.InputTag("valMuonGEMPadDigiClusters"),
     monitorDir = cms.string("L1TEMU/L1TdeGEMTPG"),
     verbose = cms.bool(False),
+    ## when multiple chambers are enabled, order them by station number!
     chambers = cms.vstring("GE11"),
     dataEmul = cms.vstring("data","emul"),
     clusterVars = cms.vstring("size", "pad", "bx"),

--- a/DQM/L1TMonitor/src/L1TdeGEMTPG.cc
+++ b/DQM/L1TMonitor/src/L1TdeGEMTPG.cc
@@ -1,0 +1,77 @@
+#include <string>
+
+#include "DQM/L1TMonitor/interface/L1TdeGEMTPG.h"
+
+L1TdeGEMTPG::L1TdeGEMTPG(const edm::ParameterSet& ps)
+    : data_token_(consumes<GEMPadDigiClusterCollection>(ps.getParameter<edm::InputTag>("data"))),
+      emul_token_(consumes<GEMPadDigiClusterCollection>(ps.getParameter<edm::InputTag>("emul"))),
+      monitorDir_(ps.getParameter<std::string>("monitorDir")),
+      verbose_(ps.getParameter<bool>("verbose")),
+
+      chambers_(ps.getParameter<std::vector<std::string>>("chambers")),
+      dataEmul_(ps.getParameter<std::vector<std::string>>("dataEmul")),
+
+      // variables
+      clusterVars_(ps.getParameter<std::vector<std::string>>("clusterVars")),
+
+      // binning
+      clusterNBin_(ps.getParameter<std::vector<unsigned>>("clusterNBin")),
+      clusterMinBin_(ps.getParameter<std::vector<double>>("clusterMinBin")),
+      clusterMaxBin_(ps.getParameter<std::vector<double>>("clusterMaxBin")) {}
+
+L1TdeGEMTPG::~L1TdeGEMTPG() {}
+
+void L1TdeGEMTPG::bookHistograms(DQMStore::IBooker& iBooker, const edm::Run&, const edm::EventSetup&) {
+  iBooker.setCurrentFolder(monitorDir_);
+
+  // chamber type
+  for (unsigned iType = 0; iType < chambers_.size(); iType++) {
+    // data vs emulator
+    for (unsigned iData = 0; iData < dataEmul_.size(); iData++) {
+      // cluster variable
+      for (unsigned iVar = 0; iVar < clusterVars_.size(); iVar++) {
+        const std::string key("cluster_" + clusterVars_[iVar] + "_" + dataEmul_[iData]);
+        const std::string histName(key + "_" + chambers_[iType]);
+        const std::string histTitle(chambers_[iType] + " Cluster " + clusterVars_[iVar] + " (" + dataEmul_[iData] +
+                                    ")");
+        chamberHistos[iType][key] =
+            iBooker.book1D(histName, histTitle, clusterNBin_[iVar], clusterMinBin_[iVar], clusterMaxBin_[iVar]);
+      }
+    }
+  }
+}
+
+void L1TdeGEMTPG::analyze(const edm::Event& e, const edm::EventSetup& c) {
+  if (verbose_)
+    edm::LogInfo("L1TdeGEMTPG") << "L1TdeGEMTPG: analyzing collections" << std::endl;
+
+  // handles
+  edm::Handle<GEMPadDigiClusterCollection> dataClusters;
+  edm::Handle<GEMPadDigiClusterCollection> emulClusters;
+  e.getByToken(data_token_, dataClusters);
+  e.getByToken(emul_token_, emulClusters);
+
+  for (auto it = dataClusters->begin(); it != dataClusters->end(); it++) {
+    auto range = dataClusters->get((*it).first);
+    const int type = ((*it).first).station();
+    for (auto cluster = range.first; cluster != range.second; cluster++) {
+      if (cluster->isValid()) {
+        chamberHistos[type]["cluster_size_data"]->Fill(cluster->pads().size());
+        chamberHistos[type]["cluster_pad_data"]->Fill(cluster->pads().front());
+        chamberHistos[type]["cluster_bx_data"]->Fill(cluster->bx());
+      }
+    }
+  }
+
+  for (auto it = emulClusters->begin(); it != emulClusters->end(); it++) {
+    auto range = emulClusters->get((*it).first);
+    const int type = ((*it).first).station();
+    for (auto cluster = range.first; cluster != range.second; cluster++) {
+      if (cluster->isValid()) {
+        chamberHistos[type]["cluster_size_emul"]->Fill(cluster->pads().size());
+        chamberHistos[type]["cluster_pad_emul"]->Fill(cluster->pads().front());
+        chamberHistos[type]["cluster_bx_emul"]->Fill(cluster->bx());
+      }
+    }
+  }
+}

--- a/DQM/L1TMonitor/src/L1TdeGEMTPG.cc
+++ b/DQM/L1TMonitor/src/L1TdeGEMTPG.cc
@@ -53,7 +53,7 @@ void L1TdeGEMTPG::analyze(const edm::Event& e, const edm::EventSetup& c) {
 
   for (auto it = dataClusters->begin(); it != dataClusters->end(); it++) {
     auto range = dataClusters->get((*it).first);
-    const int type = ((*it).first).station();
+    const int type = ((*it).first).station() - 1;
     for (auto cluster = range.first; cluster != range.second; cluster++) {
       if (cluster->isValid()) {
         chamberHistos[type]["cluster_size_data"]->Fill(cluster->pads().size());
@@ -65,7 +65,7 @@ void L1TdeGEMTPG::analyze(const edm::Event& e, const edm::EventSetup& c) {
 
   for (auto it = emulClusters->begin(); it != emulClusters->end(); it++) {
     auto range = emulClusters->get((*it).first);
-    const int type = ((*it).first).station();
+    const int type = ((*it).first).station() - 1;
     for (auto cluster = range.first; cluster != range.second; cluster++) {
       if (cluster->isValid()) {
         chamberHistos[type]["cluster_size_emul"]->Fill(cluster->pads().size());

--- a/DQM/L1TMonitorClient/interface/L1TdeGEMTPGClient.h
+++ b/DQM/L1TMonitorClient/interface/L1TdeGEMTPGClient.h
@@ -1,0 +1,46 @@
+#ifndef DQM_L1TMONITORCLIENT_L1TdeGEMTPGCLIENT_H
+#define DQM_L1TMONITORCLIENT_L1TdeGEMTPGCLIENT_H
+
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "DQMServices/Core/interface/DQMStore.h"
+#include "DQMServices/Core/interface/DQMEDHarvester.h"
+
+#include <string>
+
+class L1TdeGEMTPGClient : public DQMEDHarvester {
+public:
+  /// Constructor
+  L1TdeGEMTPGClient(const edm::ParameterSet &ps);
+
+  /// Destructor
+  ~L1TdeGEMTPGClient() override;
+
+protected:
+  void dqmEndLuminosityBlock(DQMStore::IBooker &,
+                             DQMStore::IGetter &,
+                             edm::LuminosityBlock const &,
+                             edm::EventSetup const &) override;
+  void dqmEndJob(DQMStore::IBooker &, DQMStore::IGetter &) override;
+
+private:
+  void book(DQMStore::IBooker &ibooker);
+  void processHistograms(DQMStore::IGetter &);
+
+  std::string monitorDir_;
+
+  std::vector<std::string> chambers_;
+
+  std::vector<std::string> clusterVars_;
+  std::vector<unsigned> clusterNBin_;
+  std::vector<double> clusterMinBin_;
+  std::vector<double> clusterMaxBin_;
+
+  // first key is the chamber number
+  // second key is the variable
+  std::map<uint32_t, std::map<std::string, MonitorElement *> > chamberHistos_;
+};
+
+#endif

--- a/DQM/L1TMonitorClient/python/L1TStage2EmulatorMonitorClient_cff.py
+++ b/DQM/L1TMonitorClient/python/L1TStage2EmulatorMonitorClient_cff.py
@@ -4,16 +4,16 @@ import FWCore.ParameterSet.Config as cms
 #
 # used by DQM GUI: DQM/Integration/python/test/l1t_dqm_sourceclient-*_cfg.py
 #
-# standard RawToDigi sequence must be run before the L1T module, labels 
+# standard RawToDigi sequence must be run before the L1T module, labels
 # from the standard sequence are used as default for the L1 DQM modules
 # any configuration change in the unpacking must be done in l1t_dqm_sourceclient-*_cfg.py
 #
 # see CVS for previous authors
 #
 # V.M. Ghete 2011-05-26 revised version of L1 Trigger client DQM
-#                       
+#
 
-# DQM quality tests 
+# DQM quality tests
 from DQM.L1TMonitorClient.L1TStage2EmulatorQualityTests_cff import *
 
 # Calo trigger layer2 client
@@ -31,33 +31,41 @@ from DQM.L1TMonitorClient.L1TStage2BMTFSecondEmulatorClient_cff import *
 # OMTF emulator client
 from DQM.L1TMonitorClient.L1TStage2OMTFEmulatorClient_cff import *
 
+# GEM TPG emulator client
+from DQM.L1TMonitorClient.L1TdeGEMTPGClient_cfi import *
+
 # EMTF emulator client
 from DQM.L1TMonitorClient.L1TStage2EMTFEmulatorClient_cff import *
 
-# L1 emulator event info DQM client 
+# L1 emulator event info DQM client
 from DQM.L1TMonitorClient.L1TStage2EmulatorEventInfoClient_cfi import *
 
 ## uGT emulator client
 from DQM.L1TMonitorClient.L1TStage2uGTEmulatorClient_cff import *
 
 #
-# define sequences 
+# define sequences
 #
 
 # L1T monitor client sequence (system clients and quality tests)
 l1TStage2EmulatorClients = cms.Sequence(
-		        l1tStage2CaloLayer2DEClientSummary
-                      + l1tStage2uGMTEmulatorClient
-                      + l1tStage2BMTFEmulatorClient
-                      + l1tStage2BMTFEmulatorSecondClient
-                      + l1tStage2OMTFEmulatorClient
-                      + l1tStage2EMTFEmulatorClient
-                      + l1tStage2EmulatorEventInfoClient
-                      + l1tStage2uGTEmulatorClient
-                        )
+    l1tStage2CaloLayer2DEClientSummary
+    + l1tStage2uGMTEmulatorClient
+    + l1tStage2BMTFEmulatorClient
+    + l1tStage2BMTFEmulatorSecondClient
+    + l1tStage2OMTFEmulatorClient
+    + l1tStage2EMTFEmulatorClient
+    + l1tStage2EmulatorEventInfoClient
+    + l1tStage2uGTEmulatorClient
+)
+
+_run3_l1TStage2EmulatorClients = l1TStage2EmulatorClients.copy()
+_run3_l1TStage2EmulatorClients += l1tdeGEMTPGClient
+
+from Configuration.Eras.Modifier_run3_GEM_cff import run3_GEM
+run3_GEM.toReplaceWith( l1TStage2EmulatorClients, _run3_l1TStage2EmulatorClients )
 
 l1tStage2EmulatorMonitorClient = cms.Sequence(
-                        l1TStage2EmulatorQualityTests +
-                        l1TStage2EmulatorClients
-                        )
-
+    l1TStage2EmulatorQualityTests +
+    l1TStage2EmulatorClients
+)

--- a/DQM/L1TMonitorClient/python/L1TdeGEMTPGClient_cfi.py
+++ b/DQM/L1TMonitorClient/python/L1TdeGEMTPGClient_cfi.py
@@ -1,0 +1,12 @@
+import FWCore.ParameterSet.Config as cms
+from DQMServices.Core.DQMEDHarvester import DQMEDHarvester
+
+l1tdeGEMTPGClient = DQMEDHarvester(
+    "L1TdeGEMTPGClient",
+    monitorDir = cms.string('L1TEMU/L1TdeGEMTPG'),
+    chambers = cms.vstring("GE11"),
+    clusterVars = cms.vstring("size", "pad", "bx"),
+    clusterNBin = cms.vuint32(20,384,10),
+    clusterMinBin = cms.vdouble(-0.5,-0.5,-4.5),
+    clusterMaxBin = cms.vdouble(19.5,383.5,5.5),
+)

--- a/DQM/L1TMonitorClient/src/L1TdeGEMTPGClient.cc
+++ b/DQM/L1TMonitorClient/src/L1TdeGEMTPGClient.cc
@@ -1,0 +1,82 @@
+#include "DQM/L1TMonitorClient/interface/L1TdeGEMTPGClient.h"
+
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "DQMServices/Core/interface/DQMStore.h"
+#include "TRandom.h"
+using namespace edm;
+using namespace std;
+
+L1TdeGEMTPGClient::L1TdeGEMTPGClient(const edm::ParameterSet &ps)
+    : monitorDir_(ps.getParameter<string>("monitorDir")),
+      chambers_(ps.getParameter<std::vector<std::string>>("chambers")),
+      // variables
+      clusterVars_(ps.getParameter<std::vector<std::string>>("clusterVars")),
+      // binning
+      clusterNBin_(ps.getParameter<std::vector<unsigned>>("clusterNBin")),
+      clusterMinBin_(ps.getParameter<std::vector<double>>("clusterMinBin")),
+      clusterMaxBin_(ps.getParameter<std::vector<double>>("clusterMaxBin")) {}
+
+L1TdeGEMTPGClient::~L1TdeGEMTPGClient() {}
+
+void L1TdeGEMTPGClient::dqmEndLuminosityBlock(DQMStore::IBooker &ibooker,
+                                              DQMStore::IGetter &igetter,
+                                              const edm::LuminosityBlock &lumiSeg,
+                                              const edm::EventSetup &c) {
+  book(ibooker);
+  processHistograms(igetter);
+}
+
+//--------------------------------------------------------
+void L1TdeGEMTPGClient::dqmEndJob(DQMStore::IBooker &ibooker, DQMStore::IGetter &igetter) {
+  book(ibooker);
+  processHistograms(igetter);
+}
+
+void L1TdeGEMTPGClient::book(DQMStore::IBooker &iBooker) {
+  iBooker.setCurrentFolder(monitorDir_);
+
+  // chamber type
+  for (unsigned iType = 0; iType < chambers_.size(); iType++) {
+    // cluster variable
+    for (unsigned iVar = 0; iVar < clusterVars_.size(); iVar++) {
+      const std::string key("cluster_" + clusterVars_[iVar] + "_diff");
+      const std::string histName(key + "_" + chambers_[iType]);
+      const std::string histTitle(chambers_[iType] + " Cluster " + clusterVars_[iVar] + " (Emul - Data)");
+      if (chamberHistos_[iType][key] == nullptr)
+        chamberHistos_[iType][key] =
+            iBooker.book1D(histName, histTitle, clusterNBin_[iVar], clusterMinBin_[iVar], clusterMaxBin_[iVar]);
+      else
+        chamberHistos_[iType][key]->Reset();
+    }
+  }
+}
+
+void L1TdeGEMTPGClient::processHistograms(DQMStore::IGetter &igetter) {
+  MonitorElement *dataMon;
+  MonitorElement *emulMon;
+
+  // chamber type
+  for (unsigned iType = 0; iType < chambers_.size(); iType++) {
+    // cluster variable
+    for (unsigned iVar = 0; iVar < clusterVars_.size(); iVar++) {
+      const std::string key("cluster_" + clusterVars_[iVar]);
+      const std::string histData(key + "_data_" + chambers_[iType]);
+      const std::string histEmul(key + "_emul_" + chambers_[iType]);
+
+      dataMon = igetter.get(monitorDir_ + "/" + histData);
+      emulMon = igetter.get(monitorDir_ + "/" + histEmul);
+
+      TH1F *hDiff = chamberHistos_[iType][key + "_diff"]->getTH1F();
+
+      if (dataMon && emulMon) {
+        TH1F *dataHist = dataMon->getTH1F();
+        TH1F *emulHist = emulMon->getTH1F();
+        hDiff->Add(emulHist, dataHist, 1, -1);
+      }
+    }
+  }
+}

--- a/DQM/L1TMonitorClient/src/SealModule.cc
+++ b/DQM/L1TMonitorClient/src/SealModule.cc
@@ -1,37 +1,40 @@
 #include "FWCore/Framework/interface/MakerMacros.h"
 
-#include <DQM/L1TMonitorClient/interface/L1TDTTFClient.h>
+#include "DQM/L1TMonitorClient/interface/L1TDTTFClient.h"
 DEFINE_FWK_MODULE(L1TDTTFClient);
 
-#include <DQM/L1TMonitorClient/interface/L1TDTTPGClient.h>
+#include "DQM/L1TMonitorClient/interface/L1TDTTPGClient.h"
 DEFINE_FWK_MODULE(L1TDTTPGClient);
 
 #include "DQM/L1TMonitorClient/interface/L1TRPCTFClient.h"
 DEFINE_FWK_MODULE(L1TRPCTFClient);
 
-#include <DQM/L1TMonitorClient/interface/L1TCSCTFClient.h>
+#include "DQM/L1TMonitorClient/interface/L1TdeGEMTPGClient.h"
+DEFINE_FWK_MODULE(L1TdeGEMTPGClient);
+
+#include "DQM/L1TMonitorClient/interface/L1TCSCTFClient.h"
 DEFINE_FWK_MODULE(L1TCSCTFClient);
 
-#include <DQM/L1TMonitorClient/interface/L1TGMTClient.h>
+#include "DQM/L1TMonitorClient/interface/L1TGMTClient.h"
 DEFINE_FWK_MODULE(L1TGMTClient);
 
-#include <DQM/L1TMonitorClient/interface/L1TGCTClient.h>
+#include "DQM/L1TMonitorClient/interface/L1TGCTClient.h"
 DEFINE_FWK_MODULE(L1TGCTClient);
 
-#include <DQM/L1TMonitorClient/interface/L1TEventInfoClient.h>
+#include "DQM/L1TMonitorClient/interface/L1TEventInfoClient.h"
 DEFINE_FWK_MODULE(L1TEventInfoClient);
 
-#include <DQM/L1TMonitorClient/interface/L1EmulatorErrorFlagClient.h>
+#include "DQM/L1TMonitorClient/interface/L1EmulatorErrorFlagClient.h"
 DEFINE_FWK_MODULE(L1EmulatorErrorFlagClient);
 
-#include <DQM/L1TMonitorClient/interface/L1TStage2CaloLayer2DEClient.h>
+#include "DQM/L1TMonitorClient/interface/L1TStage2CaloLayer2DEClient.h"
 DEFINE_FWK_MODULE(L1TStage2CaloLayer2DEClient);
 
-#include <DQM/L1TMonitorClient/interface/L1TStage2CaloLayer2DEClientSummary.h>
+#include "DQM/L1TMonitorClient/interface/L1TStage2CaloLayer2DEClientSummary.h"
 DEFINE_FWK_MODULE(L1TStage2CaloLayer2DEClientSummary);
 
-#include <DQM/L1TMonitorClient/interface/L1TStage2RatioClient.h>
+#include "DQM/L1TMonitorClient/interface/L1TStage2RatioClient.h"
 DEFINE_FWK_MODULE(L1TStage2RatioClient);
 
-#include <DQM/L1TMonitorClient/interface/L1TEMTFEventInfoClient.h>
+#include "DQM/L1TMonitorClient/interface/L1TEMTFEventInfoClient.h"
 DEFINE_FWK_MODULE(L1TEMTFEventInfoClient);


### PR DESCRIPTION
#### PR description:

With this PR we add data vs emulator comparison histograms for GEM trigger clusters. These are 1D histograms for each cluster property and "data-emulator" plots - which should be empty. 

At this point we do not yet have GEM clusters in the Run-3 RAW data. However, we anticipate GEM clusters to be there very soon through either the CSC unpacker, or the EMTF unpacker. At that point, I'll update the "data" inputTag to `muonCSCDigis` or `emtfStage2Digis`.

#### PR validation:

Code largely borrowed from #33085. Tested with WF 11634.0

```
11634.0_TTbar_14TeV+2021+TTbar_14TeV_TuneCP5_GenSim+Digi+Reco+HARVEST+ALCA Step0-PASSED Step1-PASSED Step2-PASSED Step3-PASSED Step4-PASSED  - time date Sat Mar 27 21:15:27 2021-date Sat Mar 27 20:43:58 2021; exit: 0 0 0 0 0
1 1 1 1 1 tests passed, 0 0 0 0 0 failed
```

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

No backport needed yet.

FYI @jshlee @akhter-towsifa