### PR TITLE
Change input collection for genVisTaus (106X)

### DIFF
--- a/PhysicsTools/NanoAOD/python/taus_cff.py
+++ b/PhysicsTools/NanoAOD/python/taus_cff.py
@@ -179,13 +179,19 @@ run2_miniAOD_80XLegacy.toModify(tauTable.variables,
                             idAntiEle = _tauId5WPMask("againstElectron%sMVA62015", doc= "Anti-electron MVA discriminator V6 (2015)")
 )
 
-tauGenJets.GenParticles = cms.InputTag("prunedGenParticles")
-tauGenJets.includeNeutrinos = cms.bool(False)
+tauGenJets.GenParticles = "finalGenParticles"
+(run2_nanoAOD_92X | run2_nanoAOD_94X2016 | run2_nanoAOD_94XMiniAODv1 |
+ run2_nanoAOD_94XMiniAODv2 | run2_nanoAOD_102Xv1 | run2_nanoAOD_106Xv1 |
+ run2_nanoAOD_106Xv2).toModify(tauGenJets, GenParticles = "prunedGenParticles")
+tauGenJets.includeNeutrinos = False
 
 genVisTaus = cms.EDProducer("GenVisTauProducer",
     src = cms.InputTag("tauGenJetsSelectorAllHadrons"),         
-    srcGenParticles = cms.InputTag("prunedGenParticles")
+    srcGenParticles = cms.InputTag("finalGenParticles")
 )
+(run2_nanoAOD_92X | run2_nanoAOD_94X2016 | run2_nanoAOD_94XMiniAODv1 |
+ run2_nanoAOD_94XMiniAODv2 | run2_nanoAOD_102Xv1 | run2_nanoAOD_106Xv1 |
+ run2_nanoAOD_106Xv2).toModify(genVisTaus, srcGenParticles = "prunedGenParticles")
 
 genVisTauTable = cms.EDProducer("SimpleCandidateFlatTableProducer",
     src = cms.InputTag("genVisTaus"),

--- a/PhysicsTools/NanoAOD/python/taus_cff.py
+++ b/PhysicsTools/NanoAOD/python/taus_cff.py
@@ -180,18 +180,14 @@ run2_miniAOD_80XLegacy.toModify(tauTable.variables,
 )
 
 tauGenJets.GenParticles = "finalGenParticles"
-(run2_nanoAOD_92X | run2_nanoAOD_94X2016 | run2_nanoAOD_94XMiniAODv1 |
- run2_nanoAOD_94XMiniAODv2 | run2_nanoAOD_102Xv1 | run2_nanoAOD_106Xv1 |
- run2_nanoAOD_106Xv2).toModify(tauGenJets, GenParticles = "prunedGenParticles")
+(run2_nanoAOD_106Xv1 & ~run2_nanoAOD_devel).toModify(tauGenJets, GenParticles = "prunedGenParticles")
 tauGenJets.includeNeutrinos = False
 
 genVisTaus = cms.EDProducer("GenVisTauProducer",
     src = cms.InputTag("tauGenJetsSelectorAllHadrons"),         
     srcGenParticles = cms.InputTag("finalGenParticles")
 )
-(run2_nanoAOD_92X | run2_nanoAOD_94X2016 | run2_nanoAOD_94XMiniAODv1 |
- run2_nanoAOD_94XMiniAODv2 | run2_nanoAOD_102Xv1 | run2_nanoAOD_106Xv1 |
- run2_nanoAOD_106Xv2).toModify(genVisTaus, srcGenParticles = "prunedGenParticles")
+(run2_nanoAOD_106Xv1 & ~run2_nanoAOD_devel).toModify(genVisTaus, srcGenParticles = "prunedGenParticles")
 
 genVisTauTable = cms.EDProducer("SimpleCandidateFlatTableProducer",
     src = cms.InputTag("genVisTaus"),

--- a/PhysicsTools/NanoAOD/python/taus_cff.py
+++ b/PhysicsTools/NanoAOD/python/taus_cff.py
@@ -179,12 +179,18 @@ run2_miniAOD_80XLegacy.toModify(tauTable.variables,
                             idAntiEle = _tauId5WPMask("againstElectron%sMVA62015", doc= "Anti-electron MVA discriminator V6 (2015)")
 )
 
-tauGenJets.GenParticles = "finalGenParticles"
-(run2_nanoAOD_106Xv1 & ~run2_nanoAOD_devel).toModify(tauGenJets, GenParticles = "prunedGenParticles")
-tauGenJets.includeNeutrinos = False
+tauGenJetsForNano = tauGenJets.clone(
+    GenParticles = "finalGenParticles",
+    includeNeutrinos = False
+)
+(run2_nanoAOD_106Xv1 & ~run2_nanoAOD_devel).toModify(tauGenJetsForNano, GenParticles = "prunedGenParticles")
+
+tauGenJetsSelectorAllHadronsForNano = tauGenJetsSelectorAllHadrons.clone(
+    src = "tauGenJetsForNano"
+)
 
 genVisTaus = cms.EDProducer("GenVisTauProducer",
-    src = cms.InputTag("tauGenJetsSelectorAllHadrons"),         
+    src = cms.InputTag("tauGenJetsSelectorAllHadronsForNano"),
     srcGenParticles = cms.InputTag("finalGenParticles")
 )
 (run2_nanoAOD_106Xv1 & ~run2_nanoAOD_devel).toModify(genVisTaus, srcGenParticles = "prunedGenParticles")
@@ -246,5 +252,5 @@ tauSequence = cms.Sequence(patTauMVAIDsSeq + finalTaus)
 _tauSequence80X =  cms.Sequence(finalTaus)
 run2_miniAOD_80XLegacy.toReplaceWith(tauSequence,_tauSequence80X)
 tauTables = cms.Sequence(tauTable)
-tauMC = cms.Sequence(tauGenJets + tauGenJetsSelectorAllHadrons + genVisTaus + genVisTauTable + tausMCMatchLepTauForTable + tausMCMatchHadTauForTable + tauMCTable)
+tauMC = cms.Sequence(tauGenJetsForNano + tauGenJetsSelectorAllHadronsForNano + genVisTaus + genVisTauTable + tausMCMatchLepTauForTable + tausMCMatchHadTauForTable + tauMCTable)
 


### PR DESCRIPTION
As title says: input collection of genParticles used to build genVisTaus is changed from `prunedGenParticles` (miniAOD collection) to `finalGenParticles` (nanoAOD collection) to ensure consistency with other genParticle-based information stored in nanoAOD, in particular to make mother indices working properly.
The change is deactivated for old nanoAOD eras to ensure backward compatibility.  

Expected changes:
* indices of mother particles of genVisTaus are correctly set,
* marginal impact on produced genVisTaus - with the new setup there is ~4/10000 less genVisTaus than with previous setup which is acceptable (tested with DY sample).

This fixes issue https://github.com/cms-nanoAOD/cmssw/issues/486.

It is a backport of #33522 to 106X for nanoAODv9 production.

#### PR validation:

Change tested with a custom workflow with DYJetsToLL sample from Summer20UL production.
Matrix tests (`runTheMatrix.py -l limited -i all --ibeos`) successful.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

It is a backport of #33522 to 106X for nanoAODv9 production.
