### PR TITLE
esConsumes migration for SiStripFedZeroSuppression, SiStripHitEffFromCalibTree, and SiStripClusterToDigiProducer

### DIFF
--- a/CalibTracker/SiStripHitEfficiency/plugins/SiStripHitEffFromCalibTree.cc
+++ b/CalibTracker/SiStripHitEfficiency/plugins/SiStripHitEffFromCalibTree.cc
@@ -148,6 +148,9 @@ private:
   float _effPlotMin;
   TString _title;
 
+  edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> _tkGeomToken;
+  edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> _tTopoToken;
+
   unsigned int nTEClayers;
 
   TH1F* bxHisto;
@@ -205,6 +208,8 @@ SiStripHitEffFromCalibTree::SiStripHitEffFromCalibTree(const edm::ParameterSet& 
   _tkMapMin = conf.getUntrackedParameter<double>("TkMapMin", 0.9);
   _effPlotMin = conf.getUntrackedParameter<double>("EffPlotMin", 0.9);
   _title = conf.getParameter<std::string>("Title");
+  _tkGeomToken = esConsumes();
+  _tTopoToken = esConsumes();
   reader = new SiStripDetInfoFileReader(FileInPath_.fullPath());
 
   nTEClayers = 9;  // number of wheels
@@ -226,14 +231,8 @@ void SiStripHitEffFromCalibTree::algoEndJob() {
 }
 
 void SiStripHitEffFromCalibTree::algoAnalyze(const edm::Event& e, const edm::EventSetup& c) {
-  edm::ESHandle<TrackerGeometry> tracker;
-  c.get<TrackerDigiGeometryRecord>().get(tracker);
-  const TrackerGeometry* tkgeom = &(*tracker);
-
-  //Retrieve tracker topology from geometry
-  edm::ESHandle<TrackerTopology> tTopoHandle;
-  c.get<TrackerTopologyRcd>().get(tTopoHandle);
-  const TrackerTopology* const tTopo = tTopoHandle.product();
+  const auto& tkgeom = c.getData(_tkGeomToken);
+  const auto& tTopo = c.getData(_tTopoToken);
 
   // read bad modules to mask
   ifstream badModules_file;
@@ -493,7 +492,7 @@ void SiStripHitEffFromCalibTree::algoAnalyze(const edm::Event& e, const edm::Eve
         stripCluster = ClusterLocX / Pitch + nstrips / 2.0;
       } else {
         DetId ClusterDetId(id);
-        const StripGeomDetUnit* stripdet = (const StripGeomDetUnit*)tkgeom->idToDetUnit(ClusterDetId);
+        const StripGeomDetUnit* stripdet = (const StripGeomDetUnit*)tkgeom.idToDetUnit(ClusterDetId);
         const StripTopology& Topo = stripdet->specificTopology();
         nstrips = Topo.nstrips();
         Pitch = stripdet->surface().bounds().width() / Topo.nstrips();
@@ -713,7 +712,7 @@ void SiStripHitEffFromCalibTree::algoAnalyze(const edm::Event& e, const edm::Eve
       //TIB
       //&&&&&&&&&&&&&&&&&
 
-      component = tTopo->tibLayer(BC[i].detid);
+      component = tTopo.tibLayer(BC[i].detid);
       SetBadComponents(0, component, BC[i], ssV, NBadComponent);
 
     } else if (a.subdetId() == SiStripDetId::TID) {
@@ -721,7 +720,7 @@ void SiStripHitEffFromCalibTree::algoAnalyze(const edm::Event& e, const edm::Eve
       //TID
       //&&&&&&&&&&&&&&&&&
 
-      component = tTopo->tidSide(BC[i].detid) == 2 ? tTopo->tidWheel(BC[i].detid) : tTopo->tidWheel(BC[i].detid) + 3;
+      component = tTopo.tidSide(BC[i].detid) == 2 ? tTopo.tidWheel(BC[i].detid) : tTopo.tidWheel(BC[i].detid) + 3;
       SetBadComponents(1, component, BC[i], ssV, NBadComponent);
 
     } else if (a.subdetId() == SiStripDetId::TOB) {
@@ -729,7 +728,7 @@ void SiStripHitEffFromCalibTree::algoAnalyze(const edm::Event& e, const edm::Eve
       //TOB
       //&&&&&&&&&&&&&&&&&
 
-      component = tTopo->tobLayer(BC[i].detid);
+      component = tTopo.tobLayer(BC[i].detid);
       SetBadComponents(2, component, BC[i], ssV, NBadComponent);
 
     } else if (a.subdetId() == SiStripDetId::TEC) {
@@ -737,7 +736,7 @@ void SiStripHitEffFromCalibTree::algoAnalyze(const edm::Event& e, const edm::Eve
       //TEC
       //&&&&&&&&&&&&&&&&&
 
-      component = tTopo->tecSide(BC[i].detid) == 2 ? tTopo->tecWheel(BC[i].detid) : tTopo->tecWheel(BC[i].detid) + 9;
+      component = tTopo.tecSide(BC[i].detid) == 2 ? tTopo.tecWheel(BC[i].detid) : tTopo.tecWheel(BC[i].detid) + 9;
       SetBadComponents(3, component, BC[i], ssV, NBadComponent);
     }
   }
@@ -758,16 +757,16 @@ void SiStripHitEffFromCalibTree::algoAnalyze(const edm::Event& e, const edm::Eve
     SiStripDetId a(detid);
     if (a.subdetId() == 3) {
       subdet = 0;
-      component = tTopo->tibLayer(detid);
+      component = tTopo.tibLayer(detid);
     } else if (a.subdetId() == 4) {
       subdet = 1;
-      component = tTopo->tidSide(detid) == 2 ? tTopo->tidWheel(detid) : tTopo->tidWheel(detid) + 3;
+      component = tTopo.tidSide(detid) == 2 ? tTopo.tidWheel(detid) : tTopo.tidWheel(detid) + 3;
     } else if (a.subdetId() == 5) {
       subdet = 2;
-      component = tTopo->tobLayer(detid);
+      component = tTopo.tobLayer(detid);
     } else if (a.subdetId() == 6) {
       subdet = 3;
-      component = tTopo->tecSide(detid) == 2 ? tTopo->tecWheel(detid) : tTopo->tecWheel(detid) + 9;
+      component = tTopo.tecSide(detid) == 2 ? tTopo.tecWheel(detid) : tTopo.tecWheel(detid) + 9;
     }
 
     SiStripQuality::Range sqrange =

--- a/CalibTracker/SiStripHitEfficiency/plugins/SiStripHitEffFromCalibTree.cc
+++ b/CalibTracker/SiStripHitEfficiency/plugins/SiStripHitEffFromCalibTree.cc
@@ -304,7 +304,7 @@ void SiStripHitEffFromCalibTree::algoAnalyze(const edm::Event& e, const edm::Eve
     cout << "A module is bad if efficiency < the avg in layer - " << threshold << " and has at least " << nModsMin
          << " nModsMin." << endl;
 
-  unsigned int run, evt, bx;
+  unsigned int run, evt, bx{0};
   double instLumi, PU;
 
   //Open the ROOT Calib Tree

--- a/RecoLocalTracker/SiStripClusterizer/plugins/SiStripClusterToDigiProducer.cc
+++ b/RecoLocalTracker/SiStripClusterizer/plugins/SiStripClusterToDigiProducer.cc
@@ -1,7 +1,7 @@
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/ESWatcher.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 #include "DataFormats/Common/interface/DetSetVector.h"
@@ -31,19 +31,21 @@ public:
 
 private:
   void process(const ClusterCollection& input, std::vector<DetDigiCollection>& output_base);
-  void initialize(const edm::EventSetup& es);
   void setDetId(const uint32_t id);
   float gain(const uint16_t& strip) const { return gainHandle->getStripGain(strip, gainRange); }
   uint16_t applyGain(const uint16_t& strip, const uint16_t& adc);
 
   edm::EDGetTokenT<ClusterCollection> token;
   SiStripApvGain::Range gainRange;
-  edm::ESHandle<SiStripGain> gainHandle;
-  uint32_t gain_cache_id, detId;
+  edm::ESGetToken<SiStripGain, SiStripGainRcd> gainToken_;
+  edm::ESWatcher<SiStripGainRcd> gainWatcher_;
+  const SiStripGain* gainHandle;
+  uint32_t detId;
 };
 
 SiStripClusterToDigiProducer::SiStripClusterToDigiProducer(const edm::ParameterSet& conf) {
   token = consumes<ClusterCollection>(conf.getParameter<edm::InputTag>("ClusterProducer"));
+  gainToken_ = esConsumes();
 
   produces<DigiCollection>("ZeroSuppressed");
   produces<DigiCollection>("VirginRaw");
@@ -52,7 +54,9 @@ SiStripClusterToDigiProducer::SiStripClusterToDigiProducer(const edm::ParameterS
 }
 
 void SiStripClusterToDigiProducer::produce(edm::Event& event, const edm::EventSetup& es) {
-  initialize(es);
+  if (gainWatcher_.check(es)) {
+    gainHandle = &es.getData(gainToken_);
+  }
 
   std::vector<DetDigiCollection> output_base;
   edm::Handle<ClusterCollection> input;
@@ -94,15 +98,6 @@ void SiStripClusterToDigiProducer::process(const ClusterCollection& input,
 
     if (!detDigis.empty())
       output_base.push_back(detDigis);
-  }
-}
-
-void SiStripClusterToDigiProducer::initialize(const edm::EventSetup& es) {
-  uint32_t g_cache_id = es.get<SiStripGainRcd>().cacheIdentifier();
-
-  if (g_cache_id != gain_cache_id) {
-    es.get<SiStripGainRcd>().get(gainHandle);
-    gain_cache_id = g_cache_id;
   }
 }
 

--- a/RecoLocalTracker/SiStripClusterizer/plugins/SiStripClusterToDigiProducer.cc
+++ b/RecoLocalTracker/SiStripClusterizer/plugins/SiStripClusterToDigiProducer.cc
@@ -32,14 +32,14 @@ public:
 private:
   void process(const ClusterCollection& input, std::vector<DetDigiCollection>& output_base);
   void setDetId(const uint32_t id);
-  float gain(const uint16_t& strip) const { return gainHandle->getStripGain(strip, gainRange); }
+  float gain(const uint16_t& strip) const { return gain_->getStripGain(strip, gainRange); }
   uint16_t applyGain(const uint16_t& strip, const uint16_t& adc);
 
   edm::EDGetTokenT<ClusterCollection> token;
   SiStripApvGain::Range gainRange;
   edm::ESGetToken<SiStripGain, SiStripGainRcd> gainToken_;
   edm::ESWatcher<SiStripGainRcd> gainWatcher_;
-  const SiStripGain* gainHandle;
+  const SiStripGain* gain_;
   uint32_t detId;
 };
 
@@ -55,7 +55,7 @@ SiStripClusterToDigiProducer::SiStripClusterToDigiProducer(const edm::ParameterS
 
 void SiStripClusterToDigiProducer::produce(edm::Event& event, const edm::EventSetup& es) {
   if (gainWatcher_.check(es)) {
-    gainHandle = &es.getData(gainToken_);
+    gain_ = &es.getData(gainToken_);
   }
 
   std::vector<DetDigiCollection> output_base;
@@ -102,7 +102,7 @@ void SiStripClusterToDigiProducer::process(const ClusterCollection& input,
 }
 
 inline void SiStripClusterToDigiProducer::setDetId(const uint32_t id) {
-  gainRange = gainHandle->getRange(id);
+  gainRange = gain_->getRange(id);
   detId = id;
 }
 

--- a/RecoLocalTracker/SiStripZeroSuppression/interface/SiStripFedZeroSuppression.h
+++ b/RecoLocalTracker/SiStripZeroSuppression/interface/SiStripFedZeroSuppression.h
@@ -52,8 +52,8 @@ public:
 private:
   edm::ESGetToken<SiStripNoises, SiStripNoisesRcd> noiseToken_;
   edm::ESGetToken<SiStripThreshold, SiStripThresholdRcd> thresholdToken_;
-  const SiStripNoises* noiseHandle_;
-  const SiStripThreshold* thresholdHandle_;
+  const SiStripNoises* noise_;
+  const SiStripThreshold* threshold_;
   edm::ESWatcher<SiStripNoisesRcd> noiseWatcher_;
   edm::ESWatcher<SiStripThresholdRcd> thresholdWatcher_;
 

--- a/RecoLocalTracker/SiStripZeroSuppression/interface/SiStripRawProcessingFactory.h
+++ b/RecoLocalTracker/SiStripZeroSuppression/interface/SiStripRawProcessingFactory.h
@@ -16,7 +16,7 @@ class SiStripRawProcessingFactory {
 public:
   static std::unique_ptr<SiStripRawProcessingAlgorithms> create(const edm::ParameterSet&, edm::ConsumesCollector);
 
-  static std::unique_ptr<SiStripFedZeroSuppression> create_Suppressor(const edm::ParameterSet&);
+  static std::unique_ptr<SiStripFedZeroSuppression> create_Suppressor(const edm::ParameterSet&, edm::ConsumesCollector);
   static std::unique_ptr<SiStripPedestalsSubtractor> create_SubtractorPed(const edm::ParameterSet&,
                                                                           edm::ConsumesCollector);
   static std::unique_ptr<SiStripCommonModeNoiseSubtractor> create_SubtractorCMN(const edm::ParameterSet&,

--- a/RecoLocalTracker/SiStripZeroSuppression/src/SiStripRawProcessingFactory.cc
+++ b/RecoLocalTracker/SiStripZeroSuppression/src/SiStripRawProcessingFactory.cc
@@ -19,7 +19,7 @@ std::unique_ptr<SiStripRawProcessingAlgorithms> SiStripRawProcessingFactory::cre
       new SiStripRawProcessingAlgorithms(iC,
                                          create_SubtractorPed(conf, iC),
                                          create_SubtractorCMN(conf, iC),
-                                         create_Suppressor(conf),
+                                         create_Suppressor(conf, iC),
                                          create_Restorer(conf, iC),
                                          conf.getParameter<bool>("doAPVRestore"),
                                          conf.getParameter<bool>("useCMMeanMap")));
@@ -61,8 +61,8 @@ std::unique_ptr<SiStripCommonModeNoiseSubtractor> SiStripRawProcessingFactory::c
   return std::unique_ptr<SiStripCommonModeNoiseSubtractor>(new MedianCMNSubtractor());
 }
 
-std::unique_ptr<SiStripFedZeroSuppression> SiStripRawProcessingFactory::create_Suppressor(
-    const edm::ParameterSet& conf) {
+std::unique_ptr<SiStripFedZeroSuppression> SiStripRawProcessingFactory::create_Suppressor(const edm::ParameterSet& conf,
+                                                                                          edm::ConsumesCollector iC) {
   const uint32_t mode = conf.getParameter<uint32_t>("SiStripFedZeroSuppressionMode");
   const bool trunc = conf.getParameter<bool>("TruncateInSuppressor");
   const bool trunc10bits = conf.getParameter<bool>("Use10bitsTruncation");
@@ -71,11 +71,11 @@ std::unique_ptr<SiStripFedZeroSuppression> SiStripRawProcessingFactory::create_S
     case 2:
     case 3:
     case 4:
-      return std::make_unique<SiStripFedZeroSuppression>(mode, trunc, trunc10bits);
+      return std::make_unique<SiStripFedZeroSuppression>(mode, &iC, trunc, trunc10bits);
     default:
       edm::LogError("SiStripRawProcessingFactory::createSuppressor")
           << "Unregistered mode: " << mode << ". Use one of {1,2,3,4}.";
-      return std::make_unique<SiStripFedZeroSuppression>(4, true, trunc10bits);
+      return std::make_unique<SiStripFedZeroSuppression>(4, &iC, true, trunc10bits);
   }
 }
 

--- a/SimTracker/SiStripDigitizer/plugins/DigiSimLinkAlgorithm.cc
+++ b/SimTracker/SiStripDigitizer/plugins/DigiSimLinkAlgorithm.cc
@@ -52,7 +52,7 @@ DigiSimLinkAlgorithm::DigiSimLinkAlgorithm(const edm::ParameterSet& conf) : conf
   theDigiSimLinkPileUpSignals = new DigiSimLinkPileUpSignals();
   theSiNoiseAdder = new SiGaussianTailNoiseAdder(theThreshold);
   theSiDigitalConverter = new SiTrivialDigitalConverter(theElectronPerADC, PreMixing_);
-  theSiZeroSuppress = new SiStripFedZeroSuppression(theFedAlgo);
+  theSiZeroSuppress = new SiStripFedZeroSuppression(theFedAlgo, nullptr);
 }
 
 DigiSimLinkAlgorithm::~DigiSimLinkAlgorithm() {

--- a/SimTracker/SiStripDigitizer/plugins/PreMixingSiStripWorker.cc
+++ b/SimTracker/SiStripDigitizer/plugins/PreMixingSiStripWorker.cc
@@ -164,7 +164,7 @@ PreMixingSiStripWorker::PreMixingSiStripWorker(const edm::ParameterSet& ps,
       theElectronPerADC(ps.getParameter<double>(peakMode ? "electronPerAdcPeak" : "electronPerAdcDec")),
       APVSaturationFromHIP_(ps.getParameter<bool>("APVSaturationFromHIP")),
       theFedAlgo(ps.getParameter<int>("FedAlgorithm_PM")),
-      theSiZeroSuppress(new SiStripFedZeroSuppression(theFedAlgo)),
+      theSiZeroSuppress(new SiStripFedZeroSuppression(theFedAlgo, &iC)),
       theSiDigitalConverter(new SiTrivialDigitalConverter(theElectronPerADC, false)),  // no premixing
       includeAPVSimulation_(ps.getParameter<bool>("includeAPVSimulation")),
       fracOfEventsToSimAPV_(ps.getParameter<double>("fracOfEventsToSimAPV")),

--- a/SimTracker/SiStripDigitizer/plugins/SiStripDigitizerAlgorithm.cc
+++ b/SimTracker/SiStripDigitizer/plugins/SiStripDigitizerAlgorithm.cc
@@ -67,7 +67,7 @@ SiStripDigitizerAlgorithm::SiStripDigitizerAlgorithm(const edm::ParameterSet& co
       theSiPileUpSignals(new SiPileUpSignals()),
       theSiNoiseAdder(new SiGaussianTailNoiseAdder(theThreshold)),
       theSiDigitalConverter(new SiTrivialDigitalConverter(theElectronPerADC, PreMixing_)),
-      theSiZeroSuppress(new SiStripFedZeroSuppression(theFedAlgo)),
+      theSiZeroSuppress(new SiStripFedZeroSuppression(theFedAlgo, &iC)),
       APVProbabilityFile(conf.getParameter<edm::FileInPath>("APVProbabilityFile")),
       includeAPVSimulation_(conf.getParameter<bool>("includeAPVSimulation")),
       apv_maxResponse_(conf.getParameter<double>("apv_maxResponse")),


### PR DESCRIPTION
#### PR description:

esConsumes migration https://github.com/cms-sw/cmssw/issues/31061 for modules in SiStrip packages not covered in https://github.com/cms-sw/cmssw/pull/31826 and https://github.com/cms-sw/cmssw/pull/32677 (I left SiStripFedZeroSuppression for after https://github.com/cms-sw/cmssw/pull/31697, and apparently overlooked SiStripHitEffFromCalibTree and SiStripClusterToDigiProducer previously).

#### PR validation:

The limited set of matrix tests ran without errors