### PR TITLE
[DD4hep] DDDetector ES producer from DB 

### DIFF
--- a/DetectorDescription/Core/interface/DDSolid.h
+++ b/DetectorDescription/Core/interface/DDSolid.h
@@ -69,6 +69,17 @@ private:
   DDSolid(const DDName&, DDSolidShape, const std::vector<double>&);
 };
 
+//! Interface to an Assembly
+/**
+   The definition of an Assembly is
+   the same as in Geant4.
+*/
+class DDAssembly : public DDSolid {
+public:
+  DDAssembly(const DDSolid& s);
+  DDAssembly(void) = delete;
+};
+
 //! Interface to a Trapezoid
 /**
    The definition (parameters, local frame) of the Trapezoid is 
@@ -387,6 +398,9 @@ public:
 // Solid generation functions
 //
 struct DDSolidFactory {
+  //! Creates an assembly
+  static DDSolid assembly(const DDName& name);
+
   //! Creates a box with side length 2*xHalf, 2*yHalf, 2*zHalf
   /** \arg \c name unique name identifying the box
       \arg \c xHalf half length in x 

--- a/DetectorDescription/Core/interface/DDSolidShapes.h
+++ b/DetectorDescription/Core/interface/DDSolidShapes.h
@@ -24,6 +24,7 @@ enum class DDSolidShape {
   ddellipticaltube = 17,
   ddcuttubs = 18,
   ddextrudedpolygon = 19,
+  ddassembly = 20,
 };
 
 std::ostream& operator<<(std::ostream& os, const DDSolidShape s);
@@ -49,7 +50,8 @@ struct DDSolidShapesName {
                                          "Sphere(section)",
                                          "EllipticalTube",
                                          "CutTubs",
-                                         "ExtrudedPolygon"};
+                                         "ExtrudedPolygon",
+                                         "Assembly"};
 
     return _names[static_cast<int>(s)];
   }

--- a/DetectorDescription/Core/interface/Store.h
+++ b/DetectorDescription/Core/interface/Store.h
@@ -66,11 +66,11 @@ namespace DDI {
 
     Store() : readOnly_(false) {}
     ~Store();
+    Store(const Store&) = delete;
+    Store& operator=(const Store&) = delete;
 
   protected:
     std::map<name_type, prep_type> reg_;
-    Store(const Store&) = delete;
-    Store& operator=(const Store&) = delete;
     bool readOnly_;
   };
 

--- a/DetectorDescription/Core/python/test/DDAssemblyXML_cfi.py
+++ b/DetectorDescription/Core/python/test/DDAssemblyXML_cfi.py
@@ -1,0 +1,8 @@
+import FWCore.ParameterSet.Config as cms
+
+XMLIdealGeometryESSource = cms.ESSource("XMLIdealGeometryESSource",
+                                        geomXMLFiles = cms.vstring('DetectorDescription/Core/test/data/materials.xml',
+                                                                   'DetectorDescription/Core/test/data/world.xml',
+                                                                   'DetectorDescription/Core/test/data/assembly.xml'),
+                                        rootNodeName = cms.string('world:MotherOfAllBoxes')
+                                        )

--- a/DetectorDescription/Core/src/Assembly.cc
+++ b/DetectorDescription/Core/src/Assembly.cc
@@ -1,0 +1,8 @@
+#include "DetectorDescription/Core/src/Assembly.h"
+
+#include "DetectorDescription/Core/interface/DDSolidShapes.h"
+#include "DetectorDescription/Core/src/Solid.h"
+
+DDI::Assembly::Assembly() : Solid(DDSolidShape::ddassembly) {}
+
+void DDI::Assembly::stream(std::ostream& os) const {}

--- a/DetectorDescription/Core/src/Assembly.h
+++ b/DetectorDescription/Core/src/Assembly.h
@@ -1,0 +1,19 @@
+#ifndef DDD_DDI_ASSEMBLY_H
+#define DDD_DDI_ASSEMBLY_H
+
+#include <iostream>
+#include "Solid.h"
+
+namespace DDI {
+
+  class Assembly : public Solid {
+  public:
+    Assembly();
+
+    double volume() const override { return -1; }
+
+    void stream(std::ostream& os) const override;
+  };
+}  // namespace DDI
+
+#endif

--- a/DetectorDescription/Core/src/DDSolid.cc
+++ b/DetectorDescription/Core/src/DDSolid.cc
@@ -5,6 +5,7 @@
 #include <string>
 #include <array>
 
+#include "DetectorDescription/Core/src/Assembly.h"
 #include "DetectorDescription/Core/src/Boolean.h"
 #include "DetectorDescription/Core/src/Box.h"
 #include "DetectorDescription/Core/src/Cons.h"
@@ -105,6 +106,9 @@ DDSolid::DDSolid(const DDName& name, DDSolidShape shape, const std::vector<doubl
       break;
     case DDSolidShape::ddextrudedpolygon:
       solid = std::make_unique<DDI::ExtrudedPolygon>(dummy, dummy, dummy, dummy, dummy, dummy);
+      break;
+    case DDSolidShape::ddassembly:
+      solid = std::make_unique<DDI::Assembly>();
       break;
     default:
       throw cms::Exception("DDException")
@@ -527,8 +531,18 @@ std::array<double, 3> DDCutTubs::highNorm(void) const {
   return std::array<double, 3>{{rep().parameters()[8], rep().parameters()[9], rep().parameters()[10]}};
 }
 
+DDAssembly::DDAssembly(const DDSolid& s) : DDSolid(s) {
+  if (s.shape() != DDSolidShape::ddassembly) {
+    std::string ex = "Solid [" + s.name().ns() + ":" + s.name().name() + "] is not a DDAssembly.\n";
+    ex = ex + "Use a different solid interface!";
+    throw cms::Exception("DDException") << ex;
+  }
+}
+
 // =================================================================================
 // =========================SolidFactory============================================
+
+DDSolid DDSolidFactory::assembly(const DDName& name) { return DDSolid(name, std::make_unique<DDI::Assembly>()); }
 
 DDSolid DDSolidFactory::box(const DDName& name, double xHalf, double yHalf, double zHalf) {
   return DDSolid(name, std::make_unique<DDI::Box>(xHalf, yHalf, zHalf));

--- a/DetectorDescription/Core/test/data/assembly.xml
+++ b/DetectorDescription/Core/test/data/assembly.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0"?>
+<DDDefinition>
+  <SolidSection>
+    <Assembly name="AssemblyVolume"/>
+    <TruncTubs name="ChildVolume" rMin="6.9551*m" rMax="9*m" cutAtStart="6.9551*m" cutAtDelta="7.20045*m" cutInside="true"
+	       startPhi="0*deg" deltaPhi="15*deg" zHalf="6.57005*m"/>
+  </SolidSection>
+  <LogicalPartSection>
+    <LogicalPart name="AssemblyVolume" category="unspecified">
+      <rSolid name="AssemblyVolume"/>
+      <rMaterial name="materials:Air"/>
+    </LogicalPart>
+    <LogicalPart name="ChildVolume" category="unspecified">
+      <rSolid name="ChildVolume"/>
+      <rMaterial name="materials:Air"/>
+    </LogicalPart>
+  </LogicalPartSection>
+  <PosPartSection label="">
+     <PosPart copyNumber="1">
+      <rParent name="AssemblyVolume"/>
+      <rChild name="ChildVolume"/>
+      <Translation z="17.4299*m" y="0.*m" x="0."/>
+    </PosPart>
+    <PosPart copyNumber="2">
+      <rParent name="AssemblyVolume"/>
+      <rChild name="ChildVolume"/>
+      <Translation z="-17.4299*m" y="0.*m" x="0."/>
+    </PosPart>
+    <PosPart copyNumber="13">
+      <rParent name="world:MotherOfAllBoxes"/>
+      <rChild name="AssemblyVolume"/>
+      <Translation z="0*m" y="0.*m" x="0."/>
+    </PosPart>
+  </PosPartSection>
+</DDDefinition>

--- a/DetectorDescription/Core/test/python/testDDAssembly.py
+++ b/DetectorDescription/Core/test/python/testDDAssembly.py
@@ -1,0 +1,25 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("DDAssemblyTest")
+process.load("DetectorDescription.Core.test.DDAssemblyXML_cfi")
+
+process.source = cms.Source("EmptySource")
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(1)
+    )
+
+process.test = cms.EDAnalyzer("PerfectGeometryAnalyzer",
+                              dumpPosInfo = cms.untracked.bool(True),
+                              label = cms.untracked.string(''),
+                              isMagField = cms.untracked.bool(False),
+                              dumpSpecs = cms.untracked.bool(False),
+                              dumpGeoHistory = cms.untracked.bool(True),
+                              outFileName = cms.untracked.string('DDAssembly.out'),
+                              numNodesToDump = cms.untracked.uint32(0),
+                              fromDB = cms.untracked.bool(False),
+                              ddRootNodeName = cms.untracked.string('world:MotherOfAllBoxes')
+                              )
+
+process.Timing = cms.Service("Timing")
+
+process.p = cms.Path(process.test)

--- a/DetectorDescription/DDCMS/plugins/DDDetectorESProducer.cc
+++ b/DetectorDescription/DDCMS/plugins/DDDetectorESProducer.cc
@@ -66,7 +66,9 @@ private:
 DDDetectorESProducer::DDDetectorESProducer(const ParameterSet& iConfig)
     : fromDB_(iConfig.getParameter<bool>("fromDB")),
       appendToDataLabel_(iConfig.getParameter<string>("appendToDataLabel")),
-      confGeomXMLFiles_(iConfig.getParameter<FileInPath>("confGeomXMLFiles").fullPath()),
+      confGeomXMLFiles_(iConfig.existsAs<FileInPath>("confGeomXMLFiles")
+                            ? iConfig.getParameter<FileInPath>("confGeomXMLFiles").fullPath()
+                            : "none"),
       rootDDName_(iConfig.getParameter<string>("rootDDName")),
       label_(iConfig.getParameter<string>("label")) {
   usesResources({edm::ESSharedResourceNames::kDD4Hep});

--- a/DetectorDescription/DDCMS/plugins/DDDetectorESProducer.cc
+++ b/DetectorDescription/DDCMS/plugins/DDDetectorESProducer.cc
@@ -66,9 +66,7 @@ private:
 DDDetectorESProducer::DDDetectorESProducer(const ParameterSet& iConfig)
     : fromDB_(iConfig.getParameter<bool>("fromDB")),
       appendToDataLabel_(iConfig.getParameter<string>("appendToDataLabel")),
-      confGeomXMLFiles_(iConfig.existsAs<FileInPath>("confGeomXMLFiles")
-                            ? iConfig.getParameter<FileInPath>("confGeomXMLFiles").fullPath()
-                            : "none"),
+      confGeomXMLFiles_(fromDB_ ? "none" : iConfig.getParameter<FileInPath>("confGeomXMLFiles").fullPath()),
       rootDDName_(iConfig.getParameter<string>("rootDDName")),
       label_(iConfig.getParameter<string>("label")) {
   usesResources({edm::ESSharedResourceNames::kDD4Hep});

--- a/DetectorDescription/DDCMS/test/python/testGeometry2021FromDB.py
+++ b/DetectorDescription/DDCMS/test/python/testGeometry2021FromDB.py
@@ -12,7 +12,6 @@ process.maxEvents = cms.untracked.PSet(
     )
 
 process.DDDetectorESProducer = cms.ESSource("DDDetectorESProducer",
-                                            confGeomXMLFiles = cms.FileInPath('Geometry/CMSCommonData/data/dd4hep/cmsExtendedGeometry2021.xml'),
                                             rootDDName = cms.string('cms:OCMS'),
                                             label = cms.string('Extended'),
                                             fromDB = cms.bool(True),

--- a/DetectorDescription/Parser/src/DDLAssembly.cc
+++ b/DetectorDescription/Parser/src/DDLAssembly.cc
@@ -1,0 +1,20 @@
+#include "DetectorDescription/Parser/src/DDLAssembly.h"
+#include "DetectorDescription/Core/interface/DDSolid.h"
+#include "DetectorDescription/Parser/interface/DDLElementRegistry.h"
+#include "DetectorDescription/Parser/src/DDLSolid.h"
+#include "DetectorDescription/Parser/src/DDXMLElement.h"
+
+class DDCompactView;
+
+DDLAssembly::DDLAssembly(DDLElementRegistry* myreg) : DDLSolid(myreg) {}
+
+void DDLAssembly::preProcessElement(const std::string& name, const std::string& nmspace, DDCompactView& cpv) {
+  myRegistry_->getElement("rSolid")->clear();
+}
+
+// Upon ending a ShapelessSolid element, call DDCore giving the box name, and dimensions.
+void DDLAssembly::processElement(const std::string& name, const std::string& nmspace, DDCompactView& cpv) {
+  DDSolid dds = DDSolidFactory::shapeless(getDDName(nmspace));
+
+  DDLSolid::setReference(nmspace, cpv);
+}

--- a/DetectorDescription/Parser/src/DDLAssembly.h
+++ b/DetectorDescription/Parser/src/DDLAssembly.h
@@ -1,0 +1,29 @@
+#ifndef DDL_Assembly_H
+#define DDL_Assembly_H
+
+#include <string>
+
+#include "DDLSolid.h"
+
+class DDCompactView;
+class DDLElementRegistry;
+
+/// DDLAssembly processes Assembly elements.
+/** @class DDLAssembly
+ * @author Ianna Osborne
+ *                                                                       
+ *  DDLAssembly.h  -  description
+ *
+ *  This is the Assembly processor.
+ *                                                                         
+ */
+
+class DDLAssembly final : public DDLSolid {
+public:
+  DDLAssembly(DDLElementRegistry* myreg);
+
+  void processElement(const std::string& name, const std::string& nmspace, DDCompactView& cpv) override;
+  void preProcessElement(const std::string& name, const std::string& nmspace, DDCompactView& cpv) override;
+};
+
+#endif

