### PR TITLE
Fix missing LHERunInfo header bug

### DIFF
--- a/GeneratorInterface/LHEInterface/plugins/ExternalLHEProducer.cc
+++ b/GeneratorInterface/LHEInterface/plugins/ExternalLHEProducer.cc
@@ -558,10 +558,10 @@ std::unique_ptr<LHERunInfoProduct> ExternalLHEProducer::generateRunInfo(std::vec
 
     std::for_each(runInfo->getHeaders().begin(),
                   runInfo->getHeaders().end(),
-                  std::bind(&LHERunInfoProduct::addHeader, product, std::placeholders::_1));
+                  std::bind(&LHERunInfoProduct::addHeader, &product, std::placeholders::_1));
     std::for_each(runInfo->getComments().begin(),
                   runInfo->getComments().end(),
-                  std::bind(&LHERunInfoProduct::addComment, product, std::placeholders::_1));
+                  std::bind(&LHERunInfoProduct::addComment, &product, std::placeholders::_1));
     if (not retValue) {
       retValue = std::make_unique<LHERunInfoProduct>(std::move(product));
     } else {


### PR DESCRIPTION
#### PR description:

Fix a bug that causes the `header` and `comment` not properly copied to `LHERunInfoPruduct` from the produced LHE events. Therefore these entities are missing in `LHERunInfoPruduct` in the output ROOT file.

#### PR validation:

Test on the process [`B2G-RunIISummer19UL17wmLHEGEN-00001`](https://cms-pdmv.cern.ch/mcm/requests?prepid=B2G-RunIISummer19UL17wmLHEGEN-00001&page=0&shown=127) and see `LHERunInfoPruduct::headers_size()` gives 8 after the fix (otherwise gives 0) in the output ROOT file.

(Resolves: #33690)