### PR TITLE
Add source_only flag for source-only dependencies in reco

### DIFF
--- a/RecoBTag/PixelCluster/plugins/BuildFile.xml
+++ b/RecoBTag/PixelCluster/plugins/BuildFile.xml
@@ -8,6 +8,6 @@
   <use name="DataFormats/BTauReco"/>
   <use name="Geometry/TrackerGeometryBuilder"/>
   <use name="Geometry/Records"/>
-  <use name="Geometry/CommonDetUnit"/>
+  <use name="Geometry/CommonDetUnit" source_only="1"/>
   <flags EDM_PLUGIN="1"/>
 </library>

--- a/RecoCaloTools/Navigation/test/BuildFile.xml
+++ b/RecoCaloTools/Navigation/test/BuildFile.xml
@@ -1,8 +1,8 @@
 <use name="DataFormats/EcalDetId"/>
 <use name="FWCore/Framework"/>
-<use name="Geometry/CaloEventSetup"/>
+<use name="Geometry/Records"/>
 <use name="Geometry/CaloTopology"/>
-<use name="RecoCaloTools/Navigation"/>
+<use name="RecoCaloTools/Navigation" source_only="1"/>
 <flags EDM_PLUGIN="1"/>
 <library file="stubs/CaloNavigationAnalyzer.cc" name="testCaloNavigationAnalyzer">
 </library>

--- a/RecoCaloTools/Navigation/test/stubs/CaloNavigationAnalyzer.cc
+++ b/RecoCaloTools/Navigation/test/stubs/CaloNavigationAnalyzer.cc
@@ -11,7 +11,7 @@
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
-#include "Geometry/CaloEventSetup/interface/CaloTopologyRecord.h"
+#include "Geometry/Records/interface/CaloTopologyRecord.h"
 #include "Geometry/CaloTopology/interface/CaloSubdetectorTopology.h"
 #include "Geometry/CaloTopology/interface/CaloTopology.h"
 #include "RecoCaloTools/Navigation/interface/EcalBarrelNavigator.h"

--- a/RecoCaloTools/Selectors/test/BuildFile.xml
+++ b/RecoCaloTools/Selectors/test/BuildFile.xml
@@ -1,6 +1,6 @@
 <use name="boost"/>
 <use name="DataFormats/HcalRecHit"/>
-<use name="RecoCaloTools/Selectors"/>
+<use name="RecoCaloTools/Selectors" source_only="1"/>
 <use name="FWCore/Framework"/>
 <use name="FWCore/ParameterSet"/>
 <use name="FWCore/Utilities"/>

--- a/RecoEgamma/EgammaIsolationAlgos/BuildFile.xml
+++ b/RecoEgamma/EgammaIsolationAlgos/BuildFile.xml
@@ -2,7 +2,7 @@
 <use name="FWCore/ParameterSet"/>
 <use name="Geometry/CaloGeometry"/>
 <use name="Geometry/CaloTopology"/>
-<use name="RecoCaloTools/Selectors"/>
+<use name="RecoCaloTools/Selectors" source_only="1"/>
 <use name="DataFormats/Candidate"/>
 <use name="DataFormats/RecoCandidate"/>
 <use name="DataFormats/ParticleFlowReco"/>

--- a/RecoEgamma/EgammaIsolationAlgos/plugins/BuildFile.xml
+++ b/RecoEgamma/EgammaIsolationAlgos/plugins/BuildFile.xml
@@ -9,7 +9,7 @@
 <use name="FWCore/ParameterSet"/>
 <use name="Geometry/CaloGeometry"/>
 <use name="Geometry/Records"/>
-<use name="RecoCaloTools/Selectors"/>
+<use name="RecoCaloTools/Selectors" source_only="1"/>
 <use name="CommonTools/Statistics"/>
 <use name="RecoEgamma/EgammaIsolationAlgos"/>
 <use name="RecoLocalCalo/EcalRecAlgos"/>

--- a/RecoEgamma/EgammaPhotonProducers/BuildFile.xml
+++ b/RecoEgamma/EgammaPhotonProducers/BuildFile.xml
@@ -19,6 +19,6 @@
 <use name="RecoTracker/CkfPattern"/>
 <use name="RecoTracker/TrackProducer"/>
 <use name="DataFormats/HcalRecHit"/>
-<use name="RecoCaloTools/Selectors"/>
+<use name="RecoCaloTools/Selectors" source_only="1"/>
 <use name="clhep"/>
 <flags EDM_PLUGIN="1"/>

