### PR TITLE
add Psi2S and BuToJPsiPrimePhi

### DIFF
--- a/Configuration/Generator/python/BuToJPsiPrimePhiToJPsiPiKK_14TeV_TuneCP5_pythia8_cfi.py
+++ b/Configuration/Generator/python/BuToJPsiPrimePhiToJPsiPiKK_14TeV_TuneCP5_pythia8_cfi.py
@@ -6,8 +6,6 @@ from Configuration.Generator.PSweightsPythia.PythiaPSweightsSettings_cfi import 
 
 generator = cms.EDFilter("Pythia8GeneratorFilter",
                          comEnergy = cms.double(14000.0),
-                         crossSection = cms.untracked.double(54000000000),
-                         filterEfficiency = cms.untracked.double(3.0e-4),
                          pythiaHepMCVerbosity = cms.untracked.bool(False),
                          maxEventsToPrint = cms.untracked.int32(0),
                          pythiaPylistVerbosity = cms.untracked.int32(0),

--- a/Configuration/Generator/python/BuToJPsiPrimePhiToJPsiPiKK_14TeV_TuneCP5_pythia8_cfi.py
+++ b/Configuration/Generator/python/BuToJPsiPrimePhiToJPsiPiKK_14TeV_TuneCP5_pythia8_cfi.py
@@ -1,0 +1,124 @@
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP5Settings_cfi import *
+from GeneratorInterface.EvtGenInterface.EvtGenSetting_cff import *
+from Configuration.Generator.PSweightsPythia.PythiaPSweightsSettings_cfi import *
+
+generator = cms.EDFilter("Pythia8GeneratorFilter",
+                         comEnergy = cms.double(14000.0),
+                         crossSection = cms.untracked.double(54000000000),
+                         filterEfficiency = cms.untracked.double(3.0e-4),
+                         pythiaHepMCVerbosity = cms.untracked.bool(False),
+                         maxEventsToPrint = cms.untracked.int32(0),
+                         pythiaPylistVerbosity = cms.untracked.int32(0),
+                         ExternalDecays = cms.PSet(
+        EvtGen130 = cms.untracked.PSet(
+            decay_table = cms.string('GeneratorInterface/EvtGenInterface/data/DECAY_2014_NOLONGLIFE.DEC'),
+            particle_property_file = cms.FileInPath('GeneratorInterface/EvtGenInterface/data/evt_2014.pdl'),
+            user_decay_embedded= cms.vstring(
+"""## my decay
+Alias      MyB+    B+
+Alias      MyB-   B-
+ChargeConj MyB-   MyB+
+#
+Alias      MyJpsi J/psi
+ChargeConj MyJpsi MyJpsi
+#
+# Alias      Myrho0       rho0
+# ChargeConj Myrho0       Myrho0
+#
+#
+Alias       Mypsi(2S)  psi(2S)
+ChargeConj  Mypsi(2S)  Mypsi(2S)
+#
+Decay MyJpsi
+1.000  mu+       mu-                     PHOTOS VLL;
+Enddecay
+#
+Decay MyB+
+1.000     Mypsi(2S) K+         PHSP;
+Enddecay
+#
+Decay MyB-
+1.000     Mypsi(2S) K-         PHSP;
+Enddecay
+#
+Decay Mypsi(2S)
+1.000   MyJpsi  pi+   pi-         VVPIPI;
+Enddecay
+#
+# Decay Myrho0
+# 1.000   pi+   pi-                  PHSP;
+# Enddecay
+#
+End"""
+     ),
+            list_forced_decays = cms.vstring('MyB+','MyB-'),
+            operates_on_particles = cms.vint32(),
+            convertPythiaCodes = cms.untracked.bool(False)
+            ),
+        parameterSets = cms.vstring('EvtGen130')
+        ),
+        PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP5SettingsBlock,
+        pythia8PSweightsSettingsBlock,
+        processParameters = cms.vstring(
+            "SoftQCD:nonDiffractive = on",
+            'PTFilter:filter = on', # this turn on the filter
+            'PTFilter:quarkToFilter = 5', # PDG id of q quark
+            'PTFilter:scaleToFilter = 1.0'),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP5Settings',
+            'pythia8PSweightsSettings',
+            'processParameters',
+        )
+    )
+)
+
+
+
+###########
+# Filters #
+###########
+bfilter = cms.EDFilter("PythiaFilter",
+        MaxEta = cms.untracked.double(9999.),
+        MinEta = cms.untracked.double(-9999.),
+        ParticleID = cms.untracked.int32(521)
+)
+
+jpsifilter = cms.EDFilter("PythiaDauVFilter",
+        verbose         = cms.untracked.int32(0), 
+        NumberDaughters = cms.untracked.int32(2), 
+        MotherID        = cms.untracked.int32(100443),  
+        ParticleID      = cms.untracked.int32(443),  
+        DaughterIDs     = cms.untracked.vint32(13, -13),
+        MinPt           = cms.untracked.vdouble(1.5, 1.5), 
+        MinEta          = cms.untracked.vdouble(-2.5, -2.5), 
+        MaxEta          = cms.untracked.vdouble( 2.5,  2.5)
+)
+
+xxxfilter = cms.EDFilter("PythiaDauVFilter",
+        verbose         = cms.untracked.int32(0), 
+        NumberDaughters = cms.untracked.int32(3), 
+        MotherID        = cms.untracked.int32(521),  
+        ParticleID      = cms.untracked.int32(100443),  
+        DaughterIDs     = cms.untracked.vint32(443, 211, -211),
+        MinPt           = cms.untracked.vdouble(5, 0.0, 0.0), 
+        MinEta          = cms.untracked.vdouble(-9999, -9999, -9999), 
+        MaxEta          = cms.untracked.vdouble( 9999,  9999,  9999)
+)
+
+decayfilter = cms.EDFilter("PythiaDauVFilter",
+        verbose         = cms.untracked.int32(0), 
+        NumberDaughters = cms.untracked.int32(2), 
+        MotherID        = cms.untracked.int32(0),  
+        ParticleID      = cms.untracked.int32(521),  
+        DaughterIDs     = cms.untracked.vint32(100443, 321),
+        MinPt           = cms.untracked.vdouble(5., 0.0), 
+        MinEta          = cms.untracked.vdouble(-9999., -9999.), 
+        MaxEta          = cms.untracked.vdouble( 9999.,  9999.)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*bfilter*jpsifilter*xxxfilter*decayfilter)

