### PR TITLE
Adding Phase II EB electron and photon IDs 

### DIFF
--- a/RecoEgamma/ElectronIdentification/python/Identification/cutBasedElectronID_Summer20_PhaseII_V0_cff.py
+++ b/RecoEgamma/ElectronIdentification/python/Identification/cutBasedElectronID_Summer20_PhaseII_V0_cff.py
@@ -1,0 +1,178 @@
+from PhysicsTools.SelectorUtils.centralIDRegistry import central_id_registry
+
+import FWCore.ParameterSet.Config as cms
+
+# Common functions and classes for ID definition are imported here:
+from RecoEgamma.ElectronIdentification.Identification.cutBasedElectronID_tools \
+    import ( EleWorkingPoint_V5,
+             configureVIDCutBasedEleID_V5 )
+
+#############################This ID is for Phase II and hence matters for EB
+#
+# The ID cuts below are optimized IDs on Summer20 Phase II simulation 
+# These are very initial tuning which will improve further as we improve 
+###our understanding on the variables for phase II (e.g noise cleaned sieie is not yet
+###used here. PF cluster isolations may be better but not yet used). We just use the Run II variables on phase II samples for the tuning 
+# See also the presentation explaining these working points:
+#  https://indico.cern.ch/event/1000891/contributions/4203637/attachments/2183448/3688820/ElectronIDtunning_EgammaMeeting_03Feb2021.pdf
+# https://indico.cern.ch/event/879937/contributions/4108369/attachments/2147436/3619904/EgammaID_phaseIIElectrontunning_pyu_2020Nov20.pdf
+#
+#
+
+# Veto working point Barrel
+idName = "cutBasedElectronID-Summer20-PhaseII-V0-veto"
+WP_Veto_EB = EleWorkingPoint_V5(
+    idName                         = idName  , # idName
+    full5x5_sigmaIEtaIEtaCut       =  0.0181 , # full5x5_sigmaIEtaIEtaCut
+    dEtaInSeedCut                  =  0.00548, # dEtaInSeedCut
+    dPhiInCut                      =  0.197, # dPhiInCut
+    hOverECut_C0                   =  0.313   , # hOverECut
+    hOverECut_CE                   =  0.   ,
+    hOverECut_Cr                   =  0.  ,
+    relCombIsolationWithEACut_C0   =  0.284  , # relCombIsolationWithEACut
+    relCombIsolationWithEACut_Cpt  =  0.  ,
+    absEInverseMinusPInverseCut    =  0.203  , # absEInverseMinusPInverseCut
+    # conversion veto cut needs no parameters, so not mentioned
+    missingHitsCut                 =  2         # missingHitsCut
+    )
+
+WP_Veto_EE = EleWorkingPoint_V5(
+    idName                         = idName  , # idName
+    full5x5_sigmaIEtaIEtaCut       =  0.0181 , # full5x5_sigmaIEtaIEtaCut
+    dEtaInSeedCut                  =  0.00548, # dEtaInSeedCut
+    dPhiInCut                      =  0.197, # dPhiInCut
+    hOverECut_C0                   =  0.313   , # hOverECut
+    hOverECut_CE                   =  0.   ,
+    hOverECut_Cr                   =  0.  ,
+    relCombIsolationWithEACut_C0   =  0.284  , # relCombIsolationWithEACut
+    relCombIsolationWithEACut_Cpt  =  0.  ,
+    absEInverseMinusPInverseCut    =  0.203  , # absEInverseMinusPInverseCut
+    # conversion veto cut needs no parameters, so not mentioned
+    missingHitsCut                 =  2         # missingHitsCut
+    )
+
+# Loose working point Barrel and Endcap
+idName = "cutBasedElectronID-Summer20-PhaseII-V0-loose"
+WP_Loose_EB = EleWorkingPoint_V5(
+    idName                         = idName  , # idName
+    full5x5_sigmaIEtaIEtaCut       = 0.0162  , # full5x5_sigmaIEtaIEtaCut
+    dEtaInSeedCut                  = 0.00409 , # dEtaInSeedCut
+    dPhiInCut                      = 0.0679  , # dPhiInCut
+    hOverECut_C0                   = 0.222    , # hOverECut
+    hOverECut_CE                   = 0.    ,
+    hOverECut_Cr                   = 0.  ,
+    relCombIsolationWithEACut_C0   = 0.223   , # relCombIsolationWithEACut
+    relCombIsolationWithEACut_Cpt  = 0.   ,
+    absEInverseMinusPInverseCut    = 0.0747   , # absEInverseMinusPInverseCut
+    # conversion veto cut needs no parameters, so not mentioned
+    missingHitsCut                 = 1          # missingHitsCut
+    )
+
+WP_Loose_EE = EleWorkingPoint_V5(
+    idName                         = idName  , # idName
+    full5x5_sigmaIEtaIEtaCut       = 0.0162  , # full5x5_sigmaIEtaIEtaCut
+    dEtaInSeedCut                  = 0.00409 , # dEtaInSeedCut
+    dPhiInCut                      = 0.0679  , # dPhiInCut
+    hOverECut_C0                   = 0.222    , # hOverECut
+    hOverECut_CE                   = 0.    ,
+    hOverECut_Cr                   = 0.  ,
+    relCombIsolationWithEACut_C0   = 0.223   , # relCombIsolationWithEACut
+    relCombIsolationWithEACut_Cpt  = 0.   ,
+    absEInverseMinusPInverseCut    = 0.0747   , # absEInverseMinusPInverseCut
+    # conversion veto cut needs no parameters, so not mentioned
+    missingHitsCut                 = 1          # missingHitsCut
+    )
+
+# Medium working point Barrel and Endcap
+idName = "cutBasedElectronID-Summer20-PhaseII-V0-medium"
+WP_Medium_EB = EleWorkingPoint_V5(
+    idName                         = idName  , # idName
+    full5x5_sigmaIEtaIEtaCut       = 0.0156 , # full5x5_sigmaIEtaIEtaCut
+    dEtaInSeedCut                  = 0.00326  , # dEtaInSeedCut
+    dPhiInCut                      = 0.0434  , # dPhiInCut
+    hOverECut_C0                   = 0.138   , # hOverECut
+    hOverECut_CE                   = 0.    ,
+    hOverECut_Cr                   = 0.  ,
+    relCombIsolationWithEACut_C0   = 0.159  , # relCombIsolationWithEACut
+    relCombIsolationWithEACut_Cpt  = 0.   ,
+    absEInverseMinusPInverseCut    = 0.0735   , # absEInverseMinusPInverseCut
+    # conversion veto cut needs no parameters, so not mentioned
+    missingHitsCut                 = 1          # missingHitsCut
+    )
+
+WP_Medium_EE = EleWorkingPoint_V5(
+    idName                         = idName  , # idName
+    full5x5_sigmaIEtaIEtaCut       = 0.0156 , # full5x5_sigmaIEtaIEtaCut
+    dEtaInSeedCut                  = 0.00326  , # dEtaInSeedCut
+    dPhiInCut                      = 0.0434  , # dPhiInCut
+    hOverECut_C0                   = 0.138   , # hOverECut
+    hOverECut_CE                   = 0.    ,
+    hOverECut_Cr                   = 0.  ,
+    relCombIsolationWithEACut_C0   = 0.159  , # relCombIsolationWithEACut
+    relCombIsolationWithEACut_Cpt  = 0.   ,
+    absEInverseMinusPInverseCut    = 0.0735   , # absEInverseMinusPInverseCut
+    # conversion veto cut needs no parameters, so not mentioned
+    missingHitsCut                 = 1          # missingHitsCut
+    )
+
+
+# Tight working point Barrel and Endcap
+idName = "cutBasedElectronID-Summer20-PhaseII-V0-tight"
+WP_Tight_EB = EleWorkingPoint_V5(
+    idName                         = idName  , # idName
+    full5x5_sigmaIEtaIEtaCut       = 0.0137  , # full5x5_sigmaIEtaIEtaCut
+    dEtaInSeedCut                  = 0.00325 , # dEtaInSeedCut
+    dPhiInCut                      = 0.0365   , # dPhiInCut
+    hOverECut_C0                   = 0.103   , # hOverECut
+    hOverECut_CE                   = 0.    ,
+    hOverECut_Cr                   = 0.  ,
+    relCombIsolationWithEACut_C0   = 0.121  , # relCombIsolationWithEACut
+    relCombIsolationWithEACut_Cpt  = 0.   ,
+    absEInverseMinusPInverseCut    = 0.0161   , # absEInverseMinusPInverseCut
+    # conversion veto cut needs no parameters, so not mentioned
+    missingHitsCut                 = 1          # missingHitsCut
+    )
+
+WP_Tight_EE = EleWorkingPoint_V5(
+    idName                         = idName  , # idName
+    full5x5_sigmaIEtaIEtaCut       = 0.0137  , # full5x5_sigmaIEtaIEtaCut
+    dEtaInSeedCut                  = 0.00325 , # dEtaInSeedCut
+    dPhiInCut                      = 0.0365   , # dPhiInCut
+    hOverECut_C0                   = 0.103   , # hOverECut
+    hOverECut_CE                   = 0.    ,
+    hOverECut_Cr                   = 0.  ,
+    relCombIsolationWithEACut_C0   = 0.121  , # relCombIsolationWithEACut
+    relCombIsolationWithEACut_Cpt  = 0.   ,
+    absEInverseMinusPInverseCut    = 0.0161   , # absEInverseMinusPInverseCut
+    # conversion veto cut needs no parameters, so not mentioned
+    missingHitsCut                 = 1          # missingHitsCut
+    )
+# Second, define what effective areas to use for pile-up correction
+isoEffAreas = "RecoEgamma/ElectronIdentification/data/PhaseII/EffectiveArea_electrons_barrel_PhaseII.txt"
+
+#
+# Set up VID configuration for all cuts and working points
+#
+
+cutBasedElectronID_Summer20_PhaseII_V0_veto   = configureVIDCutBasedEleID_V5(WP_Veto_EB,   WP_Veto_EE, isoEffAreas)
+cutBasedElectronID_Summer20_PhaseII_V0_loose  = configureVIDCutBasedEleID_V5(WP_Loose_EB,  WP_Loose_EE, isoEffAreas)
+cutBasedElectronID_Summer20_PhaseII_V0_medium = configureVIDCutBasedEleID_V5(WP_Medium_EB, WP_Medium_EE, isoEffAreas)
+cutBasedElectronID_Summer20_PhaseII_V0_tight  = configureVIDCutBasedEleID_V5(WP_Tight_EB,  WP_Tight_EE, isoEffAreas)
+
+# The MD5 sum numbers below reflect the exact set of cut variables
+# and values above. If anything changes, one has to 
+# 1) comment out the lines below about the registry and the isPOGApproved lines,
+# 2) run "calculateIdMD5 <this file name> <one of the VID config names just above>
+# 3) update the MD5 sum strings below and uncomment the lines again.
+#
+
+central_id_registry.register(cutBasedElectronID_Summer20_PhaseII_V0_veto.idName,   '75ed578c1b442ee97b1a2e50263e1aa3')
+central_id_registry.register(cutBasedElectronID_Summer20_PhaseII_V0_loose.idName,  'c43597fa43676ea1f444d06c701866dc')
+central_id_registry.register(cutBasedElectronID_Summer20_PhaseII_V0_medium.idName, '1ea055b2139ad578dbfbdec1f7c78715')
+central_id_registry.register(cutBasedElectronID_Summer20_PhaseII_V0_tight.idName,  '3c85a35b6dfbf25713db70876cb6675b')
+
+### for now until we have a database...
+cutBasedElectronID_Summer20_PhaseII_V0_veto.isPOGApproved   = cms.bool(False)
+cutBasedElectronID_Summer20_PhaseII_V0_loose.isPOGApproved  = cms.bool(False)
+cutBasedElectronID_Summer20_PhaseII_V0_medium.isPOGApproved = cms.bool(False)
+cutBasedElectronID_Summer20_PhaseII_V0_tight.isPOGApproved  = cms.bool(False)

