### PR TITLE
remove Python2 unit tests ; migrate scripts using uproot to use python3

### DIFF
--- a/DQMServices/Components/scripts/dqmdumpme.py
+++ b/DQMServices/Components/scripts/dqmdumpme.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 from __future__ import print_function
 import sys
 import numpy

--- a/DQMServices/Components/scripts/dqmiodumpindices.py
+++ b/DQMServices/Components/scripts/dqmiodumpindices.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 from __future__ import print_function
 
 import uproot

--- a/DQMServices/Components/scripts/dqmiodumpmetadata.py
+++ b/DQMServices/Components/scripts/dqmiodumpmetadata.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 from __future__ import print_function
 
 import uproot

--- a/DQMServices/Components/scripts/dqmiolistmes.py
+++ b/DQMServices/Components/scripts/dqmiolistmes.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 from __future__ import print_function
 
 import uproot

--- a/PhysicsTools/PythonAnalysis/test/BuildFile.xml
+++ b/PhysicsTools/PythonAnalysis/test/BuildFile.xml
@@ -50,7 +50,6 @@
 <test name="import-bottleneck" command="python3 -c 'import bottleneck'"/>
 <test name="import-certifi" command="python3 -c 'import certifi'"/>
 <test name="import-chardet" command="python3 -c 'import chardet'"/>
-<test name="import-cjson" command="python2 -c 'import cjson'"/>
 <test name="import-click" command="python3 -c 'import click'"/>
 <test name="import-climate" command="python3 -c 'import climate'"/>
 <test name="import-cycler" command="python3 -c 'import cycler'"/>

--- a/PhysicsTools/PythonAnalysis/test/testBottleneck.py
+++ b/PhysicsTools/PythonAnalysis/test/testBottleneck.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 
 import bottleneck

--- a/PhysicsTools/PythonAnalysis/test/testDownhill.py
+++ b/PhysicsTools/PythonAnalysis/test/testDownhill.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from __future__ import print_function
 import downhill

--- a/PhysicsTools/PythonAnalysis/test/testPandas.py
+++ b/PhysicsTools/PythonAnalysis/test/testPandas.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from __future__ import print_function
 import matplotlib

--- a/PhysicsTools/PythonAnalysis/test/testRootNumpy.py
+++ b/PhysicsTools/PythonAnalysis/test/testRootNumpy.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #taken from root_numpy examples
 #https://rootpy.github.io/root_numpy/auto_examples/tmva/plot_regression.html
 import matplotlib

--- a/PhysicsTools/PythonAnalysis/test/testTables.py
+++ b/PhysicsTools/PythonAnalysis/test/testTables.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # test for pytables
 # taken from https://kastnerkyle.github.io/posts/using-pytables-for-larger-than-ram-data-processing/

--- a/PhysicsTools/PythonAnalysis/test/testUncertainties.py
+++ b/PhysicsTools/PythonAnalysis/test/testUncertainties.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 #example taken from https://pypi.python.org/pypi/uncertainties/3.0.1
 from __future__ import print_function


### PR DESCRIPTION
to sync with unit test failures of cms-sw/cmsdist#6846