### PR TITLE
Fix non-optimized builds of SiStripApvGain_PayloadInspector.cc

### DIFF
--- a/CondCore/SiStripPlugins/plugins/SiStripApvGain_PayloadInspector.cc
+++ b/CondCore/SiStripPlugins/plugins/SiStripApvGain_PayloadInspector.cc
@@ -984,7 +984,7 @@ namespace {
           edm::LogWarning("LogicError") << "Unknown estimator: " << est;
           break;
       }
-
+      return 0.;
     }  // payload
   };
 


### PR DESCRIPTION
#### PR description:

When built with optimization off and debugging enabled via `USER_CXXFLAGS="-g -O0" scram b`, `SiStripApvGain_PayloadInspector.cc` fails to build with the diagnostic that control reaches end of non-void function:
```
/mnt/data1/dsr/tmp/CMSSW_11_3_ROOT6_X_2021-03-28-2300/src/CondCore/SiStripPlugins/plugins/SiStripApvGain_PayloadInspector.cc:988:5: error: control reaches end of non-void function [-Werror=return-type]
  988 |     }  // payload
      |     ^
```
This PR adds the missing return statement.  Presumably this is somehow optimized out in normal builds.

#### PR validation:

It compiles and is the very model of a trivial technical change.