### PR TITLE
shared memory support for SonicTriton

### DIFF
--- a/HeterogeneousCore/CUDAUtilities/interface/cudaCheck.h
+++ b/HeterogeneousCore/CUDAUtilities/interface/cudaCheck.h
@@ -6,6 +6,7 @@
 #include <sstream>
 #include <stdexcept>
 #include <string>
+#include <string_view>
 
 // CUDA headers
 #include <cuda.h>
@@ -22,19 +23,19 @@ namespace cms {
                                               const char* cmd,
                                               const char* error,
                                               const char* message,
-                                              const char* description = nullptr) {
+                                              std::string_view description = std::string_view()) {
       std::ostringstream out;
       out << "\n";
       out << file << ", line " << line << ":\n";
       out << "cudaCheck(" << cmd << ");\n";
       out << error << ": " << message << "\n";
-      if (description)
+      if (!description.empty())
         out << description << "\n";
       throw std::runtime_error(out.str());
     }
 
     inline bool cudaCheck_(
-        const char* file, int line, const char* cmd, CUresult result, const char* description = nullptr) {
+        const char* file, int line, const char* cmd, CUresult result, std::string_view description = std::string_view()) {
       if (LIKELY(result == CUDA_SUCCESS))
         return true;
 
@@ -47,12 +48,7 @@ namespace cms {
     }
 
     inline bool cudaCheck_(
-        const char* file, int line, const char* cmd, CUresult result, const std::string& description) {
-      return cudaCheck_(file, line, cmd, result, description.c_str());
-    }
-
-    inline bool cudaCheck_(
-        const char* file, int line, const char* cmd, cudaError_t result, const char* description = nullptr) {
+        const char* file, int line, const char* cmd, cudaError_t result, std::string_view description = std::string_view()) {
       if (LIKELY(result == cudaSuccess))
         return true;
 
@@ -60,11 +56,6 @@ namespace cms {
       const char* message = cudaGetErrorString(result);
       abortOnCudaError(file, line, cmd, error, message, description);
       return false;
-    }
-
-    inline bool cudaCheck_(
-        const char* file, int line, const char* cmd, cudaError_t result, const std::string& description) {
-      return cudaCheck_(file, line, cmd, result, description.c_str());
     }
   }  // namespace cuda
 }  // namespace cms

--- a/HeterogeneousCore/CUDAUtilities/interface/cudaCheck.h
+++ b/HeterogeneousCore/CUDAUtilities/interface/cudaCheck.h
@@ -34,8 +34,11 @@ namespace cms {
       throw std::runtime_error(out.str());
     }
 
