### PR TITLE
Hit counters for Run-3 shower CSC trigger (HadronicShowerTrigger-2)

### DIFF
--- a/L1Trigger/CSCTriggerPrimitives/interface/CSCAnodeLCTProcessor.h
+++ b/L1Trigger/CSCTriggerPrimitives/interface/CSCAnodeLCTProcessor.h
@@ -37,6 +37,7 @@
 #include "DataFormats/CSCDigi/interface/CSCWireDigiCollection.h"
 #include "DataFormats/CSCDigi/interface/CSCALCTDigi.h"
 #include "DataFormats/CSCDigi/interface/CSCALCTPreTriggerDigi.h"
+#include "DataFormats/CSCDigi/interface/CSCShowerDigi.h"
 #include "CondFormats/CSCObjects/interface/CSCDBL1TPParameters.h"
 #include "L1Trigger/CSCTriggerPrimitives/interface/CSCBaseboard.h"
 #include "L1Trigger/CSCTriggerPrimitives/interface/LCTQualityControl.h"
@@ -88,8 +89,12 @@ public:
   CSCALCTDigi getBestALCT(int bx) const;
   CSCALCTDigi getSecondALCT(int bx) const;
 
-  /* encode special bits for high multiplicity triggers */
-  unsigned getHighMultiplictyBits() const { return highMultiplicityBits_; }
+  /* get special bits for high multiplicity triggers */
+  unsigned getInTimeHMT() const { return inTimeHMT_; }
+  unsigned getOutTimeHMT() const { return outTimeHMT_; }
+
+  /** Returns shower bits */
+  CSCShowerDigi readoutShower() const;
 
 protected:
   /** Best LCTs in this chamber, as found by the processor.
@@ -104,6 +109,8 @@ protected:
 
   /** LCTs in this chamber, as found by the processor. */
   std::vector<std::vector<CSCALCTDigi> > ALCTContainer_;
+
+  CSCShowerDigi shower_;
 
   /** Access routines to wire digis. */
   bool getDigis(const CSCWireDigiCollection* wiredc);
@@ -123,8 +130,14 @@ protected:
   std::vector<CSCALCTPreTriggerDigi> thePreTriggerDigis;
 
   /* data members for high multiplicity triggers */
-  void encodeHighMultiplicityBits();
-  unsigned int highMultiplicityBits_;
+  void encodeHighMultiplicityBits(const std::vector<int> wire[CSCConstants::NUM_LAYERS][CSCConstants::MAX_NUM_WIRES]);
+  unsigned inTimeHMT_;
+  unsigned outTimeHMT_;
+  std::vector<unsigned> thresholds_;
+  unsigned showerMinInTBin_;
+  unsigned showerMaxInTBin_;
+  unsigned showerMinOutTBin_;
+  unsigned showerMaxOutTBin_;
 
   /** Configuration parameters. */
   unsigned int fifo_tbins, fifo_pretrig, drift_delay;

--- a/L1Trigger/CSCTriggerPrimitives/interface/CSCBaseboard.h
+++ b/L1Trigger/CSCTriggerPrimitives/interface/CSCBaseboard.h
@@ -77,6 +77,9 @@ protected:
   // CLCT Processor parameters:
   edm::ParameterSet clctParams_;
 
+  // Shower Trigger parameters:
+  edm::ParameterSet showerParams_;
+
   // chamber name, e.g. ME+1/1/9
   std::string theCSCName_;
 

--- a/L1Trigger/CSCTriggerPrimitives/interface/CSCCathodeLCTProcessor.h
+++ b/L1Trigger/CSCTriggerPrimitives/interface/CSCCathodeLCTProcessor.h
@@ -91,6 +91,10 @@ public:
   std::vector<CSCCLCTPreTriggerDigi> preTriggerDigisME1a() const;
   std::vector<CSCCLCTPreTriggerDigi> preTriggerDigisME1b() const;
 
+  /* get special bits for high multiplicity triggers */
+  unsigned getInTimeHMT() const { return inTimeHMT_; }
+  unsigned getOutTimeHMT() const { return outTimeHMT_; }
+
 protected:
   /** Best LCT in this chamber, as found by the processor. */
   CSCCLCTDigi bestCLCT[CSCConstants::MAX_CLCT_TBINS];
