### PR TITLE
TkDQM: add rechit harvester module for IT

### DIFF
--- a/DQM/SiTrackerPhase2/interface/TrackerPhase2HarvestingUtil.h
+++ b/DQM/SiTrackerPhase2/interface/TrackerPhase2HarvestingUtil.h
@@ -1,0 +1,20 @@
+#ifndef _DQM_SiTrackerPhase2_Phase2TrackerHarvestingUtil_h
+#define _DQM_SiTrackerPhase2_Phase2TrackerHarvestingUtil_h
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "DQMServices/Core/interface/MonitorElement.h"
+#include "DQMServices/Core/interface/DQMStore.h"
+#include <string>
+
+namespace phase2tkharvestutil {
+
+  typedef dqm::harvesting::MonitorElement MonitorElement;
+  typedef dqm::harvesting::DQMStore DQMStore;
+
+  MonitorElement* book1DFromPSet(const edm::ParameterSet& hpars, DQMStore::IBooker& ibooker);
+
+  MonitorElement* book2DFromPSet(const edm::ParameterSet& hpars, DQMStore::IBooker& ibooker);
+
+  MonitorElement* bookProfile1DFromPSet(const edm::ParameterSet& hpars, DQMStore::IBooker& ibooker);
+}  // namespace phase2tkharvestutil
+#endif

--- a/DQM/SiTrackerPhase2/src/TrackerPhase2HarvestingUtil.cc
+++ b/DQM/SiTrackerPhase2/src/TrackerPhase2HarvestingUtil.cc
@@ -1,0 +1,43 @@
+#include "DQM/SiTrackerPhase2/interface/TrackerPhase2HarvestingUtil.h"
+typedef dqm::harvesting::MonitorElement MonitorElement;
+typedef dqm::harvesting::DQMStore DQMStore;
+MonitorElement* phase2tkharvestutil::book1DFromPSet(const edm::ParameterSet& hpars, DQMStore::IBooker& ibooker) {
+  MonitorElement* temp = nullptr;
+  if (hpars.getParameter<bool>("switch")) {
+    temp = ibooker.book1D(hpars.getParameter<std::string>("name"),
+                          hpars.getParameter<std::string>("title"),
+                          hpars.getParameter<int32_t>("NxBins"),
+                          hpars.getParameter<double>("xmin"),
+                          hpars.getParameter<double>("xmax"));
+  }
+  return temp;
+}
+
+MonitorElement* phase2tkharvestutil::book2DFromPSet(const edm::ParameterSet& hpars, DQMStore::IBooker& ibooker) {
+  MonitorElement* temp = nullptr;
+  if (hpars.getParameter<bool>("switch")) {
+    temp = ibooker.book2D(hpars.getParameter<std::string>("name"),
+                          hpars.getParameter<std::string>("title"),
+                          hpars.getParameter<int32_t>("NxBins"),
+                          hpars.getParameter<double>("xmin"),
+                          hpars.getParameter<double>("xmax"),
+                          hpars.getParameter<int32_t>("NyBins"),
+                          hpars.getParameter<double>("ymin"),
+                          hpars.getParameter<double>("ymax"));
+  }
+  return temp;
+}
+
+MonitorElement* phase2tkharvestutil::bookProfile1DFromPSet(const edm::ParameterSet& hpars, DQMStore::IBooker& ibooker) {
+  MonitorElement* temp = nullptr;
+  if (hpars.getParameter<bool>("switch")) {
+    temp = ibooker.bookProfile(hpars.getParameter<std::string>("name"),
+                               hpars.getParameter<std::string>("title"),
+                               hpars.getParameter<int32_t>("NxBins"),
+                               hpars.getParameter<double>("xmin"),
+                               hpars.getParameter<double>("xmax"),
+                               hpars.getParameter<double>("ymin"),
+                               hpars.getParameter<double>("ymax"));
+  }
+  return temp;
+}

--- a/DQM/SiTrackerPhase2/test/harvestingstep_phase2tk_cfg.py
+++ b/DQM/SiTrackerPhase2/test/harvestingstep_phase2tk_cfg.py
@@ -76,7 +76,9 @@ from Configuration.AlCa.GlobalTag import GlobalTag
 process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase2_realistic_T21', '')
 
 # Path and EndPath definitions
