### PR TITLE
Remove dead assignments or initializations in a few Calibration packages

### DIFF
--- a/Calibration/EcalCalibAlgos/src/ClusterFillMap.cc
+++ b/Calibration/EcalCalibAlgos/src/ClusterFillMap.cc
@@ -31,22 +31,20 @@ void ClusterFillMap::fillMap(const std::vector<std::pair<DetId, float> >& v1,
       itrechit = barrelHitsCollection->find(idsIt->first);
       dummy = itrechit->energy();
       dummy *= (*m_barrelMap)[idsIt->first];
-    }
-    if (idsIt->first.subdetId() == EcalEndcap) {
+    } else if (idsIt->first.subdetId() == EcalEndcap) {
       itrechit = endcapHitsCollection->find(idsIt->first);
       dummy = itrechit->energy();
       dummy *= (*m_endcapMap)[idsIt->first];
     }
-    int ID = idsIt->first.rawId();
     if (edm::isNotFinite(dummy)) {
       dummy = 0;
     }
     if (dummy < m_minEnergyPerCrystal)
       continue;  //return 1;
     if (dummy > m_maxEnergyPerCrystal) {
-      dummy = 0;
       continue;
     }
+    int ID = idsIt->first.rawId();
     if (m_xtalRegionId[ID] == RegionNumber)
       xtlMap[m_IndexInRegion[ID]] += dummy;
     else

--- a/Calibration/EcalCalibAlgos/src/MatrixFillMap.cc
+++ b/Calibration/EcalCalibAlgos/src/MatrixFillMap.cc
@@ -101,7 +101,6 @@ void MatrixFillMap::fillEEMap(EEDetId EEmax,
       curr_y = EEmax.iy() - m_recoWindowSidey / 2 + ij;
       if (EEDetId::validDetId(curr_x, curr_y, EEmax.zside())) {
         EEDetId det = EEDetId(curr_x, curr_y, EEmax.zside(), EEDetId::XYMODE);
-        int ID = det.rawId();
         EcalRecHitCollection::const_iterator curr_recHit = endcapHitsCollection->find(det);
         double dummy = curr_recHit->energy();
         if (edm::isNotFinite(dummy)) {
@@ -110,10 +109,10 @@ void MatrixFillMap::fillEEMap(EEDetId EEmax,
         if (dummy < m_minEnergyPerCrystal)
           continue;
         if (dummy > m_maxEnergyPerCrystal) {
-          dummy = 0;
           continue;
         }
         dummy *= (*m_endcapMap)[det];
+        int ID = det.rawId();
         if (m_xtalRegionId[ID] == EENumberOfRegion)
           EExtlMap[m_IndexInRegion[ID]] += dummy;
         else

--- a/Calibration/IsolatedParticles/plugins/IsoTrackCalibration.cc
+++ b/Calibration/IsolatedParticles/plugins/IsoTrackCalibration.cc
@@ -475,7 +475,6 @@ void IsoTrackCalibration::beginRun(edm::Run const &iRun, edm::EventSetup const &
 
   // check if trigger names in (new) config
   if (changed_) {
-    changed_ = false;
     edm::LogInfo("HcalIsoTrack") << "New trigger menu found !!!";
     const unsigned int n(hltConfig_.size());
     for (unsigned itrig = 0; itrig < trigNames_.size(); itrig++) {

--- a/Calibration/Tools/src/HouseholderDecomposition.cc
+++ b/Calibration/Tools/src/HouseholderDecomposition.cc
@@ -550,20 +550,17 @@ void HouseholderDecomposition::makeRegions(const int& regLength) {
       remPhi % numSubRegPhi;  // add "addtomore" number of times (addto+-1), remaining times add just (addto)
 
   // now put it all together
-  int addedLengthEta = 0;
-  int addedLengthPhi = 0;
   int startIndexEta = mineta;
   int startIndexPhi;
-  int endIndexEta = 0;
+  int endIndexEta;
   int endIndexPhi;
   for (int i = 0; i < numSubRegEta; i++) {
-    addedLengthEta = regLength + addtoEta + addtomoreEta / abs(addtomoreEta) * (i < abs(addtomoreEta));
+    int addedLengthEta = regLength + addtoEta + addtomoreEta / abs(addtomoreEta) * (i < abs(addtomoreEta));
     endIndexEta = startIndexEta + addedLengthEta - 1;
 
     startIndexPhi = minphi;
-    endIndexPhi = 0;
     for (int j = 0; j < numSubRegPhi; j++) {
-      addedLengthPhi = regLength + addtoPhi + addtomorePhi / abs(addtomorePhi) * (j < abs(addtomorePhi));
+      int addedLengthPhi = regLength + addtoPhi + addtomorePhi / abs(addtomorePhi) * (j < abs(addtomorePhi));
       endIndexPhi = startIndexPhi + addedLengthPhi - 1;
 
       regMinPhi.push_back(startIndexPhi - regFrame * (j != 0));


### PR DESCRIPTION
#### PR description:

It fixes a few dead assignments that were pointed out by the static analyzer.
The warnings raised by the static analizer may be useful in identifying possible bugs in the code: it is therefore advisable to remove as many of those warnings as possible, in particular when their solution is rather trivial as in the present case.

#### PR validation:

It builds