### PR TITLE
Validation/RecoEgamma remove recomp histos from miniAOD Validation

### DIFF
--- a/Validation/RecoEgamma/plugins/ElectronMcMiniAODSignalValidator.cc
+++ b/Validation/RecoEgamma/plugins/ElectronMcMiniAODSignalValidator.cc
@@ -123,7 +123,6 @@ ElectronMcSignalValidatorMiniAOD::ElectronMcSignalValidatorMiniAOD(const edm::Pa
   h1_ele_photonRelativeIso_mAOD = nullptr;
   h1_ele_photonRelativeIso_mAOD_barrel = nullptr;
   h1_ele_photonRelativeIso_mAOD_endcaps = nullptr;
-
 }
 
 ElectronMcSignalValidatorMiniAOD::~ElectronMcSignalValidatorMiniAOD() {}
@@ -417,7 +416,6 @@ void ElectronMcSignalValidatorMiniAOD::bookHistograms(DQMStore::IBooker& iBooker
                                                           "photonRelativeIso_endcaps",
                                                           "Events",
                                                           "ELE_LOGY E1 P");
-
 }
 
 void ElectronMcSignalValidatorMiniAOD::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
@@ -558,7 +556,6 @@ void ElectronMcSignalValidatorMiniAOD::analyze(const edm::Event& iEvent, const e
               pt_ = elePtr->pt();
 
               okGsfFound = true;
-
             }
           }
         }

--- a/Validation/RecoEgamma/plugins/ElectronMcMiniAODSignalValidator.cc
+++ b/Validation/RecoEgamma/plugins/ElectronMcMiniAODSignalValidator.cc
@@ -25,14 +25,6 @@ ElectronMcSignalValidatorMiniAOD::ElectronMcSignalValidatorMiniAOD(const edm::Pa
   edm::ParameterSet histosSet = iConfig.getParameter<edm::ParameterSet>("histosCfg");
   edm::ParameterSet isolationSet = iConfig.getParameter<edm::ParameterSet>("isolationCfg");
 
-  //recomp
-  pfSumChargedHadronPtTmp_ =
-      consumes<edm::ValueMap<float> >(isolationSet.getParameter<edm::InputTag>("pfSumChargedHadronPtTmp"));  // iConfig
-  pfSumNeutralHadronEtTmp_ =
-      consumes<edm::ValueMap<float> >(isolationSet.getParameter<edm::InputTag>("pfSumNeutralHadronEtTmp"));  // iConfig
-  pfSumPhotonEtTmp_ =
-      consumes<edm::ValueMap<float> >(isolationSet.getParameter<edm::InputTag>("pfSumPhotonEtTmp"));  // iConfig
-
   maxPt_ = iConfig.getParameter<double>("MaxPt");
   maxAbsEta_ = iConfig.getParameter<double>("MaxAbsEta");
   deltaR_ = iConfig.getParameter<double>("DeltaR");
@@ -132,9 +124,6 @@ ElectronMcSignalValidatorMiniAOD::ElectronMcSignalValidatorMiniAOD(const edm::Pa
   h1_ele_photonRelativeIso_mAOD_barrel = nullptr;
   h1_ele_photonRelativeIso_mAOD_endcaps = nullptr;
 
-  h1_ele_chargedHadronRelativeIso_mAOD_recomp = nullptr;
-  h1_ele_neutralHadronRelativeIso_mAOD_recomp = nullptr;
-  h1_ele_photonRelativeIso_mAOD_recomp = nullptr;
 }
 
 ElectronMcSignalValidatorMiniAOD::~ElectronMcSignalValidatorMiniAOD() {}
@@ -429,34 +418,6 @@ void ElectronMcSignalValidatorMiniAOD::bookHistograms(DQMStore::IBooker& iBooker
                                                           "Events",
                                                           "ELE_LOGY E1 P");
 
-  // -- recomputed pflow over pT
-  h1_ele_chargedHadronRelativeIso_mAOD_recomp = bookH1withSumw2(iBooker,
-                                                                "chargedHadronRelativeIso_mAOD_recomp",
-                                                                "recomputed chargedHadronRelativeIso",
-                                                                100,
-                                                                0.0,
-                                                                2.,
-                                                                "chargedHadronRelativeIso",
-                                                                "Events",
-                                                                "ELE_LOGY E1 P");
-  h1_ele_neutralHadronRelativeIso_mAOD_recomp = bookH1withSumw2(iBooker,
-                                                                "neutralHadronRelativeIso_mAOD_recomp",
-                                                                "recomputed neutralHadronRelativeIso",
-                                                                100,
-                                                                0.0,
-                                                                2.,
-                                                                "neutralHadronRelativeIso",
-                                                                "Events",
-                                                                "ELE_LOGY E1 P");
-  h1_ele_photonRelativeIso_mAOD_recomp = bookH1withSumw2(iBooker,
-                                                         "photonRelativeIso_mAOD_recomp",
-                                                         "recomputed photonRelativeIso",
-                                                         100,
-                                                         0.0,
-                                                         2.,
-                                                         "photonRelativeIso",
-                                                         "Events",
-                                                         "ELE_LOGY E1 P");
 }
 
 void ElectronMcSignalValidatorMiniAOD::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
