### PR TITLE
speedup of trackValidatorJetCore and TrackAssociatorByChi2

### DIFF
--- a/SimTracker/TrackAssociation/interface/trackAssociationChi2.h
+++ b/SimTracker/TrackAssociation/interface/trackAssociationChi2.h
@@ -11,6 +11,10 @@ namespace track_associator {
   /// basic method where chi2 is computed
   double trackAssociationChi2(const reco::TrackBase::ParameterVector &rParameters,
                               const reco::TrackBase::CovarianceMatrix &recoTrackCovMatrix,
+                              const reco::TrackBase::ParameterVector &sParameters);
+
+  double trackAssociationChi2(const reco::TrackBase::ParameterVector &rParameters,
+                              const reco::TrackBase::CovarianceMatrix &recoTrackCovMatrix,
                               const Basic3DVector<double> &momAtVtx,
                               const Basic3DVector<double> &vert,
                               int charge,

--- a/SimTracker/TrackAssociation/src/trackAssociationChi2.cc
+++ b/SimTracker/TrackAssociation/src/trackAssociationChi2.cc
@@ -8,6 +8,33 @@ namespace track_associator {
 
   double trackAssociationChi2(const reco::TrackBase::ParameterVector &rParameters,
                               const reco::TrackBase::CovarianceMatrix &recoTrackCovMatrix,
+                              const reco::TrackBase::ParameterVector &sParameters) {
+    double chi2 = invalidChi2;
+
+    reco::TrackBase::ParameterVector diffParameters = rParameters - sParameters;
+    diffParameters[2] = reco::deltaPhi(diffParameters[2], 0.f);
+    chi2 = ROOT::Math::Dot(diffParameters * recoTrackCovMatrix, diffParameters);
+    chi2 /= 5;
+
+    LogDebug("TrackAssociator") << "====NEW RECO TRACK WITH PT=" << sin(rParameters[1]) / rParameters[0] << "====\n"
+                                << "qoverp sim: " << sParameters[0] << "\n"
+                                << "lambda sim: " << sParameters[1] << "\n"
+                                << "phi    sim: " << sParameters[2] << "\n"
+                                << "dxy    sim: " << sParameters[3] << "\n"
+                                << "dsz    sim: " << sParameters[4] << "\n"
+                                << ": " /*<< */ << "\n"
+                                << "qoverp rec: " << rParameters[0] << "\n"
+                                << "lambda rec: " << rParameters[1] << "\n"
+                                << "phi    rec: " << rParameters[2] << "\n"
+                                << "dxy    rec: " << rParameters[3] << "\n"
+                                << "dsz    rec: " << rParameters[4] << "\n"
+                                << ": " /*<< */ << "\n"
+                                << "chi2: " << chi2 << "\n";
+    return chi2;
+  }
+
+  double trackAssociationChi2(const reco::TrackBase::ParameterVector &rParameters,
+                              const reco::TrackBase::CovarianceMatrix &recoTrackCovMatrix,
                               const Basic3DVector<double> &momAtVtx,
                               const Basic3DVector<double> &vert,
                               int charge,
@@ -18,28 +45,7 @@ namespace track_associator {
     std::pair<bool, reco::TrackBase::ParameterVector> params =
         reco::trackingParametersAtClosestApproachToBeamSpot(vert, momAtVtx, charge, magfield, bs);
     if (params.first) {
-      reco::TrackBase::ParameterVector sParameters = params.second;
-
-      reco::TrackBase::ParameterVector diffParameters = rParameters - sParameters;
-      diffParameters[2] = reco::deltaPhi(diffParameters[2], 0.f);
-      chi2 = ROOT::Math::Dot(diffParameters * recoTrackCovMatrix, diffParameters);
-      chi2 /= 5;
-
-      LogDebug("TrackAssociator") << "====NEW RECO TRACK WITH PT="
-                                  << sin(rParameters[1]) * float(charge) / rParameters[0] << "====\n"
-                                  << "qoverp sim: " << sParameters[0] << "\n"
-                                  << "lambda sim: " << sParameters[1] << "\n"
-                                  << "phi    sim: " << sParameters[2] << "\n"
-                                  << "dxy    sim: " << sParameters[3] << "\n"
-                                  << "dsz    sim: " << sParameters[4] << "\n"
-                                  << ": " /*<< */ << "\n"
-                                  << "qoverp rec: " << rParameters[0] << "\n"
-                                  << "lambda rec: " << rParameters[1] << "\n"
-                                  << "phi    rec: " << rParameters[2] << "\n"
-                                  << "dxy    rec: " << rParameters[3] << "\n"
-                                  << "dsz    rec: " << rParameters[4] << "\n"
-                                  << ": " /*<< */ << "\n"
-                                  << "chi2: " << chi2 << "\n";
+      return trackAssociationChi2(rParameters, recoTrackCovMatrix, params.second);
     }
     return chi2;
   }

--- a/SimTracker/TrackAssociatorProducers/plugins/BuildFile.xml
+++ b/SimTracker/TrackAssociatorProducers/plugins/BuildFile.xml
@@ -8,6 +8,7 @@
 <use name="DataFormats/TrackerRecHit2D"/>
 <use name="DataFormats/TrackerCommon"/>
 <use name="DataFormats/HepMCCandidate"/>
+<use name="TrackingTools/PatternTools"/>
 <use name="TrackingTools/Records"/>
 <use name="TrackingTools/GeomPropagators"/>
 <use name="TrackingTools/TrajectoryState"/>

--- a/SimTracker/TrackAssociatorProducers/plugins/TrackAssociatorByChi2Impl.cc
+++ b/SimTracker/TrackAssociatorProducers/plugins/TrackAssociatorByChi2Impl.cc
@@ -4,35 +4,40 @@
 #include "DataFormats/Math/interface/deltaPhi.h"
 #include "DataFormats/GeometrySurface/interface/Line.h"
 #include "SimTracker/TrackAssociation/interface/trackAssociationChi2.h"
+#include "TrackingTools/PatternTools/interface/trackingParametersAtClosestApproachToBeamSpot.h"
 
 using namespace edm;
 using namespace reco;
 using namespace std;
-
-double TrackAssociatorByChi2Impl::getChi2(const TrackBase::ParameterVector& rParameters,
-                                          const TrackBase::CovarianceMatrix& recoTrackCovMatrix,
-                                          const Basic3DVector<double>& momAtVtx,
-                                          const Basic3DVector<double>& vert,
-                                          int charge,
-                                          const reco::BeamSpot& bs) const {
-  return track_associator::trackAssociationChi2(rParameters, recoTrackCovMatrix, momAtVtx, vert, charge, *mF_, bs);
-}
+using namespace track_associator;
 
 RecoToSimCollection TrackAssociatorByChi2Impl::associateRecoToSim(
-    const edm::RefToBaseVector<reco::Track>& tC, const edm::RefVector<TrackingParticleCollection>& tPCH) const {
-  const reco::BeamSpot& bs = *beamSpot_;
+    const RefToBaseVector<Track>& tC, const RefVector<TrackingParticleCollection>& tPCH) const {
+  const BeamSpot& bs = *beamSpot_;
 
   RecoToSimCollection outputCollection(productGetter_);
 
-  //dereference the edm::Refs only once
+  //dereference the Refs only once and precompute params
   std::vector<TrackingParticle const*> tPC;
+  std::vector<std::pair<bool, TrackBase::ParameterVector>> tpParams;
   tPC.reserve(tPCH.size());
+  tpParams.reserve(tPCH.size());
   for (auto const& ref : tPCH) {
-    tPC.push_back(&(*ref));
+    auto const& tp = *ref;
+    tPC.push_back(&tp);
+
+    int charge = tp.charge();
+    if (charge == 0)
+      tpParams.emplace_back(false, TrackBase::ParameterVector());
+    else {
+      using BVec = Basic3DVector<double>;
+      tpParams.emplace_back(
+          trackingParametersAtClosestApproachToBeamSpot(BVec(tp.vertex()), BVec(tp.momentum()), charge, *mF_, bs));
+    }
   }
 
   int tindex = 0;
-  for (RefToBaseVector<reco::Track>::const_iterator rt = tC.begin(); rt != tC.end(); rt++, tindex++) {
+  for (RefToBaseVector<Track>::const_iterator rt = tC.begin(); rt != tC.end(); rt++, tindex++) {
     LogDebug("TrackAssociator") << "=========LOOKING FOR ASSOCIATION==========="
                                 << "\n"
                                 << "rec::Track #" << tindex << " with pt=" << (*rt)->pt() << "\n"
@@ -57,13 +62,10 @@ RecoToSimCollection TrackAssociatorByChi2Impl::associateRecoToSim(
     for (auto tp = tPC.begin(); tp != tPC.end(); tp++, ++tpindex) {
       //skip tps with a very small pt
       //if (sqrt((*tp)->momentum().perp2())<0.5) continue;
-      int charge = (*tp)->charge();
-      if (charge == 0)
+      if (!tpParams[tpindex].first)
         continue;
-      Basic3DVector<double> momAtVtx((*tp)->momentum());
-      Basic3DVector<double> vert((*tp)->vertex());
 
-      double chi2 = getChi2(rParameters, recoTrackCovMatrix, momAtVtx, vert, charge, bs);
+      double chi2 = trackAssociationChi2(rParameters, recoTrackCovMatrix, tpParams[tpindex].second);
 
       if (chi2 < chi2cut_) {
         //-chi2 because the Association Map is ordered using std::greater
@@ -76,8 +78,8 @@ RecoToSimCollection TrackAssociatorByChi2Impl::associateRecoToSim(
 }
 
 SimToRecoCollection TrackAssociatorByChi2Impl::associateSimToReco(
-    const edm::RefToBaseVector<reco::Track>& tC, const edm::RefVector<TrackingParticleCollection>& tPCH) const {
-  const reco::BeamSpot& bs = *beamSpot_;
+    const RefToBaseVector<Track>& tC, const RefVector<TrackingParticleCollection>& tPCH) const {
+  const BeamSpot& bs = *beamSpot_;
 
   SimToRecoCollection outputCollection(productGetter_);
 
@@ -119,14 +121,17 @@ SimToRecoCollection TrackAssociatorByChi2Impl::associateSimToReco(
                                 << "==========================================="
                                 << "\n";
 
-    Basic3DVector<double> momAtVtx(aTP.momentum());
-    Basic3DVector<double> vert(aTP.vertex());
+    using BVec = Basic3DVector<double>;
+    auto const tpBoolParams =
+        trackingParametersAtClosestApproachToBeamSpot(BVec(aTP.vertex()), BVec(aTP.momentum()), charge, *mF_, bs);
+    if (!tpBoolParams.first)
+      continue;
 
     for (unsigned int tindex = 0; tindex < tC.size(); tindex++) {
       TrackBase::ParameterVector const& rParameters = tPars[tindex];
       TrackBase::CovarianceMatrix const& recoTrackCovMatrix = tCovs[tindex];
 
-      double chi2 = getChi2(rParameters, recoTrackCovMatrix, momAtVtx, vert, charge, bs);
+      double chi2 = trackAssociationChi2(rParameters, recoTrackCovMatrix, tpBoolParams.second);
 
       if (chi2 < chi2cut_) {
         //-chi2 because the Association Map is ordered using std::greater

--- a/SimTracker/TrackAssociatorProducers/plugins/TrackAssociatorByChi2Impl.h
+++ b/SimTracker/TrackAssociatorProducers/plugins/TrackAssociatorByChi2Impl.h
@@ -61,7 +61,7 @@ public:
                             const reco::BeamSpot& bs,
                             double chi2Cut,
                             bool onlyDiag)
-    : productGetter_(&productGetter), mF_(&mF), beamSpot_(&bs), chi2cut_(chi2Cut), onlyDiagonal_(onlyDiag) {}
+      : productGetter_(&productGetter), mF_(&mF), beamSpot_(&bs), chi2cut_(chi2Cut), onlyDiagonal_(onlyDiag) {}
 
   /// Association Reco To Sim with Collections
 
@@ -87,14 +87,6 @@ public:
   }
 
 private:
-  /// basic method where chi2 is computed
-  double getChi2(const reco::TrackBase::ParameterVector& rParameters,
-                 const reco::TrackBase::CovarianceMatrix& recoTrackCovMatrix,
-                 const Basic3DVector<double>& momAtVtx,
-                 const Basic3DVector<double>& vert,
-                 int charge,
-                 const reco::BeamSpot&) const;
-
   edm::EDProductGetter const* productGetter_;
   const MagneticField* mF_;
   const reco::BeamSpot* beamSpot_;

--- a/SimTracker/TrackAssociatorProducers/plugins/TrackAssociatorByChi2Impl.h
+++ b/SimTracker/TrackAssociatorProducers/plugins/TrackAssociatorByChi2Impl.h
@@ -47,7 +47,7 @@ public:
     chi2cut(conf.getParameter<double>("chi2cut")),
     onlyDiagonal(conf.getParameter<bool>("onlyDiagonal")),
     bsSrc(conf.getParameter<edm::InputTag>("beamSpot")) {
-    theMF=mF;  
+    mF_=mF;  
     if (onlyDiagonal)
       edm::LogInfo("TrackAssociator") << " ---- Using Off Diagonal Covariance Terms = 0 ---- " <<  "\n";
     else 
@@ -61,7 +61,7 @@ public:
                             const reco::BeamSpot& bs,
                             double chi2Cut,
                             bool onlyDiag)
-      : productGetter_(&productGetter), theMF(&mF), theBeamSpot(&bs), chi2cut(chi2Cut), onlyDiagonal(onlyDiag) {}
+    : productGetter_(&productGetter), mF_(&mF), beamSpot_(&bs), chi2cut_(chi2Cut), onlyDiagonal_(onlyDiag) {}
 
   /// Association Reco To Sim with Collections
 
@@ -96,10 +96,10 @@ private:
                  const reco::BeamSpot&) const;
 
   edm::EDProductGetter const* productGetter_;
-  const MagneticField* theMF;
-  const reco::BeamSpot* theBeamSpot;
-  double chi2cut;
-  bool onlyDiagonal;
+  const MagneticField* mF_;
+  const reco::BeamSpot* beamSpot_;
+  double chi2cut_;
+  bool onlyDiagonal_;
 };
 
 #endif

--- a/Validation/RecoTrack/python/TrackValidation_cff.py
+++ b/Validation/RecoTrack/python/TrackValidation_cff.py
@@ -299,6 +299,11 @@ trackingParticlesSignal = _trackingParticleRefSelector.clone(
     maxRapidity = 10,
     ptMin = 0,
 )
+## Select in-time TrackingParticles, and do the corresponding associations
+trackingParticlesInTime = trackingParticlesSignal.clone(
+    signalOnly = False,
+    intimeOnly = True,
+)
 
 # select tracks with pT > 0.9 GeV (for upgrade fake rates)
 generalTracksPt09 = cutsRecoTracks_cfi.cutsRecoTracks.clone(ptMin=0.9)
@@ -606,6 +611,10 @@ trackValidatorJetCore = trackValidator.clone(#equivalent to trackBuilding case
     associators= ["trackAssociatorByChi2"],#cms.untracked.VInputTag('MTVTrackAssociationByChi2'),
     UseAssociators = True,
     doPVAssociationPlots = True,
+    label_tp_effic = "trackingParticlesInTime",
+    label_tp_fake = "trackingParticlesInTime",
+    label_tp_effic_refvector = True,
+    label_tp_fake_refvector = True,
 )
 for _eraName, _postfix, _era in _relevantEras:
     if 'jetCoreRegionalStep' in _cfg.iterationAlgos(_postfix) :
@@ -711,6 +720,7 @@ tracksPreValidation = cms.Task(
     tracksValidationSelectorsFromPVPt09,
     tracksValidationTruth,
     trackingParticlesSignal,
+    trackingParticlesInTime,
     trackingParticlesElectron,
     trackingParticlesConversion
 )


### PR DESCRIPTION
trackValidatorJetCore is currently enabled only with seedingDeepCore; which is not in production yet.
Compared to other tracking validation cases, this one is using association by chi2.
As clarified in https://github.com/cms-sw/cmssw/pull/33531#issuecomment-840686662
`The trackAssociatorByChi2 is needed to have a "fair" performance estimation with DeepCore. DeepCore uses pixel-less seed [1], thus the associator by hits is not optimal in this case.`

A problem in timing was observed while testing #33531 , as described in https://github.com/cms-sw/cmssw/pull/33531#issuecomment-840663161 (and related messages). There are two components to resolve the problem:
- reduce the set of tracking particles to only the in-time ones (BX = 0)
- improve computational implementation of TrackAssociatorByChi2 by reducing unnecessary computations done in a nested double-loop (nTrack * nTrackingParticles )

In the test setup based on 11834.0 with `seedingDeepCore` modifier, the time in `trackValidatorJetCore` is reduced from around 5400 s/event  (averaged over the first 9 events) to 3.4 s/evt (averaged over 200 events).

Updates were tested on wf 11651 with `seedingDeepCore` (only in-time particles) to confirm that there are no changes in the DQM plots after the speedup implemented in `TrackAssociatorByChi2`