### PR TITLE
Fix debug build of L1Trigger/DTTriggerPhase2

### DIFF
--- a/L1Trigger/DTTriggerPhase2/interface/DTPattern.h
+++ b/L1Trigger/DTTriggerPhase2/interface/DTPattern.h
@@ -43,7 +43,7 @@ public:
   const std::vector<RefDTPatternHit> &genHits() const { return genHits_; }
 
   //Printing
-  friend std::ostream &operator<<(std::ostream &out, DTPattern &p);
+  friend std::ostream &operator<<(std::ostream &out, DTPattern const &p);
 
 private:
   //Generated seeds

--- a/L1Trigger/DTTriggerPhase2/src/DTPattern.cc
+++ b/L1Trigger/DTTriggerPhase2/src/DTPattern.cc
@@ -53,7 +53,7 @@ int DTPattern::latHitIn(int slId, int chId, int allowedVariance) const {
   return temp;
 }
 
-std::ostream &operator<<(std::ostream &out, DTPattern &p) {
+std::ostream &operator<<(std::ostream &out, DTPattern const &p) {
   //Friend for printing pattern information trough iostream
   out << "Pattern id: " << std::get<0>(p.id()) << " , " << std::get<1>(p.id()) << " , " << std::get<2>(p.id())
       << std::endl;

--- a/L1Trigger/DTTriggerPhase2/src/PseudoBayesGrouping.cc
+++ b/L1Trigger/DTTriggerPhase2/src/PseudoBayesGrouping.cc
@@ -348,11 +348,11 @@ void PseudoBayesGrouping::RecognisePatterns(std::vector<DTPrimitive> digisinLDow
             (allowUncorrelatedPatterns_ && ((cand->nLayerUp() >= minUncorrelatedHits_ && cand->nLayerDown() == 0) ||
                                             (cand->nLayerDown() >= minUncorrelatedHits_ && cand->nLayerUp() == 0)))) {
           if (debug_) {
-            LogDebug("PseudoBayesGrouping") << "PseudoBayesGrouping::RecognisePatterns Pattern found for pair in "
-                                            << LDown << " ," << wireDown << " ," << LUp << " ," << wireUp;
             LogDebug("PseudoBayesGrouping")
-                << "Candidate has " << cand->nhits() << " hits with quality " << cand->quality();
-            LogDebug("PseudoBayesGrouping") << *(*pat_it);
+                << "PseudoBayesGrouping::RecognisePatterns Pattern found for pair in " << LDown << " ," << wireDown
+                << " ," << LUp << " ," << wireUp << "\n"
+                << "Candidate has " << cand->nhits() << " hits with quality " << cand->quality() << "\n"
+                << *(*pat_it);
           }
           //We currently save everything at this level, might want to be more restrictive
           pidx_++;


### PR DESCRIPTION
#### PR description:

Converted operator<< for DTPattern to take a const&. Needed when call from LogDebug.

#### PR validation:

Package now builds with -DEDM_ML_DEBUG