### PR TITLE
[GCC10][HeaderChk] Include missing headers

### DIFF
--- a/FWCore/Utilities/interface/StdPairHasher.h
+++ b/FWCore/Utilities/interface/StdPairHasher.h
@@ -3,6 +3,8 @@
 /*
  tbb::hash was changed to used std::hash which does not have an implementation for std::pair.
 */
+
+#include <string>
 #include "FWCore/Utilities/interface/hash_combine.h"
 
 namespace edm {

--- a/IOPool/Streamer/interface/FRDFileHeader.h
+++ b/IOPool/Streamer/interface/FRDFileHeader.h
@@ -2,6 +2,8 @@
 #define IOPool_Streamer_FRDFileHeader_h
 
 #include <array>
+#include <cstddef>
+#include <cstdint>
 
 /*
  * FRD File Header optionally found at the beginning of the FRD RAW file


### PR DESCRIPTION
For GCC 10 , header check fails with errors in [a].  This PR includes the missing headers .

[a] https://cmssdt.cern.ch/SDT/jenkins-artifacts/pull-request-integration/PR-dac18a/15862/headers_chks.log
```
src/FWCore/Utilities/interface/StdPairHasher.h:10:50: error: ISO C++ forbids declaration of 'type name' with no type [-fpermissive]
   10 |     std::size_t operator()(const std::pair<const std::string, const std::string>& a) const noexcept {
      |                                                  ^~~
```
```
src/IOPool/Streamer/interface/FRDFileHeader.h:41:8: error: 'uint16_t' does not name a type
   41 | inline uint16_t getFRDFileHeaderVersion(const std::array<uint8_t, 4>& id, const std::array<uint8_t, 4>& version) {
      |        ^~~~~~~~

```
```
src/IOPool/Streamer/interface/FRDFileHeader.h: In function 'uint16_t getFRDFileHeaderVersion(const std::array<unsigned char, 4>&, const std::array<unsigned char, 4>&)':
src/IOPool/Streamer/interface/FRDFileHeader.h:43:3: error: 'size_t' was not declared in this scope; did you mean 'std::size_t'?
   43 |   size_t i; 
``` 