### PR TITLE
avoiding trailing whitespaces in config dump

### DIFF
--- a/FWCore/ParameterSet/python/Mixins.py
+++ b/FWCore/ParameterSet/python/Mixins.py
@@ -671,9 +671,10 @@ class _ValidatingParameterListBase(_ValidatingListBase,_ParameterTypeBase):
             if i == 0:
                 if n>nPerLine: result += '\n'+options.indentation()
             else:
-                result += ', '
                 if i % nPerLine == 0:
-                    result += '\n'+options.indentation()
+                    result += ',\n'+options.indentation()
+                else:
+                    result += ', '
             result += self.pythonValueForItem(v,options)
         if n>nPerLine:
             options.unindent()


### PR DESCRIPTION
#### PR description:

This PR is an attempt to avoid trailing whitespaces in configuration file dumps. This was noticed by @fwyzard and @Sam-Harper (and maybe others), when integrating the config for the HLT Phase-2 menu in #32903.

#### PR validation:

Checked, with one configuration file, that the update gives the expected output (no trailing whitespaces). Example:
```shell
cmsDriver.py step3 --geometry Extended2026D49 --era Phase2C9 --conditions 111X_mcRun4_realistic_T15_v5 --processName RECO2 --step RAW2DIGI,RECO --eventcontent RECO --datatier RECO --filein /store/mc/Phase2HLTTDRSummer20ReRECOMiniAOD/QCD_Pt-15to3000_TuneCP5_Flat_14TeV-pythia8/FEVT/PU200_castor_111X_mcRun4_realistic_T15_v1-v1/100000/DA18C0FC-1189-D64B-B3B6-44F3F96F1840.root --mc --no_exec -n 10 --python_filename cfg.py --customise SLHCUpgradeSimulations/Configuration/aging.customise_aging_1000,Configuration/DataProcessing/Utils.addMonitoring
edmConfigDump cfg.py > dump.py
```

#### If this PR is a backport, please specify the original PR and why you need to backport that PR:

N/A