### PR TITLE
Fix reco muon validation hlt

### DIFF
--- a/SimMuon/MCTruth/plugins/MuonAssociatorEDProducer.cc
+++ b/SimMuon/MCTruth/plugins/MuonAssociatorEDProducer.cc
@@ -108,10 +108,6 @@ void MuonAssociatorEDProducer::produce(edm::Event &event, const edm::EventSetup 
   else
     LogTrace("MuonAssociatorEDProducer") << "\t... NOT FOUND.";
 
-  edm::RefToBaseVector<reco::Track> tmpT;
-  for (size_t i = 0; i < trackCollection->size(); ++i)
-    tmpT.push_back(trackCollection->refAt(i));
-
   std::unique_ptr<reco::RecoToSimCollection> rts;
   std::unique_ptr<reco::SimToRecoCollection> str;
 
@@ -122,6 +118,10 @@ void MuonAssociatorEDProducer::produce(edm::Event &event, const edm::EventSetup 
     LogTrace("MuonAssociatorEDProducer") << "\n ignoring missing track collection."
                                          << "\n";
   } else {
+    edm::RefToBaseVector<reco::Track> tmpT;
+    for (size_t i = 0; i < trackCollection->size(); ++i)
+      tmpT.push_back(trackCollection->refAt(i));
+
     edm::LogVerbatim("MuonAssociatorEDProducer")
         << "\n >>> RecoToSim association <<< \n"
         << "     Track collection : " << tracksTag.label() << ":" << tracksTag.instance()

--- a/Validation/RecoMuon/plugins/MuonTrackValidator.cc
+++ b/Validation/RecoMuon/plugins/MuonTrackValidator.cc
@@ -421,8 +421,10 @@ void MuonTrackValidator::analyze(const edm::Event& event, const edm::EventSetup&
   TrackingParticleRefVector const& tPC = *ptr_TPrefV;
 
   edm::Handle<reco::BeamSpot> recoBeamSpotHandle;
-  event.getByToken(bsSrc_Token, recoBeamSpotHandle);
-  reco::BeamSpot bs = *recoBeamSpotHandle;
+  bool bs_Available = event.getByToken(bsSrc_Token, recoBeamSpotHandle);
+  reco::BeamSpot bs;
+  if (bs_Available) bs = *recoBeamSpotHandle;
+  edm::LogVerbatim("MuonTrackValidator") << bs;
 
   std::vector<const reco::TrackToTrackingParticleAssociator*> associator;
   if (UseAssociators) {

--- a/Validation/RecoMuon/plugins/MuonTrackValidator.cc
+++ b/Validation/RecoMuon/plugins/MuonTrackValidator.cc
@@ -423,7 +423,8 @@ void MuonTrackValidator::analyze(const edm::Event& event, const edm::EventSetup&
   edm::Handle<reco::BeamSpot> recoBeamSpotHandle;
   bool bs_Available = event.getByToken(bsSrc_Token, recoBeamSpotHandle);
   reco::BeamSpot bs;
-  if (bs_Available) bs = *recoBeamSpotHandle;
+  if (bs_Available)
+    bs = *recoBeamSpotHandle;
   edm::LogVerbatim("MuonTrackValidator") << bs;
 
   std::vector<const reco::TrackToTrackingParticleAssociator*> associator;


### PR DESCRIPTION
Bug fixes to be applied on master 12_0_X, solve the issue of PR #33610
This should change nothing anywhere comparing with master (where applicable)
the workflows like 1311.0 could be checked by testing #33610 together with this PR

The problem was caused by events where some HLT muon track collections are missing, while trying to access them.
