### PR TITLE
Modify CaloLayer1 DQM for 5BX needed for Ecal

### DIFF
--- a/DQM/L1TMonitor/interface/L1TStage2CaloLayer1.h
+++ b/DQM/L1TMonitor/interface/L1TStage2CaloLayer1.h
@@ -155,6 +155,14 @@ namespace CaloL1Information {
 
     dqm::reco::MonitorElement *last20Mismatches_;
 
+    dqm::reco::MonitorElement *ecalOccRecd5Bx_;
+    dqm::reco::MonitorElement *ecalOccRecd5BxEtWgt_;
+    dqm::reco::MonitorElement *ecalOccRecdBx1_;
+    dqm::reco::MonitorElement *ecalOccRecdBx2_;
+    dqm::reco::MonitorElement *ecalOccRecdBx3_;
+    dqm::reco::MonitorElement *ecalOccRecdBx4_;
+    dqm::reco::MonitorElement *ecalOccRecdBx5_;
+
     std::vector<std::tuple<edm::RunID, edm::LuminosityBlockID, edm::EventID, std::vector<int>>> runMismatchList;
   };
 
@@ -268,6 +276,16 @@ private:
   // Input and config info
   edm::EDGetTokenT<EcalTrigPrimDigiCollection> ecalTPSourceRecd_;
   std::string ecalTPSourceRecdLabel_;
+  edm::EDGetTokenT<EcalTrigPrimDigiCollection> ecalTPSourceRecdBx1_;
+  std::string ecalTPSourceRecdBx1Label_;
+  edm::EDGetTokenT<EcalTrigPrimDigiCollection> ecalTPSourceRecdBx2_;
+  std::string ecalTPSourceRecdBx2Label_;
+  edm::EDGetTokenT<EcalTrigPrimDigiCollection> ecalTPSourceRecdBx3_;
+  std::string ecalTPSourceRecdBx3Label_;
+  edm::EDGetTokenT<EcalTrigPrimDigiCollection> ecalTPSourceRecdBx4_;
+  std::string ecalTPSourceRecdBx4Label_;
+  edm::EDGetTokenT<EcalTrigPrimDigiCollection> ecalTPSourceRecdBx5_;
+  std::string ecalTPSourceRecdBx5Label_;
   edm::EDGetTokenT<HcalTrigPrimDigiCollection> hcalTPSourceRecd_;
   std::string hcalTPSourceRecdLabel_;
   edm::EDGetTokenT<EcalTrigPrimDigiCollection> ecalTPSourceSent_;
@@ -277,6 +295,7 @@ private:
   edm::EDGetTokenT<FEDRawDataCollection> fedRawData_;
   std::string histFolder_;
   int tpFillThreshold_;
+  int tpFillThreshold5Bx_;
   bool ignoreHFfbs_;
 };
 

