### PR TITLE
[Backport] Remove the packedCandidate to gen associations in miniAOD_customizeAllData 

### DIFF
--- a/PhysicsTools/PatAlgos/python/tools/coreTools.py
+++ b/PhysicsTools/PatAlgos/python/tools/coreTools.py
@@ -189,6 +189,8 @@ class RemoveMCMatching(ConfigToolBase):
             'prunedGenParticles',
             'prunedGenParticlesWithStatusOne',
             'packedGenParticles',
+            'packedPFCandidateToGenAssociation',
+            'lostTracksToGenAssociation',
         ]
         for attr in attrsToDelete:
             if hasattr(process,attr): delattr(process,attr)


### PR DESCRIPTION
#### PR description:

#33996 added two new collections to the `MINIAODSIM` event content, and the corresponding task. However, if cmsDriver is provided both the `MINIAODSIM` event content and the `--data` switch, the `prunedGenParticles` collection that is used to produce the associations is removed by a customizer and the job crashes due to `ProductNotFound`.

This PR adds the two new collections to the list of collections to remove with the miniAOD_customizeAllData function, inside the coreTools.py file.

#### PR validation:

The tests were performed using the `scram b runtests` inside `TauAnalysis/MCEmbeddingTools`, which first triggered the issue

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Backport of #34113 to fix the issue in #33996
