### PR TITLE
Moved ProductProvenanceRetriever to FWCore/Framework

### DIFF
--- a/DataFormats/Common/interface/ProductData.h
+++ b/DataFormats/Common/interface/ProductData.h
@@ -53,7 +53,7 @@ namespace edm {
 
     void unsafe_resetProductData() const { wrapper_.reset(); }
 
-    void setProvenance(ProductProvenanceRetriever const* provRetriever) { prov_.setStore(provRetriever); }
+    void setProvenance(ProductProvenanceLookup const* provRetriever) { prov_.setStore(provRetriever); }
 
     void setProductID(ProductID const& pid) { prov_.setProductID(pid); }
 

--- a/DataFormats/Provenance/BuildFile.xml
+++ b/DataFormats/Provenance/BuildFile.xml
@@ -1,6 +1,5 @@
 <use name="FWCore/Utilities"/>
 <use name="FWCore/Reflection"/>
-<use name="FWCore/Concurrency"/>
 <use name="rootcore"/>
 <use name="tbb"/>
 <export>

--- a/DataFormats/Provenance/interface/ProductProvenanceLookup.h
+++ b/DataFormats/Provenance/interface/ProductProvenanceLookup.h
@@ -1,0 +1,105 @@
+#ifndef DataFormats_Provenance_ProductProvenanceLookup_h
+#define DataFormats_Provenance_ProductProvenanceLookup_h
+
+/*----------------------------------------------------------------------
+  
+ProductProvenanceLookup: Gives access to the per event/lumi/run per product provenance.
+
+----------------------------------------------------------------------*/
+#include "DataFormats/Provenance/interface/BranchID.h"
+#include "DataFormats/Provenance/interface/ProductProvenance.h"
+#include "FWCore/Utilities/interface/propagate_const.h"
+#include "FWCore/Utilities/interface/Likely.h"
+#include "FWCore/Utilities/interface/thread_safety_macros.h"
+
+#include <vector>
+#include <memory>
+#include <set>
+#include <atomic>
+
+/*
+ ProductProvenanceLookup
+*/
+
+namespace edm {
+  class ProductRegistry;
+
+  class ProductProvenanceLookup {
+  public:
+    ProductProvenanceLookup();
+    explicit ProductProvenanceLookup(edm::ProductRegistry const&);
+    virtual ~ProductProvenanceLookup();
+
+    ProductProvenanceLookup& operator=(ProductProvenanceLookup const&) = delete;
+
+    ProductProvenance const* branchIDToProvenance(BranchID const& bid) const;
+    void insertIntoSet(ProductProvenance provenanceProduct) const;
+    ProductProvenance const* branchIDToProvenanceForProducedOnly(BranchID const& bid) const;
+
+    void update(edm::ProductRegistry const&);
+
+    class ProducedProvenanceInfo {
+    public:
+      ProducedProvenanceInfo(BranchID iBid) : provenance_{iBid}, isParentageSet_{false} {}
+      ProducedProvenanceInfo(ProducedProvenanceInfo&& iOther)
+          : provenance_{std::move(iOther.provenance_)},
+            isParentageSet_{iOther.isParentageSet_.load(std::memory_order_acquire)} {}
+      ProducedProvenanceInfo(ProducedProvenanceInfo const& iOther) : provenance_{iOther.provenance_.branchID()} {
+        bool isSet = iOther.isParentageSet_.load(std::memory_order_acquire);
+        if (isSet) {
+          provenance_.set(iOther.provenance_.parentageID());
+        }
+        isParentageSet_.store(isSet, std::memory_order_release);
+      }
+
+      ProducedProvenanceInfo& operator=(ProducedProvenanceInfo&& iOther) {
+        provenance_ = std::move(iOther.provenance_);
+        isParentageSet_.store(iOther.isParentageSet_.load(std::memory_order_acquire), std::memory_order_release);
+        return *this;
+      }
+      ProducedProvenanceInfo& operator=(ProducedProvenanceInfo const& iOther) {
+        bool isSet = iOther.isParentageSet_.load(std::memory_order_acquire);
+        if (isSet) {
+          provenance_ = iOther.provenance_;
+        } else {
+          provenance_ = ProductProvenance(iOther.provenance_.branchID());
+        }
+        isParentageSet_.store(isSet, std::memory_order_release);
+        return *this;
+      }
+
+      ProductProvenance const* productProvenance() const noexcept {
+        if (LIKELY(isParentageSet())) {
+          return &provenance_;
+        }
+        return nullptr;
+      }
+      BranchID branchID() const noexcept { return provenance_.branchID(); }
+
+      bool isParentageSet() const noexcept { return isParentageSet_.load(std::memory_order_acquire); }
+
+      void threadsafe_set(ParentageID id) const {
+        provenance_.set(std::move(id));
+        isParentageSet_.store(true, std::memory_order_release);
+      }
+
+      void resetParentage() { isParentageSet_.store(false, std::memory_order_release); }
+
+    private:
+      CMS_THREAD_GUARD(isParentageSet_) mutable ProductProvenance provenance_;
+      mutable std::atomic<bool> isParentageSet_;
+    };
+
+  protected:
+    virtual std::unique_ptr<const std::set<ProductProvenance>> readProvenance() const = 0;
+    virtual const ProductProvenanceLookup* nextRetriever() const = 0;
+
+    std::vector<ProducedProvenanceInfo> entryInfoSet_;
+    mutable std::atomic<const std::set<ProductProvenance>*> readEntryInfoSet_;
+    edm::propagate_const<ProductProvenanceLookup const*> parentProcessRetriever_;
+
+  private:
+    void setupEntryInfoSet(edm::ProductRegistry const&);
+  };
+}  // namespace edm
+#endif

--- a/DataFormats/Provenance/interface/ProductProvenanceRetriever.h
+++ b/DataFormats/Provenance/interface/ProductProvenanceRetriever.h
@@ -8,11 +8,9 @@ ProductProvenanceRetriever: Manages the per event/lumi/run per product provenanc
 ----------------------------------------------------------------------*/
 #include "DataFormats/Provenance/interface/BranchID.h"
 #include "DataFormats/Provenance/interface/ProductProvenance.h"
-#include "DataFormats/Provenance/interface/ProcessHistoryID.h"
+#include "DataFormats/Provenance/interface/ProductProvenanceLookup.h"
 #include "FWCore/Concurrency/interface/WaitingTaskHolder.h"
 #include "FWCore/Utilities/interface/propagate_const.h"
-#include "FWCore/Utilities/interface/Likely.h"
-#include "FWCore/Utilities/interface/thread_safety_macros.h"
 
 #include <vector>
 #include <memory>
@@ -29,19 +27,6 @@ namespace edm {
   class ModuleCallingContext;
   class ProductRegistry;
 
-  struct ProductProvenanceHasher {
-    size_t operator()(ProductProvenance const& tid) const { return tid.branchID().id(); }
-  };
-
-  struct ProductProvenanceEqual {
-    //The default operator== for ProductProvenance does not work for this case
-    // Since (a<b)==false  and (a>b)==false does not mean a==b for the operators
-    // defined for ProductProvenance
-    bool operator()(ProductProvenance const& iLHS, ProductProvenance const iRHS) const {
-      return iLHS.branchID().id() == iRHS.branchID().id();
-    }
-  };
-
   class ProvenanceReaderBase {
   public:
     ProvenanceReaderBase() {}
@@ -53,21 +38,13 @@ namespace edm {
                                      std::atomic<const std::set<ProductProvenance>*>& writeTo) const = 0;
   };
 
-  class ProductProvenanceRetriever {
+  class ProductProvenanceRetriever : public ProductProvenanceLookup {
   public:
     explicit ProductProvenanceRetriever(unsigned int iTransitionIndex);
     ProductProvenanceRetriever(unsigned int iTransitionIndex, edm::ProductRegistry const&);
     explicit ProductProvenanceRetriever(std::unique_ptr<ProvenanceReaderBase> reader);
 
     ProductProvenanceRetriever& operator=(ProductProvenanceRetriever const&) = delete;
-
-    ~ProductProvenanceRetriever();
-
-    ProductProvenance const* branchIDToProvenance(BranchID const& bid) const;
-
-    ProductProvenance const* branchIDToProvenanceForProducedOnly(BranchID const& bid) const;
-
-    void insertIntoSet(ProductProvenance provenanceProduct) const;
 
     void mergeProvenanceRetrievers(std::shared_ptr<ProductProvenanceRetriever> other);
 
@@ -79,69 +56,12 @@ namespace edm {
 
     void readProvenanceAsync(WaitingTaskHolder task, ModuleCallingContext const* moduleCallingContext) const;
 
-    void update(edm::ProductRegistry const&);
-
-    class ProducedProvenanceInfo {
-    public:
-      ProducedProvenanceInfo(BranchID iBid) : provenance_{iBid}, isParentageSet_{false} {}
-      ProducedProvenanceInfo(ProducedProvenanceInfo&& iOther)
-          : provenance_{std::move(iOther.provenance_)},
-            isParentageSet_{iOther.isParentageSet_.load(std::memory_order_acquire)} {}
-      ProducedProvenanceInfo(ProducedProvenanceInfo const& iOther) : provenance_{iOther.provenance_.branchID()} {
-        bool isSet = iOther.isParentageSet_.load(std::memory_order_acquire);
-        if (isSet) {
-          provenance_.set(iOther.provenance_.parentageID());
-        }
-        isParentageSet_.store(isSet, std::memory_order_release);
-      }
-
-      ProducedProvenanceInfo& operator=(ProducedProvenanceInfo&& iOther) {
-        provenance_ = std::move(iOther.provenance_);
-        isParentageSet_.store(iOther.isParentageSet_.load(std::memory_order_acquire), std::memory_order_release);
-        return *this;
-      }
-      ProducedProvenanceInfo& operator=(ProducedProvenanceInfo const& iOther) {
-        bool isSet = iOther.isParentageSet_.load(std::memory_order_acquire);
-        if (isSet) {
-          provenance_ = iOther.provenance_;
-        } else {
-          provenance_ = ProductProvenance(iOther.provenance_.branchID());
-        }
-        isParentageSet_.store(isSet, std::memory_order_release);
-        return *this;
-      }
-
-      ProductProvenance const* productProvenance() const noexcept {
-        if (LIKELY(isParentageSet())) {
-          return &provenance_;
-        }
-        return nullptr;
-      }
-      BranchID branchID() const noexcept { return provenance_.branchID(); }
-
-      bool isParentageSet() const noexcept { return isParentageSet_.load(std::memory_order_acquire); }
-
-      void threadsafe_set(ParentageID id) const {
-        provenance_.set(std::move(id));
-        isParentageSet_.store(true, std::memory_order_release);
-      }
-
-      void resetParentage() { isParentageSet_.store(false, std::memory_order_release); }
-
-    private:
-      CMS_THREAD_GUARD(isParentageSet_) mutable ProductProvenance provenance_;
-      mutable std::atomic<bool> isParentageSet_;
-    };
-
   private:
-    void readProvenance() const;
+    std::unique_ptr<const std::set<ProductProvenance>> readProvenance() const final;
+    const ProductProvenanceLookup* nextRetriever() const final { return nextRetriever_.get(); }
     void setTransitionIndex(unsigned int transitionIndex) { transitionIndex_ = transitionIndex; }
-    void setupEntryInfoSet(edm::ProductRegistry const&);
 
-    std::vector<ProducedProvenanceInfo> entryInfoSet_;
-    mutable std::atomic<const std::set<ProductProvenance>*> readEntryInfoSet_;
     edm::propagate_const<std::shared_ptr<ProductProvenanceRetriever>> nextRetriever_;
-    edm::propagate_const<ProductProvenanceRetriever const*> parentProcessRetriever_;
     std::shared_ptr<const ProvenanceReaderBase> provenanceReader_;
     unsigned int transitionIndex_;
   };

--- a/DataFormats/Provenance/interface/Provenance.h
+++ b/DataFormats/Provenance/interface/Provenance.h
@@ -29,7 +29,7 @@ existence.
 namespace edm {
   class MergeableRunProductMetadataBase;
   class ProductProvenance;
-  class ProductProvenanceRetriever;
+  class ProductProvenanceLookup;
 
   class Provenance {
   public:
@@ -57,7 +57,7 @@ namespace edm {
     std::string const& processName() const { return stable().processName(); }
     std::string const& productInstanceName() const { return stable().productInstanceName(); }
     std::string const& friendlyClassName() const { return stable().friendlyClassName(); }
-    ProductProvenanceRetriever const* store() const { return store_; }
+    ProductProvenanceLookup const* store() const { return store_; }
     std::set<std::string> const& branchAliases() const { return stable().branchAliases(); }
 
     // Usually branchID() and originalBranchID() return exactly the same result.
@@ -74,7 +74,7 @@ namespace edm {
 
     void write(std::ostream& os) const;
 
-    void setStore(ProductProvenanceRetriever const* store) { store_ = store; }
+    void setStore(ProductProvenanceLookup const* store) { store_ = store; }
 
     ProductID const& productID() const { return stable().productID(); }
 
@@ -90,7 +90,7 @@ namespace edm {
 
   private:
     StableProvenance stableProvenance_;
-    ProductProvenanceRetriever const* store_;
+    ProductProvenanceLookup const* store_;
     MergeableRunProductMetadataBase const* mergeableRunProductMetadata_;
   };
 

--- a/DataFormats/Provenance/interface/ProvenanceFwd.h
+++ b/DataFormats/Provenance/interface/ProvenanceFwd.h
@@ -26,7 +26,6 @@ namespace edm {
   class StableProvenance;
   class Timestamp;
   class ProductProvenanceLookup;
-  class ProductProvenanceRetriever;
 }  // namespace edm
 
 namespace cms {

--- a/DataFormats/Provenance/interface/ProvenanceFwd.h
+++ b/DataFormats/Provenance/interface/ProvenanceFwd.h
@@ -25,6 +25,7 @@ namespace edm {
   class RunID;
   class StableProvenance;
   class Timestamp;
+  class ProductProvenanceLookup;
   class ProductProvenanceRetriever;
 }  // namespace edm
 

--- a/DataFormats/Provenance/src/ProductProvenanceLookup.cc
+++ b/DataFormats/Provenance/src/ProductProvenanceLookup.cc
@@ -1,0 +1,117 @@
+#include "DataFormats/Provenance/interface/ProductProvenanceLookup.h"
+#include "DataFormats/Provenance/interface/ProductRegistry.h"
+#include "FWCore/Utilities/interface/EDMException.h"
+
+#include <cassert>
+#include <iostream>
+#include <limits>
+
+/*
+ ProductProvenanceLookup
+*/
+
+namespace edm {
+  ProductProvenanceLookup::ProductProvenanceLookup()
+      : entryInfoSet_(), readEntryInfoSet_(), parentProcessRetriever_(nullptr) {}
+
+  ProductProvenanceLookup::ProductProvenanceLookup(edm::ProductRegistry const& iReg)
+      : entryInfoSet_(), readEntryInfoSet_(), parentProcessRetriever_(nullptr) {
+    setupEntryInfoSet(iReg);
+  }
+
+  ProductProvenanceLookup::~ProductProvenanceLookup() { delete readEntryInfoSet_.load(); }
+
+  void ProductProvenanceLookup::setupEntryInfoSet(edm::ProductRegistry const& iReg) {
+    std::set<BranchID> ids;
+    for (auto const& p : iReg.productList()) {
+      if (p.second.branchType() == edm::InEvent) {
+        if (p.second.produced() or p.second.isProvenanceSetOnRead()) {
+          ids.insert(p.second.branchID());
+        }
+      }
+    }
+    entryInfoSet_.reserve(ids.size());
+    for (auto const& b : ids) {
+      entryInfoSet_.emplace_back(b);
+    }
+  }
+
+  void ProductProvenanceLookup::update(edm::ProductRegistry const& iReg) {
+    entryInfoSet_.clear();
+    setupEntryInfoSet(iReg);
+  }
+
+  void ProductProvenanceLookup::insertIntoSet(ProductProvenance entryInfo) const {
+    //NOTE:do not read provenance here because we only need the full
+    // provenance when someone tries to access it not when doing the insert
+    // doing the delay saves 20% of time when doing an analysis job
+    //readProvenance();
+    auto itFound =
+        std::lower_bound(entryInfoSet_.begin(),
+                         entryInfoSet_.end(),
+                         entryInfo.branchID(),
+                         [](auto const& iEntry, edm::BranchID const& iValue) { return iEntry.branchID() < iValue; });
+    if UNLIKELY (itFound == entryInfoSet_.end() or itFound->branchID() != entryInfo.branchID()) {
+      throw edm::Exception(edm::errors::LogicError) << "ProductProvenanceLookup::insertIntoSet passed a BranchID "
+                                                    << entryInfo.branchID().id() << " that has not been pre-registered";
+    }
+    itFound->threadsafe_set(entryInfo.moveParentageID());
+  }
+
+  ProductProvenance const* ProductProvenanceLookup::branchIDToProvenance(BranchID const& bid) const {
+    auto itFound = std::lower_bound(
+        entryInfoSet_.begin(), entryInfoSet_.end(), bid, [](auto const& iEntry, edm::BranchID const& iValue) {
+          return iEntry.branchID() < iValue;
+        });
+    if (itFound != entryInfoSet_.end() and itFound->branchID() == bid) {
+      if (auto p = itFound->productProvenance()) {
+        return p;
+      }
+    }
+    if (parentProcessRetriever_) {
+      return parentProcessRetriever_->branchIDToProvenance(bid);
+    }
+    //check in source
+    if (nullptr == readEntryInfoSet_.load()) {
+      auto readProv = readProvenance();
+      std::set<ProductProvenance> const* expected = nullptr;
+      if (readEntryInfoSet_.compare_exchange_strong(expected, readProv.get())) {
+        readProv.release();
+      }
+    }
+    auto ptr = readEntryInfoSet_.load();
+    if (ptr) {
+      ProductProvenance ei(bid);
+      auto itRead = ptr->find(ei);
+      if (itRead != ptr->end()) {
+        return &*itRead;
+      }
+    }
+    auto nr = nextRetriever();
+    if (nr) {
+      return nr->branchIDToProvenance(bid);
+    }
+    return nullptr;
+  }
+
+  ProductProvenance const* ProductProvenanceLookup::branchIDToProvenanceForProducedOnly(BranchID const& bid) const {
+    auto itFound = std::lower_bound(
+        entryInfoSet_.begin(), entryInfoSet_.end(), bid, [](auto const& iEntry, edm::BranchID const& iValue) {
+          return iEntry.branchID() < iValue;
+        });
+    if (itFound != entryInfoSet_.end() and itFound->branchID() == bid) {
+      if (auto p = itFound->productProvenance()) {
+        return p;
+      }
+    }
+    if (parentProcessRetriever_) {
+      return parentProcessRetriever_->branchIDToProvenanceForProducedOnly(bid);
+    }
+    auto nr = nextRetriever();
+    if (nr) {
+      return nr->branchIDToProvenanceForProducedOnly(bid);
+    }
+    return nullptr;
+  }
+
+}  // namespace edm

--- a/DataFormats/Provenance/src/ProductProvenanceLookup.cc
+++ b/DataFormats/Provenance/src/ProductProvenanceLookup.cc
@@ -2,9 +2,7 @@
 #include "DataFormats/Provenance/interface/ProductRegistry.h"
 #include "FWCore/Utilities/interface/EDMException.h"
 
-#include <cassert>
-#include <iostream>
-#include <limits>
+#include <algorithm>
 
 /*
  ProductProvenanceLookup

--- a/DataFormats/Provenance/src/ProductProvenanceRetriever.cc
+++ b/DataFormats/Provenance/src/ProductProvenanceRetriever.cc
@@ -12,65 +12,26 @@
 
 namespace edm {
   ProductProvenanceRetriever::ProductProvenanceRetriever(unsigned int iTransitionIndex)
-      : entryInfoSet_(),
-        readEntryInfoSet_(),
-        nextRetriever_(),
-        parentProcessRetriever_(nullptr),
-        provenanceReader_(),
-        transitionIndex_(iTransitionIndex) {}
+      : ProductProvenanceLookup(), nextRetriever_(), provenanceReader_(), transitionIndex_(iTransitionIndex) {}
 
   ProductProvenanceRetriever::ProductProvenanceRetriever(unsigned int iTransitionIndex,
                                                          edm::ProductRegistry const& iReg)
-      : entryInfoSet_(),
-        readEntryInfoSet_(),
-        nextRetriever_(),
-        parentProcessRetriever_(nullptr),
-        provenanceReader_(),
-        transitionIndex_(iTransitionIndex) {
-    setupEntryInfoSet(iReg);
-  }
+      : ProductProvenanceLookup(iReg), nextRetriever_(), provenanceReader_(), transitionIndex_(iTransitionIndex) {}
 
   ProductProvenanceRetriever::ProductProvenanceRetriever(std::unique_ptr<ProvenanceReaderBase> reader)
-      : entryInfoSet_(),
-        readEntryInfoSet_(),
+      : ProductProvenanceLookup(),
         nextRetriever_(),
-        parentProcessRetriever_(nullptr),
         provenanceReader_(reader.release()),
         transitionIndex_(std::numeric_limits<unsigned int>::max()) {
     assert(provenanceReader_);
   }
 
-  ProductProvenanceRetriever::~ProductProvenanceRetriever() { delete readEntryInfoSet_.load(); }
-
-  void ProductProvenanceRetriever::readProvenance() const {
-    if (nullptr == readEntryInfoSet_.load() && provenanceReader_) {
-      auto temp =
-          std::make_unique<std::set<ProductProvenance> const>(provenanceReader_->readProvenance(transitionIndex_));
-      std::set<ProductProvenance> const* expected = nullptr;
-      if (readEntryInfoSet_.compare_exchange_strong(expected, temp.get())) {
-        temp.release();
-      }
+  std::unique_ptr<const std::set<ProductProvenance>> ProductProvenanceRetriever::readProvenance() const {
+    std::unique_ptr<const std::set<ProductProvenance>> temp;
+    if (provenanceReader_) {
+      temp = std::make_unique<std::set<ProductProvenance> const>(provenanceReader_->readProvenance(transitionIndex_));
     }
-  }
-
-  void ProductProvenanceRetriever::setupEntryInfoSet(edm::ProductRegistry const& iReg) {
-    std::set<BranchID> ids;
-    for (auto const& p : iReg.productList()) {
-      if (p.second.branchType() == edm::InEvent) {
-        if (p.second.produced() or p.second.isProvenanceSetOnRead()) {
-          ids.insert(p.second.branchID());
-        }
-      }
-    }
-    entryInfoSet_.reserve(ids.size());
-    for (auto const& b : ids) {
-      entryInfoSet_.emplace_back(b);
-    }
-  }
-
-  void ProductProvenanceRetriever::update(edm::ProductRegistry const& iReg) {
-    entryInfoSet_.clear();
-    setupEntryInfoSet(iReg);
+    return temp;
   }
 
   void ProductProvenanceRetriever::readProvenanceAsync(WaitingTaskHolder task,
@@ -118,77 +79,12 @@ namespace edm {
     parentProcessRetriever_ = nullptr;
   }
 
-  void ProductProvenanceRetriever::insertIntoSet(ProductProvenance entryInfo) const {
-    //NOTE:do not read provenance here because we only need the full
-    // provenance when someone tries to access it not when doing the insert
-    // doing the delay saves 20% of time when doing an analysis job
-    //readProvenance();
-    auto itFound =
-        std::lower_bound(entryInfoSet_.begin(),
-                         entryInfoSet_.end(),
-                         entryInfo.branchID(),
-                         [](auto const& iEntry, edm::BranchID const& iValue) { return iEntry.branchID() < iValue; });
-    if UNLIKELY (itFound == entryInfoSet_.end() or itFound->branchID() != entryInfo.branchID()) {
-      throw edm::Exception(edm::errors::LogicError) << "ProductProvenanceRetriever::insertIntoSet passed a BranchID "
-                                                    << entryInfo.branchID().id() << " that has not been pre-registered";
-    }
-    itFound->threadsafe_set(entryInfo.moveParentageID());
-  }
-
   void ProductProvenanceRetriever::mergeProvenanceRetrievers(std::shared_ptr<ProductProvenanceRetriever> other) {
     nextRetriever_ = other;
   }
 
   void ProductProvenanceRetriever::mergeParentProcessRetriever(ProductProvenanceRetriever const& provRetriever) {
     parentProcessRetriever_ = &provRetriever;
-  }
-
-  ProductProvenance const* ProductProvenanceRetriever::branchIDToProvenance(BranchID const& bid) const {
-    auto itFound = std::lower_bound(
-        entryInfoSet_.begin(), entryInfoSet_.end(), bid, [](auto const& iEntry, edm::BranchID const& iValue) {
-          return iEntry.branchID() < iValue;
-        });
-    if (itFound != entryInfoSet_.end() and itFound->branchID() == bid) {
-      if (auto p = itFound->productProvenance()) {
-        return p;
-      }
-    }
-    if (parentProcessRetriever_) {
-      return parentProcessRetriever_->branchIDToProvenance(bid);
-    }
-    //check in source
-    readProvenance();
-    auto ptr = readEntryInfoSet_.load();
-    if (ptr) {
-      ProductProvenance ei(bid);
-      auto itRead = ptr->find(ei);
-      if (itRead != ptr->end()) {
-        return &*itRead;
-      }
-    }
-    if (nextRetriever_) {
-      return nextRetriever_->branchIDToProvenance(bid);
-    }
-    return nullptr;
-  }
-
-  ProductProvenance const* ProductProvenanceRetriever::branchIDToProvenanceForProducedOnly(BranchID const& bid) const {
-    auto itFound = std::lower_bound(
-        entryInfoSet_.begin(), entryInfoSet_.end(), bid, [](auto const& iEntry, edm::BranchID const& iValue) {
-          return iEntry.branchID() < iValue;
-        });
-    if (itFound != entryInfoSet_.end() and itFound->branchID() == bid) {
-      if (auto p = itFound->productProvenance()) {
-        return p;
-      }
-    }
-    if (parentProcessRetriever_) {
-      return parentProcessRetriever_->branchIDToProvenanceForProducedOnly(bid);
-    }
-    if (nextRetriever_) {
-      return nextRetriever_->branchIDToProvenanceForProducedOnly(bid);
-    }
-    return nullptr;
   }
 
   ProvenanceReaderBase::~ProvenanceReaderBase() {}

--- a/DataFormats/Provenance/src/Provenance.cc
+++ b/DataFormats/Provenance/src/Provenance.cc
@@ -1,7 +1,7 @@
 #include "DataFormats/Provenance/interface/Provenance.h"
 
 #include "DataFormats/Provenance/interface/MergeableRunProductMetadataBase.h"
-#include "DataFormats/Provenance/interface/ProductProvenanceRetriever.h"
+#include "DataFormats/Provenance/interface/ProductProvenanceLookup.h"
 #include "DataFormats/Provenance/interface/ProcessConfiguration.h"
 
 #include <algorithm>

--- a/FWCore/Framework/interface/EventPrincipal.h
+++ b/FWCore/Framework/interface/EventPrincipal.h
@@ -14,7 +14,7 @@ is the DataBlock.
 
 #include "DataFormats/Common/interface/WrapperBase.h"
 #include "DataFormats/Provenance/interface/BranchListIndex.h"
-#include "DataFormats/Provenance/interface/ProductProvenanceRetriever.h"
+#include "FWCore/Framework/interface/ProductProvenanceRetriever.h"
 #include "DataFormats/Provenance/interface/EventAuxiliary.h"
 #include "DataFormats/Provenance/interface/EventSelectionID.h"
 #include "FWCore/Utilities/interface/StreamID.h"

--- a/FWCore/Framework/interface/ProductProvenanceRetriever.h
+++ b/FWCore/Framework/interface/ProductProvenanceRetriever.h
@@ -6,24 +6,20 @@
 ProductProvenanceRetriever: Manages the per event/lumi/run per product provenance.
 
 ----------------------------------------------------------------------*/
-#include "DataFormats/Provenance/interface/BranchID.h"
 #include "DataFormats/Provenance/interface/ProductProvenance.h"
 #include "DataFormats/Provenance/interface/ProductProvenanceLookup.h"
 #include "FWCore/Concurrency/interface/WaitingTaskHolder.h"
 #include "FWCore/Utilities/interface/propagate_const.h"
 
-#include <vector>
 #include <memory>
 #include <set>
 #include <atomic>
-#include <string_view>
 
 /*
   ProductProvenanceRetriever
 */
 
 namespace edm {
-  class ProvenanceReaderBase;
   class ModuleCallingContext;
   class ProductRegistry;
 

--- a/FWCore/Framework/interface/ProductProvenanceRetriever.h
+++ b/FWCore/Framework/interface/ProductProvenanceRetriever.h
@@ -1,5 +1,5 @@
-#ifndef DataFormats_Provenance_BranchMapper_h
-#define DataFormats_Provenance_BranchMapper_h
+#ifndef DataFormats_Provenance_ProductProvenanceRetriever_h
+#define DataFormats_Provenance_ProductProvenanceRetriever_h
 
 /*----------------------------------------------------------------------
   

--- a/FWCore/Framework/src/ProductProvenanceRetriever.cc
+++ b/FWCore/Framework/src/ProductProvenanceRetriever.cc
@@ -3,7 +3,6 @@
 #include "FWCore/Utilities/interface/EDMException.h"
 
 #include <cassert>
-#include <iostream>
 #include <limits>
 
 /*

--- a/FWCore/Framework/src/ProductProvenanceRetriever.cc
+++ b/FWCore/Framework/src/ProductProvenanceRetriever.cc
@@ -1,4 +1,4 @@
-#include "DataFormats/Provenance/interface/ProductProvenanceRetriever.h"
+#include "FWCore/Framework/interface/ProductProvenanceRetriever.h"
 #include "DataFormats/Provenance/interface/ProductRegistry.h"
 #include "FWCore/Utilities/interface/EDMException.h"
 

--- a/FWCore/Framework/src/ProductResolvers.cc
+++ b/FWCore/Framework/src/ProductResolvers.cc
@@ -11,7 +11,7 @@
 #include "FWCore/Framework/interface/SharedResourcesAcquirer.h"
 #include "FWCore/Framework/interface/DelayedReader.h"
 #include "FWCore/Framework/src/TransitionInfoTypes.h"
-#include "DataFormats/Provenance/interface/ProductProvenanceRetriever.h"
+#include "FWCore/Framework/interface/ProductProvenanceRetriever.h"
 #include "DataFormats/Provenance/interface/BranchKey.h"
 #include "DataFormats/Provenance/interface/ParentageRegistry.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"

--- a/FWCore/Integration/test/TestParentage.cc
+++ b/FWCore/Integration/test/TestParentage.cc
@@ -3,7 +3,7 @@
 #include "DataFormats/Provenance/interface/BranchID.h"
 #include "DataFormats/Provenance/interface/Parentage.h"
 #include "DataFormats/Provenance/interface/ProductProvenance.h"
-#include "DataFormats/Provenance/interface/ProductProvenanceRetriever.h"
+#include "DataFormats/Provenance/interface/ProductProvenanceLookup.h"
 #include "DataFormats/Provenance/interface/Provenance.h"
 #include "DataFormats/TestObjects/interface/ToyProducts.h"
 #include "FWCore/Framework/interface/ConstProductRegistry.h"
@@ -37,7 +37,7 @@ namespace {
   // ProductsResolver which for SubProcesses could lead to a different
   // retriever. In SubProcesses, the following function follows the
   // links in the retrievers themselves. Both should give the same answer.
-  void getAncestorsFromRetriever(edm::ProductProvenanceRetriever const* retriever,
+  void getAncestorsFromRetriever(edm::ProductProvenanceLookup const* retriever,
                                  edm::BranchID const& branchID,
                                  std::set<edm::BranchID>& ancestors) {
     edm::ProductProvenance const* productProvenance = retriever->branchIDToProvenance(branchID);
@@ -110,7 +110,7 @@ namespace edmtest {
       }
     }
 
-    edm::ProductProvenanceRetriever const* retriever = prov->store();
+    auto const* retriever = prov->store();
     std::set<edm::BranchID> ancestorsFromRetriever;
     getAncestorsFromRetriever(retriever, prov->originalBranchID(), ancestorsFromRetriever);
 

--- a/FWCore/TFWLiteSelector/src/TFWLiteSelectorBasic.cc
+++ b/FWCore/TFWLiteSelector/src/TFWLiteSelectorBasic.cc
@@ -20,7 +20,7 @@
 #include "DataFormats/Provenance/interface/BranchIDList.h"
 #include "DataFormats/Provenance/interface/BranchIDListHelper.h"
 #include "DataFormats/Provenance/interface/BranchListIndex.h"
-#include "DataFormats/Provenance/interface/ProductProvenanceRetriever.h"
+#include "FWCore/Framework/interface/ProductProvenanceRetriever.h"
 #include "DataFormats/Provenance/interface/BranchType.h"
 #include "DataFormats/Provenance/interface/EventAuxiliary.h"
 #include "DataFormats/Provenance/interface/EventEntryDescription.h"  // kludge to allow compilation

--- a/IOPool/Output/src/PoolOutputModule.cc
+++ b/IOPool/Output/src/PoolOutputModule.cc
@@ -15,7 +15,7 @@
 #include "DataFormats/Provenance/interface/Parentage.h"
 #include "DataFormats/Provenance/interface/ParentageRegistry.h"
 #include "DataFormats/Provenance/interface/ProductProvenance.h"
-#include "DataFormats/Provenance/interface/ProductProvenanceRetriever.h"
+#include "FWCore/Framework/interface/ProductProvenanceRetriever.h"
 #include "DataFormats/Provenance/interface/SubProcessParentageHelper.h"
 #include "FWCore/Utilities/interface/Algorithms.h"
 #include "FWCore/Utilities/interface/EDMException.h"


### PR DESCRIPTION
#### PR description:

Broke ProductProvenanceRetriever into two parts and left base interface ProductProvenanceLookup in DataFormats/Provenance. This avoids having DataFormats/Provenance depend upon FWCore/Concurrency.

#### PR validation:

The code compiles and the framework unit tests pass.

solves makortel/framework#141