### PR TITLE
TrackDistanceValueMapProducer: check the size of the reference vector before copying

### DIFF
--- a/Calibration/TkAlCaRecoProducers/plugins/TrackDistanceValueMapProducer.cc
+++ b/Calibration/TkAlCaRecoProducers/plugins/TrackDistanceValueMapProducer.cc
@@ -120,7 +120,9 @@ void TrackDistanceValueMapProducer::produce(edm::StreamID streamID,
 
     // just copy the first nth
     std::vector<float> reduced_vdR2;
-    std::copy(v_dR2.begin(), v_dR2.begin() + nthClosestTrack_, std::back_inserter(reduced_vdR2));
+    std::copy(v_dR2.begin(),
+              v_dR2.begin() + std::min(v_dR2.size(), static_cast<size_t>(nthClosestTrack_)),
+              std::back_inserter(reduced_vdR2));
     v2_dR2.push_back(reduced_vdR2);
   }
 


### PR DESCRIPTION
resolves https://github.com/cms-sw/cmssw/issues/33533 (?)

#### PR description:

See https://github.com/cms-sw/cmssw/issues/33533#issuecomment-833486429
Suggested by core framework group.

#### PR validation:

Compiles, not validated on the PPC architecture, as I don't know how to do that. I let the framework people deal with it.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Not a backport, no backport needed.