### PR TITLE
Introduce PixelTopologyMap

### DIFF
--- a/Geometry/TrackerGeometryBuilder/interface/PixelTopologyMap.h
+++ b/Geometry/TrackerGeometryBuilder/interface/PixelTopologyMap.h
@@ -1,0 +1,57 @@
+#ifndef Geometry_TrackerGeometryBuilder_PixelTopologyMap_H
+#define Geometry_TrackerGeometryBuilder_PixelTopologyMap_H
+
+// system include files
+#include <map>
+#include <memory>
+#include <iostream>
+#include <iomanip>  // std::setw
+
+// user include files
+#include "Geometry/CommonDetUnit/interface/PixelGeomDetUnit.h"
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+#include "DataFormats/SiPixelDetId/interface/PixelSubdetector.h"
+#include "TrackerGeometry.h"
+
+/**
+ * A specific Pixel Tracker class to determine the number of ladders / modules in PXB
+   and number of blades/modules in PXF
+ */
+class PixelTopologyMap {
+public:
+  PixelTopologyMap(const TrackerGeometry* geom, const TrackerTopology* topo)
+      : m_trackerTopo{topo}, m_trackerGeom{geom} {
+    // build the maps
+    buildTopologyMaps();
+  }
+
+  ~PixelTopologyMap() = default;
+
+  // getter methods
+
+  inline const unsigned getPXBLadders(unsigned int lay) const { return m_pxbMap.at(lay).first; }
+  inline const unsigned getPXBModules(unsigned int lay) const { return m_pxbMap.at(lay).second; }
+  inline const unsigned getPXFBlades(int disk) const { return m_pxfMap.at(std::abs(disk)).first; }
+  inline const unsigned getPXFModules(int disk) const { return m_pxfMap.at(std::abs(disk)).second; }
+
+  // printout
+  void printAll(std::ostream& os) const;
+
+private:
+  void buildTopologyMaps();
+
+  const TrackerTopology* m_trackerTopo;
+  const TrackerGeometry* m_trackerGeom;
+
+  std::map<unsigned, std::pair<unsigned, unsigned>> m_pxbMap;
+  std::map<unsigned, std::pair<unsigned, unsigned>> m_pxfMap;
+};
+
+std::ostream& operator<<(std::ostream& os, PixelTopologyMap map) {
+  std::stringstream ss;
+  map.printAll(ss);
+  os << ss.str();
+  return os;
+}
+
+#endif

--- a/Geometry/TrackerGeometryBuilder/src/PixelTopologyMap.cc
+++ b/Geometry/TrackerGeometryBuilder/src/PixelTopologyMap.cc
@@ -1,0 +1,75 @@
+#include "Geometry/TrackerGeometryBuilder/interface/PixelTopologyMap.h"
+
+void PixelTopologyMap::printAll(std::ostream& os) const {
+  for (unsigned int i = 1; i <= m_pxbMap.size(); i++) {
+    os << "PXB layer " << std::setw(2) << i << " has: " << std::setw(2) << getPXBLadders(i) << " ladders and "
+       << std::setw(2) << getPXBModules(i) << " modules" << std::endl;
+  }
+
+  for (unsigned int j = 1; j <= m_pxfMap.size(); j++) {
+    os << "PXF disk  " << std::setw(2) << j << " has: " << std::setw(2) << getPXFBlades(j) << " blades  and "
+       << std::setw(2) << getPXFModules(j) << " modules" << std::endl;
+  }
+}
+
+void PixelTopologyMap::buildTopologyMaps() {
+  // build barrel
+  const auto& nlay = m_trackerGeom->numberOfLayers(PixelSubdetector::PixelBarrel);
+  std::vector<unsigned> maxLadder, maxModule;
+  maxLadder.resize(nlay);
+  maxModule.resize(nlay);
+  for (unsigned int i = 1; i <= nlay; i++) {
+    maxLadder.push_back(0);
+    maxModule.push_back(0);
+  }
+
+  for (auto det : m_trackerGeom->detsPXB()) {
+    const PixelGeomDetUnit* pixelDet = dynamic_cast<const PixelGeomDetUnit*>(det);
+
+    const auto& layer = m_trackerTopo->pxbLayer(pixelDet->geographicalId());
+    const auto& ladder = m_trackerTopo->pxbLadder(pixelDet->geographicalId());
+    const auto& module = m_trackerTopo->pxbModule(pixelDet->geographicalId());
+
+    if (ladder > maxLadder[layer]) {
+      maxLadder[layer] = ladder;
+    }
+
+    if (module > maxModule[layer]) {
+      maxModule[layer] = module;
+    }
+  }
+
+  for (unsigned int i = 1; i <= nlay; i++) {
+    m_pxbMap[i] = std::make_pair(maxLadder[i], maxModule[i]);
+  }
+
+  // build endcaps
+  const auto& ndisk = m_trackerGeom->numberOfLayers(PixelSubdetector::PixelEndcap);
+  std::vector<unsigned> maxBlade, maxPXFModule;
+  maxBlade.resize(ndisk);
+  maxPXFModule.resize(ndisk);
+  for (unsigned int i = 1; i <= ndisk; i++) {
+    maxBlade.push_back(0);
+    maxPXFModule.push_back(0);
+  }
+
+  for (auto det : m_trackerGeom->detsPXF()) {
+    const PixelGeomDetUnit* pixelDet = dynamic_cast<const PixelGeomDetUnit*>(det);
+
+    const auto& disk = m_trackerTopo->pxfDisk(pixelDet->geographicalId());
+    const auto& blade = m_trackerTopo->pxfBlade(pixelDet->geographicalId());
+    const auto& pxf_module = m_trackerTopo->pxfModule(pixelDet->geographicalId());
+
+    if (blade > maxBlade[disk]) {
+      maxBlade[disk] = blade;
+    }
+
+    if (pxf_module > maxPXFModule[disk]) {
+      maxPXFModule[disk] = pxf_module;
+    }
+  }
+
+  for (unsigned int i = 1; i <= ndisk; i++) {
+    m_pxfMap[i] = std::make_pair(maxBlade[i], maxPXFModule[i]);
+  }
+}

