### PR TITLE
Enable misc-definitions-in-headers clang-tidy check

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,6 +1,7 @@
 ---
 Checks: -*,
   ,boost-use-to-string,
+  ,misc-definitions-in-headers,
   ,misc-string-compare,
   ,misc-uniqueptr-reset-release,
   ,modernize-deprecated-headers,
@@ -32,6 +33,8 @@ CheckOptions:
     value:           '10'
   - key:             google-readability-namespace-comments.SpacesBeforeComments
     value:           '2'
+  - key:             misc-definitions-in-headers.HeaderFileExtensions
+    value:           'h,hh,hpp,hxx,icc'
   - key:             modernize-loop-convert.MaxCopySize
     value:           '16'
   - key:             modernize-loop-convert.MinConfidence


### PR DESCRIPTION
#### PR description:

This PR suggests to enable [`misc-definitions-in-headers`](https://releases.llvm.org/11.1.0/tools/clang/tools/extra/docs/clang-tidy/checks/misc-definitions-in-headers.html) clang-tidy check to find and fix non-inline function definitions in headers (based on a recent encounter of one slipping through https://github.com/cms-sw/cmssw/pull/33319#discussion_r608714676).

#### PR validation:

Tested that a header defining a function without `inline` gets flagged and fixed. The impact on the entire CMSSW (excluding `test`, `macros`, `bin` directories) is shown in #33366.