### PR TITLE
MTD validation: fix era in validation test configuration

### DIFF
--- a/Validation/MtdValidation/test/mtdValidation_cfg.py
+++ b/Validation/MtdValidation/test/mtdValidation_cfg.py
@@ -1,8 +1,8 @@
 import FWCore.ParameterSet.Config as cms
 
 
-from Configuration.Eras.Era_Phase2C9_cff import Phase2C9
-process = cms.Process('mtdValidation',Phase2C9)
+from Configuration.Eras.Era_Phase2C11I13M9_cff import Phase2C11I13M9
+process = cms.Process('mtdValidation',Phase2C11I13M9)
 
 
 process.load("FWCore.MessageService.MessageLogger_cfi")


### PR DESCRIPTION
#### PR description:

The era in the ```Validation/MtdValidation``` test configuration is updated to the used scenario D76.

#### PR validation:

Trivial update, code runs.