### PR TITLE
Specify separate directories to run external instances in ExternalGeneratorFilter

### DIFF
--- a/GeneratorInterface/Core/plugins/ExternalGeneratorFilter.cc
+++ b/GeneratorInterface/Core/plugins/ExternalGeneratorFilter.cc
@@ -52,16 +52,15 @@ namespace externalgen {
         if (verbose) {
           verboseCommand = "--verbose ";
         }
-        std::error_code ec;
         auto curDir = current_path();
         auto newDir = path("thread"s + std::to_string(id_));
-        create_directory(newDir, ec);
-        current_path(newDir, ec);
+        create_directory(newDir);
+        current_path(newDir);
         pipe_ =
             popen(("cmsExternalGenerator "s + verboseCommand + channel_.sharedMemoryName() + " " + channel_.uniqueID())
                       .c_str(),
                   "w");
-        current_path(curDir, ec);
+        current_path(curDir);
 
         if (nullptr == pipe_) {
           abort();

--- a/GeneratorInterface/Core/plugins/ExternalGeneratorFilter.cc
+++ b/GeneratorInterface/Core/plugins/ExternalGeneratorFilter.cc
@@ -46,15 +46,22 @@ namespace externalgen {
 
       channel_.setupWorker([&]() {
         using namespace std::string_literals;
+        using namespace std::filesystem;
         edm::LogSystem("ExternalProcess") << id_ << " starting external process \n";
         std::string verboseCommand;
         if (verbose) {
           verboseCommand = "--verbose ";
         }
+        std::error_code ec;
+        auto curDir = current_path();
+        auto newDir = path("thread"s + std::to_string(id_));
+        create_directory(newDir, ec);
+        current_path(newDir, ec);
         pipe_ =
             popen(("cmsExternalGenerator "s + verboseCommand + channel_.sharedMemoryName() + " " + channel_.uniqueID())
                       .c_str(),
                   "w");
+        current_path(curDir, ec);
 
         if (nullptr == pipe_) {
           abort();


### PR DESCRIPTION
#### PR description:

In the ExternalGeneratorFilter module, external cmsRun instances are launched by the main instance in the same working directory. 
As some types of generator will release intermediate files (e.g. H7, Sherpa), we execute the commands in different directories (specifed as `thread0`, `thread1`, ...) to avoid overlapping.

#### PR validation:

Validated over all possible GeneratorFilter-based modules as summarised in https://github.com/cms-sw/cmssw/pull/34146#issuecomment-863273408. 
Physics results show good consistency.
