### PR TITLE
LowPtElectrons: final energy regression and ID (back port of 32391)

### DIFF
--- a/PhysicsTools/PatAlgos/python/producersLayer1/lowPtElectronProducer_cff.py
+++ b/PhysicsTools/PatAlgos/python/producersLayer1/lowPtElectronProducer_cff.py
@@ -27,8 +27,6 @@ patLowPtElectrons = patElectrons.clone(
     ),
 
     # Embedding of RECO/AOD items
-
-    # Embedding of RECO/AOD items
     embedTrack                  = True,
     embedGsfElectronCore        = True,
     embedGsfTrack               = True,
@@ -71,10 +69,16 @@ from Configuration.Eras.Modifier_run2_miniAOD_94XFall17_cff import run2_miniAOD_
 
 # Schedule rekeying of seed BDT ValueMaps by reco::GsfElectron for run2_miniAOD_UL and bParking
 from Configuration.ProcessModifiers.run2_miniAOD_UL_cff import run2_miniAOD_UL
+from Configuration.Eras.Modifier_run2_miniAOD_devel_cff import run2_miniAOD_devel
 from Configuration.Eras.Modifier_bParking_cff import bParking
+
 from RecoEgamma.EgammaElectronProducers.lowPtGsfElectronSeedValueMaps_cff import rekeyLowPtGsfElectronSeedValueMaps
 from RecoEgamma.EgammaElectronProducers.lowPtGsfElectronID_cff import lowPtGsfElectronID
+from RecoEgamma.EgammaElectronProducers.lowPtGsfElectrons_cff import lowPtGsfElectrons
+
 _makePatLowPtElectronsTask = makePatLowPtElectronsTask.copy()
 _makePatLowPtElectronsTask.add(rekeyLowPtGsfElectronSeedValueMaps)
 _makePatLowPtElectronsTask.add(lowPtGsfElectronID)
 (bParking | run2_miniAOD_UL).toReplaceWith(makePatLowPtElectronsTask,_makePatLowPtElectronsTask)
+( (bParking & run2_miniAOD_UL) | (~bParking & run2_miniAOD_devel) ).toModify(
+    makePatLowPtElectronsTask, func = lambda t: t.add(lowPtGsfElectrons))

--- a/PhysicsTools/PatAlgos/python/selectionLayer1/lowPtElectronSelector_cfi.py
+++ b/PhysicsTools/PatAlgos/python/selectionLayer1/lowPtElectronSelector_cfi.py
@@ -9,9 +9,13 @@ selectedPatLowPtElectrons = cms.EDFilter("PATElectronSelector",
     cut = cms.string("pt>1. && electronID('ID')>1.5"),
 )
 
+# Modifier for run2_miniAOD_devel
+from Configuration.Eras.Modifier_run2_miniAOD_devel_cff import run2_miniAOD_devel
+run2_miniAOD_devel.toModify(selectedPatLowPtElectrons,cut = "pt>1. && electronID('ID')>-0.25")
+
 # Modifier for bParking (fully open selection)
 from Configuration.Eras.Modifier_bParking_cff import bParking
-bParking.toModify(selectedPatLowPtElectrons,cut = "")
+bParking.toModify(selectedPatLowPtElectrons,cut = "pt>1.")
 
 # Modifiers for legacy AOD
 from Configuration.Eras.Modifier_run2_miniAOD_80XLegacy_cff import run2_miniAOD_80XLegacy

