### PR TITLE
Pixel local reco: reduce code duplication in SiPixelRawToDigi related code

### DIFF
--- a/DataFormats/SiPixelDigi/interface/SiPixelDigiConstants.h
+++ b/DataFormats/SiPixelDigi/interface/SiPixelDigiConstants.h
@@ -8,13 +8,16 @@ using Word64 = cms_uint64_t;
 using Word32 = cms_uint32_t;
 
 namespace sipixelconstants {
+  constexpr cms_uint32_t dummyDetId = 0xffffffff;
+
   constexpr uint32_t CRC_bits = 1;
-  constexpr uint32_t LINK_bits = 6;
-  constexpr uint32_t ROC_bits = 5;
-  constexpr uint32_t DCOL_bits = 5;
-  constexpr uint32_t PXID_bits = 8;
+  constexpr uint32_t DCOL_bits = 5;  // double column
+  constexpr uint32_t PXID_bits = 8;  // pixel id
   constexpr uint32_t ADC_bits = 8;
   constexpr uint32_t OMIT_ERR_bits = 1;
+  // GO BACK TO OLD VALUES. THE 48-CHAN FED DOES NOT NEED A NEW FORMAT 28/9/16 d.k.
+  constexpr uint32_t LINK_bits = 6;  // 7;
+  constexpr uint32_t ROC_bits = 5;   // 4;
 
   constexpr uint32_t CRC_shift = 2;
   constexpr uint32_t ADC_shift = 0;
@@ -24,13 +27,24 @@ namespace sipixelconstants {
   constexpr uint32_t LINK_shift = ROC_shift + ROC_bits;
   constexpr uint32_t OMIT_ERR_shift = 20;
 
-  constexpr cms_uint32_t dummyDetId = 0xffffffff;
+  constexpr uint64_t CRC_mask = ~(~Word64(0) << CRC_bits);
+  constexpr uint32_t ERROR_mask = ~(~Word32(0) << ROC_bits);
+  constexpr uint32_t LINK_mask = ~(~Word32(0) << LINK_bits);
+  constexpr uint32_t ROC_mask = ~(~Word32(0) << ROC_bits);
+  constexpr uint32_t OMIT_ERR_mask = ~(~Word32(0) << OMIT_ERR_bits);
+  constexpr uint32_t DCOL_mask = ~(~Word32(0) << DCOL_bits);
+  constexpr uint32_t PXID_mask = ~(~Word32(0) << PXID_bits);
+  constexpr uint32_t ADC_mask = ~(~Word32(0) << ADC_bits);
 
-  constexpr Word64 CRC_mask = ~(~Word64(0) << CRC_bits);
-  constexpr Word32 ERROR_mask = ~(~Word32(0) << ROC_bits);
-  constexpr Word32 LINK_mask = ~(~Word32(0) << LINK_bits);
-  constexpr Word32 ROC_mask = ~(~Word32(0) << ROC_bits);
-  constexpr Word32 OMIT_ERR_mask = ~(~Word32(0) << OMIT_ERR_bits);
+  // Special for layer 1 bpix rocs 6/9/16 d.k. THIS STAYS.
+  inline namespace phase1layer1 {
+    constexpr uint32_t COL_bits1_l1 = 6;
+    constexpr uint32_t ROW_bits1_l1 = 7;
+    constexpr uint32_t ROW_shift = ADC_shift + ADC_bits;
+    constexpr uint32_t COL_shift = ROW_shift + ROW_bits1_l1;
+    constexpr uint32_t COL_mask = ~(~Word32(0) << COL_bits1_l1);
+    constexpr uint32_t ROW_mask = ~(~Word32(0) << ROW_bits1_l1);
+  }  // namespace phase1layer1
 }  // namespace sipixelconstants
 
 #endif  // DataFormats_SiPixelDigi_interface_SiPixelDigiConstants

--- a/DataFormats/SiPixelDigi/interface/SiPixelDigiConstants.h
+++ b/DataFormats/SiPixelDigi/interface/SiPixelDigiConstants.h
@@ -1,0 +1,36 @@
+#ifndef DataFormats_SiPixelDigi_interface_SiPixelDigiConstants
+#define DataFormats_SiPixelDigi_interface_SiPixelDigiConstants
+
+#include <stdint.h>
+#include "FWCore/Utilities/interface/typedefs.h"
+
+using Word64 = cms_uint64_t;
+using Word32 = cms_uint32_t;
+
+namespace sipixelconstants {
+  constexpr uint32_t CRC_bits = 1;
+  constexpr uint32_t LINK_bits = 6;
+  constexpr uint32_t ROC_bits = 5;
+  constexpr uint32_t DCOL_bits = 5;
+  constexpr uint32_t PXID_bits = 8;
+  constexpr uint32_t ADC_bits = 8;
+  constexpr uint32_t OMIT_ERR_bits = 1;
+
+  constexpr uint32_t CRC_shift = 2;
+  constexpr uint32_t ADC_shift = 0;
+  constexpr uint32_t PXID_shift = ADC_shift + ADC_bits;
+  constexpr uint32_t DCOL_shift = PXID_shift + PXID_bits;
+  constexpr uint32_t ROC_shift = DCOL_shift + DCOL_bits;
+  constexpr uint32_t LINK_shift = ROC_shift + ROC_bits;
+  constexpr uint32_t OMIT_ERR_shift = 20;
+
+  constexpr cms_uint32_t dummyDetId = 0xffffffff;
+
+  constexpr Word64 CRC_mask = ~(~Word64(0) << CRC_bits);
+  constexpr Word32 ERROR_mask = ~(~Word32(0) << ROC_bits);
+  constexpr Word32 LINK_mask = ~(~Word32(0) << LINK_bits);
+  constexpr Word32 ROC_mask = ~(~Word32(0) << ROC_bits);
+  constexpr Word32 OMIT_ERR_mask = ~(~Word32(0) << OMIT_ERR_bits);
+}  // namespace sipixelconstants
+
+#endif  // DataFormats_SiPixelDigi_interface_SiPixelDigiConstants

--- a/DataFormats/SiPixelDigi/interface/SiPixelDigiConstants.h
+++ b/DataFormats/SiPixelDigi/interface/SiPixelDigiConstants.h
@@ -45,6 +45,17 @@ namespace sipixelconstants {
     constexpr uint32_t COL_mask = ~(~Word32(0) << COL_bits1_l1);
     constexpr uint32_t ROW_mask = ~(~Word32(0) << ROW_bits1_l1);
   }  // namespace phase1layer1
+
+  // constexpr functions are available in device code (GPU) as well
+  inline namespace functions {
+    inline constexpr uint32_t getLink(uint32_t ww) { return ((ww >> LINK_shift) & LINK_mask); }
+    inline constexpr uint32_t getROC(uint32_t ww) { return ((ww >> ROC_shift) & ROC_mask); }
+    inline constexpr uint32_t getADC(uint32_t ww) { return ((ww >> ADC_shift) & ADC_mask); }
+    inline constexpr uint32_t getCol(uint32_t ww) { return ((ww >> COL_shift) & COL_mask); }
+    inline constexpr uint32_t getRow(uint32_t ww) { return ((ww >> ROW_shift) & ROW_mask); }
+    inline constexpr uint32_t getDCol(uint32_t ww) { return ((ww >> DCOL_shift) & DCOL_mask); }
+    inline constexpr uint32_t getPxId(uint32_t ww) { return ((ww >> PXID_shift) & PXID_mask); }
+  }  // namespace functions
 }  // namespace sipixelconstants
 
 #endif  // DataFormats_SiPixelDigi_interface_SiPixelDigiConstants

--- a/DataFormats/SiPixelDigi/interface/SiPixelDigiConstants.h
+++ b/DataFormats/SiPixelDigi/interface/SiPixelDigiConstants.h
@@ -1,8 +1,8 @@
 #ifndef DataFormats_SiPixelDigi_interface_SiPixelDigiConstants
 #define DataFormats_SiPixelDigi_interface_SiPixelDigiConstants
 
-#include <stdint.h>
 #include "FWCore/Utilities/interface/typedefs.h"
+#include <cstdint>
 
 using Word64 = cms_uint64_t;
 using Word32 = cms_uint32_t;

--- a/EventFilter/SiPixelRawToDigi/interface/ErrorChecker.h
+++ b/EventFilter/SiPixelRawToDigi/interface/ErrorChecker.h
@@ -6,14 +6,11 @@
  */
 
 #include "DataFormats/SiPixelDigi/interface/SiPixelDigiConstants.h"
+#include "DataFormats/SiPixelRawData/interface/SiPixelFormatterErrors.h"
 #include "EventFilter/SiPixelRawToDigi/interface/ErrorCheckerBase.h"
-#include "FWCore/Utilities/interface/typedefs.h"
 
 class ErrorChecker : public ErrorCheckerBase {
 public:
-  typedef std::vector<SiPixelRawDataError> DetErrors;
-  typedef std::map<cms_uint32_t, DetErrors> Errors;
-
   ErrorChecker();
 
   bool checkROC(bool& errorsInEvent,
@@ -21,7 +18,7 @@ public:
                 const SiPixelFrameConverter* converter,
                 const SiPixelFedCabling* theCablingTree,
                 Word32& errorWord,
-                Errors& errors) override;
+                SiPixelFormatterErrors& errors) override;
 
 private:
   bool includeErrors_;

--- a/EventFilter/SiPixelRawToDigi/interface/ErrorChecker.h
+++ b/EventFilter/SiPixelRawToDigi/interface/ErrorChecker.h
@@ -18,23 +18,12 @@ public:
 
   ErrorChecker();
 
-  void setErrorStatus(bool ErrorStatus) override;
-
-  bool checkCRC(bool& errorsInEvent, int fedId, const Word64* trailer, Errors& errors) override;
-
-  bool checkHeader(bool& errorsInEvent, int fedId, const Word64* header, Errors& errors) override;
-
-  bool checkTrailer(bool& errorsInEvent, int fedId, unsigned int nWords, const Word64* trailer, Errors& errors) override;
-
   bool checkROC(bool& errorsInEvent,
                 int fedId,
                 const SiPixelFrameConverter* converter,
                 const SiPixelFedCabling* theCablingTree,
                 Word32& errorWord,
                 Errors& errors) override;
-
-  void conversionError(
-      int fedId, const SiPixelFrameConverter* converter, int status, Word32& errorWord, Errors& errors) override;
 
 private:
   bool includeErrors;

--- a/EventFilter/SiPixelRawToDigi/interface/ErrorChecker.h
+++ b/EventFilter/SiPixelRawToDigi/interface/ErrorChecker.h
@@ -20,9 +20,7 @@ public:
                 Word32& errorWord,
                 SiPixelFormatterErrors& errors) const override;
 
-private:
-  bool includeErrors_;
-
+protected:
   cms_uint32_t errorDetId(const SiPixelFrameConverter* converter, int errorType, const Word32& word) const override;
 };
 

--- a/EventFilter/SiPixelRawToDigi/interface/ErrorChecker.h
+++ b/EventFilter/SiPixelRawToDigi/interface/ErrorChecker.h
@@ -5,14 +5,12 @@
  *  
  */
 
+#include "DataFormats/SiPixelDigi/interface/SiPixelDigiConstants.h"
 #include "EventFilter/SiPixelRawToDigi/interface/ErrorCheckerBase.h"
 #include "FWCore/Utilities/interface/typedefs.h"
 
 class ErrorChecker : public ErrorCheckerBase {
 public:
-  typedef cms_uint32_t Word32;
-  typedef cms_uint64_t Word64;
-
   typedef std::vector<SiPixelRawDataError> DetErrors;
   typedef std::map<cms_uint32_t, DetErrors> Errors;
 

--- a/EventFilter/SiPixelRawToDigi/interface/ErrorChecker.h
+++ b/EventFilter/SiPixelRawToDigi/interface/ErrorChecker.h
@@ -24,7 +24,7 @@ public:
                 Errors& errors) override;
 
 private:
-  bool includeErrors;
+  bool includeErrors_;
 
   cms_uint32_t errorDetId(const SiPixelFrameConverter* converter, int errorType, const Word32& word) const override;
 };

--- a/EventFilter/SiPixelRawToDigi/interface/ErrorChecker.h
+++ b/EventFilter/SiPixelRawToDigi/interface/ErrorChecker.h
@@ -18,7 +18,7 @@ public:
                 const SiPixelFrameConverter* converter,
                 const SiPixelFedCabling* theCablingTree,
                 Word32& errorWord,
