### PR TITLE
Extension of electron matching in nanoAOD (backport)

### DIFF
--- a/PhysicsTools/HepMCCandAlgos/plugins/MCTruthMatchers.cc
+++ b/PhysicsTools/HepMCCandAlgos/plugins/MCTruthMatchers.cc
@@ -10,37 +10,39 @@
 
 // Match by deltaR and deltaPt, ranking by deltaR (default)
 typedef reco::PhysObjectMatcher<
-  reco::CandidateView,
-  reco::GenParticleCollection,
-  reco::MCMatchSelector<reco::CandidateView::value_type,
-			reco::GenParticleCollection::value_type>,
-  reco::MatchByDRDPt<reco::CandidateView::value_type,
-		     reco::GenParticleCollection::value_type>
-> MCMatcher;
+    reco::CandidateView,
+    reco::GenParticleCollection,
+    reco::MCMatchSelector<reco::CandidateView::value_type, reco::GenParticleCollection::value_type>,
+    reco::MatchByDRDPt<reco::CandidateView::value_type, reco::GenParticleCollection::value_type> >
+    MCMatcher;
 
 // Alternative: match by deltaR and deltaPt, ranking by deltaPt
 typedef reco::PhysObjectMatcher<
-  reco::CandidateView,
-  reco::GenParticleCollection,
-  reco::MCMatchSelector<reco::CandidateView::value_type,
-			reco::GenParticleCollection::value_type>,
-  reco::MatchByDRDPt<reco::CandidateView::value_type,
-		     reco::GenParticleCollection::value_type>,
-  reco::MatchLessByDPt<reco::CandidateView,
-			 reco::GenParticleCollection>
-> MCMatcherByPt;
+    reco::CandidateView,
+    reco::GenParticleCollection,
+    reco::MCMatchSelector<reco::CandidateView::value_type, reco::GenParticleCollection::value_type>,
+    reco::MatchByDRDPt<reco::CandidateView::value_type, reco::GenParticleCollection::value_type>,
+    reco::MatchLessByDPt<reco::CandidateView, reco::GenParticleCollection> >
+    MCMatcherByPt;
 
 // JET Match by deltaR, ranking by deltaR (default)
 typedef reco::PhysObjectMatcher<
-  reco::CandidateView,
-  reco::GenJetCollection,
-  reco::MCMatchSelector<reco::CandidateView::value_type,
-			reco::GenJetCollection::value_type>,
-  reco::MatchByDR<reco::CandidateView::value_type,
-		  reco::CandidateView::value_type>
-> GenJetMatcher;
+    reco::CandidateView,
+    reco::GenJetCollection,
+    reco::MCMatchSelector<reco::CandidateView::value_type, reco::GenJetCollection::value_type>,
+    reco::MatchByDR<reco::CandidateView::value_type, reco::CandidateView::value_type> >
+    GenJetMatcher;
+
+// JET Match by deltaR and dPt, ranking by deltaR
+typedef reco::PhysObjectMatcher<
+    reco::CandidateView,
+    reco::GenJetCollection,
+    reco::MCMatchSelector<reco::CandidateView::value_type, reco::GenJetCollection::value_type>,
+    reco::MatchByDRDPt<reco::CandidateView::value_type, reco::GenJetCollection::value_type> >
+    GenJetMatcherDRPtByDR;
 
 #include "FWCore/Framework/interface/MakerMacros.h"
 DEFINE_FWK_MODULE(MCMatcher);
 DEFINE_FWK_MODULE(MCMatcherByPt);
 DEFINE_FWK_MODULE(GenJetMatcher);
+DEFINE_FWK_MODULE(GenJetMatcherDRPtByDR);

--- a/PhysicsTools/NanoAOD/plugins/CandMCMatchTableProducer.cc
+++ b/PhysicsTools/NanoAOD/plugins/CandMCMatchTableProducer.cc
@@ -7,149 +7,277 @@
 #include "DataFormats/Common/interface/View.h"
 #include "DataFormats/Candidate/interface/Candidate.h"
 #include "DataFormats/HepMCCandidate/interface/GenParticle.h"
+#include <DataFormats/Math/interface/deltaR.h>
+#include "DataFormats/JetReco/interface/GenJetCollection.h"
 
 #include <vector>
 #include <iostream>
 
