### PR TITLE
[DD4hep] Name clarification: Restore namespace to several names to enable reading sim geo DB payload

### DIFF
--- a/Geometry/TrackerCommonData/plugins/dd4hep/DDCutTubsFromPoints.cc
+++ b/Geometry/TrackerCommonData/plugins/dd4hep/DDCutTubsFromPoints.cc
@@ -25,7 +25,7 @@ static long algorithm(dd4hep::Detector& /* description */, cms::DDParsingContext
   float r_max = args.value<float>("rMax");
   float z_pos = args.value<float>("zPos");
 
-  const std::string solidOutput = args.value<std::string>("SolidName");
+  std::string solidOutput = args.value<std::string>("SolidName");
   const std::string material = args.value<std::string>("Material");
 
   auto phis = ns.vecFloat(args.str("Phi"));
@@ -49,6 +49,7 @@ static long algorithm(dd4hep::Detector& /* description */, cms::DDParsingContext
   // non-zero phi distance. Sections with zero phi distance can be used to
   // create sharp jumps.
 
+  solidOutput = ns.prepend(solidOutput);
   edm::LogVerbatim("TrackerGeom") << "DDCutTubsFromPoints debug: Parent " << args.parentName() << "\tSolid "
                                   << solidOutput << " NameSpace " << ns.name() << "\tnumber of sections "
                                   << sections.size();
@@ -106,8 +107,8 @@ static long algorithm(dd4hep::Detector& /* description */, cms::DDParsingContext
       float P3_z_l = (P1_z_l + P2_z_l) / 2;
       float P3_z_t = (P1_z_t + P2_z_t) / 2;
 
+      std::string segname(solidOutput + "_seg_" + std::to_string(segment));
       edm::LogVerbatim("TrackerGeom").log([&](auto& log) {
-        std::string segname(solidOutput + "_seg_" + std::to_string(segment));
         log << "DDCutTubsFromPoints: P1 l: " << segname << P1_x_l << " , " << P1_y_l << " , " << P1_z_l;
         log << "DDCutTubsFromPoints: P1 t: " << segname << P1_x_t << " , " << P1_y_t << " , " << P1_z_t;
         log << "DDCutTubsFromPoints: P2 l: " << segname << P2_x_l << " , " << P2_y_l << " , " << P2_z_l;
@@ -159,7 +160,7 @@ static long algorithm(dd4hep::Detector& /* description */, cms::DDParsingContext
       n_y_t /= norm;
       n_z_t /= norm;
 
-      auto seg = dd4hep::CutTube(r_min, r_max, dz, phi1, phi2, n_x_l, n_y_l, n_z_l, n_x_t, n_y_t, n_z_t);
+      auto seg = dd4hep::CutTube(segname, r_min, r_max, dz, phi1, phi2, n_x_l, n_y_l, n_z_l, n_x_t, n_y_t, n_z_t);
 
       edm::LogVerbatim("TrackerGeom") << "DDCutTubsFromPoints: CutTube(" << r_min << "," << r_max << "," << dz << ","
                                       << phi1 << "," << phi2 << "," << n_x_l << "," << n_y_l << "," << n_z_l << ","
@@ -181,7 +182,7 @@ static long algorithm(dd4hep::Detector& /* description */, cms::DDParsingContext
 
   for (unsigned i = 1; i < segments.size() - 1; i++) {
     solid = dd4hep::UnionSolid(
-        solidOutput + "_uni" + std::to_string(i + 1), solid, segments[i], dd4hep::Position(0., 0., offsets[i] - shift));
+        solidOutput + "_uni_" + std::to_string(i + 1), solid, segments[i], dd4hep::Position(0., 0., offsets[i] - shift));
   }
 
   solid = dd4hep::UnionSolid(solidOutput,

--- a/Geometry/TrackerCommonData/plugins/dd4hep/DDCutTubsFromPoints.cc
+++ b/Geometry/TrackerCommonData/plugins/dd4hep/DDCutTubsFromPoints.cc
@@ -181,8 +181,10 @@ static long algorithm(dd4hep::Detector& /* description */, cms::DDParsingContext
   float shift = offsets[0];
 
   for (unsigned i = 1; i < segments.size() - 1; i++) {
-    solid = dd4hep::UnionSolid(
-        solidOutput + "_uni_" + std::to_string(i + 1), solid, segments[i], dd4hep::Position(0., 0., offsets[i] - shift));
+    solid = dd4hep::UnionSolid(solidOutput + "_uni_" + std::to_string(i + 1),
+                               solid,
+                               segments[i],
+                               dd4hep::Position(0., 0., offsets[i] - shift));
   }
 
   solid = dd4hep::UnionSolid(solidOutput,

--- a/Geometry/TrackerCommonData/plugins/dd4hep/DDTECModuleAlgo.cc
+++ b/Geometry/TrackerCommonData/plugins/dd4hep/DDTECModuleAlgo.cc
@@ -404,6 +404,7 @@ static long algorithm(Detector& /* description */, cms::DDParsingContext& ctxt, 
   }
   //Pitch Adapter
   name = idName + "PA";
+  name = ns.prepend(name);
   if (!isStereo) {
     dx = 0.5 * pitchWidth;
     dy = 0.5 * pitchThick;


### PR DESCRIPTION
In the old DD, all names of geometry components (other than SpecPars) included the namespace. That feature promoted uniqueness of names. With DD4hep, most names still contain the namespace, but a small minority do not. Nonetheless, most of these names still are unique. Without this PR, there are a handful of names which show duplication. Internally, this duplication is not a problem because ROOT implicitly appends a hex address to all names to make them unique, but the human-readable portion of the name might show duplication.

A PR that will be submitted very soon will propose a tool for creating the simulation geometry DB payload with DD4hep. This payload will not be readable if it contains duplicate names for different components (e.g., two different solids with the same name). To prevent this duplication, the namespace needs to be restored to a handful of component names, making them match exactly their names in the old DD and preventing duplication.

In addition, a small typo was discovered in `Geometry/TrackerCommonData/plugins/dd4hep/DDCutTubsFromPoints.cc`. Fixing the typo restores the code to match the old DD and also restores the names of the solids affected to exactly match the old DD.  See the doc below and my note on the file page for more details.

This Google doc shows the names in detail and how they change with this PR:
https://docs.google.com/document/d/1kNMv9FWSRcfM_FUjzrFzNH5igZhW62ZwjYNIj98zaSM/edit?usp=sharing

Note: This PR clarifies several names but **does not actually change the geometry.**

#### PR validation:

The solids affected by this PR were checked to see that their parameters were exactly the same before and after the PR, and also that, after this PR, the DD4hep solids exactly match those in the old DD.

Code searches were performed to see if the names affected by this PR are referred to anywhere else in the code. They are not. Also, the clarifications in this PR should be safe because the names are being restored to match the old DD.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

A backport is probably not necessary since this PR only clarifies several names.