### PR TITLE
GE2/1 digi and rechit validation plots only in phase2 eras

### DIFF
--- a/Validation/MuonGEMDigis/python/PostProcessor_cff.py
+++ b/Validation/MuonGEMDigis/python/PostProcessor_cff.py
@@ -5,7 +5,11 @@ from Validation.MuonGEMHits.MuonGEMCommonParameters_cfi import GEMValidationComm
 gemDigiHarvesting = DQMEDHarvester("MuonGEMDigisHarvestor",
     GEMValidationCommonParameters,
     regionIds = cms.untracked.vint32(-1, 1),
-    stationIds = cms.untracked.vint32(1, 2),
+    stationIds = cms.untracked.vint32(1),
     layerIds = cms.untracked.vint32(1, 2, 3, 4, 5, 6),
 )
+
 MuonGEMDigisPostProcessors = cms.Sequence(gemDigiHarvesting)
+
+from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
+phase2_common.toModify( gemDigiHarvesting, stationIds = (1, 2) )

--- a/Validation/MuonGEMRecHits/python/PostProcessor_cff.py
+++ b/Validation/MuonGEMRecHits/python/PostProcessor_cff.py
@@ -5,9 +5,11 @@ from Validation.MuonGEMHits.MuonGEMCommonParameters_cfi import GEMValidationComm
 gemRecHitHarvesting = DQMEDHarvester("MuonGEMRecHitsHarvestor",
     GEMValidationCommonParameters,
     regionIds = cms.untracked.vint32(-1, 1),
-    stationIds = cms.untracked.vint32(1, 2),
+    stationIds = cms.untracked.vint32(1),
     layerIds = cms.untracked.vint32(1, 2, 3, 4, 5, 6),
 )
 
+MuonGEMRecHitsPostProcessors = cms.Sequence( gemRecHitHarvesting )
 
-MuonGEMRecHitsPostProcessors = cms.Sequence( gemRecHitHarvesting ) 
+from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
+phase2_common.toModify( gemRecHitHarvesting, stationIds = (1, 2) )


### PR DESCRIPTION
#### PR description:

While working on a different PR I noticed that WF 11634.0 and others print a lot of logerrors related to GE2/1. This should not be happening. E.g.

```
%MSG-e MuonGEMDigisHarvestor:   MuonGEMDigisHarvestor:gemDigiHarvesting@endProcessBlock  03-Jun-2021 15:06:00 CDT post-events
failed to get MuonGEMDigisV/GEMDigisTask/Pad/Occupancy/matched_pad_occ_eta_GE-21_L1
%MSG
...
%MSG-e MuonGEMDigisHarvestor:   MuonGEMDigisHarvestor:gemDigiHarvesting@endProcessBlock  03-Jun-2021 15:06:00 CDT post-events
failed to get MuonGEMDigisV/GEMDigisTask/PadCluster/Occupancy/matched_pad_occ_phi_GE+21_L2
%MSG
...
%MSG-e MuonGEMRecHitsHarvestor:   MuonGEMRecHitsHarvestor:gemRecHitHarvesting@endProcessBlock  03-Jun-2021 15:06:00 CDT post-events
failed to get MuonGEMRecHitsV/GEMRecHitsTask/Occupancy/matched_rechit_occ_phi_GE+21_L2
%MSG
```

This PR should take care of that.

#### PR validation:

Tested in WF 11634.0

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
