### PR TITLE
/validation/RecoEgamma/ Phase2 miniAOD modification v2

### DIFF
--- a/DQMOffline/EGamma/python/electronDataDiscovery.py
+++ b/DQMOffline/EGamma/python/electronDataDiscovery.py
@@ -1,6 +1,6 @@
 from __future__ import print_function
 
-#===================================================================
+# ===================================================================
 # So to get the list of input files. One must call :
 #   search(), to get the list of primary files
 #   search2(), to get the list of eventual secondary files
@@ -28,247 +28,265 @@ from __future__ import print_function
 #     /...: assumed to be the path of a text file containing the list of input data files
 #
 # All except DD_SOURCE can use wildcard *.
-#===================================================================
+# ===================================================================
 
-#import httplib, urllib, urllib2, types, string, os, sys
-import os, sys, re, das_client
+import os, sys, re  # , das_client
+import httplib, urllib, urllib2, types, string  # , os, sys
+import Utilities.General.cmssw_das_client as das_client
+import json
+from json import loads, dumps
 
 if 'DD_SOURCE' not in os.environ:
-  os.environ['DD_SOURCE'] = 'das'
+    os.environ['DD_SOURCE'] = 'das'
 if 'DD_RELEASE' not in os.environ:
-  os.environ['DD_RELEASE'] = ''
+    os.environ['DD_RELEASE'] = ''
 if 'DD_SAMPLE' not in os.environ:
-  os.environ['DD_SAMPLE'] = ''
+    os.environ['DD_SAMPLE'] = ''
 if 'DD_COND' not in os.environ:
-  os.environ['DD_COND'] = ''
+    os.environ['DD_COND'] = ''
 if 'DD_TIER' not in os.environ:
-  os.environ['DD_TIER'] = ''
+    os.environ['DD_TIER'] = ''
 if 'DD_TIER_SECONDARY' not in os.environ:
-  os.environ['DD_TIER_SECONDARY'] = ''
+    os.environ['DD_TIER_SECONDARY'] = ''
 if 'DD_RUN' not in os.environ:
-  os.environ['DD_RUN'] = ''
-  
-dd_release_re = re.compile(os.environ['DD_RELEASE'].replace('*','.*')) ;
-dd_sample_re = re.compile(os.environ['DD_SAMPLE'].replace('*','.*')) ;
-dd_cond_re = re.compile(os.environ['DD_COND'].replace('*','.*')) ;
-dd_run_re = re.compile(os.environ['DD_RUN'].replace('*','.*')) ;
+    os.environ['DD_RUN'] = ''
+
+dd_release_re = re.compile(os.environ['DD_RELEASE'].replace('*', '.*'));
+dd_sample_re = re.compile(os.environ['DD_SAMPLE'].replace('*', '.*'));
+dd_cond_re = re.compile(os.environ['DD_COND'].replace('*', '.*'));
+dd_run_re = re.compile(os.environ['DD_RUN'].replace('*', '.*'));
+
 
 def common_search(dd_tier):
+    dd_tier_re = re.compile(dd_tier.replace('*', '.*'));
 
-  dd_tier_re = re.compile(dd_tier.replace('*','.*')) ;
+    if os.environ['DD_SOURCE'] == "das":
 
-  if os.environ['DD_SOURCE'] == "das":
-  
-    query = "dataset instance=cms_dbs_prod_global"
-    if os.environ['DD_RELEASE'] != "" :
-      query = query + " release=" + os.environ['DD_RELEASE']
-    if os.environ['DD_SAMPLE'] != "":
-      query = query + " primary_dataset=" + os.environ['DD_SAMPLE']
-    if dd_tier != "":
-      query = query + " tier=" + dd_tier
-    if os.environ['DD_COND'] != "":
-      query = query + " dataset=*" + os.environ['DD_COND'] + "*"
-    if os.environ['DD_RUN'] != "":
-      query = query + " run=" + os.environ['DD_RUN']
-    #query = query + " | unique" # too long ??
-    
-    #data = os.popen('das_client.py --limit=0 --query "'+query+'"')
-    #datalines = data.readlines()
-    #data.close()
-    #datasets = []
-    #for line in datalines:
-    #  line = line.rstrip()
-    #  if line != "" and line[0] =="/":
-    #    datasets.append(line)
-    #dataset = datasets[0]
-    
-    data = das_client.json.loads(das_client.get_data('https://cmsweb.cern.ch',query,0,0,0))
-            
-    if data['nresults']==0:
-      print('[electronDataDiscovery.py] No DAS dataset for query:', query)
-      return []
-    while data['nresults']>1:
-      if data['data'][0]['dataset'][0]['name']==data['data'][1]['dataset'][0]['name']:
-        data['data'].pop(0)
-        data['nresults'] -= 1
-      else:
-        print('[electronDataDiscovery.py] Several DAS datasets for query:', query)
-        for i in range(data['nresults']):
-          print('[electronDataDiscovery.py] dataset['+str(i)+']: '+data['data'][i]['dataset'][0]['name'])
-        return []
+        query = "dataset instance=cms_dbs_prod_global"
+        if os.environ['DD_RELEASE'] != "":
+            query = query + " release=" + os.environ['DD_RELEASE']
+        if os.environ['DD_SAMPLE'] != "":
+            query = query + " primary_dataset=" + os.environ['DD_SAMPLE']
+        if dd_tier != "":
+            query = query + " tier=" + dd_tier
+        if os.environ['DD_COND'] != "":
+            query = query + " dataset=*" + os.environ['DD_COND'] + "*"
+        if os.environ['DD_RUN'] != "":
+            query = query + " run=" + os.environ['DD_RUN']
+        # query = query + " | unique" # too long ??
 
-    dataset = data['data'][0]['dataset'][0]['name']
-    
-    query = "file instance=cms_dbs_prod_global dataset="+dataset
-    
-    #data = os.popen('das_client.py --limit=0 --query "'+query+'"')
-    #datalines = data.readlines()
-    #data.close()
-    #result = []
-    #for line in datalines:
-    #  line = line.rstrip()
-    #  if line != "" and line[0] =="/":
-    #    result.append(line)
-    
-    data = das_client.json.loads(das_client.get_data('https://cmsweb.cern.ch',query,0,0,0))
-    
-    if data['nresults']==0:
-      print('[electronDataDiscovery.py] No DAS file in dataset:', dataset)
-      return []
-      
-    result = []
-    for i in range(0,data['nresults']):
-      result.append(str(data['data'][i]['file'][0]['name']))
-    
-  elif os.environ['DD_SOURCE'] == "dbs":
-  
-    input = "find file"
-    separator = " where "
-    if os.environ['DD_RELEASE'] != "":
-      input = input + separator + "release = " + os.environ['DD_RELEASE']
-      separator = " and "
-    if os.environ['DD_SAMPLE'] != "":
-      input = input + separator + "primds = " + os.environ['DD_SAMPLE']
-      separator = " and "
-    if os.environ['DD_RUN'] != "":
-      input = input + separator + "run = " + os.environ['DD_RUN']
-      separator = " and "
-    input = input + separator + "dataset like *" + os.environ['DD_COND'] + "*" + dd_tier + "*"
-    
-    data = os.popen('dbs search --url="http://cmsdbsprod.cern.ch/cms_dbs_prod_global/servlet/DBSServlet" --query "'+input+'"')
-    datalines = data.readlines()
-    data.close()
-    result = []
-    for line in datalines:
-      line = line.rstrip()
-      if line != "" and line[0] =="/":
-        result.append(line)
-    
-  elif os.environ['DD_SOURCE'] == "http":
-  
-    input = "find file"
-    separator = " where "
-    if os.environ['DD_RELEASE'] != "":
-      input = input + separator + "release = " + os.environ['DD_RELEASE']
-      separator = " and "
-    if os.environ['DD_SAMPLE'] != "":
-      input = input + separator + "primds = " + os.environ['DD_SAMPLE']
-      separator = " and "
-    if os.environ['DD_RUN'] != "":
-      input = input + separator + "run = " + os.environ['DD_RUN']
-      separator = " and "
-    input = input + separator + "dataset like *" + os.environ['DD_COND'] + "*" + dd_tier + "*"
-    
-    url = "https://cmsweb.cern.ch:443/dbs_discovery/aSearch"
-    final_input = urllib.quote(input) ;
-    
-    agent   = "Mozilla/4.0 (compatible; MSIE 5.5; Windows NT)"
-    ctypes  = "text/plain"
-    headers = { 'User-Agent':agent, 'Accept':ctypes}
-    params  = {'dbsInst':'cms_dbs_prod_global',
-               'html':0,'caseSensitive':'on','_idx':0,'pagerStep':-1,
-               'userInput':final_input,
-               'xml':0,'details':0,'cff':0,'method':'dbsapi'}
-    data    = urllib.urlencode(params,doseq=True)
-    req     = urllib2.Request(url, data, headers)
-    data    = ""
-    
-    try:
-      response = urllib2.urlopen(req)
-      data = response.read()
-    except urllib2.HTTPError as e:
-      if e.code==201:
-        print(e.headers)       
-        print(e.msg)
-        pass
-      else:
-        raise e
+        # data = os.popen('das_client.py --limit=0 --query "'+query+'"')
+        # datalines = data.readlines()
+        # data.close()
+        # datasets = []
+        # for line in datalines:
+        #  line = line.rstrip()
+        #  if line != "" and line[0] =="/":
+        #    datasets.append(line)
+        # dataset = datasets[0]
 