--- a/Geometry/TrackerGeometryBuilder/test/BuildFile.xml
+++ b/Geometry/TrackerGeometryBuilder/test/BuildFile.xml
@@ -34,6 +34,12 @@
   <flags EDM_PLUGIN="1"/>
 </library>
 
+<library file="PixelTopologyMapTest.cc" name="PixelTopologyMapTest">
+  <use name="DataFormats/TrackerCommon"/>
+  <use name="Geometry/Records"/>
+  <flags EDM_PLUGIN="1"/>
+</library>
+
 <bin file="phase1PixelTopology_t.cpp"/>
 
 <bin file="runTests.cpp" name="GeometryTrackerGeometryBuilderTestDriver">

--- a/Geometry/TrackerGeometryBuilder/test/PixelTopologyMapTest.cc
+++ b/Geometry/TrackerGeometryBuilder/test/PixelTopologyMapTest.cc
@@ -1,0 +1,95 @@
+// -*- C++ -*-
+//
+// Package:    Geometry/TrackerGeometryBuilder
+// Class:      PixelTopologyMapTest
+//
+/**\class PixelTopologyMapTest PixelTopologyMapTest.cc Geometry/TrackerGeometryBuilder/test/PixelTopologyMapTest.cc
+
+ Description: [one line class summary]
+
+ Implementation:
+     [Notes on implementation]
+*/
+//
+// Original Author:  Marco Musich
+//         Created:  Wed, 31 Mar 2021 11:01:16 GMT
+//
+//
+
+// system include files
+#include <memory>
+
+// user include files
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/global/EDAnalyzer.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+
+#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
+#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+#include "Geometry/Records/interface/TrackerTopologyRcd.h"
+#include "Geometry/CommonDetUnit/interface/PixelGeomDetUnit.h"
+#include "Geometry/TrackerGeometryBuilder/interface/PixelTopologyMap.h"
+
+//
+// class declaration
+//
+
+class PixelTopologyMapTest : public edm::global::EDAnalyzer<> {
+public:
+  explicit PixelTopologyMapTest(const edm::ParameterSet&);
+  ~PixelTopologyMapTest() override = default;
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+private:
+  void analyze(edm::StreamID, edm::Event const& iEvent, edm::EventSetup const& iSetup) const override;
+
+  // ----------member data ---------------------------
+  const edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> geomEsToken_;
+  const edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> topoToken_;
+};
+
+//
+// constructors and destructor
+//
+PixelTopologyMapTest::PixelTopologyMapTest(const edm::ParameterSet& iConfig)
+    : geomEsToken_(esConsumes()), topoToken_(esConsumes()) {}
+
+//
+// member functions
+//
+
+// ------------ method called for each event  ------------
+void PixelTopologyMapTest::analyze(edm::StreamID, edm::Event const& iEvent, edm::EventSetup const& iSetup) const {
+  using namespace edm;
+
+  // get the Tracker geometry from event setup
+  const TrackerGeometry* pDD = &iSetup.getData(geomEsToken_);
+  const TrackerTopology* tTopo = &iSetup.getData(topoToken_);
+
+  if ((pDD->isThere(GeomDetEnumerators::P2PXB)) || (pDD->isThere(GeomDetEnumerators::P2PXEC))) {
+    edm::LogPrint("PixelTopologyMapTest") << "===== Testing Phase-2 Pixel Tracker geometry =====" << std::endl;
+  } else if ((pDD->isThere(GeomDetEnumerators::P1PXB)) || (pDD->isThere(GeomDetEnumerators::P1PXEC))) {
+    edm::LogPrint("PixelTopologyMapTest") << "===== Testing Phase-1 Pixel Tracker geometry =====" << std::endl;
+  } else {
+    edm::LogPrint("PixelTopologyMapTest") << "===== Testing Phase-0 Pixel Tracker geometry =====" << std::endl;
+  }
+
+  PixelTopologyMap PTMap = PixelTopologyMap(pDD, tTopo);
+  edm::LogPrint("PixelTopologyMapTest") << PTMap << std::endl;
+}
+
+// ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
+void PixelTopologyMapTest::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  descriptions.addDefault(desc);
+}
+
+//define this as a plug-in
+DEFINE_FWK_MODULE(PixelTopologyMapTest);

