### PR TITLE
Add tbb task isolation so TTree::Fill doesn't steal framework tasks

### DIFF
--- a/PhysicsTools/NanoAOD/plugins/NanoAODOutputModule.cc
+++ b/PhysicsTools/NanoAOD/plugins/NanoAODOutputModule.cc
@@ -45,6 +45,8 @@
 
 #include <iostream>
 
+#include "tbb/task_arena.h"
+
 class NanoAODOutputModule : public edm::one::OutputModule<> {
 public:
   NanoAODOutputModule(edm::ParameterSet const& pset);
@@ -216,7 +218,7 @@ void NanoAODOutputModule::write(edm::EventForOutput const& iEvent) {
   // fill event branches
   for (auto& t : m_evstrings)
     t.fill(iEvent, *m_tree);
-  m_tree->Fill();
+  tbb::this_task_arena::isolate([&] { m_tree->Fill(); });
 
   m_processHistoryRegistry.registerProcessHistory(iEvent.processHistory());
 }
@@ -230,7 +232,7 @@ void NanoAODOutputModule::writeLuminosityBlock(edm::LuminosityBlockForOutput con
   for (auto& t : m_lumiTables)
     t.fill(iLumi, *m_lumiTree);
 
-  m_lumiTree->Fill();
+  tbb::this_task_arena::isolate([&] { m_lumiTree->Fill(); });
 
   m_processHistoryRegistry.registerProcessHistory(iLumi.processHistory());
 }
@@ -262,7 +264,7 @@ void NanoAODOutputModule::writeRun(edm::RunForOutput const& iRun) {
     }
   }
 
-  m_runTree->Fill();
+  tbb::this_task_arena::isolate([&] { m_runTree->Fill(); });
 
   m_processHistoryRegistry.registerProcessHistory(iRun.processHistory());
 }


### PR DESCRIPTION
#### PR description:

When IMT is enabled (the default for multi-threaded jobs), `TTree::Fill()` parallelizes compression using a `TTaskGroup`.  If the initial task in the group finishes before the subtasks, it can steal a framework task, which can cause large delays while the group waits for the framework task to finish.  This PR adds calls to `tbb::this_task_arena::isolate()` which prevents the initial task stealing any subtasks that it did not create.  This matches what is done in [PoolOutputModule](https://github.com/cms-sw/cmssw/blob/71f33231f1fb503b1a2cf6cff13a7b78b130cc71/IOPool/Output/src/RootOutputTree.cc#L322-L324).

Noticed while reviewing the RNTuple NanoAOD producer.

#### PR validation:

Trivial technical fix.  It compiles, and runtests passes.