### PR TITLE
Turn-off GEM-CSC integrated local trigger in valCscStage2Digis [11_3_X]

### DIFF
--- a/DQM/L1TMonitor/python/L1TStage2Emulator_cff.py
+++ b/DQM/L1TMonitor/python/L1TStage2Emulator_cff.py
@@ -59,7 +59,9 @@ valMuonGEMPadDigiClusters = simMuonGEMPadDigiClusters.clone(InputCollection = "v
 from L1Trigger.CSCTriggerPrimitives.cscTriggerPrimitiveDigis_cfi import *
 valCscStage2Digis = cscTriggerPrimitiveDigis.clone(
     CSCComparatorDigiProducer = "muonCSCDigis:MuonCSCComparatorDigi",
-    CSCWireDigiProducer = "muonCSCDigis:MuonCSCWireDigi"
+    CSCWireDigiProducer = "muonCSCDigis:MuonCSCWireDigi",
+    GEMPadDigiClusterProducer = "",
+    commonParam = dict(runME11ILT = False)
 )
 
 from Configuration.Eras.Modifier_run3_GEM_cff import run3_GEM


### PR DESCRIPTION
#### PR description:

Turn-off GEM-CSC integrated local trigger in valCscStage2Digis. GEM-CSC trigger is not yet deployed at P5. Previously it was turned off in 11_2_X.

#### PR validation:

Tested with WF 11634.0.

Also tested this on a data event (341169:517:9310078) that was crashing the T0-replay. This recipe, which crashed before, should now run:

```
cmsrel CMSSW_11_3_0
cd CMSSW_11_3_0/src/
cmsenv
git cms-init
git cms-rebase-topic -u 33679
scram b -j 4
edmPickEvents.py "/Cosmics/Tier0_REPLAY_2021-v2105100737/RAW" 341169:517:9310078
edmCopyPickMerge outputFile=pickevents.root   eventsToProcess=341169:9310078   inputFiles=/store/backfill/1/data/Tier0_REPLAY_2021/Cosmics/RAW/v2105100737/000/341/169/00000/5467c67e-1dad-4e71-b9ca-a266809f2e01.root
cmsDriver.py test --conditions 112X_dataRun3_Prompt_v5 -s RAW2DIGI,L1Reco,RECO,DQM --process reRECO --data --era Run3 --eventcontent RECO,DQM --scenario cosmics --datatier RECO,DQMIO --customise Configuration/DataProcessing/RecoTLR.customiseCosmicData -n 100 --filein=file:pickevents.root
```

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Backport of https://github.com/cms-sw/cmssw/pull/33678

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
