### PR TITLE
TkDQM remove getTH1()

### DIFF
--- a/DQM/SiStripMonitorCluster/src/SiStripMonitorCluster.cc
+++ b/DQM/SiStripMonitorCluster/src/SiStripMonitorCluster.cc
@@ -517,7 +517,7 @@ void SiStripMonitorCluster::createMEs(const edm::EventSetup& es, DQMStore::IBook
                                                      0,
                                                      0);
       if (NclusVsCycleTimeProf2D->kind() == MonitorElement::Kind::TPROFILE2D)
-        NclusVsCycleTimeProf2D->getTH1()->SetCanExtend(TH1::kAllAxes);
+        NclusVsCycleTimeProf2D->setCanExtend(TH1::kAllAxes);
     }
     if (clusterWidth_vs_amplitude_on) {
       ibooker.setCurrentFolder(topFolderName_ + "/MechanicalView/");
@@ -1402,7 +1402,7 @@ void SiStripMonitorCluster::createSubDetMEs(std::string label, DQMStore::IBooker
                                                          "");
     subdetMEs.SubDetTotClusterProf->setAxisTitle(Parameters.getParameter<std::string>("xaxis"), 1);
     if (subdetMEs.SubDetTotClusterProf->kind() == MonitorElement::Kind::TPROFILE)
-      subdetMEs.SubDetTotClusterProf->getTH1()->SetCanExtend(TH1::kAllAxes);
+      subdetMEs.SubDetTotClusterProf->setCanExtend(TH1::kAllAxes);
 
     Parameters = conf_.getParameter<edm::ParameterSet>("NumberOfClusterPerLayerTrendVar");
     HistoName = "TotalNumberOfClusterPerLayer__" + label;
@@ -1610,7 +1610,7 @@ SiStripMonitorCluster::MonitorElement* SiStripMonitorCluster::bookMETrend(const 
     return me;
   me->setAxisTitle(ParametersTrend.getParameter<std::string>("xaxis"), 1);
   if (me->kind() == MonitorElement::Kind::TPROFILE)
-    me->getTH1()->SetCanExtend(TH1::kAllAxes);
+    me->setCanExtend(TH1::kAllAxes);
   return me;
 }
 

--- a/DQM/SiStripMonitorDigi/src/SiStripMonitorDigi.cc
+++ b/DQM/SiStripMonitorDigi/src/SiStripMonitorDigi.cc
@@ -452,7 +452,7 @@ void SiStripMonitorDigi::createMEs(DQMStore::IBooker& ibooker, const edm::EventS
       ShotsVsTimeApvShotsGlobal->setAxisTitle("Time (s)", 1);
       ShotsVsTimeApvShotsGlobal->setAxisTitle("# Apv Shots", 2);
       if (ShotsVsTimeApvShotsGlobal->kind() == MonitorElement::Kind::TPROFILE)
-        ShotsVsTimeApvShotsGlobal->getTH1()->SetCanExtend(TH1::kAllAxes);
+        ShotsVsTimeApvShotsGlobal->setCanExtend(TH1::kAllAxes);
     }
 
     //cumulative number of Strips in APV shots
@@ -984,7 +984,7 @@ SiStripMonitorDigi::MonitorElement* SiStripMonitorDigi::bookMETrend(DQMStore::IB
 
   me->setAxisTitle("Lumisection", 1);
   if (me->kind() == MonitorElement::Kind::TPROFILE)
-    me->getTH1()->SetCanExtend(TH1::kAllAxes);
+    me->setCanExtend(TH1::kAllAxes);
   return me;
 }
 
@@ -1191,7 +1191,7 @@ void SiStripMonitorDigi::createSubDetMEs(DQMStore::IBooker& ibooker, std::string
     subdetMEs.SubDetTotDigiProf->setAxisTitle("Lumisection", 1);
 
     if (subdetMEs.SubDetTotDigiProf->kind() == MonitorElement::Kind::TPROFILE)
-      subdetMEs.SubDetTotDigiProf->getTH1()->SetCanExtend(TH1::kAllAxes);
+      subdetMEs.SubDetTotDigiProf->setCanExtend(TH1::kAllAxes);
   }
 
   // Number of Digi vs Bx - Profile
@@ -1305,7 +1305,7 @@ void SiStripMonitorDigi::createSubDetMEs(DQMStore::IBooker& ibooker, std::string
     subdetMEs.SubDetNApvShotsProf->setAxisTitle("Time (s)", 1);
     subdetMEs.SubDetNApvShotsProf->setAxisTitle("# Apv Shots", 2);
     if (subdetMEs.SubDetNApvShotsProf->kind() == MonitorElement::Kind::TPROFILE)
-      subdetMEs.SubDetNApvShotsProf->getTH1()->SetCanExtend(TH1::kAllAxes);
+      subdetMEs.SubDetNApvShotsProf->setCanExtend(TH1::kAllAxes);
   }
 
   SubDetMEsMap[label] = subdetMEs;

--- a/DQM/SiStripMonitorSummary/src/SiStripApvGainsDQM.cc
+++ b/DQM/SiStripMonitorSummary/src/SiStripApvGainsDQM.cc
@@ -73,7 +73,7 @@ void SiStripApvGainsDQM::fillSummaryMEs(const std::vector<uint32_t> &selectedDet
         fPSet_.getParameter<bool>("OutputSummaryAtLayerLevelAsImage")) {
       TCanvas c1("c1");
       selME.SummaryDistr->getTH1()->Draw();
-      std::string name(selME.SummaryDistr->getTH1()->GetTitle());
+      std::string name(selME.SummaryDistr->getTitle());
       name += ".png";
       c1.Print(name.c_str());
     }

--- a/DQM/SiStripMonitorSummary/src/SiStripBackPlaneCorrectionDQM.cc
+++ b/DQM/SiStripMonitorSummary/src/SiStripBackPlaneCorrectionDQM.cc
@@ -86,7 +86,7 @@ void SiStripBackPlaneCorrectionDQM::fillSummaryMEs(const std::vector<uint32_t> &
       if (fPSet_.getParameter<bool>("OutputCumulativeSummaryAtLayerLevelAsImage")) {
         TCanvas c2("c2");
         selME.SummaryOfCumulDistr->getTH1()->Draw();
-        std::string name2(selME.SummaryOfCumulDistr->getTH1()->GetTitle());
+        std::string name2(selME.SummaryOfCumulDistr->getTitle());
         name2 += ".png";
         c2.Print(name2.c_str());
       }
@@ -105,7 +105,7 @@ void SiStripBackPlaneCorrectionDQM::fillSummaryMEs(const std::vector<uint32_t> &
           fPSet_.getParameter<bool>("OutputCumulativeSummaryAtLayerLevelAsImage")) {
         TCanvas c1("c1");
         selME.SummaryOfCumulDistr->getTH1()->Draw();
-        std::string name(selME.SummaryOfCumulDistr->getTH1()->GetTitle());
+        std::string name(selME.SummaryOfCumulDistr->getTitle());
         name += ".png";
         c1.Print(name.c_str());
       }

--- a/DQM/SiStripMonitorSummary/src/SiStripBaseCondObjDQM.cc
+++ b/DQM/SiStripMonitorSummary/src/SiStripBaseCondObjDQM.cc
@@ -1128,7 +1128,7 @@ void SiStripBaseCondObjDQM::fillSummaryMEs(const std::vector<uint32_t> &selected
         fPSet_.getParameter<bool>("OutputSummaryAtLayerLevelAsImage")) {
       TCanvas c1("c1");
       selME.SummaryDistr->getTH1()->Draw();
-      std::string name(selME.SummaryDistr->getTH1()->GetTitle());
+      std::string name(selME.SummaryDistr->getTitle());
       name += ".png";
       c1.Print(name.c_str());
     }
@@ -1137,7 +1137,7 @@ void SiStripBaseCondObjDQM::fillSummaryMEs(const std::vector<uint32_t> &selected
       if (CondObj_fillId_ == "onlyCumul" || CondObj_fillId_ == "ProfileAndCumul") {
         TCanvas c1("c1");
         selME.SummaryOfCumulDistr->getTH1()->Draw();
-        std::string name(selME.SummaryOfCumulDistr->getTH1()->GetTitle());
+        std::string name(selME.SummaryOfCumulDistr->getTitle());
         name += ".png";
         c1.Print(name.c_str());
       }

--- a/DQM/SiStripMonitorSummary/src/SiStripCablingDQM.cc
+++ b/DQM/SiStripMonitorSummary/src/SiStripCablingDQM.cc
@@ -114,12 +114,12 @@ void SiStripCablingDQM::getActiveDetIds(const edm::EventSetup &eSetup) {
   ME->setAxisTitle("Sub Det", 1);
   ME->setAxisTitle("Layer", 2);
 
-  ME->getTH1()->GetXaxis()->SetBinLabel(1, "TIB");
-  ME->getTH1()->GetXaxis()->SetBinLabel(2, "TID F");
-  ME->getTH1()->GetXaxis()->SetBinLabel(3, "TID B");
-  ME->getTH1()->GetXaxis()->SetBinLabel(4, "TOB");
-  ME->getTH1()->GetXaxis()->SetBinLabel(5, "TEC F");
-  ME->getTH1()->GetXaxis()->SetBinLabel(6, "TEC B");
+  ME->setBinLabel(1, "TIB");
+  ME->setBinLabel(2, "TID F");
+  ME->setBinLabel(3, "TID B");
+  ME->setBinLabel(4, "TOB");
+  ME->setBinLabel(5, "TEC F");
+  ME->setBinLabel(6, "TEC B");
 
   for (int i = 0; i < 4; i++) {
     ME->Fill(1, i + 1, float(counterTIB[i]) / TIBDetIds[i]);
@@ -145,7 +145,7 @@ void SiStripCablingDQM::getActiveDetIds(const edm::EventSetup &eSetup) {
     TCanvas c1("c1");
     ME->getTH1()->Draw("TEXT");
     ME->getTH1()->SetStats(kFALSE);
-    std::string name(ME->getTH1()->GetTitle());
+    std::string name(ME->getTitle());
     name += ".png";
     c1.Print(name.c_str());
   }

--- a/DQM/SiStripMonitorSummary/src/SiStripLorentzAngleDQM.cc
+++ b/DQM/SiStripMonitorSummary/src/SiStripLorentzAngleDQM.cc
@@ -78,7 +78,7 @@ void SiStripLorentzAngleDQM::fillSummaryMEs(const std::vector<uint32_t> &selecte
       if (fPSet_.getParameter<bool>("OutputCumulativeSummaryAtLayerLevelAsImage")) {
         TCanvas c2("c2");
         selME.SummaryOfCumulDistr->getTH1()->Draw();
-        std::string name2(selME.SummaryOfCumulDistr->getTH1()->GetTitle());
+        std::string name2(selME.SummaryOfCumulDistr->getTitle());
         name2 += ".png";
         c2.Print(name2.c_str());
       }
@@ -97,7 +97,7 @@ void SiStripLorentzAngleDQM::fillSummaryMEs(const std::vector<uint32_t> &selecte
           fPSet_.getParameter<bool>("OutputCumulativeSummaryAtLayerLevelAsImage")) {
         TCanvas c1("c1");
         selME.SummaryOfCumulDistr->getTH1()->Draw();
-        std::string name(selME.SummaryOfCumulDistr->getTH1()->GetTitle());
+        std::string name(selME.SummaryOfCumulDistr->getTitle());
         name += ".png";
         c1.Print(name.c_str());
       }

--- a/DQM/SiStripMonitorSummary/src/SiStripPedestalsDQM.cc
+++ b/DQM/SiStripMonitorSummary/src/SiStripPedestalsDQM.cc
@@ -64,7 +64,7 @@ void SiStripPedestalsDQM::fillSummaryMEs(const std::vector<uint32_t> &selectedDe
         fPSet_.getParameter<bool>("OutputSummaryAtLayerLevelAsImage")) {
       TCanvas c1("c1");
       selME.SummaryDistr->getTH1()->Draw();
-      std::string name(selME.SummaryDistr->getTH1()->GetTitle());
+      std::string name(selME.SummaryDistr->getTitle());
       name += ".png";
       c1.Print(name.c_str());
     }

--- a/DQM/SiStripMonitorSummary/src/SiStripQualityDQM.cc
+++ b/DQM/SiStripMonitorSummary/src/SiStripQualityDQM.cc
@@ -54,7 +54,7 @@ void SiStripQualityDQM::fillSummaryMEs(const std::vector<uint32_t> &selectedDetI
         fPSet_.getParameter<bool>("OutputSummaryAtLayerLevelAsImage")) {
       TCanvas c1("c1");
       selME.SummaryDistr->getTH1()->Draw();
-      std::string name(selME.SummaryDistr->getTH1()->GetTitle());
+      std::string name(selME.SummaryDistr->getTitle());
       name += ".png";
       c1.Print(name.c_str());
     }
@@ -126,7 +126,7 @@ void SiStripQualityDQM::fillMEsForLayer(
       if (fr > 20) {
         char c[9];
         sprintf(c, "%d", sameLayerDetIds_[i]);
-        selME_.SummaryDistr->getTH1()->GetXaxis()->SetBinLabel(i + 1, c);
+        selME_.SummaryDistr->setBinLabel(i + 1, c);
       }
 
       // Fill the TkHistoMap with Quality output :
@@ -325,7 +325,7 @@ void SiStripQualityDQM::fillGrandSummaryMEs() {
 
     for (int j = 0; j < 4; j++) {
       ME[j]->Fill(i, NBadComponent[0][i][j]);
-      ME[j]->getTH1()->GetXaxis()->SetBinLabel(i, binlabel.str().c_str());
+      ME[j]->setBinLabel(i, binlabel.str());
     }
   }
   ss << "\n";
@@ -337,7 +337,7 @@ void SiStripQualityDQM::fillGrandSummaryMEs() {
 
     for (int j = 0; j < 4; j++) {
       ME[j]->Fill(i + 4, NBadComponent[1][i][j]);
-      ME[j]->getTH1()->GetXaxis()->SetBinLabel(i + 4, binlabel.str().c_str());
+      ME[j]->setBinLabel(i + 4, binlabel.str());
     }
   }
   for (int i = 4; i < 7; ++i) {
@@ -348,7 +348,7 @@ void SiStripQualityDQM::fillGrandSummaryMEs() {
 
     for (int j = 0; j < 4; j++) {
       ME[j]->Fill(i + 4, NBadComponent[1][i][j]);
-      ME[j]->getTH1()->GetXaxis()->SetBinLabel(i + 4, binlabel.str().c_str());
+      ME[j]->setBinLabel(i + 4, binlabel.str());
     }
   }
   ss << "\n";
@@ -360,7 +360,7 @@ void SiStripQualityDQM::fillGrandSummaryMEs() {
 
     for (int j = 0; j < 4; j++) {
       ME[j]->Fill(i + 10, NBadComponent[2][i][j]);
-      ME[j]->getTH1()->GetXaxis()->SetBinLabel(i + 10, binlabel.str().c_str());
+      ME[j]->setBinLabel(i + 10, binlabel.str());
     }
   }
   ss << "\n";
@@ -372,7 +372,7 @@ void SiStripQualityDQM::fillGrandSummaryMEs() {
 
     for (int j = 0; j < 4; j++) {
       ME[j]->Fill(i + 16, NBadComponent[3][i][j]);
-      ME[j]->getTH1()->GetXaxis()->SetBinLabel(i + 16, binlabel.str().c_str());
+      ME[j]->setBinLabel(i + 16, binlabel.str());
     }
   }
   for (int i = 10; i < 19; ++i) {
@@ -383,7 +383,7 @@ void SiStripQualityDQM::fillGrandSummaryMEs() {
 
     for (int j = 0; j < 4; j++) {
       ME[j]->Fill(i + 16, NBadComponent[3][i][j]);
-      ME[j]->getTH1()->GetXaxis()->SetBinLabel(i + 16, binlabel.str().c_str());
+      ME[j]->setBinLabel(i + 16, binlabel.str());
     }
   }
   ss << "\n";
@@ -413,7 +413,7 @@ void SiStripQualityDQM::fillGrandSummaryMEs() {
   for (int i = 0; i < 4; i++) {
     TCanvas c1("c1");
     ME[i]->getTH1()->Draw();
-    std::string name(ME[i]->getTH1()->GetTitle());
+    std::string name(ME[i]->getTitle());
     name += ".png";
     c1.Print(name.c_str());
   }

--- a/DQM/SiStripMonitorTrack/src/SiStripMonitorTrack.cc
+++ b/DQM/SiStripMonitorTrack/src/SiStripMonitorTrack.cc
@@ -876,7 +876,7 @@ SiStripMonitorTrack::MonitorElement* SiStripMonitorTrack::bookMETrend(DQMStore::
                                            0,
                                            "");
   if (me->kind() == MonitorElement::Kind::TPROFILE)
-    me->getTH1()->SetCanExtend(TH1::kAllAxes);
+    me->setCanExtend(TH1::kAllAxes);
 
   if (!me)
     return me;


### PR DESCRIPTION
**Title:** TkDQM : Remove usage of getTH1() from monitor element.

**PR description:**
The aim of this PR is to remove instances of getTH1() calls from MonitorElements inside TkDQM packages and use functions available from MEs instead.

**Links of last two presentations in TkDQM bi-weekly meeting:**

https://indico.cern.ch/event/992934/#b-407706-tracker-dqm

https://indico.cern.ch/event/1000804/#b-407716-tracker-dqm

**PR validation:**
Checks done with workflow 136.892 and no changes are observed.


**If this PR is a backport please specify the original PR and why you need to backport that PR:**

NA