### PR TITLE
Fix to prevent propagation of heavy neutrino from Geant4

### DIFF
--- a/SimG4Core/Generators/src/Generator.cc
+++ b/SimG4Core/Generators/src/Generator.cc
@@ -164,7 +164,7 @@ void Generator::HepMC2G4(const HepMC::GenEvent *evt_orig, G4Event *g4evt) {
         // be propagated by GEANT, so do not change their status code.
         status = 2;
       }
-      if (status == 2 && abs(pdg)==9900015){
+      if (status == 2 && abs(pdg) == 9900015) {
         status = 3;
       }
 
@@ -248,7 +248,7 @@ void Generator::HepMC2G4(const HepMC::GenEvent *evt_orig, G4Event *g4evt) {
       if (status > 3 && isExotic(pdg) && (!(isExoticNonDetectable(pdg)))) {
         status = hasDecayVertex ? 2 : 1;
       }
-      if (status == 2 && abs(pdg)==9900015){
+      if (status == 2 && abs(pdg) == 9900015) {
         status = 3;
       }
 

--- a/SimG4Core/Generators/src/Generator.cc
+++ b/SimG4Core/Generators/src/Generator.cc
@@ -152,7 +152,8 @@ void Generator::HepMC2G4(const HepMC::GenEvent *evt_orig, G4Event *g4evt) {
     for (pitr = (*vitr)->particles_begin(HepMC::children); pitr != (*vitr)->particles_end(HepMC::children); ++pitr) {
       // For purposes of this function, the status is defined as follows:
       // 1:  particles are not decayed by generator
-      // 2:  particles are decayed by generator but need to be propagated by
+      // 2:  particles are decayed by generator but need to be propagated by GEANT
+      // 3:  particles are decayed by generator and do not need to be propagated by GEANT
       int status = (*pitr)->status();
       int pdg = (*pitr)->pdg_id();
       if (status > 3 && isExotic(pdg) && (!(isExoticNonDetectable(pdg)))) {
@@ -162,6 +163,9 @@ void Generator::HepMC2G4(const HepMC::GenEvent *evt_orig, G4Event *g4evt) {
         // propagated by GEANT. Some Standard Model particles, e.g., K0, cannot
         // be propagated by GEANT, so do not change their status code.
         status = 2;
+      }
+      if (status == 2 && abs(pdg)==9900015){
+        status = 3;
       }
 
       // Particles which are not decayed by generator
@@ -243,6 +247,9 @@ void Generator::HepMC2G4(const HepMC::GenEvent *evt_orig, G4Event *g4evt) {
       }
       if (status > 3 && isExotic(pdg) && (!(isExoticNonDetectable(pdg)))) {
         status = hasDecayVertex ? 2 : 1;
+      }
+      if (status == 2 && abs(pdg)==9900015){
+        status = 3;
       }
 
       // this particle has predefined decay but has no vertex


### PR DESCRIPTION
#### PR description:

This PR implements a minor change in order to **prevent Geant4** from performing the **propagation of a heavy neutrino** (pdg=9900015) with status 2 outside of the beam pipe.
Heavy neutrinos of status 2 are the result of the event generation by Pythia+EvtGen, where EvtGen handles the decay of the heavy neutrino.

Additional information documenting the need for this fix can be found in the [hypernews thread](https://hypernews.cern.ch/HyperNews/CMS/get/simDevelopment/1956.html)

This is meant to be used for an MC production using the b-parking conditions, so a backport to 10_2_X will be submitted too, once this PR is merged.

#### PR validation:

Followed the instructions here:
http://cms-sw.github.io/PRWorkflow.html

The report of `runTheMatrix.py -l limited -i all --ibeos` is attached:
[runTheMatrix_short.log](https://github.com/cms-sw/cmssw/files/6229962/runTheMatrix_short.log)

Code checks have been performed and included as a separate commit.
