### PR TITLE
Bug fix for tag lock clean up at session closing time

### DIFF
--- a/CondCore/CondDB/src/IOVEditor.cc
+++ b/CondCore/CondDB/src/IOVEditor.cc
@@ -97,8 +97,7 @@ namespace cond {
               tag, m_session->sessionHash, cond::auth::COND_SESSION_HASH_CODE, cond::auth::COND_DBTAG_LOCK_ACCESS_CODE);
           if (!mylock)
             cond::throwException(
-                "Tag \"" + tag + "\" can't be accessed for update, because it has been locked by an other session. \"" +
-                    m_session->principalName + "\".",
+                "Tag \"" + tag + "\" can't be accessed for update, because it has been locked by an other session.",
                 "IOVEditor::load");
         }
       }

--- a/CondCore/CondDB/src/SessionImpl.cc
+++ b/CondCore/CondDB/src/SessionImpl.cc
@@ -43,14 +43,14 @@ namespace cond {
     SessionImpl::~SessionImpl() { close(); }
 
     void SessionImpl::close() {
-      if (coralSession.get()) {
+      if (isActive()) {
         if (coralSession->transaction().isActive()) {
-          coralSession->transaction().rollback();
+          rollbackTransaction();
         }
         if (!lockedTags.empty()) {
-          coralSession->transaction().start(true);
+          startTransaction(false);
           releaseTagLocks();
-          coralSession->transaction().commit();
+          commitTransaction();
         }
         coralSession.reset();
       }

--- a/CondCore/DBOutputService/test/stubs/LumiBasedUpdateAnalyzer.h
+++ b/CondCore/DBOutputService/test/stubs/LumiBasedUpdateAnalyzer.h
@@ -17,12 +17,15 @@ class LumiBasedUpdateAnalyzer : public edm::EDAnalyzer {
 public:
   explicit LumiBasedUpdateAnalyzer(const edm::ParameterSet& iConfig);
   virtual ~LumiBasedUpdateAnalyzer();
-  virtual void analyze(const edm::Event& evt, const edm::EventSetup& evtSetup);
+  virtual void beginJob();
   virtual void endJob();
+  virtual void beginLuminosityBlock(const edm::LuminosityBlock& lumiSeg, const edm::EventSetup& context);
+  virtual void endLuminosityBlock(const edm::LuminosityBlock& lumiSeg, const edm::EventSetup& iSetup);
+  virtual void analyze(const edm::Event& evt, const edm::EventSetup& evtSetup);
 
 private:
   std::string m_record;
-  bool m_tagLocks;
+  int m_ret;
   // ----------member data ---------------------------
 };
 #endif


### PR DESCRIPTION
#### PR description:

We provide a fix for a bug affecting the implicit cleanup of Tag locks when a DB session is being closed/deleted.
The available testing workflow has been rewritten to provide a more representative test case.

#### PR validation:

Unit tests and integration tests.

Backport of #33603
This code is required in the online operation of the HLT workflow.