--- a/Geometry/TrackerGeometryBuilder/test/python/testPixelTopologyMapTest_cfg.py
+++ b/Geometry/TrackerGeometryBuilder/test/python/testPixelTopologyMapTest_cfg.py
@@ -1,0 +1,66 @@
+import FWCore.ParameterSet.Config as cms
+import FWCore.ParameterSet.VarParsing as VarParsing
+
+process = cms.Process("TopologyAnalysis")
+options = VarParsing.VarParsing("analysis")
+
+options.register ('globalTag',
+                  "auto:run2_data",
+                  VarParsing.VarParsing.multiplicity.singleton, # singleton or list
+                  VarParsing.VarParsing.varType.string,          # string, int, or float
+                 "GlobalTag")
+
+options.register ('runNumber',
+                  1,
+                  VarParsing.VarParsing.multiplicity.singleton, # singleton or list
+                  VarParsing.VarParsing.varType.int,          # string, int, or float
+                  "run number")
+
+options.parseArguments()
+
+###################################################################
+# Message logger service
+###################################################################
+process.load("FWCore.MessageService.MessageLogger_cfi")
+process.MessageLogger.cerr.FwkReport.reportEvery = 1
+
+###################################################################
+# Geometry producer and standard includes
+###################################################################
+process.load("Configuration.StandardSequences.Services_cff")
+
+if 'phase2' in options.globalTag:
+    process.load("Configuration.Geometry.GeometryExtended2026D49_cff")
+    process.load("Configuration.Geometry.GeometryExtended2026D49Reco_cff")
+else:
+    process.load("Configuration.StandardSequences.GeometryRecoDB_cff")
+
+####################################################################
+# Get the GlogalTag
+####################################################################
+process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, options.globalTag, '')
+
+###################################################################
+# Empty Source
+###################################################################
+process.source = cms.Source("EmptySource",
+                            firstRun = cms.untracked.uint32(options.runNumber),
+                            numberEventsInRun = cms.untracked.uint32(1),
+                            )
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(1)
+)
+
+###################################################################
+# The analysis module
+###################################################################
+process.myanalysis = cms.EDAnalyzer("PixelTopologyMapTest")
+
+###################################################################
+# Path
+###################################################################
+process.p1 = cms.Path(process.myanalysis)
+

--- a/Geometry/TrackerGeometryBuilder/test/runTest.sh
+++ b/Geometry/TrackerGeometryBuilder/test/runTest.sh
@@ -19,6 +19,9 @@ do
   (cmsRun $entry) || die "Failure using cmsRun $entry" $?
 done
 
+cmsRun ${LOCAL_TEST_DIR}/python/testPixelTopologyMapTest_cfg.py runNumber=300000  || die "Failure using cmsRun testPixelTopologyMapTest_cfg.py runNumber=300000" $?
+cmsRun ${LOCAL_TEST_DIR}/python/testPixelTopologyMapTest_cfg.py globalTag=auto:phase2_realistic_T15  || die "Failure using cmsRun testPixelTopologyMapTest_cfg.py globalTag=auto:phase2_realistic_T15" $?
+
 FILE1=trackerParametersDD4hep.log
 FILE2=trackerParametersDDD.log
 FILE3=diff.log


### PR DESCRIPTION
#### PR description:

For calibration + monitoring purposes it is at times useful to know the number of ladders / modules in a pixel barrel layer and blades / modules in a pixel forward disk at cmsRun runtime instead that of configuration time, while being able to support at the same time Phase-0 / Phase-1 and Phase-2 Tracker Geometries. 
While it is possible to get this information by combining the `TrackerTopology` and `TrackerGeometry` ES objects, it is nice to have the information combined in a unique centralized object. 
It might be possible at a later stage to put this in the ES itself.
I am open to suggestion for a better naming.

#### PR validation:

Run the (augmented) unit tests with `scramv1 b runtests`

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Not a backport, no backport needed.
cc: @tvami 
