### PR TITLE
fix handling of air/iron in DD4hep MF construction

### DIFF
--- a/MagneticField/GeomBuilder/src/DD4hep_volumeHandle.cc
+++ b/MagneticField/GeomBuilder/src/DD4hep_volumeHandle.cc
@@ -137,8 +137,8 @@ volumeHandle::volumeHandle(const cms::DDFilteredView &fv, bool expand2Pi, bool d
           << "ctor: Unexpected shape # " << static_cast<int>(theShape) << " for vol " << name;
   }
 
-  // Get material for this volume
-  if (fv.materialName() == "Iron")
+  // The only materials used in the geometry are: materials:Air, d=0.001214; materials:Iron, d=7.87
+  if (fv.volume().material().density() > 3.)
     isIronFlag = true;
 
   if (debug) {


### PR DESCRIPTION
#### PR description:

MF yoke volumes are labelled as being iron for the purpose of [track propagation in SHP](https://github.com/cms-sw/cmssw/blob/master/TrackPropagation/SteppingHelixPropagator/src/SteppingHelixPropagator.cc#L2457) . This was broken in DD4hep because the label is based on material name, which is reported with an unexpected "materials:" namespace in DD4hep.
To avoid this, the distinction is now made based on material density.

This is the origin of a discrepancy that has been observed in the DD4hep vs DDD validation for STA muons.

#### PR validation:

Checked that the isIron flag is now assigned correctly.
