### PR TITLE
Move PFClusterWidthAlgo into CommonTools/ParticleFlow

### DIFF
--- a/CommonTools/ParticleFlow/interface/PFClusterWidthAlgo.h
+++ b/CommonTools/ParticleFlow/interface/PFClusterWidthAlgo.h
@@ -1,5 +1,5 @@
-#ifndef PFClusterShapeProducer_PFClusterWidthAlgo_H
-#define PFClusterShapeProducer_PFClusterWidthAlgo_H
+#ifndef CommonTools_ParticleFlow_PFClusterWidthAlgo_H
+#define CommonTools_ParticleFlow_PFClusterWidthAlgo_H
 #include "DataFormats/ParticleFlowReco/interface/PFCluster.h"
 #include "DataFormats/EcalRecHit/interface/EcalRecHitCollections.h"
 

--- a/CommonTools/ParticleFlow/src/PFClusterWidthAlgo.cc
+++ b/CommonTools/ParticleFlow/src/PFClusterWidthAlgo.cc
@@ -1,4 +1,4 @@
-#include "RecoParticleFlow/PFClusterTools/interface/PFClusterWidthAlgo.h"
+#include "CommonTools/ParticleFlow/interface/PFClusterWidthAlgo.h"
 #include "DataFormats/ParticleFlowReco/interface/PFRecHitFraction.h"
 #include "DataFormats/ParticleFlowReco/interface/PFRecHitFwd.h"
 #include "DataFormats/ParticleFlowReco/interface/PFRecHit.h"

--- a/RecoEcal/EgammaClusterAlgos/BuildFile.xml
+++ b/RecoEcal/EgammaClusterAlgos/BuildFile.xml
@@ -5,6 +5,7 @@
 <use name="DataFormats/Math"/>
 <use name="DataFormats/ParticleFlowReco"/>
 <use name="DataFormats/VertexReco"/>
+<use name="CommonTools/ParticleFlow"/>
 <use name="CondFormats/ESObjects"/>
 <use name="CondFormats/GBRForest"/>
 <use name="CondFormats/DataRecord"/>

--- a/RecoEcal/EgammaClusterAlgos/src/PFECALSuperClusterAlgo.cc
+++ b/RecoEcal/EgammaClusterAlgos/src/PFECALSuperClusterAlgo.cc
@@ -1,5 +1,5 @@
 #include "RecoEcal/EgammaClusterAlgos/interface/PFECALSuperClusterAlgo.h"
-#include "RecoParticleFlow/PFClusterTools/interface/PFClusterWidthAlgo.h"
+#include "CommonTools/ParticleFlow/interface/PFClusterWidthAlgo.h"
 #include "RecoParticleFlow/PFClusterTools/interface/LinkByRecHit.h"
 #include "DataFormats/ParticleFlowReco/interface/PFLayer.h"
 #include "DataFormats/ParticleFlowReco/interface/PFRecHit.h"

--- a/RecoEcal/EgammaClusterProducers/src/SCEnergyCorrectorProducer.cc
+++ b/RecoEcal/EgammaClusterProducers/src/SCEnergyCorrectorProducer.cc
@@ -4,6 +4,7 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 #include "DataFormats/EgammaReco/interface/SuperCluster.h"
+#include "DataFormats/EgammaReco/interface/SuperClusterFwd.h"
 #include "DataFormats/Common/interface/ValueMap.h"
 #include "RecoEcal/EgammaClusterAlgos/interface/SCEnergyCorrectorSemiParm.h"
 

--- a/RecoEgamma/EgammaElectronProducers/plugins/BuildFile.xml
+++ b/RecoEgamma/EgammaElectronProducers/plugins/BuildFile.xml
@@ -1,4 +1,5 @@
 <use name="CommonTools/CandAlgos"/>
+<use name="CommonTools/ParticleFlow"/>
 <use name="DataFormats/BeamSpot"/>
 <use name="DataFormats/Candidate"/>
 <use name="DataFormats/Common"/>
