### PR TITLE
Fix corrected eta in L1TkEmParticleProducer - 113X

### DIFF
--- a/L1Trigger/L1TTrackMatch/plugins/L1TkEmParticleProducer.cc
+++ b/L1Trigger/L1TTrackMatch/plugins/L1TkEmParticleProducer.cc
@@ -261,14 +261,10 @@ float L1TkEmParticleProducer::CorrectedEta(float eta, float zv) const {
   float tantheta = tan(theta);
 
   float delta;
-  if (IsBarrel) {
+  if (IsBarrel)
     delta = REcal / tantheta;
-  } else {
-    if (theta > 0)
-      delta = ZEcal;
-    if (theta < 0)
-      delta = -ZEcal;
-  }
+  else
+    delta = eta > 0 ? ZEcal : -ZEcal;
 
   float tanthetaprime = delta * tantheta / (delta - zv);
 


### PR DESCRIPTION
#### PR description:

This suggests to backport the bug fix submitted in the master with #33794
Only the bugged lines (in the CorrectedEta method of L1TkEmParticleProducer) is fixed here, letting aside all other code cleanings that are implemented in the master version of this PR.

The bug does not affect any current Phase2 workflow, because all current instances of the plugin have
```PYTHON
        PrimaryVtxConstrain = False
```
It could be useful to have it fixed in 10_3, however, just in case someone wants to test that L1TkEmParticleProducer with the PrimaryVertex constrain

#### PR validation:

It builds
No changes expected, given the actual configurations run in all current workflow (see above)