### PR TITLE
Use genTauJet modules coherently across different nanoAOD cffs

### DIFF
--- a/PhysicsTools/NanoAOD/python/nanogen_cff.py
+++ b/PhysicsTools/NanoAOD/python/nanogen_cff.py
@@ -26,10 +26,7 @@ nanogenSequence = cms.Sequence(
     genJetAK8Table+
     genJetAK8FlavourAssociation+
     genJetAK8FlavourTable+
-    tauGenJets+
-    tauGenJetsSelectorAllHadrons+
-    genVisTaus+
-    genVisTauTable+
+    genTauSequence+
     genTable+
     genParticleTables+
     genVertexTables+
@@ -80,7 +77,7 @@ def customizeNanoGENFromMini(process):
 
     process.genJetTable.src = "slimmedGenJets"
     process.genJetAK8Table.src = "slimmedGenJetsAK8"
-    process.tauGenJets.GenParticles = "prunedGenParticles"
+    process.tauGenJetsForNano.GenParticles = "prunedGenParticles"
     process.genVisTaus.srcGenParticles = "prunedGenParticles"
 
     nanoGenCommonCustomize(process)
@@ -98,7 +95,7 @@ def customizeNanoGEN(process):
 
     process.genJetTable.src = "ak4GenJets"
     process.genJetAK8Table.src = "ak8GenJets"
-    process.tauGenJets.GenParticles = "genParticles"
+    process.tauGenJetsForNano.GenParticles = "genParticles"
     process.genVisTaus.srcGenParticles = "genParticles"
 
     # In case customizeNanoGENFromMini has already been called

--- a/PhysicsTools/NanoAOD/python/taus_cff.py
+++ b/PhysicsTools/NanoAOD/python/taus_cff.py
@@ -246,5 +246,6 @@ tauSequence = cms.Sequence(patTauMVAIDsSeq + finalTaus)
 _tauSequence80X =  cms.Sequence(finalTaus)
 run2_miniAOD_80XLegacy.toReplaceWith(tauSequence,_tauSequence80X)
 tauTables = cms.Sequence(tauTable)
-tauMC = cms.Sequence(tauGenJetsForNano + tauGenJetsSelectorAllHadronsForNano + genVisTaus + genVisTauTable + tausMCMatchLepTauForTable + tausMCMatchHadTauForTable + tauMCTable)
+genTauSequence = cms.Sequence(tauGenJetsForNano + tauGenJetsSelectorAllHadronsForNano + genVisTaus + genVisTauTable)
+tauMC = cms.Sequence(genTauSequence + tausMCMatchLepTauForTable + tausMCMatchHadTauForTable + tauMCTable)
 


### PR DESCRIPTION
#### PR description:

In this PR genTauJets and related table modules are put into a new sequence called  `genTauSequence` with is then used in the original `tauMC` sequence and in `nanogenSequence` in `nanogen_cff.py`. Name of a tauGenJets module is also updated in the latter cff. Those developments are purely technical and fix issue reported in https://github.com/cms-sw/cmssw/issues/33578 and introduced by #33522 without changing physics content.

This PR will be backported to 106X for NanoAODv9

#### PR validation:

Tested with `runTheMatrix.py -l 546,547,548 -i all --ibeos`
