### PR TITLE
Use 11_2_X geometry in online and offline data global tags

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -26,13 +26,13 @@ autoCond = {
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2
     'run2_mc_pa'        :   '113X_mcRun2_pA_v3',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   '113X_dataRun2_v4',
+    'run2_data'         :   '113X_dataRun2_v5',
     # GlobalTag for Run2 data 2018B relvals only: HEM-15-16 fail
-    'run2_data_HEfail'  :   '113X_dataRun2_HEfail_v4',
+    'run2_data_HEfail'  :   '113X_dataRun2_HEfail_v5',
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
-    'run2_data_relval'  :   '113X_dataRun2_relval_v4',
+    'run2_data_relval'  :   '113X_dataRun2_relval_v5',
     # GlobalTag for Run2 HI data
-    'run2_data_promptlike_hi' : '113X_dataRun2_PromptLike_HI_v4',
+    'run2_data_promptlike_hi' : '113X_dataRun2_PromptLike_HI_v5',
     # GlobalTag for Run3 HLT: it points to the online GT
     'run3_hlt'          :   '112X_dataRun3_HLT_v3',
     # GlobalTag with fixed snapshot time for Run2 HLT RelVals: customizations to run with fixed L1 Menu

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -34,13 +34,13 @@ autoCond = {
     # GlobalTag for Run2 HI data
     'run2_data_promptlike_hi' : '113X_dataRun2_PromptLike_HI_v4',
     # GlobalTag for Run3 HLT: it points to the online GT
-    'run3_hlt'          :   '112X_dataRun3_HLT_v2',
+    'run3_hlt'          :   '112X_dataRun3_HLT_v3',
     # GlobalTag with fixed snapshot time for Run2 HLT RelVals: customizations to run with fixed L1 Menu
-    'run2_hlt_relval'   :   '112X_dataRun2_HLT_relval_v5',
+    'run2_hlt_relval'   :   '112X_dataRun2_HLT_relval_v6',
     # GlobalTag for Run3 data relvals (express GT)
-    'run3_data_express'        :   '112X_dataRun3_Express_v4',
+    'run3_data_express'        :   '112X_dataRun3_Express_v5',
     # GlobalTag for Run3 data relvals
-    'run3_data_prompt'         :   '112X_dataRun3_Prompt_v4',
+    'run3_data_prompt'         :   '112X_dataRun3_Prompt_v5',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,~0-centred beamspot)
     'phase1_2017_design'       :  '113X_mc2017_design_v4',
     # GlobalTag for MC production with realistic conditions for Phase1 2017 detector


### PR DESCRIPTION
#### PR description:

PR #31529 updated the reco geometry for 11_2_X. It was always planned to perform the corresponding updates to the online GTs (and the offline GTs, which use the same tags) once the MC validation was completed, but this was never done. This PR remedies the situation.

The GT diffs are as follows. Some of the tags were already multi-IOV tags with `hlt` synchronization. For those, the updates were implemented as IOV appends. For those records in which the data GTs used the MC tags, new tags with `hlt` synchronization were required.

The GT diffs are as follows:

**Offline data**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/113X_dataRun2_v4/113X_dataRun2_v5

**Offline data (HEM failure)**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/113X_dataRun2_HEfail_v4/113X_dataRun2_HEfail_v5

**Offline data relval**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/113X_dataRun2_relval_v4/113X_dataRun2_relval_v5

**Prompt-like HI data**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/113X_dataRun2_PromptLike_HI_v4/113X_dataRun2_PromptLike_HI_v5

**Run 3 data (HLT)**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/112X_dataRun3_HLT_v2/112X_dataRun3_HLT_v3

**Run 2 HLT RelVals**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/112X_dataRun2_HLT_relval_v5/112X_dataRun2_HLT_relval_v6

**Run 3 data (express)**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/112X_dataRun3_Express_v4/112X_dataRun3_Express_v5

**Run 3 data (prompt)**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/112X_dataRun3_Prompt_v4/112X_dataRun3_Prompt_v5

#### PR validation:

The payloads are identical to those already validated in simulation.

Technical tests were performed as well:

- `runTheMatrix.py -l limited,136.8642,138.1,138.2 --ibeos`
- addOnTests -j 8

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

A backport to 11_2_X is planned as the online GTs are intended for use in 11_2_X.