### PR TITLE
Phase-2 Inner Tracker: combined backport of 33495 and 33508

### DIFF
--- a/Configuration/AlCa/python/autoCondPhase2.py
+++ b/Configuration/AlCa/python/autoCondPhase2.py
@@ -65,16 +65,18 @@ allTags["GenError"] = {
     'T15' : ( ','.join( [ 'SiPixelGenErrorDBObject_phase2_IT_v6.1.5_25x100_v3_mc',SiPixelGenErrorRecord,connectionString, "", "2021-01-27 10:00:00"] ), ),  # cell is 25um (local-x) x 100um (local-y) , VBias=350V
     'T21' : ( ','.join( [ 'SiPixelGenErrorDBObject_phase2_IT_v6.1.5_25x100_v3_mc',SiPixelGenErrorRecord,connectionString, "", "2021-01-27 10:00:00"] ), ),  # cell is 25um (local-x) x 100um (local-y) , VBias=350V
     'T22' : ( ','.join( [ 'SiPixelGenErrorDBObject_phase2_IT_v6.1.5_50x50_v5_mc' ,SiPixelGenErrorRecord,connectionString, "", "2021-01-27 10:00:00"] ), ),  # cell is 50um (local-x) x 50um (local-y) , VBias=350V
-    'T25' : ( ','.join( [ 'SiPixelGenErrorDBObject_phase2_IT_v7.0.2_25x100_v1_mc' ,SiPixelGenErrorRecord,connectionString, "", "2021-03-17 20:00:00"] ), ),  # cell is 25um (local-x) x 100um (local-y) , VBias=350V, 3D pixels in TBPX L1
-    'T26' : ( ','.join( [ 'SiPixelGenErrorDBObject_phase2_IT_v7.0.3_mixed_v1_mc' ,SiPixelGenErrorRecord,connectionString, "", "2021-03-17 20:00:00"] ), ),  # TBPX cells are 25um (local-x) x 100um (local-y), TFPX TEPX 50 um x 50 um , VBias=350V, 3D pixels in TBPX L1
+    'T23' : ( ','.join( [ 'SiPixelGenErrorDBObject_phase2_IT_v7.0.0_25x100_v2_mc' ,SiPixelGenErrorRecord,connectionString, "", "2021-04-17 20:00:00"] ), ),  # cell is 25um (local-x) x 100um (local-y) , VBias=350V, 3D pixels in TBPX L1+L2 and TFPX R1
+    'T25' : ( ','.join( [ 'SiPixelGenErrorDBObject_phase2_IT_v7.0.2_25x100_v2_mc' ,SiPixelGenErrorRecord,connectionString, "", "2021-04-17 20:00:00"] ), ),  # cell is 25um (local-x) x 100um (local-y) , VBias=350V, 3D pixels in TBPX L1
+    'T26' : ( ','.join( [ 'SiPixelGenErrorDBObject_phase2_IT_v7.0.3_mixed_v2_mc' ,SiPixelGenErrorRecord,connectionString, "", "2021-04-17 20:00:00"] ), ),  # TBPX cells are 25um (local-x) x 100um (local-y), TFPX TEPX 50 um x 50 um , VBias=350V, 3D pixels in TBPX L1
 }
 
 allTags["Template"] = {
     'T15' : ( ','.join( [ 'SiPixelTemplateDBObject_phase2_IT_v6.1.5_25x100_v3_mc',SiPixelTemplatesRecord,connectionString, "", "2021-01-27 10:00:00"] ), ),  # cell is 25um (local-x) x 100um (local-y) , VBias=350V
     'T21' : ( ','.join( [ 'SiPixelTemplateDBObject_phase2_IT_v6.1.5_25x100_v3_mc',SiPixelTemplatesRecord,connectionString, "", "2021-01-27 10:00:00"] ), ),  # cell is 25um (local-x) x 100um (local-y) , VBias=350V
     'T22' : ( ','.join( [ 'SiPixelTemplateDBObject_phase2_IT_v6.1.5_50x50_v5_mc' ,SiPixelTemplatesRecord,connectionString, "", "2021-01-27 10:00:00"] ), ),  # cell is 50um (local-x) x 50um (local-y) , VBias=350V
-    'T25' : ( ','.join( [ 'SiPixelTemplateDBObject_phase2_IT_v7.0.2_25x100_v1_mc' ,SiPixelTemplatesRecord,connectionString, "", "2021-03-17 20:00:00"] ), ),  # cell is 25um (local-x) x 100um (local-y) , VBias=350V, 3D pixels in TBPX L1
-    'T26' : ( ','.join( [ 'SiPixelTemplateDBObject_phase2_IT_v7.0.3_mixed_v1_mc' ,SiPixelTemplatesRecord,connectionString, "", "2021-03-17 20:00:00"] ), ),  # TBPX cells are 25um (local-x) x 100um (local-y), TFPX TEPX 50 um x 50 um , VBias=350V, 3D pixels in TBPX L1
+    'T23' : ( ','.join( [ 'SiPixelTemplateDBObject_phase2_IT_v7.0.0_25x100_v2_mc' ,SiPixelTemplatesRecord,connectionString, "", "2021-04-17 20:00:00"] ), ),  # cell is 25um (local-x) x 100um (local-y) , VBias=350V, 3D pixels in TBPX L1+L2 and TFPX R1
+    'T25' : ( ','.join( [ 'SiPixelTemplateDBObject_phase2_IT_v7.0.2_25x100_v2_mc' ,SiPixelTemplatesRecord,connectionString, "", "2021-04-17 20:00:00"] ), ),  # cell is 25um (local-x) x 100um (local-y) , VBias=350V, 3D pixels in TBPX L1
+    'T26' : ( ','.join( [ 'SiPixelTemplateDBObject_phase2_IT_v7.0.3_mixed_v2_mc' ,SiPixelTemplatesRecord,connectionString, "", "2021-04-17 20:00:00"] ), ),  # TBPX cells are 25um (local-x) x 100um (local-y), TFPX TEPX 50 um x 50 um , VBias=350V, 3D pixels in TBPX L1
 }
 
 ##

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -1148,7 +1148,6 @@ upgradeProperties[2026] = {
         'Geom' : 'Extended2026D79', # N.B.: Geometry with 3D pixels in the Inner Tracker.
         'HLTmenu': '@fake2',
         'GT' : 'auto:phase2_realistic_T23',
-        'ProcessModifier': 'PixelCPEGeneric',   # This swaps template reco CPE for generic reco CPE
         'Era' : 'Phase2C11I13T23M9', # customizes for 3D Pixels and Muon M9
         'ScenToRun' : ['GenSimHLBeamSpot','DigiTrigger','RecoGlobal', 'HARVESTGlobal'],
     },

