### PR TITLE
Delay assert until after secondary file ancestor check

### DIFF
--- a/DataFormats/Provenance/interface/BranchIDListHelper.h
+++ b/DataFormats/Provenance/interface/BranchIDListHelper.h
@@ -25,7 +25,7 @@ namespace edm {
     void updateFromParent(BranchIDLists const& bidlists);
 
     ///Called by sources to convert their read indexes into the indexes used by the job
-    void fixBranchListIndexes(BranchListIndexes& indexes) const;
+    bool fixBranchListIndexes(BranchListIndexes& indexes, bool assertOnFailure = true) const;
 
     void updateFromRegistry(ProductRegistry const& reg);
 

--- a/DataFormats/Provenance/src/BranchIDListHelper.cc
+++ b/DataFormats/Provenance/src/BranchIDListHelper.cc
@@ -81,10 +81,17 @@ namespace edm {
     }
   }
 
-  void BranchIDListHelper::fixBranchListIndexes(BranchListIndexes& indexes) const {
+  bool BranchIDListHelper::fixBranchListIndexes(BranchListIndexes& indexes, bool assertOnFailure) const {
     for (BranchListIndex& i : indexes) {
-      assert(i < inputIndexToJobIndex_.size());
+      bool indexInRange = i < inputIndexToJobIndex_.size();
+      if (!indexInRange) {
+        if (assertOnFailure) {
+          assert(indexInRange);
+        }
+        return false;
+      }
       i = inputIndexToJobIndex_[i];
     }
+    return true;
   }
 }  // namespace edm

