### PR TITLE
add BeamSpot workflows to Calibration/TkAlCaRecoProducers unit test

### DIFF
--- a/Calibration/TkAlCaRecoProducers/test/parseFwkJobReport.py
+++ b/Calibration/TkAlCaRecoProducers/test/parseFwkJobReport.py
@@ -3,12 +3,13 @@ import xml.etree.ElementTree as ET
 import sys
 
 ## declare all constants here
-TARGET_LIST_OF_TAGS=['SiPixelQualityFromDbRcd_other', 'SiPixelQualityFromDbRcd_prompt', 'SiPixelQualityFromDbRcd_stuckTBM', 
+TARGET_LIST_OF_TAGS=['BeamSpotObject_ByLumi', 'BeamSpotObject_ByRun', 'BeamSpotObjectHP_ByLumi', 'BeamSpotObjectHP_ByRun',
+                     'SiPixelQualityFromDbRcd_other', 'SiPixelQualityFromDbRcd_prompt', 'SiPixelQualityFromDbRcd_stuckTBM',
                      'SiStripApvGain_pcl', 'SiStripApvGainAAG_pcl',
                      'SiStripBadStrip_pcl', 'SiPixelAli_pcl']
 TARGET_DQM_FILES=1
 TARGET_DQM_FILENAME='./DQM_V0001_R000325022__Express__PCLTest__ALCAPROMPT.root'
-TARGET_DB_FILES=7
+TARGET_DB_FILES=11
 TARGET_DB_FILENAME='sqlite_file:promptCalibConditions.db'
 TOTAL_TARGET_FILES=TARGET_DQM_FILES+TARGET_DB_FILES
 
@@ -47,16 +48,19 @@ def parseXML(xmlfile):
                 listOfInputTags.append(child.attrib['Value'])
 
     if(countDBfiles!=TARGET_DB_FILES):
-        print("ERROR! Found a not expected number of DB files",countDBfiles)
+        print("ERROR! Found an unexpected number of DB files (",countDBfiles,")")
         return -1
 
     if(countDQMfiles!=TARGET_DQM_FILES):
-        print("ERROR! Found a not expected number of DQM files",countDQMfiles)
+        print("ERROR! Found an uexpected number of DQM files (",countDQMfiles,")")
         return -1
 
     ## That's strict! 
     if(listOfInputTags!=TARGET_LIST_OF_TAGS):
-        print("ERROR! This ",[x for x in listOfTags if x not in listOfInputTags]," is the set of different tags")
+        if (listOfInputTags>TARGET_LIST_OF_TAGS):
+            print("ERROR!\n This ",[x for x in TARGET_LIST_OF_TAGS if x not in listOfInputTags]," is the set of expected tags not found in the FwdJobReport!")
+        else:
+            print("ERROR!\n This ",[x for x in listOfInputTags if x not in TARGET_LIST_OF_TAGS]," is the set of tags found in the FwkJobReport, but not expected!")
         return -1
     
     return 0
@@ -66,7 +70,7 @@ def main():
     try:
         f = open("FrameworkJobReport.xml")
     except IOError:
-        print("File not accessible")
+        print("FrameworkJobReport.xml is not accessible")
         sys.exit(1)
 
     # parse xml file

--- a/Calibration/TkAlCaRecoProducers/test/testPCLAlCaHarvesting.py
+++ b/Calibration/TkAlCaRecoProducers/test/testPCLAlCaHarvesting.py
@@ -74,17 +74,32 @@ process.maxEvents = cms.untracked.PSet(
     input = cms.untracked.int32(1)
 )
 
+##
+## Define the tags to write
+##
 process.PoolDBOutputService.toPut.append(process.ALCAHARVESTSiStripQuality_dbOutput)
 process.PoolDBOutputService.toPut.append(process.ALCAHARVESTSiStripGains_dbOutput)
 process.PoolDBOutputService.toPut.append(process.ALCAHARVESTSiStripGainsAAG_dbOutput )
 process.PoolDBOutputService.toPut.append(process.ALCAHARVESTSiPixelAli_dbOutput)
 process.PoolDBOutputService.toPut.extend(process.ALCAHARVESTSiPixelQuality_dbOutput)
+process.PoolDBOutputService.toPut.append(process.ALCAHARVESTBeamSpotByRun_dbOutput)
+process.PoolDBOutputService.toPut.append(process.ALCAHARVESTBeamSpotByLumi_dbOutput)
+process.PoolDBOutputService.toPut.append(process.ALCAHARVESTBeamSpotHPByRun_dbOutput)
+process.PoolDBOutputService.toPut.append(process.ALCAHARVESTBeamSpotHPByLumi_dbOutput)
 
+##
+## Define the file metadatas
+##
 process.pclMetadataWriter.recordsToMap.append(process.ALCAHARVESTSiStripQuality_metadata)
 process.pclMetadataWriter.recordsToMap.append(process.ALCAHARVESTSiStripGains_metadata )
 process.pclMetadataWriter.recordsToMap.append(process.ALCAHARVESTSiStripGainsAAG_metadata)
 process.pclMetadataWriter.recordsToMap.append(process.ALCAHARVESTSiPixelAli_metadata)
 process.pclMetadataWriter.recordsToMap.extend(process.ALCAHARVESTSiPixelQuality_metadata)
+process.pclMetadataWriter.recordsToMap.append(process.ALCAHARVESTBeamSpotByRun_metadata)
+process.pclMetadataWriter.recordsToMap.append(process.ALCAHARVESTBeamSpotByLumi_metadata)
+process.pclMetadataWriter.recordsToMap.append(process.ALCAHARVESTBeamSpotHPByRun_metadata)
+process.pclMetadataWriter.recordsToMap.append(process.ALCAHARVESTBeamSpotHPByLumi_metadata)
+
 
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 from Configuration.AlCa.GlobalTag import GlobalTag
@@ -94,22 +109,39 @@ process.SiStripQuality  = cms.Path(process.ALCAHARVESTSiStripQuality)
 process.alcaSiStripQualityHarvester.CalibrationThreshold = cms.untracked.uint32(0)
 
 process.SiStripGains    = cms.Path(process.ALCAHARVESTSiStripGains)
-#process.alcaSiStripGainsHarvester.
+process.alcaSiStripGainsHarvester.DQMdir=''
+process.alcaSiStripGainsHarvester.minNrEntries=0
+process.alcaSiStripGainsHarvester.GoodFracForTagProd=0
+process.alcaSiStripGainsHarvester.NClustersForTagProd=0
 
 process.SiStripGainsAAG = cms.Path(process.ALCAHARVESTSiStripGainsAAG)
-#process.alcaSiStripGainsAAGHarvester.
+process.alcaSiStripGainsAAGHarvester.minNrEntries=0
+process.alcaSiStripGainsAAGHarvester.minNrEntries=0
+process.alcaSiStripGainsAAGHarvester.GoodFracForTagProd=0
+process.alcaSiStripGainsAAGHarvester.NClustersForTagProd=0
 
 process.SiPixelAli      = cms.Path(process.ALCAHARVESTSiPixelAli)
+process.SiPixelAliMilleFileExtractor.outputBinaryFile = cms.string('')
+process.SiPixelAliPedeAlignmentProducer.algoConfig.mergeBinaryFiles=[]
 
 process.SiPixelQuality  = cms.Path(process.ALCAHARVESTSiPixelQuality)
 
 process.ALCAHARVESTDQMSaveAndMetadataWriter = cms.Path(process.dqmSaver+process.pclMetadataWriter)
+
+process.BeamSpotByRun  = cms.Path(process.ALCAHARVESTBeamSpotByRun)
+process.BeamSpotByLumi = cms.Path(process.ALCAHARVESTBeamSpotByLumi)
+process.BeamSpotHPByRun  = cms.Path(process.ALCAHARVESTBeamSpotHPByRun)
+process.BeamSpotHPByLumi = cms.Path(process.ALCAHARVESTBeamSpotHPByLumi)
 
 process.schedule = cms.Schedule(process.SiStripQuality,
                                 process.SiStripGains,    
                                 process.SiStripGainsAAG, 
                                 process.SiPixelAli,      
                                 process.SiPixelQuality,
+                                process.BeamSpotByRun,
+                                process.BeamSpotByLumi,
+                                process.BeamSpotHPByRun,
+                                process.BeamSpotHPByLumi,
                                 process.ALCAHARVESTDQMSaveAndMetadataWriter)
 
 from PhysicsTools.PatAlgos.tools.helpers import associatePatAlgosToolsTask


### PR DESCRIPTION
#### PR description:

This is a follow-up of PR https://github.com/cms-sw/cmssw/pull/33880 in which a unit test for the AlCaHarvesting / PCLMetadataWriter was adeed.
The BeamSpot workflows are added to the test and some more refinements to the configuration are added.

#### PR validation:

Run the modified unit tests.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Not a backport, no backport is needed.