### PR TITLE
Initialize id variable to silence warning

### DIFF
--- a/EventFilter/Utilities/src/FedRawDataInputSource.cc
+++ b/EventFilter/Utilities/src/FedRawDataInputSource.cc
@@ -1178,7 +1178,7 @@ void FedRawDataInputSource::readSupervisor() {
   //make sure threads finish reading
   unsigned numFinishedThreads = 0;
   while (numFinishedThreads < workerThreads_.size()) {
-    unsigned int tid;
+    unsigned tid = 0;
     while (!workerPool_.try_pop(tid)) {
       usleep(10000);
     }


### PR DESCRIPTION
#### PR description:

Initializes an unsigned to 0 to silence warning

#### PR validation:

no warning after the init