--- a/RecoEgamma/PhotonIdentification/python/Identification/mvaPhotonID_Summer20_PhaseII_V0_cff.py
+++ b/RecoEgamma/PhotonIdentification/python/Identification/mvaPhotonID_Summer20_PhaseII_V0_cff.py
@@ -1,0 +1,57 @@
+from RecoEgamma.PhotonIdentification.Identification.mvaPhotonID_tools import *
+#
+# In this file we define the locations of the MVA weights, cuts on the MVA values
+# for specific working points, and configure those cuts in VID
+#
+#
+# The following MVA is derived for PhaseII samples for photons.
+# See more documentation in these presentations:
+# https://indico.cern.ch/event/879937/contributions/4108370/attachments/2147472/3619954/Update_PhaseII_photonIDMVA_XGBoost_TMVA_Egamma_Prasant_20112020.pdf
+#
+
+###################This ID is valid for Phase II EB only##############################3
+mvaTag = "PhaseIISummer20v0"
+mvaVariablesFile = "RecoEgamma/PhotonIdentification/data/PhotonMVAEstimatorRun2VariablesFall17V1p1.txt"
+mvaWeightFiles = [
+    path.join(weightFileBaseDir, "PhaseII/PhotonID_MVA_barrel_Egamma_PhaseII_weight.xml.gz"),
+    path.join(weightFileBaseDir, "PhaseII/PhotonID_MVA_barrel_Egamma_PhaseII_weight.xml.gz"), ###To avoid any crash let it be there
+    ]
+# Set up the VID working point parameters
+wpConfig = [
+            # The working point for this MVA that is expected to have about 90% signal
+            # efficiency in each category for photons with pt>30 GeV (somewhat lower
+            # for lower pt photons).
+            {"idName" : "mvaPhoID-PhaseIISummer20-v0-wp90",
+             "cuts"   : { "EB" : 0.737502,
+                          "EE" : 0.737502 }},
+            # The working point for this MVA that is expected to have about 90% signal
+            # efficiency in each category for photons with pt>30 GeV (somewhat lower
+            # for lower pt photons).
+            {"idName" : "mvaPhoID-PhaseIISummer20-v0-wp80",
+             "cuts"   : { "EB" : 0.875003,
+                          "EE" : 0.875003 }},
+           ]
+# Create the PSet that will be fed to the MVA value map producer and the
+# VPset's for VID cuts
+configs = configureFullVIDMVAPhoID(mvaTag=mvaTag,
+                                   variablesFile=mvaVariablesFile,
+                                   weightFiles=mvaWeightFiles,
+                                   wpConfig=wpConfig,
+                                   # Category parameters
+                                   nCategories         = cms.int32(2),
+                                   categoryCuts        = category_cuts)
+mvaPhoID_PhaseIISummer20_v0_producer_config = configs["producer_config"]
+mvaPhoID_PhaseIISummer20_v0_wp90            = configs["VID_config"]["mvaPhoID-PhaseIISummer20-v0-wp90"]
+mvaPhoID_PhaseIISummer20_v0_wp80            = configs["VID_config"]["mvaPhoID-PhaseIISummer20-v0-wp80"]
+# The MD5 sum numbers below reflect the exact set of cut variables
+# and values above. If anything changes, one has to
+# 1) comment out the lines below about the registry,
+# 2) run "calculateIdMD5 <this file name> <one of the VID config names just above>
+# 3) update the MD5 sum strings below and uncomment the lines again.
+#
+central_id_registry.register( mvaPhoID_PhaseIISummer20_v0_wp90.idName,
+                              'f5b754f8aaa045498630815ed6bc000e')
+central_id_registry.register( mvaPhoID_PhaseIISummer20_v0_wp80.idName,
+                              'f8a37759d59521cb1a488aeb874b6140')
+mvaPhoID_PhaseIISummer20_v0_wp90.isPOGApproved = cms.bool(False)
+mvaPhoID_PhaseIISummer20_v0_wp80.isPOGApproved = cms.bool(False)

