### PR TITLE
Phase2-hgx282X Change the use of ESHandle to ESGetToken

### DIFF
--- a/Validation/HGCalValidation/plugins/HGCGeometryValidation.cc
+++ b/Validation/HGCalValidation/plugins/HGCGeometryValidation.cc
@@ -12,7 +12,6 @@
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"

--- a/Validation/HGCalValidation/plugins/HGCalBHValidation.cc
+++ b/Validation/HGCalValidation/plugins/HGCalBHValidation.cc
@@ -16,7 +16,6 @@
 #include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
@@ -57,6 +56,7 @@ private:
   const int iSample_, geomType_;
   const double threshold_;
   const bool ifHCAL_;
+  const edm::ESGetToken<HcalParameters, HcalParametersRcd> parToken_;
   edm::EDGetTokenT<edm::PCaloHitContainer> tok_hits_;
   edm::EDGetToken tok_hbhe_;
   int etaMax_;
@@ -75,6 +75,7 @@ HGCalBHValidation::HGCalBHValidation(const edm::ParameterSet& ps)
       geomType_(ps.getUntrackedParameter<int>("GeometryType", 0)),
       threshold_(ps.getUntrackedParameter<double>("Threshold", 12.0)),
       ifHCAL_(ps.getUntrackedParameter<bool>("ifHCAL", false)),
