### PR TITLE
Cleaning up PF contents in AOD.

### DIFF
--- a/RecoParticleFlow/Configuration/python/RecoParticleFlow_EventContent_cff.py
+++ b/RecoParticleFlow/Configuration/python/RecoParticleFlow_EventContent_cff.py
@@ -3,11 +3,6 @@ import FWCore.ParameterSet.Config as cms
 # AOD content
 RecoParticleFlowAOD = cms.PSet(
     outputCommands = cms.untracked.vstring(
-    'keep recoPFRecHits_particleFlowClusterECAL_Cleaned_*',
-    'keep recoPFRecHits_particleFlowClusterHCAL_Cleaned_*',
-    'keep recoPFRecHits_particleFlowClusterHO_Cleaned_*',
-    'keep recoPFRecHits_particleFlowClusterHF_Cleaned_*',
-    'keep recoPFRecHits_particleFlowClusterPS_Cleaned_*',
     'keep recoPFRecHits_particleFlowRecHitECAL_Cleaned_*',
     'keep recoPFRecHits_particleFlowRecHitHBHE_Cleaned_*',
     'keep recoPFRecHits_particleFlowRecHitHF_Cleaned_*',
@@ -49,8 +44,6 @@ from Configuration.Eras.Modifier_phase2_hgcal_cff import phase2_hgcal
 from Configuration.Eras.Modifier_phase2_timing_cff import phase2_timing
 phase2_hgcal.toModify( RecoParticleFlowAOD,  
     outputCommands = RecoParticleFlowAOD.outputCommands + ['keep recoPFRecHits_particleFlowRecHitHGC_Cleaned_*',
-                                                           'keep recoPFClusters_particleFlowClusterHGCal__*',
-                                                           'keep recoPFClusters_particleFlowClusterHGCalFromMultiCl__*',
                                                            'keep recoSuperClusters_simPFProducer_*_*'])
 phase2_timing.toModify( RecoParticleFlowAOD,
     outputCommands = RecoParticleFlowAOD.outputCommands + ['keep *_ecalBarrelClusterFastTimer_*_*'])


### PR DESCRIPTION
#### PR description:

We aim to reduce the PF-related event contents for AOD, in particularly for phase 2. We are dropping particleFlowCluster for HGC: `recoPFClusters_particleFlowClusterHGCal` and `recoPFClusters_particleFlowClusterHGCalFromMultiCl` (two collections one from seeded by simPF, another seeded by ticl clusters) from AOD. Note that they are still kept for RECO. Also note that particleFlowCluster for ECAL, HCAL, etc are not kept for AOD, so we are just trying to do the same thing for HGCal.

I also used this occasion to clean up unnecessary keep statements.

For AOD file of 200PU ttbar, I see the size reduction of about 25% after this change.

This is being done with consultation with @dpiparo .

#### PR validation:

Ran a few matrix tests.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Not a backport.

@bendavid @marksan87 @laurenhay @juska @kdlong 