-
 class CandMCMatchTableProducer : public edm::global::EDProducer<> {
-    public:
-        CandMCMatchTableProducer( edm::ParameterSet const & params ) :
-            objName_(params.getParameter<std::string>("objName")),
-            branchName_(params.getParameter<std::string>("branchName")),
-            doc_(params.getParameter<std::string>("docString")),
-            src_(consumes<reco::CandidateView>(params.getParameter<edm::InputTag>("src"))),
-            candMap_(consumes<edm::Association<reco::GenParticleCollection>>(params.getParameter<edm::InputTag>("mcMap")))            
-        {
-            produces<nanoaod::FlatTable>();
-            const std::string & type = params.getParameter<std::string>("objType");
-            if (type == "Muon") type_ = MMuon;
-            else if (type == "Electron") type_ = MElectron;
-            else if (type == "Tau") type_ = MTau;
-            else if (type == "Photon") type_ = MPhoton;
-            else if (type == "Other") type_ = MOther;
-            else throw cms::Exception("Configuration", "Unsupported objType '"+type+"'\n");
-    
-            switch(type_) { 
-                case MMuon: flavDoc_ = "1 = prompt muon (including gamma*->mu mu), 15 = muon from prompt tau, " // continues below
-                                       "5 = muon from b, 4 = muon from c, 3 = muon from light or unknown, 0 = unmatched"; break;
-                case MElectron: flavDoc_ = "1 = prompt electron (including gamma*->mu mu), 15 = electron from prompt tau, 22 = prompt photon (likely conversion), " // continues below
-                                           "5 = electron from b, 4 = electron from c, 3 = electron from light or unknown, 0 = unmatched"; break;
-                case MPhoton: flavDoc_ = "1 = prompt photon, 11 = prompt electron, 0 = unknown or unmatched"; break;
-                case MTau: flavDoc_    = "1 = prompt electron, 2 = prompt muon, 3 = tau->e decay, 4 = tau->mu decay, 5 = hadronic tau decay, 0 = unknown or unmatched"; break;
-                case MOther: flavDoc_  = "1 = from hard scatter, 0 = unknown or unmatched"; break;
+public:
+  CandMCMatchTableProducer(edm::ParameterSet const& params)
+      : objName_(params.getParameter<std::string>("objName")),
+        branchName_(params.getParameter<std::string>("branchName")),
+        doc_(params.getParameter<std::string>("docString")),
+        src_(consumes<reco::CandidateView>(params.getParameter<edm::InputTag>("src"))),
+        candMap_(consumes<edm::Association<reco::GenParticleCollection>>(params.getParameter<edm::InputTag>("mcMap"))) {
+    produces<nanoaod::FlatTable>();
+    const std::string& type = params.getParameter<std::string>("objType");
+    if (type == "Muon")
+      type_ = MMuon;
+    else if (type == "Electron")
+      type_ = MElectron;
+    else if (type == "ElectronDressed")
+      type_ = MElectronDressed;
+    else if (type == "Tau")
+      type_ = MTau;
+    else if (type == "Photon")
+      type_ = MPhoton;
+    else if (type == "Other")
+      type_ = MOther;
+    else
+      throw cms::Exception("Configuration", "Unsupported objType '" + type + "'\n");
+
+    switch (type_) {
+      case MMuon:
+        flavDoc_ =
+            "1 = prompt muon (including gamma*->mu mu), 15 = muon from prompt tau, "  // continues below
+            "5 = muon from b, 4 = muon from c, 3 = muon from light or unknown, 0 = unmatched";
+        break;
+      case MElectron:
+        flavDoc_ =
+            "1 = prompt electron (including gamma*->mu mu), 15 = electron from prompt tau, 22 = prompt photon (likely "
+            "conversion), "  // continues below
+            "5 = electron from b, 4 = electron from c, 3 = electron from light or unknown, 0 = unmatched";
+        break;
+      case MElectronDressed:
+        flavDoc_ =
+            "1 = prompt electron (including gamma*->mu mu), 15 = electron from prompt tau, 22 = prompt photon (likely "
+            "conversion), "  // continues below
+            "5 = electron from b, 4 = electron from c, 3 = electron from light or unknown, 0 = unmatched";
+        break;
+      case MPhoton:
+        flavDoc_ = "1 = prompt photon, 11 = prompt electron, 0 = unknown or unmatched";
+        break;
+      case MTau:
+        flavDoc_ =
+            "1 = prompt electron, 2 = prompt muon, 3 = tau->e decay, 4 = tau->mu decay, 5 = hadronic tau decay, 0 = "
+            "unknown or unmatched";
+        break;
+      case MOther:
+        flavDoc_ = "1 = from hard scatter, 0 = unknown or unmatched";
+        break;
+    }
+
+    if (type_ == MTau) {
+      candMapVisTau_ =
+          consumes<edm::Association<reco::GenParticleCollection>>(params.getParameter<edm::InputTag>("mcMapVisTau"));
+    }
+    if (type_ == MElectronDressed) {
+      candMapDressedLep_ =
+          consumes<edm::Association<reco::GenJetCollection>>(params.getParameter<edm::InputTag>("mcMapDressedLep"));
+      mapTauAnc_ = consumes<edm::ValueMap<bool>>(params.getParameter<edm::InputTag>("mapTauAnc"));
+      genPartsToken_ = consumes<reco::GenParticleCollection>(params.getParameter<edm::InputTag>("genparticles"));
+    }
+  }
+
+  ~CandMCMatchTableProducer() override {}
+
+  void produce(edm::StreamID id, edm::Event& iEvent, const edm::EventSetup& iSetup) const override {
+    edm::Handle<reco::CandidateView> cands;
+    iEvent.getByToken(src_, cands);
+    unsigned int ncand = cands->size();
+
+    auto tab = std::make_unique<nanoaod::FlatTable>(ncand, objName_, false, true);
+
+    edm::Handle<edm::Association<reco::GenParticleCollection>> map;
+    iEvent.getByToken(candMap_, map);
+
+    edm::Handle<edm::Association<reco::GenParticleCollection>> mapVisTau;
+    if (type_ == MTau) {
+      iEvent.getByToken(candMapVisTau_, mapVisTau);
+    }
+
+    edm::Handle<edm::Association<reco::GenJetCollection>> mapDressedLep;
+    edm::Handle<edm::ValueMap<bool>> mapTauAnc;
+    edm::Handle<reco::GenParticleCollection> genParts;
+    if (type_ == MElectronDressed) {
+      iEvent.getByToken(candMapDressedLep_, mapDressedLep);
+      iEvent.getByToken(mapTauAnc_, mapTauAnc);
+      iEvent.getByToken(genPartsToken_, genParts);
+    }
+
+    std::vector<int> key(ncand, -1), flav(ncand, 0);
+    for (unsigned int i = 0; i < ncand; ++i) {
+      //std::cout << "cand #" << i << ": pT = " << cands->ptrAt(i)->pt() << ", eta = " << cands->ptrAt(i)->eta() << ", phi = " << cands->ptrAt(i)->phi() << std::endl;
+      reco::GenParticleRef match = (*map)[cands->ptrAt(i)];
+      reco::GenParticleRef matchVisTau;
+      reco::GenJetRef matchDressedLep;
+      bool hasTauAnc = false;
+      if (type_ == MTau) {
+        matchVisTau = (*mapVisTau)[cands->ptrAt(i)];
+      }
+      if (type_ == MElectronDressed) {
+        matchDressedLep = (*mapDressedLep)[cands->ptrAt(i)];
+        if (matchDressedLep.isNonnull()) {
+          hasTauAnc = (*mapTauAnc)[matchDressedLep];
+        }
+      }
+      if (match.isNonnull())
+        key[i] = match.key();
+      else if (matchVisTau.isNonnull())
+        key[i] = matchVisTau.key();
+      else if (type_ != MElectronDressed)
+        continue;  // go ahead with electrons, as those may be matched to a dressed lepton
+      switch (type_) {
+        case MMuon:
+          if (match->isPromptFinalState())
+            flav[i] = 1;  // prompt
+          else if (match->isDirectPromptTauDecayProductFinalState())
+            flav[i] = 15;  // tau
+          else
+            flav[i] = getParentHadronFlag(match);  // 3 = light, 4 = charm, 5 = b
+          break;
+        case MElectron:
+          if (match->isPromptFinalState())
+            flav[i] = (match->pdgId() == 22 ? 22 : 1);  // prompt electron or photon
+          else if (match->isDirectPromptTauDecayProductFinalState())
+            flav[i] = 15;  // tau
+          else
+            flav[i] = getParentHadronFlag(match);  // 3 = light, 4 = charm, 5 = b
+          break;
+        case MElectronDressed:
+          if (matchDressedLep.isNonnull()) {
+            if (matchDressedLep->pdgId() == 22)
+              flav[i] = 22;
+            else
+              flav[i] = (hasTauAnc) ? 15 : 1;
+
+            float minpt = 0;
+            const reco::GenParticle* highestPtConstituent = nullptr;
+            for (auto& consti : matchDressedLep->getGenConstituents()) {
+              if (abs(consti->pdgId()) != 11)
+                continue;
+              if (consti->pt() < minpt)
+                continue;
+              minpt = consti->pt();
+              highestPtConstituent = consti;
             }
-
-	    if ( type_ == MTau ) {
-	      candMapVisTau_ = consumes<edm::Association<reco::GenParticleCollection>>(params.getParameter<edm::InputTag>("mcMapVisTau"));
-	    }
-        }
-
-        ~CandMCMatchTableProducer() override {}
-
-        void produce(edm::StreamID id, edm::Event& iEvent, const edm::EventSetup& iSetup) const override {
-
-            edm::Handle<reco::CandidateView> cands;
-            iEvent.getByToken(src_, cands);
-            unsigned int ncand = cands->size();
-
-            auto tab  = std::make_unique<nanoaod::FlatTable>(ncand, objName_, false, true);
-
-            edm::Handle<edm::Association<reco::GenParticleCollection>> map;
-            iEvent.getByToken(candMap_, map);
-
-	    edm::Handle<edm::Association<reco::GenParticleCollection>> mapVisTau;
-	    if ( type_ == MTau ) {
-	      iEvent.getByToken(candMapVisTau_, mapVisTau);
-	    }
-
-            std::vector<int> key(ncand, -1), flav(ncand, 0);
-            for (unsigned int i = 0; i < ncand; ++i) {
-	      //std::cout << "cand #" << i << ": pT = " << cands->ptrAt(i)->pt() << ", eta = " << cands->ptrAt(i)->eta() << ", phi = " << cands->ptrAt(i)->phi() << std::endl;
-                reco::GenParticleRef match = (*map)[cands->ptrAt(i)];
-		reco::GenParticleRef matchVisTau;
-		if ( type_ == MTau ) {
-		  matchVisTau = (*mapVisTau)[cands->ptrAt(i)];
-		}
-                if      ( match.isNonnull()       ) key[i] = match.key();
-		else if ( matchVisTau.isNonnull() ) key[i] = matchVisTau.key();
-		else continue;
-                switch(type_) {
-                    case MMuon:		        
-                        if (match->isPromptFinalState()) flav[i] = 1; // prompt
-                        else if (match->isDirectPromptTauDecayProductFinalState()) flav[i] = 15; // tau
-                        else flav[i] = getParentHadronFlag(match); // 3 = light, 4 = charm, 5 = b
-                        break;
-                    case MElectron:
-                        if (match->isPromptFinalState()) flav[i] = (match->pdgId() == 22 ? 22 : 1); // prompt electron or photon
-                        else if (match->isDirectPromptTauDecayProductFinalState()) flav[i] = 15; // tau
-                        else flav[i] = getParentHadronFlag(match); // 3 = light, 4 = charm, 5 = b
-                        break;
-                    case MPhoton:
-		        if (match->isPromptFinalState() && match->pdgId() == 22)
-			  flav[i] = 1;  // prompt photon
-			else if ((match->isPromptFinalState() || match->isDirectPromptTauDecayProductFinalState()) &&
-				 abs(match->pdgId()) == 11)
-			  flav[i] = 11;  // prompt electron
-			break;
-                    case MTau:
-		        // CV: assignment of status codes according to https://twiki.cern.ch/twiki/bin/viewauth/CMS/HiggsToTauTauWorking2016#MC_Matching
-		        if      ( match.isNonnull() && match->statusFlags().isPrompt()                  && abs(match->pdgId()) == 11 ) flav[i] = 1;
-                        else if ( match.isNonnull() && match->statusFlags().isPrompt()                  && abs(match->pdgId()) == 13 ) flav[i] = 2;
-			else if ( match.isNonnull() && match->isDirectPromptTauDecayProductFinalState() && abs(match->pdgId()) == 11 ) flav[i] = 3;
-			else if ( match.isNonnull() && match->isDirectPromptTauDecayProductFinalState() && abs(match->pdgId()) == 13 ) flav[i] = 4;
-			else if ( matchVisTau.isNonnull()                                                                            ) flav[i] = 5;
-                        break;
-                    default:
-                        flav[i] = match->statusFlags().fromHardProcess();
-                };
-            }        
-            
-            tab->addColumn<int>(branchName_+"Idx",  key, "Index into genParticle list for "+doc_, nanoaod::FlatTable::IntColumn);
-            tab->addColumn<uint8_t>(branchName_+"Flav", flav, "Flavour of genParticle for "+doc_+": "+flavDoc_, nanoaod::FlatTable::UInt8Column);
-
-            iEvent.put(std::move(tab));
-        }
-
-        static int getParentHadronFlag(const reco::GenParticleRef match) {
-            bool has4 = false;
-            for (unsigned int im = 0, nm = match->numberOfMothers(); im < nm; ++im) {
-                reco::GenParticleRef mom = match->motherRef(im);
-                assert(mom.isNonnull() && mom.isAvailable()); // sanity
-                if (mom.key() >= match.key()) continue; // prevent circular refs
-                int id = std::abs(mom->pdgId());
-                if (id / 1000 == 5 || id / 100 == 5 || id == 5) return 5;
-                if (id / 1000 == 4 || id / 100 == 4 || id == 4) has4 = true;
-                if (mom->status() == 2) {
-                    id = getParentHadronFlag(mom);
-                    if (id == 5) return 5;
-                    else if (id == 4) has4 = true;
-                }
+            if (highestPtConstituent) {
+              auto iter =
+                  std::find_if(genParts->begin(), genParts->end(), [highestPtConstituent](reco::GenParticle genp) {
+                    return (abs(genp.pdgId()) == 11) && (deltaR(genp, *highestPtConstituent) < 0.01) &&
+                           (abs(genp.pt() - highestPtConstituent->pt()) / highestPtConstituent->pt() < 0.01);
+                  });
+              if (iter != genParts->end()) {
+                key[i] = iter - genParts->begin();
+              }
             }
-            return has4 ? 4 : 3;
-        }
+          } else if (!match.isNonnull())
+            flav[i] = 0;
+          else if (match->isPromptFinalState())
+            flav[i] = (match->pdgId() == 22 ? 22 : 1);  // prompt electron or photon
+          else if (match->isDirectPromptTauDecayProductFinalState())
+            flav[i] = 15;  // tau
+          else
+            flav[i] = getParentHadronFlag(match);  // 3 = light, 4 = charm, 5 = b
+          break;
+        case MPhoton:
+          if (match->isPromptFinalState() && match->pdgId() == 22)
+            flav[i] = 1;  // prompt photon
+          else if ((match->isPromptFinalState() || match->isDirectPromptTauDecayProductFinalState()) &&
+                   abs(match->pdgId()) == 11)
+            flav[i] = 11;  // prompt electron
+          break;
+        case MTau:
+          // CV: assignment of status codes according to https://twiki.cern.ch/twiki/bin/viewauth/CMS/HiggsToTauTauWorking2016#MC_Matching
+          if (match.isNonnull() && match->statusFlags().isPrompt() && abs(match->pdgId()) == 11)
+            flav[i] = 1;
+          else if (match.isNonnull() && match->statusFlags().isPrompt() && abs(match->pdgId()) == 13)
+            flav[i] = 2;
+          else if (match.isNonnull() && match->isDirectPromptTauDecayProductFinalState() && abs(match->pdgId()) == 11)
+            flav[i] = 3;
+          else if (match.isNonnull() && match->isDirectPromptTauDecayProductFinalState() && abs(match->pdgId()) == 13)
+            flav[i] = 4;
+          else if (matchVisTau.isNonnull())
+            flav[i] = 5;
+          break;
+        default:
+          flav[i] = match->statusFlags().fromHardProcess();
+      };
+    }
 
-        static void fillDescriptions(edm::ConfigurationDescriptions & descriptions) {
-            edm::ParameterSetDescription desc;
-            desc.add<std::string>("objName")->setComment("name of the nanoaod::FlatTable to extend with this table");
-            desc.add<std::string>("branchName")->setComment("name of the column to write (the final branch in the nanoaod will be <objName>_<branchName>Idx and <objName>_<branchName>Flav");
-            desc.add<std::string>("docString")->setComment("documentation to forward to the output");
-            desc.add<edm::InputTag>("src")->setComment("physics object collection for the reconstructed objects (e.g. leptons)");
-            desc.add<edm::InputTag>("mcMap")->setComment("tag to an edm::Association<GenParticleCollection> mapping src to gen, such as the one produced by MCMatcher");
-            desc.add<std::string>("objType")->setComment("type of object to match (Muon, Electron, Tau, Photon, Other), taylors what's in t Flav branch");
-            desc.addOptional<edm::InputTag>("mcMapVisTau")->setComment("as mcMap, but pointing to the visible gen taus (only if objType == Tau)");
-            descriptions.add("candMcMatchTable", desc);
-        }
+    tab->addColumn<int>(
+        branchName_ + "Idx", key, "Index into genParticle list for " + doc_, nanoaod::FlatTable::IntColumn);
+    switch (type_) {
+      case MElectronDressed:
+        tab->addColumn<uint8_t>(branchName_ + "Flav",
+                                flav,
+                                "Flavour of genParticle (DressedLeptons for electrons) for " + doc_ + ": " + flavDoc_,
+                                nanoaod::FlatTable::UInt8Column);
+        break;
+      default:
+        tab->addColumn<uint8_t>(branchName_ + "Flav",
+                                flav,
+                                "Flavour of genParticle for " + doc_ + ": " + flavDoc_,
+                                nanoaod::FlatTable::UInt8Column);
+    }
+    iEvent.put(std::move(tab));
+  }
 
-    protected:
-        const std::string objName_, branchName_, doc_;
-        const edm::EDGetTokenT<reco::CandidateView> src_;
-        const edm::EDGetTokenT<edm::Association<reco::GenParticleCollection>> candMap_;
-        edm::EDGetTokenT<edm::Association<reco::GenParticleCollection>> candMapVisTau_;
-        enum MatchType { MMuon, MElectron, MTau, MPhoton, MOther } type_;
-        std::string flavDoc_;
+  static int getParentHadronFlag(const reco::GenParticleRef match) {
+    bool has4 = false;
+    for (unsigned int im = 0, nm = match->numberOfMothers(); im < nm; ++im) {
+      reco::GenParticleRef mom = match->motherRef(im);
+      assert(mom.isNonnull() && mom.isAvailable());  // sanity
+      if (mom.key() >= match.key())
+        continue;  // prevent circular refs
+      int id = std::abs(mom->pdgId());
+      if (id / 1000 == 5 || id / 100 == 5 || id == 5)
+        return 5;
+      if (id / 1000 == 4 || id / 100 == 4 || id == 4)
+        has4 = true;
+      if (mom->status() == 2) {
+        id = getParentHadronFlag(mom);
+        if (id == 5)
+          return 5;
+        else if (id == 4)
+          has4 = true;
+      }
+    }
+    return has4 ? 4 : 3;
+  }
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+    edm::ParameterSetDescription desc;
+    desc.add<std::string>("objName")->setComment("name of the nanoaod::FlatTable to extend with this table");
+    desc.add<std::string>("branchName")
+        ->setComment(
+            "name of the column to write (the final branch in the nanoaod will be <objName>_<branchName>Idx and "
+            "<objName>_<branchName>Flav");
+    desc.add<std::string>("docString")->setComment("documentation to forward to the output");
+    desc.add<edm::InputTag>("src")->setComment(
+        "physics object collection for the reconstructed objects (e.g. leptons)");
+    desc.add<edm::InputTag>("mcMap")->setComment(
+        "tag to an edm::Association<GenParticleCollection> mapping src to gen, such as the one produced by MCMatcher");
+    desc.add<std::string>("objType")->setComment(
+        "type of object to match (Muon, Electron, Tau, Photon, Other), taylors what's in t Flav branch");
+    desc.addOptional<edm::InputTag>("mcMapVisTau")
+        ->setComment("as mcMap, but pointing to the visible gen taus (only if objType == Tau)");
+    descriptions.add("candMcMatchTable", desc);
+  }
+
+protected:
+  const std::string objName_, branchName_, doc_;
+  const edm::EDGetTokenT<reco::CandidateView> src_;
+  const edm::EDGetTokenT<edm::Association<reco::GenParticleCollection>> candMap_;
+  edm::EDGetTokenT<edm::Association<reco::GenParticleCollection>> candMapVisTau_;
+  edm::EDGetTokenT<edm::Association<reco::GenJetCollection>> candMapDressedLep_;
+  edm::EDGetTokenT<edm::ValueMap<bool>> mapTauAnc_;
+  edm::EDGetTokenT<reco::GenParticleCollection> genPartsToken_;
+  enum MatchType { MMuon, MElectron, MTau, MPhoton, MOther, MElectronDressed } type_;
+  std::string flavDoc_;
 };
 
 #include "FWCore/Framework/interface/MakerMacros.h"
 DEFINE_FWK_MODULE(CandMCMatchTableProducer);
-

--- a/PhysicsTools/NanoAOD/plugins/CandMCMatchTableProducer.cc
+++ b/PhysicsTools/NanoAOD/plugins/CandMCMatchTableProducer.cc
@@ -264,6 +264,11 @@ public:
         "type of object to match (Muon, Electron, Tau, Photon, Other), taylors what's in t Flav branch");
     desc.addOptional<edm::InputTag>("mcMapVisTau")
         ->setComment("as mcMap, but pointing to the visible gen taus (only if objType == Tau)");
