### PR TITLE
[HGCAL] TICL iteration data member for tracksters

### DIFF
--- a/DataFormats/HGCalReco/interface/Trackster.h
+++ b/DataFormats/HGCalReco/interface/Trackster.h
@@ -20,7 +20,7 @@ namespace ticl {
   public:
     typedef math::XYZVector Vector;
 
-    enum iterationIndex { TRKEM = 0, EM, TRKHAD, HAD, MIP };
+    enum IterationIndex { TRKEM = 0, EM, TRKHAD, HAD, MIP };
 
     // types considered by the particle identification
     enum class ParticleType {
@@ -52,7 +52,7 @@ namespace ticl {
       zeroProbabilities();
     }
 
-    inline void setIteration(const Trackster::iterationIndex i) { iterationIndex_ = i; }
+    inline void setIteration(const Trackster::IterationIndex i) { iterationIndex_ = i; }
     std::vector<unsigned int> &vertices() { return vertices_; }
     std::vector<uint8_t> &vertex_multiplicity() { return vertex_multiplicity_; }
     std::vector<std::array<unsigned int, 2> > &edges() { return edges_; }
@@ -116,7 +116,7 @@ namespace ticl {
     }
     inline void setIdProbability(ParticleType type, float value) { id_probabilities_[int(type)] = 1.f; }
 
-    inline const Trackster::iterationIndex ticlIteration() const { return (iterationIndex)iterationIndex_; }
+    inline const Trackster::IterationIndex ticlIteration() const { return (IterationIndex)iterationIndex_; }
     inline const std::vector<unsigned int> &vertices() const { return vertices_; }
     inline const unsigned int vertices(int index) const { return vertices_[index]; }
     inline const std::vector<uint8_t> &vertex_multiplicity() const { return vertex_multiplicity_; }

--- a/DataFormats/HGCalReco/interface/Trackster.h
+++ b/DataFormats/HGCalReco/interface/Trackster.h
@@ -20,6 +20,8 @@ namespace ticl {
   public:
     typedef math::XYZVector Vector;
 
+    enum iterationIndex { TRKEM = 0, EM, TRKHAD, HAD, MIP };
+
     // types considered by the particle identification
     enum class ParticleType {
       photon = 0,
@@ -50,6 +52,7 @@ namespace ticl {
       zeroProbabilities();
     }
 
+    inline void setIteration(const Trackster::iterationIndex i) { iterationIndex_ = i; }
     std::vector<unsigned int> &vertices() { return vertices_; }
     std::vector<uint8_t> &vertex_multiplicity() { return vertex_multiplicity_; }
     std::vector<std::array<unsigned int, 2> > &edges() { return edges_; }
@@ -113,6 +116,7 @@ namespace ticl {
     }
     inline void setIdProbability(ParticleType type, float value) { id_probabilities_[int(type)] = 1.f; }
 
+    inline const Trackster::iterationIndex ticlIteration() const { return (iterationIndex)iterationIndex_; }
     inline const std::vector<unsigned int> &vertices() const { return vertices_; }
     inline const unsigned int vertices(int index) const { return vertices_[index]; }
     inline const std::vector<uint8_t> &vertex_multiplicity() const { return vertex_multiplicity_; }
@@ -143,6 +147,9 @@ namespace ticl {
     }
 
   private:
+    // TICL iteration producing the trackster
+    uint8_t iterationIndex_;
+
     // The vertices of the DAG are the indices of the
     // 2d objects in the global collection
     std::vector<unsigned int> vertices_;

--- a/DataFormats/HGCalReco/src/classes_def.xml
+++ b/DataFormats/HGCalReco/src/classes_def.xml
@@ -1,8 +1,7 @@
 
 <lcgdict>
-  <class name="ticl::Trackster" ClassVersion="9">
-    <version ClassVersion="9" checksum="749412802"/>
-    <version ClassVersion="8" checksum="1933596720"/>
+  <class name="ticl::Trackster" ClassVersion="8">
+    <version ClassVersion="8" checksum="749412802"/>
     <version ClassVersion="7" checksum="1072014319"/>
     <version ClassVersion="6" checksum="3003722924"/>
     <version ClassVersion="5" checksum="1679804166"/>

--- a/DataFormats/HGCalReco/src/classes_def.xml
+++ b/DataFormats/HGCalReco/src/classes_def.xml
@@ -1,6 +1,7 @@
 
 <lcgdict>
-  <class name="ticl::Trackster" ClassVersion="8">
+  <class name="ticl::Trackster" ClassVersion="9">
+    <version ClassVersion="9" checksum="749412802"/>
     <version ClassVersion="8" checksum="1933596720"/>
     <version ClassVersion="7" checksum="1072014319"/>
     <version ClassVersion="6" checksum="3003722924"/>

--- a/DataFormats/HGCalReco/src/classes_def.xml
+++ b/DataFormats/HGCalReco/src/classes_def.xml
@@ -1,6 +1,7 @@
 
 <lcgdict>
-  <class name="ticl::Trackster" ClassVersion="7">
+  <class name="ticl::Trackster" ClassVersion="8">
+    <version ClassVersion="8" checksum="1933596720"/>
     <version ClassVersion="7" checksum="1072014319"/>
     <version ClassVersion="6" checksum="3003722924"/>
     <version ClassVersion="5" checksum="1679804166"/>

--- a/RecoHGCal/TICL/plugins/TrackstersMergeProducer.cc
+++ b/RecoHGCal/TICL/plugins/TrackstersMergeProducer.cc
@@ -32,9 +32,9 @@ public:
   static void globalEndJob(TrackstersCache *);
 
 private:
-  typedef ticl::Trackster::iterationIndex TracksterIterIndex;
+  typedef ticl::Trackster::IterationIndex TracksterIterIndex;
 
-  void fillTile(TICLTracksterTiles &, const std::vector<Trackster> &);
+  void fillTile(TICLTracksterTiles &, const std::vector<Trackster> &, TracksterIterIndex);
 
   void energyRegressionAndID(const std::vector<reco::CaloCluster> &layerClusters, std::vector<Trackster> &result) const;
   void printTrackstersDebug(const std::vector<Trackster> &, const char *label) const;
@@ -129,14 +129,16 @@ TrackstersMergeProducer::TrackstersMergeProducer(const edm::ParameterSet &ps, co
   produces<std::vector<TICLCandidate>>();
 }
 
-void TrackstersMergeProducer::fillTile(TICLTracksterTiles &tracksterTile, const std::vector<Trackster> &tracksters) {
+void TrackstersMergeProducer::fillTile(TICLTracksterTiles &tracksterTile,
+                                       const std::vector<Trackster> &tracksters,
+                                       TracksterIterIndex tracksterIteration) {
   int tracksterId = 0;
   for (auto const &t : tracksters) {
-    tracksterTile.fill(t.ticlIteration(), t.barycenter().eta(), t.barycenter().phi(), tracksterId);
+    tracksterTile.fill(tracksterIteration, t.barycenter().eta(), t.barycenter().phi(), tracksterId);
     LogDebug("TrackstersMergeProducer") << "Adding tracksterId: " << tracksterId << " into bin [eta,phi]: [ "
-                                        << tracksterTile[t.ticlIteration()].etaBin(t.barycenter().eta()) << ", "
-                                        << tracksterTile[t.ticlIteration()].phiBin(t.barycenter().phi())
-                                        << "] for iteration: " << t.ticlIteration() << std::endl;
+                                        << tracksterTile[tracksterIteration].etaBin(t.barycenter().eta()) << ", "
+                                        << tracksterTile[tracksterIteration].phiBin(t.barycenter().phi())
+                                        << "] for iteration: " << tracksterIteration << std::endl;
 
     tracksterId++;
   }
@@ -213,10 +215,10 @@ void TrackstersMergeProducer::produce(edm::Event &evt, const edm::EventSetup &es
   const auto &seedingTrk = *seedingTrk_h;
   usedSeeds.resize(tracks.size(), false);
 
-  fillTile(tracksterTile, trackstersTRKEM);
-  fillTile(tracksterTile, trackstersEM);
-  fillTile(tracksterTile, trackstersTRK);
-  fillTile(tracksterTile, trackstersHAD);
+  fillTile(tracksterTile, trackstersTRKEM, TracksterIterIndex::TRKEM);
+  fillTile(tracksterTile, trackstersEM, TracksterIterIndex::EM);
+  fillTile(tracksterTile, trackstersTRK, TracksterIterIndex::TRKHAD);
+  fillTile(tracksterTile, trackstersHAD, TracksterIterIndex::HAD);
 
   auto totalNumberOfTracksters =
       trackstersTRKEM.size() + trackstersTRK.size() + trackstersEM.size() + trackstersHAD.size();

--- a/RecoHGCal/TICL/plugins/TrackstersMergeProducer.cc
+++ b/RecoHGCal/TICL/plugins/TrackstersMergeProducer.cc
@@ -129,8 +129,7 @@ TrackstersMergeProducer::TrackstersMergeProducer(const edm::ParameterSet &ps, co
   produces<std::vector<TICLCandidate>>();
 }
 
-void TrackstersMergeProducer::fillTile(TICLTracksterTiles &tracksterTile,
-                                       const std::vector<Trackster> &tracksters) {
+void TrackstersMergeProducer::fillTile(TICLTracksterTiles &tracksterTile, const std::vector<Trackster> &tracksters) {
   int tracksterId = 0;
   for (auto const &t : tracksters) {
     tracksterTile.fill(t.ticlIteration(), t.barycenter().eta(), t.barycenter().phi(), tracksterId);

--- a/RecoHGCal/TICL/plugins/TrackstersProducer.cc
+++ b/RecoHGCal/TICL/plugins/TrackstersProducer.cc
@@ -179,8 +179,19 @@ void TrackstersProducer::produce(edm::Event& evt, const edm::EventSetup& es) {
   std::copy(
       std::begin(original_layerclusters_mask), std::end(original_layerclusters_mask), std::back_inserter(*output_mask));
 
-  // Mask the used elements, accordingly
-  for (auto const& trackster : *result) {
+  for (auto& trackster : *result) {
+    if (itername_ == "TrkEM")
+      trackster.setIteration(ticl::Trackster::TRKEM);
+    else if (itername_ == "EM")
+      trackster.setIteration(ticl::Trackster::EM);
+    else if (itername_ == "TRK")
+      trackster.setIteration(ticl::Trackster::TRKHAD);
+    else if (itername_ == "HADRONIC")
+      trackster.setIteration(ticl::Trackster::HAD);
+    else if (itername_ == "MIP")
+      trackster.setIteration(ticl::Trackster::MIP);
+
+    // Mask the used elements, accordingly
     for (auto const v : trackster.vertices()) {
       // TODO(rovere): for the moment we mask the layer cluster completely. In
       // the future, properly compute the fraction of usage.

--- a/RecoHGCal/TICL/plugins/TrackstersProducer.cc
+++ b/RecoHGCal/TICL/plugins/TrackstersProducer.cc
@@ -55,6 +55,7 @@ private:
   edm::EDGetTokenT<TICLLayerTilesHFNose> layer_clusters_tiles_hfnose_token_;
   const edm::EDGetTokenT<std::vector<TICLSeedingRegion>> seeding_regions_token_;
   const std::string itername_;
+  ticl::Trackster::IterationIndex iterIndex_;
 };
 DEFINE_FWK_MODULE(TrackstersProducer);
 
@@ -96,6 +97,18 @@ TrackstersProducer::TrackstersProducer(const edm::ParameterSet& ps, const Tracks
   } else {
     layer_clusters_tiles_token_ = consumes<TICLLayerTiles>(ps.getParameter<edm::InputTag>("layer_clusters_tiles"));
   }
+
+  if (itername_ == "TrkEM")
+    iterIndex_ = ticl::Trackster::TRKEM;
+  else if (itername_ == "EM")
+    iterIndex_ = ticl::Trackster::EM;
+  else if (itername_ == "TRK")
+    iterIndex_ = ticl::Trackster::TRKHAD;
+  else if (itername_ == "HADRONIC")
+    iterIndex_ = ticl::Trackster::HAD;
+  else if (itername_ == "MIP")
+    iterIndex_ = ticl::Trackster::MIP;
+
   produces<std::vector<Trackster>>();
   produces<std::vector<float>>();  // Mask to be applied at the next iteration
 }
@@ -180,17 +193,7 @@ void TrackstersProducer::produce(edm::Event& evt, const edm::EventSetup& es) {
       std::begin(original_layerclusters_mask), std::end(original_layerclusters_mask), std::back_inserter(*output_mask));
 
   for (auto& trackster : *result) {
-    if (itername_ == "TrkEM")
-      trackster.setIteration(ticl::Trackster::TRKEM);
-    else if (itername_ == "EM")
-      trackster.setIteration(ticl::Trackster::EM);
-    else if (itername_ == "TRK")
-      trackster.setIteration(ticl::Trackster::TRKHAD);
-    else if (itername_ == "HADRONIC")
-      trackster.setIteration(ticl::Trackster::HAD);
-    else if (itername_ == "MIP")
-      trackster.setIteration(ticl::Trackster::MIP);
-
+    trackster.setIteration(iterIndex_);
     // Mask the used elements, accordingly
     for (auto const v : trackster.vertices()) {
       // TODO(rovere): for the moment we mask the layer cluster completely. In


### PR DESCRIPTION
#### PR description:

This PR adds a data member to the Trackster to store the index of the TICL iteration that produces it. 
No changes are expected in the output. 

#### PR validation:

`runTheMatrix -l limited`