### PR TITLE
L1T Bugfix for Quad Muon OS condition

### DIFF
--- a/L1Trigger/L1TGlobal/src/MuCondition.cc
+++ b/L1Trigger/L1TGlobal/src/MuCondition.cc
@@ -246,9 +246,9 @@ const bool l1t::MuCondition::evaluateCondition(const int bxEval) const {
             }
           }
 
-          // Original OS 4 muon condition (disagreement with firmware): 
+          // Original OS 4 muon condition (disagreement with firmware):
           //    if (!(((chargeCorr & 2) != 0 && equalSigns) || ((chargeCorr & 4) != 0 && posCount == 2))) {
-          // Fix by R. Cavanaugh: 
+          // Fix by R. Cavanaugh:
           //       Note that negative charge => hwCharge = 0
           //                 positive charge => hwCharge = 1
           //       Hence:  (0,0,0,0) => (posCount = 0) => 4 SS muons
@@ -260,7 +260,7 @@ const bool l1t::MuCondition::evaluateCondition(const int bxEval) const {
           //               (1,1,1,1) => (posCount = 4) => 4 SS muons
           //       A requirement (posCount == 2) implies there must be exactly 2 OS pairs of muons
           //       A requirement of at least 1 pair of OS muons implies condition should be (posCount > 0 && posCount < 4)
-	  if (!(((chargeCorr & 2) != 0 && equalSigns) || ((chargeCorr & 4) != 0 && (posCount > 0 && posCount < 4)))) {
+          if (!(((chargeCorr & 2) != 0 && equalSigns) || ((chargeCorr & 4) != 0 && (posCount > 0 && posCount < 4)))) {
             LogDebug("L1TGlobal") << "===> MuCondition:: 4 Muon Fail Charge Correlation Condition = " << chargeCorr
                                   << " posCnt " << posCount << std::endl;
             continue;

--- a/L1Trigger/L1TGlobal/src/MuCondition.cc
+++ b/L1Trigger/L1TGlobal/src/MuCondition.cc
@@ -246,7 +246,21 @@ const bool l1t::MuCondition::evaluateCondition(const int bxEval) const {
             }
           }
 
-          if (!(((chargeCorr & 2) != 0 && equalSigns) || ((chargeCorr & 4) != 0 && posCount == 2))) {
+          // Original OS 4 muon condition (disagreement with firmware): 
+          //    if (!(((chargeCorr & 2) != 0 && equalSigns) || ((chargeCorr & 4) != 0 && posCount == 2))) {
+          // Fix by R. Cavanaugh: 
+          //       Note that negative charge => hwCharge = 0
+          //                 positive charge => hwCharge = 1
+          //       Hence:  (0,0,0,0) => (posCount = 0) => 4 SS muons
+          //               (1,0,0,0) => (posCount = 1) => 1 OS muon pair, 1 SS muon pair
+          //               (1,1,0,0) => (posCount = 2) => 2 OS muon pairs
+          //               (1,0,1,0) => (posCount = 2) => 2 OS muon pairs
+          //               (0,0,1,1) => (posCount = 2) => 2 OS muon pairs
+          //               (1,1,1,0) => (posCount = 3) => 1 SS muon pair, 1 OS muon pair
+          //               (1,1,1,1) => (posCount = 4) => 4 SS muons
+          //       A requirement (posCount == 2) implies there must be exactly 2 OS pairs of muons
+          //       A requirement of at least 1 pair of OS muons implies condition should be (posCount > 0 && posCount < 4)
+	  if (!(((chargeCorr & 2) != 0 && equalSigns) || ((chargeCorr & 4) != 0 && (posCount > 0 && posCount < 4)))) {
             LogDebug("L1TGlobal") << "===> MuCondition:: 4 Muon Fail Charge Correlation Condition = " << chargeCorr
                                   << " posCnt " << posCount << std::endl;
             continue;


### PR DESCRIPTION
(cherry picked from commit 3d5a10e3edb2e92d2609c90ebe03a8e66f364ea9)

#### PR description:

This PR is a bug-fix for the uGT emulator. The uGT firmware requires at least 1 pair of OS muons for Quad Muons. The bug in the uGT emulator corresponded to a requirement of exactly 2 OS pairs of muons, which disagreed with firmware. This PR fixes that bug so that the emulator only requires at least 1 pair of OS muons for Quad Muons.

No changes in output are expected.

#### PR validation:

This PR has been validated by the following:
(1) confirming that all code changes compile correctly using l1t-integration-CMSSW_11_2_0 with tag l1t-integration-v105.3
(2) confirming that all code changes execute properly by producing test vectors
(3) confirming that the bug-fix is correct by comparing the emulator results in the test vectors with the uGT firmware.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

https://github.com/cms-l1t-offline/cmssw/pull/894

@rekovic @cavana 
