### PR TITLE
Validation/RecoMuon HTrack: make a copy instead of a reference to a temporary

### DIFF
--- a/Validation/RecoMuon/src/HTrack.cc
+++ b/Validation/RecoMuon/src/HTrack.cc
@@ -237,7 +237,7 @@ void HTrack::computeTDRResolution(const FreeTrajectoryState& fts, SimTrack& simT
 
 void HTrack::computePull(const FreeTrajectoryState& fts, SimTrack& simTrack, HResolution* hReso) {
   // x,y,z, px,py,pz
-  AlgebraicSymMatrix66 const& errors = fts.cartesianError().matrix();
+  AlgebraicSymMatrix66 const errors = fts.cartesianError().matrix();
 
   double partialPterror = errors[3][3] * pow(fts.momentum().x(), 2) + errors[4][4] * pow(fts.momentum().y(), 2);
 


### PR DESCRIPTION
in `M const& errors = fts.cartesianError().matrix();` the `cartesianError()` returns a temporary by value, while `.matrix()` returns a reference to it.
For a general return function the underlying temporary would/could be deleted after the expression is executed and the behavior of the result is undefined.
It seems like due to `.matrix()` being inlined we are getting an extension to the lifetime of the temporary.

This update is to explicitly avoid the undefined behavior.
