### PR TITLE
Fix clang warnings

### DIFF
--- a/Calibration/HcalAlCaRecoProducers/plugins/AlCaLowPUHBHEMuonFilter.cc
+++ b/Calibration/HcalAlCaRecoProducers/plugins/AlCaLowPUHBHEMuonFilter.cc
@@ -179,7 +179,7 @@ bool AlCaLowPUHBHEMuonFilter::filter(edm::Event& iEvent, edm::EventSetup const& 
               << RecMuon->innerTrack().isNonnull() << " outerTrack " << RecMuon->outerTrack().isNonnull()
               << " globalTrack " << RecMuon->globalTrack().isNonnull();
 #endif
-          if ((RecMuon->pt() < minimumMuonpT_) || fabs(RecMuon->eta() < minimumMuoneta_))
+          if ((RecMuon->pt() < minimumMuonpT_) || (RecMuon->eta() < minimumMuoneta_))
             continue;
           if ((RecMuon->track().isNonnull()) && (RecMuon->innerTrack().isNonnull()) &&
               (RecMuon->outerTrack().isNonnull()) && (RecMuon->globalTrack().isNonnull())) {

--- a/Calibration/HcalAlCaRecoProducers/plugins/AlCaLowPUHBHEMuonFilter.cc
+++ b/Calibration/HcalAlCaRecoProducers/plugins/AlCaLowPUHBHEMuonFilter.cc
@@ -179,7 +179,7 @@ bool AlCaLowPUHBHEMuonFilter::filter(edm::Event& iEvent, edm::EventSetup const& 
               << RecMuon->innerTrack().isNonnull() << " outerTrack " << RecMuon->outerTrack().isNonnull()
               << " globalTrack " << RecMuon->globalTrack().isNonnull();
 #endif
-          if ((RecMuon->pt() < minimumMuonpT_) || (RecMuon->eta() < minimumMuoneta_))
+          if ((RecMuon->pt() < minimumMuonpT_) || std::abs(RecMuon->eta()) < minimumMuoneta_)
             continue;
           if ((RecMuon->track().isNonnull()) && (RecMuon->innerTrack().isNonnull()) &&
               (RecMuon->outerTrack().isNonnull()) && (RecMuon->globalTrack().isNonnull())) {

--- a/RecoLocalTracker/Phase2TrackerRecHits/test/RecHitsValidation.cc
+++ b/RecoLocalTracker/Phase2TrackerRecHits/test/RecHitsValidation.cc
@@ -317,7 +317,7 @@ void Phase2TrackerRecHitsValidation::analyze(const edm::Event& event, const edm:
       // Fill the position histograms
       trackerLayout_->Fill(globalPosClu.z(), globalPosClu.perp());
       trackerLayoutXY_->Fill(globalPosClu.x(), globalPosClu.y());
-      if (fabs(layer) < 1000) {
+      if (layer < 1000) {
         trackerLayoutXYBar_->Fill(globalPosClu.x(), globalPosClu.y());
       } else {
         trackerLayoutXYEC_->Fill(globalPosClu.x(), globalPosClu.y());
@@ -325,7 +325,7 @@ void Phase2TrackerRecHitsValidation::analyze(const edm::Event& event, const edm:
 
       histogramLayer->second.localPosXY[det][0]->Fill(localPosClu.x(), localPosClu.y());
       histogramLayer->second.localPosXY[det][nch]->Fill(localPosClu.x(), localPosClu.y());
-      if (fabs(layer) < 1000) {
+      if (layer < 1000) {
         histogramLayer->second.globalPosXY[det][0]->Fill(globalPosClu.z(), globalPosClu.perp());
         histogramLayer->second.globalPosXY[det][nch]->Fill(globalPosClu.z(), globalPosClu.perp());
       } else {

--- a/RecoLocalTracker/SiPhase2Clusterizer/test/ClustersValidation.cc
+++ b/RecoLocalTracker/SiPhase2Clusterizer/test/ClustersValidation.cc
@@ -277,14 +277,14 @@ void Phase2TrackerClusterizerValidation::analyze(const edm::Event& event, const 
       // Fill the position histograms
       trackerLayout_->Fill(globalPosClu.z(), globalPosClu.perp());
       trackerLayoutXY_->Fill(globalPosClu.x(), globalPosClu.y());
-      if (fabs(layer) < 1000) {
+      if (layer < 1000) {
         trackerLayoutXYBar_->Fill(globalPosClu.x(), globalPosClu.y());
       } else {
         trackerLayoutXYEC_->Fill(globalPosClu.x(), globalPosClu.y());
       }
 
       histogramLayer->second.localPosXY[det]->Fill(localPosClu.x(), localPosClu.y());
-      if (fabs(layer) < 1000) {
+      if (layer < 1000) {
         histogramLayer->second.globalPosXY[det]->Fill(globalPosClu.z(), globalPosClu.perp());
       } else {
         histogramLayer->second.globalPosXY[det]->Fill(globalPosClu.x(), globalPosClu.y());


### PR DESCRIPTION
#### PR description:

There are six warnings reported by the CLANG builds which seems to be legit 
https://cmssdt.cern.ch/SDT/cgi-bin/showBuildLogs.py/slc7_amd64_gcc900/www/sun/12.0.CLANG-sun-23/CMSSW_12_0_CLANG_X_2021-05-30-2300
Not sure if the change for RecMuon->eta() was originaly meant to be over fabs(RecMuon->eta()) only 

#### PR validation:

Builds with the CLANG IB without the warnings


