### PR TITLE
TkDQM: Add standalone monitoring modules for OT Rechits and new resolution plots for ITRechits

### DIFF
--- a/DQM/SiTrackerPhase2/plugins/Phase2ITMonitorCluster.cc
+++ b/DQM/SiTrackerPhase2/plugins/Phase2ITMonitorCluster.cc
@@ -92,10 +92,8 @@ Phase2ITMonitorCluster::~Phase2ITMonitorCluster() {
 //
 // -- DQM Begin Run
 void Phase2ITMonitorCluster::dqmBeginRun(const edm::Run& iRun, const edm::EventSetup& iSetup) {
-  edm::ESHandle<TrackerGeometry> geomHandle = iSetup.getHandle(geomToken_);
-  tkGeom_ = &(*geomHandle);
-  edm::ESHandle<TrackerTopology> tTopoHandle = iSetup.getHandle(topoToken_);
-  tTopo_ = tTopoHandle.product();
+  tkGeom_ = &iSetup.getData(geomToken_);
+  tTopo_ = &iSetup.getData(topoToken_);
 }
 
 //
@@ -103,8 +101,7 @@ void Phase2ITMonitorCluster::dqmBeginRun(const edm::Run& iRun, const edm::EventS
 //
 void Phase2ITMonitorCluster::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
   // Getting the clusters
-  edm::Handle<edmNew::DetSetVector<SiPixelCluster>> itPixelClusterHandle;
-  iEvent.getByToken(itPixelClusterToken_, itPixelClusterHandle);
+  const auto& itPixelClusterHandle = iEvent.getHandle(itPixelClusterToken_);
   // Number of clusters
   std::map<std::string, unsigned int> nClsmap;
   unsigned int nclusGlobal = 0;
@@ -196,7 +193,6 @@ void Phase2ITMonitorCluster::bookHistograms(DQMStore::IBooker& ibooker,
   //Now book layer wise histos
   edm::ESWatcher<TrackerDigiGeometryRecord> theTkDigiGeomWatcher;
   if (theTkDigiGeomWatcher.check(iSetup)) {
-    edm::ESHandle<TrackerGeometry> geomHandle = iSetup.getHandle(geomToken_);
     for (auto const& det_u : tkGeom_->detUnits()) {
       //Always check TrackerNumberingBuilder before changing this part
       if (!(det_u->subDetector() == GeomDetEnumerators::SubDetector::P2PXB ||

--- a/DQM/SiTrackerPhase2/plugins/Phase2ITMonitorRecHit.cc
+++ b/DQM/SiTrackerPhase2/plugins/Phase2ITMonitorRecHit.cc
@@ -101,8 +101,7 @@ void Phase2ITMonitorRecHit::analyze(const edm::Event& iEvent, const edm::EventSe
 
 void Phase2ITMonitorRecHit::fillITHistos(const edm::Event& iEvent) {
   // Get the RecHits
-  edm::Handle<SiPixelRecHitCollection> rechits;
-  iEvent.getByToken(tokenRecHitsIT_, rechits);
+  const auto& rechits = iEvent.getHandle(tokenRecHitsIT_);
   if (!rechits.isValid())
     return;
   std::map<std::string, unsigned int> nrechitLayerMap;
@@ -173,10 +172,8 @@ void Phase2ITMonitorRecHit::fillITHistos(const edm::Event& iEvent) {
 }
 
 void Phase2ITMonitorRecHit::dqmBeginRun(const edm::Run& iRun, const edm::EventSetup& iSetup) {
-  edm::ESHandle<TrackerGeometry> geomHandle = iSetup.getHandle(geomToken_);
-  tkGeom_ = &(*geomHandle);
-  edm::ESHandle<TrackerTopology> tTopoHandle = iSetup.getHandle(topoToken_);
-  tTopo_ = tTopoHandle.product();
+  tkGeom_ = &iSetup.getData(geomToken_);
+  tTopo_ = &iSetup.getData(topoToken_);
 }
 
 void Phase2ITMonitorRecHit::bookHistograms(DQMStore::IBooker& ibooker,
@@ -206,7 +203,6 @@ void Phase2ITMonitorRecHit::bookHistograms(DQMStore::IBooker& ibooker,
   //Now book layer wise histos
   edm::ESWatcher<TrackerDigiGeometryRecord> theTkDigiGeomWatcher;
   if (theTkDigiGeomWatcher.check(iSetup)) {
-    edm::ESHandle<TrackerGeometry> geomHandle = iSetup.getHandle(geomToken_);
     for (auto const& det_u : tkGeom_->detUnits()) {
       //Always check TrackerNumberingBuilder before changing this part
       if (!(det_u->subDetector() == GeomDetEnumerators::SubDetector::P2PXB ||

--- a/DQM/SiTrackerPhase2/plugins/Phase2OTMonitorCluster.cc
+++ b/DQM/SiTrackerPhase2/plugins/Phase2OTMonitorCluster.cc
@@ -96,19 +96,15 @@ Phase2OTMonitorCluster::~Phase2OTMonitorCluster() {
 //
 // -- DQM Begin Run
 void Phase2OTMonitorCluster::dqmBeginRun(const edm::Run& iRun, const edm::EventSetup& iSetup) {
-  edm::ESHandle<TrackerGeometry> geomHandle = iSetup.getHandle(geomToken_);
-  tkGeom_ = &(*geomHandle);
-  edm::ESHandle<TrackerTopology> tTopoHandle = iSetup.getHandle(topoToken_);
-  tTopo_ = tTopoHandle.product();
+  tkGeom_ = &iSetup.getData(geomToken_);
+  tTopo_ = &iSetup.getData(topoToken_);
 }
 //
 // -- Analyze
 //
 void Phase2OTMonitorCluster::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
   // Getting the clusters
-  edm::Handle<Phase2TrackerCluster1DCollectionNew> clusterHandle;
-  iEvent.getByToken(clustersToken_, clusterHandle);
-
+  const auto& clusterHandle = iEvent.getHandle(clustersToken_);
   // Number of clusters
   std::map<std::string, unsigned int> nClustersCounter_P;  //map of detidkey vs #cls
   std::map<std::string, unsigned int> nClustersCounter_S;  //map of detidkey vs #cls
@@ -211,7 +207,6 @@ void Phase2OTMonitorCluster::bookHistograms(DQMStore::IBooker& ibooker,
   //Now book layer wise histos
   edm::ESWatcher<TrackerDigiGeometryRecord> theTkDigiGeomWatcher;
   if (theTkDigiGeomWatcher.check(iSetup)) {
-    edm::ESHandle<TrackerGeometry> geomHandle = iSetup.getHandle(geomToken_);
     for (auto const& det_u : tkGeom_->detUnits()) {
       //Always check TrackerNumberingBuilder before changing this part
       //continue if Pixel

--- a/DQM/SiTrackerPhase2/plugins/Phase2OTMonitorRecHit.cc
+++ b/DQM/SiTrackerPhase2/plugins/Phase2OTMonitorRecHit.cc
@@ -114,19 +114,16 @@ Phase2OTMonitorRecHit::~Phase2OTMonitorRecHit() {
 //
 // -- DQM Begin Run
 void Phase2OTMonitorRecHit::dqmBeginRun(const edm::Run& iRun, const edm::EventSetup& iSetup) {
-  edm::ESHandle<TrackerGeometry> geomHandle = iSetup.getHandle(geomToken_);
-  tkGeom_ = &(*geomHandle);
-  edm::ESHandle<TrackerTopology> tTopoHandle = iSetup.getHandle(topoToken_);
-  tTopo_ = tTopoHandle.product();
+  tkGeom_ = &iSetup.getData(geomToken_);
+  tTopo_ = &iSetup.getData(topoToken_);;
 }
 
 //
 // -- Analyze
 //
 void Phase2OTMonitorRecHit::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
-  // Get the RecHits
-  edm::Handle<Phase2TrackerRecHit1DCollectionNew> rechits;
-  iEvent.getByToken(tokenRecHitsOT_, rechits);
+  // Get the RecHits Phase2TrackerRecHit1DCollectionNew
+  const auto& rechits = iEvent.getHandle(tokenRecHitsOT_);
   if (!rechits.isValid())
     return;
   std::map<std::string, unsigned int> nrechitLayerMapP;

--- a/DQM/SiTrackerPhase2/plugins/Phase2OTMonitorRecHit.cc
+++ b/DQM/SiTrackerPhase2/plugins/Phase2OTMonitorRecHit.cc
@@ -1,0 +1,450 @@
+// Package:    Phase2OTMonitorRecHit
+// Class:      Phase2OTMonitorRecHit
+//
+/**\class Phase2OTMonitorRecHit Phase2OTMonitorRecHit.cc 
+ Description:  Standalone  Plugin for Phase2 RecHit validation
+*/
+//
+// Author: Suvankar Roy Chowdhury
+// Date: March 2021
+//
+// system include files
+#include <memory>
+#include <map>
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/ESWatcher.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+
+#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
+#include "Geometry/CommonDetUnit/interface/TrackerGeomDet.h"
+#include "Geometry/CommonDetUnit/interface/PixelGeomDetUnit.h"
+#include "Geometry/CommonDetUnit/interface/PixelGeomDetType.h"
+#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
+#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
+#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
+
+#include "DataFormats/Common/interface/Handle.h"
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+#include "DataFormats/SiPixelDetId/interface/PixelSubdetector.h"
+#include "DataFormats/DetId/interface/DetId.h"
+#include "DataFormats/Common/interface/DetSetVector.h"
+#include "DataFormats/Common/interface/DetSetVectorNew.h"
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+#include "DataFormats/TrackerRecHit2D/interface/Phase2TrackerRecHit1D.h"
+#include "DataFormats/TrackerRecHit2D/interface/SiPixelRecHitCollection.h"
+#include "DataFormats/GeometrySurface/interface/LocalError.h"
+#include "DataFormats/GeometryVector/interface/LocalPoint.h"
+
+// DQM Histograming
+#include "DQMServices/Core/interface/MonitorElement.h"
+#include "DQMServices/Core/interface/DQMEDAnalyzer.h"
+#include "DQMServices/Core/interface/DQMStore.h"
+
+#include "Validation/SiTrackerPhase2V/interface/TrackerPhase2ValidationUtil.h"
+#include "DQM/SiTrackerPhase2/interface/TrackerPhase2DQMUtil.h"
+
+class Phase2OTMonitorRecHit : public DQMEDAnalyzer {
+public:
+  explicit Phase2OTMonitorRecHit(const edm::ParameterSet&);
+  ~Phase2OTMonitorRecHit() override;
+  void bookHistograms(DQMStore::IBooker& ibooker, edm::Run const& iRun, edm::EventSetup const& iSetup) override;
+  void analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) override;
+  void dqmBeginRun(const edm::Run& iRun, const edm::EventSetup& iSetup) override;
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+private:
+  void bookLayerHistos(DQMStore::IBooker& ibooker, unsigned int det_id, std::string& subdir);
+
+  edm::ParameterSet config_;
+  const edm::EDGetTokenT<Phase2TrackerRecHit1DCollectionNew> tokenRecHitsOT_;
+
+  const edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> geomToken_;
+  const edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> topoToken_;
+  const TrackerGeometry* tkGeom_ = nullptr;
+  const TrackerTopology* tTopo_ = nullptr;
+
+  MonitorElement* numberRecHits_ = nullptr;
+  MonitorElement* globalXY_P_ = nullptr;
+  MonitorElement* globalRZ_P_ = nullptr;
+  MonitorElement* globalXY_S_ = nullptr;
+  MonitorElement* globalRZ_S_ = nullptr;
+  struct RecHitME {
+    // use TH1D instead of TH1F to avoid stauration at 2^31
+    // above this increments with +1 don't work for float, need double
+    MonitorElement* globalPosXY_P = nullptr;
+    MonitorElement* globalPosXY_S = nullptr;
+    MonitorElement* localPosXY_P = nullptr;
+    MonitorElement* localPosXY_S = nullptr;
+      
+    MonitorElement* numberRecHits_P = nullptr;
+    MonitorElement* numberRecHits_S = nullptr; 
+    MonitorElement* clusterSize_P = nullptr;
+    MonitorElement* clusterSize_S = nullptr;
+  };
+  std::map<std::string, RecHitME>  layerMEs_;
+};
+
+//
+// constructors
+//
+Phase2OTMonitorRecHit::Phase2OTMonitorRecHit(const edm::ParameterSet& iConfig):
+  config_(iConfig),
+  tokenRecHitsOT_(consumes<Phase2TrackerRecHit1DCollectionNew>(config_.getParameter<edm::InputTag>("rechitsSrc"))),
+  geomToken_(esConsumes<TrackerGeometry, TrackerDigiGeometryRecord, edm::Transition::BeginRun>()),
+  topoToken_(esConsumes<TrackerTopology, TrackerTopologyRcd, edm::Transition::BeginRun>())
+{      
+  edm::LogInfo("Phase2OTMonitorRecHit") << ">>> Construct Phase2OTMonitorRecHit ";
+}
+
+//
+// destructor
+//
+Phase2OTMonitorRecHit::~Phase2OTMonitorRecHit() {
+  // do anything here that needs to be done at desctruction time
+  // (e.g. close files, deallocate resources etc.)
+  edm::LogInfo("Phase2OTMonitorRecHit") << ">>> Destroy Phase2OTMonitorRecHit ";
+}
+//
+// -- DQM Begin Run
+void Phase2OTMonitorRecHit::dqmBeginRun(const edm::Run& iRun, const edm::EventSetup& iSetup) {
+  edm::ESHandle<TrackerGeometry> geomHandle = iSetup.getHandle(geomToken_);
+  tkGeom_ = &(*geomHandle);
+  edm::ESHandle<TrackerTopology> tTopoHandle = iSetup.getHandle(topoToken_);
+  tTopo_ = tTopoHandle.product();
+}
+
+
+//
+// -- Analyze
+//
+void Phase2OTMonitorRecHit::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
+
+  // Get the RecHits
+  edm::Handle<Phase2TrackerRecHit1DCollectionNew> rechits;
+  iEvent.getByToken(tokenRecHitsOT_, rechits);
+  if(!rechits.isValid())  return;
+  std::map<std::string, unsigned int>  nrechitLayerMapP;
+  std::map<std::string, unsigned int>  nrechitLayerMapS;
+  unsigned long int nTotrechitsinevt = 0;
+  // Loop over modules
+  Phase2TrackerRecHit1DCollectionNew::const_iterator DSViter; 
+  for (DSViter = rechits->begin(); DSViter != rechits->end(); ++DSViter) {
+    // Get the detector unit's id
+    unsigned int rawid(DSViter->detId());
+    DetId detId(rawid);
+    // Get the geomdet
+    const GeomDetUnit* geomDetunit(tkGeom_->idToDetUnit(detId));
+    if (!geomDetunit)
+      continue;
+    // determine the detector we are in
+    TrackerGeometry::ModuleType mType = tkGeom_->getDetectorType(detId);
+    std::string key = phase2tkutil::getOTHistoId(detId.rawId(), tTopo_);
+    nTotrechitsinevt += DSViter->size();
+    if (mType == TrackerGeometry::ModuleType::Ph2PSP) {
+      if(nrechitLayerMapP.find(key) == nrechitLayerMapP.end()) {
+	nrechitLayerMapP.insert(std::make_pair(key, DSViter->size())); 
+      } else {
+	nrechitLayerMapP[key] += DSViter->size();
+      }
+    } else if (mType == TrackerGeometry::ModuleType::Ph2PSS || mType == TrackerGeometry::ModuleType::Ph2SS){
+      if(nrechitLayerMapS.find(key) == nrechitLayerMapS.end()) {
+	nrechitLayerMapS.insert(std::make_pair(key, DSViter->size()));
+      }
+      else {
+	nrechitLayerMapS[key] += DSViter->size();
+      }
+    }
+    edmNew::DetSet<Phase2TrackerRecHit1D>::const_iterator rechitIt;
+    //loop over rechits for a single detId
+    for(rechitIt = DSViter->begin(); rechitIt != DSViter->end(); ++rechitIt) {
+      LocalPoint lp = rechitIt->localPosition();
+      Global3DPoint globalPos = geomDetunit->surface().toGlobal(lp);
+      //in mm
+      double gx = globalPos.x()*10.;
+      double gy = globalPos.y()*10.;
+      double gz = globalPos.z()*10.;
+      double gr = globalPos.perp()*10.;
+      //Fill positions
+      if (mType == TrackerGeometry::ModuleType::Ph2PSP) {
+	globalXY_P_->Fill(gx, gy);
+	globalRZ_P_->Fill(gz, gr);
+	//layer wise histo
+	layerMEs_[key].clusterSize_P->Fill(rechitIt->cluster()->size());
+	//layerMEs_[key].globalPosXY_P->Fill(gx, gy); 
+	layerMEs_[key].localPosXY_P->Fill(lp.x(), lp.y()); 
+      } else if (mType == TrackerGeometry::ModuleType::Ph2PSS || mType == TrackerGeometry::ModuleType::Ph2SS) {
+	globalXY_S_->Fill(gx, gy);
+	globalRZ_S_->Fill(gz, gr);
+	//layer wise histo
+	layerMEs_[key].clusterSize_S->Fill(rechitIt->cluster()->size());
+	//layerMEs_[key].globalPosXY_S->Fill(gx, gy); 
+	layerMEs_[key].localPosXY_S->Fill(lp.x(), lp.y()); 
+      } 
+    }//end loop over rechits of a detId
+  } //End loop over DetSetVector
+ 
+  //fill nRecHits per event
+  numberRecHits_->Fill(nTotrechitsinevt);
+  //fill nRecHit counter per layer
+  for(auto& lme : nrechitLayerMapP) {
+    layerMEs_[lme.first].numberRecHits_P->Fill(lme.second);
+  }
+  for(auto& lme : nrechitLayerMapS) {
+    layerMEs_[lme.first].numberRecHits_S->Fill(lme.second);
+  }
+}
+//
+// -- Book Histograms
+//
+void Phase2OTMonitorRecHit::bookHistograms(DQMStore::IBooker& ibooker,
+					    edm::Run const& iRun,
+					    edm::EventSetup const& iSetup) {
+  
+  std::string top_folder = config_.getParameter<std::string>("TopFolderName");
+  //std::stringstream folder_name;
+  
+  ibooker.cd();
+  edm::LogInfo("Phase2OTMonitorRecHit") << " Booking Histograms in : " << top_folder;
+  ibooker.setCurrentFolder(top_folder);
+
+  //Global histos for OT
+  numberRecHits_ =  phase2tkutil::book1DFromPSet(config_.getParameter<edm::ParameterSet>("GlobalNRecHits"), ibooker); 
+
+  globalXY_P_   = phase2tkutil::book2DFromPSet(config_.getParameter<edm::ParameterSet>("GlobalPositionXY_P"), ibooker); 
+
+  globalRZ_P_   = phase2tkutil::book2DFromPSet(config_.getParameter<edm::ParameterSet>("GlobalPositionRZ_P"), ibooker);
+
+  globalXY_S_   = phase2tkutil::book2DFromPSet(config_.getParameter<edm::ParameterSet>("GlobalPositionXY_S"), ibooker);
+
+  globalRZ_S_   = phase2tkutil::book2DFromPSet(config_.getParameter<edm::ParameterSet>("GlobalPositionRZ_S"), ibooker);
+
+  //Now book layer wise histos
+  edm::ESWatcher<TrackerDigiGeometryRecord> theTkDigiGeomWatcher;
+  if (theTkDigiGeomWatcher.check(iSetup)) {
+    for (auto const& det_u : tkGeom_->detUnits()) {
+      //Always check TrackerNumberingBuilder before changing this part
+      if(det_u->subDetector() == GeomDetEnumerators::SubDetector::P2PXB
+	 || det_u->subDetector() == GeomDetEnumerators::SubDetector::P2PXEC)
+	continue;
+      unsigned int detId_raw = det_u->geographicalId().rawId();
+      bookLayerHistos(ibooker, detId_raw, top_folder);
+    }
+  }
+}
+
+//
+// -- Book Layer Histograms
+//
+void Phase2OTMonitorRecHit::bookLayerHistos(DQMStore::IBooker& ibooker,
+					     unsigned int det_id,
+					     std::string& subdir) {
+  
+  std::string key = phase2tkutil::getOTHistoId(det_id, tTopo_);
+  if (layerMEs_.find(key) == layerMEs_.end()) {
+    
+    ibooker.cd();
+    RecHitME local_histos;
+    ibooker.setCurrentFolder(subdir+"/"+key);
+    edm::LogInfo("Phase2OTMonitorRecHit") << " Booking Histograms in : " << key;
+
+    if(tkGeom_->getDetectorType(det_id) == TrackerGeometry::ModuleType::Ph2PSP) {
+      local_histos.numberRecHits_P = phase2tkutil::book1DFromPSet(config_.getParameter<edm::ParameterSet>("NRecHitsLayer_P"), ibooker);
+      
+      local_histos.clusterSize_P = phase2tkutil::book1DFromPSet(config_.getParameter<edm::ParameterSet>("ClusterSize_P"), ibooker);
+
+      local_histos.globalPosXY_P = phase2tkutil::book2DFromPSet(config_.getParameter<edm::ParameterSet>("GlobalPositionXY_perlayer_P"), ibooker); 
+
+      local_histos.localPosXY_P = phase2tkutil::book2DFromPSet(config_.getParameter<edm::ParameterSet>("LocalPositionXY_P"), ibooker); 
+
+    }//if block for P
+    
+    ibooker.setCurrentFolder(subdir+"/"+key);
+    local_histos.numberRecHits_S = phase2tkutil::book1DFromPSet(config_.getParameter<edm::ParameterSet>("NRecHitsLayer_P"), ibooker);
+    local_histos.clusterSize_S = phase2tkutil::book1DFromPSet(config_.getParameter<edm::ParameterSet>("ClusterSize_S"), ibooker);
+    local_histos.localPosXY_S = phase2tkutil::book2DFromPSet(config_.getParameter<edm::ParameterSet>("LocalPositionXY_S"), ibooker); 
+    
+    layerMEs_.insert(std::make_pair(key, local_histos));
+  }
+}
+
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+void Phase2OTMonitorRecHit::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  // rechitMonitorOT
+  edm::ParameterSetDescription desc;
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<std::string>("name", "NumberOfRecHits");
+    psd0.add<std::string>("title", ";Number of rechits per event;");
+    psd0.add<double>("xmin", 0.0);
+    psd0.add<bool>("switch", true);
+    psd0.add<double>("xmax", 000.0);
+    psd0.add<int>("NxBins", 150);
+    desc.add<edm::ParameterSetDescription>("GlobalNRecHits", psd0);
+  }
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<std::string>("name", "Global_RecHitPosition_XY_P");
+    psd0.add<std::string>("title", "Global_RecHitPosition_XY_P;x [mm];y [mm];");
+    psd0.add<int>("NxBins", 1250);
+    psd0.add<double>("xmin", -1250.0);
+    psd0.add<double>("xmax", 1250.0);
+    psd0.add<int>("NyBins", 1250);
+    psd0.add<double>("ymin", -1250.0);
+    psd0.add<double>("ymax", 1250.0);
+    psd0.add<bool>("switch", true);
+    desc.add<edm::ParameterSetDescription>("GlobalPositionXY_P", psd0);
+  }
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<std::string>("name", "Global_RecHitPosition_XY_S");
+    psd0.add<std::string>("title", "Global_RecHitPosition_XY_S;x [mm];y [mm];");
+    psd0.add<int>("NxBins", 1250);
+    psd0.add<double>("xmin", -1250.0);
+    psd0.add<double>("xmax", 1250.0);
+    psd0.add<int>("NyBins", 1250);
+    psd0.add<double>("ymin", -1250.0);
+    psd0.add<double>("ymax", 1250.0);
+    psd0.add<bool>("switch", true);
+    desc.add<edm::ParameterSetDescription>("GlobalPositionXY_S", psd0);
+  }
+
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<std::string>("name", "Global_RecHitPosition_RZ_P");
+    psd0.add<std::string>("title", "Global_RecHitPosition_RZ_P;z [mm];r [mm]");
+    psd0.add<int>("NxBins", 1500);
+    psd0.add<double>("xmin", -3000.0);
+    psd0.add<double>("xmax", 3000.0);
+    psd0.add<int>("NyBins", 1250);
+    psd0.add<double>("ymin", 0.0);
+    psd0.add<double>("ymax", 1250.0);
+    psd0.add<bool>("switch", true);
+    desc.add<edm::ParameterSetDescription>("GlobalPositionRZ_P", psd0);
+  }
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<std::string>("name", "Global_RecHitPosition_RZ_S");
+    psd0.add<std::string>("title", "Global_RecHitPosition_RZ_S;z [mm];r [mm]");
+  
+    psd0.add<int>("NxBins", 1500);
+    psd0.add<double>("xmin", -3000.0);
+    psd0.add<double>("xmax", 3000.0);
+    psd0.add<int>("NyBins", 1250);
+    psd0.add<double>("ymin", 0.0);
+    psd0.add<double>("ymax", 1250.0);
+    psd0.add<bool>("switch", true);
+    desc.add<edm::ParameterSetDescription>("GlobalPositionRZ_S", psd0);
+  }
+  //Layer wise parameter
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<std::string>("name", "NumberOfRecHitsLayerP");
+    psd0.add<std::string>("title", ";Number of clusters per event(macro pixel sensor);");
+    psd0.add<double>("xmin", 0.0);
+    psd0.add<double>("xmax", 28000.0);
+    psd0.add<int>("NxBins", 150);
+    psd0.add<bool>("switch", true);
+    desc.add<edm::ParameterSetDescription>("NRecHitsLayer_P", psd0);
+  }
+
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<std::string>("name", "NumberOfRecHitsLayerS");
+    psd0.add<std::string>("title", ";Number of clusters per event(strip sensor);");
+    psd0.add<double>("xmin", 0.0);
+    psd0.add<double>("xmax", 28000.0);
+    psd0.add<int>("NxBins", 150);
+    psd0.add<bool>("switch", true);
+    desc.add<edm::ParameterSetDescription>("NRecHitsLayer_S", psd0);
+  }
+
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<std::string>("name", "ClusterSize_P");
+    psd0.add<std::string>("title", ";cluster size(macro pixel sensor);");
+    psd0.add<double>("xmin", -0.5);
+    psd0.add<double>("xmax", 30.5);
+    psd0.add<int>("NxBins", 31);
+    psd0.add<bool>("switch", true);
+    desc.add<edm::ParameterSetDescription>("ClusterSize_P", psd0);
+  }
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<std::string>("name", "ClusterSize_S");
+    psd0.add<std::string>("title", ";cluster size(strip sensor);");
+    psd0.add<double>("xmin", -0.5);
+    psd0.add<double>("xmax", 30.5);
+    psd0.add<int>("NxBins", 31);
+    psd0.add<bool>("switch", true);
+    desc.add<edm::ParameterSetDescription>("ClusterSize_S", psd0);
+  }
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<std::string>("name", "GlobalPositionXY_perlayer_P");
+    psd0.add<std::string>("title", "GlobalRecHitPositionXY_perlayer_P;x[mm];y[mm];");
+    psd0.add<int>("NxBins", 1250);
+    psd0.add<double>("xmin", -1250.0);
+    psd0.add<double>("xmax", 1250.0);
+    psd0.add<int>("NyBins", 1250);
+    psd0.add<double>("ymin", -1250.0);
+    psd0.add<double>("ymax", 1250.0);
+    psd0.add<bool>("switch", true);
+    desc.add<edm::ParameterSetDescription>("GlobalPositionXY_perlayer_P", psd0);
+  }
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<std::string>("name", "GlobalPositionXY_perlayer_S");
+    psd0.add<std::string>("title", "GlobalRecHitPositionXY_perlayer_S;x[mm];y[mm];");
+    psd0.add<int>("NxBins", 1250);
+    psd0.add<double>("xmin", -1250.0);
+    psd0.add<double>("xmax", 1250.0);
+    psd0.add<int>("NyBins", 1250);
+    psd0.add<double>("ymin", -1250.0);
+    psd0.add<double>("ymax", 1250.0);
+    psd0.add<bool>("switch", true);
+    desc.add<edm::ParameterSetDescription>("GlobalPositionXY_perlayer_S", psd0);
+  }
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<std::string>("name", "LocalPositionXY_P");
+    psd0.add<std::string>("title", "LocalPositionXY_P;x ;y ;");
+    psd0.add<int>("NxBins", 50);
+    psd0.add<double>("xmin", -10.0);
+    psd0.add<double>("xmax", 10.0);
+    psd0.add<int>("NyBins", 50);
+    psd0.add<double>("ymin", -10.0);
+    psd0.add<double>("ymax", 10.0);
+    psd0.add<bool>("switch", true);
+    desc.add<edm::ParameterSetDescription>("LocalPositionXY_P", psd0);
+  }
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<std::string>("name", "LocalPositionXY_S");
+    psd0.add<std::string>("title", "LocalPositionXY_S;x ;y ;");
+    psd0.add<int>("NxBins", 50);
+    psd0.add<double>("xmin", -10.0);
+    psd0.add<double>("xmax", 10.0);
+    psd0.add<int>("NyBins", 50);
+    psd0.add<double>("ymin", -10.0);
+    psd0.add<double>("ymax", 10.0);
+    psd0.add<bool>("switch", true);
+    desc.add<edm::ParameterSetDescription>("LocalPositionXY_S", psd0);
+  }
+  desc.add<std::string>("TopFolderName", "TrackerPhase2OTRecHit");
+  desc.add<bool>("Verbosity", false);
+  desc.add<edm::InputTag>("rechitsSrc", edm::InputTag("siPhase2RecHits"));
+  descriptions.add("Phase2OTMonitorRecHit", desc);
+  // or use the following to generate the label from the module's C++ type
+  //descriptions.addWithDefaultLabel(desc);
+}
+  
+//define this as a plug-in
+DEFINE_FWK_MODULE(Phase2OTMonitorRecHit);

--- a/DQM/SiTrackerPhase2/plugins/Phase2OTMonitorRecHit.cc
+++ b/DQM/SiTrackerPhase2/plugins/Phase2OTMonitorRecHit.cc
@@ -115,7 +115,8 @@ Phase2OTMonitorRecHit::~Phase2OTMonitorRecHit() {
 // -- DQM Begin Run
 void Phase2OTMonitorRecHit::dqmBeginRun(const edm::Run& iRun, const edm::EventSetup& iSetup) {
   tkGeom_ = &iSetup.getData(geomToken_);
-  tTopo_ = &iSetup.getData(topoToken_);;
+  tTopo_ = &iSetup.getData(topoToken_);
+  ;
 }
 
 //

--- a/DQM/SiTrackerPhase2/plugins/Phase2TrackerMonitorDigi.cc
+++ b/DQM/SiTrackerPhase2/plugins/Phase2TrackerMonitorDigi.cc
@@ -69,10 +69,8 @@ Phase2TrackerMonitorDigi::~Phase2TrackerMonitorDigi() {
 }
 
 void Phase2TrackerMonitorDigi::dqmBeginRun(const edm::Run& iRun, const edm::EventSetup& iSetup) {
-  edm::ESHandle<TrackerGeometry> geomHandle = iSetup.getHandle(geomToken_);
-  tkGeom_ = &(*geomHandle);
-  edm::ESHandle<TrackerTopology> tTopoHandle = iSetup.getHandle(topoToken_);
-  tTopo_ = tTopoHandle.product();
+  tkGeom_ = &iSetup.getData(geomToken_);
+  tTopo_ = &iSetup.getData(topoToken_);
 }
 
 // -- Analyze
@@ -81,11 +79,8 @@ void Phase2TrackerMonitorDigi::analyze(const edm::Event& iEvent, const edm::Even
   using namespace edm;
 
   // Get digis
-  edm::Handle<edm::DetSetVector<PixelDigi>> pixDigiHandle;
-  iEvent.getByToken(itPixelDigiToken_, pixDigiHandle);
-
-  edm::Handle<edm::DetSetVector<Phase2TrackerDigi>> otDigiHandle;
-  iEvent.getByToken(otDigiToken_, otDigiHandle);
+  const auto& pixDigiHandle = iEvent.getHandle(itPixelDigiToken_);
+  const auto& otDigiHandle = iEvent.getHandle(otDigiToken_);
 
   // Tracker Topology
   edm::ESWatcher<TrackerDigiGeometryRecord> theTkDigiGeomWatcher;

--- a/DQM/SiTrackerPhase2/test/dqmstep_phase2tk_cfg.py
+++ b/DQM/SiTrackerPhase2/test/dqmstep_phase2tk_cfg.py
@@ -110,12 +110,12 @@ process.rechits_step = cms.Path(process.siPhase2RecHits * process.siPixelRecHits
 process.load('DQM.SiTrackerPhase2.Phase2TrackerDQMFirstStep_cff')
 process.load('DQM.SiTrackerPhase2.Phase2OTMonitorRecHit_cfi')
 
-process.otdqm_seq = cms.Sequence(process.trackerphase2DQMSource.copy())#*process.Phase2OTMonitorRecHit)
+process.otdqm_seq = cms.Sequence(process.trackerphase2DQMSource.copy()*process.Phase2OTMonitorRecHit)
 
 process.load('Validation.SiTrackerPhase2V.Phase2TrackerValidationFirstStep_cff')
 process.load('Validation.SiTrackerPhase2V.Phase2OTValidateRecHit_cfi')
 
-process.otvalid_seq = cms.Sequence(process.trackerphase2ValidationSource.copy())#*process.Phase2OTValidateRecHit)
+process.otvalid_seq = cms.Sequence(process.trackerphase2ValidationSource.copy()*process.Phase2OTValidateRecHit)
 
 process.dqm_step=cms.Path(process.otdqm_seq)
 process.validation_step=cms.Path(process.otvalid_seq)

--- a/DQM/SiTrackerPhase2/test/dqmstep_phase2tk_cfg.py
+++ b/DQM/SiTrackerPhase2/test/dqmstep_phase2tk_cfg.py
@@ -1,0 +1,150 @@
+##Takes as input GEN-SIM-RECO
+# Auto generated configuration file
+# using: 
+# Revision: 1.19 
+# Source: /local/reps/CMSSW/CMSSW/Configuration/Applications/python/ConfigBuilder.py,v 
+# with command line options: step3 --conditions auto:phase2_realistic_T21 -s RAW2DIGI,L1Reco,RECO,RECOSIM,VALIDATION:@phase2Validation,DQM:@phase2 --datatier DQMIO -n 10 --geometry Extended2026D76 --era Phase2C11M9 --eventcontent DQM --no_exec
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Eras.Era_Phase2C11M9_cff import Phase2C11M9
+
+process = cms.Process('RERECO',Phase2C11M9)
+
+# import of standard configurations
+process.load('Configuration.StandardSequences.Services_cff')
+process.load('SimGeneral.HepPDTESSource.pythiapdt_cfi')
+process.load('FWCore.MessageService.MessageLogger_cfi')
+process.load('Configuration.EventContent.EventContent_cff')
+process.load('SimGeneral.MixingModule.mixNoPU_cfi')
+process.load('Configuration.Geometry.GeometryExtended2026D76Reco_cff')
+process.load('Configuration.StandardSequences.MagneticField_cff')
+process.load('Configuration.StandardSequences.RawToDigi_Data_cff')
+process.load('Configuration.StandardSequences.L1Reco_cff')
+process.load('Configuration.StandardSequences.Reconstruction_Data_cff')
+process.load('Configuration.StandardSequences.RecoSim_cff')
+process.load('Configuration.StandardSequences.Validation_cff')
+process.load('DQMServices.Core.DQMStoreNonLegacy_cff')
+process.load('DQMOffline.Configuration.DQMOffline_cff')
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(10),
+    output = cms.optional.untracked.allowed(cms.int32,cms.PSet)
+)
+
+# Input source
+process.source = cms.Source("PoolSource",
+    fileNames = cms.untracked.vstring('/store/relval/CMSSW_11_3_0_pre4/RelValTTbar_14TeV/GEN-SIM-RECO/113X_mcRun4_realistic_v4_2026D76noPU-v1/00000/cf5b0e7d-f139-4305-9baf-db9c64590966.root'),
+    secondaryFileNames = cms.untracked.vstring()
+)
+
+process.options = cms.untracked.PSet(
+    FailPath = cms.untracked.vstring(),
+    IgnoreCompletely = cms.untracked.vstring(),
+    Rethrow = cms.untracked.vstring(),
+    SkipEvent = cms.untracked.vstring(),
+    allowUnscheduled = cms.obsolete.untracked.bool,
+    canDeleteEarly = cms.untracked.vstring(),
+    deleteNonConsumedUnscheduledModules = cms.untracked.bool(True),
+    emptyRunLumiMode = cms.obsolete.untracked.string,
+    eventSetup = cms.untracked.PSet(
+        forceNumberOfConcurrentIOVs = cms.untracked.PSet(
+            allowAnyLabel_=cms.required.untracked.uint32
+        ),
+        numberOfConcurrentIOVs = cms.untracked.uint32(1)
+    ),
+    fileMode = cms.untracked.string('FULLMERGE'),
+    forceEventSetupCacheClearOnNewRun = cms.untracked.bool(False),
+    makeTriggerResults = cms.obsolete.untracked.bool,
+    numberOfConcurrentLuminosityBlocks = cms.untracked.uint32(1),
+    numberOfConcurrentRuns = cms.untracked.uint32(1),
+    numberOfStreams = cms.untracked.uint32(0),
+    numberOfThreads = cms.untracked.uint32(4),
+    printDependencies = cms.untracked.bool(False),
+    sizeOfStackForThreadsInKB = cms.optional.untracked.uint32,
+    throwIfIllegalParameter = cms.untracked.bool(True),
+    wantSummary = cms.untracked.bool(False)
+)
+
+# Production Info
+process.configurationMetadata = cms.untracked.PSet(
+    annotation = cms.untracked.string('step3 nevts:10'),
+    name = cms.untracked.string('Applications'),
+    version = cms.untracked.string('$Revision: 1.19 $')
+)
+
+# Output definition
+
+process.DQMoutput = cms.OutputModule("DQMRootOutputModule",
+    dataset = cms.untracked.PSet(
+        dataTier = cms.untracked.string('DQMIO'),
+        filterName = cms.untracked.string('')
+    ),
+    fileName = cms.untracked.string('step3_pre4_inDQM.root'),
+    outputCommands = process.DQMEventContent.outputCommands,
+    splitLevel = cms.untracked.int32(0)
+)
+
+# Additional output definition
+
+# Other statements
+process.mix.playback = True
+process.mix.digitizers = cms.PSet()
+for a in process.aliases: delattr(process, a)
+process.RandomNumberGeneratorService.restoreStateLabel=cms.untracked.string("randomEngineStateProducer")
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase2_realistic_T21', '')
+
+# Path and EndPath definitions
+process.raw2digi_step = cms.Path(process.RawToDigi)
+process.L1Reco_step = cms.Path(process.L1Reco)
+process.reconstruction_step = cms.Path(process.reconstruction)
+process.recosim_step = cms.Path(process.recosim)
+process.DQMoutput_step = cms.EndPath(process.DQMoutput)
+
+##phase2 OT rechit step
+process.load('RecoLocalTracker.Phase2TrackerRecHits.Phase2TrackerRecHits_cfi')
+process.load('RecoLocalTracker.SiPixelRecHits.SiPixelRecHits_cfi')
+process.rechits_step = cms.Path(process.siPhase2RecHits * process.siPixelRecHits)
+#DQM modules
+process.load('DQM.SiTrackerPhase2.Phase2TrackerDQMFirstStep_cff')
+process.load('DQM.SiTrackerPhase2.Phase2OTMonitorRecHit_cfi')
+
+process.otdqm_seq = cms.Sequence(process.trackerphase2DQMSource.copy())#*process.Phase2OTMonitorRecHit)
+
+process.load('Validation.SiTrackerPhase2V.Phase2TrackerValidationFirstStep_cff')
+process.load('Validation.SiTrackerPhase2V.Phase2OTValidateRecHit_cfi')
+
+process.otvalid_seq = cms.Sequence(process.trackerphase2ValidationSource.copy())#*process.Phase2OTValidateRecHit)
+
+process.dqm_step=cms.Path(process.otdqm_seq)
+process.validation_step=cms.Path(process.otvalid_seq)
+
+
+# Schedule definition
+process.schedule = cms.Schedule(process.rechits_step,
+                                process.dqm_step,
+                                process.validation_step,
+                                process.DQMoutput_step
+)
+# customisation of the process.
+
+# Automatic addition of the customisation function from SimGeneral.MixingModule.fullMixCustomize_cff
+from SimGeneral.MixingModule.fullMixCustomize_cff import setCrossingFrameOn 
+
+#call to customisation function setCrossingFrameOn imported from SimGeneral.MixingModule.fullMixCustomize_cff
+process = setCrossingFrameOn(process)
+
+# End of customisation functions
+
+
+# Customisation from command line
+
+#Have logErrorHarvester wait for the same EDProducers to finish as those providing data for the OutputModule
+from FWCore.Modules.logErrorHarvester_cff import customiseLogErrorHarvesterUsingOutputCommands
+process = customiseLogErrorHarvesterUsingOutputCommands(process)
+
+# Add early deletion of temporary data products to reduce peak memory need
+from Configuration.StandardSequences.earlyDeleteSettings_cff import customiseEarlyDelete
+process = customiseEarlyDelete(process)
+# End adding early deletion

--- a/DQM/SiTrackerPhase2/test/harvestingstep_phase2tk_cfg.py
+++ b/DQM/SiTrackerPhase2/test/harvestingstep_phase2tk_cfg.py
@@ -31,17 +31,6 @@ process.source = cms.Source("DQMRootSource",
     fileNames = cms.untracked.vstring('file:step3_pre4_inDQM.root'
     )
 )
-'''
-'file:crab/crab_nopu_pre4/step3_pre4_inDQM_1.root',
-'file:crab/crab_nopu_pre4/step3_pre4_inDQM_2.root',
-'file:crab/crab_nopu_pre4/step3_pre4_inDQM_3.root',
-'file:crab/crab_nopu_pre4/step3_pre4_inDQM_4.root',
-'file:crab/crab_nopu_pre4/step3_pre4_inDQM_5.root',
-'file:crab/crab_nopu_pre4/step3_pre4_inDQM_6.root',
-'file:crab/crab_nopu_pre4/step3_pre4_inDQM_7.root',
-'file:crab/crab_nopu_pre4/step3_pre4_inDQM_8.root',
-'file:crab/crab_nopu_pre4/step3_pre4_inDQM_9.root',
-'''
 
 process.options = cms.untracked.PSet(
     FailPath = cms.untracked.vstring(),

--- a/DQM/SiTrackerPhase2/test/harvestingstep_phase2tk_cfg.py
+++ b/DQM/SiTrackerPhase2/test/harvestingstep_phase2tk_cfg.py
@@ -1,0 +1,95 @@
+# Auto generated configuration file
+# using: 
+# Revision: 1.19 
+# Source: /local/reps/CMSSW/CMSSW/Configuration/Applications/python/ConfigBuilder.py,v 
+# with command line options: step4 --conditions auto:phase2_realistic_T21 -s HARVESTING:@phase2Validation+@phase2+@miniAODValidation+@miniAODDQM --scenario pp --filetype DQM --geometry Extended2026D76 --era Phase2C11M9 --mc -n -1 --no_exec
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Eras.Era_Phase2C11M9_cff import Phase2C11M9
+
+process = cms.Process('HARVESTING',Phase2C11M9)
+
+# import of standard configurations
+process.load('Configuration.StandardSequences.Services_cff')
+process.load('SimGeneral.HepPDTESSource.pythiapdt_cfi')
+process.load('FWCore.MessageService.MessageLogger_cfi')
+process.load('Configuration.EventContent.EventContent_cff')
+process.load('SimGeneral.MixingModule.mixNoPU_cfi')
+process.load('Configuration.Geometry.GeometryExtended2026D76Reco_cff')
+process.load('Configuration.StandardSequences.MagneticField_cff')
+process.load('Configuration.StandardSequences.DQMSaverAtRunEnd_cff')
+process.load('Configuration.StandardSequences.Harvesting_cff')
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(8000),
+    output = cms.optional.untracked.allowed(cms.int32,cms.PSet)
+)
+
+# Input source
+process.source = cms.Source("DQMRootSource",
+    fileNames = cms.untracked.vstring('file:step3_pre4_inDQM.root'
+    )
+)
+'''
+'file:crab/crab_nopu_pre4/step3_pre4_inDQM_1.root',
+'file:crab/crab_nopu_pre4/step3_pre4_inDQM_2.root',
+'file:crab/crab_nopu_pre4/step3_pre4_inDQM_3.root',
+'file:crab/crab_nopu_pre4/step3_pre4_inDQM_4.root',
+'file:crab/crab_nopu_pre4/step3_pre4_inDQM_5.root',
+'file:crab/crab_nopu_pre4/step3_pre4_inDQM_6.root',
+'file:crab/crab_nopu_pre4/step3_pre4_inDQM_7.root',
+'file:crab/crab_nopu_pre4/step3_pre4_inDQM_8.root',
+'file:crab/crab_nopu_pre4/step3_pre4_inDQM_9.root',
+'''
+
+process.options = cms.untracked.PSet(
+    FailPath = cms.untracked.vstring(),
+    IgnoreCompletely = cms.untracked.vstring(),
+    Rethrow = cms.untracked.vstring('ProductNotFound'),
+    SkipEvent = cms.untracked.vstring(),
+    allowUnscheduled = cms.obsolete.untracked.bool,
+    canDeleteEarly = cms.untracked.vstring(),
+    deleteNonConsumedUnscheduledModules = cms.untracked.bool(True),
+    emptyRunLumiMode = cms.obsolete.untracked.string,
+    eventSetup = cms.untracked.PSet(
+        forceNumberOfConcurrentIOVs = cms.untracked.PSet(
+            allowAnyLabel_=cms.required.untracked.uint32
+        ),
+        numberOfConcurrentIOVs = cms.untracked.uint32(1)
+    ),
+    fileMode = cms.untracked.string('FULLMERGE'),
+    forceEventSetupCacheClearOnNewRun = cms.untracked.bool(False),
+    makeTriggerResults = cms.obsolete.untracked.bool,
+    numberOfConcurrentLuminosityBlocks = cms.untracked.uint32(1),
+    numberOfConcurrentRuns = cms.untracked.uint32(1),
+    numberOfStreams = cms.untracked.uint32(0),
+    numberOfThreads = cms.untracked.uint32(1),
+    printDependencies = cms.untracked.bool(False),
+    sizeOfStackForThreadsInKB = cms.optional.untracked.uint32,
+    throwIfIllegalParameter = cms.untracked.bool(True),
+    wantSummary = cms.untracked.bool(False)
+)
+
+# Production Info
+process.configurationMetadata = cms.untracked.PSet(
+    annotation = cms.untracked.string('step4 nevts:-1'),
+    name = cms.untracked.string('Applications'),
+    version = cms.untracked.string('$Revision: 1.19 $')
+)
+
+# Output definition
+
+# Additional output definition
+
+# Other statements
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase2_realistic_T21', '')
+
+# Path and EndPath definitions
+process.trackerphase2ValidationHarvesting_step = cms.Path(process.trackerphase2ValidationHarvesting)
+process.dqmsave_step = cms.Path(process.DQMSaver)
+
+# Schedule definition
+process.schedule = cms.Schedule(process.trackerphase2ValidationHarvesting_step,process.dqmsave_step)
+

--- a/Validation/SiTrackerPhase2V/plugins/Phase2ITValidateCluster.cc
+++ b/Validation/SiTrackerPhase2V/plugins/Phase2ITValidateCluster.cc
@@ -120,10 +120,8 @@ Phase2ITValidateCluster::~Phase2ITValidateCluster() {
 // -- DQM Begin Run
 //
 void Phase2ITValidateCluster::dqmBeginRun(const edm::Run& iRun, const edm::EventSetup& iSetup) {
-  edm::ESHandle<TrackerGeometry> geomHandle = iSetup.getHandle(geomToken_);
-  tkGeom_ = &(*geomHandle);
-  edm::ESHandle<TrackerTopology> tTopoHandle = iSetup.getHandle(topoToken_);
-  tTopo_ = tTopoHandle.product();
+  tkGeom_ = &iSetup.getData(geomToken_);
+  tTopo_ = &iSetup.getData(topoToken_);
 }
 
 // -- Analyze
@@ -132,16 +130,13 @@ void Phase2ITValidateCluster::analyze(const edm::Event& iEvent, const edm::Event
   // Getting simHits
   std::vector<edm::Handle<edm::PSimHitContainer>> simHits;
   for (const auto& itoken : simHitTokens_) {
-    edm::Handle<edm::PSimHitContainer> simHitHandle;
-    iEvent.getByToken(itoken, simHitHandle);
+    const auto& simHitHandle = iEvent.getHandle(itoken);
     if (!simHitHandle.isValid())
       continue;
     simHits.emplace_back(simHitHandle);
   }
   // Get the SimTracks
-  edm::Handle<edm::SimTrackContainer> simTracksRaw;
-  iEvent.getByToken(simTracksToken_, simTracksRaw);
-
+  const auto& simTracksRaw = iEvent.getHandle(simTracksToken_);
   // Rearrange the simTracks for ease of use <simTrackID, simTrack>
   SimTracksMap simTracks;
   for (edm::SimTrackContainer::const_iterator simTrackIt(simTracksRaw->begin()); simTrackIt != simTracksRaw->end();
@@ -157,12 +152,9 @@ void Phase2ITValidateCluster::fillITHistos(const edm::Event& iEvent,
                                            const std::vector<edm::Handle<edm::PSimHitContainer>>& simHits,
                                            const std::map<unsigned int, SimTrack>& simTracks) {
   // Getting the clusters
-  edm::Handle<edmNew::DetSetVector<SiPixelCluster>> clusterHandle;
-  iEvent.getByToken(clustersToken_, clusterHandle);
-
+  const auto& clusterHandle = iEvent.getHandle(clustersToken_);
   // Getting PixelDigiSimLinks
-  edm::Handle<edm::DetSetVector<PixelDigiSimLink>> pixelSimLinksHandle;
-  iEvent.getByToken(simITLinksToken_, pixelSimLinksHandle);
+  const auto& pixelSimLinksHandle = iEvent.getHandle(simITLinksToken_);
 
   for (const auto& DSVItr : *clusterHandle) {
     // Getting the id of detector unit

--- a/Validation/SiTrackerPhase2V/plugins/Phase2ITValidateRecHit.cc
+++ b/Validation/SiTrackerPhase2V/plugins/Phase2ITValidateRecHit.cc
@@ -85,6 +85,11 @@ private:
     MonitorElement* pullY = nullptr;
     MonitorElement* deltaX_eta = nullptr;
     MonitorElement* deltaY_eta = nullptr;
+    MonitorElement* deltaX_clsizex = nullptr;
+    MonitorElement* deltaX_clsizey = nullptr;
+    MonitorElement* deltaY_clsizex = nullptr;
+    MonitorElement* deltaY_clsizey = nullptr;
+    MonitorElement* deltaYvsdeltaX = nullptr;
     MonitorElement* pullX_eta = nullptr;
     MonitorElement* pullY_eta = nullptr;
     //For rechits matched to primary simhits
@@ -209,6 +214,11 @@ void Phase2ITValidateRecHit::fillITHistos(const edm::Event& iEvent,
       layerMEs_[key].pullY->Fill(pully);
       layerMEs_[key].deltaX_eta->Fill(eta, dx);
       layerMEs_[key].deltaY_eta->Fill(eta, dy);
+      layerMEs_[key].deltaX_clsizex->Fill(rechit.cluster()->sizeX(), dx);
+      layerMEs_[key].deltaX_clsizey->Fill(rechit.cluster()->sizeY(), dx);
+      layerMEs_[key].deltaY_clsizex->Fill(rechit.cluster()->sizeX(), dy);
+      layerMEs_[key].deltaY_clsizey->Fill(rechit.cluster()->sizeY(), dy);
+      layerMEs_[key].deltaYvsdeltaX->Fill(dx, dy);
       layerMEs_[key].pullX_eta->Fill(eta, pullx);
       layerMEs_[key].pullY_eta->Fill(eta, pully);
       if (isPrimary) {
@@ -278,6 +288,21 @@ void Phase2ITValidateRecHit::bookLayerHistos(DQMStore::IBooker& ibooker, unsigne
 
     local_histos.deltaY_eta =
         phase2tkutil::bookProfile1DFromPSet(config_.getParameter<edm::ParameterSet>("DeltaY_eta"), ibooker);
+
+    local_histos.deltaX_clsizex =
+        phase2tkutil::bookProfile1DFromPSet(config_.getParameter<edm::ParameterSet>("DeltaX_clsizex"), ibooker);
+
+    local_histos.deltaX_clsizey =
+        phase2tkutil::bookProfile1DFromPSet(config_.getParameter<edm::ParameterSet>("DeltaX_clsizey"), ibooker);
+
+    local_histos.deltaY_clsizex =
+        phase2tkutil::bookProfile1DFromPSet(config_.getParameter<edm::ParameterSet>("DeltaY_clsizex"), ibooker);
+
+    local_histos.deltaY_clsizey =
+        phase2tkutil::bookProfile1DFromPSet(config_.getParameter<edm::ParameterSet>("DeltaY_clsizey"), ibooker);
+
+    local_histos.deltaYvsdeltaX =
+        phase2tkutil::book2DFromPSet(config_.getParameter<edm::ParameterSet>("DeltaY_vs_DeltaX"), ibooker);
 
     local_histos.pullX_eta =
         phase2tkutil::bookProfile1DFromPSet(config_.getParameter<edm::ParameterSet>("PullX_eta"), ibooker);
@@ -371,6 +396,68 @@ void Phase2ITValidateRecHit::fillDescriptions(edm::ConfigurationDescriptions& de
     psd0.add<double>("xmin", -4.1);
     desc.add<edm::ParameterSetDescription>("DeltaY_eta", psd0);
   }
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<std::string>("name", "Delta_X_vs_ClusterSizeX");
+    psd0.add<std::string>("title", ";Cluster size X;#Delta x [#mum]");
+    psd0.add<double>("ymin", -100.0);
+    psd0.add<double>("ymax", 100.0);
+    psd0.add<int>("NxBins", 21);
+    psd0.add<bool>("switch", true);
+    psd0.add<double>("xmax", 20.5);
+    psd0.add<double>("xmin", -0.5);
+    desc.add<edm::ParameterSetDescription>("DeltaX_clsizex", psd0);
+  }
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<std::string>("name", "Delta_X_vs_ClusterSizeY");
+    psd0.add<std::string>("title", ";Cluster size Y;#Delta y [#mum]");
+    psd0.add<double>("ymin", -100.0);
+    psd0.add<double>("ymax", 100.0);
+    psd0.add<int>("NxBins", 21);
+    psd0.add<bool>("switch", true);
+    psd0.add<double>("xmax", 20.5);
+    psd0.add<double>("xmin", -0.5);
+    desc.add<edm::ParameterSetDescription>("DeltaX_clsizey", psd0);
+  }
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<std::string>("name", "Delta_Y_vs_ClusterSizeX");
+    psd0.add<std::string>("title", ";Cluster size Y;#Delta y [#mum]");
+    psd0.add<double>("ymin", -100.0);
+    psd0.add<double>("ymax", 100.0);
+    psd0.add<int>("NxBins", 21);
+    psd0.add<bool>("switch", true);
+    psd0.add<double>("xmax", 20.5);
+    psd0.add<double>("xmin", -0.5);
+    desc.add<edm::ParameterSetDescription>("DeltaY_clsizex", psd0);
+  }
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<std::string>("name", "Delta_Y_vs_ClusterSizeY");
+    psd0.add<std::string>("title", ";Cluster size Y;#Delta y [#mum]");
+    psd0.add<double>("ymin", -100.0);
+    psd0.add<double>("ymax", 100.0);
+    psd0.add<int>("NxBins", 21);
+    psd0.add<bool>("switch", true);
+    psd0.add<double>("xmax", 20.5);
+    psd0.add<double>("xmin", -0.5);
+    desc.add<edm::ParameterSetDescription>("DeltaY_clsizey", psd0);
+  }
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<std::string>("name", "Delta_Y_vs_DeltaX");
+    psd0.add<std::string>("title", ";#Delta x[#mum];#Delta y[#mum]");
+    psd0.add<bool>("switch", true);
+    psd0.add<double>("ymin", -100.0);
+    psd0.add<double>("ymax", 100.0);
+    psd0.add<int>("NyBins", 100);
+    psd0.add<double>("xmax", 100.);
+    psd0.add<double>("xmin", -100.);
+    psd0.add<int>("NxBins", 100);
+    desc.add<edm::ParameterSetDescription>("DeltaY_vs_DeltaX", psd0);
+  }
+
   {
     edm::ParameterSetDescription psd0;
     psd0.add<std::string>("name", "Pull_X_vs_Eta");

--- a/Validation/SiTrackerPhase2V/plugins/Phase2ITValidateRecHit.cc
+++ b/Validation/SiTrackerPhase2V/plugins/Phase2ITValidateRecHit.cc
@@ -123,15 +123,13 @@ Phase2ITValidateRecHit::~Phase2ITValidateRecHit() {
 void Phase2ITValidateRecHit::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
   std::vector<edm::Handle<edm::PSimHitContainer>> simHits;
   for (const auto& itoken : simHitTokens_) {
-    edm::Handle<edm::PSimHitContainer> simHitHandle;
-    iEvent.getByToken(itoken, simHitHandle);
+    const auto& simHitHandle = iEvent.getHandle(itoken);
     if (!simHitHandle.isValid())
       continue;
     simHits.emplace_back(simHitHandle);
   }
   // Get the SimTracks and push them in a map of id, SimTrack
-  edm::Handle<edm::SimTrackContainer> simTracks;
-  iEvent.getByToken(simTracksToken_, simTracks);
+  const auto& simTracks = iEvent.getHandle(simTracksToken_);
 
   std::map<unsigned int, SimTrack> selectedSimTrackMap;
   for (const auto& simTrackIt : *simTracks) {
@@ -148,8 +146,7 @@ void Phase2ITValidateRecHit::fillITHistos(const edm::Event& iEvent,
                                           const std::vector<edm::Handle<edm::PSimHitContainer>>& simHits,
                                           const std::map<unsigned int, SimTrack>& selectedSimTrackMap) {
   // Get the RecHits
-  edm::Handle<SiPixelRecHitCollection> rechits;
-  iEvent.getByToken(tokenRecHitsIT_, rechits);
+  const auto& rechits = iEvent.getHandle(tokenRecHitsIT_);
   if (!rechits.isValid())
     return;
   std::map<std::string, unsigned int> nrechitLayerMap_primary;
@@ -238,10 +235,8 @@ void Phase2ITValidateRecHit::fillITHistos(const edm::Event& iEvent,
 }
 
 void Phase2ITValidateRecHit::dqmBeginRun(const edm::Run& iRun, const edm::EventSetup& iSetup) {
-  edm::ESHandle<TrackerGeometry> geomHandle = iSetup.getHandle(geomToken_);
-  tkGeom_ = &(*geomHandle);
-  edm::ESHandle<TrackerTopology> tTopoHandle = iSetup.getHandle(topoToken_);
-  tTopo_ = tTopoHandle.product();
+  tkGeom_ = &iSetup.getData(geomToken_);
+  tTopo_ = &iSetup.getData(topoToken_);
 }
 //
 // -- Book Histograms

--- a/Validation/SiTrackerPhase2V/plugins/Phase2OTValidateCluster.cc
+++ b/Validation/SiTrackerPhase2V/plugins/Phase2OTValidateCluster.cc
@@ -386,8 +386,8 @@ void Phase2OTValidateCluster::fillDescriptions(edm::ConfigurationDescriptions& d
     psd0.add<std::string>("name", "Delta_Y_Pixel_Primary");
     psd0.add<std::string>("title", "#Delta Y " + mptag + ";cluster resolution Y coordinate [#mum]");
     psd0.add<bool>("switch", true);
-    psd0.add<double>("xmin", -500);
-    psd0.add<double>("xmax", 500);
+    psd0.add<double>("xmin", -1500);
+    psd0.add<double>("xmax", 1500);
     psd0.add<int>("NxBins", 100);
     desc.add<edm::ParameterSetDescription>("Delta_Y_Pixel_Primary", psd0);
   }

--- a/Validation/SiTrackerPhase2V/plugins/Phase2OTValidateCluster.cc
+++ b/Validation/SiTrackerPhase2V/plugins/Phase2OTValidateCluster.cc
@@ -124,10 +124,8 @@ Phase2OTValidateCluster::~Phase2OTValidateCluster() {
 // -- DQM Begin Run
 //
 void Phase2OTValidateCluster::dqmBeginRun(const edm::Run& iRun, const edm::EventSetup& iSetup) {
-  edm::ESHandle<TrackerGeometry> geomHandle = iSetup.getHandle(geomToken_);
-  tkGeom_ = &(*geomHandle);
-  edm::ESHandle<TrackerTopology> tTopoHandle = iSetup.getHandle(topoToken_);
-  tTopo_ = tTopoHandle.product();
+  tkGeom_ = &iSetup.getData(geomToken_);
+  tTopo_ = &iSetup.getData(topoToken_);
 }
 
 // -- Analyze
@@ -136,16 +134,13 @@ void Phase2OTValidateCluster::analyze(const edm::Event& iEvent, const edm::Event
   // Getting simHits
   std::vector<edm::Handle<edm::PSimHitContainer>> simHits;
   for (const auto& itoken : simHitTokens_) {
-    edm::Handle<edm::PSimHitContainer> simHitHandle;
-    iEvent.getByToken(itoken, simHitHandle);
+    const auto& simHitHandle = iEvent.getHandle(itoken);
     if (!simHitHandle.isValid())
       continue;
     simHits.emplace_back(simHitHandle);
   }
   // Get the SimTracks
-  edm::Handle<edm::SimTrackContainer> simTracksRaw;
-  iEvent.getByToken(simTracksToken_, simTracksRaw);
-
+  const auto& simTracksRaw = iEvent.getHandle(simTracksToken_);
   // Rearrange the simTracks for ease of use <simTrackID, simTrack>
   SimTracksMap simTracks;
   for (edm::SimTrackContainer::const_iterator simTrackIt(simTracksRaw->begin()); simTrackIt != simTracksRaw->end();
@@ -161,12 +156,9 @@ void Phase2OTValidateCluster::fillOTHistos(const edm::Event& iEvent,
                                            const std::vector<edm::Handle<edm::PSimHitContainer>>& simHits,
                                            const std::map<unsigned int, SimTrack>& simTracks) {
   // Getting the clusters
-  edm::Handle<Phase2TrackerCluster1DCollectionNew> clusterHandle;
-  iEvent.getByToken(clustersToken_, clusterHandle);
-
+  const auto& clusterHandle = iEvent.getHandle(clustersToken_);
   // Getting PixelDigiSimLinks
-  edm::Handle<edm::DetSetVector<PixelDigiSimLink>> pixelSimLinksHandle;
-  iEvent.getByToken(simOTLinksToken_, pixelSimLinksHandle);
+  const auto& pixelSimLinksHandle = iEvent.getHandle(simOTLinksToken_);
 
   // Number of clusters
   std::map<std::string, unsigned int> nPrimarySimHits[3];

--- a/Validation/SiTrackerPhase2V/plugins/Phase2OTValidateRecHit.cc
+++ b/Validation/SiTrackerPhase2V/plugins/Phase2OTValidateRecHit.cc
@@ -66,11 +66,12 @@ public:
   void analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) override;
   void dqmBeginRun(const edm::Run& iRun, const edm::EventSetup& iSetup) override;
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
 private:
-  void fillOTHistos(const edm::Event& iEvent, 
-		    const TrackerHitAssociator& associateRecHit,
-		    const std::vector<edm::Handle<edm::PSimHitContainer>>& simHits,
-		    const std::map<unsigned int, SimTrack>& selectedSimTrackMap);
+  void fillOTHistos(const edm::Event& iEvent,
+                    const TrackerHitAssociator& associateRecHit,
+                    const std::vector<edm::Handle<edm::PSimHitContainer>>& simHits,
+                    const std::map<unsigned int, SimTrack>& selectedSimTrackMap);
 
   void bookLayerHistos(DQMStore::IBooker& ibooker, unsigned int det_id, std::string& subdir);
 
@@ -81,7 +82,7 @@ private:
   std::string geomType_;
   const edm::EDGetTokenT<Phase2TrackerRecHit1DCollectionNew> tokenRecHitsOT_;
   const edm::EDGetTokenT<edm::SimTrackContainer> simTracksToken_;
-  std::vector<edm::EDGetTokenT<edm::PSimHitContainer> > simHitTokens_;
+  std::vector<edm::EDGetTokenT<edm::PSimHitContainer>> simHitTokens_;
 
   const edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> geomToken_;
   const edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> topoToken_;
@@ -102,7 +103,7 @@ private:
     MonitorElement* deltaX_eta_P = nullptr;
     MonitorElement* deltaX_eta_S = nullptr;
     MonitorElement* deltaY_eta_P = nullptr;
-    MonitorElement* deltaY_eta_S = nullptr;    
+    MonitorElement* deltaY_eta_S = nullptr;
     MonitorElement* pullX_eta_P = nullptr;
     MonitorElement* pullX_eta_S = nullptr;
     MonitorElement* pullY_eta_P = nullptr;
@@ -116,26 +117,25 @@ private:
     MonitorElement* deltaX_primary_S;
     MonitorElement* deltaY_primary_P;
     MonitorElement* deltaY_primary_S;
-    MonitorElement*  numberRecHitsprimary_P;
-    MonitorElement*  numberRecHitsprimary_S;
+    MonitorElement* numberRecHitsprimary_P;
+    MonitorElement* numberRecHitsprimary_S;
   };
-  std::map<std::string, RecHitME>  layerMEs_;
+  std::map<std::string, RecHitME> layerMEs_;
 };
 
 //
 // constructors
 //
-Phase2OTValidateRecHit::Phase2OTValidateRecHit(const edm::ParameterSet& iConfig):
-  config_(iConfig),
-  trackerHitAssociatorConfig_(iConfig, consumesCollector()),
-  simtrackminpt_(iConfig.getParameter<double>("SimTrackMinPt")),
-  tokenRecHitsOT_(consumes<Phase2TrackerRecHit1DCollectionNew>(config_.getParameter<edm::InputTag>("rechitsSrc"))),
-  simTracksToken_(consumes<edm::SimTrackContainer>(iConfig.getParameter<edm::InputTag>("simTracksSrc"))),
-  geomToken_(esConsumes<TrackerGeometry, TrackerDigiGeometryRecord, edm::Transition::BeginRun>()),
-  topoToken_(esConsumes<TrackerTopology, TrackerTopologyRcd, edm::Transition::BeginRun>())
-{      
+Phase2OTValidateRecHit::Phase2OTValidateRecHit(const edm::ParameterSet& iConfig)
+    : config_(iConfig),
+      trackerHitAssociatorConfig_(iConfig, consumesCollector()),
+      simtrackminpt_(iConfig.getParameter<double>("SimTrackMinPt")),
+      tokenRecHitsOT_(consumes<Phase2TrackerRecHit1DCollectionNew>(config_.getParameter<edm::InputTag>("rechitsSrc"))),
+      simTracksToken_(consumes<edm::SimTrackContainer>(iConfig.getParameter<edm::InputTag>("simTracksSrc"))),
+      geomToken_(esConsumes<TrackerGeometry, TrackerDigiGeometryRecord, edm::Transition::BeginRun>()),
+      topoToken_(esConsumes<TrackerTopology, TrackerTopologyRcd, edm::Transition::BeginRun>()) {
   edm::LogInfo("Phase2OTValidateRecHit") << ">>> Construct Phase2OTValidateRecHit ";
-  for (const auto& itag :  config_.getParameter<std::vector<edm::InputTag> >("PSimHitSource"))
+  for (const auto& itag : config_.getParameter<std::vector<edm::InputTag>>("PSimHitSource"))
     simHitTokens_.push_back(consumes<edm::PSimHitContainer>(itag));
 }
 
@@ -156,12 +156,10 @@ void Phase2OTValidateRecHit::dqmBeginRun(const edm::Run& iRun, const edm::EventS
   tTopo_ = tTopoHandle.product();
 }
 
-
 //
 // -- Analyze
 //
 void Phase2OTValidateRecHit::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
-
   std::vector<edm::Handle<edm::PSimHitContainer>> simHits;
   for (const auto& itoken : simHitTokens_) {
     edm::Handle<edm::PSimHitContainer> simHitHandle;
@@ -185,19 +183,20 @@ void Phase2OTValidateRecHit::analyze(const edm::Event& iEvent, const edm::EventS
   fillOTHistos(iEvent, associateRecHit, simHits, selectedSimTrackMap);
 }
 
-void Phase2OTValidateRecHit::fillOTHistos(const edm::Event& iEvent, 
-					  const TrackerHitAssociator& associateRecHit,
-					  const std::vector<edm::Handle<edm::PSimHitContainer>>& simHits,
-					  const std::map<unsigned int, SimTrack>& selectedSimTrackMap) {
+void Phase2OTValidateRecHit::fillOTHistos(const edm::Event& iEvent,
+                                          const TrackerHitAssociator& associateRecHit,
+                                          const std::vector<edm::Handle<edm::PSimHitContainer>>& simHits,
+                                          const std::map<unsigned int, SimTrack>& selectedSimTrackMap) {
   // Get the RecHits
   edm::Handle<Phase2TrackerRecHit1DCollectionNew> rechits;
   iEvent.getByToken(tokenRecHitsOT_, rechits);
-  if(!rechits.isValid())  return;
-  std::map<std::string, unsigned int>  nrechitLayerMapP_primary;
-  std::map<std::string, unsigned int>  nrechitLayerMapS_primary;
+  if (!rechits.isValid())
+    return;
+  std::map<std::string, unsigned int> nrechitLayerMapP_primary;
+  std::map<std::string, unsigned int> nrechitLayerMapS_primary;
   unsigned long int nTotrechitsinevt = 0;
   // Loop over modules
-  Phase2TrackerRecHit1DCollectionNew::const_iterator DSViter; 
+  Phase2TrackerRecHit1DCollectionNew::const_iterator DSViter;
   for (DSViter = rechits->begin(); DSViter != rechits->end(); ++DSViter) {
     // Get the detector unit's id
     unsigned int rawid(DSViter->detId());
@@ -211,103 +210,107 @@ void Phase2OTValidateRecHit::fillOTHistos(const edm::Event& iEvent,
     std::string key = phase2tkutil::getOTHistoId(detId.rawId(), tTopo_);
     nTotrechitsinevt += DSViter->size();
     if (mType == TrackerGeometry::ModuleType::Ph2PSP) {
-      if(nrechitLayerMapP_primary.find(key) == nrechitLayerMapP_primary.end()) {
-	nrechitLayerMapP_primary.insert(std::make_pair(key, DSViter->size())); 
+      if (nrechitLayerMapP_primary.find(key) == nrechitLayerMapP_primary.end()) {
+        nrechitLayerMapP_primary.insert(std::make_pair(key, DSViter->size()));
       } else {
-	nrechitLayerMapP_primary[key] += DSViter->size();
+        nrechitLayerMapP_primary[key] += DSViter->size();
       }
-    } else if (mType == TrackerGeometry::ModuleType::Ph2PSS || mType == TrackerGeometry::ModuleType::Ph2SS){
-      if(nrechitLayerMapS_primary.find(key) == nrechitLayerMapS_primary.end()) {
-	nrechitLayerMapS_primary.insert(std::make_pair(key, DSViter->size()));
-      }
-      else {
-	nrechitLayerMapS_primary[key] += DSViter->size();
+    } else if (mType == TrackerGeometry::ModuleType::Ph2PSS || mType == TrackerGeometry::ModuleType::Ph2SS) {
+      if (nrechitLayerMapS_primary.find(key) == nrechitLayerMapS_primary.end()) {
+        nrechitLayerMapS_primary.insert(std::make_pair(key, DSViter->size()));
+      } else {
+        nrechitLayerMapS_primary[key] += DSViter->size();
       }
     }
     edmNew::DetSet<Phase2TrackerRecHit1D>::const_iterator rechitIt;
     //loop over rechits for a single detId
-    for(rechitIt = DSViter->begin(); rechitIt != DSViter->end(); ++rechitIt) {
+    for (rechitIt = DSViter->begin(); rechitIt != DSViter->end(); ++rechitIt) {
       LocalPoint lp = rechitIt->localPosition();
       //GetSimHits
       const std::vector<SimHitIdpr>& matchedId = associateRecHit.associateHitId(*rechitIt);
       //std::cout << "Nmatched SimHits = "  << matchedId.size() << ",";
-      const PSimHit* simhitClosest = 0;
+      const PSimHit* simhitClosest = nullptr;
       float mind = 1e4;
       for (unsigned int si = 0; si < simHits.size(); ++si) {
-	for(edm::PSimHitContainer::const_iterator simhitIt = simHits.at(si)->begin();
-	    simhitIt != simHits.at(si)->end(); ++simhitIt) {
-	  if(detId.rawId() != simhitIt->detUnitId())   continue;
-	  for(auto& mId : matchedId) {
-	    if(simhitIt->trackId() == mId.first) {
+        for (edm::PSimHitContainer::const_iterator simhitIt = simHits.at(si)->begin();
+             simhitIt != simHits.at(si)->end();
+             ++simhitIt) {
+          if (detId.rawId() != simhitIt->detUnitId())
+            continue;
+          for (auto& mId : matchedId) {
+            if (simhitIt->trackId() == mId.first) {
               float dx = simhitIt->localPosition().x() - lp.x();
               float dy = simhitIt->localPosition().y() - lp.y();
-	      float dist = std::sqrt(dx * dx + dy * dy);
-	      if (!simhitClosest || dist < mind) {
-		mind = dist;
-		simhitClosest = &*simhitIt;
-	      }
-	    }
-	  }
-	}//end loop over PSimhitcontainers
-      }//end loop over simHits
-      if(!simhitClosest)   continue;
+              float dist = std::sqrt(dx * dx + dy * dy);
+              if (!simhitClosest || dist < mind) {
+                mind = dist;
+                simhitClosest = &*simhitIt;
+              }
+            }
+          }
+        }  //end loop over PSimhitcontainers
+      }    //end loop over simHits
+      if (!simhitClosest)
+        continue;
       auto simTrackIt(selectedSimTrackMap.find(simhitClosest->trackId()));
       bool isPrimary = false;
       //check if simhit is primary
-      if(simTrackIt != selectedSimTrackMap.end()) isPrimary = phase2tkutil::isPrimary(simTrackIt->second, simhitClosest);
+      if (simTrackIt != selectedSimTrackMap.end())
+        isPrimary = phase2tkutil::isPrimary(simTrackIt->second, simhitClosest);
       Local3DPoint simlp(simhitClosest->localPosition());
       const LocalError& lperr = rechitIt->localPositionError();
       double dx = lp.x() - simlp.x();
       double dy = lp.y() - simlp.y();
       double pullx = 999.;
       double pully = 999.;
-      if (lperr.xx()) 
-	pullx = (lp.x() - simlp.x()) / std::sqrt(lperr.xx());
-      if (lperr.yy()) 
-	pully = (lp.y() - simlp.y()) / std::sqrt(lperr.yy());
-      float eta = geomDetunit->surface().toGlobal(lp).eta();;
+      if (lperr.xx())
+        pullx = (lp.x() - simlp.x()) / std::sqrt(lperr.xx());
+      if (lperr.yy())
+        pully = (lp.y() - simlp.y()) / std::sqrt(lperr.yy());
+      float eta = geomDetunit->surface().toGlobal(lp).eta();
+      ;
       if (mType == TrackerGeometry::ModuleType::Ph2PSP) {
-	layerMEs_[key].deltaX_P->Fill(phase2tkutil::cmtomicron * dx);
-	layerMEs_[key].deltaY_P->Fill(phase2tkutil::cmtomicron * dy);
-	layerMEs_[key].pullX_P->Fill(pullx);
-	layerMEs_[key].pullY_P->Fill(pully);
-	layerMEs_[key].deltaX_eta_P->Fill(eta, phase2tkutil::cmtomicron * dx);
-	layerMEs_[key].deltaY_eta_P->Fill(eta,phase2tkutil::cmtomicron * dy);
-	layerMEs_[key].pullX_eta_P->Fill(eta,pullx);
-	layerMEs_[key].pullY_eta_P->Fill(eta,pully);
-	if(isPrimary) {
-	  layerMEs_[key].deltaX_primary_P->Fill(phase2tkutil::cmtomicron * dx);
-	  layerMEs_[key].deltaY_primary_P->Fill(phase2tkutil::cmtomicron * dy);
-	  layerMEs_[key].pullX_primary_P->Fill(pullx);
-	  layerMEs_[key].pullY_primary_P->Fill(pully);
-	} else 
-	  nrechitLayerMapP_primary[key]--;
+        layerMEs_[key].deltaX_P->Fill(phase2tkutil::cmtomicron * dx);
+        layerMEs_[key].deltaY_P->Fill(phase2tkutil::cmtomicron * dy);
+        layerMEs_[key].pullX_P->Fill(pullx);
+        layerMEs_[key].pullY_P->Fill(pully);
+        layerMEs_[key].deltaX_eta_P->Fill(eta, phase2tkutil::cmtomicron * dx);
+        layerMEs_[key].deltaY_eta_P->Fill(eta, phase2tkutil::cmtomicron * dy);
+        layerMEs_[key].pullX_eta_P->Fill(eta, pullx);
+        layerMEs_[key].pullY_eta_P->Fill(eta, pully);
+        if (isPrimary) {
+          layerMEs_[key].deltaX_primary_P->Fill(phase2tkutil::cmtomicron * dx);
+          layerMEs_[key].deltaY_primary_P->Fill(phase2tkutil::cmtomicron * dy);
+          layerMEs_[key].pullX_primary_P->Fill(pullx);
+          layerMEs_[key].pullY_primary_P->Fill(pully);
+        } else
+          nrechitLayerMapP_primary[key]--;
       } else if (mType == TrackerGeometry::ModuleType::Ph2PSS || mType == TrackerGeometry::ModuleType::Ph2SS) {
-	layerMEs_[key].deltaX_S->Fill(phase2tkutil::cmtomicron * dx);
-	layerMEs_[key].deltaY_S->Fill(dy);
-	layerMEs_[key].pullX_S->Fill(pullx);
-	layerMEs_[key].pullY_S->Fill(pully);
-	layerMEs_[key].deltaX_eta_S->Fill(eta,phase2tkutil::cmtomicron * dx);
-	layerMEs_[key].deltaY_eta_S->Fill(eta,dy);
-	layerMEs_[key].pullX_eta_S->Fill(eta,pullx);
-	layerMEs_[key].pullY_eta_S->Fill(eta,pully);
-	if(isPrimary) {
-	  layerMEs_[key].deltaX_primary_S->Fill(phase2tkutil::cmtomicron * dx);
-	  layerMEs_[key].deltaY_primary_S->Fill(dy);
-	  layerMEs_[key].pullX_primary_S->Fill(pullx);
-	  layerMEs_[key].pullY_primary_S->Fill(pully);
-	}else 
-	  nrechitLayerMapS_primary[key]--;
+        layerMEs_[key].deltaX_S->Fill(phase2tkutil::cmtomicron * dx);
+        layerMEs_[key].deltaY_S->Fill(dy);
+        layerMEs_[key].pullX_S->Fill(pullx);
+        layerMEs_[key].pullY_S->Fill(pully);
+        layerMEs_[key].deltaX_eta_S->Fill(eta, phase2tkutil::cmtomicron * dx);
+        layerMEs_[key].deltaY_eta_S->Fill(eta, dy);
+        layerMEs_[key].pullX_eta_S->Fill(eta, pullx);
+        layerMEs_[key].pullY_eta_S->Fill(eta, pully);
+        if (isPrimary) {
+          layerMEs_[key].deltaX_primary_S->Fill(phase2tkutil::cmtomicron * dx);
+          layerMEs_[key].deltaY_primary_S->Fill(dy);
+          layerMEs_[key].pullX_primary_S->Fill(pullx);
+          layerMEs_[key].pullY_primary_S->Fill(pully);
+        } else
+          nrechitLayerMapS_primary[key]--;
       }
-    }//end loop over rechits of a detId
-  } //End loop over DetSetVector
- 
+    }  //end loop over rechits of a detId
+  }    //End loop over DetSetVector
+
   //fill nRecHits per event
   //fill nRecHit counter per layer
-  for(auto& lme : nrechitLayerMapP_primary) {
+  for (auto& lme : nrechitLayerMapP_primary) {
     layerMEs_[lme.first].numberRecHitsprimary_P->Fill(nrechitLayerMapP_primary[lme.first]);
   }
-  for(auto& lme : nrechitLayerMapS_primary) {
+  for (auto& lme : nrechitLayerMapS_primary) {
     layerMEs_[lme.first].numberRecHitsprimary_S->Fill(nrechitLayerMapS_primary[lme.first]);
   }
 }
@@ -315,18 +318,17 @@ void Phase2OTValidateRecHit::fillOTHistos(const edm::Event& iEvent,
 // -- Book Histograms
 //
 void Phase2OTValidateRecHit::bookHistograms(DQMStore::IBooker& ibooker,
-					    edm::Run const& iRun,
-					    edm::EventSetup const& iSetup) {
-  
+                                            edm::Run const& iRun,
+                                            edm::EventSetup const& iSetup) {
   std::string top_folder = config_.getParameter<std::string>("TopFolderName");
   //Now book layer wise histos
   edm::ESWatcher<TrackerDigiGeometryRecord> theTkDigiGeomWatcher;
   if (theTkDigiGeomWatcher.check(iSetup)) {
     for (auto const& det_u : tkGeom_->detUnits()) {
       //Always check TrackerNumberingBuilder before changing this part
-      if(det_u->subDetector() == GeomDetEnumerators::SubDetector::P2PXB
-	 || det_u->subDetector() == GeomDetEnumerators::SubDetector::P2PXEC)
-	continue;
+      if (det_u->subDetector() == GeomDetEnumerators::SubDetector::P2PXB ||
+          det_u->subDetector() == GeomDetEnumerators::SubDetector::P2PXEC)
+        continue;
       unsigned int detId_raw = det_u->geographicalId().rawId();
       bookLayerHistos(ibooker, detId_raw, top_folder);
     }
@@ -336,67 +338,87 @@ void Phase2OTValidateRecHit::bookHistograms(DQMStore::IBooker& ibooker,
 //
 // -- Book Layer Histograms
 //
-void Phase2OTValidateRecHit::bookLayerHistos(DQMStore::IBooker& ibooker,
-					     unsigned int det_id,
-					     std::string& subdir) {
-  
+void Phase2OTValidateRecHit::bookLayerHistos(DQMStore::IBooker& ibooker, unsigned int det_id, std::string& subdir) {
   std::string key = phase2tkutil::getOTHistoId(det_id, tTopo_);
   if (layerMEs_.find(key) == layerMEs_.end()) {
-    
     ibooker.cd();
     RecHitME local_histos;
-    ibooker.setCurrentFolder(subdir+"/"+key);
+    ibooker.setCurrentFolder(subdir + "/" + key);
     edm::LogInfo("Phase2OTValidateRecHit") << " Booking Histograms in : " << key;
 
-    if(tkGeom_->getDetectorType(det_id) == TrackerGeometry::ModuleType::Ph2PSP) {
+    if (tkGeom_->getDetectorType(det_id) == TrackerGeometry::ModuleType::Ph2PSP) {
+      local_histos.deltaX_P =
+          phase2tkutil::book1DFromPSet(config_.getParameter<edm::ParameterSet>("Delta_X_Pixel"), ibooker);
+      local_histos.deltaY_P =
+          phase2tkutil::book1DFromPSet(config_.getParameter<edm::ParameterSet>("Delta_Y_Pixel"), ibooker);
 
-      local_histos.deltaX_P = phase2tkutil::book1DFromPSet(config_.getParameter<edm::ParameterSet>("Delta_X_Pixel"), ibooker);
-      local_histos.deltaY_P = phase2tkutil::book1DFromPSet(config_.getParameter<edm::ParameterSet>("Delta_Y_Pixel"), ibooker);
+      local_histos.pullX_P =
+          phase2tkutil::book1DFromPSet(config_.getParameter<edm::ParameterSet>("Pull_X_Pixel"), ibooker);
+      local_histos.pullY_P =
+          phase2tkutil::book1DFromPSet(config_.getParameter<edm::ParameterSet>("Pull_X_Pixel"), ibooker);
 
-      local_histos.pullX_P = phase2tkutil::book1DFromPSet(config_.getParameter<edm::ParameterSet>("Pull_X_Pixel"), ibooker);
-      local_histos.pullY_P = phase2tkutil::book1DFromPSet(config_.getParameter<edm::ParameterSet>("Pull_X_Pixel"), ibooker);
+      local_histos.deltaX_eta_P =
+          phase2tkutil::bookProfile1DFromPSet(config_.getParameter<edm::ParameterSet>("Delta_X_vs_eta_Pixel"), ibooker);
+      local_histos.deltaY_eta_P =
+          phase2tkutil::bookProfile1DFromPSet(config_.getParameter<edm::ParameterSet>("Delta_Y_vs_eta_Pixel"), ibooker);
 
-      
-      local_histos.deltaX_eta_P = phase2tkutil::bookProfile1DFromPSet(config_.getParameter<edm::ParameterSet>("Delta_X_vs_eta_Pixel"), ibooker);
-      local_histos.deltaY_eta_P = phase2tkutil::bookProfile1DFromPSet(config_.getParameter<edm::ParameterSet>("Delta_Y_vs_eta_Pixel"), ibooker);
+      local_histos.pullX_eta_P =
+          phase2tkutil::bookProfile1DFromPSet(config_.getParameter<edm::ParameterSet>("Pull_X_vs_eta_Pixel"), ibooker);
+      local_histos.pullY_eta_P =
+          phase2tkutil::bookProfile1DFromPSet(config_.getParameter<edm::ParameterSet>("Pull_X_vs_eta_Pixel"), ibooker);
 
-      local_histos.pullX_eta_P = phase2tkutil::bookProfile1DFromPSet(config_.getParameter<edm::ParameterSet>("Pull_X_vs_eta_Pixel"), ibooker);
-      local_histos.pullY_eta_P = phase2tkutil::bookProfile1DFromPSet(config_.getParameter<edm::ParameterSet>("Pull_X_vs_eta_Pixel"), ibooker);
-
-      ibooker.setCurrentFolder(subdir+"/"+key+"/PrimarySimHits");
+      ibooker.setCurrentFolder(subdir + "/" + key + "/PrimarySimHits");
       //all histos for Primary particles
-      local_histos.numberRecHitsprimary_P = phase2tkutil::book1DFromPSet(config_.getParameter<edm::ParameterSet>("nRecHits_Pixel_primary"), ibooker);
-      
-      local_histos.deltaX_primary_P = phase2tkutil::book1DFromPSet(config_.getParameter<edm::ParameterSet>("Delta_X_Pixel_Primary"), ibooker);
-      local_histos.deltaY_primary_P = phase2tkutil::book1DFromPSet(config_.getParameter<edm::ParameterSet>("Delta_X_Pixel_Primary"), ibooker);
+      local_histos.numberRecHitsprimary_P =
+          phase2tkutil::book1DFromPSet(config_.getParameter<edm::ParameterSet>("nRecHits_Pixel_primary"), ibooker);
 
-      local_histos.pullX_primary_P = phase2tkutil::book1DFromPSet(config_.getParameter<edm::ParameterSet>("Pull_X_Pixel_Primary"), ibooker);
-      local_histos.pullY_primary_P = phase2tkutil::book1DFromPSet(config_.getParameter<edm::ParameterSet>("Pull_X_Pixel_Primary"), ibooker);
-    }//if block for P
-    
-    ibooker.setCurrentFolder(subdir+"/"+key);
-    local_histos.deltaX_S = phase2tkutil::book1DFromPSet(config_.getParameter<edm::ParameterSet>("Delta_X_Strip"), ibooker);
-    local_histos.deltaY_S = phase2tkutil::book1DFromPSet(config_.getParameter<edm::ParameterSet>("Delta_Y_Strip"), ibooker);
-    
-    local_histos.pullX_S = phase2tkutil::book1DFromPSet(config_.getParameter<edm::ParameterSet>("Pull_X_Strip"), ibooker);
-    local_histos.pullY_S = phase2tkutil::book1DFromPSet(config_.getParameter<edm::ParameterSet>("Pull_Y_Strip"), ibooker);
-    
-    local_histos.deltaX_eta_S = phase2tkutil::bookProfile1DFromPSet(config_.getParameter<edm::ParameterSet>("Delta_X_vs_eta_Strip"), ibooker);
-    local_histos.deltaY_eta_S = phase2tkutil::bookProfile1DFromPSet(config_.getParameter<edm::ParameterSet>("Delta_Y_vs_eta_Strip"), ibooker);
-    
-    local_histos.pullX_eta_S = phase2tkutil::bookProfile1DFromPSet(config_.getParameter<edm::ParameterSet>("Pull_X_vs_eta_Strip"), ibooker);
-    local_histos.pullY_eta_S = phase2tkutil::bookProfile1DFromPSet(config_.getParameter<edm::ParameterSet>("Pull_X_vs_eta_Pixel"), ibooker);      
+      local_histos.deltaX_primary_P =
+          phase2tkutil::book1DFromPSet(config_.getParameter<edm::ParameterSet>("Delta_X_Pixel_Primary"), ibooker);
+      local_histos.deltaY_primary_P =
+          phase2tkutil::book1DFromPSet(config_.getParameter<edm::ParameterSet>("Delta_X_Pixel_Primary"), ibooker);
+
+      local_histos.pullX_primary_P =
+          phase2tkutil::book1DFromPSet(config_.getParameter<edm::ParameterSet>("Pull_X_Pixel_Primary"), ibooker);
+      local_histos.pullY_primary_P =
+          phase2tkutil::book1DFromPSet(config_.getParameter<edm::ParameterSet>("Pull_X_Pixel_Primary"), ibooker);
+    }  //if block for P
+
+    ibooker.setCurrentFolder(subdir + "/" + key);
+    local_histos.deltaX_S =
+        phase2tkutil::book1DFromPSet(config_.getParameter<edm::ParameterSet>("Delta_X_Strip"), ibooker);
+    local_histos.deltaY_S =
+        phase2tkutil::book1DFromPSet(config_.getParameter<edm::ParameterSet>("Delta_Y_Strip"), ibooker);
+
+    local_histos.pullX_S =
+        phase2tkutil::book1DFromPSet(config_.getParameter<edm::ParameterSet>("Pull_X_Strip"), ibooker);
+    local_histos.pullY_S =
+        phase2tkutil::book1DFromPSet(config_.getParameter<edm::ParameterSet>("Pull_Y_Strip"), ibooker);
+
+    local_histos.deltaX_eta_S =
+        phase2tkutil::bookProfile1DFromPSet(config_.getParameter<edm::ParameterSet>("Delta_X_vs_eta_Strip"), ibooker);
+    local_histos.deltaY_eta_S =
+        phase2tkutil::bookProfile1DFromPSet(config_.getParameter<edm::ParameterSet>("Delta_Y_vs_eta_Strip"), ibooker);
+
+    local_histos.pullX_eta_S =
+        phase2tkutil::bookProfile1DFromPSet(config_.getParameter<edm::ParameterSet>("Pull_X_vs_eta_Strip"), ibooker);
+    local_histos.pullY_eta_S =
+        phase2tkutil::bookProfile1DFromPSet(config_.getParameter<edm::ParameterSet>("Pull_X_vs_eta_Pixel"), ibooker);
 
     //primary
-    ibooker.setCurrentFolder(subdir+"/"+key+"/PrimarySimHits");
-    local_histos.numberRecHitsprimary_S = phase2tkutil::book1DFromPSet(config_.getParameter<edm::ParameterSet>("nRecHits_Strip_primary"), ibooker);
+    ibooker.setCurrentFolder(subdir + "/" + key + "/PrimarySimHits");
+    local_histos.numberRecHitsprimary_S =
+        phase2tkutil::book1DFromPSet(config_.getParameter<edm::ParameterSet>("nRecHits_Strip_primary"), ibooker);
 
-    local_histos.deltaX_primary_S = phase2tkutil::book1DFromPSet(config_.getParameter<edm::ParameterSet>("Delta_X_Strip_Primary"), ibooker);
-    local_histos.deltaY_primary_S = phase2tkutil::book1DFromPSet(config_.getParameter<edm::ParameterSet>("Delta_Y_Strip_Primary"), ibooker);
-    
-    local_histos.pullX_primary_S = phase2tkutil::book1DFromPSet(config_.getParameter<edm::ParameterSet>("Pull_X_Strip_Primary"), ibooker);
-    local_histos.pullY_primary_S = phase2tkutil::book1DFromPSet(config_.getParameter<edm::ParameterSet>("Pull_X_Strip_Primary"), ibooker);
-    
+    local_histos.deltaX_primary_S =
+        phase2tkutil::book1DFromPSet(config_.getParameter<edm::ParameterSet>("Delta_X_Strip_Primary"), ibooker);
+    local_histos.deltaY_primary_S =
+        phase2tkutil::book1DFromPSet(config_.getParameter<edm::ParameterSet>("Delta_Y_Strip_Primary"), ibooker);
+
+    local_histos.pullX_primary_S =
+        phase2tkutil::book1DFromPSet(config_.getParameter<edm::ParameterSet>("Pull_X_Strip_Primary"), ibooker);
+    local_histos.pullY_primary_S =
+        phase2tkutil::book1DFromPSet(config_.getParameter<edm::ParameterSet>("Pull_X_Strip_Primary"), ibooker);
+
     layerMEs_.insert(std::make_pair(key, local_histos));
   }
 }
@@ -446,7 +468,7 @@ void Phase2OTValidateRecHit::fillDescriptions(edm::ConfigurationDescriptions& de
     psd0.add<double>("xmax", 500);
     psd0.add<int>("NxBins", 100);
     desc.add<edm::ParameterSetDescription>("Delta_Y_Pixel_Primary", psd0);
-  } 
+  }
 
   {
     edm::ParameterSetDescription psd0;
@@ -550,7 +572,7 @@ void Phase2OTValidateRecHit::fillDescriptions(edm::ConfigurationDescriptions& de
     desc.add<edm::ParameterSetDescription>("nRecHits_Pixel_primary", psd0);
   }
 
- //strip sensors
+  //strip sensors
   {
     edm::ParameterSetDescription psd0;
     psd0.add<std::string>("name", "Delta_X_Strip");
@@ -698,50 +720,47 @@ void Phase2OTValidateRecHit::fillDescriptions(edm::ConfigurationDescriptions& de
   desc.add<bool>("associateHitbySimTrack", true);
   desc.add<bool>("Verbosity", false);
   desc.add<bool>("associateStrip", true);
-  desc.add<edm::InputTag>("phase2TrackerSimLinkSrc", edm::InputTag("simSiPixelDigis","Tracker"));
+  desc.add<edm::InputTag>("phase2TrackerSimLinkSrc", edm::InputTag("simSiPixelDigis", "Tracker"));
   desc.add<bool>("associateRecoTracks", false);
-  desc.add<edm::InputTag>("pixelSimLinkSrc", edm::InputTag("simSiPixelDigis","Pixel"));
+  desc.add<edm::InputTag>("pixelSimLinkSrc", edm::InputTag("simSiPixelDigis", "Pixel"));
   desc.add<bool>("usePhase2Tracker", true);
-  desc.add<edm::InputTag>("OuterTrackerDigiSimLinkSource", edm::InputTag("simSiPixelDigis","Tracker"));
-  desc.add<edm::InputTag>("OuterTrackerDigiSource", edm::InputTag("mix","Tracker"));
+  desc.add<edm::InputTag>("OuterTrackerDigiSimLinkSource", edm::InputTag("simSiPixelDigis", "Tracker"));
+  desc.add<edm::InputTag>("OuterTrackerDigiSource", edm::InputTag("mix", "Tracker"));
   desc.add<edm::InputTag>("rechitsSrc", edm::InputTag("siPhase2RecHits"));
   desc.add<edm::InputTag>("simTracksSrc", edm::InputTag("g4SimHits"));
   desc.add<double>("SimTrackMinPt", 2.0);
   desc.add<std::vector<edm::InputTag>>("PSimHitSource",
-    {
-        edm::InputTag("g4SimHits:TrackerHitsTIBLowTof"),
-	edm::InputTag("g4SimHits:TrackerHitsTIBHighTof"),
-	edm::InputTag("g4SimHits:TrackerHitsTIDLowTof"),
-	edm::InputTag("g4SimHits:TrackerHitsTIDHighTof"),
-	edm::InputTag("g4SimHits:TrackerHitsTOBLowTof"),
-	edm::InputTag("g4SimHits:TrackerHitsTOBHighTof"),
-	edm::InputTag("g4SimHits:TrackerHitsTECLowTof"),
-	edm::InputTag("g4SimHits:TrackerHitsTECHighTof"),
-	edm::InputTag("g4SimHits:TrackerHitsPixelBarrelLowTof"),
-	edm::InputTag("g4SimHits:TrackerHitsPixelBarrelHighTof"),
-	edm::InputTag("g4SimHits:TrackerHitsPixelEndcapLowTof"),
-	edm::InputTag("g4SimHits:TrackerHitsPixelEndcapHighTof"),
-    });
-  
-  desc.add<std::vector<std::string>>("ROUList", 
-    {
-        "TrackerHitsPixelBarrelLowTof",
-	"TrackerHitsPixelBarrelHighTof",
-	"TrackerHitsTIBLowTof",
-	"TrackerHitsTIBHighTof",
-	"TrackerHitsTIDLowTof",
-	"TrackerHitsTIDHighTof",
-	"TrackerHitsTOBLowTof",
-	"TrackerHitsTOBHighTof",
-	"TrackerHitsPixelEndcapLowTof",
-	"TrackerHitsPixelEndcapHighTof",
-	"TrackerHitsTECLowTof",
-	"TrackerHitsTECHighTof"
-    });
+                                       {
+                                           edm::InputTag("g4SimHits:TrackerHitsTIBLowTof"),
+                                           edm::InputTag("g4SimHits:TrackerHitsTIBHighTof"),
+                                           edm::InputTag("g4SimHits:TrackerHitsTIDLowTof"),
+                                           edm::InputTag("g4SimHits:TrackerHitsTIDHighTof"),
+                                           edm::InputTag("g4SimHits:TrackerHitsTOBLowTof"),
+                                           edm::InputTag("g4SimHits:TrackerHitsTOBHighTof"),
+                                           edm::InputTag("g4SimHits:TrackerHitsTECLowTof"),
+                                           edm::InputTag("g4SimHits:TrackerHitsTECHighTof"),
+                                           edm::InputTag("g4SimHits:TrackerHitsPixelBarrelLowTof"),
+                                           edm::InputTag("g4SimHits:TrackerHitsPixelBarrelHighTof"),
+                                           edm::InputTag("g4SimHits:TrackerHitsPixelEndcapLowTof"),
+                                           edm::InputTag("g4SimHits:TrackerHitsPixelEndcapHighTof"),
+                                       });
+
+  desc.add<std::vector<std::string>>("ROUList",
+                                     {"TrackerHitsPixelBarrelLowTof",
+                                      "TrackerHitsPixelBarrelHighTof",
+                                      "TrackerHitsTIBLowTof",
+                                      "TrackerHitsTIBHighTof",
+                                      "TrackerHitsTIDLowTof",
+                                      "TrackerHitsTIDHighTof",
+                                      "TrackerHitsTOBLowTof",
+                                      "TrackerHitsTOBHighTof",
+                                      "TrackerHitsPixelEndcapLowTof",
+                                      "TrackerHitsPixelEndcapHighTof",
+                                      "TrackerHitsTECLowTof",
+                                      "TrackerHitsTECHighTof"});
 
   descriptions.add("Phase2OTValidateRecHit", desc);
-} 
- 
+}
+
 //define this as a plug-in
 DEFINE_FWK_MODULE(Phase2OTValidateRecHit);
- 

--- a/Validation/SiTrackerPhase2V/plugins/Phase2OTValidateRecHit.cc
+++ b/Validation/SiTrackerPhase2V/plugins/Phase2OTValidateRecHit.cc
@@ -1,0 +1,747 @@
+// Package:    Phase2OTValidateRecHit
+// Class:      Phase2OTValidateRecHit
+//
+/**\class Phase2OTValidateRecHit Phase2OTValidateRecHit.cc 
+ Description:  Standalone  Plugin for Phase2 RecHit validation
+*/
+//
+// Author: Suvankar Roy Chowdhury
+// Date: March 2021
+//
+// system include files
+#include <memory>
+#include <map>
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/ESWatcher.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+
+#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
+#include "Geometry/CommonDetUnit/interface/TrackerGeomDet.h"
+#include "Geometry/CommonDetUnit/interface/PixelGeomDetUnit.h"
+#include "Geometry/CommonDetUnit/interface/PixelGeomDetType.h"
+#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
+#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
+#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
+
+#include "DataFormats/Common/interface/Handle.h"
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+#include "DataFormats/SiPixelDetId/interface/PixelSubdetector.h"
+#include "DataFormats/DetId/interface/DetId.h"
+#include "DataFormats/Common/interface/DetSetVector.h"
+#include "DataFormats/Common/interface/DetSetVectorNew.h"
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+#include "DataFormats/TrackerRecHit2D/interface/Phase2TrackerRecHit1D.h"
+#include "DataFormats/TrackerRecHit2D/interface/SiPixelRecHitCollection.h"
+#include "DataFormats/GeometrySurface/interface/LocalError.h"
+#include "DataFormats/GeometryVector/interface/LocalPoint.h"
+
+#include "SimDataFormats/TrackingHit/interface/PSimHitContainer.h"
+#include "SimDataFormats/TrackingHit/interface/PSimHit.h"
+#include "SimDataFormats/TrackerDigiSimLink/interface/PixelDigiSimLink.h"
+#include "SimTracker/SiPhase2Digitizer/plugins/Phase2TrackerDigitizerFwd.h"
+#include "SimDataFormats/Track/interface/SimTrackContainer.h"
+#include "SimTracker/TrackerHitAssociation/interface/TrackerHitAssociator.h"
+
+// DQM Histograming
+#include "DQMServices/Core/interface/MonitorElement.h"
+#include "DQMServices/Core/interface/DQMEDAnalyzer.h"
+#include "DQMServices/Core/interface/DQMStore.h"
+
+#include "Validation/SiTrackerPhase2V/interface/TrackerPhase2ValidationUtil.h"
+#include "DQM/SiTrackerPhase2/interface/TrackerPhase2DQMUtil.h"
+
+class Phase2OTValidateRecHit : public DQMEDAnalyzer {
+public:
+  explicit Phase2OTValidateRecHit(const edm::ParameterSet&);
+  ~Phase2OTValidateRecHit() override;
+  void bookHistograms(DQMStore::IBooker& ibooker, edm::Run const& iRun, edm::EventSetup const& iSetup) override;
+  void analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) override;
+  void dqmBeginRun(const edm::Run& iRun, const edm::EventSetup& iSetup) override;
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+private:
+  void fillOTHistos(const edm::Event& iEvent, 
+		    const TrackerHitAssociator& associateRecHit,
+		    const std::vector<edm::Handle<edm::PSimHitContainer>>& simHits,
+		    const std::map<unsigned int, SimTrack>& selectedSimTrackMap);
+
+  void bookLayerHistos(DQMStore::IBooker& ibooker, unsigned int det_id, std::string& subdir);
+
+  edm::ParameterSet config_;
+  bool pixelFlag_;
+  TrackerHitAssociator::Config trackerHitAssociatorConfig_;
+  const double simtrackminpt_;
+  std::string geomType_;
+  const edm::EDGetTokenT<Phase2TrackerRecHit1DCollectionNew> tokenRecHitsOT_;
+  const edm::EDGetTokenT<edm::SimTrackContainer> simTracksToken_;
+  std::vector<edm::EDGetTokenT<edm::PSimHitContainer> > simHitTokens_;
+
+  const edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> geomToken_;
+  const edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> topoToken_;
+  const TrackerGeometry* tkGeom_ = nullptr;
+  const TrackerTopology* tTopo_ = nullptr;
+
+  struct RecHitME {
+    // use TH1D instead of TH1F to avoid stauration at 2^31
+    // above this increments with +1 don't work for float, need double
+    MonitorElement* deltaX_P = nullptr;
+    MonitorElement* deltaX_S = nullptr;
+    MonitorElement* deltaY_P = nullptr;
+    MonitorElement* deltaY_S = nullptr;
+    MonitorElement* pullX_P = nullptr;
+    MonitorElement* pullX_S = nullptr;
+    MonitorElement* pullY_P = nullptr;
+    MonitorElement* pullY_S = nullptr;
+    MonitorElement* deltaX_eta_P = nullptr;
+    MonitorElement* deltaX_eta_S = nullptr;
+    MonitorElement* deltaY_eta_P = nullptr;
+    MonitorElement* deltaY_eta_S = nullptr;    
+    MonitorElement* pullX_eta_P = nullptr;
+    MonitorElement* pullX_eta_S = nullptr;
+    MonitorElement* pullY_eta_P = nullptr;
+    MonitorElement* pullY_eta_S = nullptr;
+    //For rechits matched to simhits from highPT tracks
+    MonitorElement* pullX_primary_P;
+    MonitorElement* pullX_primary_S;
+    MonitorElement* pullY_primary_P;
+    MonitorElement* pullY_primary_S;
+    MonitorElement* deltaX_primary_P;
+    MonitorElement* deltaX_primary_S;
+    MonitorElement* deltaY_primary_P;
+    MonitorElement* deltaY_primary_S;
+    MonitorElement*  numberRecHitsprimary_P;
+    MonitorElement*  numberRecHitsprimary_S;
+  };
+  std::map<std::string, RecHitME>  layerMEs_;
+};
+
+//
+// constructors
+//
+Phase2OTValidateRecHit::Phase2OTValidateRecHit(const edm::ParameterSet& iConfig):
+  config_(iConfig),
+  trackerHitAssociatorConfig_(iConfig, consumesCollector()),
+  simtrackminpt_(iConfig.getParameter<double>("SimTrackMinPt")),
+  tokenRecHitsOT_(consumes<Phase2TrackerRecHit1DCollectionNew>(config_.getParameter<edm::InputTag>("rechitsSrc"))),
+  simTracksToken_(consumes<edm::SimTrackContainer>(iConfig.getParameter<edm::InputTag>("simTracksSrc"))),
+  geomToken_(esConsumes<TrackerGeometry, TrackerDigiGeometryRecord, edm::Transition::BeginRun>()),
+  topoToken_(esConsumes<TrackerTopology, TrackerTopologyRcd, edm::Transition::BeginRun>())
+{      
+  edm::LogInfo("Phase2OTValidateRecHit") << ">>> Construct Phase2OTValidateRecHit ";
+  for (const auto& itag :  config_.getParameter<std::vector<edm::InputTag> >("PSimHitSource"))
+    simHitTokens_.push_back(consumes<edm::PSimHitContainer>(itag));
+}
+
+//
+// destructor
+//
+Phase2OTValidateRecHit::~Phase2OTValidateRecHit() {
+  // do anything here that needs to be done at desctruction time
+  // (e.g. close files, deallocate resources etc.)
+  edm::LogInfo("Phase2OTValidateRecHit") << ">>> Destroy Phase2OTValidateRecHit ";
+}
+//
+// -- DQM Begin Run
+void Phase2OTValidateRecHit::dqmBeginRun(const edm::Run& iRun, const edm::EventSetup& iSetup) {
+  edm::ESHandle<TrackerGeometry> geomHandle = iSetup.getHandle(geomToken_);
+  tkGeom_ = &(*geomHandle);
+  edm::ESHandle<TrackerTopology> tTopoHandle = iSetup.getHandle(topoToken_);
+  tTopo_ = tTopoHandle.product();
+}
+
+
+//
+// -- Analyze
+//
+void Phase2OTValidateRecHit::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
+
+  std::vector<edm::Handle<edm::PSimHitContainer>> simHits;
+  for (const auto& itoken : simHitTokens_) {
+    edm::Handle<edm::PSimHitContainer> simHitHandle;
+    iEvent.getByToken(itoken, simHitHandle);
+    if (!simHitHandle.isValid())
+      continue;
+    simHits.emplace_back(simHitHandle);
+  }
+  // Get the SimTracks and push them in a map of id, SimTrack
+  edm::Handle<edm::SimTrackContainer> simTracks;
+  iEvent.getByToken(simTracksToken_, simTracks);
+
+  std::map<unsigned int, SimTrack> selectedSimTrackMap;
+  for (edm::SimTrackContainer::const_iterator simTrackIt(simTracks->begin()); simTrackIt != simTracks->end();
+       ++simTrackIt) {
+    if (simTrackIt->momentum().pt() > simtrackminpt_) {
+      selectedSimTrackMap.insert(std::make_pair(simTrackIt->trackId(), *simTrackIt));
+    }
+  }
+  TrackerHitAssociator associateRecHit(iEvent, trackerHitAssociatorConfig_);
+  fillOTHistos(iEvent, associateRecHit, simHits, selectedSimTrackMap);
+}
+
+void Phase2OTValidateRecHit::fillOTHistos(const edm::Event& iEvent, 
+					  const TrackerHitAssociator& associateRecHit,
+					  const std::vector<edm::Handle<edm::PSimHitContainer>>& simHits,
+					  const std::map<unsigned int, SimTrack>& selectedSimTrackMap) {
+  // Get the RecHits
+  edm::Handle<Phase2TrackerRecHit1DCollectionNew> rechits;
+  iEvent.getByToken(tokenRecHitsOT_, rechits);
+  if(!rechits.isValid())  return;
+  std::map<std::string, unsigned int>  nrechitLayerMapP_primary;
+  std::map<std::string, unsigned int>  nrechitLayerMapS_primary;
+  unsigned long int nTotrechitsinevt = 0;
+  // Loop over modules
+  Phase2TrackerRecHit1DCollectionNew::const_iterator DSViter; 
+  for (DSViter = rechits->begin(); DSViter != rechits->end(); ++DSViter) {
+    // Get the detector unit's id
+    unsigned int rawid(DSViter->detId());
+    DetId detId(rawid);
+    // Get the geomdet
+    const GeomDetUnit* geomDetunit(tkGeom_->idToDetUnit(detId));
+    if (!geomDetunit)
+      continue;
+    // determine the detector we are in
+    TrackerGeometry::ModuleType mType = tkGeom_->getDetectorType(detId);
+    std::string key = phase2tkutil::getOTHistoId(detId.rawId(), tTopo_);
+    nTotrechitsinevt += DSViter->size();
+    if (mType == TrackerGeometry::ModuleType::Ph2PSP) {
+      if(nrechitLayerMapP_primary.find(key) == nrechitLayerMapP_primary.end()) {
+	nrechitLayerMapP_primary.insert(std::make_pair(key, DSViter->size())); 
+      } else {
+	nrechitLayerMapP_primary[key] += DSViter->size();
+      }
+    } else if (mType == TrackerGeometry::ModuleType::Ph2PSS || mType == TrackerGeometry::ModuleType::Ph2SS){
+      if(nrechitLayerMapS_primary.find(key) == nrechitLayerMapS_primary.end()) {
+	nrechitLayerMapS_primary.insert(std::make_pair(key, DSViter->size()));
+      }
+      else {
+	nrechitLayerMapS_primary[key] += DSViter->size();
+      }
+    }
+    edmNew::DetSet<Phase2TrackerRecHit1D>::const_iterator rechitIt;
+    //loop over rechits for a single detId
+    for(rechitIt = DSViter->begin(); rechitIt != DSViter->end(); ++rechitIt) {
+      LocalPoint lp = rechitIt->localPosition();
+      //GetSimHits
+      const std::vector<SimHitIdpr>& matchedId = associateRecHit.associateHitId(*rechitIt);
+      //std::cout << "Nmatched SimHits = "  << matchedId.size() << ",";
+      const PSimHit* simhitClosest = 0;
+      float mind = 1e4;
+      for (unsigned int si = 0; si < simHits.size(); ++si) {
+	for(edm::PSimHitContainer::const_iterator simhitIt = simHits.at(si)->begin();
+	    simhitIt != simHits.at(si)->end(); ++simhitIt) {
+	  if(detId.rawId() != simhitIt->detUnitId())   continue;
+	  for(auto& mId : matchedId) {
+	    if(simhitIt->trackId() == mId.first) {
+              float dx = simhitIt->localPosition().x() - lp.x();
+              float dy = simhitIt->localPosition().y() - lp.y();
+	      float dist = std::sqrt(dx * dx + dy * dy);
+	      if (!simhitClosest || dist < mind) {
+		mind = dist;
+		simhitClosest = &*simhitIt;
+	      }
+	    }
+	  }
+	}//end loop over PSimhitcontainers
+      }//end loop over simHits
+      if(!simhitClosest)   continue;
+      auto simTrackIt(selectedSimTrackMap.find(simhitClosest->trackId()));
+      bool isPrimary = false;
+      //check if simhit is primary
+      if(simTrackIt != selectedSimTrackMap.end()) isPrimary = phase2tkutil::isPrimary(simTrackIt->second, simhitClosest);
+      Local3DPoint simlp(simhitClosest->localPosition());
+      const LocalError& lperr = rechitIt->localPositionError();
+      double dx = lp.x() - simlp.x();
+      double dy = lp.y() - simlp.y();
+      double pullx = 999.;
+      double pully = 999.;
+      if (lperr.xx()) 
+	pullx = (lp.x() - simlp.x()) / std::sqrt(lperr.xx());
+      if (lperr.yy()) 
+	pully = (lp.y() - simlp.y()) / std::sqrt(lperr.yy());
+      float eta = geomDetunit->surface().toGlobal(lp).eta();;
+      if (mType == TrackerGeometry::ModuleType::Ph2PSP) {
+	layerMEs_[key].deltaX_P->Fill(phase2tkutil::cmtomicron * dx);
+	layerMEs_[key].deltaY_P->Fill(phase2tkutil::cmtomicron * dy);
+	layerMEs_[key].pullX_P->Fill(pullx);
+	layerMEs_[key].pullY_P->Fill(pully);
+	layerMEs_[key].deltaX_eta_P->Fill(eta, phase2tkutil::cmtomicron * dx);
+	layerMEs_[key].deltaY_eta_P->Fill(eta,phase2tkutil::cmtomicron * dy);
+	layerMEs_[key].pullX_eta_P->Fill(eta,pullx);
+	layerMEs_[key].pullY_eta_P->Fill(eta,pully);
+	if(isPrimary) {
+	  layerMEs_[key].deltaX_primary_P->Fill(phase2tkutil::cmtomicron * dx);
+	  layerMEs_[key].deltaY_primary_P->Fill(phase2tkutil::cmtomicron * dy);
+	  layerMEs_[key].pullX_primary_P->Fill(pullx);
+	  layerMEs_[key].pullY_primary_P->Fill(pully);
+	} else 
+	  nrechitLayerMapP_primary[key]--;
+      } else if (mType == TrackerGeometry::ModuleType::Ph2PSS || mType == TrackerGeometry::ModuleType::Ph2SS) {
+	layerMEs_[key].deltaX_S->Fill(phase2tkutil::cmtomicron * dx);
+	layerMEs_[key].deltaY_S->Fill(dy);
+	layerMEs_[key].pullX_S->Fill(pullx);
+	layerMEs_[key].pullY_S->Fill(pully);
+	layerMEs_[key].deltaX_eta_S->Fill(eta,phase2tkutil::cmtomicron * dx);
+	layerMEs_[key].deltaY_eta_S->Fill(eta,dy);
+	layerMEs_[key].pullX_eta_S->Fill(eta,pullx);
+	layerMEs_[key].pullY_eta_S->Fill(eta,pully);
+	if(isPrimary) {
+	  layerMEs_[key].deltaX_primary_S->Fill(phase2tkutil::cmtomicron * dx);
+	  layerMEs_[key].deltaY_primary_S->Fill(dy);
+	  layerMEs_[key].pullX_primary_S->Fill(pullx);
+	  layerMEs_[key].pullY_primary_S->Fill(pully);
+	}else 
+	  nrechitLayerMapS_primary[key]--;
+      }
+    }//end loop over rechits of a detId
+  } //End loop over DetSetVector
+ 
+  //fill nRecHits per event
+  //fill nRecHit counter per layer
+  for(auto& lme : nrechitLayerMapP_primary) {
+    layerMEs_[lme.first].numberRecHitsprimary_P->Fill(nrechitLayerMapP_primary[lme.first]);
+  }
+  for(auto& lme : nrechitLayerMapS_primary) {
+    layerMEs_[lme.first].numberRecHitsprimary_S->Fill(nrechitLayerMapS_primary[lme.first]);
+  }
+}
+//
+// -- Book Histograms
+//
+void Phase2OTValidateRecHit::bookHistograms(DQMStore::IBooker& ibooker,
+					    edm::Run const& iRun,
+					    edm::EventSetup const& iSetup) {
+  
+  std::string top_folder = config_.getParameter<std::string>("TopFolderName");
+  //Now book layer wise histos
+  edm::ESWatcher<TrackerDigiGeometryRecord> theTkDigiGeomWatcher;
+  if (theTkDigiGeomWatcher.check(iSetup)) {
+    for (auto const& det_u : tkGeom_->detUnits()) {
+      //Always check TrackerNumberingBuilder before changing this part
+      if(det_u->subDetector() == GeomDetEnumerators::SubDetector::P2PXB
+	 || det_u->subDetector() == GeomDetEnumerators::SubDetector::P2PXEC)
+	continue;
+      unsigned int detId_raw = det_u->geographicalId().rawId();
+      bookLayerHistos(ibooker, detId_raw, top_folder);
+    }
+  }
+}
+
+//
+// -- Book Layer Histograms
+//
+void Phase2OTValidateRecHit::bookLayerHistos(DQMStore::IBooker& ibooker,
+					     unsigned int det_id,
+					     std::string& subdir) {
+  
+  std::string key = phase2tkutil::getOTHistoId(det_id, tTopo_);
+  if (layerMEs_.find(key) == layerMEs_.end()) {
+    
+    ibooker.cd();
+    RecHitME local_histos;
+    ibooker.setCurrentFolder(subdir+"/"+key);
+    edm::LogInfo("Phase2OTValidateRecHit") << " Booking Histograms in : " << key;
+
+    if(tkGeom_->getDetectorType(det_id) == TrackerGeometry::ModuleType::Ph2PSP) {
+
+      local_histos.deltaX_P = phase2tkutil::book1DFromPSet(config_.getParameter<edm::ParameterSet>("Delta_X_Pixel"), ibooker);
+      local_histos.deltaY_P = phase2tkutil::book1DFromPSet(config_.getParameter<edm::ParameterSet>("Delta_Y_Pixel"), ibooker);
+
+      local_histos.pullX_P = phase2tkutil::book1DFromPSet(config_.getParameter<edm::ParameterSet>("Pull_X_Pixel"), ibooker);
+      local_histos.pullY_P = phase2tkutil::book1DFromPSet(config_.getParameter<edm::ParameterSet>("Pull_X_Pixel"), ibooker);
+
+      
+      local_histos.deltaX_eta_P = phase2tkutil::bookProfile1DFromPSet(config_.getParameter<edm::ParameterSet>("Delta_X_vs_eta_Pixel"), ibooker);
+      local_histos.deltaY_eta_P = phase2tkutil::bookProfile1DFromPSet(config_.getParameter<edm::ParameterSet>("Delta_Y_vs_eta_Pixel"), ibooker);
+
+      local_histos.pullX_eta_P = phase2tkutil::bookProfile1DFromPSet(config_.getParameter<edm::ParameterSet>("Pull_X_vs_eta_Pixel"), ibooker);
+      local_histos.pullY_eta_P = phase2tkutil::bookProfile1DFromPSet(config_.getParameter<edm::ParameterSet>("Pull_X_vs_eta_Pixel"), ibooker);
+
+      ibooker.setCurrentFolder(subdir+"/"+key+"/PrimarySimHits");
+      //all histos for Primary particles
+      local_histos.numberRecHitsprimary_P = phase2tkutil::book1DFromPSet(config_.getParameter<edm::ParameterSet>("nRecHits_Pixel_primary"), ibooker);
+      
+      local_histos.deltaX_primary_P = phase2tkutil::book1DFromPSet(config_.getParameter<edm::ParameterSet>("Delta_X_Pixel_Primary"), ibooker);
+      local_histos.deltaY_primary_P = phase2tkutil::book1DFromPSet(config_.getParameter<edm::ParameterSet>("Delta_X_Pixel_Primary"), ibooker);
+
+      local_histos.pullX_primary_P = phase2tkutil::book1DFromPSet(config_.getParameter<edm::ParameterSet>("Pull_X_Pixel_Primary"), ibooker);
+      local_histos.pullY_primary_P = phase2tkutil::book1DFromPSet(config_.getParameter<edm::ParameterSet>("Pull_X_Pixel_Primary"), ibooker);
+    }//if block for P
+    
+    ibooker.setCurrentFolder(subdir+"/"+key);
+    local_histos.deltaX_S = phase2tkutil::book1DFromPSet(config_.getParameter<edm::ParameterSet>("Delta_X_Strip"), ibooker);
+    local_histos.deltaY_S = phase2tkutil::book1DFromPSet(config_.getParameter<edm::ParameterSet>("Delta_Y_Strip"), ibooker);
+    
+    local_histos.pullX_S = phase2tkutil::book1DFromPSet(config_.getParameter<edm::ParameterSet>("Pull_X_Strip"), ibooker);
+    local_histos.pullY_S = phase2tkutil::book1DFromPSet(config_.getParameter<edm::ParameterSet>("Pull_Y_Strip"), ibooker);
+    
+    local_histos.deltaX_eta_S = phase2tkutil::bookProfile1DFromPSet(config_.getParameter<edm::ParameterSet>("Delta_X_vs_eta_Strip"), ibooker);
+    local_histos.deltaY_eta_S = phase2tkutil::bookProfile1DFromPSet(config_.getParameter<edm::ParameterSet>("Delta_Y_vs_eta_Strip"), ibooker);
+    
+    local_histos.pullX_eta_S = phase2tkutil::bookProfile1DFromPSet(config_.getParameter<edm::ParameterSet>("Pull_X_vs_eta_Strip"), ibooker);
+    local_histos.pullY_eta_S = phase2tkutil::bookProfile1DFromPSet(config_.getParameter<edm::ParameterSet>("Pull_X_vs_eta_Pixel"), ibooker);      
+
+    //primary
+    ibooker.setCurrentFolder(subdir+"/"+key+"/PrimarySimHits");
+    local_histos.numberRecHitsprimary_S = phase2tkutil::book1DFromPSet(config_.getParameter<edm::ParameterSet>("nRecHits_Strip_primary"), ibooker);
+
+    local_histos.deltaX_primary_S = phase2tkutil::book1DFromPSet(config_.getParameter<edm::ParameterSet>("Delta_X_Strip_Primary"), ibooker);
+    local_histos.deltaY_primary_S = phase2tkutil::book1DFromPSet(config_.getParameter<edm::ParameterSet>("Delta_Y_Strip_Primary"), ibooker);
+    
+    local_histos.pullX_primary_S = phase2tkutil::book1DFromPSet(config_.getParameter<edm::ParameterSet>("Pull_X_Strip_Primary"), ibooker);
+    local_histos.pullY_primary_S = phase2tkutil::book1DFromPSet(config_.getParameter<edm::ParameterSet>("Pull_X_Strip_Primary"), ibooker);
+    
+    layerMEs_.insert(std::make_pair(key, local_histos));
+  }
+}
+
+void Phase2OTValidateRecHit::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  // rechitValidOT
+  //for macro-pixel sensors
+  std::string mptag = "macro-pixel sensor";
+  std::string striptag = "strip sensor";
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<std::string>("name", "Delta_X_Pixel");
+    psd0.add<std::string>("title", "#Delta X " + mptag + ";Cluster resolution X coordinate [#mum]");
+    psd0.add<bool>("switch", true);
+    psd0.add<double>("xmax", 250);
+    psd0.add<double>("xmin", -250);
+    psd0.add<int>("NxBins", 100);
+    desc.add<edm::ParameterSetDescription>("Delta_X_Pixel", psd0);
+  }
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<std::string>("name", "Delta_Y_Pixel");
+    psd0.add<std::string>("title", "#Delta Y " + mptag + ";Cluster resolution Y coordinate [#mum]");
+    psd0.add<bool>("switch", true);
+    psd0.add<double>("xmin", -1500);
+    psd0.add<double>("xmax", 1500);
+    psd0.add<int>("NxBins", 100);
+    desc.add<edm::ParameterSetDescription>("Delta_Y_Pixel", psd0);
+  }
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<std::string>("name", "Delta_X_Pixel_Primary");
+    psd0.add<std::string>("title", "#Delta X " + mptag + ";cluster resolution X coordinate [#mum]");
+    psd0.add<bool>("switch", true);
+    psd0.add<double>("xmin", -250);
+    psd0.add<double>("xmax", 250);
+    psd0.add<int>("NxBins", 100);
+    desc.add<edm::ParameterSetDescription>("Delta_X_Pixel_Primary", psd0);
+  }
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<std::string>("name", "Delta_Y_Pixel_Primary");
+    psd0.add<std::string>("title", "#Delta Y " + mptag + ";cluster resolution Y coordinate [#mum]");
+    psd0.add<bool>("switch", true);
+    psd0.add<double>("xmin", -500);
+    psd0.add<double>("xmax", 500);
+    psd0.add<int>("NxBins", 100);
+    desc.add<edm::ParameterSetDescription>("Delta_Y_Pixel_Primary", psd0);
+  } 
+
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<std::string>("name", "Delta_X_vs_Eta_Pixel");
+    psd0.add<std::string>("title", ";#eta;#Delta x [#mum]");
+    psd0.add<double>("ymin", -250.0);
+    psd0.add<double>("ymax", 250.0);
+    psd0.add<int>("NxBins", 82);
+    psd0.add<bool>("switch", true);
+    psd0.add<double>("xmax", 4.1);
+    psd0.add<double>("xmin", -4.1);
+    desc.add<edm::ParameterSetDescription>("Delta_X_vs_eta_Pixel", psd0);
+  }
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<std::string>("name", "Delta_Y_vs_Eta_Pixel");
+    psd0.add<std::string>("title", ";#eta;#Delta y [#mum]");
+    psd0.add<double>("ymin", -1500.0);
+    psd0.add<double>("ymax", 1500.0);
+    psd0.add<int>("NxBins", 82);
+    psd0.add<bool>("switch", true);
+    psd0.add<double>("xmax", 4.1);
+    psd0.add<double>("xmin", -4.1);
+    desc.add<edm::ParameterSetDescription>("Delta_Y_vs_eta_Pixel", psd0);
+  }
+
+  //Pulls macro-pixel
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<std::string>("name", "Pull_X_Pixel");
+    psd0.add<std::string>("title", ";pull x;");
+    psd0.add<double>("xmin", -4.0);
+    psd0.add<bool>("switch", true);
+    psd0.add<double>("xmax", 4.0);
+    psd0.add<int>("NxBins", 100);
+    desc.add<edm::ParameterSetDescription>("Pull_X_Pixel", psd0);
+  }
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<std::string>("name", "Pull_Y_Pixel");
+    psd0.add<std::string>("title", ";pull y;");
+    psd0.add<double>("xmin", -4.0);
+    psd0.add<bool>("switch", true);
+    psd0.add<double>("xmax", 4.0);
+    psd0.add<int>("NxBins", 100);
+    desc.add<edm::ParameterSetDescription>("Pull_Y_Pixel", psd0);
+  }
+
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<std::string>("name", "Pull_X_Pixel_Primary");
+    psd0.add<std::string>("title", ";pull x;");
+    psd0.add<double>("xmin", -4.0);
+    psd0.add<bool>("switch", true);
+    psd0.add<double>("xmax", 4.0);
+    psd0.add<int>("NxBins", 100);
+    desc.add<edm::ParameterSetDescription>("Pull_X_Pixel_Primary", psd0);
+  }
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<std::string>("name", "Pull_Y_Pixel_Primary");
+    psd0.add<std::string>("title", ";pull y;");
+    psd0.add<double>("xmin", -4.0);
+    psd0.add<bool>("switch", true);
+    psd0.add<double>("xmax", 4.0);
+    psd0.add<int>("NxBins", 100);
+    desc.add<edm::ParameterSetDescription>("Pull_Y_Pixel_Primary", psd0);
+  }
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<std::string>("name", "Pull_X_vs_Eta");
+    psd0.add<std::string>("title", ";#eta;pull x");
+    psd0.add<double>("ymax", 4.0);
+    psd0.add<int>("NxBins", 82);
+    psd0.add<bool>("switch", true);
+    psd0.add<double>("xmax", 4.1);
+    psd0.add<double>("xmin", -4.1);
+    psd0.add<double>("ymin", -4.0);
+    desc.add<edm::ParameterSetDescription>("Pull_X_vs_eta_Pixel", psd0);
+  }
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<std::string>("name", "Pull_Y_vs_Eta");
+    psd0.add<std::string>("title", ";#eta;pull y");
+    psd0.add<double>("ymax", 4.0);
+    psd0.add<int>("NxBins", 82);
+    psd0.add<bool>("switch", true);
+    psd0.add<double>("xmax", 4.1);
+    psd0.add<double>("xmin", -4.1);
+    psd0.add<double>("ymin", -4.0);
+    desc.add<edm::ParameterSetDescription>("Pull_Y_vs_eta_Pixel", psd0);
+  }
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<std::string>("name", "Number_RecHits_matched_PrimarySimTrack");
+    psd0.add<std::string>("title", "Number of RecHits matched to primary SimTrack;;");
+    psd0.add<double>("xmin", 0.0);
+    psd0.add<bool>("switch", true);
+    psd0.add<double>("xmax", 10000.0);
+    psd0.add<int>("NxBins", 100);
+    desc.add<edm::ParameterSetDescription>("nRecHits_Pixel_primary", psd0);
+  }
+
+ //strip sensors
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<std::string>("name", "Delta_X_Strip");
+    psd0.add<std::string>("title", "#Delta X " + striptag + ";Cluster resolution X coordinate [#mum]");
+    psd0.add<bool>("switch", true);
+    psd0.add<double>("xmin", -250);
+    psd0.add<double>("xmax", 250);
+    psd0.add<int>("NxBins", 100);
+    desc.add<edm::ParameterSetDescription>("Delta_X_Strip", psd0);
+  }
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<std::string>("name", "Delta_Y_Strip");
+    psd0.add<std::string>("title", "#Delta Y " + striptag + ";Cluster resolution Y coordinate [cm]");
+    psd0.add<double>("xmin", -5.0);
+    psd0.add<bool>("switch", true);
+    psd0.add<double>("xmax", 5.0);
+    psd0.add<int>("NxBins", 100);
+    desc.add<edm::ParameterSetDescription>("Delta_Y_Strip", psd0);
+  }
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<std::string>("name", "Delta_X_Strip_Primary");
+    psd0.add<std::string>("title", "#Delta X " + striptag + ";Cluster resolution X coordinate [#mum]");
+    psd0.add<bool>("switch", true);
+    psd0.add<double>("xmin", -250);
+    psd0.add<double>("xmax", 250);
+    psd0.add<int>("NxBins", 100);
+    desc.add<edm::ParameterSetDescription>("Delta_X_Strip_Primary", psd0);
+  }
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<std::string>("name", "Delta_Y_Strip_Primary");
+    psd0.add<std::string>("title", "#Delta Y " + striptag + ";Cluster resolution Y coordinate [cm]");
+    psd0.add<double>("xmin", -5.0);
+    psd0.add<bool>("switch", true);
+    psd0.add<double>("xmax", 5.0);
+    psd0.add<int>("NxBins", 100);
+    desc.add<edm::ParameterSetDescription>("Delta_Y_Strip_Primary", psd0);
+  }
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<std::string>("name", "Delta_X_vs_Eta_Strip");
+    psd0.add<std::string>("title", ";#eta;#Delta x [#mum]");
+    psd0.add<double>("ymin", -250.0);
+    psd0.add<double>("ymax", 250.0);
+    psd0.add<int>("NxBins", 82);
+    psd0.add<bool>("switch", true);
+    psd0.add<double>("xmax", 4.1);
+    psd0.add<double>("xmin", -4.1);
+    desc.add<edm::ParameterSetDescription>("Delta_X_vs_eta_Strip", psd0);
+  }
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<std::string>("name", "Delta_Y_vs_Eta_Strip");
+    psd0.add<std::string>("title", ";#eta;#Delta y [cm]");
+    psd0.add<double>("ymin", -5.0);
+    psd0.add<double>("ymax", 5.0);
+    psd0.add<int>("NxBins", 82);
+    psd0.add<bool>("switch", true);
+    psd0.add<double>("xmax", 4.1);
+    psd0.add<double>("xmin", -4.1);
+    desc.add<edm::ParameterSetDescription>("Delta_Y_vs_eta_Strip", psd0);
+  }
+  //pulls strips
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<std::string>("name", "Pull_X_Strip");
+    psd0.add<std::string>("title", ";pull x;");
+    psd0.add<double>("xmin", -4.0);
+    psd0.add<bool>("switch", true);
+    psd0.add<double>("xmax", 4.0);
+    psd0.add<int>("NxBins", 100);
+    desc.add<edm::ParameterSetDescription>("Pull_X_Strip", psd0);
+  }
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<std::string>("name", "Pull_Y_Strip");
+    psd0.add<std::string>("title", ";pull y;");
+    psd0.add<double>("xmin", -4.0);
+    psd0.add<bool>("switch", true);
+    psd0.add<double>("xmax", 4.0);
+    psd0.add<int>("NxBins", 100);
+    desc.add<edm::ParameterSetDescription>("Pull_Y_Strip", psd0);
+  }
+
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<std::string>("name", "Pull_X_Strip_Primary");
+    psd0.add<std::string>("title", ";pull x;");
+    psd0.add<double>("xmin", -4.0);
+    psd0.add<bool>("switch", true);
+    psd0.add<double>("xmax", 4.0);
+    psd0.add<int>("NxBins", 100);
+    desc.add<edm::ParameterSetDescription>("Pull_X_Strip_Primary", psd0);
+  }
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<std::string>("name", "Pull_Y_Strip_Primary");
+    psd0.add<std::string>("title", ";pull y;");
+    psd0.add<double>("xmin", -4.0);
+    psd0.add<bool>("switch", true);
+    psd0.add<double>("xmax", 4.0);
+    psd0.add<int>("NxBins", 100);
+    desc.add<edm::ParameterSetDescription>("Pull_Y_Strip_Primary", psd0);
+  }
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<std::string>("name", "Pull_X_vs_Eta_Strip");
+    psd0.add<std::string>("title", ";#eta;pull x");
+    psd0.add<double>("ymax", 4.0);
+    psd0.add<int>("NxBins", 82);
+    psd0.add<bool>("switch", true);
+    psd0.add<double>("xmax", 4.1);
+    psd0.add<double>("xmin", -4.1);
+    psd0.add<double>("ymin", -4.0);
+    desc.add<edm::ParameterSetDescription>("Pull_X_vs_eta_Strip", psd0);
+  }
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<std::string>("name", "Pull_Y_vs_Eta_Strip");
+    psd0.add<std::string>("title", ";#eta;pull y");
+    psd0.add<double>("ymax", 4.0);
+    psd0.add<int>("NxBins", 82);
+    psd0.add<bool>("switch", true);
+    psd0.add<double>("xmax", 4.1);
+    psd0.add<double>("xmin", -4.1);
+    psd0.add<double>("ymin", -4.0);
+    desc.add<edm::ParameterSetDescription>("Pull_Y_vs_eta_Strip", psd0);
+  }
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<std::string>("name", "Number_RecHits_matched_PrimarySimTrack");
+    psd0.add<std::string>("title", "Number of RecHits matched to primary SimTrack;;");
+    psd0.add<double>("xmin", 0.0);
+    psd0.add<bool>("switch", true);
+    psd0.add<double>("xmax", 10000.0);
+    psd0.add<int>("NxBins", 100);
+    desc.add<edm::ParameterSetDescription>("nRecHits_Strip_primary", psd0);
+  }
+  ///////
+  desc.add<edm::InputTag>("SimVertexSource", edm::InputTag("g4SimHits"));
+  desc.add<bool>("associatePixel", false);
+  desc.add<std::string>("TopFolderName", "TrackerPhase2OTRecHitV");
+  desc.add<bool>("associateHitbySimTrack", true);
+  desc.add<bool>("Verbosity", false);
+  desc.add<bool>("associateStrip", true);
+  desc.add<edm::InputTag>("phase2TrackerSimLinkSrc", edm::InputTag("simSiPixelDigis","Tracker"));
+  desc.add<bool>("associateRecoTracks", false);
+  desc.add<edm::InputTag>("pixelSimLinkSrc", edm::InputTag("simSiPixelDigis","Pixel"));
+  desc.add<bool>("usePhase2Tracker", true);
+  desc.add<edm::InputTag>("OuterTrackerDigiSimLinkSource", edm::InputTag("simSiPixelDigis","Tracker"));
+  desc.add<edm::InputTag>("OuterTrackerDigiSource", edm::InputTag("mix","Tracker"));
+  desc.add<edm::InputTag>("rechitsSrc", edm::InputTag("siPhase2RecHits"));
+  desc.add<edm::InputTag>("simTracksSrc", edm::InputTag("g4SimHits"));
+  desc.add<double>("SimTrackMinPt", 2.0);
+  desc.add<std::vector<edm::InputTag>>("PSimHitSource",
+    {
+        edm::InputTag("g4SimHits:TrackerHitsTIBLowTof"),
+	edm::InputTag("g4SimHits:TrackerHitsTIBHighTof"),
+	edm::InputTag("g4SimHits:TrackerHitsTIDLowTof"),
+	edm::InputTag("g4SimHits:TrackerHitsTIDHighTof"),
+	edm::InputTag("g4SimHits:TrackerHitsTOBLowTof"),
+	edm::InputTag("g4SimHits:TrackerHitsTOBHighTof"),
+	edm::InputTag("g4SimHits:TrackerHitsTECLowTof"),
+	edm::InputTag("g4SimHits:TrackerHitsTECHighTof"),
+	edm::InputTag("g4SimHits:TrackerHitsPixelBarrelLowTof"),
+	edm::InputTag("g4SimHits:TrackerHitsPixelBarrelHighTof"),
+	edm::InputTag("g4SimHits:TrackerHitsPixelEndcapLowTof"),
+	edm::InputTag("g4SimHits:TrackerHitsPixelEndcapHighTof"),
+    });
+  
+  desc.add<std::vector<std::string>>("ROUList", 
+    {
+        "TrackerHitsPixelBarrelLowTof",
+	"TrackerHitsPixelBarrelHighTof",
+	"TrackerHitsTIBLowTof",
+	"TrackerHitsTIBHighTof",
+	"TrackerHitsTIDLowTof",
+	"TrackerHitsTIDHighTof",
+	"TrackerHitsTOBLowTof",
+	"TrackerHitsTOBHighTof",
+	"TrackerHitsPixelEndcapLowTof",
+	"TrackerHitsPixelEndcapHighTof",
+	"TrackerHitsTECLowTof",
+	"TrackerHitsTECHighTof"
+    });
+
+  descriptions.add("Phase2OTValidateRecHit", desc);
+} 
+ 
+//define this as a plug-in
+DEFINE_FWK_MODULE(Phase2OTValidateRecHit);
+ 

