### PR TITLE
L1T phase-1: Fix OMTF input tags for Run 3 re-emulation workflow

### DIFF
--- a/L1Trigger/Configuration/python/customiseReEmul.py
+++ b/L1Trigger/Configuration/python/customiseReEmul.py
@@ -61,7 +61,7 @@ def L1TReEmulFromRAW2015(process):
         cms.InputTag('hcalDigis')
     )
     process.L1TReEmul = cms.Sequence(process.simEcalTriggerPrimitiveDigis * process.simHcalTriggerPrimitiveDigis * process.SimL1Emulator)
-    process.simDtTriggerPrimitiveDigis.digiTag = 'muonDTDigis'  
+    process.simDtTriggerPrimitiveDigis.digiTag = 'muonDTDigis'
     process.simCscTriggerPrimitiveDigis.CSCComparatorDigiProducer = cms.InputTag( 'muonCSCDigis', 'MuonCSCComparatorDigi')
     process.simCscTriggerPrimitiveDigis.CSCWireDigiProducer       = cms.InputTag( 'muonCSCDigis', 'MuonCSCWireDigi' )  
 
@@ -131,6 +131,7 @@ def L1TReEmulFromRAW2016(process):
                 cms.InputTag('hcalDigis'),
                 cms.InputTag('hcalDigis')
     )
+    process.simDtTriggerPrimitiveDigis.digiTag = cms.InputTag("muonDTDigis")
     process.simCscTriggerPrimitiveDigis.CSCComparatorDigiProducer = cms.InputTag( 'muonCSCDigis', 'MuonCSCComparatorDigi')
     process.simCscTriggerPrimitiveDigis.CSCWireDigiProducer       = cms.InputTag( 'muonCSCDigis', 'MuonCSCWireDigi' )  
     process.L1TReEmul = cms.Sequence(process.simEcalTriggerPrimitiveDigis * process.simHcalTriggerPrimitiveDigis * process.SimL1Emulator)
@@ -265,8 +266,8 @@ def L1TReEmulMCFromRAW(process):
     # Temporary fix for OMTF inputs in MC re-emulation
     run3_GEM.toModify(process.simOmtfDigis,
         srcRPC   = 'muonRPCDigis',
-        srcDTPh  = 'bmtfDigis',
-        srcDTTh  = 'bmtfDigis'
+        srcDTPh  = 'simDtTriggerPrimitiveDigis',
+        srcDTTh  = 'simDtTriggerPrimitiveDigis'
     )
 
     return process

--- a/L1Trigger/Configuration/python/customiseReEmul.py
+++ b/L1Trigger/Configuration/python/customiseReEmul.py
@@ -261,6 +261,14 @@ def L1TReEmulMCFromRAW(process):
     L1TReEmulFromRAW(process)
     stage2L1Trigger.toModify(process.simEmtfDigis, CSCInput = 'simCscTriggerPrimitiveDigis:MPCSORTED')
     stage2L1Trigger.toModify(process.simOmtfDigis, srcCSC   = 'simCscTriggerPrimitiveDigis:MPCSORTED')
+
+    # Temporary fix for OMTF inputs in MC re-emulation
+    run3_GEM.toModify(process.simOmtfDigis,
+        srcRPC   = 'muonRPCDigis',
+        srcDTPh  = 'bmtfDigis',
+        srcDTTh  = 'bmtfDigis'
+    )
+
     return process
 
 def L1TReEmulMCFromRAWSimEcalTP(process):


### PR DESCRIPTION
#### PR description:

in the current re-emulation workflow the input tag to the OMTF emulator are not working properly which causes OMTF muons to be missing in re-emulation. This PR fixes the issue temporarily using bmtfDigis for DT input and muonRPCDigis for RPC inputs.

#### PR validation:

Verified that it doesn't crash for Run 3 re-emulation and that missing muons are back.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Rebase of https://github.com/cms-l1t-offline/cmssw/pull/925
