### PR TITLE
keep future products from UL DIGI step

### DIFF
--- a/SimTracker/Configuration/python/SimTracker_EventContent_cff.py
+++ b/SimTracker/Configuration/python/SimTracker_EventContent_cff.py
@@ -37,7 +37,11 @@ SimTrackerDEBUG = cms.PSet(
 )
 #RAW content 
 SimTrackerRAW = cms.PSet(
-    outputCommands = cms.untracked.vstring('keep *_allTrackMCMatch_*_*')
+    outputCommands = cms.untracked.vstring(
+        'keep *_allTrackMCMatch_*_*',
+#keep future products from UL DIGI step
+        'keep *_prunedTrackingParticles_*_*',
+        'keep *_prunedDigiSimLinks_*_*')
 )
 #RECO content
 SimTrackerRECO = cms.PSet(


### PR DESCRIPTION
keep products added in #33996 so that they are forwarded appropriately by the HLT step.

tested with inputs from 10_6_X and HLT running
```
cmsDriver.py  --python_filename step3.py --eventcontent RAWSIM  --datatier GEN-SIM-RAW --fileout file:step3.root --conditions 102X_upgrade2018_realistic_v15 --customise_commands 'process.source.bypassVersionCheck = cms.untracked.bool(True)' --step HLT:2018v32 --geometry DB:Extended --filein file:step2.root --era Run2_2018,bParking  --no_exec --mc -n -1 --nThreads 8

```

@silviodonato 
it turns out that my branch made on top of 10_2_16_UL merges clearly in 10_2_X
