### PR TITLE
Bug fix in Geant4 stepping and stacking actions

### DIFF
--- a/SimG4Core/Application/interface/StackingAction.h
+++ b/SimG4Core/Application/interface/StackingAction.h
@@ -36,7 +36,7 @@ private:
 
   bool rrApplicable(const G4Track*, const G4Track&) const;
 
-  bool isItOutOfTimeWindow(const G4Region*, const G4Track*) const;
+  bool isItOutOfTimeWindow(const G4Region*, const double&) const;
 
   bool isThisRegion(const G4Region*, std::vector<const G4Region*>&) const;
 

--- a/SimG4Core/Application/interface/SteppingAction.h
+++ b/SimG4Core/Application/interface/SteppingAction.h
@@ -42,10 +42,10 @@ private:
   bool initPointer();
 
   inline bool isInsideDeadRegion(const G4Region* reg) const;
-  inline bool isOutOfTimeWindow(const G4Track* theTrack, const G4Region* reg) const;
+  inline bool isOutOfTimeWindow(const G4Region* reg, const double& time) const;
   inline bool isThisVolume(const G4VTouchable* touch, const G4VPhysicalVolume* pv) const;
 
-  bool isLowEnergy(const G4Step* aStep) const;
+  bool isLowEnergy(const G4LogicalVolume*, const G4Track*) const;
   void PrintKilledTrack(const G4Track*, const TrackStatus&) const;
 
   EventAction* eventAction_;
@@ -88,7 +88,7 @@ inline bool SteppingAction::isInsideDeadRegion(const G4Region* reg) const {
   return res;
 }
 
