### PR TITLE
Migrate part of PPS modules to use esConsumes

### DIFF
--- a/CalibPPS/ESProducers/plugins/CTPPSAlignmentInfo.cc
+++ b/CalibPPS/ESProducers/plugins/CTPPSAlignmentInfo.cc
@@ -33,40 +33,34 @@ private:
 
   edm::ESWatcher<RPRealAlignmentRecord> watcherRealAlignments_;
   edm::ESWatcher<RPMisalignedAlignmentRecord> watcherMisalignedAlignments_;
+  edm::ESGetToken<CTPPSRPAlignmentCorrectionsData, RPRealAlignmentRecord> alignmentToken_;
+
 
   void analyze(const edm::Event&, const edm::EventSetup&) override;
 
   void printInfo(const CTPPSRPAlignmentCorrectionsData& alignments, const edm::Event& event) const;
 };
 
-//----------------------------------------------------------------------------------------------------
-//----------------------------------------------------------------------------------------------------
-
-using namespace std;
-using namespace edm;
-
-//----------------------------------------------------------------------------------------------------
-
 CTPPSAlignmentInfo::CTPPSAlignmentInfo(const edm::ParameterSet& iConfig)
-    : alignmentType_(iConfig.getUntrackedParameter<std::string>("alignmentType", "real")) {}
+  : alignmentType_(iConfig.getUntrackedParameter<std::string>("alignmentType", "real")), alignmentToken_(esConsumes()) {}
 
 //----------------------------------------------------------------------------------------------------
 
 void CTPPSAlignmentInfo::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
-  edm::ESHandle<CTPPSRPAlignmentCorrectionsData> alignments;
+  //  edm::ESHandle<CTPPSRPAlignmentCorrectionsData> alignments;
 
   if (alignmentType_ == "real") {
     if (watcherRealAlignments_.check(iSetup)) {
-      iSetup.get<RPRealAlignmentRecord>().get(alignments);
-      printInfo(*alignments, iEvent);
+      auto const& alignments = iSetup.getData(alignmentToken_);
+      printInfo(alignments, iEvent);
     }
     return;
   }
 
   else if (alignmentType_ == "misaligned") {
     if (watcherMisalignedAlignments_.check(iSetup)) {
-      iSetup.get<RPMisalignedAlignmentRecord>().get(alignments);
-      printInfo(*alignments, iEvent);
+      auto const& alignments = iSetup.getData(alignmentToken_);
+      printInfo(alignments, iEvent);
     }
     return;
   }

--- a/CalibPPS/ESProducers/plugins/CTPPSAlignmentInfo.cc
+++ b/CalibPPS/ESProducers/plugins/CTPPSAlignmentInfo.cc
@@ -35,19 +35,18 @@ private:
   edm::ESWatcher<RPMisalignedAlignmentRecord> watcherMisalignedAlignments_;
   edm::ESGetToken<CTPPSRPAlignmentCorrectionsData, RPRealAlignmentRecord> alignmentToken_;
 
-
   void analyze(const edm::Event&, const edm::EventSetup&) override;
 
   void printInfo(const CTPPSRPAlignmentCorrectionsData& alignments, const edm::Event& event) const;
 };
 
 CTPPSAlignmentInfo::CTPPSAlignmentInfo(const edm::ParameterSet& iConfig)
-  : alignmentType_(iConfig.getUntrackedParameter<std::string>("alignmentType", "real")), alignmentToken_(esConsumes()) {}
+    : alignmentType_(iConfig.getUntrackedParameter<std::string>("alignmentType", "real")),
+      alignmentToken_(esConsumes()) {}
 
 //----------------------------------------------------------------------------------------------------
 
 void CTPPSAlignmentInfo::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
