### PR TITLE
Fix fatJetTable genJetAK8Idx matching

### DIFF
--- a/PhysicsTools/NanoAOD/python/jets_cff.py
+++ b/PhysicsTools/NanoAOD/python/jets_cff.py
@@ -668,7 +668,7 @@ fatJetMCTable = cms.EDProducer("SimpleCandidateFlatTableProducer",
         nBHadrons = Var("jetFlavourInfo().getbHadrons().size()", "uint8", doc="number of b-hadrons"),
         nCHadrons = Var("jetFlavourInfo().getcHadrons().size()", "uint8", doc="number of c-hadrons"),
         hadronFlavour = Var("hadronFlavour()", int, doc="flavour from hadron ghost clustering"),
-        genJetAK8Idx = Var("?genJetFwdRef().backRef().isNonnull()?genJetFwdRef().backRef().key():-1", int, doc="index of matched gen AK8 jet"),
+        genJetAK8Idx = Var("?genJetFwdRef().backRef().isNonnull() && genJetFwdRef().backRef().pt() > 100.?genJetFwdRef().backRef().key():-1", int, doc="index of matched gen AK8 jet"),
     )
 )
 


### PR DESCRIPTION
#### PR description:

Fixes issue where the GenJetAK8IDx matching did not match the corresponding GenJetAK8Table id's because of a difference in pT cut between the collections being referenced [https://hypernews.cern.ch/HyperNews/CMS/get/JetMET/2103.htm](https://hypernews.cern.ch/HyperNews/CMS/get/JetMET/2103.html)

#### PR validation:

Validated on file in question in 10_6_19_patch2. Could not find any files with the same issue present in the 12 series.
[https://cmsweb.cern.ch/das/request?instance=prod/global&input=dataset+file%3D%2Fstore%2Fmc%2FRunIISummer19UL17NanoAODv2%2FTTToHadronic_TuneCP5_13TeV-powheg-pythia8%2FNANOAODSIM%2F106X_mc2017_realistic_v8-v1%2F280000%2F1FA6BD39-B319-C143-92BC-13BC01AF4B89.root](https://cmsweb.cern.ch/das/request?instance=prod/global&input=dataset+file%3D%2Fstore%2Fmc%2FRunIISummer19UL17NanoAODv2%2FTTToHadronic_TuneCP5_13TeV-powheg-pythia8%2FNANOAODSIM%2F106X_mc2017_realistic_v8-v1%2F280000%2F1FA6BD39-B319-C143-92BC-13BC01AF4B89.root)


#### if this PR is a backport please specify the original PR and why you need to backport that PR:

NA
