### PR TITLE
CSCShowerDigi data format (HadronicShowerTrigger-1)

### DIFF
--- a/DataFormats/CSCDigi/interface/CSCShowerDigi.h
+++ b/DataFormats/CSCDigi/interface/CSCShowerDigi.h
@@ -1,0 +1,53 @@
+#ifndef DataFormats_CSCDigi_CSCShowerDigi_h
+#define DataFormats_CSCDigi_CSCShowerDigi_h
+
+#include <cstdint>
+#include <iosfwd>
+#include <limits>
+#include <vector>
+
+class CSCShowerDigi {
+public:
+  // Run-3 definitions as provided in DN-20-033
+  enum Run3Shower { kInvalid = 0, kLoose = 1, kNominal = 2, kTight = 3 };
+  enum BitMask { kInTimeMask = 0x2, kOutTimeMask = 0x2 };
+  enum BitShift { kInTimeShift = 0, kOutTimeShift = 2 };
+
+  /// Constructors
+  CSCShowerDigi(const uint16_t inTimeBits, const uint16_t outTimeBits, const uint16_t cscID);
+  /// default
+  CSCShowerDigi();
+
+  /// clear this Shower
+  void clear() { bits_ = 0; }
+
+  /// data
+  bool isValid() const;
+
+  bool isLooseInTime() const;
+  bool isNominalInTime() const;
+  bool isTightInTime() const;
+  bool isLooseOutTime() const;
+  bool isNominalOutTime() const;
+  bool isTightOutTime() const;
+
+  uint16_t bits() const { return bits_; }
+  uint16_t bitsInTime() const;
+  uint16_t bitsOutTime() const;
+
+  uint16_t getCSCID() const { return cscID_; }
+
+  /// set cscID
+  void setCSCID(const uint16_t c) { cscID_ = c; }
+
+private:
+  void setDataWord(const uint16_t newWord, uint16_t& word, const unsigned shift, const unsigned mask);
+  uint16_t getDataWord(const uint16_t word, const unsigned shift, const unsigned mask) const;
+
+  uint16_t bits_;
+  // 4-bit CSC chamber identifier
+  uint16_t cscID_;
+};
+
+std::ostream& operator<<(std::ostream& o, const CSCShowerDigi& digi);
+#endif

--- a/DataFormats/CSCDigi/interface/CSCShowerDigiCollection.h
+++ b/DataFormats/CSCDigi/interface/CSCShowerDigiCollection.h
@@ -1,0 +1,10 @@
+#ifndef DataFormats_CSCDigi_CSCShowerDigiCollection_h
+#define DataFormats_CSCDigi_CSCShowerDigiCollection_h
+
+#include "DataFormats/MuonDetId/interface/CSCDetId.h"
+#include "DataFormats/CSCDigi/interface/CSCShowerDigi.h"
+#include "DataFormats/MuonData/interface/MuonDigiCollection.h"
+
+typedef MuonDigiCollection<CSCDetId, CSCShowerDigi> CSCShowerDigiCollection;
+
+#endif

--- a/DataFormats/CSCDigi/src/CSCShowerDigi.cc
+++ b/DataFormats/CSCDigi/src/CSCShowerDigi.cc
@@ -1,0 +1,51 @@
+#include "DataFormats/CSCDigi/interface/CSCShowerDigi.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include <iomanip>
+#include <iostream>
+
+using namespace std;
+
+/// Constructors
+CSCShowerDigi::CSCShowerDigi(const uint16_t bitsInTime, const uint16_t bitsOutTime, const uint16_t cscID)
+    : cscID_(cscID) {
+  setDataWord(bitsInTime, bits_, kInTimeShift, kInTimeMask);
+  setDataWord(bitsOutTime, bits_, kOutTimeShift, kOutTimeMask);
+}
+
+/// Default
+CSCShowerDigi::CSCShowerDigi() : bits_(0), cscID_(0) {}
+
+bool CSCShowerDigi::isValid() const {
+  // any loose shower is valid
+  return isLooseInTime() or isLooseOutTime();
+}
+
+bool CSCShowerDigi::isLooseInTime() const { return bitsInTime() >= kLoose; }
+
+bool CSCShowerDigi::isNominalInTime() const { return bitsInTime() >= kNominal; }
+
+bool CSCShowerDigi::isTightInTime() const { return bitsInTime() >= kTight; }
+
+bool CSCShowerDigi::isLooseOutTime() const { return bitsOutTime() >= kLoose; }
+
+bool CSCShowerDigi::isNominalOutTime() const { return bitsOutTime() >= kNominal; }
+
+bool CSCShowerDigi::isTightOutTime() const { return bitsOutTime() >= kTight; }
+
+uint16_t CSCShowerDigi::bitsInTime() const { return getDataWord(bits_, kInTimeShift, kInTimeMask); }
+
+uint16_t CSCShowerDigi::bitsOutTime() const { return getDataWord(bits_, kOutTimeShift, kOutTimeMask); }
+
+void CSCShowerDigi::setDataWord(const uint16_t newWord, uint16_t& word, const unsigned shift, const unsigned mask) {
+  // clear the old value
+  word &= ~(mask << shift);
+
+  // set the new value
+  word |= newWord << shift;
+}
+
+uint16_t CSCShowerDigi::getDataWord(const uint16_t word, const unsigned shift, const unsigned mask) const {
+  return (word >> shift) & mask;
+}
+
+std::ostream& operator<<(std::ostream& o, const CSCShowerDigi& digi) { return o << "CSC Shower: " << digi.bits(); }

