### PR TITLE
Add init values for struct members to silence Arm warning

### DIFF
--- a/L1Trigger/L1TTrackMatch/interface/L1TrackJetProducer.h
+++ b/L1Trigger/L1TTrackMatch/interface/L1TrackJetProducer.h
@@ -8,21 +8,21 @@
 //Each individual box in the eta and phi dimension.
 //  Also used to store final cluster data for each zbin.
 struct EtaPhiBin {
-  float pTtot = 0;
-  int numtracks = 0;
-  int numttrks = 0;
-  int numtdtrks = 0;
-  int numttdtrks = 0;
-  bool used = true;
-  float phi = 0;  //average phi value (halfway b/t min and max)
-  float eta = 0;  //average eta value
+  float pTtot;
+  int numtracks;
+  int numttrks;
+  int numtdtrks;
+  int numttdtrks;
+  bool used;
+  float phi;  //average phi value (halfway b/t min and max)
+  float eta;  //average eta value
 };
 
 //store important information for plots
 struct MaxZBin {
-  int znum = 0;    //Numbered from 0 to nzbins (16, 32, or 64) in order
-  int nclust = 0;  //number of clusters in this bin
-  float zbincenter = 0;
-  EtaPhiBin *clusters = nullptr;  //list of all the clusters in this bin
-  float ht = 0;                   //sum of all cluster pTs--only the zbin with the maximum ht is stored
+  int znum;    //Numbered from 0 to nzbins (16, 32, or 64) in order
+  int nclust;  //number of clusters in this bin
+  float zbincenter;
+  EtaPhiBin *clusters;  //list of all the clusters in this bin
+  float ht;             //sum of all cluster pTs--only the zbin with the maximum ht is stored
 };

--- a/L1Trigger/L1TTrackMatch/interface/L1TrackJetProducer.h
+++ b/L1Trigger/L1TTrackMatch/interface/L1TrackJetProducer.h
@@ -8,21 +8,21 @@
 //Each individual box in the eta and phi dimension.
 //  Also used to store final cluster data for each zbin.
 struct EtaPhiBin {
-  float pTtot;
-  int numtracks;
-  int numttrks;
-  int numtdtrks;
-  int numttdtrks;
-  bool used;
-  float phi;  //average phi value (halfway b/t min and max)
-  float eta;  //average eta value
+  float pTtot = 0;
+  int numtracks = 0;
+  int numttrks = 0;
+  int numtdtrks = 0;
+  int numttdtrks = 0;
+  bool used = true;
+  float phi = 0;  //average phi value (halfway b/t min and max)
+  float eta = 0;  //average eta value
 };
 
 //store important information for plots
 struct MaxZBin {
-  int znum;    //Numbered from 0 to nzbins (16, 32, or 64) in order
-  int nclust;  //number of clusters in this bin
-  float zbincenter;
-  EtaPhiBin *clusters;  //list of all the clusters in this bin
-  float ht;             //sum of all cluster pTs--only the zbin with the maximum ht is stored
+  int znum = 0;    //Numbered from 0 to nzbins (16, 32, or 64) in order
+  int nclust = 0;  //number of clusters in this bin
+  float zbincenter = 0;
+  EtaPhiBin *clusters = nullptr;  //list of all the clusters in this bin
+  float ht = 0;                   //sum of all cluster pTs--only the zbin with the maximum ht is stored
 };

--- a/L1Trigger/L1TTrackMatch/plugins/L1TrackJetProducer.cc
+++ b/L1Trigger/L1TTrackMatch/plugins/L1TrackJetProducer.cc
@@ -274,9 +274,8 @@ void L1TrackJetProducer::L2_cluster(
     vector<Ptr<L1TTTrackType> > L1TrkPtrs_, vector<int> ttrk_, vector<int> tdtrk_, vector<int> ttdtrk_, MaxZBin &mzb) {
   const int nz = zBins_;
   MaxZBin all_zBins[nz];
-  MaxZBin mzbtemp;
   for (int z = 0; z < nz; ++z)
-    all_zBins[z] = mzbtemp;
+    all_zBins[z] = MaxZBin{0, 0, 0, nullptr, 0};
 
   float zmin = -1.0 * trkZMax_;
   float zmax = zmin + 2 * zStep_;


### PR DESCRIPTION
#### PR description:

Initializes struct members to some default. Not being init they cause a warning in Arm builds:
https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/slc7_aarch64_gcc9/CMSSW_12_0_X_2021-05-14-1100/L1Trigger/L1TTrackMatch

#### PR validation:

The warning is gone after the change (checked on Arm)


