### PR TITLE
[Backport] Adding Xi-tracks to lostTracks to 10_6_X

### DIFF
--- a/PhysicsTools/PatAlgos/plugins/PATLostTracks.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATLostTracks.cc
@@ -70,6 +70,8 @@ namespace pat {
     const double maxDxySigForNotReconstructedPrimary_;
     const bool useLegacySetup_;
     const bool fillLostInnerHits_;
+    const bool xiSelection_;
+    const double xiMassCut_;
   };
 }  // namespace pat
 
@@ -104,7 +106,9 @@ pat::PATLostTracks::PATLostTracks(const edm::ParameterSet& iConfig)
       maxDxySigForNotReconstructedPrimary_(iConfig.getParameter<edm::ParameterSet>("pvAssignment")
                                                .getParameter<double>("maxDxySigForNotReconstructedPrimary")),
       useLegacySetup_(iConfig.getParameter<bool>("useLegacySetup")),
-      fillLostInnerHits_(iConfig.getParameter<bool>("fillLostInnerHits")) {
+      fillLostInnerHits_(iConfig.getParameter<bool>("fillLostInnerHits")),
+      xiSelection_(iConfig.getParameter<bool>("xiSelection")),
+      xiMassCut_(iConfig.getParameter<double>("xiMassCut")) {
   std::vector<std::string> trkQuals(iConfig.getParameter<std::vector<std::string>>("qualsToAutoAccept"));
   std::transform(
       trkQuals.begin(), trkQuals.end(), std::back_inserter(qualsToAutoAccept_), reco::TrackBase::qualityByName);
@@ -194,10 +198,28 @@ void pat::PATLostTracks::produce(edm::StreamID, edm::Event& iEvent, const edm::E
     }
   }
   for (const auto& v0 : *lambdas) {
+    double protonCharge = 0;
     for (size_t dIdx = 0; dIdx < v0.numberOfDaughters(); dIdx++) {
       size_t key = (dynamic_cast<const reco::RecoChargedCandidate*>(v0.daughter(dIdx)))->track().key();
       if (trkStatus[key] == TrkStatus::NOTUSED)
         trkStatus[key] = TrkStatus::VTX;
+      if (xiSelection_)
+        protonCharge += v0.daughter(dIdx)->charge() * v0.daughter(dIdx)->momentum().mag2();
+    }
+    if (xiSelection_) {
+      // selecting potential Xi- -> Lambda pi candidates
+      math::XYZTLorentzVector p4Lambda(v0.px(), v0.py(), v0.pz(), sqrt(v0.momentum().mag2() + v0.mass() * v0.mass()));
+
+      for (unsigned int trkIndx = 0; trkIndx < tracks->size(); trkIndx++) {
+        reco::TrackRef trk(tracks, trkIndx);
+        if ((*trk).charge() * protonCharge < 0 || trkStatus[trkIndx] != TrkStatus::NOTUSED)
+          continue;
+
+        math::XYZTLorentzVector p4pi(
+            trk->px(), trk->py(), trk->pz(), sqrt(trk->momentum().mag2() + 0.01947995518));  // pion mass ^2
+        if ((p4Lambda + p4pi).M() < xiMassCut_)
+          trkStatus[trkIndx] = TrkStatus::VTX;  // selecting potential Xi- candidates
+      }
     }
   }
   std::vector<int> mapping(tracks->size(), -1);

--- a/PhysicsTools/PatAlgos/plugins/PATLostTracks.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATLostTracks.cc
@@ -203,8 +203,7 @@ void pat::PATLostTracks::produce(edm::StreamID, edm::Event& iEvent, const edm::E
       size_t key = (dynamic_cast<const reco::RecoChargedCandidate*>(v0.daughter(dIdx)))->track().key();
       if (trkStatus[key] == TrkStatus::NOTUSED)
         trkStatus[key] = TrkStatus::VTX;
-      if (xiSelection_)
-        protonCharge += v0.daughter(dIdx)->charge() * v0.daughter(dIdx)->momentum().mag2();
+      protonCharge += v0.daughter(dIdx)->charge() * v0.daughter(dIdx)->momentum().mag2();
     }
     if (xiSelection_) {
       // selecting potential Xi- -> Lambda pi candidates

--- a/PhysicsTools/PatAlgos/python/slimming/lostTracks_cfi.py
+++ b/PhysicsTools/PatAlgos/python/slimming/lostTracks_cfi.py
@@ -24,7 +24,9 @@ lostTracks = cms.EDProducer("PATLostTracks",
     allowMuonId = cms.bool(False),
     pvAssignment = primaryVertexAssociation.assignment,
     useLegacySetup = cms.bool(True),
-    fillLostInnerHits = cms.bool(False)
+    fillLostInnerHits = cms.bool(False),
+    xiSelection = cms.bool(False),
+    xiMassCut = cms.double(1.5)
 )
 from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
 phase1Pixel.toModify(lostTracks, covarianceVersion =1 )
@@ -36,4 +38,4 @@ from Configuration.Eras.Modifier_bParking_cff import bParking
 bParking.toModify(lostTracks, fillLostInnerHits = True)
 
 from Configuration.Eras.Modifier_run2_miniAOD_devel_cff import run2_miniAOD_devel
-(bParking | run2_miniAOD_devel).toModify(lostTracks, minPtToStoreLowQualityProps = 0.0)
+(bParking | run2_miniAOD_devel).toModify(lostTracks, minPtToStoreLowQualityProps = 0.0, xiSelection = True)


### PR DESCRIPTION
#### PR description:

This is a backport of #33891. The same results apply.

#### PR validation:

All tests run. Given no `bParking` wf is included (AFAIK) in the recommended test, the `1304.181`has been tested (successfully). See results [here](https://adiflori.web.cern.ch/adiflori/lostTracks_pr_106X/).

Would add the `1304.181` to the cmsbuild tests.