### PR TITLE
Load CLCT pre-trigger digis in CSC packer. Skeleton code to pack/unpack CSCShowerDigi (HadronicShowerTrigger-3)

### DIFF
--- a/EventFilter/CSCRawToDigi/interface/CSCDigiToRaw.h
+++ b/EventFilter/CSCRawToDigi/interface/CSCDigiToRaw.h
@@ -15,6 +15,7 @@
 #include "DataFormats/CSCDigi/interface/CSCCLCTPreTriggerCollection.h"
 #include "DataFormats/CSCDigi/interface/CSCCLCTPreTriggerDigiCollection.h"
 #include "DataFormats/CSCDigi/interface/CSCCorrelatedLCTDigiCollection.h"
+#include "DataFormats/CSCDigi/interface/CSCShowerDigiCollection.h"
 #include "DataFormats/GEMDigi/interface/GEMPadDigiClusterCollection.h"
 #include "EventFilter/CSCRawToDigi/interface/CSCEventData.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -37,6 +38,7 @@ public:
                         const CSCCLCTPreTriggerCollection* preTriggers,
                         const CSCCLCTPreTriggerDigiCollection* preTriggerDigis,
                         const CSCCorrelatedLCTDigiCollection& correlatedLCTDigis,
+                        const CSCShowerDigiCollection* showerDigis,
                         const GEMPadDigiClusterCollection* padDigiClusters,
                         FEDRawDataCollection& fed_buffers,
                         const CSCChamberMap* theMapping,
@@ -72,6 +74,7 @@ private:
   void add(const CSCALCTDigiCollection& alctDigis, FindEventDataInfo&) const;
   void add(const CSCCLCTDigiCollection& clctDigis, FindEventDataInfo&) const;
   void add(const CSCCorrelatedLCTDigiCollection& corrLCTDigis, FindEventDataInfo&) const;
+  void add(const CSCShowerDigiCollection& cscShowerDigis, FindEventDataInfo&) const;
   void add(const GEMPadDigiClusterCollection& gemPadClusters, FindEventDataInfo&) const;
   /// pick out the correct data object for this chamber
   CSCEventData& findEventData(const CSCDetId& cscDetId, FindEventDataInfo&) const;

