### PR TITLE
[backport] MTD geometry: update mtdParameters for D49 and D60 (Bug fix)

### DIFF
--- a/Geometry/MTDCommonData/data/CrystalBarPhiFlat/mtdParameters.xml
+++ b/Geometry/MTDCommonData/data/CrystalBarPhiFlat/mtdParameters.xml
@@ -6,10 +6,10 @@
     4, 4, 4, 24
   </Vector>
   <Vector name="BTL" type="numeric" nEntries="12">
-    22, 24, 16, 10, 0x1, 0x3, 0x3F, 0x3F, 1, 16, 3, 1
+    0, 0, 0, 0, 0, 0, 0, 0, 1, 16, 3, 1
   </Vector>
   <Vector name="ETL" type="numeric" nEntries="12">
-    22, 24, 16, 7, 0x1, 0x3, 0x3F, 0xFF, 24, 4, 2, 8
+    0, 0, 0, 0, 0, 0, 0, 0, 24, 4, 2, 8
   </Vector>
 
   </ConstantsSection>

--- a/Geometry/MTDCommonData/data/mtdParameters/v1/mtdParameters.xml
+++ b/Geometry/MTDCommonData/data/mtdParameters/v1/mtdParameters.xml
@@ -6,10 +6,10 @@
     4, 4, 4, 24
   </Vector>
   <Vector name="BTL" type="numeric" nEntries="12">
-    22, 24, 16, 10, 0x1, 0x3, 0x3F, 0x3F, 1, 16, 3, 1
+    0, 0, 0, 0, 0, 0, 0, 0, 1, 16, 3, 1
   </Vector>
   <Vector name="ETL" type="numeric" nEntries="12">
-    22, 24, 16, 7, 0x1, 0x3, 0x3F, 0xFF, 24, 4, 2, 8
+    0, 0, 0, 0, 0, 0, 0, 0, 24, 4, 2, 8
   </Vector>
 
   </ConstantsSection>


### PR DESCRIPTION
#### PR description:

Backport of #33647 by @parbol , fixes the unintentional use of old parameters as frame gaps for ETL pixels in scenarios D49 and D60 (where no frame was used in the past). Although strictly speaking it is a bug fix, it is not important unless someone tries to seriously use MTD in D49 or D60 in 11_3_X (which should be considered as obsolete). The net effect of the fix is anyway minor, it is mostly meant to avoid confusion in the future.

#### PR validation:

Verified in 12_0_X.