### PR TITLE
Add maxRuntime to InputSource so it would stop processing events after specified number of seconds

### DIFF
--- a/FWCore/Framework/interface/InputSource.h
+++ b/FWCore/Framework/interface/InputSource.h
@@ -384,7 +384,18 @@ namespace edm {
       }
       return false;
     }
-    bool limitReached() const { return eventLimitReached() || lumiLimitReached(); }
+    bool timeLimitReached() const {
+      if (maxRuntime_ <= 0) {
+        return false;
+      }
+      auto end = std::chrono::steady_clock::now();
+      auto elapsed = end - processingStart_;
+      if (std::chrono::duration_cast<std::chrono::seconds>(elapsed).count() > maxRuntime_) {
+        return true;
+      }
+      return false;
+    }
+    bool limitReached() const { return eventLimitReached() || lumiLimitReached() || timeLimitReached(); }
     virtual ItemType getNextItemType() = 0;
     ItemType nextItemType_();
     virtual std::shared_ptr<RunAuxiliary> readRunAuxiliary_() = 0;
@@ -414,6 +425,7 @@ namespace edm {
     int remainingLumis_;
     int readCount_;
     int maxSecondsUntilRampdown_;
+    int maxRuntime_;
     std::chrono::time_point<std::chrono::steady_clock> processingStart_;
     ProcessingMode processingMode_;
     ModuleDescription const moduleDescription_;

--- a/FWCore/Framework/interface/InputSourceDescription.h
+++ b/FWCore/Framework/interface/InputSourceDescription.h
@@ -34,6 +34,7 @@ namespace edm {
                            int maxEvents,
                            int maxLumis,
                            int maxSecondsUntilRampdown,
+                           int maxRuntime,
                            PreallocationConfiguration const& allocations)
         : moduleDescription_(md),
           productRegistry_(preg),
@@ -43,6 +44,7 @@ namespace edm {
           maxEvents_(maxEvents),
           maxLumis_(maxLumis),
           maxSecondsUntilRampdown_(maxSecondsUntilRampdown),
+          maxRuntime_(maxRuntime),
           allocations_(&allocations) {}
 
     ModuleDescription moduleDescription_;
@@ -53,6 +55,7 @@ namespace edm {
     int maxEvents_;
     int maxLumis_;
     int maxSecondsUntilRampdown_;
+    int maxRuntime_;
     PreallocationConfiguration const* allocations_;
   };
 }  // namespace edm

--- a/FWCore/Framework/src/CommonParams.h
+++ b/FWCore/Framework/src/CommonParams.h
@@ -15,7 +15,10 @@ namespace edm {
     CommonParams() : maxEventsInput_(), maxLumisInput_(), maxSecondsUntilRampdown_(), maxRuntime_() {}
 
     CommonParams(int maxEvents, int maxLumis, int maxSecondsUntilRampdown, int maxRuntime)
-        : maxEventsInput_(maxEvents), maxLumisInput_(maxLumis), maxSecondsUntilRampdown_(maxSecondsUntilRampdown), maxRuntime_(maxRuntime) {}
+        : maxEventsInput_(maxEvents),
+          maxLumisInput_(maxLumis),
+          maxSecondsUntilRampdown_(maxSecondsUntilRampdown),
+          maxRuntime_(maxRuntime) {}
 
     int maxEventsInput_;
     int maxLumisInput_;

--- a/FWCore/Framework/src/CommonParams.h
+++ b/FWCore/Framework/src/CommonParams.h
@@ -12,14 +12,15 @@ namespace edm {
   //
 
   struct CommonParams {
-    CommonParams() : maxEventsInput_(), maxLumisInput_(), maxSecondsUntilRampdown_() {}
+    CommonParams() : maxEventsInput_(), maxLumisInput_(), maxSecondsUntilRampdown_(), maxRuntime_() {}
 
-    CommonParams(int maxEvents, int maxLumis, int maxSecondsUntilRampdown)
-        : maxEventsInput_(maxEvents), maxLumisInput_(maxLumis), maxSecondsUntilRampdown_(maxSecondsUntilRampdown) {}
+    CommonParams(int maxEvents, int maxLumis, int maxSecondsUntilRampdown, int maxRuntime)
+        : maxEventsInput_(maxEvents), maxLumisInput_(maxLumis), maxSecondsUntilRampdown_(maxSecondsUntilRampdown), maxRuntime_(maxRuntime) {}
 
     int maxEventsInput_;
     int maxLumisInput_;
     int maxSecondsUntilRampdown_;
+    int maxRuntime_;
   };  // struct CommonParams
 }  // namespace edm
 

--- a/FWCore/Framework/src/EventProcessor.cc
+++ b/FWCore/Framework/src/EventProcessor.cc
@@ -170,6 +170,7 @@ namespace edm {
                                   common.maxEventsInput_,
                                   common.maxLumisInput_,
                                   common.maxSecondsUntilRampdown_,
+                                  common.maxRuntime_,
                                   allocations);
 
     areg->preSourceConstructionSignal_(md);
@@ -359,7 +360,7 @@ namespace edm {
     bool const hasSubProcesses = !subProcessVParameterSet.empty();
 
     // Validates the parameters in the 'options', 'maxEvents', 'maxLuminosityBlocks',
-    // and 'maxSecondsUntilRampdown' top level parameter sets. Default values are also
+    // 'maxSecondsUntilRampdown' and 'maxRuntime' top level parameter sets. Default values are also
     // set in here if the parameters were not explicitly set.
     validateTopLevelParameterSets(parameterSet.get());
 

--- a/FWCore/Framework/src/InputSource.cc
+++ b/FWCore/Framework/src/InputSource.cc
@@ -51,6 +51,7 @@ namespace edm {
         remainingLumis_(maxLumis_),
         readCount_(0),
         maxSecondsUntilRampdown_(desc.maxSecondsUntilRampdown_),
+        maxRuntime_(desc.maxRuntime_),
         processingMode_(RunsLumisAndEvents),
         moduleDescription_(desc.moduleDescription_),
         productRegistry_(desc.productRegistry_),
@@ -72,7 +73,7 @@ namespace edm {
       statusfilename << "source_" << getpid();
       statusFileName_ = statusfilename.str();
     }
-    if (maxSecondsUntilRampdown_ > 0) {
+    if (maxSecondsUntilRampdown_ > 0 || maxRuntime_ > 0) {
       processingStart_ = std::chrono::steady_clock::now();
     }
 
@@ -165,6 +166,8 @@ namespace edm {
           state_ = IsStop;
         }
       }
+    } else if (timeLimitReached()) {
+      state_ = IsStop;
     } else {
       ItemType newState = nextItemType_();
       if (newState == IsStop) {

--- a/FWCore/Framework/src/ScheduleItems.cc
+++ b/FWCore/Framework/src/ScheduleItems.cc
@@ -123,7 +123,8 @@ namespace edm {
     auto common = std::make_shared<CommonParams>(
         parameterSet.getUntrackedParameterSet("maxEvents").getUntrackedParameter<int>("input"),
         parameterSet.getUntrackedParameterSet("maxLuminosityBlocks").getUntrackedParameter<int>("input"),
-        parameterSet.getUntrackedParameterSet("maxSecondsUntilRampdown").getUntrackedParameter<int>("input"));
+        parameterSet.getUntrackedParameterSet("maxSecondsUntilRampdown").getUntrackedParameter<int>("input"),
+        parameterSet.getUntrackedParameterSet("maxRuntime").getUntrackedParameter<int>("input"));
     return common;
   }
 

--- a/FWCore/ParameterSet/bin/edmPluginHelp.cpp
+++ b/FWCore/ParameterSet/bin/edmPluginHelp.cpp
@@ -195,10 +195,15 @@ namespace {
     } else if (psetName == "maxSecondsUntilRampdown") {
       os << "\nDescription of \'maxSecondsUntilRampdown\' top level ParameterSet\n\n";
       edm::fillMaxSecondsUntilRampdownDescription(description);
+
+    } else if (psetName == "maxRuntine") {
+      os << "\nDescription of \'maxRuntime\' top level ParameterSet\n\n";
+      edm::fillMaxRuntimeDescription(description);
+
     } else {
       throw cms::Exception("CommandLineArgument")
           << "Unrecognized name for top level parameter set. "
-          << "Allowed values are 'options', 'maxEvents', 'maxLuminosityBlocks', and 'maxSecondsUntilRampdown'";
+          << "Allowed values are 'options', 'maxEvents', 'maxLuminosityBlocks', 'maxSecondsUntilRampdown' and 'maxRuntime'";
     }
 
     edm::DocFormatHelper dfh;
@@ -253,7 +258,7 @@ int main(int argc, char** argv) try {
       kTopLevelCommandOpt,
       boost::program_options::value<std::string>(),
       "print only the description for the top level parameter set with this name. Allowed names are 'options', "
-      "'maxEvents', 'maxLuminosityBlocks', and 'maxSecondsUntilRampdown'.");
+      "'maxEvents', 'maxLuminosityBlocks', 'maxSecondsUntilRampdown' and 'maxRuntime'.");
 
   boost::program_options::variables_map vm;
   try {

--- a/FWCore/ParameterSet/bin/edmPluginHelp.cpp
+++ b/FWCore/ParameterSet/bin/edmPluginHelp.cpp
@@ -203,7 +203,8 @@ namespace {
     } else {
       throw cms::Exception("CommandLineArgument")
           << "Unrecognized name for top level parameter set. "
-          << "Allowed values are 'options', 'maxEvents', 'maxLuminosityBlocks', 'maxSecondsUntilRampdown' and 'maxRuntime'";
+          << "Allowed values are 'options', 'maxEvents', 'maxLuminosityBlocks', 'maxSecondsUntilRampdown' and "
+             "'maxRuntime'";
     }
 
     edm::DocFormatHelper dfh;

--- a/FWCore/ParameterSet/interface/validateTopLevelParameterSets.h
+++ b/FWCore/ParameterSet/interface/validateTopLevelParameterSets.h
@@ -11,5 +11,6 @@ namespace edm {
   void fillMaxEventsDescription(ParameterSetDescription& description);
   void fillMaxLuminosityBlocksDescription(ParameterSetDescription& description);
   void fillMaxSecondsUntilRampdownDescription(ParameterSetDescription& description);
+  void fillMaxRuntimeDescription(ParameterSetDescription& description);
 }  // namespace edm
 #endif

--- a/FWCore/ParameterSet/src/validateTopLevelParameterSets.cc
+++ b/FWCore/ParameterSet/src/validateTopLevelParameterSets.cc
@@ -97,7 +97,8 @@ namespace edm {
   void validateTopLevelParameterSets(ParameterSet* processParameterSet) {
     std::string processName = processParameterSet->getParameter<std::string>("@process_name");
 
-    std::vector<std::string> psetNames{"options", "maxEvents", "maxLuminosityBlocks", "maxSecondsUntilRampdown", "maxRuntime"};
+    std::vector<std::string> psetNames{
+        "options", "maxEvents", "maxLuminosityBlocks", "maxSecondsUntilRampdown", "maxRuntime"};
 
     for (auto const& psetName : psetNames) {
       bool isTracked{false};

--- a/FWCore/ParameterSet/src/validateTopLevelParameterSets.cc
+++ b/FWCore/ParameterSet/src/validateTopLevelParameterSets.cc
@@ -90,10 +90,14 @@ namespace edm {
     description.addUntracked<int>("input", -1)->setComment("Default of -1 implies no limit.");
   }
 
+  void fillMaxRuntimeDescription(ParameterSetDescription& description) {
+    description.addUntracked<int>("input", -1)->setComment("Default of -1 implies no limit.");
+  }
+
   void validateTopLevelParameterSets(ParameterSet* processParameterSet) {
     std::string processName = processParameterSet->getParameter<std::string>("@process_name");
 
-    std::vector<std::string> psetNames{"options", "maxEvents", "maxLuminosityBlocks", "maxSecondsUntilRampdown"};
+    std::vector<std::string> psetNames{"options", "maxEvents", "maxLuminosityBlocks", "maxSecondsUntilRampdown", "maxRuntime"};
 
     for (auto const& psetName : psetNames) {
       bool isTracked{false};
@@ -118,6 +122,8 @@ namespace edm {
         fillMaxLuminosityBlocksDescription(description);
       } else if (psetName == "maxSecondsUntilRampdown") {
         fillMaxSecondsUntilRampdownDescription(description);
+      } else if (psetName == "maxRuntime") {
+        fillMaxRuntimeDescription(description);
       }
 
       try {


### PR DESCRIPTION
#### PR description:

##### Motivation:

This PR is aimed at improving Monte Carlo request validation before submitting to central production. We (PdmV) run an 8h job in HTCondor to measure time/event, size/event, required memory (PeakValueRSS) and filter efficiency as well as checking if the job finishes without crashing. Measured values are then passed to computing during request submission. In order to fit as many events as possible in the 8h, we ask users to give us an time/event estimate that we then use to calculate number of events that we can fit in 8h (roughly 28800 seconds / time per event = events to run in validation). Even with 20% "safety margin", the jobs often run out of 8h limit and are killed by HTCondor due to time/event underestimation. User gets a message that the validation was killed, so time/event has to be adjusted and validation retried. This is wasteful as we are not testing whether the user supplied a correct time/event, but we are interested in getting that value from the job report after running as many events as we can in those 8h. For example, if according to user given time/event we expected 10k events, but only 6k managed to fit in the time slot, it is still good enough and we would gladly use values from the report and consider this validation a "pass" (currently job is abruptly killed by HTCondor, so we don't get the report).

##### Changes:

This PR adds a new variable, called `maxRuntime` to the FWCore's InputSource. It represents a maximum number of seconds for the input source to keep on providing events. Number of elapsed seconds is checked after every processed event and if that value is higher than `maxRuntime`, the `state_` is set to `IsStop`, just like `eventLimitReached()` or `lumiLimitReached()`. The technical implementation is almost identical to the `maxSecondsUntilRampdown`, however, the `maxSecondsUntilRampdown` is not sufficiently "accurate" for us as this check is performed only after lumi or run end ([according to the comment](https://github.com/cms-sw/cmssw/blob/af3125e0a3f5f6a654666f00b2b777be0ac0de3f/FWCore/Framework/src/InputSource.cc#L156)), not after every event.

Relevant `maxSecondsUntilRampdown` code is [here](https://github.com/cms-sw/cmssw/blob/3e2932932c1ad48f0dd4878144cc2888a914901f/FWCore/Framework/interface/InputSource.h#L373) and [here](https://github.com/cms-sw/cmssw/blob/af3125e0a3f5f6a654666f00b2b777be0ac0de3f/FWCore/Framework/src/InputSource.cc#L154).

##### Notes: 

Such premature finish upsets `externalLHEProducer` and it throws a ["Event loop is over, but there are still lhe events to process." exception](https://github.com/cms-sw/cmssw/blob/b3d43f277097d61e247c4c8c327ab515f64acd2d/GeneratorInterface/LHEInterface/plugins/ExternalLHEProducer.cc#L333).

There is a small running time "offset" of about 20 seconds, i.e. if `maxRuntime` is set to 600, job report will have about 620 seconds of total job time. This should not be an issue as long as this is more or less constant, i.e. we would set 7.5h as `maxRuntime` for our 8h job.

#### PR validation:

 - Successfully `cmsRun` a couple of wmLHEGS, GEN and GS configs
 - `scram b runtests` tests succeeded after rebuilding `FWCore` and `IOPool`

<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->

#### If this PR is a backport please specify the original PR and why you need to backport that PR:

Not a backport, but backports will be needed.