### PR TITLE
Suggested fixes for a few possible trivial mistakes in L1Trigger/L1TTrackMatch

### DIFF
--- a/L1Trigger/L1TTrackMatch/plugins/L1TkEmParticleProducer.cc
+++ b/L1Trigger/L1TTrackMatch/plugins/L1TkEmParticleProducer.cc
@@ -264,7 +264,7 @@ float L1TkEmParticleProducer::CorrectedEta(float eta, float zv) const {
   if (IsBarrel) {
     delta = REcal / tantheta;
   } else {
-    if (theta > 0)
+    if (eta > 0)
       delta = ZEcal;
     else
       delta = -ZEcal;

--- a/L1Trigger/L1TTrackMatch/plugins/L1TkEmParticleProducer.cc
+++ b/L1Trigger/L1TTrackMatch/plugins/L1TkEmParticleProducer.cc
@@ -14,23 +14,20 @@
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/Framework/interface/EventSetup.h"
-
-#include "DataFormats/Common/interface/Handle.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "DataFormats/Common/interface/Handle.h"
 
 #include "DataFormats/L1TCorrelator/interface/TkEm.h"
 #include "DataFormats/L1TCorrelator/interface/TkEmFwd.h"
-
 #include "DataFormats/L1TCorrelator/interface/TkPrimaryVertex.h"
 
 #include "DataFormats/Math/interface/LorentzVector.h"
+#include "DataFormats/Math/interface/deltaR.h"
 
 // for L1Tracks:
 #include "DataFormats/L1TrackTrigger/interface/TTTypes.h"
-
-#include "DataFormats/Math/interface/deltaR.h"
 
 #include <string>
 #include <cmath>
@@ -60,25 +57,23 @@ private:
 
   // ----------member data ---------------------------
 
-  std::string label_;
-
-  float etMin_;  // min ET in GeV of L1EG objects
-
-  float zMax_;  // |z_track| < zMax_ in cm
-  float chi2Max_;
-  float dRMin_;
-  float dRMax_;
-  float pTMinTra_;
-  bool primaryVtxConstrain_;  // use the primary vertex (default = false)
-                              //bool DeltaZConstrain;	// use z = z of the leading track within DR < dRMax_;
-  float deltaZMax_;           // | z_track - z_primaryvtx | < deltaZMax_ in cm.
-                              // Used only when primaryVtxConstrain_ = True.
-  float isoCut_;
-  bool relativeIsolation_;
-
   const edm::EDGetTokenT<EGammaBxCollection> egToken_;
-  const edm::EDGetTokenT<std::vector<TTTrack<Ref_Phase2TrackerDigi_> > > trackToken_;
+  const edm::EDGetTokenT<L1TTTrackCollectionType> trackToken_;
   const edm::EDGetTokenT<TkPrimaryVertexCollection> vertexToken_;
+
+  const std::string label_;
+
+  const float etMin_;  // min ET in GeV of L1EG objects
+  const float zMax_;   // |z_track| < zMax_ in cm
+  const float chi2Max_;
+  const float pTMinTra_;
+  const float dR2Min_;
+  const float dR2Max_;
+  const bool primaryVtxConstrain_;  // use the primary vertex (default = false)
+  const float deltaZMax_;           // | z_track - z_primaryvtx | < deltaZMax_ in cm.
+                                    // Used only when primaryVtxConstrain_ = True.
+  const float isoCut_;
+  const bool relativeIsolation_;
 };
 
 //
@@ -86,29 +81,19 @@ private:
 //
 L1TkEmParticleProducer::L1TkEmParticleProducer(const edm::ParameterSet& iConfig)
     : egToken_(consumes<EGammaBxCollection>(iConfig.getParameter<edm::InputTag>("L1EGammaInputTag"))),
-      trackToken_(consumes<std::vector<TTTrack<Ref_Phase2TrackerDigi_> > >(
-          iConfig.getParameter<edm::InputTag>("L1TrackInputTag"))),
-      vertexToken_(consumes<TkPrimaryVertexCollection>(iConfig.getParameter<edm::InputTag>("L1VertexInputTag"))) {
-  label_ = iConfig.getParameter<std::string>("label");  // label of the collection produced
-  // e.g. EG or IsoEG if all objects are kept
-  // EGIsoTrk or IsoEGIsoTrk if only the EG or IsoEG
-  // objects that pass a cut RelIso < isoCut_ are written
-  // in the new collection.
-
-  etMin_ = (float)iConfig.getParameter<double>("ETmin");
-
-  // parameters for the calculation of the isolation :
-  zMax_ = (float)iConfig.getParameter<double>("ZMAX");
-  chi2Max_ = (float)iConfig.getParameter<double>("CHI2MAX");
-  pTMinTra_ = (float)iConfig.getParameter<double>("PTMINTRA");
-  dRMin_ = (float)iConfig.getParameter<double>("DRmin");
-  dRMax_ = (float)iConfig.getParameter<double>("DRmax");
-  primaryVtxConstrain_ = iConfig.getParameter<bool>("PrimaryVtxConstrain");
-  deltaZMax_ = (float)iConfig.getParameter<double>("DeltaZMax");
-  // cut applied on the isolation (if this number is <= 0, no cut is applied)
-  isoCut_ = (float)iConfig.getParameter<double>("IsoCut");
-  relativeIsolation_ = iConfig.getParameter<bool>("RelativeIsolation");
-
+      trackToken_(consumes<L1TTTrackCollectionType>(iConfig.getParameter<edm::InputTag>("L1TrackInputTag"))),
+      vertexToken_(consumes<TkPrimaryVertexCollection>(iConfig.getParameter<edm::InputTag>("L1VertexInputTag"))),
+      label_(iConfig.getParameter<std::string>("label")),
+      etMin_((float)iConfig.getParameter<double>("ETmin")),
+      zMax_((float)iConfig.getParameter<double>("ZMAX")),
+      chi2Max_((float)iConfig.getParameter<double>("CHI2MAX")),
+      pTMinTra_((float)iConfig.getParameter<double>("PTMINTRA")),
+      dR2Min_((float)iConfig.getParameter<double>("DRmin") * (float)iConfig.getParameter<double>("DRmin")),
+      dR2Max_((float)iConfig.getParameter<double>("DRmax") * (float)iConfig.getParameter<double>("DRmax")),
+      primaryVtxConstrain_(iConfig.getParameter<bool>("PrimaryVtxConstrain")),
+      deltaZMax_((float)iConfig.getParameter<double>("DeltaZMax")),
+      isoCut_((float)iConfig.getParameter<double>("IsoCut")),
+      relativeIsolation_(iConfig.getParameter<bool>("RelativeIsolation")) {
   produces<TkEmCollection>(label_);
 }
 
@@ -120,21 +105,20 @@ void L1TkEmParticleProducer::produce(edm::StreamID, edm::Event& iEvent, const ed
 
   auto result = std::make_unique<TkEmCollection>();
 
-  // the L1EGamma objects
-  edm::Handle<EGammaBxCollection> eGammaHandle;
-  iEvent.getByToken(egToken_, eGammaHandle);
-  EGammaBxCollection eGammaCollection = (*eGammaHandle.product());
-  EGammaBxCollection::const_iterator egIter;
-
   // the L1Tracks
-  edm::Handle<std::vector<TTTrack<Ref_Phase2TrackerDigi_> > > L1TTTrackHandle;
+  edm::Handle<L1TTTrackCollectionType> L1TTTrackHandle;
   iEvent.getByToken(trackToken_, L1TTTrackHandle);
+  if (!L1TTTrackHandle.isValid()) {
+    LogError("L1TkEmParticleProducer") << "\nWarning: L1TTTrackCollectionType not found in the event. Exit."
+                                       << std::endl;
+    return;
+  }
 
   // the primary vertex (used only if primaryVtxConstrain_ = true)
   float zvtxL1tk = -999;
+  bool primaryVtxConstrain = primaryVtxConstrain_;
   edm::Handle<TkPrimaryVertexCollection> L1VertexHandle;
   iEvent.getByToken(vertexToken_, L1VertexHandle);
-  bool primaryVtxConstrain = primaryVtxConstrain_;
   if (!L1VertexHandle.isValid()) {
     LogWarning("L1TkEmParticleProducer")
         << "Warning: TkPrimaryVertexCollection not found in the event. Won't use any PrimaryVertex constraint."
@@ -147,18 +131,16 @@ void L1TkEmParticleProducer::produce(edm::StreamID, edm::Event& iEvent, const ed
     zvtxL1tk = vtxIter->zvertex();
   }
 
-  if (!L1TTTrackHandle.isValid()) {
-    LogError("L1TkEmParticleProducer") << "\nWarning: L1TTTrackCollectionType not found in the event. Exit."
-                                       << std::endl;
-    return;
-  }
-
   // Now loop over the L1EGamma objects
 
+  edm::Handle<EGammaBxCollection> eGammaHandle;
+  iEvent.getByToken(egToken_, eGammaHandle);
   if (!eGammaHandle.isValid()) {
     LogError("L1TkEmParticleProducer") << "\nWarning: L1EmCollection not found in the event. Exit." << std::endl;
     return;
   }
+  EGammaBxCollection eGammaCollection = (*eGammaHandle.product());
+  EGammaBxCollection::const_iterator egIter;
 
   int ieg = 0;
   for (egIter = eGammaCollection.begin(0); egIter != eGammaCollection.end(0); ++egIter)  // considering BX = only
@@ -166,25 +148,23 @@ void L1TkEmParticleProducer::produce(edm::StreamID, edm::Event& iEvent, const ed
     edm::Ref<EGammaBxCollection> EGammaRef(eGammaHandle, ieg);
     ieg++;
 
+    float et = egIter->et();
+    if (et < etMin_)
+      continue;
+
     float eta = egIter->eta();
     // The eta of the L1EG object is seen from (0,0,0).
     // if primaryVtxConstrain_ = true, and for the PV constrained iso, use the zvtxL1tk to correct the eta(L1EG)
     // that is used in the calculation of DeltaR.
-    float etaPV = CorrectedEta((float)eta, zvtxL1tk);
+    float etaPV = CorrectedEta(eta, zvtxL1tk);
 
     float phi = egIter->phi();
-    float et = egIter->et();
-
-    if (et < etMin_)
-      continue;
 
     // calculate the isolation of the L1EG object with
     // respect to L1Tracks.
 
-    float trkisol = -999;
     float sumPt = 0;
     float sumPtPV = 0;
-    float trkisolPV = -999;
 
     for (const auto& track : *L1TTTrackHandle) {
       float Pt = track.momentum().perp();
@@ -199,21 +179,22 @@ void L1TkEmParticleProducer::produce(edm::StreamID, edm::Event& iEvent, const ed
       if (chi2 > chi2Max_)
         continue;
 
-      float dr = reco::deltaR(Eta, Phi, eta, phi);
-      if (dr < dRMax_ && dr >= dRMin_) {
+      float dr2 = reco::deltaR2(Eta, Phi, eta, phi);
+      if (dr2 < dR2Max_ && dr2 >= dR2Min_) {
         sumPt += Pt;
       }
 
       if (zvtxL1tk > -999 && std::abs(z - zvtxL1tk) >= deltaZMax_)
         continue;  // Now, PV constrained trackSum:
 
-      dr = reco::deltaR(Eta, Phi, etaPV, phi);  // recompute using the corrected eta
-
-      if (dr < dRMax_ && dr >= dRMin_) {
+      dr2 = reco::deltaR2(Eta, Phi, etaPV, phi);  // recompute using the corrected eta
+      if (dr2 < dR2Max_ && dr2 >= dR2Min_) {
         sumPtPV += Pt;
       }
     }  // end loop over tracks
 
+    float trkisol = -999;
+    float trkisolPV = -999;
     if (relativeIsolation_) {
       if (et > 0) {
         trkisol = sumPt / et;
@@ -224,10 +205,7 @@ void L1TkEmParticleProducer::produce(edm::StreamID, edm::Event& iEvent, const ed
       trkisolPV = sumPtPV;
     }
 
-    float isolation = trkisol;
-    if (primaryVtxConstrain) {
-      isolation = trkisolPV;
-    }
+    float isolation = primaryVtxConstrain ? trkisolPV : trkisol;
 
     const math::XYZTLorentzVector P4 = egIter->p4();
     TkEm trkEm(P4, EGammaRef, trkisol, trkisolPV);
@@ -253,30 +231,39 @@ void L1TkEmParticleProducer::produce(edm::StreamID, edm::Event& iEvent, const ed
 float L1TkEmParticleProducer::CorrectedEta(float eta, float zv) const {
   // Correct the eta of the L1EG object once we know the zvertex
 
-  bool IsBarrel = (std::abs(eta) < EtaECal);
+  if (zv == 0.)
+    return eta;
 
-  float theta = 2. * atan(exp(-eta));
-  if (theta < 0)
-    theta = theta + M_PI;
-  float tantheta = tan(theta);
-
-  float delta;
-  if (IsBarrel) {
-    delta = REcal / tantheta;
-  } else {
-    if (eta > 0)
-      delta = ZEcal;
-    else
-      delta = -ZEcal;
+  if (eta == 0) {
+    float thetaprime = atan(-REcal / zv);
+    if (thetaprime < 0)
+      thetaprime = thetaprime + M_PI;
+    float etaprime = -log(tan(0.5 * thetaprime));
+    return etaprime;
   }
 
-  float tanthetaprime = delta * tantheta / (delta - zv);
+  bool IsBarrel = (std::abs(eta) < EtaECal);
 
-  float thetaprime = atan(tanthetaprime);
-  if (thetaprime < 0)
-    thetaprime = thetaprime + M_PI;
+  float tanhalftheta = exp(-eta);
+  float tantheta = 2. * tanhalftheta / (1. - tanhalftheta * tanhalftheta);
 
-  float etaprime = -log(tan(thetaprime / 2.));
+  float delta;
+  if (IsBarrel)
+    delta = REcal / tantheta;
+  else
+    delta = eta > 0 ? ZEcal : -ZEcal;
+
+  float etaprime;
+  if (delta == zv) {
+    etaprime = 0.;
+  } else {
+    float tanthetaprime = delta * tantheta / (delta - zv);
+    float thetaprime = atan(tanthetaprime);
+    if (thetaprime < 0)
+      thetaprime = thetaprime + M_PI;
+    etaprime = -log(tan(0.5 * thetaprime));
+  }
+
   return etaprime;
 }
 
@@ -285,8 +272,21 @@ void L1TkEmParticleProducer::fillDescriptions(edm::ConfigurationDescriptions& de
   //The following says we do not know what parameters are allowed so do no validation
   // Please change this to state exactly what you do use, even if it is no parameters
   edm::ParameterSetDescription desc;
-  desc.setUnknown();
-  descriptions.addDefault(desc);
+  desc.add<string>("label", "EG");
+  desc.add<edm::InputTag>("L1EGammaInputTag", edm::InputTag("simCaloStage2Digis"));
+  desc.add<edm::InputTag>("L1TrackInputTag", edm::InputTag("TTTracksFromTrackletEmulation", "Level1TTTracks"));
+  desc.add<edm::InputTag>("L1VertexInputTag", edm::InputTag("L1TkPrimaryVertex"));
+  desc.add<double>("ETmin", -1.);
+  desc.add<bool>("RelativeIsolation", true);
+  desc.add<double>("IsoCut", 0.23);
+  desc.add<double>("ZMAX", 25.);
+  desc.add<double>("CHI2MAX", 100.);
+  desc.add<double>("PTMINTRA", 2.);
+  desc.add<double>("DRmin", 0.07);
+  desc.add<double>("DRmax", 0.30);
+  desc.add<bool>("PrimaryVtxConstrain", false);
+  desc.add<double>("DeltaZMax", 0.6);
+  descriptions.add("l1TkEmParticleProducer", desc);
 }
 
 //define this as a plug-in

--- a/L1Trigger/L1TTrackMatch/plugins/L1TkEmParticleProducer.cc
+++ b/L1Trigger/L1TTrackMatch/plugins/L1TkEmParticleProducer.cc
@@ -266,7 +266,7 @@ float L1TkEmParticleProducer::CorrectedEta(float eta, float zv) const {
   } else {
     if (theta > 0)
       delta = ZEcal;
-    if (theta < 0)
+    else
       delta = -ZEcal;
   }
 

--- a/L1Trigger/L1TTrackMatch/plugins/L1TkFastVertexProducer.cc
+++ b/L1Trigger/L1TTrackMatch/plugins/L1TkFastVertexProducer.cc
@@ -309,25 +309,10 @@ void L1TkFastVertexProducer::produce(edm::StreamID, edm::Event& iEvent, const ed
 
   // sliding windows... maximize bin i + i-1  + i+1
 
-  float zvtx_sliding = -999;
-  float sigma_max = -999;
-  int imax = -999;
+  float zvtx_sliding;
+  float sigma_max;
+  int imax;
   int nb = htmp.GetNbinsX();
-  for (int i = 2; i <= nb - 1; i++) {
-    float a0 = htmp.GetBinContent(i - 1);
-    float a1 = htmp.GetBinContent(i);
-    float a2 = htmp.GetBinContent(i + 1);
-    float sigma = a0 + a1 + a2;
-    if (sigma > sigma_max) {
-      sigma_max = sigma;
-      imax = i;
-      float z0 = htmp.GetBinCenter(i - 1);
-      float z1 = htmp.GetBinCenter(i);
-      float z2 = htmp.GetBinCenter(i + 1);
-      zvtx_sliding = (a0 * z0 + a1 * z1 + a2 * z2) / sigma;
-    }
-  }
-
   std::vector<int> found;
   found.reserve(nVtx_);
   for (int ivtx = 0; ivtx < nVtx_; ivtx++) {

--- a/L1Trigger/L1TTrackMatch/python/L1TkEmParticleProducer_cfi.py
+++ b/L1Trigger/L1TTrackMatch/python/L1TkEmParticleProducer_cfi.py
@@ -1,57 +1,55 @@
 import FWCore.ParameterSet.Config as cms
+from L1Trigger.L1TTrackMatch.l1TkEmParticleProducer_cfi import l1TkEmParticleProducer
 
-L1TkPhotons = cms.EDProducer("L1TkEmParticleProducer",
-        label = cms.string("EG"), 	# labels the collection of L1TkEmParticleProducer that is produced
-					# (not really needed actually)
-        L1EGammaInputTag = cms.InputTag("simCaloStage2Digis",""),
-                                                # When the standard sequences are used :
-                                                #   - for the Run-1 algo, use ("l1extraParticles","NonIsolated")
-                                                #     or ("l1extraParticles","Isolated")
-                                                #   - for the "old stage-2" algo (2x2 clustering), use 
-                                                #     ("SLHCL1ExtraParticles","EGamma") or ("SLHCL1ExtraParticles","IsoEGamma")
-                                                #   - for the new clustering algorithm of Jean-Baptiste et al,
-                                                #     use ("SLHCL1ExtraParticlesNewClustering","IsoEGamma") or
-                                                #     ("SLHCL1ExtraParticlesNewClustering","EGamma").
-        ETmin = cms.double( -1 ),               # Only the L1EG objects that have ET > ETmin in GeV
-                                                # are considered. ETmin < 0 means that no cut is applied.
-        RelativeIsolation = cms.bool( True ),   # default = True. The isolation variable is relative if True,
-                                                # else absolute.
-        IsoCut = cms.double( 0.23 ),             # Cut on the (Trk-based) isolation: only the L1TkEmParticle for which
-                                                # the isolation is below RelIsoCut are written into
-                                                # the output collection. When RelIsoCut < 0, no cut is applied.
-                                                # When RelativeIsolation = False, IsoCut is in GeV.
-           # Determination of the isolation w.r.t. L1Tracks :
-     	L1TrackInputTag = cms.InputTag("TTTracksFromTrackletEmulation", "Level1TTTracks"),
-        ZMAX = cms.double( 25. ),       # in cm
-        CHI2MAX = cms.double( 100. ),
-        PTMINTRA = cms.double( 2. ),    # in GeV
-        DRmin = cms.double( 0.07),
-        DRmax = cms.double( 0.30 ),
-        PrimaryVtxConstrain = cms.bool( False ),  # default = False
-						  # if set to True, the default isolation is the PV constrained one, where L1TkPrimaryVertex is used to constrain
-						  # the tracks entering in the calculation of the isolation 
+L1TkPhotons = l1TkEmParticleProducer.clone(
+        label = "EG",                # labels the collection of L1TkEmParticleProducer that is produced
+                                     # (not really needed actually)
+        L1EGammaInputTag = ("simCaloStage2Digis",""),
+                                     # When the standard sequences are used :
+                                     #   - for the Run-1 algo, use ("l1extraParticles","NonIsolated")
+                                     #     or ("l1extraParticles","Isolated")
+                                     #   - for the "old stage-2" algo (2x2 clustering), use
+                                     #     ("SLHCL1ExtraParticles","EGamma") or ("SLHCL1ExtraParticles","IsoEGamma")
+                                     #   - for the new clustering algorithm of Jean-Baptiste et al,
+                                     #     use ("SLHCL1ExtraParticlesNewClustering","IsoEGamma") or
+                                     #     ("SLHCL1ExtraParticlesNewClustering","EGamma").
+        ETmin = -1.,                 # Only the L1EG objects that have ET > ETmin in GeV
+                                     # are considered. ETmin < 0 means that no cut is applied.
+        RelativeIsolation = True,    # default = True. The isolation variable is relative if true, else absolute.
+        IsoCut = 0.23,               # Cut on the (Trk-based) isolation: only the L1TkEmParticle for which
+                                     # the isolation is below RelIsoCut are written into
+                                     # the output collection. When RelIsoCut < 0, no cut is applied.
+                                     # When RelativeIsolation = False, IsoCut is in GeV.
+                                     # Determination of the isolation w.r.t. L1Tracks :
+        L1TrackInputTag = ("TTTracksFromTrackletEmulation", "Level1TTTracks"),
+        ZMAX = 25.,                   # in cm
+        CHI2MAX = 100.,
+        PTMINTRA = 2.,                # in GeV
+        DRmin = 0.07,
+        DRmax = 0.30,
+        PrimaryVtxConstrain = False,  # default = False
+                                      # if set to True, the default isolation is the PV constrained one, where L1TkPrimaryVertex
+                                      #    is used to constrain the tracks entering in the calculation of the isolation
                                       # if set to False, the isolation is computed and stored, but not used 
-        #DeltaZConstrain = cms.bool( False ),  # default = False
-                                                  # if set to True, constrain to the z of the leading
-						  # track within DR < DRmax
-        DeltaZMax = cms.double( 0.6 ),    # in cm. Used only to compute the isolation with PrimaryVtxConstrain 
-        L1VertexInputTag = cms.InputTag("L1TkPrimaryVertex"),     # in cm. Used to compute the isolation with PrimaryVtxConstrain 
+        DeltaZMax =  0.6,             # in cm. Used only to compute the isolation with PrimaryVtxConstrain 
+        L1VertexInputTag = ("L1TkPrimaryVertex")
 )
 
 
-L1TkPhotonsTightIsol = L1TkPhotons.clone()
-L1TkPhotonsTightIsol.IsoCut = cms.double( 0.10)
+L1TkPhotonsTightIsol = L1TkPhotons.clone(
+    IsoCut = 0.10
+)
 
 #### Additional collections that right now only the menu team is using - to be renamed/redefined by the EGamma group
 # The important change is the EG seed -> PhaseII instead of PhaseI
 
-L1TkPhotonsCrystal=L1TkPhotons.clone()
-L1TkPhotonsCrystal.L1EGammaInputTag = cms.InputTag("L1EGammaClusterEmuProducer", )
-L1TkPhotonsCrystal.IsoCut = cms.double(-0.1)
+L1TkPhotonsCrystal=L1TkPhotons.clone(
+    L1EGammaInputTag = ("L1EGammaClusterEmuProducer", ),
+    IsoCut = -0.1
+)
 
-
-L1TkPhotonsHGC=L1TkPhotons.clone()
-L1TkPhotonsHGC.L1EGammaInputTag = cms.InputTag("l1EGammaEEProducer","L1EGammaCollectionBXVWithCuts")
-L1TkPhotonsHGC.IsoCut = cms.double(-0.1)
-
+L1TkPhotonsHGC=L1TkPhotons.clone(
+    L1EGammaInputTag = ("l1EGammaEEProducer","L1EGammaCollectionBXVWithCuts"),
+    IsoCut = -0.1
+)
 


### PR DESCRIPTION
#### PR description:

Starting from some sparse compilation and static analyzer warnings, I found a few apparently trivial mistakes (bugs?) in the following plugins:
- L1Trigger/L1TTrackMatch/plugins/L1TkEmParticleProducer.cc
- L1Trigger/L1TTrackMatch/plugins/L1TkFastVertexProducer.cc

The fixes suggested in this attempt PR are able to get rid of the warnings. But I suspect that they can only hide the real problem, which would require a more informed bug fix campaign there.

@cecilecaillol and @cms-sw/l1-l2 could you please have a look?

#### PR validation:

It builds
As such, no changes are expected in outputs. But I don't think the first implementation can be considered the final fix