### PR TITLE
Work around an inaccurate error message in TTreeCache::FillBuffer()

### DIFF
--- a/FWCore/Services/plugins/InitRootHandlers.cc
+++ b/FWCore/Services/plugins/InitRootHandlers.cc
@@ -169,9 +169,10 @@ namespace {
                                                           "TGClient::GetFontByName",
                                                           "Inverter::Dinv"}};
 
-  constexpr std::array<const char* const, 3> in_message_print{{"number of iterations was insufficient",
+  constexpr std::array<const char* const, 4> in_message_print{{"number of iterations was insufficient",
                                                                "bad integrand behavior",
-                                                               "integral is divergent, or slowly convergent"}};
+                                                               "integral is divergent, or slowly convergent",
+                                                               "but fEntryCurrent should not be in between the two"}};
 
   void RootErrorHandlerImpl(int level, char const* location, char const* message) {
     bool die = false;


### PR DESCRIPTION
#### PR description:

This PR works around an inaccurate error message in ROOT's `TTreeCache::FillBuffer()` that we elevate to an exception described in #33361. Motivation for this PR is to avoid further wait for the fix in ROOT to be merged and backported to 6.14 (if the backport ever happens) in the production jobs that are stuck in this problem.

Resolves #33361 (really works around it), resolves https://github.com/makortel/framework/issues/139 .

#### PR validation:

Framework unit tests run. Example case in https://github.com/cms-sw/cmssw/issues/33361 does not terminate in an exception, and the printout is visible.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Intentionally submitted to 10_6_X only. In master we'll wait for the fix in ROOT.