### PR TITLE
Migrate PF modules to esConsumes

### DIFF
--- a/RecoParticleFlow/PFClusterProducer/interface/HGCRecHitNavigator.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/HGCRecHitNavigator.h
@@ -7,6 +7,7 @@
 
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 
 template <ForwardSubdetector D1,
           typename hgcee,
@@ -41,19 +42,19 @@ public:
     descriptions.add("navigator", desc);
   }
 
-  HGCRecHitNavigator(const edm::ParameterSet& iConfig) {
+  HGCRecHitNavigator(const edm::ParameterSet& iConfig, edm::ConsumesCollector& cc) {
     if (iConfig.exists("hgcee")) {
-      eeNav_ = new hgcee(iConfig.getParameter<edm::ParameterSet>("hgcee"));
+      eeNav_ = new hgcee(iConfig.getParameter<edm::ParameterSet>("hgcee"), cc);
     } else {
       eeNav_ = nullptr;
     }
     if (iConfig.exists("hgchef")) {
-      hefNav_ = new hgchef(iConfig.getParameter<edm::ParameterSet>("hgchef"));
+      hefNav_ = new hgchef(iConfig.getParameter<edm::ParameterSet>("hgchef"), cc);
     } else {
       hefNav_ = nullptr;
     }
     if (iConfig.exists("hgcheb")) {
-      hebNav_ = new hgcheb(iConfig.getParameter<edm::ParameterSet>("hgcheb"));
+      hebNav_ = new hgcheb(iConfig.getParameter<edm::ParameterSet>("hgcheb"), cc);
     } else {
       hebNav_ = nullptr;
     }

--- a/RecoParticleFlow/PFClusterProducer/interface/InitialClusteringStepBase.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/InitialClusteringStepBase.h
@@ -25,7 +25,7 @@ class InitialClusteringStepBase {
   typedef InitialClusteringStepBase ICSB;
 
 public:
-  InitialClusteringStepBase(const edm::ParameterSet& conf, edm::ConsumesCollector& sumes)
+  InitialClusteringStepBase(const edm::ParameterSet& conf, edm::ConsumesCollector& cc)
       : _nSeeds(0),
         _nClustersFound(0),
         _layerMap({{"PS2", (int)PFLayer::PS2},

--- a/RecoParticleFlow/PFClusterProducer/interface/PFCPositionCalculatorBase.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFCPositionCalculatorBase.h
@@ -2,6 +2,7 @@
 #define __PFCPositionCalculatorBase_H__
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "DataFormats/ParticleFlowReco/interface/PFCluster.h"
 #include "DataFormats/ParticleFlowReco/interface/PFClusterFwd.h"
 
@@ -15,7 +16,7 @@ class PFCPositionCalculatorBase {
   typedef PFCPositionCalculatorBase PosCalc;
 
 public:
-  PFCPositionCalculatorBase(const edm::ParameterSet& conf)
+  PFCPositionCalculatorBase(const edm::ParameterSet& conf, edm::ConsumesCollector& sumes)
       : _minFractionInCalc(conf.getParameter<double>("minFractionInCalc")),
         _algoName(conf.getParameter<std::string>("algoName")) {}
   virtual ~PFCPositionCalculatorBase() = default;
@@ -41,6 +42,6 @@ private:
 
 // define the factory for this base class
 #include "FWCore/PluginManager/interface/PluginFactory.h"
-typedef edmplugin::PluginFactory<PFCPositionCalculatorBase*(const edm::ParameterSet&)> PFCPositionCalculatorFactory;
+typedef edmplugin::PluginFactory<PFCPositionCalculatorBase*(const edm::ParameterSet&, edm::ConsumesCollector&)> PFCPositionCalculatorFactory;
 
 #endif

--- a/RecoParticleFlow/PFClusterProducer/interface/PFCPositionCalculatorBase.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFCPositionCalculatorBase.h
@@ -16,7 +16,7 @@ class PFCPositionCalculatorBase {
   typedef PFCPositionCalculatorBase PosCalc;
 
 public:
-  PFCPositionCalculatorBase(const edm::ParameterSet& conf, edm::ConsumesCollector& sumes)
+  PFCPositionCalculatorBase(const edm::ParameterSet& conf, edm::ConsumesCollector& cc)
       : _minFractionInCalc(conf.getParameter<double>("minFractionInCalc")),
         _algoName(conf.getParameter<std::string>("algoName")) {}
   virtual ~PFCPositionCalculatorBase() = default;

--- a/RecoParticleFlow/PFClusterProducer/interface/PFCPositionCalculatorBase.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFCPositionCalculatorBase.h
@@ -42,6 +42,7 @@ private:
 
 // define the factory for this base class
 #include "FWCore/PluginManager/interface/PluginFactory.h"
-typedef edmplugin::PluginFactory<PFCPositionCalculatorBase*(const edm::ParameterSet&, edm::ConsumesCollector&)> PFCPositionCalculatorFactory;
+typedef edmplugin::PluginFactory<PFCPositionCalculatorBase*(const edm::ParameterSet&, edm::ConsumesCollector&)>
+    PFCPositionCalculatorFactory;
 
 #endif

--- a/RecoParticleFlow/PFClusterProducer/interface/PFClusterBuilderBase.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFClusterBuilderBase.h
@@ -64,6 +64,7 @@ private:
 std::ostream& operator<<(std::ostream& o, const PFClusterBuilderBase& a);
 
 #include "FWCore/PluginManager/interface/PluginFactory.h"
-typedef edmplugin::PluginFactory<PFClusterBuilderBase*(const edm::ParameterSet&, edm::ConsumesCollector&)> PFClusterBuilderFactory;
+typedef edmplugin::PluginFactory<PFClusterBuilderBase*(const edm::ParameterSet&, edm::ConsumesCollector&)>
+    PFClusterBuilderFactory;
 
 #endif

--- a/RecoParticleFlow/PFClusterProducer/interface/PFClusterBuilderBase.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFClusterBuilderBase.h
@@ -21,7 +21,7 @@ class PFClusterBuilderBase {
 
 public:
   typedef PFCPositionCalculatorBase PosCalc;
-  PFClusterBuilderBase(const edm::ParameterSet& conf, edm::ConsumesCollector& sumes)
+  PFClusterBuilderBase(const edm::ParameterSet& conf, edm::ConsumesCollector& cc)
       : _nSeeds(0),
         _nClustersFound(0),
         _minFractionToKeep(conf.getParameter<double>("minFractionToKeep")),
@@ -29,7 +29,7 @@ public:
     if (conf.exists("positionCalc")) {
       const edm::ParameterSet& pcConf = conf.getParameterSet("positionCalc");
       const std::string& algo = pcConf.getParameter<std::string>("algoName");
-      _positionCalc = PFCPositionCalculatorFactory::get()->create(algo, pcConf, sumes);
+      _positionCalc = PFCPositionCalculatorFactory::get()->create(algo, pcConf, cc);
     }
   }
   virtual ~PFClusterBuilderBase() = default;

--- a/RecoParticleFlow/PFClusterProducer/interface/PFClusterBuilderBase.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFClusterBuilderBase.h
@@ -2,6 +2,7 @@
 #define __PFClusterBuilderBase_H__
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "DataFormats/ParticleFlowReco/interface/PFCluster.h"
 #include "DataFormats/ParticleFlowReco/interface/PFClusterFwd.h"
 
@@ -20,7 +21,7 @@ class PFClusterBuilderBase {
 
 public:
   typedef PFCPositionCalculatorBase PosCalc;
-  PFClusterBuilderBase(const edm::ParameterSet& conf)
+  PFClusterBuilderBase(const edm::ParameterSet& conf, edm::ConsumesCollector& sumes)
       : _nSeeds(0),
         _nClustersFound(0),
         _minFractionToKeep(conf.getParameter<double>("minFractionToKeep")),
@@ -28,7 +29,7 @@ public:
     if (conf.exists("positionCalc")) {
       const edm::ParameterSet& pcConf = conf.getParameterSet("positionCalc");
       const std::string& algo = pcConf.getParameter<std::string>("algoName");
-      _positionCalc = PFCPositionCalculatorFactory::get()->create(algo, pcConf);
+      _positionCalc = PFCPositionCalculatorFactory::get()->create(algo, pcConf, sumes);
     }
   }
   virtual ~PFClusterBuilderBase() = default;
@@ -63,6 +64,6 @@ private:
 std::ostream& operator<<(std::ostream& o, const PFClusterBuilderBase& a);
 
 #include "FWCore/PluginManager/interface/PluginFactory.h"
-typedef edmplugin::PluginFactory<PFClusterBuilderBase*(const edm::ParameterSet&)> PFClusterBuilderFactory;
+typedef edmplugin::PluginFactory<PFClusterBuilderBase*(const edm::ParameterSet&, edm::ConsumesCollector&)> PFClusterBuilderFactory;
 
 #endif

--- a/RecoParticleFlow/PFClusterProducer/interface/PFClusterEMEnergyCorrector.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFClusterEMEnergyCorrector.h
@@ -23,6 +23,8 @@
 #include "CondFormats/DataRecord/interface/GBRDWrapperRcd.h"
 #include "CondFormats/GBRForest/interface/GBRForestD.h"
 
+#include <vector>
+
 class PFClusterEMEnergyCorrector {
 public:
   PFClusterEMEnergyCorrector(const edm::ParameterSet& conf, edm::ConsumesCollector&& cc);
@@ -89,6 +91,12 @@ private:
   double sigmalimhighEE_;
   double sigmaoffsetEE_;
   double sigmascaleEE_;
+
+private:
+  std::vector<edm::ESGetToken<GBRForestD, GBRDWrapperRcd> > forestMeanTokens_25ns_;
+  std::vector<edm::ESGetToken<GBRForestD, GBRDWrapperRcd> > forestSigmaTokens_25ns_;
+  std::vector<edm::ESGetToken<GBRForestD, GBRDWrapperRcd> > forestMeanTokens_50ns_;
+  std::vector<edm::ESGetToken<GBRForestD, GBRDWrapperRcd> > forestSigmaTokens_50ns_;
 };
 
 #endif

--- a/RecoParticleFlow/PFClusterProducer/interface/PFECALHashNavigator.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFECALHashNavigator.h
@@ -22,10 +22,10 @@ public:
   PFECALHashNavigator() {}
 
   PFECALHashNavigator(const edm::ParameterSet& iConfig, edm::ConsumesCollector& cc)
-      : PFRecHitNavigatorBase(iConfig, cc), geomToken_(cc.esConsumes<edm::Transition::BeginLuminosityBlock>()) {
-    crossBarrelEndcapBorder_ = iConfig.getParameter<bool>("crossBarrelEndcapBorder");
-    neighbourmapcalculated_ = false;
-  }
+      : PFRecHitNavigatorBase(iConfig, cc),
+        neighbourmapcalculated_(false),
+        crossBarrelEndcapBorder_(iConfig.getParameter<bool>("crossBarrelEndcapBorder")),
+        geomToken_(cc.esConsumes<edm::Transition::BeginLuminosityBlock>()) {}
 
   void init(const edm::EventSetup& iSetup) override {
     edm::ESHandle<CaloGeometry> geoHandle = iSetup.getHandle(geomToken_);

--- a/RecoParticleFlow/PFClusterProducer/interface/PFECALHashNavigator.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFECALHashNavigator.h
@@ -4,6 +4,7 @@
 #include "RecoParticleFlow/PFClusterProducer/interface/PFRecHitNavigatorBase.h"
 #include "Geometry/CaloGeometry/interface/CaloSubdetectorGeometry.h"
 #include "Geometry/CaloGeometry/interface/CaloGeometry.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 
 #include "RecoCaloTools/Navigation/interface/CaloNavigator.h"
 #include "DataFormats/EcalDetId/interface/EBDetId.h"
@@ -20,7 +21,7 @@ class PFECALHashNavigator : public PFRecHitNavigatorBase {
 public:
   PFECALHashNavigator() {}
 
-  PFECALHashNavigator(const edm::ParameterSet& iConfig) : PFRecHitNavigatorBase(iConfig) {
+  PFECALHashNavigator(const edm::ParameterSet& iConfig, edm::ConsumesCollector& cc) : PFRecHitNavigatorBase(iConfig, cc) {
     crossBarrelEndcapBorder_ = iConfig.getParameter<bool>("crossBarrelEndcapBorder");
 
     neighbourmapcalculated_ = false;

--- a/RecoParticleFlow/PFClusterProducer/interface/PFECALHashNavigator.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFECALHashNavigator.h
@@ -22,8 +22,7 @@ public:
   PFECALHashNavigator() {}
 
   PFECALHashNavigator(const edm::ParameterSet& iConfig, edm::ConsumesCollector& cc)
-      : PFRecHitNavigatorBase(iConfig, cc),
-        geomToken_(cc.esConsumes<edm::Transition::BeginLuminosityBlock>()) {
+      : PFRecHitNavigatorBase(iConfig, cc), geomToken_(cc.esConsumes<edm::Transition::BeginLuminosityBlock>()) {
     crossBarrelEndcapBorder_ = iConfig.getParameter<bool>("crossBarrelEndcapBorder");
     neighbourmapcalculated_ = false;
   }

--- a/RecoParticleFlow/PFClusterProducer/interface/PFECALHashNavigator.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFECALHashNavigator.h
@@ -21,15 +21,15 @@ class PFECALHashNavigator : public PFRecHitNavigatorBase {
 public:
   PFECALHashNavigator() {}
 
-  PFECALHashNavigator(const edm::ParameterSet& iConfig, edm::ConsumesCollector& cc) : PFRecHitNavigatorBase(iConfig, cc) {
+  PFECALHashNavigator(const edm::ParameterSet& iConfig, edm::ConsumesCollector& cc)
+      : PFRecHitNavigatorBase(iConfig, cc),
+        geomToken_(cc.esConsumes<edm::Transition::BeginLuminosityBlock>()) {
     crossBarrelEndcapBorder_ = iConfig.getParameter<bool>("crossBarrelEndcapBorder");
-
     neighbourmapcalculated_ = false;
   }
 
   void init(const edm::EventSetup& iSetup) override {
-    edm::ESHandle<CaloGeometry> geoHandle;
-    iSetup.get<CaloGeometryRecord>().get(geoHandle);
+    edm::ESHandle<CaloGeometry> geoHandle = iSetup.getHandle(geomToken_);
 
     const CaloSubdetectorGeometry* ebTmp = geoHandle->getSubdetectorGeometry(DetId::Ecal, EcalBarrel);
     const CaloSubdetectorGeometry* eeTmp = geoHandle->getSubdetectorGeometry(DetId::Ecal, EcalEndcap);
@@ -345,6 +345,9 @@ protected:
 
   /// if true, navigation will cross the barrel-endcap border
   bool crossBarrelEndcapBorder_;
+
+private:
+  edm::ESGetToken<CaloGeometry, CaloGeometryRecord> geomToken_;
 };
 
 #endif

--- a/RecoParticleFlow/PFClusterProducer/interface/PFEcalBarrelRecHitCreator.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFEcalBarrelRecHitCreator.h
@@ -27,12 +27,12 @@
 
 class PFEcalBarrelRecHitCreator : public PFRecHitCreatorBase {
 public:
-  PFEcalBarrelRecHitCreator(const edm::ParameterSet& iConfig, edm::ConsumesCollector& iC)
-      : PFRecHitCreatorBase(iConfig, iC) {
-    recHitToken_ = iC.consumes<EcalRecHitCollection>(iConfig.getParameter<edm::InputTag>("src"));
+  PFEcalBarrelRecHitCreator(const edm::ParameterSet& iConfig, edm::ConsumesCollector& cc)
+      : PFRecHitCreatorBase(iConfig, cc) {
+    recHitToken_ = cc.consumes<EcalRecHitCollection>(iConfig.getParameter<edm::InputTag>("src"));
     auto srF = iConfig.getParameter<edm::InputTag>("srFlags");
     if (not srF.label().empty())
-      srFlagToken_ = iC.consumes<EBSrFlagCollection>(srF);
+      srFlagToken_ = cc.consumes<EBSrFlagCollection>(srF);
     triggerTowerMap_ = nullptr;
   }
 

--- a/RecoParticleFlow/PFClusterProducer/interface/PFEcalBarrelRecHitCreator.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFEcalBarrelRecHitCreator.h
@@ -29,13 +29,13 @@ class PFEcalBarrelRecHitCreator : public PFRecHitCreatorBase {
 public:
   PFEcalBarrelRecHitCreator(const edm::ParameterSet& iConfig, edm::ConsumesCollector& cc)
       : PFRecHitCreatorBase(iConfig, cc),
+        recHitToken_(cc.consumes<EcalRecHitCollection>(iConfig.getParameter<edm::InputTag>("src"))),
+        triggerTowerMap_(nullptr),
         geomToken_(cc.esConsumes()),
         towerToken_(cc.esConsumes<edm::Transition::BeginLuminosityBlock>()) {
-    recHitToken_ = cc.consumes<EcalRecHitCollection>(iConfig.getParameter<edm::InputTag>("src"));
     auto srF = iConfig.getParameter<edm::InputTag>("srFlags");
     if (not srF.label().empty())
       srFlagToken_ = cc.consumes<EBSrFlagCollection>(srF);
-    triggerTowerMap_ = nullptr;
   }
 
   void importRecHits(std::unique_ptr<reco::PFRecHitCollection>& out,
@@ -99,10 +99,7 @@ public:
     }
   }
 
-  void init(const edm::EventSetup& es) override {
-    edm::ESHandle<EcalTrigTowerConstituentsMap> hTriggerTowerMap = es.getHandle(towerToken_);
-    triggerTowerMap_ = hTriggerTowerMap.product();
-  }
+  void init(const edm::EventSetup& es) override { triggerTowerMap_ = &es.getData(towerToken_); }
 
 protected:
   bool isHighInterest(const EBDetId& detid) {

--- a/RecoParticleFlow/PFClusterProducer/interface/PFEcalEndcapRecHitCreator.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFEcalEndcapRecHitCreator.h
@@ -29,12 +29,12 @@
 
 class PFEcalEndcapRecHitCreator : public PFRecHitCreatorBase {
 public:
-  PFEcalEndcapRecHitCreator(const edm::ParameterSet& iConfig, edm::ConsumesCollector& iC)
-      : PFRecHitCreatorBase(iConfig, iC) {
-    recHitToken_ = iC.consumes<EcalRecHitCollection>(iConfig.getParameter<edm::InputTag>("src"));
+  PFEcalEndcapRecHitCreator(const edm::ParameterSet& iConfig, edm::ConsumesCollector& cc)
+      : PFRecHitCreatorBase(iConfig, cc) {
+    recHitToken_ = cc.consumes<EcalRecHitCollection>(iConfig.getParameter<edm::InputTag>("src"));
     auto srF = iConfig.getParameter<edm::InputTag>("srFlags");
     if (not srF.label().empty())
-      srFlagToken_ = iC.consumes<EESrFlagCollection>(srF);
+      srFlagToken_ = cc.consumes<EESrFlagCollection>(srF);
     elecMap_ = nullptr;
   }
 

--- a/RecoParticleFlow/PFClusterProducer/interface/PFEcalEndcapRecHitCreator.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFEcalEndcapRecHitCreator.h
@@ -30,7 +30,9 @@
 class PFEcalEndcapRecHitCreator : public PFRecHitCreatorBase {
 public:
   PFEcalEndcapRecHitCreator(const edm::ParameterSet& iConfig, edm::ConsumesCollector& cc)
-      : PFRecHitCreatorBase(iConfig, cc) {
+      : PFRecHitCreatorBase(iConfig, cc),
+        geomToken_(cc.esConsumes()),
+        mappingToken_(cc.esConsumes<edm::Transition::BeginLuminosityBlock>()) {
     recHitToken_ = cc.consumes<EcalRecHitCollection>(iConfig.getParameter<edm::InputTag>("src"));
     auto srF = iConfig.getParameter<edm::InputTag>("srFlags");
     if (not srF.label().empty())
@@ -46,8 +48,7 @@ public:
 
     edm::Handle<EcalRecHitCollection> recHitHandle;
 
-    edm::ESHandle<CaloGeometry> geoHandle;
-    iSetup.get<CaloGeometryRecord>().get(geoHandle);
+    edm::ESHandle<CaloGeometry> geoHandle = iSetup.getHandle(geomToken_);
 
     bool useSrF = false;
     if (not srFlagToken_.isUninitialized()) {
@@ -101,8 +102,7 @@ public:
   }
 
   void init(const edm::EventSetup& es) override {
-    edm::ESHandle<EcalElectronicsMapping> ecalmapping;
-    es.get<EcalMappingRcd>().get(ecalmapping);
+    edm::ESHandle<EcalElectronicsMapping> ecalmapping = es.getHandle(mappingToken_);
     elecMap_ = ecalmapping.product();
   }
 
@@ -135,6 +135,10 @@ protected:
   const EcalElectronicsMapping* elecMap_;
   // selective readout flags collection
   edm::Handle<EESrFlagCollection> srFlagHandle_;
+
+private:
+  edm::ESGetToken<CaloGeometry, CaloGeometryRecord> geomToken_;
+  edm::ESGetToken<EcalElectronicsMapping, EcalMappingRcd> mappingToken_;
 };
 
 #endif

--- a/RecoParticleFlow/PFClusterProducer/interface/PFEcalEndcapRecHitCreator.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFEcalEndcapRecHitCreator.h
@@ -31,13 +31,13 @@ class PFEcalEndcapRecHitCreator : public PFRecHitCreatorBase {
 public:
   PFEcalEndcapRecHitCreator(const edm::ParameterSet& iConfig, edm::ConsumesCollector& cc)
       : PFRecHitCreatorBase(iConfig, cc),
+        recHitToken_(cc.consumes<EcalRecHitCollection>(iConfig.getParameter<edm::InputTag>("src"))),
+        elecMap_(nullptr),
         geomToken_(cc.esConsumes()),
         mappingToken_(cc.esConsumes<edm::Transition::BeginLuminosityBlock>()) {
-    recHitToken_ = cc.consumes<EcalRecHitCollection>(iConfig.getParameter<edm::InputTag>("src"));
     auto srF = iConfig.getParameter<edm::InputTag>("srFlags");
     if (not srF.label().empty())
       srFlagToken_ = cc.consumes<EESrFlagCollection>(srF);
-    elecMap_ = nullptr;
   }
 
   void importRecHits(std::unique_ptr<reco::PFRecHitCollection>& out,
@@ -101,10 +101,7 @@ public:
     }
   }
 
-  void init(const edm::EventSetup& es) override {
-    edm::ESHandle<EcalElectronicsMapping> ecalmapping = es.getHandle(mappingToken_);
-    elecMap_ = ecalmapping.product();
-  }
+  void init(const edm::EventSetup& es) override { elecMap_ = &es.getData(mappingToken_); }
 
 protected:
   bool isHighInterest(const EEDetId& detid) {

--- a/RecoParticleFlow/PFClusterProducer/interface/PFHBHERecHitCreator.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFHBHERecHitCreator.h
@@ -19,9 +19,9 @@
 class PFHBHERecHitCreator : public PFRecHitCreatorBase {
 public:
   PFHBHERecHitCreator(const edm::ParameterSet& iConfig, edm::ConsumesCollector& cc)
-      : PFRecHitCreatorBase(iConfig, cc), geomToken_(cc.esConsumes()) {
-    recHitToken_ = cc.consumes<edm::SortedCollection<HBHERecHit> >(iConfig.getParameter<edm::InputTag>("src"));
-  }
+      : PFRecHitCreatorBase(iConfig, cc),
+        recHitToken_(cc.consumes<edm::SortedCollection<HBHERecHit> >(iConfig.getParameter<edm::InputTag>("src"))),
+        geomToken_(cc.esConsumes()) {}
 
   void importRecHits(std::unique_ptr<reco::PFRecHitCollection>& out,
                      std::unique_ptr<reco::PFRecHitCollection>& cleaned,

--- a/RecoParticleFlow/PFClusterProducer/interface/PFHBHERecHitCreator.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFHBHERecHitCreator.h
@@ -18,8 +18,8 @@
 #include "RecoCaloTools/Navigation/interface/CaloNavigator.h"
 class PFHBHERecHitCreator : public PFRecHitCreatorBase {
 public:
-  PFHBHERecHitCreator(const edm::ParameterSet& iConfig, edm::ConsumesCollector& iC) : PFRecHitCreatorBase(iConfig, iC) {
-    recHitToken_ = iC.consumes<edm::SortedCollection<HBHERecHit> >(iConfig.getParameter<edm::InputTag>("src"));
+  PFHBHERecHitCreator(const edm::ParameterSet& iConfig, edm::ConsumesCollector& cc) : PFRecHitCreatorBase(iConfig, cc) {
+    recHitToken_ = cc.consumes<edm::SortedCollection<HBHERecHit> >(iConfig.getParameter<edm::InputTag>("src"));
   }
 
   void importRecHits(std::unique_ptr<reco::PFRecHitCollection>& out,

--- a/RecoParticleFlow/PFClusterProducer/interface/PFHBHERecHitCreator.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFHBHERecHitCreator.h
@@ -18,7 +18,9 @@
 #include "RecoCaloTools/Navigation/interface/CaloNavigator.h"
 class PFHBHERecHitCreator : public PFRecHitCreatorBase {
 public:
-  PFHBHERecHitCreator(const edm::ParameterSet& iConfig, edm::ConsumesCollector& cc) : PFRecHitCreatorBase(iConfig, cc) {
+  PFHBHERecHitCreator(const edm::ParameterSet& iConfig, edm::ConsumesCollector& cc)
+      : PFRecHitCreatorBase(iConfig, cc),
+        geomToken_(cc.esConsumes()) {
     recHitToken_ = cc.consumes<edm::SortedCollection<HBHERecHit> >(iConfig.getParameter<edm::InputTag>("src"));
   }
 
@@ -30,8 +32,7 @@ public:
 
     edm::Handle<edm::SortedCollection<HBHERecHit> > recHitHandle;
 
-    edm::ESHandle<CaloGeometry> geoHandle;
-    iSetup.get<CaloGeometryRecord>().get(geoHandle);
+    edm::ESHandle<CaloGeometry> geoHandle = iSetup.getHandle(geomToken_);
 
     // get the ecal geometry
     const CaloSubdetectorGeometry* hcalBarrelGeo = geoHandle->getSubdetectorGeometry(DetId::Hcal, HcalBarrel);
@@ -92,6 +93,9 @@ public:
 
 protected:
   edm::EDGetTokenT<edm::SortedCollection<HBHERecHit> > recHitToken_;
+
+private:
+  edm::ESGetToken<CaloGeometry, CaloGeometryRecord> geomToken_;
 };
 
 #endif

--- a/RecoParticleFlow/PFClusterProducer/interface/PFHBHERecHitCreator.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFHBHERecHitCreator.h
@@ -19,8 +19,7 @@
 class PFHBHERecHitCreator : public PFRecHitCreatorBase {
 public:
   PFHBHERecHitCreator(const edm::ParameterSet& iConfig, edm::ConsumesCollector& cc)
-      : PFRecHitCreatorBase(iConfig, cc),
-        geomToken_(cc.esConsumes()) {
+      : PFRecHitCreatorBase(iConfig, cc), geomToken_(cc.esConsumes()) {
     recHitToken_ = cc.consumes<edm::SortedCollection<HBHERecHit> >(iConfig.getParameter<edm::InputTag>("src"));
   }
 

--- a/RecoParticleFlow/PFClusterProducer/interface/PFHCALDenseIdNavigator.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFHCALDenseIdNavigator.h
@@ -31,7 +31,9 @@ public:
     }
   }
 
-  PFHCALDenseIdNavigator(const edm::ParameterSet& iConfig, edm::ConsumesCollector& cc) {
+  PFHCALDenseIdNavigator(const edm::ParameterSet& iConfig, edm::ConsumesCollector& cc)
+      : hcalToken_(cc.esConsumes<edm::Transition::BeginLuminosityBlock>()),
+        geomToken_(cc.esConsumes<edm::Transition::BeginLuminosityBlock>()) {
     vhcalEnum_ = iConfig.getParameter<std::vector<int>>("hcalEnums");
   }
 
@@ -40,14 +42,12 @@ public:
     if (!check)
       return;
 
-    edm::ESHandle<HcalTopology> hcalTopology;
-    iSetup.get<HcalRecNumberingRecord>().get(hcalTopology);
+    edm::ESHandle<HcalTopology> hcalTopology = iSetup.getHandle(hcalToken_);
     topology_.release();
     topology_.reset(hcalTopology.product());
 
     // Fill a vector of valid denseid's
-    edm::ESHandle<CaloGeometry> hGeom;
-    iSetup.get<CaloGeometryRecord>().get(hGeom);
+    edm::ESHandle<CaloGeometry> hGeom = iSetup.getHandle(geomToken_);
     const CaloGeometry& caloGeom = *hGeom;
 
     std::vector<DetId> vecHcal;
@@ -188,6 +188,10 @@ protected:
   std::vector<std::vector<DetId>> neighboursHcal_;
   unsigned int denseIdHcalMax_;
   unsigned int denseIdHcalMin_;
+
+private:
+  edm::ESGetToken<HcalTopology, HcalRecNumberingRecord> hcalToken_;
+  edm::ESGetToken<CaloGeometry, CaloGeometryRecord> geomToken_;
 };
 
 #endif

--- a/RecoParticleFlow/PFClusterProducer/interface/PFHCALDenseIdNavigator.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFHCALDenseIdNavigator.h
@@ -32,10 +32,9 @@ public:
   }
 
   PFHCALDenseIdNavigator(const edm::ParameterSet& iConfig, edm::ConsumesCollector& cc)
-      : hcalToken_(cc.esConsumes<edm::Transition::BeginLuminosityBlock>()),
-        geomToken_(cc.esConsumes<edm::Transition::BeginLuminosityBlock>()) {
-    vhcalEnum_ = iConfig.getParameter<std::vector<int>>("hcalEnums");
-  }
+      : vhcalEnum_(iConfig.getParameter<std::vector<int>>("hcalEnums")),
+        hcalToken_(cc.esConsumes<edm::Transition::BeginLuminosityBlock>()),
+        geomToken_(cc.esConsumes<edm::Transition::BeginLuminosityBlock>()) {}
 
   void init(const edm::EventSetup& iSetup) override {
     bool check = theRecNumberWatcher_.check(iSetup);
@@ -58,7 +57,7 @@ public:
       vecHcal.insert(vecHcal.end(), vecDetIds.begin(), vecDetIds.end());
     }
     vDenseIdHcal.reserve(vecHcal.size());
- for (auto hDetId : vecHcal) {
+    for (auto hDetId : vecHcal) {
       vDenseIdHcal.push_back(topology_.get()->detId2denseId(hDetId));
     }
     std::sort(vDenseIdHcal.begin(), vDenseIdHcal.end());

--- a/RecoParticleFlow/PFClusterProducer/interface/PFHCALDenseIdNavigator.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFHCALDenseIdNavigator.h
@@ -57,7 +57,8 @@ public:
       std::vector<DetId> vecDetIds(caloGeom.getValidDetIds(DetId::Hcal, hcalSubdet));
       vecHcal.insert(vecHcal.end(), vecDetIds.begin(), vecDetIds.end());
     }
-    for (auto hDetId : vecHcal) {
+    vDenseIdHcal.reserve(vecHcal.size());
+ for (auto hDetId : vecHcal) {
       vDenseIdHcal.push_back(topology_.get()->detId2denseId(hDetId));
     }
     std::sort(vDenseIdHcal.begin(), vDenseIdHcal.end());

--- a/RecoParticleFlow/PFClusterProducer/interface/PFHCALDenseIdNavigator.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFHCALDenseIdNavigator.h
@@ -6,6 +6,7 @@
 #include "RecoParticleFlow/PFClusterProducer/interface/PFRecHitNavigatorBase.h"
 #include "Geometry/CaloGeometry/interface/CaloSubdetectorGeometry.h"
 #include "Geometry/CaloGeometry/interface/CaloGeometry.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 
 #include "RecoCaloTools/Navigation/interface/CaloNavigator.h"
 #include "DataFormats/EcalDetId/interface/EBDetId.h"
@@ -30,7 +31,7 @@ public:
     }
   }
 
-  PFHCALDenseIdNavigator(const edm::ParameterSet& iConfig) {
+  PFHCALDenseIdNavigator(const edm::ParameterSet& iConfig, edm::ConsumesCollector& cc) {
     vhcalEnum_ = iConfig.getParameter<std::vector<int>>("hcalEnums");
   }
 

--- a/RecoParticleFlow/PFClusterProducer/interface/PFHFRecHitCreator.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFHFRecHitCreator.h
@@ -20,8 +20,8 @@
 
 class PFHFRecHitCreator final : public PFRecHitCreatorBase {
 public:
-  PFHFRecHitCreator(const edm::ParameterSet& iConfig, edm::ConsumesCollector& iC) : PFRecHitCreatorBase(iConfig, iC) {
-    recHitToken_ = iC.consumes<edm::SortedCollection<HFRecHit> >(iConfig.getParameter<edm::InputTag>("src"));
+  PFHFRecHitCreator(const edm::ParameterSet& iConfig, edm::ConsumesCollector& cc) : PFRecHitCreatorBase(iConfig, cc) {
+    recHitToken_ = cc.consumes<edm::SortedCollection<HFRecHit> >(iConfig.getParameter<edm::InputTag>("src"));
     EM_Depth_ = iConfig.getParameter<double>("EMDepthCorrection");
     HAD_Depth_ = iConfig.getParameter<double>("HADDepthCorrection");
     shortFibre_Cut = iConfig.getParameter<double>("ShortFibre_Cut");

--- a/RecoParticleFlow/PFClusterProducer/interface/PFHFRecHitCreator.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFHFRecHitCreator.h
@@ -21,8 +21,7 @@
 class PFHFRecHitCreator final : public PFRecHitCreatorBase {
 public:
   PFHFRecHitCreator(const edm::ParameterSet& iConfig, edm::ConsumesCollector& cc)
-      : PFRecHitCreatorBase(iConfig, cc),
-        geomToken_(cc.esConsumes()) {
+      : PFRecHitCreatorBase(iConfig, cc), geomToken_(cc.esConsumes()) {
     recHitToken_ = cc.consumes<edm::SortedCollection<HFRecHit> >(iConfig.getParameter<edm::InputTag>("src"));
     EM_Depth_ = iConfig.getParameter<double>("EMDepthCorrection");
     HAD_Depth_ = iConfig.getParameter<double>("HADDepthCorrection");

--- a/RecoParticleFlow/PFClusterProducer/interface/PFHFRecHitCreator.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFHFRecHitCreator.h
@@ -21,17 +21,17 @@
 class PFHFRecHitCreator final : public PFRecHitCreatorBase {
 public:
   PFHFRecHitCreator(const edm::ParameterSet& iConfig, edm::ConsumesCollector& cc)
-      : PFRecHitCreatorBase(iConfig, cc), geomToken_(cc.esConsumes()) {
-    recHitToken_ = cc.consumes<edm::SortedCollection<HFRecHit> >(iConfig.getParameter<edm::InputTag>("src"));
-    EM_Depth_ = iConfig.getParameter<double>("EMDepthCorrection");
-    HAD_Depth_ = iConfig.getParameter<double>("HADDepthCorrection");
-    shortFibre_Cut = iConfig.getParameter<double>("ShortFibre_Cut");
-    longFibre_Fraction = iConfig.getParameter<double>("LongFibre_Fraction");
-    longFibre_Cut = iConfig.getParameter<double>("LongFibre_Cut");
-    shortFibre_Fraction = iConfig.getParameter<double>("ShortFibre_Fraction");
-    thresh_HF_ = iConfig.getParameter<double>("thresh_HF");
-    HFCalib_ = iConfig.getParameter<double>("HFCalib29");
-  }
+      : PFRecHitCreatorBase(iConfig, cc),
+        recHitToken_(cc.consumes<edm::SortedCollection<HFRecHit> >(iConfig.getParameter<edm::InputTag>("src"))),
+        EM_Depth_(iConfig.getParameter<double>("EMDepthCorrection")),
+        HAD_Depth_(iConfig.getParameter<double>("HADDepthCorrection")),
+        shortFibre_Cut(iConfig.getParameter<double>("ShortFibre_Cut")),
+        longFibre_Fraction(iConfig.getParameter<double>("LongFibre_Fraction")),
+        longFibre_Cut(iConfig.getParameter<double>("LongFibre_Cut")),
+        shortFibre_Fraction(iConfig.getParameter<double>("ShortFibre_Fraction")),
+        thresh_HF_(iConfig.getParameter<double>("thresh_HF")),
+        HFCalib_(iConfig.getParameter<double>("HFCalib29")),
+        geomToken_(cc.esConsumes()) {}
 
   void importRecHits(std::unique_ptr<reco::PFRecHitCollection>& out,
                      std::unique_ptr<reco::PFRecHitCollection>& cleaned,

--- a/RecoParticleFlow/PFClusterProducer/interface/PFHFRecHitCreator.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFHFRecHitCreator.h
@@ -20,7 +20,9 @@
 
 class PFHFRecHitCreator final : public PFRecHitCreatorBase {
 public:
-  PFHFRecHitCreator(const edm::ParameterSet& iConfig, edm::ConsumesCollector& cc) : PFRecHitCreatorBase(iConfig, cc) {
+  PFHFRecHitCreator(const edm::ParameterSet& iConfig, edm::ConsumesCollector& cc)
+      : PFRecHitCreatorBase(iConfig, cc),
+        geomToken_(cc.esConsumes()) {
     recHitToken_ = cc.consumes<edm::SortedCollection<HFRecHit> >(iConfig.getParameter<edm::InputTag>("src"));
     EM_Depth_ = iConfig.getParameter<double>("EMDepthCorrection");
     HAD_Depth_ = iConfig.getParameter<double>("HADDepthCorrection");
@@ -42,8 +44,7 @@ public:
 
     edm::Handle<edm::SortedCollection<HFRecHit> > recHitHandle;
 
-    edm::ESHandle<CaloGeometry> geoHandle;
-    iSetup.get<CaloGeometryRecord>().get(geoHandle);
+    edm::ESHandle<CaloGeometry> geoHandle = iSetup.getHandle(geomToken_);
 
     // get the ecal geometry
     const CaloSubdetectorGeometry* hcalGeo = geoHandle->getSubdetectorGeometry(DetId::Hcal, HcalForward);
@@ -195,5 +196,8 @@ protected:
         return a.detId() < b.detId();
     }
   };
+
+private:
+  edm::ESGetToken<CaloGeometry, CaloGeometryRecord> geomToken_;
 };
 #endif

--- a/RecoParticleFlow/PFClusterProducer/interface/PFHGCalRecHitCreator.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFHGCalRecHitCreator.h
@@ -26,10 +26,10 @@ template <typename DET, PFLayer::Layer Layer, DetId::Detector det, unsigned subd
 class PFHGCalRecHitCreator : public PFRecHitCreatorBase {
 public:
   PFHGCalRecHitCreator(const edm::ParameterSet& iConfig, edm::ConsumesCollector& cc)
-      : PFRecHitCreatorBase(iConfig, cc), geomToken_(cc.esConsumes()) {
-    recHitToken_ = cc.consumes<HGCRecHitCollection>(iConfig.getParameter<edm::InputTag>("src"));
-    geometryInstance_ = iConfig.getParameter<std::string>("geometryInstance");
-  }
+      : PFRecHitCreatorBase(iConfig, cc),
+        recHitToken_(cc.consumes<HGCRecHitCollection>(iConfig.getParameter<edm::InputTag>("src"))),
+        geometryInstance_(iConfig.getParameter<std::string>("geometryInstance")),
+        geomToken_(cc.esConsumes()) {}
 
   void importRecHits(std::unique_ptr<reco::PFRecHitCollection>& out,
                      std::unique_ptr<reco::PFRecHitCollection>& cleaned,

--- a/RecoParticleFlow/PFClusterProducer/interface/PFHGCalRecHitCreator.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFHGCalRecHitCreator.h
@@ -25,9 +25,9 @@
 template <typename DET, PFLayer::Layer Layer, DetId::Detector det, unsigned subdet>
 class PFHGCalRecHitCreator : public PFRecHitCreatorBase {
 public:
-  PFHGCalRecHitCreator(const edm::ParameterSet& iConfig, edm::ConsumesCollector& iC)
-      : PFRecHitCreatorBase(iConfig, iC) {
-    recHitToken_ = iC.consumes<HGCRecHitCollection>(iConfig.getParameter<edm::InputTag>("src"));
+  PFHGCalRecHitCreator(const edm::ParameterSet& iConfig, edm::ConsumesCollector& cc)
+      : PFRecHitCreatorBase(iConfig, cc) {
+    recHitToken_ = cc.consumes<HGCRecHitCollection>(iConfig.getParameter<edm::InputTag>("src"));
     geometryInstance_ = iConfig.getParameter<std::string>("geometryInstance");
   }
 

--- a/RecoParticleFlow/PFClusterProducer/interface/PFHGCalRecHitCreator.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFHGCalRecHitCreator.h
@@ -26,8 +26,7 @@ template <typename DET, PFLayer::Layer Layer, DetId::Detector det, unsigned subd
 class PFHGCalRecHitCreator : public PFRecHitCreatorBase {
 public:
   PFHGCalRecHitCreator(const edm::ParameterSet& iConfig, edm::ConsumesCollector& cc)
-      : PFRecHitCreatorBase(iConfig, cc),
-        geomToken_(cc.esConsumes()) {
+      : PFRecHitCreatorBase(iConfig, cc), geomToken_(cc.esConsumes()) {
     recHitToken_ = cc.consumes<HGCRecHitCollection>(iConfig.getParameter<edm::InputTag>("src"));
     geometryInstance_ = iConfig.getParameter<std::string>("geometryInstance");
   }

--- a/RecoParticleFlow/PFClusterProducer/interface/PFHGCalRecHitCreator.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFHGCalRecHitCreator.h
@@ -26,7 +26,8 @@ template <typename DET, PFLayer::Layer Layer, DetId::Detector det, unsigned subd
 class PFHGCalRecHitCreator : public PFRecHitCreatorBase {
 public:
   PFHGCalRecHitCreator(const edm::ParameterSet& iConfig, edm::ConsumesCollector& cc)
-      : PFRecHitCreatorBase(iConfig, cc) {
+      : PFRecHitCreatorBase(iConfig, cc),
+        geomToken_(cc.esConsumes()) {
     recHitToken_ = cc.consumes<HGCRecHitCollection>(iConfig.getParameter<edm::InputTag>("src"));
     geometryInstance_ = iConfig.getParameter<std::string>("geometryInstance");
   }
@@ -36,8 +37,7 @@ public:
                      const edm::Event& iEvent,
                      const edm::EventSetup& iSetup) override {
     // Setup RecHitTools to properly compute the position of the HGCAL Cells vie their DetIds
-    edm::ESHandle<CaloGeometry> geoHandle;
-    iSetup.get<CaloGeometryRecord>().get(geoHandle);
+    edm::ESHandle<CaloGeometry> geoHandle = iSetup.getHandle(geomToken_);
     recHitTools_.setGeometry(*geoHandle);
 
     for (unsigned int i = 0; i < qualityTests_.size(); ++i) {
@@ -101,6 +101,7 @@ protected:
 
 private:
   hgcal::RecHitTools recHitTools_;
+  edm::ESGetToken<CaloGeometry, CaloGeometryRecord> geomToken_;
 };
 
 #include "DataFormats/DetId/interface/DetId.h"

--- a/RecoParticleFlow/PFClusterProducer/interface/PFHcalRecHitCreator.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFHcalRecHitCreator.h
@@ -22,9 +22,10 @@ template <typename Digi, typename Geometry, PFLayer::Layer Layer, int Detector>
 class PFHcalRecHitCreator final : public PFRecHitCreatorBase {
 public:
   PFHcalRecHitCreator(const edm::ParameterSet& iConfig, edm::ConsumesCollector& cc)
-      : PFRecHitCreatorBase(iConfig, cc), geomToken_(cc.esConsumes()), topoToken_(cc.esConsumes()) {
-    recHitToken_ = cc.consumes<edm::SortedCollection<Digi> >(iConfig.getParameter<edm::InputTag>("src"));
-  }
+      : PFRecHitCreatorBase(iConfig, cc),
+        recHitToken_(cc.consumes<edm::SortedCollection<Digi> >(iConfig.getParameter<edm::InputTag>("src"))),
+        geomToken_(cc.esConsumes()),
+        topoToken_(cc.esConsumes()) {}
 
   void importRecHits(std::unique_ptr<reco::PFRecHitCollection>& out,
                      std::unique_ptr<reco::PFRecHitCollection>& cleaned,

--- a/RecoParticleFlow/PFClusterProducer/interface/PFHcalRecHitCreator.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFHcalRecHitCreator.h
@@ -22,9 +22,7 @@ template <typename Digi, typename Geometry, PFLayer::Layer Layer, int Detector>
 class PFHcalRecHitCreator final : public PFRecHitCreatorBase {
 public:
   PFHcalRecHitCreator(const edm::ParameterSet& iConfig, edm::ConsumesCollector& cc)
-      : PFRecHitCreatorBase(iConfig, cc),
-        geomToken_(cc.esConsumes()),
-        topoToken_(cc.esConsumes()) {
+      : PFRecHitCreatorBase(iConfig, cc), geomToken_(cc.esConsumes()), topoToken_(cc.esConsumes()) {
     recHitToken_ = cc.consumes<edm::SortedCollection<Digi> >(iConfig.getParameter<edm::InputTag>("src"));
   }
 

--- a/RecoParticleFlow/PFClusterProducer/interface/PFHcalRecHitCreator.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFHcalRecHitCreator.h
@@ -21,8 +21,8 @@
 template <typename Digi, typename Geometry, PFLayer::Layer Layer, int Detector>
 class PFHcalRecHitCreator final : public PFRecHitCreatorBase {
 public:
-  PFHcalRecHitCreator(const edm::ParameterSet& iConfig, edm::ConsumesCollector& iC) : PFRecHitCreatorBase(iConfig, iC) {
-    recHitToken_ = iC.consumes<edm::SortedCollection<Digi> >(iConfig.getParameter<edm::InputTag>("src"));
+  PFHcalRecHitCreator(const edm::ParameterSet& iConfig, edm::ConsumesCollector& cc) : PFRecHitCreatorBase(iConfig, cc) {
+    recHitToken_ = cc.consumes<edm::SortedCollection<Digi> >(iConfig.getParameter<edm::InputTag>("src"));
   }
 
   void importRecHits(std::unique_ptr<reco::PFRecHitCollection>& out,

--- a/RecoParticleFlow/PFClusterProducer/interface/PFHcalRecHitCreator.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFHcalRecHitCreator.h
@@ -21,7 +21,10 @@
 template <typename Digi, typename Geometry, PFLayer::Layer Layer, int Detector>
 class PFHcalRecHitCreator final : public PFRecHitCreatorBase {
 public:
-  PFHcalRecHitCreator(const edm::ParameterSet& iConfig, edm::ConsumesCollector& cc) : PFRecHitCreatorBase(iConfig, cc) {
+  PFHcalRecHitCreator(const edm::ParameterSet& iConfig, edm::ConsumesCollector& cc)
+      : PFRecHitCreatorBase(iConfig, cc),
+        geomToken_(cc.esConsumes()),
+        topoToken_(cc.esConsumes()) {
     recHitToken_ = cc.consumes<edm::SortedCollection<Digi> >(iConfig.getParameter<edm::InputTag>("src"));
   }
 
@@ -33,10 +36,8 @@ public:
 
     edm::Handle<edm::SortedCollection<Digi> > recHitHandle;
 
-    edm::ESHandle<CaloGeometry> geoHandle;
-    iSetup.get<CaloGeometryRecord>().get(geoHandle);
-    edm::ESHandle<HcalTopology> hcalTopology;
-    iSetup.get<HcalRecNumberingRecord>().get(hcalTopology);
+    edm::ESHandle<CaloGeometry> geoHandle = iSetup.getHandle(geomToken_);
+    edm::ESHandle<HcalTopology> hcalTopology = iSetup.getHandle(topoToken_);
 
     // get the hcal geometry and topology
     const CaloSubdetectorGeometry* gTmp = geoHandle->getSubdetectorGeometry(DetId::Hcal, Detector);
@@ -93,6 +94,10 @@ public:
 protected:
   edm::EDGetTokenT<edm::SortedCollection<Digi> > recHitToken_;
   int hoDepth_;
+
+private:
+  edm::ESGetToken<CaloGeometry, CaloGeometryRecord> geomToken_;
+  edm::ESGetToken<HcalTopology, HcalRecNumberingRecord> topoToken_;
 };
 
 typedef PFHcalRecHitCreator<HBHERecHit, CaloSubdetectorGeometry, PFLayer::HCAL_BARREL1, HcalBarrel> PFHBRecHitCreator;

--- a/RecoParticleFlow/PFClusterProducer/interface/PFPSRecHitCreator.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFPSRecHitCreator.h
@@ -26,8 +26,7 @@
 class PFPSRecHitCreator final : public PFRecHitCreatorBase {
 public:
   PFPSRecHitCreator(const edm::ParameterSet& iConfig, edm::ConsumesCollector& cc)
-      : PFRecHitCreatorBase(iConfig, cc),
-        geomToken_(cc.esConsumes()) {
+      : PFRecHitCreatorBase(iConfig, cc), geomToken_(cc.esConsumes()) {
     recHitToken_ = cc.consumes<EcalRecHitCollection>(iConfig.getParameter<edm::InputTag>("src"));
   }
 

--- a/RecoParticleFlow/PFClusterProducer/interface/PFPSRecHitCreator.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFPSRecHitCreator.h
@@ -26,9 +26,9 @@
 class PFPSRecHitCreator final : public PFRecHitCreatorBase {
 public:
   PFPSRecHitCreator(const edm::ParameterSet& iConfig, edm::ConsumesCollector& cc)
-      : PFRecHitCreatorBase(iConfig, cc), geomToken_(cc.esConsumes()) {
-    recHitToken_ = cc.consumes<EcalRecHitCollection>(iConfig.getParameter<edm::InputTag>("src"));
-  }
+      : PFRecHitCreatorBase(iConfig, cc),
+        recHitToken_(cc.consumes<EcalRecHitCollection>(iConfig.getParameter<edm::InputTag>("src"))),
+        geomToken_(cc.esConsumes()) {}
 
   void importRecHits(std::unique_ptr<reco::PFRecHitCollection>& out,
                      std::unique_ptr<reco::PFRecHitCollection>& cleaned,

--- a/RecoParticleFlow/PFClusterProducer/interface/PFPSRecHitCreator.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFPSRecHitCreator.h
@@ -25,8 +25,8 @@
 
 class PFPSRecHitCreator final : public PFRecHitCreatorBase {
 public:
-  PFPSRecHitCreator(const edm::ParameterSet& iConfig, edm::ConsumesCollector& iC) : PFRecHitCreatorBase(iConfig, iC) {
-    recHitToken_ = iC.consumes<EcalRecHitCollection>(iConfig.getParameter<edm::InputTag>("src"));
+  PFPSRecHitCreator(const edm::ParameterSet& iConfig, edm::ConsumesCollector& cc) : PFRecHitCreatorBase(iConfig, cc) {
+    recHitToken_ = cc.consumes<EcalRecHitCollection>(iConfig.getParameter<edm::InputTag>("src"));
   }
 
   void importRecHits(std::unique_ptr<reco::PFRecHitCollection>& out,

--- a/RecoParticleFlow/PFClusterProducer/interface/PFPSRecHitCreator.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFPSRecHitCreator.h
@@ -25,7 +25,9 @@
 
 class PFPSRecHitCreator final : public PFRecHitCreatorBase {
 public:
-  PFPSRecHitCreator(const edm::ParameterSet& iConfig, edm::ConsumesCollector& cc) : PFRecHitCreatorBase(iConfig, cc) {
+  PFPSRecHitCreator(const edm::ParameterSet& iConfig, edm::ConsumesCollector& cc)
+      : PFRecHitCreatorBase(iConfig, cc),
+        geomToken_(cc.esConsumes()) {
     recHitToken_ = cc.consumes<EcalRecHitCollection>(iConfig.getParameter<edm::InputTag>("src"));
   }
 
@@ -36,8 +38,7 @@ public:
     beginEvent(iEvent, iSetup);
 
     edm::Handle<EcalRecHitCollection> recHitHandle;
-    edm::ESHandle<CaloGeometry> geoHandle;
-    iSetup.get<CaloGeometryRecord>().get(geoHandle);
+    edm::ESHandle<CaloGeometry> geoHandle = iSetup.getHandle(geomToken_);
 
     // get the ecal geometry
     const CaloSubdetectorGeometry* psGeometry = geoHandle->getSubdetectorGeometry(DetId::Ecal, EcalPreshower);
@@ -95,6 +96,9 @@ public:
 
 protected:
   edm::EDGetTokenT<EcalRecHitCollection> recHitToken_;
+
+private:
+  edm::ESGetToken<CaloGeometry, CaloGeometryRecord> geomToken_;
 };
 
 #endif

--- a/RecoParticleFlow/PFClusterProducer/interface/PFRecHitCaloNavigatorWithTime.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFRecHitCaloNavigatorWithTime.h
@@ -2,10 +2,13 @@
 #ifndef RecoParticleFlow_PFClusterProducer_PFRecHitCaloNavigatorWithTime_h
 #define RecoParticleFlow_PFClusterProducer_PFRecHitCaloNavigatorWithTime_h
 
-#include "RecoParticleFlow/PFClusterProducer/interface/PFRecHitNavigatorBase.h"
-#include "Geometry/CaloGeometry/interface/CaloSubdetectorGeometry.h"
-#include "Geometry/CaloGeometry/interface/CaloGeometry.h"
+#include <memory>
+
+
 #include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "Geometry/CaloGeometry/interface/CaloGeometry.h"
+#include "Geometry/CaloGeometry/interface/CaloSubdetectorGeometry.h"
+#include "RecoParticleFlow/PFClusterProducer/interface/PFRecHitNavigatorBase.h"
 
 #include "RecoCaloTools/Navigation/interface/CaloNavigator.h"
 #include "DataFormats/EcalDetId/interface/EBDetId.h"
@@ -29,7 +32,7 @@ public:
   PFRecHitCaloNavigatorWithTime(const edm::ParameterSet& iConfig, edm::ConsumesCollector& cc) {
     sigmaCut2_ = pow(iConfig.getParameter<double>("sigmaCut"), 2);
     const edm::ParameterSet& timeResConf = iConfig.getParameterSet("timeResolutionCalc");
-    _timeResolutionCalc.reset(new CaloRecHitResolutionProvider(timeResConf));
+    _timeResolutionCalc = std::make_unique<CaloRecHitResolutionProvider>(timeResConf);
   }
 
   ~PFRecHitCaloNavigatorWithTime() override {

--- a/RecoParticleFlow/PFClusterProducer/interface/PFRecHitCaloNavigatorWithTime.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFRecHitCaloNavigatorWithTime.h
@@ -5,6 +5,7 @@
 #include "RecoParticleFlow/PFClusterProducer/interface/PFRecHitNavigatorBase.h"
 #include "Geometry/CaloGeometry/interface/CaloSubdetectorGeometry.h"
 #include "Geometry/CaloGeometry/interface/CaloGeometry.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 
 #include "RecoCaloTools/Navigation/interface/CaloNavigator.h"
 #include "DataFormats/EcalDetId/interface/EBDetId.h"
@@ -25,7 +26,7 @@
 template <typename D, typename T, bool ownsTopo = true>
 class PFRecHitCaloNavigatorWithTime : public PFRecHitNavigatorBase {
 public:
-  PFRecHitCaloNavigatorWithTime(const edm::ParameterSet& iConfig) {
+  PFRecHitCaloNavigatorWithTime(const edm::ParameterSet& iConfig, edm::ConsumesCollector& cc) {
     sigmaCut2_ = pow(iConfig.getParameter<double>("sigmaCut"), 2);
     const edm::ParameterSet& timeResConf = iConfig.getParameterSet("timeResolutionCalc");
     _timeResolutionCalc.reset(new CaloRecHitResolutionProvider(timeResConf));

--- a/RecoParticleFlow/PFClusterProducer/interface/PFRecHitCaloNavigatorWithTime.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFRecHitCaloNavigatorWithTime.h
@@ -4,7 +4,6 @@
 
 #include <memory>
 
-
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "Geometry/CaloGeometry/interface/CaloGeometry.h"
 #include "Geometry/CaloGeometry/interface/CaloSubdetectorGeometry.h"

--- a/RecoParticleFlow/PFClusterProducer/interface/PFRecHitCreatorBase.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFRecHitCreatorBase.h
@@ -23,11 +23,11 @@
 class PFRecHitCreatorBase {
 public:
   PFRecHitCreatorBase() {}
-  PFRecHitCreatorBase(const edm::ParameterSet& iConfig, edm::ConsumesCollector& iC) {
+  PFRecHitCreatorBase(const edm::ParameterSet& iConfig, edm::ConsumesCollector& cc) {
     std::vector<edm::ParameterSet> qTests = iConfig.getParameter<std::vector<edm::ParameterSet> >("qualityTests");
     for (auto& qTest : qTests) {
       std::string name = qTest.getParameter<std::string>("name");
-      qualityTests_.emplace_back(PFRecHitQTestFactory::get()->create(name, qTest));
+      qualityTests_.emplace_back(PFRecHitQTestFactory::get()->create(name, qTest, cc));
     }
   }
   virtual ~PFRecHitCreatorBase() = default;

--- a/RecoParticleFlow/PFClusterProducer/interface/PFRecHitDualNavigator.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFRecHitDualNavigator.h
@@ -3,15 +3,16 @@
 
 #include "RecoParticleFlow/PFClusterProducer/interface/PFRecHitNavigatorBase.h"
 #include "DataFormats/ParticleFlowReco/interface/PFLayer.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 
 template <PFLayer::Layer D1, typename barrel, PFLayer::Layer D2, typename endcap>
 class PFRecHitDualNavigator : public PFRecHitNavigatorBase {
 public:
   PFRecHitDualNavigator() = default;
 
-  PFRecHitDualNavigator(const edm::ParameterSet& iConfig) {
-    barrelNav_ = new barrel(iConfig.getParameter<edm::ParameterSet>("barrel"));
-    endcapNav_ = new endcap(iConfig.getParameter<edm::ParameterSet>("endcap"));
+  PFRecHitDualNavigator(const edm::ParameterSet& iConfig, edm::ConsumesCollector& cc) {
+    barrelNav_ = new barrel(iConfig.getParameter<edm::ParameterSet>("barrel"), cc);
+    endcapNav_ = new endcap(iConfig.getParameter<edm::ParameterSet>("endcap"), cc);
   }
 
   void init(const edm::EventSetup& iSetup) override {

--- a/RecoParticleFlow/PFClusterProducer/interface/PFRecHitNavigatorBase.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFRecHitNavigatorBase.h
@@ -6,9 +6,8 @@
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
-#include "FWCore/Framework/interface/ESHandle.h"
-#include "FWCore/Framework/interface/EventSetup.h"
 #include "DataFormats/ParticleFlowReco/interface/PFRecHit.h"
 #include "DataFormats/ParticleFlowReco/interface/PFRecHitFwd.h"
 
@@ -28,7 +27,7 @@ public:
   typedef std::unordered_map<unsigned, unsigned> DetIdToHitIdx;
 
   PFRecHitNavigatorBase() = default;
-  PFRecHitNavigatorBase(const edm::ParameterSet& iConfig) {}
+  PFRecHitNavigatorBase(const edm::ParameterSet& iConfig, edm::ConsumesCollector& cc) {}
 
   virtual ~PFRecHitNavigatorBase() = default;
 
@@ -54,6 +53,6 @@ protected:
 };
 
 #include "FWCore/PluginManager/interface/PluginFactory.h"
-typedef edmplugin::PluginFactory<PFRecHitNavigatorBase*(const edm::ParameterSet&)> PFRecHitNavigationFactory;
+typedef edmplugin::PluginFactory<PFRecHitNavigatorBase*(const edm::ParameterSet&, edm::ConsumesCollector&)> PFRecHitNavigationFactory;
 
 #endif

--- a/RecoParticleFlow/PFClusterProducer/interface/PFRecHitNavigatorBase.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFRecHitNavigatorBase.h
@@ -53,6 +53,7 @@ protected:
 };
 
 #include "FWCore/PluginManager/interface/PluginFactory.h"
-typedef edmplugin::PluginFactory<PFRecHitNavigatorBase*(const edm::ParameterSet&, edm::ConsumesCollector&)> PFRecHitNavigationFactory;
+typedef edmplugin::PluginFactory<PFRecHitNavigatorBase*(const edm::ParameterSet&, edm::ConsumesCollector&)>
+    PFRecHitNavigationFactory;
 
 #endif

--- a/RecoParticleFlow/PFClusterProducer/interface/PFRecHitQTestBase.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFRecHitQTestBase.h
@@ -45,5 +45,6 @@ public:
 };
 
 #include "FWCore/PluginManager/interface/PluginFactory.h"
-typedef edmplugin::PluginFactory<PFRecHitQTestBase*(const edm::ParameterSet&, edm::ConsumesCollector&)> PFRecHitQTestFactory;
+typedef edmplugin::PluginFactory<PFRecHitQTestBase*(const edm::ParameterSet&, edm::ConsumesCollector&)>
+    PFRecHitQTestFactory;
 #endif

--- a/RecoParticleFlow/PFClusterProducer/interface/PFRecHitQTestBase.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFRecHitQTestBase.h
@@ -31,7 +31,7 @@
 class PFRecHitQTestBase {
 public:
   PFRecHitQTestBase() = default;
-  PFRecHitQTestBase(const edm::ParameterSet& iConfig) {}
+  PFRecHitQTestBase(const edm::ParameterSet& iConfig, edm::ConsumesCollector& cc) {}
   virtual ~PFRecHitQTestBase() = default;
 
   virtual void beginEvent(const edm::Event&, const edm::EventSetup&) = 0;
@@ -45,5 +45,5 @@ public:
 };
 
 #include "FWCore/PluginManager/interface/PluginFactory.h"
-typedef edmplugin::PluginFactory<PFRecHitQTestBase*(const edm::ParameterSet&)> PFRecHitQTestFactory;
+typedef edmplugin::PluginFactory<PFRecHitQTestBase*(const edm::ParameterSet&, edm::ConsumesCollector&)> PFRecHitQTestFactory;
 #endif

--- a/RecoParticleFlow/PFClusterProducer/interface/PFRecHitQTests.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFRecHitQTests.h
@@ -20,8 +20,8 @@ class PFRecHitQTestThreshold : public PFRecHitQTestBase {
 public:
   PFRecHitQTestThreshold() {}
 
-  PFRecHitQTestThreshold(const edm::ParameterSet& iConfig)
-      : PFRecHitQTestBase(iConfig), threshold_(iConfig.getParameter<double>("threshold")) {}
+  PFRecHitQTestThreshold(const edm::ParameterSet& iConfig, edm::ConsumesCollector& cc)
+      : PFRecHitQTestBase(iConfig, cc), threshold_(iConfig.getParameter<double>("threshold")) {}
 
   void beginEvent(const edm::Event& event, const edm::EventSetup& iSetup) override {}
 
@@ -50,8 +50,8 @@ class PFRecHitQTestDBThreshold : public PFRecHitQTestBase {
 public:
   PFRecHitQTestDBThreshold() : eventSetup_(nullptr) {}
 
-  PFRecHitQTestDBThreshold(const edm::ParameterSet& iConfig)
-      : PFRecHitQTestBase(iConfig),
+  PFRecHitQTestDBThreshold(const edm::ParameterSet& iConfig, edm::ConsumesCollector& cc)
+      : PFRecHitQTestBase(iConfig, cc),
         applySelectionsToAllCrystals_(iConfig.getParameter<bool>("applySelectionsToAllCrystals")),
         eventSetup_(nullptr) {}
 
@@ -91,7 +91,7 @@ class PFRecHitQTestHCALChannel : public PFRecHitQTestBase {
 public:
   PFRecHitQTestHCALChannel() {}
 
-  PFRecHitQTestHCALChannel(const edm::ParameterSet& iConfig) : PFRecHitQTestBase(iConfig) {
+  PFRecHitQTestHCALChannel(const edm::ParameterSet& iConfig, edm::ConsumesCollector& cc) : PFRecHitQTestBase(iConfig, cc) {
     thresholds_ = iConfig.getParameter<std::vector<int> >("maxSeverities");
     cleanThresholds_ = iConfig.getParameter<std::vector<double> >("cleaningThresholds");
     std::vector<std::string> flags = iConfig.getParameter<std::vector<std::string> >("flags");
@@ -194,7 +194,7 @@ class PFRecHitQTestHCALTimeVsDepth : public PFRecHitQTestBase {
 public:
   PFRecHitQTestHCALTimeVsDepth() {}
 
-  PFRecHitQTestHCALTimeVsDepth(const edm::ParameterSet& iConfig) : PFRecHitQTestBase(iConfig) {
+  PFRecHitQTestHCALTimeVsDepth(const edm::ParameterSet& iConfig, edm::ConsumesCollector& cc) : PFRecHitQTestBase(iConfig, cc) {
     std::vector<edm::ParameterSet> psets = iConfig.getParameter<std::vector<edm::ParameterSet> >("cuts");
     for (auto& pset : psets) {
       depths_.push_back(pset.getParameter<int>("depth"));
@@ -250,7 +250,7 @@ class PFRecHitQTestHCALThresholdVsDepth : public PFRecHitQTestBase {
 public:
   PFRecHitQTestHCALThresholdVsDepth() {}
 
-  PFRecHitQTestHCALThresholdVsDepth(const edm::ParameterSet& iConfig) : PFRecHitQTestBase(iConfig) {
+  PFRecHitQTestHCALThresholdVsDepth(const edm::ParameterSet& iConfig, edm::ConsumesCollector& cc) : PFRecHitQTestBase(iConfig, cc) {
     std::vector<edm::ParameterSet> psets = iConfig.getParameter<std::vector<edm::ParameterSet> >("cuts");
     for (auto& pset : psets) {
       depths_ = pset.getParameter<std::vector<int> >("depth");
@@ -308,8 +308,8 @@ class PFRecHitQTestHOThreshold : public PFRecHitQTestBase {
 public:
   PFRecHitQTestHOThreshold() : threshold0_(0.), threshold12_(0.) {}
 
-  PFRecHitQTestHOThreshold(const edm::ParameterSet& iConfig)
-      : PFRecHitQTestBase(iConfig),
+  PFRecHitQTestHOThreshold(const edm::ParameterSet& iConfig, edm::ConsumesCollector& cc)
+      : PFRecHitQTestBase(iConfig, cc),
         threshold0_(iConfig.getParameter<double>("threshold_ring0")),
         threshold12_(iConfig.getParameter<double>("threshold_ring12")) {}
 
@@ -351,8 +351,8 @@ class PFRecHitQTestECALMultiThreshold : public PFRecHitQTestBase {
 public:
   PFRecHitQTestECALMultiThreshold() {}
 
-  PFRecHitQTestECALMultiThreshold(const edm::ParameterSet& iConfig)
-      : PFRecHitQTestBase(iConfig),
+  PFRecHitQTestECALMultiThreshold(const edm::ParameterSet& iConfig, edm::ConsumesCollector& cc)
+      : PFRecHitQTestBase(iConfig, cc),
         thresholds_(iConfig.getParameter<std::vector<double> >("thresholds")),
         applySelectionsToAllCrystals_(iConfig.getParameter<bool>("applySelectionsToAllCrystals")) {
     if (thresholds_.size() != EcalRingCalibrationTools::N_RING_TOTAL)
@@ -426,8 +426,8 @@ class PFRecHitQTestECAL : public PFRecHitQTestBase {
 public:
   PFRecHitQTestECAL() {}
 
-  PFRecHitQTestECAL(const edm::ParameterSet& iConfig)
-      : PFRecHitQTestBase(iConfig),
+  PFRecHitQTestECAL(const edm::ParameterSet& iConfig, edm::ConsumesCollector& cc)
+      : PFRecHitQTestBase(iConfig, cc),
         thresholdCleaning_(iConfig.getParameter<double>("cleaningThreshold")),
         timingCleaning_(iConfig.getParameter<bool>("timingCleaning")),
         topologicalCleaning_(iConfig.getParameter<bool>("topologicalCleaning")),
@@ -477,8 +477,8 @@ class PFRecHitQTestES : public PFRecHitQTestBase {
 public:
   PFRecHitQTestES() : thresholdCleaning_(0.), topologicalCleaning_(false) {}
 
-  PFRecHitQTestES(const edm::ParameterSet& iConfig)
-      : PFRecHitQTestBase(iConfig),
+  PFRecHitQTestES(const edm::ParameterSet& iConfig, edm::ConsumesCollector& cc)
+      : PFRecHitQTestBase(iConfig, cc),
         thresholdCleaning_(iConfig.getParameter<double>("cleaningThreshold")),
         topologicalCleaning_(iConfig.getParameter<bool>("topologicalCleaning")) {}
 
@@ -524,8 +524,8 @@ class PFRecHitQTestHCALCalib29 : public PFRecHitQTestBase {
 public:
   PFRecHitQTestHCALCalib29() : calibFactor_(0.) {}
 
-  PFRecHitQTestHCALCalib29(const edm::ParameterSet& iConfig)
-      : PFRecHitQTestBase(iConfig), calibFactor_(iConfig.getParameter<double>("calibFactor")) {}
+  PFRecHitQTestHCALCalib29(const edm::ParameterSet& iConfig, edm::ConsumesCollector& cc)
+      : PFRecHitQTestBase(iConfig, cc), calibFactor_(iConfig.getParameter<double>("calibFactor")) {}
 
   void beginEvent(const edm::Event& event, const edm::EventSetup& iSetup) override {}
 
@@ -557,8 +557,8 @@ class PFRecHitQTestThresholdInMIPs : public PFRecHitQTestBase {
 public:
   PFRecHitQTestThresholdInMIPs() : recHitEnergy_keV_(false), threshold_(0.), mip_(0.), recHitEnergyMultiplier_(0.) {}
 
-  PFRecHitQTestThresholdInMIPs(const edm::ParameterSet& iConfig)
-      : PFRecHitQTestBase(iConfig),
+  PFRecHitQTestThresholdInMIPs(const edm::ParameterSet& iConfig, edm::ConsumesCollector& cc)
+      : PFRecHitQTestBase(iConfig, cc),
         recHitEnergy_keV_(iConfig.getParameter<bool>("recHitEnergyIs_keV")),
         threshold_(iConfig.getParameter<double>("thresholdInMIPs")),
         mip_(iConfig.getParameter<double>("mipValueInkeV")),
@@ -612,8 +612,8 @@ public:
   PFRecHitQTestThresholdInThicknessNormalizedMIPs()
       : geometryInstance_(""), recHitEnergy_keV_(0.), threshold_(0.), mip_(0.), recHitEnergyMultiplier_(0.) {}
 
-  PFRecHitQTestThresholdInThicknessNormalizedMIPs(const edm::ParameterSet& iConfig)
-      : PFRecHitQTestBase(iConfig),
+  PFRecHitQTestThresholdInThicknessNormalizedMIPs(const edm::ParameterSet& iConfig, edm::ConsumesCollector& cc)
+      : PFRecHitQTestBase(iConfig, cc),
         geometryInstance_(iConfig.getParameter<std::string>("geometryInstance")),
         recHitEnergy_keV_(iConfig.getParameter<bool>("recHitEnergyIs_keV")),
         threshold_(iConfig.getParameter<double>("thresholdInMIPs")),
@@ -674,8 +674,8 @@ class PFRecHitQTestHGCalThresholdSNR : public PFRecHitQTestBase {
 public:
   PFRecHitQTestHGCalThresholdSNR() : thresholdSNR_(0.) {}
 
-  PFRecHitQTestHGCalThresholdSNR(const edm::ParameterSet& iConfig)
-      : PFRecHitQTestBase(iConfig), thresholdSNR_(iConfig.getParameter<double>("thresholdSNR")) {}
+  PFRecHitQTestHGCalThresholdSNR(const edm::ParameterSet& iConfig, edm::ConsumesCollector& cc)
+      : PFRecHitQTestBase(iConfig, cc), thresholdSNR_(iConfig.getParameter<double>("thresholdSNR")) {}
 
   void beginEvent(const edm::Event& event, const edm::EventSetup& iSetup) override {}
 
@@ -714,8 +714,8 @@ protected:
 //
 class PFRecHitQTestDBSeedingThreshold : public PFRecHitQTestBase {
 public:
-  PFRecHitQTestDBSeedingThreshold(const edm::ParameterSet& iConfig)
-      : PFRecHitQTestBase(iConfig),
+  PFRecHitQTestDBSeedingThreshold(const edm::ParameterSet& iConfig, edm::ConsumesCollector& cc)
+      : PFRecHitQTestBase(iConfig, cc),
         applySelectionsToAllCrystals_(iConfig.getParameter<bool>("applySelectionsToAllCrystals")) {}
 
   void beginEvent(const edm::Event& event, const edm::EventSetup& iSetup) override {

--- a/RecoParticleFlow/PFClusterProducer/interface/PFRecHitQTests.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFRecHitQTests.h
@@ -203,7 +203,8 @@ class PFRecHitQTestHCALTimeVsDepth : public PFRecHitQTestBase {
 public:
   PFRecHitQTestHCALTimeVsDepth() {}
 
-  PFRecHitQTestHCALTimeVsDepth(const edm::ParameterSet& iConfig, edm::ConsumesCollector& cc) : PFRecHitQTestBase(iConfig, cc) {
+  PFRecHitQTestHCALTimeVsDepth(const edm::ParameterSet& iConfig, edm::ConsumesCollector& cc)
+      : PFRecHitQTestBase(iConfig, cc) {
     std::vector<edm::ParameterSet> psets = iConfig.getParameter<std::vector<edm::ParameterSet> >("cuts");
     for (auto& pset : psets) {
       depths_.push_back(pset.getParameter<int>("depth"));
@@ -259,7 +260,8 @@ class PFRecHitQTestHCALThresholdVsDepth : public PFRecHitQTestBase {
 public:
   PFRecHitQTestHCALThresholdVsDepth() {}
 
-  PFRecHitQTestHCALThresholdVsDepth(const edm::ParameterSet& iConfig, edm::ConsumesCollector& cc) : PFRecHitQTestBase(iConfig, cc) {
+  PFRecHitQTestHCALThresholdVsDepth(const edm::ParameterSet& iConfig, edm::ConsumesCollector& cc)
+      : PFRecHitQTestBase(iConfig, cc) {
     std::vector<edm::ParameterSet> psets = iConfig.getParameter<std::vector<edm::ParameterSet> >("cuts");
     for (auto& pset : psets) {
       depths_ = pset.getParameter<std::vector<int> >("depth");

--- a/RecoParticleFlow/PFClusterProducer/interface/RecHitTopologicalCleanerBase.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/RecHitTopologicalCleanerBase.h
@@ -4,6 +4,7 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "DataFormats/Common/interface/Handle.h"
 #include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "DataFormats/ParticleFlowReco/interface/PFRecHit.h"
 #include "DataFormats/ParticleFlowReco/interface/PFRecHitFwd.h"
 
@@ -11,7 +12,7 @@
 
 class RecHitTopologicalCleanerBase {
 public:
-  RecHitTopologicalCleanerBase(const edm::ParameterSet& conf) {}
+  RecHitTopologicalCleanerBase(const edm::ParameterSet& conf, edm::ConsumesCollector& cc) {}
   RecHitTopologicalCleanerBase(const RecHitTopologicalCleanerBase&) = delete;
   virtual ~RecHitTopologicalCleanerBase() = default;
   RecHitTopologicalCleanerBase& operator=(const RecHitTopologicalCleanerBase&) = delete;
@@ -26,7 +27,7 @@ private:
 };
 
 #include "FWCore/PluginManager/interface/PluginFactory.h"
-typedef edmplugin::PluginFactory<RecHitTopologicalCleanerBase*(const edm::ParameterSet&)>
+typedef edmplugin::PluginFactory<RecHitTopologicalCleanerBase*(const edm::ParameterSet&, edm::ConsumesCollector&)>
     RecHitTopologicalCleanerFactory;
 
 #endif

--- a/RecoParticleFlow/PFClusterProducer/plugins/Basic2DClusterForEachSeed.h
+++ b/RecoParticleFlow/PFClusterProducer/plugins/Basic2DClusterForEachSeed.h
@@ -6,8 +6,8 @@
 
 class Basic2DClusterForEachSeed : public InitialClusteringStepBase {
 public:
-  Basic2DClusterForEachSeed(const edm::ParameterSet& conf, edm::ConsumesCollector& sumes)
-      : InitialClusteringStepBase(conf, sumes) {}
+  Basic2DClusterForEachSeed(const edm::ParameterSet& conf, edm::ConsumesCollector& cc)
+      : InitialClusteringStepBase(conf, cc) {}
   ~Basic2DClusterForEachSeed() override = default;
 
   void buildClusters(const edm::Handle<reco::PFRecHitCollection>&,

--- a/RecoParticleFlow/PFClusterProducer/plugins/Basic2DGenericPFlowClusterizer.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/Basic2DGenericPFlowClusterizer.cc
@@ -21,7 +21,8 @@
 #define LOGDRESSED(x) LogDebug(x)
 #endif
 
-Basic2DGenericPFlowClusterizer::Basic2DGenericPFlowClusterizer(const edm::ParameterSet& conf, edm::ConsumesCollector& cc)
+Basic2DGenericPFlowClusterizer::Basic2DGenericPFlowClusterizer(const edm::ParameterSet& conf,
+                                                               edm::ConsumesCollector& cc)
     : PFClusterBuilderBase(conf, cc),
       _maxIterations(conf.getParameter<unsigned>("maxIterations")),
       _stoppingTolerance(conf.getParameter<double>("stoppingTolerance")),

--- a/RecoParticleFlow/PFClusterProducer/plugins/Basic2DGenericPFlowClusterizer.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/Basic2DGenericPFlowClusterizer.cc
@@ -21,8 +21,8 @@
 #define LOGDRESSED(x) LogDebug(x)
 #endif
 
-Basic2DGenericPFlowClusterizer::Basic2DGenericPFlowClusterizer(const edm::ParameterSet& conf)
-    : PFClusterBuilderBase(conf),
+Basic2DGenericPFlowClusterizer::Basic2DGenericPFlowClusterizer(const edm::ParameterSet& conf, edm::ConsumesCollector& sumes)
+    : PFClusterBuilderBase(conf, sumes),
       _maxIterations(conf.getParameter<unsigned>("maxIterations")),
       _stoppingTolerance(conf.getParameter<double>("stoppingTolerance")),
       _showerSigma2(std::pow(conf.getParameter<double>("showerSigma"), 2.0)),
@@ -70,13 +70,13 @@ Basic2DGenericPFlowClusterizer::Basic2DGenericPFlowClusterizer(const edm::Parame
   if (conf.exists("allCellsPositionCalc")) {
     const edm::ParameterSet& acConf = conf.getParameterSet("allCellsPositionCalc");
     const std::string& algoac = acConf.getParameter<std::string>("algoName");
-    _allCellsPosCalc = PFCPositionCalculatorFactory::get()->create(algoac, acConf);
+    _allCellsPosCalc = PFCPositionCalculatorFactory::get()->create(algoac, acConf, sumes);
   }
   // if necessary a third pos calc for convergence testing
   if (conf.exists("positionCalcForConvergence")) {
     const edm::ParameterSet& convConf = conf.getParameterSet("positionCalcForConvergence");
     const std::string& algoconv = convConf.getParameter<std::string>("algoName");
-    _convergencePosCalc = PFCPositionCalculatorFactory::get()->create(algoconv, convConf);
+    _convergencePosCalc = PFCPositionCalculatorFactory::get()->create(algoconv, convConf, sumes);
   }
 }
 

--- a/RecoParticleFlow/PFClusterProducer/plugins/Basic2DGenericPFlowClusterizer.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/Basic2DGenericPFlowClusterizer.cc
@@ -21,8 +21,8 @@
 #define LOGDRESSED(x) LogDebug(x)
 #endif
 
-Basic2DGenericPFlowClusterizer::Basic2DGenericPFlowClusterizer(const edm::ParameterSet& conf, edm::ConsumesCollector& sumes)
-    : PFClusterBuilderBase(conf, sumes),
+Basic2DGenericPFlowClusterizer::Basic2DGenericPFlowClusterizer(const edm::ParameterSet& conf, edm::ConsumesCollector& cc)
+    : PFClusterBuilderBase(conf, cc),
       _maxIterations(conf.getParameter<unsigned>("maxIterations")),
       _stoppingTolerance(conf.getParameter<double>("stoppingTolerance")),
       _showerSigma2(std::pow(conf.getParameter<double>("showerSigma"), 2.0)),
@@ -70,13 +70,13 @@ Basic2DGenericPFlowClusterizer::Basic2DGenericPFlowClusterizer(const edm::Parame
   if (conf.exists("allCellsPositionCalc")) {
     const edm::ParameterSet& acConf = conf.getParameterSet("allCellsPositionCalc");
     const std::string& algoac = acConf.getParameter<std::string>("algoName");
-    _allCellsPosCalc = PFCPositionCalculatorFactory::get()->create(algoac, acConf, sumes);
+    _allCellsPosCalc = PFCPositionCalculatorFactory::get()->create(algoac, acConf, cc);
   }
   // if necessary a third pos calc for convergence testing
   if (conf.exists("positionCalcForConvergence")) {
     const edm::ParameterSet& convConf = conf.getParameterSet("positionCalcForConvergence");
     const std::string& algoconv = convConf.getParameter<std::string>("algoName");
-    _convergencePosCalc = PFCPositionCalculatorFactory::get()->create(algoconv, convConf, sumes);
+    _convergencePosCalc = PFCPositionCalculatorFactory::get()->create(algoconv, convConf, cc);
   }
 }
 

--- a/RecoParticleFlow/PFClusterProducer/plugins/Basic2DGenericPFlowClusterizer.h
+++ b/RecoParticleFlow/PFClusterProducer/plugins/Basic2DGenericPFlowClusterizer.h
@@ -1,6 +1,7 @@
 #ifndef __Basic2DGenericPFlowClusterizer_H__
 #define __Basic2DGenericPFlowClusterizer_H__
 
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "RecoParticleFlow/PFClusterProducer/interface/PFClusterBuilderBase.h"
 #include "DataFormats/ParticleFlowReco/interface/PFRecHitFraction.h"
 
@@ -10,7 +11,7 @@ class Basic2DGenericPFlowClusterizer : public PFClusterBuilderBase {
   typedef Basic2DGenericPFlowClusterizer B2DGPF;
 
 public:
-  Basic2DGenericPFlowClusterizer(const edm::ParameterSet& conf);
+  Basic2DGenericPFlowClusterizer(const edm::ParameterSet& conf, edm::ConsumesCollector& sumes);
 
   ~Basic2DGenericPFlowClusterizer() override = default;
   Basic2DGenericPFlowClusterizer(const B2DGPF&) = delete;

--- a/RecoParticleFlow/PFClusterProducer/plugins/Basic2DGenericPFlowClusterizer.h
+++ b/RecoParticleFlow/PFClusterProducer/plugins/Basic2DGenericPFlowClusterizer.h
@@ -11,7 +11,7 @@ class Basic2DGenericPFlowClusterizer : public PFClusterBuilderBase {
   typedef Basic2DGenericPFlowClusterizer B2DGPF;
 
 public:
-  Basic2DGenericPFlowClusterizer(const edm::ParameterSet& conf, edm::ConsumesCollector& sumes);
+  Basic2DGenericPFlowClusterizer(const edm::ParameterSet& conf, edm::ConsumesCollector& cc);
 
   ~Basic2DGenericPFlowClusterizer() override = default;
   Basic2DGenericPFlowClusterizer(const B2DGPF&) = delete;

--- a/RecoParticleFlow/PFClusterProducer/plugins/Basic2DGenericPFlowPositionCalc.h
+++ b/RecoParticleFlow/PFClusterProducer/plugins/Basic2DGenericPFlowPositionCalc.h
@@ -13,8 +13,8 @@
 
 class Basic2DGenericPFlowPositionCalc : public PFCPositionCalculatorBase {
 public:
-  Basic2DGenericPFlowPositionCalc(const edm::ParameterSet& conf, edm::ConsumesCollector& sumes)
-      : PFCPositionCalculatorBase(conf, sumes),
+  Basic2DGenericPFlowPositionCalc(const edm::ParameterSet& conf, edm::ConsumesCollector& cc)
+      : PFCPositionCalculatorBase(conf, cc),
         _posCalcNCrystals(conf.getParameter<int>("posCalcNCrystals")),
         _minAllowedNorm(conf.getParameter<double>("minAllowedNormalization")) {
     std::vector<int> detectorEnum;

--- a/RecoParticleFlow/PFClusterProducer/plugins/Basic2DGenericPFlowPositionCalc.h
+++ b/RecoParticleFlow/PFClusterProducer/plugins/Basic2DGenericPFlowPositionCalc.h
@@ -4,6 +4,7 @@
 #include "RecoParticleFlow/PFClusterProducer/interface/PFCPositionCalculatorBase.h"
 #include "DataFormats/ParticleFlowReco/interface/PFRecHitFwd.h"
 #include "DataFormats/ParticleFlowReco/interface/PFRecHit.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
@@ -12,8 +13,8 @@
 
 class Basic2DGenericPFlowPositionCalc : public PFCPositionCalculatorBase {
 public:
-  Basic2DGenericPFlowPositionCalc(const edm::ParameterSet& conf)
-      : PFCPositionCalculatorBase(conf),
+  Basic2DGenericPFlowPositionCalc(const edm::ParameterSet& conf, edm::ConsumesCollector& sumes)
+      : PFCPositionCalculatorBase(conf, sumes),
         _posCalcNCrystals(conf.getParameter<int>("posCalcNCrystals")),
         _minAllowedNorm(conf.getParameter<double>("minAllowedNormalization")) {
     std::vector<int> detectorEnum;

--- a/RecoParticleFlow/PFClusterProducer/plugins/Basic2DGenericTopoClusterizer.h
+++ b/RecoParticleFlow/PFClusterProducer/plugins/Basic2DGenericTopoClusterizer.h
@@ -8,8 +8,8 @@ class Basic2DGenericTopoClusterizer : public InitialClusteringStepBase {
   typedef Basic2DGenericTopoClusterizer B2DGT;
 
 public:
-  Basic2DGenericTopoClusterizer(const edm::ParameterSet& conf, edm::ConsumesCollector& sumes)
-      : InitialClusteringStepBase(conf, sumes), _useCornerCells(conf.getParameter<bool>("useCornerCells")) {}
+  Basic2DGenericTopoClusterizer(const edm::ParameterSet& conf, edm::ConsumesCollector& cc)
+      : InitialClusteringStepBase(conf, cc), _useCornerCells(conf.getParameter<bool>("useCornerCells")) {}
   ~Basic2DGenericTopoClusterizer() override = default;
   Basic2DGenericTopoClusterizer(const B2DGT&) = delete;
   B2DGT& operator=(const B2DGT&) = delete;

--- a/RecoParticleFlow/PFClusterProducer/plugins/Cluster3DPCACalculator.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/Cluster3DPCACalculator.cc
@@ -11,6 +11,7 @@
 #include "RecoParticleFlow/PFClusterProducer/interface/PFCPositionCalculatorBase.h"
 #include "DataFormats/ParticleFlowReco/interface/PFRecHitFwd.h"
 #include "DataFormats/ParticleFlowReco/interface/PFRecHit.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 
 #include "DataFormats/ForwardDetId/interface/HGCalDetId.h"
 
@@ -18,8 +19,8 @@
 
 class Cluster3DPCACalculator : public PFCPositionCalculatorBase {
 public:
-  Cluster3DPCACalculator(const edm::ParameterSet& conf)
-      : PFCPositionCalculatorBase(conf),
+  Cluster3DPCACalculator(const edm::ParameterSet& conf, edm::ConsumesCollector& sumes)
+      : PFCPositionCalculatorBase(conf, sumes),
         updateTiming_(conf.getParameter<bool>("updateTiming")),
         pca_(new TPrincipal(3, "D")) {}
   Cluster3DPCACalculator(const Cluster3DPCACalculator&) = delete;

--- a/RecoParticleFlow/PFClusterProducer/plugins/Cluster3DPCACalculator.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/Cluster3DPCACalculator.cc
@@ -19,8 +19,8 @@
 
 class Cluster3DPCACalculator : public PFCPositionCalculatorBase {
 public:
-  Cluster3DPCACalculator(const edm::ParameterSet& conf, edm::ConsumesCollector& sumes)
-      : PFCPositionCalculatorBase(conf, sumes),
+  Cluster3DPCACalculator(const edm::ParameterSet& conf, edm::ConsumesCollector& cc)
+      : PFCPositionCalculatorBase(conf, cc),
         updateTiming_(conf.getParameter<bool>("updateTiming")),
         pca_(new TPrincipal(3, "D")) {}
   Cluster3DPCACalculator(const Cluster3DPCACalculator&) = delete;

--- a/RecoParticleFlow/PFClusterProducer/plugins/ECAL2DPositionCalcWithDepthCorr.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/ECAL2DPositionCalcWithDepthCorr.cc
@@ -16,9 +16,7 @@
 // sorry Stefano
 
 void ECAL2DPositionCalcWithDepthCorr::update(const edm::EventSetup& es) {
-  const CaloGeometryRecord& caloGeom = es.get<CaloGeometryRecord>();
-  edm::ESHandle<CaloGeometry> geohandle;
-  caloGeom.get(geohandle);
+  edm::ESHandle<CaloGeometry> geohandle = es.getHandle(_geomToken);
   _ebGeom = geohandle->getSubdetectorGeometry(DetId::Ecal, EcalBarrel);
   _eeGeom = geohandle->getSubdetectorGeometry(DetId::Ecal, EcalEndcap);
   _esGeom = geohandle->getSubdetectorGeometry(DetId::Ecal, EcalPreshower);

--- a/RecoParticleFlow/PFClusterProducer/plugins/ECAL2DPositionCalcWithDepthCorr.h
+++ b/RecoParticleFlow/PFClusterProducer/plugins/ECAL2DPositionCalcWithDepthCorr.h
@@ -1,6 +1,8 @@
 #ifndef __ECAL2DPositionCalcWithDepthCorr_H__
 #define __ECAL2DPositionCalcWithDepthCorr_H__
 
+#include <memory>
+
 #include "RecoParticleFlow/PFClusterProducer/interface/PFCPositionCalculatorBase.h"
 #include "DataFormats/ParticleFlowReco/interface/PFRecHitFwd.h"
 #include "DataFormats/ParticleFlowReco/interface/PFRecHit.h"
@@ -34,7 +36,7 @@ public:
     _timeResolutionCalc.reset(nullptr);
     if (conf.exists("timeResolutionCalc")) {
       const edm::ParameterSet& timeResConf = conf.getParameterSet("timeResolutionCalc");
-      _timeResolutionCalc.reset(new CaloRecHitResolutionProvider(timeResConf));
+      _timeResolutionCalc = std::make_unique<CaloRecHitResolutionProvider>(timeResConf);
     }
   }
   ECAL2DPositionCalcWithDepthCorr(const ECAL2DPositionCalcWithDepthCorr&) = delete;

--- a/RecoParticleFlow/PFClusterProducer/plugins/ECAL2DPositionCalcWithDepthCorr.h
+++ b/RecoParticleFlow/PFClusterProducer/plugins/ECAL2DPositionCalcWithDepthCorr.h
@@ -17,8 +17,8 @@
 /// This is EGM version of the ECAL position + depth correction calculation
 class ECAL2DPositionCalcWithDepthCorr : public PFCPositionCalculatorBase {
 public:
-  ECAL2DPositionCalcWithDepthCorr(const edm::ParameterSet& conf, edm::ConsumesCollector& sumes)
-      : PFCPositionCalculatorBase(conf, sumes),
+  ECAL2DPositionCalcWithDepthCorr(const edm::ParameterSet& conf, edm::ConsumesCollector& cc)
+      : PFCPositionCalculatorBase(conf, cc),
         _param_T0_EB(conf.getParameter<double>("T0_EB")),
         _param_T0_EE(conf.getParameter<double>("T0_EE")),
         _param_T0_ES(conf.getParameter<double>("T0_ES")),
@@ -30,7 +30,7 @@ public:
         _esGeom(nullptr),
         _esPlus(false),
         _esMinus(false),
-        _geomToken(sumes.esConsumes<edm::Transition::BeginLuminosityBlock>()) {
+        _geomToken(cc.esConsumes<edm::Transition::BeginLuminosityBlock>()) {
     _timeResolutionCalc.reset(nullptr);
     if (conf.exists("timeResolutionCalc")) {
       const edm::ParameterSet& timeResConf = conf.getParameterSet("timeResolutionCalc");

--- a/RecoParticleFlow/PFClusterProducer/plugins/ECAL2DPositionCalcWithDepthCorr.h
+++ b/RecoParticleFlow/PFClusterProducer/plugins/ECAL2DPositionCalcWithDepthCorr.h
@@ -7,6 +7,7 @@
 
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "Geometry/Records/interface/CaloGeometryRecord.h"
 #include "Geometry/CaloGeometry/interface/CaloGeometry.h"
 #include "Geometry/CaloGeometry/interface/CaloSubdetectorGeometry.h"
@@ -16,8 +17,8 @@
 /// This is EGM version of the ECAL position + depth correction calculation
 class ECAL2DPositionCalcWithDepthCorr : public PFCPositionCalculatorBase {
 public:
-  ECAL2DPositionCalcWithDepthCorr(const edm::ParameterSet& conf)
-      : PFCPositionCalculatorBase(conf),
+  ECAL2DPositionCalcWithDepthCorr(const edm::ParameterSet& conf, edm::ConsumesCollector& sumes)
+      : PFCPositionCalculatorBase(conf, sumes),
         _param_T0_EB(conf.getParameter<double>("T0_EB")),
         _param_T0_EE(conf.getParameter<double>("T0_EE")),
         _param_T0_ES(conf.getParameter<double>("T0_ES")),
@@ -28,7 +29,8 @@ public:
         _eeGeom(nullptr),
         _esGeom(nullptr),
         _esPlus(false),
-        _esMinus(false) {
+        _esMinus(false),
+        _geomToken(sumes.esConsumes<edm::Transition::BeginLuminosityBlock>()) {
     _timeResolutionCalc.reset(nullptr);
     if (conf.exists("timeResolutionCalc")) {
       const edm::ParameterSet& timeResConf = conf.getParameterSet("timeResolutionCalc");
@@ -60,6 +62,8 @@ private:
   std::unique_ptr<CaloRecHitResolutionProvider> _timeResolutionCalc;
 
   void calculateAndSetPositionActual(reco::PFCluster&) const;
+
+  edm::ESGetToken<CaloGeometry, CaloGeometryRecord> _geomToken;
 };
 
 DEFINE_EDM_PLUGIN(PFCPositionCalculatorFactory, ECAL2DPositionCalcWithDepthCorr, "ECAL2DPositionCalcWithDepthCorr");

--- a/RecoParticleFlow/PFClusterProducer/plugins/ECALPFSeedCleaner.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/ECALPFSeedCleaner.cc
@@ -1,10 +1,9 @@
 #include "ECALPFSeedCleaner.h"
 
-ECALPFSeedCleaner::ECALPFSeedCleaner(const edm::ParameterSet& conf, edm::ConsumesCollector& cc) 
-    : RecHitTopologicalCleanerBase(conf, cc),
-      thsToken_(cc.esConsumes<edm::Transition::BeginLuminosityBlock>()) {}
+ECALPFSeedCleaner::ECALPFSeedCleaner(const edm::ParameterSet& conf, edm::ConsumesCollector& cc)
+    : RecHitTopologicalCleanerBase(conf, cc), thsToken_(cc.esConsumes<edm::Transition::BeginLuminosityBlock>()) {}
 
-void ECALPFSeedCleaner::update(const edm::EventSetup& iSetup) { ths_ = iSetup.getHandle(thsToken_); } 
+void ECALPFSeedCleaner::update(const edm::EventSetup& iSetup) { ths_ = iSetup.getHandle(thsToken_); }
 
 void ECALPFSeedCleaner::clean(const edm::Handle<reco::PFRecHitCollection>& input, std::vector<bool>& mask) {
   //need to run over energy sorted rechits, as this is order used in seeding step

--- a/RecoParticleFlow/PFClusterProducer/plugins/ECALPFSeedCleaner.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/ECALPFSeedCleaner.cc
@@ -1,8 +1,10 @@
 #include "ECALPFSeedCleaner.h"
 
-ECALPFSeedCleaner::ECALPFSeedCleaner(const edm::ParameterSet& conf) : RecHitTopologicalCleanerBase(conf) {}
+ECALPFSeedCleaner::ECALPFSeedCleaner(const edm::ParameterSet& conf, edm::ConsumesCollector& cc) 
+    : RecHitTopologicalCleanerBase(conf, cc),
+      thsToken_(cc.esConsumes<edm::Transition::BeginLuminosityBlock>()) {}
 
-void ECALPFSeedCleaner::update(const edm::EventSetup& iSetup) { iSetup.get<EcalPFSeedingThresholdsRcd>().get(ths_); }
+void ECALPFSeedCleaner::update(const edm::EventSetup& iSetup) { ths_ = iSetup.getHandle(thsToken_); } 
 
 void ECALPFSeedCleaner::clean(const edm::Handle<reco::PFRecHitCollection>& input, std::vector<bool>& mask) {
   //need to run over energy sorted rechits, as this is order used in seeding step

--- a/RecoParticleFlow/PFClusterProducer/plugins/ECALPFSeedCleaner.h
+++ b/RecoParticleFlow/PFClusterProducer/plugins/ECALPFSeedCleaner.h
@@ -7,7 +7,7 @@
 
 class ECALPFSeedCleaner : public RecHitTopologicalCleanerBase {
 public:
-  ECALPFSeedCleaner(const edm::ParameterSet& conf);
+  ECALPFSeedCleaner(const edm::ParameterSet& conf, edm::ConsumesCollector& cc);
   ECALPFSeedCleaner(const ECALPFSeedCleaner&) = delete;
   ECALPFSeedCleaner& operator=(const ECALPFSeedCleaner&) = delete;
 
@@ -17,6 +17,7 @@ public:
 
 private:
   edm::ESHandle<EcalPFSeedingThresholds> ths_;
+  edm::ESGetToken<EcalPFSeedingThresholds, EcalPFSeedingThresholdsRcd> thsToken_;
 };
 
 DEFINE_EDM_PLUGIN(RecHitTopologicalCleanerFactory, ECALPFSeedCleaner, "ECALPFSeedCleaner");

--- a/RecoParticleFlow/PFClusterProducer/plugins/FlagsCleanerECAL.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/FlagsCleanerECAL.cc
@@ -2,7 +2,7 @@
 #include "CommonTools/Utils/interface/StringToEnumValue.h"
 #include "DataFormats/EcalRecHit/interface/EcalRecHit.h"
 
-FlagsCleanerECAL::FlagsCleanerECAL(const edm::ParameterSet& conf) : RecHitTopologicalCleanerBase(conf) {
+FlagsCleanerECAL::FlagsCleanerECAL(const edm::ParameterSet& conf, edm::ConsumesCollector& cc) : RecHitTopologicalCleanerBase(conf, cc) {
   const std::vector<std::string> flagnames = conf.getParameter<std::vector<std::string> >("RecHitFlagsToBeExcluded");
   v_chstatus_excl_ = StringToEnumValue<EcalRecHit::Flags>(flagnames);
 }

--- a/RecoParticleFlow/PFClusterProducer/plugins/FlagsCleanerECAL.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/FlagsCleanerECAL.cc
@@ -2,7 +2,8 @@
 #include "CommonTools/Utils/interface/StringToEnumValue.h"
 #include "DataFormats/EcalRecHit/interface/EcalRecHit.h"
 
-FlagsCleanerECAL::FlagsCleanerECAL(const edm::ParameterSet& conf, edm::ConsumesCollector& cc) : RecHitTopologicalCleanerBase(conf, cc) {
+FlagsCleanerECAL::FlagsCleanerECAL(const edm::ParameterSet& conf, edm::ConsumesCollector& cc)
+    : RecHitTopologicalCleanerBase(conf, cc) {
   const std::vector<std::string> flagnames = conf.getParameter<std::vector<std::string> >("RecHitFlagsToBeExcluded");
   v_chstatus_excl_ = StringToEnumValue<EcalRecHit::Flags>(flagnames);
 }

--- a/RecoParticleFlow/PFClusterProducer/plugins/FlagsCleanerECAL.h
+++ b/RecoParticleFlow/PFClusterProducer/plugins/FlagsCleanerECAL.h
@@ -2,10 +2,11 @@
 #define __FlagsCleanerECAL_H__
 
 #include "RecoParticleFlow/PFClusterProducer/interface/RecHitTopologicalCleanerBase.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 
 class FlagsCleanerECAL : public RecHitTopologicalCleanerBase {
 public:
-  FlagsCleanerECAL(const edm::ParameterSet& conf);
+  FlagsCleanerECAL(const edm::ParameterSet& conf, edm::ConsumesCollector& cc);
   FlagsCleanerECAL(const FlagsCleanerECAL&) = delete;
   FlagsCleanerECAL& operator=(const FlagsCleanerECAL&) = delete;
 

--- a/RecoParticleFlow/PFClusterProducer/plugins/Navigators.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/Navigators.cc
@@ -14,8 +14,8 @@
 class PFRecHitEcalBarrelNavigatorWithTime : public PFRecHitCaloNavigatorWithTime<EBDetId, EcalBarrelTopology> {
 public:
   PFRecHitEcalBarrelNavigatorWithTime(const edm::ParameterSet& iConfig, edm::ConsumesCollector& cc)
-    : PFRecHitCaloNavigatorWithTime(iConfig, cc),
-      geomToken_(cc.esConsumes<edm::Transition::BeginLuminosityBlock>()) {}
+      : PFRecHitCaloNavigatorWithTime(iConfig, cc),
+        geomToken_(cc.esConsumes<edm::Transition::BeginLuminosityBlock>()) {}
 
   void init(const edm::EventSetup& iSetup) override {
     edm::ESHandle<CaloGeometry> geoHandle = iSetup.getHandle(geomToken_);
@@ -29,8 +29,8 @@ private:
 class PFRecHitEcalEndcapNavigatorWithTime : public PFRecHitCaloNavigatorWithTime<EEDetId, EcalEndcapTopology> {
 public:
   PFRecHitEcalEndcapNavigatorWithTime(const edm::ParameterSet& iConfig, edm::ConsumesCollector& cc)
-    : PFRecHitCaloNavigatorWithTime(iConfig, cc),
-      geomToken_(cc.esConsumes<edm::Transition::BeginLuminosityBlock>()) {}
+      : PFRecHitCaloNavigatorWithTime(iConfig, cc),
+        geomToken_(cc.esConsumes<edm::Transition::BeginLuminosityBlock>()) {}
 
   void init(const edm::EventSetup& iSetup) override {
     edm::ESHandle<CaloGeometry> geoHandle = iSetup.getHandle(geomToken_);
@@ -43,7 +43,8 @@ private:
 
 class PFRecHitEcalBarrelNavigator final : public PFRecHitCaloNavigator<EBDetId, EcalBarrelTopology> {
 public:
-  PFRecHitEcalBarrelNavigator(const edm::ParameterSet& iConfig, edm::ConsumesCollector& cc) : geomToken_(cc.esConsumes<edm::Transition::BeginLuminosityBlock>()) {}
+  PFRecHitEcalBarrelNavigator(const edm::ParameterSet& iConfig, edm::ConsumesCollector& cc)
+      : geomToken_(cc.esConsumes<edm::Transition::BeginLuminosityBlock>()) {}
 
   void init(const edm::EventSetup& iSetup) override {
     edm::ESHandle<CaloGeometry> geoHandle = iSetup.getHandle(geomToken_);
@@ -56,7 +57,8 @@ private:
 
 class PFRecHitEcalEndcapNavigator final : public PFRecHitCaloNavigator<EEDetId, EcalEndcapTopology> {
 public:
-  PFRecHitEcalEndcapNavigator(const edm::ParameterSet& iConfig, edm::ConsumesCollector& cc) : geomToken_(cc.esConsumes<edm::Transition::BeginLuminosityBlock>()) {}
+  PFRecHitEcalEndcapNavigator(const edm::ParameterSet& iConfig, edm::ConsumesCollector& cc)
+      : geomToken_(cc.esConsumes<edm::Transition::BeginLuminosityBlock>()) {}
 
   void init(const edm::EventSetup& iSetup) override {
     edm::ESHandle<CaloGeometry> geoHandle = iSetup.getHandle(geomToken_);
@@ -76,12 +78,14 @@ public:
 
 class PFRecHitHCALDenseIdNavigator final : public PFHCALDenseIdNavigator<HcalDetId, HcalTopology, false> {
 public:
-  PFRecHitHCALDenseIdNavigator(const edm::ParameterSet& iConfig, edm::ConsumesCollector& cc) : PFHCALDenseIdNavigator(iConfig, cc) {}
+  PFRecHitHCALDenseIdNavigator(const edm::ParameterSet& iConfig, edm::ConsumesCollector& cc)
+      : PFHCALDenseIdNavigator(iConfig, cc) {}
 };
 
 class PFRecHitHCALNavigator : public PFRecHitCaloNavigator<HcalDetId, HcalTopology, false> {
 public:
-  PFRecHitHCALNavigator(const edm::ParameterSet& iConfig, edm::ConsumesCollector& cc) : hcalToken_(cc.esConsumes<edm::Transition::BeginLuminosityBlock>()) {}
+  PFRecHitHCALNavigator(const edm::ParameterSet& iConfig, edm::ConsumesCollector& cc)
+      : hcalToken_(cc.esConsumes<edm::Transition::BeginLuminosityBlock>()) {}
 
   void init(const edm::EventSetup& iSetup) override {
     edm::ESHandle<HcalTopology> hcalTopology = iSetup.getHandle(hcalToken_);
@@ -96,8 +100,8 @@ private:
 class PFRecHitHCALNavigatorWithTime : public PFRecHitCaloNavigatorWithTime<HcalDetId, HcalTopology, false> {
 public:
   PFRecHitHCALNavigatorWithTime(const edm::ParameterSet& iConfig, edm::ConsumesCollector& cc)
-    : PFRecHitCaloNavigatorWithTime(iConfig, cc),
-      hcalToken_(cc.esConsumes<edm::Transition::BeginLuminosityBlock>()) {}
+      : PFRecHitCaloNavigatorWithTime(iConfig, cc),
+        hcalToken_(cc.esConsumes<edm::Transition::BeginLuminosityBlock>()) {}
 
   void init(const edm::EventSetup& iSetup) override {
     edm::ESHandle<HcalTopology> hcalTopology = iSetup.getHandle(hcalToken_);
@@ -111,7 +115,8 @@ private:
 
 class PFRecHitCaloTowerNavigator : public PFRecHitCaloNavigator<CaloTowerDetId, CaloTowerTopology> {
 public:
-  PFRecHitCaloTowerNavigator(const edm::ParameterSet& iConfig, edm::ConsumesCollector& cc) : caloToken_(cc.esConsumes<edm::Transition::BeginLuminosityBlock>()) {}
+  PFRecHitCaloTowerNavigator(const edm::ParameterSet& iConfig, edm::ConsumesCollector& cc)
+      : caloToken_(cc.esConsumes<edm::Transition::BeginLuminosityBlock>()) {}
 
   void init(const edm::EventSetup& iSetup) override {
     edm::ESHandle<CaloTowerTopology> caloTowerTopology = iSetup.getHandle(caloToken_);

--- a/RecoParticleFlow/PFClusterProducer/plugins/Navigators.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/Navigators.cc
@@ -1,4 +1,5 @@
 #include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 
 #include "RecoParticleFlow/PFClusterProducer/interface/PFRecHitFakeNavigator.h"
 
@@ -12,7 +13,7 @@
 
 class PFRecHitEcalBarrelNavigatorWithTime : public PFRecHitCaloNavigatorWithTime<EBDetId, EcalBarrelTopology> {
 public:
-  PFRecHitEcalBarrelNavigatorWithTime(const edm::ParameterSet& iConfig) : PFRecHitCaloNavigatorWithTime(iConfig) {}
+  PFRecHitEcalBarrelNavigatorWithTime(const edm::ParameterSet& iConfig, edm::ConsumesCollector& cc) : PFRecHitCaloNavigatorWithTime(iConfig, cc) {}
 
   void init(const edm::EventSetup& iSetup) override {
     edm::ESHandle<CaloGeometry> geoHandle;
@@ -23,7 +24,7 @@ public:
 
 class PFRecHitEcalEndcapNavigatorWithTime : public PFRecHitCaloNavigatorWithTime<EEDetId, EcalEndcapTopology> {
 public:
-  PFRecHitEcalEndcapNavigatorWithTime(const edm::ParameterSet& iConfig) : PFRecHitCaloNavigatorWithTime(iConfig) {}
+  PFRecHitEcalEndcapNavigatorWithTime(const edm::ParameterSet& iConfig, edm::ConsumesCollector& cc) : PFRecHitCaloNavigatorWithTime(iConfig, cc) {}
 
   void init(const edm::EventSetup& iSetup) override {
     edm::ESHandle<CaloGeometry> geoHandle;
@@ -34,7 +35,7 @@ public:
 
 class PFRecHitEcalBarrelNavigator final : public PFRecHitCaloNavigator<EBDetId, EcalBarrelTopology> {
 public:
-  PFRecHitEcalBarrelNavigator(const edm::ParameterSet& iConfig) {}
+  PFRecHitEcalBarrelNavigator(const edm::ParameterSet& iConfig, edm::ConsumesCollector& cc) {}
 
   void init(const edm::EventSetup& iSetup) override {
     edm::ESHandle<CaloGeometry> geoHandle;
@@ -45,7 +46,7 @@ public:
 
 class PFRecHitEcalEndcapNavigator final : public PFRecHitCaloNavigator<EEDetId, EcalEndcapTopology> {
 public:
-  PFRecHitEcalEndcapNavigator(const edm::ParameterSet& iConfig) {}
+  PFRecHitEcalEndcapNavigator(const edm::ParameterSet& iConfig, edm::ConsumesCollector& cc) {}
 
   void init(const edm::EventSetup& iSetup) override {
     edm::ESHandle<CaloGeometry> geoHandle;
@@ -56,19 +57,19 @@ public:
 
 class PFRecHitPreshowerNavigator final : public PFRecHitCaloNavigator<ESDetId, EcalPreshowerTopology> {
 public:
-  PFRecHitPreshowerNavigator(const edm::ParameterSet& iConfig) {}
+  PFRecHitPreshowerNavigator(const edm::ParameterSet& iConfig, edm::ConsumesCollector& cc) {}
 
   void init(const edm::EventSetup& iSetup) override { topology_ = std::make_unique<EcalPreshowerTopology>(); }
 };
 
 class PFRecHitHCALDenseIdNavigator final : public PFHCALDenseIdNavigator<HcalDetId, HcalTopology, false> {
 public:
-  PFRecHitHCALDenseIdNavigator(const edm::ParameterSet& iConfig) : PFHCALDenseIdNavigator(iConfig) {}
+  PFRecHitHCALDenseIdNavigator(const edm::ParameterSet& iConfig, edm::ConsumesCollector& cc) : PFHCALDenseIdNavigator(iConfig, cc) {}
 };
 
 class PFRecHitHCALNavigator : public PFRecHitCaloNavigator<HcalDetId, HcalTopology, false> {
 public:
-  PFRecHitHCALNavigator(const edm::ParameterSet& iConfig) {}
+  PFRecHitHCALNavigator(const edm::ParameterSet& iConfig, edm::ConsumesCollector& cc) {}
 
   void init(const edm::EventSetup& iSetup) override {
     edm::ESHandle<HcalTopology> hcalTopology;
@@ -80,7 +81,7 @@ public:
 
 class PFRecHitHCALNavigatorWithTime : public PFRecHitCaloNavigatorWithTime<HcalDetId, HcalTopology, false> {
 public:
-  PFRecHitHCALNavigatorWithTime(const edm::ParameterSet& iConfig) : PFRecHitCaloNavigatorWithTime(iConfig) {}
+  PFRecHitHCALNavigatorWithTime(const edm::ParameterSet& iConfig, edm::ConsumesCollector& cc) : PFRecHitCaloNavigatorWithTime(iConfig, cc) {}
 
   void init(const edm::EventSetup& iSetup) override {
     edm::ESHandle<HcalTopology> hcalTopology;
@@ -92,7 +93,7 @@ public:
 
 class PFRecHitCaloTowerNavigator : public PFRecHitCaloNavigator<CaloTowerDetId, CaloTowerTopology> {
 public:
-  PFRecHitCaloTowerNavigator(const edm::ParameterSet& iConfig) {}
+  PFRecHitCaloTowerNavigator(const edm::ParameterSet& iConfig, edm::ConsumesCollector& cc) {}
 
   void init(const edm::EventSetup& iSetup) override {
     edm::ESHandle<CaloTowerTopology> caloTowerTopology;
@@ -120,21 +121,21 @@ typedef PFRecHitDualNavigator<PFLayer::ECAL_BARREL,
 
 class PFRecHitHGCEENavigator : public PFRecHitFakeNavigator<HGCEEDetId> {
 public:
-  PFRecHitHGCEENavigator(const edm::ParameterSet& iConfig) {}
+  PFRecHitHGCEENavigator(const edm::ParameterSet& iConfig, edm::ConsumesCollector& cc) {}
 
   void init(const edm::EventSetup& iSetup) override {}
 };
 
 class PFRecHitHGCHENavigator : public PFRecHitFakeNavigator<HGCHEDetId> {
 public:
-  PFRecHitHGCHENavigator(const edm::ParameterSet& iConfig) {}
+  PFRecHitHGCHENavigator(const edm::ParameterSet& iConfig, edm::ConsumesCollector& cc) {}
 
   void init(const edm::EventSetup& iSetup) override {}
 };
 
 class PFRecHitHGCHexNavigator : public PFRecHitFakeNavigator<HGCalDetId> {
 public:
-  PFRecHitHGCHexNavigator(const edm::ParameterSet& iConfig) {}
+  PFRecHitHGCHexNavigator(const edm::ParameterSet& iConfig, edm::ConsumesCollector& cc) {}
 
   void init(const edm::EventSetup& iSetup) override {}
 };

--- a/RecoParticleFlow/PFClusterProducer/plugins/Navigators.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/Navigators.cc
@@ -13,46 +13,58 @@
 
 class PFRecHitEcalBarrelNavigatorWithTime : public PFRecHitCaloNavigatorWithTime<EBDetId, EcalBarrelTopology> {
 public:
-  PFRecHitEcalBarrelNavigatorWithTime(const edm::ParameterSet& iConfig, edm::ConsumesCollector& cc) : PFRecHitCaloNavigatorWithTime(iConfig, cc) {}
+  PFRecHitEcalBarrelNavigatorWithTime(const edm::ParameterSet& iConfig, edm::ConsumesCollector& cc)
+    : PFRecHitCaloNavigatorWithTime(iConfig, cc),
+      geomToken_(cc.esConsumes<edm::Transition::BeginLuminosityBlock>()) {}
 
   void init(const edm::EventSetup& iSetup) override {
-    edm::ESHandle<CaloGeometry> geoHandle;
-    iSetup.get<CaloGeometryRecord>().get(geoHandle);
+    edm::ESHandle<CaloGeometry> geoHandle = iSetup.getHandle(geomToken_);
     topology_ = std::make_unique<EcalBarrelTopology>(*geoHandle);
   }
+
+private:
+  edm::ESGetToken<CaloGeometry, CaloGeometryRecord> geomToken_;
 };
 
 class PFRecHitEcalEndcapNavigatorWithTime : public PFRecHitCaloNavigatorWithTime<EEDetId, EcalEndcapTopology> {
 public:
-  PFRecHitEcalEndcapNavigatorWithTime(const edm::ParameterSet& iConfig, edm::ConsumesCollector& cc) : PFRecHitCaloNavigatorWithTime(iConfig, cc) {}
+  PFRecHitEcalEndcapNavigatorWithTime(const edm::ParameterSet& iConfig, edm::ConsumesCollector& cc)
+    : PFRecHitCaloNavigatorWithTime(iConfig, cc),
+      geomToken_(cc.esConsumes<edm::Transition::BeginLuminosityBlock>()) {}
 
   void init(const edm::EventSetup& iSetup) override {
-    edm::ESHandle<CaloGeometry> geoHandle;
-    iSetup.get<CaloGeometryRecord>().get(geoHandle);
+    edm::ESHandle<CaloGeometry> geoHandle = iSetup.getHandle(geomToken_);
     topology_ = std::make_unique<EcalEndcapTopology>(*geoHandle);
   }
+
+private:
+  edm::ESGetToken<CaloGeometry, CaloGeometryRecord> geomToken_;
 };
 
 class PFRecHitEcalBarrelNavigator final : public PFRecHitCaloNavigator<EBDetId, EcalBarrelTopology> {
 public:
-  PFRecHitEcalBarrelNavigator(const edm::ParameterSet& iConfig, edm::ConsumesCollector& cc) {}
+  PFRecHitEcalBarrelNavigator(const edm::ParameterSet& iConfig, edm::ConsumesCollector& cc) : geomToken_(cc.esConsumes<edm::Transition::BeginLuminosityBlock>()) {}
 
   void init(const edm::EventSetup& iSetup) override {
-    edm::ESHandle<CaloGeometry> geoHandle;
-    iSetup.get<CaloGeometryRecord>().get(geoHandle);
+    edm::ESHandle<CaloGeometry> geoHandle = iSetup.getHandle(geomToken_);
     topology_ = std::make_unique<EcalBarrelTopology>(*geoHandle);
   }
+
+private:
+  edm::ESGetToken<CaloGeometry, CaloGeometryRecord> geomToken_;
 };
 
 class PFRecHitEcalEndcapNavigator final : public PFRecHitCaloNavigator<EEDetId, EcalEndcapTopology> {
 public:
-  PFRecHitEcalEndcapNavigator(const edm::ParameterSet& iConfig, edm::ConsumesCollector& cc) {}
+  PFRecHitEcalEndcapNavigator(const edm::ParameterSet& iConfig, edm::ConsumesCollector& cc) : geomToken_(cc.esConsumes<edm::Transition::BeginLuminosityBlock>()) {}
 
   void init(const edm::EventSetup& iSetup) override {
-    edm::ESHandle<CaloGeometry> geoHandle;
-    iSetup.get<CaloGeometryRecord>().get(geoHandle);
+    edm::ESHandle<CaloGeometry> geoHandle = iSetup.getHandle(geomToken_);
     topology_ = std::make_unique<EcalEndcapTopology>(*geoHandle);
   }
+
+private:
+  edm::ESGetToken<CaloGeometry, CaloGeometryRecord> geomToken_;
 };
 
 class PFRecHitPreshowerNavigator final : public PFRecHitCaloNavigator<ESDetId, EcalPreshowerTopology> {
@@ -69,38 +81,46 @@ public:
 
 class PFRecHitHCALNavigator : public PFRecHitCaloNavigator<HcalDetId, HcalTopology, false> {
 public:
-  PFRecHitHCALNavigator(const edm::ParameterSet& iConfig, edm::ConsumesCollector& cc) {}
+  PFRecHitHCALNavigator(const edm::ParameterSet& iConfig, edm::ConsumesCollector& cc) : hcalToken_(cc.esConsumes<edm::Transition::BeginLuminosityBlock>()) {}
 
   void init(const edm::EventSetup& iSetup) override {
-    edm::ESHandle<HcalTopology> hcalTopology;
-    iSetup.get<HcalRecNumberingRecord>().get(hcalTopology);
+    edm::ESHandle<HcalTopology> hcalTopology = iSetup.getHandle(hcalToken_);
     topology_.release();
     topology_.reset(hcalTopology.product());
   }
+
+private:
+  edm::ESGetToken<HcalTopology, HcalRecNumberingRecord> hcalToken_;
 };
 
 class PFRecHitHCALNavigatorWithTime : public PFRecHitCaloNavigatorWithTime<HcalDetId, HcalTopology, false> {
 public:
-  PFRecHitHCALNavigatorWithTime(const edm::ParameterSet& iConfig, edm::ConsumesCollector& cc) : PFRecHitCaloNavigatorWithTime(iConfig, cc) {}
+  PFRecHitHCALNavigatorWithTime(const edm::ParameterSet& iConfig, edm::ConsumesCollector& cc)
+    : PFRecHitCaloNavigatorWithTime(iConfig, cc),
+      hcalToken_(cc.esConsumes<edm::Transition::BeginLuminosityBlock>()) {}
 
   void init(const edm::EventSetup& iSetup) override {
-    edm::ESHandle<HcalTopology> hcalTopology;
-    iSetup.get<HcalRecNumberingRecord>().get(hcalTopology);
+    edm::ESHandle<HcalTopology> hcalTopology = iSetup.getHandle(hcalToken_);
     topology_.release();
     topology_.reset(hcalTopology.product());
   }
+
+private:
+  edm::ESGetToken<HcalTopology, HcalRecNumberingRecord> hcalToken_;
 };
 
 class PFRecHitCaloTowerNavigator : public PFRecHitCaloNavigator<CaloTowerDetId, CaloTowerTopology> {
 public:
-  PFRecHitCaloTowerNavigator(const edm::ParameterSet& iConfig, edm::ConsumesCollector& cc) {}
+  PFRecHitCaloTowerNavigator(const edm::ParameterSet& iConfig, edm::ConsumesCollector& cc) : caloToken_(cc.esConsumes<edm::Transition::BeginLuminosityBlock>()) {}
 
   void init(const edm::EventSetup& iSetup) override {
-    edm::ESHandle<CaloTowerTopology> caloTowerTopology;
-    iSetup.get<HcalRecNumberingRecord>().get(caloTowerTopology);
+    edm::ESHandle<CaloTowerTopology> caloTowerTopology = iSetup.getHandle(caloToken_);
     topology_.release();
     topology_.reset(caloTowerTopology.product());
   }
+
+private:
+  edm::ESGetToken<CaloTowerTopology, HcalRecNumberingRecord> caloToken_;
 };
 
 typedef PFRecHitDualNavigator<PFLayer::ECAL_BARREL,

--- a/RecoParticleFlow/PFClusterProducer/plugins/PFBadHcalPseudoClusterProducer.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/PFBadHcalPseudoClusterProducer.cc
@@ -67,7 +67,7 @@ PFBadHcalPseudoClusterProducer::PFBadHcalPseudoClusterProducer(const edm::Parame
       debug_(ps.getUntrackedParameter<bool>("debug", false)),
       cacheId_quality_(0),
       cacheId_geom_(0),
-      hQualityToken_(esConsumes(edm::ESInputTag("", "withTopo"))), 
+      hQualityToken_(esConsumes(edm::ESInputTag("", "withTopo"))),
       hGeomToken_(esConsumes()) {
   produces<std::vector<reco::PFCluster>>();
   produces<std::vector<reco::PFRecHit>>("hits");

--- a/RecoParticleFlow/PFClusterProducer/plugins/PFBadHcalPseudoClusterProducer.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/PFBadHcalPseudoClusterProducer.cc
@@ -67,7 +67,7 @@ PFBadHcalPseudoClusterProducer::PFBadHcalPseudoClusterProducer(const edm::Parame
       debug_(ps.getUntrackedParameter<bool>("debug", false)),
       cacheId_quality_(0),
       cacheId_geom_(0),
-      hQualityToken_(esConsumes()), 
+      hQualityToken_(esConsumes(edm::ESInputTag("", "withTopo"))), 
       hGeomToken_(esConsumes()) {
   produces<std::vector<reco::PFCluster>>();
   produces<std::vector<reco::PFRecHit>>("hits");

--- a/RecoParticleFlow/PFClusterProducer/plugins/PFBadHcalPseudoClusterProducer.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/PFBadHcalPseudoClusterProducer.cc
@@ -57,13 +57,18 @@ private:
   unsigned long long cacheId_quality_, cacheId_geom_;
   std::vector<reco::PFCluster> badAreasC_;
   std::vector<reco::PFRecHit> badAreasRH_;
+
+  edm::ESGetToken<HcalChannelQuality, HcalChannelQualityRcd> hQualityToken_;
+  edm::ESGetToken<CaloGeometry, CaloGeometryRecord> hGeomToken_;
 };
 
 PFBadHcalPseudoClusterProducer::PFBadHcalPseudoClusterProducer(const edm::ParameterSet& ps)
     : enabled_(ps.getParameter<bool>("enable")),
       debug_(ps.getUntrackedParameter<bool>("debug", false)),
       cacheId_quality_(0),
-      cacheId_geom_(0) {
+      cacheId_geom_(0),
+      hQualityToken_(esConsumes()), 
+      hGeomToken_(esConsumes()) {
   produces<std::vector<reco::PFCluster>>();
   produces<std::vector<reco::PFRecHit>>("hits");
 }
@@ -74,12 +79,10 @@ void PFBadHcalPseudoClusterProducer::init(const EventSetup& iSetup) {
   badAreasC_.clear();
   badAreasRH_.clear();
 
-  edm::ESHandle<HcalChannelQuality> hQuality_;
-  iSetup.get<HcalChannelQualityRcd>().get("withTopo", hQuality_);
+  hQuality_ = iSetup.getHandle(hQualityToken_);
   const HcalChannelQuality& chanquality = *hQuality_;
 
-  edm::ESHandle<CaloGeometry> hGeom_;
-  iSetup.get<CaloGeometryRecord>().get(hGeom_);
+  hGeom_ = iSetup.getHandle(hGeomToken_);
   const CaloGeometry& caloGeom = *hGeom_;
   const CaloSubdetectorGeometry* hbGeom = caloGeom.getSubdetectorGeometry(DetId::Hcal, HcalBarrel);
   const CaloSubdetectorGeometry* heGeom = caloGeom.getSubdetectorGeometry(DetId::Hcal, HcalEndcap);

--- a/RecoParticleFlow/PFClusterProducer/plugins/PFClusterFromHGCalTrackster.h
+++ b/RecoParticleFlow/PFClusterProducer/plugins/PFClusterFromHGCalTrackster.h
@@ -12,6 +12,7 @@ public:
     filterByTracksterPID_ = conf.getParameter<bool>("filterByTracksterPID");
     pid_threshold_ = conf.getParameter<double>("pid_threshold");
     filter_on_categories_ = conf.getParameter<std::vector<int> >("filter_on_categories");
+    
     tracksterToken_ = cc.consumes<std::vector<ticl::Trackster> >(conf.getParameter<edm::InputTag>("tracksterSrc"));
     clusterToken_ =
         cc.consumes<reco::CaloClusterCollection>(conf.getParameter<edm::InputTag>("clusterSrc"));

--- a/RecoParticleFlow/PFClusterProducer/plugins/PFClusterFromHGCalTrackster.h
+++ b/RecoParticleFlow/PFClusterProducer/plugins/PFClusterFromHGCalTrackster.h
@@ -12,10 +12,9 @@ public:
     filterByTracksterPID_ = conf.getParameter<bool>("filterByTracksterPID");
     pid_threshold_ = conf.getParameter<double>("pid_threshold");
     filter_on_categories_ = conf.getParameter<std::vector<int> >("filter_on_categories");
-    
+
     tracksterToken_ = cc.consumes<std::vector<ticl::Trackster> >(conf.getParameter<edm::InputTag>("tracksterSrc"));
-    clusterToken_ =
-        cc.consumes<reco::CaloClusterCollection>(conf.getParameter<edm::InputTag>("clusterSrc"));
+    clusterToken_ = cc.consumes<reco::CaloClusterCollection>(conf.getParameter<edm::InputTag>("clusterSrc"));
   }
 
   ~PFClusterFromHGCalTrackster() override {}

--- a/RecoParticleFlow/PFClusterProducer/plugins/PFClusterFromHGCalTrackster.h
+++ b/RecoParticleFlow/PFClusterProducer/plugins/PFClusterFromHGCalTrackster.h
@@ -7,15 +7,14 @@
 
 class PFClusterFromHGCalTrackster : public InitialClusteringStepBase {
 public:
-  PFClusterFromHGCalTrackster(const edm::ParameterSet& conf, edm::ConsumesCollector& sumes)
-      : InitialClusteringStepBase(conf, sumes) {
+  PFClusterFromHGCalTrackster(const edm::ParameterSet& conf, edm::ConsumesCollector& cc)
+      : InitialClusteringStepBase(conf, cc) {
     filterByTracksterPID_ = conf.getParameter<bool>("filterByTracksterPID");
     pid_threshold_ = conf.getParameter<double>("pid_threshold");
     filter_on_categories_ = conf.getParameter<std::vector<int> >("filter_on_categories");
-
-    tracksterToken_ = sumes.consumes<std::vector<ticl::Trackster> >(conf.getParameter<edm::InputTag>("tracksterSrc"));
+    tracksterToken_ = cc.consumes<std::vector<ticl::Trackster> >(conf.getParameter<edm::InputTag>("tracksterSrc"));
     clusterToken_ =
-        sumes.consumes<reco::CaloClusterCollection>(conf.getParameter<edm::InputTag>("clusterSrc"));
+        cc.consumes<reco::CaloClusterCollection>(conf.getParameter<edm::InputTag>("clusterSrc"));
   }
 
   ~PFClusterFromHGCalTrackster() override {}

--- a/RecoParticleFlow/PFClusterProducer/plugins/PFClusterProducer.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/PFClusterProducer.cc
@@ -47,13 +47,13 @@ PFClusterProducer::PFClusterProducer(const edm::ParameterSet& conf)
   const edm::ParameterSet& pfcConf = conf.getParameterSet("pfClusterBuilder");
   if (!pfcConf.empty()) {
     const std::string& pfcName = pfcConf.getParameter<std::string>("algoName");
-    _pfClusterBuilder = PFClusterBuilderFactory::get()->create(pfcName, pfcConf);
+    _pfClusterBuilder = PFClusterBuilderFactory::get()->create(pfcName, pfcConf, sumes);
   }
   //setup (possible) recalcuation of positions
   const edm::ParameterSet& pConf = conf.getParameterSet("positionReCalc");
   if (!pConf.empty()) {
     const std::string& pName = pConf.getParameter<std::string>("algoName");
-    _positionReCalc = PFCPositionCalculatorFactory::get()->create(pName, pConf);
+    _positionReCalc = PFCPositionCalculatorFactory::get()->create(pName, pConf, sumes);
   }
   // see if new need to apply corrections, setup if there.
   const edm::ParameterSet& cConf = conf.getParameterSet("energyCorrector");

--- a/RecoParticleFlow/PFClusterProducer/plugins/PFClusterProducer.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/PFClusterProducer.cc
@@ -18,7 +18,7 @@ PFClusterProducer::PFClusterProducer(const edm::ParameterSet& conf)
     : _prodInitClusters(conf.getUntrackedParameter<bool>("prodInitialClusters", false)) {
   _rechitsLabel = consumes<reco::PFRecHitCollection>(conf.getParameter<edm::InputTag>("recHitsSource"));
   edm::ConsumesCollector cc = consumesCollector();
-  
+
   //setup rechit cleaners
   const edm::VParameterSet& cleanerConfs = conf.getParameterSetVector("recHitCleaners");
   for (const auto& conf : cleanerConfs) {

--- a/RecoParticleFlow/PFClusterProducer/plugins/PFClusterProducer.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/PFClusterProducer.cc
@@ -17,11 +17,13 @@
 PFClusterProducer::PFClusterProducer(const edm::ParameterSet& conf)
     : _prodInitClusters(conf.getUntrackedParameter<bool>("prodInitialClusters", false)) {
   _rechitsLabel = consumes<reco::PFRecHitCollection>(conf.getParameter<edm::InputTag>("recHitsSource"));
+  edm::ConsumesCollector cc = consumesCollector();
+  
   //setup rechit cleaners
   const edm::VParameterSet& cleanerConfs = conf.getParameterSetVector("recHitCleaners");
   for (const auto& conf : cleanerConfs) {
     const std::string& cleanerName = conf.getParameter<std::string>("algoName");
-    _cleaners.emplace_back(RecHitTopologicalCleanerFactory::get()->create(cleanerName, conf));
+    _cleaners.emplace_back(RecHitTopologicalCleanerFactory::get()->create(cleanerName, conf, cc));
   }
 
   if (conf.exists("seedCleaners")) {
@@ -29,11 +31,9 @@ PFClusterProducer::PFClusterProducer(const edm::ParameterSet& conf)
 
     for (const auto& conf : seedcleanerConfs) {
       const std::string& seedcleanerName = conf.getParameter<std::string>("algoName");
-      _seedcleaners.emplace_back(RecHitTopologicalCleanerFactory::get()->create(seedcleanerName, conf));
+      _seedcleaners.emplace_back(RecHitTopologicalCleanerFactory::get()->create(seedcleanerName, conf, cc));
     }
   }
-
-  edm::ConsumesCollector sumes = consumesCollector();
 
   // setup seed finding
   const edm::ParameterSet& sfConf = conf.getParameterSet("seedFinder");
@@ -42,18 +42,18 @@ PFClusterProducer::PFClusterProducer(const edm::ParameterSet& conf)
   //setup topo cluster builder
   const edm::ParameterSet& initConf = conf.getParameterSet("initialClusteringStep");
   const std::string& initName = initConf.getParameter<std::string>("algoName");
-  _initialClustering = InitialClusteringStepFactory::get()->create(initName, initConf, sumes);
+  _initialClustering = InitialClusteringStepFactory::get()->create(initName, initConf, cc);
   //setup pf cluster builder if requested
   const edm::ParameterSet& pfcConf = conf.getParameterSet("pfClusterBuilder");
   if (!pfcConf.empty()) {
     const std::string& pfcName = pfcConf.getParameter<std::string>("algoName");
-    _pfClusterBuilder = PFClusterBuilderFactory::get()->create(pfcName, pfcConf, sumes);
+    _pfClusterBuilder = PFClusterBuilderFactory::get()->create(pfcName, pfcConf, cc);
   }
   //setup (possible) recalcuation of positions
   const edm::ParameterSet& pConf = conf.getParameterSet("positionReCalc");
   if (!pConf.empty()) {
     const std::string& pName = pConf.getParameter<std::string>("algoName");
-    _positionReCalc = PFCPositionCalculatorFactory::get()->create(pName, pConf, sumes);
+    _positionReCalc = PFCPositionCalculatorFactory::get()->create(pName, pConf, cc);
   }
   // see if new need to apply corrections, setup if there.
   const edm::ParameterSet& cConf = conf.getParameterSet("energyCorrector");

--- a/RecoParticleFlow/PFClusterProducer/plugins/PFMultiDepthClusterProducer.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/PFMultiDepthClusterProducer.cc
@@ -15,9 +15,11 @@
 PFMultiDepthClusterProducer::PFMultiDepthClusterProducer(const edm::ParameterSet& conf) {
   _clustersLabel = consumes<reco::PFClusterCollection>(conf.getParameter<edm::InputTag>("clustersSource"));
   const edm::ParameterSet& pfcConf = conf.getParameterSet("pfClusterBuilder");
+
+  edm::ConsumesCollector&& sumes = consumesCollector();
   if (!pfcConf.empty()) {
     const std::string& pfcName = pfcConf.getParameter<std::string>("algoName");
-    _pfClusterBuilder = PFClusterBuilderFactory::get()->create(pfcName, pfcConf);
+    _pfClusterBuilder = PFClusterBuilderFactory::get()->create(pfcName, pfcConf, sumes);
   }
   // see if new need to apply corrections, setup if there.
   const edm::ParameterSet& cConf = conf.getParameterSet("energyCorrector");

--- a/RecoParticleFlow/PFClusterProducer/plugins/PFMultiDepthClusterProducer.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/PFMultiDepthClusterProducer.cc
@@ -16,10 +16,10 @@ PFMultiDepthClusterProducer::PFMultiDepthClusterProducer(const edm::ParameterSet
   _clustersLabel = consumes<reco::PFClusterCollection>(conf.getParameter<edm::InputTag>("clustersSource"));
   const edm::ParameterSet& pfcConf = conf.getParameterSet("pfClusterBuilder");
 
-  edm::ConsumesCollector&& sumes = consumesCollector();
+  edm::ConsumesCollector&& cc = consumesCollector();
   if (!pfcConf.empty()) {
     const std::string& pfcName = pfcConf.getParameter<std::string>("algoName");
-    _pfClusterBuilder = PFClusterBuilderFactory::get()->create(pfcName, pfcConf, sumes);
+    _pfClusterBuilder = PFClusterBuilderFactory::get()->create(pfcName, pfcConf, cc);
   }
   // see if new need to apply corrections, setup if there.
   const edm::ParameterSet& cConf = conf.getParameterSet("energyCorrector");

--- a/RecoParticleFlow/PFClusterProducer/plugins/PFMultiDepthClusterProducer.h
+++ b/RecoParticleFlow/PFClusterProducer/plugins/PFMultiDepthClusterProducer.h
@@ -7,6 +7,7 @@
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 
 #include "RecoParticleFlow/PFClusterProducer/interface/RecHitTopologicalCleanerBase.h"
 #include "RecoParticleFlow/PFClusterProducer/interface/SeedFinderBase.h"

--- a/RecoParticleFlow/PFClusterProducer/plugins/PFMultiDepthClusterizer.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/PFMultiDepthClusterizer.cc
@@ -9,11 +9,11 @@
 
 #include <iterator>
 
-PFMultiDepthClusterizer::PFMultiDepthClusterizer(const edm::ParameterSet& conf) : PFClusterBuilderBase(conf) {
+PFMultiDepthClusterizer::PFMultiDepthClusterizer(const edm::ParameterSet& conf, edm::ConsumesCollector& sumes) : PFClusterBuilderBase(conf, sumes) {
   if (conf.exists("allCellsPositionCalc")) {
     const edm::ParameterSet& acConf = conf.getParameterSet("allCellsPositionCalc");
     const std::string& algoac = acConf.getParameter<std::string>("algoName");
-    _allCellsPosCalc = PFCPositionCalculatorFactory::get()->create(algoac, acConf);
+    _allCellsPosCalc = PFCPositionCalculatorFactory::get()->create(algoac, acConf, sumes);
   }
 
   nSigmaEta_ = pow(conf.getParameter<double>("nSigmaEta"), 2);

--- a/RecoParticleFlow/PFClusterProducer/plugins/PFMultiDepthClusterizer.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/PFMultiDepthClusterizer.cc
@@ -9,7 +9,8 @@
 
 #include <iterator>
 
-PFMultiDepthClusterizer::PFMultiDepthClusterizer(const edm::ParameterSet& conf, edm::ConsumesCollector& cc) : PFClusterBuilderBase(conf, cc) {
+PFMultiDepthClusterizer::PFMultiDepthClusterizer(const edm::ParameterSet& conf, edm::ConsumesCollector& cc)
+    : PFClusterBuilderBase(conf, cc) {
   if (conf.exists("allCellsPositionCalc")) {
     const edm::ParameterSet& acConf = conf.getParameterSet("allCellsPositionCalc");
     const std::string& algoac = acConf.getParameter<std::string>("algoName");

--- a/RecoParticleFlow/PFClusterProducer/plugins/PFMultiDepthClusterizer.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/PFMultiDepthClusterizer.cc
@@ -9,11 +9,11 @@
 
 #include <iterator>
 
-PFMultiDepthClusterizer::PFMultiDepthClusterizer(const edm::ParameterSet& conf, edm::ConsumesCollector& sumes) : PFClusterBuilderBase(conf, sumes) {
+PFMultiDepthClusterizer::PFMultiDepthClusterizer(const edm::ParameterSet& conf, edm::ConsumesCollector& cc) : PFClusterBuilderBase(conf, cc) {
   if (conf.exists("allCellsPositionCalc")) {
     const edm::ParameterSet& acConf = conf.getParameterSet("allCellsPositionCalc");
     const std::string& algoac = acConf.getParameter<std::string>("algoName");
-    _allCellsPosCalc = PFCPositionCalculatorFactory::get()->create(algoac, acConf, sumes);
+    _allCellsPosCalc = PFCPositionCalculatorFactory::get()->create(algoac, acConf, cc);
   }
 
   nSigmaEta_ = pow(conf.getParameter<double>("nSigmaEta"), 2);

--- a/RecoParticleFlow/PFClusterProducer/plugins/PFMultiDepthClusterizer.h
+++ b/RecoParticleFlow/PFClusterProducer/plugins/PFMultiDepthClusterizer.h
@@ -3,6 +3,7 @@
 
 #include "RecoParticleFlow/PFClusterProducer/interface/PFClusterBuilderBase.h"
 #include "DataFormats/ParticleFlowReco/interface/PFRecHitFraction.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 
 #include <unordered_map>
 
@@ -10,7 +11,7 @@ class PFMultiDepthClusterizer final : public PFClusterBuilderBase {
   typedef PFMultiDepthClusterizer B2DGPF;
 
 public:
-  PFMultiDepthClusterizer(const edm::ParameterSet& conf);
+  PFMultiDepthClusterizer(const edm::ParameterSet& conf, edm::ConsumesCollector& sumes);
 
   ~PFMultiDepthClusterizer() override = default;
   PFMultiDepthClusterizer(const B2DGPF&) = delete;

--- a/RecoParticleFlow/PFClusterProducer/plugins/PFMultiDepthClusterizer.h
+++ b/RecoParticleFlow/PFClusterProducer/plugins/PFMultiDepthClusterizer.h
@@ -11,7 +11,7 @@ class PFMultiDepthClusterizer final : public PFClusterBuilderBase {
   typedef PFMultiDepthClusterizer B2DGPF;
 
 public:
-  PFMultiDepthClusterizer(const edm::ParameterSet& conf, edm::ConsumesCollector& sumes);
+  PFMultiDepthClusterizer(const edm::ParameterSet& conf, edm::ConsumesCollector& cc);
 
   ~PFMultiDepthClusterizer() override = default;
   PFMultiDepthClusterizer(const B2DGPF&) = delete;

--- a/RecoParticleFlow/PFClusterProducer/plugins/PFRecHitProducer.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/PFRecHitProducer.cc
@@ -12,16 +12,16 @@ PFRecHitProducer::PFRecHitProducer(const edm::ParameterSet& iConfig) {
   produces<reco::PFRecHitCollection>();
   produces<reco::PFRecHitCollection>("Cleaned");
 
-  edm::ConsumesCollector iC = consumesCollector();
+  edm::ConsumesCollector cc = consumesCollector();
 
   std::vector<edm::ParameterSet> creators = iConfig.getParameter<std::vector<edm::ParameterSet> >("producers");
   for (auto& creator : creators) {
     std::string name = creator.getParameter<std::string>("name");
-    creators_.emplace_back(PFRecHitFactory::get()->create(name, creator, iC));
+    creators_.emplace_back(PFRecHitFactory::get()->create(name, creator, cc));
   }
 
   edm::ParameterSet navSet = iConfig.getParameter<edm::ParameterSet>("navigator");
-  navigator_ = PFRecHitNavigationFactory::get()->create(navSet.getParameter<std::string>("name"), navSet);
+  navigator_ = PFRecHitNavigationFactory::get()->create(navSet.getParameter<std::string>("name"), navSet, cc);
 }
 
 PFRecHitProducer::~PFRecHitProducer() = default;

--- a/RecoParticleFlow/PFClusterProducer/plugins/PFlow2DClusterizerWithTime.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/PFlow2DClusterizerWithTime.cc
@@ -23,8 +23,8 @@
 #define LOGDRESSED(x) LogDebug(x)
 #endif
 
-PFlow2DClusterizerWithTime::PFlow2DClusterizerWithTime(const edm::ParameterSet& conf, edm::ConsumesCollector& sumes)
-    : PFClusterBuilderBase(conf, sumes),
+PFlow2DClusterizerWithTime::PFlow2DClusterizerWithTime(const edm::ParameterSet& conf, edm::ConsumesCollector& cc)
+    : PFClusterBuilderBase(conf, cc),
       _maxIterations(conf.getParameter<unsigned>("maxIterations")),
       _stoppingTolerance(conf.getParameter<double>("stoppingTolerance")),
       _showerSigma2(std::pow(conf.getParameter<double>("showerSigma"), 2.0)),
@@ -62,13 +62,13 @@ PFlow2DClusterizerWithTime::PFlow2DClusterizerWithTime(const edm::ParameterSet& 
   if (conf.exists("allCellsPositionCalc")) {
     const edm::ParameterSet& acConf = conf.getParameterSet("allCellsPositionCalc");
     const std::string& algoac = acConf.getParameter<std::string>("algoName");
-    _allCellsPosCalc = PFCPositionCalculatorFactory::get()->create(algoac, acConf, sumes);
+    _allCellsPosCalc = PFCPositionCalculatorFactory::get()->create(algoac, acConf, cc);
   }
   // if necessary a third pos calc for convergence testing
   if (conf.exists("positionCalcForConvergence")) {
     const edm::ParameterSet& convConf = conf.getParameterSet("positionCalcForConvergence");
     const std::string& algoconv = convConf.getParameter<std::string>("algoName");
-    _convergencePosCalc = PFCPositionCalculatorFactory::get()->create(algoconv, convConf, sumes);
+    _convergencePosCalc = PFCPositionCalculatorFactory::get()->create(algoconv, convConf, cc);
   }
   if (conf.exists("timeResolutionCalcBarrel")) {
     const edm::ParameterSet& timeResConf = conf.getParameterSet("timeResolutionCalcBarrel");

--- a/RecoParticleFlow/PFClusterProducer/plugins/PFlow2DClusterizerWithTime.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/PFlow2DClusterizerWithTime.cc
@@ -23,8 +23,8 @@
 #define LOGDRESSED(x) LogDebug(x)
 #endif
 
-PFlow2DClusterizerWithTime::PFlow2DClusterizerWithTime(const edm::ParameterSet& conf)
-    : PFClusterBuilderBase(conf),
+PFlow2DClusterizerWithTime::PFlow2DClusterizerWithTime(const edm::ParameterSet& conf, edm::ConsumesCollector& sumes)
+    : PFClusterBuilderBase(conf, sumes),
       _maxIterations(conf.getParameter<unsigned>("maxIterations")),
       _stoppingTolerance(conf.getParameter<double>("stoppingTolerance")),
       _showerSigma2(std::pow(conf.getParameter<double>("showerSigma"), 2.0)),
@@ -62,13 +62,13 @@ PFlow2DClusterizerWithTime::PFlow2DClusterizerWithTime(const edm::ParameterSet& 
   if (conf.exists("allCellsPositionCalc")) {
     const edm::ParameterSet& acConf = conf.getParameterSet("allCellsPositionCalc");
     const std::string& algoac = acConf.getParameter<std::string>("algoName");
-    _allCellsPosCalc = PFCPositionCalculatorFactory::get()->create(algoac, acConf);
+    _allCellsPosCalc = PFCPositionCalculatorFactory::get()->create(algoac, acConf, sumes);
   }
   // if necessary a third pos calc for convergence testing
   if (conf.exists("positionCalcForConvergence")) {
     const edm::ParameterSet& convConf = conf.getParameterSet("positionCalcForConvergence");
     const std::string& algoconv = convConf.getParameter<std::string>("algoName");
-    _convergencePosCalc = PFCPositionCalculatorFactory::get()->create(algoconv, convConf);
+    _convergencePosCalc = PFCPositionCalculatorFactory::get()->create(algoconv, convConf, sumes);
   }
   if (conf.exists("timeResolutionCalcBarrel")) {
     const edm::ParameterSet& timeResConf = conf.getParameterSet("timeResolutionCalcBarrel");

--- a/RecoParticleFlow/PFClusterProducer/plugins/PFlow2DClusterizerWithTime.h
+++ b/RecoParticleFlow/PFClusterProducer/plugins/PFlow2DClusterizerWithTime.h
@@ -13,7 +13,7 @@ class PFlow2DClusterizerWithTime : public PFClusterBuilderBase {
   typedef PFlow2DClusterizerWithTime B2DGPF;
 
 public:
-  PFlow2DClusterizerWithTime(const edm::ParameterSet& conf, edm::ConsumesCollector& sumes);
+  PFlow2DClusterizerWithTime(const edm::ParameterSet& conf, edm::ConsumesCollector& cc);
 
   ~PFlow2DClusterizerWithTime() override = default;
   PFlow2DClusterizerWithTime(const B2DGPF&) = delete;

--- a/RecoParticleFlow/PFClusterProducer/plugins/PFlow2DClusterizerWithTime.h
+++ b/RecoParticleFlow/PFClusterProducer/plugins/PFlow2DClusterizerWithTime.h
@@ -3,6 +3,7 @@
 
 #include "RecoParticleFlow/PFClusterProducer/interface/PFClusterBuilderBase.h"
 #include "DataFormats/ParticleFlowReco/interface/PFRecHitFraction.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 
 #include "RecoParticleFlow/PFClusterProducer/interface/CaloRecHitResolutionProvider.h"
 
@@ -12,7 +13,7 @@ class PFlow2DClusterizerWithTime : public PFClusterBuilderBase {
   typedef PFlow2DClusterizerWithTime B2DGPF;
 
 public:
-  PFlow2DClusterizerWithTime(const edm::ParameterSet& conf);
+  PFlow2DClusterizerWithTime(const edm::ParameterSet& conf, edm::ConsumesCollector& sumes);
 
   ~PFlow2DClusterizerWithTime() override = default;
   PFlow2DClusterizerWithTime(const B2DGPF&) = delete;

--- a/RecoParticleFlow/PFClusterProducer/plugins/RBXAndHPDCleaner.h
+++ b/RecoParticleFlow/PFClusterProducer/plugins/RBXAndHPDCleaner.h
@@ -2,12 +2,13 @@
 #define __RBXAndHPDCleaner_H__
 
 #include "RecoParticleFlow/PFClusterProducer/interface/RecHitTopologicalCleanerBase.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 
 #include <unordered_map>
 
 class RBXAndHPDCleaner : public RecHitTopologicalCleanerBase {
 public:
-  RBXAndHPDCleaner(const edm::ParameterSet& conf) : RecHitTopologicalCleanerBase(conf) {}
+  RBXAndHPDCleaner(const edm::ParameterSet& conf, edm::ConsumesCollector& cc) : RecHitTopologicalCleanerBase(conf, cc) {}
   RBXAndHPDCleaner(const RBXAndHPDCleaner&) = delete;
   RBXAndHPDCleaner& operator=(const RBXAndHPDCleaner&) = delete;
 

--- a/RecoParticleFlow/PFClusterProducer/plugins/RBXAndHPDCleaner.h
+++ b/RecoParticleFlow/PFClusterProducer/plugins/RBXAndHPDCleaner.h
@@ -8,7 +8,8 @@
 
 class RBXAndHPDCleaner : public RecHitTopologicalCleanerBase {
 public:
-  RBXAndHPDCleaner(const edm::ParameterSet& conf, edm::ConsumesCollector& cc) : RecHitTopologicalCleanerBase(conf, cc) {}
+  RBXAndHPDCleaner(const edm::ParameterSet& conf, edm::ConsumesCollector& cc)
+      : RecHitTopologicalCleanerBase(conf, cc) {}
   RBXAndHPDCleaner(const RBXAndHPDCleaner&) = delete;
   RBXAndHPDCleaner& operator=(const RBXAndHPDCleaner&) = delete;
 

--- a/RecoParticleFlow/PFClusterProducer/plugins/SimMappers/GenericSimClusterMapper.h
+++ b/RecoParticleFlow/PFClusterProducer/plugins/SimMappers/GenericSimClusterMapper.h
@@ -10,9 +10,9 @@ class GenericSimClusterMapper : public InitialClusteringStepBase {
   typedef GenericSimClusterMapper B2DGT;
 
 public:
-  GenericSimClusterMapper(const edm::ParameterSet& conf, edm::ConsumesCollector& sumes)
-      : InitialClusteringStepBase(conf, sumes) {
-    _simClusterToken = sumes.consumes<SimClusterCollection>(conf.getParameter<edm::InputTag>("simClusterSrc"));
+  GenericSimClusterMapper(const edm::ParameterSet& conf, edm::ConsumesCollector& cc)
+      : InitialClusteringStepBase(conf, cc) {
+    _simClusterToken = cc.consumes<SimClusterCollection>(conf.getParameter<edm::InputTag>("simClusterSrc"));
   }
   ~GenericSimClusterMapper() override = default;
   GenericSimClusterMapper(const B2DGT&) = delete;

--- a/RecoParticleFlow/PFClusterProducer/plugins/SimMappers/RealisticSimClusterMapper.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/SimMappers/RealisticSimClusterMapper.cc
@@ -44,8 +44,7 @@ namespace {
 void RealisticSimClusterMapper::updateEvent(const edm::Event& ev) { ev.getByToken(simClusterToken_, simClusterH_); }
 
 void RealisticSimClusterMapper::update(const edm::EventSetup& es) {
-  edm::ESHandle<CaloGeometry> geom;
-  es.get<CaloGeometryRecord>().get(geom);
+  edm::ESHandle<CaloGeometry> geom = es.getHandle(geomToken_);
   rhtools_.setGeometry(*geom);
 }
 

--- a/RecoParticleFlow/PFClusterProducer/plugins/SimMappers/RealisticSimClusterMapper.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/SimMappers/RealisticSimClusterMapper.cc
@@ -43,10 +43,7 @@ namespace {
 
 void RealisticSimClusterMapper::updateEvent(const edm::Event& ev) { ev.getByToken(simClusterToken_, simClusterH_); }
 
-void RealisticSimClusterMapper::update(const edm::EventSetup& es) {
-  edm::ESHandle<CaloGeometry> geom = es.getHandle(geomToken_);
-  rhtools_.setGeometry(*geom);
-}
+void RealisticSimClusterMapper::update(const edm::EventSetup& es) { rhtools_.setGeometry(es.getData(geomToken_)); }
 
 void RealisticSimClusterMapper::buildClusters(const edm::Handle<reco::PFRecHitCollection>& input,
                                               const std::vector<bool>& rechitMask,

--- a/RecoParticleFlow/PFClusterProducer/plugins/SimMappers/RealisticSimClusterMapper.h
+++ b/RecoParticleFlow/PFClusterProducer/plugins/SimMappers/RealisticSimClusterMapper.h
@@ -9,6 +9,11 @@
 #include "DataFormats/ParticleFlowReco/interface/PFRecHitFraction.h"
 #include "RecoLocalCalo/HGCalRecAlgos/interface/RecHitTools.h"
 
+//#include "FWCore/Framework/interface/ESHandle.h"
+//#include "FWCore/Framework/interface/EventSetup.h"
+//#include "FWCore/Framework/interface/ConsumesCollector.h"
+//#include "FWCore/ServiceRegistry/interface/Service.h"
+
 #include "SimDataFormats/CaloAnalysis/interface/SimClusterFwd.h"
 
 class RealisticSimClusterMapper : public InitialClusteringStepBase {
@@ -24,7 +29,9 @@ public:
         minNHitsforTiming_(conf.getParameter<unsigned int>("minNHitsforTiming")),
         useMCFractionsForExclEnergy_(conf.getParameter<bool>("useMCFractionsForExclEnergy")),
         calibMinEta_(conf.getParameter<double>("calibMinEta")),
-        calibMaxEta_(conf.getParameter<double>("calibMaxEta")) {
+        calibMaxEta_(conf.getParameter<double>("calibMaxEta")),
+        geomToken_(esConsumes()) {
+        //calibMaxEta_(conf.getParameter<double>("calibMaxEta")) {
     simClusterToken_ = sumes.consumes<SimClusterCollection>(conf.getParameter<edm::InputTag>("simClusterSrc"));
     hadronCalib_ = conf.getParameter<std::vector<double> >("hadronCalib");
     egammaCalib_ = conf.getParameter<std::vector<double> >("egammaCalib");
@@ -59,6 +66,8 @@ private:
 
   edm::EDGetTokenT<SimClusterCollection> simClusterToken_;
   edm::Handle<SimClusterCollection> simClusterH_;
+
+  edm::ESGetToken<CaloGeometry, CaloGeometryRecord> geomToken_;
 };
 
 DEFINE_EDM_PLUGIN(InitialClusteringStepFactory, RealisticSimClusterMapper, "RealisticSimClusterMapper");

--- a/RecoParticleFlow/PFClusterProducer/plugins/SimMappers/RealisticSimClusterMapper.h
+++ b/RecoParticleFlow/PFClusterProducer/plugins/SimMappers/RealisticSimClusterMapper.h
@@ -25,11 +25,10 @@ public:
         useMCFractionsForExclEnergy_(conf.getParameter<bool>("useMCFractionsForExclEnergy")),
         calibMinEta_(conf.getParameter<double>("calibMinEta")),
         calibMaxEta_(conf.getParameter<double>("calibMaxEta")),
-        geomToken_(cc.esConsumes<edm::Transition::BeginLuminosityBlock>()) {
-    simClusterToken_ = cc.consumes<SimClusterCollection>(conf.getParameter<edm::InputTag>("simClusterSrc"));
-    hadronCalib_ = conf.getParameter<std::vector<double> >("hadronCalib");
-    egammaCalib_ = conf.getParameter<std::vector<double> >("egammaCalib");
-  }
+        hadronCalib_(conf.getParameter<std::vector<double> >("hadronCalib")),
+        egammaCalib_(conf.getParameter<std::vector<double> >("egammaCalib")),
+        simClusterToken_(cc.consumes<SimClusterCollection>(conf.getParameter<edm::InputTag>("simClusterSrc"))),
+        geomToken_(cc.esConsumes<edm::Transition::BeginLuminosityBlock>()) {}
 
   ~RealisticSimClusterMapper() override {}
   RealisticSimClusterMapper(const RealisticSimClusterMapper&) = delete;

--- a/RecoParticleFlow/PFClusterProducer/plugins/SimMappers/RealisticSimClusterMapper.h
+++ b/RecoParticleFlow/PFClusterProducer/plugins/SimMappers/RealisticSimClusterMapper.h
@@ -9,11 +9,6 @@
 #include "DataFormats/ParticleFlowReco/interface/PFRecHitFraction.h"
 #include "RecoLocalCalo/HGCalRecAlgos/interface/RecHitTools.h"
 
-//#include "FWCore/Framework/interface/ESHandle.h"
-//#include "FWCore/Framework/interface/EventSetup.h"
-//#include "FWCore/Framework/interface/ConsumesCollector.h"
-//#include "FWCore/ServiceRegistry/interface/Service.h"
-
 #include "SimDataFormats/CaloAnalysis/interface/SimClusterFwd.h"
 
 class RealisticSimClusterMapper : public InitialClusteringStepBase {
@@ -30,8 +25,7 @@ public:
         useMCFractionsForExclEnergy_(conf.getParameter<bool>("useMCFractionsForExclEnergy")),
         calibMinEta_(conf.getParameter<double>("calibMinEta")),
         calibMaxEta_(conf.getParameter<double>("calibMaxEta")),
-        geomToken_(esConsumes()) {
-        //calibMaxEta_(conf.getParameter<double>("calibMaxEta")) {
+        geomToken_(sumes.esConsumes<edm::Transition::BeginLuminosityBlock>()) {
     simClusterToken_ = sumes.consumes<SimClusterCollection>(conf.getParameter<edm::InputTag>("simClusterSrc"));
     hadronCalib_ = conf.getParameter<std::vector<double> >("hadronCalib");
     egammaCalib_ = conf.getParameter<std::vector<double> >("egammaCalib");

--- a/RecoParticleFlow/PFClusterProducer/plugins/SimMappers/RealisticSimClusterMapper.h
+++ b/RecoParticleFlow/PFClusterProducer/plugins/SimMappers/RealisticSimClusterMapper.h
@@ -13,8 +13,8 @@
 
 class RealisticSimClusterMapper : public InitialClusteringStepBase {
 public:
-  RealisticSimClusterMapper(const edm::ParameterSet& conf, edm::ConsumesCollector& sumes)
-      : InitialClusteringStepBase(conf, sumes),
+  RealisticSimClusterMapper(const edm::ParameterSet& conf, edm::ConsumesCollector& cc)
+      : InitialClusteringStepBase(conf, cc),
         invisibleFraction_(conf.getParameter<double>("invisibleFraction")),
         exclusiveFraction_(conf.getParameter<double>("exclusiveFraction")),
         maxDistanceFilter_(conf.getParameter<bool>("maxDistanceFilter")),
@@ -25,8 +25,8 @@ public:
         useMCFractionsForExclEnergy_(conf.getParameter<bool>("useMCFractionsForExclEnergy")),
         calibMinEta_(conf.getParameter<double>("calibMinEta")),
         calibMaxEta_(conf.getParameter<double>("calibMaxEta")),
-        geomToken_(sumes.esConsumes<edm::Transition::BeginLuminosityBlock>()) {
-    simClusterToken_ = sumes.consumes<SimClusterCollection>(conf.getParameter<edm::InputTag>("simClusterSrc"));
+        geomToken_(cc.esConsumes<edm::Transition::BeginLuminosityBlock>()) {
+    simClusterToken_ = cc.consumes<SimClusterCollection>(conf.getParameter<edm::InputTag>("simClusterSrc"));
     hadronCalib_ = conf.getParameter<std::vector<double> >("hadronCalib");
     egammaCalib_ = conf.getParameter<std::vector<double> >("egammaCalib");
   }

--- a/RecoParticleFlow/PFClusterProducer/plugins/SpikeAndDoubleSpikeCleaner.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/SpikeAndDoubleSpikeCleaner.cc
@@ -66,8 +66,8 @@ namespace {
   }
 }  // namespace
 
-SpikeAndDoubleSpikeCleaner::SpikeAndDoubleSpikeCleaner(const edm::ParameterSet& conf)
-    : RecHitTopologicalCleanerBase(conf),
+SpikeAndDoubleSpikeCleaner::SpikeAndDoubleSpikeCleaner(const edm::ParameterSet& conf, edm::ConsumesCollector& cc)
+    : RecHitTopologicalCleanerBase(conf, cc),
       _layerMap({{"PS2", (int)PFLayer::PS2},
                  {"PS1", (int)PFLayer::PS1},
                  {"ECAL_ENDCAP", (int)PFLayer::ECAL_ENDCAP},

--- a/RecoParticleFlow/PFClusterProducer/plugins/SpikeAndDoubleSpikeCleaner.h
+++ b/RecoParticleFlow/PFClusterProducer/plugins/SpikeAndDoubleSpikeCleaner.h
@@ -3,6 +3,7 @@
 
 #include "RecoParticleFlow/PFClusterProducer/interface/RecHitTopologicalCleanerBase.h"
 #include "DataFormats/HcalRecHit/interface/HFRecHit.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 
 #include <unordered_map>
 
@@ -18,7 +19,7 @@ public:
     double _doubleSpikeThresh;
   };
 
-  SpikeAndDoubleSpikeCleaner(const edm::ParameterSet& conf);
+  SpikeAndDoubleSpikeCleaner(const edm::ParameterSet& conf, edm::ConsumesCollector& cc);
   SpikeAndDoubleSpikeCleaner(const SpikeAndDoubleSpikeCleaner&) = delete;
   SpikeAndDoubleSpikeCleaner& operator=(const SpikeAndDoubleSpikeCleaner&) = delete;
 

--- a/RecoParticleFlow/PFClusterProducer/src/PFClusterEMEnergyCorrector.cc
+++ b/RecoParticleFlow/PFClusterProducer/src/PFClusterEMEnergyCorrector.cc
@@ -126,6 +126,20 @@ PFClusterEMEnergyCorrector::PFClusterEMEnergyCorrector(const edm::ParameterSet &
                                "ecalPFClusterCor2017V2_EE_Full_ptbin1_sigma_25ns",
                                "ecalPFClusterCor2017V2_EE_Full_ptbin2_sigma_25ns",
                                "ecalPFClusterCor2017V2_EE_Full_ptbin3_sigma_25ns"});
+
+      for (short i = 0; i < (short)condnames_mean_.size(); i++) {
+        forestMeanTokens_25ns_.emplace_back(cc.esConsumes(edm::ESInputTag("", condnames_mean_[i])));
+        forestSigmaTokens_25ns_.emplace_back(cc.esConsumes(edm::ESInputTag("", condnames_sigma_[i])));
+      }
+    } else {
+      for (short i = 0; i < (short)condnames_mean_25ns_.size(); i++) {
+        forestMeanTokens_25ns_.emplace_back(cc.esConsumes(edm::ESInputTag("", condnames_mean_25ns_[i])));
+        forestSigmaTokens_25ns_.emplace_back(cc.esConsumes(edm::ESInputTag("", condnames_sigma_25ns_[i])));
+      }
+      for (short i = 0; i < (short)condnames_mean_50ns_.size(); i++) {
+        forestMeanTokens_50ns_.emplace_back(cc.esConsumes(edm::ESInputTag("", condnames_mean_50ns_[i])));
+        forestSigmaTokens_50ns_.emplace_back(cc.esConsumes(edm::ESInputTag("", condnames_sigma_50ns_[i])));
+      }
     }
   }
 }
@@ -164,15 +178,21 @@ void PFClusterEMEnergyCorrector::correctEnergies(const edm::Event &evt,
     }
 
     const std::vector<std::string> &condnames_mean = (bunchspacing == 25) ? condnames_mean_25ns_ : condnames_mean_50ns_;
-    const std::vector<std::string> &condnames_sigma =
-        (bunchspacing == 25) ? condnames_sigma_25ns_ : condnames_sigma_50ns_;
     const unsigned int ncor = condnames_mean.size();
+
     std::vector<edm::ESHandle<GBRForestD> > forestH_mean(ncor);
     std::vector<edm::ESHandle<GBRForestD> > forestH_sigma(ncor);
 
-    for (unsigned int icor = 0; icor < ncor; ++icor) {
-      es.get<GBRDWrapperRcd>().get(condnames_mean[icor], forestH_mean[icor]);
-      es.get<GBRDWrapperRcd>().get(condnames_sigma[icor], forestH_sigma[icor]);
+    if (bunchspacing == 25) {
+      for (unsigned int icor = 0; icor < ncor; ++icor) {
+        forestH_mean[icor] = es.getHandle(forestMeanTokens_25ns_[icor]);
+        forestH_sigma[icor] = es.getHandle(forestSigmaTokens_25ns_[icor]);
+      }
+    } else {
+      for (unsigned int icor = 0; icor < ncor; ++icor) {
+        forestH_mean[icor] = es.getHandle(forestMeanTokens_50ns_[icor]);
+        forestH_sigma[icor] = es.getHandle(forestSigmaTokens_50ns_[icor]);
+      }
     }
 
     std::array<float, 5> eval;
@@ -263,14 +283,13 @@ void PFClusterEMEnergyCorrector::correctEnergies(const edm::Event &evt,
     throw cms::Exception("PFClusterEMEnergyCorrector")
         << "This version of PFCluster corrections requires the SrFlagCollection information to proceed!\n";
 
-  const unsigned int ncor = condnames_mean_.size();
-
+  const unsigned int ncor = forestMeanTokens_25ns_.size();
   std::vector<edm::ESHandle<GBRForestD> > forestH_mean(ncor);
   std::vector<edm::ESHandle<GBRForestD> > forestH_sigma(ncor);
 
   for (unsigned int icor = 0; icor < ncor; ++icor) {
-    es.get<GBRDWrapperRcd>().get(condnames_mean_[icor], forestH_mean[icor]);
-    es.get<GBRDWrapperRcd>().get(condnames_sigma_[icor], forestH_sigma[icor]);
+    forestH_mean[icor] = es.getHandle(forestMeanTokens_25ns_[icor]);
+    forestH_sigma[icor] = es.getHandle(forestSigmaTokens_25ns_[icor]);
   }
 
   std::array<float, 6> evalEB;

--- a/RecoParticleFlow/PFClusterProducer/src/PFClusterEMEnergyCorrector.cc
+++ b/RecoParticleFlow/PFClusterProducer/src/PFClusterEMEnergyCorrector.cc
@@ -177,8 +177,7 @@ void PFClusterEMEnergyCorrector::correctEnergies(const edm::Event &evt,
       bunchspacing = bunchSpacingManual_;
     }
 
-    const std::vector<std::string> &condnames_mean = (bunchspacing == 25) ? condnames_mean_25ns_ : condnames_mean_50ns_;
-    const unsigned int ncor = condnames_mean.size();
+    const unsigned int ncor = (bunchspacing == 25) ? condnames_mean_25ns_.size() : condnames_mean_50ns_.size();
 
     std::vector<edm::ESHandle<GBRForestD> > forestH_mean(ncor);
     std::vector<edm::ESHandle<GBRForestD> > forestH_sigma(ncor);

--- a/RecoParticleFlow/PFClusterTools/test/ProducePFCalibrationObject.cc
+++ b/RecoParticleFlow/PFClusterTools/test/ProducePFCalibrationObject.cc
@@ -10,21 +10,20 @@
 
 #include <iostream>
 #include <vector>
-#include "CondFormats/PhysicsToolsObjects/interface/PerformancePayloadFromTFormula.h"
+//#include "CondFormats/PhysicsToolsObjects/interface/PerformancePayloadFromTFormula.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "CondCore/DBOutputService/interface/PoolDBOutputService.h"
 
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 
-#include "CondFormats/DataRecord/interface/PFCalibrationRcd.h"
-
 #include "TF1.h"
 
 using namespace std;
 using namespace edm;
 
-ProducePFCalibrationObject::ProducePFCalibrationObject(const edm::ParameterSet& pSet) {
+ProducePFCalibrationObject::ProducePFCalibrationObject(const edm::ParameterSet& pSet) 
+    : perfToken(esConsumes<edm::Transition::BeginRun>()) {
   read = pSet.getUntrackedParameter<bool>("read");
   write = pSet.getUntrackedParameter<bool>("write");
 
@@ -117,8 +116,10 @@ void ProducePFCalibrationObject::beginRun(const edm::Run& run, const edm::EventS
   if (read) {
     // ---------------------------------------------------------------------------------
     // Read the objects
-    edm::ESHandle<PerformancePayload> perfH;
-    eSetup.get<PFCalibrationRcd>().get(perfH);
+    auto perfH = eSetup.getHandle(perfToken); 
+    
+    //edm::ESHandle<PerformancePayload> perfH;
+    //eSetup.get<PFCalibrationRcd>().get(perfH);
 
     const PerformancePayloadFromTFormula* pfCalibrations =
         static_cast<const PerformancePayloadFromTFormula*>(perfH.product());

--- a/RecoParticleFlow/PFClusterTools/test/ProducePFCalibrationObject.cc
+++ b/RecoParticleFlow/PFClusterTools/test/ProducePFCalibrationObject.cc
@@ -10,7 +10,6 @@
 
 #include <iostream>
 #include <vector>
-//#include "CondFormats/PhysicsToolsObjects/interface/PerformancePayloadFromTFormula.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "CondCore/DBOutputService/interface/PoolDBOutputService.h"
 
@@ -23,17 +22,14 @@ using namespace std;
 using namespace edm;
 
 ProducePFCalibrationObject::ProducePFCalibrationObject(const edm::ParameterSet& pSet)
-    : perfToken(esConsumes<edm::Transition::BeginRun>()) {
-  read = pSet.getUntrackedParameter<bool>("read");
-  write = pSet.getUntrackedParameter<bool>("write");
-
-  fToWrite = pSet.getParameter<vector<ParameterSet> >("toWrite");
-  fToRead = pSet.getUntrackedParameter<vector<string> >("toRead");
-}
+    : read(pSet.getUntrackedParameter<bool>("read")),
+      write(pSet.getUntrackedParameter<bool>("write")),
+      fToWrite(pSet.getParameter<vector<ParameterSet> >("toWrite")),
+      fToRead(pSet.getUntrackedParameter<vector<string> >("toRead")),
+      perfToken(esConsumes<edm::Transition::BeginRun>()) {}
 
 ProducePFCalibrationObject::~ProducePFCalibrationObject() {}
 
-// void ProducePFCalibrationObject::beginJob() {
 void ProducePFCalibrationObject::beginRun(const edm::Run& run, const edm::EventSetup& eSetup) {
   cout << "[ProducePFCalibrationObject] beginJob" << endl;
 
@@ -116,13 +112,8 @@ void ProducePFCalibrationObject::beginRun(const edm::Run& run, const edm::EventS
   if (read) {
     // ---------------------------------------------------------------------------------
     // Read the objects
-    auto perfH = eSetup.getHandle(perfToken);
-
-    //edm::ESHandle<PerformancePayload> perfH;
-    //eSetup.get<PFCalibrationRcd>().get(perfH);
-
     const PerformancePayloadFromTFormula* pfCalibrations =
-        static_cast<const PerformancePayloadFromTFormula*>(perfH.product());
+        static_cast<const PerformancePayloadFromTFormula*>(&eSetup.getData(perfToken));
 
     for (vector<string>::const_iterator name = fToRead.begin(); name != fToRead.end(); ++name) {
       cout << "Function: " << *name << endl;

--- a/RecoParticleFlow/PFClusterTools/test/ProducePFCalibrationObject.cc
+++ b/RecoParticleFlow/PFClusterTools/test/ProducePFCalibrationObject.cc
@@ -22,7 +22,7 @@
 using namespace std;
 using namespace edm;
 
-ProducePFCalibrationObject::ProducePFCalibrationObject(const edm::ParameterSet& pSet) 
+ProducePFCalibrationObject::ProducePFCalibrationObject(const edm::ParameterSet& pSet)
     : perfToken(esConsumes<edm::Transition::BeginRun>()) {
   read = pSet.getUntrackedParameter<bool>("read");
   write = pSet.getUntrackedParameter<bool>("write");
@@ -116,8 +116,8 @@ void ProducePFCalibrationObject::beginRun(const edm::Run& run, const edm::EventS
   if (read) {
     // ---------------------------------------------------------------------------------
     // Read the objects
-    auto perfH = eSetup.getHandle(perfToken); 
-    
+    auto perfH = eSetup.getHandle(perfToken);
+
     //edm::ESHandle<PerformancePayload> perfH;
     //eSetup.get<PFCalibrationRcd>().get(perfH);
 

--- a/RecoParticleFlow/PFClusterTools/test/ProducePFCalibrationObject.h
+++ b/RecoParticleFlow/PFClusterTools/test/ProducePFCalibrationObject.h
@@ -12,6 +12,8 @@
 
 #include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "CondFormats/PhysicsToolsObjects/interface/PerformancePayloadFromTFormula.h"
+#include "CondFormats/DataRecord/interface/PFCalibrationRcd.h"
 
 #include <vector>
 #include <string>
@@ -38,5 +40,7 @@ private:
 
   std::vector<edm::ParameterSet> fToWrite;
   std::vector<std::string> fToRead;
+
+  const edm::ESGetToken<PerformancePayload, PFCalibrationRcd> perfToken;
 };
 #endif

--- a/RecoParticleFlow/PFProducer/interface/BlockElementImporterBase.h
+++ b/RecoParticleFlow/PFProducer/interface/BlockElementImporterBase.h
@@ -14,7 +14,7 @@
 class BlockElementImporterBase {
 public:
   typedef std::vector<std::unique_ptr<reco::PFBlockElement> > ElementList;
-  BlockElementImporterBase(const edm::ParameterSet& conf, edm::ConsumesCollector& sumes)
+  BlockElementImporterBase(const edm::ParameterSet& conf, edm::ConsumesCollector& cc)
       : _importerName(conf.getParameter<std::string>("importerName")) {}
   BlockElementImporterBase(const BlockElementImporterBase&) = delete;
   virtual ~BlockElementImporterBase() = default;

--- a/RecoParticleFlow/PFProducer/plugins/PFBlockProducer.cc
+++ b/RecoParticleFlow/PFProducer/plugins/PFBlockProducer.cc
@@ -45,9 +45,9 @@ PFBlockProducer::PFBlockProducer(const edm::ParameterSet& iConfig)
   bool debug_ = iConfig.getUntrackedParameter<bool>("debug", false);
   pfBlockAlgo_.setDebug(debug_);
 
-  edm::ConsumesCollector coll = consumesCollector();
+  edm::ConsumesCollector cc = consumesCollector();
   const std::vector<edm::ParameterSet>& importers = iConfig.getParameterSetVector("elementImporters");
-  pfBlockAlgo_.setImporters(importers, coll);
+  pfBlockAlgo_.setImporters(importers, cc);
 
   const std::vector<edm::ParameterSet>& linkdefs = iConfig.getParameterSetVector("linkDefinitions");
   pfBlockAlgo_.setLinkers(linkdefs);

--- a/RecoParticleFlow/PFProducer/plugins/PFEGammaProducer.cc
+++ b/RecoParticleFlow/PFProducer/plugins/PFEGammaProducer.cc
@@ -59,7 +59,7 @@ private:
   /// particle flow algorithm configuration
   const PFEGammaAlgo::PFEGConfigInfo pfEGConfigInfo_;
   const PFEGammaAlgo::GBRForests gbrForests_;
-  
+
   const edm::ESGetToken<ESEEIntercalibConstants, ESEEIntercalibConstantsRcd> esEEInterCalibToken_;
   const edm::ESGetToken<ESChannelStatus, ESChannelStatusRcd> esChannelStatusToken_;
 };
@@ -106,7 +106,7 @@ void PFEGammaProducer::produce(edm::StreamID, edm::Event& iEvent, const edm::Eve
 
   // preshower conditions
   auto esEEInterCalibHandle_ = iSetup.getHandle(esEEInterCalibToken_);
-  auto esChannelStatusHandle_ = iSetup.getHandle(esChannelStatusToken_);;
+  auto esChannelStatusHandle_ = iSetup.getHandle(esChannelStatusToken_);
 
   //Assign the PFAlgo Parameters
   auto const& primaryVertices = iEvent.get(vertices_);

--- a/RecoParticleFlow/PFProducer/plugins/PFEGammaProducer.cc
+++ b/RecoParticleFlow/PFProducer/plugins/PFEGammaProducer.cc
@@ -59,6 +59,9 @@ private:
   /// particle flow algorithm configuration
   const PFEGammaAlgo::PFEGConfigInfo pfEGConfigInfo_;
   const PFEGammaAlgo::GBRForests gbrForests_;
+  
+  const edm::ESGetToken<ESEEIntercalibConstants, ESEEIntercalibConstantsRcd> esEEInterCalibToken_;
+  const edm::ESGetToken<ESChannelStatus, ESChannelStatusRcd> esChannelStatusToken_;
 };
 
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -88,7 +91,9 @@ PFEGammaProducer::PFEGammaProducer(const edm::ParameterSet& iConfig)
       },
       gbrForests_{
           iConfig,
-      } {}
+      },
+      esEEInterCalibToken_(esConsumes()),
+      esChannelStatusToken_(esConsumes()) {}
 
 void PFEGammaProducer::produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const {
   LOGDRESSED("PFEGammaProducer") << "START event: " << iEvent.id().event() << " in run " << iEvent.id().run()
@@ -100,11 +105,8 @@ void PFEGammaProducer::produce(edm::StreamID, edm::Event& iEvent, const edm::Eve
   reco::SuperClusterCollection sClusters{};
 
   // preshower conditions
-  edm::ESHandle<ESEEIntercalibConstants> esEEInterCalibHandle_;
-  iSetup.get<ESEEIntercalibConstantsRcd>().get(esEEInterCalibHandle_);
-
-  edm::ESHandle<ESChannelStatus> esChannelStatusHandle_;
-  iSetup.get<ESChannelStatusRcd>().get(esChannelStatusHandle_);
+  auto esEEInterCalibHandle_ = iSetup.getHandle(esEEInterCalibToken_);
+  auto esChannelStatusHandle_ = iSetup.getHandle(esChannelStatusToken_);;
 
   //Assign the PFAlgo Parameters
   auto const& primaryVertices = iEvent.get(vertices_);

--- a/RecoParticleFlow/PFProducer/plugins/importers/EGPhotonImporter.cc
+++ b/RecoParticleFlow/PFProducer/plugins/importers/EGPhotonImporter.cc
@@ -28,9 +28,9 @@ private:
 
 DEFINE_EDM_PLUGIN(BlockElementImporterFactory, EGPhotonImporter, "EGPhotonImporter");
 
-EGPhotonImporter::EGPhotonImporter(const edm::ParameterSet& conf, edm::ConsumesCollector& sumes)
-    : BlockElementImporterBase(conf, sumes),
-      _src(sumes.consumes<reco::PhotonCollection>(conf.getParameter<edm::InputTag>("source"))),
+EGPhotonImporter::EGPhotonImporter(const edm::ParameterSet& conf, edm::ConsumesCollector& cc)
+    : BlockElementImporterBase(conf, cc),
+      _src(cc.consumes<reco::PhotonCollection>(conf.getParameter<edm::InputTag>("source"))),
       _selectionTypes({{"SeparateDetectorIso", EGPhotonImporter::SeparateDetectorIso},
                        {"CombinedDetectorIso", EGPhotonImporter::CombinedDetectorIso}}),
       _superClustersArePF(conf.getParameter<bool>("superClustersArePF")) {

--- a/RecoParticleFlow/PFProducer/plugins/importers/GSFTrackImporter.cc
+++ b/RecoParticleFlow/PFProducer/plugins/importers/GSFTrackImporter.cc
@@ -10,9 +10,9 @@
 
 class GSFTrackImporter : public BlockElementImporterBase {
 public:
-  GSFTrackImporter(const edm::ParameterSet& conf, edm::ConsumesCollector& sumes)
-      : BlockElementImporterBase(conf, sumes),
-        _src(sumes.consumes<reco::GsfPFRecTrackCollection>(conf.getParameter<edm::InputTag>("source"))),
+  GSFTrackImporter(const edm::ParameterSet& conf, edm::ConsumesCollector& cc)
+      : BlockElementImporterBase(conf, cc),
+        _src(cc.consumes<reco::GsfPFRecTrackCollection>(conf.getParameter<edm::InputTag>("source"))),
         _isSecondary(conf.getParameter<bool>("gsfsAreSecondary")),
         _superClustersArePF(conf.getParameter<bool>("superClustersArePF")) {}
 

--- a/RecoParticleFlow/PFProducer/plugins/importers/GeneralTracksImporter.cc
+++ b/RecoParticleFlow/PFProducer/plugins/importers/GeneralTracksImporter.cc
@@ -34,8 +34,7 @@ public:
           tracksSrc_ = cc.consumes<reco::TrackCollection>(conf.getParameter<edm::InputTag>("tracksSrc"));
           break;
         case pfCandidateCollection:
-          vetoPFCandidatesSrc_ =
-              cc.consumes<reco::PFCandidateCollection>(conf.getParameter<edm::InputTag>("vetoSrc"));
+          vetoPFCandidatesSrc_ = cc.consumes<reco::PFCandidateCollection>(conf.getParameter<edm::InputTag>("vetoSrc"));
           break;
       }  // switch
     }

--- a/RecoParticleFlow/PFProducer/plugins/importers/GeneralTracksImporter.cc
+++ b/RecoParticleFlow/PFProducer/plugins/importers/GeneralTracksImporter.cc
@@ -11,11 +11,11 @@
 
 class GeneralTracksImporter : public BlockElementImporterBase {
 public:
-  GeneralTracksImporter(const edm::ParameterSet& conf, edm::ConsumesCollector& sumes)
-      : BlockElementImporterBase(conf, sumes),
-        src_(sumes.consumes<reco::PFRecTrackCollection>(conf.getParameter<edm::InputTag>("source"))),
+  GeneralTracksImporter(const edm::ParameterSet& conf, edm::ConsumesCollector& cc)
+      : BlockElementImporterBase(conf, cc),
+        src_(cc.consumes<reco::PFRecTrackCollection>(conf.getParameter<edm::InputTag>("source"))),
         vetoEndcap_(conf.getParameter<bool>("vetoEndcap")),
-        muons_(sumes.consumes<reco::MuonCollection>(conf.getParameter<edm::InputTag>("muonSrc"))),
+        muons_(cc.consumes<reco::MuonCollection>(conf.getParameter<edm::InputTag>("muonSrc"))),
         trackQuality_(reco::TrackBase::qualityByName(conf.getParameter<std::string>("trackQuality"))),
         DPtovPtCut_(conf.getParameter<std::vector<double>>("DPtOverPtCuts_byTrackAlgo")),
         NHitCut_(conf.getParameter<std::vector<unsigned>>("NHitCuts_byTrackAlgo")),
@@ -26,16 +26,16 @@ public:
       vetoMode_ = conf.getParameter<unsigned>("vetoMode");
       switch (vetoMode_) {
         case pfRecTrackCollection:
-          vetoPFTracksSrc_ = sumes.consumes<reco::PFRecTrackCollection>(conf.getParameter<edm::InputTag>("vetoSrc"));
+          vetoPFTracksSrc_ = cc.consumes<reco::PFRecTrackCollection>(conf.getParameter<edm::InputTag>("vetoSrc"));
           break;
         case ticlSeedingRegion:
           vetoTICLSeedingSrc_ =
-              sumes.consumes<std::vector<TICLSeedingRegion>>(conf.getParameter<edm::InputTag>("vetoSrc"));
-          tracksSrc_ = sumes.consumes<reco::TrackCollection>(conf.getParameter<edm::InputTag>("tracksSrc"));
+              cc.consumes<std::vector<TICLSeedingRegion>>(conf.getParameter<edm::InputTag>("vetoSrc"));
+          tracksSrc_ = cc.consumes<reco::TrackCollection>(conf.getParameter<edm::InputTag>("tracksSrc"));
           break;
         case pfCandidateCollection:
           vetoPFCandidatesSrc_ =
-              sumes.consumes<reco::PFCandidateCollection>(conf.getParameter<edm::InputTag>("vetoSrc"));
+              cc.consumes<reco::PFCandidateCollection>(conf.getParameter<edm::InputTag>("vetoSrc"));
           break;
       }  // switch
     }

--- a/RecoParticleFlow/PFProducer/plugins/importers/GenericClusterImporter.cc
+++ b/RecoParticleFlow/PFProducer/plugins/importers/GenericClusterImporter.cc
@@ -4,9 +4,9 @@
 
 class GenericClusterImporter : public BlockElementImporterBase {
 public:
-  GenericClusterImporter(const edm::ParameterSet& conf, edm::ConsumesCollector& sumes)
-      : BlockElementImporterBase(conf, sumes),
-        _src(sumes.consumes<reco::PFClusterCollection>(conf.getParameter<edm::InputTag>("source"))) {}
+  GenericClusterImporter(const edm::ParameterSet& conf, edm::ConsumesCollector& cc)
+      : BlockElementImporterBase(conf, cc),
+        _src(cc.consumes<reco::PFClusterCollection>(conf.getParameter<edm::InputTag>("source"))) {}
 
   void importToBlock(const edm::Event&, ElementList&) const override;
 

--- a/RecoParticleFlow/PFProducer/plugins/importers/SpecialClusterImporter.cc
+++ b/RecoParticleFlow/PFProducer/plugins/importers/SpecialClusterImporter.cc
@@ -12,10 +12,10 @@
 template <reco::PFBlockElement::Type T>
 class SpecialClusterImporter : public BlockElementImporterBase {
 public:
-  SpecialClusterImporter(const edm::ParameterSet& conf, edm::ConsumesCollector& sumes)
-      : BlockElementImporterBase(conf, sumes),
-        _src(sumes.consumes<reco::PFClusterCollection>(conf.getParameter<edm::InputTag>("source"))),
-        _assoc(sumes.consumes<edm::ValueMap<reco::CaloClusterPtr> >(conf.getParameter<edm::InputTag>("BCtoPFCMap"))) {}
+  SpecialClusterImporter(const edm::ParameterSet& conf, edm::ConsumesCollector& cc)
+      : BlockElementImporterBase(conf, cc),
+        _src(cc.consumes<reco::PFClusterCollection>(conf.getParameter<edm::InputTag>("source"))),
+        _assoc(cc.consumes<edm::ValueMap<reco::CaloClusterPtr> >(conf.getParameter<edm::InputTag>("BCtoPFCMap"))) {}
 
   void importToBlock(const edm::Event&, ElementList&) const override;
 

--- a/RecoParticleFlow/PFProducer/plugins/importers/SuperClusterImporter.cc
+++ b/RecoParticleFlow/PFProducer/plugins/importers/SuperClusterImporter.cc
@@ -50,7 +50,7 @@ SuperClusterImporter::SuperClusterImporter(const edm::ParameterSet& conf, edm::C
       _pTbyPass(conf.getParameter<double>("minPTforBypass")),
       _minSCPt(conf.getParameter<double>("minSuperClusterPt")),
       _superClustersArePF(conf.getParameter<bool>("superClustersArePF")),
-      _ctmapToken(sumes.esConsumes()) {}
+      _ctmapToken(sumes.esConsumes<edm::Transition::BeginLuminosityBlock>()) {}
 
 void SuperClusterImporter::updateEventSetup(const edm::EventSetup& es) {
   edm::ESHandle<CaloTowerConstituentsMap> ctmaph = es.getHandle(_ctmapToken);

--- a/RecoParticleFlow/PFProducer/plugins/importers/SuperClusterImporter.cc
+++ b/RecoParticleFlow/PFProducer/plugins/importers/SuperClusterImporter.cc
@@ -52,10 +52,7 @@ SuperClusterImporter::SuperClusterImporter(const edm::ParameterSet& conf, edm::C
       _superClustersArePF(conf.getParameter<bool>("superClustersArePF")),
       _ctmapToken(cc.esConsumes<edm::Transition::BeginLuminosityBlock>()) {}
 
-void SuperClusterImporter::updateEventSetup(const edm::EventSetup& es) {
-  edm::ESHandle<CaloTowerConstituentsMap> ctmaph = es.getHandle(_ctmapToken);
-  towerMap_ = ctmaph.product();
-}
+void SuperClusterImporter::updateEventSetup(const edm::EventSetup& es) { towerMap_ = &es.getData(_ctmapToken); }
 
 void SuperClusterImporter::importToBlock(const edm::Event& e, BlockElementImporterBase::ElementList& elems) const {
   auto eb_scs = e.getHandle(_srcEB);

--- a/RecoParticleFlow/PFProducer/plugins/importers/SuperClusterImporter.cc
+++ b/RecoParticleFlow/PFProducer/plugins/importers/SuperClusterImporter.cc
@@ -5,7 +5,6 @@
 #include "DataFormats/EgammaReco/interface/SuperCluster.h"
 #include "RecoParticleFlow/PFProducer/interface/PFBlockElementSCEqual.h"
 #include "Geometry/Records/interface/CaloGeometryRecord.h"
-
 // for single tower H/E
 #include "RecoEgamma/EgammaIsolationAlgos/interface/EgammaHadTower.h"
 
@@ -34,6 +33,8 @@ private:
   CaloTowerConstituentsMap const* towerMap_;
   bool _superClustersArePF;
   static const math::XYZPoint _zero;
+
+  const edm::ESGetToken<CaloTowerConstituentsMap, CaloGeometryRecord> _ctmapToken;
 };
 
 const math::XYZPoint SuperClusterImporter::_zero = math::XYZPoint(0, 0, 0);
@@ -48,11 +49,11 @@ SuperClusterImporter::SuperClusterImporter(const edm::ParameterSet& conf, edm::C
       _maxHoverE(conf.getParameter<double>("maximumHoverE")),
       _pTbyPass(conf.getParameter<double>("minPTforBypass")),
       _minSCPt(conf.getParameter<double>("minSuperClusterPt")),
-      _superClustersArePF(conf.getParameter<bool>("superClustersArePF")) {}
+      _superClustersArePF(conf.getParameter<bool>("superClustersArePF")),
+      _ctmapToken(sumes.esConsumes()) {}
 
 void SuperClusterImporter::updateEventSetup(const edm::EventSetup& es) {
-  edm::ESHandle<CaloTowerConstituentsMap> ctmaph;
-  es.get<CaloGeometryRecord>().get(ctmaph);
+  edm::ESHandle<CaloTowerConstituentsMap> ctmaph = es.getHandle(_ctmapToken);
   towerMap_ = ctmaph.product();
 }
 

--- a/RecoParticleFlow/PFProducer/plugins/importers/SuperClusterImporter.cc
+++ b/RecoParticleFlow/PFProducer/plugins/importers/SuperClusterImporter.cc
@@ -41,16 +41,16 @@ const math::XYZPoint SuperClusterImporter::_zero = math::XYZPoint(0, 0, 0);
 
 DEFINE_EDM_PLUGIN(BlockElementImporterFactory, SuperClusterImporter, "SuperClusterImporter");
 
-SuperClusterImporter::SuperClusterImporter(const edm::ParameterSet& conf, edm::ConsumesCollector& sumes)
-    : BlockElementImporterBase(conf, sumes),
-      _srcEB(sumes.consumes<reco::SuperClusterCollection>(conf.getParameter<edm::InputTag>("source_eb"))),
-      _srcEE(sumes.consumes<reco::SuperClusterCollection>(conf.getParameter<edm::InputTag>("source_ee"))),
-      _srcTowers(sumes.consumes<CaloTowerCollection>(conf.getParameter<edm::InputTag>("source_towers"))),
+SuperClusterImporter::SuperClusterImporter(const edm::ParameterSet& conf, edm::ConsumesCollector& cc)
+    : BlockElementImporterBase(conf, cc),
+      _srcEB(cc.consumes<reco::SuperClusterCollection>(conf.getParameter<edm::InputTag>("source_eb"))),
+      _srcEE(cc.consumes<reco::SuperClusterCollection>(conf.getParameter<edm::InputTag>("source_ee"))),
+      _srcTowers(cc.consumes<CaloTowerCollection>(conf.getParameter<edm::InputTag>("source_towers"))),
       _maxHoverE(conf.getParameter<double>("maximumHoverE")),
       _pTbyPass(conf.getParameter<double>("minPTforBypass")),
       _minSCPt(conf.getParameter<double>("minSuperClusterPt")),
       _superClustersArePF(conf.getParameter<bool>("superClustersArePF")),
-      _ctmapToken(sumes.esConsumes<edm::Transition::BeginLuminosityBlock>()) {}
+      _ctmapToken(cc.esConsumes<edm::Transition::BeginLuminosityBlock>()) {}
 
 void SuperClusterImporter::updateEventSetup(const edm::EventSetup& es) {
   edm::ESHandle<CaloTowerConstituentsMap> ctmaph = es.getHandle(_ctmapToken);

--- a/RecoParticleFlow/PFProducer/plugins/importers/TrackFromParentImporter.h
+++ b/RecoParticleFlow/PFProducer/plugins/importers/TrackFromParentImporter.h
@@ -34,8 +34,7 @@ namespace pflow {
           vetoMode_ = conf.getParameter<unsigned>("vetoMode");
           switch (vetoMode_) {
             case pfRecTrackCollection:
-              vetoPFTracksSrc_ =
-                  cc.consumes<reco::PFRecTrackCollection>(conf.getParameter<edm::InputTag>("vetoSrc"));
+              vetoPFTracksSrc_ = cc.consumes<reco::PFRecTrackCollection>(conf.getParameter<edm::InputTag>("vetoSrc"));
               break;
             case ticlSeedingRegion:
               vetoTICLSeedingSrc_ =

--- a/RecoParticleFlow/PFProducer/plugins/importers/TrackFromParentImporter.h
+++ b/RecoParticleFlow/PFProducer/plugins/importers/TrackFromParentImporter.h
@@ -26,25 +26,25 @@ namespace pflow {
     template <class Collection, class Adaptor = noop::ParentCollectionAdaptor<Collection>>
     class TrackFromParentImporter : public BlockElementImporterBase {
     public:
-      TrackFromParentImporter(const edm::ParameterSet& conf, edm::ConsumesCollector& sumes)
-          : BlockElementImporterBase(conf, sumes),
-            src_(sumes.consumes<Collection>(conf.getParameter<edm::InputTag>("source"))),
+      TrackFromParentImporter(const edm::ParameterSet& conf, edm::ConsumesCollector& cc)
+          : BlockElementImporterBase(conf, cc),
+            src_(cc.consumes<Collection>(conf.getParameter<edm::InputTag>("source"))),
             vetoEndcap_(conf.getParameter<bool>("vetoEndcap")) {
         if (vetoEndcap_) {
           vetoMode_ = conf.getParameter<unsigned>("vetoMode");
           switch (vetoMode_) {
             case pfRecTrackCollection:
               vetoPFTracksSrc_ =
-                  sumes.consumes<reco::PFRecTrackCollection>(conf.getParameter<edm::InputTag>("vetoSrc"));
+                  cc.consumes<reco::PFRecTrackCollection>(conf.getParameter<edm::InputTag>("vetoSrc"));
               break;
             case ticlSeedingRegion:
               vetoTICLSeedingSrc_ =
-                  sumes.consumes<std::vector<TICLSeedingRegion>>(conf.getParameter<edm::InputTag>("vetoSrc"));
-              tracksSrc_ = sumes.consumes<reco::TrackCollection>(conf.getParameter<edm::InputTag>("tracksSrc"));
+                  cc.consumes<std::vector<TICLSeedingRegion>>(conf.getParameter<edm::InputTag>("vetoSrc"));
+              tracksSrc_ = cc.consumes<reco::TrackCollection>(conf.getParameter<edm::InputTag>("tracksSrc"));
               break;
             case pfCandidateCollection:
               vetoPFCandidatesSrc_ =
-                  sumes.consumes<reco::PFCandidateCollection>(conf.getParameter<edm::InputTag>("vetoSrc"));
+                  cc.consumes<reco::PFCandidateCollection>(conf.getParameter<edm::InputTag>("vetoSrc"));
               break;
           }  // switch
         }    // vetoEndcap_

--- a/RecoParticleFlow/PFProducer/plugins/importers/TrackTimingImporter.cc
+++ b/RecoParticleFlow/PFProducer/plugins/importers/TrackTimingImporter.cc
@@ -25,9 +25,9 @@ public:
                             : edm::EDGetTokenT<edm::ValueMap<float>>()),
         srcTimeGsf_(cc.consumes<edm::ValueMap<float>>(conf.getParameter<edm::InputTag>("timeValueMapGsf"))),
         srcTimeErrorGsf_(cc.consumes<edm::ValueMap<float>>(conf.getParameter<edm::InputTag>("timeErrorMapGsf"))),
-        srcTimeQualityGsf_(useTimeQuality_ ? cc.consumes<edm::ValueMap<float>>(
-                                                 conf.getParameter<edm::InputTag>("timeQualityMapGsf"))
-                                           : edm::EDGetTokenT<edm::ValueMap<float>>()),
+        srcTimeQualityGsf_(
+            useTimeQuality_ ? cc.consumes<edm::ValueMap<float>>(conf.getParameter<edm::InputTag>("timeQualityMapGsf"))
+                            : edm::EDGetTokenT<edm::ValueMap<float>>()),
         debug_(conf.getUntrackedParameter<bool>("debug", false)) {}
 
   void importToBlock(const edm::Event&, ElementList&) const override;

--- a/RecoParticleFlow/PFProducer/plugins/importers/TrackTimingImporter.cc
+++ b/RecoParticleFlow/PFProducer/plugins/importers/TrackTimingImporter.cc
@@ -14,18 +14,18 @@
 
 class TrackTimingImporter : public BlockElementImporterBase {
 public:
-  TrackTimingImporter(const edm::ParameterSet& conf, edm::ConsumesCollector& sumes)
-      : BlockElementImporterBase(conf, sumes),
+  TrackTimingImporter(const edm::ParameterSet& conf, edm::ConsumesCollector& cc)
+      : BlockElementImporterBase(conf, cc),
         useTimeQuality_(conf.existsAs<edm::InputTag>("timeQualityMap")),
         timeQualityThreshold_(useTimeQuality_ ? conf.getParameter<double>("timeQualityThreshold") : -99.),
-        srcTime_(sumes.consumes<edm::ValueMap<float>>(conf.getParameter<edm::InputTag>("timeValueMap"))),
-        srcTimeError_(sumes.consumes<edm::ValueMap<float>>(conf.getParameter<edm::InputTag>("timeErrorMap"))),
+        srcTime_(cc.consumes<edm::ValueMap<float>>(conf.getParameter<edm::InputTag>("timeValueMap"))),
+        srcTimeError_(cc.consumes<edm::ValueMap<float>>(conf.getParameter<edm::InputTag>("timeErrorMap"))),
         srcTimeQuality_(useTimeQuality_
-                            ? sumes.consumes<edm::ValueMap<float>>(conf.getParameter<edm::InputTag>("timeQualityMap"))
+                            ? cc.consumes<edm::ValueMap<float>>(conf.getParameter<edm::InputTag>("timeQualityMap"))
                             : edm::EDGetTokenT<edm::ValueMap<float>>()),
-        srcTimeGsf_(sumes.consumes<edm::ValueMap<float>>(conf.getParameter<edm::InputTag>("timeValueMapGsf"))),
-        srcTimeErrorGsf_(sumes.consumes<edm::ValueMap<float>>(conf.getParameter<edm::InputTag>("timeErrorMapGsf"))),
-        srcTimeQualityGsf_(useTimeQuality_ ? sumes.consumes<edm::ValueMap<float>>(
+        srcTimeGsf_(cc.consumes<edm::ValueMap<float>>(conf.getParameter<edm::InputTag>("timeValueMapGsf"))),
+        srcTimeErrorGsf_(cc.consumes<edm::ValueMap<float>>(conf.getParameter<edm::InputTag>("timeErrorMapGsf"))),
+        srcTimeQualityGsf_(useTimeQuality_ ? cc.consumes<edm::ValueMap<float>>(
                                                  conf.getParameter<edm::InputTag>("timeQualityMapGsf"))
                                            : edm::EDGetTokenT<edm::ValueMap<float>>()),
         debug_(conf.getUntrackedParameter<bool>("debug", false)) {}

--- a/RecoParticleFlow/PFProducer/src/PFBlockAlgo.cc
+++ b/RecoParticleFlow/PFProducer/src/PFBlockAlgo.cc
@@ -121,11 +121,11 @@ void PFBlockAlgo::setLinkers(const std::vector<edm::ParameterSet>& confs) {
   }    // loop over confs
 }
 
-void PFBlockAlgo::setImporters(const std::vector<edm::ParameterSet>& confs, edm::ConsumesCollector& sumes) {
+void PFBlockAlgo::setImporters(const std::vector<edm::ParameterSet>& confs, edm::ConsumesCollector& cc) {
   importers_.reserve(confs.size());
   for (const auto& conf : confs) {
     const std::string& importerName = conf.getParameter<std::string>("importerName");
-    importers_.emplace_back(BlockElementImporterFactory::get()->create(importerName, conf, sumes));
+    importers_.emplace_back(BlockElementImporterFactory::get()->create(importerName, conf, cc));
   }
 }
 

--- a/RecoParticleFlow/PFSimProducer/plugins/ConvBremSeedProducer.cc
+++ b/RecoParticleFlow/PFSimProducer/plugins/ConvBremSeedProducer.cc
@@ -417,26 +417,20 @@ void ConvBremSeedProducer::produce(Event& iEvent, const EventSetup& iSetup) {
 }
 
 void ConvBremSeedProducer::beginRun(const edm::Run& run, const EventSetup& iSetup) {
-  auto track = iSetup.getHandle(geomSearchTrackerToken_);
-  geomSearchTracker_ = track.product();
+  geomSearchTracker_ = &iSetup.getData(geomSearchTrackerToken_);
 
-  auto theTrackerInteractionGeometry = iSetup.getHandle(geometryToken_);
-  geometry_ = theTrackerInteractionGeometry.product();
+  geometry_ = &iSetup.getData(geometryToken_);
 
-  auto tracker = iSetup.getHandle(trackerToken_);
-  tracker_ = tracker.product();
+  tracker_ = &iSetup.getData(trackerToken_);
 
-  auto magfield = iSetup.getHandle(magFieldToken_beginRun_);
-  magfield_ = magfield.product();
+  magfield_ = &iSetup.getData(magFieldToken_beginRun_);
   B_ = magfield_->inTesla(GlobalPoint(0, 0, 0));
 
-  auto fieldMap = iSetup.getHandle(magFieldMapToken_);
-  fieldMap_ = fieldMap.product();
+  fieldMap_ = &iSetup.getData(magFieldMapToken_);
 
-  auto hitBuilder = iSetup.getHandle(hitBuilderToken_);
-  hitBuilder_ = hitBuilder.product();
+  hitBuilder_ = &iSetup.getData(hitBuilderToken_);
 
-  propagator_ = new PropagatorWithMaterial(alongMomentum, 0.0005, &(*magfield));
+  propagator_ = new PropagatorWithMaterial(alongMomentum, 0.0005, magfield_);
   kfUpdator_ = new KFUpdator();
 }
 

--- a/RecoParticleFlow/PFSimProducer/plugins/ConvBremSeedProducer.cc
+++ b/RecoParticleFlow/PFSimProducer/plugins/ConvBremSeedProducer.cc
@@ -120,17 +120,18 @@ using namespace std;
 using namespace reco;
 
 ConvBremSeedProducer::ConvBremSeedProducer(const ParameterSet& iConfig)
-    : conf_(iConfig), 
-      fieldMap_(nullptr), 
-      layerMap_(56, static_cast<const DetLayer*>(nullptr)), 
+    : conf_(iConfig),
+      fieldMap_(nullptr),
+      layerMap_(56, static_cast<const DetLayer*>(nullptr)),
       negLayerOffset_(27),
-      magFieldToken_(esConsumes()), 
+      magFieldToken_(esConsumes()),
       geomSearchTrackerToken_(esConsumes<edm::Transition::BeginRun>()),
       geometryToken_(esConsumes<edm::Transition::BeginRun>()),
       trackerToken_(esConsumes<edm::Transition::BeginRun>()),
       magFieldToken_beginRun_(esConsumes<edm::Transition::BeginRun>()),
       magFieldMapToken_(esConsumes<edm::Transition::BeginRun>()),
-      hitBuilderToken_(esConsumes<edm::Transition::BeginRun>(edm::ESInputTag("", conf_.getParameter<string>("TTRHBuilder")))) {
+      hitBuilderToken_(
+          esConsumes<edm::Transition::BeginRun>(edm::ESInputTag("", conf_.getParameter<string>("TTRHBuilder")))) {
   produces<ConvBremSeedCollection>();
 }
 


### PR DESCRIPTION
#### PR description:

Migration of remaining RecoParticleFlow packages to esConsumes to address #31061

#### PR validation:

Run standard limited matrix evaluation

`runTheMatrix.py -l limited -j 8 --ibeos`

@hatakeyamak @laurenhay @bendavid @rappoccio 