### PR TITLE
Fix CalibFormats/SiStripObjects comp failure for gcc10

### DIFF
--- a/CalibFormats/SiStripObjects/interface/SiStripDetInfo.h
+++ b/CalibFormats/SiStripObjects/interface/SiStripDetInfo.h
@@ -23,7 +23,7 @@
 // user include files
 #include <map>
 #include <vector>
-
+#include <stdint.h>
 // forward declarations
 
 class SiStripDetInfo {

--- a/CalibFormats/SiStripObjects/interface/SiStripDetInfo.h
+++ b/CalibFormats/SiStripObjects/interface/SiStripDetInfo.h
@@ -23,7 +23,7 @@
 // user include files
 #include <map>
 #include <vector>
-#include <stdint.h>
+#include <cstdint>
 // forward declarations
 
 class SiStripDetInfo {


### PR DESCRIPTION
#### PR description:

CalibFormats/SiStripObjects failed to compile in 2300 gcc10 IB 
it was missing the header for uint_32

#### PR validation:

CalibFormats/SiStripObjects compiles

