### PR TITLE
Migrate to esConsumes HIP and MillePede Alignment Algorithms

### DIFF
--- a/Alignment/CommonAlignmentAlgorithm/interface/AlignmentAlgorithmBase.h
+++ b/Alignment/CommonAlignmentAlgorithm/interface/AlignmentAlgorithmBase.h
@@ -112,7 +112,7 @@ public:
   };
 
   /// Constructor
-  AlignmentAlgorithmBase(const edm::ParameterSet &, edm::ConsumesCollector){};
+  AlignmentAlgorithmBase(const edm::ParameterSet &, const edm::ConsumesCollector &){};
 
   /// Destructor
   virtual ~AlignmentAlgorithmBase(){};

--- a/Alignment/CommonAlignmentAlgorithm/interface/AlignmentAlgorithmBase.h
+++ b/Alignment/CommonAlignmentAlgorithm/interface/AlignmentAlgorithmBase.h
@@ -37,6 +37,7 @@ class Trajectory;
 #include "DataFormats/Alignment/interface/TkFittedLasBeamCollectionFwd.h"
 #include "DataFormats/Alignment/interface/AliClusterValueMapFwd.h"
 #include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 
 namespace edm {
   class EventSetup;
@@ -111,7 +112,7 @@ public:
   };
 
   /// Constructor
-  AlignmentAlgorithmBase(const edm::ParameterSet &){};
+  AlignmentAlgorithmBase(const edm::ParameterSet &, edm::ConsumesCollector){};
 
   /// Destructor
   virtual ~AlignmentAlgorithmBase(){};

--- a/Alignment/CommonAlignmentAlgorithm/interface/AlignmentAlgorithmPluginFactory.h
+++ b/Alignment/CommonAlignmentAlgorithm/interface/AlignmentAlgorithmPluginFactory.h
@@ -10,7 +10,7 @@
 #include "FWCore/PluginManager/interface/PluginFactory.h"
 #include "Alignment/CommonAlignmentAlgorithm/interface/AlignmentAlgorithmBase.h"
 
-typedef edmplugin::PluginFactory<AlignmentAlgorithmBase*(const edm::ParameterSet&, edm::ConsumesCollector)>
+typedef edmplugin::PluginFactory<AlignmentAlgorithmBase*(const edm::ParameterSet&, edm::ConsumesCollector&)>
     AlignmentAlgorithmPluginFactory;
 
 #endif

--- a/Alignment/CommonAlignmentAlgorithm/interface/AlignmentAlgorithmPluginFactory.h
+++ b/Alignment/CommonAlignmentAlgorithm/interface/AlignmentAlgorithmPluginFactory.h
@@ -10,6 +10,7 @@
 #include "FWCore/PluginManager/interface/PluginFactory.h"
 #include "Alignment/CommonAlignmentAlgorithm/interface/AlignmentAlgorithmBase.h"
 
-typedef edmplugin::PluginFactory<AlignmentAlgorithmBase*(const edm::ParameterSet&)> AlignmentAlgorithmPluginFactory;
+typedef edmplugin::PluginFactory<AlignmentAlgorithmBase*(const edm::ParameterSet&, edm::ConsumesCollector)>
+    AlignmentAlgorithmPluginFactory;
 
 #endif

