### PR TITLE
Allow storing uint32_t and double in NanoAOD, and flat tables in the Runs tree, for ALCANANO

### DIFF
--- a/DataFormats/NanoAOD/interface/FlatTable.h
+++ b/DataFormats/NanoAOD/interface/FlatTable.h
@@ -41,7 +41,9 @@ namespace nanoaod {
       Float,
       Int,
       UInt8,
-      Bool
+      Bool,
+      UInt32,
+      Double
     };  // We could have other Float types with reduced mantissa, and similar
 
     FlatTable() : size_(0) {}
@@ -143,6 +145,10 @@ namespace nanoaod {
         return ColumnType::UInt8;
       else if constexpr (std::is_same<T, bool>())
         return ColumnType::Bool;
+      else if constexpr (std::is_same<T, uint32_t>())
+        return ColumnType::UInt32;
+      else if constexpr (std::is_same<T, double>())
+        return ColumnType::Double;
       else
         static_assert(dependent_false<T>::value, "unsupported type");
     }
@@ -187,6 +193,10 @@ namespace nanoaod {
         return table.uint8s_;
       else if constexpr (std::is_same<T, bool>())
         return table.uint8s_;
+      else if constexpr (std::is_same<T, uint32_t>())
+        return table.uint32s_;
+      else if constexpr (std::is_same<T, double>())
+        return table.doubles_;
       else
         static_assert(dependent_false<T>::value, "unsupported type");
     }
@@ -198,6 +208,8 @@ namespace nanoaod {
     std::vector<float> floats_;
     std::vector<int> ints_;
     std::vector<uint8_t> uint8s_;
+    std::vector<uint32_t> uint32s_;
+    std::vector<double> doubles_;
   };
 
 }  // namespace nanoaod

--- a/DataFormats/NanoAOD/src/FlatTable.cc
+++ b/DataFormats/NanoAOD/src/FlatTable.cc
@@ -25,6 +25,12 @@ void nanoaod::FlatTable::addExtension(const nanoaod::FlatTable& other) {
       case ColumnType::UInt8:
         addColumn<uint8_t>(other.columnName(i), other.columnData<uint8_t>(i), other.columnDoc(i));
         break;
+      case ColumnType::UInt32:
+        addColumn<uint32_t>(other.columnName(i), other.columnData<uint32_t>(i), other.columnDoc(i));
+        break;
+      case ColumnType::Double:
+        addColumn<double>(other.columnName(i), other.columnData<double>(i), other.columnDoc(i));
+        break;
       default:
         throw cms::Exception("LogicError", "Unsupported type");
     }
@@ -43,6 +49,10 @@ double nanoaod::FlatTable::getAnyValue(unsigned int row, unsigned int column) co
       return *(beginData<bool>(column) + row);
     case ColumnType::UInt8:
       return *(beginData<uint8_t>(column) + row);
+    case ColumnType::UInt32:
+      return *(beginData<uint32_t>(column) + row);
+    case ColumnType::Double:
+      return *(beginData<double>(column) + row);
   }
   throw cms::Exception("LogicError", "Unsupported type");
 }

--- a/DataFormats/NanoAOD/src/classes_def.xml
+++ b/DataFormats/NanoAOD/src/classes_def.xml
@@ -3,7 +3,8 @@
         <version ClassVersion="3" checksum="3066258528"/>
     </class>
     <class name="std::vector<nanoaod::FlatTable::Column>" />
-    <class name="nanoaod::FlatTable" ClassVersion="3">
+    <class name="nanoaod::FlatTable" ClassVersion="4">
+        <version ClassVersion="4" checksum="656493391"/>
         <version ClassVersion="3" checksum="2443023556"/>
     </class>
     <class name="nanoaod::FlatTable::RowView" transient="true" />

--- a/PhysicsTools/NanoAOD/plugins/TableOutputBranches.cc
+++ b/PhysicsTools/NanoAOD/plugins/TableOutputBranches.cc
@@ -25,6 +25,12 @@ void TableOutputBranches::defineBranchesFromFirstEvent(const nanoaod::FlatTable 
       case nanoaod::FlatTable::ColumnType::Bool:
         m_uint8Branches.emplace_back(var, tab.columnDoc(i), "O");
         break;
+      case nanoaod::FlatTable::ColumnType::UInt32:
+        m_uint32Branches.emplace_back(var, tab.columnDoc(i), "i");
+        break;
+      case nanoaod::FlatTable::ColumnType::Double:
+        m_doubleBranches.emplace_back(var, tab.columnDoc(i), "D");
+        break;
       default:
         throw cms::Exception("LogicError", "Unsupported type");
     }
@@ -49,7 +55,8 @@ void TableOutputBranches::branch(TTree &tree) {
     }
   }
   std::string varsize = m_singleton ? "" : "[n" + m_baseName + "]";
