### PR TITLE
add missing JetReco dependency to DataFormats/L1TParticleFlow

### DIFF
--- a/DataFormats/L1TParticleFlow/BuildFile.xml
+++ b/DataFormats/L1TParticleFlow/BuildFile.xml
@@ -4,6 +4,7 @@
 <use name="DataFormats/Common"/>
 <use name="DataFormats/L1TCorrelator"/>
 <use name="FWCore/Utilities"/>
+<use name="DataFormats/JetReco"/>
 <use name="rootrflx"/>
 
 <export>

--- a/L1Trigger/L1THGCalUtilities/BuildFile.xml
+++ b/L1Trigger/L1THGCalUtilities/BuildFile.xml
@@ -1,6 +1,9 @@
 <use name="FWCore/Framework"/>
 <use name="DataFormats/Common"/>
 <use name="DataFormats/L1THGCal"/>
+<use name="FWCore/ParameterSet"/>
+<use name="FWCore/PluginManager"/>
+<use name="SimDataFormats/CaloAnalysis"/>
 <export>
   <lib name="1"/>
 </export>


### PR DESCRIPTION
adds missing dependency as noticed by the modules IB..