--- a/RecoEgamma/Examples/plugins/BuildFile.xml
+++ b/RecoEgamma/Examples/plugins/BuildFile.xml
@@ -1,7 +1,7 @@
 <use name="RecoEgamma/EgammaMCTools"/>
 <use name="RecoEcal/EgammaCoreTools"/>
 <use name="Geometry/CaloTopology"/>
-<use name="Geometry/CommonDetUnit"/>
+<use name="Geometry/CommonDetUnit" source_only="1"/>
 <use name="Geometry/Records"/>
 <use name="Geometry/TrackerGeometryBuilder"/>
 <use name="MagneticField/Engine"/>

--- a/RecoHGCal/TICL/plugins/BuildFile.xml
+++ b/RecoHGCal/TICL/plugins/BuildFile.xml
@@ -16,7 +16,7 @@
 <use name="FWCore/PluginManager"/>
 <use name="FWCore/Utilities"/>
 <use name="Geometry/CaloGeometry"/>
-<use name="Geometry/CommonDetUnit"/>
+<use name="Geometry/CommonDetUnit" source_only="1"/>
 <use name="Geometry/HGCalCommonData"/>
 <use name="Geometry/Records"/>
 <use name="MagneticField/Engine"/>

--- a/RecoHI/HiTracking/plugins/BuildFile.xml
+++ b/RecoHI/HiTracking/plugins/BuildFile.xml
@@ -15,7 +15,7 @@
 <use name="FWCore/ParameterSet"/>
 <use name="FWCore/PluginManager"/>
 <use name="FWCore/Utilities"/>
-<use name="Geometry/CommonDetUnit"/>
+<use name="Geometry/CommonDetUnit" source_only="1"/>
 <use name="Geometry/CommonTopologies"/>
 <use name="Geometry/Records"/>
 <use name="Geometry/TrackerGeometryBuilder"/>

--- a/RecoHI/HiTracking/test/BuildFile.xml
+++ b/RecoHI/HiTracking/test/BuildFile.xml
@@ -2,7 +2,7 @@
 <use name="CommonTools/UtilAlgos"/>
 <use name="DataFormats/SiPixelDetId"/>
 <use name="DataFormats/TrackerRecHit2D"/>
-<use name="Geometry/CommonDetUnit"/>
+<use name="Geometry/CommonDetUnit" source_only="1"/>
 <use name="Geometry/Records"/>
 <use name="Geometry/TrackerGeometryBuilder"/>
 <library file="*.cc" name="RecoHIHiTrackingTest">

--- a/RecoJets/JetProducers/BuildFile.xml
+++ b/RecoJets/JetProducers/BuildFile.xml
@@ -5,7 +5,7 @@
 <use name="Geometry/CaloGeometry"/>
 <use name="Geometry/CaloTopology"/>
 <use name="Geometry/Records"/>
-<use name="Geometry/CommonDetUnit"/>
+<use name="Geometry/CommonDetUnit" source_only="1"/>
 <use name="SimDataFormats/CaloHit"/>
 <use name="SimDataFormats/Vertex"/>
 <use name="SimDataFormats/Track"/>

--- a/RecoLocalMuon/GEMCSCSegment/test/BuildFile.xml
+++ b/RecoLocalMuon/GEMCSCSegment/test/BuildFile.xml
@@ -3,7 +3,7 @@
 <use name="FWCore/ServiceRegistry"/>
 <use name="DataFormats/MuonDetId"/>
 <use name="DataFormats/GEMRecHit"/>
-<use name="Geometry/CommonDetUnit"/>
+<use name="Geometry/CommonDetUnit" source_only="1"/>
 <use name="Geometry/GEMGeometry"/>
 <use name="Geometry/CSCGeometry"/>
 <use name="Geometry/Records"/>

--- a/RecoLocalMuon/GEMRecHit/test/BuildFile.xml
+++ b/RecoLocalMuon/GEMRecHit/test/BuildFile.xml
@@ -4,7 +4,7 @@
 <use name="DataFormats/MuonDetId"/>
 <use name="DataFormats/GEMDigi"/>
 <use name="DataFormats/GEMRecHit"/>
-<use name="Geometry/CommonDetUnit"/>
+<use name="Geometry/CommonDetUnit" source_only="1"/>
 <use name="Geometry/GEMGeometry"/>
 <use name="Geometry/CSCGeometry"/>
 <use name="Geometry/Records"/>

--- a/RecoLocalTracker/Phase2TrackerRecHits/test/BuildFile.xml
+++ b/RecoLocalTracker/Phase2TrackerRecHits/test/BuildFile.xml
@@ -5,7 +5,7 @@
 <use name="DataFormats/SiPixelDetId"/>
 <use name="DataFormats/DetId"/>
 <use name="Geometry/Records"/>
