### PR TITLE
Throw when no resolution fits are available in ObjectResolutionCalc

### DIFF
--- a/PhysicsTools/PatUtils/interface/ObjectResolutionCalc.h
+++ b/PhysicsTools/PatUtils/interface/ObjectResolutionCalc.h
@@ -12,11 +12,6 @@
   \version  $Id: ObjectResolutionCalc.h,v 1.5 2008/10/08 19:19:25 gpetrucc Exp $
 */
 
-#include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/Framework/interface/Event.h"
-#include "FWCore/MessageLogger/interface/MessageLogger.h"
-#include "FWCore/Utilities/interface/Exception.h"
-
 #include "DataFormats/PatCandidates/interface/Electron.h"
 #include "DataFormats/PatCandidates/interface/Muon.h"
 #include "DataFormats/PatCandidates/interface/Tau.h"
@@ -24,11 +19,9 @@
 #include "DataFormats/PatCandidates/interface/Jet.h"
 
 #include "TF1.h"
-#include "TH1.h"
 #include "TFile.h"
-#include "TKey.h"
-#include "TString.h"
 #include "TMultiLayerPerceptron.h"
+#include "TString.h"
 
 namespace pat {
 

--- a/PhysicsTools/PatUtils/src/ObjectResolutionCalc.cc
+++ b/PhysicsTools/PatUtils/src/ObjectResolutionCalc.cc
@@ -3,6 +3,12 @@
 
 #include "PhysicsTools/PatUtils/interface/ObjectResolutionCalc.h"
 
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/Utilities/interface/Exception.h"
+
+#include "TH1.h"
+#include "TKey.h"
+
 using namespace pat;
 
 // constructor with path; default should not be used
@@ -11,9 +17,10 @@ ObjectResolutionCalc::ObjectResolutionCalc(const TString& resopath, bool useNN =
       << ("ObjectResolutionCalc") << "=== Constructing a TopObjectResolutionCalc...";
   resoFile_ = new TFile(resopath);
   if (!resoFile_)
-    edm::LogError("ObjectResolutionCalc") << "No resolutions fits for this file available: " << resopath << "...";
-  TString resObsName[8] = {"_ares", "_bres", "_cres", "_dres", "_thres", "_phres", "_etres", "_etares"};
+    throw edm::Exception(edm::errors::LogicError)
+        << "ObjectResolutionCalc: no resolutions fits for this file available: " << resopath << "...";
 
+  TString resObsName[8] = {"_ares", "_bres", "_cres", "_dres", "_thres", "_phres", "_etres", "_etares"};
   TList* keys = resoFile_->GetListOfKeys();
   TIter nextitem(keys);
   TKey* key = nullptr;
@@ -70,8 +77,10 @@ int ObjectResolutionCalc::etaBin(float eta) {
   int nrEtaBins = etaBinVals_.size() - 1;
   int bin = nrEtaBins - 1;
   for (int i = 0; i < nrEtaBins; i++) {
-    if (fabs(eta) > etaBinVals_[i] && fabs(eta) < etaBinVals_[i + 1])
+    if (fabs(eta) > etaBinVals_[i] && fabs(eta) < etaBinVals_[i + 1]) {
       bin = i;
+      break;
+    }
   }
   return bin;
 }


### PR DESCRIPTION
#### PR description:

Throw when no resolution fits are available, instead of just issuing a LogError (and crash afterwards when attempting to access the `resoFile_` with its null pointer).

Also profit for some (minor) clean up: others would be needed, in particular for the method `etaBin(...)`, which doesn't seem to be used any more though.

#### PR validation:

It builds.
No changes expected