### PR TITLE
Code performance improvements in follow-up to #31722

### DIFF
--- a/RecoPixelVertexing/PixelTrackFitting/interface/BrokenLine.h
+++ b/RecoPixelVertexing/PixelTrackFitting/interface/BrokenLine.h
@@ -208,31 +208,42 @@ namespace brokenline {
                                                                const riemannFit::VectorNd<n>& varBeta) {
     riemannFit::MatrixNd<n> c_uMat = riemannFit::MatrixNd<n>::Zero();
     for (u_int i = 0; i < n; i++) {
+      // Pre compute differences used multiple time. Notation is t<j><k> = sTotal(i + k) - sTotal(i + k - j).
+      // We pre-compute only when possible/needed
+      // The compiler with unroll this loop with a known boundary, and no tests should
+      // be actually executed.
+      const auto t10 =  (i > 0)                   ? sTotal(i)     - sTotal(i - 1) : 0;
+      const auto t21 = ((i > 0) && (i < (n - 1))) ? sTotal(i + 1) - sTotal(i - 1) : 0;
+      const auto t11 =             (i < (n - 1))  ? sTotal(i + 1) - sTotal(i)     : 0;
+      const auto t12 =             (i < (n - 2))  ? sTotal(i + 2) - sTotal(i + 1) : 0;
+      const auto t22 =             (i < (n - 2))  ? sTotal(i + 2) - sTotal(i)     : 0;
+      const auto t11xt10 = t11 * t10;
+      const auto t12xt11 = t12 * t11;
       c_uMat(i, i) = weights(i);
       if (i > 1)
-        c_uMat(i, i) += 1. / (varBeta(i - 1) * riemannFit::sqr(sTotal(i) - sTotal(i - 1)));
-      if (i > 0 && i < n - 1)
-        c_uMat(i, i) +=
-            (1. / varBeta(i)) * riemannFit::sqr((sTotal(i + 1) - sTotal(i - 1)) /
-                                                ((sTotal(i + 1) - sTotal(i)) * (sTotal(i) - sTotal(i - 1))));
-      if (i < n - 2)
-        c_uMat(i, i) += 1. / (varBeta(i + 1) * riemannFit::sqr(sTotal(i + 1) - sTotal(i)));
+        c_uMat(i, i) += 1. / (varBeta(i - 1) * riemannFit::sqr(t10));
 
       if (i > 0 && i < n - 1)
-        c_uMat(i, i + 1) =
-            1. / (varBeta(i) * (sTotal(i + 1) - sTotal(i))) *
-            (-(sTotal(i + 1) - sTotal(i - 1)) / ((sTotal(i + 1) - sTotal(i)) * (sTotal(i) - sTotal(i - 1))));
-      if (i < n - 2)
-        c_uMat(i, i + 1) +=
-            1. / (varBeta(i + 1) * (sTotal(i + 1) - sTotal(i))) *
-            (-(sTotal(i + 2) - sTotal(i)) / ((sTotal(i + 2) - sTotal(i + 1)) * (sTotal(i + 1) - sTotal(i))));
+        c_uMat(i, i) += riemannFit::sqr(t21 / t11xt10) / varBeta(i);
 
       if (i < n - 2)
-        c_uMat(i, i + 2) = 1. / (varBeta(i + 1) * (sTotal(i + 2) - sTotal(i + 1)) * (sTotal(i + 1) - sTotal(i)));
+        c_uMat(i, i) += 1. / (varBeta(i + 1) * riemannFit::sqr(t11));
 
-      c_uMat(i, i) *= 0.5;
+      if (i > 0 && i < n - 1)
+        c_uMat(i, i + 1) =  -t21 / (varBeta(i) * t11 * t11xt10);
+
+      if (i < n - 2)
+        c_uMat(i, i + 1) += -t22 / (varBeta(i + 1) * t11 * t12xt11);
+
+      if (i < n - 1) // for 2 previous steps, non diagonal element copy for this symmetric matrix
+        c_uMat(i + 1, i) = c_uMat(i, i + 1);
+
+      if (i < n - 2) {
+        c_uMat(i, i + 2) = 1. / (varBeta(i + 1) * t12xt11);
+        c_uMat(i + 2, i) = c_uMat(i, i + 2); // non-diagonal element copy.
+      }
     }
-    return c_uMat + c_uMat.transpose();
+    return c_uMat;
   }
 
   /*!

--- a/RecoPixelVertexing/PixelTrackFitting/interface/BrokenLine.h
+++ b/RecoPixelVertexing/PixelTrackFitting/interface/BrokenLine.h
@@ -212,11 +212,11 @@ namespace brokenline {
       // We pre-compute only when possible/needed
       // The compiler with unroll this loop with a known boundary, and no tests should
       // be actually executed.
-      const auto t10 =  (i > 0)                   ? sTotal(i)     - sTotal(i - 1) : 0;
+      const auto t10 = (i > 0) ? sTotal(i) - sTotal(i - 1) : 0;
       const auto t21 = ((i > 0) && (i < (n - 1))) ? sTotal(i + 1) - sTotal(i - 1) : 0;
-      const auto t11 =             (i < (n - 1))  ? sTotal(i + 1) - sTotal(i)     : 0;
-      const auto t12 =             (i < (n - 2))  ? sTotal(i + 2) - sTotal(i + 1) : 0;
-      const auto t22 =             (i < (n - 2))  ? sTotal(i + 2) - sTotal(i)     : 0;
+      const auto t11 = (i < (n - 1)) ? sTotal(i + 1) - sTotal(i) : 0;
+      const auto t12 = (i < (n - 2)) ? sTotal(i + 2) - sTotal(i + 1) : 0;
+      const auto t22 = (i < (n - 2)) ? sTotal(i + 2) - sTotal(i) : 0;
       const auto t11xt10 = t11 * t10;
       const auto t12xt11 = t12 * t11;
       c_uMat(i, i) = weights(i);
@@ -230,17 +230,17 @@ namespace brokenline {
         c_uMat(i, i) += 1. / (varBeta(i + 1) * riemannFit::sqr(t11));
 
       if (i > 0 && i < n - 1)
-        c_uMat(i, i + 1) =  -t21 / (varBeta(i) * t11 * t11xt10);
+        c_uMat(i, i + 1) = -t21 / (varBeta(i) * t11 * t11xt10);
 
       if (i < n - 2)
         c_uMat(i, i + 1) += -t22 / (varBeta(i + 1) * t11 * t12xt11);
 
-      if (i < n - 1) // for 2 previous steps, non diagonal element copy for this symmetric matrix
+      if (i < n - 1)  // for 2 previous steps, non diagonal element copy for this symmetric matrix
         c_uMat(i + 1, i) = c_uMat(i, i + 1);
 
       if (i < n - 2) {
         c_uMat(i, i + 2) = 1. / (varBeta(i + 1) * t12xt11);
-        c_uMat(i + 2, i) = c_uMat(i, i + 2); // non-diagonal element copy.
+        c_uMat(i + 2, i) = c_uMat(i, i + 2);  // non-diagonal element copy.
       }
     }
     return c_uMat;

--- a/RecoPixelVertexing/PixelTrackFitting/interface/RiemannFit.h
+++ b/RecoPixelVertexing/PixelTrackFitting/interface/RiemannFit.h
@@ -127,7 +127,7 @@ namespace riemannFit {
     constexpr uint n = N;
     const double p_t = std::min(20., fast_fit(2) * B);  // limit pt to avoid too small error!!!
     // fast_fit(3) = tan(theta) =>
-    // 1 / sqr(sin(theta)) = (sqr(sin(theta) + sqr(cos(theta))) / sqr(sin(theta))
+    // 1 / sqr(sin(theta)) = (sqr(sin(theta)) + sqr(cos(theta))) / sqr(sin(theta))
     //                     = 1 + 1 / sqr(tan(theta))
     //                     = 1 + 1 / sqr(fast_fit(3))
     const double invSqrSinTheta = 1. + 1. / sqr(fast_fit(3));

--- a/RecoPixelVertexing/PixelTrackFitting/interface/RiemannFit.h
+++ b/RecoPixelVertexing/PixelTrackFitting/interface/RiemannFit.h
@@ -257,7 +257,7 @@ namespace riemannFit {
         const double tan_c = -y2 / x2;
         const double tan_c2 = sqr(tan_c);
         cov_rad(i) =
-            1. / (1. + tan_c2) * (cov_cart(i, i) + cov_cart(i + n, i + n) * tan_c2 + 2 * cov_cart(i, i + n) * tan_c);
+            (cov_cart(i, i) + cov_cart(i + n, i + n) * tan_c2 + 2 * cov_cart(i, i + n) * tan_c) / (1. + tan_c2) ;
       }
     }
     return cov_rad;
@@ -517,7 +517,7 @@ namespace riemannFit {
 
     // scale
     const double tempQ = mc.squaredNorm();
-    const double tempS = sqrt(n * 1. / tempQ);  // scaling factor
+    const double tempS = sqrt(n / tempQ);  // scaling factor
     p3D *= tempS;
 
     // project on paraboloid
@@ -911,13 +911,14 @@ namespace riemannFit {
     // We need now to transfer back the results in the original s-z plane
     const auto sinTheta = sin(theta);
     const auto cosTheta = cos(theta);
-    auto common_factor = 1. / (sinTheta - sol(1, 0) * cosTheta);
+    const auto common_factor = 1. / (sinTheta - sol(1, 0) * cosTheta);
+    const auto sqr_common_factor = sqr(common_factor);
     Eigen::Matrix<double, 2, 2> jMat;
-    jMat << 0., common_factor * common_factor, common_factor, sol(0, 0) * cosTheta * common_factor * common_factor;
+    jMat << 0., sqr_common_factor, common_factor, sol(0, 0) * cosTheta * sqr_common_factor;
 
-    double tempM = common_factor * (sol(1, 0) * sinTheta + cosTheta);
-    double tempQ = common_factor * sol(0, 0);
-    auto cov_mq = jMat * covParamsMat * jMat.transpose();
+    const double tempM = common_factor * (sol(1, 0) * sinTheta + cosTheta);
+    const double tempQ = common_factor * sol(0, 0);
+    const auto cov_mq = jMat * covParamsMat * jMat.transpose();
 
     VectorNd<N> res = p2D_rot.row(1).transpose() - aMat.transpose() * sol;
     double chi2 = res.transpose() * vyInvMat * res;

--- a/RecoPixelVertexing/PixelTrackFitting/interface/RiemannFit.h
+++ b/RecoPixelVertexing/PixelTrackFitting/interface/RiemannFit.h
@@ -93,7 +93,7 @@ namespace riemannFit {
     for (uint k = 0; k < n; ++k) {
       for (uint l = k; l < n; ++l) {
         for (uint i = 0; i < std::min(k, l); ++i) {
-          tmp(k + n, l + n) += std::abs(s_values(k) - s_values(i)) * std::abs(s_values(l) - s_values(i)) * sig2_S(i);
+          tmp(k + n, l + n) += std::abs((s_values(k) - s_values(i)) * (s_values(l) - s_values(i))) * sig2_S(i);
         }
         tmp(l + n, k + n) = tmp(k + n, l + n);
       }

--- a/RecoPixelVertexing/PixelTrackFitting/interface/RiemannFit.h
+++ b/RecoPixelVertexing/PixelTrackFitting/interface/RiemannFit.h
@@ -257,7 +257,7 @@ namespace riemannFit {
         const double tan_c = -y2 / x2;
         const double tan_c2 = sqr(tan_c);
         cov_rad(i) =
-            (cov_cart(i, i) + cov_cart(i + n, i + n) * tan_c2 + 2 * cov_cart(i, i + n) * tan_c) / (1. + tan_c2) ;
+            (cov_cart(i, i) + cov_cart(i + n, i + n) * tan_c2 + 2 * cov_cart(i, i + n) * tan_c) / (1. + tan_c2);
       }
     }
     return cov_rad;

--- a/RecoPixelVertexing/PixelTrackFitting/plugins/storeTracks.h
+++ b/RecoPixelVertexing/PixelTrackFitting/plugins/storeTracks.h
@@ -47,7 +47,7 @@ void storeTracks(Ev& ev, const TWH& tracksWithHits, const TrackerTopology& ttopo
     reco::TrackExtra theTrackExtra{};
 
     //fill the TrackExtra with TrackingRecHitRef
-    unsigned int nHits = tracks->at(k).numberOfValidHits();
+    unsigned int nHits = (*tracks)[k].numberOfValidHits();
     theTrackExtra.setHits(hitCollProd, cc, nHits);
     cc += nHits;
     AlgebraicVector5 v = AlgebraicVector5(0, 0, 0, 0, 0);
@@ -63,7 +63,7 @@ void storeTracks(Ev& ev, const TWH& tracksWithHits, const TrackerTopology& ttopo
 
   for (int k = 0; k < nTracks; k++) {
     const reco::TrackExtraRef theTrackExtraRef(ohTE, k);
-    (tracks->at(k)).setExtra(theTrackExtraRef);
+    (*tracks)[k].setExtra(theTrackExtraRef);
   }
 
   ev.put(std::move(tracks));


### PR DESCRIPTION
#### PR description:

CMSSW https://github.com/cms-sw/cmssw/pull/31722 Patatrack integration - Pixel track reconstruction (10/N) was merged with [extra comments to be addressed](https://github.com/cms-sw/cmssw/pull/31722#pullrequestreview-623346747).

This PR addresses the performance related comments.

#### PR validation:

The code was run in workflows (step3 and step4):
- 11634.501 (CPU)
- 11634.502 (GPU)
- 11634.505 (CPU)
- 11634.506 (GPU)

The workflow results where then compared using the plots generated by `makeTrackValidationPlots.py`. The CPU workflows gave results identical to the baseline integration build. The GPU workflows displayed slight variations, but the variations are also present between multiple runs of the same version (baseline or this branch).

Unit tests were fine except one problem not related the this branch and followed up in https://github.com/cms-sw/cmssw/issues/33797