@@ -201,6 +205,17 @@ protected:
   std::vector<CSCComparatorDigi> digiV[CSCConstants::NUM_LAYERS];
   std::vector<int> thePreTriggerBXs;
   std::vector<CSCCLCTPreTriggerDigi> thePreTriggerDigis;
+
+  /* data members for high multiplicity triggers */
+  void encodeHighMultiplicityBits(
+      const std::vector<int> halfstrip[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS_7CFEBS]);
+  unsigned inTimeHMT_;
+  unsigned outTimeHMT_;
+  std::vector<unsigned> thresholds_;
+  unsigned showerMinInTBin_;
+  unsigned showerMaxInTBin_;
+  unsigned showerMinOutTBin_;
+  unsigned showerMaxOutTBin_;
 
   /** Configuration parameters. */
   unsigned int fifo_tbins, fifo_pretrig;  // only for test beam mode.

--- a/L1Trigger/CSCTriggerPrimitives/interface/CSCMotherboard.h
+++ b/L1Trigger/CSCTriggerPrimitives/interface/CSCMotherboard.h
@@ -37,6 +37,7 @@
 #include "L1Trigger/CSCTriggerPrimitives/interface/CSCAnodeLCTProcessor.h"
 #include "L1Trigger/CSCTriggerPrimitives/interface/CSCCathodeLCTProcessor.h"
 #include "DataFormats/CSCDigi/interface/CSCCorrelatedLCTDigi.h"
+#include "DataFormats/CSCDigi/interface/CSCShowerDigi.h"
 
 class CSCMotherboard : public CSCBaseboard {
 public:
@@ -64,6 +65,9 @@ public:
   /** Returns vector of all found correlated LCTs, if any. */
   std::vector<CSCCorrelatedLCTDigi> getLCTs() const;
 
+  /** Returns shower bits */
+  CSCShowerDigi readoutShower() const;
+
   /** Clears correlated LCT and passes clear signal on to cathode and anode
       LCT processors. */
   void clear();
@@ -88,6 +92,8 @@ protected:
 
   /** Container for second correlated LCT. */
   CSCCorrelatedLCTDigi secondLCT[CSCConstants::MAX_LCT_TBINS];
+
+  CSCShowerDigi shower_;
 
   // helper function to return ALCT/CLCT with correct central BX
   CSCALCTDigi getBXShiftedALCT(const CSCALCTDigi&) const;
@@ -115,8 +121,7 @@ protected:
   bool clct_to_alct;
 
   // encode special bits for high-multiplicity triggers
-  unsigned int highMultiplicityBits_;
-  bool useHighMultiplicityBits_;
+  unsigned showerSource_;
 
   /** Default values of configuration parameters. */
   static const unsigned int def_mpc_block_me1a;
@@ -178,6 +183,6 @@ protected:
   void dumpConfigParams() const;
 
   /* encode high multiplicity bits for Run-3 exotic triggers */
-  void encodeHighMultiplicityBits(unsigned alctBits);
+  void encodeHighMultiplicityBits();
 };
 #endif

--- a/L1Trigger/CSCTriggerPrimitives/interface/CSCTriggerPrimitivesBuilder.h
+++ b/L1Trigger/CSCTriggerPrimitives/interface/CSCTriggerPrimitivesBuilder.h
@@ -27,6 +27,7 @@
 #include "DataFormats/CSCDigi/interface/CSCCLCTPreTriggerDigiCollection.h"
 #include "DataFormats/CSCDigi/interface/CSCCorrelatedLCTDigiCollection.h"
 #include "DataFormats/CSCDigi/interface/CSCCLCTPreTriggerCollection.h"
+#include "DataFormats/CSCDigi/interface/CSCShowerDigiCollection.h"
 #include "DataFormats/GEMDigi/interface/GEMPadDigiClusterCollection.h"
 #include "DataFormats/GEMDigi/interface/GEMCoPadDigiCollection.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -76,6 +77,8 @@ public:
              CSCCLCTPreTriggerCollection& oc_pretrig,
              CSCCorrelatedLCTDigiCollection& oc_lct,
              CSCCorrelatedLCTDigiCollection& oc_sorted_lct,
