### PR TITLE
Fix prodlike workflow to use DIGI instead of DIGI:pdigi_valid

### DIFF
--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -915,7 +915,7 @@ class UpgradeWorkflowPremixProdLike(UpgradeWorkflowPremix,UpgradeWorkflow_ProdLi
             d = merge([stepDict[self.getStepName(step)][k]])
             tmpsteps = []
             for s in d["-s"].split(","):
-                if s == "DIGI:pdigi_valid" in s:
+                if "DIGI:pdigi_valid" in s:
                     tmpsteps.append("DIGI")
                 else:
                     tmpsteps.append(s)

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -547,6 +547,8 @@ class UpgradeWorkflow_ProdLike(UpgradeWorkflow):
     def setup_(self, step, stepName, stepDict, k, properties):
         if 'Digi' in step and 'Trigger' not in step:
             stepDict[stepName][k] = merge([{'-s': 'DIGI,L1,DIGI2RAW,HLT:@relval2021', '--datatier':'GEN-SIM-DIGI-RAW', '--eventcontent':'RAWSIM'}, stepDict[step][k]])
+        elif 'DigiTrigger' in step: # for Phase-2
+            stepDict[stepName][k] = merge([{'-s': 'DIGI,L1TrackTrigger,L1,DIGI2RAW,HLT:@fake2'}, stepDict[step][k]])
         elif 'Reco' in step:
             stepDict[stepName][k] = merge([{'-s': 'RAW2DIGI,L1Reco,RECO,RECOSIM', '--datatier':'AODSIM', '--eventcontent':'AODSIM'}, stepDict[step][k]])
         elif 'MiniAOD' in step:
@@ -562,6 +564,7 @@ class UpgradeWorkflow_ProdLike(UpgradeWorkflow):
 upgradeWFs['ProdLike'] = UpgradeWorkflow_ProdLike(
     steps = [
         'Digi',
+        'DigiTrigger',
         'Reco',
         'RecoGlobal',
         'HARVEST',
@@ -572,6 +575,7 @@ upgradeWFs['ProdLike'] = UpgradeWorkflow_ProdLike(
     ],
     PU = [
         'Digi',
+        'DigiTrigger',
         'Reco',
         'RecoGlobal',
         'HARVEST',
@@ -906,6 +910,17 @@ class UpgradeWorkflowPremixProdLike(UpgradeWorkflowPremix,UpgradeWorkflow_ProdLi
         # copy steps, then apply specializations
         UpgradeWorkflowPremix.setup_(self, step, stepName, stepDict, k, properties)
         UpgradeWorkflow_ProdLike.setup_(self, step, stepName, stepDict, k, properties)
+        #
+        if 'Digi' in step:
+            d = merge([stepDict[self.getStepName(step)][k]])
+            tmpsteps = []
+            for s in d["-s"].split(","):
+                if s == "DIGI:pdigi_valid" in s:
+                    tmpsteps.append("DIGI")
+                else:
+                    tmpsteps.append(s)
+            d = merge([{"-s" : ",".join(tmpsteps)},d])
+            stepDict[stepName][k] = d
     def condition(self, fragment, stepList, key, hasHarvest):
         # use both conditions
         return UpgradeWorkflowPremix.condition(self, fragment, stepList, key, hasHarvest) and UpgradeWorkflow_ProdLike.condition(self, fragment, stepList, key, hasHarvest)

--- a/SimGeneral/MixingModule/python/digitizers_cfi.py
+++ b/SimGeneral/MixingModule/python/digitizers_cfi.py
@@ -58,6 +58,7 @@ phase2_hgcal.toModify( theDigitizers,
                        hgceeDigitizer = cms.PSet(hgceeDigitizer),
                        hgchebackDigitizer = cms.PSet(hgchebackDigitizer),
                        hgchefrontDigitizer = cms.PSet(hgchefrontDigitizer),
+                       calotruth = cms.PSet(caloParticles), #HGCAL still needs calotruth for production mode
 )
 
 from SimCalorimetry.HGCalSimProducers.hgcalDigitizer_cfi import hfnoseDigitizer
@@ -88,6 +89,7 @@ premix_stage2.toModify(theDigitizers,
     hgceeDigitizer = dict(premixStage1 = True),
     hgchebackDigitizer = dict(premixStage1 = True),
     hgchefrontDigitizer = dict(premixStage1 = True),
+    calotruth = dict(premixStage1 = True), #HGCAL still needs calotruth for production mode
 )
 (premix_stage2 & phase2_hfnose).toModify(theDigitizers,
     hfnoseDigitizer = dict(premixStage1 = True),
@@ -104,9 +106,8 @@ theDigitizers.mergedtruth.select.signalOnlyTP = True
 
 from Configuration.ProcessModifiers.run3_ecalclustering_cff import run3_ecalclustering
 (run3_ecalclustering | phase2_hgcal).toModify( theDigitizersValid,
-                       calotruth = cms.PSet( caloParticles ) ) # Doesn't HGCal need these also without validation?
+                       calotruth = cms.PSet( caloParticles ) )
 (premix_stage2 & phase2_hgcal).toModify(theDigitizersValid, calotruth = dict(premixStage1 = True))
-
 
 phase2_timing.toModify( theDigitizersValid.mergedtruth,
                         createInitialVertexCollection = cms.bool(True) )


### PR DESCRIPTION
#### PR description:
Currently, Phase-2 prod-like workflow uses DIGI:pdigi_valid instead of DIGI. This PR is to make a clear cut between production and relvals with DIGI and DIGI:pdigi_valid respectively. To run in production mode, we need to adapt `digitizers_cfi.py` to include Calo MCTruth for HGCAL in DIGI.

No change is expected for relvals as pdigi_valid will be used as before. The change is only the size of events in production mode. With PU200 ttbar, it can save more than 30MB/events as MergeTrackTruth will not be stored.

#### PR validation:
Get proper cmsDriver(s) when use
`runTheMatrix.py --what upgrade -l 23234.0,23234.21,23434.21,23434.9921 --dryRun`

#### if this PR is a backport please specify the original PR and why you need to backport that PR:
Not a backport, and no need for backport