### PR TITLE
Making miniAOD low pt tracks threshold tunable

### DIFF
--- a/PhysicsTools/PatAlgos/plugins/PATLostTracks.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATLostTracks.cc
@@ -56,6 +56,7 @@ namespace pat {
     const double minHits_;
     const double minPixelHits_;
     const double minPtToStoreProps_;
+    const double minPtToStoreLowQualityProps_;
     const int covarianceVersion_;
     const std::vector<int> covariancePackingSchemas_;
     std::vector<reco::TrackBase::TrackQuality> qualsToAutoAccept_;
@@ -84,6 +85,7 @@ pat::PATLostTracks::PATLostTracks(const edm::ParameterSet& iConfig)
       minHits_(iConfig.getParameter<uint32_t>("minHits")),
       minPixelHits_(iConfig.getParameter<uint32_t>("minPixelHits")),
       minPtToStoreProps_(iConfig.getParameter<double>("minPtToStoreProps")),
+      minPtToStoreLowQualityProps_(iConfig.getParameter<double>("minPtToStoreLowQualityProps")),
       covarianceVersion_(iConfig.getParameter<int>("covarianceVersion")),
       covariancePackingSchemas_(iConfig.getParameter<std::vector<int>>("covariancePackingSchemas")),
       muons_(consumes<reco::MuonCollection>(iConfig.getParameter<edm::InputTag>("muons"))),
@@ -298,7 +300,7 @@ void pat::PATLostTracks::addPackedCandidate(std::vector<pat::PackedCandidate>& c
             *trk, covariancePackingSchemas_[1], covarianceVersion_);  // high quality without pixels
       }
     }
