### PR TITLE
Remove direct boost and ROOT dependencies from CondFormats/GBRForest etc.

### DIFF
--- a/CondFormats/GBRForest/BuildFile.xml
+++ b/CondFormats/GBRForest/BuildFile.xml
@@ -1,7 +1,5 @@
 <use name="FWCore/Utilities"/>
 <use name="CondFormats/Serialization"/>
-<use name="boost_serialization"/>
-<use name="root"/>
 <export>
   <lib name="1"/>
 </export>

--- a/CondFormats/GBRForest/interface/GBRForest.h
+++ b/CondFormats/GBRForest/interface/GBRForest.h
@@ -1,4 +1,3 @@
-
 #ifndef EGAMMAOBJECTS_GBRForest
 #define EGAMMAOBJECTS_GBRForest
 
@@ -19,12 +18,12 @@
 #include "CondFormats/Serialization/interface/Serializable.h"
 #include "CondFormats/GBRForest/interface/GBRTree.h"
 
-#include <vector>
 #include <cmath>
+#include <vector>
 
 class GBRForest {
 public:
-  GBRForest();
+  GBRForest() {}
 
   double GetResponse(const float* vector) const;
   double GetGradBoostClassifier(const float* vector) const;
@@ -39,7 +38,7 @@ public:
   const std::vector<GBRTree>& Trees() const { return fTrees; }
 
 protected:
-  double fInitialResponse;
+  double fInitialResponse = 0.0;
   std::vector<GBRTree> fTrees;
 
   COND_SERIALIZABLE;
@@ -48,8 +47,8 @@ protected:
 //_______________________________________________________________________
 inline double GBRForest::GetResponse(const float* vector) const {
   double response = fInitialResponse;
-  for (std::vector<GBRTree>::const_iterator it = fTrees.begin(); it != fTrees.end(); ++it) {
-    response += it->GetResponse(vector);
+  for (auto const& tree : fTrees) {
+    response += tree.GetResponse(vector);
   }
   return response;
 }
@@ -57,7 +56,7 @@ inline double GBRForest::GetResponse(const float* vector) const {
 //_______________________________________________________________________
 inline double GBRForest::GetGradBoostClassifier(const float* vector) const {
   double response = GetResponse(vector);
-  return 2.0 / (1.0 + exp(-2.0 * response)) - 1;  //MVA output between -1 and 1
+  return 2.0 / (1.0 + std::exp(-2.0 * response)) - 1;  //MVA output between -1 and 1
 }
 
 #endif

--- a/CondFormats/GBRForest/interface/GBRForest2D.h
+++ b/CondFormats/GBRForest/interface/GBRForest2D.h
@@ -19,13 +19,12 @@
 #include "CondFormats/Serialization/interface/Serializable.h"
 
 #include "GBRTree2D.h"
-#include <cstdio>
+
 #include <vector>
 
 class GBRForest2D {
 public:
-  GBRForest2D();
-  ~GBRForest2D() {}
+  GBRForest2D() {}
 
   void GetResponse(const float *vector, double &x, double &y) const;
 
@@ -38,8 +37,8 @@ public:
   const std::vector<GBRTree2D> &Trees() const { return fTrees; }
 
 protected:
-  double fInitialResponseX;
-  double fInitialResponseY;
+  double fInitialResponseX = 0.0;
+  double fInitialResponseY = 0.0;
   std::vector<GBRTree2D> fTrees;
 
   COND_SERIALIZABLE;

--- a/CondFormats/GBRForest/interface/GBRForestD.h
+++ b/CondFormats/GBRForest/interface/GBRForestD.h
@@ -18,20 +18,17 @@
 
 #include "CondFormats/Serialization/interface/Serializable.h"
 
-#include <vector>
 #include "GBRTreeD.h"
-#include <cmath>
-#include <cstdio>
-#include "Rtypes.h"
+
+#include <vector>
 
 class GBRForestD {
 public:
   typedef GBRTreeD TreeT;
 
-  GBRForestD();
+  GBRForestD() {}
   template <typename InputForestT>
   GBRForestD(const InputForestT &forest);
-  virtual ~GBRForestD();
 
   double GetResponse(const float *vector) const;
 
@@ -42,7 +39,7 @@ public:
   const std::vector<GBRTreeD> &Trees() const { return fTrees; }
 
 protected:
-  double fInitialResponse;
+  double fInitialResponse = 0.0;
   std::vector<GBRTreeD> fTrees;
 
   COND_SERIALIZABLE;

--- a/CondFormats/GBRForest/interface/GBRTree.h
+++ b/CondFormats/GBRForest/interface/GBRTree.h
@@ -28,7 +28,7 @@
 
 class GBRTree {
 public:
-  GBRTree();
+  GBRTree() {}
   explicit GBRTree(int nIntermediate, int nTerminal);
 
   double GetResponse(const float *vector) const;

--- a/CondFormats/GBRForest/interface/GBRTree2D.h
+++ b/CondFormats/GBRForest/interface/GBRTree2D.h
@@ -25,12 +25,10 @@
 #include "CondFormats/Serialization/interface/Serializable.h"
 
 #include <vector>
-#include <map>
 
 class GBRTree2D {
 public:
   GBRTree2D() {}
-  ~GBRTree2D() {}
 
   void GetResponse(const float *vector, double &x, double &y) const;
   int TerminalIndex(const float *vector) const;

--- a/CondFormats/GBRForest/interface/GBRTreeD.h
+++ b/CondFormats/GBRForest/interface/GBRTreeD.h
@@ -25,17 +25,12 @@
 #include "CondFormats/Serialization/interface/Serializable.h"
 
 #include <vector>
-#include <map>
-#include <cstdio>
-#include <cmath>
-#include "Rtypes.h"
 
 class GBRTreeD {
 public:
   GBRTreeD() {}
   template <typename InputTreeT>
   GBRTreeD(const InputTreeT &tree);
-  virtual ~GBRTreeD();
 
   //double GetResponse(const float* vector) const;
   double GetResponse(int termidx) const { return fResponses[termidx]; }

--- a/CondFormats/GBRForest/src/GBRForest.cxx
+++ b/CondFormats/GBRForest/src/GBRForest.cxx
@@ -1,4 +1,0 @@
-#include "CondFormats/GBRForest/interface/GBRForest.h"
-
-//_______________________________________________________________________
-GBRForest::GBRForest() : fInitialResponse(0.) {}

--- a/CondFormats/GBRForest/src/GBRForest2D.cxx
+++ b/CondFormats/GBRForest/src/GBRForest2D.cxx
@@ -1,7 +1,0 @@
-#include "CondFormats/GBRForest/interface/GBRForest2D.h"
-//#include <iostream>
-#include "TMVA/DecisionTree.h"
-#include "TMVA/MethodBDT.h"
-
-//_______________________________________________________________________
-GBRForest2D::GBRForest2D() : fInitialResponseX(0.), fInitialResponseY(0.) {}

--- a/CondFormats/GBRForest/src/GBRForestD.cc
+++ b/CondFormats/GBRForest/src/GBRForestD.cc
@@ -1,7 +1,0 @@
-#include "CondFormats/GBRForest/interface/GBRForestD.h"
-
-//_______________________________________________________________________
-GBRForestD::GBRForestD() : fInitialResponse(0.) {}
-
-//_______________________________________________________________________
-GBRForestD::~GBRForestD() {}

--- a/CondFormats/GBRForest/src/GBRTree.cc
+++ b/CondFormats/GBRForest/src/GBRTree.cc
@@ -1,9 +1,6 @@
 #include "CondFormats/GBRForest/interface/GBRTree.h"
 
 //_______________________________________________________________________
-GBRTree::GBRTree() {}
-
-//_______________________________________________________________________
 GBRTree::GBRTree(int nIntermediate, int nTerminal) {
   //special case, root node is terminal
   if (nIntermediate == 0)

--- a/CondFormats/GBRForest/src/GBRTree2D.cxx
+++ b/CondFormats/GBRForest/src/GBRTree2D.cxx
@@ -1,1 +1,0 @@
-#include "CondFormats/GBRForest/interface/GBRTree2D.h"

--- a/CondFormats/GBRForest/src/GBRTreeD.cc
+++ b/CondFormats/GBRForest/src/GBRTreeD.cc
@@ -1,4 +1,0 @@
-#include "CondFormats/GBRForest/interface/GBRTreeD.h"
-
-//_______________________________________________________________________
-GBRTreeD::~GBRTreeD() {}


### PR DESCRIPTION
#### PR description:

* remove unused boost and ROOT dependencies from CondFormats/GBRForest
* move one-liner functions into header files
* remove virtual constructor of GBRTreeD and GBRForestD to avoid creation of virtual table
* rename GBRTree.cxx to GBRTree.cc to conform more with CMSSW standard

#### PR validation:

CMSSW compiles.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

No backport intended.