### PR TITLE
Dedicated data members for Run-3 CSC trigger primitives

### DIFF
--- a/DataFormats/CSCDigi/interface/CSCALCTDigi.h
+++ b/DataFormats/CSCDigi/interface/CSCALCTDigi.h
@@ -128,9 +128,10 @@ private:
   uint16_t bx_;
   uint16_t trknmb_;
   uint16_t fullbx_;
-  /// Run-3 introduces high-multiplicity bits for CSCs.
-  /// Note: In DN-20-016, 3 bits are allocated for HMT in the
-  /// ALCT board. These bits are copied into the ALCT digi in CMSSW
+  // In Run-3, CSC trigger data will include the high-multiplicity
+  // bits for a chamber. These bits may indicate the observation of
+  // "exotic" events. This data member was included in a prototype.
+  // Later on, we developed a dedicated object: "CSCShowerDigi<Anode>"
   uint16_t hmt_;
 
   Version version_;

--- a/DataFormats/CSCDigi/interface/CSCCLCTDigi.h
+++ b/DataFormats/CSCDigi/interface/CSCCLCTDigi.h
@@ -18,11 +18,6 @@ class CSCCLCTDigi {
 public:
   typedef std::vector<std::vector<uint16_t>> ComparatorContainer;
 
-  enum CLCTKeyStripMasks { kEighthStripMask = 0x1, kQuartStripMask = 0x1, kHalfStripMask = 0x1f };
-  enum CLCTKeyStripShifts { kEighthStripShift = 6, kQuartStripShift = 5, kHalfStripShift = 0 };
-  // temporary to facilitate CCLUT-EMTF/OMTF integration studies
-  enum CLCTPatternMasks { kRun3SlopeMask = 0xf, kRun3PatternMask = 0x7, kLegacyPatternMask = 0xf };
-  enum CLCTPatternShifts { kRun3SlopeShift = 7, kRun3PatternShift = 4, kLegacyPatternShift = 0 };
   enum class Version { Legacy = 0, Run3 };
   // for data vs emulator studies
   enum CLCTBXMask { kBXDataMask = 0x3 };
@@ -39,8 +34,13 @@ public:
               const uint16_t trknmb = 0,
               const uint16_t fullbx = 0,
               const int16_t compCode = -1,
-              const Version version = Version::Legacy);
-  /// default
+              const Version version = Version::Legacy,
+              const bool run3_quart_strip_bit = false,
+              const bool run3_eighth_strip_bit = false,
+              const uint16_t run3_pattern = 0,
+              const uint16_t run3_slope = 0);
+
+  /// default (calls clear())
   CSCCLCTDigi();
 
   /// clear this CLCT
@@ -59,22 +59,22 @@ public:
   void setQuality(const uint16_t quality) { quality_ = quality; }
 
   /// return pattern
-  uint16_t getPattern() const;
+  uint16_t getPattern() const { return pattern_; }
 
   /// set pattern
-  void setPattern(const uint16_t pattern);
+  void setPattern(const uint16_t pattern) { pattern_ = pattern; }
 
   /// return pattern
-  uint16_t getRun3Pattern() const;
+  uint16_t getRun3Pattern() const { return run3_pattern_; }
 
   /// set pattern
-  void setRun3Pattern(const uint16_t pattern);
+  void setRun3Pattern(const uint16_t pattern) { run3_pattern_ = pattern; }
 
   /// return the slope
-  uint16_t getSlope() const;
+  uint16_t getSlope() const { return run3_slope_; }
 
   /// set the slope
-  void setSlope(const uint16_t slope);
+  void setSlope(const uint16_t slope) { run3_slope_ = slope; }
 
   /// slope in number of half-strips/layer
   /// negative means left-bending
@@ -96,22 +96,22 @@ public:
   void setBend(const uint16_t bend) { bend_ = bend; }
 
   /// return halfstrip that goes from 0 to 31 in a (D)CFEB
-  uint16_t getStrip() const;
+  uint16_t getStrip() const { return strip_; }
 
   /// set strip
   void setStrip(const uint16_t strip) { strip_ = strip; }
 
   /// set single quart strip bit
-  void setQuartStrip(const bool quartStrip);
+  void setQuartStrip(const bool quartStrip) { run3_quart_strip_bit_ = quartStrip; }
 
   /// get single quart strip bit
-  bool getQuartStrip() const;
+  bool getQuartStrip() const { return run3_quart_strip_bit_; }
 
   /// set single eighth strip bit
-  void setEighthStrip(const bool eighthStrip);
+  void setEighthStrip(const bool eighthStrip) { run3_eighth_strip_bit_ = eighthStrip; }
 
   /// get single eighth strip bit
-  bool getEighthStrip() const;
+  bool getEighthStrip() const { return run3_eighth_strip_bit_; }
 
   /// return Key CFEB ID
   uint16_t getCFEB() const { return cfeb_; }
@@ -197,22 +197,18 @@ public:
   void setRun3(bool isRun3);
 
 private:
-  void setDataWord(const uint16_t newWord, uint16_t& word, const unsigned shift, const unsigned mask);
-  uint16_t getDataWord(const uint16_t word, const unsigned shift, const unsigned mask) const;
-
   uint16_t valid_;
   uint16_t quality_;
-  // In Run-3, the 4-bit pattern number is reinterpreted as the
-  // 4-bit bending value. There will be 16 bending values * 2 (left/right)
+  // Run-1/2 pattern number.
+  // For Run-3 CLCTs, please use run3_pattern_. For some backward
+  // compatibility the trigger emulator translates run3_pattern_
+  // approximately into pattern_ with a lookup table
   uint16_t pattern_;
   uint16_t striptype_;  // not used since mid-2008
   // Common definition for left/right bending in Run-1, Run-2 and Run-3.
   // 0: right; 1: left
   uint16_t bend_;
-  // In Run-3, the strip number receives two additional bits
-  // strip[4:0] -> 1/2 strip value
-  // strip[5]   -> 1/4 strip bit
-  // strip[6]   -> 1/8 strip bit
+  // actually the half-strip number
   uint16_t strip_;
   // There are up to 7 (D)CFEBs in a chamber
   uint16_t cfeb_;
@@ -220,9 +216,20 @@ private:
   uint16_t trknmb_;
   uint16_t fullbx_;
 
-  // new in Run-3: 12-bit comparator code
+  // new members in Run-3:
+
+  // 12-bit comparator code
   // set by default to -1 for Run-1 and Run-2 CLCTs
   int16_t compCode_;
