### PR TITLE
Removed CalibTracker/SiStripCommon dependency from CalibFormats/SiStripObjects

### DIFF
--- a/Alignment/OfflineValidation/plugins/BuildFile.xml
+++ b/Alignment/OfflineValidation/plugins/BuildFile.xml
@@ -10,6 +10,7 @@
 <use name="CondFormats/BeamSpotObjects"/>
 <use name="CondFormats/RunInfo"/>
 <use name="CondFormats/SiPixelObjects"/>
+<use name="CalibTracker/SiStripCommon"/>
 <use name="DQM/TrackerRemapper"/>
 <use name="DQMServices/Core"/>
 <use name="DataFormats/BeamSpot"/>

--- a/CalibFormats/SiStripObjects/BuildFile.xml
+++ b/CalibFormats/SiStripObjects/BuildFile.xml
@@ -1,7 +1,6 @@
 <use name="FWCore/MessageLogger"/>
 <use name="DataFormats/SiStripCommon"/>
 <use name="CondFormats/SiStripObjects"/>
-<use name="CalibTracker/SiStripCommon"/>
 <use name="DataFormats/TrackerCommon"/>
 <export>
   <lib name="1"/>

--- a/CalibFormats/SiStripObjects/interface/SiStripDetInfo.h
+++ b/CalibFormats/SiStripObjects/interface/SiStripDetInfo.h
@@ -1,0 +1,71 @@
+#ifndef CalibFormats_SiStripObjects_SiStripDetInfo_h
+#define CalibFormats_SiStripObjects_SiStripDetInfo_h
+// -*- C++ -*-
+//
+// Package:     CalibFormats/SiStripObjects
+// Class  :     SiStripDetInfo
+//
+/**\class SiStripDetInfo SiStripDetInfo.h "SiStripDetInfo.h"
+
+ Description: [one line class summary]
+
+ Usage:
+    <usage>
+
+*/
+//
+// Original Author:  Christopher Jones
+//         Created:  Fri, 28 May 2021 20:02:00 GMT
+//
+
+// system include files
+
+// user include files
+#include <map>
+#include <vector>
+
+// forward declarations
+
+class SiStripDetInfo {
+public:
+  struct DetInfo {
+    DetInfo(){};
+    DetInfo(unsigned short _nApvs, double _stripLength, float _thickness)
+        : nApvs(_nApvs), stripLength(_stripLength), thickness(_thickness){};
+
+    unsigned short nApvs;
+    double stripLength;
+    float thickness;
+  };
+
+  SiStripDetInfo(std::map<uint32_t, DetInfo> iDetData, std::vector<uint32_t> iIDs) noexcept
+      : detData_{std::move(iDetData)}, detIds_{std::move(iIDs)} {}
+
+  SiStripDetInfo() = default;
+  ~SiStripDetInfo() = default;
+
+  SiStripDetInfo(const SiStripDetInfo&) = default;
+  SiStripDetInfo& operator=(const SiStripDetInfo&) = default;
+  SiStripDetInfo(SiStripDetInfo&&) = default;
+  SiStripDetInfo& operator=(SiStripDetInfo&&) = default;
+
+  // ---------- const member functions ---------------------
+  const std::vector<uint32_t>& getAllDetIds() const noexcept { return detIds_; }
+
+  const std::pair<unsigned short, double> getNumberOfApvsAndStripLength(uint32_t detId) const;
+
+  const float& getThickness(uint32_t detId) const;
+
+  const std::map<uint32_t, DetInfo>& getAllData() const noexcept { return detData_; }
+
+  // ---------- static member functions --------------------
+
+  // ---------- member functions ---------------------------
+
+private:
+  // ---------- member data --------------------------------
+  std::map<uint32_t, DetInfo> detData_;
+  std::vector<uint32_t> detIds_;
+};
+
+#endif

--- a/CalibFormats/SiStripObjects/interface/SiStripGain.h
+++ b/CalibFormats/SiStripObjects/interface/SiStripGain.h
@@ -40,6 +40,7 @@
 #include <vector>
 
 class TrackerTopology;
+class SiStripDetInfo;
 
 class SiStripGain {
 public:
@@ -48,22 +49,25 @@ public:
   const SiStripGain &operator=(const SiStripGain &) = delete;
 
   /// Kept for compatibility
-  inline SiStripGain(const SiStripApvGain &apvgain, const double &factor) : apvgain_(nullptr) {
-    multiply(apvgain, factor, std::make_pair("", ""));
+  inline SiStripGain(const SiStripApvGain &apvgain, const double &factor, const SiStripDetInfo &detInfo)
+      : apvgain_(nullptr) {
+    multiply(apvgain, factor, std::make_pair("", ""), detInfo);
   }
 
   inline SiStripGain(const SiStripApvGain &apvgain,
                      const double &factor,
-                     const std::pair<std::string, std::string> &recordLabelPair)
+                     const std::pair<std::string, std::string> &recordLabelPair,
+                     const SiStripDetInfo &detInfo)
       : apvgain_(nullptr) {
-    multiply(apvgain, factor, recordLabelPair);
+    multiply(apvgain, factor, recordLabelPair, detInfo);
   }
 
   /// Used to input additional gain values that will be multiplied to the first
   /// one
   void multiply(const SiStripApvGain &apvgain,
                 const double &factor,
-                const std::pair<std::string, std::string> &recordLabelPair);
+                const std::pair<std::string, std::string> &recordLabelPair,
+                const SiStripDetInfo &detInfo);
 
   // getters
   // For the product of all apvGains
@@ -103,6 +107,7 @@ public:
 private:
   void fillNewGain(const SiStripApvGain *apvgain,
                    const double &factor,
+                   SiStripDetInfo const &detInfo,
                    const SiStripApvGain *apvgain2 = nullptr,
                    const double &factor2 = 1.);
 

--- a/CalibFormats/SiStripObjects/interface/SiStripQuality.h
+++ b/CalibFormats/SiStripObjects/interface/SiStripQuality.h
@@ -49,7 +49,7 @@ public:
   SiStripQuality(const SiStripQuality &) = default;
   SiStripQuality(SiStripQuality &&) = default;
 
-  ~SiStripQuality() = default;
+  ~SiStripQuality() override = default;
 
   void clear() {
     v_badstrips.clear();

--- a/CalibFormats/SiStripObjects/interface/SiStripQuality.h
+++ b/CalibFormats/SiStripObjects/interface/SiStripQuality.h
@@ -23,7 +23,6 @@
 #include "CondFormats/SiStripObjects/interface/SiStripBadStrip.h"
 #include "CondFormats/SiStripObjects/interface/SiStripDetVOff.h"
 #include "CalibFormats/SiStripObjects/interface/SiStripDetInfo.h"
-#include "FWCore/ParameterSet/interface/FileInPath.h"
 #include <vector>
 
 class SiStripDetCabling;

--- a/CalibFormats/SiStripObjects/interface/SiStripQuality.h
+++ b/CalibFormats/SiStripObjects/interface/SiStripQuality.h
@@ -22,11 +22,12 @@
 #include "CondFormats/RunInfo/interface/RunInfo.h"
 #include "CondFormats/SiStripObjects/interface/SiStripBadStrip.h"
 #include "CondFormats/SiStripObjects/interface/SiStripDetVOff.h"
+#include "CalibFormats/SiStripObjects/interface/SiStripDetInfo.h"
 #include "FWCore/ParameterSet/interface/FileInPath.h"
 #include <vector>
 
 class SiStripDetCabling;
-class SiStripDetInfoFileReader;
+class SiStripDetInfo;
 class TrackerTopology;
 
 class SiStripQuality final : public SiStripBadStrip {
@@ -43,11 +44,12 @@ public:
     bool operator()(const BadComponent &p, const uint32_t i) const { return p.detid < i; }
   };
 
-  SiStripQuality();  // takes default file for SiStripDetInfoFileReader
-  SiStripQuality(edm::FileInPath &);
-  SiStripQuality(const SiStripQuality &);  // copy constructor
+  SiStripQuality() = delete;
+  explicit SiStripQuality(SiStripDetInfo);
+  SiStripQuality(const SiStripQuality &) = default;
+  SiStripQuality(SiStripQuality &&) = default;
 
-  ~SiStripQuality() override;
+  ~SiStripQuality() = default;
 
   void clear() {
     v_badstrips.clear();
@@ -76,13 +78,7 @@ public:
 
   void ReduceGranularity(double);
 
-  SiStripQuality &operator+=(const SiStripQuality &);
-  SiStripQuality &operator-=(const SiStripQuality &);
-  const SiStripQuality operator-(const SiStripQuality &) const;
-  bool operator==(const SiStripQuality &) const;
-  bool operator!=(const SiStripQuality &) const;
-
-  edm::FileInPath getFileInPath() const { return FileInPath_; }
+  SiStripQuality difference(const SiStripQuality &) const;
 
   //------- Interface for the user ----------//
   bool IsModuleUsable(const uint32_t &detid) const;
@@ -149,10 +145,8 @@ private:
                            const std::vector<int> &differentFeds,
                            const bool printDebug);
 
+  SiStripDetInfo info_;
   bool toCleanUp;
-  edm::FileInPath FileInPath_;
-  SiStripDetInfoFileReader *reader;
-
   std::vector<BadComponent> BadComponentVect;
 
   const SiStripDetCabling *SiStripDetCabling_;

--- a/CalibFormats/SiStripObjects/src/SiStripDelay.cc
+++ b/CalibFormats/SiStripObjects/src/SiStripDelay.cc
@@ -8,7 +8,6 @@
 //         Created:  26/10/2010
 
 #include "CalibFormats/SiStripObjects/interface/SiStripDelay.h"
-#include "CalibTracker/SiStripCommon/interface/SiStripDetInfoFileReader.h"
 #include "CondFormats/SiStripObjects/interface/SiStripDetSummary.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/Utilities/interface/typelookup.h"

--- a/CalibFormats/SiStripObjects/src/SiStripDetInfo.cc
+++ b/CalibFormats/SiStripObjects/src/SiStripDetInfo.cc
@@ -1,0 +1,47 @@
+// -*- C++ -*-
+//
+// Package:     CalibFormats/SiStripObjects
+// Class  :     SiStripDetInfo
+//
+// Implementation:
+//     [Notes on implementation]
+//
+// Original Author:  Christopher Jones
+//         Created:  Fri, 28 May 2021 20:10:25 GMT
+//
+
+// system include files
+
+// user include files
+#include "CalibFormats/SiStripObjects/interface/SiStripDetInfo.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+const std::pair<unsigned short, double> SiStripDetInfo::getNumberOfApvsAndStripLength(uint32_t detId) const {
+  std::map<uint32_t, DetInfo>::const_iterator it = detData_.find(detId);
+
+  if (it != detData_.end()) {
+    return std::pair<unsigned short, double>(it->second.nApvs, it->second.stripLength);
+
+  } else {
+    std::pair<unsigned short, double> defaultValue(0, 0.);
+    edm::LogWarning(
+        "SiStripDetInfoFileReader::getNumberOfApvsAndStripLength - Unable to find requested detid. Returning invalid "
+        "data ")
+        << std::endl;
+    return defaultValue;
+  }
+}
+
+const float& SiStripDetInfo::getThickness(uint32_t detId) const {
+  std::map<uint32_t, DetInfo>::const_iterator it = detData_.find(detId);
+
+  if (it != detData_.end()) {
+    return it->second.thickness;
+
+  } else {
+    static const float defaultValue = 0;
+    edm::LogWarning("SiStripDetInfo::getThickness - Unable to find requested detid. Returning invalid data ")
+        << std::endl;
+    return defaultValue;
+  }
+}