--- a/Alignment/CommonAlignmentAlgorithm/plugins/ApeSettingAlgorithm.cc
+++ b/Alignment/CommonAlignmentAlgorithm/plugins/ApeSettingAlgorithm.cc
@@ -61,7 +61,7 @@
 class ApeSettingAlgorithm : public AlignmentAlgorithmBase {
 public:
   /// Constructor
-  ApeSettingAlgorithm(const edm::ParameterSet &cfg, edm::ConsumesCollector iC);
+  ApeSettingAlgorithm(const edm::ParameterSet &cfg, const edm::ConsumesCollector &iC);
 
   /// Destructor
   ~ApeSettingAlgorithm() override;
@@ -95,7 +95,7 @@ private:
 
 // Constructor ----------------------------------------------------------------
 //____________________________________________________
-ApeSettingAlgorithm::ApeSettingAlgorithm(const edm::ParameterSet &cfg, edm::ConsumesCollector iC)
+ApeSettingAlgorithm::ApeSettingAlgorithm(const edm::ParameterSet &cfg, const edm::ConsumesCollector &iC)
     : AlignmentAlgorithmBase(cfg, iC), theConfig(cfg), theAlignableNavigator(nullptr) {
   edm::LogInfo("Alignment") << "@SUB=ApeSettingAlgorithm"
                             << "Start.";

--- a/Alignment/CommonAlignmentAlgorithm/plugins/ApeSettingAlgorithm.cc
+++ b/Alignment/CommonAlignmentAlgorithm/plugins/ApeSettingAlgorithm.cc
@@ -56,11 +56,12 @@
 #include "DataFormats/CLHEP/interface/AlgebraicObjects.h"
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 
 class ApeSettingAlgorithm : public AlignmentAlgorithmBase {
 public:
   /// Constructor
-  ApeSettingAlgorithm(const edm::ParameterSet &cfg);
+  ApeSettingAlgorithm(const edm::ParameterSet &cfg, edm::ConsumesCollector iC);
 
   /// Destructor
   ~ApeSettingAlgorithm() override;
@@ -94,8 +95,8 @@ private:
 
 // Constructor ----------------------------------------------------------------
 //____________________________________________________
-ApeSettingAlgorithm::ApeSettingAlgorithm(const edm::ParameterSet &cfg)
-    : AlignmentAlgorithmBase(cfg), theConfig(cfg), theAlignableNavigator(nullptr) {
+ApeSettingAlgorithm::ApeSettingAlgorithm(const edm::ParameterSet &cfg, edm::ConsumesCollector iC)
+    : AlignmentAlgorithmBase(cfg, iC), theConfig(cfg), theAlignableNavigator(nullptr) {
   edm::LogInfo("Alignment") << "@SUB=ApeSettingAlgorithm"
                             << "Start.";
   saveApeToAscii_ = theConfig.getUntrackedParameter<bool>("saveApeToASCII");

--- a/Alignment/CommonAlignmentProducer/interface/AlignmentProducerBase.h
+++ b/Alignment/CommonAlignmentProducer/interface/AlignmentProducerBase.h
@@ -176,11 +176,17 @@ private:
   /// Applies DB constants belonging to (Err)Rcd to Geometry, taking into
   /// account 'globalPosition' correction.
   template <class G, class Rcd, class ErrRcd>
-  void applyDB(const G*, const edm::EventSetup&, const AlignTransform&) const;
+  void applyDB(const G*,
+               const edm::EventSetup&,
+               const edm::ESGetToken<Alignments, Rcd>&,
+               const edm::ESGetToken<AlignmentErrorsExtended, ErrRcd>&,
+               const AlignTransform&) const;
 
   /// Applies DB constants for SurfaceDeformations
   template <class G, class DeformationRcd>
-  void applyDB(const G*, const edm::EventSetup&) const;
+  void applyDB(const G*,
+               const edm::EventSetup&,
+               const edm::ESGetToken<AlignmentSurfaceDeformations, DeformationRcd>&) const;
 
   /// Reads in survey records
   void readInSurveyRcds(const edm::EventSetup&);
@@ -251,6 +257,17 @@ private:
   const edm::ESGetToken<DTGeometry, MuonGeometryRecord> dtGeomToken_;
   const edm::ESGetToken<CSCGeometry, MuonGeometryRecord> cscGeomToken_;
   const edm::ESGetToken<GEMGeometry, MuonGeometryRecord> gemGeomToken_;
+
+  const edm::ESGetToken<Alignments, TrackerAlignmentRcd> tkAliToken_;
+  const edm::ESGetToken<Alignments, DTAlignmentRcd> dtAliToken_;
+  const edm::ESGetToken<Alignments, CSCAlignmentRcd> cscAliToken_;
+  const edm::ESGetToken<Alignments, GEMAlignmentRcd> gemAliToken_;
+  const edm::ESGetToken<AlignmentErrorsExtended, TrackerAlignmentErrorExtendedRcd> tkAliErrToken_;
+  const edm::ESGetToken<AlignmentErrorsExtended, DTAlignmentErrorExtendedRcd> dtAliErrToken_;
+  const edm::ESGetToken<AlignmentErrorsExtended, CSCAlignmentErrorExtendedRcd> cscAliErrToken_;
+  const edm::ESGetToken<AlignmentErrorsExtended, GEMAlignmentErrorExtendedRcd> gemAliErrToken_;
+  const edm::ESGetToken<AlignmentSurfaceDeformations, TrackerSurfaceDeformationRcd> tkSurfDefToken_;
+
   const edm::ESGetToken<Alignments, GlobalPositionRcd> gprToken_;
   const edm::ESGetToken<Alignments, TrackerSurveyRcd> tkSurveyToken_;
   const edm::ESGetToken<SurveyErrors, TrackerSurveyErrorExtendedRcd> tkSurvErrorToken_;
@@ -297,6 +314,8 @@ private:
 template <class G, class Rcd, class ErrRcd>
 void AlignmentProducerBase::applyDB(const G* geometry,
                                     const edm::EventSetup& iSetup,
+                                    const edm::ESGetToken<Alignments, Rcd>& aliToken,
+                                    const edm::ESGetToken<AlignmentErrorsExtended, ErrRcd>& errToken,
                                     const AlignTransform& globalCoordinates) const {
   // 'G' is the geometry class for that DB should be applied,
   // 'Rcd' is the record class for its Alignments
@@ -316,18 +335,18 @@ void AlignmentProducerBase::applyDB(const G* geometry,
     }
   }
 
-  edm::ESHandle<Alignments> alignments;
-  record.get(alignments);
-
-  edm::ESHandle<AlignmentErrorsExtended> alignmentErrors;
-  iSetup.get<ErrRcd>().get(alignmentErrors);
+  const Alignments* alignments = &record.get(aliToken);
+  const AlignmentErrorsExtended* alignmentErrors = &iSetup.getData(errToken);
 
   GeometryAligner aligner;
-  aligner.applyAlignments<G>(geometry, &(*alignments), &(*alignmentErrors), globalCoordinates);
+  aligner.applyAlignments<G>(geometry, alignments, alignmentErrors, globalCoordinates);
 }
 
 template <class G, class DeformationRcd>
-void AlignmentProducerBase::applyDB(const G* geometry, const edm::EventSetup& iSetup) const {
+void AlignmentProducerBase::applyDB(
+    const G* geometry,
+    const edm::EventSetup& iSetup,
+    const edm::ESGetToken<AlignmentSurfaceDeformations, DeformationRcd>& surfDefToken) const {
   // 'G' is the geometry class for that DB should be applied,
   // 'DeformationRcd' is the record class for its surface deformations
 
@@ -343,11 +362,10 @@ void AlignmentProducerBase::applyDB(const G* geometry, const edm::EventSetup& iS
           << "Validity range is " << first.eventID().run() << " - " << last.eventID().run();
     }
   }
-  edm::ESHandle<AlignmentSurfaceDeformations> surfaceDeformations;
-  record.get(surfaceDeformations);
+  const AlignmentSurfaceDeformations* surfaceDeformations = &record.get(surfDefToken);
 
   GeometryAligner aligner;
-  aligner.attachSurfaceDeformations<G>(geometry, &(*surfaceDeformations));
+  aligner.attachSurfaceDeformations<G>(geometry, surfaceDeformations);
 }
 
 #endif /* Alignment_CommonAlignmentProducer_AlignmentProducerBase_h */

--- a/Alignment/CommonAlignmentProducer/interface/AlignmentProducerBase.h
+++ b/Alignment/CommonAlignmentProducer/interface/AlignmentProducerBase.h
@@ -43,6 +43,7 @@
 #include "CondFormats/AlignmentRecord/interface/TrackerSurfaceDeformationRcd.h"
 #include "CondFormats/AlignmentRecord/interface/TrackerSurveyRcd.h"
 #include "CondFormats/AlignmentRecord/interface/TrackerSurveyErrorExtendedRcd.h"
+#include "CondFormats/GeometryObjects/interface/PTrackerParameters.h"
 #include "CondFormats/Common/interface/Time.h"
 
 #include "FWCore/Framework/interface/ESHandle.h"
@@ -57,6 +58,7 @@
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 #include "Geometry/Records/interface/IdealGeometryRecord.h"
 #include "Geometry/Records/interface/MuonGeometryRecord.h"
+#include "Geometry/Records/interface/TrackerTopologyRcd.h"
 
 #include "TrackingTools/PatternTools/interface/TrajTrackAssociation.h"
 
@@ -241,6 +243,22 @@ private:
   const bool useSurvey_;
   const bool enableAlignableUpdates_;
   std::string idealGeometryLabel;
+
+  /*** ESTokens ***/
+  const edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> ttopoToken_;
+  const edm::ESGetToken<GeometricDet, IdealGeometryRecord> geomDetToken_;
+  const edm::ESGetToken<PTrackerParameters, PTrackerParametersRcd> ptpToken_;
+  const edm::ESGetToken<DTGeometry, MuonGeometryRecord> dtGeomToken_;
+  const edm::ESGetToken<CSCGeometry, MuonGeometryRecord> cscGeomToken_;
+  const edm::ESGetToken<GEMGeometry, MuonGeometryRecord> gemGeomToken_;
+  const edm::ESGetToken<Alignments, GlobalPositionRcd> gprToken_;
+  const edm::ESGetToken<Alignments, TrackerSurveyRcd> tkSurveyToken_;
+  const edm::ESGetToken<SurveyErrors, TrackerSurveyErrorExtendedRcd> tkSurvErrorToken_;
+  const edm::ESGetToken<Alignments, DTSurveyRcd> dtSurveyToken_;
+  const edm::ESGetToken<SurveyErrors, DTSurveyErrorExtendedRcd> dtSurvErrorToken_;
+  const edm::ESGetToken<Alignments, CSCSurveyRcd> cscSurveyToken_;
+  const edm::ESGetToken<SurveyErrors, CSCSurveyErrorExtendedRcd> cscSurvErrorToken_;
+
   /*** ESWatcher ***/
 
   edm::ESWatcher<IdealGeometryRecord> watchIdealGeometryRcd_;

--- a/Alignment/CommonAlignmentProducer/interface/AlignmentProducerBase.h
+++ b/Alignment/CommonAlignmentProducer/interface/AlignmentProducerBase.h
@@ -48,6 +48,7 @@
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/ESWatcher.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 
 #include "Geometry/DTGeometry/interface/DTGeometry.h"
 #include "Geometry/CSCGeometry/interface/CSCGeometry.h"
@@ -69,7 +70,7 @@ class TrackerDigiGeometryRecord;
 
 class AlignmentProducerBase {
 protected:
-  AlignmentProducerBase(const edm::ParameterSet&);
+  AlignmentProducerBase(const edm::ParameterSet&, edm::ConsumesCollector);
 
   // 'noexcept(false)' is needed currently for multiple inheritance with Framework modules
   virtual ~AlignmentProducerBase() noexcept(false);
@@ -132,7 +133,7 @@ protected:
 
 private:
   /// Creates the choosen alignment algorithm
-  void createAlignmentAlgorithm();
+  void createAlignmentAlgorithm(edm::ConsumesCollector&);
 
   /// Creates the monitors
   void createMonitors();

--- a/Alignment/CommonAlignmentProducer/plugins/AlignmentProducer.cc
+++ b/Alignment/CommonAlignmentProducer/plugins/AlignmentProducer.cc
@@ -11,7 +11,8 @@
 
 //------------------------------------------------------------------------------
 AlignmentProducer::AlignmentProducer(const edm::ParameterSet &config)
-    : AlignmentProducerBase{config}, maxLoops_{config.getUntrackedParameter<unsigned int>("maxLoops")} {
+    : AlignmentProducerBase(config, consumesCollector()),
+      maxLoops_{config.getUntrackedParameter<unsigned int>("maxLoops")} {
   edm::LogInfo("Alignment") << "@SUB=AlignmentProducer::AlignmentProducer";
 
   // Tell the framework what data is being produced

--- a/Alignment/CommonAlignmentProducer/plugins/AlignmentProducerAsAnalyzer.cc
+++ b/Alignment/CommonAlignmentProducer/plugins/AlignmentProducerAsAnalyzer.cc
@@ -14,7 +14,8 @@
 
 //------------------------------------------------------------------------------
 AlignmentProducerAsAnalyzer::AlignmentProducerAsAnalyzer(const edm::ParameterSet& config)
-    : AlignmentProducerBase{config}, token_(produces<AlignmentToken, edm::Transition::EndProcessBlock>()) {
+    : AlignmentProducerBase(config, consumesCollector()),
+      token_(produces<AlignmentToken, edm::Transition::EndProcessBlock>()) {
   usesResource(TFileService::kSharedResource);
 
   tjTkAssociationMapToken_ = consumes<TrajTrackAssociationCollection>(tjTkAssociationMapTag_);

--- a/Alignment/CommonAlignmentProducer/python/AlignmentProducerAsAnalyzer_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/AlignmentProducerAsAnalyzer_cff.py
@@ -94,4 +94,10 @@ CSCGeometryAlignmentProducerAsAnalyzer = cms.ESProducer("CSCGeometryESModule",
     fromDDD = cms.bool(True),
     fromDD4hep = cms.bool(False)
 )
-
+GEMGeometryAlignmentProducerAsAnalyzer = cms.ESProducer("GEMGeometryESModule",
+    appendToDataLabel = cms.string('idealForAlignmentProducerBase'),
+    applyAlignment = cms.bool(False),
+    alignmentsLabel = cms.string(''),
+    fromDDD = cms.bool(True),
+    fromDD4Hep = cms.bool(False)
+)

--- a/Alignment/CommonAlignmentProducer/python/AlignmentProducer_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/AlignmentProducer_cff.py
@@ -96,3 +96,10 @@ CSCGeometryAlignmentProducer = cms.ESProducer("CSCGeometryESModule",
     fromDDD = cms.bool(True),
     fromDD4hep = cms.bool(False)
 ) 
+GEMGeometryAlignmentProducer = cms.ESProducer("GEMGeometryESModule",
+    appendToDataLabel = cms.string('idealForAlignmentProducerBase'),
+    applyAlignment = cms.bool(False),
+    alignmentsLabel = cms.string(''),
+    fromDDD = cms.bool(True),
+    fromDD4Hep = cms.bool(False)
+)

--- a/Alignment/CommonAlignmentProducer/src/AlignmentProducerBase.cc
+++ b/Alignment/CommonAlignmentProducer/src/AlignmentProducerBase.cc
@@ -51,9 +51,9 @@ AlignmentProducerBase::AlignmentProducerBase(const edm::ParameterSet& config, ed
       ttopoToken_(iC.esConsumes<edm::Transition::BeginRun>()),
       geomDetToken_(iC.esConsumes<edm::Transition::BeginRun>()),
       ptpToken_(iC.esConsumes<edm::Transition::BeginRun>()),
-      dtGeomToken_(iC.esConsumes<edm::Transition::BeginRun>(edm::ESInputTag("", idealGeometryLabel))),
-      cscGeomToken_(iC.esConsumes<edm::Transition::BeginRun>(edm::ESInputTag("", idealGeometryLabel))),
-      gemGeomToken_(iC.esConsumes<edm::Transition::BeginRun>(edm::ESInputTag("", idealGeometryLabel))),
+      //dtGeomToken_(iC.esConsumes<edm::Transition::BeginRun>(edm::ESInputTag("", "idealForAlignmentProducerBase"))),
+      //cscGeomToken_(iC.esConsumes<edm::Transition::BeginRun>(edm::ESInputTag("", "idealForAlignmentProducerBase"))),
+      //gemGeomToken_(iC.esConsumes<edm::Transition::BeginRun>(edm::ESInputTag("", "idealForAlignmentProducerBase"))),
       gprToken_(iC.esConsumes<edm::Transition::BeginRun>()),
       tkSurveyToken_(iC.esConsumes<edm::Transition::BeginRun>()),
       tkSurvErrorToken_(iC.esConsumes<edm::Transition::BeginRun>()),
@@ -427,9 +427,12 @@ void AlignmentProducerBase::createGeometries(const edm::EventSetup& iSetup, cons
   }
 
   if (doMuon_) {
-    muonDTGeometry_ = &iSetup.getData(dtGeomToken_);
-    muonCSCGeometry_ = &iSetup.getData(cscGeomToken_);
-    muonGEMGeometry_ = &iSetup.getData(gemGeomToken_);
+    iSetup.get<MuonGeometryRecord>().get(idealGeometryLabel, muonDTGeometry_);
+    iSetup.get<MuonGeometryRecord>().get(idealGeometryLabel, muonCSCGeometry_);
+    iSetup.get<MuonGeometryRecord>().get(idealGeometryLabel, muonGEMGeometry_);
+    //muonDTGeometry_ = iSetup.getHandle(dtGeomToken_);
+    //muonCSCGeometry_ = iSetup.getHandle(cscGeomToken_);
+    //muonGEMGeometry_ = iSetup.getHandle(gemGeomToken_);
   }
 }
 

--- a/Alignment/CommonAlignmentProducer/src/AlignmentProducerBase.cc
+++ b/Alignment/CommonAlignmentProducer/src/AlignmentProducerBase.cc
@@ -27,7 +27,7 @@
 #include "Geometry/Records/interface/TrackerTopologyRcd.h"
 
 //------------------------------------------------------------------------------
-AlignmentProducerBase::AlignmentProducerBase(const edm::ParameterSet& config)
+AlignmentProducerBase::AlignmentProducerBase(const edm::ParameterSet& config, edm::ConsumesCollector iC)
     : doTracker_{config.getUntrackedParameter<bool>("doTracker")},
       doMuon_{config.getUntrackedParameter<bool>("doMuon")},
       useExtras_{config.getUntrackedParameter<bool>("useExtras")},
@@ -71,7 +71,7 @@ AlignmentProducerBase::AlignmentProducerBase(const edm::ParameterSet& config)
     runAtPCL_ = false;
   }
 
-  createAlignmentAlgorithm();
+  createAlignmentAlgorithm(iC);
   createMonitors();
   createCalibrations();
 }
@@ -256,14 +256,14 @@ void AlignmentProducerBase::endLuminosityBlockImpl(const edm::LuminosityBlock&, 
 }
 
 //------------------------------------------------------------------------------
-void AlignmentProducerBase::createAlignmentAlgorithm() {
+void AlignmentProducerBase::createAlignmentAlgorithm(edm::ConsumesCollector& iC) {
   auto algoConfig = config_.getParameter<edm::ParameterSet>("algoConfig");
   algoConfig.addUntrackedParameter("RunRangeSelection", config_.getParameter<edm::VParameterSet>("RunRangeSelection"));
   algoConfig.addUntrackedParameter<align::RunNumber>("firstIOV", runAtPCL_ ? 1 : uniqueRunRanges_.front().first);
   algoConfig.addUntrackedParameter("enableAlignableUpdates", enableAlignableUpdates_);
 
   const auto& algoName = algoConfig.getParameter<std::string>("algoName");
-  alignmentAlgo_ = AlignmentAlgorithmPluginFactory::get()->create(algoName, algoConfig);
+  alignmentAlgo_ = AlignmentAlgorithmPluginFactory::get()->create(algoName, algoConfig, iC);
 }
 
 //------------------------------------------------------------------------------

--- a/Alignment/CommonAlignmentProducer/src/AlignmentProducerBase.cc
+++ b/Alignment/CommonAlignmentProducer/src/AlignmentProducerBase.cc
@@ -54,6 +54,15 @@ AlignmentProducerBase::AlignmentProducerBase(const edm::ParameterSet& config, ed
       //dtGeomToken_(iC.esConsumes<edm::Transition::BeginRun>(edm::ESInputTag("", "idealForAlignmentProducerBase"))),
       //cscGeomToken_(iC.esConsumes<edm::Transition::BeginRun>(edm::ESInputTag("", "idealForAlignmentProducerBase"))),
       //gemGeomToken_(iC.esConsumes<edm::Transition::BeginRun>(edm::ESInputTag("", "idealForAlignmentProducerBase"))),
+      tkAliToken_(iC.esConsumes<edm::Transition::BeginRun>()),
+      dtAliToken_(iC.esConsumes<edm::Transition::BeginRun>()),
+      cscAliToken_(iC.esConsumes<edm::Transition::BeginRun>()),
+      gemAliToken_(iC.esConsumes<edm::Transition::BeginRun>()),
+      tkAliErrToken_(iC.esConsumes<edm::Transition::BeginRun>()),
+      dtAliErrToken_(iC.esConsumes<edm::Transition::BeginRun>()),
+      cscAliErrToken_(iC.esConsumes<edm::Transition::BeginRun>()),
+      gemAliErrToken_(iC.esConsumes<edm::Transition::BeginRun>()),
+      tkSurfDefToken_(iC.esConsumes<edm::Transition::BeginRun>()),
       gprToken_(iC.esConsumes<edm::Transition::BeginRun>()),
       tkSurveyToken_(iC.esConsumes<edm::Transition::BeginRun>()),
       tkSurvErrorToken_(iC.esConsumes<edm::Transition::BeginRun>()),
@@ -448,20 +457,36 @@ void AlignmentProducerBase::applyAlignmentsToDB(const edm::EventSetup& setup) {
 
     if (doTracker_) {
       applyDB<TrackerGeometry, TrackerAlignmentRcd, TrackerAlignmentErrorExtendedRcd>(
-          trackerGeometry_.get(), setup, align::DetectorGlobalPosition(*globalPositions_, DetId(DetId::Tracker)));
+          trackerGeometry_.get(),
+          setup,
+          tkAliToken_,
+          tkAliErrToken_,
+          align::DetectorGlobalPosition(*globalPositions_, DetId(DetId::Tracker)));
 
-      applyDB<TrackerGeometry, TrackerSurfaceDeformationRcd>(trackerGeometry_.get(), setup);
+      applyDB<TrackerGeometry, TrackerSurfaceDeformationRcd>(trackerGeometry_.get(), setup, tkSurfDefToken_);
     }
 
     if (doMuon_) {
       applyDB<DTGeometry, DTAlignmentRcd, DTAlignmentErrorExtendedRcd>(
-          &*muonDTGeometry_, setup, align::DetectorGlobalPosition(*globalPositions_, DetId(DetId::Muon)));
+          &*muonDTGeometry_,
+          setup,
+          dtAliToken_,
+          dtAliErrToken_,
+          align::DetectorGlobalPosition(*globalPositions_, DetId(DetId::Muon)));
 
       applyDB<CSCGeometry, CSCAlignmentRcd, CSCAlignmentErrorExtendedRcd>(
-          &*muonCSCGeometry_, setup, align::DetectorGlobalPosition(*globalPositions_, DetId(DetId::Muon)));
+          &*muonCSCGeometry_,
+          setup,
+          cscAliToken_,
+          cscAliErrToken_,
+          align::DetectorGlobalPosition(*globalPositions_, DetId(DetId::Muon)));
 
       applyDB<GEMGeometry, GEMAlignmentRcd, GEMAlignmentErrorExtendedRcd>(
-          &*muonGEMGeometry_, setup, align::DetectorGlobalPosition(*globalPositions_, DetId(DetId::Muon)));
+          &*muonGEMGeometry_,
+          setup,
+          gemAliToken_,
+          gemAliErrToken_,
+          align::DetectorGlobalPosition(*globalPositions_, DetId(DetId::Muon)));
     }
   }
 }

--- a/Alignment/HIPAlignmentAlgorithm/interface/HIPAlignmentAlgorithm.h
+++ b/Alignment/HIPAlignmentAlgorithm/interface/HIPAlignmentAlgorithm.h
@@ -36,7 +36,7 @@ class TTree;
 class HIPAlignmentAlgorithm : public AlignmentAlgorithmBase {
 public:
   /// Constructor
-  HIPAlignmentAlgorithm(const edm::ParameterSet& cfg, edm::ConsumesCollector iC);
+  HIPAlignmentAlgorithm(const edm::ParameterSet& cfg, edm::ConsumesCollector& iC);
 
   /// Destructor
   ~HIPAlignmentAlgorithm() override{};

--- a/Alignment/HIPAlignmentAlgorithm/interface/HIPAlignmentAlgorithm.h
+++ b/Alignment/HIPAlignmentAlgorithm/interface/HIPAlignmentAlgorithm.h
@@ -9,6 +9,7 @@
 #include "Alignment/CommonAlignment/interface/AlignableNavigator.h"
 #include "Alignment/CommonAlignmentAlgorithm/interface/AlignmentIORoot.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "Riostream.h"
 
 #include "DataFormats/Alignment/interface/AlignmentClusterFlag.h"
@@ -21,6 +22,10 @@
 #include "Geometry/CommonTopologies/interface/SurfaceDeformation.h"
 #include "Geometry/CommonTopologies/interface/SurfaceDeformationFactory.h"
 
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+#include "Geometry/Records/interface/TrackerTopologyRcd.h"
+#include "Geometry/Records/interface/IdealGeometryRecord.h"
+
 #include "Alignment/HIPAlignmentAlgorithm/interface/HIPMonitorConfig.h"
 #include "Alignment/HIPAlignmentAlgorithm/interface/HIPAlignableSpecificParameters.h"
 #include "TFormula.h"
@@ -31,7 +36,7 @@ class TTree;
 class HIPAlignmentAlgorithm : public AlignmentAlgorithmBase {
 public:
   /// Constructor
-  HIPAlignmentAlgorithm(const edm::ParameterSet& cfg);
+  HIPAlignmentAlgorithm(const edm::ParameterSet& cfg, edm::ConsumesCollector iC);
 
   /// Destructor
   ~HIPAlignmentAlgorithm() override{};
@@ -80,6 +85,8 @@ private:
   HIPAlignableSpecificParameters* findAlignableSpecs(const Alignable* ali);
 
   // private data members
+  const edm::ESGetToken<TrackerTopology, IdealGeometryRecord> topoToken_;
+  const edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> topoToken2_;
 
   std::unique_ptr<AlignableObjectId> alignableObjectId_;
   AlignmentParameterStore* theAlignmentParameterStore;

--- a/Alignment/HIPAlignmentAlgorithm/src/HIPAlignmentAlgorithm.cc
+++ b/Alignment/HIPAlignmentAlgorithm/src/HIPAlignmentAlgorithm.cc
@@ -38,10 +38,10 @@
 #include "Alignment/HIPAlignmentAlgorithm/interface/HIPAlignmentAlgorithm.h"
 
 // Constructor ----------------------------------------------------------------
-HIPAlignmentAlgorithm::HIPAlignmentAlgorithm(const edm::ParameterSet& cfg, edm::ConsumesCollector iC)
+HIPAlignmentAlgorithm::HIPAlignmentAlgorithm(const edm::ParameterSet& cfg, edm::ConsumesCollector& iC)
     : AlignmentAlgorithmBase(cfg, iC),
-      topoToken_(iC.esConsumes<TrackerTopology, IdealGeometryRecord>()),
-      topoToken2_(iC.esConsumes<TrackerTopology, TrackerTopologyRcd>()),
+      topoToken_(iC.esConsumes<TrackerTopology, IdealGeometryRecord, edm::Transition::EndRun>()),
+      topoToken2_(iC.esConsumes<TrackerTopology, TrackerTopologyRcd, edm::Transition::EndRun>()),
       verbose(cfg.getParameter<bool>("verbosity")),
       theMonitorConfig(cfg),
       doTrackHitMonitoring(theMonitorConfig.fillTrackMonitoring || theMonitorConfig.fillTrackHitMonitoring),

--- a/Alignment/HIPAlignmentAlgorithm/src/HIPAlignmentAlgorithm.cc
+++ b/Alignment/HIPAlignmentAlgorithm/src/HIPAlignmentAlgorithm.cc
@@ -29,10 +29,6 @@
 #include "Alignment/TrackerAlignment/interface/AlignableTracker.h"
 #include "Alignment/CommonAlignment/interface/AlignableExtras.h"
 #include "DataFormats/TrackReco/interface/Track.h"
-#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
-#include "Geometry/Records/interface/TrackerTopologyRcd.h"
-#include "Geometry/Records/interface/IdealGeometryRecord.h"
-
 #include "CondFormats/AlignmentRecord/interface/GlobalPositionRcd.h"
 #include "CondFormats/AlignmentRecord/interface/TrackerAlignmentRcd.h"
 #include "FWCore/Framework/interface/ValidityInterval.h"
@@ -42,8 +38,10 @@
 #include "Alignment/HIPAlignmentAlgorithm/interface/HIPAlignmentAlgorithm.h"
 
 // Constructor ----------------------------------------------------------------
-HIPAlignmentAlgorithm::HIPAlignmentAlgorithm(const edm::ParameterSet& cfg)
-    : AlignmentAlgorithmBase(cfg),
+HIPAlignmentAlgorithm::HIPAlignmentAlgorithm(const edm::ParameterSet& cfg, edm::ConsumesCollector iC)
+    : AlignmentAlgorithmBase(cfg, iC),
+      topoToken_(iC.esConsumes<TrackerTopology, IdealGeometryRecord>()),
+      topoToken2_(iC.esConsumes<TrackerTopology, TrackerTopologyRcd>()),
       verbose(cfg.getParameter<bool>("verbosity")),
       theMonitorConfig(cfg),
       doTrackHitMonitoring(theMonitorConfig.fillTrackMonitoring || theMonitorConfig.fillTrackHitMonitoring),
@@ -136,8 +134,6 @@ void HIPAlignmentAlgorithm::initialize(const edm::EventSetup& setup,
 
   for (const auto& level : surveyResiduals_)
     theLevels.push_back(alignableObjectId_->stringToId(level));
-
-  edm::ESHandle<Alignments> globalPositionRcd;
 
   const edm::ValidityInterval& validity = setup.get<TrackerAlignmentRcd>().validityInterval();
   const edm::IOVSyncValue first1 = validity.first();
@@ -371,9 +367,7 @@ void HIPAlignmentAlgorithm::terminate(const edm::EventSetup& iSetup) {
     edm::LogWarning("Alignment") << "[HIPAlignmentAlgorithm] Using survey constraint";
 
     unsigned int nAlignable = theAlignables.size();
-    edm::ESHandle<TrackerTopology> tTopoHandle;
-    iSetup.get<IdealGeometryRecord>().get(tTopoHandle);
-    const TrackerTopology* const tTopo = tTopoHandle.product();
+    const TrackerTopology* const tTopo = &iSetup.getData(topoToken_);
     for (unsigned int i = 0; i < nAlignable; ++i) {
       const Alignable* ali = theAlignables[i];
       AlignmentParameters* ap = ali->alignmentParameters();
@@ -1160,11 +1154,7 @@ void HIPAlignmentAlgorithm::fillAlignablesMonitor(const edm::EventSetup& iSetup)
   int naligned = 0;
 
   //Retrieve tracker topology from geometry
-  edm::ESHandle<TrackerTopology> tTopoHandle;
-  //  iSetup.get<IdealGeometryRecord>().get(tTopoHandle);
-  iSetup.get<TrackerTopologyRcd>().get(tTopoHandle);
-
-  const TrackerTopology* const tTopo = tTopoHandle.product();
+  const TrackerTopology* const tTopo = &iSetup.getData(topoToken2_);
 
   for (const auto& ali : theAlignables) {
     AlignmentParameters* dap = ali->alignmentParameters();

--- a/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeAlignmentAlgorithm.cc
+++ b/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeAlignmentAlgorithm.cc
@@ -84,10 +84,10 @@ using namespace gbl;
 
 // Constructor ----------------------------------------------------------------
 //____________________________________________________
-MillePedeAlignmentAlgorithm::MillePedeAlignmentAlgorithm(const edm::ParameterSet &cfg, edm::ConsumesCollector iC)
+MillePedeAlignmentAlgorithm::MillePedeAlignmentAlgorithm(const edm::ParameterSet &cfg, edm::ConsumesCollector &iC)
     : AlignmentAlgorithmBase(cfg, iC),
-      topoToken_(iC.esConsumes<TrackerTopology, TrackerTopologyRcd>()),
-      aliThrToken_(iC.esConsumes<AlignPCLThresholds, AlignPCLThresholdsRcd>()),
+      topoToken_(iC.esConsumes<TrackerTopology, TrackerTopologyRcd, edm::Transition::BeginRun>()),
+      aliThrToken_(iC.esConsumes<AlignPCLThresholds, AlignPCLThresholdsRcd, edm::Transition::BeginRun>()),
       theConfig(cfg),
       theMode(this->decodeMode(theConfig.getUntrackedParameter<std::string>("mode"))),
       theDir(theConfig.getUntrackedParameter<std::string>("fileDir")),

--- a/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeAlignmentAlgorithm.cc
+++ b/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeAlignmentAlgorithm.cc
@@ -22,8 +22,8 @@
 #include "Alignment/MillePedeAlignmentAlgorithm/interface/MillePedeVariables.h"
 #include "Alignment/MillePedeAlignmentAlgorithm/interface/MillePedeVariablesIORoot.h"
 #include "Alignment/MillePedeAlignmentAlgorithm/src/Mille.h"        // 'unpublished' interface located in src
-#include "Alignment/MillePedeAlignmentAlgorithm/src/PedeSteerer.h"  // dito
-#include "Alignment/MillePedeAlignmentAlgorithm/src/PedeReader.h"   // dito
+#include "Alignment/MillePedeAlignmentAlgorithm/src/PedeSteerer.h"  // ditto
+#include "Alignment/MillePedeAlignmentAlgorithm/src/PedeReader.h"   // ditto
 #include "Alignment/MillePedeAlignmentAlgorithm/interface/PedeLabelerBase.h"
 #include "Alignment/MillePedeAlignmentAlgorithm/interface/PedeLabelerPluginFactory.h"
 
@@ -54,14 +54,9 @@
 #include "DataFormats/Alignment/interface/TkFittedLasBeam.h"
 #include "Alignment/LaserAlignment/interface/TsosVectorCollection.h"
 
-#include <Geometry/CommonDetUnit/interface/GeomDet.h>
-#include <Geometry/CommonDetUnit/interface/GeomDetType.h>
-#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
-#include "Geometry/Records/interface/TrackerTopologyRcd.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
+#include "Geometry/CommonDetUnit/interface/GeomDetType.h"
 #include "Geometry/Records/interface/IdealGeometryRecord.h"
-
-#include "CondFormats/PCLConfig/interface/AlignPCLThresholds.h"
-#include "CondFormats/DataRecord/interface/AlignPCLThresholdsRcd.h"
 
 #include "DataFormats/TrackerRecHit2D/interface/ProjectedSiStripRecHit2D.h"
 
@@ -89,8 +84,10 @@ using namespace gbl;
 
 // Constructor ----------------------------------------------------------------
 //____________________________________________________
-MillePedeAlignmentAlgorithm::MillePedeAlignmentAlgorithm(const edm::ParameterSet &cfg)
-    : AlignmentAlgorithmBase(cfg),
+MillePedeAlignmentAlgorithm::MillePedeAlignmentAlgorithm(const edm::ParameterSet &cfg, edm::ConsumesCollector iC)
+    : AlignmentAlgorithmBase(cfg, iC),
+      topoToken_(iC.esConsumes<TrackerTopology, TrackerTopologyRcd>()),
+      aliThrToken_(iC.esConsumes<AlignPCLThresholds, AlignPCLThresholdsRcd>()),
       theConfig(cfg),
       theMode(this->decodeMode(theConfig.getUntrackedParameter<std::string>("mode"))),
       theDir(theConfig.getUntrackedParameter<std::string>("fileDir")),
@@ -176,15 +173,11 @@ void MillePedeAlignmentAlgorithm::initialize(const edm::EventSetup &setup,
   }
 
   //Retrieve tracker topology from geometry
-  edm::ESHandle<TrackerTopology> tTopoHandle;
-  setup.get<TrackerTopologyRcd>().get(tTopoHandle);
-  const TrackerTopology *const tTopo = tTopoHandle.product();
+  const TrackerTopology *const tTopo = &setup.getData(topoToken_);
 
   //Retrieve the thresolds cuts from DB for the PCL
   if (runAtPCL_) {
-    edm::ESHandle<AlignPCLThresholds> thresholdHandle;
-    setup.get<AlignPCLThresholdsRcd>().get(thresholdHandle);
-    auto th = thresholdHandle.product();
+    const auto &th = &setup.getData(aliThrToken_);
     theThresholds = std::make_shared<AlignPCLThresholds>();
     storeThresholds(th->getNrecords(), th->getThreshold_Map());
   }

--- a/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeAlignmentAlgorithm.h
+++ b/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeAlignmentAlgorithm.h
@@ -15,12 +15,18 @@
 #include "Alignment/CommonAlignmentAlgorithm/interface/AlignmentAlgorithmBase.h"
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 
 #include "TrackingTools/TrajectoryState/interface/TrajectoryStateOnSurface.h"
 #include "TrackingTools/TransientTrackingRecHit/interface/TransientTrackingRecHit.h"
 
 #include "Alignment/ReferenceTrajectories/interface/ReferenceTrajectoryBase.h"
+
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+#include "Geometry/Records/interface/TrackerTopologyRcd.h"
+
 #include "CondFormats/PCLConfig/interface/AlignPCLThresholds.h"
+#include "CondFormats/DataRecord/interface/AlignPCLThresholdsRcd.h"
 
 #include <vector>
 #include <string>
@@ -53,7 +59,7 @@ class TrajectoryFactoryBase;
 class MillePedeAlignmentAlgorithm : public AlignmentAlgorithmBase {
 public:
   /// Constructor
-  MillePedeAlignmentAlgorithm(const edm::ParameterSet &cfg);
+  MillePedeAlignmentAlgorithm(const edm::ParameterSet &cfg, edm::ConsumesCollector iC);
 
   /// Destructor
   ~MillePedeAlignmentAlgorithm() override;
@@ -263,6 +269,10 @@ private:
   //--------------------------------------------------------
   // Data members
   //--------------------------------------------------------
+
+  const edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> topoToken_;
+  const edm::ESGetToken<AlignPCLThresholds, AlignPCLThresholdsRcd> aliThrToken_;
+
   enum EModeBit { myMilleBit = 1 << 0, myPedeRunBit = 1 << 1, myPedeSteerBit = 1 << 2, myPedeReadBit = 1 << 3 };
   unsigned int decodeMode(const std::string &mode) const;
   bool isMode(unsigned int testMode) const { return (theMode & testMode); }

--- a/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeAlignmentAlgorithm.h
+++ b/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeAlignmentAlgorithm.h
@@ -59,7 +59,7 @@ class TrajectoryFactoryBase;
 class MillePedeAlignmentAlgorithm : public AlignmentAlgorithmBase {
 public:
   /// Constructor
-  MillePedeAlignmentAlgorithm(const edm::ParameterSet &cfg, edm::ConsumesCollector iC);
+  MillePedeAlignmentAlgorithm(const edm::ParameterSet &cfg, edm::ConsumesCollector &iC);
 
   /// Destructor
   ~MillePedeAlignmentAlgorithm() override;

--- a/Alignment/MuonAlignmentAlgorithms/plugins/CSCOverlapsAlignmentAlgorithm.cc
+++ b/Alignment/MuonAlignmentAlgorithms/plugins/CSCOverlapsAlignmentAlgorithm.cc
@@ -1,7 +1,8 @@
 #include "Alignment/MuonAlignmentAlgorithms/plugins/CSCOverlapsAlignmentAlgorithm.h"
 
-CSCOverlapsAlignmentAlgorithm::CSCOverlapsAlignmentAlgorithm(const edm::ParameterSet& iConfig)
-    : AlignmentAlgorithmBase(iConfig),
+CSCOverlapsAlignmentAlgorithm::CSCOverlapsAlignmentAlgorithm(const edm::ParameterSet& iConfig,
+                                                             const edm::ConsumesCollector& iC)
+    : AlignmentAlgorithmBase(iConfig, iC),
       m_minHitsPerChamber(iConfig.getParameter<int>("minHitsPerChamber")),
       m_maxdrdz(iConfig.getParameter<double>("maxdrdz")),
       m_fiducial(iConfig.getParameter<bool>("fiducial")),

--- a/Alignment/MuonAlignmentAlgorithms/plugins/CSCOverlapsAlignmentAlgorithm.h
+++ b/Alignment/MuonAlignmentAlgorithms/plugins/CSCOverlapsAlignmentAlgorithm.h
@@ -60,7 +60,7 @@
 
 class CSCOverlapsAlignmentAlgorithm : public AlignmentAlgorithmBase {
 public:
-  CSCOverlapsAlignmentAlgorithm(const edm::ParameterSet &iConfig);
+  CSCOverlapsAlignmentAlgorithm(const edm::ParameterSet &iConfig, const edm::ConsumesCollector &);
   ~CSCOverlapsAlignmentAlgorithm() override;
 
   void initialize(const edm::EventSetup &iSetup,

--- a/Alignment/MuonAlignmentAlgorithms/plugins/CSCOverlapsAlignmentAlgorithm.h
+++ b/Alignment/MuonAlignmentAlgorithms/plugins/CSCOverlapsAlignmentAlgorithm.h
@@ -60,7 +60,7 @@
 
 class CSCOverlapsAlignmentAlgorithm : public AlignmentAlgorithmBase {
 public:
-  CSCOverlapsAlignmentAlgorithm(const edm::ParameterSet &iConfig, const edm::ConsumesCollector &);
+  CSCOverlapsAlignmentAlgorithm(const edm::ParameterSet &iConfig, edm::ConsumesCollector &);
   ~CSCOverlapsAlignmentAlgorithm() override;
 
   void initialize(const edm::EventSetup &iSetup,
@@ -133,6 +133,10 @@ public:
   bool m_makeHistograms;
 
 private:
+  const edm::ESGetToken<CSCGeometry, MuonGeometryRecord> m_cscGeometryToken;
+  const edm::ESGetToken<Propagator, TrackingComponentsRecord> m_propToken;
+  const edm::ESGetToken<TransientTrackBuilder, TransientTrackRecord> m_tthbToken;
+
   std::string m_mode_string;
   std::string m_reportFileName;
   double m_minP;
@@ -149,7 +153,6 @@ private:
   std::map<std::pair<CSCDetId, CSCDetId>, CSCPairResidualsConstraint *> m_quickChamberLookup;
 
   TrackTransformer *m_trackTransformer;
-  std::string m_propagatorName;
   const Propagator *m_propagatorPointer;
 
   TH1F *m_histP10;

--- a/Alignment/MuonAlignmentAlgorithms/plugins/MuonAlignmentFromReference.cc
+++ b/Alignment/MuonAlignmentAlgorithms/plugins/MuonAlignmentFromReference.cc
@@ -73,7 +73,7 @@ Implementation:
 
 class MuonAlignmentFromReference : public AlignmentAlgorithmBase {
 public:
-  MuonAlignmentFromReference(const edm::ParameterSet& cfg, const edm::ConsumesCollector& iC);
+  MuonAlignmentFromReference(const edm::ParameterSet& cfg, edm::ConsumesCollector& iC);
   ~MuonAlignmentFromReference() override;
 
   void initialize(const edm::EventSetup& iSetup,
@@ -109,6 +109,13 @@ private:
   void eraseNotSelectedResiduals();
 
   void fillNtuple();
+
+  // tokens
+  const edm::ESGetToken<CSCGeometry, MuonGeometryRecord> m_cscGeometryToken;
+  const edm::ESGetToken<GlobalTrackingGeometry, GlobalTrackingGeometryRecord> m_globTackingToken;
+  const edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> m_MagFieldToken;
+  const edm::ESGetToken<Propagator, TrackingComponentsRecord> m_propToken;
+  const edm::ESGetToken<DetIdAssociator, DetIdAssociatorRecord> m_DetIdToken;
 
   // configutarion paramenters:
   edm::InputTag m_muonCollectionTag;
@@ -185,8 +192,13 @@ private:
   bool m_debug;
 };
 
-MuonAlignmentFromReference::MuonAlignmentFromReference(const edm::ParameterSet& cfg, const edm::ConsumesCollector& iC)
+MuonAlignmentFromReference::MuonAlignmentFromReference(const edm::ParameterSet& cfg, edm::ConsumesCollector& iC)
     : AlignmentAlgorithmBase(cfg, iC),
+      m_cscGeometryToken(iC.esConsumes<edm::Transition::BeginRun>()),
+      m_globTackingToken(iC.esConsumes()),
+      m_MagFieldToken(iC.esConsumes()),
+      m_propToken(iC.esConsumes(edm::ESInputTag("", "SteppingHelixPropagatorAny"))),
+      m_DetIdToken(iC.esConsumes(edm::ESInputTag("", "MuonDetIdAssociator"))),
       m_muonCollectionTag(cfg.getParameter<edm::InputTag>("muonCollectionTag")),
       m_reference(cfg.getParameter<std::vector<std::string> >("reference")),
       m_minTrackPt(cfg.getParameter<double>("minTrackPt")),
@@ -335,8 +347,7 @@ void MuonAlignmentFromReference::initialize(const edm::EventSetup& iSetup,
     throw cms::Exception("MuonAlignmentFromReference")
         << "unrecognized useResiduals: \"" << m_useResiduals << "\"" << std::endl;
 
-  edm::ESHandle<CSCGeometry> cscGeometry;
-  iSetup.get<MuonGeometryRecord>().get(cscGeometry);
+  const CSCGeometry* cscGeometry = &iSetup.getData(m_cscGeometryToken);
 
   // set up the MuonResidualsFitters (which also collect residuals for fitting)
   m_me11map.clear();
@@ -389,9 +400,9 @@ void MuonAlignmentFromReference::initialize(const edm::EventSetup& iSetup,
         m_fitters[ali] = new MuonResidualsTwoBin(
             m_twoBin,
             new MuonResiduals6DOFrphiFitter(
-                residualsModel, m_minAlignmentHits, useResiduals, &(*cscGeometry), m_weightAlignment),
+                residualsModel, m_minAlignmentHits, useResiduals, cscGeometry, m_weightAlignment),
             new MuonResiduals6DOFrphiFitter(
-                residualsModel, m_minAlignmentHits, useResiduals, &(*cscGeometry), m_weightAlignment));
+                residualsModel, m_minAlignmentHits, useResiduals, cscGeometry, m_weightAlignment));
         made_fitter = true;
       }
     }
@@ -430,17 +441,10 @@ void MuonAlignmentFromReference::run(const edm::EventSetup& iSetup, const EventI
     std::cout << "****** EVENT START *******" << std::endl;
   m_counter_events++;
 
-  edm::ESHandle<GlobalTrackingGeometry> globalGeometry;
-  iSetup.get<GlobalTrackingGeometryRecord>().get(globalGeometry);
-
-  edm::ESHandle<MagneticField> magneticField;
-  iSetup.get<IdealMagneticFieldRecord>().get(magneticField);
-
-  edm::ESHandle<Propagator> prop;
-  iSetup.get<TrackingComponentsRecord>().get("SteppingHelixPropagatorAny", prop);
-
-  edm::ESHandle<DetIdAssociator> muonDetIdAssociator_;
-  iSetup.get<DetIdAssociatorRecord>().get("MuonDetIdAssociator", muonDetIdAssociator_);
+  const GlobalTrackingGeometry* globalGeometry = &iSetup.getData(m_globTackingToken);
+  const MagneticField* magneticField = &iSetup.getData(m_MagFieldToken);
+  const Propagator* prop = &iSetup.getData(m_propToken);
+  const DetIdAssociator* muonDetIdAssociator = &iSetup.getData(m_DetIdToken);
 
   if (m_muonCollectionTag.label().empty())  // use trajectories
   {
@@ -467,7 +471,7 @@ void MuonAlignmentFromReference::run(const edm::EventSetup& iSetup, const EventI
           MuonResidualsFromTrack muonResidualsFromTrack(iSetup,
                                                         magneticField,
                                                         globalGeometry,
-                                                        muonDetIdAssociator_,
+                                                        muonDetIdAssociator,
                                                         prop,
                                                         traj,
                                                         track,

--- a/Alignment/MuonAlignmentAlgorithms/plugins/MuonAlignmentFromReference.cc
+++ b/Alignment/MuonAlignmentAlgorithms/plugins/MuonAlignmentFromReference.cc
@@ -73,7 +73,7 @@ Implementation:
 
 class MuonAlignmentFromReference : public AlignmentAlgorithmBase {
 public:
-  MuonAlignmentFromReference(const edm::ParameterSet& cfg);
+  MuonAlignmentFromReference(const edm::ParameterSet& cfg, const edm::ConsumesCollector& iC);
   ~MuonAlignmentFromReference() override;
 
   void initialize(const edm::EventSetup& iSetup,
@@ -185,8 +185,8 @@ private:
   bool m_debug;
 };
 
-MuonAlignmentFromReference::MuonAlignmentFromReference(const edm::ParameterSet& cfg)
-    : AlignmentAlgorithmBase(cfg),
+MuonAlignmentFromReference::MuonAlignmentFromReference(const edm::ParameterSet& cfg, const edm::ConsumesCollector& iC)
+    : AlignmentAlgorithmBase(cfg, iC),
       m_muonCollectionTag(cfg.getParameter<edm::InputTag>("muonCollectionTag")),
       m_reference(cfg.getParameter<std::vector<std::string> >("reference")),
       m_minTrackPt(cfg.getParameter<double>("minTrackPt")),

--- a/Alignment/MuonAlignmentAlgorithms/plugins/MuonMillepedeAlgorithm.cc
+++ b/Alignment/MuonAlignmentAlgorithms/plugins/MuonMillepedeAlgorithm.cc
@@ -31,7 +31,8 @@
 
 // Constructor ----------------------------------------------------------------
 
-MuonMillepedeAlgorithm::MuonMillepedeAlgorithm(const edm::ParameterSet &cfg) : AlignmentAlgorithmBase(cfg) {
+MuonMillepedeAlgorithm::MuonMillepedeAlgorithm(const edm::ParameterSet &cfg, const edm::ConsumesCollector &iC)
+    : AlignmentAlgorithmBase(cfg, iC) {
   // parse parameters
 
   edm::LogWarning("Alignment") << "[MuonMillepedeAlgorithm] constructed.";

--- a/Alignment/MuonAlignmentAlgorithms/plugins/MuonMillepedeAlgorithm.h
+++ b/Alignment/MuonAlignmentAlgorithms/plugins/MuonMillepedeAlgorithm.h
@@ -19,7 +19,7 @@ class TTree;
 class MuonMillepedeAlgorithm : public AlignmentAlgorithmBase {
 public:
   /// Constructor
-  MuonMillepedeAlgorithm(const edm::ParameterSet& cfg);
+  MuonMillepedeAlgorithm(const edm::ParameterSet& cfg, const edm::ConsumesCollector& iC);
 
   /// Destructor
   ~MuonMillepedeAlgorithm() override{};

--- a/Alignment/SurveyAnalysis/plugins/SurveyAlignmentAlgorithm.cc
+++ b/Alignment/SurveyAnalysis/plugins/SurveyAlignmentAlgorithm.cc
@@ -5,8 +5,8 @@
 
 #include "Alignment/SurveyAnalysis/plugins/SurveyAlignmentAlgorithm.h"
 
-SurveyAlignmentAlgorithm::SurveyAlignmentAlgorithm(const edm::ParameterSet& cfg)
-    : AlignmentAlgorithmBase(cfg),
+SurveyAlignmentAlgorithm::SurveyAlignmentAlgorithm(const edm::ParameterSet& cfg, const edm::ConsumesCollector& iC)
+    : AlignmentAlgorithmBase(cfg, iC),
       theOutfile(cfg.getParameter<std::string>("outfile")),
       theIterations(cfg.getParameter<unsigned int>("nIteration")),
       theLevels(cfg.getParameter<std::vector<std::string> >("levels")) {}

--- a/Alignment/SurveyAnalysis/plugins/SurveyAlignmentAlgorithm.h
+++ b/Alignment/SurveyAnalysis/plugins/SurveyAlignmentAlgorithm.h
@@ -24,7 +24,7 @@ class AlignableExtras;
 
 class SurveyAlignmentAlgorithm : public AlignmentAlgorithmBase {
 public:
-  SurveyAlignmentAlgorithm(const edm::ParameterSet&);
+  SurveyAlignmentAlgorithm(const edm::ParameterSet&, const edm::ConsumesCollector&);
 
   /// call at start of job
   void initialize(


### PR DESCRIPTION
#### PR description:

Part of #31061.
Its purpose is to migrate the core base classes of `Alignment/CommonAlignmentAlgorithm` and percolate it down to `MillePedeAlignmentAlgorithm` and `HIPAlignmentAlgorithm`.

#### PR validation:

It compiles and runs successfully wf. 1001.0 (it exercises the MillePede algo via the `SiPixelAli` PCL worfklow).
In addition run a SiPixelAli workflow with more statistics:
```
cmsDriver.py milleStep --data --conditions auto:run3_data_express --triggerResultsProcess RECO --scenario pp --datatier ALCARECO --eventcontent ALCARECO --era Run2_2018 -s ALCA:PromptCalibProdSiPixelAli --dasquery='file dataset=/StreamExpress/Run2018B-TkAlMinBias-Express-v1/ALCARECO run=317320' -n 10000 --processName=ReAlCA
```
followed by:
```
cmsDriver.py pedeStep --data --conditions auto:run3_data_express --era Run2_2018 --scenario pp -s ALCAHARVEST:SiPixelAli --filein file:PromptCalibProdSiPixelAli.root 
```
A more thorough validation from the Tracker Alignment group is available [here](https://indico.cern.ch/event/1000811/contributions/4409493/attachments/2265304/3846194/meeting_16_06.pdf).

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This is not a backport, no backport is needed.
cc:
@antoniovagnerini @vbotta 

