### PR TITLE
Add source_only flag for source-only dependencies in calibration

### DIFF
--- a/CalibTracker/SiPhase2TrackerESProducers/plugins/BuildFile.xml
+++ b/CalibTracker/SiPhase2TrackerESProducers/plugins/BuildFile.xml
@@ -1,8 +1,11 @@
-<use name="CalibTracker/SiPhase2TrackerESProducers"/>
+<use name="CalibTracker/SiPhase2TrackerESProducers" source_only="1"/>
+<use name="CondFormats/DataRecord"/>
+<use name="CondFormats/SiPhase2TrackerObjects"/>
 <use name="DataFormats/SiStripDetId"/>
 <use name="FWCore/Framework"/>
 <use name="FWCore/MessageLogger"/>
-<use name="Geometry/CommonDetUnit"/>
+<use name="Geometry/CommonDetUnit" source_only="1"/>
+<use name="Geometry/Records"/>
 <use name="Geometry/TrackerNumberingBuilder"/>
 <library file="*.cc" name="CalibTrackerSiPhase2TrackerESProducersPlugins">
   <flags EDM_PLUGIN="1"/>

--- a/CalibTracker/SiPhase2TrackerESProducers/plugins/SiPhase2OuterTrackerFakeLorentzAngleESSource.cc
+++ b/CalibTracker/SiPhase2TrackerESProducers/plugins/SiPhase2OuterTrackerFakeLorentzAngleESSource.cc
@@ -15,10 +15,13 @@
 //
 
 // user include files
+#include "CondFormats/DataRecord/interface/SiPhase2OuterTrackerLorentzAngleRcd.h"
+#include "CondFormats/SiPhase2TrackerObjects/interface/SiPhase2OuterTrackerLorentzAngle.h"
 #include "Geometry/CommonDetUnit/interface/PixelGeomDetUnit.h"
 #include "DataFormats/SiStripDetId/interface/StripSubdetector.h"
 #include "CalibTracker/SiPhase2TrackerESProducers/interface/SiPhase2OuterTrackerFakeLorentzAngleESSource.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "Geometry/Records/interface/TrackerTopologyRcd.h"
 #include "Geometry/TrackerNumberingBuilder/interface/utils.h"
 //
 // constructors and destructor

--- a/CalibTracker/SiPixelConnectivity/BuildFile.xml
+++ b/CalibTracker/SiPixelConnectivity/BuildFile.xml
@@ -4,7 +4,7 @@
 <use name="CondFormats/SiPixelObjects"/>
 <use name="DataFormats/SiPixelDetId"/>
 <use name="DataFormats/TrackerCommon"/>
-<use name="Geometry/CommonDetUnit"/>
+<use name="Geometry/CommonDetUnit" source_only="1"/>
 <export>
   <lib name="1"/>
 </export>

--- a/CalibTracker/SiPixelErrorEstimation/BuildFile.xml
+++ b/CalibTracker/SiPixelErrorEstimation/BuildFile.xml
@@ -9,7 +9,7 @@
 <use name="DataFormats/TrackReco"/>
 <use name="DataFormats/TrajectorySeed"/>
 <use name="FWCore/MessageLogger"/>
-<use name="Geometry/CommonDetUnit"/>
+<use name="Geometry/CommonDetUnit" source_only="1"/>
 <use name="Geometry/CommonTopologies"/>
 <use name="Geometry/Records"/>
 <use name="Geometry/TrackerGeometryBuilder"/>

--- a/CalibTracker/SiPixelQuality/BuildFile.xml
+++ b/CalibTracker/SiPixelQuality/BuildFile.xml
@@ -12,7 +12,7 @@
 <use name="FWCore/Framework"/>
 <use name="FWCore/MessageLogger"/>
 <use name="FWCore/ParameterSet"/>
-<use name="Geometry/CommonDetUnit"/>
+<use name="Geometry/CommonDetUnit" source_only="1"/>
 <use name="Geometry/CommonTopologies"/>
 <use name="Geometry/TrackerGeometryBuilder"/>
 <use name="rootcling"/>

--- a/CalibTracker/SiPixelQuality/plugins/BuildFile.xml
+++ b/CalibTracker/SiPixelQuality/plugins/BuildFile.xml
@@ -16,7 +16,7 @@
  <use name="FWCore/ParameterSet"/>
  <use name="FWCore/Utilities"/>
  <use name="FWCore/Concurrency"/>
