### PR TITLE
EMTF and uGMT shower triggers (HadronicShowerTrigger-5)

### DIFF
--- a/DataFormats/CSCDigi/interface/CSCConstants.h
+++ b/DataFormats/CSCDigi/interface/CSCConstants.h
@@ -109,6 +109,12 @@ public:
     MAX_LCTS_PER_CSC = 2,
     // An MPC receives up to 18 LCTs from 9 CSCs in the trigger sector
     MAX_LCTS_PER_MPC = 18,
+    /*
+      An EMTF sector processor receives LCTs from 5 MPCS
+      or 45 chambers when not considering overlapping EMTF SPs
+      18 CSCs in ME1; 9 x 3 CSCs in ME2,3,4
+    */
+    MAX_CSCS_PER_EMTF_SP_NO_OVERLAP = 45,
     // Reference BX for LCTs in simulation and firmware
     LCT_CENTRAL_BX = 8,
     /*

--- a/L1Trigger/Configuration/python/L1Trigger_EventContent_cff.py
+++ b/L1Trigger/Configuration/python/L1Trigger_EventContent_cff.py
@@ -122,8 +122,9 @@ def _appendRun3ShowerDigis(obj):
         'keep *_simGmtShowerDigis_*_*',
         ]
     obj.outputCommands += run3ShowerDigis
-stage2L1Trigger.toModify(L1TriggerFEVTDEBUG, func=_appendRun3ShowerDigis)
 
+from Configuration.Eras.Modifier_run3_common_cff import run3_common
+(stage2L1Trigger & run3_common).toModify(L1TriggerFEVTDEBUG, func=_appendRun3ShowerDigis)
 
 # adding HGCal L1 trigger digis
 def _appendHGCalDigis(obj):

--- a/L1Trigger/Configuration/python/L1Trigger_EventContent_cff.py
+++ b/L1Trigger/Configuration/python/L1Trigger_EventContent_cff.py
@@ -115,6 +115,16 @@ stage2L1Trigger.toModify(L1TriggerRECO, func=_appendStage2Digis)
 stage2L1Trigger.toModify(L1TriggerAOD, func=_appendStage2Digis)
 stage2L1Trigger.toModify(L1TriggerFEVTDEBUG, func=_appendStage2Digis)
 
+## Run-3 EMTF and GMT showers
+def _appendRun3ShowerDigis(obj):
+    run3ShowerDigis = [
+        "keep *_simEmtfShowers_*_*",
+        'keep *_simGmtShowerDigis_*_*',
+        ]
+    obj.outputCommands += run3ShowerDigis
+stage2L1Trigger.toModify(L1TriggerFEVTDEBUG, func=_appendRun3ShowerDigis)
+
+
 # adding HGCal L1 trigger digis
 def _appendHGCalDigis(obj):
     l1HGCalDigis = [

--- a/L1Trigger/L1TMuon/plugins/L1TMuonShowerProducer.cc
+++ b/L1Trigger/L1TMuon/plugins/L1TMuonShowerProducer.cc
@@ -1,0 +1,112 @@
+// system include files
+#include <memory>
+#include <fstream>
+
+// user include files
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/ESGetToken.h"
+
+#include "DataFormats/L1TMuon/interface/RegionalMuonShower.h"
+#include "DataFormats/L1Trigger/interface/MuonShower.h"
+
+using namespace l1t;
+
+class L1TMuonShowerProducer : public edm::stream::EDProducer<> {
+public:
+  explicit L1TMuonShowerProducer(const edm::ParameterSet&);
+  ~L1TMuonShowerProducer() override;
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+private:
+  void produce(edm::Event&, const edm::EventSetup&) override;
+
+  edm::InputTag showerInputTag_;
+  edm::EDGetTokenT<l1t::RegionalMuonShowerBxCollection> showerInputToken_;
+  int bxMin_;
+  int bxMax_;
+  unsigned minNominalShowers_;
+  unsigned minTwoLooseShowers_;
+};
+
+L1TMuonShowerProducer::L1TMuonShowerProducer(const edm::ParameterSet& iConfig)
+    : showerInputTag_(iConfig.getParameter<edm::InputTag>("showerInput")),
+      showerInputToken_(consumes<l1t::RegionalMuonShowerBxCollection>(showerInputTag_)),
+      bxMin_(iConfig.getParameter<int>("bxMin")),
+      bxMax_(iConfig.getParameter<int>("bxMax")),
+      minNominalShowers_(iConfig.getParameter<unsigned>("minNominalShowers")),
+      minTwoLooseShowers_(iConfig.getParameter<unsigned>("minTwoLooseShowers")) {
+  produces<MuonShowerBxCollection>();
+}
+
+L1TMuonShowerProducer::~L1TMuonShowerProducer() {}
+
+// ------------ method called to produce the data  ------------
+void L1TMuonShowerProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  using namespace edm;
+  std::unique_ptr<MuonShowerBxCollection> outShowers(new MuonShowerBxCollection());
+
+  Handle<l1t::RegionalMuonShowerBxCollection> emtfShowers;
+  iEvent.getByToken(showerInputToken_, emtfShowers);
+  outShowers->setBXRange(bxMin_, bxMax_);
+
+  /*
+    Check each sector for a valid EMTF shower. A valid EMTF shower
+    can either be in-time or out-of-time. The minimal implementation
+    only considers the "at least 1-nominal shower" case.
+   */
+  unsigned nNominalInTime = 0;
+  unsigned nNominalOutOfTime = 0;
+  unsigned nTwoLooseInTime = 0;
+  unsigned nTwoLooseOutOfTime = 0;
+  for (size_t i = 0; i < emtfShowers->size(0); ++i) {
+    auto shower = emtfShowers->at(0, i);
+    if (shower.isValid()) {
+      // nominal
+      if (shower.isOneNominalInTime())
+        nNominalInTime++;
+      if (shower.isOneNominalOutOfTime())
+        nNominalOutOfTime++;
+      // two loose
+      if (shower.isTwoLooseInTime())
+        nTwoLooseInTime++;
+      if (shower.isTwoLooseOutOfTime())
+        nTwoLooseOutOfTime++;
+    }
+  }
+
+  const bool isOneNominalInTime(nNominalInTime >= minNominalShowers_);
+  const bool isOneNominalOutOfTime(nNominalOutOfTime >= minNominalShowers_);
+  const bool isTwoLooseInTime(nTwoLooseInTime >= minTwoLooseShowers_);
+  const bool isTwoLooseOutOfTime(nTwoLooseOutOfTime >= minTwoLooseShowers_);
+
+  // Check for at least one nominal shower
+  const bool acceptCondition(isOneNominalInTime or isOneNominalOutOfTime or isTwoLooseInTime or isTwoLooseOutOfTime);
+  if (acceptCondition) {
+    MuonShower outShower(isOneNominalInTime, isOneNominalOutOfTime, isTwoLooseInTime, isTwoLooseOutOfTime);
+    outShowers->push_back(0, outShower);
+  }
+  iEvent.put(std::move(outShowers));
+}
+
+// ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
+void L1TMuonShowerProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.add<edm::InputTag>("showerInput", edm::InputTag("simEmtfShowers", "EMTF"));
+  desc.add<int32_t>("bxMin", 0);
+  desc.add<int32_t>("bxMax", 0);
+  desc.add<uint32_t>("minNominalShowers", 1);
+  desc.add<uint32_t>("minTwoLooseShowers", 0);
+  descriptions.add("simGmtShowerDigisDef", desc);
+}
+
+//define this as a plug-in
+DEFINE_FWK_MODULE(L1TMuonShowerProducer);

