### PR TITLE
Update GEMRECO geometry in online GTs

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -34,13 +34,13 @@ autoCond = {
     # GlobalTag for Run2 HI data
     'run2_data_promptlike_hi'      : '113X_dataRun2_PromptLike_HI_v6',
     # GlobalTag for Run3 HLT: it points to the online GT
-    'run3_hlt'                     : '113X_dataRun3_HLT_v1',
+    'run3_hlt'                     : '113X_dataRun3_HLT_v2',
     # GlobalTag with fixed snapshot time for Run2 HLT RelVals: customizations to run with fixed L1 Menu
-    'run2_hlt_relval'              : '113X_dataRun2_HLT_relval_v1',
+    'run2_hlt_relval'              : '113X_dataRun2_HLT_relval_v2',
     # GlobalTag for Run3 data relvals (express GT)
-    'run3_data_express'            : '113X_dataRun3_Express_v1',
+    'run3_data_express'            : '113X_dataRun3_Express_v3',
     # GlobalTag for Run3 data relvals
-    'run3_data_prompt'             : '113X_dataRun3_Prompt_v1',
+    'run3_data_prompt'             : '113X_dataRun3_Prompt_v3',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,~0-centred beamspot)
     'phase1_2017_design'           : '113X_mc2017_design_v5',
     # GlobalTag for MC production with realistic conditions for Phase1 2017 detector


### PR DESCRIPTION
#### PR description:
Update online GTs with a new GEMRECO geometry  tag used in MWGR#4 (June 2021), as detailed in https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/4408.html and https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/4410.html. The new GEMRECO geometry tag ([`GEMRECO_Geometry_v2_hlt`](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/tags/GEMRECO_Geometry_v2_hlt)) contains a payload valid from 11_3_X which has been appended 
with since 341787.

GT diffs:
**Run 3 data HLT**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/113X_dataRun3_HLT_v1/113X_dataRun3_HLT_v2

**Run 2 HLT RelVals**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/113X_dataRun2_HLT_relval_v1/113X_dataRun2_HLT_relval_v2

**Run 3 data (express)**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/113X_dataRun3_Express_v1/113X_dataRun3_Express_v3

**Run 3 data (prompt)**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/113X_dataRun3_Prompt_v1/113X_dataRun3_Prompt_v3


#### PR validation:
Tested with:
```
runTheMatrix.py -l 138.1,138.2 --ibeos -j4
addOnTests.py -j8
```

#### Backport:
A backport for 11_3_X will be provided