### PR TITLE
PPS: direct simulation uses 14 TeV for Run3

### DIFF
--- a/Validation/CTPPS/python/simu_config/year_2021_cff.py
+++ b/Validation/CTPPS/python/simu_config/year_2021_cff.py
@@ -5,7 +5,7 @@ from Validation.CTPPS.simu_config.base_cff import *
 # base profile settings for 2021
 profile_base_2021 = profile_base.clone(
   ctppsLHCInfo = dict(
-    beamEnergy = 6500
+    beamEnergy = 7000
   ),
 
   ctppsOpticalFunctions = dict(
@@ -33,6 +33,9 @@ profile_base_2021 = profile_base.clone(
     empiricalAperture56 = cms.string("1E3*([xi] - 0.20)")
   )
 )
+
+# adjust basic settings
+generator.energy = profile_base_2021.ctppsLHCInfo.beamEnergy
 
 # geometry
 from Geometry.VeryForwardGeometry.geometryRPFromDD_2021_cfi import *


### PR DESCRIPTION
#### PR description:

The beam energy is changed to 7 TeV for the "2021" (Run 3) profile of the PPS direct simulation.

This PR is not urgent.


#### PR validation:

The comparison chart (blue = before, red dashed = with this PR) [dirsim_cmp.pdf](https://github.com/cms-sw/cmssw/files/6277413/dirsim_cmp.pdf) shows that
  * no change occurs for other than 2021 profiles
  * for 2021 profile
     * the beam energy actually shifts to 7 TeV
     * no other change is observed - this is actually expected since all elements in the simulation change act upon the _relative_ momentum loss of protons, thus the baseline shift doesn't matter.

The PPS direct simulation is not included in any central workflow, thus running matrix tests is not expected to produce any difference.



