### PR TITLE
Including jetId criteria for UL16 

### DIFF
--- a/PhysicsTools/NanoAOD/python/jets_cff.py
+++ b/PhysicsTools/NanoAOD/python/jets_cff.py
@@ -70,6 +70,8 @@ tightJetIdLepVeto = cms.EDProducer("PatJetIDValueMapProducer",
 			  ),
                           src = cms.InputTag("updatedJets")
 )
+run2_jme_2016.toModify( tightJetId.filterParams, version = "RUN2UL16CHS" )
+run2_jme_2016.toModify( tightJetIdLepVeto.filterParams, version = "RUN2UL16CHS" )
 for modifier in run2_miniAOD_80XLegacy, run2_nanoAOD_94X2016:
   modifier.toModify( tightJetId.filterParams, version = "WINTER16" )
   modifier.toModify( tightJetIdLepVeto.filterParams, version = "WINTER16" )
@@ -101,6 +103,8 @@ tightJetIdLepVetoAK8 = cms.EDProducer("PatJetIDValueMapProducer",
 			  ),
                           src = cms.InputTag("updatedJetsAK8")
 )
+run2_jme_2016.toModify( tightJetIdAK8.filterParams, version = "RUN2UL16PUPPI" )
+run2_jme_2016.toModify( tightJetIdLepVetoAK8.filterParams, version = "RUN2UL16PUPPI" )
 for modifier in run2_miniAOD_80XLegacy, run2_nanoAOD_94X2016:
   modifier.toModify( tightJetIdAK8.filterParams, version = "WINTER16" )
   modifier.toModify( tightJetIdLepVetoAK8.filterParams, version = "WINTER16" )

--- a/PhysicsTools/SelectorUtils/interface/PFJetIDSelectionFunctor.h
+++ b/PhysicsTools/SelectorUtils/interface/PFJetIDSelectionFunctor.h
@@ -675,6 +675,9 @@ public:  // interface
         if (ignoreCut(indexMUF_TR_) ||
             (muf < cut(indexMUF_TR_, double()) || std::abs(jet.eta()) <= 2.6 || std::abs(jet.eta()) > 2.7))
           passCut(ret, indexMUF_TR_);
+        if (ignoreCut(indexCEF_TR_) ||
+            (cef < cut(indexCEF_TR_, double()) || std::abs(jet.eta()) <= 2.6 || std::abs(jet.eta()) > 2.7))
+          passCut(ret, indexCEF_TR_);
       }
 
       // Cuts for 2.7 < |eta| <= 3.0 for SUMMER18 scenario
@@ -722,6 +725,9 @@ public:  // interface
         if (ignoreCut(indexMUF_TR_) ||
             (muf < cut(indexMUF_TR_, double()) || std::abs(jet.eta()) <= 2.6 || std::abs(jet.eta()) > 2.7))
           passCut(ret, indexMUF_TR_);
+        if (ignoreCut(indexCEF_TR_) ||
+            (cef < cut(indexCEF_TR_, double()) || std::abs(jet.eta()) <= 2.6 || std::abs(jet.eta()) > 2.7))
+          passCut(ret, indexCEF_TR_);
       }
 
       // Cuts for 2.7 < |eta| <= 3.0 for SUMMER18PUPPI scenario

--- a/PhysicsTools/SelectorUtils/interface/PFJetIDSelectionFunctor.h
+++ b/PhysicsTools/SelectorUtils/interface/PFJetIDSelectionFunctor.h
@@ -564,6 +564,89 @@ public:  // interface
       if (ignoreCut(indexNNeutrals_FW_U_) ||
           (nneutrals < cut(indexNNeutrals_FW_U_, int()) || std::abs(jet.eta()) <= 3.0))
         passCut(ret, indexNNeutrals_FW_U_);
