### PR TITLE
UL2016 Scale and smearing corrections (backport to 106X)

### DIFF
--- a/RecoEgamma/EgammaTools/python/calibratedEgammas_cff.py
+++ b/RecoEgamma/EgammaTools/python/calibratedEgammas_cff.py
@@ -18,8 +18,8 @@ from Configuration.ProcessModifiers.run2_miniAOD_UL_cff import run2_miniAOD_UL
 
 from Configuration.Eras.Modifier_run2_egamma_2016_cff import run2_egamma_2016
 from Configuration.Eras.Modifier_tracker_apv_vfp30_2016_cff import tracker_apv_vfp30_2016
-(run2_egamma_2016 & tracker_apv_vfp30_2016).toModify(calibratedEgammaSettings,correctionFile = _correctionFile2016ULpreVFP)
-(run2_egamma_2016 & ~tracker_apv_vfp30_2016).toModify(calibratedEgammaSettings,correctionFile = _correctionFile2016ULpostVFP)
+(run2_miniAOD_devel & run2_egamma_2016 & tracker_apv_vfp30_2016).toModify(calibratedEgammaSettings,correctionFile = _correctionFile2016ULpreVFP)
+(run2_miniAOD_devel & run2_egamma_2016 & ~tracker_apv_vfp30_2016).toModify(calibratedEgammaSettings,correctionFile = _correctionFile2016ULpostVFP)
 
 from Configuration.Eras.Modifier_run2_egamma_2017_cff import run2_egamma_2017
 (run2_miniAOD_UL & run2_egamma_2017).toModify(calibratedEgammaSettings,correctionFile = _correctionFile2017UL)

--- a/RecoEgamma/EgammaTools/python/calibratedEgammas_cff.py
+++ b/RecoEgamma/EgammaTools/python/calibratedEgammas_cff.py
@@ -18,8 +18,8 @@ from Configuration.ProcessModifiers.run2_miniAOD_UL_cff import run2_miniAOD_UL
 
 from Configuration.Eras.Modifier_run2_egamma_2016_cff import run2_egamma_2016
 from Configuration.Eras.Modifier_tracker_apv_vfp30_2016_cff import tracker_apv_vfp30_2016
-(run2_miniAOD_UL & run2_egamma_2016 & tracker_apv_vfp30_2016).toModify(calibratedEgammaSettings,correctionFile = _correctionFile2016ULpreVFP)
-(run2_miniAOD_UL & run2_egamma_2016 & ~tracker_apv_vfp30_2016).toModify(calibratedEgammaSettings,correctionFile = _correctionFile2016ULpostVFP)
+(run2_egamma_2016 & tracker_apv_vfp30_2016).toModify(calibratedEgammaSettings,correctionFile = _correctionFile2016ULpreVFP)
+(run2_egamma_2016 & ~tracker_apv_vfp30_2016).toModify(calibratedEgammaSettings,correctionFile = _correctionFile2016ULpostVFP)
 
 from Configuration.Eras.Modifier_run2_egamma_2017_cff import run2_egamma_2017
 (run2_miniAOD_UL & run2_egamma_2017).toModify(calibratedEgammaSettings,correctionFile = _correctionFile2017UL)

--- a/RecoEgamma/EgammaTools/python/calibratedEgammas_cff.py
+++ b/RecoEgamma/EgammaTools/python/calibratedEgammas_cff.py
@@ -1,9 +1,11 @@
 import FWCore.ParameterSet.Config as cms
 
