### PR TITLE
Adopt HFSignalAsymmetry flag in HF PFRecHit cleaning

### DIFF
--- a/Configuration/DataProcessing/python/RecoTLR.py
+++ b/Configuration/DataProcessing/python/RecoTLR.py
@@ -100,14 +100,23 @@ def customisePostEra_Run2_2018_pp_on_AA_express_trackingOnly(process):
     return process
 
 # 2021 equivalents
+def customize2021(process):
+    import RecoLocalCalo.HcalRecAlgos.RemoveAddSevLevel as HcalRemoveAddSevLevel
+    HcalRemoveAddSevLevel.AddFlag(process.hcalRecAlgos,"HBHENegativeNoise",8)
+    return process
+
 def customisePostEra_Run3(process):
     #start with a repeat of 2018
     customisePostEra_Run2_2018(process)
+    #add Run3 setting
+    customize2021(process)
     return process
 
 def customisePostEra_Run3_express_trackingOnly(process):
     #start with a repeat of 2018
     customisePostEra_Run2_2018_express_trackingOnly(process)
+    #add Run3 setting
+    customize2021(process)
     return process
 
 ##############################################################################

--- a/Configuration/DataProcessing/python/RecoTLR.py
+++ b/Configuration/DataProcessing/python/RecoTLR.py
@@ -99,8 +99,8 @@ def customisePostEra_Run2_2018_pp_on_AA_express_trackingOnly(process):
     _customise_PPonAATrackingOnlyDQM(process)
     return process
 
-# 2021 equivalents
-def customise2021(process):
+# Run3 equivalents
+def _hcalCustomsRun3(process):
     import RecoLocalCalo.HcalRecAlgos.RemoveAddSevLevel as HcalRemoveAddSevLevel
     HcalRemoveAddSevLevel.AddFlag(process.hcalRecAlgos,"HBHENegativeNoise",8)
     return process
@@ -108,15 +108,13 @@ def customise2021(process):
 def customisePostEra_Run3(process):
     #start with a repeat of 2018
     customisePostEra_Run2_2018(process)
-    #add Run3 setting
-    customise2021(process)
+    #add Run3 HCAL setting
+    _hcalCustomsRun3(process)
     return process
 
 def customisePostEra_Run3_express_trackingOnly(process):
     #start with a repeat of 2018
     customisePostEra_Run2_2018_express_trackingOnly(process)
-    #add Run3 setting
-    customise2021(process)
     return process
 
 ##############################################################################

--- a/Configuration/DataProcessing/python/RecoTLR.py
+++ b/Configuration/DataProcessing/python/RecoTLR.py
@@ -100,7 +100,7 @@ def customisePostEra_Run2_2018_pp_on_AA_express_trackingOnly(process):
     return process
 
 # 2021 equivalents
-def customize2021(process):
+def customise2021(process):
     import RecoLocalCalo.HcalRecAlgos.RemoveAddSevLevel as HcalRemoveAddSevLevel
     HcalRemoveAddSevLevel.AddFlag(process.hcalRecAlgos,"HBHENegativeNoise",8)
     return process
@@ -109,14 +109,14 @@ def customisePostEra_Run3(process):
     #start with a repeat of 2018
     customisePostEra_Run2_2018(process)
     #add Run3 setting
-    customize2021(process)
+    customise2021(process)
     return process
 
 def customisePostEra_Run3_express_trackingOnly(process):
     #start with a repeat of 2018
     customisePostEra_Run2_2018_express_trackingOnly(process)
     #add Run3 setting
-    customize2021(process)
+    customise2021(process)
     return process
 
 ##############################################################################

--- a/Configuration/DataProcessing/python/RecoTLR.py
+++ b/Configuration/DataProcessing/python/RecoTLR.py
@@ -115,6 +115,8 @@ def customisePostEra_Run3(process):
 def customisePostEra_Run3_express_trackingOnly(process):
     #start with a repeat of 2018
     customisePostEra_Run2_2018_express_trackingOnly(process)
+    #add Run3 HCAL setting
+    _hcalCustomsRun3(process)
     return process
 
 ##############################################################################