--- a/L1Trigger/L1TMuon/python/simDigis_cff.py
+++ b/L1Trigger/L1TMuon/python/simDigis_cff.py
@@ -77,6 +77,7 @@ from L1Trigger.L1TMuonBarrel.simBmtfDigis_cfi import *
 from L1Trigger.L1TMuonBarrel.simKBmtfStubs_cfi import *
 from L1Trigger.L1TMuonBarrel.simKBmtfDigis_cfi import *
 from L1Trigger.L1TMuonEndCap.simEmtfDigis_cfi import *
+from L1Trigger.L1TMuonEndCap.simEmtfShowers_cfi import *
 from L1Trigger.L1TMuonOverlap.simOmtfDigis_cfi import *
 from L1Trigger.L1TMuon.simGmtCaloSumDigis_cfi import *
 from L1Trigger.L1TMuon.simGmtStage2Digis_cfi import *

--- a/L1Trigger/L1TMuon/python/simGmtStage2Digis_cfi.py
+++ b/L1Trigger/L1TMuon/python/simGmtStage2Digis_cfi.py
@@ -20,6 +20,10 @@ simGmtStage2Digis = cms.EDProducer('L1TMuonProducer',
     emtfCancelMode = cms.string("coordinate") # 'tracks' or 'coordinate'
 )
 
