### PR TITLE
New binning of Run-3 CLCT slope (CCLUT-13)

### DIFF
--- a/DataFormats/CSCDigi/interface/CSCCLCTDigi.h
+++ b/DataFormats/CSCDigi/interface/CSCCLCTDigi.h
@@ -75,7 +75,9 @@ public:
   void setSlope(const uint16_t slope);
 
   /// slope in number of half-strips/layer
-  float getFractionalSlope(const uint16_t slope = 4) const;
+  /// negative means left-bending
+  /// positive means right-bending
+  float getFractionalSlope() const;
 
   /// return striptype
   uint16_t getStripType() const { return striptype_; }
@@ -84,8 +86,8 @@ public:
   void setStripType(const uint16_t stripType) { striptype_ = stripType; }
 
   /// return bending
-  /// 0: left-bending (negative delta-strip)
-  /// 1: right-bending (positive delta-strip)
+  /// 0: left-bending (negative delta-strip / delta layer)
+  /// 1: right-bending (positive delta-strip / delta layer)
   uint16_t getBend() const { return bend_; }
 
   /// set bend

--- a/DataFormats/CSCDigi/interface/CSCCorrelatedLCTDigi.h
+++ b/DataFormats/CSCDigi/interface/CSCCorrelatedLCTDigi.h
@@ -102,7 +102,14 @@ public:
   /// return the slope
   uint16_t getSlope() const;
 
+  /// slope in number of half-strips/layer
+  /// negative means left-bending
+  /// positive means right-bending
+  float getFractionalSlope() const;
+
   /// return left/right bending
+  /// 0: left-bending (negative delta-strip / delta layer)
+  /// 1: right-bending (positive delta-strip / delta layer)
   uint16_t getBend() const { return bend; }
 
   /// return BX

--- a/DataFormats/CSCDigi/src/CSCCLCTDigi.cc
+++ b/DataFormats/CSCDigi/src/CSCCLCTDigi.cc
@@ -116,14 +116,11 @@ void CSCCLCTDigi::setSlope(const uint16_t slope) {
 }
 
 // slope in number of half-strips/layer
