### PR TITLE
Migrate module configurations in {JetMETCorrections,PhysicsTools} to use automatically generated cfi default/reference configurations

### DIFF
--- a/JetMETCorrections/Type1MET/python/cleanJetFromEEnoise_cfi.py
+++ b/JetMETCorrections/Type1MET/python/cleanJetFromEEnoise_cfi.py
@@ -26,9 +26,10 @@ pfcandidateClustered = cms.EDProducer(
     )
 )
 
-pfcandidateForUnclusteredUnc = cms.EDProducer("CandPtrProjector",
-    src  = cms.InputTag("packedPFCandidates"),
-    veto = cms.InputTag("pfcandidateClustered"),
+import CommonTools.CandAlgos.candPtrProjector_cfi as _mod
+pfcandidateForUnclusteredUnc = _mod.candPtrProjector.clone(
+    src  = "packedPFCandidates",
+    veto = "pfcandidateClustered",
 )
 
 

--- a/PhysicsTools/PatAlgos/python/patMuonMerger_cfi.py
+++ b/PhysicsTools/PatAlgos/python/patMuonMerger_cfi.py
@@ -1,10 +1,10 @@
 import FWCore.ParameterSet.Config as cms
-
-mergedMuons = cms.EDProducer("PATMuonMerger",
-                             muons     = cms.InputTag("slimmedMuons"), 
-                             pfCandidates=cms.InputTag("packedPFCandidates"),
-                             otherTracks = cms.InputTag("lostTracks"),
-                             muonCut = cms.string("pt>15 && abs(eta)<2.4"),
-                             pfCandidatesCut = cms.string("pt>15 && abs(eta)<2.4"),
-                             lostTrackCut = cms.string("pt>15 && abs(eta)<2.4")
+import PhysicsTools.PatAlgos.mergedMuonsNoCuts_cfi as _mod
+mergedMuons = _mod.mergedMuonsNoCuts.clone(
+                             muons           = "slimmedMuons", 
+                             pfCandidates    = "packedPFCandidates",
+                             otherTracks     = "lostTracks",
+                             muonCut         = "pt>15 && abs(eta)<2.4",
+                             pfCandidatesCut = "pt>15 && abs(eta)<2.4",
+                             lostTrackCut    = "pt>15 && abs(eta)<2.4"
                          )

--- a/PhysicsTools/PatAlgos/python/patMuonMerger_cfi.py
+++ b/PhysicsTools/PatAlgos/python/patMuonMerger_cfi.py
@@ -1,9 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 import PhysicsTools.PatAlgos.mergedMuonsNoCuts_cfi as _mod
 mergedMuons = _mod.mergedMuonsNoCuts.clone(
-                             muons           = "slimmedMuons", 
-                             pfCandidates    = "packedPFCandidates",
-                             otherTracks     = "lostTracks",
                              muonCut         = "pt>15 && abs(eta)<2.4",
                              pfCandidatesCut = "pt>15 && abs(eta)<2.4",
                              lostTrackCut    = "pt>15 && abs(eta)<2.4"

--- a/PhysicsTools/PatUtils/python/tools/muonRecoMitigation.py
+++ b/PhysicsTools/PatUtils/python/tools/muonRecoMitigation.py
@@ -62,11 +62,13 @@ def muonRecoMitigation(process,
     
     # now cleaning ================================
     cleanedPFCandCollection=cleanCollName+postfix
+
     if runOnMiniAOD:
-        cleanedPFCandProducer = cms.EDProducer("CandPtrProjector", 
-                                               src = cms.InputTag(pfCandCollection),
-                                               veto = cms.InputTag(badMuonCollection)
-                                               )
+        import CommonTools.CandAlgos.candPtrProjector_cfi as _mod
+        cleanedPFCandProducer = _mod.candPtrProjector.clone(
+                                               src  = pfCandCollection,
+                                               veto = badMuonCollection
+                                         )
     else:
         cleanedPFCandProducer = cms.EDProducer("PFCandPtrProjector", 
                                                src = cms.InputTag(pfCandCollection),

--- a/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
+++ b/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
@@ -5,6 +5,7 @@ from PhysicsTools.PatAlgos.tools.ConfigToolBase import *
 import PhysicsTools.PatAlgos.tools.helpers as configtools
 from PhysicsTools.PatAlgos.tools.helpers import getPatAlgosToolsTask, addToProcessAndTask
 from PhysicsTools.PatAlgos.tools.jetTools import switchJetCollection
+import CommonTools.CandAlgos.candPtrProjector_cfi as _mod
 
 
 def isValidInputTag(input):
@@ -833,17 +834,17 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
         if not hasattr(process, "pfCandsForUnclusteredUnc"+postfix):
 
             #Jet projection ==
-            pfCandsNoJets = cms.EDProducer("CandPtrProjector",
+            pfCandsNoJets = _mod.candPtrProjector.clone( 
                                            src = pfCandCollection,
-                                           veto = copy.copy(jetCollection),
+                                           veto = jetCollection,
                                            )
             addToProcessAndTask("pfCandsNoJets"+postfix, pfCandsNoJets, process, task)
             metUncSequence += getattr(process, "pfCandsNoJets"+postfix)
 
             #electron projection ==
-            pfCandsNoJetsNoEle = cms.EDProducer("CandPtrProjector",
-                                                src = cms.InputTag("pfCandsNoJets"+postfix),
-                                                veto = copy.copy(electronCollection),
+            pfCandsNoJetsNoEle = _mod.candPtrProjector.clone(
+                                                src = "pfCandsNoJets"+postfix,
+                                                veto = electronCollection,
                                                 )
             if not self.getvalue("onMiniAOD"):
               pfCandsNoJetsNoEle.veto = "pfeGammaToCandidate:electrons"
@@ -851,25 +852,25 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
             metUncSequence += getattr(process, "pfCandsNoJetsNoEle"+postfix)
 
             #muon projection ==
-            pfCandsNoJetsNoEleNoMu = cms.EDProducer("CandPtrProjector",
-                                              src = cms.InputTag("pfCandsNoJetsNoEle"+postfix),
-                                              veto = copy.copy(muonCollection),
+            pfCandsNoJetsNoEleNoMu = _mod.candPtrProjector.clone(
+                                              src = "pfCandsNoJetsNoEle"+postfix,
+                                              veto = muonCollection,
                                               )
             addToProcessAndTask("pfCandsNoJetsNoEleNoMu"+postfix, pfCandsNoJetsNoEleNoMu, process, task)
             metUncSequence += getattr(process, "pfCandsNoJetsNoEleNoMu"+postfix)
 
             #tau projection ==
-            pfCandsNoJetsNoEleNoMuNoTau = cms.EDProducer("CandPtrProjector",
-                                              src = cms.InputTag("pfCandsNoJetsNoEleNoMu"+postfix),
-                                              veto = copy.copy(tauCollection),
+            pfCandsNoJetsNoEleNoMuNoTau = _mod.candPtrProjector.clone(
+                                              src = "pfCandsNoJetsNoEleNoMu"+postfix,
+                                              veto = tauCollection,
                                               )
             addToProcessAndTask("pfCandsNoJetsNoEleNoMuNoTau"+postfix, pfCandsNoJetsNoEleNoMuNoTau, process, task)
             metUncSequence += getattr(process, "pfCandsNoJetsNoEleNoMuNoTau"+postfix)
 
             #photon projection ==
-            pfCandsForUnclusteredUnc = cms.EDProducer("CandPtrProjector",
-                                              src = cms.InputTag("pfCandsNoJetsNoEleNoMuNoTau"+postfix),
-                                              veto = copy.copy(photonCollection),
+            pfCandsForUnclusteredUnc = _mod.candPtrProjector.clone(
+                                              src = "pfCandsNoJetsNoEleNoMuNoTau"+postfix,
+                                              veto = photonCollection,
                                               )
             if not self.getvalue("onMiniAOD"):
               pfCandsForUnclusteredUnc.veto = "pfeGammaToCandidate:photons"
@@ -1350,9 +1351,9 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
         pfCandCollection = self._parameters["pfCandCollection"].value
 
         #top projection on jets
-        pfCandsNotInJets = cms.EDProducer("CandPtrProjector",
+        pfCandsNotInJets = _mod.candPtrProjector.clone(
                                           src = pfCandCollection,
-                                          veto = cms.InputTag("ak4PFJets")
+                                          veto = "ak4PFJets"
                                           )
         setattr(process, "pfCandsNotInJetsUnclusteredEn"+var+postfix, pfCandsNotInJets)
         metUncSequence += getattr(process,"pfCandsNotInJetsUnclusteredEn"+var+postfix)
@@ -1922,9 +1923,9 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
         )
         addToProcessAndTask("pfcandidateClustered"+postfix, pfcandidateClustered, process, task)
         patMetModuleSequence += getattr(process,"pfcandidateClustered"+postfix)
-        pfcandidateForUnclusteredUnc = cms.EDProducer("CandPtrProjector",
+        pfcandidateForUnclusteredUnc = _mod.candPtrProjector.clone(
             src  = cands,
-            veto = cms.InputTag("pfcandidateClustered"+postfix),
+            veto = "pfcandidateClustered"+postfix,
         )
         addToProcessAndTask("pfcandidateForUnclusteredUnc"+postfix, pfcandidateForUnclusteredUnc, process, task)
         patMetModuleSequence += getattr(process,"pfcandidateForUnclusteredUnc"+postfix)
@@ -1947,9 +1948,9 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
         )
         addToProcessAndTask("superbad"+postfix, superbad, process, task)
         patMetModuleSequence += getattr(process,"superbad"+postfix)
-        pfCandidatesGoodEE2017 = cms.EDProducer("CandPtrProjector",
+        pfCandidatesGoodEE2017 = _mod.candPtrProjector.clone(
             src  = cands,
-            veto = cms.InputTag("superbad"+postfix),
+            veto = "superbad"+postfix,
         )
         addToProcessAndTask("pfCandidatesGoodEE2017"+postfix, pfCandidatesGoodEE2017, process, task)
         patMetModuleSequence += getattr(process,"pfCandidatesGoodEE2017"+postfix)


### PR DESCRIPTION
#### PR description: 
Optimization of the python configurations: Improve maintainability by cleaning up the duplicated and cloning from the default/reference configurations.
 
In this PR, 4 files changed.  (The reference PR is [PR#33207](https://github.com/cms-sw/cmssw/pull/33207) )

- commit 1 : 
Replace explicit configuration with a reference from cfipython/. (migrating EDProducer("type", .. -> typeDefaylt.clone() )
Remove the type specifications already presented in cfipython/fillDescriptions reference for improved syntax safty.

- commit 2 : 
Remove the duplicated parameters that are exactly the same value in cfipython reference.

#### PR validation:
Event Content comparison check was also done and there is no change with these updates.
Tested in CMSSW_11_3_X, the basic test all passed in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html).


@camclean @alefisico please check and confirm if this update is acceptable.