### PR TITLE
One more fix on the indexing of VFATs in GEM onlineDQM, a backport to CMSSW_11_2_X

### DIFF
--- a/DQM/GEM/plugins/GEMDAQStatusSource.cc
+++ b/DQM/GEM/plugins/GEMDAQStatusSource.cc
@@ -394,8 +394,8 @@ void GEMDAQStatusSource::analyze(edm::Event const &event, edm::EventSetup const 
       }
 
       Int_t nIdxVFAT = getVFATNumber(gid.station(), gid.roll(), vfatStat->phi());
-      mapStatusVFAT_.FillBits(key3, nIdxVFAT, unQFVFAT);
-      mapStatusVFATPerCh_.FillBits(key4Ch, nIdxVFAT, unQFVFAT);
+      mapStatusVFAT_.FillBits(key3, nIdxVFAT + 1, unQFVFAT);
+      mapStatusVFATPerCh_.FillBits(key4Ch, nIdxVFAT + 1, unQFVFAT);
     }
   }
 

--- a/DQM/GEM/plugins/GEMDigiSource.cc
+++ b/DQM/GEM/plugins/GEMDigiSource.cc
@@ -187,7 +187,7 @@ void GEMDigiSource::analyze(edm::Event const& event, edm::EventSetup const& even
       for (auto d = digis_in_det.first; d != digis_in_det.second; ++d) {
         // Filling of digi occupancy
         Int_t nIdxVFAT = getVFATNumberByStrip(gid.station(), rId.roll(), d->strip());
-        mapTotalDigi_layer_.Fill(key3, gid.chamber(), nIdxVFAT);
+        mapTotalDigi_layer_.Fill(key3, gid.chamber(), nIdxVFAT + 1);
 
         // Filling of strip
         mapStripOcc_ieta_.Fill(key3, rId.roll());  // Roll


### PR DESCRIPTION
#### PR description:
We modified the structure of GEM onlineDQM in the last time (#32791, #32792), and this is a fix for an issue on the indexing of VFATs, as like #33193. No fix on DQM GUI is necessary for this.

This is a backport of #33295 to CMSSW_11_2_X.

#### PR validation:
Test are done and one can check again by `runTheMatrix` workflows