-float CSCCLCTDigi::getFractionalSlope(const uint16_t nBits) const {
+float CSCCLCTDigi::getFractionalSlope() const {
   if (isRun3()) {
-    const float minSlope = 0;
-    const float maxSlope = 2.5;
-    const int range = pow(2, nBits);
-    const float deltaSlope = (maxSlope - minSlope) / range;
-    const float slopeValue = minSlope + deltaSlope * getSlope();
-    return (2 * getBend() - 1) * slopeValue;
+    // 4-bit slope
+    float slope[17] = {0.0, 0.125, 0.25, 0.375, 0.5, 0.625, 0.75, 0.875, 1.0, 1.125, 1.25, 1.375, 1.5, 1.625, 1.75, 2.0, 2.5};
+    return (2 * getBend() - 1) * slope[getSlope()];
   } else {
     int slope[11] = {0, 0, -8, 8, -6, 6, -4, 4, -2, 2, 0};
     return float(slope[getPattern()] / 5.);

--- a/DataFormats/CSCDigi/src/CSCCLCTDigi.cc
+++ b/DataFormats/CSCDigi/src/CSCCLCTDigi.cc
@@ -119,7 +119,8 @@ void CSCCLCTDigi::setSlope(const uint16_t slope) {
 float CSCCLCTDigi::getFractionalSlope() const {
   if (isRun3()) {
     // 4-bit slope
-    float slope[17] = {0.0, 0.125, 0.25, 0.375, 0.5, 0.625, 0.75, 0.875, 1.0, 1.125, 1.25, 1.375, 1.5, 1.625, 1.75, 2.0, 2.5};
+    float slope[17] = {
+        0.0, 0.125, 0.25, 0.375, 0.5, 0.625, 0.75, 0.875, 1.0, 1.125, 1.25, 1.375, 1.5, 1.625, 1.75, 2.0, 2.5};
     return (2 * getBend() - 1) * slope[getSlope()];
   } else {
     int slope[11] = {0, 0, -8, 8, -6, 6, -4, 4, -2, 2, 0};

--- a/DataFormats/CSCDigi/src/CSCCorrelatedLCTDigi.cc
+++ b/DataFormats/CSCDigi/src/CSCCorrelatedLCTDigi.cc
@@ -120,6 +120,18 @@ void CSCCorrelatedLCTDigi::setSlope(const uint16_t slope) {
   setDataWord(slope, pattern, kRun3SlopeShift, kRun3SlopeMask);
 }
 
+// slope in number of half-strips/layer
+float CSCCorrelatedLCTDigi::getFractionalSlope() const {
+  if (isRun3()) {
+    // 4-bit slope
+    float slope[17] = {0.0, 0.125, 0.25, 0.375, 0.5, 0.625, 0.75, 0.875, 1.0, 1.125, 1.25, 1.375, 1.5, 1.625, 1.75, 2.0, 2.5};
+    return (2 * getBend() - 1) * slope[getSlope()];
+  } else {
+    int slope[11] = {0, 0, -8, 8, -6, 6, -4, 4, -2, 2, 0};
+    return float(slope[getPattern()] / 5.);
+  }
+}
+
 /// return the fractional strip
 float CSCCorrelatedLCTDigi::getFractionalStrip(const uint16_t n) const {
   if (n == 8) {

--- a/DataFormats/CSCDigi/src/CSCCorrelatedLCTDigi.cc
+++ b/DataFormats/CSCDigi/src/CSCCorrelatedLCTDigi.cc
@@ -124,7 +124,8 @@ void CSCCorrelatedLCTDigi::setSlope(const uint16_t slope) {
 float CSCCorrelatedLCTDigi::getFractionalSlope() const {
   if (isRun3()) {
     // 4-bit slope
-    float slope[17] = {0.0, 0.125, 0.25, 0.375, 0.5, 0.625, 0.75, 0.875, 1.0, 1.125, 1.25, 1.375, 1.5, 1.625, 1.75, 2.0, 2.5};
+    float slope[17] = {
+        0.0, 0.125, 0.25, 0.375, 0.5, 0.625, 0.75, 0.875, 1.0, 1.125, 1.25, 1.375, 1.5, 1.625, 1.75, 2.0, 2.5};
     return (2 * getBend() - 1) * slope[getSlope()];
   } else {
     int slope[11] = {0, 0, -8, 8, -6, 6, -4, 4, -2, 2, 0};

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCCathodeLCTProcessor.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCCathodeLCTProcessor.cc
@@ -1454,7 +1454,7 @@ void CSCCathodeLCTProcessor::runCCLUT(CSCCLCTDigi& digi) const {
 }
 
 unsigned CSCCathodeLCTProcessor::convertSlopeToRun2Pattern(const unsigned slope) const {
-  const unsigned slopeList[32] = {10, 10, 8, 8, 8, 8, 6, 6, 6, 6, 4, 4, 4, 2, 2, 2,
-                                  10, 10, 9, 9, 9, 9, 7, 7, 7, 7, 5, 5, 5, 3, 3, 3};
+  const unsigned slopeList[32] = {10, 10, 10, 8, 8, 8, 6, 6, 6, 6, 4, 4, 2, 2, 2, 2,
+                                  10, 10, 10, 9, 9, 9, 7, 7, 7, 7, 5, 5, 3, 3, 3, 3};
   return slopeList[slope];
 }

--- a/L1Trigger/CSCTriggerPrimitives/test/macros/CCLUTLinearFitWriter.cpp
+++ b/L1Trigger/CSCTriggerPrimitives/test/macros/CCLUTLinearFitWriter.cpp
@@ -527,10 +527,11 @@ unsigned assignBending(const float fvalue) {
   unsigned value = 0;
 
   // as defined in DN-19-059, section 4.8
-  float slopes[17] = {0.0, 0.125, 0.25, 0.375, 0.5, 0.625, 0.75, 0.875, 1.0, 1.125, 1.25, 1.375, 1.5, 1.625, 1.75, 2.0, 2.5};
+  float slopes[17] = {
+      0.0, 0.125, 0.25, 0.375, 0.5, 0.625, 0.75, 0.875, 1.0, 1.125, 1.25, 1.375, 1.5, 1.625, 1.75, 2.0, 2.5};
 
-  for (unsigned i = 0; i < 16; i++){
-    if (fvalue >= slopes[i] and fvalue < slopes[i+1]) {
+  for (unsigned i = 0; i < 16; i++) {
+    if (fvalue >= slopes[i] and fvalue < slopes[i + 1]) {
       value = i;
     }
   }

--- a/L1Trigger/CSCTriggerPrimitives/test/macros/CCLUTLinearFitWriter.cpp
+++ b/L1Trigger/CSCTriggerPrimitives/test/macros/CCLUTLinearFitWriter.cpp
@@ -131,7 +131,7 @@ void writeHeaderSlopeLUT(ofstream& file);
 unsigned firmwareWord(const unsigned quality, const unsigned slope, const unsigned offset);
 void setDataWord(unsigned& word, const unsigned newWord, const unsigned shift, const unsigned mask);
 unsigned assignPosition(const float fvalue, const float fmin, const float fmax, const unsigned nbits);
-unsigned assignBending(const float fvalue, const float fmin, const float fmax, const unsigned nbits);
+unsigned assignBending(const float fvalue);
 
 int CCLUTLinearFitWriter(unsigned N_LAYER_REQUIREMENT = 3) {
   //all the patterns we will fit
@@ -340,15 +340,13 @@ int CCLUTLinearFitWriter(unsigned N_LAYER_REQUIREMENT = 3) {
       // everything is in half-strips
       const float fmaxOffset = 2;
       const float fminOffset = -1.75;
-      const float fmaxSlope = 2.5;
-      const float fminSlope = 0;
 
       // negative bending -> 0
       // positive bending -> 1
       const bool slope_sign(slope >= 0);
 
       const unsigned offset_bin = assignPosition(offset, fminOffset, fmaxOffset, 4);
-      unsigned slope_bin = assignBending(std::abs(slope), fminSlope, fmaxSlope, 4);
+      unsigned slope_bin = assignBending(std::abs(slope));
       if (slope_sign)
         slope_bin += 16;
       const unsigned fwword = firmwareWord(0, slope_bin, offset_bin);
@@ -504,7 +502,7 @@ void writeHeaderSlopeLUT(ofstream& file) {
 }
 
 unsigned assignPosition(const float fvalue, const float fmin, const float fmax, const unsigned nbits) {
-  bool debug;
+  bool debug = false;
   unsigned value = 0;
   const unsigned range = pow(2, nbits);
   const unsigned minValue = 0;
@@ -524,24 +522,22 @@ unsigned assignPosition(const float fvalue, const float fmin, const float fmax, 
   return value;
 }
 
-unsigned assignBending(const float fvalue, const float fmin, const float fmax, const unsigned nbits) {
-  bool debug;
+unsigned assignBending(const float fvalue) {
+  bool debug = false;
   unsigned value = 0;
-  const unsigned range = pow(2, nbits);
-  const unsigned minValue = 0;
-  const unsigned maxValue = range - 1;
-  const double fdelta = (fmax - fmin) / range;
 
-  if (fvalue >= fmax) {
-    value = maxValue;
-  } else if (fvalue <= fmin) {
-    value = minValue;
-  } else {
-    value = std::min(unsigned(std::floor((fvalue - fmin) / fdelta)), maxValue);
+  // as defined in DN-19-059, section 4.8
+  float slopes[17] = {0.0, 0.125, 0.25, 0.375, 0.5, 0.625, 0.75, 0.875, 1.0, 1.125, 1.25, 1.375, 1.5, 1.625, 1.75, 2.0, 2.5};
+
+  for (unsigned i = 0; i < 16; i++){
+    if (fvalue >= slopes[i] and fvalue < slopes[i+1]) {
+      value = i;
+    }
   }
-  if (debug)
-    std::cout << "fvalue " << fvalue << " " << fmin << " " << fmax << " " << nbits << " " << value << std::endl;
-
+  // overflow bin or undefined value
+  if (fvalue >= slopes[16]) {
+    value = 15;
+  }
   return value;
 }
 


### PR DESCRIPTION
#### PR description:

Previously the CLCT slope binning was fixed to ~0.156 from 0 up to 2.5 half-strips / layer in the Run-3 CLCT algorithm. This PR updates the definition so it is always a multiple of 1/8-strip/layer. First 14 bins are 1/8 wide. Last two are 1/4 and 1/2 wide. See also [DN-19-059](https://gitlab.cern.ch/tdr/notes/DN-19-059/blob/master/temp/DN-19-059_temp.pdf), section 4.8. 

Related PR: https://github.com/cms-data/L1Trigger-CSCTriggerPrimitives/pull/5

#### PR validation:

Code compiles. Tested in CMSSW_11_2_0_pre9 on single muon gun.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A. Run-3 CLCT algorithm not yet deployed at P5.

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)

@tahuang1991 