--- a/DetectorDescription/Parser/src/DDLElementRegistry.cc
+++ b/DetectorDescription/Parser/src/DDLElementRegistry.cc
@@ -1,5 +1,6 @@
 #include "DetectorDescription/Parser/interface/DDLElementRegistry.h"
 #include "DetectorDescription/Parser/src/DDLAlgorithm.h"
+#include "DetectorDescription/Parser/src/DDLAssembly.h"
 #include "DetectorDescription/Parser/src/DDLBooleanSolid.h"
 #include "DetectorDescription/Parser/src/DDLBox.h"
 #include "DetectorDescription/Parser/src/DDLCompositeMaterial.h"
@@ -68,8 +69,10 @@ std::shared_ptr<DDXMLElement> DDLElementRegistry::getElement(const std::string& 
       myret = std::make_shared<DDLSphere>(this);
     } else if (name == "EllipticalTube") {
       myret = std::make_shared<DDLEllipticalTube>(this);
-    } else if (name == "ExtrudedPolygon")
+    } else if (name == "ExtrudedPolygon") {
       myret = std::make_shared<DDLPgonGenerator>(this);
+    } else if (name == "Assembly")
+      myret = std::make_shared<DDLAssembly>(this);
 
     //  LogicalParts, Positioners, Materials, Rotations, Reflections
     //  and Specific (Specified?) Parameters

