### PR TITLE
new VFAT status plots and recHit wheel occupancy plots on GEM onlineDQM, a backport to CMSSW_11_3_X

### DIFF
--- a/DQM/GEM/interface/GEMDQMBase.h
+++ b/DQM/GEM/interface/GEMDQMBase.h
@@ -150,6 +150,26 @@ public:
           dYL_(dYL),
           dYH_(dYH){};
 
+    //MEMapInfT(GEMDQMBase *pDQMBase,
+    //          TString strName,
+    //          TString strTitle,
+    //          std::vector<Double_t> &x_binning,
+    //          std::vector<Double_t> &y_binning,
+    //          TString strTitleX = "",
+    //          TString strTitleY = "")
+    //    : pDQMBase_(pDQMBase),
+    //      strName_(strName),
+    //      strTitle_(strTitle),
+    //      strTitleX_(strTitleX),
+    //      strTitleY_(strTitleY),
+    //      bOperating_(true),
+    //      nBinsX_(nBinsX),
+    //      dXL_(dXL),
+    //      dXH_(dXH),
+    //      nBinsY_(nBinsY),
+    //      dYL_(dYL),
+    //      dYH_(dYH){};
+
     ~MEMapInfT(){};
 
     Bool_t isOperating() { return bOperating_; };
@@ -341,13 +361,13 @@ public:
               nMaxVFAT_ == other.nMaxVFAT_ && nNumStrip_ == other.nNumStrip_);
     };
 
-    Int_t nRegion_;
-    Int_t nStation_;
-    Int_t nLayer_;
-    Int_t nNumChambers_;
-    Int_t nNumEtaPartitions_;
-    Int_t nMaxVFAT_;
-    Int_t nNumStrip_;
+    Int_t nRegion_;            // the region index
+    Int_t nStation_;           // the station index
+    Int_t nLayer_;             // the layer
+    Int_t nNumChambers_;       // the number of chambers in the current station
+    Int_t nNumEtaPartitions_;  // the number of eta partitions of the chambers
+    Int_t nMaxVFAT_;   // the number of all VFATs in each chamber (= # of VFATs in eta partition * nNumEtaPartitions_)
+    Int_t nNumStrip_;  // the number of strips of each VFAT
   };
 
 public:
@@ -357,6 +377,7 @@ public:
 protected:
   int initGeometry(edm::EventSetup const &iSetup);
   int loadChambers();
+  int readRadiusEtaPartition(int nRegion, int nStation);
 
   int GenerateMEPerChamber(DQMStore::IBooker &ibooker);
   virtual int ProcessWithMEMap2(BookingHelper &bh, ME2IdsKey key) { return 0; };             // must be overrided

--- a/DQM/GEM/plugins/GEMDQMHarvester.cc
+++ b/DQM/GEM/plugins/GEMDQMHarvester.cc
@@ -35,22 +35,32 @@ protected:
   void dqmEndJob(DQMStore::IBooker &, DQMStore::IGetter &) override{};  // Cannot use; it is called after dqmSaver
 
   void drawSummaryHistogram(edm::Service<DQMStore> &store);
-  void createSummaryHist(edm::Service<DQMStore> &store, MonitorElement *h2Src, MonitorElement *&h2Sum);
+  void createSummaryHist(edm::Service<DQMStore> &store,
+                         MonitorElement *h2Src,
+                         MonitorElement *&h2Sum,
+                         std::vector<std::string> &listLayers);
+  void createSummaryVFAT(edm::Service<DQMStore> &store,
+                         MonitorElement *h2Src,
+                         std::string strSuffix,
+                         MonitorElement *&h2Sum);
   void refineSummaryHistogram(MonitorElement *h2Sum,
-                              MonitorElement *h2SrcDigiOcc,
-                              MonitorElement *h2SrcDigiMal,
-                              MonitorElement *h2SrcCStatus);
+                              MonitorElement *h2SrcOcc,
+                              MonitorElement *h2SrcCStatus,
+                              MonitorElement *h2SrcMal = nullptr,
+                              Bool_t bVarXBin = false);
 
   Float_t fReportSummary_;
   std::string strOutFile_;
 
   std::string strDirSummary_;
