### PR TITLE
Modernize code and simplify GeometricSearchTrackerBuilder

### DIFF
--- a/RecoTracker/TkDetLayers/src/GeometricSearchTrackerBuilder.cc
+++ b/RecoTracker/TkDetLayers/src/GeometricSearchTrackerBuilder.cc
@@ -41,53 +41,53 @@ GeometricSearchTracker *GeometricSearchTrackerBuilder::build(const GeometricDet 
   vector<ForwardDetLayer const *> thePosTECLayers;
   bool useBrothers = !usePhase2Stacks;
 
-  vector<const GeometricDet *> theGeometricDetLayers = theGeometricTracker->components();
-  for (const GeometricDet *theGeomDetLayer : theGeometricDetLayers) {
+  auto const &theGeometricDetLayers = theGeometricTracker->components();
+  for (auto const *theGeomDetLayer : theGeometricDetLayers) {
     if (theGeomDetLayer->type() == GeometricDet::PixelBarrel) {
-      vector<const GeometricDet *> thePxlBarGeometricDetLayers = theGeomDetLayer->components();
-      for (const GeometricDet *thisGeomDet : thePxlBarGeometricDetLayers) {
+      auto const &thePxlBarGeometricDetLayers = theGeomDetLayer->components();
+      for (auto const *thisGeomDet : thePxlBarGeometricDetLayers) {
         thePxlBarLayers.push_back(aPixelBarrelLayerBuilder.build(thisGeomDet, theGeomDetGeometry));
       }
     }
 
     if (theGeomDetLayer->type() == GeometricDet::PixelPhase1Barrel) {
-      vector<const GeometricDet *> thePxlBarGeometricDetLayers = theGeomDetLayer->components();
-      for (const GeometricDet *thisGeomDet : thePxlBarGeometricDetLayers) {
+      auto const &thePxlBarGeometricDetLayers = theGeomDetLayer->components();
+      for (auto const *thisGeomDet : thePxlBarGeometricDetLayers) {
         thePxlBarLayers.push_back(aPixelBarrelLayerBuilder.build(thisGeomDet, theGeomDetGeometry));
       }
     }
 
     if (theGeomDetLayer->type() == GeometricDet::PixelPhase2Barrel) {
-      vector<const GeometricDet *> thePxlBarGeometricDetLayers = theGeomDetLayer->components();
-      for (const GeometricDet *thisGeomDet : thePxlBarGeometricDetLayers) {
+      auto const &thePxlBarGeometricDetLayers = theGeomDetLayer->components();
+      for (auto const *thisGeomDet : thePxlBarGeometricDetLayers) {
         thePxlBarLayers.push_back(aPixelBarrelLayerBuilder.build(thisGeomDet, theGeomDetGeometry));
       }
     }
 
     if (theGeomDetLayer->type() == GeometricDet::TIB) {
-      vector<const GeometricDet *> theTIBGeometricDetLayers = theGeomDetLayer->components();
-      for (const GeometricDet *thisGeomDet : theTIBGeometricDetLayers) {
+      auto const &theTIBGeometricDetLayers = theGeomDetLayer->components();
+      for (auto const *thisGeomDet : theTIBGeometricDetLayers) {
         theTIBLayers.push_back(aTIBLayerBuilder.build(thisGeomDet, theGeomDetGeometry));
       }
     }
 
     if (theGeomDetLayer->type() == GeometricDet::TOB) {
-      vector<const GeometricDet *> theTOBGeometricDetLayers = theGeomDetLayer->components();
-      for (const GeometricDet *thisGeomDet : theTOBGeometricDetLayers) {
+      auto const &theTOBGeometricDetLayers = theGeomDetLayer->components();
+      for (auto const *thisGeomDet : theTOBGeometricDetLayers) {
         theTOBLayers.push_back(aTOBLayerBuilder.build(thisGeomDet, theGeomDetGeometry));
       }
     }
 
     if (theGeomDetLayer->type() == GeometricDet::OTPhase2Barrel) {
-      vector<const GeometricDet *> theTOBGeometricDetLayers = theGeomDetLayer->components();
-      for (const GeometricDet *thisGeomDet : theTOBGeometricDetLayers) {
+      auto const &theTOBGeometricDetLayers = theGeomDetLayer->components();
+      for (auto const *thisGeomDet : theTOBGeometricDetLayers) {
         theTOBLayers.push_back(aPhase2OTBarrelLayerBuilder.build(thisGeomDet, theGeomDetGeometry, useBrothers));
       }
     }
 
     if (theGeomDetLayer->type() == GeometricDet::PixelEndCap) {
-      vector<const GeometricDet *> thePxlFwdGeometricDetLayers = theGeomDetLayer->components();
-      for (const GeometricDet *thisGeomDet : thePxlFwdGeometricDetLayers) {
+      auto const &thePxlFwdGeometricDetLayers = theGeomDetLayer->components();
+      for (auto const *thisGeomDet : thePxlFwdGeometricDetLayers) {
         if (thisGeomDet->positionBounds().z() < 0)
           theNegPxlFwdLayers.push_back(aPixelForwardLayerBuilder.build(thisGeomDet, theGeomDetGeometry));
         else
@@ -96,8 +96,8 @@ GeometricSearchTracker *GeometricSearchTrackerBuilder::build(const GeometricDet 
     }
 
     if (theGeomDetLayer->type() == GeometricDet::PixelPhase1EndCap) {
-      vector<const GeometricDet *> thePxlFwdGeometricDetLayers = theGeomDetLayer->components();
-      for (const GeometricDet *thisGeomDet : thePxlFwdGeometricDetLayers) {
+      auto const &thePxlFwdGeometricDetLayers = theGeomDetLayer->components();
+      for (auto const *thisGeomDet : thePxlFwdGeometricDetLayers) {
         if (thisGeomDet->positionBounds().z() < 0)
           theNegPxlFwdLayers.push_back(aPhase1PixelForwardLayerBuilder.build(thisGeomDet, theGeomDetGeometry));
         else
@@ -106,8 +106,8 @@ GeometricSearchTracker *GeometricSearchTrackerBuilder::build(const GeometricDet 
     }
 
     if (theGeomDetLayer->type() == GeometricDet::PixelPhase2EndCap) {
-      vector<const GeometricDet *> thePxlFwdGeometricDetLayers = theGeomDetLayer->components();
-      for (const GeometricDet *thisGeomDet : thePxlFwdGeometricDetLayers) {
+      auto const &thePxlFwdGeometricDetLayers = theGeomDetLayer->components();
+      for (auto const *thisGeomDet : thePxlFwdGeometricDetLayers) {
         //FIXME: this is just to keep the compatibility with the PixelPhase1 extension layout
         //hopefully we can get rid of it soon
         if (thisGeomDet->positionBounds().z() < 0) {
@@ -130,8 +130,8 @@ GeometricSearchTracker *GeometricSearchTrackerBuilder::build(const GeometricDet 
     }
 
     if (theGeomDetLayer->type() == GeometricDet::TID) {
-      vector<const GeometricDet *> theTIDGeometricDetLayers = theGeomDetLayer->components();
-      for (const GeometricDet *thisGeomDet : theTIDGeometricDetLayers) {
+      auto const &theTIDGeometricDetLayers = theGeomDetLayer->components();
+      for (auto const *thisGeomDet : theTIDGeometricDetLayers) {
         if (thisGeomDet->positionBounds().z() < 0)
           theNegTIDLayers.push_back(aTIDLayerBuilder.build(thisGeomDet, theGeomDetGeometry));
         else
@@ -140,8 +140,8 @@ GeometricSearchTracker *GeometricSearchTrackerBuilder::build(const GeometricDet 
     }
 
     if (theGeomDetLayer->type() == GeometricDet::OTPhase2EndCap) {
-      vector<const GeometricDet *> theTIDGeometricDetLayers = theGeomDetLayer->components();
-      for (const GeometricDet *thisGeomDet : theTIDGeometricDetLayers) {
+      auto const &theTIDGeometricDetLayers = theGeomDetLayer->components();
+      for (auto const *thisGeomDet : theTIDGeometricDetLayers) {
         if (thisGeomDet->positionBounds().z() < 0)
           theNegTIDLayers.push_back(aPhase2EndcapLayerBuilder.build(thisGeomDet, theGeomDetGeometry, useBrothers));
         else
@@ -150,8 +150,8 @@ GeometricSearchTracker *GeometricSearchTrackerBuilder::build(const GeometricDet 
     }
 
     if (theGeomDetLayer->type() == GeometricDet::TEC) {
-      vector<const GeometricDet *> theTECGeometricDetLayers = theGeomDetLayer->components();
-      for (const GeometricDet *thisGeomDet : theTECGeometricDetLayers) {
+      auto const &theTECGeometricDetLayers = theGeomDetLayer->components();
+      for (auto const *thisGeomDet : theTECGeometricDetLayers) {
         if (thisGeomDet->positionBounds().z() < 0)
           theNegTECLayers.push_back(aTECLayerBuilder.build(thisGeomDet, theGeomDetGeometry));
         else

--- a/RecoTracker/TkDetLayers/src/GeometricSearchTrackerBuilder.cc
+++ b/RecoTracker/TkDetLayers/src/GeometricSearchTrackerBuilder.cc
@@ -42,52 +42,52 @@ GeometricSearchTracker *GeometricSearchTrackerBuilder::build(const GeometricDet 
   bool useBrothers = !usePhase2Stacks;
 
   auto const &theGeometricDetLayers = theGeometricTracker->components();
-  for (auto const *theGeomDetLayer : theGeometricDetLayers) {
+  for (auto const &theGeomDetLayer : theGeometricDetLayers) {
     if (theGeomDetLayer->type() == GeometricDet::PixelBarrel) {
       auto const &thePxlBarGeometricDetLayers = theGeomDetLayer->components();
-      for (auto const *thisGeomDet : thePxlBarGeometricDetLayers) {
+      for (auto const &thisGeomDet : thePxlBarGeometricDetLayers) {
         thePxlBarLayers.push_back(aPixelBarrelLayerBuilder.build(thisGeomDet, theGeomDetGeometry));
       }
     }
 
     if (theGeomDetLayer->type() == GeometricDet::PixelPhase1Barrel) {
       auto const &thePxlBarGeometricDetLayers = theGeomDetLayer->components();
-      for (auto const *thisGeomDet : thePxlBarGeometricDetLayers) {
+      for (auto const &thisGeomDet : thePxlBarGeometricDetLayers) {
         thePxlBarLayers.push_back(aPixelBarrelLayerBuilder.build(thisGeomDet, theGeomDetGeometry));
       }
     }
 
     if (theGeomDetLayer->type() == GeometricDet::PixelPhase2Barrel) {
       auto const &thePxlBarGeometricDetLayers = theGeomDetLayer->components();
-      for (auto const *thisGeomDet : thePxlBarGeometricDetLayers) {
+      for (auto const &thisGeomDet : thePxlBarGeometricDetLayers) {
         thePxlBarLayers.push_back(aPixelBarrelLayerBuilder.build(thisGeomDet, theGeomDetGeometry));
       }
     }
 
     if (theGeomDetLayer->type() == GeometricDet::TIB) {
       auto const &theTIBGeometricDetLayers = theGeomDetLayer->components();
-      for (auto const *thisGeomDet : theTIBGeometricDetLayers) {
+      for (auto const &thisGeomDet : theTIBGeometricDetLayers) {
         theTIBLayers.push_back(aTIBLayerBuilder.build(thisGeomDet, theGeomDetGeometry));
       }
     }
 
     if (theGeomDetLayer->type() == GeometricDet::TOB) {
       auto const &theTOBGeometricDetLayers = theGeomDetLayer->components();
-      for (auto const *thisGeomDet : theTOBGeometricDetLayers) {
+      for (auto const &thisGeomDet : theTOBGeometricDetLayers) {
         theTOBLayers.push_back(aTOBLayerBuilder.build(thisGeomDet, theGeomDetGeometry));
       }
     }
 
     if (theGeomDetLayer->type() == GeometricDet::OTPhase2Barrel) {
       auto const &theTOBGeometricDetLayers = theGeomDetLayer->components();
-      for (auto const *thisGeomDet : theTOBGeometricDetLayers) {
+      for (auto const &thisGeomDet : theTOBGeometricDetLayers) {
         theTOBLayers.push_back(aPhase2OTBarrelLayerBuilder.build(thisGeomDet, theGeomDetGeometry, useBrothers));
       }
     }
 
     if (theGeomDetLayer->type() == GeometricDet::PixelEndCap) {
       auto const &thePxlFwdGeometricDetLayers = theGeomDetLayer->components();
-      for (auto const *thisGeomDet : thePxlFwdGeometricDetLayers) {
+      for (auto const &thisGeomDet : thePxlFwdGeometricDetLayers) {
         if (thisGeomDet->positionBounds().z() < 0)
           theNegPxlFwdLayers.push_back(aPixelForwardLayerBuilder.build(thisGeomDet, theGeomDetGeometry));
         else
@@ -97,7 +97,7 @@ GeometricSearchTracker *GeometricSearchTrackerBuilder::build(const GeometricDet 
 
     if (theGeomDetLayer->type() == GeometricDet::PixelPhase1EndCap) {
       auto const &thePxlFwdGeometricDetLayers = theGeomDetLayer->components();
-      for (auto const *thisGeomDet : thePxlFwdGeometricDetLayers) {
+      for (auto const &thisGeomDet : thePxlFwdGeometricDetLayers) {
         if (thisGeomDet->positionBounds().z() < 0)
           theNegPxlFwdLayers.push_back(aPhase1PixelForwardLayerBuilder.build(thisGeomDet, theGeomDetGeometry));
         else
@@ -107,7 +107,7 @@ GeometricSearchTracker *GeometricSearchTrackerBuilder::build(const GeometricDet 
 
     if (theGeomDetLayer->type() == GeometricDet::PixelPhase2EndCap) {
       auto const &thePxlFwdGeometricDetLayers = theGeomDetLayer->components();
-      for (auto const *thisGeomDet : thePxlFwdGeometricDetLayers) {
+      for (auto const &thisGeomDet : thePxlFwdGeometricDetLayers) {
         //FIXME: this is just to keep the compatibility with the PixelPhase1 extension layout
         //hopefully we can get rid of it soon
         if (thisGeomDet->positionBounds().z() < 0) {
@@ -131,7 +131,7 @@ GeometricSearchTracker *GeometricSearchTrackerBuilder::build(const GeometricDet 
 
     if (theGeomDetLayer->type() == GeometricDet::TID) {
       auto const &theTIDGeometricDetLayers = theGeomDetLayer->components();
-      for (auto const *thisGeomDet : theTIDGeometricDetLayers) {
+      for (auto const &thisGeomDet : theTIDGeometricDetLayers) {
         if (thisGeomDet->positionBounds().z() < 0)
           theNegTIDLayers.push_back(aTIDLayerBuilder.build(thisGeomDet, theGeomDetGeometry));
         else
@@ -141,7 +141,7 @@ GeometricSearchTracker *GeometricSearchTrackerBuilder::build(const GeometricDet 
 
     if (theGeomDetLayer->type() == GeometricDet::OTPhase2EndCap) {
       auto const &theTIDGeometricDetLayers = theGeomDetLayer->components();
-      for (auto const *thisGeomDet : theTIDGeometricDetLayers) {
+      for (auto const &thisGeomDet : theTIDGeometricDetLayers) {
         if (thisGeomDet->positionBounds().z() < 0)
           theNegTIDLayers.push_back(aPhase2EndcapLayerBuilder.build(thisGeomDet, theGeomDetGeometry, useBrothers));
         else
@@ -151,7 +151,7 @@ GeometricSearchTracker *GeometricSearchTrackerBuilder::build(const GeometricDet 
 
     if (theGeomDetLayer->type() == GeometricDet::TEC) {
       auto const &theTECGeometricDetLayers = theGeomDetLayer->components();
-      for (auto const *thisGeomDet : theTECGeometricDetLayers) {
+      for (auto const &thisGeomDet : theTECGeometricDetLayers) {
         if (thisGeomDet->positionBounds().z() < 0)
           theNegTECLayers.push_back(aTECLayerBuilder.build(thisGeomDet, theGeomDetGeometry));
         else

--- a/RecoTracker/TkDetLayers/src/GeometricSearchTrackerBuilder.cc
+++ b/RecoTracker/TkDetLayers/src/GeometricSearchTrackerBuilder.cc
@@ -10,13 +10,9 @@
 #include "TIDLayerBuilder.h"
 #include "TECLayerBuilder.h"
 
-#include "Geometry/TrackerGeometryBuilder/interface/trackerHierarchy.h"
-
 #include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
 #include "Geometry/MTDNumberingBuilder/interface/MTDTopology.h"
-
-#include "DataFormats/Common/interface/Trie.h"
 
 using namespace std;
 
@@ -46,107 +42,86 @@ GeometricSearchTracker *GeometricSearchTrackerBuilder::build(const GeometricDet 
   bool useBrothers = !usePhase2Stacks;
 
   vector<const GeometricDet *> theGeometricDetLayers = theGeometricTracker->components();
-  for (vector<const GeometricDet *>::const_iterator it = theGeometricDetLayers.begin();
-       it != theGeometricDetLayers.end();
-       it++) {
-    if ((*it)->type() == GeometricDet::PixelBarrel) {
-      vector<const GeometricDet *> thePxlBarGeometricDetLayers = (*it)->components();
-      for (vector<const GeometricDet *>::const_iterator it2 = thePxlBarGeometricDetLayers.begin();
-           it2 != thePxlBarGeometricDetLayers.end();
-           it2++) {
-        thePxlBarLayers.push_back(aPixelBarrelLayerBuilder.build(*it2, theGeomDetGeometry));
+  for (const GeometricDet *theGeomDetLayer : theGeometricDetLayers) {
+    if (theGeomDetLayer->type() == GeometricDet::PixelBarrel) {
+      vector<const GeometricDet *> thePxlBarGeometricDetLayers = theGeomDetLayer->components();
+      for (const GeometricDet *thisGeomDet : thePxlBarGeometricDetLayers) {
+        thePxlBarLayers.push_back(aPixelBarrelLayerBuilder.build(thisGeomDet, theGeomDetGeometry));
       }
     }
 
-    if ((*it)->type() == GeometricDet::PixelPhase1Barrel) {
-      vector<const GeometricDet *> thePxlBarGeometricDetLayers = (*it)->components();
-      for (vector<const GeometricDet *>::const_iterator it2 = thePxlBarGeometricDetLayers.begin();
-           it2 != thePxlBarGeometricDetLayers.end();
-           it2++) {
-        thePxlBarLayers.push_back(aPixelBarrelLayerBuilder.build(*it2, theGeomDetGeometry));
+    if (theGeomDetLayer->type() == GeometricDet::PixelPhase1Barrel) {
+      vector<const GeometricDet *> thePxlBarGeometricDetLayers = theGeomDetLayer->components();
+      for (const GeometricDet *thisGeomDet : thePxlBarGeometricDetLayers) {
+        thePxlBarLayers.push_back(aPixelBarrelLayerBuilder.build(thisGeomDet, theGeomDetGeometry));
       }
     }
 
-    if ((*it)->type() == GeometricDet::PixelPhase2Barrel) {
-      vector<const GeometricDet *> thePxlBarGeometricDetLayers = (*it)->components();
-      for (vector<const GeometricDet *>::const_iterator it2 = thePxlBarGeometricDetLayers.begin();
-           it2 != thePxlBarGeometricDetLayers.end();
-           it2++) {
-        thePxlBarLayers.push_back(aPixelBarrelLayerBuilder.build(*it2, theGeomDetGeometry));
+    if (theGeomDetLayer->type() == GeometricDet::PixelPhase2Barrel) {
+      vector<const GeometricDet *> thePxlBarGeometricDetLayers = theGeomDetLayer->components();
+      for (const GeometricDet *thisGeomDet : thePxlBarGeometricDetLayers) {
+        thePxlBarLayers.push_back(aPixelBarrelLayerBuilder.build(thisGeomDet, theGeomDetGeometry));
       }
     }
 
-    if ((*it)->type() == GeometricDet::TIB) {
-      vector<const GeometricDet *> theTIBGeometricDetLayers = (*it)->components();
-      for (vector<const GeometricDet *>::const_iterator it2 = theTIBGeometricDetLayers.begin();
-           it2 != theTIBGeometricDetLayers.end();
-           it2++) {
-        theTIBLayers.push_back(aTIBLayerBuilder.build(*it2, theGeomDetGeometry));
+    if (theGeomDetLayer->type() == GeometricDet::TIB) {
+      vector<const GeometricDet *> theTIBGeometricDetLayers = theGeomDetLayer->components();
+      for (const GeometricDet *thisGeomDet : theTIBGeometricDetLayers) {
+        theTIBLayers.push_back(aTIBLayerBuilder.build(thisGeomDet, theGeomDetGeometry));
       }
     }
 
-    if ((*it)->type() == GeometricDet::TOB) {
-      vector<const GeometricDet *> theTOBGeometricDetLayers = (*it)->components();
-      for (vector<const GeometricDet *>::const_iterator it2 = theTOBGeometricDetLayers.begin();
-           it2 != theTOBGeometricDetLayers.end();
-           it2++) {
-        theTOBLayers.push_back(aTOBLayerBuilder.build(*it2, theGeomDetGeometry));
+    if (theGeomDetLayer->type() == GeometricDet::TOB) {
+      vector<const GeometricDet *> theTOBGeometricDetLayers = theGeomDetLayer->components();
+      for (const GeometricDet *thisGeomDet : theTOBGeometricDetLayers) {
+        theTOBLayers.push_back(aTOBLayerBuilder.build(thisGeomDet, theGeomDetGeometry));
       }
     }
 
-    if ((*it)->type() == GeometricDet::OTPhase2Barrel) {
-      vector<const GeometricDet *> theTOBGeometricDetLayers = (*it)->components();
-
-      for (vector<const GeometricDet *>::const_iterator it2 = theTOBGeometricDetLayers.begin();
-           it2 != theTOBGeometricDetLayers.end();
-           it2++) {
-        theTOBLayers.push_back(aPhase2OTBarrelLayerBuilder.build(*it2, theGeomDetGeometry, useBrothers));
+    if (theGeomDetLayer->type() == GeometricDet::OTPhase2Barrel) {
+      vector<const GeometricDet *> theTOBGeometricDetLayers = theGeomDetLayer->components();
+      for (const GeometricDet *thisGeomDet : theTOBGeometricDetLayers) {
+        theTOBLayers.push_back(aPhase2OTBarrelLayerBuilder.build(thisGeomDet, theGeomDetGeometry, useBrothers));
       }
     }
 
-    if ((*it)->type() == GeometricDet::PixelEndCap) {
-      vector<const GeometricDet *> thePxlFwdGeometricDetLayers = (*it)->components();
-      for (vector<const GeometricDet *>::const_iterator it2 = thePxlFwdGeometricDetLayers.begin();
-           it2 != thePxlFwdGeometricDetLayers.end();
-           it2++) {
-        if ((*it2)->positionBounds().z() < 0)
-          theNegPxlFwdLayers.push_back(aPixelForwardLayerBuilder.build(*it2, theGeomDetGeometry));
-        if ((*it2)->positionBounds().z() > 0)
-          thePosPxlFwdLayers.push_back(aPixelForwardLayerBuilder.build(*it2, theGeomDetGeometry));
+    if (theGeomDetLayer->type() == GeometricDet::PixelEndCap) {
+      vector<const GeometricDet *> thePxlFwdGeometricDetLayers = theGeomDetLayer->components();
+      for (const GeometricDet *thisGeomDet : thePxlFwdGeometricDetLayers) {
+        if (thisGeomDet->positionBounds().z() < 0)
+          theNegPxlFwdLayers.push_back(aPixelForwardLayerBuilder.build(thisGeomDet, theGeomDetGeometry));
+        else
+          thePosPxlFwdLayers.push_back(aPixelForwardLayerBuilder.build(thisGeomDet, theGeomDetGeometry));
       }
     }
 
-    if ((*it)->type() == GeometricDet::PixelPhase1EndCap) {
-      vector<const GeometricDet *> thePxlFwdGeometricDetLayers = (*it)->components();
-      for (vector<const GeometricDet *>::const_iterator it2 = thePxlFwdGeometricDetLayers.begin();
-           it2 != thePxlFwdGeometricDetLayers.end();
-           it2++) {
-        if ((*it2)->positionBounds().z() < 0)
-          theNegPxlFwdLayers.push_back(aPhase1PixelForwardLayerBuilder.build(*it2, theGeomDetGeometry));
-        if ((*it2)->positionBounds().z() > 0)
-          thePosPxlFwdLayers.push_back(aPhase1PixelForwardLayerBuilder.build(*it2, theGeomDetGeometry));
+    if (theGeomDetLayer->type() == GeometricDet::PixelPhase1EndCap) {
+      vector<const GeometricDet *> thePxlFwdGeometricDetLayers = theGeomDetLayer->components();
+      for (const GeometricDet *thisGeomDet : thePxlFwdGeometricDetLayers) {
+        if (thisGeomDet->positionBounds().z() < 0)
+          theNegPxlFwdLayers.push_back(aPhase1PixelForwardLayerBuilder.build(thisGeomDet, theGeomDetGeometry));
+        else
+          thePosPxlFwdLayers.push_back(aPhase1PixelForwardLayerBuilder.build(thisGeomDet, theGeomDetGeometry));
       }
     }
 
-    if ((*it)->type() == GeometricDet::PixelPhase2EndCap) {
-      vector<const GeometricDet *> thePxlFwdGeometricDetLayers = (*it)->components();
-      for (vector<const GeometricDet *>::const_iterator it2 = thePxlFwdGeometricDetLayers.begin();
-           it2 != thePxlFwdGeometricDetLayers.end();
-           it2++) {
+    if (theGeomDetLayer->type() == GeometricDet::PixelPhase2EndCap) {
+      vector<const GeometricDet *> thePxlFwdGeometricDetLayers = theGeomDetLayer->components();
+      for (const GeometricDet *thisGeomDet : thePxlFwdGeometricDetLayers) {
         //FIXME: this is just to keep the compatibility with the PixelPhase1 extension layout
         //hopefully we can get rid of it soon
-        if ((*it2)->positionBounds().z() < 0) {
-          if ((*it2)->type() == GeometricDet::PixelPhase2FullDisk ||
-              (*it2)->type() == GeometricDet::PixelPhase2ReducedDisk)
-            theNegPxlFwdLayers.push_back(aPhase1PixelForwardLayerBuilder.build(*it2, theGeomDetGeometry));
-          else if ((*it2)->type() == GeometricDet::PixelPhase2TDRDisk)
-            theNegPxlFwdLayers.push_back(aPhase2EndcapLayerBuilder.build(*it2, theGeomDetGeometry, false));
-        } else if ((*it2)->positionBounds().z() > 0) {
-          if ((*it2)->type() == GeometricDet::PixelPhase2FullDisk ||
-              (*it2)->type() == GeometricDet::PixelPhase2ReducedDisk)
-            thePosPxlFwdLayers.push_back(aPhase1PixelForwardLayerBuilder.build(*it2, theGeomDetGeometry));
-          else if ((*it2)->type() == GeometricDet::PixelPhase2TDRDisk)
-            thePosPxlFwdLayers.push_back(aPhase2EndcapLayerBuilder.build(*it2, theGeomDetGeometry, false));
+        if (thisGeomDet->positionBounds().z() < 0) {
+          if (thisGeomDet->type() == GeometricDet::PixelPhase2FullDisk ||
+              thisGeomDet->type() == GeometricDet::PixelPhase2ReducedDisk)
+            theNegPxlFwdLayers.push_back(aPhase1PixelForwardLayerBuilder.build(thisGeomDet, theGeomDetGeometry));
+          else if (thisGeomDet->type() == GeometricDet::PixelPhase2TDRDisk)
+            theNegPxlFwdLayers.push_back(aPhase2EndcapLayerBuilder.build(thisGeomDet, theGeomDetGeometry, false));
+        } else if (thisGeomDet->positionBounds().z() > 0) {
+          if (thisGeomDet->type() == GeometricDet::PixelPhase2FullDisk ||
+              thisGeomDet->type() == GeometricDet::PixelPhase2ReducedDisk)
+            thePosPxlFwdLayers.push_back(aPhase1PixelForwardLayerBuilder.build(thisGeomDet, theGeomDetGeometry));
+          else if (thisGeomDet->type() == GeometricDet::PixelPhase2TDRDisk)
+            thePosPxlFwdLayers.push_back(aPhase2EndcapLayerBuilder.build(thisGeomDet, theGeomDetGeometry, false));
         } else {
           edm::LogError("TkDetLayers") << "In PixelPhase2EndCap the disks are neither PixelPhase2FullDisk nor "
                                           "PixelPhase2ReducedDisk nor PixelPhase2TDRDisk...";
@@ -154,41 +129,33 @@ GeometricSearchTracker *GeometricSearchTrackerBuilder::build(const GeometricDet 
       }
     }
 
-    if ((*it)->type() == GeometricDet::TID) {
-      vector<const GeometricDet *> theTIDGeometricDetLayers = (*it)->components();
-      for (vector<const GeometricDet *>::const_iterator it2 = theTIDGeometricDetLayers.begin();
-           it2 != theTIDGeometricDetLayers.end();
-           it2++) {
-        if ((*it2)->positionBounds().z() < 0)
-          theNegTIDLayers.push_back(aTIDLayerBuilder.build(*it2, theGeomDetGeometry));
-        if ((*it2)->positionBounds().z() > 0)
-          thePosTIDLayers.push_back(aTIDLayerBuilder.build(*it2, theGeomDetGeometry));
+    if (theGeomDetLayer->type() == GeometricDet::TID) {
+      vector<const GeometricDet *> theTIDGeometricDetLayers = theGeomDetLayer->components();
+      for (const GeometricDet *thisGeomDet : theTIDGeometricDetLayers) {
+        if (thisGeomDet->positionBounds().z() < 0)
+          theNegTIDLayers.push_back(aTIDLayerBuilder.build(thisGeomDet, theGeomDetGeometry));
+        else
+          thePosTIDLayers.push_back(aTIDLayerBuilder.build(thisGeomDet, theGeomDetGeometry));
       }
     }
 
-    if ((*it)->type() == GeometricDet::OTPhase2EndCap) {
-      vector<const GeometricDet *> theTIDGeometricDetLayers = (*it)->components();
-
-      bool useBrothers = !usePhase2Stacks;
-      for (vector<const GeometricDet *>::const_iterator it2 = theTIDGeometricDetLayers.begin();
-           it2 != theTIDGeometricDetLayers.end();
-           it2++) {
-        if ((*it2)->positionBounds().z() < 0)
-          theNegTIDLayers.push_back(aPhase2EndcapLayerBuilder.build(*it2, theGeomDetGeometry, useBrothers));
-        if ((*it2)->positionBounds().z() > 0)
-          thePosTIDLayers.push_back(aPhase2EndcapLayerBuilder.build(*it2, theGeomDetGeometry, useBrothers));
+    if (theGeomDetLayer->type() == GeometricDet::OTPhase2EndCap) {
+      vector<const GeometricDet *> theTIDGeometricDetLayers = theGeomDetLayer->components();
+      for (const GeometricDet *thisGeomDet : theTIDGeometricDetLayers) {
+        if (thisGeomDet->positionBounds().z() < 0)
+          theNegTIDLayers.push_back(aPhase2EndcapLayerBuilder.build(thisGeomDet, theGeomDetGeometry, useBrothers));
+        else
+          thePosTIDLayers.push_back(aPhase2EndcapLayerBuilder.build(thisGeomDet, theGeomDetGeometry, useBrothers));
       }
     }
 
-    if ((*it)->type() == GeometricDet::TEC) {
-      vector<const GeometricDet *> theTECGeometricDetLayers = (*it)->components();
-      for (vector<const GeometricDet *>::const_iterator it2 = theTECGeometricDetLayers.begin();
-           it2 != theTECGeometricDetLayers.end();
-           it2++) {
-        if ((*it2)->positionBounds().z() < 0)
-          theNegTECLayers.push_back(aTECLayerBuilder.build(*it2, theGeomDetGeometry));
-        if ((*it2)->positionBounds().z() > 0)
-          thePosTECLayers.push_back(aTECLayerBuilder.build(*it2, theGeomDetGeometry));
+    if (theGeomDetLayer->type() == GeometricDet::TEC) {
+      vector<const GeometricDet *> theTECGeometricDetLayers = theGeomDetLayer->components();
+      for (const GeometricDet *thisGeomDet : theTECGeometricDetLayers) {
+        if (thisGeomDet->positionBounds().z() < 0)
+          theNegTECLayers.push_back(aTECLayerBuilder.build(thisGeomDet, theGeomDetGeometry));
+        else
+          thePosTECLayers.push_back(aTECLayerBuilder.build(thisGeomDet, theGeomDetGeometry));
       }
     }
   }


### PR DESCRIPTION
#### PR description:

The possible simplifications and cleanings that were proposed during the [review]( https://github.com/cms-sw/cmssw/pull/33272#issuecomment-817615743) of PR 33272 are tentatively implemented here:
- Remove unneeded includes of "Geometry/TrackerGeometryBuilder/interface/trackerHierarchy.h" and "DataFormats/Common/interface/Trie.h"
- Range based loops for the current it1 and all it2 iterators would simplify the code and improve its readability
- An else if can be used in all checks for positionBounds()->z(), to avoid repeating those checks when the first one is passed
- Avoid redefining useBrothers at L172, as it was already identically defined at L46

No changes are expected in output

@parbol @fabiocos
@mtosi @JanFSchulte @vmariani @ebrondol 

#### PR validation:

Short matrix runs without errors
