### PR TITLE
Allow specification of ES modules in ExternalGeneratorFilter

### DIFF
--- a/GeneratorInterface/Core/plugins/ExternalGeneratorFilter.cc
+++ b/GeneratorInterface/Core/plugins/ExternalGeneratorFilter.cc
@@ -206,6 +206,7 @@ private:
   std::string const config_;
   bool const verbose_;
   unsigned int waitTime_;
+  std::string const extraConfig_;
 
   //This is set at beginStream and used for globalBeginRun
   //The framework guarantees that non of those can happen concurrently
@@ -226,7 +227,8 @@ ExternalGeneratorFilter::ExternalGeneratorFilter(edm::ParameterSet const& iPSet)
       lumiInfoToken_{produces<GenLumiInfoProduct, edm::Transition::EndLuminosityBlock>()},
       config_{iPSet.getUntrackedParameter<std::string>("@python_config")},
       verbose_{iPSet.getUntrackedParameter<bool>("_external_process_verbose_")},
-      waitTime_{iPSet.getUntrackedParameter<unsigned int>("_external_process_waitTime_")} {}
+      waitTime_{iPSet.getUntrackedParameter<unsigned int>("_external_process_waitTime_")},
+      extraConfig_{iPSet.getUntrackedParameter<std::string>("_external_process_extraConfig_")} {}
 
 std::unique_ptr<externalgen::StreamCache> ExternalGeneratorFilter::beginStream(edm::StreamID iID) const {
   auto const label = moduleDescription().moduleLabel();
@@ -241,6 +243,10 @@ process = TestProcess()
   config += R"_(
 process.add_(cms.Service("InitRootHandlers", UnloadRootSigHandler=cms.untracked.bool(True)))
   )_";
+  if (not extraConfig_.empty()) {
+    config += "\n";
+    config += extraConfig_;
+  }
 
   auto cache = std::make_unique<externalgen::StreamCache>(config, iID.value(), verbose_, waitTime_);
   if (iID.value() == 0) {

--- a/GeneratorInterface/Core/python/ExternalGeneratorFilter.py
+++ b/GeneratorInterface/Core/python/ExternalGeneratorFilter.py
@@ -1,9 +1,11 @@
 import FWCore.ParameterSet.Config as cms
 
 class ExternalGeneratorFilter(cms.EDFilter):
-    def __init__(self, prod, _external_process_waitTime_ = cms.untracked.uint32(60), _external_process_verbose_ = cms.untracked.bool(False)):
+    def __init__(self, prod, _external_process_waitTime_ = cms.untracked.uint32(60), _external_process_verbose_ = cms.untracked.bool(False),
+                 _external_process_esModules_ = cms.vstring()):
         self.__dict__['_external_process_verbose_']=_external_process_verbose_
         self.__dict__['_external_process_waitTime_']=_external_process_waitTime_
+        self.__dict__['_external_process_esModules_'] = _external_process_esModules_
         self.__dict__['_prod'] = prod
         super(cms.EDFilter,self).__init__('ExternalGeneratorFilter')
     def __setattr__(self, name, value):
@@ -31,6 +33,13 @@ class ExternalGeneratorFilter(cms.EDFilter):
         newpset.addString(False,"@python_config", self._prod.dumpPython())
         newpset.addBool(False,"_external_process_verbose_", self._external_process_verbose_.value())
         newpset.addUInt32(False,"_external_process_waitTime_", self._external_process_waitTime_.value())
+        newpset.addVString(True, "_external_process_esModules_", self._external_process_esModules_.value())
+
+        extraConfig =''
+        for x in self._external_process_esModules_.value():
+            extraConfig += "process."+x+"="+parameterSet.getTopPSet_(x).dumpPython()
+            extraConfig += '\n'
+        newpset.addString(False, "_external_process_extraConfig_", extraConfig)
         self._prod.insertContentsInto(newpset)
         parameterSet.addPSet(True, self.nameInProcessDesc_(myname), newpset)
     def dumpPython(self, options=cms.PrintOptions()):
@@ -40,7 +49,8 @@ class ExternalGeneratorFilter(cms.EDFilter):
         result += "\n"+options.indentation() + self._prod.dumpPython(options)
         result +=options.indentation()+",\n"
         result += options.indentation() + "_external_process_waitTime_ = " + self._external_process_waitTime_.dumpPython(options) + ',\n'
-        result += options.indentation() + "_external_process_verbose_ = " + self._external_process_verbose_.dumpPython(options) + ','
+        result += options.indentation() + "_external_process_verbose_ = " + self._external_process_verbose_.dumpPython(options) + ',\n'
+        result += options.indentation() + "_external_process_esModules_ =" + self._external_process_esModules_.dumpPython(options) + ','
         options.unindent()
         result += "\n)\n"
         return result

--- a/GeneratorInterface/Core/python/ExternalGeneratorFilter.py
+++ b/GeneratorInterface/Core/python/ExternalGeneratorFilter.py
@@ -2,10 +2,10 @@ import FWCore.ParameterSet.Config as cms
 
 class ExternalGeneratorFilter(cms.EDFilter):
     def __init__(self, prod, _external_process_waitTime_ = cms.untracked.uint32(60), _external_process_verbose_ = cms.untracked.bool(False),
-                 _external_process_esModules_ = cms.vstring()):
+                 _external_process_components_ = cms.vstring()):
         self.__dict__['_external_process_verbose_']=_external_process_verbose_
         self.__dict__['_external_process_waitTime_']=_external_process_waitTime_
-        self.__dict__['_external_process_esModules_'] = _external_process_esModules_
+        self.__dict__['_external_process_components_'] = _external_process_components_
         self.__dict__['_prod'] = prod
         super(cms.EDFilter,self).__init__('ExternalGeneratorFilter')
     def __setattr__(self, name, value):
@@ -33,10 +33,10 @@ class ExternalGeneratorFilter(cms.EDFilter):
         newpset.addString(False,"@python_config", self._prod.dumpPython())
         newpset.addBool(False,"_external_process_verbose_", self._external_process_verbose_.value())
         newpset.addUInt32(False,"_external_process_waitTime_", self._external_process_waitTime_.value())
-        newpset.addVString(True, "_external_process_esModules_", self._external_process_esModules_.value())
+        newpset.addVString(True, "_external_process_components_", self._external_process_components_.value())
 
         extraConfig =''
-        for x in self._external_process_esModules_.value():
+        for x in self._external_process_components_.value():
             extraConfig += "process."+x+"="+parameterSet.getTopPSet_(x).dumpPython()
             extraConfig += '\n'
         newpset.addString(False, "_external_process_extraConfig_", extraConfig)
@@ -50,7 +50,7 @@ class ExternalGeneratorFilter(cms.EDFilter):
         result +=options.indentation()+",\n"
         result += options.indentation() + "_external_process_waitTime_ = " + self._external_process_waitTime_.dumpPython(options) + ',\n'
         result += options.indentation() + "_external_process_verbose_ = " + self._external_process_verbose_.dumpPython(options) + ',\n'
-        result += options.indentation() + "_external_process_esModules_ =" + self._external_process_esModules_.dumpPython(options) + ','
+        result += options.indentation() + "_external_process_components_ =" + self._external_process_components_.dumpPython(options) + ','
         options.unindent()
         result += "\n)\n"
         return result


### PR DESCRIPTION
#### PR description:

The parameter _external_process_esModules_ allows one to specify the names of ES modules which should be copied from the main process and started in the external process.

#### PR validation:

I locally copied the test config compare_external_generators_cfg.py and added the Tracer service via the parameter. The tracing showed up in the output from the external processes.

resolves makortel/framework#168