### PR TITLE
Add dependencies needed by UBSAN builds

### DIFF
--- a/DQM/TrackerRemapper/BuildFile.xml
+++ b/DQM/TrackerRemapper/BuildFile.xml
@@ -5,6 +5,7 @@
 <use name="rootgraphics"/>
 <use name="rootmath"/>
 <use name="roothistmatrix"/>
+<use name="roothistpainter"/>
 <export>
   <lib name="1"/>
 </export>

--- a/Geometry/MTDNumberingBuilder/BuildFile.xml
+++ b/Geometry/MTDNumberingBuilder/BuildFile.xml
@@ -1,6 +1,7 @@
 <use name="DataFormats/GeometrySurface"/>
 <use name="DetectorDescription/Core"/>
 <use name="Geometry/TrackerNumberingBuilder"/>
+<use name="Geometry/CommonDetUnit"/>
 <use name="DataFormats/ForwardDetId"/>
 <export>
   <lib name="1"/>


### PR DESCRIPTION
#### PR description:

Undefined behavior sanitizer builds have been failing with linker errors in Geometry/MTDNumberingBuilder:
```
GeometryMTDNumberingBuilder/MTDTopology.cc.o:(.data.rel+0x58): undefined reference to `typeinfo for GeomDet'
```
and DQM/TrackerRemapper:
```
DQMTrackerRemapper/SiStripTkMaps.cc.o:(.data.rel+0x218): undefined reference to `typeinfo for TPaletteAxis'
```
This PR adds the BuildFile.xml entries needed to resolve the missing typeinfos.

#### PR validation:

Trivial technical fix, builds successfully in CMSSW_12_0_UBSAN_X_2021-05-28-2300.