### PR TITLE
Reduced excessive number of iterations in test.

### DIFF
--- a/DataFormats/GeometryVector/test/PhiTest.cc
+++ b/DataFormats/GeometryVector/test/PhiTest.cc
@@ -57,7 +57,7 @@ static int testSmall() {  // Test with long double
 template <class valType>
 static int iterationTest(valType increm) {
   Phi<valType, ZeroTo2pi> ang1 = 0.;
-  const int iters = 123456789;
+  const int iters = 1000 * 1000;
   steady_clock::time_point startTime = steady_clock::now();
   for (int cnt = 0; cnt < iters; ++cnt) {
     ang1 += increm;
@@ -88,7 +88,7 @@ static int iterationTest(valType increm) {
 template <class valType>
 static int iter3Test(valType increm) {
   // const int iters = 1234567899;
-  const int iters = 1234567980;
+  const int iters = 1000 * 1000;
   valType ang1 = 0.;
   steady_clock::time_point startTime = steady_clock::now();
   for (int cnt = 0; cnt < iters; ++cnt) {


### PR DESCRIPTION
#### PR description:

`PhiTest` took more than an hour on ARM architecture and timed out in continuous integration.
Reduced the number of iterations to 1 million, which is enough to assess performance (typical
PC clock precision is about 10 us).

#### PR validation:

This change reduces the number of iterations of a loop test to get completion within seconds instead of about 1hour on ARM
architetcure (it's faster on Intel). This PR does not touch production code.


