### PR TITLE
bugfix RPCSeedGenerator wrong nullptr check

### DIFF
--- a/RecoMuon/MuonSeedGenerator/src/RPCSeedOverlapper.cc
+++ b/RecoMuon/MuonSeedGenerator/src/RPCSeedOverlapper.cc
@@ -36,7 +36,7 @@ void RPCSeedOverlapper::unsetIO() { isIOset = false; }
 void RPCSeedOverlapper::setGeometry(const RPCGeometry &iGeom) { rpcGeometry = &iGeom; }
 
 void RPCSeedOverlapper::run() {
-  if (isConfigured == false || isIOset == false || rpcGeometry != nullptr) {
+  if (isConfigured == false || isIOset == false || rpcGeometry == nullptr) {
     cout << "Configuration or IO is not set yet" << endl;
     return;
   }
@@ -167,7 +167,7 @@ bool RPCSeedOverlapper::isShareHit(const std::vector<TrackingRecHit const *> &re
   GlobalPoint gpos1 = rpcroll1->toGlobal(lpos1);
   cout << "The hit's position: " << gpos1.x() << ", " << gpos1.y() << ", " << gpos1.z() << endl;
   for (auto const &recHit : recHits) {
-    cout << "Checking the " << n << " th recHit from tempRecHits" << endl;
+    cout << "Checking the " << (n++) << " th recHit from tempRecHits" << endl;
     LocalPoint lpos2 = recHit->localPosition();
     DetId RPCId2 = recHit->geographicalId();
     const GeomDetUnit *rpcroll2 = rpcGeometry.idToDetUnit(RPCId2);


### PR DESCRIPTION
#### PR description:

A nullptr-check went opposite way in the RPCSeedGenerator of the RecoMuon package, discovered thanks to @perrotta. 
In addition, a minor fix to printout message is done. 

The standard sequences seem to be unaffected due to this potential bug, maybe because validity checks were done using the other flags in the same if-statement. 
Since this PR introduces only a safeguard from potential crash (+correction to the printout debug message) and does not include any significant change. Therefore we expect no change in outcomes of the standard reconstruction with this PR.
The latest change to this module is done with the PR #30687, which was also a technical change.

#### PR validation:
This PR compiles without error and passes code-checks & a runTheMatrix workflow (13250 WF for a quick check)

@andresib @mileva 

