### PR TITLE
DTGeometryESProducer Update

### DIFF
--- a/Geometry/DTGeometryBuilder/plugins/dd4hep/DTGeometryESProducer.cc
+++ b/Geometry/DTGeometryBuilder/plugins/dd4hep/DTGeometryESProducer.cc
@@ -136,24 +136,18 @@ std::shared_ptr<DTGeometry> DTGeometryESProducer::produce(const MuonGeometryReco
   }
 
   if (m_applyAlignment) {
-    edm::ESHandle<Alignments> globalPosition;
-    record.getRecord<GlobalPositionRcd>().get(m_alignmentsLabel, globalPosition);
-    edm::ESHandle<Alignments> alignments;
-    record.getRecord<DTAlignmentRcd>().get(m_alignmentsLabel, alignments);
-    edm::ESHandle<AlignmentErrorsExtended> alignmentErrors;
-    record.getRecord<DTAlignmentErrorExtendedRcd>().get(m_alignmentsLabel, alignmentErrors);
+    const auto& globalPosition = record.get(m_globalPositionToken);
+    const auto& alignments = record.get(m_alignmentsToken);
+    const auto& alignmentErrors = record.get(m_alignmentErrorsToken);
 
-    if (alignments->empty() && alignmentErrors->empty() && globalPosition->empty()) {
+    if (alignments.empty() && alignmentErrors.empty() && globalPosition.empty()) {
       edm::LogInfo("Config") << "@SUB=DTGeometryRecord::produce"
-                             << "Alignment(Error)s and global position (label '" << m_alignmentsLabel
-                             << "') empty: Geometry producer (label "
-                             << "'" << m_myLabel << "') assumes fake and does not apply.";
+                             << "Alignment and global position errors";
+
     } else {
       GeometryAligner aligner;
-      aligner.applyAlignments<DTGeometry>(&(*host),
-                                          &(*alignments),
-                                          &(*alignmentErrors),
-                                          align::DetectorGlobalPosition(*globalPosition, DetId(DetId::Muon)));
+      aligner.applyAlignments<DTGeometry>(
+          &(*host), &alignments, &alignmentErrors, align::DetectorGlobalPosition(globalPosition, DetId(DetId::Muon)));
     }
   }
 


### PR DESCRIPTION
#### PR description:

This PR follows what @cvuosalo wrote in #31288 . In the DTGeometryESProducer Class getting products by labels has been disabled. The ESGetToken now is used. 

#### PR validation:

1) Validation by "runTheMatrix.py -l 25202.1"

25202.1_TTbar_13+TTbar_13+DIGIUP15APVSimu_PU25+RECOUP15_PU25+HARVESTUP15_PU25 Step0-PASSED Step1-PASSED Step2-PASSED Step3-PASSED  - time date Mon Mar 29 09:11:53 2021-date Mon Mar 29 08:52:09 2021; exit: 0 0 0 0 1 1 1 1 tests passed, 0 0 0 0 failed

2) Validation by "cmsRun CondTools/Geometry/test/dtgeometrywriter.py" (DD & DD4Hep)

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

nothing special
