### PR TITLE
Fix use of EDAlias on 'source'

### DIFF
--- a/FWCore/Framework/src/EDConsumerBase.cc
+++ b/FWCore/Framework/src/EDConsumerBase.cc
@@ -450,6 +450,10 @@ namespace {
             modules.push_back(it->second);
           }
           foundInLabelsToDesc = true;
+        } else {
+          if (label == "source") {
+            foundInLabelsToDesc = true;
+          }
         }
       }
       if (foundInLabelsToDesc) {

--- a/FWCore/Integration/test/BuildFile.xml
+++ b/FWCore/Integration/test/BuildFile.xml
@@ -447,4 +447,6 @@
   <test name="TestFWCoreIntegrationInterProcess" command="cmsRun ${LOCALTOP}/src/FWCore/Integration/test/test_TestInterProcessProd_cfg.py"/>
 
   <test name="TestFWCoreIntegrationPutOrMerge" command="cmsRun ${LOCALTOP}/src/FWCore/Integration/test/putOrMergeTest_cfg.py"/>
+
+  <test name="TestFWCoreIntegrationInputSourceAlias" command="cmsRun ${LOCALTOP}//src/FWCore/Integration/test/inputSource_alias_Test_cfg.py"/>
 </environment>

--- a/FWCore/Integration/test/inputSource_alias_Test_cfg.py
+++ b/FWCore/Integration/test/inputSource_alias_Test_cfg.py
@@ -1,0 +1,23 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("TEST")
+
+process.load("FWCore.Framework.test.cmsExceptionsFatal_cff")
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(2)
+)
+
+process.source = cms.Source("ThingSource"
+)
+
+process.thing = cms.EDAlias(source = cms.VPSet( cms.PSet( type = cms.string("edmtestThings")) ) )
+
+
+process.OtherThing = cms.EDProducer("OtherThingProducer",
+    thingTag = cms.InputTag('thing')
+)
+
+process.Analysis = cms.EDAnalyzer("OtherThingAnalyzer")
+
+process.p = cms.Path(process.OtherThing * process.Analysis)


### PR DESCRIPTION

#### PR description:

Sources which assign the label 'source' to their data products can now properly be handled by EDAlias.

#### PR validation:

Code compiles and newly added test passes.

solves #34157
solves makortel/framework#171