### PR TITLE
add customization function to swap offlinePrimaryVertices to offlinePrimaryVerticesWithBS

### DIFF
--- a/RecoVertex/Configuration/python/replaceOfflinePrimaryVerticesWithBS.py
+++ b/RecoVertex/Configuration/python/replaceOfflinePrimaryVerticesWithBS.py
@@ -1,0 +1,26 @@
+import FWCore.ParameterSet.Config as cms
+from FWCore.ParameterSet.MassReplace import massReplaceInputTag as MassReplaceInputTag
+#
+# mass replace OfflinePrimaryVertices with OfflinePrimaryVerticesWithBS 
+# (doesn't affect defaults in the source code, e.g. provided by fillDescriptions)
+#
+def massReplaceOfflinePrimaryVerticesToUseBeamSpot(process):
+    # swap all occurrences
+    process = MassReplaceInputTag(process,"offlinePrimaryVertices","offlinePrimaryVerticesWithBS")
+    
+    # excepted of course for the primary source...
+    if hasattr(process,'offlinePrimaryVerticesWithBS'):
+        process.offlinePrimaryVerticesWithBS.src = cms.InputTag("offlinePrimaryVertices","WithBS")
+        
+    return process
+
+#
+# makes OfflinePrimaryVertices equivalent to OfflinePrimaryVerticesWithBS
+# by changing the input vertices collection of the sorted PV
+# see file https://github.com/cms-sw/cmssw/blob/master/RecoVertex/Configuration/python/RecoVertex_cff.py
+# 
+def swapOfflinePrimaryVerticesToUseBeamSpot(process):
+    if hasattr(process,'offlinePrimaryVertices'):
+        process.offlinePrimaryVertices.vertices="unsortedOfflinePrimaryVertices:WithBS"
+
+    return process


### PR DESCRIPTION
#### PR description:

The possibility to swap `offlinePrimaryVertices`  with  `offlinePrimaryVerticesWithBS` (that use the BeamSpot measurement constrain the vertex position in the x,y plane)  has been discussed in the physics coordination meeting.
This would give in principle better precision as long as the Beam Spot is measured correctly.
We'd like to study the effect of such swap at all levels by producing dedicated RelVals with this feature, in order to be compared with the regular RelVal samples.
In order to do that we provide here a customization function that changes the source of vertices of `offlinePrimaryVertices` in order to point to `unsortedOfflinePrimaryVertices:WithBS` .

As a caveat this happens at level of *already sorted* PVs, so **the unsorted collections remain the same**.

#### PR validation:

Tested a "would be" special workflow via:

```
runTheMatrix.py -l 11634.0 --command='--customise RecoVertex/Configuration/replaceOfflinePrimaryVerticesWithBS.swapOfflinePrimaryVerticesToUseBeamSpot'
```

that runs with success.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Not a backport, no backport needed.
cc:
@mtosi, @vmariani 
