### PR TITLE
[Backport] Making miniAOD low pt tracks threshold tunable for 10_6_X (#33777)

### DIFF
--- a/PhysicsTools/PatAlgos/plugins/PATLostTracks.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATLostTracks.cc
@@ -56,6 +56,7 @@ namespace pat {
     const double minHits_;
     const double minPixelHits_;
     const double minPtToStoreProps_;
+    const double minPtToStoreLowQualityProps_;
     const int covarianceVersion_;
     const std::vector<int> covariancePackingSchemas_;
     std::vector<reco::TrackBase::TrackQuality> qualsToAutoAccept_;
@@ -86,6 +87,7 @@ pat::PATLostTracks::PATLostTracks(const edm::ParameterSet& iConfig)
       minHits_(iConfig.getParameter<uint32_t>("minHits")),
       minPixelHits_(iConfig.getParameter<uint32_t>("minPixelHits")),
       minPtToStoreProps_(iConfig.getParameter<double>("minPtToStoreProps")),
+      minPtToStoreLowQualityProps_(iConfig.getParameter<double>("minPtToStoreLowQualityProps")),
       covarianceVersion_(iConfig.getParameter<int>("covarianceVersion")),
       covariancePackingSchemas_(iConfig.getParameter<std::vector<int>>("covariancePackingSchemas")),
       muons_(consumes<reco::MuonCollection>(iConfig.getParameter<edm::InputTag>("muons"))),
@@ -306,7 +308,7 @@ void pat::PATLostTracks::addPackedCandidate(std::vector<pat::PackedCandidate>& c
             *trk, covariancePackingSchemas_[1], covarianceVersion_);  // high quality without pixels
       }
     }
