### PR TITLE
[106X] Read PUPPIMET from miniAODv2

### DIFF
--- a/PhysicsTools/NanoAOD/python/nano_cff.py
+++ b/PhysicsTools/NanoAOD/python/nano_cff.py
@@ -270,8 +270,8 @@ def nanoAOD_recalibrateMETs(process,isData):
         process.patJetsPuppi.addGenPartonMatch = cms.bool(False)
         process.patJetsPuppi.addGenJetMatch = cms.bool(False)
     
-    runMetCorAndUncFromMiniAOD(process,isData=isData,metType="Puppi",postfix="Puppi",jetFlavor="AK4PFPuppi", recoMetFromPFCs=bool(nanoAOD_PuppiV15_switch.recoMetFromPFCs), reclusterJets=bool(nanoAOD_PuppiV15_switch.reclusterJets))
-    process.nanoSequenceCommon.insert(process.nanoSequenceCommon.index(process.jetSequence),cms.Sequence(process.puppiMETSequence+process.fullPatMetSequencePuppi))
+    (~run2_nanoAOD_106Xv2).toModify(runMetCorAndUncFromMiniAOD(process,isData=isData,metType="Puppi",postfix="Puppi",jetFlavor="AK4PFPuppi", recoMetFromPFCs=bool(nanoAOD_PuppiV15_switch.recoMetFromPFCs), reclusterJets=bool(nanoAOD_PuppiV15_switch.reclusterJets)))
+    (~run2_nanoAOD_106Xv2).toModify(process.nanoSequenceCommon.insert(process.nanoSequenceCommon.index(process.jetSequence),cms.Sequence(process.puppiMETSequence+process.fullPatMetSequencePuppi)))
     return process
 
 from PhysicsTools.SelectorUtils.tools.vid_id_tools import *


### PR DESCRIPTION
#### PR description:
Found differences in PuppiMET and RawPuppiMET between 106X and 120X[master] when reading the same miniAOD-v2 file
e.g., 
RawPuppiMET: https://gouskos.web.cern.ch/gouskos/xpog/nanoaod-v9/puppimet/plots/RawPuppiMET_pt_10626vanila.pdf
PuppiMET (Type1):  https://gouskos.web.cern.ch/gouskos/xpog/nanoaod-v9/puppimet/plots/PuppiMET_pt_10626vanila.pdf
 

#### PR validation:
PR validated runing the 136.8523 workflow
Also compared PuppiMET in miniAOD and nanoAOD after this fix and do agree within numerical precision
NB. This PR does not fix the diffrence between 106X and 120X in nanoAOD; Ensures that 106X nanoAOD reads directly from miniAOD