--- a/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
+++ b/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
@@ -129,11 +129,26 @@ def customiseFor2018Input(process):
 
     return process
 
+def customiseForPixelCPE(process):
+    """Customize HLT menu to remove deprecated parameters for pixel Generic and Template CPE's """
+    for producer in esproducers_by_type(process, "PixelCPEGenericESProducer"):
+        if hasattr(producer, "DoLorentz"):
+            del producer.DoLorentz
+        if hasattr(producer, "useLAAlignmentOffsets"):
+            del producer.useLAAlignmentOffsets
+
+    for producer in esproducers_by_type(process, "PixelCPETemplateRecoESProducer"):
+        if hasattr(producer, "DoLorentz"):
+            del producer.DoLorentz
+    return process
+
+
 
 # CMSSW version specific customizations
 def customizeHLTforCMSSW(process, menuType="GRun"):
 
     # add call to action function in proper order: newest last!
     # process = customiseFor12718(process)
+    process = customiseForPixelCPE(process)
 
     return process

--- a/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
+++ b/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
@@ -129,7 +129,7 @@ def customiseFor2018Input(process):
 
     return process
 
-def customiseForPixelCPE(process):
+def customiseFor33495(process):
     """Customize HLT menu to remove deprecated parameters for pixel Generic and Template CPE's """
     for producer in esproducers_by_type(process, "PixelCPEGenericESProducer"):
         if hasattr(producer, "DoLorentz"):
@@ -149,6 +149,6 @@ def customizeHLTforCMSSW(process, menuType="GRun"):
 
     # add call to action function in proper order: newest last!
     # process = customiseFor12718(process)
-    process = customiseForPixelCPE(process)
+    process = customiseFor33495(process)
 
     return process

--- a/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
+++ b/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
@@ -129,26 +129,11 @@ def customiseFor2018Input(process):
 
     return process
 
-def customiseFor33495(process):
-    """Customize HLT menu to remove deprecated parameters for pixel Generic and Template CPE's """
-    for producer in esproducers_by_type(process, "PixelCPEGenericESProducer"):
-        if hasattr(producer, "DoLorentz"):
-            del producer.DoLorentz
-        if hasattr(producer, "useLAAlignmentOffsets"):
-            del producer.useLAAlignmentOffsets
-
-    for producer in esproducers_by_type(process, "PixelCPETemplateRecoESProducer"):
-        if hasattr(producer, "DoLorentz"):
-            del producer.DoLorentz
-    return process
-
-
 
 # CMSSW version specific customizations
 def customizeHLTforCMSSW(process, menuType="GRun"):
 
     # add call to action function in proper order: newest last!
     # process = customiseFor12718(process)
-    process = customiseFor33495(process)
 
     return process

--- a/RecoLocalTracker/SiPixelRecHits/interface/PixelCPEBase.h
+++ b/RecoLocalTracker/SiPixelRecHits/interface/PixelCPEBase.h
@@ -238,7 +238,9 @@ protected:
   const SiPixelTemplateDBObject* templateDBobject_;
   bool alpha2Order;  // switch on/off E.B effect.
 
-  bool DoLorentz_;
+  bool useLAFromDB_;  //Use LA value from the database (used for generic CPE or in template CPE if an error)
+
+  bool doLorentzFromAlignment_;
   bool LoadTemplatesFromDB_;
 
   //errors for template reco for edge hits, based on observed residuals from

--- a/RecoLocalTracker/SiPixelRecHits/plugins/PixelCPEClusterRepairESProducer.cc
+++ b/RecoLocalTracker/SiPixelRecHits/plugins/PixelCPEClusterRepairESProducer.cc
@@ -53,14 +53,9 @@ PixelCPEClusterRepairESProducer::PixelCPEClusterRepairESProducer(const edm::Para
   hTTToken_ = c.consumes();
   templateDBobjectToken_ = c.consumes();
   templateDBobject2DToken_ = c.consumes();
-
-  char const* laLabel = "";  // standard LA, from calibration, label=""
-  lorentzAngleToken_ = c.consumes(edm::ESInputTag("", laLabel));
-
-  if (doLorentzFromAlignment_) {
-    lorentzAngleToken_ = c.consumes(edm::ESInputTag("", "fromAlignment"));
-
-    //std::cout<<" from ES Producer Templates "<<myname<<" "<<DoLorentz_<<std::endl;  //dk
+  if (useLAFromDB_ || doLorentzFromAlignment_) {
+    char const* laLabel = doLorentzFromAlignment_ ? "fromAlignment" : "";
+    lorentzAngleToken_ = c.consumes(edm::ESInputTag("", laLabel));
   }
 }
 
@@ -78,7 +73,6 @@ void PixelCPEClusterRepairESProducer::fillDescriptions(edm::ConfigurationDescrip
   PixelCPEClusterRepair::fillPSetDescription(desc);
 
   // specific to PixelCPEClusterRepairESProducer
-  desc.add<bool>("DoLorentz", true);
   descriptions.add("_templates2_default", desc);
 }
 

--- a/RecoLocalTracker/SiPixelRecHits/plugins/PixelCPEClusterRepairESProducer.cc
+++ b/RecoLocalTracker/SiPixelRecHits/plugins/PixelCPEClusterRepairESProducer.cc
@@ -34,7 +34,8 @@ private:
   edm::ESGetToken<SiPixel2DTemplateDBObject, SiPixel2DTemplateDBObjectESProducerRcd> templateDBobject2DToken_;
 
   edm::ParameterSet pset_;
-  bool DoLorentz_;
+  bool doLorentzFromAlignment_;
+  bool useLAFromDB_;
 };
 
 using namespace edm;
