### PR TITLE
Remove duplicate CLCTs and LCTs from trigger path in L1T CSC DQM

### DIFF
--- a/DQM/L1TMonitor/interface/L1TdeCSCTPG.h
+++ b/DQM/L1TMonitor/interface/L1TdeCSCTPG.h
@@ -22,6 +22,14 @@ protected:
   void analyze(const edm::Event&, const edm::EventSetup&) override;
 
 private:
+  // CLCTs and LCTs are considered duplicates if there is an earlier copy
+  bool isDuplicateCLCT(const CSCCLCTDigi& clct, const std::vector<CSCCLCTDigi>& container) const;
+  bool isDuplicateLCT(const CSCCorrelatedLCTDigi& lct, const std::vector<CSCCorrelatedLCTDigi>& container) const;
+
+  // all properties are the same, except for the BX which is off by +1
+  bool isCLCTOffByOneBX(const CSCCLCTDigi& lhs, const CSCCLCTDigi& rhs) const;
+  bool isLCTOffByOneBX(const CSCCorrelatedLCTDigi& lhs, const CSCCorrelatedLCTDigi& rhs) const;
+
   edm::EDGetTokenT<CSCALCTDigiCollection> dataALCT_token_;
   edm::EDGetTokenT<CSCALCTDigiCollection> emulALCT_token_;
   edm::EDGetTokenT<CSCCLCTDigiCollection> dataCLCT_token_;

--- a/DataFormats/CSCDigi/src/CSCCLCTDigi.cc
+++ b/DataFormats/CSCDigi/src/CSCCLCTDigi.cc
@@ -206,8 +206,17 @@ void CSCCLCTDigi::print() const {
 }
 
 std::ostream& operator<<(std::ostream& o, const CSCCLCTDigi& digi) {
-  return o << "CSC CLCT #" << digi.getTrknmb() << ": Valid = " << digi.isValid() << " Quality = " << digi.getQuality()
-           << " Pattern = " << digi.getPattern() << " StripType = " << digi.getStripType()
-           << " Bend = " << digi.getBend() << " Strip = " << digi.getStrip() << " KeyStrip = " << digi.getKeyStrip()
-           << " CFEB = " << digi.getCFEB() << " BX = " << digi.getBX() << " Comp Code " << digi.getCompCode();
+  if (digi.isRun3())
+    return o << "CSC CLCT #" << digi.getTrknmb() << ": Valid = " << digi.isValid() << " BX = " << digi.getBX()
+             << " Run-2 Pattern = " << digi.getPattern() << " Run-3 Pattern = " << digi.getRun3Pattern()
+             << " Quality = " << digi.getQuality() << " Comp Code " << digi.getCompCode()
+             << " Bend = " << digi.getBend() << "\n"
+             << " Slope = " << digi.getSlope() << " CFEB = " << digi.getCFEB() << " Strip = " << digi.getStrip()
+             << " KeyHalfStrip = " << digi.getKeyStrip() << " KeyQuartStrip = " << digi.getKeyStrip(4)
+             << " KeyEighthStrip = " << digi.getKeyStrip(8);
+  else
+    return o << "CSC CLCT #" << digi.getTrknmb() << ": Valid = " << digi.isValid() << " BX = " << digi.getBX()
+             << " Pattern = " << digi.getPattern() << " Quality = " << digi.getQuality() << " Bend = " << digi.getBend()
+             << " CFEB = " << digi.getCFEB() << " HalfStrip = " << digi.getStrip()
+             << " KeyHalfStrip = " << digi.getKeyStrip();
 }

--- a/DataFormats/CSCDigi/src/CSCCorrelatedLCTDigi.cc
+++ b/DataFormats/CSCDigi/src/CSCCorrelatedLCTDigi.cc
@@ -153,11 +153,19 @@ void CSCCorrelatedLCTDigi::print() const {
 }
 
 std::ostream& operator<<(std::ostream& o, const CSCCorrelatedLCTDigi& digi) {
-  return o << "CSC LCT #" << digi.getTrknmb() << ": Valid = " << digi.isValid() << " Quality = " << digi.getQuality()
-           << " MPC Link = " << digi.getMPCLink() << " cscID = " << digi.getCSCID()
-           << " syncErr = " << digi.getSyncErr() << " Type (SIM) = " << digi.getType() << "\n"
-           << "  cathode info: Strip = " << digi.getStrip() << " Pattern = " << digi.getPattern()
-           << " Bend = " << ((digi.getBend() == 0) ? 'L' : 'R') << "\n"
-           << "    anode info: Key wire = " << digi.getKeyWG() << " BX = " << digi.getBX()
-           << " bx0 = " << digi.getBX0();
+  // do not print out CSCID and sync error. They are not used anyway in the firmware, or the emulation
+  if (digi.isRun3())
+    return o << "CSC LCT #" << digi.getTrknmb() << ": Valid = " << digi.isValid() << " BX = " << digi.getBX()
+             << " Run-2 Pattern = " << digi.getPattern() << " Run-3 Pattern = " << digi.getRun3Pattern()
+             << " Quality = " << digi.getQuality() << " Bend = " << digi.getBend() << " Slope = " << digi.getSlope()
+             << "\n"
+             << " KeyHalfStrip = " << digi.getStrip() << " KeyQuartStrip = " << digi.getStrip(4)
+             << " KeyEighthStrip = " << digi.getStrip(8) << " KeyWireGroup = " << digi.getKeyWG()
+             << " Type (SIM) = " << digi.getType() << " MPC Link = " << digi.getMPCLink();
+  else
+    return o << "CSC LCT #" << digi.getTrknmb() << ": Valid = " << digi.isValid() << " BX = " << digi.getBX()
+             << " Pattern = " << digi.getPattern() << " Quality = " << digi.getQuality() << " Bend = " << digi.getBend()
+             << "\n"
+             << " KeyHalfStrip = " << digi.getStrip() << " KeyWireGroup = " << digi.getKeyWG()
+             << " Type (SIM) = " << digi.getType() << " MPC Link = " << digi.getMPCLink();
 }


### PR DESCRIPTION
#### PR description:

Remove duplicate CLCTs and LCTs from trigger path in L1T CSC DQM to better compare with DAQ path. Duplicates are (C)LCTs that have the same properties as (C)LCTs found before by the emulator, except for the BX, which is off by +1. These are typically not in the CSC DAQ because the L1A will only pick up the first one, not the second one. 

#### PR validation:

Tested on 10k events from B904 cosmic data run taken today. This run had a fixed CLCT slope mapping in the CCLUT algorithm - seems to be working now. In all, good agreement can be seen for CLCTs. 

There are still discrepancies for CLCTs, which can be attributed to (1) too many CLCTs in emulation, (2) too few CLCTs in emulation. (1) cannot be easily fixed I think since we don't know where the L1A is in the emulation. (2) might be worthwhile to look at because it points to real flaws in the CLCT emulation algorithm.

Validation plots added also below:

[CSC_dataVsEmul_B904_Cosmic_Run_210609_142357.pdf](https://github.com/cms-sw/cmssw/files/6628263/CSC_dataVsEmul_B904_Cosmic_Run_210609_142357.pdf)

I should note that the comparison was done for a pretrigger zone with size 5. CSC trigger devs are still debating whether or not this is something we should pursue. In the code now we set the pretrigger zone to 224, meaning that we accept any CLCT 2BX after a pretrigger, as opposed to a trigger that is spatially matched to the pretrigger.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)

@tahuang1991 