@@ -23,7 +24,6 @@
 <use name="RecoEgamma/EgammaElectronAlgos"/>
 <use name="RecoEgamma/EgammaElectronProducers"/>
 <use name="RecoEgamma/EgammaIsolationAlgos"/>
-<use name="RecoParticleFlow/PFClusterTools"/>
 <use name="RecoTracker/TkTrackingRegions"/>
 <use name="RecoTracker/TransientTrackingRecHit"/>
 <use name="TrackingTools/PatternTools"/>

--- a/RecoEgamma/EgammaElectronProducers/plugins/LowPtGsfElectronSCProducer.cc
+++ b/RecoEgamma/EgammaElectronProducers/plugins/LowPtGsfElectronSCProducer.cc
@@ -1,4 +1,4 @@
-#include "RecoParticleFlow/PFClusterTools/interface/PFClusterWidthAlgo.h"
+#include "CommonTools/ParticleFlow/interface/PFClusterWidthAlgo.h"
 #include "DataFormats/Common/interface/RefToPtr.h"
 #include "DataFormats/Common/interface/ValueMap.h"
 #include "DataFormats/Common/interface/ValidHandle.h"

--- a/RecoEgamma/EgammaTools/interface/HGCalShowerShapeHelper.h
+++ b/RecoEgamma/EgammaTools/interface/HGCalShowerShapeHelper.h
@@ -2,38 +2,23 @@
 #define RecoEgamma_EgammaTools_HGCalShowerShapeHelper_h
 
 // system include files
-#include <algorithm>
-#include <cstdlib>
-#include <iostream>
 #include <map>
 #include <memory>
-#include <string>
 #include <utility>
 #include <vector>
 
 // external include files
-#include <CLHEP/Vector/LorentzVector.h>
-#include <Math/Point3D.h>
-#include <Math/Point3Dfwd.h>
-#include <TMatrixD.h>
-#include <TVectorD.h>
+#include <Math/Vector3Dfwd.h>
 
 // CMSSW include files
-#include "DataFormats/CaloRecHit/interface/CaloCluster.h"
-#include "DataFormats/EgammaCandidates/interface/GsfElectron.h"
-#include "DataFormats/FWLite/interface/ESHandle.h"
+#include "DataFormats/EgammaReco/interface/SuperCluster.h"
 #include "DataFormats/ForwardDetId/interface/HGCEEDetId.h"
 #include "DataFormats/ForwardDetId/interface/HGCalDetId.h"
-#include "DataFormats/GsfTrackReco/interface/GsfTrack.h"
 #include "DataFormats/HGCRecHit/interface/HGCRecHit.h"
-#include "DataFormats/Math/interface/LorentzVector.h"
 #include "DataFormats/ParticleFlowReco/interface/PFRecHit.h"
 #include "DataFormats/ParticleFlowReco/interface/PFRecHitFraction.h"
-#include "DataFormats/TrackReco/interface/Track.h"
-#include "DataFormats/TrackReco/interface/TrackFwd.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/ESHandle.h"
-#include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -42,7 +27,6 @@
 #include "Geometry/CaloTopology/interface/HGCalTopology.h"
 #include "Geometry/Records/interface/IdealGeometryRecord.h"
 #include "RecoLocalCalo/HGCalRecAlgos/interface/RecHitTools.h"
