### PR TITLE
Modification to PythiaFilterMotherSister

### DIFF
--- a/GeneratorInterface/GenFilters/plugins/PythiaFilterMotherSister.cc
+++ b/GeneratorInterface/GenFilters/plugins/PythiaFilterMotherSister.cc
@@ -27,12 +27,11 @@ PythiaFilterMotherSister::PythiaFilterMotherSister(const edm::ParameterSet& iCon
       sisterID(iConfig.getUntrackedParameter("SisterID", 0)),
       maxSisDisplacement(iConfig.getUntrackedParameter("MaxSisterDisplacement", -1.)),
       nephewIDs(iConfig.getUntrackedParameter("NephewIDs", std::vector<int>{0})),
-      minNephewPts(iConfig.getUntrackedParameter("MinNephewPts", std::vector<double>{0.}))
-{
-   if (nephewIDs.size() != minNephewPts.size()) {
-     throw cms::Exception("BadConfig") << "PythiaFilterMotherSister: "
-                                       << "'nephewIDs' and 'minNephewPts' need same length.";
-   }
+      minNephewPts(iConfig.getUntrackedParameter("MinNephewPts", std::vector<double>{0.})) {
+  if (nephewIDs.size() != minNephewPts.size()) {
+    throw cms::Exception("BadConfig") << "PythiaFilterMotherSister: "
+                                      << "'nephewIDs' and 'minNephewPts' need same length.";
+  }
 }
 
 PythiaFilterMotherSister::~PythiaFilterMotherSister() {
@@ -79,11 +78,12 @@ bool PythiaFilterMotherSister::filter(edm::StreamID, edm::Event& iEvent, const e
                    ++nephew) {
                 int nephew_pdgId = abs((*nephew)->pdg_id());
                 for (unsigned int i = 0; i < nephewIDs.size(); i++) {
-                   if(nephew_pdgId == abs(nephewIDs.at(i)))
-                     failNephewPt += ((*nephew)->momentum().perp() < minNephewPts.at(i));
+                  if (nephew_pdgId == abs(nephewIDs.at(i)))
+                    failNephewPt += ((*nephew)->momentum().perp() < minNephewPts.at(i));
                 }
               }
-              if (failNephewPt > 0) return false;
+              if (failNephewPt > 0)
+                return false;
               // calculate displacement of the sister particle, from production to decay
               HepMC::GenVertex* v1 = (*dau)->production_vertex();
               HepMC::GenVertex* v2 = (*dau)->end_vertex();

--- a/GeneratorInterface/GenFilters/plugins/PythiaFilterMotherSister.cc
+++ b/GeneratorInterface/GenFilters/plugins/PythiaFilterMotherSister.cc
@@ -22,13 +22,17 @@ PythiaFilterMotherSister::PythiaFilterMotherSister(const edm::ParameterSet& iCon
       maxrapcut(iConfig.getUntrackedParameter("MaxRapidity", 20.)),
       minphicut(iConfig.getUntrackedParameter("MinPhi", -3.5)),
       maxphicut(iConfig.getUntrackedParameter("MaxPhi", 3.5)),
+      betaBoost(iConfig.getUntrackedParameter("BetaBoost", 0.)),
       motherIDs(iConfig.getUntrackedParameter("MotherIDs", std::vector<int>{0})),
       sisterID(iConfig.getUntrackedParameter("SisterID", 0)),
-      betaBoost(iConfig.getUntrackedParameter("BetaBoost", 0.)),
       maxSisDisplacement(iConfig.getUntrackedParameter("MaxSisterDisplacement", -1.)),
-      minTrackPt(iConfig.getUntrackedParameter("MinTrackPt", 0.)),
-      minLeptonPt(iConfig.getUntrackedParameter("MinLeptonPt", 0.)) {
-  //now do what ever initialization is needed
+      nephewIDs(iConfig.getUntrackedParameter("NephewIDs", std::vector<int>{0})),
+      minNephewPts(iConfig.getUntrackedParameter("MinNephewPts", std::vector<double>{0.}))
+{
+   if (nephewIDs.size() != minNephewPts.size()) {
+     throw cms::Exception("BadConfig") << "PythiaFilterMotherSister: "
+                                       << "'nephewIDs' and 'minNephewPts' need same length.";
+   }
 }
 
 PythiaFilterMotherSister::~PythiaFilterMotherSister() {
@@ -68,20 +72,18 @@ bool PythiaFilterMotherSister::filter(edm::StreamID, edm::Event& iEvent, const e
                ++dau) {
             // find the daugther you're interested in
             if (abs((*dau)->pdg_id()) == abs(sisterID)) {
-              int failTrackPt = 0;
-              int failLeptonPt = 0;
+              int failNephewPt = 0;
               // check pt of the nephews
               for (HepMC::GenVertex::particle_iterator nephew = (*dau)->end_vertex()->particles_begin(HepMC::children);
                    nephew != (*dau)->end_vertex()->particles_end(HepMC::children);
                    ++nephew) {
                 int nephew_pdgId = abs((*nephew)->pdg_id());
-                if (minLeptonPt > 0. and (nephew_pdgId == 11 or nephew_pdgId == 13 or nephew_pdgId == 15))
-                  failLeptonPt += ((*nephew)->momentum().perp() < minLeptonPt);
-                if (minTrackPt > 0. and nephew_pdgId == 211)
-                  failTrackPt += ((*nephew)->momentum().perp() < minTrackPt);
+                for (unsigned int i = 0; i < nephewIDs.size(); i++) {
+                   if(nephew_pdgId == abs(nephewIDs.at(i)))
+                     failNephewPt += ((*nephew)->momentum().perp() < minNephewPts.at(i));
+                }
               }
-              if (failLeptonPt > 0 or failTrackPt > 0)
-                return false;
+              if (failNephewPt > 0) return false;
               // calculate displacement of the sister particle, from production to decay
               HepMC::GenVertex* v1 = (*dau)->production_vertex();
               HepMC::GenVertex* v2 = (*dau)->end_vertex();

--- a/GeneratorInterface/GenFilters/plugins/PythiaFilterMotherSister.cc
+++ b/GeneratorInterface/GenFilters/plugins/PythiaFilterMotherSister.cc
@@ -25,7 +25,9 @@ PythiaFilterMotherSister::PythiaFilterMotherSister(const edm::ParameterSet& iCon
       motherIDs(iConfig.getUntrackedParameter("MotherIDs", std::vector<int>{0})),
       sisterID(iConfig.getUntrackedParameter("SisterID", 0)),
       betaBoost(iConfig.getUntrackedParameter("BetaBoost", 0.)),
-      maxSisDisplacement(iConfig.getUntrackedParameter("MaxSisterDisplacement", -1.)) {
+      maxSisDisplacement(iConfig.getUntrackedParameter("MaxSisterDisplacement", -1.)),
+      minTrackPt(iConfig.getUntrackedParameter("MinTrackPt", 0.)),
+      minLeptonPt(iConfig.getUntrackedParameter("MinLeptonPt", 0.)) {
   //now do what ever initialization is needed
 }
 
@@ -66,17 +68,31 @@ bool PythiaFilterMotherSister::filter(edm::StreamID, edm::Event& iEvent, const e
                ++dau) {
             // find the daugther you're interested in
             if (abs((*dau)->pdg_id()) == abs(sisterID)) {
+              bool passTrackPt = false;
+              bool passLeptonPt = false;
+              // check pt of the nephews
+              for (HepMC::GenVertex::particle_iterator nephew = (*dau)->end_vertex()->particles_begin(HepMC::children);
+                   nephew != (*dau)->end_vertex()->particles_end(HepMC::children);
+                   ++nephew) {
+                int nephew_pdgId = abs((*nephew)->pdg_id());
+                // implicit requirement that only one newphew is a lepton
+                if (nephew_pdgId == 11 or nephew_pdgId == 13 or nephew_pdgId == 15)
+                  passLeptonPt = ((*nephew)->momentum().perp() > minLeptonPt);
+                if (nephew_pdgId == 211)
+                  passTrackPt = ((*nephew)->momentum().perp() > minTrackPt);
+              }
+              if (not passLeptonPt or not passTrackPt)
+                return false;
               // calculate displacement of the sister particle, from production to decay
               HepMC::GenVertex* v1 = (*dau)->production_vertex();
               HepMC::GenVertex* v2 = (*dau)->end_vertex();
 
               double lx12 = v1->position().x() - v2->position().x();
               double ly12 = v1->position().y() - v2->position().y();
-              double lz12 = v1->position().z() - v2->position().z();
-              double lxyz12 = sqrt(lx12 * lx12 + ly12 * ly12 + lz12 * lz12);
+              double lxy12 = sqrt(lx12 * lx12 + ly12 * ly12);
 
               if (maxSisDisplacement != -1) {
-                if (lxyz12 < maxSisDisplacement) {
+                if (lxy12 < maxSisDisplacement) {
                   return true;
                 }
               } else {

--- a/GeneratorInterface/GenFilters/plugins/PythiaFilterMotherSister.cc
+++ b/GeneratorInterface/GenFilters/plugins/PythiaFilterMotherSister.cc
@@ -68,20 +68,19 @@ bool PythiaFilterMotherSister::filter(edm::StreamID, edm::Event& iEvent, const e
                ++dau) {
             // find the daugther you're interested in
             if (abs((*dau)->pdg_id()) == abs(sisterID)) {
-              bool passTrackPt = false;
-              bool passLeptonPt = false;
+              int failTrackPt = 0;
+              int failLeptonPt = 0;
               // check pt of the nephews
               for (HepMC::GenVertex::particle_iterator nephew = (*dau)->end_vertex()->particles_begin(HepMC::children);
                    nephew != (*dau)->end_vertex()->particles_end(HepMC::children);
                    ++nephew) {
                 int nephew_pdgId = abs((*nephew)->pdg_id());
-                // implicit requirement that only one newphew is a lepton
-                if (nephew_pdgId == 11 or nephew_pdgId == 13 or nephew_pdgId == 15)
-                  passLeptonPt = ((*nephew)->momentum().perp() > minLeptonPt);
-                if (nephew_pdgId == 211)
-                  passTrackPt = ((*nephew)->momentum().perp() > minTrackPt);
+                if (minLeptonPt > 0. and (nephew_pdgId == 11 or nephew_pdgId == 13 or nephew_pdgId == 15))
+                  failLeptonPt += ((*nephew)->momentum().perp() < minLeptonPt);
+                if (minTrackPt > 0. and nephew_pdgId == 211)
+                  failTrackPt += ((*nephew)->momentum().perp() < minTrackPt);
               }
-              if (not passLeptonPt or not passTrackPt)
+              if (failLeptonPt > 0 or failTrackPt > 0)
                 return false;
               // calculate displacement of the sister particle, from production to decay
               HepMC::GenVertex* v1 = (*dau)->production_vertex();

--- a/GeneratorInterface/GenFilters/plugins/PythiaFilterMotherSister.h
+++ b/GeneratorInterface/GenFilters/plugins/PythiaFilterMotherSister.h
@@ -69,5 +69,7 @@ private:
 
   const double betaBoost;
   const double maxSisDisplacement;
+  const double minTrackPt;
+  const double minLeptonPt;
 };
 #endif

--- a/GeneratorInterface/GenFilters/plugins/PythiaFilterMotherSister.h
+++ b/GeneratorInterface/GenFilters/plugins/PythiaFilterMotherSister.h
@@ -64,7 +64,7 @@ private:
   const double betaBoost;
 
   std::vector<int> motherIDs;
-  const int sisterID;   
+  const int sisterID;
   const double maxSisDisplacement;
   std::vector<int> nephewIDs;
   std::vector<double> minNephewPts;

--- a/GeneratorInterface/GenFilters/plugins/PythiaFilterMotherSister.h
+++ b/GeneratorInterface/GenFilters/plugins/PythiaFilterMotherSister.h
@@ -61,15 +61,12 @@ private:
   const double maxrapcut;
   const double minphicut;
   const double maxphicut;
-
-  //const int status;
-  std::vector<int> motherIDs;
-  const int sisterID;
-  //const int processID;
-
   const double betaBoost;
+
+  std::vector<int> motherIDs;
+  const int sisterID;   
   const double maxSisDisplacement;
-  const double minTrackPt;
-  const double minLeptonPt;
+  std::vector<int> nephewIDs;
+  std::vector<double> minNephewPts;
 };
 #endif


### PR DESCRIPTION
This PR modifies the PythiaFilterMotherSister, which is a generator filter introduced in #33308 , designed to 
efficiently select events with heavy long-lived neutrinos a B semi-leptonic decay.

The modifications are:
- 2D displacement of the long-lived particle is used instead of 3D displacement
- the possibility to cut on the pt of the decay products of the long-lived particle is added.

This PR will be followed by a backport in 10_2_X.
