### PR TITLE
modified the fillDescriptions method to create the cfi file automatically

### DIFF
--- a/DQM/BeamMonitor/plugins/OnlineBeamMonitor.cc
+++ b/DQM/BeamMonitor/plugins/OnlineBeamMonitor.cc
@@ -66,9 +66,8 @@ OnlineBeamMonitor::OnlineBeamMonitor(const ParameterSet& ps)
 
 void OnlineBeamMonitor::fillDescriptions(edm::ConfigurationDescriptions& iDesc) {
   edm::ParameterSetDescription ps;
-
   ps.addUntracked<std::string>("MonitorName", "YourSubsystemName");
-  iDesc.addDefault(ps);
+  iDesc.addWithDefaultLabel(ps);
 }
 
 //----------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
The title says it all.

This is not affecting any other file, this is just needed to parse the module into the confDB to be used in the HLT menu

A backporting to 11_3_X is in preparation