### PR TITLE
PixelToplogyMap declare overloaded operator << as inline

### DIFF
--- a/Geometry/TrackerGeometryBuilder/interface/PixelTopologyMap.h
+++ b/Geometry/TrackerGeometryBuilder/interface/PixelTopologyMap.h
@@ -47,7 +47,7 @@ private:
   std::map<unsigned, std::pair<unsigned, unsigned>> m_pxfMap;
 };
 
-std::ostream& operator<<(std::ostream& os, PixelTopologyMap map) {
+inline std::ostream& operator<<(std::ostream& os, PixelTopologyMap map) {
   std::stringstream ss;
   map.printAll(ss);
   os << ss.str();


### PR DESCRIPTION
#### PR description:

Addresses issue: https://github.com/cms-sw/cmssw/pull/33319#discussion_r608714676

#### PR validation:

It compiles

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

not a backport, no backport needed.