-inline bool SteppingAction::isOutOfTimeWindow(const G4Track* theTrack, const G4Region* reg) const {
+inline bool SteppingAction::isOutOfTimeWindow(const G4Region* reg, const double& time) const {
   double tofM = maxTrackTime;
   for (unsigned int i = 0; i < numberTimes; ++i) {
     if (reg == maxTimeRegions[i]) {
@@ -96,7 +96,7 @@ inline bool SteppingAction::isOutOfTimeWindow(const G4Track* theTrack, const G4R
       break;
     }
   }
-  return (theTrack->GetGlobalTime() > tofM);
+  return (time > tofM);
 }
 
 inline bool SteppingAction::isThisVolume(const G4VTouchable* touch, const G4VPhysicalVolume* pv) const {

--- a/SimG4Core/Application/src/StackingAction.cc
+++ b/SimG4Core/Application/src/StackingAction.cc
@@ -186,6 +186,7 @@ G4ClassificationOfNewTrack StackingAction::ClassifyNewTrack(const G4Track* aTrac
   } else {
     // secondary
     const G4Region* reg = aTrack->GetVolume()->GetLogicalVolume()->GetRegion();
+    const double time = aTrack->GetGlobalTime();
 
     // definetly killed tracks
     if (aTrack->GetTrackStatus() == fStopAndKill) {
@@ -195,14 +196,14 @@ G4ClassificationOfNewTrack StackingAction::ClassifyNewTrack(const G4Track* aTrac
 
     } else if (std::abs(aTrack->GetPosition().z()) >= maxZCentralCMS) {
       // very forward secondary
-      if (aTrack->GetGlobalTime() > maxTrackTimeForward) {
+      if (time > maxTrackTimeForward) {
         classification = fKill;
       } else {
         const G4Track* mother = trackAction->geant4Track();
         newTA->secondary(aTrack, *mother, 0);
       }
 
-    } else if (isItOutOfTimeWindow(reg, aTrack)) {
+    } else if (isItOutOfTimeWindow(reg, time)) {
       // time window check
       classification = fKill;
 
@@ -217,7 +218,7 @@ G4ClassificationOfNewTrack StackingAction::ClassifyNewTrack(const G4Track* aTrac
       if (classification != fKill && ke <= limitEnergyForVacuum && isThisRegion(reg, lowdensRegions)) {
         classification = fKill;
 
-      } else {
+      } else if (classification != fKill) {
         // very low-energy gamma
         if (pdg == 22 && killGamma && ke < kmaxGamma) {
           classification = fKill;
@@ -434,8 +435,8 @@ bool StackingAction::rrApplicable(const G4Track* aTrack, const G4Track& mother) 
   const TrackInformation& motherInfo(extractor(mother));
 
   // Check whether mother is gamma, e+, e-
-  const int genID = std::abs(motherInfo.genParticlePID());
-  return (22 != genID && 11 != genID);
+  const int genID = motherInfo.genParticlePID();
+  return (22 != genID && 11 != std::abs(genID));
 }
 
 int StackingAction::isItFromPrimary(const G4Track& mother, int flagIn) const {
@@ -449,7 +450,7 @@ int StackingAction::isItFromPrimary(const G4Track& mother, int flagIn) const {
   return flag;
 }
 
-bool StackingAction::isItOutOfTimeWindow(const G4Region* reg, const G4Track* aTrack) const {
+bool StackingAction::isItOutOfTimeWindow(const G4Region* reg, const double& t) const {
   double tofM = maxTrackTime;
   for (unsigned int i = 0; i < numberTimes; ++i) {
     if (reg == maxTimeRegions[i]) {
@@ -457,7 +458,7 @@ bool StackingAction::isItOutOfTimeWindow(const G4Region* reg, const G4Track* aTr
       break;
     }
   }
-  return (aTrack->GetGlobalTime() > tofM);
+  return (t > tofM);
 }
 
 void StackingAction::printRegions(const std::vector<const G4Region*>& reg, const std::string& word) const {

--- a/SimG4Core/Application/src/SteppingAction.cc
+++ b/SimG4Core/Application/src/SteppingAction.cc
@@ -103,7 +103,7 @@ void SteppingAction::UserSteppingAction(const G4Step* aStep) {
   const G4StepPoint* postStep = aStep->GetPostStepPoint();
 
   // NaN energy deposit
-  if (sAlive == tstat && edm::isNotFinite(aStep->GetTotalEnergyDeposit())) {
+  if (edm::isNotFinite(aStep->GetTotalEnergyDeposit())) {
     tstat = sEnergyDepNaN;
     if (nWarnings < 5) {
       ++nWarnings;
@@ -115,6 +115,14 @@ void SteppingAction::UserSteppingAction(const G4Step* aStep) {
     }
   }
 
+  // the track is killed by the process
+  if(tstat == sKilledByProcess) {
+    if (nullptr != steppingVerbose) {
+      steppingVerbose->NextStep(aStep, fpSteppingManager, false);
+    }
+    return;
+  }
+
   if (sAlive == tstat && theTrack->GetCurrentStepNumber() > maxNumberOfSteps) {
     tstat = sNumberOfSteps;
     if (nWarnings < 5) {
@@ -122,41 +130,47 @@ void SteppingAction::UserSteppingAction(const G4Step* aStep) {
       edm::LogWarning("SimG4CoreApplication")
           << "Track #" << theTrack->GetTrackID() << " " << theTrack->GetDefinition()->GetParticleName()
           << " E(MeV)= " << preStep->GetKineticEnergy() / MeV << " Nstep= " << theTrack->GetCurrentStepNumber()
-          << " is killed due to limit on number of steps;PV: " << preStep->GetPhysicalVolume()->GetName() << " at "
+          << " is killed due to limit on number of steps;/n  PV: " << preStep->GetPhysicalVolume()->GetName() << " at "
           << theTrack->GetPosition() << " StepLen(mm)= " << aStep->GetStepLength();
     }
   }
+  const double time = theTrack->GetGlobalTime();
 
   // check Z-coordinate
   if (sAlive == tstat && std::abs(theTrack->GetPosition().z()) >= maxZCentralCMS) {
-    tstat = (theTrack->GetGlobalTime() > maxTrackTimeForward) ? sOutOfTime : sVeryForward;
+    tstat = (time > maxTrackTimeForward) ? sOutOfTime : sVeryForward;
   }
 
   // check G4Region
-  if (sAlive == tstat && postStep->GetPhysicalVolume() != nullptr) {
-    const G4Region* theRegion = preStep->GetPhysicalVolume()->GetLogicalVolume()->GetRegion();
+  if (sAlive == tstat) {
+
+    // next logical volume and next region
+    const G4LogicalVolume* lv = postStep->GetPhysicalVolume()->GetLogicalVolume();
+    const G4Region* theRegion = lv->GetRegion();
 
     // kill in dead regions
-    if (isInsideDeadRegion(theRegion)) {
+    if (isInsideDeadRegion(theRegion))
       tstat = sDeadRegion;
-    }
 
     // kill out of time
-    if (sAlive == tstat && isOutOfTimeWindow(theTrack, theRegion)) {
-      tstat = sOutOfTime;
+    if (sAlive == tstat) {
+      if(isOutOfTimeWindow(theRegion, time)) 
+	tstat = sOutOfTime;
     }
 
     // kill low-energy in volumes on demand
-    if (sAlive == tstat && numberEkins > 0 && isLowEnergy(aStep)) {
-      tstat = sLowEnergy;
+    if (sAlive == tstat && numberEkins > 0) {
+      if(isLowEnergy(lv, theTrack)) 
+	tstat = sLowEnergy;
     }
 
     // kill low-energy in vacuum
-    const G4double kinEnergy = theTrack->GetKineticEnergy();
-    if (sAlive == tstat && killBeamPipe && kinEnergy < theCriticalEnergyForVacuum &&
-        theTrack->GetDefinition()->GetPDGCharge() != 0.0 && kinEnergy > 0.0 &&
-        theTrack->GetNextVolume()->GetLogicalVolume()->GetMaterial()->GetDensity() <= theCriticalDensity) {
-      tstat = sLowEnergyInVacuum;
+    if (sAlive == tstat && killBeamPipe) {
+      if(theTrack->GetKineticEnergy() < theCriticalEnergyForVacuum &&
+	 theTrack->GetDefinition()->GetPDGCharge() != 0.0 && 
+	 lv->GetMaterial()->GetDensity() <= theCriticalDensity) {
+	tstat = sLowEnergyInVacuum;
+      }
     }
   }
   // check transition tracker/calo
@@ -185,11 +199,9 @@ void SteppingAction::UserSteppingAction(const G4Step* aStep) {
   }
 }
 
-bool SteppingAction::isLowEnergy(const G4Step* aStep) const {
-  const G4StepPoint* sp = aStep->GetPostStepPoint();
-  const G4LogicalVolume* lv = sp->GetPhysicalVolume()->GetLogicalVolume();
-  const double ekin = sp->GetKineticEnergy();
-  int pCode = aStep->GetTrack()->GetDefinition()->GetPDGEncoding();
+bool SteppingAction::isLowEnergy(const G4LogicalVolume* lv, const G4Track* theTrack) const {
+  const double ekin = theTrack->GetKineticEnergy();
+  int pCode = theTrack->GetDefinition()->GetPDGEncoding();
 
   for (auto& vol : ekinVolumes) {
     if (lv == vol) {
@@ -281,9 +293,6 @@ void SteppingAction::PrintKilledTrack(const G4Track* aTrack, const TrackStatus& 
   std::string rname = "";
   std::string typ = " ";
   switch (tst) {
-    case sKilledByProcess:
-      typ = " G4Process ";
-      break;
     case sDeadRegion:
       typ = " in dead region ";
       break;
@@ -309,14 +318,18 @@ void SteppingAction::PrintKilledTrack(const G4Track* aTrack, const TrackStatus& 
       break;
   }
   G4VPhysicalVolume* pv = aTrack->GetNextVolume();
-  if (pv) {
-    vname = pv->GetLogicalVolume()->GetName();
-    rname = pv->GetLogicalVolume()->GetRegion()->GetName();
-  }
+  vname = pv->GetLogicalVolume()->GetName();
+  rname = pv->GetLogicalVolume()->GetRegion()->GetName();
 
-  edm::LogVerbatim("SimG4CoreApplication")
-      << "Track #" << aTrack->GetTrackID() << " StepN= " << aTrack->GetCurrentStepNumber() << " "
-      << aTrack->GetDefinition()->GetParticleName() << " E(MeV)= " << aTrack->GetKineticEnergy() / MeV
-      << " T(ns)= " << aTrack->GetGlobalTime() / ns << " is killed due to " << typ << " inside LV: " << vname << " ("
-      << rname << ") at " << aTrack->GetPosition();
+  const double ekin = aTrack->GetKineticEnergy();
+  if(ekin < 2*CLHEP::MeV) { return; }
+  edm::LogWarning("SimG4CoreApplication")
+      << "Track #" << aTrack->GetTrackID() << " StepN= " 
+      << aTrack->GetCurrentStepNumber() << " "
+      << aTrack->GetDefinition()->GetParticleName() 
+      << " E(MeV)=" << ekin / CLHEP::MeV
+      << " T(ns)=" << aTrack->GetGlobalTime() / CLHEP::ns 
+      << " is killed due to " << typ << "\n  LV: " << vname << " ("
+      << rname << ") at " << aTrack->GetPosition()
+      << " step(cm)=" << aTrack->GetStep()->GetStepLength()/CLHEP::cm;
 }

--- a/SimG4Core/Application/src/SteppingAction.cc
+++ b/SimG4Core/Application/src/SteppingAction.cc
@@ -116,7 +116,7 @@ void SteppingAction::UserSteppingAction(const G4Step* aStep) {
   }
 
   // the track is killed by the process
-  if(tstat == sKilledByProcess) {
+  if (tstat == sKilledByProcess) {
     if (nullptr != steppingVerbose) {
       steppingVerbose->NextStep(aStep, fpSteppingManager, false);
     }
@@ -143,7 +143,6 @@ void SteppingAction::UserSteppingAction(const G4Step* aStep) {
 
   // check G4Region
   if (sAlive == tstat) {
-
     // next logical volume and next region
     const G4LogicalVolume* lv = postStep->GetPhysicalVolume()->GetLogicalVolume();
     const G4Region* theRegion = lv->GetRegion();
@@ -154,22 +153,21 @@ void SteppingAction::UserSteppingAction(const G4Step* aStep) {
 
     // kill out of time
     if (sAlive == tstat) {
-      if(isOutOfTimeWindow(theRegion, time)) 
-	tstat = sOutOfTime;
+      if (isOutOfTimeWindow(theRegion, time))
+        tstat = sOutOfTime;
     }
 
     // kill low-energy in volumes on demand
     if (sAlive == tstat && numberEkins > 0) {
-      if(isLowEnergy(lv, theTrack)) 
-	tstat = sLowEnergy;
+      if (isLowEnergy(lv, theTrack))
+        tstat = sLowEnergy;
     }
 
     // kill low-energy in vacuum
     if (sAlive == tstat && killBeamPipe) {
-      if(theTrack->GetKineticEnergy() < theCriticalEnergyForVacuum &&
-	 theTrack->GetDefinition()->GetPDGCharge() != 0.0 && 
-	 lv->GetMaterial()->GetDensity() <= theCriticalDensity) {
-	tstat = sLowEnergyInVacuum;
+      if (theTrack->GetKineticEnergy() < theCriticalEnergyForVacuum &&
+          theTrack->GetDefinition()->GetPDGCharge() != 0.0 && lv->GetMaterial()->GetDensity() <= theCriticalDensity) {
+        tstat = sLowEnergyInVacuum;
       }
     }
   }
@@ -322,14 +320,12 @@ void SteppingAction::PrintKilledTrack(const G4Track* aTrack, const TrackStatus& 
   rname = pv->GetLogicalVolume()->GetRegion()->GetName();
 
   const double ekin = aTrack->GetKineticEnergy();
-  if(ekin < 2*CLHEP::MeV) { return; }
+  if (ekin < 2 * CLHEP::MeV) {
+    return;
+  }
   edm::LogWarning("SimG4CoreApplication")
-      << "Track #" << aTrack->GetTrackID() << " StepN= " 
-      << aTrack->GetCurrentStepNumber() << " "
-      << aTrack->GetDefinition()->GetParticleName() 
-      << " E(MeV)=" << ekin / CLHEP::MeV
-      << " T(ns)=" << aTrack->GetGlobalTime() / CLHEP::ns 
-      << " is killed due to " << typ << "\n  LV: " << vname << " ("
-      << rname << ") at " << aTrack->GetPosition()
-      << " step(cm)=" << aTrack->GetStep()->GetStepLength()/CLHEP::cm;
+      << "Track #" << aTrack->GetTrackID() << " StepN= " << aTrack->GetCurrentStepNumber() << " "
+      << aTrack->GetDefinition()->GetParticleName() << " E(MeV)=" << ekin / CLHEP::MeV
+      << " T(ns)=" << aTrack->GetGlobalTime() / CLHEP::ns << " is killed due to " << typ << "\n  LV: " << vname << " ("
+      << rname << ") at " << aTrack->GetPosition() << " step(cm)=" << aTrack->GetStep()->GetStepLength() / CLHEP::cm;
 }


### PR DESCRIPTION
#### PR description:
In an attempt to optimize Run-3 simulation and fix minor problem in Geant4 user actions a logical bug was introduced, which affect calorimeter responses. The problem was reported first by @abdoulline . In this PR the logic of filters at each step (SteppingAction) has been fixed. A minor problem is also fixed in StackingAction, which is called for each new secondary particle.

The level of the problem, identified by @abdoulline is 2-3% reduction of energy deposition in calorimeters. With the test-beam 2006 the effect is even more and may illustrated for pi- projectile: 
![image](https://user-images.githubusercontent.com/4955118/120238763-239a6480-c25d-11eb-8257-efb0ed05cfb5.png)

In the proposed fix the situation return back to normal: 
![image](https://user-images.githubusercontent.com/4955118/120238828-504e7c00-c25d-11eb-87c4-ea1e686354bd.png)

