### PR TITLE
RPC DQM migration to use ESGetToken

### DIFF
--- a/DQM/RPCMonitorClient/interface/RPCDCSSummary.h
+++ b/DQM/RPCMonitorClient/interface/RPCDCSSummary.h
@@ -3,6 +3,9 @@
 
 #include "DQMServices/Core/interface/DQMStore.h"
 #include "DQMServices/Core/interface/DQMEDHarvester.h"
+#include "CondFormats/RunInfo/interface/RunInfo.h"
+#include "CondFormats/RunInfo/interface/RunSummary.h"
+#include "CondFormats/DataRecord/interface/RunSummaryRcd.h"
 #include <map>
 
 class RPCDCSSummary : public DQMEDHarvester {
@@ -26,6 +29,8 @@ protected:
 private:
   void myBooker(DQMStore::IBooker &);
   void checkDCSbit(edm::EventSetup const &);
+
+  edm::ESGetToken<RunInfo, RunInfoRcd> runInfoToken_;
 
   bool init_;
   double defaultValue_;

--- a/DQM/RPCMonitorClient/interface/RPCDaqInfo.h
+++ b/DQM/RPCMonitorClient/interface/RPCDaqInfo.h
@@ -8,6 +8,9 @@
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "DQMServices/Core/interface/DQMStore.h"
 #include "DQMServices/Core/interface/DQMEDHarvester.h"
+#include "CondFormats/RunInfo/interface/RunInfo.h"
+#include "CondFormats/RunInfo/interface/RunSummary.h"
+#include "CondFormats/DataRecord/interface/RunSummaryRcd.h"
 
 class RPCDaqInfo : public DQMEDHarvester {
 public:
@@ -24,6 +27,8 @@ protected:
 
 private:
   void myBooker(DQMStore::IBooker &);
+
+  edm::ESGetToken<RunInfo, RunInfoRcd> runInfoToken_;
 
   bool init_;
 

--- a/DQM/RPCMonitorClient/interface/RPCDataCertification.h
+++ b/DQM/RPCMonitorClient/interface/RPCDataCertification.h
@@ -4,6 +4,9 @@
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "DQMServices/Core/interface/DQMStore.h"
 #include "DQMServices/Core/interface/DQMEDHarvester.h"
+#include "CondFormats/RunInfo/interface/RunInfo.h"
+#include "CondFormats/RunInfo/interface/RunSummary.h"
+#include "CondFormats/DataRecord/interface/RunSummaryRcd.h"
 
 class RPCDataCertification : public DQMEDHarvester {
 public:
@@ -24,6 +27,8 @@ protected:
 private:
   void myBooker(DQMStore::IBooker&);
   void checkFED(edm::EventSetup const&);
+
+  edm::ESGetToken<RunInfo, RunInfoRcd> runInfoToken_;
 
   MonitorElement* CertMap_;
   MonitorElement* totalCertFraction;

--- a/DQM/RPCMonitorClient/interface/RPCDqmClient.h
+++ b/DQM/RPCMonitorClient/interface/RPCDqmClient.h
@@ -6,6 +6,9 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "DQM/RPCMonitorClient/interface/RPCClient.h"
 
+#include "Geometry/RPCGeometry/interface/RPCGeometry.h"
+#include "Geometry/Records/interface/MuonGeometryRecord.h"
+
 #include <string>
 #include <vector>
 
@@ -44,5 +47,7 @@ private:
   std::vector<RPCClient *> clientModules_;
 
   std::vector<int> clientTag_;
+
+  edm::ESGetToken<RPCGeometry, MuonGeometryRecord> rpcGeomToken_;
 };
 #endif

--- a/DQM/RPCMonitorClient/interface/RPCEventSummary.h
+++ b/DQM/RPCMonitorClient/interface/RPCEventSummary.h
@@ -4,6 +4,9 @@
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "DQMServices/Core/interface/DQMStore.h"
 #include "DQMServices/Core/interface/DQMEDHarvester.h"
+#include "CondFormats/RunInfo/interface/RunInfo.h"
+#include "CondFormats/RunInfo/interface/RunSummary.h"
+#include "CondFormats/DataRecord/interface/RunSummaryRcd.h"
 
 #include <string>
 
@@ -25,6 +28,9 @@ protected:
 
 private:
   void clientOperation(DQMStore::IGetter &igetter);
+
+  edm::ESGetToken<RunInfo, RunInfoRcd> runInfoToken_;
+
   std::string eventInfoPath_, prefixDir_;
 
   //  bool tier0_;

--- a/DQM/RPCMonitorClient/interface/RPCMonitorLinkSynchro.h
+++ b/DQM/RPCMonitorClient/interface/RPCMonitorLinkSynchro.h
@@ -9,6 +9,7 @@
 
 #include "FWCore/Framework/interface/ESWatcher.h"
 #include "FWCore/Utilities/interface/InputTag.h"
+#include "CondFormats/RPCObjects/interface/RPCEMap.h"
 #include "CondFormats/DataRecord/interface/RPCEMapRcd.h"
 
 #include "DQM/RPCMonitorClient/interface/RPCLinkSynchroStat.h"
@@ -40,6 +41,7 @@ public:
 protected:
   edm::ParameterSet theConfig;
   edm::ESWatcher<RPCEMapRcd> theCablingWatcher;
+  edm::ESGetToken<RPCEMap, RPCEMapRcd> rpcEMapToken_;
   RPCLinkSynchroStat theSynchroStat;
 
   MonitorElement* me_delaySummary;

--- a/DQM/RPCMonitorClient/src/RPCDCSSummary.cc
+++ b/DQM/RPCMonitorClient/src/RPCDCSSummary.cc
@@ -8,8 +8,6 @@
 //#include "DQMServices/Core/interface/DQMStore.h"
 
 //CondFormats
-#include "CondFormats/RunInfo/interface/RunInfo.h"
-#include "CondFormats/DataRecord/interface/RunSummaryRcd.h"
 
 RPCDCSSummary::RPCDCSSummary(const edm::ParameterSet& ps) {
   numberOfDisks_ = ps.getUntrackedParameter<int>("NumberOfEndcapDisks", 4);
@@ -22,6 +20,8 @@ RPCDCSSummary::RPCDCSSummary(const edm::ParameterSet& ps) {
   NumberOfFeds_ = FEDRange_.second - FEDRange_.first + 1;
   init_ = false;
   defaultValue_ = 1.;
+
+  runInfoToken_ = esConsumes<edm::Transition::EndLuminosityBlock>();
 }
 
 RPCDCSSummary::~RPCDCSSummary() {}
@@ -52,9 +52,8 @@ void RPCDCSSummary::checkDCSbit(edm::EventSetup const& setup) {
   if (auto runInfoRec = setup.tryToGet<RunInfoRcd>()) {
     defaultValue_ = -1.;
     //get fed summary information
-    edm::ESHandle<RunInfo> sumFED;
-    runInfoRec->get(sumFED);
-    std::vector<int> FedsInIds = sumFED->m_fed_in;
+    auto sumFED = runInfoRec->get(runInfoToken_);
+    const std::vector<int> FedsInIds = sumFED.m_fed_in;
     unsigned int f = 0;
     bool flag = false;
     while (!flag && f < FedsInIds.size()) {

--- a/DQM/RPCMonitorClient/src/RPCDaqInfo.cc
+++ b/DQM/RPCMonitorClient/src/RPCDaqInfo.cc
@@ -1,8 +1,5 @@
 #include "DQM/RPCMonitorClient/interface/RPCDaqInfo.h"
 #include "DataFormats/FEDRawData/interface/FEDNumbering.h"
-#include "CondFormats/RunInfo/interface/RunInfo.h"
-#include "CondFormats/RunInfo/interface/RunSummary.h"
-#include "CondFormats/DataRecord/interface/RunSummaryRcd.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 
@@ -29,9 +26,8 @@ void RPCDaqInfo::dqmEndLuminosityBlock(DQMStore::IBooker& ibooker,
 
   if (auto runInfoRec = iSetup.tryToGet<RunInfoRcd>()) {
     //get fed summary information
-    edm::ESHandle<RunInfo> sumFED;
-    runInfoRec->get(sumFED);
-    std::vector<int> FedsInIds = sumFED->m_fed_in;
+    auto sumFED = runInfoRec->get(runInfoToken_);
+    const std::vector<int> FedsInIds = sumFED.m_fed_in;
 
     int FedCount = 0;
 

--- a/DQM/RPCMonitorClient/src/RPCDaqInfo.cc
+++ b/DQM/RPCMonitorClient/src/RPCDaqInfo.cc
@@ -11,6 +11,8 @@ RPCDaqInfo::RPCDaqInfo(const edm::ParameterSet& ps) {
 
   numberOfDisks_ = ps.getUntrackedParameter<int>("NumberOfEndcapDisks", 4);
 
+  runInfoToken_ = esConsumes<edm::Transition::EndLuminosityBlock>();
+
   init_ = false;
 }
 

--- a/DQM/RPCMonitorClient/src/RPCDataCertification.cc
+++ b/DQM/RPCMonitorClient/src/RPCDataCertification.cc
@@ -14,6 +14,8 @@ RPCDataCertification::RPCDataCertification(const edm::ParameterSet& ps) {
   NumberOfFeds_ = FEDRange_.second - FEDRange_.first + 1;
   offlineDQM_ = ps.getUntrackedParameter<bool>("OfflineDQM", true);
 
+  runInfoToken_ = esConsumes<edm::Transition::EndLuminosityBlock>();
+
   init_ = false;
   defaultValue_ = 1.;
 }

--- a/DQM/RPCMonitorClient/src/RPCDataCertification.cc
+++ b/DQM/RPCMonitorClient/src/RPCDataCertification.cc
@@ -6,9 +6,6 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 #include "DQMServices/Core/interface/DQMStore.h"
-//CondFormats
-#include "CondFormats/RunInfo/interface/RunInfo.h"
-#include "CondFormats/DataRecord/interface/RunSummaryRcd.h"
 
 RPCDataCertification::RPCDataCertification(const edm::ParameterSet& ps) {
   numberOfDisks_ = ps.getUntrackedParameter<int>("NumberOfEndcapDisks", 4);
@@ -50,9 +47,8 @@ void RPCDataCertification::checkFED(edm::EventSetup const& setup) {
   if (auto runInfoRec = setup.tryToGet<RunInfoRcd>()) {
     defaultValue = -1;
     //get fed summary information
-    edm::ESHandle<RunInfo> sumFED;
-    runInfoRec->get(sumFED);
-    std::vector<int> FedsInIds = sumFED->m_fed_in;
+    auto sumFED = runInfoRec->get(runInfoToken_);
+    const std::vector<int> FedsInIds = sumFED.m_fed_in;
     unsigned int f = 0;
     bool flag = false;
     while (!flag && f < FedsInIds.size()) {

--- a/DQM/RPCMonitorClient/src/RPCDqmClient.cc
+++ b/DQM/RPCMonitorClient/src/RPCDqmClient.cc
@@ -11,7 +11,6 @@
 #include "DQM/RPCMonitorClient/interface/RPCOccupancyTest.h"
 #include "DQM/RPCMonitorClient/interface/RPCNoisyStripTest.h"
 //Geometry
-#include "Geometry/RPCGeometry/interface/RPCGeometry.h"
 #include "Geometry/RPCGeometry/interface/RPCGeomServ.h"
 #include "Geometry/Records/interface/MuonGeometryRecord.h"
 //Framework
@@ -49,6 +48,8 @@ RPCDqmClient::RPCDqmClient(const edm::ParameterSet& parameters_) {
 
   //clear counters
   lumiCounter_ = 0;
+
+  rpcGeomToken_ = esConsumes<edm::Transition::EndLuminosityBlock>();
 }
 
 RPCDqmClient::~RPCDqmClient() {}
@@ -180,8 +181,7 @@ void RPCDqmClient::getMonitorElements(DQMStore::IGetter& igetter) {
 void RPCDqmClient::getRPCdetId(const edm::EventSetup& eventSetup) {
   myDetIds_.clear();
 
-  edm::ESHandle<RPCGeometry> rpcGeo;
-  eventSetup.get<MuonGeometryRecord>().get(rpcGeo);
+  auto rpcGeo = eventSetup.getHandle(rpcGeomToken_);
 
   for (auto& det : rpcGeo->dets()) {
     const RPCChamber* ch = dynamic_cast<const RPCChamber*>(det);

--- a/DQM/RPCMonitorClient/src/RPCEventSummary.cc
+++ b/DQM/RPCMonitorClient/src/RPCEventSummary.cc
@@ -2,9 +2,6 @@
 #include <sstream>
 
 #include <DQM/RPCMonitorClient/interface/RPCEventSummary.h>
-//CondFormats
-#include "CondFormats/RunInfo/interface/RunInfo.h"
-#include "CondFormats/DataRecord/interface/RunSummaryRcd.h"
 // Framework
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 //#include "FWCore/Framework/interface/LuminosityBlock.h"
@@ -63,9 +60,8 @@ void RPCEventSummary::dqmEndLuminosityBlock(DQMStore::IBooker& ibooker,
     if (auto runInfoRec = setup.tryToGet<RunInfoRcd>()) {
       defaultValue = -1;
       //get fed summary information
-      edm::ESHandle<RunInfo> sumFED;
-      runInfoRec->get(sumFED);
-      std::vector<int> FedsInIds = sumFED->m_fed_in;
+      auto sumFED = runInfoRec->get(runInfoToken_);
+      const std::vector<int> FedsInIds = sumFED.m_fed_in;
       unsigned int f = 0;
       isIn_ = false;
       while (!isIn_ && f < FedsInIds.size()) {

--- a/DQM/RPCMonitorClient/src/RPCEventSummary.cc
+++ b/DQM/RPCMonitorClient/src/RPCEventSummary.cc
@@ -33,6 +33,8 @@ RPCEventSummary::RPCEventSummary(const edm::ParameterSet& ps) {
   NumberOfFeds_ = FEDRange_.second - FEDRange_.first + 1;
 
   offlineDQM_ = ps.getUntrackedParameter<bool>("OfflineDQM", true);
+
+  runInfoToken_ = esConsumes<edm::Transition::EndLuminosityBlock>();
 }
 
 RPCEventSummary::~RPCEventSummary() { edm::LogVerbatim("rpceventsummary") << "[RPCEventSummary]: Destructor "; }

--- a/DQM/RPCMonitorClient/src/RPCMonitorLinkSynchro.cc
+++ b/DQM/RPCMonitorClient/src/RPCMonitorLinkSynchro.cc
@@ -10,7 +10,6 @@
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/ESTransientHandle.h"
 
-#include "CondFormats/RPCObjects/interface/RPCEMap.h"
 #include "CondFormats/RPCObjects/interface/RPCReadOutMapping.h"
 
 RPCMonitorLinkSynchro::RPCMonitorLinkSynchro(const edm::ParameterSet& cfg)
@@ -20,6 +19,7 @@ RPCMonitorLinkSynchro::RPCMonitorLinkSynchro(const edm::ParameterSet& cfg)
 {
   rpcRawSynchroProdItemTag_ =
       consumes<RPCRawSynchro::ProdItem>(cfg.getParameter<edm::InputTag>("rpcRawSynchroProdItemTag"));
+  rpcEMapToken_ = esConsumes<edm::Transition::BeginRun>();
 }
 
 RPCMonitorLinkSynchro::~RPCMonitorLinkSynchro() {}
@@ -31,8 +31,7 @@ void RPCMonitorLinkSynchro::endLuminosityBlock(const edm::LuminosityBlock& ls, c
 
 void RPCMonitorLinkSynchro::dqmBeginRun(const edm::Run& r, const edm::EventSetup& es) {
   if (theCablingWatcher.check(es)) {
-    edm::ESTransientHandle<RPCEMap> readoutMapping;
-    es.get<RPCEMapRcd>().get(readoutMapping);
+    edm::ESTransientHandle<RPCEMap> readoutMapping = es.getTransientHandle(rpcEMapToken_);
     std::unique_ptr<RPCReadOutMapping const> cabling{readoutMapping->convert()};
     edm::LogInfo("RPCMonitorLinkSynchro")
         << "RPCMonitorLinkSynchro - record has CHANGED!!, read map, VERSION: " << cabling->version();

--- a/DQM/RPCMonitorDigi/interface/RPCMonitorDigi.h
+++ b/DQM/RPCMonitorDigi/interface/RPCMonitorDigi.h
@@ -9,6 +9,7 @@
 #include "DQMServices/Core/interface/DQMStore.h"
 
 #include "Geometry/RPCGeometry/interface/RPCGeometry.h"
+#include "Geometry/Records/interface/MuonGeometryRecord.h"
 #include "DataFormats/Scalers/interface/DcsStatus.h"
 #include "DataFormats/MuonDetId/interface/RPCDetId.h"
 #include "DataFormats/RPCRecHit/interface/RPCRecHitCollection.h"
@@ -76,6 +77,8 @@ private:
   edm::EDGetTokenT<reco::CandidateView> muonLabel_;
   edm::EDGetTokenT<RPCRecHitCollection> rpcRecHitLabel_;
   edm::EDGetTokenT<DcsStatusCollection> scalersRawToDigiLabel_;
+
+  edm::ESGetToken<RPCGeometry, MuonGeometryRecord> rpcGeomToken_;
 };
 
 #endif


### PR DESCRIPTION
#### PR description:

This PR is for the migration of RPC DQM modules to use the esConsumes, as described in the https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideHowToGetDataFromES#In_ED_module

Related issue: #31061

#### PR validation:

Minimal checks were done with runTheMatrix.py command with WF 1325.0

@andresib @mileva