### PR TITLE
Turn-off GEM-CSC integrated local trigger in valCscStage2Digis [12_0_X]

### DIFF
--- a/DQM/L1TMonitor/python/L1TStage2Emulator_cff.py
+++ b/DQM/L1TMonitor/python/L1TStage2Emulator_cff.py
@@ -59,7 +59,9 @@ valMuonGEMPadDigiClusters = simMuonGEMPadDigiClusters.clone(InputCollection = "v
 from L1Trigger.CSCTriggerPrimitives.cscTriggerPrimitiveDigis_cfi import *
 valCscStage2Digis = cscTriggerPrimitiveDigis.clone(
     CSCComparatorDigiProducer = "muonCSCDigis:MuonCSCComparatorDigi",
-    CSCWireDigiProducer = "muonCSCDigis:MuonCSCWireDigi"
+    CSCWireDigiProducer = "muonCSCDigis:MuonCSCWireDigi",
+    GEMPadDigiClusterProducer = "",
+    commonParam = dict(runME11ILT = False)
 )
 
 from Configuration.Eras.Modifier_run3_GEM_cff import run3_GEM


### PR DESCRIPTION
#### PR description:

Turn-off GEM-CSC integrated local trigger in valCscStage2Digis. GEM-CSC trigger not yet deployed at P5. Previously it was turned off in 11_2_X. 

#### PR validation:

Tested with WF 11634.0.
```
 11634.0_TTbar_14TeV+2021+TTbar_14TeV_TuneCP5_GenSim+Digi+Reco+HARVEST+ALCA Step0-PASSED Step1-PASSED Step2-PASSED Step3-PASSED Step4-PASSED  - time date Mon May 10 10:28:02 2021-date Mon May 10 10:07:01 2021; exit: 0 0 0 0 0
1 1 1 1 1 tests passed, 0 0 0 0 0 failed
```

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Needs to be backported to 11_3_X

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
