### PR TITLE
Add source_only flag for source-only dependencies in alignment

### DIFF
--- a/Alignment/APEEstimation/plugins/BuildFile.xml
+++ b/Alignment/APEEstimation/plugins/BuildFile.xml
@@ -1,5 +1,5 @@
 <library file="*.cc" name="ApeEstimatorApeEstimatorPlugins">
-  <use name="Alignment/APEEstimation"/>
+  <use name="Alignment/APEEstimation" source_only="1"/>
   <use name="CommonTools/UtilAlgos"/>
   <use name="DataFormats/TrackingRecHit"/>
   <use name="DataFormats/TrackerRecHit2D"/>

--- a/Alignment/CommonAlignment/BuildFile.xml
+++ b/Alignment/CommonAlignment/BuildFile.xml
@@ -8,7 +8,7 @@
 <use name="FWCore/ParameterSet"/>
 <use name="FWCore/ServiceRegistry"/>
 <use name="FWCore/Utilities"/>
-<use name="Geometry/CommonDetUnit"/>
+<use name="Geometry/CommonDetUnit" source_only="1"/>
 <use name="Geometry/CommonTopologies"/>
 <use name="Geometry/TrackerGeometryBuilder"/>
 <use name="TrackingTools/TransientTrackingRecHit"/>

--- a/Alignment/CommonAlignmentAlgorithm/plugins/BuildFile.xml
+++ b/Alignment/CommonAlignmentAlgorithm/plugins/BuildFile.xml
@@ -16,7 +16,7 @@
   <use name="DataFormats/SiStripDetId"/>
   <use name="MagneticField/Engine"/>
   <use name="MagneticField/Records"/>
-  <use name="Geometry/CommonDetUnit"/>
+  <use name="Geometry/CommonDetUnit" source_only="1"/>
   <use name="TrackingTools/TransientTrackingRecHit"/>
   <flags EDM_PLUGIN="1"/>
 </library>

--- a/Alignment/CommonAlignmentMonitor/plugins/BuildFile.xml
+++ b/Alignment/CommonAlignmentMonitor/plugins/BuildFile.xml
@@ -36,7 +36,7 @@
 <library name="AlignmentMonitorSegmentDifferences" file="AlignmentMonitorSegmentDifferences.cc">
   <use name="Alignment/MuonAlignmentAlgorithms"/>
   <use name="Alignment/CommonAlignmentMonitor"/>
-  <use name="Geometry/CommonDetUnit"/>
+  <use name="Geometry/CommonDetUnit" source_only="1"/>
   <use name="Geometry/Records"/>
   <flags EDM_PLUGIN="1"/>
 </library>
@@ -44,7 +44,7 @@
 <library name="AlignmentMonitorMuonVsCurvature" file="AlignmentMonitorMuonVsCurvature.cc">
   <use name="Alignment/MuonAlignmentAlgorithms"/>
   <use name="Alignment/CommonAlignmentMonitor"/>
-  <use name="Geometry/CommonDetUnit"/>
+  <use name="Geometry/CommonDetUnit" source_only="1"/>
   <use name="Geometry/Records"/>
   <use name="MagneticField/Engine"/>
   <use name="MagneticField/Records"/>
@@ -54,7 +54,7 @@
 <library name="AlignmentMonitorMuonSystemMap1D" file="AlignmentMonitorMuonSystemMap1D.cc">
   <use name="Alignment/MuonAlignmentAlgorithms"/>
   <use name="Alignment/CommonAlignmentMonitor"/>
-  <use name="Geometry/CommonDetUnit"/>
+  <use name="Geometry/CommonDetUnit" source_only="1"/>
   <use name="Geometry/Records"/>
   <flags EDM_PLUGIN="1"/>
 </library>
@@ -90,7 +90,7 @@
   <use name="DataFormats/TrackingRecHit"/>
   <use name="Geometry/DTGeometry"/>
   <use name="Geometry/CSCGeometry"/>
-  <use name="Geometry/CommonDetUnit"/>
+  <use name="Geometry/CommonDetUnit" source_only="1"/>
   <use name="Geometry/Records"/>
   <use name="MagneticField/Engine"/>
   <use name="MagneticField/Records"/>

--- a/Alignment/CommonAlignmentProducer/plugins/BuildFile.xml
+++ b/Alignment/CommonAlignmentProducer/plugins/BuildFile.xml
@@ -34,7 +34,7 @@
   <use name="root"/>
   <use name="FWCore/ServiceRegistry"/>
   <use name="Geometry/Records"/>
