### PR TITLE
Put CSC validation plot titles back in CSCDigiTask

### DIFF
--- a/Validation/MuonCSCDigis/src/CSCALCTDigiValidation.cc
+++ b/Validation/MuonCSCDigis/src/CSCALCTDigiValidation.cc
@@ -21,8 +21,10 @@ void CSCALCTDigiValidation::bookHistograms(DQMStore::IBooker &iBooker) {
   for (int i = 1; i <= 10; ++i) {
     const std::string t1("CSCALCTDigiTime_" + CSCDetId::chamberName(i));
     const std::string t2("CSCALCTDigisPerChamber_" + CSCDetId::chamberName(i));
-    theTimeBinPlots[i - 1] = iBooker.book1D(t1, t1 + ";Wire Time Bin; Entries", 16, 0, 16);
-    theNDigisPerChamberPlots[i - 1] = iBooker.book1D(t2, t2 + ";Number of ALCTs per chamber;Entries", 4, 0, 4);
+    theTimeBinPlots[i - 1] =
+        iBooker.book1D(t1, "Wire Time Bin " + CSCDetId::chamberName(i) + ";Wire Time Bin; Entries", 16, 0, 16);
+    theNDigisPerChamberPlots[i - 1] = iBooker.book1D(
+        t2, "Number of ALCTs per chamber " + CSCDetId::chamberName(i) + ";Number of ALCTs per chamber;Entries", 4, 0, 4);
   }
 }
 

--- a/Validation/MuonCSCDigis/src/CSCCLCTDigiValidation.cc
+++ b/Validation/MuonCSCDigis/src/CSCCLCTDigiValidation.cc
@@ -21,8 +21,10 @@ void CSCCLCTDigiValidation::bookHistograms(DQMStore::IBooker &iBooker) {
   for (int i = 1; i <= 10; ++i) {
     const std::string t1("CSCCLCTDigiTime_" + CSCDetId::chamberName(i));
     const std::string t2("CSCCLCTDigisPerChamber_" + CSCDetId::chamberName(i));
-    theTimeBinPlots[i - 1] = iBooker.book1D(t1, t1 + ";Comparator Time Bin; Entries", 16, 0, 16);
-    theNDigisPerChamberPlots[i - 1] = iBooker.book1D(t2, t2 + ";Number of CLCTs per chamber;Entries", 4, 0, 4);
+    theTimeBinPlots[i - 1] = iBooker.book1D(
+        t1, "Comparator Time Bin " + CSCDetId::chamberName(i) + ";Comparator Time Bin; Entries", 16, 0, 16);
+    theNDigisPerChamberPlots[i - 1] = iBooker.book1D(
+        t2, "Number of CLCTs per chamber " + CSCDetId::chamberName(i) + ";Number of CLCTs per chamber;Entries", 4, 0, 4);
   }
 }
 