+# Muon shower trigger
+from L1Trigger.L1TMuon.simGmtShowerDigisDef_cfi import simGmtShowerDigisDef
+simGmtShowerDigis = simGmtShowerDigisDef.clone()
+
 from CondCore.CondDB.CondDB_cfi import CondDB
 CondDB.connect = cms.string("frontier://FrontierProd/CMS_CONDITIONS")
 l1ugmtdb = cms.ESSource("PoolDBESSource",

--- a/L1Trigger/L1TMuonEndCap/interface/SectorProcessorShower.h
+++ b/L1Trigger/L1TMuonEndCap/interface/SectorProcessorShower.h
@@ -1,0 +1,41 @@
+#ifndef L1Trigger_L1TMuonEndCap_SectorProcessorShower_h
+#define L1Trigger_L1TMuonEndCap_SectorProcessorShower_h
+
+/*
+  This class executes the trigger logic for the EMTF shower trigger.
+  In the basic mode, the EMTF shower sector processor will find any valid
+  CSC shower and send a trigger to the uGMT. In a possible extension, the
+  EMTF shower sector processor can also trigger on two loose showers - to
+  enhance the sensitivity to long-lived particles that produce multiple
+  smaller showers, instead of a single large shower.
+ */
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "DataFormats/L1TMuon/interface/RegionalMuonShower.h"
+#include "DataFormats/CSCDigi/interface/CSCShowerDigiCollection.h"
+#include "L1Trigger/L1TMuonEndCap/interface/Common.h"
+
+#include <vector>
+
+class SectorProcessorShower {
+public:
+  explicit SectorProcessorShower() {}
+  ~SectorProcessorShower() {}
+
+  void configure(const edm::ParameterSet&, int endcap, int sector);
+
+  void process(const CSCShowerDigiCollection& showers, l1t::RegionalMuonShowerBxCollection& out_showers) const;
+
+private:
+  int select_shower(const CSCDetId&, const CSCShowerDigi&) const;
+  int get_index_shower(int tp_endcap, int tp_sector, int tp_subsector, int tp_station, int tp_csc_ID) const;
+  bool is_in_sector_csc(int tp_endcap, int tp_sector) const;
+
+  int verbose_, endcap_, sector_;
+  bool enableOneNominalShower_;
+  bool enableTwoLooseShowers_;
+  unsigned nNominalShowers_;
+  unsigned nLooseShowers_;
+};
+
+#endif

--- a/L1Trigger/L1TMuonEndCap/plugins/L1TMuonEndCapShowerProducer.cc
+++ b/L1Trigger/L1TMuonEndCap/plugins/L1TMuonEndCapShowerProducer.cc
@@ -1,0 +1,54 @@
+#include "L1Trigger/L1TMuonEndCap/plugins/L1TMuonEndCapShowerProducer.h"
+#include "L1Trigger/L1TMuonEndCap/interface/Common.h"
+
+L1TMuonEndCapShowerProducer::L1TMuonEndCapShowerProducer(const edm::ParameterSet& iConfig)
+    : config_(iConfig),
+      tokenCSCShower_(consumes<CSCShowerDigiCollection>(iConfig.getParameter<edm::InputTag>("CSCShowerInput"))),
+      sector_processors_shower_() {
+  // Make output products
+  produces<l1t::RegionalMuonShowerBxCollection>("EMTF");
+}
+
+L1TMuonEndCapShowerProducer::~L1TMuonEndCapShowerProducer() {}
+
+void L1TMuonEndCapShowerProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  // Create pointers to output products
+  auto out_showers = std::make_unique<l1t::RegionalMuonShowerBxCollection>();
+  out_showers->clear();
+  out_showers->setBXRange(0, 0);
+
+  edm::Handle<CSCShowerDigiCollection> showersH;
+  iEvent.getByToken(tokenCSCShower_, showersH);
+  const CSCShowerDigiCollection& showers = *showersH.product();
+
+  // ___________________________________________________________________________
+  // Run the sector processors
+
+  for (int endcap = emtf::MIN_ENDCAP; endcap <= emtf::MAX_ENDCAP; ++endcap) {
+    for (int sector = emtf::MIN_TRIGSECTOR; sector <= emtf::MAX_TRIGSECTOR; ++sector) {
+      const int es = (endcap - emtf::MIN_ENDCAP) * (emtf::MAX_TRIGSECTOR - emtf::MIN_TRIGSECTOR + 1) +
+                     (sector - emtf::MIN_TRIGSECTOR);
+
+      sector_processors_shower_.at(es).configure(config_, endcap, sector);
+      sector_processors_shower_.at(es).process(showers, *out_showers);
+    }
+  }
+
+  // Fill the output products
+  iEvent.put(std::move(out_showers), "EMTF");
+}
+
+void L1TMuonEndCapShowerProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  // these are different shower selections that can be enabled
+  desc.add<bool>("enableOneNominalShowers", true);
+  desc.add<bool>("enableTwoLooseShowers", false);
+  desc.add<unsigned>("nLooseShowers", 2);
+  desc.add<unsigned>("nNominalShowers", 1);
+  desc.add<edm::InputTag>("CSCShowerInput", edm::InputTag("simCscTriggerPrimitiveDigis"));
+  descriptions.add("simEmtfShowersDef", desc);
+  descriptions.setComment("This is the generic cfi file for the EMTF shower producer");
+}
+
+// Define this as a plug-in
+DEFINE_FWK_MODULE(L1TMuonEndCapShowerProducer);

