### PR TITLE
DQMOffline/CalibMuon migration to esConsumes

### DIFF
--- a/DQMOffline/CalibMuon/interface/DTnoiseDBValidation.h
+++ b/DQMOffline/CalibMuon/interface/DTnoiseDBValidation.h
@@ -15,6 +15,8 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "RecoMuon/TrackingTools/interface/MuonServiceProxy.h"
+#include "CondFormats/DataRecord/interface/DTStatusFlagRcd.h"
+#include "Geometry/Records/interface/MuonGeometryRecord.h"
 
 #include <map>
 #include <string>
@@ -47,15 +49,18 @@ private:
 
   DQMStore *dbe_;
   // The DB label
-  std::string labelDBRef_;
-  std::string labelDB_;
+  edm::ESGetToken<DTStatusFlag, DTStatusFlagRcd> labelDBRef_;
+  edm::ESGetToken<DTStatusFlag, DTStatusFlagRcd> labelDB_;
+  const DTStatusFlag *noiseRefMap;
+  const DTStatusFlag *noiseMap;
   std::string diffTestName_, wheelTestName_, stationTestName_, sectorTestName_, layerTestName_;
 
   bool outputMEsInRootFile_;
   std::string outputFileName_;
 
   // The DTGeometry
-  edm::ESHandle<DTGeometry> dtGeom_;
+  edm::ESGetToken<DTGeometry, MuonGeometryRecord> muonGeomToken_;
+  const DTGeometry *dtGeom;
 
   // The noise map
   const DTStatusFlag *noiseMap_;

--- a/DQMOffline/CalibMuon/interface/DTt0DBValidation.h
+++ b/DQMOffline/CalibMuon/interface/DTt0DBValidation.h
@@ -19,6 +19,8 @@
 #include "DataFormats/MuonDetId/interface/DTLayerId.h"
 #include "DataFormats/MuonDetId/interface/DTWireId.h"
 #include "Geometry/DTGeometry/interface/DTGeometry.h"
+#include "Geometry/Records/interface/MuonGeometryRecord.h"
+#include "CondFormats/DataRecord/interface/DTT0Rcd.h"
 
 #include <fstream>
 #include <string>
@@ -52,8 +54,8 @@ private:
   // Switch for verbosity
   std::string metname_;
   // The DB label
-  std::string labelDBRef_;
-  std::string labelDB_;
+  edm::ESGetToken<DTT0, DTT0Rcd> labelDBRef_;
+  edm::ESGetToken<DTT0, DTT0Rcd> labelDB_;
 
   // The file which will contain the difference plot
   bool outputMEsInRootFile_;
@@ -62,11 +64,12 @@ private:
   std::string t0TestName_;
 
   // The DTGeometry
-  edm::ESHandle<DTGeometry> dtGeom_;
+  edm::ESGetToken<DTGeometry, MuonGeometryRecord> muonGeomToken_;
+  const DTGeometry *dtGeom;
 
   // The t0 map
-  const DTT0 *tZeroMap_;
   const DTT0 *tZeroRefMap_;
+  const DTT0 *tZeroMap_;
 
   // Map of the t0 and sigma per wire
   std::map<DTWireId, std::vector<float>> t0RefMap_;

--- a/DQMOffline/CalibMuon/interface/DTtTrigDBValidation.h
+++ b/DQMOffline/CalibMuon/interface/DTtTrigDBValidation.h
@@ -12,7 +12,9 @@
 
 #include "DataFormats/MuonDetId/interface/DTSuperLayerId.h"
 #include "Geometry/DTGeometry/interface/DTGeometry.h"
-
+#include "Geometry/Records/interface/MuonGeometryRecord.h"
+#include "CondFormats/DTObjects/interface/DTTtrig.h"
+#include "CondFormats/DataRecord/interface/DTTtrigRcd.h"
 #include <fstream>
 #include <string>
 #include <vector>
@@ -36,14 +38,17 @@ private:
   // Switch for verbosity
   std::string metname_;
   // The DB label
-  std::string labelDBRef_;
-  std::string labelDB_;
+  edm::ESGetToken<DTTtrig, DTTtrigRcd> labelDBRef_;
+  edm::ESGetToken<DTTtrig, DTTtrigRcd> labelDB_;
+  const DTTtrig *DTTtrigRefMap;
+  const DTTtrig *DTTtrigMap;
 
   int lowerLimit_;
   int higherLimit_;
 
   // The DTGeometry
-  edm::ESHandle<DTGeometry> dtGeom_;
+  edm::ESGetToken<DTGeometry, MuonGeometryRecord> muonGeomToken_;
+  const DTGeometry *dtGeom;
 
   // Map of the tTrig and sigma by super-layer
   std::map<DTSuperLayerId, std::pair<float, float>> tTrigRefMap_;


### PR DESCRIPTION
PR description:

Following https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideHowToGetDataFromES#In_ED_module

Fixes DT DQM modules for issue #31061
PR validation:

runTheMatrix.py -l limited -i all --ibeos