### PR TITLE
Fix for Pythia8 >= 304

### DIFF
--- a/FastSimulation/ParticleDecay/plugins/TestPythiaDecays.cc
+++ b/FastSimulation/ParticleDecay/plugins/TestPythiaDecays.cc
@@ -44,7 +44,7 @@
 typedef Pythia8::ParticleDataEntry* ParticleDataEntryPtr;
 #else
 typedef Pythia8::ParticleDataEntryPtr ParticleDataEntryPtr;
-#endif 
+#endif
 //
 // class declaration
 //

--- a/FastSimulation/ParticleDecay/plugins/TestPythiaDecays.cc
+++ b/FastSimulation/ParticleDecay/plugins/TestPythiaDecays.cc
@@ -40,6 +40,11 @@
 #include "TFile.h"
 #include "TLorentzVector.h"
 
+#if PYTHIA_VERSION_INTEGER < 8304
+typedef Pythia8::ParticleDataEntry* ParticleDataEntryPtr;
+#else
+typedef Pythia8::ParticleDataEntryPtr ParticleDataEntryPtr;
+#endif 
 //
 // class declaration
 //
@@ -119,7 +124,7 @@ TestPythiaDecays::TestPythiaDecays(const edm::ParameterSet& iConfig) {
       std::cout << "ERROR: BAD PARTICLE, pythia is not aware of pid " << pid << std::endl;
       std::exit(1);
     }
-    Pythia8::ParticleDataEntry* pd = pdt.particleDataEntryPtr(pid);
+    ParticleDataEntryPtr pd = pdt.particleDataEntryPtr(pid);
 
     // mass histograms
     double m0 = pd->m0();


### PR DESCRIPTION
#### PR description:

In Pythia 8.304 the return type of `particleDataEntryPtr(...)` function was changed from `Pythia8::ParticleDataEntry *` to `Pythia8::ParticleDataEntryPtr` (aka `std::shared_ptr<Pythia8::ParticleDataEntry>`). This PR accounts for that.

Update to Pythia 8.305 is triggered by this PR: https://github.com/cms-sw/cmsdist/pull/6948

#### PR validation:

<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
