### PR TITLE
GT Initialization: ignoring non-existing record in the plugins pre-load

### DIFF
--- a/CondCore/ESSources/plugins/CondDBESSource.cc
+++ b/CondCore/ESSources/plugins/CondDBESSource.cc
@@ -233,8 +233,12 @@ CondDBESSource::CondDBESSource(const edm::ParameterSet& iConfig)
   std::vector<std::unique_ptr<cond::DataProxyWrapperBase>> proxyWrappers(m_tagCollection.size());
   size_t ipb = 0;
   for (it = itBeg; it != itEnd; ++it) {
-    proxyWrappers[ipb++] = std::unique_ptr<cond::DataProxyWrapperBase>{
-        cond::ProxyFactory::get()->tryToCreate(buildName(it->second.recordName()))}; 
+    size_t ind = ipb++;
+    proxyWrappers[ind] = std::unique_ptr<cond::DataProxyWrapperBase>{
+      cond::ProxyFactory::get()->tryToCreate(buildName(it->second.recordName()))}; 
+    if(!proxyWrappers[ind].get()){
+      edm::LogWarning("CondDBESSource") << "Plugin for Record "<<it->second.recordName()<<" has not been found."<<std::endl;
+    }
   }
 
   // now all required libraries have been loaded

--- a/CondCore/ESSources/plugins/CondDBESSource.cc
+++ b/CondCore/ESSources/plugins/CondDBESSource.cc
@@ -237,8 +237,7 @@ CondDBESSource::CondDBESSource(const edm::ParameterSet& iConfig)
     proxyWrappers[ind] = std::unique_ptr<cond::DataProxyWrapperBase>{
         cond::ProxyFactory::get()->tryToCreate(buildName(it->second.recordName()))};
     if (!proxyWrappers[ind].get()) {
-      edm::LogWarning("CondDBESSource") << "Plugin for Record " << it->second.recordName() << " has not been found."
-                                        << std::endl;
+      edm::LogWarning("CondDBESSource") << "Plugin for Record " << it->second.recordName() << " has not been found.";
     }
   }
 

--- a/CondCore/ESSources/plugins/CondDBESSource.cc
+++ b/CondCore/ESSources/plugins/CondDBESSource.cc
@@ -235,9 +235,10 @@ CondDBESSource::CondDBESSource(const edm::ParameterSet& iConfig)
   for (it = itBeg; it != itEnd; ++it) {
     size_t ind = ipb++;
     proxyWrappers[ind] = std::unique_ptr<cond::DataProxyWrapperBase>{
-      cond::ProxyFactory::get()->tryToCreate(buildName(it->second.recordName()))}; 
-    if(!proxyWrappers[ind].get()){
-      edm::LogWarning("CondDBESSource") << "Plugin for Record "<<it->second.recordName()<<" has not been found."<<std::endl;
+        cond::ProxyFactory::get()->tryToCreate(buildName(it->second.recordName()))};
+    if (!proxyWrappers[ind].get()) {
+      edm::LogWarning("CondDBESSource") << "Plugin for Record " << it->second.recordName() << " has not been found."
+                                        << std::endl;
     }
   }
 
@@ -273,16 +274,16 @@ CondDBESSource::CondDBESSource(const edm::ParameterSet& iConfig)
     // ownership...
     ProxyP proxy(std::move(proxyWrappers[ipb++]));
     //  instert in the map
-    if(proxy.get()){
+    if (proxy.get()) {
       m_proxies.insert(std::make_pair(it->second.recordName(), proxy));
       // initialize
       boost::posix_time::ptime tagSnapshotTime = snapshotTime;
       auto tagSnapshotIter = specialSnapshots.find(it->first);
       if (tagSnapshotIter != specialSnapshots.end())
-	tagSnapshotTime = tagSnapshotIter->second;
+        tagSnapshotTime = tagSnapshotIter->second;
       // finally, if the snapshot is set to infinity, reset the snapshot to null, to take the full iov set...
       if (tagSnapshotTime == boost::posix_time::time_from_string(std::string(cond::time::MAX_TIMESTAMP)))
-	tagSnapshotTime = boost::posix_time::ptime();
+        tagSnapshotTime = boost::posix_time::ptime();
 
       proxy->lateInit(nsess, tag, tagSnapshotTime, it->second.recordLabel(), connStr, &m_queue, &m_mutex);
     }


### PR DESCRIPTION
#### PR description:

CMSSW Workflows requiring the consumption of conditions can be successfully executed  when all the records involved in the code are represented by their corresponding entries in the Global Tag loaded from the Condition Database. 

Conversely, additional Records included in the GT Record-Tag map could be ignored when they are not involved in the Workflow code.  This is the case, for instance, of Records that have been completely removed from the CMSSW Code.

This PR is addressing this last particular circumstance.  The GT initialisation has been modify to ignore the Records for which the corresponding plugin can't be found in CMSSW.

The new behaviour is obviously applied to Records added manually with toGet statements, when not present in the release.

Note that these changes are not altering the current behaviour for other possible mis-matches between release and database,  that could happen at later stage in the processing:

- Failures produced when no suitable IOV is found for a record invoked in the Workflow
- Failures produced when the payload to be used for a given record cannot be read in the release, because written with a higher boost version
- Failures produced when the Record, associated to given CondFormat in the release,  is mapped in the GT, to a Tag populated with payloads from a different class ( this is normally forbidden by policy )

#### PR validation:

Integration test, executed with a specific GT (106X_mcRun2_asymptotic_v15) triggering in 12X the condition of 'missing record plugin'

