### PR TITLE
Removed ParameterSet usage from CondFormats/EcalObjects

### DIFF
--- a/CondFormats/EcalObjects/interface/EcalMultifitParametersGPU.h
+++ b/CondFormats/EcalObjects/interface/EcalMultifitParametersGPU.h
@@ -3,7 +3,6 @@
 
 #include <array>
 
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/propagate_const_array.h"
 #include "HeterogeneousCore/CUDAUtilities/interface/device_unique_ptr.h"
 
@@ -22,7 +21,10 @@ public:
   };
 
 #ifndef __CUDACC__
-  EcalMultifitParametersGPU(edm::ParameterSet const&);
+  EcalMultifitParametersGPU(std::vector<double> const& amplitudeEB,
+                            std::vector<double> const& amplitudeEE,
+                            std::vector<double> const& timeEB,
+                            std::vector<double> const& timeEE);
 
   ~EcalMultifitParametersGPU() = default;
 

--- a/CondFormats/EcalObjects/interface/EcalRecHitParametersGPU.h
+++ b/CondFormats/EcalObjects/interface/EcalRecHitParametersGPU.h
@@ -3,7 +3,6 @@
 
 #include <array>
 
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/propagate_const_array.h"
 #include "HeterogeneousCore/CUDAUtilities/interface/device_unique_ptr.h"
 
@@ -22,11 +21,19 @@ public:
   };
 
 #ifndef __CUDACC__
-  EcalRecHitParametersGPU(edm::ParameterSet const &);
+  struct DBStatus {
+    DBStatus(int flag, std::vector<uint32_t> status) : recoflagbit{flag}, dbstatus(std::move(status)) {}
+    int recoflagbit;                 //must be a EcalRecHit::Flags
+    std::vector<uint32_t> dbstatus;  //must contain EcalChannelStatusCode::Code
+  };
+
+  /// channelStatusToBeExcluded must contain EcalChannelStatusCode::Code
+  EcalRecHitParametersGPU(std::vector<int> const& channelStatusToBeExcluded,
+                          std::vector<DBStatus> const& flagsMapDBReco);
 
   ~EcalRecHitParametersGPU() = default;
 
-  Product const &getProduct(cudaStream_t) const;
+  Product const& getProduct(cudaStream_t) const;
 
   using intvec = std::reference_wrapper<std::vector<int, cms::cuda::HostAllocator<int>> const>;
   using uint32vec = std::reference_wrapper<std::vector<uint32_t, cms::cuda::HostAllocator<uint32_t>> const>;

--- a/CondFormats/EcalObjects/interface/EcalSRSettings.h
+++ b/CondFormats/EcalObjects/interface/EcalSRSettings.h
@@ -14,8 +14,6 @@
 #include <string>
 #include <ostream>
 
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
-
 /** Class to hold ECAL Selective readout settings.
  * Up to CMSSW release 3.8.X, selective readout emulation settings was done from
  * CMSSW configuration file. From 3.8.X configuration is stored in condition database.

--- a/CondFormats/EcalObjects/src/EcalMultifitParametersGPU.cc
+++ b/CondFormats/EcalObjects/src/EcalMultifitParametersGPU.cc
@@ -3,12 +3,10 @@
 #include "FWCore/Utilities/interface/typelookup.h"
 #include "HeterogeneousCore/CUDAUtilities/interface/copyAsync.h"
 
-EcalMultifitParametersGPU::EcalMultifitParametersGPU(edm::ParameterSet const& ps) {
-  auto const& amplitudeFitParametersEB = ps.getParameter<std::vector<double>>("EBamplitudeFitParameters");
-  auto const& amplitudeFitParametersEE = ps.getParameter<std::vector<double>>("EEamplitudeFitParameters");
-  auto const& timeFitParametersEB = ps.getParameter<std::vector<double>>("EBtimeFitParameters");
-  auto const& timeFitParametersEE = ps.getParameter<std::vector<double>>("EEtimeFitParameters");
-
+EcalMultifitParametersGPU::EcalMultifitParametersGPU(std::vector<double> const& amplitudeFitParametersEB,
+                                                     std::vector<double> const& amplitudeFitParametersEE,
+                                                     std::vector<double> const& timeFitParametersEB,
+                                                     std::vector<double> const& timeFitParametersEE) {
   amplitudeFitParametersEB_.resize(amplitudeFitParametersEB.size());
   amplitudeFitParametersEE_.resize(amplitudeFitParametersEE.size());
   timeFitParametersEB_.resize(timeFitParametersEB.size());

--- a/RecoLocalCalo/EcalRecProducers/plugins/EcalMultifitParametersGPUESProducer.cc
+++ b/RecoLocalCalo/EcalRecProducers/plugins/EcalMultifitParametersGPUESProducer.cc
@@ -72,7 +72,11 @@ void EcalMultifitParametersGPUESProducer::fillDescriptions(edm::ConfigurationDes
 
 std::unique_ptr<EcalMultifitParametersGPU> EcalMultifitParametersGPUESProducer::produce(
     JobConfigurationGPURecord const&) {
-  return std::make_unique<EcalMultifitParametersGPU>(pset_);
+  return std::make_unique<EcalMultifitParametersGPU>(
+      pset_.getParameter<std::vector<double>>("EBamplitudeFitParameters"),
+      pset_.getParameter<std::vector<double>>("EEamplitudeFitParameters"),
+      pset_.getParameter<std::vector<double>>("EBtimeFitParameters"),
+      pset_.getParameter<std::vector<double>>("EEtimeFitParameters"));
 }
 
 DEFINE_FWK_EVENTSETUP_SOURCE(EcalMultifitParametersGPUESProducer);


### PR DESCRIPTION
#### PR description:

The ParameterSet are now handled by the ES modules.

#### PR validation:

The code compiles.