### PR TITLE
Prep work for the Run-3 GEM-CSC integrated local trigger

### DIFF
--- a/L1Trigger/CSCTriggerPrimitives/interface/CSCALCTCrossCLCT.h
+++ b/L1Trigger/CSCTriggerPrimitives/interface/CSCALCTCrossCLCT.h
@@ -1,0 +1,62 @@
+#ifndef L1Trigger_CSCTriggerPrimitives_CSCALCTCrossCLCT
+#define L1Trigger_CSCTriggerPrimitives_CSCALCTCrossCLCT
+
+/** \class CSCALCTCrossCLCT
+ *
+ * Helper class to check if an ALCT crosses with a CLCT in ME1/1.
+ * This check was originally introduced by Vadim Khotilovich in 2010
+ * to improve the quality of the ME1/1 LCTs that are sent to the
+ * endcap muon track finder. However, it is the policy of the EMTF
+ * group that they would like to receive all LCT information, even
+ * if an ME1/1 LCT has no physical crossing half-strips and
+ * wiregroups. The EMTF disassembles LCTs into ALCT and CLCT anyway
+ * and thus for normal trigger operations this class should not be
+ * used. However, in the event that multiple high-quality LCTs are
+ * present in ME1/1, this class could be used to trim the unphysical
+ * ones. As of writing (April 2021) no plans are in place to implement
+this feature into the CSC trigger firmware
+ *
+ * \author Sven Dildick (Rice University)
+ *
+ */
+
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include <string>
+#include <vector>
+
+class CSCLUTReader;
+class CSCALCTDigi;
+class CSCCLCTDigi;
+
+class CSCALCTCrossCLCT {
+public:
+  CSCALCTCrossCLCT(unsigned endcap, unsigned station, unsigned ring, bool isganged, const edm::ParameterSet& luts);
+
+  // check if an ALCT can cross a CLCT. Not always the case for ME1/1
+  bool doesALCTCrossCLCT(const CSCALCTDigi& a, const CSCCLCTDigi& c, bool ignoreAlctCrossClct) const;
+
+private:
+  bool doesWiregroupCrossHalfStrip(int wg, int keystrip) const;
+
+  unsigned endcap_;
+  unsigned station_;
+  unsigned ring_;
+  bool isganged_;
+
+  // strings to paths of LUTs
+  std::vector<std::string> wgCrossHsME1aFiles_;
+  std::vector<std::string> wgCrossHsME1aGangedFiles_;
+  std::vector<std::string> wgCrossHsME1bFiles_;
+
+  // unique pointers to the luts
+  std::unique_ptr<CSCLUTReader> wg_cross_min_hs_ME1a_;
+  std::unique_ptr<CSCLUTReader> wg_cross_max_hs_ME1a_;
+  std::unique_ptr<CSCLUTReader> wg_cross_min_hs_ME1a_ganged_;
+  std::unique_ptr<CSCLUTReader> wg_cross_max_hs_ME1a_ganged_;
+  std::unique_ptr<CSCLUTReader> wg_cross_min_hs_ME1b_;
+  std::unique_ptr<CSCLUTReader> wg_cross_max_hs_ME1b_;
+};
+
+#endif

--- a/L1Trigger/CSCTriggerPrimitives/interface/CSCCathodeLCTProcessor.h
+++ b/L1Trigger/CSCTriggerPrimitives/interface/CSCCathodeLCTProcessor.h
@@ -34,7 +34,7 @@
 #include "DataFormats/CSCDigi/interface/CSCCLCTDigi.h"
 #include "DataFormats/CSCDigi/interface/CSCCLCTPreTriggerDigi.h"
 #include "L1Trigger/CSCTriggerPrimitives/interface/CSCBaseboard.h"
-#include "L1Trigger/CSCTriggerPrimitives/interface/CSCComparatorCodeLUT.h"
+#include "L1Trigger/CSCTriggerPrimitives/interface/CSCLUTReader.h"
 #include "L1Trigger/CSCTriggerPrimitives/interface/LCTQualityControl.h"
 
 #include <vector>
@@ -100,9 +100,9 @@ protected:
   CSCCLCTDigi secondCLCT[CSCConstants::MAX_CLCT_TBINS];
 
   // unique pointers to the luts
-  std::array<std::unique_ptr<CSCComparatorCodeLUT>, 5> lutpos_;
-  std::array<std::unique_ptr<CSCComparatorCodeLUT>, 5> lutslope_;
-  std::array<std::unique_ptr<CSCComparatorCodeLUT>, 5> lutpatconv_;
+  std::array<std::unique_ptr<CSCLUTReader>, 5> lutpos_;
+  std::array<std::unique_ptr<CSCLUTReader>, 5> lutslope_;
+  std::array<std::unique_ptr<CSCLUTReader>, 5> lutpatconv_;
 
   /** Access routines to comparator digis. */
   bool getDigis(const CSCComparatorDigiCollection* compdc);

--- a/L1Trigger/CSCTriggerPrimitives/interface/CSCLUTReader.h
+++ b/L1Trigger/CSCTriggerPrimitives/interface/CSCLUTReader.h
@@ -1,5 +1,5 @@
-#ifndef L1Trigger_CSCTriggerPrimitives_CSCComparatorCodeLUT
-#define L1Trigger_CSCTriggerPrimitives_CSCComparatorCodeLUT
+#ifndef L1Trigger_CSCTriggerPrimitives_CSCLUTReader
+#define L1Trigger_CSCTriggerPrimitives_CSCLUTReader
 
 #include <fstream>
 #include <sstream>
