### PR TITLE
Introduce Phase2 InnerTracker TrackingRecHit validation module

### DIFF
--- a/Validation/SiTrackerPhase2V/BuildFile.xml
+++ b/Validation/SiTrackerPhase2V/BuildFile.xml
@@ -1,3 +1,9 @@
+<use name="DQM/SiTrackerPhase2"/>
+<use name="DQMServices/Core"/>
+<use name="DataFormats/TrackerCommon"/>
+<use name="DataFormats/TrackerRecHit2D"/>
+<use name="Geometry/Records"/>
+<use name="Geometry/TrackerGeometryBuilder"/>
 <use name="SimDataFormats/Track"/>
 <use name="SimDataFormats/TrackingHit"/>
 <export>

--- a/Validation/SiTrackerPhase2V/interface/Phase2ITValidateRecHitBase.h
+++ b/Validation/SiTrackerPhase2V/interface/Phase2ITValidateRecHitBase.h
@@ -1,0 +1,86 @@
+#ifndef Validation_SiTrackerPhase2_Phase2ITValidateRecHitBase_h
+#define Validation_SiTrackerPhase2_Phase2ITValidateRecHitBase_h
+
+/**\class Phase2ITValidateRecHitBase  
+ Description:  Base Class for Phase2 Validation
+*/
+//
+// Author: Marco Musich
+// Date: May 2021
+//
+
+// STL includes
+#include <memory>
+#include <map>
+#include <vector>
+#include <algorithm>
+
+// system include files
+#include "DataFormats/Common/interface/Handle.h"
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+#include "DataFormats/TrackerRecHit2D/interface/SiPixelRecHitCollection.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
+#include "Geometry/Records/interface/TrackerTopologyRcd.h"
+#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
+#include "SimDataFormats/TrackingHit/interface/PSimHit.h"
+#include "SimDataFormats/Track/interface/SimTrackContainer.h"
+
+//DQM
+#include "DQMServices/Core/interface/DQMEDAnalyzer.h"
+#include "DQMServices/Core/interface/DQMStore.h"
+#include "DQMServices/Core/interface/MonitorElement.h"
+
+class Phase2ITValidateRecHitBase : public DQMEDAnalyzer {
+public:
+  explicit Phase2ITValidateRecHitBase(const edm::ParameterSet&);
+  ~Phase2ITValidateRecHitBase() override;
+  void bookHistograms(DQMStore::IBooker& ibooker, edm::Run const& iRun, edm::EventSetup const& iSetup) override;
+  void dqmBeginRun(const edm::Run&, const edm::EventSetup&) override;
+  static void fillPSetDescription(edm::ParameterSetDescription& desc);
+
+protected:
+  void bookLayerHistos(DQMStore::IBooker& ibooker, unsigned int det_id, std::string& subdir);
+  void fillRechitHistos(const PSimHit* simhitClosest,
+                        const SiPixelRecHit* rechit,
+                        const std::map<unsigned int, SimTrack>& selectedSimTrackMap,
+                        std::map<std::string, unsigned int>& nrechitLayerMap_primary);
+
+  edm::ParameterSet config_;
+  const edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> geomToken_;
+  const edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> topoToken_;
+  const TrackerGeometry* tkGeom_ = nullptr;
+  const TrackerTopology* tTopo_ = nullptr;
+
+  struct RecHitME {
+    MonitorElement* deltaX = nullptr;
+    MonitorElement* deltaY = nullptr;
+    MonitorElement* pullX = nullptr;
+    MonitorElement* pullY = nullptr;
+    MonitorElement* deltaX_eta = nullptr;
+    MonitorElement* deltaY_eta = nullptr;
+    MonitorElement* deltaX_clsizex = nullptr;
+    MonitorElement* deltaX_clsizey = nullptr;
+    MonitorElement* deltaY_clsizex = nullptr;
+    MonitorElement* deltaY_clsizey = nullptr;
+    MonitorElement* deltaYvsdeltaX = nullptr;
+    MonitorElement* pullX_eta = nullptr;
+    MonitorElement* pullY_eta = nullptr;
+    //For rechits matched to primary simhits
+    MonitorElement* numberRecHitsprimary = nullptr;
+    MonitorElement* pullX_primary;
+    MonitorElement* pullY_primary;
+    MonitorElement* deltaX_primary;
+    MonitorElement* deltaY_primary;
+  };
+  std::map<std::string, RecHitME> layerMEs_;
+};
+
+#endif

--- a/Validation/SiTrackerPhase2V/plugins/Phase2ITValidateRecHit.cc
+++ b/Validation/SiTrackerPhase2V/plugins/Phase2ITValidateRecHit.cc
@@ -25,8 +25,6 @@
 #include "DataFormats/Common/interface/Handle.h"
 #include "DataFormats/Common/interface/DetSetVector.h"
 #include "DataFormats/DetId/interface/DetId.h"
-#include "DataFormats/GeometrySurface/interface/LocalError.h"
-#include "DataFormats/GeometryVector/interface/LocalPoint.h"
 #include "DataFormats/SiPixelDetId/interface/PixelSubdetector.h"
 #include "DataFormats/TrackerRecHit2D/interface/SiPixelRecHitCollection.h"
 #include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
@@ -35,9 +33,6 @@
 #include "Geometry/CommonDetUnit/interface/TrackerGeomDet.h"
 #include "Geometry/CommonDetUnit/interface/PixelGeomDetUnit.h"
 #include "Geometry/CommonDetUnit/interface/PixelGeomDetType.h"
-#include "Geometry/Records/interface/TrackerTopologyRcd.h"
-#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
-#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 //--- for SimHit association
 #include "SimDataFormats/Track/interface/SimTrackContainer.h"
 #include "SimDataFormats/TrackingHit/interface/PSimHit.h"
@@ -47,16 +42,16 @@
 #include "DQMServices/Core/interface/DQMEDAnalyzer.h"
 #include "DQMServices/Core/interface/DQMStore.h"
 #include "DQMServices/Core/interface/MonitorElement.h"
-#include "Validation/SiTrackerPhase2V/interface/TrackerPhase2ValidationUtil.h"
+// base class
+#include "Validation/SiTrackerPhase2V/interface/Phase2ITValidateRecHitBase.h"
 #include "DQM/SiTrackerPhase2/interface/TrackerPhase2DQMUtil.h"
 
-class Phase2ITValidateRecHit : public DQMEDAnalyzer {
+class Phase2ITValidateRecHit : public Phase2ITValidateRecHitBase {
 public:
   explicit Phase2ITValidateRecHit(const edm::ParameterSet&);
   ~Phase2ITValidateRecHit() override;
-  void bookHistograms(DQMStore::IBooker& ibooker, edm::Run const& iRun, edm::EventSetup const& iSetup) override;
   void analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) override;
-  void dqmBeginRun(const edm::Run&, const edm::EventSetup&) override;
+
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 private:
@@ -65,51 +60,21 @@ private:
                     const std::vector<edm::Handle<edm::PSimHitContainer>>& simHits,
                     const std::map<unsigned int, SimTrack>& selectedSimTrackMap);
 
-  void bookLayerHistos(DQMStore::IBooker& ibooker, unsigned int det_id, std::string& subdir);
-
   edm::ParameterSet config_;
   TrackerHitAssociator::Config trackerHitAssociatorConfig_;
   const double simtrackminpt_;
-  std::string geomType_;
   const edm::EDGetTokenT<SiPixelRecHitCollection> tokenRecHitsIT_;
   const edm::EDGetTokenT<edm::SimTrackContainer> simTracksToken_;
   std::vector<edm::EDGetTokenT<edm::PSimHitContainer>> simHitTokens_;
-  const edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> geomToken_;
-  const edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> topoToken_;
-  const TrackerGeometry* tkGeom_ = nullptr;
-  const TrackerTopology* tTopo_ = nullptr;
-  struct RecHitME {
-    MonitorElement* deltaX = nullptr;
-    MonitorElement* deltaY = nullptr;
-    MonitorElement* pullX = nullptr;
-    MonitorElement* pullY = nullptr;
-    MonitorElement* deltaX_eta = nullptr;
-    MonitorElement* deltaY_eta = nullptr;
-    MonitorElement* deltaX_clsizex = nullptr;
-    MonitorElement* deltaX_clsizey = nullptr;
-    MonitorElement* deltaY_clsizex = nullptr;
-    MonitorElement* deltaY_clsizey = nullptr;
-    MonitorElement* deltaYvsdeltaX = nullptr;
-    MonitorElement* pullX_eta = nullptr;
-    MonitorElement* pullY_eta = nullptr;
-    //For rechits matched to primary simhits
-    MonitorElement* numberRecHitsprimary = nullptr;
-    MonitorElement* pullX_primary;
-    MonitorElement* pullY_primary;
-    MonitorElement* deltaX_primary;
-    MonitorElement* deltaY_primary;
-  };
-  std::map<std::string, RecHitME> layerMEs_;
 };
 
 Phase2ITValidateRecHit::Phase2ITValidateRecHit(const edm::ParameterSet& iConfig)
-    : config_(iConfig),
+    : Phase2ITValidateRecHitBase(iConfig),
+      config_(iConfig),
       trackerHitAssociatorConfig_(iConfig, consumesCollector()),
       simtrackminpt_(iConfig.getParameter<double>("SimTrackMinPt")),
       tokenRecHitsIT_(consumes<SiPixelRecHitCollection>(iConfig.getParameter<edm::InputTag>("rechitsSrc"))),
