### PR TITLE
LowPtElectrons: embed extra info in pat::Electron for BParking UL

### DIFF
--- a/PhysicsTools/PatAlgos/python/slimming/slimmedLowPtElectrons_cfi.py
+++ b/PhysicsTools/PatAlgos/python/slimming/slimmedLowPtElectrons_cfi.py
@@ -44,7 +44,9 @@ slimmedLowPtElectrons = cms.EDProducer("PATElectronSlimmer",
 )
 
 from RecoEgamma.EgammaTools.lowPtElectronModifier_cfi import lowPtElectronModifier
+from Configuration.ProcessModifiers.run2_miniAOD_UL_cff import run2_miniAOD_UL
 from Configuration.Eras.Modifier_run2_miniAOD_devel_cff import run2_miniAOD_devel
 from Configuration.Eras.Modifier_bParking_cff import bParking
-(~bParking & run2_miniAOD_devel).toModify(slimmedLowPtElectrons.modifierConfig.modifications,
-                                          func = lambda m: m.append(lowPtElectronModifier))
+_modifiers = (~bParking & run2_miniAOD_devel) | (bParking & run2_miniAOD_UL)
+_modifiers.toModify(slimmedLowPtElectrons.modifierConfig.modifications,
+                    func = lambda m: m.append(lowPtElectronModifier))


### PR DESCRIPTION
#### PR description:

This PR enables the `LowPtElectronModifier` to embed additional information in low-pT pat::Electrons for the BParking UL campaign. The additional information concerns [photons conversions]() and [impact parameter vars]() (dxy, dz). The modifier is enabled with the logic `(bParking & run2_miniAOD_UL)`.

This logic is already enabled (by [default](https://github.com/cms-sw/cmssw/pull/33817/files?file-filters%5B%5D=.py#diff-871bd8b66df9b2a1342ddbfebcfaa9d089b604c1259c8120f90bbc51fde86491R44)) in master via PR #33817.

This PR is built on top of PR #33992, which has been recently merged. 

#### PR validation:

Local tests before/after the change based on wf 136.898.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This logic is already enabled (by [default](https://github.com/cms-sw/cmssw/pull/33817/files?file-filters%5B%5D=.py#diff-871bd8b66df9b2a1342ddbfebcfaa9d089b604c1259c8120f90bbc51fde86491R44)) in master via PR #33817.
