### PR TITLE
Fix secondary file reading when processIDs change

### DIFF
--- a/IOPool/Input/src/PoolSource.cc
+++ b/IOPool/Input/src/PoolSource.cc
@@ -226,7 +226,7 @@ namespace edm {
         checkHistoryConsistency(eventPrincipal, secondaryEventPrincipal);
         eventPrincipal.recombine(secondaryEventPrincipal, branchIDsToReplace_[InEvent]);
         eventPrincipal.mergeProvenanceRetrievers(secondaryEventPrincipal);
-        secondaryEventPrincipal.clearPrincipal();
+        secondaryEventPrincipal.clearEventPrincipal();
       } else {
         throw Exception(errors::MismatchedInputFiles, "PoolSource::readEvent_")
             << eventPrincipal.id() << " is not found in the secondary input files\n";


### PR DESCRIPTION
#### PR description:

A bug was found when trying to use the two file solution in the case where the process ID changed from one LuminosityBlock to the next.

#### PR validation:

Running the change on the job which was affected by the bug now works fine.

fixes makortel/framework#129