### PR TITLE
Fixed indexing error in  EcalPulseSymmCovariance

### DIFF
--- a/CondFormats/EcalObjects/interface/EcalPulseSymmCovariances.h
+++ b/CondFormats/EcalObjects/interface/EcalPulseSymmCovariances.h
@@ -21,6 +21,7 @@ public:
   }
 
   float val(int i, int j) const { return covval[indexFor(i, j)]; }
+  float& val(int i, int j) { return covval[indexFor(i, j)]; }
 
   COND_SERIALIZABLE;
 };

--- a/CondFormats/EcalObjects/interface/EcalPulseSymmCovariances.h
+++ b/CondFormats/EcalObjects/interface/EcalPulseSymmCovariances.h
@@ -17,7 +17,7 @@ public:
   int indexFor(int i, int j) const {
     int m = std::min(i, j);
     int n = std::max(i, j);
-    return n + (EcalPulseShape::TEMPLATESAMPLES - 1) * m;
+    return n + EcalPulseShape::TEMPLATESAMPLES * m - m * (m + 1) / 2;
   }
 
   float val(int i, int j) const { return covval[indexFor(i, j)]; }

--- a/CondFormats/EcalObjects/interface/EcalPulseSymmCovariances.h
+++ b/CondFormats/EcalObjects/interface/EcalPulseSymmCovariances.h
@@ -6,20 +6,21 @@
 #include "CondFormats/EcalObjects/interface/EcalPulseShapes.h"
 #include "CondFormats/EcalObjects/interface/EcalCondObjectContainer.h"
 
+#include <algorithm>
+
 struct EcalPulseSymmCovariance {
 public:
   EcalPulseSymmCovariance();
 
   float covval[EcalPulseShape::TEMPLATESAMPLES * (EcalPulseShape::TEMPLATESAMPLES + 1) / 2];
 
-  float val(int i, int j) const {
-    int k = -1;
-    if (j >= i)
-      k = j + (EcalPulseShape::TEMPLATESAMPLES - 1) * i;
-    else
-      k = i + (EcalPulseShape::TEMPLATESAMPLES - 1) * j;
-    return covval[k];
+  int indexFor(int i, int j) const {
+    int m = std::min(i, j);
+    int n = std::max(i, j);
+    return n + (EcalPulseShape::TEMPLATESAMPLES - 1) * m;
   }
+
+  float val(int i, int j) const { return covval[indexFor(i, j)]; }
 
   COND_SERIALIZABLE;
 };

--- a/CondFormats/EcalObjects/test/BuildFile.xml
+++ b/CondFormats/EcalObjects/test/BuildFile.xml
@@ -14,3 +14,6 @@
 </environment>
 <bin file="testSerializationEcalObjects.cpp">
 </bin>
+<bin file="EcalPulseSymmCovariance_catch2.cc">
+  <use name="catch2"/>
+</bin>

--- a/CondFormats/EcalObjects/test/EcalPulseSymmCovariance_catch2.cc
+++ b/CondFormats/EcalObjects/test/EcalPulseSymmCovariance_catch2.cc
@@ -1,0 +1,59 @@
+#include "CondFormats/EcalObjects/interface/EcalPulseSymmCovariances.h"
+
+#define CATCH_CONFIG_MAIN  // This tells Catch to provide a main() - only do this in one cpp file
+#include "catch.hpp"
+#include <iostream>
+
+TEST_CASE("EcalPulseSymmCovariance testing", "[EcalPulseSymmCovariance]") {
+  EcalPulseSymmCovariance covMutable;
+  //fill with accending values
+  float const vMin = 0.5f;
+  float v = vMin;
+
+  std::set<float> values;
+  for (auto& entry : covMutable.covval) {
+    entry = v;
+    values.insert(v);
+    v += 1.f;
+  }
+
+  float const vMax = v - 1.f;
+
+  auto const& cov = covMutable;
+
+  SECTION("Check symmetry") {
+    for (int i = 0; i < EcalPulseShape::TEMPLATESAMPLES; ++i) {
+      for (int j = 0; j < EcalPulseShape::TEMPLATESAMPLES; ++j) {
+        REQUIRE(cov.val(i, j) == cov.val(j, i));
+      }
+    }
+  }
+  SECTION("Check bounds") {
+    for (int i = 0; i < EcalPulseShape::TEMPLATESAMPLES; ++i) {
+      for (int j = 0; j < EcalPulseShape::TEMPLATESAMPLES; ++j) {
+        REQUIRE(cov.indexFor(i, j) < std::size(cov.covval));
+      }
+    }
+  }
+
+  SECTION("Check known values") {
+    for (int i = 0; i < EcalPulseShape::TEMPLATESAMPLES; ++i) {
+      for (int j = 0; j < EcalPulseShape::TEMPLATESAMPLES; ++j) {
+        REQUIRE(vMin <= cov.val(i, j));
+        REQUIRE(cov.val(i, j) <= vMax);
+        REQUIRE(values.end() != values.find(cov.val(i, j)));
+      }
+    }
+  }
+
+  SECTION("Check filling") {
+    float v = vMin;
+    EcalPulseSymmCovariance covNew;
+    for (int i = 0; i < EcalPulseShape::TEMPLATESAMPLES; ++i) {
+      for (int j = 0; j < EcalPulseShape::TEMPLATESAMPLES; ++j) {
+        covNew.val(i, j) = v;
+        REQUIRE(v == covNew.val(i, j));
+      }
+    }
+  }
+}

--- a/CondFormats/EcalObjects/test/EcalPulseSymmCovariance_catch2.cc
+++ b/CondFormats/EcalObjects/test/EcalPulseSymmCovariance_catch2.cc
@@ -28,6 +28,17 @@ TEST_CASE("EcalPulseSymmCovariance testing", "[EcalPulseSymmCovariance]") {
       }
     }
   }
