### PR TITLE
Beamspot and vertex smaring for 2017 pp ref (forward port of #33504)

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -45,6 +45,8 @@ autoCond = {
     'phase1_2017_design'           : '113X_mc2017_design_v5',
     # GlobalTag for MC production with realistic conditions for Phase1 2017 detector
     'phase1_2017_realistic'        : '113X_mc2017_realistic_v5',
+    # GlobalTag for MC production with realistic conditions for Phase1 2017 detector, for PP reference run
+    'phase1_2017_realistic_ppref'    :  '120X_mc2017_realistic_forppRef5TeV_v1',
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in DECO mode
     'phase1_2017_cosmics'          : '113X_mc2017cosmics_realistic_deco_v5',
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in PEAK mode

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -989,7 +989,7 @@ steps['ZEE_14_HI_2021']=merge([hiDefaults2021_ppReco,gen2021hiprod('ZEE_14TeV_Tu
 
 ## pp reference tests
 
-ppRefAlca2017 = {'--conditions':'auto:phase1_2017_realistic', '--era':'Run2_2017_ppRef'}
+ppRefAlca2017 = {'--conditions':'auto:phase1_2017_realistic_ppref', '--era':'Run2_2017_ppRef', '--beamspot':'Fixed_EmitRealistic5TeVppCollision2017'}
 ppRefDefaults2017=merge([ppRefAlca2017,{'-n':2}])
 
 steps['QCD_Pt_80_120_13_PPREF']=merge([ppRefDefaults2017,gen2017('QCD_Pt_80_120_13TeV_TuneCUETP8M1_cfi',Kby(9,150))])


### PR DESCRIPTION
#### PR description:
This is a forward port of PR #33504 with respect to: 1) in autoCond.py a new global tag was created and added for MC production with realistic conditions for Phase1 2017 detector for PP reference run, and 2) relval_steps.py was updated for ppRefAlca2017 pp reference test, so that it uses the new global tag and correct beamspot.

This forward port is discussed in AlCaDB HN: https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/4390/1/1/1/1/1/1/1/1/1/1/1/1/2/1.html .

**GT difference** wrt. the base GT 113X_mc2017_realistic_v5 [1] is the same as the difference [2] of standard pp collisions vs. pp reference run in 10_6_X.

#### PR validation:

Workflow 149 was tested.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This is a forward port of #33504, which is kept on hold until this PR to master is approved and merged.

[1]
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/113X_mc2017_realistic_v5/120X_mc2017_realistic_forppRef5TeV_v1
[2]
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_mc2017_realistic_v9/106X_mc2017_realistic_forppRef5TeV_v3