### PR TITLE
Fix minor mistake in CSC Run-3 slope to Run-2 pattern translation (CCLUT-15)

### DIFF
--- a/L1Trigger/CSCTriggerPrimitives/src/ComparatorCodeLUT.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/ComparatorCodeLUT.cc
@@ -146,8 +146,8 @@ int ComparatorCodeLUT::calculateComparatorCode(const pattern& halfStripPattern) 
 }
 
 unsigned ComparatorCodeLUT::convertSlopeToRun2Pattern(const unsigned slope) const {
-  const unsigned slopeList[32] = {10, 10, 10, 8, 8, 8, 6, 6, 6, 6, 4, 4, 2, 2, 2, 2,
-                                  10, 10, 10, 9, 9, 9, 7, 7, 7, 7, 5, 5, 3, 3, 3, 3};
+  const unsigned slopeList[32] = {10, 10, 10, 8, 8, 8, 6, 6, 6, 4, 4, 4, 2, 2, 2, 2,
+                                  10, 10, 10, 9, 9, 9, 7, 7, 7, 5, 5, 5, 3, 3, 3, 3};
   return slopeList[slope];
 }
 


### PR DESCRIPTION
#### PR description:

Minor fix in the slope to Run-3 lookup table. This now matches p11 of DN-20-016.

<img width="850" alt="Screen Shot 2021-06-14 at 12 51 02 PM" src="https://user-images.githubusercontent.com/4134786/121937496-5c801200-cd10-11eb-8f4d-2da843f6b002.png">

@barvic @tahuang1991 