-                SiPixelFormatterErrors& errors) override;
+                SiPixelFormatterErrors& errors) const override;
 
 private:
   bool includeErrors_;

--- a/EventFilter/SiPixelRawToDigi/interface/ErrorChecker.h
+++ b/EventFilter/SiPixelRawToDigi/interface/ErrorChecker.h
@@ -1,5 +1,5 @@
-#ifndef ErrorChecker_H
-#define ErrorChecker_H
+#ifndef EventFilter_SiPixelRawToDigi_interface_ErrorChecker_h
+#define EventFilter_SiPixelRawToDigi_interface_ErrorChecker_h
 /** \class ErrorChecker
  *
  *  
@@ -29,4 +29,4 @@ private:
   cms_uint32_t errorDetId(const SiPixelFrameConverter* converter, int errorType, const Word32& word) const override;
 };
 
-#endif
+#endif  // EventFilter_SiPixelRawToDigi_interface_ErrorChecker_h

--- a/EventFilter/SiPixelRawToDigi/interface/ErrorCheckerBase.h
+++ b/EventFilter/SiPixelRawToDigi/interface/ErrorCheckerBase.h
@@ -20,17 +20,17 @@ public:
 
   typedef std::vector<SiPixelRawDataError> DetErrors;
   typedef std::map<cms_uint32_t, DetErrors> Errors;
+  ErrorCheckerBase();
 
-  virtual ~ErrorCheckerBase(){};
+  virtual ~ErrorCheckerBase() = default;
 
-  virtual void setErrorStatus(bool ErrorStatus) = 0;
+  virtual void setErrorStatus(bool ErrorStatus);
 
-  virtual bool checkCRC(bool& errorsInEvent, int fedId, const Word64* trailer, Errors& errors) = 0;
+  virtual bool checkCRC(bool& errorsInEvent, int fedId, const Word64* trailer, Errors& errors);
 
-  virtual bool checkHeader(bool& errorsInEvent, int fedId, const Word64* header, Errors& errors) = 0;
+  virtual bool checkHeader(bool& errorsInEvent, int fedId, const Word64* header, Errors& errors);
 
-  virtual bool checkTrailer(
-      bool& errorsInEvent, int fedId, unsigned int nWords, const Word64* trailer, Errors& errors) = 0;
+  virtual bool checkTrailer(bool& errorsInEvent, int fedId, unsigned int nWords, const Word64* trailer, Errors& errors);
 
   virtual bool checkROC(bool& errorsInEvent,
                         int fedId,
@@ -40,9 +40,10 @@ public:
                         Errors& errors) = 0;
 
   virtual void conversionError(
-      int fedId, const SiPixelFrameConverter* converter, int status, Word32& errorWord, Errors& errors) = 0;
+      int fedId, const SiPixelFrameConverter* converter, int status, Word32& errorWord, Errors& errors);
 
 private:
+  bool includeErrors;
   virtual cms_uint32_t errorDetId(const SiPixelFrameConverter* converter, int errorType, const Word32& word) const = 0;
 };
 

--- a/EventFilter/SiPixelRawToDigi/interface/ErrorCheckerBase.h
+++ b/EventFilter/SiPixelRawToDigi/interface/ErrorCheckerBase.h
@@ -40,7 +40,7 @@ public:
                         Errors& errors) = 0;
 
 private:
-  bool includeErrors;
+  bool includeErrors_;
   int getConversionErrorTypeAndIssueLogMessage(int status, int fedId) const;
   virtual cms_uint32_t errorDetId(const SiPixelFrameConverter* converter, int errorType, const Word32& word) const = 0;
 };

--- a/EventFilter/SiPixelRawToDigi/interface/ErrorCheckerBase.h
+++ b/EventFilter/SiPixelRawToDigi/interface/ErrorCheckerBase.h
@@ -39,7 +39,7 @@ public:
                         Word32& errorWord,
                         SiPixelFormatterErrors& errors) const = 0;
 
-private:
+protected:
   bool includeErrors_;
   int getConversionErrorTypeAndIssueLogMessage(int status, int fedId) const;
   void addErrorToCollectionDummy(int errorType, int fedId, Word64 word, SiPixelFormatterErrors& errors) const;

--- a/EventFilter/SiPixelRawToDigi/interface/ErrorCheckerBase.h
+++ b/EventFilter/SiPixelRawToDigi/interface/ErrorCheckerBase.h
@@ -22,13 +22,15 @@ public:
 
   virtual ~ErrorCheckerBase() = default;
 
-  virtual void setErrorStatus(bool ErrorStatus);
+  void setErrorStatus(bool ErrorStatus);
 
-  virtual bool checkCRC(bool& errorsInEvent, int fedId, const Word64* trailer, Errors& errors);
+  bool checkCRC(bool& errorsInEvent, int fedId, const Word64* trailer, Errors& errors);
 
-  virtual bool checkHeader(bool& errorsInEvent, int fedId, const Word64* header, Errors& errors);
+  bool checkHeader(bool& errorsInEvent, int fedId, const Word64* header, Errors& errors);
 
-  virtual bool checkTrailer(bool& errorsInEvent, int fedId, unsigned int nWords, const Word64* trailer, Errors& errors);
+  bool checkTrailer(bool& errorsInEvent, int fedId, unsigned int nWords, const Word64* trailer, Errors& errors);
+
+  void conversionError(int fedId, const SiPixelFrameConverter* converter, int status, Word32& errorWord, Errors& errors);
 
   virtual bool checkROC(bool& errorsInEvent,
                         int fedId,
@@ -36,9 +38,6 @@ public:
                         const SiPixelFedCabling* theCablingTree,
                         Word32& errorWord,
                         Errors& errors) = 0;
-
-  virtual void conversionError(
-      int fedId, const SiPixelFrameConverter* converter, int status, Word32& errorWord, Errors& errors);
 
 private:
   bool includeErrors;

--- a/EventFilter/SiPixelRawToDigi/interface/ErrorCheckerBase.h
+++ b/EventFilter/SiPixelRawToDigi/interface/ErrorCheckerBase.h
@@ -39,6 +39,7 @@ public:
 private:
   bool includeErrors_;
   int getConversionErrorTypeAndIssueLogMessage(int status, int fedId) const;
+  void addErrorToCollectionDummy(int errorType, int fedId, Word64 word, SiPixelFormatterErrors& errors);
   virtual cms_uint32_t errorDetId(const SiPixelFrameConverter* converter, int errorType, const Word32& word) const = 0;
 };
 

--- a/EventFilter/SiPixelRawToDigi/interface/ErrorCheckerBase.h
+++ b/EventFilter/SiPixelRawToDigi/interface/ErrorCheckerBase.h
@@ -5,6 +5,7 @@
  *  
  */
 
+#include "DataFormats/SiPixelDigi/interface/SiPixelDigiConstants.h"
 #include "DataFormats/SiPixelRawData/interface/SiPixelRawDataError.h"
 
 #include <vector>
@@ -15,9 +16,6 @@ class SiPixelFedCabling;
 
 class ErrorCheckerBase {
 public:
-  typedef cms_uint32_t Word32;
-  typedef cms_uint64_t Word64;
-
   typedef std::vector<SiPixelRawDataError> DetErrors;
   typedef std::map<cms_uint32_t, DetErrors> Errors;
   ErrorCheckerBase();

--- a/EventFilter/SiPixelRawToDigi/interface/ErrorCheckerBase.h
+++ b/EventFilter/SiPixelRawToDigi/interface/ErrorCheckerBase.h
@@ -19,27 +19,30 @@ public:
 
   void setErrorStatus(bool ErrorStatus);
 
-  bool checkCRC(bool& errorsInEvent, int fedId, const Word64* trailer, SiPixelFormatterErrors& errors);
+  bool checkCRC(bool& errorsInEvent, int fedId, const Word64* trailer, SiPixelFormatterErrors& errors) const;
 
-  bool checkHeader(bool& errorsInEvent, int fedId, const Word64* header, SiPixelFormatterErrors& errors);
+  bool checkHeader(bool& errorsInEvent, int fedId, const Word64* header, SiPixelFormatterErrors& errors) const;
 
   bool checkTrailer(
-      bool& errorsInEvent, int fedId, unsigned int nWords, const Word64* trailer, SiPixelFormatterErrors& errors);
+      bool& errorsInEvent, int fedId, unsigned int nWords, const Word64* trailer, SiPixelFormatterErrors& errors) const;
 
-  void conversionError(
-      int fedId, const SiPixelFrameConverter* converter, int status, Word32& errorWord, SiPixelFormatterErrors& errors);
+  void conversionError(int fedId,
+                       const SiPixelFrameConverter* converter,
+                       int status,
+                       Word32& errorWord,
+                       SiPixelFormatterErrors& errors) const;
 
   virtual bool checkROC(bool& errorsInEvent,
                         int fedId,
                         const SiPixelFrameConverter* converter,
                         const SiPixelFedCabling* theCablingTree,
                         Word32& errorWord,
-                        SiPixelFormatterErrors& errors) = 0;
+                        SiPixelFormatterErrors& errors) const = 0;
 
 private:
   bool includeErrors_;
   int getConversionErrorTypeAndIssueLogMessage(int status, int fedId) const;
-  void addErrorToCollectionDummy(int errorType, int fedId, Word64 word, SiPixelFormatterErrors& errors);
+  void addErrorToCollectionDummy(int errorType, int fedId, Word64 word, SiPixelFormatterErrors& errors) const;
   virtual cms_uint32_t errorDetId(const SiPixelFrameConverter* converter, int errorType, const Word32& word) const = 0;
 };
 

--- a/EventFilter/SiPixelRawToDigi/interface/ErrorCheckerBase.h
+++ b/EventFilter/SiPixelRawToDigi/interface/ErrorCheckerBase.h
@@ -41,6 +41,7 @@ public:
 
 private:
   bool includeErrors;
+  int getConversionErrorTypeAndIssueLogMessage(int status, int fedId) const;
   virtual cms_uint32_t errorDetId(const SiPixelFrameConverter* converter, int errorType, const Word32& word) const = 0;
 };
 

--- a/EventFilter/SiPixelRawToDigi/interface/ErrorCheckerBase.h
+++ b/EventFilter/SiPixelRawToDigi/interface/ErrorCheckerBase.h
@@ -1,5 +1,5 @@
-#ifndef ErrorCheckerBase_H
-#define ErrorCheckerBase_H
+#ifndef EventFilter_SiPixelRawToDigi_interface_ErrorCheckerBase_h
+#define EventFilter_SiPixelRawToDigi_interface_ErrorCheckerBase_h
 /** \class ErrorCheckerBase
  *
  *  
@@ -44,4 +44,4 @@ private:
   virtual cms_uint32_t errorDetId(const SiPixelFrameConverter* converter, int errorType, const Word32& word) const = 0;
 };
 
-#endif
+#endif  // EventFilter_SiPixelRawToDigi_interface_ErrorCheckerBase_h

--- a/EventFilter/SiPixelRawToDigi/interface/ErrorCheckerBase.h
+++ b/EventFilter/SiPixelRawToDigi/interface/ErrorCheckerBase.h
@@ -6,38 +6,35 @@
  */
 
 #include "DataFormats/SiPixelDigi/interface/SiPixelDigiConstants.h"
-#include "DataFormats/SiPixelRawData/interface/SiPixelRawDataError.h"
-
-#include <vector>
-#include <map>
+#include "DataFormats/SiPixelRawData/interface/SiPixelFormatterErrors.h"
 
 class SiPixelFrameConverter;
 class SiPixelFedCabling;
 
 class ErrorCheckerBase {
 public:
-  typedef std::vector<SiPixelRawDataError> DetErrors;
-  typedef std::map<cms_uint32_t, DetErrors> Errors;
   ErrorCheckerBase();
 
   virtual ~ErrorCheckerBase() = default;
 
   void setErrorStatus(bool ErrorStatus);
 
-  bool checkCRC(bool& errorsInEvent, int fedId, const Word64* trailer, Errors& errors);
+  bool checkCRC(bool& errorsInEvent, int fedId, const Word64* trailer, SiPixelFormatterErrors& errors);
 
-  bool checkHeader(bool& errorsInEvent, int fedId, const Word64* header, Errors& errors);
+  bool checkHeader(bool& errorsInEvent, int fedId, const Word64* header, SiPixelFormatterErrors& errors);
 
-  bool checkTrailer(bool& errorsInEvent, int fedId, unsigned int nWords, const Word64* trailer, Errors& errors);
+  bool checkTrailer(
+      bool& errorsInEvent, int fedId, unsigned int nWords, const Word64* trailer, SiPixelFormatterErrors& errors);
 
-  void conversionError(int fedId, const SiPixelFrameConverter* converter, int status, Word32& errorWord, Errors& errors);
+  void conversionError(
+      int fedId, const SiPixelFrameConverter* converter, int status, Word32& errorWord, SiPixelFormatterErrors& errors);
 
   virtual bool checkROC(bool& errorsInEvent,
                         int fedId,
                         const SiPixelFrameConverter* converter,
                         const SiPixelFedCabling* theCablingTree,
                         Word32& errorWord,
-                        Errors& errors) = 0;
+                        SiPixelFormatterErrors& errors) = 0;
 
 private:
   bool includeErrors_;

