### PR TITLE
Backport ConcurrentGeneratorFilter to 106X

### DIFF
--- a/GeneratorInterface/Core/interface/ConcurrentGeneratorFilter.h
+++ b/GeneratorInterface/Core/interface/ConcurrentGeneratorFilter.h
@@ -1,0 +1,416 @@
+// -*- C++ -*-
+//
+//
+
+// class template ConcurrentGeneratorFilter<HAD> provides an EDFilter which uses
+// the hadronizer type HAD to generate partons, hadronize them,
+// and decay the resulting particles, in the CMS framework.
+
+#ifndef GeneratorInterface_Core_ConcurrentGeneratorFilter_h
+#define GeneratorInterface_Core_ConcurrentGeneratorFilter_h
+
+#include <memory>
+#include <string>
+#include <vector>
+#include <atomic>
+
+#include "FWCore/Framework/interface/global/EDFilter.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/FileBlock.h"
+#include "FWCore/Framework/interface/LuminosityBlock.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/Run.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ServiceRegistry/interface/RandomEngineSentry.h"
+#include "FWCore/Utilities/interface/BranchType.h"
+#include "FWCore/Utilities/interface/EDMException.h"
+#include "FWCore/Utilities/interface/EDGetToken.h"
+#include "FWCore/Utilities/interface/TypeID.h"
+#include "DataFormats/Provenance/interface/BranchDescription.h"
+#include "CLHEP/Random/RandomEngine.h"
+
+// LHE Run
+#include "SimDataFormats/GeneratorProducts/interface/LHERunInfoProduct.h"
+#include "GeneratorInterface/LHEInterface/interface/LHERunInfo.h"
+
+// LHE Event
+#include "SimDataFormats/GeneratorProducts/interface/LHEEventProduct.h"
+#include "GeneratorInterface/LHEInterface/interface/LHEEvent.h"
+
+#include "SimDataFormats/GeneratorProducts/interface/HepMCProduct.h"
+#include "SimDataFormats/GeneratorProducts/interface/GenRunInfoProduct.h"
+#include "SimDataFormats/GeneratorProducts/interface/GenLumiInfoHeader.h"
+#include "SimDataFormats/GeneratorProducts/interface/GenLumiInfoProduct.h"
+#include "SimDataFormats/GeneratorProducts/interface/GenEventInfoProduct.h"
+
+namespace edm {
+  namespace gen {
+    struct GenRunCache {
+      mutable std::atomic<GenRunInfoProduct*> product_{nullptr};
+      ~GenRunCache() { delete product_.load(); }
+
+      // This is called from globalEndRunProduce which is known to
+      // be safe as the framework would not be calling any other
+      // methods of this module using this run at that time
+      std::unique_ptr<GenRunInfoProduct> release() const noexcept {
+        auto retValue = product_.load();
+        product_.store(nullptr);
+        return std::unique_ptr<GenRunInfoProduct>(retValue);
+      }
+    };
+    struct GenLumiSummary {
+      mutable std::unique_ptr<GenLumiInfoProduct> lumiInfo_;
+    };
+    template <typename HAD, typename DEC>
+    struct GenStreamCache {
+      GenStreamCache(ParameterSet const& iPSet) : hadronizer_{iPSet}, nEventsInLumiBlock_{0} {}
+      HAD hadronizer_;
+      std::unique_ptr<DEC> decayer_;
+      unsigned int nEventsInLumiBlock_;
+      bool initialized_ = false;
+    };
+  }  // namespace gen
+
+  template <class HAD, class DEC>
+  class ConcurrentGeneratorFilter : public global::EDFilter<EndRunProducer,
+                                                            BeginLuminosityBlockProducer,
+                                                            EndLuminosityBlockProducer,
+                                                            RunCache<gen::GenRunCache>,
+                                                            LuminosityBlockSummaryCache<gen::GenLumiSummary>,
+                                                            StreamCache<gen::GenStreamCache<HAD, DEC>>> {
+  public:
+    typedef HAD Hadronizer;
+    typedef DEC Decayer;
+
+    // The given ParameterSet will be passed to the contained Hadronizer object.
+    explicit ConcurrentGeneratorFilter(ParameterSet const& ps);
+
+    bool filter(StreamID id, Event& e, EventSetup const& es) const override;
+    std::unique_ptr<gen::GenStreamCache<HAD, DEC>> beginStream(StreamID) const override;
+    std::shared_ptr<gen::GenRunCache> globalBeginRun(Run const&, EventSetup const&) const override;
+    std::shared_ptr<gen::GenLumiSummary> globalBeginLuminosityBlockSummary(LuminosityBlock const&,
+                                                                           EventSetup const&) const override;
+    void globalBeginLuminosityBlockProduce(LuminosityBlock&, EventSetup const&) const override;
+    void streamBeginLuminosityBlock(StreamID, LuminosityBlock const&, EventSetup const&) const override;
+    void streamEndLuminosityBlock(StreamID, LuminosityBlock const&, EventSetup const&) const override;
+    void streamEndLuminosityBlockSummary(StreamID,
+                                         LuminosityBlock const&,
+                                         EventSetup const&,
+                                         gen::GenLumiSummary*) const override;
+    void globalEndLuminosityBlockSummary(LuminosityBlock const&,
+                                         EventSetup const&,
+                                         gen::GenLumiSummary*) const override;
+    void globalEndLuminosityBlockProduce(LuminosityBlock&,
+                                         EventSetup const&,
+                                         gen::GenLumiSummary const*) const override;
+    void streamEndRun(StreamID, Run const&, EventSetup const&) const override;
+    void globalEndRun(Run const&, EventSetup const&) const override;
+    void globalEndRunProduce(Run&, EventSetup const&) const override;
+
+  private:
+    void initLumi(gen::GenStreamCache<HAD, DEC>* cache, LuminosityBlock const& index, EventSetup const& es) const;
+    ParameterSet config_;
+    mutable std::atomic<gen::GenStreamCache<HAD, DEC>*> useInLumi_{nullptr};
+  };
+
+  //------------------------------------------------------------------------
+  //
+  // Implementation
+
+  template <class HAD, class DEC>
+  ConcurrentGeneratorFilter<HAD, DEC>::ConcurrentGeneratorFilter(ParameterSet const& ps) : config_(ps) {
+    // TODO:
+    // Put the list of types produced by the filters here.
+    // The current design calls for:
+    //   * LHEGeneratorInfo
+    //   * LHEEvent
+    //   * HepMCProduct
+    // But I can not find the LHEGeneratorInfo class; it might need to
+    // be invented.
+
+    this->template produces<HepMCProduct>("unsmeared");
+    this->template produces<GenEventInfoProduct>();
+    this->template produces<GenLumiInfoHeader, edm::Transition::BeginLuminosityBlock>();
+    this->template produces<GenLumiInfoProduct, edm::Transition::EndLuminosityBlock>();
+    this->template produces<GenRunInfoProduct, edm::Transition::EndRun>();
+  }
+
+  template <class HAD, class DEC>
+  std::unique_ptr<gen::GenStreamCache<HAD, DEC>> ConcurrentGeneratorFilter<HAD, DEC>::beginStream(StreamID) const {
+    auto cache = std::make_unique<gen::GenStreamCache<HAD, DEC>>(config_);
+
+    if (config_.exists("ExternalDecays")) {
+      ParameterSet ps1 = config_.getParameter<ParameterSet>("ExternalDecays");
+      cache->decayer_.reset(new Decayer(ps1));
+    }
+
+    // We need a hadronizer during globalBeginLumiProduce, doesn't matter which one
+    gen::GenStreamCache<HAD, DEC>* expected = nullptr;
+    useInLumi_.compare_exchange_strong(expected, cache.get());
+
+    return cache;
+  }
+
+  template <class HAD, class DEC>
+  std::shared_ptr<gen::GenRunCache> ConcurrentGeneratorFilter<HAD, DEC>::globalBeginRun(Run const&,
+                                                                                        EventSetup const&) const {
+    return std::make_shared<gen::GenRunCache>();
+  }
+
+  template <class HAD, class DEC>
+  std::shared_ptr<gen::GenLumiSummary> ConcurrentGeneratorFilter<HAD, DEC>::globalBeginLuminosityBlockSummary(
+      LuminosityBlock const&, EventSetup const&) const {
+    return std::make_shared<gen::GenLumiSummary>();
+  }
+
+  template <class HAD, class DEC>
+  void ConcurrentGeneratorFilter<HAD, DEC>::initLumi(gen::GenStreamCache<HAD, DEC>* cache,
+                                                     LuminosityBlock const& lumi,
+                                                     EventSetup const& es) const {
+    cache->nEventsInLumiBlock_ = 0;
+
+    // We need all copies to see same random # for begin lumi
+    Service<RandomNumberGenerator> rng;
+    auto enginePtr = rng->cloneEngine(lumi.index());
+    cache->hadronizer_.setRandomEngine(enginePtr.get());
+    cache->decayer_->setRandomEngine(enginePtr.get());
+
+    auto unsetH = [](HAD* h) { h->setRandomEngine(nullptr); };
+    auto unsetD = [](DEC* d) { d->setRandomEngine(nullptr); };
+
+    std::unique_ptr<HAD, decltype(unsetH)> randomEngineSentry(&cache->hadronizer_, unsetH);
+    std::unique_ptr<DEC, decltype(unsetD)> randomEngineSentryDecay(cache->decayer_.get(), unsetD);
+
+    cache->hadronizer_.randomizeIndex(lumi, enginePtr.get());
+
+    if (!cache->hadronizer_.readSettings(0))
+      throw edm::Exception(errors::Configuration)
+          << "Failed to read settings for the hadronizer " << cache->hadronizer_.classname() << " \n";
+
+    if (cache->decayer_) {
+      cache->decayer_->init(es);
+      if (!cache->hadronizer_.declareStableParticles(cache->decayer_->operatesOnParticles()))
+        throw edm::Exception(errors::Configuration)
+            << "Failed to declare stable particles in hadronizer " << cache->hadronizer_.classname()
+            << " for internal parton generation\n";
+      if (!cache->hadronizer_.declareSpecialSettings(cache->decayer_->specialSettings()))
+        throw edm::Exception(errors::Configuration)
+            << "Failed to declare special settings in hadronizer " << cache->hadronizer_.classname() << "\n";
+    }
+
+    if (!cache->hadronizer_.initializeForInternalPartons())
+      throw edm::Exception(errors::Configuration)
+          << "Failed to initialize hadronizer " << cache->hadronizer_.classname()
+          << " for internal parton generation\n";
+
+    cache->initialized_ = true;
+  }
+
+  template <class HAD, class DEC>
+  bool ConcurrentGeneratorFilter<HAD, DEC>::filter(StreamID id, Event& ev, EventSetup const& /* es */) const {
+    auto cache = this->streamCache(id);
+    RandomEngineSentry<HAD> randomEngineSentry(&cache->hadronizer_, ev.streamID());
+    RandomEngineSentry<DEC> randomEngineSentryDecay(cache->decayer_.get(), ev.streamID());
+
+    cache->hadronizer_.setEDMEvent(ev);
+
+    bool passEvtGenSelector = false;
+    std::unique_ptr<HepMC::GenEvent> event(nullptr);
+
+    while (!passEvtGenSelector) {
+      event.reset();
+      cache->hadronizer_.setEDMEvent(ev);
+
+      if (!cache->hadronizer_.generatePartonsAndHadronize())
+        return false;
+
+      // this is "fake" stuff
+      // in principle, decays are done as part of full event generation,
+      // except for particles that are marked as to be kept stable
+      // but we currently keep in it the design, because we might want
+      // to use such feature for other applications
+      //
+      if (!cache->hadronizer_.decay())
+        return false;
+
+      event = cache->hadronizer_.getGenEvent();
+      if (!event.get())
+        return false;
+
+      //
+      // The external decay driver is being added to the system, it should be called here
+      //
+      if (cache->decayer_) {
+        auto t = cache->decayer_->decay(event.get());
+        if (t != event.get()) {
+          event.reset(t);
+        }
+      }
+      if (!event.get())
+        return false;
+
+      passEvtGenSelector = cache->hadronizer_.select(event.get());
+    }
+
+    // check and perform if there're any unstable particles after
+    // running external decay packages
+    //
+    // fisrt of all, put back modified event tree (after external decay)
+    //
+    cache->hadronizer_.resetEvent(std::move(event));
+
+    //
+    // now run residual decays
+    //
+    if (!cache->hadronizer_.residualDecay())
+      return false;
+
+    cache->hadronizer_.finalizeEvent();
+
+    event = cache->hadronizer_.getGenEvent();
+    if (!event.get())
+      return false;
+
+    event->set_event_number(ev.id().event());
+
+    //
+    // finally, form up EDM products !
+    //
+    std::unique_ptr<GenEventInfoProduct> genEventInfo(cache->hadronizer_.getGenEventInfo());
+    if (!genEventInfo.get()) {
+      // create GenEventInfoProduct from HepMC event in case hadronizer didn't provide one
+      genEventInfo = std::make_unique<GenEventInfoProduct>(event.get());
+    }
+
+    ev.put(std::move(genEventInfo));
+
+    std::unique_ptr<HepMCProduct> bare_product(new HepMCProduct());
+    bare_product->addHepMCData(event.release());
+    ev.put(std::move(bare_product), "unsmeared");
+    cache->nEventsInLumiBlock_++;
+    return true;
+  }
+
+  template <class HAD, class DEC>
+  void ConcurrentGeneratorFilter<HAD, DEC>::globalBeginLuminosityBlockProduce(LuminosityBlock& lumi,
+                                                                              EventSetup const& es) const {
+    // need one of the streams to finish
+    while (useInLumi_.load() == nullptr) {
+    }
+    initLumi(useInLumi_, lumi, es);
+    std::unique_ptr<GenLumiInfoHeader> genLumiInfoHeader(useInLumi_.load()->hadronizer_.getGenLumiInfoHeader());
+    lumi.put(std::move(genLumiInfoHeader));
+  }
+
+  template <class HAD, class DEC>
+  void ConcurrentGeneratorFilter<HAD, DEC>::streamBeginLuminosityBlock(StreamID id,
+                                                                       LuminosityBlock const& lumi,
+                                                                       EventSetup const& es) const {
+    if (useInLumi_ != this->streamCache(id)) {
+      initLumi(this->streamCache(id), lumi, es);
+    } else {
+      useInLumi_.store(nullptr);
+    }
+  }
+
+  template <class HAD, class DEC>
+  void ConcurrentGeneratorFilter<HAD, DEC>::streamEndLuminosityBlock(StreamID id,
+                                                                     LuminosityBlock const&,
+                                                                     EventSetup const&) const {
+    this->streamCache(id)->hadronizer_.cleanLHE();
+  }
+
+  template <class HAD, class DEC>
+  void ConcurrentGeneratorFilter<HAD, DEC>::streamEndLuminosityBlockSummary(StreamID id,
+                                                                            LuminosityBlock const&,
+                                                                            EventSetup const&,
+                                                                            gen::GenLumiSummary* iSummary) const {
+    auto cache = this->streamCache(id);
+    cache->hadronizer_.statistics();
+    if (cache->decayer_)
+      cache->decayer_->statistics();
+
+    GenRunInfoProduct genRunInfo = GenRunInfoProduct(cache->hadronizer_.getGenRunInfo());
+    std::vector<GenLumiInfoProduct::ProcessInfo> GenLumiProcess;
+    const GenRunInfoProduct::XSec& xsec = genRunInfo.internalXSec();
+    GenLumiInfoProduct::ProcessInfo temp;
+    unsigned int nEvtInLumiBlock_ = cache->nEventsInLumiBlock_;
+    temp.setProcess(0);
+    temp.setLheXSec(xsec.value(), xsec.error());  // Pythia gives error of -1
+    temp.setNPassPos(nEvtInLumiBlock_);
+    temp.setNPassNeg(0);
+    temp.setNTotalPos(nEvtInLumiBlock_);
+    temp.setNTotalNeg(0);
+    temp.setTried(nEvtInLumiBlock_, nEvtInLumiBlock_, nEvtInLumiBlock_);
+    temp.setSelected(nEvtInLumiBlock_, nEvtInLumiBlock_, nEvtInLumiBlock_);
+    temp.setKilled(nEvtInLumiBlock_, nEvtInLumiBlock_, nEvtInLumiBlock_);
+    temp.setAccepted(0, -1, -1);
+    temp.setAcceptedBr(0, -1, -1);
+    GenLumiProcess.push_back(temp);
+
+    GenLumiInfoProduct genLumiInfo;
+    genLumiInfo.setHEPIDWTUP(-1);
+    genLumiInfo.setProcessInfo(GenLumiProcess);
+
+    if (iSummary->lumiInfo_) {
+      iSummary->lumiInfo_->mergeProduct(genLumiInfo);
+    } else {
+      iSummary->lumiInfo_ = std::make_unique<GenLumiInfoProduct>(std::move(genLumiInfo));
+    }
+
+    cache->nEventsInLumiBlock_ = 0;
+
+    gen::GenStreamCache<HAD, DEC>* expected = nullptr;
+    //make it available for beginLuminosityBlockProduce
+    useInLumi_.compare_exchange_strong(expected, this->streamCache(id));
+  }
+
+  template <class HAD, class DEC>
+  void ConcurrentGeneratorFilter<HAD, DEC>::globalEndLuminosityBlockSummary(LuminosityBlock const&,
+                                                                            EventSetup const&,
+                                                                            gen::GenLumiSummary*) const {}
+
+  template <class HAD, class DEC>
+  void ConcurrentGeneratorFilter<HAD, DEC>::globalEndLuminosityBlockProduce(LuminosityBlock& lumi,
+                                                                            EventSetup const&,
+                                                                            gen::GenLumiSummary const* iSummary) const {
+    lumi.put(std::move(iSummary->lumiInfo_));
+  }
+
+  template <class HAD, class DEC>
+  void ConcurrentGeneratorFilter<HAD, DEC>::streamEndRun(StreamID id, Run const& run, EventSetup const&) const {
+    auto rCache = this->runCache(run.index());
+    auto cache = this->streamCache(id);
+
+    // If relevant, record the integrated luminosity for this run
+    // here.  To do so, we would need a standard function to invoke on
+    // the contained hadronizer that would report the integrated
+    // luminosity.
+
+    if (cache->initialized_) {
+      cache->hadronizer_.statistics();
+      if (cache->decayer_)
+        cache->decayer_->statistics();
+    }
+    GenRunInfoProduct& genRunInfo = cache->hadronizer_.getGenRunInfo();
+    GenRunInfoProduct* expect = nullptr;
+
+    std::unique_ptr<GenRunInfoProduct> griproduct(new GenRunInfoProduct(genRunInfo));
+    // All the GenRunInfoProducts for all streams shoule be identical, therefore we only need one
+    if (rCache->product_.compare_exchange_strong(expect, griproduct.get())) {
+      griproduct.release();
+    }
+  }
+
+  template <class HAD, class DEC>
+  void ConcurrentGeneratorFilter<HAD, DEC>::globalEndRun(Run const&, EventSetup const&) const {}
+
+  template <class HAD, class DEC>
+  void ConcurrentGeneratorFilter<HAD, DEC>::globalEndRunProduce(Run& run, EventSetup const&) const {
+    run.put(this->runCache(run.index())->release());
+  }
+
+}  // namespace edm
+
+#endif  // GeneratorInterface_Core_ConcurrentGeneratorFilter_h

