### PR TITLE
Fix clang warning in OnlineDB/SiStripO2O

### DIFF
--- a/OnlineDB/SiStripO2O/plugins/SiStripPayloadHandler.cc
+++ b/OnlineDB/SiStripO2O/plugins/SiStripPayloadHandler.cc
@@ -63,8 +63,8 @@ SiStripPayloadHandler<SiStripPayload>::SiStripPayloadHandler(const edm::Paramete
       m_localCondDbFile(iConfig.getParameter<std::string>("condDbFile")),
       m_targetTag(iConfig.getParameter<std::string>("targetTag")),
       m_since(iConfig.getParameter<uint32_t>("since")),
-      p_type(cond::demangledName(typeid(SiStripPayload))),
-      p_cfgstr(condObjBuilder->getConfigString(typeid(SiStripPayload))) {
+      p_type(cond::demangledName(typeid(SiStripPayload))) {
+  p_cfgstr = condObjBuilder->getConfigString(typeid(SiStripPayload));
   if (iConfig.exists("configMapDatabase"))
     m_configMapDb = iConfig.getParameter<std::string>("configMapDatabase");
   if (iConfig.exists("cfgMapDbFile"))

--- a/OnlineDB/SiStripO2O/plugins/SiStripPayloadHandler.cc
+++ b/OnlineDB/SiStripO2O/plugins/SiStripPayloadHandler.cc
@@ -51,7 +51,6 @@ private:
 
   std::string p_type;
   std::string p_cfgstr;
-  edm::Service<SiStripCondObjBuilderFromDb> condObjBuilder;
 };
 
 template <typename SiStripPayload>
@@ -64,6 +63,7 @@ SiStripPayloadHandler<SiStripPayload>::SiStripPayloadHandler(const edm::Paramete
       m_targetTag(iConfig.getParameter<std::string>("targetTag")),
       m_since(iConfig.getParameter<uint32_t>("since")),
       p_type(cond::demangledName(typeid(SiStripPayload))) {
+  edm::Service<SiStripCondObjBuilderFromDb> condObjBuilder;
   p_cfgstr = condObjBuilder->getConfigString(typeid(SiStripPayload));
   if (iConfig.exists("configMapDatabase"))
     m_configMapDb = iConfig.getParameter<std::string>("configMapDatabase");
@@ -108,6 +108,7 @@ void SiStripPayloadHandler<SiStripPayload>::analyze(const edm::Event& evt, const
     edm::LogInfo("SiStripPayloadHandler") << "[SiStripPayloadHandler::" << __func__ << "] "
                                           << "NO mapping payload hash found. Will run the long O2O. ";
     SiStripPayload* obj = nullptr;
+    edm::Service<SiStripCondObjBuilderFromDb> condObjBuilder;
     if (typeid(SiStripPayload) == typeid(SiStripApvGain)) {
       // special treatment for ApvGain : provide last payload in DB
       condObjBuilder->setLastIovGain(condDbSession.fetchPayload<SiStripApvGain>(last_hash));


### PR DESCRIPTION
#### PR description:

After moving to LLVM 12 new warning surfaced:
`OnlineDB/SiStripO2O/plugins/SiStripPayloadHandler.cc:67:16: warning: field 'condObjBuilder' is uninitialized when used here [-Wuninitialized]`
in CLANG IBs.
I'm not sure if moving the object initialization in the constructor body is fine but either way I'm bringing this to attention


#### PR validation:

builds without warning for CLANG IB