--- a/EventFilter/SiPixelRawToDigi/interface/ErrorCheckerPhase0.h
+++ b/EventFilter/SiPixelRawToDigi/interface/ErrorCheckerPhase0.h
@@ -20,9 +20,7 @@ public:
                 Word32& errorWord,
                 SiPixelFormatterErrors& errors) const override;
 
-private:
-  bool includeErrors_;
-
+protected:
   cms_uint32_t errorDetId(const SiPixelFrameConverter* converter, int errorType, const Word32& word) const override;
 };
 

--- a/EventFilter/SiPixelRawToDigi/interface/ErrorCheckerPhase0.h
+++ b/EventFilter/SiPixelRawToDigi/interface/ErrorCheckerPhase0.h
@@ -1,5 +1,5 @@
-#ifndef ErrorCheckerPhase0_H
-#define ErrorCheckerPhase0_H
+#ifndef EventFilter_SiPixelRawToDigi_interface_ErrorCheckerPhase0_h
+#define EventFilter_SiPixelRawToDigi_interface_ErrorCheckerPhase0_h
 /** \class ErrorCheckerPhase0
  *
  *  
@@ -29,4 +29,4 @@ private:
   cms_uint32_t errorDetId(const SiPixelFrameConverter* converter, int errorType, const Word32& word) const override;
 };
 
-#endif
+#endif  // EventFilter_SiPixelRawToDigi_interface_ErrorCheckerPhase0_h

--- a/EventFilter/SiPixelRawToDigi/interface/ErrorCheckerPhase0.h
+++ b/EventFilter/SiPixelRawToDigi/interface/ErrorCheckerPhase0.h
@@ -24,7 +24,7 @@ public:
                 Errors& errors) override;
 
 private:
-  bool includeErrors;
+  bool includeErrors_;
 
   cms_uint32_t errorDetId(const SiPixelFrameConverter* converter, int errorType, const Word32& word) const override;
 };

--- a/EventFilter/SiPixelRawToDigi/interface/ErrorCheckerPhase0.h
+++ b/EventFilter/SiPixelRawToDigi/interface/ErrorCheckerPhase0.h
@@ -18,7 +18,7 @@ public:
                 const SiPixelFrameConverter* converter,
                 const SiPixelFedCabling* theCablingTree,
                 Word32& errorWord,
-                SiPixelFormatterErrors& errors) override;
+                SiPixelFormatterErrors& errors) const override;
 
 private:
   bool includeErrors_;

--- a/EventFilter/SiPixelRawToDigi/interface/ErrorCheckerPhase0.h
+++ b/EventFilter/SiPixelRawToDigi/interface/ErrorCheckerPhase0.h
@@ -6,14 +6,11 @@
  */
 
 #include "DataFormats/SiPixelDigi/interface/SiPixelDigiConstants.h"
+#include "DataFormats/SiPixelRawData/interface/SiPixelFormatterErrors.h"
 #include "EventFilter/SiPixelRawToDigi/interface/ErrorCheckerBase.h"
-#include "FWCore/Utilities/interface/typedefs.h"
 
 class ErrorCheckerPhase0 : public ErrorCheckerBase {
 public:
-  typedef std::vector<SiPixelRawDataError> DetErrors;
-  typedef std::map<cms_uint32_t, DetErrors> Errors;
-
   ErrorCheckerPhase0();
 
   bool checkROC(bool& errorsInEvent,
@@ -21,7 +18,7 @@ public:
                 const SiPixelFrameConverter* converter,
                 const SiPixelFedCabling* theCablingTree,
                 Word32& errorWord,
-                Errors& errors) override;
+                SiPixelFormatterErrors& errors) override;
 
 private:
   bool includeErrors_;

--- a/EventFilter/SiPixelRawToDigi/interface/ErrorCheckerPhase0.h
+++ b/EventFilter/SiPixelRawToDigi/interface/ErrorCheckerPhase0.h
@@ -5,14 +5,12 @@
  *  
  */
 
