### PR TITLE
Replace deprecated mallinfo with mallinfo2

### DIFF
--- a/FWCore/Services/plugins/SimpleMemoryCheck.cc
+++ b/FWCore/Services/plugins/SimpleMemoryCheck.cc
@@ -584,7 +584,7 @@ namespace edm {
         eventStatOutput("LargestIncreaseRssEvent", eventDeltaRssT1_, reportData);
 
 #ifdef __linux__
-      struct mallinfo minfo = mallinfo();
+      struct mallinfo2 minfo = mallinfo2();
       reportData.insert(std::make_pair("HEAP_ARENA_SIZE_BYTES", i2str(minfo.arena)));
       reportData.insert(std::make_pair("HEAP_ARENA_N_UNUSED_CHUNKS", i2str(minfo.ordblks)));
       reportData.insert(std::make_pair("HEAP_TOP_FREE_BYTES", i2str(minfo.keepcost)));
@@ -678,7 +678,7 @@ namespace edm {
       if (eventDeltaRssT1_.deltaRss > 0)
         eventStatOutput("LargestIncreaseRssEvent", eventDeltaRssT1_, reportData);
 
-      struct mallinfo minfo = mallinfo();
+      struct mallinfo2 minfo = mallinfo2();
       reportData.push_back(mallOutput("HEAP_ARENA_SIZE_BYTES", minfo.arena));
       reportData.push_back(mallOutput("HEAP_ARENA_N_UNUSED_CHUNKS", minfo.ordblks));
       reportData.push_back(mallOutput("HEAP_TOP_FREE_BYTES", minfo.keepcost));
@@ -871,7 +871,7 @@ namespace edm {
                                       << deltaRSS;
           } else {
 #ifdef __linux__
-            struct mallinfo minfo = mallinfo();
+            struct mallinfo2 minfo = mallinfo2();
 #endif
             LogWarning("MemoryCheck") << "MemoryCheck: " << type << " " << mdname << ":" << mdlabel << " VSIZE "
                                       << current_->vsize << " " << deltaVSIZE << " RSS " << current_->rss << " "


### PR DESCRIPTION
See https://man7.org/linux/man-pages/man3/mallinfo.3.html.

This fixes a compiler warning that I have in my CMSSW builds:
```
/home/rembserj/PKGBUILDs/cmssw/src/cmssw/FWCore/Services/plugins/SimpleMemoryCheck.cc: In member function ‘void edm::service::SimpleMemoryCheck::andPrint(const string&, const string&, const string&) const’:
/home/rembserj/PKGBUILDs/cmssw/src/cmssw/FWCore/Services/plugins/SimpleMemoryCheck.cc:874:46: warning: ‘mallinfo mallinfo()’ is deprecated [-Wdeprecated-declarations]
  874 |             struct mallinfo minfo = mallinfo();
      |                                              ^
In file included from /home/rembserj/PKGBUILDs/cmssw/src/cmssw/FWCore/Services/plugins/SimpleMemoryCheck.cc:49:
/usr/include/malloc.h:118:24: note: declared here
  118 | extern struct mallinfo mallinfo (void) __THROW __MALLOC_DEPRECATED;
      |
```