-process.trackerphase2ValidationHarvesting_step = cms.Path(process.trackerphase2ValidationHarvesting)
+process.trackerphase2ValidationHarvesting_step = cms.Path(process.trackerphase2ValidationHarvesting_standalone
+##default path in production
+#process.trackerphase2ValidationHarvesting_step = cms.Path(process.trackerphase2ValidationHarvesting)
 process.dqmsave_step = cms.Path(process.DQMSaver)
 
 # Schedule definition

--- a/Validation/SiTrackerPhase2V/interface/Phase2ITValidateRecHitBase.h
+++ b/Validation/SiTrackerPhase2V/interface/Phase2ITValidateRecHitBase.h
@@ -65,7 +65,9 @@ protected:
     MonitorElement* pullX = nullptr;
     MonitorElement* pullY = nullptr;
     MonitorElement* deltaX_eta = nullptr;
+    MonitorElement* deltaX_phi = nullptr;
     MonitorElement* deltaY_eta = nullptr;
+    MonitorElement* deltaY_phi = nullptr;
     MonitorElement* deltaX_clsizex = nullptr;
     MonitorElement* deltaX_clsizey = nullptr;
     MonitorElement* deltaY_clsizex = nullptr;

--- a/Validation/SiTrackerPhase2V/interface/Phase2OTValidateRecHitBase.h
+++ b/Validation/SiTrackerPhase2V/interface/Phase2OTValidateRecHitBase.h
@@ -41,7 +41,6 @@
 #include "DQMServices/Core/interface/MonitorElement.h"
 #include "DataFormats/TrackerRecHit2D/interface/Phase2TrackerRecHit1D.h"
 
-
 class Phase2OTValidateRecHitBase : public DQMEDAnalyzer {
 public:
   explicit Phase2OTValidateRecHitBase(const edm::ParameterSet&);
@@ -49,10 +48,10 @@ public:
   void bookHistograms(DQMStore::IBooker& ibooker, edm::Run const& iRun, edm::EventSetup const& iSetup) override;
   void dqmBeginRun(const edm::Run& iRun, const edm::EventSetup& iSetup) override;
   void fillOTRecHitHistos(const PSimHit* simhitClosest,
-			  const Phase2TrackerRecHit1D* rechit,
-			  const std::map<unsigned int, SimTrack>& selectedSimTrackMap,
-			  std::map<std::string, unsigned int>& nrechitLayerMapP_primary,
-			  std::map<std::string, unsigned int>& nrechitLayerMapS_primary);
+                          const Phase2TrackerRecHit1D* rechit,
+                          const std::map<unsigned int, SimTrack>& selectedSimTrackMap,
+                          std::map<std::string, unsigned int>& nrechitLayerMapP_primary,
+                          std::map<std::string, unsigned int>& nrechitLayerMapS_primary);
 
   static void fillPSetDescription(edm::ParameterSetDescription& desc);
   void bookLayerHistos(DQMStore::IBooker& ibooker, unsigned int det_id, std::string& subdir);

--- a/Validation/SiTrackerPhase2V/interface/Phase2OTValidateRecHitBase.h
+++ b/Validation/SiTrackerPhase2V/interface/Phase2OTValidateRecHitBase.h
@@ -1,0 +1,104 @@
+// Package:    Phase2OTValidateRecHitBase
+// Class:      Phase2OTValidateRecHitBase
+//
+/**\class Phase2OTValidateRecHitBase Phase2OTValidateRecHitBase.cc 
+ Description:  Standalone  Plugin for Phase2 RecHit validation
+*/
+//
+// Author: Suvankar Roy Chowdhury
+// Date: March 2021
+//
+// system include files
+// STL includes
+#include <memory>
+#include <map>
+#include <vector>
+#include <algorithm>
+
+// system include files
+#include "DataFormats/Common/interface/Handle.h"
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+#include "DataFormats/TrackerRecHit2D/interface/SiPixelRecHitCollection.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
+#include "Geometry/Records/interface/TrackerTopologyRcd.h"
+#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
+#include "SimDataFormats/TrackingHit/interface/PSimHit.h"
+#include "SimDataFormats/Track/interface/SimTrackContainer.h"
+
+//DQM
+#include "DQMServices/Core/interface/DQMEDAnalyzer.h"
+#include "DQMServices/Core/interface/DQMStore.h"
+#include "DQMServices/Core/interface/MonitorElement.h"
+#include "DataFormats/TrackerRecHit2D/interface/Phase2TrackerRecHit1D.h"
+
+
+class Phase2OTValidateRecHitBase : public DQMEDAnalyzer {
+public:
+  explicit Phase2OTValidateRecHitBase(const edm::ParameterSet&);
+  ~Phase2OTValidateRecHitBase() override;
+  void bookHistograms(DQMStore::IBooker& ibooker, edm::Run const& iRun, edm::EventSetup const& iSetup) override;
+  void dqmBeginRun(const edm::Run& iRun, const edm::EventSetup& iSetup) override;
+  void fillOTRecHitHistos(const PSimHit* simhitClosest,
+			  const Phase2TrackerRecHit1D* rechit,
+			  const std::map<unsigned int, SimTrack>& selectedSimTrackMap,
+			  std::map<std::string, unsigned int>& nrechitLayerMapP_primary,
+			  std::map<std::string, unsigned int>& nrechitLayerMapS_primary);
+
+  static void fillPSetDescription(edm::ParameterSetDescription& desc);
+  void bookLayerHistos(DQMStore::IBooker& ibooker, unsigned int det_id, std::string& subdir);
+
+protected:
+  edm::ParameterSet config_;
+  std::string geomType_;
+  const edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> geomToken_;
+  const edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> topoToken_;
+  const TrackerGeometry* tkGeom_ = nullptr;
+  const TrackerTopology* tTopo_ = nullptr;
+
+  struct RecHitME {
+    // use TH1D instead of TH1F to avoid stauration at 2^31
+    // above this increments with +1 don't work for float, need double
+    MonitorElement* deltaX_P = nullptr;
+    MonitorElement* deltaX_S = nullptr;
+    MonitorElement* deltaY_P = nullptr;
+    MonitorElement* deltaY_S = nullptr;
+    MonitorElement* pullX_P = nullptr;
+    MonitorElement* pullX_S = nullptr;
+    MonitorElement* pullY_P = nullptr;
+    MonitorElement* pullY_S = nullptr;
+    MonitorElement* deltaX_eta_P = nullptr;
+    MonitorElement* deltaX_eta_S = nullptr;
+    MonitorElement* deltaY_eta_P = nullptr;
+    MonitorElement* deltaY_eta_S = nullptr;
+    MonitorElement* deltaX_phi_P = nullptr;
+    MonitorElement* deltaX_phi_S = nullptr;
+    MonitorElement* deltaY_phi_P = nullptr;
+    MonitorElement* deltaY_phi_S = nullptr;
+    MonitorElement* pullX_eta_P = nullptr;
+    MonitorElement* pullX_eta_S = nullptr;
+    MonitorElement* pullY_eta_P = nullptr;
+    MonitorElement* pullY_eta_S = nullptr;
+    //For rechits matched to simhits from highPT tracks
+    MonitorElement* pullX_primary_P;
+    MonitorElement* pullX_primary_S;
+    MonitorElement* pullY_primary_P;
+    MonitorElement* pullY_primary_S;
+    MonitorElement* deltaX_primary_P;
+    MonitorElement* deltaX_primary_S;
+    MonitorElement* deltaY_primary_P;
+    MonitorElement* deltaY_primary_S;
+    MonitorElement* numberRecHitsprimary_P;
+    MonitorElement* numberRecHitsprimary_S;
+  };
+  std::map<std::string, RecHitME> layerMEs_;
+};

--- a/Validation/SiTrackerPhase2V/plugins/Phase2ITRecHitHarvester.cc
+++ b/Validation/SiTrackerPhase2V/plugins/Phase2ITRecHitHarvester.cc
@@ -166,7 +166,7 @@ void Phase2ITRecHitHarvester::fillDescriptions(edm::ConfigurationDescriptions& d
 
   edm::ParameterSetDescription psd0;
   psd0.add<std::string>("name", "resolutionXFitvseta");
-  psd0.add<std::string>("title", ";#eta; X-Resolution from fit [#mum]");
+  psd0.add<std::string>("title", ";|#eta|; X-Resolution from fit [#mum]");
   psd0.add<int>("NxBins", 41);
   psd0.add<double>("xmax", 4.1);
   psd0.add<double>("xmin", 0.);
@@ -175,7 +175,7 @@ void Phase2ITRecHitHarvester::fillDescriptions(edm::ConfigurationDescriptions& d
 
   edm::ParameterSetDescription psd1;
   psd1.add<std::string>("name", "resolutionYFitvseta");
-  psd1.add<std::string>("title", ";#eta; Y-Resolution from fit [#mum]");
+  psd1.add<std::string>("title", ";|#eta|; Y-Resolution from fit [#mum]");
   psd1.add<int>("NxBins", 41);
   psd1.add<double>("xmax", 4.1);
   psd1.add<double>("xmin", 0.);
@@ -202,7 +202,7 @@ void Phase2ITRecHitHarvester::fillDescriptions(edm::ConfigurationDescriptions& d
 
   edm::ParameterSetDescription psd4;
   psd4.add<std::string>("name", "meanXFitvseta");
-  psd4.add<std::string>("title", ";#eta; Mean residual X from fit [#mum]");
+  psd4.add<std::string>("title", ";|#eta|; Mean residual X from fit [#mum]");
   psd4.add<int>("NxBins", 41);
   psd4.add<double>("xmax", 4.1);
   psd4.add<double>("xmin", 0.);
@@ -211,7 +211,7 @@ void Phase2ITRecHitHarvester::fillDescriptions(edm::ConfigurationDescriptions& d
 
   edm::ParameterSetDescription psd5;
   psd5.add<std::string>("name", "meanYFitvseta");
-  psd5.add<std::string>("title", ";#eta; Mean residual Y from fit [#mum]");
+  psd5.add<std::string>("title", ";|#eta|; Mean residual Y from fit [#mum]");
   psd5.add<int>("NxBins", 41);
   psd5.add<double>("xmax", 4.1);
   psd5.add<double>("xmin", 0.);

--- a/Validation/SiTrackerPhase2V/plugins/Phase2ITRecHitHarvester.cc
+++ b/Validation/SiTrackerPhase2V/plugins/Phase2ITRecHitHarvester.cc
@@ -1,0 +1,167 @@
+#include "DQMServices/Core/interface/DQMEDHarvester.h"
+#include "DQMServices/Core/interface/DQMStore.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+class Phase2ITRecHitHarvester : public DQMEDHarvester {
+public:
+  explicit Phase2ITRecHitHarvester(const edm::ParameterSet &);
+  ~Phase2ITRecHitHarvester();
+  void dqmEndJob(DQMStore::IBooker &ibooker, DQMStore::IGetter &igetter) override;
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+private:
+  void gausFitslices(MonitorElement* srcME, MonitorElement* meanME, MonitorElement* sigmaME);
+  void dofitsForLayer(const std::string& iFolder, DQMStore::IBooker &ibooker, DQMStore::IGetter &igetter);
+
+  // ----------member data ---------------------------
+  std::string topFolder_;
+  unsigned int nbarrelLayers_;
+  unsigned int ndisk1Rings_;//FOR IT epix//FOR OT TEDD1 rings
+  unsigned int ndisk2Rings_;//FOR IT epix//FOR OT TEDD2 rings
+  unsigned int fitThreshold_;
+  std::string ecapdisk1Name_;//FOR IT Epix//FOR OT TEDD_1
+  std::string ecapdisk2Name_;//FOR IT Fpix//FOR OT TEDD_2
+  std::string histoPhiname_;
+  std::string deltaXvsEtaname_;
+  std::string deltaXvsPhiname_;
+  std::string deltaYvsEtaname_;
+  std::string deltaYvsPhiname_;
+
+};
+
+Phase2ITRecHitHarvester::Phase2ITRecHitHarvester(const edm::ParameterSet & iConfig) :
+  topFolder_(iConfig.getParameter<std::string>("TopFolder")),
+  nbarrelLayers_(iConfig.getParameter<uint32_t>("NbarrelLayers")),
+  ndisk1Rings_(iConfig.getParameter<uint32_t>("NDisk1Rings")),
+  ndisk2Rings_(iConfig.getParameter<uint32_t>("NDisk2Rings")),
+  fitThreshold_(iConfig.getParameter<uint32_t>("NFitThreshold")),
+  ecapdisk1Name_(iConfig.getParameter<std::string>("EcapDisk1Name")),
+  ecapdisk2Name_(iConfig.getParameter<std::string>("EcapDisk2Name")),
+  deltaXvsEtaname_(iConfig.getParameter<std::string>("ResidualXvsEta")),
+  deltaXvsPhiname_(iConfig.getParameter<std::string>("ResidualXvsPhi")),
+  deltaYvsEtaname_(iConfig.getParameter<std::string>("ResidualYvsEta")),
+  deltaYvsPhiname_(iConfig.getParameter<std::string>("ResidualYvsPhi"))
+{
+}
+
+Phase2ITRecHitHarvester::~Phase2ITRecHitHarvester() {}
+
+void Phase2ITRecHitHarvester::dqmEndJob(DQMStore::IBooker &ibooker, DQMStore::IGetter &igetter) {
+  
+  for(unsigned int i = 1; i<=nbarrelLayers_; i++) {
+    std::string iFolder=topFolder_ + "/Barrel/Layer" + std::to_string(i);
+    dofitsForLayer(iFolder, ibooker, igetter);
+  } 
+  for(unsigned int iSide = 1; iSide <=2; iSide++) {
+    const std::string ecapbasedisk1 = topFolder_ + "/EndCap_Side" + std::to_string(iSide) + "/" + ecapdisk1Name_ + "/Ring" ;
+    const std::string ecapbasedisk2 = topFolder_ + "/EndCap_Side" + std::to_string(iSide) + "/" + ecapdisk2Name_ + "/Ring" ;
+    //EPix or TEDD_1
+    for(unsigned int epixr = 1; epixr<=ndisk1Rings_; epixr++) {
+      std::string iFolder=ecapbasedisk1 + std::to_string(epixr);
+      dofitsForLayer(iFolder, ibooker, igetter);
+    }
+    //FPix or TEDD_2
+    for(unsigned int fpixr = 1; fpixr<=ndisk2Rings_; fpixr++) {
+      std::string iFolder= ecapbasedisk2 + std::to_string(fpixr);
+      dofitsForLayer(iFolder, ibooker, igetter);
+    }
+  }
+  
+}
+//Function for Layer/Ring
+void Phase2ITRecHitHarvester::dofitsForLayer(const std::string& iFolder, DQMStore::IBooker &ibooker, DQMStore::IGetter &igetter) {
+    
+    MonitorElement* deltaX_eta=igetter.get(iFolder+"/"+ deltaXvsEtaname_);
+    MonitorElement* deltaX_phi=igetter.get(iFolder+"/"+ deltaXvsPhiname_);
+    MonitorElement* deltaY_eta=igetter.get(iFolder+"/" + deltaYvsEtaname_);
+    MonitorElement* deltaY_phi=igetter.get(iFolder+"/" + deltaYvsPhiname_);
+
+    std::string resFolder=iFolder+"/ResolutionFromFit/";
+
+    ibooker.cd();
+    ibooker.setCurrentFolder(resFolder);
+    MonitorElement* sigmaX_eta=ibooker.book1D("resolutionXFitvseta", ";#eta;resolution X[#mum]", 81, -4.1, 4.1);
+    MonitorElement* meanX_eta=ibooker.book1D("meanresidualXFitvseta", ";#eta;Mean residual X[#mum]", 81, -4.1, 4.1);
+    gausFitslices(deltaX_eta, meanX_eta, sigmaX_eta);
+
+    MonitorElement* sigmaY_eta=ibooker.book1D("resolutionYFitvseta", ";#eta;resolution Y", 81, -4.1, 4.1);
+    MonitorElement* meanY_eta=ibooker.book1D("meanresidualYFitvseta", ";#eta;Mean residual Y", 81, -4.1, 4.1);
+    gausFitslices(deltaY_eta, meanY_eta, sigmaY_eta);
+
+    MonitorElement* sigmaX_phi=ibooker.book1D("resolutionXFitvsphi", ";#phi;resolution X[#mum]", 36, -M_PI, M_PI);
+    MonitorElement* meanX_phi=ibooker.book1D("meanresidualXFitvsphi", ";#phi;Mean residual X[#mum]", 36, -M_PI, M_PI);
+    gausFitslices(deltaX_phi, meanX_phi, sigmaX_phi);
+
+    MonitorElement* sigmaY_phi=ibooker.book1D("resolutionYFitvsphi", ";#phi;resolution Y", 36, -M_PI, M_PI);
+    MonitorElement* meanY_phi=ibooker.book1D("meanresidualYFitvsphi", ";#phi;Mean residual Y", 36, -M_PI, M_PI);
+    gausFitslices(deltaY_phi, meanY_phi, sigmaY_phi);
+}
+void Phase2ITRecHitHarvester::gausFitslices(MonitorElement* srcME, MonitorElement* meanME, MonitorElement* sigmaME) {
+  TH2F* histo = srcME->getTH2F();
+
+  // Fit slices projected along Y from bins in X
+  const unsigned int cont_min = fitThreshold_;  //Minimum number of entries
+  for (int i = 1; i <= srcME->getNbinsX(); i++) {
+    TString iString(i);
+    TH1* histoY = histo->ProjectionY(" ", i, i);
+    const unsigned int cont = histoY->GetEntries();
+
+    if (cont >= cont_min) {
+      float minfit = histoY->GetMean() - histoY->GetRMS();
+      float maxfit = histoY->GetMean() + histoY->GetRMS();
+
+      TF1* fitFcn = new TF1(TString("g") + histo->GetName() + iString, "gaus", minfit, maxfit);
+      histoY->Fit(fitFcn, "QR0 SERIAL", "", minfit, maxfit);
+
+      double* par = fitFcn->GetParameters();
+      const double* err = fitFcn->GetParErrors();
+
+      meanME->setBinContent(i, par[1]);
+      meanME->setBinError(i, err[1]);
+
+      sigmaME->setBinContent(i, par[2]);
+      sigmaME->setBinError(i, err[2]);
+
+      if (fitFcn)
+        delete fitFcn;
+      if (histoY)
+        delete histoY;
+    } else {
+      if (histoY)
+        delete histoY;
+      continue;
+    }
+  }
+}
+
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+void Phase2ITRecHitHarvester::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  // phase2ITrechitHarvester
+  edm::ParameterSetDescription desc;
+  desc.add<std::string>("TopFolder", "TrackerPhase2ITRecHitV");
+  desc.add<unsigned int>("NbarrelLayers", 4);
+  desc.add<unsigned int>("NDisk1Rings", 5);
+  desc.add<unsigned int>("NDisk2Rings", 4);
+  desc.add<std::string>("EcapDisk1Name", "EPix");
+  desc.add<std::string>("EcapDisk2Name", "FPix");
+  desc.add<std::string>("ResidualXvsEta", "Delta_X_vs_Eta");
+  desc.add<std::string>("ResidualXvsPhi", "Delta_X_vs_Phi");
+  desc.add<std::string>("ResidualYvsEta", "Delta_Y_vs_Eta");
+  desc.add<std::string>("ResidualYvsPhi", "Delta_Y_vs_Phi");
+
+  desc.add<unsigned int>("NFitThreshold", 5);
+  
+  descriptions.add("Phase2ITRechitHarvester", desc);
+  // or use the following to generate the label from the module's C++ type
+  //descriptions.addWithDefaultLabel(desc);
+}
+
+//define this as a plug-in
+DEFINE_FWK_MODULE(Phase2ITRecHitHarvester);

--- a/Validation/SiTrackerPhase2V/plugins/Phase2ITRecHitHarvester.cc
+++ b/Validation/SiTrackerPhase2V/plugins/Phase2ITRecHitHarvester.cc
@@ -126,8 +126,8 @@ void Phase2ITRecHitHarvester::gausFitslices(MonitorElement* srcME, MonitorElemen
       float minfit = histoY->GetMean() - histoY->GetRMS();
       float maxfit = histoY->GetMean() + histoY->GetRMS();
 
-      TF1* fitFcn = new TF1(TString("g") + histo->GetName() + iString, "gaus", minfit, maxfit);
-      histoY->Fit(fitFcn, "QR0 SERIAL", "", minfit, maxfit);
+      std::unique_ptr<TF1> fitFcn{new TF1(TString("g") + histo->GetName() + iString, "gaus", minfit, maxfit)};
+      histoY->Fit(fitFcn.get(), "QR0 SERIAL", "", minfit, maxfit);
 
       double* par = fitFcn->GetParameters();
       const double* err = fitFcn->GetParErrors();
@@ -138,8 +138,6 @@ void Phase2ITRecHitHarvester::gausFitslices(MonitorElement* srcME, MonitorElemen
       sigmaME->setBinContent(i, par[2]);
       sigmaME->setBinError(i, err[2]);
 
-      if (fitFcn)
-        delete fitFcn;
       if (histoY)
         delete histoY;
     } else {
@@ -238,7 +236,7 @@ void Phase2ITRecHitHarvester::fillDescriptions(edm::ConfigurationDescriptions& d
   psd7.add<bool>("switch", true);
   desc.add<edm::ParameterSetDescription>("meanYvsphi", psd7);
 
-  desc.add<unsigned int>("NFitThreshold", 5);
+  desc.add<unsigned int>("NFitThreshold", 100);
 
   descriptions.add("Phase2ITRechitHarvester", desc);
   // or use the following to generate the label from the module's C++ type

--- a/Validation/SiTrackerPhase2V/plugins/Phase2ITRecHitHarvester.cc
+++ b/Validation/SiTrackerPhase2V/plugins/Phase2ITRecHitHarvester.cc
@@ -11,7 +11,7 @@
 class Phase2ITRecHitHarvester : public DQMEDHarvester {
 public:
   explicit Phase2ITRecHitHarvester(const edm::ParameterSet &);
-  ~Phase2ITRecHitHarvester();
+  ~Phase2ITRecHitHarvester() override;
   void dqmEndJob(DQMStore::IBooker &ibooker, DQMStore::IGetter &igetter) override;
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);

--- a/Validation/SiTrackerPhase2V/plugins/Phase2ITRecHitHarvester.cc
+++ b/Validation/SiTrackerPhase2V/plugins/Phase2ITRecHitHarvester.cc
@@ -10,100 +10,107 @@
 #include "DQM/SiTrackerPhase2/interface/TrackerPhase2HarvestingUtil.h"
 class Phase2ITRecHitHarvester : public DQMEDHarvester {
 public:
-  explicit Phase2ITRecHitHarvester(const edm::ParameterSet &);
+  explicit Phase2ITRecHitHarvester(const edm::ParameterSet&);
   ~Phase2ITRecHitHarvester() override;
-  void dqmEndJob(DQMStore::IBooker &ibooker, DQMStore::IGetter &igetter) override;
+  void dqmEndJob(DQMStore::IBooker& ibooker, DQMStore::IGetter& igetter) override;
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
 private:
   void gausFitslices(MonitorElement* srcME, MonitorElement* meanME, MonitorElement* sigmaME);
-  void dofitsForLayer(const std::string& iFolder, DQMStore::IBooker &ibooker, DQMStore::IGetter &igetter);
+  void dofitsForLayer(const std::string& iFolder, DQMStore::IBooker& ibooker, DQMStore::IGetter& igetter);
 
   // ----------member data ---------------------------
   const edm::ParameterSet config_;
   const std::string topFolder_;
   const unsigned int nbarrelLayers_;
-  const unsigned int ndisk1Rings_;//FOR IT epix//FOR OT TEDD1 rings
-  const unsigned int ndisk2Rings_;//FOR IT epix//FOR OT TEDD2 rings
+  const unsigned int ndisk1Rings_;  //FOR IT epix//FOR OT TEDD1 rings
+  const unsigned int ndisk2Rings_;  //FOR IT epix//FOR OT TEDD2 rings
   const unsigned int fitThreshold_;
-  const std::string ecapdisk1Name_;//FOR IT Epix//FOR OT TEDD_1
-  const std::string ecapdisk2Name_;//FOR IT Fpix//FOR OT TEDD_2
+  const std::string ecapdisk1Name_;  //FOR IT Epix//FOR OT TEDD_1
+  const std::string ecapdisk2Name_;  //FOR IT Fpix//FOR OT TEDD_2
   const std::string histoPhiname_;
   const std::string deltaXvsEtaname_;
   const std::string deltaXvsPhiname_;
   const std::string deltaYvsEtaname_;
   const std::string deltaYvsPhiname_;
-
 };
 
-Phase2ITRecHitHarvester::Phase2ITRecHitHarvester(const edm::ParameterSet & iConfig) :
-  config_(iConfig),
-  topFolder_(iConfig.getParameter<std::string>("TopFolder")),
-  nbarrelLayers_(iConfig.getParameter<uint32_t>("NbarrelLayers")),
-  ndisk1Rings_(iConfig.getParameter<uint32_t>("NDisk1Rings")),
-  ndisk2Rings_(iConfig.getParameter<uint32_t>("NDisk2Rings")),
-  fitThreshold_(iConfig.getParameter<uint32_t>("NFitThreshold")),
-  ecapdisk1Name_(iConfig.getParameter<std::string>("EcapDisk1Name")),
-  ecapdisk2Name_(iConfig.getParameter<std::string>("EcapDisk2Name")),
-  deltaXvsEtaname_(iConfig.getParameter<std::string>("ResidualXvsEta")),
-  deltaXvsPhiname_(iConfig.getParameter<std::string>("ResidualXvsPhi")),
-  deltaYvsEtaname_(iConfig.getParameter<std::string>("ResidualYvsEta")),
-  deltaYvsPhiname_(iConfig.getParameter<std::string>("ResidualYvsPhi"))
-{
-}
+Phase2ITRecHitHarvester::Phase2ITRecHitHarvester(const edm::ParameterSet& iConfig)
+    : config_(iConfig),
+      topFolder_(iConfig.getParameter<std::string>("TopFolder")),
+      nbarrelLayers_(iConfig.getParameter<uint32_t>("NbarrelLayers")),
+      ndisk1Rings_(iConfig.getParameter<uint32_t>("NDisk1Rings")),
+      ndisk2Rings_(iConfig.getParameter<uint32_t>("NDisk2Rings")),
+      fitThreshold_(iConfig.getParameter<uint32_t>("NFitThreshold")),
+      ecapdisk1Name_(iConfig.getParameter<std::string>("EcapDisk1Name")),
+      ecapdisk2Name_(iConfig.getParameter<std::string>("EcapDisk2Name")),
+      deltaXvsEtaname_(iConfig.getParameter<std::string>("ResidualXvsEta")),
+      deltaXvsPhiname_(iConfig.getParameter<std::string>("ResidualXvsPhi")),
+      deltaYvsEtaname_(iConfig.getParameter<std::string>("ResidualYvsEta")),
+      deltaYvsPhiname_(iConfig.getParameter<std::string>("ResidualYvsPhi")) {}
 
 Phase2ITRecHitHarvester::~Phase2ITRecHitHarvester() {}
 
-void Phase2ITRecHitHarvester::dqmEndJob(DQMStore::IBooker &ibooker, DQMStore::IGetter &igetter) {
-  
-  for(unsigned int i = 1; i<=nbarrelLayers_; i++) {
-    std::string iFolder=topFolder_ + "/Barrel/Layer" + std::to_string(i);
+void Phase2ITRecHitHarvester::dqmEndJob(DQMStore::IBooker& ibooker, DQMStore::IGetter& igetter) {
+  for (unsigned int i = 1; i <= nbarrelLayers_; i++) {
+    std::string iFolder = topFolder_ + "/Barrel/Layer" + std::to_string(i);
     dofitsForLayer(iFolder, ibooker, igetter);
-  } 
-  for(unsigned int iSide = 1; iSide <=2; iSide++) {
-    const std::string ecapbasedisk1 = topFolder_ + "/EndCap_Side" + std::to_string(iSide) + "/" + ecapdisk1Name_ + "/Ring" ;
-    const std::string ecapbasedisk2 = topFolder_ + "/EndCap_Side" + std::to_string(iSide) + "/" + ecapdisk2Name_ + "/Ring" ;
+  }
+  for (unsigned int iSide = 1; iSide <= 2; iSide++) {
+    const std::string ecapbasedisk1 =
+        topFolder_ + "/EndCap_Side" + std::to_string(iSide) + "/" + ecapdisk1Name_ + "/Ring";
+    const std::string ecapbasedisk2 =
+        topFolder_ + "/EndCap_Side" + std::to_string(iSide) + "/" + ecapdisk2Name_ + "/Ring";
     //EPix or TEDD_1
-    for(unsigned int epixr = 1; epixr<=ndisk1Rings_; epixr++) {
-      std::string iFolder=ecapbasedisk1 + std::to_string(epixr);
+    for (unsigned int epixr = 1; epixr <= ndisk1Rings_; epixr++) {
+      std::string iFolder = ecapbasedisk1 + std::to_string(epixr);
       dofitsForLayer(iFolder, ibooker, igetter);
     }
     //FPix or TEDD_2
-    for(unsigned int fpixr = 1; fpixr<=ndisk2Rings_; fpixr++) {
-      std::string iFolder= ecapbasedisk2 + std::to_string(fpixr);
+    for (unsigned int fpixr = 1; fpixr <= ndisk2Rings_; fpixr++) {
+      std::string iFolder = ecapbasedisk2 + std::to_string(fpixr);
       dofitsForLayer(iFolder, ibooker, igetter);
     }
   }
-  
 }
 //Function for Layer/Ring
-void Phase2ITRecHitHarvester::dofitsForLayer(const std::string& iFolder, DQMStore::IBooker &ibooker, DQMStore::IGetter &igetter) {
-    
-    MonitorElement* deltaX_eta=igetter.get(iFolder+"/"+ deltaXvsEtaname_);
-    MonitorElement* deltaX_phi=igetter.get(iFolder+"/"+ deltaXvsPhiname_);
-    MonitorElement* deltaY_eta=igetter.get(iFolder+"/" + deltaYvsEtaname_);
-    MonitorElement* deltaY_phi=igetter.get(iFolder+"/" + deltaYvsPhiname_);
+void Phase2ITRecHitHarvester::dofitsForLayer(const std::string& iFolder,
+                                             DQMStore::IBooker& ibooker,
+                                             DQMStore::IGetter& igetter) {
+  MonitorElement* deltaX_eta = igetter.get(iFolder + "/" + deltaXvsEtaname_);
+  MonitorElement* deltaX_phi = igetter.get(iFolder + "/" + deltaXvsPhiname_);
+  MonitorElement* deltaY_eta = igetter.get(iFolder + "/" + deltaYvsEtaname_);
+  MonitorElement* deltaY_phi = igetter.get(iFolder + "/" + deltaYvsPhiname_);
 
-    std::string resFolder=iFolder+"/ResolutionFromFit/";
+  std::string resFolder = iFolder + "/ResolutionFromFit/";
 
-    ibooker.cd();
-    ibooker.setCurrentFolder(resFolder);
-    MonitorElement* sigmaX_eta=phase2tkharvestutil::book1DFromPSet(config_.getParameter<edm::ParameterSet>("resXvseta"), ibooker);
-    MonitorElement* meanX_eta=phase2tkharvestutil::book1DFromPSet(config_.getParameter<edm::ParameterSet>("meanXvseta"), ibooker);
+  ibooker.cd();
+  ibooker.setCurrentFolder(resFolder);
+  MonitorElement* sigmaX_eta =
+      phase2tkharvestutil::book1DFromPSet(config_.getParameter<edm::ParameterSet>("resXvseta"), ibooker);
+  MonitorElement* meanX_eta =
+      phase2tkharvestutil::book1DFromPSet(config_.getParameter<edm::ParameterSet>("meanXvseta"), ibooker);
 
-    gausFitslices(deltaX_eta, meanX_eta, sigmaX_eta);
+  gausFitslices(deltaX_eta, meanX_eta, sigmaX_eta);
 
-    MonitorElement* sigmaY_eta=phase2tkharvestutil::book1DFromPSet(config_.getParameter<edm::ParameterSet>("resYvseta"), ibooker);
-    MonitorElement* meanY_eta=phase2tkharvestutil::book1DFromPSet(config_.getParameter<edm::ParameterSet>("meanYvseta"), ibooker);
-    gausFitslices(deltaY_eta, meanY_eta, sigmaY_eta);
+  MonitorElement* sigmaY_eta =
+      phase2tkharvestutil::book1DFromPSet(config_.getParameter<edm::ParameterSet>("resYvseta"), ibooker);
+  MonitorElement* meanY_eta =
+      phase2tkharvestutil::book1DFromPSet(config_.getParameter<edm::ParameterSet>("meanYvseta"), ibooker);
+  gausFitslices(deltaY_eta, meanY_eta, sigmaY_eta);
 
-    MonitorElement* sigmaX_phi=phase2tkharvestutil::book1DFromPSet(config_.getParameter<edm::ParameterSet>("resXvsphi"), ibooker);
-    MonitorElement* meanX_phi=phase2tkharvestutil::book1DFromPSet(config_.getParameter<edm::ParameterSet>("meanXvsphi"), ibooker);
-    gausFitslices(deltaX_phi, meanX_phi, sigmaX_phi);
+  MonitorElement* sigmaX_phi =
+      phase2tkharvestutil::book1DFromPSet(config_.getParameter<edm::ParameterSet>("resXvsphi"), ibooker);
+  MonitorElement* meanX_phi =
+      phase2tkharvestutil::book1DFromPSet(config_.getParameter<edm::ParameterSet>("meanXvsphi"), ibooker);
+  gausFitslices(deltaX_phi, meanX_phi, sigmaX_phi);
 
-    MonitorElement* sigmaY_phi=phase2tkharvestutil::book1DFromPSet(config_.getParameter<edm::ParameterSet>("resYvsphi"), ibooker);
-    MonitorElement* meanY_phi=phase2tkharvestutil::book1DFromPSet(config_.getParameter<edm::ParameterSet>("meanYvsphi"), ibooker);
-    gausFitslices(deltaY_phi, meanY_phi, sigmaY_phi);
+  MonitorElement* sigmaY_phi =
+      phase2tkharvestutil::book1DFromPSet(config_.getParameter<edm::ParameterSet>("resYvsphi"), ibooker);
+  MonitorElement* meanY_phi =
+      phase2tkharvestutil::book1DFromPSet(config_.getParameter<edm::ParameterSet>("meanYvsphi"), ibooker);
+  gausFitslices(deltaY_phi, meanY_phi, sigmaY_phi);
 }
 void Phase2ITRecHitHarvester::gausFitslices(MonitorElement* srcME, MonitorElement* meanME, MonitorElement* sigmaME) {
   TH2F* histo = srcME->getTH2F();
@@ -231,10 +238,8 @@ void Phase2ITRecHitHarvester::fillDescriptions(edm::ConfigurationDescriptions& d
   psd7.add<bool>("switch", true);
   desc.add<edm::ParameterSetDescription>("meanYvsphi", psd7);
 
-
-
   desc.add<unsigned int>("NFitThreshold", 5);
-  
+
   descriptions.add("Phase2ITRechitHarvester", desc);
   // or use the following to generate the label from the module's C++ type
   //descriptions.addWithDefaultLabel(desc);

--- a/Validation/SiTrackerPhase2V/plugins/Phase2ITValidateCluster.cc
+++ b/Validation/SiTrackerPhase2V/plugins/Phase2ITValidateCluster.cc
@@ -197,7 +197,7 @@ void Phase2ITValidateCluster::fillITHistos(const edm::Event& iEvent,
             if (it != clusterSimTrackIds.end() && *it == simhitIt.trackId()) {
               float dx = simhitIt.localPosition().x() - localPosCluster.x();
               float dy = simhitIt.localPosition().y() - localPosCluster.y();
-              float dist = dx*dx + dy*dy;
+              float dist = dx * dx + dy * dy;
               if (!closestSimHit || dist < mind) {
                 mind = dist;
                 closestSimHit = &simhitIt;

--- a/Validation/SiTrackerPhase2V/plugins/Phase2ITValidateCluster.cc
+++ b/Validation/SiTrackerPhase2V/plugins/Phase2ITValidateCluster.cc
@@ -197,7 +197,7 @@ void Phase2ITValidateCluster::fillITHistos(const edm::Event& iEvent,
             if (it != clusterSimTrackIds.end() && *it == simhitIt.trackId()) {
               float dx = simhitIt.localPosition().x() - localPosCluster.x();
               float dy = simhitIt.localPosition().y() - localPosCluster.y();
-              float dist = std::sqrt(dx * dx + dy * dy);
+              float dist = dx*dx + dy*dy;
               if (!closestSimHit || dist < mind) {
                 mind = dist;
                 closestSimHit = &simhitIt;

--- a/Validation/SiTrackerPhase2V/plugins/Phase2ITValidateRecHit.cc
+++ b/Validation/SiTrackerPhase2V/plugins/Phase2ITValidateRecHit.cc
@@ -142,7 +142,7 @@ void Phase2ITValidateRecHit::fillITHistos(const edm::Event& iEvent,
             if (simhitIt.trackId() == mId.first) {
               float dx = simhitIt.localPosition().x() - lp.x();
               float dy = simhitIt.localPosition().y() - lp.y();
-              float dist = std::sqrt(dx * dx + dy * dy);
+              float dist = dx*dx + dy*dy;
               if (!simhitClosest || dist < mind) {
                 mind = dist;
                 simhitClosest = &simhitIt;

--- a/Validation/SiTrackerPhase2V/plugins/Phase2ITValidateRecHit.cc
+++ b/Validation/SiTrackerPhase2V/plugins/Phase2ITValidateRecHit.cc
@@ -142,7 +142,7 @@ void Phase2ITValidateRecHit::fillITHistos(const edm::Event& iEvent,
             if (simhitIt.trackId() == mId.first) {
               float dx = simhitIt.localPosition().x() - lp.x();
               float dy = simhitIt.localPosition().y() - lp.y();
-              float dist = dx*dx + dy*dy;
+              float dist = dx * dx + dy * dy;
               if (!simhitClosest || dist < mind) {
                 mind = dist;
                 simhitClosest = &simhitIt;

--- a/Validation/SiTrackerPhase2V/plugins/Phase2ITValidateRecHit.cc
+++ b/Validation/SiTrackerPhase2V/plugins/Phase2ITValidateRecHit.cc
@@ -132,7 +132,7 @@ void Phase2ITValidateRecHit::fillITHistos(const edm::Event& iEvent,
       //GetSimHits
       const std::vector<SimHitIdpr>& matchedId = associateRecHit.associateHitId(rechit);
       const PSimHit* simhitClosest = nullptr;
-      float minx = 10000;
+      float mind = 1e4;
       LocalPoint lp = rechit.localPosition();
       for (const auto& simHitCol : simHits) {
         for (const auto& simhitIt : *simHitCol) {
@@ -140,8 +140,11 @@ void Phase2ITValidateRecHit::fillITHistos(const edm::Event& iEvent,
             continue;
           for (const auto& mId : matchedId) {
             if (simhitIt.trackId() == mId.first) {
-              if (!simhitClosest || abs(simhitIt.localPosition().x() - lp.x()) < minx) {
-                minx = abs(simhitIt.localPosition().x() - lp.x());
+              float dx = simhitIt.localPosition().x() - lp.x();
+              float dy = simhitIt.localPosition().y() - lp.y();
+              float dist = std::sqrt(dx * dx + dy * dy);
+              if (!simhitClosest || dist < mind) {
+                mind = dist;
                 simhitClosest = &simhitIt;
               }
             }

--- a/Validation/SiTrackerPhase2V/plugins/Phase2ITValidateRecHit.cc
+++ b/Validation/SiTrackerPhase2V/plugins/Phase2ITValidateRecHit.cc
@@ -132,7 +132,7 @@ void Phase2ITValidateRecHit::fillITHistos(const edm::Event& iEvent,
       //GetSimHits
       const std::vector<SimHitIdpr>& matchedId = associateRecHit.associateHitId(rechit);
       const PSimHit* simhitClosest = nullptr;
-      float mind = 1e4;
+      float minx = 10000;
       LocalPoint lp = rechit.localPosition();
       for (const auto& simHitCol : simHits) {
         for (const auto& simhitIt : *simHitCol) {
@@ -140,11 +140,8 @@ void Phase2ITValidateRecHit::fillITHistos(const edm::Event& iEvent,
             continue;
           for (const auto& mId : matchedId) {
             if (simhitIt.trackId() == mId.first) {
-              float dx = simhitIt.localPosition().x() - lp.x();
-              float dy = simhitIt.localPosition().y() - lp.y();
-              float dist = dx * dx + dy * dy;
-              if (!simhitClosest || dist < mind) {
-                mind = dist;
+              if (!simhitClosest || abs(simhitIt.localPosition().x() - lp.x()) < minx) {
+                minx = std::abs(simhitIt.localPosition().x() - lp.x());
                 simhitClosest = &simhitIt;
               }
             }

--- a/Validation/SiTrackerPhase2V/plugins/Phase2ITValidateTrackingRecHit.cc
+++ b/Validation/SiTrackerPhase2V/plugins/Phase2ITValidateTrackingRecHit.cc
@@ -157,7 +157,7 @@ void Phase2ITValidateTrackingRecHit::fillITHistos(const edm::Event& iEvent,
             if (simhitIt.trackId() == mId.first) {
               float dx = simhitIt.localPosition().x() - lp.x();
               float dy = simhitIt.localPosition().y() - lp.y();
-              float dist = dx*dx + dy*dy;
+              float dist = dx * dx + dy * dy;
               if (!simhitClosest || dist < mind) {
                 mind = dist;
                 simhitClosest = &simhitIt;

--- a/Validation/SiTrackerPhase2V/plugins/Phase2ITValidateTrackingRecHit.cc
+++ b/Validation/SiTrackerPhase2V/plugins/Phase2ITValidateTrackingRecHit.cc
@@ -147,7 +147,7 @@ void Phase2ITValidateTrackingRecHit::fillITHistos(const edm::Event& iEvent,
 
       const std::vector<SimHitIdpr>& matchedId = associateRecHit.associateHitId(*rechit);
       const PSimHit* simhitClosest = nullptr;
-      float minx = 10000;
+      float mind = 1e4;
       LocalPoint lp = rechit->localPosition();
       for (const auto& simHitCol : simHits) {
         for (const auto& simhitIt : *simHitCol) {
@@ -155,8 +155,11 @@ void Phase2ITValidateTrackingRecHit::fillITHistos(const edm::Event& iEvent,
             continue;
           for (const auto& mId : matchedId) {
             if (simhitIt.trackId() == mId.first) {
-              if (!simhitClosest || abs(simhitIt.localPosition().x() - lp.x()) < minx) {
-                minx = abs(simhitIt.localPosition().x() - lp.x());
+              float dx = simhitIt.localPosition().x() - lp.x();
+              float dy = simhitIt.localPosition().y() - lp.y();
+              float dist = std::sqrt(dx * dx + dy * dy);
+              if (!simhitClosest || dist < mind) {
+                mind = dist;
                 simhitClosest = &simhitIt;
               }
             }

--- a/Validation/SiTrackerPhase2V/plugins/Phase2ITValidateTrackingRecHit.cc
+++ b/Validation/SiTrackerPhase2V/plugins/Phase2ITValidateTrackingRecHit.cc
@@ -147,7 +147,7 @@ void Phase2ITValidateTrackingRecHit::fillITHistos(const edm::Event& iEvent,
 
       const std::vector<SimHitIdpr>& matchedId = associateRecHit.associateHitId(*rechit);
       const PSimHit* simhitClosest = nullptr;
-      float mind = 1e4;
+      float minx = 10000;
       LocalPoint lp = rechit->localPosition();
       for (const auto& simHitCol : simHits) {
         for (const auto& simhitIt : *simHitCol) {
@@ -155,11 +155,8 @@ void Phase2ITValidateTrackingRecHit::fillITHistos(const edm::Event& iEvent,
             continue;
           for (const auto& mId : matchedId) {
             if (simhitIt.trackId() == mId.first) {
-              float dx = simhitIt.localPosition().x() - lp.x();
-              float dy = simhitIt.localPosition().y() - lp.y();
-              float dist = dx * dx + dy * dy;
-              if (!simhitClosest || dist < mind) {
-                mind = dist;
+              if (!simhitClosest || std::abs(simhitIt.localPosition().x() - lp.x()) < minx) {
+                minx = std::abs(simhitIt.localPosition().x() - lp.x());
                 simhitClosest = &simhitIt;
               }
             }

--- a/Validation/SiTrackerPhase2V/plugins/Phase2ITValidateTrackingRecHit.cc
+++ b/Validation/SiTrackerPhase2V/plugins/Phase2ITValidateTrackingRecHit.cc
@@ -157,7 +157,7 @@ void Phase2ITValidateTrackingRecHit::fillITHistos(const edm::Event& iEvent,
             if (simhitIt.trackId() == mId.first) {
               float dx = simhitIt.localPosition().x() - lp.x();
               float dy = simhitIt.localPosition().y() - lp.y();
-              float dist = std::sqrt(dx * dx + dy * dy);
+              float dist = dx*dx + dy*dy;
               if (!simhitClosest || dist < mind) {
                 mind = dist;
                 simhitClosest = &simhitIt;

--- a/Validation/SiTrackerPhase2V/plugins/Phase2OTValidateCluster.cc
+++ b/Validation/SiTrackerPhase2V/plugins/Phase2OTValidateCluster.cc
@@ -204,7 +204,7 @@ void Phase2OTValidateCluster::fillOTHistos(const edm::Event& iEvent,
             if (it != clusterSimTrackIds.end() && *it == simhitIt.trackId()) {
               float dx = simhitIt.localPosition().x() - localPosCluster.x();
               float dy = simhitIt.localPosition().y() - localPosCluster.y();
-              float dist = dx*dx + dy*dy;
+              float dist = dx * dx + dy * dy;
               if (!closestSimHit || dist < mind) {
                 mind = dist;
                 closestSimHit = &simhitIt;

--- a/Validation/SiTrackerPhase2V/plugins/Phase2OTValidateCluster.cc
+++ b/Validation/SiTrackerPhase2V/plugins/Phase2OTValidateCluster.cc
@@ -204,7 +204,7 @@ void Phase2OTValidateCluster::fillOTHistos(const edm::Event& iEvent,
             if (it != clusterSimTrackIds.end() && *it == simhitIt.trackId()) {
               float dx = simhitIt.localPosition().x() - localPosCluster.x();
               float dy = simhitIt.localPosition().y() - localPosCluster.y();
-              float dist = std::sqrt(dx * dx + dy * dy);
+              float dist = dx*dx + dy*dy;
               if (!closestSimHit || dist < mind) {
                 mind = dist;
                 closestSimHit = &simhitIt;

--- a/Validation/SiTrackerPhase2V/plugins/Phase2OTValidateRecHit.cc
+++ b/Validation/SiTrackerPhase2V/plugins/Phase2OTValidateRecHit.cc
@@ -203,8 +203,6 @@ void Phase2OTValidateRecHit::fillDescriptions(edm::ConfigurationDescriptions& de
   desc.add<bool>("associateRecoTracks", false);
   desc.add<edm::InputTag>("pixelSimLinkSrc", edm::InputTag("simSiPixelDigis", "Pixel"));
   desc.add<bool>("usePhase2Tracker", true);
-  desc.add<edm::InputTag>("OuterTrackerDigiSimLinkSource", edm::InputTag("simSiPixelDigis", "Tracker"));
-  desc.add<edm::InputTag>("OuterTrackerDigiSource", edm::InputTag("mix", "Tracker"));
   desc.add<edm::InputTag>("rechitsSrc", edm::InputTag("siPhase2RecHits"));
   desc.add<edm::InputTag>("simTracksSrc", edm::InputTag("g4SimHits"));
   desc.add<double>("SimTrackMinPt", 2.0);

--- a/Validation/SiTrackerPhase2V/plugins/Phase2OTValidateRecHit.cc
+++ b/Validation/SiTrackerPhase2V/plugins/Phase2OTValidateRecHit.cc
@@ -159,7 +159,7 @@ void Phase2OTValidateRecHit::fillOTHistos(const edm::Event& iEvent,
             if (simhitIt.trackId() == mId.first) {
               float dx = simhitIt.localPosition().x() - lp.x();
               float dy = simhitIt.localPosition().y() - lp.y();
-              float dist = std::sqrt(dx * dx + dy * dy);
+              float dist = dx*dx + dy*dy;
               if (!simhitClosest || dist < mind) {
                 mind = dist;
                 simhitClosest = &simhitIt;

--- a/Validation/SiTrackerPhase2V/plugins/Phase2OTValidateRecHit.cc
+++ b/Validation/SiTrackerPhase2V/plugins/Phase2OTValidateRecHit.cc
@@ -159,7 +159,7 @@ void Phase2OTValidateRecHit::fillOTHistos(const edm::Event& iEvent,
             if (simhitIt.trackId() == mId.first) {
               float dx = simhitIt.localPosition().x() - lp.x();
               float dy = simhitIt.localPosition().y() - lp.y();
-              float dist = dx*dx + dy*dy;
+              float dist = dx * dx + dy * dy;
               if (!simhitClosest || dist < mind) {
                 mind = dist;
                 simhitClosest = &simhitIt;

--- a/Validation/SiTrackerPhase2V/plugins/Phase2OTValidateTrackingRecHit.cc
+++ b/Validation/SiTrackerPhase2V/plugins/Phase2OTValidateTrackingRecHit.cc
@@ -174,7 +174,7 @@ void Phase2OTValidateTrackingRecHit::fillOTHistos(const edm::Event& iEvent,
             if (simhitIt.trackId() == mId.first) {
               float dx = simhitIt.localPosition().x() - lp.x();
               float dy = simhitIt.localPosition().y() - lp.y();
-              float dist = std::sqrt(dx * dx + dy * dy);
+              float dist = dx*dx + dy*dy;
               if (!simhitClosest || dist < mind) {
                 mind = dist;
                 simhitClosest = &simhitIt;

--- a/Validation/SiTrackerPhase2V/plugins/Phase2OTValidateTrackingRecHit.cc
+++ b/Validation/SiTrackerPhase2V/plugins/Phase2OTValidateTrackingRecHit.cc
@@ -213,7 +213,6 @@ void Phase2OTValidateTrackingRecHit::fillDescriptions(edm::ConfigurationDescript
   desc.add<bool>("associateRecoTracks", false);
   desc.add<edm::InputTag>("pixelSimLinkSrc", edm::InputTag("simSiPixelDigis", "Pixel"));
   desc.add<bool>("usePhase2Tracker", true);
-  desc.add<edm::InputTag>("OuterTrackerDigiSource", edm::InputTag("mix", "Tracker"));
   desc.add<edm::InputTag>("rechitsSrc", edm::InputTag("siPhase2RecHits"));
   desc.add<edm::InputTag>("simTracksSrc", edm::InputTag("g4SimHits"));
   desc.add<double>("SimTrackMinPt", 2.0);

--- a/Validation/SiTrackerPhase2V/plugins/Phase2OTValidateTrackingRecHit.cc
+++ b/Validation/SiTrackerPhase2V/plugins/Phase2OTValidateTrackingRecHit.cc
@@ -213,7 +213,6 @@ void Phase2OTValidateTrackingRecHit::fillDescriptions(edm::ConfigurationDescript
   desc.add<bool>("associateRecoTracks", false);
   desc.add<edm::InputTag>("pixelSimLinkSrc", edm::InputTag("simSiPixelDigis", "Pixel"));
   desc.add<bool>("usePhase2Tracker", true);
-  desc.add<edm::InputTag>("OuterTrackerDigiSimLinkSource", edm::InputTag("simSiPixelDigis", "Tracker"));
   desc.add<edm::InputTag>("OuterTrackerDigiSource", edm::InputTag("mix", "Tracker"));
   desc.add<edm::InputTag>("rechitsSrc", edm::InputTag("siPhase2RecHits"));
   desc.add<edm::InputTag>("simTracksSrc", edm::InputTag("g4SimHits"));

--- a/Validation/SiTrackerPhase2V/plugins/Phase2OTValidateTrackingRecHit.cc
+++ b/Validation/SiTrackerPhase2V/plugins/Phase2OTValidateTrackingRecHit.cc
@@ -63,14 +63,12 @@ private:
                     const std::vector<edm::Handle<edm::PSimHitContainer>>& simHits,
                     const std::map<unsigned int, SimTrack>& selectedSimTrackMap);
 
-
   edm::ParameterSet config_;
   TrackerHitAssociator::Config trackerHitAssociatorConfig_;
   const double simtrackminpt_;
   const edm::EDGetTokenT<reco::TrackCollection> tokenTracks_;
   const edm::EDGetTokenT<edm::SimTrackContainer> simTracksToken_;
   std::vector<edm::EDGetTokenT<edm::PSimHitContainer>> simHitTokens_;
-
 };
 
 //
@@ -83,7 +81,6 @@ Phase2OTValidateTrackingRecHit::Phase2OTValidateTrackingRecHit(const edm::Parame
       simtrackminpt_(iConfig.getParameter<double>("SimTrackMinPt")),
       tokenTracks_(consumes<reco::TrackCollection>(iConfig.getParameter<edm::InputTag>("tracksSrc"))),
       simTracksToken_(consumes<edm::SimTrackContainer>(iConfig.getParameter<edm::InputTag>("simTracksSrc"))) {
- 
   edm::LogInfo("Phase2OTValidateTrackingRecHit") << ">>> Construct Phase2OTValidateTrackingRecHit ";
   for (const auto& itag : config_.getParameter<std::vector<edm::InputTag>>("PSimHitSource"))
     simHitTokens_.push_back(consumes<edm::PSimHitContainer>(itag));
@@ -123,10 +120,9 @@ void Phase2OTValidateTrackingRecHit::analyze(const edm::Event& iEvent, const edm
 }
 
 void Phase2OTValidateTrackingRecHit::fillOTHistos(const edm::Event& iEvent,
-                                          const TrackerHitAssociator& associateRecHit,
-                                          const std::vector<edm::Handle<edm::PSimHitContainer>>& simHits,
-                                          const std::map<unsigned int, SimTrack>& selectedSimTrackMap) {
-
+                                                  const TrackerHitAssociator& associateRecHit,
+                                                  const std::vector<edm::Handle<edm::PSimHitContainer>>& simHits,
+                                                  const std::map<unsigned int, SimTrack>& selectedSimTrackMap) {
   const auto& tracks = iEvent.getHandle(tokenTracks_);
   if (!tracks.isValid())
     return;
@@ -142,23 +138,23 @@ void Phase2OTValidateTrackingRecHit::fillOTHistos(const edm::Event& iEvent,
       // check that we are in the pixel
       auto subdetid = (detId.subdetId());
       if (subdetid == PixelSubdetector::PixelBarrel || subdetid == PixelSubdetector::PixelEndcap)
-	continue;
-      
+        continue;
+
       // determine the detector we are in
       TrackerGeometry::ModuleType mType = tkGeom_->getDetectorType(detId);
       std::string key = phase2tkutil::getOTHistoId(detId.rawId(), tTopo_);
       if (mType == TrackerGeometry::ModuleType::Ph2PSP) {
-	if (nrechitLayerMapP_primary.find(key) == nrechitLayerMapP_primary.end()) {
-	  nrechitLayerMapP_primary.emplace(key,1);
-	} else {
-	  nrechitLayerMapP_primary[key] += 1;
-	}
+        if (nrechitLayerMapP_primary.find(key) == nrechitLayerMapP_primary.end()) {
+          nrechitLayerMapP_primary.emplace(key, 1);
+        } else {
+          nrechitLayerMapP_primary[key] += 1;
+        }
       } else if (mType == TrackerGeometry::ModuleType::Ph2PSS || mType == TrackerGeometry::ModuleType::Ph2SS) {
-	if (nrechitLayerMapS_primary.find(key) == nrechitLayerMapS_primary.end()) {
-	  nrechitLayerMapS_primary.emplace(key,1);
-	} else {
-	  nrechitLayerMapS_primary[key] += 1;
-	}
+        if (nrechitLayerMapS_primary.find(key) == nrechitLayerMapS_primary.end()) {
+          nrechitLayerMapS_primary.emplace(key, 1);
+        } else {
+          nrechitLayerMapS_primary[key] += 1;
+        }
       }
       //GetSimHits
       const Phase2TrackerRecHit1D* rechit = dynamic_cast<const Phase2TrackerRecHit1D*>(hit);
@@ -174,7 +170,7 @@ void Phase2OTValidateTrackingRecHit::fillOTHistos(const edm::Event& iEvent,
             if (simhitIt.trackId() == mId.first) {
               float dx = simhitIt.localPosition().x() - lp.x();
               float dy = simhitIt.localPosition().y() - lp.y();
-              float dist = dx*dx + dy*dy;
+              float dist = dx * dx + dy * dy;
               if (!simhitClosest || dist < mind) {
                 mind = dist;
                 simhitClosest = &simhitIt;
@@ -185,8 +181,9 @@ void Phase2OTValidateTrackingRecHit::fillOTHistos(const edm::Event& iEvent,
       }    //end loop over simHits
       if (!simhitClosest)
         continue;
-      fillOTRecHitHistos(simhitClosest, rechit, selectedSimTrackMap, nrechitLayerMapP_primary, nrechitLayerMapS_primary);
-      
+      fillOTRecHitHistos(
+          simhitClosest, rechit, selectedSimTrackMap, nrechitLayerMapP_primary, nrechitLayerMapS_primary);
+
     }  //end loop over rechits of a track
   }    //End loop over tracks
 
@@ -204,7 +201,7 @@ void Phase2OTValidateTrackingRecHit::fillDescriptions(edm::ConfigurationDescript
   edm::ParameterSetDescription desc;
   // call the base fillPsetDescription for the plots bookings
   Phase2OTValidateRecHitBase::fillPSetDescription(desc);
-  
+
   //for macro-pixel sensors
   ///////
   desc.add<edm::InputTag>("SimVertexSource", edm::InputTag("g4SimHits"));

--- a/Validation/SiTrackerPhase2V/plugins/Phase2OTValidateTrackingRecHit.cc
+++ b/Validation/SiTrackerPhase2V/plugins/Phase2OTValidateTrackingRecHit.cc
@@ -1,7 +1,7 @@
-// Package:    Phase2OTValidateRecHit
-// Class:      Phase2OTValidateRecHit
+// Package:    Phase2OTValidateTrackingRecHit
+// Class:      Phase2OTValidateTrackingRecHit
 //
-/**\class Phase2OTValidateRecHit Phase2OTValidateRecHit.cc 
+/**\class Phase2OTValidateTrackingRecHit Phase2OTValidateTrackingRecHit.cc 
  Description:  Standalone  Plugin for Phase2 RecHit validation
 */
 //
@@ -34,7 +34,10 @@
 #include "DataFormats/DetId/interface/DetId.h"
 #include "DataFormats/Common/interface/DetSetVector.h"
 #include "DataFormats/Common/interface/DetSetVectorNew.h"
+#include "DataFormats/TrackReco/interface/Track.h"
+#include "DataFormats/TrackReco/interface/TrackFwd.h"
 #include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+
 #include "DataFormats/TrackerRecHit2D/interface/Phase2TrackerRecHit1D.h"
 #include "SimDataFormats/TrackingHit/interface/PSimHitContainer.h"
 #include "SimDataFormats/TrackingHit/interface/PSimHit.h"
@@ -46,10 +49,10 @@
 #include "Validation/SiTrackerPhase2V/interface/Phase2OTValidateRecHitBase.h"
 #include "DQM/SiTrackerPhase2/interface/TrackerPhase2DQMUtil.h"
 
-class Phase2OTValidateRecHit : public Phase2OTValidateRecHitBase {
+class Phase2OTValidateTrackingRecHit : public Phase2OTValidateRecHitBase {
 public:
-  explicit Phase2OTValidateRecHit(const edm::ParameterSet&);
-  ~Phase2OTValidateRecHit() override;
+  explicit Phase2OTValidateTrackingRecHit(const edm::ParameterSet&);
+  ~Phase2OTValidateTrackingRecHit() override;
   void analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) override;
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
@@ -60,23 +63,28 @@ private:
                     const std::vector<edm::Handle<edm::PSimHitContainer>>& simHits,
                     const std::map<unsigned int, SimTrack>& selectedSimTrackMap);
 
+
+  edm::ParameterSet config_;
   TrackerHitAssociator::Config trackerHitAssociatorConfig_;
   const double simtrackminpt_;
-  const edm::EDGetTokenT<Phase2TrackerRecHit1DCollectionNew> tokenRecHitsOT_;
+  const edm::EDGetTokenT<reco::TrackCollection> tokenTracks_;
   const edm::EDGetTokenT<edm::SimTrackContainer> simTracksToken_;
   std::vector<edm::EDGetTokenT<edm::PSimHitContainer>> simHitTokens_;
+
 };
 
 //
 // constructors
 //
-Phase2OTValidateRecHit::Phase2OTValidateRecHit(const edm::ParameterSet& iConfig)
+Phase2OTValidateTrackingRecHit::Phase2OTValidateTrackingRecHit(const edm::ParameterSet& iConfig)
     : Phase2OTValidateRecHitBase(iConfig),
+      config_(iConfig),
       trackerHitAssociatorConfig_(iConfig, consumesCollector()),
       simtrackminpt_(iConfig.getParameter<double>("SimTrackMinPt")),
-      tokenRecHitsOT_(consumes<Phase2TrackerRecHit1DCollectionNew>(iConfig.getParameter<edm::InputTag>("rechitsSrc"))),
+      tokenTracks_(consumes<reco::TrackCollection>(iConfig.getParameter<edm::InputTag>("tracksSrc"))),
       simTracksToken_(consumes<edm::SimTrackContainer>(iConfig.getParameter<edm::InputTag>("simTracksSrc"))) {
-  edm::LogInfo("Phase2OTValidateRecHit") << ">>> Construct Phase2OTValidateRecHit ";
+ 
+  edm::LogInfo("Phase2OTValidateTrackingRecHit") << ">>> Construct Phase2OTValidateTrackingRecHit ";
   for (const auto& itag : config_.getParameter<std::vector<edm::InputTag>>("PSimHitSource"))
     simHitTokens_.push_back(consumes<edm::PSimHitContainer>(itag));
 }
@@ -84,16 +92,16 @@ Phase2OTValidateRecHit::Phase2OTValidateRecHit(const edm::ParameterSet& iConfig)
 //
 // destructor
 //
-Phase2OTValidateRecHit::~Phase2OTValidateRecHit() {
+Phase2OTValidateTrackingRecHit::~Phase2OTValidateTrackingRecHit() {
   // do anything here that needs to be done at desctruction time
   // (e.g. close files, deallocate resources etc.)
-  edm::LogInfo("Phase2OTValidateRecHit") << ">>> Destroy Phase2OTValidateRecHit ";
+  edm::LogInfo("Phase2OTValidateTrackingRecHit") << ">>> Destroy Phase2OTValidateTrackingRecHit ";
 }
 
 //
 // -- Analyze
 //
-void Phase2OTValidateRecHit::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
+void Phase2OTValidateTrackingRecHit::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
   std::vector<edm::Handle<edm::PSimHitContainer>> simHits;
   for (const auto& itoken : simHitTokens_) {
     const auto& simHitHandle = iEvent.getHandle(itoken);
@@ -104,52 +112,59 @@ void Phase2OTValidateRecHit::analyze(const edm::Event& iEvent, const edm::EventS
   // Get the SimTracks and push them in a map of id, SimTrack
   const auto& simTracks = iEvent.getHandle(simTracksToken_);
   std::map<unsigned int, SimTrack> selectedSimTrackMap;
-  for (const auto& simTrackIt : *simTracks)
-    if (simTrackIt.momentum().pt() > simtrackminpt_) {
-      selectedSimTrackMap.insert(std::make_pair(simTrackIt.trackId(), simTrackIt));
+  for (edm::SimTrackContainer::const_iterator simTrackIt(simTracks->begin()); simTrackIt != simTracks->end();
+       ++simTrackIt) {
+    if (simTrackIt->momentum().pt() > simtrackminpt_) {
+      selectedSimTrackMap.insert(std::make_pair(simTrackIt->trackId(), *simTrackIt));
     }
+  }
   TrackerHitAssociator associateRecHit(iEvent, trackerHitAssociatorConfig_);
   fillOTHistos(iEvent, associateRecHit, simHits, selectedSimTrackMap);
 }
 
-void Phase2OTValidateRecHit::fillOTHistos(const edm::Event& iEvent,
+void Phase2OTValidateTrackingRecHit::fillOTHistos(const edm::Event& iEvent,
                                           const TrackerHitAssociator& associateRecHit,
                                           const std::vector<edm::Handle<edm::PSimHitContainer>>& simHits,
                                           const std::map<unsigned int, SimTrack>& selectedSimTrackMap) {
-  // Get the RecHits
-  const auto& rechits = iEvent.getHandle(tokenRecHitsOT_);
-  if (!rechits.isValid())
+
+  const auto& tracks = iEvent.getHandle(tokenTracks_);
+  if (!tracks.isValid())
     return;
   std::map<std::string, unsigned int> nrechitLayerMapP_primary;
   std::map<std::string, unsigned int> nrechitLayerMapS_primary;
-  // Loop over modules
-  Phase2TrackerRecHit1DCollectionNew::const_iterator DSViter;
-  for (const auto& DSViter : *rechits) {
-    // Get the detector unit's id
-    unsigned int rawid(DSViter.detId());
-    DetId detId(rawid);
-    // determine the detector we are in
-    TrackerGeometry::ModuleType mType = tkGeom_->getDetectorType(detId);
-    std::string key = phase2tkutil::getOTHistoId(detId.rawId(), tTopo_);
-    if (mType == TrackerGeometry::ModuleType::Ph2PSP) {
-      if (nrechitLayerMapP_primary.find(key) == nrechitLayerMapP_primary.end()) {
-        nrechitLayerMapP_primary.insert(std::make_pair(key, DSViter.size()));
-      } else {
-        nrechitLayerMapP_primary[key] += DSViter.size();
+  // Loop over tracks
+  for (const auto& track : *tracks) {
+    for (const auto& hit : track.recHits()) {
+      // Get the detector unit's id
+      if (!hit->isValid())
+        continue;
+      auto detId = hit->geographicalId();
+      // check that we are in the pixel
+      auto subdetid = (detId.subdetId());
+      if (subdetid == PixelSubdetector::PixelBarrel || subdetid == PixelSubdetector::PixelEndcap)
+	continue;
+      
+      // determine the detector we are in
+      TrackerGeometry::ModuleType mType = tkGeom_->getDetectorType(detId);
+      std::string key = phase2tkutil::getOTHistoId(detId.rawId(), tTopo_);
+      if (mType == TrackerGeometry::ModuleType::Ph2PSP) {
+	if (nrechitLayerMapP_primary.find(key) == nrechitLayerMapP_primary.end()) {
+	  nrechitLayerMapP_primary.emplace(key,1);
+	} else {
+	  nrechitLayerMapP_primary[key] += 1;
+	}
+      } else if (mType == TrackerGeometry::ModuleType::Ph2PSS || mType == TrackerGeometry::ModuleType::Ph2SS) {
+	if (nrechitLayerMapS_primary.find(key) == nrechitLayerMapS_primary.end()) {
+	  nrechitLayerMapS_primary.emplace(key,1);
+	} else {
+	  nrechitLayerMapS_primary[key] += 1;
+	}
       }
-    } else if (mType == TrackerGeometry::ModuleType::Ph2PSS || mType == TrackerGeometry::ModuleType::Ph2SS) {
-      if (nrechitLayerMapS_primary.find(key) == nrechitLayerMapS_primary.end()) {
-        nrechitLayerMapS_primary.insert(std::make_pair(key, DSViter.size()));
-      } else {
-        nrechitLayerMapS_primary[key] += DSViter.size();
-      }
-    }
-    //loop over rechits for a single detId
-    for (const auto& rechit : DSViter) {
       //GetSimHits
-      const std::vector<SimHitIdpr>& matchedId = associateRecHit.associateHitId(rechit);
+      const Phase2TrackerRecHit1D* rechit = dynamic_cast<const Phase2TrackerRecHit1D*>(hit);
+      const std::vector<SimHitIdpr>& matchedId = associateRecHit.associateHitId(*rechit);
       const PSimHit* simhitClosest = nullptr;
-      LocalPoint lp = rechit.localPosition();
+      LocalPoint lp = rechit->localPosition();
       float mind = 1e4;
       for (const auto& simHitCol : simHits) {
         for (const auto& simhitIt : *simHitCol) {
@@ -170,11 +185,10 @@ void Phase2OTValidateRecHit::fillOTHistos(const edm::Event& iEvent,
       }    //end loop over simHits
       if (!simhitClosest)
         continue;
-      fillOTRecHitHistos(
-          simhitClosest, &rechit, selectedSimTrackMap, nrechitLayerMapP_primary, nrechitLayerMapS_primary);
-
-    }  //end loop over rechits of a detId
-  }    //End loop over DetSetVector
+      fillOTRecHitHistos(simhitClosest, rechit, selectedSimTrackMap, nrechitLayerMapP_primary, nrechitLayerMapS_primary);
+      
+    }  //end loop over rechits of a track
+  }    //End loop over tracks
 
   //fill nRecHits per event
   //fill nRecHit counter per layer
@@ -186,16 +200,15 @@ void Phase2OTValidateRecHit::fillOTHistos(const edm::Event& iEvent,
   }
 }
 
-void Phase2OTValidateRecHit::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+void Phase2OTValidateTrackingRecHit::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
   // call the base fillPsetDescription for the plots bookings
   Phase2OTValidateRecHitBase::fillPSetDescription(desc);
-
+  
   //for macro-pixel sensors
   ///////
   desc.add<edm::InputTag>("SimVertexSource", edm::InputTag("g4SimHits"));
   desc.add<bool>("associatePixel", false);
-  desc.add<std::string>("TopFolderName", "TrackerPhase2OTRecHitV");
   desc.add<bool>("associateHitbySimTrack", true);
   desc.add<bool>("Verbosity", false);
   desc.add<bool>("associateStrip", true);
@@ -237,9 +250,10 @@ void Phase2OTValidateRecHit::fillDescriptions(edm::ConfigurationDescriptions& de
                                       "TrackerHitsPixelEndcapHighTof",
                                       "TrackerHitsTECLowTof",
                                       "TrackerHitsTECHighTof"});
-
-  descriptions.add("Phase2OTValidateRecHit", desc);
+  desc.add<edm::InputTag>("tracksSrc", edm::InputTag("generalTracks"));
+  desc.add<std::string>("TopFolderName", "TrackerPhase2OTTrackingRecHitV");
+  descriptions.add("Phase2OTValidateTrackingRecHit", desc);
 }
 
 //define this as a plug-in
-DEFINE_FWK_MODULE(Phase2OTValidateRecHit);
+DEFINE_FWK_MODULE(Phase2OTValidateTrackingRecHit);

--- a/Validation/SiTrackerPhase2V/python/Phase2OTValidateTrackingRecHit_cff.py
+++ b/Validation/SiTrackerPhase2V/python/Phase2OTValidateTrackingRecHit_cff.py
@@ -6,5 +6,5 @@ trackingRechitValidOT = Phase2OTValidateTrackingRecHit.clone()
 
 from Configuration.ProcessModifiers.premix_stage2_cff import premix_stage2
 premix_stage2.toModify(trackingRechitValidOT,
-    pixelSimLinkSrc = "mixData:PixelDigiSimLink",
+    phase2TrackerSimLinkSrc = "mixData:Phase2OTDigiSimLink",
 )

--- a/Validation/SiTrackerPhase2V/python/Phase2OTValidateTrackingRecHit_cff.py
+++ b/Validation/SiTrackerPhase2V/python/Phase2OTValidateTrackingRecHit_cff.py
@@ -1,0 +1,10 @@
+import FWCore.ParameterSet.Config as cms
+
+from Validation.SiTrackerPhase2V.Phase2OTValidateTrackingRecHit_cfi import * 
+
+trackingRechitValidOT = Phase2OTValidateTrackingRecHit.clone()
+
+from Configuration.ProcessModifiers.premix_stage2_cff import premix_stage2
+premix_stage2.toModify(trackingRechitValidOT,
+    pixelSimLinkSrc = "mixData:PixelDigiSimLink",
+)

--- a/Validation/SiTrackerPhase2V/python/Phase2TrackerMCHarvesting_cff.py
+++ b/Validation/SiTrackerPhase2V/python/Phase2TrackerMCHarvesting_cff.py
@@ -24,6 +24,14 @@ Phase2OTRechitHarvester_PS=Phase2ITRechitHarvester.clone(
     ResidualYvsEta = cms.string('Delta_Y_vs_Eta_Pixel'),
     ResidualYvsPhi = cms.string('Delta_Y_vs_Phi_Pixel'),
 )
+Phase2OTRechitHarvester_PS.resXvseta.name = cms.string('resolutionXFitvseta_Pixel')
+Phase2OTRechitHarvester_PS.resYvseta.name = cms.string('resolutionYFitvseta_Pixel')
+Phase2OTRechitHarvester_PS.resXvsphi.name = cms.string('resolutionXFitvsphi_Pixel')
+Phase2OTRechitHarvester_PS.resYvsphi.name = cms.string('resolutionYFitvsphi_Pixel')
+Phase2OTRechitHarvester_PS.meanXvseta.name = cms.string('meanXFitvseta_Pixel')
+Phase2OTRechitHarvester_PS.meanYvseta.name = cms.string('meanYFitvseta_Pixel')
+Phase2OTRechitHarvester_PS.meanXvsphi.name = cms.string('meanXFitvsphi_Pixel')
+Phase2OTRechitHarvester_PS.meanYvsphi.name = cms.string('meanYFitvsphi_Pixel')
 
 Phase2OTRechitHarvester_2S=Phase2OTRechitHarvester_PS.clone(
     NbarrelLayers = cms.uint32(3),
@@ -35,6 +43,15 @@ Phase2OTRechitHarvester_2S=Phase2OTRechitHarvester_PS.clone(
     ResidualYvsPhi = cms.string('Delta_Y_vs_Phi_Strip'),
 
 )
+Phase2OTRechitHarvester_2S.resXvseta.name = cms.string('resolutionXFitvseta_Strip')
+Phase2OTRechitHarvester_2S.resYvseta.name = cms.string('resolutionYFitvseta_Strip')
+Phase2OTRechitHarvester_2S.resXvsphi.name = cms.string('resolutionXFitvsphi_Strip')
+Phase2OTRechitHarvester_2S.resYvsphi.name = cms.string('resolutionYFitvsphi_Strip')
+Phase2OTRechitHarvester_2S.meanXvseta.name = cms.string('meanXFitvseta_Strip')
+Phase2OTRechitHarvester_2S.meanYvseta.name = cms.string('meanYFitvseta_Strip')
+Phase2OTRechitHarvester_2S.meanXvsphi.name = cms.string('meanXFitvsphi_Strip')
+Phase2OTRechitHarvester_2S.meanYvsphi.name = cms.string('meanYFitvsphi_Strip')
+
 #OTTracking rechit
 Phase2OTTrackingRechitHarvester_PS=Phase2OTRechitHarvester_PS.clone(
     TopFolder = cms.string('TrackerPhase2OTTrackingRecHitV')
@@ -44,7 +61,11 @@ Phase2OTTrackingRechitHarvester_2S=Phase2OTRechitHarvester_2S.clone(
     TopFolder = cms.string('TrackerPhase2OTTrackingRecHitV')
 )
 
-trackerphase2ValidationHarvesting = cms.Sequence(Phase2ITRechitHarvester*Phase2ITtrackingrechitHarvester)
+trackerphase2ValidationHarvesting = cms.Sequence(Phase2ITRechitHarvester
+                                                 * Phase2ITtrackingrechitHarvester
+                                                 * Phase2OTTrackingRechitHarvester_PS
+                                                 * Phase2OTTrackingRechitHarvester_2S
+)
 
 trackerphase2ValidationHarvesting_standalone = cms.Sequence(Phase2ITRechitHarvester
                                                             * Phase2ITtrackingrechitHarvester

--- a/Validation/SiTrackerPhase2V/python/Phase2TrackerMCHarvesting_cff.py
+++ b/Validation/SiTrackerPhase2V/python/Phase2TrackerMCHarvesting_cff.py
@@ -2,4 +2,54 @@ import FWCore.ParameterSet.Config as cms
 
 from DQMServices.Core.DQMEDHarvester import DQMEDHarvester
 
-trackerphase2ValidationHarvesting = cms.Sequence()
+from Validation.SiTrackerPhase2V.Phase2ITRechitHarvester_cfi import *
+
+#ITTracking rechit
+#clone the rechit harvester for tracking rechit
+Phase2ITtrackingrechitHarvester=Phase2ITRechitHarvester.clone(
+    TopFolder = cms.string('TrackerPhase2ITTrackingRecHitV')
+)
+
+
+##As of now this is to be used in standalone mode
+Phase2OTRechitHarvester_PS=Phase2ITRechitHarvester.clone(
+    TopFolder = cms.string('TrackerPhase2OTRecHitV'),
+    NbarrelLayers = cms.uint32(3),
+    NDisk1Rings = cms.uint32(10),
+    NDisk2Rings = cms.uint32(7),
+    EcapDisk1Name = cms.string('TEDD_1'),
+    EcapDisk2Name = cms.string('TEDD_2'),
+    ResidualXvsEta = cms.string('Delta_X_vs_Eta_Pixel'),
+    ResidualXvsPhi = cms.string('Delta_X_vs_Phi_Pixel'),
+    ResidualYvsEta = cms.string('Delta_Y_vs_Eta_Pixel'),
+    ResidualYvsPhi = cms.string('Delta_Y_vs_Phi_Pixel'),
+)
+
+Phase2OTRechitHarvester_2S=Phase2OTRechitHarvester_PS.clone(
+    NbarrelLayers = cms.uint32(3),
+    NDisk1Rings = cms.uint32(15),
+    NDisk2Rings = cms.uint32(11),
+    ResidualXvsEta = cms.string('Delta_X_vs_Eta_Strip'),
+    ResidualXvsPhi = cms.string('Delta_X_vs_Phi_Strip'),
+    ResidualYvsEta = cms.string('Delta_Y_vs_Eta_Strip'),
+    ResidualYvsPhi = cms.string('Delta_Y_vs_Phi_Strip'),
+
+)
+#OTTracking rechit
+Phase2OTTrackingRechitHarvester_PS=Phase2OTRechitHarvester_PS.clone(
+    TopFolder = cms.string('TrackerPhase2OTTrackingRecHitV')
+)
+
+Phase2OTTrackingRechitHarvester_2S=Phase2OTRechitHarvester_2S.clone(
+    TopFolder = cms.string('TrackerPhase2OTTrackingRecHitV')
+)
+
+trackerphase2ValidationHarvesting = cms.Sequence(Phase2ITRechitHarvester*Phase2ITtrackingrechitHarvester)
+
+trackerphase2ValidationHarvesting_standalone = cms.Sequence(Phase2ITRechitHarvester
+                                                            * Phase2ITtrackingrechitHarvester
+                                                            * Phase2OTRechitHarvester_PS
+                                                            * Phase2OTRechitHarvester_2S
+                                                            * Phase2OTTrackingRechitHarvester_PS
+                                                            * Phase2OTTrackingRechitHarvester_2S
+)

--- a/Validation/SiTrackerPhase2V/python/Phase2TrackerValidationFirstStep_cff.py
+++ b/Validation/SiTrackerPhase2V/python/Phase2TrackerValidationFirstStep_cff.py
@@ -4,6 +4,7 @@ from Validation.SiTrackerPhase2V.Phase2ITValidateRecHit_cff import *
 from Validation.SiTrackerPhase2V.Phase2ITValidateTrackingRecHit_cff import *
 from Validation.SiTrackerPhase2V.Phase2ITValidateCluster_cff import *
 from Validation.SiTrackerPhase2V.Phase2OTValidateCluster_cff import *
+from Validation.SiTrackerPhase2V.Phase2OTValidateTrackingRecHit_cff import *
 
 trackerphase2ValidationSource = cms.Sequence(pixDigiValid  
                                              + otDigiValid 
@@ -11,4 +12,5 @@ trackerphase2ValidationSource = cms.Sequence(pixDigiValid
                                              + trackingRechitValidIT
                                              + clusterValidIT
                                              + clusterValidOT
+                                             + trackingRechitValidOT
 )

--- a/Validation/SiTrackerPhase2V/src/Phase2ITValidateRecHitBase.cc
+++ b/Validation/SiTrackerPhase2V/src/Phase2ITValidateRecHitBase.cc
@@ -215,7 +215,7 @@ void Phase2ITValidateRecHitBase::fillPSetDescription(edm::ParameterSetDescriptio
 
   edm::ParameterSetDescription psd4;
   psd4.add<std::string>("name", "Delta_X_vs_Eta");
-  psd4.add<std::string>("title", "Delta_X_vs_Eta;#eta;#Delta x [#mum]");
+  psd4.add<std::string>("title", "Delta_X_vs_Eta;|#eta|;#Delta x [#mum]");
   psd4.add<int>("NyBins", 100);
   psd4.add<double>("ymin", -100.0);
   psd4.add<double>("ymax", 100.0);
@@ -240,7 +240,7 @@ void Phase2ITValidateRecHitBase::fillPSetDescription(edm::ParameterSetDescriptio
 
   edm::ParameterSetDescription psd5;
   psd5.add<std::string>("name", "Delta_Y_vs_Eta");
-  psd5.add<std::string>("title", "Delta_Y_vs_Eta;#eta;#Delta y [#mum]");
+  psd5.add<std::string>("title", "Delta_Y_vs_Eta;|#eta|;#Delta y [#mum]");
   psd5.add<int>("NyBins", 100);
   psd5.add<double>("ymin", -100.0);
   psd5.add<double>("ymax", 100.0);

--- a/Validation/SiTrackerPhase2V/src/Phase2ITValidateRecHitBase.cc
+++ b/Validation/SiTrackerPhase2V/src/Phase2ITValidateRecHitBase.cc
@@ -153,10 +153,12 @@ void Phase2ITValidateRecHitBase::fillRechitHistos(const PSimHit* simhitClosest,
   layerMEs_[key].deltaY->Fill(dy);
   layerMEs_[key].pullX->Fill(pullx);
   layerMEs_[key].pullY->Fill(pully);
-  layerMEs_[key].deltaX_eta->Fill(eta, dx);
-  layerMEs_[key].deltaY_eta->Fill(eta, dy);
+
+  layerMEs_[key].deltaX_eta->Fill(std::abs(eta), dx);
+  layerMEs_[key].deltaY_eta->Fill(std::abs(eta), dy);
   layerMEs_[key].deltaX_phi->Fill(phi, dx);
   layerMEs_[key].deltaY_phi->Fill(phi, dy);
+
   layerMEs_[key].deltaX_clsizex->Fill(rechit->cluster()->sizeX(), dx);
   layerMEs_[key].deltaX_clsizey->Fill(rechit->cluster()->sizeY(), dx);
   layerMEs_[key].deltaY_clsizex->Fill(rechit->cluster()->sizeX(), dy);
@@ -217,10 +219,10 @@ void Phase2ITValidateRecHitBase::fillPSetDescription(edm::ParameterSetDescriptio
   psd4.add<int>("NyBins", 100);
   psd4.add<double>("ymin", -100.0);
   psd4.add<double>("ymax", 100.0);
-  psd4.add<int>("NxBins", 82);
+  psd4.add<int>("NxBins", 41);
   psd4.add<bool>("switch", true);
   psd4.add<double>("xmax", 4.1);
-  psd4.add<double>("xmin", -4.1);
+  psd4.add<double>("xmin", 0.);
   desc.add<edm::ParameterSetDescription>("DeltaX_eta", psd4);
 
   edm::ParameterSetDescription psd4_y;
@@ -242,10 +244,10 @@ void Phase2ITValidateRecHitBase::fillPSetDescription(edm::ParameterSetDescriptio
   psd5.add<int>("NyBins", 100);
   psd5.add<double>("ymin", -100.0);
   psd5.add<double>("ymax", 100.0);
-  psd5.add<int>("NxBins", 82);
+  psd5.add<int>("NxBins", 41);
   psd5.add<bool>("switch", true);
   psd5.add<double>("xmax", 4.1);
-  psd5.add<double>("xmin", -4.1);
+  psd5.add<double>("xmin", 0.);
   desc.add<edm::ParameterSetDescription>("DeltaY_eta", psd5);
 
   edm::ParameterSetDescription psd5_y;

--- a/Validation/SiTrackerPhase2V/src/Phase2ITValidateRecHitBase.cc
+++ b/Validation/SiTrackerPhase2V/src/Phase2ITValidateRecHitBase.cc
@@ -68,10 +68,16 @@ void Phase2ITValidateRecHitBase::bookLayerHistos(DQMStore::IBooker& ibooker, uns
     local_histos.pullY = phase2tkutil::book1DFromPSet(config_.getParameter<edm::ParameterSet>("PullY"), ibooker);
 
     local_histos.deltaX_eta =
-        phase2tkutil::bookProfile1DFromPSet(config_.getParameter<edm::ParameterSet>("DeltaX_eta"), ibooker);
+        phase2tkutil::book2DFromPSet(config_.getParameter<edm::ParameterSet>("DeltaX_eta"), ibooker);
+
+    local_histos.deltaX_phi =
+        phase2tkutil::book2DFromPSet(config_.getParameter<edm::ParameterSet>("DeltaX_phi"), ibooker);
 
     local_histos.deltaY_eta =
-        phase2tkutil::bookProfile1DFromPSet(config_.getParameter<edm::ParameterSet>("DeltaY_eta"), ibooker);
+        phase2tkutil::book2DFromPSet(config_.getParameter<edm::ParameterSet>("DeltaY_eta"), ibooker);
+
+    local_histos.deltaY_phi =
+        phase2tkutil::book2DFromPSet(config_.getParameter<edm::ParameterSet>("DeltaY_phi"), ibooker);
 
     local_histos.deltaX_clsizex =
         phase2tkutil::bookProfile1DFromPSet(config_.getParameter<edm::ParameterSet>("DeltaX_clsizex"), ibooker);
@@ -142,12 +148,15 @@ void Phase2ITValidateRecHitBase::fillRechitHistos(const PSimHit* simhitClosest,
   if (lperr.yy())
     pully = (lp.y() - simlp.y()) / std::sqrt(lperr.yy());
   float eta = geomDetunit->surface().toGlobal(lp).eta();
+  float phi = geomDetunit->surface().toGlobal(lp).phi();
   layerMEs_[key].deltaX->Fill(dx);
   layerMEs_[key].deltaY->Fill(dy);
   layerMEs_[key].pullX->Fill(pullx);
   layerMEs_[key].pullY->Fill(pully);
   layerMEs_[key].deltaX_eta->Fill(eta, dx);
   layerMEs_[key].deltaY_eta->Fill(eta, dy);
+  layerMEs_[key].deltaX_phi->Fill(phi, dx);
+  layerMEs_[key].deltaY_phi->Fill(phi, dy);
   layerMEs_[key].deltaX_clsizex->Fill(rechit->cluster()->sizeX(), dx);
   layerMEs_[key].deltaX_clsizey->Fill(rechit->cluster()->sizeY(), dx);
   layerMEs_[key].deltaY_clsizex->Fill(rechit->cluster()->sizeX(), dy);
@@ -205,6 +214,7 @@ void Phase2ITValidateRecHitBase::fillPSetDescription(edm::ParameterSetDescriptio
   edm::ParameterSetDescription psd4;
   psd4.add<std::string>("name", "Delta_X_vs_Eta");
   psd4.add<std::string>("title", "Delta_X_vs_Eta;#eta;#Delta x [#mum]");
+  psd4.add<int>("NyBins", 100);
   psd4.add<double>("ymin", -100.0);
   psd4.add<double>("ymax", 100.0);
   psd4.add<int>("NxBins", 82);
@@ -213,9 +223,23 @@ void Phase2ITValidateRecHitBase::fillPSetDescription(edm::ParameterSetDescriptio
   psd4.add<double>("xmin", -4.1);
   desc.add<edm::ParameterSetDescription>("DeltaX_eta", psd4);
 
+  edm::ParameterSetDescription psd4_y;
+  psd4_y.add<std::string>("name", "Delta_X_vs_Phi");
+  ;
+  psd4_y.add<std::string>("title", "Delta_X_vs_Phi;#phi;#Delta x [#mum]");
+  psd4_y.add<int>("NyBins", 100);
+  psd4_y.add<double>("ymin", -100.0);
+  psd4_y.add<double>("ymax", 100.0);
+  psd4_y.add<int>("NxBins", 36);
+  psd4_y.add<bool>("switch", true);
+  psd4_y.add<double>("xmax", M_PI);
+  psd4_y.add<double>("xmin", -M_PI);
+  desc.add<edm::ParameterSetDescription>("DeltaX_phi", psd4_y);
+
   edm::ParameterSetDescription psd5;
   psd5.add<std::string>("name", "Delta_Y_vs_Eta");
   psd5.add<std::string>("title", "Delta_Y_vs_Eta;#eta;#Delta y [#mum]");
+  psd5.add<int>("NyBins", 100);
   psd5.add<double>("ymin", -100.0);
   psd5.add<double>("ymax", 100.0);
   psd5.add<int>("NxBins", 82);
@@ -223,6 +247,18 @@ void Phase2ITValidateRecHitBase::fillPSetDescription(edm::ParameterSetDescriptio
   psd5.add<double>("xmax", 4.1);
   psd5.add<double>("xmin", -4.1);
   desc.add<edm::ParameterSetDescription>("DeltaY_eta", psd5);
+
+  edm::ParameterSetDescription psd5_y;
+  psd5_y.add<std::string>("name", "Delta_Y_vs_Phi");
+  psd5_y.add<std::string>("title", "Delta_Y_vs_Phi;#phi;#Delta y [#mum]");
+  psd5_y.add<int>("NyBins", 100);
+  psd5_y.add<double>("ymin", -100.0);
+  psd5_y.add<double>("ymax", 100.0);
+  psd5_y.add<int>("NxBins", 36);
+  psd5_y.add<bool>("switch", true);
+  psd5_y.add<double>("xmax", M_PI);
+  psd5_y.add<double>("xmin", -M_PI);
+  desc.add<edm::ParameterSetDescription>("DeltaY_phi", psd5_y);
 
   edm::ParameterSetDescription psd6;
   psd6.add<std::string>("name", "Delta_X_vs_ClusterSizeX");

--- a/Validation/SiTrackerPhase2V/src/Phase2OTValidateRecHitBase.cc
+++ b/Validation/SiTrackerPhase2V/src/Phase2OTValidateRecHitBase.cc
@@ -475,10 +475,10 @@ void Phase2OTValidateRecHitBase::fillPSetDescription(edm::ParameterSetDescriptio
     psd0.add<int>("NyBins", 250);
     psd0.add<double>("ymin", -250.0);
     psd0.add<double>("ymax", 250.0);
-    psd0.add<int>("NxBins", 82);
+    psd0.add<int>("NxBins", 41);
     psd0.add<bool>("switch", true);
     psd0.add<double>("xmax", 4.1);
-    psd0.add<double>("xmin", -4.1);
+    psd0.add<double>("xmin", 0.);
     desc.add<edm::ParameterSetDescription>("Delta_X_vs_eta_Strip", psd0);
   }
   {
@@ -488,10 +488,10 @@ void Phase2OTValidateRecHitBase::fillPSetDescription(edm::ParameterSetDescriptio
     psd0.add<int>("NyBins", 100);
     psd0.add<double>("ymin", -5.0);
     psd0.add<double>("ymax", 5.0);
-    psd0.add<int>("NxBins", 82);
+    psd0.add<int>("NxBins", 41);
     psd0.add<bool>("switch", true);
     psd0.add<double>("xmax", 4.1);
-    psd0.add<double>("xmin", -4.1);
+    psd0.add<double>("xmin", 0.);
     desc.add<edm::ParameterSetDescription>("Delta_Y_vs_eta_Strip", psd0);
   }
 

--- a/Validation/SiTrackerPhase2V/src/Phase2OTValidateRecHitBase.cc
+++ b/Validation/SiTrackerPhase2V/src/Phase2OTValidateRecHitBase.cc
@@ -50,10 +50,10 @@ void Phase2OTValidateRecHitBase::dqmBeginRun(const edm::Run& iRun, const edm::Ev
 }
 
 void Phase2OTValidateRecHitBase::fillOTRecHitHistos(const PSimHit* simhitClosest,
-						    const Phase2TrackerRecHit1D* rechit,
-						    const std::map<unsigned int, SimTrack>& selectedSimTrackMap,
-						    std::map<std::string, unsigned int>& nrechitLayerMapP_primary,
-						    std::map<std::string, unsigned int>& nrechitLayerMapS_primary) {
+                                                    const Phase2TrackerRecHit1D* rechit,
+                                                    const std::map<unsigned int, SimTrack>& selectedSimTrackMap,
+                                                    std::map<std::string, unsigned int>& nrechitLayerMapP_primary,
+                                                    std::map<std::string, unsigned int>& nrechitLayerMapS_primary) {
   auto detId = rechit->geographicalId();
   // Get the geomdet
   const GeomDetUnit* geomDetunit(tkGeom_->idToDetUnit(detId));
@@ -81,11 +81,11 @@ void Phase2OTValidateRecHitBase::fillOTRecHitHistos(const PSimHit* simhitClosest
     pully = (dx) / std::sqrt(lperr.yy());
   float eta = geomDetunit->surface().toGlobal(lp).eta();
   float phi = geomDetunit->surface().toGlobal(lp).phi();
-  
+
   //scale for plotting
-  dx *= phase2tkutil::cmtomicron;//this is always the case
+  dx *= phase2tkutil::cmtomicron;  //this is always the case
   if (mType == TrackerGeometry::ModuleType::Ph2PSP) {
-    dy *= phase2tkutil::cmtomicron;//only for PSP sensors
+    dy *= phase2tkutil::cmtomicron;  //only for PSP sensors
 
     layerMEs_[key].deltaX_P->Fill(dx);
     layerMEs_[key].deltaY_P->Fill(dy);
@@ -136,8 +136,8 @@ void Phase2OTValidateRecHitBase::fillOTRecHitHistos(const PSimHit* simhitClosest
 // -- Book Histograms
 //
 void Phase2OTValidateRecHitBase::bookHistograms(DQMStore::IBooker& ibooker,
-                                            edm::Run const& iRun,
-                                            edm::EventSetup const& iSetup) {
+                                                edm::Run const& iRun,
+                                                edm::EventSetup const& iSetup) {
   std::string top_folder = config_.getParameter<std::string>("TopFolderName");
   //Now book layer wise histos
   edm::ESWatcher<TrackerDigiGeometryRecord> theTkDigiGeomWatcher;

--- a/Validation/SiTrackerPhase2V/src/Phase2OTValidateRecHitBase.cc
+++ b/Validation/SiTrackerPhase2V/src/Phase2OTValidateRecHitBase.cc
@@ -93,8 +93,8 @@ void Phase2OTValidateRecHitBase::fillOTRecHitHistos(const PSimHit* simhitClosest
     layerMEs_[key].pullX_P->Fill(pullx);
     layerMEs_[key].pullY_P->Fill(pully);
 
-    layerMEs_[key].deltaX_eta_P->Fill(eta, dx);
-    layerMEs_[key].deltaY_eta_P->Fill(eta, dy);
+    layerMEs_[key].deltaX_eta_P->Fill(std::abs(eta), dx);
+    layerMEs_[key].deltaY_eta_P->Fill(std::abs(eta), dy);
     layerMEs_[key].deltaX_phi_P->Fill(phi, dx);
     layerMEs_[key].deltaY_phi_P->Fill(phi, dy);
 
@@ -115,8 +115,8 @@ void Phase2OTValidateRecHitBase::fillOTRecHitHistos(const PSimHit* simhitClosest
     layerMEs_[key].pullX_S->Fill(pullx);
     layerMEs_[key].pullY_S->Fill(pully);
 
-    layerMEs_[key].deltaX_eta_S->Fill(eta, dx);
-    layerMEs_[key].deltaY_eta_S->Fill(eta, dy);
+    layerMEs_[key].deltaX_eta_S->Fill(std::abs(eta), dx);
+    layerMEs_[key].deltaY_eta_S->Fill(std::abs(eta), dy);
     layerMEs_[key].deltaX_phi_S->Fill(phi, dx);
     layerMEs_[key].deltaY_phi_S->Fill(phi, dy);
 
@@ -304,10 +304,10 @@ void Phase2OTValidateRecHitBase::fillPSetDescription(edm::ParameterSetDescriptio
     psd0.add<int>("NyBins", 250);
     psd0.add<double>("ymin", -250.0);
     psd0.add<double>("ymax", 250.0);
-    psd0.add<int>("NxBins", 82);
+    psd0.add<int>("NxBins", 41);
     psd0.add<bool>("switch", true);
     psd0.add<double>("xmax", 4.1);
-    psd0.add<double>("xmin", -4.1);
+    psd0.add<double>("xmin", 0.);
     desc.add<edm::ParameterSetDescription>("Delta_X_vs_eta_Pixel", psd0);
   }
   {
@@ -317,10 +317,10 @@ void Phase2OTValidateRecHitBase::fillPSetDescription(edm::ParameterSetDescriptio
     psd0.add<int>("NyBins", 300);
     psd0.add<double>("ymin", -1500.0);
     psd0.add<double>("ymax", 1500.0);
-    psd0.add<int>("NxBins", 82);
+    psd0.add<int>("NxBins", 41);
     psd0.add<bool>("switch", true);
     psd0.add<double>("xmax", 4.1);
-    psd0.add<double>("xmin", -4.1);
+    psd0.add<double>("xmin", 0.);
     desc.add<edm::ParameterSetDescription>("Delta_Y_vs_eta_Pixel", psd0);
   }
 

--- a/Validation/SiTrackerPhase2V/src/Phase2OTValidateRecHitBase.cc
+++ b/Validation/SiTrackerPhase2V/src/Phase2OTValidateRecHitBase.cc
@@ -300,7 +300,7 @@ void Phase2OTValidateRecHitBase::fillPSetDescription(edm::ParameterSetDescriptio
   {
     edm::ParameterSetDescription psd0;
     psd0.add<std::string>("name", "Delta_X_vs_Eta_Pixel");
-    psd0.add<std::string>("title", ";#eta;#Delta x [#mum]");
+    psd0.add<std::string>("title", ";|#eta|;#Delta x [#mum]");
     psd0.add<int>("NyBins", 250);
     psd0.add<double>("ymin", -250.0);
     psd0.add<double>("ymax", 250.0);
@@ -313,7 +313,7 @@ void Phase2OTValidateRecHitBase::fillPSetDescription(edm::ParameterSetDescriptio
   {
     edm::ParameterSetDescription psd0;
     psd0.add<std::string>("name", "Delta_Y_vs_Eta_Pixel");
-    psd0.add<std::string>("title", ";#eta;#Delta y [#mum]");
+    psd0.add<std::string>("title", ";|#eta|;#Delta y [#mum]");
     psd0.add<int>("NyBins", 300);
     psd0.add<double>("ymin", -1500.0);
     psd0.add<double>("ymax", 1500.0);
@@ -471,7 +471,7 @@ void Phase2OTValidateRecHitBase::fillPSetDescription(edm::ParameterSetDescriptio
   {
     edm::ParameterSetDescription psd0;
     psd0.add<std::string>("name", "Delta_X_vs_Eta_Strip");
-    psd0.add<std::string>("title", ";#eta;#Delta x [#mum]");
+    psd0.add<std::string>("title", ";|#eta|;#Delta x [#mum]");
     psd0.add<int>("NyBins", 250);
     psd0.add<double>("ymin", -250.0);
     psd0.add<double>("ymax", 250.0);
@@ -484,7 +484,7 @@ void Phase2OTValidateRecHitBase::fillPSetDescription(edm::ParameterSetDescriptio
   {
     edm::ParameterSetDescription psd0;
     psd0.add<std::string>("name", "Delta_Y_vs_Eta_Strip");
-    psd0.add<std::string>("title", ";#eta;#Delta y [cm]");
+    psd0.add<std::string>("title", ";|#eta|;#Delta y [cm]");
     psd0.add<int>("NyBins", 100);
     psd0.add<double>("ymin", -5.0);
     psd0.add<double>("ymax", 5.0);

--- a/Validation/SiTrackerPhase2V/src/Phase2OTValidateRecHitBase.cc
+++ b/Validation/SiTrackerPhase2V/src/Phase2OTValidateRecHitBase.cc
@@ -1,0 +1,603 @@
+// Package:    Phase2OTValidateRecHitBase
+// Class:      Phase2OTValidateRecHitBase
+//
+/**\class Phase2OTValidateRecHitBase Phase2OTValidateRecHitBase.cc 
+ Description:  Standalone  Plugin for Phase2 RecHit validation
+*/
+//
+// Author: Suvankar Roy Chowdhury
+// Date: May 2021
+//
+// system include files
+#include "Validation/SiTrackerPhase2V/interface/Phase2OTValidateRecHitBase.h"
+#include "Validation/SiTrackerPhase2V/interface/TrackerPhase2ValidationUtil.h"
+#include "DQM/SiTrackerPhase2/interface/TrackerPhase2DQMUtil.h"
+#include "FWCore/Framework/interface/ESWatcher.h"
+#include "SimDataFormats/Track/interface/SimTrackContainer.h"
+#include "DataFormats/DetId/interface/DetId.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
+#include "Geometry/CommonDetUnit/interface/TrackerGeomDet.h"
+#include "Geometry/CommonDetUnit/interface/PixelGeomDetUnit.h"
+#include "Geometry/CommonDetUnit/interface/PixelGeomDetType.h"
+#include "SimDataFormats/TrackingHit/interface/PSimHitContainer.h"
+#include "DataFormats/SiPixelDetId/interface/PixelSubdetector.h"
+#include "DataFormats/GeometrySurface/interface/LocalError.h"
+#include "DataFormats/GeometryVector/interface/LocalPoint.h"
+
+//
+// constructors
+//
+Phase2OTValidateRecHitBase::Phase2OTValidateRecHitBase(const edm::ParameterSet& iConfig)
+    : config_(iConfig),
+      geomToken_(esConsumes<TrackerGeometry, TrackerDigiGeometryRecord, edm::Transition::BeginRun>()),
+      topoToken_(esConsumes<TrackerTopology, TrackerTopologyRcd, edm::Transition::BeginRun>()) {
+  edm::LogInfo("Phase2OTValidateRecHitBase") << ">>> Construct Phase2OTValidateRecHitBase ";
+}
+
+//
+// destructor
+//
+Phase2OTValidateRecHitBase::~Phase2OTValidateRecHitBase() {
+  // do anything here that needs to be done at desctruction time
+  // (e.g. close files, deallocate resources etc.)
+  edm::LogInfo("Phase2OTValidateRecHitBase") << ">>> Destroy Phase2OTValidateRecHitBase ";
+}
+//
+// -- DQM Begin Run
+void Phase2OTValidateRecHitBase::dqmBeginRun(const edm::Run& iRun, const edm::EventSetup& iSetup) {
+  tkGeom_ = &iSetup.getData(geomToken_);
+  tTopo_ = &iSetup.getData(topoToken_);
+}
+
+void Phase2OTValidateRecHitBase::fillOTRecHitHistos(const PSimHit* simhitClosest,
+						    const Phase2TrackerRecHit1D* rechit,
+						    const std::map<unsigned int, SimTrack>& selectedSimTrackMap,
+						    std::map<std::string, unsigned int>& nrechitLayerMapP_primary,
+						    std::map<std::string, unsigned int>& nrechitLayerMapS_primary) {
+  auto detId = rechit->geographicalId();
+  // Get the geomdet
+  const GeomDetUnit* geomDetunit(tkGeom_->idToDetUnit(detId));
+  if (!geomDetunit)
+    return;
+  // determine the detector we are in
+  TrackerGeometry::ModuleType mType = tkGeom_->getDetectorType(detId);
+  std::string key = phase2tkutil::getOTHistoId(detId.rawId(), tTopo_);
+
+  LocalPoint lp = rechit->localPosition();
+  auto simTrackIt(selectedSimTrackMap.find(simhitClosest->trackId()));
+  bool isPrimary = false;
+  //check if simhit is primary
+  if (simTrackIt != selectedSimTrackMap.end())
+    isPrimary = phase2tkutil::isPrimary(simTrackIt->second, simhitClosest);
+  Local3DPoint simlp(simhitClosest->localPosition());
+  const LocalError& lperr = rechit->localPositionError();
+  double dx = lp.x() - simlp.x();
+  double dy = lp.y() - simlp.y();
+  double pullx = 999.;
+  double pully = 999.;
+  if (lperr.xx())
+    pullx = (dx) / std::sqrt(lperr.xx());
+  if (lperr.yy())
+    pully = (dx) / std::sqrt(lperr.yy());
+  float eta = geomDetunit->surface().toGlobal(lp).eta();
+  float phi = geomDetunit->surface().toGlobal(lp).phi();
+  
+  //scale for plotting
+  dx *= phase2tkutil::cmtomicron;//this is always the case
+  if (mType == TrackerGeometry::ModuleType::Ph2PSP) {
+    dy *= phase2tkutil::cmtomicron;//only for PSP sensors
+
+    layerMEs_[key].deltaX_P->Fill(dx);
+    layerMEs_[key].deltaY_P->Fill(dy);
+
+    layerMEs_[key].pullX_P->Fill(pullx);
+    layerMEs_[key].pullY_P->Fill(pully);
+
+    layerMEs_[key].deltaX_eta_P->Fill(eta, dx);
+    layerMEs_[key].deltaY_eta_P->Fill(eta, dy);
+    layerMEs_[key].deltaX_phi_P->Fill(phi, dx);
+    layerMEs_[key].deltaY_phi_P->Fill(phi, dy);
+
+    layerMEs_[key].pullX_eta_P->Fill(eta, pullx);
+    layerMEs_[key].pullY_eta_P->Fill(eta, pully);
+
+    if (isPrimary) {
+      layerMEs_[key].deltaX_primary_P->Fill(dx);
+      layerMEs_[key].deltaY_primary_P->Fill(dy);
+      layerMEs_[key].pullX_primary_P->Fill(pullx);
+      layerMEs_[key].pullY_primary_P->Fill(pully);
+    } else
+      nrechitLayerMapP_primary[key]--;
+  } else if (mType == TrackerGeometry::ModuleType::Ph2PSS || mType == TrackerGeometry::ModuleType::Ph2SS) {
+    layerMEs_[key].deltaX_S->Fill(dx);
+    layerMEs_[key].deltaY_S->Fill(dy);
+
+    layerMEs_[key].pullX_S->Fill(pullx);
+    layerMEs_[key].pullY_S->Fill(pully);
+
+    layerMEs_[key].deltaX_eta_S->Fill(eta, dx);
+    layerMEs_[key].deltaY_eta_S->Fill(eta, dy);
+    layerMEs_[key].deltaX_phi_S->Fill(phi, dx);
+    layerMEs_[key].deltaY_phi_S->Fill(phi, dy);
+
+    layerMEs_[key].pullX_eta_S->Fill(eta, pullx);
+    layerMEs_[key].pullY_eta_S->Fill(eta, pully);
+
+    if (isPrimary) {
+      layerMEs_[key].deltaX_primary_S->Fill(dx);
+      layerMEs_[key].deltaY_primary_S->Fill(dy);
+      layerMEs_[key].pullX_primary_S->Fill(pullx);
+      layerMEs_[key].pullY_primary_S->Fill(pully);
+    } else
+      nrechitLayerMapS_primary[key]--;
+  }
+}
+//
+// -- Book Histograms
+//
+void Phase2OTValidateRecHitBase::bookHistograms(DQMStore::IBooker& ibooker,
+                                            edm::Run const& iRun,
+                                            edm::EventSetup const& iSetup) {
+  std::string top_folder = config_.getParameter<std::string>("TopFolderName");
+  //Now book layer wise histos
+  edm::ESWatcher<TrackerDigiGeometryRecord> theTkDigiGeomWatcher;
+  if (theTkDigiGeomWatcher.check(iSetup)) {
+    for (auto const& det_u : tkGeom_->detUnits()) {
+      //Always check TrackerNumberingBuilder before changing this part
+      if (det_u->subDetector() == GeomDetEnumerators::SubDetector::P2PXB ||
+          det_u->subDetector() == GeomDetEnumerators::SubDetector::P2PXEC)
+        continue;
+      unsigned int detId_raw = det_u->geographicalId().rawId();
+      bookLayerHistos(ibooker, detId_raw, top_folder);
+    }
+  }
+}
+
+//
+// -- Book Layer Histograms
+//
+void Phase2OTValidateRecHitBase::bookLayerHistos(DQMStore::IBooker& ibooker, unsigned int det_id, std::string& subdir) {
+  std::string key = phase2tkutil::getOTHistoId(det_id, tTopo_);
+  if (layerMEs_.find(key) == layerMEs_.end()) {
+    ibooker.cd();
+    RecHitME local_histos;
+    ibooker.setCurrentFolder(subdir + "/" + key);
+    edm::LogInfo("Phase2OTValidateRecHitBase") << " Booking Histograms in : " << key;
+
+    if (tkGeom_->getDetectorType(det_id) == TrackerGeometry::ModuleType::Ph2PSP) {
+      local_histos.deltaX_P =
+          phase2tkutil::book1DFromPSet(config_.getParameter<edm::ParameterSet>("Delta_X_Pixel"), ibooker);
+      local_histos.deltaY_P =
+          phase2tkutil::book1DFromPSet(config_.getParameter<edm::ParameterSet>("Delta_Y_Pixel"), ibooker);
+
+      local_histos.pullX_P =
+          phase2tkutil::book1DFromPSet(config_.getParameter<edm::ParameterSet>("Pull_X_Pixel"), ibooker);
+      local_histos.pullY_P =
+          phase2tkutil::book1DFromPSet(config_.getParameter<edm::ParameterSet>("Pull_X_Pixel"), ibooker);
+
+      local_histos.deltaX_eta_P =
+          phase2tkutil::book2DFromPSet(config_.getParameter<edm::ParameterSet>("Delta_X_vs_eta_Pixel"), ibooker);
+      local_histos.deltaY_eta_P =
+          phase2tkutil::book2DFromPSet(config_.getParameter<edm::ParameterSet>("Delta_Y_vs_eta_Pixel"), ibooker);
+
+      local_histos.deltaX_phi_P =
+          phase2tkutil::book2DFromPSet(config_.getParameter<edm::ParameterSet>("Delta_X_vs_phi_Pixel"), ibooker);
+      local_histos.deltaY_phi_P =
+          phase2tkutil::book2DFromPSet(config_.getParameter<edm::ParameterSet>("Delta_Y_vs_phi_Pixel"), ibooker);
+
+      local_histos.pullX_eta_P =
+          phase2tkutil::bookProfile1DFromPSet(config_.getParameter<edm::ParameterSet>("Pull_X_vs_eta_Pixel"), ibooker);
+      local_histos.pullY_eta_P =
+          phase2tkutil::bookProfile1DFromPSet(config_.getParameter<edm::ParameterSet>("Pull_X_vs_eta_Pixel"), ibooker);
+
+      ibooker.setCurrentFolder(subdir + "/" + key + "/PrimarySimHits");
+      //all histos for Primary particles
+      local_histos.numberRecHitsprimary_P =
+          phase2tkutil::book1DFromPSet(config_.getParameter<edm::ParameterSet>("nRecHits_Pixel_primary"), ibooker);
+
+      local_histos.deltaX_primary_P =
+          phase2tkutil::book1DFromPSet(config_.getParameter<edm::ParameterSet>("Delta_X_Pixel_Primary"), ibooker);
+      local_histos.deltaY_primary_P =
+          phase2tkutil::book1DFromPSet(config_.getParameter<edm::ParameterSet>("Delta_X_Pixel_Primary"), ibooker);
+
+      local_histos.pullX_primary_P =
+          phase2tkutil::book1DFromPSet(config_.getParameter<edm::ParameterSet>("Pull_X_Pixel_Primary"), ibooker);
+      local_histos.pullY_primary_P =
+          phase2tkutil::book1DFromPSet(config_.getParameter<edm::ParameterSet>("Pull_X_Pixel_Primary"), ibooker);
+    }  //if block for P
+
+    ibooker.setCurrentFolder(subdir + "/" + key);
+    local_histos.deltaX_S =
+        phase2tkutil::book1DFromPSet(config_.getParameter<edm::ParameterSet>("Delta_X_Strip"), ibooker);
+    local_histos.deltaY_S =
+        phase2tkutil::book1DFromPSet(config_.getParameter<edm::ParameterSet>("Delta_Y_Strip"), ibooker);
+
+    local_histos.pullX_S =
+        phase2tkutil::book1DFromPSet(config_.getParameter<edm::ParameterSet>("Pull_X_Strip"), ibooker);
+    local_histos.pullY_S =
+        phase2tkutil::book1DFromPSet(config_.getParameter<edm::ParameterSet>("Pull_Y_Strip"), ibooker);
+
+    local_histos.deltaX_eta_S =
+        phase2tkutil::book2DFromPSet(config_.getParameter<edm::ParameterSet>("Delta_X_vs_eta_Strip"), ibooker);
+    local_histos.deltaY_eta_S =
+        phase2tkutil::book2DFromPSet(config_.getParameter<edm::ParameterSet>("Delta_Y_vs_eta_Strip"), ibooker);
+
+    local_histos.deltaX_phi_S =
+        phase2tkutil::book2DFromPSet(config_.getParameter<edm::ParameterSet>("Delta_X_vs_phi_Strip"), ibooker);
+    local_histos.deltaY_phi_S =
+        phase2tkutil::book2DFromPSet(config_.getParameter<edm::ParameterSet>("Delta_Y_vs_phi_Strip"), ibooker);
+
+    local_histos.pullX_eta_S =
+        phase2tkutil::bookProfile1DFromPSet(config_.getParameter<edm::ParameterSet>("Pull_X_vs_eta_Strip"), ibooker);
+    local_histos.pullY_eta_S =
+        phase2tkutil::bookProfile1DFromPSet(config_.getParameter<edm::ParameterSet>("Pull_X_vs_eta_Pixel"), ibooker);
+
+    //primary
+    ibooker.setCurrentFolder(subdir + "/" + key + "/PrimarySimHits");
+    local_histos.numberRecHitsprimary_S =
+        phase2tkutil::book1DFromPSet(config_.getParameter<edm::ParameterSet>("nRecHits_Strip_primary"), ibooker);
+
+    local_histos.deltaX_primary_S =
+        phase2tkutil::book1DFromPSet(config_.getParameter<edm::ParameterSet>("Delta_X_Strip_Primary"), ibooker);
+    local_histos.deltaY_primary_S =
+        phase2tkutil::book1DFromPSet(config_.getParameter<edm::ParameterSet>("Delta_Y_Strip_Primary"), ibooker);
+
+    local_histos.pullX_primary_S =
+        phase2tkutil::book1DFromPSet(config_.getParameter<edm::ParameterSet>("Pull_X_Strip_Primary"), ibooker);
+    local_histos.pullY_primary_S =
+        phase2tkutil::book1DFromPSet(config_.getParameter<edm::ParameterSet>("Pull_X_Strip_Primary"), ibooker);
+
+    layerMEs_.insert(std::make_pair(key, local_histos));
+  }
+}
+
+void Phase2OTValidateRecHitBase::fillPSetDescription(edm::ParameterSetDescription& desc) {
+  // rechitValidOT
+  //for macro-pixel sensors
+  std::string mptag = "macro-pixel sensor";
+  std::string striptag = "strip sensor";
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<std::string>("name", "Delta_X_Pixel");
+    psd0.add<std::string>("title", "#Delta X " + mptag + ";Cluster resolution X coordinate [#mum]");
+    psd0.add<bool>("switch", true);
+    psd0.add<double>("xmax", 250);
+    psd0.add<double>("xmin", -250);
+    psd0.add<int>("NxBins", 100);
+    desc.add<edm::ParameterSetDescription>("Delta_X_Pixel", psd0);
+  }
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<std::string>("name", "Delta_Y_Pixel");
+    psd0.add<std::string>("title", "#Delta Y " + mptag + ";Cluster resolution Y coordinate [#mum]");
+    psd0.add<bool>("switch", true);
+    psd0.add<double>("xmin", -1500);
+    psd0.add<double>("xmax", 1500);
+    psd0.add<int>("NxBins", 100);
+    desc.add<edm::ParameterSetDescription>("Delta_Y_Pixel", psd0);
+  }
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<std::string>("name", "Delta_X_Pixel_Primary");
+    psd0.add<std::string>("title", "#Delta X " + mptag + ";cluster resolution X coordinate [#mum]");
+    psd0.add<bool>("switch", true);
+    psd0.add<double>("xmin", -250);
+    psd0.add<double>("xmax", 250);
+    psd0.add<int>("NxBins", 100);
+    desc.add<edm::ParameterSetDescription>("Delta_X_Pixel_Primary", psd0);
+  }
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<std::string>("name", "Delta_Y_Pixel_Primary");
+    psd0.add<std::string>("title", "#Delta Y " + mptag + ";cluster resolution Y coordinate [#mum]");
+    psd0.add<bool>("switch", true);
+    psd0.add<double>("xmin", -500);
+    psd0.add<double>("xmax", 500);
+    psd0.add<int>("NxBins", 100);
+    desc.add<edm::ParameterSetDescription>("Delta_Y_Pixel_Primary", psd0);
+  }
+
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<std::string>("name", "Delta_X_vs_Eta_Pixel");
+    psd0.add<std::string>("title", ";#eta;#Delta x [#mum]");
+    psd0.add<int>("NyBins", 250);
+    psd0.add<double>("ymin", -250.0);
+    psd0.add<double>("ymax", 250.0);
+    psd0.add<int>("NxBins", 82);
+    psd0.add<bool>("switch", true);
+    psd0.add<double>("xmax", 4.1);
+    psd0.add<double>("xmin", -4.1);
+    desc.add<edm::ParameterSetDescription>("Delta_X_vs_eta_Pixel", psd0);
+  }
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<std::string>("name", "Delta_Y_vs_Eta_Pixel");
+    psd0.add<std::string>("title", ";#eta;#Delta y [#mum]");
+    psd0.add<int>("NyBins", 300);
+    psd0.add<double>("ymin", -1500.0);
+    psd0.add<double>("ymax", 1500.0);
+    psd0.add<int>("NxBins", 82);
+    psd0.add<bool>("switch", true);
+    psd0.add<double>("xmax", 4.1);
+    psd0.add<double>("xmin", -4.1);
+    desc.add<edm::ParameterSetDescription>("Delta_Y_vs_eta_Pixel", psd0);
+  }
+
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<std::string>("name", "Delta_X_vs_Phi_Pixel");
+    psd0.add<std::string>("title", ";#phi;#Delta x [#mum]");
+    psd0.add<int>("NyBins", 250);
+    psd0.add<double>("ymin", -250.0);
+    psd0.add<double>("ymax", 250.0);
+    psd0.add<int>("NxBins", 36);
+    psd0.add<bool>("switch", true);
+    psd0.add<double>("xmax", M_PI);
+    psd0.add<double>("xmin", -M_PI);
+    desc.add<edm::ParameterSetDescription>("Delta_X_vs_phi_Pixel", psd0);
+  }
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<std::string>("name", "Delta_Y_vs_Phi_Pixel");
+    psd0.add<std::string>("title", ";#phi;#Delta y [#mum]");
+    psd0.add<int>("NyBins", 300);
+    psd0.add<double>("ymin", -1500.0);
+    psd0.add<double>("ymax", 1500.0);
+    psd0.add<int>("NxBins", 35);
+    psd0.add<bool>("switch", true);
+    psd0.add<double>("xmax", M_PI);
+    psd0.add<double>("xmin", -M_PI);
+    desc.add<edm::ParameterSetDescription>("Delta_Y_vs_phi_Pixel", psd0);
+  }
+  //Pulls macro-pixel
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<std::string>("name", "Pull_X_Pixel");
+    psd0.add<std::string>("title", ";pull x;");
+    psd0.add<double>("xmin", -4.0);
+    psd0.add<bool>("switch", true);
+    psd0.add<double>("xmax", 4.0);
+    psd0.add<int>("NxBins", 100);
+    desc.add<edm::ParameterSetDescription>("Pull_X_Pixel", psd0);
+  }
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<std::string>("name", "Pull_Y_Pixel");
+    psd0.add<std::string>("title", ";pull y;");
+    psd0.add<double>("xmin", -4.0);
+    psd0.add<bool>("switch", true);
+    psd0.add<double>("xmax", 4.0);
+    psd0.add<int>("NxBins", 100);
+    desc.add<edm::ParameterSetDescription>("Pull_Y_Pixel", psd0);
+  }
+
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<std::string>("name", "Pull_X_Pixel_Primary");
+    psd0.add<std::string>("title", ";pull x;");
+    psd0.add<double>("xmin", -4.0);
+    psd0.add<bool>("switch", true);
+    psd0.add<double>("xmax", 4.0);
+    psd0.add<int>("NxBins", 100);
+    desc.add<edm::ParameterSetDescription>("Pull_X_Pixel_Primary", psd0);
+  }
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<std::string>("name", "Pull_Y_Pixel_Primary");
+    psd0.add<std::string>("title", ";pull y;");
+    psd0.add<double>("xmin", -4.0);
+    psd0.add<bool>("switch", true);
+    psd0.add<double>("xmax", 4.0);
+    psd0.add<int>("NxBins", 100);
+    desc.add<edm::ParameterSetDescription>("Pull_Y_Pixel_Primary", psd0);
+  }
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<std::string>("name", "Pull_X_vs_Eta");
+    psd0.add<std::string>("title", ";#eta;pull x");
+    psd0.add<double>("ymax", 4.0);
+    psd0.add<int>("NxBins", 82);
+    psd0.add<bool>("switch", true);
+    psd0.add<double>("xmax", 4.1);
+    psd0.add<double>("xmin", -4.1);
+    psd0.add<double>("ymin", -4.0);
+    desc.add<edm::ParameterSetDescription>("Pull_X_vs_eta_Pixel", psd0);
+  }
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<std::string>("name", "Pull_Y_vs_Eta");
+    psd0.add<std::string>("title", ";#eta;pull y");
+    psd0.add<double>("ymax", 4.0);
+    psd0.add<int>("NxBins", 82);
+    psd0.add<bool>("switch", true);
+    psd0.add<double>("xmax", 4.1);
+    psd0.add<double>("xmin", -4.1);
+    psd0.add<double>("ymin", -4.0);
+    desc.add<edm::ParameterSetDescription>("Pull_Y_vs_eta_Pixel", psd0);
+  }
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<std::string>("name", "Number_RecHits_matched_PrimarySimTrack");
+    psd0.add<std::string>("title", "Number of RecHits matched to primary SimTrack;;");
+    psd0.add<double>("xmin", 0.0);
+    psd0.add<bool>("switch", true);
+    psd0.add<double>("xmax", 10000.0);
+    psd0.add<int>("NxBins", 100);
+    desc.add<edm::ParameterSetDescription>("nRecHits_Pixel_primary", psd0);
+  }
+  //strip sensors
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<std::string>("name", "Delta_X_Strip");
+    psd0.add<std::string>("title", "#Delta X " + striptag + ";Cluster resolution X coordinate [#mum]");
+    psd0.add<bool>("switch", true);
+    psd0.add<double>("xmin", -250);
+    psd0.add<double>("xmax", 250);
+    psd0.add<int>("NxBins", 100);
+    desc.add<edm::ParameterSetDescription>("Delta_X_Strip", psd0);
+  }
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<std::string>("name", "Delta_Y_Strip");
+    psd0.add<std::string>("title", "#Delta Y " + striptag + ";Cluster resolution Y coordinate [cm]");
+    psd0.add<double>("xmin", -5.0);
+    psd0.add<bool>("switch", true);
+    psd0.add<double>("xmax", 5.0);
+    psd0.add<int>("NxBins", 100);
+    desc.add<edm::ParameterSetDescription>("Delta_Y_Strip", psd0);
+  }
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<std::string>("name", "Delta_X_Strip_Primary");
+    psd0.add<std::string>("title", "#Delta X " + striptag + ";Cluster resolution X coordinate [#mum]");
+    psd0.add<bool>("switch", true);
+    psd0.add<double>("xmin", -250);
+    psd0.add<double>("xmax", 250);
+    psd0.add<int>("NxBins", 100);
+    desc.add<edm::ParameterSetDescription>("Delta_X_Strip_Primary", psd0);
+  }
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<std::string>("name", "Delta_Y_Strip_Primary");
+    psd0.add<std::string>("title", "#Delta Y " + striptag + ";Cluster resolution Y coordinate [cm]");
+    psd0.add<double>("xmin", -5.0);
+    psd0.add<bool>("switch", true);
+    psd0.add<double>("xmax", 5.0);
+    psd0.add<int>("NxBins", 100);
+    desc.add<edm::ParameterSetDescription>("Delta_Y_Strip_Primary", psd0);
+  }
+
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<std::string>("name", "Delta_X_vs_Eta_Strip");
+    psd0.add<std::string>("title", ";#eta;#Delta x [#mum]");
+    psd0.add<int>("NyBins", 250);
+    psd0.add<double>("ymin", -250.0);
+    psd0.add<double>("ymax", 250.0);
+    psd0.add<int>("NxBins", 82);
+    psd0.add<bool>("switch", true);
+    psd0.add<double>("xmax", 4.1);
+    psd0.add<double>("xmin", -4.1);
+    desc.add<edm::ParameterSetDescription>("Delta_X_vs_eta_Strip", psd0);
+  }
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<std::string>("name", "Delta_Y_vs_Eta_Strip");
+    psd0.add<std::string>("title", ";#eta;#Delta y [cm]");
+    psd0.add<int>("NyBins", 100);
+    psd0.add<double>("ymin", -5.0);
+    psd0.add<double>("ymax", 5.0);
+    psd0.add<int>("NxBins", 82);
+    psd0.add<bool>("switch", true);
+    psd0.add<double>("xmax", 4.1);
+    psd0.add<double>("xmin", -4.1);
+    desc.add<edm::ParameterSetDescription>("Delta_Y_vs_eta_Strip", psd0);
+  }
+
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<std::string>("name", "Delta_X_vs_Phi_Strip");
+    psd0.add<std::string>("title", ";#phi;#Delta x [#mum]");
+    psd0.add<int>("NyBins", 250);
+    psd0.add<double>("ymin", -250.0);
+    psd0.add<double>("ymax", 250.0);
+    psd0.add<int>("NxBins", 36);
+    psd0.add<bool>("switch", true);
+    psd0.add<double>("xmax", M_PI);
+    psd0.add<double>("xmin", -M_PI);
+    desc.add<edm::ParameterSetDescription>("Delta_X_vs_phi_Strip", psd0);
+  }
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<std::string>("name", "Delta_Y_vs_Phi_Strip");
+    psd0.add<std::string>("title", ";#phi;#Delta y [cm]");
+    psd0.add<int>("NyBins", 100);
+    psd0.add<double>("ymin", -5.0);
+    psd0.add<double>("ymax", 5.0);
+    psd0.add<int>("NxBins", 36);
+    psd0.add<bool>("switch", true);
+    psd0.add<double>("xmax", M_PI);
+    psd0.add<double>("xmin", -M_PI);
+    desc.add<edm::ParameterSetDescription>("Delta_Y_vs_phi_Strip", psd0);
+  }
+  //pulls strips
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<std::string>("name", "Pull_X_Strip");
+    psd0.add<std::string>("title", ";pull x;");
+    psd0.add<double>("xmin", -4.0);
+    psd0.add<bool>("switch", true);
+    psd0.add<double>("xmax", 4.0);
+    psd0.add<int>("NxBins", 100);
+    desc.add<edm::ParameterSetDescription>("Pull_X_Strip", psd0);
+  }
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<std::string>("name", "Pull_Y_Strip");
+    psd0.add<std::string>("title", ";pull y;");
+    psd0.add<double>("xmin", -4.0);
+    psd0.add<bool>("switch", true);
+    psd0.add<double>("xmax", 4.0);
+    psd0.add<int>("NxBins", 100);
+    desc.add<edm::ParameterSetDescription>("Pull_Y_Strip", psd0);
+  }
+
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<std::string>("name", "Pull_X_Strip_Primary");
+    psd0.add<std::string>("title", ";pull x;");
+    psd0.add<double>("xmin", -4.0);
+    psd0.add<bool>("switch", true);
+    psd0.add<double>("xmax", 4.0);
+    psd0.add<int>("NxBins", 100);
+    desc.add<edm::ParameterSetDescription>("Pull_X_Strip_Primary", psd0);
+  }
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<std::string>("name", "Pull_Y_Strip_Primary");
+    psd0.add<std::string>("title", ";pull y;");
+    psd0.add<double>("xmin", -4.0);
+    psd0.add<bool>("switch", true);
+    psd0.add<double>("xmax", 4.0);
+    psd0.add<int>("NxBins", 100);
+    desc.add<edm::ParameterSetDescription>("Pull_Y_Strip_Primary", psd0);
+  }
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<std::string>("name", "Pull_X_vs_Eta_Strip");
+    psd0.add<std::string>("title", ";#eta;pull x");
+    psd0.add<double>("ymax", 4.0);
+    psd0.add<int>("NxBins", 82);
+    psd0.add<bool>("switch", true);
+    psd0.add<double>("xmax", 4.1);
+    psd0.add<double>("xmin", -4.1);
+    psd0.add<double>("ymin", -4.0);
+    desc.add<edm::ParameterSetDescription>("Pull_X_vs_eta_Strip", psd0);
+  }
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<std::string>("name", "Pull_Y_vs_Eta_Strip");
+    psd0.add<std::string>("title", ";#eta;pull y");
+    psd0.add<double>("ymax", 4.0);
+    psd0.add<int>("NxBins", 82);
+    psd0.add<bool>("switch", true);
+    psd0.add<double>("xmax", 4.1);
+    psd0.add<double>("xmin", -4.1);
+    psd0.add<double>("ymin", -4.0);
+    desc.add<edm::ParameterSetDescription>("Pull_Y_vs_eta_Strip", psd0);
+  }
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<std::string>("name", "Number_RecHits_matched_PrimarySimTrack");
+    psd0.add<std::string>("title", "Number of RecHits matched to primary SimTrack;;");
+    psd0.add<double>("xmin", 0.0);
+    psd0.add<bool>("switch", true);
+    psd0.add<double>("xmax", 10000.0);
+    psd0.add<int>("NxBins", 100);
+    desc.add<edm::ParameterSetDescription>("nRecHits_Strip_primary", psd0);
+  }
+}
+
+//define this as a plug-in
+DEFINE_FWK_MODULE(Phase2OTValidateRecHitBase);


### PR DESCRIPTION
#### PR description:
This PR introduces the following:-

- In the DQM step,  (rechit-simhit) residuals are plotted as a function of abs(eta) and phi for each layer and ring. This is done both for the IT and OT(OT is still only in standalone configuration) 
- A new module is introduced for Harvesting, which does the fits of the residual 2D histos of the previous point to make plots of mean residual and resolution from as a function of eta-phi
- For finding the closest simhit for rechits, and clusters - squared distance is used
- A new harvesting util is also added.
- The harvester module can also be configured to run for OT but it can only be used in standalone mode now.

#### PR validation:
Checked with wf 23234.0

#### if this PR is a backport please specify the original PR and why you need to backport that PR:
NA
cc @emiglior @mmusich @tsusa