### PR TITLE
Add support for zstd root output files

### DIFF
--- a/IOPool/Output/src/PoolOutputModule.cc
+++ b/IOPool/Output/src/PoolOutputModule.cc
@@ -442,7 +442,7 @@ namespace edm {
             "If over maximum, new output file will be started at next input file transition.");
     desc.addUntracked<int>("compressionLevel", 9)->setComment("ROOT compression level of output file.");
     desc.addUntracked<std::string>("compressionAlgorithm", "ZLIB")
-        ->setComment("Algorithm used to compress data in the ROOT output file, allowed values are ZLIB and LZMA");
+        ->setComment("Algorithm used to compress data in the ROOT output file, allowed values are ZLIB, LZMA, and ZSTD");
     desc.addUntracked<int>("basketSize", 16384)->setComment("Default ROOT basket size in output file.");
     desc.addUntracked<int>("eventAuxiliaryBasketSize", 16384)
         ->setComment("Default ROOT basket size in output file for EventAuxiliary branch.");

--- a/IOPool/Output/src/PoolOutputModule.cc
+++ b/IOPool/Output/src/PoolOutputModule.cc
@@ -442,7 +442,8 @@ namespace edm {
             "If over maximum, new output file will be started at next input file transition.");
     desc.addUntracked<int>("compressionLevel", 9)->setComment("ROOT compression level of output file.");
     desc.addUntracked<std::string>("compressionAlgorithm", "ZLIB")
-        ->setComment("Algorithm used to compress data in the ROOT output file, allowed values are ZLIB, LZMA, and ZSTD");
+        ->setComment(
+            "Algorithm used to compress data in the ROOT output file, allowed values are ZLIB, LZMA, and ZSTD");
     desc.addUntracked<int>("basketSize", 16384)->setComment("Default ROOT basket size in output file.");
     desc.addUntracked<int>("eventAuxiliaryBasketSize", 16384)
         ->setComment("Default ROOT basket size in output file for EventAuxiliary branch.");

--- a/IOPool/Output/src/RootOutputFile.cc
+++ b/IOPool/Output/src/RootOutputFile.cc
@@ -52,19 +52,14 @@ namespace edm {
 
   namespace {
     bool sorterForJobReportHash(BranchDescription const* lh, BranchDescription const* rh) {
-      return lh->fullClassName() < rh->fullClassName()
-                 ? true
-                 : lh->fullClassName() > rh->fullClassName()
-                       ? false
-                       : lh->moduleLabel() < rh->moduleLabel()
-                             ? true
-                             : lh->moduleLabel() > rh->moduleLabel()
-                                   ? false
-                                   : lh->productInstanceName() < rh->productInstanceName()
-                                         ? true
-                                         : lh->productInstanceName() > rh->productInstanceName()
-                                               ? false
-                                               : lh->processName() < rh->processName() ? true : false;
+      return lh->fullClassName() < rh->fullClassName()               ? true
+             : lh->fullClassName() > rh->fullClassName()             ? false
+             : lh->moduleLabel() < rh->moduleLabel()                 ? true
+             : lh->moduleLabel() > rh->moduleLabel()                 ? false
+             : lh->productInstanceName() < rh->productInstanceName() ? true
+             : lh->productInstanceName() > rh->productInstanceName() ? false
+             : lh->processName() < rh->processName()                 ? true
+                                                                     : false;
     }
 
     TFile* openTFile(char const* name, int compressionLevel) {
@@ -118,7 +113,7 @@ namespace edm {
         branchesWithStoredHistory_(),
         wrapperBaseTClass_(TClass::GetClass("edm::WrapperBase")) {
     if (om_->compressionAlgorithm() == std::string("ZLIB")) {
-      filePtr_->SetCompressionAlgorithm(ROOT::kZLIB); 
+      filePtr_->SetCompressionAlgorithm(ROOT::kZLIB);
     } else if (om_->compressionAlgorithm() == std::string("LZMA")) {
       filePtr_->SetCompressionAlgorithm(ROOT::kLZMA);
     } else if (om_->compressionAlgorithm() == std::string("ZSTD")) {

--- a/IOPool/Output/src/RootOutputFile.cc
+++ b/IOPool/Output/src/RootOutputFile.cc
@@ -118,9 +118,11 @@ namespace edm {
         branchesWithStoredHistory_(),
         wrapperBaseTClass_(TClass::GetClass("edm::WrapperBase")) {
     if (om_->compressionAlgorithm() == std::string("ZLIB")) {
-      filePtr_->SetCompressionAlgorithm(ROOT::kZLIB);
+      filePtr_->SetCompressionAlgorithm(ROOT::kZLIB); 
     } else if (om_->compressionAlgorithm() == std::string("LZMA")) {
       filePtr_->SetCompressionAlgorithm(ROOT::kLZMA);
+    } else if (om_->compressionAlgorithm() == std::string("ZSTD")) {
+      filePtr_->SetCompressionAlgorithm(ROOT::kZSTD);
     } else {
       throw Exception(errors::Configuration)
           << "PoolOutputModule configured with unknown compression algorithm '" << om_->compressionAlgorithm() << "'\n"


### PR DESCRIPTION
Feature supported for all versions of root actively in use by CMSSW 12_0_X (eg, 6.22+)