### PR TITLE
Fix circular dependency between RecoEgamma and RecoEcal

### DIFF
--- a/RecoEcal/EgammaCoreTools/interface/EcalClusterLazyTools.h
+++ b/RecoEcal/EgammaCoreTools/interface/EcalClusterLazyTools.h
@@ -35,7 +35,7 @@
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "CondFormats/EcalObjects/interface/EcalPFRecHitThresholds.h"
 #include "CondFormats/DataRecord/interface/EcalPFRecHitThresholdsRcd.h"
-#include "RecoEgamma/EgammaTools/interface/EgammaLocalCovParamDefaults.h"
+#include "RecoEcal/EgammaCoreTools/interface/EgammaLocalCovParamDefaults.h"
 #include <optional>
 
 class CaloTopology;

--- a/RecoEcal/EgammaCoreTools/interface/EcalClusterTools.h
+++ b/RecoEcal/EgammaCoreTools/interface/EcalClusterTools.h
@@ -57,7 +57,7 @@
 #include "Geometry/EcalAlgo/interface/EcalBarrelGeometry.h"
 #include "CondFormats/EcalObjects/interface/EcalPFRecHitThresholds.h"
 #include "CondFormats/DataRecord/interface/EcalPFRecHitThresholdsRcd.h"
-#include "RecoEgamma/EgammaTools/interface/EgammaLocalCovParamDefaults.h"
+#include "RecoEcal/EgammaCoreTools/interface/EgammaLocalCovParamDefaults.h"
 
 class DetId;
 class CaloTopology;

--- a/RecoEcal/EgammaCoreTools/interface/EgammaLocalCovParamDefaults.h
+++ b/RecoEcal/EgammaCoreTools/interface/EgammaLocalCovParamDefaults.h
@@ -1,5 +1,5 @@
-#ifndef RecoEgamma_EgammaTools_interface_EgammaLocalCovParamDefaults_h
-#define RecoEgamma_EgammaTools_interface_EgammaLocalCovParamDefaults_h
+#ifndef RecoEcal_EgammaCoreTools_interface_EgammaLocalCovParamDefaults_h
+#define RecoEcal_EgammaCoreTools_interface_EgammaLocalCovParamDefaults_h
 
 struct EgammaLocalCovParamDefaults {
   static constexpr float kRelEnCut = 4.7;

--- a/RecoEgamma/EgammaElectronAlgos/src/GsfElectronAlgo.cc
+++ b/RecoEgamma/EgammaElectronAlgos/src/GsfElectronAlgo.cc
@@ -25,7 +25,7 @@
 #include "RecoEgamma/EgammaElectronAlgos/interface/GsfElectronAlgo.h"
 #include "RecoEgamma/EgammaElectronAlgos/interface/ecalClusterEnergyUncertaintyElectronSpecific.h"
 #include "CommonTools/Egamma/interface/ConversionTools.h"
-#include "RecoEgamma/EgammaTools/interface/EgammaLocalCovParamDefaults.h"
+#include "RecoEcal/EgammaCoreTools/interface/EgammaLocalCovParamDefaults.h"
 
 #include <Math/Point3D.h>
 #include <memory>

--- a/RecoEgamma/EgammaElectronProducers/plugins/GsfElectronProducer.cc
+++ b/RecoEgamma/EgammaElectronProducers/plugins/GsfElectronProducer.cc
@@ -21,7 +21,7 @@
 #include "RecoEgamma/EgammaElectronAlgos/interface/EgAmbiguityTools.h"
 #include "RecoEgamma/EgammaElectronAlgos/interface/ElectronUtilities.h"
 #include "RecoEgamma/EgammaElectronAlgos/interface/GsfElectronAlgo.h"
-#include "RecoEgamma/EgammaTools/interface/EgammaLocalCovParamDefaults.h"
+#include "RecoEcal/EgammaCoreTools/interface/EgammaLocalCovParamDefaults.h"
 
 using namespace reco;
 

--- a/RecoEgamma/EgammaHLTProducers/plugins/EgammaHLTClusterShapeProducer.cc
+++ b/RecoEgamma/EgammaHLTProducers/plugins/EgammaHLTClusterShapeProducer.cc
@@ -24,7 +24,7 @@
 #include "RecoEcal/EgammaCoreTools/interface/EcalClusterLazyTools.h"
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
-#include "RecoEgamma/EgammaTools/interface/EgammaLocalCovParamDefaults.h"
+#include "RecoEcal/EgammaCoreTools/interface/EgammaLocalCovParamDefaults.h"
 
 class EgammaHLTClusterShapeProducer : public edm::global::EDProducer<> {
 public:

--- a/RecoEgamma/EgammaPhotonProducers/src/GEDPhotonProducer.cc
+++ b/RecoEgamma/EgammaPhotonProducers/src/GEDPhotonProducer.cc
@@ -47,7 +47,7 @@
 #include "RecoLocalCalo/EcalRecAlgos/interface/EcalSeverityLevelAlgoRcd.h"
 #include "CondFormats/EcalObjects/interface/EcalPFRecHitThresholds.h"
 #include "CondFormats/DataRecord/interface/EcalPFRecHitThresholdsRcd.h"
-#include "RecoEgamma/EgammaTools/interface/EgammaLocalCovParamDefaults.h"
+#include "RecoEcal/EgammaCoreTools/interface/EgammaLocalCovParamDefaults.h"
 
 class GEDPhotonProducer : public edm::stream::EDProducer<> {
 public:


### PR DESCRIPTION
#### PR description:
This is a purely technical PR and no change in physics is expected. It was pointed out by @davidlange6 [in this comment ](https://github.com/cms-sw/cmssw/pull/33148#discussion_r621076816) that in my past PR (#33148) I had introduced a circular dependency between RecoEgamma and RecoEcal. I'm fixing that in this PR. 

#### PR validation:
runTheMatrix.py limited test with 23234.0 and 136.793

This PR is not a backport. 