### PR TITLE
SiStripMonitorCluster: move from orbitNumber() to luminosityBlock()

### DIFF
--- a/DQM/SiStripMonitorCluster/src/SiStripMonitorCluster.cc
+++ b/DQM/SiStripMonitorCluster/src/SiStripMonitorCluster.cc
@@ -1,4 +1,3 @@
-
 // -*- C++ -*-
 // Package:    SiStripMonitorCluster
 // Class:      SiStripMonitorCluster
@@ -652,8 +651,15 @@ void SiStripMonitorCluster::analyze(const edm::Event& iEvent, const edm::EventSe
 
   runNb = iEvent.id().run();
   eventNb++;
-  trendVar = trendVs10Ls_ ? iEvent.orbitNumber() / (10 * 262144.0)
-                          : iEvent.orbitNumber() / (1 * 262144.0);  // 10 lumisection : lumisection
+
+  if (!iEvent.isRealData()) {
+    trendVar = trendVs10Ls_ ? iEvent.eventAuxiliary().luminosityBlock() / 10.f
+                            : iEvent.eventAuxiliary().luminosityBlock();  // 10 lumisection : lumisection
+
+  } else {
+    trendVar = trendVs10Ls_ ? iEvent.orbitNumber() / (10 * 262144.0)
+                            : iEvent.orbitNumber() / (1 * 262144.0);  // 10 lumisection : lumisection
+  }
 
   int NPixClusters = 0, NStripClusters = 0, MultiplicityRegion = 0;
   bool isPixValid = false;


### PR DESCRIPTION
#### PR description:

Attempt to solve the issue detailed in this [presentation at AlCa/DB meeting May 10th](https://indico.cern.ch/event/1030561/contributions/4327258/subcontributions/337759/attachments/2241887/3801857/SiStripDPG_RunDepMC_Valid.pdf#page=5), needed to monitor changes vs LS # in the MC as well (target Run-Dependent MC).

#### PR validation:

Compiled and run wf:  
```
runTheMatrix.py -l 250202.182 -t 4 -j 8 --command='-n 100' --ibeos
```
as expected the empty histograms are now filled:

![image](https://user-images.githubusercontent.com/5082376/117666454-2a751080-b1a4-11eb-87bb-7299ba7c3740.png)

Notice that the output file has 20 LS:
```bash
$ edmFileUtil step3.root 
step3.root
step3.root (1 runs, 20 lumis, 100 events, 394327914 bytes)
```

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This is not a backport, no backport is needed.
cc:
@arossi83 @sroychow 
