### PR TITLE
Remove explicit L2MuonProducer_cfi

### DIFF
--- a/RecoMuon/L2MuonProducer/python/L2MuonProducer_cfi.py
+++ b/RecoMuon/L2MuonProducer/python/L2MuonProducer_cfi.py
@@ -1,6 +1,0 @@
-import FWCore.ParameterSet.Config as cms
-
-# this file is deprecated! Use the one below
-from RecoMuon.L2MuonProducer.L2Muons_cff import *
-
-


### PR DESCRIPTION
#### PR description:

Remove explicit  L2MuonProducer_cfi: that file was already obsolete (and had the same name as the one implicitly created by the fillDescription method of the producer), and after #33563 got merged it risked to create a cyclic dependences, see https://github.com/cms-sw/cmssw/pull/33563#issuecomment-853637226 

#### PR validation:

It builds