### PR TITLE
update deepCore for Run3

### DIFF
--- a/DQM/TrackingMonitorSource/python/IterTrackingModules4seedMonitoring_cfi.py
+++ b/DQM/TrackingMonitorSource/python/IterTrackingModules4seedMonitoring_cfi.py
@@ -187,6 +187,42 @@ seedMonitoring['jetCoreRegionalStep'] = cms.PSet(
     trajCandPerSeedMax   = cms.double(49.5),
 )
 
+seedMonitoring['jetCoreRegionalStepBarrel'] = cms.PSet(
+    seedInputTag         = cms.InputTag("jetCoreRegionalStepSeedsBarrel"),
+    trackCandInputTag    = cms.InputTag("jetCoreRegionalStepBarrelTrackCandidates"),
+    trackSeedSizeBin     = cms.int32(100),
+    trackSeedSizeMin     = cms.double(-0.5),
+    trackSeedSizeMax     = cms.double(199.5),
+    clusterLabel         = cms.vstring('Tot'),
+    clusterBin           = cms.int32(100),
+    clusterMax           = cms.double(100000),
+    RegionProducer       = cms.InputTag("jetCoreRegionalStepBarrelTrackingRegions"),
+    RegionCandidates     = cms.InputTag("jetsForCoreTrackingBarrel"),
+    trajCandPerSeedBin   = cms.int32(50),
+    trajCandPerSeedMax   = cms.double(49.5),
+    doMVAPlots           = cms.bool(True),
+    TrackProducerForMVA  = cms.InputTag("jetCoreRegionalStepBarrelTracks"),
+    MVAProducers         = cms.InputTag("jetCoreRegionalBarrelStep"),
+)
+
+seedMonitoring['jetCoreRegionalStepEndcap'] = cms.PSet(
+    seedInputTag         = cms.InputTag("jetCoreRegionalStepSeedsEndcap"),
+    trackCandInputTag    = cms.InputTag("jetCoreRegionalStepEndcapTrackCandidates"),
+    trackSeedSizeBin     = cms.int32(100),
+    trackSeedSizeMin     = cms.double(-0.5),
+    trackSeedSizeMax     = cms.double(199.5),
+    clusterLabel         = cms.vstring('Tot'),
+    clusterBin           = cms.int32(100),
+    clusterMax           = cms.double(100000),
+    RegionProducer       = cms.InputTag("jetCoreRegionalStepEndcapTrackingRegions"),
+    RegionCandidates     = cms.InputTag("jetsForCoreTrackingEndcap"),
+    trajCandPerSeedBin   = cms.int32(50),
+    trajCandPerSeedMax   = cms.double(49.5),
+    doMVAPlots           = cms.bool(True),
+    TrackProducerForMVA  = cms.InputTag("jetCoreRegionalStepEndcapTracks"),
+    MVAProducers         = cms.InputTag("jetCoreRegionalEndcapStep"),
+)
+
 for _eraName, _postfix, _era in _cfg.allEras():
     locals()["selectedIterTrackingStep"+_postfix] = _cfg.iterationAlgos(_postfix)
 #selectedIterTrackingStep.append('muonSeededStepOutInDisplaced')

--- a/DQM/TrackingMonitorSource/python/TrackingSourceConfig_Tier0_cff.py
+++ b/DQM/TrackingMonitorSource/python/TrackingSourceConfig_Tier0_cff.py
@@ -378,7 +378,16 @@ for _eraName, _postfix, _era in _cfg.allEras():
         locals()["TrackSeedMonSequence"] = _seq
     else:
         _era.toReplaceWith(TrackSeedMonSequence, _seq)
+
+_seedingDeepCore_TrackSeedMonSequence = TrackSeedMonSequence.copy()
+_seedingDeepCore_TrackSeedMonSequence.remove(locals()["TrackSeedMonjetCoreRegionalStep"])
+_seedingDeepCore_TrackSeedMonSequence += (locals()["TrackSeedMonjetCoreRegionalStepBarrel"])
+_seedingDeepCore_TrackSeedMonSequence += (locals()["TrackSeedMonjetCoreRegionalStepEndcap"])
+from Configuration.ProcessModifiers.seedingDeepCore_cff import seedingDeepCore
+seedingDeepCore.toReplaceWith(TrackSeedMonSequence,_seedingDeepCore_TrackSeedMonSequence)
+
 TrackingDQMSourceTier0 += TrackSeedMonSequence