--- a/CalibFormats/SiStripObjects/test/BuildFile.xml
+++ b/CalibFormats/SiStripObjects/test/BuildFile.xml
@@ -10,6 +10,7 @@
 </library>
 
 <bin name="TestCalibFormatsSiStripObjects" file="UnitTests/TestSiStripGain.cc, UnitTests/TestSiStripDelay.cc, UnitTests/MasterTest.cpp">
+  <use name="CalibTracker/SiStripCommon"/>
   <use name="CalibFormats/SiStripObjects"/>
   <use name="cppunit"/>
 </bin>

--- a/CalibFormats/SiStripObjects/test/UnitTests/TestSiStripGain.cc
+++ b/CalibFormats/SiStripObjects/test/UnitTests/TestSiStripGain.cc
@@ -71,7 +71,7 @@ public:
     normVector.push_back(norm1);
     normVector.push_back(norm2);
 
-    edm::FileInPath fp("CalibTracker/SiStripCommon/data/SiStripDetInfo.dat");
+    edm::FileInPath fp(SiStripDetInfoFileReader::kDefaultFile);
     SiStripDetInfoFileReader reader(fp.fullPath());
 
     SiStripGain gain(*apvGain1, norm1, recordLabelPair1, reader.info());
@@ -88,7 +88,7 @@ public:
   }
 
   void apvGainsTest(const float &norm) {
-    edm::FileInPath fp("CalibTracker/SiStripCommon/data/SiStripDetInfo.dat");
+    edm::FileInPath fp(SiStripDetInfoFileReader::kDefaultFile);
     SiStripDetInfoFileReader reader(fp.fullPath());
 
     SiStripGain gain(*apvGain1, norm, reader.info());

--- a/CalibFormats/SiStripObjects/test/UnitTests/TestSiStripGain.cc
+++ b/CalibFormats/SiStripObjects/test/UnitTests/TestSiStripGain.cc
@@ -13,6 +13,7 @@
 
 #include "CalibFormats/SiStripObjects/interface/SiStripGain.h"
 #include "CalibTracker/SiStripCommon/interface/SiStripDetInfoFileReader.h"
+#include "FWCore/ParameterSet/interface/FileInPath.h"
 
 #ifndef TestSiStripGain_cc
 #define TestSiStripGain_cc

--- a/CalibFormats/SiStripObjects/test/UnitTests/TestSiStripGain.cc
+++ b/CalibFormats/SiStripObjects/test/UnitTests/TestSiStripGain.cc
@@ -12,6 +12,7 @@
 #include <iterator>
 
 #include "CalibFormats/SiStripObjects/interface/SiStripGain.h"
+#include "CalibTracker/SiStripCommon/interface/SiStripDetInfoFileReader.h"
 
 #ifndef TestSiStripGain_cc
 #define TestSiStripGain_cc
@@ -69,8 +70,11 @@ public:
     normVector.push_back(norm1);
     normVector.push_back(norm2);
 
-    SiStripGain gain(*apvGain1, norm1, recordLabelPair1);
-    gain.multiply(*apvGain2, norm2, recordLabelPair2);
+    edm::FileInPath fp("CalibTracker/SiStripCommon/data/SiStripDetInfo.dat");
+    SiStripDetInfoFileReader reader(fp.fullPath());
+
+    SiStripGain gain(*apvGain1, norm1, recordLabelPair1, reader.info());
+    gain.multiply(*apvGain2, norm2, recordLabelPair2, reader.info());
     SiStripApvGain::Range range = gain.getRange(detId);
 
     // Check multiplication
@@ -83,7 +87,10 @@ public:
   }
 
   void apvGainsTest(const float &norm) {
-    SiStripGain gain(*apvGain1, norm);
+    edm::FileInPath fp("CalibTracker/SiStripCommon/data/SiStripDetInfo.dat");
+    SiStripDetInfoFileReader reader(fp.fullPath());
+
+    SiStripGain gain(*apvGain1, norm, reader.info());
     SiStripApvGain::Range range = gain.getRange(detId);
     CPPUNIT_ASSERT(float(gain.getApvGain(0, range)) == float(1. / norm));
     CPPUNIT_ASSERT(float(gain.getApvGain(1, range)) == float(0.8 / norm));
@@ -91,7 +98,7 @@ public:
     CPPUNIT_ASSERT(float(gain.getApvGain(3, range)) == float(2. / norm));
     checkTag(gain, norm, "", "");
 
-    SiStripGain gain2(*apvGain2, norm);
+    SiStripGain gain2(*apvGain2, norm, reader.info());
     SiStripApvGain::Range range2 = gain2.getRange(detId);
     CPPUNIT_ASSERT(float(gain2.getApvGain(0, range2)) == float(1. / norm));
     CPPUNIT_ASSERT(float(gain2.getApvGain(1, range2)) == float(1. / (norm * 0.8)));

--- a/CalibTracker/SiStripChannelGain/BuildFile.xml
+++ b/CalibTracker/SiStripChannelGain/BuildFile.xml
@@ -4,6 +4,7 @@
 <use name="CalibFormats/SiStripObjects"/>
 <use name="CalibTracker/Records"/>
 <use name="CondFormats/SiStripObjects"/>
+<use name="CalibTracker/SiStripCommon"/>
 <use name="DataFormats/DetId"/>
 <use name="DataFormats/FEDRawData"/>
 <use name="DataFormats/TrackerCommon"/>

--- a/CalibTracker/SiStripCommon/interface/SiStripDetInfoFileReader.h
+++ b/CalibTracker/SiStripCommon/interface/SiStripDetInfoFileReader.h
@@ -30,7 +30,7 @@ class SiStripDetInfoFileReader {
 public:
   using DetInfo = SiStripDetInfo::DetInfo;
 
-  constexpr static char const * const kDefaultFile = "CalibTracker/SiStripCommon/data/SiStripDetInfo.dat";
+  constexpr static char const* const kDefaultFile = "CalibTracker/SiStripCommon/data/SiStripDetInfo.dat";
   explicit SiStripDetInfoFileReader(){};
 
   explicit SiStripDetInfoFileReader(std::string filePath);

--- a/CalibTracker/SiStripCommon/interface/SiStripDetInfoFileReader.h
+++ b/CalibTracker/SiStripCommon/interface/SiStripDetInfoFileReader.h
@@ -23,8 +23,6 @@
 #include <string>
 #include <iostream>
 #include <fstream>
-#include "FWCore/ServiceRegistry/interface/Service.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "CalibFormats/SiStripObjects/interface/SiStripDetInfo.h"
 #include <cstdint>
 
@@ -33,7 +31,6 @@ public:
   using DetInfo = SiStripDetInfo::DetInfo;
 
   explicit SiStripDetInfoFileReader(){};
-  explicit SiStripDetInfoFileReader(const edm::ParameterSet&, const edm::ActivityRegistry&);
 
   explicit SiStripDetInfoFileReader(std::string filePath);
   explicit SiStripDetInfoFileReader(const SiStripDetInfoFileReader&);

--- a/CalibTracker/SiStripCommon/interface/SiStripDetInfoFileReader.h
+++ b/CalibTracker/SiStripCommon/interface/SiStripDetInfoFileReader.h
@@ -25,19 +25,12 @@
 #include <fstream>
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "CalibFormats/SiStripObjects/interface/SiStripDetInfo.h"
 #include <cstdint>
 
 class SiStripDetInfoFileReader {
 public:
-  struct DetInfo {
-    DetInfo(){};
-    DetInfo(unsigned short _nApvs, double _stripLength, float _thickness)
-        : nApvs(_nApvs), stripLength(_stripLength), thickness(_thickness){};
-
-    unsigned short nApvs;
-    double stripLength;
-    float thickness;
-  };
+  using DetInfo = SiStripDetInfo::DetInfo;
 
   explicit SiStripDetInfoFileReader(){};
   explicit SiStripDetInfoFileReader(const edm::ParameterSet&, const edm::ActivityRegistry&);
@@ -49,23 +42,23 @@ public:
 
   SiStripDetInfoFileReader& operator=(const SiStripDetInfoFileReader& copy);
 
-  const std::vector<uint32_t>& getAllDetIds() const { return detIds_; }
+  SiStripDetInfo const& info() const { return info_; }
 
-  const std::pair<unsigned short, double> getNumberOfApvsAndStripLength(uint32_t detId) const;
+  const std::vector<uint32_t>& getAllDetIds() const { return info_.getAllDetIds(); }
 
-  const float& getThickness(uint32_t detId) const;
+  const std::pair<unsigned short, double> getNumberOfApvsAndStripLength(uint32_t detId) const {
+    return info_.getNumberOfApvsAndStripLength(detId);
+  }
 
-  const std::map<uint32_t, DetInfo>& getAllData() const { return detData_; }
+  const float& getThickness(uint32_t detId) const { return info_.getThickness(detId); }
+
+  const std::map<uint32_t, DetInfo>& getAllData() const { return info_.getAllData(); }
 
 private:
   void reader(std::string filePath);
 
   std::ifstream inputFile_;
-  //  std::string filePath_;
 
-  std::map<uint32_t, DetInfo> detData_;
-  //  std::map<uint32_t, std::pair<unsigned short, double> > detData_;
-  //std::map<uint32_t, float > detThickness_;
-  std::vector<uint32_t> detIds_;
+  SiStripDetInfo info_;
 };
 #endif

--- a/CalibTracker/SiStripCommon/interface/SiStripDetInfoFileReader.h
+++ b/CalibTracker/SiStripCommon/interface/SiStripDetInfoFileReader.h
@@ -30,6 +30,7 @@ class SiStripDetInfoFileReader {
 public:
   using DetInfo = SiStripDetInfo::DetInfo;
 
+  constexpr static char const * const kDefaultFile = "CalibTracker/SiStripCommon/data/SiStripDetInfo.dat";
   explicit SiStripDetInfoFileReader(){};
 
   explicit SiStripDetInfoFileReader(std::string filePath);

--- a/CalibTracker/SiStripCommon/src/SiStripDetInfoFileReader.cc
+++ b/CalibTracker/SiStripCommon/src/SiStripDetInfoFileReader.cc
@@ -13,8 +13,7 @@ using namespace cms;
 using namespace std;
 
 SiStripDetInfoFileReader& SiStripDetInfoFileReader::operator=(const SiStripDetInfoFileReader& copy) {
-  detData_ = copy.detData_;
-  detIds_ = copy.detIds_;
+  info_ = copy.info_;
   return *this;
 }
 
@@ -24,10 +23,7 @@ SiStripDetInfoFileReader::SiStripDetInfoFileReader(const edm::ParameterSet& pset
   reader(fp.fullPath());
 }
 
-SiStripDetInfoFileReader::SiStripDetInfoFileReader(const SiStripDetInfoFileReader& copy) {
-  detData_ = copy.detData_;
-  detIds_ = copy.detIds_;
-}
+SiStripDetInfoFileReader::SiStripDetInfoFileReader(const SiStripDetInfoFileReader& copy) : info_{copy.info_} {}
 
 SiStripDetInfoFileReader::SiStripDetInfoFileReader(std::string filePath) { reader(filePath); }
 
@@ -38,8 +34,8 @@ void SiStripDetInfoFileReader::reader(std::string filePath) {
 
   edm::LogInfo("SiStripDetInfoFileReader") << "filePath " << filePath << std::endl;
 
-  detData_.clear();
-  detIds_.clear();
+  std::map<uint32_t, DetInfo> detData_;
+  std::vector<uint32_t> detIds_;
 
   inputFile_.open(filePath.c_str());
 
@@ -88,6 +84,7 @@ void SiStripDetInfoFileReader::reader(std::string filePath) {
     return;
   }
 
+  info_ = SiStripDetInfo(detData_, detIds_);
   //   int i=0;
   //   for(std::map<uint32_t, std::pair<unsigned short, double> >::iterator it =detData_.begin(); it!=detData_.end(); it++ ) {
   //     std::cout<< it->first << " " << (it->second).first << " " << (it->second).second<<endl;
@@ -97,33 +94,3 @@ void SiStripDetInfoFileReader::reader(std::string filePath) {
 }
 
 SiStripDetInfoFileReader::~SiStripDetInfoFileReader() {}
-
-const std::pair<unsigned short, double> SiStripDetInfoFileReader::getNumberOfApvsAndStripLength(uint32_t detId) const {
-  std::map<uint32_t, DetInfo>::const_iterator it = detData_.find(detId);
-
-  if (it != detData_.end()) {
-    return std::pair<unsigned short, double>(it->second.nApvs, it->second.stripLength);
-
-  } else {
-    std::pair<unsigned short, double> defaultValue(0, 0.);
-    edm::LogWarning(
-        "SiStripDetInfoFileReader::getNumberOfApvsAndStripLength - Unable to find requested detid. Returning invalid "
-        "data ")
-        << endl;
-    return defaultValue;
-  }
-}
-
-const float& SiStripDetInfoFileReader::getThickness(uint32_t detId) const {
-  std::map<uint32_t, DetInfo>::const_iterator it = detData_.find(detId);
-
-  if (it != detData_.end()) {
-    return it->second.thickness;
-
-  } else {
-    static const float defaultValue = 0;
-    edm::LogWarning("SiStripDetInfoFileReader::getThickness - Unable to find requested detid. Returning invalid data ")
-        << endl;
-    return defaultValue;
-  }
-}

--- a/CalibTracker/SiStripCommon/src/SiStripDetInfoFileReader.cc
+++ b/CalibTracker/SiStripCommon/src/SiStripDetInfoFileReader.cc
@@ -17,12 +17,6 @@ SiStripDetInfoFileReader& SiStripDetInfoFileReader::operator=(const SiStripDetIn
   return *this;
 }
 
-SiStripDetInfoFileReader::SiStripDetInfoFileReader(const edm::ParameterSet& pset, const edm::ActivityRegistry& ar) {
-  edm::FileInPath fp(
-      pset.getUntrackedParameter<std::string>("filePath", "CalibTracker/SiStripCommon/data/SiStripDetInfo.dat"));
-  reader(fp.fullPath());
-}
-
 SiStripDetInfoFileReader::SiStripDetInfoFileReader(const SiStripDetInfoFileReader& copy) : info_{copy.info_} {}
 
 SiStripDetInfoFileReader::SiStripDetInfoFileReader(std::string filePath) { reader(filePath); }

--- a/CalibTracker/SiStripESProducers/BuildFile.xml
+++ b/CalibTracker/SiStripESProducers/BuildFile.xml
@@ -1,4 +1,5 @@
 <use name="CalibFormats/SiStripObjects"/>
+<use name="CalibTracker/SiStripCommon"/>
 <use name="CondFormats/DataRecord"/>
 <use name="CondFormats/SiStripObjects"/>
 <use name="DataFormats/SiStripCommon"/>

--- a/CalibTracker/SiStripESProducers/plugins/BuildFile.xml
+++ b/CalibTracker/SiStripESProducers/plugins/BuildFile.xml
@@ -2,6 +2,7 @@
   <use name="CalibTracker/Records"/>
   <use name="CalibTracker/SiStripESProducers"/>
   <use name="CondCore/DBOutputService"/>
+  <use name="Geometry/TrackerNumberingBuilder"/>
   <flags EDM_PLUGIN="1"/>
 </library>
 

--- a/CalibTracker/SiStripESProducers/plugins/fake/SiStripBadModuleConfigurableFakeESSource.cc
+++ b/CalibTracker/SiStripESProducers/plugins/fake/SiStripBadModuleConfigurableFakeESSource.cc
@@ -81,7 +81,7 @@ SiStripBadModuleConfigurableFakeESSource::ReturnType SiStripBadModuleConfigurabl
 
   TrackerTopology const& tTopo = iRecord.get(trackTopoToken_);
 
-  auto quality = std::make_unique<SiStripQuality>();
+  auto quality = std::make_unique<SiStripQuality>(m_detInfoFileReader.info());
 
   if (!m_doByAPVs) {
     std::vector<uint32_t> selDetIds{selectDetectors(&tTopo, m_detInfoFileReader.getAllDetIds())};

--- a/CalibTracker/SiStripESProducers/plugins/fake/SiStripQualityFakeESSource.cc
+++ b/CalibTracker/SiStripESProducers/plugins/fake/SiStripQualityFakeESSource.cc
@@ -17,6 +17,7 @@
 //
 
 #include "CalibTracker/SiStripESProducers/plugins/fake/SiStripQualityFakeESSource.h"
+#include "CalibTracker/SiStripCommon/interface/SiStripDetInfoFileReader.h"
 
 SiStripQualityFakeESSource::SiStripQualityFakeESSource(const edm::ParameterSet& iConfig) {
   setWhatProduced(this);
@@ -24,7 +25,10 @@ SiStripQualityFakeESSource::SiStripQualityFakeESSource(const edm::ParameterSet& 
 }
 
 std::unique_ptr<SiStripQuality> SiStripQualityFakeESSource::produce(const SiStripQualityRcd& iRecord) {
-  return std::make_unique<SiStripQuality>();
+  edm::FileInPath path("CalibTracker/SiStripCommon/data/SiStripDetInfo.dat");
+  SiStripDetInfoFileReader reader(path.fullPath());
+
+  return std::make_unique<SiStripQuality>(reader.info());
 }
 
 void SiStripQualityFakeESSource::setIntervalFor(const edm::eventsetup::EventSetupRecordKey&,

--- a/CalibTracker/SiStripESProducers/plugins/fake/SiStripQualityFakeESSource.cc
+++ b/CalibTracker/SiStripESProducers/plugins/fake/SiStripQualityFakeESSource.cc
@@ -25,7 +25,7 @@ SiStripQualityFakeESSource::SiStripQualityFakeESSource(const edm::ParameterSet& 
 }
 
 std::unique_ptr<SiStripQuality> SiStripQualityFakeESSource::produce(const SiStripQualityRcd& iRecord) {
-  edm::FileInPath path("CalibTracker/SiStripCommon/data/SiStripDetInfo.dat");
+  edm::FileInPath path(SiStripDetInfoFileReader::kDefaultFile);
   SiStripDetInfoFileReader reader(path.fullPath());
 
   return std::make_unique<SiStripQuality>(reader.info());

--- a/CalibTracker/SiStripESProducers/plugins/fake/SiStripQualityFakeESSource.h
+++ b/CalibTracker/SiStripESProducers/plugins/fake/SiStripQualityFakeESSource.h
@@ -23,6 +23,8 @@ class SiStripQualityFakeESSource : public edm::ESProducer, public edm::EventSetu
 public:
   SiStripQualityFakeESSource(const edm::ParameterSet&);
   ~SiStripQualityFakeESSource() override{};
+  SiStripQualityFakeESSource(const SiStripQualityFakeESSource&) = delete;
+  const SiStripQualityFakeESSource& operator=(const SiStripQualityFakeESSource&) = delete;
 
   std::unique_ptr<SiStripQuality> produce(const SiStripQualityRcd&);
 
@@ -30,9 +32,6 @@ private:
   void setIntervalFor(const edm::eventsetup::EventSetupRecordKey&,
                       const edm::IOVSyncValue& iov,
                       edm::ValidityInterval& iValidity) override;
-
-  SiStripQualityFakeESSource(const SiStripQualityFakeESSource&) = delete;
-  const SiStripQualityFakeESSource& operator=(const SiStripQualityFakeESSource&) = delete;
 };
 
 #endif

--- a/CalibTracker/SiStripESProducers/plugins/real/SiStripGainESProducer.cc
+++ b/CalibTracker/SiStripESProducers/plugins/real/SiStripGainESProducer.cc
@@ -13,6 +13,7 @@
 #include "CondFormats/SiStripObjects/interface/SiStripApvGain.h"
 #include "CondFormats/DataRecord/interface/SiStripCondDataRecords.h"
 #include "CalibTracker/Records/interface/SiStripDependentRecords.h"
+#include "CalibTracker/SiStripCommon/interface/SiStripDetInfoFileReader.h"
 
 #include "SiStripGainFactor.h"
 
@@ -91,14 +92,18 @@ SiStripGainESProducer::SiStripGainESProducer(const edm::ParameterSet& iConfig) :
 }
 
 std::unique_ptr<SiStripGain> SiStripGainESProducer::produce(const SiStripGainRcd& iRecord) {
+  edm::FileInPath fp("CalibTracker/SiStripCommon/data/SiStripDetInfo.dat");
+  SiStripDetInfoFileReader reader(fp.fullPath());
+
   const auto& apvGain = gainGetters_[0]->gain(iRecord);
   // Create a new gain object and insert the ApvGain
-  auto gain = std::make_unique<SiStripGain>(apvGain, factor_.get(apvGain, 0), gainGetters_[0]->recordLabel());
+  auto gain =
+      std::make_unique<SiStripGain>(apvGain, factor_.get(apvGain, 0), gainGetters_[0]->recordLabel(), reader.info());
 
   for (unsigned int i = 1; i < gainGetters_.size(); ++i) {
     const auto& apvGain = gainGetters_[i]->gain(iRecord);
     // Add the new ApvGain to the gain object
-    gain->multiply(apvGain, factor_.get(apvGain, i), gainGetters_[i]->recordLabel());
+    gain->multiply(apvGain, factor_.get(apvGain, i), gainGetters_[i]->recordLabel(), reader.info());
   }
 
   return gain;

--- a/CalibTracker/SiStripESProducers/plugins/real/SiStripGainESProducer.cc
+++ b/CalibTracker/SiStripESProducers/plugins/real/SiStripGainESProducer.cc
@@ -92,7 +92,7 @@ SiStripGainESProducer::SiStripGainESProducer(const edm::ParameterSet& iConfig) :
 }
 
 std::unique_ptr<SiStripGain> SiStripGainESProducer::produce(const SiStripGainRcd& iRecord) {
-  edm::FileInPath fp("CalibTracker/SiStripCommon/data/SiStripDetInfo.dat");
+  edm::FileInPath fp(SiStripDetInfoFileReader::kDefaultFile);
   SiStripDetInfoFileReader reader(fp.fullPath());
 
   const auto& apvGain = gainGetters_[0]->gain(iRecord);

--- a/CalibTracker/SiStripESProducers/plugins/real/SiStripGainSimESProducer.cc
+++ b/CalibTracker/SiStripESProducers/plugins/real/SiStripGainSimESProducer.cc
@@ -13,6 +13,7 @@
 #include "CondFormats/SiStripObjects/interface/SiStripApvGain.h"
 #include "CondFormats/DataRecord/interface/SiStripCondDataRecords.h"
 #include "CalibTracker/Records/interface/SiStripDependentRecords.h"
+#include "CalibTracker/SiStripCommon/interface/SiStripDetInfoFileReader.h"
 
 #include "SiStripGainFactor.h"
 
@@ -56,12 +57,16 @@ SiStripGainSimESProducer::SiStripGainSimESProducer(const edm::ParameterSet& iCon
 }
 
 std::unique_ptr<SiStripGain> SiStripGainSimESProducer::produce(const SiStripGainSimRcd& iRecord) {
+  const edm::FileInPath fp("CalibTracker/SiStripCommon/data/SiStripDetInfo.dat");
+  const SiStripDetInfoFileReader reader(fp.fullPath());
+
   const auto& apvGain = iRecord.get(tokenLabels_[0].token_);
-  auto gain = std::make_unique<SiStripGain>(apvGain, factor_.get(apvGain, 0), tokenLabels_[0].recordLabel_);
+  auto gain =
+      std::make_unique<SiStripGain>(apvGain, factor_.get(apvGain, 0), tokenLabels_[0].recordLabel_, reader.info());
 
   for (unsigned int i = 1; i < tokenLabels_.size(); ++i) {
     const auto& apvGain = iRecord.get(tokenLabels_[i].token_);
-    gain->multiply(apvGain, factor_.get(apvGain, i), tokenLabels_[i].recordLabel_);
+    gain->multiply(apvGain, factor_.get(apvGain, i), tokenLabels_[i].recordLabel_, reader.info());
   }
   return gain;
 }

--- a/CalibTracker/SiStripESProducers/plugins/real/SiStripGainSimESProducer.cc
+++ b/CalibTracker/SiStripESProducers/plugins/real/SiStripGainSimESProducer.cc
@@ -57,7 +57,7 @@ SiStripGainSimESProducer::SiStripGainSimESProducer(const edm::ParameterSet& iCon
 }
 
 std::unique_ptr<SiStripGain> SiStripGainSimESProducer::produce(const SiStripGainSimRcd& iRecord) {
-  const edm::FileInPath fp("CalibTracker/SiStripCommon/data/SiStripDetInfo.dat");
+  const edm::FileInPath fp(SiStripDetInfoFileReader::kDefaultFile);
   const SiStripDetInfoFileReader reader(fp.fullPath());
 
   const auto& apvGain = iRecord.get(tokenLabels_[0].token_);

--- a/CalibTracker/SiStripESProducers/plugins/real/SiStripQualityESProducer.cc
+++ b/CalibTracker/SiStripESProducers/plugins/real/SiStripQualityESProducer.cc
@@ -129,7 +129,7 @@ SiStripQualityESProducer::SiStripQualityESProducer(const edm::ParameterSet& iCon
 }
 
 std::unique_ptr<SiStripQuality> SiStripQualityESProducer::produce(const SiStripQualityRcd& iRecord) {
-  edm::FileInPath path("CalibTracker/SiStripCommon/data/SiStripDetInfo.dat");
+  edm::FileInPath path(SiStripDetInfoFileReader::kDefaultFile);
   SiStripDetInfoFileReader reader(path.fullPath());
   auto quality = std::make_unique<SiStripQuality>(reader.info());
   edm::LogInfo("SiStripQualityESProducer") << "produce called";

--- a/CalibTracker/SiStripESProducers/plugins/real/SiStripQualityESProducer.cc
+++ b/CalibTracker/SiStripESProducers/plugins/real/SiStripQualityESProducer.cc
@@ -30,6 +30,7 @@
 #include "DataFormats/SiStripCommon/interface/SiStripConstants.h"
 #include "CalibFormats/SiStripObjects/interface/SiStripQuality.h"
 #include "CalibTracker/Records/interface/SiStripDependentRecords.h"
+#include "CalibTracker/SiStripCommon/interface/SiStripDetInfoFileReader.h"
 #include "CondFormats/RunInfo/interface/RunInfo.h"
 
 namespace {
@@ -128,7 +129,9 @@ SiStripQualityESProducer::SiStripQualityESProducer(const edm::ParameterSet& iCon
 }
 
 std::unique_ptr<SiStripQuality> SiStripQualityESProducer::produce(const SiStripQualityRcd& iRecord) {
-  auto quality = std::make_unique<SiStripQuality>();
+  edm::FileInPath path("CalibTracker/SiStripCommon/data/SiStripDetInfo.dat");
+  SiStripDetInfoFileReader reader(path.fullPath());
+  auto quality = std::make_unique<SiStripQuality>(reader.info());
   edm::LogInfo("SiStripQualityESProducer") << "produce called";
 
   // Set the debug output level

--- a/CalibTracker/SiStripESProducers/src/SiStripQualityHelpers.cc
+++ b/CalibTracker/SiStripESProducers/src/SiStripQualityHelpers.cc
@@ -53,7 +53,7 @@ namespace {
 std::unique_ptr<SiStripQuality> sistrip::badStripFromFedErr(DQMStore::IGetter& dqmStore,
                                                             const SiStripFedCabling& fedCabling,
                                                             float cutoff) {
-  edm::FileInPath path("CalibTracker/SiStripCommon/data/SiStripDetInfo.dat");
+  edm::FileInPath path(SiStripDetInfoFileReader::kDefaultFile);
   SiStripDetInfoFileReader reader(path.fullPath());
 
   auto quality = std::make_unique<SiStripQuality>(reader.info());

--- a/CalibTracker/SiStripESProducers/src/SiStripQualityHelpers.cc
+++ b/CalibTracker/SiStripESProducers/src/SiStripQualityHelpers.cc
@@ -3,6 +3,7 @@
 #include "CalibFormats/SiStripObjects/interface/SiStripQuality.h"
 #include "CondFormats/SiStripObjects/interface/SiStripFedCabling.h"
 
+#include "CalibTracker/SiStripCommon/interface/SiStripDetInfoFileReader.h"
 #include "CalibTracker/SiStripESProducers/interface/SiStripQualityHelpers.h"
 
 using dqm::harvesting::DQMStore;
@@ -52,7 +53,10 @@ namespace {
 std::unique_ptr<SiStripQuality> sistrip::badStripFromFedErr(DQMStore::IGetter& dqmStore,
                                                             const SiStripFedCabling& fedCabling,
                                                             float cutoff) {
-  auto quality = std::make_unique<SiStripQuality>();
+  edm::FileInPath path("CalibTracker/SiStripCommon/data/SiStripDetInfo.dat");
+  SiStripDetInfoFileReader reader(path.fullPath());
+
+  auto quality = std::make_unique<SiStripQuality>(reader.info());
   dqmStore.cd();
   const std::string dname{"SiStrip/ReadoutView"};
   const std::string hpath{dname + "/FedIdVsApvId"};

--- a/CalibTracker/SiStripESProducers/test/testSiStripQualityESProducer.cc
+++ b/CalibTracker/SiStripESProducers/test/testSiStripQualityESProducer.cc
@@ -26,6 +26,10 @@ void testSiStripQualityESProducer::analyze(const edm::Event& e, const edm::Event
 
   char canvas[1024] = "\n&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&\n";
 
+  //NOTE: can't guarantee this is what was used to make the SiStripQuality
+  // can difference be determined without it?
+  edm::FileInPath path("CalibTracker/SiStripCommon/data/SiStripDetInfo.dat");
+
   //&&&&&&&&&&&&&&&&&&
   //First Record
   //&&&&&&&&&&&&&&&&&&
@@ -48,12 +52,12 @@ void testSiStripQualityESProducer::analyze(const edm::Event& e, const edm::Event
     edm::LogInfo("testSiStripQualityESProducer")
         << canvas << "[testSiStripQualityESProducer::analyze] Print difference (First - Second) SiStripQuality Rcd"
         << canvas << std::endl;
-    const SiStripQuality& tmp1 = *SiStripQualityESH_ - *twoSiStripQualityESH_;
+    const SiStripQuality& tmp1 = SiStripQualityESH_->difference(*twoSiStripQualityESH_);
     printObject(&tmp1);
     edm::LogInfo("testSiStripQualityESProducer")
         << canvas << "[testSiStripQualityESProducer::analyze] Print difference (Second - First) SiStripQuality Rcd"
         << canvas << std::endl;
-    const SiStripQuality& tmp2 = *twoSiStripQualityESH_ - *SiStripQualityESH_;
+    const SiStripQuality& tmp2 = twoSiStripQualityESH_->difference(*SiStripQualityESH_);
     printObject(&tmp2);
   }
 
@@ -65,12 +69,12 @@ void testSiStripQualityESProducer::analyze(const edm::Event& e, const edm::Event
     edm::LogInfo("testSiStripQualityESProducer")
         << canvas << "[testSiStripQualityESProducer::analyze] Print difference (Current - Previous) SiStripQuality Rcd"
         << canvas << std::endl;
-    const SiStripQuality& tmp1 = *SiStripQualityESH_ - *m_Quality_;
+    const SiStripQuality& tmp1 = SiStripQualityESH_->difference(*m_Quality_);
     printObject(&tmp1);
     edm::LogInfo("testSiStripQualityESProducer")
         << canvas << "[testSiStripQualityESProducer::analyze] Print difference (Previous - Current) SiStripQuality Rcd"
         << canvas << std::endl;
-    const SiStripQuality& tmp2 = *m_Quality_ - *SiStripQualityESH_;
+    const SiStripQuality& tmp2 = m_Quality_->difference(*SiStripQualityESH_);
     printObject(&tmp2);
   }
 

--- a/CalibTracker/SiStripESProducers/test/testSiStripQualityESProducer.cc
+++ b/CalibTracker/SiStripESProducers/test/testSiStripQualityESProducer.cc
@@ -26,10 +26,6 @@ void testSiStripQualityESProducer::analyze(const edm::Event& e, const edm::Event
 
   char canvas[1024] = "\n&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&\n";
 
-  //NOTE: can't guarantee this is what was used to make the SiStripQuality
-  // can difference be determined without it?
-  edm::FileInPath path("CalibTracker/SiStripCommon/data/SiStripDetInfo.dat");
-
   //&&&&&&&&&&&&&&&&&&
   //First Record
   //&&&&&&&&&&&&&&&&&&

--- a/CalibTracker/SiStripHitEfficiency/plugins/BuildFile.xml
+++ b/CalibTracker/SiStripHitEfficiency/plugins/BuildFile.xml
@@ -12,6 +12,7 @@
 <use name="Geometry/CommonDetUnit" source_only="1"/>
 <use name="Geometry/Records"/>
 <use name="Geometry/TrackerGeometryBuilder"/>
+<use name="CalibTracker/SiStripCommon"/>
 <use name="RecoTracker/Record"/>
 <use name="RecoTracker/MeasurementDet"/>
 <flags EDM_PLUGIN="1"/>

--- a/CalibTracker/SiStripHitEfficiency/plugins/SiStripHitEffFromCalibTree.cc
+++ b/CalibTracker/SiStripHitEfficiency/plugins/SiStripHitEffFromCalibTree.cc
@@ -216,7 +216,7 @@ SiStripHitEffFromCalibTree::SiStripHitEffFromCalibTree(const edm::ParameterSet& 
   if (_showRings)
     nTEClayers = 7;  // number of rings
 
-  quality_ = new SiStripQuality;
+  quality_ = new SiStripQuality(reader->info());
 }
 
 SiStripHitEffFromCalibTree::~SiStripHitEffFromCalibTree() {}
@@ -1104,7 +1104,7 @@ void SiStripHitEffFromCalibTree::makeSQLite() {
   std::vector<unsigned int> BadStripList;
   unsigned short NStrips;
   unsigned int id1;
-  std::unique_ptr<SiStripQuality> pQuality = std::make_unique<SiStripQuality>();
+  std::unique_ptr<SiStripQuality> pQuality = std::make_unique<SiStripQuality>(reader->info());
   //This is the list of the bad strips, use to mask out entire APVs
   //Now simply go through the bad hit list and mask out things that
   //are bad!

--- a/CalibTracker/SiStripQuality/plugins/SiStripQualityHotStripIdentifier.cc
+++ b/CalibTracker/SiStripQuality/plugins/SiStripQualityHotStripIdentifier.cc
@@ -15,6 +15,7 @@
 
 //Insert here the include to the algos
 #include "CalibTracker/SiStripQuality/interface/SiStripHotStripAlgorithmFromClusterOccupancy.h"
+#include "CalibTracker/SiStripCommon/interface/SiStripDetInfoFileReader.h"
 
 SiStripQualityHotStripIdentifier::SiStripQualityHotStripIdentifier(const edm::ParameterSet& iConfig)
     : ConditionDBWriter<SiStripBadStrip>(iConfig),
@@ -53,7 +54,10 @@ std::unique_ptr<SiStripBadStrip> SiStripQualityHotStripIdentifier::getNewObject(
     theIdentifier.setMinNumEntries(parameters.getUntrackedParameter<uint32_t>("MinNumEntries", 100));
     theIdentifier.setMinNumEntriesPerStrip(parameters.getUntrackedParameter<uint32_t>("MinNumEntriesPerStrip", 5));
 
-    SiStripQuality* qobj = new SiStripQuality();
+    edm::FileInPath path("CalibTracker/SiStripCommon/data/SiStripDetInfo.dat");
+    SiStripDetInfoFileReader reader(path.fullPath());
+
+    SiStripQuality* qobj = new SiStripQuality(reader.info());
     theIdentifier.extractBadStrips(qobj, ClusterPositionHistoMap, stripQuality_);
 
     edm::LogInfo("SiStripQualityHotStripIdentifier")

--- a/CalibTracker/SiStripQuality/plugins/SiStripQualityHotStripIdentifier.cc
+++ b/CalibTracker/SiStripQuality/plugins/SiStripQualityHotStripIdentifier.cc
@@ -21,8 +21,8 @@ SiStripQualityHotStripIdentifier::SiStripQualityHotStripIdentifier(const edm::Pa
     : ConditionDBWriter<SiStripBadStrip>(iConfig),
       dataLabel_(iConfig.getUntrackedParameter<std::string>("dataLabel", "")),
       conf_(iConfig),
-      fp_(iConfig.getUntrackedParameter<edm::FileInPath>(
-          "file", edm::FileInPath(SiStripDetInfoFileReader::kDefaultFile))),
+      fp_(iConfig.getUntrackedParameter<edm::FileInPath>("file",
+                                                         edm::FileInPath(SiStripDetInfoFileReader::kDefaultFile))),
       Cluster_src_(iConfig.getParameter<edm::InputTag>("Cluster_src")),
       Track_src_(iConfig.getUntrackedParameter<edm::InputTag>("Track_src")),
       tracksCollection_in_EventTree(iConfig.getUntrackedParameter<bool>("RemoveTrackClusters", false)),

--- a/CalibTracker/SiStripQuality/plugins/SiStripQualityHotStripIdentifier.cc
+++ b/CalibTracker/SiStripQuality/plugins/SiStripQualityHotStripIdentifier.cc
@@ -22,7 +22,7 @@ SiStripQualityHotStripIdentifier::SiStripQualityHotStripIdentifier(const edm::Pa
       dataLabel_(iConfig.getUntrackedParameter<std::string>("dataLabel", "")),
       conf_(iConfig),
       fp_(iConfig.getUntrackedParameter<edm::FileInPath>(
-          "file", edm::FileInPath("CalibTracker/SiStripCommon/data/SiStripDetInfo.dat"))),
+          "file", edm::FileInPath(SiStripDetInfoFileReader::kDefaultFile))),
       Cluster_src_(iConfig.getParameter<edm::InputTag>("Cluster_src")),
       Track_src_(iConfig.getUntrackedParameter<edm::InputTag>("Track_src")),
       tracksCollection_in_EventTree(iConfig.getUntrackedParameter<bool>("RemoveTrackClusters", false)),
@@ -54,7 +54,7 @@ std::unique_ptr<SiStripBadStrip> SiStripQualityHotStripIdentifier::getNewObject(
     theIdentifier.setMinNumEntries(parameters.getUntrackedParameter<uint32_t>("MinNumEntries", 100));
     theIdentifier.setMinNumEntriesPerStrip(parameters.getUntrackedParameter<uint32_t>("MinNumEntriesPerStrip", 5));
 
-    edm::FileInPath path("CalibTracker/SiStripCommon/data/SiStripDetInfo.dat");
+    edm::FileInPath path(SiStripDetInfoFileReader::kDefaultFile);
     SiStripDetInfoFileReader reader(path.fullPath());
 
     SiStripQuality* qobj = new SiStripQuality(reader.info());

--- a/CondCore/SiStripPlugins/plugins/BuildFile.xml
+++ b/CondCore/SiStripPlugins/plugins/BuildFile.xml
@@ -2,6 +2,7 @@
   <use name="CondCore/Utilities"/>
   <use name="CondCore/CondDB"/>
   <use name="CommonTools/TrackerMap"/>
+  <use name="CalibTracker/SiStripCommon"/>
   <use name="CalibTracker/StandaloneTrackerTopology"/>
 </library>
 
@@ -9,6 +10,7 @@
   <use name="CondCore/Utilities"/>
   <use name="CondCore/CondDB"/>
   <use name="CondFormats/SiStripObjects"/>
+  <use name="CalibTracker/SiStripCommon"/>
   <use name="CommonTools/TrackerMap"/>
   <use name="CalibTracker/StandaloneTrackerTopology"/>
 </library>
@@ -19,6 +21,7 @@
   <use name="CondFormats/SiStripObjects"/>
   <use name="CommonTools/TrackerMap"/>
   <use name="CalibTracker/StandaloneTrackerTopology"/>
+  <use name="CalibTracker/SiStripCommon"/>
   <use name="DQM/TrackerRemapper"/>
   <use name="roothistpainter"/>
 </library>
@@ -28,6 +31,7 @@
   <use name="CondCore/CondDB"/>
   <use name="CondFormats/SiStripObjects"/>
   <use name="CommonTools/TrackerMap"/>
+  <use name="CalibTracker/SiStripCommon"/>
   <use name="CalibTracker/StandaloneTrackerTopology"/>
   <use name="DQM/TrackerRemapper"/>
   <use name="roothistpainter"/>
@@ -38,6 +42,7 @@
   <use name="CondCore/CondDB"/>
   <use name="CondFormats/SiStripObjects"/>
   <use name="CommonTools/TrackerMap"/>
+  <use name="CalibTracker/SiStripCommon"/>
   <use name="CalibTracker/StandaloneTrackerTopology"/>
 </library>
 
@@ -45,6 +50,7 @@
   <use name="CondCore/Utilities"/>
   <use name="CondCore/CondDB"/>
   <use name="CondFormats/SiStripObjects"/>
+  <use name="CalibTracker/SiStripCommon"/>
   <use name="CommonTools/TrackerMap"/>
   <use name="CalibTracker/StandaloneTrackerTopology"/>
 </library>
@@ -55,6 +61,7 @@
   <use name="CondFormats/SiStripObjects"/>
   <use name="CommonTools/TrackerMap"/>
   <use name="CalibTracker/StandaloneTrackerTopology"/>
+  <use name="CalibTracker/SiStripCommon"/>
 </library>
 
 <library file="SiStripConfObject_PayloadInspector.cc" name="SiStripConfObject_PayloadInspector">
@@ -72,6 +79,7 @@
   <use name="CondFormats/SiStripObjects"/>
   <use name="CommonTools/TrackerMap"/>
   <use name="CalibTracker/StandaloneTrackerTopology"/>
+  <use name="CalibTracker/SiStripCommon"/>
 </library>
 
 <library file="SiStripLatency_PayloadInspector.cc" name="SiStripLatency_PayloadInspector">
@@ -79,6 +87,7 @@
   <use name="CondCore/CondDB"/>
   <use name="CondFormats/SiStripObjects"/>
   <use name="CommonTools/TrackerMap"/>
+  <use name="CalibTracker/SiStripCommon"/>
   <use name="CalibTracker/StandaloneTrackerTopology"/>
 </library>
 
@@ -87,6 +96,7 @@
   <use name="CondCore/CondDB"/>
   <use name="CondFormats/SiStripObjects"/>
   <use name="CommonTools/TrackerMap"/>
+  <use name="CalibTracker/SiStripCommon"/>
   <use name="CalibTracker/StandaloneTrackerTopology"/>
 </library>
 

--- a/CondCore/SiStripPlugins/plugins/SiStripBadStrip_PayloadInspector.cc
+++ b/CondCore/SiStripPlugins/plugins/SiStripBadStrip_PayloadInspector.cc
@@ -966,7 +966,10 @@ namespace {
       auto iov = tag.iovs.front();
       std::shared_ptr<SiStripBadStrip> payload = fetchPayload(std::get<1>(iov));
 
-      SiStripQuality* siStripQuality_ = new SiStripQuality();
+      edm::FileInPath path("CalibTracker/SiStripCommon/data/SiStripDetInfo.dat");
+      SiStripDetInfoFileReader reader(path.fullPath());
+
+      SiStripQuality* siStripQuality_ = new SiStripQuality(reader.info());
       siStripQuality_->add(payload.get());
       siStripQuality_->cleanUp();
       siStripQuality_->fillBadComponents();
@@ -1187,7 +1190,9 @@ namespace {
       // for the total
       int totNComponents[4][19][4] = {{{0}}};
 
-      SiStripQuality* f_siStripQuality_ = new SiStripQuality();
+      edm::FileInPath path("CalibTracker/SiStripCommon/data/SiStripDetInfo.dat");
+      SiStripDetInfoFileReader reader(path.fullPath());
+      SiStripQuality* f_siStripQuality_ = new SiStripQuality(reader.info());
       f_siStripQuality_->add(first_payload.get());
       f_siStripQuality_->cleanUp();
       f_siStripQuality_->fillBadComponents();
@@ -1195,7 +1200,7 @@ namespace {
       // call the filler
       SiStripPI::fillBCArrays(f_siStripQuality_, f_NTkBadComponent, f_NBadComponent, m_trackerTopo);
 
-      SiStripQuality* l_siStripQuality_ = new SiStripQuality();
+      SiStripQuality* l_siStripQuality_ = new SiStripQuality(reader.info());
       l_siStripQuality_->add(last_payload.get());
       l_siStripQuality_->cleanUp();
       l_siStripQuality_->fillBadComponents();

--- a/CondCore/SiStripPlugins/plugins/SiStripBadStrip_PayloadInspector.cc
+++ b/CondCore/SiStripPlugins/plugins/SiStripBadStrip_PayloadInspector.cc
@@ -143,7 +143,7 @@ namespace {
       auto tagname = PlotBase::getTag<0>().name;
       std::shared_ptr<SiStripBadStrip> payload = fetchPayload(std::get<1>(iov));
 
-      edm::FileInPath fp_ = edm::FileInPath("CalibTracker/SiStripCommon/data/SiStripDetInfo.dat");
+      edm::FileInPath fp_ = edm::FileInPath(SiStripDetInfoFileReader::kDefaultFile);
       SiStripDetInfoFileReader* reader = new SiStripDetInfoFileReader(fp_.fullPath());
 
       auto theIOVsince = std::to_string(std::get<0>(iov));
@@ -204,7 +204,7 @@ namespace {
       auto tagname = PlotBase::getTag<0>().name;
       std::shared_ptr<SiStripBadStrip> payload = fetchPayload(std::get<1>(iov));
 
-      edm::FileInPath fp_ = edm::FileInPath("CalibTracker/SiStripCommon/data/SiStripDetInfo.dat");
+      edm::FileInPath fp_ = edm::FileInPath(SiStripDetInfoFileReader::kDefaultFile);
       SiStripDetInfoFileReader* reader = new SiStripDetInfoFileReader(fp_.fullPath());
 
       auto theIOVsince = std::to_string(std::get<0>(iov));
@@ -258,7 +258,7 @@ namespace {
     ~SiStripBadStripFractionByRun() override = default;
 
     float getFromPayload(SiStripBadStrip& payload) override {
-      edm::FileInPath fp_ = edm::FileInPath("CalibTracker/SiStripCommon/data/SiStripDetInfo.dat");
+      edm::FileInPath fp_ = edm::FileInPath(SiStripDetInfoFileReader::kDefaultFile);
       SiStripDetInfoFileReader* reader = new SiStripDetInfoFileReader(fp_.fullPath());
 
       std::vector<uint32_t> detid;
@@ -301,7 +301,7 @@ namespace {
     ~SiStripBadStripTIBFractionByRun() override = default;
 
     float getFromPayload(SiStripBadStrip& payload) override {
-      edm::FileInPath fp_ = edm::FileInPath("CalibTracker/SiStripCommon/data/SiStripDetInfo.dat");
+      edm::FileInPath fp_ = edm::FileInPath(SiStripDetInfoFileReader::kDefaultFile);
       SiStripDetInfoFileReader* reader = new SiStripDetInfoFileReader(fp_.fullPath());
 
       std::vector<uint32_t> detid;
@@ -347,7 +347,7 @@ namespace {
     ~SiStripBadStripTOBFractionByRun() override = default;
 
     float getFromPayload(SiStripBadStrip& payload) override {
-      edm::FileInPath fp_ = edm::FileInPath("CalibTracker/SiStripCommon/data/SiStripDetInfo.dat");
+      edm::FileInPath fp_ = edm::FileInPath(SiStripDetInfoFileReader::kDefaultFile);
       SiStripDetInfoFileReader* reader = new SiStripDetInfoFileReader(fp_.fullPath());
 
       std::vector<uint32_t> detid;
@@ -393,7 +393,7 @@ namespace {
     ~SiStripBadStripTIDFractionByRun() override = default;
 
     float getFromPayload(SiStripBadStrip& payload) override {
-      edm::FileInPath fp_ = edm::FileInPath("CalibTracker/SiStripCommon/data/SiStripDetInfo.dat");
+      edm::FileInPath fp_ = edm::FileInPath(SiStripDetInfoFileReader::kDefaultFile);
       SiStripDetInfoFileReader* reader = new SiStripDetInfoFileReader(fp_.fullPath());
 
       std::vector<uint32_t> detid;
@@ -439,7 +439,7 @@ namespace {
     ~SiStripBadStripTECFractionByRun() override = default;
 
     float getFromPayload(SiStripBadStrip& payload) override {
-      edm::FileInPath fp_ = edm::FileInPath("CalibTracker/SiStripCommon/data/SiStripDetInfo.dat");
+      edm::FileInPath fp_ = edm::FileInPath(SiStripDetInfoFileReader::kDefaultFile);
       SiStripDetInfoFileReader* reader = new SiStripDetInfoFileReader(fp_.fullPath());
 
       std::vector<uint32_t> detid;
@@ -865,7 +865,7 @@ namespace {
       std::string lastIOVsince = std::to_string(std::get<0>(lastiov));
       std::string firstIOVsince = std::to_string(std::get<0>(firstiov));
 
-      edm::FileInPath fp_ = edm::FileInPath("CalibTracker/SiStripCommon/data/SiStripDetInfo.dat");
+      edm::FileInPath fp_ = edm::FileInPath(SiStripDetInfoFileReader::kDefaultFile);
       SiStripDetInfoFileReader* reader = new SiStripDetInfoFileReader(fp_.fullPath());
 
       std::string titleMap =
@@ -966,7 +966,7 @@ namespace {
       auto iov = tag.iovs.front();
       std::shared_ptr<SiStripBadStrip> payload = fetchPayload(std::get<1>(iov));
 
-      edm::FileInPath path("CalibTracker/SiStripCommon/data/SiStripDetInfo.dat");
+      edm::FileInPath path(SiStripDetInfoFileReader::kDefaultFile);
       SiStripDetInfoFileReader reader(path.fullPath());
 
       SiStripQuality* siStripQuality_ = new SiStripQuality(reader.info());
@@ -1190,7 +1190,7 @@ namespace {
       // for the total
       int totNComponents[4][19][4] = {{{0}}};
 
-      edm::FileInPath path("CalibTracker/SiStripCommon/data/SiStripDetInfo.dat");
+      edm::FileInPath path(SiStripDetInfoFileReader::kDefaultFile);
       SiStripDetInfoFileReader reader(path.fullPath());
       SiStripQuality* f_siStripQuality_ = new SiStripQuality(reader.info());
       f_siStripQuality_->add(first_payload.get());

--- a/CondCore/SiStripPlugins/test/BuildFile.xml
+++ b/CondCore/SiStripPlugins/test/BuildFile.xml
@@ -4,5 +4,6 @@
 <use name="CalibTracker/StandaloneTrackerTopology"/>
 <use name="roothistpainter"/>
 <use name="DQM/TrackerRemapper"/>
+<use name="CalibTracker/SiStripCommon"/>
 <bin file="testSiStripPayloadInspector.cpp" name="testSiStripPayloadInspector">
 </bin>

--- a/DQM/SiStripMonitorSummary/plugins/SiStripCorrelateBadStripAndNoise.h
+++ b/DQM/SiStripMonitorSummary/plugins/SiStripCorrelateBadStripAndNoise.h
@@ -45,6 +45,7 @@
 //
 class TrackerTopology;
 class TrackerGeometry;
+class SiStripDetInfoFileReader;
 class SiStripCorrelateBadStripAndNoise : public edm::EDAnalyzer {
 public:
   explicit SiStripCorrelateBadStripAndNoise(const edm::ParameterSet &);

--- a/DQM/TrackingMonitorSource/plugins/BuildFile.xml
+++ b/DQM/TrackingMonitorSource/plugins/BuildFile.xml
@@ -7,6 +7,7 @@
 <use name="DataFormats/TrackReco"/>
 <use name="DataFormats/VertexReco"/>
 <use name="DataFormats/MuonReco"/>
+<use name="Geometry/TrackerGeometryBuilder"/>
 <use name="HLTrigger/HLTcore"/>
 <use name="RecoLocalTracker/SiStripClusterizer"/>
 <flags EDM_PLUGIN="1"/>

--- a/DQMOffline/CalibTracker/plugins/BuildFile.xml
+++ b/DQMOffline/CalibTracker/plugins/BuildFile.xml
@@ -11,6 +11,7 @@
 <use name="DataFormats/SiStripDetId"/>
 <use name="CalibTracker/Records"/>
 <use name="CalibTracker/SiStripQuality"/>
+<use name="CalibTracker/SiStripCommon"/>
 <use name="CondCore/PopCon"/>
 <use name="DataFormats/TrackReco"/>
 <use name="DataFormats/TrackerRecHit2D"/>

--- a/DQMOffline/CalibTracker/plugins/SiStripQualityHotStripIdentifierRoot.cc
+++ b/DQMOffline/CalibTracker/plugins/SiStripQualityHotStripIdentifierRoot.cc
@@ -20,6 +20,7 @@
 #include "CalibTracker/SiStripQuality/interface/SiStripHotStripAlgorithmFromClusterOccupancy.h"
 #include "CalibTracker/SiStripQuality/interface/SiStripBadAPVAlgorithmFromClusterOccupancy.h"
 #include "CalibTracker/SiStripQuality/interface/SiStripBadAPVandHotStripAlgorithmFromClusterOccupancy.h"
+#include "CalibTracker/SiStripCommon/interface/SiStripDetInfoFileReader.h"
 
 SiStripQualityHotStripIdentifierRoot::SiStripQualityHotStripIdentifierRoot(const edm::ParameterSet& iConfig)
     : ConditionDBWriter<SiStripBadStrip>(iConfig),
@@ -85,7 +86,9 @@ std::unique_ptr<SiStripBadStrip> SiStripQualityHotStripIdentifierRoot::getNewObj
             conf_.getUntrackedParameter<bool>("WriteOccupancyRootFile", false));
         theIdentifier->setTrackerGeometry(tracker_);
 
-        SiStripQuality* qobj = new SiStripQuality();
+        edm::FileInPath path("CalibTracker/SiStripCommon/data/SiStripDetInfo.dat");
+        SiStripDetInfoFileReader reader(path.fullPath());
+        SiStripQuality* qobj = new SiStripQuality(reader.info());
         theIdentifier->extractBadStrips(
             qobj,
             ClusterPositionHistoMap,
@@ -130,7 +133,9 @@ std::unique_ptr<SiStripBadStrip> SiStripQualityHotStripIdentifierRoot::getNewObj
             conf_.getUntrackedParameter<bool>("WriteOccupancyRootFile", false));
         theIdentifier2->setTrackerGeometry(tracker_);
 
-        SiStripQuality* qobj = new SiStripQuality();
+        edm::FileInPath path("CalibTracker/SiStripCommon/data/SiStripDetInfo.dat");
+        SiStripDetInfoFileReader reader(path.fullPath());
+        SiStripQuality* qobj = new SiStripQuality(reader.info());
         theIdentifier2->extractBadAPVs(qobj, ClusterPositionHistoMap, SiStripQuality_);
 
         //----------
@@ -181,7 +186,9 @@ std::unique_ptr<SiStripBadStrip> SiStripQualityHotStripIdentifierRoot::getNewObj
             parameters.getUntrackedParameter<double>("OccupancyThreshold", 1.E-5));
         theIdentifier3->setMinNumOfEvents();
 
-        SiStripQuality* qobj = new SiStripQuality();
+        edm::FileInPath path("CalibTracker/SiStripCommon/data/SiStripDetInfo.dat");
+        SiStripDetInfoFileReader reader(path.fullPath());
+        SiStripQuality* qobj = new SiStripQuality(reader.info());
         theIdentifier3->extractBadAPVSandStrips(
             qobj,
             ClusterPositionHistoMap,

--- a/DQMOffline/CalibTracker/plugins/SiStripQualityHotStripIdentifierRoot.cc
+++ b/DQMOffline/CalibTracker/plugins/SiStripQualityHotStripIdentifierRoot.cc
@@ -86,7 +86,7 @@ std::unique_ptr<SiStripBadStrip> SiStripQualityHotStripIdentifierRoot::getNewObj
             conf_.getUntrackedParameter<bool>("WriteOccupancyRootFile", false));
         theIdentifier->setTrackerGeometry(tracker_);
 
-        edm::FileInPath path("CalibTracker/SiStripCommon/data/SiStripDetInfo.dat");
+        edm::FileInPath path(SiStripDetInfoFileReader::kDefaultFile);
         SiStripDetInfoFileReader reader(path.fullPath());
         SiStripQuality* qobj = new SiStripQuality(reader.info());
         theIdentifier->extractBadStrips(
@@ -133,7 +133,7 @@ std::unique_ptr<SiStripBadStrip> SiStripQualityHotStripIdentifierRoot::getNewObj
             conf_.getUntrackedParameter<bool>("WriteOccupancyRootFile", false));
         theIdentifier2->setTrackerGeometry(tracker_);
 
-        edm::FileInPath path("CalibTracker/SiStripCommon/data/SiStripDetInfo.dat");
+        edm::FileInPath path(SiStripDetInfoFileReader::kDefaultFile);
         SiStripDetInfoFileReader reader(path.fullPath());
         SiStripQuality* qobj = new SiStripQuality(reader.info());
         theIdentifier2->extractBadAPVs(qobj, ClusterPositionHistoMap, SiStripQuality_);
@@ -186,7 +186,7 @@ std::unique_ptr<SiStripBadStrip> SiStripQualityHotStripIdentifierRoot::getNewObj
             parameters.getUntrackedParameter<double>("OccupancyThreshold", 1.E-5));
         theIdentifier3->setMinNumOfEvents();
 
-        edm::FileInPath path("CalibTracker/SiStripCommon/data/SiStripDetInfo.dat");
+        edm::FileInPath path(SiStripDetInfoFileReader::kDefaultFile);
         SiStripDetInfoFileReader reader(path.fullPath());
         SiStripQuality* qobj = new SiStripQuality(reader.info());
         theIdentifier3->extractBadAPVSandStrips(

--- a/OnlineDB/SiStripESSources/plugins/BuildFile.xml
+++ b/OnlineDB/SiStripESSources/plugins/BuildFile.xml
@@ -1,4 +1,5 @@
 <library file="*.cc" name="OnlineDBSiStripESSourcesPlugins">
   <use name="OnlineDB/SiStripESSources"/>
+  <use name="Geometry/TrackerGeometryBuilder"/>
   <flags EDM_PLUGIN="1"/>
 </library>

--- a/OnlineDB/SiStripESSources/src/SiStripCondObjBuilderFromDb.cc
+++ b/OnlineDB/SiStripESSources/src/SiStripCondObjBuilderFromDb.cc
@@ -875,7 +875,7 @@ void SiStripCondObjBuilderFromDb::buildFEDRelatedObjects(SiStripConfigDb* const 
   pedestals_ = new SiStripPedestals();
   noises_ = new SiStripNoises();
   threshold_ = new SiStripThreshold();
-  quality_ = new SiStripQuality();
+  quality_ = new SiStripQuality(m_reader->info());
 
   i_trackercon detids_end = tc.end();
 

--- a/RecoLocalTracker/SiStripClusterizer/test/BuildFile.xml
+++ b/RecoLocalTracker/SiStripClusterizer/test/BuildFile.xml
@@ -1,5 +1,6 @@
 <library name="RecoLocalTrackerSiStripClusterizerTestPlugins" file="*.cc">
   <use name="RecoLocalTracker/SiStripClusterizer"/>
   <use name="SimTracker/TrackerHitAssociation"/>
+  <use name="CalibTracker/SiStripCommon"/>
   <flags EDM_PLUGIN="1"/>
 </library>

--- a/RecoLocalTracker/SiStripClusterizer/test/ClusterizerUnitTesterESProducer.cc
+++ b/RecoLocalTracker/SiStripClusterizer/test/ClusterizerUnitTesterESProducer.cc
@@ -1,8 +1,11 @@
 #include "RecoLocalTracker/SiStripClusterizer/test/ClusterizerUnitTesterESProducer.h"
+#include "CalibTracker/SiStripCommon/interface/SiStripDetInfoFileReader.h"
 
 ClusterizerUnitTesterESProducer::ClusterizerUnitTesterESProducer(const edm::ParameterSet& conf) {
   edm::FileInPath testInfo(("RecoLocalTracker/SiStripClusterizer/test/ClusterizerUnitTestDetInfo.dat"));
-  auto quality = std::make_unique<SiStripQuality>(testInfo);
+  SiStripDetInfoFileReader reader(testInfo.fullPath());
+
+  auto quality = std::make_unique<SiStripQuality>(reader.info());
   auto apvGain = std::make_unique<SiStripApvGain>();
   auto noises = std::make_unique<SiStripNoises>();
 

--- a/RecoLocalTracker/SiStripClusterizer/test/ClusterizerUnitTesterESProducer.cc
+++ b/RecoLocalTracker/SiStripClusterizer/test/ClusterizerUnitTesterESProducer.cc
@@ -11,7 +11,7 @@ ClusterizerUnitTesterESProducer::ClusterizerUnitTesterESProducer(const edm::Para
 
   extractNoiseGainQuality(conf, quality.get(), apvGain.get(), noises.get());
 
-  gain_ = std::make_shared<const SiStripGain>(*apvGain, 1);
+  gain_ = std::make_shared<const SiStripGain>(*apvGain, 1, reader.info());
 
   quality->cleanUp();
   quality->fillBadComponents();

--- a/RecoLocalTracker/SiStripRecHitConverter/plugins/BuildFile.xml
+++ b/RecoLocalTracker/SiStripRecHitConverter/plugins/BuildFile.xml
@@ -1,5 +1,6 @@
 <use name="RecoLocalTracker/SiStripRecHitConverter"/>
 <use name="CalibTracker/Records"/>
+<use name="CalibTracker/SiStripCommon"/>
 <library file="*.cc" name="RecoLocalTrackerSiStripRecHitConverterPlugins">
   <flags EDM_PLUGIN="1"/>
 </library>

--- a/RecoLocalTracker/SiStripZeroSuppression/BuildFile.xml
+++ b/RecoLocalTracker/SiStripZeroSuppression/BuildFile.xml
@@ -8,6 +8,7 @@
 <use name="CondFormats/SiStripObjects"/>
 <use name="CalibFormats/SiStripObjects"/>
 <use name="CalibTracker/Records"/>
+<use name="Geometry/TrackerGeometryBuilder"/>
 <use name="root"/>
 <export>
   <lib name="1"/>

--- a/SimTracker/SiStripDigitizer/plugins/BuildFile.xml
+++ b/SimTracker/SiStripDigitizer/plugins/BuildFile.xml
@@ -7,5 +7,6 @@
   <use name="SimGeneral/HepPDTRecord"/>
   <use name="SimGeneral/MixingModule"/>
   <use name="SimGeneral/PreMixingModule"/>
+  <use name="Geometry/TrackerNumberingBuilder"/>
   <flags EDM_PLUGIN="1"/>
 </library>


### PR DESCRIPTION
#### PR description:

CalibFormat objects should not be reading files to get intermediate data as this violates one of the guiding principles of CMSSW.  This change moves the needed information into a separate class, SiStripDetInfo and requires code that constructs a SiStripQuality or a SiStripGain to pass in the appropriate SiStripDetInfo.

The class SiStripDetInfoFileReader now returns the SiStripDetInfo.

This now makes CalibFormats/SiStripObjects independent from algorithmic code.

#### PR validation:

Code compiles.