### PR TITLE
Missing files for ECAL trigger double weights O2O scripts: backport 11_3_X

### DIFF
--- a/CondTools/Ecal/plugins/TestEcalTPGOddWeightGroupAnalyzer.cc
+++ b/CondTools/Ecal/plugins/TestEcalTPGOddWeightGroupAnalyzer.cc
@@ -1,0 +1,8 @@
+#include "CondCore/PopCon/interface/PopConAnalyzer.h"
+#include "CondTools/Ecal/interface/EcalTPGOddWeightGroupHandler.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+typedef popcon::PopConAnalyzer<popcon::EcalTPGOddWeightGroupHandler> ExTestEcalTPGOddWeightGroupAnalyzer;
+
+//define this as a plug-in
+DEFINE_FWK_MODULE(ExTestEcalTPGOddWeightGroupAnalyzer);

--- a/CondTools/Ecal/plugins/TestEcalTPGOddWeightIdMapAnalyzer.cc
+++ b/CondTools/Ecal/plugins/TestEcalTPGOddWeightIdMapAnalyzer.cc
@@ -1,0 +1,8 @@
+#include "CondCore/PopCon/interface/PopConAnalyzer.h"
+#include "CondTools/Ecal/interface/EcalTPGOddWeightIdMapHandler.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+typedef popcon::PopConAnalyzer<popcon::EcalTPGOddWeightIdMapHandler> ExTestEcalTPGOddWeightIdMapAnalyzer;
+
+//define this as a plug-in
+DEFINE_FWK_MODULE(ExTestEcalTPGOddWeightIdMapAnalyzer);

--- a/CondTools/Ecal/plugins/TestEcalTPGTPModeAnalyzer.cc
+++ b/CondTools/Ecal/plugins/TestEcalTPGTPModeAnalyzer.cc
@@ -1,0 +1,8 @@
+#include "CondCore/PopCon/interface/PopConAnalyzer.h"
+#include "CondTools/Ecal/interface/EcalTPGTPModeHandler.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+typedef popcon::PopConAnalyzer<popcon::EcalTPGTPModeHandler> ExTestEcalTPGTPModeAnalyzer;
+
+//define this as a plug-in
+DEFINE_FWK_MODULE(ExTestEcalTPGTPModeAnalyzer);


### PR DESCRIPTION
#### PR description:

Backport of #33748 to 11_3_X in order to include it in the release for June MWGR.

Added missing plugins for O2O scripts used by the new ECAL Trigger double weights mechanism. 
The files were not included in the previously merged PR #33349. 

Presentation to AlCa:  https://indico.cern.ch/event/1020767/#16-new-ecal-tpg-db-classes-for

#### PR validation:
Tested the O2O scripts manually on test DBs with the 3 plugins included in the release.
No effects on physics production.


