### PR TITLE
IORawData/CSCCommissioning file reader fixes 

### DIFF
--- a/IORawData/CSCCommissioning/src/CSCFileReader.cc
+++ b/IORawData/CSCCommissioning/src/CSCFileReader.cc
@@ -37,7 +37,12 @@ CSCFileReader::CSCFileReader(const edm::ParameterSet &pset) {
   //  this is ok as long as eighter of RUI or FU are are provided in .cfg (not both)
   nActiveRUIs = 0;
   nActiveFUs = 0;
-  fFirstReadBug = true;
+
+  /// Legacy first read EDM EvendID bug (fixed?).
+  /// Currently disabled to fix number of events with data
+  /// Added as configurable parameter
+  // fFirstReadBug = true;
+  fFirstReadBug = pset.getUntrackedParameter<bool>("FirstReadBug", false);
   for (int unit = 0; unit < nRUIs; unit++) {
     std::ostringstream ruiName, fuName;
     ruiName << "RUI" << (unit < 10 ? "0" : "") << unit << std::ends;

--- a/IORawData/CSCCommissioning/src/FileReaderDCC.cc
+++ b/IORawData/CSCCommissioning/src/FileReaderDCC.cc
@@ -17,7 +17,7 @@ FileReaderDCC::FileReaderDCC(void) {
     throw std::runtime_error(std::string("Wrong platform: sizeof(unsigned long long)!=8 || sizeof(unsigned short)!=2"));
   raw_event = new unsigned short[200000 * 40];
   end = (file_buffer_end = file_buffer + sizeof(file_buffer) / sizeof(unsigned long long));
-  bzero(raw_event, sizeof(raw_event) * 200000 * 40);
+  bzero(raw_event, sizeof(unsigned short) * 200000 * 40);
   bzero(file_buffer, sizeof(file_buffer));
   word_0 = 0;
   word_1 = 0;

--- a/IORawData/CSCCommissioning/test/readFile_b904_Run3.py
+++ b/IORawData/CSCCommissioning/test/readFile_b904_Run3.py
@@ -1,0 +1,40 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("reader")
+
+# Better to know actual number of events in the .raw data file to set maxEvents.
+# Otherwise it doesn't stop automatically at the end of reading of .raw data file
+process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(10000) )
+
+process.load("FWCore.MessageLogger.MessageLogger_cfi")
+process.MessageLogger.cout.threshold = cms.untracked.string('INFO')
+process.MessageLogger.debugModules = cms.untracked.vstring('*')
+
+process.options = cms.untracked.PSet( wantSummary = cms.untracked.bool(True) )
+
+
+process.source = cms.Source("EmptySource",
+      firstRun= cms.untracked.uint32(1),
+      numberEventsInLuminosityBlock = cms.untracked.uint32(200),
+      numberEventsInRun       = cms.untracked.uint32(0)
+)
+
+# For B904 setup ME11 chamber, which corresponds to ME+1/1/02 in the production system mapping
+#   changing to FED837 and RUI16 could let to pass data without disabling mapping consistency check unpacking flags
+process.rawDataCollector = cms.EDProducer('CSCFileReader',
+      firstEvent  = cms.untracked.int32(0),
+      FED846 = cms.untracked.vstring('RUI01'),        
+      RUI01 = cms.untracked.vstring('/afs/cern.ch/user/b/barvic/public/cscgem_tests/csc_00000001_EmuRUI01_Local_000_210422_152923_UTC.raw')
+#      FED837 = cms.untracked.vstring('RUI16'),
+#      RUI16 = cms.untracked.vstring('/afs/cern.ch/user/b/barvic/public/cscgem_tests/csc_00000001_EmuRUI01_Local_000_210519_162820_UTC.raw')
+)
+
+process.FEVT = cms.OutputModule("PoolOutputModule",
+        fileName = cms.untracked.string("/tmp/barvic/csc_00000001_EmuRUI01_Local_000_210422_152923_UTC.root"),
+        outputCommands = cms.untracked.vstring("keep *")
+)
+
+process.p = cms.Path( process.rawDataCollector)
+
+process.outpath = cms.EndPath(process.FEVT)
+

--- a/IORawData/CSCCommissioning/test/readFile_b904_Run3.py
+++ b/IORawData/CSCCommissioning/test/readFile_b904_Run3.py
@@ -1,10 +1,7 @@
 import FWCore.ParameterSet.Config as cms
+from FWCore.ParameterSet.VarParsing import VarParsing
 
 process = cms.Process("reader")
-
-# Better to know actual number of events in the .raw data file to set maxEvents.
-# Otherwise it doesn't stop automatically at the end of reading of .raw data file
-process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(10000) )
 
 process.load("FWCore.MessageLogger.MessageLogger_cfi")
 process.MessageLogger.cout.threshold = cms.untracked.string('INFO')
@@ -12,9 +9,17 @@ process.MessageLogger.debugModules = cms.untracked.vstring('*')
 
 process.options = cms.untracked.PSet( wantSummary = cms.untracked.bool(True) )
 
+options = VarParsing ('analysis')
+options.register ("firstRun", 341761, VarParsing.multiplicity.singleton, VarParsing.varType.int)
+options.maxEvents = 10000
+options.parseArguments()
+
+# Better to know actual number of events in the .raw data file to set maxEvents.
+# Otherwise it doesn't stop automatically at the end of reading of .raw data file
+process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(options.maxEvents) )
 
 process.source = cms.Source("EmptySource",
-      firstRun= cms.untracked.uint32(1),
+      firstRun= cms.untracked.uint32(options.firstRun),
       numberEventsInLuminosityBlock = cms.untracked.uint32(200),
       numberEventsInRun       = cms.untracked.uint32(0)
 )


### PR DESCRIPTION
#### PR description:
IORawData/CSCCommissioning fixes
- File reader crash fix. Fixed typo for FileReaderDCC, which was causing this tool crashes
- Changes for legacy CSCFileReader FirstReadBug to correct number of events in converted data files