-      simTracksToken_(consumes<edm::SimTrackContainer>(iConfig.getParameter<edm::InputTag>("simTracksSrc"))),
-      geomToken_(esConsumes<TrackerGeometry, TrackerDigiGeometryRecord, edm::Transition::BeginRun>()),
-      topoToken_(esConsumes<TrackerTopology, TrackerTopologyRcd, edm::Transition::BeginRun>()) {
+      simTracksToken_(consumes<edm::SimTrackContainer>(iConfig.getParameter<edm::InputTag>("simTracksSrc"))) {
   edm::LogInfo("Phase2ITValidateRecHit") << ">>> Construct Phase2ITValidateRecHit ";
   for (const auto& itName : config_.getParameter<std::vector<std::string>>("ROUList")) {
     simHitTokens_.push_back(consumes<std::vector<PSimHit>>(edm::InputTag("g4SimHits", itName)));
@@ -155,10 +120,6 @@ void Phase2ITValidateRecHit::fillITHistos(const edm::Event& iEvent,
     // Get the detector unit's id
     unsigned int rawid(DSViter.detId());
     DetId detId(rawid);
-    // Get the geomdet
-    const GeomDetUnit* geomDetunit(tkGeom_->idToDetUnit(detId));
-    if (!geomDetunit)
-      continue;
     // determine the detector we are in
     std::string key = phase2tkutil::getITHistoId(detId.rawId(), tTopo_);
     if (nrechitLayerMap_primary.find(key) == nrechitLayerMap_primary.end()) {
@@ -189,42 +150,10 @@ void Phase2ITValidateRecHit::fillITHistos(const edm::Event& iEvent,
       }    //end loop over simHits
       if (!simhitClosest)
         continue;
-      auto simTrackIt(selectedSimTrackMap.find(simhitClosest->trackId()));
-      bool isPrimary = false;
-      //check if simhit is primary
-      if (simTrackIt != selectedSimTrackMap.end())
-        isPrimary = phase2tkutil::isPrimary(simTrackIt->second, simhitClosest);
-      Local3DPoint simlp(simhitClosest->localPosition());
-      const LocalError& lperr = rechit.localPositionError();
-      double dx = phase2tkutil::cmtomicron * (lp.x() - simlp.x());
-      double dy = phase2tkutil::cmtomicron * (lp.y() - simlp.y());
-      double pullx = 999.;
-      double pully = 999.;
-      if (lperr.xx())
-        pullx = (lp.x() - simlp.x()) / std::sqrt(lperr.xx());
-      if (lperr.yy())
-        pully = (lp.y() - simlp.y()) / std::sqrt(lperr.yy());
-      float eta = geomDetunit->surface().toGlobal(lp).eta();
-      layerMEs_[key].deltaX->Fill(dx);
-      layerMEs_[key].deltaY->Fill(dy);
-      layerMEs_[key].pullX->Fill(pullx);
-      layerMEs_[key].pullY->Fill(pully);
-      layerMEs_[key].deltaX_eta->Fill(eta, dx);
-      layerMEs_[key].deltaY_eta->Fill(eta, dy);
-      layerMEs_[key].deltaX_clsizex->Fill(rechit.cluster()->sizeX(), dx);
-      layerMEs_[key].deltaX_clsizey->Fill(rechit.cluster()->sizeY(), dx);
-      layerMEs_[key].deltaY_clsizex->Fill(rechit.cluster()->sizeX(), dy);
-      layerMEs_[key].deltaY_clsizey->Fill(rechit.cluster()->sizeY(), dy);
-      layerMEs_[key].deltaYvsdeltaX->Fill(dx, dy);
-      layerMEs_[key].pullX_eta->Fill(eta, pullx);
-      layerMEs_[key].pullY_eta->Fill(eta, pully);
-      if (isPrimary) {
-        layerMEs_[key].deltaX_primary->Fill(dx);
-        layerMEs_[key].deltaY_primary->Fill(dy);
-        layerMEs_[key].pullX_primary->Fill(pullx);
-        layerMEs_[key].pullY_primary->Fill(pully);
-      } else
-        nrechitLayerMap_primary[key]--;
+
+      // call the base class method to fill the plots
+      fillRechitHistos(simhitClosest, &rechit, selectedSimTrackMap, nrechitLayerMap_primary);
+
     }  //end loop over rechits of a detId
   }    //End loop over DetSetVector
 
@@ -234,304 +163,13 @@ void Phase2ITValidateRecHit::fillITHistos(const edm::Event& iEvent,
   }
 }
 
-void Phase2ITValidateRecHit::dqmBeginRun(const edm::Run& iRun, const edm::EventSetup& iSetup) {
-  tkGeom_ = &iSetup.getData(geomToken_);
-  tTopo_ = &iSetup.getData(topoToken_);
-}
-//
-// -- Book Histograms
-//
-void Phase2ITValidateRecHit::bookHistograms(DQMStore::IBooker& ibooker,
-                                            edm::Run const& iRun,
-                                            edm::EventSetup const& iSetup) {
-  std::string top_folder = config_.getParameter<std::string>("TopFolderName");
-  edm::LogInfo("Phase2ITValidateRecHit") << " Booking Histograms in : " << top_folder;
-  edm::ESWatcher<TrackerDigiGeometryRecord> theTkDigiGeomWatcher;
-  if (theTkDigiGeomWatcher.check(iSetup)) {
-    for (auto const& det_u : tkGeom_->detUnits()) {
-      //Always check TrackerNumberingBuilder before changing this part
-      if (!(det_u->subDetector() == GeomDetEnumerators::SubDetector::P2PXB ||
-            det_u->subDetector() == GeomDetEnumerators::SubDetector::P2PXEC))
-        continue;
-      unsigned int detId_raw = det_u->geographicalId().rawId();
-      bookLayerHistos(ibooker, detId_raw, top_folder);
-    }
-  }
-}
-//
-void Phase2ITValidateRecHit::bookLayerHistos(DQMStore::IBooker& ibooker, unsigned int det_id, std::string& subdir) {
-  ibooker.cd();
-  std::string key = phase2tkutil::getITHistoId(det_id, tTopo_);
-  if (key.empty())
-    return;
-  if (layerMEs_.find(key) == layerMEs_.end()) {
-    ibooker.cd();
-    RecHitME local_histos;
-    ibooker.setCurrentFolder(subdir + "/" + key);
-    edm::LogInfo("Phase2ITValidateRecHit") << " Booking Histograms in : " << (subdir + "/" + key);
-
-    local_histos.deltaX = phase2tkutil::book1DFromPSet(config_.getParameter<edm::ParameterSet>("DeltaX"), ibooker);
-
-    local_histos.deltaY = phase2tkutil::book1DFromPSet(config_.getParameter<edm::ParameterSet>("DeltaY"), ibooker);
-
-    local_histos.pullX = phase2tkutil::book1DFromPSet(config_.getParameter<edm::ParameterSet>("PullX"), ibooker);
-
-    local_histos.pullY = phase2tkutil::book1DFromPSet(config_.getParameter<edm::ParameterSet>("PullY"), ibooker);
-
-    local_histos.deltaX_eta =
-        phase2tkutil::bookProfile1DFromPSet(config_.getParameter<edm::ParameterSet>("DeltaX_eta"), ibooker);
-
-    local_histos.deltaY_eta =
-        phase2tkutil::bookProfile1DFromPSet(config_.getParameter<edm::ParameterSet>("DeltaY_eta"), ibooker);
-
-    local_histos.deltaX_clsizex =
-        phase2tkutil::bookProfile1DFromPSet(config_.getParameter<edm::ParameterSet>("DeltaX_clsizex"), ibooker);
-
-    local_histos.deltaX_clsizey =
-        phase2tkutil::bookProfile1DFromPSet(config_.getParameter<edm::ParameterSet>("DeltaX_clsizey"), ibooker);
-
-    local_histos.deltaY_clsizex =
-        phase2tkutil::bookProfile1DFromPSet(config_.getParameter<edm::ParameterSet>("DeltaY_clsizex"), ibooker);
-
-    local_histos.deltaY_clsizey =
-        phase2tkutil::bookProfile1DFromPSet(config_.getParameter<edm::ParameterSet>("DeltaY_clsizey"), ibooker);
-
-    local_histos.deltaYvsdeltaX =
-        phase2tkutil::book2DFromPSet(config_.getParameter<edm::ParameterSet>("DeltaY_vs_DeltaX"), ibooker);
-
-    local_histos.pullX_eta =
-        phase2tkutil::bookProfile1DFromPSet(config_.getParameter<edm::ParameterSet>("PullX_eta"), ibooker);
-
-    local_histos.pullY_eta =
-        phase2tkutil::bookProfile1DFromPSet(config_.getParameter<edm::ParameterSet>("PullY_eta"), ibooker);
-    ibooker.setCurrentFolder(subdir + "/" + key + "/PrimarySimHits");
-    //all histos for Primary particles
-    local_histos.numberRecHitsprimary =
-        phase2tkutil::book1DFromPSet(config_.getParameter<edm::ParameterSet>("nRecHits_primary"), ibooker);
-
-    local_histos.deltaX_primary =
-        phase2tkutil::book1DFromPSet(config_.getParameter<edm::ParameterSet>("DeltaX_primary"), ibooker);
-
-    local_histos.deltaY_primary =
-        phase2tkutil::book1DFromPSet(config_.getParameter<edm::ParameterSet>("DeltaY_primary"), ibooker);
-
-    local_histos.pullX_primary =
-        phase2tkutil::book1DFromPSet(config_.getParameter<edm::ParameterSet>("PullX_primary"), ibooker);
-
-    local_histos.pullY_primary =
-        phase2tkutil::book1DFromPSet(config_.getParameter<edm::ParameterSet>("PullY_primary"), ibooker);
-
-    layerMEs_.emplace(key, local_histos);
-  }
-}
 void Phase2ITValidateRecHit::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   // rechitValidIT
   edm::ParameterSetDescription desc;
-  {
-    edm::ParameterSetDescription psd0;
-    psd0.add<std::string>("name", "Delta_X");
-    psd0.add<std::string>("title", "Delta_X;RecHit resolution X coordinate [#mum]");
-    psd0.add<bool>("switch", true);
-    psd0.add<double>("xmin", -100.0);
-    psd0.add<double>("xmax", 100.0);
-    psd0.add<int>("NxBins", 100);
-    desc.add<edm::ParameterSetDescription>("DeltaX", psd0);
-  }
-  {
-    edm::ParameterSetDescription psd0;
-    psd0.add<std::string>("name", "Delta_Y");
-    psd0.add<std::string>("title", "Delta_Y;RecHit resolution Y coordinate [#mum];");
-    psd0.add<bool>("switch", true);
-    psd0.add<double>("xmin", -100.0);
-    psd0.add<double>("xmax", 100.0);
-    psd0.add<int>("NxBins", 100);
-    desc.add<edm::ParameterSetDescription>("DeltaY", psd0);
-  }
-  {
-    edm::ParameterSetDescription psd0;
-    psd0.add<std::string>("name", "Pull_X");
-    psd0.add<std::string>("title", "Pull_X;pull x;");
-    psd0.add<double>("xmin", -4.0);
-    psd0.add<bool>("switch", true);
-    psd0.add<double>("xmax", 4.0);
-    psd0.add<int>("NxBins", 100);
-    desc.add<edm::ParameterSetDescription>("PullX", psd0);
-  }
-  {
-    edm::ParameterSetDescription psd0;
-    psd0.add<std::string>("name", "Pull_Y");
-    psd0.add<std::string>("title", "Pull_Y;pull y;");
-    psd0.add<double>("xmin", -4.0);
-    psd0.add<bool>("switch", true);
-    psd0.add<double>("xmax", 4.0);
-    psd0.add<int>("NxBins", 100);
-    desc.add<edm::ParameterSetDescription>("PullY", psd0);
-  }
-  {
-    edm::ParameterSetDescription psd0;
-    psd0.add<std::string>("name", "Delta_X_vs_Eta");
-    psd0.add<std::string>("title", "Delta_X_vs_Eta;#eta;#Delta x [#mum]");
-    psd0.add<double>("ymin", -100.0);
-    psd0.add<double>("ymax", 100.0);
-    psd0.add<int>("NxBins", 82);
-    psd0.add<bool>("switch", true);
-    psd0.add<double>("xmax", 4.1);
-    psd0.add<double>("xmin", -4.1);
-    desc.add<edm::ParameterSetDescription>("DeltaX_eta", psd0);
-  }
-  {
-    edm::ParameterSetDescription psd0;
-    psd0.add<std::string>("name", "Delta_Y_vs_Eta");
-    psd0.add<std::string>("title", "Delta_Y_vs_Eta;#eta;#Delta y [#mum]");
-    psd0.add<double>("ymin", -100.0);
-    psd0.add<double>("ymax", 100.0);
-    psd0.add<int>("NxBins", 82);
-    psd0.add<bool>("switch", true);
-    psd0.add<double>("xmax", 4.1);
-    psd0.add<double>("xmin", -4.1);
-    desc.add<edm::ParameterSetDescription>("DeltaY_eta", psd0);
-  }
-  {
-    edm::ParameterSetDescription psd0;
-    psd0.add<std::string>("name", "Delta_X_vs_ClusterSizeX");
-    psd0.add<std::string>("title", ";Cluster size X;#Delta x [#mum]");
-    psd0.add<double>("ymin", -100.0);
-    psd0.add<double>("ymax", 100.0);
-    psd0.add<int>("NxBins", 21);
-    psd0.add<bool>("switch", true);
-    psd0.add<double>("xmax", 20.5);
-    psd0.add<double>("xmin", -0.5);
-    desc.add<edm::ParameterSetDescription>("DeltaX_clsizex", psd0);
-  }
-  {
-    edm::ParameterSetDescription psd0;
-    psd0.add<std::string>("name", "Delta_X_vs_ClusterSizeY");
-    psd0.add<std::string>("title", ";Cluster size Y;#Delta y [#mum]");
-    psd0.add<double>("ymin", -100.0);
-    psd0.add<double>("ymax", 100.0);
-    psd0.add<int>("NxBins", 21);
-    psd0.add<bool>("switch", true);
-    psd0.add<double>("xmax", 20.5);
-    psd0.add<double>("xmin", -0.5);
-    desc.add<edm::ParameterSetDescription>("DeltaX_clsizey", psd0);
-  }
-  {
-    edm::ParameterSetDescription psd0;
-    psd0.add<std::string>("name", "Delta_Y_vs_ClusterSizeX");
-    psd0.add<std::string>("title", ";Cluster size Y;#Delta y [#mum]");
-    psd0.add<double>("ymin", -100.0);
-    psd0.add<double>("ymax", 100.0);
-    psd0.add<int>("NxBins", 21);
-    psd0.add<bool>("switch", true);
-    psd0.add<double>("xmax", 20.5);
-    psd0.add<double>("xmin", -0.5);
-    desc.add<edm::ParameterSetDescription>("DeltaY_clsizex", psd0);
-  }
-  {
-    edm::ParameterSetDescription psd0;
-    psd0.add<std::string>("name", "Delta_Y_vs_ClusterSizeY");
-    psd0.add<std::string>("title", ";Cluster size Y;#Delta y [#mum]");
-    psd0.add<double>("ymin", -100.0);
-    psd0.add<double>("ymax", 100.0);
-    psd0.add<int>("NxBins", 21);
-    psd0.add<bool>("switch", true);
-    psd0.add<double>("xmax", 20.5);
-    psd0.add<double>("xmin", -0.5);
-    desc.add<edm::ParameterSetDescription>("DeltaY_clsizey", psd0);
-  }
-  {
-    edm::ParameterSetDescription psd0;
-    psd0.add<std::string>("name", "Delta_Y_vs_DeltaX");
-    psd0.add<std::string>("title", ";#Delta x[#mum];#Delta y[#mum]");
-    psd0.add<bool>("switch", true);
-    psd0.add<double>("ymin", -100.0);
-    psd0.add<double>("ymax", 100.0);
-    psd0.add<int>("NyBins", 100);
-    psd0.add<double>("xmax", 100.);
-    psd0.add<double>("xmin", -100.);
-    psd0.add<int>("NxBins", 100);
-    desc.add<edm::ParameterSetDescription>("DeltaY_vs_DeltaX", psd0);
-  }
 
-  {
-    edm::ParameterSetDescription psd0;
-    psd0.add<std::string>("name", "Pull_X_vs_Eta");
-    psd0.add<std::string>("title", "Pull_X_vs_Eta;#eta;pull x");
-    psd0.add<double>("ymax", 4.0);
-    psd0.add<int>("NxBins", 82);
-    psd0.add<bool>("switch", true);
-    psd0.add<double>("xmax", 4.1);
-    psd0.add<double>("xmin", -4.1);
-    psd0.add<double>("ymin", -4.0);
-    desc.add<edm::ParameterSetDescription>("PullX_eta", psd0);
-  }
-  {
-    edm::ParameterSetDescription psd0;
-    psd0.add<std::string>("name", "Pull_Y_vs_Eta");
-    psd0.add<std::string>("title", "Pull_Y_vs_Eta;#eta;pull y");
-    psd0.add<double>("ymax", 4.0);
-    psd0.add<int>("NxBins", 82);
-    psd0.add<bool>("switch", true);
-    psd0.add<double>("xmax", 4.1);
-    psd0.add<double>("xmin", -4.1);
-    psd0.add<double>("ymin", -4.0);
-    desc.add<edm::ParameterSetDescription>("PullY_eta", psd0);
-  }
-  //simhits primary
-  {
-    edm::ParameterSetDescription psd0;
-    psd0.add<std::string>("name", "Number_RecHits_matched_PrimarySimTrack");
-    psd0.add<std::string>("title", "Number of RecHits matched to primary SimTrack;;");
-    psd0.add<double>("xmin", 0.0);
-    psd0.add<bool>("switch", true);
-    psd0.add<double>("xmax", 0.0);
-    psd0.add<int>("NxBins", 100);
-    desc.add<edm::ParameterSetDescription>("nRecHits_primary", psd0);
-  }
-  {
-    edm::ParameterSetDescription psd0;
-    psd0.add<std::string>("name", "Delta_X_SimHitPrimary");
-    psd0.add<std::string>("title", "Delta_X_SimHitPrimary;#delta x [#mum];");
-    psd0.add<double>("xmin", -100.0);
-    psd0.add<bool>("switch", true);
-    psd0.add<double>("xmax", 100.0);
-    psd0.add<int>("NxBins", 100);
-    desc.add<edm::ParameterSetDescription>("DeltaX_primary", psd0);
-  }
-  {
-    edm::ParameterSetDescription psd0;
-    psd0.add<std::string>("name", "Delta_Y_SimHitPrimary");
-    psd0.add<std::string>("title", "Delta_Y_SimHitPrimary;#Delta y [#mum];");
-    psd0.add<double>("xmin", -100.0);
-    psd0.add<bool>("switch", true);
-    psd0.add<double>("xmax", 100.0);
-    psd0.add<int>("NxBins", 100);
-    desc.add<edm::ParameterSetDescription>("DeltaY_primary", psd0);
-  }
-  {
-    edm::ParameterSetDescription psd0;
-    psd0.add<std::string>("name", "Pull_X_SimHitPrimary");
-    psd0.add<std::string>("title", "Pull_X_SimHitPrimary;pull x;");
-    psd0.add<double>("ymax", 4.0);
-    psd0.add<int>("NxBins", 82);
-    psd0.add<bool>("switch", true);
-    psd0.add<double>("xmax", 4.1);
-    psd0.add<double>("xmin", -4.1);
-    psd0.add<double>("ymin", -4.0);
-    desc.add<edm::ParameterSetDescription>("PullX_primary", psd0);
-  }
-  {
-    edm::ParameterSetDescription psd0;
-    psd0.add<std::string>("name", "Pull_Y_SimHitPrimary");
-    psd0.add<std::string>("title", "Pull_Y_SimHitPrimary;pull y;");
-    psd0.add<double>("ymax", 4.0);
-    psd0.add<int>("NxBins", 82);
-    psd0.add<bool>("switch", true);
-    psd0.add<double>("xmax", 4.1);
-    psd0.add<double>("xmin", -4.1);
-    psd0.add<double>("ymin", -4.0);
-    desc.add<edm::ParameterSetDescription>("PullY_primary", psd0);
-  }
+  // call the base fillPsetDescription for the plots bookings
+  Phase2ITValidateRecHitBase::fillPSetDescription(desc);
+
   //to be used in TrackerHitAssociator
   desc.add<bool>("associatePixel", true);
   desc.add<bool>("associateStrip", false);

--- a/Validation/SiTrackerPhase2V/plugins/Phase2ITValidateTrackingRecHit.cc
+++ b/Validation/SiTrackerPhase2V/plugins/Phase2ITValidateTrackingRecHit.cc
@@ -1,0 +1,575 @@
+// Package:    Phase2ITValidateTrackingRecHit
+// Class:      Phase2ITValidateTrackingRecHit
+//
+/**\class Phase2ITValidateTrackingRecHit Phase2ITValidateTrackingRecHit.cc 
+ Description:  Plugin for Phase2 TrackingRecHit validation
+*/
+//
+// Author: Shubhi Parolia, Suvankar Roy Chowdhury
+// Date: June 2020
+//
+// system include files
+#include <memory>
+#include <map>
+#include <vector>
+#include <algorithm>
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/Framework/interface/ESWatcher.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "DataFormats/Common/interface/Handle.h"
+#include "DataFormats/Common/interface/DetSetVector.h"
+#include "DataFormats/DetId/interface/DetId.h"
+#include "DataFormats/GeometrySurface/interface/LocalError.h"
+#include "DataFormats/GeometryVector/interface/LocalPoint.h"
+#include "DataFormats/SiPixelDetId/interface/PixelSubdetector.h"
+#include "DataFormats/TrackerRecHit2D/interface/SiPixelRecHitCollection.h"
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+#include "DataFormats/TrackReco/interface/Track.h"
+#include "DataFormats/TrackReco/interface/TrackFwd.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
+#include "Geometry/CommonDetUnit/interface/TrackerGeomDet.h"
+#include "Geometry/CommonDetUnit/interface/PixelGeomDetUnit.h"
+#include "Geometry/CommonDetUnit/interface/PixelGeomDetType.h"
+#include "Geometry/Records/interface/TrackerTopologyRcd.h"
+#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
+#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
+//--- for SimHit association
+#include "SimDataFormats/Track/interface/SimTrackContainer.h"
+#include "SimDataFormats/TrackingHit/interface/PSimHit.h"
+#include "SimDataFormats/TrackingHit/interface/PSimHitContainer.h"
+#include "SimTracker/TrackerHitAssociation/interface/TrackerHitAssociator.h"
+//DQM
+#include "DQMServices/Core/interface/DQMEDAnalyzer.h"
+#include "DQMServices/Core/interface/DQMStore.h"
+#include "DQMServices/Core/interface/MonitorElement.h"
+#include "Validation/SiTrackerPhase2V/interface/TrackerPhase2ValidationUtil.h"
+#include "DQM/SiTrackerPhase2/interface/TrackerPhase2DQMUtil.h"
+
+class Phase2ITValidateTrackingRecHit : public DQMEDAnalyzer {
+public:
+  explicit Phase2ITValidateTrackingRecHit(const edm::ParameterSet&);
+  ~Phase2ITValidateTrackingRecHit() override;
+  void bookHistograms(DQMStore::IBooker& ibooker, edm::Run const& iRun, edm::EventSetup const& iSetup) override;
+  void analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) override;
+  void dqmBeginRun(const edm::Run&, const edm::EventSetup&) override;
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+private:
+  void fillITHistos(const edm::Event& iEvent,
+                    const TrackerHitAssociator& associateRecHit,
+                    const std::vector<edm::Handle<edm::PSimHitContainer>>& simHits,
+                    const std::map<unsigned int, SimTrack>& selectedSimTrackMap);
+
+  void bookLayerHistos(DQMStore::IBooker& ibooker, unsigned int det_id, std::string& subdir);
+
+  edm::ParameterSet config_;
+  TrackerHitAssociator::Config trackerHitAssociatorConfig_;
+  const double simtrackminpt_;
+  std::string geomType_;
+  const edm::EDGetTokenT<reco::TrackCollection> tokenTracks_;
+  const edm::EDGetTokenT<SiPixelRecHitCollection> tokenRecHitsIT_;
+  const edm::EDGetTokenT<edm::SimTrackContainer> simTracksToken_;
+  std::vector<edm::EDGetTokenT<edm::PSimHitContainer>> simHitTokens_;
+  const edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> geomToken_;
+  const edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> topoToken_;
+  const TrackerGeometry* tkGeom_ = nullptr;
+  const TrackerTopology* tTopo_ = nullptr;
+  struct RecHitME {
+    MonitorElement* deltaX = nullptr;
+    MonitorElement* deltaY = nullptr;
+    MonitorElement* pullX = nullptr;
+    MonitorElement* pullY = nullptr;
+    MonitorElement* deltaX_eta = nullptr;
+    MonitorElement* deltaY_eta = nullptr;
+    MonitorElement* deltaX_clsizex = nullptr;
+    MonitorElement* deltaX_clsizey = nullptr;
+    MonitorElement* deltaY_clsizex = nullptr;
+    MonitorElement* deltaY_clsizey = nullptr;
+    MonitorElement* deltaYvsdeltaX = nullptr;
+    MonitorElement* pullX_eta = nullptr;
+    MonitorElement* pullY_eta = nullptr;
+    //For rechits matched to primary simhits
+    MonitorElement* numberRecHitsprimary = nullptr;
+    MonitorElement* pullX_primary;
+    MonitorElement* pullY_primary;
+    MonitorElement* deltaX_primary;
+    MonitorElement* deltaY_primary;
+  };
+  std::map<std::string, RecHitME> layerMEs_;
+};
+
+Phase2ITValidateTrackingRecHit::Phase2ITValidateTrackingRecHit(const edm::ParameterSet& iConfig)
+    : config_(iConfig),
+      trackerHitAssociatorConfig_(iConfig, consumesCollector()),
+      simtrackminpt_(iConfig.getParameter<double>("SimTrackMinPt")),
+      tokenTracks_(consumes<reco::TrackCollection>(iConfig.getParameter<edm::InputTag>("tracksSrc"))),
+      simTracksToken_(consumes<edm::SimTrackContainer>(iConfig.getParameter<edm::InputTag>("simTracksSrc"))),
+      geomToken_(esConsumes<TrackerGeometry, TrackerDigiGeometryRecord, edm::Transition::BeginRun>()),
+      topoToken_(esConsumes<TrackerTopology, TrackerTopologyRcd, edm::Transition::BeginRun>()) {
+  edm::LogInfo("Phase2ITValidateRecHit") << ">>> Construct Phase2ITValidateRecHit ";
+  for (const auto& itName : config_.getParameter<std::vector<std::string>>("ROUList")) {
+    simHitTokens_.push_back(consumes<std::vector<PSimHit>>(edm::InputTag("g4SimHits", itName)));
+  }
+}
+//
+Phase2ITValidateTrackingRecHit::~Phase2ITValidateTrackingRecHit() {
+  edm::LogInfo("Phase2ITValidateTrackingRecHit") << ">>> Destroy Phase2ITValidateTrackingRecHit ";
+}
+
+void Phase2ITValidateTrackingRecHit::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  std::vector<edm::Handle<edm::PSimHitContainer>> simHits;
+  for (const auto& itoken : simHitTokens_) {
+    const auto& simHitHandle = iEvent.getHandle(itoken);
+    if (!simHitHandle.isValid())
+      continue;
+    simHits.emplace_back(simHitHandle);
+  }
+  // Get the SimTracks and push them in a map of id, SimTrack
+  const auto& simTracks = iEvent.getHandle(simTracksToken_);
+
+  std::map<unsigned int, SimTrack> selectedSimTrackMap;
+  for (const auto& simTrackIt : *simTracks) {
+    if (simTrackIt.momentum().pt() > simtrackminpt_) {
+      selectedSimTrackMap.emplace(simTrackIt.trackId(), simTrackIt);
+    }
+  }
+  TrackerHitAssociator associateRecHit(iEvent, trackerHitAssociatorConfig_);
+  fillITHistos(iEvent, associateRecHit, simHits, selectedSimTrackMap);
+}
+
+void Phase2ITValidateTrackingRecHit::fillITHistos(const edm::Event& iEvent,
+                                                  const TrackerHitAssociator& associateRecHit,
+                                                  const std::vector<edm::Handle<edm::PSimHitContainer>>& simHits,
+                                                  const std::map<unsigned int, SimTrack>& selectedSimTrackMap) {
+  const auto& tracks = iEvent.getHandle(tokenTracks_);
+  if (!tracks.isValid())
+    return;
+
+  std::map<std::string, unsigned int> nrechitLayerMap_primary;
+
+  // loop over tracks
+  for (const auto& track : *tracks) {
+    // loop over hits
+    for (auto const& hit : track.recHits()) {
+      if (!hit->isValid())
+        continue;
+
+      auto id = hit->geographicalId();
+      // check that we are in the pixel
+      auto subdetid = (id.subdetId());
+      if (!(subdetid == PixelSubdetector::PixelBarrel) && !(subdetid == PixelSubdetector::PixelEndcap))
+        continue;
+
+      const GeomDetUnit* geomDetunit(tkGeom_->idToDetUnit(id));
+      if (!geomDetunit)
+        continue;
+      // determine the detector we are in
+      std::string key = phase2tkutil::getITHistoId(id.rawId(), tTopo_);
+      if (nrechitLayerMap_primary.find(key) == nrechitLayerMap_primary.end()) {
+        nrechitLayerMap_primary.emplace(key, 1);
+      } else {
+        nrechitLayerMap_primary[key] += 1;
+      }
+
+      const SiPixelRecHit* rechit = dynamic_cast<const SiPixelRecHit*>(hit);
+      if (!rechit)
+        continue;
+
+      const std::vector<SimHitIdpr>& matchedId = associateRecHit.associateHitId(*rechit);
+      const PSimHit* simhitClosest = nullptr;
+      float minx = 10000;
+      LocalPoint lp = rechit->localPosition();
+      for (const auto& simHitCol : simHits) {
+        for (const auto& simhitIt : *simHitCol) {
+          if (id.rawId() != simhitIt.detUnitId())
+            continue;
+          for (const auto& mId : matchedId) {
+            if (simhitIt.trackId() == mId.first) {
+              if (!simhitClosest || abs(simhitIt.localPosition().x() - lp.x()) < minx) {
+                minx = abs(simhitIt.localPosition().x() - lp.x());
+                simhitClosest = &simhitIt;
+              }
+            }
+          }
+        }  //end loop over PSimhitcontainers
+      }    //end loop over simHits
+
+      if (!simhitClosest)
+        continue;
+      auto simTrackIt(selectedSimTrackMap.find(simhitClosest->trackId()));
+      bool isPrimary = false;
+      //check if simhit is primary
+      if (simTrackIt != selectedSimTrackMap.end())
+        isPrimary = phase2tkutil::isPrimary(simTrackIt->second, simhitClosest);
+      Local3DPoint simlp(simhitClosest->localPosition());
+      const LocalError& lperr = rechit->localPositionError();
+      double dx = phase2tkutil::cmtomicron * (lp.x() - simlp.x());
+      double dy = phase2tkutil::cmtomicron * (lp.y() - simlp.y());
+      double pullx = 999.;
+      double pully = 999.;
+      if (lperr.xx())
+        pullx = (lp.x() - simlp.x()) / std::sqrt(lperr.xx());
+      if (lperr.yy())
+        pully = (lp.y() - simlp.y()) / std::sqrt(lperr.yy());
+      float eta = geomDetunit->surface().toGlobal(lp).eta();
+      layerMEs_[key].deltaX->Fill(dx);
+      layerMEs_[key].deltaY->Fill(dy);
+      layerMEs_[key].pullX->Fill(pullx);
+      layerMEs_[key].pullY->Fill(pully);
+      layerMEs_[key].deltaX_eta->Fill(eta, dx);
+      layerMEs_[key].deltaY_eta->Fill(eta, dy);
+      layerMEs_[key].deltaX_clsizex->Fill(rechit->cluster()->sizeX(), dx);
+      layerMEs_[key].deltaX_clsizey->Fill(rechit->cluster()->sizeY(), dx);
+      layerMEs_[key].deltaY_clsizex->Fill(rechit->cluster()->sizeX(), dy);
+      layerMEs_[key].deltaY_clsizey->Fill(rechit->cluster()->sizeY(), dy);
+      layerMEs_[key].deltaYvsdeltaX->Fill(dx, dy);
+      layerMEs_[key].pullX_eta->Fill(eta, pullx);
+      layerMEs_[key].pullY_eta->Fill(eta, pully);
+      if (isPrimary) {
+        layerMEs_[key].deltaX_primary->Fill(dx);
+        layerMEs_[key].deltaY_primary->Fill(dy);
+        layerMEs_[key].pullX_primary->Fill(pullx);
+        layerMEs_[key].pullY_primary->Fill(pully);
+      } else
+        nrechitLayerMap_primary[key]--;
+    }  // loop over tracking rechits
+  }    // loop over tracks
+
+  //fill nRecHit counter per layer
+  for (const auto& lme : nrechitLayerMap_primary) {
+    layerMEs_[lme.first].numberRecHitsprimary->Fill(nrechitLayerMap_primary[lme.first]);
+  }
+}
+
+void Phase2ITValidateTrackingRecHit::dqmBeginRun(const edm::Run& iRun, const edm::EventSetup& iSetup) {
+  tkGeom_ = &iSetup.getData(geomToken_);
+  tTopo_ = &iSetup.getData(topoToken_);
+}
+//
+// -- Book Histograms
+//
+void Phase2ITValidateTrackingRecHit::bookHistograms(DQMStore::IBooker& ibooker,
+                                                    edm::Run const& iRun,
+                                                    edm::EventSetup const& iSetup) {
+  std::string top_folder = config_.getParameter<std::string>("TopFolderName");
+  edm::LogInfo("Phase2ITValidateTrackingRecHit") << " Booking Histograms in : " << top_folder;
+  edm::ESWatcher<TrackerDigiGeometryRecord> theTkDigiGeomWatcher;
+  if (theTkDigiGeomWatcher.check(iSetup)) {
+    for (auto const& det_u : tkGeom_->detUnits()) {
+      //Always check TrackerNumberingBuilder before changing this part
+      if (!(det_u->subDetector() == GeomDetEnumerators::SubDetector::P2PXB ||
+            det_u->subDetector() == GeomDetEnumerators::SubDetector::P2PXEC))
+        continue;
+      unsigned int detId_raw = det_u->geographicalId().rawId();
+      bookLayerHistos(ibooker, detId_raw, top_folder);
+    }
+  }
+}
+//
+void Phase2ITValidateTrackingRecHit::bookLayerHistos(DQMStore::IBooker& ibooker,
+                                                     unsigned int det_id,
+                                                     std::string& subdir) {
+  ibooker.cd();
+  std::string key = phase2tkutil::getITHistoId(det_id, tTopo_);
+  if (key.empty())
+    return;
+  if (layerMEs_.find(key) == layerMEs_.end()) {
+    ibooker.cd();
+    RecHitME local_histos;
+    ibooker.setCurrentFolder(subdir + "/" + key);
+    edm::LogInfo("Phase2ITValidateTrackingRecHit") << " Booking Histograms in : " << (subdir + "/" + key);
+
+    local_histos.deltaX = phase2tkutil::book1DFromPSet(config_.getParameter<edm::ParameterSet>("DeltaX"), ibooker);
+
+    local_histos.deltaY = phase2tkutil::book1DFromPSet(config_.getParameter<edm::ParameterSet>("DeltaY"), ibooker);
+
+    local_histos.pullX = phase2tkutil::book1DFromPSet(config_.getParameter<edm::ParameterSet>("PullX"), ibooker);
+
+    local_histos.pullY = phase2tkutil::book1DFromPSet(config_.getParameter<edm::ParameterSet>("PullY"), ibooker);
+
+    local_histos.deltaX_eta =
+        phase2tkutil::bookProfile1DFromPSet(config_.getParameter<edm::ParameterSet>("DeltaX_eta"), ibooker);
+
+    local_histos.deltaY_eta =
+        phase2tkutil::bookProfile1DFromPSet(config_.getParameter<edm::ParameterSet>("DeltaY_eta"), ibooker);
+
+    local_histos.deltaX_clsizex =
+        phase2tkutil::bookProfile1DFromPSet(config_.getParameter<edm::ParameterSet>("DeltaX_clsizex"), ibooker);
+
+    local_histos.deltaX_clsizey =
+        phase2tkutil::bookProfile1DFromPSet(config_.getParameter<edm::ParameterSet>("DeltaX_clsizey"), ibooker);
+
+    local_histos.deltaY_clsizex =
+        phase2tkutil::bookProfile1DFromPSet(config_.getParameter<edm::ParameterSet>("DeltaY_clsizex"), ibooker);
+
+    local_histos.deltaY_clsizey =
+        phase2tkutil::bookProfile1DFromPSet(config_.getParameter<edm::ParameterSet>("DeltaY_clsizey"), ibooker);
+
+    local_histos.deltaYvsdeltaX =
+        phase2tkutil::book2DFromPSet(config_.getParameter<edm::ParameterSet>("DeltaY_vs_DeltaX"), ibooker);
+
+    local_histos.pullX_eta =
+        phase2tkutil::bookProfile1DFromPSet(config_.getParameter<edm::ParameterSet>("PullX_eta"), ibooker);
+
+    local_histos.pullY_eta =
+        phase2tkutil::bookProfile1DFromPSet(config_.getParameter<edm::ParameterSet>("PullY_eta"), ibooker);
+    ibooker.setCurrentFolder(subdir + "/" + key + "/PrimarySimHits");
+    //all histos for Primary particles
+    local_histos.numberRecHitsprimary =
+        phase2tkutil::book1DFromPSet(config_.getParameter<edm::ParameterSet>("nRecHits_primary"), ibooker);
+
+    local_histos.deltaX_primary =
+        phase2tkutil::book1DFromPSet(config_.getParameter<edm::ParameterSet>("DeltaX_primary"), ibooker);
+
+    local_histos.deltaY_primary =
+        phase2tkutil::book1DFromPSet(config_.getParameter<edm::ParameterSet>("DeltaY_primary"), ibooker);
+
+    local_histos.pullX_primary =
+        phase2tkutil::book1DFromPSet(config_.getParameter<edm::ParameterSet>("PullX_primary"), ibooker);
+
+    local_histos.pullY_primary =
+        phase2tkutil::book1DFromPSet(config_.getParameter<edm::ParameterSet>("PullY_primary"), ibooker);
+
+    layerMEs_.emplace(key, local_histos);
+  }
+}
+void Phase2ITValidateTrackingRecHit::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  // rechitValidIT
+  edm::ParameterSetDescription desc;
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<std::string>("name", "Delta_X");
+    psd0.add<std::string>("title", "Delta_X;RecHit resolution X coordinate [#mum]");
+    psd0.add<bool>("switch", true);
+    psd0.add<double>("xmin", -100.0);
+    psd0.add<double>("xmax", 100.0);
+    psd0.add<int>("NxBins", 100);
+    desc.add<edm::ParameterSetDescription>("DeltaX", psd0);
+  }
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<std::string>("name", "Delta_Y");
+    psd0.add<std::string>("title", "Delta_Y;RecHit resolution Y coordinate [#mum];");
+    psd0.add<bool>("switch", true);
+    psd0.add<double>("xmin", -100.0);
+    psd0.add<double>("xmax", 100.0);
+    psd0.add<int>("NxBins", 100);
+    desc.add<edm::ParameterSetDescription>("DeltaY", psd0);
+  }
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<std::string>("name", "Pull_X");
+    psd0.add<std::string>("title", "Pull_X;pull x;");
+    psd0.add<double>("xmin", -4.0);
+    psd0.add<bool>("switch", true);
+    psd0.add<double>("xmax", 4.0);
+    psd0.add<int>("NxBins", 100);
+    desc.add<edm::ParameterSetDescription>("PullX", psd0);
+  }
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<std::string>("name", "Pull_Y");
+    psd0.add<std::string>("title", "Pull_Y;pull y;");
+    psd0.add<double>("xmin", -4.0);
+    psd0.add<bool>("switch", true);
+    psd0.add<double>("xmax", 4.0);
+    psd0.add<int>("NxBins", 100);
+    desc.add<edm::ParameterSetDescription>("PullY", psd0);
+  }
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<std::string>("name", "Delta_X_vs_Eta");
+    psd0.add<std::string>("title", "Delta_X_vs_Eta;#eta;#Delta x [#mum]");
+    psd0.add<double>("ymin", -100.0);
+    psd0.add<double>("ymax", 100.0);
+    psd0.add<int>("NxBins", 82);
+    psd0.add<bool>("switch", true);
+    psd0.add<double>("xmax", 4.1);
+    psd0.add<double>("xmin", -4.1);
+    desc.add<edm::ParameterSetDescription>("DeltaX_eta", psd0);
+  }
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<std::string>("name", "Delta_Y_vs_Eta");
+    psd0.add<std::string>("title", "Delta_Y_vs_Eta;#eta;#Delta y [#mum]");
+    psd0.add<double>("ymin", -100.0);
+    psd0.add<double>("ymax", 100.0);
+    psd0.add<int>("NxBins", 82);
+    psd0.add<bool>("switch", true);
+    psd0.add<double>("xmax", 4.1);
+    psd0.add<double>("xmin", -4.1);
+    desc.add<edm::ParameterSetDescription>("DeltaY_eta", psd0);
+  }
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<std::string>("name", "Delta_X_vs_ClusterSizeX");
+    psd0.add<std::string>("title", ";Cluster size X;#Delta x [#mum]");
+    psd0.add<double>("ymin", -100.0);
+    psd0.add<double>("ymax", 100.0);
+    psd0.add<int>("NxBins", 21);
+    psd0.add<bool>("switch", true);
+    psd0.add<double>("xmax", 20.5);
+    psd0.add<double>("xmin", -0.5);
+    desc.add<edm::ParameterSetDescription>("DeltaX_clsizex", psd0);
+  }
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<std::string>("name", "Delta_X_vs_ClusterSizeY");
+    psd0.add<std::string>("title", ";Cluster size Y;#Delta y [#mum]");
+    psd0.add<double>("ymin", -100.0);
+    psd0.add<double>("ymax", 100.0);
+    psd0.add<int>("NxBins", 21);
+    psd0.add<bool>("switch", true);
+    psd0.add<double>("xmax", 20.5);
+    psd0.add<double>("xmin", -0.5);
+    desc.add<edm::ParameterSetDescription>("DeltaX_clsizey", psd0);
+  }
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<std::string>("name", "Delta_Y_vs_ClusterSizeX");
+    psd0.add<std::string>("title", ";Cluster size Y;#Delta y [#mum]");
+    psd0.add<double>("ymin", -100.0);
+    psd0.add<double>("ymax", 100.0);
+    psd0.add<int>("NxBins", 21);
+    psd0.add<bool>("switch", true);
+    psd0.add<double>("xmax", 20.5);
+    psd0.add<double>("xmin", -0.5);
+    desc.add<edm::ParameterSetDescription>("DeltaY_clsizex", psd0);
+  }
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<std::string>("name", "Delta_Y_vs_ClusterSizeY");
+    psd0.add<std::string>("title", ";Cluster size Y;#Delta y [#mum]");
+    psd0.add<double>("ymin", -100.0);
+    psd0.add<double>("ymax", 100.0);
+    psd0.add<int>("NxBins", 21);
+    psd0.add<bool>("switch", true);
+    psd0.add<double>("xmax", 20.5);
+    psd0.add<double>("xmin", -0.5);
+    desc.add<edm::ParameterSetDescription>("DeltaY_clsizey", psd0);
+  }
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<std::string>("name", "Delta_Y_vs_DeltaX");
+    psd0.add<std::string>("title", ";#Delta x[#mum];#Delta y[#mum]");
+    psd0.add<bool>("switch", true);
+    psd0.add<double>("ymin", -100.0);
+    psd0.add<double>("ymax", 100.0);
+    psd0.add<int>("NyBins", 100);
+    psd0.add<double>("xmax", 100.);
+    psd0.add<double>("xmin", -100.);
+    psd0.add<int>("NxBins", 100);
+    desc.add<edm::ParameterSetDescription>("DeltaY_vs_DeltaX", psd0);
+  }
+
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<std::string>("name", "Pull_X_vs_Eta");
+    psd0.add<std::string>("title", "Pull_X_vs_Eta;#eta;pull x");
+    psd0.add<double>("ymax", 4.0);
+    psd0.add<int>("NxBins", 82);
+    psd0.add<bool>("switch", true);
+    psd0.add<double>("xmax", 4.1);
+    psd0.add<double>("xmin", -4.1);
+    psd0.add<double>("ymin", -4.0);
+    desc.add<edm::ParameterSetDescription>("PullX_eta", psd0);
+  }
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<std::string>("name", "Pull_Y_vs_Eta");
+    psd0.add<std::string>("title", "Pull_Y_vs_Eta;#eta;pull y");
+    psd0.add<double>("ymax", 4.0);
+    psd0.add<int>("NxBins", 82);
+    psd0.add<bool>("switch", true);
+    psd0.add<double>("xmax", 4.1);
+    psd0.add<double>("xmin", -4.1);
+    psd0.add<double>("ymin", -4.0);
+    desc.add<edm::ParameterSetDescription>("PullY_eta", psd0);
+  }
+  //simhits primary
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<std::string>("name", "Number_RecHits_matched_PrimarySimTrack");
+    psd0.add<std::string>("title", "Number of RecHits matched to primary SimTrack;;");
+    psd0.add<double>("xmin", 0.0);
+    psd0.add<bool>("switch", true);
+    psd0.add<double>("xmax", 0.0);
+    psd0.add<int>("NxBins", 100);
+    desc.add<edm::ParameterSetDescription>("nRecHits_primary", psd0);
+  }
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<std::string>("name", "Delta_X_SimHitPrimary");
+    psd0.add<std::string>("title", "Delta_X_SimHitPrimary;#delta x [#mum];");
+    psd0.add<double>("xmin", -100.0);
+    psd0.add<bool>("switch", true);
+    psd0.add<double>("xmax", 100.0);
+    psd0.add<int>("NxBins", 100);
+    desc.add<edm::ParameterSetDescription>("DeltaX_primary", psd0);
+  }
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<std::string>("name", "Delta_Y_SimHitPrimary");
+    psd0.add<std::string>("title", "Delta_Y_SimHitPrimary;#Delta y [#mum];");
+    psd0.add<double>("xmin", -100.0);
+    psd0.add<bool>("switch", true);
+    psd0.add<double>("xmax", 100.0);
+    psd0.add<int>("NxBins", 100);
+    desc.add<edm::ParameterSetDescription>("DeltaY_primary", psd0);
+  }
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<std::string>("name", "Pull_X_SimHitPrimary");
+    psd0.add<std::string>("title", "Pull_X_SimHitPrimary;pull x;");
+    psd0.add<double>("ymax", 4.0);
+    psd0.add<int>("NxBins", 82);
+    psd0.add<bool>("switch", true);
+    psd0.add<double>("xmax", 4.1);
+    psd0.add<double>("xmin", -4.1);
+    psd0.add<double>("ymin", -4.0);
+    desc.add<edm::ParameterSetDescription>("PullX_primary", psd0);
+  }
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<std::string>("name", "Pull_Y_SimHitPrimary");
+    psd0.add<std::string>("title", "Pull_Y_SimHitPrimary;pull y;");
+    psd0.add<double>("ymax", 4.0);
+    psd0.add<int>("NxBins", 82);
+    psd0.add<bool>("switch", true);
+    psd0.add<double>("xmax", 4.1);
+    psd0.add<double>("xmin", -4.1);
+    psd0.add<double>("ymin", -4.0);
+    desc.add<edm::ParameterSetDescription>("PullY_primary", psd0);
+  }
+  //to be used in TrackerHitAssociator
+  desc.add<bool>("associatePixel", true);
+  desc.add<bool>("associateStrip", false);
+  desc.add<bool>("usePhase2Tracker", true);
+  desc.add<bool>("associateRecoTracks", false);
+  desc.add<bool>("associateHitbySimTrack", true);
+  desc.add<edm::InputTag>("pixelSimLinkSrc", edm::InputTag("simSiPixelDigis", "Pixel"));
+  desc.add<std::vector<std::string>>("ROUList",
+                                     {
+                                         "TrackerHitsPixelBarrelLowTof",
+                                         "TrackerHitsPixelBarrelHighTof",
+                                         "TrackerHitsPixelEndcapLowTof",
+                                         "TrackerHitsPixelEndcapHighTof",
+                                     });
+  //
+  desc.add<edm::InputTag>("simTracksSrc", edm::InputTag("g4SimHits"));
+  desc.add<edm::InputTag>("SimVertexSource", edm::InputTag("g4SimHits"));
+  desc.add<double>("SimTrackMinPt", 2.0);
+  desc.add<edm::InputTag>("tracksSrc", edm::InputTag("generalTracks"));
+  desc.add<std::string>("TopFolderName", "TrackerPhase2ITTrackingRecHitV");
+  desc.add<bool>("Verbosity", false);
+  descriptions.add("Phase2ITValidateTrackingRecHit", desc);
+}
+//define this as a plug-in
+DEFINE_FWK_MODULE(Phase2ITValidateTrackingRecHit);

