### PR TITLE
Use std::getenv in ExternalLHEProducer

### DIFF
--- a/GeneratorInterface/LHEInterface/plugins/ExternalLHEProducer.cc
+++ b/GeneratorInterface/LHEInterface/plugins/ExternalLHEProducer.cc
@@ -332,7 +332,7 @@ void ExternalLHEProducer::endRun(edm::Run const& run, edm::EventSetup const& es)
   nextEvent();
   if (partonLevel_) {
     // VALIDATION_RUN env variable allows to finish event processing early without errors by sending SIGINT
-    if (getenv("VALIDATION_RUN") != nullptr) {
+    if (std::getenv("VALIDATION_RUN") != nullptr) {
       edm::LogWarning("ExternalLHEProducer")
           << "Event loop is over, but there are still lhe events to process, ignoring...";
     } else {


### PR DESCRIPTION
#### PR description:

Change `::getenv` to `std::getenv` as suggested by https://github.com/cms-sw/cmssw/pull/33624#discussion_r626945855 because the former is not thread-safe.

#### PR validation:

- `scram b runtests` tests succeeded
- Tried one `cmsRun` and it succeeded

#### If this PR is a backport please specify the original PR and why you need to backport that PR:

Not a backport