### PR TITLE
Usage of displaced collections in the B-parking data

### DIFF
--- a/PhysicsTools/PatAlgos/python/slimming/MicroEventContent_cff.py
+++ b/PhysicsTools/PatAlgos/python/slimming/MicroEventContent_cff.py
@@ -88,6 +88,8 @@ MicroEventContent = cms.PSet(
         'keep recoForwardProtons_ctppsProtons_*_*',
 	# displacedStandAlone muon collection for EXO
 	'keep recoTracks_displacedStandAloneMuons__*',
+        'keep recoTracks_displacedGlobalMuons__*',
+        'keep recoTracks_displacedTracks__*',
         # L1 prefiring weights
         'keep *_prefiringweight_*_*',
         # patLowPtElectrons
@@ -118,12 +120,6 @@ MicroEventContentGEN = cms.PSet(
         'keep *_genParticles_t0_*',
     )
 )
-
-# keep displaced objects for b-parking era
-from Configuration.Eras.Modifier_bParking_cff import bParking
-_bparking_displaced_extraCommands = ['keep recoTracks_displacedGlobalMuons_*_*', 
-                                     'keep recoTracks_displacedTracks_*_*',]
-bParking.toModify(MicroEventContent,outputCommands = MicroEventContent.outputCommands + _bparking_displaced_extraCommands)
 
 # --- Only for 2018 data & MC
 _run2_HCAL_2018_extraCommands = ["keep *_packedPFCandidates_hcalDepthEnergyFractions_*"]

--- a/PhysicsTools/PatAlgos/python/slimming/MicroEventContent_cff.py
+++ b/PhysicsTools/PatAlgos/python/slimming/MicroEventContent_cff.py
@@ -119,6 +119,12 @@ MicroEventContentGEN = cms.PSet(
     )
 )
 
+# keep displaced objects for b-parking era
+from Configuration.Eras.Modifier_bParking_cff import bParking
+_bparking_displaced_extraCommands = ['keep recoTracks_displacedGlobalMuons_*_*', 
+                                     'keep recoTracks_displacedTracks_*_*',]
+bParking.toModify(MicroEventContent,outputCommands = MicroEventContent.outputCommands + _bparking_displaced_extraCommands)
+
 # --- Only for 2018 data & MC
 _run2_HCAL_2018_extraCommands = ["keep *_packedPFCandidates_hcalDepthEnergyFractions_*"]
 from Configuration.Eras.Modifier_run2_HCAL_2018_cff import run2_HCAL_2018

--- a/PhysicsTools/PatAlgos/python/slimming/slimmedTrackExtras_cff.py
+++ b/PhysicsTools/PatAlgos/python/slimming/slimmedTrackExtras_cff.py
@@ -17,6 +17,10 @@ fastSim.toModify(slimmedMuonTrackExtras, outputClusters = False)
 from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
 phase2_tracker.toModify(slimmedMuonTrackExtras, outputClusters = False)
 
+# lower minimum pt for B-parking
+from Configuration.Eras.Modifier_bParking_cff import bParking
+bParking.toModify(slimmedMuonTrackExtras, cut = "pt > 3.0")
+
 # full set of track extras not available in existing AOD
 from Configuration.Eras.Modifier_run2_miniAOD_80XLegacy_cff import run2_miniAOD_80XLegacy
 from Configuration.Eras.Modifier_run2_miniAOD_94XFall17_cff import run2_miniAOD_94XFall17


### PR DESCRIPTION
This PR includes modifications to allow usage of displaced muon collections in the B-parking data, in view of the upcoming b-parking UL re-reco, at small cost in miniAOD size.

(1) the two collections of reco::Tracks, `displacedGlobalMuons` and `displacedTracks`, are added to the miniAOD in general (not for a specific era).
The size increase was checked in a MINIAODSIM sample with similar PU conditions as the b-parking data and was found to be

displacedGlobalMuons: +256 Bytes/event +0.2%
displacedTracks: +343 Bytes/event +0.3%
Note that the `displacedStandAloneMuons` (dSA) are already included by default.

(2) thanks to the extra information (TrackExtra and TrackingRecHits) made available for the PAT muons by #31350, it should be possible to extrapolate the PAT muon trajectory to the innermost hit of the dSA, allowing for a more precise dR matching, compared to simple dR matching. In order to use this information also for low pt muons, it is proposed to lower the minimum pt at which the information is saved in MINIAOD from 4.5 GeV to 3.0 GeV, but only for the b-parking era.

The size increase was evaluated by Josh to be about 1 KB/evt, corresponding to less than +1%
#30544 (comment)

Additionally, the PR validation was done by running runTheMatrix.py -l limited -i all --ibeos, the output is attached
[runall-report-step123-master.log](https://github.com/cms-sw/cmssw/files/6616854/runall-report-step123-master.log) 

From other PRs for the b-parking, I saw mentioned the workflow ‘1304.181’ for the purpose of testing the b-parking era. 

A backport to 106X is needed and is open at #34008 