### PR TITLE
 bug-fix for infinite loop in MuonSimClassifier.cc [94X backport]

### DIFF
--- a/SimMuon/MCTruth/plugins/MuonSimClassifier.cc
+++ b/SimMuon/MCTruth/plugins/MuonSimClassifier.cc
@@ -302,6 +302,11 @@ MuonSimClassifier::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
 		  if (mMom->numberOfMothers() > 0) {
 		    mMom = mMom->motherRef();
 		  }
+              else {
+                LogTrace("MuonSimClassifier") << "\t No Mother is found ";
+                break;
+              }
+              
 		  LogTrace("MuonSimClassifier") 
 		    << "\t\t backtracking mother "<<jm<<", pdgId = "<<mMom->pdgId()<<", status= " <<mMom->status();
 		}


### PR DESCRIPTION
#### PR description:

Backport of #28802 to 94X. This infinite loop blocked MUO-RunIIFall17GS-00025 

#### PR validation:

This PR fixes
```
cmsDriver.py  --python_filename MUO-RunIIFall17DRStdmix-00026_2_cfg.py --eventcontent AODSIM --customise Configuration/DataProcessing/Utils.addMonitoring --datatier AODSIM --fileout file:MUO-RunIIFall17DRStdmix-00026.root --conditions 94X_mc2017_realistic_MuonTrackFix_01 --step RAW2DIGI,L1Reco,RECO,RECOSIM,EI --geometry DB:Extended --filein file:MUO-RunIIFall17DRStdmix-00026_0.root --era Run2_2017 --mc
```

This command was taken from PdmV recipes to reproduce the error

```
- GS: 
wget https://cms-pdmv.cern.ch/mcm/public/restapi/requests/get_test/MUO-RunIIFall17GS-00025

edit it to have 100 events (NEVENTS)

source it

it will produce 13 events

- DR: 
wget https://cms-pdmv.cern.ch/mcm/public/restapi/requests/get_test/MUO-RunIIFall17DRStdmix-00026

edit to run 13 events

source it (this is nopu, so no need to set grid env)
```