--- a/L1Trigger/L1TMuonEndCap/plugins/L1TMuonEndCapShowerProducer.h
+++ b/L1Trigger/L1TMuonEndCap/plugins/L1TMuonEndCapShowerProducer.h
@@ -1,0 +1,41 @@
+#ifndef L1Trigger_L1TMuonEndCap_L1TMuonEndCapShowerProducer_h
+#define L1Trigger_L1TMuonEndCap_L1TMuonEndCapShowerProducer_h
+
+/*
+  This EDProducer produces EMTF showers from showers in the CSC local trigger.
+  These showers could indicate the passage of a long-lived particle decaying
+  in the endcap muon system.
+
+  The logic is executed in the SectorProcessorShower class. Multiple options
+  are defined: "OneNominal", "TwoLoose"
+ */
+
+// system include files
+#include <memory>
+
+// user include files
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "L1Trigger/L1TMuonEndCap/interface/SectorProcessorShower.h"
+
+// Class declaration
+class L1TMuonEndCapShowerProducer : public edm::stream::EDProducer<> {
+public:
+  explicit L1TMuonEndCapShowerProducer(const edm::ParameterSet&);
+  ~L1TMuonEndCapShowerProducer() override;
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+private:
+  void produce(edm::Event&, const edm::EventSetup&) override;
+
+private:
+  const edm::ParameterSet& config_;
+  edm::EDGetToken tokenCSCShower_;
+  emtf::sector_array<SectorProcessorShower> sector_processors_shower_;
+};
+
+#endif

--- a/L1Trigger/L1TMuonEndCap/python/simEmtfShowers_cfi.py
+++ b/L1Trigger/L1TMuonEndCap/python/simEmtfShowers_cfi.py
@@ -1,0 +1,9 @@
+import FWCore.ParameterSet.Config as cms
+
+from L1Trigger.L1TMuonEndCap.simEmtfShowersDef_cfi import simEmtfShowersDef
+
+## producer for simulation
+simEmtfShowers = simEmtfShowersDef.clone()
+
+## producer for re-emulation on unpacked CSC shower data
+simEmtfShowersData = simEmtfShowers.clone()

