### PR TITLE
move InefficientDoubleROC.py script to python3

### DIFF
--- a/DQM/SiStripMonitorClient/scripts/InefficientDoubleROC.py
+++ b/DQM/SiStripMonitorClient/scripts/InefficientDoubleROC.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from __future__ import print_function
 import sys


### PR DESCRIPTION
Towards removing python2, I'm moving things that depend on scipy to python3.