### PR TITLE
[HGCAL] Deprecate MultiCluster

### DIFF
--- a/Configuration/EventContent/python/EventContent_cff.py
+++ b/Configuration/EventContent/python/EventContent_cff.py
@@ -278,6 +278,8 @@ AODEventContent.outputCommands.extend(CommonEventContent.outputCommands)
 
 ctpps.toModify(AODEventContent, 
     outputCommands = AODEventContent.outputCommands + RecoCTPPSAOD.outputCommands)
+phase2_hgcal.toModify(AODEventContent,
+    outputCommands = AODEventContent.outputCommands + TICL_AOD.outputCommands)
 #
 #
 # RAWAOD Data Tier definition

--- a/Configuration/EventContent/python/EventContent_cff.py
+++ b/Configuration/EventContent/python/EventContent_cff.py
@@ -278,8 +278,6 @@ AODEventContent.outputCommands.extend(CommonEventContent.outputCommands)
 
 ctpps.toModify(AODEventContent, 
     outputCommands = AODEventContent.outputCommands + RecoCTPPSAOD.outputCommands)
-phase2_hgcal.toModify(AODEventContent,
-    outputCommands = AODEventContent.outputCommands + TICL_AOD.outputCommands)
 #
 #
 # RAWAOD Data Tier definition

--- a/RecoHGCal/Configuration/python/RecoHGCal_EventContent_cff.py
+++ b/RecoHGCal/Configuration/python/RecoHGCal_EventContent_cff.py
@@ -3,7 +3,6 @@ import FWCore.ParameterSet.Config as cms
 from RecoHGCal.TICL.iterativeTICL_cff import ticlIterLabelsMerge
 
 trackstersIters = ['keep *_ticlTracksters'+iteration+'_*_*' for iteration in ticlIterLabelsMerge]