--- a/EventFilter/CSCRawToDigi/interface/CSCDigiToRaw.h
+++ b/EventFilter/CSCRawToDigi/interface/CSCDigiToRaw.h
@@ -1,5 +1,5 @@
-#ifndef EventFilter_CSCDigiToRaw_h
-#define EventFilter_CSCDigiToRaw_h
+#ifndef EventFilter_CSCRawToDigi_CSCDigiToRaw_h
+#define EventFilter_CSCRawToDigi_CSCDigiToRaw_h
 
 /** \class CSCDigiToRaw
  *
@@ -13,6 +13,7 @@
 #include "DataFormats/CSCDigi/interface/CSCALCTDigiCollection.h"
 #include "DataFormats/CSCDigi/interface/CSCCLCTDigiCollection.h"
 #include "DataFormats/CSCDigi/interface/CSCCLCTPreTriggerCollection.h"
+#include "DataFormats/CSCDigi/interface/CSCCLCTPreTriggerDigiCollection.h"
 #include "DataFormats/CSCDigi/interface/CSCCorrelatedLCTDigiCollection.h"
 #include "DataFormats/GEMDigi/interface/GEMPadDigiClusterCollection.h"
 #include "EventFilter/CSCRawToDigi/interface/CSCEventData.h"
@@ -34,6 +35,7 @@ public:
                         const CSCALCTDigiCollection& alctDigis,
                         const CSCCLCTDigiCollection& clctDigis,
                         const CSCCLCTPreTriggerCollection* preTriggers,
+                        const CSCCLCTPreTriggerDigiCollection* preTriggerDigis,
                         const CSCCorrelatedLCTDigiCollection& correlatedLCTDigis,
                         const GEMPadDigiClusterCollection* padDigiClusters,
                         FEDRawDataCollection& fed_buffers,
@@ -55,6 +57,7 @@ private:
   // specialized because it reverses strip direction
   void add(const CSCStripDigiCollection& stripDigis,
            const CSCCLCTPreTriggerCollection* preTriggers,
+           const CSCCLCTPreTriggerDigiCollection* preTriggerDigis,
            FindEventDataInfo&,
            bool packEverything) const;
   void add(const CSCWireDigiCollection& wireDigis,

--- a/EventFilter/CSCRawToDigi/interface/CSCEventData.h
+++ b/EventFilter/CSCRawToDigi/interface/CSCEventData.h
@@ -102,6 +102,7 @@ public:
   void add(const std::vector<CSCALCTDigi> &);
   void add(const std::vector<CSCCLCTDigi> &);
   void add(const std::vector<CSCCorrelatedLCTDigi> &);
+  void add(const std::vector<CSCShowerDigi> &);
   void add(const std::vector<GEMPadDigiCluster> &, const GEMDetId &);
 
   /// this will fill the DMB header, and change all related fields in

--- a/EventFilter/CSCRawToDigi/interface/CSCTMBHeader.h
+++ b/EventFilter/CSCRawToDigi/interface/CSCTMBHeader.h
@@ -10,6 +10,7 @@
 #include "DataFormats/CSCDigi/interface/CSCALCTDigi.h"
 #include "DataFormats/CSCDigi/interface/CSCCLCTDigi.h"
 #include "DataFormats/CSCDigi/interface/CSCCorrelatedLCTDigi.h"
+#include "DataFormats/CSCDigi/interface/CSCShowerDigi.h"
 #include "DataFormats/GEMDigi/interface/GEMPadDigiCluster.h"
 #include "EventFilter/CSCRawToDigi/interface/CSCVTMBHeaderFormat.h"
 #include "FWCore/Utilities/interface/Exception.h"
@@ -99,6 +100,7 @@ public:
   /// these methods need more brains to figure which one goes first
   void add(const std::vector<CSCCLCTDigi>& digis);
   void add(const std::vector<CSCCorrelatedLCTDigi>& digis);
+  void add(const std::vector<CSCShowerDigi>& digis);
 
   /// tests that packing and unpacking give same results
   static void selfTest(int firmwwareVersion, int firmwareRevision);

--- a/EventFilter/CSCRawToDigi/interface/CSCTMBHeader2006.h
+++ b/EventFilter/CSCRawToDigi/interface/CSCTMBHeader2006.h
@@ -47,6 +47,7 @@ struct CSCTMBHeader2006 : public CSCVTMBHeaderFormat {
   void addALCT1(const CSCALCTDigi& digi) override;
   void addCorrelatedLCT0(const CSCCorrelatedLCTDigi& digi) override;
   void addCorrelatedLCT1(const CSCCorrelatedLCTDigi& digi) override;
+  void addShower(const CSCShowerDigi& digi) override {}
 
   void swapCLCTs(CSCCLCTDigi& digi1, CSCCLCTDigi& digi2);
 

--- a/EventFilter/CSCRawToDigi/interface/CSCTMBHeader2007.h
+++ b/EventFilter/CSCRawToDigi/interface/CSCTMBHeader2007.h
@@ -50,6 +50,7 @@ struct CSCTMBHeader2007 : public CSCVTMBHeaderFormat {
   void addALCT1(const CSCALCTDigi& digi) override;
   void addCorrelatedLCT0(const CSCCorrelatedLCTDigi& digi) override;
   void addCorrelatedLCT1(const CSCCorrelatedLCTDigi& digi) override;
+  void addShower(const CSCShowerDigi& digi) override {}
 
   void swapCLCTs(CSCCLCTDigi& digi1, CSCCLCTDigi& digi2);
 

--- a/EventFilter/CSCRawToDigi/interface/CSCTMBHeader2007_rev0x50c3.h
+++ b/EventFilter/CSCRawToDigi/interface/CSCTMBHeader2007_rev0x50c3.h
@@ -50,6 +50,7 @@ struct CSCTMBHeader2007_rev0x50c3 : public CSCVTMBHeaderFormat {
   void addALCT1(const CSCALCTDigi& digi) override;
   void addCorrelatedLCT0(const CSCCorrelatedLCTDigi& digi) override;
   void addCorrelatedLCT1(const CSCCorrelatedLCTDigi& digi) override;
+  void addShower(const CSCShowerDigi& digi) override {}
 
   void swapCLCTs(CSCCLCTDigi& digi1, CSCCLCTDigi& digi2);
 

--- a/EventFilter/CSCRawToDigi/interface/CSCTMBHeader2013.h
+++ b/EventFilter/CSCRawToDigi/interface/CSCTMBHeader2013.h
@@ -50,6 +50,7 @@ struct CSCTMBHeader2013 : public CSCVTMBHeaderFormat {
   void addALCT1(const CSCALCTDigi& digi) override;
   void addCorrelatedLCT0(const CSCCorrelatedLCTDigi& digi) override;
   void addCorrelatedLCT1(const CSCCorrelatedLCTDigi& digi) override;
+  void addShower(const CSCShowerDigi& digi) override {}
 
   void swapCLCTs(CSCCLCTDigi& digi1, CSCCLCTDigi& digi2);
 

--- a/EventFilter/CSCRawToDigi/interface/CSCVTMBHeaderFormat.h
+++ b/EventFilter/CSCRawToDigi/interface/CSCVTMBHeaderFormat.h
@@ -4,6 +4,7 @@
 #include "DataFormats/CSCDigi/interface/CSCCLCTDigi.h"
 #include "DataFormats/CSCDigi/interface/CSCALCTDigi.h"
 #include "DataFormats/CSCDigi/interface/CSCCorrelatedLCTDigi.h"
+#include "DataFormats/CSCDigi/interface/CSCShowerDigi.h"
 #include "DataFormats/MuonDetId/interface/CSCDetId.h"
 #include "DataFormats/CSCDigi/interface/CSCConstants.h"
 #include <vector>
@@ -56,6 +57,7 @@ public:
   virtual void addALCT1(const CSCALCTDigi& digi) = 0;
   virtual void addCorrelatedLCT0(const CSCCorrelatedLCTDigi& digi) = 0;
   virtual void addCorrelatedLCT1(const CSCCorrelatedLCTDigi& digi) = 0;
+  void addShower(const CSCShowerDigi& digi) {}
 
   virtual void print(std::ostream& os) const = 0;
 

--- a/EventFilter/CSCRawToDigi/interface/CSCVTMBHeaderFormat.h
+++ b/EventFilter/CSCRawToDigi/interface/CSCVTMBHeaderFormat.h
@@ -57,7 +57,7 @@ public:
   virtual void addALCT1(const CSCALCTDigi& digi) = 0;
   virtual void addCorrelatedLCT0(const CSCCorrelatedLCTDigi& digi) = 0;
   virtual void addCorrelatedLCT1(const CSCCorrelatedLCTDigi& digi) = 0;
-  void addShower(const CSCShowerDigi& digi) {}
+  virtual void addShower(const CSCShowerDigi& digi) = 0;
 
   virtual void print(std::ostream& os) const = 0;
 

--- a/EventFilter/CSCRawToDigi/python/cscPacker_cfi.py
+++ b/EventFilter/CSCRawToDigi/python/cscPacker_cfi.py
@@ -1,22 +1,8 @@
 import FWCore.ParameterSet.Config as cms
 
-cscpacker = cms.EDProducer("CSCDigiToRawModule",
-    wireDigiTag = cms.InputTag("simMuonCSCDigis","MuonCSCWireDigi"),
-    stripDigiTag = cms.InputTag("simMuonCSCDigis","MuonCSCStripDigi"),
-    comparatorDigiTag = cms.InputTag("simMuonCSCDigis","MuonCSCComparatorDigi"),
-    alctDigiTag = cms.InputTag("simCscTriggerPrimitiveDigis"),
-    clctDigiTag = cms.InputTag("simCscTriggerPrimitiveDigis"),
-    preTriggerTag = cms.InputTag("simCscTriggerPrimitiveDigis"),
-    correlatedLCTDigiTag = cms.InputTag("simCscTriggerPrimitiveDigis", "MPCSORTED"),
-    # if min parameter = -999 always accept
-    alctWindowMin = cms.int32(-3),
-    alctWindowMax = cms.int32(3),
-    clctWindowMin = cms.int32(-3),
-    clctWindowMax = cms.int32(3),
-    preTriggerWindowMin = cms.int32(-3),
-    preTriggerWindowMax = cms.int32(1)
-)
-
+## baseline configuration in the class itself
+from EventFilter.CSCRawToDigi.cscPackerDef_cfi import cscPackerDef
+cscpacker = cscPackerDef.clone()
 
 ##
 ## Make changes for running in Run 2

--- a/EventFilter/CSCRawToDigi/python/cscPacker_cfi.py
+++ b/EventFilter/CSCRawToDigi/python/cscPacker_cfi.py
@@ -9,11 +9,13 @@ cscpacker = cscPackerDef.clone()
 ##
 # packer - simply get rid of it
 from Configuration.Eras.Modifier_run2_common_cff import run2_common
-run2_common.toModify( cscpacker, useFormatVersion = cms.uint32(2013) )
-run2_common.toModify( cscpacker, usePreTriggers = cms.bool(False) )
-run2_common.toModify( cscpacker, packEverything = cms.bool(True) )
+run2_common.toModify( cscpacker,
+                      useFormatVersion = 2013,
+                      usePreTriggers = False,
+                      packEverything = True)
 
 ## in Run-3 include GEMs
 from Configuration.Eras.Modifier_run3_GEM_cff import run3_GEM
-run3_GEM.toModify( cscpacker, padDigiClusterTag = cms.InputTag("simMuonGEMPadDigiClusters") )
-run3_GEM.toModify( cscpacker, useGEMs = cms.bool(False) )
+run3_GEM.toModify( cscpacker,
+                   padDigiClusterTag = "simMuonGEMPadDigiClusters",
+                   useGEMs = False)

--- a/EventFilter/CSCRawToDigi/python/cscUnpacker_cfi.py
+++ b/EventFilter/CSCRawToDigi/python/cscUnpacker_cfi.py
@@ -2,30 +2,12 @@ import FWCore.ParameterSet.Config as cms
 
 # Import from the generic cfi file for CSC unpacking
 from EventFilter.CSCRawToDigi.muonCSCDCCUnpacker_cfi import muonCSCDCCUnpacker
-muonCSCDigis = muonCSCDCCUnpacker.clone()
 
-# Define input to the unpacker
-muonCSCDigis.InputObjects = cms.InputTag("rawDataCollector")
-# Use CSC examiner to check for corrupt or semi-corrupt data & avoid unpacker crashes
-muonCSCDigis.UseExaminer = cms.bool(True)
-# This mask is needed by the examiner
-muonCSCDigis.ExaminerMask = cms.uint32(0x1FEBF7F6)
-# Use Examiner to unpack good chambers and skip only bad ones
-muonCSCDigis.UseSelectiveUnpacking = cms.bool(True)
-# This mask simply reduces error reporting
-muonCSCDigis.ErrorMask = cms.uint32(0x0)
-# Unpack general status digis?
-muonCSCDigis.UnpackStatusDigis = cms.bool(False)
-# Unpack FormatStatus digi?
-muonCSCDigis.UseFormatStatus = cms.bool(True)
-# Turn on lots of output
-muonCSCDigis.Debug = cms.untracked.bool(False)
-muonCSCDigis.PrintEventNumber = cms.untracked.bool(False)
-# Visualization of raw data in corrupted events
-muonCSCDigis.VisualFEDInspect = cms.untracked.bool(False)
-muonCSCDigis.VisualFEDShort = cms.untracked.bool(False)
-muonCSCDigis.FormatedEventDump = cms.untracked.bool(False)
+muonCSCDigis = muonCSCDCCUnpacker.clone(
+    # This mask is needed by the examiner
+    ExaminerMask = 0x1FEBF7F6
+)
 
 ## in Run-3 include GEMs
 from Configuration.Eras.Modifier_run3_GEM_cff import run3_GEM
-run3_GEM.toModify( muonCSCDigis, useGEMs = cms.bool(False) )
+run3_GEM.toModify( muonCSCDigis, useGEMs = False )

--- a/EventFilter/CSCRawToDigi/python/cscUnpacker_cfi.py
+++ b/EventFilter/CSCRawToDigi/python/cscUnpacker_cfi.py
@@ -1,9 +1,9 @@
 import FWCore.ParameterSet.Config as cms
 
 # Import from the generic cfi file for CSC unpacking
-import EventFilter.CSCRawToDigi.muonCSCDCCUnpacker_cfi
+from EventFilter.CSCRawToDigi.muonCSCDCCUnpacker_cfi import muonCSCDCCUnpacker
+muonCSCDigis = muonCSCDCCUnpacker.clone()
 
-muonCSCDigis = EventFilter.CSCRawToDigi.muonCSCDCCUnpacker_cfi.muonCSCDCCUnpacker.clone()
 # Define input to the unpacker
 muonCSCDigis.InputObjects = cms.InputTag("rawDataCollector")
 # Use CSC examiner to check for corrupt or semi-corrupt data & avoid unpacker crashes

--- a/EventFilter/CSCRawToDigi/src/CSCDigiToRaw.cc
+++ b/EventFilter/CSCRawToDigi/src/CSCDigiToRaw.cc
@@ -139,6 +139,7 @@ CSCEventData& CSCDigiToRaw::findEventData(const CSCDetId& cscDetId, FindEventDat
 
 void CSCDigiToRaw::add(const CSCStripDigiCollection& stripDigis,
                        const CSCCLCTPreTriggerCollection* preTriggers,
+                       const CSCCLCTPreTriggerDigiCollection* preTriggerDigis,
                        FindEventDataInfo& fedInfo,
                        bool packEverything) const {  //iterate over chambers with strip digis in them
   for (CSCStripDigiCollection::DigiRangeIterator j = stripDigis.begin(); j != stripDigis.end(); ++j) {
@@ -350,6 +351,7 @@ void CSCDigiToRaw::createFedBuffers(const CSCStripDigiCollection& stripDigis,
                                     const CSCALCTDigiCollection& alctDigis,
                                     const CSCCLCTDigiCollection& clctDigis,
                                     const CSCCLCTPreTriggerCollection* preTriggers,
+                                    const CSCCLCTPreTriggerDigiCollection* preTriggerDigis,
                                     const CSCCorrelatedLCTDigiCollection& correlatedLCTDigis,
                                     const GEMPadDigiClusterCollection* gemPadDigiClusters,
                                     FEDRawDataCollection& fed_buffers,
@@ -362,7 +364,7 @@ void CSCDigiToRaw::createFedBuffers(const CSCStripDigiCollection& stripDigis,
   //get fed object from fed_buffers
   // make a map from the index of a chamber to the event data from it
   FindEventDataInfo fedInfo{mapping, format_version};
-  add(stripDigis, preTriggers, fedInfo, packEverything);
+  add(stripDigis, preTriggers, preTriggerDigis, fedInfo, packEverything);
   add(wireDigis, alctDigis, fedInfo, packEverything);
   add(comparatorDigis, clctDigis, fedInfo, packEverything);
   add(correlatedLCTDigis, fedInfo);

--- a/EventFilter/CSCRawToDigi/src/CSCDigiToRaw.cc
+++ b/EventFilter/CSCRawToDigi/src/CSCDigiToRaw.cc
@@ -333,6 +333,15 @@ void CSCDigiToRaw::add(const CSCCorrelatedLCTDigiCollection& corrLCTDigis, FindE
   }
 }
 
+void CSCDigiToRaw::add(const CSCShowerDigiCollection& cscShowerDigis, FindEventDataInfo& fedInfo) const {
+  for (const auto& shower : cscShowerDigis) {
+    const CSCDetId& cscDetId = shower.first;
+    CSCEventData& cscData = findEventData(cscDetId, fedInfo);
+
+    cscData.add(std::vector<CSCShowerDigi>(shower.second.first, shower.second.second));
+  }
+}
+
 void CSCDigiToRaw::add(const GEMPadDigiClusterCollection& gemPadClusters, FindEventDataInfo& fedInfo) const {
   for (const auto& jclus : gemPadClusters) {
     const GEMDetId& gemDetId = jclus.first;
@@ -353,6 +362,7 @@ void CSCDigiToRaw::createFedBuffers(const CSCStripDigiCollection& stripDigis,
                                     const CSCCLCTPreTriggerCollection* preTriggers,
                                     const CSCCLCTPreTriggerDigiCollection* preTriggerDigis,
                                     const CSCCorrelatedLCTDigiCollection& correlatedLCTDigis,
+                                    const CSCShowerDigiCollection* cscShowerDigis,
                                     const GEMPadDigiClusterCollection* gemPadDigiClusters,
                                     FEDRawDataCollection& fed_buffers,
                                     const CSCChamberMap* mapping,
@@ -368,6 +378,12 @@ void CSCDigiToRaw::createFedBuffers(const CSCStripDigiCollection& stripDigis,
   add(wireDigis, alctDigis, fedInfo, packEverything);
   add(comparatorDigis, clctDigis, fedInfo, packEverything);
   add(correlatedLCTDigis, fedInfo);
+
+  // Starting Run-3, the CSC DAQ will pack/unpack CSC showers
+  if (cscShowerDigis) {
+    add(*cscShowerDigis, fedInfo);
+  }
+
   // Starting Run-3, the CSC DAQ will pack/unpack GEM clusters
   if (gemPadDigiClusters) {
     add(*gemPadDigiClusters, fedInfo);

--- a/EventFilter/CSCRawToDigi/src/CSCEventData.cc
+++ b/EventFilter/CSCRawToDigi/src/CSCEventData.cc
@@ -506,6 +506,8 @@ void CSCEventData::add(const std::vector<CSCCorrelatedLCTDigi>& digis) {
   theTMBData->tmbHeader()->add(digis);
 }
 
+void CSCEventData::add(const std::vector<CSCShowerDigi>& digis) { checkTMBClasses(); }
+
 void CSCEventData::add(const std::vector<GEMPadDigiCluster>& clusters, const GEMDetId&) { checkTMBClasses(); }
 
 std::ostream& operator<<(std::ostream& os, const CSCEventData& evt) {

--- a/EventFilter/CSCRawToDigi/src/CSCTMBHeader.cc
+++ b/EventFilter/CSCRawToDigi/src/CSCTMBHeader.cc
@@ -128,6 +128,11 @@ void CSCTMBHeader::add(const std::vector<CSCCorrelatedLCTDigi> &digis) {
     addCorrelatedLCT1(digis[1]);
 }
 
+void CSCTMBHeader::add(const std::vector<CSCShowerDigi> &digis) {
+  if (!digis.empty())
+    theHeaderFormat->addShower(digis[0]);
+}
+
 CSCTMBHeader2007 CSCTMBHeader::tmbHeader2007() const {
   CSCTMBHeader2007 *result = dynamic_cast<CSCTMBHeader2007 *>(theHeaderFormat.get());
   if (result == nullptr) {

--- a/L1Trigger/CSCTriggerPrimitives/python/cscTriggerPrimitiveDigis_cfi.py
+++ b/L1Trigger/CSCTriggerPrimitives/python/cscTriggerPrimitiveDigis_cfi.py
@@ -39,8 +39,8 @@ cscTriggerPrimitiveDigis = cms.EDProducer(
     # Write out special trigger collections
     writeOutAllCLCTs = cms.bool(False),
     writeOutAllALCTs = cms.bool(False),
-    savePreTriggers = cms.bool(False),
-    writeOutShowers = cms.bool(False),
+    savePreTriggers = cms.bool(True),
+    writeOutShowers = cms.bool(True),
 
     commonParam = auxPSets.commonParam.clone(),
     mpcParam = auxPSets.mpcParamRun1.clone(),


### PR DESCRIPTION
#### PR description:

This PR loads CLCT pre-trigger digis (`CSCCLCTPreTriggerDigiCollection`) in packer, in preparation of packing the `CSCStripDigi` based on the pretrigger decision (as is done in CMS during data taking). In addition, skeleton code was added to pack/unpack CSCShowerDigi. 

Neither addition modifies the CSC packer/unpacker. 

I also cleaned up the configuration of `cscpacker` in `cscPacker_cfi`. The same definition is already in the C++ module (fillDescriptions) and then again as commented Python code in the same file. I removed the duplicates. So `cscpacker` is now defined as a clone of `cscPackerDef` which is automatically generated by the compiler.

#### PR validation:

Code compiles and runs with WF 11634.0. There should not be any changes in any workflows.

```
11634.0_TTbar_14TeV+2021+TTbar_14TeV_TuneCP5_GenSim+Digi+Reco+HARVEST+ALCA Step0-PASSED Step1-PASSED Step2-PASSED Step3-PASSED Step4-PASSED  - time date Thu Apr 15 12:32:46 2021-date Thu Apr 15 12:03:53 2021; exit: 0 0 0 0 0
1 1 1 1 1 tests passed, 0 0 0 0 0 failed
```

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