-  <use name="Geometry/CommonDetUnit"/>
+  <use name="Geometry/CommonDetUnit" source_only="1"/>
   <use name="MagneticField/Engine"/>
   <use name="MagneticField/Records"/>
   <use name="TrackingTools/GeomPropagators"/>

--- a/Alignment/LaserAlignmentSimulation/test/BuildFile.xml
+++ b/Alignment/LaserAlignmentSimulation/test/BuildFile.xml
@@ -2,7 +2,7 @@
 <use name="FWCore/ParameterSet"/>
 <use name="FWCore/MessageLogger"/>
 <use name="Geometry/TrackerGeometryBuilder"/>
-<use name="Geometry/CommonDetUnit"/>
+<use name="Geometry/CommonDetUnit" source_only="1"/>
 <use name="DataFormats/SiStripDetId"/>
 <use name="DataFormats/DetId"/>
 <use name="SimDataFormats/TrackingHit"/>

--- a/Alignment/MillePedeAlignmentAlgorithm/BuildFile.xml
+++ b/Alignment/MillePedeAlignmentAlgorithm/BuildFile.xml
@@ -11,7 +11,7 @@
 <use name="FWCore/MessageLogger"/>
 <use name="FWCore/ParameterSet"/>
 <use name="FWCore/PluginManager"/>
-<use name="Geometry/CommonDetUnit"/>
+<use name="Geometry/CommonDetUnit" source_only="1"/>
 <use name="rootcore"/>
 <export>
   <lib name="1"/>

--- a/Alignment/MuonAlignmentAlgorithms/BuildFile.xml
+++ b/Alignment/MuonAlignmentAlgorithms/BuildFile.xml
@@ -4,7 +4,7 @@
 <use name="FWCore/Utilities"/>
 <use name="DataFormats/TrackReco"/>
 <use name="Geometry/CSCGeometry"/>
-<use name="Geometry/CommonDetUnit"/>
+<use name="Geometry/CommonDetUnit" source_only="1"/>
 <use name="TrackingTools/TrackFitters"/>
 <use name="Alignment/CommonAlignment"/>
 <use name="RecoMuon/TransientTrackingRecHit"/>

--- a/Alignment/MuonAlignmentAlgorithms/plugins/BuildFile.xml
+++ b/Alignment/MuonAlignmentAlgorithms/plugins/BuildFile.xml
@@ -3,7 +3,7 @@
 <use name="FWCore/ParameterSet"/>
 <use name="FWCore/ServiceRegistry"/>
 <library name="CSCOverlapsAlignmentAlgorithm" file="CSCOverlapsAlignmentAlgorithm.cc,CSCOverlapsTrackPreparation.cc,CSCOverlapsBeamSplashCut.cc,CSCPairResidualsConstraint.cc,CSCChamberFitter.cc,CSCAlignmentCorrections.cc">
-  <use name="Geometry/CommonDetUnit"/>
+  <use name="Geometry/CommonDetUnit" source_only="1"/>
   <use name="Geometry/Records"/>
   <use name="Geometry/CSCGeometry"/>
   <use name="MagneticField/Engine"/>
@@ -38,7 +38,7 @@
   <use name="CommonTools/UtilAlgos"/>
   <use name="DataFormats/MuonDetId"/>
   <use name="DataFormats/TrackReco"/>
-  <use name="Geometry/CommonDetUnit"/>
+  <use name="Geometry/CommonDetUnit" source_only="1"/>
   <use name="Geometry/Records"/>
   <use name="TrackingTools/PatternTools"/>
   <use name="root"/>
@@ -55,7 +55,7 @@
 </library>
 
 <library name="MuonMillepedeAlgorithm" file="MuonMillepedeAlgorithm.cc,MuonMillepedeTrackRefitter.cc">
-  <use name="Geometry/CommonDetUnit"/>
+  <use name="Geometry/CommonDetUnit" source_only="1"/>
   <use name="MagneticField/Engine"/>
   <use name="MagneticField/Records"/>
   <use name="DataFormats/GeometrySurface"/>

--- a/Alignment/MuonAlignmentAlgorithms/test/BuildFile.xml
+++ b/Alignment/MuonAlignmentAlgorithms/test/BuildFile.xml
@@ -9,7 +9,7 @@
 <use name="Geometry/CSCGeometry"/>
 <use name="Geometry/Records"/>
 <use name="TrackingTools/PatternTools"/>
