### PR TITLE
Mtd parameters update for D49 and D60 geometries (Bug fix)

### DIFF
--- a/Geometry/MTDCommonData/data/CrystalBarPhiFlat/mtdParameters.xml
+++ b/Geometry/MTDCommonData/data/CrystalBarPhiFlat/mtdParameters.xml
@@ -9,7 +9,7 @@
     22, 24, 16, 10, 0x1, 0x3, 0x3F, 0x3F, 1, 16, 3, 1
   </Vector>
   <Vector name="ETL" type="numeric" nEntries="12">
-    22, 24, 16, 7, 0x1, 0x3, 0x3F, 0xFF, 24, 4, 2, 8
+    0, 0, 0, 0, 0, 0, 0, 0, 24, 4, 2, 8
   </Vector>
 
   </ConstantsSection>

--- a/Geometry/MTDCommonData/data/CrystalBarPhiFlat/mtdParameters.xml
+++ b/Geometry/MTDCommonData/data/CrystalBarPhiFlat/mtdParameters.xml
@@ -6,7 +6,7 @@
     4, 4, 4, 24
   </Vector>
   <Vector name="BTL" type="numeric" nEntries="12">
-    22, 24, 16, 10, 0x1, 0x3, 0x3F, 0x3F, 1, 16, 3, 1
+    0, 0, 0, 0, 0, 0, 0 ,0, 1, 16, 3, 1
   </Vector>
   <Vector name="ETL" type="numeric" nEntries="12">
     0, 0, 0, 0, 0, 0, 0, 0, 24, 4, 2, 8

--- a/Geometry/MTDCommonData/data/mtdParameters/v1/mtdParameters.xml
+++ b/Geometry/MTDCommonData/data/mtdParameters/v1/mtdParameters.xml
@@ -9,7 +9,7 @@
     22, 24, 16, 10, 0x1, 0x3, 0x3F, 0x3F, 1, 16, 3, 1
   </Vector>
   <Vector name="ETL" type="numeric" nEntries="12">
-    22, 24, 16, 7, 0x1, 0x3, 0x3F, 0xFF, 24, 4, 2, 8
+    0, 0, 0, 0, 0, 0, 0, 0, 24, 4, 2, 8
   </Vector>
 
   </ConstantsSection>

--- a/Geometry/MTDCommonData/data/mtdParameters/v1/mtdParameters.xml
+++ b/Geometry/MTDCommonData/data/mtdParameters/v1/mtdParameters.xml
@@ -6,7 +6,7 @@
     4, 4, 4, 24
   </Vector>
   <Vector name="BTL" type="numeric" nEntries="12">
-    22, 24, 16, 10, 0x1, 0x3, 0x3F, 0x3F, 1, 16, 3, 1
+    0, 0, 0, 0, 0, 0, 0, 0, 1, 16, 3, 1
   </Vector>
   <Vector name="ETL" type="numeric" nEntries="12">
     0, 0, 0, 0, 0, 0, 0, 0, 24, 4, 2, 8


### PR DESCRIPTION
#### PR description:

This PR fixes a bug introduced by https://github.com/cms-sw/cmssw/pull/33340, affecting the D49 and D60 geometries. That PR reinterpreted the numbers in the BTL and ETL number vectors in the mtdParameters.xml file as interpad/and pad-to-border distances to define the dead areas around the pads, however the change was not made for the mtdParameters.xml being used by the D49 and D60 geometries. This PR updates also those numbers setting the distances as "0" to exactly reproduce the behaviour of the D49 and D60 geometries. 