### PR TITLE
[DQM/TrackerRemapper] add unit tests

### DIFF
--- a/Alignment/OfflineValidation/plugins/DMRChecker.cc
+++ b/Alignment/OfflineValidation/plugins/DMRChecker.cc
@@ -184,14 +184,10 @@ public:
 
     pixelmap = std::make_unique<Phase1PixelMaps>("COLZ0 L");
     pixelmap->bookBarrelHistograms("DMRsX", "Median Residuals x-direction", "Median Residuals");
-    pixelmap->bookBarrelBins("DMRsX");
     pixelmap->bookForwardHistograms("DMRsX", "Median Residuals x-direction", "Median Residuals");
-    pixelmap->bookForwardBins("DMRsX");
 
     pixelmap->bookBarrelHistograms("DMRsY", "Median Residuals y-direction", "Median Residuals");
-    pixelmap->bookBarrelBins("DMRsY");
     pixelmap->bookForwardHistograms("DMRsY", "Median Residuals y-direction", "Median Residuals");
-    pixelmap->bookForwardBins("DMRsY");
 
     // set no rescale
     pixelmap->setNoRescale();

--- a/Alignment/OfflineValidation/plugins/GeneralPurposeTrackAnalyzer.cc
+++ b/Alignment/OfflineValidation/plugins/GeneralPurposeTrackAnalyzer.cc
@@ -115,9 +115,7 @@ public:
 
     pixelmap = std::make_unique<Phase1PixelMaps>("COLZ0 L");
     pixelmap->bookBarrelHistograms("entriesBarrel", "# hits", "# pixel hits");
-    pixelmap->bookBarrelBins("entriesBarrel");
     pixelmap->bookForwardHistograms("entriesForward", "# hits", "# pixel hits");
-    pixelmap->bookForwardBins("entriesForward");
   }
 
   ~GeneralPurposeTrackAnalyzer() override {}