-#include "RecoParticleFlow/PFClusterProducer/interface/InitialClusteringStepBase.h"
 
 class HGCalShowerShapeHelper {
   // Good to filter/compute/store this stuff beforehand as they are common to the shower shape variables.

--- a/RecoEgamma/EgammaTools/src/HGCalShowerShapeHelper.cc
+++ b/RecoEgamma/EgammaTools/src/HGCalShowerShapeHelper.cc
@@ -1,5 +1,11 @@
 #include "RecoEgamma/EgammaTools/interface/HGCalShowerShapeHelper.h"
 
+#include <Math/Vector3D.h>
+#include <TMatrixD.h>
+#include <TVectorD.h>
+
+#include <algorithm>
+
 const double HGCalShowerShapeHelper::kLDWaferCellSize_ = 0.698;
 const double HGCalShowerShapeHelper::kHDWaferCellSize_ = 0.465;
 

--- a/RecoParticleFlow/PFProducer/BuildFile.xml
+++ b/RecoParticleFlow/PFProducer/BuildFile.xml
@@ -1,5 +1,6 @@
 <use name="CondFormats/GBRForest"/>
 <use name="CommonTools/MVAUtils"/>
+<use name="CommonTools/ParticleFlow"/>
 <use name="DataFormats/CaloRecHit"/>
 <use name="DataFormats/Common"/>
 <use name="DataFormats/EgammaCandidates"/>

--- a/RecoParticleFlow/PFProducer/plugins/BuildFile.xml
+++ b/RecoParticleFlow/PFProducer/plugins/BuildFile.xml
@@ -62,6 +62,7 @@
 </library>
 
 <library name="RecoParticleFlowPFProducerPlugins" file="*.cc">
+  <use name="CommonTools/ParticleFlow"/>
   <use name="CondFormats/DataRecord"/>
   <use name="CondFormats/PhysicsToolsObjects"/>
   <use name="DataFormats/CaloRecHit"/>

--- a/RecoParticleFlow/PFProducer/plugins/PFElectronTranslator.cc
+++ b/RecoParticleFlow/PFProducer/plugins/PFElectronTranslator.cc
@@ -1,7 +1,7 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "RecoParticleFlow/PFClusterTools/interface/PFClusterWidthAlgo.h"
+#include "CommonTools/ParticleFlow/interface/PFClusterWidthAlgo.h"
 #include "RecoEcal/EgammaCoreTools/interface/Mustache.h"
 #include "DataFormats/ParticleFlowCandidate/interface/PFCandidate.h"
 #include "DataFormats/ParticleFlowCandidate/interface/PFCandidateElectronExtra.h"

--- a/RecoParticleFlow/PFProducer/plugins/PFPhotonTranslator.cc
+++ b/RecoParticleFlow/PFProducer/plugins/PFPhotonTranslator.cc
@@ -2,7 +2,7 @@
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "RecoParticleFlow/PFClusterTools/interface/PFClusterWidthAlgo.h"
+#include "CommonTools/ParticleFlow/interface/PFClusterWidthAlgo.h"
 #include "DataFormats/ParticleFlowCandidate/interface/PFCandidate.h"
 #include "DataFormats/EgammaReco/interface/PreshowerCluster.h"
 #include "DataFormats/EgammaReco/interface/SuperCluster.h"

--- a/RecoParticleFlow/PFProducer/src/PFEGammaAlgo.cc
+++ b/RecoParticleFlow/PFProducer/src/PFEGammaAlgo.cc
@@ -11,7 +11,7 @@
 #include "DataFormats/EgammaCandidates/interface/Photon.h"
 #include "RecoParticleFlow/PFClusterTools/interface/PFEnergyCalibration.h"
 #include "RecoParticleFlow/PFClusterTools/interface/PFEnergyResolution.h"
-#include "RecoParticleFlow/PFClusterTools/interface/PFClusterWidthAlgo.h"
+#include "CommonTools/ParticleFlow/interface/PFClusterWidthAlgo.h"
 #include "RecoParticleFlow/PFTracking/interface/PFTrackAlgoTools.h"
 #include "DataFormats/Common/interface/RefToPtr.h"
 #include "RecoEcal/EgammaCoreTools/interface/Mustache.h"


### PR DESCRIPTION
#### PR description:

This PR moves `PFClusterWidthAlgo` from  RecoParticleFlow/PFClusterTools to CommonTools/ParticleFlow. That class is used both in RecoEgamma and RecoEcal as well, justifying the transition to CommonTools. Like this, the dependency of RecoEgamma on RecoParticleFlow is eliminated.

Furthermore, the includes in HGCalShowerShapeHelper are cleaned to make it not appear like RecoEgamma/EgammaTools depends on RecoParticleFlow.

#### PR validation:

CMSSW compiles.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

No backport intended.