### PR TITLE
Add argument postGenerationCommand to ExternalLHEProducer and provide mergeLHE.py script

### DIFF
--- a/Configuration/Generator/python/TTbar_Pow_LHE_13TeV_cff.py
+++ b/Configuration/Generator/python/TTbar_Pow_LHE_13TeV_cff.py
@@ -7,6 +7,7 @@ externalLHEProducer = cms.EDProducer("ExternalLHEProducer",
     outputFile = cms.string('cmsgrid_final.lhe'),
     scriptName = cms.FileInPath('GeneratorInterface/LHEInterface/data/run_generic_tarball_cvmfs.sh'),
     generateConcurrently = cms.untracked.bool(True),
+    postGenerationCommand = cms.untracked.vstring('mergeLHE.py', '-i', 'thread*/cmsgrid_final.lhe', '-o', 'cmsgrid_final.lhe'),
 )
 
 #Link to datacards:

--- a/GeneratorInterface/LHEInterface/plugins/ExternalLHEProducer.cc
+++ b/GeneratorInterface/LHEInterface/plugins/ExternalLHEProducer.cc
@@ -290,12 +290,11 @@ void ExternalLHEProducer::beginRunProduce(edm::Run& run, edm::EventSetup const& 
   }
 
   //run post-generation command if specified