--- a/Validation/SiTrackerPhase2V/plugins/Phase2ITValidateTrackingRecHit.cc
+++ b/Validation/SiTrackerPhase2V/plugins/Phase2ITValidateTrackingRecHit.cc
@@ -25,8 +25,6 @@
 #include "DataFormats/Common/interface/Handle.h"
 #include "DataFormats/Common/interface/DetSetVector.h"
 #include "DataFormats/DetId/interface/DetId.h"
-#include "DataFormats/GeometrySurface/interface/LocalError.h"
-#include "DataFormats/GeometryVector/interface/LocalPoint.h"
 #include "DataFormats/SiPixelDetId/interface/PixelSubdetector.h"
 #include "DataFormats/TrackerRecHit2D/interface/SiPixelRecHitCollection.h"
 #include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
@@ -38,8 +36,6 @@
 #include "Geometry/CommonDetUnit/interface/PixelGeomDetUnit.h"
 #include "Geometry/CommonDetUnit/interface/PixelGeomDetType.h"
 #include "Geometry/Records/interface/TrackerTopologyRcd.h"
-#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
-#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 //--- for SimHit association
 #include "SimDataFormats/Track/interface/SimTrackContainer.h"
 #include "SimDataFormats/TrackingHit/interface/PSimHit.h"
