### PR TITLE
Migrate module configurations in RecoLocalCalo to use automatically generated cfi default configurations

### DIFF
--- a/RecoLocalCalo/HcalRecProducers/python/hfQIE10Reco_cfi.py
+++ b/RecoLocalCalo/HcalRecProducers/python/hfQIE10Reco_cfi.py
@@ -1,12 +1,9 @@
 import FWCore.ParameterSet.Config as cms
-import RecoLocalCalo.HcalRecProducers.hosimplereco_cfi as _mod
+import RecoLocalCalo.HcalRecProducers.hfsimplereco_cfi as _mod
 
-hfQIE10Reco = _mod.hosimplereco.clone(
-    correctionPhaseNS = 0.0,
+hfQIE10Reco = _mod.hfsimplereco.clone(
     digiLabel = "simHcalUnsuppressedDigis:HFQIE10DigiCollection",
     Subdetector = 'HFQIE10',
-    correctForPhaseContainment = False,
-    correctForTimeslew = False,
     firstSample = 2,
     samplesToAdd = 1
 )

--- a/RecoLocalCalo/HcalRecProducers/python/hfQIE10Reco_cfi.py
+++ b/RecoLocalCalo/HcalRecProducers/python/hfQIE10Reco_cfi.py
@@ -1,15 +1,16 @@
 import FWCore.ParameterSet.Config as cms
+import RecoLocalCalo.HcalRecProducers.hosimplereco_cfi as _mod
 
-hfQIE10Reco = cms.EDProducer("HcalSimpleReconstructor",
-    correctionPhaseNS = cms.double(0.0),
-    digiLabel = cms.InputTag("simHcalUnsuppressedDigis","HFQIE10DigiCollection"),
-    Subdetector = cms.string('HFQIE10'),
-    correctForPhaseContainment = cms.bool(False),
-    correctForTimeslew = cms.bool(False),
-    dropZSmarkedPassed = cms.bool(True),
-    firstSample = cms.int32(2),
-    samplesToAdd = cms.int32(1),
-    tsFromDB = cms.bool(True)
+hfQIE10Reco = _mod.hosimplereco.clone(
+    correctionPhaseNS = 0.0,
+    digiLabel = "simHcalUnsuppressedDigis:HFQIE10DigiCollection",
+    Subdetector = 'HFQIE10',
+    correctForPhaseContainment = False,
+    correctForTimeslew = False,
+    dropZSmarkedPassed = True,
+    firstSample = 2,
+    samplesToAdd = 1,
+    tsFromDB = True
 )
 
 

--- a/RecoLocalCalo/HcalRecProducers/python/hfQIE10Reco_cfi.py
+++ b/RecoLocalCalo/HcalRecProducers/python/hfQIE10Reco_cfi.py
@@ -7,10 +7,8 @@ hfQIE10Reco = _mod.hosimplereco.clone(
     Subdetector = 'HFQIE10',
     correctForPhaseContainment = False,
     correctForTimeslew = False,
-    dropZSmarkedPassed = True,
     firstSample = 2,
-    samplesToAdd = 1,
-    tsFromDB = True
+    samplesToAdd = 1
 )
 
 


### PR DESCRIPTION
#### PR description: 
Optimization of the python configurations: Improve maintainability by cleaning up the duplicated and cloning from the default/reference configurations.
 
In this PR, 1 file changed.  (The previous PRs were  [PR#33207](https://github.com/cms-sw/cmssw/pull/33207), [PR#33307](https://github.com/cms-sw/cmssw/pull/33307) )

- commit 1 : 
Replace explicit configuration with a reference from cfipython/. (migrating EDProducer("type", .. -> typeDefaylt.clone() )
Remove the type specifications already presented in cfipython/fillDescriptions reference for improved syntax safety.

- commit 2 : 
Remove the duplicated parameters that are exactly the same value in cfipython reference.

#### PR validation:
Event Content comparison check was also done and there is no change with these updates.
Tested in CMSSW_11_3_X, the basic test all passed in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html).
