### PR TITLE
move to py3 tool definition for pybind11 

### DIFF
--- a/CondCore/CondDB/plugins/BuildFile.xml
+++ b/CondCore/CondDB/plugins/BuildFile.xml
@@ -5,7 +5,7 @@
 
 <library file="CondDBPyBind11Wrappers.cc" name="CondDBPyBind11Interface">
   <use name="CondCore/CondDB"/>
-  <use name="py2-pybind11"/>
+  <use name="py3-pybind11"/>
   <use name="python"/>
 </library>                                                                                                                                                                    
 

--- a/FWCore/ParameterSetReader/BuildFile.xml
+++ b/FWCore/ParameterSetReader/BuildFile.xml
@@ -2,5 +2,5 @@
 <use name="FWCore/PythonParameterSet"/>
 <export>
   <lib name="1"/>
-  <use name="py2-pybind11"/>
+  <use name="py3-pybind11"/>
 </export>

--- a/FWCore/PyDevParameterSet/BuildFile.xml
+++ b/FWCore/PyDevParameterSet/BuildFile.xml
@@ -1,9 +1,9 @@
 <use name="DataFormats/Provenance"/>
 <use name="FWCore/ParameterSet"/>
 <use name="FWCore/Utilities"/>
-<use name="py2-pybind11"/>
+<use name="py3-pybind11"/>
 <use name="python3"/>
 <export>
-  <use name="py2-pybind11"/>
+  <use name="py3-pybind11"/>
   <lib name="1"/>
 </export>

--- a/FWCore/PyDevParameterSet/test/BuildFile.xml
+++ b/FWCore/PyDevParameterSet/test/BuildFile.xml
@@ -1,5 +1,5 @@
 <bin name="testPyBind11ParameterSet" file="processbuilder_t.cppunit.cpp,makeprocess_t.cppunit.cc,makepset_t.cppunit.cc,readpsetsfrom_t.cppunit.cc">
-  <use name="py2-pybind11"/>
+  <use name="py3-pybind11"/>
   <use name="cppunit"/>
   <use name="FWCore/ParameterSet"/>
   <use name="FWCore/PyDevParameterSet"/>

--- a/FWCore/PythonFramework/BuildFile.xml
+++ b/FWCore/PythonFramework/BuildFile.xml
@@ -7,7 +7,7 @@
 <use name="FWCore/ServiceRegistry"/>
 <use name="FWCore/Utilities"/>
 <use name="boost"/>
-<use name="py2-pybind11"/>
+<use name="py3-pybind11"/>
 <export>
   <lib name="1"/>
 </export>

--- a/FWCore/PythonParameterSet/BuildFile.xml
+++ b/FWCore/PythonParameterSet/BuildFile.xml
@@ -1,9 +1,9 @@
 <use name="DataFormats/Provenance"/>
 <use name="FWCore/ParameterSet"/>
 <use name="FWCore/Utilities"/>
-<use name="py2-pybind11"/>
+<use name="py3-pybind11"/>
 <use name="python"/>
 <export>
-  <use name="py2-pybind11"/>
+  <use name="py3-pybind11"/>
   <lib name="1"/>
 </export>

--- a/FWCore/PythonParameterSet/test/BuildFile.xml
+++ b/FWCore/PythonParameterSet/test/BuildFile.xml
@@ -1,5 +1,5 @@
 <bin name="testPyDevParameterSet" file="processbuilder_t.cppunit.cpp,makeprocess_t.cppunit.cc,makepset_t.cppunit.cc,readpsetsfrom_t.cppunit.cc">
-  <use name="py2-pybind11"/>
+  <use name="py3-pybind11"/>
   <use name="cppunit"/>
   <use name="FWCore/ParameterSet"/>
   <use name="FWCore/PythonParameterSet"/>


### PR DESCRIPTION
pybind11 is header only and does not depend on python directly (in the tool sense). 
Requires a cmsdist upgrade.