### PR TITLE
Migrate EcalTPCondAnalyzer to use esConsumes

### DIFF
--- a/SimCalorimetry/EcalTrigPrimProducers/plugins/EcalTPCondAnalyzer.cc
+++ b/SimCalorimetry/EcalTrigPrimProducers/plugins/EcalTPCondAnalyzer.cc
@@ -16,53 +16,37 @@
 //
 
 // system include files
-#include <fstream>
-#include <iostream>
 #include <memory>
 #include <utility>
+#include <vector>
 
 // user include files
-#include "FWCore/Framework/interface/EDAnalyzer.h"
-#include "FWCore/Framework/interface/ESHandle.h"
-#include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/MakerMacros.h"
-
-#include "CondFormats/DataRecord/interface/EcalTPGCrystalStatusRcd.h"
-#include "CondFormats/DataRecord/interface/EcalTPGFineGrainEBGroupRcd.h"
-#include "CondFormats/DataRecord/interface/EcalTPGFineGrainEBIdMapRcd.h"
-#include "CondFormats/DataRecord/interface/EcalTPGFineGrainStripEERcd.h"
-#include "CondFormats/DataRecord/interface/EcalTPGFineGrainTowerEERcd.h"
-#include "CondFormats/DataRecord/interface/EcalTPGLinearizationConstRcd.h"
-#include "CondFormats/DataRecord/interface/EcalTPGLutGroupRcd.h"
-#include "CondFormats/DataRecord/interface/EcalTPGLutIdMapRcd.h"
-#include "CondFormats/DataRecord/interface/EcalTPGPedestalsRcd.h"
-#include "CondFormats/DataRecord/interface/EcalTPGPhysicsConstRcd.h"
-#include "CondFormats/DataRecord/interface/EcalTPGSlidingWindowRcd.h"
-#include "CondFormats/DataRecord/interface/EcalTPGSpikeRcd.h"
-#include "CondFormats/DataRecord/interface/EcalTPGStripStatusRcd.h"
-#include "CondFormats/DataRecord/interface/EcalTPGTowerStatusRcd.h"
-#include "CondFormats/DataRecord/interface/EcalTPGWeightGroupRcd.h"
-#include "CondFormats/DataRecord/interface/EcalTPGWeightIdMapRcd.h"
-
 #include "DataFormats/EcalDetId/interface/EcalTrigTowerDetId.h"
 #include "DataFormats/EcalDetId/interface/EcalTriggerElectronicsId.h"
-#include "Geometry/CaloGeometry/interface/CaloSubdetectorGeometry.h"
-#include "Geometry/Records/interface/CaloGeometryRecord.h"
 
 #include "SimCalorimetry/EcalTrigPrimProducers/plugins/EcalTPCondAnalyzer.h"
 
 EcalTPCondAnalyzer::EcalTPCondAnalyzer(const edm::ParameterSet &iConfig)
-
-{}
+    : tokenEndcapGeom_(esConsumes<edm::Transition::BeginRun>(edm::ESInputTag("", "EcalEndcap"))),
+      tokenBarrelGeom_(esConsumes<edm::Transition::BeginRun>(edm::ESInputTag("", "EcalBarrel"))),
+      tokenEcalTPGPhysics_(esConsumes<edm::Transition::BeginRun>()),
+      tokenEcalTPGLinearization_(esConsumes<edm::Transition::BeginRun>()),
+      tokenEcalTPGPedestals_(esConsumes<edm::Transition::BeginRun>()),
+      tokenEcalTPGWeightIdMap_(esConsumes<edm::Transition::BeginRun>()),
+      tokenEcalTPGFineGrainEBIdMap_(esConsumes<edm::Transition::BeginRun>()),
+      tokenEcalTPGLutIdMap_(esConsumes<edm::Transition::BeginRun>()),
+      tokenEcalTPGSlidingWindow_(esConsumes<edm::Transition::BeginRun>()),
+      tokenEcalTPGFineGrainStripEE_(esConsumes<edm::Transition::BeginRun>()),
+      tokenEcalTPGWeightGroup_(esConsumes<edm::Transition::BeginRun>()),
+      tokenEcalTPGLutGroup_(esConsumes<edm::Transition::BeginRun>()),
+      tokenEcalTPGFineGrainEBGroup_(esConsumes<edm::Transition::BeginRun>()),
+      tokenEcalTPGSpike_(esConsumes<edm::Transition::BeginRun>()),
+      tokenEcalTPGFineGrainTowerEE_(esConsumes<edm::Transition::BeginRun>()) {}
 
 void EcalTPCondAnalyzer::beginRun(const edm::Run &run, edm::EventSetup const &evtSetup) {
   // get geometry
-
-  edm::ESHandle<CaloSubdetectorGeometry> theEndcapGeometry_handle, theBarrelGeometry_handle;
-  evtSetup.get<EcalEndcapGeometryRecord>().get("EcalEndcap", theEndcapGeometry_handle);
-  evtSetup.get<EcalBarrelGeometryRecord>().get("EcalBarrel", theBarrelGeometry_handle);
-  theEndcapGeometry_ = &(*theEndcapGeometry_handle);
-  theBarrelGeometry_ = &(*theBarrelGeometry_handle);
+  theEndcapGeometry_ = &evtSetup.getData(tokenEndcapGeom_);
+  theBarrelGeometry_ = &evtSetup.getData(tokenBarrelGeom_);
 
   cacheID_ = this->getRecords(evtSetup);
 }
@@ -77,92 +61,42 @@ unsigned long long EcalTPCondAnalyzer::getRecords(edm::EventSetup const &setup) 
   //
   printComment();
 
-  edm::ESHandle<EcalTPGPhysicsConst> theEcalTPGPhysConst_handle;
-  setup.get<EcalTPGPhysicsConstRcd>().get(theEcalTPGPhysConst_handle);
-  const EcalTPGPhysicsConst *ecaltpPhysConst = theEcalTPGPhysConst_handle.product();
+  const auto ecaltpPhysConst = &setup.getData(tokenEcalTPGPhysics_);
   printEcalTPGPhysicsConst(ecaltpPhysConst);
+
   // for EcalFenixStrip...
-
   // get parameter records for xtals
-  edm::ESHandle<EcalTPGLinearizationConst> theEcalTPGLinearization_handle;
-  setup.get<EcalTPGLinearizationConstRcd>().get(theEcalTPGLinearization_handle);
-  const EcalTPGLinearizationConst *ecaltpLin = theEcalTPGLinearization_handle.product();
-
-  edm::ESHandle<EcalTPGPedestals> theEcalTPGPedestals_handle;
-  setup.get<EcalTPGPedestalsRcd>().get(theEcalTPGPedestals_handle);
-  const EcalTPGPedestals *ecaltpPed = theEcalTPGPedestals_handle.product();
+  const auto *ecaltpLin = &setup.getData(tokenEcalTPGLinearization_);
+  const auto *ecaltpPed = &setup.getData(tokenEcalTPGPedestals_);
   printCRYSTAL(ecaltpPed, ecaltpLin);
 
   // weight
