### PR TITLE
Backport: Including jetId criteria for UL16 

### DIFF
--- a/PhysicsTools/NanoAOD/python/jets_cff.py
+++ b/PhysicsTools/NanoAOD/python/jets_cff.py
@@ -76,6 +76,8 @@ run2_jme_2017.toModify( tightJetIdLepVeto.filterParams, version = "WINTER17" )
 for modifier in run2_nanoAOD_106Xv1, run2_nanoAOD_106Xv2, run2_miniAOD_devel:
   modifier.toModify( tightJetId.filterParams, version = "RUN2ULCHS" )
   modifier.toModify( tightJetIdLepVeto.filterParams, version = "RUN2ULCHS" )
+(run2_jme_2016 & (run2_nanoAOD_106Xv2 | run2_miniAOD_devel)).toModify( tightJetId.filterParams, version = "RUN2UL16CHS"  )
+(run2_jme_2016 & (run2_nanoAOD_106Xv2 | run2_miniAOD_devel)).toModify( tightJetIdLepVeto.filterParams, version = "RUN2UL16CHS"  )
 
 
 looseJetIdAK8 = cms.EDProducer("PatJetIDValueMapProducer",
@@ -106,6 +108,8 @@ run2_jme_2017.toModify( tightJetIdLepVetoAK8.filterParams, version = "WINTER17PU
 for modifier in run2_nanoAOD_106Xv1, run2_nanoAOD_106Xv2, run2_miniAOD_devel:
   modifier.toModify( tightJetIdAK8.filterParams, version = "RUN2ULPUPPI" )
   modifier.toModify( tightJetIdLepVetoAK8.filterParams, version = "RUN2ULPUPPI" )
+(run2_jme_2016 & (run2_nanoAOD_106Xv2 | run2_miniAOD_devel)).toModify( tightJetIdAK8.filterParams, version = "RUN2UL16PUPPI" )
+(run2_jme_2016 & (run2_nanoAOD_106Xv2 | run2_miniAOD_devel)).toModify( tightJetIdLepVetoAK8.filterParams, version = "RUN2UL16PUPPI" )
 
 
 bJetVars = cms.EDProducer("JetRegressionVarProducer",

--- a/PhysicsTools/SelectorUtils/interface/PFJetIDSelectionFunctor.h
+++ b/PhysicsTools/SelectorUtils/interface/PFJetIDSelectionFunctor.h
@@ -32,6 +32,8 @@ public:  // interface
     WINTER17PUPPI,
     SUMMER18,
     SUMMER18PUPPI,
+    RUN2UL16CHS,
+    RUN2UL16PUPPI,
     RUN2ULCHS,
     RUN2ULPUPPI,
     N_VERSIONS
@@ -63,6 +65,10 @@ public:  // interface
       version_ = SUMMER18;
     else if (versionStr == "SUMMER18PUPPI")
       version_ = SUMMER18PUPPI;
+    else if (versionStr == "RUN2UL16CHS")
+      version_ = RUN2UL16CHS;
+    else if (versionStr == "RUN2UL16PUPPI")
+      version_ = RUN2UL16PUPPI;
     else if (versionStr == "RUN2ULCHS")
       version_ = RUN2ULCHS;
     else if (versionStr == "RUN2ULPUPPI")
@@ -87,7 +93,7 @@ public:  // interface
     if (params.exists("NHF"))
       set("NHF", params.getParameter<double>("NHF"));
     if ((version_ != WINTER17 && version_ != WINTER17PUPPI && version_ != SUMMER18 && version_ != SUMMER18PUPPI &&
-         version_ != RUN2ULCHS && version_ != RUN2ULPUPPI) ||
+         version_ != RUN2UL16CHS && version_ != RUN2UL16PUPPI && version_ != RUN2ULCHS && version_ != RUN2ULPUPPI) ||
         quality_ != TIGHT) {
       if (params.exists("CEF"))
         set("CEF", params.getParameter<double>("CEF"));
@@ -143,6 +149,48 @@ public:  // interface
         set("NHF_EC", params.getParameter<double>("NHF_EC"));
       if (params.exists("NHF_FW"))
         set("NHF_FW", params.getParameter<double>("NHF_FW"));
+      if (params.exists("NEF_FW"))
+        set("NEF_FW", params.getParameter<double>("NEF_FW"));
+      if (params.exists("nNeutrals_FW_L"))
+        set("nNeutrals_FW_L", params.getParameter<int>("nNeutrals_FW_L"));
+      if (params.exists("nNeutrals_FW_U"))
+        set("nNeutrals_FW_U", params.getParameter<int>("nNeutrals_FW_U"));
+      if (quality_ == TIGHTLEPVETO) {
+        if (params.exists("MUF"))
+          set("MUF", params.getParameter<double>("MUF"));
+      }
+    }
+    if (version_ == RUN2UL16CHS) {
+      if (params.exists("NHF_TR"))
+        set("NHF_TR", params.getParameter<double>("NHF_TR"));
+      if (params.exists("NEF_TR"))
+        set("NEF_TR", params.getParameter<double>("NEF_TR"));
+      if (params.exists("NHF_EC"))
+        set("NHF_EC", params.getParameter<double>("NHF_EC"));
+      if (params.exists("NEF_EC_L"))
+        set("NEF_EC_L", params.getParameter<double>("NEF_EC_L"));
+      if (params.exists("NEF_EC_U"))
+        set("NEF_EC_U", params.getParameter<double>("NEF_EC_U"));
+      if (params.exists("nNeutrals_EC"))
+        set("nNeutrals_EC", params.getParameter<int>("nNeutrals_EC"));
+      if (params.exists("NHF_FW"))
+        set("NHF_FW", params.getParameter<double>("NHF_FW"));
+      if (params.exists("NEF_FW"))
+        set("NEF_FW", params.getParameter<double>("NEF_FW"));
+      if (params.exists("nNeutrals_FW"))
+        set("nNeutrals_FW", params.getParameter<int>("nNeutrals_FW"));
+      if (quality_ == TIGHTLEPVETO) {
+        if (params.exists("MUF"))
+          set("MUF", params.getParameter<double>("MUF"));
+      }
+    }
+    if (version_ == RUN2UL16PUPPI) {
+      if (params.exists("NHF_TR"))
+        set("NHF_TR", params.getParameter<double>("NHF_TR"));
+      if (params.exists("NEF_TR"))
+        set("NEF_TR", params.getParameter<double>("NEF_TR"));
+      if (params.exists("nNeutrals_EC"))
+        set("nNeutrals_EC", params.getParameter<int>("nNeutrals_EC"));
       if (params.exists("NEF_FW"))
         set("NEF_FW", params.getParameter<double>("NEF_FW"));
       if (params.exists("nNeutrals_FW_L"))
@@ -223,8 +271,8 @@ public:  // interface
   //
   bool operator()(const pat::Jet &jet, pat::strbitset &ret) override {
     if (version_ == FIRSTDATA || version_ == RUNIISTARTUP || version_ == WINTER16 || version_ == WINTER17 ||
-        version_ == WINTER17PUPPI || version_ == SUMMER18 || version_ == SUMMER18PUPPI || version_ == RUN2ULCHS ||
-        version_ == RUN2ULPUPPI) {
+        version_ == WINTER17PUPPI || version_ == SUMMER18 || version_ == SUMMER18PUPPI || version_ == RUN2UL16CHS ||
+        version_ == RUN2UL16PUPPI || version_ == RUN2ULCHS || version_ == RUN2ULPUPPI) {
       if (jet.currentJECLevel() == "Uncorrected" || !jet.jecSetsAvailable())
         return firstDataCuts(jet, ret, version_);
       else
@@ -241,8 +289,8 @@ public:  // interface
   //
   bool operator()(const reco::PFJet &jet, pat::strbitset &ret) {
     if (version_ == FIRSTDATA || version_ == RUNIISTARTUP || version_ == WINTER16 || version_ == WINTER17 ||
-        version_ == WINTER17PUPPI || version_ == SUMMER18 || version_ == SUMMER18PUPPI || version_ == RUN2ULCHS ||
-        version_ == RUN2ULPUPPI) {
+        version_ == WINTER17PUPPI || version_ == SUMMER18 || version_ == SUMMER18PUPPI || version_ == RUN2UL16CHS ||
+        version_ == RUN2UL16PUPPI || version_ == RUN2ULCHS || version_ == RUN2ULPUPPI) {
       return firstDataCuts(jet, ret, version_);
     } else {
       return false;
@@ -396,7 +444,7 @@ public:  // interface
     if (version_ == SUMMER18 || version_ == SUMMER18PUPPI || version_ == RUN2ULCHS || version_ == RUN2ULPUPPI)
       etaB = 2.6;
     if ((version_ != WINTER17 && version_ != WINTER17PUPPI && version_ != SUMMER18 && version_ != SUMMER18PUPPI &&
-         version_ != RUN2ULCHS && version_ != RUN2ULPUPPI) ||
+         version_ != RUN2UL16CHS && version_ != RUN2UL16PUPPI && version_ != RUN2ULCHS && version_ != RUN2ULPUPPI) ||
         quality_ != TIGHT) {
       if (ignoreCut(indexCEF_) || (cef < cut(indexCEF_, double()) || std::abs(jet.eta()) > etaB))
         passCut(ret, indexCEF_);
@@ -634,7 +682,7 @@ private:  // member variables
     push_back("CHF");
     push_back("NHF");
     if ((version_ != WINTER17 && version_ != WINTER17PUPPI && version_ != SUMMER18 && version_ != SUMMER18PUPPI &&
-         version_ != RUN2ULCHS && version_ != RUN2ULPUPPI) ||
+         version_ != RUN2UL16CHS && version_ != RUN2UL16PUPPI && version_ != RUN2ULCHS && version_ != RUN2ULPUPPI) ||
         quality_ != TIGHT)
       push_back("CEF");
     push_back("NEF");
@@ -672,6 +720,33 @@ private:  // member variables
       if (quality_ == TIGHTLEPVETO)
         push_back("MUF");
     }
+    if (version_ == RUN2UL16CHS) {
+      push_back("NHF_TR");
+      push_back("NEF_TR");
+      push_back("NHF_EC");
+      push_back("NEF_EC_L");
+      push_back("NEF_EC_U");
+      push_back("nNeutrals_EC");
+      push_back("NEF_FW");
+      push_back("NHF_FW");
+      push_back("nNeutrals_FW");
+
+      if (quality_ == TIGHTLEPVETO) {
+        push_back("MUF");
+      }
+    }
+    if (version_ == RUN2UL16PUPPI) {
+      push_back("NHF_TR");
+      push_back("NEF_TR");
+      push_back("nNeutrals_EC");
+      push_back("NEF_FW");
+      push_back("nNeutrals_FW_L");
+      push_back("nNeutrals_FW_U");
+
+      if (quality_ == TIGHTLEPVETO) {
+        push_back("MUF");
+      }
+    }
     if ((version_ == SUMMER18) || (version_ == RUN2ULCHS)) {
       push_back("NHF_TR");
       push_back("NEF_TR");
@@ -706,7 +781,7 @@ private:  // member variables
     }
 
     if ((version_ == WINTER17 || version_ == WINTER17PUPPI || version_ == SUMMER18 || version_ == SUMMER18PUPPI ||
-         version_ == RUN2ULCHS || version_ == RUN2ULPUPPI) &&
+         version_ == RUN2UL16CHS || version_ == RUN2UL16PUPPI || version_ == RUN2ULCHS || version_ == RUN2ULPUPPI) &&
         quality_ == LOOSE) {
       edm::LogWarning("BadJetIDVersion")
           << "The LOOSE operating point is only supported for the WINTER16 JetID version -- defaulting to TIGHT";
@@ -735,7 +810,7 @@ private:  // member variables
       set("CHF", 0.0);
       set("NHF", 0.9);
       if (version_ != WINTER17 && version_ != WINTER17PUPPI && version_ != SUMMER18 && version_ != SUMMER18PUPPI &&
-          version_ != RUN2ULCHS && version_ != RUN2ULPUPPI)
+          version_ != RUN2UL16CHS && version_ != RUN2UL16PUPPI && version_ != RUN2ULCHS && version_ != RUN2ULPUPPI)
         set("CEF", 0.99);
       set("NEF", 0.9);
       set("NCH", 0);
@@ -872,6 +947,27 @@ private:  // member variables
         set("NEF_FW", 0.90);
         set("nNeutrals_FW_L", 2);
         set("nNeutrals_FW_U", 15);
+      } else if (version_ == RUN2UL16CHS) {
+        set("CEF", 0.8);
+        set("MUF", 0.8);
+        set("NHF_TR", 0.9);
+        set("NEF_TR", 0.99);
+        set("NHF_EC", 0.9);
+        set("NEF_EC_L", 0.);
+        set("NEF_EC_U", 0.99);
+        set("nNeutrals_EC", 1);
+        set("NHF_FW", 0.2);
+        set("NEF_FW", 0.90);
+        set("nNeutrals_FW", 10);
+      } else if (version_ == RUN2UL16PUPPI) {
+        set("CEF", 0.8);
+        set("MUF", 0.8);
+        set("NHF_TR", 0.98);
+        set("NEF_TR", 0.99);
+        set("nNeutrals_EC", 1);
+        set("NEF_FW", 0.90);
+        set("nNeutrals_FW_L", 2);
+        set("nNeutrals_FW_U", 999999);
       } else if (version_ == RUN2ULCHS) {
         set("CEF", 0.8);
         set("MUF", 0.8);
@@ -907,7 +1003,7 @@ private:  // member variables
     indexNEF_ = index_type(&bits_, "NEF");
     indexNHF_ = index_type(&bits_, "NHF");
     if ((version_ != WINTER17 && version_ != WINTER17PUPPI && version_ != SUMMER18 && version_ != SUMMER18PUPPI &&
-         version_ != RUN2ULCHS && version_ != RUN2ULPUPPI) ||
+         version_ != RUN2UL16CHS && version_ != RUN2UL16PUPPI && version_ != RUN2ULCHS && version_ != RUN2ULPUPPI) ||
         quality_ != TIGHT)
       indexCEF_ = index_type(&bits_, "CEF");
 
@@ -976,6 +1072,31 @@ private:  // member variables
         indexMUF_ = index_type(&bits_, "MUF");
         indexMUF_TR_ = index_type(&bits_, "MUF_TR");
         indexCEF_TR_ = index_type(&bits_, "CEF_TR");
+      }
+    }
+    if (version_ == RUN2UL16CHS) {
+      indexNHF_TR_ = index_type(&bits_, "NHF_TR");
+      indexNEF_TR_ = index_type(&bits_, "NEF_TR");
+      indexNHF_EC_ = index_type(&bits_, "NHF_EC");
+      indexNEF_EC_L_ = index_type(&bits_, "NEF_EC_L");
+      indexNEF_EC_U_ = index_type(&bits_, "NEF_EC_U");
+      indexNNeutrals_EC_ = index_type(&bits_, "nNeutrals_EC");
+      indexNHF_FW_ = index_type(&bits_, "NHF_FW");
+      indexNEF_FW_ = index_type(&bits_, "NEF_FW");
+      indexNNeutrals_FW_ = index_type(&bits_, "nNeutrals_FW");
+      if (quality_ == TIGHTLEPVETO) {
+        indexMUF_ = index_type(&bits_, "MUF");
+      }
+    }
+    if (version_ == RUN2UL16PUPPI) {
+      indexNHF_TR_ = index_type(&bits_, "NHF_TR");
+      indexNEF_TR_ = index_type(&bits_, "NEF_TR");
+      indexNNeutrals_EC_ = index_type(&bits_, "nNeutrals_EC");
+      indexNEF_FW_ = index_type(&bits_, "NEF_FW");
+      indexNNeutrals_FW_L_ = index_type(&bits_, "nNeutrals_FW_L");
+      indexNNeutrals_FW_U_ = index_type(&bits_, "nNeutrals_FW_U");
+      if (quality_ == TIGHTLEPVETO) {
+        indexMUF_ = index_type(&bits_, "MUF");
       }
     }
     retInternal_ = getBitTemplate();

--- a/PhysicsTools/SelectorUtils/interface/PFJetIDSelectionFunctor.h
+++ b/PhysicsTools/SelectorUtils/interface/PFJetIDSelectionFunctor.h
@@ -569,6 +569,88 @@ public:  // interface
       if (ignoreCut(indexNNeutrals_FW_U_) ||
           (nneutrals < cut(indexNNeutrals_FW_U_, int()) || std::abs(jet.eta()) <= 3.0))
         passCut(ret, indexNNeutrals_FW_U_);
+
+    } else if (version_ == RUN2UL16CHS) {
+      // Cuts for |eta| <= 2.4 for RUN2UL16CHS scenario
+      if (ignoreCut(indexNConstituents_) ||
+          (nconstituents > cut(indexNConstituents_, int()) || std::abs(jet.eta()) > 2.4))
+        passCut(ret, indexNConstituents_);
+      if (ignoreCut(indexNEF_) || (nef < cut(indexNEF_, double()) || std::abs(jet.eta()) > 2.4))
+        passCut(ret, indexNEF_);
+      if (ignoreCut(indexNHF_) || (nhf < cut(indexNHF_, double()) || std::abs(jet.eta()) > 2.4))
+        passCut(ret, indexNHF_);
+      if (quality_ == TIGHTLEPVETO) {
+        if (ignoreCut(indexMUF_) || (muf < cut(indexMUF_, double()) || std::abs(jet.eta()) > 2.4))
+          passCut(ret, indexMUF_);
+      }
+
+      // Cuts for 2.4 <= |eta| <= 2.7 for RUN2UL16CHS scenario
+      if (ignoreCut(indexNHF_TR_) ||
+          (nhf < cut(indexNHF_TR_, double()) || std::abs(jet.eta()) <= 2.4 || std::abs(jet.eta()) > 2.7))
+        passCut(ret, indexNHF_TR_);
+      if (ignoreCut(indexNEF_TR_) ||
+          (nef < cut(indexNEF_TR_, double()) || std::abs(jet.eta()) <= 2.4 || std::abs(jet.eta()) > 2.7))
+        passCut(ret, indexNEF_TR_);
+
+      // Cuts for 2.7 < |eta| <= 3.0 for RUN2UL16CHS scenario
+      if (ignoreCut(indexNHF_EC_) ||
+          (nhf < cut(indexNHF_EC_, double()) || std::abs(jet.eta()) <= 2.7 || std::abs(jet.eta()) > 3.0))
+        passCut(ret, indexNHF_EC_);
+      if (ignoreCut(indexNEF_EC_L_) ||
+          (nef > cut(indexNEF_EC_L_, double()) || std::abs(jet.eta()) <= 2.7 || std::abs(jet.eta()) > 3.0))
+        passCut(ret, indexNEF_EC_L_);
+      if (ignoreCut(indexNEF_EC_U_) ||
+          (nef < cut(indexNEF_EC_U_, double()) || std::abs(jet.eta()) <= 2.7 || std::abs(jet.eta()) > 3.0))
+        passCut(ret, indexNEF_EC_U_);
+      if (ignoreCut(indexNNeutrals_EC_) ||
+          (nneutrals > cut(indexNNeutrals_EC_, int()) || std::abs(jet.eta()) <= 2.7 || std::abs(jet.eta()) > 3.0))
+        passCut(ret, indexNNeutrals_EC_);
+
+      // Cuts for |eta| > 3.0 for RUN2UL16CHS scenario
+      if (ignoreCut(indexNHF_FW_) || (nhf > cut(indexNHF_FW_, double()) || std::abs(jet.eta()) <= 3.0))
+        passCut(ret, indexNHF_FW_);
+      if (ignoreCut(indexNEF_FW_) || (nef < cut(indexNEF_FW_, double()) || std::abs(jet.eta()) <= 3.0))
+        passCut(ret, indexNEF_FW_);
+      if (ignoreCut(indexNNeutrals_FW_) || (nneutrals > cut(indexNNeutrals_FW_, int()) || std::abs(jet.eta()) <= 3.0))
+        passCut(ret, indexNNeutrals_FW_);
+
+    } else if (version_ == RUN2UL16PUPPI) {
+      // Cuts for |eta| <= 2.6 for RUN2UL16PUPPI scenario
+      if (ignoreCut(indexNConstituents_) ||
+          (nconstituents > cut(indexNConstituents_, int()) || std::abs(jet.eta()) > 2.4))
+        passCut(ret, indexNConstituents_);
+      if (ignoreCut(indexNEF_) || (nef < cut(indexNEF_, double()) || std::abs(jet.eta()) > 2.4))
+        passCut(ret, indexNEF_);
+      if (ignoreCut(indexNHF_) || (nhf < cut(indexNHF_, double()) || std::abs(jet.eta()) > 2.4))
+        passCut(ret, indexNHF_);
+      if (quality_ == TIGHTLEPVETO) {
+        if (ignoreCut(indexMUF_) || (muf < cut(indexMUF_, double()) || std::abs(jet.eta()) > 2.4))
+          passCut(ret, indexMUF_);
+      }
+
+      // Cuts for 2.4 <= |eta| <= 2.7 for RUN2UL16PUPPI scenario
+      if (ignoreCut(indexNHF_TR_) ||
+          (nhf < cut(indexNHF_TR_, double()) || std::abs(jet.eta()) <= 2.4 || std::abs(jet.eta()) > 2.7))
+        passCut(ret, indexNHF_TR_);
+      if (ignoreCut(indexNEF_TR_) ||
+          (nef < cut(indexNEF_TR_, double()) || std::abs(jet.eta()) <= 2.4 || std::abs(jet.eta()) > 2.7))
+        passCut(ret, indexNEF_TR_);
+
+      // Cuts for 2.7 < |eta| <= 3.0 for RUN2UL16PUPPI scenario
+      if (ignoreCut(indexNNeutrals_EC_) ||
+          (nneutrals > cut(indexNNeutrals_EC_, int()) || std::abs(jet.eta()) <= 2.7 || std::abs(jet.eta()) > 3.0))
+        passCut(ret, indexNNeutrals_EC_);
+
+      // Cuts for |eta| > 3.0 for RUN2UL16PUPPI scenario
+      if (ignoreCut(indexNEF_FW_) || (nef < cut(indexNEF_FW_, double()) || std::abs(jet.eta()) <= 3.0))
+        passCut(ret, indexNEF_FW_);
+      if (ignoreCut(indexNNeutrals_FW_L_) ||
+          (nneutrals > cut(indexNNeutrals_FW_L_, int()) || std::abs(jet.eta()) <= 3.0))
+        passCut(ret, indexNNeutrals_FW_L_);
+      if (ignoreCut(indexNNeutrals_FW_U_) ||
+          (nneutrals < cut(indexNNeutrals_FW_U_, int()) || std::abs(jet.eta()) <= 3.0))
+        passCut(ret, indexNNeutrals_FW_U_);
+
     } else if ((version_ == SUMMER18) || (version_ == RUN2ULCHS)) {
       // Cuts for |eta| <= 2.6 for SUMMER18 scenario
       if (ignoreCut(indexNConstituents_) ||
@@ -855,6 +937,23 @@ private:  // member variables
         set("NEF_FW", 0.90);
         set("nNeutrals_FW_L", 2);
         set("nNeutrals_FW_U", 15);
+      } else if (version_ == RUN2UL16CHS) {
+        set("NHF_TR", 0.9);
+        set("NEF_TR", 0.99);
+        set("NHF_EC", 0.9);
+        set("NEF_EC_L", 0.);
+        set("NEF_EC_U", 0.99);
+        set("nNeutrals_EC", 1);
+        set("NHF_FW", 0.2);
+        set("NEF_FW", 0.90);
+        set("nNeutrals_FW", 10);
+      } else if (version_ == RUN2UL16PUPPI) {
+        set("NHF_TR", 0.98);
+        set("NEF_TR", 0.99);
+        set("nNeutrals_EC", 1);
+        set("NEF_FW", 0.90);
+        set("nNeutrals_FW_L", 2);
+        set("nNeutrals_FW_U", 999999);
       } else if (version_ == RUN2ULCHS) {
         set("NHF_TR", 0.9);
         set("NEF_TR", 0.99);
@@ -948,8 +1047,8 @@ private:  // member variables
         set("nNeutrals_FW_L", 2);
         set("nNeutrals_FW_U", 15);
       } else if (version_ == RUN2UL16CHS) {
-        set("CEF", 0.8);
         set("MUF", 0.8);
+        set("CEF", 0.8);
         set("NHF_TR", 0.9);
         set("NEF_TR", 0.99);
         set("NHF_EC", 0.9);
@@ -960,8 +1059,8 @@ private:  // member variables
         set("NEF_FW", 0.90);
         set("nNeutrals_FW", 10);
       } else if (version_ == RUN2UL16PUPPI) {
-        set("CEF", 0.8);
         set("MUF", 0.8);
+        set("CEF", 0.8);
         set("NHF_TR", 0.98);
         set("NEF_TR", 0.99);
         set("nNeutrals_EC", 1);


### PR DESCRIPTION
#### PR description:

- This is a backport of #33826 
- We need this for nanoAODv9. 