### PR TITLE
raise Exception only if there are two workflows having the same name

### DIFF
--- a/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
+++ b/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
@@ -29,8 +29,14 @@ def runSelected(opt):
         testSet = set(opt.testList)
         undefSet = testSet - definedSet
         if len(undefSet)>0: raise ValueError('Undefined workflows: '+', '.join(map(str,list(undefSet))))
-        duplicates = [wf for wf in testSet if definedWf.count(wf)>1 ]
-        if len(duplicates)>0: raise ValueError('Duplicated workflows: '+', '.join(map(str,list(duplicates))))
+        duplicates = [str(wf) for wf in testSet if definedWf.count(wf)>1 ]
+        if len(duplicates)>0: 
+            for duplicate in duplicates:
+                duplicate_wfs = [wfName for wfName in mrd.nameList.keys() if duplicate in wfName]
+                if(len(duplicate_wfs)>1):
+                    raise ValueError('There are multiple workflows matching the wf number %s: \n'%duplicate + '\n'.join(duplicate_wfs) + "\nPlease remove the duplicated workflow.")
+                else:
+                    print("WARNING: Workflow %s is defined multiple time."%duplicate_wfs[0])
 
     ret = 0
     if opt.show:

--- a/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
+++ b/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
@@ -29,14 +29,15 @@ def runSelected(opt):
         testSet = set(opt.testList)
         undefSet = testSet - definedSet
         if len(undefSet)>0: raise ValueError('Undefined workflows: '+', '.join(map(str,list(undefSet))))
+        # Check if there are multiple workflows having the same workflow number 
         duplicates = [str(wf) for wf in testSet if definedWf.count(wf)>1 ]
-        if len(duplicates)>0: 
-            for duplicate in duplicates:
-                duplicate_wfs = [wfName for wfName in mrd.nameList.keys() if duplicate in wfName]
-                if(len(duplicate_wfs)>1):
-                    raise ValueError('There are multiple workflows matching the wf number %s: \n'%duplicate + '\n'.join(duplicate_wfs) + "\nPlease remove the duplicated workflow.")
-                else:
-                    print("WARNING: Workflow %s is defined multiple time."%duplicate_wfs[0])
+        for duplicate in duplicates:
+            # Raise error only if the multiple workflows with the same number have different names 
+            duplicate_wfs = [wfName for wfName in mrd.nameList.keys() if duplicate in wfName]
+            if(len(duplicate_wfs)>1):
+                raise ValueError('There are multiple workflows matching the wf number %s: \n'%duplicate + '\n'.join(duplicate_wfs) + "\nPlease remove the duplicated workflow.")
+            else:
+                print("WARNING: Workflow %s is defined multiple time."%duplicate_wfs[0])
 
     ret = 0
     if opt.show:


### PR DESCRIPTION
#### Premise

