### PR TITLE
Add the possibility to run multiple matrices in runTheMatrix.py

### DIFF
--- a/Configuration/PyReleaseValidation/python/MatrixReader.py
+++ b/Configuration/PyReleaseValidation/python/MatrixReader.py
@@ -316,7 +316,7 @@ class MatrixReader(object):
 
             self.reset(what)
 
-            if self.what != 'all' and self.what not in matrixFile:
+            if self.what != 'all' and not any(el in matrixFile for el in self.what.split(",")):
                 print("ignoring non-requested file",matrixFile)
                 continue
 
@@ -492,7 +492,7 @@ class MatrixReader(object):
     def prepare(self, useInput=None, refRel='', fromScratch=None):
         
         for matrixFile in self.files:
-            if self.what != 'all' and self.what not in matrixFile:
+            if self.what != 'all' and not any(el in matrixFile for el in self.what.split(",")):
                 print("ignoring non-requested file",matrixFile)
                 continue
             if self.what == 'all' and not self.filesDefault[matrixFile]:

--- a/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
+++ b/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
@@ -24,10 +24,13 @@ def runSelected(opt):
 
     # test for wrong input workflows
     if opt.testList:
-        definedSet = set([dwf.numId for dwf in mrd.workFlows])
+        definedWf = [dwf.numId for dwf in mrd.workFlows]
+        definedSet = set(definedWf)
         testSet = set(opt.testList)
         undefSet = testSet - definedSet
         if len(undefSet)>0: raise ValueError('Undefined workflows: '+', '.join(map(str,list(undefSet))))
+        duplicates = [wf for wf in testSet if definedWf.count(wf)>1 ]
+        if len(duplicates)>0: raise ValueError('Duplicated workflows: '+', '.join(map(str,list(duplicates))))
 
     ret = 0
     if opt.show:
@@ -175,7 +178,7 @@ if __name__ == '__main__':
                       default=None
                       )
     parser.add_option('-w','--what',
-                      help='Specify the set to be used. Argument must be the name of the set (standard, pileup,...)',
+                      help='Specify the set to be used. Argument must be the name of a set (standard, pileup,...) or multiple sets separated by commas (--what standard,pileup )',
                       dest='what',
                       default='all'
                       )


### PR DESCRIPTION
#### PR description:

This PR makes possible to use multiple matrices in runTheMatrix.py using `--what`

#### PR validation:

Tested with
```
runTheMatrix.py --showMatrix -l 101.0,10224.0,10824.506,10842.506,11634.506,11650.506,1306.0,250202.181,25202.0,9.0 --what=standard,premix,gpu,pileup,highstat,2017
```