### PR TITLE
update JERC tags in dataRun2 GTs

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -24,11 +24,11 @@ autoCond = {
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2
     'run2_mc_pa'        :   '102X_mcRun2_pA_v4',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   '102X_dataRun2_v7',
+    'run1_data'         :   '102X_dataRun2_v14',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   '102X_dataRun2_v7',
+    'run2_data'         :   '102X_dataRun2_v14',
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
-    'run2_data_relval'  :   '102X_dataRun2_relval_v10',
+    'run2_data_relval'  :   '102X_dataRun2_relval_v12',
     # GlobalTag for Run2 data 2018B relvals only: HEM-15-16 fail
     'run2_data_promptlike_HEfail' : '102X_dataRun2_PromptLike_HEfail_v1',
     # GlobalTag for Run2 data 2016H relvals only: Prompt Conditions + fixed L1 menu (to be removed)


### PR DESCRIPTION
#### PR description:

This PR is technical, to update the 102X_dataRun2 tags with JERC tags as requested in this hypernews post: https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/4397.html
It also updates the relval GT to use the QGLikehood tag QGLikelihoodObject_v1_AK4PFchs_2017, as requested in this hypernews post: https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/4357.html 

GT differences:

**Offline data**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/102X_dataRun2_v7/102X_dataRun2_v14

**Offline data relval**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/102X_dataRun2_relval_v10/102X_dataRun2_relval_v12

#### PR validation:

runTheMatrix.py -j8 -l limited,136.74,136.733,134.0 --ibeos

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

update of JER tags in 102X.
