### PR TITLE
skipPS option for CorrectedECALPFClusterProducer

### DIFF
--- a/RecoParticleFlow/PFClusterProducer/plugins/CorrectedECALPFClusterProducer.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/CorrectedECALPFClusterProducer.cc
@@ -133,8 +133,10 @@ void CorrectedECALPFClusterProducer::produce(edm::Event& e, const edm::EventSetu
 void CorrectedECALPFClusterProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
   desc.add<double>("minimumPSEnergy", 0.0);
-  desc.add<bool>("skipPS", false);
-  desc.add<edm::InputTag>("inputPS", edm::InputTag("particleFlowClusterPS"));
+  desc.ifValue(
+      edm::ParameterDescription<bool>("skipPS", false, true),
+      true >> (edm::ParameterDescription<edm::InputTag>("inputPS", edm::InputTag(""), true)) or
+          false >> (edm::ParameterDescription<edm::InputTag>("inputPS", edm::InputTag("particleFlowClusterPS"), true)));
   {
     edm::ParameterSetDescription psd0;
     psd0.add<bool>("applyCrackCorrections", false);


### PR DESCRIPTION
#### PR description:

This PR introduces a flag which allows us to skip preshower-energy based correction for PF ECAL clusters. The performance of this option is still being studied, so the default behavior is to use this correction, but the preliminary study indicates non-negligible speed-up for HLT workflow [1,2]. This switch will facilitate further studies including physics object performance.

A little more information on this option can be found in this talk:
https://indico.cern.ch/event/1040953/#35-pog-status-reports-particle

```
based on Run 3 ttbar PU sample.
[1]
[original]
FastReport ---------------------------- Job Summary ----------------------------
FastReport   CPU time avg.      when run  Real time avg.      when run     Alloc. avg.      when run   Dealloc. avg.      when run Modules
FastReport         1.1 ms         3.4 ms         1.6 ms         5.0 ms        +647 kB       +2081 kB        -607 kB       -1954 kB    hltParticleFlowRecHitECALUnseeded
FastReport         1.2 ms         3.8 ms         1.5 ms         4.7 ms        +709 kB       +2279 kB        -637 kB       -2049 kB    hltParticleFlowRecHitHBHE
FastReport         1.1 ms         3.6 ms         1.4 ms         4.4 ms        +860 kB       +2764 kB        -779 kB       -2504 kB    hltParticleFlowRecHitHF
FastReport         7.7 ms        24.9 ms         9.6 ms        30.7 ms       +1969 kB       +6329 kB        -611 kB       -1964 kB    hltParticleFlowRecHitPSUnseeded

FastReport         1.1 ms         3.4 ms         1.4 ms         4.5 ms        +381 kB       +1226 kB        -325 kB       -1045 kB    hltParticleFlowClusterECALUncorrectedUnseeded
FastReport        20.8 ms        66.8 ms        25.0 ms        80.4 ms       +4920 kB      +15816 kB       -3864 kB      -12420 kB    hltParticleFlowClusterPSUnseeded
FastReport        15.8 ms        50.8 ms        18.8 ms        60.3 ms         +64 kB        +207 kB         -15 kB         -48 kB    hltParticleFlowClusterECALUnseeded
FastReport        13.0 ms        41.7 ms        16.0 ms        51.4 ms       +1250 kB       +4019 kB       -1122 kB       -3606 kB    hltParticleFlowClusterHBHE
FastReport         2.3 ms         7.3 ms         2.8 ms         8.9 ms        +492 kB       +1583 kB        -406 kB       -1305 kB    hltParticleFlowClusterHCAL
FastReport         0.4 ms         1.3 ms         0.5 ms         1.5 ms        +376 kB       +1210 kB        -280 kB        -900 kB    hltParticleFlowClusterHF

FastReport         7.4 ms        23.9 ms         9.3 ms        29.9 ms        +798 kB       +2565 kB        -652 kB       -2098 kB    hltParticleFlowBlock
FastReport         1.8 ms         5.9 ms         2.3 ms         7.4 ms       +1194 kB       +3837 kB        -903 kB       -2903 kB    hltParticleFlow

FastReport       308.1 ms                      381.3 ms                     +70590 kB                     -56502 kB                 total
FastReport        88.8 ms                      380.8 ms                      +4417 kB                     -17447 kB                 other

[2]
[skipPS]
# skip hltParticleFlowRecHitPSUnseeded & hltParticleFlowClusterPSUnseeded
# use skipPS flag for hltParticleFlowClusterECALUnseeded

FastReport         1.1 ms         3.4 ms         1.2 ms         3.8 ms        +117 kB        +379 kB         -68 kB        -220 kB    hltParticleFlowRecHitECALUnseeded
FastReport         1.1 ms         3.4 ms         1.2 ms         3.8 ms        +167 kB        +538 kB         -79 kB        -254 kB    hltParticleFlowRecHitHBHE
FastReport         1.0 ms         3.2 ms         1.1 ms         3.4 ms        +296 kB        +953 kB        -204 kB        -656 kB    hltParticleFlowRecHitHF

FastReport         1.0 ms         3.1 ms         1.1 ms         3.5 ms        +381 kB       +1226 kB        -325 kB       -1045 kB    hltParticleFlowClusterECALUncorrectedUnseeded
FastReport         1.2 ms         3.8 ms         1.4 ms         4.5 ms         +48 kB        +155 kB          -5 kB         -18 kB    hltParticleFlowClusterECALUnseeded
FastReport        11.8 ms        38.1 ms        12.8 ms        41.2 ms       +1250 kB       +4019 kB       -1122 kB       -3606 kB    hltParticleFlowClusterHBHE
FastReport         2.1 ms         6.8 ms         2.3 ms         7.3 ms        +492 kB       +1583 kB        -406 kB       -1305 kB    hltParticleFlowClusterHCAL
FastReport         0.4 ms         1.2 ms         0.4 ms         1.3 ms        +376 kB       +1210 kB        -280 kB        -900 kB    hltParticleFlowClusterHF

FastReport         6.8 ms        21.9 ms         7.4 ms        23.8 ms        +798 kB       +2565 kB        -652 kB       -2098 kB    hltParticleFlowBlock
FastReport         1.7 ms         5.4 ms         1.8 ms         5.9 ms       +1193 kB       +3837 kB        -903 kB       -2903 kB    hltParticleFlow

FastReport       242.2 ms                      268.8 ms                     +62027 kB                     -50325 kB                 total
FastReport        91.7 ms                      365.7 ms                      +4376 kB                     -15106 kB                 other
 ```

#### PR validation:

```
runTheMatrix.py -l limited
```
was successful apart from a few input data file access errors.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This is not a backport.

@bendavid @marksan87 @laurenhay @dimkarasav