--- a/RecoEgamma/EgammaElectronProducers/plugins/LowPtGsfElectronFinalizer.cc
+++ b/RecoEgamma/EgammaElectronProducers/plugins/LowPtGsfElectronFinalizer.cc
@@ -1,0 +1,65 @@
+#include "CommonTools/CandAlgos/interface/ModifyObjectValueBase.h"
+#include "DataFormats/EgammaCandidates/interface/GsfElectron.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+
+class LowPtGsfElectronFinalizer : public edm::stream::EDProducer<> {
+public:
+  explicit LowPtGsfElectronFinalizer(const edm::ParameterSet&);
+
+  void produce(edm::Event&, const edm::EventSetup&) override;
+
+  static void fillDescriptions(edm::ConfigurationDescriptions&);
+
+private:
+  const edm::EDGetTokenT<reco::GsfElectronCollection> previousGsfElectrons_;
+  std::unique_ptr<ModifyObjectValueBase> regression_;
+
+  const edm::EDPutTokenT<reco::GsfElectronCollection> putToken_;
+};
+
+using edm::InputTag;
+using reco::GsfElectronCollection;
+
+LowPtGsfElectronFinalizer::LowPtGsfElectronFinalizer(const edm::ParameterSet& cfg)
+    : previousGsfElectrons_{consumes<GsfElectronCollection>(cfg.getParameter<InputTag>("previousGsfElectronsTag"))},
+      putToken_{produces<GsfElectronCollection>()} {
+  auto const& iconf = cfg.getParameterSet("regressionConfig");
+  auto const& mname = iconf.getParameter<std::string>("modifierName");
+  auto cc = consumesCollector();
+  regression_.reset(ModifyObjectValueFactory::get()->create(mname, iconf, cc));
+}
+
+void LowPtGsfElectronFinalizer::produce(edm::Event& event, const edm::EventSetup& setup) {
+  // Setup regression for event
+  regression_->setEvent(event);
+  regression_->setEventContent(setup);
+
+  // Create new modified electron collection
+  reco::GsfElectronCollection outputElectrons;
+  for (auto const& electron : event.get(previousGsfElectrons_)) {
+    outputElectrons.emplace_back(electron);
+    auto& newElectron = outputElectrons.back();
+    regression_->modifyObject(newElectron);
+  }
+
+  // Emplace modified electrons to event
+  event.emplace(putToken_, std::move(outputElectrons));
+}
+
+void LowPtGsfElectronFinalizer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.add<edm::InputTag>("previousGsfElectronsTag", {});
+  edm::ParameterSetDescription psd;
+  psd.setUnknown();
+  desc.add<edm::ParameterSetDescription>("regressionConfig", psd);
+  descriptions.addWithDefaultLabel(desc);
+}
+
+#include "FWCore/Framework/interface/MakerMacros.h"
+DEFINE_FWK_MODULE(LowPtGsfElectronFinalizer);

