### PR TITLE
Adding offlineVerticesWithBS to miniAOD

### DIFF
--- a/PhysicsTools/PatAlgos/python/slimming/MicroEventContent_cff.py
+++ b/PhysicsTools/PatAlgos/python/slimming/MicroEventContent_cff.py
@@ -42,6 +42,7 @@ MicroEventContent = cms.PSet(
         'drop *_*_genJets_*',
         'keep *_offlineBeamSpot_*_*',
         'keep *_offlineSlimmedPrimaryVertices_*_*',
+        'keep *_offlineSlimmedPrimaryVerticesWithBS_*_*',
         'keep patPackedCandidates_packedPFCandidates_*_*',
         'keep *_isolatedTracks_*_*',
         # low energy conversions for BPH
@@ -66,8 +67,8 @@ MicroEventContent = cms.PSet(
         'keep *_l1extraParticles_*_*',
         'keep L1GlobalTriggerReadoutRecord_gtDigis_*_*',
         # stage 2 L1 trigger
-        'keep GlobalExtBlkBXVector_simGtExtUnprefireable_*_*', 
-        'keep *_gtStage2Digis__*', 
+        'keep GlobalExtBlkBXVector_simGtExtUnprefireable_*_*',
+        'keep *_gtStage2Digis__*',
         'keep *_gmtStage2Digis_Muon_*',
         'keep *_caloStage2Digis_Jet_*',
         'keep *_caloStage2Digis_Tau_*',
@@ -172,6 +173,7 @@ cms.untracked.PSet(branch = cms.untracked.string("patTriggerObjectStandAlones_sl
 cms.untracked.PSet(branch = cms.untracked.string("patPackedGenParticles_packedGenParticles__*"),splitLevel=cms.untracked.int32(99)),
 cms.untracked.PSet(branch = cms.untracked.string("patJets_slimmedJets__*"),splitLevel=cms.untracked.int32(99)),
 cms.untracked.PSet(branch = cms.untracked.string("recoVertexs_offlineSlimmedPrimaryVertices__*"),splitLevel=cms.untracked.int32(99)),
+cms.untracked.PSet(branch = cms.untracked.string("recoVertexs_offlineSlimmedPrimaryVerticesWithBS__*"),splitLevel=cms.untracked.int32(99)),
 cms.untracked.PSet(branch = cms.untracked.string("recoCaloClusters_reducedEgamma_reducedESClusters_*"),splitLevel=cms.untracked.int32(99)),
 cms.untracked.PSet(branch = cms.untracked.string("EcalRecHitsSorted_reducedEgamma_reducedEBRecHits_*"),splitLevel=cms.untracked.int32(99)),
 cms.untracked.PSet(branch = cms.untracked.string("EcalRecHitsSorted_reducedEgamma_reducedEERecHits_*"),splitLevel=cms.untracked.int32(99)),

--- a/PhysicsTools/PatAlgos/python/slimming/offlineSlimmedPrimaryVerticesWithBS_cfi.py
+++ b/PhysicsTools/PatAlgos/python/slimming/offlineSlimmedPrimaryVerticesWithBS_cfi.py
@@ -2,8 +2,5 @@ import FWCore.ParameterSet.Config as cms
 
 offlineSlimmedPrimaryVerticesWithBS = cms.EDProducer("PATVertexSlimmer",
     src = cms.InputTag("offlinePrimaryVerticesWithBS"),
-#this works also on input file produced with CMSSW<=740pre8, needed for testing or for 72X AOD processing with 74X
     score = cms.InputTag("primaryVertexWithBSAssociation","original"),
-# this need new input file with scores made at RECO time (PR #8102, #8101), enable before MINIAOD prod in 74x
-#   score = cms.InputTag("offlinePrimaryVertices"),
 )

--- a/PhysicsTools/PatAlgos/python/slimming/offlineSlimmedPrimaryVerticesWithBS_cfi.py
+++ b/PhysicsTools/PatAlgos/python/slimming/offlineSlimmedPrimaryVerticesWithBS_cfi.py
@@ -1,0 +1,9 @@
+import FWCore.ParameterSet.Config as cms
+
+offlineSlimmedPrimaryVerticesWithBS = cms.EDProducer("PATVertexSlimmer",
+    src = cms.InputTag("offlinePrimaryVerticesWithBS"),
+#this works also on input file produced with CMSSW<=740pre8, needed for testing or for 72X AOD processing with 74X
+    score = cms.InputTag("primaryVertexAssociationWithBS","original"),
+# this need new input file with scores made at RECO time (PR #8102, #8101), enable before MINIAOD prod in 74x
+#   score = cms.InputTag("offlinePrimaryVertices"),
+)

--- a/PhysicsTools/PatAlgos/python/slimming/offlineSlimmedPrimaryVerticesWithBS_cfi.py
+++ b/PhysicsTools/PatAlgos/python/slimming/offlineSlimmedPrimaryVerticesWithBS_cfi.py
@@ -3,7 +3,7 @@ import FWCore.ParameterSet.Config as cms
 offlineSlimmedPrimaryVerticesWithBS = cms.EDProducer("PATVertexSlimmer",
     src = cms.InputTag("offlinePrimaryVerticesWithBS"),
 #this works also on input file produced with CMSSW<=740pre8, needed for testing or for 72X AOD processing with 74X
-    score = cms.InputTag("primaryVertexAssociationWithBS","original"),
+    score = cms.InputTag("primaryVertexWithBSAssociation","original"),
 # this need new input file with scores made at RECO time (PR #8102, #8101), enable before MINIAOD prod in 74x
 #   score = cms.InputTag("offlinePrimaryVertices"),
 )

--- a/PhysicsTools/PatAlgos/python/slimming/primaryVertexAssociation_cfi.py
+++ b/PhysicsTools/PatAlgos/python/slimming/primaryVertexAssociation_cfi.py
@@ -2,14 +2,14 @@ import FWCore.ParameterSet.Config as cms
 from CommonTools.RecoAlgos.sortedPFPrimaryVertices_cfi import sortedPFPrimaryVertices
 
 primaryVertexAssociation = sortedPFPrimaryVertices.clone(
-  qualityForPrimary = cms.int32(2),
-  produceSortedVertices = cms.bool(False),
-  producePileUpCollection  = cms.bool(False),
-  produceNoPileUpCollection = cms.bool(False)
+  qualityForPrimary = 2,
+  produceSortedVertices = False,
+  producePileUpCollection  = False,
+  produceNoPileUpCollection = False
 )
 
 primaryVertexWithBSAssociation = primaryVertexAssociation.clone(
-  vertices = cms.InputTag("offlinePrimaryVerticesWithBS")
+  vertices = "offlinePrimaryVerticesWithBS"
 )
 
 from Configuration.ProcessModifiers.run2_miniAOD_pp_on_AA_103X_cff import run2_miniAOD_pp_on_AA_103X

--- a/PhysicsTools/PatAlgos/python/slimming/primaryVertexAssociation_cfi.py
+++ b/PhysicsTools/PatAlgos/python/slimming/primaryVertexAssociation_cfi.py
@@ -4,10 +4,17 @@ from CommonTools.RecoAlgos.sortedPFPrimaryVertices_cfi import sortedPFPrimaryVer
 primaryVertexAssociation = sortedPFPrimaryVertices.clone(
   qualityForPrimary = cms.int32(2),
   produceSortedVertices = cms.bool(False),
-  producePileUpCollection  = cms.bool(False),  
+  producePileUpCollection  = cms.bool(False),
   produceNoPileUpCollection = cms.bool(False)
+)
+
+primaryVertexWithBSAssociation = primaryVertexAssociation.clone(
+  vertices = cms.InputTag("offlinePrimaryVerticesWithBS")
 )
 
 from Configuration.ProcessModifiers.run2_miniAOD_pp_on_AA_103X_cff import run2_miniAOD_pp_on_AA_103X
 run2_miniAOD_pp_on_AA_103X.toModify(primaryVertexAssociation,particles = "cleanedParticleFlow")
 primaryVertexAssociationCleaned = primaryVertexAssociation.clone(particles = "cleanedParticleFlow:removed")
+
+run2_miniAOD_pp_on_AA_103X.toModify(primaryVertexWithBSAssociation,particles = "cleanedParticleFlow")
+primaryVertexWithBSAssociationCleaned = primaryVertexWithBSAssociation.clone(particles = "cleanedParticleFlow:removed")

--- a/PhysicsTools/PatAlgos/python/slimming/slimming_cff.py
+++ b/PhysicsTools/PatAlgos/python/slimming/slimming_cff.py
@@ -5,6 +5,7 @@ from PhysicsTools.PatAlgos.slimming.isolatedTracks_cfi import *
 from PhysicsTools.PatAlgos.slimming.lostTracks_cfi import *
 from PhysicsTools.PatAlgos.slimming.offlineSlimmedPrimaryVertices_cfi import *
 from PhysicsTools.PatAlgos.slimming.offlineSlimmedPrimaryVertices4D_cfi import *
+from PhysicsTools.PatAlgos.slimming.offlineSlimmedPrimaryVerticesWithBS_cfi import *
 from PhysicsTools.PatAlgos.slimming.primaryVertexAssociation_cfi import *
 from PhysicsTools.PatAlgos.slimming.genParticles_cff import *
 from PhysicsTools.PatAlgos.slimming.selectedPatTrigger_cfi import *
@@ -34,7 +35,9 @@ slimmingTask = cms.Task(
     lostTracks,
     isolatedTracks,
     offlineSlimmedPrimaryVertices,
+    offlineSlimmedPrimaryVerticesWithBS,
     primaryVertexAssociation,
+    primaryVertexWithBSAssociation,
     genParticlesTask,
     selectedPatTrigger,
     slimmedPatTrigger,
@@ -82,10 +85,11 @@ from RecoHI.HiCentralityAlgos.hiHFfilters_cfi import hiHFfilters
 lostTrackChi2 = packedPFCandidateTrackChi2.clone(candidates = "lostTracks", doLostTracks = True)
 
 pp_on_AA.toReplaceWith(
-    slimmingTask, 
+    slimmingTask,
     cms.Task(slimmingTask.copy(), packedCandidateMuonID, packedPFCandidateTrackChi2, lostTrackChi2, centralityBin, hiHFfilters))
 from Configuration.ProcessModifiers.run2_miniAOD_pp_on_AA_103X_cff import run2_miniAOD_pp_on_AA_103X
 run2_miniAOD_pp_on_AA_103X.toReplaceWith(slimmingTask,cms.Task(primaryVertexAssociationCleaned,slimmingTask.copy()))
+run2_miniAOD_pp_on_AA_103X.toReplaceWith(slimmingTask,cms.Task(primaryVertexWithBSAssociationCleaned,slimmingTask.copy()))
 
 from RecoHI.HiTracking.miniAODVertexRecovery_cff import offlinePrimaryVerticesRecovery, offlineSlimmedPrimaryVerticesRecovery
 pp_on_AA.toReplaceWith(


### PR DESCRIPTION
#### PR description:

This PR adds a new collection of `offlineSlimmedPrimaryVerticesWithBS` to miniAOD format. This collection comes from AOD `offlinePrimaryVerticesWithBS` with the same slimming and association used for `offlineSlimmedPrimaryVertices`.

The relative size increase is checked on a a set of Run3 ttbar samples with multiple <PU>:

![relative](https://user-images.githubusercontent.com/16901146/118802681-b7a21e80-b8a2-11eb-9ef1-069da2041ff7.png)

The size per event:

![sizes_ttbar](https://user-images.githubusercontent.com/16901146/118802630-a3f6b800-b8a2-11eb-9dee-c21d6f6b407f.png)

The v3 shown here is the version with `minPtForLowQualityTrackProperties=0.0` with  #33777 

Further checks in the references below.

#### PR Validation and Further references

BPH Jamboree December 2020 [here](https://indico.cern.ch/event/979184/contributions/4148171/attachments/2163278/3650677/MiniAOD_Run3_Adriano_JamboreeDic2020.pdf)

xPOG Meeting February 2021 [here](https://indico.cern.ch/event/994581/contributions/4181429/attachments/2196037/3712976/xPOG%20Run3%20MiniAOD%20BPH%20Feb2021.pdf)

Further reference [here](https://github.com/AdrianoDee/miniaodstudies/blob/main/README.md)

For a complete documentation, trk4bph meetings: [1](https://indico.cern.ch/event/983890/), [2](https://indico.cern.ch/event/975219/), [3](https://indico.cern.ch/event/968995/) , [4](https://indico.cern.ch/event/964780/), [5](https://indico.cern.ch/event/963424/), [6](https://indico.cern.ch/event/955820/)
