### PR TITLE
improve precision in jacobianCurvilinearToCartesian

### DIFF
--- a/DataFormats/GeometryVector/src/TrackingJacobians.cc
+++ b/DataFormats/GeometryVector/src/TrackingJacobians.cc
@@ -36,9 +36,9 @@ AlgebraicMatrix65 jacobianCurvilinearToCartesian(const GlobalVector& momentum, i
   R(5, 5) = 1.;
 
   double p = pvec.mag(), p2 = p * p;
-  double sinlambda = pvec.z()/p, coslambda = pt/p;
-  double sinphi = pvec.y()/pt, cosphi = pvec.x()/pt;
-  
+  double sinlambda = pvec.z() / p, coslambda = pt / p;
+  double sinphi = pvec.y() / pt, cosphi = pvec.x() / pt;
+
   theJacobian(1, 3) = 1.;
   theJacobian(2, 4) = 1.;
   theJacobian(3, 0) = -q * p2 * coslambda * cosphi;

--- a/DataFormats/GeometryVector/src/TrackingJacobians.cc
+++ b/DataFormats/GeometryVector/src/TrackingJacobians.cc
@@ -36,11 +36,9 @@ AlgebraicMatrix65 jacobianCurvilinearToCartesian(const GlobalVector& momentum, i
   R(5, 5) = 1.;
 
   double p = pvec.mag(), p2 = p * p;
-  double lambda = 0.5 * M_PI - pvec.theta();
-  double phi = pvec.phi();
-  double sinlambda = sin(lambda), coslambda = cos(lambda);
-  double sinphi = sin(phi), cosphi = cos(phi);
-
+  double sinlambda = pvec.z()/p, coslambda = pt/p;
+  double sinphi = pvec.y()/pt, cosphi = pvec.x()/pt;
+  
   theJacobian(1, 3) = 1.;
   theJacobian(2, 4) = 1.;
   theJacobian(3, 0) = -q * p2 * coslambda * cosphi;


### PR DESCRIPTION
the transformation from `q/p, lambda, phi -> p{x,y,z}` depends significantly on precision for high momentum tracks. While most of the math in the `jacobianCurvilinearToCartesian` is in double, the initial step in the momentum space relied on float precision atan to get the polar and azimuth angles, which is extracted only to immediately call sincos.
The angle extraction is not necessary considering that the input momentum is in Cartesian coordinates.

Tested on 1000 muons generated in [0.5 ,1000] GeV range, comparing full double precision implementation with  other alternatives at the state conversion of tracking seeds: the number of converted covariances with a fractional change larger than 1e-3 in any of the cov matrix elements goes down by a factor of just over 100.

A more precise alternative is to convert the input momentum from `GlobalVector` (float precision) to a double-precision version. This, however has a slightly larger computational cost.

@mtosi @VinInn @vmariani @mmusich 