+
 # MessageLog
 for module in selectedModules :
     label = str(module)+'LogMessageMonCommon'

--- a/DQM/TrackingMonitorSource/python/TrackingSourceConfig_Tier0_cff.py
+++ b/DQM/TrackingMonitorSource/python/TrackingSourceConfig_Tier0_cff.py
@@ -381,7 +381,7 @@ for _eraName, _postfix, _era in _cfg.allEras():
 
 _seedingDeepCore_TrackSeedMonSequence = TrackSeedMonSequence.copy()
 _seedingDeepCore_TrackSeedMonSequence.remove(locals()["TrackSeedMonjetCoreRegionalStep"])
-_seedingDeepCore_TrackSeedMonSequence += (locals()["TrackSeedMonjetCoreRegionalStepBarrel"])
+#_seedingDeepCore_TrackSeedMonSequence += (locals()["TrackSeedMonjetCoreRegionalStepBarrel"])
 _seedingDeepCore_TrackSeedMonSequence += (locals()["TrackSeedMonjetCoreRegionalStepEndcap"])
 from Configuration.ProcessModifiers.seedingDeepCore_cff import seedingDeepCore
 seedingDeepCore.toReplaceWith(TrackSeedMonSequence,_seedingDeepCore_TrackSeedMonSequence)

--- a/RecoTracker/IterativeTracking/python/JetCoreRegionalStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/JetCoreRegionalStep_cff.py
@@ -120,12 +120,12 @@ jetCoreRegionalStepSeeds = _seedCreatorFromRegionConsecutiveHitsEDProducer.clone
     forceKinematicWithRegionDirection = True
 )
 import RecoTracker.TkSeedGenerator.deepCoreSeedGenerator_cfi
