### PR TITLE
MTD geometry: Specify explicitly the geometry era in standalone MTD tests

### DIFF
--- a/Geometry/MTDCommonData/test/testMTDGeometry.py
+++ b/Geometry/MTDCommonData/test/testMTDGeometry.py
@@ -1,6 +1,9 @@
 import FWCore.ParameterSet.Config as cms
 
-process = cms.Process("MTDGeometryTest")
+from Configuration.Eras.Era_Phase2C11I13M9_cff import Phase2C11I13M9
+from Configuration.ProcessModifiers.dd4hep_cff import dd4hep
+
+process = cms.Process("MTDGeometryTest",Phase2C11I13M9,dd4hep)
 
 process.source = cms.Source("EmptySource")
 process.maxEvents = cms.untracked.PSet(

--- a/Geometry/MTDCommonData/test/testMTDinDD4hep.py
+++ b/Geometry/MTDCommonData/test/testMTDinDD4hep.py
@@ -1,6 +1,9 @@
 import FWCore.ParameterSet.Config as cms
 
-process = cms.Process("CompareGeometryTest")
+from Configuration.Eras.Era_Phase2C11I13M9_cff import Phase2C11I13M9
+from Configuration.ProcessModifiers.dd4hep_cff import dd4hep
+
+process = cms.Process("CompareGeometryTest",Phase2C11I13M9,dd4hep)
 
 process.source = cms.Source("EmptySource")
 process.maxEvents = cms.untracked.PSet(

--- a/Geometry/MTDCommonData/test/testMTDinDDD.py
+++ b/Geometry/MTDCommonData/test/testMTDinDDD.py
@@ -1,6 +1,8 @@
 import FWCore.ParameterSet.Config as cms
 
-process = cms.Process("CompareGeometryTest")
+from Configuration.Eras.Era_Phase2C11I13M9_cff import Phase2C11I13M9
+
+process = cms.Process("CompareGeometryTest",Phase2C11I13M9)
 
 process.source = cms.Source("EmptySource")
 process.maxEvents = cms.untracked.PSet(

--- a/Geometry/MTDGeometryBuilder/test/dd4hep_mtd_cfg.py
+++ b/Geometry/MTDGeometryBuilder/test/dd4hep_mtd_cfg.py
@@ -1,7 +1,9 @@
 import FWCore.ParameterSet.Config as cms
+
+from Configuration.Eras.Era_Phase2C11I13M9_cff import Phase2C11I13M9
 from Configuration.ProcessModifiers.dd4hep_cff import dd4hep
 
-process = cms.Process("GeometryTest",dd4hep)
+process = cms.Process("GeometryTest",Phase2C11I13M9,dd4hep)
 
 process.source = cms.Source("EmptyIOVSource",
                             lastValue = cms.uint64(1),

--- a/Geometry/MTDGeometryBuilder/test/mtd_cfg.py
+++ b/Geometry/MTDGeometryBuilder/test/mtd_cfg.py
@@ -1,6 +1,8 @@
 import FWCore.ParameterSet.Config as cms
 
-process = cms.Process("GeometryTest")
+from Configuration.Eras.Era_Phase2C11I13M9_cff import Phase2C11I13M9
+
+process = cms.Process("GeometryTest",Phase2C11I13M9)
 
 process.source = cms.Source("EmptyIOVSource",
                             lastValue = cms.uint64(1),

--- a/Geometry/MTDNumberingBuilder/test/dd4hep_mtd_cfg.py
+++ b/Geometry/MTDNumberingBuilder/test/dd4hep_mtd_cfg.py
@@ -1,7 +1,9 @@
 import FWCore.ParameterSet.Config as cms
+
+from Configuration.Eras.Era_Phase2C11I13M9_cff import Phase2C11I13M9
 from Configuration.ProcessModifiers.dd4hep_cff import dd4hep
 
-process = cms.Process("GeometryTest",dd4hep)
+process = cms.Process("GeometryTest",Phase2C11I13M9,dd4hep)
 
 process.source = cms.Source("EmptyIOVSource",
                             lastValue = cms.uint64(1),

--- a/Geometry/MTDNumberingBuilder/test/mtd_cfg.py
+++ b/Geometry/MTDNumberingBuilder/test/mtd_cfg.py
@@ -1,6 +1,8 @@
 import FWCore.ParameterSet.Config as cms
 
-process = cms.Process("GeometryTest")
+from Configuration.Eras.Era_Phase2C11I13M9_cff import Phase2C11I13M9
+
+process = cms.Process("GeometryTest",Phase2C11I13M9)
 
 process.source = cms.Source("EmptyIOVSource",
                             lastValue = cms.uint64(1),

--- a/RecoMTD/DetLayers/test/mtd_cfg.py
+++ b/RecoMTD/DetLayers/test/mtd_cfg.py
@@ -1,6 +1,8 @@
 import FWCore.ParameterSet.Config as cms
 
-process = cms.Process("GeometryTest")
+from Configuration.Eras.Era_Phase2C11I13M9_cff import Phase2C11I13M9
+
+process = cms.Process("GeometryTest",Phase2C11I13M9)
 
 process.source = cms.Source("EmptySource")
 


### PR DESCRIPTION
#### PR description:

Add in the standalone MTD geometry test the era corresponding to the chosen geometry scenario (at present D76). This has no practical effect on the tests so far, but it is cleaner and safer in view of possible future updates.

#### PR validation:

No change in unit test, the full test outputs are compatible