--- a/GeneratorInterface/Core/test/Pythia8ConcurrentGeneratorFilter_WZ_TuneCP5_13TeV-pythia8_cfg.py
+++ b/GeneratorInterface/Core/test/Pythia8ConcurrentGeneratorFilter_WZ_TuneCP5_13TeV-pythia8_cfg.py
@@ -1,0 +1,167 @@
+# Auto generated configuration file
+# using: 
+# Revision: 1.19 
+# Source: /local/reps/CMSSW/CMSSW/Configuration/Applications/python/ConfigBuilder.py,v 
+# with command line options: Configuration/GenProduction/python/BTV-RunIISummer20UL17GEN-00002-fragment.py --python_filename BTV-RunIISummer20UL17GEN-00002_1_cfg.py --eventcontent RAWSIM --customise Configuration/DataProcessing/Utils.addMonitoring --datatier GEN --fileout file:BTV-RunIISummer20UL17GEN-00002.root --conditions 106X_mc2017_realistic_v6 --beamspot Realistic25ns13TeVEarly2017Collision --customise_commands process.source.numberEventsInLuminosityBlock=cms.untracked.uint32(100) --step GEN --geometry DB:Extended --era Run2_2017 --no_exec --mc -n 100 --nThreads 4 --nConcurrentLumis 0
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Eras.Era_Run2_2017_cff import Run2_2017
+
+process = cms.Process('GEN',Run2_2017)
+
+# import of standard configurations
+process.load('Configuration.StandardSequences.Services_cff')
+process.load('SimGeneral.HepPDTESSource.pythiapdt_cfi')
+process.load('FWCore.MessageService.MessageLogger_cfi')
+process.load('Configuration.EventContent.EventContent_cff')
+process.load('SimGeneral.MixingModule.mixNoPU_cfi')
+process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
+process.load('Configuration.StandardSequences.MagneticField_cff')
+process.load('Configuration.StandardSequences.Generator_cff')
+process.load('IOMC.EventVertexGenerators.VtxSmearedRealistic25ns13TeVEarly2017Collision_cfi')
+process.load('GeneratorInterface.Core.genFilterSummary_cff')
+process.load('Configuration.StandardSequences.EndOfProcess_cff')
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(100)
+)
+
+# Input source
+process.source = cms.Source("EmptySource")
+
+process.options = cms.untracked.PSet(
+
+)
+
+# Production Info
+process.configurationMetadata = cms.untracked.PSet(
+    annotation = cms.untracked.string('WZ, 13 TeV, TuneCP5'),
+    name = cms.untracked.string('\\$Source$'),
+    version = cms.untracked.string('\\$Revision$')
+)
+
+# Output definition
+
+process.RAWSIMoutput = cms.OutputModule("PoolOutputModule",
+    SelectEvents = cms.untracked.PSet(
+        SelectEvents = cms.vstring('generation_step')
+    ),
+    compressionAlgorithm = cms.untracked.string('LZMA'),
+    compressionLevel = cms.untracked.int32(1),
+    dataset = cms.untracked.PSet(
+        dataTier = cms.untracked.string('GEN'),
+        filterName = cms.untracked.string('')
+    ),
+    eventAutoFlushCompressedSize = cms.untracked.int32(20971520),
+    fileName = cms.untracked.string('file:BTV-RunIISummer20UL17GEN-00002.root'),
+    outputCommands = process.RAWSIMEventContent.outputCommands,
+    splitLevel = cms.untracked.int32(0)
+)
+
+# Additional output definition
+
+# Other statements
+process.genstepfilter.triggerConditions=cms.vstring("generation_step")
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, '106X_mc2017_realistic_v6', '')
+
+process.generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    PythiaParameters = cms.PSet(
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings', 
+            'pythia8CP5Settings', 
+            'pythia8PSweightsSettings', 
+            'processParameters'
+        ),
+        processParameters = cms.vstring('WeakDoubleBoson:ffbar2ZW    = on'),
+        pythia8CP5Settings = cms.vstring(
+            'Tune:pp 14', 
+            'Tune:ee 7', 
+            'MultipartonInteractions:ecmPow=0.03344', 
+            'MultipartonInteractions:bProfile=2', 
+            'MultipartonInteractions:pT0Ref=1.41', 
+            'MultipartonInteractions:coreRadius=0.7634', 
+            'MultipartonInteractions:coreFraction=0.63', 
+            'ColourReconnection:range=5.176', 
+            'SigmaTotal:zeroAXB=off', 
+            'SpaceShower:alphaSorder=2', 
+            'SpaceShower:alphaSvalue=0.118', 
+            'SigmaProcess:alphaSvalue=0.118', 
+            'SigmaProcess:alphaSorder=2', 
+            'MultipartonInteractions:alphaSvalue=0.118', 
+            'MultipartonInteractions:alphaSorder=2', 
+            'TimeShower:alphaSorder=2', 
+            'TimeShower:alphaSvalue=0.118', 
+            'SigmaTotal:mode = 0', 
+            'SigmaTotal:sigmaEl = 21.89', 
+            'SigmaTotal:sigmaTot = 100.309', 
+            'PDF:pSet=LHAPDF6:NNPDF31_nnlo_as_0118'
+        ),
+        pythia8CommonSettings = cms.vstring(
+            'Tune:preferLHAPDF = 2', 
+            'Main:timesAllowErrors = 10000', 
+            'Check:epTolErr = 0.01', 
+            'Beams:setProductionScalesFromLHEF = off', 
+            'SLHA:keepSM = on', 
+            'SLHA:minMassSM = 1000.', 
+            'ParticleDecays:limitTau0 = on', 
+            'ParticleDecays:tau0Max = 10', 
+            'ParticleDecays:allowPhotonRadiation = on'
+        ),
+        pythia8PSweightsSettings = cms.vstring(
+            'UncertaintyBands:doVariations = on', 
+            'UncertaintyBands:List = {isrRedHi isr:muRfac=0.707,fsrRedHi fsr:muRfac=0.707,isrRedLo isr:muRfac=1.414,fsrRedLo fsr:muRfac=1.414,isrDefHi isr:muRfac=0.5,fsrDefHi fsr:muRfac=0.5,isrDefLo isr:muRfac=2.0,fsrDefLo fsr:muRfac=2.0,isrConHi isr:muRfac=0.25,fsrConHi fsr:muRfac=0.25,isrConLo isr:muRfac=4.0,fsrConLo fsr:muRfac=4.0,fsr_G2GG_muR_dn fsr:G2GG:muRfac=0.5,fsr_G2GG_muR_up fsr:G2GG:muRfac=2.0,fsr_G2QQ_muR_dn fsr:G2QQ:muRfac=0.5,fsr_G2QQ_muR_up fsr:G2QQ:muRfac=2.0,fsr_Q2QG_muR_dn fsr:Q2QG:muRfac=0.5,fsr_Q2QG_muR_up fsr:Q2QG:muRfac=2.0,fsr_X2XG_muR_dn fsr:X2XG:muRfac=0.5,fsr_X2XG_muR_up fsr:X2XG:muRfac=2.0,fsr_G2GG_cNS_dn fsr:G2GG:cNS=-2.0,fsr_G2GG_cNS_up fsr:G2GG:cNS=2.0,fsr_G2QQ_cNS_dn fsr:G2QQ:cNS=-2.0,fsr_G2QQ_cNS_up fsr:G2QQ:cNS=2.0,fsr_Q2QG_cNS_dn fsr:Q2QG:cNS=-2.0,fsr_Q2QG_cNS_up fsr:Q2QG:cNS=2.0,fsr_X2XG_cNS_dn fsr:X2XG:cNS=-2.0,fsr_X2XG_cNS_up fsr:X2XG:cNS=2.0,isr_G2GG_muR_dn isr:G2GG:muRfac=0.5,isr_G2GG_muR_up isr:G2GG:muRfac=2.0,isr_G2QQ_muR_dn isr:G2QQ:muRfac=0.5,isr_G2QQ_muR_up isr:G2QQ:muRfac=2.0,isr_Q2QG_muR_dn isr:Q2QG:muRfac=0.5,isr_Q2QG_muR_up isr:Q2QG:muRfac=2.0,isr_X2XG_muR_dn isr:X2XG:muRfac=0.5,isr_X2XG_muR_up isr:X2XG:muRfac=2.0,isr_G2GG_cNS_dn isr:G2GG:cNS=-2.0,isr_G2GG_cNS_up isr:G2GG:cNS=2.0,isr_G2QQ_cNS_dn isr:G2QQ:cNS=-2.0,isr_G2QQ_cNS_up isr:G2QQ:cNS=2.0,isr_Q2QG_cNS_dn isr:Q2QG:cNS=-2.0,isr_Q2QG_cNS_up isr:Q2QG:cNS=2.0,isr_X2XG_cNS_dn isr:X2XG:cNS=-2.0,isr_X2XG_cNS_up isr:X2XG:cNS=2.0}', 
+            'UncertaintyBands:nFlavQ = 4', 
+            'UncertaintyBands:MPIshowers = on', 
+            'UncertaintyBands:overSampleFSR = 10.0', 
+            'UncertaintyBands:overSampleISR = 10.0', 
+            'UncertaintyBands:FSRpTmin2Fac = 20', 
+            'UncertaintyBands:ISRpTmin2Fac = 1'
+        )
+    ),
+    comEnergy = cms.double(13000.0),
+    crossSection = cms.untracked.double(27.6),
+    filterEfficiency = cms.untracked.double(1.0),
+    maxEventsToPrint = cms.untracked.int32(1),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    pythiaPylistVerbosity = cms.untracked.int32(1)
+)
+
+
+# Path and EndPath definitions
+process.generation_step = cms.Path(process.pgen)
+process.genfiltersummary_step = cms.EndPath(process.genFilterSummary)
+process.endjob_step = cms.EndPath(process.endOfProcess)
+process.RAWSIMoutput_step = cms.EndPath(process.RAWSIMoutput)
+
+# Schedule definition
+process.schedule = cms.Schedule(process.generation_step,process.genfiltersummary_step,process.endjob_step,process.RAWSIMoutput_step)
+from PhysicsTools.PatAlgos.tools.helpers import associatePatAlgosToolsTask
+associatePatAlgosToolsTask(process)
+
+#Setup FWK for multithreaded
+process.options.numberOfThreads=cms.untracked.uint32(4)
+process.options.numberOfStreams=cms.untracked.uint32(0)
+process.options.numberOfConcurrentLuminosityBlocks=cms.untracked.uint32(0)
+# filter all path with the production filter sequence
+for path in process.paths:
+	getattr(process,path).insert(0, process.generator)
+
+# customisation of the process.
+
+# Automatic addition of the customisation function from Configuration.DataProcessing.Utils
+from Configuration.DataProcessing.Utils import addMonitoring 
+
+#call to customisation function addMonitoring imported from Configuration.DataProcessing.Utils
+process = addMonitoring(process)
+
+# End of customisation functions
+
+# Customisation from command line
+
+process.source.numberEventsInLuminosityBlock=cms.untracked.uint32(100)
+# Add early deletion of temporary data products to reduce peak memory need
+from Configuration.StandardSequences.earlyDeleteSettings_cff import customiseEarlyDelete
+process = customiseEarlyDelete(process)
+# End adding early deletion