- <use name="Geometry/CommonDetUnit"/>
+ <use name="Geometry/CommonDetUnit" source_only="1"/>
  <use name="Geometry/Records"/>
  <use name="Geometry/TrackerGeometryBuilder"/>
  <use name="rootcling"/>
@@ -36,7 +36,7 @@
  <use name="FWCore/ParameterSet"/>
  <use name="FWCore/ServiceRegistry"/>
  <use name="FWCore/Utilities"/>
- <use name="Geometry/CommonDetUnit"/>
+ <use name="Geometry/CommonDetUnit" source_only="1"/>
  <use name="Geometry/Records"/>
  <use name="Geometry/TrackerGeometryBuilder"/>
  <use name="rootcling"/>

--- a/CalibTracker/SiPixelTools/BuildFile.xml
+++ b/CalibTracker/SiPixelTools/BuildFile.xml
@@ -5,7 +5,7 @@
 <use name="CondFormats/SiPixelObjects"/>
 <use name="Geometry/Records"/>
 <use name="root"/>
-<use name="Geometry/CommonDetUnit"/>
+<use name="Geometry/CommonDetUnit" source_only="1"/>
 <use name="Geometry/TrackerGeometryBuilder"/>
 <use name="DQM/SiPixelCommon"/>
 <use name="DQMServices/Core"/>

--- a/CalibTracker/SiPixelTools/plugins/BuildFile.xml
+++ b/CalibTracker/SiPixelTools/plugins/BuildFile.xml
@@ -9,7 +9,7 @@
   <use name="CondFormats/SiPixelObjects"/>
   <use name="DQM/SiPixelCommon"/>
   <use name="Geometry/Records"/>
-  <use name="Geometry/CommonDetUnit"/>
+  <use name="Geometry/CommonDetUnit" source_only="1"/>
   <use name="Geometry/TrackerGeometryBuilder"/>
   <use name="CommonTools/UtilAlgos"/>
   <library file="*.cc" name="CalibTrackerSiPixelToolsPlugin">

--- a/CalibTracker/SiStripChannelGain/BuildFile.xml
+++ b/CalibTracker/SiStripChannelGain/BuildFile.xml
@@ -12,7 +12,7 @@
 <use name="DataFormats/SiStripDetId"/>
 <use name="DataFormats/TrackReco"/>
 <use name="DataFormats/TrackerRecHit2D"/>
-<use name="Geometry/CommonDetUnit"/>
+<use name="Geometry/CommonDetUnit" source_only="1"/>
 <use name="Geometry/CommonTopologies"/>
 <use name="Geometry/Records"/>
 <use name="Geometry/TrackerGeometryBuilder"/>

--- a/CalibTracker/SiStripHitEfficiency/BuildFile.xml
+++ b/CalibTracker/SiStripHitEfficiency/BuildFile.xml
@@ -7,7 +7,7 @@
 <use name="DataFormats/Common"/>
 <use name="FWCore/Framework"/>
 <use name="FWCore/ParameterSet"/>
-<use name="Geometry/CommonDetUnit"/>
+<use name="Geometry/CommonDetUnit" source_only="1"/>
 <use name="Geometry/Records"/>
 <use name="Geometry/TrackerGeometryBuilder"/>
 <use name="MagneticField/Engine"/>

--- a/CalibTracker/SiStripHitEfficiency/plugins/BuildFile.xml
+++ b/CalibTracker/SiStripHitEfficiency/plugins/BuildFile.xml
@@ -9,7 +9,7 @@
 <use name="FWCore/Framework"/>
 <use name="FWCore/ParameterSet"/>
 <use name="FWCore/ServiceRegistry"/>
-<use name="Geometry/CommonDetUnit"/>
+<use name="Geometry/CommonDetUnit" source_only="1"/>
 <use name="Geometry/Records"/>
 <use name="Geometry/TrackerGeometryBuilder"/>
 <use name="RecoTracker/Record"/>


### PR DESCRIPTION
#### PR description:

Add `source_only` flag for source-only dependencies in `calibration`. These dependencies were automatically found with [this script](https://github.com/guitargeek/PKGBUILDs/blob/master/cmssw/update_source_only.py).

In this PR, the `source_only` change also made it obvious that some includes were missing in `SiPhase2OuterTrackerFakeLorentzAngleESSource.cc` (CMSSW did not compile anymore without adding them).

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

No backport intended.
