### PR TITLE
Add a generator filter based on properties of mother and long-lived sister of a gen particle

### DIFF
--- a/GeneratorInterface/GenFilters/plugins/PythiaFilterMotherSister.cc
+++ b/GeneratorInterface/GenFilters/plugins/PythiaFilterMotherSister.cc
@@ -8,109 +8,86 @@
 using namespace edm;
 using namespace std;
 
-
-PythiaFilterMotherSister::PythiaFilterMotherSister(const edm::ParameterSet& iConfig) :
-token_(consumes<edm::HepMCProduct>(edm::InputTag(iConfig.getUntrackedParameter("moduleLabel",std::string("generator")),"unsmeared"))),
-particleID(iConfig.getUntrackedParameter("ParticleID", 0)),
-minpcut(iConfig.getUntrackedParameter("MinP", 0.)),
-maxpcut(iConfig.getUntrackedParameter("MaxP", 10000.)),
-minptcut(iConfig.getUntrackedParameter("MinPt", 0.)),
-maxptcut(iConfig.getUntrackedParameter("MaxPt", 10000.)),
-minetacut(iConfig.getUntrackedParameter("MinEta", -10.)),
-maxetacut(iConfig.getUntrackedParameter("MaxEta", 10.)),
-minrapcut(iConfig.getUntrackedParameter("MinRapidity", -20.)),
-maxrapcut(iConfig.getUntrackedParameter("MaxRapidity", 20.)),
-minphicut(iConfig.getUntrackedParameter("MinPhi", -3.5)),
-maxphicut(iConfig.getUntrackedParameter("MaxPhi", 3.5)),
-motherIDs(iConfig.getUntrackedParameter("MotherIDs", std::vector<int>{0})),
-sisterID(iConfig.getUntrackedParameter("SisterID", 0)),
-betaBoost(iConfig.getUntrackedParameter("BetaBoost",0.)),
-maxSisDisplacement(iConfig.getUntrackedParameter("MaxSisterDisplacement", -1.))
-{
-   //now do what ever initialization is needed
-
+PythiaFilterMotherSister::PythiaFilterMotherSister(const edm::ParameterSet& iConfig)
+    : token_(consumes<edm::HepMCProduct>(
+          edm::InputTag(iConfig.getUntrackedParameter("moduleLabel", std::string("generator")), "unsmeared"))),
+      particleID(iConfig.getUntrackedParameter("ParticleID", 0)),
+      minpcut(iConfig.getUntrackedParameter("MinP", 0.)),
+      maxpcut(iConfig.getUntrackedParameter("MaxP", 10000.)),
+      minptcut(iConfig.getUntrackedParameter("MinPt", 0.)),
+      maxptcut(iConfig.getUntrackedParameter("MaxPt", 10000.)),
+      minetacut(iConfig.getUntrackedParameter("MinEta", -10.)),
+      maxetacut(iConfig.getUntrackedParameter("MaxEta", 10.)),
+      minrapcut(iConfig.getUntrackedParameter("MinRapidity", -20.)),
+      maxrapcut(iConfig.getUntrackedParameter("MaxRapidity", 20.)),
+      minphicut(iConfig.getUntrackedParameter("MinPhi", -3.5)),
+      maxphicut(iConfig.getUntrackedParameter("MaxPhi", 3.5)),
+      motherIDs(iConfig.getUntrackedParameter("MotherIDs", std::vector<int>{0})),
+      sisterID(iConfig.getUntrackedParameter("SisterID", 0)),
+      betaBoost(iConfig.getUntrackedParameter("BetaBoost", 0.)),
+      maxSisDisplacement(iConfig.getUntrackedParameter("MaxSisterDisplacement", -1.)) {
+  //now do what ever initialization is needed
 }
 
-
-PythiaFilterMotherSister::~PythiaFilterMotherSister()
-{
- 
-   // do anything here that needs to be done at desctruction time
-   // (e.g. close files, deallocate resources etc.)
-
+PythiaFilterMotherSister::~PythiaFilterMotherSister() {
+  // do anything here that needs to be done at desctruction time
+  // (e.g. close files, deallocate resources etc.)
 }
-
 
 //
 // member functions
 //
 
 // ------------ method called to produce the data  ------------
-bool PythiaFilterMotherSister::filter(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const
-{
-   using namespace edm;
-   Handle<HepMCProduct> evt;
-   iEvent.getByToken(token_, evt);
+bool PythiaFilterMotherSister::filter(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const {
+  using namespace edm;
+  Handle<HepMCProduct> evt;
+  iEvent.getByToken(token_, evt);
 
-   const HepMC::GenEvent * myGenEvent = evt->GetEvent();
-       
-   for ( HepMC::GenEvent::particle_const_iterator p = myGenEvent->particles_begin();
-         p != myGenEvent->particles_end(); ++p ) {
-     HepMC::FourVector mom = MCFilterZboostHelper::zboost((*p)->momentum(),betaBoost);
-     double rapidity = 0.5*log( (mom.e()+mom.pz()) / (mom.e()-mom.pz()) );
+  const HepMC::GenEvent* myGenEvent = evt->GetEvent();
 
-     if ( abs((*p)->pdg_id()) == particleID 
-          && mom.rho() > minpcut 
-          && mom.rho() < maxpcut
-          && (*p)->momentum().perp() > minptcut 
-          && (*p)->momentum().perp() < maxptcut
-          && mom.eta() > minetacut
-          && mom.eta() < maxetacut 
-          && rapidity > minrapcut
-          && rapidity < maxrapcut 
-          && (*p)->momentum().phi() > minphicut
-          && (*p)->momentum().phi() < maxphicut ) 
-     {
-       
-        
-       HepMC::GenParticle* mother = (*((*p)->production_vertex()->particles_in_const_begin()));
-      
-       // check various possible mothers
-       for(auto motherID : motherIDs){
+  for (HepMC::GenEvent::particle_const_iterator p = myGenEvent->particles_begin(); p != myGenEvent->particles_end();
+       ++p) {
+    HepMC::FourVector mom = MCFilterZboostHelper::zboost((*p)->momentum(), betaBoost);
+    double rapidity = 0.5 * log((mom.e() + mom.pz()) / (mom.e() - mom.pz()));
 
-         if(abs(mother->pdg_id()) == abs(motherID)){
-  
-           // loop over its daughters
-           for ( HepMC::GenVertex::particle_iterator dau = mother->end_vertex()->particles_begin(HepMC::children); 
-                                                     dau != mother->end_vertex()->particles_end(HepMC::children);
-                                                     ++dau ) {
-             // find the daugther you're interested in
-             if(abs((*dau)->pdg_id()) == abs(sisterID)) {
- 
-               // calculate displacement of the sister particle, from production to decay
-               HepMC::GenVertex* v1   = (*dau)->production_vertex();
-               HepMC::GenVertex* v2   = (*dau)->end_vertex();
+    if (abs((*p)->pdg_id()) == particleID && mom.rho() > minpcut && mom.rho() < maxpcut &&
+        (*p)->momentum().perp() > minptcut && (*p)->momentum().perp() < maxptcut && mom.eta() > minetacut &&
+        mom.eta() < maxetacut && rapidity > minrapcut && rapidity < maxrapcut && (*p)->momentum().phi() > minphicut &&
+        (*p)->momentum().phi() < maxphicut) {
+      HepMC::GenParticle* mother = (*((*p)->production_vertex()->particles_in_const_begin()));
 
-               double lx12 = v1->position().x() - v2->position().x();
-               double ly12 = v1->position().y() - v2->position().y();
-               double lz12 = v1->position().z() - v2->position().z();
-               double lxyz12 = sqrt( lx12*lx12 + ly12*ly12 + lz12*lz12 );
+      // check various possible mothers
+      for (auto motherID : motherIDs) {
+        if (abs(mother->pdg_id()) == abs(motherID)) {
+          // loop over its daughters
+          for (HepMC::GenVertex::particle_iterator dau = mother->end_vertex()->particles_begin(HepMC::children);
+               dau != mother->end_vertex()->particles_end(HepMC::children);
+               ++dau) {
+            // find the daugther you're interested in
+            if (abs((*dau)->pdg_id()) == abs(sisterID)) {
+              // calculate displacement of the sister particle, from production to decay
+              HepMC::GenVertex* v1 = (*dau)->production_vertex();
+              HepMC::GenVertex* v2 = (*dau)->end_vertex();
 
-               if(maxSisDisplacement!= -1){
-                 if(lxyz12 < maxSisDisplacement){
-                   return true; 
-                 }
-               } else {
-                  return true; 
-               }
+              double lx12 = v1->position().x() - v2->position().x();
+              double ly12 = v1->position().y() - v2->position().y();
+              double lz12 = v1->position().z() - v2->position().z();
+              double lxyz12 = sqrt(lx12 * lx12 + ly12 * ly12 + lz12 * lz12);
 
-             } 
-           } 
-         } 
-       } 
-     } 
-   } 
-   
-   return false;
+              if (maxSisDisplacement != -1) {
+                if (lxyz12 < maxSisDisplacement) {
+                  return true;
+                }
+              } else {
+                return true;
+              }
+            }
+          }
+        }
+      }
+    }
+  }
 
+  return false;
 }

--- a/GeneratorInterface/GenFilters/plugins/PythiaFilterMotherSister.cc
+++ b/GeneratorInterface/GenFilters/plugins/PythiaFilterMotherSister.cc
@@ -1,0 +1,116 @@
+
+#include "GeneratorInterface/GenFilters/plugins/PythiaFilterMotherSister.h"
+#include "GeneratorInterface/GenFilters/plugins/MCFilterZboostHelper.h"
+
+#include "SimDataFormats/GeneratorProducts/interface/HepMCProduct.h"
+#include <iostream>
+
+using namespace edm;
+using namespace std;
+
+
+PythiaFilterMotherSister::PythiaFilterMotherSister(const edm::ParameterSet& iConfig) :
+token_(consumes<edm::HepMCProduct>(edm::InputTag(iConfig.getUntrackedParameter("moduleLabel",std::string("generator")),"unsmeared"))),
+particleID(iConfig.getUntrackedParameter("ParticleID", 0)),
+minpcut(iConfig.getUntrackedParameter("MinP", 0.)),
+maxpcut(iConfig.getUntrackedParameter("MaxP", 10000.)),
+minptcut(iConfig.getUntrackedParameter("MinPt", 0.)),
+maxptcut(iConfig.getUntrackedParameter("MaxPt", 10000.)),
+minetacut(iConfig.getUntrackedParameter("MinEta", -10.)),
+maxetacut(iConfig.getUntrackedParameter("MaxEta", 10.)),
+minrapcut(iConfig.getUntrackedParameter("MinRapidity", -20.)),
+maxrapcut(iConfig.getUntrackedParameter("MaxRapidity", 20.)),
+minphicut(iConfig.getUntrackedParameter("MinPhi", -3.5)),
+maxphicut(iConfig.getUntrackedParameter("MaxPhi", 3.5)),
+motherIDs(iConfig.getUntrackedParameter("MotherIDs", std::vector<int>{0})),
+sisterID(iConfig.getUntrackedParameter("SisterID", 0)),
+betaBoost(iConfig.getUntrackedParameter("BetaBoost",0.)),
+maxSisDisplacement(iConfig.getUntrackedParameter("MaxSisterDisplacement", -1.))
+{
+   //now do what ever initialization is needed
+
+}
+
+
+PythiaFilterMotherSister::~PythiaFilterMotherSister()
+{
+ 
+   // do anything here that needs to be done at desctruction time
+   // (e.g. close files, deallocate resources etc.)
+
+}
+
+
+//
+// member functions
+//
+
+// ------------ method called to produce the data  ------------
+bool PythiaFilterMotherSister::filter(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const
+{
+   using namespace edm;
+   Handle<HepMCProduct> evt;
+   iEvent.getByToken(token_, evt);
+
+   const HepMC::GenEvent * myGenEvent = evt->GetEvent();
+       
+   for ( HepMC::GenEvent::particle_const_iterator p = myGenEvent->particles_begin();
+         p != myGenEvent->particles_end(); ++p ) {
+     HepMC::FourVector mom = MCFilterZboostHelper::zboost((*p)->momentum(),betaBoost);
+     double rapidity = 0.5*log( (mom.e()+mom.pz()) / (mom.e()-mom.pz()) );
+
+     if ( abs((*p)->pdg_id()) == particleID 
+          && mom.rho() > minpcut 
+          && mom.rho() < maxpcut
+          && (*p)->momentum().perp() > minptcut 
+          && (*p)->momentum().perp() < maxptcut
+          && mom.eta() > minetacut
+          && mom.eta() < maxetacut 
+          && rapidity > minrapcut
+          && rapidity < maxrapcut 
+          && (*p)->momentum().phi() > minphicut
+          && (*p)->momentum().phi() < maxphicut ) 
+     {
+       
+        
+       HepMC::GenParticle* mother = (*((*p)->production_vertex()->particles_in_const_begin()));
+      
+       // check various possible mothers
+       for(auto motherID : motherIDs){
+
+         if(abs(mother->pdg_id()) == abs(motherID)){
+  
+           // loop over its daughters
+           for ( HepMC::GenVertex::particle_iterator dau = mother->end_vertex()->particles_begin(HepMC::children); 
+                                                     dau != mother->end_vertex()->particles_end(HepMC::children);
+                                                     ++dau ) {
+             // find the daugther you're interested in
+             if(abs((*dau)->pdg_id()) == abs(sisterID)) {
+ 
+               // calculate displacement of the sister particle, from production to decay
+               HepMC::GenVertex* v1   = (*dau)->production_vertex();
+               HepMC::GenVertex* v2   = (*dau)->end_vertex();
+
+               double lx12 = v1->position().x() - v2->position().x();
+               double ly12 = v1->position().y() - v2->position().y();
+               double lz12 = v1->position().z() - v2->position().z();
+               double lxyz12 = sqrt( lx12*lx12 + ly12*ly12 + lz12*lz12 );
+
+               if(maxSisDisplacement!= -1){
+                 if(lxyz12 < maxSisDisplacement){
+                   return true; 
+                 }
+               } else {
+                  return true; 
+               }
+
+             } 
+           } 
+         } 
+       } 
+     } 
+   } 
+   
+   return false;
+
+}

--- a/GeneratorInterface/GenFilters/plugins/PythiaFilterMotherSister.h
+++ b/GeneratorInterface/GenFilters/plugins/PythiaFilterMotherSister.h
@@ -4,7 +4,7 @@
 //
 // Package:    PythiaFilterMotherSister
 // Class:      PythiaFilterMotherSister
-// 
+//
 /**\class PythiaFilterMotherSister PythiaFilterMotherSister.cc IOMC/PythiaFilterMotherSister/src/PythiaFilterMotherSister.cc
 
  Description: A filter to identify a particle with given id and kinematic 
@@ -15,11 +15,10 @@
      Inspired by PythiaFilterMultiMother.cc
 */
 //
-// 
-//         
 //
 //
-
+//
+//
 
 // system include files
 #include <memory>
@@ -41,34 +40,34 @@ namespace edm {
 }
 
 class PythiaFilterMotherSister : public edm::global::EDFilter<> {
-   public:
-      explicit PythiaFilterMotherSister(const edm::ParameterSet&);
-      ~PythiaFilterMotherSister() override;
+public:
+  explicit PythiaFilterMotherSister(const edm::ParameterSet&);
+  ~PythiaFilterMotherSister() override;
 
+  bool filter(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
 
-      bool filter(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
-   private:
-      // ----------member data ---------------------------
-      
-       const edm::EDGetTokenT<edm::HepMCProduct> token_;
-       const int particleID;
-       const double minpcut;
-       const double maxpcut;
-       const double minptcut;
-       const double maxptcut;
-       const double minetacut;
-       const double maxetacut;
-       const double minrapcut;
-       const double maxrapcut;
-       const double minphicut;
-       const double maxphicut;
+private:
+  // ----------member data ---------------------------
 
-       //const int status; 
-       std::vector<int> motherIDs;
-       const int sisterID;   
-       //const int processID;    
+  const edm::EDGetTokenT<edm::HepMCProduct> token_;
+  const int particleID;
+  const double minpcut;
+  const double maxpcut;
+  const double minptcut;
+  const double maxptcut;
+  const double minetacut;
+  const double maxetacut;
+  const double minrapcut;
+  const double maxrapcut;
+  const double minphicut;
+  const double maxphicut;
 
-       const double betaBoost;
-       const double maxSisDisplacement;
+  //const int status;
+  std::vector<int> motherIDs;
+  const int sisterID;
+  //const int processID;
+
+  const double betaBoost;
+  const double maxSisDisplacement;
 };
 #endif

--- a/GeneratorInterface/GenFilters/plugins/PythiaFilterMotherSister.h
+++ b/GeneratorInterface/GenFilters/plugins/PythiaFilterMotherSister.h
@@ -1,0 +1,74 @@
+#ifndef PYTHIAFILTERMOTHERSISTER_h
+#define PYTHIAFILTERMOTHERSISTER_h
+// -*- C++ -*-
+//
+// Package:    PythiaFilterMotherSister
+// Class:      PythiaFilterMotherSister
+// 
+/**\class PythiaFilterMotherSister PythiaFilterMotherSister.cc IOMC/PythiaFilterMotherSister/src/PythiaFilterMotherSister.cc
+
+ Description: A filter to identify a particle with given id and kinematic 
+                                                && given mother id (multiple mothers possible)
+                                                && given id and 3d displacement of one among mother's daughters
+
+ Implementation:
+     Inspired by PythiaFilterMultiMother.cc
+*/
+//
+// 
+//         
+//
+//
+
+
+// system include files
+#include <memory>
+
+// user include files
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/global/EDFilter.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+//
+// class decleration
+//
+namespace edm {
+  class HepMCProduct;
+}
+
+class PythiaFilterMotherSister : public edm::global::EDFilter<> {
+   public:
+      explicit PythiaFilterMotherSister(const edm::ParameterSet&);
+      ~PythiaFilterMotherSister() override;
+
+
+      bool filter(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
+   private:
+      // ----------member data ---------------------------
+      
+       const edm::EDGetTokenT<edm::HepMCProduct> token_;
+       const int particleID;
+       const double minpcut;
+       const double maxpcut;
+       const double minptcut;
+       const double maxptcut;
+       const double minetacut;
+       const double maxetacut;
+       const double minrapcut;
+       const double maxrapcut;
+       const double minphicut;
+       const double maxphicut;
+
+       //const int status; 
+       std::vector<int> motherIDs;
+       const int sisterID;   
+       //const int processID;    
+
+       const double betaBoost;
+       const double maxSisDisplacement;
+};
+#endif

--- a/GeneratorInterface/GenFilters/plugins/SealModule.cc
+++ b/GeneratorInterface/GenFilters/plugins/SealModule.cc
@@ -10,6 +10,7 @@
 #include "GeneratorInterface/GenFilters/plugins/CosmicGenFilterHelix.h"
 #include "GeneratorInterface/GenFilters/plugins/PythiaFilterIsolatedTrack.h"
 #include "GeneratorInterface/GenFilters/plugins/PythiaDauVFilterMatchID.h"
+#include "GeneratorInterface/GenFilters/plugins/PythiaFilterMotherSister.h"
 
 DEFINE_FWK_MODULE(PythiaFilter);
 DEFINE_FWK_MODULE(PythiaDauFilter);
@@ -21,3 +22,4 @@ DEFINE_FWK_MODULE(MCParticlePairFilter);
 DEFINE_FWK_MODULE(CosmicGenFilterHelix);
 DEFINE_FWK_MODULE(PythiaFilterIsolatedTrack);
 DEFINE_FWK_MODULE(PythiaDauVFilterMatchID);
+DEFINE_FWK_MODULE(PythiaFilterMotherSister);


### PR DESCRIPTION
#### PR description:

This PR introduces a new generator filter that was designed to efficiently select events with heavy long-lived neutrinos (N) from a B semi-leptonic decay: B -> l X N (-> l pi).
Events are filtered based on:
* the kinematic properties of the lepton l,
* the pdgId of the possible mother (multiple) 
* the pdgId and 3d displacement of one among the lepton's sisters. 

This is meant to be used for an MC production using the b-parking conditions, so a backport to 10_2_X will be submitted too, once this PR is merged.

It was checked that the code correctly filters B -> l X N (-> l pi) decay chains with the desired properties.

#### PR validation:

Followed the instructions here:
http://cms-sw.github.io/PRWorkflow.html

The report of `runTheMatrix.py -l limited -i all --ibeos` is attached:
[runall-report-step123-.log](https://github.com/cms-sw/cmssw/files/6234879/runall-report-step123-.log)

Code style checks have been performed and included as a separate commit.