-<use name="Geometry/CommonDetUnit"/>
+<use name="Geometry/CommonDetUnit" source_only="1"/>
 <use name="Geometry/TrackerGeometryBuilder"/>
 <use name="FWCore/Framework"/>
 <use name="FWCore/ParameterSet"/>

--- a/RecoLocalTracker/SiPhase2Clusterizer/test/BuildFile.xml
+++ b/RecoLocalTracker/SiPhase2Clusterizer/test/BuildFile.xml
@@ -7,7 +7,7 @@
 <use name="DataFormats/SiPixelDetId"/>
 <use name="DataFormats/DetId"/>
 <use name="Geometry/Records"/>
-<use name="Geometry/CommonDetUnit"/>
+<use name="Geometry/CommonDetUnit" source_only="1"/>
 <use name="Geometry/TrackerGeometryBuilder"/>
 <use name="FWCore/Framework"/>
 <use name="FWCore/ParameterSet"/>

--- a/RecoLocalTracker/SiPhase2VectorHitBuilder/BuildFile.xml
+++ b/RecoLocalTracker/SiPhase2VectorHitBuilder/BuildFile.xml
@@ -4,7 +4,7 @@
 <use name="FWCore/Framework"/>
 <use name="FWCore/Utilities"/>
 <use name="DataFormats/TrackerRecHit2D"/>
-<use name="Geometry/CommonDetUnit"/>
+<use name="Geometry/CommonDetUnit" source_only="1"/>
 <use name="Geometry/TrackerGeometryBuilder"/>
 <use name="RecoLocalTracker/Phase2TrackerRecHits"/>
 <use name="RecoLocalTracker/ClusterParameterEstimator"/>

--- a/RecoLocalTracker/SiStripRecHitConverter/BuildFile.xml
+++ b/RecoLocalTracker/SiStripRecHitConverter/BuildFile.xml
@@ -7,7 +7,7 @@
 <use name="DataFormats/SiStripDetId"/>
 <use name="RecoLocalTracker/Records"/>
 <use name="RecoLocalTracker/ClusterParameterEstimator"/>
-<use name="Geometry/CommonDetUnit"/>
+<use name="Geometry/CommonDetUnit" source_only="1"/>
 <use name="Geometry/TrackerGeometryBuilder"/>
 <use name="CondFormats/SiStripObjects"/>
 <use name="CalibFormats/SiStripObjects"/>

--- a/RecoLocalTracker/SubCollectionProducers/BuildFile.xml
+++ b/RecoLocalTracker/SubCollectionProducers/BuildFile.xml
@@ -10,7 +10,7 @@
 <use name="CommonTools/UtilAlgos"/>
 <use name="Geometry/Records"/>
 <use name="Geometry/TrackerGeometryBuilder"/>
-<use name="Geometry/CommonDetUnit"/>
+<use name="Geometry/CommonDetUnit" source_only="1"/>
 <use name="TrackingTools/TrajectoryState"/>
 <use name="DataFormats/SiPixelCluster"/>
 <use name="RecoLocalTracker/SiStripClusterizer"/>

--- a/RecoMTD/TransientTrackingRecHit/BuildFile.xml
+++ b/RecoMTD/TransientTrackingRecHit/BuildFile.xml
@@ -3,7 +3,7 @@
 <use name="FWCore/Framework"/>
 <use name="FWCore/MessageLogger"/>
 <use name="FWCore/Utilities"/>
-<use name="Geometry/CommonDetUnit"/>
+<use name="Geometry/CommonDetUnit" source_only="1"/>
 <use name="TrackingTools/TransientTrackingRecHit"/>
 <export>
   <lib name="1"/>

--- a/RecoMTD/TransientTrackingRecHit/plugins/BuildFile.xml
+++ b/RecoMTD/TransientTrackingRecHit/plugins/BuildFile.xml
@@ -1,7 +1,7 @@
 <library name="RecoMTDTransientTrackingRecHitPlugins" file="*.cc">
   <use name="FWCore/Framework"/>
   <use name="FWCore/ParameterSet"/>
-  <use name="Geometry/CommonDetUnit"/>
+  <use name="Geometry/CommonDetUnit" source_only="1"/>
   <use name="Geometry/Records"/>
   <use name="RecoMTD/TransientTrackingRecHit"/>
   <use name="TrackingTools/Records"/>

--- a/RecoMuon/CosmicMuonProducer/BuildFile.xml
+++ b/RecoMuon/CosmicMuonProducer/BuildFile.xml
@@ -12,7 +12,7 @@
 <use name="FWCore/Framework"/>
 <use name="FWCore/MessageLogger"/>
 <use name="FWCore/ParameterSet"/>
