### PR TITLE
FWCore/Framework: Add cmsRunGP which links against Google perftools profiler library.

### DIFF
--- a/FWCore/Framework/bin/BuildFile.xml
+++ b/FWCore/Framework/bin/BuildFile.xml
@@ -85,3 +85,18 @@
   <use name="FWCore/ParameterSet"/>
   <use name="FWCore/PyDevParameterSet"/>
 </bin>
+
+<bin name="cmsRunGP" file="cmsRun.cpp">
+  <use name="tbb"/>
+  <use name="boost"/>
+  <use name="boost_program_options"/>
+  <use name="jemalloc"/>
+  <use name="gperf"/>
+  <use name="FWCore/Framework"/>
+  <use name="FWCore/MessageLogger"/>
+  <use name="FWCore/PluginManager"/>
+  <use name="FWCore/ServiceRegistry"/>
+  <use name="FWCore/Utilities"/>
+  <use name="FWCore/ParameterSet"/>
+  <use name="FWCore/ParameterSetReader"/>
+</bin>


### PR DESCRIPTION
Requires https://github.com/cms-sw/cmsdist/pull/6854