--- a/GeneratorInterface/Pythia8Interface/plugins/Pythia8Hadronizer.cc
+++ b/GeneratorInterface/Pythia8Interface/plugins/Pythia8Hadronizer.cc
@@ -61,6 +61,7 @@ using namespace Pythia8;
 
 #include "GeneratorInterface/Core/interface/GeneratorFilter.h"
 #include "GeneratorInterface/Core/interface/HadronizerFilter.h"
+#include "GeneratorInterface/Core/interface/ConcurrentGeneratorFilter.h"
 #include "GeneratorInterface/Core/interface/ConcurrentHadronizerFilter.h"
 
 #include "GeneratorInterface/Pythia8Interface/plugins/LHAupLesHouches.h"
@@ -1007,6 +1008,10 @@ DEFINE_FWK_MODULE(Pythia8GeneratorFilter);
 
 typedef edm::HadronizerFilter<Pythia8Hadronizer, ExternalDecayDriver> Pythia8HadronizerFilter;
 DEFINE_FWK_MODULE(Pythia8HadronizerFilter);
+
+typedef edm::ConcurrentGeneratorFilter<Pythia8Hadronizer, ConcurrentExternalDecayDriver>
+    Pythia8ConcurrentGeneratorFilter;
+DEFINE_FWK_MODULE(Pythia8ConcurrentGeneratorFilter);
 
 typedef edm::ConcurrentHadronizerFilter<Pythia8Hadronizer, ConcurrentExternalDecayDriver>
     Pythia8ConcurrentHadronizerFilter;