@@ -11,7 +11,7 @@
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
-class CSCComparatorCodeLUT {
+class CSCLUTReader {
 public:
   enum ReadCodes {
     SUCCESS = 0,
@@ -22,10 +22,9 @@ public:
     NO_HEADER = 5
   };
 
-  /* CSCComparatorCodeLUT(); */
-  explicit CSCComparatorCodeLUT(const std::string&);
-  /* explicit CSCComparatorCodeLUT(l1t::LUT*); */
-  ~CSCComparatorCodeLUT() {}
+  /* CSCLUTReader(); */
+  explicit CSCLUTReader(const std::string&);
+  ~CSCLUTReader() {}
 
   float lookup(int code) const;
   float lookupPacked(const int input) const;

--- a/L1Trigger/CSCTriggerPrimitives/interface/GEMInternalCluster.h
+++ b/L1Trigger/CSCTriggerPrimitives/interface/GEMInternalCluster.h
@@ -69,21 +69,21 @@ public:
   int layer2_middle_es_me1a() const { return layer2_middle_es_me1a_; }
 
   // setters for first/last 1/2-strip
-  void set_layer1_first_hs(const int hs) { layer1_first_hs_= hs; }
-  void set_layer2_first_hs(const int hs) { layer2_first_hs_= hs; }
-  void set_layer1_last_hs(const int hs) { layer1_last_hs_= hs; }
-  void set_layer2_last_hs(const int hs) { layer2_last_hs_= hs; }
+  void set_layer1_first_hs(const int hs) { layer1_first_hs_ = hs; }
+  void set_layer2_first_hs(const int hs) { layer2_first_hs_ = hs; }
+  void set_layer1_last_hs(const int hs) { layer1_last_hs_ = hs; }
+  void set_layer2_last_hs(const int hs) { layer2_last_hs_ = hs; }
 
-  void set_layer1_first_hs_me1a(const int hs) { layer1_first_hs_me1a_= hs; }
-  void set_layer2_first_hs_me1a(const int hs) { layer2_first_hs_me1a_= hs; }
-  void set_layer1_last_hs_me1a(const int hs) { layer1_last_hs_me1a_= hs; }
-  void set_layer2_last_hs_me1a(const int hs) { layer2_last_hs_me1a_= hs; }
+  void set_layer1_first_hs_me1a(const int hs) { layer1_first_hs_me1a_ = hs; }
+  void set_layer2_first_hs_me1a(const int hs) { layer2_first_hs_me1a_ = hs; }
+  void set_layer1_last_hs_me1a(const int hs) { layer1_last_hs_me1a_ = hs; }
+  void set_layer2_last_hs_me1a(const int hs) { layer2_last_hs_me1a_ = hs; }
 
   // setters for middle 1/2-strip
-  void set_layer1_middle_hs(const int hs) { layer1_middle_hs_= hs; }
-  void set_layer2_middle_hs(const int hs) { layer2_middle_hs_= hs; }
-  void set_layer1_middle_hs_me1a(const int hs) { layer1_middle_hs_me1a_= hs; }
-  void set_layer2_middle_hs_me1a(const int hs) { layer2_middle_hs_me1a_= hs; }
+  void set_layer1_middle_hs(const int hs) { layer1_middle_hs_ = hs; }
+  void set_layer2_middle_hs(const int hs) { layer2_middle_hs_ = hs; }
+  void set_layer1_middle_hs_me1a(const int hs) { layer1_middle_hs_me1a_ = hs; }
+  void set_layer2_middle_hs_me1a(const int hs) { layer2_middle_hs_me1a_ = hs; }
 
   // setters for first/last 1/8-strip
   void set_layer1_first_es(const int es) { layer1_first_es_ = es; }

--- a/L1Trigger/CSCTriggerPrimitives/interface/GEMInternalCluster.h
+++ b/L1Trigger/CSCTriggerPrimitives/interface/GEMInternalCluster.h
@@ -1,0 +1,182 @@
+#ifndef L1Trigger_CSCTriggerPrimitives_GEMInternalCluster_h
+#define L1Trigger_CSCTriggerPrimitives_GEMInternalCluster_h
+
+/** \class GEMInternalCluster
+ *
+ * Helper class to contain detids, clusters and corresponding
+ * 1/2-strips, 1/8-strips and wiregroups for easy matching with CSC TPs
+ *
+ * Author: Sven Dildick (Rice University)
+ *
+ */
+
+#include "DataFormats/MuonDetId/interface/GEMDetId.h"
+#include "DataFormats/GEMDigi/interface/GEMPadDigiCluster.h"
+
+class GEMInternalCluster {
+public:
+  // constructor
+  GEMInternalCluster(const GEMDetId& id, const GEMPadDigiCluster& cluster1, const GEMPadDigiCluster& cluster2);
+
+  GEMDetId id() const { return id_; }
+  GEMPadDigiCluster cl1() const { return cl1_; }
+  GEMPadDigiCluster cl2() const { return cl2_; }
+
+  int bx() const { return bx_; }
+  int roll() const { return id_.roll(); }
+  int layer1_pad() const { return layer1_pad_; }
+  int layer1_size() const { return layer1_size_; }
+  int layer2_pad() const { return layer2_pad_; }
+  int layer2_size() const { return layer2_size_; }
+  int min_wg() const { return min_wg_; }
+  int max_wg() const { return max_wg_; }
+  bool isCoincidence() const { return isCoincidence_; }
+
+  // first and last 1/2-strips
+  int layer1_first_hs() const { return layer1_first_hs_; }
+  int layer2_first_hs() const { return layer2_first_hs_; }
+  int layer1_last_hs() const { return layer1_last_hs_; }
+  int layer2_last_hs() const { return layer2_last_hs_; }
+
+  int layer1_first_hs_me1a() const { return layer1_first_hs_me1a_; }
+  int layer2_first_hs_me1a() const { return layer2_first_hs_me1a_; }
+  int layer1_last_hs_me1a() const { return layer1_last_hs_me1a_; }
+  int layer2_last_hs_me1a() const { return layer2_last_hs_me1a_; }
+
+  // middle 1/2-strips (sum divided by two)
+  int layer1_middle_hs() const { return layer1_middle_hs_; }
+  int layer2_middle_hs() const { return layer2_middle_hs_; }
+
+  int layer1_middle_hs_me1a() const { return layer1_middle_hs_me1a_; }
+  int layer2_middle_hs_me1a() const { return layer2_middle_hs_me1a_; }
+
+  // first and last 1/8-strips
+  int layer1_first_es() const { return layer1_first_es_; }
+  int layer2_first_es() const { return layer2_first_es_; }
+  int layer1_last_es() const { return layer1_last_es_; }
+  int layer2_last_es() const { return layer2_last_es_; }
+
+  int layer1_first_es_me1a() const { return layer1_first_es_me1a_; }
+  int layer2_first_es_me1a() const { return layer2_first_es_me1a_; }
+  int layer1_last_es_me1a() const { return layer1_last_es_me1a_; }
+  int layer2_last_es_me1a() const { return layer2_last_es_me1a_; }
+
+  // middle 1/8-strips (sum divided by two)
+  int layer1_middle_es() const { return layer1_middle_es_; }
+  int layer2_middle_es() const { return layer2_middle_es_; }
+
+  int layer1_middle_es_me1a() const { return layer1_middle_es_me1a_; }
+  int layer2_middle_es_me1a() const { return layer2_middle_es_me1a_; }
+
+  // setters for first/last 1/2-strip
+  void set_layer1_first_hs(const int hs) { layer1_first_hs_= hs; }
+  void set_layer2_first_hs(const int hs) { layer2_first_hs_= hs; }
+  void set_layer1_last_hs(const int hs) { layer1_last_hs_= hs; }
+  void set_layer2_last_hs(const int hs) { layer2_last_hs_= hs; }
+
+  void set_layer1_first_hs_me1a(const int hs) { layer1_first_hs_me1a_= hs; }
+  void set_layer2_first_hs_me1a(const int hs) { layer2_first_hs_me1a_= hs; }
+  void set_layer1_last_hs_me1a(const int hs) { layer1_last_hs_me1a_= hs; }
+  void set_layer2_last_hs_me1a(const int hs) { layer2_last_hs_me1a_= hs; }
+
+  // setters for middle 1/2-strip
+  void set_layer1_middle_hs(const int hs) { layer1_middle_hs_= hs; }
+  void set_layer2_middle_hs(const int hs) { layer2_middle_hs_= hs; }
+  void set_layer1_middle_hs_me1a(const int hs) { layer1_middle_hs_me1a_= hs; }
+  void set_layer2_middle_hs_me1a(const int hs) { layer2_middle_hs_me1a_= hs; }
+
+  // setters for first/last 1/8-strip
+  void set_layer1_first_es(const int es) { layer1_first_es_ = es; }
+  void set_layer2_first_es(const int es) { layer2_first_es_ = es; }
+  void set_layer1_last_es(const int es) { layer1_last_es_ = es; }
+  void set_layer2_last_es(const int es) { layer2_last_es_ = es; }
+
+  void set_layer1_first_es_me1a(const int es) { layer1_first_es_me1a_ = es; }
+  void set_layer2_first_es_me1a(const int es) { layer2_first_es_me1a_ = es; }
+  void set_layer1_last_es_me1a(const int es) { layer1_last_es_me1a_ = es; }
+  void set_layer2_last_es_me1a(const int es) { layer2_last_es_me1a_ = es; }
+
+  // setters for middle 1/8-strip
+  void set_layer1_middle_es(const int es) { layer1_middle_es_ = es; }
+  void set_layer2_middle_es(const int es) { layer2_middle_es_ = es; }
+  void set_layer1_middle_es_me1a(const int es) { layer1_middle_es_me1a_ = es; }
+  void set_layer2_middle_es_me1a(const int es) { layer2_middle_es_me1a_ = es; }
+
+  // set the corresponding wiregroup numbers
+  void set_min_wg(const int wg) { min_wg_ = wg; }
+  void set_max_wg(const int wg) { max_wg_ = wg; }
+
+  bool has_cluster(const GEMPadDigiCluster& cluster) const;
+
+  // equality operator: detid, cluster 1 and cluster 2
+  bool operator==(const GEMInternalCluster& cluster) const;
+
+private:
+  /*
+    Detector id. There are three cases. For single clusters in layer 1
+    the GEMDetId in layer 1 is stored. Similarly, for single clusters in
+    layer 2 the GEMDetId in layer 2 is stored. For coincidences the  GEMDetId
+    in layer 1 is stored
+  */
+  GEMDetId id_;
+  GEMPadDigiCluster cl1_;
+  GEMPadDigiCluster cl2_;
+
+  // bunch crossing
+  int bx_;
+
+  // starting pads and sizes of the clusters in each layer
+  // depending on the presence of a coincidence, layer 1, layer2, or both
+  // can be filled
+  int layer1_pad_;
+  int layer1_size_;
+  int layer2_pad_;
+  int layer2_size_;
+
+  // corresponding CSC 1/2-strip coordinates (es) of the cluster
+  // in each layer (if applicable)
+  int layer1_first_hs_;
+  int layer1_last_hs_;
+  int layer2_first_hs_;
+  int layer2_last_hs_;
+  // for ME1/a
+  int layer1_first_hs_me1a_;
+  int layer1_last_hs_me1a_;
+  int layer2_first_hs_me1a_;
+  int layer2_last_hs_me1a_;
+
+  // middle CSC 1/2-strip
+  int layer1_middle_hs_;
+  int layer2_middle_hs_;
+  // for ME1/a
+  int layer1_middle_hs_me1a_;
+  int layer2_middle_hs_me1a_;
+
+  // corresponding CSC 1/8-strip coordinates (es) of the cluster
+  // in each layer (if applicable)
+  int layer1_first_es_;
+  int layer1_last_es_;
+  int layer2_first_es_;
+  int layer2_last_es_;
+  // for ME1/a
+  int layer1_first_es_me1a_;
+  int layer1_last_es_me1a_;
+  int layer2_first_es_me1a_;
+  int layer2_last_es_me1a_;
+
+  // middle CSC 1/8-strip
+  int layer1_middle_es_;
+  int layer2_middle_es_;
+  // for ME1/a
+  int layer1_middle_es_me1a_;
+  int layer2_middle_es_me1a_;
+
+  // corresponding min and max wiregroup
+  int min_wg_;
+  int max_wg_;
+
+  // flag to signal if it is a coincidence
+  bool isCoincidence_;
+};
+
+#endif

--- a/L1Trigger/CSCTriggerPrimitives/interface/LCTQualityAssignment.h
+++ b/L1Trigger/CSCTriggerPrimitives/interface/LCTQualityAssignment.h
@@ -1,0 +1,79 @@
+#ifndef L1Trigger_CSCTriggerPrimitives_LCTQualityAssignment
+#define L1Trigger_CSCTriggerPrimitives_LCTQualityAssignment
+
+/** \class LCTQualityAssignment
+ *
+ * Helper class to calculate the quality of an LCT. There
+ * is a Run-2 quality (also used for Run-1) based on the
+ * pattern Id and the number of layers. There are two Run-3
+ * LCTs qualities. One for the non-GEM TMBs and one for OTMBs
+ * which receive GEM information.
+ *
+ * \author Sven Dildick (Rice University)
+ *
+ */
+
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+class CSCALCTDigi;
+class CSCCLCTDigi;
+
+class LCTQualityAssignment {
+public:
+  // 4-bit LCT quality number. Made by TMB lookup tables and used for MPC sorting.
+  enum class LCT_QualityRun2 : unsigned int {
+    INVALID = 0,
+    NO_CLCT = 1,
+    NO_ALCT = 2,
+    CLCT_LAYER_TRIGGER = 3,
+    LOW_QUALITY = 4,
+    MARGINAL_ANODE_CATHODE = 5,
+    HQ_ANODE_MARGINAL_CATHODE = 6,
+    HQ_CATHODE_MARGINAL_ANODE = 7,
+    HQ_ACCEL_ALCT = 8,
+    HQ_RESERVED_1 = 9,
+    HQ_RESERVED_2 = 10,
+    HQ_PATTERN_2_3 = 11,
+    HQ_PATTERN_4_5 = 12,
+    HQ_PATTERN_6_7 = 13,
+    HQ_PATTERN_8_9 = 14,
+    HQ_PATTERN_10 = 15
+  };
+
+  // See DN-20-016
+  enum class LCT_QualityRun3 : unsigned int { INVALID = 0, LowQ = 1, MedQ = 2, HighQ = 3 };
+
+  // See DN-20-016
+  enum class LCT_QualityRun3GEM : unsigned int {
+    INVALID = 0,
+    ALCT_2GEM = 1,
+    CLCT_2GEM = 2,
+    ALCT_CLCT = 3,
+    ALCT_CLCT_1GEM_CSCBend = 4,
+    ALCT_CLCT_1GEM_GEMCSCBend = 5,
+    ALCT_CLCT_2GEM_CSCBend = 6,
+    ALCT_CLCT_2GEM_GEMCSCBend = 7
+  };
+
+  // constructor
+  LCTQualityAssignment(bool isRun3, unsigned station);
+
+  // quality for all LCTs in Run-1 and Run-2
+  unsigned findQualityRun2(const CSCALCTDigi& aLCT, const CSCCLCTDigi& cLCT) const;
+
+  // quality for non-ME1/1 LCTs in Run-3 without GEMs
+  unsigned findQualityRun3(const CSCALCTDigi& aLCT, const CSCCLCTDigi& cLCT) const;
+
+  // quality for LCTs in Run-3 with GEMs (old-style to be compatible with EMTF Run-2)
+  unsigned findQualityGEMv1(const CSCALCTDigi&, const CSCCLCTDigi&, int gemlayer) const;
+
+  // quality for LCTs in Run-3 with GEMs
+  unsigned findQualityGEMv2(const CSCALCTDigi&, const CSCCLCTDigi&, int gemlayer) const;
+
+private:
+  bool isRun3_;
+  unsigned station_;
+};
+
+#endif

--- a/L1Trigger/CSCTriggerPrimitives/python/cscTriggerPrimitiveDigis_cfi.py
+++ b/L1Trigger/CSCTriggerPrimitives/python/cscTriggerPrimitiveDigis_cfi.py
@@ -3,13 +3,15 @@ import FWCore.ParameterSet.Config as cms
 ## Import minBX and maxBX for the MPC
 from L1Trigger.CSCTriggerPrimitives.CSCCommonTrigger_cfi import CSCCommonTrigger
 
-## The directory params/ contains common psets, psets for the processsors,
-## for the TMBs, MPC and CCLUT.
+## The directory params/ contains common psets, psets for the ALCT and CLCT
+## processsors, for the TMBs, MPC and CCLUT, the GEM-CSC integrated local trigger,
+## and the hadronic shower trigger.
 from L1Trigger.CSCTriggerPrimitives.params.alctParams import alctPSets
 from L1Trigger.CSCTriggerPrimitives.params.clctParams import clctPSets
 from L1Trigger.CSCTriggerPrimitives.params.tmbParams import tmbPSets
 from L1Trigger.CSCTriggerPrimitives.params.auxiliaryParams import auxPSets
 from L1Trigger.CSCTriggerPrimitives.params.cclutParams import cclutParams
+from L1Trigger.CSCTriggerPrimitives.params.gemcscParams import gemcscPSets
 from L1Trigger.CSCTriggerPrimitives.params.showerParams import showerPSet
 
 cscTriggerPrimitiveDigis = cms.EDProducer(
@@ -20,6 +22,7 @@ cscTriggerPrimitiveDigis = cms.EDProducer(
     alctPSets,
     clctPSets,
     tmbPSets,
+    gemcscPSets,
 
     ## lookup tables for Run-3
     cclutParams.clone(),
@@ -69,8 +72,7 @@ run3_common.toModify( cscTriggerPrimitiveDigis,
 from Configuration.Eras.Modifier_run3_GEM_cff import run3_GEM
 run3_GEM.toModify( cscTriggerPrimitiveDigis,
                    GEMPadDigiClusterProducer = cms.InputTag("simMuonGEMPadDigiClusters"),
-                   commonParam = dict(runME11ILT = True),
-                   copadParamGE11 = auxPSets.copadParamGE11.clone()
+                   commonParam = dict(runME11ILT = True)
 )
 
 ## GEM-CSC ILT in ME2/1
@@ -81,6 +83,5 @@ phase2_muon.toModify( cscTriggerPrimitiveDigis,
                                          runME21ILT = True,
                                          runME31Up = True,
                                          runME41Up = True,
-                                         enableAlctPhase2 = True),
-                      copadParamGE21 = auxPSets.copadParamGE21.clone()
+                                         enableAlctPhase2 = True)
 )

--- a/L1Trigger/CSCTriggerPrimitives/python/params/auxiliaryParams.py
+++ b/L1Trigger/CSCTriggerPrimitives/python/params/auxiliaryParams.py
@@ -52,20 +52,8 @@ mpcParamRun2 = mpcParamRun1.clone(
     maxStubs = 18,
 )
 
-# GEM coincidence pad processors
-copadParamGE11 = cms.PSet(
-    verbosity = cms.uint32(0),
-    maxDeltaPad = cms.uint32(4),
-    maxDeltaRoll = cms.uint32(1),
-    maxDeltaBX = cms.uint32(0)
-)
-
-copadParamGE21 = copadParamGE11.clone()
-
 auxPSets = cms.PSet(
     commonParam = commonParam.clone(),
     mpcParamRun1 = mpcParamRun1.clone(),
     mpcParamRun2 = mpcParamRun2.clone(),
-    copadParamGE11 = copadParamGE11.clone(),
-    copadParamGE21 = copadParamGE21.clone()
 )

--- a/L1Trigger/CSCTriggerPrimitives/python/params/cclutParams.py
+++ b/L1Trigger/CSCTriggerPrimitives/python/params/cclutParams.py
@@ -3,24 +3,24 @@ import FWCore.ParameterSet.Config as cms
 ## LUTs for the Run-3 CSC trigger
 cclutParams = cms.PSet(
     positionLUTFiles = cms.vstring(
-        "L1Trigger/CSCTriggerPrimitives/data/CSCComparatorCodePosOffsetLUT_pat0_v1.txt",
-        "L1Trigger/CSCTriggerPrimitives/data/CSCComparatorCodePosOffsetLUT_pat1_v1.txt",
-        "L1Trigger/CSCTriggerPrimitives/data/CSCComparatorCodePosOffsetLUT_pat2_v1.txt",
-        "L1Trigger/CSCTriggerPrimitives/data/CSCComparatorCodePosOffsetLUT_pat3_v1.txt",
-        "L1Trigger/CSCTriggerPrimitives/data/CSCComparatorCodePosOffsetLUT_pat4_v1.txt"
+        "L1Trigger/CSCTriggerPrimitives/data/CCLUT/CSCComparatorCodePosOffsetLUT_pat0_v1.txt",
+        "L1Trigger/CSCTriggerPrimitives/data/CCLUT/CSCComparatorCodePosOffsetLUT_pat1_v1.txt",
+        "L1Trigger/CSCTriggerPrimitives/data/CCLUT/CSCComparatorCodePosOffsetLUT_pat2_v1.txt",
+        "L1Trigger/CSCTriggerPrimitives/data/CCLUT/CSCComparatorCodePosOffsetLUT_pat3_v1.txt",
+        "L1Trigger/CSCTriggerPrimitives/data/CCLUT/CSCComparatorCodePosOffsetLUT_pat4_v1.txt"
     ),
     slopeLUTFiles = cms.vstring(
-        "L1Trigger/CSCTriggerPrimitives/data/CSCComparatorCodeSlopeLUT_pat0_v1.txt",
-        "L1Trigger/CSCTriggerPrimitives/data/CSCComparatorCodeSlopeLUT_pat1_v1.txt",
-        "L1Trigger/CSCTriggerPrimitives/data/CSCComparatorCodeSlopeLUT_pat2_v1.txt",
-        "L1Trigger/CSCTriggerPrimitives/data/CSCComparatorCodeSlopeLUT_pat3_v1.txt",
-        "L1Trigger/CSCTriggerPrimitives/data/CSCComparatorCodeSlopeLUT_pat4_v1.txt"
+        "L1Trigger/CSCTriggerPrimitives/data/CCLUT/CSCComparatorCodeSlopeLUT_pat0_v1.txt",
+        "L1Trigger/CSCTriggerPrimitives/data/CCLUT/CSCComparatorCodeSlopeLUT_pat1_v1.txt",
+        "L1Trigger/CSCTriggerPrimitives/data/CCLUT/CSCComparatorCodeSlopeLUT_pat2_v1.txt",
+        "L1Trigger/CSCTriggerPrimitives/data/CCLUT/CSCComparatorCodeSlopeLUT_pat3_v1.txt",
+        "L1Trigger/CSCTriggerPrimitives/data/CCLUT/CSCComparatorCodeSlopeLUT_pat4_v1.txt"
     ),
     patternConversionLUTFiles = cms.vstring(
-        "L1Trigger/CSCTriggerPrimitives/data/CSCComparatorCodePatternConversionLUT_pat0_v1.txt",
-        "L1Trigger/CSCTriggerPrimitives/data/CSCComparatorCodePatternConversionLUT_pat1_v1.txt",
-        "L1Trigger/CSCTriggerPrimitives/data/CSCComparatorCodePatternConversionLUT_pat2_v1.txt",
-        "L1Trigger/CSCTriggerPrimitives/data/CSCComparatorCodePatternConversionLUT_pat3_v1.txt",
-        "L1Trigger/CSCTriggerPrimitives/data/CSCComparatorCodePatternConversionLUT_pat4_v1.txt"
+        "L1Trigger/CSCTriggerPrimitives/data/CCLUT/CSCComparatorCodePatternConversionLUT_pat0_v1.txt",
+        "L1Trigger/CSCTriggerPrimitives/data/CCLUT/CSCComparatorCodePatternConversionLUT_pat1_v1.txt",
+        "L1Trigger/CSCTriggerPrimitives/data/CCLUT/CSCComparatorCodePatternConversionLUT_pat2_v1.txt",
+        "L1Trigger/CSCTriggerPrimitives/data/CCLUT/CSCComparatorCodePatternConversionLUT_pat3_v1.txt",
+        "L1Trigger/CSCTriggerPrimitives/data/CCLUT/CSCComparatorCodePatternConversionLUT_pat4_v1.txt"
     ),
 )

--- a/L1Trigger/CSCTriggerPrimitives/python/params/gemcscParams.py
+++ b/L1Trigger/CSCTriggerPrimitives/python/params/gemcscParams.py
@@ -1,0 +1,80 @@
+import FWCore.ParameterSet.Config as cms
+
+# GEM coincidence pad processors
+copadParamGE11 = cms.PSet(
+    verbosity = cms.uint32(0),
+    maxDeltaPad = cms.uint32(4),
+    maxDeltaRoll = cms.uint32(1),
+    maxDeltaBX = cms.uint32(0)
+)
+
+copadParamGE21 = copadParamGE11.clone()
+
+## LUTs for the Run-3 GEM-CSC integrated local trigger
+gemcscParams = cms.PSet(
+
+    ## convert pad number to 1/2-strip in ME1a
+    padToHsME1aFiles = cms.vstring(
+        "L1Trigger/CSCTriggerPrimitives/data/GEMCSC/GEMCSCLUT_pad_hs_ME1a_even.txt",
+        "L1Trigger/CSCTriggerPrimitives/data/GEMCSC/GEMCSCLUT_pad_hs_ME1a_odd.txt",
+    ),
+    ## convert pad number to 1/2-strip in ME1b
+    padToHsME1bFiles = cms.vstring(
+        "L1Trigger/CSCTriggerPrimitives/data/GEMCSC/GEMCSCLUT_pad_hs_ME1b_even.txt",
+        "L1Trigger/CSCTriggerPrimitives/data/GEMCSC/GEMCSCLUT_pad_hs_ME1b_odd.txt",
+    ),
+    ## convert pad number to 1/2-strip in ME21
+    padToHsME21Files = cms.vstring(
+        "L1Trigger/CSCTriggerPrimitives/data/GEMCSC/GEMCSCLUT_pad_hs_ME21_even.txt",
+        "L1Trigger/CSCTriggerPrimitives/data/GEMCSC/GEMCSCLUT_pad_hs_ME21_odd.txt",
+    ),
+    ## convert pad number to 1/8-strip in ME1a
+    padToEsME1aFiles = cms.vstring(
+        "L1Trigger/CSCTriggerPrimitives/data/GEMCSC/GEMCSCLUT_pad_es_ME1a_even.txt",
+        "L1Trigger/CSCTriggerPrimitives/data/GEMCSC/GEMCSCLUT_pad_es_ME1a_odd.txt",
+    ),
+    ## convert pad number to 1/8-strip in ME1b
+    padToEsME1bFiles = cms.vstring(
+        "L1Trigger/CSCTriggerPrimitives/data/GEMCSC/GEMCSCLUT_pad_es_ME1b_even.txt",
+        "L1Trigger/CSCTriggerPrimitives/data/GEMCSC/GEMCSCLUT_pad_es_ME1b_odd.txt",
+    ),
+    ## convert pad number to 1/8-strip in ME21
+    padToEsME21Files = cms.vstring(
+        "L1Trigger/CSCTriggerPrimitives/data/GEMCSC/GEMCSCLUT_pad_es_ME21_even.txt",
+        "L1Trigger/CSCTriggerPrimitives/data/GEMCSC/GEMCSCLUT_pad_es_ME21_odd.txt",
+    ),
+    ## convert eta partition to minimum wiregroup in ME11
+    rollToMinWgME11Files = cms.vstring(
+        "L1Trigger/CSCTriggerPrimitives/data/GEMCSC/GEMCSCLUT_roll_l1_min_wg_ME11_even.txt",
+        "L1Trigger/CSCTriggerPrimitives/data/GEMCSC/GEMCSCLUT_roll_l1_min_wg_ME11_odd.txt",
+        "L1Trigger/CSCTriggerPrimitives/data/GEMCSC/GEMCSCLUT_roll_l2_min_wg_ME11_even.txt",
+        "L1Trigger/CSCTriggerPrimitives/data/GEMCSC/GEMCSCLUT_roll_l2_min_wg_ME11_odd.txt",
+    ),
+    ## convert eta partition to maximum wiregroup in ME11
+    rollToMaxWgME11Files = cms.vstring(
+        "L1Trigger/CSCTriggerPrimitives/data/GEMCSC/GEMCSCLUT_roll_l1_max_wg_ME11_even.txt",
+        "L1Trigger/CSCTriggerPrimitives/data/GEMCSC/GEMCSCLUT_roll_l1_max_wg_ME11_odd.txt",
+        "L1Trigger/CSCTriggerPrimitives/data/GEMCSC/GEMCSCLUT_roll_l2_max_wg_ME11_even.txt",
+        "L1Trigger/CSCTriggerPrimitives/data/GEMCSC/GEMCSCLUT_roll_l2_max_wg_ME11_odd.txt",
+    ),
+     ## convert eta partition to minimum wiregroup in ME21
+    rollToMinWgME21Files = cms.vstring(
+        "L1Trigger/CSCTriggerPrimitives/data/GEMCSC/GEMCSCLUT_roll_l1_min_wg_ME21_even.txt",
+        "L1Trigger/CSCTriggerPrimitives/data/GEMCSC/GEMCSCLUT_roll_l1_min_wg_ME21_odd.txt",
+        "L1Trigger/CSCTriggerPrimitives/data/GEMCSC/GEMCSCLUT_roll_l2_min_wg_ME21_even.txt",
+        "L1Trigger/CSCTriggerPrimitives/data/GEMCSC/GEMCSCLUT_roll_l2_min_wg_ME21_odd.txt",
+    ),
+    ## convert eta partition to maximum wiregroup in ME21
+    rollToMaxWgME21Files = cms.vstring(
+        "L1Trigger/CSCTriggerPrimitives/data/GEMCSC/GEMCSCLUT_roll_l1_max_wg_ME21_even.txt",
+        "L1Trigger/CSCTriggerPrimitives/data/GEMCSC/GEMCSCLUT_roll_l1_max_wg_ME21_odd.txt",
+        "L1Trigger/CSCTriggerPrimitives/data/GEMCSC/GEMCSCLUT_roll_l2_max_wg_ME21_even.txt",
+        "L1Trigger/CSCTriggerPrimitives/data/GEMCSC/GEMCSCLUT_roll_l2_max_wg_ME21_odd.txt",
+    ),
+)
+
+gemcscPSets = cms.PSet(
+    copadParamGE11 = copadParamGE11.clone(),
+    copadParamGE21 = copadParamGE21.clone(),
+    gemcscParams = gemcscParams.clone()
+)

--- a/L1Trigger/CSCTriggerPrimitives/python/params/tmbParams.py
+++ b/L1Trigger/CSCTriggerPrimitives/python/params/tmbParams.py
@@ -115,9 +115,26 @@ tmbPhase2GE21 = tmbPhase2.clone(
     promoteCLCTGEMquality = cms.bool(True),
 )
 
+## LUTs to map wiregroup onto min and max half-strip number that it crosses in ME1/1
+wgCrossHsME11Params = cms.PSet(
+    wgCrossHsME1aFiles = cms.vstring(
+        "L1Trigger/CSCTriggerPrimitives/data/ME11/CSCLUT_wg_min_hs_ME1a.txt",
+        "L1Trigger/CSCTriggerPrimitives/data/ME11/CSCLUT_wg_max_hs_ME1a.txt",
+    ),
+    wgCrossHsME1aGangedFiles = cms.vstring(
+        "L1Trigger/CSCTriggerPrimitives/data/ME11/CSCLUT_wg_min_hs_ME1a_ganged.txt",
+        "L1Trigger/CSCTriggerPrimitives/data/ME11/CSCLUT_wg_max_hs_ME1a_ganged.txt",
+    ),
+    wgCrossHsME1bFiles = cms.vstring(
+        "L1Trigger/CSCTriggerPrimitives/data/ME11/CSCLUT_wg_min_hs_ME1b.txt",
+        "L1Trigger/CSCTriggerPrimitives/data/ME11/CSCLUT_wg_max_hs_ME1b.txt",
+    )
+)
+
 tmbPSets = cms.PSet(
     tmbPhase1 = tmbPhase1.clone(),
     tmbPhase2 = tmbPhase2.clone(),
     tmbPhase2GE11 = tmbPhase2GE11.clone(),
     tmbPhase2GE21 = tmbPhase2GE21.clone(),
+    wgCrossHsME11Params = wgCrossHsME11Params.clone(),
 )

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCALCTCrossCLCT.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCALCTCrossCLCT.cc
@@ -1,0 +1,84 @@
+#include "L1Trigger/CSCTriggerPrimitives/interface/CSCALCTCrossCLCT.h"
+#include "L1Trigger/CSCTriggerPrimitives/interface/CSCLUTReader.h"
+#include "DataFormats/CSCDigi/interface/CSCConstants.h"
+#include "DataFormats/CSCDigi/interface/CSCALCTDigi.h"
+#include "DataFormats/CSCDigi/interface/CSCCLCTDigi.h"
+
+CSCALCTCrossCLCT::CSCALCTCrossCLCT(unsigned endcap, unsigned station, unsigned ring, bool isganged, const edm::ParameterSet& luts)
+    : endcap_(endcap), station_(station), ring_(ring), isganged_(isganged) {
+  wgCrossHsME1aFiles_ = luts.getParameter<std::vector<std::string>>("wgCrossHsME1aFiles");
+  wgCrossHsME1aGangedFiles_ = luts.getParameter<std::vector<std::string>>("wgCrossHsME1aGangedFiles");
+  wgCrossHsME1bFiles_ = luts.getParameter<std::vector<std::string>>("wgCrossHsME1bFiles");
+
+  wg_cross_min_hs_ME1a_ = std::make_unique<CSCLUTReader>(wgCrossHsME1aFiles_[0]);
+  wg_cross_max_hs_ME1a_ = std::make_unique<CSCLUTReader>(wgCrossHsME1aFiles_[1]);
+  wg_cross_min_hs_ME1a_ganged_ = std::make_unique<CSCLUTReader>(wgCrossHsME1aGangedFiles_[0]);
+  wg_cross_max_hs_ME1a_ganged_ = std::make_unique<CSCLUTReader>(wgCrossHsME1aGangedFiles_[1]);
+  wg_cross_min_hs_ME1b_ = std::make_unique<CSCLUTReader>(wgCrossHsME1bFiles_[0]);
+  wg_cross_max_hs_ME1b_ = std::make_unique<CSCLUTReader>(wgCrossHsME1bFiles_[1]);
+}
+
+bool CSCALCTCrossCLCT::doesALCTCrossCLCT(const CSCALCTDigi& a, const CSCCLCTDigi& c, bool ignoreAlctCrossClct) const {
+  // both need to valid
+  if (!c.isValid() || !a.isValid()) {
+    return false;
+  }
+
+  // when non-overlapping half-strips and wiregroups don't matter
+  if (ignoreAlctCrossClct)
+    return true;
+
+  // overlap only needs to be considered for ME1/1
+  if (station_ == 1 and ring_ == 1) {
+    return doesWiregroupCrossHalfStrip(a.getKeyWG(), c.getKeyStrip());
+  } else
+    return true;
+}
+
+bool CSCALCTCrossCLCT::doesWiregroupCrossHalfStrip(int wiregroup, int halfstrip) const {
+  const int min_hs_ME1a = wg_cross_min_hs_ME1a_->lookup(wiregroup);
+  const int max_hs_ME1a = wg_cross_max_hs_ME1a_->lookup(wiregroup);
+  const int min_hs_ME1a_ganged = wg_cross_min_hs_ME1a_ganged_->lookup(wiregroup);
+  const int max_hs_ME1a_ganged = wg_cross_max_hs_ME1a_ganged_->lookup(wiregroup);
+  const int min_hs_ME1b = wg_cross_min_hs_ME1b_->lookup(wiregroup);
+  const int max_hs_ME1b = wg_cross_max_hs_ME1b_->lookup(wiregroup);
+
+  // ME1/a half-strip starts at 128
+  if (halfstrip > CSCConstants::MAX_HALF_STRIP_ME1B) {
+    if (!isganged_) {
+      // wrap around ME11 HS number for -z endcap
+      if (endcap_ == 2) {
+        // first subtract 128
+        halfstrip -= 1 + CSCConstants::MAX_HALF_STRIP_ME1B;
+        // flip the HS
+        halfstrip = CSCConstants::MAX_HALF_STRIP_ME1A_UNGANGED - halfstrip;
+        // then add 128 again
+        halfstrip += 1 + CSCConstants::MAX_HALF_STRIP_ME1B;
+      }
+      return halfstrip >= min_hs_ME1a && halfstrip <= max_hs_ME1a;
+    }
+
+    else {
+      // wrap around ME11 HS number for -z endcap
+      if (endcap_ == 2) {
+        // first subtract 128
+        halfstrip -= 1 + CSCConstants::MAX_HALF_STRIP_ME1B;
+        // flip the HS
+        halfstrip = CSCConstants::MAX_HALF_STRIP_ME1A_GANGED - halfstrip;
+        // then add 128 again
+        halfstrip += 1 + CSCConstants::MAX_HALF_STRIP_ME1B;
+      }
+      return halfstrip >= min_hs_ME1a_ganged && halfstrip <= max_hs_ME1a_ganged;
+    }
+  }
+  // ME1/b half-strip ends at 127
+  else if (halfstrip <= CSCConstants::MAX_HALF_STRIP_ME1B) {
+    if (endcap_ == 2) {
+      halfstrip = CSCConstants::MAX_HALF_STRIP_ME1B - halfstrip;
+    }
+    return halfstrip >= min_hs_ME1b && halfstrip <= max_hs_ME1b;
+  }
+  // all other cases, return true
+  else
+    return true;
+}

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCALCTCrossCLCT.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCALCTCrossCLCT.cc
@@ -4,7 +4,8 @@
 #include "DataFormats/CSCDigi/interface/CSCALCTDigi.h"
 #include "DataFormats/CSCDigi/interface/CSCCLCTDigi.h"
 
-CSCALCTCrossCLCT::CSCALCTCrossCLCT(unsigned endcap, unsigned station, unsigned ring, bool isganged, const edm::ParameterSet& luts)
+CSCALCTCrossCLCT::CSCALCTCrossCLCT(
+    unsigned endcap, unsigned station, unsigned ring, bool isganged, const edm::ParameterSet& luts)
     : endcap_(endcap), station_(station), ring_(ring), isganged_(isganged) {
   wgCrossHsME1aFiles_ = luts.getParameter<std::vector<std::string>>("wgCrossHsME1aFiles");
   wgCrossHsME1aGangedFiles_ = luts.getParameter<std::vector<std::string>>("wgCrossHsME1aGangedFiles");

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCCathodeLCTProcessor.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCCathodeLCTProcessor.cc
@@ -92,9 +92,9 @@ CSCCathodeLCTProcessor::CSCCathodeLCTProcessor(unsigned endcap,
     patternConversionLUTFiles_ = conf.getParameter<std::vector<std::string>>("patternConversionLUTFiles");
 
     for (int i = 0; i < 5; ++i) {
-      lutpos_[i] = std::make_unique<CSCComparatorCodeLUT>(positionLUTFiles_[i]);
-      lutslope_[i] = std::make_unique<CSCComparatorCodeLUT>(slopeLUTFiles_[i]);
-      lutpatconv_[i] = std::make_unique<CSCComparatorCodeLUT>(patternConversionLUTFiles_[i]);
+      lutpos_[i] = std::make_unique<CSCLUTReader>(positionLUTFiles_[i]);
+      lutslope_[i] = std::make_unique<CSCLUTReader>(slopeLUTFiles_[i]);
+      lutpatconv_[i] = std::make_unique<CSCLUTReader>(patternConversionLUTFiles_[i]);
     }
   }
 

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCLUTReader.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCLUTReader.cc
@@ -1,8 +1,8 @@
-#include "L1Trigger/CSCTriggerPrimitives/interface/CSCComparatorCodeLUT.h"
+#include "L1Trigger/CSCTriggerPrimitives/interface/CSCLUTReader.h"
 #include "FWCore/Utilities/interface/Exception.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
-CSCComparatorCodeLUT::CSCComparatorCodeLUT(const std::string& fname)
+CSCLUTReader::CSCLUTReader(const std::string& fname)
     : nrBitsAddress_(0), nrBitsData_(0), addressMask_(0), dataMask_(0), data_(), m_codeInWidth(12), m_outWidth(32) {
   if (fname != std::string("")) {
     load(fname);
@@ -12,13 +12,13 @@ CSCComparatorCodeLUT::CSCComparatorCodeLUT(const std::string& fname)
 }
 
 // I/O functions
-void CSCComparatorCodeLUT::save(std::ofstream& output) { write(output); }
+void CSCLUTReader::save(std::ofstream& output) { write(output); }
 
-float CSCComparatorCodeLUT::data(unsigned int address) const {
+float CSCLUTReader::data(unsigned int address) const {
   return (address & addressMask_) < data_.size() ? data_[address] : 0;
 }
 
-int CSCComparatorCodeLUT::load(const std::string& inFileName) {
+int CSCLUTReader::load(const std::string& inFileName) {
   std::ifstream fstream;
   fstream.open(edm::FileInPath(inFileName.c_str()).fullPath());
   if (!fstream.good()) {
@@ -33,14 +33,14 @@ int CSCComparatorCodeLUT::load(const std::string& inFileName) {
   return readCode;
 }
 
-float CSCComparatorCodeLUT::lookup(int code) const {
+float CSCLUTReader::lookup(int code) const {
   if (m_initialized) {
     return lookupPacked(code);
   }
   return 0;
 }
 
-float CSCComparatorCodeLUT::lookupPacked(const int input) const {
+float CSCLUTReader::lookupPacked(const int input) const {
   if (m_initialized) {
     return data((unsigned int)input);
   }
@@ -48,7 +48,7 @@ float CSCComparatorCodeLUT::lookupPacked(const int input) const {
   return 0;
 }
 
-void CSCComparatorCodeLUT::initialize() {
+void CSCLUTReader::initialize() {
   if (empty()) {
     std::stringstream stream;
     stream << "#<header> V1 " << m_codeInWidth << " " << m_outWidth << " </header> " << std::endl;
@@ -61,12 +61,12 @@ void CSCComparatorCodeLUT::initialize() {
   m_initialized = true;
 }
 
-unsigned CSCComparatorCodeLUT::checkedInput(unsigned in, unsigned maxWidth) const {
+unsigned CSCLUTReader::checkedInput(unsigned in, unsigned maxWidth) const {
   unsigned maxIn = (1 << maxWidth) - 1;
   return (in < maxIn ? in : maxIn);
 }
 
-int CSCComparatorCodeLUT::read(std::istream& stream) {
+int CSCLUTReader::read(std::istream& stream) {
   data_.clear();
 
   int readHeaderCode = readHeader(stream);
@@ -120,18 +120,18 @@ int CSCComparatorCodeLUT::read(std::istream& stream) {
   return SUCCESS;
 }
 
-void CSCComparatorCodeLUT::write(std::ostream& stream) const {
+void CSCLUTReader::write(std::ostream& stream) const {
   stream << "#<header> V1 " << nrBitsAddress_ << " " << nrBitsData_ << " </header> " << std::endl;
   for (unsigned int address = 0; address < data_.size(); address++) {
     stream << (address & addressMask_) << " " << data(address) << std::endl;
   }
 }
 
-unsigned int CSCComparatorCodeLUT::maxSize() const {
+unsigned int CSCLUTReader::maxSize() const {
   return addressMask_ == std::numeric_limits<unsigned int>::max() ? addressMask_ : addressMask_ + 1;
 }
 
-int CSCComparatorCodeLUT::readHeader(std::istream& stream) {
+int CSCLUTReader::readHeader(std::istream& stream) {
   int startPos = stream.tellg();  //we are going to reset to this position before we exit
   std::string line;
   while (std::getline(stream, line)) {

--- a/L1Trigger/CSCTriggerPrimitives/src/GEMInternalCluster.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/GEMInternalCluster.cc
@@ -1,0 +1,45 @@
+#include "L1Trigger/CSCTriggerPrimitives/interface/GEMInternalCluster.h"
+#include "DataFormats/CSCDigi/interface/CSCConstants.h"
+
+GEMInternalCluster::GEMInternalCluster(const GEMDetId& id,
+                                       const GEMPadDigiCluster& cluster1,
+                                       const GEMPadDigiCluster& cluster2) {
+  id_ = id;
+
+  if (cluster1.isValid()) {
+    cl1_ = cluster1;
+    bx_ = cluster1.bx() + CSCConstants::LCT_CENTRAL_BX;
+    layer1_pad_ = cluster1.pads()[0];
+    layer1_size_ = cluster1.pads().size();
+  }
+  if (cluster2.isValid()) {
+    cl2_ = cluster2;
+    bx_ = cluster2.bx() + CSCConstants::LCT_CENTRAL_BX;
+    layer2_pad_ = cluster2.pads()[0];
+    layer2_size_ = cluster2.pads().size();
+  }
+
+  if (cluster1.isValid() and cluster2.isValid()) {
+    bx_ = cluster1.bx() + CSCConstants::LCT_CENTRAL_BX;
+    isCoincidence_ = true;
+  }
+
+  layer1_first_es_ = -1;
+  layer1_last_es_ = -1;
+  layer2_first_es_ = -1;
+  layer2_last_es_ = -1;
+  layer1_first_es_me1a_ = -1;
+  layer1_last_es_me1a_ = -1;
+  layer2_first_es_me1a_ = -1;
+  layer2_last_es_me1a_ = -1;
+  min_wg_ = -1;
+  max_wg_ = -1;
+}
+
+bool GEMInternalCluster::has_cluster(const GEMPadDigiCluster& cluster) const {
+  return cl1_ == cluster or cl2_ == cluster;
+}
+
+bool GEMInternalCluster::operator==(const GEMInternalCluster& cluster) const {
+  return id_ == cluster.id() and cl1_ == cluster.cl1() and cl2_ == cluster.cl2();
+}

--- a/L1Trigger/CSCTriggerPrimitives/src/LCTQualityAssignment.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/LCTQualityAssignment.cc
@@ -1,0 +1,231 @@
+#include "L1Trigger/CSCTriggerPrimitives/interface/LCTQualityAssignment.h"
+#include "L1Trigger/CSCTriggerPrimitives/interface/GEMInternalCluster.h"
+#include "DataFormats/CSCDigi/interface/CSCConstants.h"
+#include "DataFormats/CSCDigi/interface/CSCALCTDigi.h"
+#include "DataFormats/CSCDigi/interface/CSCCLCTDigi.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+LCTQualityAssignment::LCTQualityAssignment(bool isRun3, unsigned station) : isRun3_(isRun3), station_(station) {}
+
+// 4-bit LCT quality number.
+unsigned LCTQualityAssignment::findQualityRun2(const CSCALCTDigi& aLCT, const CSCCLCTDigi& cLCT) const {
+  LCT_QualityRun2 qual = LCT_QualityRun2::INVALID;
+
+  // Either ALCT or CLCT is invalid
+  if (!(aLCT.isValid()) || !(cLCT.isValid())) {
+    // No CLCT
+    if (aLCT.isValid() && !(cLCT.isValid()))
+      qual = LCT_QualityRun2::NO_CLCT;
+
+    // No ALCT
+    else if (!(aLCT.isValid()) && cLCT.isValid())
+      qual = LCT_QualityRun2::NO_ALCT;
+
+    // No ALCT and no CLCT
+    else
+      qual = LCT_QualityRun2::INVALID;
+  }
+  // Both ALCT and CLCT are valid
+  else {
+    const int pattern(cLCT.getPattern());
+
+    // Layer-trigger in CLCT
+    if (pattern == 1)
+      qual = LCT_QualityRun2::CLCT_LAYER_TRIGGER;
+
+    // Multi-layer pattern in CLCT
+    else {
+      // ALCT quality is the number of layers hit minus 3.
+      const bool a4(aLCT.getQuality() >= 1);
+
+      // CLCT quality is the number of layers hit.
+      const bool c4(cLCT.getQuality() >= 4);
+
+      // quality = 4; "reserved for low-quality muons in future"
+
+      // marginal anode and cathode
+      if (!a4 && !c4)
+        qual = LCT_QualityRun2::MARGINAL_ANODE_CATHODE;
+
+      // HQ anode, but marginal cathode
+      else if (a4 && !c4)
+        qual = LCT_QualityRun2::HQ_ANODE_MARGINAL_CATHODE;
+
+      // HQ cathode, but marginal anode
+      else if (!a4 && c4)
+        qual = LCT_QualityRun2::HQ_CATHODE_MARGINAL_ANODE;
+
+      // HQ muon, but accelerator ALCT
+      else if (a4 && c4) {
+        if (aLCT.getAccelerator())
+          qual = LCT_QualityRun2::HQ_ACCEL_ALCT;
+
+        else {
+          // quality =  9; "reserved for HQ muons with future patterns
+          // quality = 10; "reserved for HQ muons with future patterns
+
+          // High quality muons are determined by their CLCT pattern
+          if (pattern == 2 || pattern == 3)
+            qual = LCT_QualityRun2::HQ_PATTERN_2_3;
+
+          else if (pattern == 4 || pattern == 5)
+            qual = LCT_QualityRun2::HQ_PATTERN_4_5;
+
+          else if (pattern == 6 || pattern == 7)
+            qual = LCT_QualityRun2::HQ_PATTERN_6_7;
+
+          else if (pattern == 8 || pattern == 9)
+            qual = LCT_QualityRun2::HQ_PATTERN_8_9;
+
+          else if (pattern == 10)
+            qual = LCT_QualityRun2::HQ_PATTERN_10;
+
+          else {
+            edm::LogWarning("LCTQualityAssignment") << "findQualityRun2: Unexpected CLCT pattern id = " << pattern;
+            qual = LCT_QualityRun2::INVALID;
+          }
+        }
+      }
+    }
+  }
+  return static_cast<unsigned>(qual);
+}
+
+// 2-bit LCT quality number for Run-3
+unsigned LCTQualityAssignment::findQualityRun3(const CSCALCTDigi& aLCT, const CSCCLCTDigi& cLCT) const {
+  LCT_QualityRun3 qual = LCT_QualityRun3::INVALID;
+
+  // Run-3 definition
+  if (!(aLCT.isValid()) and !(cLCT.isValid())) {
+    qual = LCT_QualityRun3::INVALID;
+  }
+  // use number of layers on each as indicator
+  else {
+    bool a4 = (aLCT.getQuality() >= 1);
+    bool a5 = (aLCT.getQuality() >= 1);
+    bool a6 = (aLCT.getQuality() >= 1);
+
+    bool c4 = (cLCT.getQuality() >= 4);
+    bool c5 = (cLCT.getQuality() >= 4);
+    bool c6 = (cLCT.getQuality() >= 4);
+    if (a6 or c6)
+      qual = LCT_QualityRun3::HighQ;
+    else if (a5 or c5)
+      qual = LCT_QualityRun3::MedQ;
+    else if (a4 or c4)
+      qual = LCT_QualityRun3::LowQ;
+  }
+  return static_cast<unsigned>(qual);
+}
+
+unsigned LCTQualityAssignment::findQualityGEMv1(const CSCALCTDigi& aLCT, const CSCCLCTDigi& cLCT, int gemlayers) const {
+  LCT_QualityRun2 qual = LCT_QualityRun2::INVALID;
+
+  // Either ALCT or CLCT is invalid
+  if (!(aLCT.isValid()) || !(cLCT.isValid())) {
+    // No CLCT
+    if (aLCT.isValid() && !(cLCT.isValid()))
+      qual = LCT_QualityRun2::NO_CLCT;
+
+    // No ALCT
+    else if (!(aLCT.isValid()) && cLCT.isValid())
+      qual = LCT_QualityRun2::NO_ALCT;
+
+    // No ALCT and no CLCT
+    else
+      qual = LCT_QualityRun2::INVALID;
+  }
+  // Both ALCT and CLCT are valid
+  else {
+    const int pattern(cLCT.getPattern());
+
+    // Layer-trigger in CLCT
+    if (pattern == 1)
+      qual = LCT_QualityRun2::CLCT_LAYER_TRIGGER;
+
+    // Multi-layer pattern in CLCT
+    else {
+      // ALCT quality is the number of layers hit minus 3.
+      bool a4 = false;
+
+      // Case of ME11 with GEMs: require 4 layers for ALCT
+      if (station_ == 1)
+        a4 = aLCT.getQuality() >= 1;
+
+      // Case of ME21 with GEMs: require 4 layers for ALCT+GEM
+      if (station_ == 2)
+        a4 = aLCT.getQuality() + gemlayers >= 1;
+
+      // CLCT quality is the number of layers hit.
+      const bool c4((cLCT.getQuality() >= 4) or (cLCT.getQuality() >= 3 and gemlayers >= 1));
+
+      // quality = 4; "reserved for low-quality muons in future"
+
+      // marginal anode and cathode
+      if (!a4 && !c4)
+        qual = LCT_QualityRun2::MARGINAL_ANODE_CATHODE;
+
+      // HQ anode, but marginal cathode
+      else if (a4 && !c4)
+        qual = LCT_QualityRun2::HQ_ANODE_MARGINAL_CATHODE;
+
+      // HQ cathode, but marginal anode
+      else if (!a4 && c4)
+        qual = LCT_QualityRun2::HQ_CATHODE_MARGINAL_ANODE;
+
+      // HQ muon, but accelerator ALCT
+      else if (a4 && c4) {
+        if (aLCT.getAccelerator())
+          qual = LCT_QualityRun2::HQ_ACCEL_ALCT;
+
+        else {
+          // quality =  9; "reserved for HQ muons with future patterns
+          // quality = 10; "reserved for HQ muons with future patterns
+
+          // High quality muons are determined by their CLCT pattern
+          if (pattern == 2 || pattern == 3)
+            qual = LCT_QualityRun2::HQ_PATTERN_2_3;
+
+          else if (pattern == 4 || pattern == 5)
+            qual = LCT_QualityRun2::HQ_PATTERN_4_5;
+
+          else if (pattern == 6 || pattern == 7)
+            qual = LCT_QualityRun2::HQ_PATTERN_6_7;
+
+          else if (pattern == 8 || pattern == 9)
+            qual = LCT_QualityRun2::HQ_PATTERN_8_9;
+
+          else if (pattern == 10)
+            qual = LCT_QualityRun2::HQ_PATTERN_10;
+
+          else {
+            edm::LogWarning("CSCGEMMotherboard") << "findQualityGEMv1: Unexpected CLCT pattern id = " << pattern;
+            qual = LCT_QualityRun2::INVALID;
+          }
+        }
+      }
+    }
+  }
+  return static_cast<unsigned>(qual);
+}
+
+unsigned LCTQualityAssignment::findQualityGEMv2(const CSCALCTDigi& aLCT, const CSCCLCTDigi& cLCT, int gemlayers) const {
+  LCT_QualityRun3GEM qual = LCT_QualityRun3GEM::INVALID;
+
+  // ALCT and CLCT invalid
+  if (!(aLCT.isValid()) and !(cLCT.isValid())) {
+    qual = LCT_QualityRun3GEM::INVALID;
+  } else if (!aLCT.isValid() && cLCT.isValid() and gemlayers == 2) {
+    qual = LCT_QualityRun3GEM::CLCT_2GEM;
+  } else if (aLCT.isValid() && !cLCT.isValid() and gemlayers == 2) {
+    qual = LCT_QualityRun3GEM::ALCT_2GEM;
+  } else if (aLCT.isValid() && cLCT.isValid()) {
+    if (gemlayers == 0)
+      qual = LCT_QualityRun3GEM::ALCT_CLCT;
+    else if (gemlayers == 1)
+      qual = LCT_QualityRun3GEM::ALCT_CLCT_1GEM_GEMCSCBend;
+    else if (gemlayers == 2)
+      qual = LCT_QualityRun3GEM::ALCT_CLCT_2GEM_GEMCSCBend;
+  }
+  return static_cast<unsigned>(qual);
+}


### PR DESCRIPTION
#### PR description:

Prep work for the Run-3 GEM-CSC integrated local trigger. This goes together with PR https://github.com/cms-data/L1Trigger-CSCTriggerPrimitives/pull/6.
* The lookup tables were organized into CCLUT, GEMCSC and ME11.
   * CCLUT: comparator code LUT algorithm that provides better position and bending resolution
   * GEMCSC: GEM-CSC integrated trigger
   * ME11: ME11 specific LUTs for ALCTs crossing with CLCTs
* `CSCComparatorCodeLUT` renamed to `CSCLUTReader` so we can reuse it for the GEM-CSC trigger
* Helper classes `CSCALCTCrossCLCT`, `GEMInternalCluster` and `LCTQualityAssignment` were added.
   * `CSCALCTCrossCLCT`: class that checks if an ALCT crosses with a CLCT. Not always the case for ME1/1. A lengthy description was added when this class would be used
   * `GEMInternalCluster`: transient container for `GEMPadDigiCluster` and a coincidence of two `GEMPadDigiCluster`s. We will shortly be doing the GEM-CSC matching based on `GEMPadDigiCluster` instead of `GEMPadDigi` and `GEMCoPadDigi`, like in the firmware. The emulator would no longer decluster into single pads. The `GEMInternalCluster` will eliminate much of the code duplication that exists now, and nearly all of the horrible function templating.
   * `LCTQualityAssignment`: class that holds the definitions for LCT quality in Run-2 and Run-3. Documented in DN-20-016. Idea is to unload this code from the TMB classes.

#### PR validation:

Tested with WF 11634.0. There should be no changes to any of the workflows.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
