### PR TITLE
Autodetect if a GPU can be used with CMSSW (11.3.x)

### DIFF
--- a/HeterogeneousCore/CUDAServices/bin/BuildFile.xml
+++ b/HeterogeneousCore/CUDAServices/bin/BuildFile.xml
@@ -1,10 +1,9 @@
 <iftool name="cuda-gcc-support">
-  <bin name="cudaComputeCapabilities" file="cudaComputeCapabilities.cpp">
+  <bin name="cudaComputeCapabilities" file="cudaComputeCapabilities.cpp isCudaDeviceSupported.cu">
     <use name="cuda"/>
   </bin>
 
-  <bin name="cudaIsEnabled" file="cudaIsEnabled.cpp">
+  <bin name="cudaIsEnabled" file="cudaIsEnabled.cpp isCudaDeviceSupported.cu">
     <use name="cuda"/>
   </bin>
-
 </iftool>

--- a/HeterogeneousCore/CUDAServices/bin/cudaComputeCapabilities.cpp
+++ b/HeterogeneousCore/CUDAServices/bin/cudaComputeCapabilities.cpp
@@ -1,4 +1,5 @@
-// C++ standard headers
+// C/C++ standard headers
+#include <cstdlib>
 #include <iomanip>
 #include <iostream>
 
@@ -6,18 +7,26 @@
 #include <cuda_runtime.h>
 
 // CMSSW headers
-#include "HeterogeneousCore/CUDAUtilities/interface/cudaCheck.h"
+#include "isCudaDeviceSupported.h"
 
 int main() {
   int devices = 0;
-  cudaCheck(cudaGetDeviceCount(&devices));
+  cudaError_t status = cudaGetDeviceCount(&devices);
+  if (status != cudaSuccess) {
+    std::cerr << "cudaComputeCapabilities: " << cudaGetErrorString(status) << std::endl;
+    return EXIT_FAILURE;
+  }
 
   for (int i = 0; i < devices; ++i) {
     cudaDeviceProp properties;
     cudaGetDeviceProperties(&properties, i);
     std::cout << std::setw(4) << i << "    " << std::setw(2) << properties.major << "." << properties.minor << "    "
-              << properties.name << std::endl;
+              << properties.name;
+    if (not isCudaDeviceSupported(i)) {
+      std::cout << " (unsupported)";
+    }
+    std::cout << std::endl;
   }
 
-  return 0;
+  return EXIT_SUCCESS;
 }

--- a/HeterogeneousCore/CUDAServices/bin/cudaIsEnabled.cpp
+++ b/HeterogeneousCore/CUDAServices/bin/cudaIsEnabled.cpp
@@ -1,10 +1,13 @@
-#include <algorithm>
-#include <array>
+// C/C++ headers
 #include <cstdlib>
-#include <iostream>
 
+// CUDA headers
 #include <cuda_runtime.h>
 
+// local headers
+#include "isCudaDeviceSupported.h"
+
+// returns EXIT_SUCCESS if at least one visible CUDA device can be used, or EXIT_FAILURE otherwise
 int main() {
   int devices = 0;
   auto status = cudaGetDeviceCount(&devices);
@@ -12,20 +15,12 @@ int main() {
     return EXIT_FAILURE;
   }
 
-  int minimumMajor = 6;  // min minor is implicitly 0
-
-  // This approach (requiring all devices are supported) is rather
-  // conservative. In principle we could consider just dropping the
-  // unsupported devices. Currently that would be easiest to achieve
-  // in CUDAService though.
+  // check that at least one visible CUDA device can be used
   for (int i = 0; i < devices; ++i) {
-    cudaDeviceProp properties;
-    cudaGetDeviceProperties(&properties, i);
-
-    if ((not(properties.major == 3 and properties.minor == 5)) and properties.major < minimumMajor) {
-      return EXIT_FAILURE;
-    }
+    if (isCudaDeviceSupported(i))
+      return EXIT_SUCCESS;
   }
 
-  return EXIT_SUCCESS;
+  // no visible usable devices
+  return EXIT_FAILURE;
 }

