### PR TITLE
move #defines into static constexprs inside class to avoid conflicts in cmssw

### DIFF
--- a/CalibCalorimetry/EcalLaserAnalyzer/interface/TFParams.h
+++ b/CalibCalorimetry/EcalLaserAnalyzer/interface/TFParams.h
@@ -37,7 +37,11 @@ matrice fill_mat_int(matrice, matrice, matrice);
 
 class TFParams : public TObject {
 public:
-  enum { dimmat = 30, dimout = 10, nbmax_cell = 1000, SDIM2 = 10, PLSHDIM = 650 };
+  static constexpr unsigned int dimmat = 30;
+  static constexpr unsigned int dimout = 10;
+  static constexpr unsigned int nbmax_cell = 1000;
+  static constexpr int SDIM2 = 10;
+  static constexpr int PLSHDIM = 650;
 
 private:
   int ns;        // number of samples

--- a/CalibCalorimetry/EcalLaserAnalyzer/interface/TFParams.h
+++ b/CalibCalorimetry/EcalLaserAnalyzer/interface/TFParams.h
@@ -23,10 +23,7 @@
 #include "TVirtualX.h"
 #include "TObject.h"
 //#include "TMatrixD.h"
-#define SDIM2 10    /* number of samples for cristal */
-#define PLSHDIM 650 /* size of the pulse shape array */
-                    //double pulseShape( Double_t x[1], Double_t par[4] ) ;
-                    //
+
 struct matrice {
   int nb_lignes;
   int nb_colonnes;
@@ -38,11 +35,10 @@ matrice cree_mat_prod(matrice, matrice);
 void fill_mat(matrice, matrice);
 matrice fill_mat_int(matrice, matrice, matrice);
 
-#define dimmat 30
-#define dimout 10
-#define nbmax_cell 1000
-
 class TFParams : public TObject {
+public:
+  enum { dimmat = 30, dimout = 10, nbmax_cell = 1000, SDIM2 = 10, PLSHDIM = 650 };
+
 private:
   int ns;        // number of samples
   int nsmin;     // beginning of fit
@@ -57,6 +53,8 @@ private:
   int METHODE;
 
 public:
+  /* number of samples for cristal */
+  /* size of the pulse shape array */
   TFParams(int size = SDIM2, int size_sh = PLSHDIM);
   ~TFParams() override{};
   double fitpj(double **, double *, double **, double noise_val, int debug);

--- a/CalibCalorimetry/EcalLaserAnalyzer/interface/TMCReader.h
+++ b/CalibCalorimetry/EcalLaserAnalyzer/interface/TMCReader.h
@@ -5,11 +5,11 @@
 
 class TMCReader : public TObject {
 public:
-  static constexpr unsigned int FNPNMAX = 10; 
-  static constexpr unsigned int FNLMODNMAX = 9; 
-  static constexpr unsigned int FNCHANMAX = 200; 
-  static constexpr unsigned int fNpns = 2; 
-  static constexpr unsigned int fNchans = 400; 
+  static constexpr unsigned int FNPNMAX = 10;
+  static constexpr unsigned int FNLMODNMAX = 9;
+  static constexpr unsigned int FNCHANMAX = 200;
+  static constexpr unsigned int fNpns = 2;
+  static constexpr unsigned int fNchans = 400;
   static constexpr unsigned int fNbins = 102;
 
 private:

--- a/CalibCalorimetry/EcalLaserAnalyzer/interface/TMCReader.h
+++ b/CalibCalorimetry/EcalLaserAnalyzer/interface/TMCReader.h
@@ -3,69 +3,57 @@
 
 #include "TObject.h"
 
-#define FNPNMAX 10
-#define FNLMODNMAX 9
-#define FNCHANMAX 200
+class TMCReader : public TObject {
+public:
+  enum { FNPNMAX = 10, FNLMODNMAX = 9, FNCHANMAX = 200, fNpns = 2, fNchans = 400, fNbins = 102 };
 
-#define fNpns 2
-#define fNchans 400
-#define fNbins 102
-
-class TMCReader: public TObject 
-{
-
- private:	
-
-  int smN,nlmodN,arr[FNLMODNMAX];
-  long int timestart,timestop;
-  float evts[fNpns+1][FNCHANMAX+FNPNMAX];
-  double min[fNpns+1][FNCHANMAX+FNPNMAX],max[fNpns+1][FNCHANMAX+FNPNMAX];
-  double val[fNpns+1][FNCHANMAX+FNPNMAX],sig[fNpns+1][FNCHANMAX+FNPNMAX];
-  double wbin[fNpns+1][FNCHANMAX+FNPNMAX];
+private:
+  int smN, nlmodN, arr[FNLMODNMAX];
+  long int timestart, timestop;
+  float evts[fNpns + 1][FNCHANMAX + FNPNMAX];
+  double min[fNpns + 1][FNCHANMAX + FNPNMAX], max[fNpns + 1][FNCHANMAX + FNPNMAX];
+  double val[fNpns + 1][FNCHANMAX + FNPNMAX], sig[fNpns + 1][FNCHANMAX + FNPNMAX];
+  double wbin[fNpns + 1][FNCHANMAX + FNPNMAX];
   float sumprob;
 
-  int smlocal,color,lmdir,part;
+  int smlocal, color, lmdir, part;
 
   void init();
 
- public:
+public:
   // Default Constructor, mainly for Root
   TMCReader();
 
   // Destructor: Does nothing
   virtual ~TMCReader();
 
-  void validMCLaser(int,int);
-  void getMCLaserData(int,int);
+  void validMCLaser(int, int);
+  void getMCLaserData(int, int);
   void validMCPulse(int);
   void getMCPulseData(int);
 
-  int getSMNumb() {return smN;}
-  int getNbOflmodN() {return nlmodN;}
-  int getlmodN(int indx) {return arr[indx];}
-  int getstartime() {return timestart;}
-  int getstoptime() {return timestop;}
-  int getnevts(int norm) {return (int) evts[norm][0];}
+  int getSMNumb() { return smN; }
+  int getNbOflmodN() { return nlmodN; }
+  int getlmodN(int indx) { return arr[indx]; }
+  int getstartime() { return timestart; }
+  int getstoptime() { return timestop; }
+  int getnevts(int norm) { return (int)evts[norm][0]; }
 
-  void setsmlocal(int sm) {smlocal=sm;}
-  void setcolor(int c) {color=c;}
-  void setdirlmodN(int lmp) {lmdir=lmp;}
-  void setpartition(int p) {part=p;}
+  void setsmlocal(int sm) { smlocal = sm; }
+  void setcolor(int c) { color = c; }
+  void setdirlmodN(int lmp) { lmdir = lmp; }
+  void setpartition(int p) { part = p; }
 
-  void changedatatoraw(int,int,int);
-  void changedatatopeak(int,int,int);
+  void changedatatoraw(int, int, int);
+  void changedatatopeak(int, int, int);
 
-  void printeinjData(int,int,int);
-  void printlaserData(int,int,int,int);
-  void printlaserpeak(int,int,int);
-  void printnormlaserData(int,int,int,int,int);
-  void printnormlaserpeak(int,int,int,int);
-
+  void printeinjData(int, int, int);
+  void printlaserData(int, int, int, int);
+  void printlaserpeak(int, int, int);
+  void printnormlaserData(int, int, int, int, int);
+  void printnormlaserpeak(int, int, int, int);
 
   //  ClassDef(TMCReader,1)
 };
 
 #endif
-
-
-

--- a/CalibCalorimetry/EcalLaserAnalyzer/interface/TMCReader.h
+++ b/CalibCalorimetry/EcalLaserAnalyzer/interface/TMCReader.h
@@ -5,7 +5,12 @@
 
 class TMCReader : public TObject {
 public:
-  enum { FNPNMAX = 10, FNLMODNMAX = 9, FNCHANMAX = 200, fNpns = 2, fNchans = 400, fNbins = 102 };
+  static constexpr unsigned int FNPNMAX = 10; 
+  static constexpr unsigned int FNLMODNMAX = 9; 
+  static constexpr unsigned int FNCHANMAX = 200; 
+  static constexpr unsigned int fNpns = 2; 
+  static constexpr unsigned int fNchans = 400; 
+  static constexpr unsigned int fNbins = 102;
 
 private:
   int smN, nlmodN, arr[FNLMODNMAX];

--- a/CalibCalorimetry/EcalLaserAnalyzer/interface/TMConfig.h
+++ b/CalibCalorimetry/EcalLaserAnalyzer/interface/TMConfig.h
@@ -5,17 +5,16 @@
 
 class TMConfig : public TObject {
 public:
-  enum {
-    fNsmNmax = 36,  //number of SM
-    fNlmodN = 9,    //number of lmodN in a SM
-    fNmem = 10,     //number of PNs in a MEM
-    fNmodN = 4,     //number of modN in a SM
-    fNtt = 68,      //number of trigger towers in a SM
-    fNmax = 8,
-    fNburmax = 3,
-    fNseqmax = 3,
-    fNcolors = 6  //number of laser colors
-  };
+
+  static constexpr unsigned int fNsmNmax = 36;  //number of SM
+  static constexpr unsigned int fNlmodN = 9;    //number of lmodN in a SM
+  static constexpr unsigned int fNmem = 10;     //number of PNs in a MEM
+  static constexpr unsigned int fNmodN = 4;     //number of modN in a SM
+  static constexpr unsigned int fNtt = 68;      //number of trigger towers in a SM
+  static constexpr unsigned int fNmax = 8;
+  static constexpr unsigned int fNburmax = 3;
+  static constexpr unsigned int fNseqmax = 3;
+  static constexpr unsigned int fNcolors = 6;  //number of laser colors
 
 private:
   int smin;

--- a/CalibCalorimetry/EcalLaserAnalyzer/interface/TMConfig.h
+++ b/CalibCalorimetry/EcalLaserAnalyzer/interface/TMConfig.h
@@ -5,7 +5,6 @@
 
 class TMConfig : public TObject {
 public:
-
   static constexpr unsigned int fNsmNmax = 36;  //number of SM
   static constexpr unsigned int fNlmodN = 9;    //number of lmodN in a SM
   static constexpr unsigned int fNmem = 10;     //number of PNs in a MEM

--- a/CalibCalorimetry/EcalLaserAnalyzer/interface/TMConfig.h
+++ b/CalibCalorimetry/EcalLaserAnalyzer/interface/TMConfig.h
@@ -3,32 +3,33 @@
 
 #include "TObject.h"
 
-#define fNsmNmax 36  //number of SM
-#define fNlmodN 9    //number of lmodN in a SM
-#define fNmem 10     //number of PNs in a MEM
-#define fNmodN 4     //number of modN in a SM
-#define fNtt 68      //number of trigger towers in a SM
-#define fNmax 8
-#define fNburmax 3
-#define fNseqmax 3
-#define fNcolors 6   //number of laser colors
+class TMConfig : public TObject {
+public:
+  enum {
+    fNsmNmax = 36,  //number of SM
+    fNlmodN = 9,    //number of lmodN in a SM
+    fNmem = 10,     //number of PNs in a MEM
+    fNmodN = 4,     //number of modN in a SM
+    fNtt = 68,      //number of trigger towers in a SM
+    fNmax = 8,
+    fNburmax = 3,
+    fNseqmax = 3,
+    fNcolors = 6  //number of laser colors
+  };
 
-class TMConfig: public TObject 
-{
-
- private:
+private:
   int smin;
-  int arr[fNsmNmax+1][fNmodN+1];
-  int nbof[fNsmNmax+1][fNlmodN+1];
-  int towerlist[fNsmNmax+1][fNlmodN][fNmax+1];
-  int channlist[fNsmNmax+1][fNlmodN][fNmax+1];
-  int addrpn[fNsmNmax+1][fNmodN+1][fNmem];
-  int n_pin[fNsmNmax+1][fNmodN+1];
-  int seqTypeOfSignal[fNseqmax+1],numbOfEventperBurstAndSignal[fNseqmax+1];
-  int numbOfBurstperSignal[fNseqmax+1];
-  int ped_size[fNburmax+1],laser_size[fNcolors][fNseqmax+1];
-  double alpha[fNcolors],beta[fNcolors];
-  double alpha_run[fNcolors][fNsmNmax+1][fNtt],beta_run[fNcolors][fNsmNmax+1][fNtt];
+  int arr[fNsmNmax + 1][fNmodN + 1];
+  int nbof[fNsmNmax + 1][fNlmodN + 1];
+  int towerlist[fNsmNmax + 1][fNlmodN][fNmax + 1];
+  int channlist[fNsmNmax + 1][fNlmodN][fNmax + 1];
+  int addrpn[fNsmNmax + 1][fNmodN + 1][fNmem];
+  int n_pin[fNsmNmax + 1][fNmodN + 1];
+  int seqTypeOfSignal[fNseqmax + 1], numbOfEventperBurstAndSignal[fNseqmax + 1];
+  int numbOfBurstperSignal[fNseqmax + 1];
+  int ped_size[fNburmax + 1], laser_size[fNcolors][fNseqmax + 1];
+  double alpha[fNcolors], beta[fNcolors];
+  double alpha_run[fNcolors][fNsmNmax + 1][fNtt], beta_run[fNcolors][fNsmNmax + 1][fNtt];
 
   void init();
   void readSequenzaConfig();
@@ -46,63 +47,62 @@ class TMConfig: public TObject
   double alpha_start, beta_start;
 
   int firstpnSample, lastpnSample;
-  int nbofiter,nbofpresamp,samplemin,samplemax;
+  int nbofiter, nbofpresamp, samplemin, samplemax;
   int nbofpnpresamp, nbofpnsamp, nbofsamp;
 
-  int nbofmtqsamples,nbofmtqpresamp,vlastmtqsample,nbofmtqsigmas;
-  int nbofmtqsamp1esbeforemax_parab,nbofmtqsamplesaftermax_parab;
-  int thres_mtq,ampllow_trise,amplhigh_trise;
+  int nbofmtqsamples, nbofmtqpresamp, vlastmtqsample, nbofmtqsigmas;
+  int nbofmtqsamp1esbeforemax_parab, nbofmtqsamplesaftermax_parab;
+  int thres_mtq, ampllow_trise, amplhigh_trise;
 
- public:
+public:
   // Default Constructor, mainly for Root
   TMConfig();
 
   // Destructor: Does nothing
   virtual ~TMConfig();
 
-  int getfirstSM() {return smin;}
-  int getfirstSample() {return firstSample;}
-  int getlastSample() {return lastSample;}
-  int getfirstPNSample() {return firstpnSample;}
-  int getlastPNSample() {return lastpnSample;}
-  float getalpha0() {return alpha_start;}
-  float getbeta0() {return beta_start;}
-  int getsampleMin() {return samplemin;}
-  int getsampleMax() {return samplemax;}
-  int getNbOfxtalpresamples() {return nbofpresamp;}
-  int getNbOfPNpresamples() {return nbofpnpresamp;}
-  int getNbOfiterations() {return nbofiter;}
-  int getNbOfPNsamples() { return nbofpnsamp;}
-  int getNbOfxtalsamples() { return nbofsamp;}
-  double getalpha_ls(int c) { return alpha[c];}
-  double getbeta_ls(int c) { return beta[c];}
+  int getfirstSM() { return smin; }
+  int getfirstSample() { return firstSample; }
+  int getlastSample() { return lastSample; }
+  int getfirstPNSample() { return firstpnSample; }
+  int getlastPNSample() { return lastpnSample; }
+  float getalpha0() { return alpha_start; }
+  float getbeta0() { return beta_start; }
+  int getsampleMin() { return samplemin; }
+  int getsampleMax() { return samplemax; }
+  int getNbOfxtalpresamples() { return nbofpresamp; }
+  int getNbOfPNpresamples() { return nbofpnpresamp; }
+  int getNbOfiterations() { return nbofiter; }
+  int getNbOfPNsamples() { return nbofpnsamp; }
+  int getNbOfxtalsamples() { return nbofsamp; }
+  double getalpha_ls(int c) { return alpha[c]; }
+  double getbeta_ls(int c) { return beta[c]; }
 
   void loadPParams();
-  double getalpha_run(int,int,int);
-  double getbeta_run(int,int,int);
+  double getalpha_run(int, int, int);
+  double getbeta_run(int, int, int);
 
-  int getNbOf(int,int);
-  int getTNumb(int,int,int);
-  int getXNumb(int,int,int);
-  int getPNaddr(int,int,int);
-  int getNbOfPNs(int,int);
+  int getNbOf(int, int);
+  int getTNumb(int, int, int);
+  int getXNumb(int, int, int);
+  int getPNaddr(int, int, int);
+  int getNbOfPNs(int, int);
 
-  int getNbOfMatacqsamples() {return nbofmtqsamples;}
-  int getNbOfMatacqpresamples() {return nbofmtqpresamp;}
-  int getvlastMatacqsample() {return vlastmtqsample;}
-  int getNoiseCutForMatacq() {return nbofmtqsigmas;}
-  int getNbOfsamplesBefMax() {return nbofmtqsamp1esbeforemax_parab;}
-  int getNbOfsamplesAftMax() {return nbofmtqsamplesaftermax_parab;}
-  int getThresForMatacq() {return thres_mtq;}
-  int getLowLevelForTRise() {return ampllow_trise;}
-  int getHighLevelForTRise() {return amplhigh_trise;}
+  int getNbOfMatacqsamples() { return nbofmtqsamples; }
+  int getNbOfMatacqpresamples() { return nbofmtqpresamp; }
+  int getvlastMatacqsample() { return vlastmtqsample; }
+  int getNoiseCutForMatacq() { return nbofmtqsigmas; }
+  int getNbOfsamplesBefMax() { return nbofmtqsamp1esbeforemax_parab; }
+  int getNbOfsamplesAftMax() { return nbofmtqsamplesaftermax_parab; }
+  int getThresForMatacq() { return thres_mtq; }
+  int getLowLevelForTRise() { return ampllow_trise; }
+  int getHighLevelForTRise() { return amplhigh_trise; }
 
-  int getSignalTypeForSeq(int seqNumb) { return seqTypeOfSignal[seqNumb];}
-  int getNbOfBurstperSignalForSeq(int seqNumb) { return numbOfBurstperSignal[seqNumb];}
-  int getNbOfEventperBurstAndSignalForSeq(int seqNumb) { return numbOfEventperBurstAndSignal[seqNumb];}
+  int getSignalTypeForSeq(int seqNumb) { return seqTypeOfSignal[seqNumb]; }
+  int getNbOfBurstperSignalForSeq(int seqNumb) { return numbOfBurstperSignal[seqNumb]; }
+  int getNbOfEventperBurstAndSignalForSeq(int seqNumb) { return numbOfEventperBurstAndSignal[seqNumb]; }
 
   //  ClassDef(TMConfig,1)
 };
 
 #endif
-

--- a/CalibCalorimetry/EcalLaserAnalyzer/interface/TMEGeom.h
+++ b/CalibCalorimetry/EcalLaserAnalyzer/interface/TMEGeom.h
@@ -5,7 +5,7 @@
 
 class TMEGeom : public TObject {
 public:
-  enum { nTT = 25 };
+  static constexpr unsigned int nTT = 25;
 
 private:
   int ttindarr[5][5];

--- a/CalibCalorimetry/EcalLaserAnalyzer/interface/TMEGeom.h
+++ b/CalibCalorimetry/EcalLaserAnalyzer/interface/TMEGeom.h
@@ -3,62 +3,59 @@
 
 #include "TObject.h"
 
-#define nTT 25
+class TMEGeom : public TObject {
+public:
+  enum { nTT = 25 };
 
-class TMEGeom: public TObject 
-{
+private:
+  int ttindarr[5][5];
 
- private:
-
- int ttindarr[5][5];
-
-
- public:
+public:
   // Default Constructor, mainly for Root
   TMEGeom();
 
   // Destructor: Does nothing
   virtual ~TMEGeom();
 
-int nbOfXTalinmodN(int);
-int nbOfXTalinlmodN(int);
+  int nbOfXTalinmodN(int);
+  int nbOfXTalinlmodN(int);
 
-int xtaltoadcn(int);
-int adcltoxtal(int,int);
-int adcltoadcn(int,int);
-int adcltotNumb(int,int);
-int adcmtoadcn(int,int);
-int adcmtoadcl(int,int,int);
-int adcntoadcm(int);
-int adcntomodN(int);
-int adcntolmodN(int,int);
-int adcntoxtal(int);
-int tNumbtomodN(int);
-int tNumbtomodulN(int);
-int tNumbtolmodN(int);
-int tNumbtoside(int);
-int lmodNtoside(int);
-int lmodNtomodN(int);
-int lmodNtolmcha(int);
+  int xtaltoadcn(int);
+  int adcltoxtal(int, int);
+  int adcltoadcn(int, int);
+  int adcltotNumb(int, int);
+  int adcmtoadcn(int, int);
+  int adcmtoadcl(int, int, int);
+  int adcntoadcm(int);
+  int adcntomodN(int);
+  int adcntolmodN(int, int);
+  int adcntoxtal(int);
+  int tNumbtomodN(int);
+  int tNumbtomodulN(int);
+  int tNumbtolmodN(int);
+  int tNumbtoside(int);
+  int lmodNtoside(int);
+  int lmodNtomodN(int);
+  int lmodNtolmcha(int);
 
-int modN_offset(int);
-int lmodN_offset(int);
+  int modN_offset(int);
+  int lmodN_offset(int);
 
-int adcntoij(int);
-int adcltoij(int,int);
-int ijtoadcn(int,int);
-int ijtoadcl(int,int,int);
+  int adcntoij(int);
+  int adcltoij(int, int);
+  int ijtoadcn(int, int);
+  int ijtoadcl(int, int, int);
 
-int tNumbtolvcha(int);
-int tNumbtohvcha(int);
-int adcltolvcha(int,int);
-int adcltohvcha(int,int);
+  int tNumbtolvcha(int);
+  int tNumbtohvcha(int);
+  int adcltolvcha(int, int);
+  int adcltohvcha(int, int);
 
-int hvchatolvcha(int);
+  int hvchatolvcha(int);
 
-void tNumbtoij(int);
+  void tNumbtoij(int);
 
-//  ClassDef(TMEGeom,1)
+  //  ClassDef(TMEGeom,1)
 };
 
 #endif

--- a/CalibCalorimetry/EcalLaserAnalyzer/interface/TMatacq.h
+++ b/CalibCalorimetry/EcalLaserAnalyzer/interface/TMatacq.h
@@ -5,7 +5,8 @@
 
 class TMatacq : public TObject {
 public:
-  enum { NMAXSAMP = 100, NSPARAB = 16 };
+  static constexpr int NMAXSAMP = 100; 
+  static constexpr int NSPARAB = 16;
 
 private:
   int fNsamples;

--- a/CalibCalorimetry/EcalLaserAnalyzer/interface/TMatacq.h
+++ b/CalibCalorimetry/EcalLaserAnalyzer/interface/TMatacq.h
@@ -3,10 +3,10 @@
 
 #include "TObject.h"
 
-#define NMAXSAMP 100
-#define NSPARAB 16
-
 class TMatacq : public TObject {
+public:
+  enum { NMAXSAMP = 100, NSPARAB = 16 };
+
 private:
   int fNsamples;
   int fNum_samp_bef_max;

--- a/CalibCalorimetry/EcalLaserAnalyzer/interface/TMatacq.h
+++ b/CalibCalorimetry/EcalLaserAnalyzer/interface/TMatacq.h
@@ -5,7 +5,7 @@
 
 class TMatacq : public TObject {
 public:
-  static constexpr int NMAXSAMP = 100; 
+  static constexpr int NMAXSAMP = 100;
   static constexpr int NSPARAB = 16;
 
 private:

--- a/CalibCalorimetry/EcalLaserAnalyzer/interface/TPEDestalAnalysis.h
+++ b/CalibCalorimetry/EcalLaserAnalyzer/interface/TPEDestalAnalysis.h
@@ -3,28 +3,24 @@
 
 #include "TObject.h"
 
-#define fNpns 2
-#define fNchans 400
-#define ngains 3
+class TPEDestalAnalysis : public TObject {
+public:
+  enum { fNpns = 2, fNchans = 400, ngains = 3 };
 
-class TPEDestalAnalysis: public TObject 
-{
-
- private:
-
+private:
   int nevt;
-  long int timestart[ngains],timestop[ngains];
-  long int pntimestart[ngains],pntimestop[ngains];
-  double valhf[ngains][fNchans+fNpns],sighf[ngains][fNchans+fNpns];
-  double valbf[ngains][fNchans+fNpns],sigbf[ngains][fNchans+fNpns];
-  double evts[ngains][fNchans+fNpns],evtn[ngains][fNchans+fNpns];
+  long int timestart[ngains], timestop[ngains];
+  long int pntimestart[ngains], pntimestop[ngains];
+  double valhf[ngains][fNchans + fNpns], sighf[ngains][fNchans + fNpns];
+  double valbf[ngains][fNchans + fNpns], sigbf[ngains][fNchans + fNpns];
+  double evts[ngains][fNchans + fNpns], evtn[ngains][fNchans + fNpns];
 
-  double cuthflow[ngains][fNchans+fNpns],cuthfhig[ngains][fNchans+fNpns];
-  double cutbflow[ngains][fNchans+fNpns],cutbfhig[ngains][fNchans+fNpns];
+  double cuthflow[ngains][fNchans + fNpns], cuthfhig[ngains][fNchans + fNpns];
+  double cutbflow[ngains][fNchans + fNpns], cutbfhig[ngains][fNchans + fNpns];
 
   void init();
 
- public:
+public:
   // Default Constructor, mainly for Root
   TPEDestalAnalysis();
 
@@ -33,18 +29,18 @@ class TPEDestalAnalysis: public TObject
 
   void reinit();
   void reinit(int);
-  void putDateStart(int,long int);
-  void putDateStop(int,long int);
-  void putpnDateStart(int,long int);
-  void putpnDateStop(int,long int);
+  void putDateStart(int, long int);
+  void putDateStop(int, long int);
+  void putpnDateStart(int, long int);
+  void putpnDateStop(int, long int);
   void getDateStart(int);
   void getDateStop(int);
-  double getCuthflow(int g,int i) {return cuthflow[g][i];}
-  double getCutbfhig(int g,int i) {return cutbfhig[g][i];}
-  void putValues(int,int,double,double,double);
-  void putValuesWithCuts(int,int,double,double,double);
-  void computepedestalcuts(int,int,int,int);
-  void printpedestalData(int,int,int,int,int,int);
+  double getCuthflow(int g, int i) { return cuthflow[g][i]; }
+  double getCutbfhig(int g, int i) { return cutbfhig[g][i]; }
+  void putValues(int, int, double, double, double);
+  void putValuesWithCuts(int, int, double, double, double);
+  void computepedestalcuts(int, int, int, int);
+  void printpedestalData(int, int, int, int, int, int);
 
   //  ClassDef(TPEDestalAnalysis,1)
 };

--- a/CalibCalorimetry/EcalLaserAnalyzer/interface/TPEDestalAnalysis.h
+++ b/CalibCalorimetry/EcalLaserAnalyzer/interface/TPEDestalAnalysis.h
@@ -5,7 +5,9 @@
 
 class TPEDestalAnalysis : public TObject {
 public:
-  enum { fNpns = 2, fNchans = 400, ngains = 3 };
+  static constexpr unsigned int fNpns = 2;
+  static constexpr unsigned int fNchans = 400;
+  static constexpr unsigned int ngains = 3;
 
 private:
   int nevt;

--- a/CalibCalorimetry/EcalLaserAnalyzer/interface/TPNFit.h
+++ b/CalibCalorimetry/EcalLaserAnalyzer/interface/TPNFit.h
@@ -3,9 +3,10 @@
 
 #include "TObject.h"
 
-#define NMAXSAMP2 50
-
 class TPNFit : public TObject {
+public:
+  enum { NMAXSAMP2 = 50 };
+
 private:
   int fNsamples;
   int fNum_samp_bef_max;

--- a/CalibCalorimetry/EcalLaserAnalyzer/interface/TPNFit.h
+++ b/CalibCalorimetry/EcalLaserAnalyzer/interface/TPNFit.h
@@ -5,7 +5,7 @@
 
 class TPNFit : public TObject {
 public:
-  enum { NMAXSAMP2 = 50 };
+  static constexpr int NMAXSAMP2 = 50;
 
 private:
   int fNsamples;

--- a/CalibCalorimetry/EcalLaserAnalyzer/interface/TSFit.h
+++ b/CalibCalorimetry/EcalLaserAnalyzer/interface/TSFit.h
@@ -5,14 +5,12 @@
 
 class TSFit : public TObject {
 public:
-  enum {
-    SDIM = 14,     /* default number of samples for cristal */
-    PLSHDIM = 650, /* default size of the pulse shape array */
-    matdim = 5,    /* parameters fit max matrice size */
-    diminpar = 10,
-    dimoutpar = 10,
-    npar_moni = 4
-  };
+  static constexpr unsigned int SDIM = 14;     /* default number of samples for cristal */
+  static constexpr unsigned int PLSHDIM = 650; /* default size of the pulse shape array */
+  static constexpr int matdim = 5;    /* parameters fit max matrice size */
+  static constexpr unsigned int diminpar = 10;
+  static constexpr unsigned int dimoutpar = 10;
+  static constexpr unsigned int npar_moni = 4;
 
 private:
   /*

--- a/CalibCalorimetry/EcalLaserAnalyzer/interface/TSFit.h
+++ b/CalibCalorimetry/EcalLaserAnalyzer/interface/TSFit.h
@@ -1,18 +1,19 @@
 #ifndef TSFit_H
 #define TSFit_H
 
-#define SDIM 14     /* default number of samples for cristal */
-#define PLSHDIM 650 /* default size of the pulse shape array */
-//these 2 last parameters are overwritten in constructor
-
-#define matdim 5 /* parameters fit max matrice size */
-#define diminpar 10
-#define dimoutpar 10
-#define npar_moni 4
-
 #include "TObject.h"
 
 class TSFit : public TObject {
+public:
+  enum {
+    SDIM = 14,     /* default number of samples for cristal */
+    PLSHDIM = 650, /* default size of the pulse shape array */
+    matdim = 5,    /* parameters fit max matrice size */
+    diminpar = 10,
+    dimoutpar = 10,
+    npar_moni = 4
+  };
+
 private:
   /*
     nbs = nb of samples in sample data array[sdim]   nbs<=sdim  

--- a/CalibCalorimetry/EcalLaserAnalyzer/interface/TSFit.h
+++ b/CalibCalorimetry/EcalLaserAnalyzer/interface/TSFit.h
@@ -7,7 +7,7 @@ class TSFit : public TObject {
 public:
   static constexpr unsigned int SDIM = 14;     /* default number of samples for cristal */
   static constexpr unsigned int PLSHDIM = 650; /* default size of the pulse shape array */
-  static constexpr int matdim = 5;    /* parameters fit max matrice size */
+  static constexpr int matdim = 5;             /* parameters fit max matrice size */
   static constexpr unsigned int diminpar = 10;
   static constexpr unsigned int dimoutpar = 10;
   static constexpr unsigned int npar_moni = 4;

--- a/CalibCalorimetry/EcalLaserAnalyzer/interface/TShapeAnalysis.h
+++ b/CalibCalorimetry/EcalLaserAnalyzer/interface/TShapeAnalysis.h
@@ -7,7 +7,7 @@ class TTree;
 
 class TShapeAnalysis : public TObject {
 public:
-  enum { fNchsel = 1700 };
+  static constexpr int fNchsel = 1700;
 
 private:
   char filename[80];

--- a/CalibCalorimetry/EcalLaserAnalyzer/interface/TShapeAnalysis.h
+++ b/CalibCalorimetry/EcalLaserAnalyzer/interface/TShapeAnalysis.h
@@ -5,9 +5,10 @@
 #include <vector>
 class TTree;
 
-#define fNchsel 1700
-
 class TShapeAnalysis : public TObject {
+public:
+  enum { fNchsel = 1700 };
+
 private:
   char filename[80];
   long int timestart, timestop;


### PR DESCRIPTION
Fixes unit test failure in modules IB and avoids potential name clashes in global variables. 