### PR TITLE
TkDQM: introduce new harvester module for creating 2D folded occupancy maps

### DIFF
--- a/DQM/TrackingMonitor/interface/TrackAnalyzer.h
+++ b/DQM/TrackingMonitor/interface/TrackAnalyzer.h
@@ -57,6 +57,7 @@ namespace tadqm {
     void setNumberOfGoodVertices(const edm::Event&);
     void setBX(const edm::Event&);
     void setLumi(const edm::Event&, const edm::EventSetup& iSetup);
+
   private:
     void initHistos();
     void fillHistosForState(const edm::EventSetup& iSetup, const reco::Track& track, std::string sname);

--- a/DQM/TrackingMonitor/interface/TrackAnalyzer.h
+++ b/DQM/TrackingMonitor/interface/TrackAnalyzer.h
@@ -57,7 +57,6 @@ namespace tadqm {
     void setNumberOfGoodVertices(const edm::Event&);
     void setBX(const edm::Event&);
     void setLumi(const edm::Event&, const edm::EventSetup& iSetup);
-
   private:
     void initHistos();
     void fillHistosForState(const edm::EventSetup& iSetup, const reco::Track& track, std::string sname);
@@ -270,10 +269,6 @@ namespace tadqm {
       MonitorElement* TrackEtaPhi = nullptr;
       MonitorElement* TrackEtaPhiInverted = nullptr;
       MonitorElement* TrackEtaPhiInvertedoutofphase = nullptr;
-      MonitorElement* TkEtaPhi_Ratio_byFoldingmap = nullptr;
-      MonitorElement* TkEtaPhi_Ratio_byFoldingmap_op = nullptr;
-      MonitorElement* TkEtaPhi_RelativeDifference_byFoldingmap = nullptr;
-      MonitorElement* TkEtaPhi_RelativeDifference_byFoldingmap_op = nullptr;
       MonitorElement* TrackEtaPhiInner = nullptr;
       MonitorElement* TrackEtaPhiOuter = nullptr;
 

--- a/DQM/TrackingMonitor/interface/TrackEfficiencyClient.h
+++ b/DQM/TrackingMonitor/interface/TrackEfficiencyClient.h
@@ -23,11 +23,7 @@ DQM class to compute the tracking efficiency
 
 #include "DQMServices/Core/interface/DQMStore.h"
 
-#include <iostream>
-#include <fstream>
 #include <string>
-#include <vector>
-//#include <map>
 
 class TrackEfficiencyClient : public DQMEDHarvester {
 public:

--- a/DQM/TrackingMonitor/interface/TrackFoldedOccupancyClient.h
+++ b/DQM/TrackingMonitor/interface/TrackFoldedOccupancyClient.h
@@ -5,7 +5,7 @@
 // Package:    TrackingMonitor
 // Class  :    TrackFoldedOccupancyClient
 //
-//DQM class to plot occupancy in eta phi 
+//DQM class to plot occupancy in eta phi
 
 #include <string>
 
@@ -18,7 +18,6 @@
 #include "FWCore/Framework/interface/MakerMacros.h"
 
 #include "DQMServices/Core/interface/DQMStore.h"
-
 
 class TrackFoldedOccupancyClient : public DQMEDHarvester {
 public:

--- a/DQM/TrackingMonitor/interface/TrackFoldedOccupancyClient.h
+++ b/DQM/TrackingMonitor/interface/TrackFoldedOccupancyClient.h
@@ -16,7 +16,6 @@
 #include "FWCore/Framework/interface/Run.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
-
 #include "DQMServices/Core/interface/DQMStore.h"
 
 class TrackFoldedOccupancyClient : public DQMEDHarvester {

--- a/DQM/TrackingMonitor/interface/TrackFoldedOccupancyClient.h
+++ b/DQM/TrackingMonitor/interface/TrackFoldedOccupancyClient.h
@@ -43,6 +43,8 @@ private:
   edm::ParameterSet conf_;
   std::string algoName_;
   std::string quality_;
+  std::string state_;
+  std::string histTag_;
   std::string TopFolder_;
 
   MonitorElement* TkEtaPhi_RelativeDifference_byFoldingmap = nullptr;

--- a/DQM/TrackingMonitor/interface/TrackFoldedOccupancyClient.h
+++ b/DQM/TrackingMonitor/interface/TrackFoldedOccupancyClient.h
@@ -1,0 +1,55 @@
+#ifndef TrackingMonitor_TrackFoldedOccupancyClient_h
+#define TrackingMonitor_TrackFoldedOccupancyClient_h
+// -*- C++ -*-
+//
+// Package:    TrackingMonitor
+// Class  :    TrackFoldedOccupancyClient
+//
+//DQM class to plot occupancy in eta phi 
+
+#include <string>
+
+#include "DQMServices/Core/interface/DQMEDHarvester.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/LuminosityBlock.h"
+#include "FWCore/Framework/interface/Run.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "DQMServices/Core/interface/DQMStore.h"
+
+
+class TrackFoldedOccupancyClient : public DQMEDHarvester {
+public:
+  /// Constructor
+  TrackFoldedOccupancyClient(const edm::ParameterSet& ps);
+
+  /// Destructor
+  ~TrackFoldedOccupancyClient() override;
+
+protected:
+  /// BeginJob
+  void beginJob(void) override;
+
+  /// BeginRun
+  void beginRun(edm::Run const& run, edm::EventSetup const& eSetup) override;
+
+  /// EndJob
+  void dqmEndJob(DQMStore::IBooker& ibooker_, DQMStore::IGetter& igetter_) override;
+
+private:
+  /// book MEs
+  void bookMEs(DQMStore::IBooker& ibooker_);
+
+  edm::ParameterSet conf_;
+  std::string algoName_;
+  std::string quality_;
+  std::string TopFolder_;
+
+  MonitorElement* TkEtaPhi_RelativeDifference_byFoldingmap = nullptr;
+  MonitorElement* TkEtaPhi_RelativeDifference_byFoldingmap_op = nullptr;
+  MonitorElement* TkEtaPhi_Ratio_byFoldingmap = nullptr;
+  MonitorElement* TkEtaPhi_Ratio_byFoldingmap_op = nullptr;
+};
+#endif

--- a/DQM/TrackingMonitor/interface/TrackingMonitor.h
+++ b/DQM/TrackingMonitor/interface/TrackingMonitor.h
@@ -59,7 +59,7 @@ class VertexMonitor;
 class GetLumi;
 class TProfile;
 class GenericTriggerEventFlag;
-#include<iostream>
+
 class TrackingMonitor : public DQMEDAnalyzer {
 public:
   using MVACollection = std::vector<float>;
@@ -74,6 +74,7 @@ public:
 
   void analyze(const edm::Event&, const edm::EventSetup&) override;
   void bookHistograms(DQMStore::IBooker&, edm::Run const&, edm::EventSetup const&) override;
+
 private:
   void doProfileX(TH2* th2, MonitorElement* me);
   void doProfileX(MonitorElement* th2m, MonitorElement* me);

--- a/DQM/TrackingMonitor/interface/TrackingMonitor.h
+++ b/DQM/TrackingMonitor/interface/TrackingMonitor.h
@@ -59,7 +59,7 @@ class VertexMonitor;
 class GetLumi;
 class TProfile;
 class GenericTriggerEventFlag;
-
+#include<iostream>
 class TrackingMonitor : public DQMEDAnalyzer {
 public:
   using MVACollection = std::vector<float>;
@@ -74,8 +74,6 @@ public:
 
   void analyze(const edm::Event&, const edm::EventSetup&) override;
   void bookHistograms(DQMStore::IBooker&, edm::Run const&, edm::EventSetup const&) override;
-  //        virtual void dqmBeginRun(const edm::Run&, const edm::EventSetup&);
-
 private:
   void doProfileX(TH2* th2, MonitorElement* me);
   void doProfileX(MonitorElement* th2m, MonitorElement* me);

--- a/DQM/TrackingMonitor/python/TrackFoldedOccupancyClient_cfi.py
+++ b/DQM/TrackingMonitor/python/TrackFoldedOccupancyClient_cfi.py
@@ -1,0 +1,33 @@
+import FWCore.ParameterSet.Config as cms
+from DQMServices.Core.DQMEDHarvester import DQMEDHarvester
+
+TrackerMapFoldedClient = DQMEDHarvester("TrackFoldedOccupancyClient",  
+    FolderName = cms.string('Tracking/TrackParameters'),
+    AlgoName = cms.string('GenTk'),
+    TrackQuality = cms.string('generalTracks'),
+    PhiMax = cms.double(3.141592654),
+    PhiMin = cms.double(-3.141592654),
+    EtaMax = cms.double(2.5),
+    EtaMin = cms.double(-2.5),  
+    Eta2DBin = cms.int32(26),
+    Phi2DBin = cms.int32(32),
+) 
+    
+from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
+phase1Pixel.toModify(TrackerMapFoldedClient, EtaMin=-3., EtaMax=3.)
+from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
+phase2_tracker.toModify(TrackerMapFoldedClient, EtaMin=-4.5, EtaMax=4.5)
+
+TrackerMapFoldedClient_highpurity_dzPV0p1=TrackerMapFoldedClient.clone(
+    TrackQuality=cms.string('highPurityTracks/dzPV0p1')
+)
+
+TrackerMapFoldedClient_highpurity_pt0to1=TrackerMapFoldedClient.clone(
+    TrackQuality=cms.string('highPurityTracks/pt_0to1')
+)
+
+TrackerMapFoldedClient_highpurity_pt1=TrackerMapFoldedClient.clone(
+    TrackQuality=cms.string('highPurityTracks/pt_1')
+)
+
+foldedMapClientSeq=cms.Sequence(TrackerMapFoldedClient*TrackerMapFoldedClient_highpurity_dzPV0p1*TrackerMapFoldedClient_highpurity_pt0to1*TrackerMapFoldedClient_highpurity_pt1)

--- a/DQM/TrackingMonitor/python/TrackFoldedOccupancyClient_cfi.py
+++ b/DQM/TrackingMonitor/python/TrackFoldedOccupancyClient_cfi.py
@@ -5,6 +5,7 @@ TrackerMapFoldedClient = DQMEDHarvester("TrackFoldedOccupancyClient",
     FolderName = cms.string('Tracking/TrackParameters'),
     AlgoName = cms.string('GenTk'),
     TrackQuality = cms.string('generalTracks'),
+    MeasurementState = cms.string('ImpactPoint'),
     PhiMax = cms.double(3.141592654),
     PhiMin = cms.double(-3.141592654),
     EtaMax = cms.double(2.5),
@@ -31,6 +32,21 @@ TrackerMapFoldedClient_highpurity_pt1=TrackerMapFoldedClient.clone(
 )
 
 foldedMapClientSeq=cms.Sequence(TrackerMapFoldedClient*TrackerMapFoldedClient_highpurity_dzPV0p1*TrackerMapFoldedClient_highpurity_pt0to1*TrackerMapFoldedClient_highpurity_pt1)
+
+##Heavy Ions
+#pre run3 
+TrackerMapFoldedClient_heavyionTk=TrackerMapFoldedClient.clone(
+    AlgoName = cms.string('HeavyIonTk'),
+    TrackQuality = cms.string('')
+)
+#run3
+TrackerMapFoldedClient_hiConformalPixelTracks=TrackerMapFoldedClient.clone(
+    TrackQuality = cms.string('hiConformalPixelTracks')
+)
+
+folded_with_conformalpixtkclient= cms.Sequence(TrackerMapFoldedClient_hiConformalPixelTracks+foldedMapClientSeq.copy())
+from Configuration.ProcessModifiers.pp_on_AA_cff import pp_on_AA
+pp_on_AA.toReplaceWith(foldedMapClientSeq, folded_with_conformalpixtkclient)
 
 ####cosmics
 TrackerMapFoldedClient_CKFTk=TrackerMapFoldedClient.clone(

--- a/DQM/TrackingMonitor/python/TrackFoldedOccupancyClient_cfi.py
+++ b/DQM/TrackingMonitor/python/TrackFoldedOccupancyClient_cfi.py
@@ -33,12 +33,6 @@ TrackerMapFoldedClient_highpurity_pt1=TrackerMapFoldedClient.clone(
 
 foldedMapClientSeq=cms.Sequence(TrackerMapFoldedClient*TrackerMapFoldedClient_highpurity_dzPV0p1*TrackerMapFoldedClient_highpurity_pt0to1*TrackerMapFoldedClient_highpurity_pt1)
 
-##Heavy Ions
-#pre run3 
-TrackerMapFoldedClient_heavyionTk=TrackerMapFoldedClient.clone(
-    AlgoName = cms.string('HeavyIonTk'),
-    TrackQuality = cms.string('')
-)
 #run3
 TrackerMapFoldedClient_hiConformalPixelTracks=TrackerMapFoldedClient.clone(
     TrackQuality = cms.string('hiConformalPixelTracks')
@@ -47,18 +41,3 @@ TrackerMapFoldedClient_hiConformalPixelTracks=TrackerMapFoldedClient.clone(
 folded_with_conformalpixtkclient= cms.Sequence(TrackerMapFoldedClient_hiConformalPixelTracks+foldedMapClientSeq.copy())
 from Configuration.ProcessModifiers.pp_on_AA_cff import pp_on_AA
 pp_on_AA.toReplaceWith(foldedMapClientSeq, folded_with_conformalpixtkclient)
-
-####cosmics
-TrackerMapFoldedClient_CKFTk=TrackerMapFoldedClient.clone(
-    AlgoName = cms.string('CKFTk'),
-    MeasurementState = cms.string('default'),
-    TrackQuality = cms.string('')
-)
-
-TrackerMapFoldedClient_CosmicTk=TrackerMapFoldedClient.clone(
-    AlgoName = cms.string('CosmicTk'),
-    MeasurementState = cms.string('default'),
-    TrackQuality = cms.string('')
-)
-
-foldedMapClientSeq_cosmics=cms.Sequence(TrackerMapFoldedClient_CKFTk*TrackerMapFoldedClient_CosmicTk)

--- a/DQM/TrackingMonitor/python/TrackFoldedOccupancyClient_cfi.py
+++ b/DQM/TrackingMonitor/python/TrackFoldedOccupancyClient_cfi.py
@@ -31,3 +31,18 @@ TrackerMapFoldedClient_highpurity_pt1=TrackerMapFoldedClient.clone(
 )
 
 foldedMapClientSeq=cms.Sequence(TrackerMapFoldedClient*TrackerMapFoldedClient_highpurity_dzPV0p1*TrackerMapFoldedClient_highpurity_pt0to1*TrackerMapFoldedClient_highpurity_pt1)
+
+####cosmics
+TrackerMapFoldedClient_CKFTk=TrackerMapFoldedClient.clone(
+    AlgoName = cms.string('CKFTk'),
+    MeasurementState = cms.string('default'),
+    TrackQuality = cms.string('')
+)
+
+TrackerMapFoldedClient_CosmicTk=TrackerMapFoldedClient.clone(
+    AlgoName = cms.string('CosmicTk'),
+    MeasurementState = cms.string('default'),
+    TrackQuality = cms.string('')
+)
+
+foldedMapClientSeq_cosmics=cms.Sequence(TrackerMapFoldedClient_CKFTk*TrackerMapFoldedClient_CosmicTk)

--- a/DQM/TrackingMonitor/src/GetLumi.cc
+++ b/DQM/TrackingMonitor/src/GetLumi.cc
@@ -4,7 +4,6 @@
  *  \author:  Mia Tosi,40 3-B32,+41227671609 
  */
 
-#include <iostream>
 #include "DQM/TrackingMonitor/interface/GetLumi.h"
 
 #include "FWCore/Framework/interface/LuminosityBlock.h"
@@ -63,9 +62,9 @@ double GetLumi::getRawValue(edm::LuminosityBlock const& lumiBlock, edm::EventSet
   if (lumiSummary_->isValid()) {
     lumi = lumiSummary_->avgInsDelLumi();
     intDelLumi = lumiSummary_->intgDelLumi();
-    std::cout << "Luminosity in this Lumi Section " << lumi << " --> " << intDelLumi << std::endl;
+    edm::LogInfo("GetLumi") << "Luminosity in this Lumi Section " << lumi << " --> " << intDelLumi << std::endl;
   } else {
-    std::cout << "No valid data found!" << std::endl;
+    edm::LogWarning("GetLumi") << "No valid data found!" << std::endl;
   }
 
   return lumi;

--- a/DQM/TrackingMonitor/src/TrackAnalyzer.cc
+++ b/DQM/TrackingMonitor/src/TrackAnalyzer.cc
@@ -1745,32 +1745,7 @@ void TrackAnalyzer::bookHistosForState(std::string sname, DQMStore::IBooker& ibo
         ibooker.book2D(histname, histname, Eta2DBin, EtaMin, EtaMax, Phi2DBin, PhiMin, PhiMax);
     tkmes.TrackEtaPhiInvertedoutofphase->setAxisTitle("Track #eta", 1);
     tkmes.TrackEtaPhiInvertedoutofphase->setAxisTitle("Track #phi", 2);
-    /*
 
-    histname = "TkEtaPhi_Ratio_byFoldingmap_" + histTag;
-    tkmes.TkEtaPhi_Ratio_byFoldingmap =
-        ibooker.book2D(histname, histname, Eta2DBin, EtaMin, EtaMax, Phi2DBin, PhiMin, PhiMax);
-    tkmes.TkEtaPhi_Ratio_byFoldingmap->setAxisTitle("Track #eta", 1);
-    tkmes.TkEtaPhi_Ratio_byFoldingmap->setAxisTitle("Track #phi", 2);
-
-    histname = "TkEtaPhi_Ratio_byFoldingmap_op_" + histTag;
-    tkmes.TkEtaPhi_Ratio_byFoldingmap_op =
-        ibooker.book2D(histname, histname, Eta2DBin, EtaMin, EtaMax, Phi2DBin, PhiMin, PhiMax);
-    tkmes.TkEtaPhi_Ratio_byFoldingmap_op->setAxisTitle("Track #eta", 1);
-    tkmes.TkEtaPhi_Ratio_byFoldingmap_op->setAxisTitle("Track #phi", 2);
-    
-    histname = "TkEtaPhi_RelativeDifference_byFoldingmap_" + histTag;
-    tkmes.TkEtaPhi_RelativeDifference_byFoldingmap =
-        ibooker.book2D(histname, histname, Eta2DBin, EtaMin, EtaMax, Phi2DBin, PhiMin, PhiMax);
-    tkmes.TkEtaPhi_RelativeDifference_byFoldingmap->setAxisTitle("Track #eta", 1);
-    tkmes.TkEtaPhi_RelativeDifference_byFoldingmap->setAxisTitle("Track #phi", 2);
-
-    histname = "TkEtaPhi_RelativeDifference_byFoldingmap_op_" + histTag;
-    tkmes.TkEtaPhi_RelativeDifference_byFoldingmap_op =
-        ibooker.book2D(histname, histname, Eta2DBin, EtaMin, EtaMax, Phi2DBin, PhiMin, PhiMax);
-    tkmes.TkEtaPhi_RelativeDifference_byFoldingmap_op->setAxisTitle("Track #eta", 1);
-    tkmes.TkEtaPhi_RelativeDifference_byFoldingmap_op->setAxisTitle("Track #phi", 2);
-    */
     histname = "TrackQoverP_" + histTag;
     tkmes.TrackQoverP = ibooker.book1D(histname, histname, 10 * TrackQBin, TrackQMin, TrackQMax);
     tkmes.TrackQoverP->setAxisTitle("Track QoverP", 1);
@@ -1944,7 +1919,7 @@ void TrackAnalyzer::fillHistosForState(const edm::EventSetup& iSetup, const reco
   //get the kinematic parameters
   double p, px, py, pz, pt, theta, phi, eta, q;
   double pxerror, pyerror, pzerror, pterror, perror, phierror, etaerror;
-  
+
   std::string Folder = TopFolder_.substr(0, 2);
 
   auto phiIn = track.innerPosition().phi();

--- a/DQM/TrackingMonitor/src/TrackAnalyzer.cc
+++ b/DQM/TrackingMonitor/src/TrackAnalyzer.cc
@@ -1745,6 +1745,7 @@ void TrackAnalyzer::bookHistosForState(std::string sname, DQMStore::IBooker& ibo
         ibooker.book2D(histname, histname, Eta2DBin, EtaMin, EtaMax, Phi2DBin, PhiMin, PhiMax);
     tkmes.TrackEtaPhiInvertedoutofphase->setAxisTitle("Track #eta", 1);
     tkmes.TrackEtaPhiInvertedoutofphase->setAxisTitle("Track #phi", 2);
+    /*
 
     histname = "TkEtaPhi_Ratio_byFoldingmap_" + histTag;
     tkmes.TkEtaPhi_Ratio_byFoldingmap =
@@ -1757,7 +1758,7 @@ void TrackAnalyzer::bookHistosForState(std::string sname, DQMStore::IBooker& ibo
         ibooker.book2D(histname, histname, Eta2DBin, EtaMin, EtaMax, Phi2DBin, PhiMin, PhiMax);
     tkmes.TkEtaPhi_Ratio_byFoldingmap_op->setAxisTitle("Track #eta", 1);
     tkmes.TkEtaPhi_Ratio_byFoldingmap_op->setAxisTitle("Track #phi", 2);
-
+    
     histname = "TkEtaPhi_RelativeDifference_byFoldingmap_" + histTag;
     tkmes.TkEtaPhi_RelativeDifference_byFoldingmap =
         ibooker.book2D(histname, histname, Eta2DBin, EtaMin, EtaMax, Phi2DBin, PhiMin, PhiMax);
@@ -1769,7 +1770,7 @@ void TrackAnalyzer::bookHistosForState(std::string sname, DQMStore::IBooker& ibo
         ibooker.book2D(histname, histname, Eta2DBin, EtaMin, EtaMax, Phi2DBin, PhiMin, PhiMax);
     tkmes.TkEtaPhi_RelativeDifference_byFoldingmap_op->setAxisTitle("Track #eta", 1);
     tkmes.TkEtaPhi_RelativeDifference_byFoldingmap_op->setAxisTitle("Track #phi", 2);
-
+    */
     histname = "TrackQoverP_" + histTag;
     tkmes.TrackQoverP = ibooker.book1D(histname, histname, 10 * TrackQBin, TrackQMin, TrackQMax);
     tkmes.TrackQoverP->setAxisTitle("Track QoverP", 1);
@@ -1943,7 +1944,7 @@ void TrackAnalyzer::fillHistosForState(const edm::EventSetup& iSetup, const reco
   //get the kinematic parameters
   double p, px, py, pz, pt, theta, phi, eta, q;
   double pxerror, pyerror, pzerror, pterror, perror, phierror, etaerror;
-
+  
   std::string Folder = TopFolder_.substr(0, 2);
 
   auto phiIn = track.innerPosition().phi();
@@ -2026,38 +2027,8 @@ void TrackAnalyzer::fillHistosForState(const edm::EventSetup& iSetup, const reco
 
     if (Folder == "Tr") {
       tkmes.TrackEtaPhiInverted->Fill(eta, -1 * phi);
-      tkmes.TrackEtaPhiInvertedoutofphase->Fill(eta, 3.141592654 + -1 * phi);
-      tkmes.TrackEtaPhiInvertedoutofphase->Fill(eta, -1 * phi - 3.141592654);
-      tkmes.TkEtaPhi_Ratio_byFoldingmap->divide(tkmes.TrackEtaPhi, tkmes.TrackEtaPhiInverted, 1., 1., "");
-      tkmes.TkEtaPhi_Ratio_byFoldingmap_op->divide(tkmes.TrackEtaPhi, tkmes.TrackEtaPhiInvertedoutofphase, 1., 1., "");
-
-      int nx = tkmes.TrackEtaPhi->getNbinsX();
-      int ny = tkmes.TrackEtaPhi->getNbinsY();
-
-      //NOTE: for full reproducibility when using threads, this loop needs to be
-      // a critical section
-      for (int ii = 1; ii <= nx; ii++) {
-        for (int jj = 1; jj <= ny; jj++) {
-          double Sum1 = tkmes.TrackEtaPhi->getBinContent(ii, jj) + tkmes.TrackEtaPhiInverted->getBinContent(ii, jj);
-          double Sum2 =
-              tkmes.TrackEtaPhi->getBinContent(ii, jj) + tkmes.TrackEtaPhiInvertedoutofphase->getBinContent(ii, jj);
-
-          double Sub1 = tkmes.TrackEtaPhi->getBinContent(ii, jj) - tkmes.TrackEtaPhiInverted->getBinContent(ii, jj);
-          double Sub2 =
-              tkmes.TrackEtaPhi->getBinContent(ii, jj) - tkmes.TrackEtaPhiInvertedoutofphase->getBinContent(ii, jj);
-
-          if (Sum1 == 0 || Sum2 == 0) {
-            tkmes.TkEtaPhi_RelativeDifference_byFoldingmap->setBinContent(ii, jj, 1);
-            tkmes.TkEtaPhi_RelativeDifference_byFoldingmap_op->setBinContent(ii, jj, 1);
-          } else {
-            double ratio1 = Sub1 / Sum1;
-            double ratio2 = Sub2 / Sum2;
-            tkmes.TkEtaPhi_RelativeDifference_byFoldingmap->setBinContent(ii, jj, ratio1);
-            tkmes.TkEtaPhi_RelativeDifference_byFoldingmap_op->setBinContent(ii, jj, ratio2);
-          }
-        }
-      }
-
+      tkmes.TrackEtaPhiInvertedoutofphase->Fill(eta, M_PI - phi);
+      tkmes.TrackEtaPhiInvertedoutofphase->Fill(eta, -(phi + M_PI));
       //pT histograms to create efficiency vs pT plot, only for the most inefficient region.
 
       if (eta < 0. && phi < -1.6) {

--- a/DQM/TrackingMonitor/src/TrackBuildingAnalyzer.cc
+++ b/DQM/TrackingMonitor/src/TrackBuildingAnalyzer.cc
@@ -20,8 +20,6 @@
 #include <string>
 #include "TMath.h"
 
-#include <iostream>
-
 TrackBuildingAnalyzer::TrackBuildingAnalyzer(const edm::ParameterSet& iConfig)
     : doAllPlots(iConfig.getParameter<bool>("doAllPlots")),
       doAllSeedPlots(iConfig.getParameter<bool>("doSeedParameterHistos")),

--- a/DQM/TrackingMonitor/src/TrackEfficiencyClient.cc
+++ b/DQM/TrackingMonitor/src/TrackEfficiencyClient.cc
@@ -14,13 +14,6 @@
 #include "DQM/TrackingMonitor/interface/TrackEfficiencyClient.h"
 #include "DQMServices/Core/interface/DQMStore.h"
 
-#include <iostream>
-#include <iomanip>
-#include <cstdio>
-#include <string>
-#include <sstream>
-#include <cmath>
-
 //-----------------------------------------------------------------------------------
 TrackEfficiencyClient::TrackEfficiencyClient(edm::ParameterSet const& iConfig)
 //-----------------------------------------------------------------------------------

--- a/DQM/TrackingMonitor/src/TrackEfficiencyClient.cc
+++ b/DQM/TrackingMonitor/src/TrackEfficiencyClient.cc
@@ -5,14 +5,10 @@
  */
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
-
-#include "FWCore/Framework/interface/LuminosityBlock.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "FWCore/ParameterSet/interface/FileInPath.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
-
 #include "DQM/TrackingMonitor/interface/TrackEfficiencyClient.h"
-#include "DQMServices/Core/interface/DQMStore.h"
+
 
 //-----------------------------------------------------------------------------------
 TrackEfficiencyClient::TrackEfficiencyClient(edm::ParameterSet const& iConfig)

--- a/DQM/TrackingMonitor/src/TrackEfficiencyClient.cc
+++ b/DQM/TrackingMonitor/src/TrackEfficiencyClient.cc
@@ -9,7 +9,6 @@
 #include "FWCore/ParameterSet/interface/FileInPath.h"
 #include "DQM/TrackingMonitor/interface/TrackEfficiencyClient.h"
 
-
 //-----------------------------------------------------------------------------------
 TrackEfficiencyClient::TrackEfficiencyClient(edm::ParameterSet const& iConfig)
 //-----------------------------------------------------------------------------------

--- a/DQM/TrackingMonitor/src/TrackFoldedOccupancyClient.cc
+++ b/DQM/TrackingMonitor/src/TrackFoldedOccupancyClient.cc
@@ -1,0 +1,132 @@
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+#include "FWCore/Framework/interface/LuminosityBlock.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "FWCore/ParameterSet/interface/FileInPath.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "DQM/TrackingMonitor/interface/TrackFoldedOccupancyClient.h"
+#include "DQMServices/Core/interface/DQMStore.h"
+
+//-----------------------------------------------------------------------------------
+TrackFoldedOccupancyClient::TrackFoldedOccupancyClient(edm::ParameterSet const& iConfig)
+//-----------------------------------------------------------------------------------
+{
+  edm::LogInfo("TrackFoldedOccupancyClient") << "TrackFoldedOccupancyClient::Deleting TrackFoldedOccupancyClient ";
+  TopFolder_ = iConfig.getParameter<std::string>("FolderName");
+  quality_ = iConfig.getParameter<std::string>("TrackQuality");
+  algoName_ = iConfig.getParameter<std::string>("AlgoName");
+
+  conf_ = iConfig;
+}
+
+//-----------------------------------------------------------------------------------
+TrackFoldedOccupancyClient::~TrackFoldedOccupancyClient()
+//-----------------------------------------------------------------------------------
+{
+  edm::LogInfo("TrackFoldedOccupancyClient") << "TrackFoldedOccupancyClient::Deleting TrackFoldedOccupancyClient ";
+}
+
+//-----------------------------------------------------------------------------------
+void TrackFoldedOccupancyClient::beginJob(void)
+//-----------------------------------------------------------------------------------
+{
+  edm::LogInfo("TrackFoldedOccupancyClient") << "TrackFoldedOccupancyClient::beginJob done";
+}
+
+//-----------------------------------------------------------------------------------
+void TrackFoldedOccupancyClient::beginRun(edm::Run const& run, edm::EventSetup const& eSetup)
+//-----------------------------------------------------------------------------------
+{
+  edm::LogInfo("TrackFoldedOccupancyClient") << "TrackFoldedOccupancyClient:: Begining of Run";
+}
+
+//-----------------------------------------------------------------------------------
+void TrackFoldedOccupancyClient::bookMEs(DQMStore::IBooker& ibooker)
+//-----------------------------------------------------------------------------------
+{
+  ibooker.setCurrentFolder(TopFolder_ + "/" + quality_ + "/GeneralProperties/");
+  int Phi2DBin = conf_.getParameter<int>("Phi2DBin");
+  int Eta2DBin = conf_.getParameter<int>("Eta2DBin");
+  double EtaMin = conf_.getParameter<double>("EtaMin");
+  double EtaMax = conf_.getParameter<double>("EtaMax");
+  double PhiMin = conf_.getParameter<double>("PhiMin");
+  double PhiMax = conf_.getParameter<double>("PhiMax");
+
+  // use the AlgoName and Quality Name
+  std::string histname = "TkEtaPhi_RelativeDifference_byFoldingmap_ImpactPoint_" + algoName_;
+  TkEtaPhi_RelativeDifference_byFoldingmap = ibooker.book2D(histname, histname, Eta2DBin, EtaMin, EtaMax, Phi2DBin, PhiMin, PhiMax);
+  TkEtaPhi_RelativeDifference_byFoldingmap->setAxisTitle("Track #eta", 1);
+  TkEtaPhi_RelativeDifference_byFoldingmap->setAxisTitle("Track #phi", 2);
+
+  histname = "TkEtaPhi_RelativeDifference_byFoldingmap_op_ImpactPoint_" + algoName_;
+  TkEtaPhi_RelativeDifference_byFoldingmap_op = ibooker.book2D(histname, histname, Eta2DBin, EtaMin, EtaMax, Phi2DBin, PhiMin, PhiMax);
+  TkEtaPhi_RelativeDifference_byFoldingmap_op->setAxisTitle("Track #eta", 1);
+  TkEtaPhi_RelativeDifference_byFoldingmap_op->setAxisTitle("Track #phi", 2);
+  
+  histname = "TkEtaPhi_Ratio_byFoldingmap_ImpactPoint_" + algoName_;
+  TkEtaPhi_Ratio_byFoldingmap = ibooker.book2D(histname, histname, Eta2DBin, EtaMin, EtaMax, Phi2DBin, PhiMin, PhiMax);
+  TkEtaPhi_Ratio_byFoldingmap->setAxisTitle("Track #eta", 1);
+  TkEtaPhi_Ratio_byFoldingmap->setAxisTitle("Track #phi", 2);
+
+  histname = "TkEtaPhi_Ratio_byFoldingmap_op_ImpactPoint_" + algoName_;
+  TkEtaPhi_Ratio_byFoldingmap_op = ibooker.book2D(histname, histname, Eta2DBin, EtaMin, EtaMax, Phi2DBin, PhiMin, PhiMax);
+  TkEtaPhi_Ratio_byFoldingmap_op->setAxisTitle("Track #eta", 1);
+  TkEtaPhi_Ratio_byFoldingmap_op->setAxisTitle("Track #phi", 2);
+
+}
+
+//-----------------------------------------------------------------------------------
+void TrackFoldedOccupancyClient::dqmEndJob(DQMStore::IBooker& ibooker, DQMStore::IGetter& igetter)
+//-----------------------------------------------------------------------------------
+{
+  edm::LogInfo("TrackFoldedOccupancyClient") << "TrackFoldedOccupancyClient::endLuminosityBlock";
+  std::cout << "TrackFoldedOccupancyClient::endLuminosityBlock" << std::endl;
+
+  bookMEs(ibooker);
+  std::string inFolder = TopFolder_ + "/" + quality_ + "/GeneralProperties/";
+  
+  std::string hname;
+
+  hname="TrackEtaPhi_ImpactPoint_";
+  std::cout << "Reading>>>" << inFolder + hname + algoName_ << std::endl;
+  MonitorElement* TrackEtaPhi = igetter.get(inFolder + hname + algoName_);
+
+  hname="TrackEtaPhiInverted_ImpactPoint_";
+  std::cout << "Reading>>>" << inFolder + hname + algoName_ << std::endl;
+  MonitorElement* TrackEtaPhiInverted = igetter.get(inFolder + hname + algoName_);
+ 
+  hname = "TrackEtaPhiInvertedoutofphase_ImpactPoint_";
+  std::cout << "Reading>>>" << inFolder + hname + algoName_ << std::endl;
+  MonitorElement* TrackEtaPhiInvertedoutofphase = igetter.get(inFolder + hname + algoName_);
+  
+  TkEtaPhi_Ratio_byFoldingmap->divide(TrackEtaPhi, TrackEtaPhiInverted, 1., 1., "");
+  TkEtaPhi_Ratio_byFoldingmap_op->divide(TrackEtaPhi, TrackEtaPhiInvertedoutofphase, 1., 1., "");
+
+  int nx = TrackEtaPhi->getNbinsX();
+  int ny = TrackEtaPhi->getNbinsY();
+
+  for (int ii = 1; ii <= nx; ii++) {
+    for (int jj = 1; jj <= ny; jj++) {
+      
+      double Sum1 = TrackEtaPhi->getBinContent(ii, jj) + TrackEtaPhiInverted->getBinContent(ii, jj);
+      double Sum2 = TrackEtaPhi->getBinContent(ii, jj) + TrackEtaPhiInvertedoutofphase->getBinContent(ii, jj);
+      
+      double Sub1 = TrackEtaPhi->getBinContent(ii, jj) - TrackEtaPhiInverted->getBinContent(ii, jj);
+      double Sub2 = TrackEtaPhi->getBinContent(ii, jj) - TrackEtaPhiInvertedoutofphase->getBinContent(ii, jj);
+      
+      if (Sum1 == 0 || Sum2 == 0) {
+	TkEtaPhi_RelativeDifference_byFoldingmap->setBinContent(ii, jj, 1);
+	TkEtaPhi_RelativeDifference_byFoldingmap_op->setBinContent(ii, jj, 1);
+      } else {
+	double ratio1 = Sub1 / Sum1;
+	double ratio2 = Sub2 / Sum2;
+	TkEtaPhi_RelativeDifference_byFoldingmap->setBinContent(ii, jj, ratio1);
+	TkEtaPhi_RelativeDifference_byFoldingmap_op->setBinContent(ii, jj, ratio2);
+      }
+    }
+  }
+
+}
+    
+DEFINE_FWK_MODULE(TrackFoldedOccupancyClient);

--- a/DQM/TrackingMonitor/src/TrackFoldedOccupancyClient.cc
+++ b/DQM/TrackingMonitor/src/TrackFoldedOccupancyClient.cc
@@ -1,13 +1,7 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
-
-#include "FWCore/Framework/interface/LuminosityBlock.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "FWCore/ParameterSet/interface/FileInPath.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
-
 #include "DQM/TrackingMonitor/interface/TrackFoldedOccupancyClient.h"
-#include "DQMServices/Core/interface/DQMStore.h"
-
 //-----------------------------------------------------------------------------------
 TrackFoldedOccupancyClient::TrackFoldedOccupancyClient(edm::ParameterSet const& iConfig)
 //-----------------------------------------------------------------------------------
@@ -16,7 +10,6 @@ TrackFoldedOccupancyClient::TrackFoldedOccupancyClient(edm::ParameterSet const& 
   TopFolder_ = iConfig.getParameter<std::string>("FolderName");
   quality_ = iConfig.getParameter<std::string>("TrackQuality");
   algoName_ = iConfig.getParameter<std::string>("AlgoName");
-
   conf_ = iConfig;
 }
 
@@ -55,14 +48,12 @@ void TrackFoldedOccupancyClient::bookMEs(DQMStore::IBooker& ibooker)
 
   // use the AlgoName and Quality Name
   std::string histname = "TkEtaPhi_RelativeDifference_byFoldingmap_ImpactPoint_" + algoName_;
-  TkEtaPhi_RelativeDifference_byFoldingmap =
-      ibooker.book2D(histname, histname, Eta2DBin, EtaMin, EtaMax, Phi2DBin, PhiMin, PhiMax);
+  TkEtaPhi_RelativeDifference_byFoldingmap = ibooker.book2D(histname, histname, Eta2DBin, EtaMin, EtaMax, Phi2DBin, PhiMin, PhiMax);
   TkEtaPhi_RelativeDifference_byFoldingmap->setAxisTitle("Track #eta", 1);
   TkEtaPhi_RelativeDifference_byFoldingmap->setAxisTitle("Track #phi", 2);
 
   histname = "TkEtaPhi_RelativeDifference_byFoldingmap_op_ImpactPoint_" + algoName_;
-  TkEtaPhi_RelativeDifference_byFoldingmap_op =
-      ibooker.book2D(histname, histname, Eta2DBin, EtaMin, EtaMax, Phi2DBin, PhiMin, PhiMax);
+  TkEtaPhi_RelativeDifference_byFoldingmap_op = ibooker.book2D(histname, histname, Eta2DBin, EtaMin, EtaMax, Phi2DBin, PhiMin, PhiMax);
   TkEtaPhi_RelativeDifference_byFoldingmap_op->setAxisTitle("Track #eta", 1);
   TkEtaPhi_RelativeDifference_byFoldingmap_op->setAxisTitle("Track #phi", 2);
 
@@ -72,8 +63,7 @@ void TrackFoldedOccupancyClient::bookMEs(DQMStore::IBooker& ibooker)
   TkEtaPhi_Ratio_byFoldingmap->setAxisTitle("Track #phi", 2);
 
   histname = "TkEtaPhi_Ratio_byFoldingmap_op_ImpactPoint_" + algoName_;
-  TkEtaPhi_Ratio_byFoldingmap_op =
-      ibooker.book2D(histname, histname, Eta2DBin, EtaMin, EtaMax, Phi2DBin, PhiMin, PhiMax);
+  TkEtaPhi_Ratio_byFoldingmap_op = ibooker.book2D(histname, histname, Eta2DBin, EtaMin, EtaMax, Phi2DBin, PhiMin, PhiMax);
   TkEtaPhi_Ratio_byFoldingmap_op->setAxisTitle("Track #eta", 1);
   TkEtaPhi_Ratio_byFoldingmap_op->setAxisTitle("Track #phi", 2);
 }
@@ -83,23 +73,18 @@ void TrackFoldedOccupancyClient::dqmEndJob(DQMStore::IBooker& ibooker, DQMStore:
 //-----------------------------------------------------------------------------------
 {
   edm::LogInfo("TrackFoldedOccupancyClient") << "TrackFoldedOccupancyClient::endLuminosityBlock";
-  std::cout << "TrackFoldedOccupancyClient::endLuminosityBlock" << std::endl;
 
   bookMEs(ibooker);
   std::string inFolder = TopFolder_ + "/" + quality_ + "/GeneralProperties/";
 
   std::string hname;
-
   hname = "TrackEtaPhi_ImpactPoint_";
-  std::cout << "Reading>>>" << inFolder + hname + algoName_ << std::endl;
   MonitorElement* TrackEtaPhi = igetter.get(inFolder + hname + algoName_);
 
   hname = "TrackEtaPhiInverted_ImpactPoint_";
-  std::cout << "Reading>>>" << inFolder + hname + algoName_ << std::endl;
   MonitorElement* TrackEtaPhiInverted = igetter.get(inFolder + hname + algoName_);
 
   hname = "TrackEtaPhiInvertedoutofphase_ImpactPoint_";
-  std::cout << "Reading>>>" << inFolder + hname + algoName_ << std::endl;
   MonitorElement* TrackEtaPhiInvertedoutofphase = igetter.get(inFolder + hname + algoName_);
 
   TkEtaPhi_Ratio_byFoldingmap->divide(TrackEtaPhi, TrackEtaPhiInverted, 1., 1., "");

--- a/DQM/TrackingMonitor/src/TrackFoldedOccupancyClient.cc
+++ b/DQM/TrackingMonitor/src/TrackFoldedOccupancyClient.cc
@@ -55,25 +55,27 @@ void TrackFoldedOccupancyClient::bookMEs(DQMStore::IBooker& ibooker)
 
   // use the AlgoName and Quality Name
   std::string histname = "TkEtaPhi_RelativeDifference_byFoldingmap_ImpactPoint_" + algoName_;
-  TkEtaPhi_RelativeDifference_byFoldingmap = ibooker.book2D(histname, histname, Eta2DBin, EtaMin, EtaMax, Phi2DBin, PhiMin, PhiMax);
+  TkEtaPhi_RelativeDifference_byFoldingmap =
+      ibooker.book2D(histname, histname, Eta2DBin, EtaMin, EtaMax, Phi2DBin, PhiMin, PhiMax);
   TkEtaPhi_RelativeDifference_byFoldingmap->setAxisTitle("Track #eta", 1);
   TkEtaPhi_RelativeDifference_byFoldingmap->setAxisTitle("Track #phi", 2);
 
   histname = "TkEtaPhi_RelativeDifference_byFoldingmap_op_ImpactPoint_" + algoName_;
-  TkEtaPhi_RelativeDifference_byFoldingmap_op = ibooker.book2D(histname, histname, Eta2DBin, EtaMin, EtaMax, Phi2DBin, PhiMin, PhiMax);
+  TkEtaPhi_RelativeDifference_byFoldingmap_op =
+      ibooker.book2D(histname, histname, Eta2DBin, EtaMin, EtaMax, Phi2DBin, PhiMin, PhiMax);
   TkEtaPhi_RelativeDifference_byFoldingmap_op->setAxisTitle("Track #eta", 1);
   TkEtaPhi_RelativeDifference_byFoldingmap_op->setAxisTitle("Track #phi", 2);
-  
+
   histname = "TkEtaPhi_Ratio_byFoldingmap_ImpactPoint_" + algoName_;
   TkEtaPhi_Ratio_byFoldingmap = ibooker.book2D(histname, histname, Eta2DBin, EtaMin, EtaMax, Phi2DBin, PhiMin, PhiMax);
   TkEtaPhi_Ratio_byFoldingmap->setAxisTitle("Track #eta", 1);
   TkEtaPhi_Ratio_byFoldingmap->setAxisTitle("Track #phi", 2);
 
   histname = "TkEtaPhi_Ratio_byFoldingmap_op_ImpactPoint_" + algoName_;
-  TkEtaPhi_Ratio_byFoldingmap_op = ibooker.book2D(histname, histname, Eta2DBin, EtaMin, EtaMax, Phi2DBin, PhiMin, PhiMax);
+  TkEtaPhi_Ratio_byFoldingmap_op =
+      ibooker.book2D(histname, histname, Eta2DBin, EtaMin, EtaMax, Phi2DBin, PhiMin, PhiMax);
   TkEtaPhi_Ratio_byFoldingmap_op->setAxisTitle("Track #eta", 1);
   TkEtaPhi_Ratio_byFoldingmap_op->setAxisTitle("Track #phi", 2);
-
 }
 
 //-----------------------------------------------------------------------------------
@@ -85,21 +87,21 @@ void TrackFoldedOccupancyClient::dqmEndJob(DQMStore::IBooker& ibooker, DQMStore:
 
   bookMEs(ibooker);
   std::string inFolder = TopFolder_ + "/" + quality_ + "/GeneralProperties/";
-  
+
   std::string hname;
 
-  hname="TrackEtaPhi_ImpactPoint_";
+  hname = "TrackEtaPhi_ImpactPoint_";
   std::cout << "Reading>>>" << inFolder + hname + algoName_ << std::endl;
   MonitorElement* TrackEtaPhi = igetter.get(inFolder + hname + algoName_);
 
-  hname="TrackEtaPhiInverted_ImpactPoint_";
+  hname = "TrackEtaPhiInverted_ImpactPoint_";
   std::cout << "Reading>>>" << inFolder + hname + algoName_ << std::endl;
   MonitorElement* TrackEtaPhiInverted = igetter.get(inFolder + hname + algoName_);
- 
+
   hname = "TrackEtaPhiInvertedoutofphase_ImpactPoint_";
   std::cout << "Reading>>>" << inFolder + hname + algoName_ << std::endl;
   MonitorElement* TrackEtaPhiInvertedoutofphase = igetter.get(inFolder + hname + algoName_);
-  
+
   TkEtaPhi_Ratio_byFoldingmap->divide(TrackEtaPhi, TrackEtaPhiInverted, 1., 1., "");
   TkEtaPhi_Ratio_byFoldingmap_op->divide(TrackEtaPhi, TrackEtaPhiInvertedoutofphase, 1., 1., "");
 
@@ -108,25 +110,23 @@ void TrackFoldedOccupancyClient::dqmEndJob(DQMStore::IBooker& ibooker, DQMStore:
 
   for (int ii = 1; ii <= nx; ii++) {
     for (int jj = 1; jj <= ny; jj++) {
-      
       double Sum1 = TrackEtaPhi->getBinContent(ii, jj) + TrackEtaPhiInverted->getBinContent(ii, jj);
       double Sum2 = TrackEtaPhi->getBinContent(ii, jj) + TrackEtaPhiInvertedoutofphase->getBinContent(ii, jj);
-      
+
       double Sub1 = TrackEtaPhi->getBinContent(ii, jj) - TrackEtaPhiInverted->getBinContent(ii, jj);
       double Sub2 = TrackEtaPhi->getBinContent(ii, jj) - TrackEtaPhiInvertedoutofphase->getBinContent(ii, jj);
-      
+
       if (Sum1 == 0 || Sum2 == 0) {
-	TkEtaPhi_RelativeDifference_byFoldingmap->setBinContent(ii, jj, 1);
-	TkEtaPhi_RelativeDifference_byFoldingmap_op->setBinContent(ii, jj, 1);
+        TkEtaPhi_RelativeDifference_byFoldingmap->setBinContent(ii, jj, 1);
+        TkEtaPhi_RelativeDifference_byFoldingmap_op->setBinContent(ii, jj, 1);
       } else {
-	double ratio1 = Sub1 / Sum1;
-	double ratio2 = Sub2 / Sum2;
-	TkEtaPhi_RelativeDifference_byFoldingmap->setBinContent(ii, jj, ratio1);
-	TkEtaPhi_RelativeDifference_byFoldingmap_op->setBinContent(ii, jj, ratio2);
+        double ratio1 = Sub1 / Sum1;
+        double ratio2 = Sub2 / Sum2;
+        TkEtaPhi_RelativeDifference_byFoldingmap->setBinContent(ii, jj, ratio1);
+        TkEtaPhi_RelativeDifference_byFoldingmap_op->setBinContent(ii, jj, ratio2);
       }
     }
   }
-
 }
-    
+
 DEFINE_FWK_MODULE(TrackFoldedOccupancyClient);

--- a/DQM/TrackingMonitor/src/TrackFoldedOccupancyClient.cc
+++ b/DQM/TrackingMonitor/src/TrackFoldedOccupancyClient.cc
@@ -11,7 +11,7 @@ TrackFoldedOccupancyClient::TrackFoldedOccupancyClient(edm::ParameterSet const& 
   quality_ = iConfig.getParameter<std::string>("TrackQuality");
   algoName_ = iConfig.getParameter<std::string>("AlgoName");
   state_ = iConfig.getParameter<std::string>("MeasurementState");
-  histTag_ = (state_ == "default") ? algoName_ : state_ +  "_" + algoName_;
+  histTag_ = (state_ == "default") ? algoName_ : state_ + "_" + algoName_;
   conf_ = iConfig;
 }
 

--- a/DQM/TrackingMonitor/src/TrackFoldedOccupancyClient.cc
+++ b/DQM/TrackingMonitor/src/TrackFoldedOccupancyClient.cc
@@ -10,6 +10,8 @@ TrackFoldedOccupancyClient::TrackFoldedOccupancyClient(edm::ParameterSet const& 
   TopFolder_ = iConfig.getParameter<std::string>("FolderName");
   quality_ = iConfig.getParameter<std::string>("TrackQuality");
   algoName_ = iConfig.getParameter<std::string>("AlgoName");
+  state_ = iConfig.getParameter<std::string>("MeasurementState");
+  histTag_ = (state_ == "default") ? algoName_ : state_ +  "_" + algoName_;
   conf_ = iConfig;
 }
 
@@ -47,24 +49,24 @@ void TrackFoldedOccupancyClient::bookMEs(DQMStore::IBooker& ibooker)
   double PhiMax = conf_.getParameter<double>("PhiMax");
 
   // use the AlgoName and Quality Name
-  std::string histname = "TkEtaPhi_RelativeDifference_byFoldingmap_ImpactPoint_" + algoName_;
+  std::string histname = "TkEtaPhi_RelativeDifference_byFoldingmap_" + histTag_;
   TkEtaPhi_RelativeDifference_byFoldingmap =
       ibooker.book2D(histname, histname, Eta2DBin, EtaMin, EtaMax, Phi2DBin, PhiMin, PhiMax);
   TkEtaPhi_RelativeDifference_byFoldingmap->setAxisTitle("Track #eta", 1);
   TkEtaPhi_RelativeDifference_byFoldingmap->setAxisTitle("Track #phi", 2);
 
-  histname = "TkEtaPhi_RelativeDifference_byFoldingmap_op_ImpactPoint_" + algoName_;
+  histname = "TkEtaPhi_RelativeDifference_byFoldingmap_op_" + histTag_;
   TkEtaPhi_RelativeDifference_byFoldingmap_op =
       ibooker.book2D(histname, histname, Eta2DBin, EtaMin, EtaMax, Phi2DBin, PhiMin, PhiMax);
   TkEtaPhi_RelativeDifference_byFoldingmap_op->setAxisTitle("Track #eta", 1);
   TkEtaPhi_RelativeDifference_byFoldingmap_op->setAxisTitle("Track #phi", 2);
 
-  histname = "TkEtaPhi_Ratio_byFoldingmap_ImpactPoint_" + algoName_;
+  histname = "TkEtaPhi_Ratio_byFoldingmap_" + histTag_;
   TkEtaPhi_Ratio_byFoldingmap = ibooker.book2D(histname, histname, Eta2DBin, EtaMin, EtaMax, Phi2DBin, PhiMin, PhiMax);
   TkEtaPhi_Ratio_byFoldingmap->setAxisTitle("Track #eta", 1);
   TkEtaPhi_Ratio_byFoldingmap->setAxisTitle("Track #phi", 2);
 
-  histname = "TkEtaPhi_Ratio_byFoldingmap_op_ImpactPoint_" + algoName_;
+  histname = "TkEtaPhi_Ratio_byFoldingmap_op_" + histTag_;
   TkEtaPhi_Ratio_byFoldingmap_op =
       ibooker.book2D(histname, histname, Eta2DBin, EtaMin, EtaMax, Phi2DBin, PhiMin, PhiMax);
   TkEtaPhi_Ratio_byFoldingmap_op->setAxisTitle("Track #eta", 1);
@@ -81,14 +83,14 @@ void TrackFoldedOccupancyClient::dqmEndJob(DQMStore::IBooker& ibooker, DQMStore:
   std::string inFolder = TopFolder_ + "/" + quality_ + "/GeneralProperties/";
 
   std::string hname;
-  hname = "TrackEtaPhi_ImpactPoint_";
-  MonitorElement* TrackEtaPhi = igetter.get(inFolder + hname + algoName_);
+  hname = "TrackEtaPhi_";
+  MonitorElement* TrackEtaPhi = igetter.get(inFolder + hname + histTag_);
 
-  hname = "TrackEtaPhiInverted_ImpactPoint_";
-  MonitorElement* TrackEtaPhiInverted = igetter.get(inFolder + hname + algoName_);
+  hname = "TrackEtaPhiInverted_";
+  MonitorElement* TrackEtaPhiInverted = igetter.get(inFolder + hname + histTag_);
 
-  hname = "TrackEtaPhiInvertedoutofphase_ImpactPoint_";
-  MonitorElement* TrackEtaPhiInvertedoutofphase = igetter.get(inFolder + hname + algoName_);
+  hname = "TrackEtaPhiInvertedoutofphase_";
+  MonitorElement* TrackEtaPhiInvertedoutofphase = igetter.get(inFolder + hname + histTag_);
 
   TkEtaPhi_Ratio_byFoldingmap->divide(TrackEtaPhi, TrackEtaPhiInverted, 1., 1., "");
   TkEtaPhi_Ratio_byFoldingmap_op->divide(TrackEtaPhi, TrackEtaPhiInvertedoutofphase, 1., 1., "");

--- a/DQM/TrackingMonitor/src/TrackFoldedOccupancyClient.cc
+++ b/DQM/TrackingMonitor/src/TrackFoldedOccupancyClient.cc
@@ -48,12 +48,14 @@ void TrackFoldedOccupancyClient::bookMEs(DQMStore::IBooker& ibooker)
 
   // use the AlgoName and Quality Name
   std::string histname = "TkEtaPhi_RelativeDifference_byFoldingmap_ImpactPoint_" + algoName_;
-  TkEtaPhi_RelativeDifference_byFoldingmap = ibooker.book2D(histname, histname, Eta2DBin, EtaMin, EtaMax, Phi2DBin, PhiMin, PhiMax);
+  TkEtaPhi_RelativeDifference_byFoldingmap =
+      ibooker.book2D(histname, histname, Eta2DBin, EtaMin, EtaMax, Phi2DBin, PhiMin, PhiMax);
   TkEtaPhi_RelativeDifference_byFoldingmap->setAxisTitle("Track #eta", 1);
   TkEtaPhi_RelativeDifference_byFoldingmap->setAxisTitle("Track #phi", 2);
 
   histname = "TkEtaPhi_RelativeDifference_byFoldingmap_op_ImpactPoint_" + algoName_;
-  TkEtaPhi_RelativeDifference_byFoldingmap_op = ibooker.book2D(histname, histname, Eta2DBin, EtaMin, EtaMax, Phi2DBin, PhiMin, PhiMax);
+  TkEtaPhi_RelativeDifference_byFoldingmap_op =
+      ibooker.book2D(histname, histname, Eta2DBin, EtaMin, EtaMax, Phi2DBin, PhiMin, PhiMax);
   TkEtaPhi_RelativeDifference_byFoldingmap_op->setAxisTitle("Track #eta", 1);
   TkEtaPhi_RelativeDifference_byFoldingmap_op->setAxisTitle("Track #phi", 2);
 
@@ -63,7 +65,8 @@ void TrackFoldedOccupancyClient::bookMEs(DQMStore::IBooker& ibooker)
   TkEtaPhi_Ratio_byFoldingmap->setAxisTitle("Track #phi", 2);
 
   histname = "TkEtaPhi_Ratio_byFoldingmap_op_ImpactPoint_" + algoName_;
-  TkEtaPhi_Ratio_byFoldingmap_op = ibooker.book2D(histname, histname, Eta2DBin, EtaMin, EtaMax, Phi2DBin, PhiMin, PhiMax);
+  TkEtaPhi_Ratio_byFoldingmap_op =
+      ibooker.book2D(histname, histname, Eta2DBin, EtaMin, EtaMax, Phi2DBin, PhiMin, PhiMax);
   TkEtaPhi_Ratio_byFoldingmap_op->setAxisTitle("Track #eta", 1);
   TkEtaPhi_Ratio_byFoldingmap_op->setAxisTitle("Track #phi", 2);
 }

--- a/DQM/TrackingMonitorClient/python/TrackingClientConfig_Tier0_Cosmic_cff.py
+++ b/DQM/TrackingMonitorClient/python/TrackingClientConfig_Tier0_Cosmic_cff.py
@@ -59,6 +59,7 @@ from DQM.TrackingMonitor.TrackEfficiencyClient_cfi import *
 TrackEffClient.FolderName = 'Tracking/TrackParameters/TrackEfficiency'
 TrackEffClient.AlgoName   = 'CKFTk'
 
+from DQM.TrackingMonitor.TrackFoldedOccupancyClient_cfi import TrackerMapFoldedClient_CKFTk,TrackerMapFoldedClient_CosmicTk,foldedMapClientSeq_cosmics
 # Sequence
-TrackingCosmicDQMClient = cms.Sequence(trackingQTester*trackingOfflineAnalyser*TrackEffClient)
+TrackingCosmicDQMClient = cms.Sequence(trackingQTester*trackingOfflineAnalyser*TrackEffClient*foldedMapClientSeq_cosmics)
 

--- a/DQM/TrackingMonitorClient/python/TrackingClientConfig_Tier0_Cosmic_cff.py
+++ b/DQM/TrackingMonitorClient/python/TrackingClientConfig_Tier0_Cosmic_cff.py
@@ -59,7 +59,20 @@ from DQM.TrackingMonitor.TrackEfficiencyClient_cfi import *
 TrackEffClient.FolderName = 'Tracking/TrackParameters/TrackEfficiency'
 TrackEffClient.AlgoName   = 'CKFTk'
 
-from DQM.TrackingMonitor.TrackFoldedOccupancyClient_cfi import TrackerMapFoldedClient_CKFTk,TrackerMapFoldedClient_CosmicTk,foldedMapClientSeq_cosmics
+from DQM.TrackingMonitor.TrackFoldedOccupancyClient_cfi import TrackerMapFoldedClient 
+
+TrackerMapFoldedClient_CKFTk=TrackerMapFoldedClient.clone(
+    AlgoName = cms.string('CKFTk'),
+    MeasurementState = cms.string('default'),
+    TrackQuality = cms.string('')
+)
+
+TrackerMapFoldedClient_CosmicTk=TrackerMapFoldedClient.clone(
+    AlgoName = cms.string('CosmicTk'),
+    MeasurementState = cms.string('default'),
+    TrackQuality = cms.string('')
+)
+
 # Sequence
-TrackingCosmicDQMClient = cms.Sequence(trackingQTester*trackingOfflineAnalyser*TrackEffClient*foldedMapClientSeq_cosmics)
+TrackingCosmicDQMClient = cms.Sequence(trackingQTester*trackingOfflineAnalyser*TrackEffClient*TrackerMapFoldedClient_CKFTk*TrackerMapFoldedClient_CosmicTk)
 

--- a/DQM/TrackingMonitorClient/python/TrackingClientConfig_Tier0_cff.py
+++ b/DQM/TrackingMonitorClient/python/TrackingClientConfig_Tier0_cff.py
@@ -89,6 +89,9 @@ from DQM.TrackingMonitor.TrackEfficiencyClient_cfi import *
 TrackEffClient.FolderName = 'Tracking/TrackParameters/TrackEfficiency'
 TrackEffClient.AlgoName   = 'CKFTk'
 
-TrackingOfflineDQMClient = cms.Sequence(trackingQTester*trackingOfflineAnalyser*trackingEffFromHitPattern*voMonitoringClientSequence*primaryVertexResolutionClient*TrackEffClient)
+from DQM.TrackingMonitor.TrackFoldedOccupancyClient_cfi import *
 
-TrackingOfflineDQMClientZeroBias = cms.Sequence(trackingQTester*trackingOfflineAnalyser*trackingEffFromHitPatternZeroBias*voMonitoringClientSequence*primaryVertexResolutionClient*TrackEffClient)
+
+TrackingOfflineDQMClient = cms.Sequence(trackingQTester*trackingOfflineAnalyser*trackingEffFromHitPattern*voMonitoringClientSequence*primaryVertexResolutionClient*TrackEffClient*foldedMapClientSeq)
+
+TrackingOfflineDQMClientZeroBias = cms.Sequence(trackingQTester*trackingOfflineAnalyser*trackingEffFromHitPatternZeroBias*voMonitoringClientSequence*primaryVertexResolutionClient*TrackEffClient*foldedMapClientSeq)

--- a/DQM/TrackingMonitorClient/python/TrackingClientConfig_Tier0_cff.py
+++ b/DQM/TrackingMonitorClient/python/TrackingClientConfig_Tier0_cff.py
@@ -91,7 +91,6 @@ TrackEffClient.AlgoName   = 'CKFTk'
 
 from DQM.TrackingMonitor.TrackFoldedOccupancyClient_cfi import *
 
-
 TrackingOfflineDQMClient = cms.Sequence(trackingQTester*trackingOfflineAnalyser*trackingEffFromHitPattern*voMonitoringClientSequence*primaryVertexResolutionClient*TrackEffClient*foldedMapClientSeq)
 
 TrackingOfflineDQMClientZeroBias = cms.Sequence(trackingQTester*trackingOfflineAnalyser*trackingEffFromHitPatternZeroBias*voMonitoringClientSequence*primaryVertexResolutionClient*TrackEffClient*foldedMapClientSeq)

--- a/DQM/TrackingMonitorClient/python/TrackingDQMClientHeavyIons_cfi.py
+++ b/DQM/TrackingMonitorClient/python/TrackingDQMClientHeavyIons_cfi.py
@@ -1,6 +1,9 @@
 import FWCore.ParameterSet.Config as cms
 from DQMServices.Core.DQMEDHarvester import DQMEDHarvester
 
-hiTrackingDqmClientHeavyIons = DQMEDHarvester("TrackingDQMClientHeavyIons",
+hiTrackingDqmClientHI = DQMEDHarvester("TrackingDQMClientHeavyIons",
                                               FolderName = cms.string('Tracking/TrackParameters/GeneralProperties')
                                               )
+
+from DQM.TrackingMonitor.TrackFoldedOccupancyClient_cfi import TrackerMapFoldedClient_heavyionTk
+hiTrackingDqmClientHeavyIons=cms.Sequence(hiTrackingDqmClientHI*TrackerMapFoldedClient_heavyionTk)

--- a/DQM/TrackingMonitorClient/python/TrackingDQMClientHeavyIons_cfi.py
+++ b/DQM/TrackingMonitorClient/python/TrackingDQMClientHeavyIons_cfi.py
@@ -5,5 +5,10 @@ hiTrackingDqmClientHI = DQMEDHarvester("TrackingDQMClientHeavyIons",
                                               FolderName = cms.string('Tracking/TrackParameters/GeneralProperties')
                                               )
 
-from DQM.TrackingMonitor.TrackFoldedOccupancyClient_cfi import TrackerMapFoldedClient_heavyionTk
+from DQM.TrackingMonitor.TrackFoldedOccupancyClient_cfi import TrackerMapFoldedClient
+
+TrackerMapFoldedClient_heavyionTk=TrackerMapFoldedClient.clone(
+    AlgoName = cms.string('HeavyIonTk'),
+    TrackQuality = cms.string('')
+)
 hiTrackingDqmClientHeavyIons=cms.Sequence(hiTrackingDqmClientHI*TrackerMapFoldedClient_heavyionTk)


### PR DESCRIPTION
#### PR description:
This PR addresses issue #32953. The double loop causing the bad scaling has been moved to a new DQMHarvester since it is not needed to be done every event. The MEs filled by divide operation just preceding this double loop have also been moved to the Harvester. The timing of the modules running on single thread running over 50 events from wf 11634.0 with ttbar+PU events is
```
TimeReport   0.718486     TrackerCollisionSelectedTrackMonCommongeneralTracks
TimeReport   0.043952     TrackerCollisionSelectedTrackMonCommonhighPurityPV0p1
TimeReport   0.116136     TrackerCollisionSelectedTrackMonCommonhighPurityPt1
TimeReport   0.438734     TrackerCollisionSelectedTrackMonCommonhighPurityPtRange0to1
```
After changes
```
TimeReport   0.088705     TrackerCollisionSelectedTrackMonCommongeneralTracks
TimeReport   0.008117     TrackerCollisionSelectedTrackMonCommonhighPurityPV0p1
TimeReport   0.021596     TrackerCollisionSelectedTrackMonCommonhighPurityPt1
TimeReport   0.031844     TrackerCollisionSelectedTrackMonCommonhighPurityPtRange0to1
```
Additionally, some cleanup of includes and cout statements have been made in the DQM/TrackingMonitor/ pakage. 


#### PR validation:
Checked with wf 11634.0. 

#### if this PR is a backport please specify the original PR and why you need to backport that PR:
Backport needed for 11_3_X.