-<use name="Geometry/CommonDetUnit"/>
+<use name="Geometry/CommonDetUnit" source_only="1"/>
 <use name="RecoMuon/MeasurementDet"/>
 <use name="RecoMuon/Navigation"/>
 <use name="RecoMuon/TrackingTools"/>

--- a/RecoMuon/GlobalTrackingTools/BuildFile.xml
+++ b/RecoMuon/GlobalTrackingTools/BuildFile.xml
@@ -14,7 +14,7 @@
 <use name="FWCore/MessageLogger"/>
 <use name="FWCore/ParameterSet"/>
 <use name="FWCore/ServiceRegistry"/>
-<use name="Geometry/CommonDetUnit"/>
+<use name="Geometry/CommonDetUnit" source_only="1"/>
 <use name="Geometry/CSCGeometry"/>
 <use name="Geometry/DTGeometry"/>
 <use name="RecoMuon/Navigation"/>

--- a/RecoMuon/L2MuonSeedGenerator/BuildFile.xml
+++ b/RecoMuon/L2MuonSeedGenerator/BuildFile.xml
@@ -9,7 +9,7 @@
 <use name="FWCore/MessageLogger"/>
 <use name="FWCore/ParameterSet"/>
 <use name="FWCore/PluginManager"/>
-<use name="Geometry/CommonDetUnit"/>
+<use name="Geometry/CommonDetUnit" source_only="1"/>
 <use name="RecoMuon/TrackingTools"/>
 <use name="TrackingTools/DetLayers"/>
 <use name="TrackingTools/KalmanUpdators"/>

--- a/RecoMuon/L2MuonSeedGenerator/plugins/BuildFile.xml
+++ b/RecoMuon/L2MuonSeedGenerator/plugins/BuildFile.xml
@@ -8,7 +8,7 @@
     <use name="FWCore/Framework"/>
     <use name="FWCore/MessageLogger"/>
     <use name="FWCore/ParameterSet"/>
-    <use name="Geometry/CommonDetUnit"/>
+    <use name="Geometry/CommonDetUnit" source_only="1"/>
     <use name="RecoMuon/TrackingTools"/>
     <use name="TrackingTools/DetLayers"/>
     <use name="TrackingTools/KalmanUpdators"/>

--- a/RecoMuon/MuonIdentification/BuildFile.xml
+++ b/RecoMuon/MuonIdentification/BuildFile.xml
@@ -21,7 +21,7 @@
 <use name="FWCore/MessageLogger"/>
 <use name="FWCore/ParameterSet"/>
 <use name="FWCore/Utilities"/>
-<use name="Geometry/CommonDetUnit"/>
+<use name="Geometry/CommonDetUnit" source_only="1"/>
 <use name="Geometry/CSCGeometry"/>
 <use name="Geometry/Records"/>
 <use name="roothistmatrix"/>

--- a/RecoMuon/MuonIdentification/plugins/BuildFile.xml
+++ b/RecoMuon/MuonIdentification/plugins/BuildFile.xml
@@ -8,7 +8,7 @@
   <use name="FWCore/MessageLogger"/>
   <use name="FWCore/ParameterSet"/>
   <use name="FWCore/PluginManager"/>
-  <use name="Geometry/CommonDetUnit"/>
+  <use name="Geometry/CommonDetUnit" source_only="1"/>
   <use name="Geometry/Records"/>
   <use name="Geometry/CaloTopology"/>
   <use name="PhysicsTools/IsolationAlgos"/>
@@ -34,7 +34,7 @@
   <use name="FWCore/MessageLogger"/>
   <use name="FWCore/ParameterSet"/>
   <use name="FWCore/PluginManager"/>
-  <use name="Geometry/CommonDetUnit"/>
+  <use name="Geometry/CommonDetUnit" source_only="1"/>
   <use name="Geometry/Records"/>
   <use name="Geometry/CaloTopology"/>
   <use name="PhysicsTools/IsolationAlgos"/>

--- a/RecoMuon/MuonSeedGenerator/BuildFile.xml
+++ b/RecoMuon/MuonSeedGenerator/BuildFile.xml
@@ -10,7 +10,7 @@
 <use name="FWCore/MessageLogger"/>
 <use name="FWCore/ParameterSet"/>
 <use name="Geometry/CSCGeometry"/>
-<use name="Geometry/CommonDetUnit"/>
+<use name="Geometry/CommonDetUnit" source_only="1"/>
 <use name="Geometry/RPCGeometry"/>
 <use name="Geometry/Records"/>
 <use name="MagneticField/Engine"/>