--- a/DataFormats/CSCDigi/src/classes.h
+++ b/DataFormats/CSCDigi/src/classes.h
@@ -31,6 +31,8 @@
 #include "DataFormats/CSCDigi/interface/CSCCLCTPreTriggerDigiCollection.h"
 #include "DataFormats/CSCDigi/interface/CSCALCTPreTriggerDigi.h"
 #include "DataFormats/CSCDigi/interface/CSCALCTPreTriggerDigiCollection.h"
+#include "DataFormats/CSCDigi/interface/CSCShowerDigi.h"
+#include "DataFormats/CSCDigi/interface/CSCShowerDigiCollection.h"
 
 // dummy structs to ensure backward compatibility
 struct GEMCSCLCTDigi {};

--- a/DataFormats/CSCDigi/src/classes_def.xml
+++ b/DataFormats/CSCDigi/src/classes_def.xml
@@ -37,6 +37,9 @@
    <class name="CSCALCTPreTriggerDigi" ClassVersion="10">
     <version ClassVersion="10" checksum="2925979693"/>
    </class>
+   <class name="CSCShowerDigi" ClassVersion="10">
+    <version ClassVersion="10" checksum="3566030124"/>
+   </class>
    <class name="CSCCFEBStatusDigi" ClassVersion="10">
     <version ClassVersion="10" checksum="3752412263"/>
    </class>
@@ -76,6 +79,7 @@
    <class name="std::vector<CSCDDUStatusDigi>"/>
    <class name="std::vector<CSCDCCStatusDigi>"/>
    <class name="std::vector<CSCALCTStatusDigi>"/>
+   <class name="std::vector<CSCShowerDigi>"/>
 
    <class name="std::map<CSCDetId,std::vector<CSCWireDigi> >"/>
    <class name="std::map<CSCDetId,std::vector<CSCRPCDigi> >"/>
@@ -95,6 +99,7 @@
    <class name="std::map<CSCDetId,std::vector<CSCDCCStatusDigi> >"/>
    <class name="std::map<CSCDetId,std::vector<CSCALCTStatusDigi> >"/>
    <class name="std::map<CSCDetId,std::vector<CSCCLCTPreTrigger> >"/>
+   <class name="std::map<CSCDetId,std::vector<CSCShowerDigi> >"/>
 
    <class name="std::pair<CSCDetId,std::vector<CSCWireDigi> >"/>
    <class name="std::pair<CSCDetId,std::vector<CSCRPCDigi> >"/>
@@ -114,6 +119,7 @@
    <class name="std::pair<CSCDetId,std::vector<CSCDCCStatusDigi> >"/>
    <class name="std::pair<CSCDetId,std::vector<CSCALCTStatusDigi> >"/>
    <class name="std::pair<CSCDetId,std::vector<CSCCLCTPreTrigger> >"/>
+   <class name="std::pair<CSCDetId,std::vector<CSCShowerDigi> >"/>
 
 
    <class name="MuonDigiCollection<CSCDetId,CSCWireDigi>"/>
@@ -134,6 +140,7 @@
    <class name="MuonDigiCollection<CSCDetId,CSCDDUStatusDigi>"/>
    <class name="MuonDigiCollection<CSCDetId,CSCALCTStatusDigi>"/>
    <class name="MuonDigiCollection<CSCDetId,CSCCLCTPreTrigger>"/>
+   <class name="MuonDigiCollection<CSCDetId,CSCShowerDigi>"/>
 
    <class name="edm::Wrapper<MuonDigiCollection<CSCDetId,CSCWireDigi>>"  splitLevel="0"/>
    <class name="edm::Wrapper<MuonDigiCollection<CSCDetId,CSCRPCDigi>>" splitLevel="0"/>
@@ -153,5 +160,6 @@
    <class name="edm::Wrapper<MuonDigiCollection<CSCDetId,CSCDDUStatusDigi> >" splitLevel="0"/>
    <class name="edm::Wrapper<MuonDigiCollection<CSCDetId,CSCALCTStatusDigi> >" splitLevel="0"/>
    <class name="edm::Wrapper<MuonDigiCollection<CSCDetId,CSCCLCTPreTrigger> >" splitLevel="0"/>
+   <class name="edm::Wrapper<MuonDigiCollection<CSCDetId,CSCShowerDigi> >" splitLevel="0"/>
 
 </lcgdict>


### PR DESCRIPTION
#### PR description:

This is the first PR (of several) to integrate the emulator of the new hadronic shower trigger in Run-3. Each CSC chamber will send 4 bits per bunch crossing to the Muon Port Card, and to the Muon Track Finder Sector Processors. These bits are called ```TMBi\_HMT[3:0]``` for each MPC. In the simulation, they are contained in the new CSCShowerDigi data format. Two bits are allocated for in-time; two bits for out-of-time. Documentation can be found here: [DN-20-033](https://gitlab.cern.ch/tdr/notes/DN-20-033/blob/master/temp/DN-20-033_temp.pdf).

<img width="516" alt="Screen Shot 2021-04-09 at 2 04 03 PM" src="https://user-images.githubusercontent.com/4134786/114228713-7aaa4a00-993c-11eb-88fe-709aa5dffa01.png">

#### PR validation:

Code compiles. Tested with WF 11634.0.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A. We expect the (local trigger, track-finder, uGMT) firmware to be available by Summer 2021. I'll first develop the entire emulator in 11_3_X, then backport if need be.

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
