### PR TITLE
Data formats for showers in the muon system in Run-3 (HadronicShowerTrigger-4)

### DIFF
--- a/DataFormats/L1TMuon/interface/RegionalMuonShower.h
+++ b/DataFormats/L1TMuon/interface/RegionalMuonShower.h
@@ -1,0 +1,62 @@
+#ifndef DataFormats_L1Trigger_RegionalMuonShower_h
+#define DataFormats_L1Trigger_RegionalMuonShower_h
+
+#include "DataFormats/Common/interface/Ref.h"
+#include "DataFormats/L1Trigger/interface/BXVector.h"
+#include "DataFormats/L1Trigger/interface/L1TObjComparison.h"
+
+namespace l1t {
+
+  class RegionalMuonShower;
+  typedef BXVector<RegionalMuonShower> RegionalMuonShowerBxCollection;
+  typedef ObjectRefBxCollection<RegionalMuonShower> RegionalMuonShowerRefBxCollection;
+  typedef ObjectRefPair<RegionalMuonShower> RegionalMuonShowerRefPair;
+  typedef ObjectRefPairBxCollection<RegionalMuonShower> RegionalMuonShowerRefPairBxCollection;
+
+  class RegionalMuonShower {
+  public:
+    RegionalMuonShower(bool oneNominalInTime = 0,
+                       bool oneNominalOutOfTime = 0,
+                       bool twoLooseInTime = 0,
+                       bool twoLooseOutOfTime = 0);
+
+    ~RegionalMuonShower();
+
+    void setOneNominalInTime(const bool bit) { isOneNominalInTime_ = bit; }
+    void setOneNominalOutOfTime(const bool bit) { isOneNominalOutOfTime_ = bit; }
+    void setTwoLooseOutOfTime(const bool bit) { isTwoLooseOutOfTime_ = bit; }
+    void setTwoLooseInTime(const bool bit) { isTwoLooseInTime_ = bit; }
+
+    void setEndcap(const int endcap) { endcap_ = endcap; }
+    void setSector(const unsigned sector) { sector_ = sector; }
+    void setLink(const int link) { link_ = link; };
+
+    bool isValid() const;
+    bool isOneNominalInTime() const { return isOneNominalInTime_; }
+    bool isOneNominalOutOfTime() const { return isOneNominalOutOfTime_; }
+    bool isTwoLooseInTime() const { return isTwoLooseInTime_; }
+    bool isTwoLooseOutOfTime() const { return isTwoLooseOutOfTime_; }
+
+    int endcap() const { return endcap_; }
+    int sector() const { return sector_; }
+    /// Get link on which the MicroGMT receives the candidate
+    int link() const { return link_; }
+
+    bool operator==(const l1t::RegionalMuonShower& rhs) const;
+    inline bool operator!=(const l1t::RegionalMuonShower& rhs) const { return !(operator==(rhs)); };
+
+  private:
+    // Run-3 definitions as provided in DN-20-033
+    // in time and out-of-time qualities. only 2 bits each.
+    bool isOneNominalInTime_;
+    bool isOneNominalOutOfTime_;
+    bool isTwoLooseInTime_;
+    bool isTwoLooseOutOfTime_;
+    int endcap_;       //    +/-1.  For ME+ and ME-.
+    unsigned sector_;  //  1 -  6.
+    int link_;
+  };
+
+}  // namespace l1t
+
+#endif