--- a/GeneratorInterface/Pythia8Interface/test/BuildFile.xml
+++ b/GeneratorInterface/Pythia8Interface/test/BuildFile.xml
@@ -21,5 +21,4 @@
 <test name="TestGeneratorInterfacePythia8InterfaceCompareIdentical" command="cmsRun ${LOCALTOP}/src/GeneratorInterface/Pythia8Interface/test/compare_identical_generators_cfg.py"/>
 <test name="TestGeneratorInterfacePythia8InterfaceCompareExternal" command="cmsRun ${LOCALTOP}/src/GeneratorInterface/Pythia8Interface/test/compare_external_generators_cfg.py"/>
 <test name="TestGeneratorInterfacePythia8InterfaceCompareExternalStreams" command="cmsRun ${LOCALTOP}/src/GeneratorInterface/Pythia8Interface/test/compare_external_generators_streams_cfg.py"/>
-<test name="TestGeneratorInterfacePythia8ConcurrentGeneratorFilter" command="bash ${LOCALTOP}/src/GeneratorInterface/Pythia8Interface/test/test_Pythia8ConcurrentGeneratorFilter_WZ_TuneCP5_13TeV-pythia8.sh"/>
-
+<test name="TestGeneratorInterfacePythia8ConcurrentGeneratorFilter" command="${LOCALTOP}/src/GeneratorInterface/Pythia8Interface/test/test_Pythia8ConcurrentGeneratorFilter_WZ_TuneCP5_13TeV-pythia8.sh"/>

