### PR TITLE
Finalising esConsumes migration of HLTrigger/

### DIFF
--- a/CalibCalorimetry/EcalTPGTools/interface/EcalReadoutTools.h
+++ b/CalibCalorimetry/EcalTPGTools/interface/EcalReadoutTools.h
@@ -3,8 +3,7 @@
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/Framework/interface/ESHandle.h"
-
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "Geometry/Records/interface/IdealGeometryRecord.h"
 #include "Geometry/CaloTopology/interface/EcalTrigTowerConstituentsMap.h"
 #include "Geometry/EcalMapping/interface/EcalElectronicsMapping.h"
@@ -16,7 +15,14 @@ private:
   const EcalElectronicsMapping* elecMap_;
 
 public:
-  EcalReadoutTools(const edm::Event& iEvent, const edm::EventSetup& iSetup);
+  struct ESGetTokens {
+    ESGetTokens(const edm::ParameterSet&, edm::ConsumesCollector&& iC)
+        : ecalTrigTowerConstituentsMapToken{iC.esConsumes()}, ecalElectronicsMappingToken{iC.esConsumes()} {}
+    edm::ESGetToken<EcalTrigTowerConstituentsMap, IdealGeometryRecord> const ecalTrigTowerConstituentsMapToken;
+    edm::ESGetToken<EcalElectronicsMapping, EcalMappingRcd> const ecalElectronicsMappingToken;
+  };
+
+  EcalReadoutTools(const edm::Event&, const edm::EventSetup&, const ESGetTokens&);
   EcalReadoutTools(const EcalReadoutTools&) = delete;
   EcalReadoutTools& operator=(const EcalReadoutTools&) = delete;
 

--- a/CalibCalorimetry/EcalTPGTools/src/EcalReadoutTools.cc
+++ b/CalibCalorimetry/EcalTPGTools/src/EcalReadoutTools.cc
@@ -1,13 +1,8 @@
 #include "CalibCalorimetry/EcalTPGTools/interface/EcalReadoutTools.h"
 
