### PR TITLE
[HGCAL] SimTracksters from Caloparticles

### DIFF
--- a/DataFormats/HGCalReco/interface/Trackster.h
+++ b/DataFormats/HGCalReco/interface/Trackster.h
@@ -54,7 +54,7 @@ namespace ticl {
 
     inline void setIteration(const Trackster::IterationIndex i) { iterationIndex_ = i; }
     std::vector<unsigned int> &vertices() { return vertices_; }
-    std::vector<uint8_t> &vertex_multiplicity() { return vertex_multiplicity_; }
+    std::vector<float> &vertex_multiplicity() { return vertex_multiplicity_; }
     std::vector<std::array<unsigned int, 2> > &edges() { return edges_; }
     inline void setSeed(edm::ProductID pid, int index) {
       seedID_ = pid;
@@ -119,8 +119,8 @@ namespace ticl {
     inline const Trackster::IterationIndex ticlIteration() const { return (IterationIndex)iterationIndex_; }
     inline const std::vector<unsigned int> &vertices() const { return vertices_; }
     inline const unsigned int vertices(int index) const { return vertices_[index]; }
-    inline const std::vector<uint8_t> &vertex_multiplicity() const { return vertex_multiplicity_; }
-    inline const uint8_t vertex_multiplicity(int index) const { return vertex_multiplicity_[index]; }
+    inline const std::vector<float> &vertex_multiplicity() const { return vertex_multiplicity_; }
+    inline const float vertex_multiplicity(int index) const { return vertex_multiplicity_[index]; }
     inline const std::vector<std::array<unsigned int, 2> > &edges() const { return edges_; }
     inline const edm::ProductID &seedID() const { return seedID_; }
     inline const int seedIndex() const { return seedIndex_; }
@@ -153,7 +153,7 @@ namespace ticl {
     // The vertices of the DAG are the indices of the
     // 2d objects in the global collection
     std::vector<unsigned int> vertices_;
-    std::vector<uint8_t> vertex_multiplicity_;
+    std::vector<float> vertex_multiplicity_;
 
     // The edges connect two vertices together in a directed doublet
     // ATTENTION: order matters!

--- a/DataFormats/HGCalReco/src/classes_def.xml
+++ b/DataFormats/HGCalReco/src/classes_def.xml
@@ -1,6 +1,7 @@
 
 <lcgdict>
-  <class name="ticl::Trackster" ClassVersion="8">
+  <class name="ticl::Trackster" ClassVersion="9">
+    <version ClassVersion="9" checksum="1001808235"/>
     <version ClassVersion="8" checksum="749412802"/>
     <version ClassVersion="7" checksum="1072014319"/>
     <version ClassVersion="6" checksum="3003722924"/>

--- a/RecoHGCal/TICL/plugins/TrackstersFromSimClustersProducer.cc
+++ b/RecoHGCal/TICL/plugins/TrackstersFromSimClustersProducer.cc
@@ -121,7 +121,7 @@ void TrackstersFromSimClustersProducer::fillDescriptions(edm::ConfigurationDescr
                                    edm::InputTag("layerClusterSimClusterAssociationProducer"));
   desc.addUntracked<edm::InputTag>("layerClusterCaloParticleAssociator",
                                    edm::InputTag("layerClusterCaloParticleAssociationProducer"));
-  desc.add<double>("fractionCut", 0.05);
+  desc.add<double>("fractionCut", 0.);
 
   descriptions.add("trackstersFromSimClustersProducer", desc);
 }

--- a/RecoHGCal/TICL/plugins/TrackstersFromSimClustersProducer.cc
+++ b/RecoHGCal/TICL/plugins/TrackstersFromSimClustersProducer.cc
@@ -19,6 +19,9 @@
 
 #include "DataFormats/Common/interface/ValueMap.h"
 #include "SimDataFormats/Associations/interface/LayerClusterToSimClusterAssociator.h"
+#include "SimDataFormats/Associations/interface/LayerClusterToCaloParticleAssociator.h"
+
+#include "SimDataFormats/CaloAnalysis/interface/CaloParticle.h"
 #include "SimDataFormats/CaloAnalysis/interface/SimCluster.h"
 #include "RecoLocalCalo/HGCalRecAlgos/interface/RecHitTools.h"
 
@@ -72,9 +75,12 @@ private:
   const edm::EDGetTokenT<std::vector<float>> filtered_layerclusters_mask_token_;
 
   edm::EDGetTokenT<std::vector<SimCluster>> simclusters_token_;
+  edm::EDGetTokenT<std::vector<CaloParticle>> caloparticles_token_;
 
   edm::InputTag associatorLayerClusterSimCluster_;
-  edm::EDGetTokenT<hgcal::SimToRecoCollectionWithSimClusters> associatorMapSimToReco_token_;
+  edm::EDGetTokenT<hgcal::SimToRecoCollectionWithSimClusters> associatorMapSimClusterToReco_token_;
+  edm::InputTag associatorLayerClusterCaloParticle_;
+  edm::EDGetTokenT<hgcal::SimToRecoCollection> associatorMapCaloParticleToReco_token_;
   edm::ESGetToken<CaloGeometry, CaloGeometryRecord> geom_token_;
   hgcal::RecHitTools rhtools_;
 };
@@ -88,9 +94,13 @@ TrackstersFromSimClustersProducer::TrackstersFromSimClustersProducer(const edm::
           consumes<edm::ValueMap<std::pair<float, float>>>(ps.getParameter<edm::InputTag>("time_layerclusters"))),
       filtered_layerclusters_mask_token_(consumes<std::vector<float>>(ps.getParameter<edm::InputTag>("filtered_mask"))),
       simclusters_token_(consumes<std::vector<SimCluster>>(ps.getParameter<edm::InputTag>("simclusters"))),
+      caloparticles_token_(consumes<std::vector<CaloParticle>>(ps.getParameter<edm::InputTag>("caloparticles"))),
       associatorLayerClusterSimCluster_(ps.getUntrackedParameter<edm::InputTag>("layerClusterSimClusterAssociator")),
-      associatorMapSimToReco_token_(
+      associatorMapSimClusterToReco_token_(
           consumes<hgcal::SimToRecoCollectionWithSimClusters>(associatorLayerClusterSimCluster_)),
+      associatorLayerClusterCaloParticle_(
+          ps.getUntrackedParameter<edm::InputTag>("layerClusterCaloParticleAssociator")),
+      associatorMapCaloParticleToReco_token_(consumes<hgcal::SimToRecoCollection>(associatorLayerClusterCaloParticle_)),
       geom_token_(esConsumes()) {
   produces<std::vector<Trackster>>();
   produces<std::vector<float>>();
@@ -104,8 +114,11 @@ void TrackstersFromSimClustersProducer::fillDescriptions(edm::ConfigurationDescr
   desc.add<edm::InputTag>("time_layerclusters", edm::InputTag("hgcalLayerClusters", "timeLayerCluster"));
   desc.add<edm::InputTag>("filtered_mask", edm::InputTag("filteredLayerClustersSimTracksters", "ticlSimTracksters"));
   desc.add<edm::InputTag>("simclusters", edm::InputTag("mix", "MergedCaloTruth"));
+  desc.add<edm::InputTag>("caloparticles", edm::InputTag("mix", "MergedCaloTruth"));
   desc.addUntracked<edm::InputTag>("layerClusterSimClusterAssociator",
                                    edm::InputTag("layerClusterSimClusterAssociationProducer"));
+  desc.addUntracked<edm::InputTag>("layerClusterCaloParticleAssociator",
+                                   edm::InputTag("layerClusterCaloParticleAssociationProducer"));
   descriptions.add("trackstersFromSimClustersProducer", desc);
 }
 
@@ -118,34 +131,73 @@ void TrackstersFromSimClustersProducer::produce(edm::Event& evt, const edm::Even
   output_mask->resize(layerClusters.size(), 1.f);
 
   const auto& simclusters = evt.get(simclusters_token_);
-  const auto& simToRecoColl = evt.get(associatorMapSimToReco_token_);
+  const auto& caloparticles = evt.get(caloparticles_token_);
+
+  const auto& simClustersToRecoColl = evt.get(associatorMapSimClusterToReco_token_);
+  const auto& caloParticlesToRecoColl = evt.get(associatorMapCaloParticleToReco_token_);
 
   const auto& geom = es.getData(geom_token_);
   rhtools_.setGeometry(geom);
   auto num_simclusters = simclusters.size();
   result->reserve(num_simclusters);
-  for (const auto& [key, values] : simToRecoColl) {
-    auto const& sc = *(key);
-    auto simClusterIndex = &sc - &simclusters[0];
-    Trackster tmpTrackster;
-    tmpTrackster.zeroProbabilities();
-    tmpTrackster.vertices().reserve(values.size());
-    tmpTrackster.vertex_multiplicity().reserve(values.size());
 
-    for (auto const& [lc, energyScorePair] : values) {
-      if (inputClusterMask[lc.index()] > 0) {
-        tmpTrackster.vertices().push_back(lc.index());
-        double fraction = energyScorePair.first / lc->energy();
-        (*output_mask)[lc.index()] -= fraction;
-        tmpTrackster.vertex_multiplicity().push_back(static_cast<uint8_t>(std::clamp(1. / fraction, 0., 255.)));
+  for (const auto& [key, values] : caloParticlesToRecoColl) {
+    auto const& cp = *(key);
+    auto cpIndex = &cp - &caloparticles[0];
+    if (cp.g4Tracks()[0].crossedBoundary()) {
+      if (values.empty())
+        continue;
+      Trackster tmpTrackster;
+      tmpTrackster.zeroProbabilities();
+      tmpTrackster.vertices().reserve(values.size());
+      tmpTrackster.vertex_multiplicity().reserve(values.size());
+      for (auto const& [lc, energyScorePair] : values) {
+        if (inputClusterMask[lc.index()] > 0) {
+          tmpTrackster.vertices().push_back(lc.index());
+          double fraction = energyScorePair.first / lc->energy();
+          (*output_mask)[lc.index()] -= fraction;
+          tmpTrackster.vertex_multiplicity().push_back(static_cast<uint8_t>(std::clamp(1. / fraction, 1., 255.)));
+        }
+      }
+      tmpTrackster.setIdProbability(tracksterParticleTypeFromPdgId(cp.pdgId(), cp.charge()), 1.f);
+
+      tmpTrackster.setSeed(key.id(), cpIndex);
+      result->emplace_back(tmpTrackster);
+    } else {
+      for (const auto& scRef : cp.simClusters()) {
+        const auto& it = simClustersToRecoColl.find(scRef);
+        if (it == simClustersToRecoColl.end())
+          continue;
+        const auto& lcVec = it->val;
+        if (lcVec.empty())
+          continue;
+        auto const& sc = *(scRef);
+        auto simClusterIndex = &sc - &simclusters[0];
+        Trackster tmpTrackster;
+
+        tmpTrackster.zeroProbabilities();
+        tmpTrackster.vertices().reserve(lcVec.size());
+        tmpTrackster.vertex_multiplicity().reserve(lcVec.size());
+
+        for (auto const& [lc, energyScorePair] : lcVec) {
+          if (inputClusterMask[lc.index()] > 0) {
+            tmpTrackster.vertices().push_back(lc.index());
+            double fraction = energyScorePair.first / lc->energy();
+            (*output_mask)[lc.index()] -= fraction;
+            tmpTrackster.vertex_multiplicity().push_back(static_cast<uint8_t>(std::clamp(1. / fraction, 1., 255.)));
+          }
+        }
+        tmpTrackster.setIdProbability(tracksterParticleTypeFromPdgId(sc.pdgId(), sc.charge()), 1.f);
+        tmpTrackster.setSeed(scRef.id(), simClusterIndex);
+        result->emplace_back(tmpTrackster);
       }
     }
-    tmpTrackster.setIdProbability(tracksterParticleTypeFromPdgId(sc.pdgId(), sc.charge()), 1.f);
-    tmpTrackster.setSeed(key.id(), simClusterIndex);
-    result->emplace_back(tmpTrackster);
   }
+
   ticl::assignPCAtoTracksters(
       *result, layerClusters, layerClustersTimes, rhtools_.getPositionLayer(rhtools_.lastLayerEE(doNose_)).z());
+  result->shrink_to_fit();
+
   evt.put(std::move(result));
   evt.put(std::move(output_mask));
 }

--- a/RecoHGCal/TICL/plugins/TrackstersFromSimClustersProducer.cc
+++ b/RecoHGCal/TICL/plugins/TrackstersFromSimClustersProducer.cc
@@ -156,7 +156,7 @@ void TrackstersFromSimClustersProducer::produce(edm::Event& evt, const edm::Even
           tmpTrackster.vertices().push_back(lc.index());
           double fraction = energyScorePair.first / lc->energy();
           (*output_mask)[lc.index()] -= fraction;
-          tmpTrackster.vertex_multiplicity().push_back(static_cast<uint8_t>(std::clamp(1. / fraction, 1., 255.)));
+          tmpTrackster.vertex_multiplicity().push_back(1. / fraction);
         }
       }
       tmpTrackster.setIdProbability(tracksterParticleTypeFromPdgId(cp.pdgId(), cp.charge()), 1.f);
@@ -184,7 +184,7 @@ void TrackstersFromSimClustersProducer::produce(edm::Event& evt, const edm::Even
             tmpTrackster.vertices().push_back(lc.index());
             double fraction = energyScorePair.first / lc->energy();
             (*output_mask)[lc.index()] -= fraction;
-            tmpTrackster.vertex_multiplicity().push_back(static_cast<uint8_t>(std::clamp(1. / fraction, 1., 255.)));
+            tmpTrackster.vertex_multiplicity().push_back(1. / fraction);
           }
         }
         tmpTrackster.setIdProbability(tracksterParticleTypeFromPdgId(sc.pdgId(), sc.charge()), 1.f);

--- a/RecoHGCal/TICL/plugins/TrackstersFromSimClustersProducer.cc
+++ b/RecoHGCal/TICL/plugins/TrackstersFromSimClustersProducer.cc
@@ -121,7 +121,7 @@ void TrackstersFromSimClustersProducer::fillDescriptions(edm::ConfigurationDescr
                                    edm::InputTag("layerClusterSimClusterAssociationProducer"));
   desc.addUntracked<edm::InputTag>("layerClusterCaloParticleAssociator",
                                    edm::InputTag("layerClusterCaloParticleAssociationProducer"));
-  desc.add<double>("fractionCut", 0.02);
+  desc.add<double>("fractionCut", 0.05);
 
   descriptions.add("trackstersFromSimClustersProducer", desc);
 }

--- a/RecoHGCal/TICL/python/SimTracksters_cff.py
+++ b/RecoHGCal/TICL/python/SimTracksters_cff.py
@@ -20,7 +20,8 @@ ticlSimTracksters = _trackstersFromSimClustersProducer.clone(
 
 from Configuration.ProcessModifiers.premix_stage2_cff import premix_stage2
 premix_stage2.toModify(ticlSimTracksters,
-    simclusters = "mixData:MergedCaloTruth"
+    simclusters = "mixData:MergedCaloTruth",
+    caloparticles = "mixData:MergedCaloTruth",
 )
 
 ticlMultiClustersFromSimTracksters = _multiClustersFromTrackstersProducer.clone(


### PR DESCRIPTION
#### PR description:
This PR improves SimTracksters by:
  - taking into account the correct fraction of the energy of the layer cluster for the calculation of the energy of the trackster and its PCA (data format change was needed)
  - using the caloparticle as a source for layercluster if the caloparticle crossed the CALO volume boundary, otherwise use the simclusters. 
  - I expect changes in the number of simtracksters (I expect a smaller number of them)

#### PR validation:
validated using `23293.0`