-    datalines = data.readlines()
-    data.close()
-    result = []
-    for line in datalines:
-      line = line.rstrip()
-      if line != "" and line[0] =="/":
-        result.append(line)
-    
-  elif os.environ['DD_SOURCE'] == "lsf":
-  
-    dbs_path = '/'+os.environ['DD_SAMPLE']+'/'+os.environ['DD_RELEASE']+'-'+os.environ['DD_COND']+'/'+os.environ['DD_TIER']+'"'
-    if __name__ == "__main__":
-      print('dbs path:',dbs_path)
-    data = os.popen('dbs lsf --path="'+dbs_path+'"')
-    datalines = data.readlines()
-    data.close()
-    result = []
-    for line in datalines:
-      line = line.rstrip()
-      if line != "" and line[0] =="/":
-        result.append(line)
-      
-  elif os.environ['DD_SOURCE'].startswith('/castor/cern.ch/cms/'): # assumed to be a castor dir
-  
-    castor_dir = os.environ['DD_SOURCE'].replace('/castor/cern.ch/cms/','/',1)
-    result = []
-    data = os.popen('rfdir /castor/cern.ch/cms'+castor_dir)
-    subdirs = data.readlines()
-    data.close()
-    datalines = []
-    for line in subdirs:
-      line = line.rstrip()
-      subdir = line.split()[8]
-      data = os.popen('rfdir /castor/cern.ch/cms'+castor_dir+'/'+subdir)
-      datalines = data.readlines()
-      for line in datalines:
-        line = line.rstrip()
-        file = line.split()[8]
-        if file != "":
-          result.append(castor_dir+'/'+subdir+'/'+file)
-      data.close()
-      
-  elif os.environ['DD_SOURCE'].startswith('/eos/cms/'): # assumed to be an eos dir
-  
-    data = os.popen('eos find -f '+os.environ['DD_SOURCE'])
-    lines = data.readlines()
-    data.close()
-    result = []
-    for line in lines:
-      line = line.strip().replace('/eos/cms/','/',1)
-      if line == "": continue
-      if dd_sample_re.search(line) == None: continue
-      if dd_cond_re.search(line) == None: continue
-      if dd_tier_re.search(line) == None: continue
-      if dd_run_re.search(line) == None: continue
-      result.append(line)
-      
-  else: # os.environ['DD_SOURCE'] is assumed to be a file name
-  
-    result = []
-    for line in open(os.environ['DD_SOURCE']).readlines():
-      line = os.path.expandvars(line.strip())
-      if line == "": continue
-      if dd_sample_re.search(line) == None: continue
-      if dd_cond_re.search(line) == None: continue
-      if dd_tier_re.search(line) == None: continue
-      if dd_run_re.search(line) == None: continue
-      result.append(line)
-      
-    if len(result)==0:
-      diag = '[electronDataDiscovery.py] No more files after filtering with :'
-      if os.environ['DD_SAMPLE']!='': diag += ' ' + os.environ['DD_SAMPLE']
-      if os.environ['DD_COND']!='': diag += ' ' + os.environ['DD_COND']
-      if dd_tier!='': diag += ' ' + dd_tier
-      if os.environ['DD_RUN']!='': diag += ' ' + os.environ['DD_RUN']
-      print(diag)
-      
-  return result
+        data = das_client.json.loads(das_client.get_data('https://cmsweb.cern.ch', query, 0, 0, 0))
+
+        if data['nresults'] == 0:
+            print('[electronDataDiscovery.py] No DAS dataset for query:', query)
+            return []
+        while data['nresults'] > 1:
+            if data['data'][0]['dataset'][0]['name'] == data['data'][1]['dataset'][0]['name']:
+                data['data'].pop(0)
+                data['nresults'] -= 1
+            else:
+                print('[electronDataDiscovery.py] Several DAS datasets for query:', query)
+                for i in range(data['nresults']):
+                    print(
+                        '[electronDataDiscovery.py] dataset[' + str(i) + ']: ' + data['data'][i]['dataset'][0]['name'])
+                return []
+
+        dataset = data['data'][0]['dataset'][0]['name']
+
+        query = "file instance=cms_dbs_prod_global dataset=" + dataset
+
+        # data = os.popen('das_client.py --limit=0 --query "'+query+'"')
+        # datalines = data.readlines()
+        # data.close()
+        # result = []
+        # for line in datalines:
+        #  line = line.rstrip()
+        #  if line != "" and line[0] =="/":
+        #    result.append(line)
+
+        data = das_client.json.loads(das_client.get_data('https://cmsweb.cern.ch', query, 0, 0, 0))
+
+        if data['nresults'] == 0:
+            print('[electronDataDiscovery.py] No DAS file in dataset:', dataset)
+            return []
+        else:
+            print('there is %d results' % nresults)
+
+        result = []
+        for i in range(0, data['nresults']):
+            result.append(str(data['data'][i]['file'][0]['name']))
+
+    elif os.environ['DD_SOURCE'] == "dbs":
+
+        input = "find file"
+        separator = " where "
+        if os.environ['DD_RELEASE'] != "":
+            input = input + separator + "release = " + os.environ['DD_RELEASE']
+            separator = " and "
+        if os.environ['DD_SAMPLE'] != "":
+            input = input + separator + "primds = " + os.environ['DD_SAMPLE']
+            separator = " and "
+        if os.environ['DD_RUN'] != "":
+            input = input + separator + "run = " + os.environ['DD_RUN']
+            separator = " and "
+        input = input + separator + "dataset like *" + os.environ['DD_COND'] + "*" + dd_tier + "*"
+
+        data = os.popen(
+            'dbs search --url="http://cmsdbsprod.cern.ch/cms_dbs_prod_global/servlet/DBSServlet" --query "' + input + '"')
+        datalines = data.readlines()
+        data.close()
+        result = []
+        for line in datalines:
+            line = line.rstrip()
+            if line != "" and line[0] == "/":
+                result.append(line)
+
+    elif os.environ['DD_SOURCE'] == "http":
+
+        input = "find file"
+        separator = " where "
+        if os.environ['DD_RELEASE'] != "":
+            input = input + separator + "release = " + os.environ['DD_RELEASE']
+            separator = " and "
+        if os.environ['DD_SAMPLE'] != "":
+            input = input + separator + "primds = " + os.environ['DD_SAMPLE']
+            separator = " and "
+        if os.environ['DD_RUN'] != "":
+            input = input + separator + "run = " + os.environ['DD_RUN']
+            separator = " and "
+        input = input + separator + "dataset like *" + os.environ['DD_COND'] + "*" + dd_tier + "*"
+
+        url = "https://cmsweb.cern.ch:443/dbs_discovery/aSearch"
+        final_input = urllib.quote(input);
+
+        agent = "Mozilla/4.0 (compatible; MSIE 5.5; Windows NT)"
+        ctypes = "text/plain"
+        headers = {'User-Agent': agent, 'Accept': ctypes}
+        params = {'dbsInst': 'cms_dbs_prod_global',
+                  'html': 0, 'caseSensitive': 'on', '_idx': 0, 'pagerStep': -1,
+                  'userInput': final_input,
+                  'xml': 0, 'details': 0, 'cff': 0, 'method': 'dbsapi'}
+        data = urllib.urlencode(params, doseq=True)
+        req = urllib2.Request(url, data, headers)
+        data = ""
+
+        try:
+            response = urllib2.urlopen(req)
+            data = response.read()
+        except urllib2.HTTPError as e:
+            if e.code == 201:
+                print(e.headers)
+                print(e.msg)
+                pass
+            else:
+                raise e
+
+        datalines = data.readlines()
+        data.close()
+        result = []
+        for line in datalines:
+            line = line.rstrip()
+            if line != "" and line[0] == "/":
+                result.append(line)
+
+    elif os.environ['DD_SOURCE'] == "lsf":
+
+        dbs_path = '/' + os.environ['DD_SAMPLE'] + '/' + os.environ['DD_RELEASE'] + '-' + os.environ['DD_COND'] + '/' + \
+                   os.environ['DD_TIER'] + '"'
+        if __name__ == "__main__":
+            print('dbs path:', dbs_path)
+        data = os.popen('dbs lsf --path="' + dbs_path + '"')
+        datalines = data.readlines()
+        data.close()
+        result = []
+        for line in datalines:
+            line = line.rstrip()
+            if line != "" and line[0] == "/":
+                result.append(line)
+
+    elif os.environ['DD_SOURCE'].startswith('/castor/cern.ch/cms/'):  # assumed to be a castor dir
+
+        castor_dir = os.environ['DD_SOURCE'].replace('/castor/cern.ch/cms/', '/', 1)
+        result = []
+        data = os.popen('rfdir /castor/cern.ch/cms' + castor_dir)
+        subdirs = data.readlines()
+        data.close()
+        datalines = []
+        for line in subdirs:
+            line = line.rstrip()
+            subdir = line.split()[8]
+            data = os.popen('rfdir /castor/cern.ch/cms' + castor_dir + '/' + subdir)
+            datalines = data.readlines()
+            for line in datalines:
+                line = line.rstrip()
+                file = line.split()[8]
+                if file != "":
+                    result.append(castor_dir + '/' + subdir + '/' + file)
+            data.close()
+
+    elif os.environ['DD_SOURCE'].startswith('/eos/cms/'):  # assumed to be an eos dir
+
+        data = os.popen('eos find -f ' + os.environ['DD_SOURCE'])
+        lines = data.readlines()
+        data.close()
+        result = []
+        for line in lines:
+            line = line.strip().replace('/eos/cms/', '/', 1)
+            if line == "": continue
+            if dd_sample_re.search(line) == None: continue
+            if dd_cond_re.search(line) == None: continue
+            if dd_tier_re.search(line) == None: continue
+            if dd_run_re.search(line) == None: continue
+            result.append(line)
+
+    else:  # os.environ['DD_SOURCE'] is assumed to be a file name
+
+        result = []
+        for line in open(os.environ['DD_SOURCE']).readlines():
+            line = os.path.expandvars(line.strip())
+            if line == "": continue
+            if dd_sample_re.search(line) == None: continue
+            if dd_cond_re.search(line) == None: continue
+            if dd_tier_re.search(line) == None: continue
+            if dd_run_re.search(line) == None: continue
+            result.append(line)
+
+        if len(result) == 0:
+            diag = '[electronDataDiscovery.py] No more files after filtering with :'
+            if os.environ['DD_SAMPLE'] != '': diag += ' ' + os.environ['DD_SAMPLE']
+            if os.environ['DD_COND'] != '': diag += ' ' + os.environ['DD_COND']
+            if dd_tier != '': diag += ' ' + dd_tier
+            if os.environ['DD_RUN'] != '': diag += ' ' + os.environ['DD_RUN']
+            print(diag)
+
+    return result
+
 
 def search():
