### PR TITLE
initialize all of pat Muon sim info

### DIFF
--- a/DataFormats/PatCandidates/src/Muon.cc
+++ b/DataFormats/PatCandidates/src/Muon.cc
@@ -164,11 +164,13 @@ void Muon::initSimInfo() {
   simPdgId_ = 0;
   simMotherPdgId_ = 0;
   simBX_ = 999;
+  simTpEvent_ = 0;
   simProdRho_ = 0.0;
   simProdZ_ = 0.0;
   simPt_ = 0.0;
   simEta_ = 0.0;
   simPhi_ = 0.0;
+  simMatchQuality_ = 0.0;
 }
 
 /// reference to Track reconstructed in the tracker only (reimplemented from reco::Muon)


### PR DESCRIPTION
random differences in event size were observed on one of miniAOD tests in slimmedMuons.
I tracked these down to `simTpEvent_` and `simMatchQuality_`, which were indeed not initialized in the code.
This PR completes the `initSimInfo()` method to initialize these data members as well.

I used 0 for default values, since this will match the default "non-initialization"