-  for (std::vector<NamedBranchPtr> *branches : {&m_floatBranches, &m_intBranches, &m_uint8Branches}) {
+  for (std::vector<NamedBranchPtr> *branches :
+       {&m_floatBranches, &m_intBranches, &m_uint8Branches, &m_uint32Branches, &m_doubleBranches}) {
     for (auto &pair : *branches) {
       std::string branchName = makeBranchName(m_baseName, pair.name);
       pair.branch =
@@ -91,4 +98,8 @@ void TableOutputBranches::fill(const edm::EventForOutput &iEvent, TTree &tree, b
     fillColumn<int>(pair, tab);
   for (auto &pair : m_uint8Branches)
     fillColumn<uint8_t>(pair, tab);
+  for (auto &pair : m_uint32Branches)
+    fillColumn<uint32_t>(pair, tab);
+  for (auto &pair : m_doubleBranches)
+    fillColumn<double>(pair, tab);
 }

--- a/PhysicsTools/NanoAOD/plugins/TableOutputBranches.cc
+++ b/PhysicsTools/NanoAOD/plugins/TableOutputBranches.cc
@@ -66,14 +66,14 @@ void TableOutputBranches::branch(TTree &tree) {
   }
 }
 
-void TableOutputBranches::fill(const edm::EventForOutput &iEvent, TTree &tree, bool extensions) {
+void TableOutputBranches::fill(const edm::OccurrenceForOutput &iWhatever, TTree &tree, bool extensions) {
   if (m_extension != DontKnowYetIfMainOrExtension) {
     if (extensions != m_extension)
       return;  // do nothing, wait to be called with the proper flag
   }
 
   edm::Handle<nanoaod::FlatTable> handle;
-  iEvent.getByToken(m_token, handle);
+  iWhatever.getByToken(m_token, handle);
   const nanoaod::FlatTable &tab = *handle;
   m_counter = tab.size();
   m_singleton = tab.singleton();

--- a/PhysicsTools/NanoAOD/plugins/TableOutputBranches.h
+++ b/PhysicsTools/NanoAOD/plugins/TableOutputBranches.h
@@ -44,6 +44,8 @@ private:
   std::vector<NamedBranchPtr> m_floatBranches;
   std::vector<NamedBranchPtr> m_intBranches;
   std::vector<NamedBranchPtr> m_uint8Branches;
+  std::vector<NamedBranchPtr> m_uint32Branches;
+  std::vector<NamedBranchPtr> m_doubleBranches;
   bool m_branchesBooked;
 
   template <typename T>

--- a/PhysicsTools/NanoAOD/plugins/TableOutputBranches.h
+++ b/PhysicsTools/NanoAOD/plugins/TableOutputBranches.h
@@ -4,7 +4,7 @@
 #include <string>
 #include <vector>
 #include <TTree.h>
-#include "FWCore/Framework/interface/EventForOutput.h"
+#include "FWCore/Framework/interface/OccurrenceForOutput.h"
 #include "DataFormats/NanoAOD/interface/FlatTable.h"
 #include "DataFormats/Provenance/interface/BranchDescription.h"
 #include "FWCore/Utilities/interface/EDGetToken.h"
@@ -22,7 +22,7 @@ public:
 
   /// Fill the current table, if extensions == table.extension().
   /// This parameter is used so that the fill is called first for non-extensions and then for extensions
-  void fill(const edm::EventForOutput &iEvent, TTree &tree, bool extensions);
+  void fill(const edm::OccurrenceForOutput &iWhatever, TTree &tree, bool extensions);
 
 private:
   edm::EDGetToken m_token;


### PR DESCRIPTION
#### PR description:

While trying to migrate the SiStrip calibration trees (flat trees produced from ALCARECO by the DPG) to the NanoAOD framework, we ran into a few limitations:
- `nanoaod::FlatTable` can only contain Float, Int, UInt8_t and Bool columns. For calibration purposes UInt32_t (DetId) is also commonly needed, as well as double, for the few cases where the full precision should be kept.
- the NanoAODOutputModule can only handle summary tables for the Runs tree, while flat tables can also be very useful (e.g. to store a few conditions-derived quantities)

This PR adds these (the code changes follow the existing code as much as possible). Since the FlatTable dataformat needs additional members for the new types, the class version is updated. I hope that doesn't cause compatibility problems.
The changes may also be useful for similar efforts in other DPGs and POGs (in case more types need to be added they could be included here).

#### PR validation:

Implemented a flat tree with all variables for the measurement of the SiStrip Lorentz angle and backplane correction (based on SiStripCalCosmics), which uses the new types and puts a flat table in the runs tree - full validation is ongoing, but the produced file looks technically sound (the work-in-progress code can be found [here](https://github.com/pieterdavid/cmssw/compare/nanoadduint32doubleandrunflattables...pieterdavid:try_nano_calibtrees_3_1130pre6), the relevant config is [this one](https://github.com/pieterdavid/cmssw/compare/nanoadduint32doubleandrunflattables...pieterdavid:try_nano_calibtrees_3_1130pre6#diff-2c068eefe192ac5d543c9519bf6823fad145c3dffed0d5643138af2be938dde1)).

CC: @ataliercio @robervalwalsh @mmusich @tsusa @mariadalfonso @gouskos