-EcalReadoutTools::EcalReadoutTools(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
-  edm::ESHandle<EcalTrigTowerConstituentsMap> hTriggerTowerMap;
-  iSetup.get<IdealGeometryRecord>().get(hTriggerTowerMap);
-  triggerTowerMap_ = hTriggerTowerMap.product();
-
-  edm::ESHandle<EcalElectronicsMapping> ecalmapping;
-  iSetup.get<EcalMappingRcd>().get(ecalmapping);
-  elecMap_ = ecalmapping.product();
+EcalReadoutTools::EcalReadoutTools(const edm::Event&, const edm::EventSetup& iSetup, const ESGetTokens& esGetTokens) {
+  triggerTowerMap_ = &iSetup.getData(esGetTokens.ecalTrigTowerConstituentsMapToken);
+  elecMap_ = &iSetup.getData(esGetTokens.ecalElectronicsMappingToken);
 }
 
 EcalTrigTowerDetId EcalReadoutTools::readOutUnitOf(const EBDetId& xtalId) const {

--- a/HLTrigger/HLTcore/interface/TriggerExpressionData.h
+++ b/HLTrigger/HLTcore/interface/TriggerExpressionData.h
@@ -4,6 +4,8 @@
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "CondFormats/DataRecord/interface/L1TUtmTriggerMenuRcd.h"
+#include "CondFormats/L1TObjects/interface/L1TUtmTriggerMenu.h"
 #include "DataFormats/Provenance/interface/ParameterSetID.h"
 #include "DataFormats/Provenance/interface/EventID.h"
 #include "DataFormats/Common/interface/TriggerResults.h"
@@ -14,8 +16,6 @@ namespace edm {
   class EventSetup;
   class TriggerNames;
 }  // namespace edm
-
-class L1TUtmTriggerMenu;
 
 namespace triggerExpression {
 
@@ -28,6 +28,7 @@ namespace triggerExpression {
           m_hltResultsToken(),
           m_l1tResultsTag(""),
           m_l1tResultsToken(),
+          m_l1tUtmTriggerMenuToken(),
           m_l1tIgnoreMaskAndPrescale(false),
           m_throw(true),
           // l1 values and status
@@ -50,6 +51,7 @@ namespace triggerExpression {
           m_hltResultsToken(),
           m_l1tResultsTag(config.getParameter<edm::InputTag>("l1tResults")),
           m_l1tResultsToken(),
+          m_l1tUtmTriggerMenuToken(iC.esConsumes()),
           m_l1tIgnoreMaskAndPrescale(config.getParameter<bool>("l1tIgnoreMaskAndPrescale")),
           m_throw(config.getParameter<bool>("throw")),
           // l1 values and status
@@ -81,6 +83,7 @@ namespace triggerExpression {
           m_hltResultsToken(),
           m_l1tResultsTag(l1tResultsTag),
           m_l1tResultsToken(),
+          m_l1tUtmTriggerMenuToken(iC.esConsumes()),
           m_l1tIgnoreMaskAndPrescale(l1tIgnoreMaskAndPrescale),
           m_throw(doThrow),
           // l1 values and status
@@ -147,6 +150,7 @@ namespace triggerExpression {
     edm::EDGetTokenT<edm::TriggerResults> m_hltResultsToken;
     edm::InputTag m_l1tResultsTag;
     edm::EDGetTokenT<GlobalAlgBlkBxCollection> m_l1tResultsToken;
+    edm::ESGetToken<L1TUtmTriggerMenu, L1TUtmTriggerMenuRcd> const m_l1tUtmTriggerMenuToken;
     bool m_l1tIgnoreMaskAndPrescale;
     bool m_throw;
 

--- a/HLTrigger/HLTcore/src/TriggerExpressionData.cc
+++ b/HLTrigger/HLTcore/src/TriggerExpressionData.cc
@@ -1,5 +1,3 @@
-
-
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/ESHandle.h"
@@ -9,8 +7,6 @@
 #include "DataFormats/Common/interface/Handle.h"
 #include "DataFormats/Common/interface/TriggerResults.h"
 #include "DataFormats/L1TGlobal/interface/GlobalAlgBlk.h"
-#include "CondFormats/DataRecord/interface/L1TUtmTriggerMenuRcd.h"
-#include "CondFormats/L1TObjects/interface/L1TUtmTriggerMenu.h"
 #include "HLTrigger/HLTcore/interface/TriggerExpressionData.h"
 
 namespace triggerExpression {
@@ -37,7 +33,7 @@ namespace triggerExpression {
       if (m_l1tCacheID == l1tCacheID) {
         m_l1tUpdated = false;
       } else {
-        m_l1tMenu = &edm::get<L1TUtmTriggerMenu, L1TUtmTriggerMenuRcd>(setup);
+        m_l1tMenu = &setup.getData(m_l1tUtmTriggerMenuToken);
         m_l1tCacheID = l1tCacheID;
         m_l1tUpdated = true;
       }

--- a/HLTrigger/special/plugins/HLTRechitsToDigis.cc
+++ b/HLTrigger/special/plugins/HLTRechitsToDigis.cc
@@ -63,6 +63,8 @@ private:
   edm::EDGetTokenT<EBSrFlagCollection> srFlagsEBInToken_;
   edm::EDGetTokenT<EESrFlagCollection> srFlagsEEInToken_;
 
+  EcalReadoutTools::ESGetTokens const ecalReadoutToolsESGetTokens_;
+
   // input tags
   edm::InputTag digisIn_;
   edm::InputTag recHits_;
@@ -80,7 +82,8 @@ private:
 //
 // constructors and destructor
 //
-HLTRechitsToDigis::HLTRechitsToDigis(const edm::ParameterSet& iConfig) {
+HLTRechitsToDigis::HLTRechitsToDigis(const edm::ParameterSet& iConfig)
+    : ecalReadoutToolsESGetTokens_{iConfig, consumesCollector()} {
   //region to do rechit digi matching
   region_ = stringToRegion(iConfig.getParameter<std::string>("region"));
 
@@ -157,7 +160,7 @@ void HLTRechitsToDigis::produce(edm::Event& iEvent, edm::EventSetup const& setup
   // output collections
   std::unique_ptr<EBSrFlagCollection> outputEBSrFlagCollection(new EBSrFlagCollection);
   std::unique_ptr<EESrFlagCollection> outputEESrFlagCollection(new EESrFlagCollection);
-  EcalReadoutTools ecalReadOutTool(iEvent, setup);
+  EcalReadoutTools ecalReadOutTool(iEvent, setup, ecalReadoutToolsESGetTokens_);
 
   // calibrated rechits
   Handle<EcalRecHitCollection> recHitsHandle;

--- a/RecoParticleFlow/PFClusterProducer/interface/PFClusterEMEnergyCorrector.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFClusterEMEnergyCorrector.h
@@ -46,6 +46,7 @@ private:
   edm::EDGetTokenT<unsigned int> bunchSpacing_;
 
   const EcalClusterLazyTools::ESGetTokens ecalClusterToolsESGetTokens_;
+  const EcalReadoutTools::ESGetTokens ecalReadoutToolsESGetTokens_;
 
   std::vector<std::string> condnames_mean_;
   std::vector<std::string> condnames_sigma_;

--- a/RecoParticleFlow/PFClusterProducer/src/PFClusterEMEnergyCorrector.cc
+++ b/RecoParticleFlow/PFClusterProducer/src/PFClusterEMEnergyCorrector.cc
@@ -12,7 +12,9 @@ namespace {
 }  // namespace
 
 PFClusterEMEnergyCorrector::PFClusterEMEnergyCorrector(const edm::ParameterSet &conf, edm::ConsumesCollector &&cc)
-    : ecalClusterToolsESGetTokens_{std::move(cc)}, calibrator_(new PFEnergyCalibration) {
+    : ecalClusterToolsESGetTokens_{std::move(cc)},
+      ecalReadoutToolsESGetTokens_{conf, std::move(cc)},
+      calibrator_(new PFEnergyCalibration) {
   applyCrackCorrections_ = conf.getParameter<bool>("applyCrackCorrections");
   applyMVACorrections_ = conf.getParameter<bool>("applyMVACorrections");
   srfAwareCorrection_ = conf.getParameter<bool>("srfAwareCorrection");
@@ -149,7 +151,7 @@ void PFClusterEMEnergyCorrector::correctEnergies(const edm::Event &evt,
 
   // Common objects for SRF-aware and old style corrections
   EcalClusterLazyTools lazyTool(evt, ecalClusterToolsESGetTokens_.get(es), recHitsEB_, recHitsEE_);
-  EcalReadoutTools readoutTool(evt, es);
+  EcalReadoutTools readoutTool(evt, es, ecalReadoutToolsESGetTokens_);
 
   if (!srfAwareCorrection_) {
     int bunchspacing = 450;


### PR DESCRIPTION
#### PR description:

This PR is a follow-up of #33260, to finalise the `esConsumes` migration (see #31061) of `HLTrigger/`, based on this [recent IB report](https://cmssdt.cern.ch/SDT/jenkins-artifacts/ib-static-analysis/CMSSW_11_3_X_2021-04-06-2300/slc7_amd64_gcc900/reports/eventsetuprecord-get.yaml) (see mentions of `HLTrigger/`).

It requires a non-entirely-trivial update of `EcalReadoutTools`, for which I loosely followed part of what was done in #31892.

#### PR validation:

None (other than compiling).

#### If this PR is a backport, please specify the original PR and why you need to backport that PR:

N/A