### PR TITLE
Use only 1 thread when testing EventProcessor

### DIFF
--- a/FWCore/Framework/test/eventprocessor2_t.cppunit.cc
+++ b/FWCore/Framework/test/eventprocessor2_t.cppunit.cc
@@ -15,6 +15,8 @@ Test of the EventProcessor class.
 #include "FWCore/PluginManager/interface/standard.h"
 #include "FWCore/ParameterSetReader/interface/ParameterSetReader.h"
 
+#include "tbb/global_control.h"
+
 // to be called also by the other cppunit...
 void doInit() {
   static bool firstTime = true;
@@ -32,8 +34,13 @@ class testeventprocessor2 : public CppUnit::TestFixture {
   CPPUNIT_TEST(eventprocessor2Test);
   CPPUNIT_TEST_SUITE_END();
 
+  edm::propagate_const<std::unique_ptr<tbb::global_control>> m_control;
+
 public:
   void setUp() {
+    if (not m_control) {
+      m_control = std::make_unique<tbb::global_control>(tbb::global_control::max_allowed_parallelism, 1);
+    }
     //std::cout << "setting up testeventprocessor2" << std::endl;
     doInit();
   }

--- a/FWCore/Framework/test/eventprocessor_t.cppunit.cc
+++ b/FWCore/Framework/test/eventprocessor_t.cppunit.cc
@@ -23,6 +23,8 @@ Test of the EventProcessor class.
 
 #include "cppunit/extensions/HelperMacros.h"
 
+#include "tbb/global_control.h"
+
 #include <regex>
 
 #include <exception>
@@ -47,6 +49,9 @@ class testeventprocessor : public CppUnit::TestFixture {
 public:
   void setUp() {
     //std::cout << "setting up testeventprocessor" << std::endl;
+    if (not m_control) {
+      m_control = std::make_unique<tbb::global_control>(tbb::global_control::max_allowed_parallelism, 1);
+    }
     doInit();
     m_handler = std::make_unique<edm::AssertHandler>();  // propagate_const<T> has no reset() function
     sleep_secs_ = 0;
@@ -63,6 +68,7 @@ public:
 
 private:
   edm::propagate_const<std::unique_ptr<edm::AssertHandler>> m_handler;
+  edm::propagate_const<std::unique_ptr<tbb::global_control>> m_control;
   void work() {
     //std::cout << "work in testeventprocessor" << std::endl;
     std::string configuration(


### PR DESCRIPTION
#### PR description:

Explicitly call tbb::global_control in unit tests.

#### PR validation:

Code compiles and the tests pass. Running under gdb shows no additional threads happening during test (although TBB does start a few up when tbb::global_control is deleted).

fixes makortel/framework#136