### PR TITLE
Fix conditions dumping for specific tags

### DIFF
--- a/CondTools/Hcal/test/runDumpHcalCond_cfg.py
+++ b/CondTools/Hcal/test/runDumpHcalCond_cfg.py
@@ -137,7 +137,6 @@ process.source = cms.Source("EmptySource",
 
 if options.dbfile and options.dblist:
     process.es_dbfile = cms.ESSource("PoolDBESSource",
-        process.CondDBSetup,
         timetype = cms.string('runnumber'),
         connect = cms.string(options.dbfile),
         authenticationMethod = cms.untracked.uint32(0),
@@ -151,7 +150,6 @@ if options.dbfile and options.dblist:
 
 if options.frontierloc and options.frontierlist:
     process.es_frontier = cms.ESSource("PoolDBESSource",
-        process.CondDBSetup,
         timetype = cms.string('runnumber'),
         connect = cms.string(options.frontierloc),
         authenticationMethod = cms.untracked.uint32(0),


### PR DESCRIPTION
#### PR description:

-- fix dumping of conditions for specific tags which was broken by this change made by me here:

https://github.com/cms-sw/cmssw/pull/33253/files#diff-c109b319860ca1a8a784f624f28b72919f0542e8dcf74abfff6ca5d339107b7bL82

-- the change should not affect any workflow


#### PR validation:
Tested by dumping first using global tag, then using explicit tag, and observing the expected difference. 

```
cmsRun runDumpHcalCond_cfg.py geometry=DB prefix="" dumplist=Gains run=350001 globaltag=111X_dataRun3_Prompt_v5

cmsRun runDumpHcalCond_cfg.py geometry=DB prefix="" dumplist=Gains run=350002 globaltag=111X_dataRun3_Prompt_v5 frontierlist=HcalGainsRcd:HcalGains_2020_o2oTest_v1.0

diff Gains_Run350001.txt Gains_Run350002.txt
2c2
<                -1               1               1              HB  0.0015647  0.0015647  0.0015647  0.0015647   43100401
---
>                -1               1               1              HB  0.0015803  0.0015803  0.0015803  0.0015803   43100401

```

