### PR TITLE
Fix GeneratorInterface null termination issues

### DIFF
--- a/GeneratorInterface/AMPTInterface/src/AMPTHadronizer.cc
+++ b/GeneratorInterface/AMPTInterface/src/AMPTHadronizer.cc
@@ -152,7 +152,7 @@ bool AMPTHadronizer::generatePartonsAndHadronize() {
     rotateEvtPlane();
 
   // generate a AMPT event
-  AMPT(frame_.data(), bmin_, bmax_, strlen(frame_.data()));
+  AMPT(frame_.c_str(), bmin_, bmax_, frame_.length());
 
   // event information
   HepMC::GenEvent* evt = new HepMC::GenEvent();
@@ -231,7 +231,7 @@ bool AMPTHadronizer::call_amptset(
     double efrm, std::string frame, std::string proj, std::string targ, int iap, int izp, int iat, int izt) {
   // initialize hydjet
   AMPTSET(
-      efrm, frame.data(), proj.data(), targ.data(), iap, izp, iat, izt, frame.length(), proj.length(), targ.length());
+      efrm, frame.c_str(), proj.c_str(), targ.c_str(), iap, izp, iat, izt, frame.length(), proj.length(), targ.length());
   return true;
 }
 //______________________________________________________________________

--- a/GeneratorInterface/HijingInterface/src/HijingHadronizer.cc
+++ b/GeneratorInterface/HijingInterface/src/HijingHadronizer.cc
@@ -157,7 +157,7 @@ bool HijingHadronizer::generatePartonsAndHadronize() {
 
   float f_bmin = bmin_;
   float f_bmax = bmax_;
-  HIJING(frame_.data(), f_bmin, f_bmax, strlen(frame_.data()));
+  HIJING(frame_.c_str(), f_bmin, f_bmax, frame_.length());
 
   // event information
   HepMC::GenEvent* evt = new HepMC::GenEvent();
@@ -246,16 +246,16 @@ bool HijingHadronizer::call_hijset(
   float ef = efrm;
   // initialize hydjet
   HIJSET(ef,
-         frame.data(),
-         proj.data(),
-         targ.data(),
+         frame.c_str(),
+         proj.c_str(),
+         targ.c_str(),
          iap,
          izp,
          iat,
          izt,
-         strlen(frame.data()),
-         strlen(proj.data()),
-         strlen(targ.data()));
+         frame.length(),
+         proj.length(),
+         targ.length());
   return true;
 }
 

--- a/GeneratorInterface/HijingInterface/src/HijingHadronizer.cc
+++ b/GeneratorInterface/HijingInterface/src/HijingHadronizer.cc
@@ -245,17 +245,8 @@ bool HijingHadronizer::call_hijset(
     double efrm, std::string frame, std::string proj, std::string targ, int iap, int izp, int iat, int izt) {
   float ef = efrm;
   // initialize hydjet
-  HIJSET(ef,
-         frame.c_str(),
-         proj.c_str(),
-         targ.c_str(),
-         iap,
-         izp,
-         iat,
-         izt,
-         frame.length(),
-         proj.length(),
-         targ.length());
+  HIJSET(
+      ef, frame.c_str(), proj.c_str(), targ.c_str(), iap, izp, iat, izt, frame.length(), proj.length(), targ.length());
   return true;
 }
 


### PR DESCRIPTION
#### PR description:

`std::string::data()` is not guaranteed to be nul terminated, so `strlen(string.data())` is unsafe.  This corrects the problem by using `std::string::c_str()` and `std::string::length()`.  Completes a partial fix in #33687, hopefully resolves #33452.

#### PR validation:

Trivial technical fix, compiles.