### PR TITLE
Address warning messages for low-quality 3-layer ALCTs in Phase2 WFs with 12_0_0_pre2

### DIFF
--- a/L1Trigger/CSCTriggerPrimitives/interface/CSCAnodeLCTProcessor.h
+++ b/L1Trigger/CSCTriggerPrimitives/interface/CSCAnodeLCTProcessor.h
@@ -222,14 +222,25 @@ protected:
   //  set the wire hit container
   void setWireContainer(CSCALCTDigi&, CSCALCTDigi::WireContainer& wireHits) const;
 
-  /* This function looks for LCTs on the previous and next wires.  If one
+  /* This function looks for ALCTs on the previous and next wires.  If one
      exists and it has a better quality and a bx_time up to 4 clocks earlier
-     than the present, then the present LCT is cancelled.  The present LCT
+     than the present, then the present ALCT is cancelled.  The present ALCT
      also gets cancelled if it has the same quality as the one on the
      previous wire (this has not been done in 2003 test beam).  The
      cancellation is done separately for collision and accelerator patterns. */
   virtual void ghostCancellationLogic();
 
+  /* In older versions of the ALCT emulation, the ghost cancellation was performed after
+     the ALCTs were found. In December 2018 it became clear that during the study of data
+     and emulation comparison on 2018 data, a small disagreement between data and emulation
+     was found. The changes we implemented then allow re-triggering on one wiregroup after
+     some dead time once an earlier ALCT was constructed built on this wiregroup. Before this
+     commit the ALCT processor would prohibit the wiregroup from triggering in one event after
+     an ALCT was found on that wiregroup. In the firwmare, the wiregroup with ALCT is only dead
+     for a few BX before it can be triggered by next muon. The implementation of ghost cancellation
+     logic wqas changed to accommodate the re-triggering change while the idea of the ghost
+     cancellation logic is kept the same.
+  */
   virtual void ghostCancellationLogicOneWire(const int key_wire, int* ghost_cleared);
 
   virtual int getTempALCTQuality(int temp_quality) const;

--- a/L1Trigger/CSCTriggerPrimitives/interface/CSCUpgradeAnodeLCTProcessor.h
+++ b/L1Trigger/CSCTriggerPrimitives/interface/CSCUpgradeAnodeLCTProcessor.h
@@ -23,8 +23,8 @@ public:
                               unsigned chamber,
                               const edm::ParameterSet& conf);
 
-  /** Default constructor. Used for testing. */
-  CSCUpgradeAnodeLCTProcessor();
+  /** Default destructor. */
+  ~CSCUpgradeAnodeLCTProcessor() override{};
 
 private:
   /* This function looks for LCTs on the previous and next wires.  If one

--- a/L1Trigger/CSCTriggerPrimitives/python/params/alctParams.py
+++ b/L1Trigger/CSCTriggerPrimitives/python/params/alctParams.py
@@ -51,7 +51,7 @@ alctPhase2 = alctPhase1.clone(
 )
 
 alctPhase2GEM = alctPhase2.clone(
-    alctNplanesHitPattern = 3
+    alctNplanesHitPattern = 4
 )
 
 alctPSets = cms.PSet(

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCAnodeLCTProcessor.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCAnodeLCTProcessor.cc
@@ -297,6 +297,18 @@ void CSCAnodeLCTProcessor::run(const std::vector<int> wire[CSCConstants::NUM_LAY
           if (patternDetection(i_wire, hits_in_patterns)) {
             trigger = true;
             int ghost_cleared[2] = {0, 0};
+            /*
+              In older versions of the ALCT emulation, the ghost cancellation was performed after
+              the ALCTs were found. In December 2018 it became clear that during the study of data
+              and emulation comparison on 2018 data, a small disagreement between data and emulation
+              was found. The changes we implemented then allow re-triggering on one wiregroup after
+              some dead time once an earlier ALCT was constructed built on this wiregroup. Before this
+              commit the ALCT processor would prohibit the wiregroup from triggering in one event after
+              an ALCT was found on that wiregroup. In the firwmare, the wiregroup with ALCT is only dead
+              for a few BX before it can be triggered by next muon. The implementation of ghost cancellation
+              logic was changed to accommodate the re-triggering change while the idea of ghost cancellation
+              logic is kept the same.
+            */
             ghostCancellationLogicOneWire(i_wire, ghost_cleared);
 
             int bx = (use_corrected_bx) ? first_bx_corrected[i_wire] : first_bx[i_wire];