--- a/DetectorDescription/Parser/test/testSolids.xml
+++ b/DetectorDescription/Parser/test/testSolids.xml
@@ -2,7 +2,7 @@
 <DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../Schema/DDLSchema.xsd">
 
   <SolidSection label="testSolids.xml">
-    <Assembly name="assembly">
+    <Assembly name="assembly"/>
     <Trapezoid name="trap1" alp1="10*deg" alp2="10*deg" bl1="50*cm" bl2="75*cm" dz="1*m" h1="20*cm" h2="40*cm" phi="30*deg" theta="30*deg" tl1="50*cm" tl2="75*cm"/>
     <Trapezoid name="trap2" alp1="10*deg" alp2="10*deg" bl1="50*cm" bl2="75*cm" dz="1*m" h1="20*cm" h2="40*cm" tl1="50*cm" tl2="75*cm"/>
     <PseudoTrap name="ptrap1" dx1="10" dx2="3" dy1="30" dy2="10" dz="30" radius="10" atMinusZ="false"/>

--- a/DetectorDescription/Parser/test/testSolids.xml
+++ b/DetectorDescription/Parser/test/testSolids.xml
@@ -2,6 +2,7 @@
 <DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../Schema/DDLSchema.xsd">
 
   <SolidSection label="testSolids.xml">
