### PR TITLE
Migrate module config in RecoTracker{IterativeTracking} to use default cfipython v2

### DIFF
--- a/RecoTracker/IterativeTracking/python/ElectronSeeds_cff.py
+++ b/RecoTracker/IterativeTracking/python/ElectronSeeds_cff.py
@@ -29,7 +29,7 @@ trackingPhase2PU140.toReplaceWith(highPtTripletStepSeedClusterMask, seedClusterR
     )
 )
 trackingPhase2PU140.toReplaceWith(pixelPairStepSeedClusterMask, seedClusterRemoverPhase2.clone(
-    trajectories = cms.InputTag('detachedQuadStepSeeds'),
+    trajectories = 'detachedQuadStepSeeds',
     oldClusterRemovalInfo = cms.InputTag('highPtTripletStepSeedClusterMask')
     )
 )
@@ -52,10 +52,12 @@ pixelLessStepSeedClusterMask = seedClusterRemover.clone(
     oldClusterRemovalInfo = cms.InputTag('mixedTripletStepSeedClusterMask')
 )
 
-tripletElectronSeedLayers = cms.EDProducer('SeedingLayersEDProducer',
-    layerList = cms.vstring('BPix1+BPix2+BPix3', 
-                            'BPix1+BPix2+FPix1_pos', 'BPix1+BPix2+FPix1_neg', 
-                            'BPix1+FPix1_pos+FPix2_pos', 'BPix1+FPix1_neg+FPix2_neg'),
+import RecoTracker.TkSeedingLayers.seedingLayersEDProducer_cfi as _mod
+
+tripletElectronSeedLayers = _mod.seedingLayersEDProducer.clone(
+    layerList = ['BPix1+BPix2+BPix3', 
+                 'BPix1+BPix2+FPix1_pos', 'BPix1+BPix2+FPix1_neg', 
+                 'BPix1+FPix1_pos+FPix2_pos', 'BPix1+FPix1_neg+FPix2_neg'],
     BPix = cms.PSet(
     TTRHBuilder = cms.string('TTRHBuilderWithoutAngle4PixelTriplets'),
     HitProducer = cms.string('siPixelRecHits'),
@@ -138,12 +140,12 @@ trackingPhase2PU140.toReplaceWith(tripletElectronClusterMask, seedClusterRemover
     )
 )
 
-pixelPairElectronSeedLayers = cms.EDProducer('SeedingLayersEDProducer',
-    layerList = cms.vstring('BPix1+BPix2', 'BPix1+BPix3', 'BPix2+BPix3', 
-                            'BPix1+FPix1_pos', 'BPix1+FPix1_neg', 
-                            'BPix1+FPix2_pos', 'BPix1+FPix2_neg', 
-                            'BPix2+FPix1_pos', 'BPix2+FPix1_neg', 
-                            'FPix1_pos+FPix2_pos', 'FPix1_neg+FPix2_neg'),
+pixelPairElectronSeedLayers = _mod.seedingLayersEDProducer.clone(
+    layerList = ['BPix1+BPix2', 'BPix1+BPix3', 'BPix2+BPix3', 
+                 'BPix1+FPix1_pos', 'BPix1+FPix1_neg', 
+                 'BPix1+FPix2_pos', 'BPix1+FPix2_neg', 
+                 'BPix2+FPix1_pos', 'BPix2+FPix1_neg', 
+                 'FPix1_pos+FPix2_pos', 'FPix1_neg+FPix2_neg'],
     BPix = cms.PSet(
     TTRHBuilder = cms.string('WithTrackAngle'),
     HitProducer = cms.string('siPixelRecHits'),
@@ -188,10 +190,10 @@ pixelPairElectronSeeds = _seedCreatorFromRegionConsecutiveHitsEDProducer.clone(
     seedingHitSets = 'pixelPairElectronHitDoublets',
 )
 
-stripPairElectronSeedLayers = cms.EDProducer('SeedingLayersEDProducer',
-    layerList = cms.vstring('TIB1+TIB2', 'TIB1+TID1_pos', 'TIB1+TID1_neg', 'TID2_pos+TID3_pos', 'TID2_neg+TID3_neg',
-                            'TEC1_pos+TEC2_pos','TEC2_pos+TEC3_pos','TEC3_pos+TEC4_pos','TEC3_pos+TEC5_pos',
-                            'TEC1_neg+TEC2_neg','TEC2_neg+TEC3_neg','TEC3_neg+TEC4_neg','TEC3_neg+TEC5_neg'),
+stripPairElectronSeedLayers = _mod.seedingLayersEDProducer.clone(
+    layerList = ['TIB1+TIB2', 'TIB1+TID1_pos', 'TIB1+TID1_neg', 'TID2_pos+TID3_pos', 'TID2_neg+TID3_neg',
+                 'TEC1_pos+TEC2_pos','TEC2_pos+TEC3_pos','TEC3_pos+TEC4_pos','TEC3_pos+TEC5_pos',
+                 'TEC1_neg+TEC2_neg','TEC2_neg+TEC3_neg','TEC3_neg+TEC4_neg','TEC3_neg+TEC5_neg'],
     TIB = cms.PSet(
     TTRHBuilder = cms.string('WithTrackAngle'), clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutNone')),
     matchedRecHits = cms.InputTag('siStripMatchedRecHits','matchedRecHit'),

--- a/RecoTracker/IterativeTracking/python/JetCoreRegionalStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/JetCoreRegionalStep_cff.py
@@ -22,14 +22,16 @@ firstStepGoodPrimaryVertices = cms.EDFilter('PrimaryVertexObjectFilter',
      src=cms.InputTag('firstStepPrimaryVertices')
 )
 
+import RecoTracker.TkSeedingLayers.seedingLayersEDProducer_cfi as _mod
+
 # SEEDING LAYERS
-jetCoreRegionalStepSeedLayers = cms.EDProducer('SeedingLayersEDProducer',
-    layerList = cms.vstring('BPix1+BPix2', 'BPix1+BPix3', 'BPix2+BPix3', 
-                            'BPix1+FPix1_pos', 'BPix1+FPix1_neg', 
-                            'BPix2+FPix1_pos', 'BPix2+FPix1_neg', 
-                            'FPix1_pos+FPix2_pos', 'FPix1_neg+FPix2_neg',
-                            #'BPix2+TIB1','BPix2+TIB2',
-                            'BPix3+TIB1','BPix3+TIB2'),
+jetCoreRegionalStepSeedLayers = _mod.seedingLayersEDProducer.clone(
+    layerList = ['BPix1+BPix2', 'BPix1+BPix3', 'BPix2+BPix3', 
+                 'BPix1+FPix1_pos', 'BPix1+FPix1_neg', 
+                 'BPix2+FPix1_pos', 'BPix2+FPix1_neg', 
+                 'FPix1_pos+FPix2_pos', 'FPix1_neg+FPix2_neg',
+                 #'BPix2+TIB1','BPix2+TIB2',
+                 'BPix3+TIB1','BPix3+TIB2'],
     TIB = cms.PSet(
         matchedRecHits = cms.InputTag('siStripMatchedRecHits','matchedRecHit'),
         TTRHBuilder = cms.string('WithTrackAngle'), clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutNone'))

--- a/RecoTracker/IterativeTracking/python/MixedTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/MixedTripletStep_cff.py
@@ -160,10 +160,11 @@ _fastSim_mixedTripletStepSeedsA = FastSimulation.Tracking.TrajectorySeedProducer
 )
 fastSim.toReplaceWith(mixedTripletStepSeedsA,_fastSim_mixedTripletStepSeedsA)
 
+import RecoTracker.TkSeedingLayers.seedingLayersEDProducer_cfi as _mod
 
 # SEEDING LAYERS
-mixedTripletStepSeedLayersB = cms.EDProducer('SeedingLayersEDProducer',
-    layerList = cms.vstring('BPix2+BPix3+TIB1'),
+mixedTripletStepSeedLayersB = _mod.seedingLayersEDProducer.clone(
+    layerList = ['BPix2+BPix3+TIB1'],
     BPix = cms.PSet(
         TTRHBuilder = cms.string('WithTrackAngle'),
         HitProducer = cms.string('siPixelRecHits'),

--- a/RecoTracker/IterativeTracking/python/PixelLessStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/PixelLessStep_cff.py
@@ -19,8 +19,10 @@ for _eraName, _postfix, _era in _cfg.nonDefaultEras():
 
 # SEEDING LAYERS
 from RecoLocalTracker.SiStripClusterizer.SiStripClusterChargeCut_cfi import *
-pixelLessStepSeedLayers = cms.EDProducer('SeedingLayersEDProducer',
-    layerList = cms.vstring(
+import RecoTracker.TkSeedingLayers.seedingLayersEDProducer_cfi as _mod
+
+pixelLessStepSeedLayers = _mod.seedingLayersEDProducer.clone(
+    layerList = [
     #TIB
     'TIB1+TIB2+MTIB3','TIB1+TIB2+MTIB4',
     #TIB+TID
@@ -45,7 +47,7 @@ pixelLessStepSeedLayers = cms.EDProducer('SeedingLayersEDProducer',
     'TEC3_pos+TEC4_pos+MTEC5_pos','TEC3_neg+TEC4_neg+MTEC5_neg',
     'TEC3_pos+TEC5_pos+TEC6_pos', 'TEC3_neg+TEC5_neg+TEC6_neg',
     'TEC4_pos+TEC5_pos+TEC6_pos', 'TEC4_neg+TEC5_neg+TEC6_neg'    
-    ),
+    ],
     TIB = cms.PSet(
          TTRHBuilder    = cms.string('WithTrackAngle'), clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutTight')),
          matchedRecHits = cms.InputTag('siStripMatchedRecHits','matchedRecHit'),

--- a/RecoTracker/IterativeTracking/python/PixelPairStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/PixelPairStep_cff.py
@@ -12,13 +12,14 @@ pixelPairStepClusters = _cfg.clusterRemoverForIter('PixelPairStep')
 for _eraName, _postfix, _era in _cfg.nonDefaultEras():
     _era.toReplaceWith(pixelPairStepClusters, _cfg.clusterRemoverForIter('PixelPairStep', _eraName, _postfix))
 
+import RecoTracker.TkSeedingLayers.seedingLayersEDProducer_cfi as _mod
 
 # SEEDING LAYERS
-pixelPairStepSeedLayers = cms.EDProducer('SeedingLayersEDProducer',
-    layerList = cms.vstring('BPix1+BPix2', 'BPix1+BPix3', 'BPix2+BPix3', 
+pixelPairStepSeedLayers = _mod.seedingLayersEDProducer.clone(
+    layerList = ['BPix1+BPix2', 'BPix1+BPix3', 'BPix2+BPix3', 
         'BPix1+FPix1_pos', 'BPix1+FPix1_neg', 
         'BPix2+FPix1_pos', 'BPix2+FPix1_neg', 
-        'FPix1_pos+FPix2_pos', 'FPix1_neg+FPix2_neg'),
+        'FPix1_pos+FPix2_pos', 'FPix1_neg+FPix2_neg'],
     BPix = cms.PSet(
         TTRHBuilder = cms.string('WithTrackAngle'),
         HitProducer = cms.string('siPixelRecHits'),

--- a/RecoTracker/IterativeTracking/python/TobTecStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/TobTecStep_cff.py
@@ -16,13 +16,15 @@ for _eraName, _postfix, _era in _cfg.nonDefaultEras():
 
 # TRIPLET SEEDING LAYERS
 from RecoLocalTracker.SiStripClusterizer.SiStripClusterChargeCut_cfi import *
-tobTecStepSeedLayersTripl = cms.EDProducer('SeedingLayersEDProducer',
-    layerList = cms.vstring(
+import RecoTracker.TkSeedingLayers.seedingLayersEDProducer_cfi as _mod
+
+tobTecStepSeedLayersTripl = _mod.seedingLayersEDProducer.clone(
+    layerList = [
     #TOB
     'TOB1+TOB2+MTOB3','TOB1+TOB2+MTOB4',
     #TOB+MTEC
     'TOB1+TOB2+MTEC1_pos','TOB1+TOB2+MTEC1_neg',
-    ),
+    ],
     TOB = cms.PSet(
          TTRHBuilder    = cms.string('WithTrackAngle'), clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutTight')),
          matchedRecHits = cms.InputTag('siStripMatchedRecHits','matchedRecHit'),
@@ -119,14 +121,14 @@ _fastSim_tobTecStepSeedsTripl = FastSimulation.Tracking.TrajectorySeedProducer_c
 fastSim.toReplaceWith(tobTecStepSeedsTripl,_fastSim_tobTecStepSeedsTripl)
 
 # PAIR SEEDING LAYERS
-tobTecStepSeedLayersPair = cms.EDProducer('SeedingLayersEDProducer',
-    layerList = cms.vstring('TOB1+TEC1_pos','TOB1+TEC1_neg', 
-                            'TEC1_pos+TEC2_pos','TEC1_neg+TEC2_neg', 
-                            'TEC2_pos+TEC3_pos','TEC2_neg+TEC3_neg', 
-                            'TEC3_pos+TEC4_pos','TEC3_neg+TEC4_neg', 
-                            'TEC4_pos+TEC5_pos','TEC4_neg+TEC5_neg', 
-                            'TEC5_pos+TEC6_pos','TEC5_neg+TEC6_neg', 
-                            'TEC6_pos+TEC7_pos','TEC6_neg+TEC7_neg'),
+tobTecStepSeedLayersPair = _mod.seedingLayersEDProducer.clone( 
+    layerList = ['TOB1+TEC1_pos','TOB1+TEC1_neg', 
+                 'TEC1_pos+TEC2_pos','TEC1_neg+TEC2_neg', 
+                 'TEC2_pos+TEC3_pos','TEC2_neg+TEC3_neg', 
+                 'TEC3_pos+TEC4_pos','TEC3_neg+TEC4_neg', 
+                 'TEC4_pos+TEC5_pos','TEC4_neg+TEC5_neg', 
+                 'TEC5_pos+TEC6_pos','TEC5_neg+TEC6_neg', 
+                 'TEC6_pos+TEC7_pos','TEC6_neg+TEC7_neg'],
     TOB = cms.PSet(
          TTRHBuilder    = cms.string('WithTrackAngle'), clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutTight')),
          matchedRecHits = cms.InputTag('siStripMatchedRecHits','matchedRecHit'),
@@ -453,15 +455,15 @@ TobTecStep = cms.Sequence(TobTecStepTask)
 ### Following are specific for LowPU, they're collected here to
 ### not to interfere too much with the default configuration
 # SEEDING LAYERS
-tobTecStepSeedLayers = cms.EDProducer('SeedingLayersEDProducer',
-    layerList = cms.vstring('TOB1+TOB2', 
+tobTecStepSeedLayers = _mod.seedingLayersEDProducer.clone(
+    layerList = ['TOB1+TOB2', 
         'TOB1+TEC1_pos', 'TOB1+TEC1_neg', 
         'TEC1_pos+TEC2_pos', 'TEC2_pos+TEC3_pos', 
         'TEC3_pos+TEC4_pos', 'TEC4_pos+TEC5_pos', 
         'TEC5_pos+TEC6_pos', 'TEC6_pos+TEC7_pos', 
         'TEC1_neg+TEC2_neg', 'TEC2_neg+TEC3_neg', 
         'TEC3_neg+TEC4_neg', 'TEC4_neg+TEC5_neg', 
-        'TEC5_neg+TEC6_neg', 'TEC6_neg+TEC7_neg'),
+        'TEC5_neg+TEC6_neg', 'TEC6_neg+TEC7_neg'],
     TOB = cms.PSet(
         matchedRecHits = cms.InputTag('siStripMatchedRecHits','matchedRecHit'),
         skipClusters = cms.InputTag('tobTecStepClusters'),


### PR DESCRIPTION
#### PR description: 
Optimization of the python configurations: Improve maintainability by cleaning up the duplicated and cloning from the default/reference configurations. 

In this PR, 6 files changed.  
RecoTracker/IterativeTracking/python/ElectronSeeds_cff.py
RecoTracker/IterativeTracking/python/JetCoreRegionalStep_cff.py
RecoTracker/IterativeTracking/python/MixedTripletStep_cff.py
RecoTracker/IterativeTracking/python/PixelLessStep_cff.py
RecoTracker/IterativeTracking/python/PixelPairStep_cff.py
RecoTracker/IterativeTracking/python/TobTecStep_cff.py

This pr is originally from #33903 (now closed due to the unsuccessful rebasing in the RecoTracker/IterativeTracking/python/JetCoreRegionalStep_cff.py).
 
(The previous PRs were  [PR#33207](https://github.com/cms-sw/cmssw/pull/33207), [PR#33307](https://github.com/cms-sw/cmssw/pull/33307), [PR#33352](https://github.com/cms-sw/cmssw/pull/33352), [PR#33543](https://github.com/cms-sw/cmssw/pull/33543),  [PR#33563](https://github.com/cms-sw/cmssw/pull/33563),  [PR#33671](https://github.com/cms-sw/cmssw/pull/33671), [PR#33901](https://github.com/cms-sw/cmssw/pull/33901))

#### PR validation:
Event Content comparison check was also done and there is no change with these updates.
Tested in CMSSW_12_0_X, the basic test all passed in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html).