--- a/RecoLocalCalo/HcalRecAlgos/python/RemoveAddSevLevel.py
+++ b/RecoLocalCalo/HcalRecAlgos/python/RemoveAddSevLevel.py
@@ -88,6 +88,7 @@ def AddFlag(sevLevelComputer,flag="UserDefinedBit0",severity=10,verbose=True):
                 continue
             else:
                 Flags.remove(flag)
+                ChanStat=sevLevelComputer.SeverityLevels[i].ChannelStatus.value()
                 # Removing flag leaves nothing else:  need to remove this level completely
                 if len(Flags)==0 and ChanStat==['']:
                     removeSeverity=i

--- a/RecoParticleFlow/PFClusterProducer/interface/PFRecHitQTests.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFRecHitQTests.h
@@ -110,6 +110,9 @@ public:
       } else if (flag == "HFShort") {
         flags_.push_back(1 << HcalCaloFlagLabels::HFLongShort);
         depths_.push_back(2);
+      } else if (flag == "HFSignalAsymmetry") {
+        flags_.push_back(1 << 5);
+        depths_.push_back(-1);
       } else {
         flags_.push_back(-1);
         depths_.push_back(-1);

--- a/RecoParticleFlow/PFClusterProducer/interface/PFRecHitQTests.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFRecHitQTests.h
@@ -9,6 +9,7 @@
 #include "CondFormats/DataRecord/interface/EcalPFSeedingThresholdsRcd.h"
 #include "Geometry/Records/interface/HcalRecNumberingRecord.h"
 #include "Geometry/CaloTopology/interface/HcalTopology.h"
+#include "DataFormats/METReco/interface/HcalPhase1FlagLabels.h"
 
 #include <iostream>
 
@@ -111,7 +112,7 @@ public:
         flags_.push_back(1 << HcalCaloFlagLabels::HFLongShort);
         depths_.push_back(2);
       } else if (flag == "HFSignalAsymmetry") {
-        flags_.push_back(1 << 5);
+        flags_.push_back(1 << HcalPhase1FlagLabels::HFSignalAsymmetry);
         depths_.push_back(-1);
       } else {
         flags_.push_back(-1);

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowRecHitHF_cfi.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowRecHitHF_cfi.py
@@ -21,9 +21,9 @@ particleFlowRecHitHF = cms.EDProducer("PFRecHitProducer",
              qualityTests = cms.VPSet(
                   cms.PSet(
                       name = cms.string("PFRecHitQTestHCALChannel"),
-                      maxSeverities      = cms.vint32(11,9,9),
-                      cleaningThresholds = cms.vdouble(0.0,120.,60.),
-                      flags              = cms.vstring('Standard','HFLong','HFShort'),
+                      maxSeverities      = cms.vint32(11,9,9,9),
+                      cleaningThresholds = cms.vdouble(0.0,120.,60.,0.),
+                      flags              = cms.vstring('Standard','HFLong','HFShort','HFSignalAsymmetry'),
                   ),
                   cms.PSet(
                       name = cms.string("PFRecHitQTestHCALThresholdVsDepth"),


### PR DESCRIPTION
#### PR description:

HFSignalAsymmetry flag was introduced after the HF phase1 upgrade for noise flagging by HCAL DPG, but it was never adopted in PF cleaning (*). This PR adds this flag for HF PFRecHit cleaning.

(*) https://indico.cern.ch/event/944298/timetable/#10-pf-noise-cleaning-for-hcal

Also following discussions on https://github.com/cms-sw/cmssw/issues/27767 and a request from @abdoulline we put the HBHENegativeNoise flag ineffective starting from Run 3 (this flag won't be created from Run 3, so it was not really necessary, but this change was made to avoid potential confusions).

#### PR validation:

We don't expect a large change by addition of HFSignalAsymmetry to HF PFRecHit cleaning. As seen in: https://indico.cern.ch/event/1027487/#36-hf-noise-flagging-for-pf, we do not see any concerning changes. If we may say, slight reduction in MET in MET PD which is expected to include some high MET events due to noise is probably a positive effect.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This is not a backport.

@bendavid @laurenhay @marksan87 @abdoulline @toropin 