### PR TITLE
Addition to PixelDQM of Template correction to cluster charge

### DIFF
--- a/DQM/SiPixelPhase1Config/python/SiPixelPhase1OnlineDQM_cff.py
+++ b/DQM/SiPixelPhase1Config/python/SiPixelPhase1OnlineDQM_cff.py
@@ -70,6 +70,12 @@ from DQM.SiPixelPhase1Summary.SiPixelPhase1Summary_cfi import *
 
 # Track cluster                                                                                                                                                                            
 from DQM.SiPixelPhase1Track.SiPixelPhase1TrackClusters_cfi import *
+SiPixelPhase1TrackClustersOnTrackCorrCharge.enabled=cms.bool(False)
+SiPixelPhase1TrackTemplateCorr.enabled=cms.bool(False)
+SiPixelPhase1TrackClustersOnTrackCorrChargeOuter.enabled=cms.bool(False)
+SiPixelPhase1TrackTemplateCorrOuter.enabled=cms.bool(False)
+SiPixelPhase1TrackClustersOnTrackCorrChargeInner.enabled=cms.bool(False)
+SiPixelPhase1TrackTemplateCorrInner.enabled=cms.bool(False)
 from DQM.SiPixelPhase1Track.SiPixelPhase1TrackResiduals_cfi import *
 
 siPixelPhase1OnlineDQM_source = cms.Sequence(

--- a/DQM/SiPixelPhase1Track/plugins/SiPixelPhase1TrackClusters.cc
+++ b/DQM/SiPixelPhase1Track/plugins/SiPixelPhase1TrackClusters.cc
@@ -110,25 +110,24 @@ namespace {
     pixelClusterShapeCacheToken_ =
         consumes<SiPixelClusterShapeCache>(iConfig.getParameter<edm::InputTag>("clusterShapeCache"));
 
-    trackerTopoToken_ = esConsumes<TrackerTopology, TrackerTopologyRcd, edm::Transition::BeginRun>();
-    trackerGeomToken_ = esConsumes<TrackerGeometry, TrackerDigiGeometryRecord, edm::Transition::BeginRun>();
+    trackerTopoToken_ = esConsumes<edm::Transition::BeginRun>();
+    trackerGeomToken_ = esConsumes<edm::Transition::BeginRun>();
     clusterShapeHitFilterToken_ =
         esConsumes<ClusterShapeHitFilter, CkfComponentsRecord>(edm::ESInputTag("", "ClusterShapeHitFilter"));
-    templateDBobjectToken_ =
-        esConsumes<SiPixelTemplateDBObject, SiPixelTemplateDBObjectESProducerRcd, edm::Transition::BeginRun>();
+    templateDBobjectToken_ = esConsumes<edm::Transition::BeginRun>();
   }
 
   void SiPixelPhase1TrackClusters::dqmBeginRun(const edm::Run& iRun, const edm::EventSetup& iSetup) {
     // get geometry
     edm::ESHandle<TrackerGeometry> tracker = iSetup.getHandle(trackerGeomToken_);
     assert(tracker.isValid());
-
-    edm::ESHandle<TrackerTopology> tTopoHandle = iSetup.getHandle(trackerTopoToken_);
-    tkTpl = tTopoHandle.product();
+    //get topology
+    tkTpl = &iSetup.getData(trackerTopoToken_);
+    ;
 
     // Initialize 1D templates
-    edm::ESHandle<SiPixelTemplateDBObject> templateDBobject = iSetup.getHandle(templateDBobjectToken_);
-    templateDBobject_ = templateDBobject.product();
+    templateDBobject_ = &iSetup.getData(templateDBobjectToken_);
+    ;
     if (!SiPixelTemplate::pushfile(*templateDBobject_, thePixelTemp_))
       edm::LogError("SiPixelPhase1TrackClusters")
           << "Templates not filled correctly. Check the sqlite file. Using SiPixelTemplateDBObject version "

--- a/DQM/SiPixelPhase1Track/plugins/SiPixelPhase1TrackClusters.cc
+++ b/DQM/SiPixelPhase1Track/plugins/SiPixelPhase1TrackClusters.cc
@@ -113,7 +113,6 @@ namespace {
     trackerGeomToken_ = esConsumes<TrackerGeometry, TrackerDigiGeometryRecord>();
     clusterShapeHitFilterToken_ =
         esConsumes<ClusterShapeHitFilter, CkfComponentsRecord>(edm::ESInputTag("", "ClusterShapeHitFilter"));
-    //    templateDBobjectToken_ = esConsumes<SiPixelTemplateDBObject, SiPixel2DTemplateDBObjectESProducerRcd>();
     templateDBobjectToken_ = esConsumes<SiPixelTemplateDBObject, SiPixelTemplateDBObjectESProducerRcd,edm::Transition::BeginRun>();
   }
 

--- a/DQM/SiPixelPhase1Track/plugins/SiPixelPhase1TrackClusters.cc
+++ b/DQM/SiPixelPhase1Track/plugins/SiPixelPhase1TrackClusters.cc
@@ -95,7 +95,8 @@ namespace {
     edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> trackerGeomToken_;
     edm::ESGetToken<ClusterShapeHitFilter, CkfComponentsRecord> clusterShapeHitFilterToken_;
 
-    edm::ESHandle<SiPixelTemplateDBObject> templateDBobject;
+    edm::ESGetToken<SiPixelTemplateDBObject, SiPixel2DTemplateDBObjectESProducerRcd> templateDBobjectToken_;
+
   };
 
   SiPixelPhase1TrackClusters::SiPixelPhase1TrackClusters(const edm::ParameterSet& iConfig)
@@ -113,11 +114,12 @@ namespace {
     trackerGeomToken_ = esConsumes<TrackerGeometry, TrackerDigiGeometryRecord>();
     clusterShapeHitFilterToken_ =
         esConsumes<ClusterShapeHitFilter, CkfComponentsRecord>(edm::ESInputTag("", "ClusterShapeHitFilter"));
+    templateDBobjectToken_ = esConsumes<SiPixelTemplateDBObject, SiPixel2DTemplateDBObjectESProducerRcd>();
   }
 
   void SiPixelPhase1TrackClusters::dqmBeginRun(const edm::Run& iRun, const edm::EventSetup& iSetup) {
     // Initialize 1D templates
-    iSetup.get<SiPixelTemplateDBObjectESProducerRcd>().get(templateDBobject);
+    edm::ESHandle<SiPixelTemplateDBObject> templateDBobject = iSetup.getHandle(templateDBobjectToken_);
     templateDBobject_ = templateDBobject.product();
     if (!SiPixelTemplate::pushfile(*templateDBobject_, thePixelTemp_))
       edm::LogError("SiPixelPhase1TrackClusters")

--- a/DQM/SiPixelPhase1Track/plugins/SiPixelPhase1TrackClusters.cc
+++ b/DQM/SiPixelPhase1Track/plugins/SiPixelPhase1TrackClusters.cc
@@ -96,7 +96,6 @@ namespace {
     edm::ESGetToken<ClusterShapeHitFilter, CkfComponentsRecord> clusterShapeHitFilterToken_;
 
     edm::ESGetToken<SiPixelTemplateDBObject, SiPixel2DTemplateDBObjectESProducerRcd> templateDBobjectToken_;
-
   };
 
   SiPixelPhase1TrackClusters::SiPixelPhase1TrackClusters(const edm::ParameterSet& iConfig)

--- a/DQM/SiPixelPhase1Track/plugins/SiPixelPhase1TrackClusters.cc
+++ b/DQM/SiPixelPhase1Track/plugins/SiPixelPhase1TrackClusters.cc
@@ -34,8 +34,6 @@
 #include "CondFormats/SiPixelTransient/src/SiPixelTemplate.cc"
 #include "CalibTracker/Records/interface/SiPixelTemplateDBObjectESProducerRcd.h"
 
-
-
 namespace {
 
   class SiPixelPhase1TrackClusters final : public SiPixelPhase1Base {
@@ -87,7 +85,7 @@ namespace {
   private:
     const bool applyVertexCut_;
     const SiPixelTemplateDBObject* templateDBobject_;
-    std::vector< SiPixelTemplateStore > thePixelTemp_;
+    std::vector<SiPixelTemplateStore> thePixelTemp_;
 
     edm::EDGetTokenT<reco::TrackCollection> tracksToken_;
     edm::EDGetTokenT<reco::VertexCollection> offlinePrimaryVerticesToken_;
@@ -122,11 +120,10 @@ namespace {
     iSetup.get<SiPixelTemplateDBObjectESProducerRcd>().get(templateDBobject);
     templateDBobject_ = templateDBobject.product();
     if (!SiPixelTemplate::pushfile(*templateDBobject_, thePixelTemp_))
-      cout << "\nERROR: Templates not filled correctly. Check the sqlite file. Using SiPixelTemplateDBObject version "
-           << (*templateDBobject_).version() << "\n\n";
+      edm::LogError("SiPixelPhase1TrackClusters")
+          << "Templates not filled correctly. Check the sqlite file. Using SiPixelTemplateDBObject version "
+          << (*templateDBobject_).version() << std::endl;
   }
-
-
 
   void SiPixelPhase1TrackClusters::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
     if (!checktrigger(iEvent, iSetup, DCS))
@@ -247,17 +244,17 @@ namespace {
         // correct charge for track impact angle
         auto charge = cluster.charge() * ltp.absdz();
         //Correct charge with Template1D
-        float cotAlpha=ltp.dxdz();
-        float cotBeta=ltp.dydz();
+        float cotAlpha = ltp.dxdz();
+        float cotBeta = ltp.dydz();
         float locBx = 1.;
-        if(cotBeta < 0.)
+        if (cotBeta < 0.)
           locBx = -1.;
         float locBz = locBx;
-        if(cotAlpha < 0.)
+        if (cotAlpha < 0.)
           locBz = -locBx;
         templ.interpolate(templateDBobject_->getTemplateID(id), cotAlpha, cotBeta, locBz, locBx);
-	auto charge_cor = (charge*templ.qscale())/templ.r_qMeas_qTrue();
-        auto tmpl=templ.qscale()/templ.r_qMeas_qTrue();
+        auto charge_cor = (charge * templ.qscale()) / templ.r_qMeas_qTrue();
+        auto tmpl = templ.qscale() / templ.r_qMeas_qTrue();
 
         auto clustgp = pixhit->globalPosition();  // from rechit
 
@@ -298,7 +295,7 @@ namespace {
 
         histo[ON_TRACK_NCLUSTERS].fill(id, &iEvent);
         histo[ON_TRACK_CHARGE].fill(charge, id, &iEvent);
-	histo[ON_TRACK_CORRECTEDCHARGE].fill(charge_cor, id, &iEvent);
+        histo[ON_TRACK_CORRECTEDCHARGE].fill(charge_cor, id, &iEvent);
         histo[TEMPLATE_CORRECTION].fill(tmpl, id, &iEvent);
         histo[ON_TRACK_SIZE].fill(cluster.size(), id, &iEvent);
 

--- a/DQM/SiPixelPhase1Track/plugins/SiPixelPhase1TrackClusters.cc
+++ b/DQM/SiPixelPhase1Track/plugins/SiPixelPhase1TrackClusters.cc
@@ -113,7 +113,8 @@ namespace {
     trackerGeomToken_ = esConsumes<TrackerGeometry, TrackerDigiGeometryRecord>();
     clusterShapeHitFilterToken_ =
         esConsumes<ClusterShapeHitFilter, CkfComponentsRecord>(edm::ESInputTag("", "ClusterShapeHitFilter"));
-    templateDBobjectToken_ = esConsumes<SiPixelTemplateDBObject, SiPixelTemplateDBObjectESProducerRcd,edm::Transition::BeginRun>();
+    templateDBobjectToken_ =
+        esConsumes<SiPixelTemplateDBObject, SiPixelTemplateDBObjectESProducerRcd, edm::Transition::BeginRun>();
   }
 
   void SiPixelPhase1TrackClusters::dqmBeginRun(const edm::Run& iRun, const edm::EventSetup& iSetup) {

--- a/DQM/SiPixelPhase1Track/plugins/SiPixelPhase1TrackClusters.cc
+++ b/DQM/SiPixelPhase1Track/plugins/SiPixelPhase1TrackClusters.cc
@@ -95,7 +95,7 @@ namespace {
     edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> trackerGeomToken_;
     edm::ESGetToken<ClusterShapeHitFilter, CkfComponentsRecord> clusterShapeHitFilterToken_;
 
-    edm::ESGetToken<SiPixelTemplateDBObject, SiPixel2DTemplateDBObjectESProducerRcd> templateDBobjectToken_;
+    edm::ESGetToken<SiPixelTemplateDBObject, SiPixelTemplateDBObjectESProducerRcd> templateDBobjectToken_;
   };
 
   SiPixelPhase1TrackClusters::SiPixelPhase1TrackClusters(const edm::ParameterSet& iConfig)
@@ -113,7 +113,8 @@ namespace {
     trackerGeomToken_ = esConsumes<TrackerGeometry, TrackerDigiGeometryRecord>();
     clusterShapeHitFilterToken_ =
         esConsumes<ClusterShapeHitFilter, CkfComponentsRecord>(edm::ESInputTag("", "ClusterShapeHitFilter"));
-    templateDBobjectToken_ = esConsumes<SiPixelTemplateDBObject, SiPixel2DTemplateDBObjectESProducerRcd>();
+    //    templateDBobjectToken_ = esConsumes<SiPixelTemplateDBObject, SiPixel2DTemplateDBObjectESProducerRcd>();
+    templateDBobjectToken_ = esConsumes<SiPixelTemplateDBObject, SiPixelTemplateDBObjectESProducerRcd,edm::Transition::BeginRun>();
   }
 
   void SiPixelPhase1TrackClusters::dqmBeginRun(const edm::Run& iRun, const edm::EventSetup& iSetup) {

--- a/DQM/SiPixelPhase1Track/plugins/SiPixelPhase1TrackClusters.cc
+++ b/DQM/SiPixelPhase1Track/plugins/SiPixelPhase1TrackClusters.cc
@@ -58,6 +58,10 @@ namespace {
       SIZE_VS_ETA_ON_TRACK_INNER,
       ON_TRACK_CHARGE_OUTER,
       ON_TRACK_CHARGE_INNER,
+      ON_TRACK_CORRECTEDCHARGE_OUTER,
+      ON_TRACK_CORRECTEDCHARGE_INNER,
+      TEMPLATE_CORRECTION_OUTER,
+      TEMPLATE_CORRECTION_INNER,
 
       ON_TRACK_SHAPE_OUTER,
       ON_TRACK_SHAPE_INNER,
@@ -309,9 +313,13 @@ namespace {
           if (iAmOuter) {
             histo[SIZE_VS_ETA_ON_TRACK_OUTER].fill(etatk, cluster.sizeY(), id, &iEvent);
             histo[ON_TRACK_CHARGE_OUTER].fill(charge, id, &iEvent);
+            histo[ON_TRACK_CORRECTEDCHARGE_OUTER].fill(charge_cor, id, &iEvent);
+            histo[TEMPLATE_CORRECTION_OUTER].fill(tmpl, id, &iEvent);
           } else {
             histo[SIZE_VS_ETA_ON_TRACK_INNER].fill(etatk, cluster.sizeY(), id, &iEvent);
             histo[ON_TRACK_CHARGE_INNER].fill(charge, id, &iEvent);
+            histo[ON_TRACK_CORRECTEDCHARGE_INNER].fill(charge_cor, id, &iEvent);
+            histo[TEMPLATE_CORRECTION_INNER].fill(tmpl, id, &iEvent);
           }
         }
       }

--- a/DQM/SiPixelPhase1Track/plugins/SiPixelPhase1TrackClusters.cc
+++ b/DQM/SiPixelPhase1Track/plugins/SiPixelPhase1TrackClusters.cc
@@ -123,11 +123,9 @@ namespace {
     assert(tracker.isValid());
     //get topology
     tkTpl = &iSetup.getData(trackerTopoToken_);
-    ;
 
     // Initialize 1D templates
     templateDBobject_ = &iSetup.getData(templateDBobjectToken_);
-    ;
     if (!SiPixelTemplate::pushfile(*templateDBobject_, thePixelTemp_))
       edm::LogError("SiPixelPhase1TrackClusters")
           << "Templates not filled correctly. Check the sqlite file. Using SiPixelTemplateDBObject version "

--- a/DQM/SiPixelPhase1Track/python/SiPixelPhase1TrackClusters_cfi.py
+++ b/DQM/SiPixelPhase1Track/python/SiPixelPhase1TrackClusters_cfi.py
@@ -70,8 +70,18 @@ SiPixelPhase1TrackClustersOnTrackCorrCharge = DefaultHistoTrack.clone(
   xlabel = "Charge (electrons)",
 
   specs = VPSet(
-    StandardSpecifications1D,
-    Specification().groupBy("PXForward/PXRing").save()
+    Specification().groupBy("PXBarrel").save(),
+    Specification().groupBy("PXForward").save(),
+    Specification().groupBy("PXBarrel/PXLayer").save(),
+    Specification().groupBy("PXForward/PXDisk").save(),
+    Specification().groupBy("PXForward/PXRing").save(),
+    Specification(PerLayer1D).groupBy("PXBarrel/Shell/PXLayer").save(),
+    Specification(PerLayer1D).groupBy("PXForward/HalfCylinder/PXRing").save(),
+    Specification(PerLayer1D).groupBy("PXForward/HalfCylinder/PXRing/PXDisk").save(),
+    Specification(PerLadder).groupBy("PXBarrel/Shell/PXLayer/SignedLadder").save(),
+    Specification(PerLadder).groupBy("PXForward/HalfCylinder/PXRing/PXDisk/SignedBlade").save(),
+    Specification(PerModule).groupBy("PXBarrel/Shell/PXLayer/SignedLadder/PXModuleName").save(),
+    Specification(PerModule).groupBy("PXForward/HalfCylinder/PXRing/PXDisk/SignedBlade/PXModuleName").save()
   )
 )
 

--- a/DQM/SiPixelPhase1Track/python/SiPixelPhase1TrackClusters_cfi.py
+++ b/DQM/SiPixelPhase1Track/python/SiPixelPhase1TrackClusters_cfi.py
@@ -63,6 +63,25 @@ SiPixelPhase1TrackClustersOnTrackCharge = DefaultHistoTrack.clone(
   )
 )
 
+SiPixelPhase1TrackClustersOnTrackCorrCharge = DefaultHistoTrack.clone(
+  name = "charge_corr",
+  title = "Template Corrected Cluster Charge (OnTrack)",
+  range_min = 0, range_max = 80e3, range_nbins = 100,
+  xlabel = "Charge (electrons)",
+
+  specs = VPSet(
+    StandardSpecifications1D,
+    Specification().groupBy("PXForward/PXRing").save()
+  )
+)
+
+SiPixelPhase1TrackTemplateCorr = SiPixelPhase1TrackClustersOnTrackCorrCharge.clone(
+  name = "template_corr",
+  title = "Template Correction",
+  range_min = 0, range_max = 3, range_nbins = 150,
+  xlabel = "A.U."
+)
+
 SiPixelPhase1TrackClustersOnTrackBigPixelCharge = DefaultHistoTrack.clone(
   name = "bigpixelcharge",
   title = "Corrected Big Pixel Charge (OnTrack)",
@@ -488,6 +507,8 @@ SiPixelPhase1TrackClustersOnTrackShapeInner = SiPixelPhase1TrackClustersOnTrackS
 # copy this in the enum
 SiPixelPhase1TrackClustersConf = cms.VPSet(
   SiPixelPhase1TrackClustersOnTrackCharge,
+  SiPixelPhase1TrackClustersOnTrackCorrCharge,
+  SiPixelPhase1TrackTemplateCorr,
   SiPixelPhase1TrackClustersOnTrackBigPixelCharge,
   SiPixelPhase1TrackClustersOnTrackNotBigPixelCharge,
   SiPixelPhase1TrackClustersOnTrackSize,

--- a/DQM/SiPixelPhase1Track/python/SiPixelPhase1TrackClusters_cfi.py
+++ b/DQM/SiPixelPhase1Track/python/SiPixelPhase1TrackClusters_cfi.py
@@ -75,13 +75,6 @@ SiPixelPhase1TrackClustersOnTrackCorrCharge = DefaultHistoTrack.clone(
     Specification().groupBy("PXBarrel/PXLayer").save(),
     Specification().groupBy("PXForward/PXDisk").save(),
     Specification().groupBy("PXForward/PXRing").save(),
-    Specification(PerLayer1D).groupBy("PXBarrel/Shell/PXLayer").save(),
-    Specification(PerLayer1D).groupBy("PXForward/HalfCylinder/PXRing").save(),
-    Specification(PerLayer1D).groupBy("PXForward/HalfCylinder/PXRing/PXDisk").save(),
-    Specification(PerLadder).groupBy("PXBarrel/Shell/PXLayer/SignedLadder").save(),
-    Specification(PerLadder).groupBy("PXForward/HalfCylinder/PXRing/PXDisk/SignedBlade").save(),
-    Specification(PerModule).groupBy("PXBarrel/Shell/PXLayer/SignedLadder/PXModuleName").save(),
-    Specification(PerModule).groupBy("PXForward/HalfCylinder/PXRing/PXDisk/SignedBlade/PXModuleName").save()
   )
 )
 
@@ -498,6 +491,35 @@ SiPixelPhase1TrackClustersOnTrackChargeInner = SiPixelPhase1TrackClustersOnTrack
   title = "Corrected Cluster Charge (OnTrack) inner ladders"
 )
 
+SiPixelPhase1TrackClustersOnTrackCorrChargeOuter = DefaultHistoTrack.clone(
+  name = "chargeOuter_corr",
+  title = "Template Corrected Cluster Charge (OnTrack) outer ladders",
+  range_min = 0, range_max = 80e3, range_nbins = 100,
+  xlabel = "Charge (electrons)",
+
+  specs = VPSet(
+    Specification().groupBy("PXBarrel/PXLayer").save()
+  )
+)
+
+SiPixelPhase1TrackClustersOnTrackCorrChargeInner = SiPixelPhase1TrackClustersOnTrackCorrChargeOuter.clone(
+  name = "chargeInner_corr",
+  title = "Template Corrected Cluster Charge (OnTrack) inner ladders"
+)
+
+SiPixelPhase1TrackTemplateCorrOuter = SiPixelPhase1TrackClustersOnTrackCorrChargeOuter.clone(
+  name = "templateOuter_corr",
+  title = "Template Correction outer ladders",
+  range_min = 0, range_max = 3, range_nbins = 150,
+  xlabel = "A.U."
+)
+
+SiPixelPhase1TrackTemplateCorrInner = SiPixelPhase1TrackTemplateCorrOuter.clone(
+  name = "templateInner_corr",
+  title = "Template Correction inner ladders"
+)
+
+
 SiPixelPhase1TrackClustersOnTrackShapeOuter = DefaultHistoTrack.clone(
   topFolderName = "PixelPhase1/ClusterShape",
   name = "shapeFilterOuter",
@@ -536,6 +558,10 @@ SiPixelPhase1TrackClustersConf = cms.VPSet(
   SiPixelPhase1ClustersSizeVsEtaOnTrackInner,
   SiPixelPhase1TrackClustersOnTrackChargeOuter,
   SiPixelPhase1TrackClustersOnTrackChargeInner,
+  SiPixelPhase1TrackClustersOnTrackCorrChargeOuter,
+  SiPixelPhase1TrackClustersOnTrackCorrChargeInner,
+  SiPixelPhase1TrackTemplateCorrOuter,
+  SiPixelPhase1TrackTemplateCorrInner,
 
   SiPixelPhase1TrackClustersOnTrackShapeOuter,
   SiPixelPhase1TrackClustersOnTrackShapeInner,

--- a/DQMOffline/Trigger/python/SiPixel_OfflineMonitoring_TrackCluster_cff.py
+++ b/DQMOffline/Trigger/python/SiPixel_OfflineMonitoring_TrackCluster_cff.py
@@ -15,6 +15,25 @@ hltSiPixelPhase1TrackClustersOnTrackCharge = hltDefaultHistoTrack.clone(
   )
 )
 
+hltSiPixelPhase1TrackClustersOnTrackCorrCharge = hltDefaultHistoTrack.clone(
+  name = "charge_cor",
+  title = "Tempalte Corrected Cluster Charge (OnTrack)",
+  range_min = 0, range_max = 200e3, range_nbins = 200,
+  xlabel = "Charge (electrons)",
+  enabled=False,
+  specs = VPSet(
+    hltStandardSpecifications1D
+  )
+)
+
+hltSiPixelPhase1TrackTemplateCorr = hltSiPixelPhase1TrackClustersOnTrackCorrCharge.clone(
+  name = "template_corr",
+  title = "Tempalte Correction",
+  range_min = 0, range_max = 20, range_nbins = 200,
+  xlabel = "A.U.",
+  enabled=False
+)
+
 hltSiPixelPhase1TrackClustersOnTrackBigPixelCharge = DefaultHistoTrack.clone(
   name = "bigpixelcharge",
   title = "Corrected Big Pixel Charge (OnTrack)",
@@ -331,6 +350,8 @@ hltSiPixelPhase1TrackClustersConf = cms.VPSet(
 ### THE LIST DEFINED IN THE ENUM
 ### https://cmssdt.cern.ch/lxr/source/DQM/SiPixelPhase1TrackClusters/src/SiPixelPhase1TrackClusters.cc#0063
    hltSiPixelPhase1TrackClustersOnTrackCharge,
+   hltSiPixelPhase1TrackClustersOnTrackCorrCharge,
+   hltSiPixelPhase1TrackTemplateCorr,
    hltSiPixelPhase1TrackClustersOnTrackBigPixelCharge,
    hltSiPixelPhase1TrackClustersOnTrackNotBigPixelCharge,
    hltSiPixelPhase1TrackClustersOnTrackSize,

--- a/DQMOffline/Trigger/python/SiPixel_OfflineMonitoring_TrackCluster_cff.py
+++ b/DQMOffline/Trigger/python/SiPixel_OfflineMonitoring_TrackCluster_cff.py
@@ -328,6 +328,38 @@ hltSiPixelPhase1TrackClustersOnTrackChargeInner = hltSiPixelPhase1TrackClustersO
   title = "Corrected Cluster Charge (OnTrack) inner ladders"
 )
 
+
+hltSiPixelPhase1TrackClustersOnTrackCorrChargeOuter = hltDefaultHistoTrack.clone(
+  name = "chargeOuter_corr",
+  title = "Template Corrected Cluster Charge (OnTrack) outer ladders",
+  range_min = 0, range_max = 80e3, range_nbins = 100,
+  xlabel = "Charge (electrons)",
+  enabled = False,
+  specs = VPSet(
+    Specification().groupBy("PXBarrel/PXLayer").save()
+  )
+)
+
+hltSiPixelPhase1TrackClustersOnTrackCorrChargeInner = hltSiPixelPhase1TrackClustersOnTrackCorrChargeOuter.clone(
+  name = "chargeInner_corr",
+  title = "Template Corrected Cluster Charge (OnTrack) inner ladders",
+  enabled = False
+)
+
+hltSiPixelPhase1TrackTemplateCorrOuter = hltSiPixelPhase1TrackClustersOnTrackCorrChargeOuter.clone(
+  name = "templateOuter_corr",
+  title = "Template Correction outer ladders",
+  range_min = 0, range_max = 3, range_nbins = 150,
+  xlabel = "A.U.",
+  enabled = False
+)
+
+hltSiPixelPhase1TrackTemplateCorrInner = hltSiPixelPhase1TrackTemplateCorrOuter.clone(
+  name = "templateInner_corr",
+  title = "Template Correction inner ladders",
+  enabled = False
+)
+
 hltSiPixelPhase1TrackClustersOnTrackShapeOuter = hltDefaultHistoTrack.clone(
   enabled = False,
   name = "shapeFilterOuter",
@@ -369,6 +401,10 @@ hltSiPixelPhase1TrackClustersConf = cms.VPSet(
    hltSiPixelPhase1ClustersSizeVsEtaOnTrackInner,
    hltSiPixelPhase1TrackClustersOnTrackChargeOuter,
    hltSiPixelPhase1TrackClustersOnTrackChargeInner,
+   hltSiPixelPhase1TrackClustersOnTrackCorrChargeOuter,
+   hltSiPixelPhase1TrackClustersOnTrackCorrChargeInner,
+   hltSiPixelPhase1TrackTemplateCorrOuter,
+   hltSiPixelPhase1TrackTemplateCorrInner,
 
    hltSiPixelPhase1TrackClustersOnTrackShapeOuter,
    hltSiPixelPhase1TrackClustersOnTrackShapeInner,


### PR DESCRIPTION
#### PR description:

With this PR we introduce new distribution to the PixelPhase1 DQM:
   - Cluster Charge corrected with the tempalte
   - the template correction itself
  (this distribution are added for each layers/rings/disks)
#### PR validation:

runTheMatrix.py -l 11024

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Not a backport and no backport foreseen