### PR TITLE
CSCMonitorModule migration to ESConsumes

### DIFF
--- a/DQM/CSCMonitorModule/plugins/CSCDQM_EventProcessor_processCSC.cc
+++ b/DQM/CSCMonitorModule/plugins/CSCDQM_EventProcessor_processCSC.cc
@@ -1562,7 +1562,7 @@ namespace cscdqm {
             /**  for(int nLayer = 1; nLayer <= N_Layers; ++nLayer)  */
             //             scaControllerWord[nCFEB][nSample][nLayer-1] = timeSlice(cfebData, nCFEB, nSample)->scaControllerWord(nLayer);
 
-            TrigTime = (int)(timeSlice(data, nCFEB, nSample)->scaControllerWord(nLayer).trig_time);
+            // TrigTime = (int)(timeSlice(data, nCFEB, nSample)->scaControllerWord(nLayer).trig_time);
             /** --------------B */
             FreeCells = timeSlice(data, nCFEB, nSample)->get_n_free_sca_blocks();
             LCT_Pipe_Empty = timeSlice(data, nCFEB, nSample)->get_lctpipe_empty();

--- a/DQM/CSCMonitorModule/plugins/CSCDQM_EventProcessor_updateEffHistos.cc
+++ b/DQM/CSCMonitorModule/plugins/CSCDQM_EventProcessor_updateEffHistos.cc
@@ -140,6 +140,7 @@ namespace cscdqm {
       {  // Compute DQM information parameters
 
         Address adr;
+        bzero(&adr, sizeof(Address));
         adr.mask.side = adr.mask.station = adr.mask.ring = true;
         adr.mask.chamber = adr.mask.layer = adr.mask.cfeb = adr.mask.hv = false;
 
@@ -347,6 +348,7 @@ namespace cscdqm {
    */
   void EventProcessor::standbyEfficiencyHistos(HWStandbyType& standby) {
     Address adr;
+    bzero(&adr, sizeof(Address));
     adr.mask.side = true;
     adr.mask.station = adr.mask.ring = adr.mask.chamber = adr.mask.layer = adr.mask.cfeb = adr.mask.hv = false;
 

--- a/DQM/CSCMonitorModule/plugins/CSCDQM_StripClusterFinder.cc
+++ b/DQM/CSCMonitorModule/plugins/CSCDQM_StripClusterFinder.cc
@@ -174,8 +174,7 @@ namespace cscdqm {
 
   void StripClusterFinder::Match(void) {
     //              MATCHING THE OVERLAPING CLASTERS
-    bool find2match;
-    find2match = true;
+    bool find2match = true;
     do {
       find2match = FindAndMatch();
     } while (find2match);

--- a/DQM/CSCMonitorModule/plugins/CSCDQM_Summary.cc
+++ b/DQM/CSCMonitorModule/plugins/CSCDQM_Summary.cc
@@ -35,6 +35,7 @@ namespace cscdqm {
    */
   void Summary::Reset() {
     Address adr;
+    bzero(&adr, sizeof(Address));
 
     /**  Setting Zeros (no data) for each HW element (and beyond) */
     adr.mask.side = adr.mask.station = adr.mask.layer = false;
@@ -61,6 +62,7 @@ namespace cscdqm {
     if (h2->GetXaxis()->GetXmin() <= 1 && h2->GetXaxis()->GetXmax() >= 36 && h2->GetYaxis()->GetXmin() <= 1 &&
         h2->GetYaxis()->GetXmax() >= 18) {
       Address adr;
+      bzero(&adr, sizeof(Address));
       double z = 0.0;
 
       for (unsigned int x = 1; x <= 36; x++) {
@@ -114,6 +116,7 @@ namespace cscdqm {
       double factor = num / denum;
 
       Address adr;
+      bzero(&adr, sizeof(Address));
       unsigned int N = 0, n = 0;
 
       for (unsigned int x = 1; x <= 36; x++) {
@@ -197,6 +200,7 @@ namespace cscdqm {
         evs->GetYaxis()->GetXmax() >= 18 && err->GetXaxis()->GetXmin() <= 1 && err->GetXaxis()->GetXmax() >= 36 &&
         err->GetYaxis()->GetXmin() <= 1 && err->GetYaxis()->GetXmax() >= 18) {
       Address adr;
+      bzero(&adr, sizeof(Address));
       unsigned int N = 0, n = 0;
 
       for (unsigned int x = 1; x <= 36; x++) {
@@ -225,6 +229,8 @@ namespace cscdqm {
   void Summary::Write(TH2*& h2, const unsigned int station) const {
     const AddressBox* box;
     Address adr, tadr;
+    bzero(&adr, sizeof(Address));
+    bzero(&tadr, sizeof(Address));
     float area_all = 0.0, area_rep = 0.0;
 
     if (station < 1 || station > N_STATIONS)
@@ -335,6 +341,7 @@ namespace cscdqm {
         h2->GetYaxis()->GetXmax() >= 18) {
       unsigned int x, y;
       Address adr;
+      bzero(&adr, sizeof(Address));
 
       adr.mask.side = adr.mask.station = adr.mask.ring = adr.mask.chamber = true;
       adr.mask.layer = adr.mask.cfeb = adr.mask.hv = false;
@@ -385,6 +392,7 @@ namespace cscdqm {
    */
   void Summary::SetValue(const HWStatusBit bit, const int value) {
     Address adr;
+    bzero(&adr, sizeof(Address));
     adr.mask.side = adr.mask.station = adr.mask.ring = adr.mask.chamber = adr.mask.layer = adr.mask.cfeb = adr.mask.hv =
         false;
     SetValue(adr, bit, value);
@@ -503,6 +511,7 @@ namespace cscdqm {
    */
   const double Summary::GetEfficiencyHW() const {
     Address adr;
+    bzero(&adr, sizeof(Address));
     adr.mask.side = adr.mask.station = adr.mask.ring = adr.mask.chamber = adr.mask.layer = adr.mask.cfeb = adr.mask.hv =
         false;
     return GetEfficiencyHW(adr);
@@ -515,6 +524,7 @@ namespace cscdqm {
    */
   const double Summary::GetEfficiencyHW(const unsigned int station) const {
     Address adr;
+    bzero(&adr, sizeof(Address));
     adr.mask.side = adr.mask.station = adr.mask.ring = adr.mask.chamber = adr.mask.layer = adr.mask.cfeb = adr.mask.hv =
         false;
 
@@ -601,8 +611,9 @@ namespace cscdqm {
       return 0.0;
 
     Address adr;
+    bzero(&adr, sizeof(Address));
     adr.mask.side = adr.mask.ring = adr.mask.chamber = adr.mask.layer = adr.mask.cfeb = adr.mask.hv = false;
-    adr.station = true;
+    adr.mask.station = true;
     adr.station = station;
 
     return GetEfficiencyArea(adr);
@@ -616,8 +627,8 @@ namespace cscdqm {
   const double Summary::GetEfficiencyArea(const Address& adr) const {
     double all_area = 1;
 
-    if (adr.mask.side == false && adr.mask.ring == false && adr.mask.chamber == false && adr.mask.layer == false &&
-        adr.mask.cfeb == false && adr.mask.hv == false && adr.mask.station == true)
+    if ((adr.mask.side == false) && (adr.mask.ring == false) && (adr.mask.chamber == false) &&
+        (adr.mask.layer == false) && (adr.mask.cfeb == false) && (adr.mask.hv == false) && (adr.mask.station == true))
       all_area = detector.Area(adr.station);
     else
       all_area = detector.Area(adr);
@@ -698,6 +709,7 @@ namespace cscdqm {
                                  unsigned int ring,
                                  unsigned int chamber) const {
     Address adr;
+    bzero(&adr, sizeof(Address));
     adr.mask.side = adr.mask.station = adr.mask.ring = adr.mask.chamber = true;
     adr.mask.layer = adr.mask.cfeb = adr.mask.hv = false;
     adr.side = side;

--- a/DQM/CSCMonitorModule/plugins/CSCMonitorModule.cc
+++ b/DQM/CSCMonitorModule/plugins/CSCMonitorModule.cc
@@ -22,7 +22,8 @@
  * @brief  Constructor.
  * @param  ps Parameters.
  */
-CSCMonitorModule::CSCMonitorModule(const edm::ParameterSet& ps) {
+CSCMonitorModule::CSCMonitorModule(const edm::ParameterSet& ps)
+    : hcrateToken_(esConsumes<CSCCrateMap, CSCCrateMapRcd>()) {
   edm::FileInPath fp;
 
   inputTag = ps.getUntrackedParameter<edm::InputTag>("InputObjects", (edm::InputTag)INPUT_TAG_LABEL);
@@ -86,7 +87,8 @@ void CSCMonitorModule::beginRun(const edm::Run& r, const edm::EventSetup& c) {
 void CSCMonitorModule::analyze(const edm::Event& e, const edm::EventSetup& c) {
   // Get crate mapping from database
   edm::ESHandle<CSCCrateMap> hcrate;
-  c.get<CSCCrateMapRcd>().get(hcrate);
+  /// Use esConsumes to get crate mapping
+  hcrate = c.getHandle(hcrateToken_);
   pcrate = hcrate.product();
 
   cscdqm::HWStandbyType standby;

--- a/DQM/CSCMonitorModule/plugins/CSCMonitorModule.h
+++ b/DQM/CSCMonitorModule/plugins/CSCMonitorModule.h
@@ -88,6 +88,8 @@ private:
   bool prebookEffParams;
   bool processDcsScalers;
 
+  const edm::ESGetToken<CSCCrateMap, CSCCrateMapRcd> hcrateToken_;
+
   /** Pointer to crate mapping from database **/
   const CSCCrateMap* pcrate;
 


### PR DESCRIPTION
#### PR description:
Migration of CSCMonitorModule to ESConsumes. Fixes for static analyzer warnings.
- Replaced obsolete calls with new ESConsumes (reference to PR #31061)
- Fixed number of static analyzer warnings.

#### PR validation:
Code compiles and runs on test data.

