### PR TITLE
Provide access to HLTPathStatus in TriggerResultsFilter

### DIFF
--- a/HLTrigger/Configuration/python/customizeHLTforNewDatasetDefinition.py
+++ b/HLTrigger/Configuration/python/customizeHLTforNewDatasetDefinition.py
@@ -1,0 +1,24 @@
+import FWCore.ParameterSet.Config as cms
+
+def customizeHLTforNewDatasetDefinition(process):
+    # Loop over streams
+    for stream in process.streams.parameterNames_():
+        streamPaths = cms.vstring()
+        # Loop over datasets
+        for dataset in getattr( process.streams, stream ):
+            # Define dataset prescaler
+            setattr( process, 'hltPreDataset'+dataset, cms.EDFilter( "HLTPrescaler", L1GtReadoutRecordTag = cms.InputTag( "hltGtStage2Digis" ), offset = cms.uint32( 0 ) ) )
+            # Define dataset selection
+            paths = getattr( process.datasets, dataset )
+            setattr( process, 'hltDataset'+dataset, cms.EDFilter( "PathStatusFilter" , verbose = cms.untracked.bool( False ), logicalExpression = cms.string( ' or '.join(paths) ) ) )
+            # Create dataset path
+            datasetPath = 'Dataset_'+dataset+'_v1'
+            setattr( process, datasetPath, cms.Path( process.hltGtStage2Digis + getattr( process , 'hltPreDataset'+dataset ) +  getattr( process, 'hltDataset'+dataset ) + process.HLTEndSequence ) )
+            # Append dataset path
+            process.HLTSchedule.insert( process.HLTSchedule.index( process.HLTriggerFinalPath ), getattr( process, datasetPath ) )
+            setattr( process.datasets, dataset, cms.vstring( datasetPath ) )
+            streamPaths.append( datasetPath )
+        # Set stream paths
+        getattr( process, 'hltOutput'+stream ).SelectEvents.SelectEvents = streamPaths
+
+    return process

--- a/HLTrigger/HLTcore/interface/TriggerExpressionData.h
+++ b/HLTrigger/HLTcore/interface/TriggerExpressionData.h
@@ -4,6 +4,7 @@
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Common/interface/TriggerNames.h"
 #include "CondFormats/DataRecord/interface/L1TUtmTriggerMenuRcd.h"
 #include "CondFormats/L1TObjects/interface/L1TUtmTriggerMenu.h"
 #include "DataFormats/Provenance/interface/ParameterSetID.h"
