### PR TITLE
Removed FWCore/ParameterSet dependecies from *Formats packages

### DIFF
--- a/Calibration/EcalAlCaRecoProducers/plugins/SelectedElectronFEDListProducer.cc
+++ b/Calibration/EcalAlCaRecoProducers/plugins/SelectedElectronFEDListProducer.cc
@@ -4,6 +4,8 @@
 #include "HLTrigger/HLTcore/interface/defaultModuleLabel.h"
 
 #include "FWCore/Framework/interface/ESTransientHandle.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 
 //#include "DataFormats/Common/interface/Handle.h"
 

--- a/CondFormats/CSCObjects/BuildFile.xml
+++ b/CondFormats/CSCObjects/BuildFile.xml
@@ -1,6 +1,5 @@
 <use name="DataFormats/MuonDetId"/>
 <use name="FWCore/MessageLogger"/>
-<use name="FWCore/ParameterSet"/>
 <use name="CondFormats/Serialization"/>
 <use name="boost_serialization"/>
 <export>

--- a/CondFormats/CSCObjects/interface/CSCReadoutMapping.h
+++ b/CondFormats/CSCObjects/interface/CSCReadoutMapping.h
@@ -15,13 +15,9 @@
 
 #include "CondFormats/Serialization/interface/Serializable.h"
 
-#include <DataFormats/MuonDetId/interface/CSCDetId.h>
+#include "DataFormats/MuonDetId/interface/CSCDetId.h"
 #include <vector>
 #include <map>