--- a/Configuration/Generator/python/BuToJPsiPrimePhiToJPsiPiKK_14TeV_TuneCP5_pythia8_cfi.py
+++ b/Configuration/Generator/python/BuToJPsiPrimePhiToJPsiPiKK_14TeV_TuneCP5_pythia8_cfi.py
@@ -2,7 +2,6 @@ import FWCore.ParameterSet.Config as cms
 from Configuration.Generator.Pythia8CommonSettings_cfi import *
 from Configuration.Generator.MCTunes2017.PythiaCP5Settings_cfi import *
 from GeneratorInterface.EvtGenInterface.EvtGenSetting_cff import *
-from Configuration.Generator.PSweightsPythia.PythiaPSweightsSettings_cfi import *
 
 generator = cms.EDFilter("Pythia8GeneratorFilter",
                          comEnergy = cms.double(14000.0),
@@ -60,7 +59,6 @@ End"""
         PythiaParameters = cms.PSet(
         pythia8CommonSettingsBlock,
         pythia8CP5SettingsBlock,
-        pythia8PSweightsSettingsBlock,
         processParameters = cms.vstring(
             "SoftQCD:nonDiffractive = on",
             'PTFilter:filter = on', # this turn on the filter
@@ -69,7 +67,6 @@ End"""
         parameterSets = cms.vstring(
             'pythia8CommonSettings',
             'pythia8CP5Settings',
-            'pythia8PSweightsSettings',
             'processParameters',
         )
     )

