### PR TITLE
CSCRawToDigi the examiner related fixes. CMSSW_11_3_X_backport of PR#33955

### DIFF
--- a/EventFilter/CSCRawToDigi/src/CSCDCCExaminer.cc
+++ b/EventFilter/CSCRawToDigi/src/CSCDCCExaminer.cc
@@ -661,7 +661,7 @@ int32_t CSCDCCExaminer::check(const uint16_t*& buffer, int32_t length) {
         bCHAMB_PAYLOAD[currentChamber] |= (buf0[0] & 0x007f) << 7;           /// CFEBs DAV
         bCHAMB_PAYLOAD[currentChamber] |= (buf_1[2] & 0x001f);               /// CFEBs Active 5
         bCHAMB_PAYLOAD[currentChamber] |= ((buf_1[2] >> 5) & 0x0003) << 14;  /// CFEBs Active 6,7
-        bCHAMB_STATUS[currentChamber] |= (buf0[0] & 0x0080) << 15;           /// CLCT-DAV-Mismatch
+        bCHAMB_STATUS[currentChamber] |= (buf0[0] & 0x0080) << 14;           /// CLCT-DAV-Mismatch
 
       } else  /// Pre-2013 DMB Format
       {

--- a/EventFilter/CSCRawToDigi/src/CSCDDUEventData.cc
+++ b/EventFilter/CSCRawToDigi/src/CSCDDUEventData.cc
@@ -243,7 +243,7 @@ void CSCDDUEventData::unpack_data(const uint16_t* buf, CSCDCCExaminer* examiner)
       // ++i;
       if (debug)
         LogTrace("CSCDDUEventData|CSCRawToDigi") << "unpack csc data loop started";
-      theData.push_back(CSCEventData(buf));
+      theData.push_back(CSCEventData(buf, theFormatVersion));
       buf += (theData.back()).size();
       if (debug) {
         LogTrace("CSCDDUEventData|CSCRawToDigi") << "size of vector of cscData = " << theData.size();


### PR DESCRIPTION
#### PR description:
Backport of PR #33955 CSCRawToDigi examiner fixes 
- Fixed rare case of CLCT-DAV data corruption error status reporting (discovered during LS2 commissioning).
- Fixed potential issue with running of the CSC unpacker in the (not-recommended and generally not used in the production environment) mode with disabled event data examiner, which could result in the unpacker switching to the old data format

#### PR validation:
Code compiles and runs with test data

#### if this PR is a backport please specify the original PR and why you need to backport that PR:
Backport of PR #33955 for upcoming MWGRs

