### PR TITLE
fix DBG IBs warnings about EDM_ML_DEBUG redefined

### DIFF
--- a/Calibration/HcalCalibAlgos/plugins/AnalyzerMinbias.cc
+++ b/Calibration/HcalCalibAlgos/plugins/AnalyzerMinbias.cc
@@ -53,8 +53,6 @@
 #include "TH2.h"
 #include "TTree.h"
 
-#define EDM_ML_DEBUG
-
 namespace HcalMinbias {}
 
 // constructors and destructor

--- a/Calibration/HcalCalibAlgos/test/HcalIsoTrackStudy.cc
+++ b/Calibration/HcalCalibAlgos/test/HcalIsoTrackStudy.cc
@@ -83,8 +83,6 @@
 
 #include "SimDataFormats/GeneratorProducts/interface/GenEventInfoProduct.h"
 
-#define EDM_ML_DEBUG
-
 class HcalIsoTrackStudy : public edm::one::EDAnalyzer<edm::one::WatchRuns, edm::one::SharedResources> {
 public:
   explicit HcalIsoTrackStudy(edm::ParameterSet const&);

--- a/DetectorDescription/DDCMS/plugins/dd4hep/DDDefinitions2Objects.cc
+++ b/DetectorDescription/DDCMS/plugins/dd4hep/DDDefinitions2Objects.cc
@@ -29,8 +29,6 @@
 #include <unordered_map>
 #include <utility>
 
-#define EDM_ML_DEBUG
-
 using namespace std;
 using namespace dd4hep;
 using namespace cms;

--- a/FWCore/MessageService/test/UnitTestClient_Ad.cc
+++ b/FWCore/MessageService/test/UnitTestClient_Ad.cc
@@ -1,4 +1,6 @@
+#ifndef EDM_ML_DEBUG
 #define EDM_ML_DEBUG
+#endif
 
 #include "FWCore/MessageService/test/UnitTestClient_Ad.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"

--- a/FWCore/MessageService/test/UnitTestClient_Hd.cc
+++ b/FWCore/MessageService/test/UnitTestClient_Hd.cc
@@ -1,4 +1,6 @@
+#ifndef EDM_ML_DEBUG
 #define EDM_ML_DEBUG
+#endif
 
 #include "FWCore/MessageService/test/UnitTestClient_Hd.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"

--- a/FWCore/MessageService/test/UnitTestClient_Nd.h
+++ b/FWCore/MessageService/test/UnitTestClient_Nd.h
@@ -1,4 +1,6 @@
+#ifndef EDM_ML_DEBUG
 #define EDM_ML_DEBUG
+#endif
 
 #ifndef FWCore_MessageService_test_UnitTestClient_Nd_h
 #define FWCore_MessageService_test_UnitTestClient_Nd_h

--- a/FWCore/MessageService/test/UnitTestClient_Vd.cc
+++ b/FWCore/MessageService/test/UnitTestClient_Vd.cc
@@ -1,4 +1,6 @@
+#ifndef EDM_ML_DEBUG
 #define EDM_ML_DEBUG
+#endif
 
 #include "FWCore/MessageService/test/UnitTestClient_Vd.h"
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/FWCore/MessageService/test/standAloneTest.cpp
+++ b/FWCore/MessageService/test/standAloneTest.cpp
@@ -1,4 +1,6 @@
+#ifndef EDM_ML_DEBUG
 #define EDM_ML_DEBUG
+#endif
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 namespace edmtest {

--- a/FWCore/MessageService/test/unit_test_outputs/standAloneWithMessageLogger.cerr
+++ b/FWCore/MessageService/test/unit_test_outputs/standAloneWithMessageLogger.cerr
@@ -17,19 +17,19 @@ LogProblem  was used to send cat_A
 LogProblem  was used to send cat_B
 threshold DEBUG
 %MSG-d cat_A: 
- standAloneTest.cpp:7
+ standAloneTest.cpp:9
 
 %MSG
 %MSG-d cat_A: 
- standAloneTest.cpp:8
+ standAloneTest.cpp:10
  LogDebug.log was called
 %MSG
 %MSG-d cat_A: 
- standAloneTest.cpp:9
+ standAloneTest.cpp:11
 LogDebug    was used to send cat_A
 %MSG
 %MSG-d cat_B: 
- standAloneTest.cpp:10
+ standAloneTest.cpp:12
 LogDebug    was used to send cat_B
 %MSG
 LogTrace    was used to send cat_A

--- a/FWCore/MessageService/test/unit_test_outputs/u13d_debugs.log
+++ b/FWCore/MessageService/test/unit_test_outputs/u13d_debugs.log
@@ -1,9 +1,9 @@
 LogTrace was used to send this message
-%MSG-d cat_B:  UnitTestClient_Hd:sendSomeMessages Run: 1 Event: 1 UnitTestClient_Hd.cc:18
+%MSG-d cat_B:  UnitTestClient_Hd:sendSomeMessages Run: 1 Event: 1 UnitTestClient_Hd.cc:20
 LogDebug was used to send this other message
 %MSG
 IfLogTrace was used to send this message
-%MSG-d cat_B:  UnitTestClient_Hd:sendSomeMessages Run: 1 Event: 1 UnitTestClient_Hd.cc:21
+%MSG-d cat_B:  UnitTestClient_Hd:sendSomeMessages Run: 1 Event: 1 UnitTestClient_Hd.cc:23
 IfLogDebug was used to send this other message
 %MSG
 LogVerbatim was used to send this message
@@ -11,11 +11,11 @@ LogVerbatim was used to send this message
 LogInfo was used to send this other message
 %MSG
 LogTrace was used to send this message
-%MSG-d cat_B:  UnitTestClient_Hd:sendSomeMessages Run: 1 Event: 2 UnitTestClient_Hd.cc:18
+%MSG-d cat_B:  UnitTestClient_Hd:sendSomeMessages Run: 1 Event: 2 UnitTestClient_Hd.cc:20
 LogDebug was used to send this other message
 %MSG
 IfLogTrace was used to send this message
-%MSG-d cat_B:  UnitTestClient_Hd:sendSomeMessages Run: 1 Event: 2 UnitTestClient_Hd.cc:21
+%MSG-d cat_B:  UnitTestClient_Hd:sendSomeMessages Run: 1 Event: 2 UnitTestClient_Hd.cc:23
 IfLogDebug was used to send this other message
 %MSG
 LogVerbatim was used to send this message

--- a/FWCore/MessageService/test/unit_test_outputs/u16_altDebugs.mmlog
+++ b/FWCore/MessageService/test/unit_test_outputs/u16_altDebugs.mmlog
@@ -1,8 +1,8 @@
 Begin processing the 1st record. Run 1, Event 1, LumiSection 1 on stream 0 at {Timestamp} 
-%MSG-d cat_A:  UnitTestClient_Ad:sendSomeMessages Run: 1 Event: 1 UnitTestClient_Ad.cc:18
+%MSG-d cat_A:  UnitTestClient_Ad:sendSomeMessages Run: 1 Event: 1 UnitTestClient_Ad.cc:20
 LogDebug was used to send this message
 %MSG
-%MSG-d cat_B:  UnitTestClient_Ad:sendSomeMessages Run: 1 Event: 1 UnitTestClient_Ad.cc:19
+%MSG-d cat_B:  UnitTestClient_Ad:sendSomeMessages Run: 1 Event: 1 UnitTestClient_Ad.cc:21
 LogDebug was used to send this other message
 %MSG
 %MSG-e cat_A:  UnitTestClient_Ad:sendSomeMessages Run: 1 Event: 1
@@ -24,10 +24,10 @@ LogInfo was used to send this message
 LogInfo was used to send this other message
 %MSG
 Begin processing the 2nd record. Run 1, Event 2, LumiSection 1 on stream 0 at {Timestamp} 
-%MSG-d cat_A:  UnitTestClient_Ad:sendSomeMessages Run: 1 Event: 2 UnitTestClient_Ad.cc:18
+%MSG-d cat_A:  UnitTestClient_Ad:sendSomeMessages Run: 1 Event: 2 UnitTestClient_Ad.cc:20
 LogDebug was used to send this message
 %MSG
-%MSG-d cat_B:  UnitTestClient_Ad:sendSomeMessages Run: 1 Event: 2 UnitTestClient_Ad.cc:19
+%MSG-d cat_B:  UnitTestClient_Ad:sendSomeMessages Run: 1 Event: 2 UnitTestClient_Ad.cc:21
 LogDebug was used to send this other message
 %MSG
 %MSG-e cat_A:  UnitTestClient_Ad:sendSomeMessages Run: 1 Event: 2

--- a/FWCore/MessageService/test/unit_test_outputs/u1d_debugs.log
+++ b/FWCore/MessageService/test/unit_test_outputs/u1d_debugs.log
@@ -1,8 +1,8 @@
 Begin processing the 1st record. Run 1, Event 1, LumiSection 1 on stream 0 at {Timestamp} 
-%MSG-d cat_A:  UnitTestClient_Ad:sendSomeMessages Run: 1 Event: 1 UnitTestClient_Ad.cc:18
+%MSG-d cat_A:  UnitTestClient_Ad:sendSomeMessages Run: 1 Event: 1 UnitTestClient_Ad.cc:20
 LogDebug was used to send this message
 %MSG
-%MSG-d cat_B:  UnitTestClient_Ad:sendSomeMessages Run: 1 Event: 1 UnitTestClient_Ad.cc:19
+%MSG-d cat_B:  UnitTestClient_Ad:sendSomeMessages Run: 1 Event: 1 UnitTestClient_Ad.cc:21
 LogDebug was used to send this other message
 %MSG
 %MSG-e cat_A:  UnitTestClient_Ad:sendSomeMessages Run: 1 Event: 1
@@ -24,10 +24,10 @@ LogInfo was used to send this message
 LogInfo was used to send this other message
 %MSG
 Begin processing the 2nd record. Run 1, Event 2, LumiSection 1 on stream 0 at {Timestamp} 
-%MSG-d cat_A:  UnitTestClient_Ad:sendSomeMessages Run: 1 Event: 2 UnitTestClient_Ad.cc:18
+%MSG-d cat_A:  UnitTestClient_Ad:sendSomeMessages Run: 1 Event: 2 UnitTestClient_Ad.cc:20
 LogDebug was used to send this message
 %MSG
-%MSG-d cat_B:  UnitTestClient_Ad:sendSomeMessages Run: 1 Event: 2 UnitTestClient_Ad.cc:19
+%MSG-d cat_B:  UnitTestClient_Ad:sendSomeMessages Run: 1 Event: 2 UnitTestClient_Ad.cc:21
 LogDebug was used to send this other message
 %MSG
 %MSG-e cat_A:  UnitTestClient_Ad:sendSomeMessages Run: 1 Event: 2

--- a/FWCore/MessageService/test/unit_test_outputs/u33d_all.log
+++ b/FWCore/MessageService/test/unit_test_outputs/u33d_all.log
@@ -4,7 +4,7 @@ T1 beginJob warning with identifier 11 event 0
 %MSG-w cat_BJ:  UTC_Vd1:ssm_1b@beginJob pre-events
 T1 beginJob warning with identifier 12 event 0
 %MSG
-%MSG-d cat_BJ:  UTC_Vd1:ssm_1b@beginJob pre-events UnitTestClient_Vd.cc:26
+%MSG-d cat_BJ:  UTC_Vd1:ssm_1b@beginJob pre-events UnitTestClient_Vd.cc:28
 T1 beginJob debug with identifier 12 event 0
 %MSG
 %MSG-i cat_BR:  UTC_Vd1:ssm_1a@beginRun Run: 1
@@ -13,7 +13,7 @@ T1 beginRun info with identifier 11 event 0
 %MSG-i cat_BR:  UTC_Vd1:ssm_1b@beginRun Run: 1
 T1 beginRun info with identifier 12 event 0
 %MSG
-%MSG-d cat_BJ:  UTC_Vd1:ssm_1b@beginRun Run: 1 UnitTestClient_Vd.cc:31
+%MSG-d cat_BJ:  UTC_Vd1:ssm_1b@beginRun Run: 1 UnitTestClient_Vd.cc:33
 T1 beginRun debug with identifier 12 event 0
 %MSG
 %MSG-w cat_BL:  UTC_Vd1:ssm_1a@beginLumi Run: 1 Lumi: 1
@@ -22,7 +22,7 @@ T1 beginLumi warning with identifier 11 event 0
 %MSG-w cat_BL:  UTC_Vd1:ssm_1b@beginLumi Run: 1 Lumi: 1
 T1 beginLumi warning with identifier 12 event 0
 %MSG
-%MSG-d cat_BL:  UTC_Vd1:ssm_1b@beginLumi Run: 1 Lumi: 1 UnitTestClient_Vd.cc:36
+%MSG-d cat_BL:  UTC_Vd1:ssm_1b@beginLumi Run: 1 Lumi: 1 UnitTestClient_Vd.cc:38
 T1 beginLumi debug with identifier 12 event 0
 %MSG
 Begin processing the 1st record. Run 1, Event 1, LumiSection 1 on stream 0 at {Timestamp} 
@@ -50,7 +50,7 @@ T1 analyze warning with identifier 12 event 0
 %MSG-i cat_A:  UTC_Vd1:ssm_1b Run: 1 Event: 1
 T1 analyze info with identifier 12 event 0
 %MSG
-%MSG-d cat_A:  UTC_Vd1:ssm_1b Run: 1 Event: 1 UnitTestClient_Vd.cc:20
+%MSG-d cat_A:  UTC_Vd1:ssm_1b Run: 1 Event: 1 UnitTestClient_Vd.cc:22
 T1 analyze debug with identifier 12 event 0
 %MSG
 %MSG-e cat_A:  UTC_Vd2:ssm_2b Run: 1 Event: 1
@@ -87,7 +87,7 @@ T1 analyze warning with identifier 12 event 1
 %MSG-i cat_A:  UTC_Vd1:ssm_1b Run: 1 Event: 2
 T1 analyze info with identifier 12 event 1
 %MSG
-%MSG-d cat_A:  UTC_Vd1:ssm_1b Run: 1 Event: 2 UnitTestClient_Vd.cc:20
+%MSG-d cat_A:  UTC_Vd1:ssm_1b Run: 1 Event: 2 UnitTestClient_Vd.cc:22
 T1 analyze debug with identifier 12 event 1
 %MSG
 %MSG-e cat_A:  UTC_Vd2:ssm_2b Run: 1 Event: 2

--- a/Geometry/HcalAlgo/plugins/DDHCalTestBeamAlgo.cc
+++ b/Geometry/HcalAlgo/plugins/DDHCalTestBeamAlgo.cc
@@ -18,7 +18,6 @@
 #include "DetectorDescription/Core/interface/DDCurrentNamespace.h"
 #include "DetectorDescription/Core/interface/DDAlgorithmFactory.h"
 
-#define EDM_ML_DEBUG
 using namespace angle_units::operators;
 
 class DDHCalTestBeamAlgo : public DDAlgorithm {

--- a/Geometry/HcalCommonData/test/HcalRecNumberingTester.cc
+++ b/Geometry/HcalCommonData/test/HcalRecNumberingTester.cc
@@ -33,8 +33,6 @@
 #include "Geometry/Records/interface/HcalRecNumberingRecord.h"
 #include "Geometry/HcalCommonData/interface/HcalDDDRecConstants.h"
 
-#define EDM_ML_DEBUG
-
 class HcalRecNumberingTester : public edm::one::EDAnalyzer<> {
 public:
   explicit HcalRecNumberingTester(const edm::ParameterSet&);

--- a/Geometry/HcalTestBeamData/plugins/HcalTB02ParametersESModule.cc
+++ b/Geometry/HcalTestBeamData/plugins/HcalTB02ParametersESModule.cc
@@ -11,8 +11,6 @@
 
 #include <memory>
 
-#define EDM_ML_DEBUG
-
 class HcalTB02ParametersESModule : public edm::ESProducer {
 public:
   HcalTB02ParametersESModule(const edm::ParameterSet&);

--- a/Geometry/HcalTestBeamData/plugins/HcalTB06BeamParametersESModule.cc
+++ b/Geometry/HcalTestBeamData/plugins/HcalTB06BeamParametersESModule.cc
@@ -11,8 +11,6 @@
 
 #include <memory>
 
-#define EDM_ML_DEBUG
-
 class HcalTB06ParametersESModule : public edm::ESProducer {
 public:
   HcalTB06ParametersESModule(const edm::ParameterSet&);

--- a/Geometry/HcalTestBeamData/src/HcalTB02ParametersFromDD.cc
+++ b/Geometry/HcalTestBeamData/src/HcalTB02ParametersFromDD.cc
@@ -7,8 +7,6 @@
 #include "FWCore/Utilities/interface/Exception.h"
 #include "Geometry/HcalTestBeamData/interface/HcalTB02ParametersFromDD.h"
 
-#define EDM_ML_DEBUG
-
 bool HcalTB02ParametersFromDD::build(const DDCompactView* cpv, HcalTB02Parameters& php, const std::string& name) {
   DDSpecificsMatchesValueFilter filter{DDValue("ReadOutName", name, 0)};
   DDFilteredView fv(*cpv, filter);

--- a/Geometry/HcalTestBeamData/src/HcalTB06BeamParametersFromDD.cc
+++ b/Geometry/HcalTestBeamData/src/HcalTB06BeamParametersFromDD.cc
@@ -7,8 +7,6 @@
 #include "FWCore/Utilities/interface/Exception.h"
 #include "Geometry/HcalTestBeamData/interface/HcalTB06BeamParametersFromDD.h"
 
-#define EDM_ML_DEBUG
-
 bool HcalTB06BeamParametersFromDD::build(const DDCompactView* cpv,
                                          HcalTB06BeamParameters& php,
                                          const std::string& name1,

--- a/SimG4CMS/CherenkovAnalysis/plugins/CherenkovAnalysis.cc
+++ b/SimG4CMS/CherenkovAnalysis/plugins/CherenkovAnalysis.cc
@@ -38,8 +38,6 @@ Implementation:
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include <TH1F.h>
 
-#define EDM_ML_DEBUG
-
 class CherenkovAnalysis : public edm::EDAnalyzer {
 public:
   explicit CherenkovAnalysis(const edm::ParameterSet &);

--- a/SimG4CMS/CherenkovAnalysis/plugins/XtalDedxAnalysis.cc
+++ b/SimG4CMS/CherenkovAnalysis/plugins/XtalDedxAnalysis.cc
@@ -32,8 +32,6 @@
 #include <TH1F.h>
 #include <TH1I.h>
 
-#define EDM_ML_DEBUG
-
 class XtalDedxAnalysis : public edm::EDAnalyzer {
 public:
   explicit XtalDedxAnalysis(const edm::ParameterSet &);

--- a/SimG4CMS/ShowerLibraryProducer/test/AnalyzeTuples.cc
+++ b/SimG4CMS/ShowerLibraryProducer/test/AnalyzeTuples.cc
@@ -41,8 +41,6 @@ Implementation:
 #include "TH1F.h"
 #include "TH1I.h"
 
-#define EDM_ML_DEBUG
-
 class AnalyzeTuples : public edm::one::EDAnalyzer<edm::one::SharedResources> {
 public:
   explicit AnalyzeTuples(const edm::ParameterSet&);

--- a/Validation/Geometry/src/MaterialBudget.cc
+++ b/Validation/Geometry/src/MaterialBudget.cc
@@ -15,7 +15,6 @@
 #include "DD4hep/Filter.h"
 
 #include <iostream>
-#define EDM_ML_DEBUG
 
 MaterialBudget::MaterialBudget(const edm::ParameterSet& p) {
   edm::ParameterSet m_p = p.getParameter<edm::ParameterSet>("MaterialBudget");


### PR DESCRIPTION
In DBG IBs ( build with `-g -O3 -DEDM_ML_DEBUG` flags)  there many warnings about redefinition of EDM_ML_DEBUG. This PR proposes to either remove the definition from code or protect it by first checking if it is already set.