### PR TITLE
migrate DQM/TrackingMonitor to esConsumes

### DIFF
--- a/DQM/TrackingMonitor/interface/TrackEfficiencyMonitor.h
+++ b/DQM/TrackingMonitor/interface/TrackEfficiencyMonitor.h
@@ -14,23 +14,24 @@ Monitoring source to measure the track efficiency
 
 #include <memory>
 #include <fstream>
-#include "FWCore/Utilities/interface/EDGetToken.h"
-#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "DQMServices/Core/interface/DQMEDAnalyzer.h"
+#include "DQMServices/Core/interface/DQMStore.h"
+#include "DataFormats/MuonReco/interface/MuonFwd.h"
+#include "DataFormats/MuonReco/interface/MuonSelectors.h"
 #include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
-#include "DQMServices/Core/interface/DQMStore.h"
-
-#include <DQMServices/Core/interface/DQMEDAnalyzer.h>
-
+#include "FWCore/Utilities/interface/EDGetToken.h"
 #include "RecoMuon/GlobalTrackingTools/interface/DirectTrackerNavigation.h"
 #include "RecoMuon/TrackingTools/interface/MuonServiceProxy.h"
 #include "RecoTracker/MeasurementDet/interface/MeasurementTracker.h"
+#include "RecoTracker/Record/interface/CkfComponentsRecord.h"
+#include "RecoTracker/Record/interface/NavigationSchoolRecord.h"
+#include "RecoTracker/Record/interface/TrackerRecoGeometryRecord.h"
 #include "TrackingTools/TransientTrack/interface/TransientTrackBuilder.h"
-#include "DataFormats/MuonReco/interface/MuonFwd.h"
-#include "DataFormats/MuonReco/interface/MuonSelectors.h"
 
 namespace reco {
   class TransientTrack;
@@ -107,14 +108,20 @@ private:
   MonitorElement* StandaloneMuonPtEtaPhiHighPt;
   const DirectTrackerNavigation* theNavigation;
   MuonServiceProxy* theMuonServiceProxy;
-  edm::EDGetTokenT<edm::View<reco::Muon> > muonToken_;
-  edm::ESHandle<GeometricSearchTracker> theGeometricSearchTracker;
-  edm::ESHandle<Propagator> thePropagator;
-  edm::ESHandle<Propagator> thePropagatorCyl;
-  edm::ESHandle<TransientTrackBuilder> theTTrackBuilder;
-  edm::ESHandle<GeometricSearchTracker> theTracker;
-  edm::ESHandle<MagneticField> bField;
 
-  edm::ESHandle<MeasurementTracker> measurementTrackerHandle;
+  const edm::ESGetToken<TransientTrackBuilder, TransientTrackRecord> ttbToken_;
+  const edm::ESGetToken<Propagator, TrackingComponentsRecord> propToken_;
+  const edm::ESGetToken<NavigationSchool, NavigationSchoolRecord> navToken_;
+  const edm::ESGetToken<GeometricSearchTracker, TrackerRecoGeometryRecord> gstToken_;
+  const edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> mfToken_;
+  const edm::ESGetToken<MeasurementTracker, CkfComponentsRecord> mtToken_;
+
+  edm::EDGetTokenT<edm::View<reco::Muon> > muonToken_;
+
+  const Propagator* thePropagator;
+  const TransientTrackBuilder* theTTrackBuilder;
+  const GeometricSearchTracker* theTracker;
+  const MagneticField* bField;
+  const MeasurementTracker* measurementTracker;
 };
 #endif

--- a/DQM/TrackingMonitor/interface/TrackSplittingMonitor.h
+++ b/DQM/TrackingMonitor/interface/TrackSplittingMonitor.h
@@ -11,26 +11,27 @@
 // Original Author:  Nhan Tran
 //         Created:  Thu 28 22:45:30 CEST 2008
 
-#include <memory>
 #include <fstream>
-#include "FWCore/Utilities/interface/EDGetToken.h"
-#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include <memory>
+#include "DQMServices/Core/interface/DQMEDAnalyzer.h"
+#include "DQMServices/Core/interface/DQMStore.h"
 #include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
-#include "DQMServices/Core/interface/DQMStore.h"
-#include <DQMServices/Core/interface/DQMEDAnalyzer.h>
-
-#include "TrackingTools/TransientTrackingRecHit/interface/TransientTrackingRecHitBuilder.h"
-
-#include "Geometry/DTGeometry/interface/DTGeometry.h"
+#include "FWCore/Utilities/interface/EDGetToken.h"
 #include "Geometry/CSCGeometry/interface/CSCGeometry.h"
+#include "Geometry/DTGeometry/interface/DTGeometry.h"
 #include "Geometry/RPCGeometry/interface/RPCGeometry.h"
 #include "Geometry/Records/interface/MuonGeometryRecord.h"