@@ -49,16 +45,15 @@
 #include "DQMServices/Core/interface/DQMEDAnalyzer.h"
 #include "DQMServices/Core/interface/DQMStore.h"
 #include "DQMServices/Core/interface/MonitorElement.h"
-#include "Validation/SiTrackerPhase2V/interface/TrackerPhase2ValidationUtil.h"
+// base class
+#include "Validation/SiTrackerPhase2V/interface/Phase2ITValidateRecHitBase.h"
 #include "DQM/SiTrackerPhase2/interface/TrackerPhase2DQMUtil.h"
 
-class Phase2ITValidateTrackingRecHit : public DQMEDAnalyzer {
+class Phase2ITValidateTrackingRecHit : public Phase2ITValidateRecHitBase {
 public:
   explicit Phase2ITValidateTrackingRecHit(const edm::ParameterSet&);
   ~Phase2ITValidateTrackingRecHit() override;
-  void bookHistograms(DQMStore::IBooker& ibooker, edm::Run const& iRun, edm::EventSetup const& iSetup) override;
   void analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) override;
-  void dqmBeginRun(const edm::Run&, const edm::EventSetup&) override;
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 private:
@@ -66,53 +61,21 @@ private:
                     const TrackerHitAssociator& associateRecHit,
                     const std::vector<edm::Handle<edm::PSimHitContainer>>& simHits,
                     const std::map<unsigned int, SimTrack>& selectedSimTrackMap);