+
+    } else if (version_ == RUN2UL16CHS) {
+      // Cuts for |eta| <= 2.4 for RUN2UL16CHS scenario
+      if (ignoreCut(indexNConstituents_) ||
+          (nconstituents > cut(indexNConstituents_, int()) || std::abs(jet.eta()) > 2.4))
+        passCut(ret, indexNConstituents_);
+      if (ignoreCut(indexNEF_) || (nef < cut(indexNEF_, double()) || std::abs(jet.eta()) > 2.4))
+        passCut(ret, indexNEF_);
+      if (ignoreCut(indexNHF_) || (nhf < cut(indexNHF_, double()) || std::abs(jet.eta()) > 2.4))
+        passCut(ret, indexNHF_);
+      if (quality_ == TIGHTLEPVETO) {
+        if (ignoreCut(indexMUF_) || (muf < cut(indexMUF_, double()) || std::abs(jet.eta()) > 2.4))
+          passCut(ret, indexMUF_);
+      }
+
+      // Cuts for 2.4 <= |eta| <= 2.7 for RUN2UL16CHS scenario
+      if (ignoreCut(indexNHF_TR_) ||
+          (nhf < cut(indexNHF_TR_, double()) || std::abs(jet.eta()) <= 2.4 || std::abs(jet.eta()) > 2.7))
+        passCut(ret, indexNHF_TR_);
+      if (ignoreCut(indexNEF_TR_) ||
+          (nef < cut(indexNEF_TR_, double()) || std::abs(jet.eta()) <= 2.4 || std::abs(jet.eta()) > 2.7))
+        passCut(ret, indexNEF_TR_);
+
+      // Cuts for 2.7 < |eta| <= 3.0 for RUN2UL16CHS scenario
+      if (ignoreCut(indexNHF_EC_) ||
+          (nhf < cut(indexNHF_EC_, double()) || std::abs(jet.eta()) <= 2.7 || std::abs(jet.eta()) > 3.0))
+        passCut(ret, indexNHF_EC_);
+      if (ignoreCut(indexNEF_EC_L_) ||
+          (nef > cut(indexNEF_EC_L_, double()) || std::abs(jet.eta()) <= 2.7 || std::abs(jet.eta()) > 3.0))
+        passCut(ret, indexNEF_EC_L_);
+      if (ignoreCut(indexNEF_EC_U_) ||
+          (nef < cut(indexNEF_EC_U_, double()) || std::abs(jet.eta()) <= 2.7 || std::abs(jet.eta()) > 3.0))
+        passCut(ret, indexNEF_EC_U_);
+      if (ignoreCut(indexNNeutrals_EC_) ||
+          (nneutrals > cut(indexNNeutrals_EC_, int()) || std::abs(jet.eta()) <= 2.7 || std::abs(jet.eta()) > 3.0))
+        passCut(ret, indexNNeutrals_EC_);
+
+      // Cuts for |eta| > 3.0 for RUN2UL16CHS scenario
+      if (ignoreCut(indexNHF_FW_) || (nhf > cut(indexNHF_FW_, double()) || std::abs(jet.eta()) <= 3.0))
+        passCut(ret, indexNHF_FW_);
+      if (ignoreCut(indexNEF_FW_) || (nef < cut(indexNEF_FW_, double()) || std::abs(jet.eta()) <= 3.0))
+        passCut(ret, indexNEF_FW_);
+      if (ignoreCut(indexNNeutrals_FW_) || (nneutrals > cut(indexNNeutrals_FW_, int()) || std::abs(jet.eta()) <= 3.0))
+        passCut(ret, indexNNeutrals_FW_);
+
+    }
+    else if (version_ == RUN2UL16PUPPI) {
+      // Cuts for |eta| <= 2.6 for RUN2UL16PUPPI scenario
+      if (ignoreCut(indexNConstituents_) ||
+          (nconstituents > cut(indexNConstituents_, int()) || std::abs(jet.eta()) > 2.4))
+        passCut(ret, indexNConstituents_);
+      if (ignoreCut(indexNEF_) || (nef < cut(indexNEF_, double()) || std::abs(jet.eta()) > 2.4))
+        passCut(ret, indexNEF_);
+      if (ignoreCut(indexNHF_) || (nhf < cut(indexNHF_, double()) || std::abs(jet.eta()) > 2.4))
+        passCut(ret, indexNHF_);
+      if (quality_ == TIGHTLEPVETO) {
+        if (ignoreCut(indexMUF_) || (muf < cut(indexMUF_, double()) || std::abs(jet.eta()) > 2.4))
+          passCut(ret, indexMUF_);
+      }
+
+      // Cuts for 2.4 <= |eta| <= 2.7 for RUN2UL16PUPPI scenario
+      if (ignoreCut(indexNHF_TR_) ||
+          (nhf < cut(indexNHF_TR_, double()) || std::abs(jet.eta()) <= 2.4 || std::abs(jet.eta()) > 2.7))
+        passCut(ret, indexNHF_TR_);
+      if (ignoreCut(indexNEF_TR_) ||
+          (nef < cut(indexNEF_TR_, double()) || std::abs(jet.eta()) <= 2.4 || std::abs(jet.eta()) > 2.7))
+        passCut(ret, indexNEF_TR_);
+
+      // Cuts for 2.7 < |eta| <= 3.0 for RUN2UL16PUPPI scenario
+      if (ignoreCut(indexNNeutrals_EC_) ||
+          (nneutrals > cut(indexNNeutrals_EC_, int()) || std::abs(jet.eta()) <= 2.7 || std::abs(jet.eta()) > 3.0))
+        passCut(ret, indexNNeutrals_EC_);
+
+      // Cuts for |eta| > 3.0 for RUN2UL16PUPPI scenario
+      if (ignoreCut(indexNEF_FW_) || (nef < cut(indexNEF_FW_, double()) || std::abs(jet.eta()) <= 3.0))
+        passCut(ret, indexNEF_FW_);
+      if (ignoreCut(indexNNeutrals_FW_L_) ||
+          (nneutrals > cut(indexNNeutrals_FW_L_, int()) || std::abs(jet.eta()) <= 3.0))
+        passCut(ret, indexNNeutrals_FW_L_);
+      if (ignoreCut(indexNNeutrals_FW_U_) ||
+          (nneutrals < cut(indexNNeutrals_FW_U_, int()) || std::abs(jet.eta()) <= 3.0))
+        passCut(ret, indexNNeutrals_FW_U_);
+
     } else if ((version_ == SUMMER18) || (version_ == RUN2ULCHS)) {
       // Cuts for |eta| <= 2.6 for SUMMER18 scenario
       if (ignoreCut(indexNConstituents_) ||
@@ -592,9 +675,6 @@ public:  // interface
         if (ignoreCut(indexMUF_TR_) ||
             (muf < cut(indexMUF_TR_, double()) || std::abs(jet.eta()) <= 2.6 || std::abs(jet.eta()) > 2.7))
           passCut(ret, indexMUF_TR_);
-        if (ignoreCut(indexCEF_TR_) ||
-            (cef < cut(indexCEF_TR_, double()) || std::abs(jet.eta()) <= 2.6 || std::abs(jet.eta()) > 2.7))
-          passCut(ret, indexCEF_TR_);
       }
 
       // Cuts for 2.7 < |eta| <= 3.0 for SUMMER18 scenario
@@ -642,9 +722,6 @@ public:  // interface
         if (ignoreCut(indexMUF_TR_) ||
             (muf < cut(indexMUF_TR_, double()) || std::abs(jet.eta()) <= 2.6 || std::abs(jet.eta()) > 2.7))
           passCut(ret, indexMUF_TR_);
-        if (ignoreCut(indexCEF_TR_) ||
-            (cef < cut(indexCEF_TR_, double()) || std::abs(jet.eta()) <= 2.6 || std::abs(jet.eta()) > 2.7))
-          passCut(ret, indexCEF_TR_);
       }
 
       // Cuts for 2.7 < |eta| <= 3.0 for SUMMER18PUPPI scenario