@@ -349,6 +361,12 @@ void CSCAnodeLCTProcessor::run(const std::vector<int> wire[CSCConstants::NUM_LAY
 
   // Do the rest only if there is at least one trigger candidate.
   if (trigger) {
+    /* In Run-1 and Run-2, the ghost cancellation was done after the trigger.
+       In the firmware however, the ghost cancellation is done during the trigger
+       on each wiregroup in parallel. For Run-3 and beyond, the ghost cancellation is
+       implemented per wiregroup earlier in the code. See function
+       "ghostCancellationLogicOneWire". Therefore, the line below is commented out.
+    */
     //ghostCancellationLogic();
     lctSearch();
   }

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCUpgradeAnodeLCTProcessor.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCUpgradeAnodeLCTProcessor.cc
@@ -184,9 +184,9 @@ int CSCUpgradeAnodeLCTProcessor::getTempALCTQuality(int temp_quality) const {
   // Quality definition changed on 22 June 2007: it no longer depends
   // on pattern_thresh.
   int Q;
-  // hack to run the Phase-II ME2/1, ME3/1 and ME4/1 ILT
+  // hack to run the Phase-II GE2/1-ME2/1 with 3-layer ALCTs
   if (temp_quality == 3 and runPhase2_ and runME21ILT_ and isME21_)
-    Q = 4;
+    Q = 1;
   else if (temp_quality > 3)
     Q = temp_quality - 3;
   else


### PR DESCRIPTION
#### PR description:

In issue https://github.com/cms-sw/cmssw/issues/33993 @srimanob noted warning messages coming from the LCTQualityControl in Phase-2 workflows. Those are coming from 3-layer ALCTs in ME2/1 where we could match them to GE2/1 trigger primitives. 

This idea was conceived several years ago for the Phase-2 muon upgrade. By lowering the layer threshold in ME2/1 to form an ALCT from 4 to 3, we could recover ALCT inefficiency in certain parts of the ME2/1 chamber where the high voltage is lowered. In the trigger path you could eliminate the pure 3-layer ALCT from the 3-layer ALCTs that have a matching GEM hit to enhance the quality. But in the DAQ path (readout) you would likely see a large increase in data transfer in Phase-2. Those DAQ rates are not well understood. Definitely not considering the new HGCal geometry which may increase ALCT rates in ME2/1. For that reason, it is probably better to increase the threshold for ALCTs in ME2/1 back to 4 (as it was before). It will give us a more realistic picture in the simulation - rather than hopes and dreams. What can be done in the future - something that would be worth studying - is a localized reduction of the threshold from 4 to 3 layers for patterns with wiregroups where the high voltage drops. 

In the mean time, it is best to keep the threshold at 4 layers (even in scenarios with GEMs). The l1 single muon efficiency will drop slightly in the region 1.6 to 2.4 in phase-2 workflows. 

If someone (in their private studies) would like to change it back to 3 layers, I made an improvement in `CSCUpgradeAnodeLCTProcessor ::getTempALCTQuality` so that the warning messages do not appear anymore. The low quality 3-layer ALCTs in ME2/1 when the GE2/1 would be assigned a quality of 1, just like 4-layer ALCTs. 

I also added more documentation on how the ghost cancellation works in the ALCT processor. This is something that will change slightly in the Run-3 emulation, i.e. more similar to the firmware than in Run-1 and Run-2.

#### PR validation:

In CMSSW_12_0_X_2021-06-06-2300 tested with 

```
cmsDriver.py MinBias_14TeV_pythia8_TuneCP5_cfi --conditions auto:phase2_realistic_T21 -n 100 \
--era Phase2C11I13M9 --eventcontent FEVTDEBUG -s GEN,SIM --datatier GEN-SIM \
--beamspot HLLHC14TeV --geometry Extended2026D76 \
--python MinBias_14TeV_pythia8_TuneCP5_2026D76_GenSimHLBeamSpot14.py \
--customise SLHCUpgradeSimulations/Configuration/aging.customise_aging_1000 \
--no_exec --fileout file:minbias.root --nThreads 8 --mc

cmsDriver.py TTbar_14TeV_TuneCP5_cfi --conditions auto:phase2_realistic_T21 -n 10 \
--era Phase2C11I13M9 --eventcontent FEVTDEBUG -s GEN,SIM --datatier GEN-SIM \
--beamspot HLLHC14TeV --geometry Extended2026D76 \
--python TTbar_14TeV_TuneCP5_2026D76_GenSimHLBeamSpot14.py \
--customise SLHCUpgradeSimulations/Configuration/aging.customise_aging_1000 \
--no_exec --fileout file:ttbar.root --nThreads 8 --mc

cmsDriver.py step2 --conditions auto:phase2_realistic_T21 --pileup_input file:minbias.root -n 10 \
--era Phase2C11I13M9 --eventcontent FEVTDEBUGHLT -s DIGI:pdigi_valid,L1TrackTrigger,L1 \
--datatier GEN-SIM-DIGI --pileup AVE_200_BX_25ns --geometry Extended2026D76 \
--io DigiTriggerPU_2026D76PU.io --python DigiTriggerPU_2026D76PU.py \
--customise SLHCUpgradeSimulations/Configuration/aging.customise_aging_1000 \
--no_exec --filein file:ttbar.root --fileout file:step2.root --nThreads 8 --nStreams 1 --mc
```

The last step produced the output
```
Begin processing the 1st record. Run 1, Event 4, LumiSection 1 on stream 0 at 07-Jun-2021 14:36:25.685 CDT
#--------------------------------------------------------------------------
#                         FastJet release 3.4.0-beta.1
#                 M. Cacciari, G.P. Salam and G. Soyez                  
#     A software package for jet finding and analysis at colliders      
#                           http://fastjet.fr                           
#	                                                                      
# Please cite EPJC72(2012)1896 [arXiv:1111.6097] if you use this package
# for scientific work and optionally PLB641(2006)57 [hep-ph/0512210].   
#                                                                       
# FastJet is provided without warranty under the GNU GPL v2 or higher.  
# It uses T. Chan's closest pair algorithm, S. Fortune's Voronoi code
# and 3rd party plugin jet algorithms. See COPYING file for details.
#--------------------------------------------------------------------------
Begin processing the 2nd record. Run 1, Event 1, LumiSection 1 on stream 0 at 07-Jun-2021 14:37:57.045 CDT
Begin processing the 3rd record. Run 1, Event 7, LumiSection 1 on stream 0 at 07-Jun-2021 14:39:04.789 CDT
Begin processing the 4th record. Run 1, Event 8, LumiSection 1 on stream 0 at 07-Jun-2021 14:40:08.896 CDT
Begin processing the 5th record. Run 1, Event 2, LumiSection 1 on stream 0 at 07-Jun-2021 14:41:15.009 CDT
Begin processing the 6th record. Run 1, Event 5, LumiSection 1 on stream 0 at 07-Jun-2021 14:42:17.955 CDT
Begin processing the 7th record. Run 1, Event 3, LumiSection 1 on stream 0 at 07-Jun-2021 14:43:23.152 CDT
Begin processing the 8th record. Run 1, Event 9, LumiSection 1 on stream 0 at 07-Jun-2021 14:44:29.940 CDT
Begin processing the 9th record. Run 1, Event 6, LumiSection 1 on stream 0 at 07-Jun-2021 14:45:36.235 CDT
Begin processing the 10th record. Run 1, Event 10, LumiSection 1 on stream 0 at 07-Jun-2021 14:46:39.470 CDT
07-Jun-2021 14:47:48 CDT  Closed file file:ttbar.root
07-Jun-2021 14:47:48 CDT  Closed file file:minbias.root
```
 
#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)

@tahuang1991 