--- a/RecoEgamma/EgammaElectronProducers/python/lowPtGsfElectronID_cff.py
+++ b/RecoEgamma/EgammaElectronProducers/python/lowPtGsfElectronID_cff.py
@@ -13,7 +13,7 @@ lowPtGsfElectronID = defaultLowPtGsfElectronID.clone(
 from Configuration.ProcessModifiers.run2_miniAOD_UL_cff import run2_miniAOD_UL
 from Configuration.Eras.Modifier_run2_miniAOD_devel_cff import run2_miniAOD_devel
 from Configuration.Eras.Modifier_bParking_cff import bParking
-( run2_miniAOD_UL | bParking ).toModify(
+run2_miniAOD_UL.toModify(
     lowPtGsfElectronID,
     rho = "fixedGridRhoFastjetAll",
     ModelWeights = ["RecoEgamma/ElectronIdentification/data/LowPtElectrons/LowPtElectrons_ID_2020Sept15.root"],

--- a/RecoEgamma/EgammaElectronProducers/python/lowPtGsfElectronID_cff.py
+++ b/RecoEgamma/EgammaElectronProducers/python/lowPtGsfElectronID_cff.py
@@ -24,7 +24,7 @@ run2_miniAOD_devel.toModify(
     lowPtGsfElectronID,
     ModelWeights = ["RecoEgamma/ElectronIdentification/data/LowPtElectrons/LowPtElectrons_ID_2020Nov28.root"],
 )
-bParking.toModify(
+(bParking & run2_miniAOD_UL).toModify(
     lowPtGsfElectronID,
     ModelWeights = ["RecoEgamma/ElectronIdentification/data/LowPtElectrons/LowPtElectrons_ID_2021May17.root"],
 )

--- a/RecoEgamma/EgammaElectronProducers/python/lowPtGsfElectronID_cff.py
+++ b/RecoEgamma/EgammaElectronProducers/python/lowPtGsfElectronID_cff.py
@@ -11,10 +11,20 @@ lowPtGsfElectronID = defaultLowPtGsfElectronID.clone(
     )
 
 from Configuration.ProcessModifiers.run2_miniAOD_UL_cff import run2_miniAOD_UL
-run2_miniAOD_UL.toModify(
+from Configuration.Eras.Modifier_run2_miniAOD_devel_cff import run2_miniAOD_devel
+from Configuration.Eras.Modifier_bParking_cff import bParking
+( run2_miniAOD_UL | bParking ).toModify(
     lowPtGsfElectronID,
     rho = "fixedGridRhoFastjetAll",
     ModelWeights = ["RecoEgamma/ElectronIdentification/data/LowPtElectrons/LowPtElectrons_ID_2020Sept15.root"],
     ModelThresholds = [-99.],
     Version = "V1",
+)
+run2_miniAOD_devel.toModify(
+    lowPtGsfElectronID,
+    ModelWeights = ["RecoEgamma/ElectronIdentification/data/LowPtElectrons/LowPtElectrons_ID_2020Nov28.root"],
+)
+bParking.toModify(
+    lowPtGsfElectronID,
+    ModelWeights = ["RecoEgamma/ElectronIdentification/data/LowPtElectrons/LowPtElectrons_ID_2021May17.root"],
 )

--- a/RecoEgamma/EgammaElectronProducers/python/lowPtGsfElectronSequence_cff.py
+++ b/RecoEgamma/EgammaElectronProducers/python/lowPtGsfElectronSequence_cff.py
@@ -63,7 +63,7 @@ from RecoEgamma.EgammaElectronProducers.lowPtGsfElectronSuperClusters_cff import
 from RecoEgamma.EgammaElectronProducers.lowPtGsfElectronCores_cff import *
 
 # Low pT electrons
-from RecoEgamma.EgammaElectronProducers.lowPtGsfElectrons_cfi import *
+from RecoEgamma.EgammaElectronProducers.lowPtGsfElectrons_cff import lowPtGsfElectrons
 
 # Low pT Electron value maps
 from RecoEgamma.EgammaElectronProducers.lowPtGsfElectronSeedValueMaps_cff import lowPtGsfElectronSeedValueMaps

--- a/RecoEgamma/EgammaElectronProducers/python/lowPtGsfElectronsPreRegression_cfi.py
+++ b/RecoEgamma/EgammaElectronProducers/python/lowPtGsfElectronsPreRegression_cfi.py
@@ -5,7 +5,7 @@ from RecoEcal.EgammaClusterProducers.multi5x5BasicClusters_cfi import *
 from RecoEgamma.EgammaIsolationAlgos.electronTrackIsolations_cfi import trkIsol03CfgV1,trkIsol04CfgV1
 from RecoEgamma.EgammaIsolationAlgos.electronTrackIsolations_cfi import trkIsol03CfgV2,trkIsol04CfgV2
 
-lowPtGsfElectrons = cms.EDProducer(
+lowPtGsfElectronsPreRegression = cms.EDProducer(
     "LowPtGsfElectronProducer",
     
     # input collections
@@ -63,8 +63,8 @@ lowPtGsfElectrons = cms.EDProducer(
     )
 
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
-fastSim.toModify(lowPtGsfElectrons,ctfTracksTag = cms.InputTag("generalTracksBeforeMixing"))
+fastSim.toModify(lowPtGsfElectronsPreRegression,ctfTracksTag = cms.InputTag("generalTracksBeforeMixing"))
 
 from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018
-pp_on_AA_2018.toModify(lowPtGsfElectrons.preselection, minSCEtBarrel = 15.0)
-pp_on_AA_2018.toModify(lowPtGsfElectrons.preselection, minSCEtEndcaps = 15.0)
+pp_on_AA_2018.toModify(lowPtGsfElectronsPreRegression.preselection, minSCEtBarrel = 15.0)
+pp_on_AA_2018.toModify(lowPtGsfElectronsPreRegression.preselection, minSCEtEndcaps = 15.0)

--- a/RecoEgamma/EgammaElectronProducers/python/lowPtGsfElectrons_cff.py
+++ b/RecoEgamma/EgammaElectronProducers/python/lowPtGsfElectrons_cff.py
@@ -1,0 +1,55 @@
+import FWCore.ParameterSet.Config as cms
+from RecoEgamma.EgammaElectronProducers.lowPtGsfElectronsPreRegression_cfi import lowPtGsfElectronsPreRegression
+
+lowPtGsfElectrons = lowPtGsfElectronsPreRegression.clone()
+
+################################################################################
+# LowPtGsfElectronProducer above is run by default in RECO
+# LowPtGsfElectronFinalizer below is scheduled for run2_miniAOD_UL
+
+from RecoEgamma.EgammaTools.regressionModifier_cfi import regressionModifier106XUL
+_lowPtRegressionModifier = regressionModifier106XUL.clone(
+    modifierName = 'EGRegressionModifierV3',
+    rhoTag = 'fixedGridRhoFastjetAll',
+    eleRegs = dict(
+        ecalOnlyMean = dict(
+            lowEtHighEtBoundary = 20.,
+            ebLowEtForestName = "lowPtElectron_eb_ecalOnly_05To50_mean",
+            ebHighEtForestName = "lowPtElectron_eb_ecalOnly_05To50_mean",
+            eeLowEtForestName = "lowPtElectron_ee_ecalOnly_05To50_mean",
+            eeHighEtForestName = "lowPtElectron_ee_ecalOnly_05To50_mean",
+            ),
+        ecalOnlySigma = dict(
+            lowEtHighEtBoundary = 20.,
+            ebLowEtForestName = "lowPtElectron_eb_ecalOnly_05To50_sigma",
+            ebHighEtForestName = "lowPtElectron_eb_ecalOnly_05To50_sigma",
+            eeLowEtForestName = "lowPtElectron_ee_ecalOnly_05To50_sigma",
+            eeHighEtForestName = "lowPtElectron_ee_ecalOnly_05To50_sigma",
+            ),
+        epComb = dict(
+            ecalTrkRegressionConfig = dict(
+                lowEtHighEtBoundary = 20.,
+                ebLowEtForestName = "lowPtElectron_eb_ecalTrk_05To50_mean",
+                ebHighEtForestName = "lowPtElectron_eb_ecalTrk_05To50_mean",
+                eeLowEtForestName = "lowPtElectron_ee_ecalTrk_05To50_mean",
+                eeHighEtForestName = "lowPtElectron_ee_ecalTrk_05To50_mean",
+                ),
+            ecalTrkRegressionUncertConfig = dict(
+                lowEtHighEtBoundary = 20.,
+                ebLowEtForestName = "lowPtElectron_eb_ecalTrk_05To50_sigma",
+                ebHighEtForestName = "lowPtElectron_eb_ecalTrk_05To50_sigma",
+                eeLowEtForestName = "lowPtElectron_ee_ecalTrk_05To50_sigma",
+                eeHighEtForestName = "lowPtElectron_ee_ecalTrk_05To50_sigma",
+                ),
+        )
+    ),
+)
+
+from RecoEgamma.EgammaElectronProducers.lowPtGsfElectronFinalizer_cfi import lowPtGsfElectronFinalizer
+_lowPtGsfElectrons = lowPtGsfElectronFinalizer.clone(
+    previousGsfElectronsTag = "lowPtGsfElectrons::@skipCurrentProcess",
+    regressionConfig = _lowPtRegressionModifier,
+)
+
+from Configuration.ProcessModifiers.run2_miniAOD_UL_cff import run2_miniAOD_UL
+run2_miniAOD_UL.toReplaceWith(lowPtGsfElectrons,_lowPtGsfElectrons)


### PR DESCRIPTION
#### PR description:

This PR:

- Provides support for UL re-MINIAOD of both "standard" and BParking data sets, using the modifiers `bParking`, `run2_miniAOD_UL`, and `run2_miniAOD_devel`.

- Leaves the RECO sequence, and RECO/AOD content, unchanged w.r.t. 10_6_25. 
 
- Enables energy regression for certain modifier configurations (detailed below). The energy regression performance can be found on slides 6-7 [here](https://indico.cern.ch/event/1034467/contributions/4344267/attachments/2248230/3813485/LowPtElectrons_PPDMay21.pdf).

- Enables new electron ID models for certain modifier configurations (detailed below). The performance of the ID models 2020Nov28 and 2021May17 can be found on slides 4-5 [here](https://indico.cern.ch/event/1034467/contributions/4344267/attachments/2248230/3813485/LowPtElectrons_PPDMay21.pdf).

- Depends on PR cms-data/RecoEgamma-ElectronIdentification#19 

A detailed summary of the modifier configurations provided in this PR can be found at this [TWiki](https://twiki.cern.ch/twiki/bin/view/Main/RobBainbridgeSandBox#Support_for_CMSSW_releases_and_d) (see table). A brief summary is provided below.

1) *No changes to the RECO sequence are applied.*

2) *No-change policy for UL re-MINIAOD of standard data sets, modifier `(~bParking & run2_miniAOD_UL)`:*

- the functionality provided by this logic is preserved w.r.t. release CMSSW_10_6_20, which was used as part of the Winter 2020 UL re-MINIAOD campaign for standard data sets. (No energy regression is performed; the 2020Sept15 ID model is evaluated.)

3) *Changes to PAT for any future (re)MINIAOD campaign for standard data sets, modifier `(~bParking & run2_miniAOD_devel)`:*

- Energy regression is performed as part of the re-MINIAOD sequence.

- ID is evaluated as part of the re-MINIAOD sequence. A new ID weights file (2020Nov28) has been provided for use with a UL re-MINIAOD campaign. There is no appreciable extra CPU load (w.r.t. the original model), and the memory footprint will reduce (due to the smaller weights file). The 2020Nov28 model is available within PR cms-data/RecoEgamma-ElectronIdentification#19.

- Low-pT PAT electrons are selected based on the following conditions `pT > 1.0 GeV and ID score > -0.25`, which provides 90% signal efficiency, a 10% mistag rate, resulting in an increase to the MINIAOD footprint of ~1%.

4) *Changes to PAT for any future (re)MINIAOD campaign for the BParking data set, modifier `(bParking & run2_miniAOD_UL)`:*

- Energy regression is performed as part of the re-MINIAOD sequence.

- ID is evaluated as part of the re-MINIAOD sequence. A new ID weights file (2021May17), has been provided for use with a UL re-MINIAOD campaign. There is no appreciable extra CPU load (w.r.t. the original model), and the memory footprint will reduce (due to the smaller weights file). The 2021May17 model is available within PR cms-data/RecoEgamma-ElectronIdentification#19.

- Low-pT PAT electrons are selected based on the following conditions `pT > 1.0 GeV`. Computing performance studies can be found [below](https://github.com/cms-sw/cmssw/pull/33589#issuecomment-840673517). The raising of the minimum electron pT threshold from 'open' (effectively ~0.5 GeV) to 1.0 GeV reduces the MINIAOD event size by ~20%, based on the 136.898 workflow (data ParkingBPH 2018B).

#### PR validation:

  - Local checks performed for both the RECO and PAT steps, for all relevant modifier configurations
  - The following workflows were considered: 136.88811, 1325.518, 136.898
  - the 2020Nov28 and 2021May17 model performances in CMSSW were validated against our standalone test bench setup. 

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This PR is a back port of cms-sw/cmssw#32391

#### Forward port of additional functionality

- Most for the aforementioned changes are already in master (merged PR: cms-sw/cmssw#32391)
- However, a few recent changes have also been "forward ported" to a new PR to master: https://github.com/cms-sw/cmssw/pull/33725
