### PR TITLE
Utilities/StaticAnalyzers: use python3 in scripts

### DIFF
--- a/Utilities/StaticAnalyzers/scripts/callgraph.py
+++ b/Utilities/StaticAnalyzers/scripts/callgraph.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 from __future__ import print_function
 import re
 import yaml

--- a/Utilities/StaticAnalyzers/scripts/class-composition.py
+++ b/Utilities/StaticAnalyzers/scripts/class-composition.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 from __future__ import print_function
 import re
 stdcl = re.compile("^std::(.*)[^>]$")

--- a/Utilities/StaticAnalyzers/scripts/classnames-extract.py
+++ b/Utilities/StaticAnalyzers/scripts/classnames-extract.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 
 f = open('classes.txt','r')
 g = open('classnames.txt','w')

--- a/Utilities/StaticAnalyzers/scripts/data-class-funcs.py
+++ b/Utilities/StaticAnalyzers/scripts/data-class-funcs.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 from __future__ import print_function
 import re
 datacl = re.compile("^class ")

--- a/Utilities/StaticAnalyzers/scripts/edm-global-class.py
+++ b/Utilities/StaticAnalyzers/scripts/edm-global-class.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 from __future__ import print_function
 import re
 datacl = re.compile("^class ")

--- a/Utilities/StaticAnalyzers/scripts/postprocess-scan-build.py
+++ b/Utilities/StaticAnalyzers/scripts/postprocess-scan-build.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import lxml
 from bs4 import BeautifulSoup
 import sys, os

--- a/Utilities/StaticAnalyzers/scripts/statics.py
+++ b/Utilities/StaticAnalyzers/scripts/statics.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 from __future__ import print_function
 from builtins import range
 import re

--- a/Utilities/StaticAnalyzers/scripts/symbols.py
+++ b/Utilities/StaticAnalyzers/scripts/symbols.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 
 from __future__ import print_function
 import collections


### PR DESCRIPTION
Update scripts to use python3 so scripts can find packages, for example lxml for BeautifulSoup in postprocess-scan-build.py