### PR TITLE
Add CSC/DT rechits to AOD

### DIFF
--- a/RecoLocalMuon/Configuration/python/RecoLocalMuon_EventContent_cff.py
+++ b/RecoLocalMuon/Configuration/python/RecoLocalMuon_EventContent_cff.py
@@ -5,16 +5,15 @@ import FWCore.ParameterSet.Config as cms
 # AOD content
 RecoLocalMuonAOD = cms.PSet(
     outputCommands = cms.untracked.vstring(
-        'keep *_dt1DRecHits_*_*',
         'keep *_dt4DSegments_*_*', 
         'keep *_dt4DCosmicSegments_*_*',
         'keep *_cscSegments_*_*',
-        'keep *_csc2DRecHits_*_*',
         'keep *_rpcRecHits_*_*')
 )
 from Configuration.Eras.Modifier_run2_GEM_2017_cff import run2_GEM_2017
 from Configuration.Eras.Modifier_run3_GEM_cff import run3_GEM
 from Configuration.Eras.Modifier_phase2_muon_cff import phase2_muon
+from Configuration.Eras.Modifier_bParking_cff import bParking
 for e in [run2_GEM_2017, run3_GEM]:
     e.toModify( RecoLocalMuonAOD, 
                 outputCommands = RecoLocalMuonAOD.outputCommands + [
@@ -25,6 +24,11 @@ phase2_muon.toModify( RecoLocalMuonAOD,
     outputCommands = RecoLocalMuonAOD.outputCommands + [
         'keep *_me0RecHits_*_*', 
         'keep *_me0Segments_*_*'])
+bParking.toModify( RecoLocalMuonAOD, 
+    outputCommands = RecoLocalMuonAOD.outputCommands + [
+        'keep *_dt1DRecHits_*_*',
+        'keep *_csc2DRecHits_*_*'])
+
 
 # RECO content
 RecoLocalMuonRECO = cms.PSet(

--- a/RecoLocalMuon/Configuration/python/RecoLocalMuon_EventContent_cff.py
+++ b/RecoLocalMuon/Configuration/python/RecoLocalMuon_EventContent_cff.py
@@ -5,9 +5,11 @@ import FWCore.ParameterSet.Config as cms
 # AOD content
 RecoLocalMuonAOD = cms.PSet(
     outputCommands = cms.untracked.vstring(
+        'keep *_dt1DRecHits_*_*',
         'keep *_dt4DSegments_*_*', 
         'keep *_dt4DCosmicSegments_*_*',
-        'keep *_cscSegments_*_*', 
+        'keep *_cscSegments_*_*',
+        'keep *_csc2DRecHits_*_*',
         'keep *_rpcRecHits_*_*')
 )
 from Configuration.Eras.Modifier_run2_GEM_2017_cff import run2_GEM_2017


### PR DESCRIPTION
#### PR description:

This PR adds CSC/DT rechits to the AOD datatier, which are the essential inputs for searches of LLP decaying in the muon system.

Similar to #34066

<!-- Please replace this text with a description of the feature proposed or problem addressed, specifying:
  - what changes are expected in the output if any, 
  - what other PRs or externals it depends upon if any,
  - link to any additional material useful to provide a documentation for this PR (slides, JIRA tickets, related pull requestes, hypernews, TWiki or Indico pages)  -->

#### PR validation:

<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

<!-- Please replace this text with any link to  -->

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
