### PR TITLE
update Run2 data and mc GTs with JERC tags

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -16,9 +16,9 @@ autoCond = {
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run2
     'run2_design'                  : '113X_mcRun2_design_v4',
     #GlobalTag for MC production with optimistic alignment and calibrations for 2016, prior to VFP change
-    'run2_mc_pre_vfp'              : '113X_mcRun2_asymptotic_preVFP_v4',
+    'run2_mc_pre_vfp'              : '120X_mcRun2_asymptotic_preVFP_v1',
     #GlobalTag for MC production with optimistic alignment and calibrations for 2016, after VFP change
-    'run2_mc'                      : '113X_mcRun2_asymptotic_v4',
+    'run2_mc'                      : '120X_mcRun2_asymptotic_v1',
     # GlobalTag for MC production (cosmics) with starup-like alignment and calibrations for Run2, Strip tracker in peak mode
     'run2_mc_cosmics'              : '113X_mcRun2cosmics_asymptotic_deco_v4',
     # GlobalTag for MC production (Heavy Ions collisions) with optimistic alignment and calibrations for Run2
@@ -26,11 +26,11 @@ autoCond = {
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2
     'run2_mc_pa'                   : '113X_mcRun2_pA_v4',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'                    : '113X_dataRun2_v6',
+    'run2_data'                    : '120X_dataRun2_v1',
     # GlobalTag for Run2 data 2018B relvals only: HEM-15-16 fail
     'run2_data_HEfail'             : '113X_dataRun2_HEfail_v6',
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
-    'run2_data_relval'             : '113X_dataRun2_relval_v6',
+    'run2_data_relval'             : '120X_dataRun2_relval_v1',
     # GlobalTag for Run2 HI data
     'run2_data_promptlike_hi'      : '113X_dataRun2_PromptLike_HI_v6',
     # GlobalTag for Run3 HLT: it points to the online GT


### PR DESCRIPTION
#### PR description:

This PR is to update the Run2 data and MC GTs with the most up to date JERC tags, as requested in https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/4401.html

These tags were first updated in 106X (PR #33710).

Comparison between the previous GTs (in 113X) and the new ones are below:

**2016 realistic pre-VFP era**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/113X_mcRun2_asymptotic_preVFP_v4/120X_mcRun2_asymptotic_preVFP_v1

**2016 realistic post-VFP era**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/113X_mcRun2_asymptotic_v4/120X_mcRun2_asymptotic_v1

**Offline data**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/113X_dataRun2_v6/120X_dataRun2_v1

**Offline data relval**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/113X_dataRun2_relval_v6/120X_dataRun2_relval_v1


#### PR validation:

runTheMatrix.py -l limited,136.772,136.7721,1325.516,135.1 --ibeos

#### if this PR is a backport please specify the original PR and why you need to backport that PR:
It is not a backport.
