### PR TITLE
Fix leftover Timing parameters

### DIFF
--- a/Calibration/LumiAlCaRecoProducers/test/PCC_Random_Event_Integrator_cfg.py
+++ b/Calibration/LumiAlCaRecoProducers/test/PCC_Random_Event_Integrator_cfg.py
@@ -74,7 +74,6 @@ process.siPixelDigisForLumi = cms.EDProducer("SiPixelRawToDigi",
     Regions = cms.PSet(
 
     ),
-    Timing = cms.untracked.bool(False),
     UsePhase1 = cms.bool(False),
     UsePilotBlade = cms.bool(False),
     UseQualityInfo = cms.bool(False),

--- a/Calibration/LumiAlCaRecoProducers/test/PCC_Random_Event_cfg.py
+++ b/Calibration/LumiAlCaRecoProducers/test/PCC_Random_Event_cfg.py
@@ -66,7 +66,6 @@ process.siPixelDigisForLumi = cms.EDProducer("SiPixelRawToDigi",
     Regions = cms.PSet(
 
     ),
-    Timing = cms.untracked.bool(False),
     UsePhase1 = cms.bool(False),
     UsePilotBlade = cms.bool(False),
     UseQualityInfo = cms.bool(False),

--- a/Calibration/LumiAlCaRecoProducers/test/PCC_Random_cfg.py
+++ b/Calibration/LumiAlCaRecoProducers/test/PCC_Random_cfg.py
@@ -66,7 +66,6 @@ process.siPixelDigisForLumi = cms.EDProducer("SiPixelRawToDigi",
     Regions = cms.PSet(
 
     ),
-    Timing = cms.untracked.bool(False),
     UsePhase1 = cms.bool(False),
     UsePilotBlade = cms.bool(False),
     UseQualityInfo = cms.bool(False),

--- a/Calibration/LumiAlCaRecoProducers/test/PCC_ZeroBias_cfg.py
+++ b/Calibration/LumiAlCaRecoProducers/test/PCC_ZeroBias_cfg.py
@@ -70,7 +70,6 @@ process.siPixelDigisForLumi = cms.EDProducer("SiPixelRawToDigi",
     Regions = cms.PSet(
 
     ),
-    Timing = cms.untracked.bool(False),
     UsePhase1 = cms.bool(False),
     UsePilotBlade = cms.bool(False),
     UseQualityInfo = cms.bool(False),

--- a/DQM/Integration/python/clients/fed_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/fed_dqm_sourceclient-live_cfg.py
@@ -48,7 +48,6 @@ process.l1tStage2Fed.FEDDirName = cms.untracked.string(path)
 # Pixel sequence:
 process.load('Configuration.StandardSequences.MagneticField_cff')
 process.load('EventFilter.SiPixelRawToDigi.SiPixelRawToDigi_cfi')
-process.siPixelDigis.cpu.Timing = False
 process.siPixelDigis.cpu.IncludeErrors = True
 process.load('DQM.SiPixelMonitorRawData.SiPixelMonitorHLT_cfi')
 process.SiPixelHLTSource.saveFile = False

--- a/DQM/SiPixelMonitorRawData/python/sipixel_dqm_HLTsource_example_cfg.py
+++ b/DQM/SiPixelMonitorRawData/python/sipixel_dqm_HLTsource_example_cfg.py
@@ -19,7 +19,6 @@ process.es_prefer_GlobalTag = cms.ESPrefer('PoolDBESSource','GlobalTag')
 # Pixel RawToDigi conversion
 process.load("EventFilter.SiPixelRawToDigi.SiPixelRawToDigi_cfi")
 process.siPixelDigis.InputLabel = "source"
-process.siPixelDigis.Timing = False
 process.siPixelDigis.IncludeErrors = True
 
 process.load("DQM.SiPixelMonitorRawData.SiPixelMonitorHLT_cfi")

--- a/DQM/SiPixelMonitorRawData/python/sipixel_dqm_source_example_cfg.py
+++ b/DQM/SiPixelMonitorRawData/python/sipixel_dqm_source_example_cfg.py
@@ -19,7 +19,6 @@ process.es_prefer_GlobalTag = cms.ESPrefer('PoolDBESSource','GlobalTag')
 # Pixel RawToDigi conversion
 process.load("EventFilter.SiPixelRawToDigi.SiPixelRawToDigi_cfi")
 process.siPixelDigis.InputLabel = "source"
-process.siPixelDigis.Timing = False
 process.siPixelDigis.IncludeErrors = True
 
 process.load("DQM.SiPixelMonitorRawData.SiPixelMonitorRawData_cfi")

--- a/EventFilter/SiPixelRawToDigi/test/runRawToDigi_cfg.py
+++ b/EventFilter/SiPixelRawToDigi/test/runRawToDigi_cfg.py
@@ -48,7 +48,6 @@ process.siPixelDigis.InputLabel = 'siPixelRawData'
 #process.siPixelDigis.InputLabel = 'source'
 #process.siPixelDigis.InputLabel = 'rawDataCollector'
 process.siPixelDigis.IncludeErrors = True
-process.siPixelDigis.Timing = False 
 #process.siPixelDigis.UseCablingTree = True 
 
 process.MessageLogger = cms.Service("MessageLogger",

--- a/EventFilter/SiPixelRawToDigi/test/test.py
+++ b/EventFilter/SiPixelRawToDigi/test/test.py
@@ -21,7 +21,6 @@ process.GlobalTag.globaltag = "GR_R_52_V2::All"
 process.load("EventFilter.SiPixelRawToDigi.SiPixelRawToDigi_cfi")
 #process.siPixelDigis.InputLabel = "rawDataCollector"
 process.siPixelDigis.InputLabel = "rawDataCollector"
-process.siPixelDigis.Timing = True
 process.siPixelDigis.UseQualityInfo = False
 process.siPixelDigis.IncludeErrors = True
 process.siPixelDigis.ErrorList = [29]


### PR DESCRIPTION
#### PR description:

This PR removes a deprecated parameter from the module `siPixelDigis` (or `SiPixelRawToDigi`).

Based on [this regexp](https://cmssdt.cern.ch/dxr/CMSSW/search?q=regexp%3A%22Timing(+%3F)%3D.*(%5BTt%5Drue%7C%5BFf%5Dalse)%22&case=true) it should include all remaining instances.

#### PR validation:

compiles

<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->

#### if this PR is a backport please specify the original PR and why you need to backport that PR: