### PR TITLE
Explicitly using CPUExecutionProvider in ONNXRuntime python test

### DIFF
--- a/PhysicsTools/ONNXRuntime/test/plot_load_and_predict.py
+++ b/PhysicsTools/ONNXRuntime/test/plot_load_and_predict.py
@@ -21,7 +21,7 @@ from onnxruntime import datasets
 # The model is available on github `onnx...test_sigmoid <https://github.com/onnx/onnx/tree/master/onnx/backend/test/data/node/test_sigmoid>`_.
 
 example1 = get_example("sigmoid.onnx")
-sess = rt.InferenceSession(example1)
+sess = rt.InferenceSession(example1, providers=['CPUExecutionProvider'])
 
 #########################
 # Let's see the input name and shape.


### PR DESCRIPTION
Technical fix to allow the test passes after enabling GPU support of ONNXRuntime in https://github.com/cms-sw/cmsdist/pull/6776.