--- a/L1Trigger/L1TMuonEndCap/src/SectorProcessorShower.cc
+++ b/L1Trigger/L1TMuonEndCap/src/SectorProcessorShower.cc
@@ -1,0 +1,113 @@
+#include "L1Trigger/L1TMuonEndCap/interface/SectorProcessorShower.h"
+#include "DataFormats/CSCDigi/interface/CSCConstants.h"
+
+void SectorProcessorShower::configure(const edm::ParameterSet& pset, int endcap, int sector) {
+  emtf_assert(emtf::MIN_ENDCAP <= endcap && endcap <= emtf::MAX_ENDCAP);
+  emtf_assert(emtf::MIN_TRIGSECTOR <= sector && sector <= emtf::MAX_TRIGSECTOR);
+
+  endcap_ = endcap;
+  sector_ = sector;
+
+  enableTwoLooseShowers_ = pset.getParameter<bool>("enableTwoLooseShowers");
+  enableOneNominalShower_ = pset.getParameter<bool>("enableOneNominalShowers");
+  nLooseShowers_ = pset.getParameter<unsigned>("nLooseShowers");
+  nNominalShowers_ = pset.getParameter<unsigned>("nNominalShowers");
+}
+
+void SectorProcessorShower::process(const CSCShowerDigiCollection& in_showers,
+                                    l1t::RegionalMuonShowerBxCollection& out_showers) const {
+  // reset
+  std::vector<CSCShowerDigi> selected_showers;
+
+  // shower selection
+  auto chamber = in_showers.begin();
+  auto chend = in_showers.end();
+  for (; chamber != chend; ++chamber) {
+    auto digi = (*chamber).second.first;
+    auto dend = (*chamber).second.second;
+    for (; digi != dend; ++digi) {
+      // Returns CSC "link" index (0 - 45)
+      int selected_shower = select_shower((*chamber).first, *digi);
+
+      // index is valid
+      if (selected_shower >= 0) {
+        // 18 in ME1; 9x3 in ME2,3,4
+        emtf_assert(selected_shower < CSCConstants::MAX_CSCS_PER_EMTF_SP_NO_OVERLAP);
+
+        // shower is valid
+        if (digi->isValid()) {
+          selected_showers.emplace_back(*digi);
+        }
+      }
+    }
+  }
+
+  // Shower recognition logic: at least one nominal shower (see DN-20-033, section 5.2)
+  const unsigned nLooseInTime(std::count_if(
+      selected_showers.begin(), selected_showers.end(), [](CSCShowerDigi p) { return p.isLooseInTime(); }));
+  const unsigned nNominalInTime(std::count_if(
+      selected_showers.begin(), selected_showers.end(), [](CSCShowerDigi p) { return p.isNominalInTime(); }));
+  const unsigned nLooseOutOfTime(std::count_if(
+      selected_showers.begin(), selected_showers.end(), [](CSCShowerDigi p) { return p.isLooseOutTime(); }));
+  const unsigned nNominalOutOfTime(std::count_if(
+      selected_showers.begin(), selected_showers.end(), [](CSCShowerDigi p) { return p.isNominalOutTime(); }));
+
+  const bool hasTwoLooseInTime(nLooseInTime >= nLooseShowers_);
+  const bool hasOneNominalInTime(nNominalInTime >= nNominalShowers_);
+  const bool hasTwoLooseOutOfTime(nLooseOutOfTime >= nLooseShowers_);
+  const bool hasOneNominalOutOfTime(nNominalOutOfTime >= nNominalShowers_);
+
+  const bool acceptLoose(enableTwoLooseShowers_ and (hasTwoLooseInTime or hasTwoLooseOutOfTime));
+  const bool acceptNominal(enableOneNominalShower_ and (hasOneNominalInTime or hasOneNominalOutOfTime));
+  // trigger condition
+  const bool accept(acceptLoose or acceptNominal);
+
+  if (accept) {
+    // shower output
+    l1t::RegionalMuonShower out_shower(
+        hasOneNominalInTime, hasOneNominalOutOfTime, hasTwoLooseInTime, hasTwoLooseOutOfTime);
+    out_shower.setEndcap(endcap_);
+    out_shower.setSector(sector_);
+    out_showers.push_back(0, out_shower);
+  }
+}
+
+// shower selection
+int SectorProcessorShower::select_shower(const CSCDetId& tp_detId, const CSCShowerDigi& shower) const {
+  int selected = -1;
+
+  int tp_endcap = tp_detId.endcap();
+  int tp_sector = tp_detId.triggerSector();
+  int tp_station = tp_detId.station();
+  int tp_chamber = tp_detId.chamber();
+  int tp_csc_ID = shower.getCSCID();
+
+  // station 1 --> subsector 1 or 2
+  // station 2,3,4 --> subsector 0
+  int tp_subsector = (tp_station != 1) ? 0 : ((tp_chamber % 6 > 2) ? 1 : 2);
+
+  // Check if the chamber belongs to this sector processor at this BX.
+  selected = get_index_shower(tp_endcap, tp_sector, tp_subsector, tp_station, tp_csc_ID);
+  return selected;
+}
+
+int SectorProcessorShower::get_index_shower(
+    int tp_endcap, int tp_sector, int tp_subsector, int tp_station, int tp_csc_ID) const {
+  int selected = -1;
+
+  // shower trigger does not considers overlaps
+  if (is_in_sector_csc(tp_endcap, tp_sector)) {
+    if (tp_station == 1) {  // ME1: 0 - 8, 9 - 17
+      selected = (tp_subsector - 1) * 9 + (tp_csc_ID - 1);
+    } else {  // ME2,3,4: 18 - 26, 27 - 35, 36 - 44
+      selected = (tp_station)*9 + (tp_csc_ID - 1);
+    }
+  }
+
+  emtf_assert(selected != -1);
+  return selected;
+}
+
+bool SectorProcessorShower::is_in_sector_csc(int tp_endcap, int tp_sector) const {
+  return ((endcap_ == tp_endcap) && (sector_ == tp_sector));
+}


### PR DESCRIPTION
#### PR description:

Following #33446, I introduce the hadronic shower trigger emulator in the EMTF and uGMT for Run-3. Most of the logic resides in `SectorProcessorShower`, so that we retain maximum flexibility to adjust the algorithms during data taking. Both emulators are standalone and do not interfere with existing emulators. Currently, there are not yet included in any workflow.

#### PR validation:

Ran `runTheMatrix -l limited`. There should be no differences in any workflow.

