### PR TITLE
[HGCAL trigger] Fixing phi smoothing in cluster seeding

### DIFF
--- a/L1Trigger/L1THGCal/interface/backend/HGCalHistoSeedingImpl.h
+++ b/L1Trigger/L1THGCal/interface/backend/HGCalHistoSeedingImpl.h
@@ -151,6 +151,8 @@ private:
   unsigned nBins2_ = 216;
   std::vector<unsigned> binsSumsHisto_;
   double histoThreshold_ = 20.;
+  static constexpr double area_per_triggercell_ =
+      4.91E-05;  // Hex_Wafer_Area (x/z units)/N_TC (per wafer) = (0.866*((hexWafer_minimal_diameter)*(1./319.))^2 / 48)
   std::vector<double> neighbour_weights_;
   std::vector<double> smoothing_ecal_;
   std::vector<double> smoothing_hcal_;

--- a/L1Trigger/L1THGCal/python/hgcalBackEndLayer2Producer_cfi.py
+++ b/L1Trigger/L1THGCal/python/hgcalBackEndLayer2Producer_cfi.py
@@ -105,7 +105,7 @@ histoMax_C3d_clustering_params = cms.PSet(dR_multicluster=cms.double(0.03),
 # (see https://indico.cern.ch/event/806845/contributions/3359859/attachments/1815187/2966402/19-03-20_EGPerf_HGCBE.pdf
 # for more details)
 phase2_hgcalV10.toModify(histoMax_C3d_seeding_params,
-                        threshold_histo_multicluster=7.5,  # MipT
+                        threshold_histo_multicluster=8.5,  # MipT
                         )
 
 

--- a/L1Trigger/L1THGCal/src/backend/HGCalHistoSeedingImpl.cc
+++ b/L1Trigger/L1THGCal/src/backend/HGCalHistoSeedingImpl.cc
@@ -166,12 +166,12 @@ HGCalHistoSeedingImpl::Histogram HGCalHistoSeedingImpl::fillSmoothPhiHistoCluste
   for (int z_side : {-1, 1}) {
     for (unsigned bin1 = 0; bin1 < nBins1_; bin1++) {
       int nBinsSide = (binSums[bin1] - 1) / 2;
-      float R1 = kROverZMin_ + bin1 * (kROverZMax_ - kROverZMin_);
-      float R2 = R1 + (kROverZMax_ - kROverZMin_);
+      float R1 = kROverZMin_ + bin1 * (kROverZMax_ - kROverZMin_) / nBins1_;
+      float R2 = R1 + ((kROverZMax_ - kROverZMin_) / nBins1_);
       double area =
-          0.5 * (pow(R2, 2) - pow(R1, 2)) *
+          ((M_PI * (pow(R2, 2) - pow(R1, 2))) / nBins2_) *
           (1 +
-           0.5 *
+           2.0 *
                (1 -
                 pow(0.5,
                     nBinsSide)));  // Takes into account different area of bins in different R-rings + sum of quadratic weights used
@@ -196,7 +196,7 @@ HGCalHistoSeedingImpl::Histogram HGCalHistoSeedingImpl::fillSmoothPhiHistoCluste
         }
 
         auto& bin = histoSumPhiClusters.at(z_side, bin1, bin2);
-        bin.values[Bin::Content::Sum] = content / area;
+        bin.values[Bin::Content::Sum] = (content / area) * area_per_triggercell_;
         bin.weighted_x = bin_orig.weighted_x;
         bin.weighted_y = bin_orig.weighted_y;
       }


### PR DESCRIPTION
#### PR description:

Fixes smoothing normalization in the phi direction for the cluster seeding.
A more detailed description and plots can be found in this presentation:
https://indico.cern.ch/event/953230/contributions/4010533/

To summarize:
- This seeding fix impacts the population of PU clusters, in particular their eta distribution, but the seeding threshold has been tuned to in order to have roughly the same numbers of clusters reconstructed from PU as before.
- There is a slight improvement of e/g energy resolution (before corrections are applied)

#### PR validation:
Standard code checks and code-format, as well as testing workflows `23234.0` (v11 geometry) and `31434.0` (v12 geometry)
