### PR TITLE
adding a specified HFNose_noise_fC parameter set to avoid overwriting…

### DIFF
--- a/SimCalorimetry/HGCalSimProducers/python/hgcalDigitizer_cfi.py
+++ b/SimCalorimetry/HGCalSimProducers/python/hgcalDigitizer_cfi.py
@@ -54,6 +54,8 @@ HGCAL_noise_fC = cms.PSet(
     values = cms.vdouble( [x*fC_per_ele for x in nonAgedNoises] ), #100,200,300 um
     )
 
+HFNose_noise_fC = HGCAL_noise_fC.clone()
+
 HGCAL_noise_heback = cms.PSet(
     scaleByDose = cms.bool(False),
     scaleByDoseAlgo = cms.uint32(0),
@@ -196,7 +198,7 @@ hfnoseDigitizer = cms.PSet(
         ileakParam       = cms.PSet(refToPSet_ = cms.string("HGCAL_ileakParam_toUse")),
         cceParams        = cms.PSet(refToPSet_ = cms.string("HGCAL_cceParams_toUse")),
         chargeCollectionEfficiencies = cms.PSet(refToPSet_ = cms.string("HGCAL_chargeCollectionEfficiencies")),
-        noise_fC         = cms.PSet(refToPSet_ = cms.string("HGCAL_noise_fC")),
+        noise_fC         = cms.PSet(refToPSet_ = cms.string("HFNose_noise_fC")),
         doTimeSamples    = cms.bool(False),
         thresholdFollowsMIP        = cms.bool(thresholdTracksMIP),
         feCfg   = hgcROCSettings.clone()
@@ -299,6 +301,17 @@ def HGCal_setRealisticNoiseSi(process,byDose=True,byDoseAlgo=0,byDoseMap=doseMap
         )
     return process
 
+def HFNose_setRealisticNoiseSi(process,byDose=True,byDoseAlgo=0,byDoseMap=doseMap,byDoseFactor=1):
+    process.HFNose_noise_fC = cms.PSet(
+        scaleByDose = cms.bool(byDose),
+        scaleByDoseAlgo = cms.uint32(byDoseAlgo),
+        scaleByDoseFactor = cms.double(byDoseFactor),
+        doseMap = byDoseMap,
+        values = cms.vdouble( [x*fC_per_ele for x in endOfLifeNoises] ), #100,200,300 um
+        )
+    return process
+
+
 def HGCal_setRealisticNoiseSci(process,byDose=True,byDoseAlgo=0,byDoseMap=doseMap,byDoseFactor=1):
     process.HGCAL_noise_heback = cms.PSet(
         scaleByDose = cms.bool(byDose),
@@ -337,7 +350,7 @@ phase2_hgcalV10.toModify(HGCAL_noises, values = [x for x in nonAgedNoises_v9])
 def HFNose_setEndOfLifeNoise(process,byDose=True,byDoseAlgo=0,byDoseFactor=1):
     """includes all effects from radiation and gain choice"""
     # byDoseAlgo is used as a collection of bits to toggle: FLUENCE, CCE, NOISE, PULSEPERGAIN, CACHEDOP (from lsb to Msb)
-    process=HGCal_setRealisticNoiseSi(process,byDose=byDose,byDoseAlgo=byDoseAlgo,byDoseMap=doseMapNose,byDoseFactor=byDoseFactor)
+    process=HFNose_setRealisticNoiseSi(process,byDose=byDose,byDoseAlgo=byDoseAlgo,byDoseMap=doseMapNose,byDoseFactor=byDoseFactor)
     return process
 
 doseMapNose = cms.string("SimCalorimetry/HGCalSimProducers/data/doseParams_3000fb_fluka_HFNose_3.7.20.12_Eta2.4.txt")

--- a/SimGeneral/MixingModule/python/digitizers_cfi.py
+++ b/SimGeneral/MixingModule/python/digitizers_cfi.py
@@ -51,7 +51,7 @@ from Configuration.ProcessModifiers.premix_stage2_cff import premix_stage2
 )
 
 
-from SimCalorimetry.HGCalSimProducers.hgcalDigitizer_cfi import hgceeDigitizer, hgchebackDigitizer, hgchefrontDigitizer, HGCAL_noise_fC, HGCAL_noise_heback, HGCAL_chargeCollectionEfficiencies, HGCAL_ileakParam_toUse, HGCAL_cceParams_toUse, HGCAL_noises
+from SimCalorimetry.HGCalSimProducers.hgcalDigitizer_cfi import hgceeDigitizer, hgchebackDigitizer, hgchefrontDigitizer, HGCAL_noise_fC, HGCAL_noise_heback, HFNose_noise_fC, HGCAL_chargeCollectionEfficiencies, HGCAL_ileakParam_toUse, HGCAL_cceParams_toUse, HGCAL_noises
 
 from Configuration.Eras.Modifier_phase2_hgcal_cff import phase2_hgcal
 phase2_hgcal.toModify( theDigitizers,


### PR DESCRIPTION
… of default parameters for HGCal

#### PR description:

The HFnose and HGCal Si section share analogous digitization code and configuration files.
In both cases the parameters used to model the realistic detector/noise are read from a refToPSet which has been kept common up to this PR.
In recent releases, when the aging of HFNose was introduced, we have overlooked the fact that in the configuration it ends up overwriting the a crucial parameter which sets the dose/fluence map to be used. This parameter is firstly set to the default HGCAL but immediately changed afterwards to the HFnose one, which is is not suitable for HGCAL. 
This happens when the following customisation is made

--customise SLHCUpgradeSimulations/Configuration/aging.customise_aging_3000

As a result the HGCAL part of the simulation turns out to be incorrect in workflows where aging has been enabled.
This PR fixes this by introducing a separate PSet for HFNose. Initially it is made as a clone of the HGCAL_noise_fC PSet and when the customise is called it sets the proper values for HFnose, namely the doseMap.


#### PR validation:

We have checked with

```
runTheMatrix.py -w upgrade -l 23234.103
```

that the final configuration is correct and that the events obtained after the DIGI step are consistent with the ones we had in 11_2_X. For illustration two plots comparing the before and after on a handful of events.

![wrong dose map](https://user-images.githubusercontent.com/4624574/119809332-4a673c80-bee5-11eb-95ad-6e6341e21034.png)
![correct dose map](https://user-images.githubusercontent.com/4624574/119809838-cb263880-bee5-11eb-8cdb-db576115bc5f.png)

@ttrk 
@mariadalfonso  can you check the proposed changes are ok from the HFnose point of view
@franzoni  this is probably one of the last PRs you're required to follow in CMS? 
