### PR TITLE
2D Maps of Impact Parameters for TkDQM

### DIFF
--- a/DQMOffline/RecoB/plugins/PrimaryVertexMonitor.cc
+++ b/DQMOffline/RecoB/plugins/PrimaryVertexMonitor.cc
@@ -42,10 +42,14 @@ PrimaryVertexMonitor::PrimaryVertexMonitor(const edm::ParameterSet& pSet)
       dzVsPhi_pt1(nullptr),
       dxyVsEta_pt1(nullptr),
       dzVsEta_pt1(nullptr),
+      dxyVsEtaVsPhi_pt1(nullptr),
+      dzVsEtaVsPhi_pt1(nullptr),
       dxyVsPhi_pt10(nullptr),
       dzVsPhi_pt10(nullptr),
       dxyVsEta_pt10(nullptr),
-      dzVsEta_pt10(nullptr) {
+      dzVsEta_pt10(nullptr),
+      dxyVsEtaVsPhi_pt10(nullptr),
+      dzVsEtaVsPhi_pt10(nullptr) {
   //  dqmStore_ = edm::Service<DQMStore>().operator->();
 
   vertexInputTag_ = pSet.getParameter<InputTag>("vertexLabel");
@@ -176,10 +180,12 @@ void PrimaryVertexMonitor::bookHistograms(DQMStore::IBooker& iBooker, edm::Run c
   double DzMax = conf_.getParameter<double>("DzMax");
 
   int PhiBin = conf_.getParameter<int>("PhiBin");
+  int PhiBin2D = conf_.getParameter<int>("PhiBin2D");
   double PhiMin = conf_.getParameter<double>("PhiMin");
   double PhiMax = conf_.getParameter<double>("PhiMax");
 
   int EtaBin = conf_.getParameter<int>("EtaBin");
+  int EtaBin2D = conf_.getParameter<int>("EtaBin2D");
   double EtaMin = conf_.getParameter<double>("EtaMin");
   double EtaMax = conf_.getParameter<double>("EtaMax");
 
@@ -248,6 +254,38 @@ void PrimaryVertexMonitor::bookHistograms(DQMStore::IBooker& iBooker, edm::Run c
                                     "");
   dzVsEta_pt1->setAxisTitle("PV track (p_{T} > 1 GeV) #eta", 1);
   dzVsEta_pt1->setAxisTitle("PV track (p_{T} > 1 GeV) d_{z} (#mum)", 2);
+  
+  dxyVsEtaVsPhi_pt1 = iBooker.bookProfile2D ("dxyVsEtaVsPhi_pt1",
+                                     "PV tracks (p_{T} > 1 GeV) d_{xy} (#mum) VS track #eta VS track #phi",
+                                     EtaBin2D,
+                                     EtaMin,
+                                     EtaMax,
+                                     PhiBin2D,
+                                     PhiMin,
+                                     PhiMax,
+                                     DxyBin,
+                                     DxyMin,
+                                     DxyMax,
+                                     "");
+  dxyVsEtaVsPhi_pt1->setAxisTitle("PV track (p_{T} > 1 GeV) #eta", 1);
+  dxyVsEtaVsPhi_pt1->setAxisTitle("PV track (p_{T} > 1 GeV) #phi", 2);
+  dxyVsEtaVsPhi_pt1->setAxisTitle("PV track (p_{T} > 1 GeV) d_{xy} (#mum)", 3);
+  
+  dzVsEtaVsPhi_pt1 = iBooker.bookProfile2D ("dzVsEtaVsPhi_pt1",
+                                     "PV tracks (p_{T} > 1 GeV) d_{z} (#mum) VS track #eta VS track #phi",
+                                     EtaBin2D,
+                                     EtaMin,
+                                     EtaMax,
+                                     PhiBin2D,
+                                     PhiMin,
+                                     PhiMax,
+                                     DzBin,
+                                     DzMin,
+                                     DzMax,
+                                     "");
+  dzVsEtaVsPhi_pt1->setAxisTitle("PV track (p_{T} > 1 GeV) #eta", 1);
+  dzVsEtaVsPhi_pt1->setAxisTitle("PV track (p_{T} > 1 GeV) #phi", 2);
+  dzVsEtaVsPhi_pt1->setAxisTitle("PV track (p_{T} > 1 GeV) d_{z} (#mum)", 3);
 
   dxyVsPhi_pt10 = iBooker.bookProfile("dxyVsPhi_pt10",
                                       "PV tracks (p_{T} > 10 GeV) d_{xy} (#mum) VS track #phi",
@@ -296,6 +334,38 @@ void PrimaryVertexMonitor::bookHistograms(DQMStore::IBooker& iBooker, edm::Run c
                                      "");
   dzVsEta_pt10->setAxisTitle("PV track (p_{T} > 10 GeV) #eta", 1);
   dzVsEta_pt10->setAxisTitle("PV track (p_{T} > 10 GeV) d_{z} (#mum)", 2);
+  
+  dxyVsEtaVsPhi_pt10 = iBooker.bookProfile2D ("dxyVsEtaVsPhi_pt10",
+                                     "PV tracks (p_{T} > 10 GeV) d_{xy} (#mum) VS track #eta VS track #phi",
+                                     EtaBin2D,
+                                     EtaMin,
+                                     EtaMax,
+                                     PhiBin2D,
+                                     PhiMin,
+                                     PhiMax,
+                                     DxyBin,
+                                     DxyMin,
+                                     DxyMax,
+                                     "");
+  dxyVsEtaVsPhi_pt10->setAxisTitle("PV track (p_{T} > 10 GeV) #eta", 1);
+  dxyVsEtaVsPhi_pt10->setAxisTitle("PV track (p_{T} > 10 GeV) #phi", 2);
+  dxyVsEtaVsPhi_pt10->setAxisTitle("PV track (p_{T} > 10 GeV) d_{xy} (#mum)", 3);
+  
+  dzVsEtaVsPhi_pt10 = iBooker.bookProfile2D ("dzVsEtaVsPhi_pt10",
+                                     "PV tracks (p_{T} > 10 GeV) d_{z} (#mum) VS track #eta VS track #phi",
+                                     EtaBin2D,
+                                     EtaMin,
+                                     EtaMax,
+                                     PhiBin2D,
+                                     PhiMin,
+                                     PhiMax,
+                                     DzBin,
+                                     DzMin,
+                                     DzMax,
+                                     "");
+  dzVsEtaVsPhi_pt10->setAxisTitle("PV track (p_{T} > 10 GeV) #eta", 1);
+  dzVsEtaVsPhi_pt10->setAxisTitle("PV track (p_{T} > 10 GeV) #phi", 2);
+  dzVsEtaVsPhi_pt10->setAxisTitle("PV track (p_{T} > 10 GeV) d_{z} (#mum)", 3);
 }
 
 PrimaryVertexMonitor::~PrimaryVertexMonitor() {}
@@ -434,6 +504,8 @@ void PrimaryVertexMonitor::pvTracksPlots(const Vertex& v) {
     dzVsPhi_pt1->Fill(phi, Dz);
     dxyVsEta_pt1->Fill(eta, Dxy);
     dzVsEta_pt1->Fill(eta, Dz);
+    dxyVsEtaVsPhi_pt1->Fill(eta, phi, Dxy);
+    dzVsEtaVsPhi_pt1->Fill(eta, phi, Dz);
 
     if (pt < 10.)
       continue;
@@ -441,6 +513,8 @@ void PrimaryVertexMonitor::pvTracksPlots(const Vertex& v) {
     dzVsPhi_pt10->Fill(phi, Dz);
     dxyVsEta_pt10->Fill(eta, Dxy);
     dzVsEta_pt10->Fill(eta, Dz);
+    dxyVsEtaVsPhi_pt10->Fill(eta, phi, Dxy);
+    dzVsEtaVsPhi_pt10->Fill(eta, phi, Dz);
   }
   ntracks->Fill(float(nTracks));
   sumpt->Fill(sumPT);

--- a/DQMOffline/RecoB/plugins/PrimaryVertexMonitor.cc
+++ b/DQMOffline/RecoB/plugins/PrimaryVertexMonitor.cc
@@ -254,35 +254,35 @@ void PrimaryVertexMonitor::bookHistograms(DQMStore::IBooker& iBooker, edm::Run c
                                     "");
   dzVsEta_pt1->setAxisTitle("PV track (p_{T} > 1 GeV) #eta", 1);
   dzVsEta_pt1->setAxisTitle("PV track (p_{T} > 1 GeV) d_{z} (#mum)", 2);
-  
-  dxyVsEtaVsPhi_pt1 = iBooker.bookProfile2D ("dxyVsEtaVsPhi_pt1",
-                                     "PV tracks (p_{T} > 1 GeV) d_{xy} (#mum) VS track #eta VS track #phi",
-                                     EtaBin2D,
-                                     EtaMin,
-                                     EtaMax,
-                                     PhiBin2D,
-                                     PhiMin,
-                                     PhiMax,
-                                     DxyBin,
-                                     DxyMin,
-                                     DxyMax,
-                                     "");
+
+  dxyVsEtaVsPhi_pt1 = iBooker.bookProfile2D("dxyVsEtaVsPhi_pt1",
+                                            "PV tracks (p_{T} > 1 GeV) d_{xy} (#mum) VS track #eta VS track #phi",
+                                            EtaBin2D,
+                                            EtaMin,
+                                            EtaMax,
+                                            PhiBin2D,
+                                            PhiMin,
+                                            PhiMax,
+                                            DxyBin,
+                                            DxyMin,
+                                            DxyMax,
+                                            "");
   dxyVsEtaVsPhi_pt1->setAxisTitle("PV track (p_{T} > 1 GeV) #eta", 1);
   dxyVsEtaVsPhi_pt1->setAxisTitle("PV track (p_{T} > 1 GeV) #phi", 2);
   dxyVsEtaVsPhi_pt1->setAxisTitle("PV track (p_{T} > 1 GeV) d_{xy} (#mum)", 3);
-  
-  dzVsEtaVsPhi_pt1 = iBooker.bookProfile2D ("dzVsEtaVsPhi_pt1",
-                                     "PV tracks (p_{T} > 1 GeV) d_{z} (#mum) VS track #eta VS track #phi",
-                                     EtaBin2D,
-                                     EtaMin,
-                                     EtaMax,
-                                     PhiBin2D,
-                                     PhiMin,
-                                     PhiMax,
-                                     DzBin,
-                                     DzMin,
-                                     DzMax,
-                                     "");
+
+  dzVsEtaVsPhi_pt1 = iBooker.bookProfile2D("dzVsEtaVsPhi_pt1",
+                                           "PV tracks (p_{T} > 1 GeV) d_{z} (#mum) VS track #eta VS track #phi",
+                                           EtaBin2D,
+                                           EtaMin,
+                                           EtaMax,
+                                           PhiBin2D,
+                                           PhiMin,
+                                           PhiMax,
+                                           DzBin,
+                                           DzMin,
+                                           DzMax,
+                                           "");
   dzVsEtaVsPhi_pt1->setAxisTitle("PV track (p_{T} > 1 GeV) #eta", 1);
   dzVsEtaVsPhi_pt1->setAxisTitle("PV track (p_{T} > 1 GeV) #phi", 2);
   dzVsEtaVsPhi_pt1->setAxisTitle("PV track (p_{T} > 1 GeV) d_{z} (#mum)", 3);
@@ -334,35 +334,35 @@ void PrimaryVertexMonitor::bookHistograms(DQMStore::IBooker& iBooker, edm::Run c
                                      "");
   dzVsEta_pt10->setAxisTitle("PV track (p_{T} > 10 GeV) #eta", 1);
   dzVsEta_pt10->setAxisTitle("PV track (p_{T} > 10 GeV) d_{z} (#mum)", 2);
-  
-  dxyVsEtaVsPhi_pt10 = iBooker.bookProfile2D ("dxyVsEtaVsPhi_pt10",
-                                     "PV tracks (p_{T} > 10 GeV) d_{xy} (#mum) VS track #eta VS track #phi",
-                                     EtaBin2D,
-                                     EtaMin,
-                                     EtaMax,
-                                     PhiBin2D,
-                                     PhiMin,
-                                     PhiMax,
-                                     DxyBin,
-                                     DxyMin,
-                                     DxyMax,
-                                     "");
+
+  dxyVsEtaVsPhi_pt10 = iBooker.bookProfile2D("dxyVsEtaVsPhi_pt10",
+                                             "PV tracks (p_{T} > 10 GeV) d_{xy} (#mum) VS track #eta VS track #phi",
+                                             EtaBin2D,
+                                             EtaMin,
+                                             EtaMax,
+                                             PhiBin2D,
+                                             PhiMin,
+                                             PhiMax,
+                                             DxyBin,
+                                             DxyMin,
+                                             DxyMax,
+                                             "");
   dxyVsEtaVsPhi_pt10->setAxisTitle("PV track (p_{T} > 10 GeV) #eta", 1);
   dxyVsEtaVsPhi_pt10->setAxisTitle("PV track (p_{T} > 10 GeV) #phi", 2);
   dxyVsEtaVsPhi_pt10->setAxisTitle("PV track (p_{T} > 10 GeV) d_{xy} (#mum)", 3);
-  
-  dzVsEtaVsPhi_pt10 = iBooker.bookProfile2D ("dzVsEtaVsPhi_pt10",
-                                     "PV tracks (p_{T} > 10 GeV) d_{z} (#mum) VS track #eta VS track #phi",
-                                     EtaBin2D,
-                                     EtaMin,
-                                     EtaMax,
-                                     PhiBin2D,
-                                     PhiMin,
-                                     PhiMax,
-                                     DzBin,
-                                     DzMin,
-                                     DzMax,
-                                     "");
+
+  dzVsEtaVsPhi_pt10 = iBooker.bookProfile2D("dzVsEtaVsPhi_pt10",
+                                            "PV tracks (p_{T} > 10 GeV) d_{z} (#mum) VS track #eta VS track #phi",
+                                            EtaBin2D,
+                                            EtaMin,
+                                            EtaMax,
+                                            PhiBin2D,
+                                            PhiMin,
+                                            PhiMax,
+                                            DzBin,
+                                            DzMin,
+                                            DzMax,
+                                            "");
   dzVsEtaVsPhi_pt10->setAxisTitle("PV track (p_{T} > 10 GeV) #eta", 1);
   dzVsEtaVsPhi_pt10->setAxisTitle("PV track (p_{T} > 10 GeV) #phi", 2);
   dzVsEtaVsPhi_pt10->setAxisTitle("PV track (p_{T} > 10 GeV) d_{z} (#mum)", 3);

--- a/DQMOffline/RecoB/plugins/PrimaryVertexMonitor.h
+++ b/DQMOffline/RecoB/plugins/PrimaryVertexMonitor.h
@@ -66,8 +66,10 @@ private:
   MonitorElement *dxy, *dxy2, *dz, *dxyErr, *dzErr;
   MonitorElement *dxyVsPhi_pt1, *dzVsPhi_pt1;
   MonitorElement *dxyVsEta_pt1, *dzVsEta_pt1;
+  MonitorElement *dxyVsEtaVsPhi_pt1, *dzVsEtaVsPhi_pt1;
   MonitorElement *dxyVsPhi_pt10, *dzVsPhi_pt10;
   MonitorElement *dxyVsEta_pt10, *dzVsEta_pt10;
+  MonitorElement *dxyVsEtaVsPhi_pt10, *dzVsEtaVsPhi_pt10;
 };
 
 #endif

--- a/DQMOffline/RecoB/python/PrimaryVertexMonitor_cff.py
+++ b/DQMOffline/RecoB/python/PrimaryVertexMonitor_cff.py
@@ -20,9 +20,11 @@ pvMonitor = DQMEDAnalyzer('PrimaryVertexMonitor',
    DzMax          = cms.double(2000.0),
    DzMin          = cms.double(-2000.0),                                             
    PhiBin         = cms.int32(32),
+   PhiBin2D       = cms.int32(12),
    PhiMax         = cms.double(3.141592654),
    PhiMin         = cms.double(-3.141592654),
    EtaBin         = cms.int32(26),
+   EtaBin2D       = cms.int32(8),
    EtaMax         = cms.double(2.5),
    EtaMin         = cms.double(-2.5)
 )
@@ -31,5 +33,5 @@ pvMonitor = DQMEDAnalyzer('PrimaryVertexMonitor',
 from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
 from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
 phase1Pixel.toModify(pvMonitor, EtaBin=31, EtaMin=-3.0, EtaMax=3.0)
-phase2_tracker.toModify(pvMonitor, EtaBin=41, EtaMin=-4.0, EtaMax=4.0)
+phase2_tracker.toModify(pvMonitor, EtaBin=41, EtaBin2D=9, EtaMin=-4.0, EtaMax=4.0)
 


### PR DESCRIPTION
#### PR description:

We added a total of four 2D histograms showing the mean Impact Parameters as a function of track eta and phi for TkDQM. For each of the following track selections:
- PV track with pT>1 GeV
- PV track with pT>10 GeV

one histogram for dxy and one for dz is added.

#### PR validation:

The changes have been tested by running `runTheMatrix.py -l 10024`, which runs without any failed steps and produces the desired additional plots.
Here is a screenshot of the output DQM file showing one of the four maps:

<img src="https://user-images.githubusercontent.com/32901048/117827267-1d722300-b271-11eb-91b1-530379fffa8f.png" width="500">


#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This PR is not a backport.

cc:
@mmusich, @arossi83, @sroychow 