+  std::string strDirStatus_;
 };
 
 GEMDQMHarvester::GEMDQMHarvester(const edm::ParameterSet &cfg) {
   fReportSummary_ = -1.0;
   strOutFile_ = cfg.getParameter<std::string>("fromFile");
   strDirSummary_ = "GEM/EventInfo";
+  strDirStatus_ = "GEM/DAQStatus";
 }
 
 void GEMDQMHarvester::fillDescriptions(edm::ConfigurationDescriptions &descriptions) {
@@ -67,22 +77,13 @@ void GEMDQMHarvester::dqmEndLuminosityBlock(DQMStore::IBooker &,
   drawSummaryHistogram(store);
 }
 
-void GEMDQMHarvester::createSummaryHist(edm::Service<DQMStore> &store, MonitorElement *h2Src, MonitorElement *&h2Sum) {
-  store->setCurrentFolder(strDirSummary_);
-
-  Int_t nBinX = h2Src->getNbinsX(), nBinY = h2Src->getNbinsY();
-  h2Sum = store->book2D("reportSummaryMap", "", nBinX, 0.5, nBinX + 0.5, nBinY, 0.5, nBinY + 0.5);
-
-  for (Int_t i = 1; i <= nBinX; i++)
-    h2Sum->setBinLabel(i, h2Src->getTH2F()->GetXaxis()->GetBinLabel(i), 1);
-  for (Int_t i = 1; i <= nBinY; i++)
-    h2Sum->setBinLabel(i, h2Src->getTH2F()->GetYaxis()->GetBinLabel(i), 2);
-}
-
 void GEMDQMHarvester::drawSummaryHistogram(edm::Service<DQMStore> &store) {
   std::string strSrcDigiOcc = "GEM/digi/summaryOccDigi";
   std::string strSrcDigiMal = "GEM/digi/summaryMalfuncDigi";
   std::string strSrcCStatus = "GEM/DAQStatus/summaryStatus";
+
+  std::string strSrcVFATOcc = "GEM/digi/digi_det";
+  std::string strSrcVFATStatus = "GEM/DAQStatus/vfat_statusSum";
 
   store->setCurrentFolder(strDirSummary_);
 
@@ -92,31 +93,85 @@ void GEMDQMHarvester::drawSummaryHistogram(edm::Service<DQMStore> &store) {
 
   if (h2SrcDigiOcc != nullptr && h2SrcDigiMal != nullptr && h2SrcCStatus != nullptr) {
     MonitorElement *h2Sum = nullptr;
-    createSummaryHist(store, h2SrcCStatus, h2Sum);
-    refineSummaryHistogram(h2Sum, h2SrcDigiOcc, h2SrcDigiMal, h2SrcCStatus);
+    std::vector<std::string> listLayer;
+    createSummaryHist(store, h2SrcCStatus, h2Sum, listLayer);
+    refineSummaryHistogram(h2Sum, h2SrcDigiOcc, h2SrcCStatus, h2SrcDigiMal, true);
+
+    for (const auto &strSuffix : listLayer) {
+      MonitorElement *h2SrcVFATOcc = store->get(strSrcVFATOcc + strSuffix);
+      MonitorElement *h2SrcVFATStatus = store->get(strSrcVFATStatus + strSuffix);
+      if (h2SrcVFATOcc == nullptr || h2SrcVFATStatus == nullptr)
+        continue;
+      MonitorElement *h2SumVFAT = nullptr;
+      createSummaryVFAT(store, h2SrcVFATStatus, strSuffix, h2SumVFAT);
+      refineSummaryHistogram(h2SumVFAT, h2SrcVFATOcc, h2SrcVFATStatus);
+      h2SumVFAT->setTitle(h2SrcVFATStatus->getTitle());
+      h2SumVFAT->setXTitle(h2SrcVFATStatus->getAxisTitle(1));
+      h2SumVFAT->setYTitle(h2SrcVFATStatus->getAxisTitle(2));
+    }
   }
 
   store->bookFloat("reportSummary")->Fill(fReportSummary_);
 }
 
+void GEMDQMHarvester::createSummaryHist(edm::Service<DQMStore> &store,
+                                        MonitorElement *h2Src,
+                                        MonitorElement *&h2Sum,
+                                        std::vector<std::string> &listLayers) {
+  store->setCurrentFolder(strDirSummary_);
+
+  Int_t nBinX = h2Src->getNbinsX(), nBinY = h2Src->getNbinsY();
+  h2Sum = store->book2D("reportSummaryMap", "", nBinX, 0.5, nBinX + 0.5, nBinY, 0.5, nBinY + 0.5);
+
+  listLayers.clear();
+  for (Int_t i = 1; i <= nBinX; i++)
+    h2Sum->setBinLabel(i, h2Src->getTH2F()->GetXaxis()->GetBinLabel(i), 1);
+  for (Int_t i = 1; i <= nBinY; i++) {
+    std::string strLabelFull = h2Src->getTH2F()->GetYaxis()->GetBinLabel(i);
+    auto nPos = strLabelFull.find(';');
+    auto strLabel = strLabelFull.substr(0, nPos);
+    listLayers.push_back(strLabelFull.substr(nPos + 1));
+    h2Sum->setBinLabel(i, strLabel, 2);
+  }
+}
+
+void GEMDQMHarvester::createSummaryVFAT(edm::Service<DQMStore> &store,
+                                        MonitorElement *h2Src,
+                                        std::string strSuffix,
+                                        MonitorElement *&h2Sum) {
+  store->setCurrentFolder(strDirStatus_);
+
+  Int_t nBinX = h2Src->getNbinsX(), nBinY = h2Src->getNbinsY();
+  h2Sum = store->book2D("vfat_statusSummary" + strSuffix, "", nBinX, 0.5, nBinX + 0.5, nBinY, 0.5, nBinY + 0.5);
+
+  for (Int_t i = 1; i <= nBinX; i++)
+    h2Sum->setBinLabel(i, h2Src->getTH2F()->GetXaxis()->GetBinLabel(i), 1);
+  for (Int_t i = 1; i <= nBinY; i++)
+    h2Sum->setBinLabel(i, h2Src->getTH2F()->GetYaxis()->GetBinLabel(i), 2);
+}
+
 // FIXME: Need more study about how to summarize
 void GEMDQMHarvester::refineSummaryHistogram(MonitorElement *h2Sum,
-                                             MonitorElement *h2SrcDigiOcc,
-                                             MonitorElement *h2SrcDigiMal,
-                                             MonitorElement *h2SrcCStatus) {
+                                             MonitorElement *h2SrcOcc,
+                                             MonitorElement *h2SrcCStatus,
+                                             MonitorElement *h2SrcMal,
+                                             Bool_t bVarXBin) {
   Int_t nBinY = h2Sum->getNbinsY();
   for (Int_t j = 1; j <= nBinY; j++) {
-    Int_t nBinX = (Int_t)(h2SrcDigiOcc->getBinContent(0, j) + 0.5);
-    h2Sum->setBinContent(0, j, nBinX);
+    Int_t nBinX = h2Sum->getNbinsX();
+    if (bVarXBin) {
+      nBinX = (Int_t)(h2SrcOcc->getBinContent(0, j) + 0.5);
+      h2Sum->setBinContent(0, j, nBinX);
+    }
     for (Int_t i = 1; i <= nBinX; i++) {
-      Float_t fDigiOcc = h2SrcDigiOcc->getBinContent(i, j);
-      Float_t fDigiMal = h2SrcDigiMal->getBinContent(i, j);
-      Float_t fCStatus = h2SrcCStatus->getBinContent(i, j);
+      Float_t fOcc = h2SrcOcc->getBinContent(i, j);
+      Float_t fStatus = h2SrcCStatus->getBinContent(i, j);
+      Float_t fMal = (h2SrcMal != nullptr ? h2SrcMal->getBinContent(i, j) : 0.0);
 
       Float_t fRes = 0;
-      if (fCStatus > 0 || fDigiMal > 0)
+      if (fStatus > 0 || fMal > 0)
         fRes = 2;
-      else if (fDigiOcc > 0)
+      else if (fOcc > 0)
         fRes = 1;
 
       h2Sum->setBinContent(i, j, fRes);

--- a/DQM/GEM/plugins/GEMDigiSource.cc
+++ b/DQM/GEM/plugins/GEMDigiSource.cc
@@ -181,24 +181,24 @@ void GEMDigiSource::analyze(edm::Event const& event, edm::EventSetup const& even
     const BoundPlane& surface = GEMGeometry_->idToDet(gid)->surface();
     if (total_strip_layer.find(key3) == total_strip_layer.end())
       total_strip_layer[key3] = 0;
-    for (auto roll : ch.etaPartitions()) {
-      GEMDetId rId = roll->id();
+    for (auto iEta : ch.etaPartitions()) {
+      GEMDetId rId = iEta->id();
       const auto& digis_in_det = gemDigis->get(rId);
       for (auto d = digis_in_det.first; d != digis_in_det.second; ++d) {
         // Filling of digi occupancy
-        Int_t nIdxVFAT = getVFATNumberByStrip(gid.station(), rId.roll(), d->strip());
+        Int_t nIdxVFAT = getVFATNumberByStrip(gid.station(), rId.ieta(), d->strip());
         mapTotalDigi_layer_.Fill(key3, gid.chamber(), nIdxVFAT + 1);
 
         // Filling of strip
-        mapStripOcc_ieta_.Fill(key3, rId.roll());  // Roll
+        mapStripOcc_ieta_.Fill(key3, rId.ieta());  // Roll
 
-        GlobalPoint strip_global_pos = surface.toGlobal(roll->centreOfStrip(d->strip()));
+        GlobalPoint strip_global_pos = surface.toGlobal(iEta->centreOfStrip(d->strip()));
         Float_t fPhiDeg = ((Float_t)strip_global_pos.phi()) * 180.0 / 3.141592;
         if (fPhiDeg < -5.0)
           fPhiDeg += 360.0;
         mapStripOcc_phi_.Fill(key3, fPhiDeg);  // Phi
 
-        mapStripOccPerCh_.Fill(key4Ch, d->strip(), rId.roll());  // Per chamber
+        mapStripOccPerCh_.Fill(key4Ch, d->strip(), rId.ieta());  // Per chamber
 
         // For total strips
         total_strip_layer[key3]++;


### PR DESCRIPTION
#### PR description:
We've added two classes of plots for the GEM onlineDQM: One is a new representation of VFAT electronics status as a function of chamber vs. VFAT while the other class is a wheel occupancy of recHits.

This is a backport of #33767 to CMSSW_11_3_X

#### PR validation:
Test are done and one can check again by `runTheMatrix` workflows

@jshlee @watson-ij @hyunyong 