+  // 1/4-strip bit set by CCLUT (see DN-19-059)
+  bool run3_quart_strip_bit_;
+  // 1/8-strip bit set by CCLUT
+  bool run3_eighth_strip_bit_;
+  // In Run-3, the CLCT digi has 3-bit pattern ID, 0 through 4
+  uint16_t run3_pattern_;
+  // 4-bit bending value. There will be 16 bending values * 2 (left/right)
+  uint16_t run3_slope_;
+
   // which hits are in this CLCT?
   ComparatorContainer hits_;
 

--- a/DataFormats/CSCDigi/interface/CSCCLCTDigi.h
+++ b/DataFormats/CSCDigi/interface/CSCCLCTDigi.h
@@ -102,16 +102,16 @@ public:
   void setStrip(const uint16_t strip) { strip_ = strip; }
 
   /// set single quart strip bit
-  void setQuartStrip(const bool quartStrip) { run3_quart_strip_bit_ = quartStrip; }
+  void setQuartStripBit(const bool quartStripBit) { run3_quart_strip_bit_ = quartStripBit; }
 
   /// get single quart strip bit
-  bool getQuartStrip() const { return run3_quart_strip_bit_; }
+  bool getQuartStripBit() const { return run3_quart_strip_bit_; }
 
   /// set single eighth strip bit
-  void setEighthStrip(const bool eighthStrip) { run3_eighth_strip_bit_ = eighthStrip; }
+  void setEighthStripBit(const bool eighthStripBit) { run3_eighth_strip_bit_ = eighthStripBit; }
 
   /// get single eighth strip bit
-  bool getEighthStrip() const { return run3_eighth_strip_bit_; }
+  bool getEighthStripBit() const { return run3_eighth_strip_bit_; }
 
   /// return Key CFEB ID
   uint16_t getCFEB() const { return cfeb_; }

--- a/DataFormats/CSCDigi/interface/CSCCorrelatedLCTDigi.h
+++ b/DataFormats/CSCDigi/interface/CSCCorrelatedLCTDigi.h
@@ -22,6 +22,18 @@ public:
   // for data vs emulator studies
   enum LCTBXMask { kBXDataMask = 0x1 };
 
+  /// SIMULATION ONLY ////
+  enum Type {
+    CLCTALCT,      // CLCT-centric
+    ALCTCLCT,      // ALCT-centric
+    ALCTCLCTGEM,   // ALCT-CLCT-1 GEM pad
+    ALCTCLCT2GEM,  // ALCT-CLCT-2 GEM pads in coincidence
+    ALCT2GEM,      // ALCT-2 GEM pads in coincidence
+    CLCT2GEM,      // CLCT-2 GEM pads in coincidence
+    CLCTONLY,      // Missing ALCT
+    ALCTONLY       // Missing CLCT
+  };
+
   /// Constructors
   CSCCorrelatedLCTDigi(const uint16_t trknmb,
                        const uint16_t valid,
@@ -39,7 +51,8 @@ public:
                        const bool run3_quart_strip_bit = false,
                        const bool run3_eighth_strip_bit = false,
                        const uint16_t run3_pattern = 0,
-                       const uint16_t run3_slope = 0);
+                       const uint16_t run3_slope = 0,
+                       const int type = ALCTCLCT);
 
   /// default (calls clear())
   CSCCorrelatedLCTDigi();
@@ -194,18 +207,6 @@ public:
   bool isRun3() const { return version_ == Version::Run3; }
 
   void setRun3(const bool isRun3);
-
-  /// SIMULATION ONLY ////
-  enum Type {
-    CLCTALCT,      // CLCT-centric
-    ALCTCLCT,      // ALCT-centric
-    ALCTCLCTGEM,   // ALCT-CLCT-1 GEM pad
-    ALCTCLCT2GEM,  // ALCT-CLCT-2 GEM pads in coincidence
-    ALCT2GEM,      // ALCT-2 GEM pads in coincidence
-    CLCT2GEM,      // CLCT-2 GEM pads in coincidence
-    CLCTONLY,      // Missing ALCT
-    ALCTONLY       // Missing CLCT
-  };
 
   int getType() const { return type_; }
 

--- a/DataFormats/CSCDigi/interface/CSCCorrelatedLCTDigi.h
+++ b/DataFormats/CSCDigi/interface/CSCCorrelatedLCTDigi.h
@@ -63,16 +63,16 @@ public:
   uint16_t getStrip(uint16_t n = 2) const;
 
   /// set single quart strip bit
-  void setQuartStrip(const bool quartStrip) { run3_quart_strip_bit_ = quartStrip; }
+  void setQuartStripBit(const bool quartStripBit) { run3_quart_strip_bit_ = quartStripBit; }
 
   /// get single quart strip bit
-  bool getQuartStrip() const { return run3_quart_strip_bit_; }
+  bool getQuartStripBit() const { return run3_quart_strip_bit_; }
 
   /// set single eighth strip bit
-  void setEighthStrip(const bool eighthStrip) { run3_eighth_strip_bit_ = eighthStrip; }
+  void setEighthStripBit(const bool eighthStripBit) { run3_eighth_strip_bit_ = eighthStripBit; }
 
   /// get single eighth strip bit
