### PR TITLE
71X Backport, Add number of events, beginLumi's, and beginRun's to Jo…

### DIFF
--- a/FWCore/Services/interface/Timing.h
+++ b/FWCore/Services/interface/Timing.h
@@ -15,6 +15,7 @@ namespace edm {
   class ActivityRegistry;
   class Event;
   class EventSetup;
+  class GlobalContext;
   class ParameterSet;
   class ConfigurationDescriptions;
   class StreamContext;
@@ -39,6 +40,9 @@ namespace edm {
       void preModule(StreamContext const&, ModuleCallingContext const&);
       void postModule(StreamContext const&, ModuleCallingContext const&);
 
+      void postGlobalBeginRun(GlobalContext const&);
+      void postGlobalBeginLumi(GlobalContext const&);
+
       double curr_job_time_;    // seconds
       double curr_job_cpu_;     // seconds
       std::vector<double> curr_events_time_;  // seconds
@@ -55,6 +59,8 @@ namespace edm {
       std::vector<double> min_events_time_; // seconds
       std::vector<double> min_events_cpu_;  // seconds
       std::atomic<unsigned long> total_event_count_;
+      std::atomic<unsigned long> begin_lumi_count_;
+      std::atomic<unsigned long> begin_run_count_;
     };
   }
 }

--- a/FWCore/Services/src/Timing.cc
+++ b/FWCore/Services/src/Timing.cc
@@ -37,6 +37,12 @@ namespace edm {
         return t.str();
     }
 
+    static std::string ui2str(unsigned int i) {
+      std::stringstream t;
+      t << i;
+      return t.str();
+    }
+
     static double getTime() {
       struct timeval t;
       if(gettimeofday(&t, 0) < 0)
@@ -77,7 +83,9 @@ namespace edm {
         max_events_cpu_(),
         min_events_time_(),
         min_events_cpu_(),
-        total_event_count_(0) {
+        total_event_count_(0),
+        begin_lumi_count_(0),
+        begin_run_count_(0) {
       iRegistry.watchPostBeginJob(this, &Timing::postBeginJob);
       iRegistry.watchPostEndJob(this, &Timing::postEndJob);
 
@@ -89,6 +97,9 @@ namespace edm {
         iRegistry.watchPostModuleEvent(this, &Timing::postModule);
       }
           
+      iRegistry.watchPostGlobalBeginRun(this, &Timing::postGlobalBeginRun);
+      iRegistry.watchPostGlobalBeginLumi(this, &Timing::postGlobalBeginLumi);
+
       iRegistry.preallocateSignal_.connect([this](service::SystemBounds const& iBounds){
         auto nStreams = iBounds.maxNumberOfStreams();
         curr_events_time_.resize(nStreams,0.);
@@ -163,7 +174,11 @@ namespace edm {
         << " - Max event:   " << max_event_cpu << "\n"
         << " - Avg event:   " << average_event_cpu << "\n"
         << " - Total job:   " << total_job_cpu << "\n"
-        << " - Total event: " << total_event_cpu << "\n";
+        << " - Total event: " << total_event_cpu << "\n"
+        << " Processing Summary: \n"
+        << " - Number of Events:  " << total_event_count_ << "\n"
+        << " - Number of Global Begin Lumi Calls:  " << begin_lumi_count_ << "\n"
+        << " - Number of Global Begin Run Calls: " << begin_run_count_ << "\n";
 
       if(report_summary_) {
         Service<JobReport> reportSvc;
@@ -180,6 +195,12 @@ namespace edm {
         reportData.insert(std::make_pair("TotalEventCPU", d2str(total_event_cpu)));
 
         reportSvc->reportPerformanceSummary("Timing", reportData);
+
+        std::map<std::string, std::string> reportData1;
+        reportData1.insert(std::make_pair("NumberEvents", ui2str(total_event_count_)));
+        reportData1.insert(std::make_pair("NumberBeginLumiCalls", ui2str(begin_lumi_count_)));
+        reportData1.insert(std::make_pair("NumberBeginRunCalls", ui2str(begin_run_count_)));
+        reportSvc->reportPerformanceSummary("ProcessingSummary", reportData1);
       }
     }
 
@@ -239,6 +260,14 @@ namespace edm {
       << desc.moduleLabel() << " "
       << desc.moduleName() << " "
       << t;
+    }
+
+    void Timing::postGlobalBeginRun(GlobalContext const&) {
+      ++begin_run_count_;
+    }
+
+    void Timing::postGlobalBeginLumi(GlobalContext const&) {
+      ++begin_lumi_count_;
     }
   }
 }


### PR DESCRIPTION
…bReport

#### PR description:

Backport of #22408 to 7_1_X

Add number of events, beginLumi's, and beginRun's to JobReport
Also adds to the output of the Timing service in the log file

Also had to backport the little ui2str function.

Note the file was split in two different directories back in 7_1_X. It was not in the plugins directory but instead in interface and src.

#### PR validation:

Manually ran job to examine output. Relies on validation of the original PR. The code changes are nearly identical but things are somewhat different because this was in two files before and the code around the changes is different.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Backport of #22408

PdmV request, See #33478
