### PR TITLE
RPC-validation migration to use ESGetToken

### DIFF
--- a/Validation/MuonRPCDigis/interface/RPCDigiValid.h
+++ b/Validation/MuonRPCDigis/interface/RPCDigiValid.h
@@ -14,6 +14,9 @@
 #include "FWCore/Utilities/interface/EDGetToken.h"
 #include "SimDataFormats/TrackingHit/interface/PSimHitContainer.h"
 
+#include "Geometry/RPCGeometry/interface/RPCGeometry.h"
+#include "Geometry/Records/interface/MuonGeometryRecord.h"
+
 class RPCDigiValid : public DQMEDAnalyzer {
 public:
   RPCDigiValid(const edm::ParameterSet &ps);
@@ -81,6 +84,8 @@ private:
   // Tokens for accessing run data. Used for passing to edm::Event. - stanislav
   edm::EDGetTokenT<edm::PSimHitContainer> simHitToken;
   edm::EDGetTokenT<RPCDigiCollection> rpcDigiToken;
+
+  edm::ESGetToken<RPCGeometry, MuonGeometryRecord> rpcGeomToken_;
 };
 
 #endif

--- a/Validation/MuonRPCDigis/src/RPCDigiValid.cc
+++ b/Validation/MuonRPCDigis/src/RPCDigiValid.cc
@@ -7,8 +7,6 @@
 #include "DataFormats/MuonDetId/interface/RPCDetId.h"
 #include "Geometry/CommonTopologies/interface/RectangularStripTopology.h"
 #include "Geometry/CommonTopologies/interface/TrapezoidalStripTopology.h"
-#include "Geometry/RPCGeometry/interface/RPCGeometry.h"
-#include "Geometry/Records/interface/MuonGeometryRecord.h"
 
 #include <cmath>
 
@@ -27,14 +25,15 @@ RPCDigiValid::RPCDigiValid(const ParameterSet &ps) {
       ps.getUntrackedParameter<edm::InputTag>("rpcDigiTag", edm::InputTag("simMuonRPCDigis")));
 
   outputFile_ = ps.getUntrackedParameter<string>("outputFile", "rpcDigiValidPlots.root");
