### PR TITLE
L1T Phase-2: Recalibrated Phase-2 L1CaloJets Iso Tau variable threshold function 

### DIFF
--- a/L1Trigger/L1CaloTrigger/plugins/L1CaloJetProducer.cc
+++ b/L1Trigger/L1CaloTrigger/plugins/L1CaloJetProducer.cc
@@ -495,9 +495,9 @@ L1CaloJetProducer::L1CaloJetProducer(const edm::ParameterSet &iConfig)
                                   << int(tauCalibrationsHGCal.size()) << "\n";
   }
 
-  isoTauBarrel.SetParameter(0, 0.25);
-  isoTauBarrel.SetParameter(1, 0.85);
-  isoTauBarrel.SetParameter(2, 0.094);
+  isoTauBarrel.SetParameter(0, 0.30);
+  isoTauBarrel.SetParameter(1, 0.31);
+  isoTauBarrel.SetParameter(2, 0.040);
   isoTauHGCal.SetParameter(0, 0.34);
   isoTauHGCal.SetParameter(1, 0.35);
   isoTauHGCal.SetParameter(2, 0.051);


### PR DESCRIPTION

#### PR description:
Recalibrated Phase-2 L1CaloJets Iso Tau variable threshold function to recover efficiency performance from CMSSW_10_6_1_patch2. Details on recalibration studies can be found here [1].

[1] https://indico.cern.ch/event/999184/contributions/4204508/attachments/2178363/3678959/Iso_Tau_Recalibration.pdf

#### PR validation:
Efficiency and rate performance of recalibrated Iso Tau variable in Phase-2 L1CaloJets algorithm was tested on CMSSW_11_1_3 release using updated VBFHiggsTauTau and minBias samples. Details can be found in [1] above.

Backport of https://github.com/cms-l1t-offline/cmssw/pull/875

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Backport of https://github.com/cms-l1t-offline/cmssw/pull/875
