### PR TITLE
L1T bug-fix to the uGT emulator for the unconstrained pT (UPT) invariant mass correlation condition

### DIFF
--- a/L1Trigger/L1TGlobal/interface/GlobalScales.h
+++ b/L1Trigger/L1TGlobal/interface/GlobalScales.h
@@ -38,7 +38,7 @@ namespace l1t {
       double etStep;
       std::vector<std::pair<double, double>> etBins;
 
-      // Added by R.Cavanaugh for displaced muons
+      // Added displaced muons
       double uptMin;  
       double uptMax;  
       double uptStep; 

--- a/L1Trigger/L1TGlobal/interface/GlobalScales.h
+++ b/L1Trigger/L1TGlobal/interface/GlobalScales.h
@@ -38,6 +38,12 @@ namespace l1t {
       double etStep;
       std::vector<std::pair<double, double>> etBins;
 
+      // Added by R.Cavanaugh for displaced muons
+      double uptMin;  
+      double uptMax;  
+      double uptStep; 
+      std::vector<std::pair<double, double>> uptBins; 
+
       double phiMin;
       double phiMax;
       double phiStep;

--- a/L1Trigger/L1TGlobal/interface/GlobalScales.h
+++ b/L1Trigger/L1TGlobal/interface/GlobalScales.h
@@ -39,10 +39,10 @@ namespace l1t {
       std::vector<std::pair<double, double>> etBins;
 
       // Added displaced muons
-      double uptMin;  
-      double uptMax;  
-      double uptStep; 
-      std::vector<std::pair<double, double>> uptBins; 
+      double uptMin;
+      double uptMax;
+      double uptStep;
+      std::vector<std::pair<double, double>> uptBins;
 
       double phiMin;
       double phiMax;
@@ -73,7 +73,9 @@ namespace l1t {
     virtual void setLUT_DeltaEta(const std::string& lutName, std::vector<long long> lut, unsigned int precision);
     virtual void setLUT_DeltaPhi(const std::string& lutName, std::vector<long long> lut, unsigned int precision);
     virtual void setLUT_Pt(const std::string& lutName, std::vector<long long> lut, unsigned int precision);
-    virtual void setLUT_Upt(const std::string& lutName, std::vector<long long> lut, unsigned int precision); // Added for displaced muons
+    virtual void setLUT_Upt(const std::string& lutName,
+                            std::vector<long long> lut,
+                            unsigned int precision);  // Added for displaced muons
     virtual void setLUT_Cosh(const std::string& lutName, std::vector<long long> lut, unsigned int precision);
     virtual void setLUT_Cos(const std::string& lutName, std::vector<long long> lut, unsigned int precision);
     virtual void setLUT_Sin(const std::string& lutName, std::vector<long long> lut, unsigned int precision);
@@ -97,7 +99,7 @@ namespace l1t {
     long long getLUT_DeltaEta(std::string lutName, int element) const;
     long long getLUT_DeltaPhi(std::string lutName, int element) const;
     long long getLUT_Pt(const std::string& lutName, int element) const;
-    long long getLUT_Upt(const std::string& lutName, int element) const; // Added for displaced muons
+    long long getLUT_Upt(const std::string& lutName, int element) const;  // Added for displaced muons
     long long getLUT_DeltaEta_Cosh(std::string lutName, int element) const;
     long long getLUT_DeltaPhi_Cos(std::string lutName, int element) const;
     long long getLUT_Cos(const std::string& lutName, int element) const;
@@ -140,7 +142,7 @@ namespace l1t {
     std::map<std::string, std::vector<long long>> m_lut_DeltaEta;
     std::map<std::string, std::vector<long long>> m_lut_DeltaPhi;
     std::map<std::string, std::vector<long long>> m_lut_Pt;
-    std::map<std::string, std::vector<long long>> m_lut_Upt; // Added for displaced muons
+    std::map<std::string, std::vector<long long>> m_lut_Upt;  // Added for displaced muons
     std::map<std::string, std::vector<long long>> m_lut_Cosh;
     std::map<std::string, std::vector<long long>> m_lut_Cos;
     std::map<std::string, std::vector<long long>> m_lut_Sin;
@@ -149,7 +151,7 @@ namespace l1t {
     std::map<std::string, unsigned int> m_Prec_DeltaEta;
     std::map<std::string, unsigned int> m_Prec_DeltaPhi;
     std::map<std::string, unsigned int> m_Prec_Pt;
-    std::map<std::string, unsigned int> m_Prec_Upt; // Added for displaced muons
+    std::map<std::string, unsigned int> m_Prec_Upt;  // Added for displaced muons
     std::map<std::string, unsigned int> m_Prec_Cosh;
     std::map<std::string, unsigned int> m_Prec_Cos;
     std::map<std::string, unsigned int> m_Prec_Sin;

--- a/L1Trigger/L1TGlobal/interface/GlobalScales.h
+++ b/L1Trigger/L1TGlobal/interface/GlobalScales.h
@@ -73,6 +73,7 @@ namespace l1t {
     virtual void setLUT_DeltaEta(const std::string& lutName, std::vector<long long> lut, unsigned int precision);
     virtual void setLUT_DeltaPhi(const std::string& lutName, std::vector<long long> lut, unsigned int precision);
     virtual void setLUT_Pt(const std::string& lutName, std::vector<long long> lut, unsigned int precision);
+    virtual void setLUT_Upt(const std::string& lutName, std::vector<long long> lut, unsigned int precision); // Added for displaced muons
     virtual void setLUT_Cosh(const std::string& lutName, std::vector<long long> lut, unsigned int precision);
     virtual void setLUT_Cos(const std::string& lutName, std::vector<long long> lut, unsigned int precision);
     virtual void setLUT_Sin(const std::string& lutName, std::vector<long long> lut, unsigned int precision);
@@ -96,6 +97,7 @@ namespace l1t {
     long long getLUT_DeltaEta(std::string lutName, int element) const;
     long long getLUT_DeltaPhi(std::string lutName, int element) const;
     long long getLUT_Pt(const std::string& lutName, int element) const;
+    long long getLUT_Upt(const std::string& lutName, int element) const; // Added for displaced muons
     long long getLUT_DeltaEta_Cosh(std::string lutName, int element) const;
     long long getLUT_DeltaPhi_Cos(std::string lutName, int element) const;
     long long getLUT_Cos(const std::string& lutName, int element) const;
@@ -104,6 +106,7 @@ namespace l1t {
     unsigned int getPrec_DeltaEta(const std::string& lutName) const;
     unsigned int getPrec_DeltaPhi(const std::string& lutName) const;
     unsigned int getPrec_Pt(const std::string& lutName) const;
+    unsigned int getPrec_Upt(const std::string& lutName) const;  // Added for displaced muons
     unsigned int getPrec_DeltaEta_Cosh(const std::string& lutName) const;
     unsigned int getPrec_DeltaPhi_Cos(const std::string& lutName) const;
     unsigned int getPrec_Cos(const std::string& lutName) const;
@@ -137,6 +140,7 @@ namespace l1t {
     std::map<std::string, std::vector<long long>> m_lut_DeltaEta;
     std::map<std::string, std::vector<long long>> m_lut_DeltaPhi;
     std::map<std::string, std::vector<long long>> m_lut_Pt;
+    std::map<std::string, std::vector<long long>> m_lut_Upt; // Added for displaced muons
     std::map<std::string, std::vector<long long>> m_lut_Cosh;
     std::map<std::string, std::vector<long long>> m_lut_Cos;
     std::map<std::string, std::vector<long long>> m_lut_Sin;
@@ -145,6 +149,7 @@ namespace l1t {
     std::map<std::string, unsigned int> m_Prec_DeltaEta;
     std::map<std::string, unsigned int> m_Prec_DeltaPhi;
     std::map<std::string, unsigned int> m_Prec_Pt;
+    std::map<std::string, unsigned int> m_Prec_Upt; // Added for displaced muons
     std::map<std::string, unsigned int> m_Prec_Cosh;
     std::map<std::string, unsigned int> m_Prec_Cos;
     std::map<std::string, unsigned int> m_Prec_Sin;

--- a/L1Trigger/L1TGlobal/plugins/TriggerMenuParser.cc
+++ b/L1Trigger/L1TGlobal/plugins/TriggerMenuParser.cc
@@ -299,7 +299,7 @@ void l1t::TriggerMenuParser::parseCondFormats(const L1TUtmTriggerMenu* utmMenu) 
                    condition.getType() == esConditionType::CaloEsumCorrelation ||
                    condition.getType() == esConditionType::InvariantMass ||
                    condition.getType() == esConditionType::TransverseMass ||
-        	   condition.getType() == esConditionType::InvariantMassUpt) { // Added by R.Cavanaugh for displaced muons
+        	   condition.getType() == esConditionType::InvariantMassUpt) { // Added for displaced muons
           parseCorrelation(condition, chipNr);
 
           //parse Externals
@@ -590,7 +590,7 @@ bool l1t::TriggerMenuParser::parseScales(std::map<std::string, tmeventsetup::esS
             }
           }
         } break;
-        case esScaleType::UnconstrainedPtScale: { // Added by R.Cavanaugh for displaced muons
+        case esScaleType::UnconstrainedPtScale: { // Added for displaced muons
 	  scaleParam->uptMin = scale.getMinimum();
 	  scaleParam->uptMax = scale.getMaximum();
 	  scaleParam->uptStep = scale.getStep();
@@ -2591,12 +2591,10 @@ bool l1t::TriggerMenuParser::parseCorrelation(tmeventsetup::esCondition corrCond
         // cutType = cutType | 0x8;
         if (corrCond.getType() == esConditionType::TransverseMass) {
           cutType = cutType | 0x10;
-          //std::cout << "CCLA running Transverse mass cutType= " << cutType << std::endl;
         } else {
           cutType = cutType | 0x8;
-          //std::cout << "CCLA running Invarient mass cutType= " << cutType << std::endl;
         }
-      } else if (cut.getCutType() == esCutType::MassUpt) { // Added by R. Cavanaugh for displaced muons
+      } else if (cut.getCutType() == esCutType::MassUpt) { // Added for displaced muons
         LogDebug("TriggerMenuParser") << "CutType: " << cut.getCutType() << "\tMass Cut minV = " << minV
                                       << " Max = " << maxV << " precMin = " << cut.getMinimum().index
                                       << " precMax = " << cut.getMaximum().index << std::endl;

--- a/L1Trigger/L1TGlobal/plugins/TriggerMenuParser.cc
+++ b/L1Trigger/L1TGlobal/plugins/TriggerMenuParser.cc
@@ -299,7 +299,7 @@ void l1t::TriggerMenuParser::parseCondFormats(const L1TUtmTriggerMenu* utmMenu) 
                    condition.getType() == esConditionType::CaloEsumCorrelation ||
                    condition.getType() == esConditionType::InvariantMass ||
                    condition.getType() == esConditionType::TransverseMass ||
-        	   condition.getType() == esConditionType::InvariantMassUpt) { // Added for displaced muons
+                   condition.getType() == esConditionType::InvariantMassUpt) {  // Added for displaced muons
           parseCorrelation(condition, chipNr);
 
           //parse Externals
@@ -590,19 +590,19 @@ bool l1t::TriggerMenuParser::parseScales(std::map<std::string, tmeventsetup::esS
             }
           }
         } break;
-        case esScaleType::UnconstrainedPtScale: { // Added for displaced muons
-	  scaleParam->uptMin = scale.getMinimum();
-	  scaleParam->uptMax = scale.getMaximum();
-	  scaleParam->uptStep = scale.getStep();
-	  
-	  //Get bin edges 
-	  const std::vector<esBin>& binsV = scale.getBins(); 
-	  for (unsigned int i = 0; i < binsV.size(); i++) {  
-	    const esBin& bin = binsV.at(i);                  
-	    std::pair<double, double> binLimits(bin.minimum, bin.maximum); 
-	    scaleParam->uptBins.push_back(binLimits); 
-	  } 
-	} break; 
+        case esScaleType::UnconstrainedPtScale: {  // Added for displaced muons
+          scaleParam->uptMin = scale.getMinimum();
+          scaleParam->uptMax = scale.getMaximum();
+          scaleParam->uptStep = scale.getStep();
+
+          //Get bin edges
+          const std::vector<esBin>& binsV = scale.getBins();
+          for (unsigned int i = 0; i < binsV.size(); i++) {
+            const esBin& bin = binsV.at(i);
+            std::pair<double, double> binLimits(bin.minimum, bin.maximum);
+            scaleParam->uptBins.push_back(binLimits);
+          }
+        } break;
         case esScaleType::EtaScale: {
           scaleParam->etaMin = scale.getMinimum();
           scaleParam->etaMax = scale.getMaximum();
@@ -679,7 +679,7 @@ bool l1t::TriggerMenuParser::parseScales(std::map<std::string, tmeventsetup::esS
     // ---------------
     parsePt_LUTS(scaleMap, "Mass", "EG", precisions["PRECISION-EG-MU-MassPt"]);
     parsePt_LUTS(scaleMap, "Mass", "MU", precisions["PRECISION-EG-MU-MassPt"]);
-    parseUpt_LUTS(scaleMap, "Mass", "MU", precisions["PRECISION-EG-MU-MassPt"]); // Added for displaced muons
+    parseUpt_LUTS(scaleMap, "Mass", "MU", precisions["PRECISION-EG-MU-MassPt"]);  // Added for displaced muons
     parsePt_LUTS(scaleMap, "Mass", "JET", precisions["PRECISION-EG-JET-MassPt"]);
     parsePt_LUTS(scaleMap, "Mass", "TAU", precisions["PRECISION-EG-TAU-MassPt"]);
     parsePt_LUTS(scaleMap, "Mass", "ETM", precisions["PRECISION-EG-ETM-MassPt"]);
@@ -868,9 +868,9 @@ void l1t::TriggerMenuParser::parsePt_LUTS(std::map<std::string, tmeventsetup::es
 
 // Added for displaced muons
 void l1t::TriggerMenuParser::parseUpt_LUTS(std::map<std::string, tmeventsetup::esScale> scaleMap,
-					   std::string lutpfx,
-					   std::string obj1,
-					   unsigned int prec) {
+                                           std::string lutpfx,
+                                           std::string obj1,
+                                           unsigned int prec) {
   using namespace tmeventsetup;
 
   // First Delta Eta for this set
@@ -888,7 +888,6 @@ void l1t::TriggerMenuParser::parseUpt_LUTS(std::map<std::string, tmeventsetup::e
 
   m_gtScales.setLUT_Upt(lutpfx + "_" + scLabel1, lut_pt, prec);
 }
-
 
 void l1t::TriggerMenuParser::parseDeltaEta_Cosh_LUTS(std::map<std::string, tmeventsetup::esScale> scaleMap,
                                                      std::string obj1,
@@ -1363,15 +1362,15 @@ bool l1t::TriggerMenuParser::parseMuonCorr(const tmeventsetup::esObject* corrMu,
 
     switch (cut.getCutType()) {
       case esCutType::UnconstrainedPt:  // Added for displaced muons
-	lowerUnconstrainedPtInd = cut.getMinimum().index;
-	upperUnconstrainedPtInd = cut.getMaximum().index;
-	break;
+        lowerUnconstrainedPtInd = cut.getMinimum().index;
+        upperUnconstrainedPtInd = cut.getMaximum().index;
+        break;
 
       case esCutType::ImpactParameter:  // Added for displaced muons
-	lowerImpactParameterInd = cut.getMinimum().index;
-	upperImpactParameterInd = cut.getMaximum().index;
-	impactParameterLUT = l1tstr2int(cut.getData());
-	break;
+        lowerImpactParameterInd = cut.getMinimum().index;
+        upperImpactParameterInd = cut.getMaximum().index;
+        impactParameterLUT = l1tstr2int(cut.getData());
+        break;
 
       case esCutType::Threshold:
         lowerThresholdInd = cut.getMinimum().index;
@@ -1439,11 +1438,11 @@ bool l1t::TriggerMenuParser::parseMuonCorr(const tmeventsetup::esObject* corrMu,
   }  //end loop over cuts
 
   // Set the parameter cuts
-  objParameter[0].unconstrainedPtHigh = upperUnconstrainedPtInd; // Added for displacd muons
-  objParameter[0].unconstrainedPtLow = lowerUnconstrainedPtInd;  // Added for displacd muons
-  objParameter[0].impactParameterHigh = upperImpactParameterInd; // Added for displacd muons
-  objParameter[0].impactParameterLow = lowerImpactParameterInd;  // Added for displacd muons
-  objParameter[0].impactParameterLUT = impactParameterLUT;       // Added for displacd muons
+  objParameter[0].unconstrainedPtHigh = upperUnconstrainedPtInd;  // Added for displacd muons
+  objParameter[0].unconstrainedPtLow = lowerUnconstrainedPtInd;   // Added for displacd muons
+  objParameter[0].impactParameterHigh = upperImpactParameterInd;  // Added for displacd muons
+  objParameter[0].impactParameterLow = lowerImpactParameterInd;   // Added for displacd muons
+  objParameter[0].impactParameterLUT = impactParameterLUT;        // Added for displacd muons
 
   objParameter[0].ptHighThreshold = upperThresholdInd;
   objParameter[0].ptLowThreshold = lowerThresholdInd;
@@ -2641,17 +2640,17 @@ bool l1t::TriggerMenuParser::parseCorrelation(tmeventsetup::esCondition corrCond
         } else {
           cutType = cutType | 0x8;
         }
-      } else if (cut.getCutType() == esCutType::MassUpt) { // Added for displaced muons
+      } else if (cut.getCutType() == esCutType::MassUpt) {  // Added for displaced muons
         LogDebug("TriggerMenuParser") << "CutType: " << cut.getCutType() << "\tMass Cut minV = " << minV
                                       << " Max = " << maxV << " precMin = " << cut.getMinimum().index
                                       << " precMax = " << cut.getMaximum().index << std::endl;
         corrParameter.minMassCutValue = (long long)(minV * pow(10., cut.getMinimum().index));
         corrParameter.maxMassCutValue = (long long)(maxV * pow(10., cut.getMaximum().index));
         corrParameter.precMassCut = cut.getMinimum().index;
-        cutType = cutType | 0x40; // Note:    0x40 (MassUpt) is next available bit after 0x20 (TwoBodyPt)
-      }                           // Careful: cutType carries same info as esCutType, but is hard coded!!
-    }                             //          This seems like a historical hack, which may be error prone.
-  }                               //          cutType is defined here, for use later in CorrCondition.cc
+        cutType = cutType | 0x40;  // Note:    0x40 (MassUpt) is next available bit after 0x20 (TwoBodyPt)
+      }                            // Careful: cutType carries same info as esCutType, but is hard coded!!
+    }                              //          This seems like a historical hack, which may be error prone.
+  }                                //          cutType is defined here, for use later in CorrCondition.cc
   corrParameter.corrCutType = cutType;
 
   // Get the two objects that form the legs

--- a/L1Trigger/L1TGlobal/plugins/TriggerMenuParser.cc
+++ b/L1Trigger/L1TGlobal/plugins/TriggerMenuParser.cc
@@ -679,6 +679,7 @@ bool l1t::TriggerMenuParser::parseScales(std::map<std::string, tmeventsetup::esS
     // ---------------
     parsePt_LUTS(scaleMap, "Mass", "EG", precisions["PRECISION-EG-MU-MassPt"]);
     parsePt_LUTS(scaleMap, "Mass", "MU", precisions["PRECISION-EG-MU-MassPt"]);
+    parseUpt_LUTS(scaleMap, "Mass", "MU", precisions["PRECISION-EG-MU-MassPt"]); // Added for displaced muons
     parsePt_LUTS(scaleMap, "Mass", "JET", precisions["PRECISION-EG-JET-MassPt"]);
     parsePt_LUTS(scaleMap, "Mass", "TAU", precisions["PRECISION-EG-TAU-MassPt"]);
     parsePt_LUTS(scaleMap, "Mass", "ETM", precisions["PRECISION-EG-ETM-MassPt"]);
@@ -864,6 +865,30 @@ void l1t::TriggerMenuParser::parsePt_LUTS(std::map<std::string, tmeventsetup::es
 
   m_gtScales.setLUT_Pt(lutpfx + "_" + scLabel1, lut_pt, prec);
 }
+
+// Added for displaced muons
+void l1t::TriggerMenuParser::parseUpt_LUTS(std::map<std::string, tmeventsetup::esScale> scaleMap,
+					   std::string lutpfx,
+					   std::string obj1,
+					   unsigned int prec) {
+  using namespace tmeventsetup;
+
+  // First Delta Eta for this set
+  std::string scLabel1 = obj1;
+  scLabel1 += "-UPT";
+
+  //This LUT does not exist in L1 Menu file, don't fill it
+  if (scaleMap.find(scLabel1) == scaleMap.end())
+    return;
+
+  const esScale* scale1 = &scaleMap.find(scLabel1)->second;
+
+  std::vector<long long> lut_pt;
+  getLut(lut_pt, scale1, prec);
+
+  m_gtScales.setLUT_Upt(lutpfx + "_" + scLabel1, lut_pt, prec);
+}
+
 
 void l1t::TriggerMenuParser::parseDeltaEta_Cosh_LUTS(std::map<std::string, tmeventsetup::esScale> scaleMap,
                                                      std::string obj1,
@@ -1315,6 +1340,11 @@ bool l1t::TriggerMenuParser::parseMuonCorr(const tmeventsetup::esObject* corrMu,
   relativeBx = corrMu->getBxOffset();
 
   //  Loop over the cuts for this object
+  int upperUnconstrainedPtInd = -1;  // Added for displaced muons
+  int lowerUnconstrainedPtInd = 0;   // Added for displaced muons
+  int upperImpactParameterInd = -1;  // Added for displaced muons
+  int lowerImpactParameterInd = 0;   // Added for displaced muons
+  int impactParameterLUT = 0xF;      // Added for displaced muons, default is to ignore unless specified
   int upperThresholdInd = -1;
   int lowerThresholdInd = 0;
   int upperIndexInd = -1;
@@ -1332,6 +1362,17 @@ bool l1t::TriggerMenuParser::parseMuonCorr(const tmeventsetup::esObject* corrMu,
     const esCut cut = cuts.at(kk);
 
     switch (cut.getCutType()) {
+      case esCutType::UnconstrainedPt:  // Added for displaced muons
+	lowerUnconstrainedPtInd = cut.getMinimum().index;
+	upperUnconstrainedPtInd = cut.getMaximum().index;
+	break;
+
+      case esCutType::ImpactParameter:  // Added for displaced muons
+	lowerImpactParameterInd = cut.getMinimum().index;
+	upperImpactParameterInd = cut.getMaximum().index;
+	impactParameterLUT = l1tstr2int(cut.getData());
+	break;
+
       case esCutType::Threshold:
         lowerThresholdInd = cut.getMinimum().index;
         upperThresholdInd = cut.getMaximum().index;
@@ -1398,6 +1439,12 @@ bool l1t::TriggerMenuParser::parseMuonCorr(const tmeventsetup::esObject* corrMu,
   }  //end loop over cuts
 
   // Set the parameter cuts
+  objParameter[0].unconstrainedPtHigh = upperUnconstrainedPtInd; // Added for displacd muons
+  objParameter[0].unconstrainedPtLow = lowerUnconstrainedPtInd;  // Added for displacd muons
+  objParameter[0].impactParameterHigh = upperImpactParameterInd; // Added for displacd muons
+  objParameter[0].impactParameterLow = lowerImpactParameterInd;  // Added for displacd muons
+  objParameter[0].impactParameterLUT = impactParameterLUT;       // Added for displacd muons
+
   objParameter[0].ptHighThreshold = upperThresholdInd;
   objParameter[0].ptLowThreshold = lowerThresholdInd;
 

--- a/L1Trigger/L1TGlobal/plugins/TriggerMenuParser.h
+++ b/L1Trigger/L1TGlobal/plugins/TriggerMenuParser.h
@@ -15,6 +15,8 @@
  * \author  Vladimir Rekovic
  *                - indexing
  *                - correlations with overlap object removal
+ * \author R. Cavanaugh
+ *                - displaced muons
  *
  * $Date$
  * $Revision$
@@ -293,6 +295,12 @@ namespace l1t {
                       std::string lutpfx,
                       std::string obj1,
                       unsigned int prec);
+
+    // Parse LUT for Upt LUT in Mass calculation for displaced muons
+    void parseUpt_LUTS(std::map<std::string, tmeventsetup::esScale> scaleMap,
+		       std::string lutpfx,
+		       std::string obj1,
+		       unsigned int prec);
 
     // Parse LUT for Delta Eta and Cosh
     void parseDeltaEta_Cosh_LUTS(std::map<std::string, tmeventsetup::esScale> scaleMap,

--- a/L1Trigger/L1TGlobal/plugins/TriggerMenuParser.h
+++ b/L1Trigger/L1TGlobal/plugins/TriggerMenuParser.h
@@ -298,9 +298,9 @@ namespace l1t {
 
     // Parse LUT for Upt LUT in Mass calculation for displaced muons
     void parseUpt_LUTS(std::map<std::string, tmeventsetup::esScale> scaleMap,
-		       std::string lutpfx,
-		       std::string obj1,
-		       unsigned int prec);
+                       std::string lutpfx,
+                       std::string obj1,
+                       unsigned int prec);
 
     // Parse LUT for Delta Eta and Cosh
     void parseDeltaEta_Cosh_LUTS(std::map<std::string, tmeventsetup::esScale> scaleMap,

--- a/L1Trigger/L1TGlobal/src/CorrCondition.cc
+++ b/L1Trigger/L1TGlobal/src/CorrCondition.cc
@@ -1200,6 +1200,19 @@ const bool l1t::CorrCondition::evaluateCondition(const int bxEval) const {
         long long ptObj1 = m_gtScales->getLUT_Pt("Mass_" + lutName, etIndex1);
         unsigned int precPtLUTObj1 = m_gtScales->getPrec_Pt("Mass_" + lutName);
 
+        if( corrPar.corrCutType & 0x40 ) // Added for displaced muons
+          {
+	    lutName = lutObj0;
+            lutName += "-UPT";
+            ptObj0 = m_gtScales->getLUT_Upt("Mass_" + lutName, uptIndex0);
+            precPtLUTObj0 = m_gtScales->getPrec_Upt("Mass_" + lutName);
+
+            lutName = lutObj1;
+            lutName += "-UPT";
+            ptObj1 = m_gtScales->getLUT_Upt("Mass_" + lutName, uptIndex1);
+            precPtLUTObj1 = m_gtScales->getPrec_Upt("Mass_" + lutName);
+          }
+
         // Pt and Angles are at different precission.
         long long massSq = ptObj0 * ptObj1 * (coshDeltaEtaLUT - cosDeltaPhiLUT);
 

--- a/L1Trigger/L1TGlobal/src/CorrCondition.cc
+++ b/L1Trigger/L1TGlobal/src/CorrCondition.cc
@@ -321,6 +321,14 @@ const bool l1t::CorrCondition::evaluateCondition(const int bxEval) const {
   int etBin1 = 0;
   double et1Phy = 0.;
 
+  // Added by R.Cavanaugh for displaced muons
+  int uptIndex0 = 0;
+  int uptBin0 = 0;
+  double upt0Phy = 0.0;
+  int uptIndex1 = 0;
+  int uptBin1 = 0;
+  double upt1Phy = 0.0;
+
   int chrg0 = -1;
   int chrg1 = -1;
 
@@ -370,6 +378,7 @@ const bool l1t::CorrCondition::evaluateCondition(const int bxEval) const {
         phiIndex0 = (candMuVec->at(cond0bx, obj0Index))->hwPhiAtVtx();  //(*candMuVec)[obj0Index]->phiIndex();
         etaIndex0 = (candMuVec->at(cond0bx, obj0Index))->hwEtaAtVtx();
         etIndex0 = (candMuVec->at(cond0bx, obj0Index))->hwPt();
+	uptIndex0 = (candMuVec->at(cond0bx, obj0Index))->hwPtUnconstrained(); // Added by R.Cavanaugh for displaced muons
         chrg0 = (candMuVec->at(cond0bx, obj0Index))->hwCharge();
         int etaBin0 = etaIndex0;
         if (etaBin0 < 0)
@@ -377,6 +386,7 @@ const bool l1t::CorrCondition::evaluateCondition(const int bxEval) const {
         //		LogDebug("L1TGlobal") << "Muon phi" << phiIndex0 << " eta " << etaIndex0 << " etaBin0 = " << etaBin0  << " et " << etIndex0 << std::endl;
 
         etBin0 = etIndex0;
+	uptBin0 = uptIndex0;   // Added by R.Cavanaugh for displaced muons
         int ssize = m_gtScales->getMUScales().etBins.size();
         if (etBin0 >= ssize) {
           etBin0 = ssize - 1;
@@ -390,6 +400,9 @@ const bool l1t::CorrCondition::evaluateCondition(const int bxEval) const {
         eta0Phy = 0.5 * (binEdges.second + binEdges.first);
         binEdges = m_gtScales->getMUScales().etBins.at(etBin0);
         et0Phy = 0.5 * (binEdges.second + binEdges.first);
+	// Added by R.Cavanaugh for displaced muons
+        binEdges = m_gtScales->getMUScales().uptBins.at(uptBin0); 
+        upt0Phy = 0.5 * (binEdges.second + binEdges.first); 
 
         LogDebug("L1TGlobal") << "Found all quantities for the muon 0" << std::endl;
       } break;
@@ -646,6 +659,7 @@ const bool l1t::CorrCondition::evaluateCondition(const int bxEval) const {
           phiIndex1 = (candMuVec->at(cond1bx, obj1Index))->hwPhiAtVtx();  //(*candMuVec)[obj0Index]->phiIndex();
           etaIndex1 = (candMuVec->at(cond1bx, obj1Index))->hwEtaAtVtx();
           etIndex1 = (candMuVec->at(cond1bx, obj1Index))->hwPt();
+	  uptIndex1 = (candMuVec->at(cond1bx, obj1Index))->hwPtUnconstrained(); // Added by R.Cavanaugh for displaced muons
           chrg1 = (candMuVec->at(cond1bx, obj1Index))->hwCharge();
           etaBin1 = etaIndex1;
           if (etaBin1 < 0)
@@ -653,6 +667,7 @@ const bool l1t::CorrCondition::evaluateCondition(const int bxEval) const {
           //		   LogDebug("L1TGlobal") << "Muon phi" << phiIndex1 << " eta " << etaIndex1 << " etaBin1 = " << etaBin1  << " et " << etIndex1 << std::endl;
 
           etBin1 = etIndex1;
+	  uptBin1 = uptIndex1;   // Added by R.Cavanaugh for displaced muons
           int ssize = m_gtScales->getMUScales().etBins.size();
           if (etBin1 >= ssize) {
             LogTrace("L1TGlobal") << "muon2 hw et" << etBin1 << " out of scale range.  Setting to maximum.";
@@ -666,7 +681,9 @@ const bool l1t::CorrCondition::evaluateCondition(const int bxEval) const {
           eta1Phy = 0.5 * (binEdges.second + binEdges.first);
           binEdges = m_gtScales->getMUScales().etBins.at(etBin1);
           et1Phy = 0.5 * (binEdges.second + binEdges.first);
-
+	  // Added by R.Cavanaugh for displaced muons
+          binEdges = m_gtScales->getMUScales().uptBins.at(uptBin1); 
+          upt1Phy = 0.5 * (binEdges.second + binEdges.first); 
         } break;
         case CondCalo: {
           switch (cndObjTypeVec[1]) {
@@ -1149,7 +1166,7 @@ const bool l1t::CorrCondition::evaluateCondition(const int bxEval) const {
         }
       }
 
-      if (corrPar.corrCutType & 0x8 || corrPar.corrCutType & 0x10) {
+      if (corrPar.corrCutType & 0x8 || corrPar.corrCutType & 0x10 || corrPar.corrCutType & 0x40) { // R. Cavanaugh added 0x40 for massUpt
         //invariant mass calculation based on
         // M = sqrt(2*p1*p2(cosh(eta1-eta2) - cos(phi1 - phi2)))
         // but we calculate (1/2)M^2
@@ -1159,6 +1176,8 @@ const bool l1t::CorrCondition::evaluateCondition(const int bxEval) const {
         if (corrPar.corrCutType & 0x10)
           coshDeltaEtaPhy = 1.;
         double massSqPhy = et0Phy * et1Phy * (coshDeltaEtaPhy - cosDeltaPhiPhy);
+	if( corrPar.corrCutType & 0x40 ) // Added by R.Cavanaugh for displaced muons
+	  massSqPhy = upt0Phy * upt1Phy * (coshDeltaEtaPhy - cosDeltaPhiPhy);
 
         long long cosDeltaPhiLUT = m_gtScales->getLUT_DeltaPhi_Cos(lutName, deltaPhiFW);
         unsigned int precCosLUT = m_gtScales->getPrec_DeltaPhi_Cos(lutName);
@@ -1214,7 +1233,6 @@ const bool l1t::CorrCondition::evaluateCondition(const int bxEval) const {
           LogDebug("L1TGlobal") << "    Passed Invariant Mass Cut ["
                                 << (long long)(corrPar.minMassCutValue * pow(10, preShift)) << ","
                                 << (long long)(corrPar.maxMassCutValue * pow(10, preShift)) << "]" << std::endl;
-
         } else {
           LogDebug("L1TGlobal") << "    Failed Invariant Mass Cut ["
                                 << (long long)(corrPar.minMassCutValue * pow(10, preShift)) << ","

--- a/L1Trigger/L1TGlobal/src/CorrCondition.cc
+++ b/L1Trigger/L1TGlobal/src/CorrCondition.cc
@@ -321,12 +321,12 @@ const bool l1t::CorrCondition::evaluateCondition(const int bxEval) const {
   int etBin1 = 0;
   double et1Phy = 0.;
 
-  int uptIndex0 = 0;      // Added displaced muons
-  int uptBin0 = 0;        // Added displaced muons
-  double upt0Phy = 0.0;   // Added displaced muons
-  int uptIndex1 = 0;      // Added displaced muons
-  int uptBin1 = 0;        // Added displaced muons 
-  double upt1Phy = 0.0;   // Added displaced muons
+  int uptIndex0 = 0;     // Added displaced muons
+  int uptBin0 = 0;       // Added displaced muons
+  double upt0Phy = 0.0;  // Added displaced muons
+  int uptIndex1 = 0;     // Added displaced muons
+  int uptBin1 = 0;       // Added displaced muons
+  double upt1Phy = 0.0;  // Added displaced muons
 
   int chrg0 = -1;
   int chrg1 = -1;
@@ -377,14 +377,14 @@ const bool l1t::CorrCondition::evaluateCondition(const int bxEval) const {
         phiIndex0 = (candMuVec->at(cond0bx, obj0Index))->hwPhiAtVtx();  //(*candMuVec)[obj0Index]->phiIndex();
         etaIndex0 = (candMuVec->at(cond0bx, obj0Index))->hwEtaAtVtx();
         etIndex0 = (candMuVec->at(cond0bx, obj0Index))->hwPt();
-	uptIndex0 = (candMuVec->at(cond0bx, obj0Index))->hwPtUnconstrained(); // Added for displaced muons
+        uptIndex0 = (candMuVec->at(cond0bx, obj0Index))->hwPtUnconstrained();  // Added for displaced muons
         chrg0 = (candMuVec->at(cond0bx, obj0Index))->hwCharge();
         int etaBin0 = etaIndex0;
         if (etaBin0 < 0)
           etaBin0 = m_gtScales->getMUScales().etaBins.size() + etaBin0;  //twos complement
 
         etBin0 = etIndex0;
-	uptBin0 = uptIndex0;   // Added for displaced muons
+        uptBin0 = uptIndex0;  // Added for displaced muons
         int ssize = m_gtScales->getMUScales().etBins.size();
         if (etBin0 >= ssize) {
           etBin0 = ssize - 1;
@@ -656,7 +656,7 @@ const bool l1t::CorrCondition::evaluateCondition(const int bxEval) const {
           phiIndex1 = (candMuVec->at(cond1bx, obj1Index))->hwPhiAtVtx();  //(*candMuVec)[obj0Index]->phiIndex();
           etaIndex1 = (candMuVec->at(cond1bx, obj1Index))->hwEtaAtVtx();
           etIndex1 = (candMuVec->at(cond1bx, obj1Index))->hwPt();
-	  uptIndex1 = (candMuVec->at(cond1bx, obj1Index))->hwPtUnconstrained(); // Added for displaced muons
+          uptIndex1 = (candMuVec->at(cond1bx, obj1Index))->hwPtUnconstrained();  // Added for displaced muons
           chrg1 = (candMuVec->at(cond1bx, obj1Index))->hwCharge();
           etaBin1 = etaIndex1;
           if (etaBin1 < 0)
@@ -664,7 +664,7 @@ const bool l1t::CorrCondition::evaluateCondition(const int bxEval) const {
           //		   LogDebug("L1TGlobal") << "Muon phi" << phiIndex1 << " eta " << etaIndex1 << " etaBin1 = " << etaBin1  << " et " << etIndex1 << std::endl;
 
           etBin1 = etIndex1;
-	  uptBin1 = uptIndex1;   // Added for displaced muons
+          uptBin1 = uptIndex1;  // Added for displaced muons
           int ssize = m_gtScales->getMUScales().etBins.size();
           if (etBin1 >= ssize) {
             LogTrace("L1TGlobal") << "muon2 hw et" << etBin1 << " out of scale range.  Setting to maximum.";
@@ -678,9 +678,9 @@ const bool l1t::CorrCondition::evaluateCondition(const int bxEval) const {
           eta1Phy = 0.5 * (binEdges.second + binEdges.first);
           binEdges = m_gtScales->getMUScales().etBins.at(etBin1);
           et1Phy = 0.5 * (binEdges.second + binEdges.first);
-	  // Added for displaced muons
-          binEdges = m_gtScales->getMUScales().uptBins.at(uptBin1); 
-          upt1Phy = 0.5 * (binEdges.second + binEdges.first); 
+          // Added for displaced muons
+          binEdges = m_gtScales->getMUScales().uptBins.at(uptBin1);
+          upt1Phy = 0.5 * (binEdges.second + binEdges.first);
         } break;
         case CondCalo: {
           switch (cndObjTypeVec[1]) {
@@ -1163,7 +1163,8 @@ const bool l1t::CorrCondition::evaluateCondition(const int bxEval) const {
         }
       }
 
-      if (corrPar.corrCutType & 0x8 || corrPar.corrCutType & 0x10 || corrPar.corrCutType & 0x40) { // added 0x40 for massUpt
+      if (corrPar.corrCutType & 0x8 || corrPar.corrCutType & 0x10 ||
+          corrPar.corrCutType & 0x40) {  // added 0x40 for massUpt
         //invariant mass calculation based on
         // M = sqrt(2*p1*p2(cosh(eta1-eta2) - cos(phi1 - phi2)))
         // but we calculate (1/2)M^2
@@ -1173,8 +1174,8 @@ const bool l1t::CorrCondition::evaluateCondition(const int bxEval) const {
         if (corrPar.corrCutType & 0x10)
           coshDeltaEtaPhy = 1.;
         double massSqPhy = et0Phy * et1Phy * (coshDeltaEtaPhy - cosDeltaPhiPhy);
-	if( corrPar.corrCutType & 0x40 ) // Added for displaced muons
-	  massSqPhy = upt0Phy * upt1Phy * (coshDeltaEtaPhy - cosDeltaPhiPhy);
+        if (corrPar.corrCutType & 0x40)  // Added for displaced muons
+          massSqPhy = upt0Phy * upt1Phy * (coshDeltaEtaPhy - cosDeltaPhiPhy);
 
         long long cosDeltaPhiLUT = m_gtScales->getLUT_DeltaPhi_Cos(lutName, deltaPhiFW);
         unsigned int precCosLUT = m_gtScales->getPrec_DeltaPhi_Cos(lutName);
@@ -1200,18 +1201,18 @@ const bool l1t::CorrCondition::evaluateCondition(const int bxEval) const {
         long long ptObj1 = m_gtScales->getLUT_Pt("Mass_" + lutName, etIndex1);
         unsigned int precPtLUTObj1 = m_gtScales->getPrec_Pt("Mass_" + lutName);
 
-        if( corrPar.corrCutType & 0x40 ) // Added for displaced muons
-          {
-	    lutName = lutObj0;
-            lutName += "-UPT";
-            ptObj0 = m_gtScales->getLUT_Upt("Mass_" + lutName, uptIndex0);
-            precPtLUTObj0 = m_gtScales->getPrec_Upt("Mass_" + lutName);
+        if (corrPar.corrCutType & 0x40)  // Added for displaced muons
+        {
+          lutName = lutObj0;
+          lutName += "-UPT";
+          ptObj0 = m_gtScales->getLUT_Upt("Mass_" + lutName, uptIndex0);
+          precPtLUTObj0 = m_gtScales->getPrec_Upt("Mass_" + lutName);
 
-            lutName = lutObj1;
-            lutName += "-UPT";
-            ptObj1 = m_gtScales->getLUT_Upt("Mass_" + lutName, uptIndex1);
-            precPtLUTObj1 = m_gtScales->getPrec_Upt("Mass_" + lutName);
-          }
+          lutName = lutObj1;
+          lutName += "-UPT";
+          ptObj1 = m_gtScales->getLUT_Upt("Mass_" + lutName, uptIndex1);
+          precPtLUTObj1 = m_gtScales->getPrec_Upt("Mass_" + lutName);
+        }
 
         // Pt and Angles are at different precission.
         long long massSq = ptObj0 * ptObj1 * (coshDeltaEtaLUT - cosDeltaPhiLUT);

--- a/L1Trigger/L1TGlobal/src/CorrCondition.cc
+++ b/L1Trigger/L1TGlobal/src/CorrCondition.cc
@@ -321,13 +321,12 @@ const bool l1t::CorrCondition::evaluateCondition(const int bxEval) const {
   int etBin1 = 0;
   double et1Phy = 0.;
 
-  // Added by R.Cavanaugh for displaced muons
-  int uptIndex0 = 0;
-  int uptBin0 = 0;
-  double upt0Phy = 0.0;
-  int uptIndex1 = 0;
-  int uptBin1 = 0;
-  double upt1Phy = 0.0;
+  int uptIndex0 = 0;      // Added displaced muons
+  int uptBin0 = 0;        // Added displaced muons
+  double upt0Phy = 0.0;   // Added displaced muons
+  int uptIndex1 = 0;      // Added displaced muons
+  int uptBin1 = 0;        // Added displaced muons 
+  double upt1Phy = 0.0;   // Added displaced muons
 
   int chrg0 = -1;
   int chrg1 = -1;
@@ -378,15 +377,14 @@ const bool l1t::CorrCondition::evaluateCondition(const int bxEval) const {
         phiIndex0 = (candMuVec->at(cond0bx, obj0Index))->hwPhiAtVtx();  //(*candMuVec)[obj0Index]->phiIndex();
         etaIndex0 = (candMuVec->at(cond0bx, obj0Index))->hwEtaAtVtx();
         etIndex0 = (candMuVec->at(cond0bx, obj0Index))->hwPt();
-	uptIndex0 = (candMuVec->at(cond0bx, obj0Index))->hwPtUnconstrained(); // Added by R.Cavanaugh for displaced muons
+	uptIndex0 = (candMuVec->at(cond0bx, obj0Index))->hwPtUnconstrained(); // Added for displaced muons
         chrg0 = (candMuVec->at(cond0bx, obj0Index))->hwCharge();
         int etaBin0 = etaIndex0;
         if (etaBin0 < 0)
           etaBin0 = m_gtScales->getMUScales().etaBins.size() + etaBin0;  //twos complement
-        //		LogDebug("L1TGlobal") << "Muon phi" << phiIndex0 << " eta " << etaIndex0 << " etaBin0 = " << etaBin0  << " et " << etIndex0 << std::endl;
 
         etBin0 = etIndex0;
-	uptBin0 = uptIndex0;   // Added by R.Cavanaugh for displaced muons
+	uptBin0 = uptIndex0;   // Added for displaced muons
         int ssize = m_gtScales->getMUScales().etBins.size();
         if (etBin0 >= ssize) {
           etBin0 = ssize - 1;
@@ -400,9 +398,8 @@ const bool l1t::CorrCondition::evaluateCondition(const int bxEval) const {
         eta0Phy = 0.5 * (binEdges.second + binEdges.first);
         binEdges = m_gtScales->getMUScales().etBins.at(etBin0);
         et0Phy = 0.5 * (binEdges.second + binEdges.first);
-	// Added by R.Cavanaugh for displaced muons
-        binEdges = m_gtScales->getMUScales().uptBins.at(uptBin0); 
-        upt0Phy = 0.5 * (binEdges.second + binEdges.first); 
+        binEdges = m_gtScales->getMUScales().uptBins.at(uptBin0);  // Added for displaced muons
+        upt0Phy = 0.5 * (binEdges.second + binEdges.first);        // Added for displaced muons
 
         LogDebug("L1TGlobal") << "Found all quantities for the muon 0" << std::endl;
       } break;
@@ -659,7 +656,7 @@ const bool l1t::CorrCondition::evaluateCondition(const int bxEval) const {
           phiIndex1 = (candMuVec->at(cond1bx, obj1Index))->hwPhiAtVtx();  //(*candMuVec)[obj0Index]->phiIndex();
           etaIndex1 = (candMuVec->at(cond1bx, obj1Index))->hwEtaAtVtx();
           etIndex1 = (candMuVec->at(cond1bx, obj1Index))->hwPt();
-	  uptIndex1 = (candMuVec->at(cond1bx, obj1Index))->hwPtUnconstrained(); // Added by R.Cavanaugh for displaced muons
+	  uptIndex1 = (candMuVec->at(cond1bx, obj1Index))->hwPtUnconstrained(); // Added for displaced muons
           chrg1 = (candMuVec->at(cond1bx, obj1Index))->hwCharge();
           etaBin1 = etaIndex1;
           if (etaBin1 < 0)
@@ -667,7 +664,7 @@ const bool l1t::CorrCondition::evaluateCondition(const int bxEval) const {
           //		   LogDebug("L1TGlobal") << "Muon phi" << phiIndex1 << " eta " << etaIndex1 << " etaBin1 = " << etaBin1  << " et " << etIndex1 << std::endl;
 
           etBin1 = etIndex1;
-	  uptBin1 = uptIndex1;   // Added by R.Cavanaugh for displaced muons
+	  uptBin1 = uptIndex1;   // Added for displaced muons
           int ssize = m_gtScales->getMUScales().etBins.size();
           if (etBin1 >= ssize) {
             LogTrace("L1TGlobal") << "muon2 hw et" << etBin1 << " out of scale range.  Setting to maximum.";
@@ -681,7 +678,7 @@ const bool l1t::CorrCondition::evaluateCondition(const int bxEval) const {
           eta1Phy = 0.5 * (binEdges.second + binEdges.first);
           binEdges = m_gtScales->getMUScales().etBins.at(etBin1);
           et1Phy = 0.5 * (binEdges.second + binEdges.first);
-	  // Added by R.Cavanaugh for displaced muons
+	  // Added for displaced muons
           binEdges = m_gtScales->getMUScales().uptBins.at(uptBin1); 
           upt1Phy = 0.5 * (binEdges.second + binEdges.first); 
         } break;
@@ -1166,7 +1163,7 @@ const bool l1t::CorrCondition::evaluateCondition(const int bxEval) const {
         }
       }
 
-      if (corrPar.corrCutType & 0x8 || corrPar.corrCutType & 0x10 || corrPar.corrCutType & 0x40) { // R. Cavanaugh added 0x40 for massUpt
+      if (corrPar.corrCutType & 0x8 || corrPar.corrCutType & 0x10 || corrPar.corrCutType & 0x40) { // added 0x40 for massUpt
         //invariant mass calculation based on
         // M = sqrt(2*p1*p2(cosh(eta1-eta2) - cos(phi1 - phi2)))
         // but we calculate (1/2)M^2
@@ -1176,7 +1173,7 @@ const bool l1t::CorrCondition::evaluateCondition(const int bxEval) const {
         if (corrPar.corrCutType & 0x10)
           coshDeltaEtaPhy = 1.;
         double massSqPhy = et0Phy * et1Phy * (coshDeltaEtaPhy - cosDeltaPhiPhy);
-	if( corrPar.corrCutType & 0x40 ) // Added by R.Cavanaugh for displaced muons
+	if( corrPar.corrCutType & 0x40 ) // Added for displaced muons
 	  massSqPhy = upt0Phy * upt1Phy * (coshDeltaEtaPhy - cosDeltaPhiPhy);
 
         long long cosDeltaPhiLUT = m_gtScales->getLUT_DeltaPhi_Cos(lutName, deltaPhiFW);

--- a/L1Trigger/L1TGlobal/src/GlobalScales.cc
+++ b/L1Trigger/L1TGlobal/src/GlobalScales.cc
@@ -98,6 +98,22 @@ void l1t::GlobalScales::setLUT_Pt(const std::string& lutName, std::vector<long l
   return;
 }
 
+// Added for displaced muons
+void l1t::GlobalScales::setLUT_Upt(const std::string& lutName, std::vector<long long> lut, unsigned int precision) {
+  if (m_lut_Upt.count(lutName) != 0) {
+    LogTrace("GlobalScales") << "      LUT \"" << lutName << "\"already exists in the LUT map- not inserted!"
+                             << std::endl;
+    return;
+  }
+
+  // Insert this LUT into the Table                                                                                                                  
+  m_lut_Upt.insert(std::map<std::string, std::vector<long long>>::value_type(lutName, lut));
+  m_Prec_Upt.insert(std::map<std::string, unsigned int>::value_type(lutName, precision));
+
+  return;
+}
+
+
 void l1t::GlobalScales::setLUT_Cosh(const std::string& lutName, std::vector<long long> lut, unsigned int precision) {
   if (m_lut_Cosh.count(lutName) != 0) {
     LogTrace("GlobalScales") << "      LUT \"" << lutName << "\"already exists in the LUT map- not inserted!"
@@ -299,6 +315,33 @@ unsigned int l1t::GlobalScales::getPrec_Pt(const std::string& lutName) const {
     value = m_Prec_Pt.find(lutName)->second;
   } else {
     edm::LogError("GlobalScales") << "Warning: LUT " << lutName << " for Pt not found" << std::endl;
+  }
+  return value;
+}
+
+// Added for displaced muons
+long long l1t::GlobalScales::getLUT_Upt(const std::string& lutName, int element) const {
+  long long value = 0;
+
+  if (element < 0) {
+    edm::LogError("GlobalScales") << "Error: Negative index, " << element << ", requested for Upt LUT ( " << lutName
+                                  << ")" << std::endl;
+  } else if (element >= (int)m_lut_Upt.find(lutName)->second.size()) {
+    edm::LogError("GlobalScales") << "Error: Element Requested " << element << " too large for Upt LUT (" << lutName
+                                  << ") size = " << m_lut_Upt.find(lutName)->second.size() << std::endl;
+  } else {
+    value = m_lut_Upt.find(lutName)->second.at(element);
+  }
+  return value;
+}
+// Added for displaced muons
+unsigned int l1t::GlobalScales::getPrec_Upt(const std::string& lutName) const {
+  unsigned int value = 0;
+
+  if (m_Prec_Upt.find(lutName) != m_Prec_Upt.end()) {
+    value = m_Prec_Upt.find(lutName)->second;
+  } else {
+    edm::LogError("GlobalScales") << "Warning: LUT " << lutName << " for Upt not found" << std::endl;
   }
   return value;
 }
@@ -520,6 +563,12 @@ void l1t::GlobalScales::dumpAllLUTs(std::ostream& myCout) const {
        itr++) {
     dumpLUT(myCout, 8, itr->first);
   }
+  // Added for displaced muons
+  for (std::map<std::string, std::vector<long long>>::const_iterator itr = m_lut_Upt.begin(); itr != m_lut_Upt.end();
+       itr++) {
+    dumpLUT(myCout, 8, itr->first);
+  }
+
 }
 
 void l1t::GlobalScales::dumpLUT(std::ostream& myCout, int LUTtype, std::string name) const {
@@ -571,6 +620,12 @@ void l1t::GlobalScales::dumpLUT(std::ostream& myCout, int LUTtype, std::string n
       dumpV = m_lut_Pt.find(name)->second;
       prec = m_Prec_Pt.find(name)->second;
       type = "Pt";
+      break;
+    }
+    case 9: { // Added for displaced muons
+      dumpV = m_lut_Upt.find(name)->second;
+      prec = m_Prec_Upt.find(name)->second;
+      type = "Upt";
       break;
     }
   }
@@ -668,6 +723,14 @@ void l1t::GlobalScales::print(std::ostream& myCout) const {
 
   myCout << " Pt:      ";
   for (std::map<std::string, std::vector<long long>>::const_iterator itr = m_lut_Pt.begin(); itr != m_lut_Pt.end();
+       itr++) {
+    myCout << " " << itr->first;
+  }
+  myCout << std::endl;
+
+  // Added for displaced muons
+  myCout << " Upt:      ";
+  for (std::map<std::string, std::vector<long long>>::const_iterator itr = m_lut_Upt.begin(); itr != m_lut_Upt.end();
        itr++) {
     myCout << " " << itr->first;
   }

--- a/L1Trigger/L1TGlobal/src/GlobalScales.cc
+++ b/L1Trigger/L1TGlobal/src/GlobalScales.cc
@@ -106,13 +106,12 @@ void l1t::GlobalScales::setLUT_Upt(const std::string& lutName, std::vector<long 
     return;
   }
 
-  // Insert this LUT into the Table                                                                                                                  
+  // Insert this LUT into the Table
   m_lut_Upt.insert(std::map<std::string, std::vector<long long>>::value_type(lutName, lut));
   m_Prec_Upt.insert(std::map<std::string, unsigned int>::value_type(lutName, precision));
 
   return;
 }
-
 
 void l1t::GlobalScales::setLUT_Cosh(const std::string& lutName, std::vector<long long> lut, unsigned int precision) {
   if (m_lut_Cosh.count(lutName) != 0) {
@@ -568,7 +567,6 @@ void l1t::GlobalScales::dumpAllLUTs(std::ostream& myCout) const {
        itr++) {
     dumpLUT(myCout, 8, itr->first);
   }
-
 }
 
 void l1t::GlobalScales::dumpLUT(std::ostream& myCout, int LUTtype, std::string name) const {
@@ -622,7 +620,7 @@ void l1t::GlobalScales::dumpLUT(std::ostream& myCout, int LUTtype, std::string n
       type = "Pt";
       break;
     }
-    case 9: { // Added for displaced muons
+    case 9: {  // Added for displaced muons
       dumpV = m_lut_Upt.find(name)->second;
       prec = m_Prec_Upt.find(name)->second;
       type = "Upt";

--- a/L1Trigger/L1TGlobal/src/MuonTemplate.cc
+++ b/L1Trigger/L1TGlobal/src/MuonTemplate.cc
@@ -9,6 +9,7 @@
  *
  * \author: Vasile Mihai Ghete - HEPHY Vienna
  *          Vladimir Rekovic - extend for indexing
+ *          Rick Cavanaugh - extend for displaced muons
  *
  * $Date$
  * $Revision$
@@ -79,6 +80,8 @@ void MuonTemplate::print(std::ostream& myCout) const {
     myCout << "  Template for object " << i << " [ hex ]" << std::endl;
     myCout << "    ptHighThreshold   = " << std::hex << m_objectParameter[i].ptHighThreshold << std::endl;
     myCout << "    ptLowThreshold    = " << std::hex << m_objectParameter[i].ptLowThreshold << std::endl;
+    myCout << "    uptHighCut        = " << std::hex << m_objectParameter[i].unconstrainedPtHigh << std::endl;
+    myCout << "    uptLowCut         = " << std::hex << m_objectParameter[i].unconstrainedPtLow << std::endl;
     myCout << "    indexHigh           = " << std::hex << m_objectParameter[i].indexHigh << std::endl;
     myCout << "    indexLow            = " << std::hex << m_objectParameter[i].indexLow << std::endl;
     myCout << "    enableMip         = " << std::hex << m_objectParameter[i].enableMip << std::endl;
@@ -87,6 +90,7 @@ void MuonTemplate::print(std::ostream& myCout) const {
     myCout << "    charge            =" << std::dec << m_objectParameter[i].charge << std::endl;
     myCout << "    qualityLUT        = " << std::hex << m_objectParameter[i].qualityLUT << std::endl;
     myCout << "    isolationLUT      = " << std::hex << m_objectParameter[i].isolationLUT << std::endl;
+    myCout << "    impactParameterLUT= " << std::hex << m_objectParameter[i].impactParameterLUT << std::endl;
     //       myCout << "    etaRange          = "
     //       << std::hex << m_objectParameter[i].etaRange << std::endl;
     //       myCout << "    phiHigh           = "


### PR DESCRIPTION
#### PR description:

This is a bug-fix to the uGT emulator for the unconstrained pT (UPT) invariant mass correlation condition; the calculation in the original PR incorrectly used the nominal pT, rather than the UPT. The bug-fix to the emulator is somewhat extensive and required code changes in several locations:
(1) TriggerMenuParser(.h, .cc), GlobalScales.(h, .cc) all had to be modified to correctly parse, set, and get the LUT scales for UPT.
(2) CorrCondition.cc had to be modified to correctly get and apply the LUT scales for UPT to enable the correct calculation of the invariant mass for UPT using integer arithmetic based on the LUT scales for UPT.
(3) TriggerMenuParser.cc also had to be modified to correctly parse the UPT and DXY (impact parameter) cuts for muon correlation conditions.
(4) the print function in MuonTemplate.cc now includes displaced muon information, for debugging purposes.

#### PR validation:

This PR has been validated by the following:
(1) confirming that all code changes compile correctly using l1t-integration-CMSSW_11_2_0 with tag l1t-integration-v105.3
(2) confirming that all code changes execute properly by producing test vectors
(3) confirming that the bug-fix is correct by comparing the emulator results in the test vectors with the uGT firmware.

Note that the VHDL firmware independently had the same bug, which caused earlier test vector comparisons between the emulator and the firmware to (incorrectly) agree. These new validation tests now demonstrate (correct) agreement between the bug-fixed emulator with the bug-fixed firmware.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

https://github.com/cms-l1t-offline/cmssw/pull/903/

@rekovic @cavana 