### PR TITLE
All daughter decay filter

### DIFF
--- a/GeneratorInterface/GenFilters/plugins/PythiaAllDauVFilter.cc
+++ b/GeneratorInterface/GenFilters/plugins/PythiaAllDauVFilter.cc
@@ -11,7 +11,7 @@ using namespace Pythia8;
 PythiaAllDauVFilter::PythiaAllDauVFilter(const edm::ParameterSet& iConfig)
     : fVerbose(iConfig.getUntrackedParameter("verbose", 0)),
       token_(consumes<edm::HepMCProduct>(
-                    edm::InputTag(iConfig.getUntrackedParameter("moduleLabel", std::string("generator")), "unsmeared"))),
+          edm::InputTag(iConfig.getUntrackedParameter("moduleLabel", std::string("generator")), "unsmeared"))),
       particleID(iConfig.getUntrackedParameter("ParticleID", 0)),
       motherID(iConfig.getUntrackedParameter("MotherID", 0)),
       chargeconju(iConfig.getUntrackedParameter("ChargeConjugation", true)),

--- a/GeneratorInterface/GenFilters/plugins/PythiaAllDauVFilter.cc
+++ b/GeneratorInterface/GenFilters/plugins/PythiaAllDauVFilter.cc
@@ -10,8 +10,7 @@ using namespace Pythia8;
 
 PythiaAllDauVFilter::PythiaAllDauVFilter(const edm::ParameterSet& iConfig)
     : fVerbose(iConfig.getUntrackedParameter("verbose", 0)),
-      token_(consumes<edm::HepMCProduct>(
-          edm::InputTag(iConfig.getUntrackedParameter("moduleLabel", std::string("generator")), "unsmeared"))),
+      token_(consumes<edm::HepMCProduct>(iConfig.getUntrackedParameter<edm::InputTag>("moduleLabel"))),
       particleID(iConfig.getUntrackedParameter("ParticleID", 0)),
       motherID(iConfig.getUntrackedParameter("MotherID", 0)),
       chargeconju(iConfig.getUntrackedParameter("ChargeConjugation", true)),

--- a/GeneratorInterface/GenFilters/plugins/PythiaAllDauVFilter.cc
+++ b/GeneratorInterface/GenFilters/plugins/PythiaAllDauVFilter.cc
@@ -11,8 +11,7 @@ using namespace Pythia8;
 PythiaAllDauVFilter::PythiaAllDauVFilter(const edm::ParameterSet& iConfig)
     : fVerbose(iConfig.getUntrackedParameter("verbose", 0)),
       token_(consumes<edm::HepMCProduct>(
-          //          edm::InputTag(iConfig.getUntrackedParameter("moduleLabel", std::string("generator")), "unsmeared"))),
-          edm::InputTag(iConfig.getUntrackedParameter("moduleLabel", std::string("generator"))))),
+                    edm::InputTag(iConfig.getUntrackedParameter("moduleLabel", std::string("generator")), "unsmeared"))),
       particleID(iConfig.getUntrackedParameter("ParticleID", 0)),
       motherID(iConfig.getUntrackedParameter("MotherID", 0)),
       chargeconju(iConfig.getUntrackedParameter("ChargeConjugation", true)),


### PR DESCRIPTION
#### PR description:
Bug fix. ( for module added in PR #33502 )

Wrong collection name called by the module.

#### PR validation:
```
cmsrel  CMSSW_11_3_0_pre6
cd CMSSW_11_3_0_pre6/src 
cmsenv
git cms-init
git pull official-cmssw pull/33502/head
curl -s -k https://cms-pdmv.cern.ch/mcm/public/restapi/requests/get_fragment/TSG-Phase2HLTTDRWinter20GS-00251 --retry 3 --create-dirs -o Configuration/GenProduction/python/TSG-Phase2HLTTDRWinter20GS-00251-fragment.py
scram b -j 
cmsDriver.py Configuration/GenProduction/python/TSG-Phase2HLTTDRWinter20GS-00251-fragment.py --python_filename cfg2023_bs2mmg_SDR.py --eventcontent RAWSIM --customise Configuration/DataProcessing/Utils.addMonitoring --datatier GEN-SIM --fileout file:bs2mmg2023.root --conditions 113X_mcRun3_2021_realistic_v6 --beamspot Run3RoundOptics25ns13TeVLowSigmaZ --step GEN,SIM --geometry DB:Extended --era Run3 --no_exec --mc -n 10
# now please change the name of the filter used in line  97 to 
# process.decayfilter = cms.EDFilter("PythiaDauVFilter" ,  - - > process.decayfilter = cms.EDFilter("PythiaAllDauVFilter" , 
# add one more parameter to the module :
# moduleLabel = cms.untracked.InputTag("generator","unsmeared")
cmsRun cfg2023_bs2mmg_SDR.py
 
```