--- a/CondCore/SiPixelPlugins/interface/SiPixelTemplateHelper.h
+++ b/CondCore/SiPixelPlugins/interface/SiPixelTemplateHelper.h
@@ -337,13 +337,11 @@ namespace templateHelper {
         // Book the TH2Poly
         Phase1PixelMaps theMaps("text");
         if (myType == SiPixelPI::t_barrel) {
-          theMaps.bookBarrelHistograms(barrelName_, title_.c_str(), title_.c_str());
           // book the barrel bins of the TH2Poly
-          theMaps.bookBarrelBins(barrelName_);
+          theMaps.bookBarrelHistograms(barrelName_, title_.c_str(), title_.c_str());
         } else if (myType == SiPixelPI::t_forward) {
-          theMaps.bookForwardHistograms(endcapName_, title_.c_str(), title_.c_str());
           // book the forward bins of the TH2Poly
-          theMaps.bookForwardBins(endcapName_);
+          theMaps.bookForwardHistograms(endcapName_, title_.c_str(), title_.c_str());
         }
 
         std::map<unsigned int, short> templMap;

--- a/CondCore/SiPixelPlugins/plugins/SiPixelTemplateDBObject_PayloadInspector.cc
+++ b/CondCore/SiPixelPlugins/plugins/SiPixelTemplateDBObject_PayloadInspector.cc
@@ -179,15 +179,11 @@ namespace {
 
         if (myType == SiPixelPI::t_barrel) {
           theMaps.bookBarrelHistograms("templateLABarrel", "#muH", "#mu_{H} [1/T]");
-          theMaps.bookBarrelBins("templateLABarrel");
         } else if (myType == SiPixelPI::t_forward) {
           theMaps.bookForwardHistograms("templateLAForward", "#muH", "#mu_{H} [1/T]");
-          theMaps.bookForwardBins("templateLAForward");
         } else if (myType == SiPixelPI::t_all) {
           theMaps.bookBarrelHistograms("templateLA", "#muH", "#mu_{H} [1/T]");
-          theMaps.bookBarrelBins("templateLA");
           theMaps.bookForwardHistograms("templateLA", "#muH", "#mu_{H} [1/T]");
-          theMaps.bookForwardBins("templateLA");
         } else {
           edm::LogError("SiPixelTemplateDBObject_PayloadInspector")
               << " un-recognized detector type " << myType << std::endl;

--- a/DQM/TrackerRemapper/interface/Phase1PixelMaps.h
+++ b/DQM/TrackerRemapper/interface/Phase1PixelMaps.h
@@ -32,6 +32,7 @@ class Phase1PixelMaps {
 public:
   Phase1PixelMaps(const char* option)
       : m_option{option},
+        m_isBooked{std::make_pair(false, false)},
         m_trackerTopo{StandaloneTrackerTopology::fromTrackerParametersXMLFile(
             edm::FileInPath("Geometry/TrackerCommonData/data/PhaseI/trackerParameters.xml").fullPath())} {
     // set the rescale to true by default
@@ -56,11 +57,17 @@ public:
   // set option, but only if not already set
   void resetOption(const char* option);
 
+  // book them all
+  void book(const std::string& currentHistoName, const char* what, const char* zaxis);
+
   // booking methods
   void bookBarrelHistograms(const std::string& currentHistoName, const char* what, const char* zaxis);
   void bookForwardHistograms(const std::string& currentHistoName, const char* what, const char* zaxis);
   void bookBarrelBins(const std::string& currentHistoName);
   void bookForwardBins(const std::string& currentHistoName);
+
+  // fill them all
+  void fill(const std::string& currentHistoName, unsigned int id, double value);
 
   // filling methods
   void fillBarrelBin(const std::string& currentHistoName, unsigned int id, double value);
@@ -79,6 +86,7 @@ public:
 private:
   Option_t* m_option;
   bool m_autorescale;
+  std::pair<bool, bool> m_isBooked;
   TrackerTopology m_trackerTopo;
 
   std::map<uint32_t, std::shared_ptr<TGraph>> bins, binsSummary;

--- a/DQM/TrackerRemapper/interface/Phase1PixelMaps.h
+++ b/DQM/TrackerRemapper/interface/Phase1PixelMaps.h
@@ -63,8 +63,6 @@ public:
   // booking methods
   void bookBarrelHistograms(const std::string& currentHistoName, const char* what, const char* zaxis);
   void bookForwardHistograms(const std::string& currentHistoName, const char* what, const char* zaxis);
-  void bookBarrelBins(const std::string& currentHistoName);
-  void bookForwardBins(const std::string& currentHistoName);
 
   // fill them all
   void fill(const std::string& currentHistoName, unsigned int id, double value);
@@ -99,6 +97,10 @@ private:
   std::vector<edm::FileInPath> m_cornersFPIX;
 
   const indexedCorners retrieveCorners(const std::vector<edm::FileInPath>& cornerFiles, const unsigned int reads);
+
+  // called by book histograms
+  void bookBarrelBins(const std::string& currentHistoName);
+  void bookForwardBins(const std::string& currentHistoName);
 
   // graphics
   void makeNicePlotStyle(TH1* hist);

--- a/DQM/TrackerRemapper/interface/Phase1PixelMaps.h
+++ b/DQM/TrackerRemapper/interface/Phase1PixelMaps.h
@@ -33,6 +33,7 @@ public:
   Phase1PixelMaps(const char* option)
       : m_option{option},
         m_isBooked{std::make_pair(false, false)},
+        m_knownNames{{}},
         m_trackerTopo{StandaloneTrackerTopology::fromTrackerParametersXMLFile(
             edm::FileInPath("Geometry/TrackerCommonData/data/PhaseI/trackerParameters.xml").fullPath())} {
     // set the rescale to true by default
@@ -85,6 +86,8 @@ private:
   Option_t* m_option;
   bool m_autorescale;
   std::pair<bool, bool> m_isBooked;
+  std::vector<std::string> m_knownNames;
+
   TrackerTopology m_trackerTopo;
 
   std::map<uint32_t, std::shared_ptr<TGraph>> bins, binsSummary;

--- a/DQM/TrackerRemapper/interface/Phase1PixelROCMaps.h
+++ b/DQM/TrackerRemapper/interface/Phase1PixelROCMaps.h
@@ -72,6 +72,7 @@ public:
 
   bool isBarrel() { return (m_layer > 0); }
   bool isEndcap() { return (m_ring > 0); }
+  bool isFlipped() { return m_isFlipped; }
 };
 
 /*--------------------------------------------------------------------
@@ -120,6 +121,7 @@ public:
   ~Phase1PixelROCMaps() {}
 
   // Forward declarations
+  DetCoordinates findDetCoordinates(const uint32_t& t_detid);
   void fillWholeModule(const uint32_t& detid, double value);
   void fillSelectedRocs(const uint32_t& detid, const std::bitset<16>& theROCs, double value);
   void drawBarrelMaps(TCanvas& canvas, const std::string& text = "");
@@ -152,8 +154,6 @@ private:
   static constexpr const char* kVerbose = "verbose";
 
   // Forward declarations of private methods
-
-  DetCoordinates findDetCoordinates(const uint32_t& t_detid);
   std::vector<std::pair<int, int> > maskedBarrelRocsToBins(DetCoordinates coord);
   std::vector<std::tuple<int, int, int> > maskedBarrelRocsToBins(DetCoordinates coord, std::bitset<16> myRocs);
   std::vector<std::pair<int, int> > maskedForwardRocsToBins(DetCoordinates coord);

--- a/DQM/TrackerRemapper/src/Phase1PixelMaps.cc
+++ b/DQM/TrackerRemapper/src/Phase1PixelMaps.cc
@@ -59,6 +59,9 @@ void Phase1PixelMaps::bookBarrelHistograms(const std::string& currentHistoName, 
   th2p->SetOption(m_option);
   pxbTh2PolyBarrelSummary[currentHistoName] = th2p;
 
+  // book the bins
+  bookBarrelBins(currentHistoName);
+
   // set the isBooked bit to true;
   m_isBooked.first = true;
 }
@@ -99,6 +102,9 @@ void Phase1PixelMaps::bookForwardHistograms(const std::string& currentHistoName,
   th2p->SetStats(false);
   th2p->SetOption(m_option);
   pxfTh2PolyForwardSummary[currentHistoName] = th2p;
+
+  // book the bins
+  bookForwardBins(currentHistoName);
 
   m_isBooked.second = true;
 }

--- a/DQM/TrackerRemapper/test/BuildFile.xml
+++ b/DQM/TrackerRemapper/test/BuildFile.xml
@@ -1,8 +1,9 @@
 <bin file="test_catch2_*.cc" name="test_catch2_DQM_TRACKERREMAPPER">
   <use name="FWCore/Common"/>
-  <use name="CalibTracker/StandaloneTrackerTopology"/>
   <use name="DQM/TrackerRemapper"/>
+  <use name="CalibTracker/StandaloneTrackerTopology"/>
   <use name="CalibTracker/SiPixelESProducers"/>
+  <use name="CalibTracker/SiStripCommon"/>
   <use name="rootgraphics"/>
   <use name="root"/>
   <use name="catch2"/>

--- a/DQM/TrackerRemapper/test/BuildFile.xml
+++ b/DQM/TrackerRemapper/test/BuildFile.xml
@@ -1,0 +1,9 @@
+<bin file="test_catch2_*.cc" name="test_catch2_DQM_TRACKERREMAPPER">
+  <use name="FWCore/Common"/>
+  <use name="CalibTracker/StandaloneTrackerTopology"/>
+  <use name="DQM/TrackerRemapper"/>
+  <use name="CalibTracker/SiPixelESProducers"/>
+  <use name="rootgraphics"/>
+  <use name="root"/>
+  <use name="catch2"/>
+</bin>

--- a/DQM/TrackerRemapper/test/test_catch2_Phase1PixelMaps.cc
+++ b/DQM/TrackerRemapper/test/test_catch2_Phase1PixelMaps.cc
@@ -1,0 +1,48 @@
+#include "catch.hpp"
+#include <iostream>
+#include <numeric>      // std::accumulate
+#include "TCanvas.h"
+#include "DQM/TrackerRemapper/interface/Phase1PixelMaps.h"
+#include "CalibTracker/SiPixelESProducers/interface/SiPixelDetInfoFileReader.h"
+
+TEST_CASE("Phase1PixelMaps testing", "[Phase1PixelMaps]") {
+  //_____________________________________________________________
+  SECTION("Check barrel plotting") {
+    gStyle->SetOptStat(0);
+    Phase1PixelMaps theMap("");
+    TCanvas c = TCanvas("c", "c", 1200, 1200);
+    theMap.bookBarrelHistograms("mytest","test","test");
+    theMap.bookBarrelBins("mytest");
+    theMap.drawBarrelMaps("mytest",c,"colz0");
+    c.SaveAs("Phase1PixelMaps_barrel.png");
+    REQUIRE(true);
+  }
+
+  //_____________________________________________________________
+  SECTION("Check endcap plotting") {
+    gStyle->SetOptStat(0);
+    Phase1PixelMaps theMap("");
+    TCanvas c = TCanvas("c", "c", 1200, 1200);
+    theMap.bookForwardHistograms("mytest","test","test");
+    theMap.bookForwardBins("mytest");
+    theMap.drawForwardMaps("mytest",c,"colz0");
+    c.SaveAs("Phase1PixelMaps_endcap.png");
+    REQUIRE(true);
+  }
+
+  //_____________________________________________________________
+  SECTION("Check summary plotting") {
+    gStyle->SetOptStat(0);
+    Phase1PixelMaps theMap("");
+    TCanvas c = TCanvas("c", "c", 1200, 1200);
+    theMap.bookBarrelHistograms("mytest","test","test");
+    theMap.bookBarrelBins("mytest");
+    theMap.bookForwardHistograms("mytest","test","test");
+    theMap.bookForwardBins("mytest");
+    theMap.drawSummaryMaps("mytest",c);
+    c.SaveAs("Phase1PixelMaps_summary.png");
+    REQUIRE(true);
+  }
+
+
+}

--- a/DQM/TrackerRemapper/test/test_catch2_Phase1PixelMaps.cc
+++ b/DQM/TrackerRemapper/test/test_catch2_Phase1PixelMaps.cc
@@ -5,6 +5,8 @@
 #include "DQM/TrackerRemapper/interface/Phase1PixelMaps.h"
 #include "CalibTracker/SiPixelESProducers/interface/SiPixelDetInfoFileReader.h"
 
+static const std::string k_geo = "SLHCUpgradeSimulations/Geometry/data/PhaseI/PixelSkimmedGeometry_phase1.txt";
+
 TEST_CASE("Phase1PixelMaps testing", "[Phase1PixelMaps]") {
   //_____________________________________________________________
   SECTION("Check barrel plotting") {
@@ -14,7 +16,8 @@ TEST_CASE("Phase1PixelMaps testing", "[Phase1PixelMaps]") {
     theMap.bookBarrelHistograms("mytest", "test", "test");
     theMap.bookBarrelBins("mytest");
     theMap.drawBarrelMaps("mytest", c, "colz0");
-    c.SaveAs("Phase1PixelMaps_barrel.png");
+    theMap.beautifyAllHistograms();
+    c.SaveAs("Phase1PixelMaps_Barrel.png");
     REQUIRE(true);
   }
 
@@ -22,25 +25,27 @@ TEST_CASE("Phase1PixelMaps testing", "[Phase1PixelMaps]") {
   SECTION("Check endcap plotting") {
     gStyle->SetOptStat(0);
     Phase1PixelMaps theMap("");
-    TCanvas c = TCanvas("c", "c", 1200, 1200);
+    TCanvas c = TCanvas("c", "c", 1200, 800);
     theMap.bookForwardHistograms("mytest", "test", "test");
     theMap.bookForwardBins("mytest");
     theMap.drawForwardMaps("mytest", c, "colz0");
-    c.SaveAs("Phase1PixelMaps_endcap.png");
+    theMap.beautifyAllHistograms();
+    c.SaveAs("Phase1PixelMaps_Endcap.png");
     REQUIRE(true);
   }
 
   //_____________________________________________________________
   SECTION("Check summary plotting") {
     gStyle->SetOptStat(0);
-    Phase1PixelMaps theMap("");
-    TCanvas c = TCanvas("c", "c", 1200, 1200);
+    Phase1PixelMaps theMap("COLZA L");  // needed to not show the axis
+    TCanvas c = TCanvas("c", "c", 1200, 800);
     theMap.bookBarrelHistograms("mytest", "test", "test");
     theMap.bookBarrelBins("mytest");
     theMap.bookForwardHistograms("mytest", "test", "test");
     theMap.bookForwardBins("mytest");
+    theMap.beautifyAllHistograms();
     theMap.drawSummaryMaps("mytest", c);
-    c.SaveAs("Phase1PixelMaps_summary.png");
+    c.SaveAs("Phase1PixelMaps_Summary.png");
     REQUIRE(true);
   }
 
@@ -54,8 +59,7 @@ TEST_CASE("Phase1PixelMaps testing", "[Phase1PixelMaps]") {
     theMap.bookForwardHistograms("mytest", "test", "test");
     theMap.bookForwardBins("mytest");
 
-    SiPixelDetInfoFileReader reader_ = SiPixelDetInfoFileReader(
-        edm::FileInPath("SLHCUpgradeSimulations/Geometry/data/PhaseI/PixelSkimmedGeometry_phase1.txt").fullPath());
+    SiPixelDetInfoFileReader reader_ = SiPixelDetInfoFileReader(edm::FileInPath(k_geo).fullPath());
     const auto& detIds = reader_.getAllDetIds();
     int count = 0;
     for (const auto& it : detIds) {
@@ -67,9 +71,58 @@ TEST_CASE("Phase1PixelMaps testing", "[Phase1PixelMaps]") {
         theMap.fillForwardBin("mytest", it, count);
       }
     }
-
+    theMap.beautifyAllHistograms();
     theMap.drawSummaryMaps("mytest", c);
-    c.SaveAs("Phase1PixelMaps_summary_full.png");
+    c.SaveAs("Phase1PixelMaps_Summary_Filled.png");
+    REQUIRE(true);
+  }
+
+  //_____________________________________________________________
+  SECTION("Check summary filling V2") {
+    gStyle->SetOptStat(0);
+    gStyle->SetPalette(kRainBow);
+    Phase1PixelMaps theMap("COLZA L");
+
+    TCanvas c = TCanvas("c", "c", 1200, 800);
+    theMap.book("mytest", "module counts", "module counts");
+
+    SiPixelDetInfoFileReader reader_ = SiPixelDetInfoFileReader(edm::FileInPath(k_geo).fullPath());
+    const auto& detIds = reader_.getAllDetIds();
+    int count = 0;
+    for (const auto& it : detIds) {
+      count++;
+      theMap.fill("mytest", it, count);
+    }
+
+    theMap.beautifyAllHistograms();
+    theMap.drawSummaryMaps("mytest", c);
+    c.SaveAs("Phase1PixelMaps_Summary_Filled_V2.png");
+    REQUIRE(true);
+  }
+
+  //_____________________________________________________________
+  SECTION("Check summary filling V3") {
+    gStyle->SetOptStat(0);
+    gStyle->SetPalette(kBlackBody);
+    Phase1PixelMaps theMap("COLZA L");
+
+    TCanvas c = TCanvas("c", "c", 1200, 800);
+    theMap.book("mytest", "module counts", "module counts");
+
+    SiPixelDetInfoFileReader reader_ = SiPixelDetInfoFileReader(edm::FileInPath(k_geo).fullPath());
+    const auto& detIds = reader_.getAllDetIds();
+    int count = 0;
+    for (const auto& it : detIds) {
+      count++;
+      theMap.fill("mytest", it, count);
+    }
+
+    theMap.setNoRescale();
+    theMap.beautifyAllHistograms();
+    theMap.drawSummaryMaps("mytest", c);
+    theMap.setBarrelScale("mytest", std::make_pair(0., 100.));
+    theMap.setForwardScale("mytest", std::make_pair(0., 20.));
+    c.SaveAs("Phase1PixelMaps_Summary_Filled_V3.png");
     REQUIRE(true);
   }
 }

--- a/DQM/TrackerRemapper/test/test_catch2_Phase1PixelMaps.cc
+++ b/DQM/TrackerRemapper/test/test_catch2_Phase1PixelMaps.cc
@@ -13,7 +13,7 @@ TEST_CASE("Phase1PixelMaps testing", "[Phase1PixelMaps]") {
     gStyle->SetOptStat(0);
     Phase1PixelMaps theMap("");
     TCanvas c = TCanvas("c", "c", 1200, 1200);
-    theMap.bookBarrelHistograms("mytest", "test", "test");
+    theMap.bookBarrelHistograms("mytest", "test", "z-axis");
     theMap.drawBarrelMaps("mytest", c, "colz0");
     theMap.beautifyAllHistograms();
     c.SaveAs("Phase1PixelMaps_Barrel.png");
@@ -25,7 +25,7 @@ TEST_CASE("Phase1PixelMaps testing", "[Phase1PixelMaps]") {
     gStyle->SetOptStat(0);
     Phase1PixelMaps theMap("");
     TCanvas c = TCanvas("c", "c", 1200, 800);
-    theMap.bookForwardHistograms("mytest", "test", "test");
+    theMap.bookForwardHistograms("mytest", "test", "z-axis");
     theMap.drawForwardMaps("mytest", c, "colz0");
     theMap.beautifyAllHistograms();
     c.SaveAs("Phase1PixelMaps_Endcap.png");
@@ -35,10 +35,10 @@ TEST_CASE("Phase1PixelMaps testing", "[Phase1PixelMaps]") {
   //_____________________________________________________________
   SECTION("Check summary plotting") {
     gStyle->SetOptStat(0);
-    Phase1PixelMaps theMap("COLZA L");  // needed to not show the axis
+    Phase1PixelMaps theMap("textAL");  // needed to not show the axis
     TCanvas c = TCanvas("c", "c", 1200, 800);
-    theMap.bookBarrelHistograms("mytest", "test", "test");
-    theMap.bookForwardHistograms("mytest", "test", "test");
+    theMap.bookBarrelHistograms("mytest", "test", "z-axis");
+    theMap.bookForwardHistograms("mytest", "test", "z-axis");
     theMap.beautifyAllHistograms();
     theMap.drawSummaryMaps("mytest", c);
     c.SaveAs("Phase1PixelMaps_Summary.png");
@@ -50,8 +50,8 @@ TEST_CASE("Phase1PixelMaps testing", "[Phase1PixelMaps]") {
     gStyle->SetOptStat(0);
     Phase1PixelMaps theMap("COLZA L");
     TCanvas c = TCanvas("c", "c", 1200, 800);
-    theMap.bookBarrelHistograms("mytest", "test", "test");
-    theMap.bookForwardHistograms("mytest", "test", "test");
+    theMap.bookBarrelHistograms("mytest", "test", "z-axis");
+    theMap.bookForwardHistograms("mytest", "test", "z-axis");
 
     SiPixelDetInfoFileReader reader_ = SiPixelDetInfoFileReader(edm::FileInPath(k_geo).fullPath());
     const auto& detIds = reader_.getAllDetIds();

--- a/DQM/TrackerRemapper/test/test_catch2_Phase1PixelMaps.cc
+++ b/DQM/TrackerRemapper/test/test_catch2_Phase1PixelMaps.cc
@@ -14,7 +14,6 @@ TEST_CASE("Phase1PixelMaps testing", "[Phase1PixelMaps]") {
     Phase1PixelMaps theMap("");
     TCanvas c = TCanvas("c", "c", 1200, 1200);
     theMap.bookBarrelHistograms("mytest", "test", "test");
-    theMap.bookBarrelBins("mytest");
     theMap.drawBarrelMaps("mytest", c, "colz0");
     theMap.beautifyAllHistograms();
     c.SaveAs("Phase1PixelMaps_Barrel.png");
@@ -27,7 +26,6 @@ TEST_CASE("Phase1PixelMaps testing", "[Phase1PixelMaps]") {
     Phase1PixelMaps theMap("");
     TCanvas c = TCanvas("c", "c", 1200, 800);
     theMap.bookForwardHistograms("mytest", "test", "test");
-    theMap.bookForwardBins("mytest");
     theMap.drawForwardMaps("mytest", c, "colz0");
     theMap.beautifyAllHistograms();
     c.SaveAs("Phase1PixelMaps_Endcap.png");
@@ -40,9 +38,7 @@ TEST_CASE("Phase1PixelMaps testing", "[Phase1PixelMaps]") {
     Phase1PixelMaps theMap("COLZA L");  // needed to not show the axis
     TCanvas c = TCanvas("c", "c", 1200, 800);
     theMap.bookBarrelHistograms("mytest", "test", "test");
-    theMap.bookBarrelBins("mytest");
     theMap.bookForwardHistograms("mytest", "test", "test");
-    theMap.bookForwardBins("mytest");
     theMap.beautifyAllHistograms();
     theMap.drawSummaryMaps("mytest", c);
     c.SaveAs("Phase1PixelMaps_Summary.png");
@@ -55,9 +51,7 @@ TEST_CASE("Phase1PixelMaps testing", "[Phase1PixelMaps]") {
     Phase1PixelMaps theMap("COLZA L");
     TCanvas c = TCanvas("c", "c", 1200, 800);
     theMap.bookBarrelHistograms("mytest", "test", "test");
-    theMap.bookBarrelBins("mytest");
     theMap.bookForwardHistograms("mytest", "test", "test");
-    theMap.bookForwardBins("mytest");
 
     SiPixelDetInfoFileReader reader_ = SiPixelDetInfoFileReader(edm::FileInPath(k_geo).fullPath());
     const auto& detIds = reader_.getAllDetIds();

--- a/DQM/TrackerRemapper/test/test_catch2_Phase1PixelMaps.cc
+++ b/DQM/TrackerRemapper/test/test_catch2_Phase1PixelMaps.cc
@@ -1,6 +1,6 @@
 #include "catch.hpp"
 #include <iostream>
-#include <numeric>      // std::accumulate
+#include <numeric>  // std::accumulate
 #include "TCanvas.h"
 #include "DQM/TrackerRemapper/interface/Phase1PixelMaps.h"
 #include "CalibTracker/SiPixelESProducers/interface/SiPixelDetInfoFileReader.h"
@@ -11,9 +11,9 @@ TEST_CASE("Phase1PixelMaps testing", "[Phase1PixelMaps]") {
     gStyle->SetOptStat(0);
     Phase1PixelMaps theMap("");
     TCanvas c = TCanvas("c", "c", 1200, 1200);
-    theMap.bookBarrelHistograms("mytest","test","test");
+    theMap.bookBarrelHistograms("mytest", "test", "test");
     theMap.bookBarrelBins("mytest");
-    theMap.drawBarrelMaps("mytest",c,"colz0");
+    theMap.drawBarrelMaps("mytest", c, "colz0");
     c.SaveAs("Phase1PixelMaps_barrel.png");
     REQUIRE(true);
   }
@@ -23,9 +23,9 @@ TEST_CASE("Phase1PixelMaps testing", "[Phase1PixelMaps]") {
     gStyle->SetOptStat(0);
     Phase1PixelMaps theMap("");
     TCanvas c = TCanvas("c", "c", 1200, 1200);
-    theMap.bookForwardHistograms("mytest","test","test");
+    theMap.bookForwardHistograms("mytest", "test", "test");
     theMap.bookForwardBins("mytest");
-    theMap.drawForwardMaps("mytest",c,"colz0");
+    theMap.drawForwardMaps("mytest", c, "colz0");
     c.SaveAs("Phase1PixelMaps_endcap.png");
     REQUIRE(true);
   }
@@ -35,14 +35,41 @@ TEST_CASE("Phase1PixelMaps testing", "[Phase1PixelMaps]") {
     gStyle->SetOptStat(0);
     Phase1PixelMaps theMap("");
     TCanvas c = TCanvas("c", "c", 1200, 1200);
-    theMap.bookBarrelHistograms("mytest","test","test");
+    theMap.bookBarrelHistograms("mytest", "test", "test");
     theMap.bookBarrelBins("mytest");
-    theMap.bookForwardHistograms("mytest","test","test");
+    theMap.bookForwardHistograms("mytest", "test", "test");
     theMap.bookForwardBins("mytest");
-    theMap.drawSummaryMaps("mytest",c);
+    theMap.drawSummaryMaps("mytest", c);
     c.SaveAs("Phase1PixelMaps_summary.png");
     REQUIRE(true);
   }
 
+  //_____________________________________________________________
+  SECTION("Check summary filling") {
+    gStyle->SetOptStat(0);
+    Phase1PixelMaps theMap("COLZA L");
+    TCanvas c = TCanvas("c", "c", 1200, 800);
+    theMap.bookBarrelHistograms("mytest", "test", "test");
+    theMap.bookBarrelBins("mytest");
+    theMap.bookForwardHistograms("mytest", "test", "test");
+    theMap.bookForwardBins("mytest");
 
+    SiPixelDetInfoFileReader reader_ = SiPixelDetInfoFileReader(
+        edm::FileInPath("SLHCUpgradeSimulations/Geometry/data/PhaseI/PixelSkimmedGeometry_phase1.txt").fullPath());
+    const auto& detIds = reader_.getAllDetIds();
+    int count = 0;
+    for (const auto& it : detIds) {
+      count++;
+      int subid = DetId(it).subdetId();
+      if (subid == PixelSubdetector::PixelBarrel) {
+        theMap.fillBarrelBin("mytest", it, count);
+      } else if (subid == PixelSubdetector::PixelEndcap) {
+        theMap.fillForwardBin("mytest", it, count);
+      }
+    }
+
+    theMap.drawSummaryMaps("mytest", c);
+    c.SaveAs("Phase1PixelMaps_summary_full.png");
+    REQUIRE(true);
+  }
 }

--- a/DQM/TrackerRemapper/test/test_catch2_Phase1PixelROCMaps.cc
+++ b/DQM/TrackerRemapper/test/test_catch2_Phase1PixelROCMaps.cc
@@ -1,0 +1,155 @@
+#include "catch.hpp"
+#include <iostream>
+#include <numeric>  // std::accumulate
+#include "TCanvas.h"
+#include "DQM/TrackerRemapper/interface/Phase1PixelROCMaps.h"
+#include "CalibTracker/SiPixelESProducers/interface/SiPixelDetInfoFileReader.h"
+
+TEST_CASE("Phase1PixelROCMaps testing", "[Phase1PixelROCMaps]") {
+  //_____________________________________________________________
+  SECTION("Check barrel plotting") {
+    gStyle->SetOptStat(0);
+    Phase1PixelROCMaps theMap("");
+    TCanvas c = TCanvas("c", "c", 1200, 1200);
+    theMap.drawBarrelMaps(c, "testing barrel");
+    c.SaveAs("Phase1PixelROCMaps_barrel.png");
+    REQUIRE(theMap.getLayerMaps().size() == 4);
+  }
+
+  //_____________________________________________________________
+  SECTION("Check endcap plotting") {
+    gStyle->SetOptStat(0);
+    Phase1PixelROCMaps theMap("");
+    TCanvas c = TCanvas("c", "c", 1200, 600);
+    theMap.drawForwardMaps(c, "testing endcaps");
+    c.SaveAs("Phase1PixelROCMaps_endcap.png");
+    REQUIRE(theMap.getRingMaps().size() == 2);
+  }
+
+  //_____________________________________________________________
+  SECTION("Check whole detector plotting") {
+    gStyle->SetOptStat(0);
+    Phase1PixelROCMaps theMap("");
+    TCanvas c = TCanvas("c", "c", 1200, 1600);
+    theMap.drawMaps(c, "testing everything");
+    c.SaveAs("Phase1PixelROCMaps_whole.png");
+    REQUIRE(theMap.getLayerMaps().size() == 4);
+    REQUIRE(theMap.getRingMaps().size() == 2);
+  }
+
+  //_____________________________________________________________
+  SECTION("Check filling whole modules") {
+    Phase1PixelROCMaps theMap("");
+    gStyle->SetOptStat(0);
+    TCanvas c = TCanvas("c", "c", 1200, 1600);
+    SiPixelDetInfoFileReader reader_ = SiPixelDetInfoFileReader(
+        edm::FileInPath("SLHCUpgradeSimulations/Geometry/data/PhaseI/PixelSkimmedGeometry_phase1.txt").fullPath());
+    const auto& detIds = reader_.getAllDetIds();
+    for (const auto& it : detIds) {
+      int subid = DetId(it).subdetId();
+      if (subid == PixelSubdetector::PixelBarrel) {
+        int module = theMap.findDetCoordinates(it).m_s_module;
+        if (module % 2 == 0) {
+          theMap.fillWholeModule(it, 1.);
+        } else {
+          theMap.fillWholeModule(it, -1.);
+        }
+      } else if (subid == PixelSubdetector::PixelEndcap) {
+        int panel = theMap.findDetCoordinates(it).m_panel;
+        if (panel % 2 == 0) {
+          theMap.fillWholeModule(it, 1.);
+        } else {
+          theMap.fillWholeModule(it, -1.);
+        }
+      }
+    }
+    theMap.drawMaps(c, "testing whole modules");
+    c.SaveAs("Phase1PixelROCMaps_fullModules.png");
+
+    int totalEntries = 0;
+    const auto layerMaps = theMap.getLayerMaps();
+    const auto ringMaps = theMap.getRingMaps();
+
+    int nBarrel = std::accumulate(layerMaps.begin(), layerMaps.end(), 0, [](int a, const std::shared_ptr<TH2> h) {
+      return a += h.get()->GetEntries();
+    });
+
+    int nForward = std::accumulate(ringMaps.begin(), ringMaps.end(), 0, [](int a, const std::shared_ptr<TH2> h) {
+      return a += h.get()->GetEntries();
+    });
+
+    totalEntries = nBarrel + nForward;
+    // this must equal the total number of modules (1856) time the ROC/module (16)
+    REQUIRE(totalEntries == (1856 * 16));
+  }
+
+  //_____________________________________________________________
+  SECTION("Check filling in delta mode") {
+    Phase1PixelROCMaps theMap("", "#Delta: flipped vs unflipped");
+    gStyle->SetOptStat(0);
+    TCanvas c = TCanvas("c", "c", 1200, 1600);
+    SiPixelDetInfoFileReader reader_ = SiPixelDetInfoFileReader(
+        edm::FileInPath("SLHCUpgradeSimulations/Geometry/data/PhaseI/PixelSkimmedGeometry_phase1.txt").fullPath());
+    const auto& detIds = reader_.getAllDetIds();
+    for (const auto& it : detIds) {
+      bool isFlipped = theMap.findDetCoordinates(it).isFlipped();
+      theMap.fillWholeModule(it, isFlipped ? 1. : -1);
+    }
+    theMap.drawMaps(c, "testing #Delta mode");
+    c.SaveAs("Phase1PixelROCMaps_deltaMode.png");
+
+    int totalEntries = 0;
+    const auto layerMaps = theMap.getLayerMaps();
+    const auto ringMaps = theMap.getRingMaps();
+
+    int nBarrel = std::accumulate(layerMaps.begin(), layerMaps.end(), 0, [](int a, const std::shared_ptr<TH2> h) {
+      return a += h.get()->GetEntries();
+    });
+
+    int nForward = std::accumulate(ringMaps.begin(), ringMaps.end(), 0, [](int a, const std::shared_ptr<TH2> h) {
+      return a += h.get()->GetEntries();
+    });
+
+    totalEntries = nBarrel + nForward;
+    // this must equal the total number of modules (1856) time the ROC/module (16)
+    REQUIRE(totalEntries == (1856 * 16));
+  }
+
+  //_____________________________________________________________
+  SECTION("Check filling selected ROCs") {
+    Phase1PixelROCMaps theMap("");
+    gStyle->SetOptStat(0);
+    TCanvas c = TCanvas("c", "c", 1200, 1600);
+    SiPixelDetInfoFileReader reader_ = SiPixelDetInfoFileReader(
+        edm::FileInPath("SLHCUpgradeSimulations/Geometry/data/PhaseI/PixelSkimmedGeometry_phase1.txt").fullPath());
+    const auto& detIds = reader_.getAllDetIds();
+    for (const auto& it : detIds) {
+      for (unsigned i = 0; i < 16; i++) {
+        std::bitset<16> bad_rocs;
+        bad_rocs.set(i);
+        theMap.fillSelectedRocs(it, bad_rocs, i);
+      }
+      //std::bitset<16> bad_rocs(it >> 2);
+      //theMap.fillSelectedRocs(it, bad_rocs, 1.);
+    }
+
+    int totalEntries = 0;
+    const auto layerMaps = theMap.getLayerMaps();
+    const auto ringMaps = theMap.getRingMaps();
+
+    int nBarrel = std::accumulate(layerMaps.begin(), layerMaps.end(), 0, [](int a, const std::shared_ptr<TH2> h) {
+      return a += h.get()->GetEntries();
+    });
+
+    int nForward = std::accumulate(ringMaps.begin(), ringMaps.end(), 0, [](int a, const std::shared_ptr<TH2> h) {
+      return a += h.get()->GetEntries();
+    });
+
+    totalEntries = nBarrel + nForward;
+
+    theMap.drawMaps(c, "testing selected ROCs");
+    c.SaveAs("Phase1PixelROCMaps_fullROCs.png");
+    // this must equal the total number of modules (1856) time the ROC/module (16)
+    REQUIRE(totalEntries == (1856 * 16));
+  }
+}

--- a/DQM/TrackerRemapper/test/test_catch2_Phase1PixelROCMaps.cc
+++ b/DQM/TrackerRemapper/test/test_catch2_Phase1PixelROCMaps.cc
@@ -5,6 +5,8 @@
 #include "DQM/TrackerRemapper/interface/Phase1PixelROCMaps.h"
 #include "CalibTracker/SiPixelESProducers/interface/SiPixelDetInfoFileReader.h"
 
+static const std::string k_geo = "SLHCUpgradeSimulations/Geometry/data/PhaseI/PixelSkimmedGeometry_phase1.txt";
+
 TEST_CASE("Phase1PixelROCMaps testing", "[Phase1PixelROCMaps]") {
   //_____________________________________________________________
   SECTION("Check barrel plotting") {
@@ -42,8 +44,7 @@ TEST_CASE("Phase1PixelROCMaps testing", "[Phase1PixelROCMaps]") {
     Phase1PixelROCMaps theMap("");
     gStyle->SetOptStat(0);
     TCanvas c = TCanvas("c", "c", 1200, 1600);
-    SiPixelDetInfoFileReader reader_ = SiPixelDetInfoFileReader(
-        edm::FileInPath("SLHCUpgradeSimulations/Geometry/data/PhaseI/PixelSkimmedGeometry_phase1.txt").fullPath());
+    SiPixelDetInfoFileReader reader_ = SiPixelDetInfoFileReader(edm::FileInPath(k_geo).fullPath());
     const auto& detIds = reader_.getAllDetIds();
     for (const auto& it : detIds) {
       int subid = DetId(it).subdetId();
@@ -88,8 +89,7 @@ TEST_CASE("Phase1PixelROCMaps testing", "[Phase1PixelROCMaps]") {
     Phase1PixelROCMaps theMap("", "#Delta: flipped vs unflipped");
     gStyle->SetOptStat(0);
     TCanvas c = TCanvas("c", "c", 1200, 1600);
-    SiPixelDetInfoFileReader reader_ = SiPixelDetInfoFileReader(
-        edm::FileInPath("SLHCUpgradeSimulations/Geometry/data/PhaseI/PixelSkimmedGeometry_phase1.txt").fullPath());
+    SiPixelDetInfoFileReader reader_ = SiPixelDetInfoFileReader(edm::FileInPath(k_geo).fullPath());
     const auto& detIds = reader_.getAllDetIds();
     for (const auto& it : detIds) {
       bool isFlipped = theMap.findDetCoordinates(it).isFlipped();
@@ -120,8 +120,7 @@ TEST_CASE("Phase1PixelROCMaps testing", "[Phase1PixelROCMaps]") {
     Phase1PixelROCMaps theMap("");
     gStyle->SetOptStat(0);
     TCanvas c = TCanvas("c", "c", 1200, 1600);
-    SiPixelDetInfoFileReader reader_ = SiPixelDetInfoFileReader(
-        edm::FileInPath("SLHCUpgradeSimulations/Geometry/data/PhaseI/PixelSkimmedGeometry_phase1.txt").fullPath());
+    SiPixelDetInfoFileReader reader_ = SiPixelDetInfoFileReader(edm::FileInPath(k_geo).fullPath());
     const auto& detIds = reader_.getAllDetIds();
     for (const auto& it : detIds) {
       for (unsigned i = 0; i < 16; i++) {

--- a/DQM/TrackerRemapper/test/test_catch2_Phase1PixelSummaryMap.cc
+++ b/DQM/TrackerRemapper/test/test_catch2_Phase1PixelSummaryMap.cc
@@ -1,0 +1,28 @@
+#include "catch.hpp"
+#include <iostream>
+#include <numeric>  // std::accumulate
+#include "TCanvas.h"
+#include "DQM/TrackerRemapper/interface/Phase1PixelSummaryMap.h"
+#include "CalibTracker/SiPixelESProducers/interface/SiPixelDetInfoFileReader.h"
+
+static const std::string k_geo = "SLHCUpgradeSimulations/Geometry/data/PhaseI/PixelSkimmedGeometry_phase1.txt";
+
+TEST_CASE("Phase1PixelSummaryMap testing", "[Phase1PixelSummaryMap]") {
+  //_____________________________________________________________
+  SECTION("Check Phase1Pixel Summary plotting") {
+    gStyle->SetOptStat(0);
+    Phase1PixelSummaryMap theMap("colz", "test", "testing");
+    theMap.createTrackerBaseMap();
+    SiPixelDetInfoFileReader reader_ = SiPixelDetInfoFileReader(edm::FileInPath(k_geo).fullPath());
+    const auto& detIds = reader_.getAllDetIds();
+    int count = 0;
+    for (const auto& it : detIds) {
+      count++;
+      theMap.fillTrackerMap(it, count);
+    }
+    TCanvas c = TCanvas("c", "c", 1200, 1200);
+    theMap.printTrackerMap(c);
+    c.SaveAs("Phase1PixelSummaryMap.png");
+    REQUIRE(true);
+  }
+}

--- a/DQM/TrackerRemapper/test/test_catch2_SiStripTkMaps.cc
+++ b/DQM/TrackerRemapper/test/test_catch2_SiStripTkMaps.cc
@@ -1,0 +1,31 @@
+#include "catch.hpp"
+#include <iostream>
+#include <numeric>  // std::accumulate
+#include "TCanvas.h"
+#include "DQM/TrackerRemapper/interface/SiStripTkMaps.h"
+#include "CalibTracker/SiStripCommon/interface/SiStripDetInfoFileReader.h"
+
+static const std::string k_geo = "CalibTracker/SiStripCommon/data/SiStripDetInfo.dat";
+
+TEST_CASE("SiStripTkMaps testing", "[SiStripTkMaps]") {
+  //_____________________________________________________________
+  SECTION("Check SiStrip Tk Maps plotting") {
+    gStyle->SetOptStat(0);
+    SiStripTkMaps theMap("COLZA L");
+    theMap.bookMap("testing SiStripTkMaps", "counts");
+    SiStripDetInfoFileReader reader_ = SiStripDetInfoFileReader(edm::FileInPath(k_geo).fullPath());
+    const std::map<uint32_t, SiStripDetInfoFileReader::DetInfo>& DetInfos = reader_.getAllData();
+    int count = 0;
+    for (const auto& it : DetInfos) {
+      count++;
+      theMap.fill(it.first, count);
+    }
+
+    const auto filledIds = theMap.getTheFilledIds();
+    TCanvas c = TCanvas("c", "c");
+    theMap.drawMap(c, "");
+    c.SaveAs("SiStripsTkMaps.png");
+    std::cout << "SiStripTkMaps filled " << filledIds.size() << " DetIds" << std::endl;
+    REQUIRE(filledIds.size() == count);
+  }
+}

--- a/DQM/TrackerRemapper/test/test_catch2_main.cc
+++ b/DQM/TrackerRemapper/test/test_catch2_main.cc
@@ -1,0 +1,2 @@
+#define CATCH_CONFIG_MAIN  // This tells Catch to provide a main() - only do this in one cpp file
+#include "catch.hpp"


### PR DESCRIPTION
#### PR description:

The main goal of this PR is to provide catch2 unit test for the classes in the package `DQM/TrackerRemapper` 
Additionally some technical commits are added:
   * refactor code of `Phase1PixelMaps` to check if histograms are booked (ce77cf9 )
   * merge `bookBarrelBins` and `bookForwardBins` with` bookBarrelHistograms` and `bookForwardHistograms` respectively, and propagate it to dependencies (ae32d30)
   * add checks in `Phase1PixelMaps` about the histograms being booked (2b8b5bb )

#### PR validation:

Run the augmented unit tests.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This PR is not a backport and no backport is needed. 
