### PR TITLE
[DAQ_RECONSTRUCTION] Apply code-checks/format with misc-definitions-in-headers

### DIFF
--- a/EventFilter/Utilities/plugins/RecoEventOutputModuleForFU.h
+++ b/EventFilter/Utilities/plugins/RecoEventOutputModuleForFU.h
@@ -94,7 +94,7 @@ namespace evf {
     if (streamLabel_.find(testPrefix) == 0)
       streamLabel_ = std::string("stream") + streamLabel_.substr(testPrefix.size());
 
-    if (streamLabel_.find("_") != std::string::npos) {
+    if (streamLabel_.find('_') != std::string::npos) {
       throw cms::Exception("RecoEventOutputModuleForFU") << "Underscore character is reserved can not be used for "
                                                             "stream names in FFF, but was detected in stream name -: "
                                                          << streamLabel_;


### PR DESCRIPTION
code-checks/format applied on full cmssw