### PR TITLE
Update geometry tags in mcRun3 GTs

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -64,17 +64,17 @@ autoCond = {
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in PEAK mode
     'phase1_2018_cosmics_peak' :  '113X_upgrade2018cosmics_realistic_peak_v4',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2021
-    'phase1_2021_design'       : '113X_mcRun3_2021_design_v5', # GT containing design conditions for Phase1 2021
+    'phase1_2021_design'       : '113X_mcRun3_2021_design_v6', # GT containing design conditions for Phase1 2021
     # GlobalTag for MC production with realistic conditions for Phase1 2021
-    'phase1_2021_realistic'    : '113X_mcRun3_2021_realistic_v7', # GT containing realistic conditions for Phase1 2021
+    'phase1_2021_realistic'    : '113X_mcRun3_2021_realistic_v8', # GT containing realistic conditions for Phase1 2021
     # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2021,  Strip tracker in DECO mode
-    'phase1_2021_cosmics'      : '113X_mcRun3_2021cosmics_realistic_deco_v6',
+    'phase1_2021_cosmics'      : '113X_mcRun3_2021cosmics_realistic_deco_v7',
     # GlobalTag for MC production with realistic conditions for Phase1 2021 detector for Heavy Ion
-    'phase1_2021_realistic_hi' : '113X_mcRun3_2021_realistic_HI_v5',
+    'phase1_2021_realistic_hi' : '113X_mcRun3_2021_realistic_HI_v6',
     # GlobalTag for MC production with realistic conditions for Phase1 2023
-    'phase1_2023_realistic'    : '113X_mcRun3_2023_realistic_v5', # GT containing realistic conditions for Phase1 2023
+    'phase1_2023_realistic'    : '113X_mcRun3_2023_realistic_v6', # GT containing realistic conditions for Phase1 2023
     # GlobalTag for MC production with realistic conditions for Phase1 2024
-    'phase1_2024_realistic'    : '113X_mcRun3_2024_realistic_v5', # GT containing realistic conditions for Phase1 2024
+    'phase1_2024_realistic'    : '113X_mcRun3_2024_realistic_v6', # GT containing realistic conditions for Phase1 2024
     # GlobalTag for MC production with realistic conditions for Phase2
     'phase2_realistic'         : '113X_mcRun4_realistic_v6'
 }


### PR DESCRIPTION
#### PR description:
This PR updates two geometry tags in the mcRun3 GTs due to some clean-up of the detector geometry in 11_3 and the addition of a new GEM parameter called `dPhi`. More details can be found in [this HN post](https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/4389.html) and in the Minutes of [this contribution at the (vitual) AlCaDB meeting](https://indico.cern.ch/event/1025207/#16-geometry-updates-for-mcrun3). The changes are technical and are not expected to affect physics results.

The updated tags are:
- `XMLFILE_Geometry_113YV4_Extended2021_mc` with label `Extended`
- `GEMRECO_Geometry_113YV4`

The GTs diffs are:
**2021 design**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/113X_mcRun3_2021_design_v5/113X_mcRun3_2021_design_v6

**2021 realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/113X_mcRun3_2021_realistic_v7/113X_mcRun3_2021_realistic_v8

**2021 cosmics**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/113X_mcRun3_2021cosmics_realistic_deco_v6/113X_mcRun3_2021cosmics_realistic_deco_v7

**2021 heavy ion**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/113X_mcRun3_2021_realistic_HI_v5/113X_mcRun3_2021_realistic_HI_v6

**2023 realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/113X_mcRun3_2023_realistic_v5/113X_mcRun3_2023_realistic_v6

**2024 realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/113X_mcRun3_2024_realistic_v5/113X_mcRun3_2024_realistic_v6


#### PR validation:
Tested with:
`runTheMatrix.py -l limited,7.23,136.874,159.0,12034.0,12834.0 --ibeos -j 9`

#### if this PR is a backport please specify the original PR and why you need to backport that PR:
This PR is not a backport and no backport is needed