### PR TITLE
Support of db keys for O2O commands

### DIFF
--- a/CondCore/CondDB/plugins/CondDBPyBind11Wrappers.cc
+++ b/CondCore/CondDB/plugins/CondDBPyBind11Wrappers.cc
@@ -30,5 +30,9 @@ namespace cond {
 namespace py = pybind11;
 
 PYBIND11_MODULE(pluginCondDBPyBind11Interface, m) {
-  m.def("get_db_credentials", &cond::getDbCredentials, "Get db credentials for a connection string");
+  m.def("get_credentials_from_db", &cond::getDbCredentials, "Get db credentials for a connection string");
+  m.attr("default_role") = pybind11::int_(int(cond::auth::DEFAULT_ROLE));
+  m.attr("reader_role") = pybind11::int_(int(cond::auth::READER_ROLE));
+  m.attr("writer_role") = pybind11::int_(int(cond::auth::WRITER_ROLE));
+  m.attr("admin_role") = pybind11::int_(int(cond::auth::ADMIN_ROLE));
 }

--- a/CondCore/Utilities/python/conddblib.py
+++ b/CondCore/Utilities/python/conddblib.py
@@ -43,11 +43,6 @@ ORADEV = 'cms_orcoff_prep'
 ONLINEORAPRO = 'cms_orcon_prod'
 ONLINEORAINT = 'cmsintr_lb'
 
-# access role codes
-READ_ROLE = 1
-WRITE_ROLE = 2
-ADMIN_ROLE = 3
-
 # Set initial level to WARN.  This so that log statements don't occur in
 # the absense of explicit logging being enabled.
 if logger.level == logging.NOTSET:
@@ -576,15 +571,15 @@ def connect(url, authPath=None, verbose=0, as_admin=False):
                     else:
                         explicit_auth =True
                 else:
-                    import pluginCondDBPyBind11Interface as credential_store
-                    role_code = 1
+                    import pluginCondDBPyBind11Interface as auth
+                    role_code = auth.reader_role
                     if url.username == dbwriter_user_name:
-                        role_code = 2
+                        role_code = auth.writer_role
                     if check_admin:
-                        role_code = 3
+                        role_code = auth.admin_role
                     connection_string = oracle_connection_string(url.host.lower(),schema_name)
                     logging.debug('Using db key to get credentials for %s' %connection_string )
-                    (dbuser,username,password) = credential_store.get_db_credentials(connection_string,role_code,authPath)
+                    (dbuser,username,password) = auth.get_credentials_from_db(connection_string,role_code,authPath)
                     if username=='' or password=='':
                         raise Exception('No credentials found to connect on %s with the required access role.'%connection_string)
                     check_admin = False

--- a/CondCore/Utilities/python/credentials.py
+++ b/CondCore/Utilities/python/credentials.py
@@ -1,19 +1,29 @@
 import netrc
 import os
+import logging
 
 netrcFileName = '.netrc'
 defAuthPathEnvVar = 'HOME'
 authPathEnvVar = 'COND_AUTH_PATH'
 
+dbkey_filename = 'db.key'
+dbkey_folder = os.path.join('.cms_cond',dbkey_filename)
 
-def get_credentials_from_file( service, authPath ):
+reader_role = 'reader'
+writer_role = 'writer'
+admin_role  = 'admin'
+
+def netrc_machine( service, role ):
+    return '%s@%s' %(role,service)
+
+def get_credentials_from_file( machine, authPath ):
     authFile = netrcFileName
     if not authPath is None:
         authFile = os.path.join( authPath, authFile )
-    creds = netrc.netrc( authFile ).authenticators(service)
+    creds = netrc.netrc( authFile ).authenticators(machine)
     return creds
 
-def get_credentials( service, authPath=None ):
+def get_credentials( machine, authPath=None ):
     if authPath is None:
         if authPathEnvVar in os.environ:
             authPath = os.environ[authPathEnvVar]
@@ -22,5 +32,37 @@ def get_credentials( service, authPath=None ):
                 authPath = os.environ[defAuthPathEnvVar]
             else:
                 authPath = ''
-    return get_credentials_from_file( service, authPath )
+    return get_credentials_from_file( machine, authPath )
+
+def get_credentials_for_schema( service, schema, role, authPath=None ):
+    if authPath is None:
+        if authPathEnvVar in os.environ:
+            authPath = os.environ[authPathEnvVar]
+        else:
+            if defAuthPathEnvVar in os.environ:
+                authPath = os.environ[defAuthPathEnvVar]
+            else:
+                authPath = ''
+    dbkey_path = os.path.join(authPath,dbkey_folder)
+    if not os.path.exists(dbkey_path):
+        authFile = os.path.join(authPath,'.netrc')
+        if not os.path.exists(authFile):
+            raise Exception("Can't get db credentials, since neither db key nor Netrc file have been found.")
+        machine = '%s@%s.%s' %(role,schema.lower(),service)
+        logging.debug('Looking up db credentials %s in file %s ' %(machine,authFile) )
+        import netrc
+        params = netrc.netrc( authFile ).authenticators(machine)
+        if params is None:
+            msg = 'The required credentials have not been found in the .netrc file.' 
+            raise Exception(msg)
+        return params
+    else:
+        import pluginCondDBPyBind11Interface as credential_db
+        roles_map = { reader_role: credential_db.reader_role, writer_role: credential_db.writer_role, admin_role: credential_db.admin_role }
+        connection_string = 'oracle://%s/%s'%(service.lower(),schema.upper())
+        logging.debug('Looking up db credentials for %s in credential store' %connection_string )
+        (dbuser,username,password) = credential_db.get_credentials_from_db(connection_string,roles_map[role],authPath)
+        if username=='' or password=='':
+            raise Exception('No credentials found to connect on %s with the required access role.'%connection_string)       
+        return (username,dbuser,password)
 


### PR DESCRIPTION
#### PR description:

We are adding the support of db keys for the O2O command tools.
The supported key is the same already used for C++ executables and python conddb command tools.
For the O2O, a db key can be used as a replacement of the .netrc file containing the db password. The latter will be still supported, but the passwords won't be distributed any longer.
Depending on the O2O command, different levels of privileges are required:
- Read for listJobs/listConfig/dumpConfig
- Write for run
- Admin for create, enable, disable, setConfig, setFrequent
#### PR validation:

Stand-alone integration tests