--- a/RecoMuon/StandAloneTrackFinder/BuildFile.xml
+++ b/RecoMuon/StandAloneTrackFinder/BuildFile.xml
@@ -4,7 +4,7 @@
 <use name="FWCore/MessageLogger"/>
 <use name="FWCore/ParameterSet"/>
 <use name="FWCore/Utilities"/>
-<use name="Geometry/CommonDetUnit"/>
+<use name="Geometry/CommonDetUnit" source_only="1"/>
 <use name="RecoMuon/MeasurementDet"/>
 <use name="RecoMuon/Navigation"/>
 <use name="RecoMuon/TrackingTools"/>

--- a/RecoMuon/TrackerSeedGenerator/plugins/BuildFile.xml
+++ b/RecoMuon/TrackerSeedGenerator/plugins/BuildFile.xml
@@ -8,7 +8,7 @@
   <use name="FWCore/MessageLogger"/>
   <use name="FWCore/ParameterSet"/>
   <use name="FWCore/PluginManager"/>
-  <use name="Geometry/CommonDetUnit"/>
+  <use name="Geometry/CommonDetUnit" source_only="1"/>
   <use name="Geometry/Records"/>
   <use name="MagneticField/Engine"/>
   <use name="MagneticField/Records"/>

--- a/RecoMuon/TrackingTools/BuildFile.xml
+++ b/RecoMuon/TrackingTools/BuildFile.xml
@@ -10,7 +10,7 @@
 <use name="FWCore/MessageLogger"/>
 <use name="FWCore/ParameterSet"/>
 <use name="FWCore/Utilities"/>
-<use name="Geometry/CommonDetUnit"/>
+<use name="Geometry/CommonDetUnit" source_only="1"/>
 <use name="Geometry/Records"/>
 <use name="MagneticField/Engine"/>
 <use name="MagneticField/Records"/>

--- a/RecoMuon/TransientTrackingRecHit/BuildFile.xml
+++ b/RecoMuon/TransientTrackingRecHit/BuildFile.xml
@@ -3,7 +3,7 @@
 <use name="FWCore/Framework"/>
 <use name="FWCore/MessageLogger"/>
 <use name="FWCore/Utilities"/>
-<use name="Geometry/CommonDetUnit"/>
+<use name="Geometry/CommonDetUnit" source_only="1"/>
 <use name="TrackingTools/TransientTrackingRecHit"/>
 <export>
   <lib name="1"/>

--- a/RecoMuon/TransientTrackingRecHit/plugins/BuildFile.xml
+++ b/RecoMuon/TransientTrackingRecHit/plugins/BuildFile.xml
@@ -1,7 +1,7 @@
 <library name="RecoMuonTransientTrackingRecHitPlugins" file="*.cc">
   <use name="FWCore/Framework"/>
   <use name="FWCore/ParameterSet"/>
-  <use name="Geometry/CommonDetUnit"/>
+  <use name="Geometry/CommonDetUnit" source_only="1"/>
   <use name="Geometry/Records"/>
   <use name="RecoMuon/TransientTrackingRecHit"/>
   <use name="TrackingTools/Records"/>

--- a/RecoPPS/Local/BuildFile.xml
+++ b/RecoPPS/Local/BuildFile.xml
@@ -4,7 +4,7 @@
 <use name="DataFormats/CTPPSDigi"/>
 <use name="DataFormats/CTPPSReco"/>
 <use name="Geometry/VeryForwardGeometryBuilder"/>
-<use name="Geometry/VeryForwardGeometry"/>
+<use name="Geometry/VeryForwardGeometry" source_only="1"/>
 <use name="Geometry/VeryForwardRPTopology"/>
 <use name="CondFormats/PPSObjects"/>
 <use name="DataFormats/CTPPSDetId"/>

--- a/RecoParticleFlow/PFSimProducer/plugins/BuildFile.xml
+++ b/RecoParticleFlow/PFSimProducer/plugins/BuildFile.xml
@@ -12,7 +12,7 @@
   <use name="FWCore/ParameterSet"/>
   <use name="FWCore/Utilities"/>
   <use name="FastSimulation/Event"/>
-  <use name="Geometry/CommonDetUnit"/>
+  <use name="Geometry/CommonDetUnit" source_only="1"/>
   <use name="Geometry/Records"/>
   <use name="Geometry/TrackerGeometryBuilder"/>
   <use name="MagneticField/Engine"/>

--- a/RecoParticleFlow/PFTracking/BuildFile.xml
+++ b/RecoParticleFlow/PFTracking/BuildFile.xml
@@ -8,7 +8,7 @@
 <use name="DataFormats/SiPixelDetId"/>
 <use name="DataFormats/SiStripDetId"/>
 <use name="DataFormats/BeamSpot"/>
