### PR TITLE
[HGCAL] Trackster to SimTrackster associator

### DIFF
--- a/SimCalorimetry/HGCalAssociatorProducers/plugins/TSToSCAssociatorEDProducer.cc
+++ b/SimCalorimetry/HGCalAssociatorProducers/plugins/TSToSCAssociatorEDProducer.cc
@@ -75,7 +75,7 @@ void TSToSCAssociatorEDProducer::produce(edm::StreamID, edm::Event &iEvent, cons
   Handle<reco::CaloClusterCollection> LCCollection;
   iEvent.getByToken(LCCollectionToken_, LCCollection);
 
-  // associate LC and SC
+  // associate TS and SC
   LogTrace("AssociatorValidator") << "Calling associateRecoToSim method\n";
   hgcal::RecoToSimCollectionTracksters recSimColl =
       theAssociator->associateRecoToSim(TSCollection, LCCollection, SCCollection);

--- a/SimCalorimetry/HGCalAssociatorProducers/plugins/TSToSimTSAssociatorByEnergyScoreImpl.cc
+++ b/SimCalorimetry/HGCalAssociatorProducers/plugins/TSToSimTSAssociatorByEnergyScoreImpl.cc
@@ -1,0 +1,518 @@
+#include "TSToSimTSAssociatorByEnergyScoreImpl.h"
+
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+TSToSimTSAssociatorByEnergyScoreImpl::TSToSimTSAssociatorByEnergyScoreImpl(
+    edm::EDProductGetter const& productGetter,
+    bool hardScatterOnly,
+    std::shared_ptr<hgcal::RecHitTools> recHitTools,
+    const std::unordered_map<DetId, const HGCRecHit*>* hitMap)
+    : hardScatterOnly_(hardScatterOnly), recHitTools_(recHitTools), hitMap_(hitMap), productGetter_(&productGetter) {
+  layers_ = recHitTools_->lastLayerBH();
+}
+
+hgcal::association TSToSimTSAssociatorByEnergyScoreImpl::makeConnections(
+    const edm::Handle<ticl::TracksterCollection>& tCH,
+    const edm::Handle<reco::CaloClusterCollection>& lCCH,
+    const edm::Handle<ticl::TracksterCollection>& sTCH) const {
+  // Get collections
+  const auto& tracksters = *tCH.product();
+  const auto& layerClusters = *lCCH.product();
+  const auto& simTracksters = *sTCH.product();
+  auto nTracksters = tracksters.size();
+
+  //There shouldn't be any SimTrackster without vertices, but maybe they will be added later.
+  auto nSimTracksters = simTracksters.size();
+  std::vector<size_t> sTIndices;
+  for (unsigned int stId = 0; stId < nSimTracksters; ++stId) {
+    if (simTracksters[stId].vertices().empty()) {
+      LogDebug("TSToSimTSAssociatorByEnergyScoreImpl")
+          << "Excluding SimTrackster " << stId << " witH no vertices!" << std::endl;
+      continue;
+    }
+    sTIndices.emplace_back(stId);
+  }
+  nSimTracksters = sTIndices.size();
+
+  // Initialize tssInSimTrackster. To be returned outside, since it contains the
+  // information to compute the SimTrackster-To-Trackster score.
+  // tssInSimTrackster[stId]:
+  hgcal::simTracksterToTrackster tssInSimTrackster;
+  tssInSimTrackster.resize(nSimTracksters);
+  for (unsigned int i = 0; i < nSimTracksters; ++i) {
+    tssInSimTrackster[i].simTracksterId = i;
+    tssInSimTrackster[i].energy = 0.f;
+    tssInSimTrackster[i].hits_and_fractions.clear();
+  }
+
+  // Fill detIdToSimTracksterId_Map and update tssInSimTrackster
+  std::unordered_map<DetId, std::vector<hgcal::detIdInfoInCluster>> detIdToSimTracksterId_Map;
+  for (const auto& stId : sTIndices) {
+    const auto& hits_and_fractions = simTracksters[stId].hits_and_fractions();
+    for (const auto& it_haf : hits_and_fractions) {
+      const auto hitid = it_haf.first;
+      const auto itcheck = hitMap_->find(hitid);
+      if (itcheck != hitMap_->end()) {
+        const auto hit_find_it = detIdToSimTracksterId_Map.find(hitid);
+        if (hit_find_it == detIdToSimTracksterId_Map.end()) {
+          detIdToSimTracksterId_Map[hitid] = std::vector<hgcal::detIdInfoInCluster>();
+        }
+        detIdToSimTracksterId_Map[hitid].emplace_back(stId, it_haf.second);
+
+        const HGCRecHit* hit = itcheck->second;
+        tssInSimTrackster[stId].energy += it_haf.second * hit->energy();
+        tssInSimTrackster[stId].hits_and_fractions.emplace_back(hitid, it_haf.second);
+      }
+    }
+  }  // end of loop over SimTracksters
+
+#ifdef EDM_ML_DEBUG
+  LogDebug("TSToSimTSAssociatorByEnergyScoreImpl")
+      << "tssInSimTrackster INFO (Only SimTrackster filled at the moment)" << std::endl;
+  for (size_t st = 0; st < tssInSimTrackster.size(); ++st) {
+    LogDebug("TSToSimTSAssociatorByEnergyScoreImpl") << "For SimTrackster Idx: " << st << " we have: " << std::endl;
+    LogDebug("TSToSimTSAssociatorByEnergyScoreImpl")
+        << "\tSimTracksterIdx:\t" << tssInSimTrackster[st].simTracksterId << std::endl;
+    LogDebug("TSToSimTSAssociatorByEnergyScoreImpl") << "\tEnergy:\t" << tssInSimTrackster[st].energy << std::endl;
+    LogDebug("TSToSimTSAssociatorByEnergyScoreImpl") << "\t# of clusters:\t" << layerClusters.size() << std::endl;
+    double tot_energy = 0.;
+    for (auto const& haf : tssInSimTrackster[st].hits_and_fractions) {
+      LogDebug("TSToSimTSAssociatorByEnergyScoreImpl")
+          << "\tHits/fraction/energy: " << (uint32_t)haf.first << "/" << haf.second << "/"
+          << haf.second * hitMap_->at(haf.first)->energy() << std::endl;
+      tot_energy += haf.second * hitMap_->at(haf.first)->energy();
+    }
+    LogDebug("TSToSimTSAssociatorByEnergyScoreImpl") << "\tTot Sum haf: " << tot_energy << std::endl;
+    for (auto const& ts : tssInSimTrackster[st].tracksterIdToEnergyAndScore) {
+      LogDebug("TSToSimTSAssociatorByEnergyScoreImpl")
+          << "\ttsIdx/energy/score: " << ts.first << "/" << ts.second.first << "/" << ts.second.second << std::endl;
+    }
+  }
+
+  LogDebug("TSToSimTSAssociatorByEnergyScoreImpl") << "detIdToSimTracksterId_Map INFO" << std::endl;
+  for (auto const& detId : detIdToSimTracksterId_Map) {
+    LogDebug("TSToSimTSAssociatorByEnergyScoreImpl")
+        << "For detId: " << (uint32_t)detId.first
+        << " we have found the following connections with SimTracksters:" << std::endl;
+    for (auto const& st : detId.second) {
+      LogDebug("TSToSimTSAssociatorByEnergyScoreImpl")
+          << "\tSimTrackster Id: " << st.clusterId << " with fraction: " << st.fraction
+          << " and energy: " << st.fraction * hitMap_->at(detId.first)->energy() << std::endl;
+    }
+  }
+#endif
+
+  // Fill detIdToLayerClusterId_Map and stsInTrackster; update tssInSimTrackster
+  std::unordered_map<DetId, std::vector<hgcal::detIdInfoInCluster>> detIdToLayerClusterId_Map;
+  // this contains the ids of the simTracksters contributing with at least one
+  // hit to the Trackster. To be returned since this contains the information
+  // to compute the Trackster-To-SimTrackster score.
+  hgcal::tracksterToSimTrackster stsInTrackster;  //[tsId][stId]->(energy,score)
+  stsInTrackster.resize(nTracksters);
+
+  for (unsigned int tsId = 0; tsId < nTracksters; ++tsId) {
+    for (unsigned int i = 0; i < tracksters[tsId].vertices().size(); ++i) {
+      const auto lcId = tracksters[tsId].vertices(i);
+      const auto lcFractionInTs = 1.f / tracksters[tsId].vertex_multiplicity(i);
+
+      const std::vector<std::pair<DetId, float>>& hits_and_fractions = layerClusters[lcId].hitsAndFractions();
+      unsigned int numberOfHitsInLC = hits_and_fractions.size();
+
+      for (unsigned int hitId = 0; hitId < numberOfHitsInLC; hitId++) {
+        const auto rh_detid = hits_and_fractions[hitId].first;
+        const auto rhFraction = hits_and_fractions[hitId].second;
+
+        const auto hit_find_in_LC = detIdToLayerClusterId_Map.find(rh_detid);
+        if (hit_find_in_LC == detIdToLayerClusterId_Map.end()) {
+          detIdToLayerClusterId_Map[rh_detid] = std::vector<hgcal::detIdInfoInCluster>();
+        }
+        detIdToLayerClusterId_Map[rh_detid].emplace_back(lcId, rhFraction);
+
+        const auto hit_find_in_ST = detIdToSimTracksterId_Map.find(rh_detid);
+
+        if (hit_find_in_ST != detIdToSimTracksterId_Map.end()) {
+          const auto itcheck = hitMap_->find(rh_detid);
+          const HGCRecHit* hit = itcheck->second;
+          //Loops through all the simTracksters that have the layer cluster rechit under study
+          //Here is time to update the tssInSimTrackster and connect the SimTrackster with all
+          //the Tracksters that have the current rechit detid matched.
+          for (const auto& h : hit_find_in_ST->second) {
+            //tssInSimTrackster[simTracksterId][layerclusterId]-> (energy,score)
+            //ST_i - > TS_j, TS_k, ...
+            tssInSimTrackster[h.clusterId].tracksterIdToEnergyAndScore[tsId].first +=
+                lcFractionInTs * h.fraction * hit->energy();
+            //TS_i -> ST_j, ST_k, ...
+            stsInTrackster[tsId].emplace_back(h.clusterId, 0.f);
+          }
+        }
+      }  // End loop over hits on a LayerCluster
+    }    // End loop over LayerClusters in Trackster
+  }      // End of loop over Tracksters
+
+#ifdef EDM_ML_DEBUG
+  for (unsigned int tsId = 0; tsId < nTracksters; ++tsId) {
+    for (const auto& lcId : tracksters[tsId].vertices()) {
+      const auto& hits_and_fractions = layerClusters[lcId].hitsAndFractions();
+      unsigned int numberOfHitsInLC = hits_and_fractions.size();
+
+      // This vector will store, for each hit in the Layercluster, the index of
+      // the SimTrackster that contributed the most, in terms of energy, to it.
+      // Special values are:
+      //
+      // -2  --> the reconstruction fraction of the RecHit is 0 (used in the past to monitor Halo Hits)
+      // -3  --> same as before with the added condition that no SimTrackster has been linked to this RecHit
+      // -1  --> the reco fraction is >0, but no SimTrackster has been linked to it
+      // >=0 --> index of the linked SimTrackster
+      std::vector<int> hitsToSimTracksterId(numberOfHitsInLC);
+      // This will store the index of the SimTrackster linked to the LayerCluster that has the largest number of hits in common.
+      int maxSTId_byNumberOfHits = -1;
+      // This will store the maximum number of shared hits between a LayerCluster and a SimTrackster
+      unsigned int maxSTNumberOfHitsInLC = 0;
+      // This will store the index of the SimTrackster linked to the LayerCluster that has the largest energy in common.
+      int maxSTId_byEnergy = -1;
+      // This will store the maximum number of shared energy between a LayerCluster and a SimTrackster
+      float maxEnergySharedLCandST = 0.f;
+      // This will store the fraction of the LayerCluster energy shared with the best(energy) SimTrackster: e_shared/lc_energy
+      float energyFractionOfLCinST = 0.f;
+      // This will store the fraction of the SimTrackster energy shared with the Trackster: e_shared/sc_energy
+      float energyFractionOfSTinLC = 0.f;
+      std::unordered_map<unsigned, unsigned> occurrencesSTinLC;
+      unsigned int numberOfNoiseHitsInLC = 0;
+      std::unordered_map<unsigned, float> STEnergyInLC;
+
+      for (unsigned int hitId = 0; hitId < numberOfHitsInLC; hitId++) {
+        const auto rh_detid = hits_and_fractions[hitId].first;
+        const auto rhFraction = hits_and_fractions[hitId].second;
+
+        const auto hit_find_in_ST = detIdToSimTracksterId_Map.find(rh_detid);
+
+        // if the fraction is zero or the hit does not belong to any SimTrackster,
+        // set the SimTrackster Id for the hit to -1; this will
+        // contribute to the number of noise hits
+
+        // MR Remove the case in which the fraction is 0, since this could be a
+        // real hit that has been marked as halo.
+        if (rhFraction == 0.) {
+          hitsToSimTracksterId[hitId] = -2;
+        }
+        //Now check if there are SimTracksters linked to this rechit of the layercluster
+        if (hit_find_in_ST == detIdToSimTracksterId_Map.end()) {
+          hitsToSimTracksterId[hitId] -= 1;
+        } else {
+          const auto itcheck = hitMap_->find(rh_detid);
+          const HGCRecHit* hit = itcheck->second;
+          auto maxSTEnergyInLC = 0.f;
+          auto maxSTId = -1;
+          //Loop through all the linked SimTracksters
+          for (const auto& h : hit_find_in_ST->second) {
+            STEnergyInLC[h.clusterId] += h.fraction * hit->energy();
+            // Keep track of which SimTrackster contributed the most, in terms
+            // of energy, to this specific Layer Cluster.
+            if (STEnergyInLC[h.clusterId] > maxSTEnergyInLC) {
+              maxSTEnergyInLC = STEnergyInLC[h.clusterId];
+              maxSTId = h.clusterId;
+            }
+          }
+          hitsToSimTracksterId[hitId] = maxSTId;
+        }
+      }  // End loop over hits on a LayerCluster
+
+      for (const auto& c : hitsToSimTracksterId) {
+        if (c < 0) {
+          numberOfNoiseHitsInLC++;
+        } else {
+          occurrencesSTinLC[c]++;
+        }
+      }
+
+      for (const auto& c : occurrencesSTinLC) {
+        if (c.second > maxSTNumberOfHitsInLC) {
+          maxSTId_byNumberOfHits = c.first;
+          maxSTNumberOfHitsInLC = c.second;
+        }
+      }
+
+      for (const auto& c : STEnergyInLC) {
+        if (c.second > maxEnergySharedLCandST) {
+          maxSTId_byEnergy = c.first;
+          maxEnergySharedLCandST = c.second;
+        }
+      }
+
+      float totalSTEnergyOnLayer = 0.f;
+      if (maxSTId_byEnergy >= 0) {
+        totalSTEnergyOnLayer = tssInSimTrackster[maxSTId_byEnergy].energy;
+        energyFractionOfSTinLC = maxEnergySharedLCandST / totalSTEnergyOnLayer;
+        if (tracksters[tsId].raw_energy() > 0.f) {
+          energyFractionOfLCinST = maxEnergySharedLCandST / tracksters[tsId].raw_energy();
+        }
+      }
+
+      LogDebug("TSToSimTSAssociatorByEnergyScoreImpl")
+          << std::setw(12) << "TracksterID:\t" << std::setw(12) << "layerCluster\t" << std::setw(10) << "lc energy\t"
+          << std::setw(5) << "nhits\t" << std::setw(12) << "noise hits\t" << std::setw(22) << "maxSTId_byNumberOfHits\t"
+          << std::setw(8) << "nhitsST\t" << std::setw(13) << "maxSTId_byEnergy\t" << std::setw(20)
+          << "maxEnergySharedLCandST\t" << std::setw(22) << "totalSTEnergyOnLayer\t" << std::setw(22)
+          << "energyFractionOfLCinST\t" << std::setw(25) << "energyFractionOfSTinLC\t"
+          << "\n";
+      LogDebug("TSToSimTSAssociatorByEnergyScoreImpl")
+          << std::setw(12) << tsId << "\t" << std::setw(12) << lcId << "\t" << std::setw(10)
+          << tracksters[tsId].raw_energy() << "\t" << std::setw(5) << numberOfHitsInLC << "\t" << std::setw(12)
+          << numberOfNoiseHitsInLC << "\t" << std::setw(22) << maxSTId_byNumberOfHits << "\t" << std::setw(8)
+          << maxSTNumberOfHitsInLC << "\t" << std::setw(13) << maxSTId_byEnergy << "\t" << std::setw(20)
+          << maxEnergySharedLCandST << "\t" << std::setw(22) << totalSTEnergyOnLayer << "\t" << std::setw(22)
+          << energyFractionOfLCinST << "\t" << std::setw(25) << energyFractionOfSTinLC << "\n";
+    }  // End of loop over LayerClusters in Trackster
+  }    // End of loop over Tracksters
+
+  LogDebug("TSToSimTSAssociatorByEnergyScoreImpl")
+      << "Improved tssInSimTrackster INFO (Now containing the linked tracksters id and energy - score still empty)"
+      << std::endl;
+  for (size_t st = 0; st < tssInSimTrackster.size(); ++st) {
+    LogDebug("TSToSimTSAssociatorByEnergyScoreImpl") << "For SimTrackster Idx: " << st << " we have: " << std::endl;
+    LogDebug("TSToSimTSAssociatorByEnergyScoreImpl")
+        << "    SimTracksterIdx: " << tssInSimTrackster[st].simTracksterId << std::endl;
+    LogDebug("TSToSimTSAssociatorByEnergyScoreImpl") << "\tEnergy:\t" << tssInSimTrackster[st].energy << std::endl;
+    double tot_energy = 0.;
+    for (auto const& haf : tssInSimTrackster[st].hits_and_fractions) {
+      LogDebug("TSToSimTSAssociatorByEnergyScoreImpl")
+          << "\tHits/fraction/energy: " << (uint32_t)haf.first << "/" << haf.second << "/"
+          << haf.second * hitMap_->at(haf.first)->energy() << std::endl;
+      tot_energy += haf.second * hitMap_->at(haf.first)->energy();
+    }
+    LogDebug("TSToSimTSAssociatorByEnergyScoreImpl") << "\tTot Sum haf: " << tot_energy << std::endl;
+    for (auto const& ts : tssInSimTrackster[st].tracksterIdToEnergyAndScore) {
+      LogDebug("TSToSimTSAssociatorByEnergyScoreImpl")
+          << "\ttsIdx/energy/score: " << ts.first << "/" << ts.second.first << "/" << ts.second.second << std::endl;
+    }
+  }
+
+  LogDebug("TSToSimTSAssociatorByEnergyScoreImpl") << "Improved detIdToSimTracksterId_Map INFO" << std::endl;
+  for (auto const& st : detIdToSimTracksterId_Map) {
+    LogDebug("TSToSimTSAssociatorByEnergyScoreImpl")
+        << "For detId: " << (uint32_t)st.first
+        << " we have found the following connections with SimTracksters:" << std::endl;
+    for (auto const& sclu : st.second) {
+      LogDebug("TSToSimTSAssociatorByEnergyScoreImpl")
+          << "  SimTrackster Id: " << sclu.clusterId << " with fraction: " << sclu.fraction
+          << " and energy: " << sclu.fraction * hitMap_->at(st.first)->energy() << std::endl;
+    }
+  }
+#endif
+
+  // Update stsInTrackster; compute the score Trackster-to-SimTrackster,
+  // together with the returned AssociationMap
+  for (unsigned int tsId = 0; tsId < nTracksters; ++tsId) {
+    // The SimTracksters contributing to the Trackster's LayerClusters should already be unique.
+    // find the unique SimTracksters id contributing to the Trackster's LayerClusters
+    std::sort(stsInTrackster[tsId].begin(), stsInTrackster[tsId].end());
+    auto last = std::unique(stsInTrackster[tsId].begin(), stsInTrackster[tsId].end());
+    stsInTrackster[tsId].erase(last, stsInTrackster[tsId].end());
+
+    // If a reconstructed Trackster has energy 0 but is linked to a
+    // SimTrackster, assigned score 1
+    if (tracksters[tsId].raw_energy() == 0. && !stsInTrackster[tsId].empty()) {
+      for (auto& stPair : stsInTrackster[tsId]) {
+        stPair.second = 1.;
+        LogDebug("TSToSimTSAssociatorByEnergyScoreImpl")
+            << "TracksterId:\t " << tsId << "\tST id:\t" << stPair.first << "\tscore\t " << stPair.second << "\n";
+      }
+      continue;
+    }
+
+    float invTracksterEnergyWeight = 0.f;
+    for (unsigned int i = 0; i < tracksters[tsId].vertices().size(); ++i) {
+      const auto lcId = tracksters[tsId].vertices(i);
+      const auto lcFractionInTs = 1.f / tracksters[tsId].vertex_multiplicity(i);
+
+      const auto& hits_and_fractions = layerClusters[lcId].hitsAndFractions();
+      // Compute the correct normalization
+      for (auto const& haf : hits_and_fractions) {
+        invTracksterEnergyWeight += (lcFractionInTs * haf.second * hitMap_->at(haf.first)->energy()) *
+                                    (lcFractionInTs * haf.second * hitMap_->at(haf.first)->energy());
+      }
+    }
+    invTracksterEnergyWeight = 1.f / invTracksterEnergyWeight;
+
+    for (unsigned int i = 0; i < tracksters[tsId].vertices().size(); ++i) {
+      const auto lcId = tracksters[tsId].vertices(i);
+      const auto lcFractionInTs = 1.f / tracksters[tsId].vertex_multiplicity(i);
+
+      const auto& hits_and_fractions = layerClusters[lcId].hitsAndFractions();
+      unsigned int numberOfHitsInLC = hits_and_fractions.size();
+      for (unsigned int i = 0; i < numberOfHitsInLC; ++i) {
+        DetId rh_detid = hits_and_fractions[i].first;
+        float rhFraction = hits_and_fractions[i].second * lcFractionInTs;
+
+        const bool hitWithST = (detIdToSimTracksterId_Map.find(rh_detid) != detIdToSimTracksterId_Map.end());
+
+        const auto itcheck = hitMap_->find(rh_detid);
+        const HGCRecHit* hit = itcheck->second;
+        float hitEnergyWeight = hit->energy() * hit->energy();
+
+        for (auto& stPair : stsInTrackster[tsId]) {
+          float stFraction = 0.f;
+          if (hitWithST) {
+            const auto findHitIt = std::find(detIdToSimTracksterId_Map[rh_detid].begin(),
+                                             detIdToSimTracksterId_Map[rh_detid].end(),
+                                             hgcal::detIdInfoInCluster{stPair.first, 0.f});
+            if (findHitIt != detIdToSimTracksterId_Map[rh_detid].end())
+              stFraction = findHitIt->fraction;
+          }
+          stPair.second +=
+              (rhFraction - stFraction) * (rhFraction - stFraction) * hitEnergyWeight * invTracksterEnergyWeight;
+#ifdef EDM_ML_DEBUG
+          LogDebug("TSToSimTSAssociatorByEnergyScoreImpl")
+              << "rh_detid:\t" << (uint32_t)rh_detid << "\ttracksterId:\t" << tsId << "\t"
+              << "rhfraction,stFraction:\t" << rhFraction << ", " << stFraction << "\t"
+              << "hitEnergyWeight:\t" << hitEnergyWeight << "\t"
+              << "current score:\t" << stPair.second << "\t"
+              << "invTracksterEnergyWeight:\t" << invTracksterEnergyWeight << "\n";
+#endif
+        }
+      }  // End of loop over Hits within a LayerCluster
+    }    // End of loop over LayerClusters in Trackster
+
+#ifdef EDM_ML_DEBUG
+    if (stsInTrackster[tsId].empty())
+      LogDebug("TSToSimTSAssociatorByEnergyScoreImpl") << "trackster Id:\t" << tsId << "\tST id:\t-1"
+                                                    << "\tscore\t-1\n";
+#endif
+  }  // End of loop over Tracksters
+
+  // Compute the SimTrackster-To-Trackster score
+  for (const auto& stId : sTIndices) {
+    float invSTEnergyWeight = 0.f;
+
+    const unsigned int STNumberOfHits = tssInSimTrackster[stId].hits_and_fractions.size();
+    if (STNumberOfHits == 0)
+      continue;
+#ifdef EDM_ML_DEBUG
+    int tsWithMaxEnergyInST = -1;
+    //energy of the most energetic TS from all that were linked to ST
+    float maxEnergyTSinST = 0.f;
+    float STenergy = tssInSimTrackster[stId].energy;
+    //most energetic TS from all TSs linked to ST over ST energy.
+    float STEnergyFractionInTS = 0.f;
+    for (const auto& ts : tssInSimTrackster[stId].tracksterIdToEnergyAndScore) {
+      if (ts.second.first > maxEnergyTSinST) {
+        maxEnergyTSinST = ts.second.first;
+        tsWithMaxEnergyInST = ts.first;
+      }
+    }
+    if (STenergy > 0.f)
+      STEnergyFractionInTS = maxEnergyTSinST / STenergy;
+
+    LogDebug("TSToSimTSAssociatorByEnergyScoreImpl")
+        << std::setw(12) << "simTrackster\t" << std::setw(15) << "st total energy\t" << std::setw(15)
+        << "stEnergyOnLayer\t" << std::setw(14) << "STNhitsOnLayer\t" << std::setw(18) << "tsWithMaxEnergyInST\t"
+        << std::setw(15) << "maxEnergyTSinST\t" << std::setw(20) << "STEnergyFractionInTS"
+        << "\n";
+    LogDebug("TSToSimTSAssociatorByEnergyScoreImpl")
+        << std::setw(12) << stId << "\t" << std::setw(15) << simTracksters[stId].energy() << "\t" << std::setw(15)
+        << STenergy << "\t" << std::setw(14) << STNumberOfHits << "\t" << std::setw(18) << tsWithMaxEnergyInST << "\t"
+        << std::setw(15) << maxEnergyTSinST << "\t" << std::setw(20) << STEnergyFractionInTS << "\n";
+#endif
+    // Compute the correct normalization
+    for (auto const& haf : tssInSimTrackster[stId].hits_and_fractions) {
+      invSTEnergyWeight += std::pow(haf.second * hitMap_->at(haf.first)->energy(), 2);
+    }
+    invSTEnergyWeight = 1.f / invSTEnergyWeight;
+
+    for (unsigned int i = 0; i < STNumberOfHits; ++i) {
+      auto& st_hitDetId = tssInSimTrackster[stId].hits_and_fractions[i].first;
+      auto& stFraction = tssInSimTrackster[stId].hits_and_fractions[i].second;
+
+      bool hitWithLC = false;
+      if (stFraction == 0.f)
+        continue;  // hopefully this should never happen
+      const auto hit_find_in_LC = detIdToLayerClusterId_Map.find(st_hitDetId);
+      if (hit_find_in_LC != detIdToLayerClusterId_Map.end())
+        hitWithLC = true;
+      const auto itcheck = hitMap_->find(st_hitDetId);
+      const HGCRecHit* hit = itcheck->second;
+      float hitEnergyWeight = hit->energy() * hit->energy();
+      for (auto& tsPair : tssInSimTrackster[stId].tracksterIdToEnergyAndScore) {
+        unsigned int tsId = tsPair.first;
+        float tsFraction = 0.f;
+
+        for (unsigned int i = 0; i < tracksters[tsId].vertices().size(); ++i) {
+          const auto lcId = tracksters[tsId].vertices(i);
+          const auto lcFractionInTs = 1.f / tracksters[tsId].vertex_multiplicity(i);
+
+          if (hitWithLC) {
+            const auto findHitIt = std::find(detIdToLayerClusterId_Map[st_hitDetId].begin(),
+                                             detIdToLayerClusterId_Map[st_hitDetId].end(),
+                                             hgcal::detIdInfoInCluster{lcId, 0.f});
+            if (findHitIt != detIdToLayerClusterId_Map[st_hitDetId].end())
+              tsFraction = findHitIt->fraction * lcFractionInTs;
+          }
+          tsPair.second.second +=
+              (tsFraction - stFraction) * (tsFraction - stFraction) * hitEnergyWeight * invSTEnergyWeight;
+#ifdef EDM_ML_DEBUG
+          LogDebug("TSToSimTSAssociatorByEnergyScoreImpl")
+              << "STDetId:\t" << (uint32_t)st_hitDetId << "\tTracksterId:\t" << tsId << "\t"
+              << "tsFraction, stFraction:\t" << tsFraction << ", " << stFraction << "\t"
+              << "hitEnergyWeight:\t" << hitEnergyWeight << "\t"
+              << "current score:\t" << tsPair.second.second << "\t"
+              << "invSTEnergyWeight:\t" << invSTEnergyWeight << "\n";
+#endif
+        }  // End of loop over Trackster's LayerClusters
+      }    // End of loop over Tracksters linked to hits of this SimTrackster
+    }      // End of loop over hits of SimTrackster on a Layer
+#ifdef EDM_ML_DEBUG
+    if (tssInSimTrackster[stId].tracksterIdToEnergyAndScore.empty())
+      LogDebug("TSToSimTSAssociatorByEnergyScoreImpl") << "ST Id:\t" << stId << "\tTS id:\t-1 "
+                                                    << "\tscore\t-1\n";
+
+    for (const auto& tsPair : tssInSimTrackster[stId].tracksterIdToEnergyAndScore) {
+      LogDebug("TSToSimTSAssociatorByEnergyScoreImpl")
+          << "ST Id: \t" << stId << "\t TS id: \t" << tsPair.first << "\t score \t" << tsPair.second.second
+          << "\t shared energy:\t" << tsPair.second.first << "\t shared energy fraction:\t"
+          << (tsPair.second.first / STenergy) << "\n";
+    }
+#endif
+  }  // End loop over SimTrackster indices
+  return {stsInTrackster, tssInSimTrackster};
+}
+
+hgcal::RecoToSimCollectionSimTracksters TSToSimTSAssociatorByEnergyScoreImpl::associateRecoToSim(
+    const edm::Handle<ticl::TracksterCollection>& tCH,
+    const edm::Handle<reco::CaloClusterCollection>& lCCH,
+    const edm::Handle<ticl::TracksterCollection>& sTCH) const {
+  hgcal::RecoToSimCollectionSimTracksters returnValue(productGetter_);
+  const auto& links = makeConnections(tCH, lCCH, sTCH);
+
+  const auto& stsInTrackster = std::get<0>(links);
+  for (size_t tsId = 0; tsId < stsInTrackster.size(); ++tsId) {
+    for (auto& stPair : stsInTrackster[tsId]) {
+      LogDebug("TSToSimTSAssociatorByEnergyScoreImpl")
+          << "Trackster Id:\t" << tsId << "\tSimTrackster id:\t" << stPair.first << "\tscore:\t" << stPair.second << "\n";
+      // Fill AssociationMap
+      returnValue.insert(edm::Ref<ticl::TracksterCollection>(tCH, tsId),  // Ref to TS
+                         std::make_pair(edm::Ref<ticl::TracksterCollection>(sTCH, stPair.first),
+                                        stPair.second)  // Pair <Ref to ST, score>
+      );
+    }
+  }
+  return returnValue;
+}
+
+hgcal::SimToRecoCollectionSimTracksters TSToSimTSAssociatorByEnergyScoreImpl::associateSimToReco(
+    const edm::Handle<ticl::TracksterCollection>& tCH,
+    const edm::Handle<reco::CaloClusterCollection>& lCCH,
+    const edm::Handle<ticl::TracksterCollection>& sTCH) const {
+  hgcal::SimToRecoCollectionSimTracksters returnValue(productGetter_);
+  const auto& links = makeConnections(tCH, lCCH, sTCH);
+  const auto& tssInSimTrackster = std::get<1>(links);
+  for (size_t stId = 0; stId < tssInSimTrackster.size(); ++stId) {
+    for (auto& tsPair : tssInSimTrackster[stId].tracksterIdToEnergyAndScore) {
+      returnValue.insert(
+          edm::Ref<ticl::TracksterCollection>(sTCH, stId),                                // Ref to ST
+          std::make_pair(edm::Ref<ticl::TracksterCollection>(tCH, tsPair.first),     // Pair <Ref to TS,
+                         std::make_pair(tsPair.second.first, tsPair.second.second))  // pair <energy, score> >
+      );
+    }
+  }
+  return returnValue;
+}

--- a/SimCalorimetry/HGCalAssociatorProducers/plugins/TSToSimTSAssociatorByEnergyScoreImpl.cc
+++ b/SimCalorimetry/HGCalAssociatorProducers/plugins/TSToSimTSAssociatorByEnergyScoreImpl.cc
@@ -77,8 +77,7 @@ hgcal::association TSToSimTSAssociatorByEnergyScoreImpl::makeConnections(
     for (auto const& lcaf : tssInSimTrackster[st].lcs_and_fractions) {
       const auto lcEn = lcaf.second * layerClusters[lcaf.first].energy();
       LogDebug("TSToSimTSAssociatorByEnergyScoreImpl")
-          << "\tLC/fraction/energy: " << (uint32_t)lcaf.first << "/" << lcaf.second << "/"
-          << lcEn << std::endl;
+          << "\tLC/fraction/energy: " << (uint32_t)lcaf.first << "/" << lcaf.second << "/" << lcEn << std::endl;
       tot_energy += lcEn;
     }
     LogDebug("TSToSimTSAssociatorByEnergyScoreImpl") << "\tTot Sum lcaf: " << tot_energy << std::endl;
@@ -128,8 +127,8 @@ hgcal::association TSToSimTSAssociatorByEnergyScoreImpl::makeConnections(
           stsInTrackster[tsId].emplace_back(st.clusterId, 0.f);
         }
       }
-    }    // End loop over LayerClusters in Trackster
-  }      // End of loop over Tracksters
+    }  // End loop over LayerClusters in Trackster
+  }    // End of loop over Tracksters
 
 #ifdef EDM_ML_DEBUG
   for (unsigned int tsId = 0; tsId < nTracksters; ++tsId) {
@@ -255,8 +254,7 @@ hgcal::association TSToSimTSAssociatorByEnergyScoreImpl::makeConnections(
     for (auto const& lcaf : tssInSimTrackster[st].lcs_and_fractions) {
       const auto lcEn = lcaf.second * layerClusters[lcaf.first].energy();
       LogDebug("TSToSimTSAssociatorByEnergyScoreImpl")
-          << "\tLC/fraction/energy: " << (uint32_t)lcaf.first << "/" << lcaf.second << "/"
-          << lcEn << std::endl;
+          << "\tLC/fraction/energy: " << (uint32_t)lcaf.first << "/" << lcaf.second << "/" << lcEn << std::endl;
       tot_energy += lcEn;
     }
     LogDebug("TSToSimTSAssociatorByEnergyScoreImpl") << "\tTot Sum lcaf: " << tot_energy << std::endl;
@@ -325,7 +323,7 @@ hgcal::association TSToSimTSAssociatorByEnergyScoreImpl::makeConnections(
         if (lcWithST) {
           const auto findLCIt = std::find(lcToSimTracksterId_Map[lcId].begin(),
                                           lcToSimTracksterId_Map[lcId].end(),
-                                           hgcal::lcInfoInTrackster{stPair.first, 0.f});
+                                          hgcal::lcInfoInTrackster{stPair.first, 0.f});
           if (findLCIt != lcToSimTracksterId_Map[lcId].end()) {
             stFraction = findLCIt->fraction;
           }
@@ -334,19 +332,17 @@ hgcal::association TSToSimTSAssociatorByEnergyScoreImpl::makeConnections(
             (lcFractionInTs - stFraction) * (lcFractionInTs - stFraction) * lcEnergyWeight * invTracksterEnergyWeight;
 #ifdef EDM_ML_DEBUG
         LogDebug("TSToSimTSAssociatorByEnergyScoreImpl")
-            << "lcId:\t" << (uint32_t)lcId << "\ttracksterId:\t" << tsId
-            << "\ttsFraction,stFraction:\t" << lcFractionInTs << ", " << stFraction
-            << "\tlcEnergyWeight:\t" << lcEnergyWeight
-            << "\tcurrent score:\t" << stPair.second
-            << "\tinvTracksterEnergyWeight:\t" << invTracksterEnergyWeight << "\n";
+            << "lcId:\t" << (uint32_t)lcId << "\ttracksterId:\t" << tsId << "\ttsFraction,stFraction:\t"
+            << lcFractionInTs << ", " << stFraction << "\tlcEnergyWeight:\t" << lcEnergyWeight << "\tcurrent score:\t"
+            << stPair.second << "\tinvTracksterEnergyWeight:\t" << invTracksterEnergyWeight << "\n";
 #endif
       }
-    }    // End of loop over LayerClusters in Trackster
+    }  // End of loop over LayerClusters in Trackster
 
 #ifdef EDM_ML_DEBUG
     if (stsInTrackster[tsId].empty())
       LogDebug("TSToSimTSAssociatorByEnergyScoreImpl") << "trackster Id:\t" << tsId << "\tST id:\t-1"
-                                                    << "\tscore\t-1\n";
+                                                       << "\tscore\t-1\n";
 #endif
   }  // End of loop over Tracksters
 
