### PR TITLE
[HGCAL] Update TICL iterations naming

### DIFF
--- a/RecoHGCal/TICL/plugins/TrackstersProducer.cc
+++ b/RecoHGCal/TICL/plugins/TrackstersProducer.cc
@@ -102,7 +102,7 @@ TrackstersProducer::TrackstersProducer(const edm::ParameterSet& ps, const Tracks
     iterIndex_ = ticl::Trackster::TRKEM;
   else if (itername_ == "EM")
     iterIndex_ = ticl::Trackster::EM;
-  else if (itername_ == "TrkHAD")
+  else if (itername_ == "Trk")
     iterIndex_ = ticl::Trackster::TRKHAD;
   else if (itername_ == "HAD")
     iterIndex_ = ticl::Trackster::HAD;

--- a/RecoHGCal/TICL/python/HADStep_cff.py
+++ b/RecoHGCal/TICL/python/HADStep_cff.py
@@ -30,7 +30,7 @@ ticlTrackstersHAD = _trackstersProducer.clone(
     min_cos_theta = 0.866,    # ~30 degrees
     min_cos_pointing = 0.819, # ~35 degrees
     max_delta_time = -1,
-    itername = "HADRONIC"
+    itername = "HAD"
     )
 
 # MULTICLUSTERS

--- a/RecoHGCal/TICL/python/TrkStep_cff.py
+++ b/RecoHGCal/TICL/python/TrkStep_cff.py
@@ -18,7 +18,7 @@ filteredLayerClustersTrk = _filteredLayerClustersProducer.clone(
 
 # CA - PATTERN RECOGNITION
 
-ticlTrackstersTrkHAD = _trackstersProducer.clone(
+ticlTrackstersTrk = _trackstersProducer.clone(
   filtered_mask = "filteredLayerClustersTrk:Trk",
   seeding_regions = "ticlSeedingTrk",
   original_mask = 'ticlTrackstersEM',
@@ -32,18 +32,18 @@ ticlTrackstersTrkHAD = _trackstersProducer.clone(
   algo_verbosity = 2,
   oneTracksterPerTrackSeed = True,
   promoteEmptyRegionToTrackster = True,
-  itername = "TrkHAD"
+  itername = "Trk"
 )
 
 # MULTICLUSTERS
 
-ticlMultiClustersFromTrackstersTrkHAD = _multiClustersFromTrackstersProducer.clone(
-    Tracksters = "ticlTrackstersTrkHAD"
+ticlMultiClustersFromTrackstersTrk = _multiClustersFromTrackstersProducer.clone(
+    Tracksters = "ticlTrackstersTrk"
 )
 
 ticlTrkStepTask = cms.Task(ticlSeedingTrk
     ,filteredLayerClustersTrk
-    ,ticlTrackstersTrkHAD
-    ,ticlMultiClustersFromTrackstersTrkHAD)
+    ,ticlTrackstersTrk
+    ,ticlMultiClustersFromTrackstersTrk)
 
 

--- a/RecoHGCal/TICL/python/TrkStep_cff.py
+++ b/RecoHGCal/TICL/python/TrkStep_cff.py
@@ -32,7 +32,7 @@ ticlTrackstersTrk = _trackstersProducer.clone(
   algo_verbosity = 2,
   oneTracksterPerTrackSeed = True,
   promoteEmptyRegionToTrackster = True,
-  itername = "TRK"
+  itername = "TrkHAD"
 )
 
 # MULTICLUSTERS

--- a/RecoHGCal/TICL/python/TrkStep_cff.py
+++ b/RecoHGCal/TICL/python/TrkStep_cff.py
@@ -18,7 +18,7 @@ filteredLayerClustersTrk = _filteredLayerClustersProducer.clone(
 
 # CA - PATTERN RECOGNITION
 
-ticlTrackstersTrk = _trackstersProducer.clone(
+ticlTrackstersTrkHAD = _trackstersProducer.clone(
   filtered_mask = "filteredLayerClustersTrk:Trk",
   seeding_regions = "ticlSeedingTrk",
   original_mask = 'ticlTrackstersEM',
@@ -37,13 +37,13 @@ ticlTrackstersTrk = _trackstersProducer.clone(
 
 # MULTICLUSTERS
 
-ticlMultiClustersFromTrackstersTrk = _multiClustersFromTrackstersProducer.clone(
-    Tracksters = "ticlTrackstersTrk"
+ticlMultiClustersFromTrackstersTrkHAD = _multiClustersFromTrackstersProducer.clone(
+    Tracksters = "ticlTrackstersTrkHAD"
 )
 
 ticlTrkStepTask = cms.Task(ticlSeedingTrk
     ,filteredLayerClustersTrk
-    ,ticlTrackstersTrk
-    ,ticlMultiClustersFromTrackstersTrk)
+    ,ticlTrackstersTrkHAD
+    ,ticlMultiClustersFromTrackstersTrkHAD)
 
 

--- a/RecoHGCal/TICL/python/iterativeTICL_cff.py
+++ b/RecoHGCal/TICL/python/iterativeTICL_cff.py
@@ -28,13 +28,14 @@ ticlIterations = cms.Task(
     ,ticlTrkStepTask
     ,ticlHADStepTask
 )
-ticlIterLables = [_step.itername for _iteration in ticlIterations for _step in _iteration if (_step._TypedParameterizable__type == "TrackstersProducer")]
+ticlIterLabels = [_step.itername.value() for _iteration in ticlIterations for _step in _iteration if (_step._TypedParameterizable__type == "TrackstersProducer")]
 
 iterTICLTask = cms.Task(ticlLayerTileTask
     ,ticlIterations
     ,ticlTracksterMergeTask
     ,ticlPFTask
 )
+ticlIterLabelsMerge = ticlIterLabels + ["Merge"]
 
 ticlLayerTileHFNose = ticlLayerTileProducer.clone(
     detector = 'HFNose'

--- a/RecoHGCal/TICL/python/iterativeTICL_cff.py
+++ b/RecoHGCal/TICL/python/iterativeTICL_cff.py
@@ -22,14 +22,19 @@ ticlTracksterMergeTask = cms.Task(ticlTrackstersMerge, ticlMultiClustersFromTrac
 pfTICL = _pfTICLProducer.clone()
 ticlPFTask = cms.Task(pfTICL)
 
-iterTICLTask = cms.Task(ticlLayerTileTask
-    ,ticlTrkEMStepTask
+ticlIterations = cms.Task(
+    ticlTrkEMStepTask
     ,ticlEMStepTask
     ,ticlTrkStepTask
     ,ticlHADStepTask
+)
+ticlIterLables = [_step.itername for _iteration in ticlIterations for _step in _iteration if (_step._TypedParameterizable__type == "TrackstersProducer")]
+
+iterTICLTask = cms.Task(ticlLayerTileTask
+    ,ticlIterations
     ,ticlTracksterMergeTask
     ,ticlPFTask
-    )
+)
 
 ticlLayerTileHFNose = ticlLayerTileProducer.clone(
     detector = 'HFNose'

--- a/RecoHGCal/TICL/python/iterativeTICL_cff.py
+++ b/RecoHGCal/TICL/python/iterativeTICL_cff.py
@@ -22,16 +22,16 @@ ticlTracksterMergeTask = cms.Task(ticlTrackstersMerge, ticlMultiClustersFromTrac
 pfTICL = _pfTICLProducer.clone()
 ticlPFTask = cms.Task(pfTICL)
 
-ticlIterations = cms.Task(
+ticlIterationsTask = cms.Task(
     ticlTrkEMStepTask
     ,ticlEMStepTask
     ,ticlTrkStepTask
     ,ticlHADStepTask
 )
-ticlIterLabels = [_step.itername.value() for _iteration in ticlIterations for _step in _iteration if (_step._TypedParameterizable__type == "TrackstersProducer")]
+ticlIterLabels = [_step.itername.value() for _iteration in ticlIterationsTask for _step in _iteration if (_step._TypedParameterizable__type == "TrackstersProducer")]
 
 iterTICLTask = cms.Task(ticlLayerTileTask
-    ,ticlIterations
+    ,ticlIterationsTask
     ,ticlTracksterMergeTask
     ,ticlPFTask
 )

--- a/Validation/HGCalValidation/python/HGCalValidator_cfi.py
+++ b/Validation/HGCalValidation/python/HGCalValidator_cfi.py
@@ -7,6 +7,12 @@ from SimCalorimetry.HGCalAssociatorProducers.LCToCPAssociation_cfi import layerC
 from SimCalorimetry.HGCalAssociatorProducers.LCToSCAssociation_cfi import layerClusterSimClusterAssociation
 
 from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
+
+from RecoHGCal.TICL.iterativeTICL_cff import ticlIterLabels, ticlIterLabelsMerge
+
+labelMcl = [cms.InputTag("ticlMultiClustersFromTracksters"+iteration) for iteration in ticlIterLabelsMerge]
+lcInputMask = [cms.InputTag("ticlTracksters"+iteration) for iteration in ticlIterLabels]
+
 hgcalValidator = DQMEDAnalyzer(
     "HGCalValidator",
 
@@ -17,11 +23,7 @@ hgcalValidator = DQMEDAnalyzer(
     ### reco input configuration ###
     #2dlayerclusters, pfclusters, multiclusters
     label_lcl = layerClusterCaloParticleAssociation.label_lc,
-    label_mcl = cms.VInputTag(
-      cms.InputTag("ticlMultiClustersFromTrackstersTrk"),
-      cms.InputTag("ticlMultiClustersFromTrackstersEM"),
-      cms.InputTag("ticlMultiClustersFromTrackstersHAD"),
-      cms.InputTag("ticlMultiClustersFromTrackstersMerge")),
+    label_mcl = cms.VInputTag(labelMcl),
 
     associator = cms.untracked.InputTag("layerClusterCaloParticleAssociationProducer"),
 
@@ -53,12 +55,7 @@ hgcalValidator = DQMEDAnalyzer(
 
     simVertices = cms.InputTag("g4SimHits"),
 
-    LayerClustersInputMask = cms.VInputTag(
-        cms.InputTag("ticlTrackstersTrkEM"),
-        cms.InputTag("ticlTrackstersEM"),
-        cms.InputTag("ticlTrackstersTrk"),
-        cms.InputTag("ticlTrackstersHAD")
-    ),
+    LayerClustersInputMask = cms.VInputTag(lcInputMask),
 
     #Total number of layers of HGCal that we want to monitor
     #Could get this also from HGCalImagingAlgo::maxlayer but better to get it from here

--- a/Validation/HGCalValidation/python/PostProcessorHGCAL_cfi.py
+++ b/Validation/HGCalValidation/python/PostProcessorHGCAL_cfi.py
@@ -34,7 +34,7 @@ eff_simclusters.extend(["fake_phi_layer{:02d} 'LayerCluster Fake Rate vs #phi La
 eff_simclusters.extend(["merge_eta_layer{:02d} 'LayerCluster Merge Rate vs #eta Layer{:02d} in z-' NumMerge_LayerCluster_in_SimCluster_Eta_perlayer{:02d} Denom_LayerCluster_in_SimCluster_Eta_perlayer{:02d}".format(i, i%maxlayerzm+1, i, i) if (i<maxlayerzm) else "merge_eta_layer{:02d} 'LayerCluster Merge Rate vs #eta Layer{:02d} in z+' NumMerge_LayerCluster_in_SimCluster_Eta_perlayer{:02d} Denom_LayerCluster_in_SimCluster_Eta_perlayer{:02d}".format(i, i%maxlayerzm+1, i, i) for i in range(maxlayerzp) ])
 eff_simclusters.extend(["merge_phi_layer{:02d} 'LayerCluster Merge Rate vs #phi Layer{:02d} in z-' NumMerge_LayerCluster_in_SimCluster_Phi_perlayer{:02d} Denom_LayerCluster_in_SimCluster_Phi_perlayer{:02d}".format(i, i%maxlayerzm+1, i, i) if (i<maxlayerzm) else "merge_phi_layer{:02d} 'LayerCluster Merge Rate vs #phi Layer{:02d} in z+' NumMerge_LayerCluster_in_SimCluster_Phi_perlayer{:02d} Denom_LayerCluster_in_SimCluster_Phi_perlayer{:02d}".format(i, i%maxlayerzm+1, i, i) for i in range(maxlayerzp) ])
 
-subdirsSim.extend('HGCAL/HGCalValidator/simClusters/ticlTracksters'+iteration+'/' for iteration in ticlIterLabelsMerge)
+subdirsSim = ['HGCAL/HGCalValidator/simClusters/ticlTracksters'+iteration+'/' for iteration in ticlIterLabelsMerge]
 postProcessorHGCALsimclusters= DQMEDHarvester('DQMGenericClient',
     subDirs = cms.untracked.vstring(subdirsSim),
     efficiency = cms.vstring(eff_simclusters),

--- a/Validation/HGCalValidation/python/PostProcessorHGCAL_cfi.py
+++ b/Validation/HGCalValidation/python/PostProcessorHGCAL_cfi.py
@@ -1,5 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 from DQMServices.Core.DQMEDHarvester import DQMEDHarvester
+from RecoHGCal.TICL.iterativeTICL_cff import ticlIterLabelsMerge
 
 maxlayerzm =  50# last layer of BH -z
 maxlayerzp =  100# last layer of BH +z
@@ -33,14 +34,9 @@ eff_simclusters.extend(["fake_phi_layer{:02d} 'LayerCluster Fake Rate vs #phi La
 eff_simclusters.extend(["merge_eta_layer{:02d} 'LayerCluster Merge Rate vs #eta Layer{:02d} in z-' NumMerge_LayerCluster_in_SimCluster_Eta_perlayer{:02d} Denom_LayerCluster_in_SimCluster_Eta_perlayer{:02d}".format(i, i%maxlayerzm+1, i, i) if (i<maxlayerzm) else "merge_eta_layer{:02d} 'LayerCluster Merge Rate vs #eta Layer{:02d} in z+' NumMerge_LayerCluster_in_SimCluster_Eta_perlayer{:02d} Denom_LayerCluster_in_SimCluster_Eta_perlayer{:02d}".format(i, i%maxlayerzm+1, i, i) for i in range(maxlayerzp) ])
 eff_simclusters.extend(["merge_phi_layer{:02d} 'LayerCluster Merge Rate vs #phi Layer{:02d} in z-' NumMerge_LayerCluster_in_SimCluster_Phi_perlayer{:02d} Denom_LayerCluster_in_SimCluster_Phi_perlayer{:02d}".format(i, i%maxlayerzm+1, i, i) if (i<maxlayerzm) else "merge_phi_layer{:02d} 'LayerCluster Merge Rate vs #phi Layer{:02d} in z+' NumMerge_LayerCluster_in_SimCluster_Phi_perlayer{:02d} Denom_LayerCluster_in_SimCluster_Phi_perlayer{:02d}".format(i, i%maxlayerzm+1, i, i) for i in range(maxlayerzp) ])
 
+subdirsSim.extend('HGCAL/HGCalValidator/simClusters/ticlTracksters'+iteration+'/' for iteration in ticlIterLabelsMerge)
 postProcessorHGCALsimclusters= DQMEDHarvester('DQMGenericClient',
-    subDirs = cms.untracked.vstring(
-        'HGCAL/HGCalValidator/simClusters/ticlTrackstersTrkEM',
-        'HGCAL/HGCalValidator/simClusters/ticlTrackstersEM',
-        'HGCAL/HGCalValidator/simClusters/ticlTrackstersTrk',
-        'HGCAL/HGCalValidator/simClusters/ticlTrackstersHAD',
-        'HGCAL/HGCalValidator/simClusters/ticlTrackstersMerge'
-    ),
+    subDirs = cms.untracked.vstring(subdirsSim),
     efficiency = cms.vstring(eff_simclusters),
     resolution = cms.vstring(),
     cumulativeDists = cms.untracked.vstring(),
@@ -57,18 +53,15 @@ eff_multiclusters.extend(["fake_phi 'MultiCluster Fake Rate vs #phi'  Num_MultiC
 eff_multiclusters.extend(["merge_eta 'MultiCluster Merge Rate vs #eta' NumMerge_MultiCluster_Eta Denom_MultiCluster_Eta"])
 eff_multiclusters.extend(["merge_phi 'MultiCluster Merge Rate vs #phi' NumMerge_MultiCluster_Phi Denom_MultiCluster_Phi"])
 
-postProcessorHGCALmulticlusters = DQMEDHarvester('DQMGenericClient',
-subDirs = cms.untracked.vstring(
-  'HGCAL/HGCalValidator/hgcalMultiClusters/',
-  'HGCAL/HGCalValidator/ticlMultiClustersFromTrackstersTrk/',
-  'HGCAL/HGCalValidator/ticlMultiClustersFromTrackstersEM/',
-  'HGCAL/HGCalValidator/ticlMultiClustersFromTrackstersHAD/',
-  'HGCAL/HGCalValidator/ticlMultiClustersFromTrackstersMerge/',
-  ),
+subdirsMult = ['HGCAL/HGCalValidator/hgcalMultiClusters/']
+subdirsMult.extend('HGCAL/HGCalValidator/ticlMultiClustersFromTracksters'+iteration+'/' for iteration in ticlIterLabelsMerge)
 
-efficiency = cms.vstring(eff_multiclusters),
-resolution = cms.vstring(),
-cumulativeDists = cms.untracked.vstring(),
-noFlowDists = cms.untracked.vstring(),
-outputFileName = cms.untracked.string(""),
-verbose = cms.untracked.uint32(4))
+postProcessorHGCALmulticlusters = DQMEDHarvester('DQMGenericClient',
+  subDirs = cms.untracked.vstring(subdirsMult),
+  efficiency = cms.vstring(eff_multiclusters),
+  resolution = cms.vstring(),
+  cumulativeDists = cms.untracked.vstring(),
+  noFlowDists = cms.untracked.vstring(),
+  outputFileName = cms.untracked.string(""),
+  verbose = cms.untracked.uint32(4)
+)


### PR DESCRIPTION
#### PR description:

This PR updates the `itername` attribute to the latest HGCAL naming, and removes the corresponding hard-coded lists in Validation. No changes are expected in the output, except for the naming.

#### PR validation:

`runTheMatrix -l limited`