--- a/HeterogeneousCore/CUDAServices/bin/isCudaDeviceSupported.cu
+++ b/HeterogeneousCore/CUDAServices/bin/isCudaDeviceSupported.cu
@@ -1,0 +1,55 @@
+#include <cuda_runtime.h>
+
+#include "isCudaDeviceSupported.h"
+
+__global__ static void setSupported(bool* result) { *result = true; }
+
+bool isCudaDeviceSupported(int device) {
+  bool supported = false;
+  bool* supported_d;
+
+  // select the requested device - will fail if the index is invalid
+  cudaError_t status = cudaSetDevice(device);
+  if (status != cudaSuccess)
+    return false;
+
+  // allocate memory for the flag on the device
+  status = cudaMalloc(&supported_d, sizeof(bool));
+  if (status != cudaSuccess)
+    return false;
+
+  // initialise the flag on the device
+  status = cudaMemset(supported_d, 0x00, sizeof(bool));
+  if (status != cudaSuccess)
+    return false;
+
+  // try to set the flag on the device
+  setSupported<<<1, 1>>>(supported_d);
+
+  // check for an eventual error from launching the kernel on an unsupported device
+  status = cudaGetLastError();
+  if (status != cudaSuccess)
+    return false;
+
+  // wait for the kernelto run
+  status = cudaDeviceSynchronize();
+  if (status != cudaSuccess)
+    return false;
+
+  // copy the flag back to the host
+  status = cudaMemcpy(&supported, supported_d, sizeof(bool), cudaMemcpyDeviceToHost);
+  if (status != cudaSuccess)
+    return false;
+
+  // free the device memory
+  status = cudaFree(supported_d);
+  if (status != cudaSuccess)
+    return false;
+
+  // reset the device
+  status = cudaDeviceReset();
+  if (status != cudaSuccess)
+    return false;
+
+  return supported;
+}

--- a/HeterogeneousCore/CUDAServices/bin/isCudaDeviceSupported.h
+++ b/HeterogeneousCore/CUDAServices/bin/isCudaDeviceSupported.h
@@ -1,0 +1,6 @@
+#ifndef HeterogeneousCore_CUDAServices_bin_isCudaDeviceSupported_h
+#define HeterogeneousCore_CUDAServices_bin_isCudaDeviceSupported_h
+
+bool isCudaDeviceSupported(int device);
+
+#endif  // HeterogeneousCore_CUDAServices_bin_isCudaDeviceSupported_h


### PR DESCRIPTION
#### PR description:

Autodetect if a GPU can be used with CMSSW.
A GPU is deemed usable if
  - it is visible to `cudaGetDeviceCount()`;
  - it can be selected by `cudaSetDevice()`;
  - it can allocate a small amount of GPU memory;
  - it can run a kernel.

The last point in particular ensures that CMSSW has been built to support the GPUs "compute capability" (*e.g.* 7.0 for a Tesla v100, *etc.*).

`cudaComputeCapabilities` now prints `(unsupported)` after a GPU name if it cannot be used by CMSSW.

#### PR validation:

With a version of CMSSW built to support only compute capability 7.5:
```bash
$ cudaComputeCapabilities 
   0     7.0    NVIDIA Tesla V100-PCIE-32GB (unsupported)
   1     7.5    NVIDIA Tesla T4

$ cudaIsEnabled && echo true || echo false
true
```

After hiding the usable GPU:
```bash
$ export CUDA_VISIBLE_DEVICES=0

$ cudaComputeCapabilities 
   0     7.0    NVIDIA Tesla V100-PCIE-32GB (unsupported)

$ cudaIsEnabled && echo true || echo false
false
```

After hiding the unusable GPU:
```bash
$ export CUDA_VISIBLE_DEVICES=1

$ cudaComputeCapabilities 
   0     7.5    NVIDIA Tesla T4

$ cudaIsEnabled && echo true || echo false
true
```

After hiding all GPUs (or on a machine without GPUs):
```bash
$ export CUDA_VISIBLE_DEVICES= 

$ cudaComputeCapabilities 
cudaComputeCapabilities: no CUDA-capable device is detected

$ cudaIsEnabled && echo true || echo false
false
```

#### If this PR is a backport please specify the original PR and why you need to backport that PR:

Backport of #33561