-  bool getEighthStrip() const { return run3_eighth_strip_bit_; }
+  bool getEighthStripBit() const { return run3_eighth_strip_bit_; }
 
   /*
     Strips are numbered starting from 1 in CMSSW

--- a/DataFormats/CSCDigi/interface/CSCCorrelatedLCTDigi.h
+++ b/DataFormats/CSCDigi/interface/CSCCorrelatedLCTDigi.h
@@ -18,11 +18,6 @@
 
 class CSCCorrelatedLCTDigi {
 public:
-  enum LCTKeyStripMasks { kEighthStripMask = 0x1, kQuartStripMask = 0x1, kHalfStripMask = 0xff };
-  enum LCTKeyStripShifts { kEighthStripShift = 9, kQuartStripShift = 8, kHalfStripShift = 0 };
-  // temporary to facilitate CCLUT-EMTF/OMTF integration studies
-  enum LCTPatternMasks { kRun3SlopeMask = 0xf, kRun3PatternMask = 0x7, kLegacyPatternMask = 0xf };
-  enum LCTPatternShifts { kRun3SlopeShift = 7, kRun3PatternShift = 4, kLegacyPatternShift = 0 };
   enum class Version { Legacy = 0, Run3 };
   // for data vs emulator studies
   enum LCTBXMask { kBXDataMask = 0x1 };
@@ -40,9 +35,13 @@ public:
                        const uint16_t bx0 = 0,
                        const uint16_t syncErr = 0,
                        const uint16_t cscID = 0,
-                       const uint16_t hmt = 0,
-                       const Version version = Version::Legacy);
-  /// default
+                       const Version version = Version::Legacy,
+                       const bool run3_quart_strip_bit = false,
+                       const bool run3_eighth_strip_bit = false,
+                       const uint16_t run3_pattern = 0,
+                       const uint16_t run3_slope = 0);
+
+  /// default (calls clear())
   CSCCorrelatedLCTDigi();
 
   /// clear this LCT
@@ -64,16 +63,16 @@ public:
   uint16_t getStrip(uint16_t n = 2) const;
 
   /// set single quart strip bit
-  void setQuartStrip(const bool quartStrip);
+  void setQuartStrip(const bool quartStrip) { run3_quart_strip_bit_ = quartStrip; }
 
   /// get single quart strip bit
-  bool getQuartStrip() const;
+  bool getQuartStrip() const { return run3_quart_strip_bit_; }
 
   /// set single eighth strip bit
-  void setEighthStrip(const bool eighthStrip);
+  void setEighthStrip(const bool eighthStrip) { run3_eighth_strip_bit_ = eighthStrip; }
 
   /// get single eighth strip bit
-  bool getEighthStrip() const;
+  bool getEighthStrip() const { return run3_eighth_strip_bit_; }
 
   /*
     Strips are numbered starting from 1 in CMSSW
@@ -94,15 +93,14 @@ public:
    */
   float getFractionalStrip(uint16_t n = 2) const;
 
-  /// Legacy: return pattern ID
-  /// Run-3: return the bending angle value
-  uint16_t getPattern() const;
+  /// return the Run-2 pattern ID
+  uint16_t getPattern() const { return pattern; }
 
-  /// return pattern
-  uint16_t getRun3Pattern() const;
+  /// return the Run-3 pattern ID
+  uint16_t getRun3Pattern() const { return run3_pattern_; }
 
   /// return the slope
-  uint16_t getSlope() const;
+  uint16_t getSlope() const { return run3_slope_; }
 
   /// slope in number of half-strips/layer
   /// negative means left-bending
@@ -166,13 +164,13 @@ public:
   void setStrip(const uint16_t s) { strip = s; }
 
   /// set pattern
-  void setPattern(const uint16_t p);
+  void setPattern(const uint16_t p) { pattern = p; }
 
-  /// set pattern
-  void setRun3Pattern(const uint16_t pattern);
+  /// set Run-3 pattern
+  void setRun3Pattern(const uint16_t pattern) { run3_pattern_ = pattern; }
 
   /// set the slope
-  void setSlope(const uint16_t slope);
+  void setSlope(const uint16_t slope) { run3_slope_ = slope; }
 
   /// set bend
   void setBend(const uint16_t b) { bend = b; }
@@ -223,9 +221,6 @@ public:
   const GEMPadDigi& getGEM2() const { return gem2_; }
 
 private:
-  void setDataWord(const uint16_t newWord, uint16_t& word, const unsigned shift, const unsigned mask);
-  uint16_t getDataWord(const uint16_t word, const unsigned shift, const unsigned mask) const;
-
   // Note: The Run-3 data format is substantially different than the
   // Run-1/2 data format. Some explanation is provided below. For
   // more information, please check "DN-20-016".
@@ -241,13 +236,12 @@ private:
   uint16_t quality;
   // 7-bit key wire
   uint16_t keywire;
-  // In Run-3, the strip number receives two additional bits
-  // strip[7:0] -> 1/2 strip value
-  // strip[8]   -> 1/4 strip bit
-  // strip[9]   -> 1/8 strip bit
+  // actually the 8-bit half-strip number
   uint16_t strip;
-  // In Run-3, the 4-bit pattern number is reinterpreted as the
-  // 4-bit bending value. There will be 16 bending values * 2 (left/right)
+  // Run-1/2 pattern number.
+  // For Run-3 CLCTs, please use run3_pattern_. For some backward
+  // compatibility the trigger emulator translates run3_pattern_
+  // approximately into pattern_ with a lookup table
   uint16_t pattern;
   // Common definition for left/right bending in Run-1, Run-2 and Run-3.
   // 0: right; 1: left
@@ -259,12 +253,22 @@ private:
   uint16_t syncErr;
   // 4-bit CSC chamber identifier
   uint16_t cscID;
-  // In Run-3, LCT data will be carrying the high-multiplicity bits
-  // for chamber. These bits may indicate the observation of "exotic" events
-  // Depending on the chamber type 2 or 3 bits will be repurposed
-  // in the 32-bit LCT data word from the synchronization bit and
-  // quality bits.
+
+  // new members in Run-3:
+
+  // In Run-3, CSC trigger data will include the high-multiplicity
+  // bits for a chamber. These bits may indicate the observation of
+  // "exotic" events. This data member was included in a prototype.
+  // Later on, we developed a dedicated object: "CSCShowerDigi"
   uint16_t hmt;
+  // 1/4-strip bit set by CCLUT (see DN-19-059)
+  bool run3_quart_strip_bit_;
+  // 1/8-strip bit set by CCLUT
+  bool run3_eighth_strip_bit_;
+  // In Run-3, the CLCT digi has 3-bit pattern ID, 0 through 4
+  uint16_t run3_pattern_;
+  // 4-bit bending value. There will be 16 bending values * 2 (left/right)
+  uint16_t run3_slope_;
 
   /// SIMULATION ONLY ////
   int type_;

