### PR TITLE
Copy TrackerTopology for SiStripGainsPCLHarvester::dqmEndJob

### DIFF
--- a/CalibTracker/SiStripChannelGain/interface/SiStripGainsPCLHarvester.h
+++ b/CalibTracker/SiStripChannelGain/interface/SiStripGainsPCLHarvester.h
@@ -56,7 +56,6 @@ public:
 
 private:
   virtual void checkBookAPVColls(const edm::EventSetup& setup);
-  virtual void checkAndRetrieveTopology(const edm::EventSetup& setup);
   void dqmEndJob(DQMStore::IBooker& ibooker_, DQMStore::IGetter& igetter_) override;
 
   void gainQualityMonitor(DQMStore::IBooker& ibooker_, const MonitorElement* Charge_Vs_Index) const;
@@ -94,7 +93,7 @@ private:
   int CalibrationLevel;
 
   const TrackerGeometry* bareTkGeomPtr_ = nullptr;  // ugly hack to fill APV colls only once, but checks
-  const TrackerTopology* tTopo_ = nullptr;
+  std::unique_ptr<TrackerTopology> tTopo_;
 
   std::vector<std::shared_ptr<stAPVGain> > APVsCollOrdered;
   std::unordered_map<unsigned int, std::shared_ptr<stAPVGain> > APVsColl;


### PR DESCRIPTION
Closes https://github.com/cms-sw/cmssw/issues/33960

#### PR description:

Copy TrackerTopology as a workaround to use it in dqmEndJob, as suggested by @makortel in https://github.com/cms-sw/cmssw/issues/33960#issuecomment-853861808 (there are no IOVs for TrackerTopology, as far as I know, it only changes between phase0, phase1 and phase2, while this harvester is always run on a few consecutive runs, so that should be safe).
I noticed the same issue in two other strip DQMEDAnalyzers (`SiStripBadComponentInfo` and `SiStripQualityStatistics`), but I need fix another problem for those that will also change the dqmEndJob method, so I'll keep them for a separate PR that addresses both.

#### PR validation:

Compiles and unit tests pass (fixed in ASAN build)

CC: @mmusich 