@@ -420,7 +416,7 @@ hgcal::association TSToSimTSAssociatorByEnergyScoreImpl::makeConnections(
 #ifdef EDM_ML_DEBUG
     if (tssInSimTrackster[stId].tracksterIdToEnergyAndScore.empty())
       LogDebug("TSToSimTSAssociatorByEnergyScoreImpl") << "ST Id:\t" << stId << "\tTS id:\t-1 "
-                                                    << "\tscore\t-1\n";
+                                                       << "\tscore\t-1\n";
 
     for (const auto& tsPair : tssInSimTrackster[stId].tracksterIdToEnergyAndScore) {
       LogDebug("TSToSimTSAssociatorByEnergyScoreImpl")
@@ -443,8 +439,8 @@ hgcal::RecoToSimCollectionSimTracksters TSToSimTSAssociatorByEnergyScoreImpl::as
   const auto& stsInTrackster = std::get<0>(links);
   for (size_t tsId = 0; tsId < stsInTrackster.size(); ++tsId) {
     for (auto& stPair : stsInTrackster[tsId]) {
-      LogDebug("TSToSimTSAssociatorByEnergyScoreImpl")
-          << "Trackster Id:\t" << tsId << "\tSimTrackster id:\t" << stPair.first << "\tscore:\t" << stPair.second << "\n";
+      LogDebug("TSToSimTSAssociatorByEnergyScoreImpl") << "Trackster Id:\t" << tsId << "\tSimTrackster id:\t"
+                                                       << stPair.first << "\tscore:\t" << stPair.second << "\n";
       // Fill AssociationMap
       returnValue.insert(edm::Ref<ticl::TracksterCollection>(tCH, tsId),  // Ref to TS
                          std::make_pair(edm::Ref<ticl::TracksterCollection>(sTCH, stPair.first),
@@ -465,7 +461,7 @@ hgcal::SimToRecoCollectionSimTracksters TSToSimTSAssociatorByEnergyScoreImpl::as
   for (size_t stId = 0; stId < tssInSimTrackster.size(); ++stId) {
     for (auto& tsPair : tssInSimTrackster[stId].tracksterIdToEnergyAndScore) {
       returnValue.insert(
-          edm::Ref<ticl::TracksterCollection>(sTCH, stId),                                // Ref to ST
+          edm::Ref<ticl::TracksterCollection>(sTCH, stId),                           // Ref to ST
           std::make_pair(edm::Ref<ticl::TracksterCollection>(tCH, tsPair.first),     // Pair <Ref to TS,
                          std::make_pair(tsPair.second.first, tsPair.second.second))  // pair <energy, score> >
       );

--- a/SimCalorimetry/HGCalAssociatorProducers/plugins/TSToSimTSAssociatorByEnergyScoreImpl.cc
+++ b/SimCalorimetry/HGCalAssociatorProducers/plugins/TSToSimTSAssociatorByEnergyScoreImpl.cc
@@ -182,7 +182,7 @@ hgcal::association TSToSimTSAssociatorByEnergyScoreImpl::makeConnections(
           //Loop through all the linked SimTracksters
           for (const auto& st : lc_find_in_ST->second) {
             const auto stId = st.clusterId;
-            STEnergyInLC[stId] += st.fraction * layerClusyers[lc_find_in_ST.first].energy();
+            STEnergyInLC[stId] += st.fraction * layerClusters[lcId].energy();
             // Keep track of which SimTrackster contributed the most, in terms
             // of energy, to this specific Layer Cluster.
             if (STEnergyInLC[stId] > maxSTEnergyInLC) {
@@ -272,7 +272,7 @@ hgcal::association TSToSimTSAssociatorByEnergyScoreImpl::makeConnections(
     for (auto const& st : lc.second) {
       LogDebug("TSToSimTSAssociatorByEnergyScoreImpl")
           << "  SimTrackster Id: " << st.clusterId << " with fraction: " << st.fraction
-          << " and energy: " << st.fraction * layerClusyers[lc.first].energy() << std::endl;
+          << " and energy: " << st.fraction * layerClusters[lc.first].energy() << std::endl;
     }
   }
 #endif
@@ -376,7 +376,7 @@ hgcal::association TSToSimTSAssociatorByEnergyScoreImpl::makeConnections(
         << std::setw(15) << "maxEnergyTSinST\t" << std::setw(20) << "STEnergyFractionInTS"
         << "\n";
     LogDebug("TSToSimTSAssociatorByEnergyScoreImpl")
-        << std::setw(12) << stId << "\t" << std::setw(15) << simTracksters[stId].energy() << "\t" << std::setw(15)
+        << std::setw(12) << stId << "\t" << std::setw(15) << simTracksters[stId].raw_energy() << "\t" << std::setw(15)
         << STenergy << "\t" << std::setw(14) << STNumberOfLCs << "\t" << std::setw(18) << tsWithMaxEnergyInST << "\t"
         << std::setw(15) << maxEnergyTSinST << "\t" << std::setw(20) << STEnergyFractionInTS << "\n";
 #endif

--- a/SimCalorimetry/HGCalAssociatorProducers/plugins/TSToSimTSAssociatorByEnergyScoreImpl.h
+++ b/SimCalorimetry/HGCalAssociatorProducers/plugins/TSToSimTSAssociatorByEnergyScoreImpl.h
@@ -1,0 +1,64 @@
+// Original Author: Leonardo Cristella
+
+#include <vector>
+#include <map>
+#include <unordered_map>
+#include <memory>  // shared_ptr
+
+#include "DataFormats/ForwardDetId/interface/HGCalDetId.h"
+#include "DataFormats/HGCRecHit/interface/HGCRecHit.h"
+#include "SimDataFormats/Associations/interface/TracksterToSimTracksterAssociator.h"
+#include "RecoLocalCalo/HGCalRecAlgos/interface/RecHitTools.h"
+
+namespace edm {
+  class EDProductGetter;
+}
+
+namespace hgcal {
+  struct detIdInfoInCluster {
+    bool operator==(const detIdInfoInCluster &o) const { return clusterId == o.clusterId; };
+    long unsigned int clusterId;
+    float fraction;
+    detIdInfoInCluster(long unsigned int cId, float fr) {
+      clusterId = cId;
+      fraction = fr;
+    }
+  };
+
+  struct simTracksterOnLayer {
+    unsigned int simTracksterId;
+    float energy = 0;
+    std::vector<std::pair<DetId, float>> hits_and_fractions;
+    std::unordered_map<int, std::pair<float, float>> tracksterIdToEnergyAndScore;
+  };
+
+  typedef std::vector<std::vector<std::pair<unsigned int, float>>> tracksterToSimTrackster;
+  typedef std::vector<hgcal::simTracksterOnLayer> simTracksterToTrackster;
+  typedef std::tuple<tracksterToSimTrackster, simTracksterToTrackster> association;
+}  // namespace hgcal
+
+class TSToSimTSAssociatorByEnergyScoreImpl : public hgcal::TracksterToSimTracksterAssociatorBaseImpl {
+public:
+  explicit TSToSimTSAssociatorByEnergyScoreImpl(edm::EDProductGetter const &,
+                                                bool,
+                                                std::shared_ptr<hgcal::RecHitTools>,
+                                                const std::unordered_map<DetId, const HGCRecHit *> *);
+
+  hgcal::RecoToSimCollectionSimTracksters associateRecoToSim(const edm::Handle<ticl::TracksterCollection> &tCH,
+                                                          const edm::Handle<reco::CaloClusterCollection> &lCCH,
+                                                          const edm::Handle<ticl::TracksterCollection> &sTCH) const override;
+
+  hgcal::SimToRecoCollectionSimTracksters associateSimToReco(const edm::Handle<ticl::TracksterCollection> &tCH,
+                                                          const edm::Handle<reco::CaloClusterCollection> &lCCH,
+                                                          const edm::Handle<ticl::TracksterCollection> &sTCH) const override;
+
+private:
+  const bool hardScatterOnly_;
+  std::shared_ptr<hgcal::RecHitTools> recHitTools_;
+  const std::unordered_map<DetId, const HGCRecHit *> *hitMap_;
+  unsigned layers_;
+  edm::EDProductGetter const *productGetter_;
+  hgcal::association makeConnections(const edm::Handle<ticl::TracksterCollection> &tCH,
+                                     const edm::Handle<reco::CaloClusterCollection> &lCCH,
+                                     const edm::Handle<ticl::TracksterCollection> &sTCH) const;
+};

--- a/SimCalorimetry/HGCalAssociatorProducers/plugins/TSToSimTSAssociatorByEnergyScoreImpl.h
+++ b/SimCalorimetry/HGCalAssociatorProducers/plugins/TSToSimTSAssociatorByEnergyScoreImpl.h
@@ -44,13 +44,15 @@ public:
                                                 std::shared_ptr<hgcal::RecHitTools>,
                                                 const std::unordered_map<DetId, const HGCRecHit *> *);
 
-  hgcal::RecoToSimCollectionSimTracksters associateRecoToSim(const edm::Handle<ticl::TracksterCollection> &tCH,
-                                                          const edm::Handle<reco::CaloClusterCollection> &lCCH,
-                                                          const edm::Handle<ticl::TracksterCollection> &sTCH) const override;
+  hgcal::RecoToSimCollectionSimTracksters associateRecoToSim(
+      const edm::Handle<ticl::TracksterCollection> &tCH,
+      const edm::Handle<reco::CaloClusterCollection> &lCCH,
+      const edm::Handle<ticl::TracksterCollection> &sTCH) const override;
 
-  hgcal::SimToRecoCollectionSimTracksters associateSimToReco(const edm::Handle<ticl::TracksterCollection> &tCH,
-                                                          const edm::Handle<reco::CaloClusterCollection> &lCCH,
-                                                          const edm::Handle<ticl::TracksterCollection> &sTCH) const override;
+  hgcal::SimToRecoCollectionSimTracksters associateSimToReco(
+      const edm::Handle<ticl::TracksterCollection> &tCH,
+      const edm::Handle<reco::CaloClusterCollection> &lCCH,
+      const edm::Handle<ticl::TracksterCollection> &sTCH) const override;
 
 private:
   const bool hardScatterOnly_;

--- a/SimCalorimetry/HGCalAssociatorProducers/plugins/TSToSimTSAssociatorByEnergyScoreImpl.h
+++ b/SimCalorimetry/HGCalAssociatorProducers/plugins/TSToSimTSAssociatorByEnergyScoreImpl.h
@@ -15,11 +15,11 @@ namespace edm {
 }
 
 namespace hgcal {
-  struct detIdInfoInCluster {
-    bool operator==(const detIdInfoInCluster &o) const { return clusterId == o.clusterId; };
+  struct lcInfoInTrackster {
+    bool operator==(const lcInfoInTrackster &o) const { return clusterId == o.clusterId; };
     long unsigned int clusterId;
     float fraction;
-    detIdInfoInCluster(long unsigned int cId, float fr) {
+    lcInfoInTrackster(long unsigned int cId, float fr) {
       clusterId = cId;
       fraction = fr;
     }
@@ -28,7 +28,7 @@ namespace hgcal {
   struct simTracksterOnLayer {
     unsigned int simTracksterId;
     float energy = 0;
-    std::vector<std::pair<DetId, float>> hits_and_fractions;
+    std::vector<std::pair<unsigned int, float>> lcs_and_fractions;
     std::unordered_map<int, std::pair<float, float>> tracksterIdToEnergyAndScore;
   };
 

--- a/SimCalorimetry/HGCalAssociatorProducers/plugins/TSToSimTSAssociatorByEnergyScoreProducer.cc
+++ b/SimCalorimetry/HGCalAssociatorProducers/plugins/TSToSimTSAssociatorByEnergyScoreProducer.cc
@@ -1,0 +1,67 @@
+// Original author: Leonardo Cristella
+
+// user include files
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/EDGetToken.h"
+#include "FWCore/Utilities/interface/ESGetToken.h"
+
+#include "SimDataFormats/Associations/interface/TracksterToSimTracksterAssociator.h"
+#include "TSToSimTSAssociatorByEnergyScoreImpl.h"
+
+class TSToSimTSAssociatorByEnergyScoreProducer : public edm::global::EDProducer<> {
+public:
+  explicit TSToSimTSAssociatorByEnergyScoreProducer(const edm::ParameterSet &);
+  ~TSToSimTSAssociatorByEnergyScoreProducer() override;
+
+  static void fillDescriptions(edm::ConfigurationDescriptions &descriptions);
+
+private:
+  void produce(edm::StreamID, edm::Event &, const edm::EventSetup &) const override;
+  edm::EDGetTokenT<std::unordered_map<DetId, const HGCRecHit *>> hitMap_;
+  edm::ESGetToken<CaloGeometry, CaloGeometryRecord> caloGeometry_;
+  const bool hardScatterOnly_;
+  std::shared_ptr<hgcal::RecHitTools> rhtools_;
+};
+
+TSToSimTSAssociatorByEnergyScoreProducer::TSToSimTSAssociatorByEnergyScoreProducer(const edm::ParameterSet &ps)
+    : hitMap_(consumes<std::unordered_map<DetId, const HGCRecHit *>>(ps.getParameter<edm::InputTag>("hitMapTag"))),
+      caloGeometry_(esConsumes<CaloGeometry, CaloGeometryRecord>()),
+      hardScatterOnly_(ps.getParameter<bool>("hardScatterOnly")) {
+  rhtools_.reset(new hgcal::RecHitTools());
+
+  // Register the product
+  produces<hgcal::TracksterToSimTracksterAssociator>();
+}
+
+TSToSimTSAssociatorByEnergyScoreProducer::~TSToSimTSAssociatorByEnergyScoreProducer() {}
+
+void TSToSimTSAssociatorByEnergyScoreProducer::produce(edm::StreamID,
+                                                       edm::Event &iEvent,
+                                                       const edm::EventSetup &es) const {
+  edm::ESHandle<CaloGeometry> geom = es.getHandle(caloGeometry_);
+  rhtools_->setGeometry(*geom);
+
+  const auto hitMap = &iEvent.get(hitMap_);
+
+  auto impl = std::make_unique<TSToSimTSAssociatorByEnergyScoreImpl>(
+      iEvent.productGetter(), hardScatterOnly_, rhtools_, hitMap);
+  auto toPut = std::make_unique<hgcal::TracksterToSimTracksterAssociator>(std::move(impl));
+  iEvent.put(std::move(toPut));
+}
+
+void TSToSimTSAssociatorByEnergyScoreProducer::fillDescriptions(edm::ConfigurationDescriptions &cfg) {
+  edm::ParameterSetDescription desc;
+  desc.add<edm::InputTag>("hitMapTag", edm::InputTag("hgcalRecHitMapProducer"));
+  desc.add<bool>("hardScatterOnly", true);
+
+  cfg.add("simTracksterAssociatorByEnergyScore", desc);
+}
+
+//define this as a plug-in
+DEFINE_FWK_MODULE(TSToSimTSAssociatorByEnergyScoreProducer);

--- a/SimCalorimetry/HGCalAssociatorProducers/plugins/TSToSimTSAssociatorEDProducer.cc
+++ b/SimCalorimetry/HGCalAssociatorProducers/plugins/TSToSimTSAssociatorEDProducer.cc
@@ -1,0 +1,95 @@
+//
+// Original Author:  Leonardo Cristella
+//         Created:  Thu Dec  3 10:52:11 CET 2020
+//
+//
+
+// system include files
+#include <memory>
+#include <string>
+
+// user include files
+#include "FWCore/Framework/interface/global/EDProducer.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "FWCore/Framework/interface/ESHandle.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "SimDataFormats/Associations/interface/TracksterToSimTracksterAssociator.h"
+
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "DataFormats/HGCalReco/interface/Trackster.h"
+
+#include "FWCore/Utilities/interface/EDGetToken.h"
+
+//
+// class decleration
+//
+
+class TSToSimTSAssociatorEDProducer : public edm::global::EDProducer<> {
+public:
+  explicit TSToSimTSAssociatorEDProducer(const edm::ParameterSet &);
+  ~TSToSimTSAssociatorEDProducer() override;
+
+private:
+  void produce(edm::StreamID, edm::Event &, const edm::EventSetup &) const override;
+
+  edm::EDGetTokenT<ticl::TracksterCollection> TSCollectionToken_;
+  edm::EDGetTokenT<ticl::TracksterCollection> SimTSCollectionToken_;
+  edm::EDGetTokenT<reco::CaloClusterCollection> LCCollectionToken_;
+  edm::EDGetTokenT<hgcal::TracksterToSimTracksterAssociator> associatorToken_;
+};
+
+TSToSimTSAssociatorEDProducer::TSToSimTSAssociatorEDProducer(const edm::ParameterSet &pset) {
+  produces<hgcal::SimToRecoCollectionSimTracksters>();
+  produces<hgcal::RecoToSimCollectionSimTracksters>();
+
+  TSCollectionToken_ = consumes<ticl::TracksterCollection>(pset.getParameter<edm::InputTag>("label_tst"));
+  SimTSCollectionToken_ = consumes<ticl::TracksterCollection>(pset.getParameter<edm::InputTag>("label_simTst"));
+  LCCollectionToken_ = consumes<reco::CaloClusterCollection>(pset.getParameter<edm::InputTag>("label_lcl"));
+  associatorToken_ = consumes<hgcal::TracksterToSimTracksterAssociator>(pset.getParameter<edm::InputTag>("associator"));
+}
+
+TSToSimTSAssociatorEDProducer::~TSToSimTSAssociatorEDProducer() {}
+
+//
+// member functions
+//
+
+// ------------ method called to produce the data  ------------
+void TSToSimTSAssociatorEDProducer::produce(edm::StreamID, edm::Event &iEvent, const edm::EventSetup &iSetup) const {
+  using namespace edm;
+
+  edm::Handle<hgcal::TracksterToSimTracksterAssociator> theAssociator;
+  iEvent.getByToken(associatorToken_, theAssociator);
+
+  Handle<ticl::TracksterCollection> TSCollection;
+  iEvent.getByToken(TSCollectionToken_, TSCollection);
+
+  Handle<ticl::TracksterCollection> SimTSCollection;
+  iEvent.getByToken(SimTSCollectionToken_, SimTSCollection);
+
+  Handle<reco::CaloClusterCollection> LCCollection;
+  iEvent.getByToken(LCCollectionToken_, LCCollection);
+
+  // associate TS and SimTS
+  LogTrace("AssociatorValidator") << "Calling associateRecoToSim method\n";
+  hgcal::RecoToSimCollectionSimTracksters recSimColl =
+      theAssociator->associateRecoToSim(TSCollection, LCCollection, SimTSCollection);
+
+  LogTrace("AssociatorValidator") << "Calling associateSimToReco method\n";
+  hgcal::SimToRecoCollectionSimTracksters simRecColl =
+      theAssociator->associateSimToReco(TSCollection, LCCollection, SimTSCollection);
+
+  auto rts = std::make_unique<hgcal::RecoToSimCollectionSimTracksters>(recSimColl);
+  auto str = std::make_unique<hgcal::SimToRecoCollectionSimTracksters>(simRecColl);
+
+  iEvent.put(std::move(rts));
+  iEvent.put(std::move(str));
+}
+
+// define this as a plug-in
+DEFINE_FWK_MODULE(TSToSimTSAssociatorEDProducer);

--- a/SimCalorimetry/HGCalAssociatorProducers/python/TSToSimTSAssociation_cfi.py
+++ b/SimCalorimetry/HGCalAssociatorProducers/python/TSToSimTSAssociation_cfi.py
@@ -1,0 +1,8 @@
+import FWCore.ParameterSet.Config as cms
+
+tracksterSimClusterAssociation = cms.EDProducer("TSToSimTSAssociatorEDProducer",
+    associator = cms.InputTag('simTsAssocByEnergyScoreProducer'),
+    label_tst = cms.InputTag("ticlTrackstersMerge"),
+    label_simTst = cms.InputTag("ticlSimTracksters"),
+    label_lcl = cms.InputTag("hgcalLayerClusters")
+)

--- a/SimCalorimetry/HGCalAssociatorProducers/python/TSToSimTSAssociation_cfi.py
+++ b/SimCalorimetry/HGCalAssociatorProducers/python/TSToSimTSAssociation_cfi.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-tracksterSimClusterAssociation = cms.EDProducer("TSToSimTSAssociatorEDProducer",
+tracksterSimTracksterAssociation = cms.EDProducer("TSToSimTSAssociatorEDProducer",
     associator = cms.InputTag('simTsAssocByEnergyScoreProducer'),
     label_tst = cms.InputTag("ticlTrackstersMerge"),
     label_simTst = cms.InputTag("ticlSimTracksters"),

--- a/SimDataFormats/Associations/interface/TracksterToSimTracksterAssociator.h
+++ b/SimDataFormats/Associations/interface/TracksterToSimTracksterAssociator.h
@@ -23,23 +23,26 @@ namespace hgcal {
 
     // ---------- const member functions ---------------------
     /// Associate a Trackster to SimClusters
-    hgcal::RecoToSimCollectionSimTracksters associateRecoToSim(const edm::Handle<ticl::TracksterCollection> &tCH,
-                                                            const edm::Handle<reco::CaloClusterCollection> &lCCH,
-                                                            const edm::Handle<ticl::TracksterCollection> &sTCH) const {
+    hgcal::RecoToSimCollectionSimTracksters associateRecoToSim(
+        const edm::Handle<ticl::TracksterCollection> &tCH,
+        const edm::Handle<reco::CaloClusterCollection> &lCCH,
+        const edm::Handle<ticl::TracksterCollection> &sTCH) const {
       return m_impl->associateRecoToSim(tCH, lCCH, sTCH);
     };
 
     /// Associate a SimCluster to Tracksters
-    hgcal::SimToRecoCollectionSimTracksters associateSimToReco(const edm::Handle<ticl::TracksterCollection> &tCH,
-                                                            const edm::Handle<reco::CaloClusterCollection> &lCCH,
-                                                            const edm::Handle<ticl::TracksterCollection> &sTCH) const {
+    hgcal::SimToRecoCollectionSimTracksters associateSimToReco(
+        const edm::Handle<ticl::TracksterCollection> &tCH,
+        const edm::Handle<reco::CaloClusterCollection> &lCCH,
+        const edm::Handle<ticl::TracksterCollection> &sTCH) const {
       return m_impl->associateSimToReco(tCH, lCCH, sTCH);
     }
 
   private:
     TracksterToSimTracksterAssociator(const TracksterToSimTracksterAssociator &) = delete;  // stop default
 
-    const TracksterToSimTracksterAssociator &operator=(const TracksterToSimTracksterAssociator &) = delete;  // stop default
+    const TracksterToSimTracksterAssociator &operator=(const TracksterToSimTracksterAssociator &) =
+        delete;  // stop default
 
     // ---------- member data --------------------------------
     std::unique_ptr<TracksterToSimTracksterAssociatorBaseImpl> m_impl;

--- a/SimDataFormats/Associations/interface/TracksterToSimTracksterAssociator.h
+++ b/SimDataFormats/Associations/interface/TracksterToSimTracksterAssociator.h
@@ -1,0 +1,49 @@
+#ifndef SimDataFormats_Associations_TracksterToSimTracksterAssociator_h
+#define SimDataFormats_Associations_TracksterToSimTracksterAssociator_h
+// Original Author:  Leonardo Cristella
+
+// system include files
+#include <memory>
+
+// user include files
+
+#include "SimDataFormats/Associations/interface/TracksterToSimTracksterAssociatorBaseImpl.h"
+
+// forward declarations
+
+namespace hgcal {
+
+  class TracksterToSimTracksterAssociator {
+  public:
+    TracksterToSimTracksterAssociator(std::unique_ptr<hgcal::TracksterToSimTracksterAssociatorBaseImpl>);
+    TracksterToSimTracksterAssociator() = default;
+    TracksterToSimTracksterAssociator(TracksterToSimTracksterAssociator &&) = default;
+    TracksterToSimTracksterAssociator &operator=(TracksterToSimTracksterAssociator &&) = default;
+    ~TracksterToSimTracksterAssociator() = default;
+
+    // ---------- const member functions ---------------------
+    /// Associate a Trackster to SimClusters
+    hgcal::RecoToSimCollectionSimTracksters associateRecoToSim(const edm::Handle<ticl::TracksterCollection> &tCH,
+                                                            const edm::Handle<reco::CaloClusterCollection> &lCCH,
+                                                            const edm::Handle<ticl::TracksterCollection> &sTCH) const {
+      return m_impl->associateRecoToSim(tCH, lCCH, sTCH);
+    };
+
+    /// Associate a SimCluster to Tracksters
+    hgcal::SimToRecoCollectionSimTracksters associateSimToReco(const edm::Handle<ticl::TracksterCollection> &tCH,
+                                                            const edm::Handle<reco::CaloClusterCollection> &lCCH,
+                                                            const edm::Handle<ticl::TracksterCollection> &sTCH) const {
+      return m_impl->associateSimToReco(tCH, lCCH, sTCH);
+    }
+
+  private:
+    TracksterToSimTracksterAssociator(const TracksterToSimTracksterAssociator &) = delete;  // stop default
+
+    const TracksterToSimTracksterAssociator &operator=(const TracksterToSimTracksterAssociator &) = delete;  // stop default
+
+    // ---------- member data --------------------------------
+    std::unique_ptr<TracksterToSimTracksterAssociatorBaseImpl> m_impl;
+  };
+}  // namespace hgcal
+
+#endif

--- a/SimDataFormats/Associations/interface/TracksterToSimTracksterAssociatorBaseImpl.h
+++ b/SimDataFormats/Associations/interface/TracksterToSimTracksterAssociatorBaseImpl.h
@@ -1,0 +1,49 @@
+#ifndef SimDataFormats_Associations_TracksterToSimTracksterAssociatorBaseImpl_h
+#define SimDataFormats_Associations_TracksterToSimTracksterAssociatorBaseImpl_h
+
+/** \class TracksterToSimTracksterAssociatorBaseImpl
+ *
+ * Base class for TracksterToSimTracksterAssociator. Methods take as input
+ * the handles of Tracksters, LayerClusters and SimTracksters collections and return an
+ * AssociationMap (oneToManyWithQuality)
+ *
+ *  \author Leonardo Cristella
+ */
+
+#include "DataFormats/Common/interface/Handle.h"
+#include "DataFormats/Common/interface/AssociationMap.h"
+#include "DataFormats/HGCalReco/interface/Trackster.h"
+#include "DataFormats/CaloRecHit/interface/CaloClusterFwd.h"
+
+#include "SimDataFormats/CaloAnalysis/interface/SimClusterFwd.h"
+
+namespace hgcal {
+
+  typedef edm::AssociationMap<
+      edm::OneToManyWithQualityGeneric<ticl::TracksterCollection, ticl::TracksterCollection, std::pair<float, float>>>
+      SimToRecoCollectionSimTracksters;
+  typedef edm::AssociationMap<edm::OneToManyWithQualityGeneric<ticl::TracksterCollection, ticl::TracksterCollection, float>>
+      RecoToSimCollectionSimTracksters;
+
+  class TracksterToSimTracksterAssociatorBaseImpl {
+  public:
+    /// Constructor
+    TracksterToSimTracksterAssociatorBaseImpl();
+    /// Destructor
+    virtual ~TracksterToSimTracksterAssociatorBaseImpl();
+
+    /// Associate a Trackster to SimClusters
+    virtual hgcal::RecoToSimCollectionSimTracksters associateRecoToSim(
+        const edm::Handle<ticl::TracksterCollection> &tCH,
+        const edm::Handle<reco::CaloClusterCollection> &lCCH,
+        const edm::Handle<ticl::TracksterCollection> &sTCH) const;
+
+    /// Associate a SimCluster to Tracksters
+    virtual hgcal::SimToRecoCollectionSimTracksters associateSimToReco(
+        const edm::Handle<ticl::TracksterCollection> &tCH,
+        const edm::Handle<reco::CaloClusterCollection> &lCCH,
+        const edm::Handle<ticl::TracksterCollection> &sTCH) const;
+  };
+}  // namespace hgcal
+
+#endif

--- a/SimDataFormats/Associations/interface/TracksterToSimTracksterAssociatorBaseImpl.h
+++ b/SimDataFormats/Associations/interface/TracksterToSimTracksterAssociatorBaseImpl.h
@@ -22,7 +22,8 @@ namespace hgcal {
   typedef edm::AssociationMap<
       edm::OneToManyWithQualityGeneric<ticl::TracksterCollection, ticl::TracksterCollection, std::pair<float, float>>>
       SimToRecoCollectionSimTracksters;
-  typedef edm::AssociationMap<edm::OneToManyWithQualityGeneric<ticl::TracksterCollection, ticl::TracksterCollection, float>>
+  typedef edm::AssociationMap<
+      edm::OneToManyWithQualityGeneric<ticl::TracksterCollection, ticl::TracksterCollection, float>>
       RecoToSimCollectionSimTracksters;
 
   class TracksterToSimTracksterAssociatorBaseImpl {

--- a/SimDataFormats/Associations/src/TracksterToSimTracksterAssociator.cc
+++ b/SimDataFormats/Associations/src/TracksterToSimTracksterAssociator.cc
@@ -1,0 +1,7 @@
+// Original Author: Leonardo Cristella
+
+#include "SimDataFormats/Associations/interface/TracksterToSimTracksterAssociator.h"
+
+hgcal::TracksterToSimTracksterAssociator::TracksterToSimTracksterAssociator(
+    std::unique_ptr<hgcal::TracksterToSimTracksterAssociatorBaseImpl> ptr)
+    : m_impl(std::move(ptr)) {}

--- a/SimDataFormats/Associations/src/TracksterToSimTracksterAssociatorBaseImpl.cc
+++ b/SimDataFormats/Associations/src/TracksterToSimTracksterAssociatorBaseImpl.cc
@@ -1,0 +1,23 @@
+// Original Author: Leonardo Cristella
+
+#include "SimDataFormats/Associations/interface/TracksterToSimTracksterAssociatorBaseImpl.h"
+
+namespace hgcal {
+  TracksterToSimTracksterAssociatorBaseImpl::TracksterToSimTracksterAssociatorBaseImpl(){};
+  TracksterToSimTracksterAssociatorBaseImpl::~TracksterToSimTracksterAssociatorBaseImpl(){};
+
+  hgcal::RecoToSimCollectionSimTracksters TracksterToSimTracksterAssociatorBaseImpl::associateRecoToSim(
+      const edm::Handle<ticl::TracksterCollection> &tCH,
+      const edm::Handle<reco::CaloClusterCollection> &lCCH,
+      const edm::Handle<ticl::TracksterCollection> &sTCH) const {
+    return hgcal::RecoToSimCollectionSimTracksters();
+  }
+
+  hgcal::SimToRecoCollectionSimTracksters TracksterToSimTracksterAssociatorBaseImpl::associateSimToReco(
+      const edm::Handle<ticl::TracksterCollection> &tCH,
+      const edm::Handle<reco::CaloClusterCollection> &lCCH,
+      const edm::Handle<ticl::TracksterCollection> &sTCH) const {
+    return hgcal::SimToRecoCollectionSimTracksters();
+  }
+
+}  // namespace hgcal

--- a/SimDataFormats/Associations/src/classes.h
+++ b/SimDataFormats/Associations/src/classes.h
@@ -11,6 +11,7 @@
 #include "SimDataFormats/Associations/interface/TrackAssociation.h"
 #include "SimDataFormats/Associations/interface/TracksterToSimClusterAssociator.h"
 #include "SimDataFormats/Associations/interface/MultiClusterToCaloParticleAssociator.h"
+#include "SimDataFormats/Associations/interface/TracksterToSimTracksterAssociator.h"
 #include "SimDataFormats/Associations/interface/TTTrackTruthPair.h"
 
 namespace SimDataFormats_Associations {
@@ -29,6 +30,8 @@ namespace SimDataFormats_Associations {
     edm::Wrapper<hgcal::TracksterToSimClusterAssociator> dummy7;
 
     edm::Wrapper<hgcal::MultiClusterToCaloParticleAssociator> dummy8;
+
+    edm::Wrapper<hgcal::TracksterToSimTracksterAssociator> dummy9;
 
     reco::VertexSimToRecoCollection vstrc;
     reco::VertexSimToRecoCollection::const_iterator vstrci;

--- a/SimDataFormats/Associations/src/classes_def.xml
+++ b/SimDataFormats/Associations/src/classes_def.xml
@@ -21,6 +21,10 @@
   <class name="hgcal::MultiClusterToCaloParticleAssociator" persistent="false"/>
   <class name="edm::Wrapper<hgcal::MultiClusterToCaloParticleAssociator>" persistent="false"/>
 
+  <class name="hgcal::TracksterToSimTracksterAssociator" persistent="false"/>
+  <class name="edm::Wrapper<hgcal::TracksterToSimTracksterAssociator>" persistent="false"/>
+
+
   <class name="reco::VertexSimToRecoCollection" >
     <field name="transientMap_" transient="true"/>
   </class>
@@ -59,6 +63,7 @@
   <class name="edm::helpers::KeyVal<edm::RefProd<vector<SimCluster> >, edm::RefProd<vector<ticl::Trackster> > >" />
   <class name="edm::helpers::KeyVal<edm::RefProd<vector<ticl::Trackster> >, edm::RefProd<vector<SimCluster> > >" />
 
+
   <class name="hgcal::SimToRecoCollectionTracksters" >
    <field name="transientMap_" transient="true"/>
   </class>
@@ -80,10 +85,13 @@
   <class name="reco::RecoToSimCollection" >
    <field name="transientMap_" transient="true"/>
   </class>
+
+
   <class name="edm::Wrapper<edm::AssociationMap<edm::OneToManyWithQualityGeneric<edm::View<reco::Track>,vector<TrackingParticle>,double,unsigned int,edm::RefToBaseProd<reco::Track>,edm::RefProd<vector<TrackingParticle> >,edm::RefToBase<reco::Track>,edm::Ref<vector<TrackingParticle>,TrackingParticle,edm::refhelper::FindUsingAdvance<vector<TrackingParticle>,TrackingParticle> > > > >" />
   <class name="edm::Wrapper<edm::AssociationMap<edm::OneToManyWithQualityGeneric<vector<TrackingParticle>,edm::View<reco::Track>,double,unsigned int,edm::RefProd<vector<TrackingParticle> >,edm::RefToBaseProd<reco::Track>,edm::Ref<vector<TrackingParticle>,TrackingParticle,edm::refhelper::FindUsingAdvance<vector<TrackingParticle>,TrackingParticle> >,edm::RefToBase<reco::Track> > > >" />
 
-   <class name="hgcal::SimToRecoCollectionWithMultiClusters" >
+
+  <class name="hgcal::SimToRecoCollectionWithMultiClusters" >
     <field name="transientMap_" transient="true"/>
   </class>
   <class name="edm::Wrapper<hgcal::SimToRecoCollectionWithMultiClusters>" />
@@ -95,6 +103,19 @@
   <class name="edm::RefProd<vector<reco::HGCalMultiCluster> >" />
   <class name="edm::helpers::KeyVal<edm::RefProd<vector<CaloParticle> >,edm::RefProd<vector<reco::HGCalMultiCluster> > >" />
   <class name="edm::helpers::KeyVal<edm::RefProd<vector<reco::HGCalMultiCluster> >,edm::RefProd<vector<CaloParticle> > >" />
+
+
+  <class name="hgcal::SimToRecoCollectionSimTracksters" >
+    <field name="transientMap_" transient="true"/>
+  </class>
+  <class name="edm::Wrapper<hgcal::SimToRecoCollectionSimTracksters>" />
+  <class name="hgcal::RecoToSimCollectionSimTracksters" >
+    <field name="transientMap_" transient="true"/>
+  </class>
+  <class name="edm::Wrapper<hgcal::RecoToSimCollectionSimTracksters>" />
+
+  <class name="edm::helpers::KeyVal<edm::RefProd<vector<ticl::Trackster> >,edm::RefProd<vector<ticl::Trackster> > >" />
+
 
   <class name="TTTrackTruthPair<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>,Phase2TrackerDigi,edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > >" />
   <class name="std::vector<TTTrackTruthPair<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>,Phase2TrackerDigi,edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > > >" />


### PR DESCRIPTION
#### PR description:

This PR introduces an associator between TICL Tracksters and SimTracksters. Among other usages, it will be used for the final HGCAL validation based on SimTracksters in place of the current CaloParticles. No changes are expected in the output.

#### PR validation:

`runTheMatrix -l limited`