--- a/RecoEgamma/PhotonIdentification/python/PhotonMVAValueMapProducer_cfi.py
+++ b/RecoEgamma/PhotonIdentification/python/PhotonMVAValueMapProducer_cfi.py
@@ -14,6 +14,10 @@ mvaConfigsForPhoProducer.append( mvaPhoID_RunIIFall17_v1p1_producer_config )
 from RecoEgamma.PhotonIdentification.Identification.mvaPhotonID_Fall17_94X_V2_cff import *
 mvaConfigsForPhoProducer.append( mvaPhoID_RunIIFall17_v2_producer_config )
 
+###Phase II ID valid for EB 
+from RecoEgamma.PhotonIdentification.Identification.mvaPhotonID_Summer20_PhaseII_V0_cff import *
+mvaConfigsForPhoProducer.append( mvaPhoID_PhaseIISummer20_v0_producer_config )
+
 photonMVAValueMapProducer = cms.EDProducer('PhotonMVAValueMapProducer',
                                            src = cms.InputTag('slimmedPhotons'),
                                            mvaConfigurations = mvaConfigsForPhoProducer


### PR DESCRIPTION
This new PR  (closed #33514) concerns the addition of configs needed for running VID for phase II EB photon (MVA based) and electron IDs (cut based). The added configs can then be used by analysers with EgammaPostRecoTools to embed in the PAT objects. Files modified/added:

(1) RecoEgamma/ElectronIdentification/python/Identification/cutBasedElectronID_Summer20_PhaseII_V0_cff.py
(2) RecoEgamma/PhotonIdentification/python/Identification/mvaPhotonID_Summer20_PhaseII_V0_cff.py
(3) RecoEgamma/PhotonIdentification/python/PhotonMVAValueMapProducer_cfi.py

The related presentations can be seen here:
Phase II photon ID: https://indico.cern.ch/event/879937/contributions/4108370/
Phase II electron ID: https://indico.cern.ch/event/1000891/contributions/4203637/

PR for MVA files for photon (phase II) ID is here:
cms-data/RecoEgamma-PhotonIdentification#8