-
-namespace edm {
-  class ParameterSet;
-}
 
 class CSCReadoutMapping {
 public:
@@ -89,11 +85,6 @@ public:
     *  endcap = 1 (+z), 2 (-z), station, vme crate number, dmb slot number, tmb slot number.
     */
   int chamber(int endcap, int station, int vmecrate, int dmb, int tmb) const;
-
-  /** 
-    * Fill mapping store
-    */
-  virtual void fill(const edm::ParameterSet&) = 0;
 
   ///returns hardware ids given chamber id
   CSCLabel findHardwareId(const CSCDetId&) const;

--- a/CondFormats/CSCObjects/interface/CSCReadoutMappingFromFile.h
+++ b/CondFormats/CSCObjects/interface/CSCReadoutMappingFromFile.h
@@ -8,21 +8,20 @@
  * Find file from FileInPath of ParameterSet passed from calling E_Producer.
  */
 
-#include <CondFormats/CSCObjects/interface/CSCReadoutMappingForSliceTest.h>
-#include <FWCore/ParameterSet/interface/ParameterSet.h>
+#include "CondFormats/CSCObjects/interface/CSCReadoutMappingForSliceTest.h"
 #include <string>
 
 class CSCReadoutMappingFromFile : public CSCReadoutMappingForSliceTest {
 public:
   /// Constructor
-  explicit CSCReadoutMappingFromFile(const edm::ParameterSet& ps);
+  explicit CSCReadoutMappingFromFile(std::string iFullPathFileName);
   CSCReadoutMappingFromFile() {}
 
   /// Destructor
   ~CSCReadoutMappingFromFile() override;
 
   /// Fill mapping store
-  void fill(const edm::ParameterSet& ps) override;
+  void fill(std::string iFullPathFileName);
 
 private:
   std::string theMappingFile;

--- a/CondFormats/CSCObjects/src/CSCReadoutMappingFromFile.cc
+++ b/CondFormats/CSCObjects/src/CSCReadoutMappingFromFile.cc
@@ -1,6 +1,6 @@
-#include <CondFormats/CSCObjects/interface/CSCReadoutMappingFromFile.h>
-#include <FWCore/MessageLogger/interface/MessageLogger.h>
-#include <FWCore/ParameterSet/interface/FileInPath.h>
+#include "CondFormats/CSCObjects/interface/CSCReadoutMappingFromFile.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/Utilities/interface/FileInPath.h"
 #include <iostream>
 #include <fstream>
 #include <sstream>

--- a/CondFormats/CSCObjects/src/CSCReadoutMappingFromFile.cc
+++ b/CondFormats/CSCObjects/src/CSCReadoutMappingFromFile.cc
@@ -1,17 +1,17 @@
 #include "CondFormats/CSCObjects/interface/CSCReadoutMappingFromFile.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
-#include "FWCore/Utilities/interface/FileInPath.h"
 #include <iostream>
 #include <fstream>
 #include <sstream>
 
-CSCReadoutMappingFromFile::CSCReadoutMappingFromFile(const edm::ParameterSet& ps) { fill(ps); }
+CSCReadoutMappingFromFile::CSCReadoutMappingFromFile(std::string iName) { fill(std::move(iName)); }
 
 CSCReadoutMappingFromFile::~CSCReadoutMappingFromFile() {}
 
-void CSCReadoutMappingFromFile::fill(const edm::ParameterSet& ps) {
-  edm::FileInPath fp = ps.getParameter<edm::FileInPath>("theMappingFile");
-  theMappingFile = fp.fullPath();
+void CSCReadoutMappingFromFile::fill(std::string fileName) {
+  theMappingFile = std::move(fileName);
+  //  edm::FileInPath fp = ps.getParameter<edm::FileInPath>("theMappingFile");
+  //theMappingFile = fp.fullPath();
   std::ifstream in(theMappingFile.c_str());
   std::string line;
   const std::string commentFlag = "#";

--- a/CondFormats/CSCObjects/src/CSCReadoutMappingFromFile.cc
+++ b/CondFormats/CSCObjects/src/CSCReadoutMappingFromFile.cc
@@ -10,8 +10,6 @@ CSCReadoutMappingFromFile::~CSCReadoutMappingFromFile() {}
 
 void CSCReadoutMappingFromFile::fill(std::string fileName) {
   theMappingFile = std::move(fileName);
-  //  edm::FileInPath fp = ps.getParameter<edm::FileInPath>("theMappingFile");
-  //theMappingFile = fp.fullPath();
   std::ifstream in(theMappingFile.c_str());
   std::string line;
   const std::string commentFlag = "#";

--- a/CondFormats/CSCObjects/test/BuildFile.xml
+++ b/CondFormats/CSCObjects/test/BuildFile.xml
@@ -81,12 +81,10 @@
 </library>
 
 <bin name="testCSCMapping" file="testCSCMapping.cpp">
-  <use name="FWCore/ParameterSetReader"/>
   <use name="cppunit"/>
 </bin>
 
 <bin name="testCSCTriggerMapping" file="testCSCTriggerMapping.cpp">
-  <use name="FWCore/ParameterSetReader"/>
   <use name="cppunit"/>
 </bin>
 

--- a/CondFormats/CSCObjects/test/testCSCMapping.cpp
+++ b/CondFormats/CSCObjects/test/testCSCMapping.cpp
@@ -5,13 +5,13 @@
  */
 
 #include <cppunit/extensions/HelperMacros.h>
-#include <FWCore/Utilities/interface/Exception.h>
-#include <FWCore/PluginManager/interface/ProblemTracker.h>
-#include <FWCore/ParameterSet/interface/ParameterSet.h>
+#include "FWCore/Utilities/interface/Exception.h"
+#include "FWCore/PluginManager/interface/ProblemTracker.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSetReader/interface/ParameterSetReader.h"
-#include <FWCore/ParameterSet/interface/FileInPath.h>
-#include <CondFormats/CSCObjects/interface/CSCReadoutMappingFromFile.h>
-#include <DataFormats/MuonDetId/interface/CSCDetId.h>
+#include "FWCore/Utilities/interface/FileInPath.h"
+#include "CondFormats/CSCObjects/interface/CSCReadoutMappingFromFile.h"
+#include "DataFormats/MuonDetId/interface/CSCDetId.h"
 #include "Utilities/Testing/interface/CppUnit_testdriver.icpp"
 #include <iostream>
 #include <cstdlib>

--- a/CondFormats/CSCObjects/test/testCSCMapping.cpp
+++ b/CondFormats/CSCObjects/test/testCSCMapping.cpp
@@ -6,9 +6,6 @@
 
 #include <cppunit/extensions/HelperMacros.h>
 #include "FWCore/Utilities/interface/Exception.h"
-#include "FWCore/PluginManager/interface/ProblemTracker.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/ParameterSetReader/interface/ParameterSetReader.h"
 #include "FWCore/Utilities/interface/FileInPath.h"
 #include "CondFormats/CSCObjects/interface/CSCReadoutMappingFromFile.h"
 #include "DataFormats/MuonDetId/interface/CSCDetId.h"
@@ -60,13 +57,11 @@ private:
 void testCSCMapping::testRead() {
   edm::FileInPath fip("CondFormats/CSCObjects/data/csc_slice_test_map.txt");
   std::cout << "Attempt to set FileInPath to " << fip.fullPath() << std::endl;
-  edm::ParameterSet ps;
-  ps.addParameter<edm::FileInPath>("theMappingFile", fip);
 
   std::cout << myName_ << ": --- t e s t C S C M a p p i n g  ---" << std::endl;
   std::cout << "start " << dashedLine << std::endl;
 
-  CSCReadoutMappingFromFile theMapping(ps);
+  CSCReadoutMappingFromFile theMapping(fip.fullPath());
 
   // The following labels are irrelevant to hardware in slice test
   int tmb = -1;

--- a/CondFormats/CSCObjects/test/testCSCTriggerMapping.cpp
+++ b/CondFormats/CSCObjects/test/testCSCTriggerMapping.cpp
@@ -10,8 +10,6 @@
 #include <CondFormats/CSCObjects/interface/CSCTriggerMappingFromFile.h>
 #include <DataFormats/MuonDetId/interface/CSCDetId.h>
 #include "Utilities/Testing/interface/CppUnit_testdriver.icpp"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/ParameterSetReader/interface/ParameterSetReader.h"
 #include <iostream>
 #include <cstdlib>
 

--- a/CondFormats/JetMETObjects/test/BuildFile.xml
+++ b/CondFormats/JetMETObjects/test/BuildFile.xml
@@ -3,7 +3,7 @@
 </bin>
 
 <bin name="TestCondFormatsJetMETObjectsJetCorrectorParameters" file="JetCorrectorParameters_t.cpp">
-  <use name="FWCore/ParameterSet"/>
+  <use name="FWCore/Utilities"/>
   <use name="CondFormats/JetMETObjects"/>
   <use name="cppunit"/>
 </bin>

--- a/CondFormats/JetMETObjects/test/JetCorrectorParameters_t.cpp
+++ b/CondFormats/JetMETObjects/test/JetCorrectorParameters_t.cpp
@@ -1,7 +1,7 @@
 #include "Utilities/Testing/interface/CppUnit_testdriver.icpp"
 #include "cppunit/extensions/HelperMacros.h"
 
-#include "FWCore/ParameterSet/interface/FileInPath.h"
+#include "FWCore/Utilities/interface/FileInPath.h"
 #include "CondFormats/JetMETObjects/interface/JetCorrectorParameters.h"
 #include "CondFormats/JetMETObjects/interface/FactorizedJetCorrector.h"
 

--- a/CondFormats/L1TObjects/src/L1MuDTEtaPatternLut.cc
+++ b/CondFormats/L1TObjects/src/L1MuDTEtaPatternLut.cc
@@ -32,7 +32,7 @@
 // Collaborating Class Headers --
 //-------------------------------
 
-#include "FWCore/ParameterSet/interface/FileInPath.h"
+#include "FWCore/Utilities/interface/FileInPath.h"
 #include "CondFormats/L1TObjects/interface/L1TriggerLutFile.h"
 
 using namespace std;

--- a/CondFormats/L1TObjects/src/L1MuDTExtLut.cc
+++ b/CondFormats/L1TObjects/src/L1MuDTExtLut.cc
@@ -34,7 +34,7 @@
 // Collaborating Class Headers --
 //-------------------------------
 
-#include "FWCore/ParameterSet/interface/FileInPath.h"
+#include "FWCore/Utilities/interface/FileInPath.h"
 #include "CondFormats/L1TObjects/interface/DTTFBitArray.h"
 #include "CondFormats/L1TObjects/interface/L1MuDTExtParam.h"
 #include "CondFormats/L1TObjects/interface/L1TriggerLutFile.h"

--- a/CondFormats/L1TObjects/src/L1MuDTPhiLut.cc
+++ b/CondFormats/L1TObjects/src/L1MuDTPhiLut.cc
@@ -34,7 +34,7 @@
 // Collaborating Class Headers --
 //-------------------------------
 
-#include "FWCore/ParameterSet/interface/FileInPath.h"
+#include "FWCore/Utilities/interface/FileInPath.h"
 #include "CondFormats/L1TObjects/interface/DTTFBitArray.h"
 #include "CondFormats/L1TObjects/interface/L1TriggerLutFile.h"
 

--- a/CondFormats/L1TObjects/src/L1MuDTPtaLut.cc
+++ b/CondFormats/L1TObjects/src/L1MuDTPtaLut.cc
@@ -34,7 +34,7 @@
 // Collaborating Class Headers --
 //-------------------------------
 
-#include "FWCore/ParameterSet/interface/FileInPath.h"
+#include "FWCore/Utilities/interface/FileInPath.h"
 #include "CondFormats/L1TObjects/interface/DTTFBitArray.h"
 #include "CondFormats/L1TObjects/interface/L1MuDTAssParam.h"
 #include "CondFormats/L1TObjects/interface/L1TriggerLutFile.h"

--- a/CondFormats/L1TObjects/src/L1MuDTQualPatternLut.cc
+++ b/CondFormats/L1TObjects/src/L1MuDTQualPatternLut.cc
@@ -34,7 +34,7 @@
 // Collaborating Class Headers --
 //-------------------------------
 
-#include "FWCore/ParameterSet/interface/FileInPath.h"
+#include "FWCore/Utilities/interface/FileInPath.h"
 #include "CondFormats/L1TObjects/interface/L1TriggerLutFile.h"
 
 using namespace std;

--- a/CondFormats/PPSObjects/src/PPSDirectSimulationData.cc
+++ b/CondFormats/PPSObjects/src/PPSDirectSimulationData.cc
@@ -5,7 +5,7 @@
 #include "DataFormats/CTPPSDetId/interface/CTPPSPixelDetId.h"
 #include "DataFormats/CTPPSDetId/interface/CTPPSDiamondDetId.h"
 #include "FWCore/Utilities/interface/Exception.h"
-#include "FWCore/ParameterSet/interface/FileInPath.h"
+#include "FWCore/Utilities/interface/FileInPath.h"
 
 #include "TFile.h"
 

--- a/CondFormats/PhysicsToolsObjects/test/SiStripDeDx2DBuilder.cc
+++ b/CondFormats/PhysicsToolsObjects/test/SiStripDeDx2DBuilder.cc
@@ -6,7 +6,7 @@
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "CommonTools/ConditionDBWriter/interface/ConditionDBWriter.h"
-#include "FWCore/ParameterSet/interface/FileInPath.h"
+//#include "FWCore/Utilities/interface/FileInPath.h"
 
 #include "CondFormats/PhysicsToolsObjects/interface/Histogram2D.h"
 
@@ -24,7 +24,7 @@ public:
   virtual void analyze(const edm::Event&, const edm::EventSetup&);
 
 private:
-  edm::FileInPath fp_;
+  //edm::FileInPath fp_;
   bool printdebug_;
 };
 

--- a/CondFormats/PhysicsToolsObjects/test/SiStripDeDx3DBuilder.cc
+++ b/CondFormats/PhysicsToolsObjects/test/SiStripDeDx3DBuilder.cc
@@ -6,7 +6,7 @@
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "CommonTools/ConditionDBWriter/interface/ConditionDBWriter.h"
-#include "FWCore/ParameterSet/interface/FileInPath.h"
+//#include "FWCore/Utilities/interface/FileInPath.h"
 
 #include "CondFormats/PhysicsToolsObjects/interface/Histogram3D.h"
 
@@ -24,7 +24,7 @@ public:
   virtual void analyze(const edm::Event&, const edm::EventSetup&);
 
 private:
-  edm::FileInPath fp_;
+  //edm::FileInPath fp_;
   bool printdebug_;
 };
 

--- a/CondFormats/PhysicsToolsObjects/test/SiStripDeDxMipBuilder.h
+++ b/CondFormats/PhysicsToolsObjects/test/SiStripDeDxMipBuilder.h
@@ -6,7 +6,7 @@
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "CommonTools/ConditionDBWriter/interface/ConditionDBWriter.h"
-#include "FWCore/ParameterSet/interface/FileInPath.h"
+//#include "FWCore/Utilities/interface/FileInPath.h"
 
 #include "CondFormats/PhysicsToolsObjects/interface/Histogram2D.h"
 
@@ -22,7 +22,7 @@ public:
   virtual void analyze(const edm::Event&, const edm::EventSetup&);
 
 private:
-  edm::FileInPath fp_;
+  //edm::FileInPath fp_;
   bool printdebug_;
 };
 

--- a/CondFormats/SiPixelObjects/BuildFile.xml
+++ b/CondFormats/SiPixelObjects/BuildFile.xml
@@ -13,7 +13,6 @@
 <use name="DataFormats/GeometryVector"/>
 <use name="FWCore/Framework"/>
 <use name="FWCore/MessageLogger"/>
-<use name="FWCore/ParameterSet"/>
 <use name="Geometry/CommonDetUnit"/>
 <use name="Geometry/CommonTopologies"/>
 <use name="Geometry/Records"/>

--- a/CondFormats/SiPixelObjects/BuildFile.xml
+++ b/CondFormats/SiPixelObjects/BuildFile.xml
@@ -6,12 +6,9 @@
 <use name="CondFormats/Serialization"/>
 <use name="CondFormats/DataRecord"/>
 <use name="CondFormats/SiStripObjects"/>
-<use name="root"/>
 <use name="Geometry/TrackerGeometryBuilder"/>
 <use name="CondFormats/External"/>
-<use name="DataFormats/Common"/>
 <use name="DataFormats/GeometryVector"/>
-<use name="FWCore/Framework"/>
 <use name="FWCore/MessageLogger"/>
 <use name="Geometry/CommonDetUnit"/>
 <use name="Geometry/CommonTopologies"/>
@@ -19,3 +16,4 @@
 <export>
   <lib name="1"/>
 </export>
+

--- a/CondFormats/SiPixelObjects/src/SiPixelCPEGenericErrorParm.cc
+++ b/CondFormats/SiPixelObjects/src/SiPixelCPEGenericErrorParm.cc
@@ -1,5 +1,4 @@
 #include "CondFormats/SiPixelObjects/interface/SiPixelCPEGenericErrorParm.h"
-#include "FWCore/ParameterSet/interface/FileInPath.h"
 #include <fstream>
 
 void SiPixelCPEGenericErrorParm::fillCPEGenericErrorParm(double version, std::string file) {

--- a/CondFormats/SiPixelObjects/src/SiPixelQuality.cc
+++ b/CondFormats/SiPixelObjects/src/SiPixelQuality.cc
@@ -8,16 +8,12 @@
 #include "CondFormats/SiPixelObjects/interface/SiPixelQuality.h"
 #include "CondFormats/SiPixelObjects/interface/SiPixelFrameReverter.h"
 #include "CondFormats/SiPixelObjects/interface/SiPixelFrameConverter.h"
-#include "DataFormats/Common/interface/Handle.h"
-#include "FWCore/Framework/interface/ESHandle.h"
-#include "FWCore/Framework/interface/ESWatcher.h"
 #include "CondFormats/DataRecord/interface/SiPixelFedCablingMapRcd.h"
 #include "CondFormats/SiPixelObjects/interface/SiPixelFedCablingMap.h"
 #include "CondFormats/SiPixelObjects/interface/SiPixelFedCablingTree.h"
 #include "CondFormats/SiPixelObjects/interface/PixelROC.h"
 #include "CondFormats/SiPixelObjects/interface/LocalPixel.h"
 #include "Geometry/CommonDetUnit/interface/PixelGeomDetUnit.h"
-#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 
 #include <algorithm>
@@ -146,9 +142,6 @@ const std::vector<LocalPoint> SiPixelQuality::getBadRocPositions(const uint32_t&
         if (myroc->idInDetUnit() == i) {
           LocalPixel::RocRowCol local = {39, 25};  //corresponding to center of ROC row, col
           GlobalPixel global = myroc->toGlobal(LocalPixel(local));
-          //       edm::ESHandle<TrackerGeometry> geom;
-          //     es.get<TrackerDigiGeometryRecord>().get( geom );
-          //    const TrackerGeometry& theTracker(*geom);
           const PixelGeomDetUnit* theGeomDet = dynamic_cast<const PixelGeomDetUnit*>(theTracker.idToDet(detid));
 
           PixelTopology const* topology = &(theGeomDet->specificTopology());

--- a/CondFormats/SiPixelTransient/BuildFile.xml
+++ b/CondFormats/SiPixelTransient/BuildFile.xml
@@ -1,5 +1,4 @@
 <use name="FWCore/MessageLogger"/>
-<use name="FWCore/ParameterSet"/>
 <use name="FWCore/Utilities"/>
 <use name="boost"/>
 <export>

--- a/CondFormats/SiPixelTransient/src/SiPixelGenError.cc
+++ b/CondFormats/SiPixelTransient/src/SiPixelGenError.cc
@@ -30,7 +30,7 @@
 
 #ifndef SI_PIXEL_TEMPLATE_STANDALONE
 #include "CondFormats/SiPixelTransient/interface/SiPixelGenError.h"
-#include "FWCore/ParameterSet/interface/FileInPath.h"
+#include "FWCore/Utilities/interface/FileInPath.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #define LOGERROR(x) LogError(x)
 #define LOGWARNING(x) LogWarning(x)

--- a/CondFormats/SiPixelTransient/src/SiPixelTemplate.cc
+++ b/CondFormats/SiPixelTransient/src/SiPixelTemplate.cc
@@ -104,7 +104,7 @@
 #ifndef SI_PIXEL_TEMPLATE_STANDALONE
 #include "CondFormats/SiPixelTransient/interface/SiPixelTemplate.h"
 #include "CondFormats/SiPixelTransient/interface/SimplePixel.h"
-#include "FWCore/ParameterSet/interface/FileInPath.h"
+#include "FWCore/Utilities/interface/FileInPath.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #define LOGERROR(x) LogError(x)
 #define LOGINFO(x) LogInfo(x)

--- a/CondFormats/SiPixelTransient/src/SiPixelTemplate2D.cc
+++ b/CondFormats/SiPixelTransient/src/SiPixelTemplate2D.cc
@@ -38,7 +38,7 @@
 
 #ifndef SI_PIXEL_TEMPLATE_STANDALONE
 #include "CondFormats/SiPixelTransient/interface/SiPixelTemplate2D.h"
-#include "FWCore/ParameterSet/interface/FileInPath.h"
+#include "FWCore/Utilities/interface/FileInPath.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #define LOGERROR(x) LogError(x)
 #define LOGINFO(x) LogInfo(x)

--- a/DataFormats/PatCandidates/src/CovarianceParameterization.cc
+++ b/DataFormats/PatCandidates/src/CovarianceParameterization.cc
@@ -9,7 +9,7 @@
 #include "DataFormats/Math/interface/liblogintpack.h"
 #include "DataFormats/Math/interface/libminifloat.h"
 #include "DataFormats/PatCandidates/interface/CovarianceParameterization.h"
-#include "FWCore/ParameterSet/interface/FileInPath.h"
+#include "FWCore/Utilities/interface/FileInPath.h"
 
 uint16_t CompressionElement::pack(float value, float ref) const {
   float toCompress = 0;

--- a/EventFilter/CSCRawToDigi/BuildFile.xml
+++ b/EventFilter/CSCRawToDigi/BuildFile.xml
@@ -2,6 +2,7 @@
 <use name="DataFormats/CSCDigi"/>
 <use name="DataFormats/FEDRawData"/>
 <use name="CondFormats/CSCObjects"/>
+<use name="FWCore/ParameterSet"/>
 <use name="FWCore/MessageLogger"/>
 <use name="FWCore/Utilities"/>
 <export>

--- a/EventFilter/CSCRawToDigi/interface/CSCDigiToRaw.h
+++ b/EventFilter/CSCRawToDigi/interface/CSCDigiToRaw.h
@@ -21,7 +21,6 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 class FEDRawDataCollection;
-class CSCReadoutMappingFromFile;
 class CSCChamberMap;
 
 class CSCDigiToRaw {


### PR DESCRIPTION
#### PR description:

Removed FWCore/ParameterSet dependencies from *Formats packages. As a general rule, no data products (ie. classes stored in *Formats subsystems) should have any dependency upon the framework itself, which includes how we configure the framework (i.e. the ParameterSet system).

This was prompted by the fact that the CXXMODULES IBs are failing because of ROOT's attempt to create a module from FWCore/ParameterSet. That failure caused many *Formats packages to also fail. If we remove the unnecessary dependency than we should be able to avoid having ROOT even attempt the parsing.

#### PR validation:

The code compiles.