--- a/Configuration/Generator/python/Psi2SToJPsiPiPi_14TeV_TuneCP5_pythia8_cfi.py
+++ b/Configuration/Generator/python/Psi2SToJPsiPiPi_14TeV_TuneCP5_pythia8_cfi.py
@@ -1,0 +1,108 @@
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP5Settings_cfi import *
+
+generator = cms.EDFilter("Pythia8GeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    maxEventsToPrint = cms.untracked.int32(0),
+    comEnergy = cms.double(14000.0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP5SettingsBlock,
+        processParameters = cms.vstring(
+                'Charmonium:states(3S1) = 100443',
+                'Charmonium:O(3S1)[3S1(1)] = 0.76',
+                'Charmonium:O(3S1)[3S1(8)] = 0.0050',
+                'Charmonium:O(3S1)[1S0(8)] = 0.004',
+                'Charmonium:O(3S1)[3P0(8)] = 0.004',
+                'Charmonium:gg2ccbar(3S1)[3S1(1)]g = on',
+                'Charmonium:gg2ccbar(3S1)[3S1(1)]gm = on',
+                'Charmonium:gg2ccbar(3S1)[3S1(8)]g = on',
+                'Charmonium:qg2ccbar(3S1)[3S1(8)]q = on',
+                'Charmonium:qqbar2ccbar(3S1)[3S1(8)]g = on',
+                'Charmonium:gg2ccbar(3S1)[1S0(8)]g = on',
+                'Charmonium:qg2ccbar(3S1)[1S0(8)]q = on',
+                'Charmonium:qqbar2ccbar(3S1)[1S0(8)]g = on',
+                'Charmonium:gg2ccbar(3S1)[3PJ(8)]g = on',
+                'Charmonium:qg2ccbar(3S1)[3PJ(8)]q = on',
+                'Charmonium:qqbar2ccbar(3S1)[3PJ(8)]g = on',
+                '100443:onMode = off',
+                '100443:onIfMatch = 443 211 -211',
+                '443:onMode = off',
+                '443:onIfMatch = 13 -13',              
+                'PhaseSpace:pTHatMin = 10.'
+            ),
+        parameterSets = cms.vstring('pythia8CommonSettings',
+                                    'pythia8CP5Settings',
+                                    'processParameters',
+                                    )
+    )
+)
+
+# Filter with high pT cut on dimuon, trying to accomodate trigger requirements.
+
+psi2SIDfilter = cms.EDFilter("PythiaFilter",
+    ParticleID = cms.untracked.int32(100443),
+    MinPt = cms.untracked.double(0.0),
+    MinEta = cms.untracked.double(-2.4),
+    MaxEta = cms.untracked.double(2.4),
+    Status = cms.untracked.int32(2)
+)
+
+jpsifilter = cms.EDFilter("PythiaFilter",
+    ParticleID = cms.untracked.int32(443),
+    MinPt = cms.untracked.double(0.0),
+    MinEta = cms.untracked.double(-2.4),
+    MaxEta = cms.untracked.double(2.4),
+    Status = cms.untracked.int32(2)
+)
+
+# Next two muon filter are derived from muon reconstruction
+
+muminusfilter = cms.EDFilter("PythiaDauVFilter",
+    MotherID = cms.untracked.int32(0),
+    MinPt = cms.untracked.vdouble(2.),
+    ParticleID = cms.untracked.int32(443),
+    ChargeConjugation = cms.untracked.bool(False),
+    MinEta = cms.untracked.vdouble(-2.4),
+    MaxEta = cms.untracked.vdouble(2.4),
+    NumberDaughters = cms.untracked.int32(1),
+    DaughterIDs = cms.untracked.vint32(-13)
+)
+
+muplusfilter = cms.EDFilter("PythiaDauVFilter",
+    MotherID = cms.untracked.int32(0),
+    MinPt = cms.untracked.vdouble(2.),
+    ParticleID = cms.untracked.int32(443),
+    ChargeConjugation = cms.untracked.bool(False),
+    MinEta = cms.untracked.vdouble(-2.4),
+    MaxEta = cms.untracked.vdouble(2.4),
+    NumberDaughters = cms.untracked.int32(1),
+    DaughterIDs = cms.untracked.vint32(13)
+)
+
+#  two pion filter 
+piminusfilter = cms.EDFilter("PythiaDauVFilter",
+    MotherID = cms.untracked.int32(0),
+    MinPt = cms.untracked.vdouble(0.0),
+    ParticleID = cms.untracked.int32(100443),
+    ChargeConjugation = cms.untracked.bool(False),
+    MinEta = cms.untracked.vdouble(-2.4), # or 3.0 ?
+    MaxEta = cms.untracked.vdouble(2.4), # or 3.0 ?
+    NumberDaughters = cms.untracked.int32(1),
+    DaughterIDs = cms.untracked.vint32(-211)
+)
+
+piplusfilter = cms.EDFilter("PythiaDauVFilter",
+    MotherID = cms.untracked.int32(0),
+    MinPt = cms.untracked.vdouble(0.0),
+    ParticleID = cms.untracked.int32(100443),
+    ChargeConjugation = cms.untracked.bool(False),
+    MinEta = cms.untracked.vdouble(-2.4), # or 3.0 ?
+    MaxEta = cms.untracked.vdouble(2.4), # or 3.0 ?
+    NumberDaughters = cms.untracked.int32(1),
+    DaughterIDs = cms.untracked.vint32(211)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*psi2SIDfilter*jpsifilter*muminusfilter*muplusfilter*piminusfilter*piplusfilter)


### PR DESCRIPTION
#### PR description:
for the upcoming BParking reprocessing in 106X, the BPH-TRK group would need 2 dedicated relval samples in order to properly perform the validation

the 2 samples are
- Psi(2s) --> J/Psi pi^+ pi^- (with the J/Psi into muons)
- Bu --> JPsiPrime Phi with the PsiPrime into J/Psi pion (and the J/Psi into muons) and the Phi into kaons