### PR TITLE
added extra type of dark photon

### DIFF
--- a/SimG4Core/CustomPhysics/data/particle_darkphoton.txt
+++ b/SimG4Core/CustomPhysics/data/particle_darkphoton.txt
@@ -1,4 +1,5 @@
 Block MASS   #
 #  PDG code    mass                 particle
       1072000   0.0                 # darkphoton
+         1023   0.0005              # darkphoton1
 Block

--- a/SimG4Core/CustomPhysics/interface/CMSDarkPairProductionProcess.h
+++ b/SimG4Core/CustomPhysics/interface/CMSDarkPairProductionProcess.h
@@ -32,9 +32,6 @@ public:  // with description
 
   G4double MinPrimaryEnergy(const G4ParticleDefinition*, const G4Material*) override;
 
-  // Print few lines of informations about the process: validity range,
-  void PrintInfo() override;
-
 protected:
   void InitialiseProcess(const G4ParticleDefinition*) override;
 

--- a/SimG4Core/CustomPhysics/src/CMSDarkPairProductionProcess.cc
+++ b/SimG4Core/CustomPhysics/src/CMSDarkPairProductionProcess.cc
@@ -27,7 +27,8 @@ CMSDarkPairProductionProcess::CMSDarkPairProductionProcess(G4double df, const G4
 CMSDarkPairProductionProcess::~CMSDarkPairProductionProcess() {}
 
 G4bool CMSDarkPairProductionProcess::IsApplicable(const G4ParticleDefinition& p) {
-  return (p.GetParticleType() == "darkpho");
+  G4int pdg = std::abs(p.GetPDGEncoding());
+  return (pdg == 1023 || pdg == 1072000);
 }
 
 void CMSDarkPairProductionProcess::InitialiseProcess(const G4ParticleDefinition* p) {
@@ -38,8 +39,6 @@ void CMSDarkPairProductionProcess::InitialiseProcess(const G4ParticleDefinition*
   }
 }
 
-G4double CMSDarkPairProductionProcess::MinPrimaryEnergy(const G4ParticleDefinition*, const G4Material*) {
-  return 2 * electron_mass_c2;
+G4double CMSDarkPairProductionProcess::MinPrimaryEnergy(const G4ParticleDefinition* p, const G4Material*) {
+  return std::max(2 * CLHEP::electron_mass_c2 - p->GetPDGMass(), 0.0);
 }
-
-void CMSDarkPairProductionProcess::PrintInfo() {}

--- a/SimG4Core/CustomPhysics/src/CustomPDGParser.cc
+++ b/SimG4Core/CustomPhysics/src/CustomPDGParser.cc
@@ -39,7 +39,7 @@ bool CustomPDGParser::s_isRGlueball(int pdg) {
 
 bool CustomPDGParser::s_isDphoton(int pdg) {
   int pdgAbs = abs(pdg);
-  return (pdgAbs == 1072000);
+  return (pdgAbs == 1072000) || (pdgAbs == 1023);
 }
 
 bool CustomPDGParser::s_isRMeson(int pdg) {


### PR DESCRIPTION
#### PR description:
To add a backport for the purpose of dark photon signal events central production. According to the request from EXO MC convener, new code in CMSSW_12_0_X is copied with this pull request, and we would like to merge it into CMSSW_10_6_X. 

Files changed based on the CMSSW_12_0_X version:
https://github.com/y19y19/cmssw/blob/41b6e488d8f777b3c0f7b335543be7efb7d9d37a/SimG4Core/CustomPhysics/data/particle_darkphoton.txt#L4
https://github.com/y19y19/cmssw/blob/41b6e488d8f777b3c0f7b335543be7efb7d9d37a/SimG4Core/CustomPhysics/interface/CMSDarkPairProductionProcess.h#L1-L43
https://github.com/y19y19/cmssw/blob/41b6e488d8f777b3c0f7b335543be7efb7d9d37a/SimG4Core/CustomPhysics/src/CMSDarkPairProductionProcess.cc#L1-L44
https://github.com/y19y19/cmssw/blob/41b6e488d8f777b3c0f7b335543be7efb7d9d37a/SimG4Core/CustomPhysics/src/CustomPDGParser.cc#L36

