### PR TITLE
Fix indentation in EDAlias python dump

### DIFF
--- a/FWCore/ParameterSet/python/Modules.py
+++ b/FWCore/ParameterSet/python/Modules.py
@@ -700,7 +700,7 @@ if __name__ == "__main__":
         foo = cms.VPSet(cms.PSet(
             type = cms.string('Foo2')
         ))
-)
+    )
 )
 """)
 

--- a/FWCore/ParameterSet/python/Types.py
+++ b/FWCore/ParameterSet/python/Types.py
@@ -1444,7 +1444,7 @@ class EDAlias(_ConfigureComponent,_Labelable,_Parameterizable):
             options.indent()
             resultList.append(options.indentation()+name+' = '+param.dumpPython(options))
             options.unindent()
-        return '\n'.join(resultList)+'\n)'
+        return '\n'.join(resultList) + '\n' + options.indentation() + ')'
 
     # an EDAlias only references other modules by label, so it does not need their definition
     def directDependencies(self):


### PR DESCRIPTION
#### PR description:

Fix the indentation of the closing parenthesis in the python dump of an `EDAlias`.
The change is apparent only when the `EDAlias` is itself indented, for example when it is embedded in a `SwitchProducer`.

Here is an example of the dump before the fix:
```python
process.pixelTracks = SwitchProducerCUDA(
    cpu = cms.EDProducer("PixelTrackProducer",
        Cleaner = cms.string('pixelTrackCleanerBySharedHits'),
        Filter = cms.InputTag("pixelTrackFilterByKinematics"),
        Fitter = cms.InputTag("pixelFitterByHelixProjections"),
        SeedingHitSets = cms.InputTag("pixelTracksHitQuadruplets"),
        mightGet = cms.optional.untracked.vstring,
        passLabel = cms.string('pixelTracks')
    ),
    cuda = cms.EDAlias(
        pixelTrackFromSoA = cms.VPSet(
            cms.PSet(
                type = cms.string('recoTracks')
            ),
            cms.PSet(
                type = cms.string('recoTrackExtras')
            ),
            cms.PSet(
                type = cms.string('TrackingRecHitsOwned')
            )
        )
)
)
```

And here is the same after the fix:
```python
process.pixelTracks = SwitchProducerCUDA(
    cpu = cms.EDProducer("PixelTrackProducer",
        Cleaner = cms.string('pixelTrackCleanerBySharedHits'),
        Filter = cms.InputTag("pixelTrackFilterByKinematics"),
        Fitter = cms.InputTag("pixelFitterByHelixProjections"),
        SeedingHitSets = cms.InputTag("pixelTracksHitQuadruplets"),
        mightGet = cms.optional.untracked.vstring,
        passLabel = cms.string('pixelTracks')
    ),
    cuda = cms.EDAlias(
        pixelTrackFromSoA = cms.VPSet(
            cms.PSet(
                type = cms.string('recoTracks')
            ),
            cms.PSet(
                type = cms.string('recoTrackExtras')
            ),
            cms.PSet(
                type = cms.string('TrackingRecHitsOwned')
            )
        )
    )
)
``` 

#### PR validation:

None.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Backport of #33449 .