When two workflows having the same name are found, `runTheMatrix.py` gives the warning:
```
==> duplicate name found for  36634.0_TTbar_14TeV+2026D81+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTrigger+RecoGlobal+HARVESTGlobal
    keeping  :  (36634.0, 'TTbar_14TeV+2026D81+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTrigger+RecoGlobal+HARVESTGlobal', ['cmsDriver.py TTbar_14TeV_TuneCP5_cfi  --conditions auto:phase2_realistic_T26 -n 10 --era Phase2C11I13T26M9 --eventcontent FEVTDEBUG --relval 9000,100 -s GEN,SIM --datatier GEN-SIM --beamspot HLLHC14TeV --geometry Extended2026D81', 'cmsDriver.py step2  --conditions auto:phase2_realistic_T26 -s DIGI:pdigi_valid,L1TrackTrigger,L1,DIGI2RAW,HLT:@fake2 --datatier GEN-SIM-DIGI-RAW -n 10 --geometry Extended2026D81 --era Phase2C11I13T26M9 --eventcontent FEVTDEBUGHLT', 'cmsDriver.py step3  --conditions auto:phase2_realistic_T26 -s RAW2DIGI,L1Reco,RECO,RECOSIM,PAT,VALIDATION:@phase2Validation+@miniAODValidation,DQM:@phase2+@miniAODDQM --datatier GEN-SIM-RECO,MINIAODSIM,DQMIO -n 10 --geometry Extended2026D81 --era Phase2C11I13T26M9 --eventcontent FEVTDEBUGHLT,MINIAODSIM,DQM', 'cmsDriver.py step4  --conditions auto:phase2_realistic_T26 -s HARVESTING:@phase2Validation+@phase2+@miniAODValidation+@miniAODDQM --scenario pp --filetype DQM --geometry Extended2026D81 --era Phase2C11I13T26M9 --mc '], ['TTbar_14TeV_TuneCP5_2026D81_GenSimHLBeamSpot14', 'DigiTrigger_2026D81', 'RecoGlobal_2026D81', 'HARVESTGlobal_2026D81'])
    ignoring :  (36634.0, 'TTbar_14TeV+2026D81+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTrigger+RecoGlobal+HARVESTGlobal', ['cmsDriver.py TTbar_14TeV_TuneCP5_cfi  --conditions auto:phase2_realistic_T26 -n 10 --era Phase2C11I13T26M9 --eventcontent FEVTDEBUG --relval 9000,100 -s GEN,SIM --datatier GEN-SIM --beamspot HLLHC14TeV --geometry Extended2026D81', 'cmsDriver.py step2  --conditions auto:phase2_realistic_T26 -s DIGI:pdigi_valid,L1TrackTrigger,L1,DIGI2RAW,HLT:@fake2 --datatier GEN-SIM-DIGI-RAW -n 10 --geometry Extended2026D81 --era Phase2C11I13T26M9 --eventcontent FEVTDEBUGHLT', 'cmsDriver.py step3  --conditions auto:phase2_realistic_T26 -s RAW2DIGI,L1Reco,RECO,RECOSIM,PAT,VALIDATION:@phase2Validation+@miniAODValidation,DQM:@phase2+@miniAODDQM --datatier GEN-SIM-RECO,MINIAODSIM,DQMIO -n 10 --geometry Extended2026D81 --era Phase2C11I13T26M9 --eventcontent FEVTDEBUGHLT,MINIAODSIM,DQM', 'cmsDriver.py step4  --conditions auto:phase2_realistic_T26 -s HARVESTING:@phase2Validation+@phase2+@miniAODValidation+@miniAODDQM --scenario pp --filetype DQM --geometry Extended2026D81 --era Phase2C11I13T26M9 --mc '], ['TTbar_14TeV_TuneCP5_2026D81_GenSimHLBeamSpot14', 'DigiTrigger_2026D81', 'RecoGlobal_2026D81', 
```
This happens if you try to run on `runTheMatrix.py --showMatrix --what upgrade,2026`, because `2026` is a subset of `upgrade`. 
The possibility to run on multiple matrices was added by https://github.com/cms-sw/cmssw/pull/33338/. This PR added also a protection to prevent you from running on a workflow number that is used in multiple workflows.

#### PR description:

This PR allows you to run on workflow numbers (eg. `23461.97`) which are defined multiple times if and only if the duplicated workflows have the same name (eg. `23461.97_PREMIXUP26D49_PU25+2026D49PU_PMXS1+PREMIX_PremixHLBeamSpotPU`)


#### PR validation:

Previous behavior (ERROR if there are wfs defined multiple times)
```
$ runTheMatrix.py --showMatrix --what upgrade,2026 -l 23461.97
==> duplicate name found for  23461.97_PREMIXUP26D49_PU25+2026D49PU_PMXS1+PREMIX_PremixHLBeamSpotPU
    keeping  :  (23461.97, 'PREMIXUP26D49_PU25+2026D49PU_PMXS1+PREMIX_PremixHLBeamSpotPU', ['cmsDriver.py step1  --conditions auto:phase2_realistic_T15 --pileup_input das:/RelValMinBias_14TeV/CMSSW_11_3_0_pre4-113X_mcRun4_realistic_v4_2026D49noPU_rsb-v1/GEN-SIM -n 10 --era Phase2C9 --eventcontent PREMIX --procModifiers premix_stage1 --relval 100000,100 -s GEN,SIM,DIGI:pdigi_valid --pileup AVE_200_BX_25ns --datatier PREMIX --beamspot HLLHC --geometry Extended2026D49 --evt_type SingleNuE10_cfi'], ['PREMIX_2026D49PU_PremixHLBeamSpotPU_PMXS1'])
    ignoring :  (23461.97, 'PREMIXUP26D49_PU25+2026D49PU_PMXS1+PREMIX_PremixHLBeamSpotPU', ['cmsDriver.py step1  --conditions auto:phase2_realistic_T15 --pileup_input das:/RelValMinBias_14TeV/CMSSW_11_3_0_pre4-113X_mcRun4_realistic_v4_2026D49noPU_rsb-v1/GEN-SIM -n 10 --era Phase2C9 --eventcontent PREMIX --procModifiers premix_stage1 --relval 100000,100 -s GEN,SIM,DIGI:pdigi_valid --pileup AVE_200_BX_25ns --datatier PREMIX --beamspot HLLHC --geometry Extended2026D49 --evt_type SingleNuE10_cfi'], ['PREMIX_2026D49PU_PremixHLBeamSpotPU_PMXS1'])
    
[...]

Traceback (most recent call last):
  File "/cvmfs/cms.cern.ch/slc7_amd64_gcc900/cms/cmssw/CMSSW_12_0_0_pre1/bin/slc7_amd64_gcc900/runTheMatrix.py", line 544, in <module>
    ret = runSelected(opt)
  File "/cvmfs/cms.cern.ch/slc7_amd64_gcc900/cms/cmssw/CMSSW_12_0_0_pre1/bin/slc7_amd64_gcc900/runTheMatrix.py", line 33, in runSelected
    if len(duplicates)>0: raise ValueError('Duplicated workflows: '+', '.join(map(str,list(duplicates))))
ValueError: Duplicated workflows: 23461.97

```

