### PR TITLE
[HGCAL] CaloParticleSelector selects non-converted CP

### DIFF
--- a/Validation/HGCalValidation/interface/CaloParticleSelector.h
+++ b/Validation/HGCalValidation/interface/CaloParticleSelector.h
@@ -22,6 +22,7 @@ public:
                        bool intimeOnly,
                        bool chargedOnly,
                        bool stableOnly,
+                       bool notConvertedOnly,
                        const std::vector<int>& pdgId = std::vector<int>(),
                        double minPhi = -3.2,
                        double maxPhi = 3.2)
@@ -39,6 +40,7 @@ public:
         intimeOnly_(intimeOnly),
         chargedOnly_(chargedOnly),
         stableOnly_(stableOnly),
+        notConvertedOnly_(notConvertedOnly),
         pdgId_(pdgId) {
     if (minPhi >= maxPhi) {
       throw cms::Exception("Configuration")
@@ -101,6 +103,14 @@ public:
       }
     }
 
+    // select only particles which did not convert/decay before the calorimeter
+    if (notConvertedOnly_) {
+      if( cp.g4Tracks()[0].getPositionAtBoundary() == math::XYZTLorentzVectorF (0,0,0,0) )
+        return false;
+      if( cp.g4Tracks()[0].getMomentumAtBoundary() == math::XYZTLorentzVectorF (0,0,0,0) )
+        return false;
+    }
+
     auto etaOk = [&](const CaloParticle& p) -> bool {
       float eta = etaFromXYZ(p.px(), p.py(), p.pz());
       return (eta >= minRapidity_) & (eta <= maxRapidity_);
@@ -132,6 +142,7 @@ private:
   bool intimeOnly_;
   bool chargedOnly_;
   bool stableOnly_;
+  bool notConvertedOnly_;
   std::vector<int> pdgId_;
 };
 
@@ -158,6 +169,7 @@ namespace reco {
                                     cfg.getParameter<bool>("intimeOnlyCP"),
                                     cfg.getParameter<bool>("chargedOnlyCP"),
                                     cfg.getParameter<bool>("stableOnlyCP"),
+                                    cfg.getParameter<bool>("notConvertedOnlyCP"),
                                     cfg.getParameter<std::vector<int> >("pdgIdCP"),
                                     cfg.getParameter<double>("minPhiCP"),
                                     cfg.getParameter<double>("maxPhiCP"));

--- a/Validation/HGCalValidation/interface/CaloParticleSelector.h
+++ b/Validation/HGCalValidation/interface/CaloParticleSelector.h
@@ -104,11 +104,16 @@ public:
     }
 
     // select only particles which did not convert/decay before the calorimeter
-    if (notConvertedOnly_) {
-      if( cp.g4Tracks()[0].getPositionAtBoundary() == math::XYZTLorentzVectorF (0,0,0,0) )
-        return false;
-      if( cp.g4Tracks()[0].getMomentumAtBoundary() == math::XYZTLorentzVectorF (0,0,0,0) )
-        return false;
+    // in case of electrons, bremsstrahlung is usually the cause, thus this selection is skipped
+    if (std::abs(pdgid) != 11) {
+      if (notConvertedOnly_) {
+        if( cp.g4Tracks()[0].getPositionAtBoundary() == math::XYZTLorentzVectorF (0,0,0,0) ){
+          return false;
+        }
+        if( cp.g4Tracks()[0].getMomentumAtBoundary() == math::XYZTLorentzVectorF (0,0,0,0) ){
+          return false;
+        }
+      }
     }
 
     auto etaOk = [&](const CaloParticle& p) -> bool {

--- a/Validation/HGCalValidation/interface/CaloParticleSelector.h
+++ b/Validation/HGCalValidation/interface/CaloParticleSelector.h
@@ -107,10 +107,10 @@ public:
     // in case of electrons, bremsstrahlung is usually the cause, thus this selection is skipped
     if (std::abs(pdgid) != 11) {
       if (notConvertedOnly_) {
-        if( cp.g4Tracks()[0].getPositionAtBoundary() == math::XYZTLorentzVectorF (0,0,0,0) ){
+        if (cp.g4Tracks()[0].getPositionAtBoundary() == math::XYZTLorentzVectorF(0, 0, 0, 0)) {
           return false;
         }
-        if( cp.g4Tracks()[0].getMomentumAtBoundary() == math::XYZTLorentzVectorF (0,0,0,0) ){
+        if (cp.g4Tracks()[0].getMomentumAtBoundary() == math::XYZTLorentzVectorF(0, 0, 0, 0)) {
           return false;
         }
       }

--- a/Validation/HGCalValidation/plugins/HGCalValidator.cc
+++ b/Validation/HGCalValidation/plugins/HGCalValidator.cc
@@ -64,6 +64,7 @@ HGCalValidator::HGCalValidator(const edm::ParameterSet& pset)
                                     pset.getParameter<bool>("intimeOnlyCP"),
                                     pset.getParameter<bool>("chargedOnlyCP"),
                                     pset.getParameter<bool>("stableOnlyCP"),
+                                    pset.getParameter<bool>("notConvertedOnlyCP"),
                                     pset.getParameter<std::vector<int>>("pdgIdCP"));
 
   tools_.reset(new hgcal::RecHitTools());

--- a/Validation/HGCalValidation/python/CaloParticleSelectionForEfficiency_cfi.py
+++ b/Validation/HGCalValidation/python/CaloParticleSelectionForEfficiency_cfi.py
@@ -11,6 +11,7 @@ CaloParticleSelectionForEfficiency = cms.PSet(
     tipCP = cms.double(60),
     chargedOnlyCP = cms.bool(False),
     stableOnlyCP = cms.bool(False),
+    notConvertedOnlyCP = cms.bool(True),
     #311: K0, 130: K0_short, 310: K0_long
     pdgIdCP = cms.vint32(11, -11, 13, -13, 22, 111, 211, -211, 321, -321, 311, 130, 310),
     #--signal only means no PU particles
@@ -19,5 +20,5 @@ CaloParticleSelectionForEfficiency = cms.PSet(
     intimeOnlyCP = cms.bool(True),
     #The total number of rechits
     minHitCP = cms.int32(0),
-    maxSimClustersCP = cms.int32(1)
+    maxSimClustersCP = cms.int32(-1)
 )


### PR DESCRIPTION
#### PR description:

This PR correctly identify the CaloParticle which have converted in the Tracker using the `getPositionAtBoundary` and `getMomentumAtBoundary` methods from the SimTrack associated. Before this was done looking at the number of SimClusters associated, but this method was not fully correct: in the specific case of the single photons, they always had 2 SimClusters because of pair production but not always was in the Tracker. 
An exception is introduced for the electrons which most of the time undergo bremsstrahlung and therefore are always converting in the Tracker. 

It would be great if this PR manage to get into 11_3_0.

#### PR validation:

- Efficiency on single photons before the PR: 
![image](https://user-images.githubusercontent.com/5331004/113116551-d7578780-920d-11eb-81be-bf3d78189883.png)
- Efficiency on single photons after the PR: 
![image](https://user-images.githubusercontent.com/5331004/113116646-ecccb180-920d-11eb-8f86-32f26c9cd370.png)

@apsallid @lecriste @rovere @felicepantaleo 