### PR TITLE
[11_3_X] fixed esConsumes call in L1TriggerJSONMonitoring

### DIFF
--- a/HLTrigger/JSONMonitoring/plugins/L1TriggerJSONMonitoring.cc
+++ b/HLTrigger/JSONMonitoring/plugins/L1TriggerJSONMonitoring.cc
@@ -161,7 +161,7 @@ constexpr const std::array<const char*, 16> L1TriggerJSONMonitoring::tcdsTrigger
 L1TriggerJSONMonitoring::L1TriggerJSONMonitoring(edm::ParameterSet const& config)
     : level1Results_(config.getParameter<edm::InputTag>("L1Results")),
       level1ResultsToken_(consumes<GlobalAlgBlkBxCollection>(level1Results_)),
-      l1tUtmTriggerMenuRcdToken_(esConsumes()) {}
+      l1tUtmTriggerMenuRcdToken_(esConsumes<edm::Transition::BeginRun>()) {}
 
 // validate the configuration and optionally fill the default values
 void L1TriggerJSONMonitoring::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {


### PR DESCRIPTION
#### PR description:

Backport of https://github.com/cms-sw/cmssw/pull/33809

Description from the original PR below:

--------------------

Fix for a bug introduced in #33260: the module `L1TriggerJSONMonitoring` is now migrated correctly to `esConsumes`.

Spotted by TSG's FOG group during HLT-validation tests for the next MWGR.

Attn: @Sam-Harper @mzarucki @gennai

--------------------

#### PR validation:

Reproduced the issue seen by FOG, and verified that this update solves it.

#### If this PR is a backport, please specify the original PR and why you need to backport that PR:

#33809

Backport needed for the next MWGR.