### PR TITLE
Adding HtoZZ UL ID configs

### DIFF
--- a/RecoEgamma/ElectronIdentification/python/ElectronMVAValueMapProducer_cfi.py
+++ b/RecoEgamma/ElectronIdentification/python/ElectronMVAValueMapProducer_cfi.py
@@ -27,6 +27,20 @@ from RecoEgamma.ElectronIdentification.Identification.mvaElectronID_Fall17_iso_V
     import mvaEleID_Fall17_iso_V2_producer_config
 mvaConfigsForEleProducer.append( mvaEleID_Fall17_iso_V2_producer_config )
 
+
+# HZZ4l Run2 (Ultra)Legacy 
+from RecoEgamma.ElectronIdentification.Identification.mvaElectronID_Summer16UL_ID_ISO_cff \
+    import mvaEleID_Summer16UL_ID_ISO_producer_config
+mvaConfigsForEleProducer.append(mvaEleID_Summer16UL_ID_ISO_producer_config)
+
+from RecoEgamma.ElectronIdentification.Identification.mvaElectronID_Summer17UL_ID_ISO_cff \
+    import mvaEleID_Summer17UL_ID_ISO_producer_config
+mvaConfigsForEleProducer.append(mvaEleID_Summer17UL_ID_ISO_producer_config)
+
+from RecoEgamma.ElectronIdentification.Identification.mvaElectronID_Summer18UL_ID_ISO_cff \
+    import mvaEleID_Summer18UL_ID_ISO_producer_config
+mvaConfigsForEleProducer.append( mvaEleID_Summer18UL_ID_ISO_producer_config )
+
 electronMVAValueMapProducer = cms.EDProducer('ElectronMVAValueMapProducer',
                                              src = cms.InputTag('slimmedElectrons'),
                                              mvaConfigurations = mvaConfigsForEleProducer

--- a/RecoEgamma/ElectronIdentification/python/Identification/mvaElectronID_Summer16UL_ID_ISO_cff.py
+++ b/RecoEgamma/ElectronIdentification/python/Identification/mvaElectronID_Summer16UL_ID_ISO_cff.py
@@ -1,0 +1,49 @@
+import FWCore.ParameterSet.Config as cms
+from RecoEgamma.ElectronIdentification.Identification.mvaElectronID_tools import *
+from os import path
+
+mvaTag = "Summer16ULIdIso"
+
+weightFileDir = "RecoEgamma/ElectronIdentification/data/MVAWeightFiles/Summer_16UL_ID_ISO"
+
+mvaWeightFiles = cms.vstring(
+     path.join(weightFileDir, "EB1_5.weights.xml.gz"), # EB1_5
+     path.join(weightFileDir, "EB2_5.weights.xml.gz"), # EB2_5
+     path.join(weightFileDir, "EE_5.weights.xml.gz"), # EE_5
+     path.join(weightFileDir, "EB1_10.weights.xml.gz"), # EB1_10
+     path.join(weightFileDir, "EB2_10.weights.xml.gz"), # EB2_10
+     path.join(weightFileDir, "EE_10.weights.xml.gz"), # EE_10
+     )
+
+categoryCuts = cms.vstring(
+     "pt < 10. & abs(superCluster.eta) < 0.800", # EB1_5
+     "pt < 10. & abs(superCluster.eta) >= 0.800 & abs(superCluster.eta) < 1.479", # EB2_5
+     "pt < 10. & abs(superCluster.eta) >= 1.479", # EE_5
+     "pt >= 10. & abs(superCluster.eta) < 0.800", # EB1_10
+     "pt >= 10. & abs(superCluster.eta) >= 0.800 & abs(superCluster.eta) < 1.479", # EB2_10
+     "pt >= 10. & abs(superCluster.eta) >= 1.479", # EE_10
+     )
+
+mvaEleID_Summer16UL_ID_ISO_HZZ_container = EleMVARaw_WP(
+    idName = "mvaEleID-Summer16UL-ID-ISO-HZZ", mvaTag = mvaTag,
+    cutCategory0 = "1.8949071018", # EB1_5
+    cutCategory1 = "1.80714210202", # EB2_5
+    cutCategory2 = "1.64751528517", # EE_5
+    cutCategory3 = "0.339697782473", # EB1_10
+    cutCategory4 = "0.252039219555", # EB2_10
+    cutCategory5 = "-0.686263559006", # EE_10
+    )
+
+
+mvaEleID_Summer16UL_ID_ISO_producer_config = cms.PSet(
+    mvaName             = cms.string(mvaClassName),
+    mvaTag              = cms.string(mvaTag),
+    nCategories         = cms.int32(6),
+    categoryCuts        = categoryCuts,
+    weightFileNames     = mvaWeightFiles,
+    variableDefinition  = cms.string(mvaVariablesFile)
+    )
+
+mvaEleID_Summer16UL_ID_ISO_HZZ = configureVIDMVAEleID( mvaEleID_Summer16UL_ID_ISO_HZZ_container )
+
+mvaEleID_Summer16UL_ID_ISO_HZZ.isPOGApproved = cms.untracked.bool(True)

--- a/RecoEgamma/ElectronIdentification/python/Identification/mvaElectronID_Summer17UL_ID_ISO_cff.py
+++ b/RecoEgamma/ElectronIdentification/python/Identification/mvaElectronID_Summer17UL_ID_ISO_cff.py
@@ -1,0 +1,49 @@
+import FWCore.ParameterSet.Config as cms
+from RecoEgamma.ElectronIdentification.Identification.mvaElectronID_tools import *
+from os import path
+
+mvaTag = "Summer17ULIdIso"
+
+weightFileDir = "RecoEgamma/ElectronIdentification/data/MVAWeightFiles/Summer_17UL_ID_ISO"
+
+mvaWeightFiles = cms.vstring(
+     path.join(weightFileDir, "EB1_5.weights.xml.gz"), # EB1_5
+     path.join(weightFileDir, "EB2_5.weights.xml.gz"), # EB2_5
+     path.join(weightFileDir, "EE_5.weights.xml.gz"), # EE_5
+     path.join(weightFileDir, "EB1_10.weights.xml.gz"), # EB1_10
+     path.join(weightFileDir, "EB2_10.weights.xml.gz"), # EB2_10
+     path.join(weightFileDir, "EE_10.weights.xml.gz"), # EE_10
+     )
+
+categoryCuts = cms.vstring(
+     "pt < 10. & abs(superCluster.eta) < 0.800", # EB1_5
+     "pt < 10. & abs(superCluster.eta) >= 0.800 & abs(superCluster.eta) < 1.479", # EB2_5
+     "pt < 10. & abs(superCluster.eta) >= 1.479", # EE_5
+     "pt >= 10. & abs(superCluster.eta) < 0.800", # EB1_10
+     "pt >= 10. & abs(superCluster.eta) >= 0.800 & abs(superCluster.eta) < 1.479", # EB2_10
+     "pt >= 10. & abs(superCluster.eta) >= 1.479", # EE_10
+     )
+
+mvaEleID_Summer17UL_ID_ISO_HZZ_container = EleMVARaw_WP(
+    idName = "mvaEleID-Summer17UL-ID-ISO-HZZ", mvaTag = mvaTag,
+    cutCategory0 = "1.54440585808", # EB1_5
+    cutCategory1 = "1.50294621563", # EB2_5
+    cutCategory2 = "1.77306202112", # EE_5
+    cutCategory3 = "0.157262554087", # EB1_10
+    cutCategory4 = "0.0273932225081", # EB2_10
+    cutCategory5 = "-0.623050463489", # EE_10
+    )
+
+
+mvaEleID_Summer17UL_ID_ISO_producer_config = cms.PSet(
+    mvaName             = cms.string(mvaClassName),
+    mvaTag              = cms.string(mvaTag),
+    nCategories         = cms.int32(6),
+    categoryCuts        = categoryCuts,
+    weightFileNames     = mvaWeightFiles,
+    variableDefinition  = cms.string(mvaVariablesFile)
+    )
+
+mvaEleID_Summer17UL_ID_ISO_HZZ = configureVIDMVAEleID( mvaEleID_Summer17UL_ID_ISO_HZZ_container )
+
+mvaEleID_Summer17UL_ID_ISO_HZZ.isPOGApproved = cms.untracked.bool(True)

--- a/RecoEgamma/ElectronIdentification/python/Identification/mvaElectronID_Summer18UL_ID_ISO_cff.py
+++ b/RecoEgamma/ElectronIdentification/python/Identification/mvaElectronID_Summer18UL_ID_ISO_cff.py
@@ -1,0 +1,49 @@
+import FWCore.ParameterSet.Config as cms
+from RecoEgamma.ElectronIdentification.Identification.mvaElectronID_tools import *
+from os import path
+
+mvaTag = "Summer18ULIdIso"
+
+weightFileDir = "RecoEgamma/ElectronIdentification/data/MVAWeightFiles/Summer_18UL_ID_ISO"
+
+mvaWeightFiles = cms.vstring(
+     path.join(weightFileDir, "EB1_5.weights.xml.gz"), # EB1_5
+     path.join(weightFileDir, "EB2_5.weights.xml.gz"), # EB2_5
+     path.join(weightFileDir, "EE_5.weights.xml.gz"), # EE_5
+     path.join(weightFileDir, "EB1_10.weights.xml.gz"), # EB1_10
+     path.join(weightFileDir, "EB2_10.weights.xml.gz"), # EB2_10
+     path.join(weightFileDir, "EE_10.weights.xml.gz"), # EE_10
+     )
+
+categoryCuts = cms.vstring(
+     "pt < 10. & abs(superCluster.eta) < 0.800", # EB1_5
+     "pt < 10. & abs(superCluster.eta) >= 0.800 & abs(superCluster.eta) < 1.479", # EB2_5
+     "pt < 10. & abs(superCluster.eta) >= 1.479", # EE_5
+     "pt >= 10. & abs(superCluster.eta) < 0.800", # EB1_10
+     "pt >= 10. & abs(superCluster.eta) >= 0.800 & abs(superCluster.eta) < 1.479", # EB2_10
+     "pt >= 10. & abs(superCluster.eta) >= 1.479", # EE_10
+     )
+
+mvaEleID_Summer18UL_ID_ISO_HZZ_container = EleMVARaw_WP(
+    idName = "mvaEleID-Summer18UL-ID-ISO-HZZ", mvaTag = mvaTag,
+    cutCategory0 = "1.49603193295", # EB1_5
+    cutCategory1 = "1.52414154008", # EB2_5
+    cutCategory2 = "1.77694249574", # EE_5
+    cutCategory3 = "0.199463934736", # EB1_10
+    cutCategory4 = "0.076063564084", # EB2_10
+    cutCategory5 = "-0.572118857519", # EE_10
+    )
+
+
+mvaEleID_Summer18UL_ID_ISO_producer_config = cms.PSet(
+    mvaName             = cms.string(mvaClassName),
+    mvaTag              = cms.string(mvaTag),
+    nCategories         = cms.int32(6),
+    categoryCuts        = categoryCuts,
+    weightFileNames     = mvaWeightFiles,
+    variableDefinition  = cms.string(mvaVariablesFile)
+    )
+
+mvaEleID_Summer18UL_ID_ISO_HZZ = configureVIDMVAEleID( mvaEleID_Summer18UL_ID_ISO_HZZ_container )
+
+mvaEleID_Summer18UL_ID_ISO_HZZ.isPOGApproved = cms.untracked.bool(True)


### PR DESCRIPTION
This new PR (closed  #33514) concerns the addition of configs needed for running VID for recently tuned HtoZZ ID for UL.  The added configs can then be used by analysers with EgammaPostRecoTools to embed in the PAT objects. Files modified/added:

(1) RecoEgamma/ElectronIdentification/python/ElectronMVAValueMapProducer_cfi.py
(2) RecoEgamma/ElectronIdentification/python/Identification/mvaElectronID_Summer16UL_ID_ISO_cff.py
(3) RecoEgamma/ElectronIdentification/python/Identification/mvaElectronID_Summer17UL_ID_ISO_cff.py
(4) RecoEgamma/ElectronIdentification/python/Identification/mvaElectronID_Summer18UL_ID_ISO_cff.py

The related presentation can be seen here:
HtoZZ electron ID: https://indico.cern.ch/event/895972/contributions/4297090/attachments/2219102/3757479/ElectronID_Egamma31032021.pdf

PR for MVA files for electron (HtoZZ run II UL) IDs are here:
cms-data/RecoEgamma-ElectronIdentification#18

