### PR TITLE
[HGCAL] TICL SimTracksters

### DIFF
--- a/DataFormats/HGCalReco/interface/Trackster.h
+++ b/DataFormats/HGCalReco/interface/Trackster.h
@@ -114,7 +114,7 @@ namespace ticl {
         p = *(probs++);
       }
     }
-    inline void setIdProbability(ParticleType type, float value) { id_probabilities_[int(type)] = 1.f; }
+    inline void setIdProbability(ParticleType type, float value) { id_probabilities_[int(type)] = value; }
 
     inline const Trackster::IterationIndex ticlIteration() const { return (IterationIndex)iterationIndex_; }
     inline const std::vector<unsigned int> &vertices() const { return vertices_; }

--- a/RecoHGCal/Configuration/python/RecoHGCal_EventContent_cff.py
+++ b/RecoHGCal/Configuration/python/RecoHGCal_EventContent_cff.py
@@ -24,7 +24,6 @@ TICL_RECO = cms.PSet(
       'keep *_ticlTrackstersMIP_*_*',
       'keep *_ticlTrackstersMerge_*_*',
       'keep *_ticlTrackstersHFNoseTrkEM_*_*',
-      'keep *_ticlSimTracksters_*_*',
       'keep *_ticlTrackstersHFNoseEM_*_*',
       'keep *_ticlTrackstersHFNoseMIP_*_*',
       'keep *_ticlTrackstersHFNoseHAD_*_*',
@@ -37,6 +36,7 @@ TICL_RECO.outputCommands.extend(TICL_AOD.outputCommands)
 # FEVT Content
 TICL_FEVT = cms.PSet(
     outputCommands = cms.untracked.vstring(
+      'keep *_ticlSimTracksters_*_*',
       )
     )
 TICL_FEVT.outputCommands.extend(TICL_RECO.outputCommands)

--- a/RecoHGCal/Configuration/python/RecoHGCal_EventContent_cff.py
+++ b/RecoHGCal/Configuration/python/RecoHGCal_EventContent_cff.py
@@ -10,6 +10,7 @@ TICL_AOD = cms.PSet(
       'keep *_ticlMultiClustersFromTrackstersTrkEM_*_*',
       'keep *_ticlMultiClustersFromTrackstersMIP_*_*',
       'keep *_ticlMultiClustersFromTrackstersMerge_*_*',
+      'keep *_ticlMultiClustersFromSimTracksters_*_*',
       )
     )
 