New behavior (WARNING if there are wfs defined multiple times having the **same** wf name)
```
$ runTheMatrix.py --showMatrix --what upgrade,2026 -l 23461.97
==> duplicate name found for  23461.97_PREMIXUP26D49_PU25+2026D49PU_PMXS1+PREMIX_PremixHLBeamSpotPU
    keeping  :  (23461.97, 'PREMIXUP26D49_PU25+2026D49PU_PMXS1+PREMIX_PremixHLBeamSpotPU', ['cmsDriver.py step1  --conditions auto:phase2_realistic_T15 --pileup_input das:/RelValMinBias_14TeV/CMSSW_11_3_0_pre4-113X_mcRun4_realistic_v4_2026D49noPU_rsb-v1/GEN-SIM -n 10 --era Phase2C9 --eventcontent PREMIX --procModifiers premix_stage1 --relval 100000,100 -s GEN,SIM,DIGI:pdigi_valid --pileup AVE_200_BX_25ns --datatier PREMIX --beamspot HLLHC --geometry Extended2026D49 --evt_type SingleNuE10_cfi'], ['PREMIX_2026D49PU_PremixHLBeamSpotPU_PMXS1'])
    ignoring :  (23461.97, 'PREMIXUP26D49_PU25+2026D49PU_PMXS1+PREMIX_PremixHLBeamSpotPU', ['cmsDriver.py step1  --conditions auto:phase2_realistic_T15 --pileup_input das:/RelValMinBias_14TeV/CMSSW_11_3_0_pre4-113X_mcRun4_realistic_v4_2026D49noPU_rsb-v1/GEN-SIM -n 10 --era Phase2C9 --eventcontent PREMIX --procModifiers premix_stage1 --relval 100000,100 -s GEN,SIM,DIGI:pdigi_valid --pileup AVE_200_BX_25ns --datatier PREMIX --beamspot HLLHC --geometry Extended2026D49 --evt_type SingleNuE10_cfi'], ['PREMIX_2026D49PU_PremixHLBeamSpotPU_PMXS1'])
    
[...]

WARNING: Workflow 23461.97_PREMIXUP26D49_PU25+2026D49PU_PMXS1+PREMIX_PremixHLBeamSpotPU is defined multiple time.
```

New behavior (ERROR if there are wfs defined multiple times having **different** wf name)

```
[...]
Traceback (most recent call last):
  File "/afs/cern.ch/work/s/sdonato/ORP/CMSSW_12_0_X_2021-05-13-2300/bin/slc7_amd64_gcc900/runTheMatrix.py", line 551, in <module>
    ret = runSelected(opt)
  File "/afs/cern.ch/work/s/sdonato/ORP/CMSSW_12_0_X_2021-05-13-2300/bin/slc7_amd64_gcc900/runTheMatrix.py", line 38, in runSelected
    raise ValueError('There are multiple workflows matching the wf number %s: \n'%duplicate + '\n'.join(duplicate_wfs) + "\nPlease remove the duplicated workflow.")
ValueError: There are multiple workflows matching the wf number 23234.0: 
23234.0_TTbar_14TeV+2026D60+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTrigger+RecoGlobal+HARVESTGlobal
23234.0_TTbar_14TeV+2026D49+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTrigger+RecoGlobal+HARVESTGlobal
Please remove the duplicated workflow.
```
