### PR TITLE
Temporary eventcontent needed for Phase-2 RECO when RAWSIM is used as input

### DIFF
--- a/Configuration/EventContent/python/EventContent_cff.py
+++ b/Configuration/EventContent/python/EventContent_cff.py
@@ -332,7 +332,8 @@ RAWSIMEventContent.outputCommands.extend(MEtoEDMConverterFEVT.outputCommands)
 RAWSIMEventContent.outputCommands.extend(IOMCRAW.outputCommands)
 RAWSIMEventContent.outputCommands.extend(CommonEventContent.outputCommands)
 #
-# temporary collections needed for Phase-2 RECO using RAWSIM as input
+# Temporary collections needed for Phase-2 RECO using RAWSIM as input in Prod-like workflow
+# They are until packer/unpackers are done.
 #
 from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
 phase2_common.toModify(RAWSIMEventContent,
@@ -721,6 +722,22 @@ PREMIXRAWEventContent.outputCommands.append('keep *_*_MuonCSCStripDigiSimLinks_*
 PREMIXRAWEventContent.outputCommands.append('keep *_*_MuonCSCWireDigiSimLinks_*')
 PREMIXRAWEventContent.outputCommands.append('keep *_*_RPCDigiSimLink_*')
 PREMIXRAWEventContent.outputCommands.append('keep DTLayerIdDTDigiSimLinkMuonDigiCollection_*_*_*')
+#
+# Temporary eventcontent for Prod-Like Phase2 PREMIXRAW. 
+# They are until packer/unpackers are done.
+# 
+(premix_stage2 & phase2_common).toModify(PREMIXRAWEventContent, 
+                                         outputCommands = PREMIXRAWEventContent.outputCommands + [
+                                              'drop *_simSiPixelDigis_*_*',
+                                              'keep *_mixData_Pixel_*',
+                                              'keep *_mixData_Tracker_*',
+                                              'keep *_*_Phase2OTDigiSimLink_*',
+                                              'keep *_*_GEMDigiSimLink_*',
+                                              'keep *_*_GEMStripDigiSimLink_*',
+                                              'keep *_*_ME0DigiSimLink_*',
+                                              'keep *_*_ME0StripDigiSimLink_*'
+                                         ])
+
 #
 #
 ## RAW repacked event content definition

--- a/Configuration/EventContent/python/EventContent_cff.py
+++ b/Configuration/EventContent/python/EventContent_cff.py
@@ -332,6 +332,14 @@ RAWSIMEventContent.outputCommands.extend(MEtoEDMConverterFEVT.outputCommands)
 RAWSIMEventContent.outputCommands.extend(IOMCRAW.outputCommands)
 RAWSIMEventContent.outputCommands.extend(CommonEventContent.outputCommands)
 #
+# temporary collections needed for Phase-2 RECO using RAWSIM as input
+#
+from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
+phase2_common.toModify(RAWSIMEventContent,
+    outputCommands = RAWSIMEventContent.outputCommands+[
+        'keep *_sim*Digis_*_*',
+        'keep *Phase2TrackerDigi*_*_*_*'])
+#
 #
 # RAWSIMHLT Data Tier definition
 #

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -546,9 +546,9 @@ upgradeWFs['PatatrackHCALOnlyGPU'] = PatatrackWorkflow(
 class UpgradeWorkflow_ProdLike(UpgradeWorkflow):
     def setup_(self, step, stepName, stepDict, k, properties):
         if 'GenSimHLBeamSpot14' in step:
-            stepDict[stepName][k] = merge([{'--eventcontent': 'RAWSIM', '--datatier': 'GEN-SIM'}])
+            stepDict[stepName][k] = merge([{'--eventcontent': 'RAWSIM', '--datatier': 'GEN-SIM'},stepDict[step][k]])
         elif 'Digi' in step and 'Trigger' not in step:
-            stepDict[stepName][k] = merge([{'-s': 'DIGI,L1,DIGI2RAW,HLT:@relval2021', '--datatier':'GEN-SIM-DIGI-RAW', '--eventcontent':'RAWSIM'}, stepDict[step][k]])
+            stepDict[stepName][k] = merge([{'-s': 'DIGI,L1,DIGI2RAW,HLT:@relval2021', '--datatier':'GEN-SIM-RAW', '--eventcontent':'RAWSIM'}, stepDict[step][k]])
         elif 'DigiTrigger' in step: # for Phase-2
             stepDict[stepName][k] = merge([{'-s': 'DIGI,L1TrackTrigger,L1,DIGI2RAW,HLT:@fake2', '--datatier':'GEN-SIM-DIGI-RAW', '--eventcontent':'RAWSIM'}, stepDict[step][k]])
         elif 'Reco' in step:

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -545,10 +545,12 @@ upgradeWFs['PatatrackHCALOnlyGPU'] = PatatrackWorkflow(
 
 class UpgradeWorkflow_ProdLike(UpgradeWorkflow):
     def setup_(self, step, stepName, stepDict, k, properties):
-        if 'Digi' in step and 'Trigger' not in step:
+        if 'GenSimHLBeamSpot14' in step:
+            stepDict[stepName][k] = merge([{'--eventcontent': 'RAWSIM', '--datatier': 'GEN-SIM'}])
+        elif 'Digi' in step and 'Trigger' not in step:
             stepDict[stepName][k] = merge([{'-s': 'DIGI,L1,DIGI2RAW,HLT:@relval2021', '--datatier':'GEN-SIM-DIGI-RAW', '--eventcontent':'RAWSIM'}, stepDict[step][k]])
         elif 'DigiTrigger' in step: # for Phase-2
-            stepDict[stepName][k] = merge([{'-s': 'DIGI,L1TrackTrigger,L1,DIGI2RAW,HLT:@fake2'}, stepDict[step][k]])
+            stepDict[stepName][k] = merge([{'-s': 'DIGI,L1TrackTrigger,L1,DIGI2RAW,HLT:@fake2', '--datatier':'GEN-SIM-DIGI-RAW', '--eventcontent':'RAWSIM'}, stepDict[step][k]])
         elif 'Reco' in step:
             stepDict[stepName][k] = merge([{'-s': 'RAW2DIGI,L1Reco,RECO,RECOSIM', '--datatier':'AODSIM', '--eventcontent':'AODSIM'}, stepDict[step][k]])
         elif 'MiniAOD' in step:
@@ -563,6 +565,7 @@ class UpgradeWorkflow_ProdLike(UpgradeWorkflow):
         return fragment=="TTbar_14TeV" and ('2026' in key or '2021' in key)
 upgradeWFs['ProdLike'] = UpgradeWorkflow_ProdLike(
     steps = [
+        'GenSimHLBeamSpot14',
         'Digi',
         'DigiTrigger',
         'Reco',
@@ -574,6 +577,7 @@ upgradeWFs['ProdLike'] = UpgradeWorkflow_ProdLike(
         'Nano',
     ],
     PU = [
+        'GenSimHLBeamSpot14',
         'Digi',
         'DigiTrigger',
         'Reco',

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -550,7 +550,7 @@ class UpgradeWorkflow_ProdLike(UpgradeWorkflow):
         elif 'Digi' in step and 'Trigger' not in step:
             stepDict[stepName][k] = merge([{'-s': 'DIGI,L1,DIGI2RAW,HLT:@relval2021', '--datatier':'GEN-SIM-RAW', '--eventcontent':'RAWSIM'}, stepDict[step][k]])
         elif 'DigiTrigger' in step: # for Phase-2
-            stepDict[stepName][k] = merge([{'-s': 'DIGI,L1TrackTrigger,L1,DIGI2RAW,HLT:@fake2', '--datatier':'GEN-SIM-DIGI-RAW', '--eventcontent':'RAWSIM'}, stepDict[step][k]])
+            stepDict[stepName][k] = merge([{'-s': 'DIGI,L1TrackTrigger,L1,DIGI2RAW,HLT:@fake2', '--datatier':'GEN-SIM-RAW', '--eventcontent':'RAWSIM'}, stepDict[step][k]])
         elif 'Reco' in step:
             stepDict[stepName][k] = merge([{'-s': 'RAW2DIGI,L1Reco,RECO,RECOSIM', '--datatier':'AODSIM', '--eventcontent':'AODSIM'}, stepDict[step][k]])
         elif 'MiniAOD' in step:

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -787,6 +787,8 @@ class UpgradeWorkflowPremix(UpgradeWorkflow):
                 },
                 stepDict[stepName][k]
             ])
+            if "ProdLike" in self.suffix:
+                stepDict[stepNamePmx][k] = merge([{'-s': 'GEN,SIM,DIGI'},stepDict[stepNamePmx][k]])
         # setup for stage 2
         elif "Digi" in step or "Reco" in step:
             # go back to non-PU step version
@@ -923,7 +925,9 @@ class UpgradeWorkflowPremixProdLike(UpgradeWorkflowPremix,UpgradeWorkflow_ProdLi
                     tmpsteps.append("DIGI")
                 else:
                     tmpsteps.append(s)
-            d = merge([{"-s" : ",".join(tmpsteps)},d])
+            d = merge([{"-s" : ",".join(tmpsteps),
+                        "--eventcontent": "PREMIXRAW"},
+                       d])
             stepDict[stepName][k] = d
     def condition(self, fragment, stepList, key, hasHarvest):
         # use both conditions


### PR DESCRIPTION
#### PR description:
Following the discussion in Reconstruction Mattermost, this PR is to introduce a temporary eventcontent needed by Phase-2 prod-like reconstruction step.

In addition, the PR modifies Phase-2 prod-like workflows as follows:

1. Use RAWSIM for GEN-SIM, GEN-SIM-RAW
2. Use PREMIXRAW for premixing stage2
3. Use DIGI instead of DIGI:pdigi_valid for all steps

This PR covers the issue reported https://github.com/cms-sw/cmssw/issues/33172

Note:
It is unclear if we would like to have temporary content in a central place (Configuration/EventContent) as implemented in this PR, or it should be under subsystem eventcontent. This should be agreed upon.

#### PR validation:
Workflow 23234.21,23434.21,23434.9921 run out-of-box with this PR.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:
Not a backport, and no need of backporting.