@@ -24,6 +25,8 @@ namespace triggerExpression {
     // default c'tor
     Data()
         :  // configuration
+          m_usePathStatus(false),
+          m_pathStatusTokens(),
           m_hltResultsTag(""),
           m_hltResultsToken(),
           m_l1tResultsTag(""),
@@ -37,6 +40,8 @@ namespace triggerExpression {
           m_l1tCacheID(),
           m_l1tUpdated(false),
           // hlt values and status
+          m_pathStatus(),
+          m_triggerNames(),
           m_hltResults(nullptr),
           m_hltMenu(nullptr),
           m_hltCacheID(),
@@ -47,6 +52,8 @@ namespace triggerExpression {
     // explicit c'tor from a ParameterSet
     explicit Data(const edm::ParameterSet& config, edm::ConsumesCollector&& iC)
         :  // configuration
+          m_usePathStatus(config.getParameter<bool>("usePathStatus")),
+          m_pathStatusTokens(),
           m_hltResultsTag(config.getParameter<edm::InputTag>("hltResults")),
           m_hltResultsToken(),
           m_l1tResultsTag(config.getParameter<edm::InputTag>("l1tResults")),
@@ -60,25 +67,30 @@ namespace triggerExpression {
           m_l1tCacheID(),
           m_l1tUpdated(false),
           // hlt values and status
+          m_pathStatus(),
+          m_triggerNames(),
           m_hltResults(nullptr),
           m_hltMenu(nullptr),
           m_hltCacheID(),
           m_hltUpdated(false),
           // event values
           m_eventNumber() {
-      if (not m_hltResultsTag.label().empty())
+      if (not m_hltResultsTag.label().empty() && not m_usePathStatus)
         m_hltResultsToken = iC.consumes<edm::TriggerResults>(m_hltResultsTag);
       if (not m_l1tResultsTag.label().empty())
         m_l1tResultsToken = iC.consumes<GlobalAlgBlkBxCollection>(m_l1tResultsTag);
     }
 
     // explicit c'tor from single arguments
-    Data(edm::InputTag const& hltResultsTag,
+    Data(bool const& usePathStatus,
+         edm::InputTag const& hltResultsTag,
          edm::InputTag const& l1tResultsTag,
          bool l1tIgnoreMaskAndPrescale,
          bool doThrow,
          edm::ConsumesCollector&& iC)
         :  // configuration
+          m_usePathStatus(usePathStatus),
+          m_pathStatusTokens(),
           m_hltResultsTag(hltResultsTag),
           m_hltResultsToken(),
           m_l1tResultsTag(l1tResultsTag),
@@ -92,17 +104,22 @@ namespace triggerExpression {
           m_l1tCacheID(),
           m_l1tUpdated(false),
           // hlt values and status
+          m_pathStatus(),
+          m_triggerNames(),
           m_hltResults(nullptr),
           m_hltMenu(nullptr),
           m_hltCacheID(),
           m_hltUpdated(false),
           // event values
           m_eventNumber() {
-      if (not m_hltResultsTag.label().empty())
+      if (not m_hltResultsTag.label().empty() && not m_usePathStatus)
         m_hltResultsToken = iC.consumes<edm::TriggerResults>(m_hltResultsTag);
       if (not m_l1tResultsTag.label().empty())
         m_l1tResultsToken = iC.consumes<GlobalAlgBlkBxCollection>(m_l1tResultsTag);
     }
+
+    // set path status token
+    void setPathStatusToken(edm::BranchDescription const& branch, edm::ConsumesCollector&& iC);
 
     // set the new event
     bool setEvent(const edm::Event& event, const edm::EventSetup& setup);
@@ -120,6 +137,8 @@ namespace triggerExpression {
     void setThrow(bool doThrow) { m_throw = doThrow; }
 
     // read-only accessors
+
+    bool usePathStatus() const { return m_usePathStatus; }
 
     bool hasL1T() const { return not m_l1tResultsTag.label().empty(); }
 
@@ -145,7 +164,34 @@ namespace triggerExpression {
 
     bool ignoreL1MaskAndPrescale() const { return m_l1tIgnoreMaskAndPrescale; }
 
+    const std::vector<std::string>& triggerNames() const {
+      if (m_hltMenu)
+        return m_hltMenu->triggerNames();
+      return m_triggerNames;
+    }
+
+    bool passHLT(unsigned int const& index) const {
+      if (usePathStatus())
+        return m_pathStatus[index];
+      return m_hltResults && m_hltResults->accept(index);
+    }
+
+    int triggerIndex(std::string const& p) const {
+      if (usePathStatus()) {
+        auto it = std::find(m_triggerNames.begin(), m_triggerNames.end(), p);
+        if (it != m_triggerNames.end())
+          return it - m_triggerNames.begin();
+      } else if (m_hltMenu) {
+        auto index = m_hltMenu->triggerIndex(p);
+        if (index < m_hltMenu->size())
+          return index;
+      }
+      return -1;
+    }
+
     // configuration
+    bool m_usePathStatus;
+    std::map<std::string, edm::EDGetTokenT<edm::HLTPathStatus> > m_pathStatusTokens;
     edm::InputTag m_hltResultsTag;
     edm::EDGetTokenT<edm::TriggerResults> m_hltResultsToken;
     edm::InputTag m_l1tResultsTag;
@@ -161,6 +207,8 @@ namespace triggerExpression {
     bool m_l1tUpdated;
 
     // hlt values and status
+    std::vector<bool> m_pathStatus;
+    std::vector<std::string> m_triggerNames;
     const edm::TriggerResults* m_hltResults;
     const edm::TriggerNames* m_hltMenu;
     edm::ParameterSetID m_hltCacheID;

--- a/HLTrigger/HLTcore/src/TriggerExpressionPathReader.cc
+++ b/HLTrigger/HLTcore/src/TriggerExpressionPathReader.cc
@@ -1,7 +1,6 @@
 #include <cassert>
 #include <sstream>
 
-#include "FWCore/Common/interface/TriggerNames.h"
 #include "FWCore/Utilities/interface/RegexMatch.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "DataFormats/Common/interface/TriggerResults.h"
@@ -12,11 +11,11 @@ namespace triggerExpression {
 
   // define the result of the module from the HLT reults
   bool PathReader::operator()(const Data& data) const {
-    if (not data.hasHLT())
+    if (not data.hasHLT() && not data.usePathStatus())
       return false;
 
     for (auto const& trigger : m_triggers)
-      if (data.hltResults().accept(trigger.second))
+      if (data.passHLT(trigger.second))
         return true;
 
     return false;
@@ -41,19 +40,18 @@ namespace triggerExpression {
     m_triggers.clear();
 
     // check if the pattern has is a glob expression, or a single trigger name
-    const edm::TriggerNames& hltMenu = data.hltMenu();
     if (not edm::is_glob(m_pattern)) {
       // no wildcard expression
-      unsigned int index = hltMenu.triggerIndex(m_pattern);
-      if (index < hltMenu.size())
+      auto index = data.triggerIndex(m_pattern);
+      if (index >= 0)
         m_triggers.push_back(std::make_pair(m_pattern, index));
       else {
         std::stringstream msg;
         msg << "requested HLT path \"" << m_pattern << "\" does not exist - known paths are:";
-        if (hltMenu.triggerNames().empty())
+        if (data.triggerNames().empty())
           msg << " (none)";
         else
-          for (auto const& p : hltMenu.triggerNames())
+          for (auto const& p : data.triggerNames())
             msg << "\n\t" << p;
         if (data.shouldThrow())
           throw cms::Exception("Configuration") << msg.str();
@@ -63,15 +61,15 @@ namespace triggerExpression {
     } else {
       // expand wildcards in the pattern
       const std::vector<std::vector<std::string>::const_iterator>& matches =
-          edm::regexMatch(hltMenu.triggerNames(), m_pattern);
+          edm::regexMatch(data.triggerNames(), m_pattern);
       if (matches.empty()) {
         // m_pattern does not match any trigger paths
         std::stringstream msg;
         msg << "requested pattern \"" << m_pattern << "\" does not match any HLT paths - known paths are:";
-        if (hltMenu.triggerNames().empty())
+        if (data.triggerNames().empty())
           msg << " (none)";
         else
-          for (auto const& p : hltMenu.triggerNames())
+          for (auto const& p : data.triggerNames())
             msg << "\n\t" << p;
         if (data.shouldThrow())
           throw cms::Exception("Configuration") << msg.str();
@@ -80,8 +78,8 @@ namespace triggerExpression {
       } else {
         // store indices corresponding to the matching triggers
         for (auto const& match : matches) {
-          unsigned int index = hltMenu.triggerIndex(*match);
-          assert(index < hltMenu.size());
+          auto index = data.triggerIndex(*match);
+          assert(index >= 0);
           m_triggers.push_back(std::make_pair(*match, index));
         }
       }

--- a/HLTrigger/HLTfilters/plugins/TriggerResultsFilter.cc
+++ b/HLTrigger/HLTfilters/plugins/TriggerResultsFilter.cc
@@ -31,12 +31,18 @@ TriggerResultsFilter::TriggerResultsFilter(const edm::ParameterSet& config)
     : m_expression(nullptr), m_eventCache(config, consumesCollector()) {
   const std::vector<std::string>& expressions = config.getParameter<std::vector<std::string>>("triggerConditions");
   parse(expressions);
+  if (m_eventCache.usePathStatus())
+    callWhenNewProductsRegistered([this](const edm::BranchDescription& branch) {
+      this->m_eventCache.setPathStatusToken(branch, consumesCollector());
+    });
 }
 
 TriggerResultsFilter::~TriggerResultsFilter() { delete m_expression; }
 
 void TriggerResultsFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
+  // # use HLTPathStatus results
+  desc.add<bool>("usePathStatus", false);
   // # HLT results   - set to empty to ignore HLT
   desc.add<edm::InputTag>("hltResults", edm::InputTag("TriggerResults"));
   // # L1 uGT results - set to empty to ignore L1T


### PR DESCRIPTION
#### PR description:

This PR allows the TriggerResultsFilter to read the HLTPathStatus information stored in the event, making it possible to run the TriggerResultsFilter module in a path. This is needed move to a new dataset definition where each dataset would be defined in a path. In addition, a python customization file is added which converts an existing HLT menu to the new dataset definition.

@fwyzard @Sam-Harper


<!-- Please replace this text with a description of the feature proposed or problem addressed, specifying:
  - what changes are expected in the output if any, 
  - what other PRs or externals it depends upon if any,
  - link to any additional material useful to provide a documentation for this PR (slides, JIRA tickets, related pull requestes, hypernews, TWiki or Indico pages)  -->

#### PR validation:

<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

<!-- Please replace this text with any link to  -->

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