@@ -960,8 +1037,8 @@ private:  // member variables
         set("nNeutrals_FW_L", 2);
         set("nNeutrals_FW_U", 15);
       } else if (version_ == RUN2UL16CHS) {
-        set("CEF", 0.8);
         set("MUF", 0.8);
+        set("CEF", 0.8);
         set("NHF_TR", 0.9);
         set("NEF_TR", 0.99);
         set("NHF_EC", 0.9);
@@ -972,8 +1049,8 @@ private:  // member variables
         set("NEF_FW", 0.90);
         set("nNeutrals_FW", 10);
       } else if (version_ == RUN2UL16PUPPI) {
-        set("CEF", 0.8);
         set("MUF", 0.8);
+        set("CEF", 0.8);
         set("NHF_TR", 0.98);
         set("NEF_TR", 0.99);
         set("nNeutrals_EC", 1);

--- a/PhysicsTools/SelectorUtils/interface/PFJetIDSelectionFunctor.h
+++ b/PhysicsTools/SelectorUtils/interface/PFJetIDSelectionFunctor.h
@@ -610,7 +610,7 @@ public:  // interface
         passCut(ret, indexNNeutrals_FW_);
 
     } else if (version_ == RUN2UL16PUPPI) {
-      // Cuts for |eta| <= 2.6 for RUN2UL16PUPPI scenario
+      // Cuts for |eta| <= 2.4 for RUN2UL16PUPPI scenario
       if (ignoreCut(indexNConstituents_) ||
           (nconstituents > cut(indexNConstituents_, int()) || std::abs(jet.eta()) > 2.4))
         passCut(ret, indexNConstituents_);

--- a/PhysicsTools/SelectorUtils/interface/PFJetIDSelectionFunctor.h
+++ b/PhysicsTools/SelectorUtils/interface/PFJetIDSelectionFunctor.h
@@ -93,8 +93,7 @@ public:  // interface
     if (params.exists("NHF"))
       set("NHF", params.getParameter<double>("NHF"));
     if ((version_ != WINTER17 && version_ != WINTER17PUPPI && version_ != SUMMER18 && version_ != SUMMER18PUPPI &&
-         version_ != RUN2UL16CHS && version_ != RUN2UL16PUPPI &&
-         version_ != RUN2ULCHS && version_ != RUN2ULPUPPI) ||
+         version_ != RUN2UL16CHS && version_ != RUN2UL16PUPPI && version_ != RUN2ULCHS && version_ != RUN2ULPUPPI) ||
         quality_ != TIGHT) {
       if (params.exists("CEF"))
         set("CEF", params.getParameter<double>("CEF"));
@@ -161,7 +160,49 @@ public:  // interface
           set("MUF", params.getParameter<double>("MUF"));
       }
     }
