### PR TITLE
fix beam*_dqm_sourceclient-live_cfg.py

### DIFF
--- a/DQM/Integration/python/clients/beam_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/beam_dqm_sourceclient-live_cfg.py
@@ -314,6 +314,8 @@ process.dqmBeamMonitor.PVFitter.errorScale = 1.22
 #----------------------------
 # Pixel tracks/vertices reco
 process.load("RecoPixelVertexing.Configuration.RecoPixelVertexing_cff")
+from RecoVertex.PrimaryVertexProducer.OfflinePixel3DPrimaryVertices_cfi import *
+process.pixelVertices = pixelVertices.clone()
 process.pixelTracksTrackingRegions.RegionPSet.originRadius = 0.4
 process.pixelTracksTrackingRegions.RegionPSet.originHalfLength = 12
 process.pixelTracksTrackingRegions.RegionPSet.originXPos =  0.08

--- a/DQM/Integration/python/clients/beampixel_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/beampixel_dqm_sourceclient-live_cfg.py
@@ -90,6 +90,8 @@ from RecoPixelVertexing.PixelLowPtUtilities.siPixelClusterShapeCache_cfi import 
 process.siPixelClusterShapeCachePreSplitting = siPixelClusterShapeCache.clone(src = 'siPixelClustersPreSplitting')
 process.load("RecoLocalTracker.SiPixelRecHits.PixelCPEGeneric_cfi")
 process.load("RecoPixelVertexing.Configuration.RecoPixelVertexing_cff")
+from RecoVertex.PrimaryVertexProducer.OfflinePixel3DPrimaryVertices_cfi import *
+process.pixelVertices = pixelVertices.clone()
 process.pixelVertices.TkFilterParameters.minPt = process.pixelTracksTrackingRegions.RegionPSet.ptMin
 process.pixelTracksTrackingRegions.RegionPSet.originRadius     = cms.double(0.4)
 process.pixelTracksTrackingRegions.RegionPSet.originHalfLength = cms.double(15.)


### PR DESCRIPTION
resolves #33356

#### PR description:

After #31723  was merged, the import in `RecoPixelVertexing/Configuration/python/RecoPixelVertexing_cff.py` was changed as
```diff
- from RecoVertex.PrimaryVertexProducer.OfflinePixel3DPrimaryVertices_cfi import *
+ from RecoPixelVertexing.PixelVertexFinding.PixelVertexes_cff import *
```
and therefore the configuration of the client changed going from `PrimaryVertexProducer` to `PixelVertexProducer`.
This lead to issue #33356.

#### PR validation:
Run successfully in local:
```bash
cd DQM/Integration/python/clients
mkdir upload
voms-proxy-init -voms cms
cmsRun beampixel_dqm_sourceclient-live_cfg.py unitTest=True
cmsRun beam_dqm_sourceclient-live_cfg.py unitTest=True
```
#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This PR is not a backport and no backport it needed.