### PR TITLE
fix era modification of tau supplements for cases outside run2

### DIFF
--- a/PhysicsTools/NanoAOD/python/nano_cff.py
+++ b/PhysicsTools/NanoAOD/python/nano_cff.py
@@ -417,12 +417,11 @@ def nanoAOD_customizeCommon(process):
                                      jecPayload=nanoAOD_addDeepInfoAK8_switch.jecPayload)
     addTauIds_switch = cms.PSet(
         nanoAOD_addTauIds_switch = cms.untracked.bool(True),
-        nanoAOD_addBoostedTauIds_switch = cms.untracked.bool(False)
+        nanoAOD_addBoostedTauIds_switch = cms.untracked.bool(True)
     )
-    run2_miniAOD_80XLegacy.toModify(addTauIds_switch, nanoAOD_addTauIds_switch = False)
-    ((run2_nanoAOD_106Xv2 | run2_miniAOD_devel | run2_tau_ul_2016 | run2_tau_ul_2018) & \
-    (~(run2_nanoAOD_94X2016 | run2_nanoAOD_94XMiniAODv1 | run2_nanoAOD_94XMiniAODv2 | run2_nanoAOD_102Xv1 | run2_nanoAOD_106Xv1))).toModify(addTauIds_switch,
-                                                                                                                                           nanoAOD_addTauIds_switch = False, nanoAOD_addBoostedTauIds_switch = True)
+    from Configuration.ProcessModifiers.run2_miniAOD_UL_cff import run2_miniAOD_UL
+    (run2_miniAOD_80XLegacy | run2_miniAOD_UL | run2_tau_ul_2016 | run2_tau_ul_2018).toModify(addTauIds_switch, nanoAOD_addTauIds_switch = False)
+    (run2_nanoAOD_94X2016 | run2_nanoAOD_94XMiniAODv1 | run2_nanoAOD_94XMiniAODv2 | run2_nanoAOD_102Xv1 | run2_nanoAOD_106Xv1).toModify(addTauIds_switch, nanoAOD_addBoostedTauIds_switch = False)
     if addTauIds_switch.nanoAOD_addTauIds_switch:
         process = nanoAOD_addTauIds(process)
     if addTauIds_switch.nanoAOD_addBoostedTauIds_switch:

--- a/PhysicsTools/NanoAOD/python/nano_cff.py
+++ b/PhysicsTools/NanoAOD/python/nano_cff.py
@@ -419,9 +419,9 @@ def nanoAOD_customizeCommon(process):
         nanoAOD_addTauIds_switch = cms.untracked.bool(True),
         nanoAOD_addBoostedTauIds_switch = cms.untracked.bool(True)
     )
-    from Configuration.ProcessModifiers.run2_miniAOD_UL_cff import run2_miniAOD_UL
-    (run2_miniAOD_80XLegacy | run2_miniAOD_UL | run2_tau_ul_2016 | run2_tau_ul_2018).toModify(addTauIds_switch, nanoAOD_addTauIds_switch = False)
-    (run2_nanoAOD_94X2016 | run2_nanoAOD_94XMiniAODv1 | run2_nanoAOD_94XMiniAODv2 | run2_nanoAOD_102Xv1 | run2_nanoAOD_106Xv1).toModify(addTauIds_switch, nanoAOD_addBoostedTauIds_switch = False)
+    ((run2_nanoAOD_106Xv2 | run2_miniAOD_devel | run2_tau_ul_2016 | run2_tau_ul_2018) & \
+    (~(run2_nanoAOD_94X2016 | run2_nanoAOD_94XMiniAODv1 | run2_nanoAOD_94XMiniAODv2 | run2_nanoAOD_102Xv1 | run2_nanoAOD_106Xv1))).toModify(addTauIds_switch, nanoAOD_addTauIds_switch = False)
+    (run2_miniAOD_80XLegacy | run2_nanoAOD_92X | run2_nanoAOD_94X2016 | run2_nanoAOD_94XMiniAODv1 | run2_nanoAOD_94XMiniAODv2 | run2_nanoAOD_102Xv1 | run2_nanoAOD_106Xv1).toModify(addTauIds_switch, nanoAOD_addBoostedTauIds_switch = False)
     if addTauIds_switch.nanoAOD_addTauIds_switch:
         process = nanoAOD_addTauIds(process)
     if addTauIds_switch.nanoAOD_addBoostedTauIds_switch:


### PR DESCRIPTION
#### PR description:

Rearrange era modifiers that control which tau contents are calculated during nanoAOD production covering unavailabilities in miniAOD. Fixes behaviour outside run2.

resolves #33988


#### PR validation:

passed code checks and format
passed unit tests
passed limited matrix tests and 11824.0, 11825.0

