### PR TITLE
DQMOffline EGamma esConsumes modifications

### DIFF
--- a/DQMOffline/EGamma/plugins/PiZeroAnalyzer.cc
+++ b/DQMOffline/EGamma/plugins/PiZeroAnalyzer.cc
@@ -18,8 +18,7 @@
 using namespace std;
 
 PiZeroAnalyzer::PiZeroAnalyzer(const edm::ParameterSet& pset)
-  : caloGeometryToken_{esConsumes()},
-    caloTopologyToken_{esConsumes()} {
+    : caloGeometryToken_{esConsumes()}, caloTopologyToken_{esConsumes()} {
   fName_ = pset.getUntrackedParameter<std::string>("Name");
   prescaleFactor_ = pset.getUntrackedParameter<int>("prescaleFactor", 1);
 

--- a/DQMOffline/EGamma/plugins/PiZeroAnalyzer.cc
+++ b/DQMOffline/EGamma/plugins/PiZeroAnalyzer.cc
@@ -17,7 +17,9 @@
 
 using namespace std;
 
-PiZeroAnalyzer::PiZeroAnalyzer(const edm::ParameterSet& pset) {
+PiZeroAnalyzer::PiZeroAnalyzer(const edm::ParameterSet& pset)
+  : CaloGeometryToken_{esConsumes()},
+    CaloTopologyToken_{esConsumes()} {
   fName_ = pset.getUntrackedParameter<std::string>("Name");
   prescaleFactor_ = pset.getUntrackedParameter<int>("prescaleFactor", 1);
 
@@ -113,11 +115,13 @@ void PiZeroAnalyzer::makePizero(const edm::EventSetup& es,
                                 const edm::Handle<EcalRecHitCollection> rhEE) {
   const EcalRecHitCollection* hitCollection_p = rhEB.product();
 
-  edm::ESHandle<CaloGeometry> geoHandle;
-  es.get<CaloGeometryRecord>().get(geoHandle);
+  //edm::ESHandle<CaloGeometry> geoHandle;
+  //es.get<CaloGeometryRecord>().get(geoHandle);
+  auto geoHandle = es.getHandle(CaloGeometryToken_);
 
-  edm::ESHandle<CaloTopology> theCaloTopology;
-  es.get<CaloTopologyRecord>().get(theCaloTopology);
+  //edm::ESHandle<CaloTopology> theCaloTopology;
+  //es.get<CaloTopologyRecord>().get(theCaloTopology);
+  auto theCaloTopology = es.getHandle(CaloTopologyToken_);
 
   const CaloSubdetectorTopology* topology_p;
   const CaloSubdetectorGeometry* geometry_p = geoHandle->getSubdetectorGeometry(DetId::Ecal, EcalBarrel);

--- a/DQMOffline/EGamma/plugins/PiZeroAnalyzer.cc
+++ b/DQMOffline/EGamma/plugins/PiZeroAnalyzer.cc
@@ -18,8 +18,8 @@
 using namespace std;
 
 PiZeroAnalyzer::PiZeroAnalyzer(const edm::ParameterSet& pset)
-  : CaloGeometryToken_{esConsumes()},
-    CaloTopologyToken_{esConsumes()} {
+  : caloGeometryToken_{esConsumes()},
+    caloTopologyToken_{esConsumes()} {
   fName_ = pset.getUntrackedParameter<std::string>("Name");
   prescaleFactor_ = pset.getUntrackedParameter<int>("prescaleFactor", 1);
 
@@ -117,11 +117,11 @@ void PiZeroAnalyzer::makePizero(const edm::EventSetup& es,
 
   //edm::ESHandle<CaloGeometry> geoHandle;
   //es.get<CaloGeometryRecord>().get(geoHandle);
-  auto geoHandle = es.getHandle(CaloGeometryToken_);
+  auto geoHandle = es.getHandle(caloGeometryToken_);
 
   //edm::ESHandle<CaloTopology> theCaloTopology;
   //es.get<CaloTopologyRecord>().get(theCaloTopology);
-  auto theCaloTopology = es.getHandle(CaloTopologyToken_);
+  auto theCaloTopology = es.getHandle(caloTopologyToken_);
 
   const CaloSubdetectorTopology* topology_p;
   const CaloSubdetectorGeometry* geometry_p = geoHandle->getSubdetectorGeometry(DetId::Ecal, EcalBarrel);

--- a/DQMOffline/EGamma/plugins/PiZeroAnalyzer.h
+++ b/DQMOffline/EGamma/plugins/PiZeroAnalyzer.h
@@ -94,8 +94,8 @@ private:
   edm::EDGetTokenT<edm::SortedCollection<EcalRecHit, edm::StrictWeakOrdering<EcalRecHit> > > barrelEcalHits_token_;
   edm::EDGetTokenT<edm::SortedCollection<EcalRecHit, edm::StrictWeakOrdering<EcalRecHit> > > endcapEcalHits_token_;
 
-  const edm::ESGetToken<CaloGeometry, CaloGeometryRecord> CaloGeometryToken_;
-  const edm::ESGetToken<CaloTopology, CaloTopologyRecord> CaloTopologyToken_;
+  const edm::ESGetToken<CaloGeometry, CaloGeometryRecord> caloGeometryToken_;
+  const edm::ESGetToken<CaloTopology, CaloTopologyRecord> caloTopologyToken_;
 
   double minPhoEtCut_;
 

--- a/DQMOffline/EGamma/plugins/PiZeroAnalyzer.h
+++ b/DQMOffline/EGamma/plugins/PiZeroAnalyzer.h
@@ -93,6 +93,10 @@ private:
 
   edm::EDGetTokenT<edm::SortedCollection<EcalRecHit, edm::StrictWeakOrdering<EcalRecHit> > > barrelEcalHits_token_;
   edm::EDGetTokenT<edm::SortedCollection<EcalRecHit, edm::StrictWeakOrdering<EcalRecHit> > > endcapEcalHits_token_;
+
+  const edm::ESGetToken<CaloGeometry, CaloGeometryRecord> CaloGeometryToken_;
+  const edm::ESGetToken<CaloTopology, CaloTopologyRecord> CaloTopologyToken_;
+
   double minPhoEtCut_;
 
   double cutStep_;


### PR DESCRIPTION
#### PR description:

Part of #31061.
Migrated to esConsumes the DQMOffline EGamma package.

#### PR validation:

all tests passed :
37 36 35 26 16 4 1 1 1 tests passed, 0 0 0 0 0 0 0 0 0 failed

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

@beaudett @guitargeek