### PR TITLE
Moved HFRecalibration to CalibCalorimetry/HcalAlgos

### DIFF
--- a/CalibCalorimetry/HcalAlgos/interface/HFRecalibration.h
+++ b/CalibCalorimetry/HcalAlgos/interface/HFRecalibration.h
@@ -1,5 +1,5 @@
-#ifndef DataFormats_HFRecalibration_h
-#define DataFormats_HFRecalibration_h
+#ifndef CalibCalorimetry_HcalAlgos_HFRecalibration_h
+#define CalibCalorimetry_HcalAlgos_HFRecalibration_h
 //
 // Simple class with parameterized function provided by James Wetzel
 // to compansate for darkening of HF QP fibers

--- a/CalibCalorimetry/HcalAlgos/src/HFRecalibration.cc
+++ b/CalibCalorimetry/HcalAlgos/src/HFRecalibration.cc
@@ -5,11 +5,10 @@
 //              evaluated using SimG4CMS/Calo/ HFDarkening
 ///////////////////////////////////////////////////////////////////////////////
 
-#include "DataFormats/HcalCalibObjects/interface/HFRecalibration.h"
+#include "CalibCalorimetry/HcalAlgos/interface/HFRecalibration.h"
 
 // CMSSW Headers
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 using namespace edm;
 

--- a/CalibCalorimetry/HcalPlugins/src/HcalHardcodeCalibrations.h
+++ b/CalibCalorimetry/HcalPlugins/src/HcalHardcodeCalibrations.h
@@ -16,7 +16,7 @@
 #include "CondFormats/HcalObjects/interface/AllObjects.h"
 #include "CalibCalorimetry/HcalAlgos/interface/HBHERecalibration.h"
 #include "CondFormats/DataRecord/interface/HcalTPParametersRcd.h"
-#include "DataFormats/HcalCalibObjects/interface/HFRecalibration.h"
+#include "CalibCalorimetry/HcalAlgos/interface/HFRecalibration.h"
 #include "CalibCalorimetry/HcalAlgos/interface/HcalDbHardcode.h"
 #include "Geometry/Records/interface/HcalRecNumberingRecord.h"
 #include "CondFormats/DataRecord/interface/HcalAllRcds.h"

--- a/DataFormats/HcalCalibObjects/BuildFile.xml
+++ b/DataFormats/HcalCalibObjects/BuildFile.xml
@@ -1,6 +1,4 @@
 <use name="DataFormats/Common"/>
-<use name="FWCore/ParameterSet"/>
-<use name="FWCore/MessageLogger"/>
 <export>
   <lib name="1"/>
 </export>

--- a/SimCalorimetry/HcalSimProducers/interface/HcalDigitizer.h
+++ b/SimCalorimetry/HcalSimProducers/interface/HcalDigitizer.h
@@ -7,7 +7,7 @@
 #include "CondFormats/DataRecord/interface/HcalTimeSlewRecord.h"
 #include "CondFormats/HcalObjects/interface/HBHEDarkening.h"
 #include "DataFormats/DetId/interface/DetId.h"
-#include "DataFormats/HcalCalibObjects/interface/HFRecalibration.h"
+#include "CalibCalorimetry/HcalAlgos/interface/HFRecalibration.h"
 #include "FWCore/Framework/interface/ESWatcher.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "Geometry/CaloGeometry/interface/CaloGeometry.h"


### PR DESCRIPTION
#### PR description:

The class is not a data product so does not belong in DataFormats/HcalCalibObjects since it adds additional package dependencies. The new package already hosts the related class HBHERecalibration.

All code using HFRecalibration is already dependent upon CalibCalorimetry/HcalAlgos.

#### PR validation:

The code compiles.