### PR TITLE
Accessors for CLCT and LCT BX as defined in RAW data [11_2_X]

### DIFF
--- a/DataFormats/CSCDigi/interface/CSCCLCTDigi.h
+++ b/DataFormats/CSCDigi/interface/CSCCLCTDigi.h
@@ -24,6 +24,8 @@ public:
   enum CLCTPatternMasks { kRun3SlopeMask = 0xf, kRun3PatternMask = 0x7, kLegacyPatternMask = 0xf };
   enum CLCTPatternShifts { kRun3SlopeShift = 7, kRun3PatternShift = 4, kLegacyPatternShift = 0 };
   enum class Version { Legacy = 0, Run3 };
+  // for data vs emulator studies
+  enum CLCTBXMask { kBXDataMask = 0x3 };
 
   /// Constructors
   CSCCLCTDigi(const uint16_t valid,
@@ -117,6 +119,9 @@ public:
 
   /// return BX
   uint16_t getBX() const { return bx_; }
+
+  /// return 2-bit BX as in data
+  uint16_t getBXData() const { return bx_ & kBXDataMask; }
 
   /// set bx
   void setBX(const uint16_t bx) { bx_ = bx; }

--- a/DataFormats/CSCDigi/interface/CSCCorrelatedLCTDigi.h
+++ b/DataFormats/CSCDigi/interface/CSCCorrelatedLCTDigi.h
@@ -24,6 +24,8 @@ public:
   enum LCTPatternMasks { kRun3SlopeMask = 0xf, kRun3PatternMask = 0x7, kLegacyPatternMask = 0xf };
   enum LCTPatternShifts { kRun3SlopeShift = 7, kRun3PatternShift = 4, kLegacyPatternShift = 0 };
   enum class Version { Legacy = 0, Run3 };
+  // for data vs emulator studies
+  enum LCTBXMask { kBXDataMask = 0x1 };
 
   /// Constructors
   CSCCorrelatedLCTDigi(const uint16_t trknmb,
@@ -107,6 +109,9 @@ public:
 
   /// return BX
   uint16_t getBX() const { return bx; }
+
+  /// return 1-bit BX as in data
+  uint16_t getBXData() const { return bx & kBXDataMask; }
 
   /// return CLCT pattern number (in use again Feb 2011)
   /// This function should not be used for Run-3


### PR DESCRIPTION
#### PR description:

Get 2-bit CLCT BX and 1-bit LCT BX as defined in RAW data. Needed for data vs emulator studies in Run-3 L1T DQM. Same numbers as defined in `CSCTMBHeader2013::bits::clct_bxn` and `CSCTMBHeader2013::bits::MPC_Muon0_bx_`. 

#### PR validation:

Code compiles. 
 
#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Backport of https://github.com/cms-sw/cmssw/pull/33335
 
Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
