### PR TITLE
Fix EMTF unpacker crash by changing GEM station assignment.

### DIFF
--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFBlockGEM.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFBlockGEM.cc
@@ -96,7 +96,7 @@ namespace l1t {
                                 const int evt_sector,
                                 const int cluster_id,  // used to differentiate between GEM layer 1/2
                                 const int link) {
-        station = -99;  // station is not encoded in the GEM frame
+        station = 1;    // station is not encoded in the GEM frame for now. Set station = 1 since we only have GE1/1 for Run 3.
         ring = 1;       // GEMs are only in GE1/1 and GE2/1
         sector = -99;
         subsector = -99;

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFBlockGEM.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFBlockGEM.cc
@@ -96,8 +96,9 @@ namespace l1t {
                                 const int evt_sector,
                                 const int cluster_id,  // used to differentiate between GEM layer 1/2
                                 const int link) {
-        station = 1;    // station is not encoded in the GEM frame for now. Set station = 1 since we only have GE1/1 for Run 3.
-        ring = 1;       // GEMs are only in GE1/1 and GE2/1
+        station =
+            1;  // station is not encoded in the GEM frame for now. Set station = 1 since we only have GE1/1 for Run 3.
+        ring = 1;  // GEMs are only in GE1/1 and GE2/1
         sector = -99;
         subsector = -99;
         neighbor = -99;


### PR DESCRIPTION
#### PR description:

As reported in https://github.com/cms-sw/cmssw/pull/33679 and https://hypernews.cern.ch/HyperNews/CMS/get/tier0-Ops/2219.html the EMTF unpacker is causing a crash after a firmware update to include GEM inputs in EMTF DAQ output. The crash is due to the invalid station assignment and this PR fixes it. 

Since we want to keep this firmware for the next MWGR we want to get this in CMSSW as soon as possible also with a backport to 11_3_X.

<!-- Please replace this text with a description of the feature proposed or problem addressed, specifying:
  - what changes are expected in the output if any, 
  - what other PRs or externals it depends upon if any,
  - link to any additional material useful to provide a documentation for this PR (slides, JIRA tickets, related pull requestes, hypernews, TWiki or Indico pages)  -->

#### PR validation:

Validated with:

- scram b runtests
- runTheMatrix.py -l limited -i all --ibeos

<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->

FYI: @jiafulow @dildick @silviodonato 