-  edm::ESHandle<EcalTPGWeightIdMap> theEcalTPGWEightIdMap_handle;
-  setup.get<EcalTPGWeightIdMapRcd>().get(theEcalTPGWEightIdMap_handle);
-  const EcalTPGWeightIdMap *ecaltpgWeightMap = theEcalTPGWEightIdMap_handle.product();
+  const auto *ecaltpgWeightMap = &setup.getData(tokenEcalTPGWeightIdMap_);
   printWEIGHT(ecaltpgWeightMap);
 
   // .. and for EcalFenixTcp
-
-  edm::ESHandle<EcalTPGFineGrainEBIdMap> theEcalTPGFineGrainEBIdMap_handle;
-  setup.get<EcalTPGFineGrainEBIdMapRcd>().get(theEcalTPGFineGrainEBIdMap_handle);
-  const EcalTPGFineGrainEBIdMap *ecaltpgFineGrainEB = theEcalTPGFineGrainEBIdMap_handle.product();
+  const auto *ecaltpgFineGrainEB = &setup.getData(tokenEcalTPGFineGrainEBIdMap_);
   printEcalTPGFineGrainEBIdMap(ecaltpgFineGrainEB);
 
-  edm::ESHandle<EcalTPGLutIdMap> theEcalTPGLutIdMap_handle;
-  setup.get<EcalTPGLutIdMapRcd>().get(theEcalTPGLutIdMap_handle);
-  const EcalTPGLutIdMap *ecaltpgLut = theEcalTPGLutIdMap_handle.product();
+  const auto *ecaltpgLut = &setup.getData(tokenEcalTPGLutIdMap_);
   printEcalTPGLutIdMap(ecaltpgLut);
 
   // for strips
-  edm::ESHandle<EcalTPGSlidingWindow> theEcalTPGSlidingWindow_handle;
-  setup.get<EcalTPGSlidingWindowRcd>().get(theEcalTPGSlidingWindow_handle);
-  const EcalTPGSlidingWindow *ecaltpgSlidW = theEcalTPGSlidingWindow_handle.product();
-  edm::ESHandle<EcalTPGFineGrainStripEE> theEcalTPGFineGrainStripEE_handle;
-  setup.get<EcalTPGFineGrainStripEERcd>().get(theEcalTPGFineGrainStripEE_handle);
-  const EcalTPGFineGrainStripEE *ecaltpgFgStripEE = theEcalTPGFineGrainStripEE_handle.product();
-  edm::ESHandle<EcalTPGWeightGroup> theEcalTPGWEightGroup_handle;
-  setup.get<EcalTPGWeightGroupRcd>().get(theEcalTPGWEightGroup_handle);
-  const EcalTPGWeightGroup *ecaltpgWeightGroup = theEcalTPGWEightGroup_handle.product();
+  const auto *ecaltpgSlidW = &setup.getData(tokenEcalTPGSlidingWindow_);
+  const auto *ecaltpgFgStripEE = &setup.getData(tokenEcalTPGFineGrainStripEE_);
+  const auto *ecaltpgWeightGroup = &setup.getData(tokenEcalTPGWeightGroup_);
   printSTRIP(ecaltpgSlidW, ecaltpgWeightGroup, ecaltpgFgStripEE);
 
   // get parameter records for towers
-  edm::ESHandle<EcalTPGLutGroup> theEcalTPGLutGroup_handle;
-  setup.get<EcalTPGLutGroupRcd>().get(theEcalTPGLutGroup_handle);
-  const EcalTPGLutGroup *ecaltpgLutGroup = theEcalTPGLutGroup_handle.product();
-
-  edm::ESHandle<EcalTPGFineGrainEBGroup> theEcalTPGFineGrainEBGroup_handle;
-  setup.get<EcalTPGFineGrainEBGroupRcd>().get(theEcalTPGFineGrainEBGroup_handle);
-  const EcalTPGFineGrainEBGroup *ecaltpgFgEBGroup = theEcalTPGFineGrainEBGroup_handle.product();
-  edm::ESHandle<EcalTPGSpike> theEcalTPGSpike_handle;
-  setup.get<EcalTPGSpikeRcd>().get(theEcalTPGSpike_handle);
-  const EcalTPGSpike *ecaltpgSpikeTh = theEcalTPGSpike_handle.product();
+  const auto *ecaltpgLutGroup = &setup.getData(tokenEcalTPGLutGroup_);
+  const auto *ecaltpgFgEBGroup = &setup.getData(tokenEcalTPGFineGrainEBGroup_);
+  const auto *ecaltpgSpikeTh = &setup.getData(tokenEcalTPGSpike_);
+  const auto *ecaltpgFineGrainTowerEE = &setup.getData(tokenEcalTPGFineGrainTowerEE_);
 
   printTOWEREB(ecaltpgSpikeTh, ecaltpgFgEBGroup, ecaltpgLutGroup);
-  edm::ESHandle<EcalTPGFineGrainTowerEE> theEcalTPGFineGrainTowerEE_handle;
-  setup.get<EcalTPGFineGrainTowerEERcd>().get(theEcalTPGFineGrainTowerEE_handle);
-  const EcalTPGFineGrainTowerEE *ecaltpgFineGrainTowerEE = theEcalTPGFineGrainTowerEE_handle.product();
-
   printTOWEREE(ecaltpgFineGrainTowerEE, ecaltpgLutGroup);
 
-  // get parameters for BadX
-  /*  edm::ESHandle<EcalTPGCrystalStatus> theEcalTPGCrystalStatus_handle;
-    setup.get<EcalTPGCrystalStatusRcd>().get(theEcalTPGCrystalStatus_handle);
-    const EcalTPGCrystalStatus * ecaltpgBadX =
-    theEcalTPGCrystalStatus_handle.product(); printBadX(ecaltpgBadX);
-
-    // get parameters for BadTT
-    edm::ESHandle<EcalTPGTowerStatus> theEcalTPGTowerStatus_handle;
-    setup.get<EcalTPGTowerStatusRcd>().get(theEcalTPGTowerStatus_handle);
-    const EcalTPGTowerStatus * ecaltpgBadTT =
-    theEcalTPGTowerStatus_handle.product(); printBadTT(ecaltpgBadTT);
-  */
-
-  // get parameters for BadStrip
-  /*  edm::ESHandle<EcalTPGStripStatus> theEcalTPGStripStatus_handle;
-    setup.get<EcalTPGStripStatusRcd>().get(theEcalTPGStripStatus_handle);
-    const EcalTPGStripStatus * ecaltpgBadStrip =
-    theEcalTPGStripStatus_handle.product(); printBadStrip(ecaltpgBadStrip);
-  */
-
-  std::cout << "EOF" << std::endl;
+  edm::LogVerbatim("EcalTPCondAnalyzer") << "EOF";
 
   return setup.get<EcalTPGFineGrainTowerEERcd>().cacheIdentifier();
 }
