### PR TITLE
re-introduce IORawData/CSCCommissioning module for CSC data files conversion

### DIFF
--- a/IORawData/CSCCommissioning/BuildFile.xml
+++ b/IORawData/CSCCommissioning/BuildFile.xml
@@ -1,0 +1,5 @@
+<use name="FWCore/Framework"/>
+<use name="FWCore/ParameterSet"/>
+<use name="DataFormats/FEDRawData"/>
+<use name="DataFormats/Provenance"/>
+<flags   EDM_PLUGIN="1"/>

--- a/IORawData/CSCCommissioning/doc/html/details.html
+++ b/IORawData/CSCCommissioning/doc/html/details.html
@@ -1,0 +1,69 @@
+<html>
+<body>
+Technical details on <font size=+2><tt>CSCFileReader</tt></font>:
+<br><br>
+To build FED buffers <tt>CSCFileReader</tt> merges DDU data streams and
+constructs fake DCC Headers and DCC Trailers for FED buffers.
+<br>
+<br>
+For every RUI stream module instantiates <tt>FileReaderDDU</tt> class inherited from our on-line software (in TriDAS).
+<br>
+<br>
+<tt>FileReaderDDU</tt> reads file with DDU data, searches for <b>DDU Headers</b>
+and <b>DDU Trailers</b>, and finally returns event buffer. It also handles data
+corruptions.
+<br><br>
+<tt>FileReaderDDU</tt> continuously reads DDU data in blocks of definite length.
+Each time it passes through block, it searches for <b>DDU Header</b> or <b>DDU
+Trailer</b>. In same time it composes event buffer. Once it find <b>DDU Trailer</b>
+it sets an ``end mark'' in current data block and returns event buffer
+with event <i>status flag</i>, which tells that we have <i>DDU Trailer</i> in this
+event. On next call it continues passing through data block starting from
+``end mark''. If it finds <b>DDU Header</b> pattern in first two DDU words it
+sets <i>status flag</i> accordingly and goes further until it finds <b>DDU Trailer</b>
+or another <b>DDU Header</b>. If <b>DDU Header</b> appeared in a place anywhere after
+first two DDU words, program sets <i>Unknown</i> bit in <i>status flag</i> and
+returns buffer composed with data in front of this <b>DDU Header</b>.
+If program finds <b>DDU Header</b> in a right place and encounters
+second <b>DDU Header</b> it returns data between these <b>DDU Headers</b>, sets <i>DDU Header</i>
+bit in <i>status flag</i>, and starts from second <b>DDU Header</b> on next call.
+If buffer size reaches value of 50000 DDU words, <i>status flag</i> contains
+<i>DDUoversize</i> bit set.
+<br><br>
+Described scheme can be presented by following diagrams of
+buffer structure:
+<br><br>
+<table border=0 width=100%>
+<tr>
+<td valign=top>1)</td><td valign=top><nobr>[H-T]</nobr></td><td valign=top><nobr>// Normal event</nobr></td>
+</tr><tr>
+<td valign=top>2)</td><td valign=top><nobr>[H-?]H</nobr></td><td valign=top><nobr>// More likely event with corrupted trailer</nobr></td>
+</tr><tr>
+<td valign=top>3)</td><td valign=top><nobr>[H-max]</nobr></td><td valign=top><nobr>// <i>DDUoversize</i> condition</nobr></td>
+</tr><tr>
+<td valign=top>4)</td><td valign=top><nobr>[?-T]</nobr></td><td valign=top><nobr>// Could be anything</nobr></td>
+</tr><tr>
+<td valign=top>5)</td><td valign=top><nobr>[?-?]H</nobr></td><td valign=top><nobr>// Could be anything (depends on previous event)</nobr></td>
+</tr><tr>
+<td valign=top>6)</td><td valign=top><nobr>[?-max]</nobr></td><td valign=top><nobr>// Could be anything</nobr></td>
+</tr><tr>
+<td valign=top>7)</td><td valign=top><nobr>[FFFF]</nobr></td><td valign=top><nobr>// Some standard sequence to complete ethernet package</nobr></td>
+</tr>
+</table>
+<br><br>
+One remark to be made here is that <b>DDU Header</b> (as well as <b>DDU Trailer</b>)
+consists of three words with identifying pattern in second word.
+If two consecutive <b>DDU Headers</b> were found, first word of second
+<b>Header</b> goes to both events.
+<br><br>
+In <tt>FileReaderDDU</tt> for user convenience additional to <tt>read</tt> function <tt>next</tt> was
+implemented. Together with <tt>select</tt>, <tt>accept</tt>, and <tt>reject</tt>
+functions it allows user to get events of specified type. Function
+<tt>reject</tt> helps to filter out events with any of <i>status flag</i>
+bits matches defined criteria. Function <tt>accept</tt> forces <tt>next</tt>
+to return events with any of <i>status flag</i> bits matches its
+criteria. Function <tt>select</tt> requires events exactly match its
+criteria. In <tt>CSCFileReader</tt> module selection/rejection criteria
+are set to default (safe) values and cannot be changed.
+</body>
+</html>

