### PR TITLE
Rename pixelVertexCUDA|SoA to pixelVerticesCUDA|SoA

### DIFF
--- a/RecoPixelVertexing/Configuration/python/RecoPixelVertexing_cff.py
+++ b/RecoPixelVertexing/Configuration/python/RecoPixelVertexing_cff.py
@@ -13,9 +13,9 @@ pixelVerticesTask = cms.Task(
 from Configuration.ProcessModifiers.pixelNtupletFit_cff import pixelNtupletFit
 
 # build the pixel vertices in SoA format on the CPU
-from RecoPixelVertexing.PixelVertexFinding.pixelVertexCUDA_cfi import pixelVertexCUDA as _pixelVertexCUDA
+from RecoPixelVertexing.PixelVertexFinding.pixelVerticesCUDA_cfi import pixelVerticesCUDA as _pixelVerticesCUDA
 pixelVerticesSoA = SwitchProducerCUDA(
-    cpu = _pixelVertexCUDA.clone(
+    cpu = _pixelVerticesCUDA.clone(
         pixelTrackSrc = "pixelTracksSoA",
         onGPU = False
     )
@@ -39,15 +39,15 @@ pixelNtupletFit.toReplaceWith(pixelVerticesTask, cms.Task(
 from Configuration.ProcessModifiers.gpu_cff import gpu
 
 # build pixel vertices in SoA format on the GPU
-pixelVerticesCUDA = _pixelVertexCUDA.clone(
+pixelVerticesCUDA = _pixelVerticesCUDA.clone(
     pixelTrackSrc = "pixelTracksCUDA",
     onGPU = True
 )
 
 # transfer the pixel vertices in SoA format to the CPU
-from RecoPixelVertexing.PixelVertexFinding.pixelVertexSoA_cfi import pixelVertexSoA as _pixelVertexSoA
+from RecoPixelVertexing.PixelVertexFinding.pixelVerticesSoA_cfi import pixelVerticesSoA as _pixelVerticesSoA
 gpu.toModify(pixelVerticesSoA,
-    cuda = _pixelVertexSoA.clone(
+    cuda = _pixelVerticesSoA.clone(
         src = cms.InputTag("pixelVerticesCUDA")
     )
 )

--- a/RecoPixelVertexing/PixelTrackFitting/plugins/PixelTrackDumpCUDA.cc
+++ b/RecoPixelVertexing/PixelTrackFitting/plugins/PixelTrackDumpCUDA.cc
@@ -55,7 +55,7 @@ void PixelTrackDumpCUDA::fillDescriptions(edm::ConfigurationDescriptions& descri
 
   desc.add<bool>("onGPU", true);
   desc.add<edm::InputTag>("pixelTrackSrc", edm::InputTag("pixelTracksCUDA"));
-  desc.add<edm::InputTag>("pixelVertexSrc", edm::InputTag("pixelVertexCUDA"));
+  desc.add<edm::InputTag>("pixelVertexSrc", edm::InputTag("pixelVerticesCUDA"));
   descriptions.add("pixelTrackDumpCUDA", desc);
 }
 

--- a/RecoPixelVertexing/PixelVertexFinding/plugins/PixelVertexProducerCUDA.cc
+++ b/RecoPixelVertexing/PixelVertexFinding/plugins/PixelVertexProducerCUDA.cc
@@ -87,7 +87,7 @@ void PixelVertexProducerCUDA::fillDescriptions(edm::ConfigurationDescriptions& d
   desc.add<double>("PtMin", 0.5);
   desc.add<edm::InputTag>("pixelTrackSrc", edm::InputTag("pixelTracksCUDA"));
 
-  auto label = "pixelVertexCUDA";
+  auto label = "pixelVerticesCUDA";
   descriptions.add(label, desc);
 }
 

--- a/RecoPixelVertexing/PixelVertexFinding/plugins/PixelVertexProducerFromSoA.cc
+++ b/RecoPixelVertexing/PixelVertexFinding/plugins/PixelVertexProducerFromSoA.cc
@@ -54,7 +54,7 @@ void PixelVertexProducerFromSoA::fillDescriptions(edm::ConfigurationDescriptions
 
   desc.add<edm::InputTag>("TrackCollection", edm::InputTag("pixelTracks"));
   desc.add<edm::InputTag>("beamSpot", edm::InputTag("offlineBeamSpot"));
-  desc.add<edm::InputTag>("src", edm::InputTag("pixelVertexSoA"));
+  desc.add<edm::InputTag>("src", edm::InputTag("pixelVerticesSoA"));
 
   descriptions.add("pixelVertexFromSoA", desc);
 }

--- a/RecoPixelVertexing/PixelVertexFinding/plugins/PixelVertexSoAFromCUDA.cc
+++ b/RecoPixelVertexing/PixelVertexFinding/plugins/PixelVertexSoAFromCUDA.cc
@@ -43,8 +43,8 @@ PixelVertexSoAFromCUDA::PixelVertexSoAFromCUDA(const edm::ParameterSet& iConfig)
 void PixelVertexSoAFromCUDA::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
 
-  desc.add<edm::InputTag>("src", edm::InputTag("pixelVertexCUDA"));
-  descriptions.add("pixelVertexSoA", desc);
+  desc.add<edm::InputTag>("src", edm::InputTag("pixelVerticesCUDA"));
+  descriptions.add("pixelVerticesSoA", desc);
 }
 
 void PixelVertexSoAFromCUDA::acquire(edm::Event const& iEvent,

--- a/RecoTracker/Configuration/python/customizePixelOnlyForProfiling.py
+++ b/RecoTracker/Configuration/python/customizePixelOnlyForProfiling.py
@@ -6,7 +6,7 @@ import FWCore.ParameterSet.Config as cms
 def customizePixelOnlyForProfilingGPUOnly(process):
 
   process.consumer = cms.EDAnalyzer("GenericConsumer",
-      eventProducts = cms.untracked.vstring('pixelTracksCUDA', 'pixelVertexCUDA')
+      eventProducts = cms.untracked.vstring('pixelTracksCUDA', 'pixelVerticesCUDA')
   )
 
   process.consume_step = cms.EndPath(process.consumer)
@@ -28,7 +28,7 @@ def customizePixelOnlyForProfilingGPUWithHostCopy(process):
   #? process.siPixelRecHitSoAFromLegacy.convertToLegacy = False
 
   process.consumer = cms.EDAnalyzer("GenericConsumer",
-      eventProducts = cms.untracked.vstring('pixelTracksSoA', 'pixelVertexSoA')
+      eventProducts = cms.untracked.vstring('pixelTracksSoA', 'pixelVerticesSoA')
   )
 
   process.consume_step = cms.EndPath(process.consumer)


### PR DESCRIPTION
#### PR description:

Rename the GPU modules `pixelVertexCUDA` and `pixelVertexSoA` to `pixelVerticesCUDA` and `pixelVerticesSoA`, for consistency with CPU modules.


#### PR validation:

None.