### PR TITLE
Change PPS geometry ES producer to read preprocessed geometry from DB

### DIFF
--- a/Geometry/Records/interface/VeryForwardMisalignedGeometryRecord.h
+++ b/Geometry/Records/interface/VeryForwardMisalignedGeometryRecord.h
@@ -11,6 +11,7 @@
 
 #include "FWCore/Framework/interface/DependentRecordImplementation.h"
 #include "Geometry/Records/interface/IdealGeometryRecord.h"
+#include "Geometry/Records/interface/VeryForwardIdealGeometryRecord.h"
 
 #include "FWCore/Utilities/interface/mplVector.h"
 
@@ -24,6 +25,6 @@
 class VeryForwardMisalignedGeometryRecord
     : public edm::eventsetup::DependentRecordImplementation<
           VeryForwardMisalignedGeometryRecord,
-          edm::mpl::Vector<IdealGeometryRecord, RPMisalignedAlignmentRecord /*, ... */> > {};
+          edm::mpl::Vector<VeryForwardIdealGeometryRecord, IdealGeometryRecord, RPMisalignedAlignmentRecord /*, ... */> > {};
 
 #endif

--- a/Geometry/Records/interface/VeryForwardMisalignedGeometryRecord.h
+++ b/Geometry/Records/interface/VeryForwardMisalignedGeometryRecord.h
@@ -25,6 +25,7 @@
 class VeryForwardMisalignedGeometryRecord
     : public edm::eventsetup::DependentRecordImplementation<
           VeryForwardMisalignedGeometryRecord,
-          edm::mpl::Vector<VeryForwardIdealGeometryRecord, IdealGeometryRecord, RPMisalignedAlignmentRecord /*, ... */> > {};
+          edm::mpl::Vector<VeryForwardIdealGeometryRecord, IdealGeometryRecord, RPMisalignedAlignmentRecord /*, ... */> > {
+};
 
 #endif

--- a/Geometry/Records/interface/VeryForwardRealGeometryRecord.h
+++ b/Geometry/Records/interface/VeryForwardRealGeometryRecord.h
@@ -11,6 +11,7 @@
 
 #include "FWCore/Framework/interface/DependentRecordImplementation.h"
 #include "Geometry/Records/interface/IdealGeometryRecord.h"
+#include "Geometry/Records/interface/VeryForwardIdealGeometryRecord.h"
 
 #include "FWCore/Utilities/interface/mplVector.h"
 
@@ -22,6 +23,6 @@
  **/
 class VeryForwardRealGeometryRecord : public edm::eventsetup::DependentRecordImplementation<
                                           VeryForwardRealGeometryRecord,
-                                          edm::mpl::Vector<IdealGeometryRecord, RPRealAlignmentRecord /*, ... */> > {};
+                                          edm::mpl::Vector<VeryForwardIdealGeometryRecord, IdealGeometryRecord, RPRealAlignmentRecord /*, ... */> > {};
 
 #endif

--- a/Geometry/Records/interface/VeryForwardRealGeometryRecord.h
+++ b/Geometry/Records/interface/VeryForwardRealGeometryRecord.h
@@ -21,8 +21,9 @@
  * \ingroup TotemRPGeometry
  * \brief Event setup record containing the real (actual) geometry information.
  **/
-class VeryForwardRealGeometryRecord : public edm::eventsetup::DependentRecordImplementation<
-                                          VeryForwardRealGeometryRecord,
-                                          edm::mpl::Vector<VeryForwardIdealGeometryRecord, IdealGeometryRecord, RPRealAlignmentRecord /*, ... */> > {};
+class VeryForwardRealGeometryRecord
+    : public edm::eventsetup::DependentRecordImplementation<
+          VeryForwardRealGeometryRecord,
+          edm::mpl::Vector<VeryForwardIdealGeometryRecord, IdealGeometryRecord, RPRealAlignmentRecord /*, ... */> > {};
 
 #endif

--- a/Geometry/VeryForwardGeometryBuilder/interface/DetGeomDesc.h
+++ b/Geometry/VeryForwardGeometryBuilder/interface/DetGeomDesc.h
@@ -17,6 +17,7 @@
 
 #include "DetectorDescription/Core/interface/DDFilteredView.h"
 #include "DetectorDescription/DDCMS/interface/DDFilteredView.h"
+#include "CondFormats/GeometryObjects/interface/PDetGeomDesc.h"
 
 #include "DataFormats/DetId/interface/DetId.h"
 #include <Math/Rotation3D.h>
@@ -59,7 +60,10 @@ public:
   // Constructor from DD4Hep DDFilteredView
   /// \param[in] isRun2 Switch between legacy run 2-like geometry and 2021+ scenarii
   DetGeomDesc(const cms::DDFilteredView& fv, const bool isRun2);