+
+  rpcGeomToken_ = esConsumes();
 }
 
 RPCDigiValid::~RPCDigiValid() {}
 
 void RPCDigiValid::analyze(const Event &event, const EventSetup &eventSetup) {
   // Get the RPC Geometry
-  edm::ESHandle<RPCGeometry> rpcGeom;
-  eventSetup.get<MuonGeometryRecord>().get(rpcGeom);
+  auto rpcGeom = eventSetup.getHandle(rpcGeomToken_);
 
   edm::Handle<PSimHitContainer> simHit;
   edm::Handle<RPCDigiCollection> rpcDigis;

--- a/Validation/RPCRecHits/interface/RPCPointVsRecHit.h
+++ b/Validation/RPCRecHits/interface/RPCPointVsRecHit.h
@@ -10,6 +10,8 @@
 #include "FWCore/Utilities/interface/InputTag.h"
 
 #include "FWCore/ServiceRegistry/interface/Service.h"
+#include "Geometry/RPCGeometry/interface/RPCGeometry.h"
+#include "Geometry/Records/interface/MuonGeometryRecord.h"
 
 #include "DataFormats/RPCRecHit/interface/RPCRecHitCollection.h"
 #include "Validation/RPCRecHits/interface/RPCValidHistograms.h"
@@ -26,6 +28,7 @@ public:
 
 private:
   edm::EDGetTokenT<RPCRecHitCollection> refHitToken_, recHitToken_;
+  edm::ESGetToken<RPCGeometry, MuonGeometryRecord> rpcGeomToken_;
 
   std::string subDir_;
   RPCValidHistograms h_;

--- a/Validation/RPCRecHits/interface/RPCRecHitValid.h
+++ b/Validation/RPCRecHits/interface/RPCRecHitValid.h
@@ -11,6 +11,8 @@
 
 #include "DQMServices/Core/interface/DQMStore.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
+#include "Geometry/Records/interface/MuonGeometryRecord.h"
+#include "Geometry/RPCGeometry/interface/RPCGeometry.h"
 
 #include "DataFormats/MuonReco/interface/MuonFwd.h"
 #include "DataFormats/RPCRecHit/interface/RPCRecHitCollection.h"
@@ -41,6 +43,9 @@ private:
   edm::EDGetTokenT<SimParticles> simParticleToken_;
   edm::EDGetTokenT<SimHitAssoc> simHitAssocToken_;
   edm::EDGetTokenT<reco::MuonCollection> muonToken_;
+
+  edm::ESGetToken<RPCGeometry, MuonGeometryRecord> rpcGeomToken_;
+  edm::ESGetToken<RPCGeometry, MuonGeometryRecord> rpcGeomTokenInRun_;
 
   typedef MonitorElement *MEP;
   RPCValidHistograms h_;

--- a/Validation/RPCRecHits/src/RPCPointVsRecHit.cc
+++ b/Validation/RPCRecHits/src/RPCPointVsRecHit.cc
@@ -4,9 +4,7 @@
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
-#include "Geometry/RPCGeometry/interface/RPCGeometry.h"
 #include "Geometry/RPCGeometry/interface/RPCRoll.h"
-#include "Geometry/Records/interface/MuonGeometryRecord.h"
 
 using namespace std;
 
@@ -17,12 +15,13 @@ RPCPointVsRecHit::RPCPointVsRecHit(const edm::ParameterSet &pset) {
   recHitToken_ = consumes<RPCRecHitCollection>(pset.getParameter<edm::InputTag>("recHit"));
 
   subDir_ = pset.getParameter<std::string>("subDir");
+
+  rpcGeomToken_ = esConsumes();
 }
 
 void RPCPointVsRecHit::analyze(const edm::Event &event, const edm::EventSetup &eventSetup) {
   // Get the RPC Geometry
-  edm::ESHandle<RPCGeometry> rpcGeom;
-  eventSetup.get<MuonGeometryRecord>().get(rpcGeom);
+  auto rpcGeom = eventSetup.getHandle(rpcGeomToken_);
 
   // Retrieve RefHits from the event
   edm::Handle<RPCRecHitCollection> refHitHandle;

--- a/Validation/RPCRecHits/src/RPCRecHitValid.cc
+++ b/Validation/RPCRecHits/src/RPCRecHitValid.cc
@@ -11,10 +11,8 @@
 #include "Geometry/CommonDetUnit/interface/TrackingGeometry.h"
 #include "Geometry/CommonTopologies/interface/StripTopology.h"
 #include "Geometry/RPCGeometry/interface/RPCGeomServ.h"
-#include "Geometry/RPCGeometry/interface/RPCGeometry.h"
 #include "Geometry/RPCGeometry/interface/RPCRoll.h"
 #include "Geometry/RPCGeometry/interface/RPCRollSpecs.h"
-#include "Geometry/Records/interface/MuonGeometryRecord.h"
 #include "SimDataFormats/TrackingAnalysis/interface/TrackingParticle.h"
 
 #include <algorithm>
@@ -31,6 +29,9 @@ RPCRecHitValid::RPCRecHitValid(const edm::ParameterSet &pset) {
   muonToken_ = consumes<reco::MuonCollection>(pset.getParameter<edm::InputTag>("muon"));
 
   subDir_ = pset.getParameter<std::string>("subDir");
+
+  rpcGeomToken_ = esConsumes();
+  rpcGeomTokenInRun_ = esConsumes<edm::Transition::BeginRun>();
 }
 
 void RPCRecHitValid::bookHistograms(DQMStore::IBooker &booker, edm::Run const &run, edm::EventSetup const &eventSetup) {
@@ -245,8 +246,7 @@ void RPCRecHitValid::bookHistograms(DQMStore::IBooker &booker, edm::Run const &r
   }
 
   // Book roll-by-roll histograms
-  edm::ESHandle<RPCGeometry> rpcGeom;
-  eventSetup.get<MuonGeometryRecord>().get(rpcGeom);
+  auto rpcGeom = eventSetup.getHandle(rpcGeomTokenInRun_);
 
   int nRPCRollBarrel = 0, nRPCRollEndcap = 0;
 
@@ -355,8 +355,7 @@ void RPCRecHitValid::analyze(const edm::Event &event, const edm::EventSetup &eve
   h_eventCount->Fill(1);
 
   // Get the RPC Geometry
-  edm::ESHandle<RPCGeometry> rpcGeom;
-  eventSetup.get<MuonGeometryRecord>().get(rpcGeom);
+  auto rpcGeom = eventSetup.getHandle(rpcGeomToken_);
 
   // Retrieve SimHits from the event
   edm::Handle<edm::PSimHitContainer> simHitHandle;


### PR DESCRIPTION
#### PR description:

This PR is for the migration of RPC validation modules to use the esConsumes, as described in the https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideHowToGetDataFromES#In_ED_module

Related issue: #31061 

#### PR validation:
Minimal checks were done with runTheMatrix.py command with WF 1325.0

@andresib @mileva 