### PR TITLE
Change PI using literals in DataFormats/Math

### DIFF
--- a/DataFormats/Math/interface/angle_units.h
+++ b/DataFormats/Math/interface/angle_units.h
@@ -11,8 +11,8 @@ namespace angle_units {
   namespace operators {
 
     // Angle
-    constexpr double operator"" _pi(long double x) { return x * piRadians; }
-    constexpr double operator"" _pi(unsigned long long int x) { return x * piRadians; }
+    constexpr double operator"" _pi(long double x) { return double(x) * M_PI; }
+    constexpr double operator"" _pi(unsigned long long int x) { return double(x) * M_PI; }
     constexpr double operator"" _deg(long double deg) { return deg / degPerRad; }
     constexpr double operator"" _deg(unsigned long long int deg) { return deg / degPerRad; }
     constexpr double operator"" _rad(long double rad) { return rad * 1.; }

--- a/DataFormats/Math/interface/deltaPhi.h
+++ b/DataFormats/Math/interface/deltaPhi.h
@@ -65,8 +65,8 @@ namespace angle0to2pi {
 
   template <class valType>
   inline constexpr valType make0To2pi(valType angle) {
-    constexpr valType twoPi = 2._pi;
-    constexpr valType oneOverTwoPi = 1. / twoPi;
+    constexpr valType twoPi = 2. * M_PI;
+    constexpr valType oneOverTwoPi = 1. / (2. * M_PI);
     constexpr valType epsilon = 1.e-13;
 
     if ((std::abs(angle) <= epsilon) || (std::abs(twoPi - std::abs(angle)) <= epsilon))


### PR DESCRIPTION
#### PR description:

Change literals such that they compile on PPC
see 
https://github.com/cms-sw/cmssw/issues/33743#issuecomment-848572197

#### PR validation:

Compiles on PPC, precision for double is the same as using the "" _pi operator

