### PR TITLE
Deal with FastSim issue raised from #33430

### DIFF
--- a/DQM/TrackingMonitorClient/python/TrackingClientConfig_Tier0_cff.py
+++ b/DQM/TrackingMonitorClient/python/TrackingClientConfig_Tier0_cff.py
@@ -94,3 +94,16 @@ from DQM.TrackingMonitor.TrackFoldedOccupancyClient_cfi import *
 TrackingOfflineDQMClient = cms.Sequence(trackingQTester*trackingOfflineAnalyser*trackingEffFromHitPattern*voMonitoringClientSequence*primaryVertexResolutionClient*TrackEffClient*foldedMapClientSeq)
 
 TrackingOfflineDQMClientZeroBias = cms.Sequence(trackingQTester*trackingOfflineAnalyser*trackingEffFromHitPatternZeroBias*voMonitoringClientSequence*primaryVertexResolutionClient*TrackEffClient*foldedMapClientSeq)
+
+# fastsim customs
+_TrackingOfflineDQMClient_fastsim = TrackingOfflineDQMClient.copy()
+_TrackingOfflineDQMClient_fastsim.remove(foldedMapClientSeq)
+
+_TrackingOfflineDQMClientZeroBias_fastsim = TrackingOfflineDQMClientZeroBias.copy()
+_TrackingOfflineDQMClientZeroBias_fastsim.remove(foldedMapClientSeq)
+
+from Configuration.Eras.Modifier_fastSim_cff import fastSim
+fastSim.toReplaceWith(TrackingOfflineDQMClient,_TrackingOfflineDQMClient_fastsim)
+
+from Configuration.Eras.Modifier_fastSim_cff import fastSim
+fastSim.toReplaceWith(TrackingOfflineDQMClientZeroBias,_TrackingOfflineDQMClientZeroBias_fastsim)


### PR DESCRIPTION
#### PR description:

Fixes the issue reported at https://github.com/cms-sw/cmssw/pull/33463#issuecomment-822606055.
The `foldedMapClientSeq` sequence is removed in FastSim.

#### PR validation:

Run successfully:
```
runTheMatrix.py -l 2017.13,2018.13 -j 4
```

results in:

```
2017.13_TTbar_13_UP17+TTbarFS_13_trackingOnlyValidation_UP17+HARVESTUP17FS_trackingOnly Step0-PASSED Step1-PASSED  - time date Mon Apr 19 19:32:18 2021-date Mon Apr 19 19:28:34 2021; exit: 0 0
2018.13_TTbar_13_UP18+TTbarFS_13_trackingOnlyValidation_UP18+HARVESTUP18FS_trackingOnly Step0-PASSED Step1-PASSED  - time date Mon Apr 19 19:32:18 2021-date Mon Apr 19 19:28:34 2021; exit: 0 0
2 2 tests passed, 0 0 failed
```

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Not a backport, will be backported at: #33463
