### PR TITLE
L1T phase-1: uGMT ghost busting algo follows era change

### DIFF
--- a/L1Trigger/L1TMuon/python/simGmtStage2Digis_cfi.py
+++ b/L1Trigger/L1TMuon/python/simGmtStage2Digis_cfi.py
@@ -38,16 +38,28 @@ l1ugmtdb = cms.ESSource("PoolDBESSource",
 
 ## Era: Run2_2016
 from Configuration.Eras.Modifier_stage2L1Trigger_cff import stage2L1Trigger
-stage2L1Trigger.toModify(simGmtStage2Digis, barrelTFInput = cms.InputTag("simBmtfDigis", "BMTF"))
+stage2L1Trigger.toModify(simGmtStage2Digis, barrelTFInput = cms.InputTag("simBmtfDigis", "BMTF"),
+                                            autoCancelMode = cms.bool(False),
+                                            bmtfCancelMode = cms.string("tracks"),
+                                            emtfCancelMode = cms.string("coordinate"))
 
 ## Era: Run2_2017
 from Configuration.Eras.Modifier_stage2L1Trigger_2017_cff import stage2L1Trigger_2017
-stage2L1Trigger_2017.toModify(simGmtStage2Digis, barrelTFInput = cms.InputTag("simBmtfDigis", "BMTF"))
+stage2L1Trigger_2017.toModify(simGmtStage2Digis, barrelTFInput = cms.InputTag("simBmtfDigis", "BMTF"),
+                                                 autoCancelMode = cms.bool(False),
+                                                 bmtfCancelMode = cms.string("tracks"),
+                                                 emtfCancelMode = cms.string("coordinate"))
 
 ### Era: Run2_2018
 from Configuration.Eras.Modifier_stage2L1Trigger_2018_cff import stage2L1Trigger_2018
-stage2L1Trigger_2018.toModify(simGmtStage2Digis, barrelTFInput = cms.InputTag("simBmtfDigis", "BMTF"))
+stage2L1Trigger_2018.toModify(simGmtStage2Digis, barrelTFInput = cms.InputTag("simBmtfDigis", "BMTF"),
+                                                 autoCancelMode = cms.bool(False),
+                                                 bmtfCancelMode = cms.string("tracks"),
+                                                 emtfCancelMode = cms.string("coordinate"))
 
 ### Era: Run3_2021
 from Configuration.Eras.Modifier_stage2L1Trigger_2021_cff import stage2L1Trigger_2021
-stage2L1Trigger_2021.toModify(simGmtStage2Digis, barrelTFInput = cms.InputTag("simKBmtfDigis", "BMTF"))
+stage2L1Trigger_2021.toModify(simGmtStage2Digis, barrelTFInput = cms.InputTag("simKBmtfDigis", "BMTF"),
+                                                 autoCancelMode = cms.bool(False),
+                                                 bmtfCancelMode = cms.string("kftracks"),
+                                                 emtfCancelMode = cms.string("coordinate"))


### PR DESCRIPTION

#### PR description:

Modifying the ghost busting algo when the era is changes. If the emulator is run without an era it should use the firmware version as before.

#### PR validation:

Ran scram build code-checks && scram build code-format and produced the Ntuples used for menu studies, confirming that the number of muons generated at the output of uGMT decreased.

Rebase of https://github.com/cms-l1t-offline/cmssw/pull/923

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Rebase of https://github.com/cms-l1t-offline/cmssw/pull/923

@dinyar FYI