### PR TITLE
Update recommended list of MET filters

### DIFF
--- a/PhysicsTools/NanoAOD/python/extraflags_cff.py
+++ b/PhysicsTools/NanoAOD/python/extraflags_cff.py
@@ -37,7 +37,9 @@ extraFlagsTable = cms.EDProducer("GlobalVariablesTableProducer",
     )
 )
 
-extraFlagsProducers = cms.Sequence(badGlobalMuonTagger + cloneGlobalMuonTagger + BadPFMuonTagger + BadChargedCandidateTagger)
+extraFlagsProducers = cms.Sequence()
+#The following line shows an example how to recompute MET filter decisions on top of MINIAOD in case the filter has been updated/is missing. This should not be the default in general.
+#extraFlagsProducers = cms.Sequence(badGlobalMuonTagger + cloneGlobalMuonTagger + BadPFMuonTagger + BadChargedCandidateTagger)
 
 from RecoMET.METFilters.ecalBadCalibFilter_cfi import *
 ecalBadCalibFilterNanoTagger = ecalBadCalibFilter.clone(

--- a/PhysicsTools/NanoAOD/python/extraflags_cff.py
+++ b/PhysicsTools/NanoAOD/python/extraflags_cff.py
@@ -37,9 +37,7 @@ extraFlagsTable = cms.EDProducer("GlobalVariablesTableProducer",
     )
 )
 
-extraFlagsProducers = cms.Sequence()
-#The following line shows an example how to recompute MET filter decisions on top of MINIAOD in case the filter has been updated/is missing. This should not be the default in general.
-#extraFlagsProducers = cms.Sequence(badGlobalMuonTagger + cloneGlobalMuonTagger + BadPFMuonTagger + BadChargedCandidateTagger)
+extraFlagsProducers = cms.Sequence(badGlobalMuonTagger + cloneGlobalMuonTagger + BadPFMuonTagger + BadChargedCandidateTagger)
 
 from RecoMET.METFilters.ecalBadCalibFilter_cfi import *
 ecalBadCalibFilterNanoTagger = ecalBadCalibFilter.clone(

--- a/RecoMET/METFilters/python/metFilters_cff.py
+++ b/RecoMET/METFilters/python/metFilters_cff.py
@@ -100,18 +100,23 @@ metFilters = cms.Sequence(
     HBHENoiseFilterResultProducer  *
     HBHENoiseFilter *
     HBHENoiseIsoFilter *
-    EcalDeadCellTriggerPrimitiveFilter *
+    EcalDeadCellTriggerPrimitiveFilter *  
     BadPFMuonFilter *
     BadPFMuonDzFilter *
-    EcalDeadCellTriggerPrimitiveFilter * 
-    ecalBadCalibFilter *
-    eeBadScFilter
-    
+    hfNoisyHitsFilter *
+    eeBadScFilter *
+    ecalBadCalibFilter 
 )
 
 from Configuration.Eras.Modifier_phase2_hgcal_cff import phase2_hgcal
 phase2_hgcal.toReplaceWith(metFilters, metFilters.copyAndExclude([
     HBHENoiseFilterResultProducer, HBHENoiseFilter, HBHENoiseIsoFilter, # No hcalnoise for hgcal
     eeBadScFilter                                   # No EE
+]))
+
+
+from Configuration.Eras.Modifier_run2_jme_2016_cff import run2_jme_2016
+run2_jme_2016.toReplaceWith(metFilters, metFilters.copyAndExclude([
+    ecalBadCalibFilter, hfNoisyHitsFilter
 ]))
 

--- a/RecoMET/METFilters/python/metFilters_cff.py
+++ b/RecoMET/METFilters/python/metFilters_cff.py
@@ -95,39 +95,23 @@ from RecoMET.METFilters.BadPFMuonDzFilter_cfi import *
 from RecoMET.METFilters.hfNoisyHitsFilter_cfi import *
 
 metFilters = cms.Sequence(
-   HBHENoiseFilterResultProducer *
-   HBHENoiseFilter *
-   primaryVertexFilter*
-#   HBHENoiseIsoFilter*
-#   HcalStripHaloFilter *
-   CSCTightHaloFilter *
-#   hcalLaserEventFilter *
-   #Various proposals for updated halo filters.
-   ##2015 proposals: 
-   #CSCTightHaloTrkMuUnvetoFilter *
-   #CSCTightHalo2015Filter *
-   ##2016 proposals
-   #globalTightHalo2016Filter*
-   #globalSuperTightHalo2016Filter*
-   EcalDeadCellTriggerPrimitiveFilter* 
-   ecalBadCalibFilter*
-#   *goodVertices * trackingFailureFilter *
-   eeBadScFilter*
-#   ecalLaserCorrFilter *
-#   trkPOGFilters
-   chargedHadronTrackResolutionFilter *
-   BadChargedCandidateFilter*
-   BadPFMuonFilter *
-   BadPFMuonDzFilter *
-   hfNoisyHitsFilter *
-   BadChargedCandidateSummer16Filter*
-   BadPFMuonSummer16Filter *
-   muonBadTrackFilter
+    goodVertices *
+    globalSuperTightHalo2016Filter *
+    HBHENoiseFilterResultProducer  *
+    HBHENoiseFilter *
+    HBHENoiseIsoFilter *
+    EcalDeadCellTriggerPrimitiveFilter *
+    BadPFMuonFilter *
+    BadPFMuonDzFilter *
+    EcalDeadCellTriggerPrimitiveFilter * 
+    ecalBadCalibFilter *
+    eeBadScFilter
+    
 )
 
 from Configuration.Eras.Modifier_phase2_hgcal_cff import phase2_hgcal
 phase2_hgcal.toReplaceWith(metFilters, metFilters.copyAndExclude([
-    HBHENoiseFilterResultProducer, HBHENoiseFilter, # No hcalnoise for hgcal
+    HBHENoiseFilterResultProducer, HBHENoiseFilter, HBHENoiseIsoFilter, # No hcalnoise for hgcal
     eeBadScFilter                                   # No EE
 ]))
 


### PR DESCRIPTION
#### PR description:
The PR update the list of MET filters run in the global boolean Flag_METFilters.
The list was discussed here:
https://indico.cern.ch/event/1042496/#27-update-on-ul-met-filters
and corresponds to the list in this twiki:
https://twiki.cern.ch/twiki/bin/viewauth/CMS/MissingETOptionalFiltersRun2#Analysis_Recommendations_for_ana

#### PR validation:
runTheMatrix.py -l limited -i all --ibeos
is run successfully 
