### PR TITLE
fix missing leftover Timing parameter in fed_dqm_sourceclient-live_cfg.py

### DIFF
--- a/DQM/Integration/python/clients/fed_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/fed_dqm_sourceclient-live_cfg.py
@@ -48,7 +48,6 @@ process.l1tStage2Fed.FEDDirName = cms.untracked.string(path)
 # Pixel sequence:
 process.load('Configuration.StandardSequences.MagneticField_cff')
 process.load('EventFilter.SiPixelRawToDigi.SiPixelRawToDigi_cfi')
-process.siPixelDigis.cpu.Timing = False
 process.siPixelDigis.cpu.IncludeErrors = True
 process.load('DQM.SiPixelMonitorRawData.SiPixelMonitorHLT_cfi')
 process.SiPixelHLTSource.saveFile = False


### PR DESCRIPTION
resolves https://github.com/cms-sw/cmssw/issues/33623

#### PR description:

Title says it all 

#### PR validation:

Tested with:

```
cd DQM/Integration/python/clients
mkdir upload
voms-proxy-init -voms cms
cmsRun fed_dqm_sourceclient-live_cfg.py
```

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Not a backport, no backport needed