--- a/GeneratorInterface/Pythia8Interface/test/BuildFile.xml
+++ b/GeneratorInterface/Pythia8Interface/test/BuildFile.xml
@@ -21,3 +21,5 @@
 <test name="TestGeneratorInterfacePythia8InterfaceCompareIdentical" command="cmsRun ${LOCALTOP}/src/GeneratorInterface/Pythia8Interface/test/compare_identical_generators_cfg.py"/>
 <test name="TestGeneratorInterfacePythia8InterfaceCompareExternal" command="cmsRun ${LOCALTOP}/src/GeneratorInterface/Pythia8Interface/test/compare_external_generators_cfg.py"/>
 <test name="TestGeneratorInterfacePythia8InterfaceCompareExternalStreams" command="cmsRun ${LOCALTOP}/src/GeneratorInterface/Pythia8Interface/test/compare_external_generators_streams_cfg.py"/>
+<test name="TestGeneratorInterfacePythia8ConcurrentGeneratorFilter" command="bash ${LOCALTOP}/src/GeneratorInterface/Pythia8Interface/test/test_Pythia8ConcurrentGeneratorFilter_WZ_TuneCP5_13TeV-pythia8.sh"/>
+

--- a/GeneratorInterface/Pythia8Interface/test/pythia8test/runtest
+++ b/GeneratorInterface/Pythia8Interface/test/pythia8test/runtest
@@ -1,6 +1,3 @@
-cd ..
-scram b
-cd -
 rm -f testi.dat
 rm -f test.dat
 rm -f p8test.html

