### PR TITLE
[HGCAL] Fix deprecated method for ESHandle

### DIFF
--- a/RecoHGCal/TICL/plugins/PatternRecognitionbyCA.cc
+++ b/RecoHGCal/TICL/plugins/PatternRecognitionbyCA.cc
@@ -20,6 +20,7 @@ PatternRecognitionbyCA<TILES>::PatternRecognitionbyCA(const edm::ParameterSet &c
                                                       const CacheBase *cache,
                                                       edm::ConsumesCollector iC)
     : PatternRecognitionAlgoBaseT<TILES>(conf, cache),
+      caloGeomToken_(iC.esConsumes<CaloGeometry, CaloGeometryRecord>()),
       theGraph_(std::make_unique<HGCGraphT<TILES>>()),
       oneTracksterPerTrackSeed_(conf.getParameter<bool>("oneTracksterPerTrackSeed")),
       promoteEmptyRegionToTrackster_(conf.getParameter<bool>("promoteEmptyRegionToTrackster")),
@@ -54,7 +55,6 @@ PatternRecognitionbyCA<TILES>::PatternRecognitionbyCA(const edm::ParameterSet &c
     throw cms::Exception("MissingGraphDef")
         << "PatternRecognitionbyCA received an empty graph definition from the global cache";
   }
-  caloGeomToken_ = iC.esConsumes<CaloGeometry, CaloGeometryRecord>();
   eidSession_ = tensorflow::createSession(trackstersCache->eidGraphDef);
 }
 

