### PR TITLE
MTD geometry and digitization: move check for pixel active area into RectangularMTDTopology, make it usable for BTL as well

### DIFF
--- a/Geometry/MTDCommonData/data/mtdParameters/v2/mtdParameters.xml
+++ b/Geometry/MTDCommonData/data/mtdParameters/v2/mtdParameters.xml
@@ -5,8 +5,10 @@
   <Vector name="vPars" type="numeric" nEntries="4">
     4, 4, 4, 24
   </Vector>
+  <!--BTL inter-crystal gaps approximated to nearest integer value in microns-->
+  <!--in y preserve total free space, move 0.5 microns for each inter-crystal to borders-->
   <Vector name="BTL" type="numeric" nEntries="12">
-    0, 0, 0, 0, 0, 0, 0, 0, 1, 16, 3, 1
+    3733, 1867, 112, 60, 0, 0, 0, 0, 1, 16, 3, 1
   </Vector>
   <Vector name="ETL" type="numeric" nEntries="12">
     50, 50, 50, 50, 0, 0, 0, 0, 16, 16, 2, 1

--- a/Geometry/MTDGeometryBuilder/interface/RectangularMTDTopology.h
+++ b/Geometry/MTDGeometryBuilder/interface/RectangularMTDTopology.h
@@ -84,6 +84,9 @@ public:
   // PixelTopology interface.
   std::pair<float, float> pixel(const LocalPoint& p) const override;
 
+  //check whether LocalPoint is inside the pixel active area
+  bool isInPixel(const LocalPoint& p) const;
+
   // Errors
   // Error in local (cm) from the masurement errors
   LocalError localError(const MeasurementPoint&, const MeasurementError&) const override;

--- a/Geometry/MTDGeometryBuilder/src/RectangularMTDTopology.cc
+++ b/Geometry/MTDGeometryBuilder/src/RectangularMTDTopology.cc
@@ -16,6 +16,25 @@ std::pair<float, float> RectangularMTDTopology::pixel(const LocalPoint& p) const
   return std::pair<float, float>(newxbin, newybin);
 }
 
+//The following lines check whether the point is actually out of the active pixel area.
+bool RectangularMTDTopology::isInPixel(const LocalPoint& p) const {
+  bool isInside = true;
+  const auto& thepixel = pixel(p);
+  const int ixbin = static_cast<int>(thepixel.first);
+  const int iybin = static_cast<int>(thepixel.second);
+  const float fractionX = thepixel.first - ixbin;
+  const float fractionY = thepixel.second - iybin;
+  if ((fractionX > 1.0 - m_GAPxInterpadFrac || fractionX < m_GAPxInterpadFrac) ||
+      (ixbin == 0 && fractionX < m_GAPxBorderFrac) || (ixbin == m_nrows - 1 && fractionX > 1.0 - m_GAPxBorderFrac)) {
+    isInside = false;
+  }
+  if ((fractionY > 1.0 - m_GAPyInterpadFrac || fractionY < m_GAPyInterpadFrac) ||
+      (iybin == 0 && fractionY < m_GAPyBorderFrac) || (iybin == m_ncols - 1 && fractionY > 1.0 - m_GAPyBorderFrac)) {
+    isInside = false;
+  }
+  return isInside;
+}
+
 //----------------------------------------------------------------------
 // Topology interface, go from Measurement to Local corrdinates
 // pixel coordinates (mp) -> cm (LocalPoint)

--- a/SimFastTiming/FastTimingCommon/src/ETLDeviceSim.cc
+++ b/SimFastTiming/FastTimingCommon/src/ETLDeviceSim.cc
@@ -61,21 +61,12 @@ void ETLDeviceSim::getHitsResponse(const std::vector<std::tuple<int, uint32_t, f
     const auto& pentry = hit.entryPoint();
     // ETL is already in module-local coordinates so just scale to cm from mm
     Local3DPoint simscaled(convertMmToCm(pentry.x()), convertMmToCm(pentry.y()), convertMmToCm(pentry.z()));
-    const auto& thepixel = topo.pixel(simscaled);
     //The following lines check whether the pixel point is actually out of the active area.
     //If that is the case it simply ignores the point but in the future some more sophisticated function could be applied.
-    const int ixbin = int(thepixel.first);
-    const int iybin = int(thepixel.second);
-    const float fractionX = thepixel.first - ixbin;
-    const float fractionY = thepixel.second - iybin;
-    if ((fractionX > 1.0 - topo.gapxInterpadFrac() || fractionX < topo.gapxInterpadFrac()) ||
-        (ixbin == 0 && fractionX < topo.gapxBorderFrac()) ||
-        (ixbin == topo.nrows() - 1 && fractionX > 1.0 - topo.gapxBorderFrac()))
+    if (!topo.isInPixel(simscaled)) {
       continue;
-    if ((fractionY > 1.0 - topo.gapyInterpadFrac() || fractionY < topo.gapyInterpadFrac()) ||
-        (iybin == 0 && fractionY < topo.gapyBorderFrac()) ||
-        (iybin == topo.ncolumns() - 1 && fractionY > 1.0 - topo.gapyBorderFrac()))
-      continue;
+    }
+    const auto& thepixel = topo.pixel(simscaled);
     const uint8_t row(thepixel.first), col(thepixel.second);
 
     auto simHitIt =


### PR DESCRIPTION
#### PR description:

#33340 has cleaned the ```RectangularMTDTopology``` and introduced functionalities to take into account non-active areas around pixels. This has been used in the ETL digitization, but it is a general functionality potentially valid fro BTL as well. While in BTL the crystals are correctly positioned at the center of pixels, and there is so far no use of inter-crystal gaps, this PR turns the check for ETL into a general method usable also for BTL if needed.

In order to do this, the ```mtdParameters.xml``` values are updated for BTL with values extracted from the ideal geometry, rounding at 1 micron level, and for y moving a residual 0.5 inter-crystal micron to the border gap.

#### PR validation:

Test wf 34634.0 runs.