+  SECTION("Check index coverage") {
+    std::vector<bool> hitIndices(std::size(cov.covval), false);
+    for (int i = 0; i < EcalPulseShape::TEMPLATESAMPLES; ++i) {
+      for (int j = 0; j < EcalPulseShape::TEMPLATESAMPLES; ++j) {
+        hitIndices[cov.indexFor(i, j)] = true;
+      }
+    }
+    for (auto indx : hitIndices) {
+      REQUIRE(indx == true);
+    }
+  }
   SECTION("Check bounds") {
     for (int i = 0; i < EcalPulseShape::TEMPLATESAMPLES; ++i) {
       for (int j = 0; j < EcalPulseShape::TEMPLATESAMPLES; ++j) {

--- a/CondTools/Ecal/src/EcalPulseSymmCovariancesHandler.cc
+++ b/CondTools/Ecal/src/EcalPulseSymmCovariancesHandler.cc
@@ -76,12 +76,7 @@ void popcon::EcalPulseSymmCovariancesHandler::getNewObjects() {
       EcalPulseSymmCovariances::Item item;
       for (int i = 0; i < EcalPulseShape::TEMPLATESAMPLES; ++i)
         for (int j = 0; j < EcalPulseShape::TEMPLATESAMPLES; ++j) {
-          int k = -1;
-          if (j >= i)
-            k = j + (EcalPulseShape::TEMPLATESAMPLES - 1) * i;
-          else
-            k = i + (EcalPulseShape::TEMPLATESAMPLES - 1) * j;
-          item.covval[k] = covvals[i][j];
+          item.val(i, j) = covvals[i][j];
         }
 
       if (isbarrel) {


### PR DESCRIPTION
#### PR description:

The gcc build with `-O3 -g` gave in error on EcalPulseSymmCovariancesHandler saying it was writing off the end of the array held by EcalPulseSymmCovariance. The problem is the code which translated the matrix coordinates into the compacted array index was incorrect. This change provides a correct mapping.

#### PR validation:

The code compiles and the newly added unit test passes.

No attempt was made to see how the changed lookup might affect physics.