### PR TITLE
Migrate RecoParticleFlow/PFTracking to esConsumes

### DIFF
--- a/RecoParticleFlow/PFTracking/interface/LightPFTrackProducer.h
+++ b/RecoParticleFlow/PFTracking/interface/LightPFTrackProducer.h
@@ -9,6 +9,9 @@
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
 
+#include "MagneticField/Engine/interface/MagneticField.h"
+#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
+
 class PFTrackTransformer;
 class LightPFTrackProducer : public edm::stream::EDProducer<> {
 public:
@@ -28,6 +31,8 @@ private:
   ///PFTrackTransformer
   PFTrackTransformer *pfTransformer_;
   std::vector<edm::EDGetTokenT<reco::TrackCollection> > tracksContainers_;
+  
+  const edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> magneticFieldToken_;
   ///TRACK QUALITY
   bool useQuality_;
   reco::TrackBase::TrackQuality trackQuality_;

--- a/RecoParticleFlow/PFTracking/interface/LightPFTrackProducer.h
+++ b/RecoParticleFlow/PFTracking/interface/LightPFTrackProducer.h
@@ -31,7 +31,7 @@ private:
   ///PFTrackTransformer
   PFTrackTransformer *pfTransformer_;
   std::vector<edm::EDGetTokenT<reco::TrackCollection> > tracksContainers_;
-  
+
   const edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> magneticFieldToken_;
   ///TRACK QUALITY
   bool useQuality_;

--- a/RecoParticleFlow/PFTracking/interface/LightPFTrackProducer.h
+++ b/RecoParticleFlow/PFTracking/interface/LightPFTrackProducer.h
@@ -8,7 +8,6 @@
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
-
 #include "MagneticField/Engine/interface/MagneticField.h"
 #include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
 

--- a/RecoParticleFlow/PFTracking/interface/PFNuclearProducer.h
+++ b/RecoParticleFlow/PFTracking/interface/PFNuclearProducer.h
@@ -8,6 +8,9 @@
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "DataFormats/ParticleFlowReco/interface/PFNuclearInteraction.h"
 
+#include "MagneticField/Engine/interface/MagneticField.h"
+#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
+
 class PFTrackTransformer;
 class PFNuclearProducer : public edm::stream::EDProducer<> {
 public:
@@ -28,5 +31,7 @@ private:
   PFTrackTransformer *pfTransformer_;
   double likelihoodCut_;
   std::vector<edm::EDGetTokenT<reco::NuclearInteractionCollection> > nuclearContainers_;
+
+  const edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> magneticFieldToken_;
 };
 #endif

--- a/RecoParticleFlow/PFTracking/interface/PFNuclearProducer.h
+++ b/RecoParticleFlow/PFTracking/interface/PFNuclearProducer.h
@@ -7,7 +7,6 @@
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "DataFormats/ParticleFlowReco/interface/PFNuclearInteraction.h"
-
 #include "MagneticField/Engine/interface/MagneticField.h"
 #include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
 

--- a/RecoParticleFlow/PFTracking/interface/PFTrackProducer.h
+++ b/RecoParticleFlow/PFTracking/interface/PFTrackProducer.h
@@ -11,6 +11,10 @@
 #include "DataFormats/GsfTrackReco/interface/GsfTrackFwd.h"
 #include "DataFormats/MuonReco/interface/MuonFwd.h"
 #include "DataFormats/VertexReco/interface/VertexFwd.h"
+#include "TrackingTools/TransientTrack/interface/TransientTrackBuilder.h"
+#include "TrackingTools/Records/interface/TransientTrackRecord.h"
+#include "MagneticField/Engine/interface/MagneticField.h"
+#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
 #include "RecoParticleFlow/PFTracking/interface/PFTrackTransformer.h"
 
 #include <memory>
@@ -36,6 +40,9 @@ private:
 
   ///Produce the PFRecTrack collection
   void produce(edm::Event&, const edm::EventSetup&) override;
+
+  const edm::ESGetToken<TransientTrackBuilder, TransientTrackRecord> transientTrackToken_;
+  const edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> magneticFieldToken_;
 
   ///PFTrackTransformer
   std::unique_ptr<PFTrackTransformer> pfTransformer_;

--- a/RecoParticleFlow/PFTracking/plugins/GoodSeedProducer.cc
+++ b/RecoParticleFlow/PFTracking/plugins/GoodSeedProducer.cc
@@ -162,6 +162,7 @@ private:
   const edm::ESGetToken<TrajectorySmoother, TrajectoryFitter::Record> smootherToken_;
   const edm::ESGetToken<TransientTrackingRecHitBuilder, TransientRecHitRecord> trackerRecHitBuilderToken_;
   const edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> magneticFieldToken_;
+  const edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> magneticFieldTokenBeginRun_;
 
   ///TRACK QUALITY
   bool useQuality_;
@@ -194,7 +195,8 @@ GoodSeedProducer::GoodSeedProducer(const ParameterSet& iConfig, const goodseedhe
       fitterToken_(esConsumes(edm::ESInputTag("", iConfig.getParameter<string>("Fitter")))),
       smootherToken_(esConsumes(edm::ESInputTag("", iConfig.getParameter<string>("Smoother")))),
       trackerRecHitBuilderToken_(esConsumes(edm::ESInputTag("", iConfig.getParameter<std::string>("TTRHBuilder")))),
-      magneticFieldToken_(esConsumes()) {
+      magneticFieldToken_(esConsumes()),
+      magneticFieldTokenBeginRun_(esConsumes<edm::Transition::BeginRun>()){
   LogInfo("GoodSeedProducer") << "Electron PreIdentification started  ";
 
   //now do what ever initialization is needed
@@ -616,8 +618,7 @@ namespace goodseedhelpers {
 // ------------ method called once each job just before starting event loop  ------------
 void GoodSeedProducer::beginRun(const edm::Run& run, const EventSetup& es) {
   //Magnetic Field
-  ESHandle<MagneticField> magneticField;
-  es.get<IdealMagneticFieldRecord>().get(magneticField);
+  auto const& magneticField = &es.getData(magneticFieldTokenBeginRun_);
   B_ = magneticField->inTesla(GlobalPoint(0, 0, 0));
 
   pfTransformer_ = std::make_unique<PFTrackTransformer>(B_);

--- a/RecoParticleFlow/PFTracking/plugins/GoodSeedProducer.cc
+++ b/RecoParticleFlow/PFTracking/plugins/GoodSeedProducer.cc
@@ -196,7 +196,7 @@ GoodSeedProducer::GoodSeedProducer(const ParameterSet& iConfig, const goodseedhe
       smootherToken_(esConsumes(edm::ESInputTag("", iConfig.getParameter<string>("Smoother")))),
       trackerRecHitBuilderToken_(esConsumes(edm::ESInputTag("", iConfig.getParameter<std::string>("TTRHBuilder")))),
       magneticFieldToken_(esConsumes()),
-      magneticFieldTokenBeginRun_(esConsumes<edm::Transition::BeginRun>()){
+      magneticFieldTokenBeginRun_(esConsumes<edm::Transition::BeginRun>()) {
   LogInfo("GoodSeedProducer") << "Electron PreIdentification started  ";
 
   //now do what ever initialization is needed

--- a/RecoParticleFlow/PFTracking/plugins/GoodSeedProducer.cc
+++ b/RecoParticleFlow/PFTracking/plugins/GoodSeedProducer.cc
@@ -187,11 +187,14 @@ using namespace std;
 using namespace reco;
 
 GoodSeedProducer::GoodSeedProducer(const ParameterSet& iConfig, const goodseedhelpers::HeavyObjectCache*)
-    : pfTransformer_(nullptr), conf_(iConfig), resMapEtaECAL_(nullptr), resMapPhiECAL_(nullptr),
+    : pfTransformer_(nullptr),
+      conf_(iConfig),
+      resMapEtaECAL_(nullptr),
+      resMapPhiECAL_(nullptr),
       fitterToken_(esConsumes(edm::ESInputTag("", iConfig.getParameter<string>("Fitter")))),
       smootherToken_(esConsumes(edm::ESInputTag("", iConfig.getParameter<string>("Smoother")))),
       trackerRecHitBuilderToken_(esConsumes(edm::ESInputTag("", iConfig.getParameter<std::string>("TTRHBuilder")))),
-      magneticFieldToken_(esConsumes())  {
+      magneticFieldToken_(esConsumes()) {
   LogInfo("GoodSeedProducer") << "Electron PreIdentification started  ";
 
   //now do what ever initialization is needed

--- a/RecoParticleFlow/PFTracking/plugins/HGCalTrackCollectionProducer.cc
+++ b/RecoParticleFlow/PFTracking/plugins/HGCalTrackCollectionProducer.cc
@@ -4,18 +4,16 @@
 // Tracks with bad pt resolution (suspected fakes) are dropped and not in either collection
 
 #include "FWCore/Framework/interface/MakerMacros.h"
-
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "RecoParticleFlow/PFClusterProducer/interface/InitialClusteringStepBase.h"
 #include "DataFormats/ParticleFlowReco/interface/PFRecHitFraction.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "RecoParticleFlow/PFClusterProducer/interface/PFCPositionCalculatorBase.h"
 #include "RecoParticleFlow/PFTracking/interface/PFTrackAlgoTools.h"
-
 #include "DataFormats/ForwardDetId/interface/ForwardSubdetector.h"
 #include "DataFormats/Common/interface/Handle.h"
-#include "FWCore/Framework/interface/ESHandle.h"
-
-//#include "DataFormats/TrackReco/interface/Track.h"
 #include "DataFormats/ParticleFlowReco/interface/PFRecTrackFwd.h"
 #include "DataFormats/ParticleFlowReco/interface/PFRecTrack.h"
 #include "DataFormats/TrackReco/interface/Track.h"
@@ -35,11 +33,7 @@
 #include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
 #include "Geometry/Records/interface/IdealGeometryRecord.h"
 
-#include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/stream/EDProducer.h"
-
 #include <memory>
-
 #include <unordered_map>
 
 class HGCalTrackCollectionProducer : public edm::stream::EDProducer<> {

--- a/RecoParticleFlow/PFTracking/plugins/HGCalTrackCollectionProducer.cc
+++ b/RecoParticleFlow/PFTracking/plugins/HGCalTrackCollectionProducer.cc
@@ -66,8 +66,9 @@ private:
   const edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> tkerGeomToken_;
   const MagneticField* bField_;
   const TrackerGeometry* tkGeom_;
-  std::array<std::string, 1> hgc_names_;                       // 3 --> 1; extrapolate to hgcee only
-  std::array<edm::ESGetToken<HGCalGeometry, IdealGeometryRecord>, 1> hgcGeometryTokens_;  // 3 --> 1; extrapolate to hgcee only
+  std::array<std::string, 1> hgc_names_;  // 3 --> 1; extrapolate to hgcee only
+  std::array<edm::ESGetToken<HGCalGeometry, IdealGeometryRecord>, 1>
+      hgcGeometryTokens_;                              // 3 --> 1; extrapolate to hgcee only
   std::array<const HGCalGeometry*, 1> hgcGeometries_;  // 3 --> 1; extrapolate to hgcee only
   std::array<std::vector<ReferenceCountingPointer<BoundDisk> >, 1> plusSurface_,
       minusSurface_;  // 3 --> 1; extrapolate to hgcee only
@@ -86,8 +87,7 @@ HGCalTrackCollectionProducer::HGCalTrackCollectionProducer(const edm::ParameterS
       NHitCut_(iConfig.getParameter<std::vector<unsigned> >("NHitCuts_byTrackAlgo")),
       useIterTracking_(iConfig.getParameter<bool>("useIterativeTracking")),
       magneticFieldToken_(esConsumes<edm::Transition::BeginLuminosityBlock>()),
-      tkerGeomToken_(esConsumes<edm::Transition::BeginLuminosityBlock>())
-      {
+      tkerGeomToken_(esConsumes<edm::Transition::BeginLuminosityBlock>()) {
   LogDebug("HGCalTrackCollectionProducer")
       << " HGCalTrackCollectionProducer::HGCalTrackCollectionProducer " << std::endl;
 

--- a/RecoParticleFlow/PFTracking/plugins/HGCalTrackCollectionProducer.cc
+++ b/RecoParticleFlow/PFTracking/plugins/HGCalTrackCollectionProducer.cc
@@ -62,10 +62,13 @@ private:
   //  const bool _useFirstLayerOnly; // always true now
 
   // variables needed for copied extrapolation
-  edm::ESHandle<MagneticField> bField_;
-  edm::ESHandle<TrackerGeometry> tkGeom_;
+  const edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> magneticFieldToken_;
+  const edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> tkerGeomToken_;
+  const MagneticField* bField_;
+  const TrackerGeometry* tkGeom_;
   std::array<std::string, 1> hgc_names_;                       // 3 --> 1; extrapolate to hgcee only
-  std::array<edm::ESHandle<HGCalGeometry>, 1> hgcGeometries_;  // 3 --> 1; extrapolate to hgcee only
+  std::array<edm::ESGetToken<HGCalGeometry, IdealGeometryRecord>, 1> hgcGeometryTokens_;  // 3 --> 1; extrapolate to hgcee only
+  std::array<const HGCalGeometry*, 1> hgcGeometries_;  // 3 --> 1; extrapolate to hgcee only
   std::array<std::vector<ReferenceCountingPointer<BoundDisk> >, 1> plusSurface_,
       minusSurface_;  // 3 --> 1; extrapolate to hgcee only
   std::unique_ptr<PropagatorWithMaterial> mat_prop_;
@@ -81,12 +84,18 @@ HGCalTrackCollectionProducer::HGCalTrackCollectionProducer(const edm::ParameterS
                         : reco::TrackBase::highPurity),
       DPtovPtCut_(iConfig.getParameter<std::vector<double> >("DPtOverPtCuts_byTrackAlgo")),
       NHitCut_(iConfig.getParameter<std::vector<unsigned> >("NHitCuts_byTrackAlgo")),
-      useIterTracking_(iConfig.getParameter<bool>("useIterativeTracking")) {
+      useIterTracking_(iConfig.getParameter<bool>("useIterativeTracking")),
+      magneticFieldToken_(esConsumes<edm::Transition::BeginLuminosityBlock>()),
+      tkerGeomToken_(esConsumes<edm::Transition::BeginLuminosityBlock>())
+      {
   LogDebug("HGCalTrackCollectionProducer")
       << " HGCalTrackCollectionProducer::HGCalTrackCollectionProducer " << std::endl;
 
   const edm::ParameterSet& geoconf = iConfig.getParameterSet("hgcalGeometryNames");
   hgc_names_[0] = geoconf.getParameter<std::string>("HGC_ECAL");
+  for (unsigned i = 0; i < hgcGeometryTokens_.size(); i++) {
+    hgcGeometryTokens_[i] = esConsumes<edm::Transition::BeginLuminosityBlock>(edm::ESInputTag("", hgc_names_[i]));
+  }
 
   produces<reco::PFRecTrackCollection>("TracksInHGCal");
   produces<reco::PFRecTrackCollection>("TracksNotInHGCal");
@@ -97,15 +106,15 @@ HGCalTrackCollectionProducer::HGCalTrackCollectionProducer(const edm::ParameterS
 void HGCalTrackCollectionProducer::beginLuminosityBlock(const edm::LuminosityBlock& lumi, const edm::EventSetup& es) {
   constexpr float m_pion = 0.1396;
   // get dependencies for setting up propagator
-  es.get<IdealMagneticFieldRecord>().get(bField_);
-  es.get<TrackerDigiGeometryRecord>().get(tkGeom_);
+  bField_ = &es.getData(magneticFieldToken_);
+  tkGeom_ = &es.getData(tkerGeomToken_);
   // get HGC geometries (assume that layers are ordered in Z!)
   for (unsigned i = 0; i < hgcGeometries_.size(); ++i) {
-    es.get<IdealGeometryRecord>().get(hgc_names_[i], hgcGeometries_[i]);
+    hgcGeometries_[i] = &es.getData(hgcGeometryTokens_[i]);
   }
 
   // make propagator
-  mat_prop_ = std::make_unique<PropagatorWithMaterial>(alongMomentum, m_pion, bField_.product());
+  mat_prop_ = std::make_unique<PropagatorWithMaterial>(alongMomentum, m_pion, bField_);
   // setup HGC layers for track propagation
   Surface::RotationType rot;  //unit rotation matrix
   for (unsigned i = 0; i < hgcGeometries_.size(); ++i) {
@@ -147,7 +156,7 @@ void HGCalTrackCollectionProducer::produce(edm::Event& evt, const edm::EventSetu
       continue;
     bool found = false;
     const TrajectoryStateOnSurface myTSOS =
-        trajectoryStateTransform::outerStateOnSurface(*(track->trackRef()), *(tkGeom_.product()), bField_.product());
+        trajectoryStateTransform::outerStateOnSurface(*(track->trackRef()), *tkGeom_, bField_);
     auto detbegin = myTSOS.globalPosition().z() > 0 ? plusSurface_.begin() : minusSurface_.begin();
     auto detend = myTSOS.globalPosition().z() > 0 ? plusSurface_.end() : minusSurface_.end();
     for (auto det = detbegin; det != detend; ++det) {

--- a/RecoParticleFlow/PFTracking/plugins/LightPFTrackProducer.cc
+++ b/RecoParticleFlow/PFTracking/plugins/LightPFTrackProducer.cc
@@ -6,12 +6,11 @@
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "TrackingTools/PatternTools/interface/Trajectory.h"
 #include "FWCore/Framework/interface/ESHandle.h"
-#include "MagneticField/Engine/interface/MagneticField.h"
-#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
 
 using namespace std;
 using namespace edm;
-LightPFTrackProducer::LightPFTrackProducer(const ParameterSet& iConfig) : pfTransformer_(nullptr) {
+LightPFTrackProducer::LightPFTrackProducer(const ParameterSet& iConfig) : pfTransformer_(nullptr),
+    magneticFieldToken_(esConsumes<edm::Transition::BeginRun>())  {
   produces<reco::PFRecTrackCollection>();
 
   std::vector<InputTag> tags = iConfig.getParameter<vector<InputTag> >("TkColList");
@@ -51,8 +50,7 @@ void LightPFTrackProducer::produce(Event& iEvent, const EventSetup& iSetup) {
 
 // ------------ method called once each job just before starting event loop  ------------
 void LightPFTrackProducer::beginRun(const edm::Run& run, const EventSetup& iSetup) {
-  ESHandle<MagneticField> magneticField;
-  iSetup.get<IdealMagneticFieldRecord>().get(magneticField);
+  auto const& magneticField = &iSetup.getData(magneticFieldToken_);
   pfTransformer_ = new PFTrackTransformer(math::XYZVector(magneticField->inTesla(GlobalPoint(0, 0, 0))));
   pfTransformer_->OnlyProp();
 }

--- a/RecoParticleFlow/PFTracking/plugins/LightPFTrackProducer.cc
+++ b/RecoParticleFlow/PFTracking/plugins/LightPFTrackProducer.cc
@@ -9,8 +9,8 @@
 
 using namespace std;
 using namespace edm;
-LightPFTrackProducer::LightPFTrackProducer(const ParameterSet& iConfig) : pfTransformer_(nullptr),
-    magneticFieldToken_(esConsumes<edm::Transition::BeginRun>())  {
+LightPFTrackProducer::LightPFTrackProducer(const ParameterSet& iConfig)
+    : pfTransformer_(nullptr), magneticFieldToken_(esConsumes<edm::Transition::BeginRun>()) {
   produces<reco::PFRecTrackCollection>();
 
   std::vector<InputTag> tags = iConfig.getParameter<vector<InputTag> >("TkColList");

--- a/RecoParticleFlow/PFTracking/plugins/PFConversionProducer.cc
+++ b/RecoParticleFlow/PFTracking/plugins/PFConversionProducer.cc
@@ -4,21 +4,18 @@
 #include "DataFormats/VertexReco/interface/Vertex.h"
 #include "TrackingTools/PatternTools/interface/Trajectory.h"
 #include "FWCore/Framework/interface/ESHandle.h"
-//#include "MagneticField/Engine/interface/MagneticField.h"
-//#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
 #include "DataFormats/Common/interface/RefToBase.h"
 #include "CommonTools/Statistics/interface/ChiSquaredProbability.h"
-//#include "TrackingTools/TransientTrack/interface/TransientTrackBuilder.h"
-//#include "TrackingTools/Records/interface/TransientTrackRecord.h"
 #include "TrackingTools/IPTools/interface/IPTools.h"
 
 typedef std::multimap<unsigned, std::vector<unsigned> > BlockMap;
 using namespace std;
 using namespace edm;
 
-PFConversionProducer::PFConversionProducer(const ParameterSet& iConfig) : pfTransformer_(nullptr),
-    transientTrackToken_(esConsumes(edm::ESInputTag("", "TransientTrackBuilder"))), 
-    magneticFieldToken_(esConsumes<edm::Transition::BeginRun>())  {
+PFConversionProducer::PFConversionProducer(const ParameterSet& iConfig)
+    : pfTransformer_(nullptr),
+      transientTrackToken_(esConsumes(edm::ESInputTag("", "TransientTrackBuilder"))),
+      magneticFieldToken_(esConsumes<edm::Transition::BeginRun>()) {
   produces<reco::PFRecTrackCollection>();
   produces<reco::PFConversionCollection>();
 
@@ -35,7 +32,7 @@ void PFConversionProducer::produce(Event& iEvent, const EventSetup& iSetup) {
   auto pfRecTrackColl = std::make_unique<reco::PFRecTrackCollection>();
 
   TransientTrackBuilder const& thebuilder = iSetup.getData(transientTrackToken_);
-  
+
   reco::PFRecTrackRefProd pfTrackRefProd = iEvent.getRefBeforePut<reco::PFRecTrackCollection>();
   Handle<reco::ConversionCollection> convCollH;
   iEvent.getByToken(pfConversionContainer_, convCollH);

--- a/RecoParticleFlow/PFTracking/plugins/PFConversionProducer.cc
+++ b/RecoParticleFlow/PFTracking/plugins/PFConversionProducer.cc
@@ -4,19 +4,21 @@
 #include "DataFormats/VertexReco/interface/Vertex.h"
 #include "TrackingTools/PatternTools/interface/Trajectory.h"
 #include "FWCore/Framework/interface/ESHandle.h"
-#include "MagneticField/Engine/interface/MagneticField.h"
-#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
+//#include "MagneticField/Engine/interface/MagneticField.h"
+//#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
 #include "DataFormats/Common/interface/RefToBase.h"
 #include "CommonTools/Statistics/interface/ChiSquaredProbability.h"
-#include "TrackingTools/TransientTrack/interface/TransientTrackBuilder.h"
-#include "TrackingTools/Records/interface/TransientTrackRecord.h"
+//#include "TrackingTools/TransientTrack/interface/TransientTrackBuilder.h"
+//#include "TrackingTools/Records/interface/TransientTrackRecord.h"
 #include "TrackingTools/IPTools/interface/IPTools.h"
 
 typedef std::multimap<unsigned, std::vector<unsigned> > BlockMap;
 using namespace std;
 using namespace edm;
 
-PFConversionProducer::PFConversionProducer(const ParameterSet& iConfig) : pfTransformer_(nullptr) {
+PFConversionProducer::PFConversionProducer(const ParameterSet& iConfig) : pfTransformer_(nullptr),
+    transientTrackToken_(esConsumes(edm::ESInputTag("", "TransientTrackBuilder"))), 
+    magneticFieldToken_(esConsumes<edm::Transition::BeginRun>())  {
   produces<reco::PFRecTrackCollection>();
   produces<reco::PFConversionCollection>();
 
@@ -32,9 +34,8 @@ void PFConversionProducer::produce(Event& iEvent, const EventSetup& iSetup) {
   auto pfConversionColl = std::make_unique<reco::PFConversionCollection>();
   auto pfRecTrackColl = std::make_unique<reco::PFRecTrackCollection>();
 
-  edm::ESHandle<TransientTrackBuilder> builder;
-  iSetup.get<TransientTrackRecord>().get("TransientTrackBuilder", builder);
-  TransientTrackBuilder thebuilder = *(builder.product());
+  TransientTrackBuilder const& thebuilder = iSetup.getData(transientTrackToken_);
+  
   reco::PFRecTrackRefProd pfTrackRefProd = iEvent.getRefBeforePut<reco::PFRecTrackCollection>();
   Handle<reco::ConversionCollection> convCollH;
   iEvent.getByToken(pfConversionContainer_, convCollH);
@@ -164,8 +165,7 @@ void PFConversionProducer::produce(Event& iEvent, const EventSetup& iSetup) {
 
 // ------------ method called once each job just before starting event loop  ------------
 void PFConversionProducer::beginRun(const edm::Run& run, const EventSetup& iSetup) {
-  ESHandle<MagneticField> magneticField;
-  iSetup.get<IdealMagneticFieldRecord>().get(magneticField);
+  auto const& magneticField = &iSetup.getData(magneticFieldToken_);
   pfTransformer_ = new PFTrackTransformer(math::XYZVector(magneticField->inTesla(GlobalPoint(0, 0, 0))));
   pfTransformer_->OnlyProp();
 }

--- a/RecoParticleFlow/PFTracking/plugins/PFConversionProducer.h
+++ b/RecoParticleFlow/PFTracking/plugins/PFConversionProducer.h
@@ -10,6 +10,11 @@
 #include "DataFormats/ParticleFlowReco/interface/PFConversion.h"
 #include "DataFormats/ParticleFlowReco/interface/PFConversionFwd.h"
 
+#include "MagneticField/Engine/interface/MagneticField.h"
+#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
+#include "TrackingTools/TransientTrack/interface/TransientTrackBuilder.h"
+#include "TrackingTools/Records/interface/TransientTrackRecord.h"
+
 class PFTrackTransformer;
 class PFConversionProducer : public edm::stream::EDProducer<> {
 public:
@@ -30,5 +35,8 @@ private:
   PFTrackTransformer *pfTransformer_;
   edm::EDGetTokenT<reco::ConversionCollection> pfConversionContainer_;
   edm::EDGetTokenT<reco::VertexCollection> vtx_h;
+  
+  const edm::ESGetToken<TransientTrackBuilder, TransientTrackRecord> transientTrackToken_;
+  const edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> magneticFieldToken_;
 };
 #endif

--- a/RecoParticleFlow/PFTracking/plugins/PFConversionProducer.h
+++ b/RecoParticleFlow/PFTracking/plugins/PFConversionProducer.h
@@ -35,7 +35,7 @@ private:
   PFTrackTransformer *pfTransformer_;
   edm::EDGetTokenT<reco::ConversionCollection> pfConversionContainer_;
   edm::EDGetTokenT<reco::VertexCollection> vtx_h;
-  
+
   const edm::ESGetToken<TransientTrackBuilder, TransientTrackRecord> transientTrackToken_;
   const edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> magneticFieldToken_;
 };

--- a/RecoParticleFlow/PFTracking/plugins/PFConversionProducer.h
+++ b/RecoParticleFlow/PFTracking/plugins/PFConversionProducer.h
@@ -9,7 +9,6 @@
 #include "DataFormats/VertexReco/interface/VertexFwd.h"
 #include "DataFormats/ParticleFlowReco/interface/PFConversion.h"
 #include "DataFormats/ParticleFlowReco/interface/PFConversionFwd.h"
-
 #include "MagneticField/Engine/interface/MagneticField.h"
 #include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
 #include "TrackingTools/TransientTrack/interface/TransientTrackBuilder.h"

--- a/RecoParticleFlow/PFTracking/plugins/PFDisplacedTrackerVertexProducer.cc
+++ b/RecoParticleFlow/PFTracking/plugins/PFDisplacedTrackerVertexProducer.cc
@@ -7,8 +7,7 @@
 using namespace std;
 using namespace edm;
 PFDisplacedTrackerVertexProducer::PFDisplacedTrackerVertexProducer(const ParameterSet& iConfig)
-    : pfTransformer_(nullptr),
-      magneticFieldToken_(esConsumes<edm::Transition::BeginRun>())  {
+    : pfTransformer_(nullptr), magneticFieldToken_(esConsumes<edm::Transition::BeginRun>()) {
   produces<reco::PFRecTrackCollection>();
   produces<reco::PFDisplacedTrackerVertexCollection>();
 

--- a/RecoParticleFlow/PFTracking/plugins/PFDisplacedTrackerVertexProducer.cc
+++ b/RecoParticleFlow/PFTracking/plugins/PFDisplacedTrackerVertexProducer.cc
@@ -3,12 +3,12 @@
 #include "RecoParticleFlow/PFTracking/interface/PFTrackTransformer.h"
 #include "TrackingTools/PatternTools/interface/Trajectory.h"
 #include "FWCore/Framework/interface/ESHandle.h"
-#include "MagneticField/Engine/interface/MagneticField.h"
-#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
+
 using namespace std;
 using namespace edm;
 PFDisplacedTrackerVertexProducer::PFDisplacedTrackerVertexProducer(const ParameterSet& iConfig)
-    : pfTransformer_(nullptr) {
+    : pfTransformer_(nullptr),
+      magneticFieldToken_(esConsumes<edm::Transition::BeginRun>())  {
   produces<reco::PFRecTrackCollection>();
   produces<reco::PFDisplacedTrackerVertexCollection>();
 
@@ -77,8 +77,7 @@ void PFDisplacedTrackerVertexProducer::produce(Event& iEvent, const EventSetup& 
 
 // ------------ method called once each job just before starting event loop  ------------
 void PFDisplacedTrackerVertexProducer::beginRun(const edm::Run& run, const EventSetup& iSetup) {
-  ESHandle<MagneticField> magneticField;
-  iSetup.get<IdealMagneticFieldRecord>().get(magneticField);
+  auto const& magneticField = &iSetup.getData(magneticFieldToken_);
   pfTransformer_ = new PFTrackTransformer(math::XYZVector(magneticField->inTesla(GlobalPoint(0, 0, 0))));
   pfTransformer_->OnlyProp();
 }

--- a/RecoParticleFlow/PFTracking/plugins/PFDisplacedTrackerVertexProducer.h
+++ b/RecoParticleFlow/PFTracking/plugins/PFDisplacedTrackerVertexProducer.h
@@ -8,6 +8,9 @@
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "DataFormats/ParticleFlowReco/interface/PFDisplacedTrackerVertex.h"
 
+#include "MagneticField/Engine/interface/MagneticField.h"
+#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
+
 class PFTrackTransformer;
 class PFDisplacedTrackerVertexProducer : public edm::stream::EDProducer<> {
 public:
@@ -28,5 +31,7 @@ private:
   PFTrackTransformer *pfTransformer_;
   edm::EDGetTokenT<reco::PFDisplacedVertexCollection> pfDisplacedVertexContainer_;
   edm::EDGetTokenT<reco::TrackCollection> pfTrackContainer_;
+
+  const edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> magneticFieldToken_;
 };
 #endif

--- a/RecoParticleFlow/PFTracking/plugins/PFDisplacedTrackerVertexProducer.h
+++ b/RecoParticleFlow/PFTracking/plugins/PFDisplacedTrackerVertexProducer.h
@@ -7,7 +7,6 @@
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "DataFormats/ParticleFlowReco/interface/PFDisplacedTrackerVertex.h"
-
 #include "MagneticField/Engine/interface/MagneticField.h"
 #include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
 

--- a/RecoParticleFlow/PFTracking/plugins/PFDisplacedVertexCandidateProducer.cc
+++ b/RecoParticleFlow/PFTracking/plugins/PFDisplacedVertexCandidateProducer.cc
@@ -8,15 +8,13 @@
 
 #include "FWCore/ParameterSet/interface/FileInPath.h"
 
-#include "MagneticField/Engine/interface/MagneticField.h"
-#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
-
 #include <set>
 
 using namespace std;
 using namespace edm;
 
-PFDisplacedVertexCandidateProducer::PFDisplacedVertexCandidateProducer(const edm::ParameterSet& iConfig) {
+PFDisplacedVertexCandidateProducer::PFDisplacedVertexCandidateProducer(const edm::ParameterSet& iConfig) :
+    magneticFieldToken_(esConsumes()) {
   // --- Setup input collection names --- //
   inputTagTracks_ = consumes<reco::TrackCollection>(iConfig.getParameter<InputTag>("trackCollection"));
 
@@ -58,9 +56,7 @@ void PFDisplacedVertexCandidateProducer::produce(Event& iEvent, const EventSetup
       << "START event: " << iEvent.id().event() << " in run " << iEvent.id().run() << endl;
 
   // Prepare and fill useful event information for the Finder
-  edm::ESHandle<MagneticField> magField;
-  iSetup.get<IdealMagneticFieldRecord>().get(magField);
-  const MagneticField* theMagField = magField.product();
+  auto const& theMagField = &iSetup.getData(magneticFieldToken_);
 
   Handle<reco::TrackCollection> trackCollection;
   iEvent.getByToken(inputTagTracks_, trackCollection);

--- a/RecoParticleFlow/PFTracking/plugins/PFDisplacedVertexCandidateProducer.cc
+++ b/RecoParticleFlow/PFTracking/plugins/PFDisplacedVertexCandidateProducer.cc
@@ -13,8 +13,8 @@
 using namespace std;
 using namespace edm;
 
-PFDisplacedVertexCandidateProducer::PFDisplacedVertexCandidateProducer(const edm::ParameterSet& iConfig) :
-    magneticFieldToken_(esConsumes()) {
+PFDisplacedVertexCandidateProducer::PFDisplacedVertexCandidateProducer(const edm::ParameterSet& iConfig)
+    : magneticFieldToken_(esConsumes()) {
   // --- Setup input collection names --- //
   inputTagTracks_ = consumes<reco::TrackCollection>(iConfig.getParameter<InputTag>("trackCollection"));
 

--- a/RecoParticleFlow/PFTracking/plugins/PFDisplacedVertexCandidateProducer.cc
+++ b/RecoParticleFlow/PFTracking/plugins/PFDisplacedVertexCandidateProducer.cc
@@ -1,11 +1,8 @@
 #include "RecoParticleFlow/PFTracking/plugins/PFDisplacedVertexCandidateProducer.h"
-
 #include "FWCore/Framework/interface/ESHandle.h"
-
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/Utilities/interface/Exception.h"
 #include "FWCore/Framework/interface/EventSetup.h"
-
 #include "FWCore/ParameterSet/interface/FileInPath.h"
 
 #include <set>

--- a/RecoParticleFlow/PFTracking/plugins/PFDisplacedVertexCandidateProducer.h
+++ b/RecoParticleFlow/PFTracking/plugins/PFDisplacedVertexCandidateProducer.h
@@ -5,14 +5,11 @@
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
-
 #include "RecoParticleFlow/PFTracking/interface/PFDisplacedVertexCandidateFinder.h"
 #include "DataFormats/ParticleFlowReco/interface/PFDisplacedVertexCandidateFwd.h"
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
-
 #include "MagneticField/Engine/interface/MagneticField.h"
 #include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
 

--- a/RecoParticleFlow/PFTracking/plugins/PFDisplacedVertexCandidateProducer.h
+++ b/RecoParticleFlow/PFTracking/plugins/PFDisplacedVertexCandidateProducer.h
@@ -13,6 +13,9 @@
 #include "DataFormats/ParticleFlowReco/interface/PFDisplacedVertexCandidateFwd.h"
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
 
+#include "MagneticField/Engine/interface/MagneticField.h"
+#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
+
 /**\class PFDisplacedVertexCandidateProducer 
 \brief Producer for DisplacedVertices 
 
@@ -39,6 +42,8 @@ private:
   /// Input tag for main vertex to cut of dxy of secondary tracks
   edm::EDGetTokenT<reco::VertexCollection> inputTagMainVertex_;
   edm::EDGetTokenT<reco::BeamSpot> inputTagBeamSpot_;
+
+  const edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> magneticFieldToken_;
 
   /// verbose ?
   bool verbose_;

--- a/RecoParticleFlow/PFTracking/plugins/PFDisplacedVertexProducer.cc
+++ b/RecoParticleFlow/PFTracking/plugins/PFDisplacedVertexProducer.cc
@@ -1,13 +1,9 @@
 #include "RecoParticleFlow/PFTracking/plugins/PFDisplacedVertexProducer.h"
-
 #include "FWCore/Framework/interface/ESHandle.h"
-
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/Utilities/interface/Exception.h"
 #include "FWCore/Framework/interface/EventSetup.h"
-
 #include "FWCore/ParameterSet/interface/FileInPath.h"
-
 #include "DataFormats/ParticleFlowReco/interface/PFDisplacedVertexFwd.h"
 #include "DataFormats/ParticleFlowReco/interface/PFDisplacedVertexCandidateFwd.h"
 

--- a/RecoParticleFlow/PFTracking/plugins/PFDisplacedVertexProducer.cc
+++ b/RecoParticleFlow/PFTracking/plugins/PFDisplacedVertexProducer.cc
@@ -16,11 +16,11 @@
 using namespace std;
 using namespace edm;
 
-PFDisplacedVertexProducer::PFDisplacedVertexProducer(const edm::ParameterSet& iConfig) :
-    magFieldToken_(esConsumes()),
-    globTkGeomToken_(esConsumes()),
-    tkerTopoToken_(esConsumes()),
-    tkerGeomToken_(esConsumes())   {
+PFDisplacedVertexProducer::PFDisplacedVertexProducer(const edm::ParameterSet& iConfig)
+    : magFieldToken_(esConsumes()),
+      globTkGeomToken_(esConsumes()),
+      tkerTopoToken_(esConsumes()),
+      tkerGeomToken_(esConsumes()) {
   // --- Setup input collection names --- //
 
   inputTagVertexCandidates_ =
@@ -102,8 +102,7 @@ void PFDisplacedVertexProducer::produce(Event& iEvent, const EventSetup& iSetup)
   iEvent.getByToken(inputTagBeamSpot_, beamSpotHandle);
 
   // Fill useful event information for the Finder
-  pfDisplacedVertexFinder_.setEdmParameters(
-      theMagField, globTkGeom, tkerTopo, tkerGeom);
+  pfDisplacedVertexFinder_.setEdmParameters(theMagField, globTkGeom, tkerTopo, tkerGeom);
   pfDisplacedVertexFinder_.setPrimaryVertex(mainVertexHandle, beamSpotHandle);
   pfDisplacedVertexFinder_.setInput(vertexCandidates);
 

--- a/RecoParticleFlow/PFTracking/plugins/PFDisplacedVertexProducer.cc
+++ b/RecoParticleFlow/PFTracking/plugins/PFDisplacedVertexProducer.cc
@@ -8,14 +8,6 @@
 
 #include "FWCore/ParameterSet/interface/FileInPath.h"
 
-#include "MagneticField/Engine/interface/MagneticField.h"
-#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
-
-#include "Geometry/CommonDetUnit/interface/TrackingGeometry.h"
-#include "Geometry/CommonDetUnit/interface/GlobalTrackingGeometry.h"
-#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
-#include "Geometry/Records/interface/GlobalTrackingGeometryRecord.h"
-
 #include "DataFormats/ParticleFlowReco/interface/PFDisplacedVertexFwd.h"
 #include "DataFormats/ParticleFlowReco/interface/PFDisplacedVertexCandidateFwd.h"
 
@@ -24,7 +16,11 @@
 using namespace std;
 using namespace edm;
 
-PFDisplacedVertexProducer::PFDisplacedVertexProducer(const edm::ParameterSet& iConfig) {
+PFDisplacedVertexProducer::PFDisplacedVertexProducer(const edm::ParameterSet& iConfig) :
+    magFieldToken_(esConsumes()),
+    globTkGeomToken_(esConsumes()),
+    tkerTopoToken_(esConsumes()),
+    tkerGeomToken_(esConsumes())   {
   // --- Setup input collection names --- //
 
   inputTagVertexCandidates_ =
@@ -91,18 +87,10 @@ void PFDisplacedVertexProducer::produce(Event& iEvent, const EventSetup& iSetup)
 
   // Prepare useful information for the Finder
 
-  ESHandle<MagneticField> magField;
-  iSetup.get<IdealMagneticFieldRecord>().get(magField);
-  const MagneticField* theMagField = magField.product();
-
-  ESHandle<GlobalTrackingGeometry> globTkGeomHandle;
-  iSetup.get<GlobalTrackingGeometryRecord>().get(globTkGeomHandle);
-
-  ESHandle<TrackerTopology> tkerTopoHandle;
-  iSetup.get<TrackerTopologyRcd>().get(tkerTopoHandle);
-
-  ESHandle<TrackerGeometry> tkerGeomHandle;
-  iSetup.get<TrackerDigiGeometryRecord>().get(tkerGeomHandle);
+  auto const& theMagField = &iSetup.getData(magFieldToken_);
+  auto const& globTkGeom = &iSetup.getData(globTkGeomToken_);
+  auto const& tkerTopo = &iSetup.getData(tkerTopoToken_);
+  auto const& tkerGeom = &iSetup.getData(tkerGeomToken_);
 
   Handle<reco::PFDisplacedVertexCandidateCollection> vertexCandidates;
   iEvent.getByToken(inputTagVertexCandidates_, vertexCandidates);
@@ -115,7 +103,7 @@ void PFDisplacedVertexProducer::produce(Event& iEvent, const EventSetup& iSetup)
 
   // Fill useful event information for the Finder
   pfDisplacedVertexFinder_.setEdmParameters(
-      theMagField, globTkGeomHandle, tkerTopoHandle.product(), tkerGeomHandle.product());
+      theMagField, globTkGeom, tkerTopo, tkerGeom);
   pfDisplacedVertexFinder_.setPrimaryVertex(mainVertexHandle, beamSpotHandle);
   pfDisplacedVertexFinder_.setInput(vertexCandidates);
 

--- a/RecoParticleFlow/PFTracking/plugins/PFDisplacedVertexProducer.h
+++ b/RecoParticleFlow/PFTracking/plugins/PFDisplacedVertexProducer.h
@@ -5,15 +5,11 @@
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
-
 #include "RecoParticleFlow/PFTracking/interface/PFDisplacedVertexFinder.h"
-
 #include "MagneticField/Engine/interface/MagneticField.h"
 #include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
-
 #include "Geometry/CommonDetUnit/interface/TrackingGeometry.h"
 #include "Geometry/CommonDetUnit/interface/GlobalTrackingGeometry.h"
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"

--- a/RecoParticleFlow/PFTracking/plugins/PFDisplacedVertexProducer.h
+++ b/RecoParticleFlow/PFTracking/plugins/PFDisplacedVertexProducer.h
@@ -11,6 +11,14 @@
 
 #include "RecoParticleFlow/PFTracking/interface/PFDisplacedVertexFinder.h"
 
+#include "MagneticField/Engine/interface/MagneticField.h"
+#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
+
+#include "Geometry/CommonDetUnit/interface/TrackingGeometry.h"
+#include "Geometry/CommonDetUnit/interface/GlobalTrackingGeometry.h"
+#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
+#include "Geometry/Records/interface/GlobalTrackingGeometryRecord.h"
+
 /**\class PFDisplacedVertexProducer 
 \brief Producer for DisplacedVertices 
 
@@ -39,6 +47,11 @@ private:
 
   edm::EDGetTokenT<reco::VertexCollection> inputTagMainVertex_;
   edm::EDGetTokenT<reco::BeamSpot> inputTagBeamSpot_;
+
+  const edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> magFieldToken_;
+  const edm::ESGetToken<GlobalTrackingGeometry, GlobalTrackingGeometryRecord> globTkGeomToken_;
+  const edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> tkerTopoToken_;
+  const edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> tkerGeomToken_;
 
   /// verbose ?
   bool verbose_;

--- a/RecoParticleFlow/PFTracking/plugins/PFElecTkProducer.cc
+++ b/RecoParticleFlow/PFTracking/plugins/PFElecTkProducer.cc
@@ -177,9 +177,9 @@ using namespace reco;
 
 PFElecTkProducer::PFElecTkProducer(const ParameterSet& iConfig, const convbremhelpers::HeavyObjectCache*)
     : conf_(iConfig),
-      magFieldToken_(esConsumes<edm::Transition::BeginRun>()), 
+      magFieldToken_(esConsumes<edm::Transition::BeginRun>()),
       tkerGeomToken_(esConsumes<edm::Transition::BeginRun>()),
-      transientTrackToken_(esConsumes<edm::Transition::BeginRun>(edm::ESInputTag("", "TransientTrackBuilder")))  {
+      transientTrackToken_(esConsumes<edm::Transition::BeginRun>(edm::ESInputTag("", "TransientTrackBuilder"))) {
   gsfTrackLabel_ = consumes<reco::GsfTrackCollection>(iConfig.getParameter<InputTag>("GsfTrackModuleLabel"));
 
   pfTrackLabel_ = consumes<reco::PFRecTrackCollection>(iConfig.getParameter<InputTag>("PFRecTrackLabel"));

--- a/RecoParticleFlow/PFTracking/plugins/PFElecTkProducer.cc
+++ b/RecoParticleFlow/PFTracking/plugins/PFElecTkProducer.cc
@@ -132,6 +132,10 @@ private:
   double detaCutGsfClean_;
   double dphiCutGsfClean_;
 
+  const edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> magFieldToken_;
+  const edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> tkerGeomToken_;
+  const edm::ESGetToken<TransientTrackBuilder, TransientTrackRecord> transientTrackToken_;
+
   ///PFTrackTransformer
   std::unique_ptr<PFTrackTransformer> pfTransformer_;
   MultiTrajectoryStateTransform mtsTransform_;
@@ -172,7 +176,10 @@ using namespace edm;
 using namespace reco;
 
 PFElecTkProducer::PFElecTkProducer(const ParameterSet& iConfig, const convbremhelpers::HeavyObjectCache*)
-    : conf_(iConfig) {
+    : conf_(iConfig),
+      magFieldToken_(esConsumes<edm::Transition::BeginRun>()), 
+      tkerGeomToken_(esConsumes<edm::Transition::BeginRun>()),
+      transientTrackToken_(esConsumes<edm::Transition::BeginRun>(edm::ESInputTag("", "TransientTrackBuilder")))  {
   gsfTrackLabel_ = consumes<reco::GsfTrackCollection>(iConfig.getParameter<InputTag>("GsfTrackModuleLabel"));
 
   pfTrackLabel_ = consumes<reco::PFRecTrackCollection>(iConfig.getParameter<InputTag>("PFRecTrackLabel"));
@@ -1104,19 +1111,14 @@ bool PFElecTkProducer::isInnerMostWithLostHits(const reco::GsfTrackRef& nGsfTrac
 
 // ------------ method called once each job just before starting event loop  ------------
 void PFElecTkProducer::beginRun(const edm::Run& run, const EventSetup& iSetup) {
-  ESHandle<MagneticField> magneticField;
-  iSetup.get<IdealMagneticFieldRecord>().get(magneticField);
+  auto const& magneticField = &iSetup.getData(magFieldToken_);
+  auto const& tracker = &iSetup.getData(tkerGeomToken_);
 
-  ESHandle<TrackerGeometry> tracker;
-  iSetup.get<TrackerDigiGeometryRecord>().get(tracker);
-
-  mtsTransform_ = MultiTrajectoryStateTransform(tracker.product(), magneticField.product());
+  mtsTransform_ = MultiTrajectoryStateTransform(tracker, magneticField);
 
   pfTransformer_ = std::make_unique<PFTrackTransformer>(math::XYZVector(magneticField->inTesla(GlobalPoint(0, 0, 0))));
 
-  edm::ESHandle<TransientTrackBuilder> builder;
-  iSetup.get<TransientTrackRecord>().get("TransientTrackBuilder", builder);
-  TransientTrackBuilder thebuilder = *(builder.product());
+  TransientTrackBuilder thebuilder = iSetup.getData(transientTrackToken_);
 
   convBremFinder_ = std::make_unique<ConvBremPFTrackFinder>(thebuilder,
                                                             mvaConvBremFinderIDBarrelLowPt_,

--- a/RecoParticleFlow/PFTracking/plugins/PFNuclearProducer.cc
+++ b/RecoParticleFlow/PFTracking/plugins/PFNuclearProducer.cc
@@ -6,8 +6,8 @@
 
 using namespace std;
 using namespace edm;
-PFNuclearProducer::PFNuclearProducer(const ParameterSet& iConfig) : pfTransformer_(nullptr),
-    magneticFieldToken_(esConsumes<edm::Transition::BeginRun>())  {
+PFNuclearProducer::PFNuclearProducer(const ParameterSet& iConfig)
+    : pfTransformer_(nullptr), magneticFieldToken_(esConsumes<edm::Transition::BeginRun>()) {
   produces<reco::PFRecTrackCollection>();
   produces<reco::PFNuclearInteractionCollection>();
 

--- a/RecoParticleFlow/PFTracking/plugins/PFNuclearProducer.cc
+++ b/RecoParticleFlow/PFTracking/plugins/PFNuclearProducer.cc
@@ -3,11 +3,11 @@
 #include "RecoParticleFlow/PFTracking/interface/PFTrackTransformer.h"
 #include "TrackingTools/PatternTools/interface/Trajectory.h"
 #include "FWCore/Framework/interface/ESHandle.h"
-#include "MagneticField/Engine/interface/MagneticField.h"
-#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
+
 using namespace std;
 using namespace edm;
-PFNuclearProducer::PFNuclearProducer(const ParameterSet& iConfig) : pfTransformer_(nullptr) {
+PFNuclearProducer::PFNuclearProducer(const ParameterSet& iConfig) : pfTransformer_(nullptr),
+    magneticFieldToken_(esConsumes<edm::Transition::BeginRun>())  {
   produces<reco::PFRecTrackCollection>();
   produces<reco::PFNuclearInteractionCollection>();
 
@@ -66,8 +66,7 @@ void PFNuclearProducer::produce(Event& iEvent, const EventSetup& iSetup) {
 
 // ------------ method called once each job just before starting event loop  ------------
 void PFNuclearProducer::beginRun(const edm::Run& run, const EventSetup& iSetup) {
-  ESHandle<MagneticField> magneticField;
-  iSetup.get<IdealMagneticFieldRecord>().get(magneticField);
+  auto const& magneticField = &iSetup.getData(magneticFieldToken_);
   pfTransformer_ = new PFTrackTransformer(math::XYZVector(magneticField->inTesla(GlobalPoint(0, 0, 0))));
   pfTransformer_->OnlyProp();
 }

--- a/RecoParticleFlow/PFTracking/plugins/PFTrackProducer.cc
+++ b/RecoParticleFlow/PFTracking/plugins/PFTrackProducer.cc
@@ -17,7 +17,7 @@ using namespace std;
 using namespace edm;
 using namespace reco;
 PFTrackProducer::PFTrackProducer(const ParameterSet& iConfig)
-    : transientTrackToken_(esConsumes()), magneticFieldToken_(esConsumes()), pfTransformer_() {
+    : transientTrackToken_(esConsumes(edm::ESInputTag("", "TransientTrackBuilder"))), magneticFieldToken_(esConsumes<edm::Transition::BeginRun>()), pfTransformer_() {
   produces<reco::PFRecTrackCollection>();
 
   std::vector<InputTag> tags = iConfig.getParameter<vector<InputTag> >("TkColList");

--- a/RecoParticleFlow/PFTracking/plugins/PFTrackProducer.cc
+++ b/RecoParticleFlow/PFTracking/plugins/PFTrackProducer.cc
@@ -9,18 +9,15 @@
 #include "DataFormats/EgammaReco/interface/ElectronSeedFwd.h"
 #include "TrackingTools/PatternTools/interface/Trajectory.h"
 #include "FWCore/Framework/interface/ESHandle.h"
-#include "MagneticField/Engine/interface/MagneticField.h"
-#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
 #include "DataFormats/MuonReco/interface/Muon.h"
-#include "TrackingTools/TransientTrack/interface/TransientTrackBuilder.h"
-#include "TrackingTools/Records/interface/TransientTrackRecord.h"
 #include "TrackingTools/IPTools/interface/IPTools.h"
 #include "DataFormats/VertexReco/interface/Vertex.h"
 
 using namespace std;
 using namespace edm;
 using namespace reco;
-PFTrackProducer::PFTrackProducer(const ParameterSet& iConfig) : pfTransformer_() {
+PFTrackProducer::PFTrackProducer(const ParameterSet& iConfig)
+    : transientTrackToken_(esConsumes()), magneticFieldToken_(esConsumes()), pfTransformer_() {
   produces<reco::PFRecTrackCollection>();
 
   std::vector<InputTag> tags = iConfig.getParameter<vector<InputTag> >("TkColList");
@@ -77,9 +74,8 @@ void PFTrackProducer::produce(Event& iEvent, const EventSetup& iSetup) {
     dummy = reco::Vertex(p, e, 0, 0, 0);
   }
 
-  edm::ESHandle<TransientTrackBuilder> builder;
-  iSetup.get<TransientTrackRecord>().get("TransientTrackBuilder", builder);
-  TransientTrackBuilder thebuilder = *(builder.product());
+  //setup transient track builder
+  TransientTrackBuilder const& thebuilder = iSetup.getData(transientTrackToken_);
 
   // read muon collection
   Handle<reco::MuonCollection> recMuons;
@@ -202,9 +198,8 @@ void PFTrackProducer::produce(Event& iEvent, const EventSetup& iSetup) {
 
 // ------------ method called once each job just before starting event loop  ------------
 void PFTrackProducer::beginRun(const edm::Run& run, const EventSetup& iSetup) {
-  ESHandle<MagneticField> magneticField;
-  iSetup.get<IdealMagneticFieldRecord>().get(magneticField);
-  pfTransformer_ = std::make_unique<PFTrackTransformer>(math::XYZVector(magneticField->inTesla(GlobalPoint(0, 0, 0))));
+  auto const& magneticField = iSetup.getData(magneticFieldToken_);
+  pfTransformer_ = std::make_unique<PFTrackTransformer>(math::XYZVector(magneticField.inTesla(GlobalPoint(0, 0, 0))));
   if (!trajinev_)
     pfTransformer_->OnlyProp();
 }

--- a/RecoParticleFlow/PFTracking/plugins/PFTrackProducer.cc
+++ b/RecoParticleFlow/PFTracking/plugins/PFTrackProducer.cc
@@ -17,7 +17,9 @@ using namespace std;
 using namespace edm;
 using namespace reco;
 PFTrackProducer::PFTrackProducer(const ParameterSet& iConfig)
-    : transientTrackToken_(esConsumes(edm::ESInputTag("", "TransientTrackBuilder"))), magneticFieldToken_(esConsumes<edm::Transition::BeginRun>()), pfTransformer_() {
+    : transientTrackToken_(esConsumes(edm::ESInputTag("", "TransientTrackBuilder"))),
+      magneticFieldToken_(esConsumes<edm::Transition::BeginRun>()),
+      pfTransformer_() {
   produces<reco::PFRecTrackCollection>();
 
   std::vector<InputTag> tags = iConfig.getParameter<vector<InputTag> >("TkColList");

--- a/RecoParticleFlow/PFTracking/plugins/PFV0Producer.cc
+++ b/RecoParticleFlow/PFTracking/plugins/PFV0Producer.cc
@@ -10,8 +10,8 @@
 using namespace std;
 using namespace edm;
 using namespace reco;
-PFV0Producer::PFV0Producer(const ParameterSet& iConfig) : pfTransformer_(nullptr),
-    magneticFieldToken_(esConsumes<edm::Transition::BeginRun>())  {
+PFV0Producer::PFV0Producer(const ParameterSet& iConfig)
+    : pfTransformer_(nullptr), magneticFieldToken_(esConsumes<edm::Transition::BeginRun>()) {
   produces<reco::PFV0Collection>();
   produces<reco::PFRecTrackCollection>();
 

--- a/RecoParticleFlow/PFTracking/plugins/PFV0Producer.cc
+++ b/RecoParticleFlow/PFTracking/plugins/PFV0Producer.cc
@@ -6,13 +6,12 @@
 #include "TrackingTools/PatternTools/interface/Trajectory.h"
 #include "RecoParticleFlow/PFTracking/interface/PFTrackTransformer.h"
 #include "FWCore/Framework/interface/ESHandle.h"
-#include "MagneticField/Engine/interface/MagneticField.h"
-#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
 
 using namespace std;
 using namespace edm;
 using namespace reco;
-PFV0Producer::PFV0Producer(const ParameterSet& iConfig) : pfTransformer_(nullptr) {
+PFV0Producer::PFV0Producer(const ParameterSet& iConfig) : pfTransformer_(nullptr),
+    magneticFieldToken_(esConsumes<edm::Transition::BeginRun>())  {
   produces<reco::PFV0Collection>();
   produces<reco::PFRecTrackCollection>();
 
@@ -67,8 +66,7 @@ void PFV0Producer::produce(Event& iEvent, const EventSetup& iSetup) {
 
 // ------------ method called once each job just before starting event loop  ------------
 void PFV0Producer::beginRun(const edm::Run& run, const EventSetup& iSetup) {
-  ESHandle<MagneticField> magneticField;
-  iSetup.get<IdealMagneticFieldRecord>().get(magneticField);
+  auto const& magneticField = &iSetup.getData(magneticFieldToken_);
   pfTransformer_ = new PFTrackTransformer(math::XYZVector(magneticField->inTesla(GlobalPoint(0, 0, 0))));
   pfTransformer_->OnlyProp();
 }

--- a/RecoParticleFlow/PFTracking/plugins/PFV0Producer.h
+++ b/RecoParticleFlow/PFTracking/plugins/PFV0Producer.h
@@ -9,6 +9,9 @@
 #include "DataFormats/ParticleFlowReco/interface/PFV0Fwd.h"
 #include "DataFormats/Candidate/interface/VertexCompositeCandidate.h"
 
+#include "MagneticField/Engine/interface/MagneticField.h"
+#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
+
 class PFTrackTransformer;
 class PFV0Producer : public edm::stream::EDProducer<> {
 public:
@@ -28,5 +31,7 @@ private:
   ///PFTrackTransformer
   PFTrackTransformer *pfTransformer_;
   std::vector<edm::EDGetTokenT<reco::VertexCompositeCandidateCollection> > V0list_;
+
+  const edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> magneticFieldToken_;
 };
 #endif

--- a/RecoParticleFlow/PFTracking/plugins/PFV0Producer.h
+++ b/RecoParticleFlow/PFTracking/plugins/PFV0Producer.h
@@ -8,7 +8,6 @@
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "DataFormats/ParticleFlowReco/interface/PFV0Fwd.h"
 #include "DataFormats/Candidate/interface/VertexCompositeCandidate.h"
-
 #include "MagneticField/Engine/interface/MagneticField.h"
 #include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
 


### PR DESCRIPTION
#### PR description:

Migration of `RecoParticleFlow/PFTracking` package to esConsumes to address #31061

#### PR validation:

Run standard limited matrix evaluation

`runTheMatrix.py -l limited -j 8 --ibeos`

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Not a backport

@hatakeyamak 
