### PR TITLE
Add missing <cstddef> includes for size_t

### DIFF
--- a/DataFormats/HcalDigi/interface/HcalLaserDigi.h
+++ b/DataFormats/HcalDigi/interface/HcalLaserDigi.h
@@ -1,8 +1,9 @@
 #ifndef DATAFORMATS_HCALDIGI_HCALLASERDIGI_H
 #define DATAFORMATS_HCALDIGI_HCALLASERDIGI_H 1
 
-#include <vector>
+#include <cstddef>
 #include <cstdint>
+#include <vector>
 
 class HcalLaserDigi {
 public:

--- a/DataFormats/SiPixelDigi/interface/SiPixelDigisSoA.h
+++ b/DataFormats/SiPixelDigi/interface/SiPixelDigisSoA.h
@@ -1,6 +1,7 @@
 #ifndef DataFormats_SiPixelDigi_interface_SiPixelDigisSoA_h
 #define DataFormats_SiPixelDigi_interface_SiPixelDigisSoA_h
 
+#include <cstddef>
 #include <cstdint>
 #include <vector>
 


### PR DESCRIPTION
#### PR description:

To make cmssw compile with gcc 11.

#### PR validation:

Building CMSSW with gcc 11 gives errors without this PR, but succeeds with this PR.