-  return common_search(os.environ['DD_TIER'])
+    print('search in %s' % 'DD_TIER')
+    return common_search(os.environ['DD_TIER'])
+
 
 def search2():
-  return common_search(os.environ['DD_TIER_SECONDARY'])
+    return common_search(os.environ['DD_TIER_SECONDARY'])
 
-	
-	
 
+def getCMSdata(data, dbs="prod/global"):
+    # Read DAS database.
+    cmd = 'dasgoclient --query="file dataset=DATA instance=DBS" | sort'
+    cmd2 = cmd.replace('DATA', data).replace('DBS', dbs)
+    files = os.popen(cmd2).read()
+    # Create python list containing file names.
+    flist = files.split('\n')
+    del flist[-1]
+    return flist

--- a/Validation/RecoEgamma/plugins/ElectronMcMiniAODSignalValidator.cc
+++ b/Validation/RecoEgamma/plugins/ElectronMcMiniAODSignalValidator.cc
@@ -486,8 +486,6 @@ void ElectronMcSignalValidatorMiniAOD::analyze(const edm::Event& iEvent, const e
       << "Treating event " << iEvent.id() << " with " << electrons.product()->size() << " electrons";
   edm::LogInfo("ElectronMcSignalValidatorMiniAOD::analyze")
       << "Treating event " << iEvent.id() << " with " << electrons_endcaps.product()->size() << " multi slimmed electrons";
-  std::cout << "Treating event " << iEvent.id() << " with " << electrons.product()->size() << " electrons";
-  std::cout << " and with " << electrons_endcaps.product()->size() << " multi slimmed electrons" << std::endl;
   h1_recEleNum->Fill((*electrons).size());
 
   //===============================================
@@ -589,11 +587,8 @@ void ElectronMcSignalValidatorMiniAOD::analyze(const edm::Event& iEvent, const e
     for (unsigned i_elec=0; i_elec<2; ++i_elec) {
       mergedElectrons = (i_elec==0) ? electrons:electrons_endcaps ;
 
-      //std::cout << i << "/" << i_elec << std::endl;
-      //int j_elec = 0;
       for (const pat::Electron& el : *mergedElectrons) { // *electrons
         if (i_elec==0 && !el.isEB()) continue;
-        //std::cout << i << "/" << i_elec << "/" << j_elec << std::endl;
         double dphi = el.phi() - (*genParticles)[i].phi();
         if (std::abs(dphi) > CLHEP::pi) {
           dphi = dphi < 0 ? (CLHEP::twopi) + dphi : dphi - CLHEP::twopi;
@@ -610,8 +605,6 @@ void ElectronMcSignalValidatorMiniAOD::analyze(const edm::Event& iEvent, const e
               pt_ = elePtr->pt();
 
               okGsfFound = true;
-              //std::cout << "     " << i << "/" << i_elec << "/" << j_elec<< " : " << "found best Electron" << std::endl;
-              //std::cout << "evt ID : " << iEvent.id() << " - Pt : " << bestGsfElectron.pt() << " - eta : " << bestGsfElectron.eta() << " - phi : " << bestGsfElectron.phi() << std::endl;
 
               if (i_elec==0) {
                 sumChargedHadronPt_recomp = (*pfSumChargedHadronPtTmp)[elePtr];
@@ -626,10 +619,7 @@ void ElectronMcSignalValidatorMiniAOD::analyze(const edm::Event& iEvent, const e
             }
           }
         }
-        //j_elec++;
       }
-      //std::cout << " : there is " << j_elec << " electrons" << std::endl;
-      //std::cout << std::endl;
     } // end loop i_elec
 
       if (okGsfFound) {
@@ -717,5 +707,5 @@ void ElectronMcSignalValidatorMiniAOD::analyze(const edm::Event& iEvent, const e
         }
       }
     //} // end loop i_elec
-  }  // fendin loop size_t i
+  }  // end loop size_t i
 }

--- a/Validation/RecoEgamma/plugins/ElectronMcMiniAODSignalValidator.h
+++ b/Validation/RecoEgamma/plugins/ElectronMcMiniAODSignalValidator.h
@@ -29,7 +29,7 @@ private:
   // ----------member data ---------------------------
   edm::EDGetTokenT<edm::View<reco::GenParticle> > mcTruthCollection_;  // prunedGenParticles
   edm::EDGetTokenT<pat::ElectronCollection> electronToken_;            // slimmedElectrons
-  edm::EDGetTokenT<pat::ElectronCollection> electronTokenEndcaps_;            // slimmedElectrons
+  edm::EDGetTokenT<pat::ElectronCollection> electronTokenEndcaps_;     // slimmedElectrons
 
   edm::EDGetTokenT<edm::ValueMap<float> > pfSumChargedHadronPtTmp_;
   edm::EDGetTokenT<edm::ValueMap<float> > pfSumNeutralHadronEtTmp_;

--- a/Validation/RecoEgamma/plugins/ElectronMcMiniAODSignalValidator.h
+++ b/Validation/RecoEgamma/plugins/ElectronMcMiniAODSignalValidator.h
@@ -29,6 +29,7 @@ private:
   // ----------member data ---------------------------
   edm::EDGetTokenT<edm::View<reco::GenParticle> > mcTruthCollection_;  // prunedGenParticles
   edm::EDGetTokenT<pat::ElectronCollection> electronToken_;            // slimmedElectrons
+  edm::EDGetTokenT<pat::ElectronCollection> electronTokenEndcaps_;            // slimmedElectrons
 
   edm::EDGetTokenT<edm::ValueMap<float> > pfSumChargedHadronPtTmp_;
   edm::EDGetTokenT<edm::ValueMap<float> > pfSumNeutralHadronEtTmp_;

