### PR TITLE
Changing the proton propagator to the Optical Function method

### DIFF
--- a/SimPPS/Configuration/test/gluglu_step1_GEN_SIM_2021.py
+++ b/SimPPS/Configuration/test/gluglu_step1_GEN_SIM_2021.py
@@ -7,7 +7,6 @@ from Configuration.StandardSequences.Eras import eras
 process = cms.Process('SIM',eras.Run3)
 
 # import of standard configurations
-process.load("CondCore.CondDB.CondDB_cfi")
 process.load('Configuration.StandardSequences.Services_cff')
 process.load('SimGeneral.HepPDTESSource.pythiapdt_cfi')
 process.load('FWCore.MessageService.MessageLogger_cfi')
@@ -19,8 +18,7 @@ process.load('GeneratorInterface.Core.genFilterSummary_cff')
 process.load('Configuration.StandardSequences.SimIdeal_cff')
 process.load('Configuration.StandardSequences.EndOfProcess_cff')
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
-
-process.load('Configuration.Geometry.GeometryExtended2021_cff')
+process.load('Configuration.StandardSequences.GeometrySimDB_cff')
 
 process.RandomNumberGeneratorService.generator.initialSeed = cms.untracked.uint32(random.randint(0,900000000))
 
@@ -33,38 +31,32 @@ process.maxEvents = cms.untracked.PSet(
         )
 
 process.source = cms.Source("EmptySource")
-"""
-process.source = cms.Source("EmptySource",
-                firstRun = cms.untracked.uint32(324612),               #2018D
-                firstTime = cms.untracked.uint64(6612348794983940096)  
-)
-"""
+
 from Configuration.AlCa.GlobalTag import GlobalTag
-process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase1_2021_realistic', '')
-#process.GlobalTag = GlobalTag(process.GlobalTag, "106X_dataRun2_v26")
+#process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase1_2021_realistic', '')
+#process.GlobalTag = GlobalTag(process.GlobalTag, "113X_mcRun3_2021_realistic_Candidate_2021_04_09_15_03_03")
+process.GlobalTag = GlobalTag(process.GlobalTag, "113X_mcRun3_2021_realistic_Candidate_2021_04_06_19_59_53")
 
 # generator
