### PR TITLE
DTValidation migration to ESConsume

### DIFF
--- a/Validation/DTRecHits/interface/DTHitQualityUtils.h
+++ b/Validation/DTRecHits/interface/DTHitQualityUtils.h
@@ -39,7 +39,7 @@ namespace DTHitQualityUtils {
   /// Find direction and position of a segment (in local RF) from outer and inner
   /// mu SimHit in the RF of object Det
   std::pair<LocalVector, LocalPoint> findMuSimSegmentDirAndPos(
-      const std::pair<const PSimHit *, const PSimHit *> &inAndOutSimHit, const DetId detId, const DTGeometry *muonGeom);
+      const std::pair<const PSimHit *, const PSimHit *> &inAndOutSimHit, const DetId detId, const DTGeometry &muonGeom);
   /// Find the angles from a segment direction:
   /// atan(dx/dz) = "phi"   angle in the chamber RF
   /// atan(dy/dz) = "theta" angle in the chamber RF (note: this has opposite sign

--- a/Validation/DTRecHits/plugins/DTRecHitQuality.cc
+++ b/Validation/DTRecHits/plugins/DTRecHitQuality.cc
@@ -84,8 +84,7 @@ namespace {
 }
 
 // Constructor
-DTRecHitQuality::DTRecHitQuality(const ParameterSet &pset) :
-  muonGeomToken_(esConsumes()) {
+DTRecHitQuality::DTRecHitQuality(const ParameterSet &pset) : muonGeomToken_(esConsumes()) {
   // Get the debug parameter for verbose output
   debug_ = pset.getUntrackedParameter<bool>("debug");
   // the name of the simhit collection
@@ -218,7 +217,7 @@ void DTRecHitQuality::dqmAnalyze(edm::Event const &event,
   }
 
   // Get the DT Geometry
-  const DTGeometry& dtGeom = setup.getData(muonGeomToken_);
+  const DTGeometry &dtGeom = setup.getData(muonGeomToken_);
 
   // Get the SimHit collection from the event
   Handle<PSimHitContainer> simHits;

--- a/Validation/DTRecHits/plugins/DTRecHitQuality.cc
+++ b/Validation/DTRecHits/plugins/DTRecHitQuality.cc
@@ -12,7 +12,6 @@
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "Geometry/DTGeometry/interface/DTGeometry.h"
 #include "Geometry/DTGeometry/interface/DTLayer.h"
-#include "Geometry/Records/interface/MuonGeometryRecord.h"
 #include "Validation/DTRecHits/interface/DTHitQualityUtils.h"
 
 #include "DTRecHitQuality.h"
@@ -85,7 +84,8 @@ namespace {
 }
 
 // Constructor
-DTRecHitQuality::DTRecHitQuality(const ParameterSet &pset) {
+DTRecHitQuality::DTRecHitQuality(const ParameterSet &pset) :
+  muonGeomToken_(esConsumes()) {
   // Get the debug parameter for verbose output
   debug_ = pset.getUntrackedParameter<bool>("debug");
   // the name of the simhit collection
@@ -218,8 +218,7 @@ void DTRecHitQuality::dqmAnalyze(edm::Event const &event,
   }
 
   // Get the DT Geometry
-  ESHandle<DTGeometry> dtGeom;
-  setup.get<MuonGeometryRecord>().get(dtGeom);
+  const DTGeometry& dtGeom = setup.getData(muonGeomToken_);
 
   // Get the SimHit collection from the event
   Handle<PSimHitContainer> simHits;
@@ -248,7 +247,7 @@ void DTRecHitQuality::dqmAnalyze(edm::Event const &event,
 
     // Map rechits per wire
     auto const &recHitsPerWire = map1DRecHitsPerWire(dtRecHits.product());
-    compute(dtGeom.product(), simHitsPerWire, recHitsPerWire, histograms, 1);
+    compute(dtGeom, simHitsPerWire, recHitsPerWire, histograms, 1);
   }
 
   //=======================================================================================
@@ -271,7 +270,7 @@ void DTRecHitQuality::dqmAnalyze(edm::Event const &event,
     } else {
       // Map rechits per wire
       auto const &recHitsPerWire = map1DRecHitsPerWire(segment2Ds.product());
-      compute(dtGeom.product(), simHitsPerWire, recHitsPerWire, histograms, 2);
+      compute(dtGeom, simHitsPerWire, recHitsPerWire, histograms, 2);
     }
   }
 
@@ -296,7 +295,7 @@ void DTRecHitQuality::dqmAnalyze(edm::Event const &event,
 
     // Map rechits per wire
     auto const &recHitsPerWire = map1DRecHitsPerWire(segment4Ds.product());
-    compute(dtGeom.product(), simHitsPerWire, recHitsPerWire, histograms, 3);
+    compute(dtGeom, simHitsPerWire, recHitsPerWire, histograms, 3);
   }
 }
 
@@ -413,7 +412,7 @@ float DTRecHitQuality::recHitDistFromWire(const DTRecHit1D &recHit, const DTLaye
 }
 
 template <typename type>
-void DTRecHitQuality::compute(const DTGeometry *dtGeom,
+void DTRecHitQuality::compute(const DTGeometry &dtGeom,
                               const std::map<DTWireId, std::vector<PSimHit>> &simHitsPerWire,
                               const std::map<DTWireId, std::vector<type>> &recHitsPerWire,
                               Histograms const &histograms,
@@ -427,7 +426,7 @@ void DTRecHitQuality::compute(const DTGeometry *dtGeom,
     vector<PSimHit> simHitsInCell = wireAndSHits.second;
 
     // Get the layer
-    const DTLayer *layer = dtGeom->layer(wireId);
+    const DTLayer *layer = dtGeom.layer(wireId);
 
     // Look for a mu hit in the cell
     const PSimHit *muSimHit = DTHitQualityUtils::findMuSimHit(simHitsInCell);

--- a/Validation/DTRecHits/plugins/DTRecHitQuality.h
+++ b/Validation/DTRecHits/plugins/DTRecHitQuality.h
@@ -24,6 +24,7 @@
 #include "DataFormats/DTRecHit/interface/DTRecSegment2DCollection.h"
 #include "DataFormats/DTRecHit/interface/DTRecSegment4DCollection.h"
 #include "DataFormats/MuonDetId/interface/DTWireId.h"
+#include "Geometry/Records/interface/MuonGeometryRecord.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "SimDataFormats/TrackingHit/interface/PSimHitContainer.h"
 
@@ -61,6 +62,9 @@ private:
 private:
   // Switch for debug output
   bool debug_;
+
+  //Get DT Geometry
+  edm::ESGetToken<DTGeometry, MuonGeometryRecord> muonGeomToken_;
 
   // Root file name
   edm::EDGetTokenT<edm::PSimHitContainer> simHitToken_;
@@ -122,7 +126,7 @@ private:
 
   // Does the real job
   template <typename type>
-  void compute(const DTGeometry *dtGeom,
+  void compute(const DTGeometry &dtGeom,
                const std::map<DTWireId, std::vector<PSimHit>> &simHitsPerWire,
                const std::map<DTWireId, std::vector<type>> &recHitsPerWire,
                dtrechit::Histograms const &histograms,

--- a/Validation/DTRecHits/plugins/DTSegment2DQuality.cc
+++ b/Validation/DTRecHits/plugins/DTSegment2DQuality.cc
@@ -15,7 +15,6 @@
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "Geometry/DTGeometry/interface/DTGeometry.h"
 #include "Geometry/DTGeometry/interface/DTSuperLayer.h"
-#include "Geometry/Records/interface/MuonGeometryRecord.h"
 #include "SimDataFormats/TrackingHit/interface/PSimHitContainer.h"
 #include "Validation/DTRecHits/interface/DTHitQualityUtils.h"
 
@@ -44,7 +43,8 @@ namespace dtsegment2d {
 using namespace dtsegment2d;
 
 // Constructor
-DTSegment2DQuality::DTSegment2DQuality(const ParameterSet &pset) {
+DTSegment2DQuality::DTSegment2DQuality(const ParameterSet &pset) : 
+   muonGeomToken_(esConsumes()) {
   // get the debug parameter for verbose output
   debug_ = pset.getUntrackedParameter<bool>("debug");
   DTHitQualityUtils::debug = debug_;
@@ -90,8 +90,7 @@ void DTSegment2DQuality::dqmAnalyze(edm::Event const &event,
                                     edm::EventSetup const &setup,
                                     Histograms const &histograms) const {
   // Get the DT Geometry
-  ESHandle<DTGeometry> dtGeom;
-  setup.get<MuonGeometryRecord>().get(dtGeom);
+  const DTGeometry& dtGeom = setup.getData(muonGeomToken_);
 
   // Get the SimHit collection from the event
   edm::Handle<PSimHitContainer> simHits;
@@ -151,7 +150,7 @@ void DTSegment2DQuality::dqmAnalyze(edm::Event const &event,
 
     // Find direction and position of the sim Segment in SL RF
     pair<LocalVector, LocalPoint> dirAndPosSimSegm =
-        DTHitQualityUtils::findMuSimSegmentDirAndPos(inAndOutSimHit, (*slId), &(*dtGeom));
+        DTHitQualityUtils::findMuSimSegmentDirAndPos(inAndOutSimHit, (*slId), dtGeom);
 
     LocalVector simSegmLocalDir = dirAndPosSimSegm.first;
     LocalPoint simSegmLocalPos = dirAndPosSimSegm.second;
@@ -159,7 +158,7 @@ void DTSegment2DQuality::dqmAnalyze(edm::Event const &event,
       cout << "  Simulated segment:  local direction " << simSegmLocalDir << endl
            << "                      local position  " << simSegmLocalPos << endl;
     }
-    const DTSuperLayer *superLayer = dtGeom->superLayer(*slId);
+    const DTSuperLayer *superLayer = dtGeom.superLayer(*slId);
     GlobalPoint simSegmGlobalPos = superLayer->toGlobal(simSegmLocalPos);
 
     // Atan(x/z) angle and x position in SL RF

--- a/Validation/DTRecHits/plugins/DTSegment2DQuality.cc
+++ b/Validation/DTRecHits/plugins/DTSegment2DQuality.cc
@@ -43,8 +43,7 @@ namespace dtsegment2d {
 using namespace dtsegment2d;
 
 // Constructor
-DTSegment2DQuality::DTSegment2DQuality(const ParameterSet &pset) : 
-   muonGeomToken_(esConsumes()) {
+DTSegment2DQuality::DTSegment2DQuality(const ParameterSet &pset) : muonGeomToken_(esConsumes()) {
   // get the debug parameter for verbose output
   debug_ = pset.getUntrackedParameter<bool>("debug");
   DTHitQualityUtils::debug = debug_;
@@ -90,7 +89,7 @@ void DTSegment2DQuality::dqmAnalyze(edm::Event const &event,
                                     edm::EventSetup const &setup,
                                     Histograms const &histograms) const {
   // Get the DT Geometry
-  const DTGeometry& dtGeom = setup.getData(muonGeomToken_);
+  const DTGeometry &dtGeom = setup.getData(muonGeomToken_);
 
   // Get the SimHit collection from the event
   edm::Handle<PSimHitContainer> simHits;

--- a/Validation/DTRecHits/plugins/DTSegment2DQuality.h
+++ b/Validation/DTRecHits/plugins/DTSegment2DQuality.h
@@ -54,7 +54,7 @@ private:
 
   //Get DT Geometry
   edm::ESGetToken<DTGeometry, MuonGeometryRecord> muonGeomToken_;
-    
+
   // Sigma resolution on position
   double sigmaResPos_;
 

--- a/Validation/DTRecHits/plugins/DTSegment2DQuality.h
+++ b/Validation/DTRecHits/plugins/DTSegment2DQuality.h
@@ -14,6 +14,7 @@
 
 #include "DQMServices/Core/interface/DQMGlobalEDAnalyzer.h"
 #include "DataFormats/DTRecHit/interface/DTRecSegment2DCollection.h"
+#include "Geometry/Records/interface/MuonGeometryRecord.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "SimDataFormats/TrackingHit/interface/PSimHitContainer.h"
 
@@ -51,6 +52,9 @@ private:
   edm::EDGetTokenT<edm::PSimHitContainer> simHitToken_;
   edm::EDGetTokenT<DTRecSegment2DCollection> segment2DToken_;
 
+  //Get DT Geometry
+  edm::ESGetToken<DTGeometry, MuonGeometryRecord> muonGeomToken_;
+    
   // Sigma resolution on position
   double sigmaResPos_;
 

--- a/Validation/DTRecHits/plugins/DTSegment2DSLPhiQuality.cc
+++ b/Validation/DTRecHits/plugins/DTSegment2DSLPhiQuality.cc
@@ -15,7 +15,6 @@
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "Geometry/DTGeometry/interface/DTChamber.h"
 #include "Geometry/DTGeometry/interface/DTGeometry.h"
-#include "Geometry/Records/interface/MuonGeometryRecord.h"
 #include "SimDataFormats/TrackingHit/interface/PSimHitContainer.h"
 #include "Validation/DTRecHits/interface/DTHitQualityUtils.h"
 
@@ -35,7 +34,8 @@ namespace dtsegment2dsl {
 using namespace dtsegment2dsl;
 
 // Constructor
-DTSegment2DSLPhiQuality::DTSegment2DSLPhiQuality(const ParameterSet &pset) {
+DTSegment2DSLPhiQuality::DTSegment2DSLPhiQuality(const ParameterSet &pset) : 
+  muonGeomToken_(esConsumes()) {
   // Get the debug parameter for verbose output
   debug_ = pset.getUntrackedParameter<bool>("debug");
   DTHitQualityUtils::debug = debug_;
@@ -71,8 +71,7 @@ void DTSegment2DSLPhiQuality::dqmAnalyze(edm::Event const &event,
                                          edm::EventSetup const &setup,
                                          Histograms const &histograms) const {
   // Get the DT Geometry
-  ESHandle<DTGeometry> dtGeom;
-  setup.get<MuonGeometryRecord>().get(dtGeom);
+  const DTGeometry& dtGeom = setup.getData(muonGeomToken_);
 
   // Get the SimHit collection from the event
   edm::Handle<PSimHitContainer> simHits;
@@ -125,11 +124,11 @@ void DTSegment2DSLPhiQuality::dqmAnalyze(edm::Event const &event,
 
     // Find direction and position of the sim Segment in Chamber RF
     pair<LocalVector, LocalPoint> dirAndPosSimSegm =
-        DTHitQualityUtils::findMuSimSegmentDirAndPos(inAndOutSimHit, (*chamberId), &(*dtGeom));
+        DTHitQualityUtils::findMuSimSegmentDirAndPos(inAndOutSimHit, (*chamberId), dtGeom);
 
     LocalVector simSegmLocalDir = dirAndPosSimSegm.first;
     LocalPoint simSegmLocalPos = dirAndPosSimSegm.second;
-    const DTChamber *chamber = dtGeom->chamber(*chamberId);
+    const DTChamber *chamber = dtGeom.chamber(*chamberId);
     GlobalPoint simSegmGlobalPos = chamber->toGlobal(simSegmLocalPos);
 
     // Atan(x/z) angle and x position in SL RF

--- a/Validation/DTRecHits/plugins/DTSegment2DSLPhiQuality.cc
+++ b/Validation/DTRecHits/plugins/DTSegment2DSLPhiQuality.cc
@@ -34,8 +34,7 @@ namespace dtsegment2dsl {
 using namespace dtsegment2dsl;
 
 // Constructor
-DTSegment2DSLPhiQuality::DTSegment2DSLPhiQuality(const ParameterSet &pset) : 
-  muonGeomToken_(esConsumes()) {
+DTSegment2DSLPhiQuality::DTSegment2DSLPhiQuality(const ParameterSet &pset) : muonGeomToken_(esConsumes()) {
   // Get the debug parameter for verbose output
   debug_ = pset.getUntrackedParameter<bool>("debug");
   DTHitQualityUtils::debug = debug_;
@@ -71,7 +70,7 @@ void DTSegment2DSLPhiQuality::dqmAnalyze(edm::Event const &event,
                                          edm::EventSetup const &setup,
                                          Histograms const &histograms) const {
   // Get the DT Geometry
-  const DTGeometry& dtGeom = setup.getData(muonGeomToken_);
+  const DTGeometry &dtGeom = setup.getData(muonGeomToken_);
 
   // Get the SimHit collection from the event
   edm::Handle<PSimHitContainer> simHits;

--- a/Validation/DTRecHits/plugins/DTSegment2DSLPhiQuality.h
+++ b/Validation/DTRecHits/plugins/DTSegment2DSLPhiQuality.h
@@ -14,6 +14,7 @@
 
 #include "DQMServices/Core/interface/DQMGlobalEDAnalyzer.h"
 #include "DataFormats/DTRecHit/interface/DTRecSegment4DCollection.h"
+#include "Geometry/Records/interface/MuonGeometryRecord.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "SimDataFormats/TrackingHit/interface/PSimHitContainer.h"
 
@@ -50,6 +51,9 @@ private:
   edm::InputTag segment4DLabel_;
   edm::EDGetTokenT<edm::PSimHitContainer> simHitToken_;
   edm::EDGetTokenT<DTRecSegment4DCollection> segment4DToken_;
+
+  //Get DT Geometry
+  edm::ESGetToken<DTGeometry, MuonGeometryRecord> muonGeomToken_;
 
   // Sigma resolution on position
   double sigmaResPos_;

--- a/Validation/DTRecHits/plugins/DTSegment4DQuality.cc
+++ b/Validation/DTRecHits/plugins/DTSegment4DQuality.cc
@@ -15,7 +15,6 @@
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "Geometry/DTGeometry/interface/DTChamber.h"
 #include "Geometry/DTGeometry/interface/DTGeometry.h"
-#include "Geometry/Records/interface/MuonGeometryRecord.h"
 #include "SimDataFormats/TrackingHit/interface/PSimHitContainer.h"
 #include "Validation/DTRecHits/interface/DTHitQualityUtils.h"
 
@@ -53,7 +52,8 @@ namespace {
 }
 
 // Constructor
-DTSegment4DQuality::DTSegment4DQuality(const ParameterSet &pset) {
+DTSegment4DQuality::DTSegment4DQuality(const ParameterSet &pset) :
+  muonGeomToken_(esConsumes()) {
   // Get the debug parameter for verbose output
   debug_ = pset.getUntrackedParameter<bool>("debug");
   DTHitQualityUtils::debug = debug_;
@@ -112,8 +112,7 @@ void DTSegment4DQuality::dqmAnalyze(edm::Event const &event,
   const float epsilon = 5e-5;  // numerical accuracy on angles [rad}
 
   // Get the DT Geometry
-  ESHandle<DTGeometry> dtGeom;
-  setup.get<MuonGeometryRecord>().get(dtGeom);
+  const DTGeometry& dtGeom = setup.getData(muonGeomToken_);
 
   // Get the SimHit collection from the event
   edm::Handle<PSimHitContainer> simHits;
@@ -179,11 +178,11 @@ void DTSegment4DQuality::dqmAnalyze(edm::Event const &event,
 
     // Find direction and position of the sim Segment in Chamber RF
     pair<LocalVector, LocalPoint> dirAndPosSimSegm =
-        DTHitQualityUtils::findMuSimSegmentDirAndPos(inAndOutSimHit, chamberId, &(*dtGeom));
+        DTHitQualityUtils::findMuSimSegmentDirAndPos(inAndOutSimHit, chamberId, dtGeom);
 
     LocalVector simSegmLocalDir = dirAndPosSimSegm.first;
     LocalPoint simSegmLocalPos = dirAndPosSimSegm.second;
-    const DTChamber *chamber = dtGeom->chamber(chamberId);
+    const DTChamber *chamber = dtGeom.chamber(chamberId);
     GlobalPoint simSegmGlobalPos = chamber->toGlobal(simSegmLocalPos);
     GlobalVector simSegmGlobalDir = chamber->toGlobal(simSegmLocalDir);
 
@@ -313,7 +312,7 @@ void DTSegment4DQuality::dqmAnalyze(edm::Event const &event,
           alphaBestRHitRZ = DTHitQualityUtils::findSegmentAlphaAndBeta(bestRecHitLocalDirRZ).first;
 
           // Get SimSeg position and Direction in rZ SL frame
-          const DTSuperLayer *sl = dtGeom->superLayer(zedRecSeg->superLayerId());
+          const DTSuperLayer *sl = dtGeom.superLayer(zedRecSeg->superLayerId());
           LocalPoint simSegLocalPosRZTmp = sl->toLocal(simSegmGlobalPos);
           LocalVector simSegLocalDirRZ = sl->toLocal(simSegmGlobalDir);
           simSegLocalPosRZ =

--- a/Validation/DTRecHits/plugins/DTSegment4DQuality.cc
+++ b/Validation/DTRecHits/plugins/DTSegment4DQuality.cc
@@ -52,8 +52,7 @@ namespace {
 }
 
 // Constructor
-DTSegment4DQuality::DTSegment4DQuality(const ParameterSet &pset) :
-  muonGeomToken_(esConsumes()) {
+DTSegment4DQuality::DTSegment4DQuality(const ParameterSet &pset) : muonGeomToken_(esConsumes()) {
   // Get the debug parameter for verbose output
   debug_ = pset.getUntrackedParameter<bool>("debug");
   DTHitQualityUtils::debug = debug_;
@@ -112,7 +111,7 @@ void DTSegment4DQuality::dqmAnalyze(edm::Event const &event,
   const float epsilon = 5e-5;  // numerical accuracy on angles [rad}
 
   // Get the DT Geometry
-  const DTGeometry& dtGeom = setup.getData(muonGeomToken_);
+  const DTGeometry &dtGeom = setup.getData(muonGeomToken_);
 
   // Get the SimHit collection from the event
   edm::Handle<PSimHitContainer> simHits;

--- a/Validation/DTRecHits/plugins/DTSegment4DQuality.h
+++ b/Validation/DTRecHits/plugins/DTSegment4DQuality.h
@@ -27,6 +27,7 @@
 
 #include "DQMServices/Core/interface/DQMGlobalEDAnalyzer.h"
 #include "DataFormats/DTRecHit/interface/DTRecSegment4DCollection.h"
+#include "Geometry/Records/interface/MuonGeometryRecord.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "SimDataFormats/TrackingHit/interface/PSimHitContainer.h"
 
@@ -63,6 +64,9 @@ private:
   edm::InputTag segment4DLabel_;
   edm::EDGetTokenT<edm::PSimHitContainer> simHitToken_;
   edm::EDGetTokenT<DTRecSegment4DCollection> segment4DToken_;
+
+  //Get DT Geometry
+  edm::ESGetToken<DTGeometry, MuonGeometryRecord> muonGeomToken_;
 
   // Sigma resolution on position
   double sigmaResX_;

--- a/Validation/DTRecHits/src/DTHitQualityUtils.cc
+++ b/Validation/DTRecHits/src/DTHitQualityUtils.cc
@@ -139,22 +139,22 @@ pair<const PSimHit *, const PSimHit *> DTHitQualityUtils::findMuSimSegment(
 // mu SimHit in the RF of object Det (Concrete implementation of Det are MuBarSL
 // and MuBarChamber)
 pair<LocalVector, LocalPoint> DTHitQualityUtils::findMuSimSegmentDirAndPos(
-    const pair<const PSimHit *, const PSimHit *> &inAndOutSimHit, const DetId detId, const DTGeometry *muonGeom) {
+    const pair<const PSimHit *, const PSimHit *> &inAndOutSimHit, const DetId detId, const DTGeometry &muonGeom) {
   // FIXME: What should happen if outSimHit = inSimHit???? Now, this case is not
   // considered
   const PSimHit *innermostMuSimHit = inAndOutSimHit.first;
   const PSimHit *outermostMuSimHit = inAndOutSimHit.second;
 
   // Find simulated segment direction from SimHits position
-  const DTLayer *layerIn = muonGeom->layer((DTWireId(innermostMuSimHit->detUnitId())).layerId());
-  const DTLayer *layerOut = muonGeom->layer((DTWireId(outermostMuSimHit->detUnitId())).layerId());
+  const DTLayer *layerIn = muonGeom.layer((DTWireId(innermostMuSimHit->detUnitId())).layerId());
+  const DTLayer *layerOut = muonGeom.layer((DTWireId(outermostMuSimHit->detUnitId())).layerId());
   GlobalPoint inGlobalPos = layerIn->toGlobal(innermostMuSimHit->localPosition());
   GlobalPoint outGlobalPos = layerOut->toGlobal(outermostMuSimHit->localPosition());
-  LocalVector simHitDirection = (muonGeom->idToDet(detId))->toLocal(inGlobalPos - outGlobalPos);
+  LocalVector simHitDirection = (muonGeom.idToDet(detId))->toLocal(inGlobalPos - outGlobalPos);
   simHitDirection = -simHitDirection.unit();
 
   // SimHit position extrapolated at z=0 in the Det RF
-  LocalPoint outLocalPos = (muonGeom->idToDet(detId))->toLocal(outGlobalPos);
+  LocalPoint outLocalPos = (muonGeom.idToDet(detId))->toLocal(outGlobalPos);
   LocalPoint simSegLocalPosition =
       outLocalPos + simHitDirection * (-outLocalPos.z() / (simHitDirection.mag() * cos(simHitDirection.theta())));
 

--- a/Validation/MuonDTDigis/src/MuonDTDigis.cc
+++ b/Validation/MuonDTDigis/src/MuonDTDigis.cc
@@ -16,8 +16,7 @@
 using namespace edm;
 using namespace std;
 
-MuonDTDigis::MuonDTDigis(const ParameterSet &pset) :
-   muonGeomToken_(esConsumes()){
+MuonDTDigis::MuonDTDigis(const ParameterSet &pset) : muonGeomToken_(esConsumes()) {
   // ----------------------
   // Get the debug parameter for verbose output
   verbose_ = pset.getUntrackedParameter<bool>("verbose", false);

--- a/Validation/MuonDTDigis/src/MuonDTDigis.cc
+++ b/Validation/MuonDTDigis/src/MuonDTDigis.cc
@@ -16,7 +16,8 @@
 using namespace edm;
 using namespace std;
 
-MuonDTDigis::MuonDTDigis(const ParameterSet &pset) {
+MuonDTDigis::MuonDTDigis(const ParameterSet &pset) :
+   muonGeomToken_(esConsumes()){
   // ----------------------
   // Get the debug parameter for verbose output
   verbose_ = pset.getUntrackedParameter<bool>("verbose", false);
@@ -165,8 +166,7 @@ void MuonDTDigis::analyze(const Event &event, const EventSetup &eventSetup) {
          << endl;
 
   // Get the DT Geometry
-  ESHandle<DTGeometry> muonGeom;
-  eventSetup.get<MuonGeometryRecord>().get(muonGeom);
+  muonGeom = &eventSetup.getData(muonGeomToken_);
 
   // Get the Digi collection from the event
   Handle<DTDigiCollection> dtDigis;

--- a/Validation/MuonDTDigis/src/MuonDTDigis.h
+++ b/Validation/MuonDTDigis/src/MuonDTDigis.h
@@ -65,6 +65,9 @@ private:
 
   edm::EDGetTokenT<edm::PSimHitContainer> SimHitToken_;
   edm::EDGetTokenT<DTDigiCollection> DigiToken_;
+  //Get DT Geometry
+  edm::ESGetToken<DTGeometry, MuonGeometryRecord> muonGeomToken_;
+  const DTGeometry* muonGeom;
 
   // Switch for debug output
   bool verbose_;

--- a/Validation/MuonDTDigis/src/MuonDTDigis.h
+++ b/Validation/MuonDTDigis/src/MuonDTDigis.h
@@ -67,7 +67,7 @@ private:
   edm::EDGetTokenT<DTDigiCollection> DigiToken_;
   //Get DT Geometry
   edm::ESGetToken<DTGeometry, MuonGeometryRecord> muonGeomToken_;
-  const DTGeometry* muonGeom;
+  const DTGeometry *muonGeom;
 
   // Switch for debug output
   bool verbose_;


### PR DESCRIPTION
PR description:
Following https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideHowToGetDataFromES#In_ED_module

Fixes DT Validation modules for issue #31061

PR validation:
runTheMatrix.py -l limited -i all --ibeos