### PR TITLE
Replace deprecated ext/hash_map with std::unordered_map

### DIFF
--- a/CalibTracker/SiStripQuality/interface/SiStripQualityHistos.h
+++ b/CalibTracker/SiStripQuality/interface/SiStripQualityHistos.h
@@ -1,10 +1,10 @@
 #ifndef SiStripQualityHistos_H
 #define SiStripQualityHistos_H
 
-#include <ext/hash_map>
+#include <unordered_map>
 #include "TH1F.h"
 
 namespace SiStrip {
-  typedef __gnu_cxx::hash_map<unsigned int, std::shared_ptr<TH1F> > QualityHistosMap;
+  typedef std::unordered_map<unsigned int, std::shared_ptr<TH1F> > QualityHistosMap;
 }
 #endif

--- a/CalibTracker/SiStripQuality/plugins/SiStripBadModuleByHandBuilder.h
+++ b/CalibTracker/SiStripQuality/plugins/SiStripBadModuleByHandBuilder.h
@@ -11,8 +11,6 @@
 #include "CalibTracker/SiStripCommon/interface/SiStripDetInfoFileReader.h"
 #include <vector>
 
-#include <ext/hash_map>
-
 class SiStripBadModuleByHandBuilder : public ConditionDBWriter<SiStripBadStrip> {
 public:
   explicit SiStripBadModuleByHandBuilder(const edm::ParameterSet&);

--- a/CondTools/SiPixel/test/SiPixelBadModuleByHandBuilder.h
+++ b/CondTools/SiPixel/test/SiPixelBadModuleByHandBuilder.h
@@ -14,7 +14,6 @@
 #include "Geometry/Records/interface/TrackerTopologyRcd.h"
 
 #include <vector>
-#include <ext/hash_map>
 
 class SiPixelBadModuleByHandBuilder : public ConditionDBWriter<SiPixelQuality> {
 public:

--- a/CondTools/SiStrip/plugins/SiStripBadChannelBuilder.h
+++ b/CondTools/SiStrip/plugins/SiStripBadChannelBuilder.h
@@ -15,7 +15,6 @@
 
 #include <vector>
 #include <memory>
-#include <ext/hash_map>
 
 class SiStripBadChannelBuilder : public ConditionDBWriter<SiStripBadStrip> {
 public:

--- a/CondTools/SiStrip/plugins/SiStripBadFiberBuilder.h
+++ b/CondTools/SiStrip/plugins/SiStripBadFiberBuilder.h
@@ -11,8 +11,6 @@
 #include "FWCore/ParameterSet/interface/FileInPath.h"
 #include <vector>
 
-#include <ext/hash_map>
-
 class SiStripBadFiberBuilder : public ConditionDBWriter<SiStripBadStrip> {
 public:
   explicit SiStripBadFiberBuilder(const edm::ParameterSet&);

--- a/L1Trigger/GlobalTrigger/interface/L1GtAlgorithmEvaluation.h
+++ b/L1Trigger/GlobalTrigger/interface/L1GtAlgorithmEvaluation.h
@@ -15,44 +15,16 @@
  *
  */
 
-//   for L1GtLogicParser
+#include "DataFormats/L1GlobalTrigger/interface/L1GlobalTriggerObjectMapFwd.h"
 #include "DataFormats/L1GlobalTrigger/interface/L1GtLogicParser.h"
 
-// system include files
 #include <iostream>
-
 #include <map>
 #include <queue>
 #include <stack>
 #include <string>
+#include <unordered_map>
 #include <vector>
-
-// if hash map is used
-
-#include <ext/hash_map>
-
-//   how to hash std::string, using a "template specialization"
-namespace __gnu_cxx {
-
-  /**
- Explicit template specialization of hash of a string class,
- which just uses the internal char* representation as a wrapper.
- */
-  template <>
-  struct hash<std::string> {
-    size_t operator()(const std::string &x) const { return hash<const char *>()(x.c_str()); }
-  };
-
-}  // namespace __gnu_cxx
-// end hash map
-
-// user include files
-
-//   base class
-#include "DataFormats/L1GlobalTrigger/interface/L1GtLogicParser.h"
-
-//
-#include "DataFormats/L1GlobalTrigger/interface/L1GlobalTriggerObjectMapFwd.h"
 
 // forward declarations
 class L1GtAlgorithm;
@@ -79,7 +51,7 @@ public:
 
   // typedef std::map<std::string, L1GtConditionEvaluation*>
   // ConditionEvaluationMap;
-  typedef __gnu_cxx ::hash_map<std::string, L1GtConditionEvaluation *> ConditionEvaluationMap;
+  typedef std ::unordered_map<std::string, L1GtConditionEvaluation *> ConditionEvaluationMap;
   typedef ConditionEvaluationMap::const_iterator CItEvalMap;
   typedef ConditionEvaluationMap::iterator ItEvalMap;
 

--- a/L1Trigger/GlobalTrigger/src/L1GlobalTriggerGTL.cc
+++ b/L1Trigger/GlobalTrigger/src/L1GlobalTriggerGTL.cc
@@ -16,9 +16,6 @@
 // this class header
 #include "L1Trigger/GlobalTrigger/interface/L1GlobalTriggerGTL.h"
 
-// system include files
-#include <ext/hash_map>
-
 // user include files
 #include "DataFormats/L1GlobalTrigger/interface/L1GlobalTriggerObjectMap.h"
 

--- a/L1Trigger/GlobalTrigger/src/L1GtAlgorithmEvaluation.cc
+++ b/L1Trigger/GlobalTrigger/src/L1GtAlgorithmEvaluation.cc
@@ -26,7 +26,6 @@
 #include <iostream>
 
 #include <boost/algorithm/string.hpp>
-#include <ext/hash_map>
 
 // user include files
 

--- a/L1Trigger/L1TGlobal/interface/AlgorithmEvaluation.h
+++ b/L1Trigger/L1TGlobal/interface/AlgorithmEvaluation.h
@@ -17,45 +17,16 @@
  *
  */
 
-//   for L1GtLogicParser
 #include "DataFormats/L1TGlobal/interface/GlobalLogicParser.h"
-
-// system include files
-#include <iostream>
-
-#include <string>
-#include <vector>
-#include <map>
-#include <stack>
-#include <queue>
-
-// if hash map is used
-
-#include <ext/hash_map>
 #include "DataFormats/L1TGlobal/interface/GlobalObjectMapFwd.h"
 
-//   how to hash std::string, using a "template specialization"
-// DMP Comment out for not to prevent conflicts
-namespace __gnu_cxx {
-
-  /** 
-      Explicit template specialization of hash of a string class, 
-      which just uses the internal char* representation as a wrapper. 
-      */
-  template <>
-  struct hash<std::string> {
-    size_t operator()(const std::string& x) const { return hash<const char*>()(x.c_str()); }
-  };
-
-}  // namespace __gnu_cxx
-// end hash map
-
-// user include files
-
-//   base class
-#include "DataFormats/L1TGlobal/interface/GlobalLogicParser.h"
-
-//
+#include <iostream>
+#include <map>
+#include <queue>
+#include <stack>
+#include <string>
+#include <unordered_map>
+#include <vector>
 
 // forward declarations
 class GlobalAlgorithm;
@@ -84,7 +55,7 @@ namespace l1t {
     // virtual ~AlgorithmEvaluation();
 
     //typedef std::map<std::string, ConditionEvaluation*> ConditionEvaluationMap;
-    typedef __gnu_cxx ::hash_map<std::string, ConditionEvaluation*> ConditionEvaluationMap;
+    typedef std::unordered_map<std::string, ConditionEvaluation*> ConditionEvaluationMap;
     typedef ConditionEvaluationMap::const_iterator CItEvalMap;
     typedef ConditionEvaluationMap::iterator ItEvalMap;
 

--- a/L1Trigger/L1TGlobal/src/AlgorithmEvaluation.cc
+++ b/L1Trigger/L1TGlobal/src/AlgorithmEvaluation.cc
@@ -25,9 +25,6 @@
 #include <iostream>
 #include <iomanip>
 
-#include <boost/algorithm/string.hpp>
-#include <ext/hash_map>
-
 // user include files
 
 //

--- a/L1Trigger/L1TGlobal/src/GlobalBoard.cc
+++ b/L1Trigger/L1TGlobal/src/GlobalBoard.cc
@@ -20,9 +20,6 @@
 // this class header
 #include "L1Trigger/L1TGlobal/interface/GlobalBoard.h"
 
-// system include files
-#include <ext/hash_map>
-
 // user include files
 #include "DataFormats/L1TGlobal/interface/GlobalObjectMap.h"
 #include "L1Trigger/L1TGlobal/interface/TriggerMenu.h"


### PR DESCRIPTION
#### PR description:

The PR replaces the deprecated `ext/hash_map` with `std::unordered_map`. This fixes build warnings I saw in my CMSSW builds.

#### PR validation:

CMSSW compilers

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

No backport intended.