-
-  void bookLayerHistos(DQMStore::IBooker& ibooker, unsigned int det_id, std::string& subdir);
-
   edm::ParameterSet config_;
   TrackerHitAssociator::Config trackerHitAssociatorConfig_;
   const double simtrackminpt_;
-  std::string geomType_;
   const edm::EDGetTokenT<reco::TrackCollection> tokenTracks_;
-  const edm::EDGetTokenT<SiPixelRecHitCollection> tokenRecHitsIT_;
   const edm::EDGetTokenT<edm::SimTrackContainer> simTracksToken_;
   std::vector<edm::EDGetTokenT<edm::PSimHitContainer>> simHitTokens_;
-  const edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> geomToken_;
-  const edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> topoToken_;
-  const TrackerGeometry* tkGeom_ = nullptr;
-  const TrackerTopology* tTopo_ = nullptr;
-  struct RecHitME {
-    MonitorElement* deltaX = nullptr;
-    MonitorElement* deltaY = nullptr;
-    MonitorElement* pullX = nullptr;
-    MonitorElement* pullY = nullptr;
-    MonitorElement* deltaX_eta = nullptr;
-    MonitorElement* deltaY_eta = nullptr;
-    MonitorElement* deltaX_clsizex = nullptr;
-    MonitorElement* deltaX_clsizey = nullptr;
-    MonitorElement* deltaY_clsizex = nullptr;
-    MonitorElement* deltaY_clsizey = nullptr;
-    MonitorElement* deltaYvsdeltaX = nullptr;
-    MonitorElement* pullX_eta = nullptr;
-    MonitorElement* pullY_eta = nullptr;
-    //For rechits matched to primary simhits
-    MonitorElement* numberRecHitsprimary = nullptr;
-    MonitorElement* pullX_primary;
-    MonitorElement* pullY_primary;
-    MonitorElement* deltaX_primary;
-    MonitorElement* deltaY_primary;
-  };
-  std::map<std::string, RecHitME> layerMEs_;
 };
 
 Phase2ITValidateTrackingRecHit::Phase2ITValidateTrackingRecHit(const edm::ParameterSet& iConfig)
-    : config_(iConfig),
+    : Phase2ITValidateRecHitBase(iConfig),
+      config_(iConfig),
       trackerHitAssociatorConfig_(iConfig, consumesCollector()),
       simtrackminpt_(iConfig.getParameter<double>("SimTrackMinPt")),
       tokenTracks_(consumes<reco::TrackCollection>(iConfig.getParameter<edm::InputTag>("tracksSrc"))),
