### PR TITLE
MTD validation: fix range of pull profiles

### DIFF
--- a/Validation/MtdValidation/plugins/BtlLocalRecoValidation.cc
+++ b/Validation/MtdValidation/plugins/BtlLocalRecoValidation.cc
@@ -335,16 +335,16 @@ void BtlLocalRecoValidation::bookHistograms(DQMStore::IBooker& ibook,
   meLongPosPull_ = ibook.book1D("BtlLongPosPull",
                                 "BTL longitudinal position pull;X^{loc}_{RECO}-X^{loc}_{SIM}/#sigma_{xloc_{RECO}}",
                                 100,
-                                -5.5,
-                                5.5);
+                                -5.,
+                                5.);
   meLongPosPullvsE_ = ibook.bookProfile(
       "BtlLongposPullvsE",
       "BTL longitudinal position pull vs E;E_{SIM} [MeV];X^{loc}_{RECO}-X^{loc}_{SIM}/#sigma_{xloc_{RECO}}",
       20,
       0.,
       20.,
-      -1.5,
-      1.5,
+      -5.,
+      5.,
       "S");
   meLongPosPullvsEta_ = ibook.bookProfile(
       "BtlLongposPullvsEta",
@@ -352,18 +352,18 @@ void BtlLocalRecoValidation::bookHistograms(DQMStore::IBooker& ibook,
       32,
       0,
       1.55,
-      -1.5,
-      1.5,
+      -5.,
+      5.,
       "S");
   meTPullvsE_ = ibook.bookProfile(
-      "BtlTPullvsE", "BTL time pull vs E;E_{SIM} [MeV];T_{RECO}-T_{SIM}/#sigma_{T_{RECO}}", 20, 0., 20., -0.8, 0.8, "S");
+      "BtlTPullvsE", "BTL time pull vs E;E_{SIM} [MeV];T_{RECO}-T_{SIM}/#sigma_{T_{RECO}}", 20, 0., 20., -5., 5., "S");
   meTPullvsEta_ = ibook.bookProfile("BtlTPullvsEta",
                                     "BTL time pull vs #eta;|#eta_{RECO}|;T_{RECO}-T_{SIM}/#sigma_{T_{RECO}}",
                                     32,
                                     0,
                                     1.55,
-                                    -0.8,
-                                    0.8,
+                                    -5.,
+                                    5.,
                                     "S");
   meCluTime_ = ibook.book1D("BtlCluTime", "BTL cluster time ToA;ToA [ns]", 250, 0, 25);
   meCluTimeError_ = ibook.book1D("BtlCluTimeError", "BTL cluster time error;#sigma_{t} [ns]", 100, 0, 0.1);

--- a/Validation/MtdValidation/plugins/EtlLocalRecoValidation.cc
+++ b/Validation/MtdValidation/plugins/EtlLocalRecoValidation.cc
@@ -642,14 +642,14 @@ void EtlLocalRecoValidation::bookHistograms(DQMStore::IBooker& ibook,
                                       0.,
                                       100.);
   meTPullvsE_ = ibook.bookProfile(
-      "EtlTPullvsE", "ETL time pull vs E;E_{SIM} [MeV];T_{RECO}-T_{SIM}/#sigma_{T_{RECO}}", 20, 0., 2., -0.8, 0.8, "S");
+      "EtlTPullvsE", "ETL time pull vs E;E_{SIM} [MeV];T_{RECO}-T_{SIM}/#sigma_{T_{RECO}}", 20, 0., 2., -5., 5., "S");
   meTPullvsEta_ = ibook.bookProfile("EtlTPullvsEta",
                                     "ETL time pull vs #eta;|#eta_{RECO}|;T_{RECO}-T_{SIM}/#sigma_{T_{RECO}}",
                                     26,
                                     1.65,
                                     3.0,
-                                    -0.8,
-                                    0.8,
+                                    -5.,
+                                    5.,
                                     "S");
   meCluTime_[0] =
       ibook.book1D("EtlCluTimeZnegD1", "ETL cluster ToA (-Z, Single(topo1D)/First(topo2D) Disk);ToA [ns]", 250, 0, 25);


### PR DESCRIPTION
#### PR description:

Minor adjustment of y ranges for TProfiles of pulls of various properties of BTL/ETL reconstructed hits, needed to avoid an artificial truncation.

#### PR validation:

The code runs on top of #33252 in wf 34634.0 and produces pulls of witdth ~1 when running on top of #33223 , and consistent values when running on top of current default uncertainties.