+#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
+#include "MagneticField/Engine/interface/MagneticField.h"
+#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
+#include "TrackingTools/TransientTrackingRecHit/interface/TransientTrackingRecHitBuilder.h"
 
 class TProfile;
 
@@ -58,11 +59,17 @@ private:
   DQMStore* dqmStore_;
   edm::ParameterSet conf_;
 
-  edm::ESHandle<TrackerGeometry> theGeometry;
-  edm::ESHandle<MagneticField> theMagField;
-  edm::ESHandle<DTGeometry> dtGeometry;
-  edm::ESHandle<CSCGeometry> cscGeometry;
-  edm::ESHandle<RPCGeometry> rpcGeometry;
+  const edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> mfToken_;
+  const edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> tkGeomToken_;
+  const edm::ESGetToken<DTGeometry, MuonGeometryRecord> dtGeomToken_;
+  const edm::ESGetToken<CSCGeometry, MuonGeometryRecord> cscGeomToken_;
+  const edm::ESGetToken<RPCGeometry, MuonGeometryRecord> rpcGeomToken_;
+
+  const TrackerGeometry* theGeometry;
+  const MagneticField* theMagField;
+  const DTGeometry* dtGeometry;
+  const CSCGeometry* cscGeometry;
+  const RPCGeometry* rpcGeometry;
 
   edm::InputTag splitTracks_;
   edm::InputTag splitMuons_;