--- a/RecoHGCal/Configuration/python/RecoHGCal_EventContent_cff.py
+++ b/RecoHGCal/Configuration/python/RecoHGCal_EventContent_cff.py
@@ -3,7 +3,7 @@ import FWCore.ParameterSet.Config as cms
 
 #AOD content
 TICL_AOD = cms.PSet(
-  # MultiClusters will be deprecated soon
+  # 13/04/2021 Felice: MultiClusters will be deprecated soon
     outputCommands = cms.untracked.vstring(
       'keep *_ticlMultiClustersFromTrackstersEM_*_*',
       'keep *_ticlMultiClustersFromTrackstersHAD_*_*',

--- a/RecoHGCal/Configuration/python/RecoHGCal_EventContent_cff.py
+++ b/RecoHGCal/Configuration/python/RecoHGCal_EventContent_cff.py
@@ -23,6 +23,7 @@ TICL_RECO = cms.PSet(
       'keep *_ticlTrackstersMIP_*_*',
       'keep *_ticlTrackstersMerge_*_*',
       'keep *_ticlTrackstersHFNoseTrkEM_*_*',
+      'keep *_ticlSimTracksters_*_*',
       'keep *_ticlTrackstersHFNoseEM_*_*',
       'keep *_ticlTrackstersHFNoseMIP_*_*',
       'keep *_ticlTrackstersHFNoseHAD_*_*',

--- a/RecoHGCal/Configuration/python/RecoHGCal_EventContent_cff.py
+++ b/RecoHGCal/Configuration/python/RecoHGCal_EventContent_cff.py
@@ -3,6 +3,7 @@ import FWCore.ParameterSet.Config as cms
 
 #AOD content
 TICL_AOD = cms.PSet(
+  # MultiClusters will be deprecated soon
     outputCommands = cms.untracked.vstring(
       'keep *_ticlMultiClustersFromTrackstersEM_*_*',
       'keep *_ticlMultiClustersFromTrackstersHAD_*_*',

--- a/RecoHGCal/TICL/plugins/BuildFile.xml
+++ b/RecoHGCal/TICL/plugins/BuildFile.xml
@@ -2,8 +2,11 @@
 <use name="DataFormats/CaloRecHit"/>
 <use name="DataFormats/Candidate"/>
 <use name="DataFormats/Common"/>
+<use name="DataFormats/GeometrySurface"/>
 <use name="DataFormats/HGCalReco"/>
+<use name="DataFormats/L1TCorrelator"/>
 <use name="DataFormats/L1Trigger"/>
+<use name="DataFormats/Math"/>
 <use name="DataFormats/ParticleFlowCandidate"/>
 <use name="DataFormats/ParticleFlowReco"/>
 <use name="DataFormats/TrackReco"/>
@@ -11,6 +14,13 @@
 <use name="FWCore/MessageLogger"/>
 <use name="FWCore/ParameterSet"/>
 <use name="FWCore/PluginManager"/>
+<use name="FWCore/Utilities"/>
+<use name="Geometry/CaloGeometry"/>
+<use name="Geometry/CommonDetUnit"/>
+<use name="Geometry/HGCalCommonData"/>
+<use name="Geometry/Records"/>
+<use name="MagneticField/Engine"/>
+<use name="MagneticField/Records"/>
 <use name="PhysicsTools/TensorFlow"/>
 <use name="RecoLocalCalo/HGCalRecAlgos"/>
 <use name="RecoLocalCalo/HGCalRecProducers"/>
@@ -18,7 +28,9 @@
 <use name="RecoParticleFlow/PFProducer"/>
 <use name="SimDataFormats/Associations"/>
 <use name="SimDataFormats/CaloAnalysis"/>
+<use name="TrackingTools/GeomPropagators"/>
 <use name="TrackingTools/Records"/>
+<use name="TrackingTools/TrajectoryState"/>
 <library file="*.cc" name="RecoHGCalTICLPlugins">
   <flags EDM_PLUGIN="1"/>
 </library>

--- a/RecoHGCal/TICL/plugins/BuildFile.xml
+++ b/RecoHGCal/TICL/plugins/BuildFile.xml
@@ -1,18 +1,24 @@
 <use name="CommonTools/Utils"/>
-<use name="RecoLocalCalo/HGCalRecProducers"/>
-<use name="RecoLocalCalo/HGCalRecAlgos"/>
+<use name="DataFormats/CaloRecHit"/>
+<use name="DataFormats/Candidate"/>
+<use name="DataFormats/Common"/>
+<use name="DataFormats/HGCalReco"/>
+<use name="DataFormats/L1Trigger"/>
+<use name="DataFormats/ParticleFlowCandidate"/>
+<use name="DataFormats/ParticleFlowReco"/>
+<use name="DataFormats/TrackReco"/>
 <use name="FWCore/Framework"/>
+<use name="FWCore/MessageLogger"/>
 <use name="FWCore/ParameterSet"/>
 <use name="FWCore/PluginManager"/>
-<use name="DataFormats/CaloRecHit"/>
-<use name="DataFormats/ParticleFlowCandidate"/>
-<use name="DataFormats/HGCalReco"/>
-<use name="FWCore/MessageLogger"/>
-<use name="DataFormats/TrackReco"/>
-<use name="TrackingTools/Records"/>
 <use name="PhysicsTools/TensorFlow"/>
+<use name="RecoLocalCalo/HGCalRecAlgos"/>
+<use name="RecoLocalCalo/HGCalRecProducers"/>
 <use name="RecoHGCal/TICL"/>
 <use name="RecoParticleFlow/PFProducer"/>
+<use name="SimDataFormats/Associations"/>
+<use name="SimDataFormats/CaloAnalysis"/>
+<use name="TrackingTools/Records"/>
 <library file="*.cc" name="RecoHGCalTICLPlugins">
   <flags EDM_PLUGIN="1"/>
 </library>

--- a/RecoHGCal/TICL/plugins/TrackstersFromSimClustersProducer.cc
+++ b/RecoHGCal/TICL/plugins/TrackstersFromSimClustersProducer.cc
@@ -91,8 +91,7 @@ TrackstersFromSimClustersProducer::TrackstersFromSimClustersProducer(const edm::
       associatorMapSimToReco_token_(
           consumes<hgcal::SimToRecoCollectionWithSimClusters>(associatorLayerClusterSimCluster_)) {
   produces<std::vector<Trackster>>();
-  produces<std::vector<float>>();  
-
+  produces<std::vector<float>>();
 }
 
 void TrackstersFromSimClustersProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
@@ -114,7 +113,7 @@ void TrackstersFromSimClustersProducer::produce(edm::Event& evt, const edm::Even
   const auto& layerClusters = evt.get(clusters_token_);
   const auto& layerClustersTimes = evt.get(clustersTime_token_);
   const auto& inputClusterMask = evt.get(filtered_layerclusters_mask_token_);
-  output_mask->resize(layerClusters.size(),1.f);
+  output_mask->resize(layerClusters.size(), 1.f);
 
   const auto& simclusters = evt.get(simclusters_token_);
   const auto& simToRecoColl = evt.get(associatorMapSimToReco_token_);
@@ -128,17 +127,16 @@ void TrackstersFromSimClustersProducer::produce(edm::Event& evt, const edm::Even
     auto const& sc = *(key);
     auto simClusterIndex = &sc - &simclusters[0];
     Trackster tmpTrackster;
-    tmpTrackster.zeroProbabilities(); 
+    tmpTrackster.zeroProbabilities();
     tmpTrackster.vertices().reserve(values.size());
     tmpTrackster.vertex_multiplicity().reserve(values.size());
 
     for (auto const& [lc, energyScorePair] : values) {
-      if(inputClusterMask[lc.index()] > 0){
+      if (inputClusterMask[lc.index()] > 0) {
         tmpTrackster.vertices().push_back(lc.index());
-        double fraction = energyScorePair.first/lc->energy();
+        double fraction = energyScorePair.first / lc->energy();
         (*output_mask)[lc.index()] -= fraction;
-        // std::cout << lc->energy() << " " << energyScorePair.first << " " << energyScorePair.first/lc->energy() << " " << lc->energy()/energyScorePair.first << " " << (int)static_cast<uint8_t>(std::clamp(lc->energy()/energyScorePair.first, 0., 255.)) << std::endl;
-        tmpTrackster.vertex_multiplicity().push_back(static_cast<uint8_t>(std::clamp(1./fraction, 0., 255.)));
+        tmpTrackster.vertex_multiplicity().push_back(static_cast<uint8_t>(std::clamp(1. / fraction, 0., 255.)));
       }
     }
     tmpTrackster.setIdProbability(tracksterParticleTypeFromPdgId(sc.pdgId(), sc.charge()), 1.f);
@@ -149,5 +147,4 @@ void TrackstersFromSimClustersProducer::produce(edm::Event& evt, const edm::Even
       *result, layerClusters, layerClustersTimes, rhtools_.getPositionLayer(rhtools_.lastLayerEE(doNose_)).z());
   evt.put(std::move(result));
   evt.put(std::move(output_mask));
-
 }

--- a/RecoHGCal/TICL/plugins/TrackstersFromSimClustersProducer.cc
+++ b/RecoHGCal/TICL/plugins/TrackstersFromSimClustersProducer.cc
@@ -1,0 +1,100 @@
+// Author: Felice Pantaleo - felice.pantaleo@cern.ch
+// Date: 02/2021
+
+// user include files
+#include <vector>
+
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+
+#include "DataFormats/CaloRecHit/interface/CaloCluster.h"
+#include "DataFormats/ParticleFlowReco/interface/PFCluster.h"
+
+#include "DataFormats/HGCalReco/interface/Trackster.h"
+#include "DataFormats/HGCalReco/interface/TICLLayerTile.h"
+
+#include "DataFormats/Common/interface/ValueMap.h"
+#include "SimDataFormats/Associations/interface/LayerClusterToSimClusterAssociator.h"
+
+using namespace ticl;
+
+class TrackstersFromSimClustersProducer : public edm::stream::EDProducer<> {
+public:
+  explicit TrackstersFromSimClustersProducer(const edm::ParameterSet&);
+  ~TrackstersFromSimClustersProducer() override {}
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+  void produce(edm::Event&, const edm::EventSetup&) override;
+
+
+private:
+  std::string detector_;
+  bool doNose_;
+  const edm::EDGetTokenT<std::vector<reco::CaloCluster>> clusters_token_;
+  const edm::EDGetTokenT<edm::ValueMap<std::pair<float, float>>> clustersTime_token_;
+  edm::EDGetTokenT<TICLLayerTiles> layer_clusters_tiles_token_;
+  edm::EDGetTokenT<TICLLayerTilesHFNose> layer_clusters_tiles_hfnose_token_;
+  edm::EDGetTokenT<std::vector<SimCluster>> simclusters_token_;
+
+  edm::InputTag associatorLayerClusterSimCluster_;
+  edm::EDGetTokenT<hgcal::SimToRecoCollectionWithSimClusters> associatorMapSimToReco_token_;
+
+
+};
+DEFINE_FWK_MODULE(TrackstersFromSimClustersProducer);
+
+
+
+TrackstersFromSimClustersProducer::TrackstersFromSimClustersProducer(const edm::ParameterSet& ps)
+    : detector_(ps.getParameter<std::string>("detector")),
+      doNose_(detector_ == "HFNose"),
+      clusters_token_(consumes<std::vector<reco::CaloCluster>>(ps.getParameter<edm::InputTag>("layer_clusters"))),
+      clustersTime_token_(consumes<edm::ValueMap<std::pair<float, float>>>(ps.getParameter<edm::InputTag>("time_layerclusters"))),
+      simclusters_token_(consumes<std::vector<SimCluster>>(ps.getParameter<edm::InputTag>("simclusters"))),
+      associatorLayerClusterSimCluster_(ps.getUntrackedParameter<edm::InputTag>("layerClusterSimClusterAssociator")),
+      associatorMapSimToReco_token_(consumes<hgcal::SimToRecoCollectionWithSimClusters>(associatorLayerClusterSimCluster_))
+{
+
+  if (doNose_) {
+    layer_clusters_tiles_hfnose_token_ =
+        consumes<TICLLayerTilesHFNose>(ps.getParameter<edm::InputTag>("layer_clusters_hfnose_tiles"));
+  } else {
+    layer_clusters_tiles_token_ = consumes<TICLLayerTiles>(ps.getParameter<edm::InputTag>("layer_clusters_tiles"));
+  }
+  produces<std::vector<Trackster>>();
+}
+
+void TrackstersFromSimClustersProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  // hgcalMultiClusters
+  edm::ParameterSetDescription desc;
+  desc.add<std::string>("detector", "HGCAL");
+  desc.add<edm::InputTag>("layer_clusters", edm::InputTag("hgcalLayerClusters"));
+  desc.add<edm::InputTag>("time_layerclusters", edm::InputTag("hgcalLayerClusters", "timeLayerCluster"));
+  desc.add<edm::InputTag>("layer_clusters_tiles", edm::InputTag("ticlLayerTileProducer"));
+  desc.add<edm::InputTag>("layer_clusters_hfnose_tiles", edm::InputTag("ticlLayerTileHFNose"));
+  desc.add<edm::InputTag>("simclusters", edm::InputTag("mix","MergedCaloTruth"));
+  desc.addUntracked<edm::InputTag>("layerClusterSimClusterAssociator", edm::InputTag("layerClusterSimClusterAssociationProducer"));
+  descriptions.add("trackstersFromSimClustersProducer", desc);
+}
+
+void TrackstersFromSimClustersProducer::produce(edm::Event& evt, const edm::EventSetup& es) {
+  auto result = std::make_unique<std::vector<Trackster>>();
+  const auto& layerClusters = evt.get(clusters_token_);
+  const auto& layerClustersTimes = evt.get(clustersTime_token_);
+  const auto& simclusters = evt.get(simclusters_token_);
+  const auto& simToRecoColl = evt.get(associatorMapSimToReco_token_);
+  std::cout << "pippo" << std::endl;
+
+  
+  // const auto& lcsIt = simToRecoColl.find(scRef);
+
+  
+
+  evt.put(std::move(result));
+}

--- a/RecoHGCal/TICL/plugins/TrackstersFromSimClustersProducer.cc
+++ b/RecoHGCal/TICL/plugins/TrackstersFromSimClustersProducer.cc
@@ -2,7 +2,6 @@
 // Date: 02/2021
 
 // user include files
-#include <vector>
 
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/Event.h"
@@ -21,8 +20,42 @@
 
 #include "DataFormats/Common/interface/ValueMap.h"
 #include "SimDataFormats/Associations/interface/LayerClusterToSimClusterAssociator.h"
+#include "SimDataFormats/CaloAnalysis/interface/SimCluster.h"
+#include "RecoLocalCalo/HGCalRecAlgos/interface/RecHitTools.h"
+
+#include "TrackstersPCA.h"
+#include <vector>
+#include <iterator>
 
 using namespace ticl;
+
+namespace {
+  Trackster::ParticleType tracksterParticleTypeFromPdgId(int pdgId, int charge) {
+    if (pdgId == 111) {
+      return Trackster::ParticleType::neutral_pion;
+    } else {
+      pdgId = std::abs(pdgId);
+      if (pdgId == 22) {
+        return Trackster::ParticleType::photon;
+      } else if (pdgId == 11) {
+        return Trackster::ParticleType::electron;
+      } else if (pdgId == 13) {
+        return Trackster::ParticleType::muon;
+      } else {
+        bool isHadron = (pdgId > 100 and pdgId < 900) or (pdgId > 1000 and pdgId < 9000);
+        if (isHadron) {
+          if (charge != 0) {
+            return Trackster::ParticleType::charged_hadron;
+          } else {
+            return Trackster::ParticleType::neutral_hadron;
+          }
+        } else {
+          return Trackster::ParticleType::unknown;
+        }
+      }
+    }
+  }
+}  // namespace
 
 class TrackstersFromSimClustersProducer : public edm::stream::EDProducer<> {
 public:
@@ -32,10 +65,9 @@ public:
 
   void produce(edm::Event&, const edm::EventSetup&) override;
 
-
 private:
   std::string detector_;
-  bool doNose_;
+  const bool doNose_ = false;
   const edm::EDGetTokenT<std::vector<reco::CaloCluster>> clusters_token_;
   const edm::EDGetTokenT<edm::ValueMap<std::pair<float, float>>> clustersTime_token_;
   edm::EDGetTokenT<TICLLayerTiles> layer_clusters_tiles_token_;
@@ -44,23 +76,20 @@ private:
 
   edm::InputTag associatorLayerClusterSimCluster_;
   edm::EDGetTokenT<hgcal::SimToRecoCollectionWithSimClusters> associatorMapSimToReco_token_;
-
-
+  hgcal::RecHitTools rhtools_;
 };
 DEFINE_FWK_MODULE(TrackstersFromSimClustersProducer);
-
-
 
 TrackstersFromSimClustersProducer::TrackstersFromSimClustersProducer(const edm::ParameterSet& ps)
     : detector_(ps.getParameter<std::string>("detector")),
       doNose_(detector_ == "HFNose"),
       clusters_token_(consumes<std::vector<reco::CaloCluster>>(ps.getParameter<edm::InputTag>("layer_clusters"))),
-      clustersTime_token_(consumes<edm::ValueMap<std::pair<float, float>>>(ps.getParameter<edm::InputTag>("time_layerclusters"))),
+      clustersTime_token_(
+          consumes<edm::ValueMap<std::pair<float, float>>>(ps.getParameter<edm::InputTag>("time_layerclusters"))),
       simclusters_token_(consumes<std::vector<SimCluster>>(ps.getParameter<edm::InputTag>("simclusters"))),
       associatorLayerClusterSimCluster_(ps.getUntrackedParameter<edm::InputTag>("layerClusterSimClusterAssociator")),
-      associatorMapSimToReco_token_(consumes<hgcal::SimToRecoCollectionWithSimClusters>(associatorLayerClusterSimCluster_))
-{
-
+      associatorMapSimToReco_token_(
+          consumes<hgcal::SimToRecoCollectionWithSimClusters>(associatorLayerClusterSimCluster_)) {
   if (doNose_) {
     layer_clusters_tiles_hfnose_token_ =
         consumes<TICLLayerTilesHFNose>(ps.getParameter<edm::InputTag>("layer_clusters_hfnose_tiles"));
@@ -78,8 +107,9 @@ void TrackstersFromSimClustersProducer::fillDescriptions(edm::ConfigurationDescr
   desc.add<edm::InputTag>("time_layerclusters", edm::InputTag("hgcalLayerClusters", "timeLayerCluster"));
   desc.add<edm::InputTag>("layer_clusters_tiles", edm::InputTag("ticlLayerTileProducer"));
   desc.add<edm::InputTag>("layer_clusters_hfnose_tiles", edm::InputTag("ticlLayerTileHFNose"));
-  desc.add<edm::InputTag>("simclusters", edm::InputTag("mix","MergedCaloTruth"));
-  desc.addUntracked<edm::InputTag>("layerClusterSimClusterAssociator", edm::InputTag("layerClusterSimClusterAssociationProducer"));
+  desc.add<edm::InputTag>("simclusters", edm::InputTag("mix", "MergedCaloTruth"));
+  desc.addUntracked<edm::InputTag>("layerClusterSimClusterAssociator",
+                                   edm::InputTag("layerClusterSimClusterAssociationProducer"));
   descriptions.add("trackstersFromSimClustersProducer", desc);
 }
 
@@ -89,12 +119,31 @@ void TrackstersFromSimClustersProducer::produce(edm::Event& evt, const edm::Even
   const auto& layerClustersTimes = evt.get(clustersTime_token_);
   const auto& simclusters = evt.get(simclusters_token_);
   const auto& simToRecoColl = evt.get(associatorMapSimToReco_token_);
-  std::cout << "pippo" << std::endl;
 
-  
-  // const auto& lcsIt = simToRecoColl.find(scRef);
+  edm::ESHandle<CaloGeometry> geom;
+  es.get<CaloGeometryRecord>().get(geom);
+  rhtools_.setGeometry(*geom);
+  auto num_simclusters = simclusters.size();
+  result->reserve(num_simclusters);
 
-  
+  std::cout << num_simclusters << std::endl;
 
+  for (const auto& [key, values] : simToRecoColl) {
+    auto const& sc = *(key);
+    std::cout << values.size() << " " << sc.numberOfRecHits() << std::endl;
+    Trackster tmpTrackster;
+    tmpTrackster.zeroProbabilities();
+    tmpTrackster.vertices().reserve(values.size());
+    tmpTrackster.vertex_multiplicity().resize(values.size(), 1);
+
+    for (auto const& [lc, energyScorePair] : values) {
+      tmpTrackster.vertices().push_back(lc.index());
+    }
+    tmpTrackster.setIdProbability(tracksterParticleTypeFromPdgId(sc.pdgId(), sc.charge()), 1.f);
+    tmpTrackster.setSeed(key.id(), &sc - &simclusters[0]);
+    result->emplace_back(tmpTrackster);
+  }
+  ticl::assignPCAtoTracksters(
+      *result, layerClusters, layerClustersTimes, rhtools_.getPositionLayer(rhtools_.lastLayerEE(doNose_)).z());
   evt.put(std::move(result));
 }

--- a/RecoHGCal/TICL/python/SimTracksters_cff.py
+++ b/RecoHGCal/TICL/python/SimTracksters_cff.py
@@ -2,16 +2,26 @@ import FWCore.ParameterSet.Config as cms
 
 from RecoHGCal.TICL.trackstersFromSimClustersProducer_cfi import trackstersFromSimClustersProducer as _trackstersFromSimClustersProducer
 from RecoHGCal.TICL.multiClustersFromTrackstersProducer_cfi import multiClustersFromTrackstersProducer as _multiClustersFromTrackstersProducer
+from RecoHGCal.TICL.filteredLayerClustersProducer_cfi import filteredLayerClustersProducer as _filteredLayerClustersProducer
 
 
 # CA - PATTERN RECOGNITION
 
+
+filteredLayerClustersSimTracksters = _filteredLayerClustersProducer.clone(
+    clusterFilter = "ClusterFilterByAlgoAndSize",
+    algo_number = 8,
+    min_cluster_size = 0, # inclusive
+    iteration_label = "ticlSimTracksters"
+)
+
 ticlSimTracksters = _trackstersFromSimClustersProducer.clone(
+    # filtered_mask = cms.InputTag("filteredLayerClustersSimTracksters", "ticlSimTracksters"),
 )
 
 ticlMultiClustersFromSimTracksters = _multiClustersFromTrackstersProducer.clone(
     Tracksters = "ticlSimTracksters"
 )
 
-ticlSimTrackstersTask = cms.Task(ticlSimTracksters, ticlMultiClustersFromSimTracksters)
+ticlSimTrackstersTask = cms.Task(filteredLayerClustersSimTracksters, ticlSimTracksters, ticlMultiClustersFromSimTracksters)
 

--- a/RecoHGCal/TICL/python/SimTracksters_cff.py
+++ b/RecoHGCal/TICL/python/SimTracksters_cff.py
@@ -16,7 +16,6 @@ filteredLayerClustersSimTracksters = _filteredLayerClustersProducer.clone(
 )
 
 ticlSimTracksters = _trackstersFromSimClustersProducer.clone(
-    # filtered_mask = cms.InputTag("filteredLayerClustersSimTracksters", "ticlSimTracksters"),
 )
 
 ticlMultiClustersFromSimTracksters = _multiClustersFromTrackstersProducer.clone(

--- a/RecoHGCal/TICL/python/SimTracksters_cff.py
+++ b/RecoHGCal/TICL/python/SimTracksters_cff.py
@@ -18,6 +18,11 @@ filteredLayerClustersSimTracksters = _filteredLayerClustersProducer.clone(
 ticlSimTracksters = _trackstersFromSimClustersProducer.clone(
 )
 
+from Configuration.ProcessModifiers.premix_stage2_cff import premix_stage2
+premix_stage2.toModify(ticlSimTracksters,
+    simclusters = "mixData:MergedCaloTruth"
+)
+
 ticlMultiClustersFromSimTracksters = _multiClustersFromTrackstersProducer.clone(
     Tracksters = "ticlSimTracksters"
 )

--- a/RecoHGCal/TICL/python/SimTracksters_cff.py
+++ b/RecoHGCal/TICL/python/SimTracksters_cff.py
@@ -1,6 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
 from RecoHGCal.TICL.trackstersFromSimClustersProducer_cfi import trackstersFromSimClustersProducer as _trackstersFromSimClustersProducer
+from RecoHGCal.TICL.multiClustersFromTrackstersProducer_cfi import multiClustersFromTrackstersProducer as _multiClustersFromTrackstersProducer
 
 
 # CA - PATTERN RECOGNITION
@@ -8,6 +9,9 @@ from RecoHGCal.TICL.trackstersFromSimClustersProducer_cfi import trackstersFromS
 ticlSimTracksters = _trackstersFromSimClustersProducer.clone(
 )
 
+ticlMultiClustersFromSimTracksters = _multiClustersFromTrackstersProducer.clone(
+    Tracksters = "ticlSimTracksters"
+)
 
-ticlSimTrackstersTask = cms.Task(ticlSimTracksters,)
+ticlSimTrackstersTask = cms.Task(ticlSimTracksters, ticlMultiClustersFromSimTracksters)
 

--- a/RecoHGCal/TICL/python/SimTracksters_cff.py
+++ b/RecoHGCal/TICL/python/SimTracksters_cff.py
@@ -1,0 +1,13 @@
+import FWCore.ParameterSet.Config as cms
+
+from RecoHGCal.TICL.trackstersFromSimClustersProducer_cfi import trackstersFromSimClustersProducer as _trackstersFromSimClustersProducer
+
+
+# CA - PATTERN RECOGNITION
+
+ticlSimTracksters = _trackstersFromSimClustersProducer.clone(
+)
+
+
+ticlSimTrackstersTask = cms.Task(ticlSimTracksters,)
+

--- a/RecoHGCal/TICL/python/iterativeTICL_cff.py
+++ b/RecoHGCal/TICL/python/iterativeTICL_cff.py
@@ -5,7 +5,6 @@ from RecoHGCal.TICL.TrkEMStep_cff import *
 from RecoHGCal.TICL.TrkStep_cff import *
 from RecoHGCal.TICL.EMStep_cff import *
 from RecoHGCal.TICL.HADStep_cff import *
-from RecoHGCal.TICL.SimTracksters_cff import *
 
 from RecoHGCal.TICL.ticlLayerTileProducer_cfi import ticlLayerTileProducer
 from RecoHGCal.TICL.pfTICLProducer_cfi import pfTICLProducer as _pfTICLProducer

--- a/RecoHGCal/TICL/python/iterativeTICL_cff.py
+++ b/RecoHGCal/TICL/python/iterativeTICL_cff.py
@@ -5,6 +5,8 @@ from RecoHGCal.TICL.TrkEMStep_cff import *
 from RecoHGCal.TICL.TrkStep_cff import *
 from RecoHGCal.TICL.EMStep_cff import *
 from RecoHGCal.TICL.HADStep_cff import *
+from RecoHGCal.TICL.SimTracksters_cff import *
+
 from RecoHGCal.TICL.ticlLayerTileProducer_cfi import ticlLayerTileProducer
 from RecoHGCal.TICL.pfTICLProducer_cfi import pfTICLProducer as _pfTICLProducer
 from RecoHGCal.TICL.trackstersMergeProducer_cfi import trackstersMergeProducer as _trackstersMergeProducer

--- a/SimDataFormats/Associations/interface/LayerClusterToSimClusterAssociator.h
+++ b/SimDataFormats/Associations/interface/LayerClusterToSimClusterAssociator.h
@@ -19,8 +19,11 @@ namespace hgcal {
     LayerClusterToSimClusterAssociator() = default;
     LayerClusterToSimClusterAssociator(LayerClusterToSimClusterAssociator &&) = default;
     LayerClusterToSimClusterAssociator &operator=(LayerClusterToSimClusterAssociator &&) = default;
-    ~LayerClusterToSimClusterAssociator() = default;
+    LayerClusterToSimClusterAssociator(const LayerClusterToSimClusterAssociator &) = delete;  // stop default
 
+    ~LayerClusterToSimClusterAssociator() = default;
+    const LayerClusterToSimClusterAssociator &operator=(const LayerClusterToSimClusterAssociator &) =
+        delete;  // stop default
     // ---------- const member functions ---------------------
     /// Associate a LayerCluster to SimClusters
     hgcal::RecoToSimCollectionWithSimClusters associateRecoToSim(const edm::Handle<reco::CaloClusterCollection> &cCCH,
@@ -35,11 +38,6 @@ namespace hgcal {
     }
 
   private:
-    LayerClusterToSimClusterAssociator(const LayerClusterToSimClusterAssociator &) = delete;  // stop default
-
-    const LayerClusterToSimClusterAssociator &operator=(const LayerClusterToSimClusterAssociator &) =
-        delete;  // stop default
-
     // ---------- member data --------------------------------
     std::unique_ptr<LayerClusterToSimClusterAssociatorBaseImpl> m_impl;
   };

--- a/Validation/Configuration/python/globalValidation_cff.py
+++ b/Validation/Configuration/python/globalValidation_cff.py
@@ -198,7 +198,7 @@ globalValidationHCALOnly = cms.Sequence(
 )
 
 globalValidationHGCal = cms.Sequence(hgcalValidation)
-globalPrevalidationHGCal = cms.Sequence(hgcalAssociators)
+globalPrevalidationHGCal = cms.Sequence(hgcalAssociators, ticlSimTrackstersTask)
 
 globalValidationMTD = cms.Sequence()
 

--- a/Validation/Configuration/python/hgcalSimValid_cff.py
+++ b/Validation/Configuration/python/hgcalSimValid_cff.py
@@ -10,6 +10,7 @@ from Validation.HGCalValidation.simhitValidation_cff    import *
 from Validation.HGCalValidation.digiValidation_cff      import *
 from Validation.HGCalValidation.rechitValidation_cff    import *
 from Validation.HGCalValidation.hgcalHitValidation_cfi  import *
+from RecoHGCal.TICL.SimTracksters_cff import *
 
 from Validation.HGCalValidation.HGCalValidator_cfi import hgcalValidator
 from Validation.RecoParticleFlow.PFJetValidation_cff import pfJetValidation1 as _hgcalPFJetValidation

--- a/Validation/HGCalValidation/python/HGCalValidator_cfi.py
+++ b/Validation/HGCalValidation/python/HGCalValidator_cfi.py
@@ -11,6 +11,7 @@ from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
 from RecoHGCal.TICL.iterativeTICL_cff import ticlIterLabels, ticlIterLabelsMerge
 
 labelMcl = [cms.InputTag("ticlMultiClustersFromTracksters"+iteration) for iteration in ticlIterLabelsMerge]
+labelMcl.extend(["ticlMultiClustersFromSimTracksters"])
 lcInputMask = [cms.InputTag("ticlTracksters"+iteration) for iteration in ticlIterLabels]
 
 hgcalValidator = DQMEDAnalyzer(

--- a/Validation/HGCalValidation/python/HGCalValidator_cfi.py
+++ b/Validation/HGCalValidation/python/HGCalValidator_cfi.py
@@ -13,7 +13,7 @@ from RecoHGCal.TICL.iterativeTICL_cff import ticlIterLabels, ticlIterLabelsMerge
 labelMcl = [cms.InputTag("ticlMultiClustersFromTracksters"+iteration) for iteration in ticlIterLabelsMerge]
 labelMcl.extend(["ticlMultiClustersFromSimTracksters"])
 lcInputMask = [cms.InputTag("ticlTracksters"+iteration) for iteration in ticlIterLabels]
-
+lcInputMask.extend(["ticlSimTracksters"])
 hgcalValidator = DQMEDAnalyzer(
     "HGCalValidator",
 

--- a/Validation/HGCalValidation/python/PostProcessorHGCAL_cfi.py
+++ b/Validation/HGCalValidation/python/PostProcessorHGCAL_cfi.py
@@ -35,6 +35,7 @@ eff_simclusters.extend(["merge_eta_layer{:02d} 'LayerCluster Merge Rate vs #eta 
 eff_simclusters.extend(["merge_phi_layer{:02d} 'LayerCluster Merge Rate vs #phi Layer{:02d} in z-' NumMerge_LayerCluster_in_SimCluster_Phi_perlayer{:02d} Denom_LayerCluster_in_SimCluster_Phi_perlayer{:02d}".format(i, i%maxlayerzm+1, i, i) if (i<maxlayerzm) else "merge_phi_layer{:02d} 'LayerCluster Merge Rate vs #phi Layer{:02d} in z+' NumMerge_LayerCluster_in_SimCluster_Phi_perlayer{:02d} Denom_LayerCluster_in_SimCluster_Phi_perlayer{:02d}".format(i, i%maxlayerzm+1, i, i) for i in range(maxlayerzp) ])
 
 subdirsSim = ['HGCAL/HGCalValidator/simClusters/ticlTracksters'+iteration+'/' for iteration in ticlIterLabelsMerge]
+subdirsSim.extend(['HGCAL/HGCalValidator/simClusters/ticlSimTracksters'])
 postProcessorHGCALsimclusters= DQMEDHarvester('DQMGenericClient',
     subDirs = cms.untracked.vstring(subdirsSim),
     efficiency = cms.vstring(eff_simclusters),
@@ -53,7 +54,7 @@ eff_multiclusters.extend(["fake_phi 'MultiCluster Fake Rate vs #phi'  Num_MultiC
 eff_multiclusters.extend(["merge_eta 'MultiCluster Merge Rate vs #eta' NumMerge_MultiCluster_Eta Denom_MultiCluster_Eta"])
 eff_multiclusters.extend(["merge_phi 'MultiCluster Merge Rate vs #phi' NumMerge_MultiCluster_Phi Denom_MultiCluster_Phi"])
 
-subdirsMult = ['HGCAL/HGCalValidator/hgcalMultiClusters/']
+subdirsMult = ['HGCAL/HGCalValidator/hgcalMultiClusters/','HGCAL/HGCalValidator/ticlMultiClustersFromSimTracksters/']
 subdirsMult.extend('HGCAL/HGCalValidator/ticlMultiClustersFromTracksters'+iteration+'/' for iteration in ticlIterLabelsMerge)
 
 postProcessorHGCALmulticlusters = DQMEDHarvester('DQMGenericClient',

--- a/Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py
+++ b/Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py
@@ -53,8 +53,8 @@ def main(opts):
 
     #layerClusters
     if (opts.collection == layerClustersGeneralLabel):
-	hgclayclus = [hgcalPlots.hgcalLayerClustersPlotter]
-	hgcalPlots.append_hgcalLayerClustersPlots("hgcalLayerClusters", "Layer Clusters", extendedFlag)
+        hgclayclus = [hgcalPlots.hgcalLayerClustersPlotter]
+        hgcalPlots.append_hgcalLayerClustersPlots("hgcalLayerClusters", "Layer Clusters", extendedFlag)
         val.doPlots(hgclayclus, plotterDrawArgs=drawArgs)
     #simClusters
     elif (opts.collection == simClustersGeneralLabel):
@@ -91,7 +91,7 @@ def main(opts):
         val.doPlots(hgcaloPart, plotterDrawArgs=drawArgs)
     #hitValidation
     elif (opts.collection == hitValidationLabel):
-    	hgchit = [hgcalPlots.hgcalHitPlotter]
+        hgchit = [hgcalPlots.hgcalHitPlotter]
         hgcalPlots.append_hgcalHitsPlots('HGCalSimHitsV', "Simulated Hits")
         hgcalPlots.append_hgcalHitsPlots('HGCalRecHitsV', "Reconstruced Hits")
         hgcalPlots.append_hgcalDigisPlots('HGCalDigisV', "Digis")
@@ -113,11 +113,11 @@ def main(opts):
         val.doPlots(hgcaloPart, plotterDrawArgs=drawArgs)
 
         #hits
-    	hgchit = [hgcalPlots.hgcalHitPlotter]
+        hgchit = [hgcalPlots.hgcalHitPlotter]
         hgcalPlots.append_hgcalHitsPlots('HGCalSimHitsV', "Simulated Hits")
         hgcalPlots.append_hgcalHitsPlots('HGCalRecHitsV', "Reconstruced Hits")
         hgcalPlots.append_hgcalDigisPlots('HGCalDigisV', "Digis")
-    	val.doPlots(hgchit, plotterDrawArgs=drawArgs)   
+        val.doPlots(hgchit, plotterDrawArgs=drawArgs)   
 
         #calib
         hgchitcalib = [hgcalPlots.hgcalHitCalibPlotter]
@@ -129,10 +129,10 @@ def main(opts):
             hgcalPlots.append_hgcalSimClustersPlots(i_iter, i_iter)
         val.doPlots(hgcsimclus, plotterDrawArgs=drawArgs)
 
-	#layer clusters
-	hgclayclus = [hgcalPlots.hgcalLayerClustersPlotter]
-	hgcalPlots.append_hgcalLayerClustersPlots("hgcalLayerClusters", "Layer Clusters", extendedFlag)
-	val.doPlots(hgclayclus, plotterDrawArgs=drawArgs)
+        #layer clusters
+        hgclayclus = [hgcalPlots.hgcalLayerClustersPlotter] 
+        hgcalPlots.append_hgcalLayerClustersPlots("hgcalLayerClusters", "Layer Clusters", extendedFlag)
+        val.doPlots(hgclayclus, plotterDrawArgs=drawArgs)
 
         #multiclusters
         hgcmulticlus = [hgcalPlots.hgcalMultiClustersPlotter]

--- a/Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py
+++ b/Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py
@@ -9,11 +9,12 @@ from Validation.RecoTrack.plotting.validation import SeparateValidation, SimpleV
 import Validation.HGCalValidation.hgcalPlots as hgcalPlots
 import Validation.RecoTrack.plotting.plotting as plotting
 
-simClustersIters = ["ClusterLevel","ticlTrackstersTrkEM","ticlTrackstersEM","ticlTrackstersTrk","ticlTrackstersHAD"]
+simClustersIters = ["ClusterLevel","ticlTrackstersTrkEM","ticlTrackstersEM","ticlTrackstersTrk","ticlTrackstersHAD","ticlSimTracksters"]
 
 trackstersIters = ["ticlMultiClustersFromTrackstersMerge", "ticlMultiClustersFromTrackstersMIP",
                    "ticlMultiClustersFromTrackstersTrk","ticlMultiClustersFromTrackstersTrkEM",
-                   "ticlMultiClustersFromTrackstersEM", "ticlMultiClustersFromTrackstersHAD"]
+                   "ticlMultiClustersFromTrackstersEM", "ticlMultiClustersFromTrackstersHAD",
+                   "ticlMultiClustersFromSimTracksters"]
 
 simClustersGeneralLabel = 'simClusters'
 layerClustersGeneralLabel = 'hgcalLayerClusters'


### PR DESCRIPTION
#### PR description:
This PR introduces SimTracksters. 
SimTracksters are Tracksters objects containing layerclusters that are associated to the same SimClusters. 
They are run in the HGCal Validation Sequence and kept only in FEVT. 
They will be useful for benchmarking the pattern recognition as they will produce the best possible tracksters directly from simulation. 

#### PR validation:
used wf `23290.0`

@rovere @cseez @ebrondol @lecriste fyi