+    desc.addOptional<edm::InputTag>("mcMapDressedLep")
+      ->setComment("as mcMap, but pointing to gen dressed leptons (only if objType == Electrons)");
+    desc.addOptional<edm::InputTag>("mapTauAnc")
+      ->setComment("Value map of matched gen electrons containing info on the tau ancestry");
+    desc.addOptional<edm::InputTag>("genparticles")->setComment("Collection of genParticles to be stored.");
     descriptions.add("candMcMatchTable", desc);
   }
 

--- a/PhysicsTools/NanoAOD/plugins/GenJetGenPartMerger.cc
+++ b/PhysicsTools/NanoAOD/plugins/GenJetGenPartMerger.cc
@@ -1,0 +1,113 @@
+
+// system include files
+#include <memory>
+
+// user include files
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/StreamID.h"
+
+#include "DataFormats/JetReco/interface/GenJetCollection.h"
+#include "DataFormats/HepMCCandidate/interface/GenParticle.h"
+
+#include "DataFormats/Common/interface/ValueMap.h"
+
+//
+// class declaration
+//
+
+class GenJetGenPartMerger : public edm::stream::EDProducer<> {
+public:
+  explicit GenJetGenPartMerger(const edm::ParameterSet&);
+  ~GenJetGenPartMerger() override;
+
+private:
+  void beginStream(edm::StreamID) override;
+  void produce(edm::Event&, const edm::EventSetup&) override;
+  void endStream() override;
+
+  const edm::EDGetTokenT<reco::GenJetCollection> jetToken_;
+  const edm::EDGetTokenT<reco::GenParticleCollection> partToken_;
+  const edm::EDGetTokenT<edm::ValueMap<bool>> tauAncToken_;
+};
+
+//
+// constants, enums and typedefs
+//
+
+//
+// static data member definitions
+//
+
+//
+// constructors and destructor
+//
+GenJetGenPartMerger::GenJetGenPartMerger(const edm::ParameterSet& iConfig)
+    : jetToken_(consumes<reco::GenJetCollection>(iConfig.getParameter<edm::InputTag>("srcJet"))),
+      partToken_(consumes<reco::GenParticleCollection>(iConfig.getParameter<edm::InputTag>("srcPart"))),
+      tauAncToken_(consumes<edm::ValueMap<bool>>(iConfig.getParameter<edm::InputTag>("hasTauAnc"))) {
+  produces<reco::GenJetCollection>("merged");
+  produces<edm::ValueMap<bool>>("hasTauAnc");
+}
+
+GenJetGenPartMerger::~GenJetGenPartMerger() {}
+
+//
+// member functions
+//
+
+// ------------ method called to produce the data  ------------
+void GenJetGenPartMerger::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  using namespace edm;
+  std::unique_ptr<reco::GenJetCollection> merged(new reco::GenJetCollection);
+
+  std::vector<bool> hasTauAncValues;
+
+  edm::Handle<reco::GenJetCollection> jetHandle;
+  iEvent.getByToken(jetToken_, jetHandle);
+
+  edm::Handle<reco::GenParticleCollection> partHandle;
+  iEvent.getByToken(partToken_, partHandle);
+
+  edm::Handle<edm::ValueMap<bool>> tauAncHandle;
+  iEvent.getByToken(tauAncToken_, tauAncHandle);
+
+  for (unsigned int ijet = 0; ijet < jetHandle->size(); ++ijet) {
+    auto jet = jetHandle->at(ijet);
+    merged->push_back(reco::GenJet(jet));
+    reco::GenJetRef jetRef(jetHandle, ijet);
+    hasTauAncValues.push_back((*tauAncHandle)[jetRef]);
+  }
+
+  for (auto& part : *partHandle) {
+    reco::GenJet jet;
+    jet.setP4(part.p4());
+    jet.setPdgId(part.pdgId());
+    jet.setCharge(part.charge());
+    merged->push_back(jet);
+    hasTauAncValues.push_back(false);
+  }
+
+  auto newmerged = iEvent.put(std::move(merged), "merged");
+
+  std::unique_ptr<edm::ValueMap<bool>> out(new edm::ValueMap<bool>());
+  edm::ValueMap<bool>::Filler filler(*out);
+  filler.insert(newmerged, hasTauAncValues.begin(), hasTauAncValues.end());
+  filler.fill();
+
+  iEvent.put(std::move(out), "hasTauAnc");
+}
+
+// ------------ method called once each stream before processing any runs, lumis or events  ------------
+void GenJetGenPartMerger::beginStream(edm::StreamID) {}
+
+// ------------ method called once each stream after processing all runs, lumis and events  ------------
+void GenJetGenPartMerger::endStream() {}
+
+//define this as a plug-in
+DEFINE_FWK_MODULE(GenJetGenPartMerger);

