### PR TITLE
modified merging scheme and tighter outlier suppression  in primary vertex reconstruction

### DIFF
--- a/RecoVertex/PrimaryVertexProducer/interface/DAClusterizerInZ_vect.h
+++ b/RecoVertex/PrimaryVertexProducer/interface/DAClusterizerInZ_vect.h
@@ -189,7 +189,8 @@ public:
   double update(
       double beta, track_t &gtracks, vertex_t &gvertices, const double rho0 = 0, const bool updateTc = false) const;
 
-  void dump(const double beta, const vertex_t &y, const track_t &tks, const int verbosity = 0) const;
+  void dump(
+      const double beta, const vertex_t &y, const track_t &tks, const int verbosity = 0, const double rho0 = 0.) const;
   bool merge(vertex_t &y, track_t &tks, double &beta) const;
   bool purge(vertex_t &, track_t &, double &, const double) const;
   bool split(const double beta, track_t &t, vertex_t &y, double threshold = 1.) const;


### PR DESCRIPTION

#### PR description:
The 3d clustering is modified slightly in order to reduce splitting and fake rates for Run 3. This addresses fake-rate and splitting related observations made in Run 2 data. Details and results can be found in 
https://indico.cern.ch/event/1019373/contributions/4293207/attachments/2217496/3754437/2021-03-29-tuning.pdf
and 
https://indico.cern.ch/event/1023338/contributions/4298206/attachments/2219781/3758715/2021-04-01-pvtuning.pdf
The code changes are
1) remove the Tc control for merging. The net effect of this feature is an increased fake rate that does not justify the small gain in efficiency. Updates of Tc are now initiated by the split() routine.
2) the proporionality constant of the outlier suppression term is increased from 1/#tracks to 1/#clusters. The value of dzCutOff can now be seen as the soft z-cut-off for an average cluster.

Small changes in the number and composition of reconstructed vertices are expected.

#### PR validation:
The code was tested with several 11_3_0_pre4 relval samples with the results reported in the presentations mentioned above.
runTheMatrix with this PR code on top of CMSSW_11_3_X_2021-04-05-2300 produces some errors, however, I can not see any connection to the vertex reconstruction  ( 37 34 26 18 14 4 1 1 1 tests passed, 0 2 7 0 0 0 0 0 0 failed )

