### PR TITLE
Try to fix RECO+PAT sequence for bParking processing

### DIFF
--- a/PhysicsTools/PatAlgos/python/producersLayer1/lowPtElectronProducer_cff.py
+++ b/PhysicsTools/PatAlgos/python/producersLayer1/lowPtElectronProducer_cff.py
@@ -74,11 +74,13 @@ from Configuration.Eras.Modifier_bParking_cff import bParking
 
 from RecoEgamma.EgammaElectronProducers.lowPtGsfElectronSeedValueMaps_cff import rekeyLowPtGsfElectronSeedValueMaps
 from RecoEgamma.EgammaElectronProducers.lowPtGsfElectronID_cff import lowPtGsfElectronID
-from RecoEgamma.EgammaElectronProducers.lowPtGsfElectrons_cff import lowPtGsfElectrons
+from RecoEgamma.EgammaElectronProducers.lowPtGsfElectrons_cff import lowPtGsfElectrons,_lowPtGsfElectrons
+lowPtGsfElectronsTmp = lowPtGsfElectrons.clone()
 
 _makePatLowPtElectronsTask = makePatLowPtElectronsTask.copy()
 _makePatLowPtElectronsTask.add(rekeyLowPtGsfElectronSeedValueMaps)
 _makePatLowPtElectronsTask.add(lowPtGsfElectronID)
 (bParking | run2_miniAOD_UL).toReplaceWith(makePatLowPtElectronsTask,_makePatLowPtElectronsTask)
 ( (bParking & run2_miniAOD_UL) | (~bParking & run2_miniAOD_devel) ).toModify(
-    makePatLowPtElectronsTask, func = lambda t: t.add(lowPtGsfElectrons))
+    makePatLowPtElectronsTask, func = lambda t: t.add(lowPtGsfElectronsTmp))
+run2_miniAOD_UL.toReplaceWith(lowPtGsfElectronsTmp,_lowPtGsfElectrons)

--- a/RecoEgamma/EgammaElectronProducers/python/lowPtGsfElectrons_cff.py
+++ b/RecoEgamma/EgammaElectronProducers/python/lowPtGsfElectrons_cff.py
@@ -51,5 +51,5 @@ _lowPtGsfElectrons = lowPtGsfElectronFinalizer.clone(
     regressionConfig = lowPtRegressionModifier,
 )
 
-from Configuration.ProcessModifiers.run2_miniAOD_UL_cff import run2_miniAOD_UL
-run2_miniAOD_UL.toReplaceWith(lowPtGsfElectrons,_lowPtGsfElectrons)
+#from Configuration.ProcessModifiers.run2_miniAOD_UL_cff import run2_miniAOD_UL
+#run2_miniAOD_UL.toReplaceWith(lowPtGsfElectrons,_lowPtGsfElectrons)


### PR DESCRIPTION
#### PR description:
With CMSSW_10_2_26, we can't run RECO and PAT together (*). It seems the issue comes from 
https://github.com/cms-sw/cmssw/blob/CMSSW_10_6_X/RecoEgamma/EgammaElectronProducers/python/lowPtGsfElectrons_cff.py#L55
which seems to effect also RECO step. It normally works if we split between RECO and PAT, since we don't overwrite RECO lowPtGsfElectrons sequence.

This is the first try to make it runs together by moving modifier under PAT, and create tmp task for lowPtGsfElectron to avoid overlapping with RECO.

#### PR validation:
Run with the follow sequence works fine.
`cmsDriver.py RECO --conditions 106X_dataRun2_v35 --customise Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_2018 --datatier AOD,MINIAOD --era Run2_2018,bParking --eventcontent AOD,MINIAOD --filein 'file:/eos/cms/store/data/Run2018A/ParkingBPH1/RAW/v1/000/316/995/00000/FEF59114-4662-E811-8F37-FA163ECB370B.root' --fileout out.root --nThreads 8 --number 10 --scenario pp --step RAW2DIGI,L1Reco,RECO,PAT --runUnscheduled --data --procModifiers run2_miniAOD_UL --no_exec`

#### if this PR is a backport please specify the original PR and why you need to backport that PR:
This is the first PR in 10_6. Forward port can be done when agree on how to fix.

(*)
----- Begin Fatal Exception 15-Jun-2021 17:59:16 CEST-----------------------
An exception of category 'ProductNotFound' occurred while
   [0] Processing  Event run: 316995 lumi: 289 event: 436103054 stream: 4
   [1] Running path 'AODoutput_step'
   [2] Prefetching for module PoolOutputModule/'AODoutput'
   [3] Prefetching for module LowPtGsfElectronIDProducer/'lowPtGsfElectronID'
   [4] Calling method for module LowPtGsfElectronFinalizer/'lowPtGsfElectrons'
Exception Message:
Principal::getByToken: Found zero products matching all criteria
Looking for type: std::vector<reco::GsfElectron>
Looking for module label: lowPtGsfElectrons
Looking for productInstanceName: 

   Additional Info:
      [a] If you wish to continue processing events after a ProductNotFound exception,
add "SkipEvent = cms.untracked.vstring('ProductNotFound')" to the "options" PSet in the configuration.

----- End Fatal Exception -------------------------------------------------