--- a/Validation/SiTrackerPhase2V/plugins/Phase2TrackerValidateDigi.h
+++ b/Validation/SiTrackerPhase2V/plugins/Phase2TrackerValidateDigi.h
@@ -108,7 +108,9 @@ private:
 
   void fillHistogram(MonitorElement* th1, MonitorElement* th2, MonitorElement* th3, float val, int primary);
   int fillSimHitInfo(const edm::Event& iEvent, const SimTrack simTrk);
+
   bool findOTDigi(unsigned int detid, unsigned int id);
+
   bool findITPixelDigi(unsigned int detid, unsigned int id);
   void fillOTBXInfo();
   void fillITPixelBXInfo();
@@ -128,18 +130,17 @@ private:
   edm::InputTag simTrackSrc_;
   edm::InputTag simVertexSrc_;
 
-  const edm::EDGetTokenT<edm::DetSetVector<Phase2TrackerDigi> > otDigiToken_;
-  const edm::EDGetTokenT<edm::DetSetVector<PixelDigiSimLink> > otDigiSimLinkToken_;
-  const edm::EDGetTokenT<edm::DetSetVector<PixelDigi> > itPixelDigiToken_;
-  const edm::EDGetTokenT<edm::DetSetVector<PixelDigiSimLink> > itPixelDigiSimLinkToken_;
+  const edm::EDGetTokenT<edm::DetSetVector<Phase2TrackerDigi>> otDigiToken_;
+  const edm::EDGetTokenT<edm::DetSetVector<PixelDigiSimLink>> otDigiSimLinkToken_;
+  const edm::EDGetTokenT<edm::DetSetVector<PixelDigi>> itPixelDigiToken_;
+  const edm::EDGetTokenT<edm::DetSetVector<PixelDigiSimLink>> itPixelDigiSimLinkToken_;
   const edm::EDGetTokenT<edm::SimTrackContainer> simTrackToken_;
   const edm::EDGetTokenT<edm::SimVertexContainer> simVertexToken_;
