### PR TITLE
Ecal Phase 2 TP algo EcalFenix class renames

### DIFF
--- a/SimCalorimetry/EcalEBTrigPrimAlgos/interface/EcalEBFenixAmplitudeFilter.h
+++ b/SimCalorimetry/EcalEBTrigPrimAlgos/interface/EcalEBFenixAmplitudeFilter.h
@@ -1,5 +1,5 @@
-#ifndef ECAL_FENIX_AMPLITUDE_FILTER_H
-#define ECAL_FENIX_AMPLITUDE_FILTER_H
+#ifndef SimCalorimetry_EcalEBTrigPrimAlgos_EcalEBFenixAmplitudeFilter_h
+#define SimCalorimetry_EcalEBTrigPrimAlgos_EcalEBFenixAmplitudeFilter_h
 
 #include <vector>
 #include <cstdint>
@@ -8,13 +8,13 @@ class EcalTPGWeightIdMap;
 class EcalTPGWeightGroup;
 
 /** 
-   \ class EcalFenixAmplitudeFilter
+   \ class EcalEBFenixAmplitudeFilter
    \brief calculates .... for Fenix strip, barrel
    *  input: 18 bits
    *  output: 18 bits
    *  
    */
-class EcalFenixAmplitudeFilter {
+class EcalEBFenixAmplitudeFilter {
 private:
   int peakFlag_[5];
   int inputsAlreadyIn_;
@@ -29,8 +29,8 @@ private:
   int processedFgvbOutput_;
 
 public:
-  EcalFenixAmplitudeFilter();
-  virtual ~EcalFenixAmplitudeFilter();
+  EcalEBFenixAmplitudeFilter();
+  virtual ~EcalEBFenixAmplitudeFilter();
   virtual void process(std::vector<int> &addout,
                        std::vector<int> &output,
                        std::vector<int> &fgvbIn,

--- a/SimCalorimetry/EcalEBTrigPrimAlgos/interface/EcalEBFenixLinearizer.h
+++ b/SimCalorimetry/EcalEBTrigPrimAlgos/interface/EcalEBFenixLinearizer.h
@@ -59,19 +59,9 @@ void EcalEBFenixLinearizer::process(const T &df, std::vector<int> &output_percry
   // 1  8  11 18 21
   // 0  9  10 19 20
 
-  //std::cout << " EcalEBFenixLinearizer::process(const  .. DataFrame " << std::endl;
-  for (int i = 0; i < df.size(); i++) {
-    //std::cout <<  df[i] << " ";
-  }
-
   for (int i = 0; i < df.size(); i++) {
     setInput(df[i]);
     output_percry[i] = process();
-  }
-
-  //std::cout << " EcalEBFenixLinearizer::process(const  .. Final output " << std::endl;
-  for (int i = 0; i < df.size(); i++) {
-    //std::cout << " output_percry " << output_percry[i]<< " ";
   }
 
   return;

--- a/SimCalorimetry/EcalEBTrigPrimAlgos/interface/EcalEBFenixLinearizer.h
+++ b/SimCalorimetry/EcalEBTrigPrimAlgos/interface/EcalEBFenixLinearizer.h
@@ -1,5 +1,5 @@
-#ifndef ECAL_FENIX_LINEARIZER_H
-#define ECAL_FENIX_LINEARIZER_H
+#ifndef SimCalorimetry_EcalEBTrigPrimAlgos_EcalEBFenixLinearizer_h
+#define SimCalorimetry_EcalEBTrigPrimAlgos_EcalEBFenixLinearizer_h
 
 #include <DataFormats/EcalDigi/interface/EcalMGPASample.h>
 #include <CondFormats/EcalObjects/interface/EcalTPGPedestals.h>
@@ -9,14 +9,14 @@
 #include <vector>
 
 /** 
-   \class EcalFenixLinearizer
+   \class EcalEBFenixLinearizer
    \brief Linearisation for Fenix strip
    *  input: 16 bits  corresponding to input EBDataFrame
    *  output: 18 bits 
    *  
    */
 
-class EcalFenixLinearizer {
+class EcalEBFenixLinearizer {
 private:
   bool famos_;
   int uncorrectedSample_;
@@ -37,8 +37,8 @@ private:
   int process();
 
 public:
-  EcalFenixLinearizer(bool famos);
-  virtual ~EcalFenixLinearizer();
+  EcalEBFenixLinearizer(bool famos);
+  virtual ~EcalEBFenixLinearizer();
 
   template <class T>
   void process(const T &, std::vector<int> &);
@@ -49,7 +49,7 @@ public:
 };
 
 template <class T>
-void EcalFenixLinearizer::process(const T &df, std::vector<int> &output_percry) {
+void EcalEBFenixLinearizer::process(const T &df, std::vector<int> &output_percry) {
   //We know a tower numbering is:
   // S1 S2 S3 S4 S5
   //
@@ -59,7 +59,7 @@ void EcalFenixLinearizer::process(const T &df, std::vector<int> &output_percry) 
   // 1  8  11 18 21
   // 0  9  10 19 20
 
-  //std::cout << " EcalFenixLinearizer::process(const  .. DataFrame " << std::endl;
+  //std::cout << " EcalEBFenixLinearizer::process(const  .. DataFrame " << std::endl;
   for (int i = 0; i < df.size(); i++) {
     //std::cout <<  df[i] << " ";
   }
@@ -69,7 +69,7 @@ void EcalFenixLinearizer::process(const T &df, std::vector<int> &output_percry) 
     output_percry[i] = process();
   }
 
-  //std::cout << " EcalFenixLinearizer::process(const  .. Final output " << std::endl;
+  //std::cout << " EcalEBFenixLinearizer::process(const  .. Final output " << std::endl;
   for (int i = 0; i < df.size(); i++) {
     //std::cout << " output_percry " << output_percry[i]<< " ";
   }

--- a/SimCalorimetry/EcalEBTrigPrimAlgos/interface/EcalEBFenixPeakFinder.h
+++ b/SimCalorimetry/EcalEBTrigPrimAlgos/interface/EcalEBFenixPeakFinder.h
@@ -1,10 +1,10 @@
-#ifndef ECAL_FENIX_PEAKFINDER_H
-#define ECAL_FENIX_PEAKFINDER_H
+#ifndef SimCalorimetry_EcalEBTrigPrimAlgos_EcalEBFenixPeakFinder_h
+#define SimCalorimetry_EcalEBTrigPrimAlgos_EcalEBFenixPeakFinder_h
 
 #include <vector>
 
 /** 
-   \ class EcalFenixPeakFinder
+   \ class EcalEBFenixPeakFinder
    \brief calculates the peak for Fenix strip, barrel
    *  input : 18 bits
    *  output: boolean
@@ -13,7 +13,7 @@
    *  ----> do we really need caloVShape?
    */
 
-class EcalFenixPeakFinder {
+class EcalEBFenixPeakFinder {
 private:
   bool disabled;
   int setInput(int input);
@@ -23,8 +23,8 @@ private:
   int buffer_[3];
 
 public:
-  EcalFenixPeakFinder();
-  virtual ~EcalFenixPeakFinder();
+  EcalEBFenixPeakFinder();
+  virtual ~EcalEBFenixPeakFinder();
   virtual std::vector<int> process(std::vector<int>& filtout, std::vector<int>& output);
   // from CaloVShape
   //  virtual double operator()(double) const {return 0.;}

--- a/SimCalorimetry/EcalEBTrigPrimAlgos/interface/EcalEBFenixStripFormatEB.h
+++ b/SimCalorimetry/EcalEBTrigPrimAlgos/interface/EcalEBFenixStripFormatEB.h
@@ -1,5 +1,5 @@
-#ifndef ECAL_FENIX_STRIP_FORMAT_EB_H
-#define ECAL_FENIX_STRIP_FORMAT_EB_H
+#ifndef SimCalorimetry_EcalEBTrigPrimAlgos_EcalEBFenixStripFormatEB_h
+#define SimCalorimetry_EcalEBTrigPrimAlgos_EcalEBFenixStripFormatEB_h
 
 #include <vector>
 #include <cstdint>
@@ -7,7 +7,7 @@
 class EcalTPGSlidingWindow;
 
 /** 
-    \class EcalFenixStripFormatEB
+    \class EcalEBFenixStripFormatEB
    \brief Formatting for Fenix strip
   *  input: 18 bits + 3x 1bit (fgvb, gapflagbit, output from peakfinder)
    *  output:16 bits
@@ -15,7 +15,7 @@ class EcalTPGSlidingWindow;
    *  --- not really a calodataframe no?
    */
 
-class EcalFenixStripFormatEB {
+class EcalEBFenixStripFormatEB {
 private:
   int inputsFGVB_;
   int inputPeak_;
@@ -27,8 +27,8 @@ private:
   int process();
 
 public:
-  EcalFenixStripFormatEB();
-  virtual ~EcalFenixStripFormatEB();
+  EcalEBFenixStripFormatEB();
+  virtual ~EcalEBFenixStripFormatEB();
   virtual void process(std::vector<int> &, std::vector<int> &, std::vector<int> &, std::vector<int> &);
   void setParameters(uint32_t &, const EcalTPGSlidingWindow *&);
 };

--- a/SimCalorimetry/EcalEBTrigPrimAlgos/interface/EcalEBFenixTcpFormat.h
+++ b/SimCalorimetry/EcalEBTrigPrimAlgos/interface/EcalEBFenixTcpFormat.h
@@ -1,5 +1,5 @@
-#ifndef ECAL_FENIX_TCP_FORMAT_H
-#define ECAL_FENIX_TCP_FORMAT_H
+#ifndef SimCalorimetry_EcalEBTrigPrimAlgos_EcalEBFenixTcpFormat_h
+#define SimCalorimetry_EcalEBTrigPrimAlgos_EcalEBFenixTcpFormat_h
 
 #include "DataFormats/EcalDigi/interface/EcalEBTriggerPrimitiveSample.h"
 #include <vector>
@@ -10,7 +10,7 @@ class EcalTPGTowerStatus;
 class EcalTPGSpike;
 
 /** 
-    \class EcalFenixStripFormat
+    \class EcalEBFenixTcpFormat
     \brief Formatting for Fenix Tcp
     *  input 10 bits from Ettot 
     *         1 bit from fgvb
@@ -19,10 +19,10 @@ class EcalTPGSpike;
     *  simple formatting
     *  
     */
-class EcalFenixTcpFormat {
+class EcalEBFenixTcpFormat {
 public:
-  EcalFenixTcpFormat(bool tccFormat, bool debug, bool famos, int binOfMax);
-  virtual ~EcalFenixTcpFormat();
+  EcalEBFenixTcpFormat(bool tccFormat, bool debug, bool famos, int binOfMax);
+  virtual ~EcalEBFenixTcpFormat();
 
   void process(std::vector<int> &, std::vector<int> &);
   void process(std::vector<int> &Et,

--- a/SimCalorimetry/EcalEBTrigPrimAlgos/interface/EcalEBTrigPrimTestAlgo.h
+++ b/SimCalorimetry/EcalEBTrigPrimAlgos/interface/EcalEBTrigPrimTestAlgo.h
@@ -1,5 +1,5 @@
-#ifndef EcalEBTrigPrimTestAlgo_h
-#define EcalEBTrigPrimTestAlgo_h
+#ifndef SimCalorimetry_EcalEBTrigPrimAlgos_EcalEBTrigPrimTestAlgo_h
+#define SimCalorimetry_EcalEBTrigPrimAlgos_EcalEBTrigPrimTestAlgo_h
 /** \class EcalEBTrigPrimTestAlgo
 \author N. Marinelli - Univ. of Notre Dame
  * forPhase II 
@@ -25,11 +25,11 @@
 #include "Geometry/CaloGeometry/interface/CaloSubdetectorGeometry.h"
 #include "Geometry/CaloGeometry/interface/CaloCellGeometry.h"
 
-#include <SimCalorimetry/EcalEBTrigPrimAlgos/interface/EcalFenixLinearizer.h>
-#include <SimCalorimetry/EcalEBTrigPrimAlgos/interface/EcalFenixAmplitudeFilter.h>
-#include <SimCalorimetry/EcalEBTrigPrimAlgos/interface/EcalFenixPeakFinder.h>
-#include <SimCalorimetry/EcalEBTrigPrimAlgos/interface/EcalFenixStripFormatEB.h>
-#include <SimCalorimetry/EcalEBTrigPrimAlgos/interface/EcalFenixTcpFormat.h>
+#include <SimCalorimetry/EcalEBTrigPrimAlgos/interface/EcalEBFenixLinearizer.h>
+#include <SimCalorimetry/EcalEBTrigPrimAlgos/interface/EcalEBFenixAmplitudeFilter.h>
+#include <SimCalorimetry/EcalEBTrigPrimAlgos/interface/EcalEBFenixPeakFinder.h>
+#include <SimCalorimetry/EcalEBTrigPrimAlgos/interface/EcalEBFenixStripFormatEB.h>
+#include <SimCalorimetry/EcalEBTrigPrimAlgos/interface/EcalEBFenixTcpFormat.h>
 
 #include <map>
 #include <utility>
@@ -129,11 +129,11 @@ private:
 
   const EcalElectronicsMapping *theMapping_;
 
-  std::vector<EcalFenixLinearizer *> linearizer_;
-  EcalFenixAmplitudeFilter *amplitude_filter_;
-  EcalFenixPeakFinder *peak_finder_;
-  EcalFenixStripFormatEB *fenixFormatterEB_;
-  EcalFenixTcpFormat *fenixTcpFormat_;
+  std::vector<EcalEBFenixLinearizer *> linearizer_;
+  EcalEBFenixAmplitudeFilter *amplitude_filter_;
+  EcalEBFenixPeakFinder *peak_finder_;
+  EcalEBFenixStripFormatEB *fenixFormatterEB_;
+  EcalEBFenixTcpFormat *fenixTcpFormat_;
 
   //
   const EcalTPGPedestals *ecaltpPed_;
@@ -147,10 +147,10 @@ private:
   const EcalTPGTowerStatus *ecaltpgBadTT_;
   const EcalTPGSpike *ecaltpgSpike_;
 
-  EcalFenixLinearizer *getLinearizer(int i) const { return linearizer_[i]; }
+  EcalEBFenixLinearizer *getLinearizer(int i) const { return linearizer_[i]; }
   std::vector<std::vector<int> > lin_out_;
   //
-  EcalFenixAmplitudeFilter *getFilter() const { return amplitude_filter_; }
+  EcalEBFenixAmplitudeFilter *getFilter() const { return amplitude_filter_; }
   std::vector<int> filt_out_;
   std::vector<int> peak_out_;
   std::vector<int> format_out_;
@@ -159,10 +159,10 @@ private:
   std::vector<int> fgvb_out_temp_;
 
   //
-  EcalFenixPeakFinder *getPeakFinder() const { return peak_finder_; }
-  EcalFenixStripFormatEB *getFormatterEB() const { return fenixFormatterEB_; }
+  EcalEBFenixPeakFinder *getPeakFinder() const { return peak_finder_; }
+  EcalEBFenixStripFormatEB *getFormatterEB() const { return fenixFormatterEB_; }
   //
-  EcalFenixTcpFormat *getFormatter() const { return fenixTcpFormat_; }
+  EcalEBFenixTcpFormat *getFormatter() const { return fenixTcpFormat_; }
   std::vector<int> tcpformat_out_;
 };
 

--- a/SimCalorimetry/EcalEBTrigPrimAlgos/interface/EcalEBTrigPrimTestAlgo.h
+++ b/SimCalorimetry/EcalEBTrigPrimAlgos/interface/EcalEBTrigPrimTestAlgo.h
@@ -14,15 +14,10 @@
 #include "Geometry/CaloTopology/interface/EcalTrigTowerConstituentsMap.h"
 #include "DataFormats/EcalDetId/interface/EcalTriggerElectronicsId.h"
 #include "DataFormats/Common/interface/SortedCollection.h"
-//#include "DataFormats/EcalRecHit/interface/EcalRecHitCollections.h"
 #include "DataFormats/EcalDigi/interface/EcalDigiCollections.h"
 
-#include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "Geometry/CaloGeometry/interface/CaloGeometry.h"
-#include "Geometry/Records/interface/CaloGeometryRecord.h"
-#include "Geometry/CaloGeometry/interface/CaloSubdetectorGeometry.h"
 #include "Geometry/CaloGeometry/interface/CaloCellGeometry.h"
 
 #include <SimCalorimetry/EcalEBTrigPrimAlgos/interface/EcalEBFenixLinearizer.h>
@@ -37,21 +32,24 @@
 class EcalTrigTowerDetId;
 class ETPCoherenceTest;
 class EcalEBTriggerPrimitiveSample;
-class CaloSubdetectorGeometry;
 class EBDataFrame;
 
 class EcalEBTrigPrimTestAlgo {
 public:
-  explicit EcalEBTrigPrimTestAlgo(
-      const edm::EventSetup &setup, int nSamples, int binofmax, bool tcpFormat, bool barrelOnly, bool debug, bool famos);
+  // not BarrelOnly
+  explicit EcalEBTrigPrimTestAlgo(const EcalTrigTowerConstituentsMap *eTTmap,
+                                  const CaloGeometry *theGeometry,
+                                  int nSamples,
+                                  int binofmax,
+                                  bool tcpFormat,
+                                  bool debug,
+                                  bool famos);
+  //barrel only
+  explicit EcalEBTrigPrimTestAlgo(int nSamples, int binofmax, bool tcpFormat, bool debug, bool famos);
 
   virtual ~EcalEBTrigPrimTestAlgo();
 
-  //  void run(const edm::EventSetup &, const EcalRecHitCollection *col, EcalEBTrigPrimDigiCollection & result, EcalEBTrigPrimDigiCollection & resultTcp);
-  void run(const edm::EventSetup &,
-           const EBDigiCollection *col,
-           EcalEBTrigPrimDigiCollection &result,
-           EcalEBTrigPrimDigiCollection &resultTcp);
+  void run(const EBDigiCollection *col, EcalEBTrigPrimDigiCollection &result, EcalEBTrigPrimDigiCollection &resultTcp);
 
   void setPointers(const EcalTPGLinearizationConst *ecaltpLin,
                    const EcalTPGPedestals *ecaltpPed,
@@ -76,7 +74,7 @@ public:
   }
 
 private:
-  void init(const edm::EventSetup &);
+  void init();
   template <class T>
   void initStructures(std::vector<std::vector<std::pair<int, std::vector<T> > > > &towMap);
   template <class T>
@@ -97,9 +95,8 @@ private:
     return ind;
   }
 
-  edm::ESHandle<EcalTrigTowerConstituentsMap> eTTmap_;
-  //  const CaloSubdetectorGeometry *theEndcapGeometry;
-  edm::ESHandle<CaloGeometry> theGeometry;
+  const EcalTrigTowerConstituentsMap *eTTmap_ = nullptr;
+  const CaloGeometry *theGeometry_ = nullptr;
 
   float threshold;
   int nSamples_;

--- a/SimCalorimetry/EcalEBTrigPrimAlgos/src/EcalEBFenixAmplitudeFilter.cc
+++ b/SimCalorimetry/EcalEBTrigPrimAlgos/src/EcalEBFenixAmplitudeFilter.cc
@@ -32,9 +32,9 @@ int EcalEBFenixAmplitudeFilter::setInput(int input, int fgvb) {
 }
 
 void EcalEBFenixAmplitudeFilter::process(std::vector<int> &addout,
-                                       std::vector<int> &output,
-                                       std::vector<int> &fgvbIn,
-                                       std::vector<int> &fgvbOut) {
+                                         std::vector<int> &output,
+                                         std::vector<int> &fgvbIn,
+                                         std::vector<int> &fgvbOut) {
   // test
 
   inputsAlreadyIn_ = 0;
@@ -93,8 +93,8 @@ void EcalEBFenixAmplitudeFilter::process() {
 }
 
 void EcalEBFenixAmplitudeFilter::setParameters(uint32_t raw,
-                                             const EcalTPGWeightIdMap *ecaltpgWeightMap,
-                                             const EcalTPGWeightGroup *ecaltpgWeightGroup) {
+                                               const EcalTPGWeightIdMap *ecaltpgWeightMap,
+                                               const EcalTPGWeightGroup *ecaltpgWeightGroup) {
   uint32_t params_[5];
   const EcalTPGGroups::EcalTPGGroupsMap &groupmap = ecaltpgWeightGroup->getMap();
   EcalTPGGroups::EcalTPGGroupsMapItr it = groupmap.find(raw);

--- a/SimCalorimetry/EcalEBTrigPrimAlgos/src/EcalEBFenixAmplitudeFilter.cc
+++ b/SimCalorimetry/EcalEBTrigPrimAlgos/src/EcalEBFenixAmplitudeFilter.cc
@@ -1,28 +1,28 @@
-#include <SimCalorimetry/EcalEBTrigPrimAlgos/interface/EcalFenixAmplitudeFilter.h>
+#include <SimCalorimetry/EcalEBTrigPrimAlgos/interface/EcalEBFenixAmplitudeFilter.h>
 #include "CondFormats/EcalObjects/interface/EcalTPGWeightIdMap.h"
 #include "CondFormats/EcalObjects/interface/EcalTPGWeightGroup.h"
 #include "CondFormats/EcalObjects/interface/EcalTPGGroups.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include <iostream>
 
-EcalFenixAmplitudeFilter::EcalFenixAmplitudeFilter() : inputsAlreadyIn_(0), shift_(6) {}
+EcalEBFenixAmplitudeFilter::EcalEBFenixAmplitudeFilter() : inputsAlreadyIn_(0), shift_(6) {}
 
-EcalFenixAmplitudeFilter::~EcalFenixAmplitudeFilter() {}
+EcalEBFenixAmplitudeFilter::~EcalEBFenixAmplitudeFilter() {}
 
-int EcalFenixAmplitudeFilter::setInput(int input, int fgvb) {
+int EcalEBFenixAmplitudeFilter::setInput(int input, int fgvb) {
   if (input > 0X3FFFF) {
     std::cout << "ERROR IN INPUT OF AMPLITUDE FILTER" << std::endl;
     return -1;
   }
   if (inputsAlreadyIn_ < 5) {
-    //std::cout << " EcalFenixAmplitudeFilter::setInput inputsAlreadyIn_<5 input " << input << std::endl;
+    //std::cout << " EcalEBFenixAmplitudeFilter::setInput inputsAlreadyIn_<5 input " << input << std::endl;
     buffer_[inputsAlreadyIn_] = input;
     fgvbBuffer_[inputsAlreadyIn_] = fgvb;
     inputsAlreadyIn_++;
   } else {
     for (int i = 0; i < 4; i++) {
       buffer_[i] = buffer_[i + 1];
-      //std::cout << " EcalFenixAmplitudeFilter::setInput inputsAlreadyIn buffer " << buffer_[i] << std::endl;
+      //std::cout << " EcalEBFenixAmplitudeFilter::setInput inputsAlreadyIn buffer " << buffer_[i] << std::endl;
       fgvbBuffer_[i] = fgvbBuffer_[i + 1];
     }
     buffer_[4] = input;
@@ -31,7 +31,7 @@ int EcalFenixAmplitudeFilter::setInput(int input, int fgvb) {
   return 1;
 }
 
-void EcalFenixAmplitudeFilter::process(std::vector<int> &addout,
+void EcalEBFenixAmplitudeFilter::process(std::vector<int> &addout,
                                        std::vector<int> &output,
                                        std::vector<int> &fgvbIn,
                                        std::vector<int> &fgvbOut) {
@@ -45,7 +45,7 @@ void EcalFenixAmplitudeFilter::process(std::vector<int> &addout,
 
   // test end
 
-  //std::cout << "  EcalFenixAmplitudeFilter::process(std::vector<int> &addout size  " << addout.size() << std::endl;
+  //std::cout << "  EcalEBFenixAmplitudeFilter::process(std::vector<int> &addout size  " << addout.size() << std::endl;
   for (unsigned int i = 0; i < addout.size(); i++) {
     setInput(addout[i], fgvbIn[i]);
     for (unsigned int i = 0; i < 5; i++) {
@@ -69,7 +69,7 @@ void EcalFenixAmplitudeFilter::process(std::vector<int> &addout,
   return;
 }
 
-void EcalFenixAmplitudeFilter::process() {
+void EcalEBFenixAmplitudeFilter::process() {
   //UB FIXME: 5
   processedOutput_ = 0;
   processedFgvbOutput_ = 0;
@@ -92,7 +92,7 @@ void EcalFenixAmplitudeFilter::process() {
   processedFgvbOutput_ = fgvbInt;
 }
 
-void EcalFenixAmplitudeFilter::setParameters(uint32_t raw,
+void EcalEBFenixAmplitudeFilter::setParameters(uint32_t raw,
                                              const EcalTPGWeightIdMap *ecaltpgWeightMap,
                                              const EcalTPGWeightGroup *ecaltpgWeightGroup) {
   uint32_t params_[5];

--- a/SimCalorimetry/EcalEBTrigPrimAlgos/src/EcalEBFenixLinearizer.cc
+++ b/SimCalorimetry/EcalEBTrigPrimAlgos/src/EcalEBFenixLinearizer.cc
@@ -1,4 +1,4 @@
-#include <SimCalorimetry/EcalEBTrigPrimAlgos/interface/EcalFenixLinearizer.h>
+#include <SimCalorimetry/EcalEBTrigPrimAlgos/interface/EcalEBFenixLinearizer.h>
 
 #include <CondFormats/EcalObjects/interface/EcalTPGLinearizationConst.h>
 #include <CondFormats/EcalObjects/interface/EcalTPGPedestals.h>
@@ -6,10 +6,10 @@
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
-EcalFenixLinearizer::EcalFenixLinearizer(bool famos)
+EcalEBFenixLinearizer::EcalEBFenixLinearizer(bool famos)
     : famos_(famos), init_(false), linConsts_(nullptr), peds_(nullptr), badXStatus_(nullptr) {}
 
-EcalFenixLinearizer::~EcalFenixLinearizer() {
+EcalEBFenixLinearizer::~EcalEBFenixLinearizer() {
   if (init_) {
     for (int i = 0; i < (int)vectorbadXStatus_.size(); i++) {
       delete vectorbadXStatus_[i];
@@ -17,7 +17,7 @@ EcalFenixLinearizer::~EcalFenixLinearizer() {
   }
 }
 
-void EcalFenixLinearizer::setParameters(uint32_t raw,
+void EcalEBFenixLinearizer::setParameters(uint32_t raw,
                                         const EcalTPGPedestals *ecaltpPed,
                                         const EcalTPGLinearizationConst *ecaltpLin,
                                         const EcalTPGCrystalStatus *ecaltpBadX) {
@@ -48,24 +48,24 @@ void EcalFenixLinearizer::setParameters(uint32_t raw,
   }
 }
 
-int EcalFenixLinearizer::process() {
+int EcalEBFenixLinearizer::process() {
   int output = (uncorrectedSample_ - base_);  //Substract base
-  //std::cout << " EcalFenixLinearizer::process() output non bit shifted " << output << std::endl;
+  //std::cout << " EcalEBFenixLinearizer::process() output non bit shifted " << output << std::endl;
   if (famos_ || output < 0)
     return 0;
 
   if (output < 0)
     return shift_ << 12;                      // FENIX bug(!)
   output = (output * mult_) >> (shift_ + 2);  //Apply multiplicative factor
-  //std::cout << " EcalFenixLinearizer::process() output 2nd step " << output << std::endl;
+  //std::cout << " EcalEBFenixLinearizer::process() output 2nd step " << output << std::endl;
   if (output > 0X3FFFF)
     output = 0X3FFFF;  //Saturation if too high
-  //std::cout << " EcalFenixLinearizer::process() output 3rd step " << output << std::endl;
+  //std::cout << " EcalEBFenixLinearizer::process() output 3rd step " << output << std::endl;
   return output;
 }
 
-int EcalFenixLinearizer::setInput(const EcalMGPASample &RawSam) {
-  //std::cout << "  EcalFenixLinearizer::setInput RawSam.raw() " << RawSam.raw() << std::endl;
+int EcalEBFenixLinearizer::setInput(const EcalMGPASample &RawSam) {
+  //std::cout << "  EcalEBFenixLinearizer::setInput RawSam.raw() " << RawSam.raw() << std::endl;
   if (RawSam.raw() > 0X3FFF) {
     LogDebug("EcalTPG") << "ERROR IN INPUT SAMPLE OF FENIX LINEARIZER";
     return -1;
@@ -118,7 +118,7 @@ int EcalFenixLinearizer::setInput(const EcalMGPASample &RawSam) {
     }
   }
 
-  //std::cout << "  EcalFenixLinearizer::setInput   uncorrectedSample_ " << RawSam.adc() << " gainID " << gainID_ << " baseline " << base_ << std::endl;
+  //std::cout << "  EcalEBFenixLinearizer::setInput   uncorrectedSample_ " << RawSam.adc() << " gainID " << gainID_ << " baseline " << base_ << std::endl;
 
   if (famos_)
     base_ = 200;  //FIXME by preparing a correct TPG.txt for Famos

--- a/SimCalorimetry/EcalEBTrigPrimAlgos/src/EcalEBFenixLinearizer.cc
+++ b/SimCalorimetry/EcalEBTrigPrimAlgos/src/EcalEBFenixLinearizer.cc
@@ -18,9 +18,9 @@ EcalEBFenixLinearizer::~EcalEBFenixLinearizer() {
 }
 
 void EcalEBFenixLinearizer::setParameters(uint32_t raw,
-                                        const EcalTPGPedestals *ecaltpPed,
-                                        const EcalTPGLinearizationConst *ecaltpLin,
-                                        const EcalTPGCrystalStatus *ecaltpBadX) {
+                                          const EcalTPGPedestals *ecaltpPed,
+                                          const EcalTPGLinearizationConst *ecaltpLin,
+                                          const EcalTPGCrystalStatus *ecaltpBadX) {
   const EcalTPGLinearizationConstMap &linMap = ecaltpLin->getMap();
   EcalTPGLinearizationConstMapIterator it = linMap.find(raw);
 

--- a/SimCalorimetry/EcalEBTrigPrimAlgos/src/EcalEBFenixPeakFinder.cc
+++ b/SimCalorimetry/EcalEBTrigPrimAlgos/src/EcalEBFenixPeakFinder.cc
@@ -1,26 +1,26 @@
-#include <SimCalorimetry/EcalEBTrigPrimAlgos/interface/EcalFenixPeakFinder.h>
+#include <SimCalorimetry/EcalEBTrigPrimAlgos/interface/EcalEBFenixPeakFinder.h>
 #include <iostream>
 
-EcalFenixPeakFinder::EcalFenixPeakFinder() : inputsAlreadyIn_(0) {}
+EcalEBFenixPeakFinder::EcalEBFenixPeakFinder() : inputsAlreadyIn_(0) {}
 
-EcalFenixPeakFinder::~EcalFenixPeakFinder() {}
+EcalEBFenixPeakFinder::~EcalEBFenixPeakFinder() {}
 
-int EcalFenixPeakFinder::setInput(int input) {
+int EcalEBFenixPeakFinder::setInput(int input) {
   if (inputsAlreadyIn_ < 3) {
-    //std::cout << " EcalFenixPeakFinder::setInput inputsAlreadyIn_<3 input " << input << std::endl;
+    //std::cout << " EcalEBFenixPeakFinder::setInput inputsAlreadyIn_<3 input " << input << std::endl;
     buffer_[inputsAlreadyIn_] = input;
     inputsAlreadyIn_++;
   } else {
     for (int i = 0; i < 2; i++) {
       buffer_[i] = buffer_[i + 1];
-      //std::cout << " EcalFenixPeakFinder::setInput inputsAlreadyIn buffer " << buffer_[i] << std::endl;
+      //std::cout << " EcalEBFenixPeakFinder::setInput inputsAlreadyIn buffer " << buffer_[i] << std::endl;
     }
     buffer_[2] = input;
   }
   return 1;
 }
 
-int EcalFenixPeakFinder::process() {
+int EcalEBFenixPeakFinder::process() {
   if (inputsAlreadyIn_ < 3)
     return 0;
   if (buffer_[1] > buffer_[0] && buffer_[1] > buffer_[2])
@@ -29,7 +29,7 @@ int EcalFenixPeakFinder::process() {
     return 0;
 }
 
-std::vector<int> EcalFenixPeakFinder::process(std::vector<int> &filtout, std::vector<int> &output) {
+std::vector<int> EcalEBFenixPeakFinder::process(std::vector<int> &filtout, std::vector<int> &output) {
   // FIXME: 3
   inputsAlreadyIn_ = 0;
   for (unsigned int i = 0; i < 3; i++)
@@ -37,7 +37,7 @@ std::vector<int> EcalFenixPeakFinder::process(std::vector<int> &filtout, std::ve
 
   //  std::vector<int> output;
 
-  //std::cout << "  EcalFenixPeakFinder::process(   " << filtout.size() << std::endl;
+  //std::cout << "  EcalEBFenixPeakFinder::process(   " << filtout.size() << std::endl;
   // attention, we have to shift by one, because the peak is found one too late
   for (unsigned int i = 0; i < filtout.size(); i++) {
     setInput(filtout[i]);

--- a/SimCalorimetry/EcalEBTrigPrimAlgos/src/EcalEBFenixStripFormatEB.cc
+++ b/SimCalorimetry/EcalEBTrigPrimAlgos/src/EcalEBFenixStripFormatEB.cc
@@ -31,9 +31,9 @@ int EcalEBFenixStripFormatEB::process() {
 }
 
 void EcalEBFenixStripFormatEB::process(std::vector<int> &sFGVBout,
-                                     std::vector<int> &peakout,
-                                     std::vector<int> &filtout,
-                                     std::vector<int> &output) {
+                                       std::vector<int> &peakout,
+                                       std::vector<int> &filtout,
+                                       std::vector<int> &output) {
   if (peakout.size() != filtout.size() || sFGVBout.size() != filtout.size()) {
     edm::LogWarning("EcalTPG")
         << " problem in EcalEBFenixStripFormatEB: sfgvb_out, peak_out and filt_out don't have the same size";

--- a/SimCalorimetry/EcalEBTrigPrimAlgos/src/EcalEBFenixStripFormatEB.cc
+++ b/SimCalorimetry/EcalEBTrigPrimAlgos/src/EcalEBFenixStripFormatEB.cc
@@ -1,44 +1,44 @@
-#include <SimCalorimetry/EcalEBTrigPrimAlgos/interface/EcalFenixStripFormatEB.h>
+#include <SimCalorimetry/EcalEBTrigPrimAlgos/interface/EcalEBFenixStripFormatEB.h>
 #include <CondFormats/EcalObjects/interface/EcalTPGSlidingWindow.h>
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
-EcalFenixStripFormatEB::EcalFenixStripFormatEB() : shift_(0) {}
+EcalEBFenixStripFormatEB::EcalEBFenixStripFormatEB() : shift_(0) {}
 
-EcalFenixStripFormatEB::~EcalFenixStripFormatEB() {}
+EcalEBFenixStripFormatEB::~EcalEBFenixStripFormatEB() {}
 
-int EcalFenixStripFormatEB::setInput(int input, int inputPeak, int inputsFGVB) {
+int EcalEBFenixStripFormatEB::setInput(int input, int inputPeak, int inputsFGVB) {
   inputsFGVB_ = inputsFGVB;
   inputPeak_ = inputPeak;
   input_ = input;
   return 0;
 }
 
-int EcalFenixStripFormatEB::process() {
+int EcalEBFenixStripFormatEB::process() {
   //    buffer_=input_>>shift_;  //FIXME: buffer why?
 
   if (inputPeak_ == 0)
     return ((inputsFGVB_ & 0x1) << 12);
   //    int output=buffer_;
   int output = input_ >> shift_;
-  //std::cout << " EcalFenixStripFormatEB::process() input_ " << input_ << " output after shift " << output << std::endl;
+  //std::cout << " EcalEBFenixStripFormatEB::process() input_ " << input_ << " output after shift " << output << std::endl;
   if (output > 0XFFF)
     output = 0XFFF;  //ok: barrel saturates at 12 bits
   // Add stripFGVB
   output |= ((inputsFGVB_ & 0x1) << 12);
 
-  //std::cout << " EcalFenixStripFormatEB::process()  output after adding FGVB " << output << std::endl;
+  //std::cout << " EcalEBFenixStripFormatEB::process()  output after adding FGVB " << output << std::endl;
   return output;
 }
 
-void EcalFenixStripFormatEB::process(std::vector<int> &sFGVBout,
+void EcalEBFenixStripFormatEB::process(std::vector<int> &sFGVBout,
                                      std::vector<int> &peakout,
                                      std::vector<int> &filtout,
                                      std::vector<int> &output) {
   if (peakout.size() != filtout.size() || sFGVBout.size() != filtout.size()) {
     edm::LogWarning("EcalTPG")
-        << " problem in EcalFenixStripFormatEB: sfgvb_out, peak_out and filt_out don't have the same size";
+        << " problem in EcalEBFenixStripFormatEB: sfgvb_out, peak_out and filt_out don't have the same size";
   }
-  //std::cout << "  EcalFenixStripFormatEB::process(std::vector ... filtout size " << filtout.size() << std::endl;
+  //std::cout << "  EcalEBFenixStripFormatEB::process(std::vector ... filtout size " << filtout.size() << std::endl;
   for (unsigned int i = 0; i < filtout.size(); i++) {
     //std::cout << " Looping over filtout " << filtout[i] << " " << peakout[i] << std::endl;
     setInput(filtout[i], peakout[i], sFGVBout[i]);
@@ -48,7 +48,7 @@ void EcalFenixStripFormatEB::process(std::vector<int> &sFGVBout,
   return;
 }
 
-void EcalFenixStripFormatEB::setParameters(uint32_t &id, const EcalTPGSlidingWindow *&slWin) {
+void EcalEBFenixStripFormatEB::setParameters(uint32_t &id, const EcalTPGSlidingWindow *&slWin) {
   const EcalTPGSlidingWindowMap &slwinmap = slWin->getMap();
   EcalTPGSlidingWindowMapIterator it = slwinmap.find(id);
   if (it != slwinmap.end())

--- a/SimCalorimetry/EcalEBTrigPrimAlgos/src/EcalEBFenixTcpFormat.cc
+++ b/SimCalorimetry/EcalEBTrigPrimAlgos/src/EcalEBFenixTcpFormat.cc
@@ -47,12 +47,12 @@ void EcalEBFenixTcpFormat::process(std::vector<int> &Etin, std::vector<int> &Eto
 }
 
 void EcalEBFenixTcpFormat::process(std::vector<int> &Et,
-                                 std::vector<int> &fgvb,
-                                 std::vector<int> &sfgvb,
-                                 int eTTotShift,
-                                 std::vector<EcalEBTriggerPrimitiveSample> &out,
-                                 std::vector<EcalEBTriggerPrimitiveSample> &out2,
-                                 bool isInInnerRings) {
+                                   std::vector<int> &fgvb,
+                                   std::vector<int> &sfgvb,
+                                   int eTTotShift,
+                                   std::vector<EcalEBTriggerPrimitiveSample> &out,
+                                   std::vector<EcalEBTriggerPrimitiveSample> &out2,
+                                   bool isInInnerRings) {
   // put TP-s in the output
   // on request also in TcpFormat
   // for famos version we have to write dummies except for the middle
@@ -129,10 +129,10 @@ void EcalEBFenixTcpFormat::process(std::vector<int> &Et,
 }
 
 void EcalEBFenixTcpFormat::setParameters(uint32_t towid,
-                                       const EcalTPGLutGroup *ecaltpgLutGroup,
-                                       const EcalTPGLutIdMap *ecaltpgLut,
-                                       const EcalTPGTowerStatus *ecaltpgbadTT,
-                                       const EcalTPGSpike *ecaltpgSpike) {
+                                         const EcalTPGLutGroup *ecaltpgLutGroup,
+                                         const EcalTPGLutIdMap *ecaltpgLut,
+                                         const EcalTPGTowerStatus *ecaltpgbadTT,
+                                         const EcalTPGSpike *ecaltpgSpike) {
   // Get TP zeroing threshold - defaut to 1023 for old data (no record found or EE)
   spikeZeroThresh_ = 1023;
   if (ecaltpgSpike != nullptr) {

--- a/SimCalorimetry/EcalEBTrigPrimAlgos/src/EcalEBFenixTcpFormat.cc
+++ b/SimCalorimetry/EcalEBTrigPrimAlgos/src/EcalEBFenixTcpFormat.cc
@@ -1,4 +1,4 @@
-#include <SimCalorimetry/EcalEBTrigPrimAlgos/interface/EcalFenixTcpFormat.h>
+#include <SimCalorimetry/EcalEBTrigPrimAlgos/interface/EcalEBFenixTcpFormat.h>
 #include "CondFormats/EcalObjects/interface/EcalTPGLutGroup.h"
 #include "CondFormats/EcalObjects/interface/EcalTPGLutIdMap.h"
 #include "CondFormats/EcalObjects/interface/EcalTPGTowerStatus.h"
@@ -8,19 +8,19 @@
 
 using namespace std;
 
-EcalFenixTcpFormat::EcalFenixTcpFormat(bool tcpFormat, bool debug, bool famos, int binOfMax)
+EcalEBFenixTcpFormat::EcalEBFenixTcpFormat(bool tcpFormat, bool debug, bool famos, int binOfMax)
     : tcpFormat_(tcpFormat), debug_(debug), famos_(famos), binOfMax_(binOfMax) {
   status_ = 0;
   badTTStatus_ = &status_;
 }
 
-EcalFenixTcpFormat::~EcalFenixTcpFormat() {}
+EcalEBFenixTcpFormat::~EcalEBFenixTcpFormat() {}
 
-void EcalFenixTcpFormat::process(std::vector<int> &Etin, std::vector<int> &Etout) {
+void EcalEBFenixTcpFormat::process(std::vector<int> &Etin, std::vector<int> &Etout) {
   // put TP-s in the output
   // on request also in TcpFormat
   // for famos version we have to write dummies except for the middle
-  // std::cout << "   EcalFenixTcpFormat::process(... Etout size " << Etout.size() << "  Et size " << Etin.size() << std::endl;
+  // std::cout << "   EcalEBFenixTcpFormat::process(... Etout size " << Etout.size() << "  Et size " << Etin.size() << std::endl;
 
   int myEt;
   int eTTotShift = 2;
@@ -46,7 +46,7 @@ void EcalFenixTcpFormat::process(std::vector<int> &Etin, std::vector<int> &Etout
   }
 }
 
-void EcalFenixTcpFormat::process(std::vector<int> &Et,
+void EcalEBFenixTcpFormat::process(std::vector<int> &Et,
                                  std::vector<int> &fgvb,
                                  std::vector<int> &sfgvb,
                                  int eTTotShift,
@@ -56,7 +56,7 @@ void EcalFenixTcpFormat::process(std::vector<int> &Et,
   // put TP-s in the output
   // on request also in TcpFormat
   // for famos version we have to write dummies except for the middle
-  //std::cout << "   EcalFenixTcpFormat::process(... out size " << out.size() << "  Et size " << Et.size() << " Et[0] " << Et[0] << std::endl;
+  //std::cout << "   EcalEBFenixTcpFormat::process(... out size " << out.size() << "  Et size " << Et.size() << " Et[0] " << Et[0] << std::endl;
 
   int myEt;
   if (famos_) {
@@ -128,7 +128,7 @@ void EcalFenixTcpFormat::process(std::vector<int> &Et,
   }
 }
 
-void EcalFenixTcpFormat::setParameters(uint32_t towid,
+void EcalEBFenixTcpFormat::setParameters(uint32_t towid,
                                        const EcalTPGLutGroup *ecaltpgLutGroup,
                                        const EcalTPGLutIdMap *ecaltpgLut,
                                        const EcalTPGTowerStatus *ecaltpgbadTT,

--- a/SimCalorimetry/EcalEBTrigPrimAlgos/src/EcalEBTrigPrimTestAlgo.cc
+++ b/SimCalorimetry/EcalEBTrigPrimAlgos/src/EcalEBTrigPrimTestAlgo.cc
@@ -39,29 +39,44 @@ const unsigned int EcalEBTrigPrimTestAlgo::nrSamples_ = 5;
 const unsigned int EcalEBTrigPrimTestAlgo::maxNrTowers_ = 2448;
 const unsigned int EcalEBTrigPrimTestAlgo::maxNrSamplesOut_ = 10;
 
-EcalEBTrigPrimTestAlgo::EcalEBTrigPrimTestAlgo(
-    const edm::EventSetup &setup, int nSam, int binofmax, bool tcpFormat, bool barrelOnly, bool debug, bool famos)
-    : nSamples_(nSam),
+// not BarrelOnly
+EcalEBTrigPrimTestAlgo::EcalEBTrigPrimTestAlgo(const EcalTrigTowerConstituentsMap *eTTmap,
+                                               const CaloGeometry *theGeometry,
+                                               int nSam,
+                                               int binofmax,
+                                               bool tcpFormat,
+                                               bool debug,
+                                               bool famos)
+    : eTTmap_(eTTmap),
+      theGeometry_(theGeometry),
+      nSamples_(nSam),
       binOfMaximum_(binofmax),
       tcpFormat_(tcpFormat),
-      barrelOnly_(barrelOnly),
+      barrelOnly_(false),
       debug_(debug),
       famos_(famos)
 
 {
   maxNrSamples_ = 10;
-  this->init(setup);
+  this->init();
+}
+
+//barrel only
+EcalEBTrigPrimTestAlgo::EcalEBTrigPrimTestAlgo(int nSam, int binofmax, bool tcpFormat, bool debug, bool famos)
+    : nSamples_(nSam),
+      binOfMaximum_(binofmax),
+      tcpFormat_(tcpFormat),
+      barrelOnly_(true),
+      debug_(debug),
+      famos_(famos)
+
+{
+  maxNrSamples_ = 10;
+  this->init();
 }
 
 //----------------------------------------------------------------------
-void EcalEBTrigPrimTestAlgo::init(const edm::EventSetup &setup) {
-  if (!barrelOnly_) {
-    //edm::ESHandle<CaloGeometry> theGeometry;
-    //    edm::ESHandle<CaloSubdetectorGeometry> theEndcapGeometry_handle;
-    setup.get<CaloGeometryRecord>().get(theGeometry);
-    setup.get<IdealGeometryRecord>().get(eTTmap_);
-  }
-
+void EcalEBTrigPrimTestAlgo::init() {
   // initialise data structures
   initStructures(towerMapEB_);
   hitTowers_.resize(maxNrTowers_);
@@ -102,8 +117,7 @@ EcalEBTrigPrimTestAlgo::~EcalEBTrigPrimTestAlgo() {
   delete fenixTcpFormat_;
 }
 
-void EcalEBTrigPrimTestAlgo::run(const edm::EventSetup &setup,
-                                 EBDigiCollection const *digi,
+void EcalEBTrigPrimTestAlgo::run(EBDigiCollection const *digi,
                                  EcalEBTrigPrimDigiCollection &result,
                                  EcalEBTrigPrimDigiCollection &resultTcp) {
   //typedef typename Coll::Digi Digi;

--- a/SimCalorimetry/EcalEBTrigPrimAlgos/src/EcalEBTrigPrimTestAlgo.cc
+++ b/SimCalorimetry/EcalEBTrigPrimAlgos/src/EcalEBTrigPrimTestAlgo.cc
@@ -68,7 +68,7 @@ void EcalEBTrigPrimTestAlgo::init(const edm::EventSetup &setup) {
 
   linearizer_.resize(nbMaxXtals_);
   for (int i = 0; i < nbMaxXtals_; i++)
-    linearizer_[i] = new EcalFenixLinearizer(famos_);
+    linearizer_[i] = new EcalEBFenixLinearizer(famos_);
 
   //
   std::vector<int> v;
@@ -77,18 +77,18 @@ void EcalEBTrigPrimTestAlgo::init(const edm::EventSetup &setup) {
   for (int i = 0; i < 5; i++)
     lin_out_[i] = v;
   //
-  amplitude_filter_ = new EcalFenixAmplitudeFilter();
+  amplitude_filter_ = new EcalEBFenixAmplitudeFilter();
   filt_out_.resize(maxNrSamples_);
   peak_out_.resize(maxNrSamples_);
   // these two are dummy
   fgvb_out_.resize(maxNrSamples_);
   fgvb_out_temp_.resize(maxNrSamples_);
   //
-  peak_finder_ = new EcalFenixPeakFinder();
-  fenixFormatterEB_ = new EcalFenixStripFormatEB();
+  peak_finder_ = new EcalEBFenixPeakFinder();
+  fenixFormatterEB_ = new EcalEBFenixStripFormatEB();
   format_out_.resize(maxNrSamples_);
   //
-  fenixTcpFormat_ = new EcalFenixTcpFormat(tcpFormat_, debug_, famos_, binOfMaximum_);
+  fenixTcpFormat_ = new EcalEBFenixTcpFormat(tcpFormat_, debug_, famos_, binOfMaximum_);
   tcpformat_out_.resize(maxNrSamples_);
 }
 //----------------------------------------------------------------------

--- a/SimCalorimetry/EcalEBTrigPrimProducers/plugins/EcalEBTrigPrimProducer.h
+++ b/SimCalorimetry/EcalEBTrigPrimProducers/plugins/EcalEBTrigPrimProducer.h
@@ -39,6 +39,9 @@
 #include "CondFormats/EcalObjects/interface/EcalTPGWeightIdMap.h"
 #include "CondFormats/EcalObjects/interface/EcalTPGWeightGroup.h"
 #include "CondFormats/EcalObjects/interface/EcalTPGTowerStatus.h"
+#include "Geometry/CaloGeometry/interface/CaloGeometry.h"
+#include "Geometry/CaloTopology/interface/EcalTrigTowerConstituentsMap.h"
+#include "Geometry/Records/interface/CaloGeometryRecord.h"
 
 class EcalEBTrigPrimTestAlgo;
 
@@ -72,6 +75,9 @@ private:
   edm::ESGetToken<EcalTPGLutIdMap, EcalTPGLutIdMapRcd> theEcalTPGLutIdMap_Token_;
   edm::ESGetToken<EcalTPGTowerStatus, EcalTPGTowerStatusRcd> theEcalTPGTowerStatus_Token_;
   edm::ESGetToken<EcalTPGSpike, EcalTPGSpikeRcd> theEcalTPGSpike_Token_;
+  //these are only used if we also handle the endcap
+  edm::ESGetToken<EcalTrigTowerConstituentsMap, IdealGeometryRecord> eTTmapToken_;
+  edm::ESGetToken<CaloGeometry, CaloGeometryRecord> theGeometryToken_;
 
   int binOfMaximum_;
   bool fillBinOfMaximumFromHistory_;


### PR DESCRIPTION
#### PR description:

This PR renames the EcalFenix classes used in the Phase 2 ECAL TP implementation to distinguish them from the Phase 1 TP classes. The classes are renamed to EcalEBFenix* to follow the package name they are in.

While running the matrix tests for PR #33349 the Phase 2 WF showed differences to the baseline. It was noticed that the Phase 1 EcalFenix headers in `SimCalorimetry/EcalTrigPrimAlgos` and the Phase 2 EcalFenix headers in `SimCalorimetry/EcalEBTrigPrimAlgos` were previously identical, including the include guards.
With the changes to the Phase 1 TP emulator in PR #33349 the Phase 2 functions were used in some WFs in the Phase 1 code instead of the Phase 1 ones, leading to failing tests for Phase 2 WFs.

#### PR validation:

Passes Phase 2 WF 23234.0 matrix test.
