### PR TITLE
Add protection for missing handleExtResults

### DIFF
--- a/PhysicsTools/NanoAOD/plugins/L1TriggerResultsConverter.cc
+++ b/PhysicsTools/NanoAOD/plugins/L1TriggerResultsConverter.cc
@@ -135,7 +135,9 @@ void L1TriggerResultsConverter::produce(edm::Event& iEvent, const edm::EventSetu
     if (store_unprefireable_bit_) {
       edm::Handle<GlobalExtBlkBxCollection> handleExtResults;
       iEvent.getByToken(token_ext_, handleExtResults);
-      unprefireable_bit = handleExtResults->at(0, 0).getExternalDecision(GlobalExtBlk::maxExternalConditions - 1);
+      if (handleExtResults->size() != 0) {
+	unprefireable_bit = handleExtResults->at(0, 0).getExternalDecision(GlobalExtBlk::maxExternalConditions - 1);
+      }
     }
   } else {
     // Legacy access

--- a/PhysicsTools/NanoAOD/plugins/L1TriggerResultsConverter.cc
+++ b/PhysicsTools/NanoAOD/plugins/L1TriggerResultsConverter.cc
@@ -136,7 +136,7 @@ void L1TriggerResultsConverter::produce(edm::Event& iEvent, const edm::EventSetu
       edm::Handle<GlobalExtBlkBxCollection> handleExtResults;
       iEvent.getByToken(token_ext_, handleExtResults);
       if (handleExtResults->size() != 0) {
-	unprefireable_bit = handleExtResults->at(0, 0).getExternalDecision(GlobalExtBlk::maxExternalConditions - 1);
+        unprefireable_bit = handleExtResults->at(0, 0).getExternalDecision(GlobalExtBlk::maxExternalConditions - 1);
       }
     }
   } else {


### PR DESCRIPTION
Adds a protection against the error:

> A std::exception was thrown.
> vector::_M_range_check: __n (which is 0) >= this->size() (which is 0)

Happening due to empty handleExtResults. This is a rare case.
More details in:
`https://its.cern.ch/jira/browse/CMSCOMPPR-17789`

Validated on the affected events:
`RECO --conditions 106X_dataRun2_v32 --customise Configuration/DataProcessing/Utils.addMonitoring --datatier NANOAOD --era Run2_2017,run2_nanoAOD_106Xv1 --eventcontent NANOEDMAOD --filein placeholder.root --fileout file:ReReco-Run2017E-JetHT-UL2017_MiniAODv1_NanoAODv2-00002.root --nThreads 2 --no_exec --python_filename ReReco-Run2017E-JetHT-UL2017_MiniAODv1_NanoAODv2-00002_0_cfg.py --scenario pp --step NANO --data`

file on which we should be able to reproduce the crash at:

```
Processing Event run: 304197 lumi: 1 event: 875064
root://xrootd.echo.stfc.ac.uk//store/data/Run2017E/JetHT/MINIAOD/09Aug2019_UL2017-v1/30000/457A4F7E-DEEB-DB40-AE94-3687A974F426.root
```

BP in 106X is needed