### PR TITLE
[DD4hep] Re-enable DD4hep workflow for PR tests because it is stable

### DIFF
--- a/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
+++ b/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
@@ -87,7 +87,7 @@ if __name__ == '__main__':
                      10024.0, #2017 ttbar
                      10224.0, #2017 ttbar PU
                      10824.0, #2018 ttbar
- # Disable temporarily while unstable # 11634.911, #2021 DD4hep ttbar
+                     11634.911, #2021 DD4hep ttbar
                      11634.0, #2021 ttbar
                      12434.0, #2023 ttbar
                      23234.0, #2026D49 ttbar (HLT TDR baseline w/ HGCal v11)


### PR DESCRIPTION
In April the DD4hep workflow 11634.911 was showing slight instability of results, where if it was run ten times, about one run would show bit-wise different results (or different random seeds). There have been a number of changes in DD4hep-related code in both CMSSW and DD4hep since then, and the problem seems to have disappeared. Unfortunately, we don't know the specific change that fixed the problem, but there are a number of likely candidates.

The workflow has been run a total of over 30 times in CMSSW_12_0_X_2021-06-03-1100 and CMSSW_12_0_X_2021-06-06-2300 with entirely consistent results each time. It appears the workflow is now stable in the latest IBs. 