### PR TITLE
HcalDQM - Correct LED CU List for P5 (online DQM)

### DIFF
--- a/DQM/HcalCommon/src/Container1D.cc
+++ b/DQM/HcalCommon/src/Container1D.cc
@@ -614,7 +614,7 @@ namespace hcaldqm {
 
         _logger.debug(_hashmap.getName(did));
         _mes.insert(std::make_pair(
-            hash, ib.book1D(_hashmap.getName(did), _hashmap.getName(did), _qx->nbins(), _qx->min(), _qx->max())));
+            hash, ib.book1DD(_hashmap.getName(did), _hashmap.getName(did), _qx->nbins(), _qx->min(), _qx->max())));
 
         //  customize
         customize(_mes[hash]);
@@ -633,7 +633,7 @@ namespace hcaldqm {
 
         _logger.debug(_hashmap.getName(eid));
         _mes.insert(std::make_pair(
-            hash, ib.book1D(_hashmap.getName(eid), _hashmap.getName(eid), _qx->nbins(), _qx->min(), _qx->max())));
+            hash, ib.book1DD(_hashmap.getName(eid), _hashmap.getName(eid), _qx->nbins(), _qx->min(), _qx->max())));
 
         //  customize
         customize(_mes[hash]);
@@ -650,7 +650,7 @@ namespace hcaldqm {
 
         _logger.debug(_hashmap.getName(tid));
         _mes.insert(std::make_pair(
-            hash, ib.book1D(_hashmap.getName(tid), _hashmap.getName(tid), _qx->nbins(), _qx->min(), _qx->max())));
+            hash, ib.book1DD(_hashmap.getName(tid), _hashmap.getName(tid), _qx->nbins(), _qx->min(), _qx->max())));
         //  customize
         customize(_mes[hash]);
       }
@@ -687,7 +687,7 @@ namespace hcaldqm {
 
         _logger.debug(_hashmap.getName(did));
         _mes.insert(std::make_pair(
-            hash, ib.book1D(_hashmap.getName(did), _hashmap.getName(did), _qx->nbins(), _qx->min(), _qx->max())));
+            hash, ib.book1DD(_hashmap.getName(did), _hashmap.getName(did), _qx->nbins(), _qx->min(), _qx->max())));
 
         //  customize
         customize(_mes[hash]);
@@ -708,7 +708,7 @@ namespace hcaldqm {
 
         _logger.debug(_hashmap.getName(eid));
         _mes.insert(std::make_pair(
-            hash, ib.book1D(_hashmap.getName(eid), _hashmap.getName(eid), _qx->nbins(), _qx->min(), _qx->max())));
+            hash, ib.book1DD(_hashmap.getName(eid), _hashmap.getName(eid), _qx->nbins(), _qx->min(), _qx->max())));
 
         //  customize
         customize(_mes[hash]);
@@ -727,7 +727,7 @@ namespace hcaldqm {
 
         _logger.debug(_hashmap.getName(tid));
         _mes.insert(std::make_pair(
-            hash, ib.book1D(_hashmap.getName(tid), _hashmap.getName(tid), _qx->nbins(), _qx->min(), _qx->max())));
+            hash, ib.book1DD(_hashmap.getName(tid), _hashmap.getName(tid), _qx->nbins(), _qx->min(), _qx->max())));
         //  customize
         customize(_mes[hash]);
       }

