### PR TITLE
Fix CaloTopologyRecord.h location

### DIFF
--- a/Calibration/HcalCalibAlgos/test/HcalHBHEMuonSimAnalyzer.cc
+++ b/Calibration/HcalCalibAlgos/test/HcalHBHEMuonSimAnalyzer.cc
@@ -29,8 +29,8 @@
 
 #include "Geometry/CaloGeometry/interface/CaloGeometry.h"
 #include "Geometry/Records/interface/CaloGeometryRecord.h"
+#include "Geometry/Records/interface/CaloTopologyRecord.h"
 #include "Geometry/CaloGeometry/interface/CaloSubdetectorGeometry.h"
-#include "Geometry/CaloEventSetup/interface/CaloTopologyRecord.h"
 #include "Geometry/CaloTopology/interface/CaloSubdetectorTopology.h"
 #include "Geometry/CaloTopology/interface/HcalTopology.h"
 #include "Geometry/CaloTopology/interface/CaloTopology.h"


### PR DESCRIPTION
#### PR description:

Compilation is failing in Calibration/HcalCalibAlgos in the last IB due to header not found.
Found a header with that name in another location

#### PR validation:

Calibration/HcalCalibAlgos builds

