### PR TITLE
Update Cosmics2020 workflow to MWGR#3 data

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_standard.py
+++ b/Configuration/PyReleaseValidation/python/relval_standard.py
@@ -429,8 +429,8 @@ workflows[136.888521] = ['',['RunJetHT2018D','HLTDR2_2018','RECODR2_2018reHLT_HC
 workflows[137.8] = ['',['RunEGamma2018C','HLTDR2_2018','RECODR2_2018reHLT_skimEGamma_Offline_L1TEgDQM',
                         'RunEGamma2018D','HLTDR2_2018','RECODR2_2018reHLT_skimEGamma_Prompt_L1TEgDQM','HARVEST2018_L1TEgDQM_MULTIRUN']]
 ### LS2 - MWGR ###
-workflows[138.1] = ['',['RunCosmics2020','RECOCOSDRUN3','ALCACOSDRUN3','HARVESTDCRUN3']]
-workflows[138.2] = ['',['RunCosmics2020','RECOCOSDEXPRUN3','ALCACOSDEXPRUN3','HARVESTDCEXPRUN3']]
+workflows[138.1] = ['',['RunCosmics2021','RECOCOSDRUN3','ALCACOSDRUN3','HARVESTDCRUN3']]
+workflows[138.2] = ['',['RunExpressCosmics2021','RECOCOSDEXPRUN3','ALCACOSDEXPRUN3','HARVESTDCEXPRUN3']]
 
 #### Test of lumi section boundary crossing with run2 2018D ####
 workflows[136.8861] = ['',['RunEGamma2018Dml1','HLTDR2_2018ml','RECODR2_2018reHLT_skimEGamma_Prompt_L1TEgDQM','HARVEST2018_L1TEgDQM_Prompt']]

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -491,8 +491,9 @@ steps['RunSingleMu2015HLHS']={'INPUT':InputInfo(dataSet='/SingleMuon/Run2015D-v1
 steps['RunCosmics2015C']={'INPUT':InputInfo(dataSet='/Cosmics/Run2015C-v1/RAW',label='2015C',run=[256259],events=100000,location='STD')}
 steps['RunCosmics2016B']={'INPUT':InputInfo(dataSet='/Cosmics/Run2016B-v1/RAW',label='2016B',run=[272133],events=100000,location='STD')}
 
-### LS2 - MWGR#5 2020 - CSC, DAQ, DCS, DQM, DT, ECAL, GEM, HCAL, RPC, TCDS, TRACKER, TRG ###
-steps['RunCosmics2020']={'INPUT':InputInfo(dataSet='/ExpressCosmics/Commissioning2020-Express-v1/FEVT',label='2020GR5',ls={338714: [[1, 10000]]},events=100000,location='STD')}
+### LS2 - MWGR#3 2021 - CSC, DAQ, DCS, DQM, DT, ECAL, ES, GEM, HCAL, L1SCOUT, RPC, TCDS, TRG ###
+steps['RunExpressCosmics2021']={'INPUT':InputInfo(dataSet='/ExpressCosmics/Commissioning2021-Express-v1/FEVT',label='2021GR3',ls={341168: [[1, 10000]]},events=100000,location='STD')}
+steps['RunCosmics2021']={'INPUT':InputInfo(dataSet='/HLTPhysics/Commissioning2021-v1/RAW', label='2021GR3',ls={341168: [[1, 10000]]},events=100000,location='STD')} ##to be moved to Cosmics
 
 #### Test of lumi section boundary crossing with run2 2018D ####
 Run2018Dml1={320822: [[1,1]] , 320823: [[1,1]]}


### PR DESCRIPTION
This PR updates 138.1 and  138.2

```
138.1_RunCosmics2021+RunCosmics2021+RECOCOSDRUN3+ALCACOSDRUN3+HARVESTDCRUN3
138.2_RunExpressCosmics2021+RunExpressCosmics2021+RECOCOSDEXPRUN3+ALCACOSDEXPRUN3+HARVESTDCEXPRUN3
```

to use MWGR#3 2021 data (previously it was using MWGR#5 2020), specifically run `341168` 
`/ExpressCosmics/Commissioning2021-Express-v1/FEVT`  for Express and
`/HLTPhysics/Commissioning2021-v1/RAW` for Cosmics.

I chose `HLTPhysics`, instead of `Cosmics`, simply because it is 100% available on disk

#### PR validation:

`runTheMatrix.py -l 138.1,138.2 -t8`