### PR TITLE
Backport of fix for genJetAK8ID matching in fatJetMCTable

### DIFF
--- a/PhysicsTools/NanoAOD/python/jets_cff.py
+++ b/PhysicsTools/NanoAOD/python/jets_cff.py
@@ -699,7 +699,7 @@ subjetMCTable = cms.EDProducer("SimpleCandidateFlatTableProducer",
 
 ### Era dependent customization
 run2_miniAOD_80XLegacy.toModify( genJetFlavourTable, jetFlavourInfos = cms.InputTag("genJetFlavourAssociation"),)
-
+(run2_nanoAOD_106Xv1 & ~run2_nanoAOD_devel).toModify( fatJetMCTable.variables, genJetAK8Idx = Var("?genJetFwdRef().backRef().isNonnull()?genJetFwdRef().backRef().key():-1", int, doc="index of matched gen AK8 jet"))
 from RecoJets.JetProducers.QGTagger_cfi import  QGTagger
 qgtagger=QGTagger.clone(srcJets="updatedJets",srcVertexCollection="offlineSlimmedPrimaryVertices")
 

--- a/PhysicsTools/NanoAOD/python/jets_cff.py
+++ b/PhysicsTools/NanoAOD/python/jets_cff.py
@@ -669,7 +669,7 @@ fatJetMCTable = cms.EDProducer("SimpleCandidateFlatTableProducer",
         nBHadrons = Var("jetFlavourInfo().getbHadrons().size()", "uint8", doc="number of b-hadrons"),
         nCHadrons = Var("jetFlavourInfo().getcHadrons().size()", "uint8", doc="number of c-hadrons"),
         hadronFlavour = Var("hadronFlavour()", int, doc="flavour from hadron ghost clustering"),
-        genJetAK8Idx = Var("?genJetFwdRef().backRef().isNonnull()?genJetFwdRef().backRef().key():-1", int, doc="index of matched gen AK8 jet"),
+        genJetAK8Idx = Var("?genJetFwdRef().backRef().isNonnull() && genJetFwdRef().backRef().pt() > 100.?genJetFwdRef().backRef().key():-1", int, doc="index of matched gen AK8 jet"),
     )
 )
 


### PR DESCRIPTION
PR description:
Fixes issue where the GenJetAK8IDx matching did not match the corresponding GenJetAK8Table id's because of a difference in pT cut between the collections being referenced by the jet tables
[https://hypernews.cern.ch/HyperNews/CMS/get/JetMET/2103.htm](https://hypernews.cern.ch/HyperNews/CMS/get/JetMET/2103.htm)

PR validation:
Validated on file in question in 10_6_19_patch2.
We scanned the file in 10_6_19_patch2 before changes and got the same output Matej saw:
```
[lahay@cmsdev20 src]$ root -l root://cms-xrd-global.cern.ch//store/mc/RunIISummer19UL17NanoAODv2/TTToHadronic_TuneCP5_13TeV-powheg-pythia8/NANOAODSIM/106X_mc2017_realistic_v8-v1/280000/1FA6BD39-B319-C143-92BC-13BC01AF4B89.root
root [0] 
Attaching file root://cms-xrd-global.cern.ch//store/mc/RunIISummer19UL17NanoAODv2/TTToHadronic_TuneCP5_13TeV-powheg-pythia8/NANOAODSIM/106X_mc2017_realistic_v8-v1/280000/1FA6BD39-B319-C143-92BC-13BC01AF4B89.root as _file0...
(TFile *) 0x55a2cf0
root [1] Events->Scan("FatJet_genJetAK8Idx[0]:nGenJetAK8","FatJet_genJetAK8Idx[0]>nGenJetAK8 ")
************************************
*    Row   * FatJet_ge * nGenJetAK *
************************************
*      149 *         2 *         0 *
*      561 *         3 *         2 *
*     2134 *         2 *         1 *
*     2939 *         5 *         3 *
*     9582 *         3 *         0 *
*    11441 *         3 *         2 *
*    16619 *         3 *         2 *
*    17807 *         2 *         0 *
... 
```
After the change, I reproduced a subset of the events using this cmsDriver command:
```
cmsDriver.py --python_filename TOP-RunIISummer19UL17NanoAODv2-00091_1_cfg.py --eventcontent NANOAODSIM --customise Configuration/DataProcessing/Utils.addMonitoring --datatier NANOAODSIM --fileout file:TOP-RunIISummer19UL17NanoAODv2-00091.root --conditions 106X_mc2017_realistic_v8 --step NANO --filein dbs:/TTToHadronic_TuneCP5_13TeV-powheg-pythia8/RunIISummer19UL17MiniAOD-106X_mc2017_realistic_v6-v4/MINIAODSIM --era Run2_2017,run2_nanoAOD_106Xv1 --no_exec --mc -n 100
```
And the resulting output from scanning the file was:
```
[lahay@cmsdev20 src]$ root -l TOP-RunIISummer19UL17NanoAODv2-00091.root 
*** DISPLAY not set, setting it to lxplus734.cern.ch:0.0
root [0] 
Attaching file TOP-RunIISummer19UL17NanoAODv2-00091.root as _file0...
(TFile *) 0x344c970
root [1] Events->Scan("FatJet_genJetAK8Idx[0]:nGenJetAK8","FatJet_genJetAK8Idx[0]>nGenJetAK8 ")
************************************
*    Row   * FatJet_ge * nGenJetAK *
************************************
************************************
==> 0 selected entries
(long long) 0
```
if this PR is a backport please specify the original PR and why you need to backport that PR:
Original PR:
#33839 
Backport requested for production