### PR TITLE
Migrate module configurations in RecoTracker{IterativeTracking} to use default cfipython

### DIFF
--- a/RecoTracker/IterativeTracking/python/ElectronSeeds_cff.py
+++ b/RecoTracker/IterativeTracking/python/ElectronSeeds_cff.py
@@ -52,7 +52,9 @@ pixelLessStepSeedClusterMask = seedClusterRemover.clone(
     oldClusterRemovalInfo = cms.InputTag('mixedTripletStepSeedClusterMask')
 )
 
-tripletElectronSeedLayers = cms.EDProducer('SeedingLayersEDProducer',
+import RecoTracker.TkSeedingLayers.seedingLayersEDProducer_cfi as _mod
+
+tripletElectronSeedLayers = _mod.seedingLayersEDProducer.clone(
     layerList = cms.vstring('BPix1+BPix2+BPix3', 
                             'BPix1+BPix2+FPix1_pos', 'BPix1+BPix2+FPix1_neg', 
                             'BPix1+FPix1_pos+FPix2_pos', 'BPix1+FPix1_neg+FPix2_neg'),
@@ -138,7 +140,7 @@ trackingPhase2PU140.toReplaceWith(tripletElectronClusterMask, seedClusterRemover
     )
 )
 
-pixelPairElectronSeedLayers = cms.EDProducer('SeedingLayersEDProducer',
+pixelPairElectronSeedLayers = _mod.seedingLayersEDProducer.clone(
     layerList = cms.vstring('BPix1+BPix2', 'BPix1+BPix3', 'BPix2+BPix3', 
                             'BPix1+FPix1_pos', 'BPix1+FPix1_neg', 
                             'BPix1+FPix2_pos', 'BPix1+FPix2_neg', 
@@ -188,7 +190,7 @@ pixelPairElectronSeeds = _seedCreatorFromRegionConsecutiveHitsEDProducer.clone(
     seedingHitSets = 'pixelPairElectronHitDoublets',
 )
 
-stripPairElectronSeedLayers = cms.EDProducer('SeedingLayersEDProducer',
+stripPairElectronSeedLayers = _mod.seedingLayersEDProducer.clone(
     layerList = cms.vstring('TIB1+TIB2', 'TIB1+TID1_pos', 'TIB1+TID1_neg', 'TID2_pos+TID3_pos', 'TID2_neg+TID3_neg',
                             'TEC1_pos+TEC2_pos','TEC2_pos+TEC3_pos','TEC3_pos+TEC4_pos','TEC3_pos+TEC5_pos',
                             'TEC1_neg+TEC2_neg','TEC2_neg+TEC3_neg','TEC3_neg+TEC4_neg','TEC3_neg+TEC5_neg'),

--- a/RecoTracker/IterativeTracking/python/ElectronSeeds_cff.py
+++ b/RecoTracker/IterativeTracking/python/ElectronSeeds_cff.py
@@ -29,7 +29,7 @@ trackingPhase2PU140.toReplaceWith(highPtTripletStepSeedClusterMask, seedClusterR
     )
 )
 trackingPhase2PU140.toReplaceWith(pixelPairStepSeedClusterMask, seedClusterRemoverPhase2.clone(
-    trajectories = cms.InputTag('detachedQuadStepSeeds'),
+    trajectories = 'detachedQuadStepSeeds',
     oldClusterRemovalInfo = cms.InputTag('highPtTripletStepSeedClusterMask')
     )
 )
@@ -55,9 +55,9 @@ pixelLessStepSeedClusterMask = seedClusterRemover.clone(
 import RecoTracker.TkSeedingLayers.seedingLayersEDProducer_cfi as _mod
 
 tripletElectronSeedLayers = _mod.seedingLayersEDProducer.clone(
-    layerList = cms.vstring('BPix1+BPix2+BPix3', 
-                            'BPix1+BPix2+FPix1_pos', 'BPix1+BPix2+FPix1_neg', 
-                            'BPix1+FPix1_pos+FPix2_pos', 'BPix1+FPix1_neg+FPix2_neg'),
+    layerList = ['BPix1+BPix2+BPix3', 
+                 'BPix1+BPix2+FPix1_pos', 'BPix1+BPix2+FPix1_neg', 
+                 'BPix1+FPix1_pos+FPix2_pos', 'BPix1+FPix1_neg+FPix2_neg'],
     BPix = cms.PSet(
     TTRHBuilder = cms.string('TTRHBuilderWithoutAngle4PixelTriplets'),
     HitProducer = cms.string('siPixelRecHits'),
@@ -141,11 +141,11 @@ trackingPhase2PU140.toReplaceWith(tripletElectronClusterMask, seedClusterRemover
 )
 
 pixelPairElectronSeedLayers = _mod.seedingLayersEDProducer.clone(
-    layerList = cms.vstring('BPix1+BPix2', 'BPix1+BPix3', 'BPix2+BPix3', 
-                            'BPix1+FPix1_pos', 'BPix1+FPix1_neg', 
-                            'BPix1+FPix2_pos', 'BPix1+FPix2_neg', 
-                            'BPix2+FPix1_pos', 'BPix2+FPix1_neg', 
-                            'FPix1_pos+FPix2_pos', 'FPix1_neg+FPix2_neg'),
+    layerList = ['BPix1+BPix2', 'BPix1+BPix3', 'BPix2+BPix3', 
+                 'BPix1+FPix1_pos', 'BPix1+FPix1_neg', 
+                 'BPix1+FPix2_pos', 'BPix1+FPix2_neg', 
+                 'BPix2+FPix1_pos', 'BPix2+FPix1_neg', 
+                 'FPix1_pos+FPix2_pos', 'FPix1_neg+FPix2_neg'],
     BPix = cms.PSet(
     TTRHBuilder = cms.string('WithTrackAngle'),
     HitProducer = cms.string('siPixelRecHits'),
@@ -191,9 +191,9 @@ pixelPairElectronSeeds = _seedCreatorFromRegionConsecutiveHitsEDProducer.clone(
 )
 
 stripPairElectronSeedLayers = _mod.seedingLayersEDProducer.clone(
-    layerList = cms.vstring('TIB1+TIB2', 'TIB1+TID1_pos', 'TIB1+TID1_neg', 'TID2_pos+TID3_pos', 'TID2_neg+TID3_neg',
-                            'TEC1_pos+TEC2_pos','TEC2_pos+TEC3_pos','TEC3_pos+TEC4_pos','TEC3_pos+TEC5_pos',
-                            'TEC1_neg+TEC2_neg','TEC2_neg+TEC3_neg','TEC3_neg+TEC4_neg','TEC3_neg+TEC5_neg'),
+    layerList = ['TIB1+TIB2', 'TIB1+TID1_pos', 'TIB1+TID1_neg', 'TID2_pos+TID3_pos', 'TID2_neg+TID3_neg',
+                 'TEC1_pos+TEC2_pos','TEC2_pos+TEC3_pos','TEC3_pos+TEC4_pos','TEC3_pos+TEC5_pos',
+                 'TEC1_neg+TEC2_neg','TEC2_neg+TEC3_neg','TEC3_neg+TEC4_neg','TEC3_neg+TEC5_neg'],
     TIB = cms.PSet(
     TTRHBuilder = cms.string('WithTrackAngle'), clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutNone')),
     matchedRecHits = cms.InputTag('siStripMatchedRecHits','matchedRecHit'),

--- a/RecoTracker/IterativeTracking/python/JetCoreRegionalStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/JetCoreRegionalStep_cff.py
@@ -7,10 +7,7 @@ from RecoTracker.IterativeTracking.dnnQualityCuts import qualityCutDictionary
 # This step runs over all clusters
 
 # run only if there are high pT jets
-jetsForCoreTracking = cms.EDFilter('CandPtrSelector', src = cms.InputTag('ak4CaloJetsForTrk'), cut = cms.string('pt > 100 && abs(eta) < 2.5'), filter = cms.bool(False))
-
-jetsForCoreTrackingBarrel = jetsForCoreTracking.clone( cut = 'pt > 100 && abs(eta) < 2.5' )
-jetsForCoreTrackingEndcap = jetsForCoreTracking.clone( cut = 'pt > 100 && abs(eta) > 1.4 && abs(eta) < 2.5' )
+jetsForCoreTracking = cms.EDFilter('CandPtrSelector', src = cms.InputTag('ak4CaloJetsForTrk'), cut = cms.string('pt > 100 && abs(eta) < 2.5'))
 
 # care only at tracks from main PV
 firstStepGoodPrimaryVertices = cms.EDFilter('PrimaryVertexObjectFilter',
@@ -22,8 +19,10 @@ firstStepGoodPrimaryVertices = cms.EDFilter('PrimaryVertexObjectFilter',
      src=cms.InputTag('firstStepPrimaryVertices')
 )
 
+import RecoTracker.TkSeedingLayers.seedingLayersEDProducer_cfi as _mod
+
 # SEEDING LAYERS
-jetCoreRegionalStepSeedLayers = cms.EDProducer('SeedingLayersEDProducer',
+jetCoreRegionalStepSeedLayers = _mod.seedingLayersEDProducer.clone(
     layerList = cms.vstring('BPix1+BPix2', 'BPix1+BPix3', 'BPix2+BPix3', 
                             'BPix1+FPix1_pos', 'BPix1+FPix1_neg', 
                             'BPix2+FPix1_pos', 'BPix2+FPix1_neg', 
@@ -76,9 +75,6 @@ jetCoreRegionalStepTrackingRegions = _tauRegionalPixelSeedTrackingRegions.clone(
     vertexSrc      = 'firstStepGoodPrimaryVertices',
     howToUseMeasurementTracker = 'Never'
 ))
-jetCoreRegionalStepEndcapTrackingRegions = jetCoreRegionalStepTrackingRegions.clone(RegionPSet=dict(
-    JetSrc = 'jetsForCoreTrackingEndcap',
-))
 
 # Seeding
 from RecoTracker.TkHitPairs.hitPairEDProducer_cfi import hitPairEDProducer as _hitPairEDProducer
@@ -88,23 +84,10 @@ jetCoreRegionalStepHitDoublets = _hitPairEDProducer.clone(
     produceSeedingHitSets = True,
     maxElementTotal       = 12000000,
 )
-jetCoreRegionalStepEndcapHitDoublets = jetCoreRegionalStepHitDoublets.clone(
-    trackingRegions = 'jetCoreRegionalStepEndcapTrackingRegions',
-)
-
 from RecoTracker.TkSeedGenerator.seedCreatorFromRegionConsecutiveHitsEDProducer_cff import seedCreatorFromRegionConsecutiveHitsEDProducer as _seedCreatorFromRegionConsecutiveHitsEDProducer
 jetCoreRegionalStepSeeds = _seedCreatorFromRegionConsecutiveHitsEDProducer.clone(
     seedingHitSets = 'jetCoreRegionalStepHitDoublets',
     forceKinematicWithRegionDirection = True
-)
-import RecoTracker.TkSeedGenerator.deepCoreSeedGenerator_cfi
-jetCoreRegionalStepSeedsBarrel = RecoTracker.TkSeedGenerator.deepCoreSeedGenerator_cfi.deepCoreSeedGenerator.clone(#to run MCtruthSeedGenerator clone here from Validation.RecoTrack
-    vertices = "firstStepPrimaryVertices",
-    cores    = "jetsForCoreTrackingBarrel"
-)
-
-jetCoreRegionalStepSeedsEndcap = jetCoreRegionalStepSeeds.clone(
-    seedingHitSets = 'jetCoreRegionalStepEndcapHitDoublets',
 )
 
 # QUALITY CUTS DURING TRACK BUILDING
@@ -114,15 +97,14 @@ jetCoreRegionalStepTrajectoryFilter = TrackingTools.TrajectoryFiltering.Trajecto
     seedPairPenalty     = 0,
     minPt               = 0.1
 )
-jetCoreRegionalStepBarrelTrajectoryFilter = jetCoreRegionalStepTrajectoryFilter.clone(
+
+from Configuration.ProcessModifiers.seedingDeepCore_cff import seedingDeepCore
+seedingDeepCore.toModify(jetCoreRegionalStepTrajectoryFilter,
     minimumNumberOfHits = 2,
     maxConsecLostHits   = 2,
     maxLostHitsFraction = 1.1,
-    seedPairPenalty     = 0,
-    minPt               = 0.9 ## should it be slightly decrease ?
-)
-jetCoreRegionalStepEndcapTrajectoryFilter = jetCoreRegionalStepTrajectoryFilter.clone()
-
+    minPt               = 0.9
+    )
 
 from Configuration.Eras.Modifier_pp_on_XeXe_2017_cff import pp_on_XeXe_2017
 from Configuration.ProcessModifiers.pp_on_AA_cff import pp_on_AA
@@ -147,22 +129,15 @@ jetCoreRegionalStepTrajectoryBuilder = RecoTracker.CkfPattern.GroupedCkfTrajecto
     estimator = 'jetCoreRegionalStepChi2Est',
     maxDPhiForLooperReconstruction = cms.double(2.0),
     maxPtForLooperReconstruction = cms.double(0.7)
-    )    
-jetCoreRegionalStepBarrelTrajectoryBuilder = RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi.GroupedCkfTrajectoryBuilder.clone(
-    MeasurementTrackerName = '',
-    trajectoryFilter = cms.PSet(refToPSet_ = cms.string('jetCoreRegionalStepBarrelTrajectoryFilter')),
-    #clustersToSkip = cms.InputTag('jetCoreRegionalStepClusters'),
-    maxCand = 50,
-    estimator = 'jetCoreRegionalStepChi2Est',
+    )
+    
+seedingDeepCore.toModify(jetCoreRegionalStepTrajectoryBuilder,
+    maxPtForLooperReconstruction = 0.,
     keepOriginalIfRebuildFails = True,
     lockHits = False,
-    requireSeedHitsInRebuild = False
+    requireSeedHitsInRebuild = False,
 )
-jetCoreRegionalStepEndcapTrajectoryBuilder = jetCoreRegionalStepTrajectoryBuilder.clone(
-    trajectoryFilter = cms.PSet(refToPSet_ = cms.string('jetCoreRegionalStepEndcapTrajectoryFilter')),
-    #clustersToSkip = cms.InputTag('jetCoreRegionalStepClusters'),
-)
-    
+
 #customized cleaner for DeepCore
 from TrackingTools.TrajectoryCleaning.TrajectoryCleanerBySharedHits_cfi import trajectoryCleanerBySharedHits
 jetCoreRegionalStepDeepCoreTrajectoryCleaner = trajectoryCleanerBySharedHits.clone(
@@ -170,15 +145,13 @@ jetCoreRegionalStepDeepCoreTrajectoryCleaner = trajectoryCleanerBySharedHits.clo
     fractionShared = 0.45
 )
 
-############## to run MCtruthSeedGenerator ####################
-#import RecoTracker.TkSeedGenerator.deepCoreSeedGenerator_cfi
-#import Validation.RecoTrack.JetCoreMCtruthSeedGenerator_cfi
-#seedingDeepCore.toReplaceWith(jetCoreRegionalStepSeedsBarrel,
-#    RecoTracker.TkSeedGenerator.deepCoreSeedGenerator_cfi.deepCoreSeedGenerator.clone(#to run MCtruthSeedGenerator clone here from Validation.RecoTrack
-#       vertices="firstStepPrimaryVertices" 
-#    )
-#)
-
+import RecoTracker.TkSeedGenerator.deepCoreSeedGenerator_cfi
+import Validation.RecoTrack.JetCoreMCtruthSeedGenerator_cfi
+seedingDeepCore.toReplaceWith(jetCoreRegionalStepSeeds,
+    RecoTracker.TkSeedGenerator.deepCoreSeedGenerator_cfi.deepCoreSeedGenerator.clone(#to run MCtruthSeedGenerator clone here from Validation.RecoTrack
+       vertices="firstStepPrimaryVertices" 
+    )
+)
 
 # MAKING OF TRACK CANDIDATES
 import RecoTracker.CkfPattern.CkfTrackCandidates_cfi
@@ -191,22 +164,11 @@ jetCoreRegionalStepTrackCandidates = RecoTracker.CkfPattern.CkfTrackCandidates_c
     #numHitsForSeedCleaner = cms.int32(50),
     #onlyPixelHitsForSeedCleaner = cms.bool(True),
 )
-jetCoreRegionalStepBarrelTrackCandidates = jetCoreRegionalStepTrackCandidates.clone(
-    src                    = 'jetCoreRegionalStepSeedsBarrel',
-    TrajectoryBuilderPSet  = cms.PSet( refToPSet_ = cms.string('jetCoreRegionalStepBarrelTrajectoryBuilder')),
-    ### these two parameters are relevant only for the CachingSeedCleanerBySharedInput
-    #numHitsForSeedCleaner = cms.int32(50),
-    #onlyPixelHitsForSeedCleaner = cms.bool(True),
+seedingDeepCore.toModify(jetCoreRegionalStepTrackCandidates,
     TrajectoryCleaner         = 'jetCoreRegionalStepDeepCoreTrajectoryCleaner',
-    doSeedingRegionRebuilding = True,
+    doSeedingRegionRebuilding = True,    
 )
-jetCoreRegionalStepEndcapTrackCandidates = jetCoreRegionalStepTrackCandidates.clone(
-    src                    = 'jetCoreRegionalStepSeedsEndcap',
-    TrajectoryBuilderPSet  = cms.PSet( refToPSet_ = cms.string('jetCoreRegionalStepEndcapTrajectoryBuilder')),
-    ### these two parameters are relevant only for the CachingSeedCleanerBySharedInput
-    #numHitsForSeedCleaner = cms.int32(50),
-    #onlyPixelHitsForSeedCleaner = cms.bool(True),
-)
+
 
 # TRACK FITTING
 import RecoTracker.TrackProducer.TrackProducer_cfi
@@ -215,13 +177,6 @@ jetCoreRegionalStepTracks = RecoTracker.TrackProducer.TrackProducer_cfi.TrackPro
     src           = 'jetCoreRegionalStepTrackCandidates',
     Fitter        = 'FlexibleKFFittingSmoother'
 )
-jetCoreRegionalStepBarrelTracks = jetCoreRegionalStepTracks.clone(
-    src           = 'jetCoreRegionalStepBarrelTrackCandidates',
-)
-jetCoreRegionalStepEndcapTracks = jetCoreRegionalStepTracks.clone(
-    src           = 'jetCoreRegionalStepEndcapTrackCandidates',
-)
-
 
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
 import RecoTracker.FinalTrackSelectors.trackListMerger_cfi
@@ -235,6 +190,27 @@ fastSim.toReplaceWith(jetCoreRegionalStepTracks,_fastSim_jetCoreRegionalStepTrac
 
 
 # Final selection
+from RecoTracker.IterativeTracking.InitialStep_cff import initialStepClassifier1
+#from RecoTracker.IterativeTracking.DetachedTripletStep_cff import detachedTripletStepClassifier1
+
+#jetCoreRegionalStep = initialStepClassifier1.clone()
+#jetCoreRegionalStep.src='jetCoreRegionalStepTracks'
+#jetCoreRegionalStep.qualityCuts = [-0.3,0.0,0.2]
+#jetCoreRegionalStep.vertices = 'firstStepGoodPrimaryVertices'
+
+#jetCoreRegionalStepClassifier1 = initialStepClassifier1.clone()
+#jetCoreRegionalStepClassifier1.src = 'jetCoreRegionalStepTracks'
+#jetCoreRegionalStepClassifier1.qualityCuts = [-0.2,0.0,0.4]
+#jetCoreRegionalStepClassifier2 = detachedTripletStepClassifier1.clone()
+#jetCoreRegionalStepClassifier2.src = 'jetCoreRegionalStepTracks'
+
+
+
+#from RecoTracker.FinalTrackSelectors.ClassifierMerger_cfi import *
+#jetCoreRegionalStep = ClassifierMerger.clone()
+#jetCoreRegionalStep.inputClassifiers=['jetCoreRegionalStepClassifier1','jetCoreRegionalStepClassifier2']
+
+
 from RecoTracker.FinalTrackSelectors.TrackCutClassifier_cff import *
 jetCoreRegionalStep = TrackCutClassifier.clone(
     src = 'jetCoreRegionalStepTracks',
@@ -247,26 +223,15 @@ jetCoreRegionalStep = TrackCutClassifier.clone(
         maxLostLayers = [4,3,2],
         maxDz         = [0.5,0.35,0.2],
         maxDr         = [0.3,0.2,0.1]
-    ),
+	),
     vertices = 'firstStepGoodPrimaryVertices'
 )
-jetCoreRegionalStepBarrel = jetCoreRegionalStep.clone(
-    src = 'jetCoreRegionalStepBarrelTracks',
-    mva = dict(
-#	minPixelHits  = [1,1,1], # they could be easily increased to at least 2 or 3 !
-        min3DLayers   = [1,2,2],
-    ),
-)
-
 from RecoTracker.FinalTrackSelectors.TrackMVAClassifierPrompt_cfi import *
+
 trackingPhase1.toReplaceWith(jetCoreRegionalStep, TrackMVAClassifierPrompt.clone(
      mva = dict(GBRForestLabel = 'MVASelectorJetCoreRegionalStep_Phase1'),
      src = 'jetCoreRegionalStepTracks',
      qualityCuts = [-0.2,0.0,0.4]
-))
-
-trackingPhase1.toReplaceWith(jetCoreRegionalStepBarrel, jetCoreRegionalStep.clone(
-     src = 'jetCoreRegionalStepBarrelTracks',
 ))
 
 from RecoTracker.FinalTrackSelectors.TrackTfClassifier_cfi import *
@@ -275,16 +240,8 @@ trackdnn.toReplaceWith(jetCoreRegionalStep, TrackTfClassifier.clone(
      src = 'jetCoreRegionalStepTracks',
      qualityCuts = qualityCutDictionary["JetCoreRegionalStep"],
 ))
-trackdnn.toReplaceWith(jetCoreRegionalStepBarrel, TrackTfClassifier.clone(
-     src = 'jetCoreRegionalStepBarrelTracks',
-     qualityCuts = qualityCutDictionary["JetCoreRegionalStep"],
-))
 
 fastSim.toModify(jetCoreRegionalStep,vertices = 'firstStepPrimaryVerticesBeforeMixing')
-
-jetCoreRegionalStepEndcap = jetCoreRegionalStep.clone(
-    src = 'jetCoreRegionalStepEndcapTracks',
-)
 
 # Final sequence
 JetCoreRegionalStepTask = cms.Task(jetsForCoreTracking,                 
@@ -296,51 +253,10 @@ JetCoreRegionalStepTask = cms.Task(jetsForCoreTracking,
                                    jetCoreRegionalStepSeeds,
                                    jetCoreRegionalStepTrackCandidates,
                                    jetCoreRegionalStepTracks,
-                                   #jetCoreRegionalStepClassifier1,jetCoreRegionalStepClassifier2,
+#                                   jetCoreRegionalStepClassifier1,jetCoreRegionalStepClassifier2,
                                    jetCoreRegionalStep)
 JetCoreRegionalStep = cms.Sequence(JetCoreRegionalStepTask)
-
-JetCoreRegionalStepBarrelTask = cms.Task(jetsForCoreTrackingBarrel,
-                                         firstStepGoodPrimaryVertices,
-                                         #jetCoreRegionalStepClusters,
-                                         jetCoreRegionalStepSeedLayers,
-                                         jetCoreRegionalStepSeedsBarrel,
-                                         jetCoreRegionalStepBarrelTrackCandidates,
-                                         jetCoreRegionalStepBarrelTracks,
-                                         jetCoreRegionalStepBarrel)
-
-JetCoreRegionalStepEndcapTask = cms.Task(jetsForCoreTrackingEndcap,
-                                         firstStepGoodPrimaryVertices,
-                                         #jetCoreRegionalStepClusters,
-                                         jetCoreRegionalStepSeedLayers,
-                                         jetCoreRegionalStepEndcapTrackingRegions,
-                                         jetCoreRegionalStepEndcapHitDoublets,
-                                         jetCoreRegionalStepSeedsEndcap,
-                                         jetCoreRegionalStepEndcapTrackCandidates,
-                                         jetCoreRegionalStepEndcapTracks,
-                                         jetCoreRegionalStepEndcap)
-
-
-from Configuration.ProcessModifiers.seedingDeepCore_cff import seedingDeepCore
-
-from RecoTracker.FinalTrackSelectors.TrackCollectionMerger_cfi import *
-seedingDeepCore.toReplaceWith(jetCoreRegionalStepTracks, TrackCollectionMerger.clone(
-    trackProducers   = ["jetCoreRegionalStepBarrelTracks",
-                        "jetCoreRegionalStepEndcapTracks",],
-    inputClassifiers = ["jetCoreRegionalStepBarrel",
-                        "jetCoreRegionalStepEndcap",],
-    foundHitBonus    = 100.0,
-    lostHitPenalty   = 1.0
-))
-
-seedingDeepCore.toReplaceWith(jetCoreRegionalStep, jetCoreRegionalStepTracks.clone()) #(*)
-
-seedingDeepCore.toReplaceWith(JetCoreRegionalStepTask, cms.Task(
-    JetCoreRegionalStepBarrelTask,
-    JetCoreRegionalStepEndcapTask,
-    cms.Task(jetCoreRegionalStepTracks,jetCoreRegionalStep)
-))
-
+seedingDeepCore.toReplaceWith(JetCoreRegionalStep,JetCoreRegionalStep.copyAndExclude([jetCoreRegionalStepHitDoublets]))
 fastSim.toReplaceWith(JetCoreRegionalStepTask, 
                       cms.Task(jetCoreRegionalStepTracks,
                                    jetCoreRegionalStep))

--- a/RecoTracker/IterativeTracking/python/JetCoreRegionalStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/JetCoreRegionalStep_cff.py
@@ -23,12 +23,12 @@ import RecoTracker.TkSeedingLayers.seedingLayersEDProducer_cfi as _mod
 
 # SEEDING LAYERS
 jetCoreRegionalStepSeedLayers = _mod.seedingLayersEDProducer.clone(
-    layerList = cms.vstring('BPix1+BPix2', 'BPix1+BPix3', 'BPix2+BPix3', 
-                            'BPix1+FPix1_pos', 'BPix1+FPix1_neg', 
-                            'BPix2+FPix1_pos', 'BPix2+FPix1_neg', 
-                            'FPix1_pos+FPix2_pos', 'FPix1_neg+FPix2_neg',
-                            #'BPix2+TIB1','BPix2+TIB2',
-                            'BPix3+TIB1','BPix3+TIB2'),
+    layerList = ['BPix1+BPix2', 'BPix1+BPix3', 'BPix2+BPix3', 
+                 'BPix1+FPix1_pos', 'BPix1+FPix1_neg', 
+                 'BPix2+FPix1_pos', 'BPix2+FPix1_neg', 
+                 'FPix1_pos+FPix2_pos', 'FPix1_neg+FPix2_neg',
+                 #'BPix2+TIB1','BPix2+TIB2',
+                 'BPix3+TIB1','BPix3+TIB2'],
     TIB = cms.PSet(
         matchedRecHits = cms.InputTag('siStripMatchedRecHits','matchedRecHit'),
         TTRHBuilder = cms.string('WithTrackAngle'), clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutNone'))

--- a/RecoTracker/IterativeTracking/python/MixedTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/MixedTripletStep_cff.py
@@ -164,7 +164,7 @@ import RecoTracker.TkSeedingLayers.seedingLayersEDProducer_cfi as _mod
 
 # SEEDING LAYERS
 mixedTripletStepSeedLayersB = _mod.seedingLayersEDProducer.clone(
-    layerList = cms.vstring('BPix2+BPix3+TIB1'),
+    layerList = ['BPix2+BPix3+TIB1'],
     BPix = cms.PSet(
         TTRHBuilder = cms.string('WithTrackAngle'),
         HitProducer = cms.string('siPixelRecHits'),

--- a/RecoTracker/IterativeTracking/python/MixedTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/MixedTripletStep_cff.py
@@ -160,9 +160,10 @@ _fastSim_mixedTripletStepSeedsA = FastSimulation.Tracking.TrajectorySeedProducer
 )
 fastSim.toReplaceWith(mixedTripletStepSeedsA,_fastSim_mixedTripletStepSeedsA)
 
+import RecoTracker.TkSeedingLayers.seedingLayersEDProducer_cfi as _mod
 
 # SEEDING LAYERS
-mixedTripletStepSeedLayersB = cms.EDProducer('SeedingLayersEDProducer',
+mixedTripletStepSeedLayersB = _mod.seedingLayersEDProducer.clone(
     layerList = cms.vstring('BPix2+BPix3+TIB1'),
     BPix = cms.PSet(
         TTRHBuilder = cms.string('WithTrackAngle'),

--- a/RecoTracker/IterativeTracking/python/PixelLessStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/PixelLessStep_cff.py
@@ -22,7 +22,7 @@ from RecoLocalTracker.SiStripClusterizer.SiStripClusterChargeCut_cfi import *
 import RecoTracker.TkSeedingLayers.seedingLayersEDProducer_cfi as _mod
 
 pixelLessStepSeedLayers = _mod.seedingLayersEDProducer.clone(
-    layerList = cms.vstring(
+    layerList = [
     #TIB
     'TIB1+TIB2+MTIB3','TIB1+TIB2+MTIB4',
     #TIB+TID
@@ -47,7 +47,7 @@ pixelLessStepSeedLayers = _mod.seedingLayersEDProducer.clone(
     'TEC3_pos+TEC4_pos+MTEC5_pos','TEC3_neg+TEC4_neg+MTEC5_neg',
     'TEC3_pos+TEC5_pos+TEC6_pos', 'TEC3_neg+TEC5_neg+TEC6_neg',
     'TEC4_pos+TEC5_pos+TEC6_pos', 'TEC4_neg+TEC5_neg+TEC6_neg'    
-    ),
+    ],
     TIB = cms.PSet(
          TTRHBuilder    = cms.string('WithTrackAngle'), clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutTight')),
          matchedRecHits = cms.InputTag('siStripMatchedRecHits','matchedRecHit'),

--- a/RecoTracker/IterativeTracking/python/PixelLessStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/PixelLessStep_cff.py
@@ -19,7 +19,9 @@ for _eraName, _postfix, _era in _cfg.nonDefaultEras():
 
 # SEEDING LAYERS
 from RecoLocalTracker.SiStripClusterizer.SiStripClusterChargeCut_cfi import *
-pixelLessStepSeedLayers = cms.EDProducer('SeedingLayersEDProducer',
+import RecoTracker.TkSeedingLayers.seedingLayersEDProducer_cfi as _mod
+
+pixelLessStepSeedLayers = _mod.seedingLayersEDProducer.clone(
     layerList = cms.vstring(
     #TIB
     'TIB1+TIB2+MTIB3','TIB1+TIB2+MTIB4',

--- a/RecoTracker/IterativeTracking/python/PixelPairStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/PixelPairStep_cff.py
@@ -16,10 +16,10 @@ import RecoTracker.TkSeedingLayers.seedingLayersEDProducer_cfi as _mod
 
 # SEEDING LAYERS
 pixelPairStepSeedLayers = _mod.seedingLayersEDProducer.clone(
-    layerList = cms.vstring('BPix1+BPix2', 'BPix1+BPix3', 'BPix2+BPix3', 
+    layerList = ['BPix1+BPix2', 'BPix1+BPix3', 'BPix2+BPix3', 
         'BPix1+FPix1_pos', 'BPix1+FPix1_neg', 
         'BPix2+FPix1_pos', 'BPix2+FPix1_neg', 
-        'FPix1_pos+FPix2_pos', 'FPix1_neg+FPix2_neg'),
+        'FPix1_pos+FPix2_pos', 'FPix1_neg+FPix2_neg'],
     BPix = cms.PSet(
         TTRHBuilder = cms.string('WithTrackAngle'),
         HitProducer = cms.string('siPixelRecHits'),

--- a/RecoTracker/IterativeTracking/python/PixelPairStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/PixelPairStep_cff.py
@@ -12,9 +12,10 @@ pixelPairStepClusters = _cfg.clusterRemoverForIter('PixelPairStep')
 for _eraName, _postfix, _era in _cfg.nonDefaultEras():
     _era.toReplaceWith(pixelPairStepClusters, _cfg.clusterRemoverForIter('PixelPairStep', _eraName, _postfix))
 
+import RecoTracker.TkSeedingLayers.seedingLayersEDProducer_cfi as _mod
 
 # SEEDING LAYERS
-pixelPairStepSeedLayers = cms.EDProducer('SeedingLayersEDProducer',
+pixelPairStepSeedLayers = _mod.seedingLayersEDProducer.clone(
     layerList = cms.vstring('BPix1+BPix2', 'BPix1+BPix3', 'BPix2+BPix3', 
         'BPix1+FPix1_pos', 'BPix1+FPix1_neg', 
         'BPix2+FPix1_pos', 'BPix2+FPix1_neg', 

--- a/RecoTracker/IterativeTracking/python/TobTecStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/TobTecStep_cff.py
@@ -19,12 +19,12 @@ from RecoLocalTracker.SiStripClusterizer.SiStripClusterChargeCut_cfi import *
 import RecoTracker.TkSeedingLayers.seedingLayersEDProducer_cfi as _mod
 
 tobTecStepSeedLayersTripl = _mod.seedingLayersEDProducer.clone(
-    layerList = cms.vstring(
+    layerList = [
     #TOB
     'TOB1+TOB2+MTOB3','TOB1+TOB2+MTOB4',
     #TOB+MTEC
     'TOB1+TOB2+MTEC1_pos','TOB1+TOB2+MTEC1_neg',
-    ),
+    ],
     TOB = cms.PSet(
          TTRHBuilder    = cms.string('WithTrackAngle'), clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutTight')),
          matchedRecHits = cms.InputTag('siStripMatchedRecHits','matchedRecHit'),
@@ -122,13 +122,13 @@ fastSim.toReplaceWith(tobTecStepSeedsTripl,_fastSim_tobTecStepSeedsTripl)
 
 # PAIR SEEDING LAYERS
 tobTecStepSeedLayersPair = _mod.seedingLayersEDProducer.clone( 
-    layerList = cms.vstring('TOB1+TEC1_pos','TOB1+TEC1_neg', 
-                            'TEC1_pos+TEC2_pos','TEC1_neg+TEC2_neg', 
-                            'TEC2_pos+TEC3_pos','TEC2_neg+TEC3_neg', 
-                            'TEC3_pos+TEC4_pos','TEC3_neg+TEC4_neg', 
-                            'TEC4_pos+TEC5_pos','TEC4_neg+TEC5_neg', 
-                            'TEC5_pos+TEC6_pos','TEC5_neg+TEC6_neg', 
-                            'TEC6_pos+TEC7_pos','TEC6_neg+TEC7_neg'),
+    layerList = ['TOB1+TEC1_pos','TOB1+TEC1_neg', 
+                 'TEC1_pos+TEC2_pos','TEC1_neg+TEC2_neg', 
+                 'TEC2_pos+TEC3_pos','TEC2_neg+TEC3_neg', 
+                 'TEC3_pos+TEC4_pos','TEC3_neg+TEC4_neg', 
+                 'TEC4_pos+TEC5_pos','TEC4_neg+TEC5_neg', 
+                 'TEC5_pos+TEC6_pos','TEC5_neg+TEC6_neg', 
+                 'TEC6_pos+TEC7_pos','TEC6_neg+TEC7_neg'],
     TOB = cms.PSet(
          TTRHBuilder    = cms.string('WithTrackAngle'), clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutTight')),
          matchedRecHits = cms.InputTag('siStripMatchedRecHits','matchedRecHit'),
@@ -456,14 +456,14 @@ TobTecStep = cms.Sequence(TobTecStepTask)
 ### not to interfere too much with the default configuration
 # SEEDING LAYERS
 tobTecStepSeedLayers = _mod.seedingLayersEDProducer.clone(
-    layerList = cms.vstring('TOB1+TOB2', 
+    layerList = ['TOB1+TOB2', 
         'TOB1+TEC1_pos', 'TOB1+TEC1_neg', 
         'TEC1_pos+TEC2_pos', 'TEC2_pos+TEC3_pos', 
         'TEC3_pos+TEC4_pos', 'TEC4_pos+TEC5_pos', 
         'TEC5_pos+TEC6_pos', 'TEC6_pos+TEC7_pos', 
         'TEC1_neg+TEC2_neg', 'TEC2_neg+TEC3_neg', 
         'TEC3_neg+TEC4_neg', 'TEC4_neg+TEC5_neg', 
-        'TEC5_neg+TEC6_neg', 'TEC6_neg+TEC7_neg'),
+        'TEC5_neg+TEC6_neg', 'TEC6_neg+TEC7_neg'],
     TOB = cms.PSet(
         matchedRecHits = cms.InputTag('siStripMatchedRecHits','matchedRecHit'),
         skipClusters = cms.InputTag('tobTecStepClusters'),

--- a/RecoTracker/IterativeTracking/python/TobTecStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/TobTecStep_cff.py
@@ -16,7 +16,9 @@ for _eraName, _postfix, _era in _cfg.nonDefaultEras():
 
 # TRIPLET SEEDING LAYERS
 from RecoLocalTracker.SiStripClusterizer.SiStripClusterChargeCut_cfi import *
-tobTecStepSeedLayersTripl = cms.EDProducer('SeedingLayersEDProducer',
+import RecoTracker.TkSeedingLayers.seedingLayersEDProducer_cfi as _mod
+
+tobTecStepSeedLayersTripl = _mod.seedingLayersEDProducer.clone(
     layerList = cms.vstring(
     #TOB
     'TOB1+TOB2+MTOB3','TOB1+TOB2+MTOB4',
@@ -119,7 +121,7 @@ _fastSim_tobTecStepSeedsTripl = FastSimulation.Tracking.TrajectorySeedProducer_c
 fastSim.toReplaceWith(tobTecStepSeedsTripl,_fastSim_tobTecStepSeedsTripl)
 
 # PAIR SEEDING LAYERS
-tobTecStepSeedLayersPair = cms.EDProducer('SeedingLayersEDProducer',
+tobTecStepSeedLayersPair = _mod.seedingLayersEDProducer.clone( 
     layerList = cms.vstring('TOB1+TEC1_pos','TOB1+TEC1_neg', 
                             'TEC1_pos+TEC2_pos','TEC1_neg+TEC2_neg', 
                             'TEC2_pos+TEC3_pos','TEC2_neg+TEC3_neg', 
@@ -453,7 +455,7 @@ TobTecStep = cms.Sequence(TobTecStepTask)
 ### Following are specific for LowPU, they're collected here to
 ### not to interfere too much with the default configuration
 # SEEDING LAYERS
-tobTecStepSeedLayers = cms.EDProducer('SeedingLayersEDProducer',
+tobTecStepSeedLayers = _mod.seedingLayersEDProducer.clone(
     layerList = cms.vstring('TOB1+TOB2', 
         'TOB1+TEC1_pos', 'TOB1+TEC1_neg', 
         'TEC1_pos+TEC2_pos', 'TEC2_pos+TEC3_pos', 


### PR DESCRIPTION
#### PR description: 
Optimization of the python configurations: Improve maintainability by cleaning up the duplicated and cloning from the default/reference configurations.
 
In this PR, 6 files changed.  
RecoTracker/IterativeTracking/python/ElectronSeeds_cff.py
RecoTracker/IterativeTracking/python/JetCoreRegionalStep_cff.py
RecoTracker/IterativeTracking/python/MixedTripletStep_cff.py
RecoTracker/IterativeTracking/python/PixelLessStep_cff.py
RecoTracker/IterativeTracking/python/PixelPairStep_cff.py
RecoTracker/IterativeTracking/python/TobTecStep_cff.py

(The previous PRs were  [PR#33207](https://github.com/cms-sw/cmssw/pull/33207), [PR#33307](https://github.com/cms-sw/cmssw/pull/33307), [PR#33352](https://github.com/cms-sw/cmssw/pull/33352), [PR#33543](https://github.com/cms-sw/cmssw/pull/33543),  [PR#33563](https://github.com/cms-sw/cmssw/pull/33563),  [PR#33671](https://github.com/cms-sw/cmssw/pull/33671), [PR#33901](https://github.com/cms-sw/cmssw/pull/33901))

- commit 1 : Replace explicit configuration with a reference from cfipython/. (migrating EDProducer("type", .. -> typeDefault.clone()) 
- commit 2 : Remove the type specifications already presented in cfipython/fillDescriptions reference for improved syntax safety.

#### PR validation:
Event Content comparison check was also done and there is no change with these updates.
Tested in CMSSW_12_0_X, the basic test all passed in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html).