### PR TITLE
Adding Xi-compatible tracks to lostTracks collection

### DIFF
--- a/PhysicsTools/PatAlgos/plugins/PATLostTracks.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATLostTracks.cc
@@ -205,8 +205,7 @@ void pat::PATLostTracks::produce(edm::StreamID, edm::Event& iEvent, const edm::E
       // selecting potential Xi- -> Lambda pi candidates
       math::XYZTLorentzVector p4Lambda(v0.px(), v0.py(), v0.pz(), sqrt(v0.momentum().mag2() + v0.mass() * v0.mass()));
 
-      for (unsigned int trkIndx = 0; trkIndx < tracks->size(); trkIndx++)
-      {
+      for (unsigned int trkIndx = 0; trkIndx < tracks->size(); trkIndx++) {
         reco::TrackRef trk(tracks, trkIndx);
         if ((*trk).charge() * protonCharge < 0 || trkStatus[trkIndx] != TrkStatus::NOTUSED)
           continue;
@@ -214,7 +213,7 @@ void pat::PATLostTracks::produce(edm::StreamID, edm::Event& iEvent, const edm::E
         math::XYZTLorentzVector p4pi(
             trk->px(), trk->py(), trk->pz(), sqrt(trk->momentum().mag2() + 0.01947995518));  // pion mass ^2
         if ((p4Lambda + p4pi).M() < xiMassCut_)
-            trkStatus[trkIndx] = TrkStatus::VTX; // selecting potential Xi- candidates
+          trkStatus[trkIndx] = TrkStatus::VTX;  // selecting potential Xi- candidates
       }
     }
   }

--- a/PhysicsTools/PatAlgos/plugins/PATLostTracks.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATLostTracks.cc
@@ -203,14 +203,15 @@ void pat::PATLostTracks::produce(edm::StreamID, edm::Event& iEvent, const edm::E
     }
     if (xiSelection_) {
       // selecting potential Xi- -> Lambda pi candidates
-      math::XYZTLorentzVector p4Lambda(v0.px(), v0.py(), v0.pz(), sqrt(v0.momentum().mag2() + v0.mass()*v0.mass()));
+      math::XYZTLorentzVector p4Lambda(v0.px(), v0.py(), v0.pz(), sqrt(v0.momentum().mag2() + v0.mass() * v0.mass()));
 
       for (unsigned int trkIndx = 0; trkIndx < tracks->size(); trkIndx++) {
         reco::TrackRef trk(tracks, trkIndx);
         if ((*trk).charge() * protonCharge < 0)
           continue;
 
-        math::XYZTLorentzVector p4pi(trk->px(), trk->py(), trk->pz(), trk->momentum().mag2() + 0.01947995518); // pion mass ^2
+        math::XYZTLorentzVector p4pi(
+            trk->px(), trk->py(), trk->pz(), trk->momentum().mag2() + 0.01947995518);  // pion mass ^2
         if ((p4Lambda + p4pi).M() < xiMassCut_) {  // selecting potential Xi- candidates
           if (trkStatus[trkIndx] == TrkStatus::NOTUSED)
             trkStatus[trkIndx] = TrkStatus::VTX;

--- a/PhysicsTools/PatAlgos/plugins/PATLostTracks.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATLostTracks.cc
@@ -12,6 +12,8 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "CommonTools/Utils/interface/StringCutObjectSelector.h"
 
+#include "TLorentzVector.h"
+
 namespace {
   bool passesQuality(const reco::Track& trk, const std::vector<reco::TrackBase::TrackQuality>& allowedQuals) {
     for (const auto& qual : allowedQuals) {
@@ -68,6 +70,8 @@ namespace pat {
     const double maxDxyForNotReconstructedPrimary_;
     const double maxDxySigForNotReconstructedPrimary_;
     const bool useLegacySetup_;
+    const bool xiSelection_;
+    const double xiMassCut_;
   };
 }  // namespace pat
 
@@ -100,7 +104,9 @@ pat::PATLostTracks::PATLostTracks(const edm::ParameterSet& iConfig)
                                             .getParameter<double>("maxDxyForNotReconstructedPrimary")),
       maxDxySigForNotReconstructedPrimary_(iConfig.getParameter<edm::ParameterSet>("pvAssignment")
                                                .getParameter<double>("maxDxySigForNotReconstructedPrimary")),
-      useLegacySetup_(iConfig.getParameter<bool>("useLegacySetup")) {
+      useLegacySetup_(iConfig.getParameter<bool>("useLegacySetup")),
+      xiSelection_(iConfig.getParameter<double>("xiSelection")),
+      xiMassCut_(iConfig.getParameter<double>("xiMassCut")) {
   std::vector<std::string> trkQuals(iConfig.getParameter<std::vector<std::string>>("qualsToAutoAccept"));
   std::transform(
       trkQuals.begin(), trkQuals.end(), std::back_inserter(qualsToAutoAccept_), reco::TrackBase::qualityByName);
@@ -189,11 +195,27 @@ void pat::PATLostTracks::produce(edm::StreamID, edm::Event& iEvent, const edm::E
         trkStatus[key] = TrkStatus::VTX;
     }
   }
-  for (const auto& v0 : *lambdas) {
-    for (size_t dIdx = 0; dIdx < v0.numberOfDaughters(); dIdx++) {
-      size_t key = (dynamic_cast<const reco::RecoChargedCandidate*>(v0.daughter(dIdx)))->track().key();
-      if (trkStatus[key] == TrkStatus::NOTUSED)
-        trkStatus[key] = TrkStatus::VTX;
+  for (const auto& v0 : *lambdas){
+    double protonCharge = 0;
+    for(size_t dIdx=0;dIdx<v0.numberOfDaughters(); dIdx++){
+      size_t key= (dynamic_cast<const reco::RecoChargedCandidate*>(v0.daughter(dIdx)))->track().key();
+      if(trkStatus[key]==TrkStatus::NOTUSED)  trkStatus[key]=TrkStatus::VTX;
+      protonCharge += v0.daughter(dIdx)->charge() * v0.daughter(dIdx)->momentum().mag2();
+    }
+    if (xiSelection_)
+    {
+      // selecting potential Xi- -> Lambda pi candidates
+      TLorentzVector p4Lambda;
+      p4Lambda.SetPtEtaPhiM(v0.pt(),v0.eta(),v0.phi(), v0.mass());
+      for(unsigned int trkIndx=0; trkIndx < tracks->size(); trkIndx++){
+        reco::TrackRef trk(tracks,trkIndx);
+        if ((*trk).charge() * protonCharge < 0) continue;
+        TLorentzVector p4pi;
+        p4pi.SetPtEtaPhiM((*trk).pt(),(*trk).eta(),(*trk).phi(), 0.13957061);
+        if ((p4Lambda+p4pi).M() < xiMassCut_){ // selecting potential Xi- candidates
+          if(trkStatus[trkIndx]==TrkStatus::NOTUSED) trkStatus[trkIndx]=TrkStatus::VTX;
+        }
+      }
     }
   }
   std::vector<int> mapping(tracks->size(), -1);

--- a/PhysicsTools/PatAlgos/plugins/PATLostTracks.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATLostTracks.cc
@@ -105,7 +105,7 @@ pat::PATLostTracks::PATLostTracks(const edm::ParameterSet& iConfig)
       maxDxySigForNotReconstructedPrimary_(iConfig.getParameter<edm::ParameterSet>("pvAssignment")
                                                .getParameter<double>("maxDxySigForNotReconstructedPrimary")),
       useLegacySetup_(iConfig.getParameter<bool>("useLegacySetup")),
-      xiSelection_(iConfig.getParameter<double>("xiSelection")),
+      xiSelection_(iConfig.getParameter<bool>("xiSelection")),
       xiMassCut_(iConfig.getParameter<double>("xiMassCut")) {
   std::vector<std::string> trkQuals(iConfig.getParameter<std::vector<std::string>>("qualsToAutoAccept"));
   std::transform(
@@ -205,14 +205,14 @@ void pat::PATLostTracks::produce(edm::StreamID, edm::Event& iEvent, const edm::E
     }
     if (xiSelection_) {
       // selecting potential Xi- -> Lambda pi candidates
-      TLorentzVector p4Lambda;
-      p4Lambda.SetPtEtaPhiM(v0.pt(), v0.eta(), v0.phi(), v0.mass());
+      math::XYZTLorentzVector p4Lambda(v0.px(), v0.py(), v0.pz(), sqrt(v0.momentum().mag2() + v0.mass()*v0.mass()));
+
       for (unsigned int trkIndx = 0; trkIndx < tracks->size(); trkIndx++) {
         reco::TrackRef trk(tracks, trkIndx);
         if ((*trk).charge() * protonCharge < 0)
           continue;
-        TLorentzVector p4pi;
-        p4pi.SetPtEtaPhiM((*trk).pt(), (*trk).eta(), (*trk).phi(), 0.13957061);
+
+        math::XYZTLorentzVector p4pi(trk->px(), trk->py(), trk->pz(), trk->momentum().mag2() + 0.01947995518); // pion mass ^2
         if ((p4Lambda + p4pi).M() < xiMassCut_) {  // selecting potential Xi- candidates
           if (trkStatus[trkIndx] == TrkStatus::NOTUSED)
             trkStatus[trkIndx] = TrkStatus::VTX;

--- a/PhysicsTools/PatAlgos/plugins/PATLostTracks.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATLostTracks.cc
@@ -12,8 +12,6 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "CommonTools/Utils/interface/StringCutObjectSelector.h"
 
-#include "TLorentzVector.h"
-
 namespace {
   bool passesQuality(const reco::Track& trk, const std::vector<reco::TrackBase::TrackQuality>& allowedQuals) {
     for (const auto& qual : allowedQuals) {

--- a/PhysicsTools/PatAlgos/plugins/PATLostTracks.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATLostTracks.cc
@@ -195,25 +195,27 @@ void pat::PATLostTracks::produce(edm::StreamID, edm::Event& iEvent, const edm::E
         trkStatus[key] = TrkStatus::VTX;
     }
   }
-  for (const auto& v0 : *lambdas){
+  for (const auto& v0 : *lambdas) {
     double protonCharge = 0;
-    for(size_t dIdx=0;dIdx<v0.numberOfDaughters(); dIdx++){
-      size_t key= (dynamic_cast<const reco::RecoChargedCandidate*>(v0.daughter(dIdx)))->track().key();
-      if(trkStatus[key]==TrkStatus::NOTUSED)  trkStatus[key]=TrkStatus::VTX;
+    for (size_t dIdx = 0; dIdx < v0.numberOfDaughters(); dIdx++) {
+      size_t key = (dynamic_cast<const reco::RecoChargedCandidate*>(v0.daughter(dIdx)))->track().key();
+      if (trkStatus[key] == TrkStatus::NOTUSED)
+        trkStatus[key] = TrkStatus::VTX;
       protonCharge += v0.daughter(dIdx)->charge() * v0.daughter(dIdx)->momentum().mag2();
     }
-    if (xiSelection_)
-    {
+    if (xiSelection_) {
       // selecting potential Xi- -> Lambda pi candidates
       TLorentzVector p4Lambda;
-      p4Lambda.SetPtEtaPhiM(v0.pt(),v0.eta(),v0.phi(), v0.mass());
-      for(unsigned int trkIndx=0; trkIndx < tracks->size(); trkIndx++){
-        reco::TrackRef trk(tracks,trkIndx);
-        if ((*trk).charge() * protonCharge < 0) continue;
+      p4Lambda.SetPtEtaPhiM(v0.pt(), v0.eta(), v0.phi(), v0.mass());
+      for (unsigned int trkIndx = 0; trkIndx < tracks->size(); trkIndx++) {
+        reco::TrackRef trk(tracks, trkIndx);
+        if ((*trk).charge() * protonCharge < 0)
+          continue;
         TLorentzVector p4pi;
-        p4pi.SetPtEtaPhiM((*trk).pt(),(*trk).eta(),(*trk).phi(), 0.13957061);
-        if ((p4Lambda+p4pi).M() < xiMassCut_){ // selecting potential Xi- candidates
-          if(trkStatus[trkIndx]==TrkStatus::NOTUSED) trkStatus[trkIndx]=TrkStatus::VTX;
+        p4pi.SetPtEtaPhiM((*trk).pt(), (*trk).eta(), (*trk).phi(), 0.13957061);
+        if ((p4Lambda + p4pi).M() < xiMassCut_) {  // selecting potential Xi- candidates
+          if (trkStatus[trkIndx] == TrkStatus::NOTUSED)
+            trkStatus[trkIndx] = TrkStatus::VTX;
         }
       }
     }

--- a/PhysicsTools/PatAlgos/plugins/PATLostTracks.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATLostTracks.cc
@@ -205,17 +205,16 @@ void pat::PATLostTracks::produce(edm::StreamID, edm::Event& iEvent, const edm::E
       // selecting potential Xi- -> Lambda pi candidates
       math::XYZTLorentzVector p4Lambda(v0.px(), v0.py(), v0.pz(), sqrt(v0.momentum().mag2() + v0.mass() * v0.mass()));
 
-      for (unsigned int trkIndx = 0; trkIndx < tracks->size(); trkIndx++) {
+      for (unsigned int trkIndx = 0; trkIndx < tracks->size(); trkIndx++)
+      {
         reco::TrackRef trk(tracks, trkIndx);
-        if ((*trk).charge() * protonCharge < 0)
+        if ((*trk).charge() * protonCharge < 0 || trkStatus[trkIndx] != TrkStatus::NOTUSED)
           continue;
 
         math::XYZTLorentzVector p4pi(
             trk->px(), trk->py(), trk->pz(), sqrt(trk->momentum().mag2() + 0.01947995518));  // pion mass ^2
-        if ((p4Lambda + p4pi).M() < xiMassCut_) {  // selecting potential Xi- candidates
-          if (trkStatus[trkIndx] == TrkStatus::NOTUSED)
-            trkStatus[trkIndx] = TrkStatus::VTX;
-        }
+        if ((p4Lambda + p4pi).M() < xiMassCut_)
+            trkStatus[trkIndx] = TrkStatus::VTX; // selecting potential Xi- candidates
       }
     }
   }

--- a/PhysicsTools/PatAlgos/plugins/PATLostTracks.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATLostTracks.cc
@@ -211,7 +211,7 @@ void pat::PATLostTracks::produce(edm::StreamID, edm::Event& iEvent, const edm::E
           continue;
 
         math::XYZTLorentzVector p4pi(
-            trk->px(), trk->py(), trk->pz(), trk->momentum().mag2() + 0.01947995518);  // pion mass ^2
+            trk->px(), trk->py(), trk->pz(), sqrt(trk->momentum().mag2() + 0.01947995518));  // pion mass ^2
         if ((p4Lambda + p4pi).M() < xiMassCut_) {  // selecting potential Xi- candidates
           if (trkStatus[trkIndx] == TrkStatus::NOTUSED)
             trkStatus[trkIndx] = TrkStatus::VTX;

--- a/PhysicsTools/PatAlgos/python/slimming/lostTracks_cfi.py
+++ b/PhysicsTools/PatAlgos/python/slimming/lostTracks_cfi.py
@@ -24,7 +24,7 @@ lostTracks = cms.EDProducer("PATLostTracks",
     pvAssignment = primaryVertexAssociation.assignment,
     useLegacySetup = cms.bool(False), #When True: check only if track used to fit vertex[0] and do not store track detailed info for Pt between 0.5 and minPtToStoreProps GeV
     xiSelection = cms.bool(True),
-    xiMassCut = cms.bool(1.6) 
+    xiMassCut = cms.bool(1.5) 
 )
 from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
 phase1Pixel.toModify(lostTracks, covarianceVersion =1 )

--- a/PhysicsTools/PatAlgos/python/slimming/lostTracks_cfi.py
+++ b/PhysicsTools/PatAlgos/python/slimming/lostTracks_cfi.py
@@ -22,7 +22,9 @@ lostTracks = cms.EDProducer("PATLostTracks",
     minPtToStoreLowQualityProps = cms.double(0.0),
     passThroughCut = cms.string("pt>2"),
     pvAssignment = primaryVertexAssociation.assignment,
-    useLegacySetup = cms.bool(False) #When True: check only if track used to fit vertex[0] and do not store track detailed info for Pt between 0.5 and minPtToStoreProps GeV
+    useLegacySetup = cms.bool(False), #When True: check only if track used to fit vertex[0] and do not store track detailed info for Pt between 0.5 and minPtToStoreProps GeV
+    xiSelection = cms.bool(True),
+    xiMassCut = cms.bool(1.6) 
 )
 from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
 phase1Pixel.toModify(lostTracks, covarianceVersion =1 )

--- a/PhysicsTools/PatAlgos/python/slimming/lostTracks_cfi.py
+++ b/PhysicsTools/PatAlgos/python/slimming/lostTracks_cfi.py
@@ -24,7 +24,7 @@ lostTracks = cms.EDProducer("PATLostTracks",
     pvAssignment = primaryVertexAssociation.assignment,
     useLegacySetup = cms.bool(False), #When True: check only if track used to fit vertex[0] and do not store track detailed info for Pt between 0.5 and minPtToStoreProps GeV
     xiSelection = cms.bool(True),
-    xiMassCut = cms.bool(1.5) 
+    xiMassCut = cms.double(1.5)
 )
 from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
 phase1Pixel.toModify(lostTracks, covarianceVersion =1 )


### PR DESCRIPTION
#### PR description:

This PR adds to lostTracks collection all those tracks (pions) that can potentially form Λπ candidate checking the invariant mass M( Λπ)< X GeV. This PR adds to the lostTracks modules a variable `xiSelection` to turn on this selection and a tunable mass cut `(xiMassCut `).

#### PR validation:

All the tests run. 

The size increase is <~ 1% evaluated on JetHT Run2018D data with <PU>=37

See slide 10 [here](https://indico.cern.ch/event/1042169/contributions/4383052/attachments/2254247/3824630/trk4bph-RECO.pdf)