--- a/GeneratorInterface/Pythia8Interface/test/test_Pythia8ConcurrentGeneratorFilter_WZ_TuneCP5_13TeV-pythia8.sh
+++ b/GeneratorInterface/Pythia8Interface/test/test_Pythia8ConcurrentGeneratorFilter_WZ_TuneCP5_13TeV-pythia8.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+curl -s -k https://cms-pdmv.cern.ch/mcm/public/restapi/requests/get_fragment/BTV-RunIISummer20UL17GEN-00002 --retry 3 --create-dirs -o ${LOCALTOP}/src/Configuration/GenProduction/python/BTV-RunIISummer20UL17GEN-00002-fragment.py
+
+cd ${LOCALTOP}/src
+scram b
+cd ../..
+
+cmsDriver.py Configuration/GenProduction/python/BTV-RunIISummer20UL17GEN-00002-fragment.py --python_filename test_BTV-RunIISummer20UL17GEN-00002_1_cfg.py --eventcontent RAWSIM --customise Configuration/DataProcessing/Utils.addMonitoring --datatier GEN --fileout file:test_BTV-RunIISummer20UL17GEN-00002.root --conditions auto:run2_mc --beamspot Realistic25ns13TeVEarly2017Collision --customise_commands process.source.numberEventsInLuminosityBlock="cms.untracked.uint32(10)" --step GEN --geometry DB:Extended --era Run2_2017 --no_exec --mc -n 50 --nThreads 4 --nConcurrentLumis 0
+
+sed -i "s/Pythia8GeneratorFilter/Pythia8ConcurrentGeneratorFilter/g" test_BTV-RunIISummer20UL17GEN-00002_1_cfg.py
+
+cmsRun test_BTV-RunIISummer20UL17GEN-00002_1_cfg.py
+rm ${LOCALTOP}/src/Configuration/GenProduction/python/BTV-RunIISummer20UL17GEN-00002-fragment.py

