### PR TITLE
[Do not merge][GCC10] Added missing header for uint32_t

### DIFF
--- a/CalibFormats/SiStripObjects/interface/SiStripDetInfo.h
+++ b/CalibFormats/SiStripObjects/interface/SiStripDetInfo.h
@@ -23,6 +23,7 @@
 // user include files
 #include <map>
 #include <vector>
+#include <cstdint>
 
 // forward declarations
 


### PR DESCRIPTION
This should fix the gcc10 build errors
```
 CMSSW_12_0_X_2021-06-09-2300/src/CalibFormats/SiStripObjects/interface/SiStripDetInfo.h:41:27: error: 'uint32_t' was not declared in this scope
    41 |   SiStripDetInfo(std::map<uint32_t, DetInfo> iDetData, std::vector<uint32_t> iIDs) noexcept
```