### PR TITLE
Cleaning digitizer config file

### DIFF
--- a/SimGeneral/MixingModule/python/digitizers_cfi.py
+++ b/SimGeneral/MixingModule/python/digitizers_cfi.py
@@ -105,13 +105,11 @@ theDigitizersValid = cms.PSet(theDigitizers)
 theDigitizers.mergedtruth.select.signalOnlyTP = True
 
 from Configuration.ProcessModifiers.run3_ecalclustering_cff import run3_ecalclustering
-(run3_ecalclustering | phase2_hgcal).toModify( theDigitizersValid,
-                       calotruth = cms.PSet( caloParticles ) )
-(premix_stage2 & phase2_hgcal).toModify(theDigitizersValid, calotruth = dict(premixStage1 = True))
+run3_ecalclustering.toModify( theDigitizersValid, 
+                              calotruth = cms.PSet( caloParticles ) )
 
 phase2_timing.toModify( theDigitizersValid.mergedtruth,
                         createInitialVertexCollection = cms.bool(True) )
-
 
 from Configuration.ProcessModifiers.premix_stage1_cff import premix_stage1
 def _customizePremixStage1(mod):


### PR DESCRIPTION
#### PR description:
This PR is to clean up the redundant config, following the suggestion in
https://github.com/cms-sw/cmssw/pull/33847

#### PR validation:
Get proper cmsDriver(s) when use
runTheMatrix.py --what upgrade -l 23234.0,23234.21,23434.21,23434.9921 --dryRun

#### if this PR is a backport please specify the original PR and why you need to backport that PR:
Not a backport, and no need of backport. 11_3 is fine as is.