-<use name="Geometry/CommonDetUnit"/>
+<use name="Geometry/CommonDetUnit" source_only="1"/>
 <use name="Alignment/MuonAlignment"/>
 <use name="Alignment/MuonAlignmentAlgorithms"/>
 <use name="root"/>

--- a/Alignment/OfflineValidation/BuildFile.xml
+++ b/Alignment/OfflineValidation/BuildFile.xml
@@ -15,7 +15,7 @@
 <use name="DataFormats/SiStripDetId"/>
 <use name="DataFormats/TrackerRecHit2D"/>
 <use name="FWCore/MessageLogger"/>
-<use name="Geometry/CommonDetUnit"/>
+<use name="Geometry/CommonDetUnit" source_only="1"/>
 <use name="Geometry/CommonTopologies"/>
 <use name="Geometry/Records"/>
 <use name="MagneticField/Records"/>

--- a/Alignment/OfflineValidation/plugins/BuildFile.xml
+++ b/Alignment/OfflineValidation/plugins/BuildFile.xml
@@ -29,7 +29,7 @@
 <use name="FWCore/ServiceRegistry"/>
 <use name="FWCore/Utilities"/>
 <use name="Geometry/CaloGeometry"/>
-<use name="Geometry/CommonDetUnit"/>
+<use name="Geometry/CommonDetUnit" source_only="1"/>
 <use name="Geometry/CommonTopologies"/>
 <use name="Geometry/Records"/>
 <use name="Geometry/TrackerGeometryBuilder"/>

--- a/Alignment/ReferenceTrajectories/BuildFile.xml
+++ b/Alignment/ReferenceTrajectories/BuildFile.xml
@@ -6,7 +6,7 @@
 <use name="DataFormats/TrajectoryState"/>
 <use name="FWCore/MessageLogger"/>
 <use name="FWCore/PluginManager"/>
-<use name="Geometry/CommonDetUnit"/>
+<use name="Geometry/CommonDetUnit" source_only="1"/>
 <use name="TrackingTools/AnalyticalJacobians"/>
 <use name="TrackingTools/GeomPropagators"/>
 <use name="TrackingTools/MaterialEffects"/>

--- a/Alignment/TrackerAlignment/BuildFile.xml
+++ b/Alignment/TrackerAlignment/BuildFile.xml
@@ -9,7 +9,7 @@
 <use name="FWCore/MessageLogger"/>
 <use name="FWCore/ServiceRegistry"/>
 <use name="FWCore/Utilities"/>
-<use name="Geometry/CommonDetUnit"/>
+<use name="Geometry/CommonDetUnit" source_only="1"/>
 <use name="Geometry/Records"/>
 <use name="Geometry/TrackerGeometryBuilder"/>
 <export>

--- a/Alignment/TrackerAlignment/plugins/BuildFile.xml
+++ b/Alignment/TrackerAlignment/plugins/BuildFile.xml
@@ -40,7 +40,7 @@
   <use name="Geometry/Records"/>
   <use name="Geometry/TrackerNumberingBuilder"/>
   <use name="Geometry/TrackerGeometryBuilder"/>
-  <use name="Geometry/CommonDetUnit"/>
+  <use name="Geometry/CommonDetUnit" source_only="1"/>
   <use name="Geometry/CommonTopologies"/>
   <use name="root"/>
   <flags EDM_PLUGIN="1"/>

--- a/Alignment/TrackerAlignment/test/BuildFile.xml
+++ b/Alignment/TrackerAlignment/test/BuildFile.xml
@@ -6,7 +6,7 @@
 <use name="Geometry/Records"/>
 <use name="Geometry/TrackerGeometryBuilder"/>
 <library name="AlignmentTrackerAlignment_test" file="*.cpp">
-  <use name="Geometry/CommonDetUnit"/>
+  <use name="Geometry/CommonDetUnit" source_only="1"/>
   <use name="CondCore/DBOutputService"/>
   <use name="CondFormats/Alignment"/>
   <use name="CondFormats/AlignmentRecord"/>


### PR DESCRIPTION
#### PR description:

Add `source_only` flag for source-only dependencies in `alignment`. These dependencies were automatically found with [this script](https://github.com/guitargeek/PKGBUILDs/blob/master/cmssw/update_source_only.py).

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

No backport intended.