--- a/Validation/MuonCSCDigis/src/CSCComparatorDigiValidation.cc
+++ b/Validation/MuonCSCDigis/src/CSCComparatorDigiValidation.cc
@@ -17,18 +17,33 @@ CSCComparatorDigiValidation::CSCComparatorDigiValidation(const edm::ParameterSet
 CSCComparatorDigiValidation::~CSCComparatorDigiValidation() {}
 
 void CSCComparatorDigiValidation::bookHistograms(DQMStore::IBooker &iBooker) {
-  theNDigisPerEventPlot =
-      iBooker.book1D("CSCComparatorDigisPerEvent", ";CSC Comparator Digis per event;Entries", 100, 0, 100);
+  theNDigisPerEventPlot = iBooker.book1D("CSCComparatorDigisPerEvent",
+                                         "CSC Comparator Digis per event;CSC Comparator Digis per event;Entries",
+                                         100,
+                                         0,
+                                         100);
   // 10 chamber types, if you consider ME1/a and ME1/b separate
   for (int i = 1; i <= 10; ++i) {
     const std::string t1("CSCComparatorDigiTime_" + CSCDetId::chamberName(i));
     const std::string t2("CSCComparatorDigisPerLayer_" + CSCDetId::chamberName(i));
     const std::string t3("CSCComparatorStripAmplitude_" + CSCDetId::chamberName(i));
     const std::string t4("CSCComparator3StripAmplitude_" + CSCDetId::chamberName(i));
-    theTimeBinPlots[i - 1] = iBooker.book1D(t1, t1 + ";Comparator Time Bin; Entries", 16, 0, 16);
-    theNDigisPerLayerPlots[i - 1] = iBooker.book1D(t2, t2 + ";Number of Comparator Digis; Entries", 100, 0, 20);
-    theStripDigiPlots[i - 1] = iBooker.book1D(t3, t3 + ";Comparator Amplitude; Entries", 100, 0, 1000);
-    the3StripPlots[i - 1] = iBooker.book1D(t4, t4 + ";Comparator-triplet Amplitude; Entries", 100, 0, 1000);
+    theTimeBinPlots[i - 1] = iBooker.book1D(
+        t1, "Comparator Time Bin " + CSCDetId::chamberName(i) + " ;Comparator Time Bin; Entries", 16, 0, 16);
+    theNDigisPerLayerPlots[i - 1] = iBooker.book1D(
+        t2,
+        "Number of Comparator Digis " + CSCDetId::chamberName(i) + " ;Number of Comparator Digis; Entries",
+        100,
+        0,
+        20);
+    theStripDigiPlots[i - 1] = iBooker.book1D(
+        t3, "Comparator Amplitude " + CSCDetId::chamberName(i) + " ;Comparator Amplitude; Entries", 100, 0, 1000);
+    the3StripPlots[i - 1] = iBooker.book1D(
+        t4,
+        "Comparator-triplet Amplitude " + CSCDetId::chamberName(i) + " ;Comparator-triplet Amplitude; Entries",
+        100,
+        0,
+        1000);
   }
 }
 

--- a/Validation/MuonCSCDigis/src/CSCStripDigiValidation.cc
+++ b/Validation/MuonCSCDigis/src/CSCStripDigiValidation.cc
@@ -20,19 +20,32 @@ CSCStripDigiValidation::~CSCStripDigiValidation() {}
 
 void CSCStripDigiValidation::bookHistograms(DQMStore::IBooker &iBooker) {
   thePedestalPlot = iBooker.book1D("CSCPedestal", "CSC Pedestal;ADC Counts;Entries", 400, 550, 650);
-  theAmplitudePlot = iBooker.book1D("CSCStripAmplitude", ";CSC Strip Amplitude;Entries", 200, 0, 2000);
+  theAmplitudePlot = iBooker.book1D("CSCStripAmplitude", "CSC Strip Amplitude;Strip Amplitude;Entries", 200, 0, 2000);
   theRatio4to5Plot = iBooker.book1D("CSCStrip4to5", "CSC Strip Ratio tbin 4 to tbin 5;Strip Ratio;Entries", 100, 0, 1);
   theRatio6to5Plot =
       iBooker.book1D("CSCStrip6to5", "CSC Strip Ratio tbin 6 to tbin 5;Strip Ratio;Entries", 120, 0, 1.2);
   theNDigisPerLayerPlot =
-      iBooker.book1D("CSCStripDigisPerLayer", ";Number of CSC Strip Digis per layer;Entries", 48, 0, 48);
+      iBooker.book1D("CSCStripDigisPerLayer",
+                     "Number of CSC Strip Digis per layer;Number of CSC Strip Digis per layer;Entries",
+                     48,
+                     0,
+                     48);
   theNDigisPerEventPlot =
-      iBooker.book1D("CSCStripDigisPerEvent", ";Number of CSC Strip Digis per event;Entries", 100, 0, 500);
+      iBooker.book1D("CSCStripDigisPerEvent",
+                     "Number of CSC Strip Digis per event;Number of CSC Strip Digis per event;Entries",
+                     100,
+                     0,
+                     500);
 
   if (doSim_) {
     for (int i = 1; i <= 10; ++i) {
       const std::string t1("CSCStripPosResolution_" + CSCDetId::chamberName(i));
-      theResolutionPlots[i - 1] = iBooker.book1D(t1, t1 + ";Strip X Position Resolution; Entries", 100, -5, 5);
+      theResolutionPlots[i - 1] = iBooker.book1D(
+          t1,
+          "Strip X Position Resolution " + CSCDetId::chamberName(i) + ";Strip X Position Resolution; Entries",
+          100,
+          -5,
+          5);
     }
   }
 }

--- a/Validation/MuonCSCDigis/src/CSCWireDigiValidation.cc
+++ b/Validation/MuonCSCDigis/src/CSCWireDigiValidation.cc
@@ -16,14 +16,22 @@ CSCWireDigiValidation::CSCWireDigiValidation(const edm::ParameterSet &ps, edm::C
 CSCWireDigiValidation::~CSCWireDigiValidation() {}
 
 void CSCWireDigiValidation::bookHistograms(DQMStore::IBooker &iBooker) {
-  theNDigisPerEventPlot = iBooker.book1D("CSCWireDigisPerEvent", ";CSC Wire Digis per event;Entries", 100, 0, 100);
+  theNDigisPerEventPlot =
+      iBooker.book1D("CSCWireDigisPerEvent", "CSC Wire Digis per event;CSC Wire Digis per event;Entries", 100, 0, 100);
   for (int i = 1; i <= 10; ++i) {
     const std::string t1("CSCWireDigiTime_" + CSCDetId::chamberName(i));
     const std::string t2("CSCWireDigisPerLayer_" + CSCDetId::chamberName(i));
     const std::string t3("CSCWireDigiResolution_" + CSCDetId::chamberName(i));
-    theTimeBinPlots[i - 1] = iBooker.book1D(t1, t1 + ";Wire Time Bin; Entries", 16, 0, 16);
-    theNDigisPerLayerPlots[i - 1] = iBooker.book1D(t2, t2 + ";Number of Wire Digis; Entries", 100, 0, 20);
-    theResolutionPlots[i - 1] = iBooker.book1D(t3, t3 + ";Wire Y Position Resolution; Entries", 100, -10, 10);
+    theTimeBinPlots[i - 1] =
+        iBooker.book1D(t1, "Wire Time Bin " + CSCDetId::chamberName(i) + ";Wire Time Bin; Entries", 16, 0, 16);
+    theNDigisPerLayerPlots[i - 1] = iBooker.book1D(
+        t2, "Number of Wire Digis " + CSCDetId::chamberName(i) + ";Number of Wire Digis; Entries", 100, 0, 20);
+    theResolutionPlots[i - 1] = iBooker.book1D(
+        t3,
+        "Wire Y Position Resolution " + CSCDetId::chamberName(i) + ";Wire Y Position Resolution; Entries",
+        100,
+        -10,
+        10);
   }
 }
 


### PR DESCRIPTION
#### PR description:

In PR https://github.com/cms-sw/cmssw/pull/33086, I mistakenly changed plot titles to be only x-axis titles. They should also remain as plot titles. See examples below. I found this after inspecting the comparison plots in the 11_3_0_pre5_phase2 validation campaign. See also https://tinyurl.com/yghes5ry.

#### PR validation:

Code compiles.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)

<img width="537" alt="Screen Shot 2021-04-07 at 5 36 06 AM" src="https://user-images.githubusercontent.com/4134786/113853668-8858a780-9763-11eb-944f-78a15b54f99e.png">
<img width="542" alt="Screen Shot 2021-04-07 at 5 36 10 AM" src="https://user-images.githubusercontent.com/4134786/113853670-88f13e00-9763-11eb-95fa-0e9da33b2c45.png">
<img width="547" alt="Screen Shot 2021-04-07 at 5 38 24 AM" src="https://user-images.githubusercontent.com/4134786/113853671-8989d480-9763-11eb-9e1e-29fedd70b493.png">

FYI @ptcox 