-
+  // Constructor from DB object PDetGeomDesc
+  DetGeomDesc(const PDetGeomDesc& gd);
+  // Constructor from DB object PDetGeomDesc::Item
+  DetGeomDesc(const PDetGeomDesc::Item& item);
   virtual ~DetGeomDesc();
 
   enum CopyMode { cmWithChildren, cmWithoutChildren };

--- a/Geometry/VeryForwardGeometryBuilder/plugins/BuildFile.xml
+++ b/Geometry/VeryForwardGeometryBuilder/plugins/BuildFile.xml
@@ -1,5 +1,6 @@
 <use name="CondFormats/AlignmentRecord"/>
 <use name="CondFormats/PPSObjects"/>
+<use name="CondFormats/GeometryObjects"/>
 <use name="DataFormats/CTPPSDetId"/>
 <use name="DetectorDescription/Core"/>
 <use name="DetectorDescription/DDCMS"/>

--- a/Geometry/VeryForwardGeometryBuilder/plugins/CTPPSGeometryESModule.cc
+++ b/Geometry/VeryForwardGeometryBuilder/plugins/CTPPSGeometryESModule.cc
@@ -6,6 +6,8 @@
 *  Rewritten + Moved out common functionailities to DetGeomDesc(Builder) by Gabrielle Hugo.
 *  Migrated to DD4hep by Wagner Carvalho and Gabrielle Hugo.
 *
+*  Add the capability of reading PPS reco geometry from the database
+*
 ****************************************************************************/
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -19,9 +21,11 @@
 #include "DetectorDescription/DDCMS/interface/DDCompactView.h"
 #include "CondFormats/PPSObjects/interface/CTPPSRPAlignmentCorrectionsData.h"
 
+#include "CondFormats/GeometryObjects/interface/PDetGeomDesc.h"
 #include "CondFormats/AlignmentRecord/interface/RPRealAlignmentRecord.h"
 #include "CondFormats/AlignmentRecord/interface/RPMisalignedAlignmentRecord.h"
 #include "Geometry/Records/interface/IdealGeometryRecord.h"
+#include "Geometry/Records/interface/VeryForwardIdealGeometryRecord.h"
 #include "Geometry/Records/interface/VeryForwardMisalignedGeometryRecord.h"
 #include "Geometry/Records/interface/VeryForwardRealGeometryRecord.h"
 
@@ -55,27 +59,22 @@ public:
 
 private:
   std::unique_ptr<DetGeomDesc> produceIdealGD(const IdealGeometryRecord&);
+  std::unique_ptr<DetGeomDesc> produceIdealGDFromPreprocessedDB(const VeryForwardIdealGeometryRecord&);
   std::vector<int> fillCopyNos(TGeoIterator& it);
 
-  template <typename ALIGNMENT_REC>
-  struct GDTokens {
-    explicit GDTokens(edm::ESConsumesCollector&& iCC)
-        : idealGDToken_{iCC.consumesFrom<DetGeomDesc, IdealGeometryRecord>(edm::ESInputTag())},
-          alignmentToken_{iCC.consumesFrom<CTPPSRPAlignmentCorrectionsData, ALIGNMENT_REC>(edm::ESInputTag())} {}
-    const edm::ESGetToken<DetGeomDesc, IdealGeometryRecord> idealGDToken_;
-    const edm::ESGetToken<CTPPSRPAlignmentCorrectionsData, ALIGNMENT_REC> alignmentToken_;
-  };
-
   std::unique_ptr<DetGeomDesc> produceRealGD(const VeryForwardRealGeometryRecord&);
+  std::unique_ptr<DetGeomDesc> produceRealGDFromPreprocessedDB(const VeryForwardRealGeometryRecord&);
   std::unique_ptr<CTPPSGeometry> produceRealTG(const VeryForwardRealGeometryRecord&);
 
   std::unique_ptr<DetGeomDesc> produceMisalignedGD(const VeryForwardMisalignedGeometryRecord&);
+  std::unique_ptr<DetGeomDesc> produceMisalignedGDFromPreprocessedDB(const VeryForwardMisalignedGeometryRecord&);
   std::unique_ptr<CTPPSGeometry> produceMisalignedTG(const VeryForwardMisalignedGeometryRecord&);
 
