### PR TITLE
fixes a bug in the unconstrained-pT invariant-mass correlation condition

### DIFF
--- a/L1Trigger/L1TGlobal/interface/GlobalScales.h
+++ b/L1Trigger/L1TGlobal/interface/GlobalScales.h
@@ -67,6 +67,7 @@ namespace l1t {
     virtual void setLUT_DeltaEta(const std::string& lutName, std::vector<long long> lut, unsigned int precision);
     virtual void setLUT_DeltaPhi(const std::string& lutName, std::vector<long long> lut, unsigned int precision);
     virtual void setLUT_Pt(const std::string& lutName, std::vector<long long> lut, unsigned int precision);
+    virtual void setLUT_Upt(const std::string& lutName, std::vector<long long> lut, unsigned int precision); // Added for displaced muons
     virtual void setLUT_Cosh(const std::string& lutName, std::vector<long long> lut, unsigned int precision);
     virtual void setLUT_Cos(const std::string& lutName, std::vector<long long> lut, unsigned int precision);
     virtual void setLUT_Sin(const std::string& lutName, std::vector<long long> lut, unsigned int precision);
@@ -90,6 +91,7 @@ namespace l1t {
     long long getLUT_DeltaEta(std::string lutName, int element) const;
     long long getLUT_DeltaPhi(std::string lutName, int element) const;
     long long getLUT_Pt(const std::string& lutName, int element) const;
+    long long getLUT_Upt(const std::string& lutName, int element) const; // Added for displaced muons
     long long getLUT_DeltaEta_Cosh(std::string lutName, int element) const;
     long long getLUT_DeltaPhi_Cos(std::string lutName, int element) const;
     long long getLUT_Cos(const std::string& lutName, int element) const;
@@ -98,6 +100,7 @@ namespace l1t {
     unsigned int getPrec_DeltaEta(const std::string& lutName) const;
     unsigned int getPrec_DeltaPhi(const std::string& lutName) const;
     unsigned int getPrec_Pt(const std::string& lutName) const;
+    unsigned int getPrec_Upt(const std::string& lutName) const;  // Added for displaced muons
     unsigned int getPrec_DeltaEta_Cosh(const std::string& lutName) const;
     unsigned int getPrec_DeltaPhi_Cos(const std::string& lutName) const;
     unsigned int getPrec_Cos(const std::string& lutName) const;
@@ -131,6 +134,7 @@ namespace l1t {
     std::map<std::string, std::vector<long long>> m_lut_DeltaEta;
     std::map<std::string, std::vector<long long>> m_lut_DeltaPhi;
     std::map<std::string, std::vector<long long>> m_lut_Pt;
+    std::map<std::string, std::vector<long long>> m_lut_Upt; // Added for displaced muons
     std::map<std::string, std::vector<long long>> m_lut_Cosh;
     std::map<std::string, std::vector<long long>> m_lut_Cos;
     std::map<std::string, std::vector<long long>> m_lut_Sin;
@@ -139,6 +143,7 @@ namespace l1t {
     std::map<std::string, unsigned int> m_Prec_DeltaEta;
     std::map<std::string, unsigned int> m_Prec_DeltaPhi;
     std::map<std::string, unsigned int> m_Prec_Pt;
+    std::map<std::string, unsigned int> m_Prec_Upt; // Added for displaced muons
     std::map<std::string, unsigned int> m_Prec_Cosh;
     std::map<std::string, unsigned int> m_Prec_Cos;
     std::map<std::string, unsigned int> m_Prec_Sin;

--- a/L1Trigger/L1TGlobal/plugins/TriggerMenuParser.h
+++ b/L1Trigger/L1TGlobal/plugins/TriggerMenuParser.h
@@ -15,6 +15,8 @@
  * \author  Vladimir Rekovic
  *                - indexing
  *                - correlations with overlap object removal
+ * \author R. Cavanaugh
+ *                - displaced muons
  *
  * $Date$
  * $Revision$
@@ -293,6 +295,12 @@ namespace l1t {
                       std::string lutpfx,
                       std::string obj1,
                       unsigned int prec);
+
+    // Parse LUT for Upt LUT in Mass calculation for displaced muons
+    void parseUpt_LUTS(std::map<std::string, tmeventsetup::esScale> scaleMap,
+		       std::string lutpfx,
+		       std::string obj1,
+		       unsigned int prec);
 
     // Parse LUT for Delta Eta and Cosh
     void parseDeltaEta_Cosh_LUTS(std::map<std::string, tmeventsetup::esScale> scaleMap,

--- a/L1Trigger/L1TGlobal/src/CorrCondition.cc
+++ b/L1Trigger/L1TGlobal/src/CorrCondition.cc
@@ -1184,6 +1184,19 @@ const bool l1t::CorrCondition::evaluateCondition(const int bxEval) const {
         long long ptObj1 = m_gtScales->getLUT_Pt("Mass_" + lutName, etIndex1);
         unsigned int precPtLUTObj1 = m_gtScales->getPrec_Pt("Mass_" + lutName);
 
+        if( corrPar.corrCutType & 0x40 ) // Added for displaced muons
+          {
+	    lutName = lutObj0;
+            lutName += "-UPT";
+            ptObj0 = m_gtScales->getLUT_Upt("Mass_" + lutName, uptIndex0);
+            precPtLUTObj0 = m_gtScales->getPrec_Upt("Mass_" + lutName);
+
+            lutName = lutObj1;
+            lutName += "-UPT";
+            ptObj1 = m_gtScales->getLUT_Upt("Mass_" + lutName, uptIndex1);
+            precPtLUTObj1 = m_gtScales->getPrec_Upt("Mass_" + lutName);
+          }
+
         // Pt and Angles are at different precission.
         long long massSq = ptObj0 * ptObj1 * (coshDeltaEtaLUT - cosDeltaPhiLUT);
 

--- a/L1Trigger/L1TGlobal/src/GlobalScales.cc
+++ b/L1Trigger/L1TGlobal/src/GlobalScales.cc
@@ -98,6 +98,22 @@ void l1t::GlobalScales::setLUT_Pt(const std::string& lutName, std::vector<long l
   return;
 }
 
+// Added for displaced muons
+void l1t::GlobalScales::setLUT_Upt(const std::string& lutName, std::vector<long long> lut, unsigned int precision) {
+  if (m_lut_Upt.count(lutName) != 0) {
+    LogTrace("GlobalScales") << "      LUT \"" << lutName << "\"already exists in the LUT map- not inserted!"
+                             << std::endl;
+    return;
+  }
+
+  // Insert this LUT into the Table                                                                                                                  
+  m_lut_Upt.insert(std::map<std::string, std::vector<long long>>::value_type(lutName, lut));
+  m_Prec_Upt.insert(std::map<std::string, unsigned int>::value_type(lutName, precision));
+
+  return;
+}
+
+
 void l1t::GlobalScales::setLUT_Cosh(const std::string& lutName, std::vector<long long> lut, unsigned int precision) {
   if (m_lut_Cosh.count(lutName) != 0) {
     LogTrace("GlobalScales") << "      LUT \"" << lutName << "\"already exists in the LUT map- not inserted!"
@@ -299,6 +315,33 @@ unsigned int l1t::GlobalScales::getPrec_Pt(const std::string& lutName) const {
     value = m_Prec_Pt.find(lutName)->second;
   } else {
     edm::LogError("GlobalScales") << "Warning: LUT " << lutName << " for Pt not found" << std::endl;
+  }
+  return value;
+}
+
+// Added for displaced muons
+long long l1t::GlobalScales::getLUT_Upt(const std::string& lutName, int element) const {
+  long long value = 0;
+
+  if (element < 0) {
+    edm::LogError("GlobalScales") << "Error: Negative index, " << element << ", requested for Upt LUT ( " << lutName
+                                  << ")" << std::endl;
+  } else if (element >= (int)m_lut_Upt.find(lutName)->second.size()) {
+    edm::LogError("GlobalScales") << "Error: Element Requested " << element << " too large for Upt LUT (" << lutName
+                                  << ") size = " << m_lut_Upt.find(lutName)->second.size() << std::endl;
+  } else {
+    value = m_lut_Upt.find(lutName)->second.at(element);
+  }
+  return value;
+}
+// Added for displaced muons
+unsigned int l1t::GlobalScales::getPrec_Upt(const std::string& lutName) const {
+  unsigned int value = 0;
+
+  if (m_Prec_Upt.find(lutName) != m_Prec_Upt.end()) {
+    value = m_Prec_Upt.find(lutName)->second;
+  } else {
+    edm::LogError("GlobalScales") << "Warning: LUT " << lutName << " for Upt not found" << std::endl;
   }
   return value;
 }
@@ -520,6 +563,12 @@ void l1t::GlobalScales::dumpAllLUTs(std::ostream& myCout) const {
        itr++) {
     dumpLUT(myCout, 8, itr->first);
   }
+  // Added for displaced muons
+  for (std::map<std::string, std::vector<long long>>::const_iterator itr = m_lut_Upt.begin(); itr != m_lut_Upt.end();
+       itr++) {
+    dumpLUT(myCout, 8, itr->first);
+  }
+
 }
 
 void l1t::GlobalScales::dumpLUT(std::ostream& myCout, int LUTtype, std::string name) const {
@@ -571,6 +620,12 @@ void l1t::GlobalScales::dumpLUT(std::ostream& myCout, int LUTtype, std::string n
       dumpV = m_lut_Pt.find(name)->second;
       prec = m_Prec_Pt.find(name)->second;
       type = "Pt";
+      break;
+    }
+    case 9: { // Added for displaced muons
+      dumpV = m_lut_Upt.find(name)->second;
+      prec = m_Prec_Upt.find(name)->second;
+      type = "Upt";
       break;
     }
   }
@@ -668,6 +723,14 @@ void l1t::GlobalScales::print(std::ostream& myCout) const {
 
   myCout << " Pt:      ";
   for (std::map<std::string, std::vector<long long>>::const_iterator itr = m_lut_Pt.begin(); itr != m_lut_Pt.end();
+       itr++) {
+    myCout << " " << itr->first;
+  }
+  myCout << std::endl;
+
+  // Added for displaced muons
+  myCout << " Upt:      ";
+  for (std::map<std::string, std::vector<long long>>::const_iterator itr = m_lut_Upt.begin(); itr != m_lut_Upt.end();
        itr++) {
     myCout << " " << itr->first;
   }

--- a/L1Trigger/L1TGlobal/src/MuonTemplate.cc
+++ b/L1Trigger/L1TGlobal/src/MuonTemplate.cc
@@ -9,6 +9,7 @@
  *
  * \author: Vasile Mihai Ghete - HEPHY Vienna
  *          Vladimir Rekovic - extend for indexing
+ *          Rick Cavanaugh - extend for displaced muons
  *
  * $Date$
  * $Revision$
@@ -79,6 +80,8 @@ void MuonTemplate::print(std::ostream& myCout) const {
     myCout << "  Template for object " << i << " [ hex ]" << std::endl;
     myCout << "    ptHighThreshold   = " << std::hex << m_objectParameter[i].ptHighThreshold << std::endl;
     myCout << "    ptLowThreshold    = " << std::hex << m_objectParameter[i].ptLowThreshold << std::endl;
+    myCout << "    uptHighCut        = " << std::hex << m_objectParameter[i].unconstrainedPtHigh << std::endl;
+    myCout << "    uptLowCut         = " << std::hex << m_objectParameter[i].unconstrainedPtLow << std::endl;
     myCout << "    indexHigh           = " << std::hex << m_objectParameter[i].indexHigh << std::endl;
     myCout << "    indexLow            = " << std::hex << m_objectParameter[i].indexLow << std::endl;
     myCout << "    enableMip         = " << std::hex << m_objectParameter[i].enableMip << std::endl;
@@ -87,6 +90,7 @@ void MuonTemplate::print(std::ostream& myCout) const {
     myCout << "    charge            =" << std::dec << m_objectParameter[i].charge << std::endl;
     myCout << "    qualityLUT        = " << std::hex << m_objectParameter[i].qualityLUT << std::endl;
     myCout << "    isolationLUT      = " << std::hex << m_objectParameter[i].isolationLUT << std::endl;
+    myCout << "    impactParameterLUT= " << std::hex << m_objectParameter[i].impactParameterLUT << std::endl;
     //       myCout << "    etaRange          = "
     //       << std::hex << m_objectParameter[i].etaRange << std::endl;
     //       myCout << "    phiHigh           = "


### PR DESCRIPTION
(cherry picked from commit f67895d494ce3c518a7b136ac707aac08ea2e652)

#### PR description:

This is a bug-fix to the uGT emulator for the unconstrained pT (UPT) invariant mass correlation condition; the calculation in the original PR incorrectly used the nominal pT, rather than the UPT. The bug-fix to the emulator is somewhat extensive and required code changes in several locations:
(1) TriggerMenuParser(.h, .cc), GlobalScales.(h, .cc) all had to be modified to correctly parse, set, and get the LUT scales for UPT.
(2) CorrCondition.cc had to be modified to correctly get and apply the LUT scales for UPT to enable the correct calculation of the invariant mass for UPT using integer arithmetic based on the LUT scales for UPT.
(3) TriggerMenuParser.cc also had to be modified to correctly parse the UPT and DXY (impact parameter) cuts for muon correlation conditions.
(4) the print function in MuonTemplate.cc now includes displaced muon information, for debugging purposes.

#### PR validation:

This PR has been validated by the following:
(1) confirming that all code changes compile correctly using l1t-integration-CMSSW_11_2_0 with tag l1t-integration-v105.3
(2) confirming that all code changes execute properly by producing test vectors
(3) confirming that the bug-fix is correct by comparing the emulator results in the test vectors with the uGT firmware.

Note that the VHDL firmware independently had the same bug, which caused earlier test vector comparisons between the emulator and the firmware to (incorrectly) agree. These new validation tests now demonstrate (correct) agreement between the bug-fixed emulator with the bug-fixed firmware.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

https://github.com/cms-l1t-offline/cmssw/pull/903

@rekovic @boudoul 