--- a/DQM/HcalCommon/src/ContainerSingle1D.cc
+++ b/DQM/HcalCommon/src/ContainerSingle1D.cc
@@ -56,11 +56,11 @@ namespace hcaldqm {
 
   /* virtual */ void ContainerSingle1D::book(DQMStore::IBooker &ib, std::string subsystem, std::string aux) {
     ib.setCurrentFolder(subsystem + "/" + _folder + "/" + _qname);
-    _me = ib.book1D(_qname + (aux.empty() ? aux : "_" + aux),
-                    _qname + (aux.empty() ? aux : " " + aux),
-                    _qx->nbins(),
-                    _qx->min(),
-                    _qx->max());
+    _me = ib.book1DD(_qname + (aux.empty() ? aux : "_" + aux),
+                     _qname + (aux.empty() ? aux : " " + aux),
+                     _qx->nbins(),
+                     _qx->min(),
+                     _qx->max());
     customize();
   }
 

--- a/DQM/HcalTasks/plugins/DigiTask.cc
+++ b/DQM/HcalTasks/plugins/DigiTask.cc
@@ -42,37 +42,6 @@ DigiTask::DigiTask(edm::ParameterSet const& ps) : DQTask(ps) {
   _capidmbx[HcalOuter] = 1;
   _capidmbx[HcalForward] = 1;
 
-  // LED calibration channels
-  std::vector<edm::ParameterSet> vLedCalibChannels =
-      ps.getParameter<std::vector<edm::ParameterSet>>("ledCalibrationChannels");
-  for (int i = 0; i <= 3; ++i) {
-    HcalSubdetector this_subdet = HcalEmpty;
-    switch (i) {
-      case 0:
-        this_subdet = HcalBarrel;
-        break;
-      case 1:
-        this_subdet = HcalEndcap;
-        break;
-      case 2:
-        this_subdet = HcalOuter;
-        break;
-      case 3:
-        this_subdet = HcalForward;
-        break;
-      default:
-        this_subdet = HcalEmpty;
-        break;
-    }
-    std::vector<int32_t> subdet_calib_ietas = vLedCalibChannels[i].getUntrackedParameter<std::vector<int32_t>>("ieta");
-    std::vector<int32_t> subdet_calib_iphis = vLedCalibChannels[i].getUntrackedParameter<std::vector<int32_t>>("iphi");
-    std::vector<int32_t> subdet_calib_depths =
-        vLedCalibChannels[i].getUntrackedParameter<std::vector<int32_t>>("depth");
-    for (unsigned int ichannel = 0; ichannel < subdet_calib_ietas.size(); ++ichannel) {
-      _ledCalibrationChannels[this_subdet].push_back(HcalDetId(
-          HcalOther, subdet_calib_ietas[ichannel], subdet_calib_iphis[ichannel], subdet_calib_depths[ichannel]));
-    }
-  }
 }
 
 /* virtual */ void DigiTask::bookHistograms(DQMStore::IBooker& ib, edm::Run const& r, edm::EventSetup const& es) {
@@ -82,6 +51,38 @@ DigiTask::DigiTask(edm::ParameterSet const& ps) : DQTask(ps) {
   edm::ESHandle<HcalDbService> dbs;
   es.get<HcalDbRecord>().get(dbs);
   _emap = dbs->getHcalMapping();
+
+  // Book LED calibration channels from emap
+  std::vector<HcalElectronicsId> eids = _emap->allElectronicsId();
+  for (unsigned i = 0; i < eids.size(); i++) {
+    HcalElectronicsId eid = eids[i];
+    DetId id = _emap->lookup(eid);
+    if(HcalGenericDetId(id.rawId()).isHcalCalibDetId()){
+      HcalCalibDetId calibId(id);
+      if(calibId.calibFlavor() == HcalCalibDetId::CalibrationBox){
+        HcalSubdetector this_subdet = HcalEmpty;
+        switch (calibId.hcalSubdet()) {
+          case HcalBarrel:
+            this_subdet = HcalBarrel;
+            break;
+          case HcalEndcap:
+            this_subdet = HcalEndcap;
+            break;
+          case HcalOuter:
+            this_subdet = HcalOuter;
+            break;
+          case HcalForward:
+            this_subdet = HcalForward;
+            break;
+          default:
+            this_subdet = HcalEmpty;
+            break;
+        }
+        _ledCalibrationChannels[this_subdet].push_back(HcalDetId(HcalOther, calibId.ieta(), calibId.iphi(), calibId.cboxChannel()));
+      }
+    }
+  }
+
   std::vector<uint32_t> vVME;
   std::vector<uint32_t> vuTCA;
   vVME.push_back(
@@ -867,10 +868,7 @@ DigiTask::DigiTask(edm::ParameterSet const& ps) : DQTask(ps) {
         if (did.subdet() == HcalOther) {
           HcalOtherDetId hodid(digi.detid());
           if (hodid.subdet() == HcalCalibration) {
-            // New method: use configurable list of channels
-            if (std::find(_ledCalibrationChannels[HcalEndcap].begin(),
-                          _ledCalibrationChannels[HcalEndcap].end(),
-                          did) != _ledCalibrationChannels[HcalEndcap].end()) {
+            if (std::find(_ledCalibrationChannels[HcalEndcap].begin(), _ledCalibrationChannels[HcalEndcap].end(), did) != _ledCalibrationChannels[HcalEndcap].end()) {
               bool channelLEDSignalPresent = false;
               for (int i = 0; i < digi.samples(); i++) {
                 _LED_ADCvsBX_Subdet.fill(HcalDetId(HcalEndcap, 16, 1, 1), bx, digi[i].adc());
@@ -885,7 +883,23 @@ DigiTask::DigiTask(edm::ParameterSet const& ps) : DQTask(ps) {
                   _LED_CUCountvsLSmod60_Subdet.fill(HcalDetId(HcalEndcap, 16, 1, 1), _currentLS % 60);
                 }
               }
+            } else if (std::find(_ledCalibrationChannels[HcalBarrel].begin(), _ledCalibrationChannels[HcalBarrel].end(), did) != _ledCalibrationChannels[HcalBarrel].end()) {
+              bool channelLEDSignalPresent = false;
+              for (int i = 0; i < digi.samples(); i++) {
+                _LED_ADCvsBX_Subdet.fill(HcalDetId(HcalBarrel, 1, 1, 1), bx, digi[i].adc());
+
+                if (digi[i].adc() > _thresh_led) {
+                  channelLEDSignalPresent = true;
+                }
+              }
+              if (channelLEDSignalPresent) {
+                _LED_CUCountvsLS_Subdet.fill(HcalDetId(HcalBarrel, 1, 1, 1), _currentLS);
+                if (_ptype == fOnline) {
+                  _LED_CUCountvsLSmod60_Subdet.fill(HcalDetId(HcalBarrel, 1, 1, 1), _currentLS % 60);
+                }
+              }
             }
+
           }
         }
       }
@@ -1072,9 +1086,34 @@ DigiTask::DigiTask(edm::ParameterSet const& ps) : DQTask(ps) {
 
   //	HO collection
   for (HODigiCollection::const_iterator it = c_ho->begin(); it != c_ho->end(); ++it) {
+    const HODataFrame digi = (const HODataFrame)(*it);
     //	Explicit check on the DetIds present in the Collection
     HcalDetId const& did = it->id();
     if (did.subdet() != HcalOuter) {
+      // LED monitoring from calibration channels
+      if (_ptype != fLocal) {
+        if (did.subdet() == HcalOther) {
+          HcalOtherDetId hodid(did);
+          if (hodid.subdet() == HcalCalibration) {
+            if (std::find(_ledCalibrationChannels[HcalOuter].begin(), _ledCalibrationChannels[HcalOuter].end(), did) != _ledCalibrationChannels[HcalOuter].end()) {
+              bool channelLEDSignalPresent = false;
+              for (int i = 0; i < digi.size(); i++) {
+                _LED_ADCvsBX_Subdet.fill(HcalDetId(HcalOuter, 1, 1, 4), bx, digi[i].adc());
+
+                if (digi[i].adc() > _thresh_led) {
+                  channelLEDSignalPresent = true;
+                }
+              }
+              if (channelLEDSignalPresent) {
+                _LED_CUCountvsLS_Subdet.fill(HcalDetId(HcalOuter, 1, 1, 4), _currentLS);
+                if (_ptype == fOnline) {
+                  _LED_CUCountvsLSmod60_Subdet.fill(HcalDetId(HcalOuter, 1, 1, 4), _currentLS % 60);
+                }
+              }
+            }
+          }
+        }
+      }
       continue;
     }
     uint32_t rawid = _ehashmap.lookup(did);
@@ -1220,22 +1259,19 @@ DigiTask::DigiTask(edm::ParameterSet const& ps) : DQTask(ps) {
           if (did.subdet() == HcalOther) {
             HcalOtherDetId hodid(digi.detid());
             if (hodid.subdet() == HcalCalibration) {
-              // New method: use configurable list of channels
-              if (std::find(_ledCalibrationChannels[HcalForward].begin(),
-                            _ledCalibrationChannels[HcalForward].end(),
-                            did) != _ledCalibrationChannels[HcalForward].end()) {
+              if (std::find(_ledCalibrationChannels[HcalForward].begin(), _ledCalibrationChannels[HcalForward].end(), did) != _ledCalibrationChannels[HcalForward].end()) {
                 bool channelLEDSignalPresent = false;
                 for (int i = 0; i < digi.samples(); i++) {
-                  _LED_ADCvsBX_Subdet.fill(HcalDetId(HcalForward, 16, 1, 1), bx, digi[i].adc());
+                  _LED_ADCvsBX_Subdet.fill(HcalDetId(HcalForward, 29, 1, 1), bx, digi[i].adc());
 
                   if (digi[i].adc() > _thresh_led) {
                     channelLEDSignalPresent = true;
                   }
                 }
                 if (channelLEDSignalPresent) {
-                  _LED_CUCountvsLS_Subdet.fill(HcalDetId(HcalForward, 16, 1, 1), _currentLS);
+                  _LED_CUCountvsLS_Subdet.fill(HcalDetId(HcalForward, 29, 1, 1), _currentLS);
                   if (_ptype == fOnline) {
-                    _LED_CUCountvsLSmod60_Subdet.fill(HcalDetId(HcalForward, 16, 1, 1), _currentLS % 60);
+                    _LED_CUCountvsLSmod60_Subdet.fill(HcalDetId(HcalForward, 29, 1, 1), _currentLS % 60);
                   }
                 }
               }

--- a/DQM/HcalTasks/plugins/DigiTask.cc
+++ b/DQM/HcalTasks/plugins/DigiTask.cc
@@ -41,7 +41,6 @@ DigiTask::DigiTask(edm::ParameterSet const& ps) : DQTask(ps) {
   _capidmbx[HcalEndcap] = 1;
   _capidmbx[HcalOuter] = 1;
   _capidmbx[HcalForward] = 1;
-
 }
 
 /* virtual */ void DigiTask::bookHistograms(DQMStore::IBooker& ib, edm::Run const& r, edm::EventSetup const& es) {
@@ -57,9 +56,9 @@ DigiTask::DigiTask(edm::ParameterSet const& ps) : DQTask(ps) {
   for (unsigned i = 0; i < eids.size(); i++) {
     HcalElectronicsId eid = eids[i];
     DetId id = _emap->lookup(eid);
-    if(HcalGenericDetId(id.rawId()).isHcalCalibDetId()){
+    if (HcalGenericDetId(id.rawId()).isHcalCalibDetId()) {
       HcalCalibDetId calibId(id);
-      if(calibId.calibFlavor() == HcalCalibDetId::CalibrationBox){
+      if (calibId.calibFlavor() == HcalCalibDetId::CalibrationBox) {
         HcalSubdetector this_subdet = HcalEmpty;
         switch (calibId.hcalSubdet()) {
           case HcalBarrel:
@@ -78,7 +77,8 @@ DigiTask::DigiTask(edm::ParameterSet const& ps) : DQTask(ps) {
             this_subdet = HcalEmpty;
             break;
         }
-        _ledCalibrationChannels[this_subdet].push_back(HcalDetId(HcalOther, calibId.ieta(), calibId.iphi(), calibId.cboxChannel()));
+        _ledCalibrationChannels[this_subdet].push_back(
+            HcalDetId(HcalOther, calibId.ieta(), calibId.iphi(), calibId.cboxChannel()));
       }
     }
   }
@@ -788,7 +788,7 @@ DigiTask::DigiTask(edm::ParameterSet const& ps) : DQTask(ps) {
 
     //	book Number of Events vs LS histogram
     ib.setCurrentFolder(_subsystem + "/RunInfo");
-    meNumEvents1LS = ib.book1D("NumberOfEvents", "NumberOfEvents", 1, 0, 1);
+    meNumEvents1LS = ib.book1DD("NumberOfEvents", "NumberOfEvents", 1, 0, 1);
 
     //	book the flag for unknown ids and the online guy as well
     ib.setCurrentFolder(_subsystem + "/" + _name);
@@ -868,7 +868,9 @@ DigiTask::DigiTask(edm::ParameterSet const& ps) : DQTask(ps) {
         if (did.subdet() == HcalOther) {
           HcalOtherDetId hodid(digi.detid());
           if (hodid.subdet() == HcalCalibration) {
-            if (std::find(_ledCalibrationChannels[HcalEndcap].begin(), _ledCalibrationChannels[HcalEndcap].end(), did) != _ledCalibrationChannels[HcalEndcap].end()) {
+            if (std::find(_ledCalibrationChannels[HcalEndcap].begin(),
+                          _ledCalibrationChannels[HcalEndcap].end(),
+                          did) != _ledCalibrationChannels[HcalEndcap].end()) {
               bool channelLEDSignalPresent = false;
               for (int i = 0; i < digi.samples(); i++) {
                 _LED_ADCvsBX_Subdet.fill(HcalDetId(HcalEndcap, 16, 1, 1), bx, digi[i].adc());
@@ -883,7 +885,9 @@ DigiTask::DigiTask(edm::ParameterSet const& ps) : DQTask(ps) {
                   _LED_CUCountvsLSmod60_Subdet.fill(HcalDetId(HcalEndcap, 16, 1, 1), _currentLS % 60);
                 }
               }
-            } else if (std::find(_ledCalibrationChannels[HcalBarrel].begin(), _ledCalibrationChannels[HcalBarrel].end(), did) != _ledCalibrationChannels[HcalBarrel].end()) {
+            } else if (std::find(_ledCalibrationChannels[HcalBarrel].begin(),
+                                 _ledCalibrationChannels[HcalBarrel].end(),
+                                 did) != _ledCalibrationChannels[HcalBarrel].end()) {
               bool channelLEDSignalPresent = false;
               for (int i = 0; i < digi.samples(); i++) {
                 _LED_ADCvsBX_Subdet.fill(HcalDetId(HcalBarrel, 1, 1, 1), bx, digi[i].adc());
@@ -899,7 +903,6 @@ DigiTask::DigiTask(edm::ParameterSet const& ps) : DQTask(ps) {
                 }
               }
             }
-
           }
         }
       }
@@ -1095,7 +1098,8 @@ DigiTask::DigiTask(edm::ParameterSet const& ps) : DQTask(ps) {
         if (did.subdet() == HcalOther) {
           HcalOtherDetId hodid(did);
           if (hodid.subdet() == HcalCalibration) {
-            if (std::find(_ledCalibrationChannels[HcalOuter].begin(), _ledCalibrationChannels[HcalOuter].end(), did) != _ledCalibrationChannels[HcalOuter].end()) {
+            if (std::find(_ledCalibrationChannels[HcalOuter].begin(), _ledCalibrationChannels[HcalOuter].end(), did) !=
+                _ledCalibrationChannels[HcalOuter].end()) {
               bool channelLEDSignalPresent = false;
               for (int i = 0; i < digi.size(); i++) {
                 _LED_ADCvsBX_Subdet.fill(HcalDetId(HcalOuter, 1, 1, 4), bx, digi[i].adc());
@@ -1259,7 +1263,9 @@ DigiTask::DigiTask(edm::ParameterSet const& ps) : DQTask(ps) {
           if (did.subdet() == HcalOther) {
             HcalOtherDetId hodid(digi.detid());
             if (hodid.subdet() == HcalCalibration) {
-              if (std::find(_ledCalibrationChannels[HcalForward].begin(), _ledCalibrationChannels[HcalForward].end(), did) != _ledCalibrationChannels[HcalForward].end()) {
+              if (std::find(_ledCalibrationChannels[HcalForward].begin(),
+                            _ledCalibrationChannels[HcalForward].end(),
+                            did) != _ledCalibrationChannels[HcalForward].end()) {
                 bool channelLEDSignalPresent = false;
                 for (int i = 0; i < digi.samples(); i++) {
                   _LED_ADCvsBX_Subdet.fill(HcalDetId(HcalForward, 29, 1, 1), bx, digi[i].adc());

--- a/DQM/HcalTasks/plugins/FCDTask.cc
+++ b/DQM/HcalTasks/plugins/FCDTask.cc
@@ -50,7 +50,7 @@ FCDTask::FCDTask(edm::ParameterSet const& ps) {
     histoname = std::to_string(it_eid.crateId()) + "-" + std::to_string(it_eid.slot()) + "-" +
                 std::to_string(it_eid.fiberIndex()) + "-" + std::to_string(it_eid.fiberChanId());
     ib.setCurrentFolder("Hcal/FCDTask/ADC");
-    _cADC[it_eid] = ib.book1D(histoname.c_str(), histoname.c_str(), 256, 0, 256);
+    _cADC[it_eid] = ib.book1DD(histoname.c_str(), histoname.c_str(), 256, 0, 256);
     _cADC[it_eid]->setAxisTitle("ADC", 1);
     _cADC[it_eid]->setAxisTitle("N", 2);
 
@@ -60,11 +60,11 @@ FCDTask::FCDTask(edm::ParameterSet const& ps) {
     _cADC_vs_TS[it_eid]->setAxisTitle("ADC", 2);
 
     ib.setCurrentFolder("Hcal/FCDTask/TDCTime");
-    _cTDCTime[it_eid] = ib.book1D(histoname.c_str(), histoname.c_str(), 500, 0., 250.);
+    _cTDCTime[it_eid] = ib.book1DD(histoname.c_str(), histoname.c_str(), 500, 0., 250.);
     _cTDCTime[it_eid]->setAxisTitle("TDC time [ns]", 1);
 
     ib.setCurrentFolder("Hcal/FCDTask/TDC");
-    _cTDC[it_eid] = ib.book1D(histoname.c_str(), histoname.c_str(), 64, -0.5, 63.5);
+    _cTDC[it_eid] = ib.book1DD(histoname.c_str(), histoname.c_str(), 64, -0.5, 63.5);
     _cTDC[it_eid]->setAxisTitle("TDC", 1);
   }
 }

--- a/DQM/HcalTasks/plugins/LEDTask.cc
+++ b/DQM/HcalTasks/plugins/LEDTask.cc
@@ -23,7 +23,6 @@ LEDTask::LEDTask(edm::ParameterSet const& ps) : DQTask(ps) {
   _lowHBHE = ps.getUntrackedParameter<double>("lowHBHE", 20);
   _lowHO = ps.getUntrackedParameter<double>("lowHO", 20);
   _lowHF = ps.getUntrackedParameter<double>("lowHF", 20);
-
 }
 
 /* virtual */ void LEDTask::bookHistograms(DQMStore::IBooker& ib, edm::Run const& r, edm::EventSetup const& es) {
@@ -42,9 +41,9 @@ LEDTask::LEDTask(edm::ParameterSet const& ps) : DQTask(ps) {
   for (unsigned i = 0; i < eids.size(); i++) {
     HcalElectronicsId eid = eids[i];
     DetId id = _emap->lookup(eid);
-    if(HcalGenericDetId(id.rawId()).isHcalCalibDetId()){
+    if (HcalGenericDetId(id.rawId()).isHcalCalibDetId()) {
       HcalCalibDetId calibId(id);
-      if(calibId.calibFlavor() == HcalCalibDetId::CalibrationBox){
+      if (calibId.calibFlavor() == HcalCalibDetId::CalibrationBox) {
         HcalSubdetector this_subdet = HcalEmpty;
         switch (calibId.hcalSubdet()) {
           case HcalBarrel:
@@ -63,7 +62,8 @@ LEDTask::LEDTask(edm::ParameterSet const& ps) : DQTask(ps) {
             this_subdet = HcalEmpty;
             break;
         }
-        _ledCalibrationChannels[this_subdet].push_back(HcalDetId(HcalOther, calibId.ieta(), calibId.iphi(), calibId.cboxChannel()));
+        _ledCalibrationChannels[this_subdet].push_back(
+            HcalDetId(HcalOther, calibId.ieta(), calibId.iphi(), calibId.cboxChannel()));
       }
     }
   }
@@ -519,9 +519,8 @@ LEDTask::LEDTask(edm::ParameterSet const& ps) : DQTask(ps) {
       if (did.subdet() == HcalOther) {
         HcalOtherDetId hodid(did);
         if (hodid.subdet() == HcalCalibration) {
-          if (std::find(_ledCalibrationChannels[HcalOuter].begin(),
-                        _ledCalibrationChannels[HcalOuter].end(),
-                        did) != _ledCalibrationChannels[HcalOuter].end()) {
+          if (std::find(_ledCalibrationChannels[HcalOuter].begin(), _ledCalibrationChannels[HcalOuter].end(), did) !=
+              _ledCalibrationChannels[HcalOuter].end()) {
             for (int i = 0; i < digi.size(); i++) {
               if (_ptype == fOnline) {
                 _LED_ADCvsBX_Subdet.fill(HcalDetId(HcalOuter, 1, 1, 4), e.bunchCrossing(), digi[i].adc());

--- a/DQM/HcalTasks/plugins/LEDTask.cc
+++ b/DQM/HcalTasks/plugins/LEDTask.cc
@@ -24,37 +24,6 @@ LEDTask::LEDTask(edm::ParameterSet const& ps) : DQTask(ps) {
   _lowHO = ps.getUntrackedParameter<double>("lowHO", 20);
   _lowHF = ps.getUntrackedParameter<double>("lowHF", 20);
 
-  // LED calibration channels
-  std::vector<edm::ParameterSet> vLedCalibChannels =
-      ps.getParameter<std::vector<edm::ParameterSet>>("ledCalibrationChannels");
-  for (int i = 0; i <= 3; ++i) {
-    HcalSubdetector this_subdet = HcalEmpty;
-    switch (i) {
-      case 0:
-        this_subdet = HcalBarrel;
-        break;
-      case 1:
-        this_subdet = HcalEndcap;
-        break;
-      case 2:
-        this_subdet = HcalOuter;
-        break;
-      case 3:
-        this_subdet = HcalForward;
-        break;
-      default:
-        this_subdet = HcalEmpty;
-        break;
-    }
-    std::vector<int32_t> subdet_calib_ietas = vLedCalibChannels[i].getUntrackedParameter<std::vector<int32_t>>("ieta");
-    std::vector<int32_t> subdet_calib_iphis = vLedCalibChannels[i].getUntrackedParameter<std::vector<int32_t>>("iphi");
-    std::vector<int32_t> subdet_calib_depths =
-        vLedCalibChannels[i].getUntrackedParameter<std::vector<int32_t>>("depth");
-    for (unsigned int ichannel = 0; ichannel < subdet_calib_ietas.size(); ++ichannel) {
-      _ledCalibrationChannels[this_subdet].push_back(HcalDetId(
-          HcalOther, subdet_calib_ietas[ichannel], subdet_calib_iphis[ichannel], subdet_calib_depths[ichannel]));
-    }
-  }
 }
 
 /* virtual */ void LEDTask::bookHistograms(DQMStore::IBooker& ib, edm::Run const& r, edm::EventSetup const& es) {
@@ -67,6 +36,37 @@ LEDTask::LEDTask(edm::ParameterSet const& ps) : DQTask(ps) {
   edm::ESHandle<HcalDbService> dbService;
   es.get<HcalDbRecord>().get(dbService);
   _emap = dbService->getHcalMapping();
+
+  // Book LED calibration channels from emap
+  std::vector<HcalElectronicsId> eids = _emap->allElectronicsId();
+  for (unsigned i = 0; i < eids.size(); i++) {
+    HcalElectronicsId eid = eids[i];
+    DetId id = _emap->lookup(eid);
+    if(HcalGenericDetId(id.rawId()).isHcalCalibDetId()){
+      HcalCalibDetId calibId(id);
+      if(calibId.calibFlavor() == HcalCalibDetId::CalibrationBox){
+        HcalSubdetector this_subdet = HcalEmpty;
+        switch (calibId.hcalSubdet()) {
+          case HcalBarrel:
+            this_subdet = HcalBarrel;
+            break;
+          case HcalEndcap:
+            this_subdet = HcalEndcap;
+            break;
+          case HcalOuter:
+            this_subdet = HcalOuter;
+            break;
+          case HcalForward:
+            this_subdet = HcalForward;
+            break;
+          default:
+            this_subdet = HcalEmpty;
+            break;
+        }
+        _ledCalibrationChannels[this_subdet].push_back(HcalDetId(HcalOther, calibId.ieta(), calibId.iphi(), calibId.cboxChannel()));
+      }
+    }
+  }
 
   std::vector<uint32_t> vhashVME;
   std::vector<uint32_t> vhashuTCA;
@@ -514,6 +514,26 @@ LEDTask::LEDTask(edm::ParameterSet const& ps) : DQTask(ps) {
   for (HODigiCollection::const_iterator it = c_ho->begin(); it != c_ho->end(); ++it) {
     const HODataFrame digi = (const HODataFrame)(*it);
     HcalDetId did = digi.id();
+    if (did.subdet() != HcalOuter) {
+      // LED monitoring from calibration channels
+      if (did.subdet() == HcalOther) {
+        HcalOtherDetId hodid(did);
+        if (hodid.subdet() == HcalCalibration) {
+          if (std::find(_ledCalibrationChannels[HcalOuter].begin(),
+                        _ledCalibrationChannels[HcalOuter].end(),
+                        did) != _ledCalibrationChannels[HcalOuter].end()) {
+            for (int i = 0; i < digi.size(); i++) {
+              if (_ptype == fOnline) {
+                _LED_ADCvsBX_Subdet.fill(HcalDetId(HcalOuter, 1, 1, 4), e.bunchCrossing(), digi[i].adc());
+              } else if (_ptype == fLocal) {
+                _LED_ADCvsEvn_Subdet.fill(
+                    HcalDetId(HcalOuter, 1, 1, 4), e.eventAuxiliary().id().event(), digi[i].adc());
+              }
+            }
+          }
+        }
+      }
+    }
     HcalElectronicsId eid = digi.elecId();
     //double sumQ = hcaldqm::utilities::sumQ<HODataFrame>(digi, 8.5, 0, digi.size()-1);
     CaloSamples digi_fC = hcaldqm::utilities::loadADC2fCDB<HODataFrame>(_dbService, did, digi);

--- a/DQM/HcalTasks/plugins/ZDCQIE10Task.cc
+++ b/DQM/HcalTasks/plugins/ZDCQIE10Task.cc
@@ -17,11 +17,11 @@ ZDCQIE10Task::ZDCQIE10Task(edm::ParameterSet const& ps) {
     HcalZDCDetId didp(HcalZDCDetId::EM, true, channel);
     histoname = "EM_P_" + std::to_string(channel) + "_1";
     ib.setCurrentFolder("Hcal/ZDCQIE10Task/ADC_perChannel");
-    _cADC_EChannel[didp()] = ib.book1D(histoname.c_str(), histoname.c_str(), 256, 0, 256);
+    _cADC_EChannel[didp()] = ib.book1DD(histoname.c_str(), histoname.c_str(), 256, 0, 256);
     _cADC_EChannel[didp()]->setAxisTitle("ADC", 1);
     _cADC_EChannel[didp()]->setAxisTitle("N", 2);
     ib.setCurrentFolder("Hcal/ZDCQIE10Task/ADC_vs_TS_perChannel");
-    _cADC_vs_TS_EChannel[didp()] = ib.book1D(histoname.c_str(), histoname.c_str(), 10, 0, 10);
+    _cADC_vs_TS_EChannel[didp()] = ib.book1DD(histoname.c_str(), histoname.c_str(), 10, 0, 10);
     _cADC_vs_TS_EChannel[didp()]->setAxisTitle("TS", 1);
     _cADC_vs_TS_EChannel[didp()]->setAxisTitle("sum ADC", 2);
 
@@ -29,11 +29,11 @@ ZDCQIE10Task::ZDCQIE10Task(edm::ParameterSet const& ps) {
     HcalZDCDetId didm(HcalZDCDetId::EM, false, channel);
     histoname = "EM_M_" + std::to_string(channel) + "_1";
     ib.setCurrentFolder("Hcal/ZDCQIE10Task/ADC_perChannel");
-    _cADC_EChannel[didm()] = ib.book1D(histoname.c_str(), histoname.c_str(), 256, 0, 256);
+    _cADC_EChannel[didm()] = ib.book1DD(histoname.c_str(), histoname.c_str(), 256, 0, 256);
     _cADC_EChannel[didm()]->setAxisTitle("ADC", 1);
     _cADC_EChannel[didm()]->setAxisTitle("N", 2);
     ib.setCurrentFolder("Hcal/ZDCQIE10Task/ADC_vs_TS_perChannel");
-    _cADC_vs_TS_EChannel[didm()] = ib.book1D(histoname.c_str(), histoname.c_str(), 10, 0, 10);
+    _cADC_vs_TS_EChannel[didm()] = ib.book1DD(histoname.c_str(), histoname.c_str(), 10, 0, 10);
     _cADC_vs_TS_EChannel[didm()]->setAxisTitle("TS", 1);
     _cADC_vs_TS_EChannel[didm()]->setAxisTitle("sum ADC", 2);
   }
@@ -43,11 +43,11 @@ ZDCQIE10Task::ZDCQIE10Task(edm::ParameterSet const& ps) {
     HcalZDCDetId didp(HcalZDCDetId::HAD, true, channel);
     histoname = "HAD_P_" + std::to_string(channel) + "_" + std::to_string(channel + 2);
     ib.setCurrentFolder("Hcal/ZDCQIE10Task/ADC_perChannel");
-    _cADC_EChannel[didp()] = ib.book1D(histoname.c_str(), histoname.c_str(), 256, 0, 256);
+    _cADC_EChannel[didp()] = ib.book1DD(histoname.c_str(), histoname.c_str(), 256, 0, 256);
     _cADC_EChannel[didp()]->setAxisTitle("ADC", 1);
     _cADC_EChannel[didp()]->setAxisTitle("N", 2);
     ib.setCurrentFolder("Hcal/ZDCQIE10Task/ADC_vs_TS_perChannel");
-    _cADC_vs_TS_EChannel[didp()] = ib.book1D(histoname.c_str(), histoname.c_str(), 10, 0, 10);
+    _cADC_vs_TS_EChannel[didp()] = ib.book1DD(histoname.c_str(), histoname.c_str(), 10, 0, 10);
     _cADC_vs_TS_EChannel[didp()]->setAxisTitle("TS", 1);
     _cADC_vs_TS_EChannel[didp()]->setAxisTitle("sum ADC", 2);
 
@@ -55,11 +55,11 @@ ZDCQIE10Task::ZDCQIE10Task(edm::ParameterSet const& ps) {
     HcalZDCDetId didm(HcalZDCDetId::HAD, false, channel);
     histoname = "HAD_M_" + std::to_string(channel) + "_" + std::to_string(channel + 2);
     ib.setCurrentFolder("Hcal/ZDCQIE10Task/ADC_perChannel");
-    _cADC_EChannel[didm()] = ib.book1D(histoname.c_str(), histoname.c_str(), 256, 0, 256);
+    _cADC_EChannel[didm()] = ib.book1DD(histoname.c_str(), histoname.c_str(), 256, 0, 256);
     _cADC_EChannel[didm()]->setAxisTitle("ADC", 1);
     _cADC_EChannel[didm()]->setAxisTitle("N", 2);
     ib.setCurrentFolder("Hcal/ZDCQIE10Task/ADC_vs_TS_perChannel");
-    _cADC_vs_TS_EChannel[didm()] = ib.book1D(histoname.c_str(), histoname.c_str(), 10, 0, 10);
+    _cADC_vs_TS_EChannel[didm()] = ib.book1DD(histoname.c_str(), histoname.c_str(), 10, 0, 10);
     _cADC_vs_TS_EChannel[didm()]->setAxisTitle("TS", 1);
     _cADC_vs_TS_EChannel[didm()]->setAxisTitle("sum ADC", 2);
   }
@@ -69,11 +69,11 @@ ZDCQIE10Task::ZDCQIE10Task(edm::ParameterSet const& ps) {
     HcalZDCDetId didp(HcalZDCDetId::RPD, true, channel);
     histoname = "RPD_P_" + std::to_string(channel) + "_2";
     ib.setCurrentFolder("Hcal/ZDCQIE10Task/ADC_perChannel");
-    _cADC_EChannel[didp()] = ib.book1D(histoname.c_str(), histoname.c_str(), 256, 0, 256);
+    _cADC_EChannel[didp()] = ib.book1DD(histoname.c_str(), histoname.c_str(), 256, 0, 256);
     _cADC_EChannel[didp()]->setAxisTitle("ADC", 1);
     _cADC_EChannel[didp()]->setAxisTitle("N", 2);
     ib.setCurrentFolder("Hcal/ZDCQIE10Task/ADC_vs_TS_perChannel");
-    _cADC_vs_TS_EChannel[didp()] = ib.book1D(histoname.c_str(), histoname.c_str(), 10, 0, 10);
+    _cADC_vs_TS_EChannel[didp()] = ib.book1DD(histoname.c_str(), histoname.c_str(), 10, 0, 10);
     _cADC_vs_TS_EChannel[didp()]->setAxisTitle("TS", 1);
     _cADC_vs_TS_EChannel[didp()]->setAxisTitle("sum ADC", 2);
 
@@ -81,11 +81,11 @@ ZDCQIE10Task::ZDCQIE10Task(edm::ParameterSet const& ps) {
     HcalZDCDetId didm(HcalZDCDetId::RPD, false, channel);
     histoname = "RPD_M_" + std::to_string(channel) + "_2";
     ib.setCurrentFolder("Hcal/ZDCQIE10Task/ADC_perChannel");
-    _cADC_EChannel[didm()] = ib.book1D(histoname.c_str(), histoname.c_str(), 256, 0, 256);
+    _cADC_EChannel[didm()] = ib.book1DD(histoname.c_str(), histoname.c_str(), 256, 0, 256);
     _cADC_EChannel[didm()]->setAxisTitle("ADC", 1);
     _cADC_EChannel[didm()]->setAxisTitle("N", 2);
     ib.setCurrentFolder("Hcal/ZDCQIE10Task/ADC_vs_TS_perChannel");
-    _cADC_vs_TS_EChannel[didm()] = ib.book1D(histoname.c_str(), histoname.c_str(), 10, 0, 10);
+    _cADC_vs_TS_EChannel[didm()] = ib.book1DD(histoname.c_str(), histoname.c_str(), 10, 0, 10);
     _cADC_vs_TS_EChannel[didm()]->setAxisTitle("TS", 1);
     _cADC_vs_TS_EChannel[didm()]->setAxisTitle("sum ADC", 2);
   }

--- a/DQM/HcalTasks/plugins/ZDCTask.cc
+++ b/DQM/HcalTasks/plugins/ZDCTask.cc
@@ -127,7 +127,7 @@ ZDCTask::ZDCTask(edm::ParameterSet const& ps) {
     _cShape_EChannel[histoname]->setAxisTitle("fC QIE8", 2);
 
     ib.setCurrentFolder("Hcal/ZDCTask/ADC_perChannel");
-    _cADC_EChannel[histoname] = ib.book1D(histoname, histoname, xAxisADC.nbins(), xAxisADC.min(), xAxisADC.max());
+    _cADC_EChannel[histoname] = ib.book1DD(histoname, histoname, xAxisADC.nbins(), xAxisADC.min(), xAxisADC.max());
     _cADC_EChannel[histoname]->getTH1()->SetBit(
         BIT(hcaldqm::constants::BIT_OFFSET + hcaldqm::quantity::AxisType::fYAxis));
     _cADC_EChannel[histoname]->setAxisTitle("ADC QIE8", 1);
@@ -161,7 +161,7 @@ ZDCTask::ZDCTask(edm::ParameterSet const& ps) {
   _cShape->setAxisTitle("Timing", 1);
   _cShape->setAxisTitle("fC QIE8", 2);
 
-  _cADC = ib.book1D("ADC", "ADC", xAxisADC.nbins(), xAxisADC.min(), xAxisADC.max());
+  _cADC = ib.book1DD("ADC", "ADC", xAxisADC.nbins(), xAxisADC.min(), xAxisADC.max());
   _cADC->getTH1()->SetBit(BIT(hcaldqm::constants::BIT_OFFSET + hcaldqm::quantity::AxisType::fYAxis));
   _cADC->setAxisTitle("ADC QIE8", 1);
 

--- a/DQM/HcalTasks/src/DigiRunSummary.cc
+++ b/DQM/HcalTasks/src/DigiRunSummary.cc
@@ -115,7 +115,7 @@ namespace hcaldqm {
     //	book the Numer of Events - set axis extendable
     if (!_booked) {
       ib.setCurrentFolder(_subsystem + "/" + _taskname);
-      _meNumEvents = ib.book1D("NumberOfEvents", "NumberOfEvents", 1000, 1, 1001);  // 1000 to start with
+      _meNumEvents = ib.book1DD("NumberOfEvents", "NumberOfEvents", 1000, 1, 1001);  // 1000 to start with
       _meNumEvents->getTH1()->SetCanExtend(TH1::kXaxis);
 
       _cOccupancy_depth.book(ib, _emap, _subsystem);


### PR DESCRIPTION
#### PR description:
Same feature of #33827 solving the calibration channels list error and the histogram y-axis limits, on top of CMSSW_11_2_4 intended for P5 (online DQM)

#### PR validation:
Tested on local dqmGUI && passed `runTheMatrix.py` test

