### PR TITLE
do not print SiStrip O2O passwords in dbParams_

### DIFF
--- a/OnlineDB/SiStripConfigDb/src/SiStripDbParams.cc
+++ b/OnlineDB/SiStripConfigDb/src/SiStripDbParams.cc
@@ -311,7 +311,7 @@ void SiStripDbParams::print(std::stringstream& ss) const {
 
   if (!usingDbCache_) {
     if (usingDb_) {
-      ss << " Database account (ConfDb)  : " << confdb_ << std::endl;
+      ss << " Database account (ConfDb)  : " << user_ + "/******@" + path_ << std::endl;
     }
 
     ss << " Number of partitions       : " << partitions_.size();


### PR DESCRIPTION
#### PR description:

Addition to "do not print SiStrip O2O passwords in clear" #33900

prevents SiStripConfigDb.cc (https://github.com/cms-sw/cmssw/blob/CMSSW_12_0_DEVEL_X/OnlineDB/SiStripConfigDb/src/SiStripConfigDb.cc#L124) from printing password

#### PR validation:

It compiles

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

backport of #33947