### PR TITLE
More dependencies needed for UBSAN builds

### DIFF
--- a/CalibTracker/SiStripHitEfficiency/BuildFile.xml
+++ b/CalibTracker/SiStripHitEfficiency/BuildFile.xml
@@ -1,7 +1,7 @@
 <use name="RecoLocalTracker/SiStripClusterizer"/>
 <use name="CommonTools/UtilAlgos"/>
 <use name="DataFormats/DetId"/>
-<use name="DataFormats/Scalers"/>
+<use name="DataFormats/Scalers"/> <!--Needed for typeinfo for LumiScalers for UBSAN builds-->
 <use name="DataFormats/SiStripDetId"/>
 <use name="DataFormats/TrackingRecHit"/>
 <use name="DataFormats/TrackReco"/>

--- a/CalibTracker/SiStripHitEfficiency/BuildFile.xml
+++ b/CalibTracker/SiStripHitEfficiency/BuildFile.xml
@@ -1,6 +1,7 @@
 <use name="RecoLocalTracker/SiStripClusterizer"/>
 <use name="CommonTools/UtilAlgos"/>
 <use name="DataFormats/DetId"/>
+<use name="DataFormats/Scalers"/>
 <use name="DataFormats/SiStripDetId"/>
 <use name="DataFormats/TrackingRecHit"/>
 <use name="DataFormats/TrackReco"/>

--- a/DQM/DTMonitorModule/BuildFile.xml
+++ b/DQM/DTMonitorModule/BuildFile.xml
@@ -4,6 +4,7 @@
 <use name="DataFormats/DTDigi"/>
 <use name="DataFormats/L1DTTrackFinder"/>
 <use name="DataFormats/L1GlobalMuonTrigger"/>
+<use name="DataFormats/Scalers"/>
 <use name="CondFormats/DTObjects"/>
 <use name="CondFormats/DataRecord"/>
 <use name="Geometry/Records"/>

--- a/DQM/DTMonitorModule/BuildFile.xml
+++ b/DQM/DTMonitorModule/BuildFile.xml
@@ -4,7 +4,7 @@
 <use name="DataFormats/DTDigi"/>
 <use name="DataFormats/L1DTTrackFinder"/>
 <use name="DataFormats/L1GlobalMuonTrigger"/>
-<use name="DataFormats/Scalers"/>
+<use name="DataFormats/Scalers"/> <!--Needed for typeinfo for LumiScalers for UBSAN builds-->
 <use name="CondFormats/DTObjects"/>
 <use name="CondFormats/DataRecord"/>
 <use name="Geometry/Records"/>

--- a/DQM/TrackerRemapper/BuildFile.xml
+++ b/DQM/TrackerRemapper/BuildFile.xml
@@ -5,7 +5,7 @@
 <use name="rootgraphics"/>
 <use name="rootmath"/>
 <use name="roothistmatrix"/>
-<use name="roothistpainter"/>
+<use name="roothistpainter"/> <!--Needed for typeinfo for TPaletteAxis in UBSAN builds-->
 <export>
   <lib name="1"/>
 </export>

--- a/Geometry/MTDNumberingBuilder/BuildFile.xml
+++ b/Geometry/MTDNumberingBuilder/BuildFile.xml
@@ -1,7 +1,7 @@
 <use name="DataFormats/GeometrySurface"/>
 <use name="DetectorDescription/Core"/>
 <use name="Geometry/TrackerNumberingBuilder"/>
-<use name="Geometry/CommonDetUnit"/>
+<use name="Geometry/CommonDetUnit"/> <!--Needed for typeinfo for GeomDet in UBSAN builds-->
 <use name="DataFormats/ForwardDetId"/>
 <export>
   <lib name="1"/>


### PR DESCRIPTION
#### PR description:

Followup to #33933, this fixes two more missing dependencies in UBSAN builds,
```
CalibTrackerSiStripHitEfficiency/HitEff.cc.o:(.data.rel+0x3d18): undefined reference to `typeinfo for LumiScalers'
```
and
```
DQMDTMonitorModule/DTScalerInfoTask.cc.o:(.data.rel+0x3bd8): undefined reference to `typeinfo for LumiScalers'
```
This also adds comments for the two entries here and the ones in #33933 to document why the dependency is needed.

#### PR validation:

Trivial technical fix, compiles in CMSSW_12_0_UBSAN_X_2021-06-11-2300.