-  template <typename REC>
-  std::unique_ptr<DetGeomDesc> produceGD(IdealGeometryRecord const&,
+  template <typename REC , typename GEO>
+  std::unique_ptr<DetGeomDesc> produceGD(const GEO&,
                                          const std::optional<REC>&,
-                                         GDTokens<REC> const&,
+                                         edm::ESGetToken<DetGeomDesc,GEO> const&,
+                                         edm::ESGetToken<CTPPSRPAlignmentCorrectionsData,REC> const&,
                                          const char* name);
 
   const unsigned int verbosity_;
@@ -83,40 +82,70 @@ private:
 
   edm::ESGetToken<DDCompactView, IdealGeometryRecord> ddToken_;
   edm::ESGetToken<cms::DDCompactView, IdealGeometryRecord> dd4hepToken_;
-  const bool fromDD4hep_;
+  edm::ESGetToken<PDetGeomDesc, VeryForwardIdealGeometryRecord> dbToken_;
+  const bool fromPreprocessedDB_, fromDD4hep_;
 
-  const GDTokens<RPRealAlignmentRecord> gdRealTokens_;
-  const GDTokens<RPMisalignedAlignmentRecord> gdMisTokens_;
+  edm::ESGetToken<DetGeomDesc, IdealGeometryRecord> idealGDToken_;
+  edm::ESGetToken<DetGeomDesc, VeryForwardIdealGeometryRecord> idealDBGDToken_;
+  edm::ESGetToken<CTPPSRPAlignmentCorrectionsData, RPRealAlignmentRecord> realAlignmentToken_;
+  edm::ESGetToken<CTPPSRPAlignmentCorrectionsData, RPMisalignedAlignmentRecord> misAlignmentToken_;
 
-  const edm::ESGetToken<DetGeomDesc, VeryForwardRealGeometryRecord> dgdRealToken_;
-  const edm::ESGetToken<DetGeomDesc, VeryForwardMisalignedGeometryRecord> dgdMisToken_;
+  edm::ESGetToken<DetGeomDesc, VeryForwardRealGeometryRecord> dgdRealToken_;
+  edm::ESGetToken<DetGeomDesc, VeryForwardMisalignedGeometryRecord> dgdMisToken_;
 };
 
 CTPPSGeometryESModule::CTPPSGeometryESModule(const edm::ParameterSet& iConfig)
     : verbosity_(iConfig.getUntrackedParameter<unsigned int>("verbosity")),
       isRun2_(iConfig.getParameter<bool>("isRun2")),
-      fromDD4hep_(iConfig.getUntrackedParameter<bool>("fromDD4hep", false)),
-      gdRealTokens_{setWhatProduced(this, &CTPPSGeometryESModule::produceRealGD)},
-      gdMisTokens_{setWhatProduced(this, &CTPPSGeometryESModule::produceMisalignedGD)},
-      dgdRealToken_{
-          setWhatProduced(this, &CTPPSGeometryESModule::produceRealTG).consumes<DetGeomDesc>(edm::ESInputTag())},
-      dgdMisToken_{
-          setWhatProduced(this, &CTPPSGeometryESModule::produceMisalignedTG).consumes<DetGeomDesc>(edm::ESInputTag())} {
-  auto c = setWhatProduced(this, &CTPPSGeometryESModule::produceIdealGD);
+      fromPreprocessedDB_(iConfig.getUntrackedParameter<bool>("fromPreprocessedDB", false)),
+      fromDD4hep_(iConfig.getUntrackedParameter<bool>("fromDD4hep", false)) {
+  if (fromPreprocessedDB_) {
+    auto c = setWhatProduced(this, &CTPPSGeometryESModule::produceIdealGDFromPreprocessedDB);
+    dbToken_ = c.consumes<PDetGeomDesc>(edm::ESInputTag("", iConfig.getParameter<std::string>("dbTag")));
 
-  if (!fromDD4hep_) {
+    auto c1 = setWhatProduced(this, &CTPPSGeometryESModule::produceRealGDFromPreprocessedDB);
+    idealDBGDToken_ = c1.consumesFrom<DetGeomDesc, VeryForwardIdealGeometryRecord>(edm::ESInputTag());
+    realAlignmentToken_ = c1.consumesFrom<CTPPSRPAlignmentCorrectionsData, RPRealAlignmentRecord>(edm::ESInputTag());
+
+    auto c2 = setWhatProduced(this, &CTPPSGeometryESModule::produceMisalignedGDFromPreprocessedDB);
+    misAlignmentToken_ = c2.consumesFrom<CTPPSRPAlignmentCorrectionsData, RPMisalignedAlignmentRecord>(edm::ESInputTag());
+  } else if (!fromDD4hep_) {
+    auto c = setWhatProduced(this, &CTPPSGeometryESModule::produceIdealGD);
     ddToken_ = c.consumes<DDCompactView>(edm::ESInputTag("", iConfig.getParameter<std::string>("compactViewTag")));
+
+    auto c1 = setWhatProduced(this, &CTPPSGeometryESModule::produceRealGD);
+    idealGDToken_ = c1.consumesFrom<DetGeomDesc, IdealGeometryRecord>(edm::ESInputTag());
+    realAlignmentToken_ = c1.consumesFrom<CTPPSRPAlignmentCorrectionsData, RPRealAlignmentRecord>(edm::ESInputTag());
+
+    auto c2 = setWhatProduced(this, &CTPPSGeometryESModule::produceMisalignedGD);
+    misAlignmentToken_ = c2.consumesFrom<CTPPSRPAlignmentCorrectionsData, RPMisalignedAlignmentRecord>(edm::ESInputTag());
   } else {
+    auto c = setWhatProduced(this, &CTPPSGeometryESModule::produceIdealGD);
     dd4hepToken_ =
         c.consumes<cms::DDCompactView>(edm::ESInputTag("", iConfig.getParameter<std::string>("compactViewTag")));
+
+    auto c1 = setWhatProduced(this, &CTPPSGeometryESModule::produceRealGD);
+    idealGDToken_ = c1.consumesFrom<DetGeomDesc, IdealGeometryRecord>(edm::ESInputTag());
+    realAlignmentToken_ = c1.consumesFrom<CTPPSRPAlignmentCorrectionsData, RPRealAlignmentRecord>(edm::ESInputTag());
+
+    auto c2 = setWhatProduced(this, &CTPPSGeometryESModule::produceMisalignedGD);
+    misAlignmentToken_ = c2.consumesFrom<CTPPSRPAlignmentCorrectionsData, RPMisalignedAlignmentRecord>(edm::ESInputTag());
   }
+
+  auto c_RTG = setWhatProduced(this, &CTPPSGeometryESModule::produceRealTG);
+  dgdRealToken_ = c_RTG.consumes<DetGeomDesc>(edm::ESInputTag());
+  
+  auto c_MTG = setWhatProduced(this, &CTPPSGeometryESModule::produceMisalignedTG);
+  dgdMisToken_ = c_MTG.consumes<DetGeomDesc>(edm::ESInputTag());
 }
 
 void CTPPSGeometryESModule::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
   desc.addUntracked<unsigned int>("verbosity", 1);
   desc.add<bool>("isRun2", false)->setComment("Switch to legacy (2017-18) definition of diamond geometry");
+  desc.add<std::string>("dbTag", std::string());
   desc.add<std::string>("compactViewTag", std::string());
+  desc.addUntracked<bool>("fromPreprocessedDB", false);
   desc.addUntracked<bool>("fromDD4hep", false);
   descriptions.add("CTPPSGeometryESModule", desc);
 }
@@ -139,18 +168,32 @@ std::unique_ptr<DetGeomDesc> CTPPSGeometryESModule::produceIdealGD(const IdealGe
   }
 }
 
