### PR TITLE
TkDQM: remove OT validation module for vector hits workflow

### DIFF
--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -350,6 +350,7 @@ class UpgradeWorkflow_vectorHits(UpgradeWorkflow):
 upgradeWFs['vectorHits'] = UpgradeWorkflow_vectorHits(
     steps = [
         'RecoGlobal',
+        'HARVESTGlobal'
     ],
     PU = [
         'RecoGlobal',

--- a/Validation/SiTrackerPhase2V/python/Phase2TrackerMCHarvesting_cff.py
+++ b/Validation/SiTrackerPhase2V/python/Phase2TrackerMCHarvesting_cff.py
@@ -67,6 +67,9 @@ trackerphase2ValidationHarvesting = cms.Sequence(Phase2ITRechitHarvester
                                                  * Phase2OTTrackingRechitHarvester_2S
 )
 
+from Configuration.ProcessModifiers.vectorHits_cff import vectorHits
+vectorHits.toReplaceWith(trackerphase2ValidationHarvesting, trackerphase2ValidationHarvesting.copyAndExclude([Phase2OTTrackingRechitHarvester_PS,Phase2OTTrackingRechitHarvester_2S]))
+
 trackerphase2ValidationHarvesting_standalone = cms.Sequence(Phase2ITRechitHarvester
                                                             * Phase2ITtrackingrechitHarvester
                                                             * Phase2OTRechitHarvester_PS

--- a/Validation/SiTrackerPhase2V/python/Phase2TrackerValidationFirstStep_cff.py
+++ b/Validation/SiTrackerPhase2V/python/Phase2TrackerValidationFirstStep_cff.py
@@ -14,3 +14,6 @@ trackerphase2ValidationSource = cms.Sequence(pixDigiValid
                                              + clusterValidOT
                                              + trackingRechitValidOT
 )
+
+from Configuration.ProcessModifiers.vectorHits_cff import vectorHits
+vectorHits.toReplaceWith(trackerphase2ValidationSource, trackerphase2ValidationSource.copyAndExclude([trackingRechitValidOT]))


### PR DESCRIPTION
#### PR description:
This PR removes the Phase2OT tracking rechit module from the dqm and harvesting step for workflow with vector hits. Vector hits monitoring will be addressed with separate modules. Fixes crash reported [here](https://github.com/cms-sw/cmssw/pull/33863#issuecomment-863644832)
#### PR validation:
checked with workflow 23234.9
#### if this PR is a backport please specify the original PR and why you need to backport that PR:
NA