--- a/PhysicsTools/NanoAOD/python/electrons_cff.py
+++ b/PhysicsTools/NanoAOD/python/electrons_cff.py
@@ -507,14 +507,14 @@ electronsMCMatchForTable = cms.EDProducer("MCMatcher",  # cut on deltaR, deltaPt
     resolveByMatchQuality = cms.bool(True),    # False = just match input in order; True = pick lowest deltaR pair first
 )
 
-electronOldMCTable = cms.EDProducer("CandMCMatchTableProducer",
-    src     = electronTable.src,
-    mcMap   = cms.InputTag("electronsMCMatchForTable"),
-    objName = electronTable.name,
-    objType = electronTable.name, #cms.string("Electron"),
-    branchName = cms.string("genPart"),
-    docString = cms.string("MC matching to status==1 electrons or photons"),
-)
+# electronOldMCTable = cms.EDProducer("CandMCMatchTableProducer",
+#     src     = electronTable.src,
+#     mcMap   = cms.InputTag("electronsMCMatchForTable"),
+#     objName = electronTable.name,
+#     objType = electronTable.name, #cms.string("Electron"),
+#     branchName = cms.string("genPart"),
+#     docString = cms.string("MC matching to status==1 electrons or photons"),
+# )
 
 electronMCTable = cms.EDProducer("CandMCMatchTableProducer",
     src     = electronTable.src,
@@ -531,8 +531,14 @@ electronMCTable = cms.EDProducer("CandMCMatchTableProducer",
 
 electronSequence = cms.Sequence(bitmapVIDForEle + bitmapVIDForEleHEEP + isoForEle + ptRatioRelForEle + seedGainEle + slimmedElectronsWithUserData + finalElectrons)
 electronTables = cms.Sequence (electronMVATTH + electronTable)
-electronMCold = cms.Sequence(electronsMCMatchForTable + electronOldMCTable)
+electronMCold = cms.Sequence(electronsMCMatchForTable + electronMCTable)
 electronMC = cms.Sequence(particleLevelForMatching + tautaggerForMatching + matchingElecPhoton + electronsMCMatchForTable + electronsMCMatchForTableAlt + electronMCTable)
+( run2_nanoAOD_106Xv1 & ~run2_nanoAOD_devel).toModify( electronMCTable,
+                                                       mcMapDressedLep=None,
+                                                       mcMap   = cms.InputTag("electronsMCMatchForTable"),
+                                                       mapTauAnc=None,
+                                                       objType=electronTable.name,
+                                                       genparticles=None)
 ( run2_nanoAOD_106Xv1 & ~run2_nanoAOD_devel).toReplaceWith(electronMC, electronMCold)
 
 #for NANO from reminAOD, no need to run slimmedElectronsUpdated, other modules of electron sequence will run on slimmedElectrons

--- a/PhysicsTools/NanoAOD/python/electrons_cff.py
+++ b/PhysicsTools/NanoAOD/python/electrons_cff.py
@@ -532,7 +532,7 @@ electronMCTableNew = cms.EDProducer("CandMCMatchTableProducer",
 electronSequence = cms.Sequence(bitmapVIDForEle + bitmapVIDForEleHEEP + isoForEle + ptRatioRelForEle + seedGainEle + slimmedElectronsWithUserData + finalElectrons)
 electronTables = cms.Sequence (electronMVATTH + electronTable)
 electronMC = cms.Sequence(electronsMCMatchForTable + electronMCTable)
-electronMCnew = cms.Sequence(particleLevelForMatching + tautaggerForMatching + matchingElecPhoton + electronsMCMatchForTable + electronsMCMatchForTableAlt + electronMCTable)
+electronMCnew = cms.Sequence(particleLevelForMatching + tautaggerForMatching + matchingElecPhoton + electronsMCMatchForTable + electronsMCMatchForTableAlt + electronMCTableNew)
 ( run2_nanoAOD_106Xv1 & ~run2_nanoAOD_devel).toReplaceWith(electronMC, electronMCnew)
 
 #for NANO from reminAOD, no need to run slimmedElectronsUpdated, other modules of electron sequence will run on slimmedElectrons

--- a/PhysicsTools/NanoAOD/python/electrons_cff.py
+++ b/PhysicsTools/NanoAOD/python/electrons_cff.py
@@ -507,7 +507,7 @@ electronsMCMatchForTable = cms.EDProducer("MCMatcher",  # cut on deltaR, deltaPt
     resolveByMatchQuality = cms.bool(True),    # False = just match input in order; True = pick lowest deltaR pair first
 )
 
-electronMCTableOld = cms.EDProducer("CandMCMatchTableProducer",
+electronOldMCTable = cms.EDProducer("CandMCMatchTableProducer",
     src     = electronTable.src,
     mcMap   = cms.InputTag("electronsMCMatchForTable"),
     objName = electronTable.name,
@@ -531,7 +531,7 @@ electronMCTable = cms.EDProducer("CandMCMatchTableProducer",
 
 electronSequence = cms.Sequence(bitmapVIDForEle + bitmapVIDForEleHEEP + isoForEle + ptRatioRelForEle + seedGainEle + slimmedElectronsWithUserData + finalElectrons)
 electronTables = cms.Sequence (electronMVATTH + electronTable)
-electronMCold = cms.Sequence(electronsMCMatchForTable + electronMCTableOld)
+electronMCold = cms.Sequence(electronsMCMatchForTable + electronOldMCTable)
 electronMC = cms.Sequence(particleLevelForMatching + tautaggerForMatching + matchingElecPhoton + electronsMCMatchForTable + electronsMCMatchForTableAlt + electronMCTable)
 ( run2_nanoAOD_106Xv1 & ~run2_nanoAOD_devel).toReplaceWith(electronMC, electronMCold)
 

--- a/PhysicsTools/NanoAOD/python/electrons_cff.py
+++ b/PhysicsTools/NanoAOD/python/electrons_cff.py
@@ -507,7 +507,7 @@ electronsMCMatchForTable = cms.EDProducer("MCMatcher",  # cut on deltaR, deltaPt
     resolveByMatchQuality = cms.bool(True),    # False = just match input in order; True = pick lowest deltaR pair first
 )
 
-electronMCTable = cms.EDProducer("CandMCMatchTableProducer",
+electronMCTableOld = cms.EDProducer("CandMCMatchTableProducer",
     src     = electronTable.src,
     mcMap   = cms.InputTag("electronsMCMatchForTable"),
     objName = electronTable.name,
@@ -516,7 +516,7 @@ electronMCTable = cms.EDProducer("CandMCMatchTableProducer",
     docString = cms.string("MC matching to status==1 electrons or photons"),
 )
 
-electronMCTableNew = cms.EDProducer("CandMCMatchTableProducer",
+electronMCTable = cms.EDProducer("CandMCMatchTableProducer",
     src     = electronTable.src,
     mcMapDressedLep = cms.InputTag("electronsMCMatchForTableAlt"),
     mcMap   = cms.InputTag("electronsMCMatchForTable"),
@@ -531,9 +531,9 @@ electronMCTableNew = cms.EDProducer("CandMCMatchTableProducer",
 
 electronSequence = cms.Sequence(bitmapVIDForEle + bitmapVIDForEleHEEP + isoForEle + ptRatioRelForEle + seedGainEle + slimmedElectronsWithUserData + finalElectrons)
 electronTables = cms.Sequence (electronMVATTH + electronTable)
-electronMC = cms.Sequence(electronsMCMatchForTable + electronMCTable)
-electronMCnew = cms.Sequence(particleLevelForMatching + tautaggerForMatching + matchingElecPhoton + electronsMCMatchForTable + electronsMCMatchForTableAlt + electronMCTableNew)
-( run2_nanoAOD_106Xv1 & ~run2_nanoAOD_devel).toReplaceWith(electronMC, electronMCnew)
+electronMCold = cms.Sequence(electronsMCMatchForTable + electronMCTableOld)
+electronMC = cms.Sequence(particleLevelForMatching + tautaggerForMatching + matchingElecPhoton + electronsMCMatchForTable + electronsMCMatchForTableAlt + electronMCTable)
+( run2_nanoAOD_106Xv1 & ~run2_nanoAOD_devel).toReplaceWith(electronMC, electronMCold)
 
 #for NANO from reminAOD, no need to run slimmedElectronsUpdated, other modules of electron sequence will run on slimmedElectrons
 for modifier in run2_miniAOD_80XLegacy,run2_nanoAOD_94XMiniAODv1,run2_nanoAOD_94XMiniAODv2,run2_nanoAOD_94X2016,run2_nanoAOD_102Xv1,run2_nanoAOD_106Xv1:

--- a/PhysicsTools/NanoAOD/python/electrons_cff.py
+++ b/PhysicsTools/NanoAOD/python/electrons_cff.py
@@ -466,6 +466,35 @@ run2_miniAOD_80XLegacy.toModify(electronTable.variables,
 
 )
 
+from PhysicsTools.NanoAOD.particlelevel_cff import particleLevel
+particleLevelForMatching = particleLevel.clone(
+    lepMinPt    = cms.double(3.),
+    phoMinPt = cms.double(3),
+)
+tautaggerForMatching = cms.EDProducer("GenJetTauTaggerProducer",
+                                      src = cms.InputTag('particleLevelForMatching:leptons')
+)
+
+matchingElecPhoton = cms.EDProducer("GenJetGenPartMerger",
+                                    srcJet =cms.InputTag("particleLevelForMatching:leptons"),
+                                    srcPart=cms.InputTag("particleLevelForMatching:photons"),
+                                    hasTauAnc=cms.InputTag("tautaggerForMatching"),
+)
+
+
+electronsMCMatchForTableAlt = cms.EDProducer("GenJetMatcherDRPtByDR",  # cut on deltaR, deltaPt/Pt; pick best by deltaR
+    src         = electronTable.src,                 # final reco collection
+    matched     = cms.InputTag("matchingElecPhoton:merged"), # final mc-truth particle collection
+    mcPdgId     = cms.vint32(11,22),                 # one or more PDG ID (11 = el, 22 = pho); absolute values (see below)
+    checkCharge = cms.bool(False),              # True = require RECO and MC objects to have the same charge
+    mcStatus    = cms.vint32(),
+    maxDeltaR   = cms.double(0.3),              # Minimum deltaR for the match
+    maxDPtRel   = cms.double(0.5),              # Minimum deltaPt/Pt for the match
+    resolveAmbiguities    = cms.bool(True),     # Forbid two RECO objects to match to the same GEN object
+    resolveByMatchQuality = cms.bool(True),    # False = just match input in order; True = pick lowest deltaR pair first
+) 
+
+
 electronsMCMatchForTable = cms.EDProducer("MCMatcher",  # cut on deltaR, deltaPt/Pt; pick best by deltaR
     src         = electronTable.src,                 # final reco collection
     matched     = cms.InputTag("finalGenParticles"), # final mc-truth particle collection
@@ -487,9 +516,24 @@ electronMCTable = cms.EDProducer("CandMCMatchTableProducer",
     docString = cms.string("MC matching to status==1 electrons or photons"),
 )
 
+electronMCTableNew = cms.EDProducer("CandMCMatchTableProducer",
+    src     = electronTable.src,
+    mcMapDressedLep = cms.InputTag("electronsMCMatchForTableAlt"),
+    mcMap   = cms.InputTag("electronsMCMatchForTable"),
+    mapTauAnc = cms.InputTag("matchingElecPhoton:hasTauAnc"),
+    objName = electronTable.name,
+    objType = cms.string("ElectronDressed"), 
+    branchName = cms.string("genPart"),
+    docString = cms.string("MC matching to status==1 electrons or photons"),
+    genparticles     = cms.InputTag("finalGenParticles"), 
+)
+
+
 electronSequence = cms.Sequence(bitmapVIDForEle + bitmapVIDForEleHEEP + isoForEle + ptRatioRelForEle + seedGainEle + slimmedElectronsWithUserData + finalElectrons)
 electronTables = cms.Sequence (electronMVATTH + electronTable)
 electronMC = cms.Sequence(electronsMCMatchForTable + electronMCTable)
+electronMCnew = cms.Sequence(particleLevelForMatching + tautaggerForMatching + matchingElecPhoton + electronsMCMatchForTable + electronsMCMatchForTableAlt + electronMCTable)
+( run2_nanoAOD_106Xv1 & ~run2_nanoAOD_devel).toReplaceWith(electronMC, electronMCnew)
 
 #for NANO from reminAOD, no need to run slimmedElectronsUpdated, other modules of electron sequence will run on slimmedElectrons
 for modifier in run2_miniAOD_80XLegacy,run2_nanoAOD_94XMiniAODv1,run2_nanoAOD_94XMiniAODv2,run2_nanoAOD_94X2016,run2_nanoAOD_102Xv1,run2_nanoAOD_106Xv1:


### PR DESCRIPTION
#### PR description:

Backport of #32966

Electron matching to MC truth has some inefficiency due to FSR. This PR extends the matching to recover such cases, by adding the possibility that electrons can be matched to gendressed particles. This issue has been reported here:
https://indico.cern.ch/event/962278/contributions/4060711/attachments/2136665/3599026/electron_matching_nano_nov4.pdf

and further discussed here:

cms-nanoAOD#552

The electron matching is performed as follows:

    Electrons are first matched to a collection of dressed electrons. This collection is identical to the GenDressedLepton collection that is stored in nanoAOD, but with a looser pt cut. If there's a match, the Electron_genPartFlav variable is set to 1 or 15, depending on the mother of the dressed lepton. Electron_genPartIdx is the index of the electron en GenPart that corresponds to the constituent of the matched dressed leptons with highest pt and abs(pdgId)==11.
    For the electrons not matched in the previous step, the logic is the same as in the previous implementation: electrons are matched to GenPart and then Electron_genPartIdx and Electron_genPartFlav are assigned according to this match.