@@ -172,19 +106,21 @@ void EcalTPCondAnalyzer::analyze(const edm::Event &iEvent, const edm::EventSetup
 
 void EcalTPCondAnalyzer::endJob() {}
 
+void EcalTPCondAnalyzer::endRun(edm::Run const &, edm::EventSetup const &) {}
+
 void EcalTPCondAnalyzer::printEcalTPGPhysicsConst(const EcalTPGPhysicsConst *ecaltpgPhysConst) const {
   EcalTPGPhysicsConstMapIterator it;
   const EcalTPGPhysicsConstMap &mymap = ecaltpgPhysConst->getMap();
   for (it = mymap.begin(); it != mymap.end(); ++it) {
     if (it == mymap.begin()) {
-      std::cout << "\nPHYSICS_EB " << (*it).first << std::endl;
+      edm::LogVerbatim("EcalTPCondAnalyzer") << "\nPHYSICS_EB " << (*it).first;
     } else {
-      std::cout << "\nPHYSICS_EE " << (*it).first << std::endl;
+      edm::LogVerbatim("EcalTPCondAnalyzer") << "\nPHYSICS_EE " << (*it).first;
     }
-    std::cout << (*it).second.EtSat << " " << (*it).second.ttf_threshold_Low << " " << (*it).second.ttf_threshold_High
-              << std::endl;
-    std::cout << (*it).second.FG_lowThreshold << " " << (*it).second.FG_highThreshold << " " << (*it).second.FG_lowRatio
-              << " " << (*it).second.FG_highRatio << std::endl;
+    edm::LogVerbatim("EcalTPCondAnalyzer")
+        << (*it).second.EtSat << " " << (*it).second.ttf_threshold_Low << " " << (*it).second.ttf_threshold_High;
+    edm::LogVerbatim("EcalTPCondAnalyzer") << (*it).second.FG_lowThreshold << " " << (*it).second.FG_highThreshold
+                                           << " " << (*it).second.FG_lowRatio << " " << (*it).second.FG_highRatio;
   }
 }
 
@@ -198,18 +134,18 @@ void EcalTPCondAnalyzer::printSTRIP(const EcalTPGSlidingWindow *slWin,
   const EcalTPGGroups::EcalTPGGroupsMap &gMap = ecaltpgWeightGroup->getMap();
   EcalTPGGroups::EcalTPGGroupsMapItr groupId;
 
-  std::cout << std::endl;
+  edm::LogVerbatim("EcalTPCondAnalyzer");
   for (int mysub = 1; mysub <= 2; ++mysub) {
-    std::cout << std::endl;
+    edm::LogVerbatim("EcalTPCondAnalyzer");
     for (it = slwinmap.begin(); it != slwinmap.end(); ++it) {
       EcalTriggerElectronicsId elid((*it).first);
       groupId = gMap.find((*it).first);
       int subdet = elid.subdet();
       if (subdet == mysub) {
         if (subdet == 1) {
-          std::cout << "STRIP_EB " << std::dec << (*it).first << std::endl;
-          std::cout << std::hex << "0x" << (*it).second << std::endl;
-          std::cout << "" << (*groupId).second << std::endl;  // weightgroupid
+          edm::LogVerbatim("EcalTPCondAnalyzer") << "STRIP_EB " << std::dec << (*it).first << "\n"
+                                                 << std::hex << "0x" << (*it).second << "\n"
+                                                 << "" << (*groupId).second;  // weightgroupid
           EcalTPGFineGrainStripEEMapIterator it2 = fgstripEEmap.find((*it).first);
           if (it2 == fgstripEEmap.end()) {
             edm::LogWarning("EcalTPGCondAnalyzer") << " could not find strip Id " << (*it).first
@@ -217,12 +153,12 @@ void EcalTPCondAnalyzer::printSTRIP(const EcalTPGSlidingWindow *slWin,
                                                       "EcalTPGFineGranStripEEMap!!!";
           } else {
             EcalTPGFineGrainStripEE::Item item = (*it2).second;
-            std::cout << std::hex << "0x" << item.threshold << " 0x" << item.lut << std::endl;
+            edm::LogVerbatim("EcalTPCondAnalyzer") << std::hex << "0x" << item.threshold << " 0x" << item.lut;
           }
         } else if (subdet == 2) {
-          std::cout << "STRIP_EE " << std::dec << (*it).first << std::endl;
-          std::cout << std::hex << "0x" << (*it).second << std::endl;
-          std::cout << " " << (*groupId).second << std::endl;  // weightgroupid
+          edm::LogVerbatim("EcalTPCondAnalyzer") << "STRIP_EE " << std::dec << (*it).first << "\n"
+                                                 << std::hex << "0x" << (*it).second << "\n"
+                                                 << " " << (*groupId).second;  // weightgroupid
           EcalTPGFineGrainStripEEMapIterator it2 = fgstripEEmap.find((*it).first);
           if (it2 == fgstripEEmap.end()) {
             edm::LogWarning("EcalTPGCondAnalyzer") << " could not find strip Id " << (*it).first
@@ -230,7 +166,7 @@ void EcalTPCondAnalyzer::printSTRIP(const EcalTPGSlidingWindow *slWin,
                                                       "EcalTPGFineGranStripEEMap!!!";
           } else {
             EcalTPGFineGrainStripEE::Item item = (*it2).second;
-            std::cout << std::hex << "0x" << item.threshold << " 0x" << item.lut << std::endl;
+            edm::LogVerbatim("EcalTPCondAnalyzer") << std::hex << "0x" << item.threshold << " 0x" << item.lut;
           }
         }
       }
@@ -239,16 +175,15 @@ void EcalTPCondAnalyzer::printSTRIP(const EcalTPGSlidingWindow *slWin,
 }
 
 void EcalTPCondAnalyzer::printWEIGHT(const EcalTPGWeightIdMap *ecaltpgWeightIdMap) const {
-  std::cout << std::endl;
+  edm::LogVerbatim("EcalTPCondAnalyzer");
   EcalTPGWeightIdMap::EcalTPGWeightMapItr it;
   uint32_t w0, w1, w2, w3, w4;
   const EcalTPGWeightIdMap::EcalTPGWeightMap &map = ecaltpgWeightIdMap->getMap();
   for (it = map.begin(); it != map.end(); ++it) {
-    std::cout << "WEIGHT " << (*it).first << std::endl;
+    edm::LogVerbatim("EcalTPCondAnalyzer") << "WEIGHT " << (*it).first;
     (*it).second.getValues(w0, w1, w2, w3, w4);
-    std::cout << std::hex << "0x" << w0 << " 0x" << w1 << " 0x" << w2 << " 0x" << w3 << " 0x" << w4 << " " << std::endl;
-    std::cout << std::endl;
-    std::cout << std::endl;
+    edm::LogVerbatim("EcalTPCondAnalyzer")
+        << std::hex << "0x" << w0 << " 0x" << w1 << " 0x" << w2 << " 0x" << w3 << " 0x" << w4 << " \n\n\n";
   }
 }
 
@@ -257,12 +192,11 @@ void EcalTPCondAnalyzer::printEcalTPGFineGrainEBIdMap(const EcalTPGFineGrainEBId
   const EcalTPGFineGrainEBIdMap::EcalTPGFineGrainEBMap &map = ecaltpgFineGrainEB->getMap();
   uint32_t ThresholdETLow, ThresholdETHigh, RatioLow, RatioHigh, LUT;
 
-  // std::cout<<std::endl;
   for (it = map.begin(); it != map.end(); ++it) {
-    std::cout << "FG " << (*it).first << std::endl;
+    edm::LogVerbatim("EcalTPCondAnalyzer") << "FG " << (*it).first;
     (*it).second.getValues(ThresholdETLow, ThresholdETHigh, RatioLow, RatioHigh, LUT);
-    std::cout << std::hex << "0x" << ThresholdETLow << " 0x" << ThresholdETHigh << " 0x" << RatioLow << " 0x"
-              << RatioHigh << " 0x" << LUT << std::endl;
+    edm::LogVerbatim("EcalTPCondAnalyzer") << std::hex << "0x" << ThresholdETLow << " 0x" << ThresholdETHigh << " 0x"
+                                           << RatioLow << " 0x" << RatioHigh << " 0x" << LUT;
   }
 }
 
@@ -270,143 +204,127 @@ void EcalTPCondAnalyzer::printEcalTPGLutIdMap(const EcalTPGLutIdMap *ecaltpgLut)
   EcalTPGLutIdMap::EcalTPGLutMapItr it;
   const EcalTPGLutIdMap::EcalTPGLutMap &map = ecaltpgLut->getMap();
 
-  std::cout << std::endl;
+  edm::LogVerbatim("EcalTPCondAnalyzer");
   for (it = map.begin(); it != map.end(); ++it) {
-    std::cout << "LUT " << (*it).first << std::endl;
+    edm::LogVerbatim("EcalTPCondAnalyzer") << "LUT " << (*it).first;
     const unsigned int *lut = (*it).second.getLut();
     for (unsigned int i = 0; i < 1024; ++i)
-      std::cout << std::hex << "0x" << *lut++ << std::endl;
+      edm::LogVerbatim("EcalTPCondAnalyzer") << std::hex << "0x" << *lut++;
   }
 }
 
 void EcalTPCondAnalyzer::printCRYSTAL(const EcalTPGPedestals *ecaltpPed, const EcalTPGLinearizationConst *ecaltpLin) {
-  std::cout << std::endl;
+  edm::LogVerbatim("EcalTPCondAnalyzer");
   const EcalTPGPedestalsMap &pedMap = ecaltpPed->getMap();
   const EcalTPGLinearizationConstMap &linMap = ecaltpLin->getMap();
 
   const std::vector<DetId> &ebCells = theBarrelGeometry_->getValidDetIds(DetId::Ecal, EcalBarrel);
 
-  std::cout << "COMMENT ====== barrel crystals ====== " << std::endl;
+  edm::LogVerbatim("EcalTPCondAnalyzer") << "COMMENT ====== barrel crystals ====== ";
   for (std::vector<DetId>::const_iterator it = ebCells.begin(); it != ebCells.end(); ++it) {
     EBDetId id(*it);
-    std::cout << "CRYSTAL " << std::dec << id.rawId() << std::endl;
+    edm::LogVerbatim("EcalTPCondAnalyzer") << "CRYSTAL " << std::dec << id.rawId();
     const EcalTPGPedestal &ped = pedMap[id.rawId()];
     const EcalTPGLinearizationConstant &lin = linMap[id.rawId()];
-    std::cout << std::hex << " 0x" << ped.mean_x12 << " 0x" << lin.mult_x12 << " 0x" << lin.shift_x12 << std::endl;
-    std::cout << std::hex << " 0x" << ped.mean_x6 << " 0x" << lin.mult_x6 << " 0x" << lin.shift_x6 << std::endl;
-    std::cout << std::hex << " 0x" << ped.mean_x1 << " 0x" << lin.mult_x1 << " 0x" << lin.shift_x1 << std::endl;
+    edm::LogVerbatim("EcalTPCondAnalyzer")
+        << std::hex << " 0x" << ped.mean_x12 << " 0x" << lin.mult_x12 << " 0x" << lin.shift_x12 << "\n"
+        << std::hex << " 0x" << ped.mean_x6 << " 0x" << lin.mult_x6 << " 0x" << lin.shift_x6 << "\n"
+        << std::hex << " 0x" << ped.mean_x1 << " 0x" << lin.mult_x1 << " 0x" << lin.shift_x1;
   }
 
   const std::vector<DetId> &eeCells = theEndcapGeometry_->getValidDetIds(DetId::Ecal, EcalEndcap);
-  std::cout << "COMMENT ====== endcap crystals ====== " << std::endl;
+  edm::LogVerbatim("EcalTPCondAnalyzer") << "COMMENT ====== endcap crystals ====== ";
   for (std::vector<DetId>::const_iterator it = eeCells.begin(); it != eeCells.end(); ++it) {
     EEDetId id(*it);
-    std::cout << "CRYSTAL " << std::dec << id.rawId() << std::endl;
+    edm::LogVerbatim("EcalTPCondAnalyzer") << "CRYSTAL " << std::dec << id.rawId();
     const EcalTPGPedestal &ped = pedMap[id.rawId()];
     const EcalTPGLinearizationConstant &lin = linMap[id.rawId()];
-    std::cout << std::hex << " 0x" << ped.mean_x12 << " 0x" << lin.mult_x12 << " 0x" << lin.shift_x12 << std::endl;
-    std::cout << std::hex << " 0x" << ped.mean_x6 << " 0x" << lin.mult_x6 << " 0x" << lin.shift_x6 << std::endl;
-    std::cout << std::hex << " 0x" << ped.mean_x1 << " 0x" << lin.mult_x1 << " 0x" << lin.shift_x1 << std::endl;
+    edm::LogVerbatim("EcalTPCondAnalyzer")
+        << std::hex << " 0x" << ped.mean_x12 << " 0x" << lin.mult_x12 << " 0x" << lin.shift_x12 << "\n"
+        << std::hex << " 0x" << ped.mean_x6 << " 0x" << lin.mult_x6 << " 0x" << lin.shift_x6 << "\n"
+        << std::hex << " 0x" << ped.mean_x1 << " 0x" << lin.mult_x1 << " 0x" << lin.shift_x1;
   }
 }
 void EcalTPCondAnalyzer::printComment() const {
-  std::cout << "COMMENT put your comments here\n"
-            << "COMMENT =================================\n"
-            << "COMMENT           physics EB structure\n"
-            << "COMMENT\n"
-            << "COMMENT  EtSaturation (GeV), ttf_threshold_Low (GeV), "
-               "ttf_threshold_High (GeV)\n"
-            << "COMMENT  FG_lowThreshold (GeV), FG_highThreshold (GeV), "
-               "FG_lowRatio, FG_highRatio\n"
-            << "COMMENT =================================\n"
-            << "COMMENT\n"
-            << "COMMENT =================================\n"
-            << "COMMENT           physics EE structure\n"
-            << "COMMENT\n"
-            << "COMMENT  EtSaturation (GeV), ttf_threshold_Low (GeV), "
-               "ttf_threshold_High (GeV)\n"
-            << "COMMENT  FG_Threshold (GeV), dummy, dummy, dummy\n"
-            << "COMMENT =================================\n"
-            << "COMMENT\n"
-            << "COMMENT =================================\n"
-            << "COMMENT           crystal structure (same for EB and EE)\n"
-            << "COMMENT\n"
-            << "COMMENT  ped, mult, shift [gain12]\n"
-            << "COMMENT  ped, mult, shift [gain6]\n"
-            << "COMMENT  ped, mult, shift [gain1]\n"
-            << "COMMENT =================================\n"
-            << "COMMENT\n"
-            << "COMMENT =================================\n"
-            << "COMMENT           strip EB structure\n"
-            << "COMMENT\n"
-            << "COMMENT  sliding_window\n"
-            << "COMMENT  weightGroupId\n"
-            << "COMMENT  threshold_sfg lut_sfg\n"
-            << "COMMENT =================================\n"
-            << "COMMENT\n"
-            << "COMMENT =================================\n"
-            << "COMMENT           strip EE structure\n"
-            << "COMMENT\n"
-            << "COMMENT  sliding_window\n"
-            << "COMMENT  weightGroupId\n"
-            << "COMMENT  threshold_fg lut_fg\n"
-            << "COMMENT =================================\n"
-            << "COMMENT\n"
-            << "COMMENT =================================\n"
-            << "COMMENT           tower EB structure\n"
-            << "COMMENT\n"
-            << "COMMENT  LUTGroupId\n"
-            << "COMMENT  FgGroupId\n"
-            << "COMMENT  spike_killing_threshold\n"
-            << "COMMENT =================================\n"
-            << "COMMENT\n"
-            << "COMMENT =================================\n"
-            << "COMMENT           tower EE structure\n"
-            << "COMMENT\n"
-            << "COMMENT  LUTGroupId\n"
-            << "COMMENT  tower_lut_fg\n"
-            << "COMMENT =================================\n"
-            << "COMMENT\n"
-            << "COMMENT =================================\n"
-            << "COMMENT           Weight structure\n"
-            << "COMMENT\n"
-            << "COMMENT  weightGroupId\n"
-            << "COMMENT  w0, w1, w2, w3, w4\n"
-            << "COMMENT =================================\n"
-            << "COMMENT\n"
-            << "COMMENT =================================\n"
-            << "COMMENT           lut structure\n"
-            << "COMMENT\n"
-            << "COMMENT  LUTGroupId\n"
-            << "COMMENT  LUT[1-1024]\n"
-            << "COMMENT =================================\n"
-            << "COMMENT\n"
-            << "COMMENT =================================\n"
-            << "COMMENT           fg EB structure\n"
-            << "COMMENT\n"
-            << "COMMENT  FgGroupId\n"
-            << "COMMENT  el, eh, tl, th, lut_fg\n"
-            << "COMMENT =================================\n"
-            << "COMMENT" << std::endl;
+  edm::LogVerbatim("EcalTPCondAnalyzer") << "COMMENT put your comments here\n"
+                                         << "COMMENT =================================\n"
+                                         << "COMMENT           physics EB structure\n"
+                                         << "COMMENT\n"
+                                         << "COMMENT  EtSaturation (GeV), ttf_threshold_Low (GeV), "
+                                            "ttf_threshold_High (GeV)\n"
+                                         << "COMMENT  FG_lowThreshold (GeV), FG_highThreshold (GeV), "
+                                            "FG_lowRatio, FG_highRatio\n"
+                                         << "COMMENT =================================\n"
+                                         << "COMMENT\n"
+                                         << "COMMENT =================================\n"
+                                         << "COMMENT           physics EE structure\n"
+                                         << "COMMENT\n"
+                                         << "COMMENT  EtSaturation (GeV), ttf_threshold_Low (GeV), "
+                                            "ttf_threshold_High (GeV)\n"
+                                         << "COMMENT  FG_Threshold (GeV), dummy, dummy, dummy\n"
+                                         << "COMMENT =================================\n"
+                                         << "COMMENT\n"
+                                         << "COMMENT =================================\n"
+                                         << "COMMENT           crystal structure (same for EB and EE)\n"
+                                         << "COMMENT\n"
+                                         << "COMMENT  ped, mult, shift [gain12]\n"
+                                         << "COMMENT  ped, mult, shift [gain6]\n"
+                                         << "COMMENT  ped, mult, shift [gain1]\n"
+                                         << "COMMENT =================================\n"
+                                         << "COMMENT\n"
+                                         << "COMMENT =================================\n"
+                                         << "COMMENT           strip EB structure\n"
+                                         << "COMMENT\n"
+                                         << "COMMENT  sliding_window\n"
+                                         << "COMMENT  weightGroupId\n"
+                                         << "COMMENT  threshold_sfg lut_sfg\n"
+                                         << "COMMENT =================================\n"
+                                         << "COMMENT\n"
+                                         << "COMMENT =================================\n"
+                                         << "COMMENT           strip EE structure\n"
+                                         << "COMMENT\n"
+                                         << "COMMENT  sliding_window\n"
+                                         << "COMMENT  weightGroupId\n"
+                                         << "COMMENT  threshold_fg lut_fg\n"
+                                         << "COMMENT =================================\n"
+                                         << "COMMENT\n"
+                                         << "COMMENT =================================\n"
+                                         << "COMMENT           tower EB structure\n"
+                                         << "COMMENT\n"
+                                         << "COMMENT  LUTGroupId\n"
+                                         << "COMMENT  FgGroupId\n"
+                                         << "COMMENT  spike_killing_threshold\n"
+                                         << "COMMENT =================================\n"
+                                         << "COMMENT\n"
+                                         << "COMMENT =================================\n"
+                                         << "COMMENT           tower EE structure\n"
+                                         << "COMMENT\n"
+                                         << "COMMENT  LUTGroupId\n"
+                                         << "COMMENT  tower_lut_fg\n"
+                                         << "COMMENT =================================\n"
+                                         << "COMMENT\n"
+                                         << "COMMENT =================================\n"
+                                         << "COMMENT           Weight structure\n"
+                                         << "COMMENT\n"
+                                         << "COMMENT  weightGroupId\n"
+                                         << "COMMENT  w0, w1, w2, w3, w4\n"
+                                         << "COMMENT =================================\n"
+                                         << "COMMENT\n"
+                                         << "COMMENT =================================\n"
+                                         << "COMMENT           lut structure\n"
+                                         << "COMMENT\n"
+                                         << "COMMENT  LUTGroupId\n"
+                                         << "COMMENT  LUT[1-1024]\n"
+                                         << "COMMENT =================================\n"
+                                         << "COMMENT\n"
+                                         << "COMMENT =================================\n"
+                                         << "COMMENT           fg EB structure\n"
+                                         << "COMMENT\n"
+                                         << "COMMENT  FgGroupId\n"
+                                         << "COMMENT  el, eh, tl, th, lut_fg\n"
+                                         << "COMMENT =================================\n"
+                                         << "COMMENT";
 }
-
-/*void EcalTPCondAnalyzer::printTOWEREB(const EcalTPGFineGrainEBGroup
-*ecaltpgFgEBGroup,const EcalTPGLutGroup *ecaltpgLutGroup) const {
-
-    const EcalTPGGroups::EcalTPGGroupsMap &lutMap=ecaltpgLutGroup->getMap();
-    EcalTPGGroups::EcalTPGGroupsMapItr lutGroupId;
-    const EcalTPGGroups::EcalTPGGroupsMap &fgMap=ecaltpgFgEBGroup->getMap();
-    EcalTPGGroups::EcalTPGGroupsMapItr it;
-
-    std::cout<<std::endl;
-    for (it=fgMap.begin();it!=fgMap.end();++it) {
-      std::cout <<"TOWER_EB "<<std::dec<<(*it).first<<std::endl;
-      lutGroupId=lutMap.find((*it).first);
-      std::cout <<" "<<(*it).second<<std::endl;
-      std::cout <<" "<<(*lutGroupId).second<<std::endl;
-    }
-}
-*/
 
 void EcalTPCondAnalyzer::printTOWEREB(const EcalTPGSpike *ecaltpgSpikeTh,
                                       const EcalTPGFineGrainEBGroup *ecaltpgFgEBGroup,
@@ -419,14 +337,14 @@ void EcalTPCondAnalyzer::printTOWEREB(const EcalTPGSpike *ecaltpgSpikeTh,
   const EcalTPGSpike::EcalTPGSpikeMap &spikeThMap = ecaltpgSpikeTh->getMap();
   EcalTPGSpike::EcalTPGSpikeMapIterator itSpikeTh;
 
-  std::cout << std::endl;
+  edm::LogVerbatim("EcalTPCondAnalyzer");
   for (it = fgMap.begin(); it != fgMap.end(); ++it) {
-    std::cout << "TOWER_EB " << std::dec << (*it).first << std::endl;
+    edm::LogVerbatim("EcalTPCondAnalyzer") << "TOWER_EB " << std::dec << (*it).first;
     lutGroupId = lutMap.find((*it).first);
     itSpikeTh = spikeThMap.find((*it).first);
-    std::cout << " " << (*it).second << std::endl;
-    std::cout << " " << (*lutGroupId).second << std::endl;
-    std::cout << " " << (*itSpikeTh).second << std::endl;
+    edm::LogVerbatim("EcalTPCondAnalyzer") << " " << (*it).second << "\n"
+                                           << " " << (*lutGroupId).second << "\n"
+                                           << " " << (*itSpikeTh).second;
   }
 }
 
@@ -437,94 +355,10 @@ void EcalTPCondAnalyzer::printTOWEREE(const EcalTPGFineGrainTowerEE *ecaltpgFine
   const EcalTPGGroups::EcalTPGGroupsMap &lutMap = ecaltpgLutGroup->getMap();
   EcalTPGGroups::EcalTPGGroupsMapItr lutGroupId;
 
-  std::cout << std::endl;
+  edm::LogVerbatim("EcalTPCondAnalyzer");
   for (it = map.begin(); it != map.end(); ++it) {
-    std::cout << "TOWER_EE " << std::dec << (*it).first << std::endl;
+    edm::LogVerbatim("EcalTPCondAnalyzer") << "TOWER_EE " << std::dec << (*it).first;
     lutGroupId = lutMap.find((*it).first);
-    std::cout << " " << (*lutGroupId).second << std::endl;
-    std::cout << std::hex << "0x" << (*it).second << std::endl;
+    edm::LogVerbatim("EcalTPCondAnalyzer") << " " << (*lutGroupId).second << "\n" << std::hex << "0x" << (*it).second;
   }
 }
-
-/*void EcalTPCondAnalyzer::printBadX(const EcalTPGCrystalStatus *ecaltpgBadX)
-const {
-
-  std::ofstream myfile;
-  myfile.open("badXvalues.txt");
-
-  const EcalTPGCrystalStatusMap & badXMap = ecaltpgBadX->getMap();
-
-  const std::vector<DetId> & ebCells =
-theBarrelGeometry_->getValidDetIds(DetId::Ecal, EcalBarrel);
-
-  myfile <<"COMMENT ====== barrel masked crystals ====== "<<std::endl;
-  myfile << "RawId         eta      phi   " << std::endl;
-
-  for (std::vector<DetId>::const_iterator it = ebCells.begin(); it !=
-ebCells.end(); ++it) {
-
-    EBDetId id(*it) ;
-    const EcalTPGCrystalStatusCode &badXeb=badXMap[id.rawId()];
-    // Print in the text file obly the masked crystals
-    if (badXeb.getStatusCode() != 0){
-      myfile << "" << id.rawId() << "      " << id.ieta() << "      " <<
-id.iphi() << std::endl;
-    }
-
-  }
-
-  myfile << " " << std::endl;
-
-  const std::vector<DetId> & eeCells =
-theEndcapGeometry_->getValidDetIds(DetId::Ecal, EcalEndcap);
-
-  myfile <<"COMMENT ====== endcap masked crystals ====== "<<std::endl;
-  myfile << "RawId       x      y      z   " << std::endl;
-
-  for (std::vector<DetId>::const_iterator it = eeCells.begin(); it !=
-eeCells.end(); ++it) {
-
-    EEDetId id(*it) ;
-    const EcalTPGCrystalStatusCode &badXee=badXMap[id.rawId()];
-    // Print in the text file only the masked clystals
-    if (badXee.getStatusCode() != 0){
-      myfile << "" << id.rawId() << "   " << id.ix() << "      " << id.iy() << "
-"<< id.zside() << std::endl;
-    }
-  }
-
-  myfile.close();
-}
-*/
-
-/*void EcalTPCondAnalyzer::printBadTT(const EcalTPGTowerStatus *ecaltpgBadTT)
-const { std::ofstream myfilebadTT; myfilebadTT.open("badTTvalues.txt"); int ieta
-= 0; int iphi = 0;
-
-  const EcalTPGTowerStatusMap & badTTMap = ecaltpgBadTT -> getMap();
-  EcalTPGTowerStatusMapIterator it;
-
-  myfilebadTT <<"Barrel and endcap masked Trigger Towers"<<std::endl;
-  myfilebadTT <<"RawId " << "     iphi " << "  ieta " << std::endl;
-  myfilebadTT <<""<< std::endl;
-
-  for (it=badTTMap.begin();it!=badTTMap.end();++it) {
-
-    // Print in the text file only the masked barrel and endcap TTs
-    if ((*it).second != 0){
-
-      EcalTrigTowerDetId  ttId((*it).first);
-      ieta = ttId.ieta();
-      iphi = ttId.iphi();
-
-      myfilebadTT <<""<< std::dec<<(*it).first << "  " << iphi << "     " <<
-ieta << std::endl;
-
-    }
-  }
-
-
-  myfilebadTT.close();
-
-}
-*/

--- a/SimCalorimetry/EcalTrigPrimProducers/plugins/EcalTPCondAnalyzer.h
+++ b/SimCalorimetry/EcalTrigPrimProducers/plugins/EcalTPCondAnalyzer.h
@@ -14,7 +14,6 @@
 //
 //
 
-// system include files
 #include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 
@@ -22,10 +21,8 @@
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 
-#include "DataFormats/Common/interface/Handle.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
-#include "CondFormats/EcalObjects/interface/EcalTPGCrystalStatus.h"
 #include "CondFormats/EcalObjects/interface/EcalTPGFineGrainEBGroup.h"
 #include "CondFormats/EcalObjects/interface/EcalTPGFineGrainEBIdMap.h"
 #include "CondFormats/EcalObjects/interface/EcalTPGFineGrainStripEE.h"
@@ -37,33 +34,59 @@
 #include "CondFormats/EcalObjects/interface/EcalTPGPhysicsConst.h"
 #include "CondFormats/EcalObjects/interface/EcalTPGSlidingWindow.h"
 #include "CondFormats/EcalObjects/interface/EcalTPGSpike.h"
-#include "CondFormats/EcalObjects/interface/EcalTPGStripStatus.h"
-#include "CondFormats/EcalObjects/interface/EcalTPGTowerStatus.h"
 #include "CondFormats/EcalObjects/interface/EcalTPGWeightGroup.h"
 #include "CondFormats/EcalObjects/interface/EcalTPGWeightIdMap.h"
 
-class CaloSubdetectorGeometry;
-
-#include <string>
-#include <vector>
+#include "CondFormats/DataRecord/interface/EcalTPGFineGrainEBGroupRcd.h"
+#include "CondFormats/DataRecord/interface/EcalTPGFineGrainEBIdMapRcd.h"
+#include "CondFormats/DataRecord/interface/EcalTPGFineGrainStripEERcd.h"
+#include "CondFormats/DataRecord/interface/EcalTPGFineGrainTowerEERcd.h"
+#include "CondFormats/DataRecord/interface/EcalTPGLinearizationConstRcd.h"
+#include "CondFormats/DataRecord/interface/EcalTPGLutGroupRcd.h"
+#include "CondFormats/DataRecord/interface/EcalTPGLutIdMapRcd.h"
+#include "CondFormats/DataRecord/interface/EcalTPGPedestalsRcd.h"
+#include "CondFormats/DataRecord/interface/EcalTPGPhysicsConstRcd.h"
+#include "CondFormats/DataRecord/interface/EcalTPGSlidingWindowRcd.h"
+#include "CondFormats/DataRecord/interface/EcalTPGSpikeRcd.h"
+#include "CondFormats/DataRecord/interface/EcalTPGWeightGroupRcd.h"
+#include "CondFormats/DataRecord/interface/EcalTPGWeightIdMapRcd.h"
+#include "Geometry/CaloGeometry/interface/CaloSubdetectorGeometry.h"
+#include "Geometry/Records/interface/CaloGeometryRecord.h"
 
 //
 // class declaration
 //
 
-class EcalTPCondAnalyzer : public edm::one::EDAnalyzer<> {
+class EcalTPCondAnalyzer : public edm::one::EDAnalyzer<edm::one::WatchRuns> {
 public:
   explicit EcalTPCondAnalyzer(const edm::ParameterSet &);
   ~EcalTPCondAnalyzer() override;
 
   void analyze(const edm::Event &, const edm::EventSetup &) override;
   void beginJob() override;
-  void beginRun(const edm::Run &run, const edm::EventSetup &es);
+  void beginRun(const edm::Run &run, const edm::EventSetup &evtSetup) override;
   void endJob() override;
+  void endRun(edm::Run const &, edm::EventSetup const &) override;
 
 private:
   unsigned long long getRecords(edm::EventSetup const &setup);
   unsigned long long cacheID_;
+
+  edm::ESGetToken<CaloSubdetectorGeometry, EcalEndcapGeometryRecord> tokenEndcapGeom_;
+  edm::ESGetToken<CaloSubdetectorGeometry, EcalBarrelGeometryRecord> tokenBarrelGeom_;
+  edm::ESGetToken<EcalTPGPhysicsConst, EcalTPGPhysicsConstRcd> tokenEcalTPGPhysics_;
+  edm::ESGetToken<EcalTPGLinearizationConst, EcalTPGLinearizationConstRcd> tokenEcalTPGLinearization_;
+  edm::ESGetToken<EcalTPGPedestals, EcalTPGPedestalsRcd> tokenEcalTPGPedestals_;
+  edm::ESGetToken<EcalTPGWeightIdMap, EcalTPGWeightIdMapRcd> tokenEcalTPGWeightIdMap_;
+  edm::ESGetToken<EcalTPGFineGrainEBIdMap, EcalTPGFineGrainEBIdMapRcd> tokenEcalTPGFineGrainEBIdMap_;
+  edm::ESGetToken<EcalTPGLutIdMap, EcalTPGLutIdMapRcd> tokenEcalTPGLutIdMap_;
+  edm::ESGetToken<EcalTPGSlidingWindow, EcalTPGSlidingWindowRcd> tokenEcalTPGSlidingWindow_;
+  edm::ESGetToken<EcalTPGFineGrainStripEE, EcalTPGFineGrainStripEERcd> tokenEcalTPGFineGrainStripEE_;
+  edm::ESGetToken<EcalTPGWeightGroup, EcalTPGWeightGroupRcd> tokenEcalTPGWeightGroup_;
+  edm::ESGetToken<EcalTPGLutGroup, EcalTPGLutGroupRcd> tokenEcalTPGLutGroup_;
+  edm::ESGetToken<EcalTPGFineGrainEBGroup, EcalTPGFineGrainEBGroupRcd> tokenEcalTPGFineGrainEBGroup_;
+  edm::ESGetToken<EcalTPGSpike, EcalTPGSpikeRcd> tokenEcalTPGSpike_;
+  edm::ESGetToken<EcalTPGFineGrainTowerEE, EcalTPGFineGrainTowerEERcd> tokenEcalTPGFineGrainTowerEE_;
 
   const CaloSubdetectorGeometry *theEndcapGeometry_;
   const CaloSubdetectorGeometry *theBarrelGeometry_;
@@ -82,8 +105,4 @@ private:
   void printEcalTPGFineGrainEBIdMap(const EcalTPGFineGrainEBIdMap *ecaltpgFineGrainEB) const;
   void printTOWEREE(const EcalTPGFineGrainTowerEE *ecaltpgFineGrainTowerEE,
                     const EcalTPGLutGroup *ecaltpgLutGroup) const;
-  void printBadX(const EcalTPGCrystalStatus *ecaltpgBadX) const;
-  void printBadTT(const EcalTPGTowerStatus *ecaltpgBadTT) const;
-  void printBadStrip(const EcalTPGStripStatus *ecaltpgBadStrip) const;
-  void printSpikeTh(const EcalTPGSpike *ecaltpgSpike) const;
 };

--- a/SimCalorimetry/EcalTrigPrimProducers/test/readDBTPConds_GlobalTag_cfg.py
+++ b/SimCalorimetry/EcalTrigPrimProducers/test/readDBTPConds_GlobalTag_cfg.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("TPDBAn")
-process.load("CondCore.DBCommon.CondDBSetup_cfi")
+process.load("CondCore.CondDB.CondDB_cfi")
 
 process.load("Geometry.CaloEventSetup.CaloGeometry_cfi")
 
@@ -17,13 +17,28 @@ process.source = cms.Source("EmptySource",
 #    firstRun = cms.untracked.uint32(135175)
 )
 
-process.load("CondCore.DBCommon.CondDBCommon_cfi")
-process.CondDBCommon.DBParameters.authenticationPath = '/afs/cern.ch/cms/DB/conddb'
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
 process.prefer("GlobalTag")
-process.GlobalTag.globaltag = 'GR10_P_V5::All'
+process.GlobalTag.globaltag = '112X_dataRun3_HLT_v3'
 
 
 process.tpDBAnalyzer = cms.EDAnalyzer("EcalTPCondAnalyzer")
+
+process.MessageLogger = cms.Service("MessageLogger",
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        INFO = cms.untracked.PSet(
+            limit = cms.untracked.int32(0)
+        ),
+        EcalTPCondAnalyzer = cms.untracked.PSet(
+            limit = cms.untracked.int32(100000000)
+        ),
+        enable = cms.untracked.bool(True),
+        threshold = cms.untracked.string('DEBUG')
+    ),
+    debugModules = cms.untracked.vstring('tpDBAnalyzer')
+)
 
 process.p = cms.Path(process.tpDBAnalyzer)

--- a/SimCalorimetry/EcalTrigPrimProducers/test/readDBTPConds_beamv5_ideal_cfg.py
+++ b/SimCalorimetry/EcalTrigPrimProducers/test/readDBTPConds_beamv5_ideal_cfg.py
@@ -97,4 +97,21 @@ process.ecalTPConditions = cms.ESSource("PoolDBESSource",
 
 process.tpDBAnalyzer = cms.EDAnalyzer("EcalTPCondAnalyzer")
 
+process.MessageLogger = cms.Service("MessageLogger",
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        INFO = cms.untracked.PSet(
+            limit = cms.untracked.int32(0)
+        ),
+        EcalTPCondAnalyzer = cms.untracked.PSet(
+            limit = cms.untracked.int32(100000000)
+        ),
+        enable = cms.untracked.bool(True),
+        threshold = cms.untracked.string('DEBUG')
+    ),
+    debugModules = cms.untracked.vstring('tpDBAnalyzer')
+)
+
 process.p = cms.Path(process.tpDBAnalyzer)

--- a/SimCalorimetry/EcalTrigPrimProducers/test/readDBTPConds_beamv5_startup_cfg.py
+++ b/SimCalorimetry/EcalTrigPrimProducers/test/readDBTPConds_beamv5_startup_cfg.py
@@ -97,4 +97,21 @@ process.ecalTPConditions = cms.ESSource("PoolDBESSource",
 
 process.tpDBAnalyzer = cms.EDAnalyzer("EcalTPCondAnalyzer")
 
+process.MessageLogger = cms.Service("MessageLogger",
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        INFO = cms.untracked.PSet(
+            limit = cms.untracked.int32(0)
+        ),
+        EcalTPCondAnalyzer = cms.untracked.PSet(
+            limit = cms.untracked.int32(100000000)
+        ),
+        enable = cms.untracked.bool(True),
+        threshold = cms.untracked.string('DEBUG')
+    ),
+    debugModules = cms.untracked.vstring('tpDBAnalyzer')
+)
+
 process.p = cms.Path(process.tpDBAnalyzer)

--- a/SimCalorimetry/EcalTrigPrimProducers/test/readDBTPConds_cfg.py
+++ b/SimCalorimetry/EcalTrigPrimProducers/test/readDBTPConds_cfg.py
@@ -88,6 +88,22 @@ process.ecalTPConditions = cms.ESSource("PoolDBESSource",
 
 process.tpDBAnalyzer = cms.EDAnalyzer("EcalTPCondAnalyzer")
 
-process.p = cms.Path(process.tpDBAnalyzer)
+process.MessageLogger = cms.Service("MessageLogger",
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        INFO = cms.untracked.PSet(
+            limit = cms.untracked.int32(0)
+        ),
+        EcalTPCondAnalyzer = cms.untracked.PSet(
+            limit = cms.untracked.int32(100000000)
+        ),
+        enable = cms.untracked.bool(True),
+        threshold = cms.untracked.string('DEBUG')
+    ),
+    debugModules = cms.untracked.vstring('tpDBAnalyzer')
+)
 
+process.p = cms.Path(process.tpDBAnalyzer)
 


### PR DESCRIPTION
#### PR description:

Migrate EcalTPCondAnalyzer to use esConsumes and replace cout statements with LogVerbatim. This should fix a set of static analyzer warnings reported in #33349 tests.
The module has probably not been used since its migration to being a one::EDAnalyzer because it was actually broken and did not print anything. This was fixed by adding `edm::one::WatchRuns`.

#### PR validation:

Tested by running `SimCalorimetry/EcalTrigPrimProducers/test/readDBTPConds_GlobalTag_cfg.py`.