-_correctionFile2016Legacy = "EgammaAnalysis/ElectronTools/data/ScalesSmearings/Legacy2016_07Aug2017_FineEtaR9_v3_ele_unc"
-_correctionFile2017Nov17 = "EgammaAnalysis/ElectronTools/data/ScalesSmearings/Run2017_17Nov2017_v1_ele_unc"
-_correctionFile2017UL    = "EgammaAnalysis/ElectronTools/data/ScalesSmearings/Run2017_24Feb2020_runEtaR9Gain_v2"
-_correctionFile2018UL    = "EgammaAnalysis/ElectronTools/data/ScalesSmearings/Run2018_29Sep2020_RunFineEtaR9Gain"
+_correctionFile2016Legacy    = "EgammaAnalysis/ElectronTools/data/ScalesSmearings/Legacy2016_07Aug2017_FineEtaR9_v3_ele_unc"
+_correctionFile2017Nov17     = "EgammaAnalysis/ElectronTools/data/ScalesSmearings/Run2017_17Nov2017_v1_ele_unc"
+_correctionFile2016ULpreVFP  = "EgammaAnalysis/ElectronTools/data/ScalesSmearings/Run2016_UltraLegacy_preVFP_RunFineEtaR9Gain"
+_correctionFile2016ULpostVFP = "EgammaAnalysis/ElectronTools/data/ScalesSmearings/Run2016_UltraLegacy_postVFP_RunFineEtaR9Gain"
+_correctionFile2017UL        = "EgammaAnalysis/ElectronTools/data/ScalesSmearings/Run2017_24Feb2020_runEtaR9Gain_v2"
+_correctionFile2018UL        = "EgammaAnalysis/ElectronTools/data/ScalesSmearings/Run2018_29Sep2020_RunFineEtaR9Gain"
 
 calibratedEgammaSettings = cms.PSet(minEtToCalibrate = cms.double(5.0),
                                     semiDeterministic = cms.bool(True),
@@ -13,6 +15,11 @@ calibratedEgammaSettings = cms.PSet(minEtToCalibrate = cms.double(5.0),
                                     produceCalibratedObjs = cms.bool(True)
                                    )
 from Configuration.ProcessModifiers.run2_miniAOD_UL_cff import run2_miniAOD_UL
+
+from Configuration.Eras.Modifier_run2_egamma_2016_cff import run2_egamma_2016
+from Configuration.Eras.Modifier_tracker_apv_vfp30_2016_cff import tracker_apv_vfp30_2016
+(run2_miniAOD_UL & run2_egamma_2016 & tracker_apv_vfp30_2016).toModify(calibratedEgammaSettings,correctionFile = _correctionFile2016ULpreVFP)
+(run2_miniAOD_UL & run2_egamma_2016 & ~tracker_apv_vfp30_2016).toModify(calibratedEgammaSettings,correctionFile = _correctionFile2016ULpostVFP)
 
 from Configuration.Eras.Modifier_run2_egamma_2017_cff import run2_egamma_2017
 (run2_miniAOD_UL & run2_egamma_2017).toModify(calibratedEgammaSettings,correctionFile = _correctionFile2017UL)

--- a/RecoEgamma/EgammaTools/python/calibratedEgammas_cff.py
+++ b/RecoEgamma/EgammaTools/python/calibratedEgammas_cff.py
@@ -14,12 +14,15 @@ calibratedEgammaSettings = cms.PSet(minEtToCalibrate = cms.double(5.0),
                                     recHitCollectionEE = cms.InputTag('reducedEcalRecHitsEE'),
                                     produceCalibratedObjs = cms.bool(True)
                                    )
-from Configuration.ProcessModifiers.run2_miniAOD_UL_cff import run2_miniAOD_UL
+
+from Configuration.Eras.Modifier_run2_miniAOD_devel_cff import run2_miniAOD_devel
 
 from Configuration.Eras.Modifier_run2_egamma_2016_cff import run2_egamma_2016
 from Configuration.Eras.Modifier_tracker_apv_vfp30_2016_cff import tracker_apv_vfp30_2016
 (run2_miniAOD_devel & run2_egamma_2016 & tracker_apv_vfp30_2016).toModify(calibratedEgammaSettings,correctionFile = _correctionFile2016ULpreVFP)
 (run2_miniAOD_devel & run2_egamma_2016 & ~tracker_apv_vfp30_2016).toModify(calibratedEgammaSettings,correctionFile = _correctionFile2016ULpostVFP)
+
+from Configuration.ProcessModifiers.run2_miniAOD_UL_cff import run2_miniAOD_UL
 
 from Configuration.Eras.Modifier_run2_egamma_2017_cff import run2_egamma_2017
 (run2_miniAOD_UL & run2_egamma_2017).toModify(calibratedEgammaSettings,correctionFile = _correctionFile2017UL)


### PR DESCRIPTION
#### PR description:

This PR is essentially a backport of #33030 and adds UL 2016 scale and smearing corrections in miniAOD in 106X.
Backport concerning nanoAOD will be done in a separate PR. 

Changes are done only to RecoEgamma/EgammaTools/python/calibratedEgammas_cff.py 

@mariadalfonso @sroychow  