### PR TITLE
Backport of  #33776: Adding the correction structure to all electrons

### DIFF
--- a/PhysicsTools/PatAlgos/python/slimming/slimmedElectrons_cfi.py
+++ b/PhysicsTools/PatAlgos/python/slimming/slimmedElectrons_cfi.py
@@ -24,3 +24,5 @@ slimmedElectrons = cms.EDProducer("PATElectronSlimmer",
    modifierConfig = cms.PSet( modifications = cms.VPSet() )
 )
 
+from Configuration.Eras.Modifier_bParking_cff import bParking
+bParking.toModify(slimmedElectrons,dropCorrections="0")


### PR DESCRIPTION
This is just a backport of #33776 which adds the correction structure to all the electrons.
Tested on WFs: 136.898 and 1325.517

@bainbrid 