```
4.22_RunCosmics2011A+RunCosmics2011A+RECOCOSD+ALCACOSD+SKIMCOSD+HARVESTDC Step0-DAS_ERROR Step1-NOTRUN Step2-NOTRUN Step3-NOTRUN Step4-NOTRUN  - time date Wed Apr 28 11:33:51 2021-date Wed Apr 28 11:33:51 2021; exit: 1 0 0 0 0
4.53_RunPhoton2012B+RunPhoton2012B+HLTD+RECODR1reHLT+HARVESTDR1reHLT Step0-DAS_ERROR Step1-NOTRUN Step2-NOTRUN Step3-NOTRUN  - time date Wed Apr 28 11:33:51 2021-date Wed Apr 28 11:33:51 2021; exit: 1 0 0 0
5.1_TTbar+TTbarFS+HARVESTFS Step0-PASSED Step1-PASSED  - time date Wed Apr 28 11:39:49 2021-date Wed Apr 28 11:33:52 2021; exit: 0 0
7.3_CosmicsSPLoose_UP18+CosmicsSPLoose_UP18+DIGICOS_UP18+RECOCOS_UP18+ALCACOS_UP18+HARVESTCOS_UP18 Step0-PASSED Step1-PASSED Step2-PASSED Step3-PASSED Step4-PASSED  - time date Wed Apr 28 11:45:14 2021-date Wed Apr 28 11:33:52 2021; exit: 0 0 0 0 0
8.0_BeamHalo+BeamHalo+DIGICOS+RECOCOS+ALCABH+HARVESTCOS Step0-PASSED Step1-PASSED Step2-PASSED Step3-PASSED Step4-PASSED  - time date Wed Apr 28 11:44:38 2021-date Wed Apr 28 11:33:53 2021; exit: 0 0 0 0 0
9.0_Higgs200ChargedTaus+Higgs200ChargedTaus+DIGI+RECO+HARVEST Step0-PASSED Step1-PASSED Step2-PASSED Step3-PASSED  - time date Wed Apr 28 11:51:28 2021-date Wed Apr 28 11:33:53 2021; exit: 0 0 0 0
25.0_TTbar+TTbar+DIGI+RECOAlCaCalo+HARVEST+ALCATT Step0-PASSED Step1-PASSED Step2-PASSED Step3-PASSED Step4-PASSED  - time date Wed Apr 28 12:04:59 2021-date Wed Apr 28 11:39:49 2021; exit: 0 0 0 0 0
135.4_ZEE_13+ZEEFS_13+HARVESTUP15FS+MINIAODMCUP15FS Step0-PASSED Step1-PASSED Step2-PASSED  - time date Wed Apr 28 11:53:09 2021-date Wed Apr 28 11:44:39 2021; exit: 0 0 0
136.731_RunSinglePh2016B+RunSinglePh2016B+HLTDR2_2016+RECODR2_2016reHLT_skimSinglePh_HIPM+HARVESTDR2 Step0-DAS_ERROR Step1-NOTRUN Step2-NOTRUN Step3-NOTRUN  - time date Wed Apr 28 11:45:15 2021-date Wed Apr 28 11:45:14 2021; exit: 1 0 0 0
136.7611_RunJetHT2016E_reminiaod+RunJetHT2016E_reminiaod+REMINIAOD_data2016_HIPM+HARVESTDR2_REMINIAOD_data2016_HIPM Step0-DAS_ERROR Step1-NOTRUN Step2-NOTRUN  - time date Wed Apr 28 11:45:15 2021-date Wed Apr 28 11:45:15 2021; exit: 1 0 0
136.793_RunDoubleEG2017C+RunDoubleEG2017C+HLTDR2_2017+RECODR2_2017reHLT_skimDoubleEG_Prompt+HARVEST2017 Step0-DAS_ERROR Step1-NOTRUN Step2-NOTRUN Step3-NOTRUN  - time date Wed Apr 28 11:45:16 2021-date Wed Apr 28 11:45:15 2021; exit: 1 0 0 0
136.8311_RunJetHT2017F_reminiaod+RunJetHT2017F_reminiaod+REMINIAOD_data2017+HARVEST2017_REMINIAOD_data2017 Step0-DAS_ERROR Step1-NOTRUN Step2-NOTRUN  - time date Wed Apr 28 11:45:16 2021-date Wed Apr 28 11:45:16 2021; exit: 1 0 0
136.8523_RunJetHT2018C_nanoULremini+RunJetHT2018C_nanoULremini+NANOEDM2018_106Xv2+HARVESTNANOAOD2018_106Xv2 Step0-DAS_ERROR Step1-NOTRUN Step2-NOTRUN  - time date Wed Apr 28 11:45:17 2021-date Wed Apr 28 11:45:16 2021; exit: 1 0 0
136.874_RunEGamma2018C+RunEGamma2018C+HLTDR2_2018+RECODR2_2018reHLT_skimEGamma_Offline_L1TEgDQM+HARVEST2018_L1TEgDQM Step0-DAS_ERROR Step1-NOTRUN Step2-NOTRUN Step3-NOTRUN  - time date Wed Apr 28 11:45:17 2021-date Wed Apr 28 11:45:17 2021; exit: 1 0 0 0
136.88811_RunJetHT2018D_reminiaodUL+RunJetHT2018D_reminiaodUL+REMINIAOD_data2018UL+HARVEST2018_REMINIAOD_data2018UL Step0-DAS_ERROR Step1-NOTRUN Step2-NOTRUN  - time date Wed Apr 28 11:45:18 2021-date Wed Apr 28 11:45:17 2021; exit: 1 0 0
140.53_RunHI2011+RunHI2011+RECOHID11+HARVESTDHI Step0-DAS_ERROR Step1-NOTRUN Step2-NOTRUN  - time date Wed Apr 28 11:45:18 2021-date Wed Apr 28 11:45:18 2021; exit: 1 0 0
140.56_RunHI2018+RunHI2018+RECOHID18+HARVESTDHI18 Step0-DAS_ERROR Step1-NOTRUN Step2-NOTRUN  - time date Wed Apr 28 11:45:19 2021-date Wed Apr 28 11:45:18 2021; exit: 1 0 0
158.01_HydjetQ_reminiaodPbPb2018_INPUT+HydjetQ_reminiaodPbPb2018_INPUT+REMINIAODHI2018PPRECOMB+HARVESTHI2018PPRECOMINIAOD Step0-DAS_ERROR Step1-NOTRUN Step2-NOTRUN  - time date Wed Apr 28 11:45:19 2021-date Wed Apr 28 11:45:19 2021; exit: 1 0 0
1306.0_SingleMuPt1_UP15+SingleMuPt1_UP15+DIGIUP15+RECOUP15+HARVESTUP15 Step0-PASSED Step1-PASSED Step2-PASSED Step3-PASSED  - time date Wed Apr 28 12:02:50 2021-date Wed Apr 28 11:45:19 2021; exit: 0 0 0 0
1325.81_TTbar_13_106Xv1NanoAODINPUT+TTbar_13_106Xv1NanoAODINPUT+NANOEDMMC2017_106XMiniAODv1+HARVESTNANOAODMC2017_106XMiniAODv1 Step0-DAS_ERROR Step1-NOTRUN Step2-NOTRUN  - time date Wed Apr 28 11:51:29 2021-date Wed Apr 28 11:51:28 2021; exit: 1 0 0
1330.0_ZMM_13+ZMM_13+DIGIUP15+RECOUP15_L1TMuDQM+HARVESTUP15_L1TMuDQM+NANOUP15 Step0-PASSED Step1-PASSED Step2-PASSED Step3-PASSED Step4-PASSED  - time date Wed Apr 28 12:15:40 2021-date Wed Apr 28 11:51:29 2021; exit: 0 0 0 0 0
101.0_SingleElectronE120EHCAL+SingleElectronE120EHCAL Step0-PASSED  - time date Wed Apr 28 11:57:04 2021-date Wed Apr 28 11:53:09 2021; exit: 0
312.0_Pyquen_ZeemumuJets_pt10_2760GeV_2021+Pyquen_ZeemumuJets_pt10_2760GeV_2021+DIGIHI2021MIX+RECOHI2021MIX+HARVESTHI2021PPRECO Step0-FAILED Step1-NOTRUN Step2-NOTRUN Step3-NOTRUN  - time date Wed Apr 28 12:00:43 2021-date Wed Apr 28 11:57:05 2021; exit: 23808 0 0 0
25202.0_TTbar_13+TTbar_13+DIGIUP15_PU25+RECOUP15_PU25+HARVESTUP15_PU25+NANOUP15_PU25 Step0-PASSED Step1-FAILED Step2-NOTRUN Step3-NOTRUN Step4-NOTRUN  - time date Wed Apr 28 12:11:35 2021-date Wed Apr 28 12:00:44 2021; exit: 0 23808 0 0 0
1000.0_RunMinBias2011A+RunMinBias2011A+TIER0+SKIMD+HARVESTDfst2+ALCASPLIT Step0-DAS_ERROR Step1-NOTRUN Step2-NOTRUN Step3-NOTRUN Step4-NOTRUN  - time date Wed Apr 28 12:02:52 2021-date Wed Apr 28 12:02:50 2021; exit: 1 0 0 0 0
1001.0_RunMinBias2011A+RunMinBias2011A+TIER0EXP+ALCAEXP+ALCAHARVDSIPIXELCALRUN1+ALCAHARVD1+ALCAHARVD2+ALCAHARVD3+ALCAHARVD4+ALCAHARVD5 Step0-DAS_ERROR Step1-NOTRUN Step2-NOTRUN Step3-NOTRUN Step4-NOTRUN Step5-NOTRUN Step6-NOTRUN Step7-NOTRUN Step8-NOTRUN  - time date Wed Apr 28 12:02:52 2021-date Wed Apr 28 12:02:52 2021; exit: 1 0 0 0 0 0 0 0 0
10024.0_TTbar_13+2017+TTbar_13TeV_TuneCUETP8M1_GenSim+Digi+RecoFakeHLT+HARVESTFakeHLT+ALCA+Nano Step0-PASSED Step1-PASSED Step2-PASSED Step3-PASSED Step4-PASSED Step5-PASSED  - time date Wed Apr 28 12:36:01 2021-date Wed Apr 28 12:02:52 2021; exit: 0 0 0 0 0 0
10042.0_ZMM_13+2017+ZMM_13TeV_TuneCUETP8M1_GenSim+Digi+RecoFakeHLT+HARVESTFakeHLT+ALCA+Nano Step0-PASSED Step1-PASSED Step2-PASSED Step3-PASSED Step4-PASSED Step5-PASSED  - time date Wed Apr 28 12:28:29 2021-date Wed Apr 28 12:05:00 2021; exit: 0 0 0 0 0 0
10224.0_TTbar_13+2017PU+TTbar_13TeV_TuneCUETP8M1_GenSim+DigiPU+RecoFakeHLTPU+HARVESTFakeHLTPU+Nano Step0-PASSED Step1-FAILED Step2-NOTRUN Step3-NOTRUN Step4-NOTRUN  - time date Wed Apr 28 12:23:30 2021-date Wed Apr 28 12:11:36 2021; exit: 0 23808 0 0 0
10824.0_TTbar_13+2018+TTbar_13TeV_TuneCUETP8M1_GenSim+Digi+RecoFakeHLT+HARVESTFakeHLT+ALCA+Nano Step0-PASSED Step1-PASSED Step2-PASSED Step3-PASSED Step4-PASSED Step5-PASSED  - time date Wed Apr 28 12:38:29 2021-date Wed Apr 28 12:15:41 2021; exit: 0 0 0 0 0 0
11634.0_TTbar_14TeV+2021+TTbar_14TeV_TuneCP5_GenSim+Digi+Reco+HARVEST+ALCA Step0-PASSED Step1-PASSED Step2-PASSED Step3-PASSED Step4-PASSED  - time date Wed Apr 28 12:46:51 2021-date Wed Apr 28 12:23:30 2021; exit: 0 0 0 0 0
11634.911_TTbar_14TeV+2021_DD4hep+TTbar_14TeV_TuneCP5_GenSim+Digi+Reco+HARVEST+ALCA Step0-PASSED Step1-PASSED Step2-PASSED Step3-PASSED Step4-PASSED  - time date Wed Apr 28 12:55:47 2021-date Wed Apr 28 12:28:30 2021; exit: 0 0 0 0 0
12434.0_TTbar_14TeV+2023+TTbar_14TeV_TuneCP5_GenSim+Digi+Reco+HARVEST+ALCA Step0-PASSED Step1-PASSED Step2-PASSED Step3-PASSED Step4-PASSED  - time date Wed Apr 28 12:57:08 2021-date Wed Apr 28 12:36:02 2021; exit: 0 0 0 0 0
23234.0_TTbar_14TeV+2026D49+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTrigger+RecoGlobal+HARVESTGlobal Step0-PASSED Step1-PASSED Step2-PASSED Step3-PASSED  - time date Wed Apr 28 13:08:59 2021-date Wed Apr 28 12:38:30 2021; exit: 0 0 0 0
28234.0_TTbar_14TeV+2026D60+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTrigger+RecoGlobal+HARVESTGlobal Step0-PASSED Step1-PASSED Step2-PASSED Step3-PASSED  - time date Wed Apr 28 13:19:52 2021-date Wed Apr 28 12:46:52 2021; exit: 0 0 0 0
34634.0_TTbar_14TeV+2026D76+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTrigger+RecoGlobal+HARVESTGlobal Step0-PASSED Step1-PASSED Step2-PASSED Step3-PASSED  - time date Wed Apr 28 13:26:41 2021-date Wed Apr 28 12:55:47 2021; exit: 0 0 0 0
34834.999_TTbar_14TeV+2026D76PU_PMXS1S2PR+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+PREMIX_PremixHLBeamSpot14PU+DigiTriggerPU+RecoGlobalPU+HARVESTGlobalPU Step0-PASSED Step1-FAILED Step2-NOTRUN Step3-NOTRUN Step4-NOTRUN  - time date Wed Apr 28 13:16:30 2021-date Wed Apr 28 12:57:09 2021; exit: 0 21504 0 0 0
250202.181_TTbar_13UP18+TTbar_13UP18+PREMIXUP18_PU25+DIGIPRMXLOCALUP18_PU25+RECOPRMXUP18_PU25+HARVESTUP18_PU25 Step0-PASSED Step1-PASSED Step2-PASSED Step3-PASSED Step4-PASSED  - time date Wed Apr 28 13:40:34 2021-date Wed Apr 28 13:09:00 2021; exit: 0 0 0 0 0
22 18 17 16 11 3 0 0 0 tests passed, 16 3 0 0 0 0 0 0 0 failed
```

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)

@dinyar 