+             CSCShowerDigiCollection& oc_shower,
+             CSCShowerDigiCollection& oc_shower_anode,
              GEMCoPadDigiCollection& oc_gemcopad);
 
   /** Max values of trigger labels for all CSCs; used to construct TMB

--- a/L1Trigger/CSCTriggerPrimitives/plugins/CSCTriggerPrimitivesProducer.h
+++ b/L1Trigger/CSCTriggerPrimitives/plugins/CSCTriggerPrimitivesProducer.h
@@ -89,6 +89,9 @@ private:
   // Write out pre-triggers
   bool savePreTriggers_;
 
+  // write out showrs
+  bool writeOutShowers_;
+
   // switch to enable the integrated local triggers in ME11 and ME21
   bool runME11ILT_;
   bool runME21ILT_;

--- a/L1Trigger/CSCTriggerPrimitives/python/cscTriggerPrimitiveDigis_cfi.py
+++ b/L1Trigger/CSCTriggerPrimitives/python/cscTriggerPrimitiveDigis_cfi.py
@@ -10,6 +10,7 @@ from L1Trigger.CSCTriggerPrimitives.params.clctParams import clctPSets
 from L1Trigger.CSCTriggerPrimitives.params.tmbParams import tmbPSets
 from L1Trigger.CSCTriggerPrimitives.params.auxiliaryParams import auxPSets
 from L1Trigger.CSCTriggerPrimitives.params.cclutParams import cclutParams
+from L1Trigger.CSCTriggerPrimitives.params.showerParams import showerPSet
 
 cscTriggerPrimitiveDigis = cms.EDProducer(
     "CSCTriggerPrimitivesProducer",
@@ -39,9 +40,11 @@ cscTriggerPrimitiveDigis = cms.EDProducer(
     writeOutAllCLCTs = cms.bool(False),
     writeOutAllALCTs = cms.bool(False),
     savePreTriggers = cms.bool(False),
+    writeOutShowers = cms.bool(False),
 
     commonParam = auxPSets.commonParam.clone(),
-    mpcParam = auxPSets.mpcParamRun1.clone()
+    mpcParam = auxPSets.mpcParamRun1.clone(),
+    showerParam = showerPSet.clone()
 )
 
 

--- a/L1Trigger/CSCTriggerPrimitives/python/params/showerParams.py
+++ b/L1Trigger/CSCTriggerPrimitives/python/params/showerParams.py
@@ -1,0 +1,73 @@
+import FWCore.ParameterSet.Config as cms
+
+#Parameterset for the hadronic shower trigger for Run-3
+showerPSet = cms.PSet(
+    ## what kind of shower triggers the logic?
+    ## 0: cathode-only (TMB/OTMB)
+    ## 1: anode-only (from ALCT board)
+    ## 2: cathode or anode showers
+    ##    loose -> 'loose anode or loose cathode'
+    ##    nominal -> 'nominal anode or nominal cathode'
+    ##    tight -> 'tight anode or tight cathode'
+    source  = cms.uint32(0),
+
+    ## settings for cathode showers (counting CSCComparatorDigi)
+    cathodeShower = cms.PSet(
+        ## {loose, nominal, tight} thresholds for hit counters
+        ## loose ~ 0.75 kHz
+        ## nominal ~ 0.5  kHz
+        ## tight ~ 0.25 kHz
+        showerThresholds = cms.vuint32(
+            # ME1/1
+            100, 100, 100,
+            # ME1/2
+            54, 55, 61,
+            # ME1/3
+            20, 20, 30,
+            # ME2/1
+            35, 35, 35,
+            # ME2/2
+            29, 29, 35,
+            # ME3/1
+            35, 35, 40,
+            # ME3/2
+            24, 25, 30,
+            # ME4/1
+            36, 40, 40,
+            # ME4/2
+            26, 30, 30
+        ),
+        showerMinInTBin = cms.uint32(6),
+        showerMaxInTBin = cms.uint32(8),
+        showerMinOutTBin = cms.uint32(2),
+        showerMaxOutTBin = cms.uint32(5),
+    ),
+    ## settings for anode showers (counting CSCWireDigi)
+    anodeShower = cms.PSet(
+        ## {loose, nominal, tight} thresholds for hit counters
+        showerThresholds = cms.vuint32(
+            # ME1/1
+            104, 105, 107,
+            # ME1/2
+            92, 100, 102,
+            # ME1/3
+            32, 33, 48,
+            # ME2/1
+            133, 134, 136,
+            # ME2/2
+            83, 84, 86,
+            # ME3/1
+            130, 131, 133,
+            # ME3/2
+            74, 80, 87,
+            # ME4/1
+            127, 128, 130,
+            # ME4/2
+            88, 89, 94
+        ),
+        showerMinInTBin = cms.uint32(8),
+        showerMaxInTBin = cms.uint32(10),
+        showerMinOutTBin = cms.uint32(4),
+        showerMaxOutTBin = cms.uint32(7),
+    )
+)

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCAnodeLCTProcessor.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCAnodeLCTProcessor.cc
@@ -1399,7 +1399,7 @@ void CSCAnodeLCTProcessor::setWireContainer(CSCALCTDigi& alct, CSCALCTDigi::Wire
 }
 
 void CSCAnodeLCTProcessor::encodeHighMultiplicityBits(
-                                                      const std::vector<int> wires[CSCConstants::NUM_LAYERS][CSCConstants::MAX_NUM_WIRES]) {
+    const std::vector<int> wires[CSCConstants::NUM_LAYERS][CSCConstants::MAX_NUM_WIRES]) {
   inTimeHMT_ = 0;
   outTimeHMT_ = 0;
 

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCAnodeLCTProcessor.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCAnodeLCTProcessor.cc
@@ -247,9 +247,9 @@ std::vector<CSCALCTDigi> CSCAnodeLCTProcessor::run(const CSCWireDigiCollection* 
   }
 
   // Get wire digis in this chamber from wire digi collection.
-  bool noDigis = getDigis(wiredc);
+  bool hasDigis = getDigis(wiredc);
 
-  if (!noDigis) {
+  if (hasDigis) {
     // First get wire times from the wire digis.
     std::vector<int> wire[CSCConstants::NUM_LAYERS][CSCConstants::MAX_NUM_WIRES];
     readWireDigis(wire);
@@ -369,7 +369,7 @@ void CSCAnodeLCTProcessor::run(const std::vector<int> wire[CSCConstants::NUM_LAY
 
 bool CSCAnodeLCTProcessor::getDigis(const CSCWireDigiCollection* wiredc) {
   // Routine for getting digis and filling digiV vector.
-  bool noDigis = true;
+  bool hasDigis = false;
 
   // Loop over layers and save wire digis on each one into digiV[layer].
   for (int i_layer = 0; i_layer < CSCConstants::NUM_LAYERS; i_layer++) {
@@ -385,7 +385,7 @@ bool CSCAnodeLCTProcessor::getDigis(const CSCWireDigiCollection* wiredc) {
     }
 
     if (!digiV[i_layer].empty()) {
-      noDigis = false;
+      hasDigis = true;
       if (infoV > 1) {
         LogTrace("CSCAnodeLCTProcessor") << "found " << digiV[i_layer].size() << " wire digi(s) in layer " << i_layer
                                          << " of " << theCSCName_ << " (trig. sector " << theSector << " subsector "
@@ -397,7 +397,7 @@ bool CSCAnodeLCTProcessor::getDigis(const CSCWireDigiCollection* wiredc) {
     }
   }
 
-  return noDigis;
+  return hasDigis;
 }
 
 void CSCAnodeLCTProcessor::getDigis(const CSCWireDigiCollection* wiredc, const CSCDetId& id) {

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCBaseboard.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCBaseboard.cc
@@ -21,6 +21,8 @@ CSCBaseboard::CSCBaseboard(unsigned endcap,
 
   commonParams_ = conf.getParameter<edm::ParameterSet>("commonParam");
 
+  showerParams_ = conf.getParameterSet("showerParam");
+
   theCSCName_ = CSCDetId::chamberName(theEndcap, theStation, theRing, theChamber);
 
   runPhase2_ = commonParams_.getParameter<bool>("runPhase2");

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCGEMMotherboard.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCGEMMotherboard.cc
@@ -273,9 +273,6 @@ CSCCorrelatedLCTDigi CSCGEMMotherboard::constructLCTsGEM(const CSCALCTDigi& alct
   // Not used in Run-2. Will not be assigned in Run-3
   thisLCT.setSyncErr(0);
   thisLCT.setCSCID(theTrigChamber);
-  // in Run-3 we plan to denote the presence of exotic signatures in the chamber
-  if (useHighMultiplicityBits_)
-    thisLCT.setHMT(highMultiplicityBits_);
 
   // future work: add a section that produces LCTs according
   // to the new LCT dataformat (not yet defined)

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCGEMMotherboardME11.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCGEMMotherboardME11.cc
@@ -60,8 +60,7 @@ void CSCGEMMotherboardME11::run(const CSCWireDigiCollection* wiredc,
   CSCGEMMotherboard::clear();
 
   // encode high multiplicity bits
-  unsigned alctBits = alctProc->getHighMultiplictyBits();
-  encodeHighMultiplicityBits(alctBits);
+  encodeHighMultiplicityBits();
 
   if (gem_g != nullptr) {
     if (infoV >= 0)

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCGEMMotherboardME21.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCGEMMotherboardME21.cc
@@ -43,8 +43,7 @@ void CSCGEMMotherboardME21::run(const CSCWireDigiCollection* wiredc,
   CSCGEMMotherboard::clear();
 
   // encode high multiplicity bits
-  unsigned alctBits = alctProc->getHighMultiplictyBits();
-  encodeHighMultiplicityBits(alctBits);
+  encodeHighMultiplicityBits();
 
   if (gem_g != nullptr) {
     if (infoV >= 0)

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboard.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboard.cc
@@ -38,10 +38,6 @@ CSCMotherboard::CSCMotherboard(unsigned endcap,
 
   clct_to_alct = tmbParams_.getParameter<bool>("clctToAlct");
 
-  // special tmb bits
-  useHighMultiplicityBits_ = tmbParams_.getParameter<bool>("useHighMultiplicityBits");
-  highMultiplicityBits_ = 0;
-
   // whether to readout only the earliest two LCTs in readout window
   readout_earliest_2 = tmbParams_.getParameter<bool>("tmbReadoutEarliest2");
 
@@ -59,6 +55,9 @@ CSCMotherboard::CSCMotherboard(unsigned endcap,
 
   // quality control of stubs
   qualityControl_ = std::make_unique<LCTQualityControl>(endcap, station, sector, subsector, chamber, conf);
+
+  // shower-trigger source
+  showerSource_ = showerParams_.getParameter<unsigned>("source");
 }
 
 CSCMotherboard::CSCMotherboard() : CSCBaseboard() {
@@ -102,6 +101,9 @@ void CSCMotherboard::clear() {
     firstLCT[bx].clear();
     secondLCT[bx].clear();
   }
+
+  // reset the shower trigger
+  shower_.clear();
 }
 
 // Set configuration parameters obtained via EventSetup mechanism.
@@ -150,8 +152,7 @@ void CSCMotherboard::run(const CSCWireDigiCollection* wiredc, const CSCComparato
     return;
 
   // encode high multiplicity bits
-  unsigned alctBits = alctProc->getHighMultiplictyBits();
-  encodeHighMultiplicityBits(alctBits);
+  encodeHighMultiplicityBits();
 
   // CLCT-centric matching
   if (clct_to_alct) {
@@ -428,6 +429,8 @@ std::vector<CSCCorrelatedLCTDigi> CSCMotherboard::getLCTs() const {
   return tmpV;
 }
 
+CSCShowerDigi CSCMotherboard::readoutShower() const { return shower_; }
+
 void CSCMotherboard::correlateLCTs(
     const CSCALCTDigi& bALCT, const CSCALCTDigi& sALCT, const CSCCLCTDigi& bCLCT, const CSCCLCTDigi& sCLCT, int type) {
   CSCALCTDigi bestALCT = bALCT;
@@ -527,10 +530,6 @@ CSCCorrelatedLCTDigi CSCMotherboard::constructLCTs(const CSCALCTDigi& aLCT,
     thisLCT.setEighthStrip(cLCT.getEighthStrip());
     thisLCT.setRun3Pattern(cLCT.getRun3Pattern());
   }
-
-  // in Run-3 we plan to denote the presence of exotic signatures in the chamber
-  if (useHighMultiplicityBits_)
-    thisLCT.setHMT(highMultiplicityBits_);
 
   // make sure to shift the ALCT BX from 8 to 3 and the CLCT BX from 8 to 7!
   thisLCT.setALCT(getBXShiftedALCT(aLCT));
@@ -708,11 +707,36 @@ CSCCLCTDigi CSCMotherboard::getBXShiftedCLCT(const CSCCLCTDigi& cLCT) const {
   return cLCT_shifted;
 }
 
-void CSCMotherboard::encodeHighMultiplicityBits(unsigned alctBits) {
-  // encode the high multiplicity bits in the (O)TMB based on
-  // the high multiplicity bits from the ALCT processor
-  // draft version: simply rellay the ALCT bits.
-  // future versions may involve also bits from the CLCT processor
-  // this depends on memory constraints in the TMB FPGA
-  highMultiplicityBits_ = alctBits;
+void CSCMotherboard::encodeHighMultiplicityBits() {
+  // get the hmt bits
+  unsigned cathodeInTime = clctProc->getInTimeHMT();
+  unsigned cathodeOutTime = clctProc->getOutTimeHMT();
+  unsigned anodeInTime = alctProc->getInTimeHMT();
+  unsigned anodeOutTime = alctProc->getOutTimeHMT();
+
+  unsigned inTimeHMT_;
+  unsigned outTimeHMT_;
+
+  // set the value according to source
+  switch (showerSource_) {
+    case 0:
+      inTimeHMT_ = cathodeInTime;
+      outTimeHMT_ = cathodeOutTime;
+      break;
+    case 1:
+      inTimeHMT_ = anodeInTime;
+      outTimeHMT_ = anodeOutTime;
+      break;
+    case 2:
+      inTimeHMT_ = (anodeInTime & CSCShowerDigi::kInTimeMask) | (cathodeInTime & CSCShowerDigi::kInTimeMask);
+      outTimeHMT_ = (anodeOutTime & CSCShowerDigi::kOutTimeMask) | (cathodeOutTime & CSCShowerDigi::kOutTimeMask);
+      break;
+    default:
+      inTimeHMT_ = cathodeInTime;
+      outTimeHMT_ = cathodeOutTime;
+      break;
+  };
+
+  // create a new object
+  shower_ = CSCShowerDigi(inTimeHMT_, outTimeHMT_, theTrigChamber);
 }

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboard.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboard.cc
@@ -708,12 +708,14 @@ CSCCLCTDigi CSCMotherboard::getBXShiftedCLCT(const CSCCLCTDigi& cLCT) const {
 }
 
 void CSCMotherboard::encodeHighMultiplicityBits() {
-  // get the hmt bits
+  // get the high multiplicity
+  // for anode this reflects what is already in the anode CSCShowerDigi object
   unsigned cathodeInTime = clctProc->getInTimeHMT();
   unsigned cathodeOutTime = clctProc->getOutTimeHMT();
   unsigned anodeInTime = alctProc->getInTimeHMT();
   unsigned anodeOutTime = alctProc->getOutTimeHMT();
 
+  // assign the bits
   unsigned inTimeHMT_;
   unsigned outTimeHMT_;
 

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboardME11.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboardME11.cc
@@ -72,8 +72,7 @@ void CSCMotherboardME11::run(const CSCWireDigiCollection* wiredc, const CSCCompa
     return;
 
   // encode high multiplicity bits
-  unsigned alctBits = alctProc->getHighMultiplictyBits();
-  encodeHighMultiplicityBits(alctBits);
+  encodeHighMultiplicityBits();
 
   int used_alct_mask[20];
   int used_clct_mask[20];

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCTriggerPrimitivesBuilder.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCTriggerPrimitivesBuilder.cc
@@ -119,6 +119,8 @@ void CSCTriggerPrimitivesBuilder::build(const CSCBadChambers* badChambers,
                                         CSCCLCTPreTriggerCollection& oc_pretrig,
                                         CSCCorrelatedLCTDigiCollection& oc_lct,
                                         CSCCorrelatedLCTDigiCollection& oc_sorted_lct,
+                                        CSCShowerDigiCollection& oc_shower,
+                                        CSCShowerDigiCollection& oc_shower_anode,
                                         GEMCoPadDigiCollection& oc_gemcopad) {
   // CSC geometry.
   for (int endc = min_endcap; endc <= max_endcap; endc++) {
@@ -178,6 +180,8 @@ void CSCTriggerPrimitivesBuilder::build(const CSCBadChambers* badChambers,
               const std::vector<CSCCLCTDigi>& clctV1a = tmb11->clctProc->readoutCLCTsME1a();
               const std::vector<CSCCLCTPreTriggerDigi>& pretriggerV1a = tmb11->clctProc->preTriggerDigisME1a();
               const std::vector<CSCALCTPreTriggerDigi>& alctpretriggerV = tmb11->alctProc->preTriggerDigis();
+              const CSCShowerDigi& shower = tmb11->readoutShower();
+              const CSCShowerDigi& anodeShower = tmb11->alctProc->readoutShower();
 
               if (infoV > 1)
                 LogTrace("CSCTriggerPrimitivesBuilder")
@@ -198,6 +202,10 @@ void CSCTriggerPrimitivesBuilder::build(const CSCBadChambers* badChambers,
               put(pretriggerV, oc_pretrigger, detid, " ME1b CLCT pre-trigger digi");
               put(preTriggerBXs, oc_pretrig, detid, " ME1b CLCT pre-trigger BX");
               put(alctpretriggerV, oc_alctpretrigger, detid, " ME1b ALCT pre-trigger digi");
+              if (shower.isValid())
+                oc_shower.insertDigi(detid, shower);
+              if (anodeShower.isValid())
+                oc_shower_anode.insertDigi(detid, anodeShower);
 
               // ME1/a
 
@@ -246,6 +254,8 @@ void CSCTriggerPrimitivesBuilder::build(const CSCBadChambers* badChambers,
               const std::vector<CSCCLCTPreTriggerDigi>& pretriggerV1a = tmb11GEM->clctProc->preTriggerDigisME1a();
               const std::vector<GEMCoPadDigi>& copads = tmb11GEM->coPadProcessor->readoutCoPads();
               const std::vector<CSCALCTPreTriggerDigi>& alctpretriggerV = tmb11GEM->alctProc->preTriggerDigis();
+              const CSCShowerDigi& shower = tmb11GEM->readoutShower();
+              const CSCShowerDigi& anodeShower = tmb11GEM->alctProc->readoutShower();
 
               // ME1/b
               if (!(lctV.empty() && alctV.empty() && clctV.empty()) and infoV > 1) {
@@ -262,6 +272,10 @@ void CSCTriggerPrimitivesBuilder::build(const CSCBadChambers* badChambers,
               put(preTriggerBXs, oc_pretrig, detid, " ME1b CLCT pre-trigger BX");
               put(copads, oc_gemcopad, gemId, " GEM coincidence pad");
               put(alctpretriggerV, oc_alctpretrigger, detid, " ME1b ALCT pre-trigger digi");
+              if (shower.isValid())
+                oc_shower.insertDigi(detid, shower);
+              if (anodeShower.isValid())
+                oc_shower_anode.insertDigi(detid, anodeShower);
 
               // ME1/a
               if (disableME1a_)
@@ -303,6 +317,8 @@ void CSCTriggerPrimitivesBuilder::build(const CSCBadChambers* badChambers,
               const std::vector<CSCCLCTPreTriggerDigi>& pretriggerV = tmb21GEM->clctProc->preTriggerDigis();
               const std::vector<GEMCoPadDigi>& copads = tmb21GEM->coPadProcessor->readoutCoPads();
               const std::vector<CSCALCTPreTriggerDigi>& alctpretriggerV = tmb21GEM->alctProc->preTriggerDigis();
+              const CSCShowerDigi& shower = tmb21GEM->readoutShower();
+              const CSCShowerDigi& anodeShower = tmb21GEM->alctProc->readoutShower();
 
               if (!(alctV.empty() && clctV.empty() && lctV.empty()) and infoV > 1) {
                 LogTrace("L1CSCTrigger") << "CSCTriggerPrimitivesBuilder got results in " << detid;
@@ -318,6 +334,10 @@ void CSCTriggerPrimitivesBuilder::build(const CSCBadChambers* badChambers,
               put(preTriggerBXs, oc_pretrig, detid, " ME21 CLCT pre-trigger BX");
               put(copads, oc_gemcopad, gemId, " GEM coincidence pad");
               put(alctpretriggerV, oc_alctpretrigger, detid, " ME21 ALCT pre-trigger digi");
+              if (shower.isValid())
+                oc_shower.insertDigi(detid, shower);
+              if (anodeShower.isValid())
+                oc_shower_anode.insertDigi(detid, anodeShower);
             }
             // running upgraded ME2/1-ME3/1-ME4/1 TMBs (without GEMs or RPCs)
             else if (runPhase2_ and ring == 1 and
@@ -339,6 +359,8 @@ void CSCTriggerPrimitivesBuilder::build(const CSCBadChambers* badChambers,
               const std::vector<int>& preTriggerBXs = utmb->clctProc->preTriggerBXs();
               const std::vector<CSCCLCTPreTriggerDigi>& pretriggerV = utmb->clctProc->preTriggerDigis();
               const std::vector<CSCALCTPreTriggerDigi>& alctpretriggerV = utmb->alctProc->preTriggerDigis();
+              const CSCShowerDigi& shower = utmb->readoutShower();
+              const CSCShowerDigi& anodeShower = utmb->alctProc->readoutShower();
 
               if (!(alctV.empty() && clctV.empty() && lctV.empty()) and infoV > 1) {
                 LogTrace("L1CSCTrigger") << "CSCTriggerPrimitivesBuilder got results in " << detid;
@@ -353,6 +375,10 @@ void CSCTriggerPrimitivesBuilder::build(const CSCBadChambers* badChambers,
               put(pretriggerV, oc_pretrigger, detid, " CLCT pre-trigger digi");
               put(preTriggerBXs, oc_pretrig, detid, " CLCT pre-trigger BX");
               put(alctpretriggerV, oc_alctpretrigger, detid, " ALCT pre-trigger digi");
+              if (shower.isValid())
+                oc_shower.insertDigi(detid, shower);
+              if (anodeShower.isValid())
+                oc_shower_anode.insertDigi(detid, anodeShower);
             }
 
             // running non-upgraded TMB
@@ -371,6 +397,8 @@ void CSCTriggerPrimitivesBuilder::build(const CSCBadChambers* badChambers,
               const std::vector<int>& preTriggerBXs = tmb->clctProc->preTriggerBXs();
               const std::vector<CSCCLCTPreTriggerDigi>& pretriggerV = tmb->clctProc->preTriggerDigis();
               const std::vector<CSCALCTPreTriggerDigi>& alctpretriggerV = tmb->alctProc->preTriggerDigis();
+              const CSCShowerDigi& shower = tmb->readoutShower();
+              const CSCShowerDigi& anodeShower = tmb->alctProc->readoutShower();
 
               if (!(alctV.empty() && clctV.empty() && lctV.empty()) and infoV > 1) {
                 LogTrace("L1CSCTrigger") << "CSCTriggerPrimitivesBuilder got results in " << detid;
@@ -385,6 +413,10 @@ void CSCTriggerPrimitivesBuilder::build(const CSCBadChambers* badChambers,
               put(pretriggerV, oc_pretrigger, detid, tmb->getCSCName() + " CLCT pre-trigger digi");
               put(preTriggerBXs, oc_pretrig, detid, tmb->getCSCName() + " CLCT pre-trigger BX");
               put(alctpretriggerV, oc_alctpretrigger, detid, tmb->getCSCName() + " ALCT pre-trigger digi");
+              if (shower.isValid())
+                oc_shower.insertDigi(detid, shower);
+              if (anodeShower.isValid())
+                oc_shower_anode.insertDigi(detid, anodeShower);
             }  // non-upgraded TMB
           }
         }

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCUpgradeMotherboard.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCUpgradeMotherboard.cc
@@ -85,8 +85,7 @@ void CSCUpgradeMotherboard::run(const CSCWireDigiCollection* wiredc, const CSCCo
     return;
 
   // encode high multiplicity bits
-  unsigned alctBits = alctProc->getHighMultiplictyBits();
-  encodeHighMultiplicityBits(alctBits);
+  encodeHighMultiplicityBits();
 
   int used_clct_mask[20];
   for (int c = 0; c < 20; ++c)


### PR DESCRIPTION
#### PR description:

This PR adds the code to count cathode/anode hits and packs the result in a `CSCShowerDigi` object. Follow-up of https://github.com/cms-sw/cmssw/pull/33389. The hit counters are not enabled yet.

#### PR validation:

Code compiles. The hit counters run parallel with the ordinary ALCT and CLCT finding.  Tested with WF 11634.0. There should be no differences. 

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A. We expect the (local trigger, track-finder, uGMT) firmware to be available by Summer 2021. I'll first develop the entire emulator in 11_3_X, then backport if need be.

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