+    <Assembly name="assembly">
     <Trapezoid name="trap1" alp1="10*deg" alp2="10*deg" bl1="50*cm" bl2="75*cm" dz="1*m" h1="20*cm" h2="40*cm" phi="30*deg" theta="30*deg" tl1="50*cm" tl2="75*cm"/>
     <Trapezoid name="trap2" alp1="10*deg" alp2="10*deg" bl1="50*cm" bl2="75*cm" dz="1*m" h1="20*cm" h2="40*cm" tl1="50*cm" tl2="75*cm"/>
     <PseudoTrap name="ptrap1" dx1="10" dx2="3" dy1="30" dy2="10" dz="30" radius="10" atMinusZ="false"/>


### PR DESCRIPTION
#### PR description:

Tidy up the ES producer configuration - drop an optional FileInPath.

`StandardSequences` should use an auto-generated `DDDetectorESProducerFromDB` configuration fragment for dd4hep Era.

@civanch, @cvuosalo - FYI

<!-- Please replace this text with a description of the feature proposed or problem addressed, specifying:
  - what changes are expected in the output if any, 
  - what other PRs or externals it depends upon if any,
  - link to any additional material useful to provide a documentation for this PR (slides, JIRA tickets, related pull requestes, hypernews, TWiki or Indico pages)  -->

#### PR validation:

<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

<!-- Please replace this text with any link to  -->

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
