### PR TITLE
Resolved uninitialized value warning in PixelTrackFitting

### DIFF
--- a/RecoPixelVertexing/PixelTrackFitting/interface/RiemannFit.h
+++ b/RecoPixelVertexing/PixelTrackFitting/interface/RiemannFit.h
@@ -515,7 +515,7 @@ namespace riemannFit {
     // scale
     const double tempQ = mc.squaredNorm();
     const double tempS = sqrt(n * 1. / tempQ);  // scaling factor
-    p3D *= tempS;
+    p3D.block(0, 0, 2, n) *= tempS;
 
     // project on paraboloid
     p3D.row(2) = p3D.block(0, 0, 2, n).colwise().squaredNorm();


### PR DESCRIPTION

#### PR description:

This resolves the warning:
```
Eigen/src/Core/functors/AssignmentFunctors.h:92:62: warning: '*((void*)& p3D +88)' is used uninitialized in this function [-Wuninitialized]
   92 |   EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE void assignCoeff(DstScalar& a, const SrcScalar& b) const { a *= b; }
      |                                                            ~~^~~~
```

The last row of the matrix is not initialized yet, and gets initialized right after.

#### PR validation:

The fix is limited and well understood. `scram b runtests` succeeds except for 5x5 matrices in `testEigenGPUNoFit_t`, and this problem is already followed up in https://github.com/cms-sw/cmssw/issues/33797.