-template <typename REC>
-std::unique_ptr<DetGeomDesc> CTPPSGeometryESModule::produceGD(IdealGeometryRecord const& iIdealRec,
-                                                              std::optional<REC> const& iAlignRec,
-                                                              GDTokens<REC> const& iTokens,
-                                                              const char* name) {
+std::unique_ptr<DetGeomDesc> CTPPSGeometryESModule::produceIdealGDFromPreprocessedDB(const VeryForwardIdealGeometryRecord& iRecord) {
+
+    // Get the PDetGeomDesc from EventSetup
+    auto const& myDB = iRecord.get(dbToken_);
+
+    edm::LogInfo("CTPPSGeometryESModule") << " myDB size = " << myDB.container_.size();
+
+    // Build geo from PDetGeomDesc DB object.
+    auto pdet = std::make_unique<DetGeomDesc>(myDB);
+    return pdet;
+
+}
+
+template <typename REC , typename GEO>
+std::unique_ptr<DetGeomDesc> CTPPSGeometryESModule::produceGD(GEO const& iIdealRec,
+                                        std::optional<REC> const& iAlignRec,
+                                        edm::ESGetToken<DetGeomDesc,GEO> const& iGDToken,
+                                        edm::ESGetToken<CTPPSRPAlignmentCorrectionsData,REC> const& iAlignToken,
+                                        const char* name) {
   // get the input GeometricalDet
-  auto const& idealGD = iIdealRec.get(iTokens.idealGDToken_);
+  auto const& idealGD = iIdealRec.get(iGDToken);
 
   // load alignments
   CTPPSRPAlignmentCorrectionsData const* alignments = nullptr;
   if (iAlignRec) {
-    auto alignmentsHandle = iAlignRec->getHandle(iTokens.alignmentToken_);
+    auto alignmentsHandle = iAlignRec->getHandle(iAlignToken);
     if (alignmentsHandle.isValid()) {
       alignments = alignmentsHandle.product();
     }
@@ -168,10 +211,32 @@ std::unique_ptr<DetGeomDesc> CTPPSGeometryESModule::produceGD(IdealGeometryRecor
   return CTPPSGeometryESCommon::applyAlignments(idealGD, alignments);
 }
 
+std::unique_ptr<DetGeomDesc> CTPPSGeometryESModule::produceRealGDFromPreprocessedDB(const VeryForwardRealGeometryRecord& iRecord) {
+  return produceGD(iRecord.getRecord<VeryForwardIdealGeometryRecord>(),
+                   iRecord.tryToGetRecord<RPRealAlignmentRecord>(),
+                   idealDBGDToken_,
+                   realAlignmentToken_,
+                   "CTPPSGeometryESModule::produceRealGDFromPreprocessedDB");
+}
+
+//----------------------------------------------------------------------------------------------------
+
+std::unique_ptr<DetGeomDesc> CTPPSGeometryESModule::produceMisalignedGDFromPreprocessedDB(
+    const VeryForwardMisalignedGeometryRecord& iRecord) {
+  return produceGD(iRecord.getRecord<VeryForwardIdealGeometryRecord>(),
+                   iRecord.tryToGetRecord<RPMisalignedAlignmentRecord>(),
+                   idealDBGDToken_,
+                   misAlignmentToken_,
+                   "CTPPSGeometryESModule::produceMisalignedGDFromPreprocessedDB");
+}
+
+//----------------------------------------------------------------------------------------------------
+
 std::unique_ptr<DetGeomDesc> CTPPSGeometryESModule::produceRealGD(const VeryForwardRealGeometryRecord& iRecord) {
   return produceGD(iRecord.getRecord<IdealGeometryRecord>(),
                    iRecord.tryToGetRecord<RPRealAlignmentRecord>(),
-                   gdRealTokens_,
+                   idealGDToken_,
+                   realAlignmentToken_,
                    "CTPPSGeometryESModule::produceRealGD");
 }
 
@@ -181,7 +246,8 @@ std::unique_ptr<DetGeomDesc> CTPPSGeometryESModule::produceMisalignedGD(
     const VeryForwardMisalignedGeometryRecord& iRecord) {
   return produceGD(iRecord.getRecord<IdealGeometryRecord>(),
                    iRecord.tryToGetRecord<RPMisalignedAlignmentRecord>(),
-                   gdMisTokens_,
+                   idealGDToken_,
+                   misAlignmentToken_,
                    "CTPPSGeometryESModule::produceMisalignedGD");
 }
 

--- a/Geometry/VeryForwardGeometryBuilder/plugins/CTPPSGeometryESModule.cc
+++ b/Geometry/VeryForwardGeometryBuilder/plugins/CTPPSGeometryESModule.cc
@@ -70,11 +70,11 @@ private:
   std::unique_ptr<DetGeomDesc> produceMisalignedGDFromPreprocessedDB(const VeryForwardMisalignedGeometryRecord&);
   std::unique_ptr<CTPPSGeometry> produceMisalignedTG(const VeryForwardMisalignedGeometryRecord&);
 
-  template <typename REC , typename GEO>
+  template <typename REC, typename GEO>
   std::unique_ptr<DetGeomDesc> produceGD(const GEO&,
                                          const std::optional<REC>&,
-                                         edm::ESGetToken<DetGeomDesc,GEO> const&,
-                                         edm::ESGetToken<CTPPSRPAlignmentCorrectionsData,REC> const&,
+                                         edm::ESGetToken<DetGeomDesc, GEO> const&,
+                                         edm::ESGetToken<CTPPSRPAlignmentCorrectionsData, REC> const&,
                                          const char* name);
 
   const unsigned int verbosity_;
@@ -108,7 +108,8 @@ CTPPSGeometryESModule::CTPPSGeometryESModule(const edm::ParameterSet& iConfig)
     realAlignmentToken_ = c1.consumesFrom<CTPPSRPAlignmentCorrectionsData, RPRealAlignmentRecord>(edm::ESInputTag());
 
     auto c2 = setWhatProduced(this, &CTPPSGeometryESModule::produceMisalignedGDFromPreprocessedDB);
-    misAlignmentToken_ = c2.consumesFrom<CTPPSRPAlignmentCorrectionsData, RPMisalignedAlignmentRecord>(edm::ESInputTag());
+    misAlignmentToken_ =
+        c2.consumesFrom<CTPPSRPAlignmentCorrectionsData, RPMisalignedAlignmentRecord>(edm::ESInputTag());
   } else if (!fromDD4hep_) {
     auto c = setWhatProduced(this, &CTPPSGeometryESModule::produceIdealGD);
     ddToken_ = c.consumes<DDCompactView>(edm::ESInputTag("", iConfig.getParameter<std::string>("compactViewTag")));
@@ -118,7 +119,8 @@ CTPPSGeometryESModule::CTPPSGeometryESModule(const edm::ParameterSet& iConfig)
     realAlignmentToken_ = c1.consumesFrom<CTPPSRPAlignmentCorrectionsData, RPRealAlignmentRecord>(edm::ESInputTag());
 
     auto c2 = setWhatProduced(this, &CTPPSGeometryESModule::produceMisalignedGD);
-    misAlignmentToken_ = c2.consumesFrom<CTPPSRPAlignmentCorrectionsData, RPMisalignedAlignmentRecord>(edm::ESInputTag());
+    misAlignmentToken_ =
+        c2.consumesFrom<CTPPSRPAlignmentCorrectionsData, RPMisalignedAlignmentRecord>(edm::ESInputTag());
   } else {
     auto c = setWhatProduced(this, &CTPPSGeometryESModule::produceIdealGD);
     dd4hepToken_ =
@@ -129,12 +131,13 @@ CTPPSGeometryESModule::CTPPSGeometryESModule(const edm::ParameterSet& iConfig)
     realAlignmentToken_ = c1.consumesFrom<CTPPSRPAlignmentCorrectionsData, RPRealAlignmentRecord>(edm::ESInputTag());
 
     auto c2 = setWhatProduced(this, &CTPPSGeometryESModule::produceMisalignedGD);
-    misAlignmentToken_ = c2.consumesFrom<CTPPSRPAlignmentCorrectionsData, RPMisalignedAlignmentRecord>(edm::ESInputTag());
+    misAlignmentToken_ =
+        c2.consumesFrom<CTPPSRPAlignmentCorrectionsData, RPMisalignedAlignmentRecord>(edm::ESInputTag());
   }
 
   auto c_RTG = setWhatProduced(this, &CTPPSGeometryESModule::produceRealTG);
   dgdRealToken_ = c_RTG.consumes<DetGeomDesc>(edm::ESInputTag());
-  
+
   auto c_MTG = setWhatProduced(this, &CTPPSGeometryESModule::produceMisalignedTG);
   dgdMisToken_ = c_MTG.consumes<DetGeomDesc>(edm::ESInputTag());
 }
@@ -168,25 +171,25 @@ std::unique_ptr<DetGeomDesc> CTPPSGeometryESModule::produceIdealGD(const IdealGe
   }
 }
 
