### PR TITLE
Adding the correction structure to all electrons 

### DIFF
--- a/PhysicsTools/PatAlgos/python/slimming/slimmedElectrons_cfi.py
+++ b/PhysicsTools/PatAlgos/python/slimming/slimmedElectrons_cfi.py
@@ -2,13 +2,13 @@ import FWCore.ParameterSet.Config as cms
 
 slimmedElectrons = cms.EDProducer("PATElectronSlimmer",
    src = cms.InputTag("selectedPatElectrons"),                                  
-   dropSuperCluster = cms.string("pt < 1"), # you can put a cut to slim selectively, e.g. pt < 10
-   dropBasicClusters = cms.string("pt < 1"), # you can put a cut to slim selectively, e.g. pt < 10
-   dropPFlowClusters = cms.string("pt < 1"), # you can put a cut to slim selectively, e.g. pt < 10
-   dropPreshowerClusters = cms.string("pt < 1"), # you can put a cut to slim selectively, e.g. pt < 10
-   dropSeedCluster = cms.string("pt < 1"), # you can put a cut to slim selectively, e.g. pt < 10
-   dropRecHits = cms.string("pt < 1"), # you can put a cut to slim selectively, e.g. pt < 10
-   dropCorrections = cms.string("pt < 1"), # you can put a cut to slim selectively, e.g. pt < 10
+   dropSuperCluster = cms.string("pt < 2"), # you can put a cut to slim selectively, e.g. pt < 10
+   dropBasicClusters = cms.string("pt < 2"), # you can put a cut to slim selectively, e.g. pt < 10
+   dropPFlowClusters = cms.string("pt < 2"), # you can put a cut to slim selectively, e.g. pt < 10
+   dropPreshowerClusters = cms.string("pt < 2"), # you can put a cut to slim selectively, e.g. pt < 10
+   dropSeedCluster = cms.string("pt < 2"), # you can put a cut to slim selectively, e.g. pt < 10
+   dropRecHits = cms.string("pt < 2"), # you can put a cut to slim selectively, e.g. pt < 10
+   dropCorrections = cms.string("pt < 2"), # you can put a cut to slim selectively, e.g. pt < 10
    dropIsolations = cms.string("pt < 5"), # you can put a cut to slim selectively, e.g. pt < 10
    dropShapes = cms.string("pt < 5"), # you can put a cut to slim selectively, e.g. pt < 10
    dropSaturation = cms.string("pt < 5"), # you can put a cut to slim selectively, e.g. pt < 10

--- a/PhysicsTools/PatAlgos/python/slimming/slimmedElectrons_cfi.py
+++ b/PhysicsTools/PatAlgos/python/slimming/slimmedElectrons_cfi.py
@@ -2,13 +2,13 @@ import FWCore.ParameterSet.Config as cms
 
 slimmedElectrons = cms.EDProducer("PATElectronSlimmer",
    src = cms.InputTag("selectedPatElectrons"),                                  
-   dropSuperCluster = cms.string("0"), # you can put a cut to slim selectively, e.g. pt < 10
-   dropBasicClusters = cms.string("0"), # you can put a cut to slim selectively, e.g. pt < 10
-   dropPFlowClusters = cms.string("0"), # you can put a cut to slim selectively, e.g. pt < 10
-   dropPreshowerClusters = cms.string("0"), # you can put a cut to slim selectively, e.g. pt < 10
-   dropSeedCluster = cms.string("0"), # you can put a cut to slim selectively, e.g. pt < 10
-   dropRecHits = cms.string("0"), # you can put a cut to slim selectively, e.g. pt < 10
-   dropCorrections = cms.string("pt < 5"), # you can put a cut to slim selectively, e.g. pt < 10
+   dropSuperCluster = cms.string("pt < 1"), # you can put a cut to slim selectively, e.g. pt < 10
+   dropBasicClusters = cms.string("pt < 1"), # you can put a cut to slim selectively, e.g. pt < 10
+   dropPFlowClusters = cms.string("pt < 1"), # you can put a cut to slim selectively, e.g. pt < 10
+   dropPreshowerClusters = cms.string("pt < 1"), # you can put a cut to slim selectively, e.g. pt < 10
+   dropSeedCluster = cms.string("pt < 1"), # you can put a cut to slim selectively, e.g. pt < 10
+   dropRecHits = cms.string("pt < 1"), # you can put a cut to slim selectively, e.g. pt < 10
+   dropCorrections = cms.string("pt < 1"), # you can put a cut to slim selectively, e.g. pt < 10
    dropIsolations = cms.string("pt < 5"), # you can put a cut to slim selectively, e.g. pt < 10
    dropShapes = cms.string("pt < 5"), # you can put a cut to slim selectively, e.g. pt < 10
    dropSaturation = cms.string("pt < 5"), # you can put a cut to slim selectively, e.g. pt < 10

--- a/PhysicsTools/PatAlgos/python/slimming/slimmedElectrons_cfi.py
+++ b/PhysicsTools/PatAlgos/python/slimming/slimmedElectrons_cfi.py
@@ -2,13 +2,13 @@ import FWCore.ParameterSet.Config as cms
 
 slimmedElectrons = cms.EDProducer("PATElectronSlimmer",
    src = cms.InputTag("selectedPatElectrons"),                                  
-   dropSuperCluster = cms.string("pt < 2"), # you can put a cut to slim selectively, e.g. pt < 10
-   dropBasicClusters = cms.string("pt < 2"), # you can put a cut to slim selectively, e.g. pt < 10
-   dropPFlowClusters = cms.string("pt < 2"), # you can put a cut to slim selectively, e.g. pt < 10
-   dropPreshowerClusters = cms.string("pt < 2"), # you can put a cut to slim selectively, e.g. pt < 10
-   dropSeedCluster = cms.string("pt < 2"), # you can put a cut to slim selectively, e.g. pt < 10
-   dropRecHits = cms.string("pt < 2"), # you can put a cut to slim selectively, e.g. pt < 10
-   dropCorrections = cms.string("pt < 2"), # you can put a cut to slim selectively, e.g. pt < 10
+   dropSuperCluster = cms.string("0"), # you can put a cut to slim selectively, e.g. pt < 10
+   dropBasicClusters = cms.string("0"), # you can put a cut to slim selectively, e.g. pt < 10
+   dropPFlowClusters = cms.string("0"), # you can put a cut to slim selectively, e.g. pt < 10
+   dropPreshowerClusters = cms.string("0"), # you can put a cut to slim selectively, e.g. pt < 10
+   dropSeedCluster = cms.string("0"), # you can put a cut to slim selectively, e.g. pt < 10
+   dropRecHits = cms.string("0"), # you can put a cut to slim selectively, e.g. pt < 10
+   dropCorrections = cms.string("0"), # you can put a cut to slim selectively, e.g. pt < 10
    dropIsolations = cms.string("pt < 5"), # you can put a cut to slim selectively, e.g. pt < 10
    dropShapes = cms.string("pt < 5"), # you can put a cut to slim selectively, e.g. pt < 10
    dropSaturation = cms.string("pt < 5"), # you can put a cut to slim selectively, e.g. pt < 10


### PR DESCRIPTION
In the context of low pT GED electrons for UL, in order to make the
regression work on GED electrons below 5 GeV,
dropCorrections = cms.string(" pt < 5") needs to be removed and made
available for all the electrons here:
https://cmssdt.cern.ch/lxr/source/PhysicsTools/PatAlgos/python/slimming/slimmedElectrons_cfi.py#0003

If this is not done, then the H/E and E/p take result in wrong results since they need to access
correction structure when the electron is regressed.

By removing this condition, we tested on a 136.88811 WF (JetHT - same as used by @bainbrid  for low pT electrons), the sample size increase is 0.04%.