--- a/DataFormats/L1TMuon/interface/RegionalMuonShower.h
+++ b/DataFormats/L1TMuon/interface/RegionalMuonShower.h
@@ -15,10 +15,10 @@ namespace l1t {
 
   class RegionalMuonShower {
   public:
-    RegionalMuonShower(bool oneNominalInTime = 0,
-                       bool oneNominalOutOfTime = 0,
-                       bool twoLooseInTime = 0,
-                       bool twoLooseOutOfTime = 0);
+    RegionalMuonShower(bool oneNominalInTime = false,
+                       bool oneNominalOutOfTime = false,
+                       bool twoLooseInTime = false,
+                       bool twoLooseOutOfTime = false);
 
     ~RegionalMuonShower();
 

--- a/DataFormats/L1TMuon/src/RegionalMuonShower.cc
+++ b/DataFormats/L1TMuon/src/RegionalMuonShower.cc
@@ -1,7 +1,10 @@
 #include "DataFormats/L1TMuon/interface/RegionalMuonShower.h"
 
-l1t::RegionalMuonShower::RegionalMuonShower(bool oneNominalInTime, bool oneNominalOutOfTime, bool twoLooseInTime, bool twoLooseOutOfTime) :
-      isOneNominalInTime_(oneNominalInTime),
+l1t::RegionalMuonShower::RegionalMuonShower(bool oneNominalInTime,
+                                            bool oneNominalOutOfTime,
+                                            bool twoLooseInTime,
+                                            bool twoLooseOutOfTime)
+    : isOneNominalInTime_(oneNominalInTime),
       isOneNominalOutOfTime_(oneNominalOutOfTime),
       isTwoLooseInTime_(twoLooseInTime),
       isTwoLooseOutOfTime_(twoLooseOutOfTime),

--- a/DataFormats/L1TMuon/src/RegionalMuonShower.cc
+++ b/DataFormats/L1TMuon/src/RegionalMuonShower.cc
@@ -1,0 +1,21 @@
+#include "DataFormats/L1TMuon/interface/RegionalMuonShower.h"
+
+l1t::RegionalMuonShower::RegionalMuonShower(bool oneNominalInTime, bool oneNominalOutOfTime, bool twoLooseInTime, bool twoLooseOutOfTime) :
+      isOneNominalInTime_(oneNominalInTime),
+      isOneNominalOutOfTime_(oneNominalOutOfTime),
+      isTwoLooseInTime_(twoLooseInTime),
+      isTwoLooseOutOfTime_(twoLooseOutOfTime),
+      endcap_(0),
+      sector_(0),
+      link_(0) {}
+
+l1t::RegionalMuonShower::~RegionalMuonShower() {}
+
+bool l1t::RegionalMuonShower::isValid() const {
+  return isTwoLooseInTime_ or isTwoLooseOutOfTime_ or isTwoLooseOutOfTime_ or isOneNominalOutOfTime_;
+}
+
+bool l1t::RegionalMuonShower::operator==(const l1t::RegionalMuonShower& rhs) const {
+  return (isTwoLooseInTime_ == rhs.isTwoLooseInTime() and isOneNominalInTime_ == rhs.isOneNominalInTime() and
+          isTwoLooseOutOfTime_ == rhs.isTwoLooseOutOfTime() and isOneNominalOutOfTime_ == rhs.isOneNominalOutOfTime());
+}

--- a/DataFormats/L1TMuon/src/classes.h
+++ b/DataFormats/L1TMuon/src/classes.h
@@ -5,6 +5,7 @@
 #include "DataFormats/L1TMuon/interface/MuonCaloSum.h"
 #include "DataFormats/L1TMuon/interface/RegionalMuonCandFwd.h"
 #include "DataFormats/L1TMuon/interface/RegionalMuonCand.h"
+#include "DataFormats/L1TMuon/interface/RegionalMuonShower.h"
 #include "DataFormats/L1TMuon/interface/EMTFDaqOut.h"
 #include "DataFormats/L1TMuon/interface/EMTFHit.h"
 #include "DataFormats/L1TMuon/interface/EMTFRoad.h"

--- a/DataFormats/L1TMuon/src/classes_def.xml
+++ b/DataFormats/L1TMuon/src/classes_def.xml
@@ -13,6 +13,13 @@
   <class name="l1t::RegionalMuonCandBxCollection"/>
   <class name="edm::Wrapper<l1t::RegionalMuonCandBxCollection>"/>
 
+  <class name="l1t::RegionalMuonShower" ClassVersion="10">
+    <version ClassVersion="10" checksum="3501434665"/>
+  </class>
+  <class name="std::vector<l1t::RegionalMuonShower>"/>
+  <class name="l1t::RegionalMuonShowerBxCollection"/>
+  <class name="edm::Wrapper<l1t::RegionalMuonShowerBxCollection>"/>
+
   <class name="l1t::MuonCaloSum"/>
   <class name="std::vector<l1t::MuonCaloSum>"/>
   <class name="l1t::MuonCaloSumBxCollection"/>

--- a/DataFormats/L1Trigger/interface/MuonShower.h
+++ b/DataFormats/L1Trigger/interface/MuonShower.h
@@ -27,10 +27,10 @@ namespace l1t {
 
   class MuonShower : public L1Candidate {
   public:
-    MuonShower(bool oneNominalInTime = 0,
-               bool oneNominalOutOfTime = 0,
-               bool twoLooseInTime = 0,
-               bool twoLooseOutOfTime = 0);
+    MuonShower(bool oneNominalInTime = false,
+               bool oneNominalOutOfTime = false,
+               bool twoLooseInTime = false,
+               bool twoLooseOutOfTime = false);
 
     ~MuonShower() override;
 

--- a/DataFormats/L1Trigger/interface/MuonShower.h
+++ b/DataFormats/L1Trigger/interface/MuonShower.h
@@ -1,0 +1,62 @@
+#ifndef DataFormats_L1Trigger_MuonShower_h
+#define DataFormats_L1Trigger_MuonShower_h
+
+/*
+  This class is derived from the L1Candidate primarily to interface easily
+  with the Global Muon Trigger. In the trigger system the MuonShower object
+  carries only up to 4 bits of information, 2 for in-time showers,
+  2 for out-of-time showers.
+*/
+
+#include "DataFormats/Common/interface/Ref.h"
+#include "DataFormats/L1Trigger/interface/L1Candidate.h"
+#include "DataFormats/L1Trigger/interface/BXVector.h"
+#include "DataFormats/L1Trigger/interface/L1TObjComparison.h"
+
+namespace l1t {
+
+  class MuonShower;
+  typedef BXVector<MuonShower> MuonShowerBxCollection;
+  typedef edm::Ref<MuonShowerBxCollection> MuonShowerRef;
+  typedef edm::RefVector<MuonShowerBxCollection> MuonShowerRefVector;
+  typedef std::vector<MuonShowerRef> MuonShowerVectorRef;
+
+  typedef ObjectRefBxCollection<MuonShower> MuonShowerRefBxCollection;
+  typedef ObjectRefPair<MuonShower> MuonShowerRefPair;
+  typedef ObjectRefPairBxCollection<MuonShower> MuonShowerRefPairBxCollection;
+
+  class MuonShower : public L1Candidate {
+  public:
+    MuonShower(bool oneNominalInTime = 0,
+               bool oneNominalOutOfTime = 0,
+               bool twoLooseInTime = 0,
+               bool twoLooseOutOfTime = 0);
+
+    ~MuonShower() override;
+
+    void setOneNominalInTime(const bool bit) { isOneNominalInTime_ = bit; }
+    void setOneNominalOutOfTime(const bool bit) { isOneNominalOutOfTime_ = bit; }
+    void setTwoLooseInTime(const bool bit) { isTwoLooseInTime_ = bit; }
+    void setTwoLooseOutOfTime(const bool bit) { isTwoLooseOutOfTime_ = bit; }
+
+    bool isValid() const;
+    bool isOneNominalInTime() const { return isOneNominalInTime_; }
+    bool isOneNominalOutOfTime() const { return isOneNominalOutOfTime_; }
+    bool isTwoLooseInTime() const { return isTwoLooseInTime_; }
+    bool isTwoLooseOutOfTime() const { return isTwoLooseOutOfTime_; }
+
+    virtual bool operator==(const l1t::MuonShower& rhs) const;
+    virtual inline bool operator!=(const l1t::MuonShower& rhs) const { return !(operator==(rhs)); };
+
+  private:
+    // Run-3 definitions as provided in DN-20-033
+    // in time and out-of-time qualities. only 2 bits each.
+    bool isOneNominalInTime_;
+    bool isOneNominalOutOfTime_;
+    bool isTwoLooseInTime_;
+    bool isTwoLooseOutOfTime_;
+  };
+
+}  // namespace l1t
+
+#endif

--- a/DataFormats/L1Trigger/src/MuonShower.cc
+++ b/DataFormats/L1Trigger/src/MuonShower.cc
@@ -1,0 +1,19 @@
+#include "DataFormats/L1Trigger/interface/MuonShower.h"
+
+l1t::MuonShower::MuonShower(bool oneNominalInTime, bool oneNominalOutOfTime, bool twoLooseInTime, bool twoLooseOutOfTime)
+    : L1Candidate(math::PtEtaPhiMLorentzVector{0., 0., 0., 0.}, 0., 0., 0., 0, 0),
+      isOneNominalInTime_(oneNominalInTime),
+      isOneNominalOutOfTime_(oneNominalOutOfTime),
+      isTwoLooseInTime_(twoLooseInTime),
+      isTwoLooseOutOfTime_(twoLooseOutOfTime) {}
+
+l1t::MuonShower::~MuonShower() {}
+
+bool l1t::MuonShower::isValid() const {
+  return isTwoLooseInTime_ or isTwoLooseOutOfTime_ or isTwoLooseOutOfTime_ or isOneNominalOutOfTime_;
+}
+
+bool l1t::MuonShower::operator==(const l1t::MuonShower& rhs) const {
+  return (isTwoLooseInTime_ == rhs.isTwoLooseInTime() and isOneNominalInTime_ == rhs.isOneNominalInTime() and
+          isTwoLooseOutOfTime_ == rhs.isTwoLooseOutOfTime() and isOneNominalOutOfTime_ == rhs.isOneNominalOutOfTime());
+}

--- a/DataFormats/L1Trigger/src/classes.h
+++ b/DataFormats/L1Trigger/src/classes.h
@@ -26,6 +26,7 @@
 #include "DataFormats/L1Trigger/interface/EtSum.h"
 #include "DataFormats/L1Trigger/interface/Jet.h"
 #include "DataFormats/L1Trigger/interface/Muon.h"
+#include "DataFormats/L1Trigger/interface/MuonShower.h"
 #include "DataFormats/L1Trigger/interface/Tau.h"
 #include "DataFormats/L1Trigger/interface/CaloSpare.h"
 #include "DataFormats/L1Trigger/interface/L1DataEmulResult.h"

--- a/DataFormats/L1Trigger/src/classes_def.xml
+++ b/DataFormats/L1Trigger/src/classes_def.xml
@@ -102,6 +102,20 @@
   <class name="l1t::MuonVectorRef"/>
   <class name="edm::Wrapper<l1t::MuonVectorRef>"/>
 
+  <class name="l1t::MuonShower" ClassVersion="10">
+   <version ClassVersion="10" checksum="3869296059"/>
+  </class>
+  <class name="edm::Ptr<l1t::MuonShower>"/>
+  <class name="l1t::MuonShowerBxCollection"/>
+  <class name="std::vector<l1t::MuonShower>"/>
+  <class name="edm::Wrapper<l1t::MuonShowerBxCollection>"/>
+  <class name="l1t::MuonShowerRef"/>
+  <class name="edm::Wrapper<l1t::MuonShowerRef>"/>
+  <class name="l1t::MuonShowerRefVector"/>
+  <class name="edm::Wrapper<l1t::MuonShowerRefVector>"/>
+  <class name="l1t::MuonShowerVectorRef"/>
+  <class name="edm::Wrapper<l1t::MuonShowerVectorRef>"/>
+
   <class name="l1t::CaloSpare" ClassVersion="13">
    <version ClassVersion="13" checksum="50826133"/>
    <version ClassVersion="12" checksum="3118488206"/>


### PR DESCRIPTION
#### PR description:

Data formats for showers in the muon system in Run-3. `RegionalMuonShowers` are be created from "OR"-ed combinations of `CSCShowerDigi` in a dedicated sector processor for showers (emulator to follow in a separate pull request). Similarly, `MuonShowers` are created from "OR"-ed combinations of `RegionalMuonShower` in a global muon trigger module. From the class definition `RegionalMuonShower` and `MuonShower` look like bulky objects, but in the trigger they only carry 4 bits of information per BX. Additional documentation in DN-20-033.

Documentation now also provided in [DN-15-017](https://gitlab.cern.ch/tdr/notes/DN-15-017/uploads/f08b31205b34ce754317d2cf6d12b25b/DN-15-017_temp.pdf)

#### PR validation:

Code compiles. The new objects are not yet plugged in to the emulators. There should be no difference with respect to the baseline.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)

@dinyar 