### PR TITLE
CondTools/HLT: migrate to esConsumes

### DIFF
--- a/CondTools/HLT/src/AlCaRecoTriggerBitsRcdRead.cc
+++ b/CondTools/HLT/src/AlCaRecoTriggerBitsRcdRead.cc
@@ -56,6 +56,7 @@ private:
   void printMap(edm::RunNumber_t firstRun, edm::RunNumber_t lastRun, const AlCaRecoTriggerBits &triggerMap) const;
 
   // members
+  edm::ESGetToken<AlCaRecoTriggerBits, AlCaRecoTriggerBitsRcd> triggerBitsToken_;
   const OutputType outputType_;
   edm::ESWatcher<AlCaRecoTriggerBitsRcd> watcher_;
   edm::RunNumber_t firstRun_;
@@ -69,7 +70,10 @@ private:
 ///////////////////////////////////////////////////////////////////////
 
 AlCaRecoTriggerBitsRcdRead::AlCaRecoTriggerBitsRcdRead(const edm::ParameterSet &cfg)
-    : outputType_(this->stringToEnum(cfg.getUntrackedParameter<std::string>("outputType"))), firstRun_(0), lastRun_(0) {
+    : triggerBitsToken_(esConsumes<edm::Transition::BeginRun>()),
+      outputType_(this->stringToEnum(cfg.getUntrackedParameter<std::string>("outputType"))),
+      firstRun_(0),
+      lastRun_(0) {
   //   edm::LogInfo("") << "@SUB=AlCaRecoTriggerBitsRcdRead"
   // 		   << cfg.getParameter<std::string>("@module_label");
 
@@ -119,8 +123,7 @@ void AlCaRecoTriggerBitsRcdRead::beginRun(const edm::Run &run, const edm::EventS
       this->printMap(firstRun_, lastRun_, lastTriggerBits_);
 
     // Get AlCaRecoTriggerBits from EventSetup:
-    edm::ESHandle<AlCaRecoTriggerBits> triggerBits;
-    iSetup.get<AlCaRecoTriggerBitsRcd>().get(triggerBits);
+    const auto &triggerBits = &iSetup.getData(triggerBitsToken_);
     lastTriggerBits_ = *triggerBits;  // copy for later use
     firstRun_ = run.run();            // keep track where it started
   }

--- a/CondTools/HLT/src/AlCaRecoTriggerBitsRcdUpdate.cc
+++ b/CondTools/HLT/src/AlCaRecoTriggerBitsRcdUpdate.cc
@@ -44,6 +44,7 @@ private:
   /// Takes over memory uresponsibility for 'bitsToWrite'.
   void writeBitsToDB(AlCaRecoTriggerBits *bitsToWrite) const;
 
+  edm::ESGetToken<AlCaRecoTriggerBits, AlCaRecoTriggerBitsRcd> triggerBitsToken_;
   unsigned int nEventCalls_;
   const unsigned int firstRunIOV_;
   const int lastRunIOV_;
@@ -58,7 +59,8 @@ private:
 ///////////////////////////////////////////////////////////////////////
 
 AlCaRecoTriggerBitsRcdUpdate::AlCaRecoTriggerBitsRcdUpdate(const edm::ParameterSet &cfg)
-    : nEventCalls_(0),
+    : triggerBitsToken_(esConsumes()),
+      nEventCalls_(0),
       firstRunIOV_(cfg.getParameter<unsigned int>("firstRunIOV")),
       lastRunIOV_(cfg.getParameter<int>("lastRunIOV")),
       startEmpty_(cfg.getParameter<bool>("startEmpty")),
@@ -98,8 +100,7 @@ AlCaRecoTriggerBitsRcdUpdate::createStartTriggerBits(bool startEmpty, const edm:
   if (startEmpty) {
     return new AlCaRecoTriggerBits;
   } else {
-    edm::ESHandle<AlCaRecoTriggerBits> triggerBits;
-    evtSetup.get<AlCaRecoTriggerBitsRcd>().get(triggerBits);
+    const auto &triggerBits = &evtSetup.getData(triggerBitsToken_);
     return new AlCaRecoTriggerBits(*triggerBits);  // copy old one
   }
 }


### PR DESCRIPTION
#### PR description:

Part of esConsumes migration #31061.
Migrated CondTools/HLT

#### PR validation:

Run successfully the commands in the README file of this packages:
```bash
python run_wf.py -f frontier://PromptProd/CMS_CONDITIONS -i AlCaRecoHLTpaths8e29_1e31_v24_offline -d AlCaRecoHLTpaths_TEST
cmsRun AlCaRecoTriggerBitsRcdRead_TEMPL_cfg.py inputDB=sqlite_file:AlCaRecoHLTpaths_TEST.db inputTag=AlCaRecoHLTpaths_TEST
```

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Not a backport, no backport needed.