+#include "DataFormats/SiPixelDigi/interface/SiPixelDigiConstants.h"
 #include "EventFilter/SiPixelRawToDigi/interface/ErrorCheckerBase.h"
 #include "FWCore/Utilities/interface/typedefs.h"
 
 class ErrorCheckerPhase0 : public ErrorCheckerBase {
 public:
-  typedef cms_uint32_t Word32;
-  typedef cms_uint64_t Word64;
-
   typedef std::vector<SiPixelRawDataError> DetErrors;
   typedef std::map<cms_uint32_t, DetErrors> Errors;
 

--- a/EventFilter/SiPixelRawToDigi/interface/ErrorCheckerPhase0.h
+++ b/EventFilter/SiPixelRawToDigi/interface/ErrorCheckerPhase0.h
@@ -18,23 +18,12 @@ public:
 
   ErrorCheckerPhase0();
 
-  void setErrorStatus(bool ErrorStatus) override;
-
-  bool checkCRC(bool& errorsInEvent, int fedId, const Word64* trailer, Errors& errors) override;
-
-  bool checkHeader(bool& errorsInEvent, int fedId, const Word64* header, Errors& errors) override;
-
-  bool checkTrailer(bool& errorsInEvent, int fedId, unsigned int nWords, const Word64* trailer, Errors& errors) override;
-
   bool checkROC(bool& errorsInEvent,
                 int fedId,
                 const SiPixelFrameConverter* converter,
                 const SiPixelFedCabling* theCablingTree,
                 Word32& errorWord,
                 Errors& errors) override;
-
-  void conversionError(
-      int fedId, const SiPixelFrameConverter* converter, int status, Word32& errorWord, Errors& errors) override;
 
 private:
   bool includeErrors;

--- a/EventFilter/SiPixelRawToDigi/interface/PixelDataFormatter.h
+++ b/EventFilter/SiPixelRawToDigi/interface/PixelDataFormatter.h
@@ -1,5 +1,5 @@
-#ifndef PixelDataFormatter_H
-#define PixelDataFormatter_H
+#ifndef EventFilter_SiPixelRawToDigi_interface_PixelDataFormatter_h
+#define EventFilter_SiPixelRawToDigi_interface_PixelDataFormatter_h
 /** \class PixelDataFormatter
  *
  *  Transforms Pixel raw data of a given  FED to orca digi
@@ -130,4 +130,4 @@ private:
   cms_uint32_t errorDetId(const SiPixelFrameConverter* converter, int fedId, int errorType, const Word32& word) const;
 };
 
-#endif
+#endif  // EventFilter_SiPixelRawToDigi_interface_PixelDataFormatter_h

--- a/EventFilter/SiPixelRawToDigi/interface/PixelDataFormatter.h
+++ b/EventFilter/SiPixelRawToDigi/interface/PixelDataFormatter.h
@@ -33,17 +33,20 @@
 //
 // Add the phase1 format
 //
+// CMSSW include(s)
 #include "CondFormats/SiPixelObjects/interface/SiPixelFrameReverter.h"
 #include "DataFormats/SiPixelDigi/interface/PixelDigi.h"
 #include "DataFormats/Common/interface/DetSetVector.h"
 #include "DataFormats/SiPixelRawData/interface/SiPixelRawDataError.h"
 #include "DataFormats/SiPixelDigi/interface/SiPixelDigiConstants.h"
 #include "DataFormats/DetId/interface/DetIdCollection.h"
+#include "DataFormats/SiPixelDetId/interface/PixelFEDChannel.h"
+#include "DataFormats/FEDRawData/interface/FEDRawData.h"
 #include "EventFilter/SiPixelRawToDigi/interface/ErrorChecker.h"
 #include "EventFilter/SiPixelRawToDigi/interface/ErrorCheckerPhase0.h"
 #include "FWCore/Utilities/interface/typedefs.h"
-#include "DataFormats/SiPixelDetId/interface/PixelFEDChannel.h"
 
+// standard include(s)
 #include <vector>
 #include <map>
 #include <set>
@@ -57,22 +60,22 @@ class SiPixelFedCablingTree;
 
 class PixelDataFormatter {
 public:
-  typedef edm::DetSetVector<PixelDigi> Collection;
-
-  typedef std::map<int, FEDRawData> RawData;
-  typedef std::vector<PixelDigi> DetDigis;
-  typedef std::map<cms_uint32_t, DetDigis> Digis;
-  typedef std::pair<DetDigis::const_iterator, DetDigis::const_iterator> Range;
-  typedef std::vector<SiPixelRawDataError> DetErrors;
-  typedef std::map<cms_uint32_t, DetErrors> Errors;
-  typedef std::vector<PixelFEDChannel> DetBadChannels;
-  typedef std::map<cms_uint32_t, DetBadChannels> BadChannels;
+  using DetErrors = std::vector<SiPixelRawDataError>;
+  using Errors = std::map<cms_uint32_t, DetErrors>;
+  using Collection = edm::DetSetVector<PixelDigi>;
+  using RawData = std::map<int, FEDRawData>;
+  using DetDigis = std::vector<PixelDigi>;
+  using Digis = std::map<cms_uint32_t, DetDigis>;
+  using DetBadChannels = std::vector<PixelFEDChannel>;
+  using BadChannels = std::map<cms_uint32_t, DetBadChannels>;
+  using FEDWordsMap = std::map<int, std::vector<Word32>>;
+  using ModuleIDSet = std::set<unsigned int>;
 
   PixelDataFormatter(const SiPixelFedCablingTree* map, bool phase1 = false);
 
   void setErrorStatus(bool ErrorStatus);
   void setQualityStatus(bool QualityStatus, const SiPixelQuality* QualityInfo);
-  void setModulesToUnpack(const std::set<unsigned int>* moduleIds);
+  void setModulesToUnpack(const ModuleIDSet* moduleIds);
   void passFrameReverter(const SiPixelFrameReverter* reverter);
 
   int nDigis() const { return theDigiCounter; }
@@ -98,7 +101,7 @@ private:
   SiPixelFedCablingTree const* theCablingTree;
   const SiPixelFrameReverter* theFrameReverter;
   const SiPixelQuality* badPixelInfo;
-  const std::set<unsigned int>* modulesToUnpack;
+  const ModuleIDSet* modulesToUnpack;
 
   bool includeErrors;
   bool useQualityInfo;
@@ -111,10 +114,8 @@ private:
 
   int checkError(const Word32& data) const;
 
-  int digi2word(cms_uint32_t detId, const PixelDigi& digi, std::map<int, std::vector<Word32> >& words) const;
-  int digi2wordPhase1Layer1(cms_uint32_t detId,
-                            const PixelDigi& digi,
-                            std::map<int, std::vector<Word32> >& words) const;
+  int digi2word(cms_uint32_t detId, const PixelDigi& digi, FEDWordsMap& words) const;
+  int digi2wordPhase1Layer1(cms_uint32_t detId, const PixelDigi& digi, FEDWordsMap& words) const;
 
   std::string print(const PixelDigi& digi) const;
   std::string print(const Word64& word) const;

--- a/EventFilter/SiPixelRawToDigi/interface/PixelDataFormatter.h
+++ b/EventFilter/SiPixelRawToDigi/interface/PixelDataFormatter.h
@@ -37,6 +37,7 @@
 #include "DataFormats/SiPixelDigi/interface/PixelDigi.h"
 #include "DataFormats/Common/interface/DetSetVector.h"
 #include "DataFormats/SiPixelRawData/interface/SiPixelRawDataError.h"
+#include "DataFormats/SiPixelDigi/interface/SiPixelDigiConstants.h"
 #include "DataFormats/DetId/interface/DetIdCollection.h"
 #include "EventFilter/SiPixelRawToDigi/interface/ErrorChecker.h"
 #include "EventFilter/SiPixelRawToDigi/interface/ErrorCheckerPhase0.h"
@@ -67,9 +68,6 @@ public:
   typedef std::vector<PixelFEDChannel> DetBadChannels;
   typedef std::map<cms_uint32_t, DetBadChannels> BadChannels;
 
-  typedef cms_uint32_t Word32;
-  typedef cms_uint64_t Word64;
-
   PixelDataFormatter(const SiPixelFedCablingTree* map, bool phase1 = false);
 
   void setErrorStatus(bool ErrorStatus);
@@ -93,8 +91,6 @@ public:
                        edmNew::DetSetVector<PixelFEDChannel>& disabled_channelcollection,
                        DetErrors& nodeterrors);
 
-  cms_uint32_t getLinkId(cms_uint32_t word32) { return (word32 >> LINK_shift) & LINK_mask; }
-
 private:
   mutable int theDigiCounter;
   mutable int theWordCounter;
@@ -110,10 +106,6 @@ private:
   int hasDetDigis;
   std::unique_ptr<ErrorCheckerBase> errorcheck;
 
-  // For the 32bit data format (moved from *.cc namespace, keep uppercase for compatibility)
-  // Add special layer 1 roc for phase1
-  int ADC_shift, PXID_shift, DCOL_shift, ROC_shift, LINK_shift, ROW_shift, COL_shift;
-  Word32 LINK_mask, ROC_mask, DCOL_mask, PXID_mask, ADC_mask, ROW_mask, COL_mask;
   int maxROCIndex;
   bool phase1;
 

--- a/EventFilter/SiPixelRawToDigi/interface/PixelDataFormatter.h
+++ b/EventFilter/SiPixelRawToDigi/interface/PixelDataFormatter.h
@@ -71,15 +71,15 @@ public:
   using FEDWordsMap = std::map<int, std::vector<Word32>>;
   using ModuleIDSet = std::set<unsigned int>;
 
-  PixelDataFormatter(const SiPixelFedCablingTree* map, bool phase1 = false);
+  PixelDataFormatter(const SiPixelFedCablingTree* map, bool phase1_ = false);
 
   void setErrorStatus(bool ErrorStatus);
   void setQualityStatus(bool QualityStatus, const SiPixelQuality* QualityInfo);
   void setModulesToUnpack(const ModuleIDSet* moduleIds);
   void passFrameReverter(const SiPixelFrameReverter* reverter);
 
-  int nDigis() const { return theDigiCounter; }
-  int nWords() const { return theWordCounter; }
+  int nDigis() const { return theDigiCounter_; }
+  int nWords() const { return theWordCounter_; }
 
   void interpretRawData(bool& errorsInEvent, int fedId, const FEDRawData& data, Collection& digis, Errors& errors);
 
@@ -95,22 +95,22 @@ public:
                        DetErrors& nodeterrors);
 
 private:
-  mutable int theDigiCounter;
-  mutable int theWordCounter;
+  mutable int theDigiCounter_;
+  mutable int theWordCounter_;
 
-  SiPixelFedCablingTree const* theCablingTree;
-  const SiPixelFrameReverter* theFrameReverter;
-  const SiPixelQuality* badPixelInfo;
-  const ModuleIDSet* modulesToUnpack;
+  SiPixelFedCablingTree const* theCablingTree_;
+  const SiPixelFrameReverter* theFrameReverter_;
+  const SiPixelQuality* badPixelInfo_;
+  const ModuleIDSet* modulesToUnpack_;
 
-  bool includeErrors;
-  bool useQualityInfo;
-  int allDetDigis;
-  int hasDetDigis;
-  std::unique_ptr<ErrorCheckerBase> errorcheck;
+  bool includeErrors_;
+  bool useQualityInfo_;
+  int allDetDigis_;
+  int hasDetDigis_;
+  std::unique_ptr<ErrorCheckerBase> errorcheck_;
 
-  int maxROCIndex;
-  bool phase1;
+  int maxROCIndex_;
+  bool phase1_;
 
   int checkError(const Word32& data) const;
 

--- a/EventFilter/SiPixelRawToDigi/interface/PixelUnpackingRegions.h
+++ b/EventFilter/SiPixelRawToDigi/interface/PixelUnpackingRegions.h
@@ -1,5 +1,5 @@
-#ifndef PixelUnpackingRegions_H
-#define PixelUnpackingRegions_H
+#ifndef EventFilter_SiPixelRawToDigi_interface_PixelUnpackingRegions_h
+#define EventFilter_SiPixelRawToDigi_interface_PixelUnpackingRegions_h
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
@@ -126,4 +126,4 @@ private:
   edm::ESGetToken<SiPixelFedCablingMap, SiPixelFedCablingMapRcd> cablingMapToken_;
 };
 
-#endif
+#endif  // EventFilter_SiPixelRawToDigi_interface_PixelUnpackingRegions_h

--- a/EventFilter/SiPixelRawToDigi/plugins/SiPixelRawToDigi.cc
+++ b/EventFilter/SiPixelRawToDigi/plugins/SiPixelRawToDigi.cc
@@ -37,9 +37,12 @@
 #include "DataFormats/SiPixelDigi/interface/PixelDigi.h"
 #include "DataFormats/SiPixelDetId/interface/PixelFEDChannel.h"
 #include "DataFormats/SiPixelRawData/interface/SiPixelRawDataError.h"
+#include "DataFormats/SiPixelDigi/interface/SiPixelDigiConstants.h"
 
 #include "EventFilter/SiPixelRawToDigi/interface/PixelDataFormatter.h"
 #include "EventFilter/SiPixelRawToDigi/interface/PixelUnpackingRegions.h"
+
+using namespace sipixelconstants;
 
 /** \class SiPixelRawToDigi
  *  Plug-in module that performs Raw data to digi conversion 

--- a/EventFilter/SiPixelRawToDigi/src/ErrorChecker.cc
+++ b/EventFilter/SiPixelRawToDigi/src/ErrorChecker.cc
@@ -25,7 +25,7 @@ bool ErrorChecker::checkROC(bool& errorsInEvent,
                             const SiPixelFrameConverter* converter,
                             const SiPixelFedCabling* theCablingTree,
                             Word32& errorWord,
-                            SiPixelFormatterErrors& errors) {
+                            SiPixelFormatterErrors& errors) const {
   int errorType = (errorWord >> ROC_shift) & ERROR_mask;
   if LIKELY (errorType < 25)
     return true;

--- a/EventFilter/SiPixelRawToDigi/src/ErrorChecker.cc
+++ b/EventFilter/SiPixelRawToDigi/src/ErrorChecker.cc
@@ -16,32 +16,7 @@
 using namespace std;
 using namespace edm;
 using namespace sipixelobjects;
-
-namespace {
-  constexpr int CRC_bits = 1;
-  constexpr int LINK_bits = 6;
-  constexpr int ROC_bits = 5;
-  constexpr int DCOL_bits = 5;
-  constexpr int PXID_bits = 8;
-  constexpr int ADC_bits = 8;
-  constexpr int OMIT_ERR_bits = 1;
-
-  constexpr int CRC_shift = 2;
-  constexpr int ADC_shift = 0;
-  constexpr int PXID_shift = ADC_shift + ADC_bits;
-  constexpr int DCOL_shift = PXID_shift + PXID_bits;
-  constexpr int ROC_shift = DCOL_shift + DCOL_bits;
-  constexpr int LINK_shift = ROC_shift + ROC_bits;
-  constexpr int OMIT_ERR_shift = 20;
-
-  constexpr cms_uint32_t dummyDetId = 0xffffffff;
-
-  constexpr ErrorChecker::Word64 CRC_mask = ~(~ErrorChecker::Word64(0) << CRC_bits);
-  constexpr ErrorChecker::Word32 ERROR_mask = ~(~ErrorChecker::Word32(0) << ROC_bits);
-  constexpr ErrorChecker::Word32 LINK_mask = ~(~ErrorChecker::Word32(0) << LINK_bits);
-  constexpr ErrorChecker::Word32 ROC_mask = ~(~ErrorChecker::Word32(0) << ROC_bits);
-  constexpr ErrorChecker::Word32 OMIT_ERR_mask = ~(~ErrorChecker::Word32(0) << OMIT_ERR_bits);
-}  // namespace
+using namespace sipixelconstants;
 
 ErrorChecker::ErrorChecker() { includeErrors = false; }
 

--- a/EventFilter/SiPixelRawToDigi/src/ErrorChecker.cc
+++ b/EventFilter/SiPixelRawToDigi/src/ErrorChecker.cc
@@ -18,7 +18,7 @@ using namespace edm;
 using namespace sipixelobjects;
 using namespace sipixelconstants;
 
-ErrorChecker::ErrorChecker() { includeErrors = false; }
+ErrorChecker::ErrorChecker() : ErrorCheckerBase(){};
 
 bool ErrorChecker::checkROC(bool& errorsInEvent,
                             int fedId,

--- a/EventFilter/SiPixelRawToDigi/src/ErrorChecker.cc
+++ b/EventFilter/SiPixelRawToDigi/src/ErrorChecker.cc
@@ -25,7 +25,7 @@ bool ErrorChecker::checkROC(bool& errorsInEvent,
                             const SiPixelFrameConverter* converter,
                             const SiPixelFedCabling* theCablingTree,
                             Word32& errorWord,
-                            Errors& errors) {
+                            SiPixelFormatterErrors& errors) {
   int errorType = (errorWord >> ROC_shift) & ERROR_mask;
   if LIKELY (errorType < 25)
     return true;

--- a/EventFilter/SiPixelRawToDigi/src/ErrorChecker.cc
+++ b/EventFilter/SiPixelRawToDigi/src/ErrorChecker.cc
@@ -45,63 +45,6 @@ namespace {
 
 ErrorChecker::ErrorChecker() { includeErrors = false; }
 
-void ErrorChecker::setErrorStatus(bool ErrorStatus) { includeErrors = ErrorStatus; }
-
-bool ErrorChecker::checkCRC(bool& errorsInEvent, int fedId, const Word64* trailer, Errors& errors) {
-  int CRC_BIT = (*trailer >> CRC_shift) & CRC_mask;
-  if (CRC_BIT == 0)
-    return true;
-  errorsInEvent = true;
-  if (includeErrors) {
-    int errorType = 39;
-    SiPixelRawDataError error(*trailer, errorType, fedId);
-    errors[dummyDetId].push_back(error);
-  }
-  return false;
-}
-
-bool ErrorChecker::checkHeader(bool& errorsInEvent, int fedId, const Word64* header, Errors& errors) {
-  FEDHeader fedHeader(reinterpret_cast<const unsigned char*>(header));
-  if (!fedHeader.check())
-    return false;  // throw exception?
-  if (fedHeader.sourceID() != fedId) {
-    LogDebug("PixelDataFormatter::interpretRawData, fedHeader.sourceID() != fedId")
-        << ", sourceID = " << fedHeader.sourceID() << ", fedId = " << fedId << ", errorType = 32";
-    errorsInEvent = true;
-    if (includeErrors) {
-      int errorType = 32;
-      SiPixelRawDataError error(*header, errorType, fedId);
-      errors[dummyDetId].push_back(error);
-    }
-  }
-  return fedHeader.moreHeaders();
-}
-
-bool ErrorChecker::checkTrailer(
-    bool& errorsInEvent, int fedId, unsigned int nWords, const Word64* trailer, Errors& errors) {
-  FEDTrailer fedTrailer(reinterpret_cast<const unsigned char*>(trailer));
-  if (!fedTrailer.check()) {
-    if (includeErrors) {
-      int errorType = 33;
-      SiPixelRawDataError error(*trailer, errorType, fedId);
-      errors[dummyDetId].push_back(error);
-    }
-    errorsInEvent = true;
-    LogError("FedTrailerCheck") << "fedTrailer.check failed, Fed: " << fedId << ", errorType = 33";
-    return false;
-  }
-  if (fedTrailer.fragmentLength() != nWords) {
-    LogError("FedTrailerLenght") << "fedTrailer.fragmentLength()!= nWords !! Fed: " << fedId << ", errorType = 34";
-    errorsInEvent = true;
-    if (includeErrors) {
-      int errorType = 34;
-      SiPixelRawDataError error(*trailer, errorType, fedId);
-      errors[dummyDetId].push_back(error);
-    }
-  }
-  return fedTrailer.moreTrailers();
-}
-
 bool ErrorChecker::checkROC(bool& errorsInEvent,
                             int fedId,
                             const SiPixelFrameConverter* converter,
@@ -109,8 +52,8 @@ bool ErrorChecker::checkROC(bool& errorsInEvent,
                             Word32& errorWord,
                             Errors& errors) {
   int errorType = (errorWord >> ROC_shift) & ERROR_mask;
-  if
-    LIKELY(errorType < 25) return true;
+  if LIKELY (errorType < 25)
+    return true;
 
   switch (errorType) {
     case (25): {
@@ -175,54 +118,6 @@ bool ErrorChecker::checkROC(bool& errorsInEvent,
     errors[detId].push_back(error);
   }
   return false;
-}
-
-void ErrorChecker::conversionError(
-    int fedId, const SiPixelFrameConverter* converter, int status, Word32& errorWord, Errors& errors) {
-  switch (status) {
-    case (1): {
-      LogDebug("ErrorChecker::conversionError") << " Fed: " << fedId << "  invalid channel Id (errorType=35)";
-      if (includeErrors) {
-        int errorType = 35;
-        SiPixelRawDataError error(errorWord, errorType, fedId);
-        cms_uint32_t detId = errorDetId(converter, errorType, errorWord);
-        errors[detId].push_back(error);
-      }
-      break;
-    }
-    case (2): {
-      LogDebug("ErrorChecker::conversionError") << " Fed: " << fedId << "  invalid ROC Id (errorType=36)";
-      if (includeErrors) {
-        int errorType = 36;
-        SiPixelRawDataError error(errorWord, errorType, fedId);
-        cms_uint32_t detId = errorDetId(converter, errorType, errorWord);
-        errors[detId].push_back(error);
-      }
-      break;
-    }
-    case (3): {
-      LogDebug("ErrorChecker::conversionError") << " Fed: " << fedId << "  invalid dcol/pixel value (errorType=37)";
-      if (includeErrors) {
-        int errorType = 37;
-        SiPixelRawDataError error(errorWord, errorType, fedId);
-        cms_uint32_t detId = errorDetId(converter, errorType, errorWord);
-        errors[detId].push_back(error);
-      }
-      break;
-    }
-    case (4): {
-      LogDebug("ErrorChecker::conversionError") << " Fed: " << fedId << "  dcol/pixel read out of order (errorType=38)";
-      if (includeErrors) {
-        int errorType = 38;
-        SiPixelRawDataError error(errorWord, errorType, fedId);
-        cms_uint32_t detId = errorDetId(converter, errorType, errorWord);
-        errors[detId].push_back(error);
-      }
-      break;
-    }
-    default:
-      LogDebug("ErrorChecker::conversionError") << "  cabling check returned unexpected result, status = " << status;
-  };
 }
 
 // this function finds the detId for an error word that cannot be processed in word2digi

--- a/EventFilter/SiPixelRawToDigi/src/ErrorChecker.cc
+++ b/EventFilter/SiPixelRawToDigi/src/ErrorChecker.cc
@@ -85,7 +85,7 @@ bool ErrorChecker::checkROC(bool& errorsInEvent,
       return true;
   };
 
-  if (includeErrors) {
+  if (includeErrors_) {
     // store error
     SiPixelRawDataError error(errorWord, errorType, fedId);
     cms_uint32_t detId;

--- a/EventFilter/SiPixelRawToDigi/src/ErrorCheckerBase.cc
+++ b/EventFilter/SiPixelRawToDigi/src/ErrorCheckerBase.cc
@@ -22,14 +22,20 @@ ErrorCheckerBase::ErrorCheckerBase() : includeErrors_(false) {}
 
 void ErrorCheckerBase::setErrorStatus(bool ErrorStatus) { includeErrors_ = ErrorStatus; }
 
-void ErrorCheckerBase::addErrorToCollectionDummy(int errorType, int fedId, Word64 word, SiPixelFormatterErrors& errors) {
+void ErrorCheckerBase::addErrorToCollectionDummy(int errorType,
+                                                 int fedId,
+                                                 Word64 word,
+                                                 SiPixelFormatterErrors& errors) const {
   if (includeErrors_) {
     SiPixelRawDataError error(word, errorType, fedId);
     errors[sipixelconstants::dummyDetId].push_back(error);
   }
 }
 
-bool ErrorCheckerBase::checkCRC(bool& errorsInEvent, int fedId, const Word64* trailer, SiPixelFormatterErrors& errors) {
+bool ErrorCheckerBase::checkCRC(bool& errorsInEvent,
+                                int fedId,
+                                const Word64* trailer,
+                                SiPixelFormatterErrors& errors) const {
   const int CRC_BIT = (*trailer >> CRC_shift) & CRC_mask;
   const bool isCRCcorrect = (CRC_BIT == 0);
   if (!isCRCcorrect)
@@ -41,7 +47,7 @@ bool ErrorCheckerBase::checkCRC(bool& errorsInEvent, int fedId, const Word64* tr
 bool ErrorCheckerBase::checkHeader(bool& errorsInEvent,
                                    int fedId,
                                    const Word64* header,
-                                   SiPixelFormatterErrors& errors) {
+                                   SiPixelFormatterErrors& errors) const {
   FEDHeader fedHeader(reinterpret_cast<const unsigned char*>(header));
   const bool fedHeaderCorrect = fedHeader.check();
   // if not fedHeaderCorrect throw exception?
@@ -56,7 +62,7 @@ bool ErrorCheckerBase::checkHeader(bool& errorsInEvent,
 }
 
 bool ErrorCheckerBase::checkTrailer(
-    bool& errorsInEvent, int fedId, unsigned int nWords, const Word64* trailer, SiPixelFormatterErrors& errors) {
+    bool& errorsInEvent, int fedId, unsigned int nWords, const Word64* trailer, SiPixelFormatterErrors& errors) const {
   FEDTrailer fedTrailer(reinterpret_cast<const unsigned char*>(trailer));
   const bool fedTrailerCorrect = fedTrailer.check();
   if (!fedTrailerCorrect) {
@@ -74,8 +80,11 @@ bool ErrorCheckerBase::checkTrailer(
   return fedTrailerCorrect && fedTrailer.moreTrailers();
 }
 
-void ErrorCheckerBase::conversionError(
-    int fedId, const SiPixelFrameConverter* converter, int status, Word32& errorWord, SiPixelFormatterErrors& errors) {
+void ErrorCheckerBase::conversionError(int fedId,
+                                       const SiPixelFrameConverter* converter,
+                                       int status,
+                                       Word32& errorWord,
+                                       SiPixelFormatterErrors& errors) const {
   const int errorType = getConversionErrorTypeAndIssueLogMessage(status, fedId);
   // errorType == 0 means unexpected error, in this case we don't include it in the error collection
   if (errorType && includeErrors_) {

--- a/EventFilter/SiPixelRawToDigi/src/ErrorCheckerBase.cc
+++ b/EventFilter/SiPixelRawToDigi/src/ErrorCheckerBase.cc
@@ -1,0 +1,151 @@
+#include "EventFilter/SiPixelRawToDigi/interface/ErrorCheckerBase.h"
+
+#include "CondFormats/SiPixelObjects/interface/SiPixelFrameConverter.h"
+
+#include "DataFormats/DetId/interface/DetId.h"
+#include "DataFormats/SiPixelDetId/interface/PixelSubdetector.h"
+#include "DataFormats/FEDRawData/interface/FEDHeader.h"
+#include "DataFormats/FEDRawData/interface/FEDTrailer.h"
+
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+#include <bitset>
+#include <sstream>
+#include <iostream>
+
+using namespace std;
+using namespace edm;
+using namespace sipixelobjects;
+
+namespace {
+  constexpr int CRC_bits = 1;
+  constexpr int LINK_bits = 6;
+  constexpr int ROC_bits = 5;
+  constexpr int DCOL_bits = 5;
+  constexpr int PXID_bits = 8;
+  constexpr int ADC_bits = 8;
+  constexpr int OMIT_ERR_bits = 1;
+
+  constexpr int CRC_shift = 2;
+  constexpr int ADC_shift = 0;
+  constexpr int PXID_shift = ADC_shift + ADC_bits;
+  constexpr int DCOL_shift = PXID_shift + PXID_bits;
+  constexpr int ROC_shift = DCOL_shift + DCOL_bits;
+  constexpr int LINK_shift = ROC_shift + ROC_bits;
+  constexpr int OMIT_ERR_shift = 20;
+
+  constexpr cms_uint32_t dummyDetId = 0xffffffff;
+
+  constexpr ErrorCheckerBase::Word64 CRC_mask = ~(~ErrorCheckerBase::Word64(0) << CRC_bits);
+  constexpr ErrorCheckerBase::Word32 ERROR_mask = ~(~ErrorCheckerBase::Word32(0) << ROC_bits);
+  constexpr ErrorCheckerBase::Word32 LINK_mask = ~(~ErrorCheckerBase::Word32(0) << LINK_bits);
+  constexpr ErrorCheckerBase::Word32 ROC_mask = ~(~ErrorCheckerBase::Word32(0) << ROC_bits);
+  constexpr ErrorCheckerBase::Word32 OMIT_ERR_mask = ~(~ErrorCheckerBase::Word32(0) << OMIT_ERR_bits);
+}  // namespace
+
+ErrorCheckerBase::ErrorCheckerBase() : includeErrors(false) {}
+
+void ErrorCheckerBase::setErrorStatus(bool ErrorStatus) { includeErrors = ErrorStatus; }
+
+bool ErrorCheckerBase::checkCRC(bool& errorsInEvent, int fedId, const Word64* trailer, Errors& errors) {
+  int CRC_BIT = (*trailer >> CRC_shift) & CRC_mask;
+  if (CRC_BIT == 0)
+    return true;
+  errorsInEvent = true;
+  if (includeErrors) {
+    int errorType = 39;
+    SiPixelRawDataError error(*trailer, errorType, fedId);
+    errors[dummyDetId].push_back(error);
+  }
+  return false;
+}
+
+bool ErrorCheckerBase::checkHeader(bool& errorsInEvent, int fedId, const Word64* header, Errors& errors) {
+  FEDHeader fedHeader(reinterpret_cast<const unsigned char*>(header));
+  if (!fedHeader.check())
+    return false;  // throw exception?
+  if (fedHeader.sourceID() != fedId) {
+    LogDebug("PixelDataFormatter::interpretRawData, fedHeader.sourceID() != fedId")
+        << ", sourceID = " << fedHeader.sourceID() << ", fedId = " << fedId << ", errorType = 32";
+    errorsInEvent = true;
+    if (includeErrors) {
+      int errorType = 32;
+      SiPixelRawDataError error(*header, errorType, fedId);
+      errors[dummyDetId].push_back(error);
+    }
+  }
+  return fedHeader.moreHeaders();
+}
+
+bool ErrorCheckerBase::checkTrailer(
+    bool& errorsInEvent, int fedId, unsigned int nWords, const Word64* trailer, Errors& errors) {
+  FEDTrailer fedTrailer(reinterpret_cast<const unsigned char*>(trailer));
+  if (!fedTrailer.check()) {
+    if (includeErrors) {
+      int errorType = 33;
+      SiPixelRawDataError error(*trailer, errorType, fedId);
+      errors[dummyDetId].push_back(error);
+    }
+    errorsInEvent = true;
+    LogError("FedTrailerCheck") << "fedTrailer.check failed, Fed: " << fedId << ", errorType = 33";
+    return false;
+  }
+  if (fedTrailer.fragmentLength() != nWords) {
+    LogError("FedTrailerLenght") << "fedTrailer.fragmentLength()!= nWords !! Fed: " << fedId << ", errorType = 34";
+    errorsInEvent = true;
+    if (includeErrors) {
+      int errorType = 34;
+      SiPixelRawDataError error(*trailer, errorType, fedId);
+      errors[dummyDetId].push_back(error);
+    }
+  }
+  return fedTrailer.moreTrailers();
+}
+
+void ErrorCheckerBase::conversionError(
+    int fedId, const SiPixelFrameConverter* converter, int status, Word32& errorWord, Errors& errors) {
+  switch (status) {
+    case (1): {
+      LogDebug("ErrorChecker::conversionError") << " Fed: " << fedId << "  invalid channel Id (errorType=35)";
+      if (includeErrors) {
+        int errorType = 35;
+        SiPixelRawDataError error(errorWord, errorType, fedId);
+        cms_uint32_t detId = errorDetId(converter, errorType, errorWord);
+        errors[detId].push_back(error);
+      }
+      break;
+    }
+    case (2): {
+      LogDebug("ErrorChecker::conversionError") << " Fed: " << fedId << "  invalid ROC Id (errorType=36)";
+      if (includeErrors) {
+        int errorType = 36;
+        SiPixelRawDataError error(errorWord, errorType, fedId);
+        cms_uint32_t detId = errorDetId(converter, errorType, errorWord);
+        errors[detId].push_back(error);
+      }
+      break;
+    }
+    case (3): {
+      LogDebug("ErrorChecker::conversionError") << " Fed: " << fedId << "  invalid dcol/pixel value (errorType=37)";
+      if (includeErrors) {
+        int errorType = 37;
+        SiPixelRawDataError error(errorWord, errorType, fedId);
+        cms_uint32_t detId = errorDetId(converter, errorType, errorWord);
+        errors[detId].push_back(error);
+      }
+      break;
+    }
+    case (4): {
+      LogDebug("ErrorChecker::conversionError") << " Fed: " << fedId << "  dcol/pixel read out of order (errorType=38)";
+      if (includeErrors) {
+        int errorType = 38;
+        SiPixelRawDataError error(errorWord, errorType, fedId);
+        cms_uint32_t detId = errorDetId(converter, errorType, errorWord);
+        errors[detId].push_back(error);
+      }
+      break;
+    }
+    default:
+      LogDebug("ErrorChecker::conversionError") << "  cabling check returned unexpected result, status = " << status;
+  };
+}

--- a/EventFilter/SiPixelRawToDigi/src/ErrorCheckerBase.cc
+++ b/EventFilter/SiPixelRawToDigi/src/ErrorCheckerBase.cc
@@ -16,32 +16,7 @@
 using namespace std;
 using namespace edm;
 using namespace sipixelobjects;
-
-namespace {
-  constexpr int CRC_bits = 1;
-  constexpr int LINK_bits = 6;
-  constexpr int ROC_bits = 5;
-  constexpr int DCOL_bits = 5;
-  constexpr int PXID_bits = 8;
-  constexpr int ADC_bits = 8;
-  constexpr int OMIT_ERR_bits = 1;
-
-  constexpr int CRC_shift = 2;
-  constexpr int ADC_shift = 0;
-  constexpr int PXID_shift = ADC_shift + ADC_bits;
-  constexpr int DCOL_shift = PXID_shift + PXID_bits;
-  constexpr int ROC_shift = DCOL_shift + DCOL_bits;
-  constexpr int LINK_shift = ROC_shift + ROC_bits;
-  constexpr int OMIT_ERR_shift = 20;
-
-  constexpr cms_uint32_t dummyDetId = 0xffffffff;
-
-  constexpr ErrorCheckerBase::Word64 CRC_mask = ~(~ErrorCheckerBase::Word64(0) << CRC_bits);
-  constexpr ErrorCheckerBase::Word32 ERROR_mask = ~(~ErrorCheckerBase::Word32(0) << ROC_bits);
-  constexpr ErrorCheckerBase::Word32 LINK_mask = ~(~ErrorCheckerBase::Word32(0) << LINK_bits);
-  constexpr ErrorCheckerBase::Word32 ROC_mask = ~(~ErrorCheckerBase::Word32(0) << ROC_bits);
-  constexpr ErrorCheckerBase::Word32 OMIT_ERR_mask = ~(~ErrorCheckerBase::Word32(0) << OMIT_ERR_bits);
-}  // namespace
+using namespace sipixelconstants;
 
 ErrorCheckerBase::ErrorCheckerBase() : includeErrors(false) {}
 

--- a/EventFilter/SiPixelRawToDigi/src/ErrorCheckerBase.cc
+++ b/EventFilter/SiPixelRawToDigi/src/ErrorCheckerBase.cc
@@ -43,19 +43,16 @@ bool ErrorCheckerBase::checkHeader(bool& errorsInEvent,
                                    const Word64* header,
                                    SiPixelFormatterErrors& errors) {
   FEDHeader fedHeader(reinterpret_cast<const unsigned char*>(header));
-  if (!fedHeader.check())
-    return false;  // throw exception?
-  if (fedHeader.sourceID() != fedId) {
+  const bool fedHeaderCorrect = fedHeader.check();
+  // if not fedHeaderCorrect throw exception?
+  if (fedHeaderCorrect && (fedHeader.sourceID() != fedId)) {
+    int errorType = 32;
+    addErrorToCollectionDummy(errorType, fedId, *header, errors);
     LogDebug("PixelDataFormatter::interpretRawData, fedHeader.sourceID() != fedId")
-        << ", sourceID = " << fedHeader.sourceID() << ", fedId = " << fedId << ", errorType = 32";
+        << ", sourceID = " << fedHeader.sourceID() << ", fedId = " << fedId << ", errorType = " << errorType;
     errorsInEvent = true;
-    if (includeErrors_) {
-      int errorType = 32;
-      SiPixelRawDataError error(*header, errorType, fedId);
-      errors[sipixelconstants::dummyDetId].push_back(error);
-    }
   }
-  return fedHeader.moreHeaders();
+  return fedHeaderCorrect && fedHeader.moreHeaders();
 }
 
 bool ErrorCheckerBase::checkTrailer(

--- a/EventFilter/SiPixelRawToDigi/src/ErrorCheckerBase.cc
+++ b/EventFilter/SiPixelRawToDigi/src/ErrorCheckerBase.cc
@@ -22,7 +22,7 @@ ErrorCheckerBase::ErrorCheckerBase() : includeErrors_(false) {}
 
 void ErrorCheckerBase::setErrorStatus(bool ErrorStatus) { includeErrors_ = ErrorStatus; }
 
-bool ErrorCheckerBase::checkCRC(bool& errorsInEvent, int fedId, const Word64* trailer, Errors& errors) {
+bool ErrorCheckerBase::checkCRC(bool& errorsInEvent, int fedId, const Word64* trailer, SiPixelFormatterErrors& errors) {
   const int CRC_BIT = (*trailer >> CRC_shift) & CRC_mask;
   const bool isCRCcorrect = (CRC_BIT == 0);
   errorsInEvent = (errorsInEvent || !isCRCcorrect);
@@ -34,7 +34,10 @@ bool ErrorCheckerBase::checkCRC(bool& errorsInEvent, int fedId, const Word64* tr
   return isCRCcorrect;
 }
 
-bool ErrorCheckerBase::checkHeader(bool& errorsInEvent, int fedId, const Word64* header, Errors& errors) {
+bool ErrorCheckerBase::checkHeader(bool& errorsInEvent,
+                                   int fedId,
+                                   const Word64* header,
+                                   SiPixelFormatterErrors& errors) {
   FEDHeader fedHeader(reinterpret_cast<const unsigned char*>(header));
   if (!fedHeader.check())
     return false;  // throw exception?
@@ -52,7 +55,7 @@ bool ErrorCheckerBase::checkHeader(bool& errorsInEvent, int fedId, const Word64*
 }
 
 bool ErrorCheckerBase::checkTrailer(
-    bool& errorsInEvent, int fedId, unsigned int nWords, const Word64* trailer, Errors& errors) {
+    bool& errorsInEvent, int fedId, unsigned int nWords, const Word64* trailer, SiPixelFormatterErrors& errors) {
   FEDTrailer fedTrailer(reinterpret_cast<const unsigned char*>(trailer));
   if (!fedTrailer.check()) {
     if (includeErrors_) {
@@ -77,7 +80,7 @@ bool ErrorCheckerBase::checkTrailer(
 }
 
 void ErrorCheckerBase::conversionError(
-    int fedId, const SiPixelFrameConverter* converter, int status, Word32& errorWord, Errors& errors) {
+    int fedId, const SiPixelFrameConverter* converter, int status, Word32& errorWord, SiPixelFormatterErrors& errors) {
   const int errorType = getConversionErrorTypeAndIssueLogMessage(status, fedId);
   // errorType == 0 means unexpected error, in this case we don't include it in the error collection
   if (errorType && includeErrors_) {

--- a/EventFilter/SiPixelRawToDigi/src/ErrorCheckerBase.cc
+++ b/EventFilter/SiPixelRawToDigi/src/ErrorCheckerBase.cc
@@ -23,16 +23,15 @@ ErrorCheckerBase::ErrorCheckerBase() : includeErrors(false) {}
 void ErrorCheckerBase::setErrorStatus(bool ErrorStatus) { includeErrors = ErrorStatus; }
 
 bool ErrorCheckerBase::checkCRC(bool& errorsInEvent, int fedId, const Word64* trailer, Errors& errors) {
-  int CRC_BIT = (*trailer >> CRC_shift) & CRC_mask;
-  if (CRC_BIT == 0)
-    return true;
-  errorsInEvent = true;
-  if (includeErrors) {
-    int errorType = 39;
+  const int CRC_BIT = (*trailer >> CRC_shift) & CRC_mask;
+  const bool isCRCcorrect = (CRC_BIT == 0);
+  errorsInEvent = (errorsInEvent || !isCRCcorrect);
+  if (includeErrors && !isCRCcorrect) {
+    const int errorType = 39;
     SiPixelRawDataError error(*trailer, errorType, fedId);
     errors[dummyDetId].push_back(error);
   }
-  return false;
+  return isCRCcorrect;
 }
 
 bool ErrorCheckerBase::checkHeader(bool& errorsInEvent, int fedId, const Word64* header, Errors& errors) {

--- a/EventFilter/SiPixelRawToDigi/src/ErrorCheckerBase.cc
+++ b/EventFilter/SiPixelRawToDigi/src/ErrorCheckerBase.cc
@@ -22,15 +22,19 @@ ErrorCheckerBase::ErrorCheckerBase() : includeErrors_(false) {}
 
 void ErrorCheckerBase::setErrorStatus(bool ErrorStatus) { includeErrors_ = ErrorStatus; }
 
+void ErrorCheckerBase::addErrorToCollectionDummy(int errorType, int fedId, Word64 word, SiPixelFormatterErrors& errors) {
+  if (includeErrors_) {
+    SiPixelRawDataError error(word, errorType, fedId);
+    errors[sipixelconstants::dummyDetId].push_back(error);
+  }
+}
+
 bool ErrorCheckerBase::checkCRC(bool& errorsInEvent, int fedId, const Word64* trailer, SiPixelFormatterErrors& errors) {
   const int CRC_BIT = (*trailer >> CRC_shift) & CRC_mask;
   const bool isCRCcorrect = (CRC_BIT == 0);
+  if (!isCRCcorrect)
+    addErrorToCollectionDummy(39, fedId, *trailer, errors);
   errorsInEvent = (errorsInEvent || !isCRCcorrect);
-  if (includeErrors_ && !isCRCcorrect) {
-    const int errorType = 39;
-    SiPixelRawDataError error(*trailer, errorType, fedId);
-    errors[sipixelconstants::dummyDetId].push_back(error);
-  }
   return isCRCcorrect;
 }
 

--- a/EventFilter/SiPixelRawToDigi/src/ErrorCheckerPhase0.cc
+++ b/EventFilter/SiPixelRawToDigi/src/ErrorCheckerPhase0.cc
@@ -25,7 +25,7 @@ bool ErrorCheckerPhase0::checkROC(bool& errorsInEvent,
                                   const SiPixelFrameConverter* converter,
                                   const SiPixelFedCabling* theCablingTree,
                                   Word32& errorWord,
-                                  Errors& errors) {
+                                  SiPixelFormatterErrors& errors) {
   int errorType = (errorWord >> ROC_shift) & ERROR_mask;
   if LIKELY (errorType < 25)
     return true;

--- a/EventFilter/SiPixelRawToDigi/src/ErrorCheckerPhase0.cc
+++ b/EventFilter/SiPixelRawToDigi/src/ErrorCheckerPhase0.cc
@@ -70,7 +70,7 @@ bool ErrorCheckerPhase0::checkROC(bool& errorsInEvent,
       return true;
   };
 
-  if (includeErrors) {
+  if (includeErrors_) {
     // check to see if overflow error for type 30, change type to 40 if so
     if (errorType == 30) {
       int StateMach_bits = 4;

--- a/EventFilter/SiPixelRawToDigi/src/ErrorCheckerPhase0.cc
+++ b/EventFilter/SiPixelRawToDigi/src/ErrorCheckerPhase0.cc
@@ -18,7 +18,7 @@ using namespace edm;
 using namespace sipixelobjects;
 using namespace sipixelconstants;
 
-ErrorCheckerPhase0::ErrorCheckerPhase0() { includeErrors = false; }
+ErrorCheckerPhase0::ErrorCheckerPhase0() : ErrorCheckerBase(){};
 
 bool ErrorCheckerPhase0::checkROC(bool& errorsInEvent,
                                   int fedId,

--- a/EventFilter/SiPixelRawToDigi/src/ErrorCheckerPhase0.cc
+++ b/EventFilter/SiPixelRawToDigi/src/ErrorCheckerPhase0.cc
@@ -25,7 +25,7 @@ bool ErrorCheckerPhase0::checkROC(bool& errorsInEvent,
                                   const SiPixelFrameConverter* converter,
                                   const SiPixelFedCabling* theCablingTree,
                                   Word32& errorWord,
-                                  SiPixelFormatterErrors& errors) {
+                                  SiPixelFormatterErrors& errors) const {
   int errorType = (errorWord >> ROC_shift) & ERROR_mask;
   if LIKELY (errorType < 25)
     return true;

--- a/EventFilter/SiPixelRawToDigi/src/ErrorCheckerPhase0.cc
+++ b/EventFilter/SiPixelRawToDigi/src/ErrorCheckerPhase0.cc
@@ -16,32 +16,7 @@
 using namespace std;
 using namespace edm;
 using namespace sipixelobjects;
-
-namespace {
-  constexpr int CRC_bits = 1;
-  constexpr int LINK_bits = 6;
-  constexpr int ROC_bits = 5;
-  constexpr int DCOL_bits = 5;
-  constexpr int PXID_bits = 8;
-  constexpr int ADC_bits = 8;
-  constexpr int OMIT_ERR_bits = 1;
-
-  constexpr int CRC_shift = 2;
-  constexpr int ADC_shift = 0;
-  constexpr int PXID_shift = ADC_shift + ADC_bits;
-  constexpr int DCOL_shift = PXID_shift + PXID_bits;
-  constexpr int ROC_shift = DCOL_shift + DCOL_bits;
-  constexpr int LINK_shift = ROC_shift + ROC_bits;
-  constexpr int OMIT_ERR_shift = 20;
-
-  constexpr cms_uint32_t dummyDetId = 0xffffffff;
-
-  constexpr ErrorCheckerPhase0::Word64 CRC_mask = ~(~ErrorCheckerPhase0::Word64(0) << CRC_bits);
-  constexpr ErrorCheckerPhase0::Word32 ERROR_mask = ~(~ErrorCheckerPhase0::Word32(0) << ROC_bits);
-  constexpr ErrorCheckerPhase0::Word32 LINK_mask = ~(~ErrorCheckerPhase0::Word32(0) << LINK_bits);
-  constexpr ErrorCheckerPhase0::Word32 ROC_mask = ~(~ErrorCheckerPhase0::Word32(0) << ROC_bits);
-  constexpr ErrorCheckerPhase0::Word32 OMIT_ERR_mask = ~(~ErrorCheckerPhase0::Word32(0) << OMIT_ERR_bits);
-}  // namespace
+using namespace sipixelconstants;
 
 ErrorCheckerPhase0::ErrorCheckerPhase0() { includeErrors = false; }
 

--- a/EventFilter/SiPixelRawToDigi/src/PixelDataFormatter.cc
+++ b/EventFilter/SiPixelRawToDigi/src/PixelDataFormatter.cc
@@ -129,8 +129,8 @@ void PixelDataFormatter::interpretRawData(
       theWordCounter--;
       continue;
     }
-    int nlink = (ww >> LINK_shift) & LINK_mask;
-    int nroc = (ww >> ROC_shift) & ROC_mask;
+    int nlink = getLink(ww);
+    int nroc = getROC(ww);
 
     if ((nlink != link) | (nroc != roc)) {  // new roc
       link = nlink;
@@ -173,13 +173,13 @@ void PixelDataFormatter::interpretRawData(
     if UNLIKELY (skipROC || !rocp)
       continue;
 
-    int adc = (ww >> ADC_shift) & ADC_mask;
+    int adc = getADC(ww);
     std::unique_ptr<LocalPixel> local;
 
     if (phase1 && layer == 1) {  // special case for layer 1ROC
       // for l1 roc use the roc column and row index instead of dcol and pixel index.
-      int col = (ww >> COL_shift) & COL_mask;
-      int row = (ww >> ROW_shift) & ROW_mask;
+      int col = getCol(ww);
+      int row = getRow(ww);
 
       LocalPixel::RocRowCol localCR = {row, col};  // build pixel
       if UNLIKELY (!localCR.valid()) {
@@ -191,9 +191,8 @@ void PixelDataFormatter::interpretRawData(
       local = std::make_unique<LocalPixel>(localCR);  // local pixel coordinate
 
     } else {  // phase0 and phase1 except bpix layer 1
-      int dcol = (ww >> DCOL_shift) & DCOL_mask;
-      int pxid = (ww >> PXID_shift) & PXID_mask;
-
+      int dcol = getDCol(ww);
+      int pxid = getPxId(ww);
       LocalPixel::DcolPxid localDP = {dcol, pxid};
 
       if UNLIKELY (!localDP.valid()) {

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelRawToClusterGPUKernel.cu
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelRawToClusterGPUKernel.cu
@@ -22,6 +22,7 @@
 #include "CondFormats/SiPixelObjects/interface/SiPixelROCsStatusAndMapping.h"
 #include "DataFormats/FEDRawData/interface/FEDNumbering.h"
 #include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+#include "DataFormats/SiPixelDigi/interface/SiPixelDigiConstants.h"
 #include "HeterogeneousCore/CUDAUtilities/interface/cudaCheck.h"
 #include "HeterogeneousCore/CUDAUtilities/interface/device_unique_ptr.h"
 #include "HeterogeneousCore/CUDAUtilities/interface/host_unique_ptr.h"
@@ -51,14 +52,6 @@ namespace pixelgpudetails {
   }
 
   ////////////////////
-
-  __device__ uint32_t getLink(uint32_t ww) {
-    return ((ww >> pixelgpudetails::LINK_shift) & pixelgpudetails::LINK_mask);
-  }
-
-  __device__ uint32_t getRoc(uint32_t ww) { return ((ww >> pixelgpudetails::ROC_shift) & pixelgpudetails::ROC_mask); }
-
-  __device__ uint32_t getADC(uint32_t ww) { return ((ww >> pixelgpudetails::ADC_shift) & pixelgpudetails::ADC_mask); }
 
   __device__ bool isBarrel(uint32_t rawId) {
     return (PixelSubdetector::PixelBarrel == ((rawId >> DetId::kSubdetOffset) & DetId::kSubdetMask));
@@ -378,8 +371,8 @@ namespace pixelgpudetails {
         continue;
       }
 
-      uint32_t link = getLink(ww);  // Extract link
-      uint32_t roc = getRoc(ww);    // Extract Roc in link
+      uint32_t link = sipixelconstants::getLink(ww);  // Extract link
+      uint32_t roc = sipixelconstants::getROC(ww);    // Extract Roc in link
       pixelgpudetails::DetIdGPU detId = getRawId(cablingMap, fedId, link, roc);
 
       uint8_t errorType = checkROC(ww, fedId, link, cablingMap, debug);
@@ -454,7 +447,7 @@ namespace pixelgpudetails {
       pixelgpudetails::Pixel globalPix = frameConversion(barrel, side, layer, rocIdInDetUnit, localPix);
       xx[gIndex] = globalPix.row;  // origin shifting by 1 0-159
       yy[gIndex] = globalPix.col;  // origin shifting by 1 0-415
-      adc[gIndex] = getADC(ww);
+      adc[gIndex] = sipixelconstants::getADC(ww);
       pdigi[gIndex] = pixelgpudetails::pack(globalPix.row, globalPix.col, adc[gIndex]);
       moduleId[gIndex] = detId.moduleId;
       rawIdArr[gIndex] = rawId;

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelRawToClusterGPUKernel.cu
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelRawToClusterGPUKernel.cu
@@ -277,7 +277,7 @@ namespace pixelgpudetails {
       case 36:
       case 40: {
         uint32_t roc = 1;
-        uint32_t link = (errWord >> sipixelconstants::LINK_shift) & sipixelconstants::LINK_mask;
+        uint32_t link = sipixelconstants::getLink(errWord);
         uint32_t rID_temp = getRawId(cablingMap, fedId, link, roc).rawId;
         if (rID_temp != gpuClustering::invalidModuleId)
           rID = rID_temp;
@@ -318,8 +318,8 @@ namespace pixelgpudetails {
       }
       case 37:
       case 38: {
-        uint32_t roc = (errWord >> sipixelconstants::ROC_shift) & sipixelconstants::ROC_mask;
-        uint32_t link = (errWord >> sipixelconstants::LINK_shift) & sipixelconstants::LINK_mask;
+        uint32_t roc = sipixelconstants::getROC(errWord);
+        uint32_t link = sipixelconstants::getLink(errWord);
         uint32_t rID_temp = getRawId(cablingMap, fedId, link, roc).rawId;
         if (rID_temp != gpuClustering::invalidModuleId)
           rID = rID_temp;
@@ -414,8 +414,8 @@ namespace pixelgpudetails {
       // ***special case of layer to 1 be handled here
       pixelgpudetails::Pixel localPix;
       if (layer == 1) {
-        uint32_t col = (ww >> sipixelconstants::COL_shift) & sipixelconstants::COL_mask;
-        uint32_t row = (ww >> sipixelconstants::ROW_shift) & sipixelconstants::ROW_mask;
+        uint32_t col = sipixelconstants::getCol(ww);
+        uint32_t row = sipixelconstants::getRow(ww);
         localPix.row = row;
         localPix.col = col;
         if (includeErrors) {
@@ -429,8 +429,8 @@ namespace pixelgpudetails {
         }
       } else {
         // ***conversion rules for dcol and pxid
-        uint32_t dcol = (ww >> sipixelconstants::DCOL_shift) & sipixelconstants::DCOL_mask;
-        uint32_t pxid = (ww >> sipixelconstants::PXID_shift) & sipixelconstants::PXID_mask;
+        uint32_t dcol = sipixelconstants::getDCol(ww);
+        uint32_t pxid = sipixelconstants::getPxId(ww);
         uint32_t row = pixelgpudetails::numRowsInRoc - pxid / 2;
         uint32_t col = dcol * 2 + pxid % 2;
         localPix.row = row;

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelRawToClusterGPUKernel.cu
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelRawToClusterGPUKernel.cu
@@ -188,7 +188,7 @@ namespace pixelgpudetails {
                               uint32_t link,
                               const SiPixelROCsStatusAndMapping *cablingMap,
                               bool debug = false) {
-    uint8_t errorType = (errorWord >> pixelgpudetails::ROC_shift) & pixelgpudetails::ERROR_mask;
+    uint8_t errorType = (errorWord >> sipixelconstants::ROC_shift) & sipixelconstants::ERROR_mask;
     if (errorType < 25)
       return 0;
     bool errorFound = false;
@@ -226,7 +226,7 @@ namespace pixelgpudetails {
       case (29): {
         if (debug)
           printf("Timeout on a channel (errorType = 29)\n");
-        if ((errorWord >> pixelgpudetails::OMIT_ERR_shift) & pixelgpudetails::OMIT_ERR_mask) {
+        if ((errorWord >> sipixelconstants::OMIT_ERR_shift) & sipixelconstants::OMIT_ERR_mask) {
           if (debug)
             printf("...first errorType=29 error, this gets masked out\n");
         }
@@ -277,7 +277,7 @@ namespace pixelgpudetails {
       case 36:
       case 40: {
         uint32_t roc = 1;
-        uint32_t link = (errWord >> pixelgpudetails::LINK_shift) & pixelgpudetails::LINK_mask;
+        uint32_t link = (errWord >> sipixelconstants::LINK_shift) & sipixelconstants::LINK_mask;
         uint32_t rID_temp = getRawId(cablingMap, fedId, link, roc).rawId;
         if (rID_temp != gpuClustering::invalidModuleId)
           rID = rID_temp;
@@ -318,8 +318,8 @@ namespace pixelgpudetails {
       }
       case 37:
       case 38: {
-        uint32_t roc = (errWord >> pixelgpudetails::ROC_shift) & pixelgpudetails::ROC_mask;
-        uint32_t link = (errWord >> pixelgpudetails::LINK_shift) & pixelgpudetails::LINK_mask;
+        uint32_t roc = (errWord >> sipixelconstants::ROC_shift) & sipixelconstants::ROC_mask;
+        uint32_t link = (errWord >> sipixelconstants::LINK_shift) & sipixelconstants::LINK_mask;
         uint32_t rID_temp = getRawId(cablingMap, fedId, link, roc).rawId;
         if (rID_temp != gpuClustering::invalidModuleId)
           rID = rID_temp;
@@ -414,8 +414,8 @@ namespace pixelgpudetails {
       // ***special case of layer to 1 be handled here
       pixelgpudetails::Pixel localPix;
       if (layer == 1) {
-        uint32_t col = (ww >> pixelgpudetails::COL_shift) & pixelgpudetails::COL_mask;
-        uint32_t row = (ww >> pixelgpudetails::ROW_shift) & pixelgpudetails::ROW_mask;
+        uint32_t col = (ww >> sipixelconstants::COL_shift) & sipixelconstants::COL_mask;
+        uint32_t row = (ww >> sipixelconstants::ROW_shift) & sipixelconstants::ROW_mask;
         localPix.row = row;
         localPix.col = col;
         if (includeErrors) {
@@ -429,8 +429,8 @@ namespace pixelgpudetails {
         }
       } else {
         // ***conversion rules for dcol and pxid
-        uint32_t dcol = (ww >> pixelgpudetails::DCOL_shift) & pixelgpudetails::DCOL_mask;
-        uint32_t pxid = (ww >> pixelgpudetails::PXID_shift) & pixelgpudetails::PXID_mask;
+        uint32_t dcol = (ww >> sipixelconstants::DCOL_shift) & sipixelconstants::DCOL_mask;
+        uint32_t pxid = (ww >> sipixelconstants::PXID_shift) & sipixelconstants::PXID_mask;
         uint32_t row = pixelgpudetails::numRowsInRoc - pxid / 2;
         uint32_t col = dcol * 2 + pxid % 2;
         localPix.row = row;

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelRawToClusterGPUKernel.h
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelRawToClusterGPUKernel.h
@@ -22,60 +22,28 @@ class SiPixelGainForHLTonGPU;
 
 namespace pixelgpudetails {
 
-  // Phase 1 geometry constants
-  const uint32_t layerStartBit = 20;
-  const uint32_t ladderStartBit = 12;
-  const uint32_t moduleStartBit = 2;
+  inline namespace phase1geometry {
+    const uint32_t layerStartBit = 20;
+    const uint32_t ladderStartBit = 12;
+    const uint32_t moduleStartBit = 2;
 
-  const uint32_t panelStartBit = 10;
-  const uint32_t diskStartBit = 18;
-  const uint32_t bladeStartBit = 12;
+    const uint32_t panelStartBit = 10;
+    const uint32_t diskStartBit = 18;
+    const uint32_t bladeStartBit = 12;
 
-  const uint32_t layerMask = 0xF;
-  const uint32_t ladderMask = 0xFF;
-  const uint32_t moduleMask = 0x3FF;
-  const uint32_t panelMask = 0x3;
-  const uint32_t diskMask = 0xF;
-  const uint32_t bladeMask = 0x3F;
-
-  const uint32_t LINK_bits = 6;
-  const uint32_t ROC_bits = 5;
-  const uint32_t DCOL_bits = 5;
-  const uint32_t PXID_bits = 8;
-  const uint32_t ADC_bits = 8;
-
-  // special for layer 1
-  const uint32_t LINK_bits_l1 = 6;
-  const uint32_t ROC_bits_l1 = 5;
-  const uint32_t COL_bits_l1 = 6;
-  const uint32_t ROW_bits_l1 = 7;
-  const uint32_t OMIT_ERR_bits = 1;
+    const uint32_t layerMask = 0xF;
+    const uint32_t ladderMask = 0xFF;
+    const uint32_t moduleMask = 0x3FF;
+    const uint32_t panelMask = 0x3;
+    const uint32_t diskMask = 0xF;
+    const uint32_t bladeMask = 0x3F;
+  }  // namespace phase1geometry
 
   const uint32_t maxROCIndex = 8;
   const uint32_t numRowsInRoc = 80;
   const uint32_t numColsInRoc = 52;
 
   const uint32_t MAX_WORD = 2000;
-
-  const uint32_t ADC_shift = 0;
-  const uint32_t PXID_shift = ADC_shift + ADC_bits;
-  const uint32_t DCOL_shift = PXID_shift + PXID_bits;
-  const uint32_t ROC_shift = DCOL_shift + DCOL_bits;
-  const uint32_t LINK_shift = ROC_shift + ROC_bits_l1;
-  // special for layer 1 ROC
-  const uint32_t ROW_shift = ADC_shift + ADC_bits;
-  const uint32_t COL_shift = ROW_shift + ROW_bits_l1;
-  const uint32_t OMIT_ERR_shift = 20;
-
-  const uint32_t LINK_mask = ~(~uint32_t(0) << LINK_bits_l1);
-  const uint32_t ROC_mask = ~(~uint32_t(0) << ROC_bits_l1);
-  const uint32_t COL_mask = ~(~uint32_t(0) << COL_bits_l1);
-  const uint32_t ROW_mask = ~(~uint32_t(0) << ROW_bits_l1);
-  const uint32_t DCOL_mask = ~(~uint32_t(0) << DCOL_bits);
-  const uint32_t PXID_mask = ~(~uint32_t(0) << PXID_bits);
-  const uint32_t ADC_mask = ~(~uint32_t(0) << ADC_bits);
-  const uint32_t ERROR_mask = ~(~uint32_t(0) << ROC_bits_l1);
-  const uint32_t OMIT_ERR_mask = ~(~uint32_t(0) << OMIT_ERR_bits);
 
   struct DetIdGPU {
     uint32_t rawId;


### PR DESCRIPTION
### PR description:

This PR should resolve some duplication issues, namely:
1. from #32483 reuse existing constants in `SiPixelRawToClusterGPUKernel`
2. #26731 avoid code duplication in `SiPixelRawToDigi` `ErrorChecker's`

Accordingly, the changes made can be categorized this way:
1. Reusing different bit manipulation constants in all the `ErrorCheckers`, as well as `PixelDataFormatter` and `SiPixelRawToClusterGPUKernel`
As part of this effort I introduced a new namespace with some `constexpr` variables and functions named `sipixelconstants` and placed it in `DataFormats/SiPixelDigi`. It should probably have a different name, and I suppose a more appropriate place would be `DataFormats/SiPixelRawToDigi`, but I let that the more experienced contributors decide. I just didn't want to do the fifth rebase yet.
2. Move common functions from `ErrorCheckerPhase0` and `ErrorChecker` (this is phase 1) to `ErrorCheckerBase`
This is really not harmful.

### PR validation:

Since this PR influences parts of the code which don't contribute to `DQM` histograms, there was a custom validation that took place.

Basically, I was just printing the `FED errors` before and after the changes and comparing them.

#### This is the description of this validation:

---
#### Phase 0 - workflow 136.731

1. Run workflow, modify # of events to `4000`
```sh
runTheMatrix.py -e -l 136.731 --ibeos -t 4 -j 0 --maxSteps=3
```

2. Run `step2` and `step3`
 During `step3` log events with `FED errors`.

3. Select events with at least one `FED error`:
    In repository `/afs/cern.ch/work/a/aczirkos/public/errorchecker_validation/phase1`
    the file `runlumievent.txt` contains `378` entries of `run:lumi:event`

4. With `edmPickEventy.py` use this file to filter the events
```sh
edmPickEvents.py "SinglePhoton/Run2016B-v2/RAW" <filename> --crab
```

5. Run with `crab`
```sh
crab submit -c pickevents_crab.py
crab getoutput
```

Example result file in repository `/afs/cern.ch/work/a/aczirkos/public/errorchecker_validation/phase0` the file `step2.root`

6. Run on reduced dataset `step3` before and after the changes.

Use some custom `LogDebug` to track error collection. Make sure that no messages get dropped (indicated at the end of some generated log file).

Example of adding `LogDebug` entry:
```diff
diff --git a/EventFilter/SiPixelRawToDigi/src/PixelDataFormatter.cc b/EventFilter/SiPixelRawToDigi/src/PixelDataFormatter.cc
index 5557f806144..02a177018b5 100644
--- a/EventFilter/SiPixelRawToDigi/src/PixelDataFormatter.cc
+++ b/EventFilter/SiPixelRawToDigi/src/PixelDataFormatter.cc
@@ -417,6 +417,11 @@ void PixelDataFormatter::unpackFEDErrors(PixelDataFormatter::Errors const& error
                                          DetErrors& nodeterrors) {
   const uint32_t dummyDetId = 0xffffffff;
   for (const auto& [errorDetId, rawErrorsVec] : errors) {
+	for (auto const& aPixelError : rawErrorsVec) {
+        LogDebug("FedErrors") << "DETID: " << errorDetId << "; FED: " << aPixelError.getFedId()
+                              << ", TYPE: " << aPixelError.getType() << ", WORD: " << aPixelError.getWord32()
+                              << ", MSG: " << aPixelError.getMessage();
+      }
     if (errorDetId == dummyDetId) {  // errors given dummy detId must be sorted by Fed
       nodeterrors.insert(nodeterrors.end(), rawErrorsVec.begin(), rawErrorsVec.end());
     } else {
```

Example `MessageLogger` entry for `cmsDriver.py` python config file:
```py
# Output info to file detailedInfo.log
process.MessageLogger = cms.Service("MessageLogger",
    destinations = cms.untracked.vstring('detailedInfo'),
    categories         = cms.untracked.vstring('FedErrors'),
    debugModules  = cms.untracked.vstring('*'),
        detailedInfo          = cms.untracked.PSet(
        threshold =  cms.untracked.string('DEBUG'),
        default    =  cms.untracked.PSet(limit = cms.untracked.int32(0)),
        INFO       =  cms.untracked.PSet(limit = cms.untracked.int32(0)),
        DEBUG   = cms.untracked.PSet(limit = cms.untracked.int32(0)),
        FedErrors = cms.untracked.PSet(limit = cms.untracked.int32(10000000))
    )
)
```

8. Compare the two log files

Extract lines with FED errors
```sh
grep DETID detailedInfo.log > errors01.log
```

##### Results
##### Number # of FED errors by type in the validation data
```
      1 TYPE:30
     15 TYPE:31
    148 TYPE:37
    249 TYPE:40
```

In the repository `/afs/cern.ch/work/a/aczirkos/public/errorchecker_validation/phase0` there are the log files, root file and python config of the validation:
```sh
ls -halt /afs/cern.ch/work/a/aczirkos/public/errorchecker_validation/phase0 
total 238M
drwxr-xr-x. 2 aczirkos zh 2,0K máj  28 15.38 .
-rw-r--r--. 1 aczirkos zh  62K máj  28 15.38 step3.py
drwxr-xr-x. 4 aczirkos zh 2,0K máj  28 15.31 ..
-rw-r--r--. 1 aczirkos zh  36K máj  25 16.01 errors_01.log
-rw-r--r--. 1 aczirkos zh  36K máj  25 16.01 errors_02.log
-rw-r--r--. 1 aczirkos zh 7,1K máj  25 16.01 select_events.txt
-rw-r--r--. 1 aczirkos zh 237M máj  25 14.37 step2.root
```

One can compare the errors (in `bash` shell) such as
```sh
diff <(sort errors_01.log) <(sort errors_02.log)
```
In this example `errors_01.log` is before and `errors_02.log` is after changes.
They should have no differences.

---
#### Phase 1 workflow 136.816

1. Run workflow, only single-threaded
```sh
runTheMatrix.py -e -l 136.816 --ibeos -t 1 -j 0 --maxSteps=3
```

Since FED errors are more common in the phase 1 data, running on *100* events will suffice.

2. Basically do the same as with phase 0 just without steps 2-5. (since almost all events have errors)

##### Results
##### Number # of FED errors by type in the validation data
```
  21500 TYPE:25
     93 TYPE:30
     55 TYPE:31
   6683 TYPE:37
```
Now from the repository `/afs/cern.ch/work/a/aczirkos/public/errorchecker_validation/phase1`
```sh
ls -halt /afs/cern.ch/work/a/aczirkos/public/errorchecker_validation/phase1/
total 882M
drwxr-xr-x. 2 aczirkos zh 2,0K máj  28 17.26 .
-rw-r--r--. 1 aczirkos zh 2,7M máj  28 17.25 errors_02.log
-rw-r--r--. 1 aczirkos zh 2,7M máj  28 16.49 errors_01.log
-rw-r--r--. 1 aczirkos zh  20K máj  28 15.38 step3.py
-rw-r--r--. 1 aczirkos zh 876M máj  28 15.36 step2.root
drwxr-xr-x. 4 aczirkos zh 2,0K máj  28 15.31 ..
```
And comparing the results (again, `errors_01.log` is before and `errors_02.log` is after changes)
```sh
diff <(sort errors_01.log) <(sort errors_02.log)
```
Again, no differences should appear.

### if this PR is a backport please specify the original PR and why you need to backport that PR:
it is not