### PR TITLE
Migrate the code to DQMGlobalEDAnalyzer 

### DIFF
--- a/Validation/HGCalValidation/plugins/HGCalTriggerValidator.cc
+++ b/Validation/HGCalValidation/plugins/HGCalTriggerValidator.cc
@@ -17,7 +17,7 @@
 #include "FWCore/Common/interface/Provenance.h"
 
 #include <DQMServices/Core/interface/DQMStore.h>
-#include <DQMServices/Core/interface/DQMEDAnalyzer.h>
+#include "DQMServices/Core/interface/DQMGlobalEDAnalyzer.h"
 
 #include "DataFormats/ForwardDetId/interface/HGCalDetId.h"
 #include "DataFormats/L1THGCal/interface/HGCalTriggerCell.h"
@@ -33,75 +33,76 @@
 // class declaration
 //
 
-class HGCalTriggerValidator : public DQMEDAnalyzer {
+struct Histograms {
+  //histogram tc related
+  dqm::reco::MonitorElement *h_tc_n_;
+  dqm::reco::MonitorElement *h_tc_mipPt_;
+  dqm::reco::MonitorElement *h_tc_pt_;
+  dqm::reco::MonitorElement *h_tc_energy_;
+  dqm::reco::MonitorElement *h_tc_eta_;
+  dqm::reco::MonitorElement *h_tc_phi_;
+  dqm::reco::MonitorElement *h_tc_x_;
+  dqm::reco::MonitorElement *h_tc_y_;
+  dqm::reco::MonitorElement *h_tc_z_;
+  dqm::reco::MonitorElement *h_tc_layer_;
+
+  //histogram cl related
+  dqm::reco::MonitorElement *h_cl_n_;
+  dqm::reco::MonitorElement *h_cl_mipPt_;
+  dqm::reco::MonitorElement *h_cl_pt_;
+  dqm::reco::MonitorElement *h_cl_energy_;
+  dqm::reco::MonitorElement *h_cl_eta_;
+  dqm::reco::MonitorElement *h_cl_phi_;
+  dqm::reco::MonitorElement *h_cl_layer_;
+  dqm::reco::MonitorElement *h_cl_cells_n_;
+
+  //histogram multicl related
+  dqm::reco::MonitorElement *h_cl3d_n_;
+  dqm::reco::MonitorElement *h_cl3d_pt_;
+  dqm::reco::MonitorElement *h_cl3d_energy_;
+  dqm::reco::MonitorElement *h_cl3d_eta_;
+  dqm::reco::MonitorElement *h_cl3d_phi_;
+  dqm::reco::MonitorElement *h_cl3d_clusters_n_;
+  // cluster shower shapes
+  dqm::reco::MonitorElement *h_cl3d_showerlength_;
+  dqm::reco::MonitorElement *h_cl3d_coreshowerlength_;
+  dqm::reco::MonitorElement *h_cl3d_firstlayer_;
+  dqm::reco::MonitorElement *h_cl3d_maxlayer_;
+  dqm::reco::MonitorElement *h_cl3d_seetot_;
+  dqm::reco::MonitorElement *h_cl3d_seemax_;
+  dqm::reco::MonitorElement *h_cl3d_spptot_;
+  dqm::reco::MonitorElement *h_cl3d_sppmax_;
+  dqm::reco::MonitorElement *h_cl3d_szz_;
+  dqm::reco::MonitorElement *h_cl3d_srrtot_;
+  dqm::reco::MonitorElement *h_cl3d_srrmax_;
+  dqm::reco::MonitorElement *h_cl3d_srrmean_;
+  dqm::reco::MonitorElement *h_cl3d_emaxe_;
+  dqm::reco::MonitorElement *h_cl3d_bdteg_;
+  dqm::reco::MonitorElement *h_cl3d_quality_;
+
+  //histogram tower related
+  dqm::reco::MonitorElement *h_tower_n_;
+  dqm::reco::MonitorElement *h_tower_pt_;
+  dqm::reco::MonitorElement *h_tower_energy_;
+  dqm::reco::MonitorElement *h_tower_eta_;
+  dqm::reco::MonitorElement *h_tower_phi_;
+  dqm::reco::MonitorElement *h_tower_etEm_;
+  dqm::reco::MonitorElement *h_tower_etHad_;
+  dqm::reco::MonitorElement *h_tower_iEta_;
+  dqm::reco::MonitorElement *h_tower_iPhi_;
+};
+
+class HGCalTriggerValidator : public DQMGlobalEDAnalyzer<Histograms> {
 public:
   explicit HGCalTriggerValidator(const edm::ParameterSet &);
   ~HGCalTriggerValidator() override;
 
-  void analyze(const edm::Event &, const edm::EventSetup &) override;
-
-protected:
-  void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
+private:
+  void bookHistograms(DQMStore::IBooker&, edm::Run const&, edm::EventSetup const&, Histograms&) const override;
+  void dqmAnalyze(edm::Event const&, edm::EventSetup const&, Histograms const&) const override;
 
 private:
   // ----------member data ---------------------------
-  //histogram tc related
-  MonitorElement *h_tc_n_;
-  MonitorElement *h_tc_mipPt_;
-  MonitorElement *h_tc_pt_;
-  MonitorElement *h_tc_energy_;
-  MonitorElement *h_tc_eta_;
-  MonitorElement *h_tc_phi_;
-  MonitorElement *h_tc_x_;
-  MonitorElement *h_tc_y_;
-  MonitorElement *h_tc_z_;
-  MonitorElement *h_tc_layer_;
-
-  //histogram cl related
-  MonitorElement *h_cl_n_;
-  MonitorElement *h_cl_mipPt_;
-  MonitorElement *h_cl_pt_;
-  MonitorElement *h_cl_energy_;
-  MonitorElement *h_cl_eta_;
-  MonitorElement *h_cl_phi_;
-  MonitorElement *h_cl_layer_;
-  MonitorElement *h_cl_cells_n_;
-
-  //histogram multicl related
-  MonitorElement *h_cl3d_n_;
-  MonitorElement *h_cl3d_pt_;
-  MonitorElement *h_cl3d_energy_;
-  MonitorElement *h_cl3d_eta_;
-  MonitorElement *h_cl3d_phi_;
-  MonitorElement *h_cl3d_clusters_n_;
-  // cluster shower shapes
-  MonitorElement *h_cl3d_showerlength_;
-  MonitorElement *h_cl3d_coreshowerlength_;
-  MonitorElement *h_cl3d_firstlayer_;
-  MonitorElement *h_cl3d_maxlayer_;
-  MonitorElement *h_cl3d_seetot_;
-  MonitorElement *h_cl3d_seemax_;
-  MonitorElement *h_cl3d_spptot_;
-  MonitorElement *h_cl3d_sppmax_;
-  MonitorElement *h_cl3d_szz_;
-  MonitorElement *h_cl3d_srrtot_;
-  MonitorElement *h_cl3d_srrmax_;
-  MonitorElement *h_cl3d_srrmean_;
-  MonitorElement *h_cl3d_emaxe_;
-  MonitorElement *h_cl3d_bdteg_;
-  MonitorElement *h_cl3d_quality_;
-
-  //histogram tower related
-  MonitorElement *h_tower_n_;
-  MonitorElement *h_tower_pt_;
-  MonitorElement *h_tower_energy_;
-  MonitorElement *h_tower_eta_;
-  MonitorElement *h_tower_phi_;
-  MonitorElement *h_tower_etEm_;
-  MonitorElement *h_tower_etHad_;
-  MonitorElement *h_tower_iEta_;
-  MonitorElement *h_tower_iPhi_;
-
   edm::EDGetToken trigger_cells_token_;
   edm::EDGetToken clusters_token_;
   edm::EDGetToken multiclusters_token_;
@@ -109,92 +110,98 @@ private:
 
   std::unique_ptr<HGCalTriggerClusterIdentificationBase> id_;
 
-  HGCalTriggerTools triggerTools_;
+  std::shared_ptr<HGCalTriggerTools> triggerTools_;
 };
 
 HGCalTriggerValidator::HGCalTriggerValidator(const edm::ParameterSet &iConfig)
-    : trigger_cells_token_{consumes<l1t::HGCalTriggerCellBxCollection>(
-          iConfig.getParameter<edm::InputTag>("TriggerCells"))},
+    : trigger_cells_token_{consumes<l1t::HGCalTriggerCellBxCollection>(iConfig.getParameter<edm::InputTag>("TriggerCells"))},
       clusters_token_{consumes<l1t::HGCalClusterBxCollection>(iConfig.getParameter<edm::InputTag>("Clusters"))},
-      multiclusters_token_{
-          consumes<l1t::HGCalMulticlusterBxCollection>(iConfig.getParameter<edm::InputTag>("Multiclusters"))},
+      multiclusters_token_{consumes<l1t::HGCalMulticlusterBxCollection>(iConfig.getParameter<edm::InputTag>("Multiclusters"))},
       towers_token_{consumes<l1t::HGCalTowerBxCollection>(iConfig.getParameter<edm::InputTag>("Towers"))},
       id_{HGCalTriggerClusterIdentificationFactory::get()->create("HGCalTriggerClusterIdentificationBDT")} {
+          
   id_->initialize(iConfig.getParameter<edm::ParameterSet>("EGIdentification"));
+  triggerTools_ = std::make_shared<HGCalTriggerTools>();
+
 }
 
 HGCalTriggerValidator::~HGCalTriggerValidator() {}
 
-void HGCalTriggerValidator::bookHistograms(DQMStore::IBooker &iBooker, edm::Run const &, edm::EventSetup const &) {
+void HGCalTriggerValidator::bookHistograms(DQMStore::IBooker& iBooker,
+                                           edm::Run const&,
+                                           edm::EventSetup const& iSetup,
+                                           Histograms& histograms) const {
+  iBooker.cd();
   iBooker.setCurrentFolder("HGCALTPG");
 
   //initiating histograms
   // trigger cells
-  h_tc_n_ = iBooker.book1D("tc_n", "trigger cell number; number", 400, 0, 400);
-  h_tc_mipPt_ = iBooker.book1D("tc_mipPt", "trigger cell mipPt; mipPt", 400, 0, 400);
-  h_tc_pt_ = iBooker.book1D("tc_pt", "trigger cell pt; pt [GeV]", 15, 0, 15);
-  h_tc_energy_ = iBooker.book1D("tc_energy", "trigger cell energy; energy [GeV]", 70, 0, 70);
-  h_tc_eta_ = iBooker.book1D("tc_eta", "trigger cell eta; eta", 60, -3.14, 3.14);
-  h_tc_phi_ = iBooker.book1D("tc_phi", "trigger cell phi; phi", 60, -3.14, 3.14);
-  h_tc_x_ = iBooker.book1D("tc_x", "trigger cell x; x [cm]", 500, -250, 250);
-  h_tc_y_ = iBooker.book1D("tc_y", "trigger cell y; y [cm]", 500, -250, 250);
-  h_tc_z_ = iBooker.book1D("tc_z", "trigger cell z; z [cm]", 1100, -550, 550);
-  h_tc_layer_ = iBooker.book1D("tc_layer", "trigger cell layer; layer", 50, 0, 50);
+  histograms.h_tc_n_ = iBooker.book1D("tc_n", "trigger cell number; number", 400, 0, 400);
+  histograms.h_tc_mipPt_ = iBooker.book1D("tc_mipPt", "trigger cell mipPt; mipPt", 400, 0, 400);
+  histograms.h_tc_pt_ = iBooker.book1D("tc_pt", "trigger cell pt; pt [GeV]", 15, 0, 15);
+  histograms.h_tc_energy_ = iBooker.book1D("tc_energy", "trigger cell energy; energy [GeV]", 70, 0, 70);
+  histograms.h_tc_eta_ = iBooker.book1D("tc_eta", "trigger cell eta; eta", 60, -3.14, 3.14);
+  histograms.h_tc_phi_ = iBooker.book1D("tc_phi", "trigger cell phi; phi", 60, -3.14, 3.14);
+  histograms.h_tc_x_ = iBooker.book1D("tc_x", "trigger cell x; x [cm]", 500, -250, 250);
+  histograms.h_tc_y_ = iBooker.book1D("tc_y", "trigger cell y; y [cm]", 500, -250, 250);
+  histograms.h_tc_z_ = iBooker.book1D("tc_z", "trigger cell z; z [cm]", 1100, -550, 550);
+  histograms.h_tc_layer_ = iBooker.book1D("tc_layer", "trigger cell layer; layer", 50, 0, 50);
 
   // cluster 2D histograms
-  h_cl_n_ = iBooker.book1D("cl_n", "cluster2D number; number", 80, 0, 80);
-  h_cl_mipPt_ = iBooker.book1D("cl_mipPt", "cluster2D mipPt; mipPt", 600, 0, 600);
-  h_cl_pt_ = iBooker.book1D("cl_pt", "cluster2D pt; pt [GeV]", 20, 0, 20);
-  h_cl_energy_ = iBooker.book1D("cl_energy", "cluster2D energy; energy [GeV]", 80, 0, 80);
-  h_cl_eta_ = iBooker.book1D("cl_eta", "cluster2D eta; eta", 60, -3.14, 3.14);
-  h_cl_phi_ = iBooker.book1D("cl_phi", "cluster2D phi; phi", 60, -3.14, 3.14);
-  h_cl_cells_n_ = iBooker.book1D("cl_cells_n", "cluster2D cells_n; cells_n", 16, 0, 16);
-  h_cl_layer_ = iBooker.book1D("cl_layer", "cluster2D layer; layer", 50, 0, 50);
+  histograms.h_cl_n_ = iBooker.book1D("cl_n", "cluster2D number; number", 80, 0, 80);
+  histograms.h_cl_mipPt_ = iBooker.book1D("cl_mipPt", "cluster2D mipPt; mipPt", 600, 0, 600);
+  histograms.h_cl_pt_ = iBooker.book1D("cl_pt", "cluster2D pt; pt [GeV]", 20, 0, 20);
+  histograms.h_cl_energy_ = iBooker.book1D("cl_energy", "cluster2D energy; energy [GeV]", 80, 0, 80);
+  histograms.h_cl_eta_ = iBooker.book1D("cl_eta", "cluster2D eta; eta", 60, -3.14, 3.14);
+  histograms.h_cl_phi_ = iBooker.book1D("cl_phi", "cluster2D phi; phi", 60, -3.14, 3.14);
+  histograms.h_cl_cells_n_ = iBooker.book1D("cl_cells_n", "cluster2D cells_n; cells_n", 16, 0, 16);
+  histograms.h_cl_layer_ = iBooker.book1D("cl_layer", "cluster2D layer; layer", 50, 0, 50);
 
   // multiclusters
-  h_cl3d_n_ = iBooker.book1D("cl3d_n", "cl3duster3D number; number", 12, 0, 12);
-  h_cl3d_pt_ = iBooker.book1D("cl3d_pt", "cl3duster3D pt; pt [GeV]", 50, 0, 50);
-  h_cl3d_energy_ = iBooker.book1D("cl3d_energy", "cl3duster3D energy; energy [GeV]", 80, 0, 80);
-  h_cl3d_eta_ = iBooker.book1D("cl3d_eta", "cl3duster3D eta; eta", 60, -3.14, 3.14);
-  h_cl3d_phi_ = iBooker.book1D("cl3d_phi", "cl3duster3D phi; phi", 60, -3.14, 3.14);
-  h_cl3d_clusters_n_ = iBooker.book1D("cl3d_clusters_n", "cl3duster3D clusters_n; clusters_n", 30, 0, 30);
+  histograms.h_cl3d_n_ = iBooker.book1D("cl3d_n", "cl3duster3D number; number", 12, 0, 12);
+  histograms.h_cl3d_pt_ = iBooker.book1D("cl3d_pt", "cl3duster3D pt; pt [GeV]", 50, 0, 50);
+  histograms.h_cl3d_energy_ = iBooker.book1D("cl3d_energy", "cl3duster3D energy; energy [GeV]", 80, 0, 80);
+  histograms.h_cl3d_eta_ = iBooker.book1D("cl3d_eta", "cl3duster3D eta; eta", 60, -3.14, 3.14);
+  histograms.h_cl3d_phi_ = iBooker.book1D("cl3d_phi", "cl3duster3D phi; phi", 60, -3.14, 3.14);
+  histograms.h_cl3d_clusters_n_ = iBooker.book1D("cl3d_clusters_n", "cl3duster3D clusters_n; clusters_n", 30, 0, 30);
   // cluster shower shapes
-  h_cl3d_showerlength_ = iBooker.book1D("cl3d_showerlength", "cl3duster3D showerlength; showerlength", 50, 0, 50);
-  h_cl3d_coreshowerlength_ =
-      iBooker.book1D("cl3d_coreshowerlength", "cl3duster3D coreshowerlength; coreshowerlength", 16, 0, 16);
-  h_cl3d_firstlayer_ = iBooker.book1D("cl3d_firstlayer", "cl3duster3D firstlayer; firstlayer", 50, 0, 50);
-  h_cl3d_maxlayer_ = iBooker.book1D("cl3d_maxlayer", "cl3duster3D maxlayer; maxlayer", 50, 0, 50);
-  h_cl3d_seetot_ = iBooker.book1D("cl3d_seetot", "cl3duster3D seetot; seetot", 50, 0, 0.05);
-  h_cl3d_seemax_ = iBooker.book1D("cl3d_seemax", "cl3duster3D seemax; seemax", 40, 0, 0.04);
-  h_cl3d_spptot_ = iBooker.book1D("cl3d_spptot", "cl3duster3D spptot; spptot", 800, 0, 0.08);
-  h_cl3d_sppmax_ = iBooker.book1D("cl3d_sppmax", "cl3duster3D sppmax; sppmax", 800, 0, 0.08);
-  h_cl3d_szz_ = iBooker.book1D("cl3d_szz", "cl3duster3D szz; szz", 50, 0, 50);
-  h_cl3d_srrtot_ = iBooker.book1D("cl3d_srrtot", "cl3duster3D srrtot; srrtot", 800, 0, 0.008);
-  h_cl3d_srrmax_ = iBooker.book1D("cl3d_srrmax", "cl3duster3D srrmax; srrmax", 900, 0, 0.009);
-  h_cl3d_srrmean_ = iBooker.book1D("cl3d_srrmean", "cl3duster3D srrmean; srrmean", 800, 0, 0.008);
-  h_cl3d_emaxe_ = iBooker.book1D("cl3d_emaxe", "cl3duster3D emaxe; emaxe", 15, 0, 1.5);
-  h_cl3d_bdteg_ = iBooker.book1D("cl3d_bdteg", "cl3duster3D bdteg; bdteg", 30, -0.7, 0.4);
-  h_cl3d_quality_ = iBooker.book1D("cl3d_quality", "cl3duster3D quality; quality", 20, 0, 2);
+  histograms.h_cl3d_showerlength_ = iBooker.book1D("cl3d_showerlength", "cl3duster3D showerlength; showerlength", 50, 0, 50);
+  histograms.h_cl3d_coreshowerlength_ = iBooker.book1D("cl3d_coreshowerlength", "cl3duster3D coreshowerlength; coreshowerlength", 16, 0, 16);
+  histograms.h_cl3d_firstlayer_ = iBooker.book1D("cl3d_firstlayer", "cl3duster3D firstlayer; firstlayer", 50, 0, 50);
+  histograms.h_cl3d_maxlayer_ = iBooker.book1D("cl3d_maxlayer", "cl3duster3D maxlayer; maxlayer", 50, 0, 50);
+  histograms.h_cl3d_seetot_ = iBooker.book1D("cl3d_seetot", "cl3duster3D seetot; seetot", 50, 0, 0.05);
+  histograms.h_cl3d_seemax_ = iBooker.book1D("cl3d_seemax", "cl3duster3D seemax; seemax", 40, 0, 0.04);
+  histograms.h_cl3d_spptot_ = iBooker.book1D("cl3d_spptot", "cl3duster3D spptot; spptot", 800, 0, 0.08);
+  histograms.h_cl3d_sppmax_ = iBooker.book1D("cl3d_sppmax", "cl3duster3D sppmax; sppmax", 800, 0, 0.08);
+  histograms.h_cl3d_szz_ = iBooker.book1D("cl3d_szz", "cl3duster3D szz; szz", 50, 0, 50);
+  histograms.h_cl3d_srrtot_ = iBooker.book1D("cl3d_srrtot", "cl3duster3D srrtot; srrtot", 800, 0, 0.008);
+  histograms.h_cl3d_srrmax_ = iBooker.book1D("cl3d_srrmax", "cl3duster3D srrmax; srrmax", 900, 0, 0.009);
+  histograms.h_cl3d_srrmean_ = iBooker.book1D("cl3d_srrmean", "cl3duster3D srrmean; srrmean", 800, 0, 0.008);
+  histograms.h_cl3d_emaxe_ = iBooker.book1D("cl3d_emaxe", "cl3duster3D emaxe; emaxe", 15, 0, 1.5);
+  histograms.h_cl3d_bdteg_ = iBooker.book1D("cl3d_bdteg", "cl3duster3D bdteg; bdteg", 30, -0.7, 0.4);
+  histograms.h_cl3d_quality_ = iBooker.book1D("cl3d_quality", "cl3duster3D quality; quality", 20, 0, 2);
 
   // towers
-  h_tower_n_ = iBooker.book1D("tower_n", "tower n; number", 400, 1200, 1600);
-  h_tower_pt_ = iBooker.book1D("tower_pt", "tower pt; pt [GeV]", 50, 0, 50);
-  h_tower_energy_ = iBooker.book1D("tower_energy", "tower energy; energy [GeV]", 200, 0, 200);
-  h_tower_eta_ = iBooker.book1D("tower_eta", "tower eta; eta", 60, -3.14, 3.14);
-  h_tower_phi_ = iBooker.book1D("tower_phi", "tower phi; phi", 60, -3.14, 3.14);
-  h_tower_etEm_ = iBooker.book1D("tower_etEm", "tower etEm; etEm", 50, 0, 50);
-  h_tower_etHad_ = iBooker.book1D("tower_etHad", "tower etHad; etHad", 30, 0, 0.3);
-  h_tower_iEta_ = iBooker.book1D("tower_iEta", "tower iEta; iEta", 20, 0, 20);
-  h_tower_iPhi_ = iBooker.book1D("tower_iPhi", "tower iPhi; iPhi", 80, 0, 80);
+  histograms.h_tower_n_ = iBooker.book1D("tower_n", "tower n; number", 400, 1200, 1600);
+  histograms.h_tower_pt_ = iBooker.book1D("tower_pt", "tower pt; pt [GeV]", 50, 0, 50);
+  histograms.h_tower_energy_ = iBooker.book1D("tower_energy", "tower energy; energy [GeV]", 200, 0, 200);
+  histograms.h_tower_eta_ = iBooker.book1D("tower_eta", "tower eta; eta", 60, -3.14, 3.14);
+  histograms.h_tower_phi_ = iBooker.book1D("tower_phi", "tower phi; phi", 60, -3.14, 3.14);
+  histograms.h_tower_etEm_ = iBooker.book1D("tower_etEm", "tower etEm; etEm", 50, 0, 50);
+  histograms.h_tower_etHad_ = iBooker.book1D("tower_etHad", "tower etHad; etHad", 30, 0, 0.3);
+  histograms.h_tower_iEta_ = iBooker.book1D("tower_iEta", "tower iEta; iEta", 20, 0, 20);
+  histograms.h_tower_iPhi_ = iBooker.book1D("tower_iPhi", "tower iPhi; iPhi", 80, 0, 80);
 }
 
-void HGCalTriggerValidator::analyze(const edm::Event &iEvent, const edm::EventSetup &iSetup) {
+void HGCalTriggerValidator::dqmAnalyze(edm::Event const& iEvent, 
+                                       edm::EventSetup const& iSetup, 
+                                       Histograms const& histograms) const {
   int tc_n = 0;
   int cl_n = 0;
   int cl3d_n = 0;
   int tower_n = 0;
 
-  triggerTools_.eventSetup(iSetup);
+  triggerTools_->eventSetup(iSetup);
 
   // retrieve trigger cells
   edm::Handle<l1t::HGCalTriggerCellBxCollection> trigger_cells_h;
@@ -205,18 +212,18 @@ void HGCalTriggerValidator::analyze(const edm::Event &iEvent, const edm::EventSe
     for (auto tc_itr = trigger_cells.begin(0); tc_itr != trigger_cells.end(0); tc_itr++) {
       tc_n++;
       HGCalDetId id(tc_itr->detId());
-      h_tc_pt_->Fill(tc_itr->pt());
-      h_tc_mipPt_->Fill(tc_itr->mipPt());
-      h_tc_energy_->Fill(tc_itr->energy());
-      h_tc_eta_->Fill(tc_itr->eta());
-      h_tc_phi_->Fill(tc_itr->phi());
-      h_tc_x_->Fill(tc_itr->position().x());
-      h_tc_y_->Fill(tc_itr->position().y());
-      h_tc_z_->Fill(tc_itr->position().z());
-      h_tc_layer_->Fill(triggerTools_.layerWithOffset(id));
+      histograms.h_tc_pt_->Fill(tc_itr->pt());
+      histograms.h_tc_mipPt_->Fill(tc_itr->mipPt());
+      histograms.h_tc_energy_->Fill(tc_itr->energy());
+      histograms.h_tc_eta_->Fill(tc_itr->eta());
+      histograms.h_tc_phi_->Fill(tc_itr->phi());
+      histograms.h_tc_x_->Fill(tc_itr->position().x());
+      histograms.h_tc_y_->Fill(tc_itr->position().y());
+      histograms.h_tc_z_->Fill(tc_itr->position().z());
+      histograms.h_tc_layer_->Fill(triggerTools_->layerWithOffset(id));
     }
   }
-  h_tc_n_->Fill(tc_n);
+  histograms.h_tc_n_->Fill(tc_n);
 
   // retrieve clusters
   edm::Handle<l1t::HGCalClusterBxCollection> clusters_h;
@@ -226,16 +233,16 @@ void HGCalTriggerValidator::analyze(const edm::Event &iEvent, const edm::EventSe
   if (clusters_h.isValid()) {
     for (auto cl_itr = clusters.begin(0); cl_itr != clusters.end(0); cl_itr++) {
       cl_n++;
-      h_cl_mipPt_->Fill(cl_itr->mipPt());
-      h_cl_pt_->Fill(cl_itr->pt());
-      h_cl_energy_->Fill(cl_itr->energy());
-      h_cl_eta_->Fill(cl_itr->eta());
-      h_cl_phi_->Fill(cl_itr->phi());
-      h_cl_layer_->Fill(triggerTools_.layerWithOffset(cl_itr->detId()));
-      h_cl_cells_n_->Fill(cl_itr->constituents().size());
+      histograms.h_cl_mipPt_->Fill(cl_itr->mipPt());
+      histograms.h_cl_pt_->Fill(cl_itr->pt());
+      histograms.h_cl_energy_->Fill(cl_itr->energy());
+      histograms.h_cl_eta_->Fill(cl_itr->eta());
+      histograms.h_cl_phi_->Fill(cl_itr->phi());
+      histograms.h_cl_layer_->Fill(triggerTools_->layerWithOffset(cl_itr->detId()));
+      histograms.h_cl_cells_n_->Fill(cl_itr->constituents().size());
     }
   }
-  h_cl_n_->Fill(cl_n);
+  histograms.h_cl_n_->Fill(cl_n);
 
   // retrieve clusters 3D
   edm::Handle<l1t::HGCalMulticlusterBxCollection> multiclusters_h;
@@ -245,30 +252,30 @@ void HGCalTriggerValidator::analyze(const edm::Event &iEvent, const edm::EventSe
   if (multiclusters_h.isValid()) {
     for (auto cl3d_itr = multiclusters.begin(0); cl3d_itr != multiclusters.end(0); cl3d_itr++) {
       cl3d_n++;
-      h_cl3d_pt_->Fill(cl3d_itr->pt());
-      h_cl3d_energy_->Fill(cl3d_itr->energy());
-      h_cl3d_eta_->Fill(cl3d_itr->eta());
-      h_cl3d_phi_->Fill(cl3d_itr->phi());
-      h_cl3d_clusters_n_->Fill(cl3d_itr->constituents().size());
+      histograms.h_cl3d_pt_->Fill(cl3d_itr->pt());
+      histograms.h_cl3d_energy_->Fill(cl3d_itr->energy());
+      histograms.h_cl3d_eta_->Fill(cl3d_itr->eta());
+      histograms.h_cl3d_phi_->Fill(cl3d_itr->phi());
+      histograms.h_cl3d_clusters_n_->Fill(cl3d_itr->constituents().size());
       // cluster shower shapes
-      h_cl3d_showerlength_->Fill(cl3d_itr->showerLength());
-      h_cl3d_coreshowerlength_->Fill(cl3d_itr->coreShowerLength());
-      h_cl3d_firstlayer_->Fill(cl3d_itr->firstLayer());
-      h_cl3d_maxlayer_->Fill(cl3d_itr->maxLayer());
-      h_cl3d_seetot_->Fill(cl3d_itr->sigmaEtaEtaTot());
-      h_cl3d_seemax_->Fill(cl3d_itr->sigmaEtaEtaMax());
-      h_cl3d_spptot_->Fill(cl3d_itr->sigmaPhiPhiTot());
-      h_cl3d_sppmax_->Fill(cl3d_itr->sigmaPhiPhiMax());
-      h_cl3d_szz_->Fill(cl3d_itr->sigmaZZ());
-      h_cl3d_srrtot_->Fill(cl3d_itr->sigmaRRTot());
-      h_cl3d_srrmax_->Fill(cl3d_itr->sigmaRRMax());
-      h_cl3d_srrmean_->Fill(cl3d_itr->sigmaRRMean());
-      h_cl3d_emaxe_->Fill(cl3d_itr->eMax() / cl3d_itr->energy());
-      h_cl3d_bdteg_->Fill(id_->value(*cl3d_itr));
-      h_cl3d_quality_->Fill(cl3d_itr->hwQual());
+      histograms.h_cl3d_showerlength_->Fill(cl3d_itr->showerLength());
+      histograms.h_cl3d_coreshowerlength_->Fill(cl3d_itr->coreShowerLength());
+      histograms.h_cl3d_firstlayer_->Fill(cl3d_itr->firstLayer());
+      histograms.h_cl3d_maxlayer_->Fill(cl3d_itr->maxLayer());
+      histograms.h_cl3d_seetot_->Fill(cl3d_itr->sigmaEtaEtaTot());
+      histograms.h_cl3d_seemax_->Fill(cl3d_itr->sigmaEtaEtaMax());
+      histograms.h_cl3d_spptot_->Fill(cl3d_itr->sigmaPhiPhiTot());
+      histograms.h_cl3d_sppmax_->Fill(cl3d_itr->sigmaPhiPhiMax());
+      histograms.h_cl3d_szz_->Fill(cl3d_itr->sigmaZZ());
+      histograms.h_cl3d_srrtot_->Fill(cl3d_itr->sigmaRRTot());
+      histograms.h_cl3d_srrmax_->Fill(cl3d_itr->sigmaRRMax());
+      histograms.h_cl3d_srrmean_->Fill(cl3d_itr->sigmaRRMean());
+      histograms.h_cl3d_emaxe_->Fill(cl3d_itr->eMax() / cl3d_itr->energy());
+      histograms.h_cl3d_bdteg_->Fill(id_->value(*cl3d_itr));
+      histograms.h_cl3d_quality_->Fill(cl3d_itr->hwQual());
     }
   }
-  h_cl3d_n_->Fill(cl3d_n);
+  histograms.h_cl3d_n_->Fill(cl3d_n);
 
   // retrieve towers
   edm::Handle<l1t::HGCalTowerBxCollection> towers_h;
@@ -278,17 +285,17 @@ void HGCalTriggerValidator::analyze(const edm::Event &iEvent, const edm::EventSe
   if (towers_h.isValid()) {
     for (auto tower_itr = towers.begin(0); tower_itr != towers.end(0); tower_itr++) {
       tower_n++;
-      h_tower_pt_->Fill(tower_itr->pt());
-      h_tower_energy_->Fill(tower_itr->energy());
-      h_tower_eta_->Fill(tower_itr->eta());
-      h_tower_phi_->Fill(tower_itr->phi());
-      h_tower_etEm_->Fill(tower_itr->etEm());
-      h_tower_etHad_->Fill(tower_itr->etHad());
-      h_tower_iEta_->Fill(tower_itr->id().iEta());
-      h_tower_iPhi_->Fill(tower_itr->id().iPhi());
+      histograms.h_tower_pt_->Fill(tower_itr->pt());
+      histograms.h_tower_energy_->Fill(tower_itr->energy());
+      histograms.h_tower_eta_->Fill(tower_itr->eta());
+      histograms.h_tower_phi_->Fill(tower_itr->phi());
+      histograms.h_tower_etEm_->Fill(tower_itr->etEm());
+      histograms.h_tower_etHad_->Fill(tower_itr->etHad());
+      histograms.h_tower_iEta_->Fill(tower_itr->id().iEta());
+      histograms.h_tower_iPhi_->Fill(tower_itr->id().iPhi());
     }
   }
-  h_tower_n_->Fill(tower_n);
+  histograms.h_tower_n_->Fill(tower_n);
 }
 
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/Validation/HGCalValidation/plugins/HGCalTriggerValidator.cc
+++ b/Validation/HGCalValidation/plugins/HGCalTriggerValidator.cc
@@ -98,8 +98,8 @@ public:
   ~HGCalTriggerValidator() override;
 
 private:
-  void bookHistograms(DQMStore::IBooker&, edm::Run const&, edm::EventSetup const&, Histograms&) const override;
-  void dqmAnalyze(edm::Event const&, edm::EventSetup const&, Histograms const&) const override;
+  void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &, Histograms &) const override;
+  void dqmAnalyze(edm::Event const &, edm::EventSetup const &, Histograms const &) const override;
 
 private:
   // ----------member data ---------------------------
@@ -119,18 +119,16 @@ HGCalTriggerValidator::HGCalTriggerValidator(const edm::ParameterSet &iConfig)
       multiclusters_token_{consumes<l1t::HGCalMulticlusterBxCollection>(iConfig.getParameter<edm::InputTag>("Multiclusters"))},
       towers_token_{consumes<l1t::HGCalTowerBxCollection>(iConfig.getParameter<edm::InputTag>("Towers"))},
       id_{HGCalTriggerClusterIdentificationFactory::get()->create("HGCalTriggerClusterIdentificationBDT")} {
-          
   id_->initialize(iConfig.getParameter<edm::ParameterSet>("EGIdentification"));
   triggerTools_ = std::make_shared<HGCalTriggerTools>();
-
 }
 
 HGCalTriggerValidator::~HGCalTriggerValidator() {}
 
-void HGCalTriggerValidator::bookHistograms(DQMStore::IBooker& iBooker,
-                                           edm::Run const&,
-                                           edm::EventSetup const& iSetup,
-                                           Histograms& histograms) const {
+void HGCalTriggerValidator::bookHistograms(DQMStore::IBooker &iBooker,
+                                           edm::Run const &,
+                                           edm::EventSetup const &iSetup,
+                                           Histograms &histograms) const {
   iBooker.cd();
   iBooker.setCurrentFolder("HGCALTPG");
 
@@ -193,9 +191,9 @@ void HGCalTriggerValidator::bookHistograms(DQMStore::IBooker& iBooker,
   histograms.h_tower_iPhi_ = iBooker.book1D("tower_iPhi", "tower iPhi; iPhi", 80, 0, 80);
 }
 
-void HGCalTriggerValidator::dqmAnalyze(edm::Event const& iEvent, 
-                                       edm::EventSetup const& iSetup, 
-                                       Histograms const& histograms) const {
+void HGCalTriggerValidator::dqmAnalyze(edm::Event const &iEvent,
+                                       edm::EventSetup const &iSetup,
+                                       Histograms const &histograms) const {
   int tc_n = 0;
   int cl_n = 0;
   int cl3d_n = 0;

--- a/Validation/HGCalValidation/plugins/HGCalTriggerValidator.cc
+++ b/Validation/HGCalValidation/plugins/HGCalTriggerValidator.cc
@@ -114,9 +114,11 @@ private:
 };
 
 HGCalTriggerValidator::HGCalTriggerValidator(const edm::ParameterSet &iConfig)
-    : trigger_cells_token_{consumes<l1t::HGCalTriggerCellBxCollection>(iConfig.getParameter<edm::InputTag>("TriggerCells"))},
+    : trigger_cells_token_{consumes<l1t::HGCalTriggerCellBxCollection>(
+          iConfig.getParameter<edm::InputTag>("TriggerCells"))},
       clusters_token_{consumes<l1t::HGCalClusterBxCollection>(iConfig.getParameter<edm::InputTag>("Clusters"))},
-      multiclusters_token_{consumes<l1t::HGCalMulticlusterBxCollection>(iConfig.getParameter<edm::InputTag>("Multiclusters"))},
+      multiclusters_token_{
+          consumes<l1t::HGCalMulticlusterBxCollection>(iConfig.getParameter<edm::InputTag>("Multiclusters"))},
       towers_token_{consumes<l1t::HGCalTowerBxCollection>(iConfig.getParameter<edm::InputTag>("Towers"))},
       id_{HGCalTriggerClusterIdentificationFactory::get()->create("HGCalTriggerClusterIdentificationBDT")} {
   id_->initialize(iConfig.getParameter<edm::ParameterSet>("EGIdentification"));
@@ -163,8 +165,10 @@ void HGCalTriggerValidator::bookHistograms(DQMStore::IBooker &iBooker,
   histograms.h_cl3d_phi_ = iBooker.book1D("cl3d_phi", "cl3duster3D phi; phi", 60, -3.14, 3.14);
   histograms.h_cl3d_clusters_n_ = iBooker.book1D("cl3d_clusters_n", "cl3duster3D clusters_n; clusters_n", 30, 0, 30);
   // cluster shower shapes
-  histograms.h_cl3d_showerlength_ = iBooker.book1D("cl3d_showerlength", "cl3duster3D showerlength; showerlength", 50, 0, 50);
-  histograms.h_cl3d_coreshowerlength_ = iBooker.book1D("cl3d_coreshowerlength", "cl3duster3D coreshowerlength; coreshowerlength", 16, 0, 16);
+  histograms.h_cl3d_showerlength_ =
+      iBooker.book1D("cl3d_showerlength", "cl3duster3D showerlength; showerlength", 50, 0, 50);
+  histograms.h_cl3d_coreshowerlength_ =
+      iBooker.book1D("cl3d_coreshowerlength", "cl3duster3D coreshowerlength; coreshowerlength", 16, 0, 16);
   histograms.h_cl3d_firstlayer_ = iBooker.book1D("cl3d_firstlayer", "cl3duster3D firstlayer; firstlayer", 50, 0, 50);
   histograms.h_cl3d_maxlayer_ = iBooker.book1D("cl3d_maxlayer", "cl3duster3D maxlayer; maxlayer", 50, 0, 50);
   histograms.h_cl3d_seetot_ = iBooker.book1D("cl3d_seetot", "cl3duster3D seetot; seetot", 50, 0, 0.05);

--- a/Validation/HGCalValidation/python/hgcalRunEmulatorValidationTPG_cff.py
+++ b/Validation/HGCalValidation/python/hgcalRunEmulatorValidationTPG_cff.py
@@ -14,9 +14,11 @@ from Validation.HGCalValidation.hgcalValidationTPG_cfi import *
 from DQMServices.Core.DQM_cfg import *
 from DQMServices.Components.DQMEnvironment_cfi import *
 from Configuration.StandardSequences.EDMtoMEAtJobEnd_cff import *
-# import DQMStore service
-from DQMOffline.Configuration.DQMOffline_cff import *
-dqmSaver.workflow = '/validation/' + 'HGCAL' + '/TPG'
 
+onlineSaver = cms.EDAnalyzer("DQMFileSaverOnline",
+    producer = cms.untracked.string('DQM'),
+    path = cms.untracked.string('./'),
+    tag = cms.untracked.string('new')
+)
 
-hgcalTPGRunEmulatorValidation = cms.Sequence(hgcalTriggerPrimitives*hgcalTrigPrimValidation*dqmSaver)
+hgcalTPGRunEmulatorValidation = cms.Sequence(hgcalTriggerPrimitives*hgcalTrigPrimValidation*onlineSaver)

--- a/Validation/HGCalValidation/test/python/testValidationHGCalTrigPrim_RelVal_cfg.py
+++ b/Validation/HGCalValidation/test/python/testValidationHGCalTrigPrim_RelVal_cfg.py
@@ -1,8 +1,14 @@
 import FWCore.ParameterSet.Config as cms 
-from Configuration.ProcessModifiers.convertHGCalDigisSim_cff import convertHGCalDigisSim
+#from Configuration.ProcessModifiers.convertHGCalDigisSim_cff import convertHGCalDigisSim
 
-from Configuration.Eras.Era_Phase2_cff import Phase2
-process = cms.Process('DIGI',Phase2,convertHGCalDigisSim)
+#from Configuration.Eras.Era_Phase2_cff import Phase2
+#process = cms.Process('DIGI',Phase2,convertHGCalDigisSim)
+
+# -*- coding: utf-8 -*-
+
+from Configuration.Eras.Era_Phase2C9_cff import Phase2C9
+
+process = cms.Process('USER',Phase2C9)
 
 # import of standard configurations
 process.load('Configuration.StandardSequences.Services_cff')
@@ -10,8 +16,9 @@ process.load('SimGeneral.HepPDTESSource.pythiapdt_cfi')
 process.load('FWCore.MessageService.MessageLogger_cfi')
 process.load('Configuration.EventContent.EventContent_cff')
 process.load('SimGeneral.MixingModule.mixNoPU_cfi')
-process.load('Configuration.Geometry.GeometryExtended2023D17Reco_cff')
-process.load('Configuration.Geometry.GeometryExtended2023D17_cff')
+#process.load('Configuration.Geometry.GeometryExtended2023D17Reco_cff')
+#process.load('Configuration.Geometry.GeometryExtended2023D17_cff')
+process.load('Configuration.Geometry.GeometryExtended2026D49Reco_cff')
 process.load('Configuration.StandardSequences.MagneticField_cff')
 process.load('Configuration.StandardSequences.Generator_cff')
 process.load('IOMC.EventVertexGenerators.VtxSmearedHLLHC14TeV_cfi')
@@ -31,6 +38,29 @@ process.load("Configuration.StandardSequences.EDMtoMEAtJobEnd_cff")
 # import DQMStore service
 process.load('DQMOffline.Configuration.DQMOffline_cff')
 
+#import FWCore.ParameterSet.Config as cms
+#process.MessageLogger = cms.Service("MessageLogger",
+#        destinations = cms.untracked.vstring(                           #1
+#                'myOutputFile'                                          #2
+#        ),
+#        myOutputFile = cms.untracked.PSet(                              #3
+#                threshold = cms.untracked.string( 'WARNING' )          #4
+#        ),
+#)
+
+import FWCore.ParameterSet.Config as cms
+process.MessageLogger = cms.Service("MessageLogger",
+                     destinations       =  cms.untracked.vstring('debugmessages'),
+                     categories         = cms.untracked.vstring('interestingToMe'),
+                     debugModules  = cms.untracked.vstring('*'),
+
+                     debugmessages          = cms.untracked.PSet(
+                                                threshold =  cms.untracked.string('DEBUG'),
+                                                INFO       =  cms.untracked.PSet(limit = cms.untracked.int32(0)),
+                                                DEBUG   = cms.untracked.PSet(limit = cms.untracked.int32(0)),
+                                                interestingToMe = cms.untracked.PSet(limit = cms.untracked.int32(10000000))
+                                                    )
+)
 
 process.maxEvents = cms.untracked.PSet(
     input = cms.untracked.int32(15)
@@ -38,7 +68,9 @@ process.maxEvents = cms.untracked.PSet(
 
 # Input source
 process.source = cms.Source("PoolSource",
-       fileNames = cms.untracked.vstring('file:/afs/cern.ch/work/j/jsauvan/public/HGCAL/TestingRelVal/CMSSW_9_3_7/RelValSingleGammaPt35/GEN-SIM-DIGI-RAW/93X_upgrade2023_realistic_v5_2023D17noPU-v2/2661406C-972C-E811-9754-0025905A60DE.root'),
+       #fileNames = cms.untracked.vstring('file:/afs/cern.ch/work/j/jsauvan/public/HGCAL/TestingRelVal/CMSSW_9_3_7/RelValSingleGammaPt35/GEN-SIM-DIGI-RAW/93X_upgrade2023_realistic_v5_2023D17noPU-v2/2661406C-972C-E811-9754-0025905A60DE.root'),
+#       fileNames = cms.untracked.vstring('file:/data_cms_upgrade/sauvan/HGCAL/DIGI/Phase2HLTTDRWinter20DIGI/TT_TuneCP5_14TeV-powheg-pythia8/GEN-SIM-DIGI-RAW/PU200_110X_mcRun4_realistic_v3-v2/2D0339A5-751F-3543-BA5B-456EA6E5E294.root'),
+       fileNames = cms.untracked.vstring('root://cms-xrd-global.cern.ch///eos/cms//store/mc/Phase2HLTTDRWinter20DIGI/QCD_Pt-15to7000_TuneCP5_Flat_14TeV-pythia8/GEN-SIM-DIGI-RAW/FlatPU0To200_castor_110X_mcRun4_realistic_v3_ext1-v1/260000/003F2BA9-0D02-5A43-A53F-4161E513BFA6.root'),
        inputCommands=cms.untracked.vstring(
            'keep *',
            'drop l1tEMTFHit2016Extras_simEmtfDigis_CSC_HLT',
@@ -71,11 +103,22 @@ process.hgcl1tpg_step = cms.Path(process.hgcalTriggerPrimitives)
 process.load('Validation.HGCalValidation.hgcalValidationTPG_cff')
 process.hgcalValidationTPG_step = cms.Path(process.runHGCALValidationTPG)
 
-process.dqmSaver.workflow = '/validation/' + 'HGCAL' + '/TPG'
-process.dqmsave_step = cms.Path(process.dqmSaver)
+#process.dqmSaver.workflow = '/validation/' + 'HGCAL' + '/TPG'
+#process.dqmsave_step = cms.Path(process.dqmSaver)
+
+# NEW added
+process.onlineSaver = cms.EDAnalyzer("DQMFileSaverOnline",
+    producer = cms.untracked.string('DQM'),
+    path = cms.untracked.string('./'),
+    tag = cms.untracked.string('new'),
+)
+
+process.o = cms.EndPath(process.onlineSaver)
+process.schedule = cms.Schedule(process.hgcl1tpg_step, process.hgcalValidationTPG_step, process.o)
+# END NEW added 
 
 # Schedule definition
-process.schedule = cms.Schedule(process.hgcl1tpg_step, process.hgcalValidationTPG_step, process.dqmsave_step)
+#process.schedule = cms.Schedule(process.hgcl1tpg_step, process.hgcalValidationTPG_step, process.dqmsave_step)
 
 # Add early deletion of temporary data products to reduce peak memory need
 #from Configuration.StandardSequences.earlyDeleteSettings_cff import customiseEarlyDelete


### PR DESCRIPTION
We updated the validation code for HGCal Trigger Primitives:
- migration to DQMGlobalEDAnalyzer 
- update the configuration file in order to be able to save the produced histograms. 
