### PR TITLE
cleanup BuildFile, remove unnecessary deps

### DIFF
--- a/FWCore/ParameterSetReader/BuildFile.xml
+++ b/FWCore/ParameterSetReader/BuildFile.xml
@@ -2,5 +2,4 @@
 <use name="FWCore/PythonParameterSet"/>
 <export>
   <lib name="1"/>
-  <use name="py3-pybind11"/>
 </export>

--- a/FWCore/PyDevParameterSet/BuildFile.xml
+++ b/FWCore/PyDevParameterSet/BuildFile.xml
@@ -4,6 +4,5 @@
 <use name="py3-pybind11"/>
 <use name="python3"/>
 <export>
-  <use name="py3-pybind11"/>
   <lib name="1"/>
 </export>

--- a/FWCore/PythonParameterSet/BuildFile.xml
+++ b/FWCore/PythonParameterSet/BuildFile.xml
@@ -4,6 +4,5 @@
 <use name="py3-pybind11"/>
 <use name="python"/>
 <export>
-  <use name="py3-pybind11"/>
   <lib name="1"/>
 </export>


### PR DESCRIPTION
Cleanup BuildFiles, there is no need to have dependency explicitly exported via `<export></export>`