### PR TITLE
migrate SLHCUpgradeSimulations/Geometry to esConsumes

### DIFF
--- a/SLHCUpgradeSimulations/Geometry/test/ModuleInfo_Phase2.cc
+++ b/SLHCUpgradeSimulations/Geometry/test/ModuleInfo_Phase2.cc
@@ -75,6 +75,9 @@ public:
 
 private:
   // ----------member data ---------------------------
+  edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> geom_esToken;
+  edm::ESGetToken<GeometricDet, IdealGeometryRecord> geomDet_esToken;
+  edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> topo_esToken;
   bool fromDDD_;
   bool printDDD_;
 };
@@ -104,9 +107,7 @@ ModuleInfo_Phase2::~ModuleInfo_Phase2() {
 // ------------ method called to produce the data  ------------
 void ModuleInfo_Phase2::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
   //Retrieve tracker topology from geometry
-  edm::ESHandle<TrackerTopology> tTopoHandle;
-  iSetup.get<TrackerTopologyRcd>().get(tTopoHandle);
-  const TrackerTopology* const tTopo = tTopoHandle.product();
+  const TrackerTopology* const tTopo = &iSetup.getData(topo_esToken);
 
   edm::LogInfo("ModuleInfo_Phase2") << "begins";
 
@@ -124,15 +125,12 @@ void ModuleInfo_Phase2::analyze(const edm::Event& iEvent, const edm::EventSetup&
   //
   // get the GeometricDet
   //
-  edm::ESHandle<GeometricDet> rDD;
+  const GeometricDet* rDD = &iSetup.getData(geomDet_esToken);
 
-  iSetup.get<IdealGeometryRecord>().get(rDD);
-  edm::LogInfo("ModuleInfo_Phase2") << " Top node is  " << rDD.product() << " " << rDD.product()->name() << std::endl;
-  edm::LogInfo("ModuleInfo_Phase2") << " And Contains  Daughters: " << rDD.product()->deepComponents().size()
-                                    << std::endl;
+  edm::LogInfo("ModuleInfo_Phase2") << " Top node is  " << rDD << " " << rDD->name() << std::endl;
+  edm::LogInfo("ModuleInfo_Phase2") << " And Contains  Daughters: " << rDD->deepComponents().size() << std::endl;
   //first instance tracking geometry
-  edm::ESHandle<TrackerGeometry> pDD;
-  iSetup.get<TrackerDigiGeometryRecord>().get(pDD);
+  const TrackerGeometry* pDD = &iSetup.getData(geom_esToken);
   //
 
   // counters

--- a/SLHCUpgradeSimulations/Geometry/test/StdHitNtuplizer.cc
+++ b/SLHCUpgradeSimulations/Geometry/test/StdHitNtuplizer.cc
@@ -7,8 +7,6 @@
 
 #include "FWCore/PluginManager/interface/ModuleDef.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
-
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
@@ -28,8 +26,6 @@
 #include "SimDataFormats/Vertex/interface/SimVertexContainer.h"
 
 #include "DataFormats/DetId/interface/DetId.h"
-#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
-#include "Geometry/Records/interface/TrackerTopologyRcd.h"
 #include "DataFormats/SiPixelDetId/interface/PixelSubdetector.h"
 #include "DataFormats/Common/interface/DetSetVector.h"
 #include "DataFormats/SiPixelCluster/interface/SiPixelCluster.h"
@@ -39,8 +35,6 @@
 
 // Geometry
 #include "MagneticField/Engine/interface/MagneticField.h"
-#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
-#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 #include "Geometry/TrackerGeometryBuilder/interface/RectangularPixelTopology.h"
 #include "Geometry/TrackerGeometryBuilder/interface/PixelTopologyBuilder.h"
 #include "Geometry/CommonDetUnit/interface/GeomDetType.h"
@@ -64,7 +58,9 @@ using namespace edm;
 using namespace reco;
 
 StdHitNtuplizer::StdHitNtuplizer(edm::ParameterSet const& conf)
-    : conf_(conf),
+    : geom_esToken(esConsumes()),
+      topo_esToken(esConsumes()),
+      conf_(conf),
       trackerHitAssociatorConfig_(conf, consumesCollector()),
       src_(conf.getParameter<edm::InputTag>("src")),
       rphiRecHits_(conf.getParameter<edm::InputTag>("rphiRecHits")),
@@ -117,15 +113,10 @@ void StdHitNtuplizer::beginJob() {
 // Functions that gets called by framework every event
 void StdHitNtuplizer::analyze(const edm::Event& e, const edm::EventSetup& es) {
   //Retrieve tracker topology from geometry
-  edm::ESHandle<TrackerTopology> tTopoHandle;
-  es.get<TrackerTopologyRcd>().get(tTopoHandle);
-  const TrackerTopology* const tTopo = tTopoHandle.product();
+  const TrackerTopology* const tTopo = &es.getData(topo_esToken);
 
   // geometry setup
-  edm::ESHandle<TrackerGeometry> geometry;
-
-  es.get<TrackerDigiGeometryRecord>().get(geometry);
-  const TrackerGeometry* theGeometry = &(*geometry);
+  const TrackerGeometry* theGeometry = &es.getData(geom_esToken);
 
   // fastsim rechits
   //edm::Handle<SiTrackerGSRecHit2DCollection> theGSRecHits;

--- a/SLHCUpgradeSimulations/Geometry/test/StdHitNtuplizer.h
+++ b/SLHCUpgradeSimulations/Geometry/test/StdHitNtuplizer.h
@@ -30,6 +30,11 @@
 #include "SimDataFormats/Track/interface/SimTrackContainer.h"
 #include "SimTracker/TrackerHitAssociation/interface/TrackerHitAssociator.h"
 
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+#include "Geometry/Records/interface/TrackerTopologyRcd.h"
+#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
+#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
+
 class TTree;
 class TFile;
 class RectangularPixelTopology;
@@ -68,6 +73,8 @@ protected:
   void fillPRecHit(const int subid, trackingRecHit_iterator pixeliter, const GeomDet* PixGeom);
 
 private:
+  edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> geom_esToken;
+  edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> topo_esToken;
   edm::ParameterSet conf_;
   TrackerHitAssociator::Config trackerHitAssociatorConfig_;
   edm::InputTag src_;


### PR DESCRIPTION
#### PR description:

Migrate `SLHCUpgradeSimulations/Geometry` test code to `esConsumes`.
Part of #31061.

#### PR validation:

Run unit tests with `scramv1 b runtests`.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Not a backport, no backport is needed.