### PR TITLE
Fix sign error in expression in GEM digitizer

### DIFF
--- a/SimMuon/GEMDigitizer/src/GEMSignalModel.cc
+++ b/SimMuon/GEMDigitizer/src/GEMSignalModel.cc
@@ -57,8 +57,8 @@ void GEMSignalModel::simulate(const GEMEtaPartition* roll,
       if (partMom <= elecMomCut1)
         elecEff = elecEffLowCoeff * std::exp(elecEffLowParam0 * partMom * momConvFact);
       if (partMom > elecMomCut1 && partMom < elecMomCut2)
-        elecEff = elecEffMidCoeff * log(elecEffMidParam1 * partMom * momConvFact - elecEffMidParam0) /
-                  (elecEffMidCoeff + log(elecEffMidParam1 * partMom * momConvFact - elecEffMidParam0));
+        elecEff = elecEffMidCoeff * log(elecEffMidParam1 * partMom * momConvFact + elecEffMidParam0) /
+                  (elecEffMidCoeff + log(elecEffMidParam1 * partMom * momConvFact + elecEffMidParam0));
       if (partMom > elecMomCut2)
         elecEff = 1.;
       if (checkElecEff < elecEff)


### PR DESCRIPTION

#### PR description:

A sign error was introduced when turning magic numbers into named parameter in the following commit:
https://github.com/cms-sw/cmssw/commit/334761919eca55c5c93f6e58574b55432c4f42ef#diff-a4f2f038afa58c34cba02c63dd10a0a5e318afd43c03b05dd941b99c6e00b3a4
The negative sign is used twice, once in the parameter, once in the expression.

@jshlee @yeckang 

<!-- Please replace this text with a description of the feature proposed or problem addressed, specifying:
  - what changes are expected in the output if any, 
  - what other PRs or externals it depends upon if any,
  - link to any additional material useful to provide a documentation for this PR (slides, JIRA tickets, related pull requestes, hypernews, TWiki or Indico pages)  -->

#### PR validation:

Checked on a small test. The GEM digi and rechit distributions changed slightly.

Plotting the eff. expression with the correct (i.e. the original expression, and the expression reverted to by this PR) or incorrect signs (i.e. the expression after the changes to add named parameters instead of magic), you can see that the eff. should be lower for the particular branch:
![eff_check](https://user-images.githubusercontent.com/29137092/122194685-a0217a00-ced0-11eb-8452-99dd8a96a02b.png)


and you can see slightly less gem hits in the cluster size plot for instance:
![all_OldVSNew_TTbar14TeV2026D76PUwPRMXwf34834p999c_GEMDetIdGEMRecHitsOwnedRangeMap_gemRecHits__RECO_obj_collection__data__clusterSize](https://user-images.githubusercontent.com/29137092/122194241-3903c580-ced0-11eb-992b-6fc00da1b514.png)

<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

<!-- Please replace this text with any link to  -->

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
