### PR TITLE
Template for migrating Sensitive Detectors to esConsumes

### DIFF
--- a/SimG4CMS/Calo/interface/CaloSD.h
+++ b/SimG4CMS/Calo/interface/CaloSD.h
@@ -20,6 +20,7 @@
 #include "SimG4Core/SensitiveDetector/interface/SensitiveCaloDetector.h"
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ParameterSetfwd.h"
 
 #include "G4VPhysicalVolume.hh"
 #include "G4Track.hh"
@@ -44,7 +45,6 @@ class CaloSD : public SensitiveCaloDetector,
                public Observer<const EndOfEvent*> {
 public:
   CaloSD(const std::string& aSDname,
-         const edm::EventSetup& es,
          const SensitiveDetectorCatalog& clg,
          edm::ParameterSet const& p,
          const SimTrackManager*,

--- a/SimG4CMS/Calo/interface/CaloTrkProcessing.h
+++ b/SimG4CMS/Calo/interface/CaloTrkProcessing.h
@@ -4,6 +4,8 @@
 #include "SimG4Core/Notification/interface/Observer.h"
 #include "SimG4Core/SensitiveDetector/interface/SensitiveCaloDetector.h"
 
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/ParameterSet/interface/ParameterSetfwd.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include "G4VTouchable.hh"

--- a/SimG4CMS/Calo/interface/ECalSD.h
+++ b/SimG4CMS/Calo/interface/ECalSD.h
@@ -14,6 +14,8 @@
 #include "Geometry/EcalCommonData/interface/EcalNumberingScheme.h"
 #include "CondFormats/GeometryObjects/interface/EcalSimulationParameters.h"
 #include "DataFormats/DetId/interface/DetId.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/ParameterSet/interface/ParameterSetfwd.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #ifdef plotDebug

--- a/SimG4CMS/Calo/src/CaloSD.cc
+++ b/SimG4CMS/Calo/src/CaloSD.cc
@@ -11,6 +11,7 @@
 #include "Geometry/Records/interface/HcalParametersRcd.h"
 #include "CondFormats/GeometryObjects/interface/CaloSimulationParameters.h"
 #include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/Exception.h"
 
 #include "G4EventManager.hh"
@@ -33,13 +34,12 @@
 //#define EDM_ML_DEBUG
 
 CaloSD::CaloSD(const std::string& name,
-               const edm::EventSetup& es,
                const SensitiveDetectorCatalog& clg,
                edm::ParameterSet const& p,
                const SimTrackManager* manager,
                float timeSliceUnit,
                bool ignoreTkID)
-    : SensitiveCaloDetector(name, es, clg, p),
+    : SensitiveCaloDetector(name, clg),
       G4VGFlashSensitiveDetector(),
       eminHit(0.),
       currentHit(nullptr),

--- a/SimG4CMS/Calo/src/CaloTrkProcessing.cc
+++ b/SimG4CMS/Calo/src/CaloTrkProcessing.cc
@@ -9,6 +9,7 @@
 #include "Geometry/Records/interface/HcalParametersRcd.h"
 #include "CondFormats/GeometryObjects/interface/CaloSimulationParameters.h"
 #include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/Exception.h"
 
 #include "G4EventManager.hh"
@@ -27,7 +28,7 @@ CaloTrkProcessing::CaloTrkProcessing(const std::string& name,
                                      const SensitiveDetectorCatalog& clg,
                                      edm::ParameterSet const& p,
                                      const SimTrackManager*)
-    : SensitiveCaloDetector(name, es, clg, p), lastTrackID_(-1) {
+    : SensitiveCaloDetector(name, clg), lastTrackID_(-1) {
   //Initialise the parameter set
   bool dd4hep = p.getParameter<bool>("g4GeometryDD4hepSource");
   int addlevel = dd4hep ? 1 : 0;

--- a/SimG4CMS/Calo/src/ECalSD.cc
+++ b/SimG4CMS/Calo/src/ECalSD.cc
@@ -45,7 +45,6 @@ ECalSD::ECalSD(const std::string& name,
                edm::ParameterSet const& p,
                const SimTrackManager* manager)
     : CaloSD(name,
-             es,
              clg,
              p,
              manager,

--- a/SimG4CMS/Calo/src/HCalSD.cc
+++ b/SimG4CMS/Calo/src/HCalSD.cc
@@ -50,7 +50,6 @@ HCalSD::HCalSD(const std::string& name,
                edm::ParameterSet const& p,
                const SimTrackManager* manager)
     : CaloSD(name,
-             es,
              clg,
              p,
              manager,

--- a/SimG4CMS/Calo/src/HFNoseSD.cc
+++ b/SimG4CMS/Calo/src/HFNoseSD.cc
@@ -33,7 +33,6 @@ HFNoseSD::HFNoseSD(const std::string& name,
                    edm::ParameterSet const& p,
                    const SimTrackManager* manager)
     : CaloSD(name,
-             es,
              clg,
              p,
              manager,

--- a/SimG4CMS/Calo/src/HGCSD.cc
+++ b/SimG4CMS/Calo/src/HGCSD.cc
@@ -38,7 +38,6 @@ HGCSD::HGCSD(const std::string& name,
              edm::ParameterSet const& p,
              const SimTrackManager* manager)
     : CaloSD(name,
-             es,
              clg,
              p,
              manager,

--- a/SimG4CMS/Calo/src/HGCScintSD.cc
+++ b/SimG4CMS/Calo/src/HGCScintSD.cc
@@ -36,7 +36,6 @@ HGCScintSD::HGCScintSD(const std::string& name,
                        edm::ParameterSet const& p,
                        const SimTrackManager* manager)
     : CaloSD(name,
-             es,
              clg,
              p,
              manager,

--- a/SimG4CMS/Calo/src/HGCalSD.cc
+++ b/SimG4CMS/Calo/src/HGCalSD.cc
@@ -34,7 +34,6 @@ HGCalSD::HGCalSD(const std::string& name,
                  edm::ParameterSet const& p,
                  const SimTrackManager* manager)
     : CaloSD(name,
-             es,
              clg,
              p,
              manager,

--- a/SimG4CMS/CherenkovAnalysis/interface/DreamSD.h
+++ b/SimG4CMS/CherenkovAnalysis/interface/DreamSD.h
@@ -4,6 +4,9 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "SimG4CMS/Calo/interface/CaloSD.h"
 
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/ParameterSet/interface/ParameterSetfwd.h"
+
 #include "G4PhysicsFreeVector.hh"
 
 #include <DD4hep/DD4hepUnits.h>

--- a/SimG4CMS/CherenkovAnalysis/src/DreamSD.cc
+++ b/SimG4CMS/CherenkovAnalysis/src/DreamSD.cc
@@ -39,7 +39,7 @@ DreamSD::DreamSD(const std::string &name,
                  const SensitiveDetectorCatalog &clg,
                  edm::ParameterSet const &p,
                  const SimTrackManager *manager)
-    : CaloSD(name, es, clg, p, manager) {
+    : CaloSD(name, clg, p, manager) {
   edm::ParameterSet m_EC = p.getParameter<edm::ParameterSet>("ECalSD");
   useBirk_ = m_EC.getParameter<bool>("UseBirkLaw");
   doCherenkov_ = m_EC.getParameter<bool>("doCherenkov");

--- a/SimG4CMS/EcalTestBeam/interface/EcalTBH4BeamSD.h
+++ b/SimG4CMS/EcalTestBeam/interface/EcalTBH4BeamSD.h
@@ -10,6 +10,8 @@
 #include "Geometry/EcalCommonData/interface/EcalNumberingScheme.h"
 #include "SimG4CMS/Calo/interface/CaloSD.h"
 
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/ParameterSet/interface/ParameterSetfwd.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 //#include "G4String.hh"

--- a/SimG4CMS/EcalTestBeam/src/EcalTBH4BeamSD.cc
+++ b/SimG4CMS/EcalTestBeam/src/EcalTBH4BeamSD.cc
@@ -24,7 +24,7 @@ EcalTBH4BeamSD::EcalTBH4BeamSD(const std::string &name,
                                const SensitiveDetectorCatalog &clg,
                                edm::ParameterSet const &p,
                                const SimTrackManager *manager)
-    : CaloSD(name, es, clg, p, manager), numberingScheme(nullptr) {
+    : CaloSD(name, clg, p, manager), numberingScheme(nullptr) {
   edm::ParameterSet m_EcalTBH4BeamSD = p.getParameter<edm::ParameterSet>("EcalTBH4BeamSD");
   useBirk = m_EcalTBH4BeamSD.getParameter<bool>("UseBirkLaw");
   birk1 = m_EcalTBH4BeamSD.getParameter<double>("BirkC1") * (g / (MeV * cm2));

--- a/SimG4CMS/FP420/interface/FP420SD.h
+++ b/SimG4CMS/FP420/interface/FP420SD.h
@@ -19,6 +19,9 @@
 #include "SimG4CMS/FP420/interface/FP420G4HitCollection.h"
 #include "SimG4CMS/FP420/interface/FP420NumberingScheme.h"
 
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/ParameterSet/interface/ParameterSetfwd.h"
+
 #include "G4Step.hh"
 #include "G4StepPoint.hh"
 #include "G4Track.hh"

--- a/SimG4CMS/FP420/plugins/FP420SD.cc
+++ b/SimG4CMS/FP420/plugins/FP420SD.cc
@@ -21,6 +21,7 @@
 
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include "SimG4Core/Notification/interface/TrackInformation.h"
@@ -48,7 +49,7 @@ FP420SD::FP420SD(const std::string& name,
                  const SensitiveDetectorCatalog& clg,
                  edm::ParameterSet const& p,
                  const SimTrackManager* manager)
-    : SensitiveTkDetector(name, es, clg, p),
+    : SensitiveTkDetector(name, clg),
       numberingScheme(nullptr),
       hcID(-1),
       theHC(nullptr),

--- a/SimG4CMS/Forward/interface/BHMSD.h
+++ b/SimG4CMS/Forward/interface/BHMSD.h
@@ -3,6 +3,8 @@
 
 #include "SimG4CMS/Forward/interface/TimingSD.h"
 
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/ParameterSet/interface/ParameterSetfwd.h"
 #include <string>
 
 class SimTrackManager;

--- a/SimG4CMS/Forward/interface/Bcm1fSD.h
+++ b/SimG4CMS/Forward/interface/Bcm1fSD.h
@@ -2,6 +2,8 @@
 #define Forward_Bcm1fSD_h
 
 #include "SimG4CMS/Forward/interface/TimingSD.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/ParameterSet/interface/ParameterSetfwd.h"
 
 #include <string>
 

--- a/SimG4CMS/Forward/interface/BscSD.h
+++ b/SimG4CMS/Forward/interface/BscSD.h
@@ -2,6 +2,8 @@
 #define SimG4CMSForward_BscSD_h
 
 #include "SimG4CMS/Forward/interface/TimingSD.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/ParameterSet/interface/ParameterSetfwd.h"
 
 #include <string>
 

--- a/SimG4CMS/Forward/interface/CastorSD.h
+++ b/SimG4CMS/Forward/interface/CastorSD.h
@@ -25,6 +25,9 @@
 #include "SimG4CMS/Forward/interface/CastorShowerLibrary.h"
 #include "SimG4CMS/Forward/interface/CastorNumberingScheme.h"
 #include "SimDataFormats/CaloHit/interface/CastorShowerEvent.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/ParameterSet/interface/ParameterSetfwd.h"
+
 #include "G4LogicalVolume.hh"
 
 class CastorSD : public CaloSD {

--- a/SimG4CMS/Forward/interface/MtdSD.h
+++ b/SimG4CMS/Forward/interface/MtdSD.h
@@ -2,6 +2,8 @@
 #define SimG4CMSForward_MtdSD_h
 
 #include "SimG4CMS/Forward/interface/TimingSD.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/ParameterSet/interface/ParameterSetfwd.h"
 
 #include "Geometry/MTDCommonData/interface/MTDNumberingScheme.h"
 #include "Geometry/MTDCommonData/interface/MTDBaseNumber.h"

--- a/SimG4CMS/Forward/interface/PltSD.h
+++ b/SimG4CMS/Forward/interface/PltSD.h
@@ -2,6 +2,8 @@
 #define Forward_PltSD_h
 
 #include "SimG4CMS/Forward/interface/TimingSD.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/ParameterSet/interface/ParameterSetfwd.h"
 
 #include <string>
 

--- a/SimG4CMS/Forward/interface/TimingSD.h
+++ b/SimG4CMS/Forward/interface/TimingSD.h
@@ -28,11 +28,7 @@ class G4ProcessTypeEnumerator;
 
 class TimingSD : public SensitiveTkDetector, public Observer<const BeginOfEvent*> {
 public:
-  TimingSD(const std::string&,
-           const edm::EventSetup&,
-           const SensitiveDetectorCatalog&,
-           const edm::ParameterSet&,
-           const SimTrackManager*);
+  TimingSD(const std::string&, const SensitiveDetectorCatalog&, const SimTrackManager*);
 
   ~TimingSD() override;
 

--- a/SimG4CMS/Forward/interface/TotemSD.h
+++ b/SimG4CMS/Forward/interface/TotemSD.h
@@ -31,6 +31,9 @@
 #include "SimG4CMS/Forward/interface/TotemG4HitCollection.h"
 #include "SimG4CMS/Forward/interface/TotemVDetectorOrganization.h"
 
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/ParameterSet/interface/ParameterSetfwd.h"
+
 #include "G4Step.hh"
 #include "G4StepPoint.hh"
 #include "G4Track.hh"

--- a/SimG4CMS/Forward/interface/TotemT2ScintSD.h
+++ b/SimG4CMS/Forward/interface/TotemT2ScintSD.h
@@ -3,6 +3,8 @@
 
 #include "SimG4CMS/Calo/interface/CaloSD.h"
 #include "SimG4CMS/Forward/interface/TotemT2ScintNumberingScheme.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/ParameterSet/interface/ParameterSetfwd.h"
 
 class TotemT2ScintSD : public CaloSD {
 public:

--- a/SimG4CMS/Forward/interface/ZdcSD.h
+++ b/SimG4CMS/Forward/interface/ZdcSD.h
@@ -9,6 +9,8 @@
 #include "SimG4CMS/Calo/interface/CaloSD.h"
 #include "SimG4CMS/Forward/interface/ZdcShowerLibrary.h"
 #include "SimG4CMS/Forward/interface/ZdcNumberingScheme.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/ParameterSet/interface/ParameterSetfwd.h"
 
 class ZdcSD : public CaloSD {
 public:

--- a/SimG4CMS/Forward/src/BHMSD.cc
+++ b/SimG4CMS/Forward/src/BHMSD.cc
@@ -3,6 +3,7 @@
 
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include "G4Step.hh"
@@ -16,7 +17,7 @@ BHMSD::BHMSD(const std::string& name,
              const SensitiveDetectorCatalog& clg,
              edm::ParameterSet const& p,
              const SimTrackManager* manager)
-    : TimingSD(name, es, clg, p, manager), numberingScheme(nullptr) {
+    : TimingSD(name, clg, manager), numberingScheme(nullptr) {
   //Parameters
   edm::ParameterSet m_p = p.getParameter<edm::ParameterSet>("BHMSD");
   int verbn = m_p.getUntrackedParameter<int>("Verbosity");

--- a/SimG4CMS/Forward/src/Bcm1fSD.cc
+++ b/SimG4CMS/Forward/src/Bcm1fSD.cc
@@ -15,6 +15,7 @@
 #include "FWCore/Framework/interface/ESTransientHandle.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include "G4Track.hh"
@@ -35,7 +36,7 @@ Bcm1fSD::Bcm1fSD(const std::string& name,
                  const SensitiveDetectorCatalog& clg,
                  edm::ParameterSet const& p,
                  const SimTrackManager* manager)
-    : TimingSD(name, es, clg, p, manager) {
+    : TimingSD(name, clg, manager) {
   edm::ParameterSet m_TrackerSD = p.getParameter<edm::ParameterSet>("Bcm1fSD");
   energyCut = m_TrackerSD.getParameter<double>("EnergyThresholdForPersistencyInGeV") * GeV;  //default must be 0.5 (?)
   energyHistoryCut =

--- a/SimG4CMS/Forward/src/BscSD.cc
+++ b/SimG4CMS/Forward/src/BscSD.cc
@@ -12,6 +12,7 @@
 
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include "G4Step.hh"
@@ -25,7 +26,7 @@ BscSD::BscSD(const std::string& name,
              const SensitiveDetectorCatalog& clg,
              edm::ParameterSet const& p,
              const SimTrackManager* manager)
-    : TimingSD(name, es, clg, p, manager), numberingScheme(nullptr) {
+    : TimingSD(name, clg, manager), numberingScheme(nullptr) {
   //Parameters
   edm::ParameterSet m_p = p.getParameter<edm::ParameterSet>("BscSD");
   int verbn = m_p.getUntrackedParameter<int>("Verbosity");

--- a/SimG4CMS/Forward/src/CastorSD.cc
+++ b/SimG4CMS/Forward/src/CastorSD.cc
@@ -33,7 +33,7 @@ CastorSD::CastorSD(const std::string& name,
                    const SensitiveDetectorCatalog& clg,
                    edm::ParameterSet const& p,
                    const SimTrackManager* manager)
-    : CaloSD(name, es, clg, p, manager),
+    : CaloSD(name, clg, p, manager),
       numberingScheme(nullptr),
       lvC3EF(nullptr),
       lvC3HF(nullptr),

--- a/SimG4CMS/Forward/src/MtdSD.cc
+++ b/SimG4CMS/Forward/src/MtdSD.cc
@@ -2,6 +2,7 @@
 
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include "Geometry/Records/interface/IdealGeometryRecord.h"
@@ -23,7 +24,7 @@ MtdSD::MtdSD(const std::string& name,
              const SensitiveDetectorCatalog& clg,
              edm::ParameterSet const& p,
              const SimTrackManager* manager)
-    : TimingSD(name, es, clg, p, manager), numberingScheme(nullptr) {
+    : TimingSD(name, clg, manager), numberingScheme(nullptr) {
   //Parameters
   edm::ParameterSet m_p = p.getParameter<edm::ParameterSet>("MtdSD");
   int verbn = m_p.getUntrackedParameter<int>("Verbosity");

--- a/SimG4CMS/Forward/src/PltSD.cc
+++ b/SimG4CMS/Forward/src/PltSD.cc
@@ -3,6 +3,7 @@
 #include "FWCore/Framework/interface/ESTransientHandle.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include "G4Step.hh"
@@ -20,7 +21,7 @@ PltSD::PltSD(const std::string& name,
              const SensitiveDetectorCatalog& clg,
              edm::ParameterSet const& p,
              const SimTrackManager* manager)
-    : TimingSD(name, es, clg, p, manager) {
+    : TimingSD(name, clg, manager) {
   edm::ParameterSet m_TrackerSD = p.getParameter<edm::ParameterSet>("PltSD");
   energyCut =
       m_TrackerSD.getParameter<double>("EnergyThresholdForPersistencyInGeV") * CLHEP::GeV;  //default must be 0.5

--- a/SimG4CMS/Forward/src/TimingSD.cc
+++ b/SimG4CMS/Forward/src/TimingSD.cc
@@ -37,12 +37,8 @@ static const double invns = 1.0 / CLHEP::nanosecond;
 static const double invdeg = 1.0 / CLHEP::deg;
 
 //-------------------------------------------------------------------
-TimingSD::TimingSD(const std::string& name,
-                   const edm::EventSetup& es,
-                   const SensitiveDetectorCatalog& clg,
-                   edm::ParameterSet const& p,
-                   const SimTrackManager* manager)
-    : SensitiveTkDetector(name, es, clg, p),
+TimingSD::TimingSD(const std::string& name, const SensitiveDetectorCatalog& clg, const SimTrackManager* manager)
+    : SensitiveTkDetector(name, clg),
       theManager(manager),
       theHC(nullptr),
       currentHit(nullptr),

--- a/SimG4CMS/Forward/src/TotemSD.cc
+++ b/SimG4CMS/Forward/src/TotemSD.cc
@@ -15,6 +15,7 @@
 // user include files
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include "SimG4Core/Notification/interface/TrackInformation.h"
@@ -49,7 +50,7 @@ TotemSD::TotemSD(const std::string& name,
                  const SensitiveDetectorCatalog& clg,
                  edm::ParameterSet const& p,
                  const SimTrackManager* manager)
-    : SensitiveTkDetector(name, es, clg, p),
+    : SensitiveTkDetector(name, clg),
       numberingScheme(nullptr),
       hcID(-1),
       theHC(nullptr),

--- a/SimG4CMS/Forward/src/TotemT2ScintSD.cc
+++ b/SimG4CMS/Forward/src/TotemT2ScintSD.cc
@@ -1,5 +1,6 @@
 #include "SimG4CMS/Forward/interface/TotemT2ScintSD.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "SimG4Core/Notification/interface/TrackInformation.h"
 
 #include "G4SDManager.hh"
@@ -22,7 +23,6 @@ TotemT2ScintSD::TotemT2ScintSD(const std::string& name,
                                edm::ParameterSet const& p,
                                const SimTrackManager* manager)
     : CaloSD(name,
-             es,
              clg,
              p,
              manager,

--- a/SimG4CMS/Forward/src/ZdcSD.cc
+++ b/SimG4CMS/Forward/src/ZdcSD.cc
@@ -9,6 +9,7 @@
 #include "SimG4CMS/Forward/interface/ZdcSD.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/Framework/interface/ESTransientHandle.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "Geometry/Records/interface/IdealGeometryRecord.h"
 #include "SimG4Core/Notification/interface/TrackInformation.h"
 
@@ -29,7 +30,7 @@ ZdcSD::ZdcSD(const std::string& name,
              const SensitiveDetectorCatalog& clg,
              edm::ParameterSet const& p,
              const SimTrackManager* manager)
-    : CaloSD(name, es, clg, p, manager) {
+    : CaloSD(name, clg, p, manager) {
   edm::ParameterSet m_ZdcSD = p.getParameter<edm::ParameterSet>("ZdcSD");
   useShowerLibrary = m_ZdcSD.getParameter<bool>("UseShowerLibrary");
   useShowerHits = m_ZdcSD.getParameter<bool>("UseShowerHits");

--- a/SimG4CMS/HGCalTestBeam/plugins/AHCalSD.cc
+++ b/SimG4CMS/HGCalTestBeam/plugins/AHCalSD.cc
@@ -3,6 +3,9 @@
 #include "SimG4Core/Notification/interface/TrackInformation.h"
 #include "Geometry/HGCalCommonData/interface/AHCalParameters.h"
 
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
 #include "DataFormats/DetId/interface/DetId.h"
 #include "DataFormats/HcalDetId/interface/HcalDetId.h"
 
@@ -49,7 +52,6 @@ AHCalSD::AHCalSD(const std::string& name,
                  edm::ParameterSet const& p,
                  const SimTrackManager* manager)
     : CaloSD(name,
-             es,
              clg,
              p,
              manager,

--- a/SimG4CMS/HGCalTestBeam/plugins/HGCalTB16SD01.cc
+++ b/SimG4CMS/HGCalTestBeam/plugins/HGCalTB16SD01.cc
@@ -1,4 +1,6 @@
 #include "FWCore/Utilities/interface/Exception.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "SimG4CMS/Calo/interface/CaloSD.h"
 #include "SimG4Core/Notification/interface/TrackInformation.h"
 
@@ -42,7 +44,7 @@ HGCalTB16SD01::HGCalTB16SD01(const std::string& name,
                              const SensitiveDetectorCatalog& clg,
                              edm::ParameterSet const& p,
                              const SimTrackManager* manager)
-    : CaloSD(name, es, clg, p, manager), initialize_(true) {
+    : CaloSD(name, clg, p, manager), initialize_(true) {
   // Values from NIM 80 (1970) 239-244: as implemented in Geant3
   edm::ParameterSet m_HC = p.getParameter<edm::ParameterSet>("HGCalTestBeamSD");
   matName_ = m_HC.getParameter<std::string>("Material");

--- a/SimG4CMS/HcalTestBeam/plugins/HcalTB02SD.cc
+++ b/SimG4CMS/HcalTestBeam/plugins/HcalTB02SD.cc
@@ -15,6 +15,7 @@
 // user include files
 #include "FWCore/Framework/interface/ESTransientHandle.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "Geometry/Records/interface/IdealGeometryRecord.h"
 #include "HcalTB02SD.h"
 #include "HcalTB02HcalNumberingScheme.h"
@@ -37,7 +38,7 @@ HcalTB02SD::HcalTB02SD(const std::string& name,
                        const SensitiveDetectorCatalog& clg,
                        edm::ParameterSet const& p,
                        const SimTrackManager* manager)
-    : CaloSD(name, es, clg, p, manager) {
+    : CaloSD(name, clg, p, manager) {
   numberingScheme_.reset(nullptr);
   edm::ParameterSet m_SD = p.getParameter<edm::ParameterSet>("HcalTB02SD");
   useBirk_ = m_SD.getUntrackedParameter<bool>("UseBirkLaw", false);

--- a/SimG4CMS/HcalTestBeam/plugins/HcalTB02SD.h
+++ b/SimG4CMS/HcalTestBeam/plugins/HcalTB02SD.h
@@ -24,6 +24,8 @@
 // user include files
 #include "SimG4CMS/Calo/interface/CaloSD.h"
 #include "Geometry/HcalTestBeamData/interface/HcalTB02Parameters.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/ParameterSet/interface/ParameterSetfwd.h"
 #include "HcalTB02NumberingScheme.h"
 
 class HcalTB02SD : public CaloSD {

--- a/SimG4CMS/HcalTestBeam/plugins/HcalTB06BeamSD.cc
+++ b/SimG4CMS/HcalTestBeam/plugins/HcalTB06BeamSD.cc
@@ -6,6 +6,7 @@
 #include "SimG4Core/Notification/interface/TrackInformation.h"
 #include "SimDataFormats/HcalTestBeam/interface/HcalTestBeamNumbering.h"
 #include "Geometry/Records/interface/IdealGeometryRecord.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/Utilities/interface/Exception.h"
 #include "HcalTB06BeamSD.h"
@@ -22,7 +23,7 @@ HcalTB06BeamSD::HcalTB06BeamSD(const std::string& name,
                                const SensitiveDetectorCatalog& clg,
                                edm::ParameterSet const& p,
                                const SimTrackManager* manager)
-    : CaloSD(name, es, clg, p, manager) {
+    : CaloSD(name, clg, p, manager) {
   // Values from NIM 80 (1970) 239-244: as implemented in Geant3
   edm::ParameterSet m_HC = p.getParameter<edm::ParameterSet>("HcalTB06BeamSD");
   useBirk_ = m_HC.getParameter<bool>("UseBirkLaw");

--- a/SimG4CMS/HcalTestBeam/plugins/HcalTB06BeamSD.h
+++ b/SimG4CMS/HcalTestBeam/plugins/HcalTB06BeamSD.h
@@ -7,6 +7,8 @@
 ///////////////////////////////////////////////////////////////////////////////
 
 #include "SimG4CMS/Calo/interface/CaloSD.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/ParameterSet/interface/ParameterSetfwd.h"
 #include "Geometry/HcalTestBeamData/interface/HcalTB06BeamParameters.h"
 #include "G4String.hh"
 

--- a/SimG4CMS/Muon/interface/MuonSensitiveDetector.h
+++ b/SimG4CMS/Muon/interface/MuonSensitiveDetector.h
@@ -20,9 +20,7 @@
 #include "SimG4Core/SensitiveDetector/interface/SensitiveTkDetector.h"
 #include "DataFormats/GeometryVector/interface/LocalPoint.h"
 #include "CondFormats/GeometryObjects/interface/MuonOffsetMap.h"
-
-#include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/ParameterSet/interface/ParameterSetfwd.h"
+#include "Geometry/MuonNumbering/interface/MuonGeometryConstants.h"
 
 #include <string>
 
@@ -40,9 +38,13 @@ class SimTrackManager;
 class MuonSensitiveDetector : public SensitiveTkDetector, public Observer<const BeginOfEvent*> {
 public:
   explicit MuonSensitiveDetector(const std::string&,
-                                 const edm::EventSetup&,
+                                 const MuonOffsetMap*,
+                                 const MuonGeometryConstants&,
                                  const SensitiveDetectorCatalog&,
-                                 edm::ParameterSet const&,
+                                 double ePersistentCutGeV,
+                                 bool allMuonsPersistent,
+                                 bool aPrintHits,
+                                 bool dd4hep,
                                  const SimTrackManager*);
   ~MuonSensitiveDetector() override;
   G4bool ProcessHits(G4Step*, G4TouchableHistory*) override;

--- a/SimG4CMS/Muon/interface/MuonSensitiveDetector.h
+++ b/SimG4CMS/Muon/interface/MuonSensitiveDetector.h
@@ -21,6 +21,9 @@
 #include "DataFormats/GeometryVector/interface/LocalPoint.h"
 #include "CondFormats/GeometryObjects/interface/MuonOffsetMap.h"
 
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/ParameterSet/interface/ParameterSetfwd.h"
+
 #include <string>
 
 class MuonSlaveSD;

--- a/SimG4CMS/Muon/src/MuonSensitiveDetector.cc
+++ b/SimG4CMS/Muon/src/MuonSensitiveDetector.cc
@@ -14,15 +14,10 @@
 #include "Geometry/MuonNumbering/interface/MuonGeometryConstants.h"
 #include "Geometry/MuonNumbering/interface/MuonBaseNumber.h"
 #include "Geometry/MuonNumbering/interface/MuonSimHitNumberingScheme.h"
-#include "Geometry/Records/interface/IdealGeometryRecord.h"
 
 #include "SimG4Core/Notification/interface/TrackInformation.h"
 #include "SimG4Core/Notification/interface/G4TrackToParticleID.h"
 #include "SimG4Core/Physics/interface/G4ProcessTypeEnumerator.h"
-
-#include "FWCore/Framework/interface/ESHandle.h"
-#include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 #include "G4VProcess.hh"
 #include "G4EventManager.hh"
@@ -38,9 +33,13 @@
 //#define EDM_ML_DEBUG
 
 MuonSensitiveDetector::MuonSensitiveDetector(const std::string& name,
-                                             const edm::EventSetup& es,
+                                             const MuonOffsetMap* offmap,
+                                             const MuonGeometryConstants& constants,
                                              const SensitiveDetectorCatalog& clg,
-                                             edm::ParameterSet const& p,
+                                             double aEPersistentCutGeV,
+                                             bool aAllMuonsPersistent,
+                                             bool aPrintHits,
+                                             bool dd4hep,
                                              const SimTrackManager* manager)
     : SensitiveTkDetector(name, clg),
       thePV(nullptr),
@@ -48,13 +47,11 @@ MuonSensitiveDetector::MuonSensitiveDetector(const std::string& name,
       theDetUnitId(0),
       newDetUnitId(0),
       theTrackID(0),
+      printHits(aPrintHits),
+      thePrinter(nullptr),
+      ePersistentCutGeV(aEPersistentCutGeV),
+      allMuonsPersistent(aAllMuonsPersistent),
       theManager(manager) {
-  edm::ParameterSet m_MuonSD = p.getParameter<edm::ParameterSet>("MuonSD");
-  ePersistentCutGeV = m_MuonSD.getParameter<double>("EnergyThresholdForPersistency") / CLHEP::GeV;  //Default 1. GeV
-  allMuonsPersistent = m_MuonSD.getParameter<bool>("AllMuonsPersistent");
-  printHits = m_MuonSD.getParameter<bool>("PrintHits");
-  bool dd4hep = p.getParameter<bool>("g4GeometryDD4hepSource");
-  //
   // Here simply create 1 MuonSlaveSD for the moment
   //
 #ifdef EDM_ML_DEBUG
@@ -62,16 +59,6 @@ MuonSensitiveDetector::MuonSensitiveDetector(const std::string& name,
 #endif
   detector = new MuonSubDetector(name);
 
-  //The constants take time to calculate and are needed by many helpers
-  edm::ESHandle<MuonOffsetMap> mom;
-  es.get<IdealGeometryRecord>().get(mom);
-  const MuonOffsetMap* offmap = (mom.isValid()) ? mom.product() : nullptr;
-  edm::LogVerbatim("MuonSim") << "Finds the offset map at " << offmap;
-  edm::ESHandle<MuonGeometryConstants> mdc;
-  es.get<IdealGeometryRecord>().get(mdc);
-  if (!mdc.isValid())
-    throw cms::Exception("MuonSensitiveDetector") << "Cannot find MuonGeometryConstants\n";
-  MuonGeometryConstants constants = *(mdc.product());
   G4String sdet = "unknown";
   if (detector->isEndcap()) {
     theRotation = new MuonEndcapFrameRotation();

--- a/SimG4CMS/Muon/src/MuonSensitiveDetector.cc
+++ b/SimG4CMS/Muon/src/MuonSensitiveDetector.cc
@@ -22,6 +22,7 @@
 
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 #include "G4VProcess.hh"
 #include "G4EventManager.hh"
@@ -41,7 +42,7 @@ MuonSensitiveDetector::MuonSensitiveDetector(const std::string& name,
                                              const SensitiveDetectorCatalog& clg,
                                              edm::ParameterSet const& p,
                                              const SimTrackManager* manager)
-    : SensitiveTkDetector(name, es, clg, p),
+    : SensitiveTkDetector(name, clg),
       thePV(nullptr),
       theHit(nullptr),
       theDetUnitId(0),

--- a/SimG4CMS/Muon/src/MuonSensitiveDetectorBuilder.cc
+++ b/SimG4CMS/Muon/src/MuonSensitiveDetectorBuilder.cc
@@ -17,9 +17,15 @@
 #include "SimG4Core/Notification/interface/SimActivityRegistryEnroller.h"
 #include "SimG4Core/SensitiveDetector/interface/SensitiveDetectorPluginFactory.h"
 
+#include "Geometry/MuonNumbering/interface/MuonGeometryConstants.h"
+#include "Geometry/Records/interface/IdealGeometryRecord.h"
+
 #include "SimG4CMS/Muon/interface/MuonSensitiveDetector.h"
 
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/PluginManager/interface/ModuleDef.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 class MuonSensitiveDetectorBuilder : public SensitiveDetectorMakerBase {
   SensitiveDetector* make(const std::string& iname,
@@ -28,7 +34,23 @@ class MuonSensitiveDetectorBuilder : public SensitiveDetectorMakerBase {
                           const edm::ParameterSet& p,
                           const SimTrackManager* man,
                           SimActivityRegistry& reg) const override {
-    MuonSensitiveDetector* sd = new MuonSensitiveDetector(iname, es, clg, p, man);
+    edm::ESHandle<MuonOffsetMap> mom;
+    es.get<IdealGeometryRecord>().get(mom);
+    const MuonOffsetMap* offmap = (mom.isValid()) ? mom.product() : nullptr;
+    edm::LogVerbatim("MuonSim") << "Finds the offset map at " << offmap;
+    edm::ESHandle<MuonGeometryConstants> mdc;
+    es.get<IdealGeometryRecord>().get(mdc);
+
+    edm::ParameterSet m_MuonSD = p.getParameter<edm::ParameterSet>("MuonSD");
+    auto ePersistentCutGeV =
+        m_MuonSD.getParameter<double>("EnergyThresholdForPersistency") / CLHEP::GeV;  //Default 1. GeV
+    auto allMuonsPersistent = m_MuonSD.getParameter<bool>("AllMuonsPersistent");
+    auto printHits = m_MuonSD.getParameter<bool>("PrintHits");
+    bool dd4hep = p.getParameter<bool>("g4GeometryDD4hepSource");
+    //
+
+    MuonSensitiveDetector* sd = new MuonSensitiveDetector(
+        iname, offmap, *mdc, clg, ePersistentCutGeV, allMuonsPersistent, printHits, dd4hep, man);
     SimActivityRegistryEnroller::enroll(reg, sd);
     return sd;
   }

--- a/SimG4CMS/Muon/src/MuonSensitiveDetectorBuilder.cc
+++ b/SimG4CMS/Muon/src/MuonSensitiveDetectorBuilder.cc
@@ -48,7 +48,6 @@ public:
   }
 
   std::unique_ptr<SensitiveDetector> make(const std::string& iname,
-                                          const edm::EventSetup& es,
                                           const SensitiveDetectorCatalog& clg,
                                           const edm::ParameterSet& p,
                                           const SimTrackManager* man,

--- a/SimG4CMS/Muon/src/MuonSensitiveDetectorBuilder.cc
+++ b/SimG4CMS/Muon/src/MuonSensitiveDetectorBuilder.cc
@@ -30,7 +30,7 @@
 
 class MuonSensitiveDetectorBuilder : public SensitiveDetectorMakerBase {
 public:
-  explicit MuonSensitiveDetectorBuilder(edm::ConsumesCollector cc) {}
+  explicit MuonSensitiveDetectorBuilder(edm::ParameterSet const&, edm::ConsumesCollector cc) {}
 
   void beginRun(const edm::EventSetup& es) final {
     edm::ESHandle<MuonOffsetMap> mom;

--- a/SimG4CMS/Muon/src/MuonSensitiveDetectorBuilder.cc
+++ b/SimG4CMS/Muon/src/MuonSensitiveDetectorBuilder.cc
@@ -1,0 +1,37 @@
+// -*- C++ -*-
+//
+// Package:     SimG4CMS/Muon
+// Class  :     MuonSensitiveDetectorBuilder
+//
+// Implementation:
+//     [Notes on implementation]
+//
+// Original Author:  Christopher Jones
+//         Created:  Fri, 04 Jun 2021 18:18:17 GMT
+//
+
+// system include files
+
+// user include files
+#include "SimG4Core/SensitiveDetector/interface/SensitiveDetectorMakerBase.h"
+#include "SimG4Core/Notification/interface/SimActivityRegistryEnroller.h"
+#include "SimG4Core/SensitiveDetector/interface/SensitiveDetectorPluginFactory.h"
+
+#include "SimG4CMS/Muon/interface/MuonSensitiveDetector.h"
+
+#include "FWCore/PluginManager/interface/ModuleDef.h"
+
+class MuonSensitiveDetectorBuilder : public SensitiveDetectorMakerBase {
+  SensitiveDetector* make(const std::string& iname,
+                          const edm::EventSetup& es,
+                          const SensitiveDetectorCatalog& clg,
+                          const edm::ParameterSet& p,
+                          const SimTrackManager* man,
+                          SimActivityRegistry& reg) const override {
+    MuonSensitiveDetector* sd = new MuonSensitiveDetector(iname, es, clg, p, man);
+    SimActivityRegistryEnroller::enroll(reg, sd);
+    return sd;
+  }
+};
+
+DEFINE_EDM_PLUGIN(SensitiveDetectorPluginFactory, MuonSensitiveDetectorBuilder, "MuonSensitiveDetector");

--- a/SimG4CMS/Muon/src/MuonSensitiveDetectorBuilder.cc
+++ b/SimG4CMS/Muon/src/MuonSensitiveDetectorBuilder.cc
@@ -28,12 +28,12 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 class MuonSensitiveDetectorBuilder : public SensitiveDetectorMakerBase {
-  SensitiveDetector* make(const std::string& iname,
-                          const edm::EventSetup& es,
-                          const SensitiveDetectorCatalog& clg,
-                          const edm::ParameterSet& p,
-                          const SimTrackManager* man,
-                          SimActivityRegistry& reg) const override {
+  std::unique_ptr<SensitiveDetector> make(const std::string& iname,
+                                          const edm::EventSetup& es,
+                                          const SensitiveDetectorCatalog& clg,
+                                          const edm::ParameterSet& p,
+                                          const SimTrackManager* man,
+                                          SimActivityRegistry& reg) const override {
     edm::ESHandle<MuonOffsetMap> mom;
     es.get<IdealGeometryRecord>().get(mom);
     const MuonOffsetMap* offmap = (mom.isValid()) ? mom.product() : nullptr;
@@ -49,9 +49,9 @@ class MuonSensitiveDetectorBuilder : public SensitiveDetectorMakerBase {
     bool dd4hep = p.getParameter<bool>("g4GeometryDD4hepSource");
     //
 
-    MuonSensitiveDetector* sd = new MuonSensitiveDetector(
+    auto sd = std::make_unique<MuonSensitiveDetector>(
         iname, offmap, *mdc, clg, ePersistentCutGeV, allMuonsPersistent, printHits, dd4hep, man);
-    SimActivityRegistryEnroller::enroll(reg, sd);
+    SimActivityRegistryEnroller::enroll(reg, sd.get());
     return sd;
   }
 };

--- a/SimG4CMS/Muon/src/MuonSensitiveDetectorBuilder.cc
+++ b/SimG4CMS/Muon/src/MuonSensitiveDetectorBuilder.cc
@@ -56,4 +56,4 @@ class MuonSensitiveDetectorBuilder : public SensitiveDetectorMakerBase {
   }
 };
 
-DEFINE_EDM_PLUGIN(SensitiveDetectorPluginFactory, MuonSensitiveDetectorBuilder, "MuonSensitiveDetector");
+DEFINE_SENSITIVEDETECTORBUILDER(MuonSensitiveDetectorBuilder, MuonSensitiveDetector);

--- a/SimG4CMS/Muon/src/MuonSensitiveDetectorBuilder.cc
+++ b/SimG4CMS/Muon/src/MuonSensitiveDetectorBuilder.cc
@@ -32,7 +32,10 @@
 class MuonSensitiveDetectorBuilder : public SensitiveDetectorMakerBase {
 public:
   explicit MuonSensitiveDetectorBuilder(edm::ParameterSet const& p, edm::ConsumesCollector cc)
-      : offmap_{nullptr}, mdc_{nullptr}, offsetToken_{cc.esConsumes()}, geomConstantsToken_{cc.esConsumes()} {
+      : offmap_{nullptr},
+        mdc_{nullptr},
+        offsetToken_{cc.esConsumes<edm::Transition::BeginRun>()},
+        geomConstantsToken_{cc.esConsumes<edm::Transition::BeginRun>()} {
     edm::ParameterSet muonSD = p.getParameter<edm::ParameterSet>("MuonSD");
     ePersistentCutGeV_ = muonSD.getParameter<double>("EnergyThresholdForPersistency") / CLHEP::GeV;  //Default 1. GeV
     allMuonsPersistent_ = muonSD.getParameter<bool>("AllMuonsPersistent");

--- a/SimG4CMS/Muon/src/MuonSensitiveDetectorBuilder.cc
+++ b/SimG4CMS/Muon/src/MuonSensitiveDetectorBuilder.cc
@@ -24,10 +24,14 @@
 
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/PluginManager/interface/ModuleDef.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 class MuonSensitiveDetectorBuilder : public SensitiveDetectorMakerBase {
+public:
+  explicit MuonSensitiveDetectorBuilder(edm::ConsumesCollector cc) {}
+
   void beginRun(const edm::EventSetup& es) final {
     edm::ESHandle<MuonOffsetMap> mom;
     es.get<IdealGeometryRecord>().get(mom);

--- a/SimG4CMS/Muon/src/module.cc
+++ b/SimG4CMS/Muon/src/module.cc
@@ -1,5 +1,0 @@
-#include "SimG4CMS/Muon/interface/MuonSensitiveDetector.h"
-#include "SimG4Core/SensitiveDetector/interface/SensitiveDetectorPluginFactory.h"
-#include "FWCore/PluginManager/interface/ModuleDef.h"
-
-DEFINE_SENSITIVEDETECTOR(MuonSensitiveDetector);

--- a/SimG4CMS/PPS/interface/PPSDiamondSD.h
+++ b/SimG4CMS/PPS/interface/PPSDiamondSD.h
@@ -18,6 +18,9 @@
 #include "SimG4Core/Notification/interface/BeginOfEvent.h"
 #include "SimG4Core/Notification/interface/EndOfEvent.h"
 
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/ParameterSet/interface/ParameterSetfwd.h"
+
 #include <string>
 
 class G4Step;

--- a/SimG4CMS/PPS/interface/PPSPixelSD.h
+++ b/SimG4CMS/PPS/interface/PPSPixelSD.h
@@ -32,6 +32,9 @@
 #include "SimG4CMS/PPS/interface/PPSVDetectorOrganization.h"
 #include "SimG4Core/Notification/interface/SimTrackManager.h"
 
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/ParameterSet/interface/ParameterSetfwd.h"
+
 #include <string>
 
 class TrackingSlaveSD;

--- a/SimG4CMS/PPS/interface/TotemRPSD.h
+++ b/SimG4CMS/PPS/interface/TotemRPSD.h
@@ -14,6 +14,9 @@
 #include "SimG4Core/Notification/interface/BeginOfEvent.h"
 #include "SimG4Core/Notification/interface/EndOfEvent.h"
 
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/ParameterSet/interface/ParameterSetfwd.h"
+
 #include <string>
 
 class G4Step;

--- a/SimG4CMS/PPS/src/PPSDiamondSD.cc
+++ b/SimG4CMS/PPS/src/PPSDiamondSD.cc
@@ -6,6 +6,7 @@
 #include "SimG4CMS/PPS/interface/PPSDiamondSD.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "SimG4Core/Notification/interface/TrackInformation.h"
 #include "SimG4Core/Geometry/interface/SensitiveDetectorCatalog.h"
 #include "SimG4Core/Physics/interface/G4ProcessTypeEnumerator.h"
@@ -30,7 +31,7 @@ PPSDiamondSD::PPSDiamondSD(const std::string& name_,
                            const SensitiveDetectorCatalog& clg,
                            edm::ParameterSet const& p,
                            const SimTrackManager* manager)
-    : SensitiveTkDetector(name_, es, clg, p),
+    : SensitiveTkDetector(name_, clg),
       numberingScheme_(nullptr),
       hcID_(-1),
       theHC_(nullptr),

--- a/SimG4CMS/PPS/src/PPSPixelSD.cc
+++ b/SimG4CMS/PPS/src/PPSPixelSD.cc
@@ -15,6 +15,7 @@
 // user include files
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 #include "SimG4Core/Notification/interface/TrackInformation.h"
 #include "SimG4Core/Notification/interface/G4TrackToParticleID.h"
@@ -39,7 +40,7 @@ PPSPixelSD::PPSPixelSD(const std::string& name_,
                        const SensitiveDetectorCatalog& clg,
                        edm::ParameterSet const& p,
                        SimTrackManager const* manager)
-    : SensitiveTkDetector(name_, es, clg, p),
+    : SensitiveTkDetector(name_, clg),
       numberingScheme_(nullptr),
       hcID_(-1),
       theHC_(nullptr),

--- a/SimG4CMS/PPS/src/TotemRPSD.cc
+++ b/SimG4CMS/PPS/src/TotemRPSD.cc
@@ -7,6 +7,7 @@
 
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 #include "SimG4Core/Notification/interface/TrackInformation.h"
 #include "SimG4Core/Notification/interface/G4TrackToParticleID.h"
@@ -35,7 +36,7 @@ TotemRPSD::TotemRPSD(const std::string& name_,
                      const SensitiveDetectorCatalog& clg,
                      edm::ParameterSet const& p,
                      const SimTrackManager* manager)
-    : SensitiveTkDetector(name_, es, clg, p),
+    : SensitiveTkDetector(name_, clg),
       numberingScheme_(nullptr),
       hcID_(-1),
       theHC_(nullptr),

--- a/SimG4CMS/ShowerLibraryProducer/interface/HFChamberSD.h
+++ b/SimG4CMS/ShowerLibraryProducer/interface/HFChamberSD.h
@@ -5,6 +5,8 @@
 #include "SimG4Core/Notification/interface/SimTrackManager.h"
 
 #include "SimG4CMS/ShowerLibraryProducer/interface/HFShowerG4Hit.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/ParameterSet/interface/ParameterSetfwd.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include "G4Track.hh"

--- a/SimG4CMS/ShowerLibraryProducer/interface/HFWedgeSD.h
+++ b/SimG4CMS/ShowerLibraryProducer/interface/HFWedgeSD.h
@@ -5,6 +5,8 @@
 #include "SimG4Core/Notification/interface/SimTrackManager.h"
 
 #include "SimG4CMS/ShowerLibraryProducer/interface/HFShowerG4Hit.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/ParameterSet/interface/ParameterSetfwd.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include "G4VPhysicalVolume.hh"

--- a/SimG4CMS/ShowerLibraryProducer/src/FiberSD.cc
+++ b/SimG4CMS/ShowerLibraryProducer/src/FiberSD.cc
@@ -24,11 +24,7 @@ FiberSD::FiberSD(const std::string& iname,
                  const SensitiveDetectorCatalog& clg,
                  edm::ParameterSet const& p,
                  const SimTrackManager* manager)
-    : SensitiveCaloDetector(iname, es, clg, p),
-      m_trackManager(manager),
-      theShower(nullptr),
-      theHCID(-1),
-      theHC(nullptr) {
+    : SensitiveCaloDetector(iname, clg), m_trackManager(manager), theShower(nullptr), theHCID(-1), theHC(nullptr) {
   edm::LogVerbatim("FiberSim") << "FiberSD : Instantiating for " << iname;
   // Get pointer to HcalDDDConstants and HcalSimulationConstants
   edm::ESHandle<HcalSimulationConstants> hdsc;

--- a/SimG4CMS/ShowerLibraryProducer/src/HFChamberSD.cc
+++ b/SimG4CMS/ShowerLibraryProducer/src/HFChamberSD.cc
@@ -21,7 +21,7 @@ HFChamberSD::HFChamberSD(const std::string& name,
                          const SensitiveDetectorCatalog& clg,
                          edm::ParameterSet const& p,
                          const SimTrackManager* manager)
-    : SensitiveCaloDetector(name, es, clg, p), m_trackManager(manager), theHCID(-1), theHC(nullptr), theNSteps(0) {
+    : SensitiveCaloDetector(name, clg), m_trackManager(manager), theHCID(-1), theHC(nullptr), theNSteps(0) {
   edm::LogVerbatim("FiberSim") << "HFChamberSD : Instantiated for " << name;
 }
 

--- a/SimG4CMS/ShowerLibraryProducer/src/HFWedgeSD.cc
+++ b/SimG4CMS/ShowerLibraryProducer/src/HFWedgeSD.cc
@@ -21,7 +21,7 @@ HFWedgeSD::HFWedgeSD(const std::string& iname,
                      const SensitiveDetectorCatalog& clg,
                      edm::ParameterSet const& p,
                      const SimTrackManager* manager)
-    : SensitiveCaloDetector(iname, es, clg, p), m_trackManager(manager), hcID(-1), theHC(nullptr), currentHit(nullptr) {
+    : SensitiveCaloDetector(iname, clg), m_trackManager(manager), hcID(-1), theHC(nullptr), currentHit(nullptr) {
   edm::LogVerbatim("FiberSim") << "HFWedgeSD : Instantiated for " << iname;
 }
 

--- a/SimG4CMS/Tracker/interface/TkAccumulatingSensitiveDetector.h
+++ b/SimG4CMS/Tracker/interface/TkAccumulatingSensitiveDetector.h
@@ -11,6 +11,8 @@
 #include "SimG4Core/Notification/interface/BeginOfEvent.h"
 #include "SimG4Core/Notification/interface/EndOfEvent.h"
 #include "SimG4Core/Notification/interface/BeginOfJob.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/ParameterSet/interface/ParameterSetfwd.h"
 
 #include "G4Step.hh"
 #include "G4Track.hh"

--- a/SimG4CMS/Tracker/src/TkAccumulatingSensitiveDetector.cc
+++ b/SimG4CMS/Tracker/src/TkAccumulatingSensitiveDetector.cc
@@ -48,7 +48,7 @@ TkAccumulatingSensitiveDetector::TkAccumulatingSensitiveDetector(const std::stri
                                                                  const SensitiveDetectorCatalog& clg,
                                                                  edm::ParameterSet const& p,
                                                                  const SimTrackManager* manager)
-    : SensitiveTkDetector(name, es, clg, p),
+    : SensitiveTkDetector(name, clg),
       theManager(manager),
       rTracker(1200. * CLHEP::mm),
       zTracker(3000. * CLHEP::mm),

--- a/SimG4Core/Application/interface/RunManagerMTWorker.h
+++ b/SimG4Core/Application/interface/RunManagerMTWorker.h
@@ -9,6 +9,8 @@
 
 #include <memory>
 #include <tbb/concurrent_vector.h>
+#include <unordered_map>
+#include <string>
 
 namespace edm {
   class ParameterSet;
@@ -34,6 +36,7 @@ class G4Field;
 
 class SensitiveTkDetector;
 class SensitiveCaloDetector;
+class SensitiveDetectorMakerBase;
 
 class SimWatcher;
 class SimProducer;
@@ -43,6 +46,7 @@ public:
   explicit RunManagerMTWorker(const edm::ParameterSet& iConfig, edm::ConsumesCollector&& i);
   ~RunManagerMTWorker();
 
+  void beginRun(const edm::EventSetup&);
   void endRun();
 
   std::unique_ptr<G4SimEvent> produce(const edm::Event& inpevt,
@@ -62,7 +66,7 @@ public:
   SimTrackManager* GetSimTrackManager();
   std::vector<SensitiveTkDetector*>& sensTkDetectors();
   std::vector<SensitiveCaloDetector*>& sensCaloDetectors();
-  std::vector<std::shared_ptr<SimProducer> >& producers();
+  std::vector<std::shared_ptr<SimProducer>>& producers();
 
   void initializeG4(RunManagerMT* runManagerMaster, const edm::EventSetup& es);
 
@@ -106,6 +110,7 @@ private:
 
   G4SimEvent* m_simEvent;
   std::unique_ptr<CMSSteppingVerbose> m_sVerbose;
+  std::unordered_map<std::string, std::unique_ptr<SensitiveDetectorMakerBase>> m_sdMakers;
 };
 
 #endif

--- a/SimG4Core/Application/plugins/OscarMTProducer.cc
+++ b/SimG4Core/Application/plugins/OscarMTProducer.cc
@@ -29,6 +29,7 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include <iostream>
+#include <memory>
 
 namespace edm {
   class StreamID;
@@ -141,7 +142,7 @@ std::unique_ptr<OscarMTMasterThread> OscarMTProducer::initializeGlobalCache(cons
   StaticRandomEngineSetUnset random(nullptr);
   edm::LogVerbatim("SimG4CoreApplication") << "OscarMTProducer::initializeGlobalCache";
 
-  return std::unique_ptr<OscarMTMasterThread>(new OscarMTMasterThread(iConfig));
+  return std::make_unique<OscarMTMasterThread>(iConfig);
 }
 
 std::shared_ptr<int> OscarMTProducer::globalBeginRun(const edm::Run& iRun,

--- a/SimG4Core/Application/plugins/OscarMTProducer.cc
+++ b/SimG4Core/Application/plugins/OscarMTProducer.cc
@@ -168,6 +168,7 @@ void OscarMTProducer::globalEndJob(OscarMTMasterThread* masterThread) {
 
 void OscarMTProducer::beginRun(const edm::Run&, const edm::EventSetup& es) {
   edm::LogVerbatim("SimG4CoreApplication") << "OscarMTProducer::beginRun";
+  m_runManagerWorker->beginRun(es);
   m_runManagerWorker->initializeG4(m_masterThread->runManagerMasterPtr(), es);
   edm::LogVerbatim("SimG4CoreApplication") << "OscarMTProducer::beginRun done";
 }

--- a/SimG4Core/Application/src/RunManagerMTWorker.cc
+++ b/SimG4Core/Application/src/RunManagerMTWorker.cc
@@ -167,7 +167,7 @@ RunManagerMTWorker::RunManagerMTWorker(const edm::ParameterSet& iConfig, edm::Co
       m_p(iConfig),
       m_simEvent(nullptr),
       m_sVerbose(nullptr) {
-  m_sdMakers = sim::sensitiveDetectorMakers(iC, std::vector<std::string>());
+  m_sdMakers = sim::sensitiveDetectorMakers(m_p, iC, std::vector<std::string>());
   std::vector<edm::ParameterSet> watchers = iConfig.getParameter<std::vector<edm::ParameterSet> >("Watchers");
   m_hasWatchers = !watchers.empty();
   initializeTLS();

--- a/SimG4Core/Application/src/RunManagerMTWorker.cc
+++ b/SimG4Core/Application/src/RunManagerMTWorker.cc
@@ -320,9 +320,8 @@ void RunManagerMTWorker::initializeG4(RunManagerMT* runManagerMaster, const edm:
   }
 
   // attach sensitive detector
-  AttachSD attach;
   auto sensDets =
-      attach.create(es, runManagerMaster->catalog(), m_p, m_tls->trackManager.get(), *(m_tls->registry.get()));
+      sim::attachSD(es, runManagerMaster->catalog(), m_p, m_tls->trackManager.get(), *(m_tls->registry.get()));
 
   m_tls->sensTkDets.swap(sensDets.first);
   m_tls->sensCaloDets.swap(sensDets.second);

--- a/SimG4Core/Application/src/RunManagerMTWorker.cc
+++ b/SimG4Core/Application/src/RunManagerMTWorker.cc
@@ -47,6 +47,8 @@
 #include "SimG4Core/SensitiveDetector/interface/AttachSD.h"
 #include "SimG4Core/SensitiveDetector/interface/SensitiveTkDetector.h"
 #include "SimG4Core/SensitiveDetector/interface/SensitiveCaloDetector.h"
+#include "SimG4Core/SensitiveDetector/interface/SensitiveDetectorMakerBase.h"
+#include "SimG4Core/SensitiveDetector/interface/sensitiveDetectorMakers.h"
 
 #include "G4Timer.hh"
 #include "G4Event.hh"
@@ -320,8 +322,9 @@ void RunManagerMTWorker::initializeG4(RunManagerMT* runManagerMaster, const edm:
   }
 
   // attach sensitive detector
+  auto makers = sim::sensitiveDetectorMakers(std::vector<std::string>());
   auto sensDets =
-      sim::attachSD(es, runManagerMaster->catalog(), m_p, m_tls->trackManager.get(), *(m_tls->registry.get()));
+      sim::attachSD(makers, es, runManagerMaster->catalog(), m_p, m_tls->trackManager.get(), *(m_tls->registry.get()));
 
   m_tls->sensTkDets.swap(sensDets.first);
   m_tls->sensCaloDets.swap(sensDets.second);

--- a/SimG4Core/Application/src/RunManagerMTWorker.cc
+++ b/SimG4Core/Application/src/RunManagerMTWorker.cc
@@ -167,7 +167,7 @@ RunManagerMTWorker::RunManagerMTWorker(const edm::ParameterSet& iConfig, edm::Co
       m_p(iConfig),
       m_simEvent(nullptr),
       m_sVerbose(nullptr) {
-  m_sdMakers = sim::sensitiveDetectorMakers(std::vector<std::string>());
+  m_sdMakers = sim::sensitiveDetectorMakers(iC, std::vector<std::string>());
   std::vector<edm::ParameterSet> watchers = iConfig.getParameter<std::vector<edm::ParameterSet> >("Watchers");
   m_hasWatchers = !watchers.empty();
   initializeTLS();

--- a/SimG4Core/GeometryProducer/interface/GeometryProducer.h
+++ b/SimG4Core/GeometryProducer/interface/GeometryProducer.h
@@ -10,12 +10,12 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 #include "SimG4Core/Notification/interface/SimActivityRegistry.h"
-#include "SimG4Core/SensitiveDetector/interface/AttachSD.h"
 #include "SimG4Core/SensitiveDetector/interface/SensitiveCaloDetector.h"
 #include "SimG4Core/SensitiveDetector/interface/SensitiveDetector.h"
 #include "SimG4Core/SensitiveDetector/interface/SensitiveTkDetector.h"
 
 #include <memory>
+#include <unordered_map>
 
 namespace sim {
   class FieldBuilder;
@@ -30,6 +30,7 @@ class SimProducer;
 class DDDWorld;
 class G4RunManagerKernel;
 class SimTrackManager;
+class SensitiveDetectorMakerBase;
 class DDCompactView;
 
 class GeometryProducer : public edm::one::EDProducer<edm::one::SharedResources, edm::one::WatchRuns> {
@@ -59,6 +60,7 @@ private:
   std::unique_ptr<SimTrackManager> m_trackManager;
   std::vector<SensitiveTkDetector *> m_sensTkDets;
   std::vector<SensitiveCaloDetector *> m_sensCaloDets;
+  std::unordered_map<std::string, std::unique_ptr<SensitiveDetectorMakerBase>> m_sdMakers;
   edm::ParameterSet m_p;
 
   mutable const DDCompactView *m_pDD;

--- a/SimG4Core/GeometryProducer/interface/GeometryProducer.h
+++ b/SimG4Core/GeometryProducer/interface/GeometryProducer.h
@@ -57,7 +57,6 @@ private:
   std::vector<std::shared_ptr<SimProducer>> m_producers;
   std::unique_ptr<sim::FieldBuilder> m_fieldBuilder;
   std::unique_ptr<SimTrackManager> m_trackManager;
-  AttachSD *m_attach;
   std::vector<SensitiveTkDetector *> m_sensTkDets;
   std::vector<SensitiveCaloDetector *> m_sensCaloDets;
   edm::ParameterSet m_p;

--- a/SimG4Core/GeometryProducer/src/GeometryProducer.cc
+++ b/SimG4Core/GeometryProducer/src/GeometryProducer.cc
@@ -4,6 +4,7 @@
 
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/ESTransientHandle.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "FWCore/Utilities/interface/Exception.h"
 
@@ -78,7 +79,7 @@ GeometryProducer::GeometryProducer(edm::ParameterSet const &p)
     m_registry.connect(*otherRegistry);
   createWatchers(m_p, m_registry, m_watchers, m_producers);
 
-  m_sdMakers = sim::sensitiveDetectorMakers(std::vector<std::string>());
+  m_sdMakers = sim::sensitiveDetectorMakers(consumesCollector(), std::vector<std::string>());
 
   produces<int>();
 }

--- a/SimG4Core/GeometryProducer/src/GeometryProducer.cc
+++ b/SimG4Core/GeometryProducer/src/GeometryProducer.cc
@@ -79,7 +79,7 @@ GeometryProducer::GeometryProducer(edm::ParameterSet const &p)
     m_registry.connect(*otherRegistry);
   createWatchers(m_p, m_registry, m_watchers, m_producers);
 
-  m_sdMakers = sim::sensitiveDetectorMakers(consumesCollector(), std::vector<std::string>());
+  m_sdMakers = sim::sensitiveDetectorMakers(m_p, consumesCollector(), std::vector<std::string>());
 
   produces<int>();
 }

--- a/SimG4Core/GeometryProducer/src/GeometryProducer.cc
+++ b/SimG4Core/GeometryProducer/src/GeometryProducer.cc
@@ -16,6 +16,7 @@
 #include "SimG4Core/Notification/interface/SimTrackManager.h"
 #include "SimG4Core/Watcher/interface/SimProducer.h"
 #include "SimG4Core/Watcher/interface/SimWatcherFactory.h"
+#include "SimG4Core/SensitiveDetector/interface/sensitiveDetectorMakers.h"
 
 #include "MagneticField/Engine/interface/MagneticField.h"
 #include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
@@ -145,8 +146,9 @@ void GeometryProducer::produce(edm::Event &e, const edm::EventSetup &es) {
     // instantiate and attach the sensitive detectors
     m_trackManager = std::make_unique<SimTrackManager>();
     {
+      auto makers = sim::sensitiveDetectorMakers(std::vector<std::string>());
       std::pair<std::vector<SensitiveTkDetector *>, std::vector<SensitiveCaloDetector *>> sensDets =
-          sim::attachSD(es, catalog, m_p, m_trackManager.get(), m_registry);
+          sim::attachSD(makers, es, catalog, m_p, m_trackManager.get(), m_registry);
 
       m_sensTkDets.swap(sensDets.first);
       m_sensCaloDets.swap(sensDets.second);

--- a/SimG4Core/GeometryProducer/src/GeometryProducer.cc
+++ b/SimG4Core/GeometryProducer/src/GeometryProducer.cc
@@ -62,7 +62,6 @@ static void createWatchers(const edm::ParameterSet &iP,
 GeometryProducer::GeometryProducer(edm::ParameterSet const &p)
     : m_kernel(nullptr),
       m_pField(p.getParameter<edm::ParameterSet>("MagneticField")),
-      m_attach(nullptr),
       m_p(p),
       m_pDD(nullptr),
       m_pDD4hep(nullptr),
@@ -79,10 +78,7 @@ GeometryProducer::GeometryProducer(edm::ParameterSet const &p)
   produces<int>();
 }
 
-GeometryProducer::~GeometryProducer() {
-  delete m_attach;
-  delete m_kernel;
-}
+GeometryProducer::~GeometryProducer() { delete m_kernel; }
 
 void GeometryProducer::updateMagneticField(edm::EventSetup const &es) {
   if (m_pUseMagneticField) {
@@ -148,11 +144,9 @@ void GeometryProducer::produce(edm::Event &e, const edm::EventSetup &es) {
     edm::LogInfo("GeometryProducer") << " instantiating sensitive detectors ";
     // instantiate and attach the sensitive detectors
     m_trackManager = std::make_unique<SimTrackManager>();
-    if (m_attach == nullptr)
-      m_attach = new AttachSD;
     {
       std::pair<std::vector<SensitiveTkDetector *>, std::vector<SensitiveCaloDetector *>> sensDets =
-          m_attach->create(es, catalog, m_p, m_trackManager.get(), m_registry);
+          sim::attachSD(es, catalog, m_p, m_trackManager.get(), m_registry);
 
       m_sensTkDets.swap(sensDets.first);
       m_sensCaloDets.swap(sensDets.second);

--- a/SimG4Core/SensitiveDetector/interface/AttachSD.h
+++ b/SimG4Core/SensitiveDetector/interface/AttachSD.h
@@ -2,6 +2,9 @@
 #define SimG4Core_SensitiveDetector_AttachSD_h
 
 #include <vector>
+#include <string>
+#include <unordered_map>
+#include <memory>
 
 namespace edm {
   class EventSetup;
@@ -11,11 +14,13 @@ namespace edm {
 class SensitiveDetectorCatalog;
 class SensitiveTkDetector;
 class SensitiveCaloDetector;
+class SensitiveDetectorMakerBase;
 class SimActivityRegistry;
 class SimTrackManager;
 
 namespace sim {
-  std::pair<std::vector<SensitiveTkDetector *>, std::vector<SensitiveCaloDetector *> > attachSD(
+  std::pair<std::vector<SensitiveTkDetector *>, std::vector<SensitiveCaloDetector *>> attachSD(
+      const std::unordered_map<std::string, std::unique_ptr<SensitiveDetectorMakerBase>> &,
       const edm::EventSetup &,
       const SensitiveDetectorCatalog &,
       edm::ParameterSet const &,

--- a/SimG4Core/SensitiveDetector/interface/AttachSD.h
+++ b/SimG4Core/SensitiveDetector/interface/AttachSD.h
@@ -14,17 +14,13 @@ class SensitiveCaloDetector;
 class SimActivityRegistry;
 class SimTrackManager;
 
-class AttachSD {
-public:
-  AttachSD();
-  ~AttachSD();
-
-  std::pair<std::vector<SensitiveTkDetector *>, std::vector<SensitiveCaloDetector *> > create(
+namespace sim {
+  std::pair<std::vector<SensitiveTkDetector *>, std::vector<SensitiveCaloDetector *> > attachSD(
       const edm::EventSetup &,
       const SensitiveDetectorCatalog &,
       edm::ParameterSet const &,
       const SimTrackManager *,
-      SimActivityRegistry &reg) const;
+      SimActivityRegistry &reg);
 };
 
 #endif

--- a/SimG4Core/SensitiveDetector/interface/SensitiveCaloDetector.h
+++ b/SimG4Core/SensitiveDetector/interface/SensitiveCaloDetector.h
@@ -9,11 +9,8 @@
 
 class SensitiveCaloDetector : public SensitiveDetector {
 public:
-  explicit SensitiveCaloDetector(const std::string& iname,
-                                 const edm::EventSetup& es,
-                                 const SensitiveDetectorCatalog& clg,
-                                 edm::ParameterSet const& p)
-      : SensitiveDetector(iname, es, clg, p, true){};
+  explicit SensitiveCaloDetector(const std::string& iname, const SensitiveDetectorCatalog& clg)
+      : SensitiveDetector(iname, clg, true){};
 
   virtual void fillHits(edm::PCaloHitContainer&, const std::string& hname) = 0;
   virtual void reset(){};

--- a/SimG4Core/SensitiveDetector/interface/SensitiveDetector.h
+++ b/SimG4Core/SensitiveDetector/interface/SensitiveDetector.h
@@ -1,8 +1,6 @@
 #ifndef SimG4Core_SensitiveDetector_H
 #define SimG4Core_SensitiveDetector_H
 
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
-
 #include "DataFormats/GeometryVector/interface/LocalPoint.h"
 #include "SimG4Core/Geometry/interface/SensitiveDetectorCatalog.h"
 #include "SimG4Core/Notification/interface/TrackInformation.h"
@@ -18,17 +16,9 @@ class G4HCofThisEvent;
 class G4TouchableHistory;
 class G4VPhysicalVolume;
 
-namespace edm {
-  class EventSetup;
-}
-
 class SensitiveDetector : public G4VSensitiveDetector {
 public:
-  explicit SensitiveDetector(const std::string& iname,
-                             const edm::EventSetup& es,
-                             const SensitiveDetectorCatalog&,
-                             edm::ParameterSet const& p,
-                             bool calo);
+  explicit SensitiveDetector(const std::string& iname, const SensitiveDetectorCatalog&, bool calo);
 
   ~SensitiveDetector() override;
 

--- a/SimG4Core/SensitiveDetector/interface/SensitiveDetectorMaker.h
+++ b/SimG4Core/SensitiveDetector/interface/SensitiveDetectorMaker.h
@@ -16,6 +16,7 @@
 #include "SimG4Core/Notification/interface/SimActivityRegistryEnroller.h"
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 
 // forward declarations
 class SimTrackManager;
@@ -30,7 +31,7 @@ namespace edm {
 template <class T>
 class SensitiveDetectorMaker : public SensitiveDetectorMakerBase {
 public:
-  explicit SensitiveDetectorMaker(){};
+  explicit SensitiveDetectorMaker(edm::ConsumesCollector){};
   SensitiveDetectorMaker(const SensitiveDetectorMaker&) = delete;
   const SensitiveDetectorMaker& operator=(const SensitiveDetectorMaker&) = delete;
 

--- a/SimG4Core/SensitiveDetector/interface/SensitiveDetectorMaker.h
+++ b/SimG4Core/SensitiveDetector/interface/SensitiveDetectorMaker.h
@@ -35,15 +35,15 @@ public:
   const SensitiveDetectorMaker& operator=(const SensitiveDetectorMaker&) = delete;
 
   // ---------- const member functions ---------------------
-  SensitiveDetector* make(const std::string& iname,
-                          const edm::EventSetup& es,
-                          const SensitiveDetectorCatalog& clg,
-                          const edm::ParameterSet& p,
-                          const SimTrackManager* man,
-                          SimActivityRegistry& reg) const override {
-    T* sd = new T(iname, es, clg, p, man);
-    SimActivityRegistryEnroller::enroll(reg, sd);
-    return static_cast<SensitiveDetector*>(sd);
+  std::unique_ptr<SensitiveDetector> make(const std::string& iname,
+                                          const edm::EventSetup& es,
+                                          const SensitiveDetectorCatalog& clg,
+                                          const edm::ParameterSet& p,
+                                          const SimTrackManager* man,
+                                          SimActivityRegistry& reg) const override {
+    auto sd = std::make_unique<T>(iname, es, clg, p, man);
+    SimActivityRegistryEnroller::enroll(reg, sd.get());
+    return sd;
   };
 };
 

--- a/SimG4Core/SensitiveDetector/interface/SensitiveDetectorMaker.h
+++ b/SimG4Core/SensitiveDetector/interface/SensitiveDetectorMaker.h
@@ -31,7 +31,7 @@ namespace edm {
 template <class T>
 class SensitiveDetectorMaker : public SensitiveDetectorMakerBase {
 public:
-  explicit SensitiveDetectorMaker(edm::ConsumesCollector){};
+  explicit SensitiveDetectorMaker(edm::ParameterSet const&, edm::ConsumesCollector){};
   SensitiveDetectorMaker(const SensitiveDetectorMaker&) = delete;
   const SensitiveDetectorMaker& operator=(const SensitiveDetectorMaker&) = delete;
 

--- a/SimG4Core/SensitiveDetector/interface/SensitiveDetectorMaker.h
+++ b/SimG4Core/SensitiveDetector/interface/SensitiveDetectorMaker.h
@@ -31,6 +31,8 @@ template <class T>
 class SensitiveDetectorMaker : public SensitiveDetectorMakerBase {
 public:
   explicit SensitiveDetectorMaker(){};
+  SensitiveDetectorMaker(const SensitiveDetectorMaker&) = delete;
+  const SensitiveDetectorMaker& operator=(const SensitiveDetectorMaker&) = delete;
 
   // ---------- const member functions ---------------------
   SensitiveDetector* make(const std::string& iname,
@@ -43,10 +45,6 @@ public:
     SimActivityRegistryEnroller::enroll(reg, sd);
     return static_cast<SensitiveDetector*>(sd);
   };
-
-private:
-  SensitiveDetectorMaker(const SensitiveDetectorMaker&) = delete;
-  const SensitiveDetectorMaker& operator=(const SensitiveDetectorMaker&) = delete;
 };
 
 #endif

--- a/SimG4Core/SensitiveDetector/interface/SensitiveDetectorMakerBase.h
+++ b/SimG4Core/SensitiveDetector/interface/SensitiveDetectorMakerBase.h
@@ -27,18 +27,27 @@ namespace edm {
 
 class SensitiveDetectorMakerBase {
 public:
-  explicit SensitiveDetectorMakerBase(){};
-  virtual ~SensitiveDetectorMakerBase(){};
+  explicit SensitiveDetectorMakerBase() = default;
+  virtual ~SensitiveDetectorMakerBase();
   SensitiveDetectorMakerBase(const SensitiveDetectorMakerBase&) = delete;
   const SensitiveDetectorMakerBase& operator=(const SensitiveDetectorMakerBase&) = delete;
 
+  virtual void beginRun(edm::EventSetup const&);
+
   // ---------- const member functions ---------------------
+  //deprecated API
   virtual std::unique_ptr<SensitiveDetector> make(const std::string& iname,
                                                   const edm::EventSetup& es,
                                                   const SensitiveDetectorCatalog& clg,
                                                   const edm::ParameterSet& p,
                                                   const SimTrackManager* man,
-                                                  SimActivityRegistry& reg) const = 0;
+                                                  SimActivityRegistry& reg) const;
+
+  virtual std::unique_ptr<SensitiveDetector> make(const std::string& iname,
+                                                  const SensitiveDetectorCatalog& clg,
+                                                  const edm::ParameterSet& p,
+                                                  const SimTrackManager* man,
+                                                  SimActivityRegistry& reg) const;
 };
 
 #endif

--- a/SimG4Core/SensitiveDetector/interface/SensitiveDetectorMakerBase.h
+++ b/SimG4Core/SensitiveDetector/interface/SensitiveDetectorMakerBase.h
@@ -13,6 +13,7 @@
 
 // system include files
 #include <string>
+#include <memory>
 
 // forward declarations
 class SimActivityRegistry;
@@ -32,12 +33,12 @@ public:
   const SensitiveDetectorMakerBase& operator=(const SensitiveDetectorMakerBase&) = delete;
 
   // ---------- const member functions ---------------------
-  virtual SensitiveDetector* make(const std::string& iname,
-                                  const edm::EventSetup& es,
-                                  const SensitiveDetectorCatalog& clg,
-                                  const edm::ParameterSet& p,
-                                  const SimTrackManager* man,
-                                  SimActivityRegistry& reg) const = 0;
+  virtual std::unique_ptr<SensitiveDetector> make(const std::string& iname,
+                                                  const edm::EventSetup& es,
+                                                  const SensitiveDetectorCatalog& clg,
+                                                  const edm::ParameterSet& p,
+                                                  const SimTrackManager* man,
+                                                  SimActivityRegistry& reg) const = 0;
 };
 
 #endif

--- a/SimG4Core/SensitiveDetector/interface/SensitiveDetectorMakerBase.h
+++ b/SimG4Core/SensitiveDetector/interface/SensitiveDetectorMakerBase.h
@@ -28,6 +28,8 @@ class SensitiveDetectorMakerBase {
 public:
   explicit SensitiveDetectorMakerBase(){};
   virtual ~SensitiveDetectorMakerBase(){};
+  SensitiveDetectorMakerBase(const SensitiveDetectorMakerBase&) = delete;
+  const SensitiveDetectorMakerBase& operator=(const SensitiveDetectorMakerBase&) = delete;
 
   // ---------- const member functions ---------------------
   virtual SensitiveDetector* make(const std::string& iname,
@@ -36,10 +38,6 @@ public:
                                   const edm::ParameterSet& p,
                                   const SimTrackManager* man,
                                   SimActivityRegistry& reg) const = 0;
-
-private:
-  SensitiveDetectorMakerBase(const SensitiveDetectorMakerBase&) = delete;
-  const SensitiveDetectorMakerBase& operator=(const SensitiveDetectorMakerBase&) = delete;
 };
 
 #endif

--- a/SimG4Core/SensitiveDetector/interface/SensitiveDetectorPluginFactory.h
+++ b/SimG4Core/SensitiveDetector/interface/SensitiveDetectorPluginFactory.h
@@ -12,4 +12,7 @@ typedef edmplugin::PluginFactory<SensitiveDetectorMakerBase *()> SensitiveDetect
 
 #define DEFINE_SENSITIVEDETECTOR(type) \
   DEFINE_EDM_PLUGIN(SensitiveDetectorPluginFactory, SensitiveDetectorMaker<type>, #type)
+
+#define DEFINE_SENSITIVEDETECTORBUILDER(type, name) DEFINE_EDM_PLUGIN(SensitiveDetectorPluginFactory, type, #name)
+
 #endif

--- a/SimG4Core/SensitiveDetector/interface/SensitiveDetectorPluginFactory.h
+++ b/SimG4Core/SensitiveDetector/interface/SensitiveDetectorPluginFactory.h
@@ -5,10 +5,11 @@
 #include "SimG4Core/SensitiveDetector/interface/SensitiveDetectorMakerBase.h"
 #include "SimG4Core/SensitiveDetector/interface/SensitiveDetectorMaker.h"
 #include "FWCore/PluginManager/interface/PluginFactory.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 
 #include <string>
 
-typedef edmplugin::PluginFactory<SensitiveDetectorMakerBase *()> SensitiveDetectorPluginFactory;
+typedef edmplugin::PluginFactory<SensitiveDetectorMakerBase *(edm::ConsumesCollector)> SensitiveDetectorPluginFactory;
 
 #define DEFINE_SENSITIVEDETECTOR(type) \
   DEFINE_EDM_PLUGIN(SensitiveDetectorPluginFactory, SensitiveDetectorMaker<type>, #type)

--- a/SimG4Core/SensitiveDetector/interface/SensitiveDetectorPluginFactory.h
+++ b/SimG4Core/SensitiveDetector/interface/SensitiveDetectorPluginFactory.h
@@ -9,7 +9,11 @@
 
 #include <string>
 
-typedef edmplugin::PluginFactory<SensitiveDetectorMakerBase *(edm::ConsumesCollector)> SensitiveDetectorPluginFactory;
+namespace edm {
+  class ParameterSet;
+}
+typedef edmplugin::PluginFactory<SensitiveDetectorMakerBase *(edm::ParameterSet const &, edm::ConsumesCollector)>
+    SensitiveDetectorPluginFactory;
 
 #define DEFINE_SENSITIVEDETECTOR(type) \
   DEFINE_EDM_PLUGIN(SensitiveDetectorPluginFactory, SensitiveDetectorMaker<type>, #type)

--- a/SimG4Core/SensitiveDetector/interface/SensitiveTkDetector.h
+++ b/SimG4Core/SensitiveDetector/interface/SensitiveTkDetector.h
@@ -7,11 +7,8 @@
 
 class SensitiveTkDetector : public SensitiveDetector {
 public:
-  explicit SensitiveTkDetector(const std::string& iname,
-                               const edm::EventSetup& es,
-                               const SensitiveDetectorCatalog& clg,
-                               edm::ParameterSet const& p)
-      : SensitiveDetector(iname, es, clg, p, false) {}
+  explicit SensitiveTkDetector(const std::string& iname, const SensitiveDetectorCatalog& clg)
+      : SensitiveDetector(iname, clg, false) {}
   virtual void fillHits(edm::PSimHitContainer&, const std::string& hname) = 0;
 };
 

--- a/SimG4Core/SensitiveDetector/interface/sensitiveDetectorMakers.h
+++ b/SimG4Core/SensitiveDetector/interface/sensitiveDetectorMakers.h
@@ -26,11 +26,12 @@
 
 // user include files
 #include "SimG4Core/SensitiveDetector/interface/SensitiveDetectorMakerBase.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 
 // forward declarations
 
 namespace sim {
   std::unordered_map<std::string, std::unique_ptr<SensitiveDetectorMakerBase>> sensitiveDetectorMakers(
-      std::vector<std::string> const& chosenMakers);
+      edm::ConsumesCollector, std::vector<std::string> const& chosenMakers);
 }
 #endif

--- a/SimG4Core/SensitiveDetector/interface/sensitiveDetectorMakers.h
+++ b/SimG4Core/SensitiveDetector/interface/sensitiveDetectorMakers.h
@@ -1,0 +1,36 @@
+#ifndef SimG4Core_SensitiveDetector_sensitiveDetectorMakers_h
+#define SimG4Core_SensitiveDetector_sensitiveDetectorMakers_h
+// -*- C++ -*-
+//
+// Package:     SimG4Core/SensitiveDetector
+// Class  :     sensitiveDetectorMakers
+//
+/**\function sensitiveDetectorMakers
+
+ Description: Makes it easy to find what SensitiveDetectorMakerBase are available
+
+ Usage:
+    <usage>
+
+*/
+//
+// Original Author:  Christopher Jones
+//         Created:  Mon, 07 Jun 2021 19:48:31 GMT
+//
+
+// system include files
+#include <string>
+#include <vector>
+#include <memory>
+#include <unordered_map>
+
+// user include files
+#include "SimG4Core/SensitiveDetector/interface/SensitiveDetectorMakerBase.h"
+
+// forward declarations
+
+namespace sim {
+  std::unordered_map<std::string, std::unique_ptr<SensitiveDetectorMakerBase>> sensitiveDetectorMakers(
+      std::vector<std::string> const& chosenMakers);
+}
+#endif

--- a/SimG4Core/SensitiveDetector/interface/sensitiveDetectorMakers.h
+++ b/SimG4Core/SensitiveDetector/interface/sensitiveDetectorMakers.h
@@ -29,9 +29,11 @@
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 
 // forward declarations
-
+namespace edm {
+  class ParameterSet;
+}
 namespace sim {
   std::unordered_map<std::string, std::unique_ptr<SensitiveDetectorMakerBase>> sensitiveDetectorMakers(
-      edm::ConsumesCollector, std::vector<std::string> const& chosenMakers);
+      edm::ParameterSet const&, edm::ConsumesCollector, std::vector<std::string> const& chosenMakers);
 }
 #endif

--- a/SimG4Core/SensitiveDetector/src/AttachSD.cc
+++ b/SimG4Core/SensitiveDetector/src/AttachSD.cc
@@ -1,28 +1,37 @@
-#include "SimG4Core/SensitiveDetector/interface/SensitiveDetectorPluginFactory.h"
 #include "SimG4Core/SensitiveDetector/interface/SensitiveDetector.h"
 #include "SimG4Core/SensitiveDetector/interface/SensitiveTkDetector.h"
 #include "SimG4Core/SensitiveDetector/interface/SensitiveCaloDetector.h"
 #include "SimG4Core/SensitiveDetector/interface/AttachSD.h"
+#include "SimG4Core/SensitiveDetector/interface/sensitiveDetectorMakers.h"
 
+#include "FWCore/Utilities/interface/Exception.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include <string>
 #include <sstream>
+#include <algorithm>
 
-std::pair<std::vector<SensitiveTkDetector*>, std::vector<SensitiveCaloDetector*> > sim::attachSD(
+std::pair<std::vector<SensitiveTkDetector*>, std::vector<SensitiveCaloDetector*>> sim::attachSD(
+    const std::unordered_map<std::string, std::unique_ptr<SensitiveDetectorMakerBase>>& makers,
     const edm::EventSetup& es,
     const SensitiveDetectorCatalog& clg,
     edm::ParameterSet const& p,
     const SimTrackManager* man,
     SimActivityRegistry& reg) {
-  std::pair<std::vector<SensitiveTkDetector*>, std::vector<SensitiveCaloDetector*> > detList;
+  std::pair<std::vector<SensitiveTkDetector*>, std::vector<SensitiveCaloDetector*>> detList;
   const std::vector<std::string_view>& rouNames = clg.readoutNames();
+
+  //auto makers = sim::sensitiveDetectorMakers(makerNames);
+
   edm::LogVerbatim("SimG4CoreSensitiveDetector") << " AttachSD: Initialising " << rouNames.size() << " SDs";
   for (auto& rname : rouNames) {
     std::string_view className = clg.className({rname.data(), rname.size()});
-    std::unique_ptr<SensitiveDetectorMakerBase> temp{
-        SensitiveDetectorPluginFactory::get()->create({className.data(), className.size()})};
+    auto makerItr = makers.find(std::string(className.data(), className.size()));
+    if (makerItr == makers.end()) {
+      throw cms::Exception("MissingSensitiveDetector")
+          << "Asked to use " << className << " sensitive detector but it was not in the list of preloaded ones.";
+    }
 
-    std::unique_ptr<SensitiveDetector> sd{temp->make({rname.data(), rname.size()}, es, clg, p, man, reg)};
+    std::unique_ptr<SensitiveDetector> sd{makerItr->second->make({rname.data(), rname.size()}, es, clg, p, man, reg)};
 
     std::stringstream ss;
     ss << " AttachSD: created a " << className << " with name " << rname;

--- a/SimG4Core/SensitiveDetector/src/AttachSD.cc
+++ b/SimG4Core/SensitiveDetector/src/AttachSD.cc
@@ -20,8 +20,6 @@ std::pair<std::vector<SensitiveTkDetector*>, std::vector<SensitiveCaloDetector*>
   std::pair<std::vector<SensitiveTkDetector*>, std::vector<SensitiveCaloDetector*>> detList;
   const std::vector<std::string_view>& rouNames = clg.readoutNames();
 
-  //auto makers = sim::sensitiveDetectorMakers(makerNames);
-
   edm::LogVerbatim("SimG4CoreSensitiveDetector") << " AttachSD: Initialising " << rouNames.size() << " SDs";
   for (auto& rname : rouNames) {
     std::string_view className = clg.className({rname.data(), rname.size()});

--- a/SimG4Core/SensitiveDetector/src/AttachSD.cc
+++ b/SimG4Core/SensitiveDetector/src/AttachSD.cc
@@ -8,16 +8,12 @@
 #include <string>
 #include <sstream>
 
-AttachSD::AttachSD() {}
-
-AttachSD::~AttachSD() {}
-
-std::pair<std::vector<SensitiveTkDetector*>, std::vector<SensitiveCaloDetector*> > AttachSD::create(
+std::pair<std::vector<SensitiveTkDetector*>, std::vector<SensitiveCaloDetector*> > sim::attachSD(
     const edm::EventSetup& es,
     const SensitiveDetectorCatalog& clg,
     edm::ParameterSet const& p,
     const SimTrackManager* man,
-    SimActivityRegistry& reg) const {
+    SimActivityRegistry& reg) {
   std::pair<std::vector<SensitiveTkDetector*>, std::vector<SensitiveCaloDetector*> > detList;
   const std::vector<std::string_view>& rouNames = clg.readoutNames();
   edm::LogVerbatim("SimG4CoreSensitiveDetector") << " AttachSD: Initialising " << rouNames.size() << " SDs";

--- a/SimG4Core/SensitiveDetector/src/SensitiveDetector.cc
+++ b/SimG4Core/SensitiveDetector/src/SensitiveDetector.cc
@@ -15,11 +15,7 @@
 
 #include <sstream>
 
-SensitiveDetector::SensitiveDetector(const std::string& iname,
-                                     const edm::EventSetup& es,
-                                     const SensitiveDetectorCatalog& clg,
-                                     edm::ParameterSet const& p,
-                                     bool calo)
+SensitiveDetector::SensitiveDetector(const std::string& iname, const SensitiveDetectorCatalog& clg, bool calo)
     : G4VSensitiveDetector(iname), m_isCalo(calo) {
   // for CMS hits
   m_namesOfSD.push_back(iname);

--- a/SimG4Core/SensitiveDetector/src/SensitiveDetectorMakerBase.cc
+++ b/SimG4Core/SensitiveDetector/src/SensitiveDetectorMakerBase.cc
@@ -1,0 +1,55 @@
+// -*- C++ -*-
+//
+// Package:     SimG4Core/SensitiveDetector
+// Class  :     SensitiveDetectorMakerBase
+//
+// Implementation:
+//     [Notes on implementation]
+//
+// Original Author:  Christopher Jones
+//         Created:  Tue, 08 Jun 2021 13:25:09 GMT
+//
+
+// system include files
+
+// user include files
+#include "SimG4Core/SensitiveDetector/interface/SensitiveDetectorMakerBase.h"
+
+//
+// constants, enums and typedefs
+//
+
+//
+// static data member definitions
+//
+
+SensitiveDetectorMakerBase::~SensitiveDetectorMakerBase() = default;
+
+//
+// member functions
+//
+void SensitiveDetectorMakerBase::beginRun(edm::EventSetup const&) {}
+
+//
+// const member functions
+//
+std::unique_ptr<SensitiveDetector> SensitiveDetectorMakerBase::make(const std::string& iname,
+                                                                    const edm::EventSetup& es,
+                                                                    const SensitiveDetectorCatalog& clg,
+                                                                    const edm::ParameterSet& p,
+                                                                    const SimTrackManager* man,
+                                                                    SimActivityRegistry& reg) const {
+  return make(iname, clg, p, man, reg);
+}
+
+std::unique_ptr<SensitiveDetector> SensitiveDetectorMakerBase::make(const std::string& iname,
+                                                                    const SensitiveDetectorCatalog& clg,
+                                                                    const edm::ParameterSet& p,
+                                                                    const SimTrackManager* man,
+                                                                    SimActivityRegistry& reg) const {
+  return std::unique_ptr<SensitiveDetector>();
+}
+
+//
+// static member functions
+//

--- a/SimG4Core/SensitiveDetector/src/sensitiveDetectorMakers.cc
+++ b/SimG4Core/SensitiveDetector/src/sensitiveDetectorMakers.cc
@@ -20,7 +20,7 @@
 
 namespace sim {
   std::unordered_map<std::string, std::unique_ptr<SensitiveDetectorMakerBase>> sensitiveDetectorMakers(
-      edm::ConsumesCollector cc, std::vector<std::string> const& chosenMakers) {
+      edm::ParameterSet const& pset, edm::ConsumesCollector cc, std::vector<std::string> const& chosenMakers) {
     std::unordered_map<std::string, std::unique_ptr<SensitiveDetectorMakerBase>> retValue;
     if (chosenMakers.empty()) {
       //load all
@@ -31,12 +31,12 @@ namespace sim {
             << "When trying to load all SensitiveDetectorMakerBase, no plugins found";
       } else {
         for (auto const& info : infosItr->second) {
-          retValue[info.name_] = SensitiveDetectorPluginFactory::get()->create(info.name_, cc);
+          retValue[info.name_] = SensitiveDetectorPluginFactory::get()->create(info.name_, pset, cc);
         }
       }
     } else {
       for (auto const& name : chosenMakers) {
-        retValue[name] = SensitiveDetectorPluginFactory::get()->create(name, cc);
+        retValue[name] = SensitiveDetectorPluginFactory::get()->create(name, pset, cc);
       }
     }
     return retValue;

--- a/SimG4Core/SensitiveDetector/src/sensitiveDetectorMakers.cc
+++ b/SimG4Core/SensitiveDetector/src/sensitiveDetectorMakers.cc
@@ -26,7 +26,7 @@ namespace sim {
       //load all
       auto const& categoriesToInfo = edmplugin::PluginManager::get()->categoryToInfos();
       auto infosItr = categoriesToInfo.find(SensitiveDetectorPluginFactory::get()->category());
-      if (infosItr != categoriesToInfo.end()) {
+      if (infosItr == categoriesToInfo.end()) {
         throw cms::Exception("MissingPlugins")
             << "When trying to load all SensitiveDetectorMakerBase, no plugins found";
       } else {

--- a/SimG4Core/SensitiveDetector/src/sensitiveDetectorMakers.cc
+++ b/SimG4Core/SensitiveDetector/src/sensitiveDetectorMakers.cc
@@ -1,0 +1,44 @@
+// -*- C++ -*-
+//
+// Package:     SimG4Core/SensitiveDetector
+// Class  :     sensitiveDetectorMakers
+//
+// Implementation:
+//     [Notes on implementation]
+//
+// Original Author:  Christopher Jones
+//         Created:  Mon, 07 Jun 2021 19:48:40 GMT
+//
+
+// system include files
+
+// user include files
+#include "SimG4Core/SensitiveDetector/interface/sensitiveDetectorMakers.h"
+#include "SimG4Core/SensitiveDetector/interface/SensitiveDetectorPluginFactory.h"
+#include "FWCore/PluginManager/interface/PluginManager.h"
+#include "FWCore/Utilities/interface/Exception.h"
+
+namespace sim {
+  std::unordered_map<std::string, std::unique_ptr<SensitiveDetectorMakerBase>> sensitiveDetectorMakers(
+      std::vector<std::string> const& chosenMakers) {
+    std::unordered_map<std::string, std::unique_ptr<SensitiveDetectorMakerBase>> retValue;
+    if (chosenMakers.empty()) {
+      //load all
+      auto const& categoriesToInfo = edmplugin::PluginManager::get()->categoryToInfos();
+      auto infosItr = categoriesToInfo.find(SensitiveDetectorPluginFactory::get()->category());
+      if (infosItr != categoriesToInfo.end()) {
+        throw cms::Exception("MissingPlugins")
+            << "When trying to load all SensitiveDetectorMakerBase, no plugins found";
+      } else {
+        for (auto const& info : infosItr->second) {
+          retValue[info.name_] = SensitiveDetectorPluginFactory::get()->create(info.name_);
+        }
+      }
+    } else {
+      for (auto const& name : chosenMakers) {
+        retValue[name] = SensitiveDetectorPluginFactory::get()->create(name);
+      }
+    }
+    return retValue;
+  }
+}  // namespace sim

--- a/SimG4Core/SensitiveDetector/src/sensitiveDetectorMakers.cc
+++ b/SimG4Core/SensitiveDetector/src/sensitiveDetectorMakers.cc
@@ -20,7 +20,7 @@
 
 namespace sim {
   std::unordered_map<std::string, std::unique_ptr<SensitiveDetectorMakerBase>> sensitiveDetectorMakers(
-      std::vector<std::string> const& chosenMakers) {
+      edm::ConsumesCollector cc, std::vector<std::string> const& chosenMakers) {
     std::unordered_map<std::string, std::unique_ptr<SensitiveDetectorMakerBase>> retValue;
     if (chosenMakers.empty()) {
       //load all
@@ -31,12 +31,12 @@ namespace sim {
             << "When trying to load all SensitiveDetectorMakerBase, no plugins found";
       } else {
         for (auto const& info : infosItr->second) {
-          retValue[info.name_] = SensitiveDetectorPluginFactory::get()->create(info.name_);
+          retValue[info.name_] = SensitiveDetectorPluginFactory::get()->create(info.name_, cc);
         }
       }
     } else {
       for (auto const& name : chosenMakers) {
-        retValue[name] = SensitiveDetectorPluginFactory::get()->create(name);
+        retValue[name] = SensitiveDetectorPluginFactory::get()->create(name, cc);
       }
     }
     return retValue;


### PR DESCRIPTION
#### PR description:

This implements  a path towards handling esConsumes in OscarMTProducer. The idea is
- split reading the EventSetup out of the SensitiveDetectors themselves
- implement custom 'builders' for each SensitiveDetector type
  - these register what EventSetup data products will be consumed
  - acquire the data products in the `beginRun` method
  - build the actual SensitiveDetector when needed
  - all builders are loaded in the module constructor (although there is a future expansion option to use the ParameterSet to restrict the allowed set)

This change modifies all the infrastructure to support this change and rewrites the MuonSensitiveDetector as an example for how this should be done.

NOTE: further esConsumes calls are needed in OscarMTProducer, however all the remaining ones should be knowable at construction time.

#### PR validation:

The code compiles and workflow 1.0 runs fine.