### PR TITLE
keep future products from UL DIGI step

### DIFF
--- a/SimTracker/Configuration/python/SimTracker_EventContent_cff.py
+++ b/SimTracker/Configuration/python/SimTracker_EventContent_cff.py
@@ -37,7 +37,11 @@ SimTrackerDEBUG = cms.PSet(
 )
 #RAW content 
 SimTrackerRAW = cms.PSet(
-    outputCommands = cms.untracked.vstring('keep *_allTrackMCMatch_*_*')
+    outputCommands = cms.untracked.vstring(
+        'keep *_allTrackMCMatch_*_*',
+#keep future products from UL DIGI step
+        'keep *_prunedTrackingParticles_*_*',
+        'keep *_prunedDigiSimLinks_*_*')
 )
 #RECO content
 SimTrackerRECO = cms.PSet(


### PR DESCRIPTION
same as #34081

keep products added in #33996 so that they are forwarded appropriately by the HLT step.

