### PR TITLE
Added time info to the displaced vertexes for muon guns

### DIFF
--- a/IOMC/ParticleGuns/src/FlatRandomPtAndDxyGunProducer.cc
+++ b/IOMC/ParticleGuns/src/FlatRandomPtAndDxyGunProducer.cc
@@ -109,7 +109,9 @@ void FlatRandomPtAndDxyGunProducer::produce(Event& e, const EventSetup& es) {
         break;
     }
 
-    HepMC::GenVertex* Vtx1 = new HepMC::GenVertex(HepMC::FourVector(vx, vy, vz));
+    float time = sqrt(vx * vx + vy * vy + vz * vz);
+
+    HepMC::GenVertex* Vtx1 = new HepMC::GenVertex(HepMC::FourVector(vx, vy, vz, time));
 
     int PartID = fPartIDs[ip];
     const HepPDT::ParticleData* PData = fPDGTable->particle(HepPDT::ParticleID(abs(PartID)));
@@ -124,7 +126,7 @@ void FlatRandomPtAndDxyGunProducer::produce(Event& e, const EventSetup& es) {
     fEvt->add_vertex(Vtx1);
 
     if (fAddAntiParticle) {
-      HepMC::GenVertex* Vtx2 = new HepMC::GenVertex(HepMC::FourVector(-vx, -vy, -vz));
+      HepMC::GenVertex* Vtx2 = new HepMC::GenVertex(HepMC::FourVector(-vx, -vy, -vz, time));
       HepMC::FourVector ap(-px, -py, -pz, energy);
       int APartID = -PartID;
       if (PartID == 22 || PartID == 23) {


### PR DESCRIPTION
#### PR description:

Not sure if it is needed to report this as an issue first, but as we already got a proposed fix I thought I'd be better to go with a PR instead.  

As it stands now, particle guns with varying pT/dxy generate particles instantaneously in the displaced vertexes. This is rather unphysical and in some cases -depending on particle mass/momentum- it results in particles that reach into the outer detectors faster than lightspeed. This can throw the timing of local reconstruction algorithms off: either failing to reconstruct the physical object or assigning it a wrong BX which makes samples generated with this setup -DisplacedMuon guns for example- unreliable. We've checked this kind of effects happen for local L1 muon reconstruction, with DT trigger primitives suffering from both of these two effects.

The proposed fix is to add timing information to the vertexes to take into account the time of flight from the origin from an hypothetical invisible parnent.

Tagging @dildick as well as the original author in case he wants to comment.

#### PR validation:

scram build code-format run without code checks warnings/changes
scram build runs successfully without warnings