-
-
 process.generator = cms.EDFilter("ExhumeGeneratorFilter",
     ExhumeParameters = cms.PSet(
         AlphaEw = cms.double(0.0072974),
         B = cms.double(4.0),
-        BottomMass = cms.double(4.6),
-        CharmMass = cms.double(1.42),
-        HiggsMass = cms.double(120.0),
+        MuonMass = cms.double(0.1057),
+        BottomMass = cms.double(4.65),
+        CharmMass = cms.double(1.28),
+        StrangeMass = cms.double(0.095),
+        TauMass = cms.double(1.78),
+        TopMass = cms.double(172.8),
+        WMass = cms.double(80.38),
+        ZMass = cms.double(91.187),
+        HiggsMass = cms.double(125.1),
         HiggsVev = cms.double(246.0),
         LambdaQCD = cms.double(80.0),
         MinQt2 = cms.double(0.64),
-        MuonMass = cms.double(0.1057),
         PDF = cms.double(11000),
         Rg = cms.double(1.2),
-        StrangeMass = cms.double(0.19),
-        Survive = cms.double(0.03),
-        TauMass = cms.double(1.77),
-        TopMass = cms.double(175.0),
-        WMass = cms.double(80.33),
-        ZMass = cms.double(91.187)
+        Survive = cms.double(0.03)
     ),
     ExhumeProcess = cms.PSet(
         MassRangeHigh = cms.double(2000.0),
@@ -75,7 +67,7 @@ process.generator = cms.EDFilter("ExhumeGeneratorFilter",
     PythiaParameters = cms.PSet(
         parameterSets = cms.vstring()
     ),
-    comEnergy = cms.double(13000.0),
+    comEnergy = cms.double(14000.0),
     maxEventsToPrint = cms.untracked.int32(2),
     pythiaHepMCVerbosity = cms.untracked.bool(False),
     pythiaPylistVerbosity = cms.untracked.int32(1)
@@ -88,7 +80,6 @@ process.configurationMetadata = cms.untracked.PSet(
     version = cms.untracked.string('$Revision: 1.19 $')
 )
 
-
 process.ProductionFilterSequence = cms.Sequence(process.generator)
 
 ############
@@ -99,7 +90,6 @@ process.o1 = cms.OutputModule("PoolOutputModule",
 
 process.generation_step = cms.Path(process.pgen)
 process.simulation_step = cms.Path(process.psim)
-
 
 process.genfiltersummary_step = cms.EndPath(process.genFilterSummary)
 process.outpath = cms.EndPath(process.o1)

--- a/SimPPS/Configuration/test/gluglu_step1_GEN_SIM_2021.py
+++ b/SimPPS/Configuration/test/gluglu_step1_GEN_SIM_2021.py
@@ -33,9 +33,7 @@ process.maxEvents = cms.untracked.PSet(
 process.source = cms.Source("EmptySource")
 
 from Configuration.AlCa.GlobalTag import GlobalTag
-#process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase1_2021_realistic', '')
-#process.GlobalTag = GlobalTag(process.GlobalTag, "113X_mcRun3_2021_realistic_Candidate_2021_04_09_15_03_03")
-process.GlobalTag = GlobalTag(process.GlobalTag, "113X_mcRun3_2021_realistic_Candidate_2021_04_06_19_59_53")
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase1_2021_realistic', '')
 
 # generator
 process.generator = cms.EDFilter("ExhumeGeneratorFilter",

--- a/SimPPS/Configuration/test/gluglu_step2_DIGI_DIGI2RAW_2021.py
+++ b/SimPPS/Configuration/test/gluglu_step2_DIGI_DIGI2RAW_2021.py
@@ -65,8 +65,8 @@ process.FEVTDEBUGoutput = cms.OutputModule("PoolOutputModule",
         filterName = cms.untracked.string('')
     ),
     eventAutoFlushCompressedSize = cms.untracked.int32(5242880),
-    fileName = cms.untracked.string('GluGlu_step2_DIGI_DIGI2RAW2021.root'),
-    outputCommands = process.FEVTDEBUGEventContent.outputCommands + ['keep *_CTPPS*_*_*',"keep *_*RP*_*_*",'keep *_LHCTransport_*_*'],
+    fileName = cms.untracked.string('GluGlu_step2_DIGI_DIGI2RAW_2021.root'),
+    outputCommands = process.FEVTDEBUGEventContent.outputCommands + ['keep *_CTPPS*_*_*',"keep *_*RP*_*_*",'keep *_generatorSmeared_*_*'],
     splitLevel = cms.untracked.int32(0)
 )
 
@@ -74,9 +74,7 @@ process.FEVTDEBUGoutput = cms.OutputModule("PoolOutputModule",
 
 # Other statements
 from Configuration.AlCa.GlobalTag import GlobalTag
-process.GlobalTag = GlobalTag(process.GlobalTag, '113X_mcRun3_2021_realistic_Candidate_2021_04_09_15_03_03', '')
-process.GlobalTag = GlobalTag(process.GlobalTag, "113X_mcRun3_2021_realistic_Candidate_2021_04_06_19_59_53")
-#process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase1_2021_realistic', '')
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase1_2021_realistic', '')
 
 
 # Path and EndPath definitions

--- a/SimPPS/Configuration/test/gluglu_step2_DIGI_DIGI2RAW_2021.py
+++ b/SimPPS/Configuration/test/gluglu_step2_DIGI_DIGI2RAW_2021.py
@@ -8,9 +8,8 @@ from Configuration.StandardSequences.Eras import eras
 process = cms.Process('DIGI2RAW',eras.Run3)
 
 # import of standard configurations
-process.load("CondCore.CondDB.CondDB_cfi")
 process.load('Configuration.StandardSequences.Services_cff')
-process.load('SimGeneral.HepPDTESSource.pythiapdt_cfi')
+#process.load('SimGeneral.HepPDTESSource.pythiapdt_cfi')
 process.load('FWCore.MessageService.MessageLogger_cfi')
 process.load('Configuration.EventContent.EventContent_cff')
 process.load('Configuration.StandardSequences.MagneticField_cff')
@@ -20,11 +19,7 @@ process.load('Configuration.StandardSequences.SimL1Emulator_cff')
 process.load('Configuration.StandardSequences.DigiToRaw_cff')
 process.load('Configuration.StandardSequences.EndOfProcess_cff')
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
-
-# Since the PPS simulation geometry is not yet in the database, the line below is needed
 process.load('Configuration.StandardSequences.GeometryDB_cff')
-#process.load("Geometry.VeryForwardGeometry.geometryPPS_CMSxz_fromDD_2021_cfi")
-process.load("Geometry.VeryForwardGeometry.geometryRPFromDB_cfi")
 
 # Input source
 process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(-1))
@@ -79,8 +74,9 @@ process.FEVTDEBUGoutput = cms.OutputModule("PoolOutputModule",
 
 # Other statements
 from Configuration.AlCa.GlobalTag import GlobalTag
-#process.GlobalTag = GlobalTag(process.GlobalTag, '111X_mcRun3_2021_realistic_Candidate_2020_06_03_17_55_10', '')
-process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase1_2021_realistic', '')
+process.GlobalTag = GlobalTag(process.GlobalTag, '113X_mcRun3_2021_realistic_Candidate_2021_04_09_15_03_03', '')
+process.GlobalTag = GlobalTag(process.GlobalTag, "113X_mcRun3_2021_realistic_Candidate_2021_04_06_19_59_53")
+#process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase1_2021_realistic', '')
 
 
 # Path and EndPath definitions

--- a/SimPPS/Configuration/test/gluglu_step3_RAW2DIGI_L1Reco_RECO_2021.py
+++ b/SimPPS/Configuration/test/gluglu_step3_RAW2DIGI_L1Reco_RECO_2021.py
@@ -16,8 +16,6 @@ process.load('Configuration.StandardSequences.RawToDigi_cff')
 process.load('Configuration.StandardSequences.Reconstruction_cff')
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 process.load('Configuration.StandardSequences.GeometryDB_cff')
-process.load("Geometry.VeryForwardGeometry.geometryPPS_CMSxz_fromDD_2018_cfi")           # CMS frame
-process.load('CalibPPS.ESProducers.ppsPixelTopologyESSourceRun2_cfi')          # temporary solution, the 2021 geometry is the same as run2, force the usage of run2 topology 
 
 
 process.maxEvents = cms.untracked.PSet(
@@ -26,7 +24,7 @@ process.maxEvents = cms.untracked.PSet(
 
 # Input source
 process.source = cms.Source("PoolSource",
-    fileNames = cms.untracked.vstring('file:GluGlu_step2_DIGI_DIGI2RAW2021.root'),
+    fileNames = cms.untracked.vstring('file:GluGlu_step2_DIGI_DIGI2RAW_2021.root'),
     secondaryFileNames = cms.untracked.vstring()
 )
 
@@ -41,15 +39,13 @@ process.options = cms.untracked.PSet(
 
 process.output = cms.OutputModule("PoolOutputModule",
     fileName = cms.untracked.string('GluGlu_step3_RAW2DIGI_RECO_2021.root'),
-    outputCommands = cms.untracked.vstring("drop *","keep SimVertexs_g4SimHits_*_*","keep PSimHits*_*_*_*","keep CTPPS*_*_*_*","keep *_*RP*_*_*",'keep *_LHCTransport_*_*')
+    outputCommands = cms.untracked.vstring("drop *","keep SimVertexs_g4SimHits_*_*","keep PSimHits*_*_*_*","keep CTPPS*_*_*_*","keep *_*RP*_*_*",'keep *_generatorSmeared_*_*')
 )
 
 # Additional output definition
 # Other statements
 from Configuration.AlCa.GlobalTag import GlobalTag
-#process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase1_2021_realistic', '')
-#process.GlobalTag = GlobalTag(process.GlobalTag, '113X_mcRun3_2021_realistic_Candidate_2021_04_09_15_03_03', '')
-process.GlobalTag = GlobalTag(process.GlobalTag, "113X_mcRun3_2021_realistic_Candidate_2021_04_06_19_59_53")
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase1_2021_realistic', '')
 
 # Path and EndPath definitions
 process.raw2digi_step = cms.Path(process.RawToDigi)

--- a/SimPPS/Configuration/test/gluglu_step3_RAW2DIGI_L1Reco_RECO_2021.py
+++ b/SimPPS/Configuration/test/gluglu_step3_RAW2DIGI_L1Reco_RECO_2021.py
@@ -12,21 +12,16 @@ process.load('FWCore.MessageService.MessageLogger_cfi')
 process.load("Configuration.EventContent.EventContent_cff")
 process.load('Configuration.StandardSequences.MagneticField_cff')
 process.load('Configuration.StandardSequences.EndOfProcess_cff')
+process.load('Configuration.StandardSequences.RawToDigi_cff')
+process.load('Configuration.StandardSequences.Reconstruction_cff')
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 process.load('Configuration.StandardSequences.GeometryDB_cff')
-process.load("Geometry.VeryForwardGeometry.geometryRPFromDB_cfi")
-#process.load("Geometry.VeryForwardGeometry.geometryPPS_CMSxz_fromDD_2021_cfi")           # CMS frame
+process.load("Geometry.VeryForwardGeometry.geometryPPS_CMSxz_fromDD_2018_cfi")           # CMS frame
+process.load('CalibPPS.ESProducers.ppsPixelTopologyESSourceRun2_cfi')          # temporary solution, the 2021 geometry is the same as run2, force the usage of run2 topology 
 
 
 process.maxEvents = cms.untracked.PSet(
     input = cms.untracked.int32(-1)
-)
-
-process.source = cms.Source("EmptyIOVSource",
-    timetype = cms.string('runnumber'),
-    firstValue = cms.uint64(1),
-    lastValue = cms.uint64(1),
-    interval = cms.uint64(1)
 )
 
 # Input source
@@ -45,31 +40,20 @@ process.options = cms.untracked.PSet(
 # Output definition
 
 process.output = cms.OutputModule("PoolOutputModule",
-    fileName = cms.untracked.string('GluGlu_step3_RAW2DIGI_RECO2021.root'),
+    fileName = cms.untracked.string('GluGlu_step3_RAW2DIGI_RECO_2021.root'),
     outputCommands = cms.untracked.vstring("drop *","keep SimVertexs_g4SimHits_*_*","keep PSimHits*_*_*_*","keep CTPPS*_*_*_*","keep *_*RP*_*_*",'keep *_LHCTransport_*_*')
 )
-
 
 # Additional output definition
 # Other statements
 from Configuration.AlCa.GlobalTag import GlobalTag
-process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase1_2021_realistic', '')
-
-# modify CTPPS 2018 raw-to-digi modules ONLY FOR PARTICLE GUN, TO AVOID RUN THIS FOR THE WHOLE CMS
-process.load('Configuration.StandardSequences.RawToDigi_cff')
-             
-# do not make testID for simulation - keeping the frame
-from EventFilter.CTPPSRawToDigi.totemRPRawToDigi_cfi import totemRPRawToDigi
-totemRPRawToDigi.RawToDigi.testID = cms.uint32(1)
-
-from RecoPPS.Local.totemRPLocalReconstruction_cff import totemRPLocalReconstruction
-process.load('RecoPPS.Local.totemRPLocalReconstruction_cff')
-from RecoPPS.Local.ctppsPixelLocalReconstruction_cff import ctppsPixelLocalReconstruction
-process.load('RecoPPS.Local.ctppsPixelLocalReconstruction_cff')
+#process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase1_2021_realistic', '')
+#process.GlobalTag = GlobalTag(process.GlobalTag, '113X_mcRun3_2021_realistic_Candidate_2021_04_09_15_03_03', '')
+process.GlobalTag = GlobalTag(process.GlobalTag, "113X_mcRun3_2021_realistic_Candidate_2021_04_06_19_59_53")
 
 # Path and EndPath definitions
-process.raw2digi_step = cms.Path(process.ctppsRawToDigi)
-process.reco_step = cms.Path(process.totemRPLocalReconstruction*process.ctppsPixelLocalReconstruction)
+process.raw2digi_step = cms.Path(process.RawToDigi)
+process.reco_step = cms.Path(process.reconstruction)
 process.endjob_step = cms.EndPath(process.endOfProcess)
 process.output_step = cms.EndPath(process.output)
 
@@ -80,4 +64,3 @@ process.schedule = cms.Schedule(process.raw2digi_step,process.reco_step,process.
 for path in process.paths:
     #  getattr(process,path)._seq = process.ProductionFilterSequence * getattr(process,path)._seq
     getattr(process,path)._seq = getattr(process,path)._seq
-

--- a/SimPPS/Configuration/test/pg_step1_GEN_SIM_2021.py
+++ b/SimPPS/Configuration/test/pg_step1_GEN_SIM_2021.py
@@ -7,7 +7,6 @@ from Configuration.StandardSequences.Eras import eras
 process = cms.Process('SIM',eras.Run3)
 
 # import of standard configurations
-process.load("CondCore.CondDB.CondDB_cfi")
 process.load('Configuration.StandardSequences.Services_cff')
 process.load('SimGeneral.HepPDTESSource.pythiapdt_cfi')
 process.load('FWCore.MessageService.MessageLogger_cfi')
@@ -19,8 +18,7 @@ process.load('GeneratorInterface.Core.genFilterSummary_cff')
 process.load('Configuration.StandardSequences.SimIdeal_cff')
 process.load('Configuration.StandardSequences.EndOfProcess_cff')
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
-
-process.load('Configuration.Geometry.GeometryExtended2021_cff')
+process.load('Configuration.StandardSequences.GeometrySimDB_cff')
 
 process.RandomNumberGeneratorService.generator.initialSeed = cms.untracked.uint32(random.randint(0,900000000))
 
@@ -33,16 +31,9 @@ process.maxEvents = cms.untracked.PSet(
         )
 
 process.source = cms.Source("EmptySource")
-"""
-process.source = cms.Source("EmptySource",
-                firstRun = cms.untracked.uint32(324612),               #2018D
-                firstTime = cms.untracked.uint64(6612348794983940096)  
-)
-"""
 from Configuration.AlCa.GlobalTag import GlobalTag
-process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase1_2021_realistic', '')
-#process.GlobalTag = GlobalTag(process.GlobalTag, "106X_dataRun2_v26")
-
+#process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase1_2021_realistic', '')
+process.GlobalTag = GlobalTag(process.GlobalTag, '113X_mcRun3_2021_realistic_Candidate_2021_04_06_19_59_53', '')
 # generator
 
 phi_min = -math.pi
@@ -51,7 +42,7 @@ t_min   = 0.
 t_max   = 2.
 xi_min  = 0.03
 xi_max  = 0.15
-ecms = 13000.
+ecms = 14000. # ATTENTION: if using HECTOR propagator, currently the energy is hardcoded as 6500 but the optics file is prepared for 7 TeV
 
 process.generator = cms.EDProducer("RandomtXiGunProducer",
         PGunParameters = cms.PSet(
@@ -90,4 +81,3 @@ process.schedule = cms.Schedule(process.generation_step,process.genfiltersummary
 # filter all path with the production filter sequence
 for path in process.paths:
     getattr(process,path)._seq = process.ProductionFilterSequence * getattr(process,path)._seq
-

--- a/SimPPS/Configuration/test/pg_step1_GEN_SIM_2021.py
+++ b/SimPPS/Configuration/test/pg_step1_GEN_SIM_2021.py
@@ -32,16 +32,28 @@ process.maxEvents = cms.untracked.PSet(
 
 process.source = cms.Source("EmptySource")
 from Configuration.AlCa.GlobalTag import GlobalTag
-#process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase1_2021_realistic', '')
-process.GlobalTag = GlobalTag(process.GlobalTag, '113X_mcRun3_2021_realistic_Candidate_2021_04_06_19_59_53', '')
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase1_2021_realistic', '')
+#process.GlobalTag = GlobalTag(process.GlobalTag, '113X_mcRun3_2021_realistic_Candidate_2021_04_06_19_59_53', '')
 # generator
+"""
+process.GlobalTag.toGet = cms.VPSet(
+                 cms.PSet(
+                     record = cms.string('LHCInfoRcd'),
+                     tag = cms.string("LHCInfo_2021_mc_v1")
+                 ),
+                 cms.PSet(
+                     record = cms.string('CTPPSOpticsRcd'),
+                     tag = cms.string("PPSOpticalFunctions_2021_mc_v1")
+                 )
+     )
+"""
 
 phi_min = -math.pi
 phi_max = math.pi
 t_min   = 0.
 t_max   = 2.
-xi_min  = 0.03
-xi_max  = 0.15
+xi_min  = 0.02
+xi_max  = 0.20
 ecms = 14000. # ATTENTION: if using HECTOR propagator, currently the energy is hardcoded as 6500 but the optics file is prepared for 7 TeV
 
 process.generator = cms.EDProducer("RandomtXiGunProducer",

--- a/SimPPS/Configuration/test/pg_step2_DIGI_DIGI2RAW_2021.py
+++ b/SimPPS/Configuration/test/pg_step2_DIGI_DIGI2RAW_2021.py
@@ -8,9 +8,8 @@ from Configuration.StandardSequences.Eras import eras
 process = cms.Process('DIGI2RAW',eras.Run3)
 
 # import of standard configurations
-process.load("CondCore.CondDB.CondDB_cfi")
 process.load('Configuration.StandardSequences.Services_cff')
-process.load('SimGeneral.HepPDTESSource.pythiapdt_cfi')
+#process.load('SimGeneral.HepPDTESSource.pythiapdt_cfi')
 process.load('FWCore.MessageService.MessageLogger_cfi')
 process.load('Configuration.EventContent.EventContent_cff')
 process.load('Configuration.StandardSequences.MagneticField_cff')
@@ -20,11 +19,10 @@ process.load('Configuration.StandardSequences.SimL1Emulator_cff')
 process.load('Configuration.StandardSequences.DigiToRaw_cff')
 process.load('Configuration.StandardSequences.EndOfProcess_cff')
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+process.load('Configuration.StandardSequences.GeometryDB_cff')
 
 # Since the PPS simulation geometry is not yet in the database, the line below is needed
-process.load('Configuration.StandardSequences.GeometryDB_cff')
 #process.load("Geometry.VeryForwardGeometry.geometryPPS_CMSxz_fromDD_2021_cfi")
-process.load("Geometry.VeryForwardGeometry.geometryRPFromDB_cfi")
 
 # Input source
 process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(-1))
@@ -79,8 +77,8 @@ process.FEVTDEBUGoutput = cms.OutputModule("PoolOutputModule",
 
 # Other statements
 from Configuration.AlCa.GlobalTag import GlobalTag
-#process.GlobalTag = GlobalTag(process.GlobalTag, '111X_mcRun3_2021_realistic_Candidate_2020_06_03_17_55_10', '')
-process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase1_2021_realistic', '')
+process.GlobalTag = GlobalTag(process.GlobalTag, '113X_mcRun3_2021_realistic_Candidate_2021_04_06_19_59_53', '')
+#process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase1_2021_realistic', '')
 
 
 # Path and EndPath definitions

--- a/SimPPS/Configuration/test/pg_step2_DIGI_DIGI2RAW_2021.py
+++ b/SimPPS/Configuration/test/pg_step2_DIGI_DIGI2RAW_2021.py
@@ -69,7 +69,7 @@ process.FEVTDEBUGoutput = cms.OutputModule("PoolOutputModule",
     ),
     eventAutoFlushCompressedSize = cms.untracked.int32(5242880),
     fileName = cms.untracked.string('step2_DIGI_DIGI2RAW2021.root'),
-    outputCommands = process.FEVTDEBUGEventContent.outputCommands + ['keep *_CTPPS*_*_*',"keep *_*RP*_*_*",'keep *_LHCTransport_*_*'],
+    outputCommands = process.FEVTDEBUGEventContent.outputCommands + ['keep *_CTPPS*_*_*',"keep *_*RP*_*_*",'keep *_generatorSmeared_*_*'],
     splitLevel = cms.untracked.int32(0)
 )
 
@@ -77,8 +77,8 @@ process.FEVTDEBUGoutput = cms.OutputModule("PoolOutputModule",
 
 # Other statements
 from Configuration.AlCa.GlobalTag import GlobalTag
-process.GlobalTag = GlobalTag(process.GlobalTag, '113X_mcRun3_2021_realistic_Candidate_2021_04_06_19_59_53', '')
-#process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase1_2021_realistic', '')
+#process.GlobalTag = GlobalTag(process.GlobalTag, '113X_mcRun3_2021_realistic_Candidate_2021_04_06_19_59_53', '')
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase1_2021_realistic', '')
 
 
 # Path and EndPath definitions

--- a/SimPPS/Configuration/test/pg_step3_MCDB_RAW2DIGI_RECO_2021.py
+++ b/SimPPS/Configuration/test/pg_step3_MCDB_RAW2DIGI_RECO_2021.py
@@ -13,20 +13,15 @@ process.load("Configuration.EventContent.EventContent_cff")
 process.load('Configuration.StandardSequences.MagneticField_cff')
 process.load('Configuration.StandardSequences.EndOfProcess_cff')
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+process.load('Configuration.StandardSequences.RawToDigi_cff')
+process.load('Configuration.StandardSequences.Reconstruction_cff')
 process.load('Configuration.StandardSequences.GeometryDB_cff')
-process.load("Geometry.VeryForwardGeometry.geometryRPFromDB_cfi")
-#process.load("Geometry.VeryForwardGeometry.geometryPPS_CMSxz_fromDD_2021_cfi")           # CMS frame
-
+#process.load("Geometry.VeryForwardGeometry.geometryRPFromDB_cfi")
+process.load("Geometry.VeryForwardGeometry.geometryPPS_CMSxz_fromDD_2018_cfi") # CMS frame, 2021 = 2018
+process.load('CalibPPS.ESProducers.ppsPixelTopologyESSourceRun2_cfi')          # temporary solution, the 2021 geometry is the same as run2, force the usage of run2 topology 
 
 process.maxEvents = cms.untracked.PSet(
     input = cms.untracked.int32(-1)
-)
-
-process.source = cms.Source("EmptyIOVSource",
-    timetype = cms.string('runnumber'),
-    firstValue = cms.uint64(1),
-    lastValue = cms.uint64(1),
-    interval = cms.uint64(1)
 )
 
 # Input source
@@ -53,23 +48,14 @@ process.output = cms.OutputModule("PoolOutputModule",
 # Additional output definition
 # Other statements
 from Configuration.AlCa.GlobalTag import GlobalTag
-process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase1_2021_realistic', '')
-
-# modify CTPPS 2018 raw-to-digi modules ONLY FOR PARTICLE GUN, TO AVOID RUN THIS FOR THE WHOLE CMS
-process.load('Configuration.StandardSequences.RawToDigi_cff')
-             
-# do not make testID for simulation - keeping the frame
-from EventFilter.CTPPSRawToDigi.totemRPRawToDigi_cfi import totemRPRawToDigi
-totemRPRawToDigi.RawToDigi.testID = cms.uint32(1)
-
-from RecoPPS.Local.totemRPLocalReconstruction_cff import totemRPLocalReconstruction
-process.load('RecoPPS.Local.totemRPLocalReconstruction_cff')
-from RecoPPS.Local.ctppsPixelLocalReconstruction_cff import ctppsPixelLocalReconstruction
-process.load('RecoPPS.Local.ctppsPixelLocalReconstruction_cff')
+#process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase1_2021_realistic', '')
+process.GlobalTag = GlobalTag(process.GlobalTag, '113X_mcRun3_2021_realistic_Candidate_2021_04_06_19_59_53', '')
 
 # Path and EndPath definitions
-process.raw2digi_step = cms.Path(process.ctppsRawToDigi)
-process.reco_step = cms.Path(process.totemRPLocalReconstruction*process.ctppsPixelLocalReconstruction)
+#process.raw2digi_step = cms.Path(process.RawToDigi)
+#process.reco_step = cms.Path(process.reconstruction)
+process.raw2digi_step = cms.Path(process.ctppsRawToDigi) # to avoid full CMS digitization
+process.reco_step = cms.Path(process.totemRPLocalReconstruction*process.ctppsPixelLocalReconstruction) # to avoid full CMS reconstruction
 process.endjob_step = cms.EndPath(process.endOfProcess)
 process.output_step = cms.EndPath(process.output)
 
@@ -80,4 +66,3 @@ process.schedule = cms.Schedule(process.raw2digi_step,process.reco_step,process.
 for path in process.paths:
     #  getattr(process,path)._seq = process.ProductionFilterSequence * getattr(process,path)._seq
     getattr(process,path)._seq = getattr(process,path)._seq
-

--- a/SimPPS/Configuration/test/pg_step3_MCDB_RAW2DIGI_RECO_2021.py
+++ b/SimPPS/Configuration/test/pg_step3_MCDB_RAW2DIGI_RECO_2021.py
@@ -17,8 +17,8 @@ process.load('Configuration.StandardSequences.RawToDigi_cff')
 process.load('Configuration.StandardSequences.Reconstruction_cff')
 process.load('Configuration.StandardSequences.GeometryDB_cff')
 #process.load("Geometry.VeryForwardGeometry.geometryRPFromDB_cfi")
-process.load("Geometry.VeryForwardGeometry.geometryPPS_CMSxz_fromDD_2018_cfi") # CMS frame, 2021 = 2018
-process.load('CalibPPS.ESProducers.ppsPixelTopologyESSourceRun2_cfi')          # temporary solution, the 2021 geometry is the same as run2, force the usage of run2 topology 
+#process.load("Geometry.VeryForwardGeometry.geometryPPS_CMSxz_fromDD_2018_cfi") # CMS frame, 2021 = 2018
+#process.load('CalibPPS.ESProducers.ppsPixelTopologyESSourceRun2_cfi')          # temporary solution, the 2021 geometry is the same as run2, force the usage of run2 topology 
 
 process.maxEvents = cms.untracked.PSet(
     input = cms.untracked.int32(-1)
@@ -41,15 +41,15 @@ process.options = cms.untracked.PSet(
 
 process.output = cms.OutputModule("PoolOutputModule",
     fileName = cms.untracked.string('step3_RAW2DIGI_RECO2021.root'),
-    outputCommands = cms.untracked.vstring("drop *","keep SimVertexs_g4SimHits_*_*","keep PSimHits*_*_*_*","keep CTPPS*_*_*_*","keep *_*RP*_*_*",'keep *_LHCTransport_*_*')
+    outputCommands = cms.untracked.vstring("drop *","keep SimVertexs_g4SimHits_*_*","keep PSimHits*_*_*_*","keep CTPPS*_*_*_*","keep *_*RP*_*_*",'keep *_generatorSmeared_*_*')
 )
 
 
 # Additional output definition
 # Other statements
 from Configuration.AlCa.GlobalTag import GlobalTag
-#process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase1_2021_realistic', '')
-process.GlobalTag = GlobalTag(process.GlobalTag, '113X_mcRun3_2021_realistic_Candidate_2021_04_06_19_59_53', '')
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase1_2021_realistic', '')
+#process.GlobalTag = GlobalTag(process.GlobalTag, '113X_mcRun3_2021_realistic_Candidate_2021_04_06_19_59_53', '')
 
 # Path and EndPath definitions
 #process.raw2digi_step = cms.Path(process.RawToDigi)

--- a/SimTransport/PPSProtonTransport/python/OpticalFunctionsConfig_cfi.py
+++ b/SimTransport/PPSProtonTransport/python/OpticalFunctionsConfig_cfi.py
@@ -125,6 +125,29 @@ _config_2018 = cms.PSet(
   )
 )
 
+_config_2021 = cms.PSet(
+  opticalFunctionConfig = cms.PSet(
+          es_source = cms.PSet(
+                  validityRange = cms.EventRange("0:min - 999999:max"),
+                  opticalFunctions = cms.VPSet(
+                          cms.PSet( xangle = cms.double(110.444), fileName = cms.FileInPath("CalibPPS/ESProducers/data/optical_functions/2021/version_pre3/110.444urad.root") ),
+                          cms.PSet( xangle = cms.double(184.017), fileName = cms.FileInPath("CalibPPS/ESProducers/data/optical_functions/2021/version_pre3/184.017urad.root") )
+                  )
+          ),
+          defaultCrossingAngle = cms.double(0.0)
+  ),
+  optics_parameters = cms.PSet(
+         empiricalAperture45_xi0_int = cms.double(0.079),
+          empiricalAperture45_xi0_slp = cms.double(4.211E-04),
+          empiricalAperture45_a_int = cms.double(42.8),
+          empiricalAperture45_a_slp = cms.double(0.669),
+          empiricalAperture56_xi0_int = cms.double(0.074),
+          empiricalAperture56_xi0_slp = cms.double(6.604E-04),
+          empiricalAperture56_a_int = cms.double(-22.7),
+          empiricalAperture56_a_slp = cms.double(1.600)
+  )
+)
+
 _opticalfunctionsTransportSetup_2016_preTS2 =cms.PSet(
                 opticalFunctionConfig = _config_2016_preTS2.opticalFunctionConfig,
                 optics_parameters =  cms.PSet(_baseOpticalFunctionsParameters,_config_2016_preTS2.optics_parameters)
@@ -146,11 +169,17 @@ _opticalfunctionsTransportSetup_2017_postTS2 =cms.PSet(
 )
 
 opticalfunctionsTransportSetup_2018 =cms.PSet(
-                opticalFunctionConfig = _config_2018.opticalFunctionConfig,
-                optics_parameters = cms.PSet(_baseOpticalFunctionsParameters, _config_2018.optics_parameters)
+                _baseOpticalFunctionsParameters,
+                _config_2018.opticalFunctionConfig,
+                _config_2018.optics_parameters
+)
+
+opticalfunctionsTransportSetup_2021 =cms.PSet(
+                _baseOpticalFunctionsParameters,
+                _config_2021.opticalFunctionConfig,
+                _config_2021.optics_parameters
 )
 
 # Default setup
 opticalfunctionsTransportSetup_2016 = _opticalfunctionsTransportSetup_2016_preTS2.clone()
 opticalfunctionsTransportSetup_2017 = _opticalfunctionsTransportSetup_2017_preTS2.clone()
-opticalfunctionsTransportSetup_2021 = opticalfunctionsTransportSetup_2018.clone()

--- a/SimTransport/PPSProtonTransport/python/PPSTransportESSources_cfi.py
+++ b/SimTransport/PPSProtonTransport/python/PPSTransportESSources_cfi.py
@@ -1,19 +1,33 @@
 import FWCore.ParameterSet.Config as cms
 
 # beam optics
+from CondCore.CondDB.CondDB_cfi import *
 from CalibPPS.ESProducers.ctppsBeamParametersFromLHCInfoESSource_cfi import *
 from CalibPPS.ESProducers.ctppsInterpolatedOpticalFunctionsESSource_cfi import *
 ctppsInterpolatedOpticalFunctionsESSource.lhcInfoLabel = ""
 
-
-# For optical functions from root file, when they are not yet in the database, use the definitino below
 """
-from SimTransport.PPSProtonTransport.OpticalFunctionsConfig_cfi import *
+# For optical functions and LHCinfo not yet in a GT, use the definitino below
+ppsTransportESSource = cms.ESSource("PoolDBESSource")
 
-_opticsConfig = cms.PSet(
-                    defaultCrossingAngle=cms.double(0.0),
-                    es_source = cms.PSet()
-                )
+_ppsESSource2021 = cms.ESSource("PoolDBESSource",
+     connect = cms.string('frontier://FrontierProd/CMS_CONDITIONS'),
+     timetype = cms.untracked.string('runnumber'),
+     toGet = cms.VPSet(
+                 cms.PSet(
+                     record = cms.string('LHCInfoRcd'),
+                     tag = cms.string("LHCInfo_2021_mc_v1")
+                 ),
+                 cms.PSet(
+                     record = cms.string('CTPPSOpticsRcd'),
+                     tag = cms.string("PPSOpticalFunctions_2021_mc_v1")
+                 )
+     )
+)
+
+from Configuration.Eras.Modifier_ctpps_2021_cff import ctpps_2021
+ctpps_2021.toReplaceWith(ppsTransportESSource,_ppsESSource2021)
+del _ppsESSource2021
 
 from Configuration.Eras.Modifier_ctpps_2016_cff import ctpps_2016
 ctpps_2016.toReplaceWith(_opticsConfig, opticalfunctionsTransportSetup_2016.opticalFunctionConfig)

--- a/SimTransport/PPSProtonTransport/python/PPSTransport_cff.py
+++ b/SimTransport/PPSProtonTransport/python/PPSTransport_cff.py
@@ -25,8 +25,10 @@ ctpps_2017.toReplaceWith(_LHCTransportPSet, _hector_2017)
 
 from Configuration.Eras.Modifier_ctpps_2018_cff import ctpps_2018
 ctpps_2018.toReplaceWith(_LHCTransportPSet,_hector_2018)
+#ctpps_2018.toReplaceWith(_LHCTransportPSet,_opticalfunctionsTransportSetup_2018)
 
 from Configuration.Eras.Modifier_ctpps_2021_cff import ctpps_2021
-ctpps_2021.toReplaceWith(_LHCTransportPSet, _hector_2021) # there is no LHCInfo tag for Run3 yet, force to use a nonDB propagation
+#ctpps_2021.toReplaceWith(_LHCTransportPSet, _hector_2021) # there is no LHCInfo tag for Run3 yet, force to use a nonDB propagation
+ctpps_2021.toReplaceWith(_LHCTransportPSet, _opticalfunctionsTransportSetup_2021) # there is no LHCInfo tag for Run3 yet, force to use a nonDB propagation
 
 LHCTransport = cms.EDProducer("PPSSimTrackProducer",_commonParameters,_LHCTransportPSet)


### PR DESCRIPTION
#### PR description:

Simple change in the configuration file to use the approximate optical function for Run3 instead of the HECTOR (which uses ideal optics from LHC). It needs the record LHCInfoRcd and CTPPSOpticsRcd, which are in process of being integrated into the GT
#### PR validation:
All standard test has been done: scram b runtests, scram b code-checks and scram b code-formats

The runTheMatrix  -l limited -i all --ibeos ran without any error with the official GT, but in this case, since the record below is not in any official GT, an ESSource has been provided on config. 

Then the essource was removed and runTheMatrix was tested with the GT 113X_mcRun3_2021_realistic_Candidate_2021_04_06_19_59_53 with no error, however, the correct GT should be 113X_mcRun3_2021_realistic_Candidate_2021_04_09_15_03_03 (14TeV scenario), in which case, there was some wf that failed, however, the wf that runs PPS works fine (the GT above was proposed to solve the problem of #33266 )

In summary: this PR needs the GT 113X_mcRun3_2021_realistic_Candidate_2021_04_09_15_03_03 to be integrated.