-  } else if (!useLegacySetup_ && trk->pt() > 0.5) {
+  } else if (!useLegacySetup_ && trk->pt() > minPtToStoreLowQualityProps_) {
     if (trk->hitPattern().numberOfValidPixelHits() > 0) {
       cands.back().setTrackProperties(
           *trk, covariancePackingSchemas_[2], covarianceVersion_);  // low quality with pixels

--- a/PhysicsTools/PatAlgos/plugins/PATPackedCandidateProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATPackedCandidateProducer.cc
@@ -33,158 +33,123 @@
 //#define CRAZYSORT
 
 namespace pat {
-/// conversion map from quality flags used in PV association and miniAOD one
-const static int qualityMap[8] = {1, 0, 1, 1, 4, 4, 5, 6};
+  /// conversion map from quality flags used in PV association and miniAOD one
+  const static int qualityMap[8] = {1, 0, 1, 1, 4, 4, 5, 6};
 
-class PATPackedCandidateProducer : public edm::global::EDProducer<> {
-public:
-  explicit PATPackedCandidateProducer(const edm::ParameterSet &);
-  ~PATPackedCandidateProducer() override;
+  class PATPackedCandidateProducer : public edm::global::EDProducer<> {
+  public:
+    explicit PATPackedCandidateProducer(const edm::ParameterSet &);
+    ~PATPackedCandidateProducer() override;
 
-  void produce(edm::StreamID, edm::Event &,
-               const edm::EventSetup &) const override;
+    void produce(edm::StreamID, edm::Event &, const edm::EventSetup &) const override;
 
-  // sorting of cands to maximize the zlib compression
-  static bool candsOrdering(pat::PackedCandidate const &i,
-                            pat::PackedCandidate const &j) {
-    if (std::abs(i.charge()) == std::abs(j.charge())) {
-      if (i.charge() != 0) {
-        if (i.hasTrackDetails() and !j.hasTrackDetails())
-          return true;
-        if (!i.hasTrackDetails() and j.hasTrackDetails())
-          return false;
-        if (i.covarianceSchema() > j.covarianceSchema())
-          return true;
-        if (i.covarianceSchema() < j.covarianceSchema())
-          return false;
+    // sorting of cands to maximize the zlib compression
+    static bool candsOrdering(pat::PackedCandidate const &i, pat::PackedCandidate const &j) {
+      if (std::abs(i.charge()) == std::abs(j.charge())) {
+        if (i.charge() != 0) {
+          if (i.hasTrackDetails() and !j.hasTrackDetails())
+            return true;
+          if (!i.hasTrackDetails() and j.hasTrackDetails())
+            return false;
+          if (i.covarianceSchema() > j.covarianceSchema())
+            return true;
+          if (i.covarianceSchema() < j.covarianceSchema())
+            return false;
+        }
+        if (i.vertexRef() == j.vertexRef())
+          return i.eta() > j.eta();
+        else
+          return i.vertexRef().key() < j.vertexRef().key();
       }
-      if (i.vertexRef() == j.vertexRef())
-        return i.eta() > j.eta();
-      else
-        return i.vertexRef().key() < j.vertexRef().key();
+      return std::abs(i.charge()) > std::abs(j.charge());
     }
-    return std::abs(i.charge()) > std::abs(j.charge());
-  }
 
-  template <typename T>
-  static std::vector<size_t> sort_indexes(const std::vector<T> &v) {
-    std::vector<size_t> idx(v.size());
-    for (size_t i = 0; i != idx.size(); ++i)
-      idx[i] = i;
-    std::sort(idx.begin(), idx.end(), [&v](size_t i1, size_t i2) {
-      return candsOrdering(v[i1], v[i2]);
-    });
-    return idx;
-  }
+    template <typename T>
+    static std::vector<size_t> sort_indexes(const std::vector<T> &v) {
+      std::vector<size_t> idx(v.size());
+      for (size_t i = 0; i != idx.size(); ++i)
+        idx[i] = i;
+      std::sort(idx.begin(), idx.end(), [&v](size_t i1, size_t i2) { return candsOrdering(v[i1], v[i2]); });
+      return idx;
+    }
 
-private:
-  // if PuppiSrc && PuppiNoLepSrc are empty, usePuppi is false
-  // otherwise assumes that if they are set, you wanted to use puppi and will
-  // throw an exception if the puppis are not found
-  const bool usePuppi_;
+  private:
+    // if PuppiSrc && PuppiNoLepSrc are empty, usePuppi is false
+    // otherwise assumes that if they are set, you wanted to use puppi and will
+    // throw an exception if the puppis are not found
+    const bool usePuppi_;
 
-  const edm::EDGetTokenT<reco::PFCandidateCollection> Cands_;
-  const edm::EDGetTokenT<reco::VertexCollection> PVs_;
-  const edm::EDGetTokenT<edm::Association<reco::VertexCollection>> PVAsso_;
-  const edm::EDGetTokenT<edm::ValueMap<int>> PVAssoQuality_;
-  const edm::EDGetTokenT<reco::VertexCollection> PVOrigs_;
-  const edm::EDGetTokenT<reco::TrackCollection> TKOrigs_;
-  const edm::EDGetTokenT<edm::ValueMap<float>> PuppiWeight_;
-  const edm::EDGetTokenT<edm::ValueMap<float>> PuppiWeightNoLep_;
-  const edm::EDGetTokenT<edm::ValueMap<reco::CandidatePtr>> PuppiCandsMap_;
-  const edm::EDGetTokenT<std::vector<reco::PFCandidate>> PuppiCands_;
-  const edm::EDGetTokenT<std::vector<reco::PFCandidate>> PuppiCandsNoLep_;
-  std::vector<edm::EDGetTokenT<edm::View<reco::Candidate>>> SVWhiteLists_;
-  const bool storeChargedHadronIsolation_;
-  const edm::EDGetTokenT<edm::ValueMap<bool>> ChargedHadronIsolation_;
+    const edm::EDGetTokenT<reco::PFCandidateCollection> Cands_;
+    const edm::EDGetTokenT<reco::VertexCollection> PVs_;
+    const edm::EDGetTokenT<edm::Association<reco::VertexCollection>> PVAsso_;
+    const edm::EDGetTokenT<edm::ValueMap<int>> PVAssoQuality_;
+    const edm::EDGetTokenT<reco::VertexCollection> PVOrigs_;
+    const edm::EDGetTokenT<reco::TrackCollection> TKOrigs_;
+    const edm::EDGetTokenT<edm::ValueMap<float>> PuppiWeight_;
+    const edm::EDGetTokenT<edm::ValueMap<float>> PuppiWeightNoLep_;
+    const edm::EDGetTokenT<edm::ValueMap<reco::CandidatePtr>> PuppiCandsMap_;
+    const edm::EDGetTokenT<std::vector<reco::PFCandidate>> PuppiCands_;
+    const edm::EDGetTokenT<std::vector<reco::PFCandidate>> PuppiCandsNoLep_;
+    std::vector<edm::EDGetTokenT<edm::View<reco::Candidate>>> SVWhiteLists_;
+    const bool storeChargedHadronIsolation_;
+    const edm::EDGetTokenT<edm::ValueMap<bool>> ChargedHadronIsolation_;
 
-  const double minPtForChargedHadronProperties_;
-  const double minPtForTrackProperties_;
-  const double minPtForLowQualityTrackProperties_;
-  const int covarianceVersion_;
-  const std::vector<int> covariancePackingSchemas_;
+    const double minPtForChargedHadronProperties_;
+    const double minPtForTrackProperties_;
+    const double minPtForLowQualityTrackProperties_;
+    const int covarianceVersion_;
+    const std::vector<int> covariancePackingSchemas_;
 
-  const std::vector<int> pfCandidateTypesForHcalDepth_;
-  const bool storeHcalDepthEndcapOnly_;
+    const std::vector<int> pfCandidateTypesForHcalDepth_;
+    const bool storeHcalDepthEndcapOnly_;
 
-  const bool storeTiming_;
-  const bool storePfGammaEnFr_;
+    const bool storeTiming_;
+    const bool storePfGammaEnFr_;
 
-  // for debugging
-  float calcDxy(float dx, float dy, float phi) const {
-    return -dx * std::sin(phi) + dy * std::cos(phi);
-  }
-  float calcDz(reco::Candidate::Point p, reco::Candidate::Point v,
-               const reco::Candidate &c) const {
-    return p.Z() - v.Z() -
-           ((p.X() - v.X()) * c.px() + (p.Y() - v.Y()) * c.py()) * c.pz() /
-               (c.pt() * c.pt());
-  }
-};
-} // namespace pat
+    // for debugging
+    float calcDxy(float dx, float dy, float phi) const { return -dx * std::sin(phi) + dy * std::cos(phi); }
+    float calcDz(reco::Candidate::Point p, reco::Candidate::Point v, const reco::Candidate &c) const {
+      return p.Z() - v.Z() - ((p.X() - v.X()) * c.px() + (p.Y() - v.Y()) * c.py()) * c.pz() / (c.pt() * c.pt());
+    }
+  };
+}  // namespace pat
 
-pat::PATPackedCandidateProducer::PATPackedCandidateProducer(
-    const edm::ParameterSet &iConfig)
-    : usePuppi_(
-          !iConfig.getParameter<edm::InputTag>("PuppiSrc").encode().empty() ||
-          !iConfig.getParameter<edm::InputTag>("PuppiNoLepSrc")
-               .encode()
-               .empty()),
-      Cands_(consumes<reco::PFCandidateCollection>(
-          iConfig.getParameter<edm::InputTag>("inputCollection"))),
-      PVs_(consumes<reco::VertexCollection>(
-          iConfig.getParameter<edm::InputTag>("inputVertices"))),
-      PVAsso_(consumes<edm::Association<reco::VertexCollection>>(
-          iConfig.getParameter<edm::InputTag>("vertexAssociator"))),
-      PVAssoQuality_(consumes<edm::ValueMap<int>>(
-          iConfig.getParameter<edm::InputTag>("vertexAssociator"))),
-      PVOrigs_(consumes<reco::VertexCollection>(
-          iConfig.getParameter<edm::InputTag>("originalVertices"))),
-      TKOrigs_(consumes<reco::TrackCollection>(
-          iConfig.getParameter<edm::InputTag>("originalTracks"))),
-      PuppiWeight_(usePuppi_
-                       ? consumes<edm::ValueMap<float>>(
-                             iConfig.getParameter<edm::InputTag>("PuppiSrc"))
-                       : edm::EDGetTokenT<edm::ValueMap<float>>()),
-      PuppiWeightNoLep_(
-          usePuppi_ ? consumes<edm::ValueMap<float>>(
-                          iConfig.getParameter<edm::InputTag>("PuppiNoLepSrc"))
-                    : edm::EDGetTokenT<edm::ValueMap<float>>()),
-      PuppiCandsMap_(
-          usePuppi_ ? consumes<edm::ValueMap<reco::CandidatePtr>>(
-                          iConfig.getParameter<edm::InputTag>("PuppiSrc"))
-                    : edm::EDGetTokenT<edm::ValueMap<reco::CandidatePtr>>()),
-      PuppiCands_(usePuppi_
-                      ? consumes<std::vector<reco::PFCandidate>>(
-                            iConfig.getParameter<edm::InputTag>("PuppiSrc"))
-                      : edm::EDGetTokenT<std::vector<reco::PFCandidate>>()),
+pat::PATPackedCandidateProducer::PATPackedCandidateProducer(const edm::ParameterSet &iConfig)
+    : usePuppi_(!iConfig.getParameter<edm::InputTag>("PuppiSrc").encode().empty() ||
+                !iConfig.getParameter<edm::InputTag>("PuppiNoLepSrc").encode().empty()),
+      Cands_(consumes<reco::PFCandidateCollection>(iConfig.getParameter<edm::InputTag>("inputCollection"))),
+      PVs_(consumes<reco::VertexCollection>(iConfig.getParameter<edm::InputTag>("inputVertices"))),
+      PVAsso_(
+          consumes<edm::Association<reco::VertexCollection>>(iConfig.getParameter<edm::InputTag>("vertexAssociator"))),
+      PVAssoQuality_(consumes<edm::ValueMap<int>>(iConfig.getParameter<edm::InputTag>("vertexAssociator"))),
+      PVOrigs_(consumes<reco::VertexCollection>(iConfig.getParameter<edm::InputTag>("originalVertices"))),
+      TKOrigs_(consumes<reco::TrackCollection>(iConfig.getParameter<edm::InputTag>("originalTracks"))),
+      PuppiWeight_(usePuppi_ ? consumes<edm::ValueMap<float>>(iConfig.getParameter<edm::InputTag>("PuppiSrc"))
+                             : edm::EDGetTokenT<edm::ValueMap<float>>()),
+      PuppiWeightNoLep_(usePuppi_ ? consumes<edm::ValueMap<float>>(iConfig.getParameter<edm::InputTag>("PuppiNoLepSrc"))
+                                  : edm::EDGetTokenT<edm::ValueMap<float>>()),
+      PuppiCandsMap_(usePuppi_
+                         ? consumes<edm::ValueMap<reco::CandidatePtr>>(iConfig.getParameter<edm::InputTag>("PuppiSrc"))
+                         : edm::EDGetTokenT<edm::ValueMap<reco::CandidatePtr>>()),
+      PuppiCands_(usePuppi_ ? consumes<std::vector<reco::PFCandidate>>(iConfig.getParameter<edm::InputTag>("PuppiSrc"))
+                            : edm::EDGetTokenT<std::vector<reco::PFCandidate>>()),
       PuppiCandsNoLep_(
-          usePuppi_ ? consumes<std::vector<reco::PFCandidate>>(
-                          iConfig.getParameter<edm::InputTag>("PuppiNoLepSrc"))
+          usePuppi_ ? consumes<std::vector<reco::PFCandidate>>(iConfig.getParameter<edm::InputTag>("PuppiNoLepSrc"))
                     : edm::EDGetTokenT<std::vector<reco::PFCandidate>>()),
-      storeChargedHadronIsolation_(
-          !iConfig.getParameter<edm::InputTag>("chargedHadronIsolation")
-               .encode()
-               .empty()),
-      ChargedHadronIsolation_(consumes<edm::ValueMap<bool>>(
-          iConfig.getParameter<edm::InputTag>("chargedHadronIsolation"))),
-      minPtForChargedHadronProperties_(
-          iConfig.getParameter<double>("minPtForChargedHadronProperties")),
-      minPtForTrackProperties_(
-          iConfig.getParameter<double>("minPtForTrackProperties")),
+      storeChargedHadronIsolation_(!iConfig.getParameter<edm::InputTag>("chargedHadronIsolation").encode().empty()),
+      ChargedHadronIsolation_(
+          consumes<edm::ValueMap<bool>>(iConfig.getParameter<edm::InputTag>("chargedHadronIsolation"))),
+      minPtForChargedHadronProperties_(iConfig.getParameter<double>("minPtForChargedHadronProperties")),
+      minPtForTrackProperties_(iConfig.getParameter<double>("minPtForTrackProperties")),
       minPtForLowQualityTrackProperties_(iConfig.getParameter<double>("minPtForLowQualityTrackProperties")),
       covarianceVersion_(iConfig.getParameter<int>("covarianceVersion")),
-      covariancePackingSchemas_(
-          iConfig.getParameter<std::vector<int>>("covariancePackingSchemas")),
-      pfCandidateTypesForHcalDepth_(iConfig.getParameter<std::vector<int>>(
-          "pfCandidateTypesForHcalDepth")),
-      storeHcalDepthEndcapOnly_(
-          iConfig.getParameter<bool>("storeHcalDepthEndcapOnly")),
+      covariancePackingSchemas_(iConfig.getParameter<std::vector<int>>("covariancePackingSchemas")),
+      pfCandidateTypesForHcalDepth_(iConfig.getParameter<std::vector<int>>("pfCandidateTypesForHcalDepth")),
+      storeHcalDepthEndcapOnly_(iConfig.getParameter<bool>("storeHcalDepthEndcapOnly")),
       storeTiming_(iConfig.getParameter<bool>("storeTiming")),
       storePfGammaEnFr_(iConfig.getParameter<bool>("storePfGammaEnFractions")) {
   std::vector<edm::InputTag> sv_tags =
-      iConfig.getParameter<std::vector<edm::InputTag>>(
-          "secondaryVerticesForWhiteList");
+      iConfig.getParameter<std::vector<edm::InputTag>>("secondaryVerticesForWhiteList");
   for (const auto &itag : sv_tags) {
     SVWhiteLists_.push_back(consumes<edm::View<reco::Candidate>>(itag));
   }
@@ -194,14 +159,12 @@ pat::PATPackedCandidateProducer::PATPackedCandidateProducer(
   produces<edm::Association<reco::PFCandidateCollection>>();
 
   if (not pfCandidateTypesForHcalDepth_.empty())
-    produces<edm::ValueMap<pat::HcalDepthEnergyFractions>>(
-        "hcalDepthEnergyFractions");
+    produces<edm::ValueMap<pat::HcalDepthEnergyFractions>>("hcalDepthEnergyFractions");
 }
 
 pat::PATPackedCandidateProducer::~PATPackedCandidateProducer() {}
 
-void pat::PATPackedCandidateProducer::produce(
-    edm::StreamID, edm::Event &iEvent, const edm::EventSetup &iSetup) const {
+void pat::PATPackedCandidateProducer::produce(edm::StreamID, edm::Event &iEvent, const edm::EventSetup &iSetup) const {
   edm::Handle<reco::PFCandidateCollection> cands;
   iEvent.getByToken(Cands_, cands);
 
@@ -230,8 +193,7 @@ void pat::PATPackedCandidateProducer::produce(
   iEvent.getByToken(PVAsso_, assoHandle);
   edm::Handle<edm::ValueMap<int>> assoQualityHandle;
   iEvent.getByToken(PVAssoQuality_, assoQualityHandle);
-  const edm::Association<reco::VertexCollection> &associatedPV =
-      *(assoHandle.product());
+  const edm::Association<reco::VertexCollection> &associatedPV = *(assoHandle.product());
   const edm::ValueMap<int> &associationQuality = *(assoQualityHandle.product());
 
   edm::Handle<edm::ValueMap<bool>> chargedHadronIsolationHandle;
@@ -243,22 +205,17 @@ void pat::PATPackedCandidateProducer::produce(
   for (auto itoken : SVWhiteLists_) {
     edm::Handle<edm::View<reco::Candidate>> svWhiteListHandle;
     iEvent.getByToken(itoken, svWhiteListHandle);
-    const edm::View<reco::Candidate> &svWhiteList =
-        *(svWhiteListHandle.product());
+    const edm::View<reco::Candidate> &svWhiteList = *(svWhiteListHandle.product());
     for (unsigned int i = 0; i < svWhiteList.size(); i++) {
       // Whitelist via Ptrs
-      for (unsigned int j = 0; j < svWhiteList[i].numberOfSourceCandidatePtrs();
-           j++) {
-        const edm::Ptr<reco::Candidate> &c =
-            svWhiteList[i].sourceCandidatePtr(j);
+      for (unsigned int j = 0; j < svWhiteList[i].numberOfSourceCandidatePtrs(); j++) {
+        const edm::Ptr<reco::Candidate> &c = svWhiteList[i].sourceCandidatePtr(j);
         if (c.id() == cands.id())
           whiteList.insert(c.key());
       }
       // Whitelist via RecoCharged
-      for (auto dau = svWhiteList[i].begin(); dau != svWhiteList[i].end();
-           dau++) {
-        const reco::RecoChargedCandidate *chCand =
-            dynamic_cast<const reco::RecoChargedCandidate *>(&(*dau));
+      for (auto dau = svWhiteList[i].begin(); dau != svWhiteList[i].end(); dau++) {
+        const reco::RecoChargedCandidate *chCand = dynamic_cast<const reco::RecoChargedCandidate *>(&(*dau));
         if (chCand != nullptr) {
           whiteListTk.insert(chCand->track());
         }
@@ -287,8 +244,7 @@ void pat::PATPackedCandidateProducer::produce(
   for (unsigned int ic = 0, nc = cands->size(); ic < nc; ++ic) {
     const reco::PFCandidate &cand = (*cands)[ic];
     const reco::Track *ctrack = nullptr;
-    if ((abs(cand.pdgId()) == 11 || cand.pdgId() == 22) &&
-        cand.gsfTrackRef().isNonnull()) {
+    if ((abs(cand.pdgId()) == 11 || cand.pdgId() == 22) && cand.gsfTrackRef().isNonnull()) {
       ctrack = &*cand.gsfTrackRef();
     } else if (cand.trackRef().isNonnull()) {
       ctrack = &*cand.trackRef();
@@ -305,15 +261,11 @@ void pat::PATPackedCandidateProducer::produce(
       }
       PV = reco::VertexRef(PVs, pvi);
       math::XYZPoint vtx = cand.vertex();
-      pat::PackedCandidate::LostInnerHits lostHits =
-          pat::PackedCandidate::noLostInnerHits;
-      const reco::VertexRef &PVOrig =
-          associatedPV[reco::CandidatePtr(cands, ic)];
+      pat::PackedCandidate::LostInnerHits lostHits = pat::PackedCandidate::noLostInnerHits;
+      const reco::VertexRef &PVOrig = associatedPV[reco::CandidatePtr(cands, ic)];
       if (PVOrig.isNonnull())
-        PV = reco::VertexRef(
-            PVs,
-            PVOrig
-                .key()); // WARNING: assume the PV slimmer is keeping same order
+        PV = reco::VertexRef(PVs,
+                             PVOrig.key());  // WARNING: assume the PV slimmer is keeping same order
       int quality = associationQuality[reco::CandidatePtr(cands, ic)];
       //          if ((size_t)pvi!=PVOrig.key()) std::cout << "not closest in Z"
       //          << pvi << " " << PVOrig.key() << " " << cand.pt() << " " <<
@@ -327,72 +279,59 @@ void pat::PATPackedCandidateProducer::produce(
       float etaAtVtx = ctrack->eta();
       float phiAtVtx = ctrack->phi();
 
-      int nlost = ctrack->hitPattern().numberOfLostHits(
-          reco::HitPattern::MISSING_INNER_HITS);
+      int nlost = ctrack->hitPattern().numberOfLostHits(reco::HitPattern::MISSING_INNER_HITS);
       if (nlost == 0) {
-        if (ctrack->hitPattern().hasValidHitInPixelLayer(
-                PixelSubdetector::SubDetector::PixelBarrel, 1)) {
+        if (ctrack->hitPattern().hasValidHitInPixelLayer(PixelSubdetector::SubDetector::PixelBarrel, 1)) {
           lostHits = pat::PackedCandidate::validHitInFirstPixelBarrelLayer;
         }
       } else {
-        lostHits = (nlost == 1 ? pat::PackedCandidate::oneLostInnerHit
-                               : pat::PackedCandidate::moreLostInnerHits);
+        lostHits = (nlost == 1 ? pat::PackedCandidate::oneLostInnerHit : pat::PackedCandidate::moreLostInnerHits);
       }
 
-      outPtrP->push_back(pat::PackedCandidate(cand.polarP4(), vtx, ptTrk,
-                                              etaAtVtx, phiAtVtx, cand.pdgId(),
-                                              PVRefProd, PV.key()));
-      outPtrP->back().setAssociationQuality(
-          pat::PackedCandidate::PVAssociationQuality(qualityMap[quality]));
+      outPtrP->push_back(
+          pat::PackedCandidate(cand.polarP4(), vtx, ptTrk, etaAtVtx, phiAtVtx, cand.pdgId(), PVRefProd, PV.key()));
+      outPtrP->back().setAssociationQuality(pat::PackedCandidate::PVAssociationQuality(qualityMap[quality]));
       outPtrP->back().setCovarianceVersion(covarianceVersion_);
-      if (cand.trackRef().isNonnull() && PVOrig.isNonnull() &&
-          PVOrig->trackWeight(cand.trackRef()) > 0.5 && quality == 7) {
-        outPtrP->back().setAssociationQuality(
-            pat::PackedCandidate::UsedInFitTight);
+      if (cand.trackRef().isNonnull() && PVOrig.isNonnull() && PVOrig->trackWeight(cand.trackRef()) > 0.5 &&
+          quality == 7) {
+        outPtrP->back().setAssociationQuality(pat::PackedCandidate::UsedInFitTight);
       }
       // properties of the best track
       outPtrP->back().setLostInnerHits(lostHits);
-      if (outPtrP->back().pt() > minPtForTrackProperties_ ||
-          outPtrP->back().ptTrk() > minPtForTrackProperties_ ||
+      if (outPtrP->back().pt() > minPtForTrackProperties_ || outPtrP->back().ptTrk() > minPtForTrackProperties_ ||
           whiteList.find(ic) != whiteList.end() ||
-          (cand.trackRef().isNonnull() &&
-           whiteListTk.find(cand.trackRef()) != whiteListTk.end())) {
-        outPtrP->back().setFirstHit(ctrack->hitPattern().getHitPattern(
-            reco::HitPattern::TRACK_HITS, 0));
+          (cand.trackRef().isNonnull() && whiteListTk.find(cand.trackRef()) != whiteListTk.end())) {
+        outPtrP->back().setFirstHit(ctrack->hitPattern().getHitPattern(reco::HitPattern::TRACK_HITS, 0));
         if (abs(outPtrP->back().pdgId()) == 22) {
-          outPtrP->back().setTrackProperties(
-              *ctrack, covariancePackingSchemas_[4], covarianceVersion_);
+          outPtrP->back().setTrackProperties(*ctrack, covariancePackingSchemas_[4], covarianceVersion_);
         } else {
           if (ctrack->hitPattern().numberOfValidPixelHits() > 0) {
-            outPtrP->back().setTrackProperties(
-                *ctrack, covariancePackingSchemas_[0],
-                covarianceVersion_); // high quality
+            outPtrP->back().setTrackProperties(*ctrack,
+                                               covariancePackingSchemas_[0],
+                                               covarianceVersion_);  // high quality
           } else {
-            outPtrP->back().setTrackProperties(
-                *ctrack, covariancePackingSchemas_[1], covarianceVersion_);
+            outPtrP->back().setTrackProperties(*ctrack, covariancePackingSchemas_[1], covarianceVersion_);
           }
         }
         // outPtrP->back().setTrackProperties(*ctrack,tsos.curvilinearError());
       } else {
         if (outPtrP->back().pt() > minPtForLowQualityTrackProperties_) {
           if (ctrack->hitPattern().numberOfValidPixelHits() > 0)
-            outPtrP->back().setTrackProperties(
-                *ctrack, covariancePackingSchemas_[2],
-                covarianceVersion_); // low quality, with pixels
+            outPtrP->back().setTrackProperties(*ctrack,
+                                               covariancePackingSchemas_[2],
+                                               covarianceVersion_);  // low quality, with pixels
           else
-            outPtrP->back().setTrackProperties(
-                *ctrack, covariancePackingSchemas_[3],
-                covarianceVersion_); // low quality, without pixels
+            outPtrP->back().setTrackProperties(*ctrack,
+                                               covariancePackingSchemas_[3],
+                                               covarianceVersion_);  // low quality, without pixels
         }
       }
 
       // these things are always for the CKF track
-      outPtrP->back().setTrackHighPurity(
-          cand.trackRef().isNonnull() &&
-          cand.trackRef()->quality(reco::Track::highPurity));
+      outPtrP->back().setTrackHighPurity(cand.trackRef().isNonnull() &&
+                                         cand.trackRef()->quality(reco::Track::highPurity));
       if (cand.muonRef().isNonnull()) {
-        outPtrP->back().setMuonID(cand.muonRef()->isStandAloneMuon(),
-                                  cand.muonRef()->isGlobalMuon());
+        outPtrP->back().setMuonID(cand.muonRef()->isStandAloneMuon(), cand.muonRef()->isGlobalMuon());
       }
     } else {
       if (!PVs->empty()) {
@@ -400,44 +339,35 @@ void pat::PATPackedCandidateProducer::produce(
         PVpos = PV->position();
       }
 
-      outPtrP->push_back(
-          pat::PackedCandidate(cand.polarP4(), PVpos, cand.pt(), cand.eta(),
-                               cand.phi(), cand.pdgId(), PVRefProd, PV.key()));
+      outPtrP->push_back(pat::PackedCandidate(
+          cand.polarP4(), PVpos, cand.pt(), cand.eta(), cand.phi(), cand.pdgId(), PVRefProd, PV.key()));
       outPtrP->back().setAssociationQuality(
-          pat::PackedCandidate::PVAssociationQuality(
-              pat::PackedCandidate::UsedInFitTight));
+          pat::PackedCandidate::PVAssociationQuality(pat::PackedCandidate::UsedInFitTight));
     }
 
     // neutrals and isolated charged hadrons
 
     bool isIsolatedChargedHadron = false;
     if (storeChargedHadronIsolation_) {
-      const edm::ValueMap<bool> &chargedHadronIsolation =
-          *(chargedHadronIsolationHandle.product());
+      const edm::ValueMap<bool> &chargedHadronIsolation = *(chargedHadronIsolationHandle.product());
       isIsolatedChargedHadron =
-          ((cand.pt() > minPtForChargedHadronProperties_) &&
-           (chargedHadronIsolation[reco::PFCandidateRef(cands, ic)]));
+          ((cand.pt() > minPtForChargedHadronProperties_) && (chargedHadronIsolation[reco::PFCandidateRef(cands, ic)]));
       outPtrP->back().setIsIsolatedChargedHadron(isIsolatedChargedHadron);
     }
 
     if (abs(cand.pdgId()) == 1 || abs(cand.pdgId()) == 130) {
-      outPtrP->back().setHcalFraction(cand.hcalEnergy() /
-                                      (cand.ecalEnergy() + cand.hcalEnergy()));
+      outPtrP->back().setHcalFraction(cand.hcalEnergy() / (cand.ecalEnergy() + cand.hcalEnergy()));
     } else if ((cand.charge() || (storePfGammaEnFr_ && cand.pdgId() == 22)) && cand.pt() > 0.5) {
-      outPtrP->back().setHcalFraction(cand.hcalEnergy() /
-                                      (cand.ecalEnergy() + cand.hcalEnergy()));
-      outPtrP->back().setCaloFraction((cand.hcalEnergy() + cand.ecalEnergy()) /
-                                      cand.energy());
+      outPtrP->back().setHcalFraction(cand.hcalEnergy() / (cand.ecalEnergy() + cand.hcalEnergy()));
+      outPtrP->back().setCaloFraction((cand.hcalEnergy() + cand.ecalEnergy()) / cand.energy());
     } else {
       outPtrP->back().setHcalFraction(0);
       outPtrP->back().setCaloFraction(0);
     }
 
     if (isIsolatedChargedHadron) {
-      outPtrP->back().setRawCaloFraction(
-          (cand.rawEcalEnergy() + cand.rawHcalEnergy()) / cand.energy());
-      outPtrP->back().setRawHcalFraction(
-          cand.rawHcalEnergy() / (cand.rawEcalEnergy() + cand.rawHcalEnergy()));
+      outPtrP->back().setRawCaloFraction((cand.rawEcalEnergy() + cand.rawHcalEnergy()) / cand.energy());
+      outPtrP->back().setRawHcalFraction(cand.rawHcalEnergy() / (cand.rawEcalEnergy() + cand.rawHcalEnergy()));
     } else {
       outPtrP->back().setRawCaloFraction(0);
       outPtrP->back().setRawHcalFraction(0);
@@ -448,17 +378,14 @@ void pat::PATPackedCandidateProducer::produce(
     pat::HcalDepthEnergyFractions hcalDepthEFrac(dummyVector);
 
     // storing HcalDepthEnergyFraction information
-    if (std::find(pfCandidateTypesForHcalDepth_.begin(),
-                  pfCandidateTypesForHcalDepth_.end(),
-                  abs(cand.pdgId())) != pfCandidateTypesForHcalDepth_.end()) {
+    if (std::find(pfCandidateTypesForHcalDepth_.begin(), pfCandidateTypesForHcalDepth_.end(), abs(cand.pdgId())) !=
+        pfCandidateTypesForHcalDepth_.end()) {
       if (!storeHcalDepthEndcapOnly_ ||
-          fabs(outPtrP->back().eta()) >
-              1.3) { // storeHcalDepthEndcapOnly_==false -> store all eta of
-                     // selected PF types, if true, only |eta|>1.3 of selected
-                     // PF types will be stored
-        std::vector<float> hcalDepthEnergyFractionTmp(
-            cand.hcalDepthEnergyFractions().begin(),
-            cand.hcalDepthEnergyFractions().end());
+          fabs(outPtrP->back().eta()) > 1.3) {  // storeHcalDepthEndcapOnly_==false -> store all eta of
+                                                // selected PF types, if true, only |eta|>1.3 of selected
+                                                // PF types will be stored
+        std::vector<float> hcalDepthEnergyFractionTmp(cand.hcalDepthEnergyFractions().begin(),
+                                                      cand.hcalDepthEnergyFractions().end());
         hcalDepthEFrac.reset(hcalDepthEnergyFractionTmp);
       }
     }
@@ -467,8 +394,7 @@ void pat::PATPackedCandidateProducer::produce(
     // specifically this is the PFLinker requirements to apply the e/gamma
     // regression
     if (cand.particleId() == reco::PFCandidate::e ||
-        (cand.particleId() == reco::PFCandidate::gamma &&
-         cand.mva_nothing_gamma() > 0.)) {
+        (cand.particleId() == reco::PFCandidate::gamma && cand.mva_nothing_gamma() > 0.)) {
       outPtrP->back().setGoodEgamma();
     }
 
@@ -490,8 +416,7 @@ void pat::PATPackedCandidateProducer::produce(
           if (puppiCandsNoLepPtrs[ipcnl] == pkrefPtr) {
             foundNoLep = true;
             puppiWeightNoLepVal =
-                puppiCandsNoLep->at(ipcnl).pt() /
-                cand.pt(); // a hack for now, should use the value map
+                puppiCandsNoLep->at(ipcnl).pt() / cand.pt();  // a hack for now, should use the value map
             break;
           }
         }
@@ -508,7 +433,7 @@ void pat::PATPackedCandidateProducer::produce(
       outPtrP->back().setTime(cand.time(), cand.timeError());
     }
 
-    mapping[ic] = ic; // trivial at the moment!
+    mapping[ic] = ic;  // trivial at the moment!
     if (cand.trackRef().isNonnull() && cand.trackRef().id() == TKOrigs.id()) {
       mappingTk[cand.trackRef().key()] = ic;
     }
@@ -521,8 +446,7 @@ void pat::PATPackedCandidateProducer::produce(
     outPtrPSorted->push_back((*outPtrP)[order[i]]);
     reverseOrder[order[i]] = i;
     mappingReverse[order[i]] = i;
-    hcalDepthEnergyFractions_Ordered.push_back(
-        hcalDepthEnergyFractions[order[i]]);
+    hcalDepthEnergyFractions_Ordered.push_back(hcalDepthEnergyFractions[order[i]]);
   }
 
   // Fix track association for sorted candidates
@@ -535,14 +459,11 @@ void pat::PATPackedCandidateProducer::produce(
     mappingPuppi[i] = reverseOrder[mappingPuppi[i]];
   }
 
-  edm::OrphanHandle<pat::PackedCandidateCollection> oh =
-      iEvent.put(std::move(outPtrPSorted));
+  edm::OrphanHandle<pat::PackedCandidateCollection> oh = iEvent.put(std::move(outPtrPSorted));
 
   // now build the two maps
-  auto pf2pc =
-      std::make_unique<edm::Association<pat::PackedCandidateCollection>>(oh);
-  auto pc2pf =
-      std::make_unique<edm::Association<reco::PFCandidateCollection>>(cands);
+  auto pf2pc = std::make_unique<edm::Association<pat::PackedCandidateCollection>>(oh);
+  auto pc2pf = std::make_unique<edm::Association<reco::PFCandidateCollection>>(cands);
   edm::Association<pat::PackedCandidateCollection>::Filler pf2pcFiller(*pf2pc);
   edm::Association<reco::PFCandidateCollection>::Filler pc2pfFiller(*pc2pf);
   pf2pcFiller.insert(cands, mappingReverse.begin(), mappingReverse.end());
@@ -558,18 +479,14 @@ void pat::PATPackedCandidateProducer::produce(
   iEvent.put(std::move(pc2pf));
 
   // HCAL depth energy fraction additions using ValueMap
-  auto hcalDepthEnergyFractionsV =
-      std::make_unique<edm::ValueMap<HcalDepthEnergyFractions>>();
-  edm::ValueMap<HcalDepthEnergyFractions>::Filler
-      fillerHcalDepthEnergyFractions(*hcalDepthEnergyFractionsV);
+  auto hcalDepthEnergyFractionsV = std::make_unique<edm::ValueMap<HcalDepthEnergyFractions>>();
+  edm::ValueMap<HcalDepthEnergyFractions>::Filler fillerHcalDepthEnergyFractions(*hcalDepthEnergyFractionsV);
   fillerHcalDepthEnergyFractions.insert(
-      cands, hcalDepthEnergyFractions_Ordered.begin(),
-      hcalDepthEnergyFractions_Ordered.end());
+      cands, hcalDepthEnergyFractions_Ordered.begin(), hcalDepthEnergyFractions_Ordered.end());
   fillerHcalDepthEnergyFractions.fill();
 
   if (not pfCandidateTypesForHcalDepth_.empty())
-    iEvent.put(std::move(hcalDepthEnergyFractionsV),
-               "hcalDepthEnergyFractions");
+    iEvent.put(std::move(hcalDepthEnergyFractionsV), "hcalDepthEnergyFractions");
 }
 
 using pat::PATPackedCandidateProducer;

--- a/PhysicsTools/PatAlgos/plugins/PATPackedCandidateProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATPackedCandidateProducer.cc
@@ -100,6 +100,7 @@ private:
 
   const double minPtForChargedHadronProperties_;
   const double minPtForTrackProperties_;
+  const double minPtForLowQualityTrackProperties_;
   const int covarianceVersion_;
   const std::vector<int> covariancePackingSchemas_;
 
@@ -171,6 +172,7 @@ pat::PATPackedCandidateProducer::PATPackedCandidateProducer(
           iConfig.getParameter<double>("minPtForChargedHadronProperties")),
       minPtForTrackProperties_(
           iConfig.getParameter<double>("minPtForTrackProperties")),
+      minPtForLowQualityTrackProperties_(iConfig.getParameter<double>("minPtForLowQualityTrackProperties")),
       covarianceVersion_(iConfig.getParameter<int>("covarianceVersion")),
       covariancePackingSchemas_(
           iConfig.getParameter<std::vector<int>>("covariancePackingSchemas")),
@@ -372,7 +374,7 @@ void pat::PATPackedCandidateProducer::produce(
         }
         // outPtrP->back().setTrackProperties(*ctrack,tsos.curvilinearError());
       } else {
-        if (outPtrP->back().pt() > 0.5) {
+        if (outPtrP->back().pt() > minPtForLowQualityTrackProperties_) {
           if (ctrack->hitPattern().numberOfValidPixelHits() > 0)
             outPtrP->back().setTrackProperties(
                 *ctrack, covariancePackingSchemas_[2],

--- a/PhysicsTools/PatAlgos/python/slimming/lostTracks_cfi.py
+++ b/PhysicsTools/PatAlgos/python/slimming/lostTracks_cfi.py
@@ -19,6 +19,7 @@ lostTracks = cms.EDProducer("PATLostTracks",
     covariancePackingSchemas = packedPFCandidates.covariancePackingSchemas,
     qualsToAutoAccept = cms.vstring("highPurity"),
     minPtToStoreProps = cms.double(0.95),
+    minPtToStoreLowQualityProps = cms.double(0.0),
     passThroughCut = cms.string("0"),
     allowMuonId = cms.bool(False),
     pvAssignment = primaryVertexAssociation.assignment,
@@ -33,4 +34,3 @@ run2_miniAOD_UL.toModify(lostTracks, passThroughCut="pt>2", allowMuonId=True, us
 
 from Configuration.Eras.Modifier_bParking_cff import bParking
 bParking.toModify(lostTracks, fillLostInnerHits = True)
-

--- a/PhysicsTools/PatAlgos/python/slimming/lostTracks_cfi.py
+++ b/PhysicsTools/PatAlgos/python/slimming/lostTracks_cfi.py
@@ -19,7 +19,7 @@ lostTracks = cms.EDProducer("PATLostTracks",
     covariancePackingSchemas = packedPFCandidates.covariancePackingSchemas,
     qualsToAutoAccept = cms.vstring("highPurity"),
     minPtToStoreProps = cms.double(0.95),
-    minPtToStoreLowQualityProps = cms.double(0.0),
+    minPtToStoreLowQualityProps = cms.double(0.5),
     passThroughCut = cms.string("0"),
     allowMuonId = cms.bool(False),
     pvAssignment = primaryVertexAssociation.assignment,
@@ -34,3 +34,6 @@ run2_miniAOD_UL.toModify(lostTracks, passThroughCut="pt>2", allowMuonId=True, us
 
 from Configuration.Eras.Modifier_bParking_cff import bParking
 bParking.toModify(lostTracks, fillLostInnerHits = True)
+
+from Configuration.Eras.Modifier_run2_miniAOD_devel_cff import run2_miniAOD_devel
+(bParking | run2_miniAOD_devel).toModify(lostTracks, minPtToStoreLowQualityProps = 0.0)

--- a/PhysicsTools/PatAlgos/python/slimming/packedPFCandidates_cfi.py
+++ b/PhysicsTools/PatAlgos/python/slimming/packedPFCandidates_cfi.py
@@ -7,7 +7,7 @@ packedPFCandidates = cms.EDProducer("PATPackedCandidateProducer",
     originalTracks = cms.InputTag("generalTracks"),
     vertexAssociator = cms.InputTag("primaryVertexAssociation","original"),
     PuppiSrc = cms.InputTag("puppi"),
-    PuppiNoLepSrc = cms.InputTag("puppiNoLep"),    
+    PuppiNoLepSrc = cms.InputTag("puppiNoLep"),
     chargedHadronIsolation = cms.InputTag("chargedHadronPFTrackIsolation"),
     minPtForChargedHadronProperties = cms.double(3.0),
     secondaryVerticesForWhiteList = cms.VInputTag(
@@ -15,13 +15,14 @@ packedPFCandidates = cms.EDProducer("PATPackedCandidateProducer",
       cms.InputTag("inclusiveCandidateSecondaryVerticesCvsL"),
       cms.InputTag("generalV0Candidates","Kshort"),
       cms.InputTag("generalV0Candidates","Lambda"),
-      ),      
+      ),
     minPtForTrackProperties = cms.double(0.95),
-    covarianceVersion = cms.int32(0), #so far: 0 is Phase0, 1 is Phase1   
-#    covariancePackingSchemas = cms.vint32(1,257,513,769,0),  # a cheaper schema in kb/ev 
+    minPtForLowQualityTrackProperties = cms.double(0.0),
+    covarianceVersion = cms.int32(0), #so far: 0 is Phase0, 1 is Phase1
+#    covariancePackingSchemas = cms.vint32(1,257,513,769,0),  # a cheaper schema in kb/ev
     covariancePackingSchemas = cms.vint32(8,264,520,776,0),   # more accurate schema +0.6kb/ev
     pfCandidateTypesForHcalDepth = cms.vint32(),
-    storeHcalDepthEndcapOnly = cms.bool(False), # switch to store info only for endcap 
+    storeHcalDepthEndcapOnly = cms.bool(False), # switch to store info only for endcap
     storeTiming = cms.bool(False),
     storePfGammaEnFractions = cms.bool(False)
 )
@@ -41,7 +42,7 @@ run2_HCAL_2018.toModify(packedPFCandidates,
 
 from Configuration.Eras.Modifier_run3_common_cff import run3_common
 run3_common.toModify(packedPFCandidates,
-    pfCandidateTypesForHcalDepth = [], # For now, no PF cand type is considered for addition of Hcal depth energy frac 
+    pfCandidateTypesForHcalDepth = [], # For now, no PF cand type is considered for addition of Hcal depth energy frac
     storeHcalDepthEndcapOnly = False
 )
 

--- a/PhysicsTools/PatAlgos/python/slimming/packedPFCandidates_cfi.py
+++ b/PhysicsTools/PatAlgos/python/slimming/packedPFCandidates_cfi.py
@@ -17,7 +17,7 @@ packedPFCandidates = cms.EDProducer("PATPackedCandidateProducer",
       cms.InputTag("generalV0Candidates","Lambda"),
       ),
     minPtForTrackProperties = cms.double(0.95),
-    minPtForLowQualityTrackProperties = cms.double(0.0),
+    minPtForLowQualityTrackProperties = cms.double(0.5),
     covarianceVersion = cms.int32(0), #so far: 0 is Phase0, 1 is Phase1
 #    covariancePackingSchemas = cms.vint32(1,257,513,769,0),  # a cheaper schema in kb/ev
     covariancePackingSchemas = cms.vint32(8,264,520,776,0),   # more accurate schema +0.6kb/ev
@@ -51,3 +51,7 @@ phase2_timing.toModify(packedPFCandidates, storeTiming = True)
 
 from Configuration.ProcessModifiers.run2_miniAOD_UL_cff import run2_miniAOD_UL
 run2_miniAOD_UL.toModify(packedPFCandidates, storePfGammaEnFractions = True)
+
+from Configuration.Eras.Modifier_run2_miniAOD_devel_cff import run2_miniAOD_devel
+from Configuration.Eras.Modifier_bParking_cff import bParking
+(bParking | run2_miniAOD_devel).toModify(packedPFCandidates, minPtForLowQualityTrackProperties = 0.0)


### PR DESCRIPTION
#### PR description:

This is a backport to 10_6_X of #33777 

#### PR validation:

All the tests running

#### Further references

BPH Jamboree December 2020 [here](https://indico.cern.ch/event/979184/contributions/4148171/attachments/2163278/3650677/MiniAOD_Run3_Adriano_JamboreeDic2020.pdf)

xPOG Meeting February 2021 [here](https://indico.cern.ch/event/994581/contributions/4181429/attachments/2196037/3712976/xPOG%20Run3%20MiniAOD%20BPH%20Feb2021.pdf)

Further reference [here](https://github.com/AdrianoDee/miniaodstudies/blob/main/README.md)

For a complete documentation, trk4bph meetings: [1](https://indico.cern.ch/event/983890/), [2](https://indico.cern.ch/event/975219/), [3](https://indico.cern.ch/event/968995/) , [4](https://indico.cern.ch/event/964780/), [5](https://indico.cern.ch/event/963424/), [6](https://indico.cern.ch/event/955820/)