-  } else if (!useLegacySetup_ && trk->pt() > 0.5) {
+  } else if (!useLegacySetup_ && trk->pt() > minPtToStoreLowQualityProps_) {
     if (trk->hitPattern().numberOfValidPixelHits() > 0) {
       cands.back().setTrackProperties(
           *trk, covariancePackingSchemas_[2], covarianceVersion_);  // low quality with pixels

--- a/PhysicsTools/PatAlgos/plugins/PATPackedCandidateProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATPackedCandidateProducer.cc
@@ -93,6 +93,7 @@ namespace pat {
 
     const double minPtForChargedHadronProperties_;
     const double minPtForTrackProperties_;
+    const double minPtForLowQualityTrackProperties_;
     const int covarianceVersion_;
     const std::vector<int> covariancePackingSchemas_;
 
@@ -131,6 +132,7 @@ pat::PATPackedCandidateProducer::PATPackedCandidateProducer(const edm::Parameter
           consumes<edm::ValueMap<bool>>(iConfig.getParameter<edm::InputTag>("chargedHadronIsolation"))),
       minPtForChargedHadronProperties_(iConfig.getParameter<double>("minPtForChargedHadronProperties")),
       minPtForTrackProperties_(iConfig.getParameter<double>("minPtForTrackProperties")),
+      minPtForLowQualityTrackProperties_(iConfig.getParameter<double>("minPtForLowQualityTrackProperties")),
       covarianceVersion_(iConfig.getParameter<int>("covarianceVersion")),
       covariancePackingSchemas_(iConfig.getParameter<std::vector<int>>("covariancePackingSchemas")),
       pfCandidateTypesForHcalDepth_(iConfig.getParameter<std::vector<int>>("pfCandidateTypesForHcalDepth")),
@@ -305,7 +307,7 @@ void pat::PATPackedCandidateProducer::produce(edm::StreamID, edm::Event &iEvent,
         }
         // outPtrP->back().setTrackProperties(*ctrack,tsos.curvilinearError());
       } else {
-        if (outPtrP->back().pt() > 0.5) {
+        if (outPtrP->back().pt() > minPtForLowQualityTrackProperties_) {
           if (ctrack->hitPattern().numberOfValidPixelHits() > 0)
             outPtrP->back().setTrackProperties(*ctrack,
                                                covariancePackingSchemas_[2],

--- a/PhysicsTools/PatAlgos/python/slimming/MicroEventContent_cff.py
+++ b/PhysicsTools/PatAlgos/python/slimming/MicroEventContent_cff.py
@@ -42,6 +42,7 @@ MicroEventContent = cms.PSet(
         'drop *_*_genJets_*',
         'keep *_offlineBeamSpot_*_*',
         'keep *_offlineSlimmedPrimaryVertices_*_*',
+        'keep *_offlineSlimmedPrimaryVerticesWithBS_*_*',
         'keep patPackedCandidates_packedPFCandidates_*_*',
         'keep *_isolatedTracks_*_*',
         # low energy conversions for BPH
@@ -66,8 +67,8 @@ MicroEventContent = cms.PSet(
         'keep *_l1extraParticles_*_*',
         'keep L1GlobalTriggerReadoutRecord_gtDigis_*_*',
         # stage 2 L1 trigger
-        'keep GlobalExtBlkBXVector_simGtExtUnprefireable_*_*', 
-        'keep *_gtStage2Digis__*', 
+        'keep GlobalExtBlkBXVector_simGtExtUnprefireable_*_*',
+        'keep *_gtStage2Digis__*',
         'keep *_gmtStage2Digis_Muon_*',
         'keep *_caloStage2Digis_Jet_*',
         'keep *_caloStage2Digis_Tau_*',
@@ -172,6 +173,7 @@ cms.untracked.PSet(branch = cms.untracked.string("patTriggerObjectStandAlones_sl
 cms.untracked.PSet(branch = cms.untracked.string("patPackedGenParticles_packedGenParticles__*"),splitLevel=cms.untracked.int32(99)),
 cms.untracked.PSet(branch = cms.untracked.string("patJets_slimmedJets__*"),splitLevel=cms.untracked.int32(99)),
 cms.untracked.PSet(branch = cms.untracked.string("recoVertexs_offlineSlimmedPrimaryVertices__*"),splitLevel=cms.untracked.int32(99)),
+cms.untracked.PSet(branch = cms.untracked.string("recoVertexs_offlineSlimmedPrimaryVerticesWithBS__*"),splitLevel=cms.untracked.int32(99)),
 cms.untracked.PSet(branch = cms.untracked.string("recoCaloClusters_reducedEgamma_reducedESClusters_*"),splitLevel=cms.untracked.int32(99)),
 cms.untracked.PSet(branch = cms.untracked.string("EcalRecHitsSorted_reducedEgamma_reducedEBRecHits_*"),splitLevel=cms.untracked.int32(99)),
 cms.untracked.PSet(branch = cms.untracked.string("EcalRecHitsSorted_reducedEgamma_reducedEERecHits_*"),splitLevel=cms.untracked.int32(99)),

--- a/PhysicsTools/PatAlgos/python/slimming/MicroEventContent_cff.py
+++ b/PhysicsTools/PatAlgos/python/slimming/MicroEventContent_cff.py
@@ -42,7 +42,6 @@ MicroEventContent = cms.PSet(
         'drop *_*_genJets_*',
         'keep *_offlineBeamSpot_*_*',
         'keep *_offlineSlimmedPrimaryVertices_*_*',
-        'keep *_offlineSlimmedPrimaryVerticesWithBS_*_*',
         'keep patPackedCandidates_packedPFCandidates_*_*',
         'keep *_isolatedTracks_*_*',
         # low energy conversions for BPH
@@ -67,8 +66,8 @@ MicroEventContent = cms.PSet(
         'keep *_l1extraParticles_*_*',
         'keep L1GlobalTriggerReadoutRecord_gtDigis_*_*',
         # stage 2 L1 trigger
-        'keep GlobalExtBlkBXVector_simGtExtUnprefireable_*_*',
-        'keep *_gtStage2Digis__*',
+        'keep GlobalExtBlkBXVector_simGtExtUnprefireable_*_*', 
+        'keep *_gtStage2Digis__*', 
         'keep *_gmtStage2Digis_Muon_*',
         'keep *_caloStage2Digis_Jet_*',
         'keep *_caloStage2Digis_Tau_*',
@@ -173,7 +172,6 @@ cms.untracked.PSet(branch = cms.untracked.string("patTriggerObjectStandAlones_sl
 cms.untracked.PSet(branch = cms.untracked.string("patPackedGenParticles_packedGenParticles__*"),splitLevel=cms.untracked.int32(99)),
 cms.untracked.PSet(branch = cms.untracked.string("patJets_slimmedJets__*"),splitLevel=cms.untracked.int32(99)),
 cms.untracked.PSet(branch = cms.untracked.string("recoVertexs_offlineSlimmedPrimaryVertices__*"),splitLevel=cms.untracked.int32(99)),
-cms.untracked.PSet(branch = cms.untracked.string("recoVertexs_offlineSlimmedPrimaryVerticesWithBS__*"),splitLevel=cms.untracked.int32(99)),
 cms.untracked.PSet(branch = cms.untracked.string("recoCaloClusters_reducedEgamma_reducedESClusters_*"),splitLevel=cms.untracked.int32(99)),
 cms.untracked.PSet(branch = cms.untracked.string("EcalRecHitsSorted_reducedEgamma_reducedEBRecHits_*"),splitLevel=cms.untracked.int32(99)),
 cms.untracked.PSet(branch = cms.untracked.string("EcalRecHitsSorted_reducedEgamma_reducedEERecHits_*"),splitLevel=cms.untracked.int32(99)),

--- a/PhysicsTools/PatAlgos/python/slimming/lostTracks_cfi.py
+++ b/PhysicsTools/PatAlgos/python/slimming/lostTracks_cfi.py
@@ -19,6 +19,7 @@ lostTracks = cms.EDProducer("PATLostTracks",
     covariancePackingSchemas = packedPFCandidates.covariancePackingSchemas,
     qualsToAutoAccept = cms.vstring("highPurity"),
     minPtToStoreProps = cms.double(0.95),
+    minPtToStoreLowQualityProps = cms.double(0.0),
     passThroughCut = cms.string("pt>2"),
     pvAssignment = primaryVertexAssociation.assignment,
     useLegacySetup = cms.bool(False) #When True: check only if track used to fit vertex[0] and do not store track detailed info for Pt between 0.5 and minPtToStoreProps GeV

--- a/PhysicsTools/PatAlgos/python/slimming/packedPFCandidates_cfi.py
+++ b/PhysicsTools/PatAlgos/python/slimming/packedPFCandidates_cfi.py
@@ -7,7 +7,7 @@ packedPFCandidates = cms.EDProducer("PATPackedCandidateProducer",
     originalTracks = cms.InputTag("generalTracks"),
     vertexAssociator = cms.InputTag("primaryVertexAssociation","original"),
     PuppiSrc = cms.InputTag("puppi"),
-    PuppiNoLepSrc = cms.InputTag("puppiNoLep"),    
+    PuppiNoLepSrc = cms.InputTag("puppiNoLep"),
     chargedHadronIsolation = cms.InputTag("chargedHadronPFTrackIsolation"),
     minPtForChargedHadronProperties = cms.double(3.0),
     secondaryVerticesForWhiteList = cms.VInputTag(
@@ -15,13 +15,14 @@ packedPFCandidates = cms.EDProducer("PATPackedCandidateProducer",
       cms.InputTag("inclusiveCandidateSecondaryVerticesCvsL"),
       cms.InputTag("generalV0Candidates","Kshort"),
       cms.InputTag("generalV0Candidates","Lambda"),
-      ),      
+      ),
     minPtForTrackProperties = cms.double(0.95),
-    covarianceVersion = cms.int32(0), #so far: 0 is Phase0, 1 is Phase1   
-#    covariancePackingSchemas = cms.vint32(1,257,513,769,0),  # a cheaper schema in kb/ev 
+    minPtForLowQualityTrackProperties = cms.double(0.0),
+    covarianceVersion = cms.int32(0), #so far: 0 is Phase0, 1 is Phase1
+#    covariancePackingSchemas = cms.vint32(1,257,513,769,0),  # a cheaper schema in kb/ev
     covariancePackingSchemas = cms.vint32(8,264,520,776,0),   # more accurate schema +0.6kb/ev
     pfCandidateTypesForHcalDepth = cms.vint32(),
-    storeHcalDepthEndcapOnly = cms.bool(False), # switch to store info only for endcap 
+    storeHcalDepthEndcapOnly = cms.bool(False), # switch to store info only for endcap
     storeTiming = cms.bool(False),
     timeMap = cms.InputTag(""),
     timeMapErr = cms.InputTag("")
@@ -42,7 +43,7 @@ run2_HCAL_2018.toModify(packedPFCandidates,
 
 from Configuration.Eras.Modifier_run3_common_cff import run3_common
 run3_common.toModify(packedPFCandidates,
-    pfCandidateTypesForHcalDepth = [], # For now, no PF cand type is considered for addition of Hcal depth energy frac 
+    pfCandidateTypesForHcalDepth = [], # For now, no PF cand type is considered for addition of Hcal depth energy frac
     storeHcalDepthEndcapOnly = False
 )
 


### PR DESCRIPTION
This PR make configurable the minimun pT for a track to be stored with a reduced precision covariance matrix, previously hard coded to be 0.5 GeV. In order to make also the latter configurable at run time a new variable `minPtForLowQualityTrackProperties` is defined in PATPackedCandidateProducer.  This is also added to PATLostTracks with `minPtToStoreLowQualityProps`.

The further proposal is to lower it to 0.0 GeV for PATPackedCandidateProducer. The impact on miniAOD format size is in the range of 2.5-4.5 % (depending on  PU). 

The relative size increase is checked on a a set of Run3 ttbar samples with multiple < PU >:

![relative](https://user-images.githubusercontent.com/16901146/118802681-b7a21e80-b8a2-11eb-9ef1-069da2041ff7.png)

The size per event:

![sizes_ttbar](https://user-images.githubusercontent.com/16901146/118802630-a3f6b800-b8a2-11eb-9dee-c21d6f6b407f.png)

The withBS shown here refers to the addition of `offlineSlimmedPrimaryVerticesWithBS` as in  #33778

Further checks in the references below.

#### PR Validation and Further references

BPH Jamboree December 2020 [here](https://indico.cern.ch/event/979184/contributions/4148171/attachments/2163278/3650677/MiniAOD_Run3_Adriano_JamboreeDic2020.pdf)

xPOG Meeting February 2021 [here](https://indico.cern.ch/event/994581/contributions/4181429/attachments/2196037/3712976/xPOG%20Run3%20MiniAOD%20BPH%20Feb2021.pdf)

Further reference [here](https://github.com/AdrianoDee/miniaodstudies/blob/main/README.md)

For a complete documentation, trk4bph meetings: [1](https://indico.cern.ch/event/983890/), [2](https://indico.cern.ch/event/975219/), [3](https://indico.cern.ch/event/968995/) , [4](https://indico.cern.ch/event/964780/), [5](https://indico.cern.ch/event/963424/), [6](https://indico.cern.ch/event/955820/)
