### PR TITLE
Recluster AK4 jets in HI reMiniAOD to avoid rare crash

### DIFF
--- a/PhysicsTools/PatAlgos/python/producersHeavyIons/heavyIonJets_cff.py
+++ b/PhysicsTools/PatAlgos/python/producersHeavyIons/heavyIonJets_cff.py
@@ -70,6 +70,13 @@ recoPFJetsHIpostAODTask = cms.Task(
     patJetCorrFactors
 )
 
+from Configuration.ProcessModifiers.run2_miniAOD_pp_on_AA_103X_cff import run2_miniAOD_pp_on_AA_103X
+from RecoJets.JetProducers.ak4PFJets_cfi import ak4PFJets,ak4PFJetsCHS
+_recoPFJetsHIpostAODTask = recoPFJetsHIpostAODTask.copy()
+_recoPFJetsHIpostAODTask.add(ak4PFJets,ak4PFJetsCHS)
+run2_miniAOD_pp_on_AA_103X.toReplaceWith(recoPFJetsHIpostAODTask, _recoPFJetsHIpostAODTask)
+
+
 recoJetsHIpostAODTask = cms.Task(
     recoPFJetsHIpostAODTask,
     allPartons,

--- a/PhysicsTools/PatAlgos/python/producersHeavyIons/heavyIonJets_cff.py
+++ b/PhysicsTools/PatAlgos/python/producersHeavyIons/heavyIonJets_cff.py
@@ -72,6 +72,8 @@ recoPFJetsHIpostAODTask = cms.Task(
 
 from Configuration.ProcessModifiers.run2_miniAOD_pp_on_AA_103X_cff import run2_miniAOD_pp_on_AA_103X
 from RecoJets.JetProducers.ak4PFJets_cfi import ak4PFJets,ak4PFJetsCHS
+ak4PFJets.src = "pfEmptyCollection"
+ak4PFJetsCHS.src = "pfEmptyCollection"
 _recoPFJetsHIpostAODTask = recoPFJetsHIpostAODTask.copy()
 _recoPFJetsHIpostAODTask.add(ak4PFJets,ak4PFJetsCHS)
 run2_miniAOD_pp_on_AA_103X.toReplaceWith(recoPFJetsHIpostAODTask, _recoPFJetsHIpostAODTask)

--- a/PhysicsTools/PatAlgos/python/producersHeavyIons/heavyIonJets_cff.py
+++ b/PhysicsTools/PatAlgos/python/producersHeavyIons/heavyIonJets_cff.py
@@ -72,10 +72,9 @@ recoPFJetsHIpostAODTask = cms.Task(
 
 from Configuration.ProcessModifiers.run2_miniAOD_pp_on_AA_103X_cff import run2_miniAOD_pp_on_AA_103X
 from RecoJets.JetProducers.ak4PFJets_cfi import ak4PFJets,ak4PFJetsCHS
-ak4PFJets.src = "pfEmptyCollection"
-ak4PFJetsCHS.src = "pfEmptyCollection"
+from CommonTools.ParticleFlow.pfNoPileUpJME_cff import *
 _recoPFJetsHIpostAODTask = recoPFJetsHIpostAODTask.copy()
-_recoPFJetsHIpostAODTask.add(ak4PFJets,ak4PFJetsCHS)
+_recoPFJetsHIpostAODTask.add(ak4PFJets,pfNoPileUpJMETask,ak4PFJetsCHS)
 run2_miniAOD_pp_on_AA_103X.toReplaceWith(recoPFJetsHIpostAODTask, _recoPFJetsHIpostAODTask)
 
 


### PR DESCRIPTION
#### PR description:

This PR fixes a crash that is discussed in 
https://github.com/cms-sw/cmssw/issues/33564
The crash occurs rarely when HI miniAOD is created from existing AOD ("re-miniAOD").
The solution it to recluster ak4PFJets and ak4PFJetsCHS

#### PR validation:

The recipe for testing this fix may be found in the issue mentioned above. 

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

We should backport to 11_2_X, where the HI miniAOD was produced.

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