-trackstersHFNoseIters = ['keep *_ticlTrackstersHFNose'+iteration+'_*_*' for iteration in ticlIterLabelsMerge]
 
 #AOD content
 TICL_AOD = cms.PSet(
@@ -14,7 +13,11 @@ TICL_AOD = cms.PSet(
 TICL_RECO = cms.PSet(
     outputCommands = cms.untracked.vstring(
       trackstersIters +
-      trackstersHFNoseIters +
+      ['keep *_ticlTrackstersHFNoseTrkEM_*_*',
+       'keep *_ticlTrackstersHFNoseEM_*_*',
+       'keep *_ticlTrackstersHFNoseMIP_*_*',
+       'keep *_ticlTrackstersHFNoseHAD_*_*',
+       'keep *_ticlTrackstersHFNoseMerge_*_*',] +
       ['keep *_pfTICL_*_*']
       )
     )

--- a/RecoHGCal/Configuration/python/RecoHGCal_EventContent_cff.py
+++ b/RecoHGCal/Configuration/python/RecoHGCal_EventContent_cff.py
@@ -5,6 +5,11 @@ from RecoHGCal.TICL.iterativeTICL_cff import ticlIterLabelsMerge
 trackstersIters = ['keep *_ticlTracksters'+iteration+'_*_*' for iteration in ticlIterLabelsMerge]
 trackstersHFNoseIters = ['keep *_ticlTrackstersHFNose'+iteration+'_*_*' for iteration in ticlIterLabelsMerge]
 
+#AOD content
+TICL_AOD = cms.PSet(
+    outputCommands = cms.untracked.vstring()
+    )
+
 #RECO content
 TICL_RECO = cms.PSet(
     outputCommands = cms.untracked.vstring(
@@ -13,6 +18,7 @@ TICL_RECO = cms.PSet(
       ['keep *_pfTICL_*_*']
       )
     )
+TICL_RECO.outputCommands.extend(TICL_AOD.outputCommands)
 
 # FEVT Content
 TICL_FEVT = cms.PSet(

--- a/RecoHGCal/Configuration/python/RecoHGCal_EventContent_cff.py
+++ b/RecoHGCal/Configuration/python/RecoHGCal_EventContent_cff.py
@@ -1,38 +1,18 @@
 import FWCore.ParameterSet.Config as cms
 
+from RecoHGCal.TICL.iterativeTICL_cff import ticlIterLabelsMerge
 
-#AOD content
-TICL_AOD = cms.PSet(
-  # 13/04/2021 Felice: MultiClusters will be deprecated soon
-    outputCommands = cms.untracked.vstring(
-      'keep *_ticlMultiClustersFromTrackstersEM_*_*',
-      'keep *_ticlMultiClustersFromTrackstersHAD_*_*',
-      'keep *_ticlMultiClustersFromTrackstersTrk_*_*',
-      'keep *_ticlMultiClustersFromTrackstersTrkEM_*_*',
-      'keep *_ticlMultiClustersFromTrackstersMIP_*_*',
-      'keep *_ticlMultiClustersFromTrackstersMerge_*_*',
-      'keep *_ticlMultiClustersFromSimTracksters_*_*',
-      )
-    )
+trackstersIters = ['keep *_ticlTracksters'+iteration+'_*_*' for iteration in ticlIterLabelsMerge]
+trackstersHFNoseIters = ['keep *_ticlTrackstersHFNose'+iteration+'_*_*' for iteration in ticlIterLabelsMerge]
 
 #RECO content
 TICL_RECO = cms.PSet(
     outputCommands = cms.untracked.vstring(
-      'keep *_ticlTrackstersTrkEM_*_*',
-      'keep *_ticlTrackstersEM_*_*',
-      'keep *_ticlTrackstersHAD_*_*',
-      'keep *_ticlTrackstersTrk_*_*',
-      'keep *_ticlTrackstersMIP_*_*',
-      'keep *_ticlTrackstersMerge_*_*',
-      'keep *_ticlTrackstersHFNoseTrkEM_*_*',
-      'keep *_ticlTrackstersHFNoseEM_*_*',
-      'keep *_ticlTrackstersHFNoseMIP_*_*',
-      'keep *_ticlTrackstersHFNoseHAD_*_*',
-      'keep *_ticlTrackstersHFNoseMerge_*_*',
-      'keep *_pfTICL_*_*'
+      trackstersIters +
+      trackstersHFNoseIters +
+      ['keep *_pfTICL_*_*']
       )
     )
-TICL_RECO.outputCommands.extend(TICL_AOD.outputCommands)
 
 # FEVT Content
 TICL_FEVT = cms.PSet(
@@ -41,4 +21,3 @@ TICL_FEVT = cms.PSet(
       )
     )
 TICL_FEVT.outputCommands.extend(TICL_RECO.outputCommands)
-

--- a/RecoHGCal/TICL/python/EMStep_cff.py
+++ b/RecoHGCal/TICL/python/EMStep_cff.py
@@ -3,7 +3,6 @@ import FWCore.ParameterSet.Config as cms
 from RecoHGCal.TICL.TICLSeedingRegions_cff import ticlSeedingGlobal, ticlSeedingGlobalHFNose
 from RecoHGCal.TICL.trackstersProducer_cfi import trackstersProducer as _trackstersProducer
 from RecoHGCal.TICL.filteredLayerClustersProducer_cfi import filteredLayerClustersProducer as _filteredLayerClustersProducer
-from RecoHGCal.TICL.multiClustersFromTrackstersProducer_cfi import multiClustersFromTrackstersProducer as _multiClustersFromTrackstersProducer
 
 # CLUSTER FILTERING/MASKING
 
@@ -38,16 +37,9 @@ ticlTrackstersEM = _trackstersProducer.clone(
     algo_verbosity = 0,
 )
 
-# MULTICLUSTERS
-
-ticlMultiClustersFromTrackstersEM = _multiClustersFromTrackstersProducer.clone(
-    Tracksters = "ticlTrackstersEM"
-)
-
 ticlEMStepTask = cms.Task(ticlSeedingGlobal
     ,filteredLayerClustersEM
-    ,ticlTrackstersEM
-    ,ticlMultiClustersFromTrackstersEM)
+    ,ticlTrackstersEM)
 
 filteredLayerClustersHFNoseEM = filteredLayerClustersEM.clone(
     LayerClusters = 'hgcalLayerClustersHFNose',

--- a/RecoHGCal/TICL/python/HADStep_cff.py
+++ b/RecoHGCal/TICL/python/HADStep_cff.py
@@ -4,7 +4,6 @@ from RecoHGCal.TICL.TICLSeedingRegions_cff import ticlSeedingGlobal, ticlSeeding
 from RecoHGCal.TICL.ticlLayerTileProducer_cfi import ticlLayerTileProducer as _ticlLayerTileProducer
 from RecoHGCal.TICL.trackstersProducer_cfi import trackstersProducer as _trackstersProducer
 from RecoHGCal.TICL.filteredLayerClustersProducer_cfi import filteredLayerClustersProducer as _filteredLayerClustersProducer
-from RecoHGCal.TICL.multiClustersFromTrackstersProducer_cfi import multiClustersFromTrackstersProducer as _multiClustersFromTrackstersProducer
 
 # CLUSTER FILTERING/MASKING
 
@@ -33,16 +32,9 @@ ticlTrackstersHAD = _trackstersProducer.clone(
     itername = "HAD"
     )
 
-# MULTICLUSTERS
-
-ticlMultiClustersFromTrackstersHAD = _multiClustersFromTrackstersProducer.clone(
-    Tracksters = "ticlTrackstersHAD"
-    )
-
 ticlHADStepTask = cms.Task(ticlSeedingGlobal
     ,filteredLayerClustersHAD
-    ,ticlTrackstersHAD
-    ,ticlMultiClustersFromTrackstersHAD)
+    ,ticlTrackstersHAD)
 
 filteredLayerClustersHFNoseHAD = _filteredLayerClustersProducer.clone(
     min_cluster_size = 2, # inclusive

--- a/RecoHGCal/TICL/python/MIPStep_cff.py
+++ b/RecoHGCal/TICL/python/MIPStep_cff.py
@@ -3,7 +3,6 @@ import FWCore.ParameterSet.Config as cms
 from RecoHGCal.TICL.TICLSeedingRegions_cff import ticlSeedingGlobal, ticlSeedingGlobalHFNose
 from RecoHGCal.TICL.trackstersProducer_cfi import trackstersProducer as _trackstersProducer
 from RecoHGCal.TICL.filteredLayerClustersProducer_cfi import filteredLayerClustersProducer as _filteredLayerClustersProducer
-from RecoHGCal.TICL.multiClustersFromTrackstersProducer_cfi import multiClustersFromTrackstersProducer as _multiClustersFromTrackstersProducer
 
 # CLUSTER FILTERING/MASKING
 
@@ -29,16 +28,9 @@ ticlTrackstersMIP = _trackstersProducer.clone(
     max_delta_time = -1
 )
 
-# MULTICLUSTERS
-
-ticlMultiClustersFromTrackstersMIP = _multiClustersFromTrackstersProducer.clone(
-    Tracksters = "ticlTrackstersMIP"
-)
-
 ticlMIPStepTask = cms.Task(ticlSeedingGlobal
     ,filteredLayerClustersMIP
-    ,ticlTrackstersMIP
-    ,ticlMultiClustersFromTrackstersMIP)
+    ,ticlTrackstersMIP)
 
 filteredLayerClustersHFNoseMIP = filteredLayerClustersMIP.clone(
     LayerClusters = 'hgcalLayerClustersHFNose',

--- a/RecoHGCal/TICL/python/SimTracksters_cff.py
+++ b/RecoHGCal/TICL/python/SimTracksters_cff.py
@@ -1,7 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
 from RecoHGCal.TICL.trackstersFromSimClustersProducer_cfi import trackstersFromSimClustersProducer as _trackstersFromSimClustersProducer
-from RecoHGCal.TICL.multiClustersFromTrackstersProducer_cfi import multiClustersFromTrackstersProducer as _multiClustersFromTrackstersProducer
 from RecoHGCal.TICL.filteredLayerClustersProducer_cfi import filteredLayerClustersProducer as _filteredLayerClustersProducer
 
 
@@ -23,9 +22,4 @@ premix_stage2.toModify(ticlSimTracksters,
     simclusters = "mixData:MergedCaloTruth"
 )
 
-ticlMultiClustersFromSimTracksters = _multiClustersFromTrackstersProducer.clone(
-    Tracksters = "ticlSimTracksters"
-)
-
-ticlSimTrackstersTask = cms.Task(filteredLayerClustersSimTracksters, ticlSimTracksters, ticlMultiClustersFromSimTracksters)
-
+ticlSimTrackstersTask = cms.Task(filteredLayerClustersSimTracksters, ticlSimTracksters)

--- a/RecoHGCal/TICL/python/TrkEMStep_cff.py
+++ b/RecoHGCal/TICL/python/TrkEMStep_cff.py
@@ -3,7 +3,6 @@ import FWCore.ParameterSet.Config as cms
 from RecoHGCal.TICL.TICLSeedingRegions_cff import ticlSeedingTrk, ticlSeedingTrkHFNose
 from RecoHGCal.TICL.trackstersProducer_cfi import trackstersProducer as _trackstersProducer
 from RecoHGCal.TICL.filteredLayerClustersProducer_cfi import filteredLayerClustersProducer as _filteredLayerClustersProducer
-from RecoHGCal.TICL.multiClustersFromTrackstersProducer_cfi import multiClustersFromTrackstersProducer as _multiClustersFromTrackstersProducer
 
 # CLUSTER FILTERING/MASKING
 
@@ -37,17 +36,9 @@ ticlTrackstersTrkEM = _trackstersProducer.clone(
     algo_verbosity = 0,
 )
 
-
-# MULTICLUSTERS
-
-ticlMultiClustersFromTrackstersTrkEM = _multiClustersFromTrackstersProducer.clone(
-    Tracksters = "ticlTrackstersTrkEM"
-)
-
 ticlTrkEMStepTask = cms.Task(ticlSeedingTrk
     ,filteredLayerClustersTrkEM
-    ,ticlTrackstersTrkEM
-    ,ticlMultiClustersFromTrackstersTrkEM)
+    ,ticlTrackstersTrkEM)
 
 filteredLayerClustersHFNoseTrkEM = filteredLayerClustersTrkEM.clone(
     LayerClusters = 'hgcalLayerClustersHFNose',

--- a/RecoHGCal/TICL/python/TrkStep_cff.py
+++ b/RecoHGCal/TICL/python/TrkStep_cff.py
@@ -4,7 +4,6 @@ from RecoHGCal.TICL.TICLSeedingRegions_cff import ticlSeedingTrk
 from RecoHGCal.TICL.ticlLayerTileProducer_cfi import ticlLayerTileProducer as _ticlLayerTileProducer
 from RecoHGCal.TICL.trackstersProducer_cfi import trackstersProducer as _trackstersProducer
 from RecoHGCal.TICL.filteredLayerClustersProducer_cfi import filteredLayerClustersProducer as _filteredLayerClustersProducer
-from RecoHGCal.TICL.multiClustersFromTrackstersProducer_cfi import multiClustersFromTrackstersProducer as _multiClustersFromTrackstersProducer
 
 # CLUSTER FILTERING/MASKING
 
@@ -35,15 +34,8 @@ ticlTrackstersTrk = _trackstersProducer.clone(
   itername = "Trk"
 )
 
-# MULTICLUSTERS
-
-ticlMultiClustersFromTrackstersTrk = _multiClustersFromTrackstersProducer.clone(
-    Tracksters = "ticlTrackstersTrk"
-)
-
 ticlTrkStepTask = cms.Task(ticlSeedingTrk
     ,filteredLayerClustersTrk
-    ,ticlTrackstersTrk
-    ,ticlMultiClustersFromTrackstersTrk)
+    ,ticlTrackstersTrk)
 
 

--- a/RecoHGCal/TICL/python/iterativeTICL_cff.py
+++ b/RecoHGCal/TICL/python/iterativeTICL_cff.py
@@ -9,15 +9,11 @@ from RecoHGCal.TICL.HADStep_cff import *
 from RecoHGCal.TICL.ticlLayerTileProducer_cfi import ticlLayerTileProducer
 from RecoHGCal.TICL.pfTICLProducer_cfi import pfTICLProducer as _pfTICLProducer
 from RecoHGCal.TICL.trackstersMergeProducer_cfi import trackstersMergeProducer as _trackstersMergeProducer
-from RecoHGCal.TICL.multiClustersFromTrackstersProducer_cfi import multiClustersFromTrackstersProducer as _multiClustersFromTrackstersProducer
 
 ticlLayerTileTask = cms.Task(ticlLayerTileProducer)
 
 ticlTrackstersMerge = _trackstersMergeProducer.clone()
-ticlMultiClustersFromTrackstersMerge = _multiClustersFromTrackstersProducer.clone(
-    Tracksters = "ticlTrackstersMerge"
-)
-ticlTracksterMergeTask = cms.Task(ticlTrackstersMerge, ticlMultiClustersFromTrackstersMerge)
+ticlTracksterMergeTask = cms.Task(ticlTrackstersMerge)
 
 
 pfTICL = _pfTICLProducer.clone()

--- a/RecoHGCal/TICL/python/ticl_iterations.py
+++ b/RecoHGCal/TICL/python/ticl_iterations.py
@@ -14,7 +14,6 @@ from RecoHGCal.TICL.ticlSeedingRegionProducer_cfi import ticlSeedingRegionProduc
 from RecoHGCal.TICL.ticlLayerTileProducer_cfi import ticlLayerTileProducer
 from RecoHGCal.TICL.trackstersProducer_cfi import trackstersProducer
 from RecoHGCal.TICL.filteredLayerClustersProducer_cfi import filteredLayerClustersProducer
-from RecoHGCal.TICL.multiClustersFromTrackstersProducer_cfi import multiClustersFromTrackstersProducer
 from RecoHGCal.TICL.ticlCandidateFromTrackstersProducer_cfi import ticlCandidateFromTrackstersProducer
 from RecoHGCal.TICL.pfTICLProducer_cfi import pfTICLProducer
 from Validation.HGCalValidation.ticlPFValidationDefault_cfi import ticlPFValidationDefault as ticlPFValidation
@@ -22,7 +21,7 @@ from Validation.HGCalValidation.ticlPFValidationDefault_cfi import ticlPFValidat
 ## withReco: requires full reco of the event to run this part
 ## i.e. collections of generalTracks can be accessed
 def TICL_iterations_withReco(process):
-  process.FEVTDEBUGHLTEventContent.outputCommands.extend(['keep *_multiClustersFromTracksters*_*_*',
+  process.FEVTDEBUGHLTEventContent.outputCommands.extend([
     'keep *_ticlCandidateFromTrackstersProducer*_*_*',
     'keep *_pfTICLProducer*_*_*'])
 
@@ -47,11 +46,6 @@ def TICL_iterations_withReco(process):
     min_cos_pointing = 0.9
   )
 
-  process.multiClustersFromTrackstersTrk = multiClustersFromTrackstersProducer.clone(
-      label = "TrkMultiClustersFromTracksterByCA",
-      Tracksters = "trackstersTrk"
-  )
-
   process.ticlSeedingGlobal = ticlSeedingRegionProducer.clone(
     algoId = 2
   )
@@ -73,11 +67,6 @@ def TICL_iterations_withReco(process):
       out_in_dfs = False,
   )
 
-  process.multiClustersFromTrackstersMIP = multiClustersFromTrackstersProducer.clone(
-      label = "MIPMultiClustersFromTracksterByCA",
-      Tracksters = "trackstersMIP"
-  )
-
   process.filteredLayerClusters = filteredLayerClustersProducer.clone(
       clusterFilter = "ClusterFilterByAlgoAndSize",
       min_cluster_size = 2,
@@ -97,11 +86,6 @@ def TICL_iterations_withReco(process):
       min_cos_pointing = 0.9 # ~26 degrees
   )
 
-  process.multiClustersFromTrackstersEM = multiClustersFromTrackstersProducer.clone(
-      Tracksters = "trackstersEM"
-  )
-
-
   process.trackstersHAD = trackstersProducer.clone(
       filtered_mask = "filteredLayerClusters:algo8",
       seeding_regions = "ticlSeedingGlobal",
@@ -109,10 +93,6 @@ def TICL_iterations_withReco(process):
       min_layers_per_trackster = 10,
       min_cos_theta = 0.8, 
       min_cos_pointing = 0.7
-  )
-
-  process.multiClustersFromTrackstersHAD = multiClustersFromTrackstersProducer.clone(
-      Tracksters = "trackstersHAD"
   )
 
   process.ticlCandidateFromTrackstersProducer = ticlCandidateFromTrackstersProducer.clone()
@@ -125,16 +105,12 @@ def TICL_iterations_withReco(process):
       process.ticlSeedingTrk,
       process.filteredLayerClustersTrk,
       process.trackstersTrk,
-      process.multiClustersFromTrackstersTrk,
       process.ticlSeedingGlobal,
       process.filteredLayerClustersMIP,
       process.trackstersMIP,
-      process.multiClustersFromTrackstersMIP,
       process.filteredLayerClusters,
       process.trackstersEM,
-      process.multiClustersFromTrackstersEM,
       process.trackstersHAD,
-      process.multiClustersFromTrackstersHAD,
       process.ticlCandidateFromTrackstersProducer,
       process.pfTICLProducer)
 
@@ -154,8 +130,6 @@ def TICL_iterations_withReco(process):
 ## TICL_iterations: to be run with local HGCAL reco only
 ## i.e. collections of generalTracks (track-seeded iteration) NOT available
 def TICL_iterations(process):
-  process.FEVTDEBUGHLTEventContent.outputCommands.extend(['keep *_multiClustersFromTracksters*_*_*'])
-
   process.ticlLayerTileProducer = ticlLayerTileProducer.clone()
 
   process.ticlSeedingGlobal = ticlSeedingRegionProducer.clone(
@@ -177,11 +151,6 @@ def TICL_iterations(process):
       min_cos_theta = 0.99, # ~10 degrees
   )
 
-  process.multiClustersFromTrackstersMIP = multiClustersFromTrackstersProducer.clone(
-      label = "MIPMultiClustersFromTracksterByCA",
-      Tracksters = "trackstersMIP"
-  )
-
   process.filteredLayerClusters = filteredLayerClustersProducer.clone(
       clusterFilter = "ClusterFilterByAlgoAndSize",
       min_cluster_size = 2,
@@ -199,10 +168,6 @@ def TICL_iterations(process):
       min_cos_pointing = 0.7
   )
 
-  process.multiClustersFromTracksters = multiClustersFromTrackstersProducer.clone(
-      Tracksters = "tracksters"
-  )
-
   process.HGCalUncalibRecHit = HGCalUncalibRecHit
   process.HGCalRecHit = HGCalRecHit
   process.hgcalLayerClusters = hgcalLayerClusters
@@ -214,10 +179,8 @@ def TICL_iterations(process):
       process.ticlLayerTileProducer,
       process.ticlSeedingGlobal,
       process.trackstersMIP,
-      process.multiClustersFromTrackstersMIP,
       process.filteredLayerClusters,
       process.tracksters,
-      process.multiClustersFromTracksters,
       process.hgcalMultiClusters)
   process.schedule = cms.Schedule(process.raw2digi_step,process.FEVTDEBUGHLToutput_step)
   process.schedule.associate(process.TICL_Task)

--- a/RecoParticleFlow/PFClusterProducer/plugins/PFClusterFromHGCalTrackster.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/PFClusterFromHGCalTrackster.cc
@@ -47,12 +47,13 @@ void PFClusterFromHGCalTrackster::buildClusters(const edm::Handle<reco::PFRecHit
     reco::PFCluster& back = output.back();
 
     std::vector<std::pair<DetId, float> > hitsAndFractions;
-    for (uint8_t lcId = 0; lcId < tst.vertices().size(); ++lcId) {
-      const auto fraction = 1.f / tst.vertex_multiplicity(lcId);
-      for (const auto& cell : clusters[tst.vertices(lcId)].hitsAndFractions()) {
+    int iLC =0;
+    std::for_each(std::begin(tst.vertices()), std::end(tst.vertices()), [&](unsigned int lcId) {
+      const auto fraction = 1.f / tst.vertex_multiplicity(iLC++);
+      for (const auto& cell : clusters[lcId].hitsAndFractions()) {
         hitsAndFractions.emplace_back(cell.first, cell.second * fraction);
       }
-    }
+    });
 
     for (const auto& hAndF : hitsAndFractions) {
       auto itr = detIdToIndex.find(hAndF.first);

--- a/RecoParticleFlow/PFClusterProducer/plugins/PFClusterFromHGCalTrackster.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/PFClusterFromHGCalTrackster.cc
@@ -11,9 +11,9 @@ void PFClusterFromHGCalTrackster::updateEvent(const edm::Event& ev) {
 }
 
 void PFClusterFromHGCalTrackster::buildClusters(const edm::Handle<reco::PFRecHitCollection>& input,
-                                                   const std::vector<bool>& rechitMask,
-                                                   const std::vector<bool>& seedable,
-                                                   reco::PFClusterCollection& output) {
+                                                const std::vector<bool>& rechitMask,
+                                                const std::vector<bool>& seedable,
+                                                reco::PFClusterCollection& output) {
   auto const& hits = *input;
 
   const auto& tracksters = *trackstersH_;

--- a/RecoParticleFlow/PFClusterProducer/plugins/PFClusterFromHGCalTrackster.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/PFClusterFromHGCalTrackster.cc
@@ -47,7 +47,7 @@ void PFClusterFromHGCalTrackster::buildClusters(const edm::Handle<reco::PFRecHit
     reco::PFCluster& back = output.back();
 
     std::vector<std::pair<DetId, float> > hitsAndFractions;
-    int iLC =0;
+    int iLC = 0;
     std::for_each(std::begin(tst.vertices()), std::end(tst.vertices()), [&](unsigned int lcId) {
       const auto fraction = 1.f / tst.vertex_multiplicity(iLC++);
       for (const auto& cell : clusters[lcId].hitsAndFractions()) {

--- a/RecoParticleFlow/PFClusterProducer/plugins/PFClusterFromHGCalTrackster.h
+++ b/RecoParticleFlow/PFClusterProducer/plugins/PFClusterFromHGCalTrackster.h
@@ -1,27 +1,26 @@
-#ifndef __RecoParticleFlow_PFClusterProducer_PFClusterFromHGCalMultiCluster_H__
-#define __RecoParticleFlow_PFClusterProducer_PFClusterFromHGCalMultiCluster_H__
+#ifndef __RecoParticleFlow_PFClusterProducer_PFClusterFromHGCalTrackster_H__
+#define __RecoParticleFlow_PFClusterProducer_PFClusterFromHGCalTrackster_H__
 
 #include "DataFormats/HGCalReco/interface/Trackster.h"
-#include "DataFormats/ParticleFlowReco/interface/HGCalMultiCluster.h"
 #include "DataFormats/ParticleFlowReco/interface/PFRecHitFraction.h"
 #include "RecoParticleFlow/PFClusterProducer/interface/InitialClusteringStepBase.h"
 
-class PFClusterFromHGCalMultiCluster : public InitialClusteringStepBase {
+class PFClusterFromHGCalTrackster : public InitialClusteringStepBase {
 public:
-  PFClusterFromHGCalMultiCluster(const edm::ParameterSet& conf, edm::ConsumesCollector& sumes)
+  PFClusterFromHGCalTrackster(const edm::ParameterSet& conf, edm::ConsumesCollector& sumes)
       : InitialClusteringStepBase(conf, sumes) {
     filterByTracksterPID_ = conf.getParameter<bool>("filterByTracksterPID");
     pid_threshold_ = conf.getParameter<double>("pid_threshold");
     filter_on_categories_ = conf.getParameter<std::vector<int> >("filter_on_categories");
 
-    clusterToken_ =
-        sumes.consumes<std::vector<reco::HGCalMultiCluster> >(conf.getParameter<edm::InputTag>("clusterSrc"));
     tracksterToken_ = sumes.consumes<std::vector<ticl::Trackster> >(conf.getParameter<edm::InputTag>("tracksterSrc"));
+    clusterToken_ =
+        sumes.consumes<reco::CaloClusterCollection>(conf.getParameter<edm::InputTag>("clusterSrc"));
   }
 
-  ~PFClusterFromHGCalMultiCluster() override {}
-  PFClusterFromHGCalMultiCluster(const PFClusterFromHGCalMultiCluster&) = delete;
-  PFClusterFromHGCalMultiCluster& operator=(const PFClusterFromHGCalMultiCluster&) = delete;
+  ~PFClusterFromHGCalTrackster() override {}
+  PFClusterFromHGCalTrackster(const PFClusterFromHGCalTrackster&) = delete;
+  PFClusterFromHGCalTrackster& operator=(const PFClusterFromHGCalTrackster&) = delete;
 
   void updateEvent(const edm::Event&) final;
 
@@ -35,13 +34,13 @@ private:
   float pid_threshold_;
   std::vector<int> filter_on_categories_;
 
-  edm::EDGetTokenT<std::vector<reco::HGCalMultiCluster> > clusterToken_;
-  edm::Handle<std::vector<reco::HGCalMultiCluster> > clusterH_;
-
   edm::EDGetTokenT<std::vector<ticl::Trackster> > tracksterToken_;
   edm::Handle<std::vector<ticl::Trackster> > trackstersH_;
+
+  edm::EDGetTokenT<reco::CaloClusterCollection> clusterToken_;
+  edm::Handle<reco::CaloClusterCollection> clusterH_;
 };
 
-DEFINE_EDM_PLUGIN(InitialClusteringStepFactory, PFClusterFromHGCalMultiCluster, "PFClusterFromHGCalMultiCluster");
+DEFINE_EDM_PLUGIN(InitialClusteringStepFactory, PFClusterFromHGCalTrackster, "PFClusterFromHGCalTrackster");
 
 #endif

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterHGC_cfi.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterHGC_cfi.py
@@ -44,12 +44,12 @@ _positionCalcPCA_HGCal = cms.PSet(
         updateTiming = cms.bool(False)
 )
 
-_hgcalMultiClusterMapper_HGCal = cms.PSet(
-    algoName = cms.string("PFClusterFromHGCalMultiCluster"),
+_hgcalTracksterMapper_HGCal = cms.PSet(
+    algoName = cms.string("PFClusterFromHGCalTrackster"),
     thresholdsByDetector = cms.VPSet(
     ),
-    clusterSrc = cms.InputTag("ticlMultiClustersFromTrackstersMerge"),
     tracksterSrc = cms.InputTag("ticlTrackstersMerge"),
+    clusterSrc = cms.InputTag("hgcalLayerClusters"),
     filterByTracksterPID = cms.bool(False),
     pid_threshold = cms.double(0.8),
     filter_on_categories = cms.vint32([0, 1]),
@@ -68,5 +68,5 @@ particleFlowClusterHGCal = cms.EDProducer(
     )
 
 particleFlowClusterHGCalFromMultiCl = particleFlowClusterHGCal.clone(
-    initialClusteringStep = _hgcalMultiClusterMapper_HGCal
+    initialClusteringStep = _hgcalTracksterMapper_HGCal
 )

--- a/Validation/HGCalValidation/interface/HGCalValidator.h
+++ b/Validation/HGCalValidation/interface/HGCalValidator.h
@@ -16,7 +16,7 @@
 #include "RecoLocalCalo/HGCalRecAlgos/interface/RecHitTools.h"
 #include "DataFormats/ParticleFlowReco/interface/PFCluster.h"
 #include "DataFormats/ParticleFlowCandidate/interface/PFCandidate.h"
-#include "DataFormats/ParticleFlowReco/interface/HGCalMultiCluster.h"
+#include "DataFormats/HGCalReco/interface/Trackster.h"
 #include "SimDataFormats/CaloAnalysis/interface/CaloParticle.h"
 #include "SimDataFormats/CaloAnalysis/interface/SimCluster.h"
 #include "SimDataFormats/Vertex/interface/SimVertex.h"
@@ -62,7 +62,7 @@ public:
 protected:
   edm::ESGetToken<CaloGeometry, CaloGeometryRecord> caloGeomToken_;
   edm::InputTag label_lcl;
-  std::vector<edm::InputTag> label_mcl;
+  std::vector<edm::InputTag> label_tst;
   edm::InputTag associator_;
   edm::InputTag associatorSim_;
   const bool SaveGeneralInfo_;
@@ -70,14 +70,14 @@ protected:
   const bool doCaloParticleSelection_;
   const bool doSimClustersPlots_;
   const bool doLayerClustersPlots_;
-  const bool doMultiClustersPlots_;
+  const bool doTrackstersPlots_;
   std::vector<edm::InputTag> label_clustersmask;
   const edm::FileInPath cummatbudinxo_;
 
   std::vector<edm::EDGetTokenT<reco::CaloClusterCollection>> labelToken;
   edm::EDGetTokenT<std::vector<SimCluster>> simClusters_;
   edm::EDGetTokenT<reco::CaloClusterCollection> layerclusters_;
-  std::vector<edm::EDGetTokenT<std::vector<reco::HGCalMultiCluster>>> label_mclTokens;
+  std::vector<edm::EDGetTokenT<ticl::TracksterCollection>> label_tstTokens;
   edm::EDGetTokenT<std::vector<CaloParticle>> label_cp_effic;
   edm::EDGetTokenT<std::vector<CaloParticle>> label_cp_fake;
   edm::EDGetTokenT<std::vector<SimVertex>> simVertices_;

--- a/Validation/HGCalValidation/interface/HGCalValidator.h
+++ b/Validation/HGCalValidation/interface/HGCalValidator.h
@@ -75,7 +75,7 @@ protected:
   const edm::FileInPath cummatbudinxo_;
 
   std::vector<edm::EDGetTokenT<reco::CaloClusterCollection>> labelToken;
-  edm::EDGetTokenT<std::vector<SimCluster>> simclusters_;
+  edm::EDGetTokenT<std::vector<SimCluster>> simClusters_;
   edm::EDGetTokenT<reco::CaloClusterCollection> layerclusters_;
   std::vector<edm::EDGetTokenT<std::vector<reco::HGCalMultiCluster>>> label_mclTokens;
   edm::EDGetTokenT<std::vector<CaloParticle>> label_cp_effic;

--- a/Validation/HGCalValidation/interface/HGVHistoProducerAlgo.h
+++ b/Validation/HGCalValidation/interface/HGVHistoProducerAlgo.h
@@ -17,7 +17,7 @@
 #include "DataFormats/HGCRecHit/interface/HGCRecHitCollections.h"
 #include "DataFormats/ForwardDetId/interface/HGCalDetId.h"
 #include "DataFormats/HGCRecHit/interface/HGCRecHit.h"
-#include "DataFormats/ParticleFlowReco/interface/HGCalMultiCluster.h"
+#include "DataFormats/HGCalReco/interface/Trackster.h"
 
 #include "RecoLocalCalo/HGCalRecAlgos/interface/RecHitTools.h"
 #include "SimDataFormats/CaloAnalysis/interface/CaloParticle.h"
@@ -138,54 +138,54 @@ struct HGVHistoProducerAlgoHistograms {
   std::vector<std::unordered_map<int, dqm::reco::MonitorElement*>> h_sharedenergy_simcluster2layercl_vs_eta_perlayer;
   std::vector<std::unordered_map<int, dqm::reco::MonitorElement*>> h_sharedenergy_simcluster2layercl_vs_phi_perlayer;
 
-  //For multiclusters
-  std::vector<dqm::reco::MonitorElement*> h_score_multicl2caloparticle;
-  std::vector<dqm::reco::MonitorElement*> h_score_caloparticle2multicl;
-  std::vector<dqm::reco::MonitorElement*> h_energy_vs_score_multicl2caloparticle;
-  std::vector<dqm::reco::MonitorElement*> h_energy_vs_score_caloparticle2multicl;
-  std::vector<dqm::reco::MonitorElement*> h_num_multicl_eta;
-  std::vector<dqm::reco::MonitorElement*> h_num_multicl_phi;
-  std::vector<dqm::reco::MonitorElement*> h_numMerge_multicl_eta;
-  std::vector<dqm::reco::MonitorElement*> h_numMerge_multicl_phi;
-  std::vector<dqm::reco::MonitorElement*> h_sharedenergy_multicl2caloparticle;
-  std::vector<dqm::reco::MonitorElement*> h_sharedenergy_caloparticle2multicl;
-  std::vector<dqm::reco::MonitorElement*> h_sharedenergy_caloparticle2multicl_assoc;
-  std::vector<dqm::reco::MonitorElement*> h_sharedenergy_multicl2caloparticle_vs_eta;
-  std::vector<dqm::reco::MonitorElement*> h_sharedenergy_multicl2caloparticle_vs_phi;
-  std::vector<dqm::reco::MonitorElement*> h_sharedenergy_caloparticle2multicl_vs_eta;
-  std::vector<dqm::reco::MonitorElement*> h_sharedenergy_caloparticle2multicl_vs_phi;
-  std::vector<dqm::reco::MonitorElement*> h_denom_multicl_eta;
-  std::vector<dqm::reco::MonitorElement*> h_denom_multicl_phi;
+  //For Tracksters
+  std::vector<dqm::reco::MonitorElement*> h_score_trackster2caloparticle;
+  std::vector<dqm::reco::MonitorElement*> h_score_caloparticle2trackster;
+  std::vector<dqm::reco::MonitorElement*> h_energy_vs_score_trackster2caloparticle;
+  std::vector<dqm::reco::MonitorElement*> h_energy_vs_score_caloparticle2trackster;
+  std::vector<dqm::reco::MonitorElement*> h_num_trackster_eta;
+  std::vector<dqm::reco::MonitorElement*> h_num_trackster_phi;
+  std::vector<dqm::reco::MonitorElement*> h_numMerge_trackster_eta;
+  std::vector<dqm::reco::MonitorElement*> h_numMerge_trackster_phi;
+  std::vector<dqm::reco::MonitorElement*> h_sharedenergy_trackster2caloparticle;
+  std::vector<dqm::reco::MonitorElement*> h_sharedenergy_caloparticle2trackster;
+  std::vector<dqm::reco::MonitorElement*> h_sharedenergy_caloparticle2trackster_assoc;
+  std::vector<dqm::reco::MonitorElement*> h_sharedenergy_trackster2caloparticle_vs_eta;
+  std::vector<dqm::reco::MonitorElement*> h_sharedenergy_trackster2caloparticle_vs_phi;
+  std::vector<dqm::reco::MonitorElement*> h_sharedenergy_caloparticle2trackster_vs_eta;
+  std::vector<dqm::reco::MonitorElement*> h_sharedenergy_caloparticle2trackster_vs_phi;
+  std::vector<dqm::reco::MonitorElement*> h_denom_trackster_eta;
+  std::vector<dqm::reco::MonitorElement*> h_denom_trackster_phi;
   std::vector<dqm::reco::MonitorElement*> h_num_caloparticle_eta;
   std::vector<dqm::reco::MonitorElement*> h_num_caloparticle_phi;
-  std::vector<dqm::reco::MonitorElement*> h_numDup_multicl_eta;
-  std::vector<dqm::reco::MonitorElement*> h_numDup_multicl_phi;
+  std::vector<dqm::reco::MonitorElement*> h_numDup_trackster_eta;
+  std::vector<dqm::reco::MonitorElement*> h_numDup_trackster_phi;
   std::vector<dqm::reco::MonitorElement*> h_denom_caloparticle_eta;
   std::vector<dqm::reco::MonitorElement*> h_denom_caloparticle_phi;
-  std::vector<dqm::reco::MonitorElement*> h_multiclusternum;
-  std::vector<dqm::reco::MonitorElement*> h_contmulticlusternum;
-  std::vector<dqm::reco::MonitorElement*> h_noncontmulticlusternum;
-  std::vector<dqm::reco::MonitorElement*> h_clusternum_in_multicluster;
-  std::vector<std::unordered_map<int, dqm::reco::MonitorElement*>> h_clusternum_in_multicluster_perlayer;
-  std::vector<dqm::reco::MonitorElement*> h_multiplicityOfLCinMCL;
+  std::vector<dqm::reco::MonitorElement*> h_tracksternum;
+  std::vector<dqm::reco::MonitorElement*> h_conttracksternum;
+  std::vector<dqm::reco::MonitorElement*> h_nonconttracksternum;
+  std::vector<dqm::reco::MonitorElement*> h_clusternum_in_trackster;
+  std::vector<std::unordered_map<int, dqm::reco::MonitorElement*>> h_clusternum_in_trackster_perlayer;
+  std::vector<dqm::reco::MonitorElement*> h_multiplicityOfLCinTST;
   std::vector<dqm::reco::MonitorElement*> h_multiplicity_numberOfEventsHistogram;
   std::vector<dqm::reco::MonitorElement*> h_multiplicity_zminus_numberOfEventsHistogram;
   std::vector<dqm::reco::MonitorElement*> h_multiplicity_zplus_numberOfEventsHistogram;
-  std::vector<dqm::reco::MonitorElement*> h_multiplicityOfLCinMCL_vs_layercluster;
-  std::vector<dqm::reco::MonitorElement*> h_multiplicityOfLCinMCL_vs_layercluster_zminus;
-  std::vector<dqm::reco::MonitorElement*> h_multiplicityOfLCinMCL_vs_layercluster_zplus;
-  std::vector<dqm::reco::MonitorElement*> h_multiplicityOfLCinMCL_vs_layerclusterenergy;
-  std::vector<dqm::reco::MonitorElement*> h_clusternum_in_multicluster_vs_layer;
-  std::vector<dqm::reco::MonitorElement*> h_multicluster_pt;
-  std::vector<dqm::reco::MonitorElement*> h_multicluster_eta;
-  std::vector<dqm::reco::MonitorElement*> h_multicluster_phi;
-  std::vector<dqm::reco::MonitorElement*> h_multicluster_energy;
-  std::vector<dqm::reco::MonitorElement*> h_multicluster_x;
-  std::vector<dqm::reco::MonitorElement*> h_multicluster_y;
-  std::vector<dqm::reco::MonitorElement*> h_multicluster_z;
-  std::vector<dqm::reco::MonitorElement*> h_multicluster_firstlayer;
-  std::vector<dqm::reco::MonitorElement*> h_multicluster_lastlayer;
-  std::vector<dqm::reco::MonitorElement*> h_multicluster_layersnum;
+  std::vector<dqm::reco::MonitorElement*> h_multiplicityOfLCinTST_vs_layercluster;
+  std::vector<dqm::reco::MonitorElement*> h_multiplicityOfLCinTST_vs_layercluster_zminus;
+  std::vector<dqm::reco::MonitorElement*> h_multiplicityOfLCinTST_vs_layercluster_zplus;
+  std::vector<dqm::reco::MonitorElement*> h_multiplicityOfLCinTST_vs_layerclusterenergy;
+  std::vector<dqm::reco::MonitorElement*> h_clusternum_in_trackster_vs_layer;
+  std::vector<dqm::reco::MonitorElement*> h_trackster_pt;
+  std::vector<dqm::reco::MonitorElement*> h_trackster_eta;
+  std::vector<dqm::reco::MonitorElement*> h_trackster_phi;
+  std::vector<dqm::reco::MonitorElement*> h_trackster_energy;
+  std::vector<dqm::reco::MonitorElement*> h_trackster_x;
+  std::vector<dqm::reco::MonitorElement*> h_trackster_y;
+  std::vector<dqm::reco::MonitorElement*> h_trackster_z;
+  std::vector<dqm::reco::MonitorElement*> h_trackster_firstlayer;
+  std::vector<dqm::reco::MonitorElement*> h_trackster_lastlayer;
+  std::vector<dqm::reco::MonitorElement*> h_trackster_layersnum;
 };
 
 using Density = hgcal_clustering::Density;
@@ -226,7 +226,7 @@ public:
                                    unsigned int layers,
                                    std::vector<int> thicknesses);
 
-  void bookMultiClusterHistos(DQMStore::IBooker& ibook, Histograms& histograms, unsigned int layers);
+  void bookTracksterHistos(DQMStore::IBooker& ibook, Histograms& histograms, unsigned int layers);
 
   void layerClusters_to_CaloParticles(const Histograms& histograms,
                                       edm::Handle<reco::CaloClusterCollection> clusterHandle,
@@ -251,14 +251,15 @@ public:
                                     unsigned int layers,
                                     const hgcal::RecoToSimCollectionWithSimClusters& recSimColl,
                                     const hgcal::SimToRecoCollectionWithSimClusters& simRecColl) const;
-  void multiClusters_to_CaloParticles(const Histograms& histograms,
-                                      int count,
-                                      const std::vector<reco::HGCalMultiCluster>& multiClusters,
-                                      std::vector<CaloParticle> const& cP,
-                                      std::vector<size_t> const& cPIndices,
-                                      std::vector<size_t> const& cPSelectedIndices,
-                                      std::unordered_map<DetId, const HGCRecHit*> const&,
-                                      unsigned int layers) const;
+  void tracksters_to_CaloParticles(const Histograms& histograms,
+                                   int count,
+                                   const ticl::TracksterCollection& Tracksters,
+                                   const reco::CaloClusterCollection& layerClusters,
+                                   std::vector<CaloParticle> const& cP,
+                                   std::vector<size_t> const& cPIndices,
+                                   std::vector<size_t> const& cPSelectedIndices,
+                                   std::unordered_map<DetId, const HGCRecHit*> const&,
+                                   unsigned int layers) const;
   void fill_info_histos(const Histograms& histograms, unsigned int layers) const;
   void fill_caloparticle_histos(const Histograms& histograms,
                                 int pdgid,
@@ -298,9 +299,10 @@ public:
                                          const hgcal::RecoToSimCollectionWithSimClusters& recSimColl,
                                          const hgcal::SimToRecoCollectionWithSimClusters& simRecColl) const;
   void fill_cluster_histos(const Histograms& histograms, int count, const reco::CaloCluster& cluster) const;
-  void fill_multi_cluster_histos(const Histograms& histograms,
+  void fill_trackster_histos(const Histograms& histograms,
                                  int count,
-                                 const std::vector<reco::HGCalMultiCluster>& multiClusters,
+                                 const ticl::TracksterCollection& Tracksters,
+                                 const reco::CaloClusterCollection& layerClusters,
                                  std::vector<CaloParticle> const& cP,
                                  std::vector<size_t> const& cPIndices,
                                  std::vector<size_t> const& cPSelectedIndices,
@@ -319,9 +321,9 @@ public:
     float fraction;
   };
 
-  struct detIdInfoInMultiCluster {
-    bool operator==(const detIdInfoInMultiCluster& o) const { return multiclusterId == o.multiclusterId; };
-    unsigned int multiclusterId;
+  struct detIdInfoInTrackster {
+    bool operator==(const detIdInfoInTrackster& o) const { return tracksterId == o.tracksterId; };
+    unsigned int tracksterId;
     long unsigned int clusterId;
     float fraction;
   };
@@ -368,8 +370,8 @@ private:
   int nintScore_;
   double minSharedEneFrac_, maxSharedEneFrac_;
   int nintSharedEneFrac_;
-  double minMCLSharedEneFrac_, maxMCLSharedEneFrac_;
-  int nintMCLSharedEneFrac_;
+  double minTSTSharedEneFrac_, maxTSTSharedEneFrac_;
+  int nintTSTSharedEneFrac_;
   double minTotNsimClsperthick_, maxTotNsimClsperthick_;
   int nintTotNsimClsperthick_;
   double minTotNClsperthick_, maxTotNClsperthick_;
@@ -390,16 +392,16 @@ private:
   int nintClEneperthickperlayer_;
   double minCellsEneDensperthick_, maxCellsEneDensperthick_;
   int nintCellsEneDensperthick_;
-  double minTotNMCLs_, maxTotNMCLs_;
-  int nintTotNMCLs_;
-  double minTotNClsinMCLs_, maxTotNClsinMCLs_;
-  int nintTotNClsinMCLs_;
-  double minTotNClsinMCLsperlayer_, maxTotNClsinMCLsperlayer_;
-  int nintTotNClsinMCLsperlayer_;
+  double minTotNTSTs_, maxTotNTSTs_;
+  int nintTotNTSTs_;
+  double minTotNClsinTSTs_, maxTotNClsinTSTs_;
+  int nintTotNClsinTSTs_;
+  double minTotNClsinTSTsperlayer_, maxTotNClsinTSTsperlayer_;
+  int nintTotNClsinTSTsperlayer_;
   double minMplofLCs_, maxMplofLCs_;
   int nintMplofLCs_;
-  double minSizeCLsinMCLs_, maxSizeCLsinMCLs_;
-  int nintSizeCLsinMCLs_;
+  double minSizeCLsinTSTs_, maxSizeCLsinTSTs_;
+  int nintSizeCLsinTSTs_;
   double minClEnepermultiplicity_, maxClEnepermultiplicity_;
   int nintClEnepermultiplicity_;
   double minX_, maxX_;

--- a/Validation/HGCalValidation/interface/HGVHistoProducerAlgo.h
+++ b/Validation/HGCalValidation/interface/HGVHistoProducerAlgo.h
@@ -109,7 +109,7 @@ struct HGVHistoProducerAlgoHistograms {
   std::unordered_map<int, dqm::reco::MonitorElement*> h_caloparticle_lastlayer_matchedtoRecHit;
   std::unordered_map<int, dqm::reco::MonitorElement*> h_caloparticle_layersnum_matchedtoRecHit;
 
-  //For simclusters
+  //For SimClusters
   std::unordered_map<int, dqm::reco::MonitorElement*> h_simclusternum_perlayer;
   std::unordered_map<int, dqm::reco::MonitorElement*> h_simclusternum_perthick;
   dqm::reco::MonitorElement* h_mixedhitssimcluster_zminus;
@@ -244,7 +244,7 @@ public:
                                     edm::Handle<reco::CaloClusterCollection> clusterHandle,
                                     const reco::CaloClusterCollection& clusters,
                                     edm::Handle<std::vector<SimCluster>> simClusterHandle,
-                                    std::vector<SimCluster> const& simclusters,
+                                    std::vector<SimCluster> const& simClusters,
                                     std::vector<size_t> const& sCIndices,
                                     const std::vector<float>& mask,
                                     std::unordered_map<DetId, const HGCRecHit*> const&,
@@ -281,16 +281,16 @@ public:
                                    std::vector<int> thicknesses,
                                    const hgcal::RecoToSimCollection& recSimColl,
                                    const hgcal::SimToRecoCollection& simRecColl) const;
-  void fill_simcluster_histos(const Histograms& histograms,
-                              std::vector<SimCluster> const& simclusters,
+  void fill_simCluster_histos(const Histograms& histograms,
+                              std::vector<SimCluster> const& simClusters,
                               unsigned int layers,
                               std::vector<int> thicknesses) const;
-  void fill_simclusterassosiation_histos(const Histograms& histograms,
+  void fill_simClusterassosiation_histos(const Histograms& histograms,
                                          int count,
                                          edm::Handle<reco::CaloClusterCollection> clusterHandle,
                                          const reco::CaloClusterCollection& clusters,
                                          edm::Handle<std::vector<SimCluster>> simClusterHandle,
-                                         std::vector<SimCluster> const& simclusters,
+                                         std::vector<SimCluster> const& simClusters,
                                          std::vector<size_t> const& sCIndices,
                                          const std::vector<float>& mask,
                                          std::unordered_map<DetId, const HGCRecHit*> const& hitMap,

--- a/Validation/HGCalValidation/interface/HGVHistoProducerAlgo.h
+++ b/Validation/HGCalValidation/interface/HGVHistoProducerAlgo.h
@@ -300,14 +300,14 @@ public:
                                          const hgcal::SimToRecoCollectionWithSimClusters& simRecColl) const;
   void fill_cluster_histos(const Histograms& histograms, int count, const reco::CaloCluster& cluster) const;
   void fill_trackster_histos(const Histograms& histograms,
-                                 int count,
-                                 const ticl::TracksterCollection& Tracksters,
-                                 const reco::CaloClusterCollection& layerClusters,
-                                 std::vector<CaloParticle> const& cP,
-                                 std::vector<size_t> const& cPIndices,
-                                 std::vector<size_t> const& cPSelectedIndices,
-                                 std::unordered_map<DetId, const HGCRecHit*> const&,
-                                 unsigned int layers) const;
+                             int count,
+                             const ticl::TracksterCollection& Tracksters,
+                             const reco::CaloClusterCollection& layerClusters,
+                             std::vector<CaloParticle> const& cP,
+                             std::vector<size_t> const& cPIndices,
+                             std::vector<size_t> const& cPSelectedIndices,
+                             std::unordered_map<DetId, const HGCRecHit*> const&,
+                             unsigned int layers) const;
   double distance2(const double x1, const double y1, const double x2, const double y2) const;
   double distance(const double x1, const double y1, const double x2, const double y2) const;
 

--- a/Validation/HGCalValidation/interface/HGVHistoProducerAlgo.h
+++ b/Validation/HGCalValidation/interface/HGVHistoProducerAlgo.h
@@ -286,7 +286,7 @@ public:
                               std::vector<SimCluster> const& simClusters,
                               unsigned int layers,
                               std::vector<int> thicknesses) const;
-  void fill_simClusterassosiation_histos(const Histograms& histograms,
+  void fill_simClusterAssociation_histos(const Histograms& histograms,
                                          int count,
                                          edm::Handle<reco::CaloClusterCollection> clusterHandle,
                                          const reco::CaloClusterCollection& clusters,

--- a/Validation/HGCalValidation/plugins/HGCalValidator.cc
+++ b/Validation/HGCalValidation/plugins/HGCalValidator.cc
@@ -42,7 +42,7 @@ HGCalValidator::HGCalValidator(const edm::ParameterSet& pset)
 
   density_ = consumes<Density>(edm::InputTag("hgcalLayerClusters"));
 
-  simclusters_ = consumes<std::vector<SimCluster>>(pset.getParameter<edm::InputTag>("label_scl"));
+  simClusters_ = consumes<std::vector<SimCluster>>(pset.getParameter<edm::InputTag>("label_scl"));
 
   layerclusters_ = consumes<reco::CaloClusterCollection>(label_lcl);
 
@@ -115,7 +115,7 @@ void HGCalValidator::bookHistograms(DQMStore::IBooker& ibook,
     ibook.setCurrentFolder(dirName_);
   }
 
-  //Booking histograms concerning with simclusters
+  //Booking histograms concerning with simClusters
   if (doSimClustersPlots_) {
     ibook.cd();
     ibook.setCurrentFolder(dirName_ + "simClusters/ClusterLevel");
@@ -147,7 +147,7 @@ void HGCalValidator::bookHistograms(DQMStore::IBooker& ibook,
       histoProducerAlgo_->bookSimClusterAssociationHistos(
           ibook, histograms.histoProducerAlgo, totallayers_to_monitor_, thicknesses_to_monitor_);
     }  //end of loop over masks
-  }    //if for simcluster plots
+  }    //if for simCluster plots
 
   //Booking histograms concerning with hgcal layer clusters
   if (doLayerClustersPlots_) {
@@ -278,8 +278,8 @@ void HGCalValidator::dqmAnalyze(const edm::Event& event,
   //get collections from the event
   //simClusters
   edm::Handle<std::vector<SimCluster>> simClustersHandle;
-  event.getByToken(simclusters_, simClustersHandle);
-  std::vector<SimCluster> const& simclusters = *simClustersHandle;
+  event.getByToken(simClusters_, simClustersHandle);
+  std::vector<SimCluster> const& simClusters = *simClustersHandle;
 
   //Layer clusters
   edm::Handle<reco::CaloClusterCollection> clusterHandle;
@@ -291,16 +291,16 @@ void HGCalValidator::dqmAnalyze(const edm::Event& event,
   event.getByToken(density_, densityHandle);
   const Density& densities = *densityHandle;
 
-  auto nSimClusters = simclusters.size();
+  auto nSimClusters = simClusters.size();
   std::vector<size_t> sCIndices;
   //There shouldn't be any SimTracks from different crossings, but maybe they will be added later.
   //At the moment there should be one SimTrack in each SimCluster.
   for (unsigned int scId = 0; scId < nSimClusters; ++scId) {
-    if (simclusters[scId].g4Tracks()[0].eventId().event() != 0 or
-        simclusters[scId].g4Tracks()[0].eventId().bunchCrossing() != 0) {
+    if (simClusters[scId].g4Tracks()[0].eventId().event() != 0 or
+        simClusters[scId].g4Tracks()[0].eventId().bunchCrossing() != 0) {
       LogDebug("HGCalValidator") << "Excluding SimClusters from event: "
-                                 << simclusters[scId].g4Tracks()[0].eventId().event()
-                                 << " with BX: " << simclusters[scId].g4Tracks()[0].eventId().bunchCrossing()
+                                 << simClusters[scId].g4Tracks()[0].eventId().event()
+                                 << " with BX: " << simClusters[scId].g4Tracks()[0].eventId().bunchCrossing()
                                  << std::endl;
       continue;
     }
@@ -308,11 +308,11 @@ void HGCalValidator::dqmAnalyze(const edm::Event& event,
   }
 
   // ##############################################
-  // fill simcluster histograms
+  // fill simCluster histograms
   // ##############################################
   if (doSimClustersPlots_) {
-    histoProducerAlgo_->fill_simcluster_histos(
-        histograms.histoProducerAlgo, simclusters, totallayers_to_monitor_, thicknesses_to_monitor_);
+    histoProducerAlgo_->fill_simCluster_histos(
+        histograms.histoProducerAlgo, simClusters, totallayers_to_monitor_, thicknesses_to_monitor_);
 
     for (unsigned int ws = 0; ws < label_clustersmask.size(); ws++) {
       const auto& inputClusterMask = event.get(clustersMaskTokens_[ws]);
@@ -324,12 +324,12 @@ void HGCalValidator::dqmAnalyze(const edm::Event& event,
       event.getByToken(associatorMapRtSim, recotosimCollectionH);
       auto recSimColl = *recotosimCollectionH;
 
-      histoProducerAlgo_->fill_simclusterassosiation_histos(histograms.histoProducerAlgo,
+      histoProducerAlgo_->fill_simClusterassosiation_histos(histograms.histoProducerAlgo,
                                                             ws,
                                                             clusterHandle,
                                                             clusters,
                                                             simClustersHandle,
-                                                            simclusters,
+                                                            simClusters,
                                                             sCIndices,
                                                             inputClusterMask,
                                                             *hitMap,
@@ -338,7 +338,7 @@ void HGCalValidator::dqmAnalyze(const edm::Event& event,
                                                             simRecColl);
 
       //General Info on simClusters
-      LogTrace("HGCalValidator") << "\n# of simclusters: " << nSimClusters << " label_clustersmask[ws].label() "
+      LogTrace("HGCalValidator") << "\n# of SimClusters: " << nSimClusters << ", layerClusters mask label: "
                                  << label_clustersmask[ws].label() << "\n";
     }  //end of loop overs masks
   }

--- a/Validation/HGCalValidation/plugins/HGCalValidator.cc
+++ b/Validation/HGCalValidation/plugins/HGCalValidator.cc
@@ -338,8 +338,8 @@ void HGCalValidator::dqmAnalyze(const edm::Event& event,
                                                             simRecColl);
 
       //General Info on simClusters
-      LogTrace("HGCalValidator") << "\n# of SimClusters: " << nSimClusters << ", layerClusters mask label: "
-                                 << label_clustersmask[ws].label() << "\n";
+      LogTrace("HGCalValidator") << "\n# of SimClusters: " << nSimClusters
+                                 << ", layerClusters mask label: " << label_clustersmask[ws].label() << "\n";
     }  //end of loop overs masks
   }
 

--- a/Validation/HGCalValidation/plugins/HGCalValidator.cc
+++ b/Validation/HGCalValidation/plugins/HGCalValidator.cc
@@ -324,7 +324,7 @@ void HGCalValidator::dqmAnalyze(const edm::Event& event,
       event.getByToken(associatorMapRtSim, recotosimCollectionH);
       auto recSimColl = *recotosimCollectionH;
 
-      histoProducerAlgo_->fill_simClusterassosiation_histos(histograms.histoProducerAlgo,
+      histoProducerAlgo_->fill_simClusterAssociation_histos(histograms.histoProducerAlgo,
                                                             ws,
                                                             clusterHandle,
                                                             clusters,

--- a/Validation/HGCalValidation/python/HGCalPostProcessor_cff.py
+++ b/Validation/HGCalValidation/python/HGCalPostProcessor_cff.py
@@ -3,7 +3,7 @@ import FWCore.ParameterSet.Config as cms
 from Validation.HGCalValidation.HGCalSimHitsClient_cff import *
 from Validation.HGCalValidation.HGCalDigiClient_cff    import *
 from Validation.HGCalValidation.HGCalRecHitsClient_cff import *
-from Validation.HGCalValidation.PostProcessorHGCAL_cfi import postProcessorHGCALlayerclusters,postProcessorHGCALsimclusters,postProcessorHGCALmulticlusters
+from Validation.HGCalValidation.PostProcessorHGCAL_cfi import postProcessorHGCALlayerclusters,postProcessorHGCALsimclusters,postProcessorHGCALTracksters
 
 hgcalPostProcessor = cms.Sequence(hgcalSimHitClientEE
     + hgcalSimHitClientHEF
@@ -18,4 +18,4 @@ hgcalPostProcessor = cms.Sequence(hgcalSimHitClientEE
 hgcalValidatorPostProcessor = cms.Sequence(
     postProcessorHGCALlayerclusters+
     postProcessorHGCALsimclusters+
-    postProcessorHGCALmulticlusters)
+    postProcessorHGCALTracksters)

--- a/Validation/HGCalValidation/python/HGCalValidator_cfi.py
+++ b/Validation/HGCalValidation/python/HGCalValidator_cfi.py
@@ -10,8 +10,8 @@ from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
 
 from RecoHGCal.TICL.iterativeTICL_cff import ticlIterLabels, ticlIterLabelsMerge
 
-labelMcl = [cms.InputTag("ticlMultiClustersFromTracksters"+iteration) for iteration in ticlIterLabelsMerge]
-labelMcl.extend(["ticlMultiClustersFromSimTracksters"])
+labelTst = [cms.InputTag("ticlTracksters"+iteration) for iteration in ticlIterLabelsMerge]
+labelTst.extend(["ticlSimTracksters"])
 lcInputMask = [cms.InputTag("ticlTracksters"+iteration) for iteration in ticlIterLabels]
 lcInputMask.extend(["ticlSimTracksters"])
 hgcalValidator = DQMEDAnalyzer(
@@ -22,9 +22,9 @@ hgcalValidator = DQMEDAnalyzer(
     CaloParticleSelectionForEfficiency,
 
     ### reco input configuration ###
-    #2dlayerclusters, pfclusters, multiclusters
+    #2DLayerClusters, PFClusters, Tracksters
     label_lcl = layerClusterCaloParticleAssociation.label_lc,
-    label_mcl = cms.VInputTag(labelMcl),
+    label_tst = cms.VInputTag(labelTst),
 
     associator = cms.untracked.InputTag("layerClusterCaloParticleAssociationProducer"),
 
@@ -40,8 +40,8 @@ hgcalValidator = DQMEDAnalyzer(
     doSimClustersPlots = cms.untracked.bool(True),
     #Layer Cluster related plots
     doLayerClustersPlots = cms.untracked.bool(True),
-    #Multi Cluster related plots
-    doMultiClustersPlots = cms.untracked.bool(True),
+    #Trackster related plots
+    doTrackstersPlots = cms.untracked.bool(True),
 
     #The cumulative material budget in front of each layer. To be more specific, it
     #is the material budget just in front of the active material (not including it).

--- a/Validation/HGCalValidation/python/HGVHistoProducerAlgoBlock_cfi.py
+++ b/Validation/HGCalValidation/python/HGVHistoProducerAlgoBlock_cfi.py
@@ -78,10 +78,10 @@ HGVHistoProducerAlgoBlock = cms.PSet(
     maxSharedEneFrac = cms.double(1.),
     nintSharedEneFrac = cms.int32(100),
 
-    #Same as above for multiclusters
-    minMCLSharedEneFrac = cms.double(0.),
-    maxMCLSharedEneFrac = cms.double(1.0),
-    nintMCLSharedEneFrac = cms.int32(100),
+    #Same as above for tracksters
+    minTSTSharedEneFrac = cms.double(0.),
+    maxTSTSharedEneFrac = cms.double(1.0),
+    nintTSTSharedEneFrac = cms.int32(100),
 
     #Parameters for the total number of simclusters per thickness
     minTotNsimClsperthick = cms.double(0.),
@@ -133,31 +133,31 @@ HGVHistoProducerAlgoBlock = cms.PSet(
     maxCellsEneDensperthick = cms.double(100.),
     nintCellsEneDensperthick = cms.int32(200),
 
-    #Parameters for the total number of multiclusters per event
+    #Parameters for the total number of tracksters per event
     #We always treet one event as two events, one in +z one in -z
-    minTotNMCLs = cms.double(0.),
-    maxTotNMCLs = cms.double(50.),
-    nintTotNMCLs = cms.int32(50),
+    minTotNTSTs = cms.double(0.),
+    maxTotNTSTs = cms.double(50.),
+    nintTotNTSTs = cms.int32(50),
 
-    #Parameters for the total number of layer clusters in multicluster
-    minTotNClsinMCLs = cms.double(0.),
-    maxTotNClsinMCLs = cms.double(400.),
-    nintTotNClsinMCLs = cms.int32(100),
+    #Parameters for the total number of layer clusters in trackster
+    minTotNClsinTSTs = cms.double(0.),
+    maxTotNClsinTSTs = cms.double(400.),
+    nintTotNClsinTSTs = cms.int32(100),
 
-    #Parameters for the total number of layer clusters in multicluster per layer
-    minTotNClsinMCLsperlayer = cms.double(0.),
-    maxTotNClsinMCLsperlayer = cms.double(50.),
-    nintTotNClsinMCLsperlayer = cms.int32(50),
+    #Parameters for the total number of layer clusters in trackster per layer
+    minTotNClsinTSTsperlayer = cms.double(0.),
+    maxTotNClsinTSTsperlayer = cms.double(50.),
+    nintTotNClsinTSTsperlayer = cms.int32(50),
 
-    #Parameters for the multiplicity of layer clusters in multicluster
+    #Parameters for the multiplicity of layer clusters in trackster
     minMplofLCs = cms.double(0.),
     maxMplofLCs = cms.double(20.),
     nintMplofLCs = cms.int32(20),
 
     #Parameters for cluster size
-    minSizeCLsinMCLs = cms.double(0.),
-    maxSizeCLsinMCLs = cms.double(50.),
-    nintSizeCLsinMCLs = cms.int32(50),
+    minSizeCLsinTSTs = cms.double(0.),
+    maxSizeCLsinTSTs = cms.double(50.),
+    nintSizeCLsinTSTs = cms.int32(50),
 
     #Parameters for the energy of a cluster per multiplicity
     minClEnepermultiplicity  = cms.double(0.),

--- a/Validation/HGCalValidation/python/PostProcessorHGCAL_cfi.py
+++ b/Validation/HGCalValidation/python/PostProcessorHGCAL_cfi.py
@@ -45,21 +45,21 @@ postProcessorHGCALsimclusters= DQMEDHarvester('DQMGenericClient',
     outputFileName = cms.untracked.string(""),
     verbose = cms.untracked.uint32(4))
 
-eff_multiclusters = ["effic_eta 'MultiCluster Efficiency vs #eta' Num_CaloParticle_Eta Denom_CaloParticle_Eta"]
-eff_multiclusters.extend(["effic_phi 'MultiCluster Efficiency vs #phi' Num_CaloParticle_Phi Denom_CaloParticle_Phi"])
-eff_multiclusters.extend(["duplicate_eta 'MultiCluster Duplicate(Split) Rate vs #eta' NumDup_MultiCluster_Eta Denom_MultiCluster_Eta"])
-eff_multiclusters.extend(["duplicate_phi 'MultiCluster Duplicate(Split) Rate vs #phi' NumDup_MultiCluster_Phi Denom_MultiCluster_Phi"])
-eff_multiclusters.extend(["fake_eta 'MultiCluster Fake Rate vs #eta' Num_MultiCluster_Eta Denom_MultiCluster_Eta fake"])
-eff_multiclusters.extend(["fake_phi 'MultiCluster Fake Rate vs #phi'  Num_MultiCluster_Phi Denom_MultiCluster_Phi fake"])
-eff_multiclusters.extend(["merge_eta 'MultiCluster Merge Rate vs #eta' NumMerge_MultiCluster_Eta Denom_MultiCluster_Eta"])
-eff_multiclusters.extend(["merge_phi 'MultiCluster Merge Rate vs #phi' NumMerge_MultiCluster_Phi Denom_MultiCluster_Phi"])
+eff_tracksters = ["effic_eta 'Trackster Efficiency vs #eta' Num_CaloParticle_Eta Denom_CaloParticle_Eta"]
+eff_tracksters.extend(["effic_phi 'Trackster Efficiency vs #phi' Num_CaloParticle_Phi Denom_CaloParticle_Phi"])
+eff_tracksters.extend(["duplicate_eta 'Trackster Duplicate(Split) Rate vs #eta' NumDup_Trackster_Eta Denom_Trackster_Eta"])
+eff_tracksters.extend(["duplicate_phi 'Trackster Duplicate(Split) Rate vs #phi' NumDup_Trackster_Phi Denom_Trackster_Phi"])
+eff_tracksters.extend(["fake_eta 'Trackster Fake Rate vs #eta' Num_Trackster_Eta Denom_Trackster_Eta fake"])
+eff_tracksters.extend(["fake_phi 'Trackster Fake Rate vs #phi'  Num_Trackster_Phi Denom_Trackster_Phi fake"])
+eff_tracksters.extend(["merge_eta 'Trackster Merge Rate vs #eta' NumMerge_Trackster_Eta Denom_Trackster_Eta"])
+eff_tracksters.extend(["merge_phi 'Trackster Merge Rate vs #phi' NumMerge_Trackster_Phi Denom_Trackster_Phi"])
 
-subdirsMult = ['HGCAL/HGCalValidator/hgcalMultiClusters/','HGCAL/HGCalValidator/ticlMultiClustersFromSimTracksters/']
-subdirsMult.extend('HGCAL/HGCalValidator/ticlMultiClustersFromTracksters'+iteration+'/' for iteration in ticlIterLabelsMerge)
+subdirsTracksters = ['HGCAL/HGCalValidator/hgcalTracksters/','HGCAL/HGCalValidator/ticlSimTracksters/']
+subdirsTracksters.extend('HGCAL/HGCalValidator/ticlTracksters'+iteration+'/' for iteration in ticlIterLabelsMerge)
 
-postProcessorHGCALmulticlusters = DQMEDHarvester('DQMGenericClient',
-  subDirs = cms.untracked.vstring(subdirsMult),
-  efficiency = cms.vstring(eff_multiclusters),
+postProcessorHGCALTracksters = DQMEDHarvester('DQMGenericClient',
+  subDirs = cms.untracked.vstring(subdirsTracksters),
+  efficiency = cms.vstring(eff_tracksters),
   resolution = cms.vstring(),
   cumulativeDists = cms.untracked.vstring(),
   noFlowDists = cms.untracked.vstring(),

--- a/Validation/HGCalValidation/python/hgcalPlots.py
+++ b/Validation/HGCalValidation/python/hgcalPlots.py
@@ -1301,7 +1301,7 @@ _merges_zplus_phi = PlotGroup("MergeRate_vs_phi", _mergeplots_zplus_phi, ncols=1
 _merges_zplus = PlotGroup("MergeRate_vs_layer", _mergeplots_zplus, ncols=1)
 
 #--------------------------------------------------------------------------------------------
-# SIMCLUSTERS
+# SimClusters
 #--------------------------------------------------------------------------------------------
 
 _common_sc_score = {"title": "Score SimCluster to LayerClusters in z-",
@@ -1559,7 +1559,7 @@ _common = {"stat": True, "drawStyle": "hist", "staty": 0.65 }
 #--------------------------------------------------------------------------------------------
 # MULTICLUSTERS
 #--------------------------------------------------------------------------------------------
-_common_score = {#"title": "Score CaloParticle to MultiClusters",
+_common_score = {#"title": "Score CaloParticle to Tracksters",
                  "stat": False,
                  "ymin": 0.1,
                  "ymax": 100000,
@@ -1570,11 +1570,11 @@ _common_score = {#"title": "Score CaloParticle to MultiClusters",
                  "ylog": True
                 }
 _common_score.update(_legend_common)
-_score_caloparticle_to_multiclusters = PlotGroup("ScoreCaloParticlesToMultiClusters", [
-        Plot("Score_caloparticle2multicl", **_common_score)
+_score_caloparticle_to_tracksters = PlotGroup("ScoreCaloParticlesToTracksters", [
+        Plot("Score_caloparticle2trackster", **_common_score)
         ], ncols=1)
 
-_common_score = {#"title": "Score MultiCluster to CaloParticles",
+_common_score = {#"title": "Score Trackster to CaloParticles",
                  "stat": False,
                  "ymin": 0.1,
                  "ymax": 100000,
@@ -1585,37 +1585,37 @@ _common_score = {#"title": "Score MultiCluster to CaloParticles",
                  "ylog": True
                 }
 _common_score.update(_legend_common)
-_score_multicluster_to_caloparticles = PlotGroup("ScoreMultiClustersToCaloParticles", [
-        Plot("Score_multicl2caloparticle", **_common_score)
+_score_trackster_to_caloparticles = PlotGroup("ScoreTrackstersToCaloParticles", [
+        Plot("Score_trackster2caloparticle", **_common_score)
         ], ncols=1)
 
-_common_shared= {"title": "Shared Energy CaloParticle To Multi Cluster ",
+_common_shared= {"title": "Shared Energy CaloParticle To Trackster ",
                  "stat": False,
                  "legend": True,
                  "xmin": 0,
                  "xmax": 1.0,
                }
 _common_shared.update(_legend_common)
-_shared_plots = [ Plot("SharedEnergy_caloparticle2multicl", **_common_shared) ]
+_shared_plots = [ Plot("SharedEnergy_caloparticle2trackster", **_common_shared) ]
 _common_shared["xmin"] = -4.0
 _common_shared["xmax"] = 4.0
-_shared_plots.extend([Plot("SharedEnergy_caloparticle2multicl_vs_eta", xtitle="CaloParticle #eta", **_common_shared)])
-_shared_plots.extend([Plot("SharedEnergy_caloparticle2multicl_vs_phi", xtitle="CaloParticle #phi", **_common_shared)])
-_sharedEnergy_caloparticle_to_multicluster = PlotGroup("SharedEnergy_CaloParticleToMultiCluster", _shared_plots, ncols=3)
+_shared_plots.extend([Plot("SharedEnergy_caloparticle2trackster_vs_eta", xtitle="CaloParticle #eta", **_common_shared)])
+_shared_plots.extend([Plot("SharedEnergy_caloparticle2trackster_vs_phi", xtitle="CaloParticle #phi", **_common_shared)])
+_sharedEnergy_caloparticle_to_trackster = PlotGroup("SharedEnergy_CaloParticleToTrackster", _shared_plots, ncols=3)
 
-_common_shared= {"title": "Shared Energy Multi Cluster To CaloParticle ",
+_common_shared= {"title": "Shared Energy Trackster To CaloParticle ",
                  "stat": False,
                  "legend": True,
                  "xmin": 0,
                  "xmax": 1.0,
                 }
 _common_shared.update(_legend_common)
-_shared_plots2 = [Plot("SharedEnergy_multicluster2caloparticle", **_common_shared)]
+_shared_plots2 = [Plot("SharedEnergy_trackster2caloparticle", **_common_shared)]
 _common_shared["xmin"] = -4.0
 _common_shared["xmax"] = 4.0
-_shared_plots2.extend([Plot("SharedEnergy_multicl2caloparticle_vs_eta", xtitle="MultiCluster #eta", **_common_shared)])
-_shared_plots2.extend([Plot("SharedEnergy_multicl2caloparticle_vs_phi", xtitle="MultiCluster #phi", **_common_shared)])
-_sharedEnergy_multicluster_to_caloparticle = PlotGroup("SharedEnergy_MultiClusterToCaloParticle", _shared_plots2, ncols=3)
+_shared_plots2.extend([Plot("SharedEnergy_trackster2caloparticle_vs_eta", xtitle="Trackster #eta", **_common_shared)])
+_shared_plots2.extend([Plot("SharedEnergy_trackster2caloparticle_vs_phi", xtitle="Trackster #phi", **_common_shared)])
+_sharedEnergy_trackster_to_caloparticle = PlotGroup("SharedEnergy_TracksterToCaloParticle", _shared_plots2, ncols=3)
 
 
 _common_assoc = {#"title": "Cell Association Table",
@@ -1660,96 +1660,96 @@ _merges = PlotGroup("MergeRate", _mergeplots, ncols=3)
 _common_energy_score = dict(removeEmptyBins=True, xbinlabelsize=10, xbinlabeloption="d")
 _common_energy_score["ymax"] = 1.
 _common_energy_score["xmax"] = 1.0
-_energyscore_cp2mcl = PlotOnSideGroup("Energy_vs_Score_CaloParticlesToMultiClusters", Plot("Energy_vs_Score_caloparticle2multi", drawStyle="COLZ", adjustMarginRight=0.1, **_common_energy_score), ncols=1)
+_energyscore_cp2mcl = PlotOnSideGroup("Energy_vs_Score_CaloParticlesToTracksters", Plot("Energy_vs_Score_caloparticle2trackster", drawStyle="COLZ", adjustMarginRight=0.1, **_common_energy_score), ncols=1)
 _common_energy_score["ymax"] = 1.
 _common_energy_score["xmax"] = 1.0
-_energyscore_mcl2cp = PlotOnSideGroup("Energy_vs_Score_MultiClustersToCaloParticles", Plot("Energy_vs_Score_multi2caloparticle", drawStyle="COLZ", adjustMarginRight=0.1, **_common_energy_score), ncols=1)
+_energyscore_mcl2cp = PlotOnSideGroup("Energy_vs_Score_TrackstersToCaloParticles", Plot("Energy_vs_Score_trackster2caloparticle", drawStyle="COLZ", adjustMarginRight=0.1, **_common_energy_score), ncols=1)
 
 #Coming back to the usual box definition
 _common = {"stat": True, "drawStyle": "hist", "staty": 0.65 }
 
-_totmulticlusternum = PlotGroup("TotalNumberofMultiClusters", [
-  Plot("totmulticlusternum", xtitle="", **_common)
+_tottracksternum = PlotGroup("TotalNumberofTracksters", [
+  Plot("tottracksternum", xtitle="", **_common)
 ],ncols=1)
 
-_multicluster_layernum_plots = [Plot("multicluster_firstlayer", xtitle="MultiCluster First Layer", **_common)]
-_multicluster_layernum_plots.extend([Plot("multicluster_lastlayer", xtitle="MultiCluster Last Layer", **_common)])
-_multicluster_layernum_plots.extend([Plot("multicluster_layersnum", xtitle="MultiCluster Number of Layers", **_common)])
-_multicluster_layernum = PlotGroup("LayerNumbersOfMultiCluster", _multicluster_layernum_plots, ncols=3)
+_trackster_layernum_plots = [Plot("trackster_firstlayer", xtitle="Trackster First Layer", **_common)]
+_trackster_layernum_plots.extend([Plot("trackster_lastlayer", xtitle="Trackster Last Layer", **_common)])
+_trackster_layernum_plots.extend([Plot("trackster_layersnum", xtitle="Trackster Number of Layers", **_common)])
+_trackster_layernum = PlotGroup("LayerNumbersOfTrackster", _trackster_layernum_plots, ncols=3)
 
 _common["xmax"] = 50
-_clusternum_in_multicluster = PlotGroup("NumberofLayerClustersinMultiCluster",[
-  Plot("clusternum_in_multicluster", xtitle="", **_common)
+_clusternum_in_trackster = PlotGroup("NumberofLayerClustersinTrackster",[
+  Plot("clusternum_in_trackster", xtitle="", **_common)
 ],ncols=1)
 
 _common = {"stat": True, "drawStyle": "hist", "staty": 0.65}
 _common = {"stat": True, "drawStyle": "pcolz", "staty": 0.65}
 
-_clusternum_in_multicluster_vs_layer = PlotGroup("NumberofLayerClustersinMultiClusterPerLayer",[
-  Plot("clusternum_in_multicluster_vs_layer", xtitle="Layer number", ytitle = "<2d Layer Clusters in Multicluster>",  **_common)
+_clusternum_in_trackster_vs_layer = PlotGroup("NumberofLayerClustersinTracksterPerLayer",[
+  Plot("clusternum_in_trackster_vs_layer", xtitle="Layer number", ytitle = "<2d Layer Clusters in Trackster>",  **_common)
 ],ncols=1)
 
 _common["scale"] = 100.
 #, ztitle = "% of clusters" normalizeToUnitArea=True
-_multiplicity_numberOfEventsHistogram = "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/ticlMultiClustersFromTrackstersEM/multiplicity_numberOfEventsHistogram"
-_multiplicity_zminus_numberOfEventsHistogram = "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/ticlMultiClustersFromTrackstersEM/multiplicity_zminus_numberOfEventsHistogram"
-_multiplicity_zplus_numberOfEventsHistogram = "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/ticlMultiClustersFromTrackstersEM/multiplicity_zplus_numberOfEventsHistogram"
+_multiplicity_numberOfEventsHistogram = "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/ticlTrackstersMerge/multiplicity_numberOfEventsHistogram"
+_multiplicity_zminus_numberOfEventsHistogram = "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/ticlTrackstersMerge/multiplicity_zminus_numberOfEventsHistogram"
+_multiplicity_zplus_numberOfEventsHistogram = "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/ticlTrackstersMerge/multiplicity_zplus_numberOfEventsHistogram"
 
-_multiplicityOfLCinMCL_plots = [Plot("multiplicityOfLCinMCL", xtitle="Layer Cluster multiplicity in Multiclusters", ytitle = "Cluster size (n_{hit})", 
+_multiplicityOfLCinTST_plots = [Plot("multiplicityOfLCinTST", xtitle="Layer Cluster multiplicity in Tracksters", ytitle = "Cluster size (n_{hit})", 
                                 drawCommand = "colz text45", normalizeToNumberOfEvents = True, **_common)]
-_multiplicityOfLCinMCL_plots.extend([Plot("multiplicityOfLCinMCL_vs_layerclusterenergy", xtitle="Layer Cluster multiplicity in Multiclusters", ytitle = "Cluster Energy (GeV)", 
+_multiplicityOfLCinTST_plots.extend([Plot("multiplicityOfLCinTST_vs_layerclusterenergy", xtitle="Layer Cluster multiplicity in Tracksters", ytitle = "Cluster Energy (GeV)", 
                                 drawCommand = "colz text45", normalizeToNumberOfEvents = True, **_common)]) 
-_multiplicityOfLCinMCL_plots.extend([Plot("multiplicityOfLCinMCL_vs_layercluster_zplus", xtitle="Layer Cluster multiplicity in Multiclusters", ytitle = "Layer Number", 
+_multiplicityOfLCinTST_plots.extend([Plot("multiplicityOfLCinTST_vs_layercluster_zplus", xtitle="Layer Cluster multiplicity in Tracksters", ytitle = "Layer Number", 
                                 drawCommand = "colz text45", normalizeToNumberOfEvents = True, **_common)])
-_multiplicityOfLCinMCL_plots.extend([Plot("multiplicityOfLCinMCL_vs_layercluster_zminus", xtitle="Layer Cluster multiplicity in Multiclusters", ytitle = "Layer Number", 
+_multiplicityOfLCinTST_plots.extend([Plot("multiplicityOfLCinTST_vs_layercluster_zminus", xtitle="Layer Cluster multiplicity in Tracksters", ytitle = "Layer Number", 
                                 drawCommand = "colz text45", normalizeToNumberOfEvents = True, **_common)])
-_multiplicityOfLCinMCL = PlotGroup("MultiplcityofLCinMLC", _multiplicityOfLCinMCL_plots, ncols=2)
+_multiplicityOfLCinTST = PlotGroup("MultiplcityofLCinTST", _multiplicityOfLCinTST_plots, ncols=2)
 
 _common = {"stat": True, "drawStyle": "hist", "staty": 0.65}
 #--------------------------------------------------------------------------------------------
 # z-
 #--------------------------------------------------------------------------------------------
-_clusternum_in_multicluster_perlayer_zminus_EE = PlotGroup("NumberofLayerClustersinMultiClusterPerLayer_zminus_EE", [
-  Plot("clusternum_in_multicluster_perlayer{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzm)
+_clusternum_in_trackster_perlayer_zminus_EE = PlotGroup("NumberofLayerClustersinTracksterPerLayer_zminus_EE", [
+  Plot("clusternum_in_trackster_perlayer{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzm)
 ], ncols=7)
 
-_clusternum_in_multicluster_perlayer_zminus_FH = PlotGroup("NumberofLayerClustersinMultiClusterPerLayer_zminus_FH", [
-  Plot("clusternum_in_multicluster_perlayer{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzm,lastLayerFHzm)
+_clusternum_in_trackster_perlayer_zminus_FH = PlotGroup("NumberofLayerClustersinTracksterPerLayer_zminus_FH", [
+  Plot("clusternum_in_trackster_perlayer{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzm,lastLayerFHzm)
 ], ncols=7)
 
-_clusternum_in_multicluster_perlayer_zminus_BH = PlotGroup("NumberofLayerClustersinMultiClusterPerLayer_zminus_BH", [
-  Plot("clusternum_in_multicluster_perlayer{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerFHzm,maxlayerzm)
+_clusternum_in_trackster_perlayer_zminus_BH = PlotGroup("NumberofLayerClustersinTracksterPerLayer_zminus_BH", [
+  Plot("clusternum_in_trackster_perlayer{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerFHzm,maxlayerzm)
 ], ncols=7)
 
 #--------------------------------------------------------------------------------------------
 # z+
 #--------------------------------------------------------------------------------------------
-_clusternum_in_multicluster_perlayer_zplus_EE = PlotGroup("NumberofLayerClustersinMultiClusterPerLayer_zplus_EE", [
-  Plot("clusternum_in_multicluster_perlayer{:02d}".format(i), xtitle="", **_common) for i in range(maxlayerzm,lastLayerEEzp)
+_clusternum_in_trackster_perlayer_zplus_EE = PlotGroup("NumberofLayerClustersinTracksterPerLayer_zplus_EE", [
+  Plot("clusternum_in_trackster_perlayer{:02d}".format(i), xtitle="", **_common) for i in range(maxlayerzm,lastLayerEEzp)
 ], ncols=7)
 
-_clusternum_in_multicluster_perlayer_zplus_FH = PlotGroup("NumberofLayerClustersinMultiClusterPerLayer_zplus_FH", [
-  Plot("clusternum_in_multicluster_perlayer{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzp,lastLayerFHzp)
+_clusternum_in_trackster_perlayer_zplus_FH = PlotGroup("NumberofLayerClustersinTracksterPerLayer_zplus_FH", [
+  Plot("clusternum_in_trackster_perlayer{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzp,lastLayerFHzp)
 ], ncols=7)
 
-_clusternum_in_multicluster_perlayer_zplus_BH = PlotGroup("NumberofLayerClustersinMultiClusterPerLayer_zplus_BH", [
-  Plot("clusternum_in_multicluster_perlayer{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerFHzp,maxlayerzp)
+_clusternum_in_trackster_perlayer_zplus_BH = PlotGroup("NumberofLayerClustersinTracksterPerLayer_zplus_BH", [
+  Plot("clusternum_in_trackster_perlayer{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerFHzp,maxlayerzp)
 ], ncols=7)
 
 #Coming back to the usual box definition
 _common = {"stat": True, "drawStyle": "hist", "staty": 0.65 }
 
-#Some multiclusters quantities
-_multicluster_eppe_plots = [Plot("multicluster_eta", xtitle="MultiCluster #eta", **_common)]
-_multicluster_eppe_plots.extend([Plot("multicluster_phi", xtitle="MultiCluster #phi", **_common)])
-_multicluster_eppe_plots.extend([Plot("multicluster_pt", xtitle="MultiCluster p_{T}", **_common)])
-_multicluster_eppe_plots.extend([Plot("multicluster_energy", xtitle="MultiCluster Energy", **_common)])
-_multicluster_eppe = PlotGroup("EtaPhiPtEnergy", _multicluster_eppe_plots, ncols=2)
+#Some tracksters quantities
+_trackster_eppe_plots = [Plot("trackster_eta", xtitle="Trackster #eta", **_common)]
+_trackster_eppe_plots.extend([Plot("trackster_phi", xtitle="Trackster #phi", **_common)])
+_trackster_eppe_plots.extend([Plot("trackster_pt", xtitle="Trackster p_{T}", **_common)])
+_trackster_eppe_plots.extend([Plot("trackster_energy", xtitle="Trackster Energy", **_common)])
+_trackster_eppe = PlotGroup("EtaPhiPtEnergy", _trackster_eppe_plots, ncols=2)
 
-_multicluster_xyz_plots = [Plot("multicluster_x", xtitle="MultiCluster x", **_common)]
-_multicluster_xyz_plots.extend([Plot("multicluster_y", xtitle="MultiCluster y", **_common)])
-_multicluster_xyz_plots.extend([Plot("multicluster_z", xtitle="MultiCluster z", **_common)])
-_multicluster_xyz = PlotGroup("XYZ", _multicluster_xyz_plots, ncols=3)
+_trackster_xyz_plots = [Plot("trackster_x", xtitle="Trackster x", **_common)]
+_trackster_xyz_plots.extend([Plot("trackster_y", xtitle="Trackster y", **_common)])
+_trackster_xyz_plots.extend([Plot("trackster_z", xtitle="Trackster z", **_common)])
+_trackster_xyz = PlotGroup("XYZ", _trackster_xyz_plots, ncols=3)
 
 #--------------------------------------------------------------------------------------------
 # SIMHITS, DIGIS, RECHITS
@@ -1945,21 +1945,21 @@ _ReconstructableEnergyOverCPenergy = PlotGroup("ReconstructableEnergyOverCPenerg
   Plot("h_EoP_CPene_scint_calib_fraction", title="EoP_CPene_scint_calib_fraction", **_common),
 ])
 
-_ParticleFlowClusterHGCalFromMultiCl_Closest_EoverCPenergy = PlotGroup("ParticleFlowClusterHGCalFromMultiCl", [
+_ParticleFlowClusterHGCalFromTrackster_Closest_EoverCPenergy = PlotGroup("ParticleFlowClusterHGCalFromTrackster", [
   Plot("hgcal_EoP_CPene_100_calib_fraction", title="hgcal_EoP_CPene_100_calib_fraction", **_common),
   Plot("hgcal_EoP_CPene_200_calib_fraction", title="hgcal_EoP_CPene_200_calib_fraction", **_common),
   Plot("hgcal_EoP_CPene_300_calib_fraction", title="hgcal_EoP_CPene_300_calib_fraction", **_common),
   Plot("hgcal_EoP_CPene_scint_calib_fraction", title="hgcal_EoP_CPene_scint_calib_fraction", **_common),
 ])
 
-_EcalDrivenGsfElectronsFromMultiCl_Closest_EoverCPenergy = PlotGroup("EcalDrivenGsfElectronsFromMultiCl", [
+_EcalDrivenGsfElectronsFromTrackster_Closest_EoverCPenergy = PlotGroup("EcalDrivenGsfElectronsFromTrackster", [
   Plot("hgcal_ele_EoP_CPene_100_calib_fraction", title="hgcal_ele_EoP_CPene_100_calib_fraction", **_common),
   Plot("hgcal_ele_EoP_CPene_200_calib_fraction", title="hgcal_ele_EoP_CPene_200_calib_fraction", **_common),
   Plot("hgcal_ele_EoP_CPene_300_calib_fraction", title="hgcal_ele_EoP_CPene_300_calib_fraction", **_common),
   Plot("hgcal_ele_EoP_CPene_scint_calib_fraction", title="hgcal_ele_EoP_CPene_scint_calib_fraction", **_common),
 ])
 
-_PhotonsFromMultiCl_Closest_EoverCPenergy = PlotGroup("PhotonsFromMultiCl", [
+_PhotonsFromTrackster_Closest_EoverCPenergy = PlotGroup("PhotonsFromTrackster", [
   Plot("hgcal_photon_EoP_CPene_100_calib_fraction", title="hgcal_photon_EoP_CPene_100_calib_fraction", **_common),
   Plot("hgcal_photon_EoP_CPene_200_calib_fraction", title="hgcal_photon_EoP_CPene_200_calib_fraction", **_common),
   Plot("hgcal_photon_EoP_CPene_300_calib_fraction", title="hgcal_photon_EoP_CPene_300_calib_fraction", **_common),
@@ -2425,58 +2425,58 @@ def append_hgcalSimClustersPlots(collection, name_collection):
 def _hgcalFolders(lastDirName="hgcalLayerClusters"):
     return "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/"+lastDirName
 
-_multiclustersAllPlots = [
+_trackstersAllPlots = [
   _efficiencies,
   _duplicates,
   _fakes,
   _merges,
-  _multicluster_eppe,
-  _multicluster_xyz,
-  _totmulticlusternum,
-  _score_caloparticle_to_multiclusters,
-  _score_multicluster_to_caloparticles,
-  _sharedEnergy_caloparticle_to_multicluster,
-  _sharedEnergy_multicluster_to_caloparticle,
+  _trackster_eppe,
+  _trackster_xyz,
+  _tottracksternum,
+  _score_caloparticle_to_tracksters,
+  _score_trackster_to_caloparticles,
+  _sharedEnergy_caloparticle_to_trackster,
+  _sharedEnergy_trackster_to_caloparticle,
   #_energyscore_cp2mcl_mcl2cp,
   _energyscore_cp2mcl,
   _energyscore_mcl2cp,
-  _clusternum_in_multicluster,
-  _clusternum_in_multicluster_vs_layer,
-  _clusternum_in_multicluster_perlayer_zminus_EE,
-  _clusternum_in_multicluster_perlayer_zminus_FH,
-  _clusternum_in_multicluster_perlayer_zminus_BH,
-  _clusternum_in_multicluster_perlayer_zplus_EE,
-  _clusternum_in_multicluster_perlayer_zplus_FH,
-  _clusternum_in_multicluster_perlayer_zplus_BH,
-  _multicluster_layernum,
-  _multiplicityOfLCinMCL,
+  _clusternum_in_trackster,
+  _clusternum_in_trackster_vs_layer,
+  _clusternum_in_trackster_perlayer_zminus_EE,
+  _clusternum_in_trackster_perlayer_zminus_FH,
+  _clusternum_in_trackster_perlayer_zminus_BH,
+  _clusternum_in_trackster_perlayer_zplus_EE,
+  _clusternum_in_trackster_perlayer_zplus_FH,
+  _clusternum_in_trackster_perlayer_zplus_BH,
+  _trackster_layernum,
+  _multiplicityOfLCinTST,
 ]
 
-hgcalMultiClustersPlotter = Plotter()
-def append_hgcalMultiClustersPlots(collection = 'ticlMultiClustersFromTrackstersMerge', name_collection = "MultiClustersMerge"):
+hgcalTrackstersPlotter = Plotter()
+def append_hgcalTrackstersPlots(collection = 'ticlTrackstersMerge', name_collection = "TrackstersMerge"):
   # Appending all plots for MCs
-  hgcalMultiClustersPlotter.append(collection, [
+  hgcalTrackstersPlotter.append(collection, [
               _hgcalFolders(collection)
               ], PlotFolder(
-              *_multiclustersAllPlots,
+              *_trackstersAllPlots,
               loopSubFolders=False,
-              purpose=PlotPurpose.Timing, page="MultiClusters", section=name_collection))
+              purpose=PlotPurpose.Timing, page="Tracksters", section=name_collection))
 
   #We append here two PlotFolder because we want the text to be in percent
   #and the number of events are different in zplus and zminus
-  #hgcalMultiClustersPlotter.append("Multiplicity", [
+  #hgcalTrackstersPlotter.append("Multiplicity", [
   #            dqmfolder
   #            ], PlotFolder(
-  #            _multiplicityOfLCinMCL_vs_layercluster_zminus,
+  #            _multiplicityOfLCinTST_vs_layercluster_zminus,
   #            loopSubFolders=False,
   #            purpose=PlotPurpose.Timing, page=collection,
   #            numberOfEventsHistogram=_multiplicity_zminus_numberOfEventsHistogram
   #            ))
   #
-  #hgcalMultiClustersPlotter.append("Multiplicity", [
+  #hgcalTrackstersPlotter.append("Multiplicity", [
   #            dqmfolder
   #            ], PlotFolder(
-  #            _multiplicityOfLCinMCL_vs_layercluster_zplus,
+  #            _multiplicityOfLCinTST_vs_layercluster_zplus,
   #            loopSubFolders=False,
   #            purpose=PlotPurpose.Timing, page=collection,
   #            numberOfEventsHistogram=_multiplicity_zplus_numberOfEventsHistogram
@@ -2537,7 +2537,7 @@ def append_hgcalCaloParticlesPlots(files, collection = '-211', name_collection =
   return hgcalCaloParticlesPlotter
 
 #=================================================================================================
-def create_hgcalTrackstersPlotter(files, collection = 'ticlTrackstersMerge', name_collection = "MultiClustersMerge"):
+def create_hgcalTrackstersPlotter(files, collection = 'ticlTrackstersMerge', name_collection = "TrackstersMerge"):
   grouped = {"cosAngle Beta": PlotGroup("cosAngle_Beta_per_layer",[],ncols=10), "cosAngle Beta Weighted": PlotGroup("cosAngle_Beta_Weighted_per_layer",[],ncols=10)}
   groupingFlag = " on Layer "
 
@@ -2588,7 +2588,7 @@ def create_hgcalTrackstersPlotter(files, collection = 'ticlTrackstersMerge', nam
         hgcalTrackstersPlotter.append(name_collection+"_TICLDebugger",
             [dqmfolder], PlotFolder(pg,
                                     loopSubFolders=False,
-                                    purpose=PlotPurpose.Timing, page="MultiClusters", section=name_collection)
+                                    purpose=PlotPurpose.Timing, page="Tracksters", section=name_collection)
             #numberOfEventsHistogram=_multiplicity_tracksters_numberOfEventsHistogram)
             )
 
@@ -2598,7 +2598,7 @@ def create_hgcalTrackstersPlotter(files, collection = 'ticlTrackstersMerge', nam
       hgcalTrackstersPlotter.append(name_collection+"_TICLDebugger",
           [dqmfolder], PlotFolder(grouped[group],
                                   loopSubFolders=False,
-                                  purpose=PlotPurpose.Timing, page="MultiClusters", section=name_collection)
+                                  purpose=PlotPurpose.Timing, page="Tracksters", section=name_collection)
           #numberOfEventsHistogram=_multiplicity_tracksters_numberOfEventsHistogram)
           )
 
@@ -2772,26 +2772,26 @@ hgcalHitCalibPlotter.append("ReconstructableEnergyOverCPenergy", [
         purpose=PlotPurpose.Timing, page=hitCalibrationLabel, section=hitCalibrationLabel
         ))
 
-hgcalHitCalibPlotter.append("ParticleFlowClusterHGCalFromMultiCl_Closest_EoverCPenergy", [
+hgcalHitCalibPlotter.append("ParticleFlowClusterHGCalFromTrackster_Closest_EoverCPenergy", [
         "DQMData/Run 1/HGCalHitCalibration/Run summary",
         ], PlotFolder(
-        _ParticleFlowClusterHGCalFromMultiCl_Closest_EoverCPenergy,
+        _ParticleFlowClusterHGCalFromTrackster_Closest_EoverCPenergy,
         loopSubFolders=False,
         purpose=PlotPurpose.Timing, page=hitCalibrationLabel, section=hitCalibrationLabel
         ))
 
-hgcalHitCalibPlotter.append("PhotonsFromMultiCl_Closest_EoverCPenergy", [
+hgcalHitCalibPlotter.append("PhotonsFromTrackster_Closest_EoverCPenergy", [
         "DQMData/Run 1/HGCalHitCalibration/Run summary",
         ], PlotFolder(
-        _PhotonsFromMultiCl_Closest_EoverCPenergy,
+        _PhotonsFromTrackster_Closest_EoverCPenergy,
         loopSubFolders=False,
         purpose=PlotPurpose.Timing, page=hitCalibrationLabel, section=hitCalibrationLabel
         ))
 
-hgcalHitCalibPlotter.append("EcalDrivenGsfElectronsFromMultiCl_Closest_EoverCPenergy", [
+hgcalHitCalibPlotter.append("EcalDrivenGsfElectronsFromTrackster_Closest_EoverCPenergy", [
         "DQMData/Run 1/HGCalHitCalibration/Run summary",
         ], PlotFolder(
-        _EcalDrivenGsfElectronsFromMultiCl_Closest_EoverCPenergy,
+        _EcalDrivenGsfElectronsFromTrackster_Closest_EoverCPenergy,
         loopSubFolders=False,
         purpose=PlotPurpose.Timing, page=hitCalibrationLabel, section=hitCalibrationLabel
         ))

--- a/Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py
+++ b/Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py
@@ -5,28 +5,29 @@ import os
 import argparse
 from time import time
 
+from RecoHGCal.TICL.iterativeTICL_cff import ticlIterLabels, ticlIterLabelsMerge
+
 from Validation.RecoTrack.plotting.validation import SeparateValidation, SimpleValidation, SimpleSample
 import Validation.HGCalValidation.hgcalPlots as hgcalPlots
 import Validation.RecoTrack.plotting.plotting as plotting
 
-simClustersIters = ["ClusterLevel","ticlTrackstersTrkEM","ticlTrackstersEM","ticlTrackstersTrk","ticlTrackstersHAD","ticlSimTracksters"]
+simClustersIters = ["ClusterLevel","ticlSimTracksters"]
+simClustersIters.extend('ticlTracksters'+iteration for iteration in ticlIterLabels)
 
-trackstersIters = ["ticlMultiClustersFromTrackstersMerge", "ticlMultiClustersFromTrackstersMIP",
-                   "ticlMultiClustersFromTrackstersTrk","ticlMultiClustersFromTrackstersTrkEM",
-                   "ticlMultiClustersFromTrackstersEM", "ticlMultiClustersFromTrackstersHAD",
-                   "ticlMultiClustersFromSimTracksters"]
+trackstersIters = ['ticlTracksters'+iteration for iteration in ticlIterLabelsMerge]
+trackstersIters.extend(["ticlSimTracksters"])
 
 simClustersGeneralLabel = 'simClusters'
 layerClustersGeneralLabel = 'hgcalLayerClusters'
-multiclustersGeneralLabel = 'hgcalMultiClusters'
-trackstersGeneralLabel = 'allTiclMultiClusters'
+trackstersGeneralLabel = 'hgcalTracksters'
+allTrackstersLabel = 'allTiclTracksters'
 hitValidationLabel = 'hitValidation'
 hitCalibrationLabel = 'hitCalibration'
 caloParticlesLabel = 'caloParticles'
 allLabel = 'all'
 
 collection_choices = [layerClustersGeneralLabel]
-collection_choices.extend([simClustersGeneralLabel]+[multiclustersGeneralLabel]+[trackstersGeneralLabel]+[hitValidationLabel]+[hitCalibrationLabel]+[allLabel]+[caloParticlesLabel])
+collection_choices.extend([simClustersGeneralLabel]+[trackstersGeneralLabel]+[allTrackstersLabel]+[hitValidationLabel]+[hitCalibrationLabel]+[allLabel]+[caloParticlesLabel])
 
 def main(opts):
 
@@ -62,21 +63,19 @@ def main(opts):
         for i_iter in simClustersIters:
             hgcalPlots.append_hgcalSimClustersPlots(i_iter, i_iter)
         val.doPlots(hgcsimclus, plotterDrawArgs=drawArgs)
-    #multiClusters
-    elif (opts.collection == multiclustersGeneralLabel):
-        hgcmulticlus = [hgcalPlots.hgcalMultiClustersPlotter]
-        hgcalPlots.append_hgcalMultiClustersPlots(multiclustersGeneralLabel, "MultiClusters")
-        val.doPlots(hgcmulticlus, plotterDrawArgs=drawArgs)
-    #ticlTracksters
+    #tracksters
     elif (opts.collection == trackstersGeneralLabel):
-        hgcmulticlus = [hgcalPlots.hgcalMultiClustersPlotter]
-        for i_iter in trackstersIters :
-            tracksterCollection = i_iter.replace("ticlMultiClustersFromTracksters","ticlTracksters")
-            hgcalPlots.append_hgcalMultiClustersPlots(i_iter, tracksterCollection)
-        val.doPlots(hgcmulticlus, plotterDrawArgs=drawArgs)
+        hgctrackster = [hgcalPlots.hgcalTrackstersPlotter]
+        hgcalPlots.append_hgcalTrackstersPlots(trackstersGeneralLabel, "Tracksters")
+        val.doPlots(hgctrackster, plotterDrawArgs=drawArgs)
+    #ticlTracksters
+    elif (opts.collection == allTrackstersLabel):
+        hgctrackster = [hgcalPlots.hgcalTrackstersPlotter]
+        for tracksterCollection in trackstersIters :
+            hgcalPlots.append_hgcalTrackstersPlots(tracksterCollection, tracksterCollection)
+        val.doPlots(hgctrackster, plotterDrawArgs=drawArgs)
         # TICLTrackstersEdges plots
-        for i_iter in trackstersIters :
-            tracksterCollection = i_iter.replace("ticlMultiClustersFromTracksters","ticlTracksters")
+        for tracksterCollection in trackstersIters :
             hgctracksters = [hgcalPlots.create_hgcalTrackstersPlotter(sample.files(), tracksterCollection, tracksterCollection)]
             val.doPlots(hgctracksters, plotterDrawArgs=drawArgs)
     elif (opts.collection == caloParticlesLabel):
@@ -134,15 +133,13 @@ def main(opts):
         hgcalPlots.append_hgcalLayerClustersPlots("hgcalLayerClusters", "Layer Clusters", extendedFlag)
         val.doPlots(hgclayclus, plotterDrawArgs=drawArgs)
 
-        #multiclusters
-        hgcmulticlus = [hgcalPlots.hgcalMultiClustersPlotter]
-        for i_iter in trackstersIters :
-            tracksterCollection = i_iter.replace("ticlMultiClustersFromTracksters","ticlTracksters")
-            hgcalPlots.append_hgcalMultiClustersPlots(i_iter, tracksterCollection)
-        val.doPlots(hgcmulticlus, plotterDrawArgs=drawArgs)
+        #tracksters
+        hgctrackster = [hgcalPlots.hgcalTrackstersPlotter]
+        for tracksterCollection in trackstersIters :
+            hgcalPlots.append_hgcalTrackstersPlots(tracksterCollection, tracksterCollection)
+        val.doPlots(hgctrackster, plotterDrawArgs=drawArgs)
         #TICLTrackstersEdges plots
-        for i_iter in trackstersIters :
-            tracksterCollection = i_iter.replace("ticlMultiClustersFromTracksters","ticlTracksters")
+        for tracksterCollection in trackstersIters :
             hgctracksters = [hgcalPlots.create_hgcalTrackstersPlotter(sample.files(), tracksterCollection, tracksterCollection)]
             val.doPlots(hgctracksters, plotterDrawArgs=drawArgs)
 

--- a/Validation/HGCalValidation/src/HGVHistoProducerAlgo.cc
+++ b/Validation/HGCalValidation/src/HGVHistoProducerAlgo.cc
@@ -16,8 +16,8 @@ const double ScoreCutLCtoCP_ = 0.1;
 const double ScoreCutCPtoLC_ = 0.1;
 const double ScoreCutLCtoSC_ = 0.1;
 const double ScoreCutSCtoLC_ = 0.1;
-const double ScoreCutMCLtoCPFakeMerge_ = 0.6;
-const double ScoreCutCPtoMCLEffDup_ = 0.2;
+const double ScoreCutTSTtoCPFakeMerge_ = 0.6;
+const double ScoreCutCPtoTSTEffDup_ = 0.2;
 
 HGVHistoProducerAlgo::HGVHistoProducerAlgo(const edm::ParameterSet& pset)
     :  //parameters for eta
@@ -97,10 +97,10 @@ HGVHistoProducerAlgo::HGVHistoProducerAlgo(const edm::ParameterSet& pset)
       maxSharedEneFrac_(pset.getParameter<double>("maxSharedEneFrac")),
       nintSharedEneFrac_(pset.getParameter<int>("nintSharedEneFrac")),
 
-      //Same as above for multiclusters
-      minMCLSharedEneFrac_(pset.getParameter<double>("minMCLSharedEneFrac")),
-      maxMCLSharedEneFrac_(pset.getParameter<double>("maxMCLSharedEneFrac")),
-      nintMCLSharedEneFrac_(pset.getParameter<int>("nintMCLSharedEneFrac")),
+      //Same as above for Tracksters
+      minTSTSharedEneFrac_(pset.getParameter<double>("minTSTSharedEneFrac")),
+      maxTSTSharedEneFrac_(pset.getParameter<double>("maxTSTSharedEneFrac")),
+      nintTSTSharedEneFrac_(pset.getParameter<int>("nintTSTSharedEneFrac")),
 
       //Parameters for the total number of SimClusters per thickness
       minTotNsimClsperthick_(pset.getParameter<double>("minTotNsimClsperthick")),
@@ -152,31 +152,31 @@ HGVHistoProducerAlgo::HGVHistoProducerAlgo(const edm::ParameterSet& pset)
       maxCellsEneDensperthick_(pset.getParameter<double>("maxCellsEneDensperthick")),
       nintCellsEneDensperthick_(pset.getParameter<int>("nintCellsEneDensperthick")),
 
-      //Parameters for the total number of multiclusters per event
+      //Parameters for the total number of Tracksters per event
       //We always treet one event as two events, one in +z one in -z
-      minTotNMCLs_(pset.getParameter<double>("minTotNMCLs")),
-      maxTotNMCLs_(pset.getParameter<double>("maxTotNMCLs")),
-      nintTotNMCLs_(pset.getParameter<int>("nintTotNMCLs")),
+      minTotNTSTs_(pset.getParameter<double>("minTotNTSTs")),
+      maxTotNTSTs_(pset.getParameter<double>("maxTotNTSTs")),
+      nintTotNTSTs_(pset.getParameter<int>("nintTotNTSTs")),
 
-      //Parameters for the total number of layer clusters in multicluster
-      minTotNClsinMCLs_(pset.getParameter<double>("minTotNClsinMCLs")),
-      maxTotNClsinMCLs_(pset.getParameter<double>("maxTotNClsinMCLs")),
-      nintTotNClsinMCLs_(pset.getParameter<int>("nintTotNClsinMCLs")),
+      //Parameters for the total number of layer clusters in Trackster
+      minTotNClsinTSTs_(pset.getParameter<double>("minTotNClsinTSTs")),
+      maxTotNClsinTSTs_(pset.getParameter<double>("maxTotNClsinTSTs")),
+      nintTotNClsinTSTs_(pset.getParameter<int>("nintTotNClsinTSTs")),
 
-      //Parameters for the total number of layer clusters in multicluster per layer
-      minTotNClsinMCLsperlayer_(pset.getParameter<double>("minTotNClsinMCLsperlayer")),
-      maxTotNClsinMCLsperlayer_(pset.getParameter<double>("maxTotNClsinMCLsperlayer")),
-      nintTotNClsinMCLsperlayer_(pset.getParameter<int>("nintTotNClsinMCLsperlayer")),
+      //Parameters for the total number of layer clusters in Trackster per layer
+      minTotNClsinTSTsperlayer_(pset.getParameter<double>("minTotNClsinTSTsperlayer")),
+      maxTotNClsinTSTsperlayer_(pset.getParameter<double>("maxTotNClsinTSTsperlayer")),
+      nintTotNClsinTSTsperlayer_(pset.getParameter<int>("nintTotNClsinTSTsperlayer")),
 
-      //Parameters for the multiplicity of layer clusters in multicluster
+      //Parameters for the multiplicity of layer clusters in Trackster
       minMplofLCs_(pset.getParameter<double>("minMplofLCs")),
       maxMplofLCs_(pset.getParameter<double>("maxMplofLCs")),
       nintMplofLCs_(pset.getParameter<int>("nintMplofLCs")),
 
       //Parameters for cluster size
-      minSizeCLsinMCLs_(pset.getParameter<double>("minSizeCLsinMCLs")),
-      maxSizeCLsinMCLs_(pset.getParameter<double>("maxSizeCLsinMCLs")),
-      nintSizeCLsinMCLs_(pset.getParameter<int>("nintSizeCLsinMCLs")),
+      minSizeCLsinTSTs_(pset.getParameter<double>("minSizeCLsinTSTs")),
+      maxSizeCLsinTSTs_(pset.getParameter<double>("maxSizeCLsinTSTs")),
+      nintSizeCLsinTSTs_(pset.getParameter<int>("nintSizeCLsinTSTs")),
 
       //Parameters for the energy of a cluster per thickness per layer
       minClEnepermultiplicity_(pset.getParameter<double>("minClEnepermultiplicity")),
@@ -963,110 +963,110 @@ void HGVHistoProducerAlgo::bookClusterHistos_CellLevel(DQMStore::IBooker& ibook,
 }
 //----------------------------------------------------------------------------------------------------------------------------
 
-void HGVHistoProducerAlgo::bookMultiClusterHistos(DQMStore::IBooker& ibook,
+void HGVHistoProducerAlgo::bookTracksterHistos(DQMStore::IBooker& ibook,
                                                   Histograms& histograms,
                                                   unsigned int layers) {
-  histograms.h_score_multicl2caloparticle.push_back(ibook.book1D(
-      "Score_multicl2caloparticle", "Score of Multi Cluster per CaloParticle", nintScore_, minScore_, maxScore_));
-  histograms.h_score_caloparticle2multicl.push_back(ibook.book1D(
-      "Score_caloparticle2multicl", "Score of CaloParticle per Multi Cluster", nintScore_, minScore_, maxScore_));
-  histograms.h_energy_vs_score_multicl2caloparticle.push_back(
-      ibook.book2D("Energy_vs_Score_multi2caloparticle",
-                   "Energy vs Score of Multi Cluster per CaloParticle",
+  histograms.h_score_trackster2caloparticle.push_back(ibook.book1D(
+      "Score_trackster2caloparticle", "Score of Trackster per CaloParticle", nintScore_, minScore_, maxScore_));
+  histograms.h_score_caloparticle2trackster.push_back(ibook.book1D(
+      "Score_caloparticle2trackster", "Score of CaloParticle per Trackster", nintScore_, minScore_, maxScore_));
+  histograms.h_energy_vs_score_trackster2caloparticle.push_back(
+      ibook.book2D("Energy_vs_Score_trackster2caloparticle",
+                   "Energy vs Score of Trackster per CaloParticle",
                    nintScore_,
                    minScore_,
                    maxScore_,
                    nintSharedEneFrac_,
-                   minMCLSharedEneFrac_,
-                   maxMCLSharedEneFrac_));
-  histograms.h_energy_vs_score_caloparticle2multicl.push_back(
-      ibook.book2D("Energy_vs_Score_caloparticle2multi",
-                   "Energy vs Score of CaloParticle per Multi Cluster",
+                   minTSTSharedEneFrac_,
+                   maxTSTSharedEneFrac_));
+  histograms.h_energy_vs_score_caloparticle2trackster.push_back(
+      ibook.book2D("Energy_vs_Score_caloparticle2trackster",
+                   "Energy vs Score of CaloParticle per Trackster",
                    nintScore_,
                    minScore_,
                    maxScore_,
                    nintSharedEneFrac_,
-                   minMCLSharedEneFrac_,
-                   maxMCLSharedEneFrac_));
+                   minTSTSharedEneFrac_,
+                   maxTSTSharedEneFrac_));
 
-  //back to all multiclusters
-  histograms.h_num_multicl_eta.push_back(
-      ibook.book1D("Num_MultiCluster_Eta", "Num MultiCluster Eta per Multi Cluster ", nintEta_, minEta_, maxEta_));
-  histograms.h_numMerge_multicl_eta.push_back(ibook.book1D(
-      "NumMerge_MultiCluster_Eta", "Num Merge MultiCluster Eta per Multi Cluster ", nintEta_, minEta_, maxEta_));
-  histograms.h_denom_multicl_eta.push_back(
-      ibook.book1D("Denom_MultiCluster_Eta", "Denom MultiCluster Eta per Multi Cluster", nintEta_, minEta_, maxEta_));
-  histograms.h_num_multicl_phi.push_back(
-      ibook.book1D("Num_MultiCluster_Phi", "Num MultiCluster Phi per Multi Cluster ", nintPhi_, minPhi_, maxPhi_));
-  histograms.h_numMerge_multicl_phi.push_back(ibook.book1D(
-      "NumMerge_MultiCluster_Phi", "Num Merge MultiCluster Phi per Multi Cluster", nintPhi_, minPhi_, maxPhi_));
-  histograms.h_denom_multicl_phi.push_back(
-      ibook.book1D("Denom_MultiCluster_Phi", "Denom MultiCluster Phi per Multi Cluster", nintPhi_, minPhi_, maxPhi_));
-  histograms.h_sharedenergy_multicl2caloparticle.push_back(
-      ibook.book1D("SharedEnergy_multicluster2caloparticle",
-                   "Shared Energy of Multi Cluster per Calo Particle in each layer",
+  //back to all Tracksters
+  histograms.h_num_trackster_eta.push_back(
+      ibook.book1D("Num_Trackster_Eta", "Num Trackster Eta per Trackster ", nintEta_, minEta_, maxEta_));
+  histograms.h_numMerge_trackster_eta.push_back(ibook.book1D(
+      "NumMerge_Trackster_Eta", "Num Merge Trackster Eta per Trackster ", nintEta_, minEta_, maxEta_));
+  histograms.h_denom_trackster_eta.push_back(
+      ibook.book1D("Denom_Trackster_Eta", "Denom Trackster Eta per Trackster", nintEta_, minEta_, maxEta_));
+  histograms.h_num_trackster_phi.push_back(
+      ibook.book1D("Num_Trackster_Phi", "Num Trackster Phi per Trackster ", nintPhi_, minPhi_, maxPhi_));
+  histograms.h_numMerge_trackster_phi.push_back(ibook.book1D(
+      "NumMerge_Trackster_Phi", "Num Merge Trackster Phi per Trackster", nintPhi_, minPhi_, maxPhi_));
+  histograms.h_denom_trackster_phi.push_back(
+      ibook.book1D("Denom_Trackster_Phi", "Denom Trackster Phi per Trackster", nintPhi_, minPhi_, maxPhi_));
+  histograms.h_sharedenergy_trackster2caloparticle.push_back(
+      ibook.book1D("SharedEnergy_trackster2caloparticle",
+                   "Shared Energy of Trackster per Calo Particle in each layer",
                    nintSharedEneFrac_,
-                   minMCLSharedEneFrac_,
-                   maxMCLSharedEneFrac_));
-  histograms.h_sharedenergy_multicl2caloparticle_vs_eta.push_back(
-      ibook.bookProfile("SharedEnergy_multicl2caloparticle_vs_eta",
-                        "Shared Energy of MultiCluster vs #eta per best Calo Particle in each layer",
+                   minTSTSharedEneFrac_,
+                   maxTSTSharedEneFrac_));
+  histograms.h_sharedenergy_trackster2caloparticle_vs_eta.push_back(
+      ibook.bookProfile("SharedEnergy_trackster2caloparticle_vs_eta",
+                        "Shared Energy of Trackster vs #eta per best Calo Particle in each layer",
                         nintEta_,
                         minEta_,
                         maxEta_,
-                        minMCLSharedEneFrac_,
-                        maxMCLSharedEneFrac_));
-  histograms.h_sharedenergy_multicl2caloparticle_vs_phi.push_back(
-      ibook.bookProfile("SharedEnergy_multicl2caloparticle_vs_phi",
-                        "Shared Energy of MultiCluster vs #phi per best Calo Particle in each layer",
+                        minTSTSharedEneFrac_,
+                        maxTSTSharedEneFrac_));
+  histograms.h_sharedenergy_trackster2caloparticle_vs_phi.push_back(
+      ibook.bookProfile("SharedEnergy_trackster2caloparticle_vs_phi",
+                        "Shared Energy of Trackster vs #phi per best Calo Particle in each layer",
                         nintPhi_,
                         minPhi_,
                         maxPhi_,
-                        minMCLSharedEneFrac_,
-                        maxMCLSharedEneFrac_));
-  histograms.h_sharedenergy_caloparticle2multicl.push_back(
-      ibook.book1D("SharedEnergy_caloparticle2multicl",
-                   "Shared Energy of CaloParticle per Multi Cluster",
+                        minTSTSharedEneFrac_,
+                        maxTSTSharedEneFrac_));
+  histograms.h_sharedenergy_caloparticle2trackster.push_back(
+      ibook.book1D("SharedEnergy_caloparticle2trackster",
+                   "Shared Energy of CaloParticle per Trackster",
                    nintSharedEneFrac_,
-                   minMCLSharedEneFrac_,
-                   maxMCLSharedEneFrac_));
-  histograms.h_sharedenergy_caloparticle2multicl_assoc.push_back(
-      ibook.book1D("SharedEnergy_caloparticle2multicl_assoc",
-                   "Shared Energy of Associated CaloParticle per Multi Cluster",
+                   minTSTSharedEneFrac_,
+                   maxTSTSharedEneFrac_));
+  histograms.h_sharedenergy_caloparticle2trackster_assoc.push_back(
+      ibook.book1D("SharedEnergy_caloparticle2trackster_assoc",
+                   "Shared Energy of Associated CaloParticle per Trackster",
                    nintSharedEneFrac_,
-                   minMCLSharedEneFrac_,
-                   maxMCLSharedEneFrac_));
-  histograms.h_sharedenergy_caloparticle2multicl_vs_eta.push_back(
-      ibook.bookProfile("SharedEnergy_caloparticle2multicl_vs_eta",
-                        "Shared Energy of CaloParticle vs #eta per best Multi Cluster",
+                   minTSTSharedEneFrac_,
+                   maxTSTSharedEneFrac_));
+  histograms.h_sharedenergy_caloparticle2trackster_vs_eta.push_back(
+      ibook.bookProfile("SharedEnergy_caloparticle2trackster_vs_eta",
+                        "Shared Energy of CaloParticle vs #eta per best Trackster",
                         nintEta_,
                         minEta_,
                         maxEta_,
-                        minMCLSharedEneFrac_,
-                        maxMCLSharedEneFrac_));
-  histograms.h_sharedenergy_caloparticle2multicl_vs_phi.push_back(
-      ibook.bookProfile("SharedEnergy_caloparticle2multicl_vs_phi",
-                        "Shared Energy of CaloParticle vs #phi per best Multi Cluster",
+                        minTSTSharedEneFrac_,
+                        maxTSTSharedEneFrac_));
+  histograms.h_sharedenergy_caloparticle2trackster_vs_phi.push_back(
+      ibook.bookProfile("SharedEnergy_caloparticle2trackster_vs_phi",
+                        "Shared Energy of CaloParticle vs #phi per best Trackster",
                         nintPhi_,
                         minPhi_,
                         maxPhi_,
-                        minMCLSharedEneFrac_,
-                        maxMCLSharedEneFrac_));
+                        minTSTSharedEneFrac_,
+                        maxTSTSharedEneFrac_));
   histograms.h_num_caloparticle_eta.push_back(
-      ibook.book1D("Num_CaloParticle_Eta", "Num CaloParticle Eta per Multi Cluster", nintEta_, minEta_, maxEta_));
-  histograms.h_numDup_multicl_eta.push_back(
-      ibook.book1D("NumDup_MultiCluster_Eta", "Num Duplicate MultiCl vs Eta", nintEta_, minEta_, maxEta_));
+      ibook.book1D("Num_CaloParticle_Eta", "Num CaloParticle Eta per Trackster", nintEta_, minEta_, maxEta_));
+  histograms.h_numDup_trackster_eta.push_back(
+      ibook.book1D("NumDup_Trackster_Eta", "Num Duplicate Trackster vs Eta", nintEta_, minEta_, maxEta_));
   histograms.h_denom_caloparticle_eta.push_back(
-      ibook.book1D("Denom_CaloParticle_Eta", "Denom CaloParticle Eta per Multi Cluster", nintEta_, minEta_, maxEta_));
+      ibook.book1D("Denom_CaloParticle_Eta", "Denom CaloParticle Eta per Trackster", nintEta_, minEta_, maxEta_));
   histograms.h_num_caloparticle_phi.push_back(
-      ibook.book1D("Num_CaloParticle_Phi", "Num CaloParticle Phi per Multi Cluster", nintPhi_, minPhi_, maxPhi_));
-  histograms.h_numDup_multicl_phi.push_back(
-      ibook.book1D("NumDup_MultiCluster_Phi", "Num Duplicate MultiCl vs Phi", nintPhi_, minPhi_, maxPhi_));
+      ibook.book1D("Num_CaloParticle_Phi", "Num CaloParticle Phi per Trackster", nintPhi_, minPhi_, maxPhi_));
+  histograms.h_numDup_trackster_phi.push_back(
+      ibook.book1D("NumDup_Trackster_Phi", "Num Duplicate Trackster vs Phi", nintPhi_, minPhi_, maxPhi_));
   histograms.h_denom_caloparticle_phi.push_back(
-      ibook.book1D("Denom_CaloParticle_Phi", "Denom CaloParticle Phi per Multi Cluster", nintPhi_, minPhi_, maxPhi_));
+      ibook.book1D("Denom_CaloParticle_Phi", "Denom CaloParticle Phi per Trackster", nintPhi_, minPhi_, maxPhi_));
 
-  std::unordered_map<int, dqm::reco::MonitorElement*> clusternum_in_multicluster_perlayer;
-  clusternum_in_multicluster_perlayer.clear();
+  std::unordered_map<int, dqm::reco::MonitorElement*> clusternum_in_trackster_perlayer;
+  clusternum_in_trackster_perlayer.clear();
 
   for (unsigned ilayer = 0; ilayer < 2 * layers; ++ilayer) {
     auto istr1 = std::to_string(ilayer);
@@ -1082,54 +1082,54 @@ void HGVHistoProducerAlgo::bookMultiClusterHistos(DQMStore::IBooker& ibook,
       istr2 = std::to_string(ilayer - (layers - 1)) + " in z+";
     }
 
-    clusternum_in_multicluster_perlayer[ilayer] =
-        ibook.book1D("clusternum_in_multicluster_perlayer" + istr1,
-                     "Number of layer clusters in multicluster for layer " + istr2,
-                     nintTotNClsinMCLsperlayer_,
-                     minTotNClsinMCLsperlayer_,
-                     maxTotNClsinMCLsperlayer_);
+    clusternum_in_trackster_perlayer[ilayer] =
+        ibook.book1D("clusternum_in_trackster_perlayer" + istr1,
+                     "Number of layer clusters in Trackster for layer " + istr2,
+                     nintTotNClsinTSTsperlayer_,
+                     minTotNClsinTSTsperlayer_,
+                     maxTotNClsinTSTsperlayer_);
   }
 
-  histograms.h_clusternum_in_multicluster_perlayer.push_back(std::move(clusternum_in_multicluster_perlayer));
+  histograms.h_clusternum_in_trackster_perlayer.push_back(std::move(clusternum_in_trackster_perlayer));
 
-  histograms.h_multiclusternum.push_back(
-      ibook.book1D("totmulticlusternum", "total number of multiclusters", nintTotNMCLs_, minTotNMCLs_, maxTotNMCLs_));
+  histograms.h_tracksternum.push_back(
+      ibook.book1D("tottracksternum", "total number of Tracksters", nintTotNTSTs_, minTotNTSTs_, maxTotNTSTs_));
 
-  histograms.h_contmulticlusternum.push_back(ibook.book1D("contmulticlusternum",
-                                                          "number of multiclusters with 3 contiguous layers",
-                                                          nintTotNMCLs_,
-                                                          minTotNMCLs_,
-                                                          maxTotNMCLs_));
+  histograms.h_conttracksternum.push_back(ibook.book1D("conttracksternum",
+                                                          "number of Tracksters with 3 contiguous layers",
+                                                          nintTotNTSTs_,
+                                                          minTotNTSTs_,
+                                                          maxTotNTSTs_));
 
-  histograms.h_noncontmulticlusternum.push_back(ibook.book1D("noncontmulticlusternum",
-                                                             "number of multiclusters without 3 contiguous layers",
-                                                             nintTotNMCLs_,
-                                                             minTotNMCLs_,
-                                                             maxTotNMCLs_));
+  histograms.h_nonconttracksternum.push_back(ibook.book1D("nonconttracksternum",
+                                                             "number of Tracksters without 3 contiguous layers",
+                                                             nintTotNTSTs_,
+                                                             minTotNTSTs_,
+                                                             maxTotNTSTs_));
 
-  histograms.h_clusternum_in_multicluster.push_back(ibook.book1D("clusternum_in_multicluster",
-                                                                 "total number of layer clusters in multicluster",
-                                                                 nintTotNClsinMCLs_,
-                                                                 minTotNClsinMCLs_,
-                                                                 maxTotNClsinMCLs_));
+  histograms.h_clusternum_in_trackster.push_back(ibook.book1D("clusternum_in_trackster",
+                                                                 "total number of layer clusters in Trackster",
+                                                                 nintTotNClsinTSTs_,
+                                                                 minTotNClsinTSTs_,
+                                                                 maxTotNClsinTSTs_));
 
-  histograms.h_clusternum_in_multicluster_vs_layer.push_back(
-      ibook.bookProfile("clusternum_in_multicluster_vs_layer",
-                        "Profile of 2d layer clusters in multicluster vs layer number",
+  histograms.h_clusternum_in_trackster_vs_layer.push_back(
+      ibook.bookProfile("clusternum_in_trackster_vs_layer",
+                        "Profile of 2d layer clusters in Trackster vs layer number",
                         2 * layers,
                         0.,
                         2. * layers,
-                        minTotNClsinMCLsperlayer_,
-                        maxTotNClsinMCLsperlayer_));
+                        minTotNClsinTSTsperlayer_,
+                        maxTotNClsinTSTsperlayer_));
 
-  histograms.h_multiplicityOfLCinMCL.push_back(ibook.book2D("multiplicityOfLCinMCL",
-                                                            "Multiplicity vs Layer cluster size in Multiclusters",
+  histograms.h_multiplicityOfLCinTST.push_back(ibook.book2D("multiplicityOfLCinTST",
+                                                            "Multiplicity vs Layer cluster size in Tracksters",
                                                             nintMplofLCs_,
                                                             minMplofLCs_,
                                                             maxMplofLCs_,
-                                                            nintSizeCLsinMCLs_,
-                                                            minSizeCLsinMCLs_,
-                                                            maxSizeCLsinMCLs_));
+                                                            nintSizeCLsinTSTs_,
+                                                            minSizeCLsinTSTs_,
+                                                            maxSizeCLsinTSTs_));
 
   histograms.h_multiplicity_numberOfEventsHistogram.push_back(ibook.book1D("multiplicity_numberOfEventsHistogram",
                                                                            "multiplicity numberOfEventsHistogram",
@@ -1151,8 +1151,8 @@ void HGVHistoProducerAlgo::bookMultiClusterHistos(DQMStore::IBooker& ibook,
                    minMplofLCs_,
                    maxMplofLCs_));
 
-  histograms.h_multiplicityOfLCinMCL_vs_layercluster_zminus.push_back(
-      ibook.book2D("multiplicityOfLCinMCL_vs_layercluster_zminus",
+  histograms.h_multiplicityOfLCinTST_vs_layercluster_zminus.push_back(
+      ibook.book2D("multiplicityOfLCinTST_vs_layercluster_zminus",
                    "Multiplicity vs Layer number in z-",
                    nintMplofLCs_,
                    minMplofLCs_,
@@ -1161,8 +1161,8 @@ void HGVHistoProducerAlgo::bookMultiClusterHistos(DQMStore::IBooker& ibook,
                    0.,
                    (float)layers));
 
-  histograms.h_multiplicityOfLCinMCL_vs_layercluster_zplus.push_back(
-      ibook.book2D("multiplicityOfLCinMCL_vs_layercluster_zplus",
+  histograms.h_multiplicityOfLCinTST_vs_layercluster_zplus.push_back(
+      ibook.book2D("multiplicityOfLCinTST_vs_layercluster_zplus",
                    "Multiplicity vs Layer number in z+",
                    nintMplofLCs_,
                    minMplofLCs_,
@@ -1171,8 +1171,8 @@ void HGVHistoProducerAlgo::bookMultiClusterHistos(DQMStore::IBooker& ibook,
                    0.,
                    (float)layers));
 
-  histograms.h_multiplicityOfLCinMCL_vs_layerclusterenergy.push_back(
-      ibook.book2D("multiplicityOfLCinMCL_vs_layerclusterenergy",
+  histograms.h_multiplicityOfLCinTST_vs_layerclusterenergy.push_back(
+      ibook.book2D("multiplicityOfLCinTST_vs_layerclusterenergy",
                    "Multiplicity vs Layer cluster energy",
                    nintMplofLCs_,
                    minMplofLCs_,
@@ -1181,26 +1181,26 @@ void HGVHistoProducerAlgo::bookMultiClusterHistos(DQMStore::IBooker& ibook,
                    minClEnepermultiplicity_,
                    maxClEnepermultiplicity_));
 
-  histograms.h_multicluster_pt.push_back(
-      ibook.book1D("multicluster_pt", "Pt of the multicluster", nintPt_, minPt_, maxPt_));
-  histograms.h_multicluster_eta.push_back(
-      ibook.book1D("multicluster_eta", "Eta of the multicluster", nintEta_, minEta_, maxEta_));
-  histograms.h_multicluster_phi.push_back(
-      ibook.book1D("multicluster_phi", "Phi of the multicluster", nintPhi_, minPhi_, maxPhi_));
-  histograms.h_multicluster_energy.push_back(
-      ibook.book1D("multicluster_energy", "Energy of the multicluster", nintEne_, minEne_, maxEne_));
-  histograms.h_multicluster_x.push_back(
-      ibook.book1D("multicluster_x", "X position of the multicluster", nintX_, minX_, maxX_));
-  histograms.h_multicluster_y.push_back(
-      ibook.book1D("multicluster_y", "Y position of the multicluster", nintY_, minY_, maxY_));
-  histograms.h_multicluster_z.push_back(
-      ibook.book1D("multicluster_z", "Z position of the multicluster", nintZ_, minZ_, maxZ_));
-  histograms.h_multicluster_firstlayer.push_back(
-      ibook.book1D("multicluster_firstlayer", "First layer of the multicluster", 2 * layers, 0., (float)2 * layers));
-  histograms.h_multicluster_lastlayer.push_back(
-      ibook.book1D("multicluster_lastlayer", "Last layer of the multicluster", 2 * layers, 0., (float)2 * layers));
-  histograms.h_multicluster_layersnum.push_back(ibook.book1D(
-      "multicluster_layersnum", "Number of layers of the multicluster", 2 * layers, 0., (float)2 * layers));
+  histograms.h_trackster_pt.push_back(
+      ibook.book1D("trackster_pt", "Pt of the Trackster", nintPt_, minPt_, maxPt_));
+  histograms.h_trackster_eta.push_back(
+      ibook.book1D("trackster_eta", "Eta of the Trackster", nintEta_, minEta_, maxEta_));
+  histograms.h_trackster_phi.push_back(
+      ibook.book1D("trackster_phi", "Phi of the Trackster", nintPhi_, minPhi_, maxPhi_));
+  histograms.h_trackster_energy.push_back(
+      ibook.book1D("trackster_energy", "Energy of the Trackster", nintEne_, minEne_, maxEne_));
+  histograms.h_trackster_x.push_back(
+      ibook.book1D("trackster_x", "X position of the Trackster", nintX_, minX_, maxX_));
+  histograms.h_trackster_y.push_back(
+      ibook.book1D("trackster_y", "Y position of the Trackster", nintY_, minY_, maxY_));
+  histograms.h_trackster_z.push_back(
+      ibook.book1D("trackster_z", "Z position of the Trackster", nintZ_, minZ_, maxZ_));
+  histograms.h_trackster_firstlayer.push_back(
+      ibook.book1D("trackster_firstlayer", "First layer of the Trackster", 2 * layers, 0., (float)2 * layers));
+  histograms.h_trackster_lastlayer.push_back(
+      ibook.book1D("trackster_lastlayer", "Last layer of the Trackster", 2 * layers, 0., (float)2 * layers));
+  histograms.h_trackster_layersnum.push_back(ibook.book1D(
+      "trackster_layersnum", "Number of layers of the Trackster", 2 * layers, 0., (float)2 * layers));
 }
 
 void HGVHistoProducerAlgo::fill_info_histos(const Histograms& histograms, unsigned int layers) const {
@@ -2274,28 +2274,29 @@ void HGVHistoProducerAlgo::fill_generic_cluster_histos(const Histograms& histogr
   histograms.h_longdepthbarycentre_zminus[count]->Fill(sumldbarmi / sumeneallclusmi);
 }
 
-void HGVHistoProducerAlgo::multiClusters_to_CaloParticles(const Histograms& histograms,
+void HGVHistoProducerAlgo::tracksters_to_CaloParticles(const Histograms& histograms,
                                                           int count,
-                                                          const std::vector<reco::HGCalMultiCluster>& multiClusters,
+                                                          const ticl::TracksterCollection& tracksters,
+                                                          const reco::CaloClusterCollection& layerClusters,
                                                           std::vector<CaloParticle> const& cP,
                                                           std::vector<size_t> const& cPIndices,
                                                           std::vector<size_t> const& cPSelectedIndices,
                                                           std::unordered_map<DetId, const HGCRecHit*> const& hitMap,
                                                           unsigned int layers) const {
-  auto nMultiClusters = multiClusters.size();
+  auto nTracksters = tracksters.size();
   //Consider CaloParticles coming from the hard scatterer, excluding the PU contribution.
   auto nCaloParticles = cPIndices.size();
 
   std::unordered_map<DetId, std::vector<HGVHistoProducerAlgo::detIdInfoInCluster>> detIdToCaloParticleId_Map;
-  std::unordered_map<DetId, std::vector<HGVHistoProducerAlgo::detIdInfoInMultiCluster>> detIdToMultiClusterId_Map;
-  std::vector<int> tracksters_fakemerge(nMultiClusters, 0);
-  std::vector<int> tracksters_duplicate(nMultiClusters, 0);
+  std::unordered_map<DetId, std::vector<HGVHistoProducerAlgo::detIdInfoInTrackster>> detIdToTracksterId_Map;
+  std::vector<int> tracksters_fakemerge(nTracksters, 0);
+  std::vector<int> tracksters_duplicate(nTracksters, 0);
 
-  // this contains the ids of the caloparticles contributing with at least one hit to the multi cluster and the reconstruction error
-  //cpsInLayerCluster[multicluster][CPids]
-  //Connects a multicluster with all related caloparticles.
-  std::vector<std::vector<std::pair<unsigned int, float>>> cpsInMultiCluster;
-  cpsInMultiCluster.resize(nMultiClusters);
+  // this contains the ids of the CaloParticles contributing with at least one hit to the Trackster and the reconstruction error
+  //cpsInLayerCluster[trackster][CPids]
+  //Connects a Trackster with all related CaloParticles.
+  std::vector<std::vector<std::pair<unsigned int, float>>> cpsInTrackster;
+  cpsInTrackster.resize(nTracksters);
 
   //cPOnLayer[caloparticle][layer]
   //This defines a "calo particle on layer" concept. It is only filled in case
@@ -2374,34 +2375,36 @@ void HGVHistoProducerAlgo::multiClusters_to_CaloParticles(const Histograms& hist
           }
         }
       }  // end of loop through simhits
-    }    // end of loop through simclusters
-  }      // end of loop through caloparticles
+    }    // end of loop through SimClusters
+  }      // end of loop through CaloParticles
 
-  //Loop through multiclusters
-  for (unsigned int mclId = 0; mclId < nMultiClusters; ++mclId) {
-    const auto& hits_and_fractions = multiClusters[mclId].hitsAndFractions();
-    if (!hits_and_fractions.empty()) {
-      std::unordered_map<unsigned, float> CPEnergyInMCL;
+  //Loop through Tracksters
+  for (unsigned int tstId = 0; tstId < nTracksters; ++tstId) {
+    for (const auto lcId : tracksters[tstId].vertices()) {
+      const auto& hits_and_fractions = layerClusters[lcId].hitsAndFractions();
+      if (hits_and_fractions.empty()) continue;
+
+      std::unordered_map<unsigned, float> CPEnergyInTST;
       int maxCPId_byNumberOfHits = -1;
-      unsigned int maxCPNumberOfHitsInMCL = 0;
+      unsigned int maxCPNumberOfHitsInTST = 0;
       int maxCPId_byEnergy = -1;
-      float maxEnergySharedMCLandCP = 0.f;
-      float energyFractionOfMCLinCP = 0.f;
-      float energyFractionOfCPinMCL = 0.f;
+      float maxEnergySharedTSTandCP = 0.f;
+      float energyFractionOfTSTinCP = 0.f;
+      float energyFractionOfCPinTST = 0.f;
 
       //In case of matched rechit-simhit, so matched
-      //caloparticle-layercluster-multicluster, he counts and saves the number of
+      //CaloParticle-LayerCluster-Trackster, he counts and saves the number of
       //rechits related to the maximum energy CaloParticle out of all
-      //CaloParticles related to that layer cluster and multicluster.
+      //CaloParticles related to that layer cluster and Trackster.
 
-      std::unordered_map<unsigned, unsigned> occurrencesCPinMCL;
-      unsigned int numberOfNoiseHitsInMCL = 0;
-      unsigned int numberOfHaloHitsInMCL = 0;
-      unsigned int numberOfHitsInMCL = 0;
+      std::unordered_map<unsigned, unsigned> occurrencesCPinTST;
+      unsigned int numberOfNoiseHitsInTST = 0;
+      unsigned int numberOfHaloHitsInTST = 0;
+      unsigned int numberOfHitsInTST = 0;
 
       //number of hits related to that cluster.
       unsigned int numberOfHitsInLC = hits_and_fractions.size();
-      numberOfHitsInMCL += numberOfHitsInLC;
+      numberOfHitsInTST += numberOfHitsInLC;
       std::unordered_map<unsigned, float> CPEnergyInLC;
 
       //hitsToCaloParticleId is a vector of ints, one for each rechit of the
@@ -2444,12 +2447,12 @@ void HGVHistoProducerAlgo::multiClusters_to_CaloParticles(const Histograms& hist
         //So, something like:
         //detid: (layer cluster 1, hit fraction) , (layer cluster 2, hit fraction), (layer cluster 3, hit fraction) ...
         //here comparing with the calo particle map above the
-        auto hit_find_in_LC = detIdToMultiClusterId_Map.find(rh_detid);
-        if (hit_find_in_LC == detIdToMultiClusterId_Map.end()) {
-          detIdToMultiClusterId_Map[rh_detid] = std::vector<HGVHistoProducerAlgo::detIdInfoInMultiCluster>();
+        auto hit_find_in_LC = detIdToTracksterId_Map.find(rh_detid);
+        if (hit_find_in_LC == detIdToTracksterId_Map.end()) {
+          detIdToTracksterId_Map[rh_detid] = std::vector<HGVHistoProducerAlgo::detIdInfoInTrackster>();
         }
-        detIdToMultiClusterId_Map[rh_detid].emplace_back(
-            HGVHistoProducerAlgo::detIdInfoInMultiCluster{mclId, mclId, rhFraction});
+        detIdToTracksterId_Map[rh_detid].emplace_back(
+            HGVHistoProducerAlgo::detIdInfoInTrackster{tstId, tstId, rhFraction});
 
         //Check whether the rechit of the layer cluster under study has a sim hit in the same cell.
         auto hit_find_in_CP = detIdToCaloParticleId_Map.find(rh_detid);
@@ -2462,7 +2465,7 @@ void HGVHistoProducerAlgo::multiClusters_to_CaloParticles(const Histograms& hist
         // real hit that has been marked as halo.
         if (rhFraction == 0.) {
           hitsToCaloParticleId[hitId] = -2;
-          numberOfHaloHitsInMCL++;
+          numberOfHaloHitsInTST++;
         }
         if (hit_find_in_CP == detIdToCaloParticleId_Map.end()) {
           hitsToCaloParticleId[hitId] -= 1;
@@ -2475,21 +2478,21 @@ void HGVHistoProducerAlgo::multiClusters_to_CaloParticles(const Histograms& hist
             //So, from all layers clusters, find the rechits that are connected with a calo particle and save/calculate the
             //energy of that calo particle as the sum over all rechits of the rechits energy weighted
             //by the caloparticle's fraction related to that rechit.
-            CPEnergyInMCL[h.clusterId] += shared_fraction * hit->energy();
+            CPEnergyInTST[h.clusterId] += shared_fraction * hit->energy();
             //Same but for layer clusters for the cell association per layer
             CPEnergyInLC[h.clusterId] += shared_fraction * hit->energy();
             //Here cPOnLayer[caloparticle][layer] describe above is set.
-            //Here for multi clusters with matched rechit the CP fraction times hit energy is added and saved .
-            cPOnLayer[h.clusterId][lcLayerId].layerClusterIdToEnergyAndScore[mclId].first +=
+            //Here for Tracksters with matched rechit the CP fraction times hit energy is added and saved .
+            cPOnLayer[h.clusterId][lcLayerId].layerClusterIdToEnergyAndScore[tstId].first +=
                 shared_fraction * hit->energy();
-            cPOnLayer[h.clusterId][lcLayerId].layerClusterIdToEnergyAndScore[mclId].second = FLT_MAX;
-            //cpsInMultiCluster[multicluster][CPids]
-            //Connects a multi cluster with all related caloparticles.
-            cpsInMultiCluster[mclId].emplace_back(h.clusterId, FLT_MAX);
+            cPOnLayer[h.clusterId][lcLayerId].layerClusterIdToEnergyAndScore[tstId].second = FLT_MAX;
+            //cpsInTrackster[trackster][CPids]
+            //Connects a Trackster with all related CaloParticles.
+            cpsInTrackster[tstId].emplace_back(h.clusterId, FLT_MAX);
             //From all CaloParticles related to a layer cluster, he saves id and energy of the calo particle
             //that after simhit-rechit matching in layer has the maximum energy.
             if (shared_fraction > maxCPEnergyInLC) {
-              //energy is used only here. cpid is saved for multiclusters
+              //energy is used only here. cpid is saved for Tracksters
               maxCPEnergyInLC = CPEnergyInLC[h.clusterId];
               maxCPId = h.clusterId;
             }
@@ -2504,42 +2507,42 @@ void HGVHistoProducerAlgo::multiClusters_to_CaloParticles(const Histograms& hist
       //In case of matched rechit-simhit, he counts and saves the number of rechits related to the maximum energy CaloParticle.
       for (auto c : hitsToCaloParticleId) {
         if (c < 0) {
-          numberOfNoiseHitsInMCL++;
+          numberOfNoiseHitsInTST++;
         } else {
-          occurrencesCPinMCL[c]++;
+          occurrencesCPinTST[c]++;
         }
       }
 
       //Below from all maximum energy CaloParticles, he saves the one with the largest amount
       //of related rechits.
-      for (auto& c : occurrencesCPinMCL) {
-        if (c.second > maxCPNumberOfHitsInMCL) {
+      for (auto& c : occurrencesCPinTST) {
+        if (c.second > maxCPNumberOfHitsInTST) {
           maxCPId_byNumberOfHits = c.first;
-          maxCPNumberOfHitsInMCL = c.second;
+          maxCPNumberOfHitsInTST = c.second;
         }
       }
 
-      //Find the CaloParticle that has the maximum energy shared with the multicluster under study.
-      for (auto& c : CPEnergyInMCL) {
-        if (c.second > maxEnergySharedMCLandCP) {
+      //Find the CaloParticle that has the maximum energy shared with the Trackster under study.
+      for (auto& c : CPEnergyInTST) {
+        if (c.second > maxEnergySharedTSTandCP) {
           maxCPId_byEnergy = c.first;
-          maxEnergySharedMCLandCP = c.second;
+          maxEnergySharedTSTandCP = c.second;
         }
       }
-      //The energy of the CaloParticle that found to have the maximum energy shared with the multicluster under study.
+      //The energy of the CaloParticle that found to have the maximum energy shared with the Trackster under study.
       float totalCPEnergyFromLayerCP = 0.f;
       if (maxCPId_byEnergy >= 0) {
         //Loop through all layers
         for (unsigned int j = 0; j < layers * 2; ++j) {
           totalCPEnergyFromLayerCP = totalCPEnergyFromLayerCP + cPOnLayer[maxCPId_byEnergy][j].energy;
         }
-        energyFractionOfCPinMCL = maxEnergySharedMCLandCP / totalCPEnergyFromLayerCP;
-        if (multiClusters[mclId].energy() > 0.f) {
-          energyFractionOfMCLinCP = maxEnergySharedMCLandCP / multiClusters[mclId].energy();
+        energyFractionOfCPinTST = maxEnergySharedTSTandCP / totalCPEnergyFromLayerCP;
+        if (tracksters[tstId].raw_energy() > 0.f) {
+          energyFractionOfTSTinCP = maxEnergySharedTSTandCP / tracksters[tstId].raw_energy();
         }
       }
 
-      LogDebug("HGCalValidator") << std::setw(12) << "multiCluster"
+      LogDebug("HGCalValidator") << std::setw(12) << "Trackster"
                                  << "\t"  //LogDebug("HGCalValidator")
                                  << std::setw(10) << "mulcl energy"
                                  << "\t" << std::setw(5) << "nhits"
@@ -2547,51 +2550,52 @@ void HGVHistoProducerAlgo::multiClusters_to_CaloParticles(const Histograms& hist
                                  << "\t" << std::setw(22) << "maxCPId_byNumberOfHits"
                                  << "\t" << std::setw(8) << "nhitsCP"
                                  << "\t" << std::setw(16) << "maxCPId_byEnergy"
-                                 << "\t" << std::setw(23) << "maxEnergySharedMCLandCP"
+                                 << "\t" << std::setw(23) << "maxEnergySharedTSTandCP"
                                  << "\t" << std::setw(22) << "totalCPEnergyFromAllLayerCP"
-                                 << "\t" << std::setw(22) << "energyFractionOfMCLinCP"
-                                 << "\t" << std::setw(25) << "energyFractionOfCPinMCL"
+                                 << "\t" << std::setw(22) << "energyFractionOfTSTinCP"
+                                 << "\t" << std::setw(25) << "energyFractionOfCPinTST"
                                  << "\t" << std::endl;
-      LogDebug("HGCalValidator") << std::setw(12) << mclId << "\t"  //LogDebug("HGCalValidator")
-                                 << std::setw(10) << multiClusters[mclId].energy() << "\t" << std::setw(5)
-                                 << numberOfHitsInMCL << "\t" << std::setw(12) << numberOfNoiseHitsInMCL << "\t"
+      LogDebug("HGCalValidator") << std::setw(12) << tstId << "\t"  //LogDebug("HGCalValidator")
+                                 << std::setw(10) << tracksters[tstId].raw_energy() << "\t" << std::setw(5)
+                                 << numberOfHitsInTST << "\t" << std::setw(12) << numberOfNoiseHitsInTST << "\t"
                                  << std::setw(22) << maxCPId_byNumberOfHits << "\t" << std::setw(8)
-                                 << maxCPNumberOfHitsInMCL << "\t" << std::setw(16) << maxCPId_byEnergy << "\t"
-                                 << std::setw(23) << maxEnergySharedMCLandCP << "\t" << std::setw(22)
-                                 << totalCPEnergyFromLayerCP << "\t" << std::setw(22) << energyFractionOfMCLinCP << "\t"
-                                 << std::setw(25) << energyFractionOfCPinMCL << std::endl;
+                                 << maxCPNumberOfHitsInTST << "\t" << std::setw(16) << maxCPId_byEnergy << "\t"
+                                 << std::setw(23) << maxEnergySharedTSTandCP << "\t" << std::setw(22)
+                                 << totalCPEnergyFromLayerCP << "\t" << std::setw(22) << energyFractionOfTSTinCP << "\t"
+                                 << std::setw(25) << energyFractionOfCPinTST << std::endl;
 
-    }  //end of loop through multi clusters
-  }
-  //Loop through multiclusters
-  for (unsigned int mclId = 0; mclId < nMultiClusters; ++mclId) {
-    const auto& hits_and_fractions = multiClusters[mclId].hitsAndFractions();
-    if (!hits_and_fractions.empty()) {
-      // find the unique caloparticles id contributing to the multi clusters
-      //cpsInMultiCluster[multicluster][CPids]
-      std::sort(cpsInMultiCluster[mclId].begin(), cpsInMultiCluster[mclId].end());
-      auto last = std::unique(cpsInMultiCluster[mclId].begin(), cpsInMultiCluster[mclId].end());
-      cpsInMultiCluster[mclId].erase(last, cpsInMultiCluster[mclId].end());
+    }  //end of loop through Trackster's layerClusters
+  } //end of loop through Tracksters
+  //Loop through Tracksters
+  for (unsigned int tstId = 0; tstId < nTracksters; ++tstId) {
+    for (const auto lcId : tracksters[tstId].vertices()) {
+      const auto& hits_and_fractions = layerClusters[lcId].hitsAndFractions();
+      if (hits_and_fractions.empty()) continue;
+      // find the unique CaloParticles id contributing to the Tracksters
+      //cpsInTrackster[trackster][CPids]
+      std::sort(cpsInTrackster[tstId].begin(), cpsInTrackster[tstId].end());
+      auto last = std::unique(cpsInTrackster[tstId].begin(), cpsInTrackster[tstId].end());
+      cpsInTrackster[tstId].erase(last, cpsInTrackster[tstId].end());
 
-      if (multiClusters[mclId].energy() == 0. && !cpsInMultiCluster[mclId].empty()) {
-        //Loop through all CaloParticles contributing to multicluster mclId.
-        for (auto& cpPair : cpsInMultiCluster[mclId]) {
-          //In case of a multi cluster with zero energy but related CaloParticles the score is set to 1.
+      if (tracksters[tstId].raw_energy() == 0. && !cpsInTrackster[tstId].empty()) {
+        //Loop through all CaloParticles contributing to Trackster tstId.
+        for (auto& cpPair : cpsInTrackster[tstId]) {
+          //In case of a Trackster with zero energy but related CaloParticles the score is set to 1.
           cpPair.second = 1.;
-          LogDebug("HGCalValidator") << "multiCluster Id: \t" << mclId << "\t CP id: \t" << cpPair.first
+          LogDebug("HGCalValidator") << "Trackster Id: \t" << tstId << "\t CP id: \t" << cpPair.first
                                      << "\t score \t" << cpPair.second << std::endl;
-          histograms.h_score_multicl2caloparticle[count]->Fill(cpPair.second);
+          histograms.h_score_trackster2caloparticle[count]->Fill(cpPair.second);
         }
         continue;
       }
 
       // Compute the correct normalization
-      float invMultiClusterEnergyWeight = 0.f;
-      for (auto const& haf : multiClusters[mclId].hitsAndFractions()) {
-        invMultiClusterEnergyWeight +=
+      float invTracksterEnergyWeight = 0.f;
+      for (auto const& haf : hits_and_fractions) {
+        invTracksterEnergyWeight +=
             (haf.second * hitMap.at(haf.first)->energy()) * (haf.second * hitMap.at(haf.first)->energy());
       }
-      invMultiClusterEnergyWeight = 1.f / invMultiClusterEnergyWeight;
+      invTracksterEnergyWeight = 1.f / invTracksterEnergyWeight;
 
       unsigned int numberOfHitsInLC = hits_and_fractions.size();
       for (unsigned int i = 0; i < numberOfHitsInLC; ++i) {
@@ -2606,7 +2610,7 @@ void HGVHistoProducerAlgo::multiClusters_to_CaloParticles(const Histograms& hist
         const HGCRecHit* hit = itcheck->second;
         float hitEnergyWeight = hit->energy() * hit->energy();
 
-        for (auto& cpPair : cpsInMultiCluster[mclId]) {
+        for (auto& cpPair : cpsInTrackster[tstId]) {
           float cpFraction = 0.f;
           if (!hitWithNoCP) {
             auto findHitIt = std::find(detIdToCaloParticleId_Map[rh_detid].begin(),
@@ -2620,63 +2624,63 @@ void HGVHistoProducerAlgo::multiClusters_to_CaloParticles(const Histograms& hist
             cpPair.second = 0.f;
           }
           cpPair.second +=
-              (rhFraction - cpFraction) * (rhFraction - cpFraction) * hitEnergyWeight * invMultiClusterEnergyWeight;
+              (rhFraction - cpFraction) * (rhFraction - cpFraction) * hitEnergyWeight * invTracksterEnergyWeight;
         }
       }  //end of loop through rechits of layer cluster
 
-      //In case of a multi cluster with some energy but none related CaloParticles print some info.
-      if (cpsInMultiCluster[mclId].empty())
-        LogDebug("HGCalValidator") << "multiCluster Id: \t" << mclId << "\tCP id:\t-1 "
+      //In case of a Trackster with some energy but none related CaloParticles print some info.
+      if (cpsInTrackster[tstId].empty())
+        LogDebug("HGCalValidator") << "Trackster Id: \t" << tstId << "\tCP id:\t-1 "
                                    << "\t score \t-1"
                                    << "\n";
 
-      auto score = std::min_element(std::begin(cpsInMultiCluster[mclId]),
-                                    std::end(cpsInMultiCluster[mclId]),
+      auto score = std::min_element(std::begin(cpsInTrackster[tstId]),
+                                    std::end(cpsInTrackster[tstId]),
                                     [](const auto& obj1, const auto& obj2) { return obj1.second < obj2.second; });
-      for (auto& cpPair : cpsInMultiCluster[mclId]) {
-        // LogDebug("HGCalValidator") << "multiCluster Id: \t" << mclId
+      for (auto& cpPair : cpsInTrackster[tstId]) {
+        // LogDebug("HGCalValidator") << "Trackster Id: \t" << tstId
         // 			   << "\t CP id: \t" << cpPair.first
         // 			   << "\t score \t" << cpPair.second
         // 			   << "\n";
-        LogDebug("HGCalValidator") << "multiCluster Id: \t" << mclId << "\t CP id: \t" << cpPair.first << "\t score \t"
+        LogDebug("HGCalValidator") << "Trackster Id: \t" << tstId << "\t CP id: \t" << cpPair.first << "\t score \t"
                                    << cpPair.second << std::endl;
         if (cpPair.first == score->first) {
-          histograms.h_score_multicl2caloparticle[count]->Fill(score->second);
+          histograms.h_score_trackster2caloparticle[count]->Fill(score->second);
         }
         float sharedeneCPallLayers = 0.;
         //Loop through all layers
         for (unsigned int j = 0; j < layers * 2; ++j) {
-          auto const& cp_linked = cPOnLayer[cpPair.first][j].layerClusterIdToEnergyAndScore[mclId];
+          auto const& cp_linked = cPOnLayer[cpPair.first][j].layerClusterIdToEnergyAndScore[tstId];
           sharedeneCPallLayers += cp_linked.first;
         }  //end of loop through layers
         LogDebug("HGCalValidator") << "sharedeneCPallLayers " << sharedeneCPallLayers << std::endl;
         if (cpPair.first == score->first) {
-          histograms.h_sharedenergy_multicl2caloparticle[count]->Fill(sharedeneCPallLayers /
-                                                                      multiClusters[mclId].energy());
-          histograms.h_energy_vs_score_multicl2caloparticle[count]->Fill(
-              score->second, sharedeneCPallLayers / multiClusters[mclId].energy());
+          histograms.h_sharedenergy_trackster2caloparticle[count]->Fill(sharedeneCPallLayers /
+                                                                      tracksters[tstId].raw_energy());
+          histograms.h_energy_vs_score_trackster2caloparticle[count]->Fill(
+              score->second, sharedeneCPallLayers / tracksters[tstId].raw_energy());
         }
       }
-      auto assocFakeMerge = std::count_if(std::begin(cpsInMultiCluster[mclId]),
-                                          std::end(cpsInMultiCluster[mclId]),
-                                          [](const auto& obj) { return obj.second < ScoreCutMCLtoCPFakeMerge_; });
-      tracksters_fakemerge[mclId] = assocFakeMerge;
-    }
-  }  //end of loop through multiclusters
+      auto assocFakeMerge = std::count_if(std::begin(cpsInTrackster[tstId]),
+                                          std::end(cpsInTrackster[tstId]),
+                                          [](const auto& obj) { return obj.second < ScoreCutTSTtoCPFakeMerge_; });
+      tracksters_fakemerge[tstId] = assocFakeMerge;
+    }  //end of loop through Trackster's layerClusters
+  }  //end of loop through Tracksters
 
   std::unordered_map<int, std::vector<float>> score3d;
-  std::unordered_map<int, std::vector<float>> mclsharedenergy;
-  std::unordered_map<int, std::vector<float>> mclsharedenergyfrac;
+  std::unordered_map<int, std::vector<float>> tstSharedEnergy;
+  std::unordered_map<int, std::vector<float>> tstSharedEnergyFrac;
 
   for (unsigned int i = 0; i < nCaloParticles; ++i) {
     auto cpIndex = cPIndices[i];
-    score3d[cpIndex].resize(nMultiClusters);
-    mclsharedenergy[cpIndex].resize(nMultiClusters);
-    mclsharedenergyfrac[cpIndex].resize(nMultiClusters);
-    for (unsigned int j = 0; j < nMultiClusters; ++j) {
+    score3d[cpIndex].resize(nTracksters);
+    tstSharedEnergy[cpIndex].resize(nTracksters);
+    tstSharedEnergyFrac[cpIndex].resize(nTracksters);
+    for (unsigned int j = 0; j < nTracksters; ++j) {
       score3d[cpIndex][j] = FLT_MAX;
-      mclsharedenergy[cpIndex][j] = 0.f;
-      mclsharedenergyfrac[cpIndex][j] = 0.f;
+      tstSharedEnergy[cpIndex][j] = 0.f;
+      tstSharedEnergyFrac[cpIndex][j] = 0.f;
     }
   }
 
@@ -2684,86 +2688,86 @@ void HGVHistoProducerAlgo::multiClusters_to_CaloParticles(const Histograms& hist
   // gen-level, namely efficiency an duplicate. In this loop we should restrict
   // only to the selected caloParaticles.
   for (const auto& cpId : cPSelectedIndices) {
-    //We need to keep the multiclusters ids that are related to
+    //We need to keep the Tracksters ids that are related to
     //CaloParticle under study for the final filling of the score.
-    std::vector<unsigned int> cpId_mclId_related;
-    cpId_mclId_related.clear();
+    std::vector<unsigned int> cpId_tstId_related;
+    cpId_tstId_related.clear();
 
     float CPenergy = 0.f;
     for (unsigned int layerId = 0; layerId < layers * 2; ++layerId) {
       unsigned int CPNumberOfHits = cPOnLayer[cpId][layerId].hits_and_fractions.size();
-      //Below gives the CP energy related to multicluster per layer.
+      //Below gives the CP energy related to Trackster per layer.
       CPenergy += cPOnLayer[cpId][layerId].energy;
       if (CPNumberOfHits == 0)
         continue;
-      int mclWithMaxEnergyInCP = -1;
-      //This is the maximum energy related to multicluster per layer.
-      float maxEnergyMCLperlayerinCP = 0.f;
-      float CPEnergyFractionInMCLperlayer = 0.f;
-      //Remember and not confused by name. layerClusterIdToEnergyAndScore contains the multicluster id.
-      for (const auto& mcl : cPOnLayer[cpId][layerId].layerClusterIdToEnergyAndScore) {
-        if (mcl.second.first > maxEnergyMCLperlayerinCP) {
-          maxEnergyMCLperlayerinCP = mcl.second.first;
-          mclWithMaxEnergyInCP = mcl.first;
+      int tstWithMaxEnergyInCP = -1;
+      //This is the maximum energy related to Trackster per layer.
+      float maxEnergyTSTperlayerinCP = 0.f;
+      float CPEnergyFractionInTSTperlayer = 0.f;
+      //Remember and not confused by name. layerClusterIdToEnergyAndScore contains the Trackster id.
+      for (const auto& tst : cPOnLayer[cpId][layerId].layerClusterIdToEnergyAndScore) {
+        if (tst.second.first > maxEnergyTSTperlayerinCP) {
+          maxEnergyTSTperlayerinCP = tst.second.first;
+          tstWithMaxEnergyInCP = tst.first;
         }
       }
       if (CPenergy > 0.f)
-        CPEnergyFractionInMCLperlayer = maxEnergyMCLperlayerinCP / CPenergy;
+        CPEnergyFractionInTSTperlayer = maxEnergyTSTperlayerinCP / CPenergy;
 
       LogDebug("HGCalValidator") << std::setw(8) << "LayerId:\t" << std::setw(12) << "caloparticle\t" << std::setw(15)
                                  << "cp total energy\t" << std::setw(15) << "cpEnergyOnLayer\t" << std::setw(14)
-                                 << "CPNhitsOnLayer\t" << std::setw(18) << "mclWithMaxEnergyInCP\t" << std::setw(15)
-                                 << "maxEnergyMCLinCP\t" << std::setw(20) << "CPEnergyFractionInMCL"
+                                 << "CPNhitsOnLayer\t" << std::setw(18) << "tstWithMaxEnergyInCP\t" << std::setw(15)
+                                 << "maxEnergyTSTinCP\t" << std::setw(20) << "CPEnergyFractionInTST"
                                  << "\n";
       LogDebug("HGCalValidator") << std::setw(8) << layerId << "\t" << std::setw(12) << cpId << "\t" << std::setw(15)
                                  << cP[cpId].energy() << "\t" << std::setw(15) << CPenergy << "\t" << std::setw(14)
-                                 << CPNumberOfHits << "\t" << std::setw(18) << mclWithMaxEnergyInCP << "\t"
-                                 << std::setw(15) << maxEnergyMCLperlayerinCP << "\t" << std::setw(20)
-                                 << CPEnergyFractionInMCLperlayer << "\n";
+                                 << CPNumberOfHits << "\t" << std::setw(18) << tstWithMaxEnergyInCP << "\t"
+                                 << std::setw(15) << maxEnergyTSTperlayerinCP << "\t" << std::setw(20)
+                                 << CPEnergyFractionInTSTperlayer << "\n";
 
       for (unsigned int i = 0; i < CPNumberOfHits; ++i) {
         auto& cp_hitDetId = cPOnLayer[cpId][layerId].hits_and_fractions[i].first;
         auto& cpFraction = cPOnLayer[cpId][layerId].hits_and_fractions[i].second;
 
-        bool hitWithNoMCL = false;
+        bool hitWithNoTST = false;
         if (cpFraction == 0.f)
           continue;  //hopefully this should never happen
-        auto hit_find_in_MCL = detIdToMultiClusterId_Map.find(cp_hitDetId);
-        if (hit_find_in_MCL == detIdToMultiClusterId_Map.end())
-          hitWithNoMCL = true;
+        auto hit_find_in_TST = detIdToTracksterId_Map.find(cp_hitDetId);
+        if (hit_find_in_TST == detIdToTracksterId_Map.end())
+          hitWithNoTST = true;
         auto itcheck = hitMap.find(cp_hitDetId);
         const HGCRecHit* hit = itcheck->second;
         float hitEnergyWeight = hit->energy() * hit->energy();
         for (auto& lcPair : cPOnLayer[cpId][layerId].layerClusterIdToEnergyAndScore) {
-          unsigned int multiClusterId = lcPair.first;
-          if (std::find(std::begin(cpId_mclId_related), std::end(cpId_mclId_related), multiClusterId) ==
-              std::end(cpId_mclId_related)) {
-            cpId_mclId_related.push_back(multiClusterId);
+          unsigned int tracksterId = lcPair.first;
+          if (std::find(std::begin(cpId_tstId_related), std::end(cpId_tstId_related), tracksterId) ==
+              std::end(cpId_tstId_related)) {
+            cpId_tstId_related.push_back(tracksterId);
           }
-          float mclFraction = 0.f;
+          float tstFraction = 0.f;
 
-          if (!hitWithNoMCL) {
-            auto findHitIt = std::find(detIdToMultiClusterId_Map[cp_hitDetId].begin(),
-                                       detIdToMultiClusterId_Map[cp_hitDetId].end(),
-                                       HGVHistoProducerAlgo::detIdInfoInMultiCluster{multiClusterId, 0, 0.f});
-            if (findHitIt != detIdToMultiClusterId_Map[cp_hitDetId].end())
-              mclFraction = findHitIt->fraction;
+          if (!hitWithNoTST) {
+            auto findHitIt = std::find(detIdToTracksterId_Map[cp_hitDetId].begin(),
+                                       detIdToTracksterId_Map[cp_hitDetId].end(),
+                                       HGVHistoProducerAlgo::detIdInfoInTrackster{tracksterId, 0, 0.f});
+            if (findHitIt != detIdToTracksterId_Map[cp_hitDetId].end())
+              tstFraction = findHitIt->fraction;
           }
           //Observe here that we do not divide as before by the layer cluster energy weight. We should sum first
           //over all layers and divide with the total CP energy over all layers.
           if (lcPair.second.second == FLT_MAX) {
             lcPair.second.second = 0.f;
           }
-          lcPair.second.second += (mclFraction - cpFraction) * (mclFraction - cpFraction) * hitEnergyWeight;
-          LogDebug("HGCalValidator") << "multiClusterId:\t" << multiClusterId << "\t"
-                                     << "mclfraction,cpfraction:\t" << mclFraction << ", " << cpFraction << "\t"
+          lcPair.second.second += (tstFraction - cpFraction) * (tstFraction - cpFraction) * hitEnergyWeight;
+          LogDebug("HGCalValidator") << "TracksterId:\t" << tracksterId << "\t"
+                                     << "tstfraction,cpfraction:\t" << tstFraction << ", " << cpFraction << "\t"
                                      << "hitEnergyWeight:\t" << hitEnergyWeight << "\t"
                                      << "currect score numerator:\t" << lcPair.second.second << "\n";
         }
       }  //end of loop through sim hits of current calo particle
 
       if (cPOnLayer[cpId][layerId].layerClusterIdToEnergyAndScore.empty())
-        LogDebug("HGCalValidator") << "CP Id: \t" << cpId << "\t MCL id:\t-1 "
+        LogDebug("HGCalValidator") << "CP Id: \t" << cpId << "\t TST id:\t-1 "
                                    << "\t layer \t " << layerId << " Sub score in \t -1"
                                    << "\n";
 
@@ -2773,7 +2777,7 @@ void HGVHistoProducerAlgo::multiClusters_to_CaloParticles(const Histograms& hist
           score3d[cpId][lcPair.first] = 0.f;
         }
         score3d[cpId][lcPair.first] += lcPair.second.second;
-        mclsharedenergy[cpId][lcPair.first] += lcPair.second.first;
+        tstSharedEnergy[cpId][lcPair.first] += lcPair.second.first;
       }
     }  //end of loop through layers
 
@@ -2790,29 +2794,29 @@ void HGVHistoProducerAlgo::multiClusters_to_CaloParticles(const Histograms& hist
     }
     invCPEnergyWeight = 1.f / invCPEnergyWeight;
 
-    //Loop through related multiclusters here
+    //Loop through related Tracksters here
     //Will switch to vector for access because it is faster
-    std::vector<int> cpId_mclId_related_vec(cpId_mclId_related.begin(), cpId_mclId_related.end());
-    for (unsigned int i = 0; i < cpId_mclId_related_vec.size(); ++i) {
-      auto mclId = cpId_mclId_related_vec[i];
+    std::vector<int> cpId_tstId_related_vec(cpId_tstId_related.begin(), cpId_tstId_related.end());
+    for (unsigned int i = 0; i < cpId_tstId_related_vec.size(); ++i) {
+      auto tstId = cpId_tstId_related_vec[i];
       //Now time for the denominator
-      score3d[cpId][mclId] = score3d[cpId][mclId] * invCPEnergyWeight;
-      mclsharedenergyfrac[cpId][mclId] = (mclsharedenergy[cpId][mclId] / CPenergy);
+      score3d[cpId][tstId] = score3d[cpId][tstId] * invCPEnergyWeight;
+      tstSharedEnergyFrac[cpId][tstId] = (tstSharedEnergy[cpId][tstId] / CPenergy);
 
-      LogDebug("HGCalValidator") << "CP Id: \t" << cpId << "\t MCL id: \t" << mclId << "\t score \t"  //
-                                 << score3d[cpId][mclId] << "\t"
+      LogDebug("HGCalValidator") << "CP Id: \t" << cpId << "\t TST id: \t" << tstId << "\t score \t"  //
+                                 << score3d[cpId][tstId] << "\t"
                                  << "invCPEnergyWeight \t" << invCPEnergyWeight << "\t"
-                                 << "shared energy:\t" << mclsharedenergy[cpId][mclId] << "\t"
-                                 << "shared energy fraction:\t" << mclsharedenergyfrac[cpId][mclId] << "\n";
+                                 << "shared energy:\t" << tstSharedEnergy[cpId][tstId] << "\t"
+                                 << "shared energy fraction:\t" << tstSharedEnergyFrac[cpId][tstId] << "\n";
 
-      histograms.h_score_caloparticle2multicl[count]->Fill(score3d[cpId][mclId]);
+      histograms.h_score_caloparticle2trackster[count]->Fill(score3d[cpId][tstId]);
 
-      histograms.h_sharedenergy_caloparticle2multicl[count]->Fill(mclsharedenergyfrac[cpId][mclId]);
-      histograms.h_energy_vs_score_caloparticle2multicl[count]->Fill(score3d[cpId][mclId],
-                                                                     mclsharedenergyfrac[cpId][mclId]);
-    }  //end of loop through multiclusters
+      histograms.h_sharedenergy_caloparticle2trackster[count]->Fill(tstSharedEnergyFrac[cpId][tstId]);
+      histograms.h_energy_vs_score_caloparticle2trackster[count]->Fill(score3d[cpId][tstId],
+                                                                     tstSharedEnergyFrac[cpId][tstId]);
+    }  //end of loop through Tracksters
 
-    auto is_assoc = [&](const auto& v) -> bool { return v < ScoreCutCPtoMCLEffDup_; };
+    auto is_assoc = [&](const auto& v) -> bool { return v < ScoreCutCPtoTSTEffDup_; };
 
     auto assocDup = std::count_if(std::begin(score3d[cpId]), std::end(score3d[cpId]), is_assoc);
 
@@ -2820,13 +2824,13 @@ void HGVHistoProducerAlgo::multiClusters_to_CaloParticles(const Histograms& hist
       histograms.h_num_caloparticle_eta[count]->Fill(cP[cpId].g4Tracks()[0].momentum().eta());
       histograms.h_num_caloparticle_phi[count]->Fill(cP[cpId].g4Tracks()[0].momentum().phi());
       auto best = std::min_element(std::begin(score3d[cpId]), std::end(score3d[cpId]));
-      auto bestmclId = std::distance(std::begin(score3d[cpId]), best);
+      auto bestTstId = std::distance(std::begin(score3d[cpId]), best);
 
-      histograms.h_sharedenergy_caloparticle2multicl_vs_eta[count]->Fill(cP[cpId].g4Tracks()[0].momentum().eta(),
-                                                                         multiClusters[bestmclId].energy() / CPenergy);
-      histograms.h_sharedenergy_caloparticle2multicl_vs_phi[count]->Fill(cP[cpId].g4Tracks()[0].momentum().phi(),
-                                                                         multiClusters[bestmclId].energy() / CPenergy);
-      histograms.h_sharedenergy_caloparticle2multicl_assoc[count]->Fill(mclsharedenergyfrac[cpId][bestmclId]);
+      histograms.h_sharedenergy_caloparticle2trackster_vs_eta[count]->Fill(cP[cpId].g4Tracks()[0].momentum().eta(),
+                                                                         tracksters[bestTstId].raw_energy() / CPenergy);
+      histograms.h_sharedenergy_caloparticle2trackster_vs_phi[count]->Fill(cP[cpId].g4Tracks()[0].momentum().phi(),
+                                                                         tracksters[bestTstId].raw_energy() / CPenergy);
+      histograms.h_sharedenergy_caloparticle2trackster_assoc[count]->Fill(tstSharedEnergyFrac[cpId][bestTstId]);
     }
     if (assocDup >= 2) {
       auto match = std::find_if(std::begin(score3d[cpId]), std::end(score3d[cpId]), is_assoc);
@@ -2843,47 +2847,49 @@ void HGVHistoProducerAlgo::multiClusters_to_CaloParticles(const Histograms& hist
   // Here we do fill the plots to compute the different metrics linked to
   // reco-level, namely fake-rate an merge-rate. In this loop we should *not*
   // restrict only to the selected caloParaticles.
-  for (unsigned int mclId = 0; mclId < nMultiClusters; ++mclId) {
-    const auto& hits_and_fractions = multiClusters[mclId].hitsAndFractions();
-    if (!hits_and_fractions.empty()) {
-      auto assocFakeMerge = tracksters_fakemerge[mclId];
-      auto assocDuplicate = tracksters_duplicate[mclId];
+  for (unsigned int tstId = 0; tstId < nTracksters; ++tstId) {
+    for (const auto lcId : tracksters[tstId].vertices()) {
+      const auto& hits_and_fractions = layerClusters[lcId].hitsAndFractions();
+      if (hits_and_fractions.empty()) continue;
+      auto assocFakeMerge = tracksters_fakemerge[tstId];
+      auto assocDuplicate = tracksters_duplicate[tstId];
       if (assocDuplicate) {
-        histograms.h_numDup_multicl_eta[count]->Fill(multiClusters[mclId].eta());
-        histograms.h_numDup_multicl_phi[count]->Fill(multiClusters[mclId].phi());
+        histograms.h_numDup_trackster_eta[count]->Fill(tracksters[tstId].barycenter().eta());
+        histograms.h_numDup_trackster_phi[count]->Fill(tracksters[tstId].barycenter().phi());
       }
       if (assocFakeMerge > 0) {
-        histograms.h_num_multicl_eta[count]->Fill(multiClusters[mclId].eta());
-        histograms.h_num_multicl_phi[count]->Fill(multiClusters[mclId].phi());
-        auto best = std::min_element(std::begin(cpsInMultiCluster[mclId]),
-                                     std::end(cpsInMultiCluster[mclId]),
+        histograms.h_num_trackster_eta[count]->Fill(tracksters[tstId].barycenter().eta());
+        histograms.h_num_trackster_phi[count]->Fill(tracksters[tstId].barycenter().phi());
+        auto best = std::min_element(std::begin(cpsInTrackster[tstId]),
+                                     std::end(cpsInTrackster[tstId]),
                                      [](const auto& obj1, const auto& obj2) { return obj1.second < obj2.second; });
 
         //This is the shared energy taking the best caloparticle in each layer
         float sharedeneCPallLayers = 0.;
         //Loop through all layers
         for (unsigned int j = 0; j < layers * 2; ++j) {
-          auto const& best_cp_linked = cPOnLayer[best->first][j].layerClusterIdToEnergyAndScore[mclId];
+          auto const& best_cp_linked = cPOnLayer[best->first][j].layerClusterIdToEnergyAndScore[tstId];
           sharedeneCPallLayers += best_cp_linked.first;
         }  //end of loop through layers
-        histograms.h_sharedenergy_multicl2caloparticle_vs_eta[count]->Fill(
-            multiClusters[mclId].eta(), sharedeneCPallLayers / multiClusters[mclId].energy());
-        histograms.h_sharedenergy_multicl2caloparticle_vs_phi[count]->Fill(
-            multiClusters[mclId].phi(), sharedeneCPallLayers / multiClusters[mclId].energy());
+        histograms.h_sharedenergy_trackster2caloparticle_vs_eta[count]->Fill(
+            tracksters[tstId].barycenter().eta(), sharedeneCPallLayers / tracksters[tstId].raw_energy());
+        histograms.h_sharedenergy_trackster2caloparticle_vs_phi[count]->Fill(
+            tracksters[tstId].barycenter().phi(), sharedeneCPallLayers / tracksters[tstId].raw_energy());
       }
       if (assocFakeMerge >= 2) {
-        histograms.h_numMerge_multicl_eta[count]->Fill(multiClusters[mclId].eta());
-        histograms.h_numMerge_multicl_phi[count]->Fill(multiClusters[mclId].phi());
+        histograms.h_numMerge_trackster_eta[count]->Fill(tracksters[tstId].barycenter().eta());
+        histograms.h_numMerge_trackster_phi[count]->Fill(tracksters[tstId].barycenter().phi());
       }
-      histograms.h_denom_multicl_eta[count]->Fill(multiClusters[mclId].eta());
-      histograms.h_denom_multicl_phi[count]->Fill(multiClusters[mclId].phi());
+      histograms.h_denom_trackster_eta[count]->Fill(tracksters[tstId].barycenter().eta());
+      histograms.h_denom_trackster_phi[count]->Fill(tracksters[tstId].barycenter().phi());
     }
   }
 }
 
-void HGVHistoProducerAlgo::fill_multi_cluster_histos(const Histograms& histograms,
+void HGVHistoProducerAlgo::fill_trackster_histos(const Histograms& histograms,
                                                      int count,
-                                                     const std::vector<reco::HGCalMultiCluster>& multiClusters,
+                                                     const ticl::TracksterCollection& tracksters,
+                                                     const reco::CaloClusterCollection& layerClusters,
                                                      std::vector<CaloParticle> const& cP,
                                                      std::vector<size_t> const& cPIndices,
                                                      std::vector<size_t> const& cPSelectedIndices,
@@ -2892,179 +2898,178 @@ void HGVHistoProducerAlgo::fill_multi_cluster_histos(const Histograms& histogram
   //Each event to be treated as two events:
   //an event in +ve endcap, plus another event in -ve endcap.
 
-  //To keep track of total num of multiclusters
-  int tnmclmz = 0;  //-z
-  int tnmclpz = 0;  //+z
-  //To count the number of multiclusters with 3 contiguous layers per event.
-  int tncontmclpz = 0;  //+z
-  int tncontmclmz = 0;  //-z
-  //For the number of multiclusters without 3 contiguous layers per event.
-  int tnnoncontmclpz = 0;  //+z
-  int tnnoncontmclmz = 0;  //-z
-  //We want to check below the score of cont and non cont multiclusters
-  std::vector<bool> contmulti;
-  contmulti.clear();
+  //To keep track of total num of Tracksters
+  int totNTstZm = 0;  //-z
+  int totNTstZp = 0;  //+z
+  //To count the number of Tracksters with 3 contiguous layers per event.
+  int totNContTstZp = 0;  //+z
+  int totNContTstZm = 0;  //-z
+  //For the number of Tracksters without 3 contiguous layers per event.
+  int totNNotContTstZp = 0;  //+z
+  int totNNotContTstZm = 0;  //-z
+  //We want to check below the score of cont and non cont Tracksters
+  std::vector<bool> contTracksters;
+  contTracksters.clear();
 
-  //[mclId]-> vector of 2d layer clusters size
+  //[tstId]-> vector of 2d layer clusters size
   std::unordered_map<unsigned int, std::vector<unsigned int>> multiplicity;
-  //[mclId]-> [layer][cluster size]
+  //[tstId]-> [layer][cluster size]
   std::unordered_map<unsigned int, std::vector<unsigned int>> multiplicity_vs_layer;
   //We will need for the scale text option
-  // unsigned int totallcinmcls = 0;
-  // for (unsigned int mclId = 0; mclId < nMultiClusters; ++mclId) {
-  //   totallcinmcls = totallcinmcls + multiClusters[mclId].clusters().size();
+  // unsigned int totalLcInTsts = 0;
+  // for (unsigned int tstId = 0; tstId < nTracksters; ++tstId) {
+  //   totalLcInTsts = totalLcInTsts + tracksters[tstId].vertices().size();
   // }
 
-  auto nMultiClusters = multiClusters.size();
-  //loop through multiclusters of the event
-  for (unsigned int mclId = 0; mclId < nMultiClusters; ++mclId) {
-    const auto layerClusters = multiClusters[mclId].clusters();
-    auto nLayerClusters = layerClusters.size();
+  auto nTracksters = tracksters.size();
+  //loop through Tracksters of the event
+  for (unsigned int tstId = 0; tstId < nTracksters; ++tstId) {
+    auto nLayerClusters = tracksters[tstId].vertices().size();
 
     if (nLayerClusters == 0)
       continue;
 
-    if (multiClusters[mclId].z() < 0.) {
-      tnmclmz++;
+    if (tracksters[tstId].barycenter().z() < 0.) {
+      totNTstZm++;
     }
-    if (multiClusters[mclId].z() > 0.) {
-      tnmclpz++;
+    if (tracksters[tstId].barycenter().z() > 0.) {
+      totNTstZp++;
     }
 
-    //Total number of layer clusters in multicluster
-    int tnlcinmcl = 0;
+    //Total number of layer clusters in Trackster
+    int tnLcInTst = 0;
 
-    //To keep track of total num of layer clusters per multicluster
-    //tnlcinmclperlaypz[layerid], tnlcinmclperlaymz[layerid]
-    std::vector<int> tnlcinmclperlay(1000, 0);  //+z
+    //To keep track of total num of layer clusters per Trackster
+    //tnLcInTstperlaypz[layerid], tnLcInTstperlaymz[layerid]
+    std::vector<int> tnLcInTstperlay(1000, 0);  //+z
 
-    //For the layers the multicluster expands to. Will use a set because there would be many
+    //For the layers the Trackster expands to. Will use a set because there would be many
     //duplicates and then go back to vector for random access, since they say it is faster.
-    std::set<int> multicluster_layers;
+    std::set<int> trackster_layers;
 
-    bool multiclusterInZplus = false;
-    bool multiclusterInZminus = false;
+    bool tracksterInZplus = false;
+    bool tracksterInZminus = false;
 
     //Loop through layer clusters
-    for (unsigned int lcId = 0; lcId < nLayerClusters; ++lcId) {
+    for (const auto lcId : tracksters[tstId].vertices()) {
       //take the hits and their fraction of the specific layer cluster.
-      const std::vector<std::pair<DetId, float>>& hits_and_fractions = layerClusters[lcId]->hitsAndFractions();
+      const std::vector<std::pair<DetId, float>>& hits_and_fractions = layerClusters[lcId].hitsAndFractions();
 
-      //For the multiplicity of the 2d layer clusters in multiclusters
-      multiplicity[mclId].emplace_back(hits_and_fractions.size());
+      //For the multiplicity of the 2d layer clusters in Tracksters
+      multiplicity[tstId].emplace_back(hits_and_fractions.size());
 
       const auto firstHitDetId = hits_and_fractions[0].first;
       //The layer that the layer cluster belongs to
       int layerid = recHitTools_->getLayerWithOffset(firstHitDetId) +
                     layers * ((recHitTools_->zside(firstHitDetId) + 1) >> 1) - 1;
-      multicluster_layers.insert(layerid);
-      multiplicity_vs_layer[mclId].emplace_back(layerid);
+      trackster_layers.insert(layerid);
+      multiplicity_vs_layer[tstId].emplace_back(layerid);
 
-      tnlcinmclperlay[layerid]++;
-      tnlcinmcl++;
+      tnLcInTstperlay[layerid]++;
+      tnLcInTst++;
 
       if (recHitTools_->zside(firstHitDetId) > 0.) {
-        multiclusterInZplus = true;
+        tracksterInZplus = true;
       }
       if (recHitTools_->zside(firstHitDetId) < 0.) {
-        multiclusterInZminus = true;
+        tracksterInZminus = true;
       }
 
-    }  //end of loop through layerclusters
+    }  // end of loop through layerClusters
 
-    //Per layer : Loop 0->99
+    // Per layer : Loop 0->99
     for (unsigned ilayer = 0; ilayer < layers * 2; ++ilayer) {
-      if (histograms.h_clusternum_in_multicluster_perlayer[count].count(ilayer) && tnlcinmclperlay[ilayer] != 0) {
-        histograms.h_clusternum_in_multicluster_perlayer[count].at(ilayer)->Fill((float)tnlcinmclperlay[ilayer]);
+      if (histograms.h_clusternum_in_trackster_perlayer[count].count(ilayer) && tnLcInTstperlay[ilayer] != 0) {
+        histograms.h_clusternum_in_trackster_perlayer[count].at(ilayer)->Fill((float)tnLcInTstperlay[ilayer]);
       }
-      //For the profile now of 2d layer cluster in multiclusters vs layer number.
-      if (tnlcinmclperlay[ilayer] != 0) {
-        histograms.h_clusternum_in_multicluster_vs_layer[count]->Fill((float)ilayer, (float)tnlcinmclperlay[ilayer]);
+      // For the profile now of 2d layer cluster in Tracksters vs layer number.
+      if (tnLcInTstperlay[ilayer] != 0) {
+        histograms.h_clusternum_in_trackster_vs_layer[count]->Fill((float)ilayer, (float)tnLcInTstperlay[ilayer]);
       }
-    }  //end of loop over layers
+    }  // end of loop over layers
 
-    //Looking for multiclusters with 3 contiguous layers per event.
-    std::vector<int> multicluster_layers_vec(multicluster_layers.begin(), multicluster_layers.end());
-    //Since we want to also check for non contiguous multiclusters
-    bool contimulti = false;
+    // Looking for Tracksters with 3 contiguous layers per event.
+    std::vector<int> trackster_layers_vec(trackster_layers.begin(), trackster_layers.end());
+    // Since we want to also check for non contiguous Tracksters
+    bool contiTrackster = false;
     //Observe that we start from 1 and go up to size - 1 element.
-    if (multicluster_layers_vec.size() >= 3) {
-      for (unsigned int i = 1; i < multicluster_layers_vec.size() - 1; ++i) {
-        if ((multicluster_layers_vec[i - 1] + 1 == multicluster_layers_vec[i]) &&
-            (multicluster_layers_vec[i + 1] - 1 == multicluster_layers_vec[i])) {
-          //So, this is a multicluster with 3 contiguous layers per event
-          if (multiclusterInZplus) {
-            tncontmclpz++;
+    if (trackster_layers_vec.size() >= 3) {
+      for (unsigned int i = 1; i < trackster_layers_vec.size() - 1; ++i) {
+        if ((trackster_layers_vec[i - 1] + 1 == trackster_layers_vec[i]) &&
+            (trackster_layers_vec[i + 1] - 1 == trackster_layers_vec[i])) {
+          //So, this is a Trackster with 3 contiguous layers per event
+          if (tracksterInZplus) {
+            totNContTstZp++;
           }
-          if (multiclusterInZminus) {
-            tncontmclmz++;
+          if (tracksterInZminus) {
+            totNContTstZm++;
           }
-          contimulti = true;
+          contiTrackster = true;
           break;
         }
       }
     }
-    //Count non contiguous multiclusters
-    if (!contimulti) {
-      if (multiclusterInZplus) {
-        tnnoncontmclpz++;
+    // Count non contiguous Tracksters
+    if (!contiTrackster) {
+      if (tracksterInZplus) {
+        totNNotContTstZp++;
       }
-      if (multiclusterInZminus) {
-        tnnoncontmclmz++;
+      if (tracksterInZminus) {
+        totNNotContTstZm++;
       }
     }
 
-    //Save for the score
-    contmulti.push_back(contimulti);
+    // Save for the score
+    contTracksters.push_back(contiTrackster);
 
-    histograms.h_clusternum_in_multicluster[count]->Fill(tnlcinmcl);
+    histograms.h_clusternum_in_trackster[count]->Fill(tnLcInTst);
 
-    for (unsigned int lc = 0; lc < multiplicity[mclId].size(); ++lc) {
+    for (unsigned int lc = 0; lc < multiplicity[tstId].size(); ++lc) {
       //multiplicity of the current LC
-      float mlp = std::count(std::begin(multiplicity[mclId]), std::end(multiplicity[mclId]), multiplicity[mclId][lc]);
+      float mlp = std::count(std::begin(multiplicity[tstId]), std::end(multiplicity[tstId]), multiplicity[tstId][lc]);
       //LogDebug("HGCalValidator") << "mlp %" << (100. * mlp)/ ((float) nLayerClusters) << std::endl;
-      // histograms.h_multiplicityOfLCinMCL[count]->Fill( mlp , multiplicity[mclId][lc] , 100. / (float) totallcinmcls );
-      histograms.h_multiplicityOfLCinMCL[count]->Fill(mlp, multiplicity[mclId][lc]);
+      // histograms.h_multiplicityOfLCinTST[count]->Fill( mlp , multiplicity[tstId][lc] , 100. / (float) totalLcInTsts );
+      histograms.h_multiplicityOfLCinTST[count]->Fill(mlp, multiplicity[tstId][lc]);
       //When we will plot with the text option we want the entries to be the same
-      //as the % of the current cell over the whole number of clusters. For this we need an extra histo.
+      //as the % of the current cell over the whole number of layerClusters. For this we need an extra histo.
       histograms.h_multiplicity_numberOfEventsHistogram[count]->Fill(mlp);
       //For the cluster multiplicity vs layer
       //First with the -z endcap (V10:0->49)
-      if (multiplicity_vs_layer[mclId][lc] < layers) {
-        histograms.h_multiplicityOfLCinMCL_vs_layercluster_zminus[count]->Fill(mlp, multiplicity_vs_layer[mclId][lc]);
+      if (multiplicity_vs_layer[tstId][lc] < layers) {
+        histograms.h_multiplicityOfLCinTST_vs_layercluster_zminus[count]->Fill(mlp, multiplicity_vs_layer[tstId][lc]);
         histograms.h_multiplicity_zminus_numberOfEventsHistogram[count]->Fill(mlp);
       } else {  //Then for the +z (V10:50->99)
-        histograms.h_multiplicityOfLCinMCL_vs_layercluster_zplus[count]->Fill(
-            mlp, multiplicity_vs_layer[mclId][lc] - layers);
+        histograms.h_multiplicityOfLCinTST_vs_layercluster_zplus[count]->Fill(
+            mlp, multiplicity_vs_layer[tstId][lc] - layers);
         histograms.h_multiplicity_zplus_numberOfEventsHistogram[count]->Fill(mlp);
       }
       //For the cluster multiplicity vs cluster energy
-      histograms.h_multiplicityOfLCinMCL_vs_layerclusterenergy[count]->Fill(mlp, layerClusters[lc]->energy());
+      histograms.h_multiplicityOfLCinTST_vs_layerclusterenergy[count]->Fill(mlp, layerClusters[tracksters[tstId].vertices(lc)].energy());
     }
 
-    if (!multicluster_layers.empty()) {
-      histograms.h_multicluster_x[count]->Fill(multiClusters[mclId].x());
-      histograms.h_multicluster_y[count]->Fill(multiClusters[mclId].y());
-      histograms.h_multicluster_z[count]->Fill(multiClusters[mclId].z());
-      histograms.h_multicluster_eta[count]->Fill(multiClusters[mclId].eta());
-      histograms.h_multicluster_phi[count]->Fill(multiClusters[mclId].phi());
+    if (!trackster_layers.empty()) {
+      histograms.h_trackster_x[count]->Fill(tracksters[tstId].barycenter().x());
+      histograms.h_trackster_y[count]->Fill(tracksters[tstId].barycenter().y());
+      histograms.h_trackster_z[count]->Fill(tracksters[tstId].barycenter().z());
+      histograms.h_trackster_eta[count]->Fill(tracksters[tstId].barycenter().eta());
+      histograms.h_trackster_phi[count]->Fill(tracksters[tstId].barycenter().phi());
 
-      histograms.h_multicluster_firstlayer[count]->Fill((float)*multicluster_layers.begin());
-      histograms.h_multicluster_lastlayer[count]->Fill((float)*multicluster_layers.rbegin());
-      histograms.h_multicluster_layersnum[count]->Fill((float)multicluster_layers.size());
+      histograms.h_trackster_firstlayer[count]->Fill((float)*trackster_layers.begin());
+      histograms.h_trackster_lastlayer[count]->Fill((float)*trackster_layers.rbegin());
+      histograms.h_trackster_layersnum[count]->Fill((float)trackster_layers.size());
 
-      histograms.h_multicluster_pt[count]->Fill(multiClusters[mclId].pt());
+      histograms.h_trackster_pt[count]->Fill(tracksters[tstId].raw_pt());
 
-      histograms.h_multicluster_energy[count]->Fill(multiClusters[mclId].energy());
+      histograms.h_trackster_energy[count]->Fill(tracksters[tstId].raw_energy());
     }
 
-  }  //end of loop through multiclusters
+  }  //end of loop through Tracksters
 
-  histograms.h_multiclusternum[count]->Fill(tnmclmz + tnmclpz);
-  histograms.h_contmulticlusternum[count]->Fill(tncontmclpz + tncontmclmz);
-  histograms.h_noncontmulticlusternum[count]->Fill(tnnoncontmclpz + tnnoncontmclmz);
+  histograms.h_tracksternum[count]->Fill(totNTstZm + totNTstZp);
+  histograms.h_conttracksternum[count]->Fill(totNContTstZp + totNContTstZm);
+  histograms.h_nonconttracksternum[count]->Fill(totNNotContTstZp + totNNotContTstZm);
 
-  multiClusters_to_CaloParticles(histograms, count, multiClusters, cP, cPIndices, cPSelectedIndices, hitMap, layers);
+  tracksters_to_CaloParticles(histograms, count, tracksters, layerClusters, cP, cPIndices, cPSelectedIndices, hitMap, layers);
 }
 
 double HGVHistoProducerAlgo::distance2(const double x1,

--- a/Validation/HGCalValidation/src/HGVHistoProducerAlgo.cc
+++ b/Validation/HGCalValidation/src/HGVHistoProducerAlgo.cc
@@ -41,7 +41,7 @@ HGVHistoProducerAlgo::HGVHistoProducerAlgo(const edm::ParameterSet& pset)
       maxPhi_(pset.getParameter<double>("maxPhi")),
       nintPhi_(pset.getParameter<int>("nintPhi")),
 
-      //parameters for counting mixed hits simclusters
+      //parameters for counting mixed hits SimClusters
       minMixedHitsSimCluster_(pset.getParameter<double>("minMixedHitsSimCluster")),
       maxMixedHitsSimCluster_(pset.getParameter<double>("maxMixedHitsSimCluster")),
       nintMixedHitsSimCluster_(pset.getParameter<int>("nintMixedHitsSimCluster")),
@@ -51,7 +51,7 @@ HGVHistoProducerAlgo::HGVHistoProducerAlgo(const edm::ParameterSet& pset)
       maxMixedHitsCluster_(pset.getParameter<double>("maxMixedHitsCluster")),
       nintMixedHitsCluster_(pset.getParameter<int>("nintMixedHitsCluster")),
 
-      //parameters for the total amount of energy clustered by all layer clusters (fraction over caloparticles)
+      //parameters for the total amount of energy clustered by all layer clusters (fraction over CaloParticless)
       minEneCl_(pset.getParameter<double>("minEneCl")),
       maxEneCl_(pset.getParameter<double>("maxEneCl")),
       nintEneCl_(pset.getParameter<int>("nintEneCl")),
@@ -66,7 +66,7 @@ HGVHistoProducerAlgo::HGVHistoProducerAlgo(const edm::ParameterSet& pset)
       maxZpos_(pset.getParameter<double>("maxZpos")),
       nintZpos_(pset.getParameter<int>("nintZpos")),
 
-      //Parameters for the total number of simclusters per layer
+      //Parameters for the total number of SimClusters per layer
       minTotNsimClsperlay_(pset.getParameter<double>("minTotNsimClsperlay")),
       maxTotNsimClsperlay_(pset.getParameter<double>("maxTotNsimClsperlay")),
       nintTotNsimClsperlay_(pset.getParameter<int>("nintTotNsimClsperlay")),
@@ -76,7 +76,7 @@ HGVHistoProducerAlgo::HGVHistoProducerAlgo(const edm::ParameterSet& pset)
       maxTotNClsperlay_(pset.getParameter<double>("maxTotNClsperlay")),
       nintTotNClsperlay_(pset.getParameter<int>("nintTotNClsperlay")),
 
-      //Parameters for the energy clustered by layer clusters per layer (fraction over caloparticles)
+      //Parameters for the energy clustered by layer clusters per layer (fraction over CaloParticless)
       minEneClperlay_(pset.getParameter<double>("minEneClperlay")),
       maxEneClperlay_(pset.getParameter<double>("maxEneClperlay")),
       nintEneClperlay_(pset.getParameter<int>("nintEneClperlay")),
@@ -102,7 +102,7 @@ HGVHistoProducerAlgo::HGVHistoProducerAlgo(const edm::ParameterSet& pset)
       maxMCLSharedEneFrac_(pset.getParameter<double>("maxMCLSharedEneFrac")),
       nintMCLSharedEneFrac_(pset.getParameter<int>("nintMCLSharedEneFrac")),
 
-      //Parameters for the total number of simclusters per thickness
+      //Parameters for the total number of SimClusters per thickness
       minTotNsimClsperthick_(pset.getParameter<double>("minTotNsimClsperthick")),
       maxTotNsimClsperthick_(pset.getParameter<double>("maxTotNsimClsperthick")),
       nintTotNsimClsperthick_(pset.getParameter<int>("nintTotNsimClsperthick")),
@@ -214,25 +214,25 @@ void HGVHistoProducerAlgo::bookCaloParticleHistos(DQMStore::IBooker& ibook,
                                                   int pdgid,
                                                   unsigned int layers) {
   histograms.h_caloparticle_eta[pdgid] =
-      ibook.book1D("N of caloparticle vs eta", "N of caloparticle vs eta", nintEta_, minEta_, maxEta_);
+      ibook.book1D("N of caloparticle vs eta", "N of caloParticles vs eta", nintEta_, minEta_, maxEta_);
   histograms.h_caloparticle_eta_Zorigin[pdgid] =
       ibook.book2D("Eta vs Zorigin", "Eta vs Zorigin", nintEta_, minEta_, maxEta_, nintZpos_, minZpos_, maxZpos_);
 
   histograms.h_caloparticle_energy[pdgid] =
-      ibook.book1D("Energy", "Energy of caloparticle", nintEne_, minEne_, maxEne_);
-  histograms.h_caloparticle_pt[pdgid] = ibook.book1D("Pt", "Pt of caloparticle", nintPt_, minPt_, maxPt_);
-  histograms.h_caloparticle_phi[pdgid] = ibook.book1D("Phi", "Phi of caloparticle", nintPhi_, minPhi_, maxPhi_);
+      ibook.book1D("Energy", "Energy of CaloParticles", nintEne_, minEne_, maxEne_);
+  histograms.h_caloparticle_pt[pdgid] = ibook.book1D("Pt", "Pt of CaloParticles", nintPt_, minPt_, maxPt_);
+  histograms.h_caloparticle_phi[pdgid] = ibook.book1D("Phi", "Phi of CaloParticles", nintPhi_, minPhi_, maxPhi_);
   histograms.h_caloparticle_selfenergy[pdgid] =
       ibook.book1D("SelfEnergy", "Total Energy of Hits in Sim Clusters (matched)", nintEne_, minEne_, maxEne_);
   histograms.h_caloparticle_energyDifference[pdgid] =
       ibook.book1D("EnergyDifference", "(Energy-SelfEnergy)/Energy", 300., -5., 1.);
 
   histograms.h_caloparticle_nSimClusters[pdgid] =
-      ibook.book1D("Num Sim Clusters", "Num Sim Clusters in caloparticle", 100, 0., 100.);
+      ibook.book1D("Num Sim Clusters", "Num Sim Clusters in CaloParticles", 100, 0., 100.);
   histograms.h_caloparticle_nHitsInSimClusters[pdgid] =
-      ibook.book1D("Num Hits in Sim Clusters", "Num Hits in Sim Clusters in caloparticle", 1000, 0., 1000.);
+      ibook.book1D("Num Hits in Sim Clusters", "Num Hits in Sim Clusters in CaloParticles", 1000, 0., 1000.);
   histograms.h_caloparticle_nHitsInSimClusters_matchedtoRecHit[pdgid] = ibook.book1D(
-      "Num Rec-matched Hits in Sim Clusters", "Num Hits in Sim Clusters (matched) in caloparticle", 1000, 0., 1000.);
+      "Num Rec-matched Hits in Sim Clusters", "Num Hits in Sim Clusters (matched) in CaloParticles", 1000, 0., 1000.);
 
   histograms.h_caloparticle_nHits_matched_energy[pdgid] =
       ibook.book1D("Energy of Rec-matched Hits", "Energy of Hits in Sim Clusters (matched)", 100, 0., 10.);
@@ -265,18 +265,18 @@ void HGVHistoProducerAlgo::bookCaloParticleHistos(DQMStore::IBooker& ibook,
                    110.);
 
   histograms.h_caloparticle_firstlayer[pdgid] =
-      ibook.book1D("First Layer", "First layer of the caloparticle", 2 * layers, 0., (float)2 * layers);
+      ibook.book1D("First Layer", "First layer of the CaloParticles", 2 * layers, 0., (float)2 * layers);
   histograms.h_caloparticle_lastlayer[pdgid] =
-      ibook.book1D("Last Layer", "Last layer of the caloparticle", 2 * layers, 0., (float)2 * layers);
+      ibook.book1D("Last Layer", "Last layer of the CaloParticles", 2 * layers, 0., (float)2 * layers);
   histograms.h_caloparticle_layersnum[pdgid] =
-      ibook.book1D("Number of Layers", "Number of layers of the caloparticle", 2 * layers, 0., (float)2 * layers);
+      ibook.book1D("Number of Layers", "Number of layers of the CaloParticles", 2 * layers, 0., (float)2 * layers);
   histograms.h_caloparticle_firstlayer_matchedtoRecHit[pdgid] = ibook.book1D(
-      "First Layer (rec-matched hit)", "First layer of the caloparticle (matched)", 2 * layers, 0., (float)2 * layers);
+      "First Layer (rec-matched hit)", "First layer of the CaloParticles (matched)", 2 * layers, 0., (float)2 * layers);
   histograms.h_caloparticle_lastlayer_matchedtoRecHit[pdgid] = ibook.book1D(
-      "Last Layer (rec-matched hit)", "Last layer of the caloparticle (matched)", 2 * layers, 0., (float)2 * layers);
+      "Last Layer (rec-matched hit)", "Last layer of the CaloParticles (matched)", 2 * layers, 0., (float)2 * layers);
   histograms.h_caloparticle_layersnum_matchedtoRecHit[pdgid] =
       ibook.book1D("Number of Layers (rec-matched hit)",
-                   "Number of layers of the caloparticle (matched)",
+                   "Number of layers of the CaloParticles (matched)",
                    2 * layers,
                    0.,
                    (float)2 * layers);
@@ -620,14 +620,14 @@ void HGVHistoProducerAlgo::bookClusterHistos_ClusterLevel(DQMStore::IBooker& ibo
   //z-
   histograms.h_energyclustered_zminus.push_back(
       ibook.book1D("energyclustered_zminus",
-                   "percent of total energy clustered by all layer clusters over caloparticles energy in z-",
+                   "percent of total energy clustered by all layer clusters over CaloParticless energy in z-",
                    nintEneCl_,
                    minEneCl_,
                    maxEneCl_));
   //z+
   histograms.h_energyclustered_zplus.push_back(
       ibook.book1D("energyclustered_zplus",
-                   "percent of total energy clustered by all layer clusters over caloparticles energy in z+",
+                   "percent of total energy clustered by all layer clusters over CaloParticless energy in z+",
                    nintEneCl_,
                    minEneCl_,
                    maxEneCl_));
@@ -670,7 +670,7 @@ void HGVHistoProducerAlgo::bookClusterHistos_ClusterLevel(DQMStore::IBooker& ibo
                                                             maxTotNClsperlay_);
     histograms.h_energyclustered_perlayer[ilayer] =
         ibook.book1D("energyclustered_perlayer" + istr1,
-                     "percent of total energy clustered by layer clusters over caloparticles energy for layer " + istr2,
+                     "percent of total energy clustered by layer clusters over CaloParticless energy for layer " + istr2,
                      nintEneClperlay_,
                      minEneClperlay_,
                      maxEneClperlay_);
@@ -1218,31 +1218,31 @@ void HGVHistoProducerAlgo::fill_info_histos(const Histograms& histograms, unsign
 
 void HGVHistoProducerAlgo::fill_caloparticle_histos(const Histograms& histograms,
                                                     int pdgid,
-                                                    const CaloParticle& caloparticle,
+                                                    const CaloParticle& caloParticle,
                                                     std::vector<SimVertex> const& simVertices,
                                                     unsigned int layers,
                                                     std::unordered_map<DetId, const HGCRecHit*> const& hitMap) const {
-  const auto eta = getEta(caloparticle.eta());
+  const auto eta = getEta(caloParticle.eta());
   if (histograms.h_caloparticle_eta.count(pdgid)) {
     histograms.h_caloparticle_eta.at(pdgid)->Fill(eta);
   }
   if (histograms.h_caloparticle_eta_Zorigin.count(pdgid)) {
     histograms.h_caloparticle_eta_Zorigin.at(pdgid)->Fill(
-        simVertices.at(caloparticle.g4Tracks()[0].vertIndex()).position().z(), eta);
+        simVertices.at(caloParticle.g4Tracks()[0].vertIndex()).position().z(), eta);
   }
 
   if (histograms.h_caloparticle_energy.count(pdgid)) {
-    histograms.h_caloparticle_energy.at(pdgid)->Fill(caloparticle.energy());
+    histograms.h_caloparticle_energy.at(pdgid)->Fill(caloParticle.energy());
   }
   if (histograms.h_caloparticle_pt.count(pdgid)) {
-    histograms.h_caloparticle_pt.at(pdgid)->Fill(caloparticle.pt());
+    histograms.h_caloparticle_pt.at(pdgid)->Fill(caloParticle.pt());
   }
   if (histograms.h_caloparticle_phi.count(pdgid)) {
-    histograms.h_caloparticle_phi.at(pdgid)->Fill(caloparticle.phi());
+    histograms.h_caloparticle_phi.at(pdgid)->Fill(caloParticle.phi());
   }
 
   if (histograms.h_caloparticle_nSimClusters.count(pdgid)) {
-    histograms.h_caloparticle_nSimClusters.at(pdgid)->Fill(caloparticle.simClusters().size());
+    histograms.h_caloparticle_nSimClusters.at(pdgid)->Fill(caloParticle.simClusters().size());
 
     int simHits = 0;
     int minLayerId = 999;
@@ -1255,7 +1255,7 @@ void HGVHistoProducerAlgo::fill_caloparticle_histos(const Histograms& histograms
     float energy = 0.;
     std::map<int, double> totenergy_layer;
 
-    for (auto const& sc : caloparticle.simClusters()) {
+    for (auto const& sc : caloParticle.simClusters()) {
       LogDebug("HGCalValidator") << " This sim cluster has " << sc->hits_and_fractions().size() << " simHits and "
                                  << sc->energy() << " energy. " << std::endl;
       simHits += sc->hits_and_fractions().size();
@@ -1282,7 +1282,7 @@ void HGVHistoProducerAlgo::fill_caloparticle_histos(const Histograms& histograms
           } else {
             totenergy_layer.emplace(layerId, hit->energy());
           }
-          if (caloparticle.simClusters().size() == 1)
+          if (caloParticle.simClusters().size() == 1)
             histograms.h_caloparticle_nHits_matched_energy_layer_1SimCl.at(pdgid)->Fill(layerId,
                                                                                         hit->energy() * h_and_f.second);
         } else {
@@ -1307,21 +1307,21 @@ void HGVHistoProducerAlgo::fill_caloparticle_histos(const Histograms& histograms
     histograms.h_caloparticle_nHitsInSimClusters.at(pdgid)->Fill((float)simHits);
     histograms.h_caloparticle_nHitsInSimClusters_matchedtoRecHit.at(pdgid)->Fill((float)simHits_matched);
     histograms.h_caloparticle_selfenergy.at(pdgid)->Fill((float)energy);
-    histograms.h_caloparticle_energyDifference.at(pdgid)->Fill((float)1. - energy / caloparticle.energy());
+    histograms.h_caloparticle_energyDifference.at(pdgid)->Fill((float)1. - energy / caloParticle.energy());
 
     //Calculate sum energy per-layer
     auto i = totenergy_layer.begin();
     double sum_energy = 0.0;
     while (i != totenergy_layer.end()) {
       sum_energy += i->second;
-      histograms.h_caloparticle_sum_energy_layer.at(pdgid)->Fill(i->first, sum_energy / caloparticle.energy() * 100.);
+      histograms.h_caloparticle_sum_energy_layer.at(pdgid)->Fill(i->first, sum_energy / caloParticle.energy() * 100.);
       i++;
     }
   }
 }
 
-void HGVHistoProducerAlgo::HGVHistoProducerAlgo::fill_simcluster_histos(const Histograms& histograms,
-                                                                        std::vector<SimCluster> const& simclusters,
+void HGVHistoProducerAlgo::HGVHistoProducerAlgo::fill_simCluster_histos(const Histograms& histograms,
+                                                                        std::vector<SimCluster> const& simClusters,
                                                                         unsigned int layers,
                                                                         std::vector<int> thicknesses) const {
   //Each event to be treated as two events: an event in +ve endcap,
@@ -1330,7 +1330,7 @@ void HGVHistoProducerAlgo::HGVHistoProducerAlgo::fill_simcluster_histos(const Hi
   //-z: 0->49
   //+z: 50->99
 
-  //To keep track of total num of simclusters per layer
+  //To keep track of total num of simClusters per layer
   //tnscpl[layerid]
   std::vector<int> tnscpl(1000, 0);  //tnscpl.clear(); tnscpl.reserve(1000);
 
@@ -1344,16 +1344,16 @@ void HGVHistoProducerAlgo::HGVHistoProducerAlgo::fill_simcluster_histos(const Hi
     tnscpthplus.insert(std::pair<std::string, int>(std::to_string(*it), 0));
     tnscpthminus.insert(std::pair<std::string, int>(std::to_string(*it), 0));
   }
-  //To keep track of the total num of simclusters with mixed thickness hits per event
+  //To keep track of the total num of simClusters with mixed thickness hits per event
   tnscpthplus.insert(std::pair<std::string, int>("mixed", 0));
   tnscpthminus.insert(std::pair<std::string, int>("mixed", 0));
 
-  //loop through simclusters
-  for (unsigned int ic = 0; ic < simclusters.size(); ++ic) {
-    const auto& sc = simclusters[ic];
+  //loop through simClusters
+  for (unsigned int ic = 0; ic < simClusters.size(); ++ic) {
+    const auto& sc = simClusters[ic];
     const auto& hitsAndFractions = sc.hits_and_fractions();
 
-    //Auxillary variables to count the number of different kind of hits in each simcluster
+    //Auxillary variables to count the number of different kind of hits in each simCluster
     int nthhits120p = 0;
     int nthhits200p = 0;
     int nthhits300p = 0;
@@ -1364,10 +1364,10 @@ void HGVHistoProducerAlgo::HGVHistoProducerAlgo::fill_simcluster_histos(const Hi
     int nthhitsscintm = 0;
     //For the hits thickness of the layer cluster.
     double thickness = 0.;
-    //To keep track if we added the simcluster in a specific layer
+    //To keep track if we added the simCluster in a specific layer
     std::vector<int> occurenceSCinlayer(1000, 0);  //[layerid][0 if not added]
 
-    //loop through hits of the simcluster
+    //loop through hits of the simCluster
     for (const auto& hAndF : hitsAndFractions) {
       const DetId sh_detid = hAndF.first;
 
@@ -1377,7 +1377,7 @@ void HGVHistoProducerAlgo::HGVHistoProducerAlgo::fill_simcluster_histos(const Hi
       //zside that the current cluster belongs to.
       int zside = recHitTools_->zside(sh_detid);
 
-      //add the simcluster to the relevant layer. A simcluster may give contribution to several layers.
+      //add the simCluster to the relevant layer. A SimCluster may give contribution to several layers.
       if (occurenceSCinlayer[layerid] == 0) {
         tnscpl[layerid]++;
       }
@@ -1388,7 +1388,7 @@ void HGVHistoProducerAlgo::HGVHistoProducerAlgo::fill_simcluster_histos(const Hi
       } else if (sh_detid.det() == DetId::HGCalHSc) {
         thickness = -1;
       } else {
-        LogDebug("HGCalValidator") << "These are HGCal simclusters, you shouldn't be here !!! " << layerid << "\n";
+        LogDebug("HGCalValidator") << "These are HGCal simClusters, you shouldn't be here !!! " << layerid << "\n";
         continue;
       }
 
@@ -1434,7 +1434,7 @@ void HGVHistoProducerAlgo::HGVHistoProducerAlgo::fill_simcluster_histos(const Hi
       tnscpthminus[std::to_string((int)thickness)]++;
     }
 
-  }  //end of loop through simclusters of the event
+  }  //end of loop through SimClusters of the event
 
   //Per layer : Loop 0->99
   for (unsigned ilayer = 0; ilayer < layers * 2; ++ilayer) {
@@ -1455,13 +1455,13 @@ void HGVHistoProducerAlgo::HGVHistoProducerAlgo::fill_simcluster_histos(const Hi
   histograms.h_mixedhitssimcluster_zminus->Fill(tnscpthminus["mixed"]);
 }
 
-void HGVHistoProducerAlgo::HGVHistoProducerAlgo::fill_simclusterassosiation_histos(
+void HGVHistoProducerAlgo::HGVHistoProducerAlgo::fill_simClusterassosiation_histos(
     const Histograms& histograms,
     int count,
     edm::Handle<reco::CaloClusterCollection> clusterHandle,
     const reco::CaloClusterCollection& clusters,
     edm::Handle<std::vector<SimCluster>> simClusterHandle,
-    std::vector<SimCluster> const& simclusters,
+    std::vector<SimCluster> const& simClusters,
     std::vector<size_t> const& sCIndices,
     const std::vector<float>& mask,
     std::unordered_map<DetId, const HGCRecHit*> const& hitMap,
@@ -1481,7 +1481,7 @@ void HGVHistoProducerAlgo::HGVHistoProducerAlgo::fill_simclusterassosiation_hist
                                clusterHandle,
                                clusters,
                                simClusterHandle,
-                               simclusters,
+                               simClusters,
                                sCIndices,
                                mask,
                                hitMap,
@@ -1514,7 +1514,7 @@ void HGVHistoProducerAlgo::layerClusters_to_CaloParticles(const Histograms& hist
   std::unordered_map<DetId, std::vector<HGVHistoProducerAlgo::detIdInfoInCluster>> detIdToLayerClusterId_Map;
 
   // The association has to be done in an all-vs-all fashion.
-  // For this reason we use the full set of caloParticles, with the only filter on bx
+  // For this reason we use the full set of CaloParticles, with the only filter on bx
   for (const auto& cpId : cPIndices) {
     const SimClusterRefVector& simClusterRefVector = cP[cpId].simClusters();
     for (const auto& it_sc : simClusterRefVector) {
@@ -1781,7 +1781,7 @@ void HGVHistoProducerAlgo::layerClusters_to_SimClusters(
 
   // Here we do fill the plots to compute the different metrics linked to
   // reco-level, namely fake-rate and merge-rate. In this loop we should *not*
-  // restrict only to the selected simClusters.
+  // restrict only to the selected SimClusters.
   for (unsigned int lcId = 0; lcId < nLayerClusters; ++lcId) {
     if (mask[lcId] != 0.) {
       LogDebug("HGCalValidator") << "Skipping layer cluster " << lcId << " not belonging to mask" << std::endl;
@@ -1810,11 +1810,11 @@ void HGVHistoProducerAlgo::layerClusters_to_SimClusters(
       }
       continue;
     }
-    //Loop through all simClusters linked to the layer cluster under study
+    //Loop through all SimClusters linked to the layer cluster under study
     for (const auto& scPair : scs) {
       LogDebug("HGCalValidator") << "layerCluster Id: \t" << lcId << "\t SC id: \t" << scPair.first.index()
                                  << "\t score \t" << scPair.second << std::endl;
-      //This should be filled #layerclusters in layer x #linked SimClusters
+      //This should be filled #layerClusters in layer x #linked SimClusters
       histograms.h_score_layercl2simcluster_perlayer[count].at(lcLayerId)->Fill(scPair.second);
       auto const& sc_linked =
           std::find_if(std::begin(lcsInSimClusterMap[scPair.first]),
@@ -1830,7 +1830,7 @@ void HGVHistoProducerAlgo::layerClusters_to_SimClusters(
       histograms.h_energy_vs_score_layercl2simcluster_perlayer[count].at(lcLayerId)->Fill(
           scPair.second, sc_linked->second.first / clusters[lcId].energy());
     }
-    //Here he counts how many of the linked simclusters of the layer cluster under study have a score above a certain value.
+    //Here he counts how many of the linked SimClusters of the layer cluster under study have a score above a certain value.
     const auto assoc =
         std::count_if(std::begin(scs), std::end(scs), [](const auto& obj) { return obj.second < ScoreCutLCtoSC_; });
     if (assoc) {
@@ -1842,7 +1842,7 @@ void HGVHistoProducerAlgo::layerClusters_to_SimClusters(
       }
       const auto& best = std::min_element(
           std::begin(scs), std::end(scs), [](const auto& obj1, const auto& obj2) { return obj1.second < obj2.second; });
-      //From all simclusters he founds the one with the best (lowest) score and takes his scId
+      //From all SimClusters he founds the one with the best (lowest) score and takes his scId
       const auto& best_sc_linked =
           std::find_if(std::begin(lcsInSimClusterMap[best->first]),
                        std::end(lcsInSimClusterMap[best->first]),
@@ -1861,7 +1861,7 @@ void HGVHistoProducerAlgo::layerClusters_to_SimClusters(
 
   // Here we do fill the plots to compute the different metrics linked to
   // gen-level, namely efficiency and duplicate. In this loop we should restrict
-  // only to the selected simClusters.
+  // only to the selected SimClusters.
   for (const auto& scId : sCIndices) {
     const edm::Ref<SimClusterCollection> scRef(simClusterHandle, scId);
     const auto& lcsIt = lcsInSimClusterMap.find(scRef);
@@ -1901,7 +1901,7 @@ void HGVHistoProducerAlgo::layerClusters_to_SimClusters(
         return lcLayerId;
       };
 
-      //Loop through layer clusters linked to the simcluster under study
+      //Loop through layer clusters linked to the SimCluster under study
       for (const auto& lcPair : lcs) {
         auto lcId = lcPair.first.index();
         if (mask[lcId] != 0.) {
@@ -2004,7 +2004,7 @@ void HGVHistoProducerAlgo::fill_generic_cluster_histos(const Histograms& histogr
   //for the longitudinal depth barycenter
   std::vector<double> ldbar(1000, 0.0);  //ldbar.clear(); ldbar.reserve(1000);
 
-  //We need to compare with the total amount of energy coming from caloparticles
+  //We need to compare with the total amount of energy coming from CaloParticles
   double caloparteneplus = 0.;
   double caloparteneminus = 0.;
   for (const auto& cpId : cPIndices) {
@@ -2017,15 +2017,15 @@ void HGVHistoProducerAlgo::fill_generic_cluster_histos(const Histograms& histogr
   }
 
   //loop through clusters of the event
-  for (unsigned int layerclusterIndex = 0; layerclusterIndex < clusters.size(); layerclusterIndex++) {
-    const std::vector<std::pair<DetId, float>> hits_and_fractions = clusters[layerclusterIndex].hitsAndFractions();
+  for (unsigned int lcId = 0; lcId < clusters.size(); lcId++) {
+    const std::vector<std::pair<DetId, float>> hits_and_fractions = clusters[lcId].hitsAndFractions();
 
-    const DetId seedid = clusters[layerclusterIndex].seed();
+    const DetId seedid = clusters[lcId].seed();
     const double seedx = recHitTools_->getPosition(seedid).x();
     const double seedy = recHitTools_->getPosition(seedid).y();
-    DetId maxid = findmaxhit(clusters[layerclusterIndex], hitMap);
+    DetId maxid = findmaxhit(clusters[lcId], hitMap);
 
-    // const DetId maxid = clusters[layerclusterIndex].max();
+    // const DetId maxid = clusters[lcId].max();
     double maxx = recHitTools_->getPosition(maxid).x();
     double maxy = recHitTools_->getPosition(maxid).y();
 
@@ -2203,12 +2203,12 @@ void HGVHistoProducerAlgo::fill_generic_cluster_histos(const Histograms& histogr
     }
     if (histograms.h_distancebetseedandmaxcellvsclusterenergy_perthickperlayer.count(seedstr)) {
       histograms.h_distancebetseedandmaxcellvsclusterenergy_perthickperlayer.at(seedstr)->Fill(
-          distancebetseedandmax, clusters[layerclusterIndex].energy());
+          distancebetseedandmax, clusters[lcId].energy());
     }
 
     //Energy clustered per layer
-    tecpl[layerid] = tecpl[layerid] + clusters[layerclusterIndex].energy();
-    ldbar[layerid] = ldbar[layerid] + clusters[layerclusterIndex].energy() * cummatbudg[(double)lay];
+    tecpl[layerid] = tecpl[layerid] + clusters[lcId].energy();
+    ldbar[layerid] = ldbar[layerid] + clusters[lcId].energy() * cummatbudg[(double)lay];
 
   }  //end of loop through clusters of the event
 
@@ -2333,9 +2333,9 @@ void HGVHistoProducerAlgo::multiClusters_to_CaloParticles(const Histograms& hist
           const HGCRecHit* hit = itcheck->second;
           //Since the current hit from sim cluster has a reconstructed hit with the same detid,
           //make a map that will connect a detid with:
-          //1. the caloparticles that have a simcluster with sim hits in that cell via caloparticle id.
+          //1. the CaloParticles that have a SimCluster with sim hits in that cell via caloparticle id.
           //2. the sum of all simhits fractions that contributes to that detid.
-          //So, keep in mind that in case of multiple caloparticles contributing in the same cell
+          //So, keep in mind that in case of multiple CaloParticles contributing in the same cell
           //the fraction is the sum over all calo particles. So, something like:
           //detid: (caloparticle 1, sum of hits fractions in that detid over all cp) , (caloparticle 2, sum of hits fractions in that detid over all cp), (caloparticle 3, sum of hits fractions in that detid over all cp) ...
           auto hit_find_it = detIdToCaloParticleId_Map.find(hitid);
@@ -2838,7 +2838,7 @@ void HGVHistoProducerAlgo::multiClusters_to_CaloParticles(const Histograms& hist
     histograms.h_denom_caloparticle_eta[count]->Fill(cP[cpId].g4Tracks()[0].momentum().eta());
     histograms.h_denom_caloparticle_phi[count]->Fill(cP[cpId].g4Tracks()[0].momentum().phi());
 
-  }  //end of loop through caloparticles
+  }  //end of loop through CaloParticles
 
   // Here we do fill the plots to compute the different metrics linked to
   // reco-level, namely fake-rate an merge-rate. In this loop we should *not*

--- a/Validation/HGCalValidation/src/HGVHistoProducerAlgo.cc
+++ b/Validation/HGCalValidation/src/HGVHistoProducerAlgo.cc
@@ -668,12 +668,12 @@ void HGVHistoProducerAlgo::bookClusterHistos_ClusterLevel(DQMStore::IBooker& ibo
                                                             nintTotNClsperlay_,
                                                             minTotNClsperlay_,
                                                             maxTotNClsperlay_);
-    histograms.h_energyclustered_perlayer[ilayer] =
-        ibook.book1D("energyclustered_perlayer" + istr1,
-                     "percent of total energy clustered by layer clusters over CaloParticless energy for layer " + istr2,
-                     nintEneClperlay_,
-                     minEneClperlay_,
-                     maxEneClperlay_);
+    histograms.h_energyclustered_perlayer[ilayer] = ibook.book1D(
+        "energyclustered_perlayer" + istr1,
+        "percent of total energy clustered by layer clusters over CaloParticless energy for layer " + istr2,
+        nintEneClperlay_,
+        minEneClperlay_,
+        maxEneClperlay_);
   }
 
   //---------------------------------------------------------------------------------------------------------------------------
@@ -963,9 +963,7 @@ void HGVHistoProducerAlgo::bookClusterHistos_CellLevel(DQMStore::IBooker& ibook,
 }
 //----------------------------------------------------------------------------------------------------------------------------
 
-void HGVHistoProducerAlgo::bookTracksterHistos(DQMStore::IBooker& ibook,
-                                                  Histograms& histograms,
-                                                  unsigned int layers) {
+void HGVHistoProducerAlgo::bookTracksterHistos(DQMStore::IBooker& ibook, Histograms& histograms, unsigned int layers) {
   histograms.h_score_trackster2caloparticle.push_back(ibook.book1D(
       "Score_trackster2caloparticle", "Score of Trackster per CaloParticle", nintScore_, minScore_, maxScore_));
   histograms.h_score_caloparticle2trackster.push_back(ibook.book1D(
@@ -992,14 +990,14 @@ void HGVHistoProducerAlgo::bookTracksterHistos(DQMStore::IBooker& ibook,
   //back to all Tracksters
   histograms.h_num_trackster_eta.push_back(
       ibook.book1D("Num_Trackster_Eta", "Num Trackster Eta per Trackster ", nintEta_, minEta_, maxEta_));
-  histograms.h_numMerge_trackster_eta.push_back(ibook.book1D(
-      "NumMerge_Trackster_Eta", "Num Merge Trackster Eta per Trackster ", nintEta_, minEta_, maxEta_));
+  histograms.h_numMerge_trackster_eta.push_back(
+      ibook.book1D("NumMerge_Trackster_Eta", "Num Merge Trackster Eta per Trackster ", nintEta_, minEta_, maxEta_));
   histograms.h_denom_trackster_eta.push_back(
       ibook.book1D("Denom_Trackster_Eta", "Denom Trackster Eta per Trackster", nintEta_, minEta_, maxEta_));
   histograms.h_num_trackster_phi.push_back(
       ibook.book1D("Num_Trackster_Phi", "Num Trackster Phi per Trackster ", nintPhi_, minPhi_, maxPhi_));
-  histograms.h_numMerge_trackster_phi.push_back(ibook.book1D(
-      "NumMerge_Trackster_Phi", "Num Merge Trackster Phi per Trackster", nintPhi_, minPhi_, maxPhi_));
+  histograms.h_numMerge_trackster_phi.push_back(
+      ibook.book1D("NumMerge_Trackster_Phi", "Num Merge Trackster Phi per Trackster", nintPhi_, minPhi_, maxPhi_));
   histograms.h_denom_trackster_phi.push_back(
       ibook.book1D("Denom_Trackster_Phi", "Denom Trackster Phi per Trackster", nintPhi_, minPhi_, maxPhi_));
   histograms.h_sharedenergy_trackster2caloparticle.push_back(
@@ -1024,12 +1022,11 @@ void HGVHistoProducerAlgo::bookTracksterHistos(DQMStore::IBooker& ibook,
                         maxPhi_,
                         minTSTSharedEneFrac_,
                         maxTSTSharedEneFrac_));
-  histograms.h_sharedenergy_caloparticle2trackster.push_back(
-      ibook.book1D("SharedEnergy_caloparticle2trackster",
-                   "Shared Energy of CaloParticle per Trackster",
-                   nintSharedEneFrac_,
-                   minTSTSharedEneFrac_,
-                   maxTSTSharedEneFrac_));
+  histograms.h_sharedenergy_caloparticle2trackster.push_back(ibook.book1D("SharedEnergy_caloparticle2trackster",
+                                                                          "Shared Energy of CaloParticle per Trackster",
+                                                                          nintSharedEneFrac_,
+                                                                          minTSTSharedEneFrac_,
+                                                                          maxTSTSharedEneFrac_));
   histograms.h_sharedenergy_caloparticle2trackster_assoc.push_back(
       ibook.book1D("SharedEnergy_caloparticle2trackster_assoc",
                    "Shared Energy of Associated CaloParticle per Trackster",
@@ -1082,12 +1079,11 @@ void HGVHistoProducerAlgo::bookTracksterHistos(DQMStore::IBooker& ibook,
       istr2 = std::to_string(ilayer - (layers - 1)) + " in z+";
     }
 
-    clusternum_in_trackster_perlayer[ilayer] =
-        ibook.book1D("clusternum_in_trackster_perlayer" + istr1,
-                     "Number of layer clusters in Trackster for layer " + istr2,
-                     nintTotNClsinTSTsperlayer_,
-                     minTotNClsinTSTsperlayer_,
-                     maxTotNClsinTSTsperlayer_);
+    clusternum_in_trackster_perlayer[ilayer] = ibook.book1D("clusternum_in_trackster_perlayer" + istr1,
+                                                            "Number of layer clusters in Trackster for layer " + istr2,
+                                                            nintTotNClsinTSTsperlayer_,
+                                                            minTotNClsinTSTsperlayer_,
+                                                            maxTotNClsinTSTsperlayer_);
   }
 
   histograms.h_clusternum_in_trackster_perlayer.push_back(std::move(clusternum_in_trackster_perlayer));
@@ -1095,23 +1091,20 @@ void HGVHistoProducerAlgo::bookTracksterHistos(DQMStore::IBooker& ibook,
   histograms.h_tracksternum.push_back(
       ibook.book1D("tottracksternum", "total number of Tracksters", nintTotNTSTs_, minTotNTSTs_, maxTotNTSTs_));
 
-  histograms.h_conttracksternum.push_back(ibook.book1D("conttracksternum",
-                                                          "number of Tracksters with 3 contiguous layers",
+  histograms.h_conttracksternum.push_back(ibook.book1D(
+      "conttracksternum", "number of Tracksters with 3 contiguous layers", nintTotNTSTs_, minTotNTSTs_, maxTotNTSTs_));
+
+  histograms.h_nonconttracksternum.push_back(ibook.book1D("nonconttracksternum",
+                                                          "number of Tracksters without 3 contiguous layers",
                                                           nintTotNTSTs_,
                                                           minTotNTSTs_,
                                                           maxTotNTSTs_));
 
-  histograms.h_nonconttracksternum.push_back(ibook.book1D("nonconttracksternum",
-                                                             "number of Tracksters without 3 contiguous layers",
-                                                             nintTotNTSTs_,
-                                                             minTotNTSTs_,
-                                                             maxTotNTSTs_));
-
   histograms.h_clusternum_in_trackster.push_back(ibook.book1D("clusternum_in_trackster",
-                                                                 "total number of layer clusters in Trackster",
-                                                                 nintTotNClsinTSTs_,
-                                                                 minTotNClsinTSTs_,
-                                                                 maxTotNClsinTSTs_));
+                                                              "total number of layer clusters in Trackster",
+                                                              nintTotNClsinTSTs_,
+                                                              minTotNClsinTSTs_,
+                                                              maxTotNClsinTSTs_));
 
   histograms.h_clusternum_in_trackster_vs_layer.push_back(
       ibook.bookProfile("clusternum_in_trackster_vs_layer",
@@ -1181,26 +1174,22 @@ void HGVHistoProducerAlgo::bookTracksterHistos(DQMStore::IBooker& ibook,
                    minClEnepermultiplicity_,
                    maxClEnepermultiplicity_));
 
-  histograms.h_trackster_pt.push_back(
-      ibook.book1D("trackster_pt", "Pt of the Trackster", nintPt_, minPt_, maxPt_));
+  histograms.h_trackster_pt.push_back(ibook.book1D("trackster_pt", "Pt of the Trackster", nintPt_, minPt_, maxPt_));
   histograms.h_trackster_eta.push_back(
       ibook.book1D("trackster_eta", "Eta of the Trackster", nintEta_, minEta_, maxEta_));
   histograms.h_trackster_phi.push_back(
       ibook.book1D("trackster_phi", "Phi of the Trackster", nintPhi_, minPhi_, maxPhi_));
   histograms.h_trackster_energy.push_back(
       ibook.book1D("trackster_energy", "Energy of the Trackster", nintEne_, minEne_, maxEne_));
-  histograms.h_trackster_x.push_back(
-      ibook.book1D("trackster_x", "X position of the Trackster", nintX_, minX_, maxX_));
-  histograms.h_trackster_y.push_back(
-      ibook.book1D("trackster_y", "Y position of the Trackster", nintY_, minY_, maxY_));
-  histograms.h_trackster_z.push_back(
-      ibook.book1D("trackster_z", "Z position of the Trackster", nintZ_, minZ_, maxZ_));
+  histograms.h_trackster_x.push_back(ibook.book1D("trackster_x", "X position of the Trackster", nintX_, minX_, maxX_));
+  histograms.h_trackster_y.push_back(ibook.book1D("trackster_y", "Y position of the Trackster", nintY_, minY_, maxY_));
+  histograms.h_trackster_z.push_back(ibook.book1D("trackster_z", "Z position of the Trackster", nintZ_, minZ_, maxZ_));
   histograms.h_trackster_firstlayer.push_back(
       ibook.book1D("trackster_firstlayer", "First layer of the Trackster", 2 * layers, 0., (float)2 * layers));
   histograms.h_trackster_lastlayer.push_back(
       ibook.book1D("trackster_lastlayer", "Last layer of the Trackster", 2 * layers, 0., (float)2 * layers));
-  histograms.h_trackster_layersnum.push_back(ibook.book1D(
-      "trackster_layersnum", "Number of layers of the Trackster", 2 * layers, 0., (float)2 * layers));
+  histograms.h_trackster_layersnum.push_back(
+      ibook.book1D("trackster_layersnum", "Number of layers of the Trackster", 2 * layers, 0., (float)2 * layers));
 }
 
 void HGVHistoProducerAlgo::fill_info_histos(const Histograms& histograms, unsigned int layers) const {
@@ -2202,8 +2191,8 @@ void HGVHistoProducerAlgo::fill_generic_cluster_histos(const Histograms& histogr
       histograms.h_distancebetseedandmaxcell_perthickperlayer.at(seedstr)->Fill(distancebetseedandmax);
     }
     if (histograms.h_distancebetseedandmaxcellvsclusterenergy_perthickperlayer.count(seedstr)) {
-      histograms.h_distancebetseedandmaxcellvsclusterenergy_perthickperlayer.at(seedstr)->Fill(
-          distancebetseedandmax, clusters[lcId].energy());
+      histograms.h_distancebetseedandmaxcellvsclusterenergy_perthickperlayer.at(seedstr)->Fill(distancebetseedandmax,
+                                                                                               clusters[lcId].energy());
     }
 
     //Energy clustered per layer
@@ -2275,14 +2264,14 @@ void HGVHistoProducerAlgo::fill_generic_cluster_histos(const Histograms& histogr
 }
 
 void HGVHistoProducerAlgo::tracksters_to_CaloParticles(const Histograms& histograms,
-                                                          int count,
-                                                          const ticl::TracksterCollection& tracksters,
-                                                          const reco::CaloClusterCollection& layerClusters,
-                                                          std::vector<CaloParticle> const& cP,
-                                                          std::vector<size_t> const& cPIndices,
-                                                          std::vector<size_t> const& cPSelectedIndices,
-                                                          std::unordered_map<DetId, const HGCRecHit*> const& hitMap,
-                                                          unsigned int layers) const {
+                                                       int count,
+                                                       const ticl::TracksterCollection& tracksters,
+                                                       const reco::CaloClusterCollection& layerClusters,
+                                                       std::vector<CaloParticle> const& cP,
+                                                       std::vector<size_t> const& cPIndices,
+                                                       std::vector<size_t> const& cPSelectedIndices,
+                                                       std::unordered_map<DetId, const HGCRecHit*> const& hitMap,
+                                                       unsigned int layers) const {
   auto nTracksters = tracksters.size();
   //Consider CaloParticles coming from the hard scatterer, excluding the PU contribution.
   auto nCaloParticles = cPIndices.size();
@@ -2382,7 +2371,8 @@ void HGVHistoProducerAlgo::tracksters_to_CaloParticles(const Histograms& histogr
   for (unsigned int tstId = 0; tstId < nTracksters; ++tstId) {
     for (const auto lcId : tracksters[tstId].vertices()) {
       const auto& hits_and_fractions = layerClusters[lcId].hitsAndFractions();
-      if (hits_and_fractions.empty()) continue;
+      if (hits_and_fractions.empty())
+        continue;
 
       std::unordered_map<unsigned, float> CPEnergyInTST;
       int maxCPId_byNumberOfHits = -1;
@@ -2565,12 +2555,13 @@ void HGVHistoProducerAlgo::tracksters_to_CaloParticles(const Histograms& histogr
                                  << std::setw(25) << energyFractionOfCPinTST << std::endl;
 
     }  //end of loop through Trackster's layerClusters
-  } //end of loop through Tracksters
+  }    //end of loop through Tracksters
   //Loop through Tracksters
   for (unsigned int tstId = 0; tstId < nTracksters; ++tstId) {
     for (const auto lcId : tracksters[tstId].vertices()) {
       const auto& hits_and_fractions = layerClusters[lcId].hitsAndFractions();
-      if (hits_and_fractions.empty()) continue;
+      if (hits_and_fractions.empty())
+        continue;
       // find the unique CaloParticles id contributing to the Tracksters
       //cpsInTrackster[trackster][CPids]
       std::sort(cpsInTrackster[tstId].begin(), cpsInTrackster[tstId].end());
@@ -2582,8 +2573,8 @@ void HGVHistoProducerAlgo::tracksters_to_CaloParticles(const Histograms& histogr
         for (auto& cpPair : cpsInTrackster[tstId]) {
           //In case of a Trackster with zero energy but related CaloParticles the score is set to 1.
           cpPair.second = 1.;
-          LogDebug("HGCalValidator") << "Trackster Id: \t" << tstId << "\t CP id: \t" << cpPair.first
-                                     << "\t score \t" << cpPair.second << std::endl;
+          LogDebug("HGCalValidator") << "Trackster Id: \t" << tstId << "\t CP id: \t" << cpPair.first << "\t score \t"
+                                     << cpPair.second << std::endl;
           histograms.h_score_trackster2caloparticle[count]->Fill(cpPair.second);
         }
         continue;
@@ -2656,7 +2647,7 @@ void HGVHistoProducerAlgo::tracksters_to_CaloParticles(const Histograms& histogr
         LogDebug("HGCalValidator") << "sharedeneCPallLayers " << sharedeneCPallLayers << std::endl;
         if (cpPair.first == score->first) {
           histograms.h_sharedenergy_trackster2caloparticle[count]->Fill(sharedeneCPallLayers /
-                                                                      tracksters[tstId].raw_energy());
+                                                                        tracksters[tstId].raw_energy());
           histograms.h_energy_vs_score_trackster2caloparticle[count]->Fill(
               score->second, sharedeneCPallLayers / tracksters[tstId].raw_energy());
         }
@@ -2666,7 +2657,7 @@ void HGVHistoProducerAlgo::tracksters_to_CaloParticles(const Histograms& histogr
                                           [](const auto& obj) { return obj.second < ScoreCutTSTtoCPFakeMerge_; });
       tracksters_fakemerge[tstId] = assocFakeMerge;
     }  //end of loop through Trackster's layerClusters
-  }  //end of loop through Tracksters
+  }    //end of loop through Tracksters
 
   std::unordered_map<int, std::vector<float>> score3d;
   std::unordered_map<int, std::vector<float>> tstSharedEnergy;
@@ -2813,7 +2804,7 @@ void HGVHistoProducerAlgo::tracksters_to_CaloParticles(const Histograms& histogr
 
       histograms.h_sharedenergy_caloparticle2trackster[count]->Fill(tstSharedEnergyFrac[cpId][tstId]);
       histograms.h_energy_vs_score_caloparticle2trackster[count]->Fill(score3d[cpId][tstId],
-                                                                     tstSharedEnergyFrac[cpId][tstId]);
+                                                                       tstSharedEnergyFrac[cpId][tstId]);
     }  //end of loop through Tracksters
 
     auto is_assoc = [&](const auto& v) -> bool { return v < ScoreCutCPtoTSTEffDup_; };
@@ -2826,10 +2817,10 @@ void HGVHistoProducerAlgo::tracksters_to_CaloParticles(const Histograms& histogr
       auto best = std::min_element(std::begin(score3d[cpId]), std::end(score3d[cpId]));
       auto bestTstId = std::distance(std::begin(score3d[cpId]), best);
 
-      histograms.h_sharedenergy_caloparticle2trackster_vs_eta[count]->Fill(cP[cpId].g4Tracks()[0].momentum().eta(),
-                                                                         tracksters[bestTstId].raw_energy() / CPenergy);
-      histograms.h_sharedenergy_caloparticle2trackster_vs_phi[count]->Fill(cP[cpId].g4Tracks()[0].momentum().phi(),
-                                                                         tracksters[bestTstId].raw_energy() / CPenergy);
+      histograms.h_sharedenergy_caloparticle2trackster_vs_eta[count]->Fill(
+          cP[cpId].g4Tracks()[0].momentum().eta(), tracksters[bestTstId].raw_energy() / CPenergy);
+      histograms.h_sharedenergy_caloparticle2trackster_vs_phi[count]->Fill(
+          cP[cpId].g4Tracks()[0].momentum().phi(), tracksters[bestTstId].raw_energy() / CPenergy);
       histograms.h_sharedenergy_caloparticle2trackster_assoc[count]->Fill(tstSharedEnergyFrac[cpId][bestTstId]);
     }
     if (assocDup >= 2) {
@@ -2850,7 +2841,8 @@ void HGVHistoProducerAlgo::tracksters_to_CaloParticles(const Histograms& histogr
   for (unsigned int tstId = 0; tstId < nTracksters; ++tstId) {
     for (const auto lcId : tracksters[tstId].vertices()) {
       const auto& hits_and_fractions = layerClusters[lcId].hitsAndFractions();
-      if (hits_and_fractions.empty()) continue;
+      if (hits_and_fractions.empty())
+        continue;
       auto assocFakeMerge = tracksters_fakemerge[tstId];
       auto assocDuplicate = tracksters_duplicate[tstId];
       if (assocDuplicate) {
@@ -2887,14 +2879,14 @@ void HGVHistoProducerAlgo::tracksters_to_CaloParticles(const Histograms& histogr
 }
 
 void HGVHistoProducerAlgo::fill_trackster_histos(const Histograms& histograms,
-                                                     int count,
-                                                     const ticl::TracksterCollection& tracksters,
-                                                     const reco::CaloClusterCollection& layerClusters,
-                                                     std::vector<CaloParticle> const& cP,
-                                                     std::vector<size_t> const& cPIndices,
-                                                     std::vector<size_t> const& cPSelectedIndices,
-                                                     std::unordered_map<DetId, const HGCRecHit*> const& hitMap,
-                                                     unsigned int layers) const {
+                                                 int count,
+                                                 const ticl::TracksterCollection& tracksters,
+                                                 const reco::CaloClusterCollection& layerClusters,
+                                                 std::vector<CaloParticle> const& cP,
+                                                 std::vector<size_t> const& cPIndices,
+                                                 std::vector<size_t> const& cPSelectedIndices,
+                                                 std::unordered_map<DetId, const HGCRecHit*> const& hitMap,
+                                                 unsigned int layers) const {
   //Each event to be treated as two events:
   //an event in +ve endcap, plus another event in -ve endcap.
 
@@ -3044,7 +3036,8 @@ void HGVHistoProducerAlgo::fill_trackster_histos(const Histograms& histograms,
         histograms.h_multiplicity_zplus_numberOfEventsHistogram[count]->Fill(mlp);
       }
       //For the cluster multiplicity vs cluster energy
-      histograms.h_multiplicityOfLCinTST_vs_layerclusterenergy[count]->Fill(mlp, layerClusters[tracksters[tstId].vertices(lc)].energy());
+      histograms.h_multiplicityOfLCinTST_vs_layerclusterenergy[count]->Fill(
+          mlp, layerClusters[tracksters[tstId].vertices(lc)].energy());
     }
 
     if (!trackster_layers.empty()) {
@@ -3069,7 +3062,8 @@ void HGVHistoProducerAlgo::fill_trackster_histos(const Histograms& histograms,
   histograms.h_conttracksternum[count]->Fill(totNContTstZp + totNContTstZm);
   histograms.h_nonconttracksternum[count]->Fill(totNNotContTstZp + totNNotContTstZm);
 
-  tracksters_to_CaloParticles(histograms, count, tracksters, layerClusters, cP, cPIndices, cPSelectedIndices, hitMap, layers);
+  tracksters_to_CaloParticles(
+      histograms, count, tracksters, layerClusters, cP, cPIndices, cPSelectedIndices, hitMap, layers);
 }
 
 double HGVHistoProducerAlgo::distance2(const double x1,

--- a/Validation/HGCalValidation/src/HGVHistoProducerAlgo.cc
+++ b/Validation/HGCalValidation/src/HGVHistoProducerAlgo.cc
@@ -2839,42 +2839,39 @@ void HGVHistoProducerAlgo::tracksters_to_CaloParticles(const Histograms& histogr
   // reco-level, namely fake-rate an merge-rate. In this loop we should *not*
   // restrict only to the selected caloParaticles.
   for (unsigned int tstId = 0; tstId < nTracksters; ++tstId) {
-    for (const auto lcId : tracksters[tstId].vertices()) {
-      const auto& hits_and_fractions = layerClusters[lcId].hitsAndFractions();
-      if (hits_and_fractions.empty())
-        continue;
-      auto assocFakeMerge = tracksters_fakemerge[tstId];
-      auto assocDuplicate = tracksters_duplicate[tstId];
-      if (assocDuplicate) {
-        histograms.h_numDup_trackster_eta[count]->Fill(tracksters[tstId].barycenter().eta());
-        histograms.h_numDup_trackster_phi[count]->Fill(tracksters[tstId].barycenter().phi());
-      }
-      if (assocFakeMerge > 0) {
-        histograms.h_num_trackster_eta[count]->Fill(tracksters[tstId].barycenter().eta());
-        histograms.h_num_trackster_phi[count]->Fill(tracksters[tstId].barycenter().phi());
-        auto best = std::min_element(std::begin(cpsInTrackster[tstId]),
-                                     std::end(cpsInTrackster[tstId]),
-                                     [](const auto& obj1, const auto& obj2) { return obj1.second < obj2.second; });
-
-        //This is the shared energy taking the best caloparticle in each layer
-        float sharedeneCPallLayers = 0.;
-        //Loop through all layers
-        for (unsigned int j = 0; j < layers * 2; ++j) {
-          auto const& best_cp_linked = cPOnLayer[best->first][j].layerClusterIdToEnergyAndScore[tstId];
-          sharedeneCPallLayers += best_cp_linked.first;
-        }  //end of loop through layers
-        histograms.h_sharedenergy_trackster2caloparticle_vs_eta[count]->Fill(
-            tracksters[tstId].barycenter().eta(), sharedeneCPallLayers / tracksters[tstId].raw_energy());
-        histograms.h_sharedenergy_trackster2caloparticle_vs_phi[count]->Fill(
-            tracksters[tstId].barycenter().phi(), sharedeneCPallLayers / tracksters[tstId].raw_energy());
-      }
-      if (assocFakeMerge >= 2) {
-        histograms.h_numMerge_trackster_eta[count]->Fill(tracksters[tstId].barycenter().eta());
-        histograms.h_numMerge_trackster_phi[count]->Fill(tracksters[tstId].barycenter().phi());
-      }
-      histograms.h_denom_trackster_eta[count]->Fill(tracksters[tstId].barycenter().eta());
-      histograms.h_denom_trackster_phi[count]->Fill(tracksters[tstId].barycenter().phi());
+    if (tracksters[tstId].vertices().empty())
+      continue;
+    auto assocFakeMerge = tracksters_fakemerge[tstId];
+    auto assocDuplicate = tracksters_duplicate[tstId];
+    if (assocDuplicate) {
+      histograms.h_numDup_trackster_eta[count]->Fill(tracksters[tstId].barycenter().eta());
+      histograms.h_numDup_trackster_phi[count]->Fill(tracksters[tstId].barycenter().phi());
     }
+    if (assocFakeMerge > 0) {
+      histograms.h_num_trackster_eta[count]->Fill(tracksters[tstId].barycenter().eta());
+      histograms.h_num_trackster_phi[count]->Fill(tracksters[tstId].barycenter().phi());
+      auto best = std::min_element(std::begin(cpsInTrackster[tstId]),
+                                   std::end(cpsInTrackster[tstId]),
+                                   [](const auto& obj1, const auto& obj2) { return obj1.second < obj2.second; });
+
+      //This is the shared energy taking the best caloparticle in each layer
+      float sharedeneCPallLayers = 0.;
+      //Loop through all layers
+      for (unsigned int j = 0; j < layers * 2; ++j) {
+        auto const& best_cp_linked = cPOnLayer[best->first][j].layerClusterIdToEnergyAndScore[tstId];
+        sharedeneCPallLayers += best_cp_linked.first;
+      }  //end of loop through layers
+      histograms.h_sharedenergy_trackster2caloparticle_vs_eta[count]->Fill(
+          tracksters[tstId].barycenter().eta(), sharedeneCPallLayers / tracksters[tstId].raw_energy());
+      histograms.h_sharedenergy_trackster2caloparticle_vs_phi[count]->Fill(
+          tracksters[tstId].barycenter().phi(), sharedeneCPallLayers / tracksters[tstId].raw_energy());
+    }
+    if (assocFakeMerge >= 2) {
+      histograms.h_numMerge_trackster_eta[count]->Fill(tracksters[tstId].barycenter().eta());
+      histograms.h_numMerge_trackster_phi[count]->Fill(tracksters[tstId].barycenter().phi());
+    }
+    histograms.h_denom_trackster_eta[count]->Fill(tracksters[tstId].barycenter().eta());
+    histograms.h_denom_trackster_phi[count]->Fill(tracksters[tstId].barycenter().phi());
   }
 }
 

--- a/Validation/HGCalValidation/src/HGVHistoProducerAlgo.cc
+++ b/Validation/HGCalValidation/src/HGVHistoProducerAlgo.cc
@@ -1444,7 +1444,7 @@ void HGVHistoProducerAlgo::HGVHistoProducerAlgo::fill_simCluster_histos(const Hi
   histograms.h_mixedhitssimcluster_zminus->Fill(tnscpthminus["mixed"]);
 }
 
-void HGVHistoProducerAlgo::HGVHistoProducerAlgo::fill_simClusterassosiation_histos(
+void HGVHistoProducerAlgo::HGVHistoProducerAlgo::fill_simClusterAssociation_histos(
     const Histograms& histograms,
     int count,
     edm::Handle<reco::CaloClusterCollection> clusterHandle,


### PR DESCRIPTION
#### PR description:

This PR replaces the usage of HGCal MultiCluster with Trackster.
No changes are expected, apart from
- naming shift ("MultiCluster" -> "Trackster") in DQM output.
- O(10%) difference in the MEs using the MultiCluster/Trackster energy (which may change of 0.01% for numerical precision) due to overflow migration; I verified that the unbinned histogram mean is identical. 

#### PR validation:

`runTheMatrix -l limited`