### PR TITLE
[DD4he] Disable DD4hep workflow 11634.911 in PR tests while it produces unstable results

### DIFF
--- a/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
+++ b/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
@@ -87,7 +87,7 @@ if __name__ == '__main__':
                      10024.0, #2017 ttbar
                      10224.0, #2017 ttbar PU
                      10824.0, #2018 ttbar
-                     11634.911, #2021 DD4hep ttbar
+ # Disable temporarily while unstable # 11634.911, #2021 DD4hep ttbar
                      11634.0, #2021 ttbar
                      12434.0, #2023 ttbar
                      23234.0, #2026D49 ttbar (HLT TDR baseline w/ HGCal v11)


### PR DESCRIPTION
The DD4hep workflow 11634.911 is once again showing instability in its results. For several weeks it was stable, but some recent change, possibly the new versions of DD4hep and ROOT, has re-activated its instability. Any change in the geometry causes a change in the simulation histories, which then changes the bit-wise results of simulation, even if there are no qualitative changes. Somehow, from run to run of the workflow, the geometry can be slightly changed, possibly due to an uninitialized variable taking on different values each time.

Note that the instability being observed is on the 10% level, that is, about 90% of the time the workflow produces consistent results.

The failed comparisons in PR tests for this workflow create unnecessary confusion, so it is best to remove the workflow for now until the instability can be resolved.