-    inline bool cudaCheck_(
-        const char* file, int line, const char* cmd, CUresult result, std::string_view description = std::string_view()) {
+    inline bool cudaCheck_(const char* file,
+                           int line,
+                           const char* cmd,
+                           CUresult result,
+                           std::string_view description = std::string_view()) {
       if (LIKELY(result == CUDA_SUCCESS))
         return true;
 
@@ -47,8 +50,11 @@ namespace cms {
       return false;
     }
 
-    inline bool cudaCheck_(
-        const char* file, int line, const char* cmd, cudaError_t result, std::string_view description = std::string_view()) {
+    inline bool cudaCheck_(const char* file,
+                           int line,
+                           const char* cmd,
+                           cudaError_t result,
+                           std::string_view description = std::string_view()) {
       if (LIKELY(result == cudaSuccess))
         return true;
 

--- a/HeterogeneousCore/CUDAUtilities/interface/cudaCheck.h
+++ b/HeterogeneousCore/CUDAUtilities/interface/cudaCheck.h
@@ -5,6 +5,7 @@
 #include <iostream>
 #include <sstream>
 #include <stdexcept>
+#include <string>
 
 // CUDA headers
 #include <cuda.h>
@@ -46,6 +47,11 @@ namespace cms {
     }
 
     inline bool cudaCheck_(
+        const char* file, int line, const char* cmd, CUresult result, const std::string& description) {
+      return cudaCheck_(file, line, cmd, result, description.c_str());
+    }
+
+    inline bool cudaCheck_(
         const char* file, int line, const char* cmd, cudaError_t result, const char* description = nullptr) {
       if (LIKELY(result == cudaSuccess))
         return true;
@@ -56,6 +62,10 @@ namespace cms {
       return false;
     }
 
+    inline bool cudaCheck_(
+        const char* file, int line, const char* cmd, cudaError_t result, const std::string& description) {
+      return cudaCheck_(file, line, cmd, result, description.c_str());
+    }
   }  // namespace cuda
 }  // namespace cms
 

--- a/HeterogeneousCore/SonicCore/src/SonicClientBase.cc
+++ b/HeterogeneousCore/SonicCore/src/SonicClientBase.cc
@@ -73,6 +73,10 @@ void SonicClientBase::finish(bool success, std::exception_ptr eptr) {
     holder_.reset();
   } else if (eptr)
     std::rethrow_exception(eptr);
+
+  //reset client data now (usually done at end of produce())
+  if (eptr)
+    reset();
 }
 
 void SonicClientBase::fillBasePSetDescription(edm::ParameterSetDescription& desc, bool allowRetry) {

--- a/HeterogeneousCore/SonicTriton/BuildFile.xml
+++ b/HeterogeneousCore/SonicTriton/BuildFile.xml
@@ -6,7 +6,9 @@
 <use name="HeterogeneousCore/SonicCore"/>
 <use name="triton-inference-server"/>
 <use name="protobuf"/>
-<use name="cuda"/>
+<iftool name="cuda">
+  <use name="cuda"/>
+</iftool>
 <export>
   <lib   name="1"/>
 </export>

--- a/HeterogeneousCore/SonicTriton/BuildFile.xml
+++ b/HeterogeneousCore/SonicTriton/BuildFile.xml
@@ -4,6 +4,7 @@
 <use name="FWCore/ParameterSet"/>
 <use name="FWCore/Utilities"/>
 <use name="HeterogeneousCore/SonicCore"/>
+<use name="HeterogeneousCore/CUDAUtilities"/>
 <use name="triton-inference-server"/>
 <use name="protobuf"/>
 <iftool name="cuda">

--- a/HeterogeneousCore/SonicTriton/BuildFile.xml
+++ b/HeterogeneousCore/SonicTriton/BuildFile.xml
@@ -6,6 +6,7 @@
 <use name="HeterogeneousCore/SonicCore"/>
 <use name="triton-inference-server"/>
 <use name="protobuf"/>
+<use name="cuda"/>
 <export>
   <lib   name="1"/>
 </export>

--- a/HeterogeneousCore/SonicTriton/README.md
+++ b/HeterogeneousCore/SonicTriton/README.md
@@ -30,6 +30,12 @@ The model information from the server can be printed by enabling `verbose` outpu
 * `preferredServer`: name of preferred server, for testing (see [Services](#services) below)
 * `timeout`: maximum allowed time for a request
 * `outputs`: optional, specify which output(s) the server should send
+* `verbose`: enable verbose printouts (default: false)
+* `useSharedMemory`: enable use of shared memory (see [below](#shared-memory)) with local servers (default: true)
+
+The batch size should be set using the client accessor, in order to ensure a consistent value across all inputs:
+* `setBatchSize()`: set a new batch size
+  * some models may not support batching
 
 Useful `TritonData` accessors include:
 * `variableDims()`: return true if any variable dimensions
@@ -39,8 +45,6 @@ Useful `TritonData` accessors include:
 * `byteSize()`: return number of bytes for data type
 * `dname()`: return name of data type
 * `batchSize()`: return current batch size
-* `setBatchSize()`: set a new batch size
-  * some models may not support batching
 
 To update the `TritonData` shape in the variable-dimension case:
 * `setShape(const std::vector<int64_t>& newShape)`: update all (variable) dimensions with values provided in `newShape`
@@ -49,8 +53,27 @@ To update the `TritonData` shape in the variable-dimension case:
 There are specific local input and output containers that should be used in producers.
 Here, `T` is a primitive type, and the two aliases listed below are passed to `TritonInputData::toServer()`
 and returned by `TritonOutputData::fromServer()`, respectively:
-* `TritonInput<T> = std::vector<std::vector<T>>`
+* `TritonInputContainer<T> = std::shared_ptr<TritonInput<T>> = std::shared_ptr<std::vector<std::vector<T>>>`
 * `TritonOutput<T> = std::vector<edm::Span<const T*>>`
+
+The `TritonInputContainer` object should be created using the helper function described below.
+It expects one vector per batch entry (i.e. the size of the outer vector is the batch size).
+Therefore, it is best to call `TritonClient::setBatchSize()`, if necessary, before calling the helper.
+It will also reserve the expected size of the input in each inner vector (by default),
+if the concrete shape is available (i.e. `setShape()` was already called, if the input has variable dimensions).
+* `allocate<T>()`: return a `TritonInputContainer` properly allocated for the batch and input sizes
+
+### Shared memory
+
+If the local fallback server (see [Services](#services) below) is in use,
+input and output data can be transferred via shared memory rather than gRPC.
+Both CPU and GPU (CUDA) shared memory are supported.
+This is more efficient for some algorithms;
+if shared memory is not more efficient for an algorithm, it can be disabled in the Python configuration for the client.
+
+For outputs, shared memory can only be used if the batch size and concrete shape are known in advance,
+because the shared memory region for the output must be registered before the inference call is made.
+As with the inputs, this is handled automatically, and the use of shared memory can be disabled if desired.
 
 ## Modules
 
@@ -71,7 +94,7 @@ If an `edm::GlobalCache` of type `T` is needed, there are two changes:
 In a SONIC Triton producer, the basic flow should follow this pattern:
 1. `acquire()`:  
     a. access input object(s) from `TritonInputMap`  
-    b. allocate input data using `std::make_shared<TritonInput<T>>()`  
+    b. allocate input data using `allocate<T>()`  
     c. fill input data  
     d. set input shape(s) (optional, only if any variable dimensions)  
     e. convert using `toServer()` function of input object(s)  

--- a/HeterogeneousCore/SonicTriton/interface/TritonClient.h
+++ b/HeterogeneousCore/SonicTriton/interface/TritonClient.h
@@ -49,9 +49,9 @@ public:
   static void fillPSetDescription(edm::ParameterSetDescription& iDesc);
 
 protected:
-  //helper
-  bool getResults(std::shared_ptr<nvidia::inferenceserver::client::InferResult> results);
-
+  //helpers
+  void getResults(std::shared_ptr<nvidia::inferenceserver::client::InferResult> results);
+  bool checkEptr();
   void evaluate() override;
 
   void reportServerSideStats(const ServerSideStats& stats) const;

--- a/HeterogeneousCore/SonicTriton/interface/TritonClient.h
+++ b/HeterogeneousCore/SonicTriton/interface/TritonClient.h
@@ -52,6 +52,8 @@ protected:
   //helpers
   void getResults(std::shared_ptr<nvidia::inferenceserver::client::InferResult> results);
   void evaluate() override;
+  template <typename F>
+  bool handle_exception(F&& call);
 
   void reportServerSideStats(const ServerSideStats& stats) const;
   ServerSideStats summarizeServerStats(const inference::ModelStatistics& start_status,

--- a/HeterogeneousCore/SonicTriton/interface/TritonClient.h
+++ b/HeterogeneousCore/SonicTriton/interface/TritonClient.h
@@ -13,7 +13,7 @@
 #include <exception>
 #include <unordered_map>
 
-#include "HeterogeneousCore/SonicTriton/interface/grpc_client_gpu.h"
+#include "grpc_client.h"
 #include "grpc_service.pb.h"
 
 class TritonClient : public SonicClient<TritonInputMap, TritonOutputMap> {

--- a/HeterogeneousCore/SonicTriton/interface/TritonClient.h
+++ b/HeterogeneousCore/SonicTriton/interface/TritonClient.h
@@ -5,6 +5,7 @@
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "HeterogeneousCore/SonicCore/interface/SonicClient.h"
 #include "HeterogeneousCore/SonicTriton/interface/TritonData.h"
+#include "HeterogeneousCore/SonicTriton/interface/TritonService.h"
 
 #include <map>
 #include <vector>
@@ -12,7 +13,7 @@
 #include <exception>
 #include <unordered_map>
 
-#include "grpc_client.h"
+#include "HeterogeneousCore/SonicTriton/interface/grpc_client_gpu.h"
 #include "grpc_service.pb.h"
 
 class TritonClient : public SonicClient<TritonInputMap, TritonOutputMap> {
@@ -31,11 +32,18 @@ public:
   //constructor
   TritonClient(const edm::ParameterSet& params, const std::string& debugName);
 
+  //destructor
+  ~TritonClient() override;
+
   //accessors
   unsigned batchSize() const { return batchSize_; }
   bool verbose() const { return verbose_; }
+  bool useSharedMemory() const { return useSharedMemory_; }
+  void setUseSharedMemory(bool useShm) { useSharedMemory_ = useShm; }
   bool setBatchSize(unsigned bsize);
   void reset() override;
+  bool noBatch() const { return noBatch_; }
+  TritonServerType serverType() const { return serverType_; }
 
   //for fillDescriptions
   static void fillPSetDescription(edm::ParameterSetDescription& iDesc);
@@ -57,6 +65,8 @@ protected:
   unsigned batchSize_;
   bool noBatch_;
   bool verbose_;
+  bool useSharedMemory_;
+  TritonServerType serverType_;
 
   //IO pointers for triton
   std::vector<nvidia::inferenceserver::client::InferInput*> inputsTriton_;
@@ -65,6 +75,13 @@ protected:
   std::unique_ptr<nvidia::inferenceserver::client::InferenceServerGrpcClient> client_;
   //stores timeout, model name and version
   nvidia::inferenceserver::client::InferOptions options_;
+
+private:
+  friend TritonInputData;
+  friend TritonOutputData;
+
+  //private accessors only used by data
+  auto client() { return client_.get(); }
 };
 
 #endif

--- a/HeterogeneousCore/SonicTriton/interface/TritonClient.h
+++ b/HeterogeneousCore/SonicTriton/interface/TritonClient.h
@@ -51,7 +51,6 @@ public:
 protected:
   //helpers
   void getResults(std::shared_ptr<nvidia::inferenceserver::client::InferResult> results);
-  bool checkEptr();
   void evaluate() override;
 
   void reportServerSideStats(const ServerSideStats& stats) const;

--- a/HeterogeneousCore/SonicTriton/interface/TritonData.h
+++ b/HeterogeneousCore/SonicTriton/interface/TritonData.h
@@ -10,19 +10,31 @@
 #include <numeric>
 #include <algorithm>
 #include <memory>
-#include <any>
+#include <atomic>
 
-#include "grpc_client.h"
+#include "HeterogeneousCore/SonicTriton/interface/grpc_client_gpu.h"
 #include "grpc_service.pb.h"
 
 //forward declaration
 class TritonClient;
+template <typename IO>
+class TritonMemResource;
+template <typename IO>
+class TritonHeapResource;
+template <typename IO>
+class TritonCpuShmResource;
+template <typename IO>
+class TritonGpuShmResource;
 
 //aliases for local input and output types
 template <typename DT>
 using TritonInput = std::vector<std::vector<DT>>;
 template <typename DT>
 using TritonOutput = std::vector<edm::Span<const DT*>>;
+
+//other useful typdefs
+template <typename DT>
+using TritonInputContainer = std::shared_ptr<TritonInput<DT>>;
 
 //store all the info needed for triton input and output
 template <typename IO>
@@ -34,7 +46,7 @@ public:
   using ShapeView = edm::Span<ShapeType::const_iterator>;
 
   //constructor
-  TritonData(const std::string& name, const TensorMetadata& model_info, bool noBatch);
+  TritonData(const std::string& name, const TensorMetadata& model_info, TritonClient* client, const std::string& pid);
 
   //some members can be modified
   bool setShape(const ShapeType& newShape) { return setShape(newShape, true); }
@@ -42,7 +54,10 @@ public:
 
   //io accessors
   template <typename DT>
-  void toServer(std::shared_ptr<TritonInput<DT>> ptr);
+  TritonInputContainer<DT> allocate(bool reserve = true);
+  template <typename DT>
+  void toServer(TritonInputContainer<DT> ptr);
+  bool prepare();
   template <typename DT>
   TritonOutput<DT> fromServer() const;
 
@@ -60,14 +75,23 @@ public:
 
 private:
   friend class TritonClient;
+  friend class TritonMemResource<IO>;
+  friend class TritonHeapResource<IO>;
+  friend class TritonCpuShmResource<IO>;
+  friend class TritonGpuShmResource<IO>;
 
-  //private accessors only used by client
+  //private accessors only used internally or by client
+  unsigned fullLoc(unsigned loc) const { return loc + (noBatch_ ? 0 : 1); }
   bool setShape(const ShapeType& newShape, bool canThrow);
   bool setShape(unsigned loc, int64_t val, bool canThrow);
   void setBatchSize(unsigned bsize);
   void reset();
   void setResult(std::shared_ptr<Result> result) { result_ = result; }
   IO* data() { return data_.get(); }
+  bool updateMem(size_t size, bool can_throw);
+  void computeSizes();
+  void resetSizes();
+  nvidia::inferenceserver::client::InferenceServerGrpcClient* client();
 
   //helpers
   bool anyNeg(const ShapeView& vec) const {
@@ -76,11 +100,20 @@ private:
   int64_t dimProduct(const ShapeView& vec) const {
     return std::accumulate(vec.begin(), vec.end(), 1, std::multiplies<int64_t>());
   }
-  void createObject(IO** ioptr) const;
+  void createObject(IO** ioptr);
+  //generates a unique id number for each instance of the class
+  unsigned uid() const {
+    static std::atomic<unsigned> uid{0};
+    return ++uid;
+  }
+  std::string xput() const;
 
   //members
   std::string name_;
   std::shared_ptr<IO> data_;
+  TritonClient* client_;
+  bool useShm_;
+  std::string shmName_;
   const ShapeType dims_;
   bool noBatch_;
   unsigned batchSize_;
@@ -91,7 +124,11 @@ private:
   std::string dname_;
   inference::DataType dtype_;
   int64_t byteSize_;
-  std::any holder_;
+  size_t sizeShape_;
+  size_t byteSizePerBatch_;
+  size_t totalByteSize_;
+  mutable std::shared_ptr<void> holder_;
+  std::shared_ptr<TritonMemResource<IO>> memResource_;
   std::shared_ptr<Result> result_;
 };
 
@@ -102,8 +139,17 @@ using TritonOutputMap = std::unordered_map<std::string, TritonOutputData>;
 
 //avoid "explicit specialization after instantiation" error
 template <>
+std::string TritonInputData::xput() const;
+template <>
+std::string TritonOutputData::xput() const;
+template <>
+template <typename DT>
+TritonInputContainer<DT> TritonInputData::allocate(bool reserve);
+template <>
 template <typename DT>
 void TritonInputData::toServer(std::shared_ptr<TritonInput<DT>> ptr);
+template <>
+bool TritonOutputData::prepare();
 template <>
 template <typename DT>
 TritonOutput<DT> TritonOutputData::fromServer() const;
@@ -112,9 +158,9 @@ void TritonInputData::reset();
 template <>
 void TritonOutputData::reset();
 template <>
-void TritonInputData::createObject(nvidia::inferenceserver::client::InferInput** ioptr) const;
+void TritonInputData::createObject(nvidia::inferenceserver::client::InferInput** ioptr);
 template <>
-void TritonOutputData::createObject(nvidia::inferenceserver::client::InferRequestedOutput** ioptr) const;
+void TritonOutputData::createObject(nvidia::inferenceserver::client::InferRequestedOutput** ioptr);
 
 //explicit template instantiation declarations
 extern template class TritonData<nvidia::inferenceserver::client::InferInput>;

--- a/HeterogeneousCore/SonicTriton/interface/TritonData.h
+++ b/HeterogeneousCore/SonicTriton/interface/TritonData.h
@@ -12,7 +12,7 @@
 #include <memory>
 #include <atomic>
 
-#include "HeterogeneousCore/SonicTriton/interface/grpc_client_gpu.h"
+#include "grpc_client.h"
 #include "grpc_service.pb.h"
 
 //forward declaration

--- a/HeterogeneousCore/SonicTriton/interface/TritonData.h
+++ b/HeterogeneousCore/SonicTriton/interface/TritonData.h
@@ -23,8 +23,10 @@ template <typename IO>
 class TritonHeapResource;
 template <typename IO>
 class TritonCpuShmResource;
+#ifdef TRITON_ENABLE_GPU
 template <typename IO>
 class TritonGpuShmResource;
+#endif
 
 //aliases for local input and output types
 template <typename DT>
@@ -78,7 +80,9 @@ private:
   friend class TritonMemResource<IO>;
   friend class TritonHeapResource<IO>;
   friend class TritonCpuShmResource<IO>;
+#ifdef TRITON_ENABLE_GPU
   friend class TritonGpuShmResource<IO>;
+#endif
 
   //private accessors only used internally or by client
   unsigned fullLoc(unsigned loc) const { return loc + (noBatch_ ? 0 : 1); }

--- a/HeterogeneousCore/SonicTriton/interface/TritonData.h
+++ b/HeterogeneousCore/SonicTriton/interface/TritonData.h
@@ -127,7 +127,7 @@ private:
   size_t sizeShape_;
   size_t byteSizePerBatch_;
   size_t totalByteSize_;
-  mutable std::shared_ptr<void> holder_;
+  std::shared_ptr<void> holder_;
   std::shared_ptr<TritonMemResource<IO>> memResource_;
   std::shared_ptr<Result> result_;
 };

--- a/HeterogeneousCore/SonicTriton/interface/TritonData.h
+++ b/HeterogeneousCore/SonicTriton/interface/TritonData.h
@@ -51,15 +51,15 @@ public:
   TritonData(const std::string& name, const TensorMetadata& model_info, TritonClient* client, const std::string& pid);
 
   //some members can be modified
-  bool setShape(const ShapeType& newShape) { return setShape(newShape, true); }
-  bool setShape(unsigned loc, int64_t val) { return setShape(loc, val, true); }
+  void setShape(const ShapeType& newShape);
+  void setShape(unsigned loc, int64_t val);
 
   //io accessors
   template <typename DT>
   TritonInputContainer<DT> allocate(bool reserve = true);
   template <typename DT>
   void toServer(TritonInputContainer<DT> ptr);
-  bool prepare();
+  void prepare();
   template <typename DT>
   TritonOutput<DT> fromServer() const;
 
@@ -86,13 +86,11 @@ private:
 
   //private accessors only used internally or by client
   unsigned fullLoc(unsigned loc) const { return loc + (noBatch_ ? 0 : 1); }
-  bool setShape(const ShapeType& newShape, bool canThrow);
-  bool setShape(unsigned loc, int64_t val, bool canThrow);
   void setBatchSize(unsigned bsize);
   void reset();
   void setResult(std::shared_ptr<Result> result) { result_ = result; }
   IO* data() { return data_.get(); }
-  bool updateMem(size_t size, bool can_throw);
+  void updateMem(size_t size);
   void computeSizes();
   void resetSizes();
   nvidia::inferenceserver::client::InferenceServerGrpcClient* client();
@@ -153,7 +151,7 @@ template <>
 template <typename DT>
 void TritonInputData::toServer(std::shared_ptr<TritonInput<DT>> ptr);
 template <>
-bool TritonOutputData::prepare();
+void TritonOutputData::prepare();
 template <>
 template <typename DT>
 TritonOutput<DT> TritonOutputData::fromServer() const;

--- a/HeterogeneousCore/SonicTriton/interface/TritonException.h
+++ b/HeterogeneousCore/SonicTriton/interface/TritonException.h
@@ -1,0 +1,14 @@
+#ifndef HeterogeneousCore_SonicTriton_TritonException
+#define HeterogeneousCore_SonicTriton_TritonException
+
+#include "FWCore/Utilities/interface/Exception.h"
+
+#include <string>
+
+class TritonException : public cms::Exception {
+public:
+  explicit TritonException(std::string const& aCategory);
+  void convertToWarning() const;
+};
+
+#endif

--- a/HeterogeneousCore/SonicTriton/interface/TritonMemResource.h
+++ b/HeterogeneousCore/SonicTriton/interface/TritonMemResource.h
@@ -1,0 +1,87 @@
+#ifndef HeterogeneousCore_SonicTriton_TritonMemResource
+#define HeterogeneousCore_SonicTriton_TritonMemResource
+
+#include <string>
+
+//forward declaration
+template <typename IO>
+class TritonData;
+struct cudaIpcMemHandle_st;
+typedef cudaIpcMemHandle_st cudaIpcMemHandle_t;
+
+//base class for memory operations
+template <typename IO>
+class TritonMemResource {
+public:
+  TritonMemResource(TritonData<IO>* data, const std::string& name, size_t size, bool canThrow);
+  virtual ~TritonMemResource() {}
+  uint8_t* addr() { return addr_; }
+  size_t size() const { return size_; }
+  bool status() const { return status_; }
+  virtual void copy(const void* values, size_t offset) {}
+  virtual void copy(const uint8_t** values) {}
+  virtual bool set(bool canThrow);
+
+protected:
+  //member variables
+  TritonData<IO>* data_;
+  std::string name_;
+  size_t size_;
+  uint8_t* addr_;
+  bool status_;
+};
+
+template <typename IO>
+class TritonHeapResource : public TritonMemResource<IO> {
+public:
+  TritonHeapResource(TritonData<IO>* data, const std::string& name, size_t size, bool canThrow);
+  ~TritonHeapResource() override {}
+  void copy(const void* values, size_t offset) override {}
+  void copy(const uint8_t** values) override {}
+  bool set(bool canThrow) override { return true; }
+};
+
+template <typename IO>
+class TritonCpuShmResource : public TritonMemResource<IO> {
+public:
+  TritonCpuShmResource(TritonData<IO>* data, const std::string& name, size_t size, bool canThrow);
+  ~TritonCpuShmResource() override;
+  void copy(const void* values, size_t offset) override {}
+  void copy(const uint8_t** values) override {}
+};
+
+template <typename IO>
+class TritonGpuShmResource : public TritonMemResource<IO> {
+public:
+  TritonGpuShmResource(TritonData<IO>* data, const std::string& name, size_t size, bool canThrow);
+  ~TritonGpuShmResource() override;
+  void copy(const void* values, size_t offset) override {}
+  void copy(const uint8_t** values) override {}
+
+protected:
+  int deviceId_;
+  std::shared_ptr<cudaIpcMemHandle_t> handle_;
+};
+
+using TritonInputHeapResource = TritonHeapResource<nvidia::inferenceserver::client::InferInput>;
+using TritonInputCpuShmResource = TritonCpuShmResource<nvidia::inferenceserver::client::InferInput>;
+using TritonInputGpuShmResource = TritonGpuShmResource<nvidia::inferenceserver::client::InferInput>;
+using TritonOutputHeapResource = TritonHeapResource<nvidia::inferenceserver::client::InferRequestedOutput>;
+using TritonOutputCpuShmResource = TritonCpuShmResource<nvidia::inferenceserver::client::InferRequestedOutput>;
+using TritonOutputGpuShmResource = TritonGpuShmResource<nvidia::inferenceserver::client::InferRequestedOutput>;
+
+//avoid "explicit specialization after instantiation" error
+template <>
+void TritonInputHeapResource::copy(const void* values, size_t offset);
+template <>
+void TritonInputCpuShmResource::copy(const void* values, size_t offset);
+template <>
+void TritonInputGpuShmResource::copy(const void* values, size_t offset);
+template <>
+void TritonOutputHeapResource::copy(const uint8_t** values);
+template <>
+void TritonOutputCpuShmResource::copy(const uint8_t** values);
+template <>
+void TritonOutputGpuShmResource::copy(const uint8_t** values);
+
+#endif

--- a/HeterogeneousCore/SonicTriton/interface/TritonMemResource.h
+++ b/HeterogeneousCore/SonicTriton/interface/TritonMemResource.h
@@ -22,9 +22,9 @@ public:
   size_t size() const { return size_; }
   bool status() const { return status_; }
   //used for input
-  virtual void copy(const void* values, size_t offset) {}
+  virtual void copyInput(const void* values, size_t offset) {}
   //used for output
-  virtual void copy(const uint8_t** values) {}
+  virtual const uint8_t* copyOutput() { return nullptr; }
   virtual bool set(bool canThrow);
 
 protected:
@@ -41,8 +41,8 @@ class TritonHeapResource : public TritonMemResource<IO> {
 public:
   TritonHeapResource(TritonData<IO>* data, const std::string& name, size_t size, bool canThrow);
   ~TritonHeapResource() override {}
-  void copy(const void* values, size_t offset) override {}
-  void copy(const uint8_t** values) override {}
+  void copyInput(const void* values, size_t offset) override {}
+  const uint8_t* copyOutput() override { return nullptr; }
   bool set(bool canThrow) override { return true; }
 };
 
@@ -51,8 +51,8 @@ class TritonCpuShmResource : public TritonMemResource<IO> {
 public:
   TritonCpuShmResource(TritonData<IO>* data, const std::string& name, size_t size, bool canThrow);
   ~TritonCpuShmResource() override;
-  void copy(const void* values, size_t offset) override {}
-  void copy(const uint8_t** values) override {}
+  void copyInput(const void* values, size_t offset) override {}
+  const uint8_t* copyOutput() override { return nullptr; }
 };
 
 template <typename IO>
@@ -60,8 +60,8 @@ class TritonGpuShmResource : public TritonMemResource<IO> {
 public:
   TritonGpuShmResource(TritonData<IO>* data, const std::string& name, size_t size, bool canThrow);
   ~TritonGpuShmResource() override;
-  void copy(const void* values, size_t offset) override {}
-  void copy(const uint8_t** values) override {}
+  void copyInput(const void* values, size_t offset) override {}
+  const uint8_t* copyOutput() override { return nullptr; }
 
 protected:
   int deviceId_;
@@ -77,16 +77,16 @@ using TritonOutputGpuShmResource = TritonGpuShmResource<nvidia::inferenceserver:
 
 //avoid "explicit specialization after instantiation" error
 template <>
-void TritonInputHeapResource::copy(const void* values, size_t offset);
+void TritonInputHeapResource::copyInput(const void* values, size_t offset);
 template <>
-void TritonInputCpuShmResource::copy(const void* values, size_t offset);
+void TritonInputCpuShmResource::copyInput(const void* values, size_t offset);
 template <>
-void TritonInputGpuShmResource::copy(const void* values, size_t offset);
+void TritonInputGpuShmResource::copyInput(const void* values, size_t offset);
 template <>
-void TritonOutputHeapResource::copy(const uint8_t** values);
+const uint8_t* TritonOutputHeapResource::copyOutput();
 template <>
-void TritonOutputCpuShmResource::copy(const uint8_t** values);
+const uint8_t* TritonOutputCpuShmResource::copyOutput();
 template <>
-void TritonOutputGpuShmResource::copy(const uint8_t** values);
+const uint8_t* TritonOutputGpuShmResource::copyOutput();
 
 #endif

--- a/HeterogeneousCore/SonicTriton/interface/TritonMemResource.h
+++ b/HeterogeneousCore/SonicTriton/interface/TritonMemResource.h
@@ -4,13 +4,13 @@
 #include <string>
 #include <memory>
 
-#include "HeterogeneousCore/SonicTriton/interface/grpc_client_gpu.h"
+#include "grpc_client.h"
+
+#include "cuda_runtime_api.h"
 
 //forward declaration
 template <typename IO>
 class TritonData;
-struct cudaIpcMemHandle_st;
-typedef cudaIpcMemHandle_st cudaIpcMemHandle_t;
 
 //base class for memory operations
 template <typename IO>
@@ -21,7 +21,9 @@ public:
   uint8_t* addr() { return addr_; }
   size_t size() const { return size_; }
   bool status() const { return status_; }
+  //used for input
   virtual void copy(const void* values, size_t offset) {}
+  //used for output
   virtual void copy(const uint8_t** values) {}
   virtual bool set(bool canThrow);
 

--- a/HeterogeneousCore/SonicTriton/interface/TritonMemResource.h
+++ b/HeterogeneousCore/SonicTriton/interface/TritonMemResource.h
@@ -14,16 +14,16 @@ class TritonData;
 template <typename IO>
 class TritonMemResource {
 public:
-  TritonMemResource(TritonData<IO>* data, const std::string& name, size_t size, bool canThrow);
+  TritonMemResource(TritonData<IO>* data, const std::string& name, size_t size);
   virtual ~TritonMemResource() {}
   uint8_t* addr() { return addr_; }
   size_t size() const { return size_; }
-  bool status() const { return status_; }
+  virtual void close() {}
   //used for input
   virtual void copyInput(const void* values, size_t offset) {}
   //used for output
   virtual const uint8_t* copyOutput() { return nullptr; }
-  virtual bool set(bool canThrow);
+  virtual void set();
 
 protected:
   //member variables
@@ -31,24 +31,25 @@ protected:
   std::string name_;
   size_t size_;
   uint8_t* addr_;
-  bool status_;
+  bool closed_;
 };
 
 template <typename IO>
 class TritonHeapResource : public TritonMemResource<IO> {
 public:
-  TritonHeapResource(TritonData<IO>* data, const std::string& name, size_t size, bool canThrow);
+  TritonHeapResource(TritonData<IO>* data, const std::string& name, size_t size);
   ~TritonHeapResource() override {}
   void copyInput(const void* values, size_t offset) override {}
   const uint8_t* copyOutput() override { return nullptr; }
-  bool set(bool canThrow) override { return true; }
+  void set() override {}
 };
 
 template <typename IO>
 class TritonCpuShmResource : public TritonMemResource<IO> {
 public:
-  TritonCpuShmResource(TritonData<IO>* data, const std::string& name, size_t size, bool canThrow);
+  TritonCpuShmResource(TritonData<IO>* data, const std::string& name, size_t size);
   ~TritonCpuShmResource() override;
+  void close() override;
   void copyInput(const void* values, size_t offset) override {}
   const uint8_t* copyOutput() override { return nullptr; }
 };
@@ -74,8 +75,9 @@ const uint8_t* TritonOutputCpuShmResource::copyOutput();
 template <typename IO>
 class TritonGpuShmResource : public TritonMemResource<IO> {
 public:
-  TritonGpuShmResource(TritonData<IO>* data, const std::string& name, size_t size, bool canThrow);
+  TritonGpuShmResource(TritonData<IO>* data, const std::string& name, size_t size);
   ~TritonGpuShmResource() override;
+  void close() override;
   void copyInput(const void* values, size_t offset) override {}
   const uint8_t* copyOutput() override { return nullptr; }
 

--- a/HeterogeneousCore/SonicTriton/interface/TritonMemResource.h
+++ b/HeterogeneousCore/SonicTriton/interface/TritonMemResource.h
@@ -2,6 +2,9 @@
 #define HeterogeneousCore_SonicTriton_TritonMemResource
 
 #include <string>
+#include <memory>
+
+#include "HeterogeneousCore/SonicTriton/interface/grpc_client_gpu.h"
 
 //forward declaration
 template <typename IO>

--- a/HeterogeneousCore/SonicTriton/interface/TritonService.h
+++ b/HeterogeneousCore/SonicTriton/interface/TritonService.h
@@ -19,6 +19,8 @@ namespace edm {
   class ModuleDescription;
 }  // namespace edm
 
+enum class TritonServerType { Remote = 0, LocalCPU = 1, LocalGPU = 2 };
+
 class TritonService {
 public:
   //classes and defs
@@ -79,7 +81,9 @@ public:
 
   //accessors
   void addModel(const std::string& modelName, const std::string& path);
-  std::pair<std::string, bool> serverAddress(const std::string& model, const std::string& preferred = "") const;
+  std::pair<std::string, TritonServerType> serverAddress(const std::string& model,
+                                                         const std::string& preferred = "") const;
+  const std::string& pid() const { return pid_; }
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
@@ -94,6 +98,7 @@ private:
   unsigned currentModuleId_;
   bool allowAddModel_;
   bool startedFallback_;
+  std::string pid_;
   std::unordered_map<std::string, Model> unservedModels_;
   //this represents a many:many:many map
   std::unordered_map<std::string, Server> servers_;

--- a/HeterogeneousCore/SonicTriton/interface/grpc_client_gpu.h
+++ b/HeterogeneousCore/SonicTriton/interface/grpc_client_gpu.h
@@ -1,0 +1,7 @@
+#ifndef HeterogeneousCore_SonicTriton_grpc_client_gpu
+#define HeterogeneousCore_SonicTriton_grpc_client_gpu
+
+#define TRITON_ENABLE_GPU
+#include "grpc_client.h"
+
+#endif

--- a/HeterogeneousCore/SonicTriton/interface/grpc_client_gpu.h
+++ b/HeterogeneousCore/SonicTriton/interface/grpc_client_gpu.h
@@ -1,7 +1,0 @@
-#ifndef HeterogeneousCore_SonicTriton_grpc_client_gpu
-#define HeterogeneousCore_SonicTriton_grpc_client_gpu
-
-#define TRITON_ENABLE_GPU
-#include "grpc_client.h"
-
-#endif

--- a/HeterogeneousCore/SonicTriton/interface/triton_utils.h
+++ b/HeterogeneousCore/SonicTriton/interface/triton_utils.h
@@ -19,20 +19,6 @@ namespace triton_utils {
 
   //helper to turn triton error into exception
   void throwIfError(const Error& err, std::string_view msg);
-
-  //helper to turn triton error into warning
-  bool warnIfError(const Error& err, std::string_view msg);
-
-  //helper to do either
-  bool warnOrThrowIfError(const Error& err, std::string_view msg, bool canThrow);
-
-  //generic version w/o Error
-  void warnOrThrow(std::string_view msg, bool canThrow);
-
-#ifdef TRITON_ENABLE_GPU
-  bool cudaCheck(cudaError_t result, std::string_view msg, bool canThrow);
-#endif
-
 }  // namespace triton_utils
 
 extern template std::string triton_utils::printColl(const edm::Span<std::vector<int64_t>::const_iterator>& coll,

--- a/HeterogeneousCore/SonicTriton/interface/triton_utils.h
+++ b/HeterogeneousCore/SonicTriton/interface/triton_utils.h
@@ -8,7 +8,9 @@
 #include <vector>
 #include <unordered_set>
 
-#include "grpc_client.h"
+#include "HeterogeneousCore/SonicTriton/interface/grpc_client_gpu.h"
+
+#include "cuda_runtime_api.h"
 
 namespace triton_utils {
 
@@ -22,6 +24,14 @@ namespace triton_utils {
 
   //helper to turn triton error into warning
   bool warnIfError(const Error& err, std::string_view msg);
+
+  //helper to do either
+  bool warnOrThrowIfError(const Error& err, std::string_view msg, bool canThrow);
+
+  //generic version w/o Error
+  void warnOrThrow(std::string_view msg, bool canThrow);
+
+  bool cudaCheck(cudaError_t result, std::string_view msg, bool canThrow);
 
 }  // namespace triton_utils
 

--- a/HeterogeneousCore/SonicTriton/interface/triton_utils.h
+++ b/HeterogeneousCore/SonicTriton/interface/triton_utils.h
@@ -10,8 +10,6 @@
 
 #include "grpc_client.h"
 
-#include "cuda_runtime_api.h"
-
 namespace triton_utils {
 
   using Error = nvidia::inferenceserver::client::Error;
@@ -31,7 +29,9 @@ namespace triton_utils {
   //generic version w/o Error
   void warnOrThrow(std::string_view msg, bool canThrow);
 
+#ifdef TRITON_ENABLE_GPU
   bool cudaCheck(cudaError_t result, std::string_view msg, bool canThrow);
+#endif
 
 }  // namespace triton_utils
 

--- a/HeterogeneousCore/SonicTriton/interface/triton_utils.h
+++ b/HeterogeneousCore/SonicTriton/interface/triton_utils.h
@@ -8,7 +8,7 @@
 #include <vector>
 #include <unordered_set>
 
-#include "HeterogeneousCore/SonicTriton/interface/grpc_client_gpu.h"
+#include "grpc_client.h"
 
 #include "cuda_runtime_api.h"
 

--- a/HeterogeneousCore/SonicTriton/scripts/cmsTriton
+++ b/HeterogeneousCore/SonicTriton/scripts/cmsTriton
@@ -4,7 +4,7 @@
 USEDOCKER=""
 GPU=""
 VERBOSE=""
-VERBOSE_ARGS="--log-verbose=1 --log-error=1 --log-info=1"
+VERBOSE_ARGS="--log-verbose=1 --log-error=1 --log-warning=1 --log-info=1"
 WTIME=120
 SERVER=triton_server_instance
 RETRIES=3
@@ -177,7 +177,7 @@ start_docker(){
 	done
 
 	$DRYRUN $DOCKER run -d --name ${SERVER} \
-		--shm-size=1g --ulimit memlock=-1 --ulimit stack=67108864 \
+		--shm-size=1g --ulimit memlock=-1 --ulimit stack=67108864 --ipc="host" --cap-add=IPC_OWNER \
 		-p${HTTPPORT}:${HTTPPORT} -p${GRPCPORT}:${GRPCPORT} -p${METRPORT}:${METRPORT} $EXTRA $MOUNTARGS \
 		${IMAGE} tritonserver $PORTARGS $REPOARGS $VERBOSE
 }

--- a/HeterogeneousCore/SonicTriton/src/TritonData.cc
+++ b/HeterogeneousCore/SonicTriton/src/TritonData.cc
@@ -139,6 +139,7 @@ bool TritonData<IO>::updateMem(size_t size, bool canThrow) {
   bool status = true;
   if (!memResource_ or size > memResource_->size()) {
     if (useShm_ and client_->serverType() == TritonServerType::LocalCPU) {
+      //need to destroy before constructing new instance because shared memory key will be reused
       memResource_.reset();
       memResource_ = std::make_shared<TritonCpuShmResource<IO>>(this, shmName_, size, canThrow);
     } else if (useShm_ and client_->serverType() == TritonServerType::LocalGPU) {

--- a/HeterogeneousCore/SonicTriton/src/TritonData.cc
+++ b/HeterogeneousCore/SonicTriton/src/TritonData.cc
@@ -192,7 +192,7 @@ void TritonInputData::toServer(TritonInputContainer<DT> ptr) {
   computeSizes();
   updateMem(totalByteSize_, true);
   for (unsigned i0 = 0; i0 < batchSize_; ++i0) {
-    memResource_->copy(data_in[i0].data(), i0 * byteSizePerBatch_);
+    memResource_->copyInput(data_in[i0].data(), i0 * byteSizePerBatch_);
   }
   memResource_->set(true);
 
@@ -222,8 +222,7 @@ TritonOutput<DT> TritonOutputData::fromServer() const {
                                             << " (should be " << byteSize_ << " for " << dname_ << ")";
   }
 
-  const uint8_t* r0;
-  memResource_->copy(&r0);
+  const uint8_t* r0 = memResource_->copyOutput();
   const DT* r1 = reinterpret_cast<const DT*>(r0);
 
   TritonOutput<DT> dataOut;

--- a/HeterogeneousCore/SonicTriton/src/TritonData.cc
+++ b/HeterogeneousCore/SonicTriton/src/TritonData.cc
@@ -142,10 +142,13 @@ bool TritonData<IO>::updateMem(size_t size, bool canThrow) {
       //need to destroy before constructing new instance because shared memory key will be reused
       memResource_.reset();
       memResource_ = std::make_shared<TritonCpuShmResource<IO>>(this, shmName_, size, canThrow);
-    } else if (useShm_ and client_->serverType() == TritonServerType::LocalGPU) {
+    }
+#ifdef TRITON_ENABLE_GPU
+    else if (useShm_ and client_->serverType() == TritonServerType::LocalGPU) {
       memResource_.reset();
       memResource_ = std::make_shared<TritonGpuShmResource<IO>>(this, shmName_, size, canThrow);
     }
+#endif
     //for remote/heap, size increases don't matter
     else if (!memResource_)
       memResource_ = std::make_shared<TritonHeapResource<IO>>(this, shmName_, size, canThrow);

--- a/HeterogeneousCore/SonicTriton/src/TritonData.cc
+++ b/HeterogeneousCore/SonicTriton/src/TritonData.cc
@@ -90,14 +90,14 @@ void TritonData<IO>::setShape(unsigned loc, int64_t val) {
 
   //check boundary
   if (locFull >= fullShape_.size())
-    throw cms::Exception("TritonError") << name_ << " setShape(): dimension " << locFull << " out of bounds ("
+    throw cms::Exception("TritonDataError") << name_ << " setShape(): dimension " << locFull << " out of bounds ("
                                         << fullShape_.size() << ")";
 
   if (val != fullShape_[locFull]) {
     if (dims_[locFull] == -1)
       fullShape_[locFull] = val;
     else
-      throw cms::Exception("TritonError")
+      throw cms::Exception("TritonDataError")
           << name_ << " setShape(): attempt to change value of non-variable shape dimension " << loc;
   }
 }

--- a/HeterogeneousCore/SonicTriton/src/TritonData.cc
+++ b/HeterogeneousCore/SonicTriton/src/TritonData.cc
@@ -90,8 +90,8 @@ void TritonData<IO>::setShape(unsigned loc, int64_t val) {
 
   //check boundary
   if (locFull >= fullShape_.size())
-    throw cms::Exception("TritonDataError") << name_ << " setShape(): dimension " << locFull << " out of bounds ("
-                                        << fullShape_.size() << ")";
+    throw cms::Exception("TritonDataError")
+        << name_ << " setShape(): dimension " << locFull << " out of bounds (" << fullShape_.size() << ")";
 
   if (val != fullShape_[locFull]) {
     if (dims_[locFull] == -1)

--- a/HeterogeneousCore/SonicTriton/src/TritonData.cc
+++ b/HeterogeneousCore/SonicTriton/src/TritonData.cc
@@ -1,10 +1,11 @@
 #include "HeterogeneousCore/SonicTriton/interface/TritonData.h"
+#include "HeterogeneousCore/SonicTriton/interface/TritonClient.h"
+#include "HeterogeneousCore/SonicTriton/interface/TritonMemResource.h"
 #include "HeterogeneousCore/SonicTriton/interface/triton_utils.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include "model_config.pb.h"
 
-#include <cstring>
 #include <sstream>
 
 namespace ni = nvidia::inferenceserver;
@@ -22,10 +23,17 @@ namespace nvidia {
 //fullShape: if batching is enabled, first entry is batch size; values can be modified
 //shape: view into fullShape, excluding batch size entry
 template <typename IO>
-TritonData<IO>::TritonData(const std::string& name, const TritonData<IO>::TensorMetadata& model_info, bool noBatch)
+TritonData<IO>::TritonData(const std::string& name,
+                           const TritonData<IO>::TensorMetadata& model_info,
+                           TritonClient* client,
+                           const std::string& pid)
     : name_(name),
+      client_(client),
+      useShm_(client_->useSharedMemory()),
+      //ensure unique name for shared memory region
+      shmName_(useShm_ ? pid + "_" + xput() + std::to_string(uid()) : ""),
       dims_(model_info.shape().begin(), model_info.shape().end()),
-      noBatch_(noBatch),
+      noBatch_(client_->noBatch()),
       batchSize_(0),
       fullShape_(dims_),
       shape_(fullShape_.begin() + (noBatch_ ? 0 : 1), fullShape_.end()),
@@ -33,7 +41,8 @@ TritonData<IO>::TritonData(const std::string& name, const TritonData<IO>::Tensor
       productDims_(variableDims_ ? -1 : dimProduct(shape_)),
       dname_(model_info.datatype()),
       dtype_(ni::ProtocolStringToDataType(dname_)),
-      byteSize_(ni::GetDataTypeByteSize(dtype_)) {
+      byteSize_(ni::GetDataTypeByteSize(dtype_)),
+      totalByteSize_(0) {
   //create input or output object
   IO* iotmp;
   createObject(&iotmp);
@@ -41,13 +50,30 @@ TritonData<IO>::TritonData(const std::string& name, const TritonData<IO>::Tensor
 }
 
 template <>
-void TritonInputData::createObject(nic::InferInput** ioptr) const {
+void TritonInputData::createObject(nic::InferInput** ioptr) {
   nic::InferInput::Create(ioptr, name_, fullShape_, dname_);
 }
 
 template <>
-void TritonOutputData::createObject(nic::InferRequestedOutput** ioptr) const {
+void TritonOutputData::createObject(nic::InferRequestedOutput** ioptr) {
   nic::InferRequestedOutput::Create(ioptr, name_);
+  //another specialization for output: can't use shared memory if output size is not known
+  useShm_ &= !variableDims_;
+}
+
+template <>
+std::string TritonInputData::xput() const {
+  return "input";
+}
+
+template <>
+std::string TritonOutputData::xput() const {
+  return "output";
+}
+
+template <typename IO>
+nic::InferenceServerGrpcClient* TritonData<IO>::client() {
+  return client_->client();
 }
 
 //setters
@@ -63,31 +89,23 @@ bool TritonData<IO>::setShape(const TritonData<IO>::ShapeType& newShape, bool ca
 template <typename IO>
 bool TritonData<IO>::setShape(unsigned loc, int64_t val, bool canThrow) {
   std::stringstream msg;
-  unsigned full_loc = loc + (noBatch_ ? 0 : 1);
+  unsigned locFull = fullLoc(loc);
 
   //check boundary
-  if (full_loc >= fullShape_.size()) {
-    msg << name_ << " setShape(): dimension " << full_loc << " out of bounds (" << fullShape_.size() << ")";
-    if (canThrow)
-      throw cms::Exception("TritonDataError") << msg.str();
-    else {
-      edm::LogWarning("TritonDataWarning") << msg.str();
-      return false;
-    }
+  if (locFull >= fullShape_.size()) {
+    msg << name_ << " setShape(): dimension " << locFull << " out of bounds (" << fullShape_.size() << ")";
+    triton_utils::warnOrThrow(msg.str(), canThrow);
+    return false;
   }
 
-  if (val != fullShape_[full_loc]) {
-    if (dims_[full_loc] == -1) {
-      fullShape_[full_loc] = val;
+  if (val != fullShape_[locFull]) {
+    if (dims_[locFull] == -1) {
+      fullShape_[locFull] = val;
       return true;
     } else {
       msg << name_ << " setShape(): attempt to change value of non-variable shape dimension " << loc;
-      if (canThrow)
-        throw cms::Exception("TritonDataError") << msg.str();
-      else {
-        edm::LogWarning("TritonDataError") << msg.str();
-        return false;
-      }
+      triton_utils::warnOrThrow(msg.str(), canThrow);
+      return false;
     }
   }
 
@@ -101,15 +119,65 @@ void TritonData<IO>::setBatchSize(unsigned bsize) {
     fullShape_[0] = batchSize_;
 }
 
+template <typename IO>
+void TritonData<IO>::computeSizes() {
+  sizeShape_ = sizeShape();
+  byteSizePerBatch_ = byteSize_ * sizeShape_;
+  totalByteSize_ = byteSizePerBatch_ * batchSize_;
+}
+template <typename IO>
+void TritonData<IO>::resetSizes() {
+  sizeShape_ = 0;
+  byteSizePerBatch_ = 0;
+  totalByteSize_ = 0;
+}
+
+//create a memory resource if none exists;
+//otherwise, reuse the memory resource, resizing it if necessary
+template <typename IO>
+bool TritonData<IO>::updateMem(size_t size, bool canThrow) {
+  bool status = true;
+  if (!memResource_ or size > memResource_->size()) {
+    if (useShm_ and client_->serverType() == TritonServerType::LocalCPU) {
+      memResource_.reset();
+      memResource_ = std::make_shared<TritonCpuShmResource<IO>>(this, shmName_, size, canThrow);
+    } else if (useShm_ and client_->serverType() == TritonServerType::LocalGPU) {
+      memResource_.reset();
+      memResource_ = std::make_shared<TritonGpuShmResource<IO>>(this, shmName_, size, canThrow);
+    }
+    //for remote/heap, size increases don't matter
+    else if (!memResource_)
+      memResource_ = std::make_shared<TritonHeapResource<IO>>(this, shmName_, size, canThrow);
+
+    status &= memResource_->status();
+  }
+
+  return status;
+}
+
 //io accessors
 template <>
 template <typename DT>
-void TritonInputData::toServer(std::shared_ptr<TritonInput<DT>> ptr) {
+TritonInputContainer<DT> TritonInputData::allocate(bool reserve) {
+  //automatically creates a vector for each batch entry (if batch size known)
+  auto ptr = std::make_shared<TritonInput<DT>>(batchSize_);
+  if (reserve and !anyNeg(shape_)) {
+    computeSizes();
+    for (auto& vec : *ptr) {
+      vec.reserve(sizeShape_);
+    }
+  }
+  return ptr;
+}
+
+template <>
+template <typename DT>
+void TritonInputData::toServer(TritonInputContainer<DT> ptr) {
   const auto& data_in = *ptr;
 
   //check batch size
   if (data_in.size() != batchSize_) {
-    throw cms::Exception("TritonDataError") << name_ << " input(): input vector has size " << data_in.size()
+    throw cms::Exception("TritonDataError") << name_ << " toServer(): input vector has size " << data_in.size()
                                             << " but specified batch size is " << batchSize_;
   }
 
@@ -117,48 +185,51 @@ void TritonInputData::toServer(std::shared_ptr<TritonInput<DT>> ptr) {
   data_->SetShape(fullShape_);
 
   if (byteSize_ != sizeof(DT))
-    throw cms::Exception("TritonDataError") << name_ << " input(): inconsistent byte size " << sizeof(DT)
+    throw cms::Exception("TritonDataError") << name_ << " toServer(): inconsistent byte size " << sizeof(DT)
                                             << " (should be " << byteSize_ << " for " << dname_ << ")";
 
-  int64_t nInput = sizeShape();
+  computeSizes();
+  updateMem(totalByteSize_, true);
   for (unsigned i0 = 0; i0 < batchSize_; ++i0) {
-    const DT* arr = data_in[i0].data();
-    triton_utils::throwIfError(data_->AppendRaw(reinterpret_cast<const uint8_t*>(arr), nInput * byteSize_),
-                               name_ + " input(): unable to set data for batch entry " + std::to_string(i0));
+    memResource_->copy(data_in[i0].data(), i0 * byteSizePerBatch_);
   }
+  memResource_->set(true);
 
   //keep input data in scope
-  holder_ = std::move(ptr);
+  holder_ = ptr;
+}
+
+//sets up shared memory for outputs, if possible
+template <>
+bool TritonOutputData::prepare() {
+  computeSizes();
+
+  bool status = updateMem(totalByteSize_, false) && memResource_->set(false);
+
+  return status;
 }
 
 template <>
 template <typename DT>
 TritonOutput<DT> TritonOutputData::fromServer() const {
   if (!result_) {
-    throw cms::Exception("TritonDataError") << name_ << " output(): missing result";
+    throw cms::Exception("TritonDataError") << name_ << " fromServer(): missing result";
   }
 
   if (byteSize_ != sizeof(DT)) {
-    throw cms::Exception("TritonDataError") << name_ << " output(): inconsistent byte size " << sizeof(DT)
+    throw cms::Exception("TritonDataError") << name_ << " fromServer(): inconsistent byte size " << sizeof(DT)
                                             << " (should be " << byteSize_ << " for " << dname_ << ")";
   }
 
-  uint64_t nOutput = sizeShape();
-  TritonOutput<DT> dataOut;
   const uint8_t* r0;
-  size_t contentByteSize;
-  size_t expectedContentByteSize = nOutput * byteSize_ * batchSize_;
-  triton_utils::throwIfError(result_->RawData(name_, &r0, &contentByteSize), "output(): unable to get raw");
-  if (contentByteSize != expectedContentByteSize) {
-    throw cms::Exception("TritonDataError") << name_ << " output(): unexpected content byte size " << contentByteSize
-                                            << " (expected " << expectedContentByteSize << ")";
-  }
-
+  memResource_->copy(&r0);
   const DT* r1 = reinterpret_cast<const DT*>(r0);
+
+  TritonOutput<DT> dataOut;
   dataOut.reserve(batchSize_);
   for (unsigned i0 = 0; i0 < batchSize_; ++i0) {
-    auto offset = i0 * nOutput;
-    dataOut.emplace_back(r1 + offset, r1 + offset + nOutput);
+    auto offset = i0 * sizeShape_;
+    dataOut.emplace_back(r1 + offset, r1 + offset + sizeShape_);
   }
 
   return dataOut;
@@ -166,20 +237,33 @@ TritonOutput<DT> TritonOutputData::fromServer() const {
 
 template <>
 void TritonInputData::reset() {
-  data_->Reset();
   holder_.reset();
+  data_->Reset();
+  //reset shape
+  if (variableDims_) {
+    for (unsigned i = 0; i < shape_.size(); ++i) {
+      unsigned locFull = fullLoc(i);
+      fullShape_[locFull] = dims_[locFull];
+    }
+  }
+  resetSizes();
 }
 
 template <>
 void TritonOutputData::reset() {
   result_.reset();
+  holder_.reset();
+  resetSizes();
 }
 
 //explicit template instantiation declarations
 template class TritonData<nic::InferInput>;
 template class TritonData<nic::InferRequestedOutput>;
 
-template void TritonInputData::toServer(std::shared_ptr<TritonInput<float>> data_in);
-template void TritonInputData::toServer(std::shared_ptr<TritonInput<int64_t>> data_in);
+template TritonInputContainer<float> TritonInputData::allocate(bool reserve);
+template TritonInputContainer<int64_t> TritonInputData::allocate(bool reserve);
+
+template void TritonInputData::toServer(TritonInputContainer<float> data_in);
+template void TritonInputData::toServer(TritonInputContainer<int64_t> data_in);
 
 template TritonOutput<float> TritonOutputData::fromServer() const;

--- a/HeterogeneousCore/SonicTriton/src/TritonException.cc
+++ b/HeterogeneousCore/SonicTriton/src/TritonException.cc
@@ -1,0 +1,8 @@
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "HeterogeneousCore/SonicTriton/interface/TritonException.h"
+
+TritonException::TritonException(std::string const& aCategory) : cms::Exception(aCategory) {}
+
+void TritonException::convertToWarning() const {
+  edm::LogWarning(category()) << explainSelf();
+}

--- a/HeterogeneousCore/SonicTriton/src/TritonException.cc
+++ b/HeterogeneousCore/SonicTriton/src/TritonException.cc
@@ -3,6 +3,4 @@
 
 TritonException::TritonException(std::string const& aCategory) : cms::Exception(aCategory) {}
 
-void TritonException::convertToWarning() const {
-  edm::LogWarning(category()) << explainSelf();
-}
+void TritonException::convertToWarning() const { edm::LogWarning(category()) << explainSelf(); }

--- a/HeterogeneousCore/SonicTriton/src/TritonMemResource.cc
+++ b/HeterogeneousCore/SonicTriton/src/TritonMemResource.cc
@@ -3,8 +3,6 @@
 #include "HeterogeneousCore/SonicTriton/interface/TritonMemResource.h"
 #include "HeterogeneousCore/SonicTriton/interface/triton_utils.h"
 
-#include "grpc_client.h"
-
 #include <cstring>
 #include <fcntl.h>
 #include <sys/mman.h>
@@ -118,6 +116,12 @@ const uint8_t* TritonOutputCpuShmResource::copyOutput() {
   return addr_;
 }
 
+template class TritonHeapResource<nic::InferInput>;
+template class TritonCpuShmResource<nic::InferInput>;
+template class TritonHeapResource<nic::InferRequestedOutput>;
+template class TritonCpuShmResource<nic::InferRequestedOutput>;
+
+#ifdef TRITON_ENABLE_GPU
 template <typename IO>
 TritonGpuShmResource<IO>::TritonGpuShmResource(TritonData<IO>* data, const std::string& name, size_t size, bool canThrow)
     : TritonMemResource<IO>(data, name, size, canThrow), deviceId_(0), handle_(std::make_shared<cudaIpcMemHandle_t>()) {
@@ -161,9 +165,6 @@ const uint8_t* TritonOutputGpuShmResource::copyOutput() {
   return ptr->data();
 }
 
-template class TritonHeapResource<nic::InferInput>;
-template class TritonCpuShmResource<nic::InferInput>;
 template class TritonGpuShmResource<nic::InferInput>;
-template class TritonHeapResource<nic::InferRequestedOutput>;
-template class TritonCpuShmResource<nic::InferRequestedOutput>;
 template class TritonGpuShmResource<nic::InferRequestedOutput>;
+#endif

--- a/HeterogeneousCore/SonicTriton/src/TritonMemResource.cc
+++ b/HeterogeneousCore/SonicTriton/src/TritonMemResource.cc
@@ -1,0 +1,169 @@
+#include "HeterogeneousCore/SonicTriton/interface/TritonData.h"
+#include "HeterogeneousCore/SonicTriton/interface/TritonClient.h"
+#include "HeterogeneousCore/SonicTriton/interface/TritonMemResource.h"
+#include "HeterogeneousCore/SonicTriton/interface/triton_utils.h"
+
+#include "HeterogeneousCore/SonicTriton/interface/grpc_client_gpu.h"
+
+#include "cuda_runtime_api.h"
+
+#include <cstring>
+#include <fcntl.h>
+#include <sys/mman.h>
+#include <unistd.h>
+
+namespace ni = nvidia::inferenceserver;
+namespace nic = ni::client;
+
+template <typename IO>
+TritonMemResource<IO>::TritonMemResource(TritonData<IO>* data, const std::string& name, size_t size, bool canThrow)
+    : data_(data), name_(name), size_(size), addr_(nullptr), status_(true) {}
+
+template <typename IO>
+bool TritonMemResource<IO>::set(bool canThrow) {
+  return triton_utils::warnOrThrowIfError(data_->data_->SetSharedMemory(name_, data_->totalByteSize_, 0),
+                                          "unable to set shared memory (" + name_ + ")",
+                                          canThrow);
+}
+
+template <typename IO>
+TritonHeapResource<IO>::TritonHeapResource(TritonData<IO>* data, const std::string& name, size_t size, bool canThrow)
+    : TritonMemResource<IO>(data, name, size, canThrow) {}
+
+template <>
+void TritonInputHeapResource::copy(const void* values, size_t offset) {
+  triton_utils::throwIfError(
+      data_->data_->AppendRaw(reinterpret_cast<const uint8_t*>(values), data_->byteSizePerBatch_),
+      data_->name_ + " toServer(): unable to set data for batch entry " +
+          std::to_string(offset / data_->byteSizePerBatch_));
+}
+
+template <>
+void TritonOutputHeapResource::copy(const uint8_t** values) {
+  size_t contentByteSize;
+  triton_utils::throwIfError(data_->result_->RawData(data_->name_, values, &contentByteSize),
+                             data_->name_ + " fromServer(): unable to get raw");
+  if (contentByteSize != data_->totalByteSize_) {
+    throw cms::Exception("TritonDataError") << data_->name_ << " fromServer(): unexpected content byte size "
+                                            << contentByteSize << " (expected " << data_->totalByteSize_ << ")";
+  }
+}
+
+//shared memory helpers based on:
+// https://github.com/triton-inference-server/server/blob/v2.3.0/src/clients/c++/examples/shm_utils.cc (cpu)
+// https://github.com/triton-inference-server/server/blob/v2.3.0/src/clients/c++/examples/simple_grpc_cudashm_client.cc (gpu)
+
+template <typename IO>
+TritonCpuShmResource<IO>::TritonCpuShmResource(TritonData<IO>* data, const std::string& name, size_t size, bool canThrow)
+    : TritonMemResource<IO>(data, name, size, canThrow) {
+  //get shared memory region descriptor
+  int shm_fd = shm_open(this->name_.c_str(), O_RDWR | O_CREAT | O_EXCL, S_IRUSR | S_IWUSR);
+  if (shm_fd == -1) {
+    triton_utils::warnOrThrow("unable to get shared memory descriptor for key: " + this->name_, canThrow);
+    this->status_ &= false;
+  }
+
+  //extend shared memory object
+  int res = ftruncate(shm_fd, this->size_);
+  if (res == -1) {
+    triton_utils::warnOrThrow(
+        "unable to initialize shared memory key " + this->name_ + " to requested size: " + std::to_string(this->size_),
+        canThrow);
+    this->status_ &= false;
+  }
+
+  //map to process address space
+  constexpr size_t offset(0);
+  this->addr_ = (uint8_t*)mmap(nullptr, this->size_, PROT_READ | PROT_WRITE, MAP_SHARED, shm_fd, offset);
+  if (this->addr_ == MAP_FAILED) {
+    triton_utils::warnOrThrow("unable to map to process address space for shared memory key: " + this->name_, canThrow);
+    this->status_ &= false;
+  }
+
+  //close descriptor
+  if (::close(shm_fd) == -1) {
+    triton_utils::warnOrThrow("unable to close descriptor for shared memory key: " + this->name_, canThrow);
+    this->status_ &= false;
+  }
+
+  this->status_ &= triton_utils::warnOrThrowIfError(
+      this->data_->client()->RegisterSystemSharedMemory(this->name_, this->name_, this->size_),
+      "unable to register shared memory region: " + this->name_,
+      canThrow);
+}
+
+template <typename IO>
+TritonCpuShmResource<IO>::~TritonCpuShmResource<IO>() {
+  triton_utils::warnIfError(this->data_->client()->UnregisterSystemSharedMemory(this->name_),
+                            "unable to unregister shared memory region: " + this->name_);
+
+  //unmap
+  int tmp_fd = munmap(this->addr_, this->size_);
+  if (tmp_fd == -1)
+    edm::LogWarning("TritonWarning") << "unable to munmap for shared memory key: " << this->name_;
+
+  //unlink
+  int shm_fd = shm_unlink(this->name_.c_str());
+  if (shm_fd == -1)
+    edm::LogWarning("TritonWarning") << "unable to unlink for shared memory key: " << this->name_;
+}
+
+template <>
+void TritonInputCpuShmResource::copy(const void* values, size_t offset) {
+  std::memcpy(addr_ + offset, values, data_->byteSizePerBatch_);
+}
+
+template <>
+void TritonOutputCpuShmResource::copy(const uint8_t** values) {
+  *values = addr_;
+}
+
+template <typename IO>
+TritonGpuShmResource<IO>::TritonGpuShmResource(TritonData<IO>* data, const std::string& name, size_t size, bool canThrow)
+    : TritonMemResource<IO>(data, name, size, canThrow), deviceId_(0), handle_(std::make_shared<cudaIpcMemHandle_t>()) {
+  this->status_ &= triton_utils::cudaCheck(
+      cudaMalloc((void**)&this->addr_, this->size_), "unable to allocate GPU memory for key: " + this->name_, canThrow);
+  //todo: get server device id somehow?
+  this->status_ &= triton_utils::cudaCheck(
+      cudaSetDevice(deviceId_), "unable to set device ID to " + std::to_string(deviceId_), canThrow);
+  this->status_ &= triton_utils::cudaCheck(
+      cudaIpcGetMemHandle(handle_.get(), this->addr_), "unable to get IPC handle for key: " + this->name_, canThrow);
+  this->status_ &= triton_utils::warnOrThrowIfError(
+      this->data_->client()->RegisterCudaSharedMemory(this->name_, *handle_, deviceId_, this->size_),
+      "unable to register CUDA shared memory region: " + this->name_,
+      canThrow);
+}
+
+template <typename IO>
+TritonGpuShmResource<IO>::~TritonGpuShmResource<IO>() {
+  triton_utils::warnIfError(this->data_->client()->UnregisterCudaSharedMemory(this->name_),
+                            "unable to unregister CUDA shared memory region: " + this->name_);
+  triton_utils::cudaCheck(cudaFree(this->addr_), "unable to free GPU memory for key: " + this->name_, false);
+}
+
+template <>
+void TritonInputGpuShmResource::copy(const void* values, size_t offset) {
+  triton_utils::cudaCheck(
+      cudaMemcpy((void*)(addr_ + offset), values, data_->byteSizePerBatch_, cudaMemcpyHostToDevice),
+      data_->name_ + " toServer(): unable to memcpy " + std::to_string(data_->byteSizePerBatch_) + " bytes to GPU",
+      true);
+}
+
+template <>
+void TritonOutputGpuShmResource::copy(const uint8_t** values) {
+  //copy back from gpu, keep in scope
+  auto ptr = std::make_shared<std::vector<uint8_t>>(data_->totalByteSize_);
+  triton_utils::cudaCheck(
+      cudaMemcpy((void*)(ptr->data()), (void*)(addr_), data_->totalByteSize_, cudaMemcpyDeviceToHost),
+      data_->name_ + " fromServer(): unable to memcpy " + std::to_string(data_->totalByteSize_) + " bytes from GPU",
+      true);
+  *values = ptr->data();
+  data_->holder_ = ptr;
+}
+
+template class TritonHeapResource<nic::InferInput>;
+template class TritonCpuShmResource<nic::InferInput>;
+template class TritonGpuShmResource<nic::InferInput>;
+template class TritonHeapResource<nic::InferRequestedOutput>;
+template class TritonCpuShmResource<nic::InferRequestedOutput>;
+template class TritonGpuShmResource<nic::InferRequestedOutput>;

--- a/HeterogeneousCore/SonicTriton/src/TritonMemResource.cc
+++ b/HeterogeneousCore/SonicTriton/src/TritonMemResource.cc
@@ -2,6 +2,7 @@
 #include "HeterogeneousCore/SonicTriton/interface/TritonClient.h"
 #include "HeterogeneousCore/SonicTriton/interface/TritonMemResource.h"
 #include "HeterogeneousCore/SonicTriton/interface/triton_utils.h"
+#include "HeterogeneousCore/CUDAUtilities/interface/cudaCheck.h"
 
 #include <cstring>
 #include <fcntl.h>
@@ -12,19 +13,18 @@ namespace ni = nvidia::inferenceserver;
 namespace nic = ni::client;
 
 template <typename IO>
-TritonMemResource<IO>::TritonMemResource(TritonData<IO>* data, const std::string& name, size_t size, bool canThrow)
-    : data_(data), name_(name), size_(size), addr_(nullptr), status_(true) {}
+TritonMemResource<IO>::TritonMemResource(TritonData<IO>* data, const std::string& name, size_t size)
+    : data_(data), name_(name), size_(size), addr_(nullptr), closed_(false) {}
 
 template <typename IO>
-bool TritonMemResource<IO>::set(bool canThrow) {
-  return triton_utils::warnOrThrowIfError(data_->data_->SetSharedMemory(name_, data_->totalByteSize_, 0),
-                                          "unable to set shared memory (" + name_ + ")",
-                                          canThrow);
+void TritonMemResource<IO>::set() {
+  triton_utils::throwIfError(data_->data_->SetSharedMemory(name_, data_->totalByteSize_, 0),
+                             "unable to set shared memory (" + name_ + ")");
 }
 
 template <typename IO>
-TritonHeapResource<IO>::TritonHeapResource(TritonData<IO>* data, const std::string& name, size_t size, bool canThrow)
-    : TritonMemResource<IO>(data, name, size, canThrow) {}
+TritonHeapResource<IO>::TritonHeapResource(TritonData<IO>* data, const std::string& name, size_t size)
+    : TritonMemResource<IO>(data, name, size) {}
 
 template <>
 void TritonInputHeapResource::copyInput(const void* values, size_t offset) {
@@ -52,58 +52,58 @@ const uint8_t* TritonOutputHeapResource::copyOutput() {
 // https://github.com/triton-inference-server/server/blob/v2.3.0/src/clients/c++/examples/simple_grpc_cudashm_client.cc (gpu)
 
 template <typename IO>
-TritonCpuShmResource<IO>::TritonCpuShmResource(TritonData<IO>* data, const std::string& name, size_t size, bool canThrow)
-    : TritonMemResource<IO>(data, name, size, canThrow) {
+TritonCpuShmResource<IO>::TritonCpuShmResource(TritonData<IO>* data, const std::string& name, size_t size)
+    : TritonMemResource<IO>(data, name, size) {
   //get shared memory region descriptor
   int shm_fd = shm_open(this->name_.c_str(), O_RDWR | O_CREAT | O_EXCL, S_IRUSR | S_IWUSR);
-  if (shm_fd == -1) {
-    triton_utils::warnOrThrow("unable to get shared memory descriptor for key: " + this->name_, canThrow);
-    this->status_ &= false;
-  }
+  if (shm_fd == -1)
+    throw cms::Exception("TritonError") << "unable to get shared memory descriptor for key: " + this->name_;
 
   //extend shared memory object
   int res = ftruncate(shm_fd, this->size_);
-  if (res == -1) {
-    triton_utils::warnOrThrow(
-        "unable to initialize shared memory key " + this->name_ + " to requested size: " + std::to_string(this->size_),
-        canThrow);
-    this->status_ &= false;
-  }
+  if (res == -1)
+    throw cms::Exception("TritonError") << "unable to initialize shared memory key " + this->name_ +
+                                               " to requested size: " + std::to_string(this->size_);
 
   //map to process address space
   constexpr size_t offset(0);
   this->addr_ = (uint8_t*)mmap(nullptr, this->size_, PROT_READ | PROT_WRITE, MAP_SHARED, shm_fd, offset);
-  if (this->addr_ == MAP_FAILED) {
-    triton_utils::warnOrThrow("unable to map to process address space for shared memory key: " + this->name_, canThrow);
-    this->status_ &= false;
-  }
+  if (this->addr_ == MAP_FAILED)
+    throw cms::Exception("TritonError") << "unable to map to process address space for shared memory key: " +
+                                               this->name_;
 
   //close descriptor
-  if (::close(shm_fd) == -1) {
-    triton_utils::warnOrThrow("unable to close descriptor for shared memory key: " + this->name_, canThrow);
-    this->status_ &= false;
-  }
+  if (::close(shm_fd) == -1)
+    throw cms::Exception("TritonError") << "unable to close descriptor for shared memory key: " + this->name_;
 
-  this->status_ &= triton_utils::warnOrThrowIfError(
-      this->data_->client()->RegisterSystemSharedMemory(this->name_, this->name_, this->size_),
-      "unable to register shared memory region: " + this->name_,
-      canThrow);
+  triton_utils::throwIfError(this->data_->client()->RegisterSystemSharedMemory(this->name_, this->name_, this->size_),
+                             "unable to register shared memory region: " + this->name_);
 }
 
 template <typename IO>
 TritonCpuShmResource<IO>::~TritonCpuShmResource<IO>() {
-  triton_utils::warnIfError(this->data_->client()->UnregisterSystemSharedMemory(this->name_),
-                            "unable to unregister shared memory region: " + this->name_);
+  close();
+}
+
+template <typename IO>
+void TritonCpuShmResource<IO>::close() {
+  if (this->closed_)
+    return;
+
+  triton_utils::throwIfError(this->data_->client()->UnregisterSystemSharedMemory(this->name_),
+                             "unable to unregister shared memory region: " + this->name_);
 
   //unmap
   int tmp_fd = munmap(this->addr_, this->size_);
   if (tmp_fd == -1)
-    edm::LogWarning("TritonWarning") << "unable to munmap for shared memory key: " << this->name_;
+    throw cms::Exception("TritonError") << "unable to munmap for shared memory key: " << this->name_;
 
   //unlink
   int shm_fd = shm_unlink(this->name_.c_str());
   if (shm_fd == -1)
-    edm::LogWarning("TritonWarning") << "unable to unlink for shared memory key: " << this->name_;
+    throw cms::Exception("TritonError") << "unable to unlink for shared memory key: " << this->name_;
+
+  this->closed_ = true;
 }
 
 template <>
@@ -123,44 +123,46 @@ template class TritonCpuShmResource<nic::InferRequestedOutput>;
 
 #ifdef TRITON_ENABLE_GPU
 template <typename IO>
-TritonGpuShmResource<IO>::TritonGpuShmResource(TritonData<IO>* data, const std::string& name, size_t size, bool canThrow)
-    : TritonMemResource<IO>(data, name, size, canThrow), deviceId_(0), handle_(std::make_shared<cudaIpcMemHandle_t>()) {
+TritonGpuShmResource<IO>::TritonGpuShmResource(TritonData<IO>* data, const std::string& name, size_t size)
+    : TritonMemResource<IO>(data, name, size), deviceId_(0), handle_(std::make_shared<cudaIpcMemHandle_t>()) {
   //todo: get server device id somehow?
-  this->status_ &= triton_utils::cudaCheck(
-      cudaSetDevice(deviceId_), "unable to set device ID to " + std::to_string(deviceId_), canThrow);
-  this->status_ &= triton_utils::cudaCheck(
-      cudaMalloc((void**)&this->addr_, this->size_), "unable to allocate GPU memory for key: " + this->name_, canThrow);
-  this->status_ &= triton_utils::cudaCheck(
-      cudaIpcGetMemHandle(handle_.get(), this->addr_), "unable to get IPC handle for key: " + this->name_, canThrow);
-  this->status_ &= triton_utils::warnOrThrowIfError(
+  cudaCheck(cudaSetDevice(deviceId_), "unable to set device ID to " + std::to_string(deviceId_));
+  cudaCheck(cudaMalloc((void**)&this->addr_, this->size_), "unable to allocate GPU memory for key: " + this->name_);
+  cudaCheck(cudaIpcGetMemHandle(handle_.get(), this->addr_), "unable to get IPC handle for key: " + this->name_);
+  triton_utils::throwIfError(
       this->data_->client()->RegisterCudaSharedMemory(this->name_, *handle_, deviceId_, this->size_),
-      "unable to register CUDA shared memory region: " + this->name_,
-      canThrow);
+      "unable to register CUDA shared memory region: " + this->name_);
 }
 
 template <typename IO>
 TritonGpuShmResource<IO>::~TritonGpuShmResource<IO>() {
-  triton_utils::warnIfError(this->data_->client()->UnregisterCudaSharedMemory(this->name_),
-                            "unable to unregister CUDA shared memory region: " + this->name_);
-  triton_utils::cudaCheck(cudaFree(this->addr_), "unable to free GPU memory for key: " + this->name_, false);
+  close();
+}
+
+template <typename IO>
+void TritonGpuShmResource<IO>::close() {
+  if (this->closed_)
+    return;
+  triton_utils::throwIfError(this->data_->client()->UnregisterCudaSharedMemory(this->name_),
+                             "unable to unregister CUDA shared memory region: " + this->name_);
+  cudaCheck(cudaFree(this->addr_), "unable to free GPU memory for key: " + this->name_);
+  this->closed_ = true;
 }
 
 template <>
 void TritonInputGpuShmResource::copyInput(const void* values, size_t offset) {
-  triton_utils::cudaCheck(
+  cudaCheck(
       cudaMemcpy(addr_ + offset, values, data_->byteSizePerBatch_, cudaMemcpyHostToDevice),
-      data_->name_ + " toServer(): unable to memcpy " + std::to_string(data_->byteSizePerBatch_) + " bytes to GPU",
-      true);
+      data_->name_ + " toServer(): unable to memcpy " + std::to_string(data_->byteSizePerBatch_) + " bytes to GPU");
 }
 
 template <>
 const uint8_t* TritonOutputGpuShmResource::copyOutput() {
   //copy back from gpu, keep in scope
   auto ptr = std::make_shared<std::vector<uint8_t>>(data_->totalByteSize_);
-  triton_utils::cudaCheck(
+  cudaCheck(
       cudaMemcpy(ptr->data(), addr_, data_->totalByteSize_, cudaMemcpyDeviceToHost),
-      data_->name_ + " fromServer(): unable to memcpy " + std::to_string(data_->totalByteSize_) + " bytes from GPU",
-      true);
+      data_->name_ + " fromServer(): unable to memcpy " + std::to_string(data_->totalByteSize_) + " bytes from GPU");
   data_->holder_ = ptr;
   return ptr->data();
 }

--- a/HeterogeneousCore/SonicTriton/src/TritonService.cc
+++ b/HeterogeneousCore/SonicTriton/src/TritonService.cc
@@ -58,7 +58,8 @@ TritonService::TritonService(const edm::ParameterSet& pset, edm::ActivityRegistr
       fallbackOpts_(pset.getParameterSet("fallback")),
       currentModuleId_(0),
       allowAddModel_(false),
-      startedFallback_(false) {
+      startedFallback_(false),
+      pid_(std::to_string(::getpid())) {
   //module construction is assumed to be serial (correct at the time this code was written)
   areg.watchPreModuleConstruction(this, &TritonService::preModuleConstruction);
   areg.watchPostModuleConstruction(this, &TritonService::postModuleConstruction);
@@ -158,8 +159,8 @@ void TritonService::preModuleDestruction(edm::ModuleDescription const& desc) {
 }
 
 //second return value is only true if fallback CPU server is being used
-std::pair<std::string, bool> TritonService::serverAddress(const std::string& model,
-                                                          const std::string& preferred) const {
+std::pair<std::string, TritonServerType> TritonService::serverAddress(const std::string& model,
+                                                                      const std::string& preferred) const {
   auto mit = models_.find(model);
   if (mit == models_.end())
     throw cms::Exception("MissingModel") << "There are no servers that provide model " << model;
@@ -178,8 +179,10 @@ std::pair<std::string, bool> TritonService::serverAddress(const std::string& mod
 
   //todo: use some algorithm to select server rather than just picking arbitrarily
   const auto& serverInfo(servers_.find(serverName)->second);
-  bool isFallbackCPU = serverInfo.isFallback and !fallbackOpts_.useGPU;
-  return std::make_pair(serverInfo.url, isFallbackCPU);
+  return std::make_pair(serverInfo.url,
+                        serverInfo.isFallback
+                            ? fallbackOpts_.useGPU ? TritonServerType::LocalGPU : TritonServerType::LocalCPU
+                            : TritonServerType::Remote);
 }
 
 void TritonService::preBeginJob(edm::PathsAndConsumesOfModulesBase const&, edm::ProcessContext const&) {
@@ -208,7 +211,7 @@ void TritonService::preBeginJob(edm::PathsAndConsumesOfModulesBase const&, edm::
   }
 
   //assemble server start command
-  std::string command("cmsTriton -P -1 -p " + std::to_string(::getpid()));
+  std::string command("cmsTriton -P -1 -p " + pid_);
   if (fallbackOpts_.debug)
     command += " -c";
   if (fallbackOpts_.verbose)

--- a/HeterogeneousCore/SonicTriton/src/TritonService.cc
+++ b/HeterogeneousCore/SonicTriton/src/TritonService.cc
@@ -179,10 +179,14 @@ std::pair<std::string, TritonServerType> TritonService::serverAddress(const std:
 
   //todo: use some algorithm to select server rather than just picking arbitrarily
   const auto& serverInfo(servers_.find(serverName)->second);
-  return std::make_pair(serverInfo.url,
-                        serverInfo.isFallback
-                            ? fallbackOpts_.useGPU ? TritonServerType::LocalGPU : TritonServerType::LocalCPU
-                            : TritonServerType::Remote);
+  auto serverType = TritonServerType::Remote;
+  if (serverInfo.isFallback) {
+    if (fallbackOpts_.useGPU)
+      serverType = TritonServerType::LocalGPU;
+    else
+      serverType = TritonServerType::LocalCPU;
+  }
+  return std::make_pair(serverInfo.url, serverType);
 }
 
 void TritonService::preBeginJob(edm::PathsAndConsumesOfModulesBase const&, edm::ProcessContext const&) {

--- a/HeterogeneousCore/SonicTriton/src/TritonService.cc
+++ b/HeterogeneousCore/SonicTriton/src/TritonService.cc
@@ -181,10 +181,12 @@ std::pair<std::string, TritonServerType> TritonService::serverAddress(const std:
   const auto& serverInfo(servers_.find(serverName)->second);
   auto serverType = TritonServerType::Remote;
   if (serverInfo.isFallback) {
-    if (fallbackOpts_.useGPU)
-      serverType = TritonServerType::LocalGPU;
-    else
+    if (!fallbackOpts_.useGPU)
       serverType = TritonServerType::LocalCPU;
+#ifdef TRITON_ENABLE_GPU
+    else
+      serverType = TritonServerType::LocalGPU;
+#endif
   }
   return std::make_pair(serverInfo.url, serverType);
 }

--- a/HeterogeneousCore/SonicTriton/src/triton_utils.cc
+++ b/HeterogeneousCore/SonicTriton/src/triton_utils.cc
@@ -1,7 +1,7 @@
 #include "HeterogeneousCore/SonicTriton/interface/triton_utils.h"
+#include "HeterogeneousCore/SonicTriton/interface/TritonException.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/Utilities/interface/Exception.h"
-#include "FWCore/Utilities/interface/Likely.h"
 
 #include <sstream>
 #include <experimental/iterator>
@@ -20,7 +20,7 @@ namespace triton_utils {
 
   void throwIfError(const Error& err, std::string_view msg) {
     if (!err.IsOk())
-      throw cms::Exception("TritonFailure") << msg << (err.Message().empty() ? "" : ": " + err.Message());
+      throw TritonException("TritonFailure") << msg << (err.Message().empty() ? "" : ": " + err.Message());
   }
 }  // namespace triton_utils
 

--- a/HeterogeneousCore/SonicTriton/src/triton_utils.cc
+++ b/HeterogeneousCore/SonicTriton/src/triton_utils.cc
@@ -39,6 +39,7 @@ namespace triton_utils {
     warnOrThrowIfError(Error("client-side problem"), msg, canThrow);
   }
 
+#ifdef TRITON_ENABLE_GPU
   bool cudaCheck(cudaError_t result, std::string_view msg, bool canThrow) {
     if (LIKELY(result == cudaSuccess))
       return true;
@@ -47,6 +48,7 @@ namespace triton_utils {
     warnOrThrowIfError(Error(cudaMsg), msg, canThrow);
     return false;
   }
+#endif
 }  // namespace triton_utils
 
 template std::string triton_utils::printColl(const edm::Span<std::vector<int64_t>::const_iterator>& coll,

--- a/HeterogeneousCore/SonicTriton/src/triton_utils.cc
+++ b/HeterogeneousCore/SonicTriton/src/triton_utils.cc
@@ -22,33 +22,6 @@ namespace triton_utils {
     if (!err.IsOk())
       throw cms::Exception("TritonFailure") << msg << (err.Message().empty() ? "" : ": " + err.Message());
   }
-
-  bool warnIfError(const Error& err, std::string_view msg) {
-    if (!err.IsOk())
-      edm::LogWarning("TritonWarning") << msg << (err.Message().empty() ? "" : ": " + err.Message());
-    return err.IsOk();
-  }
-
-  bool warnOrThrowIfError(const Error& err, std::string_view msg, bool canThrow) {
-    if (canThrow)
-      throwIfError(err, msg);
-    return !canThrow ? warnIfError(err, msg) : err.IsOk();
-  }
-
-  void warnOrThrow(std::string_view msg, bool canThrow) {
-    warnOrThrowIfError(Error("client-side problem"), msg, canThrow);
-  }
-
-#ifdef TRITON_ENABLE_GPU
-  bool cudaCheck(cudaError_t result, std::string_view msg, bool canThrow) {
-    if (LIKELY(result == cudaSuccess))
-      return true;
-
-    std::string cudaMsg(std::string(cudaGetErrorName(result)) + ": " + cudaGetErrorString(result));
-    warnOrThrowIfError(Error(cudaMsg), msg, canThrow);
-    return false;
-  }
-#endif
 }  // namespace triton_utils
 
 template std::string triton_utils::printColl(const edm::Span<std::vector<int64_t>::const_iterator>& coll,

--- a/HeterogeneousCore/SonicTriton/test/BuildFile.xml
+++ b/HeterogeneousCore/SonicTriton/test/BuildFile.xml
@@ -1,5 +1,6 @@
 <environment>
-  <test name="TestHeterogeneousCoreSonicTritonProducer" command="${LOCALTOP}/src/HeterogeneousCore/SonicTriton/test/unittest.sh ${LOCALTOP}"/>
+  <test name="TestHeterogeneousCoreSonicTritonProducerCPU" command="${LOCALTOP}/src/HeterogeneousCore/SonicTriton/test/unittest.sh ${LOCALTOP} CPU"/>
+  <test name="TestHeterogeneousCoreSonicTritonProducerGPU" command="${LOCALTOP}/src/HeterogeneousCore/SonicTriton/test/unittest.sh ${LOCALTOP} GPU"/>
   <library file="*.cc" name="testHeterogenousCoreSonicTriton">
     <flags EDM_PLUGIN="1"/>
     <use name="FWCore/ParameterSet"/>

--- a/HeterogeneousCore/SonicTriton/test/TritonGraphModules.cc
+++ b/HeterogeneousCore/SonicTriton/test/TritonGraphModules.cc
@@ -15,7 +15,8 @@ public:
       : nodeMin_(cfg.getParameter<unsigned>("nodeMin")),
         nodeMax_(cfg.getParameter<unsigned>("nodeMax")),
         edgeMin_(cfg.getParameter<unsigned>("edgeMin")),
-        edgeMax_(cfg.getParameter<unsigned>("edgeMax")) {}
+        edgeMax_(cfg.getParameter<unsigned>("edgeMax")),
+        brief_(cfg.getParameter<bool>("brief")) {}
   void makeInput(edm::Event const& iEvent, TritonInputMap& iInput) const {
     //get event-based seed for RNG
     unsigned int runNum_uint = static_cast<unsigned int>(iEvent.id().run());
@@ -32,15 +33,13 @@ public:
     //set shapes
     auto& input1 = iInput.at("x__0");
     input1.setShape(0, nnodes);
-    auto data1 = std::make_shared<TritonInput<float>>(1);
+    auto data1 = input1.allocate<float>();
     auto& vdata1 = (*data1)[0];
-    vdata1.reserve(input1.sizeShape());
 
     auto& input2 = iInput.at("edgeindex__1");
     input2.setShape(1, nedges);
-    auto data2 = std::make_shared<TritonInput<int64_t>>(1);
+    auto data2 = input2.allocate<int64_t>();
     auto& vdata2 = (*data2)[0];
-    vdata2.reserve(input2.sizeShape());
 
     //fill
     std::normal_distribution<float> randx(-10, 4);
@@ -62,27 +61,33 @@ public:
     const auto& output1 = iOutput.begin()->second;
     // convert from server format
     const auto& tmp = output1.fromServer<float>();
-    std::stringstream msg;
-    for (int i = 0; i < output1.shape()[0]; ++i) {
-      msg << "output " << i << ": ";
-      for (int j = 0; j < output1.shape()[1]; ++j) {
-        msg << tmp[0][output1.shape()[1] * i + j] << " ";
+    if (brief_)
+      edm::LogInfo(debugName) << "output shape: " << output1.shape()[0] << ", " << output1.shape()[1];
+    else {
+      std::stringstream msg;
+      for (int i = 0; i < output1.shape()[0]; ++i) {
+        msg << "output " << i << ": ";
+        for (int j = 0; j < output1.shape()[1]; ++j) {
+          msg << tmp[0][output1.shape()[1] * i + j] << " ";
+        }
+        msg << "\n";
       }
-      msg << "\n";
+      edm::LogInfo(debugName) << msg.str();
     }
-    edm::LogInfo(debugName) << msg.str();
   }
   static void fillPSetDescription(edm::ParameterSetDescription& desc) {
     desc.add<unsigned>("nodeMin", 100);
     desc.add<unsigned>("nodeMax", 4000);
     desc.add<unsigned>("edgeMin", 8000);
     desc.add<unsigned>("edgeMax", 15000);
+    desc.add<bool>("brief", false);
   }
 
 private:
   //members
   unsigned nodeMin_, nodeMax_;
   unsigned edgeMin_, edgeMax_;
+  bool brief_;
 };
 
 class TritonGraphProducer : public TritonEDProducer<> {

--- a/HeterogeneousCore/SonicTriton/test/TritonGraphModules.cc
+++ b/HeterogeneousCore/SonicTriton/test/TritonGraphModules.cc
@@ -64,7 +64,7 @@ public:
     if (brief_)
       edm::LogInfo(debugName) << "output shape: " << output1.shape()[0] << ", " << output1.shape()[1];
     else {
-      std::stringstream msg;
+      edm::LogInfo msg(debugName);
       for (int i = 0; i < output1.shape()[0]; ++i) {
         msg << "output " << i << ": ";
         for (int j = 0; j < output1.shape()[1]; ++j) {
@@ -72,7 +72,6 @@ public:
         }
         msg << "\n";
       }
-      edm::LogInfo(debugName) << msg.str();
     }
   }
   static void fillPSetDescription(edm::ParameterSetDescription& desc) {

--- a/HeterogeneousCore/SonicTriton/test/TritonImageProducer.cc
+++ b/HeterogeneousCore/SonicTriton/test/TritonImageProducer.cc
@@ -10,12 +10,14 @@
 #include <string>
 #include <vector>
 #include <map>
+#include <cmath>
+#include <random>
 
 class TritonImageProducer : public TritonEDProducer<> {
 public:
   explicit TritonImageProducer(edm::ParameterSet const& cfg)
       : TritonEDProducer<>(cfg, "TritonImageProducer"),
-        batchSize_(cfg.getParameter<unsigned>("batchSize")),
+        batchSize_(cfg.getParameter<int>("batchSize")),
         topN_(cfg.getParameter<unsigned>("topN")) {
     //load score list
     std::string imageListFile(cfg.getParameter<edm::FileInPath>("imageList").fullPath());
@@ -30,14 +32,26 @@ public:
     }
   }
   void acquire(edm::Event const& iEvent, edm::EventSetup const& iSetup, Input& iInput) override {
-    client_->setBatchSize(batchSize_);
+    int actualBatchSize = batchSize_;
+    //negative batch = generate random batch size from 1 to abs(batch)
+    if (batchSize_ < 0) {
+      //get event-based seed for RNG
+      unsigned int runNum_uint = static_cast<unsigned int>(iEvent.id().run());
+      unsigned int lumiNum_uint = static_cast<unsigned int>(iEvent.id().luminosityBlock());
+      unsigned int evNum_uint = static_cast<unsigned int>(iEvent.id().event());
+      std::uint32_t seed = (lumiNum_uint << 10) + (runNum_uint << 20) + evNum_uint;
+      std::mt19937 rng(seed);
+      std::uniform_int_distribution<int> randint(1, std::abs(batchSize_));
+      actualBatchSize = randint(rng);
+    }
+
+    client_->setBatchSize(actualBatchSize);
     // create an npix x npix x ncol image w/ arbitrary color value
     // model only has one input, so just pick begin()
     auto& input1 = iInput.begin()->second;
-    auto data1 = std::make_shared<TritonInput<float>>();
-    data1->reserve(batchSize_);
-    for (unsigned i = 0; i < batchSize_; ++i) {
-      data1->emplace_back(input1.sizeDims(), 0.5f);
+    auto data1 = input1.allocate<float>();
+    for (auto& vdata1 : *data1) {
+      vdata1.assign(input1.sizeDims(), 0.5f);
     }
     // convert to server format
     input1.toServer(data1);
@@ -51,7 +65,7 @@ public:
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
     edm::ParameterSetDescription desc;
     TritonClient::fillPSetDescription(desc);
-    desc.add<unsigned>("batchSize", 1);
+    desc.add<int>("batchSize", 1);
     desc.add<unsigned>("topN", 5);
     desc.add<edm::FileInPath>("imageList");
     //to ensure distinct cfi names
@@ -82,7 +96,7 @@ private:
     }
   }
 
-  unsigned batchSize_;
+  int batchSize_;
   unsigned topN_;
   std::vector<std::string> imageList_;
 };


### PR DESCRIPTION
#### PR description:

* Added `allocate()` function to streamline creation of input vectors
* Expanded unit testing: now two tests, one for CPU and one for GPU (each tests both gRPC and shared memory)
* Shared memory used automatically (by default) for local fallback server (either CPU or GPU)
* `useSharedMemory` client config parameter to disable this for a specific algorithm/producer
* Shared memory regions are reused from one event to the next, and only reallocated if the existing region is too small; this is necessary to achieve performance improvements (otherwise the high cost of reallocating e.g. every event dwarfs any improvement)
* Documentation updated accordingly

#### PR validation:

Confirmed that the same outputs are achieved whether using gRPC or shared memory, and unit tests pass as expected.

Tested performance of the two example models (ResNet50 and Graph Attention Network):
* CPU shared memory: 3-12% faster (client-side), 3-4% faster (server-side)
* GPU shared memory: 15-20% faster (client-side), 10-45% faster (server-side)

The performance improvements depend on the amount of data being transferred, as well as the size of the model (which controls how long the inference takes).

The impact of these latency decreases on throughput will be tested in the near future, once realistic workflows are prepared.

Technical details: this branch is squashed from several previous development branches.

Requires: https://github.com/cms-sw/cmsdist/pull/6929