### PR TITLE
[DD4hep] Set material temperature and pressure to NTP instead of default STP

### DIFF
--- a/DetectorDescription/DDCMS/plugins/dd4hep/DDDefinitions2Objects.cc
+++ b/DetectorDescription/DDCMS/plugins/dd4hep/DDDefinitions2Objects.cc
@@ -556,6 +556,8 @@ void Converter<DDLElementaryMaterial>::operator()(xml_h element) const {
     }
 
     mix->AddElement(elt, 1.0);
+    mix->SetTemperature(ns.context()->description.stdConditions().temperature);
+    mix->SetPressure(ns.context()->description.stdConditions().pressure);
 
     /// Create medium from the material
     TGeoMedium* medium = mgr.GetMedium(matname);
@@ -621,6 +623,8 @@ void Converter<DDLCompositeMaterial>::operator()(xml_h element) const {
       ns.context()->unresolvedMaterials[nam].emplace_back(
           cms::DDParsingContext::CompositeMaterial(ns.prepend(fracname), fraction));
     }
+    mix->SetTemperature(ns.context()->description.stdConditions().temperature);
+    mix->SetPressure(ns.context()->description.stdConditions().pressure);
     mix->SetRadLen(0e0);
     /// Create medium from the material
     TGeoMedium* medium = mgr.GetMedium(matname);

--- a/DetectorDescription/DDCMS/src/DDDetector.cc
+++ b/DetectorDescription/DDCMS/src/DDDetector.cc
@@ -21,6 +21,8 @@ namespace cms {
     m_description->addExtension<cms::DDVectorsMap>(&m_vectors);
     m_description->addExtension<dd4hep::PartSelectionMap>(&m_partsels);
     m_description->addExtension<dd4hep::SpecParRegistry>(&m_specpars);
+    m_description->setStdConditions("NTP");
+    edm::LogVerbatim("Geometry") << "DDDetector::ctor Setting DD4hep STD conditions to NTP";
     if (bigXML)
       processXML(fileName);
     else


### PR DESCRIPTION
When the geometry is being built, the materials used in the geometry are also constructed. Previously, with DD4hep, no temperature or pressure was specified for the materials, so they gained the defaults from ROOT, which are STP, Standard Temperature and Pressure, 273.15 K and 1 atm. However, with DDD the material temperatures are 293.15, which corresponds to NTP, Normal Temperature and Pressure.

This PR sets the DD4hep conditions to NTP, and then uses those values to set the material temperatures and pressures.

#### PR validation:

The test script `SimG4Core/PrintGeomInfo/test/python/g4OverlapCheck_dd4hep_cfg.py` shows that the material temperatures with this PR are now 293.15 K.

No backport.