--- a/DataFormats/CSCDigi/interface/CSCShowerDigi.h
+++ b/DataFormats/CSCDigi/interface/CSCShowerDigi.h
@@ -10,8 +10,6 @@ class CSCShowerDigi {
 public:
   // Run-3 definitions as provided in DN-20-033
   enum Run3Shower { kInvalid = 0, kLoose = 1, kNominal = 2, kTight = 3 };
-  enum BitMask { kInTimeMask = 0x2, kOutTimeMask = 0x2 };
-  enum BitShift { kInTimeShift = 0, kOutTimeShift = 2 };
 
   /// Constructors
   CSCShowerDigi(const uint16_t inTimeBits, const uint16_t outTimeBits, const uint16_t cscID);
@@ -19,7 +17,7 @@ public:
   CSCShowerDigi();
 
   /// clear this Shower
-  void clear() { bits_ = 0; }
+  void clear();
 
   /// data
   bool isValid() const;
@@ -27,13 +25,12 @@ public:
   bool isLooseInTime() const;
   bool isNominalInTime() const;
   bool isTightInTime() const;
-  bool isLooseOutTime() const;
-  bool isNominalOutTime() const;
-  bool isTightOutTime() const;
+  bool isLooseOutOfTime() const;
+  bool isNominalOutOfTime() const;
+  bool isTightOutOfTime() const;
 
-  uint16_t bits() const { return bits_; }
-  uint16_t bitsInTime() const;
-  uint16_t bitsOutTime() const;
+  uint16_t bitsInTime() const { return bitsInTime_; }
+  uint16_t bitsOutOfTime() const { return bitsOutOfTime_; }
 
   uint16_t getCSCID() const { return cscID_; }
 
@@ -41,10 +38,8 @@ public:
   void setCSCID(const uint16_t c) { cscID_ = c; }
 
 private:
-  void setDataWord(const uint16_t newWord, uint16_t& word, const unsigned shift, const unsigned mask);
-  uint16_t getDataWord(const uint16_t word, const unsigned shift, const unsigned mask) const;
-
-  uint16_t bits_;
+  uint16_t bitsInTime_;
+  uint16_t bitsOutOfTime_;
   // 4-bit CSC chamber identifier
   uint16_t cscID_;
 };

--- a/DataFormats/CSCDigi/src/CSCCLCTDigi.cc
+++ b/DataFormats/CSCDigi/src/CSCCLCTDigi.cc
@@ -25,7 +25,11 @@ CSCCLCTDigi::CSCCLCTDigi(const uint16_t valid,
                          const uint16_t trknmb,
                          const uint16_t fullbx,
                          const int16_t compCode,
-                         const Version version)
+                         const Version version,
+                         const bool run3_quart_strip_bit,
+                         const bool run3_eighth_strip_bit,
+                         const uint16_t run3_pattern,
+                         const uint16_t run3_slope)
     : valid_(valid),
       quality_(quality),
       pattern_(pattern),
