### PR TITLE
Remove deprecated usages of isnan or isinf

### DIFF
--- a/CalibCalorimetry/HcalAlgos/interface/HcalPulseShapes.h
+++ b/CalibCalorimetry/HcalAlgos/interface/HcalPulseShapes.h
@@ -7,6 +7,7 @@
 #include "CalibCalorimetry/HcalAlgos/interface/HcalPulseShape.h"
 #include "DataFormats/HcalDetId/interface/HcalDetId.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Utilities/interface/isFinite.h"
 #include "CalibFormats/HcalObjects/interface/HcalDbService.h"
 #include "CalibFormats/HcalObjects/interface/HcalDbRecord.h"
 
@@ -62,7 +63,7 @@ public:
     for (unsigned i = 0; i < 2 * nbin - 1; ++i) {
       for (unsigned j = 0; j < std::min(i + 1, nbin); ++j) {
         double tmp = f1(j) * f2(i - j);
-        if (std::isnan(tmp) or std::isinf(tmp))
+        if (edm::isNotFinite(tmp))
           continue;
         result[i] += tmp;
       }

--- a/DQMOffline/Muon/src/GEMEfficiencyHarvester.cc
+++ b/DQMOffline/Muon/src/GEMEfficiencyHarvester.cc
@@ -1,6 +1,7 @@
 #include "DQMOffline/Muon/interface/GEMEfficiencyHarvester.h"
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/Utilities/interface/isFinite.h"
 
 #include "TEfficiency.h"
 
@@ -365,7 +366,7 @@ void GEMEfficiencyHarvester::doResolution(DQMStore::IBooker& ibooker,
     // FIXME
     // `GetSkewness` seems to returns nan when its histogram has no entry..
     const double skewness = hist->GetSkewness();
-    if (not std::isnan(skewness))
+    if (edm::isFinite(skewness))
       h_skewness->SetBinContent(xbin, ybin, skewness);
 
     h_mean->SetBinError(xbin, ybin, hist->GetMeanError());

--- a/FastSimulation/CTPPSFastTrackingProducer/plugins/CTPPSFastTrackingProducer.cc
+++ b/FastSimulation/CTPPSFastTrackingProducer/plugins/CTPPSFastTrackingProducer.cc
@@ -28,6 +28,7 @@ Implementation:
 #include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/ParameterSet/interface/FileInPath.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/isFinite.h"
 #include "FWCore/Utilities/interface/StreamID.h"
 #include "FastSimDataFormats/CTPPSFastSim/interface/CTPPSFastRecHit.h"
 #include "FastSimDataFormats/CTPPSFastSim/interface/CTPPSFastRecHitContainer.h"
@@ -416,7 +417,7 @@ void CTPPSFastTrackingProducer::ReconstructArm(
   y2 *= mm_to_um;
   pps_station->setPositions(x1, y1, x2, y2);
   double energy = pps_station->getE(AM);  // dummy call needed to calculate some Hector internal parameter
-  if (std::isnan(energy) || std::isinf(energy))
+  if (edm::isNotFinite(energy))
     return;
   tx = pps_station->getTXIP();  // change orientation to CMS
   ty = pps_station->getTYIP();

--- a/FastSimulation/CTPPSFastTrackingProducer/plugins/CTPPSFastTrackingProducer.cc
+++ b/FastSimulation/CTPPSFastTrackingProducer/plugins/CTPPSFastTrackingProducer.cc
@@ -320,7 +320,6 @@ bool CTPPSFastTrackingProducer::SearchTrack(int i,
                                             double& X2d,
                                             double& Y2d) {
   // Given 1 hit in Tracker1 and 1 hit in Tracker2 try to make a track with Hector
-  double theta = 0.;
   xi = 0;
   t = 0;
   partP = 0;
@@ -361,8 +360,7 @@ bool CTPPSFastTrackingProducer::SearchTrack(int i,
   thx *= -Direction;                                                      //  invert to the CMS ref frame
 
   // Protect for unphysical results
-  if (std::isnan(eloss) || std::isinf(eloss) || std::isnan(thx) || std::isinf(thx) || std::isnan(thy) ||
-      std::isinf(thy))
+  if (edm::isNotFinite(eloss) || edm::isNotFinite(thx) || edm::isNotFinite(thy))
     return false;
   //
 
@@ -379,18 +377,17 @@ bool CTPPSFastTrackingProducer::SearchTrack(int i,
     return false;
   //
   // Calculate the reconstructed track parameters
-  theta = sqrt(thx * thx + thy * thy) * urad;
+  double theta = sqrt(thx * thx + thy * thy) * urad;
   xi = eloss / fBeamEnergy;
   double energy = fBeamEnergy * (1. - xi);
   partP = sqrt(energy * energy - PPSTools::ProtonMassSQ);
   t = -2. * (PPSTools::ProtonMassSQ - fBeamEnergy * energy + fBeamMomentum * partP * cos(theta));
-  pt = sqrt(pow(partP * thx * urad, 2) + pow(partP * thy * urad, 2));
+  pt = partP * theta;
   if (xi < 0. || xi > 1. || t < 0. || t > 10. || pt <= 0.) {
     xi = 0.;
     t = 0.;
     partP = 0.;
     pt = 0.;
-    theta = 0.;
     x0 = 0.;
     y0 = 0.;
     return false;  // unphysical values

--- a/RecoBTag/FeatureTools/src/deep_helpers.cc
+++ b/RecoBTag/FeatureTools/src/deep_helpers.cc
@@ -1,5 +1,6 @@
 #include "RecoBTag/FeatureTools/interface/deep_helpers.h"
 #include "DataFormats/PatCandidates/interface/PackedCandidate.h"
+#include "FWCore/Utilities/interface/isFinite.h"
 
 namespace btagbtvdeep {
 
@@ -18,13 +19,11 @@ namespace btagbtvdeep {
 
   // remove infs and NaNs with value  (adapted from DeepNTuples)
   const float catch_infs(const float in, const float replace_value) {
-    if (in == in) {  // check if NaN
-      if (std::isinf(in))
-        return replace_value;
-      else if (in < -1e32 || in > 1e32)
-        return replace_value;
-      return in;
-    }
+    if (edm::isNotFinite(in))
+      return replace_value;
+    else if (in < -1e32 || in > 1e32)
+      return replace_value;
+    return in;
     return replace_value;
   }
 

--- a/RecoBTag/FeatureTools/src/deep_helpers.cc
+++ b/RecoBTag/FeatureTools/src/deep_helpers.cc
@@ -21,10 +21,9 @@ namespace btagbtvdeep {
   const float catch_infs(const float in, const float replace_value) {
     if (edm::isNotFinite(in))
       return replace_value;
-    else if (in < -1e32 || in > 1e32)
+    if (in < -1e32 || in > 1e32)
       return replace_value;
     return in;
-    return replace_value;
   }
 
   // remove infs/NaN and bound (adapted from DeepNTuples)

--- a/RecoParticleFlow/PFProducer/src/MLPFModel.cc
+++ b/RecoParticleFlow/PFProducer/src/MLPFModel.cc
@@ -1,5 +1,6 @@
 #include "RecoParticleFlow/PFProducer/interface/MLPFModel.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/Utilities/interface/isFinite.h"
 #include "DataFormats/ParticleFlowReco/interface/PFCluster.h"
 #include "DataFormats/ParticleFlowReco/interface/PFBlock.h"
 #include "DataFormats/ParticleFlowReco/interface/PFBlockElementSuperCluster.h"
@@ -148,7 +149,7 @@ namespace reco::mlpf {
   float normalize(float in) {
     if (std::abs(in) > 1e4f) {
       return 0.0;
-    } else if (std::isnan(in)) {
+    } else if (edm::isNotFinite(in)) {
       return 0.0;
     }
     return in;

--- a/RecoTracker/SpecialSeedGenerators/src/SeedGeneratorForCosmics.cc
+++ b/RecoTracker/SpecialSeedGenerators/src/SeedGeneratorForCosmics.cc
@@ -2,6 +2,7 @@
 #include "RecoTracker/TkHitPairs/interface/CosmicLayerPairs.h"
 #include "RecoPixelVertexing/PixelTriplets/interface/CosmicLayerTriplets.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/Utilities/interface/isFinite.h"
 #include "TrackingTools/Records/interface/TransientRecHitRecord.h"
 #include "RecoTracker/TkSeedGenerator/interface/FastHelix.h"
 void SeedGeneratorForCosmics::init(const SiStripRecHit2DCollection& collstereo,
@@ -117,8 +118,8 @@ bool SeedGeneratorForCosmics::seeds(TrajectorySeedCollection& output,
     FastHelix helix(inner, middle, outer, magfield->nominalValue(), &(*magfield));
     GlobalVector gv = helix.stateAtVertex().momentum();
     float ch = helix.stateAtVertex().charge();
-    float Mom = sqrt(gv.x() * gv.x() + gv.y() * gv.y() + gv.z() * gv.z());
-    if (Mom > 1000 || std::isnan(Mom))
+    float mom2 = gv.x() * gv.x() + gv.y() * gv.y() + gv.z() * gv.z();
+    if (mom2 > 1e06f || edm::isNotFinite(mom2))
       continue;  // ChangedByDaniele
 
     if (gv.y() > 0) {


### PR DESCRIPTION
#### PR description:

According to the static analyzer, as of CMSSW_11_3_X_2021-04-12-2300 only 7 occurrencies of the deprecated `isnan()` or `isinf()` calls remained in CMSSW

This PR finally gets rid of all them

#### PR validation:

It builds
