### PR TITLE
Migrate module config in RecoEcal to use default cfipython

### DIFF
--- a/RecoEcal/EgammaClusterProducers/python/islandBasicClusters_cfi.py
+++ b/RecoEcal/EgammaClusterProducers/python/islandBasicClusters_cfi.py
@@ -1,51 +1,34 @@
 import FWCore.ParameterSet.Config as cms
+import RecoEcal.EgammaClusterProducers.IslandClusterProducer_cfi as _mod
 
 # Island BasicCluster producer
-islandBasicClusters = cms.EDProducer("IslandClusterProducer",
-	barrelHits = cms.InputTag('ecalRecHit','EcalRecHitsEB'),
-	endcapHits = cms.InputTag('ecalRecHit','EcalRecHitsEE'), 			 
-    barrelClusterCollection = cms.string('islandBarrelBasicClusters'),
-    IslandEndcapSeedThr = cms.double(0.18),
-    barrelShapeAssociation = cms.string('islandBarrelShapeAssoc'),
-    clustershapecollectionEE = cms.string('islandEndcapShape'),
-    clustershapecollectionEB = cms.string('islandBarrelShape'),
-    VerbosityLevel = cms.string('ERROR'),
-    endcapShapeAssociation = cms.string('islandEndcapShapeAssoc'),
-    endcapClusterCollection = cms.string('islandEndcapBasicClusters'),
-    IslandBarrelSeedThr = cms.double(0.5),
-    posCalcParameters = cms.PSet( T0_barl      = cms.double(7.4),
-                                  T0_endc      = cms.double(3.1),        
-                                  T0_endcPresh = cms.double(1.2),
-                                  LogWeighted  = cms.bool(True),
-                                  W0           = cms.double(4.2),
-                                  X0           = cms.double(0.89)
-                                 ),
+islandBasicClusters = _mod.IslandClusterProducer.clone(
+    endcapShapeAssociation = 'islandEndcapShapeAssoc',
+    posCalcParameters = dict(),
     # recHit flags to be excluded from seeding
-    SeedRecHitFlagToBeExcludedEB = cms.vstring(
+    SeedRecHitFlagToBeExcludedEB = [
         'kFaultyHardware',
         'kTowerRecovered',
         'kDead'
-        ),
-    SeedRecHitFlagToBeExcludedEE = cms.vstring(
+        ],
+    SeedRecHitFlagToBeExcludedEE = [
         'kFaultyHardware',
         'kNeighboursRecovered',
         'kTowerRecovered',
         'kDead',
         'kWeird'
-        ),
+        ],
     # recHit flags to be excluded from clustering
-    RecHitFlagToBeExcludedEB = cms.vstring(
+    RecHitFlagToBeExcludedEB = [
         'kWeird',
         'kDiWeird',
         'kOutOfTime',
         'kTowerRecovered'
-        ),
-    RecHitFlagToBeExcludedEE = cms.vstring(
+        ],
+    RecHitFlagToBeExcludedEE = [
         'kWeird',
         'kDiWeird',
         'kOutOfTime',
         'kTowerRecovered'
-        )
+        ]
 )
-
-

--- a/RecoEcal/EgammaClusterProducers/python/particleFlowSuperClusterECALBox_cfi.py
+++ b/RecoEcal/EgammaClusterProducers/python/particleFlowSuperClusterECALBox_cfi.py
@@ -1,76 +1,68 @@
 import FWCore.ParameterSet.Config as cms
+import RecoEcal.EgammaClusterProducers.particleFlowSuperClusterECALMustache_cfi as _mod
 
-particleFlowSuperClusterECALBox = cms.EDProducer("PFECALSuperClusterProducer",
+particleFlowSuperClusterECALBox = _mod.particleFlowSuperClusterECALMustache.clone(
     # verbosity
-    verbose = cms.untracked.bool(False),
+    verbose = False,
     # clustering type: "Box" or "Mustache"
-    ClusteringType = cms.string("Box"),
+    ClusteringType = "Box",
     # energy weighting: "Raw", "CalibratedNoPS", "CalibratedTotal"
-    EnergyWeight = cms.string("Raw"),
+    EnergyWeight = "Raw",
 
     # this overrides both dphi cuts below if true!
-    useDynamicDPhiWindow = cms.bool(False),
+    useDynamicDPhiWindow = False,
 
     # PFClusters collection
-    PFClusters = cms.InputTag("particleFlowClusterECAL"),
-    ESAssociation = cms.InputTag("particleFlowClusterECAL"),
-    BeamSpot = cms.InputTag("offlineBeamSpot"),
+    PFClusters = "particleFlowClusterECAL",
+    ESAssociation = "particleFlowClusterECAL",
+    BeamSpot = "offlineBeamSpot",
 
-    PFBasicClusterCollectionBarrel = cms.string("particleFlowBasicClusterECALBarrel"),
-    PFSuperClusterCollectionBarrel = cms.string("particleFlowSuperClusterECALBarrel"),
-    PFBasicClusterCollectionEndcap = cms.string("particleFlowBasicClusterECALEndcap"),
-    PFSuperClusterCollectionEndcap = cms.string("particleFlowSuperClusterECALEndcap"),
-    PFBasicClusterCollectionPreshower = cms.string("particleFlowBasicClusterECALPreshower"),
-    PFSuperClusterCollectionEndcapWithPreshower = cms.string("particleFlowSuperClusterECALEndcapWithPreshower"),
+    PFBasicClusterCollectionBarrel = "particleFlowBasicClusterECALBarrel",
+    PFSuperClusterCollectionBarrel = "particleFlowSuperClusterECALBarrel",
+    PFBasicClusterCollectionEndcap = "particleFlowBasicClusterECALEndcap",
+    PFSuperClusterCollectionEndcap = "particleFlowSuperClusterECALEndcap",
+    PFBasicClusterCollectionPreshower = "particleFlowBasicClusterECALPreshower",
+    PFSuperClusterCollectionEndcapWithPreshower = "particleFlowSuperClusterECALEndcapWithPreshower",
 
     # use preshower ?
-    use_preshower = cms.bool(True),
+    use_preshower = True,
 
     # are the seed thresholds Et or Energy?
-    seedThresholdIsET = cms.bool(True),
+    seedThresholdIsET = True,
 
     # regression setup
-    useRegression = cms.bool(False), # regressions are mustache only
-    regressionConfig = cms.PSet(
-        regressionKeyEB = cms.string('pfscecal_EBCorrection_offline_v2'),
-        uncertaintyKeyEB = cms.string('pfscecal_EBUncertainty_offline_v2'),
-        regressionKeyEE = cms.string('pfscecal_EECorrection_offline_v2'),
-        uncertaintyKeyEE = cms.string('pfscecal_EEUncertainty_offline_v2'),
-        vertexCollection = cms.InputTag("offlinePrimaryVertices"),
-        ecalRecHitsEB = cms.InputTag('ecalRecHit','EcalRecHitsEB'),
-        ecalRecHitsEE = cms.InputTag('ecalRecHit','EcalRecHitsEE'),
-        applySigmaIetaIphiBug = cms.bool(False)
-    ),
+    useRegression = False, # regressions are mustache only
+    regressionConfig = dict(),
 
     # threshold for final SuperCluster Et
-    thresh_SCEt = cms.double(4.0),
+    thresh_SCEt = 4.0,
 
     # threshold in ECAL
-    thresh_PFClusterSeedBarrel = cms.double(3.0),
-    thresh_PFClusterBarrel = cms.double(0.5),
+    thresh_PFClusterSeedBarrel = 3.0,
+    thresh_PFClusterBarrel = 0.5,
 
-    thresh_PFClusterSeedEndcap = cms.double(5.0),
-    thresh_PFClusterEndcap = cms.double(0.5),
+    thresh_PFClusterSeedEndcap = 5.0,
+    thresh_PFClusterEndcap = 0.5,
 
     # window width in ECAL
-    phiwidth_SuperClusterBarrel = cms.double(0.28),
-    etawidth_SuperClusterBarrel = cms.double(0.04),
+    phiwidth_SuperClusterBarrel = 0.28,
+    etawidth_SuperClusterBarrel = 0.04,
 
-    phiwidth_SuperClusterEndcap = cms.double(0.28),
-    etawidth_SuperClusterEndcap = cms.double(0.04),
+    phiwidth_SuperClusterEndcap = 0.28,
+    etawidth_SuperClusterEndcap = 0.04,
 
     # threshold in preshower
-    thresh_PFClusterES = cms.double(0.),
+    thresh_PFClusterES = 0.,
 
     # turn on merging of the seed cluster to its nearest neighbors
     # that share a rechit
-    doSatelliteClusterMerge = cms.bool(False),
-    satelliteClusterSeedThreshold = cms.double(50.0),
-    satelliteMajorityFraction = cms.double(0.5),
-    dropUnseedable = cms.bool(False),
+    doSatelliteClusterMerge = False,
+    satelliteClusterSeedThreshold = 50.0,
+    satelliteMajorityFraction = 0.5,
+    dropUnseedable = False,
     #thresh_PFClusterMustacheOutBarrel = cms.double(0.),
     #thresh_PFClusterMustacheOutEndcap = cms.double(0.),
 
     # corrections
-    applyCrackCorrections = cms.bool(False)
+    applyCrackCorrections = False
 )

--- a/RecoEcal/EgammaClusterProducers/python/particleFlowSuperClusterECALBox_cfi.py
+++ b/RecoEcal/EgammaClusterProducers/python/particleFlowSuperClusterECALBox_cfi.py
@@ -60,8 +60,6 @@ particleFlowSuperClusterECALBox = _mod.particleFlowSuperClusterECALMustache.clon
     satelliteClusterSeedThreshold = 50.0,
     satelliteMajorityFraction = 0.5,
     dropUnseedable = False,
-    #thresh_PFClusterMustacheOutBarrel = cms.double(0.),
-    #thresh_PFClusterMustacheOutEndcap = cms.double(0.),
 
     # corrections
     applyCrackCorrections = False

--- a/RecoEcal/EgammaClusterProducers/src/PFECALSuperClusterProducer.cc
+++ b/RecoEcal/EgammaClusterProducers/src/PFECALSuperClusterProducer.cc
@@ -121,8 +121,6 @@ PFECALSuperClusterProducer::PFECALSuperClusterProducer(const edm::ParameterSet& 
   superClusterAlgo_.setSatelliteThreshold(satelliteClusterSeedThreshold);
   superClusterAlgo_.setMajorityFraction(satelliteMajorityFraction);
   superClusterAlgo_.setDropUnseedable(dropUnseedable);
-  //superClusterAlgo_.setThreshPFClusterMustacheOutBarrel( threshPFClusterMustacheOutBarrel );
-  //superClusterAlgo_.setThreshPFClusterMustacheOutEndcap( threshPFClusterMustacheOutEndcap );
 
   //Load the ECAL energy calibration
   thePFEnergyCalibration_ = std::make_shared<PFEnergyCalibration>();

--- a/RecoEcal/EgammaClusterProducers/src/PFECALSuperClusterProducer.cc
+++ b/RecoEcal/EgammaClusterProducers/src/PFECALSuperClusterProducer.cc
@@ -94,9 +94,6 @@ PFECALSuperClusterProducer::PFECALSuperClusterProducer(const edm::ParameterSet& 
   double phiwidthSuperClusterEndcap = iConfig.getParameter<double>("phiwidth_SuperClusterEndcap");
   double etawidthSuperClusterEndcap = iConfig.getParameter<double>("etawidth_SuperClusterEndcap");
 
-  //double threshPFClusterMustacheOutBarrel = iConfig.getParameter<double>("thresh_PFClusterMustacheOutBarrel");
-  //double threshPFClusterMustacheOutEndcap = iConfig.getParameter<double>("thresh_PFClusterMustacheOutEndcap");
-
   double doSatelliteClusterMerge = iConfig.getParameter<bool>("doSatelliteClusterMerge");
   double satelliteClusterSeedThreshold = iConfig.getParameter<double>("satelliteClusterSeedThreshold");
   double satelliteMajorityFraction = iConfig.getParameter<double>("satelliteMajorityFraction");


### PR DESCRIPTION
#### PR description: 
Optimization of the python configurations: Improve maintainability by cleaning up the duplicated and cloning from the default/reference configurations.

Migrating EDProducer("type", .. -> typeDefault.clone() and drop the type specifications already presented in cfipython/fillDescriptions reference. Also, cleanup the duplicated parameters that are exactly the same value in cfipython reference.

(The previous PRs were  [PR#33207](https://github.com/cms-sw/cmssw/pull/33207), [PR#33307](https://github.com/cms-sw/cmssw/pull/33307), [PR#33352](https://github.com/cms-sw/cmssw/pull/33352), [PR#33543](https://github.com/cms-sw/cmssw/pull/33543),[PR#33563](https://github.com/cms-sw/cmssw/pull/33563) )
 
In this PR, 2 files changed.  
- RecoEcal/EgammaClusterProducers


#### PR validation:
Event Content comparison check was also done and there is no change with these updates.
Tested in CMSSW_11_3_X, the basic test all passed in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html).