--- a/Validation/RecoEgamma/python/ElectronMcFakeValidator_gedGsfElectrons_cfi.py
+++ b/Validation/RecoEgamma/python/ElectronMcFakeValidator_gedGsfElectrons_cfi.py
@@ -19,7 +19,7 @@ electronMcFakeHistosCfg = cms.PSet(
   Nbinpopmatching = cms.int32(75), Popmatchingmin = cms.double(0.0), Popmatchingmax = cms.double(1.5),
   Nbinerror = cms.int32(30), Energyerrormax = cms.double(30.0),
   EfficiencyFlag = cms.bool(True), StatOverflowFlag = cms.bool(False),
-  NbinOPV = cms.int32(81), OPV_min = cms.double(-0.5), OPV_max = cms.double(79.5), # OPV : Offline Primary Vertices
+  NbinOPV = cms.int32(80), OPV_min = cms.double(-0.5), OPV_max = cms.double(79.5), # OPV : Offline Primary Vertices
   NbinELE = cms.int32(11), ELE_min = cms.double(-0.5), ELE_max = cms.double(10.5), # ELE : recEleNum
   NbinCORE = cms.int32(21), CORE_min = cms.double(-0.5), CORE_max = cms.double(20.5), # CORE : recCoreNum
   NbinTRACK = cms.int32(41), TRACK_min = cms.double(-0.5), TRACK_max = cms.double(40.5), # TRACK : recTrackNum

--- a/Validation/RecoEgamma/python/ElectronMcSignalValidatorMiniAOD_cfi.py
+++ b/Validation/RecoEgamma/python/ElectronMcSignalValidatorMiniAOD_cfi.py
@@ -3,45 +3,71 @@ import FWCore.ParameterSet.Config as cms
 from RecoEgamma.EgammaElectronProducers.gedGsfElectronFinalizer_cfi import gedGsfElectrons as _gedGsfElectrons
 
 electronMcSignalHistosCfg = cms.PSet(
-  Nbinxyz = cms.int32(50),
-  Nbinpt = cms.int32(50), Nbinpt2D = cms.int32(50), Nbinpteff = cms.int32(19),Ptmax = cms.double(100.0),
-  Nbinfhits = cms.int32(30), Fhitsmax = cms.double(30.0),
-  Nbineta = cms.int32(50), Nbineta2D = cms.int32(50),Etamin = cms.double(-2.5), Etamax = cms.double(2.5),
-  Nbindeta = cms.int32(100), Detamin = cms.double(-0.005), Detamax = cms.double(0.005), 
-  Nbindetamatch = cms.int32(100), Nbindetamatch2D = cms.int32(50), Detamatchmin = cms.double(-0.05), Detamatchmax = cms.double(0.05),
-  Nbinphi = cms.int32(64), Nbinphi2D = cms.int32(32), Phimin = cms.double(-3.2), Phimax = cms.double(3.2),
-  Nbindphi = cms.int32(100), Dphimin = cms.double(-0.01), Dphimax = cms.double(0.01),
-  Nbindphimatch = cms.int32(100), Nbindphimatch2D = cms.int32(50), Dphimatchmin = cms.double(-0.2), Dphimatchmax = cms.double(0.2),
-  Nbinmee = cms.int32(100), Meemin = cms.double(0.0), Meemax = cms.double(150.),
-  Nbinhoe = cms.int32(100), Hoemin = cms.double(0.0), Hoemax = cms.double(0.5),
-  Nbinpoptrue = cms.int32(75), Poptruemin = cms.double(0.0), Poptruemax = cms.double(1.5),
-  EfficiencyFlag = cms.bool(True), StatOverflowFlag = cms.bool(False)
+    Nbinxyz=cms.int32(50),
+    Nbinpt=cms.int32(50), Nbinpt2D=cms.int32(50), Nbinpteff=cms.int32(19), Ptmax=cms.double(100.0),
+    Nbinfhits=cms.int32(30), Fhitsmax=cms.double(30.0),
+    Nbineta=cms.int32(50), Nbineta2D=cms.int32(50), Etamin=cms.double(-2.5), Etamax=cms.double(2.5),
+    Nbindeta=cms.int32(100), Detamin=cms.double(-0.005), Detamax=cms.double(0.005),
+    Nbindetamatch=cms.int32(100), Nbindetamatch2D=cms.int32(50), Detamatchmin=cms.double(-0.05),
+    Detamatchmax=cms.double(0.05),
+    Nbinphi=cms.int32(64), Nbinphi2D=cms.int32(32), Phimin=cms.double(-3.2), Phimax=cms.double(3.2),
+    Nbindphi=cms.int32(100), Dphimin=cms.double(-0.01), Dphimax=cms.double(0.01),
+    Nbindphimatch=cms.int32(100), Nbindphimatch2D=cms.int32(50), Dphimatchmin=cms.double(-0.2),
+    Dphimatchmax=cms.double(0.2),
+    Nbinmee=cms.int32(100), Meemin=cms.double(0.0), Meemax=cms.double(150.),
+    Nbinhoe=cms.int32(100), Hoemin=cms.double(0.0), Hoemax=cms.double(0.5),
+    Nbinpoptrue=cms.int32(75), Poptruemin=cms.double(0.0), Poptruemax=cms.double(1.5),
+    EfficiencyFlag=cms.bool(True), StatOverflowFlag=cms.bool(False)
 )
 
-electronPFIsolationCfg = cms.PSet(    
-    pfSumChargedHadronPtTmp = cms.InputTag("miniAODElectronIsolation", _gedGsfElectrons.pfIsolationValues.pfSumChargedHadronPt.getProductInstanceLabel()),
-    pfSumNeutralHadronEtTmp = cms.InputTag("miniAODElectronIsolation", _gedGsfElectrons.pfIsolationValues.pfSumNeutralHadronEt.getProductInstanceLabel()), # 
-    pfSumPhotonEtTmp = cms.InputTag("miniAODElectronIsolation", _gedGsfElectrons.pfIsolationValues.pfSumPhotonEt.getProductInstanceLabel()), #  
+electronPFIsolationCfg = cms.PSet(
+    pfSumChargedHadronPtTmp=cms.InputTag("miniAODElectronIsolation",
+                                         _gedGsfElectrons.pfIsolationValues.pfSumChargedHadronPt.getProductInstanceLabel()),
+    pfSumNeutralHadronEtTmp=cms.InputTag("miniAODElectronIsolation",
+                                         _gedGsfElectrons.pfIsolationValues.pfSumNeutralHadronEt.getProductInstanceLabel()),
+    #
+    pfSumPhotonEtTmp=cms.InputTag("miniAODElectronIsolation",
+                                  _gedGsfElectrons.pfIsolationValues.pfSumPhotonEt.getProductInstanceLabel()),  #
 )
 
 from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
+
 electronMcSignalValidatorMiniAOD = DQMEDAnalyzer('ElectronMcSignalValidatorMiniAOD',
 
-    Verbosity = cms.untracked.int32(0),
-    FinalStep = cms.string("AtJobEnd"),
-    InputFile = cms.string(""),
-    OutputFile = cms.string(""),
-    InputFolderName = cms.string("EgammaV/ElectronMcSignalValidatorMiniAOD"), # 
-    OutputFolderName = cms.string("EgammaV/ElectronMcSignalValidatorMiniAOD"), # 
+                                                 Verbosity=cms.untracked.int32(0),
+                                                 FinalStep=cms.string("AtJobEnd"),
+                                                 InputFile=cms.string(""),
+                                                 OutputFile=cms.string(""),
+                                                 InputFolderName=cms.string("EgammaV/ElectronMcSignalValidatorMiniAOD"),
+                                                 #
+                                                 OutputFolderName=cms.string(
+                                                     "EgammaV/ElectronMcSignalValidatorMiniAOD"),  #
 
-    mcTruthCollection = cms.InputTag("prunedGenParticles"),
-    electrons = cms.InputTag("slimmedElectrons"),
-    
-    MaxPt = cms.double(100.0),
-    DeltaR = cms.double(0.05),
-    MaxAbsEta = cms.double(2.5),
-    MatchingID = cms.vint32(11,-11),
-    MatchingMotherID = cms.vint32(23,24,-24,32),
-    histosCfg = cms.PSet(electronMcSignalHistosCfg),
-    isolationCfg = cms.PSet(electronPFIsolationCfg),
+                                                 mcTruthCollection=cms.InputTag("prunedGenParticles"),
+                                                 electrons=cms.InputTag("slimmedElectrons"),
+                                                 electrons_endcaps=cms.InputTag("slimmedElectrons"),
+                                                 # temp for miniAOD tests
+
+                                                 MaxPt=cms.double(100.0),
+                                                 DeltaR=cms.double(0.05),
+                                                 MaxAbsEta=cms.double(2.5),
+                                                 MatchingID=cms.vint32(11, -11),
+                                                 MatchingMotherID=cms.vint32(23, 24, -24, 32),
+                                                 histosCfg=cms.PSet(electronMcSignalHistosCfg),
+                                                 isolationCfg=cms.PSet(electronPFIsolationCfg),
+                                                 )
+
+from Configuration.Eras.Modifier_phase2_hgcal_cff import phase2_hgcal
+
+phase2_hgcal.toModify(
+    electronMcSignalValidatorMiniAOD,
+    # electrons = cms.InputTag("slimmedElectronsFromMultiCl"),
+    electrons_endcaps=cms.InputTag("slimmedElectronsFromMultiCl"),
+    MaxAbsEta=cms.double(3.0),
+    histosCfg=dict(
+        Nbineta=60,
+        Nbineta2D=60,
+        Etamin=-3.0,
+        Etamax=3.0,
+    ),
 )

--- a/Validation/RecoEgamma/python/ElectronMcSignalValidatorPt1000_gedGsfElectrons_cfi.py
+++ b/Validation/RecoEgamma/python/ElectronMcSignalValidatorPt1000_gedGsfElectrons_cfi.py
@@ -23,7 +23,7 @@ electronMcSignalHistosCfg = cms.PSet(
   Nbinpoptrue = cms.int32(75), Poptruemin = cms.double(0.0), Poptruemax = cms.double(1.5),
   Nbinerror = cms.int32(30), Energyerrormax = cms.double(150.0),
   EfficiencyFlag = cms.bool(True), StatOverflowFlag = cms.bool(False),
-  NbinOPV = cms.int32(81), OPV_min = cms.double(-0.5), OPV_max = cms.double(79.5), # OPV : Offline Primary Vertices
+  NbinOPV = cms.int32(80), OPV_min = cms.double(-0.5), OPV_max = cms.double(79.5), # OPV : Offline Primary Vertices
   NbinELE = cms.int32(11), ELE_min = cms.double(-0.5), ELE_max = cms.double(10.5), # ELE : recEleNum
   NbinCORE = cms.int32(21), CORE_min = cms.double(-0.5), CORE_max = cms.double(20.5), # CORE : recCoreNum
   NbinTRACK = cms.int32(41), TRACK_min = cms.double(-0.5), TRACK_max = cms.double(40.5), # TRACK : recTrackNum

--- a/Validation/RecoEgamma/python/ElectronMcSignalValidator_gedGsfElectrons_cfi.py
+++ b/Validation/RecoEgamma/python/ElectronMcSignalValidator_gedGsfElectrons_cfi.py
@@ -18,7 +18,7 @@ electronMcSignalHistosCfg = cms.PSet(
   Nbinpoptrue = cms.int32(75), Poptruemin = cms.double(0.0), Poptruemax = cms.double(1.5),
   Nbinerror = cms.int32(30), Energyerrormax = cms.double(30.0),
   EfficiencyFlag = cms.bool(True), StatOverflowFlag = cms.bool(False),
-  NbinOPV = cms.int32(81), OPV_min = cms.double(-0.5), OPV_max = cms.double(79.5), # OPV : Offline Primary Vertices
+  NbinOPV = cms.int32(80), OPV_min = cms.double(-0.5), OPV_max = cms.double(79.5), # OPV : Offline Primary Vertices
   NbinELE = cms.int32(11), ELE_min = cms.double(-0.5), ELE_max = cms.double(10.5), # ELE : recEleNum
   NbinCORE = cms.int32(21), CORE_min = cms.double(-0.5), CORE_max = cms.double(20.5), # CORE : recCoreNum
   NbinTRACK = cms.int32(41), TRACK_min = cms.double(-0.5), TRACK_max = cms.double(40.5), # TRACK : recTrackNum

--- a/Validation/RecoEgamma/test/ElectronMcSignalPostValidationMiniAOD_cfg.py
+++ b/Validation/RecoEgamma/test/ElectronMcSignalPostValidationMiniAOD_cfg.py
@@ -3,14 +3,20 @@ import sys
 import os
 import FWCore.ParameterSet.Config as cms
 
+from electronValidationCheck_Env import env
+cmsEnv = env() # be careful, cmsEnv != cmsenv. cmsEnv is local
 
-#process = cms.Process("electronValidation")
-#from Configuration.Eras.Era_Run2_2017_cff import Run2_2017
-#process = cms.Process("electronPostValidation",Run2_2017)
-from Configuration.Eras.Era_Phase2_cff import Phase2
-process = cms.Process('electronPostValidation',Phase2) 
+cmsEnv.checkSample() # check the sample value
+cmsEnv.checkValues()
 
-process.options = cms.untracked.PSet( )
+if cmsEnv.beginTag() == 'Run2_2017':
+    from Configuration.Eras.Era_Run2_2017_cff import Run2_2017
+    process = cms.Process("electronPostValidation",Run2_2017)
+else:
+    from Configuration.Eras.Era_Phase2_cff import Phase2
+    process = cms.Process('electronPostValidation',Phase2)
+
+#process.options = cms.untracked.PSet( )
 
 process.DQMStore = cms.Service("DQMStore")
 process.load("Validation.RecoEgamma.ElectronMcSignalPostValidatorMiniAOD_cfi")
@@ -27,13 +33,26 @@ process.load('DQMOffline.Configuration.DQMOffline_cff')
 # actually read in the DQM root file
 process.load("DQMServices.Components.DQMFileReader_cfi")
 
+# others
+# import of standard configurations
+process.load('SimGeneral.HepPDTESSource.pythiapdt_cfi')
+process.load('FWCore.MessageService.MessageLogger_cfi')
+process.load('Configuration.EventContent.EventContent_cff')
+process.load('SimGeneral.MixingModule.mixNoPU_cfi')
+process.load('Configuration.Geometry.GeometryExtended2026D76Reco_cff')
+process.load('Configuration.StandardSequences.MagneticField_cff')
+process.load('Configuration.StandardSequences.DQMSaverAtRunEnd_cff')
+process.load('Configuration.StandardSequences.Harvesting_cff')
+
+
 from DQMServices.Components.DQMStoreStats_cfi import *
 dqmStoreStats.runOnEndJob = cms.untracked.bool(True)
 
 process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(1))
 
-t1 = os.environ['TEST_HISTOS_FILE'].split('.')
-localFileInput = os.environ['TEST_HISTOS_FILE'].replace(".root", "_a.root") #
+print('= inputPostFile : %s' % os.environ['inputPostFile'])
+t1 = os.environ['inputPostFile'].split('.')
+localFileInput = os.environ['inputPostFile'].replace(".root", "_a.root") #
 # Source
 process.source = cms.Source ("PoolSource",fileNames = cms.untracked.vstring("file:" + localFileInput),
 secondaryFileNames = cms.untracked.vstring(),)
@@ -43,7 +62,7 @@ process.electronMcSignalPostValidatorMiniAOD.OutputFolderName = cms.string("Egam
 
 from Configuration.AlCa.autoCond import autoCond
 #process.GlobalTag.globaltag = os.environ['TEST_GLOBAL_TAG']#+'::All'
-process.GlobalTag.globaltag = '93X_upgrade2023_realistic_v0'
+process.GlobalTag.globaltag = '113X_mcRun4_realistic_v4'
 #process.GlobalTag.globaltag = '93X_mc2017_realistic_v1'
 
 process.dqmSaver.workflow = '/electronHistos/' + t1[1] + '/RECO3'

--- a/Validation/RecoEgamma/test/ElectronMcSignalPostValidation_cfg.py
+++ b/Validation/RecoEgamma/test/ElectronMcSignalPostValidation_cfg.py
@@ -14,7 +14,7 @@ if cmsEnv.beginTag() == 'Run2_2017':
     process = cms.Process("electronPostValidation",Run2_2017)
 else:
     from Configuration.Eras.Era_Phase2_cff import Phase2
-    process = cms.Process('electronPostValidation',Phase2) 
+    process = cms.Process('electronPostValidation',Phase2)
 
 process.DQMStore = cms.Service("DQMStore")
 process.load("Validation.RecoEgamma.ElectronMcSignalPostValidator_cfi")
@@ -31,13 +31,26 @@ process.load('DQMOffline.Configuration.DQMOffline_cff')
 # actually read in the DQM root file
 process.load("DQMServices.Components.DQMFileReader_cfi")
 
+# others
+# import of standard configurations
+process.load('SimGeneral.HepPDTESSource.pythiapdt_cfi')
+process.load('FWCore.MessageService.MessageLogger_cfi')
+process.load('Configuration.EventContent.EventContent_cff')
+process.load('SimGeneral.MixingModule.mixNoPU_cfi')
+process.load('Configuration.Geometry.GeometryExtended2026D76Reco_cff')
+process.load('Configuration.StandardSequences.MagneticField_cff')
+process.load('Configuration.StandardSequences.DQMSaverAtRunEnd_cff')
+process.load('Configuration.StandardSequences.Harvesting_cff')
+
+
 from DQMServices.Components.DQMStoreStats_cfi import *
 dqmStoreStats.runOnEndJob = cms.untracked.bool(True)
 
 process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(1))
 
+print('= inputPostFile : %s' % os.environ['inputPostFile'])
 t1 = os.environ['inputPostFile'].split('.')
-localFileInput = os.environ['inputPostFile'].replace(".root", "_a.root") #
+localFileInput = os.environ['inputPostFile'].replace("_a.root", ".root") #
 # Source
 process.source = cms.Source ("PoolSource",fileNames = cms.untracked.vstring("file:" + localFileInput),
 secondaryFileNames = cms.untracked.vstring(),)
@@ -47,7 +60,7 @@ process.electronMcSignalPostValidator.OutputFolderName = cms.string("EgammaV/Ele
 
 from Configuration.AlCa.autoCond import autoCond
 #process.GlobalTag.globaltag = os.environ['TEST_GLOBAL_TAG']#+'::All'
-process.GlobalTag.globaltag = '93X_upgrade2023_realistic_v2'
+process.GlobalTag.globaltag = '113X_mcRun4_realistic_v4'
 #process.GlobalTag.globaltag = '93X_mc2017_realistic_v1'
 #process.GlobalTag.globaltag = '92X_upgrade2017_realistic_v10'
 

--- a/Validation/RecoEgamma/test/ElectronMcSignalValidationMiniAOD_cfg.py
+++ b/Validation/RecoEgamma/test/ElectronMcSignalValidationMiniAOD_cfg.py
@@ -2,66 +2,59 @@ from __future__ import print_function
 
 import sys
 import os
-import DQMOffline.EGamma.electronDataDiscovery as dd
 import FWCore.ParameterSet.Config as cms
 
+print('Number of arguments:', len(sys.argv), 'arguments.')
+print('Argument List:', str(sys.argv))
+# first arg : cmsRun
+# second arg : name of the _cfg file
+# third arg : sample name (ex. ZEE_14)
 
-#process = cms.Process("electronValidation")
-#from Configuration.Eras.Era_Run2_2017_cff import Run2_2017
-#process = cms.Process("electronValidation",Run2_2017)
-from Configuration.Eras.Era_Phase2_cff import Phase2
-process = cms.Process('electronValidation',Phase2) 
+from electronValidationCheck_Env import env
+cmsEnv = env() # be careful, cmsEnv != cmsenv. cmsEnv is local
 
-process.options = cms.untracked.PSet( )
+cmsEnv.checkSample() # check the sample value
+cmsEnv.checkValues()
 
-#from FWCore.Modules.printContent_cfi import * 
+import DQMOffline.EGamma.electronDataDiscovery as dd
+
+if cmsEnv.beginTag() == 'Run2_2017':
+    from Configuration.Eras.Era_Run2_2017_cff import Run2_2017
+    process = cms.Process("electronValidation",Run2_2017)
+else:
+    from Configuration.Eras.Era_Phase2_cff import Phase2
+    process = cms.Process('electronValidation',Phase2)
+
+#process.options = cms.untracked.PSet( )
 
 process.DQMStore = cms.Service("DQMStore")
 process.load("DQMServices.Components.DQMStoreStats_cfi")
 from DQMServices.Components.DQMStoreStats_cfi import *
 dqmStoreStats.runOnEndJob = cms.untracked.bool(True)
 
-# OLD WAY
-
 print("reading files ...")
 max_number = -1 # number of events
 process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(max_number))
-process.source = cms.Source ("PoolSource",
-#eventsToProcess = cms.untracked.VEventRange('1:2682-1:2682'), 
-#eventsToProcess = cms.untracked.VEventRange('1:8259-1:8259'), 
-#eventsToProcess = cms.untracked.VEventRange('1:10-1:10'), 
-fileNames = cms.untracked.vstring([
+
+data = os.environ['data']
+flist = dd.getCMSdata(data)
+process.source = cms.Source("PoolSource", fileNames = cms.untracked.vstring(*flist))
+
+#process.source = cms.Source ("PoolSource",
+#eventsToProcess = cms.untracked.VEventRange('1:2682-1:2682'),
+#eventsToProcess = cms.untracked.VEventRange('1:8259-1:8259'),
+#eventsToProcess = cms.untracked.VEventRange('1:10-1:10'),
+#fileNames = cms.untracked.vstring([
 #        'file:PAT_249120E2-D1EC-E611-83C2-0CC47A7C347A.root',
 #        'file:PAT_76F9AD07-D3EC-E611-AA87-0CC47A745250.root',
 #        'file:PAT_FA0E1D02-D5EC-E611-B8CA-0025905A6080.root',
 #        'file:PAT_EE728E01-D5EC-E611-9DC5-0025905A6126.root',
 #        '/store/relval/CMSSW_9_1_0_pre2/RelValSingleElectronPt10/MINIAODSIM/90X_upgrade2017_realistic_v20-v1/00000/66B5E60E-5619-E711-8E17-0CC47A4D7632.root',
 #        '/store/relval/CMSSW_9_1_0_pre2/RelValSingleElectronPt10/MINIAODSIM/90X_upgrade2017_realistic_v20-v1/00000/BC08FC0E-5619-E711-98E5-0CC47A4D760C.root',
-    ]),
-secondaryFileNames = cms.untracked.vstring() )
-process.source.fileNames.extend(dd.search())
-print("reading files done")
-
-#process.printTree = cms.EDAnalyzer("ParticleListDrawer",
-#  maxEventsToPrint = cms.untracked.int32(1),
-#  printVertex = cms.untracked.bool(False),
-#  printOnlyHardInteraction = cms.untracked.bool(False), # Print only status=3 particles. This will not work for Pythia8, which does not have any such particles.
-#  src = cms.InputTag("prunedGenParticles")
-#)
-
-# NEW WAY
-#print "reading files ..."
-#readFiles = cms.untracked.vstring()
-#secFiles = cms.untracked.vstring() 
-#process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(-1) )
-#process.source = cms.Source ("PoolSource",fileNames = readFiles, secondaryFileNames = secFiles)
+#    ]),
+#secondaryFileNames = cms.untracked.vstring() )
 #process.source.fileNames.extend(dd.search())
-#DD_SOURCE_TEMP = os.environ['DD_SOURCE']
-#TEMP = os.environ['DD_SOURCE'].replace("MINIAODSIM", "GEN-SIM-RECO" ) 
-#os.environ['DD_SOURCE'] = os.environ['DD_SOURCE'].replace("MINIAODSIM", "GEN-SIM-RECO" ) 
-#process.source.secondaryFileNames.extend(dd.search2())
-#os.environ['DD_SOURCE'] = DD_SOURCE_TEMP
-#print "done"
+print("reading files done")
 
 process.load('Configuration.StandardSequences.Services_cff')
 process.load('SimGeneral.HepPDTESSource.pythiapdt_cfi')
@@ -73,12 +66,12 @@ process.load('Configuration.StandardSequences.MagneticField_38T_cff')
 process.load('Configuration.StandardSequences.RawToDigi_cff')
 process.load('Configuration.StandardSequences.Reconstruction_cff')
 process.load('Configuration.StandardSequences.EndOfProcess_cff')
-process.load("Configuration.StandardSequences.EDMtoMEAtJobEnd_cff") # new 
+process.load("Configuration.StandardSequences.EDMtoMEAtJobEnd_cff") # new
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 
 from Configuration.AlCa.autoCond import autoCond
 #process.GlobalTag.globaltag = os.environ['TEST_GLOBAL_TAG']#+'::All'
-process.GlobalTag.globaltag = '93X_upgrade2023_realistic_v0'
+process.GlobalTag.globaltag = '113X_mcRun4_realistic_v4'
 #process.GlobalTag.globaltag = '93X_mc2017_realistic_v1'
 
 # FOR DATA REDONE FROM RAW, ONE MUST HIDE IsoFromDeps
@@ -101,15 +94,15 @@ process.load("DQMServices.Components.DQMEnvironment_cfi")
 process.EDM = cms.OutputModule("PoolOutputModule",
 outputCommands = cms.untracked.vstring('drop *',"keep *_MEtoEDMConverter_*_*"),
 #fileName = cms.untracked.string(TEST_HISTOS_FILE)
-fileName = cms.untracked.string(os.environ['TEST_HISTOS_FILE'].replace(".root", "_a.root"))
+fileName = cms.untracked.string(os.environ['outputFile'].replace(".root", "_a.root"))
 )
 
 process.electronMcSignalValidatorMiniAOD.InputFolderName = cms.string("EgammaV/ElectronMcSignalValidatorMiniAOD")
 process.electronMcSignalValidatorMiniAOD.OutputFolderName = cms.string("EgammaV/ElectronMcSignalValidatorMiniAOD")
 
-#process.p = cms.Path(process.ElectronIsolation * process.electronMcSignalValidatorMiniAOD * process.MEtoEDMConverter ) # * process.dqmStoreStats 
+#process.p = cms.Path(process.ElectronIsolation * process.electronMcSignalValidatorMiniAOD * process.MEtoEDMConverter ) # * process.dqmStoreStats
 #process.p = cms.Path(process.electronMcSignalValidatorMiniAOD * process.MEtoEDMConverter * process.dqmStoreStats)
-process.p = cms.Path( process.miniAODElectronIsolation * process.ElectronIsolation * process.electronMcSignalValidatorMiniAOD * process.MEtoEDMConverter ) #  process.printContent * 
+process.p = cms.Path( process.miniAODElectronIsolation * process.ElectronIsolation * process.electronMcSignalValidatorMiniAOD * process.MEtoEDMConverter ) #  process.printContent *
 process.outpath = cms.EndPath(
 process.EDM,
 )

--- a/Validation/RecoEgamma/test/ElectronMcSignalValidation_gedGsfElectrons_cfg.py
+++ b/Validation/RecoEgamma/test/ElectronMcSignalValidation_gedGsfElectrons_cfg.py
@@ -2,7 +2,6 @@ from __future__ import print_function
 
 import sys
 import os
-import DQMOffline.EGamma.electronDataDiscovery as dd
 import FWCore.ParameterSet.Config as cms
 
 print('Number of arguments:', len(sys.argv), 'arguments.')
@@ -12,44 +11,64 @@ print('Argument List:', str(sys.argv))
 # third arg : sample name (ex. ZEE_14)
 
 from electronValidationCheck_Env import env
-cmsEnv = env() # be careful, cmsEnv != cmsenv. cmsEnv is local
 
-cmsEnv.checkSample() # check the sample value
+cmsEnv = env()  # be careful, cmsEnv != cmsenv. cmsEnv is local
+
+cmsEnv.checkSample()  # check the sample value
 cmsEnv.checkValues()
+
+import DQMOffline.EGamma.electronDataDiscovery as dd
 
 if cmsEnv.beginTag() == 'Run2_2017':
     from Configuration.Eras.Era_Run2_2017_cff import Run2_2017
-    process = cms.Process("electronValidation",Run2_2017)
+
+    process = cms.Process("electronValidation", Run2_2017)
 else:
     from Configuration.Eras.Era_Phase2_cff import Phase2
-    process = cms.Process('electronValidation',Phase2) 
+
+    process = cms.Process('electronValidation', Phase2)
 
 process.DQMStore = cms.Service("DQMStore")
 process.load("DQMServices.Components.DQMStoreStats_cfi")
 from DQMServices.Components.DQMStoreStats_cfi import *
+
 dqmStoreStats.runOnEndJob = cms.untracked.bool(True)
 
-#max_skipped = 165
-max_number = -1 # 10 # number of events
-process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(max_number))
-#process.source = cms.Source ("PoolSource",skipEvents = cms.untracked.uint32(max_skipped), fileNames = cms.untracked.vstring(),secondaryFileNames = cms.untracked.vstring())
+# max_skipped = 165
+max_number = -1  # 10 # number of events
+process.maxEvents = cms.untracked.PSet(input=cms.untracked.int32(max_number))
+# process.source = cms.Source ("PoolSource",skipEvents = cms.untracked.uint32(max_skipped), fileNames = cms.untracked.vstring(),secondaryFileNames = cms.untracked.vstring())
 
-process.source = cms.Source ("PoolSource", fileNames = cms.untracked.vstring(),secondaryFileNames = cms.untracked.vstring()) # std value
-process.source.fileNames.extend(dd.search())  # to be commented for local run only
+data = os.environ['data']
+flist = dd.getCMSdata(data)
+process.source = cms.Source("PoolSource", fileNames=cms.untracked.vstring(*flist))
 
-#process.source = cms.Source ("PoolSource",
+# process.source = cms.Source ("PoolSource", fileNames = cms.untracked.vstring(),secondaryFileNames = cms.untracked.vstring()) # std value
+# process.source.fileNames.extend(dd.search())  # to be commented for local run only
+
+# process.source = cms.Source ("PoolSource",
 #    fileNames = cms.untracked.vstring(
 #    [
-    #'file:/eos/user/a/archiron/HGCal_Shares/step3_A8F750A4-6D87-E711-A476-0CC47A4D7600.root',
-    #'file:/eos/user/a/archiron/HGCal_Shares/step3_AE79E794-7287-E711-9D2A-0CC47A78A3EE.root',
-    #'file:/eos/user/a/archiron/HGCal_Shares/step3_D801BDAF-7087-E711-AEF8-0CC47A7C354A.root',
-    
-    #'file:/eos/user/r/rovere/www/shared/step3.root',
+# 'file:/eos/user/a/archiron/HGCal_Shares/step3_A8F750A4-6D87-E711-A476-0CC47A4D7600.root',
+# 'file:/eos/user/a/archiron/HGCal_Shares/step3_AE79E794-7287-E711-9D2A-0CC47A78A3EE.root',
+# 'file:/eos/user/a/archiron/HGCal_Shares/step3_D801BDAF-7087-E711-AEF8-0CC47A7C354A.root',
 
-    #'root://cms-xrd-global.cern.ch//store/relval/CMSSW_9_3_2/RelValQCD_Pt-15To7000_Flat_14TeV/GEN-SIM-RECO/93X_upgrade2023_realistic_v2_2023D17noPU-v1/10000/00FF6760-F8A6-E711-AA68-0025905A60D6.root',
-#    ]
-#    )
-#)  # for local run only
+# 'file:/eos/user/r/rovere/www/shared/step3.root',
+
+# 'root://cms-xrd-global.cern.ch//store/relval/CMSSW_9_3_2/RelValQCD_Pt-15To7000_Flat_14TeV/GEN-SIM-RECO/93X_upgrade2023_realistic_v2_2023D17noPU-v1/10000/00FF6760-F8A6-E711-AA68-0025905A60D6.root',
+# 'root://cms-xrd-global.cern.ch//store/relval/CMSSW_11_3_0_pre4/RelValZEE_14/GEN-SIM-RECO/113X_mcRun4_realistic_v4_2026D76noPU-v1/00000/0d87e1b9-1398-4a32-9775-e2d170c00df3.root',
+# 'root://cms-xrd-global.cern.ch//store/relval/CMSSW_11_3_0_pre4/RelValZEE_14/GEN-SIM-RECO/113X_mcRun4_realistic_v4_2026D76noPU-v1/00000/22bff740-c71a-4527-a6ac-58360438960b.root',
+# 'root://cms-xrd-global.cern.ch//store/relval/CMSSW_11_3_0_pre4/RelValZEE_14/GEN-SIM-RECO/113X_mcRun4_realistic_v4_2026D76noPU-v1/00000/268ccf98-9216-493b-a1ff-403db31fbfd2.root',
+# 'root://cms-xrd-global.cern.ch//store/relval/CMSSW_11_3_0_pre4/RelValZEE_14/GEN-SIM-RECO/113X_mcRun4_realistic_v4_2026D76noPU-v1/00000/515c0b30-2803-490e-a1bf-06722f934a2f.root',
+# 'root://cms-xrd-global.cern.ch//store/relval/CMSSW_11_3_0_pre4/RelValZEE_14/GEN-SIM-RECO/113X_mcRun4_realistic_v4_2026D76noPU-v1/00000/7f266520-2cf7-4245-859c-3cb82b4e4cea.root',
+# 'root://cms-xrd-global.cern.ch//store/relval/CMSSW_11_3_0_pre4/RelValZEE_14/GEN-SIM-RECO/113X_mcRun4_realistic_v4_2026D76noPU-v1/00000/9c7caca7-9179-4d91-a4fa-2cc37cef73a1.root',
+# 'root://cms-xrd-global.cern.ch//store/relval/CMSSW_11_3_0_pre4/RelValZEE_14/GEN-SIM-RECO/113X_mcRun4_realistic_v4_2026D76noPU-v1/00000/a75081f2-16e5-499e-ac41-6b98afddbf28.root',
+# 'root://cms-xrd-global.cern.ch//store/relval/CMSSW_11_3_0_pre4/RelValZEE_14/GEN-SIM-RECO/113X_mcRun4_realistic_v4_2026D76noPU-v1/00000/b714a540-be23-423c-9b71-b92b07235dde.root',
+# 'root://cms-xrd-global.cern.ch//store/relval/CMSSW_11_3_0_pre4/RelValZEE_14/GEN-SIM-RECO/113X_mcRun4_realistic_v4_2026D76noPU-v1/00000/cf9fb9fc-8450-4d7f-a285-41007aed4158.root',
+
+# ]
+# )
+# )  # for local run only
 
 process.load('Configuration.StandardSequences.Services_cff')
 process.load('SimGeneral.HepPDTESSource.pythiapdt_cfi')
@@ -61,14 +80,16 @@ process.load('Configuration.StandardSequences.MagneticField_38T_cff')
 process.load('Configuration.StandardSequences.RawToDigi_cff')
 process.load('Configuration.StandardSequences.Reconstruction_cff')
 process.load('Configuration.StandardSequences.EndOfProcess_cff')
-process.load("Configuration.StandardSequences.EDMtoMEAtJobEnd_cff") # new 
+process.load("Configuration.StandardSequences.EDMtoMEAtJobEnd_cff")  # new
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 
 from Configuration.AlCa.autoCond import autoCond
-#process.GlobalTag.globaltag = os.environ['TEST_GLOBAL_TAG'] + '::All'
-process.GlobalTag.globaltag = '93X_upgrade2023_realistic_v2'
-#process.GlobalTag.globaltag = '93X_mc2017_realistic_v1'
-#process.GlobalTag.globaltag = '92X_upgrade2017_realistic_v10'
+
+# process.GlobalTag.globaltag = os.environ['TEST_GLOBAL_TAG'] + '::All'
+process.GlobalTag.globaltag = '113X_mcRun4_realistic_v4'
+# process.GlobalTag.globaltag = '113X_mcRun3_2021_realistic_v4'
+# process.GlobalTag.globaltag = '93X_mc2017_realistic_v1'
+# process.GlobalTag.globaltag = '92X_upgrade2017_realistic_v10'
 
 # FOR DATA REDONE FROM RAW, ONE MUST HIDE IsoFromDeps
 # CONFIGURATION
@@ -80,17 +101,17 @@ process.load("DQMServices.Core.DQM_cfg")
 process.load("DQMServices.Components.DQMEnvironment_cfi")
 
 process.EDM = cms.OutputModule("PoolOutputModule",
-outputCommands = cms.untracked.vstring('drop *',"keep *_MEtoEDMConverter_*_*"),
-fileName = cms.untracked.string(os.environ['outputFile'].replace(".root", "_a.root"))
-#fileName = cms.untracked.string('electronHistos.ValFullZEEStartup_13_gedGsfE_a.root') # for local run only
-)
+                               outputCommands=cms.untracked.vstring('drop *', "keep *_MEtoEDMConverter_*_*"),
+                               fileName=cms.untracked.string(os.environ['outputFile'].replace(".root", "_a.root"))
+                               # fileName = cms.untracked.string('electronHistos.ValFullZEEStartup_13_gedGsfE_a.root') # for local run only
+                               )
 
 process.electronMcSignalValidator.InputFolderName = cms.string("EgammaV/ElectronMcSignalValidator")
 process.electronMcSignalValidator.OutputFolderName = cms.string("EgammaV/ElectronMcSignalValidator")
 
-#process.p = cms.Path(process.electronIsoFromDeps * process.electronMcSignalValidator * process.MEtoEDMConverter * process.dqmStoreStats)
+# process.p = cms.Path(process.electronIsoFromDeps * process.electronMcSignalValidator * process.MEtoEDMConverter * process.dqmStoreStats)
 process.p = cms.Path(process.electronMcSignalValidator * process.MEtoEDMConverter * process.dqmStoreStats)
 
 process.outpath = cms.EndPath(
-process.EDM,
+    process.EDM,
 )

--- a/Validation/RecoEgamma/test/electronValidationCheck_Env.py
+++ b/Validation/RecoEgamma/test/electronValidationCheck_Env.py
@@ -1,13 +1,14 @@
 #! /usr/bin/env python
-#-*-coding: utf-8 -*-
+# -*-coding: utf-8 -*-
 
 from __future__ import print_function
-import os,sys
+import os, sys
+
 
 class env:
     def checkSample(self):
-        if ( 'DD_SAMPLE' not in os.environ ) or ( os.environ['DD_SAMPLE'] == '' ):
-            if ( len(sys.argv) > 2 ): # no else part since if sample does not exist, we had quit previously
+        if ('DD_SAMPLE' not in os.environ) or (os.environ['DD_SAMPLE'] == ''):
+            if (len(sys.argv) > 2):  # no else part since if sample does not exist, we had quit previously
                 sampleName = str(sys.argv[2])
                 os.environ['DD_SAMPLE'] = 'RelVal' + sampleName
                 print('Sample name:', sampleName, ' - ', os.environ['DD_SAMPLE'])
@@ -18,20 +19,22 @@ class env:
                 quit()
 
     def beginTag(self):
-	beginTag = 'Phase2'
-#	beginTag = 'Run2_2017'
-	return beginTag
+        beginTag = 'Phase2'
+        # beginTag = 'Run2_2017'
+        return beginTag
 
     def dd_tier(self):
         dd_tier = 'GEN-SIM-RECO'
-        return dd_tier 
+        dd_tier = 'MINIAODSIM'
+        return dd_tier
 
     def tag_startup(self):
-        tag_startup = '93X_upgrade2023_realistic_v2_2023D17noPU'
-#        tag_startup = '93X_upgrade2023_realistic_v2_2023D17PU140'
-#        tag_startup = '93X_upgrade2023_realistic_v0_D17PU200'
-#        tag_startup = '92X_upgrade2023_realistic_v2_2023D17noPU' 
-#        tag_startup = '93X_upgrade2023_realistic_v0_D17PU200'
+        tag_startup = '113X_mcRun4_realistic_v4_2026D76noPU'
+        # tag_startup = '113X_mcRun3_2021_realistic_v7'
+        # tag_startup = '93X_upgrade2023_realistic_v2_2023D17PU140'
+        # tag_startup = '93X_upgrade2023_realistic_v0_D17PU200'
+        # tag_startup = '92X_upgrade2023_realistic_v2_2023D17noPU'
+        # tag_startup = '93X_upgrade2023_realistic_v0_D17PU200'
         return tag_startup
 
     def data_version(self):
@@ -43,8 +46,8 @@ class env:
         return test_global_tag
 
     def dd_cond(self):
-#        dd_cond = 'PU25ns_' + self.test_global_tag() + '-' + self.data_version() # PU
-        dd_cond = self.test_global_tag() + '-' + self.data_version()              # noPU
+        # dd_cond = 'PU25ns_' + self.test_global_tag() + '-' + self.data_version() # PU
+        dd_cond = self.test_global_tag() + '-' + self.data_version()  # noPU
         return dd_cond
 
     def checkValues(self):
@@ -55,40 +58,45 @@ class env:
         print(self.test_global_tag())
         print(self.dd_cond())
         print('-----')
-        
+
         os.environ['beginTag'] = self.beginTag()
 
-        if ( 'DD_TIER' not in os.environ ) or ( os.environ['DD_TIER'] == '' ):
-            os.environ['DD_TIER'] = self.dd_tier() # 'GEN-SIM-RECO'
-        if 'TAG_STARTUP' not in os.environ: # TAG_STARTUP from OvalFile
-            os.environ['TAG_STARTUP'] = self.tag_startup() # '93X_upgrade2023_realistic_v0_D17PU200' 
-        if 'DATA_VERSION' not in os.environ: # DATA_VERSION from OvalFile
-            os.environ['DATA_VERSION'] = self.data_version() # 'v1'
-        if 'TEST_GLOBAL_TAG' not in os.environ: # TEST_GLOBAL_TAG from OvalFile
-            os.environ['TEST_GLOBAL_TAG'] = self.test_global_tag() # os.environ['TAG_STARTUP']
-        if ( 'DD_COND' not in os.environ ) or ( os.environ['DD_COND'] == '' ):
-            os.environ['DD_COND'] = self.dd_cond() # 'PU25ns_' + os.environ['TEST_GLOBAL_TAG'] + '-' + os.environ['DATA_VERSION']
+        if ('DD_TIER' not in os.environ) or (os.environ['DD_TIER'] == ''):
+            os.environ['DD_TIER'] = self.dd_tier()  # 'GEN-SIM-RECO'
+        if 'TAG_STARTUP' not in os.environ:  # TAG_STARTUP from OvalFile
+            os.environ['TAG_STARTUP'] = self.tag_startup()  # '93X_upgrade2023_realistic_v0_D17PU200'
+        if 'DATA_VERSION' not in os.environ:  # DATA_VERSION from OvalFile
+            os.environ['DATA_VERSION'] = self.data_version()  # 'v1'
+        if 'TEST_GLOBAL_TAG' not in os.environ:  # TEST_GLOBAL_TAG from OvalFile
+            os.environ['TEST_GLOBAL_TAG'] = self.test_global_tag()  # os.environ['TAG_STARTUP']
+        if ('DD_COND' not in os.environ) or (os.environ['DD_COND'] == ''):
+            os.environ[
+                'DD_COND'] = self.dd_cond()  # 'PU25ns_' + os.environ['TEST_GLOBAL_TAG'] + '-' + os.environ['DATA_VERSION']
 
         os.environ['DD_RELEASE'] = os.environ['CMSSW_VERSION']
-	    #os.environ['DD_RELEASE'] = "CMSSW_9_3_0_pre3" 
+        # os.environ['DD_RELEASE'] = "CMSSW_11_3_0_pre3"
 
         print('=====')
-        if ( 'DD_SAMPLE_OUT' not in os.environ ) or ( os.environ['DD_SAMPLE_OUT'] == '' ):
+        if ('DD_SAMPLE_OUT' not in os.environ) or (os.environ['DD_SAMPLE_OUT'] == ''):
             os.environ['DD_SAMPLE_OUT'] = os.environ['DD_SAMPLE'].replace("RelVal", "ValFull")
         print('=====')
 
-        os.environ['DD_SOURCE'] = '/eos/cms/store/relval/' + os.environ['DD_RELEASE'] + '/' + os.environ['DD_SAMPLE'] + '/' + os.environ['DD_TIER'] + '/' + os.environ['DD_COND']
+        os.environ['DD_SOURCE'] = '/eos/cms/store/relval/' + os.environ['DD_RELEASE'] + '/' + os.environ[
+            'DD_SAMPLE'] + '/' + os.environ['DD_TIER'] + '/' + os.environ['DD_COND']
+        os.environ['data'] = '/' + os.environ['DD_SAMPLE'] + '/' + os.environ['DD_RELEASE'] + '-' + os.environ[
+            'DD_COND'] + '/' + os.environ['DD_TIER']
         os.environ['outputFile'] = 'electronHistos.' + os.environ['DD_SAMPLE_OUT'] + '_gedGsfE.root'
-        if ( 'inputPostFile' not in os.environ ) or ( os.environ['inputPostFile'] == '' ):
+        if ('inputPostFile' not in os.environ) or (os.environ['inputPostFile'] == ''):
+            print('inputPostFile : %s' % os.environ['outputFile'])
             os.environ['inputPostFile'] = os.environ['outputFile']
-        
+
         print('DD_RELEASE', os.environ['DD_RELEASE'])
         print('DD_SAMPLE', os.environ['DD_SAMPLE'])
         print('DD_SAMPLE_OUT', os.environ['DD_SAMPLE_OUT'])
         print('DD_COND', os.environ['DD_COND'])
         print('DD_TIER', os.environ['DD_TIER'])
         print('DD_SOURCE', os.environ['DD_SOURCE'])
+        print('data', os.environ['data'])
         print('outputFile    :', os.environ['outputFile'])
         print('inputPostFile :', os.environ['inputPostFile'])
         print('beginTag : ', self.beginTag())
- 


### PR DESCRIPTION
#### PR description:

Implemented a workaround in the miniAOD validation to read the electron collections from two different collections (one for the barrel, one for the HGCAL). The values are adjusted for PHASE2 validation via an era modifier
Improved the binning in a few plots.

The modifications are made in Validation/RecoEGamma/plugins folder (ElectronMcMiniAODSignalValidator.cc/h) and into the Validation/RecoEGamma/python folder (ElectronMcSignalValidatorMiniAOD_cfi.py).  We also modified ElectronMcSignalValidator_gedGsfElectrons_cfi.py, ElectronMcFakeValidator_gedGsfElectrons_cfi.py & ElectronMcSignalValidatorPt1000_gedGsfElectrons_cfi.py for binning.

We also made some corrections into DQMOffline/Egamma/python folder (electronDataDiscovery.py) by implementing a new function wich help us with local runs into Validation/RecoEgamma/tests folders (ElectronMcSignalPostValidation_cfg.py, ElectronMcSignalPostValidationMiniAOD_cfg.py, ElectronMcSignalValidationMiniAOD_cfg.py, ElectronMcSignalValidation_gedGsfElectrons_cfg.py, electronValidationCheck_Env.py).

![miniAOD_corrections](https://user-images.githubusercontent.com/5586847/114546526-89a33c00-9c5d-11eb-8f3f-b5115bd984db.png)

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

for miniAOD improvement, the différences can be seen : 
before : https://cms-egamma.web.cern.ch/validation/Electrons/Dev/index.php?action=/11_3_0_pre4_PHASE2_miniAOD3_DQM_dev/FullvsFull_CMSSW_11_3_0_pre4/RECO-miniAOD_ZEE_14#TOP
after : https://cms-egamma.web.cern.ch/validation/Electrons/Dev/index.php?action=/11_3_0_pre4_PHASE2_miniAOD6_DQM_dev/FullvsFull_CMSSW_11_3_0_pre4/RECO-miniAOD_ZEE_14#TOP

the binning improvement is only a regularization of the number of bins for histos with primary vertices (80 instead of 81). This avoid some drops into the curves of histograms.

#### PR validation:

compilation is OK, basics tests (scram b runtests or local tests) are OK too.
runTheMatrix.py -l limited -i all --ibeos tests are fine (38 37 36 27 17 4 1 1 1 tests passed, 0 0 0 0 0 0 0 0 0 failed
).
here is the run-log : 
[runall-report-step123-.log](https://github.com/cms-sw/cmssw/files/6303598/runall-report-step123-.log)


Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch  -> OK.
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)  -> OK.
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)  -> OK.

@beaudett