### PR TITLE
Vertex smearing and beamspot for PP ref UL MC

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -49,6 +49,8 @@ autoCond = {
     'phase1_2017_design'       :  '106X_mc2017_design_IdealBS_v6',
     # GlobalTag for MC production with realistic conditions for Phase1 2017 detector
     'phase1_2017_realistic'    :  '106X_mc2017_realistic_v9',
+    # GlobalTag for MC production with realistic conditions for Phase1 2017 detector, for PP reference run
+    'phase1_2017_realistic_ppref'    :  '106X_mc2017_realistic_forppRef5TeV_v3',
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in DECO mode
     'phase1_2017_cosmics'      :  '106X_mc2017cosmics_realistic_deco_v4',
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in PEAK mode

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -957,7 +957,7 @@ steps['ZEEMM_13_HI']=merge([hiDefaults2018_ppReco,gen2018hiprod('ZEEMM_13TeV_Tun
 
 ## pp reference tests
 
-ppRefAlca2017 = {'--conditions':'auto:phase1_2017_realistic', '--era':'Run2_2017_ppRef'}
+ppRefAlca2017 = {'--conditions':'auto:phase1_2017_realistic_ppref', '--era':'Run2_2017_ppRef', '--beamspot':'Fixed_EmitRealistic5TeVppCollision2017'}
 ppRefDefaults2017=merge([ppRefAlca2017,{'-n':2}])
 
 steps['QCD_Pt_80_120_13_PPREF']=merge([ppRefDefaults2017,gen2017('QCD_Pt_80_120_13TeV_TuneCUETP8M1_cfi',Kby(9,150))])

--- a/Configuration/StandardSequences/python/VtxSmeared.py
+++ b/Configuration/StandardSequences/python/VtxSmeared.py
@@ -53,6 +53,7 @@ VtxSmeared = {
     'Realistic50ns13TeVCollision': 'IOMC.EventVertexGenerators.VtxSmearedRealistic50ns13TeVCollision_cfi',
     'Nominal5TeVpp2015Collision':    'IOMC.EventVertexGenerators.VtxSmearedNominal5TeVpp2015Collision_cfi',
     'Realistic5TeVppCollision2017':    'IOMC.EventVertexGenerators.VtxSmearedRealistic5TeVppCollision2017_cfi',
+    'Fixed_EmitRealistic5TeVppCollision2017':    'IOMC.EventVertexGenerators.VtxSmearedFixed_EmitRealistic5TeVppCollision2017_cfi',
     'Realistic25ns13TeV2016Collision':    'IOMC.EventVertexGenerators.VtxSmearedRealistic25ns13TeV2016Collision_cfi',
     'Realistic100ns13TeVCollisionBetaStar90m' : 'IOMC.EventVertexGenerators.VtxSmearedRealistic100ns13TeVCollisionBetaStar90m_cfi',
     'Realistic100ns13TeVCollisionBetaStar90mLowBunches' : 'IOMC.EventVertexGenerators.VtxSmearedRealistic100ns13TeVCollisionBetaStar90mLowBunches_cfi',

--- a/IOMC/EventVertexGenerators/python/VtxSmearedFixed_EmitRealistic5TeVppCollision2017_cfi.py
+++ b/IOMC/EventVertexGenerators/python/VtxSmearedFixed_EmitRealistic5TeVppCollision2017_cfi.py
@@ -1,0 +1,7 @@
+import FWCore.ParameterSet.Config as cms
+
+from IOMC.EventVertexGenerators.VtxSmearedParameters_cfi import Fixed_EmitRealistic5TeVppCollision2017VtxSmearingParameters,VtxSmearedCommon
+VtxSmeared = cms.EDProducer("BetafuncEvtVtxGenerator",
+    Fixed_EmitRealistic5TeVppCollision2017VtxSmearingParameters,
+    VtxSmearedCommon
+)

--- a/IOMC/EventVertexGenerators/python/VtxSmearedParameters_cfi.py
+++ b/IOMC/EventVertexGenerators/python/VtxSmearedParameters_cfi.py
@@ -638,6 +638,19 @@ Realistic5TeVppCollision2017VtxSmearingParameters = cms.PSet(
     Z0 = cms.double(0.619)
 )
 
+# Fixed Emittance (X2) in Beam spot extracted from data for 2017 pp run @ 5 TeV
+Fixed_EmitRealistic5TeVppCollision2017VtxSmearingParameters = cms.PSet(
+    Phi = cms.double(0.0),
+    BetaStar = cms.double(311),
+    Emittance = cms.double(7.6e-8),
+    Alpha = cms.double(0.0),
+    SigmaZ = cms.double(5.82),
+    TimeOffset = cms.double(0.0),
+    X0 = cms.double(-0.0228),
+    Y0 = cms.double(0.0795),
+    Z0 = cms.double(0.619)
+)
+
 # From 2018B 3.8T data
 # BS parameters extracted from run 316199, fill 6675 (from StreamExpressAlignment, HP BS):
 # X0         =  0.09676  [cm]


### PR DESCRIPTION
#### PR description:

We are preparing for the UL MC of 2017G, the 5 TeV pp reference dataset.
A GT was prepared by Alca:
https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/4390/1/1/1/1/1/1/1/1/1/1/3.html

They have requested that it be tested in a relval workflow, which is the goal of this PR.
It turns out that the final vertex smearing used for the processing in 94X ( #28573 ), was never propagated to 106X, so this is also included in this PR.

The relval workflow implementing both the updated vertex smearing and beamspot is 149.


#### PR validation:

Workflow 149 was tested. 

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

EDIT:
This PR is now a backport.  The PP ref GTs have been forwarded ported and added to the autoconds in #33655

@christopheralanwest 