-<use name="Geometry/CommonDetUnit"/>
+<use name="Geometry/CommonDetUnit" source_only="1"/>
 <use name="Geometry/TrackerGeometryBuilder"/>
 <use name="Geometry/Records"/>
 <use name="FWCore/Framework"/>

--- a/RecoPixelVertexing/PixelLowPtUtilities/test/BuildFile.xml
+++ b/RecoPixelVertexing/PixelLowPtUtilities/test/BuildFile.xml
@@ -1,7 +1,7 @@
 <library file="ClusterShapeExtractor.cc" name="ClusterShapeExtractor">
   <use name="root"/>
   <use name="FWCore/Framework"/>
-  <use name="Geometry/CommonDetUnit"/>
+  <use name="Geometry/CommonDetUnit" source_only="1"/>
   <use name="Geometry/Records"/>
   <use name="Geometry/TrackerGeometryBuilder"/>
   <use name="DataFormats/TrackerRecHit2D"/>

--- a/RecoPixelVertexing/PixelTrackFitting/BuildFile.xml
+++ b/RecoPixelVertexing/PixelTrackFitting/BuildFile.xml
@@ -13,7 +13,7 @@
 <use name="FWCore/MessageLogger"/>
 <use name="FWCore/ParameterSet"/>
 <use name="FWCore/Utilities"/>
-<use name="Geometry/CommonDetUnit"/>
+<use name="Geometry/CommonDetUnit" source_only="1"/>
 <use name="Geometry/Records"/>
 <use name="Geometry/TrackerGeometryBuilder"/>
 <use name="MagneticField/Engine"/>

--- a/RecoTracker/ConversionSeedGenerators/plugins/BuildFile.xml
+++ b/RecoTracker/ConversionSeedGenerators/plugins/BuildFile.xml
@@ -3,7 +3,7 @@
 <use name="DataFormats/Common"/>
 <use name="FWCore/ParameterSet"/>
 <use name="Geometry/Records"/>
-<use name="Geometry/CommonDetUnit"/>
+<use name="Geometry/CommonDetUnit" source_only="1"/>
 <use name="DataFormats/TrajectorySeed"/>
 <use name="Geometry/TrackerGeometryBuilder"/>
 <use name="DataFormats/SiStripDetId"/>

--- a/RecoTracker/FinalTrackSelectors/plugins/BuildFile.xml
+++ b/RecoTracker/FinalTrackSelectors/plugins/BuildFile.xml
@@ -16,7 +16,7 @@
 <use name="FWCore/MessageLogger"/>
 <use name="FWCore/ParameterSet"/>
 <use name="FWCore/PluginManager"/>
-<use name="Geometry/CommonDetUnit"/>
+<use name="Geometry/CommonDetUnit" source_only="1"/>
 <use name="Geometry/Records"/>
 <use name="Geometry/TrackerGeometryBuilder"/>
 <use name="TrackingTools/Records"/>

--- a/RecoTracker/SpecialSeedGenerators/BuildFile.xml
+++ b/RecoTracker/SpecialSeedGenerators/BuildFile.xml
@@ -10,7 +10,7 @@
 <use name="FWCore/Framework"/>
 <use name="FWCore/MessageLogger"/>
 <use name="FWCore/ParameterSet"/>
-<use name="Geometry/CommonDetUnit"/>
+<use name="Geometry/CommonDetUnit" source_only="1"/>
 <use name="Geometry/TrackerGeometryBuilder"/>
 <use name="MagneticField/Engine"/>
 <use name="RecoPixelVertexing/PixelTriplets"/>

--- a/RecoTracker/TkDetLayers/test/BuildFile.xml
+++ b/RecoTracker/TkDetLayers/test/BuildFile.xml
@@ -1,5 +1,5 @@
 <use name="Geometry/TrackerNumberingBuilder"/>
-<use name="Geometry/CommonDetUnit"/>
+<use name="Geometry/CommonDetUnit" source_only="1"/>
 <use name="Geometry/TrackerGeometryBuilder"/>
 <use name="FWCore/Framework"/>
 <use name="RecoTracker/TkDetLayers"/>

--- a/RecoTracker/TkNavigation/test/BuildFile.xml
+++ b/RecoTracker/TkNavigation/test/BuildFile.xml
@@ -5,7 +5,7 @@
 <use name="Geometry/Records"/>
 <use name="FWCore/MessageLogger"/>
 <use name="RecoTracker/Record"/>
