### PR TITLE
Fix valEmtfStage2Digis for unpacked GEM clusters in GEN-SIM-RAW

### DIFF
--- a/DQM/L1TMonitor/python/L1TStage2Emulator_cff.py
+++ b/DQM/L1TMonitor/python/L1TStage2Emulator_cff.py
@@ -71,7 +71,8 @@ run3_GEM.toModify( valCscStage2Digis, GEMPadDigiClusterProducer = "valMuonGEMPad
 from L1Trigger.L1TMuonEndCap.simEmtfDigis_cfi import *
 valEmtfStage2Digis = simEmtfDigis.clone(
     CSCInput = "emtfStage2Digis",
-    RPCInput = "muonRPCDigis"
+    RPCInput = "muonRPCDigis",
+    GEMInput = 'valMuonGEMPadDigiClusters'
 )
 
 # uGMT


### PR DESCRIPTION
#### PR description:

In response to issue https://github.com/cms-sw/cmssw/issues/32634. This would allow the `dqmoffline` to run on GEN-SIM-RAW in Run-3 scenarios with GEMs included. Previously, `valEmtfStage2Digis` crashed because it could not find `simMuonGEMPadDigiClusters`. That is expected. A solution is provided where the GEM trigger primitive producers are run on unpacked GEM digis in GEN-SIM-RAW. Those GEM TP producers have prefixes ```valMuon```. `valMuonGEMPadDigiClusters` may be replaced with `emtfStage2Digis` once the EMTF unpacker has been updated for GEM TPs in data and the collection is available in the event.

#### PR validation:

Code compiles. Tried the recipe in the first message of https://github.com/cms-sw/cmssw/issues/32634.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
