### PR TITLE
Removed unnecessary includes in CalibFormats/*Objects

### DIFF
--- a/CalibFormats/CastorObjects/interface/CastorDbService.h
+++ b/CalibFormats/CastorObjects/interface/CastorDbService.h
@@ -17,9 +17,6 @@
 #include "CalibFormats/CastorObjects/interface/CastorCalibrationsSet.h"
 #include "CalibFormats/CastorObjects/interface/CastorCalibrationWidthsSet.h"
 
-#include "FWCore/Framework/interface/ModuleFactory.h"
-#include "FWCore/Framework/interface/ESProducer.h"
-
 #include "CondFormats/CastorObjects/interface/AllObjects.h"
 
 class CastorCalibrations;

--- a/CalibFormats/HcalObjects/interface/HcalDbService.h
+++ b/CalibFormats/HcalObjects/interface/HcalDbService.h
@@ -14,9 +14,6 @@
 #include "CalibFormats/HcalObjects/interface/HcalCalibrationsSet.h"
 #include "CalibFormats/HcalObjects/interface/HcalCalibrationWidthsSet.h"
 
-#include "FWCore/Framework/interface/ModuleFactory.h"
-#include "FWCore/Framework/interface/ESProducer.h"
-
 #include "CondFormats/HcalObjects/interface/AllObjects.h"
 
 class HcalCalibrations;

--- a/Calibration/EcalAlCaRecoProducers/plugins/SelectedElectronFEDListProducer.cc
+++ b/Calibration/EcalAlCaRecoProducers/plugins/SelectedElectronFEDListProducer.cc
@@ -6,6 +6,7 @@
 #include "FWCore/Framework/interface/ESTransientHandle.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 
 //#include "DataFormats/Common/interface/Handle.h"
 

--- a/CaloOnlineTools/HcalOnlineDb/bin/hcalLUT.cc
+++ b/CaloOnlineTools/HcalOnlineDb/bin/hcalLUT.cc
@@ -4,6 +4,7 @@
 #include "TString.h"
 #include "PhysicsTools/FWLite/interface/CommandLineParser.h"
 #include "CaloOnlineTools/HcalOnlineDb/interface/HcalLutManager.h"
+#include "FWCore/Utilities/interface/FileInPath.h"
 
 using namespace std;
 

--- a/CommonTools/ParticleFlow/plugins/PFCandidateRecalibrator.cc
+++ b/CommonTools/ParticleFlow/plugins/PFCandidateRecalibrator.cc
@@ -11,6 +11,8 @@
 #include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/ESWatcher.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 
 #include "FWCore/Framework/interface/Event.h"

--- a/SimCalorimetry/CastorSim/src/CastorAmplifier.cc
+++ b/SimCalorimetry/CastorSim/src/CastorAmplifier.cc
@@ -12,6 +12,7 @@
 #include "CLHEP/Random/RandGaussQ.h"
 
 #include <iostream>
+#include <cassert>
 
 CastorAmplifier::CastorAmplifier(const CastorSimParameterMap *parameters, bool addNoise)
     : theDbService(nullptr), theParameterMap(parameters), theStartingCapId(0), addNoise_(addNoise) {}

--- a/SimCalorimetry/CastorSim/src/CastorCoderFactory.cc
+++ b/SimCalorimetry/CastorSim/src/CastorCoderFactory.cc
@@ -1,6 +1,7 @@
 #include "CalibFormats/CastorObjects/interface/CastorCoderDb.h"
 #include "CalibFormats/CastorObjects/interface/CastorNominalCoder.h"
 #include "SimCalorimetry/CastorSim/src/CastorCoderFactory.h"
+#include <cassert>
 
 CastorCoderFactory::CastorCoderFactory(CoderType coderType) : theCoderType(coderType), theDbService(nullptr) {}
 

--- a/SimCalorimetry/CastorSim/src/CastorSimParameters.cc
+++ b/SimCalorimetry/CastorSim/src/CastorSimParameters.cc
@@ -6,6 +6,7 @@
 #include "DataFormats/HcalDetId/interface/HcalSubdetector.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "SimCalorimetry/CastorSim/src/CastorSimParameters.h"
+#include <cassert>
 
 CastorSimParameters::CastorSimParameters(double simHitToPhotoelectrons,
                                          double photoelectronsToAnalog,

--- a/SimCalorimetry/HcalTrigPrimAlgos/interface/HcalTriggerPrimitiveAlgo.h
+++ b/SimCalorimetry/HcalTrigPrimAlgos/interface/HcalTriggerPrimitiveAlgo.h
@@ -16,6 +16,8 @@
 #include "SimCalorimetry/HcalTrigPrimAlgos/interface/HcalFeatureHFEMBit.h"
 #include "SimCalorimetry/HcalTrigPrimAlgos/interface/HcalFinegrainBit.h"
 
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
 #include <map>
 #include <vector>
 


### PR DESCRIPTION
#### PR description:

Removed unnecessary includes from FWCore/Framework.

#### PR validation:

Code compiles.