### PR TITLE
Fix of anti-mu cff for tauReco at miniAOD

### DIFF
--- a/RecoTauTag/RecoTau/python/hpsPFTauDiscriminationByMuonRejectionSimple_cff.py
+++ b/RecoTauTag/RecoTau/python/hpsPFTauDiscriminationByMuonRejectionSimple_cff.py
@@ -8,9 +8,9 @@ IDWPdefinitionsSimple = cms.VPSet()
 for wp in hpsPFTauDiscriminationByMuonRejection3.IDWPdefinitions:
     aWP = copy.deepcopy(wp)
     aWP.IDname = wp.IDname.value().replace('MuonRejection3','MuonRejectionSimple')
-    delattr(aWP,"discriminatorOption")
-    setattr(aWP,"maxNumberOfRPCMuons",cms.int32(-1))
-    setattr(aWP,"maxNumberOfSTAMuons",cms.int32(-1))
+    del aWP.discriminatorOption
+    aWP.maxNumberOfRPCMuons = cms.int32(-1)
+    aWP.maxNumberOfSTAMuons = cms.int32(-1)
     IDWPdefinitionsSimple.append(aWP)
 
 hpsPFTauDiscriminationByMuonRejectionSimple = pfRecoTauDiscriminationAgainstMuonSimple.clone(

--- a/RecoTauTag/RecoTau/python/hpsPFTauDiscriminationByMuonRejectionSimple_cff.py
+++ b/RecoTauTag/RecoTau/python/hpsPFTauDiscriminationByMuonRejectionSimple_cff.py
@@ -1,15 +1,16 @@
 import FWCore.ParameterSet.Config as cms
+import copy
 
 from RecoTauTag.RecoTau.pfRecoTauDiscriminationAgainstMuonSimple_cfi import pfRecoTauDiscriminationAgainstMuonSimple
 from RecoTauTag.Configuration.HPSPFTaus_cff import hpsPFTauDiscriminationByMuonRejection3
 
 IDWPdefinitionsSimple = cms.VPSet()
 for wp in hpsPFTauDiscriminationByMuonRejection3.IDWPdefinitions:
-    aWP = wp.copy()
+    aWP = copy.deepcopy(wp)
     aWP.IDname = wp.IDname.value().replace('MuonRejection3','MuonRejectionSimple')
-    del aWP.discriminatorOption
-    aWP.maxNumberOfRPCMuons = cms.int32(-1)
-    aWP.maxNumberOfSTAMuons = cms.int32(-1)
+    delattr(aWP,"discriminatorOption")
+    setattr(aWP,"maxNumberOfRPCMuons",cms.int32(-1))
+    setattr(aWP,"maxNumberOfSTAMuons",cms.int32(-1))
     IDWPdefinitionsSimple.append(aWP)
 
 hpsPFTauDiscriminationByMuonRejectionSimple = pfRecoTauDiscriminationAgainstMuonSimple.clone(


### PR DESCRIPTION
This PR contains a fix of the way in which PSets configuring WPs of anti-mu tauID used by tauReco at miniAOD are created from their counterparts for regular tauReco at AOD. Namely, the fix is a replacement of (shallow) copying by deep-copying of the original PSets. 

The fix solves issues occurring when tauReco-at-mini configuration was pickled (e.g. when used with crab) or being a subject of `customiseEarlyDelete`. No changes expected in terms of performance.

#### PR validation:

Unit test passed successfully. 
Matrix tests were not run as they are irrelevant in this PR because the modified cff is not included to official workflows.