-      simTracksToken_(consumes<edm::SimTrackContainer>(iConfig.getParameter<edm::InputTag>("simTracksSrc"))),
-      geomToken_(esConsumes<TrackerGeometry, TrackerDigiGeometryRecord, edm::Transition::BeginRun>()),
-      topoToken_(esConsumes<TrackerTopology, TrackerTopologyRcd, edm::Transition::BeginRun>()) {
+      simTracksToken_(consumes<edm::SimTrackContainer>(iConfig.getParameter<edm::InputTag>("simTracksSrc"))) {
   edm::LogInfo("Phase2ITValidateRecHit") << ">>> Construct Phase2ITValidateRecHit ";
   for (const auto& itName : config_.getParameter<std::vector<std::string>>("ROUList")) {
     simHitTokens_.push_back(consumes<std::vector<PSimHit>>(edm::InputTag("g4SimHits", itName)));
@@ -203,42 +166,10 @@ void Phase2ITValidateTrackingRecHit::fillITHistos(const edm::Event& iEvent,
 
       if (!simhitClosest)
         continue;
-      auto simTrackIt(selectedSimTrackMap.find(simhitClosest->trackId()));
-      bool isPrimary = false;
-      //check if simhit is primary
-      if (simTrackIt != selectedSimTrackMap.end())
-        isPrimary = phase2tkutil::isPrimary(simTrackIt->second, simhitClosest);
-      Local3DPoint simlp(simhitClosest->localPosition());
-      const LocalError& lperr = rechit->localPositionError();
-      double dx = phase2tkutil::cmtomicron * (lp.x() - simlp.x());
-      double dy = phase2tkutil::cmtomicron * (lp.y() - simlp.y());
-      double pullx = 999.;
-      double pully = 999.;
-      if (lperr.xx())
-        pullx = (lp.x() - simlp.x()) / std::sqrt(lperr.xx());
-      if (lperr.yy())
-        pully = (lp.y() - simlp.y()) / std::sqrt(lperr.yy());
-      float eta = geomDetunit->surface().toGlobal(lp).eta();
-      layerMEs_[key].deltaX->Fill(dx);
-      layerMEs_[key].deltaY->Fill(dy);
-      layerMEs_[key].pullX->Fill(pullx);
-      layerMEs_[key].pullY->Fill(pully);
-      layerMEs_[key].deltaX_eta->Fill(eta, dx);
-      layerMEs_[key].deltaY_eta->Fill(eta, dy);
-      layerMEs_[key].deltaX_clsizex->Fill(rechit->cluster()->sizeX(), dx);
-      layerMEs_[key].deltaX_clsizey->Fill(rechit->cluster()->sizeY(), dx);
-      layerMEs_[key].deltaY_clsizex->Fill(rechit->cluster()->sizeX(), dy);
-      layerMEs_[key].deltaY_clsizey->Fill(rechit->cluster()->sizeY(), dy);
-      layerMEs_[key].deltaYvsdeltaX->Fill(dx, dy);
-      layerMEs_[key].pullX_eta->Fill(eta, pullx);
-      layerMEs_[key].pullY_eta->Fill(eta, pully);
-      if (isPrimary) {
-        layerMEs_[key].deltaX_primary->Fill(dx);
-        layerMEs_[key].deltaY_primary->Fill(dy);
-        layerMEs_[key].pullX_primary->Fill(pullx);
-        layerMEs_[key].pullY_primary->Fill(pully);
-      } else
-        nrechitLayerMap_primary[key]--;
+
+      // call the base class method to fill the plots
+      fillRechitHistos(simhitClosest, rechit, selectedSimTrackMap, nrechitLayerMap_primary);
+
     }  // loop over tracking rechits
   }    // loop over tracks
 
@@ -248,306 +179,13 @@ void Phase2ITValidateTrackingRecHit::fillITHistos(const edm::Event& iEvent,
   }
 }
 
-void Phase2ITValidateTrackingRecHit::dqmBeginRun(const edm::Run& iRun, const edm::EventSetup& iSetup) {
-  tkGeom_ = &iSetup.getData(geomToken_);
-  tTopo_ = &iSetup.getData(topoToken_);
-}
-//
-// -- Book Histograms
-//
-void Phase2ITValidateTrackingRecHit::bookHistograms(DQMStore::IBooker& ibooker,
-                                                    edm::Run const& iRun,
-                                                    edm::EventSetup const& iSetup) {
-  std::string top_folder = config_.getParameter<std::string>("TopFolderName");
-  edm::LogInfo("Phase2ITValidateTrackingRecHit") << " Booking Histograms in : " << top_folder;
-  edm::ESWatcher<TrackerDigiGeometryRecord> theTkDigiGeomWatcher;
-  if (theTkDigiGeomWatcher.check(iSetup)) {
-    for (auto const& det_u : tkGeom_->detUnits()) {
-      //Always check TrackerNumberingBuilder before changing this part
-      if (!(det_u->subDetector() == GeomDetEnumerators::SubDetector::P2PXB ||
-            det_u->subDetector() == GeomDetEnumerators::SubDetector::P2PXEC))
-        continue;
-      unsigned int detId_raw = det_u->geographicalId().rawId();
-      bookLayerHistos(ibooker, detId_raw, top_folder);
-    }
-  }
-}
-//
-void Phase2ITValidateTrackingRecHit::bookLayerHistos(DQMStore::IBooker& ibooker,
-                                                     unsigned int det_id,
-                                                     std::string& subdir) {
-  ibooker.cd();
-  std::string key = phase2tkutil::getITHistoId(det_id, tTopo_);
-  if (key.empty())
-    return;
-  if (layerMEs_.find(key) == layerMEs_.end()) {
-    ibooker.cd();
-    RecHitME local_histos;
-    ibooker.setCurrentFolder(subdir + "/" + key);
-    edm::LogInfo("Phase2ITValidateTrackingRecHit") << " Booking Histograms in : " << (subdir + "/" + key);
-
-    local_histos.deltaX = phase2tkutil::book1DFromPSet(config_.getParameter<edm::ParameterSet>("DeltaX"), ibooker);
-
-    local_histos.deltaY = phase2tkutil::book1DFromPSet(config_.getParameter<edm::ParameterSet>("DeltaY"), ibooker);
-
-    local_histos.pullX = phase2tkutil::book1DFromPSet(config_.getParameter<edm::ParameterSet>("PullX"), ibooker);
-
-    local_histos.pullY = phase2tkutil::book1DFromPSet(config_.getParameter<edm::ParameterSet>("PullY"), ibooker);
-
-    local_histos.deltaX_eta =
-        phase2tkutil::bookProfile1DFromPSet(config_.getParameter<edm::ParameterSet>("DeltaX_eta"), ibooker);
-
-    local_histos.deltaY_eta =
-        phase2tkutil::bookProfile1DFromPSet(config_.getParameter<edm::ParameterSet>("DeltaY_eta"), ibooker);
-
-    local_histos.deltaX_clsizex =
-        phase2tkutil::bookProfile1DFromPSet(config_.getParameter<edm::ParameterSet>("DeltaX_clsizex"), ibooker);
-
-    local_histos.deltaX_clsizey =
-        phase2tkutil::bookProfile1DFromPSet(config_.getParameter<edm::ParameterSet>("DeltaX_clsizey"), ibooker);
-
-    local_histos.deltaY_clsizex =
-        phase2tkutil::bookProfile1DFromPSet(config_.getParameter<edm::ParameterSet>("DeltaY_clsizex"), ibooker);
-
-    local_histos.deltaY_clsizey =
-        phase2tkutil::bookProfile1DFromPSet(config_.getParameter<edm::ParameterSet>("DeltaY_clsizey"), ibooker);
-
-    local_histos.deltaYvsdeltaX =
-        phase2tkutil::book2DFromPSet(config_.getParameter<edm::ParameterSet>("DeltaY_vs_DeltaX"), ibooker);
-
-    local_histos.pullX_eta =
-        phase2tkutil::bookProfile1DFromPSet(config_.getParameter<edm::ParameterSet>("PullX_eta"), ibooker);
-
-    local_histos.pullY_eta =
-        phase2tkutil::bookProfile1DFromPSet(config_.getParameter<edm::ParameterSet>("PullY_eta"), ibooker);
-    ibooker.setCurrentFolder(subdir + "/" + key + "/PrimarySimHits");
-    //all histos for Primary particles
-    local_histos.numberRecHitsprimary =
-        phase2tkutil::book1DFromPSet(config_.getParameter<edm::ParameterSet>("nRecHits_primary"), ibooker);
-
-    local_histos.deltaX_primary =
-        phase2tkutil::book1DFromPSet(config_.getParameter<edm::ParameterSet>("DeltaX_primary"), ibooker);
-
-    local_histos.deltaY_primary =
-        phase2tkutil::book1DFromPSet(config_.getParameter<edm::ParameterSet>("DeltaY_primary"), ibooker);
-
-    local_histos.pullX_primary =
-        phase2tkutil::book1DFromPSet(config_.getParameter<edm::ParameterSet>("PullX_primary"), ibooker);
-
-    local_histos.pullY_primary =
-        phase2tkutil::book1DFromPSet(config_.getParameter<edm::ParameterSet>("PullY_primary"), ibooker);
-
-    layerMEs_.emplace(key, local_histos);
-  }
-}
 void Phase2ITValidateTrackingRecHit::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   // rechitValidIT
   edm::ParameterSetDescription desc;
-  {
-    edm::ParameterSetDescription psd0;
-    psd0.add<std::string>("name", "Delta_X");
-    psd0.add<std::string>("title", "Delta_X;RecHit resolution X coordinate [#mum]");
-    psd0.add<bool>("switch", true);
-    psd0.add<double>("xmin", -100.0);
-    psd0.add<double>("xmax", 100.0);
-    psd0.add<int>("NxBins", 100);
-    desc.add<edm::ParameterSetDescription>("DeltaX", psd0);
-  }
-  {
-    edm::ParameterSetDescription psd0;
-    psd0.add<std::string>("name", "Delta_Y");
-    psd0.add<std::string>("title", "Delta_Y;RecHit resolution Y coordinate [#mum];");
-    psd0.add<bool>("switch", true);
-    psd0.add<double>("xmin", -100.0);
-    psd0.add<double>("xmax", 100.0);
-    psd0.add<int>("NxBins", 100);
-    desc.add<edm::ParameterSetDescription>("DeltaY", psd0);
-  }
-  {
-    edm::ParameterSetDescription psd0;
-    psd0.add<std::string>("name", "Pull_X");
-    psd0.add<std::string>("title", "Pull_X;pull x;");
-    psd0.add<double>("xmin", -4.0);
-    psd0.add<bool>("switch", true);
-    psd0.add<double>("xmax", 4.0);
-    psd0.add<int>("NxBins", 100);
-    desc.add<edm::ParameterSetDescription>("PullX", psd0);
-  }
-  {
-    edm::ParameterSetDescription psd0;
-    psd0.add<std::string>("name", "Pull_Y");
-    psd0.add<std::string>("title", "Pull_Y;pull y;");
-    psd0.add<double>("xmin", -4.0);
-    psd0.add<bool>("switch", true);
-    psd0.add<double>("xmax", 4.0);
-    psd0.add<int>("NxBins", 100);
-    desc.add<edm::ParameterSetDescription>("PullY", psd0);
-  }
-  {
-    edm::ParameterSetDescription psd0;
-    psd0.add<std::string>("name", "Delta_X_vs_Eta");
-    psd0.add<std::string>("title", "Delta_X_vs_Eta;#eta;#Delta x [#mum]");
-    psd0.add<double>("ymin", -100.0);
-    psd0.add<double>("ymax", 100.0);
-    psd0.add<int>("NxBins", 82);
-    psd0.add<bool>("switch", true);
-    psd0.add<double>("xmax", 4.1);
-    psd0.add<double>("xmin", -4.1);
-    desc.add<edm::ParameterSetDescription>("DeltaX_eta", psd0);
-  }
-  {
-    edm::ParameterSetDescription psd0;
-    psd0.add<std::string>("name", "Delta_Y_vs_Eta");
-    psd0.add<std::string>("title", "Delta_Y_vs_Eta;#eta;#Delta y [#mum]");
-    psd0.add<double>("ymin", -100.0);
-    psd0.add<double>("ymax", 100.0);
-    psd0.add<int>("NxBins", 82);
-    psd0.add<bool>("switch", true);
-    psd0.add<double>("xmax", 4.1);
-    psd0.add<double>("xmin", -4.1);
-    desc.add<edm::ParameterSetDescription>("DeltaY_eta", psd0);
-  }
-  {
-    edm::ParameterSetDescription psd0;
-    psd0.add<std::string>("name", "Delta_X_vs_ClusterSizeX");
-    psd0.add<std::string>("title", ";Cluster size X;#Delta x [#mum]");
-    psd0.add<double>("ymin", -100.0);
-    psd0.add<double>("ymax", 100.0);
-    psd0.add<int>("NxBins", 21);
-    psd0.add<bool>("switch", true);
-    psd0.add<double>("xmax", 20.5);
-    psd0.add<double>("xmin", -0.5);
-    desc.add<edm::ParameterSetDescription>("DeltaX_clsizex", psd0);
-  }
-  {
-    edm::ParameterSetDescription psd0;
-    psd0.add<std::string>("name", "Delta_X_vs_ClusterSizeY");
-    psd0.add<std::string>("title", ";Cluster size Y;#Delta y [#mum]");
-    psd0.add<double>("ymin", -100.0);
-    psd0.add<double>("ymax", 100.0);
-    psd0.add<int>("NxBins", 21);
-    psd0.add<bool>("switch", true);
-    psd0.add<double>("xmax", 20.5);
-    psd0.add<double>("xmin", -0.5);
-    desc.add<edm::ParameterSetDescription>("DeltaX_clsizey", psd0);
-  }
-  {
-    edm::ParameterSetDescription psd0;
-    psd0.add<std::string>("name", "Delta_Y_vs_ClusterSizeX");
-    psd0.add<std::string>("title", ";Cluster size Y;#Delta y [#mum]");
-    psd0.add<double>("ymin", -100.0);
-    psd0.add<double>("ymax", 100.0);
-    psd0.add<int>("NxBins", 21);
-    psd0.add<bool>("switch", true);
-    psd0.add<double>("xmax", 20.5);
-    psd0.add<double>("xmin", -0.5);
-    desc.add<edm::ParameterSetDescription>("DeltaY_clsizex", psd0);
-  }
-  {
-    edm::ParameterSetDescription psd0;
-    psd0.add<std::string>("name", "Delta_Y_vs_ClusterSizeY");
-    psd0.add<std::string>("title", ";Cluster size Y;#Delta y [#mum]");
-    psd0.add<double>("ymin", -100.0);
-    psd0.add<double>("ymax", 100.0);
-    psd0.add<int>("NxBins", 21);
-    psd0.add<bool>("switch", true);
-    psd0.add<double>("xmax", 20.5);
-    psd0.add<double>("xmin", -0.5);
-    desc.add<edm::ParameterSetDescription>("DeltaY_clsizey", psd0);
-  }
-  {
-    edm::ParameterSetDescription psd0;
-    psd0.add<std::string>("name", "Delta_Y_vs_DeltaX");
-    psd0.add<std::string>("title", ";#Delta x[#mum];#Delta y[#mum]");
-    psd0.add<bool>("switch", true);
-    psd0.add<double>("ymin", -100.0);
-    psd0.add<double>("ymax", 100.0);
-    psd0.add<int>("NyBins", 100);
-    psd0.add<double>("xmax", 100.);
-    psd0.add<double>("xmin", -100.);
-    psd0.add<int>("NxBins", 100);
-    desc.add<edm::ParameterSetDescription>("DeltaY_vs_DeltaX", psd0);
-  }
 
-  {
-    edm::ParameterSetDescription psd0;
-    psd0.add<std::string>("name", "Pull_X_vs_Eta");
-    psd0.add<std::string>("title", "Pull_X_vs_Eta;#eta;pull x");
-    psd0.add<double>("ymax", 4.0);
-    psd0.add<int>("NxBins", 82);
-    psd0.add<bool>("switch", true);
-    psd0.add<double>("xmax", 4.1);
-    psd0.add<double>("xmin", -4.1);
-    psd0.add<double>("ymin", -4.0);
-    desc.add<edm::ParameterSetDescription>("PullX_eta", psd0);
-  }
-  {
-    edm::ParameterSetDescription psd0;
-    psd0.add<std::string>("name", "Pull_Y_vs_Eta");
-    psd0.add<std::string>("title", "Pull_Y_vs_Eta;#eta;pull y");
-    psd0.add<double>("ymax", 4.0);
-    psd0.add<int>("NxBins", 82);
-    psd0.add<bool>("switch", true);
-    psd0.add<double>("xmax", 4.1);
-    psd0.add<double>("xmin", -4.1);
-    psd0.add<double>("ymin", -4.0);
-    desc.add<edm::ParameterSetDescription>("PullY_eta", psd0);
-  }
-  //simhits primary
-  {
-    edm::ParameterSetDescription psd0;
-    psd0.add<std::string>("name", "Number_RecHits_matched_PrimarySimTrack");
-    psd0.add<std::string>("title", "Number of RecHits matched to primary SimTrack;;");
-    psd0.add<double>("xmin", 0.0);
-    psd0.add<bool>("switch", true);
-    psd0.add<double>("xmax", 0.0);
-    psd0.add<int>("NxBins", 100);
-    desc.add<edm::ParameterSetDescription>("nRecHits_primary", psd0);
-  }
-  {
-    edm::ParameterSetDescription psd0;
-    psd0.add<std::string>("name", "Delta_X_SimHitPrimary");
-    psd0.add<std::string>("title", "Delta_X_SimHitPrimary;#delta x [#mum];");
-    psd0.add<double>("xmin", -100.0);
-    psd0.add<bool>("switch", true);
-    psd0.add<double>("xmax", 100.0);
-    psd0.add<int>("NxBins", 100);
-    desc.add<edm::ParameterSetDescription>("DeltaX_primary", psd0);
-  }
-  {
-    edm::ParameterSetDescription psd0;
-    psd0.add<std::string>("name", "Delta_Y_SimHitPrimary");
-    psd0.add<std::string>("title", "Delta_Y_SimHitPrimary;#Delta y [#mum];");
-    psd0.add<double>("xmin", -100.0);
-    psd0.add<bool>("switch", true);
-    psd0.add<double>("xmax", 100.0);
-    psd0.add<int>("NxBins", 100);
-    desc.add<edm::ParameterSetDescription>("DeltaY_primary", psd0);
-  }
-  {
-    edm::ParameterSetDescription psd0;
-    psd0.add<std::string>("name", "Pull_X_SimHitPrimary");
-    psd0.add<std::string>("title", "Pull_X_SimHitPrimary;pull x;");
-    psd0.add<double>("ymax", 4.0);
-    psd0.add<int>("NxBins", 82);
-    psd0.add<bool>("switch", true);
-    psd0.add<double>("xmax", 4.1);
-    psd0.add<double>("xmin", -4.1);
-    psd0.add<double>("ymin", -4.0);
-    desc.add<edm::ParameterSetDescription>("PullX_primary", psd0);
-  }
-  {
-    edm::ParameterSetDescription psd0;
-    psd0.add<std::string>("name", "Pull_Y_SimHitPrimary");
-    psd0.add<std::string>("title", "Pull_Y_SimHitPrimary;pull y;");
-    psd0.add<double>("ymax", 4.0);
-    psd0.add<int>("NxBins", 82);
-    psd0.add<bool>("switch", true);
-    psd0.add<double>("xmax", 4.1);
-    psd0.add<double>("xmin", -4.1);
-    psd0.add<double>("ymin", -4.0);
-    desc.add<edm::ParameterSetDescription>("PullY_primary", psd0);
-  }
+  // call the base fillPsetDescription for the plots bookings
+  Phase2ITValidateRecHitBase::fillPSetDescription(desc);
+
   //to be used in TrackerHitAssociator
   desc.add<bool>("associatePixel", true);
   desc.add<bool>("associateStrip", false);

--- a/Validation/SiTrackerPhase2V/python/Phase2ITValidateTrackingRecHit_cff.py
+++ b/Validation/SiTrackerPhase2V/python/Phase2ITValidateTrackingRecHit_cff.py
@@ -1,0 +1,8 @@
+import FWCore.ParameterSet.Config as cms
+from Validation.SiTrackerPhase2V.Phase2ITValidateTrackingRecHit_cfi import Phase2ITValidateTrackingRecHit
+trackingRechitValidIT = Phase2ITValidateTrackingRecHit.clone()
+
+from Configuration.ProcessModifiers.premix_stage2_cff import premix_stage2
+premix_stage2.toModify(trackingRechitValidIT,
+    pixelSimLinkSrc = "mixData:PixelDigiSimLink",
+)

--- a/Validation/SiTrackerPhase2V/python/Phase2TrackerValidationFirstStep_cff.py
+++ b/Validation/SiTrackerPhase2V/python/Phase2TrackerValidationFirstStep_cff.py
@@ -1,13 +1,14 @@
 import FWCore.ParameterSet.Config as cms
 from Validation.SiTrackerPhase2V.Phase2TrackerValidateDigi_cff import *
 from Validation.SiTrackerPhase2V.Phase2ITValidateRecHit_cff import *
+from Validation.SiTrackerPhase2V.Phase2ITValidateTrackingRecHit_cff import *
 from Validation.SiTrackerPhase2V.Phase2ITValidateCluster_cff import *
 from Validation.SiTrackerPhase2V.Phase2OTValidateCluster_cff import *
-
 
 trackerphase2ValidationSource = cms.Sequence(pixDigiValid  
                                              + otDigiValid 
                                              + rechitValidIT
+                                             + trackingRechitValidIT
                                              + clusterValidIT
                                              + clusterValidOT
 )

--- a/Validation/SiTrackerPhase2V/src/Phase2ITValidateRecHitBase.cc
+++ b/Validation/SiTrackerPhase2V/src/Phase2ITValidateRecHitBase.cc
@@ -1,0 +1,355 @@
+#include "FWCore/Framework/interface/ESWatcher.h"
+#include "Validation/SiTrackerPhase2V/interface/Phase2ITValidateRecHitBase.h"
+#include "Validation/SiTrackerPhase2V/interface/TrackerPhase2ValidationUtil.h"
+#include "DQM/SiTrackerPhase2/interface/TrackerPhase2DQMUtil.h"
+#include "SimDataFormats/Track/interface/SimTrackContainer.h"
+#include "DataFormats/DetId/interface/DetId.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
+#include "Geometry/CommonDetUnit/interface/TrackerGeomDet.h"
+#include "Geometry/CommonDetUnit/interface/PixelGeomDetUnit.h"
+#include "Geometry/CommonDetUnit/interface/PixelGeomDetType.h"
+#include "SimDataFormats/TrackingHit/interface/PSimHitContainer.h"
+#include "DataFormats/SiPixelDetId/interface/PixelSubdetector.h"
+#include "DataFormats/GeometrySurface/interface/LocalError.h"
+#include "DataFormats/GeometryVector/interface/LocalPoint.h"
+
+Phase2ITValidateRecHitBase::~Phase2ITValidateRecHitBase() = default;
+
+Phase2ITValidateRecHitBase::Phase2ITValidateRecHitBase(const edm::ParameterSet& iConfig)
+    : config_(iConfig),
+      geomToken_(esConsumes<TrackerGeometry, TrackerDigiGeometryRecord, edm::Transition::BeginRun>()),
+      topoToken_(esConsumes<TrackerTopology, TrackerTopologyRcd, edm::Transition::BeginRun>()) {
+  edm::LogInfo("Phase2ITValidateRecHitBase") << ">>> Construct Phase2ITValidateRecHitBase ";
+}
+
+void Phase2ITValidateRecHitBase::dqmBeginRun(const edm::Run& iRun, const edm::EventSetup& iSetup) {
+  tkGeom_ = &iSetup.getData(geomToken_);
+  tTopo_ = &iSetup.getData(topoToken_);
+}
+//
+// -- Book Histograms
+//
+void Phase2ITValidateRecHitBase::bookHistograms(DQMStore::IBooker& ibooker,
+                                                edm::Run const& iRun,
+                                                edm::EventSetup const& iSetup) {
+  std::string top_folder = config_.getParameter<std::string>("TopFolderName");
+  edm::LogInfo("Phase2ITValidateRecHitBase") << " Booking Histograms in : " << top_folder;
+  edm::ESWatcher<TrackerDigiGeometryRecord> theTkDigiGeomWatcher;
+  if (theTkDigiGeomWatcher.check(iSetup)) {
+    for (auto const& det_u : tkGeom_->detUnits()) {
+      //Always check TrackerNumberingBuilder before changing this part
+      if (!(det_u->subDetector() == GeomDetEnumerators::SubDetector::P2PXB ||
+            det_u->subDetector() == GeomDetEnumerators::SubDetector::P2PXEC))
+        continue;
+      unsigned int detId_raw = det_u->geographicalId().rawId();
+      bookLayerHistos(ibooker, detId_raw, top_folder);
+    }
+  }
+}
+
+//
+void Phase2ITValidateRecHitBase::bookLayerHistos(DQMStore::IBooker& ibooker, unsigned int det_id, std::string& subdir) {
+  ibooker.cd();
+  std::string key = phase2tkutil::getITHistoId(det_id, tTopo_);
+  if (key.empty())
+    return;
+  if (layerMEs_.find(key) == layerMEs_.end()) {
+    ibooker.cd();
+    RecHitME local_histos;
+    ibooker.setCurrentFolder(subdir + "/" + key);
+    edm::LogInfo("Phase2ITValidateRecHit") << " Booking Histograms in : " << (subdir + "/" + key);
+
+    local_histos.deltaX = phase2tkutil::book1DFromPSet(config_.getParameter<edm::ParameterSet>("DeltaX"), ibooker);
+
+    local_histos.deltaY = phase2tkutil::book1DFromPSet(config_.getParameter<edm::ParameterSet>("DeltaY"), ibooker);
+
+    local_histos.pullX = phase2tkutil::book1DFromPSet(config_.getParameter<edm::ParameterSet>("PullX"), ibooker);
+
+    local_histos.pullY = phase2tkutil::book1DFromPSet(config_.getParameter<edm::ParameterSet>("PullY"), ibooker);
+
+    local_histos.deltaX_eta =
+        phase2tkutil::bookProfile1DFromPSet(config_.getParameter<edm::ParameterSet>("DeltaX_eta"), ibooker);
+
+    local_histos.deltaY_eta =
+        phase2tkutil::bookProfile1DFromPSet(config_.getParameter<edm::ParameterSet>("DeltaY_eta"), ibooker);
+
+    local_histos.deltaX_clsizex =
+        phase2tkutil::bookProfile1DFromPSet(config_.getParameter<edm::ParameterSet>("DeltaX_clsizex"), ibooker);
+
+    local_histos.deltaX_clsizey =
+        phase2tkutil::bookProfile1DFromPSet(config_.getParameter<edm::ParameterSet>("DeltaX_clsizey"), ibooker);
+
+    local_histos.deltaY_clsizex =
+        phase2tkutil::bookProfile1DFromPSet(config_.getParameter<edm::ParameterSet>("DeltaY_clsizex"), ibooker);
+
+    local_histos.deltaY_clsizey =
+        phase2tkutil::bookProfile1DFromPSet(config_.getParameter<edm::ParameterSet>("DeltaY_clsizey"), ibooker);
+
+    local_histos.deltaYvsdeltaX =
+        phase2tkutil::book2DFromPSet(config_.getParameter<edm::ParameterSet>("DeltaY_vs_DeltaX"), ibooker);
+
+    local_histos.pullX_eta =
+        phase2tkutil::bookProfile1DFromPSet(config_.getParameter<edm::ParameterSet>("PullX_eta"), ibooker);
+
+    local_histos.pullY_eta =
+        phase2tkutil::bookProfile1DFromPSet(config_.getParameter<edm::ParameterSet>("PullY_eta"), ibooker);
+    ibooker.setCurrentFolder(subdir + "/" + key + "/PrimarySimHits");
+    //all histos for Primary particles
+    local_histos.numberRecHitsprimary =
+        phase2tkutil::book1DFromPSet(config_.getParameter<edm::ParameterSet>("nRecHits_primary"), ibooker);
+
+    local_histos.deltaX_primary =
+        phase2tkutil::book1DFromPSet(config_.getParameter<edm::ParameterSet>("DeltaX_primary"), ibooker);
+
+    local_histos.deltaY_primary =
+        phase2tkutil::book1DFromPSet(config_.getParameter<edm::ParameterSet>("DeltaY_primary"), ibooker);
+
+    local_histos.pullX_primary =
+        phase2tkutil::book1DFromPSet(config_.getParameter<edm::ParameterSet>("PullX_primary"), ibooker);
+
+    local_histos.pullY_primary =
+        phase2tkutil::book1DFromPSet(config_.getParameter<edm::ParameterSet>("PullY_primary"), ibooker);
+
+    layerMEs_.emplace(key, local_histos);
+  }
+}
+
+void Phase2ITValidateRecHitBase::fillRechitHistos(const PSimHit* simhitClosest,
+                                                  const SiPixelRecHit* rechit,
+                                                  const std::map<unsigned int, SimTrack>& selectedSimTrackMap,
+                                                  std::map<std::string, unsigned int>& nrechitLayerMap_primary) {
+  auto id = rechit->geographicalId();
+  std::string key = phase2tkutil::getITHistoId(id.rawId(), tTopo_);
+  const GeomDetUnit* geomDetunit(tkGeom_->idToDetUnit(id));
+  if (!geomDetunit)
+    return;
+
+  LocalPoint lp = rechit->localPosition();
+  auto simTrackIt(selectedSimTrackMap.find(simhitClosest->trackId()));
+  bool isPrimary = false;
+  //check if simhit is primary
+  if (simTrackIt != selectedSimTrackMap.end())
+    isPrimary = phase2tkutil::isPrimary(simTrackIt->second, simhitClosest);
+
+  Local3DPoint simlp(simhitClosest->localPosition());
+  const LocalError& lperr = rechit->localPositionError();
+  double dx = phase2tkutil::cmtomicron * (lp.x() - simlp.x());
+  double dy = phase2tkutil::cmtomicron * (lp.y() - simlp.y());
+  double pullx = 999.;
+  double pully = 999.;
+  if (lperr.xx())
+    pullx = (lp.x() - simlp.x()) / std::sqrt(lperr.xx());
+  if (lperr.yy())
+    pully = (lp.y() - simlp.y()) / std::sqrt(lperr.yy());
+  float eta = geomDetunit->surface().toGlobal(lp).eta();
+  layerMEs_[key].deltaX->Fill(dx);
+  layerMEs_[key].deltaY->Fill(dy);
+  layerMEs_[key].pullX->Fill(pullx);
+  layerMEs_[key].pullY->Fill(pully);
+  layerMEs_[key].deltaX_eta->Fill(eta, dx);
+  layerMEs_[key].deltaY_eta->Fill(eta, dy);
+  layerMEs_[key].deltaX_clsizex->Fill(rechit->cluster()->sizeX(), dx);
+  layerMEs_[key].deltaX_clsizey->Fill(rechit->cluster()->sizeY(), dx);
+  layerMEs_[key].deltaY_clsizex->Fill(rechit->cluster()->sizeX(), dy);
+  layerMEs_[key].deltaY_clsizey->Fill(rechit->cluster()->sizeY(), dy);
+  layerMEs_[key].deltaYvsdeltaX->Fill(dx, dy);
+  layerMEs_[key].pullX_eta->Fill(eta, pullx);
+  layerMEs_[key].pullY_eta->Fill(eta, pully);
+  if (isPrimary) {
+    layerMEs_[key].deltaX_primary->Fill(dx);
+    layerMEs_[key].deltaY_primary->Fill(dy);
+    layerMEs_[key].pullX_primary->Fill(pullx);
+    layerMEs_[key].pullY_primary->Fill(pully);
+  } else {
+    nrechitLayerMap_primary[key]--;
+  }
+}
+
+void Phase2ITValidateRecHitBase::fillPSetDescription(edm::ParameterSetDescription& desc) {
+  edm::ParameterSetDescription psd0;
+  psd0.add<std::string>("name", "Delta_X");
+  psd0.add<std::string>("title", "Delta_X;RecHit resolution X coordinate [#mum]");
+  psd0.add<bool>("switch", true);
+  psd0.add<double>("xmin", -100.0);
+  psd0.add<double>("xmax", 100.0);
+  psd0.add<int>("NxBins", 100);
+  desc.add<edm::ParameterSetDescription>("DeltaX", psd0);
+
+  edm::ParameterSetDescription psd1;
+  psd1.add<std::string>("name", "Delta_Y");
+  psd1.add<std::string>("title", "Delta_Y;RecHit resolution Y coordinate [#mum];");
+  psd1.add<bool>("switch", true);
+  psd1.add<double>("xmin", -100.0);
+  psd1.add<double>("xmax", 100.0);
+  psd1.add<int>("NxBins", 100);
+  desc.add<edm::ParameterSetDescription>("DeltaY", psd1);
+
+  edm::ParameterSetDescription psd2;
+  psd2.add<std::string>("name", "Pull_X");
+  psd2.add<std::string>("title", "Pull_X;pull x;");
+  psd2.add<double>("xmin", -4.0);
+  psd2.add<bool>("switch", true);
+  psd2.add<double>("xmax", 4.0);
+  psd2.add<int>("NxBins", 100);
+  desc.add<edm::ParameterSetDescription>("PullX", psd2);
+
+  edm::ParameterSetDescription psd3;
+  psd3.add<std::string>("name", "Pull_Y");
+  psd3.add<std::string>("title", "Pull_Y;pull y;");
+  psd3.add<double>("xmin", -4.0);
+  psd3.add<bool>("switch", true);
+  psd3.add<double>("xmax", 4.0);
+  psd3.add<int>("NxBins", 100);
+  desc.add<edm::ParameterSetDescription>("PullY", psd3);
+
+  edm::ParameterSetDescription psd4;
+  psd4.add<std::string>("name", "Delta_X_vs_Eta");
+  psd4.add<std::string>("title", "Delta_X_vs_Eta;#eta;#Delta x [#mum]");
+  psd4.add<double>("ymin", -100.0);
+  psd4.add<double>("ymax", 100.0);
+  psd4.add<int>("NxBins", 82);
+  psd4.add<bool>("switch", true);
+  psd4.add<double>("xmax", 4.1);
+  psd4.add<double>("xmin", -4.1);
+  desc.add<edm::ParameterSetDescription>("DeltaX_eta", psd4);
+
+  edm::ParameterSetDescription psd5;
+  psd5.add<std::string>("name", "Delta_Y_vs_Eta");
+  psd5.add<std::string>("title", "Delta_Y_vs_Eta;#eta;#Delta y [#mum]");
+  psd5.add<double>("ymin", -100.0);
+  psd5.add<double>("ymax", 100.0);
+  psd5.add<int>("NxBins", 82);
+  psd5.add<bool>("switch", true);
+  psd5.add<double>("xmax", 4.1);
+  psd5.add<double>("xmin", -4.1);
+  desc.add<edm::ParameterSetDescription>("DeltaY_eta", psd5);
+
+  edm::ParameterSetDescription psd6;
+  psd6.add<std::string>("name", "Delta_X_vs_ClusterSizeX");
+  psd6.add<std::string>("title", ";Cluster size X;#Delta x [#mum]");
+  psd6.add<double>("ymin", -100.0);
+  psd6.add<double>("ymax", 100.0);
+  psd6.add<int>("NxBins", 21);
+  psd6.add<bool>("switch", true);
+  psd6.add<double>("xmax", 20.5);
+  psd6.add<double>("xmin", -0.5);
+  desc.add<edm::ParameterSetDescription>("DeltaX_clsizex", psd6);
+
+  edm::ParameterSetDescription psd7;
+  psd7.add<std::string>("name", "Delta_X_vs_ClusterSizeY");
+  psd7.add<std::string>("title", ";Cluster size Y;#Delta y [#mum]");
+  psd7.add<double>("ymin", -100.0);
+  psd7.add<double>("ymax", 100.0);
+  psd7.add<int>("NxBins", 21);
+  psd7.add<bool>("switch", true);
+  psd7.add<double>("xmax", 20.5);
+  psd7.add<double>("xmin", -0.5);
+  desc.add<edm::ParameterSetDescription>("DeltaX_clsizey", psd7);
+
+  edm::ParameterSetDescription psd8;
+  psd8.add<std::string>("name", "Delta_Y_vs_ClusterSizeX");
+  psd8.add<std::string>("title", ";Cluster size Y;#Delta y [#mum]");
+  psd8.add<double>("ymin", -100.0);
+  psd8.add<double>("ymax", 100.0);
+  psd8.add<int>("NxBins", 21);
+  psd8.add<bool>("switch", true);
+  psd8.add<double>("xmax", 20.5);
+  psd8.add<double>("xmin", -0.5);
+  desc.add<edm::ParameterSetDescription>("DeltaY_clsizex", psd8);
+
+  edm::ParameterSetDescription psd9;
+  psd9.add<std::string>("name", "Delta_Y_vs_ClusterSizeY");
+  psd9.add<std::string>("title", ";Cluster size Y;#Delta y [#mum]");
+  psd9.add<double>("ymin", -100.0);
+  psd9.add<double>("ymax", 100.0);
+  psd9.add<int>("NxBins", 21);
+  psd9.add<bool>("switch", true);
+  psd9.add<double>("xmax", 20.5);
+  psd9.add<double>("xmin", -0.5);
+  desc.add<edm::ParameterSetDescription>("DeltaY_clsizey", psd9);
+
+  edm::ParameterSetDescription psd10;
+  psd10.add<std::string>("name", "Delta_Y_vs_DeltaX");
+  psd10.add<std::string>("title", ";#Delta x[#mum];#Delta y[#mum]");
+  psd10.add<bool>("switch", true);
+  psd10.add<double>("ymin", -100.0);
+  psd10.add<double>("ymax", 100.0);
+  psd10.add<int>("NyBins", 100);
+  psd10.add<double>("xmax", 100.);
+  psd10.add<double>("xmin", -100.);
+  psd10.add<int>("NxBins", 100);
+  desc.add<edm::ParameterSetDescription>("DeltaY_vs_DeltaX", psd10);
+
+  edm::ParameterSetDescription psd11;
+  psd11.add<std::string>("name", "Pull_X_vs_Eta");
+  psd11.add<std::string>("title", "Pull_X_vs_Eta;#eta;pull x");
+  psd11.add<double>("ymax", 4.0);
+  psd11.add<int>("NxBins", 82);
+  psd11.add<bool>("switch", true);
+  psd11.add<double>("xmax", 4.1);
+  psd11.add<double>("xmin", -4.1);
+  psd11.add<double>("ymin", -4.0);
+  desc.add<edm::ParameterSetDescription>("PullX_eta", psd11);
+
+  edm::ParameterSetDescription psd12;
+  psd12.add<std::string>("name", "Pull_Y_vs_Eta");
+  psd12.add<std::string>("title", "Pull_Y_vs_Eta;#eta;pull y");
+  psd12.add<double>("ymax", 4.0);
+  psd12.add<int>("NxBins", 82);
+  psd12.add<bool>("switch", true);
+  psd12.add<double>("xmax", 4.1);
+  psd12.add<double>("xmin", -4.1);
+  psd12.add<double>("ymin", -4.0);
+  desc.add<edm::ParameterSetDescription>("PullY_eta", psd12);
+
+  //simhits primary
+
+  edm::ParameterSetDescription psd13;
+  psd13.add<std::string>("name", "Number_RecHits_matched_PrimarySimTrack");
+  psd13.add<std::string>("title", "Number of RecHits matched to primary SimTrack;;");
+  psd13.add<double>("xmin", 0.0);
+  psd13.add<bool>("switch", true);
+  psd13.add<double>("xmax", 0.0);
+  psd13.add<int>("NxBins", 100);
+  desc.add<edm::ParameterSetDescription>("nRecHits_primary", psd13);
+
+  edm::ParameterSetDescription psd14;
+  psd14.add<std::string>("name", "Delta_X_SimHitPrimary");
+  psd14.add<std::string>("title", "Delta_X_SimHitPrimary;#delta x [#mum];");
+  psd14.add<double>("xmin", -100.0);
+  psd14.add<bool>("switch", true);
+  psd14.add<double>("xmax", 100.0);
+  psd14.add<int>("NxBins", 100);
+  desc.add<edm::ParameterSetDescription>("DeltaX_primary", psd14);
+
+  edm::ParameterSetDescription psd15;
+  psd15.add<std::string>("name", "Delta_Y_SimHitPrimary");
+  psd15.add<std::string>("title", "Delta_Y_SimHitPrimary;#Delta y [#mum];");
+  psd15.add<double>("xmin", -100.0);
+  psd15.add<bool>("switch", true);
+  psd15.add<double>("xmax", 100.0);
+  psd15.add<int>("NxBins", 100);
+  desc.add<edm::ParameterSetDescription>("DeltaY_primary", psd15);
+
+  edm::ParameterSetDescription psd16;
+  psd16.add<std::string>("name", "Pull_X_SimHitPrimary");
+  psd16.add<std::string>("title", "Pull_X_SimHitPrimary;pull x;");
+  psd16.add<double>("ymax", 4.0);
+  psd16.add<int>("NxBins", 82);
+  psd16.add<bool>("switch", true);
+  psd16.add<double>("xmax", 4.1);
+  psd16.add<double>("xmin", -4.1);
+  psd16.add<double>("ymin", -4.0);
+  desc.add<edm::ParameterSetDescription>("PullX_primary", psd16);
+
+  edm::ParameterSetDescription psd17;
+  psd17.add<std::string>("name", "Pull_Y_SimHitPrimary");
+  psd17.add<std::string>("title", "Pull_Y_SimHitPrimary;pull y;");
+  psd17.add<double>("ymax", 4.0);
+  psd17.add<int>("NxBins", 82);
+  psd17.add<bool>("switch", true);
+  psd17.add<double>("xmax", 4.1);
+  psd17.add<double>("xmin", -4.1);
+  psd17.add<double>("ymin", -4.0);
+  desc.add<edm::ParameterSetDescription>("PullY_primary", psd17);
+}


### PR DESCRIPTION
#### PR description:

This PR introduces a new Validation module for the Phase-2 Inner Tracker `TrackingRecHits`. 
This will allow to monitor the performance of the Inner Tracker CPE used for the final track fit (Template) as opposed to the CPE (without track angles) used for computing the `SiPixelRecHit` position used in track seeding.
In order to reduce code duplication the new class `Phase2ITValidateTrackingRecHit` is made to inherit from a base class `Phase2ITValidateRecHitBase`.
The preexisting class `Phase2ITValidateRecHit` is also made to inherit from `Phase2ITValidateRecHitBase` and changed to use the base class methods and members.

#### PR validation:

Run `runTheMatrix.py -l 23234.0 --ibeos` (Phase-2 D49 workflow) successfully and obtained plots in the new directory `TrackerPhase2ITTrackingRecHitV`.

![image](https://user-images.githubusercontent.com/5082376/118821442-8bdd6380-b8b7-11eb-97e4-db1ab9b172c8.png)

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Not a backport and no backport is needed.
cc:
@sroychow @emiglior 
