### PR TITLE
MTD validation: update standalone test configuration to scenario D76, use up-to-date fragments

### DIFF
--- a/Validation/MtdValidation/test/mtdValidation_cfg.py
+++ b/Validation/MtdValidation/test/mtdValidation_cfg.py
@@ -7,21 +7,9 @@ process = cms.Process('mtdValidation',Phase2C9)
 
 process.load("FWCore.MessageService.MessageLogger_cfi")
 
-process.load("Configuration.Geometry.GeometryExtended2026D49_cff")
+process.load("Configuration.Geometry.GeometryExtended2026D76Reco_cff")
 
 process.load('SimGeneral.MixingModule.mixNoPU_cfi')
-
-process.load("Geometry.MTDNumberingBuilder.mtdNumberingGeometry_cfi")
-process.load("Geometry.MTDNumberingBuilder.mtdTopology_cfi")
-process.load("Geometry.MTDGeometryBuilder.mtdGeometry_cfi")
-process.load("Geometry.MTDGeometryBuilder.mtdParameters_cfi")
-
-process.mtdGeometry = cms.ESProducer("MTDDigiGeometryESModule",
-    alignmentsLabel = cms.string(''),
-    appendToDataLabel = cms.string(''),
-    applyAlignment = cms.bool(False),
-    fromDDD = cms.bool(True)
-)
 
 process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(-1) )
 
@@ -53,8 +41,13 @@ etlValidation = cms.Sequence(process.etlSimHits + process.etlDigiHits + process.
 # --- Global Validation
 process.load("Validation.MtdValidation.mtdTracks_cfi")
 
+process.btlDigiHits.LocalPositionDebug = True
+process.etlDigiHits.LocalPositionDebug = True
+process.btlLocalReco.LocalPositionDebug = True
+process.etlLocalReco.LocalPositionDebug = True
+
 process.DQMStore = cms.Service("DQMStore")
 
 process.load("DQMServices.FileIO.DQMFileSaverOnline_cfi")
 
-process.p = cms.Path( process.mix + btlValidation + etlValidation + process.globalReco + process.dqmSaver)
+process.p = cms.Path( process.mix + btlValidation + etlValidation + process.mtdTracks + process.dqmSaver)


### PR DESCRIPTION
#### PR description:

Update of the standalone test configuration in ```Validation/MtdValidation/test``` to use geometry scenario D76, the more modern definition of geometry fragments, and newly introduced flags for expert checks.

#### PR validation:

The cfg correctly runs on the output of wf 34634.0 and provides the desired output.