--- a/DQM/TrackingMonitor/src/LogMessageMonitor.cc
+++ b/DQM/TrackingMonitor/src/LogMessageMonitor.cc
@@ -114,8 +114,7 @@ void LogMessageMonitor::analyze(const edm::Event& iEvent, const edm::EventSetup&
     lumiDetails_->getValue(iEvent);
 
   // Take the ErrorSummaryEntry container
-  edm::Handle<std::vector<edm::ErrorSummaryEntry> > errors;
-  iEvent.getByToken(errorToken_, errors);
+  edm::Handle<std::vector<edm::ErrorSummaryEntry> > errors = iEvent.getHandle(errorToken_);
   // Check that errors is valid
   if (!errors.isValid())
     return;

--- a/DQM/TrackingMonitor/src/TrackAnalyzer.cc
+++ b/DQM/TrackingMonitor/src/TrackAnalyzer.cc
@@ -1105,8 +1105,7 @@ void TrackAnalyzer::bookHistosForBeamSpot(DQMStore::IBooker& ibooker) {
 void TrackAnalyzer::setNumberOfGoodVertices(const edm::Event& iEvent) {
   good_vertices_ = 0;
 
-  edm::Handle<reco::VertexCollection> recoPrimaryVerticesHandle;
-  iEvent.getByToken(pvToken_, recoPrimaryVerticesHandle);
+  edm::Handle<reco::VertexCollection> recoPrimaryVerticesHandle = iEvent.getHandle(pvToken_);
   if (recoPrimaryVerticesHandle.isValid())
     if (!recoPrimaryVerticesHandle->empty())
       for (const auto& v : *recoPrimaryVerticesHandle)
@@ -1120,24 +1119,21 @@ void TrackAnalyzer::setLumi(const edm::Event& iEvent, const edm::EventSetup& iSe
   // as done by pixelLumi http://cmslxr.fnal.gov/source/DQM/PixelLumi/plugins/PixelLumiDQM.cc
 
   if (forceSCAL_) {
-    edm::Handle<LumiScalersCollection> lumiScalers;
-    iEvent.getByToken(lumiscalersToken_, lumiScalers);
+    edm::Handle<LumiScalersCollection> lumiScalers = iEvent.getHandle(lumiscalersToken_);
     if (lumiScalers.isValid() && !lumiScalers->empty()) {
       LumiScalersCollection::const_iterator scalit = lumiScalers->begin();
       scal_lumi_ = scalit->instantLumi();
     } else
       scal_lumi_ = -1;
   } else {
-    edm::Handle<OnlineLuminosityRecord> metaData;
-    iEvent.getByToken(metaDataToken_, metaData);
+    edm::Handle<OnlineLuminosityRecord> metaData = iEvent.getHandle(metaDataToken_);
     if (metaData.isValid())
       scal_lumi_ = metaData->instLumi();
     else
       scal_lumi_ = -1;
   }
 
-  edm::Handle<edmNew::DetSetVector<SiPixelCluster> > pixelClusters;
-  iEvent.getByToken(pixelClustersToken_, pixelClusters);
+  edm::Handle<edmNew::DetSetVector<SiPixelCluster> > pixelClusters = iEvent.getHandle(pixelClustersToken_);
   if (pixelClusters.isValid()) {
     TrackerTopology const& tTopo = iSetup.getData(trackerTopologyToken_);
 
@@ -1285,8 +1281,7 @@ void TrackAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSe
   }
 
   if (doDCAPlots_ || doBSPlots_ || doSIPPlots_ || doAllPlots_) {
-    edm::Handle<reco::BeamSpot> recoBeamSpotHandle;
-    iEvent.getByToken(beamSpotToken_, recoBeamSpotHandle);
+    edm::Handle<reco::BeamSpot> recoBeamSpotHandle = iEvent.getHandle(beamSpotToken_);
     const reco::BeamSpot& bs = *recoBeamSpotHandle;
 
     DistanceOfClosestApproachError->Fill(track.dxyError());
@@ -1321,8 +1316,7 @@ void TrackAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSe
   }
 
   if (doDCAPlots_ || doPVPlots_ || doSIPPlots_ || doAllPlots_) {
-    edm::Handle<reco::VertexCollection> recoPrimaryVerticesHandle;
-    iEvent.getByToken(pvToken_, recoPrimaryVerticesHandle);
+    edm::Handle<reco::VertexCollection> recoPrimaryVerticesHandle = iEvent.getHandle(pvToken_);
     if (recoPrimaryVerticesHandle.isValid() && !recoPrimaryVerticesHandle->empty()) {
       const reco::Vertex& pv = (*recoPrimaryVerticesHandle)[0];
 

--- a/DQM/TrackingMonitor/src/TrackEfficiencyMonitor.cc
+++ b/DQM/TrackingMonitor/src/TrackEfficiencyMonitor.cc
@@ -6,7 +6,7 @@
 
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
-//#include "TrackingTools/TransientTrack/interface/TransientTrackBuilder.h"
+#include "TrackingTools/TransientTrack/interface/TransientTrackBuilder.h"
 #include "TrackingTools/Records/interface/TransientTrackRecord.h"
 #include "TrackingTools/TransientTrack/interface/TransientTrack.h"
 #include "MagneticField/Engine/interface/MagneticField.h"
@@ -18,33 +18,30 @@
 #include <string>
 
 // needed to compute the efficiency
-
+#include "CommonTools/UtilAlgos/interface/TFileService.h"
+#include "DataFormats/GeometrySurface/interface/BoundPlane.h"
+#include "DataFormats/GeometrySurface/interface/Cylinder.h"
+#include "DataFormats/GeometrySurface/interface/Plane.h"
+#include "DataFormats/GeometrySurface/interface/RectangularPlaneBounds.h"
+#include "DataFormats/Math/interface/Vector3D.h"
+#include "DataFormats/MuonReco/interface/Muon.h"
 #include "DataFormats/TrackCandidate/interface/TrackCandidate.h"
 #include "DataFormats/TrackCandidate/interface/TrackCandidateCollection.h"
-#include "DataFormats/MuonReco/interface/Muon.h"
+#include "RecoTracker/TkDetLayers/interface/GeometricSearchTracker.h"
+#include "TrackPropagation/SteppingHelixPropagator/interface/SteppingHelixPropagator.h"
 #include "TrackingTools/GeomPropagators/interface/Propagator.h"
+#include "TrackingTools/GeomPropagators/interface/SmartPropagator.h"
 #include "TrackingTools/PatternTools/interface/TwoTrackMinimumDistance.h"
 #include "TrackingTools/Records/interface/TrackingComponentsRecord.h"
 
-#include "TrackPropagation/SteppingHelixPropagator/interface/SteppingHelixPropagator.h"
-#include "TrackingTools/GeomPropagators/interface/SmartPropagator.h"
-#include "DataFormats/Math/interface/Vector3D.h"
-#include "DataFormats/GeometrySurface/interface/Plane.h"
-#include "DataFormats/GeometrySurface/interface/BoundPlane.h"
-#include "DataFormats/GeometrySurface/interface/RectangularPlaneBounds.h"
-
-#include "CommonTools/UtilAlgos/interface/TFileService.h"
-#include "DataFormats/GeometrySurface/interface/Cylinder.h"
-
-#include "RecoTracker/Record/interface/TrackerRecoGeometryRecord.h"
-#include <RecoTracker/TkDetLayers/interface/GeometricSearchTracker.h>
-
-#include "RecoTracker/Record/interface/CkfComponentsRecord.h"
-#include "TrackingTools/Records/interface/TrackingComponentsRecord.h"
-#include "RecoTracker/Record/interface/NavigationSchoolRecord.h"
-
 //-----------------------------------------------------------------------------------
 TrackEfficiencyMonitor::TrackEfficiencyMonitor(const edm::ParameterSet& iConfig)
+    : ttbToken_(esConsumes(edm::ESInputTag("", "TransientTrackBuilder"))),
+      propToken_(esConsumes(edm::ESInputTag("", "SteppingHelixPropagatorAny"))),
+      navToken_(esConsumes(edm::ESInputTag("", "CosmicNavigationSchool"))),
+      gstToken_(esConsumes()),
+      mfToken_(esConsumes()),
+      mtToken_(esConsumes())
 //-----------------------------------------------------------------------------------
 {
   dqmStore_ = edm::Service<DQMStore>().operator->();
@@ -276,27 +273,23 @@ void TrackEfficiencyMonitor::bookHistograms(DQMStore::IBooker& ibooker,
 void TrackEfficiencyMonitor::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
 //-----------------------------------------------------------------------------------
 {
-  edm::Handle<reco::TrackCollection> tkTracks;
-  iEvent.getByToken(theTKTracksToken_, tkTracks);
-  edm::Handle<reco::TrackCollection> staTracks;
-  iEvent.getByToken(theSTATracksToken_, staTracks);
-  edm::ESHandle<NavigationSchool> nav;
-  iSetup.get<NavigationSchoolRecord>().get("CosmicNavigationSchool", nav);
-  iSetup.get<CkfComponentsRecord>().get(measurementTrackerHandle);
+  edm::Handle<reco::TrackCollection> tkTracks = iEvent.getHandle(theTKTracksToken_);
+  edm::Handle<reco::TrackCollection> staTracks = iEvent.getHandle(theSTATracksToken_);
 
   //initialize values
   failedToPropagate = 0;
   nCompatibleLayers = 0;
   findDetLayer = false;
 
-  iSetup.get<TransientTrackRecord>().get("TransientTrackBuilder", theTTrackBuilder);
-  iSetup.get<TrackingComponentsRecord>().get("SteppingHelixPropagatorAny", thePropagator);
-  iSetup.get<IdealMagneticFieldRecord>().get(bField);
-  iSetup.get<TrackerRecoGeometryRecord>().get(theTracker);
+  const NavigationSchool& nav = iSetup.getData(navToken_);
+  measurementTracker = &iSetup.getData(mtToken_);
+  theTTrackBuilder = &iSetup.getData(ttbToken_);
+  thePropagator = &iSetup.getData(propToken_);
+  bField = &iSetup.getData(mfToken_);
+  theTracker = &iSetup.getData(gstToken_);
   theNavigation = new DirectTrackerNavigation(theTracker);
 
-  edm::Handle<edm::View<reco::Muon> > muons;
-  iEvent.getByToken(muonToken_, muons);
+  edm::Handle<edm::View<reco::Muon> > muons = iEvent.getHandle(muonToken_);
   if (!muons.isValid())
     return;
   for (edm::View<reco::Muon>::const_iterator muon = muons->begin(); muon != muons->end(); ++muon) {
@@ -347,10 +340,10 @@ void TrackEfficiencyMonitor::analyze(const edm::Event& iEvent, const edm::EventS
       }
 
       if (isGoodMuon)
-        testTrackerTracks(tkTracks, staTracks, *nav.product());
+        testTrackerTracks(tkTracks, staTracks, nav);
 
     } else if (staTracks->size() == 1 || staTracks->size() == 2)
-      testTrackerTracks(tkTracks, staTracks, *nav.product());
+      testTrackerTracks(tkTracks, staTracks, nav);
   }
 
   if (!trackEfficiency_ && tkTracks->size() == 1) {
@@ -568,7 +561,7 @@ bool TrackEfficiencyMonitor::trackerAcceptance(TrajectoryStateOnSurface theTSOS,
   //Propagator*  theTmpPropagator = new SteppingHelixPropagator(&*bField,anyDirection);
 
   //Propagator*  theTmpPropagator = &*thePropagator;
-  Propagator* theTmpPropagator = &*thePropagator->clone();
+  Propagator* theTmpPropagator = thePropagator->clone();
 
   if (theTSOS.globalPosition().y() < 0)
     theTmpPropagator->setPropagationDirection(oppositeToMomentum);
@@ -610,7 +603,7 @@ int TrackEfficiencyMonitor::compatibleLayers(const NavigationSchool& navigationS
   // check the number of compatible layers
   //---------------------------------------------------
 
-  std::vector<const BarrelDetLayer*> barrelTOBLayers = measurementTrackerHandle->geometricSearchTracker()->tobLayers();
+  std::vector<const BarrelDetLayer*> barrelTOBLayers = measurementTracker->geometricSearchTracker()->tobLayers();
 
   unsigned int layers = 0;
   for (unsigned int k = 0; k < barrelTOBLayers.size(); k++) {
@@ -618,7 +611,7 @@ int TrackEfficiencyMonitor::compatibleLayers(const NavigationSchool& navigationS
 
     //Propagator*  theTmpPropagator = new SteppingHelixPropagator(&*bField,anyDirection);
 
-    Propagator* theTmpPropagator = &*thePropagator->clone();
+    Propagator* theTmpPropagator = thePropagator->clone();
     theTmpPropagator->setPropagationDirection(alongMomentum);
 
     TrajectoryStateOnSurface startTSOS = theTmpPropagator->propagate(*theTSOS.freeState(), firstLay->surface());
@@ -678,7 +671,7 @@ std::pair<TrajectoryStateOnSurface, const DetLayer*> TrackEfficiencyMonitor::fin
 {
   //Propagator*  theTmpPropagator = new SteppingHelixPropagator(&*bField,anyDirection);
 
-  Propagator* theTmpPropagator = &*thePropagator->clone();
+  Propagator* theTmpPropagator = thePropagator->clone();
   theTmpPropagator->setPropagationDirection(alongMomentum);
 
   std::vector<const DetLayer*>::const_iterator itl;

--- a/DQM/TrackingMonitor/src/TrackingMonitor.cc
+++ b/DQM/TrackingMonitor/src/TrackingMonitor.cc
@@ -747,15 +747,13 @@ void TrackingMonitor::analyze(const edm::Event& iEvent, const edm::EventSetup& i
   std::string Folder = MEFolderName.substr(0, 2);
   float lumi = -1.;
   if (forceSCAL_) {
-    edm::Handle<LumiScalersCollection> lumiScalers;
-    iEvent.getByToken(lumiscalersToken_, lumiScalers);
+    edm::Handle<LumiScalersCollection> lumiScalers = iEvent.getHandle(lumiscalersToken_);
     if (lumiScalers.isValid() && !lumiScalers->empty()) {
       LumiScalersCollection::const_iterator scalit = lumiScalers->begin();
       lumi = scalit->instantLumi();
     }
   } else {
-    edm::Handle<OnlineLuminosityRecord> metaData;
-    iEvent.getByToken(metaDataToken_, metaData);
+    edm::Handle<OnlineLuminosityRecord> metaData = iEvent.getHandle(metaDataToken_);
     if (metaData.isValid())
       lumi = metaData->instLumi();
   }
@@ -772,12 +770,10 @@ void TrackingMonitor::analyze(const edm::Event& iEvent, const edm::EventSetup& i
     NumberEventsOfVsBX->Fill(bx);
 
   // get the track collection
-  edm::Handle<edm::View<reco::Track> > trackHandle;
-  iEvent.getByToken(trackToken_, trackHandle);
+  edm::Handle<edm::View<reco::Track> > trackHandle = iEvent.getHandle(trackToken_);
 
   int numberOfTracks_den = 0;
-  edm::Handle<edm::View<reco::Track> > allTrackHandle;
-  iEvent.getByToken(allTrackToken_, allTrackHandle);
+  edm::Handle<edm::View<reco::Track> > allTrackHandle = iEvent.getHandle(allTrackToken_);
   if (allTrackHandle.isValid()) {
     for (edm::View<reco::Track>::const_iterator track = allTrackHandle->begin(); track != allTrackHandle->end();
          ++track) {
@@ -786,8 +782,7 @@ void TrackingMonitor::analyze(const edm::Event& iEvent, const edm::EventSetup& i
     }
   }
 
-  edm::Handle<reco::VertexCollection> pvHandle;
-  iEvent.getByToken(pvSrcToken_, pvHandle);
+  edm::Handle<reco::VertexCollection> pvHandle = iEvent.getHandle(pvSrcToken_);
   reco::Vertex const* pv0 = nullptr;
   if (pvHandle.isValid()) {
     pv0 = &pvHandle->front();
@@ -894,21 +889,18 @@ void TrackingMonitor::analyze(const edm::Event& iEvent, const edm::EventSetup& i
       MagneticField const& theMF = iSetup.getData(magneticFieldToken_);
 
       // get the candidate collection
-      edm::Handle<TrackCandidateCollection> theTCHandle;
-      iEvent.getByToken(trackCandidateToken_, theTCHandle);
+      edm::Handle<TrackCandidateCollection> theTCHandle = iEvent.getHandle(trackCandidateToken_);
       const TrackCandidateCollection& theTCCollection = *theTCHandle;
 
       if (theTCHandle.isValid()) {
         // get the beam spot
-        edm::Handle<reco::BeamSpot> recoBeamSpotHandle;
-        iEvent.getByToken(bsSrcToken_, recoBeamSpotHandle);
+        edm::Handle<reco::BeamSpot> recoBeamSpotHandle = iEvent.getHandle(bsSrcToken_);
         const reco::BeamSpot& bs = *recoBeamSpotHandle;
 
         NumberOfTrackCandidates->Fill(theTCCollection.size());
 
         // get the seed collection
-        edm::Handle<edm::View<TrajectorySeed> > seedHandle;
-        iEvent.getByToken(seedToken_, seedHandle);
+        edm::Handle<edm::View<TrajectorySeed> > seedHandle = iEvent.getHandle(seedToken_);
         const edm::View<TrajectorySeed>& seedCollection = *seedHandle;
         if (seedHandle.isValid() && !seedCollection.empty())
           FractionCandidatesOverSeeds->Fill(double(theTCCollection.size()) / double(seedCollection.size()));
@@ -927,15 +919,13 @@ void TrackingMonitor::analyze(const edm::Event& iEvent, const edm::EventSetup& i
         std::vector<const MVACollection*> mvaCollections;
         std::vector<const QualityMaskCollection*> qualityMaskCollections;
 
-        edm::Handle<edm::View<reco::Track> > htracks;
-        iEvent.getByToken(mvaTrackToken_, htracks);
+        edm::Handle<edm::View<reco::Track> > htracks = iEvent.getHandle(mvaTrackToken_);
 
         edm::Handle<MVACollection> hmva;
         edm::Handle<QualityMaskCollection> hqual;
         for (const auto& tokenTpl : mvaQualityTokens_) {
-          iEvent.getByToken(std::get<0>(tokenTpl), hmva);
-          iEvent.getByToken(std::get<1>(tokenTpl), hqual);
-
+          hmva = iEvent.getHandle(std::get<0>(tokenTpl));
+          hqual = iEvent.getHandle(std::get<1>(tokenTpl));
           mvaCollections.push_back(hmva.product());
           qualityMaskCollections.push_back(hqual.product());
         }
@@ -947,8 +937,7 @@ void TrackingMonitor::analyze(const edm::Event& iEvent, const edm::EventSetup& i
 
     if (doAllSeedPlots || doSeedNumberPlot || doSeedVsClusterPlot || runTrackBuildingAnalyzerForSeed) {
       // get the seed collection
-      edm::Handle<edm::View<TrajectorySeed> > seedHandle;
-      iEvent.getByToken(seedToken_, seedHandle);
+      edm::Handle<edm::View<TrajectorySeed> > seedHandle = iEvent.getHandle(seedToken_);
 
       // fill the seed info
       if (seedHandle.isValid()) {
@@ -969,8 +958,7 @@ void TrackingMonitor::analyze(const edm::Event& iEvent, const edm::EventSetup& i
         }
 
         if (doAllSeedPlots || runTrackBuildingAnalyzerForSeed) {
-          edm::Handle<std::vector<SeedStopInfo> > stopHandle;
-          iEvent.getByToken(seedStopInfoToken_, stopHandle);
+          edm::Handle<std::vector<SeedStopInfo> > stopHandle = iEvent.getHandle(seedStopInfoToken_);
           const auto& seedStopInfo = *stopHandle;
 
           if (seedStopInfo.size() == seedCollection.size()) {
@@ -979,8 +967,7 @@ void TrackingMonitor::analyze(const edm::Event& iEvent, const edm::EventSetup& i
             MagneticField const& theMF = iSetup.getData(magneticFieldToken_);
 
             // get the beam spot
-            edm::Handle<reco::BeamSpot> recoBeamSpotHandle;
-            iEvent.getByToken(bsSrcToken_, recoBeamSpotHandle);
+            edm::Handle<reco::BeamSpot> recoBeamSpotHandle = iEvent.getHandle(bsSrcToken_);
             const reco::BeamSpot& bs = *recoBeamSpotHandle;
 
             TransientTrackingRecHitBuilder const& theTTRHBuilder = iSetup.getData(transientTrackingRecHitBuilderToken_);
@@ -1004,15 +991,13 @@ void TrackingMonitor::analyze(const edm::Event& iEvent, const edm::EventSetup& i
     // plots for tracking regions
     if (doRegionPlots) {
       if (!regionToken_.isUninitialized()) {
-        edm::Handle<edm::OwnVector<TrackingRegion> > hregions;
-        iEvent.getByToken(regionToken_, hregions);
+        edm::Handle<edm::OwnVector<TrackingRegion> > hregions = iEvent.getHandle(regionToken_);
         const auto& regions = *hregions;
         NumberOfTrackingRegions->Fill(regions.size());
 
         theTrackBuildingAnalyzer->analyze(regions);
       } else if (!regionLayerSetsToken_.isUninitialized()) {
-        edm::Handle<TrackingRegionsSeedingLayerSets> hregions;
-        iEvent.getByToken(regionLayerSetsToken_, hregions);
+        edm::Handle<TrackingRegionsSeedingLayerSets> hregions = iEvent.getHandle(regionLayerSetsToken_);
         const auto& regions = *hregions;
         NumberOfTrackingRegions->Fill(regions.regionsSize());
 
@@ -1020,8 +1005,7 @@ void TrackingMonitor::analyze(const edm::Event& iEvent, const edm::EventSetup& i
       }
 
       if (doRegionCandidatePlots) {
-        edm::Handle<reco::CandidateView> hcandidates;
-        iEvent.getByToken(regionCandidateToken_, hcandidates);
+        edm::Handle<reco::CandidateView> hcandidates = iEvent.getHandle(regionCandidateToken_);
         theTrackBuildingAnalyzer->analyze(*hcandidates);
       }
     }
@@ -1155,10 +1139,8 @@ void TrackingMonitor::setNclus(const edm::Event& iEvent, std::vector<int>& array
   int ncluster_pix = -1;
   int ncluster_strip = -1;
 
-  edm::Handle<edmNew::DetSetVector<SiStripCluster> > strip_clusters;
-  iEvent.getByToken(stripClustersToken_, strip_clusters);
-  edm::Handle<edmNew::DetSetVector<SiPixelCluster> > pixel_clusters;
-  iEvent.getByToken(pixelClustersToken_, pixel_clusters);
+  edm::Handle<edmNew::DetSetVector<SiStripCluster> > strip_clusters = iEvent.getHandle(stripClustersToken_);
+  edm::Handle<edmNew::DetSetVector<SiPixelCluster> > pixel_clusters = iEvent.getHandle(pixelClustersToken_);
 
   if (strip_clusters.isValid() && pixel_clusters.isValid()) {
     ncluster_pix = (*pixel_clusters).dataSize();

--- a/DQM/TrackingMonitor/src/TrackingRecoMaterialAnalyser.cc
+++ b/DQM/TrackingMonitor/src/TrackingRecoMaterialAnalyser.cc
@@ -176,14 +176,13 @@ void TrackingRecoMaterialAnalyser::analyze(const edm::Event &event, const edm::E
 
   refitter_.setServices(setup);
 
-  Handle<TrackCollection> tracks;
-  Handle<VertexCollection> vertices;
+  Handle<TrackCollection> tracks = event.getHandle(tracksToken_);
+  Handle<VertexCollection> vertices = event.getHandle(verticesToken_);
 
   // Get the TrackerTopology
   const TrackerTopology *const tTopo = &setup.getData(tTopoToken_);
 
   // Get Tracks
-  event.getByToken(tracksToken_, tracks);
   if (!tracks.isValid() || tracks->empty()) {
     LogInfo("TrackingRecoMaterialAnalyser") << "Invalid or empty track collection" << endl;
     return;
@@ -196,15 +195,13 @@ void TrackingRecoMaterialAnalyser::analyze(const edm::Event &event, const edm::E
   };
 
   // Get BeamSpot
-  Handle<BeamSpot> beamSpot;
-  event.getByToken(beamspotToken_, beamSpot);
+  Handle<BeamSpot> beamSpot = event.getHandle(beamspotToken_);
   // Bail out if missing
   if (!beamSpot.isValid())
     return;
 
   reco::Vertex::Point pv(beamSpot->position());
   if (usePV_) {
-    event.getByToken(verticesToken_, vertices);
     if (vertices.isValid() && !vertices->empty()) {
       // Since we need to use eta and Z information from the tracks, in
       // order not to have the reco material distribution washed out due

--- a/DQM/TrackingMonitor/src/V0Monitor.cc
+++ b/DQM/TrackingMonitor/src/V0Monitor.cc
@@ -237,29 +237,25 @@ void V0Monitor::analyze(edm::Event const& iEvent, edm::EventSetup const& iSetup)
 
   float lumi = -1.;
   if (forceSCAL_) {
-    edm::Handle<LumiScalersCollection> lumiScalers;
-    iEvent.getByToken(lumiscalersToken_, lumiScalers);
+    edm::Handle<LumiScalersCollection> lumiScalers = iEvent.getHandle(lumiscalersToken_);
     if (lumiScalers.isValid() && !lumiScalers->empty()) {
       LumiScalersCollection::const_iterator scalit = lumiScalers->begin();
       lumi = scalit->instantLumi();
     }
   } else {
-    edm::Handle<OnlineLuminosityRecord> metaData;
-    iEvent.getByToken(metaDataToken_, metaData);
+    edm::Handle<OnlineLuminosityRecord> metaData = iEvent.getHandle(metaDataToken_);
     if (metaData.isValid())
       lumi = metaData->instLumi();
   }
 
   n_vs_lumi_->Fill(lumi);
 
-  edm::Handle<reco::BeamSpot> beamspotHandle;
-  iEvent.getByToken(bsToken_, beamspotHandle);
+  edm::Handle<reco::BeamSpot> beamspotHandle = iEvent.getHandle(bsToken_);
   reco::BeamSpot const* bs = nullptr;
   if (beamspotHandle.isValid())
     bs = &(*beamspotHandle);
 
-  edm::Handle<reco::VertexCollection> pvHandle;
-  iEvent.getByToken(pvToken_, pvHandle);
+  edm::Handle<reco::VertexCollection> pvHandle = iEvent.getHandle(pvToken_);
   reco::Vertex const* pv = nullptr;
   size_t nPV = 0;
   if (pvHandle.isValid()) {
@@ -286,8 +282,7 @@ void V0Monitor::analyze(edm::Event const& iEvent, edm::EventSetup const& iSetup)
   float nLS = static_cast<float>(iEvent.id().luminosityBlock());
   n_vs_LS_->Fill(nLS);
 
-  edm::Handle<reco::VertexCompositeCandidateCollection> v0Handle;
-  iEvent.getByToken(v0Token_, v0Handle);
+  edm::Handle<reco::VertexCompositeCandidateCollection> v0Handle = iEvent.getHandle(v0Token_);
   int n = (v0Handle.isValid() ? v0Handle->size() : -1);
   v0_N_->Fill(n);
   v0_N_vs_BX_->Fill(bx, n);

--- a/DQM/TrackingMonitor/src/VertexMonitor.cc
+++ b/DQM/TrackingMonitor/src/VertexMonitor.cc
@@ -90,8 +90,7 @@ void VertexMonitor::analyze(const edm::Event& iEvent, const edm::EventSetup& iSe
 
   size_t totalNumPV = 0;
   size_t totalNumBADndofPV = 0;
-  edm::Handle<reco::VertexCollection> pvHandle;
-  iEvent.getByToken(pvToken_, pvHandle);
+  edm::Handle<reco::VertexCollection> pvHandle = iEvent.getHandle(pvToken_);
   if (pvHandle.isValid()) {
     totalNumPV = pvHandle->size();
     //      std::cout << "totalNumPV : " << totalNumPV << std::endl;
@@ -110,8 +109,7 @@ void VertexMonitor::analyze(const edm::Event& iEvent, const edm::EventSetup& iSe
   }
 
   size_t totalNumGoodPV = 0;
-  edm::Handle<reco::VertexCollection> selpvHandle;
-  iEvent.getByToken(selpvToken_, selpvHandle);
+  edm::Handle<reco::VertexCollection> selpvHandle = iEvent.getHandle(selpvToken_);
   if (selpvHandle.isValid())
     totalNumGoodPV = selpvHandle->size();
   else

--- a/DQM/TrackingMonitor/src/dEdxAnalyzer.cc
+++ b/DQM/TrackingMonitor/src/dEdxAnalyzer.cc
@@ -149,14 +149,12 @@ void dEdxAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSet
     return;
 
   if (doDeDxPlots_ || doAllPlots_) {
-    edm::Handle<reco::TrackCollection> trackCollectionHandle;
-    iEvent.getByToken(trackToken_, trackCollectionHandle);
+    edm::Handle<reco::TrackCollection> trackCollectionHandle = iEvent.getHandle(trackToken_);
     if (!trackCollectionHandle.isValid())
       return;
 
     for (unsigned int i = 0; i < dEdxInputList_.size(); i++) {
-      edm::Handle<reco::DeDxDataValueMap> dEdxObjectHandle;
-      iEvent.getByToken(dEdxTokenList_[i], dEdxObjectHandle);
+      edm::Handle<reco::DeDxDataValueMap> dEdxObjectHandle = iEvent.getHandle(dEdxTokenList_[i]);
       if (!dEdxObjectHandle.isValid())
         continue;
       const edm::ValueMap<reco::DeDxData> dEdxColl = *dEdxObjectHandle.product();

--- a/DQM/TrackingMonitor/src/dEdxHitAnalyzer.cc
+++ b/DQM/TrackingMonitor/src/dEdxHitAnalyzer.cc
@@ -131,14 +131,12 @@ void dEdxHitAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& i
     return;
 
   if (doDeDxPlots_ || doAllPlots_) {
-    edm::Handle<reco::TrackCollection> trackCollectionHandle;
-    iEvent.getByToken(trackToken_, trackCollectionHandle);
+    edm::Handle<reco::TrackCollection> trackCollectionHandle = iEvent.getHandle(trackToken_);
     if (!trackCollectionHandle.isValid())
       return;
 
     for (unsigned int i = 0; i < dEdxInputList_.size(); i++) {
-      edm::Handle<reco::DeDxHitInfoAss> dEdxObjectHandle;
-      iEvent.getByToken(dEdxTokenList_[i], dEdxObjectHandle);
+      edm::Handle<reco::DeDxHitInfoAss> dEdxObjectHandle = iEvent.getHandle(dEdxTokenList_[i]);
       if (!dEdxObjectHandle.isValid())
         continue;
 


### PR DESCRIPTION
#### PR description:

Part of #31061.
The main purpose of this PR is to migrate the package DQM/TrackingMonitor to `esConsumes`. 
I profit of this PR to remove also the deprecated calls to `event::getByToken()` in favour of `getHandle`. 

#### PR validation:

It compiles

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Not a backport, no backport needed.

