### PR TITLE
Change "eight" to "eighth" in the CSC CLCT and LCT data format (CCLUT-14)

### DIFF
--- a/DataFormats/CSCDigi/interface/CSCCLCTDigi.h
+++ b/DataFormats/CSCDigi/interface/CSCCLCTDigi.h
@@ -18,8 +18,8 @@ class CSCCLCTDigi {
 public:
   typedef std::vector<std::vector<uint16_t>> ComparatorContainer;
 
-  enum CLCTKeyStripMasks { kEightStripMask = 0x1, kQuartStripMask = 0x1, kHalfStripMask = 0x1f };
-  enum CLCTKeyStripShifts { kEightStripShift = 6, kQuartStripShift = 5, kHalfStripShift = 0 };
+  enum CLCTKeyStripMasks { kEighthStripMask = 0x1, kQuartStripMask = 0x1, kHalfStripMask = 0x1f };
+  enum CLCTKeyStripShifts { kEighthStripShift = 6, kQuartStripShift = 5, kHalfStripShift = 0 };
   // temporary to facilitate CCLUT-EMTF/OMTF integration studies
   enum CLCTPatternMasks { kRun3SlopeMask = 0xf, kRun3PatternMask = 0x7, kLegacyPatternMask = 0xf };
   enum CLCTPatternShifts { kRun3SlopeShift = 7, kRun3PatternShift = 4, kLegacyPatternShift = 0 };
@@ -105,11 +105,11 @@ public:
   /// get single quart strip bit
   bool getQuartStrip() const;
 
-  /// set single eight strip bit
-  void setEightStrip(const bool eightStrip);
+  /// set single eighth strip bit
+  void setEighthStrip(const bool eighthStrip);
 
-  /// get single eight strip bit
-  bool getEightStrip() const;
+  /// get single eighth strip bit
+  bool getEighthStrip() const;
 
   /// return Key CFEB ID
   uint16_t getCFEB() const { return cfeb_; }
@@ -133,7 +133,7 @@ public:
   /// (32 halfstrips). There are 5 cfebs.  The "strip_" variable is one
   /// of 32 halfstrips on the keylayer of a single CFEB, so that
   /// Halfstrip = (cfeb*32 + strip).
-  /// This function can also return the quartstrip or eightstrip
+  /// This function can also return the quartstrip or eighthstrip
   /// when the comparator code has been set
   uint16_t getKeyStrip(const uint16_t n = 2) const;
 

--- a/DataFormats/CSCDigi/interface/CSCCorrelatedLCTDigi.h
+++ b/DataFormats/CSCDigi/interface/CSCCorrelatedLCTDigi.h
@@ -18,8 +18,8 @@
 
 class CSCCorrelatedLCTDigi {
 public:
-  enum LCTKeyStripMasks { kEightStripMask = 0x1, kQuartStripMask = 0x1, kHalfStripMask = 0xff };
-  enum LCTKeyStripShifts { kEightStripShift = 9, kQuartStripShift = 8, kHalfStripShift = 0 };
+  enum LCTKeyStripMasks { kEighthStripMask = 0x1, kQuartStripMask = 0x1, kHalfStripMask = 0xff };
+  enum LCTKeyStripShifts { kEighthStripShift = 9, kQuartStripShift = 8, kHalfStripShift = 0 };
   // temporary to facilitate CCLUT-EMTF/OMTF integration studies
   enum LCTPatternMasks { kRun3SlopeMask = 0xf, kRun3PatternMask = 0x7, kLegacyPatternMask = 0xf };
   enum LCTPatternShifts { kRun3SlopeShift = 7, kRun3PatternShift = 4, kLegacyPatternShift = 0 };
@@ -69,11 +69,11 @@ public:
   /// get single quart strip bit
   bool getQuartStrip() const;
 
-  /// set single eight strip bit
-  void setEightStrip(const bool eightStrip);
+  /// set single eighth strip bit
+  void setEighthStrip(const bool eighthStrip);
 
-  /// get single eight strip bit
-  bool getEightStrip() const;
+  /// get single eighth strip bit
+  bool getEighthStrip() const;
 
   /*
     Strips are numbered starting from 1 in CMSSW

--- a/DataFormats/CSCDigi/src/CSCCLCTDigi.cc
+++ b/DataFormats/CSCDigi/src/CSCCLCTDigi.cc
@@ -133,7 +133,7 @@ float CSCCLCTDigi::getFractionalSlope(const uint16_t nBits) const {
 uint16_t CSCCLCTDigi::getKeyStrip(const uint16_t n) const {
   // 10-bit case for strip data word
   if (compCode_ != -1 and n == 8) {
-    return getKeyStrip(4) * 2 + getEightStrip();
+    return getKeyStrip(4) * 2 + getEighthStrip();
   }
   // 9-bit case for strip data word
   else if (compCode_ != -1 and n == 4) {
@@ -164,10 +164,10 @@ bool CSCCLCTDigi::getQuartStrip() const {
   return getDataWord(strip_, kQuartStripShift, kQuartStripMask);
 }
 
-bool CSCCLCTDigi::getEightStrip() const {
+bool CSCCLCTDigi::getEighthStrip() const {
   if (!isRun3())
     return false;
-  return getDataWord(strip_, kEightStripShift, kEightStripMask);
+  return getDataWord(strip_, kEighthStripShift, kEighthStripMask);
 }
 
 void CSCCLCTDigi::setQuartStrip(const bool quartStrip) {
@@ -176,10 +176,10 @@ void CSCCLCTDigi::setQuartStrip(const bool quartStrip) {
   setDataWord(quartStrip, strip_, kQuartStripShift, kQuartStripMask);
 }
 
-void CSCCLCTDigi::setEightStrip(const bool eightStrip) {
+void CSCCLCTDigi::setEighthStrip(const bool eighthStrip) {
   if (!isRun3())
     return;
-  setDataWord(eightStrip, strip_, kEightStripShift, kEightStripMask);
+  setDataWord(eighthStrip, strip_, kEighthStripShift, kEighthStripMask);
 }
 
 void CSCCLCTDigi::setRun3(const bool isRun3) { version_ = isRun3 ? Version::Run3 : Version::Legacy; }

--- a/DataFormats/CSCDigi/src/CSCCorrelatedLCTDigi.cc
+++ b/DataFormats/CSCDigi/src/CSCCorrelatedLCTDigi.cc
@@ -72,7 +72,7 @@ void CSCCorrelatedLCTDigi::clear() {
 uint16_t CSCCorrelatedLCTDigi::getStrip(const uint16_t n) const {
   // all 10 bits
   if (n == 8) {
-    return 2 * getStrip(4) + getEightStrip();
+    return 2 * getStrip(4) + getEighthStrip();
   }
   // lowest 9 bits
   else if (n == 4) {
@@ -90,10 +90,10 @@ void CSCCorrelatedLCTDigi::setQuartStrip(const bool quartStrip) {
   setDataWord(quartStrip, strip, kQuartStripShift, kQuartStripMask);
 }
 
-void CSCCorrelatedLCTDigi::setEightStrip(const bool eightStrip) {
+void CSCCorrelatedLCTDigi::setEighthStrip(const bool eighthStrip) {
   if (!isRun3())
     return;
-  setDataWord(eightStrip, strip, kEightStripShift, kEightStripMask);
+  setDataWord(eighthStrip, strip, kEighthStripShift, kEighthStripMask);
 }
 
 bool CSCCorrelatedLCTDigi::getQuartStrip() const {
@@ -102,10 +102,10 @@ bool CSCCorrelatedLCTDigi::getQuartStrip() const {
   return getDataWord(strip, kQuartStripShift, kQuartStripMask);
 }
 
-bool CSCCorrelatedLCTDigi::getEightStrip() const {
+bool CSCCorrelatedLCTDigi::getEighthStrip() const {
   if (!isRun3())
     return false;
-  return getDataWord(strip, kEightStripShift, kEightStripMask);
+  return getDataWord(strip, kEighthStripShift, kEighthStripMask);
 }
 
 uint16_t CSCCorrelatedLCTDigi::getSlope() const {

--- a/L1Trigger/CSCTriggerPrimitives/interface/LCTQualityControl.h
+++ b/L1Trigger/CSCTriggerPrimitives/interface/LCTQualityControl.h
@@ -62,7 +62,7 @@ public:
   unsigned get_csc_max_wire(int station, int ring) const;
   unsigned get_csc_max_halfstrip(int station, int ring) const;
   unsigned get_csc_max_quartstrip(int station, int ring) const;
-  unsigned get_csc_max_eightstrip(int station, int ring) const;
+  unsigned get_csc_max_eighthstrip(int station, int ring) const;
 
   // slope values
   std::pair<int, int> get_csc_clct_min_max_slope() const;

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCCathodeLCTProcessor.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCCathodeLCTProcessor.cc
@@ -1353,7 +1353,7 @@ void CSCCathodeLCTProcessor::runCCLUT(CSCCLCTDigi& digi) const {
     strm << "+                  Before CCCLUT algorithm:                       +\n";
     strm << "++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++\n";
     strm << " Old CLCT digi " << digi << "\n";
-    strm << " 1/4 strip bit " << digi.getQuartStrip() << " 1/8 strip bit " << digi.getEightStrip() << "\n";
+    strm << " 1/4 strip bit " << digi.getQuartStrip() << " 1/8 strip bit " << digi.getEighthStrip() << "\n";
     strm << " 1/4 strip number " << digi.getKeyStrip(4) << " 1/8 strip number " << digi.getKeyStrip(8) << "\n";
     strm << "++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++\n";
     LogDebug("CSCCathodeLCTProcessor") << strm.str();
@@ -1430,7 +1430,7 @@ void CSCCathodeLCTProcessor::runCCLUT(CSCCLCTDigi& digi) const {
   // store the new 1/2, 1/4 and 1/8 strip positions
   digi.setStrip(halfstrip - digi.getCFEB() * CSCConstants::NUM_HALF_STRIPS_PER_CFEB);
   digi.setQuartStrip(std::get<1>(stripoffset));
-  digi.setEightStrip(std::get<2>(stripoffset));
+  digi.setEighthStrip(std::get<2>(stripoffset));
 
   // store the bending angle value in the pattern data member
   digi.setSlope(slopeCCValue);
@@ -1446,7 +1446,7 @@ void CSCCathodeLCTProcessor::runCCLUT(CSCCLCTDigi& digi) const {
     strm << "+                  CCCLUT algorithm results:                       +\n";
     strm << "++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++\n";
     strm << " New CLCT digi " << digi << "\n";
-    strm << " 1/4 strip bit " << digi.getQuartStrip() << " 1/8 strip bit " << digi.getEightStrip() << "\n";
+    strm << " 1/4 strip bit " << digi.getQuartStrip() << " 1/8 strip bit " << digi.getEighthStrip() << "\n";
     strm << " 1/4 strip number " << digi.getKeyStrip(4) << " 1/8 strip number " << digi.getKeyStrip(8) << "\n";
     strm << "++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++\n";
     LogDebug("CSCCathodeLCTProcessor") << strm.str();

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCGEMMotherboard.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCGEMMotherboard.cc
@@ -150,7 +150,7 @@ CSCCorrelatedLCTDigi CSCGEMMotherboard::constructLCTsGEM(const CSCALCTDigi& alct
       // 4-bit slope value derived with the CCLUT algorithm
       thisLCT.setSlope(clct.getSlope());
       thisLCT.setQuartStrip(clct.getQuartStrip());
-      thisLCT.setEightStrip(clct.getEightStrip());
+      thisLCT.setEighthStrip(clct.getEighthStrip());
       thisLCT.setRun3Pattern(clct.getRun3Pattern());
     }
   } else if (alct.isValid() and clct.isValid() and not gem1.isValid() and gem2.isValid()) {
@@ -175,7 +175,7 @@ CSCCorrelatedLCTDigi CSCGEMMotherboard::constructLCTsGEM(const CSCALCTDigi& alct
       // 4-bit slope value derived with the CCLUT algorithm
       thisLCT.setSlope(clct.getSlope());
       thisLCT.setQuartStrip(clct.getQuartStrip());
-      thisLCT.setEightStrip(clct.getEightStrip());
+      thisLCT.setEighthStrip(clct.getEighthStrip());
       thisLCT.setRun3Pattern(clct.getRun3Pattern());
     }
   } else if (alct.isValid() and gem2.isValid() and not clct.isValid()) {
@@ -249,7 +249,7 @@ CSCCorrelatedLCTDigi CSCGEMMotherboard::constructLCTsGEM(const CSCALCTDigi& alct
       // 4-bit slope value derived with the CCLUT algorithm
       thisLCT.setSlope(clct.getSlope());
       thisLCT.setQuartStrip(clct.getQuartStrip());
-      thisLCT.setEightStrip(clct.getEightStrip());
+      thisLCT.setEighthStrip(clct.getEighthStrip());
       thisLCT.setRun3Pattern(clct.getRun3Pattern());
     }
   }

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboard.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboard.cc
@@ -524,7 +524,7 @@ CSCCorrelatedLCTDigi CSCMotherboard::constructLCTs(const CSCALCTDigi& aLCT,
     // 4-bit slope value derived with the CCLUT algorithm
     thisLCT.setSlope(cLCT.getSlope());
     thisLCT.setQuartStrip(cLCT.getQuartStrip());
-    thisLCT.setEightStrip(cLCT.getEightStrip());
+    thisLCT.setEighthStrip(cLCT.getEighthStrip());
     thisLCT.setRun3Pattern(cLCT.getRun3Pattern());
   }
 

--- a/L1Trigger/CSCTriggerPrimitives/src/LCTQualityControl.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/LCTQualityControl.cc
@@ -115,13 +115,13 @@ void LCTQualityControl::checkValid(const CSCCLCTDigi& clct, unsigned max_stubs) 
     checkRange(clct.getCompCode(), 0, std::pow(2, 12) - 1, "CSCCLCTDigi with invalid comparator code: ", errors);
 
     const unsigned max_quartstrip = get_csc_max_quartstrip(theStation, theRing);
-    const unsigned max_eightstrip = get_csc_max_eightstrip(theStation, theRing);
+    const unsigned max_eighthstrip = get_csc_max_eighthstrip(theStation, theRing);
 
     // CLCT key quart-strip must be within bounds
     checkRange(clct.getKeyStrip(4), 0, max_quartstrip - 1, "CSCCLCTDigi with invalid key quart-strip: ", errors);
 
-    // CLCT key eight-strip must be within bounds
-    checkRange(clct.getKeyStrip(8), 0, max_eightstrip - 1, "CSCCLCTDigi with invalid key quart-strip: ", errors);
+    // CLCT key eighth-strip must be within bounds
+    checkRange(clct.getKeyStrip(8), 0, max_eighthstrip - 1, "CSCCLCTDigi with invalid key quart-strip: ", errors);
   }
 
   reportErrors(clct, errors);
@@ -132,7 +132,7 @@ void LCTQualityControl::checkValid(const CSCCorrelatedLCTDigi& lct) const { chec
 void LCTQualityControl::checkValid(const CSCCorrelatedLCTDigi& lct, const unsigned station, const unsigned ring) const {
   const unsigned max_strip = get_csc_max_halfstrip(station, ring);
   const unsigned max_quartstrip = get_csc_max_quartstrip(station, ring);
-  const unsigned max_eightstrip = get_csc_max_eightstrip(station, ring);
+  const unsigned max_eighthstrip = get_csc_max_eighthstrip(station, ring);
   const unsigned max_wire = get_csc_max_wire(station, ring);
   const auto& [min_pattern, max_pattern] = get_csc_lct_min_max_pattern();
   const unsigned max_quality = get_csc_lct_max_quality();
@@ -154,8 +154,8 @@ void LCTQualityControl::checkValid(const CSCCorrelatedLCTDigi& lct, const unsign
   // LCT key quart-strip must be within bounds
   checkRange(lct.getStrip(4), 0, max_quartstrip - 1, "CSCCorrelatedLCTDigi with invalid key quart-strip: ", errors);
 
-  // LCT key eight-strip must be within bounds
-  checkRange(lct.getStrip(8), 0, max_eightstrip - 1, "CSCCorrelatedLCTDigi with invalid key eight-strip: ", errors);
+  // LCT key eighth-strip must be within bounds
+  checkRange(lct.getStrip(8), 0, max_eighthstrip - 1, "CSCCorrelatedLCTDigi with invalid key eighth-strip: ", errors);
 
   // LCT key wire-group must be within bounds
   checkRange(lct.getKeyWG(), 0, max_wire - 1, "CSCCorrelatedLCTDigi with invalid wire-group: ", errors);
@@ -306,7 +306,7 @@ unsigned LCTQualityControl::get_csc_max_quartstrip(int station, int ring) const 
   return get_csc_max_halfstrip(station, ring) * 2;
 }
 
-unsigned LCTQualityControl::get_csc_max_eightstrip(int station, int ring) const {
+unsigned LCTQualityControl::get_csc_max_eighthstrip(int station, int ring) const {
   return get_csc_max_halfstrip(station, ring) * 4;
 }
 


### PR DESCRIPTION
#### PR description:

Grammatical change in the CSC CLCT and LCT data format, to avoid confusion between 8 neighboring strips and 1/8 of a strip. I used these commands in `DataFormats/CSCDigi` and `L1Trigger/CSCTriggerPrimitives`
```
git grep -lz eight | xargs -0 sed -i -e 's/eight/eighth/g'
git grep -lz EightStrip | xargs -0 sed -i -e 's/EightStrip/EighthStrip/g'
```

#### PR validation:

Code compiles.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
