### PR TITLE
Bug fix for tag lock clean up at session closing time

### DIFF
--- a/CondCore/CondDB/src/IOVEditor.cc
+++ b/CondCore/CondDB/src/IOVEditor.cc
@@ -97,8 +97,7 @@ namespace cond {
               tag, m_session->sessionHash, cond::auth::COND_SESSION_HASH_CODE, cond::auth::COND_DBTAG_LOCK_ACCESS_CODE);
           if (!mylock)
             cond::throwException(
-                "Tag \"" + tag + "\" can't be accessed for update, because it has been locked by an other session. \"" +
-                    m_session->principalName + "\".",
+                "Tag \"" + tag + "\" can't be accessed for update, because it has been locked by an other session.",
                 "IOVEditor::load");
         }
       }

--- a/CondCore/CondDB/src/SessionImpl.cc
+++ b/CondCore/CondDB/src/SessionImpl.cc
@@ -43,15 +43,15 @@ namespace cond {
     SessionImpl::~SessionImpl() { close(); }
 
     void SessionImpl::close() {
-      if (coralSession.get()) {
-        if (coralSession->transaction().isActive()) {
-          coralSession->transaction().rollback();
-        }
+      if( isActive() ) {
+	if(coralSession->transaction().isActive()){
+	  rollbackTransaction();
+	}
         if (!lockedTags.empty()) {
-          coralSession->transaction().start(true);
-          releaseTagLocks();
-          coralSession->transaction().commit();
-        }
+	  startTransaction(false);
+	  releaseTagLocks();
+          commitTransaction();
+	}
         coralSession.reset();
       }
       transaction.reset();

--- a/CondCore/CondDB/src/SessionImpl.cc
+++ b/CondCore/CondDB/src/SessionImpl.cc
@@ -43,15 +43,15 @@ namespace cond {
     SessionImpl::~SessionImpl() { close(); }
 
     void SessionImpl::close() {
-      if( isActive() ) {
-	if(coralSession->transaction().isActive()){
-	  rollbackTransaction();
-	}
+      if (isActive()) {
+        if (coralSession->transaction().isActive()) {
+          rollbackTransaction();
+        }
         if (!lockedTags.empty()) {
-	  startTransaction(false);
-	  releaseTagLocks();
+          startTransaction(false);
+          releaseTagLocks();
           commitTransaction();
-	}
+        }
         coralSession.reset();
       }
       transaction.reset();

--- a/CondCore/DBOutputService/test/stubs/LumiBasedUpdateAnalyzer.cc
+++ b/CondCore/DBOutputService/test/stubs/LumiBasedUpdateAnalyzer.cc
@@ -9,26 +9,35 @@
 #include <iostream>
 
 LumiBasedUpdateAnalyzer::LumiBasedUpdateAnalyzer(const edm::ParameterSet& iConfig)
-    : m_record(iConfig.getParameter<std::string>("record")) {}
+  : m_record(iConfig.getParameter<std::string>("record")), m_ret(-2) {}
+
 LumiBasedUpdateAnalyzer::~LumiBasedUpdateAnalyzer() {
-  std::cout << "LumiBasedUpdateAnalyzer::~LumiBasedUpdateAnalyzer" << std::endl;
 }
-void LumiBasedUpdateAnalyzer::analyze(const edm::Event& evt, const edm::EventSetup& evtSetup) {
-  std::cout << "LumiBasedUpdateAnalyzer::analyze " << std::endl;
+
+void LumiBasedUpdateAnalyzer::beginJob() {
   edm::Service<cond::service::OnlineDBOutputService> mydbservice;
   if (!mydbservice.isAvailable()) {
-    std::cout << "Service is unavailable" << std::endl;
+    return;
+  }
+  mydbservice->lockRecords();
+}
+    
+void LumiBasedUpdateAnalyzer::endJob() {
+  edm::Service<cond::service::OnlineDBOutputService> mydbservice;
+  if (mydbservice.isAvailable()) {
+    mydbservice->releaseLocks();
+  }
+}
+
+void LumiBasedUpdateAnalyzer::beginLuminosityBlock(const edm::LuminosityBlock& lumiSeg, const edm::EventSetup& context) {
+  edm::Service<cond::service::OnlineDBOutputService> mydbservice;
+  if (!mydbservice.isAvailable()) {
     return;
   }
   mydbservice->logger().start();
-  if (!m_tagLocks) {
-    mydbservice->lockRecords();
-    m_tagLocks = true;
-  }
   ::sleep(2);
-  //unsigned int irun = evt.id().run();
-  unsigned int irun = evt.getLuminosityBlock().run();
-  unsigned int lumiId = evt.getLuminosityBlock().luminosityBlock();
+  unsigned int irun = lumiSeg.getRun().run();
+  unsigned int lumiId = lumiSeg.luminosityBlock();
   std::string tag = mydbservice->tag(m_record);
   std::cout << "tag " << tag << std::endl;
   std::cout << "run " << irun << std::endl;
@@ -39,20 +48,26 @@ void LumiBasedUpdateAnalyzer::analyze(const edm::Event& evt, const edm::EventSet
   mybeamspot.SetType(int(lumiId));
   std::cout << mybeamspot.GetBeamType() << std::endl;
   mydbservice->logger().logDebug() << "BeamType: " << mybeamspot.GetBeamType();
-  int ret = 0;
+  m_ret = 0;
   try {
     mydbservice->writeForNextLumisection(&mybeamspot, m_record);
   } catch (const std::exception& e) {
     std::cout << "Error:" << e.what() << std::endl;
     mydbservice->logger().logError() << e.what();
-    ret = -1;
-  }
-  mydbservice->logger().end(ret);
-}
-void LumiBasedUpdateAnalyzer::endJob() {
-  if (m_tagLocks) {
-    edm::Service<cond::service::OnlineDBOutputService> mydbservice;
-    mydbservice->releaseLocks();
+    m_ret = -1;
   }
 }
+
+void LumiBasedUpdateAnalyzer::endLuminosityBlock(const edm::LuminosityBlock& lumiSeg, const edm::EventSetup& iSetup) {
+  edm::Service<cond::service::OnlineDBOutputService> mydbservice;
+  if (mydbservice.isAvailable()) {
+    mydbservice->logger().logInfo() << "EndLuminosityBlock";
+    mydbservice->logger().end(m_ret);
+  }
+}
+
+void LumiBasedUpdateAnalyzer::analyze(const edm::Event& evt, const edm::EventSetup& evtSetup) {
+  std::cout << "LumiBasedUpdateAnalyzer::analyze " << std::endl;
+}
+
 DEFINE_FWK_MODULE(LumiBasedUpdateAnalyzer);

--- a/CondCore/DBOutputService/test/stubs/LumiBasedUpdateAnalyzer.cc
+++ b/CondCore/DBOutputService/test/stubs/LumiBasedUpdateAnalyzer.cc
@@ -9,10 +9,9 @@
 #include <iostream>
 
 LumiBasedUpdateAnalyzer::LumiBasedUpdateAnalyzer(const edm::ParameterSet& iConfig)
-  : m_record(iConfig.getParameter<std::string>("record")), m_ret(-2) {}
+    : m_record(iConfig.getParameter<std::string>("record")), m_ret(-2) {}
 
-LumiBasedUpdateAnalyzer::~LumiBasedUpdateAnalyzer() {
-}
+LumiBasedUpdateAnalyzer::~LumiBasedUpdateAnalyzer() {}
 
 void LumiBasedUpdateAnalyzer::beginJob() {
   edm::Service<cond::service::OnlineDBOutputService> mydbservice;
@@ -21,7 +20,7 @@ void LumiBasedUpdateAnalyzer::beginJob() {
   }
   mydbservice->lockRecords();
 }
-    
+
 void LumiBasedUpdateAnalyzer::endJob() {
   edm::Service<cond::service::OnlineDBOutputService> mydbservice;
   if (mydbservice.isAvailable()) {
@@ -29,7 +28,8 @@ void LumiBasedUpdateAnalyzer::endJob() {
   }
 }
 
-void LumiBasedUpdateAnalyzer::beginLuminosityBlock(const edm::LuminosityBlock& lumiSeg, const edm::EventSetup& context) {
+void LumiBasedUpdateAnalyzer::beginLuminosityBlock(const edm::LuminosityBlock& lumiSeg,
+                                                   const edm::EventSetup& context) {
   edm::Service<cond::service::OnlineDBOutputService> mydbservice;
   if (!mydbservice.isAvailable()) {
     return;

--- a/CondCore/DBOutputService/test/stubs/LumiBasedUpdateAnalyzer.h
+++ b/CondCore/DBOutputService/test/stubs/LumiBasedUpdateAnalyzer.h
@@ -17,12 +17,15 @@ class LumiBasedUpdateAnalyzer : public edm::EDAnalyzer {
 public:
   explicit LumiBasedUpdateAnalyzer(const edm::ParameterSet& iConfig);
   virtual ~LumiBasedUpdateAnalyzer();
-  virtual void analyze(const edm::Event& evt, const edm::EventSetup& evtSetup);
+  virtual void beginJob();
   virtual void endJob();
+  virtual void beginLuminosityBlock(const edm::LuminosityBlock& lumiSeg, const edm::EventSetup& context);
+  virtual void endLuminosityBlock(const edm::LuminosityBlock& lumiSeg, const edm::EventSetup& iSetup);
+  virtual void analyze(const edm::Event& evt, const edm::EventSetup& evtSetup);
 
 private:
   std::string m_record;
-  bool m_tagLocks;
+  int m_ret;
   // ----------member data ---------------------------
 };
 #endif


### PR DESCRIPTION
#### PR description:

We provide a fix for a bug affecting the implicit cleanup of Tag locks when a DB session is being closed/deleted.
The available testing workflow has been rewritten to provide a more representative test case.

#### PR validation:

Unit tests and integration tests.

