### PR TITLE
Migrate module configurations in RecoTracker{ConversionSeedGenerators,DeDx} to use default cfipython v2

### DIFF
--- a/RecoTracker/ConversionSeedGenerators/python/ConversionStep2_cff.py
+++ b/RecoTracker/ConversionSeedGenerators/python/ConversionStep2_cff.py
@@ -13,79 +13,80 @@ conv2Clusters = trackClusterRemover.clone(
     TrackQuality          = 'highPurity'
 )
 
-conv2LayerPairs = cms.EDProducer('SeedingLayersEDProducer',
-                                layerList = cms.vstring('BPix1+BPix2', 
+import RecoTracker.TkSeedingLayers.seedingLayersEDProducer_cfi as _mod
 
-                                                        'BPix2+BPix3', 
-                                                        'BPix2+FPix1_pos', 
-                                                        'BPix2+FPix1_neg', 
-                                                        'BPix2+FPix2_pos', 
-                                                        'BPix2+FPix2_neg', 
+conv2LayerPairs = _mod.seedingLayersEDProducer.clone(
+                                layerList = ['BPix1+BPix2', 
+                                             'BPix2+BPix3', 
+                                             'BPix2+FPix1_pos', 
+                                             'BPix2+FPix1_neg', 
+                                             'BPix2+FPix2_pos', 
+                                             'BPix2+FPix2_neg', 
 
-                                                        'FPix1_pos+FPix2_pos', 
-                                                        'FPix1_neg+FPix2_neg',
+                                             'FPix1_pos+FPix2_pos', 
+                                             'FPix1_neg+FPix2_neg',
 
-                                                        'BPix3+TIB1', 
-                                                        
-                                                        'TIB1+TID1_pos', 
-                                                        'TIB1+TID1_neg', 
-                                                        'TIB1+TID2_pos', 
-                                                        'TIB1+TID2_neg',
-                                                        'TIB1+TIB2',
-                                                      
-                                                        'TIB2+TID1_pos', 
-                                                        'TIB2+TID1_neg', 
-                                                        'TIB2+TID2_pos', 
-                                                        'TIB2+TID2_neg', 
-                                                        'TIB2+TIB3',
-                                                      
-                                                        'TIB3+TIB4', 
-                                                        'TIB3+TID1_pos', 
-                                                        'TIB3+TID1_neg', 
+                                             'BPix3+TIB1', 
+                                             
+                                             'TIB1+TID1_pos', 
+                                             'TIB1+TID1_neg', 
+                                             'TIB1+TID2_pos', 
+                                             'TIB1+TID2_neg',
+                                             'TIB1+TIB2',
+                                             
+                                             'TIB2+TID1_pos', 
+                                             'TIB2+TID1_neg', 
+                                             'TIB2+TID2_pos', 
+                                             'TIB2+TID2_neg', 
+                                             'TIB2+TIB3',
+                                             
+                                             'TIB3+TIB4', 
+                                             'TIB3+TID1_pos', 
+                                             'TIB3+TID1_neg', 
 
-                                                        'TIB4+TOB1',
+                                             'TIB4+TOB1',
 
-                                                        'TOB1+TOB2', 
-                                                        'TOB1+TEC1_pos', 
-                                                        'TOB1+TEC1_neg', 
+                                             'TOB1+TOB2', 
+                                             'TOB1+TEC1_pos', 
+                                             'TOB1+TEC1_neg', 
 
-                                                        'TOB2+TOB3',  
-                                                        'TOB2+TEC1_pos', 
-                                                        'TOB2+TEC1_neg', 
-                                                        
-                                                        'TOB3+TOB4', 
-                                                        'TOB3+TEC1_pos', 
-                                                        'TOB3+TEC1_neg', 
-                                                        
-                                                        'TOB4+TOB5',
+                                             'TOB2+TOB3',  
+                                             'TOB2+TEC1_pos', 
+                                             'TOB2+TEC1_neg', 
+                                             
+                                             'TOB3+TOB4', 
+                                             'TOB3+TEC1_pos', 
+                                             'TOB3+TEC1_neg', 
+                                             
+                                             'TOB4+TOB5',
 
-                                                        'TOB5+TOB6',
+                                             'TOB5+TOB6',
 
-                                                        'TID1_pos+TID2_pos', 
-                                                        'TID2_pos+TID3_pos', 
-                                                        'TID3_pos+TEC1_pos', 
+                                             'TID1_pos+TID2_pos', 
+                                             'TID2_pos+TID3_pos', 
+                                             'TID3_pos+TEC1_pos', 
 
-                                                        'TID1_neg+TID2_neg', 
-                                                        'TID2_neg+TID3_neg', 
-                                                        'TID3_neg+TEC1_neg', 
+                                             'TID1_neg+TID2_neg', 
+                                             'TID2_neg+TID3_neg', 
+                                             'TID3_neg+TEC1_neg', 
 
-                                                        'TEC1_pos+TEC2_pos', 
-                                                        'TEC2_pos+TEC3_pos', 
-                                                        'TEC3_pos+TEC4_pos',
-                                                        'TEC4_pos+TEC5_pos',
-                                                        'TEC5_pos+TEC6_pos',
-                                                        'TEC6_pos+TEC7_pos',
-                                                        'TEC7_pos+TEC8_pos',
+                                             'TEC1_pos+TEC2_pos', 
+                                             'TEC2_pos+TEC3_pos', 
+                                             'TEC3_pos+TEC4_pos',
+                                             'TEC4_pos+TEC5_pos',
+                                             'TEC5_pos+TEC6_pos',
+                                             'TEC6_pos+TEC7_pos',
+                                             'TEC7_pos+TEC8_pos',
 
-                                                        'TEC1_neg+TEC2_neg', 
-                                                        'TEC2_neg+TEC3_neg', 
-                                                        'TEC3_neg+TEC4_neg',
-                                                        'TEC4_neg+TEC5_neg',
-                                                        'TEC5_neg+TEC6_neg',
-                                                        'TEC6_neg+TEC7_neg',
-                                                        'TEC7_neg+TEC8_neg'
-                                                        #other combinations could be added
-                                                        ),
+                                             'TEC1_neg+TEC2_neg', 
+                                             'TEC2_neg+TEC3_neg', 
+                                             'TEC3_neg+TEC4_neg',
+                                             'TEC4_neg+TEC5_neg',
+                                             'TEC5_neg+TEC6_neg',
+                                             'TEC6_neg+TEC7_neg',
+                                             'TEC7_neg+TEC8_neg'
+                                             #other combinations could be added
+                                             ],
                                 
                                 BPix = cms.PSet(
                                     TTRHBuilder = cms.string('WithTrackAngle'),

--- a/RecoTracker/ConversionSeedGenerators/python/ConversionStep_cff.py
+++ b/RecoTracker/ConversionSeedGenerators/python/ConversionStep_cff.py
@@ -120,9 +120,10 @@ _convLayerPairsLayerList =['BPix1+BPix2',
 _convLayerPairsLayerList.extend(_convLayerPairsStripOnlyLayers)
                                                         
     
-             
-convLayerPairs = cms.EDProducer('SeedingLayersEDProducer',
-                                layerList = cms.vstring(_convLayerPairsLayerList),
+import RecoTracker.TkSeedingLayers.seedingLayersEDProducer_cfi as _mod
+
+convLayerPairs = _mod.seedingLayersEDProducer.clone(
+                                layerList = _convLayerPairsLayerList, 
                                 BPix = cms.PSet(
                                     TTRHBuilder = cms.string('WithTrackAngle'),
                                     HitProducer = cms.string('siPixelRecHits'),

--- a/RecoTracker/DeDx/python/dedxEstimators_cff.py
+++ b/RecoTracker/DeDx/python/dedxEstimators_cff.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
 dedxHitInfo = cms.EDProducer("DeDxHitInfoProducer",
-    tracks                     = cms.InputTag("generalTracks"),
+    tracks             = cms.InputTag("generalTracks"),
 
     minTrackHits       = cms.uint32(0),
     minTrackPt         = cms.double(10),
@@ -26,24 +26,15 @@ dedxHitInfo = cms.EDProducer("DeDxHitInfoProducer",
     lowPtTracksDeDxThreshold = cms.double(3.5), # threshold on tracks
 )
 
-dedxHarmonic2 = cms.EDProducer("DeDxEstimatorProducer",
-    tracks                     = cms.InputTag("generalTracks"),
- 
-    estimator      = cms.string('generic'),
-    fraction       = cms.double(0.4),        #Used only if estimator='truncated'
-    exponent       = cms.double(-2.0),       #Used only if estimator='generic'
- 
-    UseStrip       = cms.bool(True),
-    UsePixel       = cms.bool(False),
-    ShapeTest      = cms.bool(True),
-    MeVperADCStrip = cms.double(3.61e-06*265),
-    MeVperADCPixel = cms.double(3.61e-06),
+import RecoTracker.DeDx.DeDxEstimatorProducer_cfi as _mod
 
-    Reccord            = cms.string("SiStripDeDxMip_3D_Rcd"), #used only for discriminators : estimators='productDiscrim' or 'btagDiscrim' or 'smirnovDiscrim' or 'asmirnovDiscrim'
-    ProbabilityMode    = cms.string("Accumulation"),          #used only for discriminators : estimators='productDiscrim' or 'btagDiscrim' or 'smirnovDiscrim' or 'asmirnovDiscrim'
+dedxHarmonic2 = _mod.DeDxEstimatorProducer.clone(
+    estimator      = 'generic',
+    fraction       = 0.4,        #Used only if estimator='truncated'
+    exponent       = -2.0,       #Used only if estimator='generic'
 
-    UseCalibration  = cms.bool(False),
-    calibrationPath = cms.string(""),
+    Reccord            = "SiStripDeDxMip_3D_Rcd", #used only for discriminators : estimators='productDiscrim' or 'btagDiscrim' or 'smirnovDiscrim' or 'asmirnovDiscrim'
+    ProbabilityMode    = "Accumulation",          #used only for discriminators : estimators='productDiscrim' or 'btagDiscrim' or 'smirnovDiscrim' or 'asmirnovDiscrim'
 )
 
 from Configuration.Eras.Modifier_fastSim_cff import fastSim


### PR DESCRIPTION
#### PR description: 
Optimization of the python configurations: Improve maintainability by cleaning up the duplicated and cloning from the default/reference configurations.
(I re-make this PR. the original one PR #33901 was spoilt by my mistake..)
 
In this PR, 3 files changed.  
- RecoTracker/ConversionSeedGenerators/python/ConversionStep2_cff.py
- RecoTracker/ConversionSeedGenerators/python/ConversionStep_cff.py
- RecoTracker/DeDx/python/dedxEstimators_cff.py

(The previous PRs were  [PR#33207](https://github.com/cms-sw/cmssw/pull/33207), [PR#33307](https://github.com/cms-sw/cmssw/pull/33307), [PR#33352](https://github.com/cms-sw/cmssw/pull/33352), [PR#33543](https://github.com/cms-sw/cmssw/pull/33543),  [PR#33563](https://github.com/cms-sw/cmssw/pull/33563),  [PR#33671](https://github.com/cms-sw/cmssw/pull/33671),[PR#34007](https://github.com/cms-sw/cmssw/pull/34007),[PR#34009](https://github.com/cms-sw/cmssw/pull/34009) )

Updates: 
Replace explicit configuration with a reference from cfipython/. (migrating EDProducer("type", .. -> typeDefault.clone()) 
Remove the type specifications already presented in cfipython/fillDescriptions reference for improved syntax safety.
Remove the duplicated parameters that are exactly the same value in cfipython reference.

#### PR validation:
Event Content comparison check was also done and there is no change with these updates.
Tested in CMSSW_12_0_X, the basic test all passed in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html).