### PR TITLE
 Geometry/TrackerGeometryBuilder: update documentation after #27448

### DIFF
--- a/Geometry/TrackerGeometryBuilder/README.md
+++ b/Geometry/TrackerGeometryBuilder/README.md
@@ -14,20 +14,20 @@ helper methods are available (and other can be added if needed): `GeomDetEnumera
 `GeomDetEnumerators::isTrackerStrip(subdet)` and equivalent methods in the `GeomDetType` class. The present map between
 enumerators and the returned values of the above methods are summarized in the table below:
 
-| `GeometricDet::GDEnumType` | `GeomDetEnumerators::SubDetector` | `GeomDetEnumerators::subDetGeom[id]` | `isTrackerPixel` | `isTrackerStrip` | `isBarrel` | `isEndcap` | 
-|-------|------|--------|------|------|-------|-------|
-| `PixelBarrel` | `PixelBarrel` | `PixelBarrel` | `true` | `false` | `true` | `false` |
-| `PixelEndCap` | `PixelEndcap` | `PixelEndcap` | `true` | `false` | `false` | `true` |
-| `TIB` | `TIB` | `TIB` | `false` | `true` | `true` | `false` |
-| `TID` | `TID` | `TID` | `false` | `true` | `false` | `true` |
-| `TOB` | `TOB` | `TOB` | `false` | `true` | `true` | `false` |
-| `TEC` | `TEC` | `TEC` | `false` | `true` | `false` | `true` |
-| `PixelPhase1Barrel` | `P1PXB` | `PixelBarrel` | `true` | `false` | `true` | `false` |
-| `PixelPhase1EndCap` | `P1PXEC` | `PixelEndcap` | `true` | `false` | `false` | `true` |
-| `PixelPhase2Barrel` | `P2PXB` | `PixelBarrel` | `true` | `false` | `true` | `false` |
-| `PixelPhase2EndCap` | `P2PXEC` | `PixelEndcap` | `true` | `false` | `false` | `true` |
-| `OTPhase2Barrel` | `P2OTB` | `TOB` | `true` | `false` | `true` | `false` |
-| `OTPhase2EndCap` | `P2OTEC` | `TID` | `true` | `false` | `false` | `true` |
+| `GeometricDet::GDEnumType` | `GeomDetEnumerators::SubDetector` | `GeomDetEnumerators::subDetGeom[id]` | `isTrackerPixel` | `isTrackerStrip` | `isInnerTracker` | `isOuterTracker` | `isBarrel` | `isEndcap` |
+|-------|------|--------|------|------|-------|-------|-------|-------|
+| `PixelBarrel` | `PixelBarrel` | `PixelBarrel` | `true` | `false` | `true` |  `false` | `true` | `false` |
+| `PixelEndCap` | `PixelEndcap` | `PixelEndcap` | `true` | `false` | `true` |  `false` | `false` | `true` |
+| `TIB` | `TIB` | `TIB` | `false` | `true` | `false` | `true` | `true` | `false` |
+| `TID` | `TID` | `TID` | `false` | `true` | `false` | `true` | `false` | `true` |
+| `TOB` | `TOB` | `TOB` | `false` | `true` | `false` | `true` |`true` | `false` |
+| `TEC` | `TEC` | `TEC` | `false` | `true` | `false` | `true` |`false` | `true` |
+| `PixelPhase1Barrel` | `P1PXB` | `PixelBarrel` | `true` | `false` | `true` |  `false` | `true` | `false` |
+| `PixelPhase1EndCap` | `P1PXEC` | `PixelEndcap` | `true` | `false` | `true` |  `false` | `false` | `true` |
+| `PixelPhase2Barrel` | `P2PXB` | `PixelBarrel` | `true` | `false` |`true` |  `false` | `true` | `false` |
+| `PixelPhase2EndCap` | `P2PXEC` | `PixelEndcap` | `true` | `false` | `true` | `false` | `false` | `true` |
+| `OTPhase2Barrel` | `P2OTB` | `TOB` | `true` | `false` | `false` | `true` |`true` | `false` |
+| `OTPhase2EndCap` | `P2OTEC` | `TID` | `true` | `false` | `false` | `true` | `false` | `true` |
 
 ### `TrackerGeometry` useful methods
 


### PR DESCRIPTION
#### PR description:

Commit https://github.com/cms-sw/cmssw/commit/69c8898814ce3be38134d8a3a5bcea09951a537c introduced new methods for `GeomDetEnumerators` and `GeomDetType` but the documentation was not updated. 
This PR remedies that situation.

#### PR validation:

Nothing particular, changes are trivial.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Not a backport is needed.