-  if (postGenerationCommand_.size() > 0) {
+  if (!postGenerationCommand_.empty()) {
     std::vector<std::string> postcmd = postGenerationCommand_;
     try {
       postcmd[0] = edm::FileInPath(postcmd[0]).fullPath();
-    }
-    catch (const edm::Exception & e) {
+    } catch (const edm::Exception& e) {
       edm::LogWarning("ExternalLHEProducer") << postcmd[0] << " is not a relative path. Run it as a shell command.";
     }
     executeScript(postcmd, 0, true);
@@ -547,7 +546,8 @@ void ExternalLHEProducer::fillDescriptions(edm::ConfigurationDescriptions& descr
   desc.addUntracked<bool>("generateConcurrently", false)
       ->setComment("If true, run the script concurrently in separate processes.");
   desc.addUntracked<std::vector<std::string>>("postGenerationCommand", std::vector<std::string>())
-      ->setComment("Command to run after the generation script has completed. The first argument can be a relative path.");
+      ->setComment(
+          "Command to run after the generation script has completed. The first argument can be a relative path.");
 
   edm::ParameterSetDescription nPartonMappingDesc;
   nPartonMappingDesc.add<unsigned>("idprup");

--- a/GeneratorInterface/LHEInterface/plugins/ExternalLHEProducer.cc
+++ b/GeneratorInterface/LHEInterface/plugins/ExternalLHEProducer.cc
@@ -80,7 +80,7 @@ private:
 
   std::vector<std::string> makeArgs(uint32_t nEvents, unsigned int nThreads, std::uint32_t seed) const;
   int closeDescriptors(int preserve) const;
-  void executeScript(std::vector<std::string> const& args, int id) const;
+  void executeScript(std::vector<std::string> const& args, int id, bool isPost) const;
 
   void nextEvent();
   std::unique_ptr<LHERunInfoProduct> generateRunInfo(std::vector<std::string> const& files) const;
@@ -95,6 +95,7 @@ private:
   unsigned int nThreads_{1};
   std::string outputContents_;
   bool generateConcurrently_{false};
+  const std::vector<std::string> postGenerationCommand_;
 
   // Used only if nPartonMapping is in the configuration
   std::map<unsigned, std::pair<unsigned, unsigned>> nPartonMapping_{};
@@ -131,7 +132,8 @@ ExternalLHEProducer::ExternalLHEProducer(const edm::ParameterSet& iConfig)
       npars_(iConfig.getParameter<uint32_t>("numberOfParameters")),
       nEvents_(iConfig.getUntrackedParameter<uint32_t>("nEvents")),
       storeXML_(iConfig.getUntrackedParameter<bool>("storeXML")),
-      generateConcurrently_(iConfig.getUntrackedParameter<bool>("generateConcurrently")) {
+      generateConcurrently_(iConfig.getUntrackedParameter<bool>("generateConcurrently")),
+      postGenerationCommand_(iConfig.getUntrackedParameter<std::vector<std::string>>("postGenerationCommand")) {
   if (npars_ != args_.size())
     throw cms::Exception("ExternalLHEProducer")
         << "Problem with configuration: " << args_.size() << " script arguments given, expected " << npars_;
@@ -267,7 +269,7 @@ void ExternalLHEProducer::beginRunProduce(edm::Run& run, edm::EventSetup const& 
             using namespace std::string_literals;
             auto out = path("thread"s + std::to_string(t)) / path(outputFile_);
             infiles[t] = out.native();
-            executeScript(makeArgs(nEvents, 1, seed + t), t);
+            executeScript(makeArgs(nEvents, 1, seed + t), t, false);
           } catch (...) {
             char expected = 0;
             if (exceptSet.compare_exchange_strong(expected, 1)) {
@@ -284,7 +286,19 @@ void ExternalLHEProducer::beginRunProduce(edm::Run& run, edm::EventSetup const& 
     }
   } else {
     infiles = std::vector<std::string>(1, outputFile_);
-    executeScript(makeArgs(nEvents_, nThreads_, seed), 0);
+    executeScript(makeArgs(nEvents_, nThreads_, seed), 0, false);
+  }
+
+  //run post-generation command if specified
+  if (postGenerationCommand_.size() > 0) {
+    std::vector<std::string> postcmd = postGenerationCommand_;
+    try {
+      postcmd[0] = edm::FileInPath(postcmd[0]).fullPath();
+    }
+    catch (const edm::Exception & e) {
+      edm::LogWarning("ExternalLHEProducer") << postcmd[0] << " is not a relative path. Run it as a shell command.";
+    }
+    executeScript(postcmd, 0, true);
   }
 
   //fill LHEXMLProduct (streaming read directly into compressed buffer to save memory)
@@ -414,7 +428,7 @@ int ExternalLHEProducer::closeDescriptors(int preserve) const {
 }
 
 // ------------ Execute the script associated with this producer ------------
-void ExternalLHEProducer::executeScript(std::vector<std::string> const& args, int id) const {
+void ExternalLHEProducer::executeScript(std::vector<std::string> const& args, int id, bool isPost) const {
   // Fork a script, wait until it finishes.
 
   int rc = 0, rc2 = 0;
@@ -434,12 +448,19 @@ void ExternalLHEProducer::executeScript(std::vector<std::string> const& args, in
         << "Failed to set pipe file descriptor flags (errno=" << rc << ", " << strerror(rc) << ")";
   }
 
-  unsigned int argc = 1 + args.size();
+  unsigned int argc_pre = 0;
+  // For generation command the first argument gives to the scriptName
+  if (!isPost) {
+    argc_pre = 1;
+  }
+  unsigned int argc = argc_pre + args.size();
   // TODO: assert that we have a reasonable number of arguments
   char** argv = new char*[argc + 1];
-  argv[0] = strdup(scriptName_.c_str());
-  for (unsigned int i = 1; i < argc; i++) {
-    argv[i] = strdup(args[i - 1].c_str());
+  if (!isPost) {
+    argv[0] = strdup(scriptName_.c_str());
+  }
+  for (unsigned int i = 0; i < args.size(); i++) {
+    argv[argc_pre + i] = strdup(args[i].c_str());
   }
   argv[argc] = nullptr;
 
@@ -447,7 +468,7 @@ void ExternalLHEProducer::executeScript(std::vector<std::string> const& args, in
   if (pid == 0) {
     // The child process
     if (!(rc = closeDescriptors(filedes[1]))) {
-      if (generateConcurrently_) {
+      if (!isPost && generateConcurrently_) {
         using namespace std::filesystem;
         using namespace std::string_literals;
         std::error_code ec;
@@ -525,6 +546,8 @@ void ExternalLHEProducer::fillDescriptions(edm::ConfigurationDescriptions& descr
   desc.addUntracked<bool>("storeXML", false);
   desc.addUntracked<bool>("generateConcurrently", false)
       ->setComment("If true, run the script concurrently in separate processes.");
+  desc.addUntracked<std::vector<std::string>>("postGenerationCommand", std::vector<std::string>())
+      ->setComment("Command to run after the generation script has completed. The first argument can be a relative path.");
 
   edm::ParameterSetDescription nPartonMappingDesc;
   nPartonMappingDesc.add<unsigned>("idprup");

--- a/GeneratorInterface/LHEInterface/scripts/mergeLHE.py
+++ b/GeneratorInterface/LHEInterface/scripts/mergeLHE.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python
+
+from __future__ import print_function
+import argparse
+import glob
+import sys
+import os
+
+def main(argv = None):
+    """Main routine of the script.
+
+    Arguments:
+    - `argv`: arguments passed to the main routine
+    """
+
+    if argv == None:
+        argv = sys.argv[1:]
+
+    parser = argparse.ArgumentParser(
+        description="Merge specified input LHE files")
+    parser.add_argument("-i", "--input", dest="input",
+                        type=str, help="input LHE path(s) separated by comma. Shell-type wildcards are supported.")
+    parser.add_argument("-o", "--output", dest="output",
+                        default='output.lhe', type=str, help="output LHE path.")
+    parser.add_argument("--maxEvents", dest="maxEvents",
+                        default=-1, type=int,
+                        help="Maximum number of events to process.")
+    args = parser.parse_args(argv)
+
+    print('>>> launch mergeLHE.py', os.path.abspath(os.getcwd()))
+    inputfiles = []
+    for path in args.input.split(','):
+        findfiles = glob.glob(path)
+        if len(findfiles) == 0:
+            print('Warning: cannot find files in %s' % path)
+        inputfiles += findfiles
+    print('>>> Merge %d files: [%s]' % (len(inputfiles), ', '.join(inputfiles)))
+
+    run_script = '''
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("LHE")
+
+process.source = cms.Source("LHESource",
+	fileNames = cms.untracked.vstring({paths})
+)
+
+process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32({maxEvents}))
+
+process.load("FWCore.MessageService.MessageLogger_cfi")
+process.MessageLogger.cerr.FwkReport.reportEvery = cms.untracked.int32(1000)
+
+process.writer = cms.EDAnalyzer("LHEWriter")
+
+process.p = cms.Path(process.writer)
+    '''.format(paths=','.join(['"file:%s"'%p for p in inputfiles]), maxEvents=args.maxEvents)
+
+    with open('mergeLHE_cff.py', 'w') as f:
+        f.write(run_script)
+
+    os.system('cmsRun mergeLHE_cff.py')
+    os.rename('writer.lhe', args.output)
+    os.remove('mergeLHE_cff.py')
+
+if __name__=="__main__":
+    main()

--- a/GeneratorInterface/LHEInterface/scripts/mergeLHE.py
+++ b/GeneratorInterface/LHEInterface/scripts/mergeLHE.py
@@ -2,9 +2,148 @@
 
 from __future__ import print_function
 import argparse
+import math
 import glob
 import sys
 import os
+
+class BaseLHEMerger(object):
+    """Base class of the LHE merge schemes"""
+    def __init__(self, inputFiles, outputFileName):
+        self.inputFiles = inputFiles
+        self.outputFileName = outputFileName
+
+    def merge(self):
+        """Output the merged LHE"""
+        pass
+
+class DefaultLHEMerger(BaseLHEMerger):
+    """Default LHE merge scheme that copies the header of the first LHE file, merges and outputs the init block, then concatenates all event blocks."""
+    def __init__(self, inputFiles, outputFileName):
+        super(DefaultLHEMerger, self).__init__(inputFiles, outputFileName)
+        self._f = [self.file_iterator(name) for name in self.inputFiles] # line-by-line iterator for each input file
+        self._init_str = [] # initiated blocks for each input file
+        self._nevent = []   # number of events for each input file
+
+    def file_iterator(self, path):
+        """Line-by-line iterator of a txt file"""
+        with open(path, 'r') as f:
+            for line in f:
+                yield line
+
+    def merge_init_blocks(self):
+        """Calculate the output init blocks by merging the input init block info
+        Formula used (same with the MadGraph5LHEMerger scheme):
+            XSECUP = sum(xsecup * no.events) / tot.events
+            XERRUP = sqrt( sum(sigma^2 * no.events^2) ) / tot.events
+            XMAXUP = max(xmaxup)
+        """
+        # Initiate collected init block info. Will be in format of {iprocess: [xsecup, xerrup, xmaxup]}
+        new_init_block = {}
+        old_init_block = [{} for _ in self._init_str]
+
+        # Read init block from input LHEs
+        for i, bl in enumerate(self._init_str): # loop over files
+            nline = int(bl.split('\n')[0].strip().split()[-1])
+            for bl_line in bl.split('\n')[1:nline + 1]: # loop over lines in <init> block
+                bl_line_sp = bl_line.split()
+                old_init_block[i][int(bl_line_sp[3])] = [float(bl_line_sp[0]), float(bl_line_sp[1]), float(bl_line_sp[2])]
+            # After reading all subprocesses info, store the rest content in <init> block for the first file
+            if i == 0:
+                info_after_subprocess = bl.strip().split('\n')[nline + 1:]
+            print('Input file: %s' % self.inputFiles[i])
+            for ipr in sorted(list(old_init_block[i].keys()), reverse=True): # reverse order: follow the MG5 custom
+                print('  xsecup, xerrup, xmaxup, lprup: %.6E, %.6E, %.6E, %d' % tuple(old_init_block[i][ipr] + [ipr]))
+
+        # Calculate merged init block
+        for i in range(len(self._f)):
+            for ipr in old_init_block[i]:
+                # Initiate the subprocess for the new block if it is found for the first time in one input file
+                if ipr not in new_init_block:
+                    new_init_block[ipr] = [0., 0., 0.]
+                new_init_block[ipr][0] += old_init_block[i][ipr][0] * self._nevent[i] # xsec
+                new_init_block[ipr][1] += old_init_block[i][ipr][1]**2 * self._nevent[i]**2 # xerrup
+                new_init_block[ipr][2] = max(new_init_block[ipr][2], old_init_block[i][ipr][2]) # xmaxup
+        tot_nevent = sum([self._nevent[i] for i in range(len(self._f))])
+
+        # Write first line of the <init> block (modify the nprocess at the last)
+        self._merged_init_str = self._init_str[0].split('\n')[0].strip().rsplit(' ', 1)[0] + ' ' + str(len(new_init_block)) + '\n'
+        # Form the merged init block
+        print('\nOutput file: %s' % self.outputFileName)
+        for ipr in sorted(list(new_init_block.keys()), reverse=True): # reverse order: follow the MG5 custom
+            new_init_block[ipr][0] /= tot_nevent
+            new_init_block[ipr][1] = math.sqrt(new_init_block[ipr][1]) / tot_nevent
+            print('  xsecup, xerrup, xmaxup, lprup: %.6E, %.6E, %.6E, %d' % tuple(new_init_block[ipr] + [ipr]))
+            self._merged_init_str += '%.6E %.6E %.6E %d\n' % tuple(new_init_block[ipr] + [ipr])
+        self._merged_init_str += '\n'.join(info_after_subprocess)
+        if len(info_after_subprocess):
+            self._merged_init_str += '\n'
+
+        return self._merged_init_str
+
+    def merge(self):
+        with open(self.outputFileName, 'w') as fw:
+            # Read the header for the first file then write to the output
+            while True:
+                line = next(self._f[0])
+                if line.startswith('<init>'):
+                    break
+                else:
+                    fw.write(line)
+
+            # Let all inputFiles reach the start of <init> block
+            for i in range(1, len(self._f)):
+                while(not next(self._f[i]).startswith('<init>')):
+                    pass
+
+            # Read <init> blocks for all inputFiles
+            for i in range(len(self._f)):
+                init_str = ''
+                while True:
+                    line = next(self._f[i])
+                    if line.startswith('</init>'):
+                        break
+                    else:
+                        init_str += line
+                self._init_str.append(init_str)
+
+            # Iterate over all events file-by-file and write events temporarily to .tmp.lhe
+            with open('.tmp.lhe', 'w') as _fwtmp:
+                for i in range(len(self._f)):
+                    nevent = 0
+                    while True:
+                        line = next(self._f[i])
+                        if line.startswith('</event>'):
+                            nevent += 1
+                        if line.startswith('</LesHouchesEvents>'):
+                            break
+                        else:
+                            _fwtmp.write(line)
+                    self._nevent.append(nevent)
+                    self._f[i].close()
+
+            # Merge the init blocks and write to the output
+            fw.write('<init>\n' + self.merge_init_blocks() + '</init>\n')
+
+            # Write event blocks in .tmp.lhe back to the output
+            with open('.tmp.lhe', 'r') as _ftmp:
+                for _line in _ftmp:
+                    fw.write(_line)
+            fw.write('</LesHouchesEvents>\n')
+            os.remove('.tmp.lhe')
+
+
+class MadGraph5LHEMerger(BaseLHEMerger):
+    """Use the merger script in genproductions dedicated for MadGraph5-produced LHEs"""
+    def __init__(self, inputFiles, outputFileName):
+        super(MadGraph5LHEMerger, self).__init__(inputFiles, outputFileName)
+        self._merger_script_url = 'https://raw.githubusercontent.com/cms-sw/genproductions/5c1e865a6fbe3a762a28363835d9a804c9cf0dbe/bin/MadGraph5_aMCatNLO/Utilities/merge.pl'
+
+    def merge(self):
+        print('Info: use the merger script in genproductions dedicated for MadGraph5-produced LHEs')
+        os.system('curl -L %s | perl - %s %s.gz .banner.txt' % (self._merger_script_url, ' '.join(self.inputFiles), self.outputFileName))
+        os.system('gzip -df %s.gz' % self.outputFileName)
+
 
 def main(argv = None):
     """Main routine of the script.
@@ -17,50 +156,38 @@ def main(argv = None):
         argv = sys.argv[1:]
 
     parser = argparse.ArgumentParser(
-        description="Merge specified input LHE files")
-    parser.add_argument("-i", "--input", dest="input",
-                        type=str, help="input LHE path(s) separated by comma. Shell-type wildcards are supported.")
-    parser.add_argument("-o", "--output", dest="output",
-                        default='output.lhe', type=str, help="output LHE path.")
-    parser.add_argument("--maxEvents", dest="maxEvents",
-                        default=-1, type=int,
-                        help="Maximum number of events to process.")
+        description="Merge specified input LHE files (three available modes).")
+    parser.add_argument("-i", "--inputPaths", dest="inputPaths",
+                        required=True, type=str, help="input LHE path(s) separated by comma. Shell-type wildcards are supported. E.g. -i 'a/*.lhe,b/*.lhe'")
+    parser.add_argument("-o", "--outputFileName", dest="outputFileName",
+                        default='output.lhe', type=str, help="output LHE name (should not be a path).")
+    parser.add_argument("--forceMadGraph5LHEMerger", dest="forceMadGraph5LHEMerger",
+                        action='store_true',
+                        help="Force to use the merger script in genproductions dedicated for MadGraph5-produced LHEs.")
     args = parser.parse_args(argv)
 
     print('>>> launch mergeLHE.py', os.path.abspath(os.getcwd()))
-    inputfiles = []
-    for path in args.input.split(','):
-        findfiles = glob.glob(path)
-        if len(findfiles) == 0:
+    inputFiles = []
+    for path in args.inputPaths.split(','):
+        findFiles = glob.glob(path)
+        if len(findFiles) == 0:
             print('Warning: cannot find files in %s' % path)
-        inputfiles += findfiles
-    print('>>> Merge %d files: [%s]' % (len(inputfiles), ', '.join(inputfiles)))
+        inputFiles += findFiles
+    inputFiles.sort()
+    print('>>> Merge %d files: [%s]' % (len(inputFiles), ', '.join(inputFiles)))
 
-    run_script = '''
-import FWCore.ParameterSet.Config as cms
+    # Check arguments
+    assert len(inputFiles) > 1, 'Input LHE files should be more than 1.'
+    assert '/' not in args.outputFileName, "outputFileName should not be a path."
 
-process = cms.Process("LHE")
+    # Determine the merging scheme
+    if args.forceMadGraph5LHEMerger:
+        lhe_merger = MadGraph5LHEMerger(inputFiles, args.outputFileName)
+    else:
+        lhe_merger = DefaultLHEMerger(inputFiles, args.outputFileName)
 
-process.source = cms.Source("LHESource",
-	fileNames = cms.untracked.vstring({paths})
-)
-
-process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32({maxEvents}))
-
-process.load("FWCore.MessageService.MessageLogger_cfi")
-process.MessageLogger.cerr.FwkReport.reportEvery = cms.untracked.int32(1000)
-
-process.writer = cms.EDAnalyzer("LHEWriter")
-
-process.p = cms.Path(process.writer)
-    '''.format(paths=','.join(['"file:%s"'%p for p in inputfiles]), maxEvents=args.maxEvents)
-
-    with open('mergeLHE_cff.py', 'w') as f:
-        f.write(run_script)
-
-    os.system('cmsRun mergeLHE_cff.py')
-    os.rename('writer.lhe', args.output)
-    os.remove('mergeLHE_cff.py')
+    # Do merging
+    lhe_merger.merge()
 
 if __name__=="__main__":
     main()


### PR DESCRIPTION
#### PR description:

- Add an argument `postGenerationCommand` to ExternalLHEProducer module that can run a self-specified command right after LHE event generation (i.e. launched by the `ScriptName`).
- Add a `mergeLHE.py` script that merges LHEs using cmssw utility.
- Resolves: #33544 
  Now we provide `postGenerationCommand` to merge LHE events after concurrent LHE event generation for the later use of H7GeneratorFilter.

#### PR validation:

Pass workflow 535.0