### PR TITLE
Removed ParameterSet usage from SimBeamSpotObjects

### DIFF
--- a/CondFormats/BeamSpotObjects/BuildFile.xml
+++ b/CondFormats/BeamSpotObjects/BuildFile.xml
@@ -1,8 +1,6 @@
 <use name="CondFormats/Serialization"/>
 <use name="FWCore/Utilities"/>
-<use name="FWCore/ParameterSet"/>
 <use name="CondFormats/Common"/>
-<use name="CLHEP"/>
 <export>
   <lib name="1"/>
 </export>

--- a/CondFormats/BeamSpotObjects/interface/SimBeamSpotObjects.h
+++ b/CondFormats/BeamSpotObjects/interface/SimBeamSpotObjects.h
@@ -10,10 +10,6 @@
 #include "CondFormats/Serialization/interface/Serializable.h"
 
 #include <sstream>
-#include "CLHEP/Units/GlobalSystemOfUnits.h"
-#include "CLHEP/Units/GlobalPhysicalConstants.h"
-
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 class SimBeamSpotObjects {
 public:
@@ -27,18 +23,6 @@ public:
   double fTimeOffset;
 
   void print(std::stringstream& ss) const;
-
-  void read(edm::ParameterSet& p) {
-    fX0 = p.getParameter<double>("X0") * cm;
-    fY0 = p.getParameter<double>("Y0") * cm;
-    fZ0 = p.getParameter<double>("Z0") * cm;
-    fSigmaZ = p.getParameter<double>("SigmaZ") * cm;
-    fAlpha = p.getParameter<double>("Alpha") * radian;
-    fPhi = p.getParameter<double>("Phi") * radian;
-    fbetastar = p.getParameter<double>("BetaStar") * cm;
-    femittance = p.getParameter<double>("Emittance") * cm;              // this is not the normalized emittance
-    fTimeOffset = p.getParameter<double>("TimeOffset") * ns * c_light;  // HepMC time units are mm
-  }
 
   COND_SERIALIZABLE;
 };


### PR DESCRIPTION
#### PR description:

Removed ParameterSet usage from SimBeamSpotObjects. Moved the usage to the only piece of code that used it, BeamProfile2DB. 

Updated BeamProfile2DB to be a global::EDAnalyzer with a complete fillDescriptions.

#### PR validation:

Code compiles.