--- a/IORawData/CSCCommissioning/doc/html/index.html
+++ b/IORawData/CSCCommissioning/doc/html/index.html
@@ -1,0 +1,59 @@
+<html>
+<body>
+<font size=+2><tt>CSCCommissioning</tt></font> package operates with local DAQ data of the
+<a href="http://cms-emu-slicetest.web.cern.ch/cms-emu-slicetest/">CSC SliceTest</a>.
+Two modules of this package are <tt>CSCFileReader</tt> and <tt>CSCFileDumper</tt>.
+First is capable of reading CSC local data and populating CMSSW data stream
+(<tt><a href="https://twiki.cern.ch/twiki/bin/view/CMS/WorkBookCMSSWFramework#ProcModel">edm::Event</a></tt>)
+with raw CSC data. Second module does an opposite job of selecting CSC data from the
+<tt><a href="https://twiki.cern.ch/twiki/bin/view/CMS/WorkBookCMSSWFramework#ProcModel">edm::Event</a></tt>
+and dumping them into local DAQ files.
+<br>
+<br>
+CSC DAQ data are composed of up to 40 data streams from independent sources &#151; Readout Units (RUIs).
+These streams are gathered in 4 FED crates (FED stands for Front End Driver) and travel
+downstream of global DAQ via 4 S-Links. Each FED is assigned with its own FED ID (750-759).
+Unlike global data taking, in local mode RUIs log data independently each in a separate set of files.
+<br>
+<br>
+<font color=red>If you are working with plain local DAQ data format (one set of files per each RUI; see
+for EmuRUI?? in file name), than you may find this paragraph useful.</font><br>
+If you work in CMSSW_1_3_0 or later (package revision V00-04-04 and higher) you should
+instruct <tt>CSCFileReader</tt> module to build FED buffers from selected RUIs (see
+<a href="http://cmssw.cvs.cern.ch/cgi-bin/cmssw.cgi/CMSSW/IORawData/CSCCommissioning/test/readFile.cfg?rev=1.6&cvsroot=CMSSW&content-type=text/vnd.viewcvs-markup">
+test/readFile.cfg</a> for example). To do that you need to specify parameter set (<tt>PSet</tt>)
+which defines RUI file sets (<i>RUI00</i>, <i>RUI01</i>, ... <i>RUI09</i>) and then assign each
+RUI to the appropriate FED (<i>FED750</i>, <i>FED751</i>, <i>FED752</i>, <i>FED753</i>). The module builds FED buffers
+from RUI buffers with the same L1A. Therefore, you should always maintain order of files in
+RUI file sets (module expects only incrementing L1A from file to file).
+In CMSSW prior to CMSSW_1_3_0 (package revision prior to V00-04-04) you are
+able to handle 1 FED with 1 RUI in it. Just specify <i>fileNames</i> as it is done in
+<a href="http://cmssw.cvs.cern.ch/cgi-bin/cmssw.cgi/CMSSW/IORawData/CSCCommissioning/test/readFile.cfg?rev=1.4&cvsroot=CMSSW&content-type=text/vnd.viewcvs-markup">
+test/readFile.cfg</a>.
+<br>
+<br>
+Module also supports alternative data format, produced by local Event Builder emulator (see FU in
+file name). In this case you need to assign <i>FU1</i>, <i>FU2</i>, ... with corresponding
+file names and remove FED parameters (though, having them in configuration doesn't affect
+anything). Set <i>tfDDUnumber=0</i> if Track-Finder records present in readout or
+<i>tfDDUnumber=-1</i> if not. See 
+<a href="http://cmssw.cvs.cern.ch/cgi-bin/cmssw.cgi/CMSSW/IORawData/CSCCommissioning/test/readFile.cfg?view=markup">test/readFile.cfg</a> for example.
+
+<br>
+<br>
+Special trigger RUI should not be mixed with DAQ RUIs which were described above (such
+configuration is not forbidden, but doesn't make much sense). Instead, trigger RUI solely
+goes to FED with ID=760.
+<br>
+<br>
+<tt>CSCFileDumper</tt> module selects CSC FED buffers from CMSSW data stream and
+logs them into files specified in <i>output</i> parameter. It automatically appends _FEDID
+(_750, _751, ... _760) to the end of every FED file. Be careful: one FED file may contain
+several RUIs, while in true local DAQ mode every RUI logs separate file.
+<br>
+<br>
+
+<hr>
+Technical details on <a href="./details.html"><tt>CSCFileReader</tt></a>
+</body>
+</html>

--- a/IORawData/CSCCommissioning/doc/html/overview.html
+++ b/IORawData/CSCCommissioning/doc/html/overview.html
@@ -1,0 +1,12 @@
+<! Template File - Modify as required.>
+<! Use as a brief project description that appears on your main page>
+<! Links are not encouraged from this section - use index.html for this>
+This Text Inserted from File doc/html/overview.html
+<table border=0 width=100%>
+<tr>
+<td align=center><b>Status :</b></td>
+<td align=center>
+Unknown
+</td>
+</tr>
+</table>

--- a/IORawData/CSCCommissioning/src/CSCFileDumper.cc
+++ b/IORawData/CSCCommissioning/src/CSCFileDumper.cc
@@ -16,9 +16,9 @@
 
 #include "FWCore/ServiceRegistry/interface/Service.h"
 
+#include <cstdio>
 #include <iostream>
 #include <sstream>
-#include <stdio.h>
 
 CSCFileDumper::CSCFileDumper(const edm::ParameterSet &pset) {
   i_token = consumes<FEDRawDataCollection>(pset.getParameter<edm::InputTag>("source"));
@@ -46,7 +46,7 @@ CSCFileDumper::CSCFileDumper(const edm::ParameterSet &pset) {
    */
 
   if (events.length()) {
-    for (size_t pos1 = 0, pos2 = events.find(",");; pos1 = pos2 + 1, pos2 = events.find(",", pos2 + 1)) {
+    for (size_t pos1 = 0, pos2 = events.find(',');; pos1 = pos2 + 1, pos2 = events.find(',', pos2 + 1)) {
       if (pos2 != std::string::npos) {
         long event = 0;
         if (sscanf(events.substr(pos1, pos2 - pos1).c_str(), "%ld", &event) == 1 && event >= 0)
@@ -100,7 +100,7 @@ void CSCFileDumper::analyze(const edm::Event &e, const edm::EventSetup &c) {
         std::ostringstream name;
         name << output << "_FED" << id << ".raw" << std::ends;
         FILE *file;
-        if ((file = fopen(name.str().c_str(), "wt")) == NULL) {
+        if ((file = fopen(name.str().c_str(), "wt")) == nullptr) {
           edm::LogError("CSCFileDumper") << "Cannot open the file: " << name.str();
           continue;
         } else

--- a/IORawData/CSCCommissioning/src/CSCFileDumper.cc
+++ b/IORawData/CSCCommissioning/src/CSCFileDumper.cc
@@ -1,0 +1,117 @@
+#include <iomanip>
+
+#include "CSCFileDumper.h"
+
+//Framework stuff
+#include "DataFormats/Common/interface/Handle.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+//FEDRawData
+#include "DataFormats/FEDRawData/interface/FEDRawData.h"
+#include "DataFormats/FEDRawData/interface/FEDNumbering.h"
+#include "DataFormats/FEDRawData/interface/FEDRawDataCollection.h"
+
+#include "DataFormats/MuonDetId/interface/CSCDetId.h"
+
+#include "FWCore/ServiceRegistry/interface/Service.h"
+
+#include <iostream>
+#include <sstream>
+#include <stdio.h>
+
+CSCFileDumper::CSCFileDumper(const edm::ParameterSet &pset) {
+  i_token = consumes<FEDRawDataCollection>(pset.getParameter<edm::InputTag>("source"));
+  // source_ = pset.getUntrackedParameter<std::string>("source","rawDataCollector");
+  output = pset.getUntrackedParameter<std::string>("output");
+  events = pset.getUntrackedParameter<std::string>("events", "");
+
+  cscFEDids.clear();
+  /*
+    for (unsigned int id=FEDNumbering::MINCSCFEDID;
+         id<=FEDNumbering::MAXCSCFEDID; ++id)   // loop over DCCs
+      {
+        cscFEDids.push_back(id);
+      }
+   */
+  for (unsigned int id = FEDNumbering::MINCSCDDUFEDID; id <= FEDNumbering::MAXCSCDDUFEDID; ++id)  // loop over DDUs
+  {
+    cscFEDids.push_back(id);
+  }
+  /*
+    for (unsigned int id=FEDNumbering::MINCSCTFFEDID; id<=FEDNumbering::MAXCSCTFFEDID; id++)
+      {
+         cscFEDids.push_back(id);
+      }
+   */
+
+  if (events.length()) {
+    for (size_t pos1 = 0, pos2 = events.find(",");; pos1 = pos2 + 1, pos2 = events.find(",", pos2 + 1)) {
+      if (pos2 != std::string::npos) {
+        long event = 0;
+        if (sscanf(events.substr(pos1, pos2 - pos1).c_str(), "%ld", &event) == 1 && event >= 0)
+          eventsToDump.insert((unsigned long)event);
+        else
+          edm::LogError("CSCFileDumper") << " cannot parse events (" << events
+                                         << ") parameter: " << events.substr(pos1, pos2 - pos1);
+      } else {
+        long event = 0;
+        if (sscanf(events.substr(pos1, events.length() - pos1).c_str(), "%ld", &event) == 1 && event >= 0)
+          eventsToDump.insert((unsigned long)event);
+        else
+          edm::LogError("CSCFileDumper") << " cannot parse events (" << events
+                                         << ") parameter: " << events.substr(pos1, events.length() - pos1);
+        break;
+      }
+    }
+    std::ostringstream tmp;
+    for (std::set<unsigned long>::const_iterator evt = eventsToDump.begin(); evt != eventsToDump.end(); evt++)
+      tmp << *evt << " ";
+    edm::LogInfo("CSCFileDumper") << " Following events will be dumped: " << tmp.str();
+  } else
+    edm::LogInfo("CSCFileDumper") << " All events will be dumped";
+}
+
+CSCFileDumper::~CSCFileDumper(void) {
+  std::map<int, FILE *>::const_iterator stream = dump_files.begin();
+  while (stream != dump_files.end()) {
+    fclose(stream->second);
+    stream++;
+  }
+}
+
+void CSCFileDumper::analyze(const edm::Event &e, const edm::EventSetup &c) {
+  // Get a handle to the FED data collection
+  edm::Handle<FEDRawDataCollection> rawdata;
+  e.getByToken(i_token, rawdata);
+
+  // Get a handle to the FED data collection
+
+  for (unsigned int i = 0; i < cscFEDids.size(); i++)  //for each of our DCCs
+  {
+    unsigned int id = cscFEDids[i];
+    std::map<int, FILE *>::const_iterator stream = dump_files.find(id);
+    /// Take a reference to this FED's data
+    const FEDRawData &fedData = rawdata->FEDData(id);
+    unsigned short int length = fedData.size();
+
+    if (length && (eventsToDump.empty() || (eventsToDump.find((unsigned long)e.id().event()) != eventsToDump.end()))) {
+      if (stream == dump_files.end()) {
+        std::ostringstream name;
+        name << output << "_FED" << id << ".raw" << std::ends;
+        FILE *file;
+        if ((file = fopen(name.str().c_str(), "wt")) == NULL) {
+          edm::LogError("CSCFileDumper") << "Cannot open the file: " << name.str();
+          continue;
+        } else
+          dump_files[id] = file;
+        stream = dump_files.find(id);
+      }
+
+      // Event buffer
+      size_t size = length / 2;
+      const unsigned short *buf = (unsigned short *)fedData.data();
+      fwrite(buf, 2, size, stream->second);
+    }
+  }
+}

--- a/IORawData/CSCCommissioning/src/CSCFileDumper.h
+++ b/IORawData/CSCCommissioning/src/CSCFileDumper.h
@@ -9,7 +9,7 @@
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "DataFormats/FEDRawData/interface/FEDRawDataCollection.h"
 
-#include <stdio.h>
+#include <cstdio>
 
 class CSCFileDumper : public edm::EDAnalyzer {
 public:
@@ -21,9 +21,9 @@ public:
   //	int fedID_first, fedID_last;
 
   CSCFileDumper(const edm::ParameterSet& pset);
-  virtual ~CSCFileDumper(void);
+  ~CSCFileDumper(void) override;
 
-  void analyze(const edm::Event& e, const edm::EventSetup& c);
+  void analyze(const edm::Event& e, const edm::EventSetup& c) override;
 
 private:
   std::vector<unsigned int> cscFEDids;

--- a/IORawData/CSCCommissioning/src/CSCFileDumper.h
+++ b/IORawData/CSCCommissioning/src/CSCFileDumper.h
@@ -1,0 +1,36 @@
+#ifndef CSCFileDumper_h
+#define CSCFileDumper_h
+
+#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "DataFormats/Common/interface/Handle.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "DataFormats/FEDRawData/interface/FEDRawDataCollection.h"
+
+#include <stdio.h>
+
+class CSCFileDumper : public edm::EDAnalyzer {
+public:
+  std::map<int, FILE*> dump_files;
+  std::set<unsigned long> eventsToDump;
+  //	std::??? rangesToDump; to be implemented
+
+  std::string output, events;
+  //	int fedID_first, fedID_last;
+
+  CSCFileDumper(const edm::ParameterSet& pset);
+  virtual ~CSCFileDumper(void);
+
+  void analyze(const edm::Event& e, const edm::EventSetup& c);
+
+private:
+  std::vector<unsigned int> cscFEDids;
+
+  // std::string source_;
+  /// Token for consumes interface & access to data
+  edm::EDGetTokenT<FEDRawDataCollection> i_token;
+};
+
+#endif

--- a/IORawData/CSCCommissioning/src/CSCFileReader.cc
+++ b/IORawData/CSCCommissioning/src/CSCFileReader.cc
@@ -1,7 +1,7 @@
 #include "CSCFileReader.h"
 
-#include <errno.h>
-#include <stdlib.h>
+#include <cerrno>
+#include <cstdlib>
 #include <cstring>
 
 #include <IORawData/CSCCommissioning/src/CSCFileReader.h>
@@ -154,17 +154,17 @@ CSCFileReader::CSCFileReader(const edm::ParameterSet &pset) {
   // For efficiency reasons create this big chunk of data only once
   tmpBuf = new unsigned short[200000 * nRUIs + 4 * 4];
   // Event buffer and its length for every FU
-  fuEvent[0] = 0;
+  fuEvent[0] = nullptr;
   fuEventSize[0] = 0;
-  fuEvent[1] = 0;
+  fuEvent[1] = nullptr;
   fuEventSize[1] = 0;
-  fuEvent[2] = 0;
+  fuEvent[2] = nullptr;
   fuEventSize[2] = 0;
-  fuEvent[3] = 0;
+  fuEvent[3] = nullptr;
   fuEventSize[3] = 0;
   // Event buffer and its length for every RU
   for (int rui = 0; rui < nRUIs; rui++) {
-    ruBuf[rui] = 0;
+    ruBuf[rui] = nullptr;
     ruBufSize[rui] = 0;
   }
   LogDebug("CSCFileReader|ctor") << "... and finished";
@@ -182,7 +182,7 @@ int CSCFileReader::readRUI(int rui, const unsigned short *&buf, size_t &length) 
   do {
     try {
       length = RUI[rui].next(buf);
-    } catch (std::runtime_error & err) {
+    } catch (std::runtime_error &err) {
       throw cms::Exception("CSCFileReader|reading") << "EndOfStream: " << err.what() << " (errno=" << errno << ")";
     }
     if (length == 0)  // end of file, try next one
@@ -330,7 +330,7 @@ int CSCFileReader::nextEventFromFUs(FEDRawDataCollection *data) {
 
   // Compose event from DDC record striped of Track-Finder DDU and a separate TF DDU event
   unsigned long long *start = (unsigned long long *)fuEvent[readyToGo];
-  unsigned long long *end = 0;
+  unsigned long long *end = nullptr;
   enum { Header = 1, Trailer = 2 };
   unsigned int eventStatus = 0;
   for (int dduRecord = 0; dduRecord <= tfDDUnumber; dduRecord++) {

--- a/IORawData/CSCCommissioning/src/CSCFileReader.cc
+++ b/IORawData/CSCCommissioning/src/CSCFileReader.cc
@@ -1,0 +1,445 @@
+#include "CSCFileReader.h"
+
+#include <errno.h>
+#include <stdlib.h>
+#include <cstring>
+
+#include <IORawData/CSCCommissioning/src/CSCFileReader.h>
+
+#include <DataFormats/FEDRawData/interface/FEDHeader.h>
+#include <DataFormats/FEDRawData/interface/FEDTrailer.h>
+#include <DataFormats/FEDRawData/interface/FEDNumbering.h>
+
+#include <DataFormats/Provenance/interface/EventID.h>
+#include <DataFormats/Provenance/interface/Timestamp.h>
+#include <DataFormats/FEDRawData/interface/FEDRawData.h>
+#include <DataFormats/FEDRawData/interface/FEDRawDataCollection.h>
+
+#include <FWCore/ParameterSet/interface/ParameterSet.h>
+#include <FWCore/Utilities/interface/Exception.h>
+
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+#include <vector>
+#include <string>
+#include <iosfwd>
+#include <sstream>
+#include <iostream>
+#include <algorithm>
+
+#define nRUIs 40
+#define nFUs 4
+
+CSCFileReader::CSCFileReader(const edm::ParameterSet &pset) {
+  runNumber = pset.getUntrackedParameter<unsigned int>("runNumber", 1);
+  LogDebug("CSCFileReader|ctor") << "Started ...";
+  // Below some data members are recycled for both cases: RUIs and FUs
+  //  this is ok as long as eighter of RUI or FU are are provided in .cfg (not both)
+  nActiveRUIs = 0;
+  nActiveFUs = 0;
+  fFirstReadBug = true;
+  for (int unit = 0; unit < nRUIs; unit++) {
+    std::ostringstream ruiName, fuName;
+    ruiName << "RUI" << (unit < 10 ? "0" : "") << unit << std::ends;
+    fuName << "FU" << unit << std::ends;
+    std::vector<std::string> ruiFiles =
+        pset.getUntrackedParameter<std::vector<std::string> >(ruiName.str().c_str(), std::vector<std::string>(0));
+    std::vector<std::string> fuFiles =
+        pset.getUntrackedParameter<std::vector<std::string> >(fuName.str().c_str(), std::vector<std::string>(0));
+    if (ruiFiles.begin() != ruiFiles.end())
+      nActiveRUIs++;
+    if (fuFiles.begin() != fuFiles.end())
+      nActiveFUs++;
+  }
+  if (nActiveFUs && nActiveRUIs)
+    throw cms::Exception("CSCFileReader|configuration")
+        << "RUIs and FUs in conflict: either RUI or FU may be defined at a time, not both";
+  if (!nActiveFUs && !nActiveRUIs)
+    throw cms::Exception("CSCFileReader|configuration") << "Module lacks configuration";
+
+  // Get list of RUI input files from cfg file
+  for (int rui = 0; rui < nRUIs && !nActiveFUs; rui++) {
+    std::ostringstream name;
+    name << "RUI" << (rui < 10 ? "0" : "") << rui << std::ends;
+
+    // Obtain list of files associated with current RUI
+    fileNames[rui] =
+        pset.getUntrackedParameter<std::vector<std::string> >(name.str().c_str(), std::vector<std::string>(0));
+    currentFile[rui] = fileNames[rui].begin();
+
+    // If list of files is not empty, open first file
+    if (currentFile[rui] != fileNames[rui].end()) {
+      try {
+        RUI[rui].open(currentFile[rui]->c_str());
+      } catch (std::runtime_error &err) {
+        throw cms::Exception("CSCFileReader") << "InputFileMissing: " << err.what() << " (errno=" << errno << ")";
+      }
+      nActiveRUIs++;
+    }
+
+    // Filter out possible corruptions
+    RUI[rui].reject(FileReaderDDU::DDUoversize | FileReaderDDU::FFFF | FileReaderDDU::Unknown);
+    // Do not select anything in particular
+    RUI[rui].select(0);
+
+    currentL1A[rui] = -1;
+  }
+
+  // Get list of FU input files from .cfg file
+  for (int fu = 0; fu < nFUs && !nActiveRUIs; fu++) {
+    std::ostringstream name;
+    name << "FU" << fu << std::ends;
+
+    // Obtain list of files associated with current FU
+    fileNames[fu] =
+        pset.getUntrackedParameter<std::vector<std::string> >(name.str().c_str(), std::vector<std::string>(0));
+    currentFile[fu] = fileNames[fu].begin();
+
+    // If list of files is not empty, open first file
+    if (currentFile[fu] != fileNames[fu].end()) {
+      try {
+        FU[fu].open(currentFile[fu]->c_str());
+      } catch (std::runtime_error &err) {
+        throw cms::Exception("CSCFileReader") << "InputFileMissing: " << err.what() << " (errno=" << errno << ")";
+      }
+      nActiveFUs++;
+    }
+
+    // Filter out possible corruptions
+    FU[fu].reject(FileReaderDCC::DCCoversize | FileReaderDCC::FFFF | FileReaderDCC::Unknown);
+    // Do not select anything in particular
+    FU[fu].select(0);
+
+    currentL1A[fu] = -1;
+  }
+
+  if (nActiveRUIs && !nActiveFUs) {
+    // Assign RUIs to FEDs
+    for (int fed = FEDNumbering::MINCSCFEDID; fed <= FEDNumbering::MAXCSCFEDID; fed++) {
+      std::ostringstream name;
+      name << "FED" << fed << std::ends;
+      std::vector<std::string> rui_list =
+          pset.getUntrackedParameter<std::vector<std::string> >(name.str().c_str(), std::vector<std::string>(0));
+      for (std::vector<std::string>::const_iterator rui = rui_list.begin(); rui != rui_list.end(); rui++)
+        FED[fed].push_back((unsigned int)atoi(rui->c_str() + rui->length() - 2));
+    }
+    for (int fed = FEDNumbering::MINCSCDDUFEDID; fed <= FEDNumbering::MAXCSCDDUFEDID; fed++) {
+      std::ostringstream name;
+      name << "FED" << fed << std::ends;
+      std::vector<std::string> rui_list =
+          pset.getUntrackedParameter<std::vector<std::string> >(name.str().c_str(), std::vector<std::string>(0));
+      for (std::vector<std::string>::const_iterator rui = rui_list.begin(); rui != rui_list.end(); rui++)
+        FED[fed].push_back((unsigned int)atoi(rui->c_str() + rui->length() - 2));
+    }
+
+    // Do the same for Track-Finder FED
+    for (int fed = FEDNumbering::MINCSCTFFEDID; fed <= FEDNumbering::MAXCSCTFFEDID; fed++) {
+      std::ostringstream name;
+      name << "FED" << fed << std::ends;
+      std::vector<std::string> rui_list =
+          pset.getUntrackedParameter<std::vector<std::string> >(name.str().c_str(), std::vector<std::string>(0));
+      for (std::vector<std::string>::const_iterator rui = rui_list.begin(); rui != rui_list.end(); rui++)
+        FED[fed].push_back((unsigned int)atoi(rui->c_str() + rui->length() - 2));
+    }
+  }
+  // Starting point
+  firstEvent = pset.getUntrackedParameter<int>("firstEvent", 0);
+  nEvents = 0;
+  expectedNextL1A = -1;
+
+  // If Track-Finder was in readout specify its position in the record or set -1 otherwise
+  //  Current agriment is that if there is a TF event it is first DDU record
+  tfDDUnumber = pset.getUntrackedParameter<int>("tfDDUnumber", -1);
+
+  // For efficiency reasons create this big chunk of data only once
+  tmpBuf = new unsigned short[200000 * nRUIs + 4 * 4];
+  // Event buffer and its length for every FU
+  fuEvent[0] = 0;
+  fuEventSize[0] = 0;
+  fuEvent[1] = 0;
+  fuEventSize[1] = 0;
+  fuEvent[2] = 0;
+  fuEventSize[2] = 0;
+  fuEvent[3] = 0;
+  fuEventSize[3] = 0;
+  // Event buffer and its length for every RU
+  for (int rui = 0; rui < nRUIs; rui++) {
+    ruBuf[rui] = 0;
+    ruBufSize[rui] = 0;
+  }
+  LogDebug("CSCFileReader|ctor") << "... and finished";
+  produces<FEDRawDataCollection>();
+}
+
+CSCFileReader::~CSCFileReader(void) {
+  if (tmpBuf)
+    delete[] tmpBuf;
+}
+
+int CSCFileReader::readRUI(int rui, const unsigned short *&buf, size_t &length) {
+  if (currentFile[rui] == fileNames[rui].end())
+    return -1;
+  do {
+    try {
+      length = RUI[rui].next(buf);
+    } catch (std::runtime_error & err) {
+      throw cms::Exception("CSCFileReader|reading") << "EndOfStream: " << err.what() << " (errno=" << errno << ")";
+    }
+    if (length == 0)  // end of file, try next one
+    {
+      if (++currentFile[rui] != fileNames[rui].end()) {
+        try {
+          RUI[rui].open(currentFile[rui]->c_str());
+        } catch (std::runtime_error &err) {
+          throw cms::Exception("CSCFileReader|reading")
+              << "InputFileMissing: " << err.what() << " (errno=" << errno << ")";
+        }
+      } else
+        return -1;
+    }
+  } while (length == 0);
+  return buf[2] | ((buf[3] & 0xFF) << 16);
+}
+
+int CSCFileReader::readFU(int fu, const unsigned short *&buf, size_t &length) {
+  if (currentFile[fu] == fileNames[fu].end())
+    return -1;
+  do {
+    try {
+      length = FU[fu].next(buf);
+    } catch (std::runtime_error &err) {
+      throw cms::Exception("CSCFileReader|reading") << "EndOfStream: " << err.what() << " (errno=" << errno << ")";
+    }
+    if (length == 0)  // end of file, try next one
+    {
+      if (++currentFile[fu] != fileNames[fu].end()) {
+        try {
+          FU[fu].open(currentFile[fu]->c_str());
+        } catch (std::runtime_error &err) {
+          throw cms::Exception("CSCFileReader|reading")
+              << "InputFileMissing: " << err.what() << " (errno=" << errno << ")";
+        }
+      } else
+        return -1;
+    }
+  } while (length == 0);
+  // Take L1A from first DDU header in the DCC record (shift=8)
+  return buf[2 + 8] | ((buf[3 + 8] & 0xFF) << 16);
+}
+
+int CSCFileReader::buildEventFromRUIs(FEDRawDataCollection *data) {
+  int eventNumber = -1;  // Will determine below
+
+  do {
+    // Read next event from RUIs
+    for (int rui = 0; rui < nRUIs; rui++) {
+      // read event from the RUI only in two cases:
+      //     1) it is readable (currentL1A>0) and we expect next event from the RUI
+      //     2) it is first time (expectedNextL1A<0)
+      if ((currentL1A[rui] > 0 && currentL1A[rui] < expectedNextL1A) || expectedNextL1A < 0) {
+        currentL1A[rui] = readRUI(rui, ruBuf[rui], ruBufSize[rui]);
+        //	    std::cout << "read rui" << rui << " l1a: " << currentL1A[rui] << " size: " << ruBufSize[rui] << std::endl;
+      }
+    }
+    eventNumber = -1;
+
+    // Select lowest L1A from all RUIs and don't expect next event from RUIs that currently hold higher L1A
+    for (int rui = 0; rui < nRUIs; rui++)
+      if (currentL1A[rui] >= 0 && (eventNumber > currentL1A[rui] || eventNumber == -1))
+        eventNumber = currentL1A[rui];
+    // No readable RUIs => fall out
+    if (eventNumber < 0)
+      return -1;
+    // Expect next event to be incremented by 1 wrt. to the current event
+    expectedNextL1A = eventNumber + 1;
+
+  } while (nEvents++ < firstEvent);
+
+  for (std::map<unsigned int, std::list<unsigned int> >::const_iterator fed = FED.begin(); fed != FED.end(); fed++)
+    if (fed->first < (unsigned int)FEDNumbering::MINCSCTFFEDID) {
+      // Now let's pretend that DDU data were wrapped with DCC Header (2 64-bit words) and Trailer (2 64-bit words):
+      unsigned short *dccBuf = tmpBuf, *dccCur = dccBuf;
+      dccCur[3] = 0x5000;
+      dccCur[2] = 0x0000;
+      dccCur[1] = 0x0000;
+      dccCur[0] = 0x005F;  // Fake DCC Header 1
+      dccCur[7] = 0xD900;
+      dccCur[6] = 0x0000;
+      dccCur[5] = 0x0000;
+      dccCur[4] = 0x0017;  // Fake DCC Header 2
+      dccCur += 8;
+
+      for (std::list<unsigned int>::const_iterator rui = fed->second.begin(); rui != fed->second.end(); rui++) {
+        //cout<<"Event:"<<eventNumber<<"  FED:"<<fed->first<<"  RUI:"<<*(fed->second.begin())<<" currL1A:"<<currentL1A[*rui]<<endl;
+        if (currentL1A[*rui] == eventNumber) {
+          if (dccCur - dccBuf + ruBufSize[*rui] >= 200000 * nRUIs + 8)
+            throw cms::Exception("CSCFileReader|eventBuffer")
+                << "OutOfBuffer: Event size exceeds maximal size allowed!";
+          memcpy(dccCur, ruBuf[*rui], ruBufSize[*rui] * sizeof(unsigned short));
+          dccCur += ruBufSize[*rui];
+        }
+      }
+      dccCur[3] = 0xEF00;
+      dccCur[2] = 0x0000;
+      dccCur[1] = 0x0000;
+      dccCur[0] = 0x0000;  // Fake DCC Trailer 2
+      dccCur[7] = 0xAF00;
+      dccCur[6] = 0x0000;
+      dccCur[5] = 0x0000;
+      dccCur[4] = 0x0007;  // Fake DCC Trailer 2
+      dccCur += 8;
+
+      FEDRawData &fedRawData = data->FEDData(fed->first);
+      fedRawData.resize((dccCur - dccBuf) * sizeof(unsigned short));
+      std::copy((unsigned char *)dccBuf, (unsigned char *)dccCur, fedRawData.data());
+    } else {
+      for (std::list<unsigned int>::const_iterator rui = fed->second.begin(); rui != fed->second.end(); rui++) {
+        FEDRawData &fedRawData = data->FEDData(fed->first);
+        fedRawData.resize(ruBufSize[*rui] * sizeof(unsigned short));
+        std::copy((unsigned char *)ruBuf[*rui], (unsigned char *)(ruBuf[*rui] + ruBufSize[*rui]), fedRawData.data());
+      }
+    }
+
+  return eventNumber;
+}
+
+int CSCFileReader::nextEventFromFUs(FEDRawDataCollection *data) {
+  int eventNumber = -1;  // Will determine below
+
+  // If this is a first time - read one event from each FU
+  if (expectedNextL1A < 0)
+    for (int fu = 0; fu < nFUs; fu++)
+      currentL1A[fu] = readFU(fu, fuEvent[fu], fuEventSize[fu]);
+
+  // Keep buffers for every FU ready at all times
+  // When buffer from some FU is ready to go as the next event,
+  //  release it, but read next one
+  int readyToGo = -1;
+  for (int fu = 0; fu < nFUs; fu++) {
+    // If FU is readable and (first loop of this cycle or current FU holds smallest L1A)
+    if (currentL1A[fu] >= 0 && (eventNumber < 0 || currentL1A[fu] < eventNumber)) {
+      readyToGo = fu;
+      eventNumber = currentL1A[fu];
+    }
+  }
+  // No readable FUs => fall out
+  if (readyToGo < 0)
+    return -1;
+
+  expectedNextL1A = eventNumber + 1;
+
+  // Compose event from DDC record striped of Track-Finder DDU and a separate TF DDU event
+  unsigned long long *start = (unsigned long long *)fuEvent[readyToGo];
+  unsigned long long *end = 0;
+  enum { Header = 1, Trailer = 2 };
+  unsigned int eventStatus = 0;
+  for (int dduRecord = 0; dduRecord <= tfDDUnumber; dduRecord++) {
+    unsigned long long word_0 = 0, word_1 = 0, word_2 = 0;
+    size_t dduWordCount = 0;
+    while (!end && dduWordCount < fuEventSize[readyToGo]) {
+      unsigned long long *dduWord = start;
+
+      while (dduWordCount < fuEventSize[readyToGo]) {
+        word_0 = word_1;    // delay by 2 DDU words
+        word_1 = word_2;    // delay by 1 DDU word
+        word_2 = *dduWord;  // current DDU word
+        if ((word_2 & 0xFFFFFFFFFFFF0000LL) == 0x8000000180000000LL) {
+          if (eventStatus & Header)  // Second header
+          {
+            word_2 = word_1;
+            end = dduWord;
+            break;
+          }
+          start = dduWord;
+        }
+        if ((word_0 & 0xFFFFFFFFFFFF0000LL) == 0x8000FFFF80000000LL) {
+          eventStatus |= Trailer;
+          end = ++dduWord;
+          break;
+        }
+        // Increase counters by one DDU word
+        dduWord++;
+        dduWordCount++;
+      }
+    }
+    // If reach max length
+    if (dduWordCount == fuEventSize[readyToGo]) {
+      end = (unsigned long long *)(fuEvent[readyToGo] + fuEventSize[readyToGo]);
+      break;
+    }
+  }
+  // Include 0x5xxx preHeader if exists
+  if (start > (unsigned long long *)fuEvent[readyToGo] && (*(start - 1) & 0xF000000000000000LL) == 0x5000000000000000LL)
+    start--;
+
+  // If Track-Finder DDU was in readout
+  if (tfDDUnumber >= 0) {
+    // Cut out Track-Finder DDU from the buffer
+    if (!end)
+      throw cms::Exception("CSCFileReader|lookingForTF") << " Sanity check failed (end==0)! Should never happen";
+
+    FEDRawData &tfRawData = data->FEDData(FEDNumbering::MINCSCTFFEDID);
+    tfRawData.resize((end - start) * sizeof(unsigned long long));
+    std::copy((unsigned char *)start, (unsigned char *)end, tfRawData.data());
+
+    // Create a new buffer from everything before and after TF DDU
+    unsigned short *event = tmpBuf;
+    memcpy(event, fuEvent[readyToGo], ((unsigned short *)start - fuEvent[readyToGo]) * sizeof(unsigned short));
+    event += ((unsigned short *)start - fuEvent[readyToGo]);
+    memcpy(event, end, (fuEvent[readyToGo] + fuEventSize[readyToGo] - (unsigned short *)end) * sizeof(unsigned short));
+    event += fuEvent[readyToGo] + fuEventSize[readyToGo] - (unsigned short *)end;
+    FEDRawData &fedRawData = data->FEDData(FEDNumbering::MINCSCFEDID);
+    fedRawData.resize((fuEventSize[readyToGo] - ((unsigned short *)end - (unsigned short *)start)) *
+                      sizeof(unsigned short));
+    std::copy((unsigned char *)tmpBuf, (unsigned char *)event, fedRawData.data());
+  } else {
+    FEDRawData &fedRawData = data->FEDData(FEDNumbering::MINCSCFEDID);
+    fedRawData.resize((fuEventSize[readyToGo]) * sizeof(unsigned short));
+    std::copy((unsigned char *)fuEvent[readyToGo],
+              (unsigned char *)(fuEvent[readyToGo] + fuEventSize[readyToGo]),
+              fedRawData.data());
+  }
+
+  currentL1A[readyToGo] = readFU(readyToGo, fuEvent[readyToGo], fuEventSize[readyToGo]);
+
+  return eventNumber;
+}
+
+int CSCFileReader::fillRawData(edm::Event &e, /* edm::Timestamp& tstamp,*/ FEDRawDataCollection *&data) {
+  edm::EventID eID = e.id();
+  data = new FEDRawDataCollection();
+
+  if (fFirstReadBug) {
+    eID = edm::EventID(runNumber, 1U, 1);
+    fFirstReadBug = false;
+    return true;
+  }
+
+  // int runNumber   = 0; // Unknown at the level of EMu local DAQ
+  int eventNumber = -1;  // Will determine below
+
+  if (!nActiveFUs && nActiveRUIs) {
+    eventNumber = buildEventFromRUIs(data);
+    //      std::cout << eventNumber << std::endl;
+  } else {
+    eventNumber = nextEventFromFUs(data);
+  }
+
+  if (eventNumber < 0)
+    return false;
+
+  eID = edm::EventID(runNumber, 1U, eventNumber);
+
+  return true;
+}
+
+void CSCFileReader::produce(edm::Event &e, edm::EventSetup const &es) {
+  edm::Handle<FEDRawDataCollection> rawdata;
+  FEDRawDataCollection *fedcoll = nullptr;
+  fillRawData(e, fedcoll);
+  std::unique_ptr<FEDRawDataCollection> bare_product(fedcoll);
+  e.put(std::move(bare_product));
+}
+
+#undef nRUIs
+#undef nFUs

--- a/IORawData/CSCCommissioning/src/CSCFileReader.h
+++ b/IORawData/CSCCommissioning/src/CSCFileReader.h
@@ -1,0 +1,57 @@
+#ifndef CSCFileReader_h
+#define CSCFileReader_h
+
+#include "FWCore/Framework/interface/EDProducer.h"
+#include "IORawData/DTCommissioning/plugins/RawFile.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "DataFormats/Provenance/interface/EventID.h"
+#include "DataFormats/FEDRawData/interface/FEDRawDataCollection.h"
+
+#include <vector>
+#include <string>
+#include <list>
+#include <map>
+
+#include "FileReaderDDU.h"
+#include "FileReaderDCC.h"
+
+class CSCFileReader : public edm::EDProducer {
+private:
+  std::vector<std::string> fileNames[40];
+  std::vector<std::string>::const_iterator currentFile[40];
+
+  int firstEvent, nEvents, tfDDUnumber;
+  int expectedNextL1A, currentL1A[40];
+  int nActiveRUIs, nActiveFUs;
+  unsigned int runNumber;
+
+  unsigned short *tmpBuf;
+  const unsigned short *fuEvent[4];
+  size_t fuEventSize[4];
+  const unsigned short *ruBuf[40];
+  size_t ruBufSize[40];
+
+  FileReaderDDU RUI[40];
+  FileReaderDCC FU[4];
+
+  std::map<unsigned int, std::list<unsigned int> > FED;
+
+  int readRUI(int rui, const unsigned short *&buf, size_t &length);
+  int buildEventFromRUIs(FEDRawDataCollection *data);
+
+  int readFU(int fu, const unsigned short *&buf, size_t &length);
+  int nextEventFromFUs(FEDRawDataCollection *data);
+
+public:
+  CSCFileReader(const edm::ParameterSet &pset);
+  ~CSCFileReader(void) override;
+
+  virtual int fillRawData(edm::Event &e, /* edm::Timestamp& tstamp,*/ FEDRawDataCollection *&data);
+
+  void produce(edm::Event &, edm::EventSetup const &) override;
+
+  bool fFirstReadBug;
+};
+
+#endif

--- a/IORawData/CSCCommissioning/src/FileReaderDCC.cc
+++ b/IORawData/CSCCommissioning/src/FileReaderDCC.cc
@@ -1,11 +1,11 @@
 #include "FileReaderDCC.h"
-#include <iostream>     // cerr
-#include <errno.h>      // errno
-#include <string.h>     // bzero, memcpy
-#include <stdlib.h>     // exit
-#include <sys/types.h>  // open
-#include <sys/stat.h>   // open
+#include <cerrno>       // errno
+#include <cstdlib>      // exit
+#include <cstring>      // bzero, memcpy
 #include <fcntl.h>      // open
+#include <iostream>     // cerr
+#include <sys/stat.h>   // open
+#include <sys/types.h>  // open
 #include <unistd.h>     // read, close
 
 #ifndef O_LARGEFILE  //for OSX
@@ -55,7 +55,7 @@ size_t FileReaderDCC::read(const unsigned short *&buf) {
 
   eventStatus = 0;
   size_t dccWordCount = 0;
-  end = 0;
+  end = nullptr;
 
   while (!end && dccWordCount < 50000 * 40) {
     unsigned long long *dccWord = start;

--- a/IORawData/CSCCommissioning/src/FileReaderDCC.cc
+++ b/IORawData/CSCCommissioning/src/FileReaderDCC.cc
@@ -1,0 +1,154 @@
+#include "FileReaderDCC.h"
+#include <iostream>     // cerr
+#include <errno.h>      // errno
+#include <string.h>     // bzero, memcpy
+#include <stdlib.h>     // exit
+#include <sys/types.h>  // open
+#include <sys/stat.h>   // open
+#include <fcntl.h>      // open
+#include <unistd.h>     // read, close
+
+#ifndef O_LARGEFILE  //for OSX
+#define O_LARGEFILE 0
+#endif
+
+FileReaderDCC::FileReaderDCC(void) {
+  if (sizeof(unsigned long long) != 8 || sizeof(unsigned short) != 2)
+    throw std::runtime_error(std::string("Wrong platform: sizeof(unsigned long long)!=8 || sizeof(unsigned short)!=2"));
+  raw_event = new unsigned short[200000 * 40];
+  end = (file_buffer_end = file_buffer + sizeof(file_buffer) / sizeof(unsigned long long));
+  bzero(raw_event, sizeof(raw_event));
+  bzero(file_buffer, sizeof(file_buffer));
+  word_0 = 0;
+  word_1 = 0;
+  word_2 = 0;
+  eventStatus = 0;
+  selectCriteria = Header | Trailer;
+  rejectCriteria = DCCoversize | FFFF | Unknown;
+  acceptCriteria = 0x3F;  // Everything
+  fd = 0;
+}
+
+FileReaderDCC::~FileReaderDCC(void) {
+  if (fd)
+    close(fd);
+}
+
+int FileReaderDCC::open(const char *filename) {
+  if (fd)
+    close(fd);
+  fd = ::open(filename, O_RDONLY | O_LARGEFILE);
+  if (fd == -1)
+    throw(std::runtime_error(std::string("Error opening ").append(filename).append(" data file.")));
+  return fd;
+}
+
+size_t FileReaderDCC::read(const unsigned short *&buf) {
+  // Check for ubnormal situation
+  if (end > file_buffer_end || end < file_buffer)
+    throw(std::runtime_error("Error of reading"));
+  if (!fd)
+    throw(std::runtime_error("Open some file first"));
+
+  unsigned long long *start = end;
+  unsigned short *event = raw_event;
+
+  eventStatus = 0;
+  size_t dccWordCount = 0;
+  end = 0;
+
+  while (!end && dccWordCount < 50000 * 40) {
+    unsigned long long *dccWord = start;
+    unsigned long long preHeader = 0;
+
+    // Did we reach end of current buffer and want to read next block?
+    // If it was first time and we don't have file buffer then we won't get inside
+    while (dccWord < file_buffer_end && dccWordCount < 50000) {
+      word_0 = word_1;                                                // delay by 2 DCC words
+      word_1 = word_2;                                                // delay by 1 DCC word
+      word_2 = *dccWord;                                              // current DCC word
+      if ((word_1 & 0xF0000000000000FFLL) == 0x500000000000005FLL &&  // let's call this a preHeader
+          (word_2 & 0xFF000000000000FFLL) == 0xD900000000000017LL)    // and this is a header
+      {
+        if (eventStatus & Header)  // Second header
+        {
+          word_2 = word_1;  // Fall back to get rigth preHeader next time
+          end = dccWord;    // Even if we end with preHeader of next evet put it to the end of this event too
+          break;
+        }
+        if (dccWordCount > 1)  // Extra words between trailer and header
+        {
+          if ((word_0 & 0xFFFFFFFFFFFF0000LL) == 0xFFFFFFFFFFFF0000LL)
+            eventStatus |= FFFF;
+          word_2 = word_1;  // Fall back to get rigth preHeader next time
+          end = dccWord;
+          break;
+        }
+        eventStatus |= Header;
+        if (event == raw_event)
+          preHeader = word_1;  // If preHeader not yet in event then put it there
+        start = dccWord;
+      }
+      if ((word_1 & 0xFF00000000000000LL) == 0xEF00000000000000LL &&
+          (word_2 & 0xFF0000000000000FLL) == 0xAF00000000000007LL) {
+        eventStatus |= Trailer;
+        end = ++dccWord;
+        break;
+      }
+      // Increase counters by one DCC word
+      dccWord++;
+      dccWordCount++;
+    }
+
+    // If have DCC Header
+    if (preHeader) {
+      // Need to account first word of DCC Header
+      memcpy(event, &preHeader, sizeof(preHeader));
+      event += sizeof(preHeader) / sizeof(unsigned short);
+    }
+
+    // Take care of the rest
+    memcpy(event, start, (dccWord - start) * sizeof(unsigned long long));
+    event += (dccWord - start) * sizeof(unsigned long long) / sizeof(unsigned short);
+
+    // If reach max length
+    if (dccWordCount == 50000 * 40) {
+      end = dccWord;
+      break;
+    }
+
+    if (!end) {
+      // Need to read next block for the rest of this event
+      ssize_t length = ::read(fd, file_buffer, sizeof(file_buffer));
+      if (length == -1)
+        throw(std::runtime_error("Error of reading"));
+      if (length == 0) {
+        eventStatus |= EndOfStream;
+        end = (file_buffer_end = file_buffer + sizeof(file_buffer) / sizeof(unsigned long long));
+        break;
+      }
+      file_buffer_end = file_buffer + length / sizeof(unsigned long long);
+
+      // Will start from the beginning of new buffer next time we read it
+      start = file_buffer;
+    }
+  }
+
+  if (!end)
+    eventStatus |= DCCoversize;
+  if (!(eventStatus & Header) && !(eventStatus & Trailer) && !(eventStatus & FFFF))
+    eventStatus |= Unknown;
+
+  buf = (const unsigned short *)raw_event;
+  return (eventStatus & FFFF ? event - raw_event - 4 : event - raw_event);
+}
+
+size_t FileReaderDCC::next(const unsigned short *&buf) {
+  size_t size = 0;
+  do {
+    if ((size = read(buf)) == 0)
+      break;
+  } while (rejectCriteria & eventStatus || !(acceptCriteria & eventStatus) ||
+           (selectCriteria ? selectCriteria != eventStatus : 0));
+  return size;
+}

--- a/IORawData/CSCCommissioning/src/FileReaderDCC.cc
+++ b/IORawData/CSCCommissioning/src/FileReaderDCC.cc
@@ -17,7 +17,7 @@ FileReaderDCC::FileReaderDCC(void) {
     throw std::runtime_error(std::string("Wrong platform: sizeof(unsigned long long)!=8 || sizeof(unsigned short)!=2"));
   raw_event = new unsigned short[200000 * 40];
   end = (file_buffer_end = file_buffer + sizeof(file_buffer) / sizeof(unsigned long long));
-  bzero(raw_event, sizeof(raw_event));
+  bzero(raw_event, sizeof(raw_event) * 200000 * 40);
   bzero(file_buffer, sizeof(file_buffer));
   word_0 = 0;
   word_1 = 0;

--- a/IORawData/CSCCommissioning/src/FileReaderDCC.h
+++ b/IORawData/CSCCommissioning/src/FileReaderDCC.h
@@ -1,0 +1,50 @@
+#ifndef FileReaderDCC_h
+#define FileReaderDCC_h
+
+#include <stdexcept>  // std::runtime_error
+#include <unistd.h>   // size_t
+
+class FileReaderDCC {
+private:
+  unsigned short *raw_event;  //[200000*40];
+
+  unsigned long long word_0, word_1, word_2;  // To remember some history
+  unsigned long long file_buffer[4000];       // Read data block for efficiency
+
+  unsigned long long *end, *file_buffer_end;  // where stoped last time and where is end
+
+public:
+  enum { Header = 1, Trailer = 2, DCCoversize = 4, FFFF = 8, Unknown = 16, EndOfStream = 32 };
+  enum {
+    Type1 = Header | Trailer,
+    Type2 = Header,
+    Type3 = Header | DCCoversize,
+    Type4 = Trailer,
+    Type5 = Unknown,
+    Type6 = Unknown | DCCoversize,
+    Type7 = FFFF
+  };  // Andrey Korytov's notations
+private:
+  unsigned int eventStatus, selectCriteria, acceptCriteria, rejectCriteria;
+
+  int fd;
+
+public:
+  int open(const char *filename);
+  size_t read(const unsigned short *&buf);  // Just plain read function
+  size_t next(const unsigned short *&buf);  // Same as ``read'', but returns only events pass certain criteria
+  void select(unsigned int criteria) throw() { selectCriteria = criteria; }  // return events satisfying all criteria
+  void accept(unsigned int criteria) throw() {
+    acceptCriteria = criteria;
+  }  // return all events satisfying any of criteria
+  void reject(unsigned int criteria) throw() {
+    rejectCriteria = criteria;
+  }  // return events not satisfying any of criteria
+
+  unsigned int status(void) const throw() { return eventStatus; }
+
+  FileReaderDCC(void);
+  virtual ~FileReaderDCC(void);
+};
+
+#endif

--- a/IORawData/CSCCommissioning/src/FileReaderDDU.cc
+++ b/IORawData/CSCCommissioning/src/FileReaderDDU.cc
@@ -1,11 +1,11 @@
 #include "FileReaderDDU.h"
-#include <iostream>     // cerr
-#include <errno.h>      // errno
-#include <string.h>     // bzero, memcpy
-#include <stdlib.h>     // exit
-#include <sys/types.h>  // open
-#include <sys/stat.h>   // open
+#include <cerrno>       // errno
+#include <cstdlib>      // exit
+#include <cstring>      // bzero, memcpy
 #include <fcntl.h>      // open
+#include <iostream>     // cerr
+#include <sys/stat.h>   // open
+#include <sys/types.h>  // open
 #include <unistd.h>     // read, close
 
 #ifndef O_LARGEFILE  //for OSX
@@ -54,7 +54,7 @@ size_t FileReaderDDU::read(const unsigned short *&buf) {
 
   eventStatus = 0;
   size_t dduWordCount = 0;
-  end = 0;
+  end = nullptr;
 
   while (!end && dduWordCount < 50000) {
     unsigned long long *dduWord = start;

--- a/IORawData/CSCCommissioning/src/FileReaderDDU.cc
+++ b/IORawData/CSCCommissioning/src/FileReaderDDU.cc
@@ -1,0 +1,152 @@
+#include "FileReaderDDU.h"
+#include <iostream>     // cerr
+#include <errno.h>      // errno
+#include <string.h>     // bzero, memcpy
+#include <stdlib.h>     // exit
+#include <sys/types.h>  // open
+#include <sys/stat.h>   // open
+#include <fcntl.h>      // open
+#include <unistd.h>     // read, close
+
+#ifndef O_LARGEFILE  //for OSX
+#define O_LARGEFILE 0
+#endif
+
+FileReaderDDU::FileReaderDDU(void) {
+  if (sizeof(unsigned long long) != 8 || sizeof(unsigned short) != 2)
+    throw std::runtime_error(std::string("Wrong platform: sizeof(unsigned long long)!=8 || sizeof(unsigned short)!=2"));
+  end = (file_buffer_end = file_buffer + sizeof(file_buffer) / sizeof(unsigned long long));
+  bzero(raw_event, sizeof(raw_event));
+  bzero(file_buffer, sizeof(file_buffer));
+  word_0 = 0;
+  word_1 = 0;
+  word_2 = 0;
+  eventStatus = 0;
+  selectCriteria = Header | Trailer;
+  rejectCriteria = DDUoversize | FFFF | Unknown;
+  acceptCriteria = 0x3F;  // Everything
+  fd = 0;
+}
+
+FileReaderDDU::~FileReaderDDU(void) {
+  if (fd)
+    close(fd);
+}
+
+int FileReaderDDU::open(const char *filename) {
+  if (fd)
+    close(fd);
+  fd = ::open(filename, O_RDONLY | O_LARGEFILE);
+  if (fd == -1)
+    throw(std::runtime_error(std::string("Error opening ").append(filename).append(" data file.")));
+  return fd;
+}
+
+size_t FileReaderDDU::read(const unsigned short *&buf) {
+  // Check for ubnormal situation
+  if (end > file_buffer_end || end < file_buffer)
+    throw(std::runtime_error("Error of reading"));
+  if (!fd)
+    throw(std::runtime_error("Open some file first"));
+
+  unsigned long long *start = end;
+  unsigned short *event = raw_event;
+
+  eventStatus = 0;
+  size_t dduWordCount = 0;
+  end = 0;
+
+  while (!end && dduWordCount < 50000) {
+    unsigned long long *dduWord = start;
+    unsigned long long preHeader = 0;
+
+    // Did we reach end of current buffer and want to read next block?
+    // If it was first time and we don't have file buffer then we won't get inside
+    while (dduWord < file_buffer_end && dduWordCount < 50000) {
+      word_0 = word_1;    // delay by 2 DDU words
+      word_1 = word_2;    // delay by 1 DDU word
+      word_2 = *dduWord;  // current DDU word
+      if ((word_2 & 0xFFFFFFFFFFFF0000LL) == 0x8000000180000000LL) {
+        if (eventStatus & Header)  // Second header
+        {
+          word_2 = word_1;  // Fall back to get rigth preHeader next time
+          end = dduWord;    // Even if we end with preHeader of next evet put it to the end of this event too
+          break;
+        }
+        if (dduWordCount > 1)  // Extra words between trailer and header
+        {
+          if ((word_0 & 0xFFFFFFFFFFFF0000LL) == 0xFFFFFFFFFFFF0000LL)
+            eventStatus |= FFFF;
+          word_2 = word_1;  // Fall back to get rigth preHeader next time
+          end = dduWord;
+          break;
+        }
+        eventStatus |= Header;
+        if (event == raw_event)
+          preHeader = word_1;  // If preHeader not yet in event then put it there
+        start = dduWord;
+      }
+      if ((word_0 & 0xFFFFFFFFFFFF0000LL) == 0x8000FFFF80000000LL) {
+        eventStatus |= Trailer;
+        end = ++dduWord;
+        break;
+      }
+      // Increase counters by one DDU word
+      dduWord++;
+      dduWordCount++;
+    }
+
+    // If have DDU Header
+    if (preHeader) {
+      // Need to account first word of DDU Header
+      memcpy(event, &preHeader, sizeof(preHeader));
+      event += sizeof(preHeader) / sizeof(unsigned short);
+    }
+
+    // Take care of the rest
+    memcpy(event, start, (dduWord - start) * sizeof(unsigned long long));
+    event += (dduWord - start) * sizeof(unsigned long long) / sizeof(unsigned short);
+
+    // If reach max length
+    if (dduWordCount == 50000) {
+      end = dduWord;
+      break;
+    }
+
+    if (!end) {
+      // Need to read next block for the rest of this event
+      ssize_t length = ::read(fd, file_buffer, sizeof(file_buffer));
+      if (length == -1)
+        throw(std::runtime_error("Error of reading"));
+      if (length == 0) {
+        eventStatus |= EndOfStream;
+        end = (file_buffer_end = file_buffer + sizeof(file_buffer) / sizeof(unsigned long long));
+        break;
+      }
+      file_buffer_end = file_buffer + length / sizeof(unsigned long long);
+
+      // Will start from the beginning of new buffer next time we read it
+      start = file_buffer;
+    }
+  }
+
+  if (!end)
+    eventStatus |= DDUoversize;
+  if (!(eventStatus & Header) && !(eventStatus & Trailer) && !(eventStatus & FFFF))
+    eventStatus |= Unknown;
+
+  buf = (const unsigned short *)raw_event;
+  return (eventStatus & FFFF ? event - raw_event - 4 : event - raw_event);
+}
+
+size_t FileReaderDDU::next(const unsigned short *&buf, int prescaling) {
+  size_t size = 0;
+  for (int i = 0; i < prescaling; i++) {
+    do {
+      if ((size = read(buf)) == 0)
+        break;
+    } while (rejectCriteria & eventStatus || !(acceptCriteria & eventStatus) ||
+             (selectCriteria ? selectCriteria != eventStatus : 0));
+  }
+  return size;
+}

--- a/IORawData/CSCCommissioning/src/FileReaderDDU.h
+++ b/IORawData/CSCCommissioning/src/FileReaderDDU.h
@@ -1,0 +1,51 @@
+#ifndef FileReaderDDU_h
+#define FileReaderDDU_h
+
+#include <stdexcept>  // std::runtime_error
+#include <unistd.h>   // size_t
+
+class FileReaderDDU {
+private:
+  unsigned short raw_event[200000];
+
+  unsigned long long word_0, word_1, word_2;  // To remember some history
+  unsigned long long file_buffer[4000];       // Read data block for efficiency
+
+  unsigned long long *end, *file_buffer_end;  // where stoped last time and where is end
+
+public:
+  enum { Header = 1, Trailer = 2, DDUoversize = 4, FFFF = 8, Unknown = 16, EndOfStream = 32 };
+  enum {
+    Type1 = Header | Trailer,
+    Type2 = Header,
+    Type3 = Header | DDUoversize,
+    Type4 = Trailer,
+    Type5 = Unknown,
+    Type6 = Unknown | DDUoversize,
+    Type7 = FFFF
+  };  // Andrey Korytov's notations
+private:
+  unsigned int eventStatus, selectCriteria, acceptCriteria, rejectCriteria;
+
+  int fd;
+
+public:
+  int open(const char *filename);
+  size_t read(const unsigned short *&buf);  // Just plain read function
+  size_t next(const unsigned short *&buf,
+              int prescaling = 1);  // Same as ``read'', but returns only events pass certain criteria
+  void select(unsigned int criteria) throw() { selectCriteria = criteria; }  // return events satisfying all criteria
+  void accept(unsigned int criteria) throw() {
+    acceptCriteria = criteria;
+  }  // return all events satisfying any of criteria
+  void reject(unsigned int criteria) throw() {
+    rejectCriteria = criteria;
+  }  // return events not satisfying any of criteria
+
+  unsigned int status(void) const throw() { return eventStatus; }
+
+  FileReaderDDU(void);
+  virtual ~FileReaderDDU(void);
+};
+
+#endif

--- a/IORawData/CSCCommissioning/src/SealModule.cc
+++ b/IORawData/CSCCommissioning/src/SealModule.cc
@@ -1,0 +1,6 @@
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/PluginManager/interface/ModuleDef.h"
+#include "CSCFileReader.h"
+#include "CSCFileDumper.h"
+DEFINE_FWK_MODULE(CSCFileReader);
+DEFINE_FWK_MODULE(CSCFileDumper);

--- a/IORawData/CSCCommissioning/test/dumpTest.py
+++ b/IORawData/CSCCommissioning/test/dumpTest.py
@@ -1,0 +1,26 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("TEST")
+
+process.load("FWCore.MessageLogger.MessageLogger_cfi")
+process.MessageLogger.cout.placeholder = cms.untracked.bool(False)
+process.MessageLogger.cout.threshold = cms.untracked.string('INFO')
+process.MessageLogger.debugModules = cms.untracked.vstring('*')
+
+process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(-1) )
+
+process.source = cms.Source ("PoolSource", 
+	duplicateCheckMode = cms.untracked.string('noDuplicateCheck'),
+    	fileNames = cms.untracked.vstring(
+	'file:/tmp/barvic/csc_00221766_Cosmic.root'
+    )
+)
+
+process.cscdumper = cms.EDAnalyzer("CSCFileDumper",
+    source = cms.InputTag("rawDataCollector"),
+    output = cms.untracked.string("/tmp/barvic/raw_dump"),
+#    events = cms.untracked.string("1073500,1166393")
+)
+
+process.p = cms.Path(process.cscdumper)
+

--- a/IORawData/CSCCommissioning/test/readFile.py
+++ b/IORawData/CSCCommissioning/test/readFile.py
@@ -1,0 +1,33 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("reader")
+
+process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(-1) )
+
+process.load("FWCore.MessageLogger.MessageLogger_cfi")
+process.MessageLogger.cout.placeholder = cms.untracked.bool(False)
+process.MessageLogger.cout.threshold = cms.untracked.string('INFO')
+process.MessageLogger.debugModules = cms.untracked.vstring('*')
+
+process.options = cms.untracked.PSet( wantSummary = cms.untracked.bool(True) )
+
+process.source = cms.Source("EmptySource",
+      firstRun= cms.untracked.uint32(298313),
+      numberEventsInLuminosityBlock = cms.untracked.uint32(200),
+      numberEventsInRun       = cms.untracked.uint32(0)
+)
+
+process.rawDataCollector = cms.EDProducer('CSCFileReader',
+      firstEvent  = cms.untracked.int32(0),
+      FED856 = cms.untracked.vstring('RUI33'),
+      RUI33 = cms.untracked.vstring('/tmp/barvic/csc_00298313_EmuRUI33_Local_000.raw')
+)
+
+process.FEVT = cms.OutputModule("PoolOutputModule",
+        fileName = cms.untracked.string("/tmp/barvic/csc_00298313_GEM_Test.root"),
+        outputCommands = cms.untracked.vstring("keep *")
+)
+
+process.p = cms.Path( process.rawDataCollector)
+
+process.outpath = cms.EndPath(process.FEVT)

--- a/IORawData/CSCCommissioning/test/stripDCC.cc
+++ b/IORawData/CSCCommissioning/test/stripDCC.cc
@@ -1,0 +1,35 @@
+#include <stdio.h>
+#include <errno.h>
+#include "../src/FileReaderDDU.cc"
+// To compile: g++ -o stripDCC stripDCC.cc
+
+int main(int argc, char *argv[]) {
+  if (argc != 3) {
+    printf("Usage: ./stripDCC INPUT_FILENAME OUTPUT_FILENAME\n");
+    return 0;
+  }
+  FILE *out;
+  if ((out = fopen(argv[2], "wt")) == NULL) {
+    printf("Cannot open output file: %s (errno=%d)\n", argv[2], errno);
+    return 1;
+  }
+  FileReaderDDU reader;
+  reader.reject(FileReaderDDU::Unknown);
+  reader.select(0);
+  try {
+    reader.open(argv[1]);
+  } catch (std::runtime_error &e) {
+    printf("Cannot open input file: %s (errno=%d)\n", argv[1], errno);
+  }
+  const unsigned short *buf = 0;
+  size_t length = 0;
+  int nEvents = 0;
+  while ((length = reader.next(buf)) != 0) {
+    fwrite(buf, 2, length, out);
+    nEvents++;
+  }
+  fclose(out);
+
+  printf("nEvents=%d\n", nEvents);
+  return 0;
+}


### PR DESCRIPTION
#### PR description:
Re-introduce IORawData/CSCCommissioning CSC-specific utilities module, which was originally used to convert CSC Local DAQ raw data format files to/from CMSSW ROOT raw data files format.
- convert CSC local DAQ raw data files to CMSSW root data files
- extract CSC raw data from CMSSW root data files and convert it to CSC local DAQ raw data format files

This module was removed from the IORawData back in 2013 because of failed dependencies (it was depending on obsolete DaqSource), which were not fixed at that time.

This module is still used by members of CSC group for various commissioning and development tasks, when CSC Local DAQ raw data files are produced and which needs to be converted to CMSSW-compatible data format for further processing with CMSSW-based analysises.
Also it provides extraction and conversion of CMSSW format raw data to CSC Local DAQ raw data format files to use with CSC standalone tools outside of CMSSW framework.

#### PR validation:
It compiles and was tested with recently produced CSC Local DAQ files.

