### PR TITLE
setCovarianceVersion for all lost tracks

### DIFF
--- a/PhysicsTools/PatAlgos/plugins/PATLostTracks.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATLostTracks.cc
@@ -284,7 +284,7 @@ void pat::PATLostTracks::addPackedCandidate(std::vector<pat::PackedCandidate>& c
       pat::PackedCandidate(p4, trk->vertex(), trk->pt(), trk->eta(), trk->phi(), id, pvSlimmedColl, pvSlimmed.key()));
 
   cands.back().setTrackHighPurity(trk->quality(reco::TrackBase::highPurity));
-
+  cands.back().setCovarianceVersion(covarianceVersion_);
   cands.back().setLostInnerHits(lostHits);
   if (trk->pt() > minPtToStoreProps_ || trkStatus == TrkStatus::VTX) {
     if (useLegacySetup_ || std::abs(id) == 11 || trkStatus == TrkStatus::VTX) {


### PR DESCRIPTION
as a part of review of #33622 and cms-data/DataFormats-PatCandidates#2, a use case was identified where it is important to know which covarianceVersion_ value corresponds to the collection of packed candidate consistently.

The same is applied in https://github.com/cms-sw/cmssw/blob/6d2f66057131baacc2fcbdd203588c41c885b42c/PhysicsTools/PatAlgos/plugins/PATPackedCandidateProducer.cc#L284 since the beginning of using covariance parameterization.

This update will avoid potential crashes if functionality in #33622 or similar is applied.