-jetCoreRegionalStepBarrelSeeds = RecoTracker.TkSeedGenerator.deepCoreSeedGenerator_cfi.deepCoreSeedGenerator.clone(#to run MCtruthSeedGenerator clone here from Validation.RecoTrack
+jetCoreRegionalStepSeedsBarrel = RecoTracker.TkSeedGenerator.deepCoreSeedGenerator_cfi.deepCoreSeedGenerator.clone(#to run MCtruthSeedGenerator clone here from Validation.RecoTrack
     vertices = "firstStepPrimaryVertices",
     cores    = "jetsForCoreTrackingBarrel"
 )
 
-jetCoreRegionalStepEndcapSeeds = _seedCreatorFromRegionConsecutiveHitsEDProducer.clone(
+jetCoreRegionalStepSeedsEndcap = _seedCreatorFromRegionConsecutiveHitsEDProducer.clone(
     seedingHitSets = 'jetCoreRegionalStepEndcapHitDoublets',
     forceKinematicWithRegionDirection = True
 )
@@ -239,7 +239,7 @@ jetCoreRegionalStepTrackCandidates = RecoTracker.CkfPattern.CkfTrackCandidates_c
     #onlyPixelHitsForSeedCleaner = cms.bool(True),
 )
 jetCoreRegionalStepBarrelTrackCandidates = RecoTracker.CkfPattern.CkfTrackCandidates_cfi.ckfTrackCandidates.clone(
-    src                    = 'jetCoreRegionalStepBarrelSeeds',
+    src                    = 'jetCoreRegionalStepSeedsBarrel',
     maxSeedsBeforeCleaning = 10000,
     TrajectoryBuilderPSet  = cms.PSet( refToPSet_ = cms.string('jetCoreRegionalStepBarrelTrajectoryBuilder')),
     NavigationSchool       = 'SimpleNavigationSchool',
@@ -250,7 +250,7 @@ jetCoreRegionalStepBarrelTrackCandidates = RecoTracker.CkfPattern.CkfTrackCandid
     doSeedingRegionRebuilding = True,
 )
 jetCoreRegionalStepEndcapTrackCandidates = RecoTracker.CkfPattern.CkfTrackCandidates_cfi.ckfTrackCandidates.clone(
-    src                    = 'jetCoreRegionalStepEndcapSeeds',
+    src                    = 'jetCoreRegionalStepSeedsEndcap',
     maxSeedsBeforeCleaning = 10000,
     TrajectoryBuilderPSet  = cms.PSet( refToPSet_ = cms.string('jetCoreRegionalStepEndcapTrajectoryBuilder')),
     NavigationSchool       = 'SimpleNavigationSchool',
@@ -413,7 +413,7 @@ JetCoreRegionalStepBarrelTask = cms.Task(jetsForCoreTrackingBarrel,
                                          jetCoreRegionalStepSeedLayers,
                                          jetCoreRegionalStepBarrelTrackingRegions,
                                          jetCoreRegionalStepBarrelHitDoublets,
-                                         jetCoreRegionalStepBarrelSeeds,
+                                         jetCoreRegionalStepSeedsBarrel,
                                          jetCoreRegionalStepBarrelTrackCandidates,
                                          jetCoreRegionalStepBarrelTracks,
                                          #                                   jetCoreRegionalStepClassifier1,jetCoreRegionalStepClassifier2,
@@ -426,7 +426,7 @@ JetCoreRegionalStepEndcapTask = cms.Task(jetsForCoreTrackingEndcap,
                                          jetCoreRegionalStepSeedLayers,
                                          jetCoreRegionalStepEndcapTrackingRegions,
                                          jetCoreRegionalStepEndcapHitDoublets,
-                                         jetCoreRegionalStepEndcapSeeds,
+                                         jetCoreRegionalStepSeedsEndcap,
                                          jetCoreRegionalStepEndcapTrackCandidates,
                                          jetCoreRegionalStepEndcapTracks,
                                          #                                   jetCoreRegionalStepClassifier1,jetCoreRegionalStepClassifier2,
@@ -455,7 +455,6 @@ seedingDeepCore.toReplaceWith(jetCoreRegionalStep, jetCoreRegionalStepTracks.clo
 #        cms.PSet(type = cms.string("uchars")),
 #    )
 #)
-
 ## change the alias-from to point to jetCoreRegionalStepTracks
 #seedingDeepCore.toModify(jetCoreRegionalStep,
 #    jetCoreRegionalStepImpl = None,

--- a/RecoTracker/IterativeTracking/python/JetCoreRegionalStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/JetCoreRegionalStep_cff.py
@@ -173,7 +173,7 @@ jetCoreRegionalStepDeepCoreTrajectoryCleaner = trajectoryCleanerBySharedHits.clo
 ############## to run MCtruthSeedGenerator ####################
 #import RecoTracker.TkSeedGenerator.deepCoreSeedGenerator_cfi
 #import Validation.RecoTrack.JetCoreMCtruthSeedGenerator_cfi
-#seedingDeepCore.toReplaceWith(jetCoreRegionalStepSeeds,
+#seedingDeepCore.toReplaceWith(jetCoreRegionalStepSeedsBarrel,
 #    RecoTracker.TkSeedGenerator.deepCoreSeedGenerator_cfi.deepCoreSeedGenerator.clone(#to run MCtruthSeedGenerator clone here from Validation.RecoTrack
 #       vertices="firstStepPrimaryVertices" 
 #    )
@@ -269,10 +269,6 @@ trackingPhase1.toReplaceWith(jetCoreRegionalStepBarrel, jetCoreRegionalStep.clon
      src = 'jetCoreRegionalStepBarrelTracks',
 ))
 
-jetCoreRegionalStepEndcap = jetCoreRegionalStep.clone(
-    src = 'jetCoreRegionalStepEndcapTracks',
-)
-
 from RecoTracker.FinalTrackSelectors.TrackTfClassifier_cfi import *
 from RecoTracker.FinalTrackSelectors.trackSelectionTf_cfi import *
 trackdnn.toReplaceWith(jetCoreRegionalStep, TrackTfClassifier.clone(
@@ -283,12 +279,12 @@ trackdnn.toReplaceWith(jetCoreRegionalStepBarrel, TrackTfClassifier.clone(
      src = 'jetCoreRegionalStepBarrelTracks',
      qualityCuts = qualityCutDictionary["JetCoreRegionalStep"],
 ))
-trackdnn.toReplaceWith(jetCoreRegionalStepEndcap, TrackTfClassifier.clone(
-     src = 'jetCoreRegionalStepEndcapTracks',
-     qualityCuts = qualityCutDictionary["JetCoreRegionalStep"],
-))
 
 fastSim.toModify(jetCoreRegionalStep,vertices = 'firstStepPrimaryVerticesBeforeMixing')
+
+jetCoreRegionalStepEndcap = jetCoreRegionalStep.clone(
+    src = 'jetCoreRegionalStepEndcapTracks',
+)
 
 # Final sequence
 JetCoreRegionalStepTask = cms.Task(jetsForCoreTracking,                 

--- a/RecoTracker/IterativeTracking/python/iterativeTkConfig.py
+++ b/RecoTracker/IterativeTracking/python/iterativeTkConfig.py
@@ -83,7 +83,12 @@ _multipleSeedProducers_trackingPhase1 = {
     "PixelPairStep": ["A", "B"],
     "MixedTripletStep": ["A", "B"],
     "TobTecStep": ["Pair", "Tripl"],
+#    "JetCoreRegionalStep": ["Barrel","Endcap"],
 }
+from Configuration.ProcessModifiers.seedingDeepCore_cff import seedingDeepCore
+seedingDeepCore.toModify(_multipleSeedProducers_trackingPhase1, func=lambda x: x.update({"JetCoreRegionalStep": ["Barrel","Endcap"]}))
+
+
 _multipleSeedProducers_trackingPhase2PU140 = {}
 _oldStyleHasSelector = set([
     "InitialStep",

--- a/RecoTracker/IterativeTracking/python/iterativeTkConfig.py
+++ b/RecoTracker/IterativeTracking/python/iterativeTkConfig.py
@@ -83,7 +83,6 @@ _multipleSeedProducers_trackingPhase1 = {
     "PixelPairStep": ["A", "B"],
     "MixedTripletStep": ["A", "B"],
     "TobTecStep": ["Pair", "Tripl"],
-#    "JetCoreRegionalStep": ["Barrel","Endcap"],
 }
 from Configuration.ProcessModifiers.seedingDeepCore_cff import seedingDeepCore
 seedingDeepCore.toModify(_multipleSeedProducers_trackingPhase1, func=lambda x: x.update({"JetCoreRegionalStep": ["Barrel","Endcap"]}))

--- a/RecoTracker/TkSeedGenerator/plugins/DeepCoreSeedGenerator.cc
+++ b/RecoTracker/TkSeedGenerator/plugins/DeepCoreSeedGenerator.cc
@@ -562,7 +562,7 @@ void DeepCoreSeedGenerator::fillDescriptions(edm::ConfigurationDescriptions& des
   desc.add<edm::InputTag>("pixelClusters", edm::InputTag("siPixelClustersPreSplitting"));
   desc.add<edm::InputTag>("cores", edm::InputTag("jetsForCoreTracking"));
   desc.add<double>("ptMin", 100);
-  desc.add<double>("deltaR", 0.25); // the current training makes use of 0.1
+  desc.add<double>("deltaR", 0.25);  // the current training makes use of 0.1
   desc.add<double>("chargeFractionMin", 18000.0);
   desc.add<double>("centralMIPCharge", 2);
   desc.add<std::string>("pixelCPE", "PixelCPEGeneric");

--- a/RecoTracker/TkSeedGenerator/plugins/DeepCoreSeedGenerator.cc
+++ b/RecoTracker/TkSeedGenerator/plugins/DeepCoreSeedGenerator.cc
@@ -243,7 +243,7 @@ void DeepCoreSeedGenerator::produce(edm::Event& iEvent, const edm::EventSetup& i
         input_tensors[1].second.matrix<float>()(0, 0) = 0.0;
         for (int x = 0; x < jetDimX; x++) {
           for (int y = 0; y < jetDimY; y++) {
-            for (int l = 0; l < 4; l++) {
+            for (int l = 0; l < Nlayer; l++) {
               input_tensors[2].second.tensor<float, 4>()(0, x, y, l) = 0.0;
             }
           }

--- a/RecoTracker/TkSeedGenerator/plugins/DeepCoreSeedGenerator.cc
+++ b/RecoTracker/TkSeedGenerator/plugins/DeepCoreSeedGenerator.cc
@@ -40,6 +40,7 @@
 #include "DataFormats/Common/interface/DetSetVector.h"
 #include "DataFormats/Common/interface/DetSet.h"
 #include "DataFormats/SiPixelCluster/interface/SiPixelCluster.h"
+#include "DataFormats/SiPixelDetId/interface/PixelSubdetector.h"
 #include "DataFormats/VertexReco/interface/Vertex.h"
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "DataFormats/VertexReco/interface/VertexFwd.h"
@@ -270,7 +271,7 @@ void DeepCoreSeedGenerator::produce(edm::Event& iEvent, const edm::EventSetup& i
 
           for (const auto& aCluster : detset) {
             det_id_type aClusterID = detset.id();
-            if (DetId(aClusterID).subdetId() != 1)
+            if (DetId(aClusterID).subdetId() != PixelSubdetector::PixelBarrel)
               continue;
 
             int lay = tTopo->layer(det->geographicalId());
@@ -560,8 +561,8 @@ void DeepCoreSeedGenerator::fillDescriptions(edm::ConfigurationDescriptions& des
   desc.add<edm::InputTag>("vertices", edm::InputTag("offlinePrimaryVertices"));
   desc.add<edm::InputTag>("pixelClusters", edm::InputTag("siPixelClustersPreSplitting"));
   desc.add<edm::InputTag>("cores", edm::InputTag("jetsForCoreTracking"));
-  desc.add<double>("ptMin", 300);
-  desc.add<double>("deltaR", 0.1);
+  desc.add<double>("ptMin", 100);
+  desc.add<double>("deltaR", 0.25); // the current training makes use of 0.1
   desc.add<double>("chargeFractionMin", 18000.0);
   desc.add<double>("centralMIPCharge", 2);
   desc.add<std::string>("pixelCPE", "PixelCPEGeneric");

--- a/Validation/RecoTrack/python/TrackValidation_cff.py
+++ b/Validation/RecoTrack/python/TrackValidation_cff.py
@@ -46,7 +46,7 @@ for _eraName, _postfix, _era in _cfg.allEras():
         locals()["_electronSeedProducers"+_postfix] = ["tripletElectronSeeds"]
 
 _removeForFastSimSeedProducers =["initialStepSeedsPreSplitting",
-                                 "jetCoreRegionalStepSeeds",
+                                 "jetCoreRegionalStepSeedsBarrel","jetCoreRegionalStepSeedsEndcap",
                                  "muonSeededSeedsInOut",
                                  "muonSeededSeedsOutIn"]
 _seedProducers_fastSim = [ x for x in _seedProducers if x not in _removeForFastSimSeedProducers]
@@ -892,8 +892,10 @@ trackValidatorSeedingTrackingOnly = _trackValidatorSeedingBuilding.clone(
     dirName = "Tracking/TrackSeeding/",
     label = _seedSelectors,
     doSeedPlots = True,
-    doResolutionPlotsForLabels = [ "seedTracksjetCoreRegionalStepSeeds",]
+    doResolutionPlotsForLabels = [ "seedTracksjetCoreRegionalStepSeedsBarrel","seedTracksjetCoreRegionalStepSeedsEndcap"]
 )
+seedingDeepCore.toModify(trackValidatorSeedingTrackingOnly, doResolutionPlotsForLabels = ["seedTracksjetCoreRegionalStepSeedsBarrel","seedTracksjetCoreRegionalStepSeedsEndcap"] )
+
 trackValidatorSeedingPreSplittingTrackingOnly = trackValidatorSeedingTrackingOnly.clone(
     associators = ["quickTrackAssociatorByHitsPreSplitting"],
     label = _seedSelectorsPreSplitting,
@@ -911,8 +913,8 @@ trackValidatorJetCoreSeedingTrackingOnly = trackValidatorSeedingTrackingOnly.clo
 for _eraName, _postfix, _era in _relevantEras:
     if 'jetCoreRegionalStep' in _cfg.iterationAlgos(_postfix) :
       _setForEra(trackValidatorJetCoreSeedingTrackingOnly, _eraName, _era,
-            label = [ "seedTracksjetCoreRegionalStepSeeds",],
-            doResolutionPlotsForLabels = [ "seedTracksjetCoreRegionalStepSeeds",]
+                 label = [ "seedTracksjetCoreRegionalStepSeedsBarrel","seedTracksjetCoreRegionalStepSeedsEndcap"],
+                 doResolutionPlotsForLabels = [ "seedTracksjetCoreRegionalStepSeedsBarrel","seedTracksjetCoreRegionalStepSeedsEndcap"]
       )
     
 for _eraName, _postfix, _era in _relevantErasAndFastSim:

--- a/Validation/RecoTrack/python/TrackValidation_cff.py
+++ b/Validation/RecoTrack/python/TrackValidation_cff.py
@@ -894,7 +894,7 @@ trackValidatorSeedingTrackingOnly = _trackValidatorSeedingBuilding.clone(
     dirName = "Tracking/TrackSeeding/",
     label = _seedSelectors,
     doSeedPlots = True,
-    doResolutionPlotsForLabels = [ "seedTracksjetCoreRegionalStepSeedsBarrel","seedTracksjetCoreRegionalStepSeedsEndcap"]
+    doResolutionPlotsForLabels = [ "seedTracksjetCoreRegionalStepSeeds" ]
 )
 seedingDeepCore.toModify(trackValidatorSeedingTrackingOnly, doResolutionPlotsForLabels = ["seedTracksjetCoreRegionalStepSeedsBarrel","seedTracksjetCoreRegionalStepSeedsEndcap"] )
 
@@ -915,8 +915,8 @@ trackValidatorJetCoreSeedingTrackingOnly = trackValidatorSeedingTrackingOnly.clo
 for _eraName, _postfix, _era in _relevantEras:
     if 'jetCoreRegionalStep' in _cfg.iterationAlgos(_postfix) :
       _setForEra(trackValidatorJetCoreSeedingTrackingOnly, _eraName, _era,
-                 label = [ "seedTracksjetCoreRegionalStepSeedsBarrel","seedTracksjetCoreRegionalStepSeedsEndcap"],
-                 doResolutionPlotsForLabels = [ "seedTracksjetCoreRegionalStepSeedsBarrel","seedTracksjetCoreRegionalStepSeedsEndcap"]
+                 label = [ "seedTracksjetCoreRegionalStepSeedsBarrel","seedTracksjetCoreRegionalStepSeedsEndcap" ],
+                 doResolutionPlotsForLabels = [ "seedTracksjetCoreRegionalStepSeedsBarrel","seedTracksjetCoreRegionalStepSeedsEndcap" ]
       )
     
 for _eraName, _postfix, _era in _relevantErasAndFastSim:

--- a/Validation/RecoTrack/python/TrackValidation_cff.py
+++ b/Validation/RecoTrack/python/TrackValidation_cff.py
@@ -46,9 +46,11 @@ for _eraName, _postfix, _era in _cfg.allEras():
         locals()["_electronSeedProducers"+_postfix] = ["tripletElectronSeeds"]
 
 _removeForFastSimSeedProducers =["initialStepSeedsPreSplitting",
+                                 "jetCoreRegionalStepSeeds",
                                  "jetCoreRegionalStepSeedsBarrel","jetCoreRegionalStepSeedsEndcap",
                                  "muonSeededSeedsInOut",
                                  "muonSeededSeedsOutIn"]
+
 _seedProducers_fastSim = [ x for x in _seedProducers if x not in _removeForFastSimSeedProducers]
 
 _removeForFastTrackProducers = ["initialStepTracksPreSplitting",


### PR DESCRIPTION
#### PR description:
during the special deepCore validation [1]
it has been highlighted that the current implementation of the jetCore for Run3 is suboptimal

as presented at the RECO meeting, the first approach is to 
1. apply the old seeding of the jetCore step in the "endcap" region
2. apply the new deepCore seeding to jets w/ pT > 100 GeV (instead of the currently 300 GeV)
3. build seeds via deepCore in a cone of at least 0.25 wrt the jet axis (instead of the current 0.1)

this PR adjusts these points

[1]
https://its.cern.ch/jira/browse/PDMVRELVALS-107


#### PR validation:
the code has been explicitly tested on QCD high pT bin sample w/o PU
applying the `--procModifiers seedingDeepCore`

there is a not negligible increase in the seeds multiplicity, but its purity is better
efficiency
![image](https://user-images.githubusercontent.com/4946419/116141924-99009b80-a6d9-11eb-89d7-90f64e0fcaff.png)
![image](https://user-images.githubusercontent.com/4946419/116141940-9d2cb900-a6d9-11eb-91d0-a44fe5934e0a.png)
fakerate
![image](https://user-images.githubusercontent.com/4946419/116141991-aae23e80-a6d9-11eb-8471-5dc62f9e8337.png)

seeding fake vs collection
![image](https://user-images.githubusercontent.com/4946419/116142047-bafa1e00-a6d9-11eb-8744-18c970411ecb.png)
seeding efficiency vs collection
![image](https://user-images.githubusercontent.com/4946419/116142090-c8170d00-a6d9-11eb-81ca-1e4eb9faab55.png)


**FOR TESTING**
* TTbar : runTheMatrix --what upgrade -l 11634.17
* QCD high pt :  runTheMatrix --what upgrade -l 11723.17 