--- a/GeneratorInterface/Pythia8Interface/test/test_Pythia8ConcurrentGeneratorFilter_WZ_TuneCP5_13TeV-pythia8.sh
+++ b/GeneratorInterface/Pythia8Interface/test/test_Pythia8ConcurrentGeneratorFilter_WZ_TuneCP5_13TeV-pythia8.sh
@@ -1,13 +1,11 @@
-#!/bin/bash
-curl -s -k https://cms-pdmv.cern.ch/mcm/public/restapi/requests/get_fragment/BTV-RunIISummer20UL17GEN-00002 --retry 3 --create-dirs -o ${LOCALTOP}/src/Configuration/GenProduction/python/BTV-RunIISummer20UL17GEN-00002-fragment.py
+#!/bin/bash -ex
+curl -s -k https://cms-pdmv.cern.ch/mcm/public/restapi/requests/get_fragment/BTV-RunIISummer20UL17GEN-00002 --retry 3 --create-dirs -o ${LOCALTOP}/src/GeneratorInterface/Pythia8Interface/python/BTV-RunIISummer20UL17GEN-00002-fragment.py
 
 cd ${LOCALTOP}/src
-scram b
-cd ../..
 
-cmsDriver.py Configuration/GenProduction/python/BTV-RunIISummer20UL17GEN-00002-fragment.py --python_filename test_BTV-RunIISummer20UL17GEN-00002_1_cfg.py --eventcontent RAWSIM --customise Configuration/DataProcessing/Utils.addMonitoring --datatier GEN --fileout file:test_BTV-RunIISummer20UL17GEN-00002.root --conditions auto:run2_mc --beamspot Realistic25ns13TeVEarly2017Collision --customise_commands process.source.numberEventsInLuminosityBlock="cms.untracked.uint32(10)" --step GEN --geometry DB:Extended --era Run2_2017 --no_exec --mc -n 50 --nThreads 4 --nConcurrentLumis 0
+cmsDriver.py GeneratorInterface/Pythia8Interface/python/BTV-RunIISummer20UL17GEN-00002-fragment.py --python_filename test_BTV-RunIISummer20UL17GEN-00002_1_cfg.py --eventcontent RAWSIM --customise Configuration/DataProcessing/Utils.addMonitoring --datatier GEN --fileout file:test_BTV-RunIISummer20UL17GEN-00002.root --conditions auto:run2_mc --beamspot Realistic25ns13TeVEarly2017Collision --customise_commands process.source.numberEventsInLuminosityBlock="cms.untracked.uint32(10)" --step GEN --geometry DB:Extended --era Run2_2017 --no_exec --mc -n 40 --nThreads 4 --nConcurrentLumis 0
 
 sed -i "s/Pythia8GeneratorFilter/Pythia8ConcurrentGeneratorFilter/g" test_BTV-RunIISummer20UL17GEN-00002_1_cfg.py
 
 cmsRun test_BTV-RunIISummer20UL17GEN-00002_1_cfg.py
-rm ${LOCALTOP}/src/Configuration/GenProduction/python/BTV-RunIISummer20UL17GEN-00002-fragment.py
+rm ${LOCALTOP}/src/GeneratorInterface/Pythia8Interface/python/BTV-RunIISummer20UL17GEN-00002-fragment.py

--- a/GeneratorInterface/Pythia8Interface/test/test_Pythia8ConcurrentGeneratorFilter_WZ_TuneCP5_13TeV-pythia8.sh
+++ b/GeneratorInterface/Pythia8Interface/test/test_Pythia8ConcurrentGeneratorFilter_WZ_TuneCP5_13TeV-pythia8.sh
@@ -1,11 +1,13 @@
 #!/bin/bash -ex
