### PR TITLE
Updated physics configurations for Geant4 

### DIFF
--- a/SimG4Core/Application/src/StackingAction.cc
+++ b/SimG4Core/Application/src/StackingAction.cc
@@ -171,8 +171,8 @@ StackingAction::~StackingAction() { delete newTA; }
 G4ClassificationOfNewTrack StackingAction::ClassifyNewTrack(const G4Track* aTrack) {
   // G4 interface part
   G4ClassificationOfNewTrack classification = fUrgent;
-  int pdg = aTrack->GetDefinition()->GetPDGEncoding();
-  int abspdg = std::abs(pdg);
+  const int pdg = aTrack->GetDefinition()->GetPDGEncoding();
+  const int abspdg = std::abs(pdg);
 
   // primary
   if (aTrack->GetCreatorProcess() == nullptr || aTrack->GetParentID() == 0) {
@@ -208,13 +208,13 @@ G4ClassificationOfNewTrack StackingAction::ClassifyNewTrack(const G4Track* aTrac
 
     } else {
       // potentially good for tracking
-      double ke = aTrack->GetKineticEnergy();
+      const double ke = aTrack->GetKineticEnergy();
 
       // kill tracks in specific regions
-      if (classification != fKill && isThisRegion(reg, deadRegions)) {
+      if (isThisRegion(reg, deadRegions)) {
         classification = fKill;
       }
-      if (ke <= limitEnergyForVacuum && isThisRegion(reg, lowdensRegions)) {
+      if (classification != fKill && ke <= limitEnergyForVacuum && isThisRegion(reg, lowdensRegions)) {
         classification = fKill;
 
       } else {
@@ -346,14 +346,14 @@ void StackingAction::PrepareNewEvent() {}
 
 void StackingAction::initPointer() {
   // prepare region vector
-  unsigned int num = maxTimeNames.size();
+  const unsigned int num = maxTimeNames.size();
   maxTimeRegions.resize(num, nullptr);
 
   // Russian roulette
-  std::vector<G4Region*>* rs = G4RegionStore::GetInstance();
+  const std::vector<G4Region*>* rs = G4RegionStore::GetInstance();
 
   for (auto& reg : *rs) {
-    G4String rname = reg->GetName();
+    const G4String& rname = reg->GetName();
     if ((gRusRoEcal < 1.0 || nRusRoEcal < 1.0) && rname == "EcalRegion") {
       regionEcal = reg;
     }
@@ -434,8 +434,8 @@ bool StackingAction::rrApplicable(const G4Track* aTrack, const G4Track& mother) 
   const TrackInformation& motherInfo(extractor(mother));
 
   // Check whether mother is gamma, e+, e-
-  int genID = motherInfo.genParticlePID();
-  return (22 == genID || 11 == genID || -11 == genID) ? false : true;
+  const int genID = std::abs(motherInfo.genParticlePID());
+  return (22 != genID && 11 != genID);
 }
 
 int StackingAction::isItFromPrimary(const G4Track& mother, int flagIn) const {
@@ -457,7 +457,7 @@ bool StackingAction::isItOutOfTimeWindow(const G4Region* reg, const G4Track* aTr
       break;
     }
   }
-  return (aTrack->GetGlobalTime() > tofM) ? true : false;
+  return (aTrack->GetGlobalTime() > tofM);
 }
 
 void StackingAction::printRegions(const std::vector<const G4Region*>& reg, const std::string& word) const {

--- a/SimG4Core/PhysicsLists/interface/CMSHadronPhysicsFTFP_BERT.h
+++ b/SimG4Core/PhysicsLists/interface/CMSHadronPhysicsFTFP_BERT.h
@@ -23,7 +23,8 @@
 class CMSHadronPhysicsFTFP_BERT : public G4HadronPhysicsFTFP_BERT {
 public:
   explicit CMSHadronPhysicsFTFP_BERT(G4int verb);
-  explicit CMSHadronPhysicsFTFP_BERT(G4double e1, G4double e2, G4double e3);
+  explicit CMSHadronPhysicsFTFP_BERT(G4double e1, G4double e2, G4double e3, 
+                                     G4double e4, G4double e5);
   ~CMSHadronPhysicsFTFP_BERT() override;
 
   void ConstructProcess() override;

--- a/SimG4Core/PhysicsLists/interface/CMSHadronPhysicsFTFP_BERT.h
+++ b/SimG4Core/PhysicsLists/interface/CMSHadronPhysicsFTFP_BERT.h
@@ -23,8 +23,7 @@
 class CMSHadronPhysicsFTFP_BERT : public G4HadronPhysicsFTFP_BERT {
 public:
   explicit CMSHadronPhysicsFTFP_BERT(G4int verb);
-  explicit CMSHadronPhysicsFTFP_BERT(G4double e1, G4double e2, G4double e3, 
-                                     G4double e4, G4double e5);
+  explicit CMSHadronPhysicsFTFP_BERT(G4double e1, G4double e2, G4double e3, G4double e4, G4double e5);
   ~CMSHadronPhysicsFTFP_BERT() override;
 
   void ConstructProcess() override;

--- a/SimG4Core/PhysicsLists/plugins/FTFPCMS_BERT.cc
+++ b/SimG4Core/PhysicsLists/plugins/FTFPCMS_BERT.cc
@@ -8,23 +8,19 @@
 #include "G4IonPhysics.hh"
 #include "G4StoppingPhysics.hh"
 #include "G4HadronElasticPhysics.hh"
-#include "G4NeutronTrackingCut.hh"
-#include "G4HadronicProcessStore.hh"
 
 FTFPCMS_BERT::FTFPCMS_BERT(const edm::ParameterSet& p) : PhysicsList(p) {
   int ver = p.getUntrackedParameter<int>("Verbosity", 0);
   bool emPhys = p.getUntrackedParameter<bool>("EMPhysics", true);
   bool hadPhys = p.getUntrackedParameter<bool>("HadPhysics", true);
-  bool tracking = p.getParameter<bool>("TrackingCut");
-  double timeLimit = p.getParameter<double>("MaxTrackTime") * CLHEP::ns;
   double minFTFP = p.getParameter<double>("EminFTFP") * CLHEP::GeV;
   double maxBERT = p.getParameter<double>("EmaxBERT") * CLHEP::GeV;
   double maxBERTpi = p.getParameter<double>("EmaxBERTpi") * CLHEP::GeV;
-  edm::LogInfo("PhysicsList") << "You are using the simulation engine: FTFP_BERT \n Flags for EM Physics " << emPhys
-                              << ", for Hadronic Physics " << hadPhys << " and tracking cut " << tracking
-                              << "   t(ns)= " << timeLimit / CLHEP::ns << "\n  transition energy Bertini/FTFP from "
-                              << minFTFP / CLHEP::GeV << " to " << maxBERT / CLHEP::GeV << ":" << maxBERTpi / CLHEP::GeV
-                              << " GeV";
+  edm::LogVerbatim("PhysicsList") << "CMS Physics List FTFP_BERT: "
+                                  << "\n Flags for EM Physics: " << emPhys 
+                                  << "; Hadronic Physics: " << hadPhys 
+                                  << "\n  transition energy Bertini/FTFP from " << minFTFP / CLHEP::GeV << " to "
+                                  << maxBERT / CLHEP::GeV << ":" << maxBERTpi / CLHEP::GeV << " GeV";
 
   if (emPhys) {
     // EM Physics
@@ -39,25 +35,17 @@ FTFPCMS_BERT::FTFPCMS_BERT(const edm::ParameterSet& p) : PhysicsList(p) {
   RegisterPhysics(new G4DecayPhysics(ver));
 
   if (hadPhys) {
-    G4HadronicProcessStore::Instance()->SetVerbose(ver);
 
     // Hadron Elastic scattering
     RegisterPhysics(new G4HadronElasticPhysics(ver));
 
     // Hadron Physics
-    RegisterPhysics(new CMSHadronPhysicsFTFP_BERT(minFTFP, maxBERT, maxBERTpi));
+    RegisterPhysics(new CMSHadronPhysicsFTFP_BERT(minFTFP, maxBERT, maxBERTpi, minFTFP, maxBERT));
 
     // Stopping Physics
     RegisterPhysics(new G4StoppingPhysics(ver));
 
     // Ion Physics
     RegisterPhysics(new G4IonPhysics(ver));
-
-    // Neutron tracking cut
-    if (tracking) {
-      G4NeutronTrackingCut* ncut = new G4NeutronTrackingCut(ver);
-      ncut->SetTimeLimit(timeLimit);
-      RegisterPhysics(ncut);
-    }
   }
 }

--- a/SimG4Core/PhysicsLists/plugins/FTFPCMS_BERT.cc
+++ b/SimG4Core/PhysicsLists/plugins/FTFPCMS_BERT.cc
@@ -17,8 +17,7 @@ FTFPCMS_BERT::FTFPCMS_BERT(const edm::ParameterSet& p) : PhysicsList(p) {
   double maxBERT = p.getParameter<double>("EmaxBERT") * CLHEP::GeV;
   double maxBERTpi = p.getParameter<double>("EmaxBERTpi") * CLHEP::GeV;
   edm::LogVerbatim("PhysicsList") << "CMS Physics List FTFP_BERT: "
-                                  << "\n Flags for EM Physics: " << emPhys 
-                                  << "; Hadronic Physics: " << hadPhys 
+                                  << "\n Flags for EM Physics: " << emPhys << "; Hadronic Physics: " << hadPhys
                                   << "\n  transition energy Bertini/FTFP from " << minFTFP / CLHEP::GeV << " to "
                                   << maxBERT / CLHEP::GeV << ":" << maxBERTpi / CLHEP::GeV << " GeV";
 
@@ -35,7 +34,6 @@ FTFPCMS_BERT::FTFPCMS_BERT(const edm::ParameterSet& p) : PhysicsList(p) {
   RegisterPhysics(new G4DecayPhysics(ver));
 
   if (hadPhys) {
-
     // Hadron Elastic scattering
     RegisterPhysics(new G4HadronElasticPhysics(ver));
 

--- a/SimG4Core/PhysicsLists/plugins/FTFPCMS_BERT_EML.cc
+++ b/SimG4Core/PhysicsLists/plugins/FTFPCMS_BERT_EML.cc
@@ -7,22 +7,18 @@
 #include "G4IonPhysics.hh"
 #include "G4StoppingPhysics.hh"
 #include "G4HadronElasticPhysics.hh"
-#include "G4NeutronTrackingCut.hh"
-#include "G4HadronicProcessStore.hh"
 #include "G4EmStandardPhysics_option1.hh"
 
 FTFPCMS_BERT_EML::FTFPCMS_BERT_EML(const edm::ParameterSet& p) : PhysicsList(p) {
   int ver = p.getUntrackedParameter<int>("Verbosity", 0);
   bool emPhys = p.getUntrackedParameter<bool>("EMPhysics", true);
   bool hadPhys = p.getUntrackedParameter<bool>("HadPhysics", true);
-  bool tracking = p.getParameter<bool>("TrackingCut");
-  double timeLimit = p.getParameter<double>("MaxTrackTime") * CLHEP::ns;
   double minFTFP = p.getParameter<double>("EminFTFP") * CLHEP::GeV;
   double maxBERT = p.getParameter<double>("EmaxBERT") * CLHEP::GeV;
   double maxBERTpi = p.getParameter<double>("EmaxBERTpi") * CLHEP::GeV;
-  edm::LogVerbatim("PhysicsList") << "You are using the simulation engine: FTFP_BERT_EML: \n Flags for EM Physics: "
-                                  << emPhys << "; Hadronic Physics: " << hadPhys << "; tracking cut: " << tracking
-                                  << "; time limit(ns)= " << timeLimit / CLHEP::ns
+  edm::LogVerbatim("PhysicsList") << "CMS Physics List FTFP_BERT_EML: "
+                                  << "\n Flags for EM Physics: " << emPhys 
+                                  << "; Hadronic Physics: " << hadPhys 
                                   << "\n  transition energy Bertini/FTFP from " << minFTFP / CLHEP::GeV << " to "
                                   << maxBERT / CLHEP::GeV << ":" << maxBERTpi / CLHEP::GeV << " GeV";
 
@@ -39,25 +35,16 @@ FTFPCMS_BERT_EML::FTFPCMS_BERT_EML(const edm::ParameterSet& p) : PhysicsList(p) 
   this->RegisterPhysics(new G4DecayPhysics(ver));
 
   if (hadPhys) {
-    G4HadronicProcessStore::Instance()->SetVerbose(ver);
-
     // Hadron Elastic scattering
     RegisterPhysics(new G4HadronElasticPhysics(ver));
 
     // Hadron Physics
-    RegisterPhysics(new CMSHadronPhysicsFTFP_BERT(minFTFP, maxBERT, maxBERTpi));
+    RegisterPhysics(new CMSHadronPhysicsFTFP_BERT(minFTFP, maxBERT, maxBERTpi, minFTFP, maxBERT));
 
     // Stopping Physics
     RegisterPhysics(new G4StoppingPhysics(ver));
 
     // Ion Physics
     RegisterPhysics(new G4IonPhysics(ver));
-
-    // Neutron tracking cut
-    if (tracking) {
-      G4NeutronTrackingCut* ncut = new G4NeutronTrackingCut(ver);
-      ncut->SetTimeLimit(timeLimit);
-      RegisterPhysics(ncut);
-    }
   }
 }

--- a/SimG4Core/PhysicsLists/plugins/FTFPCMS_BERT_EML.cc
+++ b/SimG4Core/PhysicsLists/plugins/FTFPCMS_BERT_EML.cc
@@ -17,8 +17,7 @@ FTFPCMS_BERT_EML::FTFPCMS_BERT_EML(const edm::ParameterSet& p) : PhysicsList(p) 
   double maxBERT = p.getParameter<double>("EmaxBERT") * CLHEP::GeV;
   double maxBERTpi = p.getParameter<double>("EmaxBERTpi") * CLHEP::GeV;
   edm::LogVerbatim("PhysicsList") << "CMS Physics List FTFP_BERT_EML: "
-                                  << "\n Flags for EM Physics: " << emPhys 
-                                  << "; Hadronic Physics: " << hadPhys 
+                                  << "\n Flags for EM Physics: " << emPhys << "; Hadronic Physics: " << hadPhys
                                   << "\n  transition energy Bertini/FTFP from " << minFTFP / CLHEP::GeV << " to "
                                   << maxBERT / CLHEP::GeV << ":" << maxBERTpi / CLHEP::GeV << " GeV";
 

--- a/SimG4Core/PhysicsLists/plugins/FTFPCMS_BERT_EMM.cc
+++ b/SimG4Core/PhysicsLists/plugins/FTFPCMS_BERT_EMM.cc
@@ -17,8 +17,7 @@ FTFPCMS_BERT_EMM::FTFPCMS_BERT_EMM(const edm::ParameterSet& p) : PhysicsList(p) 
   double maxBERT = p.getParameter<double>("EmaxBERT") * CLHEP::GeV;
   double maxBERTpi = p.getParameter<double>("EmaxBERTpi") * CLHEP::GeV;
   edm::LogVerbatim("PhysicsList") << "CMS Physics List FTFP_BERT_EMM: "
-				  << "\n Flags for EM Physics: " << emPhys 
-                                  << "; Hadronic Physics: " << hadPhys 
+                                  << "\n Flags for EM Physics: " << emPhys << "; Hadronic Physics: " << hadPhys
                                   << "\n Transition energy Bertini/FTFP from " << minFTFP / CLHEP::GeV << " to "
                                   << maxBERT / CLHEP::GeV << "; for pions to " << maxBERTpi / CLHEP::GeV << " GeV";
 

--- a/SimG4Core/PhysicsLists/plugins/FTFPCMS_BERT_EMM.cc
+++ b/SimG4Core/PhysicsLists/plugins/FTFPCMS_BERT_EMM.cc
@@ -1,8 +1,6 @@
 #include "FTFPCMS_BERT_EMM.h"
 #include "SimG4Core/PhysicsLists/interface/CMSEmStandardPhysics.h"
-#include "SimG4Core/PhysicsLists/interface/CMSEmStandardPhysicsLPM.h"
 #include "SimG4Core/PhysicsLists/interface/CMSHadronPhysicsFTFP_BERT.h"
-#include "SimG4Core/PhysicsLists/interface/CMSHadronPhysicsFTFP_BERT106.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include "G4DecayPhysics.hh"
@@ -10,27 +8,23 @@
 #include "G4IonPhysics.hh"
 #include "G4StoppingPhysics.hh"
 #include "G4HadronElasticPhysics.hh"
-#include "G4NeutronTrackingCut.hh"
-#include "G4HadronicProcessStore.hh"
 
 FTFPCMS_BERT_EMM::FTFPCMS_BERT_EMM(const edm::ParameterSet& p) : PhysicsList(p) {
   int ver = p.getUntrackedParameter<int>("Verbosity", 0);
   bool emPhys = p.getUntrackedParameter<bool>("EMPhysics", true);
   bool hadPhys = p.getUntrackedParameter<bool>("HadPhysics", true);
-  bool tracking = p.getParameter<bool>("TrackingCut");
-  double timeLimit = p.getParameter<double>("MaxTrackTime") * CLHEP::ns;
   double minFTFP = p.getParameter<double>("EminFTFP") * CLHEP::GeV;
   double maxBERT = p.getParameter<double>("EmaxBERT") * CLHEP::GeV;
   double maxBERTpi = p.getParameter<double>("EmaxBERTpi") * CLHEP::GeV;
-  edm::LogVerbatim("PhysicsList") << "You are using the simulation engine: FTFP_BERT_EMM: \n Flags for EM Physics: "
-                                  << emPhys << "; Hadronic Physics: " << hadPhys << "; tracking cut: " << tracking
-                                  << "; time limit(ns)= " << timeLimit / CLHEP::ns
+  edm::LogVerbatim("PhysicsList") << "CMS Physics List FTFP_BERT_EMM: "
+				  << "\n Flags for EM Physics: " << emPhys 
+                                  << "; Hadronic Physics: " << hadPhys 
                                   << "\n Transition energy Bertini/FTFP from " << minFTFP / CLHEP::GeV << " to "
                                   << maxBERT / CLHEP::GeV << "; for pions to " << maxBERTpi / CLHEP::GeV << " GeV";
 
   if (emPhys) {
     // EM Physics
-    RegisterPhysics(new CMSEmStandardPhysicsLPM(ver));
+    RegisterPhysics(new CMSEmStandardPhysics(ver, p));
 
     // Synchroton Radiation & GN Physics
     G4EmExtraPhysics* gn = new G4EmExtraPhysics(ver);
@@ -41,25 +35,16 @@ FTFPCMS_BERT_EMM::FTFPCMS_BERT_EMM(const edm::ParameterSet& p) : PhysicsList(p) 
   this->RegisterPhysics(new G4DecayPhysics(ver));
 
   if (hadPhys) {
-    G4HadronicProcessStore::Instance()->SetVerbose(ver);
-
     // Hadron Elastic scattering
     RegisterPhysics(new G4HadronElasticPhysics(ver));
 
     // Hadron Physics
-    RegisterPhysics(new CMSHadronPhysicsFTFP_BERT106(minFTFP, maxBERT, maxBERTpi));
+    RegisterPhysics(new CMSHadronPhysicsFTFP_BERT(minFTFP, maxBERT, maxBERTpi, minFTFP, maxBERT));
 
     // Stopping Physics
     RegisterPhysics(new G4StoppingPhysics(ver));
 
     // Ion Physics
     RegisterPhysics(new G4IonPhysics(ver));
-
-    // Neutron tracking cut
-    if (tracking) {
-      G4NeutronTrackingCut* ncut = new G4NeutronTrackingCut(ver);
-      ncut->SetTimeLimit(timeLimit);
-      RegisterPhysics(ncut);
-    }
   }
 }

--- a/SimG4Core/PhysicsLists/plugins/FTFPCMS_BERT_EMM_TRK.cc
+++ b/SimG4Core/PhysicsLists/plugins/FTFPCMS_BERT_EMM_TRK.cc
@@ -8,51 +8,29 @@
 #include "G4IonPhysics.hh"
 #include "G4StoppingPhysics.hh"
 #include "G4HadronElasticPhysics.hh"
-#include "G4NeutronTrackingCut.hh"
-#include "G4HadronicProcessStore.hh"
 
 FTFPCMS_BERT_EMM_TRK::FTFPCMS_BERT_EMM_TRK(const edm::ParameterSet& p) : PhysicsList(p) {
   int ver = p.getUntrackedParameter<int>("Verbosity", 0);
-  bool emPhys = p.getUntrackedParameter<bool>("EMPhysics", true);
-  bool hadPhys = p.getUntrackedParameter<bool>("HadPhysics", true);
-  bool tracking = p.getParameter<bool>("TrackingCut");
-  double timeLimit = p.getParameter<double>("MaxTrackTime") * CLHEP::ns;
-  edm::LogInfo("PhysicsList") << "You are using the simulation engine: "
-                              << "FTFP_BERT_EMM_TRK \n Flags for EM Physics " << emPhys << ", for Hadronic Physics "
-                              << hadPhys << " and tracking cut " << tracking << "   t(ns)= " << timeLimit / CLHEP::ns;
+  edm::LogVerbatim("PhysicsList") << "CMS Physics List FTFP_BERT_EMM_TRK";
 
-  if (emPhys) {
-    // EM Physics
-    RegisterPhysics(new CMSEmStandardPhysics(ver, p));
+  // EM physics
+  RegisterPhysics(new CMSEmStandardPhysics(ver, p));
 
-    // Synchroton Radiation & GN Physics
-    G4EmExtraPhysics* gn = new G4EmExtraPhysics(ver);
-    RegisterPhysics(gn);
-  }
+  // gamma and lepto-nuclear physics
+  RegisterPhysics(new G4EmExtraPhysics(ver));
 
   // Decays
-  this->RegisterPhysics(new G4DecayPhysics(ver));
+  RegisterPhysics(new G4DecayPhysics(ver));
 
-  if (hadPhys) {
-    G4HadronicProcessStore::Instance()->SetVerbose(ver);
+  // Hadron elastic scattering
+  RegisterPhysics(new G4HadronElasticPhysics(ver));
 
-    // Hadron Elastic scattering
-    RegisterPhysics(new G4HadronElasticPhysics(ver));
+  // Hadron inelastic physics
+  RegisterPhysics(new CMSHadronPhysicsFTFP_BERT(3*CLHEP::GeV, 6*CLHEP::GeV, 12*CLHEP::GeV, 2*CLHEP::GeV, 4*CLHEP::GeV));
 
-    // Hadron Physics
-    RegisterPhysics(new CMSHadronPhysicsFTFP_BERT(ver));
+  // Stopping physics
+  RegisterPhysics(new G4StoppingPhysics(ver));
 
-    // Stopping Physics
-    RegisterPhysics(new G4StoppingPhysics(ver));
-
-    // Ion Physics
-    RegisterPhysics(new G4IonPhysics(ver));
-
-    // Neutron tracking cut
-    if (tracking) {
-      G4NeutronTrackingCut* ncut = new G4NeutronTrackingCut(ver);
-      ncut->SetTimeLimit(timeLimit);
-      RegisterPhysics(ncut);
-    }
-  }
+  // Ion physics
+  RegisterPhysics(new G4IonPhysics(ver));
 }

--- a/SimG4Core/PhysicsLists/plugins/FTFPCMS_BERT_EMM_TRK.cc
+++ b/SimG4Core/PhysicsLists/plugins/FTFPCMS_BERT_EMM_TRK.cc
@@ -26,7 +26,8 @@ FTFPCMS_BERT_EMM_TRK::FTFPCMS_BERT_EMM_TRK(const edm::ParameterSet& p) : Physics
   RegisterPhysics(new G4HadronElasticPhysics(ver));
 
   // Hadron inelastic physics
-  RegisterPhysics(new CMSHadronPhysicsFTFP_BERT(3*CLHEP::GeV, 6*CLHEP::GeV, 12*CLHEP::GeV, 2*CLHEP::GeV, 4*CLHEP::GeV));
+  RegisterPhysics(
+      new CMSHadronPhysicsFTFP_BERT(3 * CLHEP::GeV, 6 * CLHEP::GeV, 12 * CLHEP::GeV, 2 * CLHEP::GeV, 4 * CLHEP::GeV));
 
   // Stopping physics
   RegisterPhysics(new G4StoppingPhysics(ver));

--- a/SimG4Core/PhysicsLists/plugins/FTFPCMS_BERT_EMN.cc
+++ b/SimG4Core/PhysicsLists/plugins/FTFPCMS_BERT_EMN.cc
@@ -17,8 +17,7 @@ FTFPCMS_BERT_EMN::FTFPCMS_BERT_EMN(const edm::ParameterSet& p) : PhysicsList(p) 
   double maxBERT = p.getParameter<double>("EmaxBERT") * CLHEP::GeV;
   double maxBERTpi = p.getParameter<double>("EmaxBERTpi") * CLHEP::GeV;
   edm::LogVerbatim("PhysicsList") << "CMS Physics List FTFP_BERT_EMN: "
-                                  << "\n Flags for EM Physics: " << emPhys 
-                                  << "; Hadronic Physics: " << hadPhys 
+                                  << "\n Flags for EM Physics: " << emPhys << "; Hadronic Physics: " << hadPhys
                                   << "\n  transition energy Bertini/FTFP from " << minFTFP / CLHEP::GeV << " to "
                                   << maxBERT / CLHEP::GeV << ":" << maxBERTpi / CLHEP::GeV << " GeV";
 

--- a/SimG4Core/PhysicsLists/plugins/FTFPCMS_BERT_EMN.cc
+++ b/SimG4Core/PhysicsLists/plugins/FTFPCMS_BERT_EMN.cc
@@ -8,21 +8,17 @@
 #include "G4IonPhysics.hh"
 #include "G4StoppingPhysics.hh"
 #include "G4HadronElasticPhysics.hh"
-#include "G4NeutronTrackingCut.hh"
-#include "G4HadronicProcessStore.hh"
 
 FTFPCMS_BERT_EMN::FTFPCMS_BERT_EMN(const edm::ParameterSet& p) : PhysicsList(p) {
   int ver = p.getUntrackedParameter<int>("Verbosity", 0);
   bool emPhys = p.getUntrackedParameter<bool>("EMPhysics", true);
   bool hadPhys = p.getUntrackedParameter<bool>("HadPhysics", true);
-  bool tracking = p.getParameter<bool>("TrackingCut");
-  double timeLimit = p.getParameter<double>("MaxTrackTime") * CLHEP::ns;
   double minFTFP = p.getParameter<double>("EminFTFP") * CLHEP::GeV;
   double maxBERT = p.getParameter<double>("EmaxBERT") * CLHEP::GeV;
   double maxBERTpi = p.getParameter<double>("EmaxBERTpi") * CLHEP::GeV;
-  edm::LogVerbatim("PhysicsList") << "You are using the simulation engine: FTFP_BERT_EMN: \n Flags for EM Physics: "
-                                  << emPhys << "; Hadronic Physics: " << hadPhys << "; tracking cut: " << tracking
-                                  << "; time limit(ns)= " << timeLimit / CLHEP::ns
+  edm::LogVerbatim("PhysicsList") << "CMS Physics List FTFP_BERT_EMN: "
+                                  << "\n Flags for EM Physics: " << emPhys 
+                                  << "; Hadronic Physics: " << hadPhys 
                                   << "\n  transition energy Bertini/FTFP from " << minFTFP / CLHEP::GeV << " to "
                                   << maxBERT / CLHEP::GeV << ":" << maxBERTpi / CLHEP::GeV << " GeV";
 
@@ -39,25 +35,16 @@ FTFPCMS_BERT_EMN::FTFPCMS_BERT_EMN(const edm::ParameterSet& p) : PhysicsList(p) 
   this->RegisterPhysics(new G4DecayPhysics(ver));
 
   if (hadPhys) {
-    G4HadronicProcessStore::Instance()->SetVerbose(ver);
-
     // Hadron Elastic scattering
     RegisterPhysics(new G4HadronElasticPhysics(ver));
 
     // Hadron Physics
-    RegisterPhysics(new CMSHadronPhysicsFTFP_BERT(minFTFP, maxBERT, maxBERTpi));
+    RegisterPhysics(new CMSHadronPhysicsFTFP_BERT(minFTFP, maxBERT, maxBERTpi, minFTFP, maxBERT));
 
     // Stopping Physics
     RegisterPhysics(new G4StoppingPhysics(ver));
 
     // Ion Physics
     RegisterPhysics(new G4IonPhysics(ver));
-
-    // Neutron tracking cut
-    if (tracking) {
-      G4NeutronTrackingCut* ncut = new G4NeutronTrackingCut(ver);
-      ncut->SetTimeLimit(timeLimit);
-      RegisterPhysics(ncut);
-    }
   }
 }

--- a/SimG4Core/PhysicsLists/plugins/FTFPCMS_BERT_EMY.cc
+++ b/SimG4Core/PhysicsLists/plugins/FTFPCMS_BERT_EMY.cc
@@ -17,8 +17,7 @@ FTFPCMS_BERT_EMY::FTFPCMS_BERT_EMY(const edm::ParameterSet& p) : PhysicsList(p) 
   double maxBERT = p.getParameter<double>("EmaxBERT") * CLHEP::GeV;
   double maxBERTpi = p.getParameter<double>("EmaxBERTpi") * CLHEP::GeV;
   edm::LogVerbatim("PhysicsList") << "CMS Physics List FTFP_BERT_EMY: "
-                                  << "\n Flags for EM Physics: " << emPhys 
-                                  << "; Hadronic Physics: " << hadPhys 
+                                  << "\n Flags for EM Physics: " << emPhys << "; Hadronic Physics: " << hadPhys
                                   << "\n  transition energy Bertini/FTFP from " << minFTFP / CLHEP::GeV << " to "
                                   << maxBERT / CLHEP::GeV << ":" << maxBERTpi / CLHEP::GeV << " GeV";
 

--- a/SimG4Core/PhysicsLists/plugins/FTFPCMS_BERT_EMY.cc
+++ b/SimG4Core/PhysicsLists/plugins/FTFPCMS_BERT_EMY.cc
@@ -8,29 +8,23 @@
 #include "G4IonPhysics.hh"
 #include "G4StoppingPhysics.hh"
 #include "G4HadronElasticPhysics.hh"
-#include "G4NeutronTrackingCut.hh"
-#include "G4HadronicProcessStore.hh"
-#include "G4EmParameters.hh"
 
 FTFPCMS_BERT_EMY::FTFPCMS_BERT_EMY(const edm::ParameterSet& p) : PhysicsList(p) {
   int ver = p.getUntrackedParameter<int>("Verbosity", 0);
   bool emPhys = p.getUntrackedParameter<bool>("EMPhysics", true);
   bool hadPhys = p.getUntrackedParameter<bool>("HadPhysics", true);
-  bool tracking = p.getParameter<bool>("TrackingCut");
-  double timeLimit = p.getParameter<double>("MaxTrackTime") * CLHEP::ns;
   double minFTFP = p.getParameter<double>("EminFTFP") * CLHEP::GeV;
   double maxBERT = p.getParameter<double>("EmaxBERT") * CLHEP::GeV;
   double maxBERTpi = p.getParameter<double>("EmaxBERTpi") * CLHEP::GeV;
-  edm::LogVerbatim("PhysicsList") << "You are using the simulation engine: FTFP_BERT_EMY \n Flags for EM Physics "
-                                  << emPhys << ", for Hadronic Physics " << hadPhys << " and tracking cut " << tracking
-                                  << "   t(ns)= " << timeLimit / CLHEP::ns << "\n  transition energy Bertini/FTFP from "
-                                  << minFTFP / CLHEP::GeV << " to " << maxBERT / CLHEP::GeV << ":"
-                                  << maxBERTpi / CLHEP::GeV << " GeV";
+  edm::LogVerbatim("PhysicsList") << "CMS Physics List FTFP_BERT_EMY: "
+                                  << "\n Flags for EM Physics: " << emPhys 
+                                  << "; Hadronic Physics: " << hadPhys 
+                                  << "\n  transition energy Bertini/FTFP from " << minFTFP / CLHEP::GeV << " to "
+                                  << maxBERT / CLHEP::GeV << ":" << maxBERTpi / CLHEP::GeV << " GeV";
 
   if (emPhys) {
     // EM Physics
     RegisterPhysics(new G4EmStandardPhysics_option3(ver));
-    G4EmParameters::Instance()->SetMscStepLimitType(fUseSafetyPlus);
 
     // Synchroton Radiation & GN Physics
     G4EmExtraPhysics* gn = new G4EmExtraPhysics(ver);
@@ -41,25 +35,16 @@ FTFPCMS_BERT_EMY::FTFPCMS_BERT_EMY(const edm::ParameterSet& p) : PhysicsList(p) 
   this->RegisterPhysics(new G4DecayPhysics(ver));
 
   if (hadPhys) {
-    G4HadronicProcessStore::Instance()->SetVerbose(ver);
-
     // Hadron Elastic scattering
     RegisterPhysics(new G4HadronElasticPhysics(ver));
 
     // Hadron Physics
-    RegisterPhysics(new CMSHadronPhysicsFTFP_BERT(minFTFP, maxBERT, maxBERTpi));
+    RegisterPhysics(new CMSHadronPhysicsFTFP_BERT(minFTFP, maxBERT, maxBERTpi, minFTFP, maxBERT));
 
     // Stopping Physics
     RegisterPhysics(new G4StoppingPhysics(ver));
 
     // Ion Physics
     RegisterPhysics(new G4IonPhysics(ver));
-
-    // Neutron tracking cut
-    if (tracking) {
-      G4NeutronTrackingCut* ncut = new G4NeutronTrackingCut(ver);
-      ncut->SetTimeLimit(timeLimit);
-      RegisterPhysics(ncut);
-    }
   }
 }

--- a/SimG4Core/PhysicsLists/plugins/FTFPCMS_BERT_EMZ.cc
+++ b/SimG4Core/PhysicsLists/plugins/FTFPCMS_BERT_EMZ.cc
@@ -8,23 +8,19 @@
 #include "G4IonPhysics.hh"
 #include "G4StoppingPhysics.hh"
 #include "G4HadronElasticPhysics.hh"
-#include "G4NeutronTrackingCut.hh"
-#include "G4HadronicProcessStore.hh"
 
 FTFPCMS_BERT_EMZ::FTFPCMS_BERT_EMZ(const edm::ParameterSet& p) : PhysicsList(p) {
   int ver = p.getUntrackedParameter<int>("Verbosity", 0);
   bool emPhys = p.getUntrackedParameter<bool>("EMPhysics", true);
   bool hadPhys = p.getUntrackedParameter<bool>("HadPhysics", true);
-  bool tracking = p.getParameter<bool>("TrackingCut");
-  double timeLimit = p.getParameter<double>("MaxTrackTime") * CLHEP::ns;
   double minFTFP = p.getParameter<double>("EminFTFP") * CLHEP::GeV;
   double maxBERT = p.getParameter<double>("EmaxBERT") * CLHEP::GeV;
   double maxBERTpi = p.getParameter<double>("EmaxBERTpi") * CLHEP::GeV;
-  edm::LogVerbatim("PhysicsList") << "You are using the simulation engine: FTFP_BERT_EMZ \n Flags for EM Physics "
-                                  << emPhys << ", for Hadronic Physics " << hadPhys << " and tracking cut " << tracking
-                                  << "   t(ns)= " << timeLimit / CLHEP::ns << "\n  transition energy Bertini/FTFP from "
-                                  << minFTFP / CLHEP::GeV << " to " << maxBERT / CLHEP::GeV << ":"
-                                  << maxBERTpi / CLHEP::GeV << " GeV";
+  edm::LogVerbatim("PhysicsList") << "CMS Physics List FTFP_BERT_EMZ: "
+                                  << "\n Flags for EM Physics: " << emPhys 
+                                  << "; Hadronic Physics: " << hadPhys 
+                                  << "\n  transition energy Bertini/FTFP from " << minFTFP / CLHEP::GeV << " to "
+                                  << maxBERT / CLHEP::GeV << ":" << maxBERTpi / CLHEP::GeV << " GeV";
 
   if (emPhys) {
     // EM Physics
@@ -39,25 +35,16 @@ FTFPCMS_BERT_EMZ::FTFPCMS_BERT_EMZ(const edm::ParameterSet& p) : PhysicsList(p) 
   this->RegisterPhysics(new G4DecayPhysics(ver));
 
   if (hadPhys) {
-    G4HadronicProcessStore::Instance()->SetVerbose(ver);
-
     // Hadron Elastic scattering
     RegisterPhysics(new G4HadronElasticPhysics(ver));
 
     // Hadron Physics
-    RegisterPhysics(new CMSHadronPhysicsFTFP_BERT(minFTFP, maxBERT, maxBERTpi));
+    RegisterPhysics(new CMSHadronPhysicsFTFP_BERT(minFTFP, maxBERT, maxBERTpi, minFTFP, maxBERT));
 
     // Stopping Physics
     RegisterPhysics(new G4StoppingPhysics(ver));
 
     // Ion Physics
     RegisterPhysics(new G4IonPhysics(ver));
-
-    // Neutron tracking cut
-    if (tracking) {
-      G4NeutronTrackingCut* ncut = new G4NeutronTrackingCut(ver);
-      ncut->SetTimeLimit(timeLimit);
-      RegisterPhysics(ncut);
-    }
   }
 }

--- a/SimG4Core/PhysicsLists/plugins/FTFPCMS_BERT_EMZ.cc
+++ b/SimG4Core/PhysicsLists/plugins/FTFPCMS_BERT_EMZ.cc
@@ -17,8 +17,7 @@ FTFPCMS_BERT_EMZ::FTFPCMS_BERT_EMZ(const edm::ParameterSet& p) : PhysicsList(p) 
   double maxBERT = p.getParameter<double>("EmaxBERT") * CLHEP::GeV;
   double maxBERTpi = p.getParameter<double>("EmaxBERTpi") * CLHEP::GeV;
   edm::LogVerbatim("PhysicsList") << "CMS Physics List FTFP_BERT_EMZ: "
-                                  << "\n Flags for EM Physics: " << emPhys 
-                                  << "; Hadronic Physics: " << hadPhys 
+                                  << "\n Flags for EM Physics: " << emPhys << "; Hadronic Physics: " << hadPhys
                                   << "\n  transition energy Bertini/FTFP from " << minFTFP / CLHEP::GeV << " to "
                                   << maxBERT / CLHEP::GeV << ":" << maxBERTpi / CLHEP::GeV << " GeV";
 

--- a/SimG4Core/PhysicsLists/src/CMSEmStandardPhysics.cc
+++ b/SimG4Core/PhysicsLists/src/CMSEmStandardPhysics.cc
@@ -51,6 +51,7 @@ CMSEmStandardPhysics::CMSEmStandardPhysics(G4int ver, const edm::ParameterSet& p
   param->SetStepFunction(0.8, 1 * CLHEP::mm);
   param->SetMscRangeFactor(0.2);
   param->SetMscStepLimitType(fMinimal);
+  param->SetFluo(false);
   SetPhysicsType(bElectromagnetic);
   fRangeFactor = p.getParameter<double>("G4MscRangeFactor");
   fGeomFactor = p.getParameter<double>("G4MscGeomFactor");
@@ -99,7 +100,6 @@ void CMSEmStandardPhysics::ConstructProcess() {
   G4ParticleDefinition* particle = G4Gamma::Gamma();
 
   G4PhotoElectricEffect* pee = new G4PhotoElectricEffect();
-  pee->SetEmModel(new G4LivermorePhotoElectricModel());
 
   if (G4EmParameters::Instance()->GeneralProcessActive()) {
     G4GammaGeneralProcess* sp = new G4GammaGeneralProcess();

--- a/SimG4Core/PhysicsLists/src/CMSHadronPhysicsFTFP_BERT.cc
+++ b/SimG4Core/PhysicsLists/src/CMSHadronPhysicsFTFP_BERT.cc
@@ -4,14 +4,16 @@
 #include "G4Threading.hh"
 
 CMSHadronPhysicsFTFP_BERT::CMSHadronPhysicsFTFP_BERT(G4int)
-    : CMSHadronPhysicsFTFP_BERT(3. * CLHEP::GeV, 6. * CLHEP::GeV, 12 * CLHEP::GeV) {}
+  : CMSHadronPhysicsFTFP_BERT(3*CLHEP::GeV, 6*CLHEP::GeV, 12*CLHEP::GeV, 3*CLHEP::GeV, 6*CLHEP::GeV) {}
 
-CMSHadronPhysicsFTFP_BERT::CMSHadronPhysicsFTFP_BERT(G4double e1, G4double e2, G4double e3)
+CMSHadronPhysicsFTFP_BERT::CMSHadronPhysicsFTFP_BERT(G4double e1, G4double e2, G4double e3, G4double e4, G4double e5)
     : G4HadronPhysicsFTFP_BERT("hInelastic FTFP_BERT", false) {
   minFTFP_pion = e1;
   maxBERT_pion = e3;
   minFTFP_kaon = e1;
   maxBERT_kaon = e2;
+  minFTFP_kaon = e4;
+  maxBERT_kaon = e5;
   minFTFP_proton = e1;
   maxBERT_proton = e2;
   minFTFP_neutron = e1;

--- a/SimG4Core/PhysicsLists/src/CMSHadronPhysicsFTFP_BERT.cc
+++ b/SimG4Core/PhysicsLists/src/CMSHadronPhysicsFTFP_BERT.cc
@@ -4,7 +4,7 @@
 #include "G4Threading.hh"
 
 CMSHadronPhysicsFTFP_BERT::CMSHadronPhysicsFTFP_BERT(G4int)
-  : CMSHadronPhysicsFTFP_BERT(3*CLHEP::GeV, 6*CLHEP::GeV, 12*CLHEP::GeV, 3*CLHEP::GeV, 6*CLHEP::GeV) {}
+    : CMSHadronPhysicsFTFP_BERT(3 * CLHEP::GeV, 6 * CLHEP::GeV, 12 * CLHEP::GeV, 3 * CLHEP::GeV, 6 * CLHEP::GeV) {}
 
 CMSHadronPhysicsFTFP_BERT::CMSHadronPhysicsFTFP_BERT(G4double e1, G4double e2, G4double e3, G4double e4, G4double e5)
     : G4HadronPhysicsFTFP_BERT("hInelastic FTFP_BERT", false) {


### PR DESCRIPTION
#### PR description:
After migration to Geant4 10.7 Physics Lists require modifications. In this PR Physics Lists based on FTF string model are updated:
1) Neutron time cut is removed from Physics List in order to avoid duplication of such cut also implemented in CMS Stepping and Stacking actions. This removes inconsistency not allowing tracking of neutrons to ZDC, in Stepping action a different time cut is applied to the forward neutrons.
2) SteppingAction and StackingAction classes very reviewed and a coherent modification for time window check is added. Also minor clean-up of these classes is done. A minor bug is fixed, which means definite kill of particle which is out of time.
3) CMS hadron inelastic physics constructor allows specific configuration for pions, kaons, protons, and neutrons
4) FTFP_BERT_EMM is CMS default using Geant4 10.7 overlap between the Bertini Cascade and the FTF string model, except more wide overlap for pions
5) FTFP_BERT_EMM_TRK use optimized overlap for kaons on top of FTFP_BERT_EMM 

It is expected, that regression will be broken due to forward neutrons especially in QCD FWs.

#### PR validation:
private


#### if this PR is a backport please specify the original PR and why you need to backport that PR:
no
