### PR TITLE
[RFC] Add RNTuple NanoAOD output module

### DIFF
--- a/PhysicsTools/NanoAOD/plugins/BuildFile.xml
+++ b/PhysicsTools/NanoAOD/plugins/BuildFile.xml
@@ -8,6 +8,7 @@
 <use name="PhysicsTools/PatAlgos"/>
 <use name="DataFormats/NanoAOD"/>
 <use name="roothistmatrix"/>
+<use name="rootntuple"/>
 <use name="RecoVertex/VertexTools"/>
 <use name="RecoVertex/VertexPrimitives"/>
 <use name="DataFormats/L1TGlobal"/>
@@ -18,7 +19,6 @@
 <use name="CondTools/BTau"/>
 <use name="fastjet"/>
 <use name="fastjet-contrib"/>
-<lib name="ROOTNTuple"/>
 <library file="*.cc" name="PhysicsToolsNanoAODPlugins">
   <flags EDM_PLUGIN="1"/>
 </library>

--- a/PhysicsTools/NanoAOD/plugins/BuildFile.xml
+++ b/PhysicsTools/NanoAOD/plugins/BuildFile.xml
@@ -18,6 +18,7 @@
 <use name="CondTools/BTau"/>
 <use name="fastjet"/>
 <use name="fastjet-contrib"/>
+<lib name="ROOTNTuple"/>
 <library file="*.cc" name="PhysicsToolsNanoAODPlugins">
   <flags EDM_PLUGIN="1"/>
 </library>

