### PR TITLE
RPC condtools inverseMaps esConsumes update

### DIFF
--- a/CondTools/RPC/plugins/RPCInverseCPPFLinkMapESProducer.cc
+++ b/CondTools/RPC/plugins/RPCInverseCPPFLinkMapESProducer.cc
@@ -1,5 +1,7 @@
 #include "CondTools/RPC/plugins/RPCInverseCPPFLinkMapESProducer.h"
 
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
@@ -10,7 +12,8 @@
 #include "CondFormats/DataRecord/interface/RPCInverseCPPFLinkMapRcd.h"
 
 RPCInverseCPPFLinkMapESProducer::RPCInverseCPPFLinkMapESProducer(edm::ParameterSet const& _config) {
-  setWhatProduced(this);
+  auto cc = setWhatProduced(this);
+  es_rpc_cppf_l_map_token_ = cc.consumesFrom<RPCAMCLinkMap, RPCCPPFLinkMapRcd>();
 }
 
 void RPCInverseCPPFLinkMapESProducer::fillDescriptions(edm::ConfigurationDescriptions& _descs) {
@@ -23,9 +26,8 @@ void RPCInverseCPPFLinkMapESProducer::setupRPCCPPFLinkMap(RPCCPPFLinkMapRcd cons
   RPCInverseAMCLinkMap::map_type& _inverse_map(inverse_linkmap->getMap());
   _inverse_map.clear();
 
-  edm::ESHandle<RPCAMCLinkMap> _es_map;
-  _rcd.get(_es_map);
-  RPCAMCLinkMap const& _map = *(_es_map.product());
+  RPCAMCLinkMap const& _map = _rcd.get(es_rpc_cppf_l_map_token_);
+
   for (auto const& _link : _map.getMap()) {
     _inverse_map.insert(RPCInverseAMCLinkMap::map_type::value_type(_link.second, _link.first));
   }

--- a/CondTools/RPC/plugins/RPCInverseCPPFLinkMapESProducer.h
+++ b/CondTools/RPC/plugins/RPCInverseCPPFLinkMapESProducer.h
@@ -5,9 +5,12 @@
 
 #include "FWCore/Framework/interface/ESProducer.h"
 #include "FWCore/Framework/interface/ESProductHost.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Utilities/interface/ESGetToken.h"
 #include "FWCore/Utilities/interface/ReusableObjectHolder.h"
 
 #include "CondFormats/RPCObjects/interface/RPCInverseAMCLinkMap.h"
+#include "CondFormats/RPCObjects/interface/RPCAMCLinkMap.h"
 
 namespace edm {
   class ParameterSet;
@@ -31,6 +34,8 @@ private:
   void setupRPCCPPFLinkMap(RPCCPPFLinkMapRcd const&, RPCInverseAMCLinkMap*);
 
   edm::ReusableObjectHolder<HostType> holder_;
+
+  edm::ESGetToken<RPCAMCLinkMap, RPCCPPFLinkMapRcd> es_rpc_cppf_l_map_token_;
 };
 
 #endif  // CondTools_RPC_RPCInverseCPPFLinkMapESProducer_h

--- a/CondTools/RPC/plugins/RPCInverseLBLinkMapESProducer.cc
+++ b/CondTools/RPC/plugins/RPCInverseLBLinkMapESProducer.cc
@@ -1,5 +1,7 @@
 #include "CondTools/RPC/plugins/RPCInverseLBLinkMapESProducer.h"
 
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
@@ -12,7 +14,9 @@
 #include "DataFormats/MuonDetId/interface/RPCDetId.h"
 
 RPCInverseLBLinkMapESProducer::RPCInverseLBLinkMapESProducer(edm::ParameterSet const& _config) {
-  setWhatProduced(this);
+  auto cc = setWhatProduced(this);
+
+  es_rpc_lb_map_token_ = cc.consumesFrom<RPCLBLinkMap, RPCLBLinkMapRcd>();
 }
 
 void RPCInverseLBLinkMapESProducer::fillDescriptions(edm::ConfigurationDescriptions& _descs) {
@@ -25,9 +29,8 @@ void RPCInverseLBLinkMapESProducer::setupRPCLBLinkMap(RPCLBLinkMapRcd const& _rc
   RPCInverseLBLinkMap::map_type& _inverse_map(inverse_linkmap->getMap());
   _inverse_map.clear();
 
-  edm::ESHandle<RPCLBLinkMap> _es_map;
-  _rcd.get(_es_map);
-  RPCLBLinkMap const& _map = *(_es_map.product());
+  RPCLBLinkMap const& _map = _rcd.get(es_rpc_lb_map_token_);
+
   for (auto const& _link : _map.getMap()) {
     _inverse_map.insert(RPCInverseLBLinkMap::map_type::value_type(_link.second.getRPCDetId().rawId(), _link));
   }

--- a/CondTools/RPC/plugins/RPCInverseLBLinkMapESProducer.h
+++ b/CondTools/RPC/plugins/RPCInverseLBLinkMapESProducer.h
@@ -5,9 +5,12 @@
 
 #include "FWCore/Framework/interface/ESProducer.h"
 #include "FWCore/Framework/interface/ESProductHost.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Utilities/interface/ESGetToken.h"
 #include "FWCore/Utilities/interface/ReusableObjectHolder.h"
 
 #include "CondFormats/RPCObjects/interface/RPCInverseLBLinkMap.h"
+#include "CondFormats/RPCObjects/interface/RPCLBLinkMap.h"
 
 namespace edm {
   class ParameterSet;
@@ -31,6 +34,8 @@ private:
   void setupRPCLBLinkMap(RPCLBLinkMapRcd const&, RPCInverseLBLinkMap*);
 
   edm::ReusableObjectHolder<HostType> holder_;
+
+  edm::ESGetToken<RPCLBLinkMap, RPCLBLinkMapRcd> es_rpc_lb_map_token_;
 };
 
 #endif  // CondTools_RPC_RPCInverseLBLinkMapESProducer_h

--- a/CondTools/RPC/plugins/RPCInverseOMTFLinkMapESProducer.cc
+++ b/CondTools/RPC/plugins/RPCInverseOMTFLinkMapESProducer.cc
@@ -1,5 +1,7 @@
 #include "CondTools/RPC/plugins/RPCInverseOMTFLinkMapESProducer.h"
 
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
@@ -10,7 +12,8 @@
 #include "CondFormats/DataRecord/interface/RPCInverseOMTFLinkMapRcd.h"
 
 RPCInverseOMTFLinkMapESProducer::RPCInverseOMTFLinkMapESProducer(edm::ParameterSet const& _config) {
-  setWhatProduced(this);
+  auto cc = setWhatProduced(this);
+  es_rpc_omt_l_map_token_ = cc.consumesFrom<RPCAMCLinkMap, RPCOMTFLinkMapRcd>();
 }
 
 void RPCInverseOMTFLinkMapESProducer::fillDescriptions(edm::ConfigurationDescriptions& _descs) {
@@ -23,10 +26,8 @@ void RPCInverseOMTFLinkMapESProducer::setupRPCOMTFLinkMap(RPCOMTFLinkMapRcd cons
   RPCInverseAMCLinkMap::map_type& _inverse_map(inverse_linkmap->getMap());
   _inverse_map.clear();
 
-  edm::ESHandle<RPCAMCLinkMap> _es_map;
-  _rcd.get(_es_map);
+  RPCAMCLinkMap const& _map = _rcd.get(es_rpc_omt_l_map_token_);
 
-  RPCAMCLinkMap const& _map = *(_es_map.product());
   for (auto const& _link : _map.getMap()) {
     _inverse_map.insert(RPCInverseAMCLinkMap::map_type::value_type(_link.second, _link.first));
   }

--- a/CondTools/RPC/plugins/RPCInverseOMTFLinkMapESProducer.h
+++ b/CondTools/RPC/plugins/RPCInverseOMTFLinkMapESProducer.h
@@ -5,9 +5,12 @@
 
 #include "FWCore/Framework/interface/ESProducer.h"
 #include "FWCore/Framework/interface/ESProductHost.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Utilities/interface/ESGetToken.h"
 #include "FWCore/Utilities/interface/ReusableObjectHolder.h"
 
 #include "CondFormats/RPCObjects/interface/RPCInverseAMCLinkMap.h"
+#include "CondFormats/RPCObjects/interface/RPCAMCLinkMap.h"
 
 namespace edm {
   class ParameterSet;
@@ -31,6 +34,8 @@ private:
   void setupRPCOMTFLinkMap(RPCOMTFLinkMapRcd const&, RPCInverseAMCLinkMap*);
 
   edm::ReusableObjectHolder<HostType> holder_;
+
+  edm::ESGetToken<RPCAMCLinkMap, RPCOMTFLinkMapRcd> es_rpc_omt_l_map_token_;
 };
 
 #endif  // CondTools_RPC_RPCInverseOMTFLinkMapESProducer_h

--- a/CondTools/RPC/plugins/RPCInverseTwinMuxLinkMapESProducer.cc
+++ b/CondTools/RPC/plugins/RPCInverseTwinMuxLinkMapESProducer.cc
@@ -1,5 +1,7 @@
 #include "CondTools/RPC/plugins/RPCInverseTwinMuxLinkMapESProducer.h"
 
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
@@ -10,7 +12,8 @@
 #include "CondFormats/DataRecord/interface/RPCInverseTwinMuxLinkMapRcd.h"
 
 RPCInverseTwinMuxLinkMapESProducer::RPCInverseTwinMuxLinkMapESProducer(edm::ParameterSet const& _config) {
-  setWhatProduced(this);
+  auto cc = setWhatProduced(this);
+  es_rpc_tm_l_map_token_ = cc.consumesFrom<RPCAMCLinkMap, RPCTwinMuxLinkMapRcd>();
 }
 
 void RPCInverseTwinMuxLinkMapESProducer::fillDescriptions(edm::ConfigurationDescriptions& _descs) {
@@ -23,9 +26,7 @@ void RPCInverseTwinMuxLinkMapESProducer::setupRPCTwinMuxLinkMap(RPCTwinMuxLinkMa
   RPCInverseAMCLinkMap::map_type& _inverse_map(inverse_linkmap->getMap());
   _inverse_map.clear();
 
-  edm::ESHandle<RPCAMCLinkMap> _es_map;
-  _rcd.get(_es_map);
-  RPCAMCLinkMap const& _map = *(_es_map.product());
+  RPCAMCLinkMap const& _map = _rcd.get(es_rpc_tm_l_map_token_);
   for (auto const& _link : _map.getMap()) {
     _inverse_map.insert(RPCInverseAMCLinkMap::map_type::value_type(_link.second, _link.first));
   }

--- a/CondTools/RPC/plugins/RPCInverseTwinMuxLinkMapESProducer.h
+++ b/CondTools/RPC/plugins/RPCInverseTwinMuxLinkMapESProducer.h
@@ -5,9 +5,12 @@
 
 #include "FWCore/Framework/interface/ESProducer.h"
 #include "FWCore/Framework/interface/ESProductHost.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Utilities/interface/ESGetToken.h"
 #include "FWCore/Utilities/interface/ReusableObjectHolder.h"
 
 #include "CondFormats/RPCObjects/interface/RPCInverseAMCLinkMap.h"
+#include "CondFormats/RPCObjects/interface/RPCAMCLinkMap.h"
 
 namespace edm {
   class ParameterSet;
@@ -31,6 +34,8 @@ private:
   void setupRPCTwinMuxLinkMap(RPCTwinMuxLinkMapRcd const&, RPCInverseAMCLinkMap*);
 
   edm::ReusableObjectHolder<HostType> holder_;
+
+  edm::ESGetToken<RPCAMCLinkMap, RPCTwinMuxLinkMapRcd> es_rpc_tm_l_map_token_;
 };
 
 #endif  // CondTools_RPC_RPCInverseTwinMuxLinkMapESProducer_h


### PR DESCRIPTION
#### PR description:

This PR is to update the RPC Inversemap ES Producers under the condtools package to use esconsumes. 
The inversemaps are needed during the Digi2Raw step to pack the raw event. Currently they are not used central data processing, but they are needed for the ongoing development and finalizing the packers.
Ping also @jhgoh and @andresib @dilsonjd 

#### PR validation:

Tested with runTheMatrix (2021+ZMM_14TeV_TuneCP5_GenSim+Digi+Reco+HARVEST+ALCA)  without failures

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

