### PR TITLE
fix filling of pythia userhooks

### DIFF
--- a/GeneratorInterface/Pythia8Interface/plugins/Pythia8Hadronizer.cc
+++ b/GeneratorInterface/Pythia8Interface/plugins/Pythia8Hadronizer.cc
@@ -446,7 +446,9 @@ bool Pythia8Hadronizer::initializeForInternalPartons() {
   }
 
   if (!(fUserHooksVector->hooks).empty() && !UserHooksSet) {
-    fMasterGen->setUserHooksPtr(fUserHooksVector);
+    for (auto &fUserHook : fUserHooksVector->hooks) {
+      fMasterGen->addUserHooksPtr(fUserHook);
+    }
     UserHooksSet = true;
   }
 
@@ -589,7 +591,9 @@ bool Pythia8Hadronizer::initializeForExternalPartons() {
   }
 
   if (!(fUserHooksVector->hooks).empty() && !UserHooksSet) {
-    fMasterGen->setUserHooksPtr(fUserHooksVector);
+    for (auto &fUserHook : fUserHooksVector->hooks) {
+      fMasterGen->addUserHooksPtr(fUserHook);
+    }
     UserHooksSet = true;
   }
 


### PR DESCRIPTION
PR is a back-port of this pull request from steve mrenna:  https://github.com/cms-sw/cmssw/pull/34068 
we need a back-port to the current run 3 cmssw release which is still 11_2. 
the original PR was to fix a segmentation fault of P8 when using userhooks. the code crashed at the start of a new lumisection. 
I tested that the PR helps to avoid the crash and TSG-Run3Winter21GS-00071 runs fine. More tests already done for the master PR. 