@@ -471,16 +432,6 @@ void ElectronMcSignalValidatorMiniAOD::analyze(const edm::Event& iEvent, const e
   iEvent.getByToken(mcTruthCollection_, genParticles);
 
   edm::Handle<pat::ElectronCollection> mergedElectrons;
-
-  //recomp
-  edm::Handle<edm::ValueMap<float> > pfSumChargedHadronPtTmp;
-  edm::Handle<edm::ValueMap<float> > pfSumNeutralHadronEtTmp;
-  edm::Handle<edm::ValueMap<float> > pfSumPhotonEtTmp; /**/
-
-  //recomp
-  iEvent.getByToken(pfSumChargedHadronPtTmp_, pfSumChargedHadronPtTmp);
-  iEvent.getByToken(pfSumNeutralHadronEtTmp_, pfSumNeutralHadronEtTmp);
-  iEvent.getByToken(pfSumPhotonEtTmp_, pfSumPhotonEtTmp); /**/
 
   edm::LogInfo("ElectronMcSignalValidatorMiniAOD::analyze")
       << "Treating event " << iEvent.id() << " with " << electrons.product()->size() << " electrons";
@@ -608,16 +559,6 @@ void ElectronMcSignalValidatorMiniAOD::analyze(const edm::Event& iEvent, const e
 
               okGsfFound = true;
 
-              if (i_elec == 0) {
-                sumChargedHadronPt_recomp = (*pfSumChargedHadronPtTmp)[elePtr];
-                relisoChargedHadronPt_recomp = sumChargedHadronPt_recomp / pt_;
-
-                sumNeutralHadronPt_recomp = (*pfSumNeutralHadronEtTmp)[elePtr];
-                relisoNeutralHadronPt_recomp = sumNeutralHadronPt_recomp / pt_;
-
-                sumPhotonPt_recomp = (*pfSumPhotonEtTmp)[elePtr];
-                relisoPhotonPt_recomp = sumPhotonPt_recomp / pt_; /**/
-              }
             }
           }
         }
@@ -699,12 +640,6 @@ void ElectronMcSignalValidatorMiniAOD::analyze(const edm::Event& iEvent, const e
                                                              one_over_pt);
           h1_ele_photonRelativeIso_mAOD_endcaps->Fill(bestGsfElectron.pfIsolationVariables().sumPhotonEt * one_over_pt);
         }
-        //if (i_elec==0){
-        // -- recomputed pflow over pT
-        h1_ele_chargedHadronRelativeIso_mAOD_recomp->Fill(relisoChargedHadronPt_recomp);
-        h1_ele_neutralHadronRelativeIso_mAOD_recomp->Fill(relisoNeutralHadronPt_recomp);
-        h1_ele_photonRelativeIso_mAOD_recomp->Fill(relisoPhotonPt_recomp);
-        //} /**/
       }
     }
     //} // end loop i_elec