@@ -37,6 +41,10 @@ CSCCLCTDigi::CSCCLCTDigi(const uint16_t valid,
       trknmb_(trknmb),
       fullbx_(fullbx),
       compCode_(compCode),
+      run3_quart_strip_bit_(run3_quart_strip_bit),
+      run3_eighth_strip_bit_(run3_eighth_strip_bit),
+      run3_pattern_(run3_pattern),
+      run3_slope_(run3_slope),
       version_(version) {
   hits_.resize(NUM_LAYERS);
   for (auto& p : hits_) {
@@ -45,23 +53,8 @@ CSCCLCTDigi::CSCCLCTDigi(const uint16_t valid,
 }
 
 /// Default
-CSCCLCTDigi::CSCCLCTDigi()
-    : valid_(0),
-      quality_(0),
-      pattern_(0),
-      striptype_(0),
-      bend_(0),
-      strip_(0),
-      cfeb_(0),
-      bx_(0),
-      trknmb_(0),
-      fullbx_(0),
-      compCode_(-1),
-      version_(Version::Legacy) {
-  hits_.resize(NUM_LAYERS);
-  for (auto& p : hits_) {
-    p.resize(CLCT_PATTERN_WIDTH);
-  }
+CSCCLCTDigi::CSCCLCTDigi() {
+  clear();  // set contents to zero
 }
 
 /// Clears this CLCT.
@@ -76,43 +69,18 @@ void CSCCLCTDigi::clear() {
   bx_ = 0;
   trknmb_ = 0;
   fullbx_ = 0;
+  // Run-3 variables
   compCode_ = -1;
+  run3_quart_strip_bit_ = false;
+  run3_eighth_strip_bit_ = false;
+  run3_pattern_ = 0;
+  run3_slope_ = 0;
+  version_ = Version::Legacy;
   hits_.clear();
   hits_.resize(NUM_LAYERS);
   for (auto& p : hits_) {
     p.resize(CLCT_PATTERN_WIDTH);
   }
-  setSlope(0);
-}
-
-uint16_t CSCCLCTDigi::getPattern() const { return getDataWord(pattern_, kLegacyPatternShift, kLegacyPatternMask); }
-
-void CSCCLCTDigi::setPattern(const uint16_t pattern) {
-  setDataWord(pattern, pattern_, kLegacyPatternShift, kLegacyPatternMask);
-}
-
-uint16_t CSCCLCTDigi::getRun3Pattern() const {
-  if (!isRun3())
-    return 0;
-  return getDataWord(pattern_, kRun3PatternShift, kRun3PatternMask);
-}
-
-void CSCCLCTDigi::setRun3Pattern(const uint16_t pattern) {
-  if (!isRun3())
-    return;
-  setDataWord(pattern, pattern_, kRun3PatternShift, kRun3PatternMask);
-}
-
-uint16_t CSCCLCTDigi::getSlope() const {
-  if (!isRun3())
-    return 0;
-  return getDataWord(pattern_, kRun3SlopeShift, kRun3SlopeMask);
-}
-
-void CSCCLCTDigi::setSlope(const uint16_t slope) {
-  if (!isRun3())
-    return;
-  setDataWord(slope, pattern_, kRun3SlopeShift, kRun3SlopeMask);
 }
 
 // slope in number of half-strips/layer
@@ -152,32 +120,6 @@ float CSCCLCTDigi::getFractionalStrip(const uint16_t n) const {
   } else {
     return 0.5f * (getKeyStrip(n) + 0.5);
   }
-}
-
-uint16_t CSCCLCTDigi::getStrip() const { return getDataWord(strip_, kHalfStripShift, kHalfStripMask); }
-
-bool CSCCLCTDigi::getQuartStrip() const {
-  if (!isRun3())
-    return false;
-  return getDataWord(strip_, kQuartStripShift, kQuartStripMask);
-}
-
-bool CSCCLCTDigi::getEighthStrip() const {
-  if (!isRun3())
-    return false;
-  return getDataWord(strip_, kEighthStripShift, kEighthStripMask);
-}
-
-void CSCCLCTDigi::setQuartStrip(const bool quartStrip) {
-  if (!isRun3())
-    return;
-  setDataWord(quartStrip, strip_, kQuartStripShift, kQuartStripMask);
-}
-
-void CSCCLCTDigi::setEighthStrip(const bool eighthStrip) {
-  if (!isRun3())
-    return;
-  setDataWord(eighthStrip, strip_, kEighthStripShift, kEighthStripMask);
 }
 
 void CSCCLCTDigi::setRun3(const bool isRun3) { version_ = isRun3 ? Version::Run3 : Version::Legacy; }
@@ -261,18 +203,6 @@ void CSCCLCTDigi::print() const {
   } else {
     edm::LogVerbatim("CSCDigi") << "Not a valid Cathode LCT.";
   }
-}
-
-void CSCCLCTDigi::setDataWord(const uint16_t newWord, uint16_t& word, const unsigned shift, const unsigned mask) {
-  // clear the old value
-  word &= ~(mask << shift);
-
-  // set the new value
-  word |= newWord << shift;
-}
-
-uint16_t CSCCLCTDigi::getDataWord(const uint16_t word, const unsigned shift, const unsigned mask) const {
-  return (word >> shift) & mask;
 }
 
 std::ostream& operator<<(std::ostream& o, const CSCCLCTDigi& digi) {

--- a/DataFormats/CSCDigi/src/CSCCLCTDigi.cc
+++ b/DataFormats/CSCDigi/src/CSCCLCTDigi.cc
@@ -99,11 +99,11 @@ float CSCCLCTDigi::getFractionalSlope() const {
 uint16_t CSCCLCTDigi::getKeyStrip(const uint16_t n) const {
   // 10-bit case for strip data word
   if (compCode_ != -1 and n == 8) {
-    return getKeyStrip(4) * 2 + getEighthStrip();
+    return getKeyStrip(4) * 2 + getEighthStripBit();
   }
   // 9-bit case for strip data word
   else if (compCode_ != -1 and n == 4) {
-    return getKeyStrip(2) * 2 + getQuartStrip();
+    return getKeyStrip(2) * 2 + getQuartStripBit();
   }
   // 8-bit case for strip data word (all other cases)
   else {

--- a/DataFormats/CSCDigi/src/CSCComparatorDigi.cc
+++ b/DataFormats/CSCDigi/src/CSCComparatorDigi.cc
@@ -104,13 +104,15 @@ void CSCComparatorDigi::print() const {
   std::ostringstream ost;
   ost << "CSCComparatorDigi | strip " << getStrip() << " | comparator " << getComparator() << " | first time bin "
       << getTimeBin() << " | time bins on ";
-  std::copy(getTimeBinsOn().begin(), getTimeBinsOn().end(), std::ostream_iterator<int>(ost, " "));
+  std::vector<int> tbins = getTimeBinsOn();
+  std::copy(tbins.begin(), tbins.end(), std::ostream_iterator<int>(ost, " "));
   edm::LogVerbatim("CSCDigi") << ost.str();
 }
 
 std::ostream& operator<<(std::ostream& o, const CSCComparatorDigi& digi) {
   o << "CSCComparatorDigi Strip:" << digi.getStrip() << ", Comparator: " << digi.getComparator()
     << ", First Time Bin On: " << digi.getTimeBin() << ", Time Bins On: ";
-  std::copy(digi.getTimeBinsOn().begin(), digi.getTimeBinsOn().end(), std::ostream_iterator<int>(o, " "));
+  std::vector<int> tbins = digi.getTimeBinsOn();
+  std::copy(tbins.begin(), tbins.end(), std::ostream_iterator<int>(o, " "));
   return o;
 }

--- a/DataFormats/CSCDigi/src/CSCCorrelatedLCTDigi.cc
+++ b/DataFormats/CSCDigi/src/CSCCorrelatedLCTDigi.cc
@@ -27,7 +27,8 @@ CSCCorrelatedLCTDigi::CSCCorrelatedLCTDigi(const uint16_t itrknmb,
                                            const bool run3_quart_strip_bit,
                                            const bool run3_eighth_strip_bit,
                                            const uint16_t run3_pattern,
-                                           const uint16_t run3_slope)
+                                           const uint16_t run3_slope,
+                                           const int type)
     : trknmb(itrknmb),
       valid(ivalid),
       quality(iquality),
@@ -40,10 +41,12 @@ CSCCorrelatedLCTDigi::CSCCorrelatedLCTDigi(const uint16_t itrknmb,
       bx0(ibx0),
       syncErr(isyncErr),
       cscID(icscID),
+      hmt(0),
       run3_quart_strip_bit_(run3_quart_strip_bit),
       run3_eighth_strip_bit_(run3_eighth_strip_bit),
       run3_pattern_(run3_pattern),
       run3_slope_(run3_slope),
+      type_(type),
       version_(version) {}
 
 /// Default
@@ -73,7 +76,7 @@ void CSCCorrelatedLCTDigi::clear() {
   run3_pattern_ = 0;
   run3_slope_ = 0;
   // clear the components
-  type_ = 0;
+  type_ = 1;
   alct_.clear();
   clct_.clear();
   gem1_ = GEMPadDigi();
@@ -133,7 +136,7 @@ void CSCCorrelatedLCTDigi::setRun3(const bool isRun3) { version_ = isRun3 ? Vers
 bool CSCCorrelatedLCTDigi::operator==(const CSCCorrelatedLCTDigi& rhs) const {
   return ((trknmb == rhs.trknmb) && (quality == rhs.quality) && (keywire == rhs.keywire) && (strip == rhs.strip) &&
           (pattern == rhs.pattern) && (bend == rhs.bend) && (bx == rhs.bx) && (valid == rhs.valid) &&
-          (mpclink == rhs.mpclink) && (hmt == rhs.hmt));
+          (mpclink == rhs.mpclink));
 }
 
 /// Debug
@@ -143,8 +146,7 @@ void CSCCorrelatedLCTDigi::print() const {
                                 << " Quality = " << getQuality() << " Key Wire = " << getKeyWG()
                                 << " Strip = " << getStrip() << " Pattern = " << getPattern()
                                 << " Bend = " << ((getBend() == 0) ? 'L' : 'R') << " BX = " << getBX()
-                                << " MPC Link = " << getMPCLink() << " Type (SIM) = " << getType()
-                                << " HMT Bit = " << getHMT();
+                                << " MPC Link = " << getMPCLink() << " Type (SIM) = " << getType();
   } else {
     edm::LogVerbatim("CSCDigi") << "Not a valid correlated LCT.";
   }
@@ -153,7 +155,7 @@ void CSCCorrelatedLCTDigi::print() const {
 std::ostream& operator<<(std::ostream& o, const CSCCorrelatedLCTDigi& digi) {
   return o << "CSC LCT #" << digi.getTrknmb() << ": Valid = " << digi.isValid() << " Quality = " << digi.getQuality()
            << " MPC Link = " << digi.getMPCLink() << " cscID = " << digi.getCSCID()
-           << " syncErr = " << digi.getSyncErr() << " Type (SIM) = " << digi.getType() << " HMT Bit = " << digi.getHMT()
+           << " syncErr = " << digi.getSyncErr() << " Type (SIM) = " << digi.getType()
            << "\n"
            << "  cathode info: Strip = " << digi.getStrip() << " Pattern = " << digi.getPattern()
            << " Bend = " << ((digi.getBend() == 0) ? 'L' : 'R') << "\n"

--- a/DataFormats/CSCDigi/src/CSCCorrelatedLCTDigi.cc
+++ b/DataFormats/CSCDigi/src/CSCCorrelatedLCTDigi.cc
@@ -155,8 +155,7 @@ void CSCCorrelatedLCTDigi::print() const {
 std::ostream& operator<<(std::ostream& o, const CSCCorrelatedLCTDigi& digi) {
   return o << "CSC LCT #" << digi.getTrknmb() << ": Valid = " << digi.isValid() << " Quality = " << digi.getQuality()
            << " MPC Link = " << digi.getMPCLink() << " cscID = " << digi.getCSCID()
-           << " syncErr = " << digi.getSyncErr() << " Type (SIM) = " << digi.getType()
-           << "\n"
+           << " syncErr = " << digi.getSyncErr() << " Type (SIM) = " << digi.getType() << "\n"
            << "  cathode info: Strip = " << digi.getStrip() << " Pattern = " << digi.getPattern()
            << " Bend = " << ((digi.getBend() == 0) ? 'L' : 'R') << "\n"
            << "    anode info: Key wire = " << digi.getKeyWG() << " BX = " << digi.getBX()

--- a/DataFormats/CSCDigi/src/CSCCorrelatedLCTDigi.cc
+++ b/DataFormats/CSCDigi/src/CSCCorrelatedLCTDigi.cc
@@ -83,11 +83,11 @@ void CSCCorrelatedLCTDigi::clear() {
 uint16_t CSCCorrelatedLCTDigi::getStrip(const uint16_t n) const {
   // all 10 bits
   if (n == 8) {
-    return 2 * getStrip(4) + getEighthStrip();
+    return 2 * getStrip(4) + getEighthStripBit();
   }
   // lowest 9 bits
   else if (n == 4) {
-    return 2 * getStrip(2) + getQuartStrip();
+    return 2 * getStrip(2) + getQuartStripBit();
   }
   // lowest 8 bits
   else {

--- a/DataFormats/CSCDigi/src/CSCShowerDigi.cc
+++ b/DataFormats/CSCDigi/src/CSCShowerDigi.cc
@@ -6,18 +6,21 @@
 using namespace std;
 
 /// Constructors
-CSCShowerDigi::CSCShowerDigi(const uint16_t bitsInTime, const uint16_t bitsOutTime, const uint16_t cscID)
-    : cscID_(cscID) {
-  setDataWord(bitsInTime, bits_, kInTimeShift, kInTimeMask);
-  setDataWord(bitsOutTime, bits_, kOutTimeShift, kOutTimeMask);
-}
+CSCShowerDigi::CSCShowerDigi(const uint16_t bitsInTime, const uint16_t bitsOutOfTime, const uint16_t cscID)
+    : bitsInTime_(bitsInTime), bitsOutOfTime_(bitsOutOfTime), cscID_(cscID) {}
 
 /// Default
-CSCShowerDigi::CSCShowerDigi() : bits_(0), cscID_(0) {}
+CSCShowerDigi::CSCShowerDigi() : bitsInTime_(0), bitsOutOfTime_(0), cscID_(0) {}
+
+void CSCShowerDigi::clear() {
+  bitsInTime_ = 0;
+  bitsOutOfTime_ = 0;
+  cscID_ = 0;
+}
 
 bool CSCShowerDigi::isValid() const {
   // any loose shower is valid
-  return isLooseInTime() or isLooseOutTime();
+  return isLooseInTime() or isLooseOutOfTime();
 }
 
 bool CSCShowerDigi::isLooseInTime() const { return bitsInTime() >= kLoose; }
@@ -26,26 +29,12 @@ bool CSCShowerDigi::isNominalInTime() const { return bitsInTime() >= kNominal; }
 
 bool CSCShowerDigi::isTightInTime() const { return bitsInTime() >= kTight; }
 
-bool CSCShowerDigi::isLooseOutTime() const { return bitsOutTime() >= kLoose; }
+bool CSCShowerDigi::isLooseOutOfTime() const { return bitsOutOfTime() >= kLoose; }
 
-bool CSCShowerDigi::isNominalOutTime() const { return bitsOutTime() >= kNominal; }
+bool CSCShowerDigi::isNominalOutOfTime() const { return bitsOutOfTime() >= kNominal; }
 
-bool CSCShowerDigi::isTightOutTime() const { return bitsOutTime() >= kTight; }
+bool CSCShowerDigi::isTightOutOfTime() const { return bitsOutOfTime() >= kTight; }
 
-uint16_t CSCShowerDigi::bitsInTime() const { return getDataWord(bits_, kInTimeShift, kInTimeMask); }
-
-uint16_t CSCShowerDigi::bitsOutTime() const { return getDataWord(bits_, kOutTimeShift, kOutTimeMask); }
-
-void CSCShowerDigi::setDataWord(const uint16_t newWord, uint16_t& word, const unsigned shift, const unsigned mask) {
-  // clear the old value
-  word &= ~(mask << shift);
-
-  // set the new value
-  word |= newWord << shift;
+std::ostream& operator<<(std::ostream& o, const CSCShowerDigi& digi) {
+  return o << "CSC Shower: in-time bits " << digi.bitsInTime() << ", out-of-time bits " << digi.bitsOutOfTime();
 }
-
-uint16_t CSCShowerDigi::getDataWord(const uint16_t word, const unsigned shift, const unsigned mask) const {
-  return (word >> shift) & mask;
-}
-
-std::ostream& operator<<(std::ostream& o, const CSCShowerDigi& digi) { return o << "CSC Shower: " << digi.bits(); }

--- a/DataFormats/CSCDigi/src/CSCWireDigi.cc
+++ b/DataFormats/CSCDigi/src/CSCWireDigi.cc
@@ -67,12 +67,14 @@ void CSCWireDigi::print() const {
       << " BX # " << getWireGroupBX() << " | "
       << " BX + Wire " << std::hex << getBXandWireGroup() << " | " << std::dec << " First Time Bin On " << getTimeBin()
       << " | Time Bins On ";
-  std::copy(getTimeBinsOn().begin(), getTimeBinsOn().end(), std::ostream_iterator<int>(ost, " "));
+  std::vector<int> tbins = getTimeBinsOn();
+  std::copy(tbins.begin(), tbins.end(), std::ostream_iterator<int>(ost, " "));
   edm::LogVerbatim("CSCDigi") << ost.str();
 }
 
 std::ostream& operator<<(std::ostream& o, const CSCWireDigi& digi) {
   o << " CSCWireDigi wg: " << digi.getWireGroup() << ", First Time Bin On: " << digi.getTimeBin() << ", Time Bins On: ";
-  std::copy(digi.getTimeBinsOn().begin(), digi.getTimeBinsOn().end(), std::ostream_iterator<int>(o, " "));
+  std::vector<int> tbins = digi.getTimeBinsOn();
+  std::copy(tbins.begin(), tbins.end(), std::ostream_iterator<int>(o, " "));
   return o;
 }

--- a/DataFormats/CSCDigi/src/classes_def.xml
+++ b/DataFormats/CSCDigi/src/classes_def.xml
@@ -11,7 +11,8 @@
    <class name="CSCComparatorDigi" ClassVersion="10">
     <version ClassVersion="10" checksum="656608282"/>
    </class>
-   <class name="CSCCorrelatedLCTDigi" ClassVersion="12">
+   <class name="CSCCorrelatedLCTDigi" ClassVersion="13">
+    <version ClassVersion="13" checksum="537762368"/>
     <version ClassVersion="12" checksum="1516836035"/>
     <version ClassVersion="11" checksum="2118578151"/>
     <version ClassVersion="10" checksum="1301481852"/>
@@ -20,7 +21,8 @@
     <version ClassVersion="11" checksum="56593764"/>
     <version ClassVersion="10" checksum="967689346"/>
    </class>
-   <class name="CSCCLCTDigi" ClassVersion="12">
+   <class name="CSCCLCTDigi" ClassVersion="13">
+    <version ClassVersion="13" checksum="695892295"/>
     <version ClassVersion="12" checksum="1002733592"/>
     <version ClassVersion="11" checksum="511203876"/>
     <version ClassVersion="10" checksum="3910057547"/>
@@ -37,7 +39,8 @@
    <class name="CSCALCTPreTriggerDigi" ClassVersion="10">
     <version ClassVersion="10" checksum="2925979693"/>
    </class>
-   <class name="CSCShowerDigi" ClassVersion="10">
+   <class name="CSCShowerDigi" ClassVersion="11">
+    <version ClassVersion="11" checksum="3092485146"/>
     <version ClassVersion="10" checksum="3566030124"/>
    </class>
    <class name="CSCCFEBStatusDigi" ClassVersion="10">

--- a/DataFormats/L1CSCTrackFinder/src/classes_def.xml
+++ b/DataFormats/L1CSCTrackFinder/src/classes_def.xml
@@ -13,7 +13,8 @@
     <version ClassVersion="10" checksum="3445513287"/>
    </class>
 
-   <class name="csctf::TrackStub" ClassVersion="13">
+   <class name="csctf::TrackStub" ClassVersion="14">
+    <version ClassVersion="14" checksum="3081088872"/>
     <version ClassVersion="13" checksum="1877810363"/>
     <version ClassVersion="12" checksum="1100843423"/>
     <version ClassVersion="11" checksum="2137081572"/>

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCCathodeLCTProcessor.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCCathodeLCTProcessor.cc
@@ -1335,7 +1335,7 @@ void CSCCathodeLCTProcessor::runCCLUT(CSCCLCTDigi& digi) const {
     strm << "+                  Before CCCLUT algorithm:                       +\n";
     strm << "++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++\n";
     strm << " Old CLCT digi " << digi << "\n";
-    strm << " 1/4 strip bit " << digi.getQuartStrip() << " 1/8 strip bit " << digi.getEighthStrip() << "\n";
+    strm << " 1/4 strip bit " << digi.getQuartStripBit() << " 1/8 strip bit " << digi.getEighthStripBit() << "\n";
     strm << " 1/4 strip number " << digi.getKeyStrip(4) << " 1/8 strip number " << digi.getKeyStrip(8) << "\n";
     strm << "++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++\n";
     LogDebug("CSCCathodeLCTProcessor") << strm.str();
@@ -1411,8 +1411,8 @@ void CSCCathodeLCTProcessor::runCCLUT(CSCCLCTDigi& digi) const {
 
   // store the new 1/2, 1/4 and 1/8 strip positions
   digi.setStrip(halfstrip - digi.getCFEB() * CSCConstants::NUM_HALF_STRIPS_PER_CFEB);
-  digi.setQuartStrip(std::get<1>(stripoffset));
-  digi.setEighthStrip(std::get<2>(stripoffset));
+  digi.setQuartStripBit(std::get<1>(stripoffset));
+  digi.setEighthStripBit(std::get<2>(stripoffset));
 
   // store the bending angle value in the pattern data member
   digi.setSlope(slopeCCValue);
@@ -1428,7 +1428,7 @@ void CSCCathodeLCTProcessor::runCCLUT(CSCCLCTDigi& digi) const {
     strm << "+                  CCCLUT algorithm results:                       +\n";
     strm << "++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++\n";
     strm << " New CLCT digi " << digi << "\n";
-    strm << " 1/4 strip bit " << digi.getQuartStrip() << " 1/8 strip bit " << digi.getEighthStrip() << "\n";
+    strm << " 1/4 strip bit " << digi.getQuartStripBit() << " 1/8 strip bit " << digi.getEighthStripBit() << "\n";
     strm << " 1/4 strip number " << digi.getKeyStrip(4) << " 1/8 strip number " << digi.getKeyStrip(8) << "\n";
     strm << "++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++\n";
     LogDebug("CSCCathodeLCTProcessor") << strm.str();

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCGEMMotherboard.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCGEMMotherboard.cc
@@ -145,8 +145,8 @@ CSCCorrelatedLCTDigi CSCGEMMotherboard::constructLCTsGEM(const CSCALCTDigi& alct
       thisLCT.setRun3(true);
       // 4-bit slope value derived with the CCLUT algorithm
       thisLCT.setSlope(clct.getSlope());
-      thisLCT.setQuartStrip(clct.getQuartStrip());
-      thisLCT.setEighthStrip(clct.getEighthStrip());
+      thisLCT.setQuartStripBit(clct.getQuartStripBit());
+      thisLCT.setEighthStripBit(clct.getEighthStripBit());
       thisLCT.setRun3Pattern(clct.getRun3Pattern());
     }
   } else if (alct.isValid() and clct.isValid() and not gem1.isValid() and gem2.isValid()) {
@@ -170,8 +170,8 @@ CSCCorrelatedLCTDigi CSCGEMMotherboard::constructLCTsGEM(const CSCALCTDigi& alct
       thisLCT.setRun3(true);
       // 4-bit slope value derived with the CCLUT algorithm
       thisLCT.setSlope(clct.getSlope());
-      thisLCT.setQuartStrip(clct.getQuartStrip());
-      thisLCT.setEighthStrip(clct.getEighthStrip());
+      thisLCT.setQuartStripBit(clct.getQuartStripBit());
+      thisLCT.setEighthStripBit(clct.getEighthStripBit());
       thisLCT.setRun3Pattern(clct.getRun3Pattern());
     }
   } else if (alct.isValid() and gem2.isValid() and not clct.isValid()) {
@@ -244,8 +244,8 @@ CSCCorrelatedLCTDigi CSCGEMMotherboard::constructLCTsGEM(const CSCALCTDigi& alct
       thisLCT.setRun3(true);
       // 4-bit slope value derived with the CCLUT algorithm
       thisLCT.setSlope(clct.getSlope());
-      thisLCT.setQuartStrip(clct.getQuartStrip());
-      thisLCT.setEighthStrip(clct.getEighthStrip());
+      thisLCT.setQuartStripBit(clct.getQuartStripBit());
+      thisLCT.setEighthStripBit(clct.getEighthStripBit());
       thisLCT.setRun3Pattern(clct.getRun3Pattern());
     }
   }

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboard.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboard.cc
@@ -515,8 +515,8 @@ void CSCMotherboard::encodeHighMultiplicityBits() {
       outTimeHMT_ = anodeOutTime;
       break;
     case 2:
-      inTimeHMT_ = (anodeInTime & CSCShowerDigi::kInTimeMask) | (cathodeInTime & CSCShowerDigi::kInTimeMask);
-      outTimeHMT_ = (anodeOutTime & CSCShowerDigi::kOutTimeMask) | (cathodeOutTime & CSCShowerDigi::kOutTimeMask);
+      inTimeHMT_ = anodeInTime | cathodeInTime;
+      outTimeHMT_ = anodeOutTime | cathodeOutTime;
       break;
     default:
       inTimeHMT_ = cathodeInTime;

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboard.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboard.cc
@@ -420,8 +420,8 @@ CSCCorrelatedLCTDigi CSCMotherboard::constructLCTs(const CSCALCTDigi& aLCT,
     thisLCT.setRun3(true);
     // 4-bit slope value derived with the CCLUT algorithm
     thisLCT.setSlope(cLCT.getSlope());
-    thisLCT.setQuartStrip(cLCT.getQuartStrip());
-    thisLCT.setEighthStrip(cLCT.getEighthStrip());
+    thisLCT.setQuartStripBit(cLCT.getQuartStripBit());
+    thisLCT.setEighthStripBit(cLCT.getEighthStripBit());
     thisLCT.setRun3Pattern(cLCT.getRun3Pattern());
   }
 

--- a/L1Trigger/L1TMuon/BuildFile.xml
+++ b/L1Trigger/L1TMuon/BuildFile.xml
@@ -8,6 +8,7 @@
 <use name="DataFormats/L1TMuon"/>
 <use name="DataFormats/L1Trigger"/>
 <use name="DataFormats/RPCRecHit"/>
+<use name="DataFormats/CSCDigi"/>
 <use name="FWCore/PluginManager"/>
 <use name="L1Trigger/L1TCommon"/>
 <use name="L1Trigger/CSCTriggerPrimitives"/>

--- a/L1Trigger/L1TMuonEndCap/src/SectorProcessorShower.cc
+++ b/L1Trigger/L1TMuonEndCap/src/SectorProcessorShower.cc
@@ -48,9 +48,9 @@ void SectorProcessorShower::process(const CSCShowerDigiCollection& in_showers,
   const unsigned nNominalInTime(std::count_if(
       selected_showers.begin(), selected_showers.end(), [](CSCShowerDigi p) { return p.isNominalInTime(); }));
   const unsigned nLooseOutOfTime(std::count_if(
-      selected_showers.begin(), selected_showers.end(), [](CSCShowerDigi p) { return p.isLooseOutTime(); }));
+      selected_showers.begin(), selected_showers.end(), [](CSCShowerDigi p) { return p.isLooseOutOfTime(); }));
   const unsigned nNominalOutOfTime(std::count_if(
-      selected_showers.begin(), selected_showers.end(), [](CSCShowerDigi p) { return p.isNominalOutTime(); }));
+      selected_showers.begin(), selected_showers.end(), [](CSCShowerDigi p) { return p.isNominalOutOfTime(); }));
 
   const bool hasTwoLooseInTime(nLooseInTime >= nLooseShowers_);
   const bool hasOneNominalInTime(nNominalInTime >= nNominalShowers_);


### PR DESCRIPTION
#### PR description:

In previous PRs (#29456, #29205, #32880) I defined the Run-3 CSC TP formats based on a detector note DN-20-016. In the CLCT and LCT I extended the definition of existing data members with bit masks and bit shifts. It was pointed out to me that although this method is economical, it does not prevent data formats from being misinterpreted, should the bit masks or shifts change in the future. CMSSW would not record changes in bit masks and shifts as changes in the data formats, as opposed to changes in data members. 

Bottom line: 1/4-strip bit, 1/8-strip bit, Run-3 pattern and slope now have corresponding data members in CLCT and LCT. In-time bits and out-of-time bits are separated in the CSCShowerDigi.

#### PR validation:

Tested with WF 11634.0. There should be no changes in any workflow.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
