### PR TITLE
HGCal/TICL: Examples of clang-tidy replacement of getByToken with getHandle

### DIFF
--- a/RecoHGCal/TICL/plugins/FilteredLayerClustersProducer.cc
+++ b/RecoHGCal/TICL/plugins/FilteredLayerClustersProducer.cc
@@ -74,8 +74,8 @@ void FilteredLayerClustersProducer::produce(edm::Event& evt, const edm::EventSet
   edm::Handle<std::vector<reco::CaloCluster>> clusterHandle;
   edm::Handle<std::vector<float>> inputClustersMaskHandle;
   auto availableLayerClusters = std::make_unique<ticl::HgcalClusterFilterMask>();
-  evt.getByToken(clusters_token_, clusterHandle);
-  evt.getByToken(clustersMask_token_, inputClustersMaskHandle);
+  clusterHandle = evt.getHandle(clusters_token_);
+  inputClustersMaskHandle = evt.getHandle(clustersMask_token_);
   const auto& inputClusterMask = *inputClustersMaskHandle;
 
   // Transfer input mask in output

--- a/RecoHGCal/TICL/plugins/MultiClustersFromTrackstersProducer.cc
+++ b/RecoHGCal/TICL/plugins/MultiClustersFromTrackstersProducer.cc
@@ -48,10 +48,10 @@ void MultiClustersFromTrackstersProducer::fillDescriptions(edm::ConfigurationDes
 void MultiClustersFromTrackstersProducer::produce(edm::Event& evt, const edm::EventSetup& es) {
   auto multiclusters = std::make_unique<std::vector<reco::HGCalMultiCluster>>();
   edm::Handle<std::vector<ticl::Trackster>> tracksterHandle;
-  evt.getByToken(tracksters_token_, tracksterHandle);
+  tracksterHandle = evt.getHandle(tracksters_token_);
 
   edm::Handle<std::vector<reco::CaloCluster>> layer_clustersHandle;
-  evt.getByToken(layer_clusters_token_, layer_clustersHandle);
+  layer_clustersHandle = evt.getHandle(layer_clusters_token_);
 
   auto const& tracksters = *tracksterHandle;
   auto const& layerClusters = *layer_clustersHandle;

--- a/RecoHGCal/TICL/plugins/PFTICLProducer.cc
+++ b/RecoHGCal/TICL/plugins/PFTICLProducer.cc
@@ -72,12 +72,12 @@ void PFTICLProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptio
 void PFTICLProducer::produce(edm::Event& evt, const edm::EventSetup& es) {
   //get TICLCandidates
   edm::Handle<edm::View<TICLCandidate>> ticl_cand_h;
-  evt.getByToken(ticl_candidates_, ticl_cand_h);
+  ticl_cand_h = evt.getHandle(ticl_candidates_);
   const auto ticl_candidates = *ticl_cand_h;
   edm::Handle<edm::ValueMap<float>> trackTimeH, trackTimeErrH, trackTimeQualH;
-  evt.getByToken(srcTrackTime_, trackTimeH);
-  evt.getByToken(srcTrackTimeError_, trackTimeErrH);
-  evt.getByToken(srcTrackTimeQuality_, trackTimeQualH);
+  trackTimeH = evt.getHandle(srcTrackTime_);
+  trackTimeErrH = evt.getHandle(srcTrackTimeError_);
+  trackTimeQualH = evt.getHandle(srcTrackTimeQuality_);
   const auto muonH = evt.getHandle(muons_);
   const auto muons = *muonH;
 

--- a/RecoHGCal/TICL/plugins/SeedingRegionByTracks.cc
+++ b/RecoHGCal/TICL/plugins/SeedingRegionByTracks.cc
@@ -43,7 +43,7 @@ void SeedingRegionByTracks::makeRegions(const edm::Event &ev,
                                         const edm::EventSetup &es,
                                         std::vector<TICLSeedingRegion> &result) {
   edm::Handle<reco::TrackCollection> tracks_h;
-  ev.getByToken(tracks_token_, tracks_h);
+  tracks_h = ev.getHandle(tracks_token_);
   edm::ProductID trkId = tracks_h.id();
   auto bFieldProd = bfield_.product();
   const Propagator &prop = (*propagator_);

--- a/RecoHGCal/TICL/plugins/TICLCandidateFromTrackstersProducer.cc
+++ b/RecoHGCal/TICL/plugins/TICLCandidateFromTrackstersProducer.cc
@@ -108,7 +108,7 @@ void TICLCandidateFromTrackstersProducer::produce(edm::Event& evt, const edm::Ev
   // adds one TICLCandidate for each trackster that has a minimum particle probability
   for (auto& trackster_token : trackster_tokens_) {
     edm::Handle<std::vector<Trackster>> trackster_h;
-    evt.getByToken(trackster_token, trackster_h);
+    trackster_h = evt.getHandle(trackster_token);
     for (size_t i_trackster = 0; i_trackster < trackster_h->size(); ++i_trackster) {
       auto const& trackster = trackster_h->at(i_trackster);
       auto id_prob_begin = std::begin(trackster.id_probabilities());

--- a/RecoHGCal/TICL/plugins/TICLLayerTileProducer.cc
+++ b/RecoHGCal/TICL/plugins/TICLLayerTileProducer.cc
@@ -57,9 +57,9 @@ void TICLLayerTileProducer::produce(edm::Event &evt, const edm::EventSetup &) {
 
   edm::Handle<std::vector<reco::CaloCluster>> cluster_h;
   if (doNose_)
-    evt.getByToken(clusters_HFNose_token_, cluster_h);
+    cluster_h = evt.getHandle(clusters_HFNose_token_);
   else
-    evt.getByToken(clusters_token_, cluster_h);
+    cluster_h = evt.getHandle(clusters_token_);
 
   const auto &layerClusters = *cluster_h;
   int lcId = 0;

--- a/RecoHGCal/TICL/plugins/TracksterP4FromEnergySumPlugin.cc
+++ b/RecoHGCal/TICL/plugins/TracksterP4FromEnergySumPlugin.cc
@@ -37,7 +37,7 @@ namespace ticl {
                                        edm::Event& event) const {
     // Find best vertex
     edm::Handle<std::vector<reco::Vertex>> vertex_h;
-    event.getByToken(vertex_token_, vertex_h);
+    vertex_h = event.getHandle(vertex_token_);
     auto vertex_coll = *vertex_h;
     reco::Vertex best_vertex;
     if (!vertex_coll.empty()) {
@@ -48,7 +48,7 @@ namespace ticl {
     }
 
     edm::Handle<std::vector<reco::CaloCluster>> layer_clusters_h;
-    event.getByToken(layer_clusters_token_, layer_clusters_h);
+    layer_clusters_h = event.getHandle(layer_clusters_token_);
 
     auto size = std::min(tracksters.size(), ticl_cands.size());
     for (size_t i = 0; i < size; ++i) {

--- a/RecoHGCal/TICL/plugins/TracksterP4FromTrackAndPCA.cc
+++ b/RecoHGCal/TICL/plugins/TracksterP4FromTrackAndPCA.cc
@@ -30,7 +30,7 @@ namespace ticl {
                                          std::vector<TICLCandidate>& ticl_cands,
                                          edm::Event& event) const {
     edm::Handle<reco::TrackCollection> tracks_h;
-    event.getByToken(tracks_token_, tracks_h);
+    tracks_h = event.getHandle(tracks_token_);
     edm::ProductID trkId = tracks_h.id();
     const reco::TrackCollection& trackCollection = *tracks_h.product();
 

--- a/RecoHGCal/TICL/plugins/TrackstersMergeProducer.cc
+++ b/RecoHGCal/TICL/plugins/TrackstersMergeProducer.cc
@@ -183,35 +183,35 @@ void TrackstersMergeProducer::produce(edm::Event &evt, const edm::EventSetup &es
   // associating seed to the index of the trackster in the merged collection and the iteration that found it
   std::map<int, std::vector<std::pair<int, TracksterIterIndex>>> seedToTracksterAssociator;
   edm::Handle<std::vector<reco::Track>> track_h;
-  evt.getByToken(tracks_token_, track_h);
+  track_h = evt.getHandle(tracks_token_);
   const auto &tracks = *track_h;
 
   edm::Handle<std::vector<reco::CaloCluster>> cluster_h;
-  evt.getByToken(clusters_token_, cluster_h);
+  cluster_h = evt.getHandle(clusters_token_);
   const auto &layerClusters = *cluster_h;
 
   edm::Handle<edm::ValueMap<std::pair<float, float>>> clustersTime_h;
-  evt.getByToken(clustersTime_token_, clustersTime_h);
+  clustersTime_h = evt.getHandle(clustersTime_token_);
   const auto &layerClustersTimes = *clustersTime_h;
 
   edm::Handle<std::vector<Trackster>> trackstersem_h;
-  evt.getByToken(trackstersem_token_, trackstersem_h);
+  trackstersem_h = evt.getHandle(trackstersem_token_);
   const auto &trackstersEM = *trackstersem_h;
 
   edm::Handle<std::vector<Trackster>> tracksterstrkem_h;
-  evt.getByToken(tracksterstrkem_token_, tracksterstrkem_h);
+  tracksterstrkem_h = evt.getHandle(tracksterstrkem_token_);
   const auto &trackstersTRKEM = *tracksterstrkem_h;
 
   edm::Handle<std::vector<Trackster>> tracksterstrk_h;
-  evt.getByToken(tracksterstrk_token_, tracksterstrk_h);
+  tracksterstrk_h = evt.getHandle(tracksterstrk_token_);
   const auto &trackstersTRK = *tracksterstrk_h;
 
   edm::Handle<std::vector<Trackster>> trackstershad_h;
-  evt.getByToken(trackstershad_token_, trackstershad_h);
+  trackstershad_h = evt.getHandle(trackstershad_token_);
   const auto &trackstersHAD = *trackstershad_h;
 
   edm::Handle<std::vector<TICLSeedingRegion>> seedingTrk_h;
-  evt.getByToken(seedingTrk_token_, seedingTrk_h);
+  seedingTrk_h = evt.getHandle(seedingTrk_token_);
   const auto &seedingTrk = *seedingTrk_h;
   usedSeeds.resize(tracks.size(), false);
 

--- a/RecoHGCal/TICL/test/TiclDebugger.cc
+++ b/RecoHGCal/TICL/test/TiclDebugger.cc
@@ -86,7 +86,7 @@ void TiclDebugger::analyze(const edm::Event& iEvent, const edm::EventSetup& iSet
 
   edm::Handle<std::vector<ticl::Trackster>> trackstersMergeH;
 
-  iEvent.getByToken(trackstersMergeToken_, trackstersMergeH);
+  trackstersMergeH = iEvent.getHandle(trackstersMergeToken_);
   auto const& tracksters = *trackstersMergeH.product();
   std::vector<int> sorted_tracksters_idx(tracksters.size());
   iota(begin(sorted_tracksters_idx), end(sorted_tracksters_idx), 0);
@@ -95,15 +95,15 @@ void TiclDebugger::analyze(const edm::Event& iEvent, const edm::EventSetup& iSet
   });
 
   edm::Handle<std::vector<reco::CaloCluster>> layerClustersH;
-  iEvent.getByToken(layerClustersToken_, layerClustersH);
+  layerClustersH = iEvent.getHandle(layerClustersToken_);
   auto const& layerClusters = *layerClustersH.product();
 
   edm::Handle<std::vector<reco::Track>> tracksH;
-  iEvent.getByToken(tracksToken_, tracksH);
+  tracksH = iEvent.getHandle(tracksToken_);
   const auto& tracks = *tracksH.product();
 
   edm::Handle<std::vector<CaloParticle>> caloParticlesH;
-  iEvent.getByToken(caloParticlesToken_, caloParticlesH);
+  caloParticlesH = iEvent.getHandle(caloParticlesToken_);
   auto const& caloParticles = *caloParticlesH.product();
   std::vector<std::pair<int, float>> bestCPMatches;
 


### PR DESCRIPTION
#### PR description:
Changes produced by clang-tidy using CMS custom checker cms-handle.
Running
USER_CODE_CHECKS=cms-handle scram b code-checks-all 
for the HGCal/TICL package produced these changes.

The cms-handle checker replaces event.getByToken(token,handle) call with the equivalent handle=getHandle(token) call.

Resolves https://github.com/makortel/framework/issues/153