### PR TITLE
Backport (of  #33966) to 106X: Adding necessary electron structures for low pT part of slimmedElectron collection

### DIFF
--- a/PhysicsTools/PatAlgos/python/slimming/slimmedElectrons_cfi.py
+++ b/PhysicsTools/PatAlgos/python/slimming/slimmedElectrons_cfi.py
@@ -26,3 +26,6 @@ slimmedElectrons = cms.EDProducer("PATElectronSlimmer",
 
 from Configuration.Eras.Modifier_bParking_cff import bParking
 bParking.toModify(slimmedElectrons,dropCorrections="0")
+bParking.toModify(slimmedElectrons,dropIsolations="0")
+bParking.toModify(slimmedElectrons,dropShapes="0")
+bParking.toModify(slimmedElectrons,dropClassifications="0")

--- a/PhysicsTools/PatAlgos/python/slimming/slimmedElectrons_cfi.py
+++ b/PhysicsTools/PatAlgos/python/slimming/slimmedElectrons_cfi.py
@@ -25,7 +25,4 @@ slimmedElectrons = cms.EDProducer("PATElectronSlimmer",
 )
 
 from Configuration.Eras.Modifier_bParking_cff import bParking
-bParking.toModify(slimmedElectrons,dropCorrections="0")
-bParking.toModify(slimmedElectrons,dropIsolations="0")
-bParking.toModify(slimmedElectrons,dropShapes="0")
-bParking.toModify(slimmedElectrons,dropClassifications="0")
+bParking.toModify(slimmedElectrons,dropCorrections="0", dropIsolations="0", dropShapes="0", dropClassifications="0")


### PR DESCRIPTION
This is just a backport of #33966  which adds the needed structures to all the electrons to enable low pT electron analyses using slimmedElectron collection.
Tested on WFs: 136.898 

@bainbrid @cavalari 