--- a/DQM/L1TMonitor/python/L1TStage2CaloLayer1_cfi.py
+++ b/DQM/L1TMonitor/python/L1TStage2CaloLayer1_cfi.py
@@ -3,6 +3,11 @@ import FWCore.ParameterSet.Config as cms
 from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
 l1tStage2CaloLayer1 = DQMEDAnalyzer('L1TStage2CaloLayer1',
     ecalTPSourceRecd = cms.InputTag("caloLayer1Digis"),
+    ecalTPSourceRecdBx1 = cms.InputTag("caloLayer1Digis","EcalDigisBx1"),
+    ecalTPSourceRecdBx2 = cms.InputTag("caloLayer1Digis","EcalDigisBx2"),
+    ecalTPSourceRecdBx3 = cms.InputTag("caloLayer1Digis","EcalDigisBx3"),
+    ecalTPSourceRecdBx4 = cms.InputTag("caloLayer1Digis","EcalDigisBx4"),
+    ecalTPSourceRecdBx5 = cms.InputTag("caloLayer1Digis","EcalDigisBx5"),
     hcalTPSourceRecd = cms.InputTag("caloLayer1Digis"),
     ecalTPSourceSent = cms.InputTag("ecalDigis","EcalTriggerPrimitives"),
     hcalTPSourceSent = cms.InputTag("hcalDigis"),

--- a/DQM/L1TMonitor/src/L1TStage2CaloLayer1.cc
+++ b/DQM/L1TMonitor/src/L1TStage2CaloLayer1.cc
@@ -5,6 +5,7 @@
  */
 //Modified by Bhawna Gomber <bhawna.gomber@cern.ch>
 //Modified by Andrew Loeliger <andrew.loeliger@cern.ch>
+//Modified by Ho-Fung Tsoi <ho.fung.tsoi@cern.ch>
 
 #include "DQM/L1TMonitor/interface/L1TStage2CaloLayer1.h"
 
@@ -21,6 +22,16 @@
 L1TStage2CaloLayer1::L1TStage2CaloLayer1(const edm::ParameterSet& ps)
     : ecalTPSourceRecd_(consumes<EcalTrigPrimDigiCollection>(ps.getParameter<edm::InputTag>("ecalTPSourceRecd"))),
       ecalTPSourceRecdLabel_(ps.getParameter<edm::InputTag>("ecalTPSourceRecd").label()),
+      ecalTPSourceRecdBx1_(consumes<EcalTrigPrimDigiCollection>(ps.getParameter<edm::InputTag>("ecalTPSourceRecdBx1"))),
+      ecalTPSourceRecdBx1Label_(ps.getParameter<edm::InputTag>("ecalTPSourceRecdBx1").label()),
+      ecalTPSourceRecdBx2_(consumes<EcalTrigPrimDigiCollection>(ps.getParameter<edm::InputTag>("ecalTPSourceRecdBx2"))),
+      ecalTPSourceRecdBx2Label_(ps.getParameter<edm::InputTag>("ecalTPSourceRecdBx2").label()),
+      ecalTPSourceRecdBx3_(consumes<EcalTrigPrimDigiCollection>(ps.getParameter<edm::InputTag>("ecalTPSourceRecdBx3"))),
+      ecalTPSourceRecdBx3Label_(ps.getParameter<edm::InputTag>("ecalTPSourceRecdBx3").label()),
+      ecalTPSourceRecdBx4_(consumes<EcalTrigPrimDigiCollection>(ps.getParameter<edm::InputTag>("ecalTPSourceRecdBx4"))),
+      ecalTPSourceRecdBx4Label_(ps.getParameter<edm::InputTag>("ecalTPSourceRecdBx4").label()),
+      ecalTPSourceRecdBx5_(consumes<EcalTrigPrimDigiCollection>(ps.getParameter<edm::InputTag>("ecalTPSourceRecdBx5"))),
+      ecalTPSourceRecdBx5Label_(ps.getParameter<edm::InputTag>("ecalTPSourceRecdBx5").label()),
       hcalTPSourceRecd_(consumes<HcalTrigPrimDigiCollection>(ps.getParameter<edm::InputTag>("hcalTPSourceRecd"))),
       hcalTPSourceRecdLabel_(ps.getParameter<edm::InputTag>("hcalTPSourceRecd").label()),
       ecalTPSourceSent_(consumes<EcalTrigPrimDigiCollection>(ps.getParameter<edm::InputTag>("ecalTPSourceSent"))),
@@ -30,6 +41,7 @@ L1TStage2CaloLayer1::L1TStage2CaloLayer1(const edm::ParameterSet& ps)
       fedRawData_(consumes<FEDRawDataCollection>(ps.getParameter<edm::InputTag>("fedRawDataLabel"))),
       histFolder_(ps.getParameter<std::string>("histFolder")),
       tpFillThreshold_(ps.getUntrackedParameter<int>("etDistributionsFillThreshold", 0)),
+      tpFillThreshold5Bx_(ps.getUntrackedParameter<int>("etDistributionsFillThreshold5Bx", 1)),
       ignoreHFfbs_(ps.getUntrackedParameter<bool>("ignoreHFfbs", false)) {}
 
 L1TStage2CaloLayer1::~L1TStage2CaloLayer1() {}
@@ -193,6 +205,63 @@ void L1TStage2CaloLayer1::dqmAnalyze(const edm::Event& event,
 
   if (nEcalMismatch > streamCache(event.streamID())->streamNumMaxEvtMismatchECAL)
     streamCache(event.streamID())->streamNumMaxEvtMismatchECAL = nEcalMismatch;
+
+  edm::Handle<EcalTrigPrimDigiCollection> ecalTPsRecdBx1;
+  event.getByToken(ecalTPSourceRecdBx1_, ecalTPsRecdBx1);
+  edm::Handle<EcalTrigPrimDigiCollection> ecalTPsRecdBx2;
+  event.getByToken(ecalTPSourceRecdBx2_, ecalTPsRecdBx2);
+  edm::Handle<EcalTrigPrimDigiCollection> ecalTPsRecdBx3;
+  event.getByToken(ecalTPSourceRecdBx3_, ecalTPsRecdBx3);
+  edm::Handle<EcalTrigPrimDigiCollection> ecalTPsRecdBx4;
+  event.getByToken(ecalTPSourceRecdBx4_, ecalTPsRecdBx4);
+  edm::Handle<EcalTrigPrimDigiCollection> ecalTPsRecdBx5;
+  event.getByToken(ecalTPSourceRecdBx5_, ecalTPsRecdBx5);
+
+  for (const auto& tp : (*ecalTPsRecdBx1)) {
+    if (tp.compressedEt() > tpFillThreshold5Bx_) {
+      const int ieta = tp.id().ieta();
+      const int iphi = tp.id().iphi();
+      eventMonitors.ecalOccRecdBx1_->Fill(ieta, iphi);
+      eventMonitors.ecalOccRecd5Bx_->Fill(1);
+      eventMonitors.ecalOccRecd5BxEtWgt_->Fill(1, tp.compressedEt());
+    }
+  }
+  for (const auto& tp : (*ecalTPsRecdBx2)) {
+    if (tp.compressedEt() > tpFillThreshold5Bx_) {
+      const int ieta = tp.id().ieta();
+      const int iphi = tp.id().iphi();
+      eventMonitors.ecalOccRecdBx2_->Fill(ieta, iphi);
+      eventMonitors.ecalOccRecd5Bx_->Fill(2);
+      eventMonitors.ecalOccRecd5BxEtWgt_->Fill(2, tp.compressedEt());
+    }
+  }
+  for (const auto& tp : (*ecalTPsRecdBx3)) {
+    if (tp.compressedEt() > tpFillThreshold5Bx_) {
+      const int ieta = tp.id().ieta();
+      const int iphi = tp.id().iphi();
+      eventMonitors.ecalOccRecdBx3_->Fill(ieta, iphi);
+      eventMonitors.ecalOccRecd5Bx_->Fill(3);
+      eventMonitors.ecalOccRecd5BxEtWgt_->Fill(3, tp.compressedEt());
+    }
+  }
+  for (const auto& tp : (*ecalTPsRecdBx4)) {
+    if (tp.compressedEt() > tpFillThreshold5Bx_) {
+      const int ieta = tp.id().ieta();
+      const int iphi = tp.id().iphi();
+      eventMonitors.ecalOccRecdBx4_->Fill(ieta, iphi);
+      eventMonitors.ecalOccRecd5Bx_->Fill(4);
+      eventMonitors.ecalOccRecd5BxEtWgt_->Fill(4, tp.compressedEt());
+    }
+  }
+  for (const auto& tp : (*ecalTPsRecdBx5)) {
+    if (tp.compressedEt() > tpFillThreshold5Bx_) {
+      const int ieta = tp.id().ieta();
+      const int iphi = tp.id().iphi();
+      eventMonitors.ecalOccRecdBx5_->Fill(ieta, iphi);
+      eventMonitors.ecalOccRecd5Bx_->Fill(5);
+      eventMonitors.ecalOccRecd5BxEtWgt_->Fill(5, tp.compressedEt());
+    }
+  }
 
   edm::Handle<HcalTrigPrimDigiCollection> hcalTPsSent;
   event.getByToken(hcalTPSourceSent_, hcalTPsSent);
@@ -441,6 +510,15 @@ void L1TStage2CaloLayer1::bookHistograms(DQMStore::IBooker& ibooker,
   eventMonitors.ecalTPRawEtRecd_ = bookEt("ecalTPRawEtRecd", "ECal Raw Et Layer1 Readout");
   eventMonitors.ecalTPRawEtSentAndRecd_ = bookEt("ecalTPRawEtMatch", "ECal Raw Et FULL MATCH");
   eventMonitors.ecalTPRawEtSent_ = bookEt("ecalTPRawEtSent", "ECal Raw Et TCC Readout");
+  eventMonitors.ecalOccRecd5Bx_ = ibooker.book1D(
+      "ecalOccRecd5Bx", "ECal TP Values Averaged vs BX", 5, 1, 6);
+  eventMonitors.ecalOccRecd5BxEtWgt_ = ibooker.book1D(
+      "ecalOccRecd5BxEtWgt", "ECal TP*Et Averaged vs BX", 5, 1, 6);
+  eventMonitors.ecalOccRecdBx1_ = bookEcalOccupancy("ecalOccRecdBx1", "ECal TP Occupancy for BX1");
+  eventMonitors.ecalOccRecdBx2_ = bookEcalOccupancy("ecalOccRecdBx2", "ECal TP Occupancy for BX2");
+  eventMonitors.ecalOccRecdBx3_ = bookEcalOccupancy("ecalOccRecdBx3", "ECal TP Occupancy for BX3");
+  eventMonitors.ecalOccRecdBx4_ = bookEcalOccupancy("ecalOccRecdBx4", "ECal TP Occupancy for BX4");
+  eventMonitors.ecalOccRecdBx5_ = bookEcalOccupancy("ecalOccRecdBx5", "ECal TP Occupancy for BX5");
 
   ibooker.setCurrentFolder(histFolder_ + "/ECalDetail/TCCDebug");
   eventMonitors.ecalOccSentNotRecd_ =

--- a/DQM/L1TMonitor/src/L1TStage2CaloLayer1.cc
+++ b/DQM/L1TMonitor/src/L1TStage2CaloLayer1.cc
@@ -510,10 +510,8 @@ void L1TStage2CaloLayer1::bookHistograms(DQMStore::IBooker& ibooker,
   eventMonitors.ecalTPRawEtRecd_ = bookEt("ecalTPRawEtRecd", "ECal Raw Et Layer1 Readout");
   eventMonitors.ecalTPRawEtSentAndRecd_ = bookEt("ecalTPRawEtMatch", "ECal Raw Et FULL MATCH");
   eventMonitors.ecalTPRawEtSent_ = bookEt("ecalTPRawEtSent", "ECal Raw Et TCC Readout");
-  eventMonitors.ecalOccRecd5Bx_ = ibooker.book1D(
-      "ecalOccRecd5Bx", "ECal TP Values Averaged vs BX", 5, 1, 6);
-  eventMonitors.ecalOccRecd5BxEtWgt_ = ibooker.book1D(
-      "ecalOccRecd5BxEtWgt", "ECal TP*Et Averaged vs BX", 5, 1, 6);
+  eventMonitors.ecalOccRecd5Bx_ = ibooker.book1D("ecalOccRecd5Bx", "ECal TP Values Averaged vs BX", 5, 1, 6);
+  eventMonitors.ecalOccRecd5BxEtWgt_ = ibooker.book1D("ecalOccRecd5BxEtWgt", "ECal TP*Et Averaged vs BX", 5, 1, 6);
   eventMonitors.ecalOccRecdBx1_ = bookEcalOccupancy("ecalOccRecdBx1", "ECal TP Occupancy for BX1");
   eventMonitors.ecalOccRecdBx2_ = bookEcalOccupancy("ecalOccRecdBx2", "ECal TP Occupancy for BX2");
   eventMonitors.ecalOccRecdBx3_ = bookEcalOccupancy("ecalOccRecdBx3", "ECal TP Occupancy for BX3");

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/CaloLayer1Unpacker.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/CaloLayer1Unpacker.cc
@@ -32,6 +32,7 @@ namespace l1t {
         makeRegions(ctp7_phi, ctp7Data, res->getRegions());
       } else if (N_BX == 5) {
         const uint32_t* ptr5 = ptr;
+        ptr += 192*2;
         UCTCTP7RawData ctp7Data(ptr);
         makeECalTPGs(ctp7_phi, ctp7Data, res->getEcalDigis());
         makeHCalTPGs(ctp7_phi, ctp7Data, res->getHcalDigis());

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/CaloLayer1Unpacker.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/CaloLayer1Unpacker.cc
@@ -32,7 +32,7 @@ namespace l1t {
         makeRegions(ctp7_phi, ctp7Data, res->getRegions());
       } else if (N_BX == 5) {
         const uint32_t* ptr5 = ptr;
-        ptr += 192*2;
+        ptr += 192 * 2;
         UCTCTP7RawData ctp7Data(ptr);
         makeECalTPGs(ctp7_phi, ctp7Data, res->getEcalDigis());
         makeHCalTPGs(ctp7_phi, ctp7Data, res->getHcalDigis());


### PR DESCRIPTION
#### PR description:

Modifications are made to add DQM CaloLayer1 monitoring elements for 5BX, which are needed for ECAL: two 5-bin 1D plots for TPs averages vs BX (with or without Et-weighted), and five 2D TPs occupancy plots. Unpacker is modified to point to the proper sample when filling the 5BX histograms (the middle BX is the "standard").

#### PR validation:

For testing, the unpacker is modified to fill 5 times the EcalDigisBx for 5BX inside the "if(N_BX==1)" since now we always get BX=1, so the 5BX histograms can get filled for testing (this modification is for our own testing purpose so is not included in this PR). The codes can be compiled and are tested with an offline DQM workflow "runTheMatrix.py -l 10823.0", the 5BX histograms show up in the DQM root files and are properly filled.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

<!-- Please replace this text with any link to  -->

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