+      parToken_(esConsumes<HcalParameters, HcalParametersRcd, edm::Transition::BeginRun>(edm::ESInputTag{})),
       etaMax_(100) {
   usesResource(TFileService::kSharedResource);
 
@@ -103,9 +104,7 @@ void HGCalBHValidation::fillDescriptions(edm::ConfigurationDescriptions& descrip
 void HGCalBHValidation::beginRun(edm::Run const&, edm::EventSetup const& es) {
   if (geomType_ == 0) {
     std::string label;
-    edm::ESHandle<HcalParameters> parHandle;
-    es.get<HcalParametersRcd>().get(label, parHandle);
-    const HcalParameters* hpar = &(*parHandle);
+    const HcalParameters* hpar = &es.getData(parToken_);
     const std::vector<int> etaM = hpar->etaMax;
     etaMax_ = etaM[1];
   }

--- a/Validation/HGCalValidation/plugins/HGCalDigiClient.cc
+++ b/Validation/HGCalValidation/plugins/HGCalDigiClient.cc
@@ -21,8 +21,10 @@
 
 class HGCalDigiClient : public DQMEDHarvester {
 private:
-  std::string nameDetector_;
-  int verbosity_;
+  const std::string nameDetector_;
+  const int verbosity_;
+  const edm::ESGetToken<HcalDDDRecConstants, HcalRecNumberingRecord> tok_hcal_;
+  const edm::ESGetToken<HGCalDDDConstants, IdealGeometryRecord> tok_hgcal_;
   int layers_;
 
 public:
@@ -37,19 +39,17 @@ public:
 
 HGCalDigiClient::HGCalDigiClient(const edm::ParameterSet &iConfig)
     : nameDetector_(iConfig.getParameter<std::string>("DetectorName")),
-      verbosity_(iConfig.getUntrackedParameter<int>("Verbosity", 0)) {}
+      verbosity_(iConfig.getUntrackedParameter<int>("Verbosity", 0)),
+      tok_hcal_(esConsumes<HcalDDDRecConstants, HcalRecNumberingRecord, edm::Transition::BeginRun>(edm::ESInputTag{})),
+      tok_hgcal_(esConsumes<HGCalDDDConstants, IdealGeometryRecord, edm::Transition::BeginRun>(edm::ESInputTag{"", nameDetector_})) {}
 
 void HGCalDigiClient::beginRun(const edm::Run &run, const edm::EventSetup &iSetup) {
   if (nameDetector_ == "HCal") {
-    edm::ESHandle<HcalDDDRecConstants> pHRNDC;
-    iSetup.get<HcalRecNumberingRecord>().get(pHRNDC);
-    const HcalDDDRecConstants *hcons = &(*pHRNDC);
+    const HcalDDDRecConstants *hcons = &iSetup.getData(tok_hcal_);
     layers_ = hcons->getMaxDepth(1);
   } else {
-    edm::ESHandle<HGCalDDDConstants> pHGDC;
-    iSetup.get<IdealGeometryRecord>().get(nameDetector_, pHGDC);
-    const HGCalDDDConstants &hgcons_ = (*pHGDC);
-    layers_ = hgcons_.layers(true);
+    const HGCalDDDConstants *hgcons = &iSetup.getData(tok_hgcal_);
+    layers_ = hgcons->layers(true);
   }
 }
 

--- a/Validation/HGCalValidation/plugins/HGCalDigiClient.cc
+++ b/Validation/HGCalValidation/plugins/HGCalDigiClient.cc
@@ -41,7 +41,8 @@ HGCalDigiClient::HGCalDigiClient(const edm::ParameterSet &iConfig)
     : nameDetector_(iConfig.getParameter<std::string>("DetectorName")),
       verbosity_(iConfig.getUntrackedParameter<int>("Verbosity", 0)),
       tok_hcal_(esConsumes<HcalDDDRecConstants, HcalRecNumberingRecord, edm::Transition::BeginRun>(edm::ESInputTag{})),
-      tok_hgcal_(esConsumes<HGCalDDDConstants, IdealGeometryRecord, edm::Transition::BeginRun>(edm::ESInputTag{"", nameDetector_})) {}
+      tok_hgcal_(esConsumes<HGCalDDDConstants, IdealGeometryRecord, edm::Transition::BeginRun>(
+          edm::ESInputTag{"", nameDetector_})) {}
 
 void HGCalDigiClient::beginRun(const edm::Run &run, const edm::EventSetup &iSetup) {
   if (nameDetector_ == "HCal") {

--- a/Validation/HGCalValidation/plugins/HGCalDigiValidation.cc
+++ b/Validation/HGCalValidation/plugins/HGCalDigiValidation.cc
@@ -29,7 +29,6 @@
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/ESTransientHandle.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
@@ -79,11 +78,16 @@ private:
       const T1& detId, const T2* geom, int layer, uint16_t adc, double charge, bool mode, bool threshold);
 
   // ----------member data ---------------------------
-  std::string nameDetector_;
-  edm::EDGetToken digiSource_;
-  bool ifNose_, ifHCAL_;
-  int verbosity_, SampleIndx_;
+  const std::string nameDetector_;
+  const bool ifNose_, ifHCAL_;
+  const int verbosity_, SampleIndx_;
+  const edm::ESGetToken<HcalDDDRecConstants, HcalRecNumberingRecord> tok_hcalc_;
+  const edm::ESGetToken<HGCalDDDConstants, IdealGeometryRecord> tok_hgcalc_;
+  const edm::ESGetToken<CaloGeometry, CaloGeometryRecord> tok_hcalg_;
+  const edm::ESGetToken<HGCalGeometry, IdealGeometryRecord> tok_hgcalg_;
+  const edm::ESGetToken<HcalDbService, HcalDbRecord> tok_cond_;
   int layers_, firstLayer_;
+  edm::EDGetToken digiSource_;
 
   std::map<int, int> OccupancyMap_plus_;
   std::map<int, int> OccupancyMap_minus_;
@@ -104,6 +108,11 @@ HGCalDigiValidation::HGCalDigiValidation(const edm::ParameterSet& iConfig)
       ifHCAL_(iConfig.getParameter<bool>("ifHCAL")),
       verbosity_(iConfig.getUntrackedParameter<int>("Verbosity", 0)),
       SampleIndx_(iConfig.getUntrackedParameter<int>("SampleIndx", 0)),
+      tok_hcalc_(esConsumes<HcalDDDRecConstants, HcalRecNumberingRecord, edm::Transition::BeginRun>(edm::ESInputTag{})),
+      tok_hgcalc_(esConsumes<HGCalDDDConstants, IdealGeometryRecord, edm::Transition::BeginRun>(edm::ESInputTag{"", nameDetector_})),
+      tok_hcalg_(esConsumes<CaloGeometry, CaloGeometryRecord>()),
+      tok_hgcalg_(esConsumes<HGCalGeometry, IdealGeometryRecord>(edm::ESInputTag{"", nameDetector_})),
+      tok_cond_(esConsumes<HcalDbService, HcalDbRecord>()),
       firstLayer_(1) {
   auto temp = iConfig.getParameter<edm::InputTag>("DigiSource");
   if ((nameDetector_ == "HGCalEESensitive") || (nameDetector_ == "HGCalHESiliconSensitive") ||
@@ -141,19 +150,9 @@ void HGCalDigiValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
   const CaloGeometry* geom1(nullptr);
   int geomType(0);
   if (nameDetector_ == "HCal") {
-    edm::ESHandle<CaloGeometry> geom;
-    iSetup.get<CaloGeometryRecord>().get(geom);
-    if (!geom.isValid())
-      edm::LogVerbatim("HGCalValidation") << "HGCalDigiValidation: Cannot get "
-                                          << "valid Geometry Object for " << nameDetector_;
-    geom1 = geom.product();
+    geom1 = &iSetup.getData(tok_hcalg_);
   } else {
-    edm::ESHandle<HGCalGeometry> geom;
-    iSetup.get<IdealGeometryRecord>().get(nameDetector_, geom);
-    if (!geom.isValid())
-      edm::LogVerbatim("HGCalValidation") << "HGCalDigiValidation: Cannot get "
-                                          << "valid Geometry Object for " << nameDetector_;
-    geom0 = geom.product();
+    geom0 = &iSetup.getData(tok_hgcalg_);
     if (geom0->topology().waferHexagon8())
       geomType = 1;
     else if (geom0->topology().tileTrapezoid())
@@ -252,8 +251,7 @@ void HGCalDigiValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
       if (verbosity_ > 0)
         edm::LogVerbatim("HGCalValidation")
             << nameDetector_ << " with " << theHEDigiContainers->size() << " element(s)";
-      edm::ESHandle<HcalDbService> conditions;
-      iSetup.get<HcalDbRecord>().get(conditions);
+      const HcalDbService* conditions = &iSetup.getData(tok_cond_);
 
       for (const auto& it : *(theHEDigiContainers.product())) {
         QIE11DataFrame df(it);
@@ -357,16 +355,12 @@ void HGCalDigiValidation::fillDigiInfo() {
 
 void HGCalDigiValidation::dqmBeginRun(const edm::Run&, const edm::EventSetup& iSetup) {
   if (nameDetector_ == "HCal") {
-    edm::ESHandle<HcalDDDRecConstants> pHRNDC;
-    iSetup.get<HcalRecNumberingRecord>().get(pHRNDC);
-    const HcalDDDRecConstants* hcons = &(*pHRNDC);
+    const HcalDDDRecConstants *hcons = &iSetup.getData(tok_hcalc_);
     layers_ = hcons->getMaxDepth(1);
   } else {
-    edm::ESHandle<HGCalDDDConstants> pHGDC;
-    iSetup.get<IdealGeometryRecord>().get(nameDetector_, pHGDC);
-    const HGCalDDDConstants& hgcons_ = (*pHGDC);
-    layers_ = hgcons_.layers(true);
-    firstLayer_ = hgcons_.firstLayer();
+    const HGCalDDDConstants *hgcons = &iSetup.getData(tok_hgcalc_);
+    layers_ = hgcons->layers(true);
+    firstLayer_ = hgcons->firstLayer();
   }
 
   if (verbosity_ > 0)

--- a/Validation/HGCalValidation/plugins/HGCalDigiValidation.cc
+++ b/Validation/HGCalValidation/plugins/HGCalDigiValidation.cc
@@ -109,7 +109,8 @@ HGCalDigiValidation::HGCalDigiValidation(const edm::ParameterSet& iConfig)
       verbosity_(iConfig.getUntrackedParameter<int>("Verbosity", 0)),
       SampleIndx_(iConfig.getUntrackedParameter<int>("SampleIndx", 0)),
       tok_hcalc_(esConsumes<HcalDDDRecConstants, HcalRecNumberingRecord, edm::Transition::BeginRun>(edm::ESInputTag{})),
-      tok_hgcalc_(esConsumes<HGCalDDDConstants, IdealGeometryRecord, edm::Transition::BeginRun>(edm::ESInputTag{"", nameDetector_})),
+      tok_hgcalc_(esConsumes<HGCalDDDConstants, IdealGeometryRecord, edm::Transition::BeginRun>(
+          edm::ESInputTag{"", nameDetector_})),
       tok_hcalg_(esConsumes<CaloGeometry, CaloGeometryRecord>()),
       tok_hgcalg_(esConsumes<HGCalGeometry, IdealGeometryRecord>(edm::ESInputTag{"", nameDetector_})),
       tok_cond_(esConsumes<HcalDbService, HcalDbRecord>()),
@@ -174,8 +175,9 @@ void HGCalDigiValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
         ntot++;
         nused++;
         DetId detId = it.id();
-        int layer = ((geomType == 0) ? HGCalDetId(detId).layer()
-                                     : (geomType == 1) ? HGCSiliconDetId(detId).layer() : HFNoseDetId(detId).layer());
+        int layer = ((geomType == 0)   ? HGCalDetId(detId).layer()
+                     : (geomType == 1) ? HGCSiliconDetId(detId).layer()
+                                       : HFNoseDetId(detId).layer());
         const HGCSample& hgcSample = it.sample(SampleIndx_);
         uint16_t gain = hgcSample.toa();
         uint16_t adc = hgcSample.data();
@@ -355,10 +357,10 @@ void HGCalDigiValidation::fillDigiInfo() {
 
 void HGCalDigiValidation::dqmBeginRun(const edm::Run&, const edm::EventSetup& iSetup) {
   if (nameDetector_ == "HCal") {
-    const HcalDDDRecConstants *hcons = &iSetup.getData(tok_hcalc_);
+    const HcalDDDRecConstants* hcons = &iSetup.getData(tok_hcalc_);
     layers_ = hcons->getMaxDepth(1);
   } else {
-    const HGCalDDDConstants *hgcons = &iSetup.getData(tok_hgcalc_);
+    const HGCalDDDConstants* hgcons = &iSetup.getData(tok_hgcalc_);
     layers_ = hgcons->layers(true);
     firstLayer_ = hgcons->firstLayer();
   }

--- a/Validation/HGCalValidation/plugins/HGCalSimHitStudy.cc
+++ b/Validation/HGCalValidation/plugins/HGCalSimHitStudy.cc
@@ -17,7 +17,6 @@
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/one/EDAnalyzer.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
@@ -331,14 +330,12 @@ void HGCalSimHitStudy::analyzeHits(int ih, std::string const& name, std::vector<
 void HGCalSimHitStudy::beginRun(const edm::Run&, const edm::EventSetup& iSetup) {
   for (unsigned int k = 0; k < nameDetectors_.size(); ++k) {
     if (heRebuild_[k]) {
-      edm::ESHandle<HcalDDDRecConstants> pHRNDC = iSetup.getHandle(tok_hrndc_);
-      hcons_ = pHRNDC.product();
+      hcons_ = &iSetup.getData(tok_hrndc_);
       layers_.emplace_back(hcons_->getMaxDepth(1));
       hgcons_.emplace_back(nullptr);
       layerFront_.emplace_back(40);
     } else {
-      edm::ESHandle<HGCalDDDConstants> pHGDC = iSetup.getHandle(tok_hgcGeom_[k]);
-      hgcons_.emplace_back(pHGDC.product());
+      hgcons_.emplace_back(&iSetup.getData(tok_hgcGeom_[k]));
       layers_.emplace_back(hgcons_.back()->layers(false));
       if (k == 0)
         layerFront_.emplace_back(0);

--- a/Validation/HGCalValidation/plugins/HGCalSimHitValidation.cc
+++ b/Validation/HGCalValidation/plugins/HGCalSimHitValidation.cc
@@ -24,7 +24,6 @@
 #include "DQMServices/Core/interface/DQMStore.h"
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/ESTransientHandle.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
@@ -86,18 +85,23 @@ private:
   void analyzeHits(std::vector<PCaloHit>& hits);
   void fillOccupancyMap(std::map<int, int>& OccupancyMap, int layer);
   void fillHitsInfo(std::pair<hitsinfo, energysum> hit_, unsigned int itimeslice, double esum);
-  bool defineGeometry(edm::ESTransientHandle<DDCompactView>& ddViewH);
-  bool defineGeometry(edm::ESTransientHandle<cms::DDCompactView>& ddViewH);
+  bool defineGeometry(const DDCompactView* ddViewH);
+  bool defineGeometry(const cms::DDCompactView* ddViewH);
 
   // ----------member data ---------------------------
-  std::string nameDetector_, caloHitSource_;
+  const std::string nameDetector_, caloHitSource_;
   const HGCalDDDConstants* hgcons_;
   const HcalDDDRecConstants* hcons_;
-  std::vector<double> times_;
-  int verbosity_;
-  bool heRebuild_, testNumber_, symmDet_, fromDDD_;
+  const std::vector<double> times_;
+  const int verbosity_;
+  const bool testNumber_, fromDDD_;
+  const edm::ESGetToken<HcalDDDRecConstants, HcalRecNumberingRecord> tok_hcal_;
+  const edm::ESGetToken<HGCalDDDConstants, IdealGeometryRecord> tok_hgcal_;
+  const edm::ESGetToken<DDCompactView, IdealGeometryRecord> tok_cpv_;
+  const edm::ESGetToken<cms::DDCompactView, IdealGeometryRecord> tok_cpvc_;
   edm::EDGetTokenT<edm::PCaloHitContainer> tok_hits_;
   edm::EDGetTokenT<edm::HepMCProduct> tok_hepMC_;
+  bool heRebuild_, symmDet_;
   unsigned int layers_;
   int firstLayer_;
   std::map<uint32_t, HepGeom::Transform3D> transMap_;
@@ -116,8 +120,12 @@ HGCalSimHitValidation::HGCalSimHitValidation(const edm::ParameterSet& iConfig)
       times_(iConfig.getParameter<std::vector<double> >("TimeSlices")),
       verbosity_(iConfig.getUntrackedParameter<int>("Verbosity", 0)),
       testNumber_(iConfig.getUntrackedParameter<bool>("TestNumber", true)),
-      symmDet_(true),
       fromDDD_(iConfig.getUntrackedParameter<bool>("fromDDD", true)),
+      tok_hcal_(esConsumes<HcalDDDRecConstants, HcalRecNumberingRecord, edm::Transition::BeginRun>(edm::ESInputTag{})),
+      tok_hgcal_(esConsumes<HGCalDDDConstants, IdealGeometryRecord, edm::Transition::BeginRun>(edm::ESInputTag{"", nameDetector_})),
+      tok_cpv_(esConsumes<DDCompactView, IdealGeometryRecord, edm::Transition::BeginRun>()),
+      tok_cpvc_(esConsumes<cms::DDCompactView, IdealGeometryRecord, edm::Transition::BeginRun>()),
+      symmDet_(true),
       firstLayer_(1) {
   heRebuild_ = (nameDetector_ == "HCal") ? true : false;
   tok_hepMC_ = consumes<edm::HepMCProduct>(edm::InputTag("generatorSmeared"));
@@ -365,7 +373,7 @@ void HGCalSimHitValidation::fillHitsInfo(std::pair<hitsinfo, energysum> hits, un
   }
 }
 
-bool HGCalSimHitValidation::defineGeometry(edm::ESTransientHandle<DDCompactView>& ddViewH) {
+bool HGCalSimHitValidation::defineGeometry(const DDCompactView* ddViewH) {
   if (verbosity_ > 0)
     edm::LogVerbatim("HGCalValidation") << "Initialize HGCalDDDConstants (DDD) for " << nameDetector_ << " : "
                                         << hgcons_;
@@ -413,7 +421,7 @@ bool HGCalSimHitValidation::defineGeometry(edm::ESTransientHandle<DDCompactView>
   return true;
 }
 
-bool HGCalSimHitValidation::defineGeometry(edm::ESTransientHandle<cms::DDCompactView>& ddViewH) {
+bool HGCalSimHitValidation::defineGeometry(const cms::DDCompactView* ddViewH) {
   if (verbosity_ > 0)
     edm::LogVerbatim("HGCalValidation") << "Initialize HGCalDDDConstants (DD4hep) for " << nameDetector_ << " : "
                                         << hgcons_;
@@ -458,23 +466,17 @@ bool HGCalSimHitValidation::defineGeometry(edm::ESTransientHandle<cms::DDCompact
 // ------------ method called when starting to processes a run  ------------
 void HGCalSimHitValidation::dqmBeginRun(const edm::Run&, const edm::EventSetup& iSetup) {
   if (heRebuild_) {
-    edm::ESHandle<HcalDDDRecConstants> pHRNDC;
-    iSetup.get<HcalRecNumberingRecord>().get(pHRNDC);
-    hcons_ = &(*pHRNDC);
+    hcons_ = &iSetup.getData(tok_hcal_);
     layers_ = hcons_->getMaxDepth(1);
   } else {
-    edm::ESHandle<HGCalDDDConstants> pHGDC;
-    iSetup.get<IdealGeometryRecord>().get(nameDetector_, pHGDC);
-    hgcons_ = &(*pHGDC);
+    hgcons_ = &iSetup.getData(tok_hgcal_);
     layers_ = hgcons_->layers(false);
     firstLayer_ = hgcons_->firstLayer();
     if (fromDDD_) {
-      edm::ESTransientHandle<DDCompactView> pDD;
-      iSetup.get<IdealGeometryRecord>().get(pDD);
+      const DDCompactView* pDD = &iSetup.getData(tok_cpv_);
       defineGeometry(pDD);
     } else {
-      edm::ESTransientHandle<cms::DDCompactView> pDD;
-      iSetup.get<IdealGeometryRecord>().get(pDD);
+      const cms::DDCompactView* pDD = &iSetup.getData(tok_cpvc_);
       defineGeometry(pDD);
     }
   }

--- a/Validation/HGCalValidation/plugins/HGCalSimHitValidation.cc
+++ b/Validation/HGCalValidation/plugins/HGCalSimHitValidation.cc
@@ -122,7 +122,8 @@ HGCalSimHitValidation::HGCalSimHitValidation(const edm::ParameterSet& iConfig)
       testNumber_(iConfig.getUntrackedParameter<bool>("TestNumber", true)),
       fromDDD_(iConfig.getUntrackedParameter<bool>("fromDDD", true)),
       tok_hcal_(esConsumes<HcalDDDRecConstants, HcalRecNumberingRecord, edm::Transition::BeginRun>(edm::ESInputTag{})),
-      tok_hgcal_(esConsumes<HGCalDDDConstants, IdealGeometryRecord, edm::Transition::BeginRun>(edm::ESInputTag{"", nameDetector_})),
+      tok_hgcal_(esConsumes<HGCalDDDConstants, IdealGeometryRecord, edm::Transition::BeginRun>(
+          edm::ESInputTag{"", nameDetector_})),
       tok_cpv_(esConsumes<DDCompactView, IdealGeometryRecord, edm::Transition::BeginRun>()),
       tok_cpvc_(esConsumes<cms::DDCompactView, IdealGeometryRecord, edm::Transition::BeginRun>()),
       symmDet_(true),

--- a/Validation/HGCalValidation/plugins/HGCalSimHitsClient.cc
+++ b/Validation/HGCalValidation/plugins/HGCalSimHitsClient.cc
@@ -11,8 +11,6 @@
 #include "DQMServices/Core/interface/DQMStore.h"
 
 #include "FWCore/Framework/interface/Run.h"
-#include "FWCore/Framework/interface/ESHandle.h"
-#include "FWCore/Framework/interface/ESTransientHandle.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
@@ -28,8 +26,10 @@
 class HGCalSimHitsClient : public DQMEDHarvester {
 private:
   //member data
-  std::string nameDetector_;
-  int nTimes_, verbosity_;
+  const std::string nameDetector_;
+  const int nTimes_, verbosity_;
+  const edm::ESGetToken<HcalDDDRecConstants, HcalRecNumberingRecord> tok_hcal_;
+  const edm::ESGetToken<HGCalDDDConstants, IdealGeometryRecord> tok_hgcal_;
   unsigned int layers_;
 
 public:
@@ -45,19 +45,17 @@ public:
 HGCalSimHitsClient::HGCalSimHitsClient(const edm::ParameterSet &iConfig)
     : nameDetector_(iConfig.getParameter<std::string>("DetectorName")),
       nTimes_(iConfig.getParameter<int>("TimeSlices")),
-      verbosity_(iConfig.getUntrackedParameter<int>("Verbosity", 0)) {}
+      verbosity_(iConfig.getUntrackedParameter<int>("Verbosity", 0)),
+      tok_hcal_(esConsumes<HcalDDDRecConstants, HcalRecNumberingRecord, edm::Transition::BeginRun>(edm::ESInputTag{})),
+      tok_hgcal_(esConsumes<HGCalDDDConstants, IdealGeometryRecord, edm::Transition::BeginRun>(edm::ESInputTag{"", nameDetector_})) {}
 
 void HGCalSimHitsClient::beginRun(const edm::Run &run, const edm::EventSetup &iSetup) {
   if (nameDetector_ == "HCal") {
-    edm::ESHandle<HcalDDDRecConstants> pHRNDC;
-    iSetup.get<HcalRecNumberingRecord>().get(pHRNDC);
-    const HcalDDDRecConstants *hcons = &(*pHRNDC);
+    const HcalDDDRecConstants *hcons = &iSetup.getData(tok_hcal_);
     layers_ = hcons->getMaxDepth(1);
   } else {
-    edm::ESHandle<HGCalDDDConstants> pHGDC;
-    iSetup.get<IdealGeometryRecord>().get(nameDetector_, pHGDC);
-    const HGCalDDDConstants &hgcons = (*pHGDC);
-    layers_ = hgcons.layers(false);
+    const HGCalDDDConstants *hgcons = &iSetup.getData(tok_hgcal_);
+    layers_ = hgcons->layers(true);
   }
   if (verbosity_ > 0)
     edm::LogVerbatim("HGCalValidation") << "Initialize HGCalSimHitsClient for " << nameDetector_ << " : " << layers_;

--- a/Validation/HGCalValidation/plugins/HGCalSimHitsClient.cc
+++ b/Validation/HGCalValidation/plugins/HGCalSimHitsClient.cc
@@ -47,7 +47,8 @@ HGCalSimHitsClient::HGCalSimHitsClient(const edm::ParameterSet &iConfig)
       nTimes_(iConfig.getParameter<int>("TimeSlices")),
       verbosity_(iConfig.getUntrackedParameter<int>("Verbosity", 0)),
       tok_hcal_(esConsumes<HcalDDDRecConstants, HcalRecNumberingRecord, edm::Transition::BeginRun>(edm::ESInputTag{})),
-      tok_hgcal_(esConsumes<HGCalDDDConstants, IdealGeometryRecord, edm::Transition::BeginRun>(edm::ESInputTag{"", nameDetector_})) {}
+      tok_hgcal_(esConsumes<HGCalDDDConstants, IdealGeometryRecord, edm::Transition::BeginRun>(
+          edm::ESInputTag{"", nameDetector_})) {}
 
 void HGCalSimHitsClient::beginRun(const edm::Run &run, const edm::EventSetup &iSetup) {
   if (nameDetector_ == "HCal") {


### PR DESCRIPTION
#### PR description:

Change the use of ESHandle to ESGetToken in some of the validation codes of HGCal

#### PR validation:

Use the runTheMatrix test workflows 35034.0 and 37434.0

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Nothing special