-<use name="RecoTracker/TkNavigation"/>
+<use name="RecoTracker/TkNavigation" source_only="1"/>
 <use name="TrackingTools/DetLayers"/>
 <library file="*.cc" name="RecoTrackerTkNavigationTest">
   <flags EDM_PLUGIN="1"/>

--- a/RecoTracker/TkSeedGenerator/BuildFile.xml
+++ b/RecoTracker/TkSeedGenerator/BuildFile.xml
@@ -5,7 +5,7 @@
 <use name="DataFormats/Common"/>
 <use name="FWCore/ParameterSet"/>
 <use name="Geometry/Records"/>
-<use name="Geometry/CommonDetUnit"/>
+<use name="Geometry/CommonDetUnit" source_only="1"/>
 <use name="DataFormats/TrajectorySeed"/>
 <use name="DataFormats/TrackerRecHit2D"/>
 <use name="Geometry/TrackerGeometryBuilder"/>

--- a/RecoTracker/TkSeedGenerator/plugins/BuildFile.xml
+++ b/RecoTracker/TkSeedGenerator/plugins/BuildFile.xml
@@ -19,12 +19,12 @@
 <use name="FWCore/ParameterSet"/>
 <use name="FWCore/PluginManager"/>
 <use name="FWCore/Utilities"/>
-<use name="Geometry/CommonDetUnit"/>
+<use name="Geometry/CommonDetUnit" source_only="1"/>
 <use name="Geometry/Records"/>
 <use name="Geometry/TrackerGeometryBuilder"/>
 <use name="MagneticField/Engine"/>
 <use name="MagneticField/Records"/>
-<use name="MagneticField/UniformEngine"/>
+<use name="MagneticField/UniformEngine" source_only="1"/>
 <use name="PhysicsTools/TensorFlow"/>
 <use name="RecoPixelVertexing/PixelLowPtUtilities"/>
 <use name="RecoPixelVertexing/PixelTrackFitting"/>

--- a/RecoTracker/TkSeedingLayers/BuildFile.xml
+++ b/RecoTracker/TkSeedingLayers/BuildFile.xml
@@ -5,7 +5,7 @@
 <use name="FWCore/Framework"/>
 <use name="FWCore/ParameterSet"/>
 <use name="FWCore/PluginManager"/>
-<use name="Geometry/CommonDetUnit"/>
+<use name="Geometry/CommonDetUnit" source_only="1"/>
 <use name="Geometry/Records"/>
 <use name="RecoTracker/Record"/>
 <use name="RecoTracker/TkDetLayers"/>

--- a/RecoTracker/TrackProducer/BuildFile.xml
+++ b/RecoTracker/TrackProducer/BuildFile.xml
@@ -8,7 +8,7 @@
 <use name="FWCore/Framework"/>
 <use name="FWCore/MessageLogger"/>
 <use name="FWCore/ParameterSet"/>
-<use name="Geometry/CommonDetUnit"/>
+<use name="Geometry/CommonDetUnit" source_only="1"/>
 <use name="Geometry/Records"/>
 <use name="Geometry/TrackerGeometryBuilder"/>
 <use name="MagneticField/Engine"/>

--- a/RecoVertex/V0Producer/BuildFile.xml
+++ b/RecoVertex/V0Producer/BuildFile.xml
@@ -6,7 +6,7 @@
 <use name="DataFormats/RecoCandidate"/>
 <use name="DataFormats/TrackReco"/>
 <use name="DataFormats/VertexReco"/>
-<use name="Geometry/CommonDetUnit"/>
+<use name="Geometry/CommonDetUnit" source_only="1"/>
 <use name="FWCore/Framework"/>
 <use name="FWCore/ParameterSet"/>
 <use name="FWCore/MessageLogger"/>

--- a/RecoVertex/V0Producer/test/BuildFile.xml
+++ b/RecoVertex/V0Producer/test/BuildFile.xml
@@ -9,7 +9,7 @@
 <use name="SimDataFormats/Vertex"/>
 <use name="root"/>
 <use name="TrackingTools/TrajectoryState"/>
-<use name="Geometry/CommonDetUnit"/>
+<use name="Geometry/CommonDetUnit" source_only="1"/>
 <use name="Geometry/Records"/>
 <use name="Geometry/TrackerGeometryBuilder"/>
 <use name="TrackingTools/TransientTrack"/>

--- a/TrackingTools/GsfTools/BuildFile.xml
+++ b/TrackingTools/GsfTools/BuildFile.xml
@@ -5,7 +5,7 @@
 </export>
 <use name="FWCore/MessageLogger"/>
 <use name="FWCore/Utilities"/>
