### PR TITLE
[HGCAL] LayerClusters to SimTracksters associator

### DIFF
--- a/SimCalorimetry/HGCalAssociatorProducers/plugins/LCToSimTSAssociatorByEnergyScoreImpl.cc
+++ b/SimCalorimetry/HGCalAssociatorProducers/plugins/LCToSimTSAssociatorByEnergyScoreImpl.cc
@@ -46,7 +46,7 @@ hgcal::RecoToSimTracksterCollection LCToSimTSAssociatorByEnergyScoreImpl::associ
         }
         else {
           LogDebug("LCToSimTSAssociatorByEnergyScoreImpl")
-            << "layerCluster Id: \t" << lcId << "\t CP Id: \t" << cpPair->first << "\t score \t" << cpPair->second << "\n";
+            << "layerCluster Id: \t" << lcId << "\t CP Id: \t" << cpPair->first.index() << "\t score \t" << cpPair->second << "\n";
           // Fill AssociationMap
           returnValue.insert(lcRef,  // Ref to LC
                              std::make_pair(edm::Ref<ticl::TracksterCollection>(sTCH, tsId), // Pair <Ref to TS, score>
@@ -73,7 +73,7 @@ hgcal::RecoToSimTracksterCollection LCToSimTSAssociatorByEnergyScoreImpl::associ
         }
         else {
           LogDebug("LCToSimTSAssociatorByEnergyScoreImpl")
-            << "layerCluster Id: \t" << lcId << "\t SC Id: \t" << scPair->first << "\t score \t" << scPair->second << "\n";
+            << "layerCluster Id: \t" << lcId << "\t SC Id: \t" << scPair->first.index() << "\t score \t" << scPair->second << "\n";
           // Fill AssociationMap
           returnValue.insert(lcRef,  // Ref to LC
                              std::make_pair(edm::Ref<ticl::TracksterCollection>(sTCH, tsId), // Pair <Ref to TS, score>

--- a/SimCalorimetry/HGCalAssociatorProducers/plugins/LCToSimTSAssociatorByEnergyScoreImpl.cc
+++ b/SimCalorimetry/HGCalAssociatorProducers/plugins/LCToSimTSAssociatorByEnergyScoreImpl.cc
@@ -1,0 +1,61 @@
+// Original Author: Marco Rovere
+//
+
+#include "LCToSimTSAssociatorByEnergyScoreImpl.h"
+
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+LCToSimTSAssociatorByEnergyScoreImpl::LCToSimTSAssociatorByEnergyScoreImpl(
+    edm::EDProductGetter const& productGetter,
+    bool hardScatterOnly,
+    std::shared_ptr<hgcal::RecHitTools> recHitTools)
+    : hardScatterOnly_(hardScatterOnly), recHitTools_(recHitTools), productGetter_(&productGetter) {
+  layers_ = recHitTools_->lastLayerBH();
+}
+
+
+hgcal::RecoToSimCollection LCToSimTSAssociatorByEnergyScoreImpl::associateRecoToSim(
+    const edm::Handle<reco::CaloClusterCollection>& cCCH, const edm::Handle<ticl::TracksterCollection> &sTCH) const {
+  hgcal::RecoToSimCollection returnValue(productGetter_);
+/*
+  for (size_t lcId = 0; lcId < cCCH.size(); ++lcId) {
+    for (const auto tst : sTCH) {
+      if (tst.seedID() == )
+
+
+
+
+    for (auto& cpPair : cpsInLayerCluster[lcId]) {
+      LogDebug("LCToSimTSAssociatorByEnergyScoreImpl")
+          << "layerCluster Id: \t" << lcId << "\t CP id: \t" << cpPair.first << "\t score \t" << cpPair.second << "\n";
+      // Fill AssociationMap
+      returnValue.insert(edm::Ref<reco::CaloClusterCollection>(cCCH, lcId),  // Ref to LC
+                         std::make_pair(edm::Ref<CaloParticleCollection>(cPCH, cpPair.first),
+                                        cpPair.second)  // Pair <Ref to CP, score>
+      );
+    }
+  }
+*/
+  return returnValue;
+}
+
+hgcal::SimToRecoCollection LCToSimTSAssociatorByEnergyScoreImpl::associateSimToReco(
+    const edm::Handle<reco::CaloClusterCollection>& cCCH, const edm::Handle<CaloParticleCollection>& cPCH) const {
+  hgcal::SimToRecoCollection returnValue(productGetter_);
+/*
+  const auto& links = makeConnections(cCCH, cPCH);
+  const auto& cPOnLayer = std::get<1>(links);
+  for (size_t cpId = 0; cpId < cPOnLayer.size(); ++cpId) {
+    for (size_t layerId = 0; layerId < cPOnLayer[cpId].size(); ++layerId) {
+      for (auto& lcPair : cPOnLayer[cpId][layerId].layerClusterIdToEnergyAndScore) {
+        returnValue.insert(
+            edm::Ref<CaloParticleCollection>(cPCH, cpId),                              // Ref to CP
+            std::make_pair(edm::Ref<reco::CaloClusterCollection>(cCCH, lcPair.first),  // Pair <Ref to LC,
+                           std::make_pair(lcPair.second.first, lcPair.second.second))  // pair <energy, score> >
+        );
+      }
+    }
+  }
+*/
+  return returnValue;
+}

--- a/SimCalorimetry/HGCalAssociatorProducers/plugins/LCToSimTSAssociatorByEnergyScoreImpl.cc
+++ b/SimCalorimetry/HGCalAssociatorProducers/plugins/LCToSimTSAssociatorByEnergyScoreImpl.cc
@@ -7,17 +7,16 @@
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
-LCToSimTSAssociatorByEnergyScoreImpl::LCToSimTSAssociatorByEnergyScoreImpl(
-    edm::EDProductGetter const& productGetter,
-    bool hardScatterOnly)
-    : hardScatterOnly_(hardScatterOnly), productGetter_(&productGetter) {
-}
-
+LCToSimTSAssociatorByEnergyScoreImpl::LCToSimTSAssociatorByEnergyScoreImpl(edm::EDProductGetter const& productGetter)
+    : productGetter_(&productGetter) {}
 
 hgcal::RecoToSimTracksterCollection LCToSimTSAssociatorByEnergyScoreImpl::associateRecoToSim(
-    const edm::Handle<reco::CaloClusterCollection>& cCCH, const edm::Handle<ticl::TracksterCollection> &sTCH,
-    const edm::Handle<CaloParticleCollection>& cPCH, const hgcal::RecoToSimCollection &lCToCPs,
-    const edm::Handle<SimClusterCollection>& sCCH, const hgcal::RecoToSimCollectionWithSimClusters &lCToSCs) const {
+    const edm::Handle<reco::CaloClusterCollection>& cCCH,
+    const edm::Handle<ticl::TracksterCollection>& sTCH,
+    const edm::Handle<CaloParticleCollection>& cPCH,
+    const hgcal::RecoToSimCollection& lCToCPs,
+    const edm::Handle<SimClusterCollection>& sCCH,
+    const hgcal::RecoToSimCollectionWithSimClusters& lCToSCs) const {
   hgcal::RecoToSimTracksterCollection returnValue(productGetter_);
 
   const auto simTracksters = *sTCH.product();
@@ -25,153 +24,158 @@ hgcal::RecoToSimTracksterCollection LCToSimTSAssociatorByEnergyScoreImpl::associ
   for (size_t lcId = 0; lcId < cCCH.product()->size(); ++lcId) {
     const edm::Ref<reco::CaloClusterCollection> lcRef(cCCH, lcId);
     for (size_t tsId = 0; tsId < simTracksters.size(); ++tsId) {
-
       if (simTracksters[tsId].seedID() == cPCH.id()) {
         const auto& cpIt = lCToCPs.find(lcRef);
         if (cpIt == lCToCPs.end()) {
           LogDebug("LCToSimTSAssociatorByEnergyScoreImpl")
-            << "layerCluster Id " << lcId << " not found in CaloParticle association map\n";
+              << "LayerCluster Id " << lcId << " not found in CaloParticle association map\n";
           continue;
         }
 
         const edm::Ref<CaloParticleCollection> cpRef(cPCH, simTracksters[tsId].seedIndex());
         const auto& cps = cpIt->val;
-        const auto cpPair = std::find_if(std::begin(cps), std::end(cps),
-                                         [&cpRef](const std::pair<edm::Ref<CaloParticleCollection>, float>& p) {
-                         return p.first == cpRef;
-                       });
+        const auto cpPair = std::find_if(
+            std::begin(cps), std::end(cps), [&cpRef](const std::pair<edm::Ref<CaloParticleCollection>, float>& p) {
+              return p.first == cpRef;
+            });
         if (cpPair == cps.end()) {
-          LogDebug("LCToSimTSAssociatorByEnergyScoreImpl")
-            << "CaloParticle Id " << simTracksters[tsId].seedIndex() << " not found in LayerCluster association map\n";
+          LogDebug("LCToSimTSAssociatorByEnergyScoreImpl") << "CaloParticle Id " << simTracksters[tsId].seedIndex()
+                                                           << " not found in LayerCluster association map\n";
           continue;
-        }
-        else {
+        } else {
           LogDebug("LCToSimTSAssociatorByEnergyScoreImpl")
-            << "layerCluster Id: \t" << lcId << "\t CP Id: \t" << cpPair->first.index() << "\t score \t" << cpPair->second << "\n";
+              << "LayerCluster Id: \t" << lcId << "\t CaloParticle Id: \t" << cpPair->first.index() << "\t score \t"
+              << cpPair->second << "\n";
           // Fill AssociationMap
-          returnValue.insert(lcRef,  // Ref to LC
-                             std::make_pair(edm::Ref<ticl::TracksterCollection>(sTCH, tsId), // Pair <Ref to TS, score>
+          returnValue.insert(lcRef,                                                           // Ref to LC
+                             std::make_pair(edm::Ref<ticl::TracksterCollection>(sTCH, tsId),  // Pair <Ref to TS, score>
                                             cpPair->second));
         }
-      }
-      else if (simTracksters[tsId].seedID() == sCCH.id()) {
+      } else if (simTracksters[tsId].seedID() == sCCH.id()) {
         const auto& scIt = lCToSCs.find(lcRef);
         if (scIt == lCToSCs.end()) {
           LogDebug("LCToSimTSAssociatorByEnergyScoreImpl")
-            << "layerCluster Id " << lcId << " not found in SimCluster association map\n";
+              << "LayerCluster Id " << lcId << " not found in SimCluster association map\n";
           continue;
         }
 
         const edm::Ref<SimClusterCollection> scRef(sCCH, simTracksters[tsId].seedIndex());
         const auto& scs = scIt->val;
-        const auto scPair = std::find_if(std::begin(scs), std::end(scs),
-                                         [&scRef](const std::pair<edm::Ref<SimClusterCollection>, float>& p) {
-                         return p.first == scRef;
-                       });
+        const auto scPair = std::find_if(
+            std::begin(scs), std::end(scs), [&scRef](const std::pair<edm::Ref<SimClusterCollection>, float>& p) {
+              return p.first == scRef;
+            });
         if (scPair == scs.end()) {
           LogDebug("LCToSimTSAssociatorByEnergyScoreImpl")
-            << "SimCluster Id " << simTracksters[tsId].seedIndex() << " not found in LayerCluster association map\n";
+              << "SimCluster Id " << simTracksters[tsId].seedIndex() << " not found in LayerCluster association map\n";
           continue;
-        }
-        else {
+        } else {
           LogDebug("LCToSimTSAssociatorByEnergyScoreImpl")
-            << "layerCluster Id: \t" << lcId << "\t SC Id: \t" << scPair->first.index() << "\t score \t" << scPair->second << "\n";
+              << "LayerCluster Id: \t" << lcId << "\t SimCluster Id: \t" << scPair->first.index() << "\t score \t"
+              << scPair->second << "\n";
           // Fill AssociationMap
-          returnValue.insert(lcRef,  // Ref to LC
-                             std::make_pair(edm::Ref<ticl::TracksterCollection>(sTCH, tsId), // Pair <Ref to TS, score>
+          returnValue.insert(lcRef,                                                           // Ref to LC
+                             std::make_pair(edm::Ref<ticl::TracksterCollection>(sTCH, tsId),  // Pair <Ref to TS, score>
                                             scPair->second));
         }
+      } else {
+        LogDebug("LCToSimTSAssociatorByEnergyScoreImpl")
+            << "The seedID " << simTracksters[tsId].seedID() << " of SimTrackster " << tsId
+            << " is neither a CaloParticle nor a SimCluster!\n";
       }
-      else {
-          LogDebug("LCToSimTSAssociatorByEnergyScoreImpl")
-            << "The seedID " << simTracksters[tsId].seedID() << " of SimTrackster " << tsId << " is neither a CaloParticle nor a SimCluster!\n";
-      }
-    } // end loop over simTracksters
-  } // end loop over layerClusters
+    }  // end loop over simTracksters
+  }    // end loop over layerClusters
 
   return returnValue;
 }
 
 hgcal::SimTracksterToRecoCollection LCToSimTSAssociatorByEnergyScoreImpl::associateSimToReco(
-    const edm::Handle<reco::CaloClusterCollection>& cCCH, const edm::Handle<ticl::TracksterCollection> &sTCH,
-    const edm::Handle<CaloParticleCollection>& cPCH, const hgcal::SimToRecoCollection &cPToLCs,
-    const edm::Handle<SimClusterCollection>& sCCH, const hgcal::SimToRecoCollectionWithSimClusters &sCToLCs) const {
+    const edm::Handle<reco::CaloClusterCollection>& cCCH,
+    const edm::Handle<ticl::TracksterCollection>& sTCH,
+    const edm::Handle<CaloParticleCollection>& cPCH,
+    const hgcal::SimToRecoCollection& cPToLCs,
+    const edm::Handle<SimClusterCollection>& sCCH,
+    const hgcal::SimToRecoCollectionWithSimClusters& sCToLCs) const {
   hgcal::SimTracksterToRecoCollection returnValue(productGetter_);
 
   const auto simTracksters = *sTCH.product();
   for (size_t tsId = 0; tsId < simTracksters.size(); ++tsId) {
-
     if (simTracksters[tsId].seedID() == cPCH.id()) {
       const auto cpId = simTracksters[tsId].seedIndex();
       const edm::Ref<CaloParticleCollection> cpRef(cPCH, cpId);
       const auto& lcIt = cPToLCs.find(cpRef);
       if (lcIt == cPToLCs.end()) {
         LogDebug("LCToSimTSAssociatorByEnergyScoreImpl")
-          << "CaloParticle Id " << cpId << " not found in LayerCluster association map\n";
+            << "CaloParticle Id " << cpId << " not found in LayerCluster association map\n";
         continue;
       }
 
       const auto& lcs = lcIt->val;
       for (size_t lcId = 0; lcId < lcs.size(); ++lcId) {
         const edm::Ref<reco::CaloClusterCollection> lcRef(cCCH, lcId);
-        const auto lcPair = std::find_if(std::begin(lcs), std::end(lcs),
-                                         [&lcRef](const std::pair<edm::Ref<reco::CaloClusterCollection>, std::pair<float, float>>& p) {
-                         return p.first == lcRef;
-                       });
+        const auto lcPair =
+            std::find_if(std::begin(lcs),
+                         std::end(lcs),
+                         [&lcRef](const std::pair<edm::Ref<reco::CaloClusterCollection>, std::pair<float, float>>& p) {
+                           return p.first == lcRef;
+                         });
         if (lcPair == lcs.end()) {
           LogDebug("LCToSimTSAssociatorByEnergyScoreImpl")
-            << "LayerCluster Id " << lcId << " not found in CaloParticle association map\n";
+              << "LayerCluster Id " << lcId << " not found in CaloParticle association map\n";
           continue;
-        }
-        else {
+        } else {
           LogDebug("LCToSimTSAssociatorByEnergyScoreImpl")
-            << "CaloParticle Id: \t" << cpId << "\t LayerCluster Id: \t" << lcPair->first.index() << "\t score \t" << lcPair->second.second << "\n";
+              << "CaloParticle Id: \t" << cpId << "\t LayerCluster Id: \t" << lcPair->first.index() << "\t score \t"
+              << lcPair->second.second << "\n";
           // Fill AssociationMap
-          returnValue.insert(edm::Ref<ticl::TracksterCollection>(sTCH, tsId),  // Ref to TS
-                             std::make_pair(lcRef, // Pair <Ref to LC,
-                                            std::make_pair(lcPair->second.first, lcPair->second.second)) // pair <energy, score> >
+          returnValue.insert(
+              edm::Ref<ticl::TracksterCollection>(sTCH, tsId),                             // Ref to TS
+              std::make_pair(lcRef,                                                        // Pair <Ref to LC,
+                             std::make_pair(lcPair->second.first, lcPair->second.second))  // pair <energy, score> >
           );
         }
       }
-    }
-    else if (simTracksters[tsId].seedID() == sCCH.id()) {
+    } else if (simTracksters[tsId].seedID() == sCCH.id()) {
       const auto scId = simTracksters[tsId].seedIndex();
       const edm::Ref<SimClusterCollection> scRef(sCCH, scId);
       const auto& lcIt = sCToLCs.find(scRef);
       if (lcIt == sCToLCs.end()) {
         LogDebug("LCToSimTSAssociatorByEnergyScoreImpl")
-          << "SimCluster Id " << scId << " not found in LayerCluster association map\n";
+            << "SimCluster Id " << scId << " not found in LayerCluster association map\n";
         continue;
       }
 
       const auto& lcs = lcIt->val;
       for (size_t lcId = 0; lcId < lcs.size(); ++lcId) {
         const edm::Ref<reco::CaloClusterCollection> lcRef(cCCH, lcId);
-        const auto lcPair = std::find_if(std::begin(lcs), std::end(lcs),
-                                         [&lcRef](const std::pair<edm::Ref<reco::CaloClusterCollection>, std::pair<float, float>>& p) {
-                         return p.first == lcRef;
-                       });
+        const auto lcPair =
+            std::find_if(std::begin(lcs),
+                         std::end(lcs),
+                         [&lcRef](const std::pair<edm::Ref<reco::CaloClusterCollection>, std::pair<float, float>>& p) {
+                           return p.first == lcRef;
+                         });
         if (lcPair == lcs.end()) {
           LogDebug("LCToSimTSAssociatorByEnergyScoreImpl")
-            << "LayerCluster Id " << lcId << " not found in SimCluster association map\n";
+              << "LayerCluster Id " << lcId << " not found in SimCluster association map\n";
           continue;
-        }
-        else {
+        } else {
           LogDebug("LCToSimTSAssociatorByEnergyScoreImpl")
-            << "SimCluster Id: \t" << scId << "\t LayerCluster Id: \t" << lcPair->first.index() << "\t score \t" << lcPair->second.second << "\n";
+              << "SimCluster Id: \t" << scId << "\t LayerCluster Id: \t" << lcPair->first.index() << "\t score \t"
+              << lcPair->second.second << "\n";
           // Fill AssociationMap
-          returnValue.insert(edm::Ref<ticl::TracksterCollection>(sTCH, tsId),  // Ref to TS
-                             std::make_pair(lcRef, // Pair <Ref to LC,
-                                            std::make_pair(lcPair->second.first, lcPair->second.second)) // pair <energy, score> >
-                            );
+          returnValue.insert(
+              edm::Ref<ticl::TracksterCollection>(sTCH, tsId),                             // Ref to TS
+              std::make_pair(lcRef,                                                        // Pair <Ref to LC,
+                             std::make_pair(lcPair->second.first, lcPair->second.second))  // pair <energy, score> >
+          );
         }
       }
-    }
-    else {
-        LogDebug("LCToSimTSAssociatorByEnergyScoreImpl")
-          << "The seedID " << simTracksters[tsId].seedID() << " of SimTrackster " << tsId << " is neither a CaloParticle nor a SimCluster!\n";
+    } else {
+      LogDebug("LCToSimTSAssociatorByEnergyScoreImpl")
+          << "The seedID " << simTracksters[tsId].seedID() << " of SimTrackster " << tsId
+          << " is neither a CaloParticle nor a SimCluster!\n";
     }
 
-  } // end loop over simTracksters
+  }  // end loop over simTracksters
   return returnValue;
 }

--- a/SimCalorimetry/HGCalAssociatorProducers/plugins/LCToSimTSAssociatorByEnergyScoreImpl.h
+++ b/SimCalorimetry/HGCalAssociatorProducers/plugins/LCToSimTSAssociatorByEnergyScoreImpl.h
@@ -1,0 +1,32 @@
+// Original Author: Marco Rovere
+
+#include <vector>
+#include <map>
+#include <unordered_map>
+#include <memory>  // shared_ptr
+
+#include "SimDataFormats/Associations/interface/LayerClusterToSimTracksterAssociator.h"
+#include "RecoLocalCalo/HGCalRecAlgos/interface/RecHitTools.h"
+
+namespace edm {
+  class EDProductGetter;
+}
+
+class LCToSimTSAssociatorByEnergyScoreImpl : public hgcal::LayerClusterToSimTracksterAssociatorBaseImpl {
+public:
+  explicit LCToSimTSAssociatorByEnergyScoreImpl(edm::EDProductGetter const &,
+                                             bool,
+                                             std::shared_ptr<hgcal::RecHitTools>);
+
+  hgcal::RecoToSimCollection associateRecoToSim(const edm::Handle<reco::CaloClusterCollection> &cCH,
+                                                const edm::Handle<ticl::TracksterCollection> &sTCH) const override;
+
+  hgcal::SimToRecoCollection associateSimToReco(const edm::Handle<reco::CaloClusterCollection> &cCH,
+                                                const edm::Handle<CaloParticleCollection> &cPCH) const override;
+
+private:
+  const bool hardScatterOnly_;
+  std::shared_ptr<hgcal::RecHitTools> recHitTools_;
+  unsigned layers_;
+  edm::EDProductGetter const *productGetter_;
+};

--- a/SimCalorimetry/HGCalAssociatorProducers/plugins/LCToSimTSAssociatorByEnergyScoreImpl.h
+++ b/SimCalorimetry/HGCalAssociatorProducers/plugins/LCToSimTSAssociatorByEnergyScoreImpl.h
@@ -1,4 +1,6 @@
 // Original Author: Leonardo Cristella
+#ifndef SimCalorimetry_HGCalAssociatorProducers_LCToSimTSAssociatorByEnergyScoreImpl_h
+#define SimCalorimetry_HGCalAssociatorProducers_LCToSimTSAssociatorByEnergyScoreImpl_h
 
 #include <vector>
 #include <map>
@@ -19,24 +21,26 @@ namespace edm {
 
 class LCToSimTSAssociatorByEnergyScoreImpl : public hgcal::LayerClusterToSimTracksterAssociatorBaseImpl {
 public:
-  explicit LCToSimTSAssociatorByEnergyScoreImpl(edm::EDProductGetter const &,
-                                             bool);
+  explicit LCToSimTSAssociatorByEnergyScoreImpl(edm::EDProductGetter const &);
 
-  hgcal::RecoToSimTracksterCollection associateRecoToSim(const edm::Handle<reco::CaloClusterCollection> &cCH,
-                                                const edm::Handle<ticl::TracksterCollection> &sTCH,
-                                                const edm::Handle<CaloParticleCollection>& cPCH,
-                                                const hgcal::RecoToSimCollection &lCToCPs,
-                                                const edm::Handle<SimClusterCollection>& sCCH,
-                                                const hgcal::RecoToSimCollectionWithSimClusters &lCToSCs) const override;
+  hgcal::RecoToSimTracksterCollection associateRecoToSim(
+      const edm::Handle<reco::CaloClusterCollection> &cCH,
+      const edm::Handle<ticl::TracksterCollection> &sTCH,
+      const edm::Handle<CaloParticleCollection> &cPCH,
+      const hgcal::RecoToSimCollection &lCToCPs,
+      const edm::Handle<SimClusterCollection> &sCCH,
+      const hgcal::RecoToSimCollectionWithSimClusters &lCToSCs) const override;
 
-  hgcal::SimTracksterToRecoCollection associateSimToReco(const edm::Handle<reco::CaloClusterCollection> &cCH,
-                                                const edm::Handle<ticl::TracksterCollection> &sTCH,
-                                                const edm::Handle<CaloParticleCollection>& cPCH,
-                                                const hgcal::SimToRecoCollection &cPToLCs,
-                                                const edm::Handle<SimClusterCollection>& sCCH,
-                                                const hgcal::SimToRecoCollectionWithSimClusters &sCToLCs) const override;
+  hgcal::SimTracksterToRecoCollection associateSimToReco(
+      const edm::Handle<reco::CaloClusterCollection> &cCH,
+      const edm::Handle<ticl::TracksterCollection> &sTCH,
+      const edm::Handle<CaloParticleCollection> &cPCH,
+      const hgcal::SimToRecoCollection &cPToLCs,
+      const edm::Handle<SimClusterCollection> &sCCH,
+      const hgcal::SimToRecoCollectionWithSimClusters &sCToLCs) const override;
 
 private:
-  const bool hardScatterOnly_;
   edm::EDProductGetter const *productGetter_;
 };
+
+#endif

--- a/SimCalorimetry/HGCalAssociatorProducers/plugins/LCToSimTSAssociatorByEnergyScoreImpl.h
+++ b/SimCalorimetry/HGCalAssociatorProducers/plugins/LCToSimTSAssociatorByEnergyScoreImpl.h
@@ -8,6 +8,11 @@
 #include "SimDataFormats/Associations/interface/LayerClusterToSimTracksterAssociator.h"
 #include "RecoLocalCalo/HGCalRecAlgos/interface/RecHitTools.h"
 
+#include "SimDataFormats/CaloAnalysis/interface/CaloParticleFwd.h"
+#include "SimDataFormats/Associations/interface/LayerClusterToCaloParticleAssociator.h"
+#include "SimDataFormats/CaloAnalysis/interface/SimClusterFwd.h"
+#include "SimDataFormats/Associations/interface/LayerClusterToSimClusterAssociator.h"
+
 namespace edm {
   class EDProductGetter;
 }
@@ -15,18 +20,19 @@ namespace edm {
 class LCToSimTSAssociatorByEnergyScoreImpl : public hgcal::LayerClusterToSimTracksterAssociatorBaseImpl {
 public:
   explicit LCToSimTSAssociatorByEnergyScoreImpl(edm::EDProductGetter const &,
-                                             bool,
-                                             std::shared_ptr<hgcal::RecHitTools>);
+                                             bool);
 
-  hgcal::RecoToSimCollection associateRecoToSim(const edm::Handle<reco::CaloClusterCollection> &cCH,
+  hgcal::RecoToSimTracksterCollection associateRecoToSim(const edm::Handle<reco::CaloClusterCollection> &cCH,
+                                                const edm::Handle<ticl::TracksterCollection> &sTCH,
+                                                const edm::Handle<CaloParticleCollection>& cPCH,
+                                                const hgcal::RecoToSimCollection &lCToCPs,
+                                                const edm::Handle<SimClusterCollection>& sCCH,
+                                                const hgcal::RecoToSimCollectionWithSimClusters &lCToSCs) const override;
+
+  hgcal::SimTracksterToRecoCollection associateSimToReco(const edm::Handle<reco::CaloClusterCollection> &cCH,
                                                 const edm::Handle<ticl::TracksterCollection> &sTCH) const override;
-
-  hgcal::SimToRecoCollection associateSimToReco(const edm::Handle<reco::CaloClusterCollection> &cCH,
-                                                const edm::Handle<CaloParticleCollection> &cPCH) const override;
 
 private:
   const bool hardScatterOnly_;
-  std::shared_ptr<hgcal::RecHitTools> recHitTools_;
-  unsigned layers_;
   edm::EDProductGetter const *productGetter_;
 };

--- a/SimCalorimetry/HGCalAssociatorProducers/plugins/LCToSimTSAssociatorByEnergyScoreImpl.h
+++ b/SimCalorimetry/HGCalAssociatorProducers/plugins/LCToSimTSAssociatorByEnergyScoreImpl.h
@@ -1,4 +1,4 @@
-// Original Author: Marco Rovere
+// Original Author: Leonardo Cristella
 
 #include <vector>
 #include <map>
@@ -30,7 +30,11 @@ public:
                                                 const hgcal::RecoToSimCollectionWithSimClusters &lCToSCs) const override;
 
   hgcal::SimTracksterToRecoCollection associateSimToReco(const edm::Handle<reco::CaloClusterCollection> &cCH,
-                                                const edm::Handle<ticl::TracksterCollection> &sTCH) const override;
+                                                const edm::Handle<ticl::TracksterCollection> &sTCH,
+                                                const edm::Handle<CaloParticleCollection>& cPCH,
+                                                const hgcal::SimToRecoCollection &cPToLCs,
+                                                const edm::Handle<SimClusterCollection>& sCCH,
+                                                const hgcal::SimToRecoCollectionWithSimClusters &sCToLCs) const override;
 
 private:
   const bool hardScatterOnly_;

--- a/SimCalorimetry/HGCalAssociatorProducers/plugins/LCToSimTSAssociatorByEnergyScoreProducer.cc
+++ b/SimCalorimetry/HGCalAssociatorProducers/plugins/LCToSimTSAssociatorByEnergyScoreProducer.cc
@@ -1,0 +1,62 @@
+// Original author: Marco Rovere
+
+// user include files
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/EDGetToken.h"
+#include "FWCore/Utilities/interface/ESGetToken.h"
+
+#include "SimDataFormats/Associations/interface/LayerClusterToSimTracksterAssociator.h"
+#include "LCToSimTSAssociatorByEnergyScoreImpl.h"
+
+class LCToSimTSAssociatorByEnergyScoreProducer : public edm::global::EDProducer<> {
+public:
+  explicit LCToSimTSAssociatorByEnergyScoreProducer(const edm::ParameterSet &);
+  ~LCToSimTSAssociatorByEnergyScoreProducer() override;
+
+  static void fillDescriptions(edm::ConfigurationDescriptions &descriptions);
+
+private:
+  void produce(edm::StreamID, edm::Event &, const edm::EventSetup &) const override;
+  edm::ESGetToken<CaloGeometry, CaloGeometryRecord> caloGeometry_;
+  const bool hardScatterOnly_;
+  std::shared_ptr<hgcal::RecHitTools> rhtools_;
+};
+
+LCToSimTSAssociatorByEnergyScoreProducer::LCToSimTSAssociatorByEnergyScoreProducer(const edm::ParameterSet &ps)
+    : caloGeometry_(esConsumes<CaloGeometry, CaloGeometryRecord>()),
+      hardScatterOnly_(ps.getParameter<bool>("hardScatterOnly")) {
+  rhtools_.reset(new hgcal::RecHitTools());
+
+  // Register the product
+  produces<hgcal::LayerClusterToSimTracksterAssociator>();
+}
+
+LCToSimTSAssociatorByEnergyScoreProducer::~LCToSimTSAssociatorByEnergyScoreProducer() {}
+
+void LCToSimTSAssociatorByEnergyScoreProducer::produce(edm::StreamID,
+                                                    edm::Event &iEvent,
+                                                    const edm::EventSetup &es) const {
+  edm::ESHandle<CaloGeometry> geom = es.getHandle(caloGeometry_);
+  rhtools_->setGeometry(*geom);
+
+  auto impl =
+      std::make_unique<LCToSimTSAssociatorByEnergyScoreImpl>(iEvent.productGetter(), hardScatterOnly_);
+  auto toPut = std::make_unique<hgcal::LayerClusterToSimTracksterAssociator>(std::move(impl));
+  iEvent.put(std::move(toPut));
+}
+
+void LCToSimTSAssociatorByEnergyScoreProducer::fillDescriptions(edm::ConfigurationDescriptions &cfg) {
+  edm::ParameterSetDescription desc;
+  desc.add<bool>("hardScatterOnly", true);
+
+  cfg.add("layerClusterSimTracksterAssociatorByEnergyScore", desc);
+}
+
+//define this as a plug-in
+DEFINE_FWK_MODULE(LCToSimTSAssociatorByEnergyScoreProducer);

--- a/SimCalorimetry/HGCalAssociatorProducers/plugins/LCToSimTSAssociatorByEnergyScoreProducer.cc
+++ b/SimCalorimetry/HGCalAssociatorProducers/plugins/LCToSimTSAssociatorByEnergyScoreProducer.cc
@@ -24,13 +24,11 @@ public:
 private:
   void produce(edm::StreamID, edm::Event &, const edm::EventSetup &) const override;
   edm::ESGetToken<CaloGeometry, CaloGeometryRecord> caloGeometry_;
-  const bool hardScatterOnly_;
   std::shared_ptr<hgcal::RecHitTools> rhtools_;
 };
 
 LCToSimTSAssociatorByEnergyScoreProducer::LCToSimTSAssociatorByEnergyScoreProducer(const edm::ParameterSet &ps)
-    : caloGeometry_(esConsumes<CaloGeometry, CaloGeometryRecord>()),
-      hardScatterOnly_(ps.getParameter<bool>("hardScatterOnly")) {
+    : caloGeometry_(esConsumes<CaloGeometry, CaloGeometryRecord>()) {
   rhtools_.reset(new hgcal::RecHitTools());
 
   // Register the product
@@ -40,21 +38,18 @@ LCToSimTSAssociatorByEnergyScoreProducer::LCToSimTSAssociatorByEnergyScoreProduc
 LCToSimTSAssociatorByEnergyScoreProducer::~LCToSimTSAssociatorByEnergyScoreProducer() {}
 
 void LCToSimTSAssociatorByEnergyScoreProducer::produce(edm::StreamID,
-                                                    edm::Event &iEvent,
-                                                    const edm::EventSetup &es) const {
+                                                       edm::Event &iEvent,
+                                                       const edm::EventSetup &es) const {
   edm::ESHandle<CaloGeometry> geom = es.getHandle(caloGeometry_);
   rhtools_->setGeometry(*geom);
 
-  auto impl =
-      std::make_unique<LCToSimTSAssociatorByEnergyScoreImpl>(iEvent.productGetter(), hardScatterOnly_);
+  auto impl = std::make_unique<LCToSimTSAssociatorByEnergyScoreImpl>(iEvent.productGetter());
   auto toPut = std::make_unique<hgcal::LayerClusterToSimTracksterAssociator>(std::move(impl));
   iEvent.put(std::move(toPut));
 }
 
 void LCToSimTSAssociatorByEnergyScoreProducer::fillDescriptions(edm::ConfigurationDescriptions &cfg) {
   edm::ParameterSetDescription desc;
-  desc.add<bool>("hardScatterOnly", true);
-
   cfg.add("layerClusterSimTracksterAssociatorByEnergyScore", desc);
 }
 

--- a/SimCalorimetry/HGCalAssociatorProducers/plugins/LCToSimTSAssociatorByEnergyScoreProducer.cc
+++ b/SimCalorimetry/HGCalAssociatorProducers/plugins/LCToSimTSAssociatorByEnergyScoreProducer.cc
@@ -1,4 +1,4 @@
-// Original author: Marco Rovere
+// Original author: Leonardo Cristella
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"

--- a/SimCalorimetry/HGCalAssociatorProducers/plugins/LCToSimTSAssociatorEDProducer.cc
+++ b/SimCalorimetry/HGCalAssociatorProducers/plugins/LCToSimTSAssociatorEDProducer.cc
@@ -53,19 +53,19 @@ private:
   edm::EDGetTokenT<hgcal::SimToRecoCollectionWithSimClusters> associationMapSCToLCToken_;
 };
 
-LCToSimTSAssociatorEDProducer::LCToSimTSAssociatorEDProducer(const edm::ParameterSet &pset) :
-  LCCollectionToken_(consumes<reco::CaloClusterCollection>(pset.getParameter<edm::InputTag>("label_lc"))),
-  SimTSCollectionToken_(consumes<ticl::TracksterCollection>(pset.getParameter<edm::InputTag>("label_simTst"))),
-  associatorToken_(consumes<hgcal::LayerClusterToSimTracksterAssociator>(pset.getParameter<edm::InputTag>("associator"))),
-  CPCollectionToken_(consumes<CaloParticleCollection>(pset.getParameter<edm::InputTag>("label_cp"))),
-  associatorCP_(pset.getParameter<edm::InputTag>("associator_cp")),
-  associationMapLCToCPToken_(consumes<hgcal::RecoToSimCollection>(associatorCP_)),
-  associationMapCPToLCToken_(consumes<hgcal::SimToRecoCollection>(associatorCP_)),
-  SCCollectionToken_(consumes<SimClusterCollection>(pset.getParameter<edm::InputTag>("label_scl"))),
-  associatorSC_(pset.getParameter<edm::InputTag>("associator_sc")),
-  associationMapLCToSCToken_(consumes<hgcal::RecoToSimCollectionWithSimClusters>(associatorSC_)),
-  associationMapSCToLCToken_(consumes<hgcal::SimToRecoCollectionWithSimClusters>(associatorSC_))
-{
+LCToSimTSAssociatorEDProducer::LCToSimTSAssociatorEDProducer(const edm::ParameterSet &pset)
+    : LCCollectionToken_(consumes<reco::CaloClusterCollection>(pset.getParameter<edm::InputTag>("label_lc"))),
+      SimTSCollectionToken_(consumes<ticl::TracksterCollection>(pset.getParameter<edm::InputTag>("label_simTst"))),
+      associatorToken_(
+          consumes<hgcal::LayerClusterToSimTracksterAssociator>(pset.getParameter<edm::InputTag>("associator"))),
+      CPCollectionToken_(consumes<CaloParticleCollection>(pset.getParameter<edm::InputTag>("label_cp"))),
+      associatorCP_(pset.getParameter<edm::InputTag>("associator_cp")),
+      associationMapLCToCPToken_(consumes<hgcal::RecoToSimCollection>(associatorCP_)),
+      associationMapCPToLCToken_(consumes<hgcal::SimToRecoCollection>(associatorCP_)),
+      SCCollectionToken_(consumes<SimClusterCollection>(pset.getParameter<edm::InputTag>("label_scl"))),
+      associatorSC_(pset.getParameter<edm::InputTag>("associator_sc")),
+      associationMapLCToSCToken_(consumes<hgcal::RecoToSimCollectionWithSimClusters>(associatorSC_)),
+      associationMapSCToLCToken_(consumes<hgcal::SimToRecoCollectionWithSimClusters>(associatorSC_)) {
   produces<hgcal::SimTracksterToRecoCollection>();
   produces<hgcal::RecoToSimTracksterCollection>();
 }
@@ -91,20 +91,22 @@ void LCToSimTSAssociatorEDProducer::produce(edm::StreamID, edm::Event &iEvent, c
 
   Handle<CaloParticleCollection> CPCollection;
   iEvent.getByToken(CPCollectionToken_, CPCollection);
-  const auto& LCToCPsColl = iEvent.get(associationMapLCToCPToken_);
-  const auto& CPToLCsColl = iEvent.get(associationMapCPToLCToken_);
+  const auto &LCToCPsColl = iEvent.get(associationMapLCToCPToken_);
+  const auto &CPToLCsColl = iEvent.get(associationMapCPToLCToken_);
 
   Handle<SimClusterCollection> SCCollection;
   iEvent.getByToken(SCCollectionToken_, SCCollection);
-  const auto& LCToSCsColl = iEvent.get(associationMapLCToSCToken_);
-  const auto& SCToLCsColl = iEvent.get(associationMapSCToLCToken_);
+  const auto &LCToSCsColl = iEvent.get(associationMapLCToSCToken_);
+  const auto &SCToLCsColl = iEvent.get(associationMapSCToLCToken_);
 
   // associate LC and SimTS
   LogTrace("AssociatorValidator") << "Calling associateRecoToSim method\n";
-  hgcal::RecoToSimTracksterCollection recSimColl = theAssociator->associateRecoToSim(LCCollection, SimTSCollection, CPCollection, LCToCPsColl, SCCollection, LCToSCsColl);
+  hgcal::RecoToSimTracksterCollection recSimColl = theAssociator->associateRecoToSim(
+      LCCollection, SimTSCollection, CPCollection, LCToCPsColl, SCCollection, LCToSCsColl);
 
   LogTrace("AssociatorValidator") << "Calling associateSimToReco method\n";
-  hgcal::SimTracksterToRecoCollection simRecColl = theAssociator->associateSimToReco(LCCollection, SimTSCollection, CPCollection, CPToLCsColl, SCCollection, SCToLCsColl);
+  hgcal::SimTracksterToRecoCollection simRecColl = theAssociator->associateSimToReco(
+      LCCollection, SimTSCollection, CPCollection, CPToLCsColl, SCCollection, SCToLCsColl);
 
   auto rts = std::make_unique<hgcal::RecoToSimTracksterCollection>(recSimColl);
   auto str = std::make_unique<hgcal::SimTracksterToRecoCollection>(simRecColl);

--- a/SimCalorimetry/HGCalAssociatorProducers/plugins/LCToSimTSAssociatorEDProducer.cc
+++ b/SimCalorimetry/HGCalAssociatorProducers/plugins/LCToSimTSAssociatorEDProducer.cc
@@ -44,11 +44,13 @@ private:
 
   edm::EDGetTokenT<CaloParticleCollection> CPCollectionToken_;
   edm::InputTag associatorCP_;
-  edm::EDGetTokenT<hgcal::RecoToSimCollection> associationMapCPToken_;
+  edm::EDGetTokenT<hgcal::RecoToSimCollection> associationMapLCToCPToken_;
+  edm::EDGetTokenT<hgcal::SimToRecoCollection> associationMapCPToLCToken_;
 
   edm::EDGetTokenT<SimClusterCollection> SCCollectionToken_;
   edm::InputTag associatorSC_;
-  edm::EDGetTokenT<hgcal::RecoToSimCollectionWithSimClusters> associationMapSCToken_;
+  edm::EDGetTokenT<hgcal::RecoToSimCollectionWithSimClusters> associationMapLCToSCToken_;
+  edm::EDGetTokenT<hgcal::SimToRecoCollectionWithSimClusters> associationMapSCToLCToken_;
 };
 
 LCToSimTSAssociatorEDProducer::LCToSimTSAssociatorEDProducer(const edm::ParameterSet &pset) :
@@ -57,10 +59,12 @@ LCToSimTSAssociatorEDProducer::LCToSimTSAssociatorEDProducer(const edm::Paramete
   associatorToken_(consumes<hgcal::LayerClusterToSimTracksterAssociator>(pset.getParameter<edm::InputTag>("associator"))),
   CPCollectionToken_(consumes<CaloParticleCollection>(pset.getParameter<edm::InputTag>("label_cp"))),
   associatorCP_(pset.getParameter<edm::InputTag>("associator_cp")),
-  associationMapCPToken_(consumes<hgcal::RecoToSimCollection>(associatorCP_)),
+  associationMapLCToCPToken_(consumes<hgcal::RecoToSimCollection>(associatorCP_)),
+  associationMapCPToLCToken_(consumes<hgcal::SimToRecoCollection>(associatorCP_)),
   SCCollectionToken_(consumes<SimClusterCollection>(pset.getParameter<edm::InputTag>("label_scl"))),
   associatorSC_(pset.getParameter<edm::InputTag>("associator_sc")),
-  associationMapSCToken_(consumes<hgcal::RecoToSimCollectionWithSimClusters>(associatorSC_))
+  associationMapLCToSCToken_(consumes<hgcal::RecoToSimCollectionWithSimClusters>(associatorSC_)),
+  associationMapSCToLCToken_(consumes<hgcal::SimToRecoCollectionWithSimClusters>(associatorSC_))
 {
   produces<hgcal::SimTracksterToRecoCollection>();
   produces<hgcal::RecoToSimTracksterCollection>();
@@ -87,18 +91,20 @@ void LCToSimTSAssociatorEDProducer::produce(edm::StreamID, edm::Event &iEvent, c
 
   Handle<CaloParticleCollection> CPCollection;
   iEvent.getByToken(CPCollectionToken_, CPCollection);
-  const auto& LCToCPsColl = iEvent.get(associationMapCPToken_);
+  const auto& LCToCPsColl = iEvent.get(associationMapLCToCPToken_);
+  const auto& CPToLCsColl = iEvent.get(associationMapCPToLCToken_);
 
   Handle<SimClusterCollection> SCCollection;
   iEvent.getByToken(SCCollectionToken_, SCCollection);
-  const auto& LCToSCsColl = iEvent.get(associationMapSCToken_);
+  const auto& LCToSCsColl = iEvent.get(associationMapLCToSCToken_);
+  const auto& SCToLCsColl = iEvent.get(associationMapSCToLCToken_);
 
   // associate LC and SimTS
   LogTrace("AssociatorValidator") << "Calling associateRecoToSim method\n";
   hgcal::RecoToSimTracksterCollection recSimColl = theAssociator->associateRecoToSim(LCCollection, SimTSCollection, CPCollection, LCToCPsColl, SCCollection, LCToSCsColl);
 
   LogTrace("AssociatorValidator") << "Calling associateSimToReco method\n";
-  hgcal::SimTracksterToRecoCollection simRecColl = theAssociator->associateSimToReco(LCCollection, SimTSCollection);
+  hgcal::SimTracksterToRecoCollection simRecColl = theAssociator->associateSimToReco(LCCollection, SimTSCollection, CPCollection, CPToLCsColl, SCCollection, SCToLCsColl);
 
   auto rts = std::make_unique<hgcal::RecoToSimTracksterCollection>(recSimColl);
   auto str = std::make_unique<hgcal::SimTracksterToRecoCollection>(simRecColl);

--- a/SimCalorimetry/HGCalAssociatorProducers/plugins/LCToSimTSAssociatorEDProducer.cc
+++ b/SimCalorimetry/HGCalAssociatorProducers/plugins/LCToSimTSAssociatorEDProducer.cc
@@ -56,10 +56,10 @@ LCToSimTSAssociatorEDProducer::LCToSimTSAssociatorEDProducer(const edm::Paramete
   SimTSCollectionToken_(consumes<ticl::TracksterCollection>(pset.getParameter<edm::InputTag>("label_simTst"))),
   associatorToken_(consumes<hgcal::LayerClusterToSimTracksterAssociator>(pset.getParameter<edm::InputTag>("associator"))),
   CPCollectionToken_(consumes<CaloParticleCollection>(pset.getParameter<edm::InputTag>("label_cp"))),
-  associatorCP_(pset.getUntrackedParameter<edm::InputTag>("layerClusterCaloParticleAssociator")),
+  associatorCP_(pset.getParameter<edm::InputTag>("associator_cp")),
   associationMapCPToken_(consumes<hgcal::RecoToSimCollection>(associatorCP_)),
   SCCollectionToken_(consumes<SimClusterCollection>(pset.getParameter<edm::InputTag>("label_scl"))),
-  associatorSC_(pset.getUntrackedParameter<edm::InputTag>("layerClusterSimClusterAssociator")),
+  associatorSC_(pset.getParameter<edm::InputTag>("associator_sc")),
   associationMapSCToken_(consumes<hgcal::RecoToSimCollectionWithSimClusters>(associatorSC_))
 {
   produces<hgcal::SimTracksterToRecoCollection>();

--- a/SimCalorimetry/HGCalAssociatorProducers/plugins/LCToSimTSAssociatorEDProducer.cc
+++ b/SimCalorimetry/HGCalAssociatorProducers/plugins/LCToSimTSAssociatorEDProducer.cc
@@ -1,0 +1,111 @@
+//
+// Original Author:  Leonardo Cristella
+//         Created:  Thu Dec  3 10:52:11 CET 2020
+//
+//
+
+// system include files
+#include <memory>
+#include <string>
+
+// user include files
+#include "FWCore/Framework/interface/global/EDProducer.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "FWCore/Framework/interface/ESHandle.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "SimDataFormats/Associations/interface/LayerClusterToSimTracksterAssociator.h"
+
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "SimDataFormats/CaloAnalysis/interface/CaloParticleFwd.h"
+#include "DataFormats/CaloRecHit/interface/CaloClusterFwd.h"
+
+#include "FWCore/Utilities/interface/EDGetToken.h"
+
+//
+// class decleration
+//
+
+class LCToSimTSAssociatorEDProducer : public edm::global::EDProducer<> {
+public:
+  explicit LCToSimTSAssociatorEDProducer(const edm::ParameterSet &);
+  ~LCToSimTSAssociatorEDProducer() override;
+
+private:
+  void produce(edm::StreamID, edm::Event &, const edm::EventSetup &) const override;
+
+  edm::EDGetTokenT<reco::CaloClusterCollection> LCCollectionToken_;
+  edm::EDGetTokenT<ticl::TracksterCollection> SimTSCollectionToken_;
+  edm::EDGetTokenT<hgcal::LayerClusterToSimTracksterAssociator> associatorToken_;
+
+  edm::EDGetTokenT<CaloParticleCollection> CPCollectionToken_;
+  edm::InputTag associatorCP_;
+  edm::EDGetTokenT<hgcal::RecoToSimCollection> associationMapCPToken_;
+
+  edm::EDGetTokenT<SimClusterCollection> SCCollectionToken_;
+  edm::InputTag associatorSC_;
+  edm::EDGetTokenT<hgcal::RecoToSimCollectionWithSimClusters> associationMapSCToken_;
+};
+
+LCToSimTSAssociatorEDProducer::LCToSimTSAssociatorEDProducer(const edm::ParameterSet &pset) :
+  LCCollectionToken_(consumes<reco::CaloClusterCollection>(pset.getParameter<edm::InputTag>("label_lc"))),
+  SimTSCollectionToken_(consumes<ticl::TracksterCollection>(pset.getParameter<edm::InputTag>("label_simTst"))),
+  associatorToken_(consumes<hgcal::LayerClusterToSimTracksterAssociator>(pset.getParameter<edm::InputTag>("associator"))),
+  CPCollectionToken_(consumes<CaloParticleCollection>(pset.getParameter<edm::InputTag>("label_cp"))),
+  associatorCP_(pset.getUntrackedParameter<edm::InputTag>("layerClusterCaloParticleAssociator")),
+  associationMapCPToken_(consumes<hgcal::RecoToSimCollection>(associatorCP_)),
+  SCCollectionToken_(consumes<SimClusterCollection>(pset.getParameter<edm::InputTag>("label_scl"))),
+  associatorSC_(pset.getUntrackedParameter<edm::InputTag>("layerClusterSimClusterAssociator")),
+  associationMapSCToken_(consumes<hgcal::RecoToSimCollectionWithSimClusters>(associatorSC_))
+{
+  produces<hgcal::SimTracksterToRecoCollection>();
+  produces<hgcal::RecoToSimTracksterCollection>();
+}
+
+LCToSimTSAssociatorEDProducer::~LCToSimTSAssociatorEDProducer() {}
+
+//
+// member functions
+//
+
+// ------------ method called to produce the data  ------------
+void LCToSimTSAssociatorEDProducer::produce(edm::StreamID, edm::Event &iEvent, const edm::EventSetup &iSetup) const {
+  using namespace edm;
+
+  edm::Handle<hgcal::LayerClusterToSimTracksterAssociator> theAssociator;
+  iEvent.getByToken(associatorToken_, theAssociator);
+
+  Handle<reco::CaloClusterCollection> LCCollection;
+  iEvent.getByToken(LCCollectionToken_, LCCollection);
+
+  Handle<ticl::TracksterCollection> SimTSCollection;
+  iEvent.getByToken(SimTSCollectionToken_, SimTSCollection);
+
+  Handle<CaloParticleCollection> CPCollection;
+  iEvent.getByToken(CPCollectionToken_, CPCollection);
+  const auto& LCToCPsColl = iEvent.get(associationMapCPToken_);
+
+  Handle<SimClusterCollection> SCCollection;
+  iEvent.getByToken(SCCollectionToken_, SCCollection);
+  const auto& LCToSCsColl = iEvent.get(associationMapSCToken_);
+
+  // associate LC and SimTS
+  LogTrace("AssociatorValidator") << "Calling associateRecoToSim method\n";
+  hgcal::RecoToSimTracksterCollection recSimColl = theAssociator->associateRecoToSim(LCCollection, SimTSCollection, CPCollection, LCToCPsColl, SCCollection, LCToSCsColl);
+
+  LogTrace("AssociatorValidator") << "Calling associateSimToReco method\n";
+  hgcal::SimTracksterToRecoCollection simRecColl = theAssociator->associateSimToReco(LCCollection, SimTSCollection);
+
+  auto rts = std::make_unique<hgcal::RecoToSimTracksterCollection>(recSimColl);
+  auto str = std::make_unique<hgcal::SimTracksterToRecoCollection>(simRecColl);
+
+  iEvent.put(std::move(rts));
+  iEvent.put(std::move(str));
+}
+
+// define this as a plug-in
+DEFINE_FWK_MODULE(LCToSimTSAssociatorEDProducer);

--- a/SimCalorimetry/HGCalAssociatorProducers/python/LCToSimTSAssociation_cfi.py
+++ b/SimCalorimetry/HGCalAssociatorProducers/python/LCToSimTSAssociation_cfi.py
@@ -1,0 +1,21 @@
+import FWCore.ParameterSet.Config as cms
+
+layerClusterSimTracksterAssociation = cms.EDProducer("LCToSimTSAssociatorEDProducer",
+    label_lc = cms.InputTag("hgcalLayerClusters"),
+    label_simTst = cms.InputTag("ticlSimTracksters"),
+    associator = cms.InputTag('lcSimTSAssocByEnergyScoreProducer'),
+    label_cp = cms.InputTag("mix","MergedCaloTruth"),
+    associator_cp = cms.InputTag('layerClusterCaloParticleAssociationProducer'),
+    label_scl = cms.InputTag("mix","MergedCaloTruth"),
+    associator_sc = cms.InputTag('layerClusterSimClusterAssociationProducer'),
+)
+
+from Configuration.ProcessModifiers.premix_stage2_cff import premix_stage2
+premix_stage2.toModify(layerClusterSimTracksterAssociation,
+    label_cp = "mixData:MergedCaloTruth",
+    label_scl = "mixData:MergedCaloTruth"
+)
+
+layerClusterSimTracksterAssociationHFNose = layerClusterSimTracksterAssociation.clone(
+    label_lc = "hgcalLayerClustersHFNose"
+)

--- a/SimDataFormats/Associations/interface/LayerClusterToSimTracksterAssociator.h
+++ b/SimDataFormats/Associations/interface/LayerClusterToSimTracksterAssociator.h
@@ -23,22 +23,24 @@ namespace hgcal {
 
     // ---------- const member functions ---------------------
     /// Associate a LayerCluster to SimTracksters
-    hgcal::RecoToSimTracksterCollection associateRecoToSim(const edm::Handle<reco::CaloClusterCollection> &cCCH,
-                                                  const edm::Handle<ticl::TracksterCollection> &stCH,
-                                                  const edm::Handle<CaloParticleCollection>& cPCH,
-                                                  const hgcal::RecoToSimCollection &lCToCPs,
-                                                  const edm::Handle<SimClusterCollection>& sCCH,
-                                                  const hgcal::RecoToSimCollectionWithSimClusters &lCToSCs) const {
+    hgcal::RecoToSimTracksterCollection associateRecoToSim(
+        const edm::Handle<reco::CaloClusterCollection> &cCCH,
+        const edm::Handle<ticl::TracksterCollection> &stCH,
+        const edm::Handle<CaloParticleCollection> &cPCH,
+        const hgcal::RecoToSimCollection &lCToCPs,
+        const edm::Handle<SimClusterCollection> &sCCH,
+        const hgcal::RecoToSimCollectionWithSimClusters &lCToSCs) const {
       return m_impl->associateRecoToSim(cCCH, stCH, cPCH, lCToCPs, sCCH, lCToSCs);
     };
 
     /// Associate a SimTrackster to LayerClusters
-    hgcal::SimTracksterToRecoCollection associateSimToReco(const edm::Handle<reco::CaloClusterCollection> &cCCH,
-                                                  const edm::Handle<ticl::TracksterCollection> &sTCH,
-                                                  const edm::Handle<CaloParticleCollection>& cPCH,
-                                                  const hgcal::SimToRecoCollection &cpToLCs,
-                                                  const edm::Handle<SimClusterCollection>& sCCH,
-                                                  const hgcal::SimToRecoCollectionWithSimClusters &sCToLCs) const {
+    hgcal::SimTracksterToRecoCollection associateSimToReco(
+        const edm::Handle<reco::CaloClusterCollection> &cCCH,
+        const edm::Handle<ticl::TracksterCollection> &sTCH,
+        const edm::Handle<CaloParticleCollection> &cPCH,
+        const hgcal::SimToRecoCollection &cpToLCs,
+        const edm::Handle<SimClusterCollection> &sCCH,
+        const hgcal::SimToRecoCollectionWithSimClusters &sCToLCs) const {
       return m_impl->associateSimToReco(cCCH, sTCH, cPCH, cpToLCs, sCCH, sCToLCs);
     }
 

--- a/SimDataFormats/Associations/interface/LayerClusterToSimTracksterAssociator.h
+++ b/SimDataFormats/Associations/interface/LayerClusterToSimTracksterAssociator.h
@@ -23,15 +23,19 @@ namespace hgcal {
 
     // ---------- const member functions ---------------------
     /// Associate a LayerCluster to SimTracksters
-    hgcal::RecoToSimCollection associateRecoToSim(const edm::Handle<reco::CaloClusterCollection> &cCCH,
-                                                  const edm::Handle<ticl::TracksterCollection> &stCH) const {
-      return m_impl->associateRecoToSim(cCCH, stCH);
+    hgcal::RecoToSimTracksterCollection associateRecoToSim(const edm::Handle<reco::CaloClusterCollection> &cCCH,
+                                                  const edm::Handle<ticl::TracksterCollection> &stCH,
+                                                  const edm::Handle<CaloParticleCollection>& cPCH,
+                                                  const hgcal::RecoToSimCollection &lCToCPs,
+                                                  const edm::Handle<SimClusterCollection>& sCCH,
+                                                  const hgcal::RecoToSimCollectionWithSimClusters &lCToSCs) const {
+      return m_impl->associateRecoToSim(cCCH, stCH, cPCH, lCToCPs, sCCH, lCToSCs);
     };
 
     /// Associate a SimTrackster to LayerClusters
-    hgcal::SimToRecoCollection associateSimToReco(const edm::Handle<reco::CaloClusterCollection> &cCCH,
-                                                  const edm::Handle<CaloParticleCollection> &cPCH) const {
-      return m_impl->associateSimToReco(cCCH, cPCH);
+    hgcal::SimTracksterToRecoCollection associateSimToReco(const edm::Handle<reco::CaloClusterCollection> &cCCH,
+                                                  const edm::Handle<ticl::TracksterCollection> &sTCH) const {
+      return m_impl->associateSimToReco(cCCH, sTCH);
     }
 
   private:

--- a/SimDataFormats/Associations/interface/LayerClusterToSimTracksterAssociator.h
+++ b/SimDataFormats/Associations/interface/LayerClusterToSimTracksterAssociator.h
@@ -1,6 +1,6 @@
 #ifndef SimDataFormats_Associations_LayerClusterToSimTracksterAssociator_h
 #define SimDataFormats_Associations_LayerClusterToSimTracksterAssociator_h
-// Original Author:  Marco Rovere
+// Original Author:  Leonardo Cristella
 
 // system include files
 #include <memory>
@@ -34,8 +34,12 @@ namespace hgcal {
 
     /// Associate a SimTrackster to LayerClusters
     hgcal::SimTracksterToRecoCollection associateSimToReco(const edm::Handle<reco::CaloClusterCollection> &cCCH,
-                                                  const edm::Handle<ticl::TracksterCollection> &sTCH) const {
-      return m_impl->associateSimToReco(cCCH, sTCH);
+                                                  const edm::Handle<ticl::TracksterCollection> &sTCH,
+                                                  const edm::Handle<CaloParticleCollection>& cPCH,
+                                                  const hgcal::SimToRecoCollection &cpToLCs,
+                                                  const edm::Handle<SimClusterCollection>& sCCH,
+                                                  const hgcal::SimToRecoCollectionWithSimClusters &sCToLCs) const {
+      return m_impl->associateSimToReco(cCCH, sTCH, cPCH, cpToLCs, sCCH, sCToLCs);
     }
 
   private:

--- a/SimDataFormats/Associations/interface/LayerClusterToSimTracksterAssociator.h
+++ b/SimDataFormats/Associations/interface/LayerClusterToSimTracksterAssociator.h
@@ -1,0 +1,48 @@
+#ifndef SimDataFormats_Associations_LayerClusterToSimTracksterAssociator_h
+#define SimDataFormats_Associations_LayerClusterToSimTracksterAssociator_h
+// Original Author:  Marco Rovere
+
+// system include files
+#include <memory>
+
+// user include files
+
+#include "SimDataFormats/Associations/interface/LayerClusterToSimTracksterAssociatorBaseImpl.h"
+
+// forward declarations
+
+namespace hgcal {
+
+  class LayerClusterToSimTracksterAssociator {
+  public:
+    LayerClusterToSimTracksterAssociator(std::unique_ptr<hgcal::LayerClusterToSimTracksterAssociatorBaseImpl>);
+    LayerClusterToSimTracksterAssociator() = default;
+    LayerClusterToSimTracksterAssociator(LayerClusterToSimTracksterAssociator &&) = default;
+    LayerClusterToSimTracksterAssociator &operator=(LayerClusterToSimTracksterAssociator &&) = default;
+    ~LayerClusterToSimTracksterAssociator() = default;
+
+    // ---------- const member functions ---------------------
+    /// Associate a LayerCluster to SimTracksters
+    hgcal::RecoToSimCollection associateRecoToSim(const edm::Handle<reco::CaloClusterCollection> &cCCH,
+                                                  const edm::Handle<ticl::TracksterCollection> &stCH) const {
+      return m_impl->associateRecoToSim(cCCH, stCH);
+    };
+
+    /// Associate a SimTrackster to LayerClusters
+    hgcal::SimToRecoCollection associateSimToReco(const edm::Handle<reco::CaloClusterCollection> &cCCH,
+                                                  const edm::Handle<CaloParticleCollection> &cPCH) const {
+      return m_impl->associateSimToReco(cCCH, cPCH);
+    }
+
+  private:
+    LayerClusterToSimTracksterAssociator(const LayerClusterToSimTracksterAssociator &) = delete;  // stop default
+
+    const LayerClusterToSimTracksterAssociator &operator=(const LayerClusterToSimTracksterAssociator &) =
+        delete;  // stop default
+
+    // ---------- member data --------------------------------
+    std::unique_ptr<LayerClusterToSimTracksterAssociatorBaseImpl> m_impl;
+  };
+}  // namespace hgcal
+
+#endif

--- a/SimDataFormats/Associations/interface/LayerClusterToSimTracksterAssociatorBaseImpl.h
+++ b/SimDataFormats/Associations/interface/LayerClusterToSimTracksterAssociatorBaseImpl.h
@@ -16,15 +16,18 @@
 #include "DataFormats/HGCalReco/interface/Trackster.h"
 
 #include "SimDataFormats/CaloAnalysis/interface/CaloParticleFwd.h"
+#include "LayerClusterToCaloParticleAssociatorBaseImpl.h"
+#include "SimDataFormats/CaloAnalysis/interface/SimClusterFwd.h"
+#include "LayerClusterToSimClusterAssociatorBaseImpl.h"
 
 namespace hgcal {
 
   typedef edm::AssociationMap<
-      edm::OneToManyWithQualityGeneric<CaloParticleCollection, reco::CaloClusterCollection, std::pair<float, float>>>
-      SimToRecoCollection;
+      edm::OneToManyWithQualityGeneric<ticl::TracksterCollection, reco::CaloClusterCollection, std::pair<float, float>>>
+      SimTracksterToRecoCollection;
   typedef edm::AssociationMap<
       edm::OneToManyWithQualityGeneric<reco::CaloClusterCollection, ticl::TracksterCollection, float>>
-      RecoToSimCollection;
+      RecoToSimTracksterCollection;
 
   class LayerClusterToSimTracksterAssociatorBaseImpl {
   public:
@@ -34,12 +37,16 @@ namespace hgcal {
     virtual ~LayerClusterToSimTracksterAssociatorBaseImpl();
 
     /// Associate a LayerCluster to SimTracksters
-    virtual hgcal::RecoToSimCollection associateRecoToSim(const edm::Handle<reco::CaloClusterCollection> &cCH,
-                                                          const edm::Handle<ticl::TracksterCollection> &sTCH) const;
+    virtual hgcal::RecoToSimTracksterCollection associateRecoToSim(const edm::Handle<reco::CaloClusterCollection> &cCH,
+                                                          const edm::Handle<ticl::TracksterCollection> &sTCH,
+                                                          const edm::Handle<CaloParticleCollection>& cPCH,
+                                                          const hgcal::RecoToSimCollection &lCToCPs,
+                                                          const edm::Handle<SimClusterCollection>& sCCH,
+                                                          const hgcal::RecoToSimCollectionWithSimClusters &lCToSCs) const;
 
     /// Associate a SimTrackster to LayerClusters
-    virtual hgcal::SimToRecoCollection associateSimToReco(const edm::Handle<reco::CaloClusterCollection> &cCH,
-                                                          const edm::Handle<CaloParticleCollection> &cPCH) const;
+    virtual hgcal::SimTracksterToRecoCollection associateSimToReco(const edm::Handle<reco::CaloClusterCollection> &cCH,
+                                                          const edm::Handle<ticl::TracksterCollection> &sTCH) const;
   };
 }  // namespace hgcal
 

--- a/SimDataFormats/Associations/interface/LayerClusterToSimTracksterAssociatorBaseImpl.h
+++ b/SimDataFormats/Associations/interface/LayerClusterToSimTracksterAssociatorBaseImpl.h
@@ -3,7 +3,7 @@
 
 /** \class LayerClusterToSimTracksterAssociatorBaseImpl
  *
- * Base class for LayerClusterToSimTracksterAssociators.  Methods take as input
+ * Base class for LayerClusterToSimTracksterAssociators. Methods take as input
  * the handle of LayerClusters and the SimTrackster collections and return an
  * AssociationMap (oneToManyWithQuality)
  *
@@ -37,20 +37,22 @@ namespace hgcal {
     virtual ~LayerClusterToSimTracksterAssociatorBaseImpl();
 
     /// Associate a LayerCluster to SimTracksters
-    virtual hgcal::RecoToSimTracksterCollection associateRecoToSim(const edm::Handle<reco::CaloClusterCollection> &cCH,
-                                                          const edm::Handle<ticl::TracksterCollection> &sTCH,
-                                                          const edm::Handle<CaloParticleCollection>& cPCH,
-                                                          const hgcal::RecoToSimCollection &lCToCPs,
-                                                          const edm::Handle<SimClusterCollection>& sCCH,
-                                                          const hgcal::RecoToSimCollectionWithSimClusters &lCToSCs) const;
+    virtual hgcal::RecoToSimTracksterCollection associateRecoToSim(
+        const edm::Handle<reco::CaloClusterCollection> &cCH,
+        const edm::Handle<ticl::TracksterCollection> &sTCH,
+        const edm::Handle<CaloParticleCollection> &cPCH,
+        const hgcal::RecoToSimCollection &lCToCPs,
+        const edm::Handle<SimClusterCollection> &sCCH,
+        const hgcal::RecoToSimCollectionWithSimClusters &lCToSCs) const;
 
     /// Associate a SimTrackster to LayerClusters
-    virtual hgcal::SimTracksterToRecoCollection associateSimToReco(const edm::Handle<reco::CaloClusterCollection> &cCH,
-                                                          const edm::Handle<ticl::TracksterCollection> &sTCH,
-                                                          const edm::Handle<CaloParticleCollection>& cPCH,
-                                                          const hgcal::SimToRecoCollection &cPToLCs,
-                                                          const edm::Handle<SimClusterCollection>& sCCH,
-                                                          const hgcal::SimToRecoCollectionWithSimClusters &sCToLCs) const;
+    virtual hgcal::SimTracksterToRecoCollection associateSimToReco(
+        const edm::Handle<reco::CaloClusterCollection> &cCH,
+        const edm::Handle<ticl::TracksterCollection> &sTCH,
+        const edm::Handle<CaloParticleCollection> &cPCH,
+        const hgcal::SimToRecoCollection &cPToLCs,
+        const edm::Handle<SimClusterCollection> &sCCH,
+        const hgcal::SimToRecoCollectionWithSimClusters &sCToLCs) const;
   };
 }  // namespace hgcal
 

--- a/SimDataFormats/Associations/interface/LayerClusterToSimTracksterAssociatorBaseImpl.h
+++ b/SimDataFormats/Associations/interface/LayerClusterToSimTracksterAssociatorBaseImpl.h
@@ -7,7 +7,7 @@
  * the handle of LayerClusters and the SimTrackster collections and return an
  * AssociationMap (oneToManyWithQuality)
  *
- *  \author Marco Rovere
+ *  \author Leonardo Cristella
  */
 
 #include "DataFormats/Common/interface/Handle.h"
@@ -46,7 +46,11 @@ namespace hgcal {
 
     /// Associate a SimTrackster to LayerClusters
     virtual hgcal::SimTracksterToRecoCollection associateSimToReco(const edm::Handle<reco::CaloClusterCollection> &cCH,
-                                                          const edm::Handle<ticl::TracksterCollection> &sTCH) const;
+                                                          const edm::Handle<ticl::TracksterCollection> &sTCH,
+                                                          const edm::Handle<CaloParticleCollection>& cPCH,
+                                                          const hgcal::SimToRecoCollection &cPToLCs,
+                                                          const edm::Handle<SimClusterCollection>& sCCH,
+                                                          const hgcal::SimToRecoCollectionWithSimClusters &sCToLCs) const;
   };
 }  // namespace hgcal
 

--- a/SimDataFormats/Associations/interface/LayerClusterToSimTracksterAssociatorBaseImpl.h
+++ b/SimDataFormats/Associations/interface/LayerClusterToSimTracksterAssociatorBaseImpl.h
@@ -1,0 +1,46 @@
+#ifndef SimDataFormats_Associations_LayerClusterToSimTracksterAssociatorBaseImpl_h
+#define SimDataFormats_Associations_LayerClusterToSimTracksterAssociatorBaseImpl_h
+
+/** \class LayerClusterToSimTracksterAssociatorBaseImpl
+ *
+ * Base class for LayerClusterToSimTracksterAssociators.  Methods take as input
+ * the handle of LayerClusters and the SimTrackster collections and return an
+ * AssociationMap (oneToManyWithQuality)
+ *
+ *  \author Marco Rovere
+ */
+
+#include "DataFormats/Common/interface/Handle.h"
+#include "DataFormats/Common/interface/AssociationMap.h"
+#include "DataFormats/CaloRecHit/interface/CaloClusterFwd.h"
+#include "DataFormats/HGCalReco/interface/Trackster.h"
+
+#include "SimDataFormats/CaloAnalysis/interface/CaloParticleFwd.h"
+
+namespace hgcal {
+
+  typedef edm::AssociationMap<
+      edm::OneToManyWithQualityGeneric<CaloParticleCollection, reco::CaloClusterCollection, std::pair<float, float>>>
+      SimToRecoCollection;
+  typedef edm::AssociationMap<
+      edm::OneToManyWithQualityGeneric<reco::CaloClusterCollection, ticl::TracksterCollection, float>>
+      RecoToSimCollection;
+
+  class LayerClusterToSimTracksterAssociatorBaseImpl {
+  public:
+    /// Constructor
+    LayerClusterToSimTracksterAssociatorBaseImpl();
+    /// Destructor
+    virtual ~LayerClusterToSimTracksterAssociatorBaseImpl();
+
+    /// Associate a LayerCluster to SimTracksters
+    virtual hgcal::RecoToSimCollection associateRecoToSim(const edm::Handle<reco::CaloClusterCollection> &cCH,
+                                                          const edm::Handle<ticl::TracksterCollection> &sTCH) const;
+
+    /// Associate a SimTrackster to LayerClusters
+    virtual hgcal::SimToRecoCollection associateSimToReco(const edm::Handle<reco::CaloClusterCollection> &cCH,
+                                                          const edm::Handle<CaloParticleCollection> &cPCH) const;
+  };
+}  // namespace hgcal
+
+#endif

--- a/SimDataFormats/Associations/src/LayerClusterToSimTracksterAssociator.cc
+++ b/SimDataFormats/Associations/src/LayerClusterToSimTracksterAssociator.cc
@@ -1,0 +1,7 @@
+// Original Author: Marco Rovere
+
+#include "SimDataFormats/Associations/interface/LayerClusterToSimTracksterAssociator.h"
+
+hgcal::LayerClusterToSimTracksterAssociator::LayerClusterToSimTracksterAssociator(
+    std::unique_ptr<hgcal::LayerClusterToSimTracksterAssociatorBaseImpl> ptr)
+    : m_impl(std::move(ptr)) {}

--- a/SimDataFormats/Associations/src/LayerClusterToSimTracksterAssociator.cc
+++ b/SimDataFormats/Associations/src/LayerClusterToSimTracksterAssociator.cc
@@ -1,4 +1,4 @@
-// Original Author: Marco Rovere
+// Original Author: Leonardo Cristella
 
 #include "SimDataFormats/Associations/interface/LayerClusterToSimTracksterAssociator.h"
 

--- a/SimDataFormats/Associations/src/LayerClusterToSimTracksterAssociatorBaseImpl.cc
+++ b/SimDataFormats/Associations/src/LayerClusterToSimTracksterAssociatorBaseImpl.cc
@@ -7,16 +7,22 @@ namespace hgcal {
   LayerClusterToSimTracksterAssociatorBaseImpl::~LayerClusterToSimTracksterAssociatorBaseImpl(){};
 
   hgcal::RecoToSimTracksterCollection LayerClusterToSimTracksterAssociatorBaseImpl::associateRecoToSim(
-      const edm::Handle<reco::CaloClusterCollection> &cCCH, const edm::Handle<ticl::TracksterCollection> &sTCH,
-      const edm::Handle<CaloParticleCollection>& cPCH, const hgcal::RecoToSimCollection &lCToCPs,
-      const edm::Handle<SimClusterCollection>& sCCH, const hgcal::RecoToSimCollectionWithSimClusters &lCToSCs) const {
+      const edm::Handle<reco::CaloClusterCollection> &cCCH,
+      const edm::Handle<ticl::TracksterCollection> &sTCH,
+      const edm::Handle<CaloParticleCollection> &cPCH,
+      const hgcal::RecoToSimCollection &lCToCPs,
+      const edm::Handle<SimClusterCollection> &sCCH,
+      const hgcal::RecoToSimCollectionWithSimClusters &lCToSCs) const {
     return hgcal::RecoToSimTracksterCollection();
   }
 
   hgcal::SimTracksterToRecoCollection LayerClusterToSimTracksterAssociatorBaseImpl::associateSimToReco(
-      const edm::Handle<reco::CaloClusterCollection> &cCCH, const edm::Handle<ticl::TracksterCollection> &sTCH,
-      const edm::Handle<CaloParticleCollection>& cPCH, const hgcal::SimToRecoCollection &cPToLCs,
-      const edm::Handle<SimClusterCollection>& sCCH, const hgcal::SimToRecoCollectionWithSimClusters &sCToLCs) const {
+      const edm::Handle<reco::CaloClusterCollection> &cCCH,
+      const edm::Handle<ticl::TracksterCollection> &sTCH,
+      const edm::Handle<CaloParticleCollection> &cPCH,
+      const hgcal::SimToRecoCollection &cPToLCs,
+      const edm::Handle<SimClusterCollection> &sCCH,
+      const hgcal::SimToRecoCollectionWithSimClusters &sCToLCs) const {
     return hgcal::SimTracksterToRecoCollection();
   }
 

--- a/SimDataFormats/Associations/src/LayerClusterToSimTracksterAssociatorBaseImpl.cc
+++ b/SimDataFormats/Associations/src/LayerClusterToSimTracksterAssociatorBaseImpl.cc
@@ -1,4 +1,4 @@
-// Original Author: Marco Rovere
+// Original Author: Leonardo Cristella
 
 #include "SimDataFormats/Associations/interface/LayerClusterToSimTracksterAssociatorBaseImpl.h"
 
@@ -14,7 +14,9 @@ namespace hgcal {
   }
 
   hgcal::SimTracksterToRecoCollection LayerClusterToSimTracksterAssociatorBaseImpl::associateSimToReco(
-      const edm::Handle<reco::CaloClusterCollection> &cCCH, const edm::Handle<ticl::TracksterCollection> &sTCH) const {
+      const edm::Handle<reco::CaloClusterCollection> &cCCH, const edm::Handle<ticl::TracksterCollection> &sTCH,
+      const edm::Handle<CaloParticleCollection>& cPCH, const hgcal::SimToRecoCollection &cPToLCs,
+      const edm::Handle<SimClusterCollection>& sCCH, const hgcal::SimToRecoCollectionWithSimClusters &sCToLCs) const {
     return hgcal::SimTracksterToRecoCollection();
   }
 

--- a/SimDataFormats/Associations/src/LayerClusterToSimTracksterAssociatorBaseImpl.cc
+++ b/SimDataFormats/Associations/src/LayerClusterToSimTracksterAssociatorBaseImpl.cc
@@ -1,0 +1,19 @@
+// Original Author: Marco Rovere
+
+#include "SimDataFormats/Associations/interface/LayerClusterToSimTracksterAssociatorBaseImpl.h"
+
+namespace hgcal {
+  LayerClusterToSimTracksterAssociatorBaseImpl::LayerClusterToSimTracksterAssociatorBaseImpl(){};
+  LayerClusterToSimTracksterAssociatorBaseImpl::~LayerClusterToSimTracksterAssociatorBaseImpl(){};
+
+  hgcal::RecoToSimCollection LayerClusterToSimTracksterAssociatorBaseImpl::associateRecoToSim(
+      const edm::Handle<reco::CaloClusterCollection> &cCCH, const edm::Handle<ticl::TracksterCollection> &cPCH) const {
+    return hgcal::RecoToSimCollection();
+  }
+
+  hgcal::SimToRecoCollection LayerClusterToSimTracksterAssociatorBaseImpl::associateSimToReco(
+      const edm::Handle<reco::CaloClusterCollection> &cCCH, const edm::Handle<CaloParticleCollection> &cPCH) const {
+    return hgcal::SimToRecoCollection();
+  }
+
+}  // namespace hgcal

--- a/SimDataFormats/Associations/src/LayerClusterToSimTracksterAssociatorBaseImpl.cc
+++ b/SimDataFormats/Associations/src/LayerClusterToSimTracksterAssociatorBaseImpl.cc
@@ -6,14 +6,16 @@ namespace hgcal {
   LayerClusterToSimTracksterAssociatorBaseImpl::LayerClusterToSimTracksterAssociatorBaseImpl(){};
   LayerClusterToSimTracksterAssociatorBaseImpl::~LayerClusterToSimTracksterAssociatorBaseImpl(){};
 
-  hgcal::RecoToSimCollection LayerClusterToSimTracksterAssociatorBaseImpl::associateRecoToSim(
-      const edm::Handle<reco::CaloClusterCollection> &cCCH, const edm::Handle<ticl::TracksterCollection> &cPCH) const {
-    return hgcal::RecoToSimCollection();
+  hgcal::RecoToSimTracksterCollection LayerClusterToSimTracksterAssociatorBaseImpl::associateRecoToSim(
+      const edm::Handle<reco::CaloClusterCollection> &cCCH, const edm::Handle<ticl::TracksterCollection> &sTCH,
+      const edm::Handle<CaloParticleCollection>& cPCH, const hgcal::RecoToSimCollection &lCToCPs,
+      const edm::Handle<SimClusterCollection>& sCCH, const hgcal::RecoToSimCollectionWithSimClusters &lCToSCs) const {
+    return hgcal::RecoToSimTracksterCollection();
   }
 
-  hgcal::SimToRecoCollection LayerClusterToSimTracksterAssociatorBaseImpl::associateSimToReco(
-      const edm::Handle<reco::CaloClusterCollection> &cCCH, const edm::Handle<CaloParticleCollection> &cPCH) const {
-    return hgcal::SimToRecoCollection();
+  hgcal::SimTracksterToRecoCollection LayerClusterToSimTracksterAssociatorBaseImpl::associateSimToReco(
+      const edm::Handle<reco::CaloClusterCollection> &cCCH, const edm::Handle<ticl::TracksterCollection> &sTCH) const {
+    return hgcal::SimTracksterToRecoCollection();
   }
 
 }  // namespace hgcal

--- a/SimDataFormats/Associations/src/classes.h
+++ b/SimDataFormats/Associations/src/classes.h
@@ -13,6 +13,7 @@
 #include "SimDataFormats/Associations/interface/MultiClusterToCaloParticleAssociator.h"
 #include "SimDataFormats/Associations/interface/TracksterToSimTracksterAssociator.h"
 #include "SimDataFormats/Associations/interface/TTTrackTruthPair.h"
+#include "SimDataFormats/Associations/interface/LayerClusterToSimTracksterAssociator.h"
 
 namespace SimDataFormats_Associations {
   struct SimDataFormats_Associations {
@@ -32,6 +33,8 @@ namespace SimDataFormats_Associations {
     edm::Wrapper<hgcal::MultiClusterToCaloParticleAssociator> dummy8;
 
     edm::Wrapper<hgcal::TracksterToSimTracksterAssociator> dummy9;
+
+    edm::Wrapper<hgcal::LayerClusterToSimTracksterAssociator> dummy10;
 
     reco::VertexSimToRecoCollection vstrc;
     reco::VertexSimToRecoCollection::const_iterator vstrci;

--- a/SimDataFormats/Associations/src/classes_def.xml
+++ b/SimDataFormats/Associations/src/classes_def.xml
@@ -24,6 +24,9 @@
   <class name="hgcal::TracksterToSimTracksterAssociator" persistent="false"/>
   <class name="edm::Wrapper<hgcal::TracksterToSimTracksterAssociator>" persistent="false"/>
 
+  <class name="hgcal::LayerClusterToSimTracksterAssociator" persistent="false"/>
+  <class name="edm::Wrapper<hgcal::LayerClusterToSimTracksterAssociator>" persistent="false"/>
+
 
   <class name="reco::VertexSimToRecoCollection" >
     <field name="transientMap_" transient="true"/>
@@ -115,6 +118,19 @@
   <class name="edm::Wrapper<hgcal::RecoToSimCollectionSimTracksters>" />
 
   <class name="edm::helpers::KeyVal<edm::RefProd<vector<ticl::Trackster> >,edm::RefProd<vector<ticl::Trackster> > >" />
+
+
+  <class name="hgcal::SimTracksterToRecoCollection" >
+   <field name="transientMap_" transient="true"/>
+  </class>
+  <class name="edm::Wrapper<hgcal::SimTracksterToRecoCollection>" />
+  <class name="hgcal::RecoToSimTracksterCollection" >
+   <field name="transientMap_" transient="true"/>
+  </class>
+  <class name="edm::Wrapper<hgcal::RecoToSimTracksterCollection>" />
+
+  <class name="edm::helpers::KeyVal<edm::RefProd<vector<reco::CaloCluster> >,edm::RefProd<vector<ticl::Trackster> > >" />
+  <class name="edm::helpers::KeyVal<edm::RefProd<vector<ticl::Trackster> >,edm::RefProd<vector<reco::CaloCluster> > >" />
 
 
   <class name="TTTrackTruthPair<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>,Phase2TrackerDigi,edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > >" />


### PR DESCRIPTION
#### PR description:

This PR introduces an associator between LayerClusters and TICL SimTracksters.
Together with the Trackster-to-SimTrackster associator, it will be used to assess the TICL performance in building 3D Tracksters.
A usage example of the associator is provided [here](https://github.com/lecriste/cmssw/commit/b348c0f27e580cbd9d58724617eb232e90bbff16).
No changes are expected in the output.

#### PR validation:

`runTheMatrix -l limited`