--- a/PhysicsTools/NanoAOD/plugins/EventStringOutputFields.cc
+++ b/PhysicsTools/NanoAOD/plugins/EventStringOutputFields.cc
@@ -4,7 +4,7 @@
 void EventStringOutputFields::registerToken(const edm::EDGetToken &token) { m_tokens.push_back(token); }
 
 void EventStringOutputFields::createFields(RNTupleModel &model) {
-  m_evstrings = RNTupleFieldPtr<std::vector<std::string>>("EventStrings", model);
+  m_evstrings = RNTupleFieldPtr<std::vector<std::string>>("EventStrings", "", model);
 }
 
 void EventStringOutputFields::fill(const edm::EventForOutput &iEvent) {

--- a/PhysicsTools/NanoAOD/plugins/EventStringOutputFields.cc
+++ b/PhysicsTools/NanoAOD/plugins/EventStringOutputFields.cc
@@ -1,9 +1,7 @@
 #include "FWCore/Framework/interface/EventForOutput.h"
 #include "PhysicsTools/NanoAOD/plugins/EventStringOutputFields.h"
 
-void EventStringOutputFields::registerToken(const edm::EDGetToken &token) {
-  m_tokens.push_back(token);
-}
+void EventStringOutputFields::registerToken(const edm::EDGetToken &token) { m_tokens.push_back(token); }
 
 void EventStringOutputFields::createFields(RNTupleModel &model) {
   m_evstrings = RNTupleFieldPtr<std::vector<std::string>>("EventStrings", model);

--- a/PhysicsTools/NanoAOD/plugins/EventStringOutputFields.cc
+++ b/PhysicsTools/NanoAOD/plugins/EventStringOutputFields.cc
@@ -1,0 +1,26 @@
+#include "FWCore/Framework/interface/EventForOutput.h"
+#include "PhysicsTools/NanoAOD/plugins/EventStringOutputFields.h"
+
+void EventStringOutputFields::register_token(const edm::EDGetToken &token) {
+  m_tokens.push_back(token);
+}
+
+void EventStringOutputFields::createFields(RNTupleModel &model) {
+  m_evstrings = RNTupleFieldPtr<std::vector<std::string>>("EventStrings", model);
+}
+
+void EventStringOutputFields::fill(const edm::EventForOutput &iEvent) {
+  std::vector<std::string> evstrings;
+  if (m_lastLumi != iEvent.id().luminosityBlock()) {
+    edm::Handle<std::string> handle;
+    for (const auto &t : m_tokens) {
+      iEvent.getByToken(t, handle);
+      const std::string &evstr = *handle;
+      if (!evstr.empty()) {
+        evstrings.push_back(evstr);
+      }
+    }
+    m_lastLumi = iEvent.id().luminosityBlock();
+  }
+  m_evstrings.fill(evstrings);
+}

--- a/PhysicsTools/NanoAOD/plugins/EventStringOutputFields.cc
+++ b/PhysicsTools/NanoAOD/plugins/EventStringOutputFields.cc
@@ -1,7 +1,7 @@
 #include "FWCore/Framework/interface/EventForOutput.h"
 #include "PhysicsTools/NanoAOD/plugins/EventStringOutputFields.h"
 
-void EventStringOutputFields::register_token(const edm::EDGetToken &token) {
+void EventStringOutputFields::registerToken(const edm::EDGetToken &token) {
   m_tokens.push_back(token);
 }
 

--- a/PhysicsTools/NanoAOD/plugins/EventStringOutputFields.h
+++ b/PhysicsTools/NanoAOD/plugins/EventStringOutputFields.h
@@ -1,0 +1,47 @@
+#ifndef PhysicsTools_NanoAOD_EventStringOutputFields_h
+#define PhysicsTools_NanoAOD_EventStringOutputFields_h
+
+#include <string>
+#include <vector>
+#include "FWCore/Framework/interface/EventForOutput.h"
+#include "FWCore/Utilities/interface/EDGetToken.h"
+
+#include <ROOT/RNTupleModel.hxx>
+using ROOT::Experimental::RNTupleModel;
+
+#include "RNTupleFieldPtr.h"
+
+class EventStringOutputFields {
+private:
+  std::vector<edm::EDGetToken> m_tokens;
+  RNTupleFieldPtr<std::vector<std::string>> m_evstrings;
+  long m_lastLumi = -1;
+public:
+  EventStringOutputFields() = default;
+
+  void register_token(const edm::EDGetToken &token) {
+    m_tokens.push_back(token);
+  }
+
+  void createFields(RNTupleModel &model) {
+    m_evstrings = RNTupleFieldPtr<std::vector<std::string>>("EventStrings", model);
+  }
+
+  void fill(const edm::EventForOutput &iEvent) {
+    std::vector<std::string> evstrings;
+    if (m_lastLumi != iEvent.id().luminosityBlock()) {
+      edm::Handle<std::string> handle;
+      for (const auto &t : m_tokens) {
+        iEvent.getByToken(t, handle);
+        const std::string &evstr = *handle;
+        if (!evstr.empty()) {
+          evstrings.push_back(evstr);
+        }
+      }
+      m_lastLumi = iEvent.id().luminosityBlock();
+    }
+    m_evstrings.fill(evstrings);
+  }
+};
+
+#endif

--- a/PhysicsTools/NanoAOD/plugins/EventStringOutputFields.h
+++ b/PhysicsTools/NanoAOD/plugins/EventStringOutputFields.h
@@ -18,7 +18,7 @@ private:
 public:
   EventStringOutputFields() = default;
 
-  void register_token(const edm::EDGetToken &token);
+  void registerToken(const edm::EDGetToken &token);
   void createFields(RNTupleModel &model);
   void fill(const edm::EventForOutput &iEvent);
 };

--- a/PhysicsTools/NanoAOD/plugins/EventStringOutputFields.h
+++ b/PhysicsTools/NanoAOD/plugins/EventStringOutputFields.h
@@ -3,7 +3,6 @@
 
 #include <string>
 #include <vector>
-#include "FWCore/Framework/interface/EventForOutput.h"
 #include "FWCore/Utilities/interface/EDGetToken.h"
 
 #include <ROOT/RNTupleModel.hxx>
@@ -19,29 +18,9 @@ private:
 public:
   EventStringOutputFields() = default;
 
-  void register_token(const edm::EDGetToken &token) {
-    m_tokens.push_back(token);
-  }
-
-  void createFields(RNTupleModel &model) {
-    m_evstrings = RNTupleFieldPtr<std::vector<std::string>>("EventStrings", model);
-  }
-
-  void fill(const edm::EventForOutput &iEvent) {
-    std::vector<std::string> evstrings;
-    if (m_lastLumi != iEvent.id().luminosityBlock()) {
-      edm::Handle<std::string> handle;
-      for (const auto &t : m_tokens) {
-        iEvent.getByToken(t, handle);
-        const std::string &evstr = *handle;
-        if (!evstr.empty()) {
-          evstrings.push_back(evstr);
-        }
-      }
-      m_lastLumi = iEvent.id().luminosityBlock();
-    }
-    m_evstrings.fill(evstrings);
-  }
+  void register_token(const edm::EDGetToken &token);
+  void createFields(RNTupleModel &model);
+  void fill(const edm::EventForOutput &iEvent);
 };
 
 #endif

--- a/PhysicsTools/NanoAOD/plugins/EventStringOutputFields.h
+++ b/PhysicsTools/NanoAOD/plugins/EventStringOutputFields.h
@@ -15,6 +15,7 @@ private:
   std::vector<edm::EDGetToken> m_tokens;
   RNTupleFieldPtr<std::vector<std::string>> m_evstrings;
   long m_lastLumi = -1;
+
 public:
   EventStringOutputFields() = default;
 

--- a/PhysicsTools/NanoAOD/plugins/NanoAODRNTupleOutputModule.cc
+++ b/PhysicsTools/NanoAOD/plugins/NanoAODRNTupleOutputModule.cc
@@ -279,6 +279,11 @@ void NanoAODRNTupleOutputModule::reallyCloseFile() {
   run_ntuple->PrintInfo();
   run_ntuple->PrintInfo(ROOT::Experimental::ENTupleInfo::kStorageDetails);
 
+  auto pset_ntuple = ROOT::Experimental::RNTupleReader::Open(
+    edm::poolNames::parameterSetsTreeName(), m_fileName);
+  pset_ntuple->PrintInfo();
+  pset_ntuple->PrintInfo(ROOT::Experimental::ENTupleInfo::kStorageDetails);
+
   edm::Service<edm::JobReport> jr;
   jr->outputFileClosed(m_jrToken);
 }

--- a/PhysicsTools/NanoAOD/plugins/NanoAODRNTupleOutputModule.cc
+++ b/PhysicsTools/NanoAOD/plugins/NanoAODRNTupleOutputModule.cc
@@ -173,7 +173,7 @@ void NanoAODRNTupleOutputModule::openFile(edm::FileBlock const&) {
   const auto& keeps = keptProducts();
   for (const auto& keep : keeps[edm::InRun]) {
     if (keep.first->className() == "nanoaod::MergeableCounterTable") {
-      //m_runTables.push_back(SummaryTableOutputBranches(keep.first, keep.second));
+      m_run.register_token(keep.second);
     }
     else if (keep.first->className() == "nanoaod::UniqueString" &&
              keep.first->moduleLabel() == "nanoMetadata")

--- a/PhysicsTools/NanoAOD/plugins/NanoAODRNTupleOutputModule.cc
+++ b/PhysicsTools/NanoAOD/plugins/NanoAODRNTupleOutputModule.cc
@@ -284,6 +284,11 @@ void NanoAODRNTupleOutputModule::reallyCloseFile() {
   pset_ntuple->PrintInfo();
   pset_ntuple->PrintInfo(ROOT::Experimental::ENTupleInfo::kStorageDetails);
 
+  auto md_ntuple = ROOT::Experimental::RNTupleReader::Open(
+    edm::poolNames::metaDataTreeName(), m_fileName);
+  md_ntuple->PrintInfo();
+  md_ntuple->PrintInfo(ROOT::Experimental::ENTupleInfo::kStorageDetails);
+
   edm::Service<edm::JobReport> jr;
   jr->outputFileClosed(m_jrToken);
 }
@@ -292,6 +297,10 @@ void NanoAODRNTupleOutputModule::writeProvenance() {
   PSetNTuple pntuple;
   pntuple.fill(edm::pset::Registry::instance(), *m_file);
   pntuple.finalizeWrite();
+
+  MetadataNTuple mdntuple;
+  mdntuple.fill(m_processHistoryRegistry, *m_file);
+  mdntuple.finalizeWrite();
 }
 
 void NanoAODRNTupleOutputModule::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {

--- a/PhysicsTools/NanoAOD/plugins/NanoAODRNTupleOutputModule.cc
+++ b/PhysicsTools/NanoAOD/plugins/NanoAODRNTupleOutputModule.cc
@@ -185,11 +185,6 @@ void NanoAODRNTupleOutputModule::openFile(edm::FileBlock const&) {
           keep.first->className() + " in Run branch");
     }
   }
-
-  // TODO move to reallyCloseFile, here for quick debugging
-  if (m_writeProvenance) {
-    writeProvenance();
-  }
 }
 
 void NanoAODRNTupleOutputModule::initializeNTuple(edm::EventForOutput const& iEvent) {
@@ -248,9 +243,9 @@ void NanoAODRNTupleOutputModule::write(edm::EventForOutput const& iEvent) {
 }
 
 void NanoAODRNTupleOutputModule::reallyCloseFile() {
-  //if (m_writeProvenance) {
-  //  writeProvenance();
-  //}
+  if (m_writeProvenance) {
+    writeProvenance();
+  }
   // write ntuple to disk by calling the RNTupleWriter destructor
   m_ntuple.reset();
   m_lumi.finalizeWrite();
@@ -324,6 +319,16 @@ void NanoAODRNTupleOutputModule::fillDescriptions(edm::ConfigurationDescriptions
                                          "keep nanoaodMergeableCounterTable_*Table_*_*",
                                          "keep nanoaodUniqueString_nanoMetadata_*_*"};
   edm::one::OutputModule<>::fillDescription(desc, keep);
+
+  //Used by Workflow management for their own meta data
+  edm::ParameterSetDescription dataSet;
+  dataSet.setAllowAnything();
+  desc.addUntracked<edm::ParameterSetDescription>("dataset", dataSet)
+      ->setComment("PSet is only used by Data Operations and not by this module.");
+
+  edm::ParameterSetDescription branchSet;
+  branchSet.setAllowAnything();
+  desc.add<edm::ParameterSetDescription>("branches", branchSet);
 
   descriptions.addDefault(desc);
 }

--- a/PhysicsTools/NanoAOD/plugins/NanoAODRNTupleOutputModule.cc
+++ b/PhysicsTools/NanoAOD/plugins/NanoAODRNTupleOutputModule.cc
@@ -67,7 +67,7 @@ private:
 
   std::unique_ptr<TFile> m_file;
   std::unique_ptr<RNTupleWriter> m_ntuple;
-  TableCollections m_tables;
+  TableCollectionSet m_tables;
   std::vector<TriggerOutputFields> m_triggers;
   EventStringOutputFields m_evstrings;
 

--- a/PhysicsTools/NanoAOD/plugins/NanoAODRNTupleOutputModule.cc
+++ b/PhysicsTools/NanoAOD/plugins/NanoAODRNTupleOutputModule.cc
@@ -37,10 +37,7 @@ using ROOT::Experimental::RNTupleWriteOptions;
 #include "DataFormats/NanoAOD/interface/UniqueString.h"
 #include "DataFormats/Provenance/interface/ProcessHistoryRegistry.h"
 
-#include "PhysicsTools/NanoAOD/plugins/EventStringOutputFields.h"
 #include "PhysicsTools/NanoAOD/plugins/NanoAODRNTuples.h"
-#include "PhysicsTools/NanoAOD/plugins/TableOutputFields.h"
-#include "PhysicsTools/NanoAOD/plugins/TriggerOutputFields.h"
 
 class NanoAODRNTupleOutputModule : public edm::one::OutputModule<> {
 public:

--- a/PhysicsTools/NanoAOD/plugins/NanoAODRNTupleOutputModule.cc
+++ b/PhysicsTools/NanoAOD/plugins/NanoAODRNTupleOutputModule.cc
@@ -142,7 +142,6 @@ bool NanoAODRNTupleOutputModule::isFileOpen() const {
 
 void NanoAODRNTupleOutputModule::openFile(edm::FileBlock const&) {
   m_file = std::make_unique<TFile>(m_fileName.c_str(), "RECREATE", "", m_compressionLevel);
-  // todo check if m_file is valid?
   edm::Service<edm::JobReport> jr;
   cms::Digest branchHash;
   m_jrToken = jr->outputFileOpened(m_fileName,

--- a/PhysicsTools/NanoAOD/plugins/NanoAODRNTupleOutputModule.cc
+++ b/PhysicsTools/NanoAOD/plugins/NanoAODRNTupleOutputModule.cc
@@ -189,10 +189,8 @@ void NanoAODRNTupleOutputModule::initializeNTuple(edm::EventForOutput const& iEv
   auto model = RNTupleModel::Create();
   m_commonFields.createFields(*model);
 
-  //m_tables.clear();
   const auto& keeps = keptProducts();
   for (const auto& keep: keeps[edm::InEvent]) {
-    //std::cout << "branch name: " << keep.first->branchName() << "\n";
     if (keep.first->className() == "nanoaod::FlatTable") {
       edm::Handle<nanoaod::FlatTable> handle;
       const auto& token = keep.second;
@@ -211,9 +209,8 @@ void NanoAODRNTupleOutputModule::initializeNTuple(edm::EventForOutput const& iEv
   for (auto& trigger: m_triggers) {
     trigger.createFields(iEvent, *model);
   }
-  m_tables.print();
   m_evstrings.createFields(*model);
-  // todo use Append
+  // TODO use Append
   RNTupleWriteOptions options;
   options.SetCompression(m_file->GetCompressionSettings());
   m_ntuple = std::make_unique<RNTupleWriter>(std::move(model),
@@ -249,41 +246,6 @@ void NanoAODRNTupleOutputModule::reallyCloseFile() {
   m_run.finalizeWrite();
   m_file->Write();
   m_file->Close();
-
-  auto ntuple = ROOT::Experimental::RNTupleReader::Open("Events", m_fileName);
-  ntuple->PrintInfo();
-  ntuple->PrintInfo(ROOT::Experimental::ENTupleInfo::kStorageDetails);
-
-  auto muons = ntuple->GetViewCollection("Muon");
-  auto muon_pt = muons.GetView<float>("pt");
-  auto num_entries = 0;
-  for (auto e: ntuple->GetEntryRange()) {
-    std::cout << "entry " << num_entries++ << ":\n";
-    auto num_muons = 0;
-    for (auto m: muons.GetCollectionRange(e)) {
-      std::cout << "pt: " << muon_pt(m) << "\n";
-      num_muons++;
-    }
-    std::cout << "... total " << num_muons << " muons\n";
-  }
-
-  auto lumi_ntuple = ROOT::Experimental::RNTupleReader::Open("LuminosityBlocks", m_fileName);
-  lumi_ntuple->PrintInfo();
-  lumi_ntuple->PrintInfo(ROOT::Experimental::ENTupleInfo::kStorageDetails);
-
-  auto run_ntuple = ROOT::Experimental::RNTupleReader::Open("Runs", m_fileName);
-  run_ntuple->PrintInfo();
-  run_ntuple->PrintInfo(ROOT::Experimental::ENTupleInfo::kStorageDetails);
-
-  auto pset_ntuple = ROOT::Experimental::RNTupleReader::Open(
-    edm::poolNames::parameterSetsTreeName(), m_fileName);
-  pset_ntuple->PrintInfo();
-  pset_ntuple->PrintInfo(ROOT::Experimental::ENTupleInfo::kStorageDetails);
-
-  auto md_ntuple = ROOT::Experimental::RNTupleReader::Open(
-    edm::poolNames::metaDataTreeName(), m_fileName);
-  md_ntuple->PrintInfo();
-  md_ntuple->PrintInfo(ROOT::Experimental::ENTupleInfo::kStorageDetails);
 
   edm::Service<edm::JobReport> jr;
   jr->outputFileClosed(m_jrToken);

--- a/PhysicsTools/NanoAOD/plugins/NanoAODRNTupleOutputModule.cc
+++ b/PhysicsTools/NanoAOD/plugins/NanoAODRNTupleOutputModule.cc
@@ -169,7 +169,7 @@ void NanoAODRNTupleOutputModule::openFile(edm::FileBlock const&) {
   const auto& keeps = keptProducts();
   for (const auto& keep : keeps[edm::InRun]) {
     if (keep.first->className() == "nanoaod::MergeableCounterTable") {
-      m_run.register_token(keep.second);
+      m_run.registerToken(keep.second);
     }
     else if (keep.first->className() == "nanoaod::UniqueString" &&
              keep.first->moduleLabel() == "nanoMetadata")
@@ -199,7 +199,7 @@ void NanoAODRNTupleOutputModule::initializeNTuple(edm::EventForOutput const& iEv
       m_triggers.emplace_back(TriggerOutputFields(keep.first->processName(), keep.second));
     } else if (keep.first->className() == "std::basic_string<char,std::char_traits<char> >" &&
                keep.first->productInstanceName() == "genModel") {
-      m_evstrings.register_token(keep.second);
+      m_evstrings.registerToken(keep.second);
     } else {
       throw cms::Exception("Configuration", "NanoAODOutputModule cannot handle class " + keep.first->className());
     }

--- a/PhysicsTools/NanoAOD/plugins/NanoAODRNTupleOutputModule.cc
+++ b/PhysicsTools/NanoAOD/plugins/NanoAODRNTupleOutputModule.cc
@@ -12,6 +12,7 @@
 
 #include <string>
 
+#include <ROOT/RNTuple.hxx>
 #include <ROOT/RNTupleModel.hxx>
 
 #include "FWCore/Framework/interface/one/OutputModule.h"
@@ -33,33 +34,39 @@ public:
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 private:
+  void openFile(edm::FileBlock const&) override;
+  bool isFileOpen() const override;
   void write(edm::EventForOutput const& e) override;
   void writeLuminosityBlock(edm::LuminosityBlockForOutput const&) override;
   void writeRun(edm::RunForOutput const&) override;
-  bool isFileOpen() const override;
-  void openFile(edm::FileBlock const&) override;
   void reallyCloseFile() override;
 
   std::string m_fileName;
   std::string m_logicalFileName;
   edm::JobReport::Token m_jrToken;
+
+  std::unique_ptr<ROOT::Experimental::RNTupleModel> m_model;
 };
 
 NanoAODRNTupleOutputModule::NanoAODRNTupleOutputModule(edm::ParameterSet const& pset)
     : edm::one::OutputModuleBase::OutputModuleBase(pset),
       edm::one::OutputModule<>(pset),
       m_fileName(pset.getUntrackedParameter<std::string>("fileName")),
-      m_logicalFileName(pset.getUntrackedParameter<std::string>("logicalFileName")) {}
+      m_logicalFileName(pset.getUntrackedParameter<std::string>("logicalFileName")),
+      m_model(ROOT::Experimental::RNTupleModel::Create()) {}
 
 NanoAODRNTupleOutputModule::~NanoAODRNTupleOutputModule() {}
 
-void NanoAODRNTupleOutputModule::write(edm::EventForOutput const& iEvent) {}
 void NanoAODRNTupleOutputModule::writeLuminosityBlock(edm::LuminosityBlockForOutput const& iLumi) {}
 void NanoAODRNTupleOutputModule::writeRun(edm::RunForOutput const& iRun) {}
-bool NanoAODRNTupleOutputModule::isFileOpen() const { return false; }
+
+bool NanoAODRNTupleOutputModule::isFileOpen() const {
+  return nullptr != m_model.get();
+}
 
 void NanoAODRNTupleOutputModule::openFile(edm::FileBlock const&) {
-  // TODO open RNTuple
+  // m_model->MakeField<std::vector<float>>("floats");
+
   edm::Service<edm::JobReport> jr;
   cms::Digest branchHash;
   m_jrToken = jr->outputFileOpened(m_fileName,
@@ -75,7 +82,16 @@ void NanoAODRNTupleOutputModule::openFile(edm::FileBlock const&) {
                                    std::vector<std::string>());
 }
 
+void NanoAODRNTupleOutputModule::write(edm::EventForOutput const& iEvent) {
+
+}
+
 void NanoAODRNTupleOutputModule::reallyCloseFile() {
+  {
+    auto ntuple = ROOT::Experimental::RNTupleWriter::Recreate(std::move(m_model), "ntuple", m_fileName);
+    ntuple->Fill();
+  }
+
   edm::Service<edm::JobReport> jr;
   jr->outputFileClosed(m_jrToken);
 }
@@ -85,6 +101,14 @@ void NanoAODRNTupleOutputModule::fillDescriptions(edm::ConfigurationDescriptions
 
   desc.addUntracked<std::string>("fileName");
   desc.addUntracked<std::string>("logicalFileName", "");
+
+  const std::vector<std::string> keep = {"drop *",
+                                         "keep nanoaodFlatTable_*Table_*_*",
+                                         "keep edmTriggerResults_*_*_*",
+                                         "keep String_*_genModel_*",
+                                         "keep nanoaodMergeableCounterTable_*Table_*_*",
+                                         "keep nanoaodUniqueString_nanoMetadata_*_*"};
+  edm::one::OutputModule<>::fillDescription(desc, keep);
 
   descriptions.addDefault(desc);
 }

--- a/PhysicsTools/NanoAOD/plugins/NanoAODRNTupleOutputModule.cc
+++ b/PhysicsTools/NanoAOD/plugins/NanoAODRNTupleOutputModule.cc
@@ -35,11 +35,16 @@ private:
   bool isFileOpen() const override;
   void openFile(edm::FileBlock const&) override;
   void reallyCloseFile() override;
+
+  std::string m_fileName;
+  std::string m_logicalFileName;
 };
 
 NanoAODRNTupleOutputModule::NanoAODRNTupleOutputModule(edm::ParameterSet const& pset)
     : edm::one::OutputModuleBase::OutputModuleBase(pset),
-      edm::one::OutputModule<>(pset) {}
+      edm::one::OutputModule<>(pset),
+      m_fileName(pset.getUntrackedParameter<std::string>("fileName")),
+      m_logicalFileName(pset.getUntrackedParameter<std::string>("logicalFileName")) {}
 
 NanoAODRNTupleOutputModule::~NanoAODRNTupleOutputModule() {}
 
@@ -52,7 +57,10 @@ void NanoAODRNTupleOutputModule::reallyCloseFile() {}
 
 void NanoAODRNTupleOutputModule::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
+
   desc.addUntracked<std::string>("fileName");
+  desc.addUntracked<std::string>("logicalFileName", "");
+
   descriptions.addDefault(desc);
 }
 

--- a/PhysicsTools/NanoAOD/plugins/NanoAODRNTupleOutputModule.cc
+++ b/PhysicsTools/NanoAOD/plugins/NanoAODRNTupleOutputModule.cc
@@ -1,0 +1,59 @@
+// -*- C++ -*-
+//
+// Package:     PhysicsTools/NanoAODOutput
+// Class  :     NanoAODRNTupleOutputModule
+//
+// Implementation:
+//     [Notes on implementation]
+//
+// Original Author:  Max Orok
+//         Created:  Wed, 13 Jan 2021 14:21:41 GMT
+//
+
+#include <string>
+
+#include <ROOT/RNTupleModel.hxx>
+
+#include "FWCore/Framework/interface/one/OutputModule.h"
+#include "FWCore/Framework/interface/RunForOutput.h"
+#include "FWCore/Framework/interface/LuminosityBlockForOutput.h"
+#include "FWCore/Framework/interface/EventForOutput.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+class NanoAODRNTupleOutputModule : public edm::one::OutputModule<> {
+public:
+  NanoAODRNTupleOutputModule(edm::ParameterSet const& pset);
+  ~NanoAODRNTupleOutputModule() override;
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+private:
+  void write(edm::EventForOutput const& e) override;
+  void writeLuminosityBlock(edm::LuminosityBlockForOutput const&) override;
+  void writeRun(edm::RunForOutput const&) override;
+  bool isFileOpen() const override;
+  void openFile(edm::FileBlock const&) override;
+  void reallyCloseFile() override;
+};
+
+NanoAODRNTupleOutputModule::NanoAODRNTupleOutputModule(edm::ParameterSet const& pset)
+    : edm::one::OutputModuleBase::OutputModuleBase(pset),
+      edm::one::OutputModule<>(pset) {}
+
+NanoAODRNTupleOutputModule::~NanoAODRNTupleOutputModule() {}
+
+void NanoAODRNTupleOutputModule::write(edm::EventForOutput const& iEvent) {}
+void NanoAODRNTupleOutputModule::writeLuminosityBlock(edm::LuminosityBlockForOutput const& iLumi) {}
+void NanoAODRNTupleOutputModule::writeRun(edm::RunForOutput const& iRun) {}
+bool NanoAODRNTupleOutputModule::isFileOpen() const { return false; }
+void NanoAODRNTupleOutputModule::openFile(edm::FileBlock const&) {}
+void NanoAODRNTupleOutputModule::reallyCloseFile() {}
+
+void NanoAODRNTupleOutputModule::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.addUntracked<std::string>("fileName");
+  descriptions.addDefault(desc);
+}
+
+DEFINE_FWK_MODULE(NanoAODRNTupleOutputModule);

--- a/PhysicsTools/NanoAOD/plugins/NanoAODRNTuples.cc
+++ b/PhysicsTools/NanoAOD/plugins/NanoAODRNTuples.cc
@@ -61,3 +61,39 @@ void RunNTuple::fill(const edm::RunForOutput& iRun, TFile& file) {
 void RunNTuple::finalizeWrite() {
   m_ntuple.reset();
 }
+
+void PSetNTuple::createFields(TFile& file) {
+  auto model = RNTupleModel::Create();
+  m_pset = RNTupleFieldPtr<PSetType>(edm::poolNames::idToParameterSetBlobsBranchName(), *model);
+  // TODO use Append when we bump our RNTuple version
+  RNTupleWriteOptions options;
+  options.SetCompression(file.GetCompressionSettings());
+  m_ntuple = std::make_unique<RNTupleWriter>(std::move(model),
+    std::make_unique<RPageSinkFile>(edm::poolNames::parameterSetsTreeName(), file, options)
+  );
+}
+
+void PSetNTuple::fill(edm::pset::Registry* pset, TFile& file) {
+  if (!pset) {
+    throw cms::Exception("LogicError", "null edm::pset::Registry::Instance pointer");
+  }
+  if (!m_ntuple) {
+    createFields(file);
+  }
+  PSetType entry;
+  for (const auto& ps: *pset) {
+    // TODO fix string pair hack
+    //entry.first = ps.first;
+    //entry.second.pset() = ps.second.toString();
+    std::ostringstream oss;
+    oss << ps.first;
+    entry.first = oss.str();
+    entry.second = ps.second.toString();
+    m_pset.fill(entry);
+    m_ntuple->Fill();
+  }
+}
+
+void PSetNTuple::finalizeWrite() {
+  m_ntuple.reset();
+}

--- a/PhysicsTools/NanoAOD/plugins/NanoAODRNTuples.cc
+++ b/PhysicsTools/NanoAOD/plugins/NanoAODRNTuples.cc
@@ -17,8 +17,10 @@ void LumiNTuple::createFields(const edm::LuminosityBlockID& id, TFile& file) {
   m_luminosityBlock = RNTupleFieldPtr<UInt_t>("luminosityBlock", *model);
   // TODO use Append when we bump our RNTuple version:
   // m_ntuple = RNTupleWriter::Append(std::move(model), "LuminosityBlocks", file);
+  RNTupleWriteOptions options;
+  options.SetCompression(file.GetCompressionSettings());
   m_ntuple = std::make_unique<RNTupleWriter>(std::move(model),
-    std::make_unique<RPageSinkFile>("LuminosityBlocks", file, RNTupleWriteOptions())
+    std::make_unique<RPageSinkFile>("LuminosityBlocks", file, options)
   );
 }
 
@@ -40,8 +42,10 @@ void RunNTuple::createFields(const edm::RunForOutput& iRun, TFile& file) {
   auto model = RNTupleModel::Create();
   m_run = RNTupleFieldPtr<UInt_t>("run", *model);
   // TODO use Append when we bump our RNTuple version
+  RNTupleWriteOptions options;
+  options.SetCompression(file.GetCompressionSettings());
   m_ntuple = std::make_unique<RNTupleWriter>(std::move(model),
-    std::make_unique<RPageSinkFile>("Runs", file, RNTupleWriteOptions())
+    std::make_unique<RPageSinkFile>("Runs", file, options)
   );
 }
 

--- a/PhysicsTools/NanoAOD/plugins/NanoAODRNTuples.cc
+++ b/PhysicsTools/NanoAOD/plugins/NanoAODRNTuples.cc
@@ -1,0 +1,33 @@
+#include "PhysicsTools/NanoAOD/plugins/NanoAODRNTuples.h"
+
+#include <ROOT/RNTuple.hxx>
+#include <ROOT/RNTupleModel.hxx>
+#include <ROOT/RNTupleOptions.hxx>
+#include <ROOT/RPageStorageFile.hxx>
+using ROOT::Experimental::RNTupleModel;
+using ROOT::Experimental::RNTupleWriter;
+using ROOT::Experimental::Detail::RPageSinkFile;
+using ROOT::Experimental::RNTupleWriteOptions;
+
+#include "RNTupleFieldPtr.h"
+
+void LumiNTuple::createFields(TFile& file) {
+  auto model = RNTupleModel::Create();
+  m_run = RNTupleFieldPtr<UInt_t>("run", *model);
+  m_luminosityBlock = RNTupleFieldPtr<UInt_t>("luminosityBlock", *model);
+  // TODO use Append when we bump our RNTuple version:
+  // m_ntuple = RNTupleWriter::Append(std::move(model), "LuminosityBlocks", file);
+  m_ntuple = std::make_unique<RNTupleWriter>(std::move(model),
+    std::make_unique<RPageSinkFile>("LuminosityBlocks", file, RNTupleWriteOptions())
+  );
+}
+
+void LumiNTuple::fill(const edm::LuminosityBlockID& id) {
+  m_run.fill(id.run());
+  m_luminosityBlock.fill(id.value());
+  m_ntuple->Fill();
+}
+
+void LumiNTuple::write() {
+  m_ntuple.reset();
+}

--- a/PhysicsTools/NanoAOD/plugins/NanoAODRNTuples.cc
+++ b/PhysicsTools/NanoAOD/plugins/NanoAODRNTuples.cc
@@ -17,8 +17,8 @@ using ROOT::Experimental::Detail::RPageSinkFile;
 
 void LumiNTuple::createFields(const edm::LuminosityBlockID& id, TFile& file) {
   auto model = RNTupleModel::Create();
-  m_run = RNTupleFieldPtr<UInt_t>("run", *model);
-  m_luminosityBlock = RNTupleFieldPtr<UInt_t>("luminosityBlock", *model);
+  m_run = RNTupleFieldPtr<UInt_t>("run", "", *model);
+  m_luminosityBlock = RNTupleFieldPtr<UInt_t>("luminosityBlock", "", *model);
   // TODO use Append when we bump our RNTuple version:
   // m_ntuple = RNTupleWriter::Append(std::move(model), "LuminosityBlocks", file);
   RNTupleWriteOptions options;
@@ -42,7 +42,7 @@ void RunNTuple::registerToken(const edm::EDGetToken& token) { m_tokens.push_back
 
 void RunNTuple::createFields(const edm::RunForOutput& iRun, TFile& file) {
   auto model = RNTupleModel::Create();
-  m_run = RNTupleFieldPtr<UInt_t>("run", *model);
+  m_run = RNTupleFieldPtr<UInt_t>("run", "", *model);
 
   edm::Handle<nanoaod::MergeableCounterTable> handle;
   for (const auto& token : m_tokens) {
@@ -76,8 +76,8 @@ void RunNTuple::finalizeWrite() { m_ntuple.reset(); }
 void PSetNTuple::createFields(TFile& file) {
   // use a collection to emulate std::pair
   auto pairModel = RNTupleModel::Create();
-  m_psetId = RNTupleFieldPtr<std::string>("first", *pairModel);
-  m_psetBlob = RNTupleFieldPtr<std::string>("second", *pairModel);
+  m_psetId = RNTupleFieldPtr<std::string>("first", "", *pairModel);
+  m_psetBlob = RNTupleFieldPtr<std::string>("second", "", *pairModel);
   auto model = RNTupleModel::Create();
   m_collection = model->MakeCollection(edm::poolNames::idToParameterSetBlobsBranchName(), std::move(pairModel));
   // TODO use Append when we bump our RNTuple version
@@ -110,7 +110,7 @@ void PSetNTuple::finalizeWrite() { m_ntuple.reset(); }
 void MetadataNTuple::createFields(TFile& file) {
   auto procHistModel = RNTupleModel::Create();
   // ProcessHistory.transients_.phid_ replacement
-  m_phId = RNTupleFieldPtr<std::string>("transients_phid_", *procHistModel);
+  m_phId = RNTupleFieldPtr<std::string>("transients_phid_", "", *procHistModel);
   auto model = RNTupleModel::Create();
   m_procHist = model->MakeCollection(edm::poolNames::processHistoryBranchName(), std::move(procHistModel));
   RNTupleWriteOptions options;

--- a/PhysicsTools/NanoAOD/plugins/NanoAODRNTuples.cc
+++ b/PhysicsTools/NanoAOD/plugins/NanoAODRNTuples.cc
@@ -41,7 +41,7 @@ void LumiNTuple::finalizeWrite() {
   m_ntuple.reset();
 }
 
-void RunNTuple::register_token(const edm::EDGetToken &token) {
+void RunNTuple::registerToken(const edm::EDGetToken &token) {
   m_tokens.push_back(token);
 }
 

--- a/PhysicsTools/NanoAOD/plugins/NanoAODRNTuples.cc
+++ b/PhysicsTools/NanoAOD/plugins/NanoAODRNTuples.cc
@@ -45,7 +45,6 @@ void RunNTuple::register_token(const edm::EDGetToken &token) {
   m_tokens.push_back(token);
 }
 
-// TODO SummaryTableOutput fields
 void RunNTuple::createFields(const edm::RunForOutput& iRun, TFile& file) {
   auto model = RNTupleModel::Create();
   m_run = RNTupleFieldPtr<UInt_t>("run", *model);
@@ -120,6 +119,7 @@ void PSetNTuple::finalizeWrite() {
   m_ntuple.reset();
 }
 
+// TODO blocked on RNTuple typedef member field support
 void MetadataNTuple::createFields(TFile& file) {
   auto procHistModel = RNTupleModel::Create();
   // ProcessHistory.transients_.phid_ replacement

--- a/PhysicsTools/NanoAOD/plugins/NanoAODRNTuples.cc
+++ b/PhysicsTools/NanoAOD/plugins/NanoAODRNTuples.cc
@@ -8,9 +8,9 @@
 #include <ROOT/RNTupleOptions.hxx>
 #include <ROOT/RPageStorageFile.hxx>
 using ROOT::Experimental::RNTupleModel;
+using ROOT::Experimental::RNTupleWriteOptions;
 using ROOT::Experimental::RNTupleWriter;
 using ROOT::Experimental::Detail::RPageSinkFile;
-using ROOT::Experimental::RNTupleWriteOptions;
 
 #include "RNTupleFieldPtr.h"
 #include "SummaryTableOutputFields.h"
@@ -24,8 +24,7 @@ void LumiNTuple::createFields(const edm::LuminosityBlockID& id, TFile& file) {
   RNTupleWriteOptions options;
   options.SetCompression(file.GetCompressionSettings());
   m_ntuple = std::make_unique<RNTupleWriter>(std::move(model),
-    std::make_unique<RPageSinkFile>("LuminosityBlocks", file, options)
-  );
+                                             std::make_unique<RPageSinkFile>("LuminosityBlocks", file, options));
 }
 
 void LumiNTuple::fill(const edm::LuminosityBlockID& id, TFile& file) {
@@ -37,31 +36,25 @@ void LumiNTuple::fill(const edm::LuminosityBlockID& id, TFile& file) {
   m_ntuple->Fill();
 }
 
-void LumiNTuple::finalizeWrite() {
-  m_ntuple.reset();
-}
+void LumiNTuple::finalizeWrite() { m_ntuple.reset(); }
 
-void RunNTuple::registerToken(const edm::EDGetToken &token) {
-  m_tokens.push_back(token);
-}
+void RunNTuple::registerToken(const edm::EDGetToken& token) { m_tokens.push_back(token); }
 
 void RunNTuple::createFields(const edm::RunForOutput& iRun, TFile& file) {
   auto model = RNTupleModel::Create();
   m_run = RNTupleFieldPtr<UInt_t>("run", *model);
 
   edm::Handle<nanoaod::MergeableCounterTable> handle;
-  for (const auto &token : m_tokens) {
+  for (const auto& token : m_tokens) {
     iRun.getByToken(token, handle);
-    const nanoaod::MergeableCounterTable &tab = *handle;
+    const nanoaod::MergeableCounterTable& tab = *handle;
     m_tables.push_back(SummaryTableOutputFields(tab, *model));
   }
 
   // TODO use Append when we bump our RNTuple version
   RNTupleWriteOptions options;
   options.SetCompression(file.GetCompressionSettings());
-  m_ntuple = std::make_unique<RNTupleWriter>(std::move(model),
-    std::make_unique<RPageSinkFile>("Runs", file, options)
-  );
+  m_ntuple = std::make_unique<RNTupleWriter>(std::move(model), std::make_unique<RPageSinkFile>("Runs", file, options));
 }
 
 void RunNTuple::fill(const edm::RunForOutput& iRun, TFile& file) {
@@ -72,15 +65,13 @@ void RunNTuple::fill(const edm::RunForOutput& iRun, TFile& file) {
   edm::Handle<nanoaod::MergeableCounterTable> handle;
   for (std::size_t i = 0; i < m_tokens.size(); i++) {
     iRun.getByToken(m_tokens.at(i), handle);
-    const nanoaod::MergeableCounterTable &tab = *handle;
+    const nanoaod::MergeableCounterTable& tab = *handle;
     m_tables.at(i).fill(tab);
   }
   m_ntuple->Fill();
 }
 
-void RunNTuple::finalizeWrite() {
-  m_ntuple.reset();
-}
+void RunNTuple::finalizeWrite() { m_ntuple.reset(); }
 
 void PSetNTuple::createFields(TFile& file) {
   // use a collection to emulate std::pair
@@ -88,14 +79,12 @@ void PSetNTuple::createFields(TFile& file) {
   m_psetId = RNTupleFieldPtr<std::string>("first", *pairModel);
   m_psetBlob = RNTupleFieldPtr<std::string>("second", *pairModel);
   auto model = RNTupleModel::Create();
-  m_collection = model->MakeCollection(
-    edm::poolNames::idToParameterSetBlobsBranchName(), std::move(pairModel));
+  m_collection = model->MakeCollection(edm::poolNames::idToParameterSetBlobsBranchName(), std::move(pairModel));
   // TODO use Append when we bump our RNTuple version
   RNTupleWriteOptions options;
   options.SetCompression(file.GetCompressionSettings());
-  m_ntuple = std::make_unique<RNTupleWriter>(std::move(model),
-    std::make_unique<RPageSinkFile>(edm::poolNames::parameterSetsTreeName(), file, options)
-  );
+  m_ntuple = std::make_unique<RNTupleWriter>(
+      std::move(model), std::make_unique<RPageSinkFile>(edm::poolNames::parameterSetsTreeName(), file, options));
 }
 
 void PSetNTuple::fill(edm::pset::Registry* pset, TFile& file) {
@@ -105,7 +94,7 @@ void PSetNTuple::fill(edm::pset::Registry* pset, TFile& file) {
   if (!m_ntuple) {
     createFields(file);
   }
-  for (const auto& ps: *pset) {
+  for (const auto& ps : *pset) {
     std::ostringstream oss;
     oss << ps.first;
     m_psetId.fill(oss.str());
@@ -115,9 +104,7 @@ void PSetNTuple::fill(edm::pset::Registry* pset, TFile& file) {
   }
 }
 
-void PSetNTuple::finalizeWrite() {
-  m_ntuple.reset();
-}
+void PSetNTuple::finalizeWrite() { m_ntuple.reset(); }
 
 // TODO blocked on RNTuple typedef member field support
 void MetadataNTuple::createFields(TFile& file) {
@@ -125,13 +112,11 @@ void MetadataNTuple::createFields(TFile& file) {
   // ProcessHistory.transients_.phid_ replacement
   m_phId = RNTupleFieldPtr<std::string>("transients_phid_", *procHistModel);
   auto model = RNTupleModel::Create();
-  m_procHist = model->MakeCollection(edm::poolNames::processHistoryBranchName(),
-    std::move(procHistModel));
+  m_procHist = model->MakeCollection(edm::poolNames::processHistoryBranchName(), std::move(procHistModel));
   RNTupleWriteOptions options;
   options.SetCompression(file.GetCompressionSettings());
-  m_ntuple = std::make_unique<RNTupleWriter>(std::move(model),
-    std::make_unique<RPageSinkFile>(edm::poolNames::metaDataTreeName(), file, options)
-  );
+  m_ntuple = std::make_unique<RNTupleWriter>(
+      std::move(model), std::make_unique<RPageSinkFile>(edm::poolNames::metaDataTreeName(), file, options));
 }
 
 void MetadataNTuple::fill(const edm::ProcessHistoryRegistry& procHist, TFile& file) {
@@ -147,6 +132,4 @@ void MetadataNTuple::fill(const edm::ProcessHistoryRegistry& procHist, TFile& fi
   m_ntuple->Fill();
 }
 
-void MetadataNTuple::finalizeWrite() {
-  m_ntuple.reset();
-}
+void MetadataNTuple::finalizeWrite() { m_ntuple.reset(); }

--- a/PhysicsTools/NanoAOD/plugins/NanoAODRNTuples.h
+++ b/PhysicsTools/NanoAOD/plugins/NanoAODRNTuples.h
@@ -2,6 +2,7 @@
 #define PhysicsTools_NanoAOD_NanoAODRNTuples_h
 
 #include "FWCore/Framework/interface/LuminosityBlockForOutput.h"
+#include "FWCore/Framework/interface/RunForOutput.h"
 
 #include "TFile.h"
 #include <ROOT/RNTuple.hxx>
@@ -12,13 +13,25 @@ using ROOT::Experimental::RNTupleWriter;
 class LumiNTuple {
 public:
   LumiNTuple() = default;
-  void createFields(TFile& file);
-  void fill(const edm::LuminosityBlockID& id);
-  void write();
+  void fill(const edm::LuminosityBlockID& id, TFile& file);
+  void finalizeWrite();
 private:
+  void createFields(const edm::LuminosityBlockID& id, TFile& file);
   std::unique_ptr<RNTupleWriter> m_ntuple;
   RNTupleFieldPtr<UInt_t> m_run;
   RNTupleFieldPtr<UInt_t> m_luminosityBlock;
+};
+
+class RunNTuple {
+public:
+  RunNTuple() = default;
+  void fill(const edm::RunForOutput& iRun, TFile& file);
+  void finalizeWrite();
+private:
+  void createFields(const edm::RunForOutput& iRun, TFile& file);
+  std::unique_ptr<RNTupleWriter> m_ntuple;
+  RNTupleFieldPtr<UInt_t> m_run;
+  // TODO SummaryTableOutput fields
 };
 
 #endif

--- a/PhysicsTools/NanoAOD/plugins/NanoAODRNTuples.h
+++ b/PhysicsTools/NanoAOD/plugins/NanoAODRNTuples.h
@@ -10,6 +10,7 @@
 
 #include "TFile.h"
 #include <ROOT/RNTuple.hxx>
+using ROOT::Experimental::RCollectionNTuple;
 using ROOT::Experimental::RNTupleWriter;
 
 #include "RNTupleFieldPtr.h"
@@ -44,11 +45,18 @@ public:
   void fill(edm::pset::Registry* pset, TFile& file);
   void finalizeWrite();
 private:
-  using PSetType = std::pair<std::string, std::string>;
-  //using PSetType = std::pair<edm::ParameterSetID, edm::ParameterSetBlob>;
+  // TODO blocked on RNTuple std::pair support
+  // using PSetType = std::pair<edm::ParameterSetID, edm::ParameterSetBlob>;
+  // RNTupleFieldPtr<PSetType> m_pset;
   void createFields(TFile& file);
+  // TODO blocked on RNTuple typedef member field support:
+  // https://github.com/root-project/root/issues/7861
+  // RNTupleFieldPtr<edm::ParameterSetID> m_psetId;
+  // RNTupleFieldPtr<edm::ParameterSetBlob> m_psetBlob;
+  std::shared_ptr<RCollectionNTuple> m_collection;
+  RNTupleFieldPtr<std::string> m_psetId;
+  RNTupleFieldPtr<std::string> m_psetBlob;
   std::unique_ptr<RNTupleWriter> m_ntuple;
-  RNTupleFieldPtr<PSetType> m_pset;
 };
 
 #endif

--- a/PhysicsTools/NanoAOD/plugins/NanoAODRNTuples.h
+++ b/PhysicsTools/NanoAOD/plugins/NanoAODRNTuples.h
@@ -1,0 +1,24 @@
+#ifndef PhysicsTools_NanoAOD_NanoAODRNTuples_h
+#define PhysicsTools_NanoAOD_NanoAODRNTuples_h
+
+#include "FWCore/Framework/interface/LuminosityBlockForOutput.h"
+
+#include "TFile.h"
+#include <ROOT/RNTuple.hxx>
+using ROOT::Experimental::RNTupleWriter;
+
+#include "RNTupleFieldPtr.h"
+
+class LumiNTuple {
+public:
+  LumiNTuple() = default;
+  void createFields(TFile& file);
+  void fill(const edm::LuminosityBlockID& id);
+  void write();
+private:
+  std::unique_ptr<RNTupleWriter> m_ntuple;
+  RNTupleFieldPtr<UInt_t> m_run;
+  RNTupleFieldPtr<UInt_t> m_luminosityBlock;
+};
+
+#endif

--- a/PhysicsTools/NanoAOD/plugins/NanoAODRNTuples.h
+++ b/PhysicsTools/NanoAOD/plugins/NanoAODRNTuples.h
@@ -4,6 +4,7 @@
 #include "DataFormats/Provenance/interface/BranchType.h"
 #include "DataFormats/Provenance/interface/ParameterSetBlob.h"
 #include "DataFormats/Provenance/interface/ParameterSetID.h"
+#include "DataFormats/Provenance/interface/ProcessHistoryRegistry.h"
 #include "FWCore/Framework/interface/LuminosityBlockForOutput.h"
 #include "FWCore/Framework/interface/RunForOutput.h"
 #include "FWCore/ParameterSet/interface/Registry.h"
@@ -56,6 +57,19 @@ private:
   std::shared_ptr<RCollectionNTuple> m_collection;
   RNTupleFieldPtr<std::string> m_psetId;
   RNTupleFieldPtr<std::string> m_psetBlob;
+  std::unique_ptr<RNTupleWriter> m_ntuple;
+};
+
+class MetadataNTuple {
+public:
+  MetadataNTuple() = default;
+  void fill(const edm::ProcessHistoryRegistry& procHist, TFile& file);
+  void finalizeWrite();
+private:
+  void createFields(TFile& file);
+  std::shared_ptr<RCollectionNTuple> m_procHist;
+
+  RNTupleFieldPtr<std::string> m_phId;
   std::unique_ptr<RNTupleWriter> m_ntuple;
 };
 

--- a/PhysicsTools/NanoAOD/plugins/NanoAODRNTuples.h
+++ b/PhysicsTools/NanoAOD/plugins/NanoAODRNTuples.h
@@ -1,8 +1,12 @@
 #ifndef PhysicsTools_NanoAOD_NanoAODRNTuples_h
 #define PhysicsTools_NanoAOD_NanoAODRNTuples_h
 
+#include "DataFormats/Provenance/interface/BranchType.h"
+#include "DataFormats/Provenance/interface/ParameterSetBlob.h"
+#include "DataFormats/Provenance/interface/ParameterSetID.h"
 #include "FWCore/Framework/interface/LuminosityBlockForOutput.h"
 #include "FWCore/Framework/interface/RunForOutput.h"
+#include "FWCore/ParameterSet/interface/Registry.h"
 
 #include "TFile.h"
 #include <ROOT/RNTuple.hxx>
@@ -32,6 +36,19 @@ private:
   std::unique_ptr<RNTupleWriter> m_ntuple;
   RNTupleFieldPtr<UInt_t> m_run;
   // TODO SummaryTableOutput fields
+};
+
+class PSetNTuple {
+public:
+  PSetNTuple() = default;
+  void fill(edm::pset::Registry* pset, TFile& file);
+  void finalizeWrite();
+private:
+  using PSetType = std::pair<std::string, std::string>;
+  //using PSetType = std::pair<edm::ParameterSetID, edm::ParameterSetBlob>;
+  void createFields(TFile& file);
+  std::unique_ptr<RNTupleWriter> m_ntuple;
+  RNTupleFieldPtr<PSetType> m_pset;
 };
 
 #endif

--- a/PhysicsTools/NanoAOD/plugins/NanoAODRNTuples.h
+++ b/PhysicsTools/NanoAOD/plugins/NanoAODRNTuples.h
@@ -8,6 +8,7 @@
 #include "FWCore/Framework/interface/LuminosityBlockForOutput.h"
 #include "FWCore/Framework/interface/RunForOutput.h"
 #include "FWCore/ParameterSet/interface/Registry.h"
+#include "FWCore/Utilities/interface/EDGetToken.h"
 
 #include "TFile.h"
 #include <ROOT/RNTuple.hxx>
@@ -15,6 +16,7 @@ using ROOT::Experimental::RCollectionNTuple;
 using ROOT::Experimental::RNTupleWriter;
 
 #include "RNTupleFieldPtr.h"
+#include "SummaryTableOutputFields.h"
 
 class LumiNTuple {
 public:
@@ -31,13 +33,15 @@ private:
 class RunNTuple {
 public:
   RunNTuple() = default;
+  void register_token(const edm::EDGetToken &token);
   void fill(const edm::RunForOutput& iRun, TFile& file);
   void finalizeWrite();
 private:
   void createFields(const edm::RunForOutput& iRun, TFile& file);
+  std::vector<edm::EDGetToken> m_tokens;
   std::unique_ptr<RNTupleWriter> m_ntuple;
   RNTupleFieldPtr<UInt_t> m_run;
-  // TODO SummaryTableOutput fields
+  std::vector<SummaryTableOutputFields> m_tables;
 };
 
 class PSetNTuple {

--- a/PhysicsTools/NanoAOD/plugins/NanoAODRNTuples.h
+++ b/PhysicsTools/NanoAOD/plugins/NanoAODRNTuples.h
@@ -15,8 +15,11 @@
 using ROOT::Experimental::RCollectionNTuple;
 using ROOT::Experimental::RNTupleWriter;
 
-#include "RNTupleFieldPtr.h"
-#include "SummaryTableOutputFields.h"
+#include "PhysicsTools/NanoAOD/plugins/EventStringOutputFields.h"
+#include "PhysicsTools/NanoAOD/plugins/RNTupleFieldPtr.h"
+#include "PhysicsTools/NanoAOD/plugins/SummaryTableOutputFields.h"
+#include "PhysicsTools/NanoAOD/plugins/TableOutputFields.h"
+#include "PhysicsTools/NanoAOD/plugins/TriggerOutputFields.h"
 
 class LumiNTuple {
 public:

--- a/PhysicsTools/NanoAOD/plugins/NanoAODRNTuples.h
+++ b/PhysicsTools/NanoAOD/plugins/NanoAODRNTuples.h
@@ -12,7 +12,7 @@
 
 #include "TFile.h"
 #include <ROOT/RNTuple.hxx>
-using ROOT::Experimental::RCollectionNTuple;
+using ROOT::Experimental::RCollectionNTupleWriter;
 using ROOT::Experimental::RNTupleWriter;
 
 #include "PhysicsTools/NanoAOD/plugins/EventStringOutputFields.h"
@@ -64,7 +64,7 @@ private:
   // https://github.com/root-project/root/issues/7861
   // RNTupleFieldPtr<edm::ParameterSetID> m_psetId;
   // RNTupleFieldPtr<edm::ParameterSetBlob> m_psetBlob;
-  std::shared_ptr<RCollectionNTuple> m_collection;
+  std::shared_ptr<RCollectionNTupleWriter> m_collection;
   RNTupleFieldPtr<std::string> m_psetId;
   RNTupleFieldPtr<std::string> m_psetBlob;
   std::unique_ptr<RNTupleWriter> m_ntuple;
@@ -78,7 +78,7 @@ public:
 
 private:
   void createFields(TFile& file);
-  std::shared_ptr<RCollectionNTuple> m_procHist;
+  std::shared_ptr<RCollectionNTupleWriter> m_procHist;
 
   RNTupleFieldPtr<std::string> m_phId;
   std::unique_ptr<RNTupleWriter> m_ntuple;

--- a/PhysicsTools/NanoAOD/plugins/NanoAODRNTuples.h
+++ b/PhysicsTools/NanoAOD/plugins/NanoAODRNTuples.h
@@ -36,7 +36,7 @@ private:
 class RunNTuple {
 public:
   RunNTuple() = default;
-  void register_token(const edm::EDGetToken &token);
+  void registerToken(const edm::EDGetToken &token);
   void fill(const edm::RunForOutput& iRun, TFile& file);
   void finalizeWrite();
 private:

--- a/PhysicsTools/NanoAOD/plugins/NanoAODRNTuples.h
+++ b/PhysicsTools/NanoAOD/plugins/NanoAODRNTuples.h
@@ -26,6 +26,7 @@ public:
   LumiNTuple() = default;
   void fill(const edm::LuminosityBlockID& id, TFile& file);
   void finalizeWrite();
+
 private:
   void createFields(const edm::LuminosityBlockID& id, TFile& file);
   std::unique_ptr<RNTupleWriter> m_ntuple;
@@ -36,9 +37,10 @@ private:
 class RunNTuple {
 public:
   RunNTuple() = default;
-  void registerToken(const edm::EDGetToken &token);
+  void registerToken(const edm::EDGetToken& token);
   void fill(const edm::RunForOutput& iRun, TFile& file);
   void finalizeWrite();
+
 private:
   void createFields(const edm::RunForOutput& iRun, TFile& file);
   std::vector<edm::EDGetToken> m_tokens;
@@ -52,6 +54,7 @@ public:
   PSetNTuple() = default;
   void fill(edm::pset::Registry* pset, TFile& file);
   void finalizeWrite();
+
 private:
   // TODO blocked on RNTuple std::pair support
   // using PSetType = std::pair<edm::ParameterSetID, edm::ParameterSetBlob>;
@@ -72,6 +75,7 @@ public:
   MetadataNTuple() = default;
   void fill(const edm::ProcessHistoryRegistry& procHist, TFile& file);
   void finalizeWrite();
+
 private:
   void createFields(TFile& file);
   std::shared_ptr<RCollectionNTuple> m_procHist;

--- a/PhysicsTools/NanoAOD/plugins/RNTupleFieldPtr.h
+++ b/PhysicsTools/NanoAOD/plugins/RNTupleFieldPtr.h
@@ -7,6 +7,7 @@ using ROOT::Experimental::RNTupleModel;
 template <typename T>
 class RNTupleFieldPtr {
 public:
+  RNTupleFieldPtr() = default;
   explicit RNTupleFieldPtr(const std::string& name, RNTupleModel& model)
       : m_name(name)
   {

--- a/PhysicsTools/NanoAOD/plugins/RNTupleFieldPtr.h
+++ b/PhysicsTools/NanoAOD/plugins/RNTupleFieldPtr.h
@@ -8,17 +8,12 @@ template <typename T>
 class RNTupleFieldPtr {
 public:
   RNTupleFieldPtr() = default;
-  explicit RNTupleFieldPtr(const std::string& name, RNTupleModel& model)
-      : m_name(name)
-  {
+  explicit RNTupleFieldPtr(const std::string& name, RNTupleModel& model) : m_name(name) {
     m_field = model.MakeField<T>(m_name);
   }
-  void fill(const T& value) {
-    *m_field = value;
-  }
-  const std::string& getFieldName() const {
-    return m_name;
-  }
+  void fill(const T& value) { *m_field = value; }
+  const std::string& getFieldName() const { return m_name; }
+
 private:
   std::string m_name;
   std::shared_ptr<T> m_field;

--- a/PhysicsTools/NanoAOD/plugins/RNTupleFieldPtr.h
+++ b/PhysicsTools/NanoAOD/plugins/RNTupleFieldPtr.h
@@ -8,8 +8,8 @@ template <typename T>
 class RNTupleFieldPtr {
 public:
   RNTupleFieldPtr() = default;
-  explicit RNTupleFieldPtr(const std::string& name, RNTupleModel& model) : m_name(name) {
-    m_field = model.MakeField<T>(m_name);
+  explicit RNTupleFieldPtr(const std::string& name, const std::string& desc, RNTupleModel& model) : m_name(name) {
+    m_field = model.MakeField<T>({m_name, desc});
   }
   void fill(const T& value) { *m_field = value; }
   const std::string& getFieldName() const { return m_name; }

--- a/PhysicsTools/NanoAOD/plugins/RNTupleFieldPtr.h
+++ b/PhysicsTools/NanoAOD/plugins/RNTupleFieldPtr.h
@@ -1,0 +1,26 @@
+#ifndef PhysicsTools_NanoAOD_RNTupleFieldPtr_h
+#define PhysicsTools_NanoAOD_RNTupleFieldPtr_h
+
+#include <ROOT/RNTupleModel.hxx>
+using ROOT::Experimental::RNTupleModel;
+
+template <typename T>
+class RNTupleFieldPtr {
+public:
+  explicit RNTupleFieldPtr(const std::string& name, RNTupleModel& model)
+      : m_name(name)
+  {
+    m_field = model.MakeField<T>(m_name);
+  }
+  void fill(const T& value) {
+    *m_field = value;
+  }
+  const std::string& getFieldName() const {
+    return m_name;
+  }
+private:
+  std::string m_name;
+  std::shared_ptr<T> m_field;
+};
+
+#endif

--- a/PhysicsTools/NanoAOD/plugins/SummaryTableOutputFields.cc
+++ b/PhysicsTools/NanoAOD/plugins/SummaryTableOutputFields.cc
@@ -1,9 +1,8 @@
 #include "PhysicsTools/NanoAOD/plugins/SummaryTableOutputFields.h"
 
 template <typename T, typename Col>
-std::vector<RNTupleFieldPtr<T>> SummaryTableOutputFields::makeFields(
-  const std::vector<Col> &tabcols, RNTupleModel &model)
-{
+std::vector<RNTupleFieldPtr<T>> SummaryTableOutputFields::makeFields(const std::vector<Col> &tabcols,
+                                                                     RNTupleModel &model) {
   std::vector<RNTupleFieldPtr<T>> fields;
   fields.reserve(tabcols.size());
   for (const auto &col : tabcols) {
@@ -15,8 +14,7 @@ std::vector<RNTupleFieldPtr<T>> SummaryTableOutputFields::makeFields(
 
 template <typename T, typename Col>
 void SummaryTableOutputFields::fillScalarFields(const std::vector<Col> &tabcols,
-  std::vector<RNTupleFieldPtr<T>> fields)
-{
+                                                std::vector<RNTupleFieldPtr<T>> fields) {
   if (tabcols.size() != fields.size()) {
     throw cms::Exception("LogicError", "Mismatch in table columns");
   }
@@ -30,8 +28,7 @@ void SummaryTableOutputFields::fillScalarFields(const std::vector<Col> &tabcols,
 
 template <typename T, typename Col>
 void SummaryTableOutputFields::fillVectorFields(const std::vector<Col> &tabcols,
-  std::vector<RNTupleFieldPtr<T>> fields)
-{
+                                                std::vector<RNTupleFieldPtr<T>> fields) {
   if (tabcols.size() != fields.size()) {
     throw cms::Exception("LogicError", "Mismatch in table columns");
   }
@@ -47,9 +44,7 @@ void SummaryTableOutputFields::fillVectorFields(const std::vector<Col> &tabcols,
   }
 }
 
-SummaryTableOutputFields::SummaryTableOutputFields(
-  const nanoaod::MergeableCounterTable &tab, RNTupleModel &model)
-{
+SummaryTableOutputFields::SummaryTableOutputFields(const nanoaod::MergeableCounterTable &tab, RNTupleModel &model) {
   // TODO use std::int64_t when supported
   m_intFields = makeFields<std::uint64_t>(tab.intCols(), model);
   m_floatFields = makeFields<double>(tab.floatCols(), model);

--- a/PhysicsTools/NanoAOD/plugins/SummaryTableOutputFields.cc
+++ b/PhysicsTools/NanoAOD/plugins/SummaryTableOutputFields.cc
@@ -7,7 +7,7 @@ std::vector<RNTupleFieldPtr<T>> SummaryTableOutputFields::makeFields(const std::
   fields.reserve(tabcols.size());
   for (const auto &col : tabcols) {
     // TODO field description
-    fields.emplace_back(RNTupleFieldPtr<T>(col.name, model));
+    fields.emplace_back(RNTupleFieldPtr<T>(col.name, col.doc, model));
   }
   return fields;
 }

--- a/PhysicsTools/NanoAOD/plugins/SummaryTableOutputFields.cc
+++ b/PhysicsTools/NanoAOD/plugins/SummaryTableOutputFields.cc
@@ -5,6 +5,7 @@ std::vector<RNTupleFieldPtr<T>> SummaryTableOutputFields::makeFields(
   const std::vector<Col> &tabcols, RNTupleModel &model)
 {
   std::vector<RNTupleFieldPtr<T>> fields;
+  fields.reserve(tabcols.size());
   for (const auto &col : tabcols) {
     // TODO field description
     fields.emplace_back(RNTupleFieldPtr<T>(col.name, model));

--- a/PhysicsTools/NanoAOD/plugins/SummaryTableOutputFields.cc
+++ b/PhysicsTools/NanoAOD/plugins/SummaryTableOutputFields.cc
@@ -1,0 +1,68 @@
+#include "PhysicsTools/NanoAOD/plugins/SummaryTableOutputFields.h"
+
+template <typename T, typename Col>
+std::vector<RNTupleFieldPtr<T>> SummaryTableOutputFields::makeFields(
+  const std::vector<Col> &tabcols, RNTupleModel &model)
+{
+  std::vector<RNTupleFieldPtr<T>> fields;
+  for (const auto &col : tabcols) {
+    // TODO field description
+    fields.emplace_back(RNTupleFieldPtr<T>(col.name, model));
+  }
+  return fields;
+}
+
+template <typename T, typename Col>
+void SummaryTableOutputFields::fillScalarFields(const std::vector<Col> &tabcols,
+  std::vector<RNTupleFieldPtr<T>> fields)
+{
+  if (tabcols.size() != fields.size()) {
+    throw cms::Exception("LogicError", "Mismatch in table columns");
+  }
+  for (std::size_t i = 0; i < tabcols.size(); ++i) {
+    if (tabcols[i].name != fields[i].getFieldName()) {
+      throw cms::Exception("LogicError", "Mismatch in table columns");
+    }
+    fields[i].fill(tabcols[i].value);
+  }
+}
+
+template <typename T, typename Col>
+void SummaryTableOutputFields::fillVectorFields(const std::vector<Col> &tabcols,
+  std::vector<RNTupleFieldPtr<T>> fields)
+{
+  if (tabcols.size() != fields.size()) {
+    throw cms::Exception("LogicError", "Mismatch in table columns");
+  }
+  for (std::size_t i = 0; i < tabcols.size(); ++i) {
+    if (tabcols[i].name != fields[i].getFieldName()) {
+      throw cms::Exception("LogicError", "Mismatch in table columns");
+    }
+    auto data = tabcols[i].values;
+    // TODO remove this awful hack when std::int64_t is supported
+    // -- turns std::vector<int64_t> into std::vector<uint64_t>
+    T casted_data(data.begin(), data.end());
+    fields[i].fill(casted_data);
+  }
+}
+
+SummaryTableOutputFields::SummaryTableOutputFields(
+  const nanoaod::MergeableCounterTable &tab, RNTupleModel &model)
+{
+  // TODO use std::int64_t when supported
+  m_intFields = makeFields<std::uint64_t>(tab.intCols(), model);
+  m_floatFields = makeFields<double>(tab.floatCols(), model);
+  m_floatWithNormFields = makeFields<double>(tab.floatWithNormCols(), model);
+  m_vintFields = makeFields<std::vector<std::uint64_t>>(tab.vintCols(), model);
+  m_vfloatFields = makeFields<std::vector<double>>(tab.vfloatCols(), model);
+  m_vfloatWithNormFields = makeFields<std::vector<double>>(tab.vfloatWithNormCols(), model);
+}
+
+void SummaryTableOutputFields::fill(const nanoaod::MergeableCounterTable &tab) {
+  fillScalarFields(tab.intCols(), m_intFields);
+  fillScalarFields(tab.floatCols(), m_floatFields);
+  fillScalarFields(tab.floatWithNormCols(), m_floatWithNormFields);
+  fillVectorFields(tab.vintCols(), m_vintFields);
+  fillVectorFields(tab.vfloatCols(), m_vfloatFields);
+  fillVectorFields(tab.vfloatWithNormCols(), m_vfloatWithNormFields);
+}

--- a/PhysicsTools/NanoAOD/plugins/SummaryTableOutputFields.h
+++ b/PhysicsTools/NanoAOD/plugins/SummaryTableOutputFields.h
@@ -1,0 +1,83 @@
+#ifndef PhysicsTools_NanoAOD_SummaryTableOutputFields_h
+#define PhysicsTools_NanoAOD_SummaryTableOutputFields_h
+
+#include "DataFormats/NanoAOD/interface/MergeableCounterTable.h"
+
+#include "RNTupleFieldPtr.h"
+
+class SummaryTableOutputFields {
+public:
+  SummaryTableOutputFields() = default;
+  SummaryTableOutputFields(const nanoaod::MergeableCounterTable &tab, RNTupleModel &model) {
+    // TODO use std::int64_t when supported
+    m_intFields = makeFields<std::uint64_t>(tab.intCols(), model);
+    m_floatFields = makeFields<double>(tab.floatCols(), model);
+    m_floatWithNormFields = makeFields<double>(tab.floatWithNormCols(), model);
+    m_vintFields = makeFields<std::vector<std::uint64_t>>(tab.vintCols(), model);
+    m_vfloatFields = makeFields<std::vector<double>>(tab.vfloatCols(), model);
+    m_vfloatWithNormFields = makeFields<std::vector<double>>(tab.vfloatWithNormCols(), model);
+  }
+  void fill(const nanoaod::MergeableCounterTable &tab) {
+    fillScalarFields(tab.intCols(), m_intFields);
+    fillScalarFields(tab.floatCols(), m_floatFields);
+    fillScalarFields(tab.floatWithNormCols(), m_floatWithNormFields);
+    fillVectorFields(tab.vintCols(), m_vintFields);
+    fillVectorFields(tab.vfloatCols(), m_vfloatFields);
+    fillVectorFields(tab.vfloatWithNormCols(), m_vfloatWithNormFields);
+  }
+private:
+  template <typename T, typename Col>
+  std::vector<RNTupleFieldPtr<T>> makeFields(const std::vector<Col> &tabcols,
+    RNTupleModel &model)
+  {
+    std::vector<RNTupleFieldPtr<T>> fields;
+    for (const auto &col : tabcols) {
+      // TODO field description
+      fields.emplace_back(RNTupleFieldPtr<T>(col.name, model));
+    }
+    return fields;
+  }
+
+  template <typename T, typename Col>
+  static void fillScalarFields(const std::vector<Col> &tabcols,
+    std::vector<RNTupleFieldPtr<T>> fields)
+  {
+    if (tabcols.size() != fields.size()) {
+      throw cms::Exception("LogicError", "Mismatch in table columns");
+    }
+    for (std::size_t i = 0; i < tabcols.size(); ++i) {
+      if (tabcols[i].name != fields[i].getFieldName()) {
+        throw cms::Exception("LogicError", "Mismatch in table columns");
+      }
+      fields[i].fill(tabcols[i].value);
+    }
+  }
+
+  template <typename T, typename Col>
+  static void fillVectorFields(const std::vector<Col> &tabcols,
+    std::vector<RNTupleFieldPtr<T>> fields)
+  {
+    if (tabcols.size() != fields.size()) {
+      throw cms::Exception("LogicError", "Mismatch in table columns");
+    }
+    for (std::size_t i = 0; i < tabcols.size(); ++i) {
+      if (tabcols[i].name != fields[i].getFieldName()) {
+        throw cms::Exception("LogicError", "Mismatch in table columns");
+      }
+      auto data = tabcols[i].values;
+      // TODO remove this awful hack when std::int64_t is supported
+      // -- turns std::vector<int64_t> into std::vector<uint64_t>
+      T casted_data(data.begin(), data.end());
+      fields[i].fill(casted_data);
+    }
+  }
+
+  std::vector<RNTupleFieldPtr<std::uint64_t>> m_intFields;
+  std::vector<RNTupleFieldPtr<double>> m_floatFields;
+  std::vector<RNTupleFieldPtr<double>> m_floatWithNormFields;
+  std::vector<RNTupleFieldPtr<std::vector<double>>> m_vfloatFields;
+  std::vector<RNTupleFieldPtr<std::vector<double>>> m_vfloatWithNormFields;
+  std::vector<RNTupleFieldPtr<std::vector<std::uint64_t>>> m_vintFields;
+};
+
+#endif

--- a/PhysicsTools/NanoAOD/plugins/SummaryTableOutputFields.h
+++ b/PhysicsTools/NanoAOD/plugins/SummaryTableOutputFields.h
@@ -10,16 +10,14 @@ public:
   SummaryTableOutputFields() = default;
   SummaryTableOutputFields(const nanoaod::MergeableCounterTable &tab, RNTupleModel &model);
   void fill(const nanoaod::MergeableCounterTable &tab);
+
 private:
   template <typename T, typename Col>
-  std::vector<RNTupleFieldPtr<T>> makeFields(const std::vector<Col> &tabcols,
-    RNTupleModel &model);
+  std::vector<RNTupleFieldPtr<T>> makeFields(const std::vector<Col> &tabcols, RNTupleModel &model);
   template <typename T, typename Col>
-  static void fillScalarFields(const std::vector<Col> &tabcols,
-    std::vector<RNTupleFieldPtr<T>> fields);
+  static void fillScalarFields(const std::vector<Col> &tabcols, std::vector<RNTupleFieldPtr<T>> fields);
   template <typename T, typename Col>
-  static void fillVectorFields(const std::vector<Col> &tabcols,
-    std::vector<RNTupleFieldPtr<T>> fields);
+  static void fillVectorFields(const std::vector<Col> &tabcols, std::vector<RNTupleFieldPtr<T>> fields);
 
   std::vector<RNTupleFieldPtr<std::uint64_t>> m_intFields;
   std::vector<RNTupleFieldPtr<double>> m_floatFields;

--- a/PhysicsTools/NanoAOD/plugins/SummaryTableOutputFields.h
+++ b/PhysicsTools/NanoAOD/plugins/SummaryTableOutputFields.h
@@ -8,69 +8,18 @@
 class SummaryTableOutputFields {
 public:
   SummaryTableOutputFields() = default;
-  SummaryTableOutputFields(const nanoaod::MergeableCounterTable &tab, RNTupleModel &model) {
-    // TODO use std::int64_t when supported
-    m_intFields = makeFields<std::uint64_t>(tab.intCols(), model);
-    m_floatFields = makeFields<double>(tab.floatCols(), model);
-    m_floatWithNormFields = makeFields<double>(tab.floatWithNormCols(), model);
-    m_vintFields = makeFields<std::vector<std::uint64_t>>(tab.vintCols(), model);
-    m_vfloatFields = makeFields<std::vector<double>>(tab.vfloatCols(), model);
-    m_vfloatWithNormFields = makeFields<std::vector<double>>(tab.vfloatWithNormCols(), model);
-  }
-  void fill(const nanoaod::MergeableCounterTable &tab) {
-    fillScalarFields(tab.intCols(), m_intFields);
-    fillScalarFields(tab.floatCols(), m_floatFields);
-    fillScalarFields(tab.floatWithNormCols(), m_floatWithNormFields);
-    fillVectorFields(tab.vintCols(), m_vintFields);
-    fillVectorFields(tab.vfloatCols(), m_vfloatFields);
-    fillVectorFields(tab.vfloatWithNormCols(), m_vfloatWithNormFields);
-  }
+  SummaryTableOutputFields(const nanoaod::MergeableCounterTable &tab, RNTupleModel &model);
+  void fill(const nanoaod::MergeableCounterTable &tab);
 private:
   template <typename T, typename Col>
   std::vector<RNTupleFieldPtr<T>> makeFields(const std::vector<Col> &tabcols,
-    RNTupleModel &model)
-  {
-    std::vector<RNTupleFieldPtr<T>> fields;
-    for (const auto &col : tabcols) {
-      // TODO field description
-      fields.emplace_back(RNTupleFieldPtr<T>(col.name, model));
-    }
-    return fields;
-  }
-
+    RNTupleModel &model);
   template <typename T, typename Col>
   static void fillScalarFields(const std::vector<Col> &tabcols,
-    std::vector<RNTupleFieldPtr<T>> fields)
-  {
-    if (tabcols.size() != fields.size()) {
-      throw cms::Exception("LogicError", "Mismatch in table columns");
-    }
-    for (std::size_t i = 0; i < tabcols.size(); ++i) {
-      if (tabcols[i].name != fields[i].getFieldName()) {
-        throw cms::Exception("LogicError", "Mismatch in table columns");
-      }
-      fields[i].fill(tabcols[i].value);
-    }
-  }
-
+    std::vector<RNTupleFieldPtr<T>> fields);
   template <typename T, typename Col>
   static void fillVectorFields(const std::vector<Col> &tabcols,
-    std::vector<RNTupleFieldPtr<T>> fields)
-  {
-    if (tabcols.size() != fields.size()) {
-      throw cms::Exception("LogicError", "Mismatch in table columns");
-    }
-    for (std::size_t i = 0; i < tabcols.size(); ++i) {
-      if (tabcols[i].name != fields[i].getFieldName()) {
-        throw cms::Exception("LogicError", "Mismatch in table columns");
-      }
-      auto data = tabcols[i].values;
-      // TODO remove this awful hack when std::int64_t is supported
-      // -- turns std::vector<int64_t> into std::vector<uint64_t>
-      T casted_data(data.begin(), data.end());
-      fields[i].fill(casted_data);
-    }
-  }
+    std::vector<RNTupleFieldPtr<T>> fields);
 
   std::vector<RNTupleFieldPtr<std::uint64_t>> m_intFields;
   std::vector<RNTupleFieldPtr<double>> m_floatFields;

--- a/PhysicsTools/NanoAOD/plugins/TableOutputFields.cc
+++ b/PhysicsTools/NanoAOD/plugins/TableOutputFields.cc
@@ -219,14 +219,10 @@ void TableCollections::add(const edm::EDGetToken& table_token,
   auto collection = std::find_if(m_collections.begin(), m_collections.end(),
     [&](const TableCollection& c) { return c.getCollectionName() == table.name(); });
   if (collection == m_collections.end()) {
-    std::cout << "adding new collection: \n";
-    print_table(table);
     m_collections.emplace_back(TableCollection());
     m_collections.back().add(table_token, table);
     return;
   }
-  std::cout << "adding to existing collection : \n";
-  print_table(table);
   collection->add(table_token, table);
 }
 

--- a/PhysicsTools/NanoAOD/plugins/TableOutputFields.cc
+++ b/PhysicsTools/NanoAOD/plugins/TableOutputFields.cc
@@ -1,0 +1,285 @@
+#include "PhysicsTools/NanoAOD/plugins/TableOutputFields.h"
+
+namespace {
+  void print_table(const nanoaod::FlatTable& table) {
+    std::cout << "FlatTable {\n";
+    std::cout << "  name: " << (table.name().empty() ? "// anon" : table.name()) << "\n";
+    std::cout << "  singleton: " << (table.singleton() ? "true" : "false") << "\n";
+    std::cout << "  size: " << table.size() << "\n";
+    std::cout << "  extension: " << (table.extension() ? "true" : "false") << "\n";
+    std::cout << "  fields: {\n";
+    for (std::size_t i = 0; i < table.nColumns(); i++) {
+      std::cout << "    " << (table.columnName(i).empty() ? "// anon" : table.columnName(i)) << ": ";
+      switch(table.columnType(i)) {
+        case nanoaod::FlatTable::ColumnType::Float:
+          std::cout << "f32,"; break;
+        case nanoaod::FlatTable::ColumnType::Int:
+          std::cout << "i32,"; break;
+        case nanoaod::FlatTable::ColumnType::UInt8:
+          std::cout << "u8,"; break;
+        case nanoaod::FlatTable::ColumnType::Bool:
+          std::cout << "bool,"; break;
+        default:
+          throw cms::Exception("LogicError", "Unsupported type");
+      }
+      std::cout << "\n";
+    }
+    std::cout << "  }\n}\n";
+  }
+} // anonymous namespace
+
+void TableOutputFields::print() const {
+  for (const auto& field: m_floatFields) {
+    std::cout << "  " << field.getFlatTableName() << ": f32,\n";
+  }
+  for (const auto& field: m_intFields) {
+    std::cout << "  " << field.getFlatTableName() << ": i32,\n";
+  }
+  for (const auto& field: m_uint8Fields) {
+    std::cout << "  " << field.getFlatTableName() << ": u8,\n";
+  }
+  for (const auto& field: m_boolFields) {
+    std::cout << "  " << field.getFlatTableName() << ": bool,\n";
+  }
+}
+
+void TableOutputFields::createFields(const edm::EventForOutput& event, RNTupleModel& model) {
+  edm::Handle<nanoaod::FlatTable> handle;
+  event.getByToken(m_token, handle);
+  const nanoaod::FlatTable& table = *handle;
+  for (std::size_t i = 0; i < table.nColumns(); i++) {
+    switch(table.columnType(i)) {
+      case nanoaod::FlatTable::ColumnType::Float:
+        m_floatFields.emplace_back(FlatTableField<float>(table, i, model)); break;
+      case nanoaod::FlatTable::ColumnType::Int:
+        m_intFields.emplace_back(FlatTableField<int>(table, i, model)); break;
+      case nanoaod::FlatTable::ColumnType::UInt8:
+        m_uint8Fields.emplace_back(FlatTableField<std::uint8_t>(table, i, model)); break;
+      case nanoaod::FlatTable::ColumnType::Bool:
+        m_boolFields.emplace_back(FlatTableField<bool>(table, i, model)); break;
+      default:
+        throw cms::Exception("LogicError", "Unsupported type");
+    }
+  }
+}
+
+void TableOutputFields::fillEntry(const nanoaod::FlatTable& table, std::size_t i) {
+  for (auto& field : m_floatFields) {
+    field.fill(table, i);
+  }
+  for (auto& field : m_intFields) {
+    field.fill(table, i);
+  }
+  for (auto& field : m_uint8Fields) {
+    field.fill(table, i);
+  }
+  for (auto& field : m_boolFields) {
+    field.fill(table, i);
+  }
+}
+
+const edm::EDGetToken& TableOutputFields::getToken() const {
+  return m_token;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
+void TableOutputVectorFields::createFields(const edm::EventForOutput& event, RNTupleModel& model) {
+  edm::Handle<nanoaod::FlatTable> handle;
+  event.getByToken(m_token, handle);
+  const nanoaod::FlatTable& table = *handle;
+  for (std::size_t i = 0; i < table.nColumns(); i++) {
+    switch(table.columnType(i)) {
+      case nanoaod::FlatTable::ColumnType::Float:
+        m_vfloatFields.emplace_back(FlatTableField<std::vector<float>>(table, i, model));
+        break;
+      case nanoaod::FlatTable::ColumnType::Int:
+        m_vintFields.emplace_back(FlatTableField<std::vector<int>>(table, i, model));
+        break;
+      case nanoaod::FlatTable::ColumnType::UInt8:
+        m_vuint8Fields.emplace_back(FlatTableField<std::vector<std::uint8_t>>(table, i, model));
+        break;
+      case nanoaod::FlatTable::ColumnType::Bool:
+        m_vboolFields.emplace_back(FlatTableField<std::vector<bool>>(table, i, model));
+        break;
+      default:
+        throw cms::Exception("LogicError", "Unsupported type");
+    }
+  }
+}
+void TableOutputVectorFields::fill(const edm::EventForOutput& event) {
+  edm::Handle<nanoaod::FlatTable> handle;
+  event.getByToken(m_token, handle);
+  const auto& table = *handle;
+  for (auto& field : m_vfloatFields) {
+    field.fillVectored(table);
+  }
+  for (auto& field : m_vintFields) {
+    field.fillVectored(table);
+  }
+  for (auto& field : m_vuint8Fields) {
+    field.fillVectored(table);
+  }
+  for (auto& field : m_vboolFields) {
+    field.fillVectored(table);
+  }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
+void TableCollection::add(const edm::EDGetToken& table_token, const nanoaod::FlatTable& table) {
+  if (m_collectionName.empty()) {
+    m_collectionName = table.name();
+    // TODO ensure this isn't moved from twice?
+  }
+  if (table.extension()) {
+    m_extensions.emplace_back(TableOutputFields(table_token));
+    return;
+  }
+  if (hasMainTable()) {
+    throw cms::Exception("LogicError", "Trying to save multiple main tables for " + m_collectionName + "\n");
+ }
+  m_main = TableOutputFields(table_token);
+}
+
+void TableCollection::createFields(const edm::EventForOutput& event, RNTupleModel& eventModel) {
+  auto collectionModel = RNTupleModel::Create();
+  m_main.createFields(event, *collectionModel);
+  for (auto& extension: m_extensions) {
+    extension.createFields(event, *collectionModel);
+  }
+  m_collection = eventModel.MakeCollection(m_collectionName, std::move(collectionModel));
+}
+
+void TableCollection::fill(const edm::EventForOutput& event) {
+  edm::Handle<nanoaod::FlatTable> handle;
+  event.getByToken(m_main.getToken(), handle);
+  const auto& main_table = *handle;
+  auto table_size = main_table.size();
+  // todo check table sizes
+  for (std::size_t i = 0; i < table_size; i++) {
+    m_main.fillEntry(main_table, i);
+    for (auto& ext: m_extensions) {
+      edm::Handle<nanoaod::FlatTable> handle;
+      event.getByToken(ext.getToken(), handle);
+      const auto& ext_table = *handle;
+      ext.fillEntry(ext_table, i);
+    }
+    m_collection->Fill();
+  }
+  //if (num_fill != num_fill_ext) {
+  //  throw cms::Exception("LogicError",
+  //    "Mismatch in number of entries between extension and main table for " + m_collectionName);
+  //}
+}
+void TableCollection::print() const {
+  std::cout << "Collection: " << m_collectionName << " {\n";
+  m_main.print();
+  for (const auto& ext: m_extensions) {
+    ext.print();
+  }
+  std::cout << "}\n";
+}
+
+bool TableCollection::hasMainTable() {
+  return !m_main.getToken().isUninitialized();
+}
+
+const std::string& TableCollection::getCollectionName() const {
+  return m_collectionName;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
+void TableCollections::add(const edm::EDGetToken& table_token,
+  const nanoaod::FlatTable& table)
+{
+  // skip empty tables -- requirement of RNTuple to define schema before filling
+  if (table.nColumns() == 0) {
+    std::cout << "Warning: skipping empty table: \n";
+    print_table(table);
+    return;
+  }
+  // Can handle either anonymous table or anonymous column but not both
+  // - anonymous table: use column names directly as top-level fields
+  // - anonymous column: use the table name as the field name
+  if (table.name().empty() && hasAnonymousColumn(table)) {
+    throw cms::Exception("LogicError", "Anonymous FlatTable and anonymous field");
+  }
+  // case 1: create a top-level RNTuple field for each table column
+  if (table.name().empty() || hasAnonymousColumn(table)) {
+    if (table.singleton()) {
+      m_singletonFields.emplace_back(TableOutputFields(table_token));
+    } else {
+      m_vectorFields.emplace_back(TableOutputVectorFields(table_token));
+    }
+    return;
+  }
+  // case 2: Named singleton and vector tables are both written as RNTuple collections.
+  auto collection = std::find_if(m_collections.begin(), m_collections.end(),
+    [&](const TableCollection& c) { return c.getCollectionName() == table.name(); });
+  if (collection == m_collections.end()) {
+    std::cout << "adding new collection: \n";
+    print_table(table);
+    m_collections.emplace_back(TableCollection());
+    m_collections.back().add(table_token, table);
+    return;
+  }
+  std::cout << "adding to existing collection : \n";
+  print_table(table);
+  collection->add(table_token, table);
+}
+
+void TableCollections::print() const {
+  for (const auto& collection: m_collections) {
+    collection.print();
+    std::cout << "\n";
+  }
+}
+
+void TableCollections::createFields(const edm::EventForOutput& event,
+  RNTupleModel& eventModel)
+{
+  for (auto& collection: m_collections) {
+    if (!collection.hasMainTable()) {
+      throw cms::Exception("LogicError", "Trying to save an extension table for " +
+        collection.getCollectionName() + " without the corresponding main table\n");
+    }
+    collection.createFields(event, eventModel);
+  }
+  for (auto& table: m_singletonFields) {
+    table.createFields(event, eventModel);
+  }
+  for (auto& table: m_vectorFields) {
+    table.createFields(event, eventModel);
+  }
+}
+
+void TableCollections::fill(const edm::EventForOutput& event) {
+  for (auto& collection: m_collections) {
+    collection.fill(event);
+  }
+  for (auto& fields: m_singletonFields) {
+    edm::Handle<nanoaod::FlatTable> handle;
+    event.getByToken(fields.getToken(), handle);
+    const auto& table = *handle;
+    fields.fillEntry(table, 0);
+  }
+  for (auto& fields: m_vectorFields) {
+    fields.fill(event);
+  }
+}
+
+bool TableCollections::hasAnonymousColumn(const nanoaod::FlatTable& table) {
+  int num_anon = 0;
+  for (std::size_t i = 0; i < table.nColumns(); i++) {
+    if (table.columnName(i).empty()) {
+      num_anon++;
+    }
+  }
+  if (num_anon > 1) {
+    throw cms::Exception("LogicError", "FlatTable `" + table.name() +
+      "` has " + std::to_string(num_anon) + "anonymous fields");
+  }
+  return num_anon;
+}

--- a/PhysicsTools/NanoAOD/plugins/TableOutputFields.cc
+++ b/PhysicsTools/NanoAOD/plugins/TableOutputFields.cc
@@ -10,15 +10,19 @@ namespace {
     std::cout << "  fields: {\n";
     for (std::size_t i = 0; i < table.nColumns(); i++) {
       std::cout << "    " << (table.columnName(i).empty() ? "// anon" : table.columnName(i)) << ": ";
-      switch(table.columnType(i)) {
+      switch (table.columnType(i)) {
         case nanoaod::FlatTable::ColumnType::Float:
-          std::cout << "f32,"; break;
+          std::cout << "f32,";
+          break;
         case nanoaod::FlatTable::ColumnType::Int:
-          std::cout << "i32,"; break;
+          std::cout << "i32,";
+          break;
         case nanoaod::FlatTable::ColumnType::UInt8:
-          std::cout << "u8,"; break;
+          std::cout << "u8,";
+          break;
         case nanoaod::FlatTable::ColumnType::Bool:
-          std::cout << "bool,"; break;
+          std::cout << "bool,";
+          break;
         default:
           throw cms::Exception("LogicError", "Unsupported type");
       }
@@ -26,19 +30,19 @@ namespace {
     }
     std::cout << "  }\n}\n";
   }
-} // anonymous namespace
+}  // anonymous namespace
 
 void TableOutputFields::print() const {
-  for (const auto& field: m_floatFields) {
+  for (const auto& field : m_floatFields) {
     std::cout << "  " << field.getFlatTableName() << ": f32,\n";
   }
-  for (const auto& field: m_intFields) {
+  for (const auto& field : m_intFields) {
     std::cout << "  " << field.getFlatTableName() << ": i32,\n";
   }
-  for (const auto& field: m_uint8Fields) {
+  for (const auto& field : m_uint8Fields) {
     std::cout << "  " << field.getFlatTableName() << ": u8,\n";
   }
-  for (const auto& field: m_boolFields) {
+  for (const auto& field : m_boolFields) {
     std::cout << "  " << field.getFlatTableName() << ": bool,\n";
   }
 }
@@ -48,15 +52,19 @@ void TableOutputFields::createFields(const edm::EventForOutput& event, RNTupleMo
   event.getByToken(m_token, handle);
   const nanoaod::FlatTable& table = *handle;
   for (std::size_t i = 0; i < table.nColumns(); i++) {
-    switch(table.columnType(i)) {
+    switch (table.columnType(i)) {
       case nanoaod::FlatTable::ColumnType::Float:
-        m_floatFields.emplace_back(FlatTableField<float>(table, i, model)); break;
+        m_floatFields.emplace_back(FlatTableField<float>(table, i, model));
+        break;
       case nanoaod::FlatTable::ColumnType::Int:
-        m_intFields.emplace_back(FlatTableField<int>(table, i, model)); break;
+        m_intFields.emplace_back(FlatTableField<int>(table, i, model));
+        break;
       case nanoaod::FlatTable::ColumnType::UInt8:
-        m_uint8Fields.emplace_back(FlatTableField<std::uint8_t>(table, i, model)); break;
+        m_uint8Fields.emplace_back(FlatTableField<std::uint8_t>(table, i, model));
+        break;
       case nanoaod::FlatTable::ColumnType::Bool:
-        m_boolFields.emplace_back(FlatTableField<bool>(table, i, model)); break;
+        m_boolFields.emplace_back(FlatTableField<bool>(table, i, model));
+        break;
       default:
         throw cms::Exception("LogicError", "Unsupported type");
     }
@@ -78,9 +86,7 @@ void TableOutputFields::fillEntry(const nanoaod::FlatTable& table, std::size_t i
   }
 }
 
-const edm::EDGetToken& TableOutputFields::getToken() const {
-  return m_token;
-}
+const edm::EDGetToken& TableOutputFields::getToken() const { return m_token; }
 
 ///////////////////////////////////////////////////////////////////////////////
 
@@ -89,7 +95,7 @@ void TableOutputVectorFields::createFields(const edm::EventForOutput& event, RNT
   event.getByToken(m_token, handle);
   const nanoaod::FlatTable& table = *handle;
   for (std::size_t i = 0; i < table.nColumns(); i++) {
-    switch(table.columnType(i)) {
+    switch (table.columnType(i)) {
       case nanoaod::FlatTable::ColumnType::Float:
         m_vfloatFields.emplace_back(FlatTableField<std::vector<float>>(table, i, model));
         break;
@@ -137,14 +143,14 @@ void TableCollection::add(const edm::EDGetToken& table_token, const nanoaod::Fla
   }
   if (hasMainTable()) {
     throw cms::Exception("LogicError", "Trying to save multiple main tables for " + m_collectionName + "\n");
- }
+  }
   m_main = TableOutputFields(table_token);
 }
 
 void TableCollection::createFields(const edm::EventForOutput& event, RNTupleModel& eventModel) {
   auto collectionModel = RNTupleModel::Create();
   m_main.createFields(event, *collectionModel);
-  for (auto& extension: m_extensions) {
+  for (auto& extension : m_extensions) {
     extension.createFields(event, *collectionModel);
   }
   m_collection = eventModel.MakeCollection(m_collectionName, std::move(collectionModel));
@@ -157,13 +163,13 @@ void TableCollection::fill(const edm::EventForOutput& event) {
   auto table_size = main_table.size();
   for (std::size_t i = 0; i < table_size; i++) {
     m_main.fillEntry(main_table, i);
-    for (auto& ext: m_extensions) {
+    for (auto& ext : m_extensions) {
       edm::Handle<nanoaod::FlatTable> handle;
       event.getByToken(ext.getToken(), handle);
       const auto& ext_table = *handle;
       if (ext_table.size() != table_size) {
         throw cms::Exception("LogicError",
-          "Mismatch in number of entries between extension and main table for " + m_collectionName);
+                             "Mismatch in number of entries between extension and main table for " + m_collectionName);
       }
       ext.fillEntry(ext_table, i);
     }
@@ -174,25 +180,19 @@ void TableCollection::fill(const edm::EventForOutput& event) {
 void TableCollection::print() const {
   std::cout << "Collection: " << m_collectionName << " {\n";
   m_main.print();
-  for (const auto& ext: m_extensions) {
+  for (const auto& ext : m_extensions) {
     ext.print();
   }
   std::cout << "}\n";
 }
 
-bool TableCollection::hasMainTable() {
-  return !m_main.getToken().isUninitialized();
-}
+bool TableCollection::hasMainTable() { return !m_main.getToken().isUninitialized(); }
 
-const std::string& TableCollection::getCollectionName() const {
-  return m_collectionName;
-}
+const std::string& TableCollection::getCollectionName() const { return m_collectionName; }
 
 ///////////////////////////////////////////////////////////////////////////////
 
-void TableCollectionSet::add(const edm::EDGetToken& table_token,
-  const nanoaod::FlatTable& table)
-{
+void TableCollectionSet::add(const edm::EDGetToken& table_token, const nanoaod::FlatTable& table) {
   // skip empty tables -- requirement of RNTuple to define schema before filling
   if (table.nColumns() == 0) {
     std::cout << "Warning: skipping empty table: \n";
@@ -215,8 +215,9 @@ void TableCollectionSet::add(const edm::EDGetToken& table_token,
     return;
   }
   // case 2: Named singleton and vector tables are both written as RNTuple collections.
-  auto collection = std::find_if(m_collections.begin(), m_collections.end(),
-    [&](const TableCollection& c) { return c.getCollectionName() == table.name(); });
+  auto collection = std::find_if(m_collections.begin(), m_collections.end(), [&](const TableCollection& c) {
+    return c.getCollectionName() == table.name();
+  });
   if (collection == m_collections.end()) {
     m_collections.emplace_back(TableCollection());
     m_collections.back().add(table_token, table);
@@ -226,41 +227,40 @@ void TableCollectionSet::add(const edm::EDGetToken& table_token,
 }
 
 void TableCollectionSet::print() const {
-  for (const auto& collection: m_collections) {
+  for (const auto& collection : m_collections) {
     collection.print();
     std::cout << "\n";
   }
 }
 
-void TableCollectionSet::createFields(const edm::EventForOutput& event,
-  RNTupleModel& eventModel)
-{
-  for (auto& collection: m_collections) {
+void TableCollectionSet::createFields(const edm::EventForOutput& event, RNTupleModel& eventModel) {
+  for (auto& collection : m_collections) {
     if (!collection.hasMainTable()) {
-      throw cms::Exception("LogicError", "Trying to save an extension table for " +
-        collection.getCollectionName() + " without the corresponding main table\n");
+      throw cms::Exception("LogicError",
+                           "Trying to save an extension table for " + collection.getCollectionName() +
+                               " without the corresponding main table\n");
     }
     collection.createFields(event, eventModel);
   }
-  for (auto& table: m_singletonFields) {
+  for (auto& table : m_singletonFields) {
     table.createFields(event, eventModel);
   }
-  for (auto& table: m_vectorFields) {
+  for (auto& table : m_vectorFields) {
     table.createFields(event, eventModel);
   }
 }
 
 void TableCollectionSet::fill(const edm::EventForOutput& event) {
-  for (auto& collection: m_collections) {
+  for (auto& collection : m_collections) {
     collection.fill(event);
   }
-  for (auto& fields: m_singletonFields) {
+  for (auto& fields : m_singletonFields) {
     edm::Handle<nanoaod::FlatTable> handle;
     event.getByToken(fields.getToken(), handle);
     const auto& table = *handle;
     fields.fillEntry(table, 0);
   }
-  for (auto& fields: m_vectorFields) {
+  for (auto& fields : m_vectorFields) {
     fields.fill(event);
   }
 }
@@ -273,8 +273,8 @@ bool TableCollectionSet::hasAnonymousColumn(const nanoaod::FlatTable& table) {
     }
   }
   if (num_anon > 1) {
-    throw cms::Exception("LogicError", "FlatTable `" + table.name() +
-      "` has " + std::to_string(num_anon) + "anonymous fields");
+    throw cms::Exception("LogicError",
+                         "FlatTable `" + table.name() + "` has " + std::to_string(num_anon) + "anonymous fields");
   }
   return num_anon;
 }

--- a/PhysicsTools/NanoAOD/plugins/TableOutputFields.cc
+++ b/PhysicsTools/NanoAOD/plugins/TableOutputFields.cc
@@ -153,6 +153,10 @@ void TableCollection::createFields(const edm::EventForOutput& event, RNTupleMode
   for (auto& extension : m_extensions) {
     extension.createFields(event, *collectionModel);
   }
+  edm::Handle<nanoaod::FlatTable> handle;
+  event.getByToken(m_main.getToken(), handle);
+  const nanoaod::FlatTable& table = *handle;
+  collectionModel->SetDescription(table.doc());
   m_collection = eventModel.MakeCollection(m_collectionName, std::move(collectionModel));
 }
 

--- a/PhysicsTools/NanoAOD/plugins/TableOutputFields.cc
+++ b/PhysicsTools/NanoAOD/plugins/TableOutputFields.cc
@@ -1,7 +1,7 @@
 #include "PhysicsTools/NanoAOD/plugins/TableOutputFields.h"
 
 namespace {
-  void print_table(const nanoaod::FlatTable& table) {
+  void printTable(const nanoaod::FlatTable& table) {
     std::cout << "FlatTable {\n";
     std::cout << "  name: " << (table.name().empty() ? "// anon" : table.name()) << "\n";
     std::cout << "  singleton: " << (table.singleton() ? "true" : "false") << "\n";
@@ -196,7 +196,7 @@ void TableCollections::add(const edm::EDGetToken& table_token,
   // skip empty tables -- requirement of RNTuple to define schema before filling
   if (table.nColumns() == 0) {
     std::cout << "Warning: skipping empty table: \n";
-    print_table(table);
+    printTable(table);
     return;
   }
   // Can handle either anonymous table or anonymous column but not both

--- a/PhysicsTools/NanoAOD/plugins/TableOutputFields.cc
+++ b/PhysicsTools/NanoAOD/plugins/TableOutputFields.cc
@@ -190,7 +190,7 @@ const std::string& TableCollection::getCollectionName() const {
 
 ///////////////////////////////////////////////////////////////////////////////
 
-void TableCollections::add(const edm::EDGetToken& table_token,
+void TableCollectionSet::add(const edm::EDGetToken& table_token,
   const nanoaod::FlatTable& table)
 {
   // skip empty tables -- requirement of RNTuple to define schema before filling
@@ -225,14 +225,14 @@ void TableCollections::add(const edm::EDGetToken& table_token,
   collection->add(table_token, table);
 }
 
-void TableCollections::print() const {
+void TableCollectionSet::print() const {
   for (const auto& collection: m_collections) {
     collection.print();
     std::cout << "\n";
   }
 }
 
-void TableCollections::createFields(const edm::EventForOutput& event,
+void TableCollectionSet::createFields(const edm::EventForOutput& event,
   RNTupleModel& eventModel)
 {
   for (auto& collection: m_collections) {
@@ -250,7 +250,7 @@ void TableCollections::createFields(const edm::EventForOutput& event,
   }
 }
 
-void TableCollections::fill(const edm::EventForOutput& event) {
+void TableCollectionSet::fill(const edm::EventForOutput& event) {
   for (auto& collection: m_collections) {
     collection.fill(event);
   }
@@ -265,7 +265,7 @@ void TableCollections::fill(const edm::EventForOutput& event) {
   }
 }
 
-bool TableCollections::hasAnonymousColumn(const nanoaod::FlatTable& table) {
+bool TableCollectionSet::hasAnonymousColumn(const nanoaod::FlatTable& table) {
   int num_anon = 0;
   for (std::size_t i = 0; i < table.nColumns(); i++) {
     if (table.columnName(i).empty()) {

--- a/PhysicsTools/NanoAOD/plugins/TableOutputFields.h
+++ b/PhysicsTools/NanoAOD/plugins/TableOutputFields.h
@@ -14,6 +14,54 @@ using ROOT::Experimental::RNTupleModel;
 using ROOT::Experimental::RNTupleWriter;
 using ROOT::Experimental::RCollectionNTuple;
 
+template<typename T>
+class FlatTableField {
+public:
+  FlatTableField() = default;
+  FlatTableField(const nanoaod::FlatTable& table, std::size_t i, RNTupleModel& model) {
+    m_flatTableName = table.columnName(i);
+    // case 1: field has a name (table may or may not have a name)
+    if (!table.columnName(i).empty()) {
+      m_field = RNTupleFieldPtr<T>(table.columnName(i), model);
+      return;
+    }
+    // case 2: field doesn't have a name: use the table name as the RNTuple field name
+    if (table.name().empty()) {
+      throw cms::Exception("LogicError", "Empty FlatTable name and field name");
+    }
+    m_field = RNTupleFieldPtr<T>(table.name(), model);
+  }
+  // For collection fields and singleton fields
+  void fill(const nanoaod::FlatTable& table, std::size_t i) {
+    int col_idx = table.columnIndex(m_flatTableName);
+    if (col_idx == -1) {
+      throw cms::Exception("LogicError", "Missing column in input for "
+        + table.name() + "_" + m_flatTableName);
+    }
+    m_field.fill(table.columnData<T>(col_idx)[i]);
+  }
+  // For vector fields without a collection, we have to buffer the results
+  // internally and then fill the RNTuple field
+  void fillVectored(const nanoaod::FlatTable& table) {
+    int col_idx = table.columnIndex(m_flatTableName);
+    if (col_idx == -1) {
+      throw cms::Exception("LogicError", "Missing column in input for "
+        + table.name() + "_" + m_flatTableName);
+    }
+    std::vector<typename T::value_type> buf(table.size());
+    for (std::size_t i = 0; i < table.size(); i++) {
+      buf[i] = table.columnData<typename T::value_type>(col_idx)[i];
+    }
+    m_field.fill(buf);
+  }
+  const std::string& getFlatTableName() const {
+    return m_flatTableName;
+  }
+private:
+  RNTupleFieldPtr<T> m_field;
+  std::string m_flatTableName;
+};
+
 void print_table(const nanoaod::FlatTable& table) {
   std::cout << "FlatTable {\n";
   std::cout << "  name: " << (table.name().empty() ? "// anon" : table.name()) << "\n";
@@ -44,22 +92,19 @@ class TableOutputFields {
 public:
   TableOutputFields() = default;
   explicit TableOutputFields(const edm::EDGetToken& token) //, const nanoaod::FlatTable& table)
-        : m_token(token)
-  {
-
-  }
+        : m_token(token) {}
   void print() const {
     for (const auto& field: m_floatFields) {
-      std::cout << "  " << field.getFieldName() << ": f32,\n";
+      std::cout << "  " << field.getFlatTableName() << ": f32,\n";
     }
     for (const auto& field: m_intFields) {
-      std::cout << "  " << field.getFieldName() << ": i32,\n";
+      std::cout << "  " << field.getFlatTableName() << ": i32,\n";
     }
     for (const auto& field: m_uint8Fields) {
-      std::cout << "  " << field.getFieldName() << ": u8,\n";
+      std::cout << "  " << field.getFlatTableName() << ": u8,\n";
     }
     for (const auto& field: m_boolFields) {
-      std::cout << "  " << field.getFieldName() << ": bool,\n";
+      std::cout << "  " << field.getFlatTableName() << ": bool,\n";
     }
   }
   void createFields(const edm::EventForOutput& event, RNTupleModel& model) {
@@ -69,39 +114,30 @@ public:
     for (std::size_t i = 0; i < table.nColumns(); i++) {
       switch(table.columnType(i)) {
         case nanoaod::FlatTable::ColumnType::Float:
-          m_floatFields.emplace_back(RNTupleFieldPtr<float>(table.columnName(i), model)); break;
+          m_floatFields.emplace_back(FlatTableField<float>(table, i, model)); break;
         case nanoaod::FlatTable::ColumnType::Int:
-          m_intFields.emplace_back(RNTupleFieldPtr<int>(table.columnName(i), model)); break;
+          m_intFields.emplace_back(FlatTableField<int>(table, i, model)); break;
         case nanoaod::FlatTable::ColumnType::UInt8:
-          m_uint8Fields.emplace_back(RNTupleFieldPtr<std::uint8_t>(table.columnName(i), model)); break;
+          m_uint8Fields.emplace_back(FlatTableField<std::uint8_t>(table, i, model)); break;
         case nanoaod::FlatTable::ColumnType::Bool:
-          m_boolFields.emplace_back(RNTupleFieldPtr<bool>(table.columnName(i), model)); break;
+          m_boolFields.emplace_back(FlatTableField<bool>(table, i, model)); break;
         default:
           throw cms::Exception("LogicError", "Unsupported type");
       }
     }
   }
   void fillEntry(const nanoaod::FlatTable& table, std::size_t i) {
-    auto column_index = [&](const std::string& field_name) -> int {
-      int col_idx = table.columnIndex(field_name);
-      if (col_idx == -1) {
-        // todo rntuple naming?
-        throw cms::Exception("LogicError", "Missing column in input for "
-          + table.name() + "_" + field_name);
-      }
-      return col_idx;
-    };
-    for (auto& field: m_floatFields) {
-      field.fill(table.columnData<float>(column_index(field.getFieldName()))[i]);
+    for (auto& field : m_floatFields) {
+      field.fill(table, i);
     }
-    for (auto& field: m_intFields) {
-      field.fill(table.columnData<int>(column_index(field.getFieldName()))[i]);
+    for (auto& field : m_intFields) {
+      field.fill(table, i);
     }
-    for (auto& field: m_uint8Fields) {
-      field.fill(table.columnData<std::uint8_t>(column_index(field.getFieldName()))[i]);
+    for (auto& field : m_uint8Fields) {
+      field.fill(table, i);
     }
-    for (auto& field: m_boolFields) {
-      field.fill(table.columnData<bool>(column_index(field.getFieldName()))[i]);
+    for (auto& field : m_boolFields) {
+      field.fill(table, i);
     }
   }
   const edm::EDGetToken& getToken() const {
@@ -110,10 +146,63 @@ public:
 
 private:
   edm::EDGetToken m_token;
-  std::vector<RNTupleFieldPtr<float>> m_floatFields;
-  std::vector<RNTupleFieldPtr<int>> m_intFields;
-  std::vector<RNTupleFieldPtr<std::uint8_t>> m_uint8Fields;
-  std::vector<RNTupleFieldPtr<bool>> m_boolFields;
+  std::vector<FlatTableField<float>> m_floatFields;
+  std::vector<FlatTableField<int>> m_intFields;
+  std::vector<FlatTableField<std::uint8_t>> m_uint8Fields;
+  std::vector<FlatTableField<bool>> m_boolFields;
+};
+
+class TableOutputVectorFields {
+public:
+  TableOutputVectorFields() = default;
+  explicit TableOutputVectorFields(const edm::EDGetToken& token)
+        : m_token(token) {}
+  void createFields(const edm::EventForOutput& event, RNTupleModel& model) {
+    edm::Handle<nanoaod::FlatTable> handle;
+    event.getByToken(m_token, handle);
+    const nanoaod::FlatTable& table = *handle;
+    for (std::size_t i = 0; i < table.nColumns(); i++) {
+      switch(table.columnType(i)) {
+        case nanoaod::FlatTable::ColumnType::Float:
+          m_vfloatFields.emplace_back(FlatTableField<std::vector<float>>(table, i, model));
+          break;
+        case nanoaod::FlatTable::ColumnType::Int:
+          m_vintFields.emplace_back(FlatTableField<std::vector<int>>(table, i, model));
+          break;
+        case nanoaod::FlatTable::ColumnType::UInt8:
+          m_vuint8Fields.emplace_back(FlatTableField<std::vector<std::uint8_t>>(table, i, model));
+          break;
+        case nanoaod::FlatTable::ColumnType::Bool:
+          m_vboolFields.emplace_back(FlatTableField<std::vector<bool>>(table, i, model));
+          break;
+        default:
+          throw cms::Exception("LogicError", "Unsupported type");
+      }
+    }
+  }
+  void fill(const edm::EventForOutput& event) {
+    edm::Handle<nanoaod::FlatTable> handle;
+    event.getByToken(m_token, handle);
+    const auto& table = *handle;
+    for (auto& field : m_vfloatFields) {
+      field.fillVectored(table);
+    }
+    for (auto& field : m_vintFields) {
+      field.fillVectored(table);
+    }
+    for (auto& field : m_vuint8Fields) {
+      field.fillVectored(table);
+    }
+    for (auto& field : m_vboolFields) {
+      field.fillVectored(table);
+    }
+  }
+private:
+  edm::EDGetToken m_token;
+  std::vector<FlatTableField<std::vector<float>>> m_vfloatFields;
+  std::vector<FlatTableField<std::vector<int>>> m_vintFields;
+  std::vector<FlatTableField<std::vector<std::uint8_t>>> m_vuint8Fields;
+  std::vector<FlatTableField<std::vector<bool>>> m_vboolFields;
 };
 
 class TableCollection {
@@ -198,23 +287,22 @@ class TableCollections {
         print_table(table);
         return;
       }
-      // skip anonymous tables for now
-      // TODO add to m_topLevelFields;
-      if (table.name().empty()) {
-        std::cout << "skipping anonymous table:\n";
-        print_table(table);
+      // Can handle either anonymous table or anonymous column but not both
+      // - anonymous table: use column names directly as top-level fields
+      // - anonymous column: use the table name as the field name
+      if (table.name().empty() && hasAnonymousColumn(table)) {
+        throw cms::Exception("LogicError", "Anonymous FlatTable and anonymous field");
+      }
+      // case 1: create a top-level RNTuple field for each table column
+      if (table.name().empty() || hasAnonymousColumn(table)) {
+        if (table.singleton()) {
+          m_singletonFields.emplace_back(TableOutputFields(table_token));
+        } else {
+          m_vectorFields.emplace_back(TableOutputVectorFields(table_token));
+        }
         return;
       }
-      // skip tables with anonymous fields for now
-      // TODO add to m_topLevelFields;
-      for (std::size_t i = 0; i < table.nColumns(); i++) {
-        auto col_name = table.columnName(i).empty() ? "// anon" : table.columnName(i);
-        if (table.columnName(i).empty()) {
-          std::cout << "skipping table with anonymous fields:\n";
-          print_table(table);
-          return;
-        }
-      }
+      // case 2: Named singleton and vector tables are both written as RNTuple collections.
       auto collection = std::find_if(m_collections.begin(), m_collections.end(),
         [&](const TableCollection& c) { return c.getCollectionName() == table.name(); });
       if (collection == m_collections.end()) {
@@ -242,17 +330,46 @@ class TableCollections {
         }
         collection.createFields(event, eventModel);
       }
-      // todo top-level fields
+      for (auto& table: m_singletonFields) {
+        table.createFields(event, eventModel);
+      }
+      for (auto& table: m_vectorFields) {
+        table.createFields(event, eventModel);
+      }
     }
     void fill(const edm::EventForOutput& event) {
       for (auto& collection: m_collections) {
         collection.fill(event);
       }
-      // todo top-level fields
+      for (auto& fields: m_singletonFields) {
+        edm::Handle<nanoaod::FlatTable> handle;
+        event.getByToken(fields.getToken(), handle);
+        const auto& table = *handle;
+        fields.fillEntry(table, 0);
+      }
+      for (auto& fields: m_vectorFields) {
+        fields.fill(event);
+      }
     }
   private:
+    // Returns true if the FlatTable has an anonymous column. Throws a cms::Exception
+    // if there is more than one anonymous column.
+    static bool hasAnonymousColumn(const nanoaod::FlatTable& table) {
+      int num_anon = 0;
+      for (std::size_t i = 0; i < table.nColumns(); i++) {
+        if (table.columnName(i).empty()) {
+          num_anon++;
+        }
+      }
+      if (num_anon > 1) {
+        throw cms::Exception("LogicError", "FlatTable `" + table.name() +
+          "` has " + std::to_string(num_anon) + "anonymous fields");
+      }
+      return num_anon;
+    }
     std::vector<TableCollection> m_collections;
-    std::vector<TableOutputFields> m_topLevelFields;
+    std::vector<TableOutputFields> m_singletonFields;
+    std::vector<TableOutputVectorFields> m_vectorFields;
 };
 
 #endif

--- a/PhysicsTools/NanoAOD/plugins/TableOutputFields.h
+++ b/PhysicsTools/NanoAOD/plugins/TableOutputFields.h
@@ -3,6 +3,7 @@
 
 #include "RNTupleFieldPtr.h"
 
+#include "FWCore/Framework/interface/EventForOutput.h"
 #include "DataFormats/NanoAOD/interface/FlatTable.h"
 #include "FWCore/Utilities/interface/EDGetToken.h"
 
@@ -62,88 +63,15 @@ private:
   std::string m_flatTableName;
 };
 
-void print_table(const nanoaod::FlatTable& table) {
-  std::cout << "FlatTable {\n";
-  std::cout << "  name: " << (table.name().empty() ? "// anon" : table.name()) << "\n";
-  std::cout << "  singleton: " << (table.singleton() ? "true" : "false") << "\n";
-  std::cout << "  size: " << table.size() << "\n";
-  std::cout << "  extension: " << (table.extension() ? "true" : "false") << "\n";
-  std::cout << "  fields: {\n";
-  for (std::size_t i = 0; i < table.nColumns(); i++) {
-    std::cout << "    " << (table.columnName(i).empty() ? "// anon" : table.columnName(i)) << ": ";
-    switch(table.columnType(i)) {
-      case nanoaod::FlatTable::ColumnType::Float:
-        std::cout << "f32,"; break;
-      case nanoaod::FlatTable::ColumnType::Int:
-        std::cout << "i32,"; break;
-      case nanoaod::FlatTable::ColumnType::UInt8:
-        std::cout << "u8,"; break;
-      case nanoaod::FlatTable::ColumnType::Bool:
-        std::cout << "bool,"; break;
-      default:
-        throw cms::Exception("LogicError", "Unsupported type");
-    }
-    std::cout << "\n";
-  }
-  std::cout << "  }\n}\n";
-}
-
 class TableOutputFields {
 public:
   TableOutputFields() = default;
-  explicit TableOutputFields(const edm::EDGetToken& token) //, const nanoaod::FlatTable& table)
+  explicit TableOutputFields(const edm::EDGetToken& token)
         : m_token(token) {}
-  void print() const {
-    for (const auto& field: m_floatFields) {
-      std::cout << "  " << field.getFlatTableName() << ": f32,\n";
-    }
-    for (const auto& field: m_intFields) {
-      std::cout << "  " << field.getFlatTableName() << ": i32,\n";
-    }
-    for (const auto& field: m_uint8Fields) {
-      std::cout << "  " << field.getFlatTableName() << ": u8,\n";
-    }
-    for (const auto& field: m_boolFields) {
-      std::cout << "  " << field.getFlatTableName() << ": bool,\n";
-    }
-  }
-  void createFields(const edm::EventForOutput& event, RNTupleModel& model) {
-    edm::Handle<nanoaod::FlatTable> handle;
-    event.getByToken(m_token, handle);
-    const nanoaod::FlatTable& table = *handle;
-    for (std::size_t i = 0; i < table.nColumns(); i++) {
-      switch(table.columnType(i)) {
-        case nanoaod::FlatTable::ColumnType::Float:
-          m_floatFields.emplace_back(FlatTableField<float>(table, i, model)); break;
-        case nanoaod::FlatTable::ColumnType::Int:
-          m_intFields.emplace_back(FlatTableField<int>(table, i, model)); break;
-        case nanoaod::FlatTable::ColumnType::UInt8:
-          m_uint8Fields.emplace_back(FlatTableField<std::uint8_t>(table, i, model)); break;
-        case nanoaod::FlatTable::ColumnType::Bool:
-          m_boolFields.emplace_back(FlatTableField<bool>(table, i, model)); break;
-        default:
-          throw cms::Exception("LogicError", "Unsupported type");
-      }
-    }
-  }
-  void fillEntry(const nanoaod::FlatTable& table, std::size_t i) {
-    for (auto& field : m_floatFields) {
-      field.fill(table, i);
-    }
-    for (auto& field : m_intFields) {
-      field.fill(table, i);
-    }
-    for (auto& field : m_uint8Fields) {
-      field.fill(table, i);
-    }
-    for (auto& field : m_boolFields) {
-      field.fill(table, i);
-    }
-  }
-  const edm::EDGetToken& getToken() const {
-    return m_token;
-  }
-
+  void print() const;
+  void createFields(const edm::EventForOutput& event, RNTupleModel& model);
+  void fillEntry(const nanoaod::FlatTable& table, std::size_t i);
+  const edm::EDGetToken& getToken() const;
 private:
   edm::EDGetToken m_token;
   std::vector<FlatTableField<float>> m_floatFields;
@@ -157,46 +85,8 @@ public:
   TableOutputVectorFields() = default;
   explicit TableOutputVectorFields(const edm::EDGetToken& token)
         : m_token(token) {}
-  void createFields(const edm::EventForOutput& event, RNTupleModel& model) {
-    edm::Handle<nanoaod::FlatTable> handle;
-    event.getByToken(m_token, handle);
-    const nanoaod::FlatTable& table = *handle;
-    for (std::size_t i = 0; i < table.nColumns(); i++) {
-      switch(table.columnType(i)) {
-        case nanoaod::FlatTable::ColumnType::Float:
-          m_vfloatFields.emplace_back(FlatTableField<std::vector<float>>(table, i, model));
-          break;
-        case nanoaod::FlatTable::ColumnType::Int:
-          m_vintFields.emplace_back(FlatTableField<std::vector<int>>(table, i, model));
-          break;
-        case nanoaod::FlatTable::ColumnType::UInt8:
-          m_vuint8Fields.emplace_back(FlatTableField<std::vector<std::uint8_t>>(table, i, model));
-          break;
-        case nanoaod::FlatTable::ColumnType::Bool:
-          m_vboolFields.emplace_back(FlatTableField<std::vector<bool>>(table, i, model));
-          break;
-        default:
-          throw cms::Exception("LogicError", "Unsupported type");
-      }
-    }
-  }
-  void fill(const edm::EventForOutput& event) {
-    edm::Handle<nanoaod::FlatTable> handle;
-    event.getByToken(m_token, handle);
-    const auto& table = *handle;
-    for (auto& field : m_vfloatFields) {
-      field.fillVectored(table);
-    }
-    for (auto& field : m_vintFields) {
-      field.fillVectored(table);
-    }
-    for (auto& field : m_vuint8Fields) {
-      field.fillVectored(table);
-    }
-    for (auto& field : m_vboolFields) {
-      field.fillVectored(table);
-    }
-  }
+  void createFields(const edm::EventForOutput& event, RNTupleModel& model);
+  void fill(const edm::EventForOutput& event);
 private:
   edm::EDGetToken m_token;
   std::vector<FlatTableField<std::vector<float>>> m_vfloatFields;
@@ -208,69 +98,18 @@ private:
 class TableCollection {
   public:
     TableCollection() = default;
-    // invariants:
+    // Invariants:
     // * table has a non-empty base name
     // * table has at least one column
-    void add(const edm::EDGetToken& table_token, const nanoaod::FlatTable& table) {
-      if (m_collectionName.empty()) {
-        m_collectionName = table.name();
-        // TODO ensure this isn't moved from twice?
-      }
-      if (table.extension()) {
-        m_extensions.emplace_back(TableOutputFields(table_token));
-        return;
-      }
-      if (hasMainTable()) {
-        throw cms::Exception("LogicError", "Trying to save multiple main tables for " + m_collectionName + "\n");
-     }
-      m_main = TableOutputFields(table_token);
-    }
+    void add(const edm::EDGetToken& table_token, const nanoaod::FlatTable& table);
     // Invariants:
     // * m_main not null
     // * m_collectionName not empty
-    void createFields(const edm::EventForOutput& event, RNTupleModel& eventModel) {
-      auto collectionModel = RNTupleModel::Create();
-      m_main.createFields(event, *collectionModel);
-      for (auto& extension: m_extensions) {
-        extension.createFields(event, *collectionModel);
-      }
-      m_collection = eventModel.MakeCollection(m_collectionName, std::move(collectionModel));
-    }
-    void fill(const edm::EventForOutput& event) {
-      edm::Handle<nanoaod::FlatTable> handle;
-      event.getByToken(m_main.getToken(), handle);
-      const auto& main_table = *handle;
-      auto table_size = main_table.size();
-      // todo check table sizes
-      for (std::size_t i = 0; i < table_size; i++) {
-        m_main.fillEntry(main_table, i);
-        for (auto& ext: m_extensions) {
-          edm::Handle<nanoaod::FlatTable> handle;
-          event.getByToken(ext.getToken(), handle);
-          const auto& ext_table = *handle;
-          ext.fillEntry(ext_table, i);
-        }
-        m_collection->Fill();
-      }
-      //if (num_fill != num_fill_ext) {
-      //  throw cms::Exception("LogicError",
-      //    "Mismatch in number of entries between extension and main table for " + m_collectionName);
-      //}
-    }
-    void print() const {
-      std::cout << "Collection: " << m_collectionName << " {\n";
-      m_main.print();
-      for (const auto& ext: m_extensions) {
-        ext.print();
-      }
-      std::cout << "}\n";
-    }
-    bool hasMainTable() {
-      return !m_main.getToken().isUninitialized();
-    }
-    const std::string& getCollectionName() const {
-      return m_collectionName;
-    }
+    void createFields(const edm::EventForOutput& event, RNTupleModel& eventModel);
+    void fill(const edm::EventForOutput& event);
+    void print() const;
+    bool hasMainTable();
+    const std::string& getCollectionName() const;
   private:
     std::string m_collectionName;
     std::shared_ptr<RCollectionNTuple> m_collection;
@@ -280,93 +119,14 @@ class TableCollection {
 
 class TableCollections {
   public:
-    void add(const edm::EDGetToken& table_token, const nanoaod::FlatTable& table) {
-      // skip empty tables -- requirement of RNTuple to define schema before filling
-      if (table.nColumns() == 0) {
-        std::cout << "Warning: skipping empty table: \n";
-        print_table(table);
-        return;
-      }
-      // Can handle either anonymous table or anonymous column but not both
-      // - anonymous table: use column names directly as top-level fields
-      // - anonymous column: use the table name as the field name
-      if (table.name().empty() && hasAnonymousColumn(table)) {
-        throw cms::Exception("LogicError", "Anonymous FlatTable and anonymous field");
-      }
-      // case 1: create a top-level RNTuple field for each table column
-      if (table.name().empty() || hasAnonymousColumn(table)) {
-        if (table.singleton()) {
-          m_singletonFields.emplace_back(TableOutputFields(table_token));
-        } else {
-          m_vectorFields.emplace_back(TableOutputVectorFields(table_token));
-        }
-        return;
-      }
-      // case 2: Named singleton and vector tables are both written as RNTuple collections.
-      auto collection = std::find_if(m_collections.begin(), m_collections.end(),
-        [&](const TableCollection& c) { return c.getCollectionName() == table.name(); });
-      if (collection == m_collections.end()) {
-        std::cout << "adding new collection: \n";
-        print_table(table);
-        m_collections.emplace_back(TableCollection());
-        m_collections.back().add(table_token, table);
-        return;
-      }
-      std::cout << "adding to existing collection : \n";
-      print_table(table);
-      collection->add(table_token, table);
-    }
-    void print() const {
-      for (const auto& collection: m_collections) {
-        collection.print();
-        std::cout << "\n";
-      }
-    }
-    void createFields(const edm::EventForOutput& event, RNTupleModel& eventModel) {
-      for (auto& collection: m_collections) {
-        if (!collection.hasMainTable()) {
-          throw cms::Exception("LogicError", "Trying to save an extension table for " +
-            collection.getCollectionName() + " without the corresponding main table\n");
-        }
-        collection.createFields(event, eventModel);
-      }
-      for (auto& table: m_singletonFields) {
-        table.createFields(event, eventModel);
-      }
-      for (auto& table: m_vectorFields) {
-        table.createFields(event, eventModel);
-      }
-    }
-    void fill(const edm::EventForOutput& event) {
-      for (auto& collection: m_collections) {
-        collection.fill(event);
-      }
-      for (auto& fields: m_singletonFields) {
-        edm::Handle<nanoaod::FlatTable> handle;
-        event.getByToken(fields.getToken(), handle);
-        const auto& table = *handle;
-        fields.fillEntry(table, 0);
-      }
-      for (auto& fields: m_vectorFields) {
-        fields.fill(event);
-      }
-    }
+    void add(const edm::EDGetToken& table_token, const nanoaod::FlatTable& table);
+    void createFields(const edm::EventForOutput& event, RNTupleModel& eventModel);
+    void fill(const edm::EventForOutput& event);
+    void print() const;
   private:
     // Returns true if the FlatTable has an anonymous column. Throws a cms::Exception
     // if there is more than one anonymous column.
-    static bool hasAnonymousColumn(const nanoaod::FlatTable& table) {
-      int num_anon = 0;
-      for (std::size_t i = 0; i < table.nColumns(); i++) {
-        if (table.columnName(i).empty()) {
-          num_anon++;
-        }
-      }
-      if (num_anon > 1) {
-        throw cms::Exception("LogicError", "FlatTable `" + table.name() +
-          "` has " + std::to_string(num_anon) + "anonymous fields");
-      }
-      return num_anon;
-    }
+    static bool hasAnonymousColumn(const nanoaod::FlatTable& table);
     std::vector<TableCollection> m_collections;
     std::vector<TableOutputFields> m_singletonFields;
     std::vector<TableOutputVectorFields> m_vectorFields;

--- a/PhysicsTools/NanoAOD/plugins/TableOutputFields.h
+++ b/PhysicsTools/NanoAOD/plugins/TableOutputFields.h
@@ -11,11 +11,11 @@
 
 #include <ROOT/RNTuple.hxx>
 #include <ROOT/RNTupleModel.hxx>
+using ROOT::Experimental::RCollectionNTuple;
 using ROOT::Experimental::RNTupleModel;
 using ROOT::Experimental::RNTupleWriter;
-using ROOT::Experimental::RCollectionNTuple;
 
-template<typename T>
+template <typename T>
 class FlatTableField {
 public:
   FlatTableField() = default;
@@ -36,8 +36,7 @@ public:
   void fill(const nanoaod::FlatTable& table, std::size_t i) {
     int col_idx = table.columnIndex(m_flatTableName);
     if (col_idx == -1) {
-      throw cms::Exception("LogicError", "Missing column in input for "
-        + table.name() + "_" + m_flatTableName);
+      throw cms::Exception("LogicError", "Missing column in input for " + table.name() + "_" + m_flatTableName);
     }
     m_field.fill(table.columnData<T>(col_idx)[i]);
   }
@@ -46,8 +45,7 @@ public:
   void fillVectored(const nanoaod::FlatTable& table) {
     int col_idx = table.columnIndex(m_flatTableName);
     if (col_idx == -1) {
-      throw cms::Exception("LogicError", "Missing column in input for "
-        + table.name() + "_" + m_flatTableName);
+      throw cms::Exception("LogicError", "Missing column in input for " + table.name() + "_" + m_flatTableName);
     }
     std::vector<typename T::value_type> buf(table.size());
     for (std::size_t i = 0; i < table.size(); i++) {
@@ -55,9 +53,8 @@ public:
     }
     m_field.fill(buf);
   }
-  const std::string& getFlatTableName() const {
-    return m_flatTableName;
-  }
+  const std::string& getFlatTableName() const { return m_flatTableName; }
+
 private:
   RNTupleFieldPtr<T> m_field;
   std::string m_flatTableName;
@@ -66,12 +63,12 @@ private:
 class TableOutputFields {
 public:
   TableOutputFields() = default;
-  explicit TableOutputFields(const edm::EDGetToken& token)
-        : m_token(token) {}
+  explicit TableOutputFields(const edm::EDGetToken& token) : m_token(token) {}
   void print() const;
   void createFields(const edm::EventForOutput& event, RNTupleModel& model);
   void fillEntry(const nanoaod::FlatTable& table, std::size_t i);
   const edm::EDGetToken& getToken() const;
+
 private:
   edm::EDGetToken m_token;
   std::vector<FlatTableField<float>> m_floatFields;
@@ -83,10 +80,10 @@ private:
 class TableOutputVectorFields {
 public:
   TableOutputVectorFields() = default;
-  explicit TableOutputVectorFields(const edm::EDGetToken& token)
-        : m_token(token) {}
+  explicit TableOutputVectorFields(const edm::EDGetToken& token) : m_token(token) {}
   void createFields(const edm::EventForOutput& event, RNTupleModel& model);
   void fill(const edm::EventForOutput& event);
+
 private:
   edm::EDGetToken m_token;
   std::vector<FlatTableField<std::vector<float>>> m_vfloatFields;
@@ -96,40 +93,42 @@ private:
 };
 
 class TableCollection {
-  public:
-    TableCollection() = default;
-    // Invariants:
-    // * table has a non-empty base name
-    // * table has at least one column
-    void add(const edm::EDGetToken& table_token, const nanoaod::FlatTable& table);
-    // Invariants:
-    // * m_main not null
-    // * m_collectionName not empty
-    void createFields(const edm::EventForOutput& event, RNTupleModel& eventModel);
-    void fill(const edm::EventForOutput& event);
-    void print() const;
-    bool hasMainTable();
-    const std::string& getCollectionName() const;
-  private:
-    std::string m_collectionName;
-    std::shared_ptr<RCollectionNTuple> m_collection;
-    TableOutputFields m_main;
-    std::vector<TableOutputFields> m_extensions;
+public:
+  TableCollection() = default;
+  // Invariants:
+  // * table has a non-empty base name
+  // * table has at least one column
+  void add(const edm::EDGetToken& table_token, const nanoaod::FlatTable& table);
+  // Invariants:
+  // * m_main not null
+  // * m_collectionName not empty
+  void createFields(const edm::EventForOutput& event, RNTupleModel& eventModel);
+  void fill(const edm::EventForOutput& event);
+  void print() const;
+  bool hasMainTable();
+  const std::string& getCollectionName() const;
+
+private:
+  std::string m_collectionName;
+  std::shared_ptr<RCollectionNTuple> m_collection;
+  TableOutputFields m_main;
+  std::vector<TableOutputFields> m_extensions;
 };
 
 class TableCollectionSet {
-  public:
-    void add(const edm::EDGetToken& table_token, const nanoaod::FlatTable& table);
-    void createFields(const edm::EventForOutput& event, RNTupleModel& eventModel);
-    void fill(const edm::EventForOutput& event);
-    void print() const;
-  private:
-    // Returns true if the FlatTable has an anonymous column. Throws a cms::Exception
-    // if there is more than one anonymous column.
-    static bool hasAnonymousColumn(const nanoaod::FlatTable& table);
-    std::vector<TableCollection> m_collections;
-    std::vector<TableOutputFields> m_singletonFields;
-    std::vector<TableOutputVectorFields> m_vectorFields;
+public:
+  void add(const edm::EDGetToken& table_token, const nanoaod::FlatTable& table);
+  void createFields(const edm::EventForOutput& event, RNTupleModel& eventModel);
+  void fill(const edm::EventForOutput& event);
+  void print() const;
+
+private:
+  // Returns true if the FlatTable has an anonymous column. Throws a cms::Exception
+  // if there is more than one anonymous column.
+  static bool hasAnonymousColumn(const nanoaod::FlatTable& table);
+  std::vector<TableCollection> m_collections;
+  std::vector<TableOutputFields> m_singletonFields;
+  std::vector<TableOutputVectorFields> m_vectorFields;
 };
 
 #endif

--- a/PhysicsTools/NanoAOD/plugins/TableOutputFields.h
+++ b/PhysicsTools/NanoAOD/plugins/TableOutputFields.h
@@ -23,14 +23,14 @@ public:
     m_flatTableName = table.columnName(i);
     // case 1: field has a name (table may or may not have a name)
     if (!table.columnName(i).empty()) {
-      m_field = RNTupleFieldPtr<T>(table.columnName(i), model);
+      m_field = RNTupleFieldPtr<T>(table.columnName(i), table.columnDoc(i), model);
       return;
     }
     // case 2: field doesn't have a name: use the table name as the RNTuple field name
     if (table.name().empty()) {
       throw cms::Exception("LogicError", "Empty FlatTable name and field name");
     }
-    m_field = RNTupleFieldPtr<T>(table.name(), model);
+    m_field = RNTupleFieldPtr<T>(table.name(), table.doc(), model);
   }
   // For collection fields and singleton fields
   void fill(const nanoaod::FlatTable& table, std::size_t i) {

--- a/PhysicsTools/NanoAOD/plugins/TableOutputFields.h
+++ b/PhysicsTools/NanoAOD/plugins/TableOutputFields.h
@@ -117,7 +117,7 @@ class TableCollection {
     std::vector<TableOutputFields> m_extensions;
 };
 
-class TableCollections {
+class TableCollectionSet {
   public:
     void add(const edm::EDGetToken& table_token, const nanoaod::FlatTable& table);
     void createFields(const edm::EventForOutput& event, RNTupleModel& eventModel);

--- a/PhysicsTools/NanoAOD/plugins/TableOutputFields.h
+++ b/PhysicsTools/NanoAOD/plugins/TableOutputFields.h
@@ -11,7 +11,7 @@
 
 #include <ROOT/RNTuple.hxx>
 #include <ROOT/RNTupleModel.hxx>
-using ROOT::Experimental::RCollectionNTuple;
+using ROOT::Experimental::RCollectionNTupleWriter;
 using ROOT::Experimental::RNTupleModel;
 using ROOT::Experimental::RNTupleWriter;
 
@@ -110,7 +110,7 @@ public:
 
 private:
   std::string m_collectionName;
-  std::shared_ptr<RCollectionNTuple> m_collection;
+  std::shared_ptr<RCollectionNTupleWriter> m_collection;
   TableOutputFields m_main;
   std::vector<TableOutputFields> m_extensions;
 };

--- a/PhysicsTools/NanoAOD/plugins/TableOutputFields.h
+++ b/PhysicsTools/NanoAOD/plugins/TableOutputFields.h
@@ -1,0 +1,266 @@
+#include "DataFormats/NanoAOD/interface/FlatTable.h"
+#include "FWCore/Utilities/interface/EDGetToken.h"
+
+#include <algorithm>
+
+#include <ROOT/RNTuple.hxx>
+#include <ROOT/RNTupleModel.hxx>
+using ROOT::Experimental::RNTupleModel;
+using ROOT::Experimental::RNTupleWriter;
+using ROOT::Experimental::RCollectionNTuple;
+
+void print_table(const nanoaod::FlatTable& table) {
+  std::cout << "FlatTable {\n";
+  std::cout << "  name: " << (table.name().empty() ? "// anon" : table.name()) << "\n";
+  std::cout << "  singleton: " << (table.singleton() ? "true" : "false") << "\n";
+  std::cout << "  size: " << table.size() << "\n";
+  std::cout << "  extension: " << (table.extension() ? "true" : "false") << "\n";
+  std::cout << "  fields: {\n";
+  for (std::size_t i = 0; i < table.nColumns(); i++) {
+    std::cout << "    " << (table.columnName(i).empty() ? "// anon" : table.columnName(i)) << ": ";
+    switch(table.columnType(i)) {
+      case nanoaod::FlatTable::ColumnType::Float:
+        std::cout << "f32,"; break;
+      case nanoaod::FlatTable::ColumnType::Int:
+        std::cout << "i32,"; break;
+      case nanoaod::FlatTable::ColumnType::UInt8:
+        std::cout << "u8,"; break;
+      case nanoaod::FlatTable::ColumnType::Bool:
+        std::cout << "bool,"; break;
+      default:
+        throw cms::Exception("LogicError", "Unsupported type");
+    }
+    std::cout << "\n";
+  }
+  std::cout << "  }\n}\n";
+}
+
+template <typename T>
+class RNTupleFieldPtr {
+public:
+  explicit RNTupleFieldPtr(const std::string& name, RNTupleModel& model)
+      : m_name(name)
+  {
+    m_field = model.MakeField<T>(m_name);
+  }
+  void fillEntry(const nanoaod::FlatTable table, std::size_t i) {
+    int col_idx = table.columnIndex(m_name);
+    if (col_idx == -1) {
+      // todo rntuple naming?
+      throw cms::Exception("LogicError", "Missing column in input for " + table.name() + "_" + m_name);
+    }
+    *m_field = table.columnData<T>(col_idx)[i];
+  }
+  const std::string& getFieldName() const {
+    return m_name;
+  }
+private:
+  std::string m_name;
+  std::shared_ptr<T> m_field;
+};
+
+class TableOutputFields {
+public:
+  TableOutputFields() = default;
+  explicit TableOutputFields(const edm::EDGetToken& token) //, const nanoaod::FlatTable& table)
+        : m_token(token)
+  {
+
+  }
+  void print() const {
+    for (const auto& field: m_floatFields) {
+      std::cout << "  " << field.getFieldName() << ": f32,\n";
+    }
+    for (const auto& field: m_intFields) {
+      std::cout << "  " << field.getFieldName() << ": i32,\n";
+    }
+    for (const auto& field: m_uint8Fields) {
+      std::cout << "  " << field.getFieldName() << ": u8,\n";
+    }
+    for (const auto& field: m_boolFields) {
+      std::cout << "  " << field.getFieldName() << ": bool,\n";
+    }
+  }
+  void createFields(const edm::EventForOutput& event, RNTupleModel& model) {
+    edm::Handle<nanoaod::FlatTable> handle;
+    event.getByToken(m_token, handle);
+    const nanoaod::FlatTable& table = *handle;
+    for (std::size_t i = 0; i < table.nColumns(); i++) {
+      switch(table.columnType(i)) {
+        case nanoaod::FlatTable::ColumnType::Float:
+          m_floatFields.emplace_back(RNTupleFieldPtr<float>(table.columnName(i), model)); break;
+        case nanoaod::FlatTable::ColumnType::Int:
+          m_intFields.emplace_back(RNTupleFieldPtr<int>(table.columnName(i), model)); break;
+        case nanoaod::FlatTable::ColumnType::UInt8:
+          m_uint8Fields.emplace_back(RNTupleFieldPtr<std::uint8_t>(table.columnName(i), model)); break;
+        case nanoaod::FlatTable::ColumnType::Bool:
+          m_boolFields.emplace_back(RNTupleFieldPtr<bool>(table.columnName(i), model)); break;
+        default:
+          throw cms::Exception("LogicError", "Unsupported type");
+      }
+    }
+  }
+  void fillEntry(const nanoaod::FlatTable& table, std::size_t i) {
+    for (auto& field: m_floatFields) {
+      field.fillEntry(table, i);
+    }
+    for (auto& field: m_intFields) {
+      field.fillEntry(table, i);
+    }
+    for (auto& field: m_uint8Fields) {
+      field.fillEntry(table, i);
+    }
+    for (auto& field: m_boolFields) {
+      field.fillEntry(table, i);
+    }
+  }
+  const edm::EDGetToken& getToken() const {
+    return m_token;
+  }
+
+private:
+  edm::EDGetToken m_token;
+  std::vector<RNTupleFieldPtr<float>> m_floatFields;
+  std::vector<RNTupleFieldPtr<int>> m_intFields;
+  std::vector<RNTupleFieldPtr<std::uint8_t>> m_uint8Fields;
+  std::vector<RNTupleFieldPtr<bool>> m_boolFields;
+};
+
+class TableCollection {
+  public:
+    TableCollection() = default;
+    // invariants:
+    // * table has a non-empty base name
+    // * table has at least one column
+    void add(const edm::EDGetToken& table_token, const nanoaod::FlatTable& table) {
+      if (m_collectionName.empty()) {
+        m_collectionName = table.name();
+        // TODO ensure this isn't moved from twice?
+      }
+      if (table.extension()) {
+        m_extensions.emplace_back(TableOutputFields(table_token));
+        return;
+      }
+      if (hasMainTable()) {
+        throw cms::Exception("LogicError", "Trying to save multiple main tables for " + m_collectionName + "\n");
+     }
+      m_main = TableOutputFields(table_token);
+    }
+    // Invariants:
+    // * m_main not null
+    // * m_collectionName not empty
+    void createFields(const edm::EventForOutput& event, RNTupleModel& eventModel) {
+      auto collectionModel = RNTupleModel::Create();
+      m_main.createFields(event, *collectionModel);
+      for (auto& extension: m_extensions) {
+        extension.createFields(event, *collectionModel);
+      }
+      m_collection = eventModel.MakeCollection(m_collectionName, std::move(collectionModel));
+    }
+    void fill(const edm::EventForOutput& event) {
+      edm::Handle<nanoaod::FlatTable> handle;
+      event.getByToken(m_main.getToken(), handle);
+      const auto& main_table = *handle;
+      auto table_size = main_table.size();
+      // todo check table sizes
+      for (std::size_t i = 0; i < table_size; i++) {
+        m_main.fillEntry(main_table, i);
+        for (auto& ext: m_extensions) {
+          edm::Handle<nanoaod::FlatTable> handle;
+          event.getByToken(ext.getToken(), handle);
+          const auto& ext_table = *handle;
+          ext.fillEntry(ext_table, i);
+        }
+        m_collection->Fill();
+      }
+      //if (num_fill != num_fill_ext) {
+      //  throw cms::Exception("LogicError",
+      //    "Mismatch in number of entries between extension and main table for " + m_collectionName);
+      //}
+    }
+    void print() const {
+      std::cout << "Collection: " << m_collectionName << " {\n";
+      m_main.print();
+      for (const auto& ext: m_extensions) {
+        ext.print();
+      }
+      std::cout << "}\n";
+    }
+    bool hasMainTable() {
+      return !m_main.getToken().isUninitialized();
+    }
+    const std::string& getCollectionName() const {
+      return m_collectionName;
+    }
+  private:
+    std::string m_collectionName;
+    std::shared_ptr<RCollectionNTuple> m_collection;
+    TableOutputFields m_main;
+    std::vector<TableOutputFields> m_extensions;
+};
+
+class TableCollections {
+  public:
+    void add(const edm::EDGetToken& table_token, const nanoaod::FlatTable& table) {
+      // skip empty tables -- requirement of RNTuple to define schema before filling
+      if (table.nColumns() == 0) {
+        std::cout << "Warning: skipping empty table: \n";
+        print_table(table);
+        return;
+      }
+      // skip anonymous tables for now
+      // TODO add to m_topLevelFields;
+      if (table.name().empty()) {
+        std::cout << "skipping anonymous table:\n";
+        print_table(table);
+        return;
+      }
+      // skip tables with anonymous fields for now
+      // TODO add to m_topLevelFields;
+      for (std::size_t i = 0; i < table.nColumns(); i++) {
+        auto col_name = table.columnName(i).empty() ? "// anon" : table.columnName(i);
+        if (table.columnName(i).empty()) {
+          std::cout << "skipping table with anonymous fields:\n";
+          print_table(table);
+          return;
+        }
+      }
+      auto collection = std::find_if(m_collections.begin(), m_collections.end(),
+        [&](const TableCollection& c) { return c.getCollectionName() == table.name(); });
+      if (collection == m_collections.end()) {
+        std::cout << "adding new collection: \n";
+        print_table(table);
+        m_collections.emplace_back(TableCollection());
+        m_collections.back().add(table_token, table);
+        return;
+      }
+      std::cout << "adding to existing collection : \n";
+      print_table(table);
+      collection->add(table_token, table);
+    }
+    void print() const {
+      for (const auto& collection: m_collections) {
+        collection.print();
+        std::cout << "\n";
+      }
+    }
+    void createFields(const edm::EventForOutput& event, RNTupleModel& eventModel) {
+      for (auto& collection: m_collections) {
+        if (!collection.hasMainTable()) {
+          throw cms::Exception("LogicError", "Trying to save an extension table for " +
+            collection.getCollectionName() + " without the corresponding main table\n");
+        }
+        collection.createFields(event, eventModel);
+      }
+      // todo top-level fields
+    }
+    void fill(const edm::EventForOutput& event) {
+      for (auto& collection: m_collections) {
+        collection.fill(event);
+      }
+      // todo top-level fields
+    }
+  private:
+    std::vector<TableCollection> m_collections;
+    std::vector<TableOutputFields> m_topLevelFields;
+};

--- a/PhysicsTools/NanoAOD/plugins/TriggerOutputFields.cc
+++ b/PhysicsTools/NanoAOD/plugins/TriggerOutputFields.cc
@@ -1,0 +1,95 @@
+#include "TriggerOutputFields.h"
+
+#include "RNTupleFieldPtr.h"
+
+#include "DataFormats/Common/interface/TriggerResults.h"
+#include "FWCore/Common/interface/TriggerNames.h"
+#include "FWCore/Framework/interface/EventForOutput.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/Registry.h"
+#include "FWCore/Utilities/interface/EDGetToken.h"
+#include "FWCore/Utilities/interface/Exception.h"
+
+namespace {
+
+void trim_version_suffix(std::string& trigger_name) {
+  // HLT and L1 triggers have version suffixes we trim before filling the RNTuple
+  if (trigger_name.compare(0, 3, "HLT") != 0 && trigger_name.compare(0, 2, "L1") != 0) {
+    return;
+  }
+  auto vfound = trigger_name.rfind("_v");
+  if (vfound == std::string::npos) {
+    return;
+  }
+  trigger_name.replace(vfound, trigger_name.size() - vfound, "");
+}
+
+bool is_nanoaod_trigger(const std::string& name) {
+  return name.compare(0, 3, "HLT") == 0 || name.compare(0, 4, "Flag") == 0
+    || name.compare(0, 2, "L1") == 0;
+}
+
+} // anonymous namespace
+
+std::vector<std::string> TriggerOutputFields::getTriggerNames(
+  const edm::TriggerResults& triggerResults)
+{
+  edm::pset::Registry* psetRegistry = edm::pset::Registry::instance();
+  edm::ParameterSet const* pset = psetRegistry->getMapped(triggerResults.parameterSetID());
+  if (nullptr == pset || !pset->existsAs<std::vector<std::string>>("@trigger_paths", true)) {
+    return {};
+  }
+  edm::TriggerNames names(*pset);
+  if (names.size() != triggerResults.size()) {
+    throw cms::Exception("LogicError") << "TriggerOutputFields::getTriggerNames "
+      "Encountered vector\n of trigger names and a TriggerResults object with\n"
+      "different sizes.  This should be impossible.\n"
+      "Please send information to reproduce this problem to\nthe edm developers.\n";
+  }
+  return names.triggerNames();
+}
+
+void TriggerOutputFields::createFields(const edm::EventForOutput& event, RNTupleModel& model) {
+  m_lastRun = event.id().run();
+  edm::Handle<edm::TriggerResults> handle;
+  event.getByToken(m_token, handle);
+  // TODO check if handle is valid?
+  const edm::TriggerResults& triggerResults = *handle;
+  std::vector<std::string> triggerNames(TriggerOutputFields::getTriggerNames(triggerResults));
+  m_triggerFields.reserve(triggerNames.size());
+  for (std::size_t i = 0; i < triggerNames.size(); i++) {
+    auto& name = triggerNames[i];
+    if (!is_nanoaod_trigger(name)) {
+      continue;
+    }
+    trim_version_suffix(name);
+    makeUniqueFieldName(model, name);
+    m_triggerFields.emplace_back(RNTupleFieldPtr<bool>(name, model));
+    m_triggerFieldIndices.push_back(i);
+  }
+}
+
+void TriggerOutputFields::makeUniqueFieldName(RNTupleModel& model, std::string& name) {
+  // fix with cache of names in a higher-level object, don't ask the RNTupleModel each time
+  const auto* existing_field = model.Get<bool>(name);
+  if (!existing_field) {
+    return;
+  }
+  edm::LogWarning("TriggerOutputFields") << "Found a branch with name " << name
+    << " already present. Will add suffix _p" << m_processName << " to the new branch.\n";
+  name += std::string("_p") + m_processName;
+}
+
+void TriggerOutputFields::fill(const edm::EventForOutput& event) {
+  if (m_lastRun != event.id().run()) {
+    std::cout << "skipping trigger output from run " << event.id().run() << "\n";
+    return;
+  }
+  edm::Handle<edm::TriggerResults> handle;
+  event.getByToken(m_token, handle);
+  const edm::TriggerResults& triggers = *handle;
+  for (std::size_t i = 0; i < m_triggerFields.size(); i++) {
+    m_triggerFields[i].fill(triggers.accept(m_triggerFieldIndices.at(i)));
+  }
+}

--- a/PhysicsTools/NanoAOD/plugins/TriggerOutputFields.cc
+++ b/PhysicsTools/NanoAOD/plugins/TriggerOutputFields.cc
@@ -35,6 +35,12 @@ bool is_nanoaod_trigger(const std::string& name) {
 std::vector<std::string> TriggerOutputFields::getTriggerNames(
   const edm::TriggerResults& triggerResults)
 {
+  // Trigger names are either stored in the TriggerResults object (e.g. L1) or
+  // need to be looked up in the registry (e.g. HLT)
+  auto triggerNames = triggerResults.getTriggerNames();
+  if (!triggerNames.empty()) {
+    return triggerNames;
+  }
   edm::pset::Registry* psetRegistry = edm::pset::Registry::instance();
   edm::ParameterSet const* pset = psetRegistry->getMapped(triggerResults.parameterSetID());
   if (nullptr == pset || !pset->existsAs<std::vector<std::string>>("@trigger_paths", true)) {

--- a/PhysicsTools/NanoAOD/plugins/TriggerOutputFields.cc
+++ b/PhysicsTools/NanoAOD/plugins/TriggerOutputFields.cc
@@ -33,9 +33,10 @@ namespace {
 
 }  // anonymous namespace
 
-TriggerFieldPtr::TriggerFieldPtr(std::string name, int index, std::string fieldName, RNTupleModel& model)
+TriggerFieldPtr::TriggerFieldPtr(
+    std::string name, int index, std::string fieldName, std::string fieldDesc, RNTupleModel& model)
     : m_triggerName(name), m_triggerIndex(index) {
-  m_field = RNTupleFieldPtr<bool>(fieldName, model);
+  m_field = RNTupleFieldPtr<bool>(fieldName, fieldDesc, model);
 }
 
 void TriggerFieldPtr::fill(const edm::TriggerResults& triggers) {
@@ -82,7 +83,8 @@ void TriggerOutputFields::createFields(const edm::EventForOutput& event, RNTuple
     trimVersionSuffix(name);
     std::string modelName = name;
     makeUniqueFieldName(model, modelName);
-    m_triggerFields.emplace_back(TriggerFieldPtr(name, i, modelName, model));
+    std::string desc = std::string("Trigger/flag bit (process: ") + m_processName + ")";
+    m_triggerFields.emplace_back(TriggerFieldPtr(name, i, modelName, desc, model));
   }
 }
 

--- a/PhysicsTools/NanoAOD/plugins/TriggerOutputFields.cc
+++ b/PhysicsTools/NanoAOD/plugins/TriggerOutputFields.cc
@@ -80,7 +80,6 @@ void TriggerOutputFields::createFields(const edm::EventForOutput& event, RNTuple
   m_triggerFields.reserve(triggerNames.size());
   for (std::size_t i = 0; i < triggerNames.size(); i++) {
     auto& name = triggerNames[i];
-    std::cout << name << "\n";
     if (!is_nanoaod_trigger(name)) {
       continue;
     }

--- a/PhysicsTools/NanoAOD/plugins/TriggerOutputFields.cc
+++ b/PhysicsTools/NanoAOD/plugins/TriggerOutputFields.cc
@@ -15,7 +15,7 @@
 
 namespace {
 
-void trim_version_suffix(std::string& trigger_name) {
+void trimVersionSuffix(std::string& trigger_name) {
   // HLT and L1 triggers have version suffixes we trim before filling the RNTuple
   if (trigger_name.compare(0, 3, "HLT") != 0 && trigger_name.compare(0, 2, "L1") != 0) {
     return;
@@ -27,7 +27,7 @@ void trim_version_suffix(std::string& trigger_name) {
   trigger_name.replace(vfound, trigger_name.size() - vfound, "");
 }
 
-bool is_nanoaod_trigger(const std::string& name) {
+bool isNanoaodTrigger(const std::string& name) {
   return name.compare(0, 3, "HLT") == 0 || name.compare(0, 4, "Flag") == 0
     || name.compare(0, 2, "L1") == 0;
 }
@@ -80,10 +80,10 @@ void TriggerOutputFields::createFields(const edm::EventForOutput& event, RNTuple
   m_triggerFields.reserve(triggerNames.size());
   for (std::size_t i = 0; i < triggerNames.size(); i++) {
     auto& name = triggerNames[i];
-    if (!is_nanoaod_trigger(name)) {
+    if (!isNanoaodTrigger(name)) {
       continue;
     }
-    trim_version_suffix(name);
+    trimVersionSuffix(name);
     std::string modelName = name;
     makeUniqueFieldName(model, modelName);
     m_triggerFields.emplace_back(TriggerFieldPtr(name, i, modelName, model));
@@ -98,10 +98,10 @@ void TriggerOutputFields::updateTriggerFields(const edm::TriggerResults& trigger
     t.setIndex(-1);
     for (std::size_t j = 0; j < newNames.size(); j++) {
       auto& name = newNames[j];
-      if (!is_nanoaod_trigger(name)) {
+      if (!isNanoaodTrigger(name)) {
         continue;
       }
-      trim_version_suffix(name);
+      trimVersionSuffix(name);
       if (name == t.getTriggerName()) {
         t.setIndex(j);
       }
@@ -110,10 +110,10 @@ void TriggerOutputFields::updateTriggerFields(const edm::TriggerResults& trigger
   // find new triggers
   for (std::size_t j = 0; j < newNames.size(); j++) {
     auto& name = newNames[j];
-    if (!is_nanoaod_trigger(name)) {
+    if (!isNanoaodTrigger(name)) {
       continue;
     }
-    trim_version_suffix(name);
+    trimVersionSuffix(name);
     if (std::none_of(m_triggerFields.cbegin(), m_triggerFields.cend(),
       [&](const TriggerFieldPtr& t) { return t.getTriggerName() == name; }))
     {

--- a/PhysicsTools/NanoAOD/plugins/TriggerOutputFields.h
+++ b/PhysicsTools/NanoAOD/plugins/TriggerOutputFields.h
@@ -10,6 +10,24 @@ namespace edm {
   class TriggerResults;
 }
 
+class TriggerFieldPtr {
+public:
+  TriggerFieldPtr() = default;
+  TriggerFieldPtr(std::string name, int index, std::string fieldName, RNTupleModel& model);
+  void fill(const edm::TriggerResults& triggers);
+  const std::string& getTriggerName() const {
+    return m_triggerName;
+  }
+  void setIndex(int newIndex) {
+    m_triggerIndex = newIndex;
+  }
+private:
+  RNTupleFieldPtr<bool> m_field;
+  // The trigger results name extracted from the TriggerResults with version suffixes trimmed
+  std::string m_triggerName;
+  int m_triggerIndex = -1;
+};
+
 class TriggerOutputFields {
 public:
   TriggerOutputFields() = default;
@@ -20,13 +38,14 @@ public:
 
 private:
   static std::vector<std::string> getTriggerNames(const edm::TriggerResults& triggerResults);
+  // Update trigger field information on run boundaries
+  void updateTriggerFields(const edm::TriggerResults& triggerResults);
   void makeUniqueFieldName(/*const*/ RNTupleModel& model, std::string& name);
 
   edm::EDGetToken m_token;
   long m_lastRun;
   std::string m_processName;
-  std::vector<RNTupleFieldPtr<bool>> m_triggerFields;
-  std::vector<int> m_triggerFieldIndices;
+  std::vector<TriggerFieldPtr> m_triggerFields;
 };
 
 #endif

--- a/PhysicsTools/NanoAOD/plugins/TriggerOutputFields.h
+++ b/PhysicsTools/NanoAOD/plugins/TriggerOutputFields.h
@@ -1,0 +1,32 @@
+#ifndef PhysicsTools_NanoAOD_TriggerOutputFields_h
+#define PhysicsTools_NanoAOD_TriggerOutputFields_h
+
+#include "RNTupleFieldPtr.h"
+
+#include "FWCore/Utilities/interface/EDGetToken.h"
+
+namespace edm {
+  class EventForOutput;
+  class TriggerResults;
+}
+
+class TriggerOutputFields {
+public:
+  TriggerOutputFields() = default;
+  explicit TriggerOutputFields(const std::string& processName, const edm::EDGetToken &token)
+      : m_token(token), m_lastRun(-1), m_processName(processName) {}
+  void createFields(const edm::EventForOutput& event, RNTupleModel& model);
+  void fill(const edm::EventForOutput& event);
+
+private:
+  static std::vector<std::string> getTriggerNames(const edm::TriggerResults& triggerResults);
+  void makeUniqueFieldName(/*const*/ RNTupleModel& model, std::string& name);
+
+  edm::EDGetToken m_token;
+  long m_lastRun;
+  std::string m_processName;
+  std::vector<RNTupleFieldPtr<bool>> m_triggerFields;
+  std::vector<int> m_triggerFieldIndices;
+};
+
+#endif

--- a/PhysicsTools/NanoAOD/plugins/TriggerOutputFields.h
+++ b/PhysicsTools/NanoAOD/plugins/TriggerOutputFields.h
@@ -8,19 +8,16 @@
 namespace edm {
   class EventForOutput;
   class TriggerResults;
-}
+}  // namespace edm
 
 class TriggerFieldPtr {
 public:
   TriggerFieldPtr() = default;
   TriggerFieldPtr(std::string name, int index, std::string fieldName, RNTupleModel& model);
   void fill(const edm::TriggerResults& triggers);
-  const std::string& getTriggerName() const {
-    return m_triggerName;
-  }
-  void setIndex(int newIndex) {
-    m_triggerIndex = newIndex;
-  }
+  const std::string& getTriggerName() const { return m_triggerName; }
+  void setIndex(int newIndex) { m_triggerIndex = newIndex; }
+
 private:
   RNTupleFieldPtr<bool> m_field;
   // The trigger results name extracted from the TriggerResults with version suffixes trimmed
@@ -31,7 +28,7 @@ private:
 class TriggerOutputFields {
 public:
   TriggerOutputFields() = default;
-  explicit TriggerOutputFields(const std::string& processName, const edm::EDGetToken &token)
+  explicit TriggerOutputFields(const std::string& processName, const edm::EDGetToken& token)
       : m_token(token), m_lastRun(-1), m_processName(processName) {}
   void createFields(const edm::EventForOutput& event, RNTupleModel& model);
   void fill(const edm::EventForOutput& event);

--- a/PhysicsTools/NanoAOD/plugins/TriggerOutputFields.h
+++ b/PhysicsTools/NanoAOD/plugins/TriggerOutputFields.h
@@ -13,7 +13,7 @@ namespace edm {
 class TriggerFieldPtr {
 public:
   TriggerFieldPtr() = default;
-  TriggerFieldPtr(std::string name, int index, std::string fieldName, RNTupleModel& model);
+  TriggerFieldPtr(std::string name, int index, std::string fieldName, std::string fieldDesc, RNTupleModel& model);
   void fill(const edm::TriggerResults& triggers);
   const std::string& getTriggerName() const { return m_triggerName; }
   void setIndex(int newIndex) { m_triggerIndex = newIndex; }


### PR DESCRIPTION
#### PR description:
This PR adds a new output module that generates ROOT RNTuple NanoAODs. The new 
module is based on the existing `TTree` output module class `NanoAODOutputModule`. 

Because of the RNTuple dependency, the module will likely only be functional
in the ROOT6 master integration branches.

The new module is a prototype and is missing some features. In particular, backfilling, 
(creating new branches as required and adding them to the output file) is not yet 
supported. The new module also requires unit tests. Some preliminary verification tests have
been conducted against the existing output module comparing `Events` tree output data.

We have tried to adhere as much as possible to the TTree module conventions 
but there are some differences. For example, collections are a first-class concept 
in RNTuple. Instead of requiring the user to define a separate branch `nElectron` 
for the Electron collection, and having branches named `Electron_charge`, the RNTuple
analogue is to create an Electron collection directly and access fields through dot
notation (`Electron.charge`). An alias mechanism for branch name discrepancies is 
envisioned to avoid disrupting analysis workflows.

Note: RNTuple currently prints a stability warning when writing to disk, which was treated
as a fatal error when running `cmsRun` configuration scripts. The current workaround is to 
disable the ROOT error handler in the configuration script:
```python
process.add_(cms.Service("InitRootHandlers", ResetRootErrHandler = cms.untracked.bool(False))) 
```

There is more information about this project here: 
https://iris-hep.org/assets/pdf/Max_Orok_proposal.pdf
Review comments are greatly appreciated.

cc @jblomer, @dan131riley