-<use name="Geometry/CommonDetUnit"/>
+<use name="Geometry/CommonDetUnit" source_only="1"/>
 <use name="DataFormats/GeometrySurface"/>
 <use name="TrackingTools/GeomPropagators"/>
 <use name="TrackingTools/TrajectoryParametrization"/>

--- a/TrackingTools/KalmanUpdators/BuildFile.xml
+++ b/TrackingTools/KalmanUpdators/BuildFile.xml
@@ -6,7 +6,7 @@
 <use name="TrackingTools/TrajectoryState"/>
 <use name="TrackingTools/DetLayers"/>
 <use name="TrackingTools/GeomPropagators"/>
-<use name="Geometry/CommonDetUnit"/>
+<use name="Geometry/CommonDetUnit" source_only="1"/>
 <use name="Geometry/CommonTopologies"/>
 <export>
   <lib name="1"/>

--- a/TrackingTools/PatternTools/BuildFile.xml
+++ b/TrackingTools/PatternTools/BuildFile.xml
@@ -7,7 +7,7 @@
 <use name="DataFormats/TrackerRecHit2D"/>
 <use name="FWCore/MessageLogger"/>
 <use name="FWCore/Utilities"/>
-<use name="Geometry/CommonDetUnit"/>
+<use name="Geometry/CommonDetUnit" source_only="1"/>
 <use name="TrackingTools/AnalyticalJacobians"/>
 <use name="TrackingTools/GeomPropagators"/>
 <use name="TrackingTools/TrajectoryParametrization"/>

--- a/TrackingTools/TrackAssociator/BuildFile.xml
+++ b/TrackingTools/TrackAssociator/BuildFile.xml
@@ -20,7 +20,7 @@
 <use name="FWCore/ParameterSet"/>
 <use name="FWCore/Utilities"/>
 <use name="Geometry/CaloGeometry"/>
-<use name="Geometry/CommonDetUnit"/>
+<use name="Geometry/CommonDetUnit" source_only="1"/>
 <use name="Geometry/CSCGeometry"/>
 <use name="Geometry/DTGeometry"/>
 <use name="Geometry/GEMGeometry"/>

--- a/TrackingTools/TrackAssociator/test/BuildFile.xml
+++ b/TrackingTools/TrackAssociator/test/BuildFile.xml
@@ -7,7 +7,7 @@
 <use name="FWCore/Framework"/>
 <use name="FWCore/ParameterSet"/>
 <use name="Geometry/CaloGeometry"/>
-<use name="Geometry/CommonDetUnit"/>
+<use name="Geometry/CommonDetUnit" source_only="1"/>
 <use name="Geometry/Records"/>
 <use name="MagneticField/Engine"/>
 <use name="MagneticField/Records"/>

--- a/TrackingTools/TransientTrack/BuildFile.xml
+++ b/TrackingTools/TransientTrack/BuildFile.xml
@@ -3,7 +3,7 @@
 <use name="DataFormats/GsfTrackReco"/>
 <use name="DataFormats/TrackReco"/>
 <use name="FWCore/Framework"/>
-<use name="Geometry/CommonDetUnit"/>
+<use name="Geometry/CommonDetUnit" source_only="1"/>
 <use name="Geometry/Records"/>
 <use name="TrackingTools/GeomPropagators"/>
 <use name="TrackingTools/GsfTools"/>

--- a/TrackingTools/TransientTrack/plugins/BuildFile.xml
+++ b/TrackingTools/TransientTrack/plugins/BuildFile.xml
@@ -1,5 +1,5 @@
 <library file="*.cc" name="TrackingToolsTransientTrackPlugins">
-  <use name="Geometry/CommonDetUnit"/>
+  <use name="Geometry/CommonDetUnit" source_only="1"/>
   <use name="Geometry/Records"/>
   <use name="TrackingTools/Records"/>
   <use name="TrackingTools/TransientTrack"/>

--- a/TrackingTools/TransientTrackingRecHit/BuildFile.xml
+++ b/TrackingTools/TransientTrackingRecHit/BuildFile.xml
@@ -2,7 +2,7 @@
 <use name="clhep"/>
 <use name="FWCore/Utilities"/>
 <use name="FWCore/MessageLogger"/>
-<use name="Geometry/CommonDetUnit"/>
+<use name="Geometry/CommonDetUnit" source_only="1"/>
 <use name="DataFormats/Common"/>
 <use name="DataFormats/TrackingRecHit"/>
 <use name="DataFormats/TrackerRecHit2D"/>


### PR DESCRIPTION
#### PR description:

Add `source_only` flag for source-only dependencies in `reco`. These dependencies were automatically found with [this script](https://github.com/guitargeek/PKGBUILDs/blob/master/cmssw/update_source_only.py).

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

No backport intended.