-std::unique_ptr<DetGeomDesc> CTPPSGeometryESModule::produceIdealGDFromPreprocessedDB(const VeryForwardIdealGeometryRecord& iRecord) {
+std::unique_ptr<DetGeomDesc> CTPPSGeometryESModule::produceIdealGDFromPreprocessedDB(
+    const VeryForwardIdealGeometryRecord& iRecord) {
+  // Get the PDetGeomDesc from EventSetup
+  auto const& myDB = iRecord.get(dbToken_);
 
-    // Get the PDetGeomDesc from EventSetup
-    auto const& myDB = iRecord.get(dbToken_);
+  edm::LogInfo("CTPPSGeometryESModule") << " myDB size = " << myDB.container_.size();
 
-    edm::LogInfo("CTPPSGeometryESModule") << " myDB size = " << myDB.container_.size();
-
-    // Build geo from PDetGeomDesc DB object.
-    auto pdet = std::make_unique<DetGeomDesc>(myDB);
-    return pdet;
-
+  // Build geo from PDetGeomDesc DB object.
+  auto pdet = std::make_unique<DetGeomDesc>(myDB);
+  return pdet;
 }
 
-template <typename REC , typename GEO>
-std::unique_ptr<DetGeomDesc> CTPPSGeometryESModule::produceGD(GEO const& iIdealRec,
-                                        std::optional<REC> const& iAlignRec,
-                                        edm::ESGetToken<DetGeomDesc,GEO> const& iGDToken,
-                                        edm::ESGetToken<CTPPSRPAlignmentCorrectionsData,REC> const& iAlignToken,
-                                        const char* name) {
+template <typename REC, typename GEO>
+std::unique_ptr<DetGeomDesc> CTPPSGeometryESModule::produceGD(
+    GEO const& iIdealRec,
+    std::optional<REC> const& iAlignRec,
+    edm::ESGetToken<DetGeomDesc, GEO> const& iGDToken,
+    edm::ESGetToken<CTPPSRPAlignmentCorrectionsData, REC> const& iAlignToken,
+    const char* name) {
   // get the input GeometricalDet
   auto const& idealGD = iIdealRec.get(iGDToken);
 
@@ -211,7 +214,8 @@ std::unique_ptr<DetGeomDesc> CTPPSGeometryESModule::produceGD(GEO const& iIdealR
   return CTPPSGeometryESCommon::applyAlignments(idealGD, alignments);
 }
 
-std::unique_ptr<DetGeomDesc> CTPPSGeometryESModule::produceRealGDFromPreprocessedDB(const VeryForwardRealGeometryRecord& iRecord) {
+std::unique_ptr<DetGeomDesc> CTPPSGeometryESModule::produceRealGDFromPreprocessedDB(
+    const VeryForwardRealGeometryRecord& iRecord) {
   return produceGD(iRecord.getRecord<VeryForwardIdealGeometryRecord>(),
                    iRecord.tryToGetRecord<RPRealAlignmentRecord>(),
                    idealDBGDToken_,

--- a/Geometry/VeryForwardGeometryBuilder/src/DetGeomDesc.cc
+++ b/Geometry/VeryForwardGeometryBuilder/src/DetGeomDesc.cc
@@ -75,6 +75,37 @@ DetGeomDesc::DetGeomDesc(const DetGeomDesc& ref, CopyMode cm) {
   m_z = ref.m_z;
 }
 
+// Constructor from DB object PDetGeomDesc::Item
+DetGeomDesc::DetGeomDesc(const PDetGeomDesc::Item& item)
+    : m_name(item.name_),
+      m_copy(item.copy_),
+      m_isDD4hep(true),
+      m_params(item.params_),  // default unit from DD4hep (cm)
+      m_sensorType(item.sensorType_),
+      m_geographicalID(item.geographicalID_),
+      m_z(item.z_)  // converted from cm (DD4hep) to mm
+{
+  Translation trans(item.dx_, item.dy_, item.dz_);
+  m_trans = trans;
+  RotationMatrix rot(item.axx_, item.axy_, item.axz_, item.ayx_, item.ayy_, item.ayz_, item.azx_, item.azy_, item.azz_);
+  m_rot = rot;
+  // Set the m_isABox flag for the box shaped sensors, so that m_params are properly set
+  if( (m_name == DDD_CTPPS_PIXELS_SENSOR_NAME || m_name == DDD_CTPPS_PIXELS_SENSOR_NAME_2x2 ||
+       m_name == DDD_CTPPS_DIAMONDS_SEGMENT_NAME || m_name == DDD_CTPPS_UFSD_SEGMENT_NAME ||
+       m_name.substr(0,7) == DDD_TOTEM_TIMING_SENSOR_TMPL.substr(0,7)) && m_params.size()>2 )
+    m_isABox = true;
+  else
+    m_isABox = false;
+  m_diamondBoxParams = computeDiamondDimensions(m_isABox, m_isDD4hep, m_params);
+}
+
+DetGeomDesc::DetGeomDesc(const PDetGeomDesc& pd) {
+  for (auto i : pd.container_) {
+    DetGeomDesc* gd = new DetGeomDesc(i);
+    this->addComponent(gd);
+  }
+}
+
 DetGeomDesc::~DetGeomDesc() { deepDeleteComponents(); }
 
 void DetGeomDesc::addComponent(DetGeomDesc* det) { m_container.emplace_back(det); }

--- a/Geometry/VeryForwardGeometryBuilder/src/DetGeomDesc.cc
+++ b/Geometry/VeryForwardGeometryBuilder/src/DetGeomDesc.cc
@@ -80,10 +80,10 @@ DetGeomDesc::DetGeomDesc(const PDetGeomDesc::Item& item)
     : m_name(item.name_),
       m_copy(item.copy_),
       m_isDD4hep(true),
-      m_params(item.params_),  // default unit from DD4hep (cm)
+      m_params(item.params_),  // default unit from DD4hep
       m_sensorType(item.sensorType_),
       m_geographicalID(item.geographicalID_),
-      m_z(item.z_)  // converted from cm (DD4hep) to mm
+      m_z(item.z_)  // converted from DD4hep to mm
 {
   Translation trans(item.dx_, item.dy_, item.dz_);
   m_trans = trans;

--- a/Geometry/VeryForwardGeometryBuilder/src/DetGeomDesc.cc
+++ b/Geometry/VeryForwardGeometryBuilder/src/DetGeomDesc.cc
@@ -90,9 +90,10 @@ DetGeomDesc::DetGeomDesc(const PDetGeomDesc::Item& item)
   RotationMatrix rot(item.axx_, item.axy_, item.axz_, item.ayx_, item.ayy_, item.ayz_, item.azx_, item.azy_, item.azz_);
   m_rot = rot;
   // Set the m_isABox flag for the box shaped sensors, so that m_params are properly set
-  if( (m_name == DDD_CTPPS_PIXELS_SENSOR_NAME || m_name == DDD_CTPPS_PIXELS_SENSOR_NAME_2x2 ||
+  if ((m_name == DDD_CTPPS_PIXELS_SENSOR_NAME || m_name == DDD_CTPPS_PIXELS_SENSOR_NAME_2x2 ||
        m_name == DDD_CTPPS_DIAMONDS_SEGMENT_NAME || m_name == DDD_CTPPS_UFSD_SEGMENT_NAME ||
-       m_name.substr(0,7) == DDD_TOTEM_TIMING_SENSOR_TMPL.substr(0,7)) && m_params.size()>2 )
+       m_name.substr(0, 7) == DDD_TOTEM_TIMING_SENSOR_TMPL.substr(0, 7)) &&
+      m_params.size() > 2)
     m_isABox = true;
   else
     m_isABox = false;
@@ -100,7 +101,7 @@ DetGeomDesc::DetGeomDesc(const PDetGeomDesc::Item& item)
 }
 
 DetGeomDesc::DetGeomDesc(const PDetGeomDesc& pd) {
-  for (auto i : pd.container_) {
+  for (const auto& i : pd.container_) {
     DetGeomDesc* gd = new DetGeomDesc(i);
     this->addComponent(gd);
   }
@@ -153,7 +154,7 @@ void DetGeomDesc::deepDeleteComponents() {
 }
 
 std::string DetGeomDesc::computeNameWithNoNamespace(std::string_view nameFromView) const {
-  const auto& semiColonPos = nameFromView.find(":");
+  const auto& semiColonPos = nameFromView.find(':');
   const std::string name{(semiColonPos != std::string::npos ? nameFromView.substr(semiColonPos + 1) : nameFromView)};
   return name;
 }

--- a/Geometry/VeryForwardGeometryBuilder/test/print_geometry_info_geomFromDB_cfg.py
+++ b/Geometry/VeryForwardGeometryBuilder/test/print_geometry_info_geomFromDB_cfg.py
@@ -1,0 +1,69 @@
+import FWCore.ParameterSet.Config as cms
+process = cms.Process("GeometryInfo")
+
+# minimum of logs
+process.MessageLogger = cms.Service("MessageLogger",
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True),
+        threshold = cms.untracked.string('INFO')
+    )
+)
+
+# geometry
+process.load("CondCore.CondDB.CondDB_cfi")
+# input database (in this case local sqlite file)
+#process.CondDB.connect = 'sqlite_file:../../CondTools/Geometry/PPSGeometry_oldDD_multiIOV.db'
+process.CondDB.connect = cms.string( 'frontier://FrontierPrep/CMS_CONDITIONS' )
+
+process.PoolDBESSource = cms.ESSource("PoolDBESSource",
+    process.CondDB,
+    DumpStat=cms.untracked.bool(True),
+    toGet = cms.VPSet(
+      cms.PSet(
+        record = cms.string('VeryForwardIdealGeometryRecord'),
+        tag = cms.string("PPS_RecoGeometry_test_v1")
+      )
+    )
+)
+
+process.ctppsGeometryESModule = cms.ESProducer("CTPPSGeometryESModule",
+    fromPreprocessedDB = cms.untracked.bool(True),
+    fromDD4hep = cms.untracked.bool(False),
+    verbosity = cms.untracked.uint32(1),
+)
+
+
+# load alignment correction
+process.load("CalibPPS.ESProducers.ctppsRPAlignmentCorrectionsDataESSourceXML_cfi")
+process.ctppsRPAlignmentCorrectionsDataESSourceXML.RealFiles = cms.vstring(
+    "Geometry/VeryForwardGeometryBuilder/test/alignment_file_1.xml",
+    "Geometry/VeryForwardGeometryBuilder/test/alignment_file_2.xml",
+)
+process.ctppsRPAlignmentCorrectionsDataESSourceXML.verbosity = 1
+
+# no events to process
+process.source = cms.Source("EmptySource",
+#  firstRun = cms.untracked.uint32(273725),  # start run for 2016-2017
+  firstRun = cms.untracked.uint32(314747),  # start run for 2018
+  firstLuminosityBlock = cms.untracked.uint32(1),
+  firstEvent = cms.untracked.uint32(1),
+  numberEventsInLuminosityBlock = cms.untracked.uint32(3),
+  numberEventsInRun = cms.untracked.uint32(30)
+)
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(1)
+)
+
+process.ctppsGeometryInfo = cms.EDAnalyzer("CTPPSGeometryInfo",
+    geometryType = cms.untracked.string("real"),
+    printRPInfo = cms.untracked.bool(True),
+    printSensorInfo = cms.untracked.bool(True)
+)
+
+process.p = cms.Path(
+    process.ctppsGeometryInfo
+)


### PR DESCRIPTION
#### PR description:

The goal of this PR is to make the ES producer `CTPPSGeometryESModule.cc` able to read the PPS reco geometry from conditions data stored in the database. Currently, PPS geometry is read directly from XML files.

- No changes are expected in the output.
- We plan a future PR that will change the default reco sequence to consume conditions data from DB. 

@fabferro @jan-kaspar 

<!-- Please replace this text with a description of the feature proposed or problem addressed, specifying:
  - what changes are expected in the output if any, 
  - what other PRs or externals it depends upon if any,
  - link to any additional material useful to provide a documentation for this PR (slides, JIRA tickets, related pull requestes, hypernews, TWiki or Indico pages)  -->

#### PR validation:

The following validation tests have been performed:

-  Comparison of pot and sensor positions obtained from XML (current producer) and from DB (changed producer). Perfect agreement is found.
-  Reco workflow. Local tests have been run to compare the current and the changed versions of the producer. Nearly perfect agreement has been observed, as can be seen from a sample of plots shown below. Only a few very tiny differences (probably at the round level) among hundreds of histograms. See the Mean for theta_x and theta_y histograms in the bottom canvas (top row = baseline ; bottom row = changed producer) as the only visible differences.

![reco_cmp](https://user-images.githubusercontent.com/9204751/119693024-47574800-be22-11eb-8b4f-c137ce41b482.png)

![base_vs_db_1](https://user-images.githubusercontent.com/9204751/119693175-6c4bbb00-be22-11eb-87e1-8e0373308c50.png)

The tests with the changed producer used conditions data from a local sqlite file and also the same data uploaded to the Prep database as a test tag: https://cms-conddb.cern.ch/cmsDbBrowser/list/Prep/tags/PPS_RecoGeometry_test_v1.

<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Not a backport.

<!-- Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)  -->
