### PR TITLE
Issue fix in Exotica HLT validation code

### DIFF
--- a/HLTriggerOffline/Exotica/src/HLTExoticaPlotter.cc
+++ b/HLTriggerOffline/Exotica/src/HLTExoticaPlotter.cc
@@ -216,7 +216,9 @@ void HLTExoticaPlotter::bookHist(DQMStore::IBooker &iBooker,
     h = new TH1F(name.c_str(), title.c_str(), nBins, min, max);
   } else if (variable.find("MaxPt") != std::string::npos) {
     std::string desc =
-        (variable == "MaxPt1") ? "Leading" : (variable == "MaxPt2") ? "Next-to-Leading" : "Next-to-next-to-Leading";
+        (variable == "MaxPt1") ? "Leading"
+        : (variable == "MaxPt2") ? "Next-to-Leading"
+        : "Next-to-next-to-Leading";
     std::string title = "pT of " + desc + " " + sourceUpper + " " + objType +
                         " "
                         "where event pass the " +

--- a/HLTriggerOffline/Exotica/src/HLTExoticaPlotter.cc
+++ b/HLTriggerOffline/Exotica/src/HLTExoticaPlotter.cc
@@ -126,9 +126,14 @@ void HLTExoticaPlotter::analyze(const bool &isPassTrigger,
     totalobjectssize++;
   totalobjectssize *= countobjects.size();
   // Fill the histos if pass the trigger (just the two with higher pt)
+  unsigned int jaux = 0;
+  // jaux is being used as a dedicated counter to avoid getting
+  // a non-existent element inside dxys
+  // more information in the issue https://github.com/cms-sw/cmssw/issues/32550
   for (size_t j = 0; j < matches.size(); ++j) {
     // Is this object owned by this trigger? If not we are not interested...
     if (_objectsType.find(matches[j].pdgId()) == _objectsType.end()) {
+      ++jaux;
       continue;
     }
 
@@ -149,8 +154,10 @@ void HLTExoticaPlotter::analyze(const bool &isPassTrigger,
     }
 
     if (!dxys.empty() &&
-        (objType == EVTColContainer::ELEC || objType == EVTColContainer::MUON || objType == EVTColContainer::MUTRK))
-      this->fillHist(isPassTrigger, source, objTypeStr, "Dxy", dxys[j]);
+        (objType == EVTColContainer::ELEC || objType == EVTColContainer::MUON || objType == EVTColContainer::MUTRK)){
+      this->fillHist(isPassTrigger, source, objTypeStr, "Dxy", dxys[jaux]);
+      ++jaux;
+    }
 
     if (countobjects[objType] == 0) {
       if (!(TString(objTypeStr).Contains("MET") || TString(objTypeStr).Contains("MHT")) || source != "gen") {

--- a/HLTriggerOffline/Exotica/src/HLTExoticaPlotter.cc
+++ b/HLTriggerOffline/Exotica/src/HLTExoticaPlotter.cc
@@ -154,7 +154,7 @@ void HLTExoticaPlotter::analyze(const bool &isPassTrigger,
     }
 
     if (!dxys.empty() &&
-        (objType == EVTColContainer::ELEC || objType == EVTColContainer::MUON || objType == EVTColContainer::MUTRK)){
+        (objType == EVTColContainer::ELEC || objType == EVTColContainer::MUON || objType == EVTColContainer::MUTRK)) {
       this->fillHist(isPassTrigger, source, objTypeStr, "Dxy", dxys[jaux]);
       ++jaux;
     }

--- a/HLTriggerOffline/Exotica/src/HLTExoticaPlotter.cc
+++ b/HLTriggerOffline/Exotica/src/HLTExoticaPlotter.cc
@@ -215,10 +215,15 @@ void HLTExoticaPlotter::bookHist(DQMStore::IBooker &iBooker,
     double max = _parametersDxy[2];
     h = new TH1F(name.c_str(), title.c_str(), nBins, min, max);
   } else if (variable.find("MaxPt") != std::string::npos) {
-    std::string desc =
-        (variable == "MaxPt1") ? "Leading"
-        : (variable == "MaxPt2") ? "Next-to-Leading"
-        : "Next-to-next-to-Leading";
+    std::string desc;  //=
+    //        (variable == "MaxPt1") ? "Leading" : (variable == "MaxPt2") ? "Next-to-Leading" : "Next-to-next-to-Leading";
+    if (variable == "MaxPt1") {
+      desc = "Leading";
+    } else if (variable == "MaxPt2") {
+      desc = "Next-to-Leading";
+    } else {
+      desc = "Next-to-next-to-Leading";
+    }
     std::string title = "pT of " + desc + " " + sourceUpper + " " + objType +
                         " "
                         "where event pass the " +

--- a/HLTriggerOffline/Exotica/src/HLTExoticaSubAnalysis.cc
+++ b/HLTriggerOffline/Exotica/src/HLTExoticaSubAnalysis.cc
@@ -659,9 +659,18 @@ void HLTExoticaSubAnalysis::analyze(const edm::Event &iEvent, const edm::EventSe
       }
     }
 
+    int jel = 0;
+    int jmu = 0;
+    int jmutrk = 0;
+
+    // jel, jmu and jmutrk are being used as a dedicated counters to avoid getting
+    // non-existent elements inside trkObjs[11], trkObjs[13] and trkObjs[130], respectively
+    // more information in the issue https://github.com/cms-sw/cmssw/issues/32550
+
     for (size_t j = 0; (j != matchesReco.size()) && isPassedLeadingCut; ++j) {
       const unsigned int objType = matchesReco[j].pdgId();
-      // std::cout << "(4) Gonna call with " << objType << std::endl;
+      //std::cout << "(4) Gonna call with " << objType << std::endl;
+
       const std::string objTypeStr = EVTColContainer::getTypeString(objType);
 
       float pt = matchesReco[j].pt();
@@ -703,10 +712,25 @@ void HLTExoticaSubAnalysis::analyze(const edm::Event &iEvent, const edm::EventSe
         this->fillHist("rec", objTypeStr, "SumEt", theSumEt[objType]);
       }
 
-      if (trkObjs[objType].size() >= j + 1) {
-        float dxyRec = trkObjs[objType].at(j)->dxy(cols->bs->position());
+      if(objType == 11){
+        float dxyRec = trkObjs[objType].at(jel)->dxy(cols->bs->position());
         this->fillHist("rec", objTypeStr, "Dxy", dxyRec);
         dxys.push_back(dxyRec);
+        ++jel;
+      }
+
+      if(objType == 13){
+        float dxyRec = trkObjs[objType].at(jmu)->dxy(cols->bs->position());
+        this->fillHist("rec", objTypeStr, "Dxy", dxyRec);
+        dxys.push_back(dxyRec);
+        ++jmu;
+      }
+
+      if(objType == 130){
+        float dxyRec = trkObjs[objType].at(jmutrk)->dxy(cols->bs->position());
+        this->fillHist("rec", objTypeStr, "Dxy", dxyRec);
+        dxys.push_back(dxyRec);
+        ++jmutrk;
       }
 
     }  // Closes loop in reco

--- a/HLTriggerOffline/Exotica/src/HLTExoticaSubAnalysis.cc
+++ b/HLTriggerOffline/Exotica/src/HLTExoticaSubAnalysis.cc
@@ -712,21 +712,21 @@ void HLTExoticaSubAnalysis::analyze(const edm::Event &iEvent, const edm::EventSe
         this->fillHist("rec", objTypeStr, "SumEt", theSumEt[objType]);
       }
 
-      if(objType == 11){
+      if (objType == 11) {
         float dxyRec = trkObjs[objType].at(jel)->dxy(cols->bs->position());
         this->fillHist("rec", objTypeStr, "Dxy", dxyRec);
         dxys.push_back(dxyRec);
         ++jel;
       }
 
-      if(objType == 13){
+      if (objType == 13) {
         float dxyRec = trkObjs[objType].at(jmu)->dxy(cols->bs->position());
         this->fillHist("rec", objTypeStr, "Dxy", dxyRec);
         dxys.push_back(dxyRec);
         ++jmu;
       }
 
-      if(objType == 130){
+      if (objType == 130) {
         float dxyRec = trkObjs[objType].at(jmutrk)->dxy(cols->bs->position());
         this->fillHist("rec", objTypeStr, "Dxy", dxyRec);
         dxys.push_back(dxyRec);


### PR DESCRIPTION
This is an issue fix of the Exotica HLT validation code. The mentioned issue is https://github.com/cms-sw/cmssw/issues/32550. 

To summarize: there was an index running from 0 to the `matches` vector size `matches.size()`, that was fetching for elements inside the vector `dxys`, while there was no guaranteed one to one correspondence between their sizes in https://github.com/cms-sw/cmssw/blob/393431e92ddacdecbf24d4ff8cca29951177ee7a/HLTriggerOffline/Exotica/src/HLTExoticaPlotter.cc#L151-L153
Some dedicated counters to correctly fill `dxys` and get its elements were created.

The code was tested using local files and showed no more discrepancy between the size of the `dxys` vector with the index that get its elements. The command `runTheMatrix.py -l limited -i all --ibeos` was run with success.