-  std::vector<edm::EDGetTokenT<edm::PSimHitContainer> > simHitTokens_;
-
-  edm::Handle<edm::DetSetVector<PixelDigi> > itPixelDigiHandle_;
-  edm::Handle<edm::DetSetVector<Phase2TrackerDigi> > otDigiHandle_;
-  edm::Handle<edm::DetSetVector<PixelDigiSimLink> > itPixelSimLinkHandle_;
-  edm::Handle<edm::DetSetVector<PixelDigiSimLink> > otSimLinkHandle_;
+  const edm::DetSetVector<PixelDigiSimLink>* otSimLink_;
+  const edm::DetSetVector<PixelDigiSimLink>* itSimLink_;
+  const edm::DetSetVector<Phase2TrackerDigi>* otdigis_;
+  const edm::DetSetVector<PixelDigi>* itdigis_;
+  std::vector<edm::EDGetTokenT<edm::PSimHitContainer>> simHitTokens_;
   edm::Handle<edm::PSimHitContainer> simHits;
   edm::Handle<edm::SimTrackContainer> simTracks;
   edm::Handle<edm::SimVertexContainer> simVertices;


### PR DESCRIPTION
#### PR description:
This PR adds 

- Modules for OT Rechit monitoring and validation. These can be run only with a standalone config - DQM/SiTrackerPhase2/test/dqmstep_phase2tk_cfg.py. The input to the config should be a GEN-SIM-RECO file. It runs the IT and OT rechit producers together with the DQM & Validation step.
- Fixes an axis range in OT cluster validation module.
- For IT rechits, plots of  cluster res vs cluster size(in X & Y) are added. 
- For IT rechits, a scatter plot of res Y vs res X is added 

#### PR validation:
Validated with wf 23234.0, 34634.0.

cc @gabriel-rmrz @mmusich @tsusa @emiglior 