### PR TITLE
Fix mistake in muon shower valid flag. Enable showers in L1T (HadronicShowerTrigger-6)

### DIFF
--- a/DataFormats/L1TMuon/src/RegionalMuonShower.cc
+++ b/DataFormats/L1TMuon/src/RegionalMuonShower.cc
@@ -15,7 +15,7 @@ l1t::RegionalMuonShower::RegionalMuonShower(bool oneNominalInTime,
 l1t::RegionalMuonShower::~RegionalMuonShower() {}
 
 bool l1t::RegionalMuonShower::isValid() const {
-  return isTwoLooseInTime_ or isTwoLooseOutOfTime_ or isTwoLooseOutOfTime_ or isOneNominalOutOfTime_;
+  return isOneNominalInTime_ or isTwoLooseInTime_ or isOneNominalOutOfTime_ or isTwoLooseOutOfTime_;
 }
 
 bool l1t::RegionalMuonShower::operator==(const l1t::RegionalMuonShower& rhs) const {

--- a/DataFormats/L1Trigger/src/MuonShower.cc
+++ b/DataFormats/L1Trigger/src/MuonShower.cc
@@ -10,7 +10,7 @@ l1t::MuonShower::MuonShower(bool oneNominalInTime, bool oneNominalOutOfTime, boo
 l1t::MuonShower::~MuonShower() {}
 
 bool l1t::MuonShower::isValid() const {
-  return isTwoLooseInTime_ or isTwoLooseOutOfTime_ or isTwoLooseOutOfTime_ or isOneNominalOutOfTime_;
+  return isOneNominalInTime_ or isTwoLooseInTime_ or isOneNominalOutOfTime_ or isTwoLooseOutOfTime_;
 }
 
 bool l1t::MuonShower::operator==(const l1t::MuonShower& rhs) const {

--- a/L1Trigger/L1TMuon/plugins/L1TMuonShowerProducer.cc
+++ b/L1Trigger/L1TMuon/plugins/L1TMuonShowerProducer.cc
@@ -33,17 +33,13 @@ private:
   edm::EDGetTokenT<l1t::RegionalMuonShowerBxCollection> showerInputToken_;
   int bxMin_;
   int bxMax_;
-  unsigned minNominalShowers_;
-  unsigned minTwoLooseShowers_;
 };
 
 L1TMuonShowerProducer::L1TMuonShowerProducer(const edm::ParameterSet& iConfig)
     : showerInputTag_(iConfig.getParameter<edm::InputTag>("showerInput")),
       showerInputToken_(consumes<l1t::RegionalMuonShowerBxCollection>(showerInputTag_)),
       bxMin_(iConfig.getParameter<int>("bxMin")),
-      bxMax_(iConfig.getParameter<int>("bxMax")),
-      minNominalShowers_(iConfig.getParameter<unsigned>("minNominalShowers")),
-      minTwoLooseShowers_(iConfig.getParameter<unsigned>("minTwoLooseShowers")) {
+      bxMax_(iConfig.getParameter<int>("bxMax")) {
   produces<MuonShowerBxCollection>();
 }
 
@@ -63,30 +59,25 @@ void L1TMuonShowerProducer::produce(edm::Event& iEvent, const edm::EventSetup& i
     can either be in-time or out-of-time. The minimal implementation
     only considers the "at least 1-nominal shower" case.
    */
-  unsigned nNominalInTime = 0;
-  unsigned nNominalOutOfTime = 0;
-  unsigned nTwoLooseInTime = 0;
-  unsigned nTwoLooseOutOfTime = 0;
+  bool isOneNominalInTime = false;
+  bool isOneNominalOutOfTime = false;
+  bool isTwoLooseInTime = false;
+  bool isTwoLooseOutOfTime = false;
   for (size_t i = 0; i < emtfShowers->size(0); ++i) {
     auto shower = emtfShowers->at(0, i);
     if (shower.isValid()) {
       // nominal
       if (shower.isOneNominalInTime())
-        nNominalInTime++;
+        isOneNominalInTime = true;
       if (shower.isOneNominalOutOfTime())
-        nNominalOutOfTime++;
+        isOneNominalOutOfTime = true;
       // two loose
       if (shower.isTwoLooseInTime())
-        nTwoLooseInTime++;
+        isTwoLooseInTime = true;
       if (shower.isTwoLooseOutOfTime())
-        nTwoLooseOutOfTime++;
+        isTwoLooseOutOfTime = true;
     }
   }
-
-  const bool isOneNominalInTime(nNominalInTime >= minNominalShowers_);
-  const bool isOneNominalOutOfTime(nNominalOutOfTime >= minNominalShowers_);
-  const bool isTwoLooseInTime(nTwoLooseInTime >= minTwoLooseShowers_);
-  const bool isTwoLooseOutOfTime(nTwoLooseOutOfTime >= minTwoLooseShowers_);
 
   // Check for at least one nominal shower
   const bool acceptCondition(isOneNominalInTime or isOneNominalOutOfTime or isTwoLooseInTime or isTwoLooseOutOfTime);

--- a/L1Trigger/L1TMuon/python/simDigis_cff.py
+++ b/L1Trigger/L1TMuon/python/simDigis_cff.py
@@ -86,6 +86,13 @@ from Configuration.Eras.Modifier_stage2L1Trigger_cff import stage2L1Trigger
 #
 stage2L1Trigger.toReplaceWith(SimL1TMuonTask, cms.Task(SimL1TMuonCommonTask, simTwinMuxDigis, simBmtfDigis, simKBmtfStubs, simKBmtfDigis, simEmtfDigis, simOmtfDigis, simGmtCaloSumDigis, simGmtStage2Digis))
 
+## hadronic shower trigger for Run-3
+from Configuration.Eras.Modifier_run3_common_cff import run3_common
+_run3_Shower_SimL1TMuonTask = SimL1TMuonTask.copy()
+_run3_Shower_SimL1TMuonTask.add(simEmtfShowers)
+_run3_Shower_SimL1TMuonTask.add(simGmtShowerDigis)
+(stage2L1Trigger & run3_common).toReplaceWith( SimL1TMuonTask, _run3_Shower_SimL1TMuonTask )
+
 #
 # Phase-2 Trigger
 #


### PR DESCRIPTION
#### PR description:

Fix mistake in muon shower valid flag. The valid flag was not considering nominal muon showers in-time. I'm also enabling the showers in the sequence for Run-3 scenarios. Only the one-nominal-shower case is enabled for the time being. edmEventSize now shows the shower collections
```
CSCDetIdCSCShowerDigiMuonDigiCollection_simCscTriggerPrimitiveDigis_Anode_HLT. 331.6 309.2
CSCDetIdCSCShowerDigiMuonDigiCollection_simCscTriggerPrimitiveDigis__HLT. 324.6 302
l1tRegionalMuonShowerBXVector_simEmtfShowers_EMTF_HLT. 312.4 272.4
l1tMuonShowerBXVector_simGmtShowerDigis__HLT. 296.6 256.7
```

#### PR validation:

* Tested on Run-3 GEN-SIM-RAW samples
* Tested WF 11634.0
* scram b runtests
* scram b code-format; scram b code-checks

There should be no changes in WFs.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)

@kakwok @Nik-Menendez