@@ -42,8 +43,8 @@ using namespace edm;
 PixelCPEClusterRepairESProducer::PixelCPEClusterRepairESProducer(const edm::ParameterSet& p) {
   std::string myname = p.getParameter<std::string>("ComponentName");
 
-  //DoLorentz_ = p.getParameter<bool>("DoLorentz"); // True when LA from alignment is used
-  DoLorentz_ = p.getParameter<bool>("DoLorentz");
+  useLAFromDB_ = p.getParameter<bool>("useLAFromDB");
+  doLorentzFromAlignment_ = p.getParameter<bool>("doLorentzFromAlignment");
 
   pset_ = p;
   auto c = setWhatProduced(this, myname);
@@ -52,11 +53,15 @@ PixelCPEClusterRepairESProducer::PixelCPEClusterRepairESProducer(const edm::Para
   hTTToken_ = c.consumes();
   templateDBobjectToken_ = c.consumes();
   templateDBobject2DToken_ = c.consumes();
-  if (DoLorentz_) {
-    lorentzAngleToken_ = c.consumes(edm::ESInputTag("", "fromAlignment"));
-  }
 
-  //std::cout<<" from ES Producer Templates "<<myname<<" "<<DoLorentz_<<std::endl;  //dk
+  char const* laLabel = "";  // standard LA, from calibration, label=""
+  lorentzAngleToken_ = c.consumes(edm::ESInputTag("", laLabel));
+
+  if (doLorentzFromAlignment_) {
+    lorentzAngleToken_ = c.consumes(edm::ESInputTag("", "fromAlignment"));
+
+    //std::cout<<" from ES Producer Templates "<<myname<<" "<<DoLorentz_<<std::endl;  //dk
+  }
 }
 
 PixelCPEClusterRepairESProducer::~PixelCPEClusterRepairESProducer() {}
@@ -79,10 +84,11 @@ void PixelCPEClusterRepairESProducer::fillDescriptions(edm::ConfigurationDescrip
 
 std::unique_ptr<PixelClusterParameterEstimator> PixelCPEClusterRepairESProducer::produce(
     const TkPixelCPERecord& iRecord) {
-  // Normal, default LA actually is NOT needed
-  // null is ok becuse LA is not use by templates in this mode
+  // Normal, default LA is used in case of template failure, load it unless
+  // turned off
+  // if turned off, null is ok, becomes zero
   const SiPixelLorentzAngle* lorentzAngleProduct = nullptr;
-  if (DoLorentz_) {  //  LA correction from alignment
+  if (useLAFromDB_ || doLorentzFromAlignment_) {
     lorentzAngleProduct = &iRecord.get(lorentzAngleToken_);
   }
 

--- a/RecoLocalTracker/SiPixelRecHits/plugins/PixelCPEFastESProducer.cc
+++ b/RecoLocalTracker/SiPixelRecHits/plugins/PixelCPEFastESProducer.cc
@@ -89,8 +89,6 @@ void PixelCPEFastESProducer::fillDescriptions(edm::ConfigurationDescriptions& de
   // specific to PixelCPEFastESProducer
   desc.add<std::string>("ComponentName", "PixelCPEFast");
   desc.add<edm::ESInputTag>("MagneticFieldRecord", edm::ESInputTag());
-  desc.add<bool>("useLAAlignmentOffsets", false);
-  desc.add<bool>("DoLorentz", false);
 
   descriptions.add("PixelCPEFastESProducer", desc);
 }

--- a/RecoLocalTracker/SiPixelRecHits/plugins/PixelCPEFastESProducer.cc
+++ b/RecoLocalTracker/SiPixelRecHits/plugins/PixelCPEFastESProducer.cc
@@ -89,6 +89,8 @@ void PixelCPEFastESProducer::fillDescriptions(edm::ConfigurationDescriptions& de
   // specific to PixelCPEFastESProducer
   desc.add<std::string>("ComponentName", "PixelCPEFast");
   desc.add<edm::ESInputTag>("MagneticFieldRecord", edm::ESInputTag());
+  desc.addOptional<bool>("useLAAlignmentOffsets", false)->setComment("deprecated");
+  desc.addOptional<bool>("DoLorentz", false)->setComment("deprecated");
 
   descriptions.add("PixelCPEFastESProducer", desc);
 }

--- a/RecoLocalTracker/SiPixelRecHits/plugins/PixelCPEGenericESProducer.cc
+++ b/RecoLocalTracker/SiPixelRecHits/plugins/PixelCPEGenericESProducer.cc
@@ -66,9 +66,6 @@ PixelCPEGenericESProducer::PixelCPEGenericESProducer(const edm::ParameterSet& p)
   if (UseErrorsFromTemplates_) {
     genErrorDBObjectToken_ = c.consumes();
   }
-
-  //std::cout<<" ESProducer "<<myname<<" "<<useLAWidthFromDB_<<" "<<useLAAlignmentOffsets_<<" "
-  //	   <<UseErrorsFromTemplates_<<std::endl; //dk
 }
 
 std::unique_ptr<PixelClusterParameterEstimator> PixelCPEGenericESProducer::produce(const TkPixelCPERecord& iRecord) {

--- a/RecoLocalTracker/SiPixelRecHits/plugins/PixelCPEGenericESProducer.cc
+++ b/RecoLocalTracker/SiPixelRecHits/plugins/PixelCPEGenericESProducer.cc
@@ -45,9 +45,9 @@ PixelCPEGenericESProducer::PixelCPEGenericESProducer(const edm::ParameterSet& p)
   // Use LA-width from DB. If both (upper and this) are false LA-width is calcuated from LA-offset
   useLAWidthFromDB_ = p.getParameter<bool>("useLAWidthFromDB");
   // Use Alignment LA-offset
-  const bool useLAAlignmentOffsets = p.getParameter<bool>("useLAAlignmentOffsets");
+  const bool doLorentzFromAlignment = p.getParameter<bool>("doLorentzFromAlignment");
   char const* laLabel = "";  // standard LA, from calibration, label=""
-  if (useLAAlignmentOffsets) {
+  if (doLorentzFromAlignment) {
     laLabel = "fromAlignment";
   }
 
@@ -108,8 +108,6 @@ void PixelCPEGenericESProducer::fillDescriptions(edm::ConfigurationDescriptions&
   // specific to PixelCPEGenericESProducer
   desc.add<std::string>("ComponentName", "PixelCPEGeneric");
   desc.add<edm::ESInputTag>("MagneticFieldRecord", edm::ESInputTag(""));
-  desc.add<bool>("useLAAlignmentOffsets", false);
-  desc.add<bool>("DoLorentz", false);
   descriptions.add("_generic_default", desc);
 }
 

--- a/RecoLocalTracker/SiPixelRecHits/plugins/PixelCPEGenericESProducer.cc
+++ b/RecoLocalTracker/SiPixelRecHits/plugins/PixelCPEGenericESProducer.cc
@@ -105,6 +105,8 @@ void PixelCPEGenericESProducer::fillDescriptions(edm::ConfigurationDescriptions&
   // specific to PixelCPEGenericESProducer
   desc.add<std::string>("ComponentName", "PixelCPEGeneric");
   desc.add<edm::ESInputTag>("MagneticFieldRecord", edm::ESInputTag(""));
+  desc.addOptional<bool>("useLAAlignmentOffsets", false)->setComment("deprecated");
+  desc.addOptional<bool>("DoLorentz", false)->setComment("deprecated");
   descriptions.add("_generic_default", desc);
 }
 

--- a/RecoLocalTracker/SiPixelRecHits/plugins/PixelCPETemplateRecoESProducer.cc
+++ b/RecoLocalTracker/SiPixelRecHits/plugins/PixelCPETemplateRecoESProducer.cc
@@ -48,14 +48,10 @@ PixelCPETemplateRecoESProducer::PixelCPETemplateRecoESProducer(const edm::Parame
   pDDToken_ = c.consumes();
   hTTToken_ = c.consumes();
   templateDBobjectToken_ = c.consumes();
-
-  char const* laLabel = "";  // standard LA, from calibration, label=""
-  lorentzAngleToken_ = c.consumes(edm::ESInputTag("", laLabel));
-
-  if (doLorentzFromAlignment_) {
-    lorentzAngleToken_ = c.consumes(edm::ESInputTag("", "fromAlignment"));
+  if (useLAFromDB_ || doLorentzFromAlignment_) {
+    char const* laLabel = doLorentzFromAlignment_ ? "fromAlignment" : "";
+    lorentzAngleToken_ = c.consumes(edm::ESInputTag("", laLabel));
   }
-  //std::cout<<" from ES Producer Templates "<<myname<<" "<<DoLorentz_<<std::endl;  //dk
 }
 
 std::unique_ptr<PixelClusterParameterEstimator> PixelCPETemplateRecoESProducer::produce(

--- a/RecoLocalTracker/SiPixelRecHits/plugins/PixelCPETemplateRecoESProducer.cc
+++ b/RecoLocalTracker/SiPixelRecHits/plugins/PixelCPETemplateRecoESProducer.cc
@@ -30,7 +30,8 @@ private:
   edm::ESGetToken<SiPixelTemplateDBObject, SiPixelTemplateDBObjectESProducerRcd> templateDBobjectToken_;
 
   edm::ParameterSet pset_;
-  bool DoLorentz_;
+  bool doLorentzFromAlignment_;
+  bool useLAFromDB_;
 };
 
 using namespace edm;
@@ -38,8 +39,8 @@ using namespace edm;
 PixelCPETemplateRecoESProducer::PixelCPETemplateRecoESProducer(const edm::ParameterSet& p) {
   std::string myname = p.getParameter<std::string>("ComponentName");
 
-  //DoLorentz_ = p.getParameter<bool>("DoLorentz"); // True when LA from alignment is used
-  DoLorentz_ = p.getParameter<bool>("DoLorentz");
+  useLAFromDB_ = p.getParameter<bool>("useLAFromDB");
+  doLorentzFromAlignment_ = p.getParameter<bool>("doLorentzFromAlignment");
 
   pset_ = p;
   auto c = setWhatProduced(this, myname);
@@ -47,7 +48,11 @@ PixelCPETemplateRecoESProducer::PixelCPETemplateRecoESProducer(const edm::Parame
   pDDToken_ = c.consumes();
   hTTToken_ = c.consumes();
   templateDBobjectToken_ = c.consumes();
-  if (DoLorentz_) {
+
+  char const* laLabel = "";  // standard LA, from calibration, label=""
+  lorentzAngleToken_ = c.consumes(edm::ESInputTag("", laLabel));
+
+  if (doLorentzFromAlignment_) {
     lorentzAngleToken_ = c.consumes(edm::ESInputTag("", "fromAlignment"));
   }
   //std::cout<<" from ES Producer Templates "<<myname<<" "<<DoLorentz_<<std::endl;  //dk
@@ -55,10 +60,11 @@ PixelCPETemplateRecoESProducer::PixelCPETemplateRecoESProducer(const edm::Parame
 
 std::unique_ptr<PixelClusterParameterEstimator> PixelCPETemplateRecoESProducer::produce(
     const TkPixelCPERecord& iRecord) {
-  // Normal, deafult LA actually is NOT needed
-  // null is ok becuse LA is not use by templates in this mode
+  // Normal, default LA is used in case of template failure, load it unless
+  // turned off
+  // if turned off, null is ok, becomes zero
   const SiPixelLorentzAngle* lorentzAngleProduct = nullptr;
-  if (DoLorentz_) {  //  LA correction from alignment
+  if (useLAFromDB_ || doLorentzFromAlignment_) {
     lorentzAngleProduct = &iRecord.get(lorentzAngleToken_);
   }
 
@@ -81,7 +87,6 @@ void PixelCPETemplateRecoESProducer::fillDescriptions(edm::ConfigurationDescript
 
   // specific to PixelCPETemplateRecoESProducer
   desc.add<std::string>("ComponentName", "PixelCPETemplateReco");
-  desc.add<bool>("DoLorentz", true);
   descriptions.add("_templates_default", desc);
 }
 

--- a/RecoLocalTracker/SiPixelRecHits/plugins/PixelCPETemplateRecoESProducer.cc
+++ b/RecoLocalTracker/SiPixelRecHits/plugins/PixelCPETemplateRecoESProducer.cc
@@ -83,6 +83,7 @@ void PixelCPETemplateRecoESProducer::fillDescriptions(edm::ConfigurationDescript
 
   // specific to PixelCPETemplateRecoESProducer
   desc.add<std::string>("ComponentName", "PixelCPETemplateReco");
+  desc.addOptional<bool>("DoLorentz", true)->setComment("deprecated");
   descriptions.add("_templates_default", desc);
 }
 

--- a/RecoLocalTracker/SiPixelRecHits/src/PixelCPEBase.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/PixelCPEBase.cc
@@ -106,7 +106,8 @@ PixelCPEBase::PixelCPEBase(edm::ParameterSet const& conf,
 
   // For Templates only
   // Compute the Lorentz shifts for this detector element for templates (from Alignment)
-  DoLorentz_ = conf.getParameter<bool>("DoLorentz");
+  doLorentzFromAlignment_ = conf.getParameter<bool>("doLorentzFromAlignment");
+  useLAFromDB_ = conf.getParameter<bool>("useLAFromDB");
 
   LogDebug("PixelCPEBase") << " LA constants - " << lAOffset_ << " " << lAWidthBPix_ << " " << lAWidthFPix_
                            << endl;  //dk
@@ -194,7 +195,8 @@ void PixelCPEBase::fillDetParams() {
     p.bx = Bfield.x();
 
     //---  Compute the Lorentz shifts for this detector element
-    if ((theFlag_ == 0) || DoLorentz_) {  // do always for generic and if(DOLorentz) for templates
+    if ((theFlag_ == 0) || useLAFromDB_ ||
+        doLorentzFromAlignment_) {  // do always for generic and if(DOLorentz) for templates
       p.driftDirection = driftDirection(p, Bfield);
       computeLorentzShifts(p);
     }
@@ -470,4 +472,6 @@ void PixelCPEBase::fillPSetDescription(edm::ParameterSetDescription& desc) {
   desc.add<double>("lAOffset", 0.0);
   desc.add<double>("lAWidthBPix", 0.0);
   desc.add<double>("lAWidthFPix", 0.0);
+  desc.add<bool>("doLorentzFromAlignment", false);
+  desc.add<bool>("useLAFromDB", true);
 }

--- a/RecoLocalTracker/SiPixelRecHits/src/PixelCPEBase.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/PixelCPEBase.cc
@@ -196,7 +196,7 @@ void PixelCPEBase::fillDetParams() {
 
     //---  Compute the Lorentz shifts for this detector element
     if ((theFlag_ == 0) || useLAFromDB_ ||
-        doLorentzFromAlignment_) {  // do always for generic and if(DOLorentz) for templates
+        doLorentzFromAlignment_) {  // do always for generic and if using LA from DB or alignment for templates
       p.driftDirection = driftDirection(p, Bfield);
       computeLorentzShifts(p);
     }

--- a/RecoLocalTracker/SiPixelRecHits/src/PixelCPEClusterRepair.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/PixelCPEClusterRepair.cc
@@ -324,6 +324,11 @@ void PixelCPEClusterRepair::callTempReco1D(DetParam const& theDetParam,
   // We have a boolean denoting whether the reco failed or not
   theClusterParam.hasFilledProb_ = false;
 
+  // In case of template reco failure, these are the lorentz drift corrections
+  // to be applied
+  float lorentzshiftX = 0.5f * theDetParam.lorentzShiftInCmX;
+  float lorentzshiftY = 0.5f * theDetParam.lorentzShiftInCmY;
+
   // ******************************************************************
   //--- Call normal TemplateReco
   //
@@ -363,30 +368,24 @@ void PixelCPEClusterRepair::callTempReco1D(DetParam const& theDetParam,
 
     theClusterParam.probabilityX_ = theClusterParam.probabilityY_ = theClusterParam.probabilityQ_ = 0.f;
     theClusterParam.qBin_ = 0;
+    //
+    // Template reco has failed, compute position estimates based on cluster center of gravity + Lorentz drift
+    // Future improvement would be to call generic reco instead
 
-    // Gavril: what do we do in this case ? For now, just return the cluster center of gravity in microns
-    // In the x case, apply a rough Lorentz drift average correction
-    // To do: call PixelCPEGeneric whenever PixelTempReco1D fails
-    float lorentz_drift = -999.9;
-    if (!GeomDetEnumerators::isEndcap(theDetParam.thePart))
-      lorentz_drift = 60.0f;  // in microns
-    else
-      lorentz_drift = 10.0f;  // in microns
-    // GG: trk angles needed to correct for bows/kinks
     if (theClusterParam.with_track_angle) {
       theClusterParam.templXrec_ =
-          theDetParam.theTopol->localX(theClusterParam.theCluster->x(), theClusterParam.loc_trk_pred) -
-          lorentz_drift * micronsToCm;  // rough Lorentz drift correction
+          theDetParam.theTopol->localX(theClusterParam.theCluster->x(), theClusterParam.loc_trk_pred) + lorentzshiftX;
       theClusterParam.templYrec_ =
-          theDetParam.theTopol->localY(theClusterParam.theCluster->y(), theClusterParam.loc_trk_pred);
+          theDetParam.theTopol->localY(theClusterParam.theCluster->y(), theClusterParam.loc_trk_pred) + lorentzshiftY;
     } else {
       edm::LogError("PixelCPEClusterRepair") << "@SUB = PixelCPEClusterRepair::localPosition"
                                              << "Should never be here. PixelCPEClusterRepair should always be called "
                                                 "with track angles. This is a bad error !!! ";
 
-      theClusterParam.templXrec_ = theDetParam.theTopol->localX(theClusterParam.theCluster->x()) -
-                                   lorentz_drift * micronsToCm;  // rough Lorentz drift correction
-      theClusterParam.templYrec_ = theDetParam.theTopol->localY(theClusterParam.theCluster->y());
+      theClusterParam.templXrec_ =
+          theDetParam.theTopol->localX(theClusterParam.theCluster->x(), theClusterParam.loc_trk_pred) + lorentzshiftX;
+      theClusterParam.templYrec_ =
+          theDetParam.theTopol->localY(theClusterParam.theCluster->y(), theClusterParam.loc_trk_pred) + lorentzshiftY;
     }
   } else {
     //--- Template Reco succeeded.  The probabilities are filled.
@@ -422,6 +421,11 @@ void PixelCPEClusterRepair::callTempReco2D(DetParam const& theDetParam,
   theClusterParam.qBin_ = 0;
   // We have a boolean denoting whether the reco failed or not
   theClusterParam.hasFilledProb_ = false;
+
+  // In case of template reco failure, these are the lorentz drift corrections
+  // to be applied
+  float lorentzshiftX = 0.5f * theDetParam.lorentzShiftInCmX;
+  float lorentzshiftY = 0.5f * theDetParam.lorentzShiftInCmY;
 
   // ******************************************************************
   //--- Call 2D TemplateReco
@@ -482,29 +486,26 @@ void PixelCPEClusterRepair::callTempReco2D(DetParam const& theDetParam,
 
     theClusterParam.probabilityX_ = theClusterParam.probabilityY_ = theClusterParam.probabilityQ_ = 0.f;
     theClusterParam.qBin_ = 0;
-    // GG: what do we do in this case?  For now, just return the cluster center of gravity in microns
-    // In the x case, apply a rough Lorentz drift average correction
-    float lorentz_drift = -999.9;
-    if (!GeomDetEnumerators::isEndcap(theDetParam.thePart))
-      lorentz_drift = 60.0f;  // in microns  // &&& replace with a constant (globally)
-    else
-      lorentz_drift = 10.0f;  // in microns
-    // GG: trk angles needed to correct for bows/kinks
+
+    // 2D Template reco has failed, compute position estimates based on cluster center of gravity + Lorentz drift
+    // Future improvement would be to call generic reco instead
+
     if (theClusterParam.with_track_angle) {
       theClusterParam.templXrec_ =
-          theDetParam.theTopol->localX(theClusterParam.theCluster->x(), theClusterParam.loc_trk_pred) -
-          lorentz_drift * micronsToCm;  // rough Lorentz drift correction
+          theDetParam.theTopol->localX(theClusterParam.theCluster->x(), theClusterParam.loc_trk_pred) + lorentzshiftX;
       theClusterParam.templYrec_ =
-          theDetParam.theTopol->localY(theClusterParam.theCluster->y(), theClusterParam.loc_trk_pred);
+          theDetParam.theTopol->localY(theClusterParam.theCluster->y(), theClusterParam.loc_trk_pred) + lorentzshiftY;
     } else {
       edm::LogError("PixelCPEClusterRepair") << "@SUB = PixelCPEClusterRepair::localPosition"
                                              << "Should never be here. PixelCPEClusterRepair should always be called "
                                                 "with track angles. This is a bad error !!! ";
 
-      theClusterParam.templXrec_ = theDetParam.theTopol->localX(theClusterParam.theCluster->x()) -
-                                   lorentz_drift * micronsToCm;  // rough Lorentz drift correction
-      theClusterParam.templYrec_ = theDetParam.theTopol->localY(theClusterParam.theCluster->y());
+      theClusterParam.templXrec_ =
+          theDetParam.theTopol->localX(theClusterParam.theCluster->x(), theClusterParam.loc_trk_pred) + lorentzshiftX;
+      theClusterParam.templYrec_ =
+          theDetParam.theTopol->localY(theClusterParam.theCluster->y(), theClusterParam.loc_trk_pred) + lorentzshiftY;
     }
+
   } else {
     //--- Template Reco succeeded.
     theClusterParam.hasFilledProb_ = true;

--- a/RecoLocalTracker/SiPixelRecHits/src/PixelCPEClusterRepair.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/PixelCPEClusterRepair.cc
@@ -382,10 +382,8 @@ void PixelCPEClusterRepair::callTempReco1D(DetParam const& theDetParam,
                                              << "Should never be here. PixelCPEClusterRepair should always be called "
                                                 "with track angles. This is a bad error !!! ";
 
-      theClusterParam.templXrec_ =
-          theDetParam.theTopol->localX(theClusterParam.theCluster->x(), theClusterParam.loc_trk_pred) + lorentzshiftX;
-      theClusterParam.templYrec_ =
-          theDetParam.theTopol->localY(theClusterParam.theCluster->y(), theClusterParam.loc_trk_pred) + lorentzshiftY;
+      theClusterParam.templXrec_ = theDetParam.theTopol->localX(theClusterParam.theCluster->x()) + lorentzshiftX;
+      theClusterParam.templYrec_ = theDetParam.theTopol->localY(theClusterParam.theCluster->y()) + lorentzshiftY;
     }
   } else {
     //--- Template Reco succeeded.  The probabilities are filled.
@@ -500,10 +498,8 @@ void PixelCPEClusterRepair::callTempReco2D(DetParam const& theDetParam,
                                              << "Should never be here. PixelCPEClusterRepair should always be called "
                                                 "with track angles. This is a bad error !!! ";
 
-      theClusterParam.templXrec_ =
-          theDetParam.theTopol->localX(theClusterParam.theCluster->x(), theClusterParam.loc_trk_pred) + lorentzshiftX;
-      theClusterParam.templYrec_ =
-          theDetParam.theTopol->localY(theClusterParam.theCluster->y(), theClusterParam.loc_trk_pred) + lorentzshiftY;
+      theClusterParam.templXrec_ = theDetParam.theTopol->localX(theClusterParam.theCluster->x()) + lorentzshiftX;
+      theClusterParam.templYrec_ = theDetParam.theTopol->localY(theClusterParam.theCluster->y()) + lorentzshiftY;
     }
 
   } else {

--- a/RecoLocalTracker/SiPixelRecHits/src/PixelCPETemplateReco.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/PixelCPETemplateReco.cc
@@ -328,10 +328,8 @@ LocalPoint PixelCPETemplateReco::localPosition(DetParam const& theDetParam, Clus
         edm::LogError("PixelCPETemplateReco") << "@SUB = PixelCPETemplateReco::localPosition"
                                               << "Should never be here. PixelCPETemplateReco should always be called "
                                                  "with track angles. This is a bad error !!! ";
-        theClusterParam.templXrec_ =
-            theDetParam.theTopol->localX(theClusterParam.theCluster->x(), theClusterParam.loc_trk_pred) + lorentzshiftX;
-        theClusterParam.templYrec_ =
-            theDetParam.theTopol->localY(theClusterParam.theCluster->y(), theClusterParam.loc_trk_pred) + lorentzshiftY;
+        theClusterParam.templXrec_ = theDetParam.theTopol->localX(theClusterParam.theCluster->x()) + lorentzshiftX;
+        theClusterParam.templYrec_ = theDetParam.theTopol->localY(theClusterParam.theCluster->y()) + lorentzshiftY;
       }
     } else {
       // go from micrometer to centimeter

--- a/RecoLocalTracker/SiPixelRecHits/src/PixelCPETemplateReco.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/PixelCPETemplateReco.cc
@@ -151,6 +151,13 @@ LocalPoint PixelCPETemplateReco::localPosition(DetParam const& theDetParam, Clus
 
   // Store these offsets (to be added later) in a LocalPoint after tranforming
   // them from measurement units (pixel units) to local coordinates (cm)
+  //
+  //
+
+  // In case of template reco failure, these are the lorentz drift corrections
+  // to be applied
+  float lorentzshiftX = 0.5f * theDetParam.lorentzShiftInCmX;
+  float lorentzshiftY = 0.5f * theDetParam.lorentzShiftInCmY;
 
   // ggiurgiu@jhu.edu 12/09/2010 : update call with trk angles needed for bow/kink corrections
   LocalPoint lp;
@@ -255,29 +262,22 @@ LocalPoint PixelCPETemplateReco::localPosition(DetParam const& theDetParam, Clus
     LogDebug("PixelCPETemplateReco::localPosition")
         << "reconstruction failed with error " << theClusterParam.ierr << "\n";
 
-    // Gavril: what do we do in this case ? For now, just return the cluster center of gravity in microns
-    // In the x case, apply a rough Lorentz drift average correction
-    // To do: call PixelCPEGeneric whenever PixelTempReco1D fails
-    float lorentz_drift = -999.9;
-    if (!fpix)
-      lorentz_drift = 60.0f;  // in microns
-    else
-      lorentz_drift = 10.0f;  // in microns
+    // Template reco has failed, compute position estimates based on cluster center of gravity + Lorentz drift
+    // Future improvement would be to call generic reco instead
+
     // ggiurgiu@jhu.edu, 21/09/2010 : trk angles needed to correct for bows/kinks
     if (theClusterParam.with_track_angle) {
       theClusterParam.templXrec_ =
-          theDetParam.theTopol->localX(theClusterParam.theCluster->x(), theClusterParam.loc_trk_pred) -
-          lorentz_drift * micronsToCm;  // rough Lorentz drift correction
+          theDetParam.theTopol->localX(theClusterParam.theCluster->x(), theClusterParam.loc_trk_pred) + lorentzshiftX;
       theClusterParam.templYrec_ =
-          theDetParam.theTopol->localY(theClusterParam.theCluster->y(), theClusterParam.loc_trk_pred);
+          theDetParam.theTopol->localY(theClusterParam.theCluster->y(), theClusterParam.loc_trk_pred) + lorentzshiftY;
     } else {
       edm::LogError("PixelCPETemplateReco") << "@SUB = PixelCPETemplateReco::localPosition"
                                             << "Should never be here. PixelCPETemplateReco should always be called "
                                                "with track angles. This is a bad error !!! ";
 
-      theClusterParam.templXrec_ = theDetParam.theTopol->localX(theClusterParam.theCluster->x()) -
-                                   lorentz_drift * micronsToCm;  // rough Lorentz drift correction
-      theClusterParam.templYrec_ = theDetParam.theTopol->localY(theClusterParam.theCluster->y());
+      theClusterParam.templXrec_ = theDetParam.theTopol->localX(theClusterParam.theCluster->x()) + lorentzshiftX;
+      theClusterParam.templYrec_ = theDetParam.theTopol->localY(theClusterParam.theCluster->y()) + lorentzshiftY;
     }
   } else if UNLIKELY (UseClusterSplitter_ && theClusterParam.templQbin_ == 0) {
     edm::LogError("PixelCPETemplateReco") << " PixelCPETemplateReco: Qbin = 0 but using cluster splitter, we should "
@@ -315,33 +315,23 @@ LocalPoint PixelCPETemplateReco::localPosition(DetParam const& theDetParam, Clus
        
        */
     if (theClusterParam.ierr != 0) {
-      LogDebug("PixelCPETemplateReco::localPosition")
-          << "reconstruction failed with error " << theClusterParam.ierr << "\n";
-
-      // Gavril: what do we do in this case ? For now, just return the cluster center of gravity in microns
-      // In the x case, apply a rough Lorentz drift average correction
-      // To do: call PixelCPEGeneric whenever PixelTempReco1D fails
-      float lorentz_drift = -999.9f;
-      if (!fpix)
-        lorentz_drift = 60.0f;  // in microns
-      else
-        lorentz_drift = 10.0f;  // in microns
+      // Template reco has failed, compute position estimates based on cluster center of gravity + Lorentz drift
+      // Future improvement would be to call generic reco instead
 
       // ggiurgiu@jhu.edu, 12/09/2010 : trk angles needed to correct for bows/kinks
       if (theClusterParam.with_track_angle) {
         theClusterParam.templXrec_ =
-            theDetParam.theTopol->localX(theClusterParam.theCluster->x(), theClusterParam.loc_trk_pred) -
-            lorentz_drift * micronsToCm;  // rough Lorentz drift correction
+            theDetParam.theTopol->localX(theClusterParam.theCluster->x(), theClusterParam.loc_trk_pred) + lorentzshiftX;
         theClusterParam.templYrec_ =
-            theDetParam.theTopol->localY(theClusterParam.theCluster->y(), theClusterParam.loc_trk_pred);
+            theDetParam.theTopol->localY(theClusterParam.theCluster->y(), theClusterParam.loc_trk_pred) + lorentzshiftY;
       } else {
         edm::LogError("PixelCPETemplateReco") << "@SUB = PixelCPETemplateReco::localPosition"
                                               << "Should never be here. PixelCPETemplateReco should always be called "
                                                  "with track angles. This is a bad error !!! ";
-
-        theClusterParam.templXrec_ = theDetParam.theTopol->localX(theClusterParam.theCluster->x()) -
-                                     lorentz_drift * micronsToCm;  // very rough Lorentz drift correction
-        theClusterParam.templYrec_ = theDetParam.theTopol->localY(theClusterParam.theCluster->y());
+        theClusterParam.templXrec_ =
+            theDetParam.theTopol->localX(theClusterParam.theCluster->x(), theClusterParam.loc_trk_pred) + lorentzshiftX;
+        theClusterParam.templYrec_ =
+            theDetParam.theTopol->localY(theClusterParam.theCluster->y(), theClusterParam.loc_trk_pred) + lorentzshiftY;
       }
     } else {
       // go from micrometer to centimeter
@@ -377,7 +367,7 @@ LocalPoint PixelCPETemplateReco::localPosition(DetParam const& theDetParam, Clus
     theClusterParam.templYrec_ += lp.y();
 
     // Compute the Alignment Group Corrections [template ID should already be selected from call to reco procedure]
-    if (DoLorentz_) {
+    if (doLorentzFromAlignment_) {
       // Do only if the lotentzshift has meaningfull numbers
       if (theDetParam.lorentzShiftInCmX != 0.0 || theDetParam.lorentzShiftInCmY != 0.0) {
         // the LA width/shift returned by templates use (+)


### PR DESCRIPTION
#### PR description:

This is a combined backport of the commit of PRs #33495 and #33508. 
The changes propose here are needed to fix some minor issues with the determination of the template CPE reconstruction in the case of the Pixel 3D sensors for the Phase-2 inner tracker.
More discussion is available at: https://github.com/cms-sw/cmssw/pull/33495#issuecomment-824616464.
Commit https://github.com/cms-sw/cmssw/pull/33792/commits/2044fd55de151707a1bfbf508e76345d16508ce4 removes the changes that break the current online menus in 11.3.X (introduced after https://github.com/cms-sw/cmssw/pull/33792#discussion_r635894241).
A backport has become necessary in order to allow the production of a small set of samples for detailed POG-level checks on different phase-2 Inner Tracker sensor choices to be handled in CMSSW_11_3_X.

#### PR validation:

Tested and validated privately in the master branch. It compiles in the 11.3.X branch. The branch has also been tested successfully with `addOnTests.py`.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This is a backport of the commits of PRs  #33495 and #33508. 

@cms-sw/upgrade-l2 @emiglior FYI.
