### PR TITLE
[backport 106X] PUID UL16 and UL16APV training and working points

### DIFF
--- a/RecoJets/JetProducers/python/PileupJetIDCutParams_cfi.py
+++ b/RecoJets/JetProducers/python/PileupJetIDCutParams_cfi.py
@@ -73,6 +73,40 @@ full_106x_UL17_chs_wp = cms.PSet(
 full_106x_UL18_chs_wp = full_106x_UL17_chs_wp.clone()
 
 ###########################################################
+## Working points for the 106X UL16 training
+###########################################################
+full_106x_UL16_chs_wp = cms.PSet(
+    # 4 Eta Categories  0-2.5 2.5-2.75 2.75-3.0 3.0-5.0
+    # 5 Pt Categories   0-10, 10-20, 20-30, 30-40, 40-50
+
+    #Tight Id
+    Pt010_Tight  = cms.vdouble(-0.95, -0.70, -0.52, -0.49),
+    Pt1020_Tight = cms.vdouble(-0.95, -0.70, -0.52, -0.49),
+    Pt2030_Tight = cms.vdouble(-0.90, -0.57, -0.43, -0.42),
+    Pt3040_Tight = cms.vdouble(-0.71, -0.36, -0.29, -0.23),
+    Pt4050_Tight = cms.vdouble(-0.42, -0.09, -0.14, -0.02),
+
+    #Medium Id
+    Pt010_Medium  = cms.vdouble(0.20, -0.56, -0.43, -0.38),
+    Pt1020_Medium = cms.vdouble(0.20, -0.56, -0.43, -0.38),
+    Pt2030_Medium = cms.vdouble(0.62, -0.39, -0.32, -0.29),
+    Pt3040_Medium = cms.vdouble(0.86, -0.10, -0.15, -0.08),
+    Pt4050_Medium = cms.vdouble(0.93, 0.19, 0.04, 0.12),
+
+    #Loose Id
+    Pt010_Loose  = cms.vdouble(0.71, -0.32, -0.30, -0.22),
+    Pt1020_Loose = cms.vdouble(0.71, -0.32, -0.30, -0.22),
+    Pt2030_Loose = cms.vdouble(0.87, -0.08, -0.16, -0.12),
+    Pt3040_Loose = cms.vdouble(0.94, 0.24, 0.05, 0.10),
+    Pt4050_Loose = cms.vdouble(0.97, 0.48, 0.26, 0.29)
+)
+
+##########################################################
+## Working points for the 106X UL16 APV training
+###########################################################
+full_106x_UL16APV_chs_wp = full_106x_UL16_chs_wp.clone()
+
+###########################################################
 ## Working points for the 80X training
 ###########################################################
 full_80x_chs_wp  = cms.PSet(

--- a/RecoJets/JetProducers/python/PileupJetIDParams_cfi.py
+++ b/RecoJets/JetProducers/python/PileupJetIDParams_cfi.py
@@ -169,6 +169,16 @@ for train in full_106x_UL18_chs.trainings:
     train.tmvaWeights = train.tmvaWeights.value().replace("UL17", "UL18")
 
 ####################################################################################################################
+full_106x_UL16_chs = full_106x_UL17_chs.clone(JetIdParams = full_106x_UL16_chs_wp)
+for train in full_106x_UL16_chs.trainings:
+    train.tmvaWeights = train.tmvaWeights.value().replace("UL17", "UL16")
+
+####################################################################################################################
+full_106x_UL16APV_chs = full_106x_UL17_chs.clone(JetIdParams = full_106x_UL16APV_chs_wp)
+for train in full_106x_UL16APV_chs.trainings:
+    train.tmvaWeights = train.tmvaWeights.value().replace("UL17", "UL16APV")
+
+####################################################################################################################
 full_80x_chs = cms.PSet(
         impactParTkThreshold = cms.double(1.),
         cutBased = cms.bool(False),

--- a/RecoJets/JetProducers/python/PileupJetID_cfi.py
+++ b/RecoJets/JetProducers/python/PileupJetID_cfi.py
@@ -3,6 +3,7 @@ from Configuration.ProcessModifiers.run2_miniAOD_UL_cff import run2_miniAOD_UL
 from Configuration.Eras.Modifier_run2_miniAOD_devel_cff import run2_miniAOD_devel
 from Configuration.Eras.Modifier_run2_jme_2017_cff import run2_jme_2017
 from Configuration.Eras.Modifier_run2_jme_2016_cff import run2_jme_2016
+from Configuration.Eras.Modifier_tracker_apv_vfp30_2016_cff import tracker_apv_vfp30_2016
 from RecoJets.JetProducers.PileupJetIDParams_cfi import *
 
 #_stdalgos_4x = cms.VPSet(full,   cutbased,PhilV1)
@@ -18,6 +19,8 @@ _chsalgos_94x = cms.VPSet(full_94x_chs,cutbased)
 _chsalgos_102x = cms.VPSet(full_102x_chs,cutbased)
 _chsalgos_106X_UL17 = cms.VPSet(full_106x_UL17_chs,cutbased)
 _chsalgos_106X_UL18 = cms.VPSet(full_106x_UL18_chs,cutbased)
+_chsalgos_106X_UL16 = cms.VPSet(full_106x_UL16_chs,cutbased)
+_chsalgos_106X_UL16APV = cms.VPSet(full_106x_UL16APV_chs,cutbased)
 
 _stdalgos    = _chsalgos_81x
 
@@ -39,6 +42,8 @@ pileupJetId = cms.EDProducer('PileupJetIdProducer',
 )
 run2_miniAOD_UL.toModify(pileupJetId, algos = _chsalgos_106X_UL17)
 (run2_miniAOD_devel & (~run2_jme_2016) & (~run2_jme_2017)).toModify(pileupJetId, algos = _chsalgos_106X_UL18)
+(run2_miniAOD_devel & run2_jme_2016 & ~tracker_apv_vfp30_2016).toModify(pileupJetId, algos = _chsalgos_106X_UL16)
+(run2_miniAOD_devel & run2_jme_2016 & tracker_apv_vfp30_2016).toModify(pileupJetId, algos = _chsalgos_106X_UL16APV)
 
 # Calculate variables, but don't run MVAs
 pileupJetIdCalculator = pileupJetId.clone(


### PR DESCRIPTION
#### PR description:
- This PR is a backport to 10_6_X release cycle.
- The original PR #33857 is already merged into master
- Changes similar to #32872, allowing use of new UL16(APV) training via `run2_miniAOD_devel`
- Also need backport of merged https://github.com/cms-data/RecoJets-JetProducers/pull/13 (V05-14-00) into cmsdist

#### PR validation:
- passes basic tests
- test with https://github.com/cms-data/RecoJets-JetProducers/pull/13

FYI: @alefisico @camclean @marinakolosova @mariadalfonso 
