### PR TITLE
[DD4hep] Re-enable DD4hep workflow 11634.911 for PR tests

### DIFF
--- a/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
+++ b/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
@@ -84,7 +84,7 @@ if __name__ == '__main__':
                      10024.0, #2017 ttbar
                      10224.0, #2017 ttbar PU
                      10824.0, #2018 ttbar
-#temporarly remove DD4HEP from the short matrix 11634.911, #2021 DD4hep ttbar
+                     11634.911, #2021 DD4hep ttbar
                      11634.0, #2021 ttbar
                      12434.0, #2023 ttbar
                      23234.0, #2026D49 ttbar (HLT TDR baseline w/ HGCal v11)


### PR DESCRIPTION
DD4hep workflow 11634.911 was disabled for PR tests  in PR #33141 because it was giving fluctuating results. Different runs of the workflow were giving one or the other of two sets of results.

After PR #33199, it appears the instability has been fixed. Repeated tests of simulation with CMSSW_11_3_X_2021-04-02-1100 and  CMSSW_11_3_X_2021-04-06-1100 show consistent results (identical sequences of random seeds). It should be safe to run this workflow for PR tests.

No backport is needed.