--- a/RecoHGCal/TICL/plugins/PatternRecognitionbyCA.cc
+++ b/RecoHGCal/TICL/plugins/PatternRecognitionbyCA.cc
@@ -71,8 +71,8 @@ void PatternRecognitionbyCA<TILES>::makeTracksters(
     return;
 
   edm::EventSetup const &es = input.es;
-  edm::ESHandle<CaloGeometry> geom = es.getHandle(caloGeomToken_);
-  rhtools_.setGeometry(*geom);
+  const CaloGeometry& geom = es.getData(caloGeomToken_);
+  rhtools_.setGeometry(geom);
 
   theGraph_->setVerbosity(PatternRecognitionAlgoBaseT<TILES>::algo_verbosity_);
   theGraph_->clear();

--- a/RecoHGCal/TICL/plugins/PatternRecognitionbyCA.cc
+++ b/RecoHGCal/TICL/plugins/PatternRecognitionbyCA.cc
@@ -16,7 +16,9 @@
 using namespace ticl;
 
 template <typename TILES>
-PatternRecognitionbyCA<TILES>::PatternRecognitionbyCA(const edm::ParameterSet &conf, const CacheBase *cache, edm::ConsumesCollector iC)
+PatternRecognitionbyCA<TILES>::PatternRecognitionbyCA(const edm::ParameterSet &conf,
+                                                      const CacheBase *cache,
+                                                      edm::ConsumesCollector iC)
     : PatternRecognitionAlgoBaseT<TILES>(conf, cache),
       theGraph_(std::make_unique<HGCGraphT<TILES>>()),
       oneTracksterPerTrackSeed_(conf.getParameter<bool>("oneTracksterPerTrackSeed")),

--- a/RecoHGCal/TICL/plugins/PatternRecognitionbyCA.cc
+++ b/RecoHGCal/TICL/plugins/PatternRecognitionbyCA.cc
@@ -71,7 +71,7 @@ void PatternRecognitionbyCA<TILES>::makeTracksters(
     return;
 
   edm::EventSetup const &es = input.es;
-  const CaloGeometry& geom = es.getData(caloGeomToken_);
+  const CaloGeometry &geom = es.getData(caloGeomToken_);
   rhtools_.setGeometry(geom);
 
   theGraph_->setVerbosity(PatternRecognitionAlgoBaseT<TILES>::algo_verbosity_);

--- a/RecoHGCal/TICL/plugins/PatternRecognitionbyCA.h
+++ b/RecoHGCal/TICL/plugins/PatternRecognitionbyCA.h
@@ -27,11 +27,11 @@ namespace ticl {
                                      const edm::ProductID& collectionID) const;
 
   private:
-    edm::ESGetToken<CaloGeometry, CaloGeometryRecord> caloGeomToken_;
     void mergeTrackstersTRK(const std::vector<Trackster>&,
                             const std::vector<reco::CaloCluster>&,
                             std::vector<Trackster>&,
                             std::unordered_map<int, std::vector<int>>& seedToTracksterAssociation) const;
+    edm::ESGetToken<CaloGeometry, CaloGeometryRecord> caloGeomToken_;
     const std::unique_ptr<HGCGraphT<TILES>> theGraph_;
     const bool oneTracksterPerTrackSeed_;
     const bool promoteEmptyRegionToTrackster_;

--- a/RecoHGCal/TICL/plugins/PatternRecognitionbyCA.h
+++ b/RecoHGCal/TICL/plugins/PatternRecognitionbyCA.h
@@ -7,13 +7,14 @@
 #include "RecoHGCal/TICL/plugins/PatternRecognitionAlgoBase.h"
 #include "RecoLocalCalo/HGCalRecAlgos/interface/RecHitTools.h"
 #include "PhysicsTools/TensorFlow/interface/TensorFlow.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "HGCGraph.h"
 
 namespace ticl {
   template <typename TILES>
   class PatternRecognitionbyCA final : public PatternRecognitionAlgoBaseT<TILES> {
   public:
-    PatternRecognitionbyCA(const edm::ParameterSet& conf, const CacheBase* cache);
+    PatternRecognitionbyCA(const edm::ParameterSet& conf, const CacheBase* cache, edm::ConsumesCollector iC);
     ~PatternRecognitionbyCA() override;
 
     void makeTracksters(const typename PatternRecognitionAlgoBaseT<TILES>::Inputs& input,
@@ -26,6 +27,7 @@ namespace ticl {
                                      const edm::ProductID& collectionID) const;
 
   private:
+    edm::ESGetToken<CaloGeometry, CaloGeometryRecord> caloGeomToken_;
     void mergeTrackstersTRK(const std::vector<Trackster>&,
                             const std::vector<reco::CaloCluster>&,
                             std::vector<Trackster>&,

--- a/RecoHGCal/TICL/plugins/TrackstersProducer.cc
+++ b/RecoHGCal/TICL/plugins/TrackstersProducer.cc
@@ -81,8 +81,8 @@ void TrackstersProducer::globalEndJob(TrackstersCache* cache) {
 TrackstersProducer::TrackstersProducer(const edm::ParameterSet& ps, const TrackstersCache* cache)
     : detector_(ps.getParameter<std::string>("detector")),
       doNose_(detector_ == "HFNose"),
-      myAlgo_(std::make_unique<PatternRecognitionbyCA<TICLLayerTiles>>(ps, cache)),
-      myAlgoHFNose_(std::make_unique<PatternRecognitionbyCA<TICLLayerTilesHFNose>>(ps, cache)),
+      myAlgo_(std::make_unique<PatternRecognitionbyCA<TICLLayerTiles>>(ps, cache, consumesCollector())),
+      myAlgoHFNose_(std::make_unique<PatternRecognitionbyCA<TICLLayerTilesHFNose>>(ps, cache, consumesCollector())),
       clusters_token_(consumes<std::vector<reco::CaloCluster>>(ps.getParameter<edm::InputTag>("layer_clusters"))),
       filtered_layerclusters_mask_token_(consumes<std::vector<float>>(ps.getParameter<edm::InputTag>("filtered_mask"))),
       original_layerclusters_mask_token_(consumes<std::vector<float>>(ps.getParameter<edm::InputTag>("original_mask"))),

--- a/RecoHGCal/TICL/test/TiclDebugger.cc
+++ b/RecoHGCal/TICL/test/TiclDebugger.cc
@@ -54,6 +54,7 @@ private:
   const edm::InputTag caloParticles_;
   const edm::InputTag layerClusters_;
   hgcal::RecHitTools rhtools_;
+  edm::ESGetToken<CaloGeometry, CaloGeometryRecord> caloGeometry_token_;
   edm::EDGetTokenT<std::vector<ticl::Trackster>> trackstersMergeToken_;
   edm::EDGetTokenT<std::vector<reco::Track>> tracksToken_;
   edm::EDGetTokenT<std::vector<CaloParticle>> caloParticlesToken_;
@@ -66,6 +67,7 @@ TiclDebugger::TiclDebugger(const edm::ParameterSet& iConfig)
       caloParticles_(iConfig.getParameter<edm::InputTag>("caloParticles")),
       layerClusters_(iConfig.getParameter<edm::InputTag>("layerClusters")) {
   edm::ConsumesCollector&& iC = consumesCollector();
+  caloGeometry_token_ = esConsumes<CaloGeometry, CaloGeometryRecord, edm::Transition::BeginRun>();
   trackstersMergeToken_ = iC.consumes<std::vector<ticl::Trackster>>(trackstersMerge_);
   tracksToken_ = iC.consumes<std::vector<reco::Track>>(tracks_);
   caloParticlesToken_ = iC.consumes<std::vector<CaloParticle>>(caloParticles_);
@@ -209,8 +211,7 @@ void TiclDebugger::analyze(const edm::Event& iEvent, const edm::EventSetup& iSet
 }
 
 void TiclDebugger::beginRun(edm::Run const&, edm::EventSetup const& es) {
-  edm::ESHandle<CaloGeometry> geom;
-  es.get<CaloGeometryRecord>().get(geom);
+  edm::ESHandle<CaloGeometry> geom = es.getHandle(caloGeometry_token_);
   rhtools_.setGeometry(*geom);
 }
 

--- a/RecoHGCal/TICL/test/TiclDebugger.cc
+++ b/RecoHGCal/TICL/test/TiclDebugger.cc
@@ -65,9 +65,9 @@ TiclDebugger::TiclDebugger(const edm::ParameterSet& iConfig)
     : trackstersMerge_(iConfig.getParameter<edm::InputTag>("trackstersMerge")),
       tracks_(iConfig.getParameter<edm::InputTag>("tracks")),
       caloParticles_(iConfig.getParameter<edm::InputTag>("caloParticles")),
-      layerClusters_(iConfig.getParameter<edm::InputTag>("layerClusters")) {
+      layerClusters_(iConfig.getParameter<edm::InputTag>("layerClusters")),
+      caloGeometry_token_(esConsumes<CaloGeometry, CaloGeometryRecord, edm::Transition::BeginRun>()) {
   edm::ConsumesCollector&& iC = consumesCollector();
-  caloGeometry_token_ = esConsumes<CaloGeometry, CaloGeometryRecord, edm::Transition::BeginRun>();
   trackstersMergeToken_ = iC.consumes<std::vector<ticl::Trackster>>(trackstersMerge_);
   tracksToken_ = iC.consumes<std::vector<reco::Track>>(tracks_);
   caloParticlesToken_ = iC.consumes<std::vector<CaloParticle>>(caloParticles_);
@@ -211,7 +211,7 @@ void TiclDebugger::analyze(const edm::Event& iEvent, const edm::EventSetup& iSet
 }
 
 void TiclDebugger::beginRun(edm::Run const&, edm::EventSetup const& es) {
-  const CaloGeometry& geom = es.getHandle(caloGeometry_token_);
+  const CaloGeometry& geom = es.getData(caloGeometry_token_);
   rhtools_.setGeometry(geom);
 }
 

--- a/RecoHGCal/TICL/test/TiclDebugger.cc
+++ b/RecoHGCal/TICL/test/TiclDebugger.cc
@@ -211,8 +211,8 @@ void TiclDebugger::analyze(const edm::Event& iEvent, const edm::EventSetup& iSet
 }
 
 void TiclDebugger::beginRun(edm::Run const&, edm::EventSetup const& es) {
-  edm::ESHandle<CaloGeometry> geom = es.getHandle(caloGeometry_token_);
-  rhtools_.setGeometry(*geom);
+  const CaloGeometry& geom = es.getHandle(caloGeometry_token_);
+  rhtools_.setGeometry(geom);
 }
 
 void TiclDebugger::beginJob() {}

--- a/RecoLocalCalo/HGCalRecAlgos/interface/HGCal3DClustering.h
+++ b/RecoLocalCalo/HGCalRecAlgos/interface/HGCal3DClustering.h
@@ -24,7 +24,9 @@ public:
       : radii(radii_in),
         minClusters(min_clusters),
         es(0),
-        clusterTools(std::make_unique<hgcal::ClusterTools>(conf, sumes)) {}
+        clusterTools(std::make_unique<hgcal::ClusterTools>(conf, sumes)) {
+   caloGeomToken_ = sumes.esConsumes<CaloGeometry, CaloGeometryRecord>(); 
+  }
 
   HGCal3DClustering(const edm::ParameterSet& conf, edm::ConsumesCollector& sumes)
       : HGCal3DClustering(conf,
@@ -35,8 +37,7 @@ public:
   void getEvent(const edm::Event& ev) { clusterTools->getEvent(ev); }
   void getEventSetup(const edm::EventSetup& es) {
     clusterTools->getEventSetup(es);
-    edm::ESHandle<CaloGeometry> geom;
-    es.get<CaloGeometryRecord>().get(geom);
+    edm::ESHandle<CaloGeometry> geom = es.getHandle(caloGeomToken_);
     rhtools_.setGeometry(*geom);
     maxlayer = rhtools_.lastLayerBH();
     points.clear();
@@ -91,6 +92,7 @@ private:
   std::vector<float> zees;                           /*!< vector to contain z position of each layer. */
   std::unique_ptr<hgcal::ClusterTools> clusterTools; /*!< instance of tools to simplify cluster access. */
   hgcal::RecHitTools rhtools_;                       /*!< instance of tools to access RecHit information. */
+  edm::ESGetToken<CaloGeometry, CaloGeometryRecord> caloGeomToken_;
 };
 
 #endif

--- a/RecoLocalCalo/HGCalRecAlgos/interface/HGCal3DClustering.h
+++ b/RecoLocalCalo/HGCalRecAlgos/interface/HGCal3DClustering.h
@@ -25,8 +25,7 @@ public:
         minClusters(min_clusters),
         es(0),
         clusterTools(std::make_unique<hgcal::ClusterTools>(conf, sumes)),
-        caloGeomToken_(sumes.esConsumes<CaloGeometry, CaloGeometryRecord>()) {
-  }
+        caloGeomToken_(sumes.esConsumes<CaloGeometry, CaloGeometryRecord>()) {}
 
   HGCal3DClustering(const edm::ParameterSet& conf, edm::ConsumesCollector& sumes)
       : HGCal3DClustering(conf,

--- a/RecoLocalCalo/HGCalRecAlgos/interface/HGCal3DClustering.h
+++ b/RecoLocalCalo/HGCalRecAlgos/interface/HGCal3DClustering.h
@@ -24,8 +24,8 @@ public:
       : radii(radii_in),
         minClusters(min_clusters),
         es(0),
-        clusterTools(std::make_unique<hgcal::ClusterTools>(conf, sumes)) {
-    caloGeomToken_ = sumes.esConsumes<CaloGeometry, CaloGeometryRecord>();
+        clusterTools(std::make_unique<hgcal::ClusterTools>(conf, sumes)),
+        caloGeomToken_(sumes.esConsumes<CaloGeometry, CaloGeometryRecord>()) {
   }
 
   HGCal3DClustering(const edm::ParameterSet& conf, edm::ConsumesCollector& sumes)
@@ -37,8 +37,8 @@ public:
   void getEvent(const edm::Event& ev) { clusterTools->getEvent(ev); }
   void getEventSetup(const edm::EventSetup& es) {
     clusterTools->getEventSetup(es);
-    edm::ESHandle<CaloGeometry> geom = es.getHandle(caloGeomToken_);
-    rhtools_.setGeometry(*geom);
+    const CaloGeometry& geom = es.getData(caloGeomToken_);
+    rhtools_.setGeometry(geom);
     maxlayer = rhtools_.lastLayerBH();
     points.clear();
     minpos.clear();

--- a/RecoLocalCalo/HGCalRecAlgos/interface/HGCal3DClustering.h
+++ b/RecoLocalCalo/HGCalRecAlgos/interface/HGCal3DClustering.h
@@ -25,7 +25,7 @@ public:
         minClusters(min_clusters),
         es(0),
         clusterTools(std::make_unique<hgcal::ClusterTools>(conf, sumes)) {
-   caloGeomToken_ = sumes.esConsumes<CaloGeometry, CaloGeometryRecord>(); 
+    caloGeomToken_ = sumes.esConsumes<CaloGeometry, CaloGeometryRecord>();
   }
 
   HGCal3DClustering(const edm::ParameterSet& conf, edm::ConsumesCollector& sumes)

--- a/RecoLocalCalo/HGCalRecAlgos/interface/HGCalDepthPreClusterer.h
+++ b/RecoLocalCalo/HGCalRecAlgos/interface/HGCalDepthPreClusterer.h
@@ -30,8 +30,8 @@ public:
       : radii(radii_in),
         minClusters(min_clusters),
         realSpaceCone(real_space_cone),
-        clusterTools(std::make_unique<hgcal::ClusterTools>(conf, sumes)) {
-    caloGeomToken_ = sumes.esConsumes<CaloGeometry, CaloGeometryRecord>();
+        clusterTools(std::make_unique<hgcal::ClusterTools>(conf, sumes)),
+        caloGeomToken_(sumes.esConsumes<CaloGeometry, CaloGeometryRecord>()) {
   }
 
   void getEvent(const edm::Event& ev) { clusterTools->getEvent(ev); }

--- a/RecoLocalCalo/HGCalRecAlgos/interface/HGCalDepthPreClusterer.h
+++ b/RecoLocalCalo/HGCalRecAlgos/interface/HGCalDepthPreClusterer.h
@@ -30,13 +30,14 @@ public:
       : radii(radii_in),
         minClusters(min_clusters),
         realSpaceCone(real_space_cone),
-        clusterTools(std::make_unique<hgcal::ClusterTools>(conf, sumes)) {}
+        clusterTools(std::make_unique<hgcal::ClusterTools>(conf, sumes)) {
+    caloGeomToken_ = sumes.esConsumes<CaloGeometry, CaloGeometryRecord>();
+  }
 
   void getEvent(const edm::Event& ev) { clusterTools->getEvent(ev); }
   void getEventSetup(const edm::EventSetup& es) {
     clusterTools->getEventSetup(es);
-    edm::ESHandle<CaloGeometry> geom;
-    es.get<CaloGeometryRecord>().get(geom);
+    edm::ESHandle<CaloGeometry> geom = es.getHandle(caloGeomToken_);
     rhtools_.setGeometry(*geom);
   }
 
@@ -52,6 +53,7 @@ private:
 
   std::unique_ptr<hgcal::ClusterTools> clusterTools;
   hgcal::RecHitTools rhtools_; /*!< instance of tools to access RecHit information. */
+  edm::ESGetToken<CaloGeometry, CaloGeometryRecord> caloGeomToken_;
 };
 
 #endif

--- a/RecoLocalCalo/HGCalRecAlgos/interface/HGCalDepthPreClusterer.h
+++ b/RecoLocalCalo/HGCalRecAlgos/interface/HGCalDepthPreClusterer.h
@@ -31,8 +31,7 @@ public:
         minClusters(min_clusters),
         realSpaceCone(real_space_cone),
         clusterTools(std::make_unique<hgcal::ClusterTools>(conf, sumes)),
-        caloGeomToken_(sumes.esConsumes<CaloGeometry, CaloGeometryRecord>()) {
-  }
+        caloGeomToken_(sumes.esConsumes<CaloGeometry, CaloGeometryRecord>()) {}
 
   void getEvent(const edm::Event& ev) { clusterTools->getEvent(ev); }
   void getEventSetup(const edm::EventSetup& es) {

--- a/RecoLocalCalo/HGCalRecProducers/interface/HGCalClusteringAlgoBase.h
+++ b/RecoLocalCalo/HGCalRecProducers/interface/HGCalClusteringAlgoBase.h
@@ -49,7 +49,8 @@ class HGCalClusteringAlgoBase {
 public:
   enum VerbosityLevel { pDEBUG = 0, pWARNING = 1, pINFO = 2, pERROR = 3 };
 
-  HGCalClusteringAlgoBase(VerbosityLevel v, reco::CaloCluster::AlgoId algo, edm::ConsumesCollector iC) : verbosity_(v), algoId_(algo){
+  HGCalClusteringAlgoBase(VerbosityLevel v, reco::CaloCluster::AlgoId algo, edm::ConsumesCollector iC)
+      : verbosity_(v), algoId_(algo) {
     caloGeomToken_ = iC.esConsumes<CaloGeometry, CaloGeometryRecord>();
   };
   virtual ~HGCalClusteringAlgoBase() {}

--- a/RecoLocalCalo/HGCalRecProducers/interface/HGCalClusteringAlgoBase.h
+++ b/RecoLocalCalo/HGCalRecProducers/interface/HGCalClusteringAlgoBase.h
@@ -50,9 +50,8 @@ public:
   enum VerbosityLevel { pDEBUG = 0, pWARNING = 1, pINFO = 2, pERROR = 3 };
 
   HGCalClusteringAlgoBase(VerbosityLevel v, reco::CaloCluster::AlgoId algo, edm::ConsumesCollector iC)
-      : verbosity_(v), algoId_(algo) {
-    caloGeomToken_ = iC.esConsumes<CaloGeometry, CaloGeometryRecord>();
-  };
+      : verbosity_(v), algoId_(algo),
+        caloGeomToken_(iC.esConsumes<CaloGeometry, CaloGeometryRecord>()) {}
   virtual ~HGCalClusteringAlgoBase() {}
 
   virtual void populate(const HGCRecHitCollection &hits) = 0;

--- a/RecoLocalCalo/HGCalRecProducers/interface/HGCalClusteringAlgoBase.h
+++ b/RecoLocalCalo/HGCalRecProducers/interface/HGCalClusteringAlgoBase.h
@@ -2,6 +2,7 @@
 #define RecoLocalCalo_HGCalRecProducers_HGCalClusteringAlgoBase_h
 
 #include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 
 #include "DataFormats/HGCRecHit/interface/HGCRecHitCollections.h"
 #include "DataFormats/Math/interface/Point3D.h"
@@ -48,7 +49,9 @@ class HGCalClusteringAlgoBase {
 public:
   enum VerbosityLevel { pDEBUG = 0, pWARNING = 1, pINFO = 2, pERROR = 3 };
 
-  HGCalClusteringAlgoBase(VerbosityLevel v, reco::CaloCluster::AlgoId algo) : verbosity_(v), algoId_(algo){};
+  HGCalClusteringAlgoBase(VerbosityLevel v, reco::CaloCluster::AlgoId algo, edm::ConsumesCollector iC) : verbosity_(v), algoId_(algo){
+    caloGeomToken_ = iC.esConsumes<CaloGeometry, CaloGeometryRecord>();
+  };
   virtual ~HGCalClusteringAlgoBase() {}
 
   virtual void populate(const HGCRecHitCollection &hits) = 0;
@@ -59,8 +62,7 @@ public:
   virtual void getEventSetupPerAlgorithm(const edm::EventSetup &es) {}
 
   inline void getEventSetup(const edm::EventSetup &es) {
-    edm::ESHandle<CaloGeometry> geom;
-    es.get<CaloGeometryRecord>().get(geom);
+    edm::ESHandle<CaloGeometry> geom = es.getHandle(caloGeomToken_);
     rhtools_.setGeometry(*geom);
     maxlayer_ = rhtools_.lastLayer(isNose_);
     lastLayerEE_ = rhtools_.lastLayerEE(isNose_);
@@ -85,6 +87,8 @@ public:
   bool isNose_;
 
 protected:
+  edm::ESGetToken<CaloGeometry, CaloGeometryRecord> caloGeomToken_;
+
   // The verbosity level
   VerbosityLevel verbosity_;
 

--- a/RecoLocalCalo/HGCalRecProducers/interface/HGCalClusteringAlgoBase.h
+++ b/RecoLocalCalo/HGCalRecProducers/interface/HGCalClusteringAlgoBase.h
@@ -87,8 +87,6 @@ public:
   bool isNose_;
 
 protected:
-  edm::ESGetToken<CaloGeometry, CaloGeometryRecord> caloGeomToken_;
-
   // The verbosity level
   VerbosityLevel verbosity_;
 
@@ -99,6 +97,9 @@ protected:
 
   // The algo id
   reco::CaloCluster::AlgoId algoId_;
+
+  edm::ESGetToken<CaloGeometry, CaloGeometryRecord> caloGeomToken_;
+
 };
 
 #endif

--- a/RecoLocalCalo/HGCalRecProducers/interface/HGCalClusteringAlgoBase.h
+++ b/RecoLocalCalo/HGCalRecProducers/interface/HGCalClusteringAlgoBase.h
@@ -50,8 +50,7 @@ public:
   enum VerbosityLevel { pDEBUG = 0, pWARNING = 1, pINFO = 2, pERROR = 3 };
 
   HGCalClusteringAlgoBase(VerbosityLevel v, reco::CaloCluster::AlgoId algo, edm::ConsumesCollector iC)
-      : verbosity_(v), algoId_(algo),
-        caloGeomToken_(iC.esConsumes<CaloGeometry, CaloGeometryRecord>()) {}
+      : verbosity_(v), algoId_(algo), caloGeomToken_(iC.esConsumes<CaloGeometry, CaloGeometryRecord>()) {}
   virtual ~HGCalClusteringAlgoBase() {}
 
   virtual void populate(const HGCRecHitCollection &hits) = 0;
@@ -99,7 +98,6 @@ protected:
   reco::CaloCluster::AlgoId algoId_;
 
   edm::ESGetToken<CaloGeometry, CaloGeometryRecord> caloGeomToken_;
-
 };
 
 #endif

--- a/RecoLocalCalo/HGCalRecProducers/interface/HGCalImagingAlgo.h
+++ b/RecoLocalCalo/HGCalRecProducers/interface/HGCalImagingAlgo.h
@@ -30,10 +30,10 @@ using Density = hgcal_clustering::Density;
 
 class HGCalImagingAlgo : public HGCalClusteringAlgoBase {
 public:
-  HGCalImagingAlgo(const edm::ParameterSet &ps)
+  HGCalImagingAlgo(const edm::ParameterSet &ps, edm::ConsumesCollector iC)
       : HGCalClusteringAlgoBase(
             (HGCalClusteringAlgoBase::VerbosityLevel)ps.getUntrackedParameter<unsigned int>("verbosity", 3),
-            reco::CaloCluster::undefined),
+            reco::CaloCluster::undefined, iC),
         thresholdW0_(ps.getParameter<std::vector<double>>("thresholdW0")),
         positionDeltaRho_c_(ps.getParameter<std::vector<double>>("positionDeltaRho_c")),
         vecDeltas_(ps.getParameter<std::vector<double>>("deltac")),

--- a/RecoLocalCalo/HGCalRecProducers/interface/HGCalImagingAlgo.h
+++ b/RecoLocalCalo/HGCalRecProducers/interface/HGCalImagingAlgo.h
@@ -33,7 +33,8 @@ public:
   HGCalImagingAlgo(const edm::ParameterSet &ps, edm::ConsumesCollector iC)
       : HGCalClusteringAlgoBase(
             (HGCalClusteringAlgoBase::VerbosityLevel)ps.getUntrackedParameter<unsigned int>("verbosity", 3),
-            reco::CaloCluster::undefined, iC),
+            reco::CaloCluster::undefined,
+            iC),
         thresholdW0_(ps.getParameter<std::vector<double>>("thresholdW0")),
         positionDeltaRho_c_(ps.getParameter<std::vector<double>>("positionDeltaRho_c")),
         vecDeltas_(ps.getParameter<std::vector<double>>("deltac")),

--- a/RecoLocalCalo/HGCalRecProducers/interface/HGCalLayerClusterAlgoFactory.h
+++ b/RecoLocalCalo/HGCalRecProducers/interface/HGCalLayerClusterAlgoFactory.h
@@ -5,6 +5,7 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "RecoLocalCalo/HGCalRecProducers/interface/HGCalClusteringAlgoBase.h"
 
-typedef edmplugin::PluginFactory<HGCalClusteringAlgoBase*(const edm::ParameterSet&, edm::ConsumesCollector)> HGCalLayerClusterAlgoFactory;
+typedef edmplugin::PluginFactory<HGCalClusteringAlgoBase*(const edm::ParameterSet&, edm::ConsumesCollector)>
+    HGCalLayerClusterAlgoFactory;
 
 #endif

--- a/RecoLocalCalo/HGCalRecProducers/interface/HGCalLayerClusterAlgoFactory.h
+++ b/RecoLocalCalo/HGCalRecProducers/interface/HGCalLayerClusterAlgoFactory.h
@@ -5,6 +5,6 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "RecoLocalCalo/HGCalRecProducers/interface/HGCalClusteringAlgoBase.h"
 
-typedef edmplugin::PluginFactory<HGCalClusteringAlgoBase*(const edm::ParameterSet&)> HGCalLayerClusterAlgoFactory;
+typedef edmplugin::PluginFactory<HGCalClusteringAlgoBase*(const edm::ParameterSet&, edm::ConsumesCollector)> HGCalLayerClusterAlgoFactory;
 
 #endif

--- a/RecoLocalCalo/HGCalRecProducers/interface/HGCalRecHitWorkerBaseClass.h
+++ b/RecoLocalCalo/HGCalRecProducers/interface/HGCalRecHitWorkerBaseClass.h
@@ -2,6 +2,7 @@
 #define RecoLocalCalo_HGCalRecProducers_HGCalRecHitWorkerBaseClass_hh
 
 #include "DataFormats/HGCRecHit/interface/HGCRecHitCollections.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 
 namespace edm {
   class Event;
@@ -11,7 +12,7 @@ namespace edm {
 
 class HGCalRecHitWorkerBaseClass {
 public:
-  HGCalRecHitWorkerBaseClass(const edm::ParameterSet&){};
+  HGCalRecHitWorkerBaseClass(const edm::ParameterSet&, edm::ConsumesCollector){};
   virtual ~HGCalRecHitWorkerBaseClass(){};
 
   virtual void set(const edm::EventSetup& es) = 0;

--- a/RecoLocalCalo/HGCalRecProducers/interface/HGCalRecHitWorkerFactory.h
+++ b/RecoLocalCalo/HGCalRecProducers/interface/HGCalRecHitWorkerFactory.h
@@ -3,6 +3,6 @@
 
 #include "FWCore/PluginManager/interface/PluginFactory.h"
 #include "RecoLocalCalo/HGCalRecProducers/interface/HGCalRecHitWorkerBaseClass.h"
-typedef edmplugin::PluginFactory<HGCalRecHitWorkerBaseClass*(const edm::ParameterSet&)> HGCalRecHitWorkerFactory;
+typedef edmplugin::PluginFactory<HGCalRecHitWorkerBaseClass*(const edm::ParameterSet&, edm::ConsumesCollector)> HGCalRecHitWorkerFactory;
 
 #endif

--- a/RecoLocalCalo/HGCalRecProducers/interface/HGCalRecHitWorkerFactory.h
+++ b/RecoLocalCalo/HGCalRecProducers/interface/HGCalRecHitWorkerFactory.h
@@ -3,6 +3,7 @@
 
 #include "FWCore/PluginManager/interface/PluginFactory.h"
 #include "RecoLocalCalo/HGCalRecProducers/interface/HGCalRecHitWorkerBaseClass.h"
-typedef edmplugin::PluginFactory<HGCalRecHitWorkerBaseClass*(const edm::ParameterSet&, edm::ConsumesCollector)> HGCalRecHitWorkerFactory;
+typedef edmplugin::PluginFactory<HGCalRecHitWorkerBaseClass*(const edm::ParameterSet&, edm::ConsumesCollector)>
+    HGCalRecHitWorkerFactory;
 
 #endif

--- a/RecoLocalCalo/HGCalRecProducers/interface/HGCalUncalibRecHitWorkerBaseClass.h
+++ b/RecoLocalCalo/HGCalRecProducers/interface/HGCalUncalibRecHitWorkerBaseClass.h
@@ -3,6 +3,7 @@
 
 #include "DataFormats/HGCRecHit/interface/HGCRecHitCollections.h"
 #include "DataFormats/HGCDigi/interface/HGCDigiCollections.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 
 namespace edm {
   class Event;
@@ -14,7 +15,7 @@ namespace edm {
 // change in the future.
 class HGCalUncalibRecHitWorkerBaseClass {
 public:
-  HGCalUncalibRecHitWorkerBaseClass(const edm::ParameterSet&) {}
+  HGCalUncalibRecHitWorkerBaseClass(const edm::ParameterSet& ps, edm::ConsumesCollector iC) {}
   virtual ~HGCalUncalibRecHitWorkerBaseClass() {}
 
   // do event setup things

--- a/RecoLocalCalo/HGCalRecProducers/interface/HGCalUncalibRecHitWorkerFactory.h
+++ b/RecoLocalCalo/HGCalRecProducers/interface/HGCalUncalibRecHitWorkerFactory.h
@@ -3,7 +3,7 @@
 
 #include "FWCore/PluginManager/interface/PluginFactory.h"
 #include "RecoLocalCalo/HGCalRecProducers/interface/HGCalUncalibRecHitWorkerBaseClass.h"
-typedef edmplugin::PluginFactory<HGCalUncalibRecHitWorkerBaseClass*(const edm::ParameterSet&)>
+typedef edmplugin::PluginFactory<HGCalUncalibRecHitWorkerBaseClass*(const edm::ParameterSet&, edm::ConsumesCollector)>
     HGCalUncalibRecHitWorkerFactory;
 
 #endif

--- a/RecoLocalCalo/HGCalRecProducers/plugins/HGCalCLUEAlgo.h
+++ b/RecoLocalCalo/HGCalRecProducers/plugins/HGCalCLUEAlgo.h
@@ -29,10 +29,10 @@ using Density = hgcal_clustering::Density;
 template <typename TILE>
 class HGCalCLUEAlgoT : public HGCalClusteringAlgoBase {
 public:
-  HGCalCLUEAlgoT(const edm::ParameterSet& ps)
+  HGCalCLUEAlgoT(const edm::ParameterSet& ps, edm::ConsumesCollector iC)
       : HGCalClusteringAlgoBase(
             (HGCalClusteringAlgoBase::VerbosityLevel)ps.getUntrackedParameter<unsigned int>("verbosity", 3),
-            reco::CaloCluster::undefined),
+            reco::CaloCluster::undefined, iC),
         thresholdW0_(ps.getParameter<std::vector<double>>("thresholdW0")),
         positionDeltaRho2_(ps.getParameter<double>("positionDeltaRho2")),
         vecDeltas_(ps.getParameter<std::vector<double>>("deltac")),

--- a/RecoLocalCalo/HGCalRecProducers/plugins/HGCalCLUEAlgo.h
+++ b/RecoLocalCalo/HGCalRecProducers/plugins/HGCalCLUEAlgo.h
@@ -32,7 +32,8 @@ public:
   HGCalCLUEAlgoT(const edm::ParameterSet& ps, edm::ConsumesCollector iC)
       : HGCalClusteringAlgoBase(
             (HGCalClusteringAlgoBase::VerbosityLevel)ps.getUntrackedParameter<unsigned int>("verbosity", 3),
-            reco::CaloCluster::undefined, iC),
+            reco::CaloCluster::undefined,
+            iC),
         thresholdW0_(ps.getParameter<std::vector<double>>("thresholdW0")),
         positionDeltaRho2_(ps.getParameter<double>("positionDeltaRho2")),
         vecDeltas_(ps.getParameter<std::vector<double>>("deltac")),

--- a/RecoLocalCalo/HGCalRecProducers/plugins/HGCalLayerClusterProducer.cc
+++ b/RecoLocalCalo/HGCalRecProducers/plugins/HGCalLayerClusterProducer.cc
@@ -87,10 +87,10 @@ HGCalLayerClusterProducer::HGCalLayerClusterProducer(const edm::ParameterSet& ps
 
   auto pluginPSet = ps.getParameter<edm::ParameterSet>("plugin");
   if (detector == "HFNose") {
-    algo = HGCalLayerClusterAlgoFactory::get()->create("HFNoseCLUE", pluginPSet);
+    algo = HGCalLayerClusterAlgoFactory::get()->create("HFNoseCLUE", pluginPSet, consumesCollector());
     algo->setAlgoId(algoId, true);
   } else {
-    algo = HGCalLayerClusterAlgoFactory::get()->create(pluginPSet.getParameter<std::string>("type"), pluginPSet);
+    algo = HGCalLayerClusterAlgoFactory::get()->create(pluginPSet.getParameter<std::string>("type"), pluginPSet, consumesCollector());
     algo->setAlgoId(algoId);
   }
 

--- a/RecoLocalCalo/HGCalRecProducers/plugins/HGCalLayerClusterProducer.cc
+++ b/RecoLocalCalo/HGCalRecProducers/plugins/HGCalLayerClusterProducer.cc
@@ -90,7 +90,8 @@ HGCalLayerClusterProducer::HGCalLayerClusterProducer(const edm::ParameterSet& ps
     algo = HGCalLayerClusterAlgoFactory::get()->create("HFNoseCLUE", pluginPSet, consumesCollector());
     algo->setAlgoId(algoId, true);
   } else {
-    algo = HGCalLayerClusterAlgoFactory::get()->create(pluginPSet.getParameter<std::string>("type"), pluginPSet, consumesCollector());
+    algo = HGCalLayerClusterAlgoFactory::get()->create(
+        pluginPSet.getParameter<std::string>("type"), pluginPSet, consumesCollector());
     algo->setAlgoId(algoId);
   }
 

--- a/RecoLocalCalo/HGCalRecProducers/plugins/HGCalRecHitProducer.cc
+++ b/RecoLocalCalo/HGCalRecProducers/plugins/HGCalRecHitProducer.cc
@@ -55,7 +55,7 @@ HGCalRecHitProducer::HGCalRecHitProducer(const edm::ParameterSet& ps)
       hefRechitCollection_(ps.getParameter<std::string>("HGCHEFrechitCollection")),
       hebRechitCollection_(ps.getParameter<std::string>("HGCHEBrechitCollection")),
       hfnoseRechitCollection_(ps.getParameter<std::string>("HGCHFNoserechitCollection")),
-      worker_{HGCalRecHitWorkerFactory::get()->create(ps.getParameter<std::string>("algo"), ps)} {
+      worker_{HGCalRecHitWorkerFactory::get()->create(ps.getParameter<std::string>("algo"), ps, consumesCollector())} {
   produces<HGCeeRecHitCollection>(eeRechitCollection_);
   produces<HGChefRecHitCollection>(hefRechitCollection_);
   produces<HGChebRecHitCollection>(hebRechitCollection_);

--- a/RecoLocalCalo/HGCalRecProducers/plugins/HGCalRecHitWorkerSimple.cc
+++ b/RecoLocalCalo/HGCalRecProducers/plugins/HGCalRecHitWorkerSimple.cc
@@ -11,7 +11,8 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "RecoLocalCalo/HGCalRecProducers/interface/ComputeClusterTime.h"
 
-HGCalRecHitWorkerSimple::HGCalRecHitWorkerSimple(const edm::ParameterSet& ps, edm::ConsumesCollector iC) : HGCalRecHitWorkerBaseClass(ps, iC) {
+HGCalRecHitWorkerSimple::HGCalRecHitWorkerSimple(const edm::ParameterSet& ps, edm::ConsumesCollector iC)
+    : HGCalRecHitWorkerBaseClass(ps, iC) {
   rechitMaker_ = std::make_unique<HGCalRecHitSimpleAlgo>();
   tools_ = std::make_unique<hgcal::RecHitTools>();
   constexpr float keV2GeV = 1e-6;

--- a/RecoLocalCalo/HGCalRecProducers/plugins/HGCalRecHitWorkerSimple.cc
+++ b/RecoLocalCalo/HGCalRecProducers/plugins/HGCalRecHitWorkerSimple.cc
@@ -98,13 +98,12 @@ HGCalRecHitWorkerSimple::HGCalRecHitWorkerSimple(const edm::ParameterSet& ps, ed
 }
 
 void HGCalRecHitWorkerSimple::set(const edm::EventSetup& es) {
-  edm::ESHandle<CaloGeometry> geom = es.getHandle(caloGeomToken_);
-  es.get<CaloGeometryRecord>().get(geom);
-  tools_->setGeometry(*geom);
-  rechitMaker_->set(*geom);
+  const CaloGeometry& geom = es.getData(caloGeomToken_);
+  tools_->setGeometry(geom);
+  rechitMaker_->set(geom);
   if (hgcEE_isSiFE_) {
-    edm::ESHandle<HGCalGeometry> hgceeGeoHandle = es.getHandle(ee_geometry_token_);
-    ddds_[0] = &(hgceeGeoHandle->topology().dddConstants());
+    edm::const HGCalGeometry& hgceeGeoHandle = es.getData(ee_geometry_token_);
+    ddds_[0] = &(hgceeGeoHandle.topology().dddConstants());
   } else {
     ddds_[0] = nullptr;
   }

--- a/RecoLocalCalo/HGCalRecProducers/plugins/HGCalRecHitWorkerSimple.cc
+++ b/RecoLocalCalo/HGCalRecProducers/plugins/HGCalRecHitWorkerSimple.cc
@@ -12,15 +12,14 @@
 #include "RecoLocalCalo/HGCalRecProducers/interface/ComputeClusterTime.h"
 
 HGCalRecHitWorkerSimple::HGCalRecHitWorkerSimple(const edm::ParameterSet& ps, edm::ConsumesCollector iC)
-    : HGCalRecHitWorkerBaseClass(ps, iC) {
+    : HGCalRecHitWorkerBaseClass(ps, iC),
+      caloGeomToken_(iC.esConsumes<CaloGeometry, CaloGeometryRecord>()),
+      ee_geometry_token_(iC.esConsumes(edm::ESInputTag("", "HGCalEESensitive"))),
+      hef_geometry_token_(iC.esConsumes(edm::ESInputTag("", "HGCalHESiliconSensitive"))),
+      hfnose_geometry_token_(iC.esConsumes(edm::ESInputTag("", "HGCalHFNoseSensitive"))) {
   rechitMaker_ = std::make_unique<HGCalRecHitSimpleAlgo>();
   tools_ = std::make_unique<hgcal::RecHitTools>();
   constexpr float keV2GeV = 1e-6;
-
-  caloGeomToken_ = iC.esConsumes<CaloGeometry, CaloGeometryRecord>();
-  ee_geometry_token_ = iC.esConsumes(edm::ESInputTag("", "HGCalEESensitive"));
-  hef_geometry_token_ = iC.esConsumes(edm::ESInputTag("", "HGCalHESiliconSensitive"));
-  hfnose_geometry_token_ = iC.esConsumes(edm::ESInputTag("", "HGCalHFNoseSensitive"));
 
   // HGCee constants
   hgcEE_keV2DIGI_ = ps.getParameter<double>("HGCEE_keV2DIGI");
@@ -102,7 +101,7 @@ void HGCalRecHitWorkerSimple::set(const edm::EventSetup& es) {
   tools_->setGeometry(geom);
   rechitMaker_->set(geom);
   if (hgcEE_isSiFE_) {
-    edm::const HGCalGeometry& hgceeGeoHandle = es.getData(ee_geometry_token_);
+    const HGCalGeometry& hgceeGeoHandle = es.getData(ee_geometry_token_);
     ddds_[0] = &(hgceeGeoHandle.topology().dddConstants());
   } else {
     ddds_[0] = nullptr;

--- a/RecoLocalCalo/HGCalRecProducers/plugins/HGCalRecHitWorkerSimple.cc
+++ b/RecoLocalCalo/HGCalRecProducers/plugins/HGCalRecHitWorkerSimple.cc
@@ -11,10 +11,16 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "RecoLocalCalo/HGCalRecProducers/interface/ComputeClusterTime.h"
 
-HGCalRecHitWorkerSimple::HGCalRecHitWorkerSimple(const edm::ParameterSet& ps) : HGCalRecHitWorkerBaseClass(ps) {
+HGCalRecHitWorkerSimple::HGCalRecHitWorkerSimple(const edm::ParameterSet& ps, edm::ConsumesCollector iC) : HGCalRecHitWorkerBaseClass(ps, iC) {
   rechitMaker_ = std::make_unique<HGCalRecHitSimpleAlgo>();
   tools_ = std::make_unique<hgcal::RecHitTools>();
   constexpr float keV2GeV = 1e-6;
+
+  caloGeomToken_ = iC.esConsumes<CaloGeometry, CaloGeometryRecord>();
+  ee_geometry_token_ = iC.esConsumes(edm::ESInputTag("", "HGCalEESensitive"));
+  hef_geometry_token_ = iC.esConsumes(edm::ESInputTag("", "HGCalHESiliconSensitive"));
+  hfnose_geometry_token_ = iC.esConsumes(edm::ESInputTag("", "HGCalHFNoseSensitive"));
+
   // HGCee constants
   hgcEE_keV2DIGI_ = ps.getParameter<double>("HGCEE_keV2DIGI");
   hgcEE_fCPerMIP_ = ps.getParameter<std::vector<double> >("HGCEE_fCPerMIP");
@@ -91,28 +97,25 @@ HGCalRecHitWorkerSimple::HGCalRecHitWorkerSimple(const edm::ParameterSet& ps) : 
 }
 
 void HGCalRecHitWorkerSimple::set(const edm::EventSetup& es) {
-  edm::ESHandle<CaloGeometry> geom;
+  edm::ESHandle<CaloGeometry> geom = es.getHandle(caloGeomToken_);
   es.get<CaloGeometryRecord>().get(geom);
   tools_->setGeometry(*geom);
   rechitMaker_->set(*geom);
   if (hgcEE_isSiFE_) {
-    edm::ESHandle<HGCalGeometry> hgceeGeoHandle;
-    es.get<IdealGeometryRecord>().get("HGCalEESensitive", hgceeGeoHandle);
+    edm::ESHandle<HGCalGeometry> hgceeGeoHandle = es.getHandle(ee_geometry_token_);
     ddds_[0] = &(hgceeGeoHandle->topology().dddConstants());
   } else {
     ddds_[0] = nullptr;
   }
   if (hgcHEF_isSiFE_) {
-    edm::ESHandle<HGCalGeometry> hgchefGeoHandle;
-    es.get<IdealGeometryRecord>().get("HGCalHESiliconSensitive", hgchefGeoHandle);
+    edm::ESHandle<HGCalGeometry> hgchefGeoHandle = es.getHandle(hef_geometry_token_);
     ddds_[1] = &(hgchefGeoHandle->topology().dddConstants());
   } else {
     ddds_[1] = nullptr;
   }
   ddds_[2] = nullptr;
   if (hgcHFNose_isSiFE_) {
-    edm::ESHandle<HGCalGeometry> hgchfnoseGeoHandle;
-    es.get<IdealGeometryRecord>().get("HGCalHFNoseSensitive", hgchfnoseGeoHandle);
+    edm::ESHandle<HGCalGeometry> hgchfnoseGeoHandle = es.getHandle(hfnose_geometry_token_);
     ddds_[3] = &(hgchfnoseGeoHandle->topology().dddConstants());
   } else {
     ddds_[3] = nullptr;

--- a/RecoLocalCalo/HGCalRecProducers/plugins/HGCalRecHitWorkerSimple.h
+++ b/RecoLocalCalo/HGCalRecProducers/plugins/HGCalRecHitWorkerSimple.h
@@ -12,6 +12,7 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 #include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 
 #include "Geometry/HGCalGeometry/interface/HGCalGeometry.h"
 #include "RecoLocalCalo/HGCalRecAlgos/interface/RecHitTools.h"
@@ -19,7 +20,7 @@
 
 class HGCalRecHitWorkerSimple : public HGCalRecHitWorkerBaseClass {
 public:
-  HGCalRecHitWorkerSimple(const edm::ParameterSet&);
+  HGCalRecHitWorkerSimple(const edm::ParameterSet&, edm::ConsumesCollector iC);
   ~HGCalRecHitWorkerSimple() override;
 
   void set(const edm::EventSetup& es) override;
@@ -27,6 +28,11 @@ public:
 
 protected:
   enum detectortype { hgcee = 1, hgcfh = 2, hgcbh = 3, hgchfnose = 4 };
+
+  edm::ESGetToken<CaloGeometry, CaloGeometryRecord> caloGeomToken_;
+  edm::ESGetToken<HGCalGeometry, IdealGeometryRecord> ee_geometry_token_;
+  edm::ESGetToken<HGCalGeometry, IdealGeometryRecord> hef_geometry_token_;
+  edm::ESGetToken<HGCalGeometry, IdealGeometryRecord> hfnose_geometry_token_;
 
   double hgcEE_keV2DIGI_, hgceeUncalib2GeV_;
   std::vector<double> hgcEE_fCPerMIP_;

--- a/RecoLocalCalo/HGCalRecProducers/plugins/HGCalUncalibRecHitProducer.cc
+++ b/RecoLocalCalo/HGCalRecProducers/plugins/HGCalUncalibRecHitProducer.cc
@@ -18,7 +18,7 @@ HGCalUncalibRecHitProducer::HGCalUncalibRecHitProducer(const edm::ParameterSet& 
       hefHitCollection_(ps.getParameter<std::string>("HGCHEFhitCollection")),
       hebHitCollection_(ps.getParameter<std::string>("HGCHEBhitCollection")),
       hfnoseHitCollection_(ps.getParameter<std::string>("HGCHFNosehitCollection")),
-      worker_{HGCalUncalibRecHitWorkerFactory::get()->create(ps.getParameter<std::string>("algo"), ps)} {
+      worker_{HGCalUncalibRecHitWorkerFactory::get()->create(ps.getParameter<std::string>("algo"), ps, consumesCollector())} {
   produces<HGCeeUncalibratedRecHitCollection>(eeHitCollection_);
   produces<HGChefUncalibratedRecHitCollection>(hefHitCollection_);
   produces<HGChebUncalibratedRecHitCollection>(hebHitCollection_);

--- a/RecoLocalCalo/HGCalRecProducers/plugins/HGCalUncalibRecHitProducer.cc
+++ b/RecoLocalCalo/HGCalRecProducers/plugins/HGCalUncalibRecHitProducer.cc
@@ -18,7 +18,8 @@ HGCalUncalibRecHitProducer::HGCalUncalibRecHitProducer(const edm::ParameterSet& 
       hefHitCollection_(ps.getParameter<std::string>("HGCHEFhitCollection")),
       hebHitCollection_(ps.getParameter<std::string>("HGCHEBhitCollection")),
       hfnoseHitCollection_(ps.getParameter<std::string>("HGCHFNosehitCollection")),
-      worker_{HGCalUncalibRecHitWorkerFactory::get()->create(ps.getParameter<std::string>("algo"), ps, consumesCollector())} {
+      worker_{HGCalUncalibRecHitWorkerFactory::get()->create(
+          ps.getParameter<std::string>("algo"), ps, consumesCollector())} {
   produces<HGCeeUncalibratedRecHitCollection>(eeHitCollection_);
   produces<HGChefUncalibratedRecHitCollection>(hefHitCollection_);
   produces<HGChebUncalibratedRecHitCollection>(hebHitCollection_);

--- a/RecoLocalCalo/HGCalRecProducers/plugins/HGCalUncalibRecHitWorkerWeights.cc
+++ b/RecoLocalCalo/HGCalRecProducers/plugins/HGCalUncalibRecHitWorkerWeights.cc
@@ -74,17 +74,14 @@ HGCalUncalibRecHitWorkerWeights::HGCalUncalibRecHitWorkerWeights(const edm::Para
 
 void HGCalUncalibRecHitWorkerWeights::set(const edm::EventSetup& es) {
   if (uncalibMaker_ee_.isSiFESim()) {
-    const HGCalGeometry& hgceeGeo = es.getData(ee_geometry_token_);
-    uncalibMaker_ee_.setGeometry(hgceeGeo);
+    uncalibMaker_ee_.setGeometry(&es.getData(ee_geometry_token_));
   }
   if (uncalibMaker_hef_.isSiFESim()) {
-    edm::ESHandle<HGCalGeometry> hgchefGeoHandle = es.getHandle(hef_geometry_token_);
-    uncalibMaker_hef_.setGeometry(hgchefGeoHandle.product());
+    uncalibMaker_hef_.setGeometry(&es.getData(hef_geometry_token_));
   }
   uncalibMaker_heb_.setGeometry(nullptr);
   if (uncalibMaker_hfnose_.isSiFESim()) {
-    edm::ESHandle<HGCalGeometry> hgchfnoseGeoHandle = es.getHandle(hfnose_geometry_token_);
-    uncalibMaker_hfnose_.setGeometry(hgchfnoseGeoHandle.product());
+    uncalibMaker_hfnose_.setGeometry(&es.getData(hfnose_geometry_token_));
   }
 }
 

--- a/RecoLocalCalo/HGCalRecProducers/plugins/HGCalUncalibRecHitWorkerWeights.cc
+++ b/RecoLocalCalo/HGCalRecProducers/plugins/HGCalUncalibRecHitWorkerWeights.cc
@@ -59,9 +59,9 @@ void configureIt(const edm::ParameterSet& conf, HGCalUncalibRecHitRecWeightsAlgo
 
 HGCalUncalibRecHitWorkerWeights::HGCalUncalibRecHitWorkerWeights(const edm::ParameterSet& ps, edm::ConsumesCollector iC)
     : HGCalUncalibRecHitWorkerBaseClass(ps, iC),
-  ee_geometry_token_(iC.esConsumes(edm::ESInputTag("", "HGCalEESensitive"))),
-  hef_geometry_token_(iC.esConsumes(edm::ESInputTag("", "HGCalHESiliconSensitive"))),
-  hfnose_geometry_token_(iC.esConsumes(edm::ESInputTag("", "HGCalHFNoseSensitive"))) {
+      ee_geometry_token_(iC.esConsumes(edm::ESInputTag("", "HGCalEESensitive"))),
+      hef_geometry_token_(iC.esConsumes(edm::ESInputTag("", "HGCalHESiliconSensitive"))),
+      hfnose_geometry_token_(iC.esConsumes(edm::ESInputTag("", "HGCalHFNoseSensitive"))) {
   const edm::ParameterSet& ee_cfg = ps.getParameterSet("HGCEEConfig");
   const edm::ParameterSet& hef_cfg = ps.getParameterSet("HGCHEFConfig");
   const edm::ParameterSet& heb_cfg = ps.getParameterSet("HGCHEBConfig");

--- a/RecoLocalCalo/HGCalRecProducers/plugins/HGCalUncalibRecHitWorkerWeights.cc
+++ b/RecoLocalCalo/HGCalRecProducers/plugins/HGCalUncalibRecHitWorkerWeights.cc
@@ -58,10 +58,10 @@ void configureIt(const edm::ParameterSet& conf, HGCalUncalibRecHitRecWeightsAlgo
 }
 
 HGCalUncalibRecHitWorkerWeights::HGCalUncalibRecHitWorkerWeights(const edm::ParameterSet& ps, edm::ConsumesCollector iC)
-    : HGCalUncalibRecHitWorkerBaseClass(ps, iC) {
-  ee_geometry_token_ = iC.esConsumes(edm::ESInputTag("", "HGCalEESensitive"));
-  hef_geometry_token_ = iC.esConsumes(edm::ESInputTag("", "HGCalHESiliconSensitive"));
-  hfnose_geometry_token_ = iC.esConsumes(edm::ESInputTag("", "HGCalHFNoseSensitive"));
+    : HGCalUncalibRecHitWorkerBaseClass(ps, iC),
+  ee_geometry_token_(iC.esConsumes(edm::ESInputTag("", "HGCalEESensitive"))),
+  hef_geometry_token_(iC.esConsumes(edm::ESInputTag("", "HGCalHESiliconSensitive"))),
+  hfnose_geometry_token_(iC.esConsumes(edm::ESInputTag("", "HGCalHFNoseSensitive"))) {
   const edm::ParameterSet& ee_cfg = ps.getParameterSet("HGCEEConfig");
   const edm::ParameterSet& hef_cfg = ps.getParameterSet("HGCHEFConfig");
   const edm::ParameterSet& heb_cfg = ps.getParameterSet("HGCHEBConfig");
@@ -74,8 +74,8 @@ HGCalUncalibRecHitWorkerWeights::HGCalUncalibRecHitWorkerWeights(const edm::Para
 
 void HGCalUncalibRecHitWorkerWeights::set(const edm::EventSetup& es) {
   if (uncalibMaker_ee_.isSiFESim()) {
-    edm::ESHandle<HGCalGeometry> hgceeGeoHandle = es.getHandle(ee_geometry_token_);
-    uncalibMaker_ee_.setGeometry(hgceeGeoHandle.product());
+    const HGCalGeometry& hgceeGeo = es.getData(ee_geometry_token_);
+    uncalibMaker_ee_.setGeometry(hgceeGeo);
   }
   if (uncalibMaker_hef_.isSiFESim()) {
     edm::ESHandle<HGCalGeometry> hgchefGeoHandle = es.getHandle(hef_geometry_token_);

--- a/RecoLocalCalo/HGCalRecProducers/plugins/HGCalUncalibRecHitWorkerWeights.cc
+++ b/RecoLocalCalo/HGCalRecProducers/plugins/HGCalUncalibRecHitWorkerWeights.cc
@@ -1,6 +1,7 @@
 #include "RecoLocalCalo/HGCalRecProducers/plugins/HGCalUncalibRecHitWorkerWeights.h"
 
 #include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/ESProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
@@ -56,8 +57,11 @@ void configureIt(const edm::ParameterSet& conf, HGCalUncalibRecHitRecWeightsAlgo
   }
 }
 
-HGCalUncalibRecHitWorkerWeights::HGCalUncalibRecHitWorkerWeights(const edm::ParameterSet& ps)
-    : HGCalUncalibRecHitWorkerBaseClass(ps) {
+HGCalUncalibRecHitWorkerWeights::HGCalUncalibRecHitWorkerWeights(const edm::ParameterSet& ps, edm::ConsumesCollector iC)
+    : HGCalUncalibRecHitWorkerBaseClass(ps, iC) {
+  ee_geometry_token_ = iC.esConsumes(edm::ESInputTag("", "HGCalEESensitive"));
+  hef_geometry_token_ = iC.esConsumes(edm::ESInputTag("", "HGCalHESiliconSensitive"));
+  hfnose_geometry_token_ = iC.esConsumes(edm::ESInputTag("", "HGCalHFNoseSensitive"));
   const edm::ParameterSet& ee_cfg = ps.getParameterSet("HGCEEConfig");
   const edm::ParameterSet& hef_cfg = ps.getParameterSet("HGCHEFConfig");
   const edm::ParameterSet& heb_cfg = ps.getParameterSet("HGCHEBConfig");
@@ -70,19 +74,16 @@ HGCalUncalibRecHitWorkerWeights::HGCalUncalibRecHitWorkerWeights(const edm::Para
 
 void HGCalUncalibRecHitWorkerWeights::set(const edm::EventSetup& es) {
   if (uncalibMaker_ee_.isSiFESim()) {
-    edm::ESHandle<HGCalGeometry> hgceeGeoHandle;
-    es.get<IdealGeometryRecord>().get("HGCalEESensitive", hgceeGeoHandle);
+    edm::ESHandle<HGCalGeometry> hgceeGeoHandle = es.getHandle(ee_geometry_token_);
     uncalibMaker_ee_.setGeometry(hgceeGeoHandle.product());
   }
   if (uncalibMaker_hef_.isSiFESim()) {
-    edm::ESHandle<HGCalGeometry> hgchefGeoHandle;
-    es.get<IdealGeometryRecord>().get("HGCalHESiliconSensitive", hgchefGeoHandle);
+    edm::ESHandle<HGCalGeometry> hgchefGeoHandle = es.getHandle(hef_geometry_token_);
     uncalibMaker_hef_.setGeometry(hgchefGeoHandle.product());
   }
   uncalibMaker_heb_.setGeometry(nullptr);
   if (uncalibMaker_hfnose_.isSiFESim()) {
-    edm::ESHandle<HGCalGeometry> hgchfnoseGeoHandle;
-    es.get<IdealGeometryRecord>().get("HGCalHFNoseSensitive", hgchfnoseGeoHandle);
+    edm::ESHandle<HGCalGeometry> hgchfnoseGeoHandle = es.getHandle(hfnose_geometry_token_);
     uncalibMaker_hfnose_.setGeometry(hgchfnoseGeoHandle.product());
   }
 }

--- a/RecoLocalCalo/HGCalRecProducers/plugins/HGCalUncalibRecHitWorkerWeights.h
+++ b/RecoLocalCalo/HGCalRecProducers/plugins/HGCalUncalibRecHitWorkerWeights.h
@@ -14,6 +14,7 @@
 #include "DataFormats/HGCDigi/interface/HGCDataFrame.h"
 #include "DataFormats/HGCDigi/interface/HGCSample.h"
 #include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 
 namespace edm {
   class Event;
@@ -23,7 +24,7 @@ namespace edm {
 
 class HGCalUncalibRecHitWorkerWeights : public HGCalUncalibRecHitWorkerBaseClass {
 public:
-  HGCalUncalibRecHitWorkerWeights(const edm::ParameterSet&);
+  HGCalUncalibRecHitWorkerWeights(const edm::ParameterSet&, edm::ConsumesCollector iC);
   ~HGCalUncalibRecHitWorkerWeights() override{};
 
   void set(const edm::EventSetup& es) override;
@@ -36,6 +37,9 @@ public:
                     HGChfnoseUncalibratedRecHitCollection& result) override;
 
 protected:
+  edm::ESGetToken<HGCalGeometry, IdealGeometryRecord> ee_geometry_token_;
+  edm::ESGetToken<HGCalGeometry, IdealGeometryRecord> hef_geometry_token_;
+  edm::ESGetToken<HGCalGeometry, IdealGeometryRecord> hfnose_geometry_token_;
   HGCalUncalibRecHitRecWeightsAlgo<HGCalDataFrame> uncalibMaker_ee_;
   HGCalUncalibRecHitRecWeightsAlgo<HGCalDataFrame> uncalibMaker_hef_;
   HGCalUncalibRecHitRecWeightsAlgo<HGCalDataFrame> uncalibMaker_heb_;

--- a/RecoParticleFlow/PFTracking/plugins/HGCalTrackCollectionProducer.cc
+++ b/RecoParticleFlow/PFTracking/plugins/HGCalTrackCollectionProducer.cc
@@ -133,8 +133,6 @@ void HGCalTrackCollectionProducer::beginLuminosityBlock(const edm::LuminosityBlo
 }
 
 void HGCalTrackCollectionProducer::produce(edm::Event& evt, const edm::EventSetup& iSetup) {
-  edm::ESHandle<MagneticField> bField_ = iSetup.getHandle(bFieldToken_);
-  edm::ESHandle<TrackerGeometry> tkGeom_ = iSetup.getHandle(trkGeomToken_);
   edm::Handle<edm::View<reco::PFRecTrack> > trackHandle;
   evt.getByToken(src_, trackHandle);
   const auto& tracks = *trackHandle;

--- a/RecoParticleFlow/PFTracking/plugins/HGCalTrackCollectionProducer.cc
+++ b/RecoParticleFlow/PFTracking/plugins/HGCalTrackCollectionProducer.cc
@@ -133,6 +133,8 @@ void HGCalTrackCollectionProducer::beginLuminosityBlock(const edm::LuminosityBlo
 }
 
 void HGCalTrackCollectionProducer::produce(edm::Event& evt, const edm::EventSetup& iSetup) {
+  edm::ESHandle<MagneticField> bField_ = iSetup.getHandle(bFieldToken_);
+  edm::ESHandle<TrackerGeometry> tkGeom_ = iSetup.getHandle(trkGeomToken_);
   edm::Handle<edm::View<reco::PFRecTrack> > trackHandle;
   evt.getByToken(src_, trackHandle);
   const auto& tracks = *trackHandle;

--- a/Validation/HGCalValidation/plugins/HGCalHitCalibration.cc
+++ b/Validation/HGCalValidation/plugins/HGCalHitCalibration.cc
@@ -82,7 +82,9 @@ private:
 };
 
 HGCalHitCalibration::HGCalHitCalibration(const edm::ParameterSet& iConfig)
-    : caloGeomToken_(esConsumes<CaloGeometry, CaloGeometryRecord>()), rawRecHits_(iConfig.getParameter<bool>("rawRecHits")), debug_(iConfig.getParameter<int>("debug")) {
+    : caloGeomToken_(esConsumes<CaloGeometry, CaloGeometryRecord>()),
+      rawRecHits_(iConfig.getParameter<bool>("rawRecHits")),
+      debug_(iConfig.getParameter<int>("debug")) {
   auto detector = iConfig.getParameter<std::string>("detector");
   auto recHitsEE = iConfig.getParameter<edm::InputTag>("recHitsEE");
   auto recHitsFH = iConfig.getParameter<edm::InputTag>("recHitsFH");

--- a/Validation/HGCalValidation/plugins/HGCalHitCalibration.cc
+++ b/Validation/HGCalValidation/plugins/HGCalHitCalibration.cc
@@ -62,6 +62,7 @@ private:
   edm::EDGetTokenT<std::vector<reco::Photon> > photons_;
 
   int algo_, depletion0_;
+  edm::ESGetToken<CaloGeometry, CaloGeometryRecord> caloGeomToken_;
   bool rawRecHits_;
   int debug_;
   hgcal::RecHitTools recHitTools_;
@@ -81,7 +82,7 @@ private:
 };
 
 HGCalHitCalibration::HGCalHitCalibration(const edm::ParameterSet& iConfig)
-    : rawRecHits_(iConfig.getParameter<bool>("rawRecHits")), debug_(iConfig.getParameter<int>("debug")) {
+    : caloGeomToken_(esConsumes<CaloGeometry, CaloGeometryRecord>()), rawRecHits_(iConfig.getParameter<bool>("rawRecHits")), debug_(iConfig.getParameter<int>("debug")) {
   auto detector = iConfig.getParameter<std::string>("detector");
   auto recHitsEE = iConfig.getParameter<edm::InputTag>("recHitsEE");
   auto recHitsFH = iConfig.getParameter<edm::InputTag>("recHitsFH");
@@ -191,8 +192,7 @@ void HGCalHitCalibration::fillWithRecHits(std::map<DetId, const HGCRecHit*>& hit
 void HGCalHitCalibration::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
   using namespace edm;
 
-  edm::ESHandle<CaloGeometry> geom;
-  iSetup.get<CaloGeometryRecord>().get(geom);
+  edm::ESHandle<CaloGeometry> geom = iSetup.getHandle(caloGeomToken_);
   recHitTools_.setGeometry(*geom);
 
   Handle<HGCRecHitCollection> recHitHandleEE;

--- a/Validation/HGCalValidation/plugins/HGCalRecHitValidation.cc
+++ b/Validation/HGCalValidation/plugins/HGCalRecHitValidation.cc
@@ -69,6 +69,7 @@ private:
 
   // ----------member data ---------------------------
   std::string nameDetector_;
+  edm::ESGetToken<CaloGeometry, CaloGeometryRecord> caloGeomToken_;
   edm::EDGetToken recHitSource_;
   bool ifHCAL_;
   int verbosity_;
@@ -88,6 +89,7 @@ private:
 
 HGCalRecHitValidation::HGCalRecHitValidation(const edm::ParameterSet& iConfig)
     : nameDetector_(iConfig.getParameter<std::string>("DetectorName")),
+      caloGeomToken_(esConsumes<CaloGeometry, CaloGeometryRecord>()),
       ifHCAL_(iConfig.getParameter<bool>("ifHCAL")),
       verbosity_(iConfig.getUntrackedParameter<int>("Verbosity", 0)),
       firstLayer_(1) {
@@ -123,8 +125,7 @@ void HGCalRecHitValidation::analyze(const edm::Event& iEvent, const edm::EventSe
   bool ok(true);
   unsigned int ntot(0), nused(0);
   if (nameDetector_ == "HCal") {
-    edm::ESHandle<CaloGeometry> geom;
-    iSetup.get<CaloGeometryRecord>().get(geom);
+    edm::ESHandle<CaloGeometry> geom = iSetup.getHandle(caloGeomToken_);
     if (!geom.isValid()) {
       edm::LogVerbatim("HGCalValidation") << "Cannot get valid HGCalGeometry "
                                           << "Object for " << nameDetector_;

--- a/Validation/HGCalValidation/plugins/HGCalRecHitValidation.cc
+++ b/Validation/HGCalValidation/plugins/HGCalRecHitValidation.cc
@@ -70,13 +70,9 @@ private:
   // ----------member data ---------------------------
   std::string nameDetector_;
   edm::ESGetToken<CaloGeometry, CaloGeometryRecord> caloGeomToken_;
-  edm::ESGetToken<HGCalGeometry, IdealGeometryRecord> ee_geometry_token_;
-  edm::ESGetToken<HGCalGeometry, IdealGeometryRecord> hesil_geometry_token_;
-  edm::ESGetToken<HGCalGeometry, IdealGeometryRecord> hesci_geometry_token_;
+  edm::ESGetToken<HGCalGeometry, IdealGeometryRecord> geometry_token_;
   edm::ESGetToken<HcalDDDRecConstants, HcalRecNumberingRecord> pHRNDCToken_;
-  edm::ESGetToken<HGCalGeometry, IdealGeometryRecord> ee_geometry_beginRun_token_;
-  edm::ESGetToken<HGCalGeometry, IdealGeometryRecord> hesil_geometry_beginRun_token_;
-  edm::ESGetToken<HGCalGeometry, IdealGeometryRecord> hesci_geometry_beginRun_token_;
+  edm::ESGetToken<HGCalGeometry, IdealGeometryRecord> geometry_beginRun_token_;
   edm::EDGetToken recHitSource_;
   bool ifHCAL_;
   int verbosity_;
@@ -97,16 +93,10 @@ private:
 HGCalRecHitValidation::HGCalRecHitValidation(const edm::ParameterSet& iConfig)
     : nameDetector_(iConfig.getParameter<std::string>("DetectorName")),
       caloGeomToken_(esConsumes<CaloGeometry, CaloGeometryRecord>()),
-      ee_geometry_token_(esConsumes(edm::ESInputTag("", "HGCalEESensitive"))),
-      hesil_geometry_token_(esConsumes(edm::ESInputTag("", "HGCalHESiliconSensitive"))),
-      hesci_geometry_token_(esConsumes(edm::ESInputTag("", "HGCalHFNoseSensitive"))),
+      geometry_token_(esConsumes(edm::ESInputTag("", nameDetector_))),
       pHRNDCToken_(esConsumes<HcalDDDRecConstants, HcalRecNumberingRecord>()),
-      ee_geometry_beginRun_token_(esConsumes<HGCalGeometry, IdealGeometryRecord, edm::Transition::BeginRun>(
-          edm::ESInputTag("", "HGCalEESensitive"))),
-      hesil_geometry_beginRun_token_(esConsumes<HGCalGeometry, IdealGeometryRecord, edm::Transition::BeginRun>(
-          edm::ESInputTag("", "HGCalHESiliconSensitive"))),
-      hesci_geometry_beginRun_token_(esConsumes<HGCalGeometry, IdealGeometryRecord, edm::Transition::BeginRun>(
-          edm::ESInputTag("", "HGCalHFNoseSensitive"))),
+      geometry_beginRun_token_(esConsumes<HGCalGeometry, IdealGeometryRecord, edm::Transition::BeginRun>(
+          edm::ESInputTag("", nameDetector_))),
       ifHCAL_(iConfig.getParameter<bool>("ifHCAL")),
       verbosity_(iConfig.getUntrackedParameter<int>("Verbosity", 0)),
       firstLayer_(1) {
@@ -189,14 +179,7 @@ void HGCalRecHitValidation::analyze(const edm::Event& iEvent, const edm::EventSe
       }
     }
   } else {
-    edm::ESHandle<HGCalGeometry> geomHandle;
-    if (nameDetector_ == "HGCalEESensitive") {
-      geomHandle = iSetup.getHandle(ee_geometry_token_);
-    } else if (nameDetector_ == "HGCalHESiliconSensitive") {
-      geomHandle = iSetup.getHandle(hesil_geometry_token_);
-    } else if (nameDetector_ == "HGCalHEScintillatorSensitive") {
-      geomHandle = iSetup.getHandle(hesci_geometry_token_);
-    }
+    edm::ESHandle<HGCalGeometry> geomHandle = iSetup.getHandle(geometry_token_);
     if (!geomHandle.isValid()) {
       edm::LogVerbatim("HGCalValidation") << "Cannot get valid HGCalGeometry "
                                           << "Object for " << nameDetector_;
@@ -298,14 +281,7 @@ void HGCalRecHitValidation::dqmBeginRun(const edm::Run&, const edm::EventSetup& 
     const HcalDDDRecConstants& hcons = iSetup.getData(pHRNDCToken_);
     layers_ = hcons.getMaxDepth(1);
   } else {
-    edm::ESHandle<HGCalGeometry> geomHandle;
-    if (nameDetector_ == "HGCalEESensitive") {
-      geomHandle = iSetup.getHandle(ee_geometry_beginRun_token_);
-    } else if (nameDetector_ == "HGCalHESiliconSensitive") {
-      geomHandle = iSetup.getHandle(hesil_geometry_beginRun_token_);
-    } else if (nameDetector_ == "HGCalHEScintillatorSensitive") {
-      geomHandle = iSetup.getHandle(hesci_geometry_beginRun_token_);
-    }
+    edm::ESHandle<HGCalGeometry> geomHandle = iSetup.getHandle(geometry_beginRun_token_);
     if (!geomHandle.isValid()) {
       edm::LogVerbatim("HGCalValidation") << "Cannot get valid HGCalGeometry "
                                           << "Object for " << nameDetector_;

--- a/Validation/HGCalValidation/plugins/HGCalRecHitValidation.cc
+++ b/Validation/HGCalValidation/plugins/HGCalRecHitValidation.cc
@@ -70,6 +70,7 @@ private:
   // ----------member data ---------------------------
   std::string nameDetector_;
   edm::ESGetToken<CaloGeometry, CaloGeometryRecord> caloGeomToken_;
+  edm::ESGetToken<HcalDDDRecConstants, HcalRecNumberingRecord> pHRNDCToken_;
   edm::EDGetToken recHitSource_;
   bool ifHCAL_;
   int verbosity_;
@@ -90,6 +91,7 @@ private:
 HGCalRecHitValidation::HGCalRecHitValidation(const edm::ParameterSet& iConfig)
     : nameDetector_(iConfig.getParameter<std::string>("DetectorName")),
       caloGeomToken_(esConsumes<CaloGeometry, CaloGeometryRecord>()),
+      pHRNDCToken_(esConsumes<HcalDDDRecConstants, HcalRecNumberingRecord>()),
       ifHCAL_(iConfig.getParameter<bool>("ifHCAL")),
       verbosity_(iConfig.getUntrackedParameter<int>("Verbosity", 0)),
       firstLayer_(1) {
@@ -272,10 +274,8 @@ void HGCalRecHitValidation::fillHitsInfo(HitsInfo& hits) {
 
 void HGCalRecHitValidation::dqmBeginRun(const edm::Run&, const edm::EventSetup& iSetup) {
   if (nameDetector_ == "HCal") {
-    edm::ESHandle<HcalDDDRecConstants> pHRNDC;
-    iSetup.get<HcalRecNumberingRecord>().get(pHRNDC);
-    const HcalDDDRecConstants* hcons = &(*pHRNDC);
-    layers_ = hcons->getMaxDepth(1);
+    const HcalDDDRecConstants& hcons = iSetup.getData(pHRNDCToken_);
+    layers_ = hcons.getMaxDepth(1);
   } else {
     edm::ESHandle<HGCalDDDConstants> pHGDC;
     iSetup.get<IdealGeometryRecord>().get(nameDetector_, pHGDC);


### PR DESCRIPTION
#### PR description:

Fix `ESHandle` for many HGCal modules.
Twiki pages used [here](https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideHowToGetDataFromES) and [here](https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideEDMGetDataFromEvent#Consumes_and_Helpers).

#### PR validation:

- runTheMatrix `23293.0_CloseByParticleGun` successful

thanks to @makortel for the help
