### PR TITLE
Update for cmsswSequenceInfo without extra sequences

### DIFF
--- a/DQMOffline/Configuration/scripts/cmsswSequenceInfo.py
+++ b/DQMOffline/Configuration/scripts/cmsswSequenceInfo.py
@@ -39,7 +39,7 @@ def inspectsequence(seq):
     if seq.step not in ("HARVESTING", "ALCAHARVEST"):
         # cmsDriver refuses to run some steps on their own, so we add this to them
         # only loading a single module that we can blacklist later
-        otherstep = "RAW2DIGI:siPixelDigis,"
+        otherstep = ""
 
     wd = tempfile.mkdtemp()
 

--- a/DQMOffline/Configuration/scripts/cmsswSequenceInfo.py
+++ b/DQMOffline/Configuration/scripts/cmsswSequenceInfo.py
@@ -35,11 +35,6 @@ def inspectsequence(seq):
     sep = ":"
     if not seq.seqname:
         sep = ""
-    otherstep = ""
-    if seq.step not in ("HARVESTING", "ALCAHARVEST"):
-        # cmsDriver refuses to run some steps on their own, so we add this to them
-        # only loading a single module that we can blacklist later
-        otherstep = ""
 
     wd = tempfile.mkdtemp()
 
@@ -55,7 +50,7 @@ def inspectsequence(seq):
         "cmsDriver.py",
         "step3",
         "--conditions", "auto:run2_data",                                    # conditions is mandatory, but should not affect the result.
-        "-s", otherstep+seq.step+sep+seq.seqname,                            # running only DQM seems to be not possible, so also load a single module for RAW2DIGI
+        "-s", seq.step+sep+seq.seqname,                            # running only DQM seems to be not possible, so also load a single module for RAW2DIGI
         "--process", "DUMMY", 
         "--mc" if seq.mc else "", "--data" if seq.data else "", "--fast" if seq.fast else "", # random switches 
         "--era" if seq.era else "", seq.era,                                 # era is important as it trigger e.g. switching phase0/pahse1/phase2


### PR DESCRIPTION
This PR tries to fix issue described in:
https://github.com/cms-sw/cmssw/pull/33428#issuecomment-828375525
removing the siPixelDigis module from the sequences to avoid timeouts