-curl -s -k https://cms-pdmv.cern.ch/mcm/public/restapi/requests/get_fragment/BTV-RunIISummer20UL17GEN-00002 --retry 3 --create-dirs -o ${LOCALTOP}/src/GeneratorInterface/Pythia8Interface/python/BTV-RunIISummer20UL17GEN-00002-fragment.py
 
-cd ${LOCALTOP}/src
+cd ${LOCALTOP}
+curl -s -k https://cms-pdmv.cern.ch/mcm/public/restapi/requests/get_fragment/BTV-RunIISummer20UL17GEN-00002 --retry 3 --create-dirs -o ${LOCALTOP}/tmp/GIP8/BTV-RunIISummer20UL17GEN-00002-fragment.py
+touch ${LOCALTOP}/tmp/GIP8/__init__.py
+export PYTHONPATH="${LOCALTOP}/tmp${PYTHONPATH:+:$PYTHONPATH}"
 
-cmsDriver.py GeneratorInterface/Pythia8Interface/python/BTV-RunIISummer20UL17GEN-00002-fragment.py --python_filename test_BTV-RunIISummer20UL17GEN-00002_1_cfg.py --eventcontent RAWSIM --customise Configuration/DataProcessing/Utils.addMonitoring --datatier GEN --fileout file:test_BTV-RunIISummer20UL17GEN-00002.root --conditions auto:run2_mc --beamspot Realistic25ns13TeVEarly2017Collision --customise_commands process.source.numberEventsInLuminosityBlock="cms.untracked.uint32(10)" --step GEN --geometry DB:Extended --era Run2_2017 --no_exec --mc -n 40 --nThreads 4 --nConcurrentLumis 0
+cmsDriver.py GIP8/BTV-RunIISummer20UL17GEN-00002-fragment.py --python_filename test_BTV-RunIISummer20UL17GEN-00002_1_cfg.py --eventcontent RAWSIM --customise Configuration/DataProcessing/Utils.addMonitoring --datatier GEN --fileout file:test_BTV-RunIISummer20UL17GEN-00002.root --conditions auto:run2_mc --beamspot Realistic25ns13TeVEarly2017Collision --customise_commands process.source.numberEventsInLuminosityBlock="cms.untracked.uint32(10)" --step GEN --geometry DB:Extended --era Run2_2017 --no_exec --mc -n 40 --nThreads 4 --nConcurrentLumis 0
 
 sed -i "s/Pythia8GeneratorFilter/Pythia8ConcurrentGeneratorFilter/g" test_BTV-RunIISummer20UL17GEN-00002_1_cfg.py
 
 cmsRun test_BTV-RunIISummer20UL17GEN-00002_1_cfg.py
-rm ${LOCALTOP}/src/GeneratorInterface/Pythia8Interface/python/BTV-RunIISummer20UL17GEN-00002-fragment.py
+rm -rf ${LOCALTOP}/tmp/GIP8


### PR DESCRIPTION
#### PR description:

**This PR is a backport of #33883.** 

It implements a thread-safe module `ConcurrentGeneratorFilter` for GEN workflows. This module replicates the Generator for each stream in order to run them concurrently and only works for thread-friendly hadronizers, decayers, and filters. It also provides a concurrent module of the Pythia8 generator, `Pythia8ConcurrentGeneratorFilter`. More detailed explanation and validation can be found in [these slides](https://indico.cern.ch/event/1045566/contributions/4392194/attachments/2261959/3839785/21.06.10_PPD_Concurrent%20GEN%20processing.pdf)(thanks to @colizz).

#### PR validation:

This PR is validated on multiple datasets, by replacing `Pythia8GeneratorFilter` with `Pythia8ConcurrentGeneratorFilter` in the GEN step configuration(see page 7 and 9 of above slides). Below is a quick test on [BTV-RunIISummer20UL17GEN-00002](https://cms-pdmv.cern.ch/mcm/requests?prepid=BTV-RunIISummer20UL17GEN-00002&page=0&shown=127) with 4 threads. There is also a unittest, `GeneratorInterface/Pythia8Interface/test/test_Pythia8ConcurrentGeneratorFilter_WZ_TuneCP5_13TeV-pythia8.sh`.

```bash
cmsrel CMSSW_10_6_X_2021-06-16-2300
cd CMSSW_10_6_X_2021-06-16-2300/src/
cmsenv
git cms-merge-topic PhyM73:bp-feature-ConcurrentGeneratorFilter
curl -s -k https://cms-pdmv.cern.ch/mcm/public/restapi/requests/get_fragment/BTV-RunIISummer20UL17GEN-00002 --retry 3 --create-dirs -o Configuration/GenProduction/python/BTV-RunIISummer20UL17GEN-00002-fragment.py
scram b -j 8
cd ../..
cmsDriver.py Configuration/GenProduction/python/BTV-RunIISummer20UL17GEN-00002-fragment.py --python_filename BTV-RunIISummer20UL17GEN-00002_1_cfg.py --eventcontent RAWSIM --customise Configuration/DataProcessing/Utils.addMonitoring --datatier GEN --fileout file:BTV-RunIISummer20UL17GEN-00002.root --conditions 106X_mc2017_realistic_v6 --beamspot Realistic25ns13TeVEarly2017Collision --customise_commands process.source.numberEventsInLuminosityBlock="cms.untracked.uint32(10)" --step GEN --geometry DB:Extended --era Run2_2017 --no_exec --mc -n 100 --nThreads 4 --nConcurrentLumis 0

sed -i "s/Pythia8GeneratorFilter/Pythia8ConcurrentGeneratorFilter/g" BTV-RunIISummer20UL17GEN-00002_1_cfg.py
cmsRun -e -j BTV-RunIISummer20UL17GEN-00002_report.xml BTV-RunIISummer20UL17GEN-00002_1_cfg.py
```