-    if ((version_ == SUMMER18) || (version_ == RUN2UL16CHS) || (version_ == RUN2ULCHS)) {
+    if (version_ == RUN2UL16CHS) {
+      if (params.exists("NHF_TR"))
+        set("NHF_TR", params.getParameter<double>("NHF_TR"));
+      if (params.exists("NEF_TR"))
+        set("NEF_TR", params.getParameter<double>("NEF_TR"));
+      if (params.exists("NHF_EC"))
+        set("NHF_EC", params.getParameter<double>("NHF_EC"));
+      if (params.exists("NEF_EC_L"))
+        set("NEF_EC_L", params.getParameter<double>("NEF_EC_L"));
+      if (params.exists("NEF_EC_U"))
+        set("NEF_EC_U", params.getParameter<double>("NEF_EC_U"));
+      if (params.exists("nNeutrals_EC"))
+        set("nNeutrals_EC", params.getParameter<int>("nNeutrals_EC"));
+      if (params.exists("NHF_FW"))
+        set("NHF_FW", params.getParameter<double>("NHF_FW"));
+      if (params.exists("NEF_FW"))
+        set("NEF_FW", params.getParameter<double>("NEF_FW"));
+      if (params.exists("nNeutrals_FW"))
+        set("nNeutrals_FW", params.getParameter<int>("nNeutrals_FW"));
+      if (quality_ == TIGHTLEPVETO) {
+        if (params.exists("MUF"))
+          set("MUF", params.getParameter<double>("MUF"));
+      }
+    }
+    if (version_ == RUN2UL16PUPPI) {
+      if (params.exists("NHF_TR"))
+        set("NHF_TR", params.getParameter<double>("NHF_TR"));
+      if (params.exists("NEF_TR"))
+        set("NEF_TR", params.getParameter<double>("NEF_TR"));
+      if (params.exists("nNeutrals_EC"))
+        set("nNeutrals_EC", params.getParameter<int>("nNeutrals_EC"));
+      if (params.exists("NEF_FW"))
+        set("NEF_FW", params.getParameter<double>("NEF_FW"));
+      if (params.exists("nNeutrals_FW_L"))
+        set("nNeutrals_FW_L", params.getParameter<int>("nNeutrals_FW_L"));
+      if (params.exists("nNeutrals_FW_U"))
+        set("nNeutrals_FW_U", params.getParameter<int>("nNeutrals_FW_U"));
+      if (quality_ == TIGHTLEPVETO) {
+        if (params.exists("MUF"))
+          set("MUF", params.getParameter<double>("MUF"));
+      }
+    }
+    if ((version_ == SUMMER18) || (version_ == RUN2ULCHS)) {
       if (params.exists("NHF_TR"))
         set("NHF_TR", params.getParameter<double>("NHF_TR"));
       if (params.exists("NEF_TR"))
@@ -189,7 +230,7 @@ public:  // interface
           set("CEF_TR", params.getParameter<double>("CEF_TR"));
       }
     }
