### PR TITLE
fix issue with watching Runs and LuminosityBlocks in Calibration/TkAlCaRecoProducers [11.3.X]

### DIFF
--- a/Calibration/TkAlCaRecoProducers/interface/AlcaBeamSpotHarvester.h
+++ b/Calibration/TkAlCaRecoProducers/interface/AlcaBeamSpotHarvester.h
@@ -13,7 +13,7 @@
 
 // #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
-class AlcaBeamSpotHarvester : public edm::one::EDAnalyzer<> {
+class AlcaBeamSpotHarvester : public edm::one::EDAnalyzer<edm::one::WatchRuns, edm::one::WatchLuminosityBlocks> {
 public:
   /// Constructor
   AlcaBeamSpotHarvester(const edm::ParameterSet &);
@@ -23,10 +23,10 @@ public:
 
   // Operations
   void analyze(const edm::Event &, const edm::EventSetup &) override;
-  void beginRun(const edm::Run &, const edm::EventSetup &);
-  void endRun(const edm::Run &, const edm::EventSetup &);
-  void beginLuminosityBlock(const edm::LuminosityBlock &, const edm::EventSetup &);
-  void endLuminosityBlock(const edm::LuminosityBlock &, const edm::EventSetup &);
+  void beginRun(const edm::Run &, const edm::EventSetup &) override;
+  void endRun(const edm::Run &, const edm::EventSetup &) override;
+  void beginLuminosityBlock(const edm::LuminosityBlock &, const edm::EventSetup &) override;
+  void endLuminosityBlock(const edm::LuminosityBlock &, const edm::EventSetup &) override;
 
 protected:
 private:

--- a/Calibration/TkAlCaRecoProducers/plugins/PCLMetadataWriter.cc
+++ b/Calibration/TkAlCaRecoProducers/plugins/PCLMetadataWriter.cc
@@ -18,7 +18,7 @@
 #include <vector>
 #include <iostream>
 
-class PCLMetadataWriter : public edm::one::EDAnalyzer<> {
+class PCLMetadataWriter : public edm::one::EDAnalyzer<edm::one::WatchRuns> {
 public:
   /// Constructor
   PCLMetadataWriter(const edm::ParameterSet &);
@@ -28,8 +28,8 @@ public:
 
   // Operations
   void analyze(const edm::Event &, const edm::EventSetup &) override;
-  void beginRun(const edm::Run &, const edm::EventSetup &);
-  void endRun(const edm::Run &, const edm::EventSetup &);
+  void beginRun(const edm::Run &, const edm::EventSetup &) override;
+  void endRun(const edm::Run &, const edm::EventSetup &) override;
 
 protected:
 private:


### PR DESCRIPTION
backport or #33866 

#### PR description:

In PR https://github.com/cms-sw/cmssw/pull/32432 the classes `AlcaBeamSpotHarvester` and `PCLMetadataWriter` have been migrated from legacy `EDAnalyzer`s to `edm::one::EDAnalyzer`, though not correctly as they need to observe both `Run` and `LuminosityBlock` transitions in order to support `beginRun|LuminosityBlock` and `endRun|LuminosityBlock`methods that are doing actual work. This has resulted e.g. in the problem reported in this [Tier-0 Hypernew thread](https://hypernews.cern.ch/HyperNews/CMS/get/tier0-Ops/2213/1.html).
This PR fixes the issue.

#### PR validation:

It compiles.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This is a backport of PR https://github.com/cms-sw/cmssw/pull/33866, needed to support upcoming MWGRs