### PR TITLE
Fix typo in the fillDescriptions method of RecoParticleFlow/PFClusterProducer/interface/HGCRecHitNavigator.h

### DIFF
--- a/RecoParticleFlow/PFClusterProducer/interface/HGCRecHitNavigator.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/HGCRecHitNavigator.h
@@ -34,8 +34,8 @@ public:
     desc.add<edm::ParameterSetDescription>("hgchef", deschef);
 
     edm::ParameterSetDescription descheb;
-    deschef.add<std::string>("name", "PFRecHitHGCHENavigator");
-    deschef.add<std::string>("topologySource", "HGCalHEScintillatorSensitive");
+    descheb.add<std::string>("name", "PFRecHitHGCHENavigator");
+    descheb.add<std::string>("topologySource", "HGCalHEScintillatorSensitive");
     desc.add<edm::ParameterSetDescription>("hgcheb", descheb);
 
     descriptions.add("navigator", desc);


### PR DESCRIPTION
#### PR description:

Fixed a typo in the name of one PSet, when filling its parameter content

#### PR validation:

It builds

As far as I can see, the `hgcheb` PSet is explicitely redefined when used in the actual configs:
- RecoEgamma/EgammaHLTProducers/python/HLTEgPhaseIITestSequence_cff.py
- RecoParticleFlow/PFClusterProducer/python/particleFlowRecHitHGC_cfi.py

Therefore, even though the PSet were wrongly defined in the fillDescription method of the HGCRecHitNavigator, I don't expect any effect on the outputs: let have a look at the automatic tests results, anyhow.