-    if ((version_ == SUMMER18PUPPI) || (version_ == RUN2UL16PUPPI) || (version_ == RUN2ULPUPPI)) {
+    if ((version_ == SUMMER18PUPPI) || (version_ == RUN2ULPUPPI)) {
       if (params.exists("NHF_TR"))
         set("NHF_TR", params.getParameter<double>("NHF_TR"));
       if (params.exists("NEF_TR"))
@@ -674,7 +715,34 @@ private:  // member variables
       if (quality_ == TIGHTLEPVETO)
         push_back("MUF");
     }
-    if ((version_ == SUMMER18) || (version_ == RUN2UL16CHS) || (version_ == RUN2ULCHS)) {
+    if (version_ == RUN2UL16CHS) {
+      push_back("NHF_TR");
+      push_back("NEF_TR");
+      push_back("NHF_EC");
+      push_back("NEF_EC_L");
+      push_back("NEF_EC_U");
+      push_back("nNeutrals_EC");
+      push_back("NEF_FW");
+      push_back("NHF_FW");
+      push_back("nNeutrals_FW");
+
+      if (quality_ == TIGHTLEPVETO) {
+        push_back("MUF");
+      }
+    }
+    if (version_ == RUN2UL16PUPPI) {
+      push_back("NHF_TR");
+      push_back("NEF_TR");
+      push_back("nNeutrals_EC");
+      push_back("NEF_FW");
+      push_back("nNeutrals_FW_L");
+      push_back("nNeutrals_FW_U");
+
+      if (quality_ == TIGHTLEPVETO) {
+        push_back("MUF");
+      }
+    }
+    if ((version_ == SUMMER18) || (version_ == RUN2ULCHS)) {
       push_back("NHF_TR");
       push_back("NEF_TR");
       push_back("NCH_TR");
@@ -691,7 +759,7 @@ private:  // member variables
         push_back("CEF_TR");
       }
     }
-    if ((version_ == SUMMER18PUPPI) || (version_ == RUN2UL16PUPPI) || (version_ == RUN2ULPUPPI)) {
+    if ((version_ == SUMMER18PUPPI) || (version_ == RUN2ULPUPPI)) {
       push_back("NHF_TR");
       push_back("NEF_TR");
       push_back("NHF_EC");

--- a/PhysicsTools/SelectorUtils/interface/PFJetIDSelectionFunctor.h
+++ b/PhysicsTools/SelectorUtils/interface/PFJetIDSelectionFunctor.h
@@ -271,7 +271,7 @@ public:  // interface
   //
   bool operator()(const pat::Jet &jet, pat::strbitset &ret) override {
     if (version_ == FIRSTDATA || version_ == RUNIISTARTUP || version_ == WINTER16 || version_ == WINTER17 ||
-        version_ == WINTER17PUPPI || version_ == SUMMER18 || version_ == SUMMER18PUPPI || version_ == RUN2UL16CHS || 
+        version_ == WINTER17PUPPI || version_ == SUMMER18 || version_ == SUMMER18PUPPI || version_ == RUN2UL16CHS ||
         version_ == RUN2UL16PUPPI || version_ == RUN2ULCHS || version_ == RUN2ULPUPPI) {
       if (jet.currentJECLevel() == "Uncorrected" || !jet.jecSetsAvailable())
         return firstDataCuts(jet, ret, version_);
@@ -609,8 +609,7 @@ public:  // interface
       if (ignoreCut(indexNNeutrals_FW_) || (nneutrals > cut(indexNNeutrals_FW_, int()) || std::abs(jet.eta()) <= 3.0))
         passCut(ret, indexNNeutrals_FW_);
 
-    }
-    else if (version_ == RUN2UL16PUPPI) {
+    } else if (version_ == RUN2UL16PUPPI) {
       // Cuts for |eta| <= 2.6 for RUN2UL16PUPPI scenario
       if (ignoreCut(indexNConstituents_) ||
           (nconstituents > cut(indexNConstituents_, int()) || std::abs(jet.eta()) > 2.4))

--- a/PhysicsTools/SelectorUtils/interface/PFJetIDSelectionFunctor.h
+++ b/PhysicsTools/SelectorUtils/interface/PFJetIDSelectionFunctor.h
@@ -32,6 +32,8 @@ public:  // interface
     WINTER17PUPPI,
     SUMMER18,
     SUMMER18PUPPI,
+    RUN2UL16CHS,
+    RUN2UL16PUPPI,
     RUN2ULCHS,
     RUN2ULPUPPI,
     N_VERSIONS
@@ -63,6 +65,10 @@ public:  // interface
       version_ = SUMMER18;
     else if (versionStr == "SUMMER18PUPPI")
       version_ = SUMMER18PUPPI;
+    else if (versionStr == "RUN2UL16CHS")
+      version_ = RUN2UL16CHS;
+    else if (versionStr == "RUN2UL16PUPPI")
+      version_ = RUN2UL16PUPPI;
     else if (versionStr == "RUN2ULCHS")
       version_ = RUN2ULCHS;
     else if (versionStr == "RUN2ULPUPPI")
@@ -87,6 +93,7 @@ public:  // interface
     if (params.exists("NHF"))
       set("NHF", params.getParameter<double>("NHF"));
     if ((version_ != WINTER17 && version_ != WINTER17PUPPI && version_ != SUMMER18 && version_ != SUMMER18PUPPI &&
+         version_ != RUN2UL16CHS && version_ != RUN2UL16PUPPI &&
          version_ != RUN2ULCHS && version_ != RUN2ULPUPPI) ||
         quality_ != TIGHT) {
       if (params.exists("CEF"))
@@ -154,7 +161,7 @@ public:  // interface
           set("MUF", params.getParameter<double>("MUF"));
       }
     }
-    if ((version_ == SUMMER18) || (version_ == RUN2ULCHS)) {
+    if ((version_ == SUMMER18) || (version_ == RUN2UL16CHS) || (version_ == RUN2ULCHS)) {
       if (params.exists("NHF_TR"))
         set("NHF_TR", params.getParameter<double>("NHF_TR"));
       if (params.exists("NEF_TR"))
@@ -182,7 +189,7 @@ public:  // interface
           set("CEF_TR", params.getParameter<double>("CEF_TR"));
       }
     }
-    if ((version_ == SUMMER18PUPPI) || (version_ == RUN2ULPUPPI)) {
+    if ((version_ == SUMMER18PUPPI) || (version_ == RUN2UL16PUPPI) || (version_ == RUN2ULPUPPI)) {
       if (params.exists("NHF_TR"))
         set("NHF_TR", params.getParameter<double>("NHF_TR"));
       if (params.exists("NEF_TR"))
@@ -223,8 +230,8 @@ public:  // interface
   //
   bool operator()(const pat::Jet &jet, pat::strbitset &ret) override {
     if (version_ == FIRSTDATA || version_ == RUNIISTARTUP || version_ == WINTER16 || version_ == WINTER17 ||
-        version_ == WINTER17PUPPI || version_ == SUMMER18 || version_ == SUMMER18PUPPI || version_ == RUN2ULCHS ||
-        version_ == RUN2ULPUPPI) {
+        version_ == WINTER17PUPPI || version_ == SUMMER18 || version_ == SUMMER18PUPPI || version_ == RUN2UL16CHS || 
+        version_ == RUN2UL16PUPPI || version_ == RUN2ULCHS || version_ == RUN2ULPUPPI) {
       if (jet.currentJECLevel() == "Uncorrected" || !jet.jecSetsAvailable())
         return firstDataCuts(jet, ret, version_);
       else
@@ -241,8 +248,8 @@ public:  // interface
   //
   bool operator()(const reco::PFJet &jet, pat::strbitset &ret) {
     if (version_ == FIRSTDATA || version_ == RUNIISTARTUP || version_ == WINTER16 || version_ == WINTER17 ||
-        version_ == WINTER17PUPPI || version_ == SUMMER18 || version_ == SUMMER18PUPPI || version_ == RUN2ULCHS ||
-        version_ == RUN2ULPUPPI) {
+        version_ == WINTER17PUPPI || version_ == SUMMER18 || version_ == SUMMER18PUPPI || version_ == RUN2UL16CHS ||
+        version_ == RUN2UL16PUPPI || version_ == RUN2ULCHS || version_ == RUN2ULPUPPI) {
       return firstDataCuts(jet, ret, version_);
     } else {
       return false;
@@ -391,7 +398,7 @@ public:  // interface
     if (version_ == SUMMER18 || version_ == SUMMER18PUPPI || version_ == RUN2ULCHS || version_ == RUN2ULPUPPI)
       etaB = 2.6;
     if ((version_ != WINTER17 && version_ != WINTER17PUPPI && version_ != SUMMER18 && version_ != SUMMER18PUPPI &&
-         version_ != RUN2ULCHS && version_ != RUN2ULPUPPI) ||
+         version_ != RUN2UL16CHS && version_ != RUN2UL16PUPPI && version_ != RUN2ULCHS && version_ != RUN2ULPUPPI) ||
         quality_ != TIGHT) {
       if (ignoreCut(indexCEF_) || (cef < cut(indexCEF_, double()) || std::abs(jet.eta()) > etaB))
         passCut(ret, indexCEF_);
@@ -629,7 +636,7 @@ private:  // member variables
     push_back("CHF");
     push_back("NHF");
     if ((version_ != WINTER17 && version_ != WINTER17PUPPI && version_ != SUMMER18 && version_ != SUMMER18PUPPI &&
-         version_ != RUN2ULCHS && version_ != RUN2ULPUPPI) ||
+         version_ != RUN2UL16CHS && version_ != RUN2UL16PUPPI && version_ != RUN2ULCHS && version_ != RUN2ULPUPPI) ||
         quality_ != TIGHT)
       push_back("CEF");
     push_back("NEF");
@@ -667,7 +674,7 @@ private:  // member variables
       if (quality_ == TIGHTLEPVETO)
         push_back("MUF");
     }
-    if ((version_ == SUMMER18) || (version_ == RUN2ULCHS)) {
+    if ((version_ == SUMMER18) || (version_ == RUN2UL16CHS) || (version_ == RUN2ULCHS)) {
       push_back("NHF_TR");
       push_back("NEF_TR");
       push_back("NCH_TR");
@@ -684,7 +691,7 @@ private:  // member variables
         push_back("CEF_TR");
       }
     }
-    if ((version_ == SUMMER18PUPPI) || (version_ == RUN2ULPUPPI)) {
+    if ((version_ == SUMMER18PUPPI) || (version_ == RUN2UL16PUPPI) || (version_ == RUN2ULPUPPI)) {
       push_back("NHF_TR");
       push_back("NEF_TR");
       push_back("NHF_EC");
@@ -701,7 +708,7 @@ private:  // member variables
     }
 
     if ((version_ == WINTER17 || version_ == WINTER17PUPPI || version_ == SUMMER18 || version_ == SUMMER18PUPPI ||
-         version_ == RUN2ULCHS || version_ == RUN2ULPUPPI) &&
+         version_ == RUN2UL16CHS || version_ == RUN2UL16PUPPI || version_ == RUN2ULCHS || version_ == RUN2ULPUPPI) &&
         quality_ == LOOSE) {
       edm::LogWarning("BadJetIDVersion")
           << "The LOOSE operating point is only supported for the WINTER16 JetID version -- defaulting to TIGHT";
@@ -730,7 +737,7 @@ private:  // member variables
       set("CHF", 0.0);
       set("NHF", 0.9);
       if (version_ != WINTER17 && version_ != WINTER17PUPPI && version_ != SUMMER18 && version_ != SUMMER18PUPPI &&
-          version_ != RUN2ULCHS && version_ != RUN2ULPUPPI)
+          version_ != RUN2UL16CHS && version_ != RUN2UL16PUPPI && version_ != RUN2ULCHS && version_ != RUN2ULPUPPI)
         set("CEF", 0.99);
       set("NEF", 0.9);
       set("NCH", 0);
@@ -775,6 +782,23 @@ private:  // member variables
         set("NEF_FW", 0.90);
         set("nNeutrals_FW_L", 2);
         set("nNeutrals_FW_U", 15);
+      } else if (version_ == RUN2UL16CHS) {
+        set("NHF_TR", 0.9);
+        set("NEF_TR", 0.99);
+        set("NHF_EC", 0.9);
+        set("NEF_EC_L", 0.);
+        set("NEF_EC_U", 0.99);
+        set("nNeutrals_EC", 1);
+        set("NHF_FW", 0.2);
+        set("NEF_FW", 0.90);
+        set("nNeutrals_FW", 10);
+      } else if (version_ == RUN2UL16PUPPI) {
+        set("NHF_TR", 0.98);
+        set("NEF_TR", 0.99);
+        set("nNeutrals_EC", 1);
+        set("NEF_FW", 0.90);
+        set("nNeutrals_FW_L", 2);
+        set("nNeutrals_FW_U", 999999);
       } else if (version_ == RUN2ULCHS) {
         set("NHF_TR", 0.9);
         set("NEF_TR", 0.99);
@@ -867,6 +891,27 @@ private:  // member variables
         set("NEF_FW", 0.90);
         set("nNeutrals_FW_L", 2);
         set("nNeutrals_FW_U", 15);
+      } else if (version_ == RUN2UL16CHS) {
+        set("CEF", 0.8);
+        set("MUF", 0.8);
+        set("NHF_TR", 0.9);
+        set("NEF_TR", 0.99);
+        set("NHF_EC", 0.9);
+        set("NEF_EC_L", 0.);
+        set("NEF_EC_U", 0.99);
+        set("nNeutrals_EC", 1);
+        set("NHF_FW", 0.2);
+        set("NEF_FW", 0.90);
+        set("nNeutrals_FW", 10);
+      } else if (version_ == RUN2UL16PUPPI) {
+        set("CEF", 0.8);
+        set("MUF", 0.8);
+        set("NHF_TR", 0.98);
+        set("NEF_TR", 0.99);
+        set("nNeutrals_EC", 1);
+        set("NEF_FW", 0.90);
+        set("nNeutrals_FW_L", 2);
+        set("nNeutrals_FW_U", 999999);
       } else if (version_ == RUN2ULCHS) {
         set("CEF", 0.8);
         set("MUF", 0.8);
@@ -902,7 +947,7 @@ private:  // member variables
     indexNEF_ = index_type(&bits_, "NEF");
     indexNHF_ = index_type(&bits_, "NHF");
     if ((version_ != WINTER17 && version_ != WINTER17PUPPI && version_ != SUMMER18 && version_ != SUMMER18PUPPI &&
-         version_ != RUN2ULCHS && version_ != RUN2ULPUPPI) ||
+         version_ != RUN2UL16CHS && version_ != RUN2UL16PUPPI && version_ != RUN2ULCHS && version_ != RUN2ULPUPPI) ||
         quality_ != TIGHT)
       indexCEF_ = index_type(&bits_, "CEF");
 
@@ -971,6 +1016,31 @@ private:  // member variables
         indexMUF_ = index_type(&bits_, "MUF");
         indexMUF_TR_ = index_type(&bits_, "MUF_TR");
         indexCEF_TR_ = index_type(&bits_, "CEF_TR");
+      }
+    }
+    if (version_ == RUN2UL16CHS) {
+      indexNHF_TR_ = index_type(&bits_, "NHF_TR");
+      indexNEF_TR_ = index_type(&bits_, "NEF_TR");
+      indexNHF_EC_ = index_type(&bits_, "NHF_EC");
+      indexNEF_EC_L_ = index_type(&bits_, "NEF_EC_L");
+      indexNEF_EC_U_ = index_type(&bits_, "NEF_EC_U");
+      indexNNeutrals_EC_ = index_type(&bits_, "nNeutrals_EC");
+      indexNHF_FW_ = index_type(&bits_, "NHF_FW");
+      indexNEF_FW_ = index_type(&bits_, "NEF_FW");
+      indexNNeutrals_FW_ = index_type(&bits_, "nNeutrals_FW");
+      if (quality_ == TIGHTLEPVETO) {
+        indexMUF_ = index_type(&bits_, "MUF");
+      }
+    }
+    if (version_ == RUN2UL16PUPPI) {
+      indexNHF_TR_ = index_type(&bits_, "NHF_TR");
+      indexNEF_TR_ = index_type(&bits_, "NEF_TR");
+      indexNNeutrals_EC_ = index_type(&bits_, "nNeutrals_EC");
+      indexNEF_FW_ = index_type(&bits_, "NEF_FW");
+      indexNNeutrals_FW_L_ = index_type(&bits_, "nNeutrals_FW_L");
+      indexNNeutrals_FW_U_ = index_type(&bits_, "nNeutrals_FW_U");
+      if (quality_ == TIGHTLEPVETO) {
+        indexMUF_ = index_type(&bits_, "MUF");
       }
     }
     retInternal_ = getBitTemplate();


### PR DESCRIPTION
#### PR description:

 - Including the jetId criteria for UL16 campaigns as described [in this twiki.](https://twiki.cern.ch/twiki/bin/view/CMS/JetID13TeVUL#Preliminary_Recommendations_for)
 - A backport to CMSSW_10_6_X will follow right after for nanoAODv9 

#### PR validation:

- I run the usual `runTheMatrix` tests and all passed succesfully.

FYI @camclean 