### PR TITLE
Remove hardcoded number (255) about the L1 prefiring

### DIFF
--- a/L1Trigger/L1TGlobal/plugins/L1TExtCondProducer.cc
+++ b/L1Trigger/L1TGlobal/plugins/L1TExtCondProducer.cc
@@ -95,12 +95,7 @@ L1TExtCondProducer::L1TExtCondProducer(const ParameterSet& iConfig)
       l1GtMenuToken_(esConsumes<L1TUtmTriggerMenu, L1TUtmTriggerMenuRcd>()) {
   makeTriggerRulePrefireVetoBit_ = false;
 
-  m_triggerRulePrefireVetoBit = 255;
-  if (m_triggerRulePrefireVetoBit > GlobalExtBlk::maxExternalConditions - 1) {
-    m_triggerRulePrefireVetoBit = GlobalExtBlk::maxExternalConditions - 1;
-    edm::LogWarning("L1TExtCondProducer")
-        << "Default trigger rule prefire veto bit number too large. Resetting to " << m_triggerRulePrefireVetoBit;
-  }
+  m_triggerRulePrefireVetoBit = GlobalExtBlk::maxExternalConditions - 1;
 
   if (!(tcdsInputTag_ == edm::InputTag(""))) {
     tcdsRecordToken_ = consumes<TCDSRecord>(tcdsInputTag_);

--- a/PhysicsTools/NanoAOD/plugins/L1TriggerResultsConverter.cc
+++ b/PhysicsTools/NanoAOD/plugins/L1TriggerResultsConverter.cc
@@ -68,7 +68,6 @@ private:
   std::vector<unsigned int> mask_;
   std::vector<unsigned int> indices_;
 
-  const unsigned int m_triggerRulePrefireVetoBit = 255;
 };
 
 //
@@ -137,8 +136,7 @@ void L1TriggerResultsConverter::produce(edm::Event& iEvent, const edm::EventSetu
     if (store_unprefireable_bit_) {
       edm::Handle<GlobalExtBlkBxCollection> handleExtResults;
       iEvent.getByToken(token_ext_, handleExtResults);
-      unprefireable_bit = handleExtResults->at(0, 0).getExternalDecision(
-          std::max(m_triggerRulePrefireVetoBit, GlobalExtBlk::maxExternalConditions - 1));
+      unprefireable_bit = handleExtResults->at(0, 0).getExternalDecision(GlobalExtBlk::maxExternalConditions - 1);
     }
   } else {
     // Legacy access

--- a/PhysicsTools/NanoAOD/plugins/L1TriggerResultsConverter.cc
+++ b/PhysicsTools/NanoAOD/plugins/L1TriggerResultsConverter.cc
@@ -67,7 +67,6 @@ private:
   std::vector<std::string> names_;
   std::vector<unsigned int> mask_;
   std::vector<unsigned int> indices_;
-
 };
 
 //


### PR DESCRIPTION
#### PR description:

Resolves: #26494 (@apana @rekovic @peruzzim )
@fabiocos whenever we will change constant in `GlobalExtBlk::maxExternalConditions` in the future, we should be able to recover the old constant by the class versioning of the data format. Is it correct?

FYI. `GlobalExtBlk::maxExternalConditions` is defined here https://github.com/cms-sw/cmssw/blob/master/DataFormats/L1TGlobal/interface/GlobalExtBlk.h

#### PR validation:

`runTheMatrix.py -l 136.8523,136.874 -i all --ibeos`

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

No backport needed