--- a/IOPool/Input/src/PoolSource.cc
+++ b/IOPool/Input/src/PoolSource.cc
@@ -215,15 +215,17 @@ namespace edm {
   }
 
   void PoolSource::readEvent_(EventPrincipal& eventPrincipal) {
-    primaryFileSequence_->readEvent(eventPrincipal);
+    bool readEventSucceeded = primaryFileSequence_->readEvent(eventPrincipal);
+    assert(readEventSucceeded);
     if (secondaryFileSequence_ && !branchIDsToReplace_[InEvent].empty()) {
       bool found = secondaryFileSequence_->skipToItem(
           eventPrincipal.run(), eventPrincipal.luminosityBlock(), eventPrincipal.id().event());
       if (found) {
         EventPrincipal& secondaryEventPrincipal = *secondaryEventPrincipals_[eventPrincipal.streamID().value()];
-        secondaryFileSequence_->readEvent(secondaryEventPrincipal);
+        bool readEventSucceeded = secondaryFileSequence_->readEvent(secondaryEventPrincipal);
         checkConsistency(eventPrincipal, secondaryEventPrincipal);
         checkHistoryConsistency(eventPrincipal, secondaryEventPrincipal);
+        assert(readEventSucceeded);
         eventPrincipal.recombine(secondaryEventPrincipal, branchIDsToReplace_[InEvent]);
         eventPrincipal.mergeProvenanceRetrievers(secondaryEventPrincipal);
         secondaryEventPrincipal.clearPrincipal();

--- a/IOPool/Input/src/RootEmbeddedFileSequence.cc
+++ b/IOPool/Input/src/RootEmbeddedFileSequence.cc
@@ -176,7 +176,8 @@ namespace edm {
     assert(rootFile());
     bool found = rootFile()->nextEventEntry();
     if (found) {
-      found = rootFile()->readCurrentEvent(cache);
+      auto [found2, succeeded] = rootFile()->readCurrentEvent(cache);
+      found = found2;
     }
     if (!found) {
       setAtNextFile();
@@ -223,7 +224,8 @@ namespace edm {
     assert(rootFile());
     bool found = rootFile()->setEntryAtNextEventInLumi(id.run(), id.luminosityBlock());
     if (found) {
-      found = rootFile()->readCurrentEvent(cache);
+      auto [found2, succeeded] = rootFile()->readCurrentEvent(cache);
+      found = found2;
     }
     if (!found) {
       found = skipToItemInNewFile(id.run(), id.luminosityBlock(), 0);
@@ -247,7 +249,8 @@ namespace edm {
                                         << id << " in file id " << idx.fileNameHash() << "\n";
     }
     assert(rootFile());
-    found = rootFile()->readCurrentEvent(cache);
+    auto [found2, succeeded] = rootFile()->readCurrentEvent(cache);
+    found = found2;
     assert(found);
     fileNameHash = idx.fileNameHash();
     if (fileNameHash == 0U) {
@@ -296,11 +299,11 @@ namespace edm {
     }
     rootFile()->nextEventEntry();
 
-    bool found = rootFile()->readCurrentEvent(cache);
+    auto [found, succeeded] = rootFile()->readCurrentEvent(cache);
     if (!found) {
       rootFile()->setAtEventEntry(0);
-      found = rootFile()->readCurrentEvent(cache);
-      assert(found);
+      auto [found2, succeeded] = rootFile()->readCurrentEvent(cache);
+      assert(found2);
     }
     fileNameHash = lfnHash();
     --eventsRemainingInFile_;
@@ -336,7 +339,8 @@ namespace edm {
     assert(rootFile());
     bool found = rootFile()->setEntryAtNextEventInLumi(id.run(), id.luminosityBlock());
     if (found) {
-      found = rootFile()->readCurrentEvent(cache);
+      auto [found2, succeeded] = rootFile()->readCurrentEvent(cache);
+      found = found2;
     }
     if (!found) {
       found = rootFile()->setEntryAtItem(id.run(), id.luminosityBlock(), 0);

--- a/IOPool/Input/src/RootFile.h
+++ b/IOPool/Input/src/RootFile.h
@@ -29,6 +29,7 @@ RootFile.h // used by ROOT input sources
 #include <map>
 #include <memory>
 #include <string>
+#include <tuple>
 #include <vector>
 
 namespace edm {
@@ -202,8 +203,8 @@ namespace edm {
 
     void reportOpened(std::string const& inputType);
     void close();
-    bool readCurrentEvent(EventPrincipal& cache);
-    void readEvent(EventPrincipal& cache);
+    std::tuple<bool, bool> readCurrentEvent(EventPrincipal& cache, bool assertOnFailure = true);
+    bool readEvent(EventPrincipal& cache);
 
     std::shared_ptr<LuminosityBlockAuxiliary> readLuminosityBlockAuxiliary_();
     std::shared_ptr<RunAuxiliary> readRunAuxiliary_();
@@ -274,9 +275,10 @@ namespace edm {
     void fillIndexIntoFile();
     EventAuxiliary fillEventAuxiliary(IndexIntoFile::EntryNumber_t entry);
     EventAuxiliary const& fillThisEventAuxiliary();
-    void fillEventHistory(EventAuxiliary& evtAux,
+    bool fillEventHistory(EventAuxiliary& evtAux,
                           EventSelectionIDVector& eventSelectionIDs,
-                          BranchListIndexes& branchListIndexes);
+                          BranchListIndexes& branchListIndexes,
+                          bool assertOnFailure = true);
     std::shared_ptr<LuminosityBlockAuxiliary> fillLumiAuxiliary();
     std::shared_ptr<RunAuxiliary> fillRunAuxiliary();
     std::string const& newBranchToOldBranch(std::string const& newBranch) const;

--- a/IOPool/Input/src/RootInputFileSequence.cc
+++ b/IOPool/Input/src/RootInputFileSequence.cc
@@ -81,9 +81,9 @@ namespace edm {
   //  when it is asked to do so.
   //
 
-  void RootInputFileSequence::readEvent(EventPrincipal& eventPrincipal) {
+  bool RootInputFileSequence::readEvent(EventPrincipal& eventPrincipal) {
     assert(rootFile());
-    rootFile()->readEvent(eventPrincipal);
+    return rootFile()->readEvent(eventPrincipal);
   }
 
   bool RootInputFileSequence::containedInCurrentFile(RunNumber_t run,

--- a/IOPool/Input/src/RootInputFileSequence.h
+++ b/IOPool/Input/src/RootInputFileSequence.h
@@ -38,7 +38,7 @@ namespace edm {
     RootInputFileSequence& operator=(RootInputFileSequence const&) = delete;  // Disallow copying and moving
 
     bool containedInCurrentFile(RunNumber_t run, LuminosityBlockNumber_t lumi, EventNumber_t event) const;
-    void readEvent(EventPrincipal& cache);
+    bool readEvent(EventPrincipal& cache);
     std::shared_ptr<LuminosityBlockAuxiliary> readLuminosityBlockAuxiliary_();
     void readLuminosityBlock_(LuminosityBlockPrincipal& lumiPrincipal);
     std::shared_ptr<RunAuxiliary> readRunAuxiliary_();


### PR DESCRIPTION
#### PR description:

When using secondary file input it is required that the secondary files be ancestors of the primary files. There is a check that exists for this that will throw an exception with a helpful message if this requirement is violated. Unfortunately, there was a bug that allowed an assertion to fail when the requirement was violated before the check was done.

This moves the assertion until after the check is completed (see checkHistoryConsistency in PoolSource.cc). The changes are done such that the behavior is identical in every function stack different than the one that caused the problem.

It came out a little more complex than I had hoped because there were multiple other code stacks and various dependencies that prevented just moving a single line of code. There were a couple alternatives:

1. Simply remove the assert. There will be an exception in every case that I know about even without the assert. It is only there as a safety precaution in some complex code.

2. Refactor the code. It might come out simpler, but the changes would be more extensive.

See #33716 and https://hypernews.cern.ch/HyperNews/CMS/get/edmFramework/3921/1/1/1/1/1/1/1/3/2/1.html

#### PR validation:

Relies on existing tests. I also manually tested the changes on the input files where the problem was originally reported.
