### PR TITLE
[11_3_X] Fix missing LHERunInfo header bug

### DIFF
--- a/GeneratorInterface/LHEInterface/plugins/ExternalLHEProducer.cc
+++ b/GeneratorInterface/LHEInterface/plugins/ExternalLHEProducer.cc
@@ -551,10 +551,10 @@ std::unique_ptr<LHERunInfoProduct> ExternalLHEProducer::generateRunInfo(std::vec
 
     std::for_each(runInfo->getHeaders().begin(),
                   runInfo->getHeaders().end(),
-                  std::bind(&LHERunInfoProduct::addHeader, product, std::placeholders::_1));
+                  std::bind(&LHERunInfoProduct::addHeader, &product, std::placeholders::_1));
     std::for_each(runInfo->getComments().begin(),
                   runInfo->getComments().end(),
-                  std::bind(&LHERunInfoProduct::addComment, product, std::placeholders::_1));
+                  std::bind(&LHERunInfoProduct::addComment, &product, std::placeholders::_1));
     if (not retValue) {
       retValue = std::make_unique<LHERunInfoProduct>(std::move(product));
     } else {


### PR DESCRIPTION
#### PR description:

**This is a 11_3_X backport from #33831**

Fix a bug that causes the `header` and `comment` not properly copied to `LHERunInfoProduct` from the produced LHE events. Therefore these entities are missing in LHERunInfoPruduct in the output ROOT file.

#### PR validation:

See #33831.