### PR TITLE
Migrate ED modules to use esConsumes

### DIFF
--- a/DQMOffline/Muon/interface/CSCOfflineMonitor.h
+++ b/DQMOffline/Muon/interface/CSCOfflineMonitor.h
@@ -91,6 +91,10 @@ private:
   edm::EDGetTokenT<CSCRecHit2DCollection> rh_token;
   edm::EDGetTokenT<CSCSegmentCollection> se_token;
 
+  const edm::ESGetToken<CSCGeometry, MuonGeometryRecord> cscGeomToken_;
+
+  const edm::ESGetToken<CSCCrateMap, CSCCrateMapRcd> hcrateToken_;
+
   // modules
   void doOccupancies(edm::Handle<CSCStripDigiCollection> strips,
                      edm::Handle<CSCWireDigiCollection> wires,

--- a/DQMOffline/Muon/interface/DTSegmentsTask.h
+++ b/DQMOffline/Muon/interface/DTSegmentsTask.h
@@ -41,6 +41,8 @@ private:
   bool checkNoisyChannels;
   edm::ParameterSet parameters;
 
+  const edm::ESGetToken<DTStatusFlag, DTStatusFlagRcd> statusMapToken_;
+
   // the histos
   std::vector<MonitorElement *> phiHistos;
   std::vector<MonitorElement *> thetaHistos;

--- a/DQMOffline/Muon/interface/GEMEfficiencyAnalyzer.h
+++ b/DQMOffline/Muon/interface/GEMEfficiencyAnalyzer.h
@@ -18,6 +18,10 @@
 #include "DataFormats/MuonReco/interface/MuonSelectors.h"
 #include "RecoMuon/TrackingTools/interface/MuonServiceProxy.h"
 #include "TrackingTools/TransientTrack/interface/TransientTrack.h"
+#include "TrackingTools/TransientTrack/interface/TransientTrackBuilder.h"   
+#include "TrackingTools/Records/interface/TransientTrackRecord.h"      
+#include "Geometry/CommonTopologies/interface/GlobalTrackingGeometry.h"                                                            
+#include "Geometry/Records/interface/GlobalTrackingGeometryRecord.h"  
 
 class GEMEfficiencyAnalyzer : public GEMOfflineDQMBase {
 public:
@@ -30,6 +34,8 @@ protected:
   void analyze(const edm::Event &event, const edm::EventSetup &eventSetup) override;
 
 private:
+
+
   struct GEMLayerData {
     GEMLayerData(Disk::DiskPointer surface, std::vector<const GEMChamber *> chambers, int region, int station, int layer)
         : surface(surface), chambers(chambers), region(region), station(station), layer(layer) {}
@@ -37,7 +43,12 @@ private:
     Disk::DiskPointer surface;
     std::vector<const GEMChamber *> chambers;
     int region, station, layer;
+
   };
+
+  const edm::ESGetToken<GEMGeometry, MuonGeometryRecord> gemToken_;                                                                
+  const edm::ESGetToken<GlobalTrackingGeometry,  GlobalTrackingGeometryRecord>  globalGeomToken_;                                  
+  const edm::ESGetToken<TransientTrackBuilder, TransientTrackRecord> trasientTranckToken_;     
 
   MonitorElement *bookNumerator1D(DQMStore::IBooker &, MonitorElement *);
   MonitorElement *bookNumerator2D(DQMStore::IBooker &, MonitorElement *);

--- a/DQMOffline/Muon/interface/GEMEfficiencyAnalyzer.h
+++ b/DQMOffline/Muon/interface/GEMEfficiencyAnalyzer.h
@@ -22,8 +22,12 @@
 #include "TrackingTools/Records/interface/TransientTrackRecord.h"
 #include "Geometry/CommonTopologies/interface/GlobalTrackingGeometry.h"
 #include "Geometry/Records/interface/GlobalTrackingGeometryRecord.h"
+#include "Geometry/GEMGeometry/interface/GEMGeometry.h"
+#include "Geometry/Records/interface/MuonGeometryRecord.h"
+
 
 class GEMEfficiencyAnalyzer : public GEMOfflineDQMBase {
+
 public:
   explicit GEMEfficiencyAnalyzer(const edm::ParameterSet &);
   ~GEMEfficiencyAnalyzer() override;
@@ -43,9 +47,10 @@ private:
     int region, station, layer;
   };
 
-  const edm::ESGetToken<GEMGeometry, MuonGeometryRecord> gemToken_;
+  const edm::ESGetToken<GEMGeometry, MuonGeometryRecord> gemToken1_;  
+  const edm::ESGetToken<GEMGeometry, MuonGeometryRecord> gemToken2_;
   const edm::ESGetToken<GlobalTrackingGeometry, GlobalTrackingGeometryRecord> globalGeomToken_;
-  const edm::ESGetToken<TransientTrackBuilder, TransientTrackRecord> trasientTranckToken_;
+  const edm::ESGetToken<TransientTrackBuilder, TransientTrackRecord> trasientTrackToken_;
 
   MonitorElement *bookNumerator1D(DQMStore::IBooker &, MonitorElement *);
   MonitorElement *bookNumerator2D(DQMStore::IBooker &, MonitorElement *);

--- a/DQMOffline/Muon/interface/GEMEfficiencyAnalyzer.h
+++ b/DQMOffline/Muon/interface/GEMEfficiencyAnalyzer.h
@@ -18,10 +18,10 @@
 #include "DataFormats/MuonReco/interface/MuonSelectors.h"
 #include "RecoMuon/TrackingTools/interface/MuonServiceProxy.h"
 #include "TrackingTools/TransientTrack/interface/TransientTrack.h"
-#include "TrackingTools/TransientTrack/interface/TransientTrackBuilder.h"   
-#include "TrackingTools/Records/interface/TransientTrackRecord.h"      
-#include "Geometry/CommonTopologies/interface/GlobalTrackingGeometry.h"                                                            
-#include "Geometry/Records/interface/GlobalTrackingGeometryRecord.h"  
+#include "TrackingTools/TransientTrack/interface/TransientTrackBuilder.h"
+#include "TrackingTools/Records/interface/TransientTrackRecord.h"
+#include "Geometry/CommonTopologies/interface/GlobalTrackingGeometry.h"
+#include "Geometry/Records/interface/GlobalTrackingGeometryRecord.h"
 
 class GEMEfficiencyAnalyzer : public GEMOfflineDQMBase {
 public:
@@ -34,8 +34,6 @@ protected:
   void analyze(const edm::Event &event, const edm::EventSetup &eventSetup) override;
 
 private:
-
-
   struct GEMLayerData {
     GEMLayerData(Disk::DiskPointer surface, std::vector<const GEMChamber *> chambers, int region, int station, int layer)
         : surface(surface), chambers(chambers), region(region), station(station), layer(layer) {}
@@ -43,12 +41,11 @@ private:
     Disk::DiskPointer surface;
     std::vector<const GEMChamber *> chambers;
     int region, station, layer;
-
   };
 
-  const edm::ESGetToken<GEMGeometry, MuonGeometryRecord> gemToken_;                                                                
-  const edm::ESGetToken<GlobalTrackingGeometry,  GlobalTrackingGeometryRecord>  globalGeomToken_;                                  
-  const edm::ESGetToken<TransientTrackBuilder, TransientTrackRecord> trasientTranckToken_;     
+  const edm::ESGetToken<GEMGeometry, MuonGeometryRecord> gemToken_;
+  const edm::ESGetToken<GlobalTrackingGeometry, GlobalTrackingGeometryRecord> globalGeomToken_;
+  const edm::ESGetToken<TransientTrackBuilder, TransientTrackRecord> trasientTranckToken_;
 
   MonitorElement *bookNumerator1D(DQMStore::IBooker &, MonitorElement *);
   MonitorElement *bookNumerator2D(DQMStore::IBooker &, MonitorElement *);

--- a/DQMOffline/Muon/interface/GEMEfficiencyAnalyzer.h
+++ b/DQMOffline/Muon/interface/GEMEfficiencyAnalyzer.h
@@ -25,9 +25,7 @@
 #include "Geometry/GEMGeometry/interface/GEMGeometry.h"
 #include "Geometry/Records/interface/MuonGeometryRecord.h"
 
-
 class GEMEfficiencyAnalyzer : public GEMOfflineDQMBase {
-
 public:
   explicit GEMEfficiencyAnalyzer(const edm::ParameterSet &);
   ~GEMEfficiencyAnalyzer() override;
@@ -47,7 +45,7 @@ private:
     int region, station, layer;
   };
 
-  const edm::ESGetToken<GEMGeometry, MuonGeometryRecord> gemToken1_;  
+  const edm::ESGetToken<GEMGeometry, MuonGeometryRecord> gemToken1_;
   const edm::ESGetToken<GEMGeometry, MuonGeometryRecord> gemToken2_;
   const edm::ESGetToken<GlobalTrackingGeometry, GlobalTrackingGeometryRecord> globalGeomToken_;
   const edm::ESGetToken<TransientTrackBuilder, TransientTrackRecord> trasientTrackToken_;

--- a/DQMOffline/Muon/interface/GEMOfflineMonitor.h
+++ b/DQMOffline/Muon/interface/GEMOfflineMonitor.h
@@ -30,9 +30,7 @@ private:
   edm::EDGetTokenT<GEMDigiCollection> digi_token_;
   edm::EDGetTokenT<GEMRecHitCollection> rechit_token_;
 
-
-
-  const edm::ESGetToken<GEMGeometry, MuonGeometryRecord> gemToken_;  
+  const edm::ESGetToken<GEMGeometry, MuonGeometryRecord> gemToken_;
 
   bool do_digi_occupancy_;
   bool do_hit_occupancy_;

--- a/DQMOffline/Muon/interface/GEMOfflineMonitor.h
+++ b/DQMOffline/Muon/interface/GEMOfflineMonitor.h
@@ -8,6 +8,7 @@
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "DataFormats/GEMDigi/interface/GEMDigiCollection.h"
 #include "DataFormats/GEMRecHit/interface/GEMRecHitCollection.h"
+#include "Geometry/Records/interface/MuonGeometryRecord.h"
 
 class GEMOfflineMonitor : public GEMOfflineDQMBase {
 public:
@@ -28,6 +29,10 @@ private:
 
   edm::EDGetTokenT<GEMDigiCollection> digi_token_;
   edm::EDGetTokenT<GEMRecHitCollection> rechit_token_;
+
+
+
+  const edm::ESGetToken<GEMGeometry, MuonGeometryRecord> gemToken_;  
 
   bool do_digi_occupancy_;
   bool do_hit_occupancy_;

--- a/DQMOffline/Muon/interface/MuonEnergyDepositAnalyzer.h
+++ b/DQMOffline/Muon/interface/MuonEnergyDepositAnalyzer.h
@@ -25,6 +25,9 @@
 #include "DataFormats/MuonReco/interface/MuonFwd.h"
 #include "DataFormats/MuonReco/interface/MuonEnergy.h"
 
+#include "TrackingTools/TransientTrack/interface/TransientTrackBuilder.h"                                                           
+#include "TrackingTools/Records/interface/TransientTrackRecord.h"               
+
 class MuonEnergyDepositAnalyzer : public DQMEDAnalyzer {
 public:
   /// Constructor
@@ -41,6 +44,10 @@ private:
   // ----------member data ---------------------------
   edm::ParameterSet parameters;
   edm::EDGetTokenT<reco::MuonCollection> theMuonCollectionLabel_;
+
+  edm::ESHandle<TransientTrackBuilder> theB;                                          
+                                             
+  edm::ESGetToken<TransientTrackBuilder, TransientTrackRecord> trasientTrackToken_;   
 
   // Switch for verbosity
   std::string metname;

--- a/DQMOffline/Muon/interface/MuonEnergyDepositAnalyzer.h
+++ b/DQMOffline/Muon/interface/MuonEnergyDepositAnalyzer.h
@@ -25,8 +25,8 @@
 #include "DataFormats/MuonReco/interface/MuonFwd.h"
 #include "DataFormats/MuonReco/interface/MuonEnergy.h"
 
-#include "TrackingTools/TransientTrack/interface/TransientTrackBuilder.h"                                                           
-#include "TrackingTools/Records/interface/TransientTrackRecord.h"               
+#include "TrackingTools/TransientTrack/interface/TransientTrackBuilder.h"
+#include "TrackingTools/Records/interface/TransientTrackRecord.h"
 
 class MuonEnergyDepositAnalyzer : public DQMEDAnalyzer {
 public:
@@ -45,9 +45,9 @@ private:
   edm::ParameterSet parameters;
   edm::EDGetTokenT<reco::MuonCollection> theMuonCollectionLabel_;
 
-  edm::ESHandle<TransientTrackBuilder> theB;                                          
-                                             
-  edm::ESGetToken<TransientTrackBuilder, TransientTrackRecord> trasientTrackToken_;   
+  edm::ESHandle<TransientTrackBuilder> theB;
+
+  edm::ESGetToken<TransientTrackBuilder, TransientTrackRecord> trasientTrackToken_;
 
   // Switch for verbosity
   std::string metname;

--- a/DQMOffline/Muon/interface/MuonIdDQM.h
+++ b/DQMOffline/Muon/interface/MuonIdDQM.h
@@ -73,6 +73,8 @@ private:
   edm::Handle<CSCSegmentCollection> cscSegmentCollectionH_;
   edm::ESHandle<GlobalTrackingGeometry> geometry_;
 
+  const edm::ESGetToken<GlobalTrackingGeometry, GlobalTrackingGeometryRecord> trackingGeomToken_;
+
   // trackerMuon == 0; globalMuon == 1
   MonitorElement* hNumChambers[4];
   MonitorElement* hNumMatches[4];

--- a/DQMOffline/Muon/src/CSCOfflineMonitor.cc
+++ b/DQMOffline/Muon/src/CSCOfflineMonitor.cc
@@ -10,7 +10,9 @@ using namespace std;
 ///////////////////
 //  CONSTRUCTOR  //
 ///////////////////
-CSCOfflineMonitor::CSCOfflineMonitor(const edm::ParameterSet& pset) {
+CSCOfflineMonitor::CSCOfflineMonitor(const edm::ParameterSet& pset)
+    : cscGeomToken_(esConsumes<CSCGeometry, MuonGeometryRecord>()),
+      hcrateToken_(esConsumes<CSCCrateMap, CSCCrateMapRcd>()) {
   rd_token = consumes<FEDRawDataCollection>(pset.getParameter<edm::InputTag>("FEDRawDataCollectionTag"));
   sd_token = consumes<CSCStripDigiCollection>(pset.getParameter<edm::InputTag>("stripDigiTag"));
   wd_token = consumes<CSCWireDigiCollection>(pset.getParameter<edm::InputTag>("wireDigiTag"));
@@ -817,7 +819,8 @@ void CSCOfflineMonitor::analyze(const edm::Event& event, const edm::EventSetup& 
 
   // Get the CSC Geometry :
   edm::ESHandle<CSCGeometry> cscGeom;
-  eventSetup.get<MuonGeometryRecord>().get(cscGeom);
+
+  cscGeom = eventSetup.getHandle(cscGeomToken_);
 
   // Get the RecHits collection :
   edm::Handle<CSCRecHit2DCollection> recHits;
@@ -1802,7 +1805,9 @@ void CSCOfflineMonitor::doBXMonitor(edm::Handle<CSCALCTDigiCollection> alcts,
   // Loop over raw data to get TMBHeader information
   // Taking code from EventFilter/CSCRawToDigis/CSCDCCUnpacker.cc
   edm::ESHandle<CSCCrateMap> hcrate;
-  eventSetup.get<CSCCrateMapRcd>().get(hcrate);
+
+  hcrate = eventSetup.getHandle(hcrateToken_);
+
   const CSCCrateMap* pcrate = hcrate.product();
 
   // Try to get raw data

--- a/DQMOffline/Muon/src/DTSegmentsTask.cc
+++ b/DQMOffline/Muon/src/DTSegmentsTask.cc
@@ -24,7 +24,8 @@
 using namespace edm;
 using namespace std;
 
-DTSegmentsTask::DTSegmentsTask(const edm::ParameterSet& pset) {
+DTSegmentsTask::DTSegmentsTask(const edm::ParameterSet& pset)
+    : statusMapToken_(esConsumes<DTStatusFlag, DTStatusFlagRcd>()) {
   debug = pset.getUntrackedParameter<bool>("debug", false);
   parameters = pset;
 
@@ -112,7 +113,7 @@ void DTSegmentsTask::analyze(const edm::Event& event, const edm::EventSetup& set
   //  bool checkNoisyChannels = parameters.getUntrackedParameter<bool>("checkNoisyChannels",false);
   ESHandle<DTStatusFlag> statusMap;
   if (checkNoisyChannels) {
-    setup.get<DTStatusFlagRcd>().get(statusMap);
+    statusMap = setup.getHandle(statusMapToken_);
   }
 
   // Get the 4D segment collection from the event

--- a/DQMOffline/Muon/src/GEMEfficiencyAnalyzer.cc
+++ b/DQMOffline/Muon/src/GEMEfficiencyAnalyzer.cc
@@ -10,13 +10,11 @@
 #include "Validation/MuonHits/interface/MuonHitHelper.h"
 #include "Validation/MuonGEMHits/interface/GEMValidationUtils.h"
 
-
-GEMEfficiencyAnalyzer::GEMEfficiencyAnalyzer(const edm::ParameterSet& pset) 
-  : GEMOfflineDQMBase(pset),
-    gemToken_(esConsumes<GEMGeometry, MuonGeometryRecord>()),
-    globalGeomToken_(esConsumes<GlobalTrackingGeometry,  GlobalTrackingGeometryRecord>()),
-    trasientTranckToken_(esConsumes<TransientTrackBuilder, TransientTrackRecord>()) {
-
+GEMEfficiencyAnalyzer::GEMEfficiencyAnalyzer(const edm::ParameterSet& pset)
+    : GEMOfflineDQMBase(pset),
+      gemToken_(esConsumes<GEMGeometry, MuonGeometryRecord>()),
+      globalGeomToken_(esConsumes<GlobalTrackingGeometry, GlobalTrackingGeometryRecord>()),
+      trasientTranckToken_(esConsumes<TransientTrackBuilder, TransientTrackRecord>()) {
   name_ = pset.getUntrackedParameter<std::string>("name");
   folder_ = pset.getUntrackedParameter<std::string>("folder");
 
@@ -110,9 +108,7 @@ void GEMEfficiencyAnalyzer::fillDescriptions(edm::ConfigurationDescriptions& des
 void GEMEfficiencyAnalyzer::bookHistograms(DQMStore::IBooker& ibooker,
                                            edm::Run const& run,
                                            edm::EventSetup const& isetup) {
-
-
-  edm::ESHandle<GEMGeometry> gem;  
+  edm::ESHandle<GEMGeometry> gem;
   gem = isetup.getHandle(gemToken_);
 
   if (not gem.isValid()) {
@@ -326,9 +322,8 @@ void GEMEfficiencyAnalyzer::analyze(const edm::Event& event, const edm::EventSet
     return;
   }
 
-  edm::ESHandle<GEMGeometry> gem;  
+  edm::ESHandle<GEMGeometry> gem;
   gem = setup.getHandle(gemToken_);
-
 
   if (not gem.isValid()) {
     edm::LogError(kLogCategory_) << "GEMGeometry is invalid" << std::endl;
@@ -339,16 +334,13 @@ void GEMEfficiencyAnalyzer::analyze(const edm::Event& event, const edm::EventSet
 
   global_tracking_geometry = setup.getHandle(globalGeomToken_);
 
-
-
-
   if (not global_tracking_geometry.isValid()) {
     edm::LogError(kLogCategory_) << "GlobalTrackingGeometry is invalid" << std::endl;
     return;
   }
 
   edm::ESHandle<TransientTrackBuilder> transient_track_builder;
-   transient_track_builder=setup.getHandle(trasientTranckToken_);
+  transient_track_builder = setup.getHandle(trasientTranckToken_);
 
   if (not transient_track_builder.isValid()) {
     edm::LogError(kLogCategory_) << "TransientTrackRecord is invalid" << std::endl;

--- a/DQMOffline/Muon/src/GEMEfficiencyAnalyzer.cc
+++ b/DQMOffline/Muon/src/GEMEfficiencyAnalyzer.cc
@@ -12,11 +12,11 @@
 
 GEMEfficiencyAnalyzer::GEMEfficiencyAnalyzer(const edm::ParameterSet& pset)
     : GEMOfflineDQMBase(pset),
-      gemToken1_(esConsumes<GEMGeometry, MuonGeometryRecord>()),                                                                    
-      gemToken2_(esConsumes<GEMGeometry, MuonGeometryRecord>()),  
+      gemToken1_(esConsumes<GEMGeometry, MuonGeometryRecord>()),
+      gemToken2_(esConsumes<GEMGeometry, MuonGeometryRecord>()),
       globalGeomToken_(esConsumes<GlobalTrackingGeometry, GlobalTrackingGeometryRecord>()),
-      trasientTrackToken_(esConsumes<TransientTrackBuilder, TransientTrackRecord>(edm::ESInputTag("", "TransientTrackBuilder")))  {
-
+      trasientTrackToken_(
+          esConsumes<TransientTrackBuilder, TransientTrackRecord>(edm::ESInputTag("", "TransientTrackBuilder"))) {
   name_ = pset.getUntrackedParameter<std::string>("name");
   folder_ = pset.getUntrackedParameter<std::string>("folder");
 

--- a/DQMOffline/Muon/src/GEMEfficiencyAnalyzer.cc
+++ b/DQMOffline/Muon/src/GEMEfficiencyAnalyzer.cc
@@ -12,7 +12,7 @@
 
 GEMEfficiencyAnalyzer::GEMEfficiencyAnalyzer(const edm::ParameterSet& pset)
     : GEMOfflineDQMBase(pset),
-      gemToken1_(esConsumes<GEMGeometry, MuonGeometryRecord>()),
+      gemToken1_(esConsumes<edm::Transition::BeginRun>()),
       gemToken2_(esConsumes<GEMGeometry, MuonGeometryRecord>()),
       globalGeomToken_(esConsumes<GlobalTrackingGeometry, GlobalTrackingGeometryRecord>()),
       trasientTrackToken_(

--- a/DQMOffline/Muon/src/GEMEfficiencyAnalyzer.cc
+++ b/DQMOffline/Muon/src/GEMEfficiencyAnalyzer.cc
@@ -6,13 +6,17 @@
 #include "DataFormats/Math/interface/deltaPhi.h"
 #include "DataFormats/GeometryCommonDetAlgo/interface/ErrorFrameTransformer.h"
 #include "DataFormats/GeometrySurface/interface/SimpleDiskBounds.h"
-#include "Geometry/CommonTopologies/interface/GlobalTrackingGeometry.h"
-#include "Geometry/Records/interface/GlobalTrackingGeometryRecord.h"
 #include "Geometry/CommonTopologies/interface/StripTopology.h"
 #include "Validation/MuonHits/interface/MuonHitHelper.h"
 #include "Validation/MuonGEMHits/interface/GEMValidationUtils.h"
 
-GEMEfficiencyAnalyzer::GEMEfficiencyAnalyzer(const edm::ParameterSet& pset) : GEMOfflineDQMBase(pset) {
+
+GEMEfficiencyAnalyzer::GEMEfficiencyAnalyzer(const edm::ParameterSet& pset) 
+  : GEMOfflineDQMBase(pset),
+    gemToken_(esConsumes<GEMGeometry, MuonGeometryRecord>()),
+    globalGeomToken_(esConsumes<GlobalTrackingGeometry,  GlobalTrackingGeometryRecord>()),
+    trasientTranckToken_(esConsumes<TransientTrackBuilder, TransientTrackRecord>()) {
+
   name_ = pset.getUntrackedParameter<std::string>("name");
   folder_ = pset.getUntrackedParameter<std::string>("folder");
 
@@ -106,8 +110,11 @@ void GEMEfficiencyAnalyzer::fillDescriptions(edm::ConfigurationDescriptions& des
 void GEMEfficiencyAnalyzer::bookHistograms(DQMStore::IBooker& ibooker,
                                            edm::Run const& run,
                                            edm::EventSetup const& isetup) {
-  edm::ESHandle<GEMGeometry> gem;
-  isetup.get<MuonGeometryRecord>().get(gem);
+
+
+  edm::ESHandle<GEMGeometry> gem;  
+  gem = isetup.getHandle(gemToken_);
+
   if (not gem.isValid()) {
     edm::LogError(kLogCategory_) << "GEMGeometry is invalid" << std::endl;
     return;
@@ -319,22 +326,30 @@ void GEMEfficiencyAnalyzer::analyze(const edm::Event& event, const edm::EventSet
     return;
   }
 
-  edm::ESHandle<GEMGeometry> gem;
-  setup.get<MuonGeometryRecord>().get(gem);
+  edm::ESHandle<GEMGeometry> gem;  
+  gem = setup.getHandle(gemToken_);
+
+
   if (not gem.isValid()) {
     edm::LogError(kLogCategory_) << "GEMGeometry is invalid" << std::endl;
     return;
   }
 
   edm::ESHandle<GlobalTrackingGeometry> global_tracking_geometry;
-  setup.get<GlobalTrackingGeometryRecord>().get(global_tracking_geometry);
+
+  global_tracking_geometry = setup.getHandle(globalGeomToken_);
+
+
+
+
   if (not global_tracking_geometry.isValid()) {
     edm::LogError(kLogCategory_) << "GlobalTrackingGeometry is invalid" << std::endl;
     return;
   }
 
   edm::ESHandle<TransientTrackBuilder> transient_track_builder;
-  setup.get<TransientTrackRecord>().get("TransientTrackBuilder", transient_track_builder);
+   transient_track_builder=setup.getHandle(trasientTranckToken_);
+
   if (not transient_track_builder.isValid()) {
     edm::LogError(kLogCategory_) << "TransientTrackRecord is invalid" << std::endl;
     return;

--- a/DQMOffline/Muon/src/GEMEfficiencyAnalyzer.cc
+++ b/DQMOffline/Muon/src/GEMEfficiencyAnalyzer.cc
@@ -12,9 +12,11 @@
 
 GEMEfficiencyAnalyzer::GEMEfficiencyAnalyzer(const edm::ParameterSet& pset)
     : GEMOfflineDQMBase(pset),
-      gemToken_(esConsumes<GEMGeometry, MuonGeometryRecord>()),
+      gemToken1_(esConsumes<GEMGeometry, MuonGeometryRecord>()),                                                                    
+      gemToken2_(esConsumes<GEMGeometry, MuonGeometryRecord>()),  
       globalGeomToken_(esConsumes<GlobalTrackingGeometry, GlobalTrackingGeometryRecord>()),
-      trasientTranckToken_(esConsumes<TransientTrackBuilder, TransientTrackRecord>()) {
+      trasientTrackToken_(esConsumes<TransientTrackBuilder, TransientTrackRecord>(edm::ESInputTag("", "TransientTrackBuilder")))  {
+
   name_ = pset.getUntrackedParameter<std::string>("name");
   folder_ = pset.getUntrackedParameter<std::string>("folder");
 
@@ -109,7 +111,7 @@ void GEMEfficiencyAnalyzer::bookHistograms(DQMStore::IBooker& ibooker,
                                            edm::Run const& run,
                                            edm::EventSetup const& isetup) {
   edm::ESHandle<GEMGeometry> gem;
-  gem = isetup.getHandle(gemToken_);
+  gem = isetup.getHandle(gemToken1_);
 
   if (not gem.isValid()) {
     edm::LogError(kLogCategory_) << "GEMGeometry is invalid" << std::endl;
@@ -323,7 +325,7 @@ void GEMEfficiencyAnalyzer::analyze(const edm::Event& event, const edm::EventSet
   }
 
   edm::ESHandle<GEMGeometry> gem;
-  gem = setup.getHandle(gemToken_);
+  gem = setup.getHandle(gemToken2_);
 
   if (not gem.isValid()) {
     edm::LogError(kLogCategory_) << "GEMGeometry is invalid" << std::endl;
@@ -340,7 +342,7 @@ void GEMEfficiencyAnalyzer::analyze(const edm::Event& event, const edm::EventSet
   }
 
   edm::ESHandle<TransientTrackBuilder> transient_track_builder;
-  transient_track_builder = setup.getHandle(trasientTranckToken_);
+  transient_track_builder = setup.getHandle(trasientTrackToken_);
 
   if (not transient_track_builder.isValid()) {
     edm::LogError(kLogCategory_) << "TransientTrackRecord is invalid" << std::endl;

--- a/DQMOffline/Muon/src/GEMOfflineMonitor.cc
+++ b/DQMOffline/Muon/src/GEMOfflineMonitor.cc
@@ -4,10 +4,8 @@
 #include "Geometry/Records/interface/MuonGeometryRecord.h"
 #include "Validation/MuonGEMHits/interface/GEMValidationUtils.h"
 
-GEMOfflineMonitor::GEMOfflineMonitor(const edm::ParameterSet& pset) 
-  : GEMOfflineDQMBase(pset),
-    gemToken_(esConsumes<GEMGeometry, MuonGeometryRecord>()) {
-
+GEMOfflineMonitor::GEMOfflineMonitor(const edm::ParameterSet& pset)
+    : GEMOfflineDQMBase(pset), gemToken_(esConsumes<GEMGeometry, MuonGeometryRecord>()) {
   digi_token_ = consumes<GEMDigiCollection>(pset.getParameter<edm::InputTag>("digiTag"));
   rechit_token_ = consumes<GEMRecHitCollection>(pset.getParameter<edm::InputTag>("recHitTag"));
   do_digi_occupancy_ = pset.getUntrackedParameter<bool>("doDigiOccupancy");
@@ -28,10 +26,9 @@ void GEMOfflineMonitor::fillDescriptions(edm::ConfigurationDescriptions& descrip
 }
 
 void GEMOfflineMonitor::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const& run, edm::EventSetup const& setup) {
- 
-  edm::ESHandle<GEMGeometry> gem;  
+  edm::ESHandle<GEMGeometry> gem;
   gem = setup.getHandle(gemToken_);
-  
+
   if (not gem.isValid()) {
     edm::LogError(log_category_) << "GEMGeometry is invalid" << std::endl;
     return;
@@ -136,8 +133,8 @@ void GEMOfflineMonitor::analyze(const edm::Event& event, const edm::EventSetup& 
     }
   }
 
-  edm::ESHandle<GEMGeometry> gem;                                                                                                      gem = setup.getHandle(gemToken_);    
- 
+  edm::ESHandle<GEMGeometry> gem;
+  gem = setup.getHandle(gemToken_);
 
   if (not gem.isValid()) {
     edm::LogError(log_category_) << "GEMGeometry is invalid" << std::endl;

--- a/DQMOffline/Muon/src/GEMOfflineMonitor.cc
+++ b/DQMOffline/Muon/src/GEMOfflineMonitor.cc
@@ -4,7 +4,10 @@
 #include "Geometry/Records/interface/MuonGeometryRecord.h"
 #include "Validation/MuonGEMHits/interface/GEMValidationUtils.h"
 
-GEMOfflineMonitor::GEMOfflineMonitor(const edm::ParameterSet& pset) : GEMOfflineDQMBase(pset) {
+GEMOfflineMonitor::GEMOfflineMonitor(const edm::ParameterSet& pset) 
+  : GEMOfflineDQMBase(pset),
+    gemToken_(esConsumes<GEMGeometry, MuonGeometryRecord>()) {
+
   digi_token_ = consumes<GEMDigiCollection>(pset.getParameter<edm::InputTag>("digiTag"));
   rechit_token_ = consumes<GEMRecHitCollection>(pset.getParameter<edm::InputTag>("recHitTag"));
   do_digi_occupancy_ = pset.getUntrackedParameter<bool>("doDigiOccupancy");
@@ -25,8 +28,10 @@ void GEMOfflineMonitor::fillDescriptions(edm::ConfigurationDescriptions& descrip
 }
 
 void GEMOfflineMonitor::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const& run, edm::EventSetup const& setup) {
-  edm::ESHandle<GEMGeometry> gem;
-  setup.get<MuonGeometryRecord>().get(gem);
+ 
+  edm::ESHandle<GEMGeometry> gem;  
+  gem = setup.getHandle(gemToken_);
+  
   if (not gem.isValid()) {
     edm::LogError(log_category_) << "GEMGeometry is invalid" << std::endl;
     return;
@@ -131,8 +136,9 @@ void GEMOfflineMonitor::analyze(const edm::Event& event, const edm::EventSetup& 
     }
   }
 
-  edm::ESHandle<GEMGeometry> gem;
-  setup.get<MuonGeometryRecord>().get(gem);
+  edm::ESHandle<GEMGeometry> gem;                                                                                                      gem = setup.getHandle(gemToken_);    
+ 
+
   if (not gem.isValid()) {
     edm::LogError(log_category_) << "GEMGeometry is invalid" << std::endl;
     return;

--- a/DQMOffline/Muon/src/MuonEnergyDepositAnalyzer.cc
+++ b/DQMOffline/Muon/src/MuonEnergyDepositAnalyzer.cc
@@ -22,8 +22,7 @@ using namespace std;
 using namespace edm;
 
 MuonEnergyDepositAnalyzer::MuonEnergyDepositAnalyzer(const edm::ParameterSet& pSet)
-  : trasientTrackToken_(esConsumes<TransientTrackBuilder, TransientTrackRecord>())  {
-
+    : trasientTrackToken_(esConsumes<TransientTrackBuilder, TransientTrackRecord>()) {
   parameters = pSet;
 
   theMuonCollectionLabel_ = consumes<reco::MuonCollection>(parameters.getParameter<InputTag>("MuonCollection"));
@@ -211,9 +210,7 @@ void MuonEnergyDepositAnalyzer::analyze(const edm::Event& iEvent, const edm::Eve
 
     // plot for energy tests
 
- 
     theB = iSetup.getHandle(trasientTrackToken_);
-    
 
     reco::TransientTrack TransTrack;
 

--- a/DQMOffline/Muon/src/MuonEnergyDepositAnalyzer.cc
+++ b/DQMOffline/Muon/src/MuonEnergyDepositAnalyzer.cc
@@ -21,7 +21,9 @@
 using namespace std;
 using namespace edm;
 
-MuonEnergyDepositAnalyzer::MuonEnergyDepositAnalyzer(const edm::ParameterSet& pSet) {
+MuonEnergyDepositAnalyzer::MuonEnergyDepositAnalyzer(const edm::ParameterSet& pSet)
+  : trasientTrackToken_(esConsumes<TransientTrackBuilder, TransientTrackRecord>())  {
+
   parameters = pSet;
 
   theMuonCollectionLabel_ = consumes<reco::MuonCollection>(parameters.getParameter<InputTag>("MuonCollection"));
@@ -208,8 +210,11 @@ void MuonEnergyDepositAnalyzer::analyze(const edm::Event& iEvent, const edm::Eve
       hoS9DepEnergy->Fill(muEnergy.hoS9);
 
     // plot for energy tests
-    edm::ESHandle<TransientTrackBuilder> theB;
-    iSetup.get<TransientTrackRecord>().get("TransientTrackBuilder", theB);
+
+ 
+    theB = iSetup.getHandle(trasientTrackToken_);
+    
+
     reco::TransientTrack TransTrack;
 
     if (recoMu->isGlobalMuon())

--- a/DQMOffline/Muon/src/MuonEnergyDepositAnalyzer.cc
+++ b/DQMOffline/Muon/src/MuonEnergyDepositAnalyzer.cc
@@ -22,8 +22,8 @@ using namespace std;
 using namespace edm;
 
 MuonEnergyDepositAnalyzer::MuonEnergyDepositAnalyzer(const edm::ParameterSet& pSet)
-  : trasientTrackToken_(esConsumes<TransientTrackBuilder, TransientTrackRecord>(edm::ESInputTag("", "TransientTrackBuilder"))) {
-
+    : trasientTrackToken_(
+          esConsumes<TransientTrackBuilder, TransientTrackRecord>(edm::ESInputTag("", "TransientTrackBuilder"))) {
   parameters = pSet;
 
   theMuonCollectionLabel_ = consumes<reco::MuonCollection>(parameters.getParameter<InputTag>("MuonCollection"));

--- a/DQMOffline/Muon/src/MuonEnergyDepositAnalyzer.cc
+++ b/DQMOffline/Muon/src/MuonEnergyDepositAnalyzer.cc
@@ -22,7 +22,8 @@ using namespace std;
 using namespace edm;
 
 MuonEnergyDepositAnalyzer::MuonEnergyDepositAnalyzer(const edm::ParameterSet& pSet)
-    : trasientTrackToken_(esConsumes<TransientTrackBuilder, TransientTrackRecord>()) {
+  : trasientTrackToken_(esConsumes<TransientTrackBuilder, TransientTrackRecord>(edm::ESInputTag("", "TransientTrackBuilder"))) {
+
   parameters = pSet;
 
   theMuonCollectionLabel_ = consumes<reco::MuonCollection>(parameters.getParameter<InputTag>("MuonCollection"));

--- a/DQMOffline/Muon/src/MuonIdDQM.cc
+++ b/DQMOffline/Muon/src/MuonIdDQM.cc
@@ -1,8 +1,7 @@
 #include "DQMOffline/Muon/interface/MuonIdDQM.h"
 
 MuonIdDQM::MuonIdDQM(const edm::ParameterSet& iConfig)
-  : trackingGeomToken_(esConsumes<GlobalTrackingGeometry, GlobalTrackingGeometryRecord>()) {
-
+    : trackingGeomToken_(esConsumes<GlobalTrackingGeometry, GlobalTrackingGeometryRecord>()) {
   inputMuonCollection_ = consumes<reco::MuonCollection>(iConfig.getParameter<edm::InputTag>("inputMuonCollection"));
   inputDTRecSegment4DCollection_ =
       consumes<DTRecSegment4DCollection>(iConfig.getParameter<edm::InputTag>("inputDTRecSegment4DCollection"));
@@ -13,8 +12,6 @@ MuonIdDQM::MuonIdDQM(const edm::ParameterSet& iConfig)
   useTrackerMuonsNotGlobalMuons_ = iConfig.getUntrackedParameter<bool>("useTrackerMuonsNotGlobalMuons");
   useGlobalMuonsNotTrackerMuons_ = iConfig.getUntrackedParameter<bool>("useGlobalMuonsNotTrackerMuons");
   baseFolder_ = iConfig.getUntrackedParameter<std::string>("baseFolder");
-
-
 }
 
 MuonIdDQM::~MuonIdDQM() {}
@@ -134,9 +131,8 @@ void MuonIdDQM::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
   iEvent.getByToken(inputMuonCollection_, muonCollectionH_);
   iEvent.getByToken(inputDTRecSegment4DCollection_, dtSegmentCollectionH_);
   iEvent.getByToken(inputCSCSegmentCollection_, cscSegmentCollectionH_);
-  
+
   geometry_ = iSetup.getHandle(trackingGeomToken_);
-  
 
   for (MuonCollection::const_iterator muon = muonCollectionH_->begin(); muon != muonCollectionH_->end(); ++muon) {
     // trackerMuon == 0; globalMuon == 1; trackerMuon && !globalMuon == 2; globalMuon && !trackerMuon == 3

--- a/DQMOffline/Muon/src/MuonIdDQM.cc
+++ b/DQMOffline/Muon/src/MuonIdDQM.cc
@@ -1,6 +1,8 @@
 #include "DQMOffline/Muon/interface/MuonIdDQM.h"
 
-MuonIdDQM::MuonIdDQM(const edm::ParameterSet& iConfig) {
+MuonIdDQM::MuonIdDQM(const edm::ParameterSet& iConfig)
+  : trackingGeomToken_(esConsumes<GlobalTrackingGeometry, GlobalTrackingGeometryRecord>()) {
+
   inputMuonCollection_ = consumes<reco::MuonCollection>(iConfig.getParameter<edm::InputTag>("inputMuonCollection"));
   inputDTRecSegment4DCollection_ =
       consumes<DTRecSegment4DCollection>(iConfig.getParameter<edm::InputTag>("inputDTRecSegment4DCollection"));
@@ -11,6 +13,8 @@ MuonIdDQM::MuonIdDQM(const edm::ParameterSet& iConfig) {
   useTrackerMuonsNotGlobalMuons_ = iConfig.getUntrackedParameter<bool>("useTrackerMuonsNotGlobalMuons");
   useGlobalMuonsNotTrackerMuons_ = iConfig.getUntrackedParameter<bool>("useGlobalMuonsNotTrackerMuons");
   baseFolder_ = iConfig.getUntrackedParameter<std::string>("baseFolder");
+
+
 }
 
 MuonIdDQM::~MuonIdDQM() {}
@@ -130,7 +134,9 @@ void MuonIdDQM::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
   iEvent.getByToken(inputMuonCollection_, muonCollectionH_);
   iEvent.getByToken(inputDTRecSegment4DCollection_, dtSegmentCollectionH_);
   iEvent.getByToken(inputCSCSegmentCollection_, cscSegmentCollectionH_);
-  iSetup.get<GlobalTrackingGeometryRecord>().get(geometry_);
+  
+  geometry_ = iSetup.getHandle(trackingGeomToken_);
+  
 
   for (MuonCollection::const_iterator muon = muonCollectionH_->begin(); muon != muonCollectionH_->end(); ++muon) {
     // trackerMuon == 0; globalMuon == 1; trackerMuon && !globalMuon == 2; globalMuon && !trackerMuon == 3


### PR DESCRIPTION
#### PR description:

Migrate ED modules to use esConsumes, for the DQMOffline/Muon package. 
