### PR TITLE
Migrate module configuration in RecoTracker{SpecialSeedGenerators} to use default cfipython

### DIFF
--- a/RecoTracker/SpecialSeedGenerators/python/CombinatorialSeedGeneratorForBeamHalo_cff.py
+++ b/RecoTracker/SpecialSeedGenerators/python/CombinatorialSeedGeneratorForBeamHalo_cff.py
@@ -4,8 +4,9 @@ import FWCore.ParameterSet.Config as cms
 from RecoTracker.TkSeedingLayers.PixelLayerPairs_cfi import *
 #get the module combinatorialbeamhaloseedfinder
 from RecoTracker.SpecialSeedGenerators.CombinatorialSeedGeneratorForBeamHalo_cfi import *
+import RecoTracker.TkSeedingLayers.seedingLayersEDProducer_cfi as _mod
 
-beamhaloTrackerSeedingLayers = cms.EDProducer("SeedingLayersEDProducer",
-    layerInfo,
-    layerList = layerList
+beamhaloTrackerSeedingLayers = _mod.seedingLayersEDProducer.clone(
+    layerList = layerList,
+    **layerInfo
 )

--- a/RecoTracker/SpecialSeedGenerators/python/CombinatorialSeedGeneratorForBeamHalo_cff.py
+++ b/RecoTracker/SpecialSeedGenerators/python/CombinatorialSeedGeneratorForBeamHalo_cff.py
@@ -7,6 +7,6 @@ from RecoTracker.SpecialSeedGenerators.CombinatorialSeedGeneratorForBeamHalo_cfi
 import RecoTracker.TkSeedingLayers.seedingLayersEDProducer_cfi as _mod
 
 beamhaloTrackerSeedingLayers = _mod.seedingLayersEDProducer.clone(
+    layerInfo,
     layerList = layerList,
-    **layerInfo
 )

--- a/RecoTracker/SpecialSeedGenerators/python/CombinatorialSeedGeneratorForBeamHalo_cfi.py
+++ b/RecoTracker/SpecialSeedGenerators/python/CombinatorialSeedGeneratorForBeamHalo_cfi.py
@@ -9,7 +9,7 @@ import FWCore.ParameterSet.Config as cms
 from RecoTracker.TkTrackingRegions.GlobalTrackingRegion_cfi import *
 from RecoLocalTracker.SiStripClusterizer.SiStripClusterChargeCut_cfi import *
 
-layerInfo = cms.PSet(
+layerInfo = dict(
     TID = cms.PSet(
         matchedRecHits = cms.InputTag("siStripMatchedRecHits","matchedRecHit"),
         useRingSlector = cms.bool(False),
@@ -41,7 +41,7 @@ layerInfo = cms.PSet(
     ),
 )
 
-layerList = cms.vstring(
+layerList = [
     'FPix1_pos+FPix2_pos', 
     'FPix1_neg+FPix2_neg', 
     'TID2_pos+TID3_pos', 
@@ -60,7 +60,7 @@ layerList = cms.vstring(
     'MTEC7_pos+MTEC8_pos',
     'MTEC8_neg+MTEC9_neg',
     'MTEC8_pos+MTEC9_pos'
-    )
+    ]
 
 beamhaloTrackerSeeds = cms.EDProducer("CtfSpecialSeedGenerator",
     SeedMomentum = cms.double(15.0), ##initial momentum in GeV !!!set to a lower value for slice test data

--- a/RecoTracker/SpecialSeedGenerators/python/CombinatorialSeedGeneratorForBeamHalo_cfi.py
+++ b/RecoTracker/SpecialSeedGenerators/python/CombinatorialSeedGeneratorForBeamHalo_cfi.py
@@ -9,7 +9,7 @@ import FWCore.ParameterSet.Config as cms
 from RecoTracker.TkTrackingRegions.GlobalTrackingRegion_cfi import *
 from RecoLocalTracker.SiStripClusterizer.SiStripClusterChargeCut_cfi import *
 
-layerInfo = dict(
+layerInfo = cms.PSet(
     TID = cms.PSet(
         matchedRecHits = cms.InputTag("siStripMatchedRecHits","matchedRecHit"),
         useRingSlector = cms.bool(False),

--- a/RecoTracker/SpecialSeedGenerators/python/CombinatorialSeedGeneratorForCosmicsP5_cff.py
+++ b/RecoTracker/SpecialSeedGenerators/python/CombinatorialSeedGeneratorForCosmicsP5_cff.py
@@ -24,28 +24,28 @@ import RecoTracker.TkSeedingLayers.seedingLayersEDProducer_cfi as _mod
 
 # seeding layers
 combinatorialcosmicseedingtripletsP5 = _mod.seedingLayersEDProducer.clone(
+    layerInfo,
     layerList = ['MTOB4+MTOB5+MTOB6', 
-        'MTOB3+MTOB5+MTOB6', 
-        'MTOB3+MTOB4+MTOB5', 
-        'TOB2+MTOB4+MTOB5', 
-        'MTOB3+MTOB4+MTOB6', 
-        'TOB2+MTOB4+MTOB6'],
-    **layerInfo
+                 'MTOB3+MTOB5+MTOB6', 
+                 'MTOB3+MTOB4+MTOB5', 
+                 'TOB2+MTOB4+MTOB5', 
+                 'MTOB3+MTOB4+MTOB6', 
+                 'TOB2+MTOB4+MTOB6'],
 )
 combinatorialcosmicseedingpairsTOBP5 = _mod.seedingLayersEDProducer.clone( 
+    layerInfo,
     layerList = ['MTOB5+MTOB6', 
-        'MTOB4+MTOB5'],
-    **layerInfo
+                 'MTOB4+MTOB5'],
 )
 combinatorialcosmicseedingpairsTECposP5 = _mod.seedingLayersEDProducer.clone(
     layerList = ['TEC1_pos+TEC2_pos', 
-        'TEC2_pos+TEC3_pos', 
-        'TEC3_pos+TEC4_pos', 
-        'TEC4_pos+TEC5_pos', 
-        'TEC5_pos+TEC6_pos', 
-        'TEC6_pos+TEC7_pos', 
-        'TEC7_pos+TEC8_pos', 
-        'TEC8_pos+TEC9_pos'],
+                 'TEC2_pos+TEC3_pos', 
+                 'TEC3_pos+TEC4_pos', 
+                 'TEC4_pos+TEC5_pos', 
+                 'TEC5_pos+TEC6_pos', 
+                 'TEC6_pos+TEC7_pos', 
+                 'TEC7_pos+TEC8_pos', 
+                 'TEC8_pos+TEC9_pos'],
     TEC = cms.PSet(
         minRing = cms.int32(5),
         matchedRecHits = cms.InputTag("siStripMatchedRecHits","matchedRecHit"),
@@ -58,13 +58,13 @@ combinatorialcosmicseedingpairsTECposP5 = _mod.seedingLayersEDProducer.clone(
 )
 combinatorialcosmicseedingpairsTECnegP5 = _mod.seedingLayersEDProducer.clone(
     layerList = ['TEC1_neg+TEC2_neg', 
-        'TEC2_neg+TEC3_neg', 
-        'TEC3_neg+TEC4_neg', 
-        'TEC4_neg+TEC5_neg', 
-        'TEC5_neg+TEC6_neg', 
-        'TEC6_neg+TEC7_neg', 
-        'TEC7_neg+TEC8_neg', 
-        'TEC8_neg+TEC9_neg'],
+                 'TEC2_neg+TEC3_neg', 
+                 'TEC3_neg+TEC4_neg', 
+                 'TEC4_neg+TEC5_neg', 
+                 'TEC5_neg+TEC6_neg', 
+                 'TEC6_neg+TEC7_neg', 
+                 'TEC7_neg+TEC8_neg', 
+                 'TEC8_neg+TEC9_neg'],
     TEC = cms.PSet(
         minRing = cms.int32(5),
         matchedRecHits = cms.InputTag("siStripMatchedRecHits","matchedRecHit"),

--- a/RecoTracker/SpecialSeedGenerators/python/CombinatorialSeedGeneratorForCosmicsP5_cff.py
+++ b/RecoTracker/SpecialSeedGenerators/python/CombinatorialSeedGeneratorForCosmicsP5_cff.py
@@ -20,30 +20,32 @@ from RecoLocalTracker.SiStripRecHitConverter.StripCPEfromTrackAngle_cfi import *
 from RecoTracker.TransientTrackingRecHit.TransientTrackingRecHitBuilder_cfi import *
 from RecoTracker.TransientTrackingRecHit.TransientTrackingRecHitBuilderWithoutRefit_cfi import *
 from RecoTracker.SpecialSeedGenerators.CombinatorialSeedGeneratorForCosmics_cfi import *
+import RecoTracker.TkSeedingLayers.seedingLayersEDProducer_cfi as _mod
+
 # seeding layers
-combinatorialcosmicseedingtripletsP5 = cms.EDProducer("SeedingLayersEDProducer",
-    layerInfo,
-    layerList = cms.vstring('MTOB4+MTOB5+MTOB6', 
+combinatorialcosmicseedingtripletsP5 = _mod.seedingLayersEDProducer.clone(
+    layerList = ['MTOB4+MTOB5+MTOB6', 
         'MTOB3+MTOB5+MTOB6', 
         'MTOB3+MTOB4+MTOB5', 
         'TOB2+MTOB4+MTOB5', 
         'MTOB3+MTOB4+MTOB6', 
-        'TOB2+MTOB4+MTOB6')
+        'TOB2+MTOB4+MTOB6'],
+    **layerInfo
 )
-combinatorialcosmicseedingpairsTOBP5 = cms.EDProducer("SeedingLayersEDProducer",
-    layerInfo,
-    layerList = cms.vstring('MTOB5+MTOB6', 
-        'MTOB4+MTOB5')
+combinatorialcosmicseedingpairsTOBP5 = _mod.seedingLayersEDProducer.clone( 
+    layerList = ['MTOB5+MTOB6', 
+        'MTOB4+MTOB5'],
+    **layerInfo
 )
-combinatorialcosmicseedingpairsTECposP5 = cms.EDProducer("SeedingLayersEDProducer",
-    layerList = cms.vstring('TEC1_pos+TEC2_pos', 
+combinatorialcosmicseedingpairsTECposP5 = _mod.seedingLayersEDProducer.clone(
+    layerList = ['TEC1_pos+TEC2_pos', 
         'TEC2_pos+TEC3_pos', 
         'TEC3_pos+TEC4_pos', 
         'TEC4_pos+TEC5_pos', 
         'TEC5_pos+TEC6_pos', 
         'TEC6_pos+TEC7_pos', 
         'TEC7_pos+TEC8_pos', 
-        'TEC8_pos+TEC9_pos'),
+        'TEC8_pos+TEC9_pos'],
     TEC = cms.PSet(
         minRing = cms.int32(5),
         matchedRecHits = cms.InputTag("siStripMatchedRecHits","matchedRecHit"),
@@ -54,15 +56,15 @@ combinatorialcosmicseedingpairsTECposP5 = cms.EDProducer("SeedingLayersEDProduce
         maxRing = cms.int32(7)
     )
 )
-combinatorialcosmicseedingpairsTECnegP5 = cms.EDProducer("SeedingLayersEDProducer",
-    layerList = cms.vstring('TEC1_neg+TEC2_neg', 
+combinatorialcosmicseedingpairsTECnegP5 = _mod.seedingLayersEDProducer.clone(
+    layerList = ['TEC1_neg+TEC2_neg', 
         'TEC2_neg+TEC3_neg', 
         'TEC3_neg+TEC4_neg', 
         'TEC4_neg+TEC5_neg', 
         'TEC5_neg+TEC6_neg', 
         'TEC6_neg+TEC7_neg', 
         'TEC7_neg+TEC8_neg', 
-        'TEC8_neg+TEC9_neg'),
+        'TEC8_neg+TEC9_neg'],
     TEC = cms.PSet(
         minRing = cms.int32(5),
         matchedRecHits = cms.InputTag("siStripMatchedRecHits","matchedRecHit"),

--- a/RecoTracker/SpecialSeedGenerators/python/CombinatorialSeedGeneratorForCosmicsRegionalReconstruction_cff.py
+++ b/RecoTracker/SpecialSeedGenerators/python/CombinatorialSeedGeneratorForCosmicsRegionalReconstruction_cff.py
@@ -1,8 +1,9 @@
 import FWCore.ParameterSet.Config as cms
 
 from RecoTracker.SpecialSeedGenerators.CombinatorialSeedGeneratorForCosmicsRegionalReconstruction_cfi import *
+import RecoTracker.TkSeedingLayers.seedingLayersEDProducer_cfi as _mod
 
-regionalCosmicTrackerSeedingLayers = cms.EDProducer("SeedingLayersEDProducer",
-    layerInfo,
-    layerList = layerList
+regionalCosmicTrackerSeedingLayers = _mod.seedingLayersEDProducer.clone(
+    layerList = layerList,
+    **layerInfo
 )

--- a/RecoTracker/SpecialSeedGenerators/python/CombinatorialSeedGeneratorForCosmicsRegionalReconstruction_cff.py
+++ b/RecoTracker/SpecialSeedGenerators/python/CombinatorialSeedGeneratorForCosmicsRegionalReconstruction_cff.py
@@ -4,6 +4,6 @@ from RecoTracker.SpecialSeedGenerators.CombinatorialSeedGeneratorForCosmicsRegio
 import RecoTracker.TkSeedingLayers.seedingLayersEDProducer_cfi as _mod
 
 regionalCosmicTrackerSeedingLayers = _mod.seedingLayersEDProducer.clone(
-    layerList = layerList,
-    **layerInfo
+    layerInfo,
+    layerList = layerList
 )

--- a/RecoTracker/SpecialSeedGenerators/python/CombinatorialSeedGeneratorForCosmicsRegionalReconstruction_cfi.py
+++ b/RecoTracker/SpecialSeedGenerators/python/CombinatorialSeedGeneratorForCosmicsRegionalReconstruction_cfi.py
@@ -2,7 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 from RecoLocalTracker.SiStripClusterizer.SiStripClusterChargeCut_cfi import *
 
-layerInfo = dict(
+layerInfo = cms.PSet(
     TOB = cms.PSet(
       TTRHBuilder = cms.string('WithTrackAngle'),
       clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutNone'))

--- a/RecoTracker/SpecialSeedGenerators/python/CombinatorialSeedGeneratorForCosmicsRegionalReconstruction_cfi.py
+++ b/RecoTracker/SpecialSeedGenerators/python/CombinatorialSeedGeneratorForCosmicsRegionalReconstruction_cfi.py
@@ -2,7 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 from RecoLocalTracker.SiStripClusterizer.SiStripClusterChargeCut_cfi import *
 
-layerInfo = cms.PSet(
+layerInfo = dict(
     TOB = cms.PSet(
       TTRHBuilder = cms.string('WithTrackAngle'),
       clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutNone'))
@@ -15,19 +15,19 @@ layerInfo = cms.PSet(
       maxRing = cms.int32(7)
       )
 )
-layerList = cms.vstring('TOB6+TOB5',
-                        'TOB6+TOB4', 
-                        'TOB6+TOB3',
-                        'TOB5+TOB4',
-                        'TOB5+TOB3',
-                        'TOB4+TOB3',
-                        'TEC1_neg+TOB6',
-                        'TEC1_neg+TOB5',
-                        'TEC1_neg+TOB4',
-                        'TEC1_pos+TOB6',
-                        'TEC1_pos+TOB5',
-                        'TEC1_pos+TOB4'                                   
-                        )
+layerList = ['TOB6+TOB5',
+             'TOB6+TOB4', 
+             'TOB6+TOB3',
+             'TOB5+TOB4',
+             'TOB5+TOB3',
+             'TOB4+TOB3',
+             'TEC1_neg+TOB6',
+             'TEC1_neg+TOB5',
+             'TEC1_neg+TOB4',
+             'TEC1_pos+TOB6',
+             'TEC1_pos+TOB5',
+             'TEC1_pos+TOB4'                                   
+             ]
 from RecoTracker.TkSeedGenerator.SeedFromConsecutiveHitsCreator_cfi import SeedFromConsecutiveHitsCreator as _SeedFromConsecutiveHitsCreator
 CosmicSeedCreator = _SeedFromConsecutiveHitsCreator.clone(
     ComponentName = 'CosmicSeedCreator',

--- a/RecoTracker/SpecialSeedGenerators/python/CombinatorialSeedGeneratorForCosmics_cfi.py
+++ b/RecoTracker/SpecialSeedGenerators/python/CombinatorialSeedGeneratorForCosmics_cfi.py
@@ -36,7 +36,7 @@ layerInfo = cms.PSet(
         clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutNone')),
         rphiRecHits = cms.InputTag("siStripMatchedRecHits","rphiRecHit"),
         maxRing = cms.int32(7)
-  )
+    )
 )
 combinatorialcosmicseedingtripletsTOB_layerList = cms.vstring('MTOB4+MTOB5+MTOB6',
     'MTOB3+MTOB5+MTOB6',
@@ -69,24 +69,26 @@ combinatorialcosmicseedfinder = cms.EDProducer("CtfSpecialSeedGenerator",
         GlobalY = cms.double(300.0)
     ),
     Charges = cms.vint32(-1),
-    OrderedHitsFactoryPSets = cms.VPSet(cms.PSet(
-        ComponentName = cms.string('GenericTripletGenerator'),
-        LayerSrc = cms.InputTag("combinatorialcosmicseedingtripletsTOB"),
-        PropagationDirection = cms.string('alongMomentum'),
-        NavigationDirection = cms.string('outsideIn')
-    ), 
-    cms.PSet(
-        ComponentName = cms.string('GenericPairGenerator'),
-        LayerSrc = cms.InputTag("combinatorialcosmicseedingpairsTECpos"),
-        PropagationDirection = cms.string('alongMomentum'),
-        NavigationDirection = cms.string('outsideIn')
-    ), 
-    cms.PSet(
-        ComponentName = cms.string('GenericTripletGenerator'),
-        LayerSrc = cms.InputTag("combinatorialcosmicseedingtripletsTIB"),
-        PropagationDirection = cms.string('oppositeToMomentum'),
-        NavigationDirection = cms.string('insideOut')
-    )),
+    OrderedHitsFactoryPSets = cms.VPSet(
+        cms.PSet(
+            ComponentName = cms.string('GenericTripletGenerator'),
+            LayerSrc = cms.InputTag("combinatorialcosmicseedingtripletsTOB"),
+            PropagationDirection = cms.string('alongMomentum'),
+            NavigationDirection = cms.string('outsideIn')
+        ), 
+        cms.PSet(
+            ComponentName = cms.string('GenericPairGenerator'),
+            LayerSrc = cms.InputTag("combinatorialcosmicseedingpairsTECpos"),
+            PropagationDirection = cms.string('alongMomentum'),
+            NavigationDirection = cms.string('outsideIn')
+        ), 
+        cms.PSet(
+            ComponentName = cms.string('GenericTripletGenerator'),
+            LayerSrc = cms.InputTag("combinatorialcosmicseedingtripletsTIB"),
+            PropagationDirection = cms.string('oppositeToMomentum'),
+            NavigationDirection = cms.string('insideOut')
+        )
+    ),
     UseScintillatorsConstraint = cms.bool(True),
     TTRHBuilder = cms.string('WithTrackAngle'),
     LowerScintillatorParameters = cms.PSet(

--- a/RecoTracker/SpecialSeedGenerators/python/CombinatorialSeedGeneratorForCosmics_cfi.py
+++ b/RecoTracker/SpecialSeedGenerators/python/CombinatorialSeedGeneratorForCosmics_cfi.py
@@ -6,7 +6,7 @@ import FWCore.ParameterSet.Config as cms
 from RecoTracker.TkTrackingRegions.GlobalTrackingRegion_cfi import *
 from RecoLocalTracker.SiStripClusterizer.SiStripClusterChargeCut_cfi import *
 
-layerInfo = cms.PSet(
+layerInfo = dict(
     MTIB = cms.PSet(
         TTRHBuilder = cms.string('WithTrackAngle'),
             clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutNone')),

--- a/RecoTracker/SpecialSeedGenerators/python/CombinatorialSeedGeneratorForCosmics_cfi.py
+++ b/RecoTracker/SpecialSeedGenerators/python/CombinatorialSeedGeneratorForCosmics_cfi.py
@@ -53,9 +53,9 @@ combinatorialcosmicseedingpairsTECpos_layerList = cms.vstring('TEC1_pos+TEC2_pos
     'TEC7_pos+TEC8_pos',
     'TEC8_pos+TEC9_pos')
 combinatorialcosmicseedingtripletsTIB_layerList = cms.vstring('TIB1+TIB2+MTIB3')
+
 combinatorialcosmicseedfinder = cms.EDProducer("CtfSpecialSeedGenerator",
     SeedMomentum = cms.double(5.0), ##initial momentum in GeV !!!set to a lower value for slice test data
-
     ErrorRescaling = cms.double(50.0),
     RegionFactoryPSet = cms.PSet(
         RegionPSetBlock,
@@ -75,18 +75,18 @@ combinatorialcosmicseedfinder = cms.EDProducer("CtfSpecialSeedGenerator",
         PropagationDirection = cms.string('alongMomentum'),
         NavigationDirection = cms.string('outsideIn')
     ), 
-        cms.PSet(
-            ComponentName = cms.string('GenericPairGenerator'),
-            LayerSrc = cms.InputTag("combinatorialcosmicseedingpairsTECpos"),
-            PropagationDirection = cms.string('alongMomentum'),
-            NavigationDirection = cms.string('outsideIn')
-        ), 
-        cms.PSet(
-            ComponentName = cms.string('GenericTripletGenerator'),
-            LayerSrc = cms.InputTag("combinatorialcosmicseedingtripletsTIB"),
-            PropagationDirection = cms.string('oppositeToMomentum'),
-            NavigationDirection = cms.string('insideOut')
-        )),
+    cms.PSet(
+        ComponentName = cms.string('GenericPairGenerator'),
+        LayerSrc = cms.InputTag("combinatorialcosmicseedingpairsTECpos"),
+        PropagationDirection = cms.string('alongMomentum'),
+        NavigationDirection = cms.string('outsideIn')
+    ), 
+    cms.PSet(
+        ComponentName = cms.string('GenericTripletGenerator'),
+        LayerSrc = cms.InputTag("combinatorialcosmicseedingtripletsTIB"),
+        PropagationDirection = cms.string('oppositeToMomentum'),
+        NavigationDirection = cms.string('insideOut')
+    )),
     UseScintillatorsConstraint = cms.bool(True),
     TTRHBuilder = cms.string('WithTrackAngle'),
     LowerScintillatorParameters = cms.PSet(

--- a/RecoTracker/SpecialSeedGenerators/python/CombinatorialSeedGeneratorForCosmics_cfi.py
+++ b/RecoTracker/SpecialSeedGenerators/python/CombinatorialSeedGeneratorForCosmics_cfi.py
@@ -6,34 +6,37 @@ import FWCore.ParameterSet.Config as cms
 from RecoTracker.TkTrackingRegions.GlobalTrackingRegion_cfi import *
 from RecoLocalTracker.SiStripClusterizer.SiStripClusterChargeCut_cfi import *
 
-layerInfo = dict(
+layerInfo = cms.PSet(
     MTIB = cms.PSet(
         TTRHBuilder = cms.string('WithTrackAngle'),
-            clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutNone')),
+        clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutNone')),
         rphiRecHits = cms.InputTag("siStripMatchedRecHits","rphiRecHit")
     ),
     TIB = cms.PSet(
         matchedRecHits = cms.InputTag("siStripMatchedRecHits","matchedRecHit"),
         TTRHBuilder = cms.string('WithTrackAngle'),
-            clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutNone'))
+        clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutNone'))
     ),
     MTOB = cms.PSet(
-        TTRHBuilder = cms.string('WithTrackAngle'),            clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutNone')),
+        TTRHBuilder = cms.string('WithTrackAngle'),
+        clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutNone')),
         rphiRecHits = cms.InputTag("siStripMatchedRecHits","rphiRecHit")
     ),
     TOB = cms.PSet(
         matchedRecHits = cms.InputTag("siStripMatchedRecHits","matchedRecHit"),
-        TTRHBuilder = cms.string('WithTrackAngle'),            clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutNone'))
+        TTRHBuilder = cms.string('WithTrackAngle'),
+        clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutNone'))
     ),
     TEC = cms.PSet(
         useSimpleRphiHitsCleaner = cms.bool(True),
         minRing = cms.int32(5),
         matchedRecHits = cms.InputTag("siStripMatchedRecHits","matchedRecHit"),
         useRingSlector = cms.bool(False),
-        TTRHBuilder = cms.string('WithTrackAngle'),            clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutNone')),
+        TTRHBuilder = cms.string('WithTrackAngle'),
+        clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutNone')),
         rphiRecHits = cms.InputTag("siStripMatchedRecHits","rphiRecHit"),
         maxRing = cms.int32(7)
-    ),
+  )
 )
 combinatorialcosmicseedingtripletsTOB_layerList = cms.vstring('MTOB4+MTOB5+MTOB6',
     'MTOB3+MTOB5+MTOB6',

--- a/RecoTracker/SpecialSeedGenerators/python/SimpleCosmicBONSeeder_cff.py
+++ b/RecoTracker/SpecialSeedGenerators/python/SimpleCosmicBONSeeder_cff.py
@@ -3,7 +3,7 @@ import FWCore.ParameterSet.Config as cms
 from RecoTracker.SpecialSeedGenerators.SimpleCosmicBONSeeder_cfi import *
 import RecoTracker.TkSeedingLayers.seedingLayersEDProducer_cfi as _mod
 
-simpleCosmicBONSeedingLayers= _mod.seedingLayersEDProducer.clone(
+simpleCosmicBONSeedingLayers = _mod.seedingLayersEDProducer.clone(
+    layerInfo,
     layerList = cms.vstring(*layerList),
-    **layerInfo
 )

--- a/RecoTracker/SpecialSeedGenerators/python/SimpleCosmicBONSeeder_cff.py
+++ b/RecoTracker/SpecialSeedGenerators/python/SimpleCosmicBONSeeder_cff.py
@@ -1,8 +1,9 @@
 import FWCore.ParameterSet.Config as cms
 
 from RecoTracker.SpecialSeedGenerators.SimpleCosmicBONSeeder_cfi import *
+import RecoTracker.TkSeedingLayers.seedingLayersEDProducer_cfi as _mod
 
-simpleCosmicBONSeedingLayers = cms.EDProducer("SeedingLayersEDProducer",
-    layerInfo,
-    layerList = cms.vstring(*layerList)
+simpleCosmicBONSeedingLayers= _mod.seedingLayersEDProducer.clone(
+    layerList = cms.vstring(*layerList),
+    **layerInfo
 )

--- a/RecoTracker/SpecialSeedGenerators/python/SimpleCosmicBONSeeder_cfi.py
+++ b/RecoTracker/SpecialSeedGenerators/python/SimpleCosmicBONSeeder_cfi.py
@@ -1,5 +1,5 @@
 import FWCore.ParameterSet.Config as cms
-
+import RecoTracker.SpecialSeedGenerators.CombinatorialSeedGeneratorForCosmics_cfi
 def makeSimpleCosmicSeedLayers(*layers):
     layerList = cms.vstring()
     if 'ALL' in layers: 
@@ -27,34 +27,8 @@ def makeSimpleCosmicSeedLayers(*layers):
     #print "SEEDING LAYER LIST = ", layerList
     return layerList
 
-layerInfo = dict(
-    MTIB = cms.PSet(
-        TTRHBuilder = cms.string('WithTrackAngle'),
-            clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutNone')),
-        rphiRecHits = cms.InputTag("siStripMatchedRecHits","rphiRecHit")
-    ),
-    TIB = cms.PSet(
-        matchedRecHits = cms.InputTag("siStripMatchedRecHits","matchedRecHit"),
-        TTRHBuilder = cms.string('WithTrackAngle'),
-            clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutNone'))
-    ),
-    MTOB = cms.PSet(
-        TTRHBuilder = cms.string('WithTrackAngle'),            clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutNone')),
-        rphiRecHits = cms.InputTag("siStripMatchedRecHits","rphiRecHit")
-    ),
-    TOB = cms.PSet(
-        matchedRecHits = cms.InputTag("siStripMatchedRecHits","matchedRecHit"),
-        TTRHBuilder = cms.string('WithTrackAngle'),            clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutNone'))
-    ),
-    TEC = cms.PSet(
-        useSimpleRphiHitsCleaner = cms.bool(False),
-        minRing = cms.int32(5),
-        matchedRecHits = cms.InputTag("siStripMatchedRecHits","matchedRecHit"),
-        useRingSlector = cms.bool(False),
-        TTRHBuilder = cms.string('WithTrackAngle'),            clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutNone')),
-        rphiRecHits = cms.InputTag("siStripMatchedRecHits","rphiRecHit"),
-        maxRing = cms.int32(7)
-    ),
+layerInfo = RecoTracker.SpecialSeedGenerators.CombinatorialSeedGeneratorForCosmics_cfi.layerInfo.clone(
+    TEC = dict(useSimpleRphiHitsCleaner = False)
 )
 layerList = makeSimpleCosmicSeedLayers('ALL'),
 

--- a/RecoTracker/SpecialSeedGenerators/python/SimpleCosmicBONSeeder_cfi.py
+++ b/RecoTracker/SpecialSeedGenerators/python/SimpleCosmicBONSeeder_cfi.py
@@ -1,7 +1,5 @@
 import FWCore.ParameterSet.Config as cms
 
-import RecoTracker.SpecialSeedGenerators.CombinatorialSeedGeneratorForCosmics_cfi
-
 def makeSimpleCosmicSeedLayers(*layers):
     layerList = cms.vstring()
     if 'ALL' in layers: 
@@ -29,8 +27,34 @@ def makeSimpleCosmicSeedLayers(*layers):
     #print "SEEDING LAYER LIST = ", layerList
     return layerList
 
-layerInfo = RecoTracker.SpecialSeedGenerators.CombinatorialSeedGeneratorForCosmics_cfi.layerInfo.clone(
-    TEC = dict(useSimpleRphiHitsCleaner = False)
+layerInfo = dict(
+    MTIB = cms.PSet(
+        TTRHBuilder = cms.string('WithTrackAngle'),
+            clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutNone')),
+        rphiRecHits = cms.InputTag("siStripMatchedRecHits","rphiRecHit")
+    ),
+    TIB = cms.PSet(
+        matchedRecHits = cms.InputTag("siStripMatchedRecHits","matchedRecHit"),
+        TTRHBuilder = cms.string('WithTrackAngle'),
+            clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutNone'))
+    ),
+    MTOB = cms.PSet(
+        TTRHBuilder = cms.string('WithTrackAngle'),            clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutNone')),
+        rphiRecHits = cms.InputTag("siStripMatchedRecHits","rphiRecHit")
+    ),
+    TOB = cms.PSet(
+        matchedRecHits = cms.InputTag("siStripMatchedRecHits","matchedRecHit"),
+        TTRHBuilder = cms.string('WithTrackAngle'),            clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutNone'))
+    ),
+    TEC = cms.PSet(
+        useSimpleRphiHitsCleaner = cms.bool(False),
+        minRing = cms.int32(5),
+        matchedRecHits = cms.InputTag("siStripMatchedRecHits","matchedRecHit"),
+        useRingSlector = cms.bool(False),
+        TTRHBuilder = cms.string('WithTrackAngle'),            clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutNone')),
+        rphiRecHits = cms.InputTag("siStripMatchedRecHits","rphiRecHit"),
+        maxRing = cms.int32(7)
+    ),
 )
 layerList = makeSimpleCosmicSeedLayers('ALL'),
 


### PR DESCRIPTION
#### PR description: 
Optimization of the python configurations: Improve maintainability by cleaning up the duplicated and cloning from the default/reference configurations. 

RecoTracker/SpecialSeedGenerators/python/CombinatorialSeedGeneratorForBeamHalo_cff.py
RecoTracker/SpecialSeedGenerators/python/CombinatorialSeedGeneratorForBeamHalo_cfi.py
RecoTracker/SpecialSeedGenerators/python/CombinatorialSeedGeneratorForCosmics_cfi.py
RecoTracker/SpecialSeedGenerators/python/CombinatorialSeedGeneratorForCosmicsP5_cff.py
RecoTracker/SpecialSeedGenerators/python/CombinatorialSeedGeneratorForCosmicsRegionalReconstruction_cfi.py
RecoTracker/SpecialSeedGenerators/python/CombinatorialSeedGeneratorForCosmicsRegionalReconstruction_cff.py
RecoTracker/SpecialSeedGenerators/python/SimpleCosmicBONSeeder_cfi.py 
RecoTracker/SpecialSeedGenerators/python/SimpleCosmicBONSeeder_cff.py 
 
(The previous PRs were  [PR#33207](https://github.com/cms-sw/cmssw/pull/33207), [PR#33307](https://github.com/cms-sw/cmssw/pull/33307), [PR#33352](https://github.com/cms-sw/cmssw/pull/33352), [PR#33543](https://github.com/cms-sw/cmssw/pull/33543),  [PR#33563](https://github.com/cms-sw/cmssw/pull/33563),  [PR#33671](https://github.com/cms-sw/cmssw/pull/33671), [PR#33901](https://github.com/cms-sw/cmssw/pull/33901), [PR#34007](https://github.com/cms-sw/cmssw/pull/34007))

#### PR validation:
Event Content comparison check was also done and there is no change with these updates.
Tested in CMSSW_12_0_X, the basic test all passed in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html).