### PR TITLE
TDC simulation for QIE10 (HF)

### DIFF
--- a/CalibFormats/CaloObjects/src/CaloSamples.cc
+++ b/CalibFormats/CaloObjects/src/CaloSamples.cc
@@ -1,6 +1,7 @@
 #include "CalibFormats/CaloObjects/interface/CaloSamples.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include <cmath>
+#include <csignal>
 #include <iostream>
 
 CaloSamples::CaloSamples() : id_(), size_(0), presamples_(0), preciseSize_(0), precisePresamples_(0) { setBlank(); }
@@ -51,6 +52,12 @@ CaloSamples &CaloSamples::operator+=(double value) {
 CaloSamples &CaloSamples::operator+=(const CaloSamples &other) {
   if (size_ != other.size_ || presamples_ != other.presamples_ || preciseSize_ != other.preciseSize_) {
     edm::LogError("CaloHitResponse") << "Mismatched calo signals ";
+    DetId id = other.id();
+    if (id.det() == DetId::Detector::Hcal) {
+      std::cout << "this: " << *this << std::endl;
+      std::cout << "other: " << other << std::endl;
+      raise(SIGSEGV);
+    }
   }
   int i;
   for (i = 0; i < size_; ++i) {

--- a/CalibFormats/HcalObjects/src/HcalCoderDb.cc
+++ b/CalibFormats/HcalObjects/src/HcalCoderDb.cc
@@ -11,7 +11,7 @@ HcalCoderDb::HcalCoderDb(const HcalQIECoder& fCoder, const HcalQIEShape& fShape)
 
 template <class Digi>
 void HcalCoderDb::adc2fC_(const Digi& df, CaloSamples& clf) const {
-  clf = CaloSamples(df.id(), df.size());
+  // clf = CaloSamples(df.id(), df.size());
   for (int i = 0; i < df.size(); i++) {
     clf[i] = mCoder->charge(*mShape, df[i].adc(), df[i].capid());
   }
@@ -20,7 +20,7 @@ void HcalCoderDb::adc2fC_(const Digi& df, CaloSamples& clf) const {
 
 template <>
 void HcalCoderDb::adc2fC_<QIE10DataFrame>(const QIE10DataFrame& df, CaloSamples& clf) const {
-  clf = CaloSamples(df.id(), df.samples());
+  // clf = CaloSamples(df.id(), df.samples());
   for (int i = 0; i < df.samples(); i++) {
     clf[i] = mCoder->charge(*mShape, df[i].adc(), df[i].capid());
     if (df[i].soi())

--- a/SimCalorimetry/CaloSimAlgos/interface/CaloHitResponse.h
+++ b/SimCalorimetry/CaloSimAlgos/interface/CaloHitResponse.h
@@ -35,8 +35,8 @@ public:
   typedef std::map<DetId, CaloSamples> AnalogSignalMap;
   // get this from somewhere external
   enum { BUNCHSPACE = 25 };
-  double dt = 0.5;
-  int invdt = 2;
+  const double dt = 0.5;
+  const int invdt = 2;
 
   CaloHitResponse(const CaloVSimParameterMap *parameterMap, const CaloVShape *shape);
   CaloHitResponse(const CaloVSimParameterMap *parameterMap, const CaloShapes *shapes);

--- a/SimCalorimetry/CaloSimAlgos/interface/CaloHitResponse.h
+++ b/SimCalorimetry/CaloSimAlgos/interface/CaloHitResponse.h
@@ -35,6 +35,8 @@ public:
   typedef std::map<DetId, CaloSamples> AnalogSignalMap;
   // get this from somewhere external
   enum { BUNCHSPACE = 25 };
+  double dt = 0.5;
+  int invdt = 2;
 
   CaloHitResponse(const CaloVSimParameterMap *parameterMap, const CaloVShape *shape);
   CaloHitResponse(const CaloVSimParameterMap *parameterMap, const CaloShapes *shapes);

--- a/SimCalorimetry/CaloSimAlgos/interface/CaloHitResponse.h
+++ b/SimCalorimetry/CaloSimAlgos/interface/CaloHitResponse.h
@@ -35,8 +35,8 @@ public:
   typedef std::map<DetId, CaloSamples> AnalogSignalMap;
   // get this from somewhere external
   enum { BUNCHSPACE = 25 };
-  const double dt = 0.5;
-  const int invdt = 2;
+  constexpr static double dt = 0.5;
+  constexpr static int invdt = 2;
 
   CaloHitResponse(const CaloVSimParameterMap *parameterMap, const CaloVShape *shape);
   CaloHitResponse(const CaloVSimParameterMap *parameterMap, const CaloShapes *shapes);

--- a/SimCalorimetry/CaloSimAlgos/src/CaloHitResponse.cc
+++ b/SimCalorimetry/CaloSimAlgos/src/CaloHitResponse.cc
@@ -130,7 +130,7 @@ CaloSamples CaloHitResponse::makeAnalogSignal(const PCaloHit &hit, CLHEP::HepRan
     // use 0.5ns binning for precise sample
     for (int bin = 0; bin < result.size() * BUNCHSPACE * invdt; bin++) {
       sampleBin = bin / (BUNCHSPACE * invdt);
-      double pulseBit = (*shape)(binTime)*signal;
+      double pulseBit = (*shape)(binTime)*signal*dt;
       result[sampleBin] += pulseBit;
       result.preciseAtMod(bin) += pulseBit;
       binTime += dt;

--- a/SimCalorimetry/CaloSimAlgos/src/CaloHitResponse.cc
+++ b/SimCalorimetry/CaloSimAlgos/src/CaloHitResponse.cc
@@ -130,7 +130,7 @@ CaloSamples CaloHitResponse::makeAnalogSignal(const PCaloHit &hit, CLHEP::HepRan
     // use 0.5ns binning for precise sample
     for (int bin = 0; bin < result.size() * BUNCHSPACE * invdt; bin++) {
       sampleBin = bin / (BUNCHSPACE * invdt);
-      double pulseBit = (*shape)(binTime)*signal*dt;
+      double pulseBit = (*shape)(binTime)*signal * dt;
       result[sampleBin] += pulseBit;
       result.preciseAtMod(bin) += pulseBit;
       binTime += dt;

--- a/SimCalorimetry/CaloSimAlgos/src/CaloHitResponse.cc
+++ b/SimCalorimetry/CaloSimAlgos/src/CaloHitResponse.cc
@@ -177,7 +177,7 @@ CaloSamples CaloHitResponse::makeBlankSignal(const DetId &detId) const {
   int preciseSize(storePrecise ? parameters.readoutFrameSize() * BUNCHSPACE * invdt : 0);
   CaloSamples result(detId, parameters.readoutFrameSize(), preciseSize);
   result.setPresamples(parameters.binOfMaximum() - 1);
-  if (storePrecise){
+  if (storePrecise) {
     result.setPreciseSize(preciseSize);
     result.setPrecise(result.presamples() * BUNCHSPACE * invdt, dt);
   }

--- a/SimCalorimetry/HcalSimAlgos/interface/HFSimParameters.h
+++ b/SimCalorimetry/HcalSimAlgos/interface/HFSimParameters.h
@@ -23,10 +23,12 @@ public:
   double fCtoGeV(const DetId& detId) const;
 
   double samplingFactor() const;
+  double threshold_currentTDC() const { return threshold_currentTDC_; }
 
 private:
   const HcalDbService* theDbService;
   double theSamplingFactor;
+  double threshold_currentTDC_;
 };
 
 #endif

--- a/SimCalorimetry/HcalSimAlgos/interface/HcalTDC.h
+++ b/SimCalorimetry/HcalSimAlgos/interface/HcalTDC.h
@@ -6,6 +6,7 @@
 #include "DataFormats/HcalDetId/interface/HcalGenericDetId.h"
 #include "SimCalorimetry/HcalSimAlgos/interface/HcalTDCParameters.h"
 #include "DataFormats/HcalDigi/interface/QIE11DataFrame.h"
+#include "DataFormats/HcalDigi/interface/QIE10DataFrame.h"
 #include "DataFormats/HcalDetId/interface/HcalDetId.h"
 
 class HcalDbService;
@@ -22,6 +23,9 @@ public:
   /// adds timing information to the digi
   /// template <class Digi>
   void timing(const CaloSamples& lf, QIE11DataFrame& digi) const;
+  void timing(const CaloSamples& lf, QIE10DataFrame& digi) const;
+
+  std::vector<int> leadingEdgeTDC(const CaloSamples& lf) const;
 
   /// the Producer will probably update this every event
   void setDbService(const HcalDbService* service);

--- a/SimCalorimetry/HcalSimAlgos/interface/HcalTDCParameters.h
+++ b/SimCalorimetry/HcalSimAlgos/interface/HcalTDCParameters.h
@@ -12,6 +12,7 @@ public:
   int alreadyTransitionCode() const { return 62; }
   int noTransitionCode() const { return 63; }
   int unlockedCode() const { return 61; }
+  int invalidCode() const { return 60; }
 
 private:
   int nbits_;

--- a/SimCalorimetry/HcalSimAlgos/src/HFSimParameters.cc
+++ b/SimCalorimetry/HcalSimAlgos/src/HFSimParameters.cc
@@ -18,7 +18,9 @@ HFSimParameters::HFSimParameters(double simHitToPhotoelectrons,
       theSamplingFactor(samplingFactor) {}
 
 HFSimParameters::HFSimParameters(const edm::ParameterSet& p)
-    : CaloSimParameters(p), theDbService(nullptr), theSamplingFactor(p.getParameter<double>("samplingFactor")) {}
+    : CaloSimParameters(p), theDbService(nullptr),
+      theSamplingFactor(p.getParameter<double>("samplingFactor")),
+      threshold_currentTDC_(p.getParameter<double>("threshold_currentTDC")) {}
 
 double HFSimParameters::photoelectronsToAnalog(const DetId& detId) const {
   // pe/fC = pe/GeV * GeV/fC  = (0.24 pe/GeV * 6 for photomult * 0.2146GeV/fC)

--- a/SimCalorimetry/HcalSimAlgos/src/HFSimParameters.cc
+++ b/SimCalorimetry/HcalSimAlgos/src/HFSimParameters.cc
@@ -18,7 +18,8 @@ HFSimParameters::HFSimParameters(double simHitToPhotoelectrons,
       theSamplingFactor(samplingFactor) {}
 
 HFSimParameters::HFSimParameters(const edm::ParameterSet& p)
-    : CaloSimParameters(p), theDbService(nullptr),
+    : CaloSimParameters(p),
+      theDbService(nullptr),
       theSamplingFactor(p.getParameter<double>("samplingFactor")),
       threshold_currentTDC_(p.getParameter<double>("threshold_currentTDC")) {}
 

--- a/SimCalorimetry/HcalSimAlgos/src/HcalElectronicsSim.cc
+++ b/SimCalorimetry/HcalSimAlgos/src/HcalElectronicsSim.cc
@@ -139,7 +139,7 @@ void HcalElectronicsSim::analogToDigital(
     CLHEP::HepRandomEngine* engine, CaloSamples& lf, QIE10DataFrame& result, double preMixFactor, unsigned preMixBits) {
   analogToDigitalImpl(engine, lf, result, preMixFactor, preMixBits);
   if (!PreMixDigis) {
-    const HcalSimParameters& pars = static_cast<const HcalSimParameters&>(theParameterMap->simParameters(lf.id()));
+    const HFSimParameters& pars = static_cast<const HFSimParameters&>(theParameterMap->simParameters(lf.id()));
     if (pars.threshold_currentTDC() > 0.) {
       HcalTDC theTDC((pars.threshold_currentTDC()));
       theTDC.timing(lf, result);

--- a/SimCalorimetry/HcalSimAlgos/src/HcalElectronicsSim.cc
+++ b/SimCalorimetry/HcalSimAlgos/src/HcalElectronicsSim.cc
@@ -138,6 +138,13 @@ void HcalElectronicsSim::analogToDigital(
 void HcalElectronicsSim::analogToDigital(
     CLHEP::HepRandomEngine* engine, CaloSamples& lf, QIE10DataFrame& result, double preMixFactor, unsigned preMixBits) {
   analogToDigitalImpl(engine, lf, result, preMixFactor, preMixBits);
+  if (!PreMixDigis) {
+    const HcalSimParameters& pars = static_cast<const HcalSimParameters&>(theParameterMap->simParameters(lf.id()));
+    if (pars.threshold_currentTDC() > 0.) {
+      HcalTDC theTDC((pars.threshold_currentTDC()));
+      theTDC.timing(lf, result);
+    }
+  }
 }
 
 void HcalElectronicsSim::analogToDigital(

--- a/SimCalorimetry/HcalSimAlgos/src/HcalSignalGenerator.cc
+++ b/SimCalorimetry/HcalSimAlgos/src/HcalSignalGenerator.cc
@@ -16,8 +16,16 @@ bool HcalSignalGenerator<HcalQIE10DigitizerTraits>::validDigi(
 template <>
 CaloSamples HcalSignalGenerator<HcalQIE10DigitizerTraits>::samplesInPE(
     const HcalSignalGenerator<HcalQIE10DigitizerTraits>::DIGI& digi) {
+  bool storePrecise = true;
   HcalDetId cell = digi.id();
-  CaloSamples result = CaloSamples(cell, digi.samples());
+  const CaloSimParameters& parameters = theParameterMap->simParameters(cell);
+  int preciseSize(storePrecise ? parameters.readoutFrameSize() * CaloHitResponse::BUNCHSPACE * CaloHitResponse::invdt
+                               : 0);
+  CaloSamples result = CaloSamples(cell, digi.samples(), preciseSize);
+  if (storePrecise) {
+    result.setPreciseSize(preciseSize);
+    result.setPrecise(result.presamples() * CaloHitResponse::BUNCHSPACE * CaloHitResponse::invdt, CaloHitResponse::dt);
+  }
 
   // first, check if there was an overflow in this fake digi:
   bool overflow = false;

--- a/SimCalorimetry/HcalSimAlgos/src/HcalTDC.cc
+++ b/SimCalorimetry/HcalSimAlgos/src/HcalTDC.cc
@@ -39,7 +39,6 @@ std::vector<int> HcalTDC::leadingEdgeTDC(const CaloSamples& lf) const {
   bool risingReady(true);
   int tdcBins = theTDCParameters.nbins();
   bool hasTDCValues = true;
-  std::cout << "preciseSize=" << lf.preciseSize() << " lfSize=" << lf.size() << std::endl;
   if (lf.preciseSize() == 0)
     hasTDCValues = false;
 

--- a/SimCalorimetry/HcalSimAlgos/src/HcalTDC.cc
+++ b/SimCalorimetry/HcalSimAlgos/src/HcalTDC.cc
@@ -14,7 +14,6 @@ void HcalTDC::timing(const CaloSamples& lf, QIE11DataFrame& digi) const {
   std::vector<int> packedTDCs = leadingEdgeTDC(lf);
 
   for (int ibin = 0; ibin < lf.size(); ++ibin) {
-
     digi.setSample(ibin, digi[ibin].adc(), packedTDCs[ibin], digi[ibin].soi());
 
   }  // loop over bunch crossing bins
@@ -24,7 +23,6 @@ void HcalTDC::timing(const CaloSamples& lf, QIE10DataFrame& digi) const {
   std::vector<int> packedTDCs = leadingEdgeTDC(lf);
 
   for (int ibin = 0; ibin < lf.size(); ++ibin) {
-
     QIE10DataFrame::Sample sam = digi[ibin];
     digi.setSample(ibin, sam.adc(), packedTDCs[ibin] /*LE TDC*/, 0. /*TE TDC*/, sam.capid(), sam.soi(), sam.ok());
 
@@ -96,7 +94,6 @@ std::vector<int> HcalTDC::leadingEdgeTDC(const CaloSamples& lf) const {
   }  // loop over bunch crossing bins
 
   return result;
-
 }
 
 void HcalTDC::setDbService(const HcalDbService* service) { theDbService = service; }

--- a/SimCalorimetry/HcalSimProducers/python/hcalSimParameters_cfi.py
+++ b/SimCalorimetry/HcalSimProducers/python/hcalSimParameters_cfi.py
@@ -18,7 +18,7 @@ hcalSimParameters = cms.PSet(
         photoelectronsToAnalog = cms.double(2.79),
         simHitToPhotoelectrons = cms.double(6.0),
         syncPhase = cms.bool(True),
-        timePhase = cms.double(14.0),
+        timePhase = cms.double(10.0),
         doSiPMSmearing = cms.bool(False),
         sipmTau = cms.double(0.),
         threshold_currentTDC = cms.double(-999.),
@@ -32,7 +32,7 @@ hcalSimParameters = cms.PSet(
         photoelectronsToAnalog = cms.double(1.843),
         simHitToPhotoelectrons = cms.double(6.0),
         syncPhase = cms.bool(True),
-        timePhase = cms.double(13.0),
+        timePhase = cms.double(9.0),
         doSiPMSmearing = cms.bool(False),
         sipmTau = cms.double(0.),
         threshold_currentTDC = cms.double(-999.),
@@ -180,8 +180,8 @@ run3_common.toModify( hcalSimParameters,
                readoutFrameSize = cms.int32(10), 
                binOfMaximum     = cms.int32(6)
               ),
-    hf1 = dict( threshold_currentTDC = cms.double(18.7) ),
-    hf2 = dict( threshold_currentTDC = cms.double(18.7) ),
+    hf1 = dict( threshold_currentTDC = cms.double(3.) ),
+    hf2 = dict( threshold_currentTDC = cms.double(3.) ),
 ) 
 
 

--- a/SimCalorimetry/HcalSimProducers/python/hcalSimParameters_cfi.py
+++ b/SimCalorimetry/HcalSimProducers/python/hcalSimParameters_cfi.py
@@ -179,7 +179,9 @@ run3_common.toModify( hcalSimParameters,
     he = dict(
                readoutFrameSize = cms.int32(10), 
                binOfMaximum     = cms.int32(6)
-              )
+              ),
+    hf1 = dict( threshold_currentTDC = cms.double(18.7) ),
+    hf2 = dict( threshold_currentTDC = cms.double(18.7) ),
 ) 
 
 


### PR DESCRIPTION
#### PR description:

* This PR adds TDC timing simulation for the HF --> enables the use of data noise filters in MC
* Presentation in HCAL DPG: https://indico.cern.ch/event/1026044/contributions/4324030/attachments/2227968/3774461/qie10tdc_mseidel.pdf
  * Pulse shape deemed sufficient (no update)
  * Eta-dependence comes from PCaloHits in the HF shower library, will be fixed separately

#### PR validation:

MC [unit: TDC = ns/2] vs data [ns] comparison:

<img width="1171" alt="image" src="https://user-images.githubusercontent.com/1311783/119506689-71e7c900-bd6e-11eb-8abe-7f4a01cdbcd5.png">
