### PR TITLE
Added link needed for debug build of SimTransport/PPSProtonTransport

### DIFF
--- a/SimTransport/PPSProtonTransport/BuildFile.xml
+++ b/SimTransport/PPSProtonTransport/BuildFile.xml
@@ -1,6 +1,7 @@
 <use   name="FWCore/Framework"/>
 <use   name="FWCore/ParameterSet"/>
 <use   name="SimDataFormats/GeneratorProducts"/>
+<use   name="SimDataFormats/Forward"/>
 <use   name="SimGeneral/HepPDTRecord"/>
 <use   name="Utilities/PPS"/>
 <use   name="SimTransport/TotemRPProtonTransportParametrization"/>


### PR DESCRIPTION
#### PR description:

When compiled with -DEDM_ML_DEBUG there was a missing symbol which comes from SimDataFormats/Forward.

#### PR validation:

The code now compiles and links with -DEDM_ML_DEBUG set.