### PR TITLE
Initialize data members to avoid compiler warnings

### DIFF
--- a/TrackingTools/DetLayers/interface/DetGroup.h
+++ b/TrackingTools/DetLayers/interface/DetGroup.h
@@ -43,7 +43,7 @@ public:
   typedef std::vector<DetGroupElement> Base;
   typedef DetGroupElement::DetWithState DetWithState;
 
-  DetGroup() {}
+  DetGroup() : index_(0), indexSize_(0) {}
   DetGroup(DetGroup const& rhs) : Base(rhs), index_(rhs.index_), indexSize_(rhs.indexSize_) {}
   DetGroup(DetGroup&& rhs) noexcept : Base(std::forward<Base>(rhs)), index_(rhs.index_), indexSize_(rhs.indexSize_) {}
   DetGroup& operator=(DetGroup const& rhs) {


### PR DESCRIPTION
With `-O3` in DBG IBs, compiler complains about possible uninitialized daa member [a].  This Pr proposes to initialize the data members in default constructor.

[a] 
```
  TrackingTools/DetLayers/interface/DetGroup.h:48:81: warning: '*((void*)&<anonymous> +24)' may be used uninitialized in this function [-Wmaybe-uninitialized]
    48 |   DetGroup(DetGroup&& rhs) noexcept : Base(std::forward<Base>(rhs)), index_(rhs.index_), indexSize_(rhs.indexSize_) {}

```