-
   if (alignmentType_ == "real") {
     if (watcherRealAlignments_.check(iSetup)) {
       auto const& alignments = iSetup.getData(alignmentToken_);

--- a/CalibPPS/ESProducers/plugins/CTPPSAlignmentInfo.cc
+++ b/CalibPPS/ESProducers/plugins/CTPPSAlignmentInfo.cc
@@ -1,9 +1,9 @@
 /****************************************************************************
-*
-* Authors:
-*  Jan Kašpar (jan.kaspar@gmail.com) 
-*    
-****************************************************************************/
+ *
+ * Authors:
+ *  Jan Kašpar (jan.kaspar@gmail.com) 
+ *    
+ ****************************************************************************/
 
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -47,7 +47,6 @@ CTPPSAlignmentInfo::CTPPSAlignmentInfo(const edm::ParameterSet& iConfig)
 //----------------------------------------------------------------------------------------------------
 
 void CTPPSAlignmentInfo::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
-  //  edm::ESHandle<CTPPSRPAlignmentCorrectionsData> alignments;
 
   if (alignmentType_ == "real") {
     if (watcherRealAlignments_.check(iSetup)) {

--- a/CalibPPS/ESProducers/plugins/PrintTotemDAQMapping.cc
+++ b/CalibPPS/ESProducers/plugins/PrintTotemDAQMapping.cc
@@ -1,10 +1,10 @@
 /****************************************************************************
-*
-* This is a part of TOTEM offline software.
-* Authors: 
-*  Jan Kašpar (jan.kaspar@gmail.com) 
-*
-****************************************************************************/
+ *
+ * This is a part of TOTEM offline software.
+ * Authors: 
+ *  Jan Kašpar (jan.kaspar@gmail.com) 
+ *
+ ****************************************************************************/
 
 #include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
@@ -24,45 +24,40 @@
  **/
 class PrintTotemDAQMapping : public edm::one::EDAnalyzer<> {
 public:
+
   PrintTotemDAQMapping(const edm::ParameterSet &ps);
   ~PrintTotemDAQMapping() override {}
 
 private:
-  /// label of the CTPPS sub-system
+/// label of the CTPPS sub-system
   std::string subSystemName;
-
+  edm::ESGetToken<TotemDAQMapping, TotemReadoutRcd> mappingToken_;
+  edm::ESGetToken<TotemAnalysisMask, TotemReadoutRcd> maskToken_;
   void analyze(const edm::Event &e, const edm::EventSetup &es) override;
 };
 
-using namespace std;
-using namespace edm;
-
-//----------------------------------------------------------------------------------------------------
-
 PrintTotemDAQMapping::PrintTotemDAQMapping(const edm::ParameterSet &ps)
-    : subSystemName(ps.getUntrackedParameter<string>("subSystem")) {}
+  : subSystemName(ps.getUntrackedParameter<std::string>("subSystem")), mappingToken_(esConsumes(edm::ESInputTag("", subSystemName))), maskToken_(esConsumes(edm::ESInputTag("", subSystemName))) {}
 
 //----------------------------------------------------------------------------------------------------
 
-void PrintTotemDAQMapping::analyze(const edm::Event &, edm::EventSetup const &es) {
-  // get mapping
-  ESHandle<TotemDAQMapping> mapping;
-  es.get<TotemReadoutRcd>().get(subSystemName, mapping);
+void PrintTotemDAQMapping::analyze(const edm::Event &, edm::EventSetup const &es) 
+{
+// get mapping
+  auto const& mapping = es.getData(mappingToken_);
 
-  // get analysis mask to mask channels
-  ESHandle<TotemAnalysisMask> analysisMask;
-  es.get<TotemReadoutRcd>().get(subSystemName, analysisMask);
+// get analysis mask to mask channels
+  auto const& analysisMask = es.getData(maskToken_);
 
-  // print mapping
-  printf("* DAQ mapping\n");
-  for (const auto &p : mapping->VFATMapping)
-    cout << "    " << p.first << " -> " << p.second << endl;
+// print mapping
+  for (const auto &p : mapping.VFATMapping)
+    edm::LogInfo("PrintTotemDAQMapping mapping")  << "    " << p.first << " -> " << p.second;
 
-  // print mapping
-  printf("* mask\n");
-  for (const auto &p : analysisMask->analysisMask)
-    cout << "    " << p.first << ": fullMask=" << p.second.fullMask << ", number of masked channels "
-         << p.second.maskedChannels.size() << endl;
+// print mapping
+  for (const auto &p : analysisMask.analysisMask)
+    edm::LogInfo("PrintTotemDAQMapping mask") << "    " << p.first << ": fullMask=" << p.second.fullMask 
+					      << ", number of masked channels "
+					      << p.second.maskedChannels.size();
 }
 
 //----------------------------------------------------------------------------------------------------

--- a/CalibPPS/ESProducers/plugins/PrintTotemDAQMapping.cc
+++ b/CalibPPS/ESProducers/plugins/PrintTotemDAQMapping.cc
@@ -24,12 +24,11 @@
  **/
 class PrintTotemDAQMapping : public edm::one::EDAnalyzer<> {
 public:
-
   PrintTotemDAQMapping(const edm::ParameterSet &ps);
   ~PrintTotemDAQMapping() override {}
 
 private:
-/// label of the CTPPS sub-system
+  /// label of the CTPPS sub-system
   std::string subSystemName;
   edm::ESGetToken<TotemDAQMapping, TotemReadoutRcd> mappingToken_;
   edm::ESGetToken<TotemAnalysisMask, TotemReadoutRcd> maskToken_;
@@ -37,27 +36,27 @@ private:
 };
 
 PrintTotemDAQMapping::PrintTotemDAQMapping(const edm::ParameterSet &ps)
-  : subSystemName(ps.getUntrackedParameter<std::string>("subSystem")), mappingToken_(esConsumes(edm::ESInputTag("", subSystemName))), maskToken_(esConsumes(edm::ESInputTag("", subSystemName))) {}
+    : subSystemName(ps.getUntrackedParameter<std::string>("subSystem")),
+      mappingToken_(esConsumes(edm::ESInputTag("", subSystemName))),
+      maskToken_(esConsumes(edm::ESInputTag("", subSystemName))) {}
 
 //----------------------------------------------------------------------------------------------------
 
-void PrintTotemDAQMapping::analyze(const edm::Event &, edm::EventSetup const &es) 
-{
-// get mapping
-  auto const& mapping = es.getData(mappingToken_);
+void PrintTotemDAQMapping::analyze(const edm::Event &, edm::EventSetup const &es) {
+  // get mapping
+  auto const &mapping = es.getData(mappingToken_);
 
-// get analysis mask to mask channels
-  auto const& analysisMask = es.getData(maskToken_);
+  // get analysis mask to mask channels
+  auto const &analysisMask = es.getData(maskToken_);
 
-// print mapping
+  // print mapping
   for (const auto &p : mapping.VFATMapping)
-    edm::LogInfo("PrintTotemDAQMapping mapping")  << "    " << p.first << " -> " << p.second;
+    edm::LogInfo("PrintTotemDAQMapping mapping") << "    " << p.first << " -> " << p.second;
 
-// print mapping
+  // print mapping
   for (const auto &p : analysisMask.analysisMask)
-    edm::LogInfo("PrintTotemDAQMapping mask") << "    " << p.first << ": fullMask=" << p.second.fullMask 
-					      << ", number of masked channels "
-					      << p.second.maskedChannels.size();
+    edm::LogInfo("PrintTotemDAQMapping mask") << "    " << p.first << ": fullMask=" << p.second.fullMask
+                                              << ", number of masked channels " << p.second.maskedChannels.size();
 }
 
 //----------------------------------------------------------------------------------------------------

--- a/DQM/CTPPS/plugins/TotemRPDQMSource.cc
+++ b/DQM/CTPPS/plugins/TotemRPDQMSource.cc
@@ -53,6 +53,8 @@ private:
   edm::EDGetTokenT<edm::DetSetVector<TotemRPUVPattern>> tokenUVPattern;
   edm::EDGetTokenT<edm::DetSetVector<TotemRPLocalTrack>> tokenLocalTrack;
 
+  edm::ESGetToken<CTPPSGeometry,VeryForwardRealGeometryRecord> geometryToken_;
+
   /// plots related to one RP
   struct PotPlots {
     MonitorElement *vfat_problem = nullptr, *vfat_missing = nullptr, *vfat_ec_bc_error = nullptr,
@@ -176,7 +178,10 @@ TotemRPDQMSource::PlanePlots::PlanePlots(DQMStore::IBooker &ibooker, unsigned in
 //----------------------------------------------------------------------------------------------------
 
 TotemRPDQMSource::TotemRPDQMSource(const edm::ParameterSet &ps)
-    : verbosity(ps.getUntrackedParameter<unsigned int>("verbosity", 0)) {
+  : verbosity(ps.getUntrackedParameter<unsigned int>("verbosity", 0)),
+    geometryToken_(esConsumes())
+      
+ {
   tokenStatus = consumes<DetSetVector<TotemVFATStatus>>(ps.getParameter<edm::InputTag>("tagStatus"));
 
   tokenDigi = consumes<DetSetVector<TotemRPDigi>>(ps.getParameter<edm::InputTag>("tagDigi"));
@@ -219,8 +224,7 @@ void TotemRPDQMSource::bookHistograms(DQMStore::IBooker &ibooker, edm::Run const
 
 void TotemRPDQMSource::analyze(edm::Event const &event, edm::EventSetup const &eventSetup) {
   // get event setup data
-  ESHandle<CTPPSGeometry> geometry;
-  eventSetup.get<VeryForwardRealGeometryRecord>().get(geometry);
+  auto const& geometry = eventSetup.getData(geometryToken_);
 
   // get event data
   Handle<DetSetVector<TotemVFATStatus>> status;
@@ -341,7 +345,7 @@ void TotemRPDQMSource::analyze(edm::Event const &event, edm::EventSetup const &e
       if (!ft.isValid())
         continue;
 
-      double rp_z = geometry->rpTranslation(rpId).z();
+      double rp_z = geometry.rpTranslation(rpId).z();
 
       for (unsigned int plNum = 0; plNum < 10; ++plNum) {
         TotemRPDetId plId = rpId;
@@ -356,7 +360,7 @@ void TotemRPDQMSource::analyze(edm::Event const &event, edm::EventSetup const &e
         double ft_x = ft.x0() + ft.tx() * (ft_z - rp_z);
         double ft_y = ft.y0() + ft.ty() * (ft_z - rp_z);
 
-        double ft_v = geometry->globalToLocal(plId, CTPPSGeometry::Vector(ft_x, ft_y, ft_z)).y();
+        double ft_v = geometry.globalToLocal(plId, CTPPSGeometry::Vector(ft_x, ft_y, ft_z)).y();
 
         bool hasMatchingHit = false;
         const auto &hit_ds_it = hits->find(plId);
@@ -563,12 +567,12 @@ void TotemRPDQMSource::analyze(edm::Event const &event, edm::EventSetup const &e
       TotemRPDetId plId_U(rpId);
       plId_U.setPlane(1);
 
-      double rp_x = (geometry->sensor(plId_V)->translation().x() + geometry->sensor(plId_U)->translation().x()) / 2.;
-      double rp_y = (geometry->sensor(plId_V)->translation().y() + geometry->sensor(plId_U)->translation().y()) / 2.;
+      double rp_x = (geometry.sensor(plId_V)->translation().x() + geometry.sensor(plId_U)->translation().x()) / 2.;
+      double rp_y = (geometry.sensor(plId_V)->translation().y() + geometry.sensor(plId_U)->translation().y()) / 2.;
 
       // mean read-out direction of U and V planes
-      const auto &rod_U = geometry->localToGlobalDirection(plId_U, CTPPSGeometry::Vector(0., 1., 0.));
-      const auto &rod_V = geometry->localToGlobalDirection(plId_V, CTPPSGeometry::Vector(0., 1., 0.));
+      const auto &rod_U = geometry.localToGlobalDirection(plId_U, CTPPSGeometry::Vector(0., 1., 0.));
+      const auto &rod_V = geometry.localToGlobalDirection(plId_V, CTPPSGeometry::Vector(0., 1., 0.));
 
       double x = ft.x0() - rp_x;
       double y = ft.y0() - rp_y;

--- a/DQM/CTPPS/plugins/TotemRPDQMSource.cc
+++ b/DQM/CTPPS/plugins/TotemRPDQMSource.cc
@@ -53,7 +53,7 @@ private:
   edm::EDGetTokenT<edm::DetSetVector<TotemRPUVPattern>> tokenUVPattern;
   edm::EDGetTokenT<edm::DetSetVector<TotemRPLocalTrack>> tokenLocalTrack;
 
-  edm::ESGetToken<CTPPSGeometry,VeryForwardRealGeometryRecord> geometryToken_;
+  edm::ESGetToken<CTPPSGeometry, VeryForwardRealGeometryRecord> geometryToken_;
 
   /// plots related to one RP
   struct PotPlots {
@@ -178,10 +178,10 @@ TotemRPDQMSource::PlanePlots::PlanePlots(DQMStore::IBooker &ibooker, unsigned in
 //----------------------------------------------------------------------------------------------------
 
 TotemRPDQMSource::TotemRPDQMSource(const edm::ParameterSet &ps)
-  : verbosity(ps.getUntrackedParameter<unsigned int>("verbosity", 0)),
-    geometryToken_(esConsumes())
-      
- {
+    : verbosity(ps.getUntrackedParameter<unsigned int>("verbosity", 0)),
+      geometryToken_(esConsumes())
+
+{
   tokenStatus = consumes<DetSetVector<TotemVFATStatus>>(ps.getParameter<edm::InputTag>("tagStatus"));
 
   tokenDigi = consumes<DetSetVector<TotemRPDigi>>(ps.getParameter<edm::InputTag>("tagDigi"));
@@ -224,7 +224,7 @@ void TotemRPDQMSource::bookHistograms(DQMStore::IBooker &ibooker, edm::Run const
 
 void TotemRPDQMSource::analyze(edm::Event const &event, edm::EventSetup const &eventSetup) {
   // get event setup data
-  auto const& geometry = eventSetup.getData(geometryToken_);
+  auto const &geometry = eventSetup.getData(geometryToken_);
 
   // get event data
   Handle<DetSetVector<TotemVFATStatus>> status;

--- a/DQM/CTPPS/plugins/TotemTimingDQMSource.cc
+++ b/DQM/CTPPS/plugins/TotemTimingDQMSource.cc
@@ -98,8 +98,8 @@ private:
   edm::EDGetTokenT<edm::DetSetVector<TotemTimingRecHit>> tokenRecHit_;
   edm::EDGetTokenT<std::vector<TotemFEDInfo>> tokenFEDInfo_;
 
-  edm::ESGetToken<CTPPSGeometry,VeryForwardRealGeometryRecord> geometryToken_;
-  edm::ESGetToken<CTPPSGeometry,VeryForwardRealGeometryRecord> geometryTokenBeginRun_;
+  edm::ESGetToken<CTPPSGeometry, VeryForwardRealGeometryRecord> geometryToken_;
+  edm::ESGetToken<CTPPSGeometry, VeryForwardRealGeometryRecord> geometryTokenBeginRun_;
 
   double minimumStripAngleForTomography_;
   double maximumStripAngleForTomography_;
@@ -409,7 +409,7 @@ TotemTimingDQMSource::TotemTimingDQMSource(const edm::ParameterSet &ps)
       // tokenTrack_(consumes<edm::DetSetVector<TotemTimingLocalTrack>>(
       //     ps.getParameter<edm::InputTag>("tagLocalTracks"))),
       tokenFEDInfo_(consumes<std::vector<TotemFEDInfo>>(ps.getParameter<edm::InputTag>("tagFEDInfo"))),
-      geometryToken_(esConsumes()), 
+      geometryToken_(esConsumes()),
       geometryTokenBeginRun_(esConsumes<edm::Transition::BeginRun>()),
       minimumStripAngleForTomography_(ps.getParameter<double>("minimumStripAngleForTomography")),
       maximumStripAngleForTomography_(ps.getParameter<double>("maximumStripAngleForTomography")),
@@ -425,7 +425,7 @@ TotemTimingDQMSource::~TotemTimingDQMSource() {}
 
 void TotemTimingDQMSource::dqmBeginRun(const edm::Run &iRun, const edm::EventSetup &iSetup) {
   // Get detector shifts from the geometry (if present)
-  auto const& geom = iSetup.getData(geometryTokenBeginRun_);
+  auto const &geom = iSetup.getData(geometryTokenBeginRun_);
 
   const TotemTimingDetId detid_top(0, TOTEM_TIMING_STATION_ID, TOTEM_TIMING_BOT_RP_ID, 0, 0);
   const TotemTimingDetId detid_bot(0, TOTEM_TIMING_STATION_ID, TOTEM_TIMING_TOP_RP_ID, 0, 7);
@@ -482,7 +482,7 @@ std::shared_ptr<totemds::Cache> TotemTimingDQMSource::globalBeginLuminosityBlock
 
 void TotemTimingDQMSource::analyze(const edm::Event &event, const edm::EventSetup &eventSetup) {
   // get event setup data
-  auto const& geometry = eventSetup.getData(geometryToken_);
+  auto const &geometry = eventSetup.getData(geometryToken_);
 
   // get event data
   edm::Handle<edm::DetSetVector<TotemRPLocalTrack>> stripTracks;
@@ -496,7 +496,7 @@ void TotemTimingDQMSource::analyze(const edm::Event &event, const edm::EventSetu
 
   edm::Handle<edm::DetSetVector<TotemTimingRecHit>> timingRecHits;
   event.getByToken(tokenRecHit_, timingRecHits);
- 
+
   // check validity
   bool valid = true;
   valid &= timingDigis.isValid();

--- a/DQM/CTPPS/plugins/TotemTimingDQMSource.cc
+++ b/DQM/CTPPS/plugins/TotemTimingDQMSource.cc
@@ -96,8 +96,10 @@ private:
   edm::EDGetTokenT<edm::DetSetVector<TotemRPLocalTrack>> tokenLocalTrack_;
   edm::EDGetTokenT<edm::DetSetVector<TotemTimingDigi>> tokenDigi_;
   edm::EDGetTokenT<edm::DetSetVector<TotemTimingRecHit>> tokenRecHit_;
-  // edm::EDGetTokenT<edm::DetSetVector<TotemTimingLocalTrack>> tokenTrack_;
   edm::EDGetTokenT<std::vector<TotemFEDInfo>> tokenFEDInfo_;
+
+  edm::ESGetToken<CTPPSGeometry,VeryForwardRealGeometryRecord> geometryToken_;
+  edm::ESGetToken<CTPPSGeometry,VeryForwardRealGeometryRecord> geometryTokenBeginRun_;
 
   double minimumStripAngleForTomography_;
   double maximumStripAngleForTomography_;
@@ -407,6 +409,8 @@ TotemTimingDQMSource::TotemTimingDQMSource(const edm::ParameterSet &ps)
       // tokenTrack_(consumes<edm::DetSetVector<TotemTimingLocalTrack>>(
       //     ps.getParameter<edm::InputTag>("tagLocalTracks"))),
       tokenFEDInfo_(consumes<std::vector<TotemFEDInfo>>(ps.getParameter<edm::InputTag>("tagFEDInfo"))),
+      geometryToken_(esConsumes()), 
+      geometryTokenBeginRun_(esConsumes<edm::Transition::BeginRun>()),
       minimumStripAngleForTomography_(ps.getParameter<double>("minimumStripAngleForTomography")),
       maximumStripAngleForTomography_(ps.getParameter<double>("maximumStripAngleForTomography")),
       samplesForNoise_(ps.getUntrackedParameter<unsigned int>("samplesForNoise", 5)),
@@ -421,19 +425,18 @@ TotemTimingDQMSource::~TotemTimingDQMSource() {}
 
 void TotemTimingDQMSource::dqmBeginRun(const edm::Run &iRun, const edm::EventSetup &iSetup) {
   // Get detector shifts from the geometry (if present)
-  edm::ESHandle<CTPPSGeometry> geometry_;
-  iSetup.get<VeryForwardRealGeometryRecord>().get(geometry_);
-  const CTPPSGeometry *geom = geometry_.product();
+  auto const& geom = iSetup.getData(geometryTokenBeginRun_);
+
   const TotemTimingDetId detid_top(0, TOTEM_TIMING_STATION_ID, TOTEM_TIMING_BOT_RP_ID, 0, 0);
   const TotemTimingDetId detid_bot(0, TOTEM_TIMING_STATION_ID, TOTEM_TIMING_TOP_RP_ID, 0, 7);
   verticalShiftTop_ = 0;
   verticalShiftBot_ = 0;
   {
-    const DetGeomDesc *det_top = geom->sensorNoThrow(detid_top);
+    const DetGeomDesc *det_top = geom.sensorNoThrow(detid_top);
     if (det_top) {
       verticalShiftTop_ = det_top->translation().y() + det_top->getDiamondDimensions().yHalfWidth;
     }
-    const DetGeomDesc *det_bot = geom->sensorNoThrow(detid_bot);
+    const DetGeomDesc *det_bot = geom.sensorNoThrow(detid_bot);
     if (det_bot)
       verticalShiftBot_ = det_bot->translation().y() + det_bot->getDiamondDimensions().yHalfWidth;
   }
@@ -479,8 +482,7 @@ std::shared_ptr<totemds::Cache> TotemTimingDQMSource::globalBeginLuminosityBlock
 
 void TotemTimingDQMSource::analyze(const edm::Event &event, const edm::EventSetup &eventSetup) {
   // get event setup data
-  edm::ESHandle<CTPPSGeometry> geometry;
-  eventSetup.get<VeryForwardRealGeometryRecord>().get(geometry);
+  auto const& geometry = eventSetup.getData(geometryToken_);
 
   // get event data
   edm::Handle<edm::DetSetVector<TotemRPLocalTrack>> stripTracks;
@@ -494,10 +496,7 @@ void TotemTimingDQMSource::analyze(const edm::Event &event, const edm::EventSetu
 
   edm::Handle<edm::DetSetVector<TotemTimingRecHit>> timingRecHits;
   event.getByToken(tokenRecHit_, timingRecHits);
-
-  // edm::Handle<edm::DetSetVector<TotemTimingLocalTrack>> timingLocalTracks;
-  // event.getByToken(timingLocalTracks, timingLocalTracks);
-
+ 
   // check validity
   bool valid = true;
   valid &= timingDigis.isValid();
@@ -684,8 +683,8 @@ void TotemTimingDQMSource::analyze(const edm::Event &event, const edm::EventSetu
             double rp_x = 0;
             double rp_y = 0;
             try {
-              rp_x = (geometry->sensor(plId_V)->translation().x() + geometry->sensor(plId_U)->translation().x()) / 2;
-              rp_y = (geometry->sensor(plId_V)->translation().y() + geometry->sensor(plId_U)->translation().y()) / 2;
+              rp_x = (geometry.sensor(plId_V)->translation().x() + geometry.sensor(plId_U)->translation().x()) / 2;
+              rp_y = (geometry.sensor(plId_V)->translation().y() + geometry.sensor(plId_U)->translation().y()) / 2;
             } catch (const cms::Exception &) {
               continue;
             }


### PR DESCRIPTION
#### PR description:
As requested in issue #31061, this PR migrates to esConsumes the following packages:
CalibPPS and Dqm/CTPPS 

#### PR validation:
Private checks have been done showing no changes in reconstruction, simulation and DQM plots of PPS.

No backport needed.

@jan-kaspar 