--- a/Validation/RecoEgamma/plugins/ElectronMcMiniAODSignalValidator.h
+++ b/Validation/RecoEgamma/plugins/ElectronMcMiniAODSignalValidator.h
@@ -43,13 +43,6 @@ private:
   std::vector<int> matchingMotherIDs_;
   std::string outputInternalPath_;
 
-  float sumChargedHadronPt_recomp;
-  float sumNeutralHadronPt_recomp;
-  float sumPhotonPt_recomp;
-  float relisoChargedHadronPt_recomp;
-  float relisoNeutralHadronPt_recomp;
-  float relisoPhotonPt_recomp;
-
   // histos limits and binning
 
   int xyz_nbin;
@@ -139,9 +132,6 @@ private:
   MonitorElement *h1_ele_photonRelativeIso_mAOD_barrel;
   MonitorElement *h1_ele_photonRelativeIso_mAOD_endcaps;
 
-  MonitorElement *h1_ele_chargedHadronRelativeIso_mAOD_recomp;
-  MonitorElement *h1_ele_neutralHadronRelativeIso_mAOD_recomp;
-  MonitorElement *h1_ele_photonRelativeIso_mAOD_recomp;
 };
 
 #endif

--- a/Validation/RecoEgamma/plugins/ElectronMcMiniAODSignalValidator.h
+++ b/Validation/RecoEgamma/plugins/ElectronMcMiniAODSignalValidator.h
@@ -131,7 +131,6 @@ private:
   MonitorElement *h1_ele_photonRelativeIso_mAOD;
   MonitorElement *h1_ele_photonRelativeIso_mAOD_barrel;
   MonitorElement *h1_ele_photonRelativeIso_mAOD_endcaps;
-
 };
 
 #endif

--- a/Validation/RecoEgamma/test/ElectronMcSignalHistosMiniAOD.txt
+++ b/Validation/RecoEgamma/test/ElectronMcSignalHistosMiniAOD.txt
@@ -61,9 +61,3 @@ ElectronMcSignalValidatorMiniAOD/h_ele_photonRelativeIso_mAOD           1 1 0 0
 ElectronMcSignalValidatorMiniAOD/h_ele_photonRelativeIso_mAOD_barrel    1 1 0 0
 ElectronMcSignalValidatorMiniAOD/h_ele_photonRelativeIso_mAOD_endcaps   1 1 1 1
 
-recomputed pflow over pT
-
-ElectronMcSignalValidatorMiniAOD/h_ele_chargedHadronRelativeIso_mAOD_recomp           1 1 1 0
-ElectronMcSignalValidatorMiniAOD/h_ele_neutralHadronRelativeIso_mAOD_recomp           1 1 1 0
-ElectronMcSignalValidatorMiniAOD/h_ele_photonRelativeIso_mAOD_recomp                  1 1 1 0
-


### PR DESCRIPTION
#### PR description:
Removing of unused recomp plots in miniAOD EGamma Validation (Validation/RecoEgamma/plugins/ElectronMcMiniAODSignalValidator.cc/h). Those histograms are comparing the PF-isolation computed at the RECO-level and that re-computed on-the-fly from the PF candidates (this comparison is done with a different plotting tool, not in DQM). 
These histograms were not much useful and we drop them.

<!-- Please replace this text with a description of the feature proposed or problem addressed, specifying:
  - what changes are expected in the output if any, 
  - what other PRs or externals it depends upon if any,
  - link to any additional material useful to provide a documentation for this PR (slides, JIRA tickets, related pull requestes, hypernews, TWiki or Indico pages)  -->

#### PR validation:
compilation is OK, basics tests (scram b runtests or local tests) are OK too.
runTheMatrix.py -l limited -i all --ibeos tests are fine (38 37 36 27 17 4 1 1 1 tests passed, 0 0 0 0 0 0 0 0 0 failed).
here is the run-log :
[runall-report-step123-.log](https://github.com/cms-sw/cmssw/files/6398417/runall-report-step123-.log)

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

<!-- Please replace this text with any link to  -->

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch -> OK.
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html) -> OK.
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html) -> OK.

@beaudett 