### PR TITLE
MTD reconstruction: revision of the AODSIM event content

### DIFF
--- a/RecoLocalFastTime/Configuration/python/RecoLocalFastTime_EventContent_cff.py
+++ b/RecoLocalFastTime/Configuration/python/RecoLocalFastTime_EventContent_cff.py
@@ -17,8 +17,6 @@ RecoLocalFastTimeRECO.outputCommands.extend(RecoLocalFastTimeAOD.outputCommands)
 #FEVT
 RecoLocalFastTimeFEVT = cms.PSet(
     outputCommands = cms.untracked.vstring(
-        'keep *_mtdRecHits_*_*',
-        'keep *_mtdClusters_*_*',
         'keep *_mtdUncalibratedRecHits_*_*',
         'keep *_mtdTrackingRecHits_*_*',
     )

--- a/RecoLocalFastTime/Configuration/python/RecoLocalFastTime_EventContent_cff.py
+++ b/RecoLocalFastTime/Configuration/python/RecoLocalFastTime_EventContent_cff.py
@@ -18,6 +18,8 @@ RecoLocalFastTimeRECO = cms.PSet(
 )
 #AOD content
 RecoLocalFastTimeAOD = cms.PSet(
-    outputCommands = cms.untracked.vstring()
+    outputCommands = cms.untracked.vstring(
+        'keep *_mtdClusters_*_*',
+    )
 )
 

--- a/RecoLocalFastTime/Configuration/python/RecoLocalFastTime_EventContent_cff.py
+++ b/RecoLocalFastTime/Configuration/python/RecoLocalFastTime_EventContent_cff.py
@@ -1,23 +1,26 @@
 import FWCore.ParameterSet.Config as cms
 
-#FEVT
-RecoLocalFastTimeFEVT = cms.PSet(
-    outputCommands = cms.untracked.vstring(
-        'keep *_mtdUncalibratedRecHits_*_*',
-        'keep *_mtdRecHits_*_*',
-        'keep *_mtdClusters_*_*',
-        'keep *_mtdTrackingRecHits_*_*'
-        )
-)
-#RECO content
-RecoLocalFastTimeRECO = cms.PSet(
-    outputCommands = cms.untracked.vstring(
-        'keep *_mtdRecHits_*_*',
-        'keep *_mtdClusters_*_*',
-        )
-)
 #AOD content
 RecoLocalFastTimeAOD = cms.PSet(
     outputCommands = cms.untracked.vstring()
 )
 
+#RECO content
+RecoLocalFastTimeRECO = cms.PSet(
+    outputCommands = cms.untracked.vstring(
+        'keep *_mtdRecHits_*_*',
+        'keep *_mtdClusters_*_*',
+    )
+)
+RecoLocalFastTimeRECO.outputCommands.extend(RecoLocalFastTimeAOD.outputCommands)
+
+#FEVT
+RecoLocalFastTimeFEVT = cms.PSet(
+    outputCommands = cms.untracked.vstring(
+        'keep *_mtdRecHits_*_*',
+        'keep *_mtdClusters_*_*',
+        'keep *_mtdUncalibratedRecHits_*_*',
+        'keep *_mtdTrackingRecHits_*_*',
+    )
+)
+RecoLocalFastTimeFEVT.outputCommands.extend(RecoLocalFastTimeRECO.outputCommands)

--- a/RecoLocalFastTime/Configuration/python/RecoLocalFastTime_EventContent_cff.py
+++ b/RecoLocalFastTime/Configuration/python/RecoLocalFastTime_EventContent_cff.py
@@ -18,8 +18,6 @@ RecoLocalFastTimeRECO = cms.PSet(
 )
 #AOD content
 RecoLocalFastTimeAOD = cms.PSet(
-    outputCommands = cms.untracked.vstring(
-        'keep *_mtdClusters_*_*',
-    )
+    outputCommands = cms.untracked.vstring()
 )
 

--- a/RecoLocalFastTime/Configuration/python/RecoLocalFastTime_EventContent_cff.py
+++ b/RecoLocalFastTime/Configuration/python/RecoLocalFastTime_EventContent_cff.py
@@ -12,14 +12,12 @@ RecoLocalFastTimeFEVT = cms.PSet(
 #RECO content
 RecoLocalFastTimeRECO = cms.PSet(
     outputCommands = cms.untracked.vstring(
-        'keep *_mtdRecHits_*_*', 
-        'keep *_mtdClusters_*_*',       
+        'keep *_mtdRecHits_*_*',
+        'keep *_mtdClusters_*_*',
         )
 )
 #AOD content
 RecoLocalFastTimeAOD = cms.PSet(
-    outputCommands = cms.untracked.vstring(
-         'keep *_mtdClusters_*_*',
-    )
+    outputCommands = cms.untracked.vstring()
 )
 

--- a/RecoMTD/Configuration/python/RecoMTD_EventContent_cff.py
+++ b/RecoMTD/Configuration/python/RecoMTD_EventContent_cff.py
@@ -16,8 +16,7 @@ RecoMTDRECO.outputCommands.extend(RecoMTDFEVT.outputCommands)
 #AOD
 RecoMTDAOD = cms.PSet(
     outputCommands = cms.untracked.vstring(
-        'keep *_trackExtenderWithMTD_*_*',
-        'drop recoTracks_trackExtenderWithMTD_*_*',
-        'drop recoTrackExtras_trackExtenderWithMTD_*_*',
+        'keep intedmValueMap_trackExtenderWithMTD_*_*',
+        'keep floatedmValueMap_trackExtenderWithMTD_*_*',
         'keep *_mtdTrackQualityMVA_*_*')
 )

--- a/RecoMTD/Configuration/python/RecoMTD_EventContent_cff.py
+++ b/RecoMTD/Configuration/python/RecoMTD_EventContent_cff.py
@@ -1,17 +1,17 @@
 import FWCore.ParameterSet.Config as cms
 
-#FEVT content
-RecoMTDFEVT = cms.PSet(
+#RECO content
+RecoMTDRECO = cms.PSet(
     outputCommands = cms.untracked.vstring(
         'keep *_trackExtenderWithMTD_*_*',
         'keep *_mtdTrackQualityMVA_*_*')
 )
 
-#RECO content
-RecoMTDRECO = cms.PSet(
+#FEVT content
+RecoMTDFEVT = cms.PSet(
     outputCommands = cms.untracked.vstring()
 )
-RecoMTDRECO.outputCommands.extend(RecoMTDFEVT.outputCommands)
+RecoMTDFEVT.outputCommands.extend(RecoMTDRECO.outputCommands)
 
 #AOD
 RecoMTDAOD = cms.PSet(

--- a/RecoMTD/Configuration/python/RecoMTD_EventContent_cff.py
+++ b/RecoMTD/Configuration/python/RecoMTD_EventContent_cff.py
@@ -1,18 +1,5 @@
 import FWCore.ParameterSet.Config as cms
 
-#RECO content
-RecoMTDRECO = cms.PSet(
-    outputCommands = cms.untracked.vstring(
-        'keep *_trackExtenderWithMTD_*_*',
-        'keep *_mtdTrackQualityMVA_*_*')
-)
-
-#FEVT content
-RecoMTDFEVT = cms.PSet(
-    outputCommands = cms.untracked.vstring()
-)
-RecoMTDFEVT.outputCommands.extend(RecoMTDRECO.outputCommands)
-
 #AOD
 RecoMTDAOD = cms.PSet(
     outputCommands = cms.untracked.vstring(
@@ -20,3 +7,18 @@ RecoMTDAOD = cms.PSet(
         'keep floatedmValueMap_trackExtenderWithMTD_*_*',
         'keep *_mtdTrackQualityMVA_*_*')
 )
+
+#RECO content
+RecoMTDRECO = cms.PSet(
+    outputCommands = cms.untracked.vstring(
+         'keep *_trackExtenderWithMTD_*_*',
+         'keep *_mtdTrackQualityMVA_*_*',
+    )
+)
+RecoMTDRECO.outputCommands.extend(RecoMTDAOD.outputCommands)
+
+#FEVT content
+RecoMTDFEVT = cms.PSet(
+    outputCommands = cms.untracked.vstring()
+)
+RecoMTDFEVT.outputCommands.extend(RecoMTDRECO.outputCommands)

--- a/RecoMTD/Configuration/python/RecoMTD_EventContent_cff.py
+++ b/RecoMTD/Configuration/python/RecoMTD_EventContent_cff.py
@@ -11,8 +11,8 @@ RecoMTDAOD = cms.PSet(
 #RECO content
 RecoMTDRECO = cms.PSet(
     outputCommands = cms.untracked.vstring(
-         'keep *_trackExtenderWithMTD_*_*',
-         'keep *_mtdTrackQualityMVA_*_*',
+         'keep recoTrack*_trackExtenderWithMTD_*_*',
+         'keep TrackingRecHitsOwned_trackExtenderWithMTD_*_*',
     )
 )
 RecoMTDRECO.outputCommands.extend(RecoMTDAOD.outputCommands)

--- a/RecoMTD/Configuration/python/RecoMTD_EventContent_cff.py
+++ b/RecoMTD/Configuration/python/RecoMTD_EventContent_cff.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
-#AOD
-RecoMTDAOD = cms.PSet(
+#FEVT content
+RecoMTDFEVT = cms.PSet(
     outputCommands = cms.untracked.vstring(
         'keep *_trackExtenderWithMTD_*_*',
         'keep *_mtdTrackQualityMVA_*_*')
@@ -9,12 +9,15 @@ RecoMTDAOD = cms.PSet(
 
 #RECO content
 RecoMTDRECO = cms.PSet(
-    outputCommands = cms.untracked.vstring() 
+    outputCommands = cms.untracked.vstring()
 )
-RecoMTDRECO.outputCommands.extend(RecoMTDAOD.outputCommands)
+RecoMTDRECO.outputCommands.extend(RecoMTDFEVT.outputCommands)
 
-#FEVT content
-RecoMTDFEVT = cms.PSet(
-    outputCommands = cms.untracked.vstring() 
+#AOD
+RecoMTDAOD = cms.PSet(
+    outputCommands = cms.untracked.vstring(
+        'keep *_trackExtenderWithMTD_*_*',
+        'drop recoTracks_trackExtenderWithMTD_*_*',
+        'drop recoTrackExtras_trackExtenderWithMTD_*_*',
+        'keep *_mtdTrackQualityMVA_*_*')
 )
-RecoMTDFEVT.outputCommands.extend(RecoMTDRECO.outputCommands)

--- a/RecoMTD/TimingIDTools/interface/MTDTrackQualityMVA.h
+++ b/RecoMTD/TimingIDTools/interface/MTDTrackQualityMVA.h
@@ -38,7 +38,8 @@ public:
   //---getters---
   // 4D
   float operator()(const reco::TrackRef& trk,
-                   const reco::TrackRef& ext_trk,
+                   const edm::ValueMap<int>& npixBarrels,
+                   const edm::ValueMap<int>& npixEndcaps,
                    const edm::ValueMap<float>& btl_chi2s,
                    const edm::ValueMap<float>& btl_time_chi2s,
                    const edm::ValueMap<float>& etl_chi2s,

--- a/RecoMTD/TimingIDTools/plugins/MTDTrackQualityMVAProducer.cc
+++ b/RecoMTD/TimingIDTools/plugins/MTDTrackQualityMVAProducer.cc
@@ -44,14 +44,14 @@ private:
   edm::EDGetTokenT<edm::ValueMap<float>> etlMatchTimeChi2Token_;
   edm::EDGetTokenT<edm::ValueMap<float>> mtdTimeToken_;
   edm::EDGetTokenT<edm::ValueMap<float>> pathLengthToken_;
-  edm::EDGetTokenT<edm::ValueMap<int>> trackAssocToken_;
+  edm::EDGetTokenT<edm::ValueMap<int>> npixBarrelToken_;
+  edm::EDGetTokenT<edm::ValueMap<int>> npixEndcapToken_;
 
   MTDTrackQualityMVA mva_;
 };
 
 MTDTrackQualityMVAProducer::MTDTrackQualityMVAProducer(const ParameterSet& iConfig)
     : tracksToken_(consumes<reco::TrackCollection>(iConfig.getParameter<edm::InputTag>("tracksSrc"))),
-      tracksMTDToken_(consumes<reco::TrackCollection>(iConfig.getParameter<edm::InputTag>("tracksMTDSrc"))),
       btlMatchChi2Token_(consumes<edm::ValueMap<float>>(iConfig.getParameter<edm::InputTag>("btlMatchChi2Src"))),
       btlMatchTimeChi2Token_(
           consumes<edm::ValueMap<float>>(iConfig.getParameter<edm::InputTag>("btlMatchTimeChi2Src"))),
@@ -60,7 +60,8 @@ MTDTrackQualityMVAProducer::MTDTrackQualityMVAProducer(const ParameterSet& iConf
           consumes<edm::ValueMap<float>>(iConfig.getParameter<edm::InputTag>("etlMatchTimeChi2Src"))),
       mtdTimeToken_(consumes<edm::ValueMap<float>>(iConfig.getParameter<edm::InputTag>("mtdTimeSrc"))),
       pathLengthToken_(consumes<edm::ValueMap<float>>(iConfig.getParameter<edm::InputTag>("pathLengthSrc"))),
-      trackAssocToken_(consumes<edm::ValueMap<int>>(iConfig.getParameter<edm::InputTag>("trackAssocSrc"))),
+      npixBarrelToken_(consumes<edm::ValueMap<int>>(iConfig.getParameter<edm::InputTag>("npixBarrelSrc"))),
+      npixEndcapToken_(consumes<edm::ValueMap<int>>(iConfig.getParameter<edm::InputTag>("npixEndcapSrc"))),
       mva_(iConfig.getParameter<edm::FileInPath>("qualityBDT_weights_file").fullPath()) {
   produces<edm::ValueMap<float>>(mvaName);
 }
@@ -69,8 +70,6 @@ MTDTrackQualityMVAProducer::MTDTrackQualityMVAProducer(const ParameterSet& iConf
 void MTDTrackQualityMVAProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
   desc.add<edm::InputTag>("tracksSrc", edm::InputTag("generalTracks"))->setComment("Input tracks collection");
-  desc.add<edm::InputTag>("tracksMTDSrc", edm::InputTag("trackExtenderWithMTD"))
-      ->setComment("Input tracks collection for MTD extended tracks");
   desc.add<edm::InputTag>("btlMatchChi2Src", edm::InputTag("trackExtenderWithMTD", "btlMatchChi2"))
       ->setComment("BTL Chi2 Matching value Map");
   desc.add<edm::InputTag>("btlMatchTimeChi2Src", edm::InputTag("trackExtenderWithMTD", "btlMatchTimeChi2"))
@@ -79,12 +78,14 @@ void MTDTrackQualityMVAProducer::fillDescriptions(edm::ConfigurationDescriptions
       ->setComment("ETL Chi2 Matching value Map");
   desc.add<edm::InputTag>("etlMatchTimeChi2Src", edm::InputTag("trackExtenderWithMTD", "etlMatchTimeChi2"))
       ->setComment("ETL Chi2 Matching value Map");
-  desc.add<edm::InputTag>("mtdTimeSrc", edm::InputTag("trackExtenderWithMTD", "tmtd"))
+  desc.add<edm::InputTag>("mtdTimeSrc", edm::InputTag("trackExtenderWithMTD", "generalTracktmtd"))
       ->setComment("MTD TIme value Map");
-  desc.add<edm::InputTag>("pathLengthSrc", edm::InputTag("trackExtenderWithMTD", "pathLength"))
+  desc.add<edm::InputTag>("pathLengthSrc", edm::InputTag("trackExtenderWithMTD", "generalTrackPathLength"))
       ->setComment("MTD PathLength value Map");
-  desc.add<edm::InputTag>("trackAssocSrc", edm::InputTag("trackExtenderWithMTD", "generalTrackassoc"))
-      ->setComment("Association between General and MTD Extended tracks");
+  desc.add<edm::InputTag>("npixBarrelSrc", edm::InputTag("trackExtenderWithMTD", "npixBarrel"))
+      ->setComment("# of Barrel pixel associated to refitted tracks");
+  desc.add<edm::InputTag>("npixEndcapSrc", edm::InputTag("trackExtenderWithMTD", "npixEndcap"))
+      ->setComment("# of Endcap pixel associated to refitted tracks");
   desc.add<edm::FileInPath>("qualityBDT_weights_file",
                             edm::FileInPath("RecoMTD/TimingIDTools/data/clf4D_MTDquality_bo.xml"))
       ->setComment("Track MTD quality BDT weights");
@@ -108,15 +109,13 @@ void MTDTrackQualityMVAProducer::produce(edm::Event& ev, const edm::EventSetup& 
   ev.getByToken(tracksToken_, tracksH);
   const auto& tracks = *tracksH;
 
-  edm::Handle<reco::TrackCollection> tracksMTDH;
-  ev.getByToken(tracksMTDToken_, tracksMTDH);
-
   const auto& btlMatchChi2 = ev.get(btlMatchChi2Token_);
   const auto& btlMatchTimeChi2 = ev.get(btlMatchTimeChi2Token_);
   const auto& etlMatchChi2 = ev.get(etlMatchChi2Token_);
   const auto& etlMatchTimeChi2 = ev.get(etlMatchTimeChi2Token_);
   const auto& pathLength = ev.get(pathLengthToken_);
-  const auto& trackAssoc = ev.get(trackAssocToken_);
+  const auto& npixBarrel = ev.get(npixBarrelToken_);
+  const auto& npixEndcap = ev.get(npixEndcapToken_);
   const auto& mtdTime = ev.get(mtdTimeToken_);
 
   std::vector<float> mvaOutRaw;
@@ -124,12 +123,11 @@ void MTDTrackQualityMVAProducer::produce(edm::Event& ev, const edm::EventSetup& 
   //Loop over tracks collection
   for (unsigned int itrack = 0; itrack < tracks.size(); ++itrack) {
     const reco::TrackRef trackref(tracksH, itrack);
-    if (trackAssoc[trackref] == -1)
+    if (pathLength[trackref] == -1.)
       mvaOutRaw.push_back(-1.);
     else {
-      const reco::TrackRef mtdTrackref = reco::TrackRef(tracksMTDH, trackAssoc[trackref]);
       mvaOutRaw.push_back(mva_(
-          trackref, mtdTrackref, btlMatchChi2, btlMatchTimeChi2, etlMatchChi2, etlMatchTimeChi2, mtdTime, pathLength));
+          trackref, npixBarrel, npixEndcap, btlMatchChi2, btlMatchTimeChi2, etlMatchChi2, etlMatchTimeChi2, mtdTime, pathLength));
     }
   }
   fillValueMap(ev, tracksH, mvaOutRaw, mvaName);

--- a/RecoMTD/TimingIDTools/plugins/MTDTrackQualityMVAProducer.cc
+++ b/RecoMTD/TimingIDTools/plugins/MTDTrackQualityMVAProducer.cc
@@ -126,8 +126,15 @@ void MTDTrackQualityMVAProducer::produce(edm::Event& ev, const edm::EventSetup& 
     if (pathLength[trackref] == -1.)
       mvaOutRaw.push_back(-1.);
     else {
-      mvaOutRaw.push_back(mva_(
-          trackref, npixBarrel, npixEndcap, btlMatchChi2, btlMatchTimeChi2, etlMatchChi2, etlMatchTimeChi2, mtdTime, pathLength));
+      mvaOutRaw.push_back(mva_(trackref,
+                               npixBarrel,
+                               npixEndcap,
+                               btlMatchChi2,
+                               btlMatchTimeChi2,
+                               etlMatchChi2,
+                               etlMatchTimeChi2,
+                               mtdTime,
+                               pathLength));
     }
   }
   fillValueMap(ev, tracksH, mvaOutRaw, mvaName);

--- a/RecoMTD/TimingIDTools/src/MTDTrackQualityMVA.cc
+++ b/RecoMTD/TimingIDTools/src/MTDTrackQualityMVA.cc
@@ -13,15 +13,14 @@ MTDTrackQualityMVA::MTDTrackQualityMVA(std::string weights_file) {
 }
 
 float MTDTrackQualityMVA::operator()(const reco::TrackRef& trk,
-                                     const reco::TrackRef& ext_trk,
+                                     const edm::ValueMap<int>& npixBarrels,
+                                     const edm::ValueMap<int>& npixEndcaps,
                                      const edm::ValueMap<float>& btl_chi2s,
                                      const edm::ValueMap<float>& btl_time_chi2s,
                                      const edm::ValueMap<float>& etl_chi2s,
                                      const edm::ValueMap<float>& etl_time_chi2s,
                                      const edm::ValueMap<float>& tmtds,
                                      const edm::ValueMap<float>& trk_lengths) const {
-  const auto& pattern = ext_trk->hitPattern();
-
   std::map<std::string, float> vars;
 
   //---training performed only above 0.5 GeV
@@ -30,23 +29,23 @@ float MTDTrackQualityMVA::operator()(const reco::TrackRef& trk,
     return -1;
 
   //---training performed only for tracks with MTD hits
-  if (tmtds[ext_trk] > 0) {
+  if (tmtds[trk] > 0) {
     vars.emplace(vars_[int(VarID::pt)], trk->pt());
     vars.emplace(vars_[int(VarID::eta)], trk->eta());
     vars.emplace(vars_[int(VarID::phi)], trk->phi());
     vars.emplace(vars_[int(VarID::chi2)], trk->chi2());
     vars.emplace(vars_[int(VarID::ndof)], trk->ndof());
     vars.emplace(vars_[int(VarID::numberOfValidHits)], trk->numberOfValidHits());
-    vars.emplace(vars_[int(VarID::numberOfValidPixelBarrelHits)], pattern.numberOfValidPixelBarrelHits());
-    vars.emplace(vars_[int(VarID::numberOfValidPixelEndcapHits)], pattern.numberOfValidPixelEndcapHits());
-    vars.emplace(vars_[int(VarID::btlMatchChi2)], btl_chi2s.contains(ext_trk.id()) ? btl_chi2s[ext_trk] : -1);
+    vars.emplace(vars_[int(VarID::numberOfValidPixelBarrelHits)], npixBarrels[trk]);
+    vars.emplace(vars_[int(VarID::numberOfValidPixelEndcapHits)], npixEndcaps[trk]);
+    vars.emplace(vars_[int(VarID::btlMatchChi2)], btl_chi2s.contains(trk.id()) ? btl_chi2s[trk] : -1);
     vars.emplace(vars_[int(VarID::btlMatchTimeChi2)],
-                 btl_time_chi2s.contains(ext_trk.id()) ? btl_time_chi2s[ext_trk] : -1);
-    vars.emplace(vars_[int(VarID::etlMatchChi2)], etl_chi2s.contains(ext_trk.id()) ? etl_chi2s[ext_trk] : -1);
+                 btl_time_chi2s.contains(trk.id()) ? btl_time_chi2s[trk] : -1);
+    vars.emplace(vars_[int(VarID::etlMatchChi2)], etl_chi2s.contains(trk.id()) ? etl_chi2s[trk] : -1);
     vars.emplace(vars_[int(VarID::etlMatchTimeChi2)],
-                 etl_time_chi2s.contains(ext_trk.id()) ? etl_time_chi2s[ext_trk] : -1);
-    vars.emplace(vars_[int(VarID::mtdt)], tmtds[ext_trk]);
-    vars.emplace(vars_[int(VarID::path_len)], trk_lengths[ext_trk]);
+                 etl_time_chi2s.contains(trk.id()) ? etl_time_chi2s[trk] : -1);
+    vars.emplace(vars_[int(VarID::mtdt)], tmtds[trk]);
+    vars.emplace(vars_[int(VarID::path_len)], trk_lengths[trk]);
     return 1. / (1 + sqrt(2 / (1 + mva_->evaluate(vars, false)) - 1));  //return values between 0-1 (probability)
   } else
     return -1;

--- a/RecoMTD/TimingIDTools/src/MTDTrackQualityMVA.cc
+++ b/RecoMTD/TimingIDTools/src/MTDTrackQualityMVA.cc
@@ -39,11 +39,9 @@ float MTDTrackQualityMVA::operator()(const reco::TrackRef& trk,
     vars.emplace(vars_[int(VarID::numberOfValidPixelBarrelHits)], npixBarrels[trk]);
     vars.emplace(vars_[int(VarID::numberOfValidPixelEndcapHits)], npixEndcaps[trk]);
     vars.emplace(vars_[int(VarID::btlMatchChi2)], btl_chi2s.contains(trk.id()) ? btl_chi2s[trk] : -1);
-    vars.emplace(vars_[int(VarID::btlMatchTimeChi2)],
-                 btl_time_chi2s.contains(trk.id()) ? btl_time_chi2s[trk] : -1);
+    vars.emplace(vars_[int(VarID::btlMatchTimeChi2)], btl_time_chi2s.contains(trk.id()) ? btl_time_chi2s[trk] : -1);
     vars.emplace(vars_[int(VarID::etlMatchChi2)], etl_chi2s.contains(trk.id()) ? etl_chi2s[trk] : -1);
-    vars.emplace(vars_[int(VarID::etlMatchTimeChi2)],
-                 etl_time_chi2s.contains(trk.id()) ? etl_time_chi2s[trk] : -1);
+    vars.emplace(vars_[int(VarID::etlMatchTimeChi2)], etl_time_chi2s.contains(trk.id()) ? etl_time_chi2s[trk] : -1);
     vars.emplace(vars_[int(VarID::mtdt)], tmtds[trk]);
     vars.emplace(vars_[int(VarID::path_len)], trk_lengths[trk]);
     return 1. / (1 + sqrt(2 / (1 + mva_->evaluate(vars, false)) - 1));  //return values between 0-1 (probability)

--- a/RecoMTD/TrackExtender/plugins/TrackExtenderWithMTD.cc
+++ b/RecoMTD/TrackExtender/plugins/TrackExtenderWithMTD.cc
@@ -371,9 +371,8 @@ private:
   edm::EDPutToken etlMatchChi2Token;
   edm::EDPutToken btlMatchTimeChi2Token;
   edm::EDPutToken etlMatchTimeChi2Token;
-  edm::EDPutToken pathLengthToken;
-  edm::EDPutToken tmtdToken;
-  edm::EDPutToken sigmatmtdToken;
+  edm::EDPutToken npixBarrelToken;
+  edm::EDPutToken npixEndcapToken;
   edm::EDPutToken pOrigTrkToken;
   edm::EDPutToken betaOrigTrkToken;
   edm::EDPutToken t0OrigTrkToken;
@@ -455,9 +454,8 @@ TrackExtenderWithMTDT<TrackCollection>::TrackExtenderWithMTDT(const ParameterSet
   etlMatchChi2Token = produces<edm::ValueMap<float>>("etlMatchChi2");
   btlMatchTimeChi2Token = produces<edm::ValueMap<float>>("btlMatchTimeChi2");
   etlMatchTimeChi2Token = produces<edm::ValueMap<float>>("etlMatchTimeChi2");
-  pathLengthToken = produces<edm::ValueMap<float>>("pathLength");
-  tmtdToken = produces<edm::ValueMap<float>>("tmtd");
-  sigmatmtdToken = produces<edm::ValueMap<float>>("sigmatmtd");
+  npixBarrelToken = produces<edm::ValueMap<int>>("npixBarrel");
+  npixEndcapToken = produces<edm::ValueMap<int>>("npixEndcap");
   pOrigTrkToken = produces<edm::ValueMap<float>>("generalTrackp");
   betaOrigTrkToken = produces<edm::ValueMap<float>>("generalTrackBeta");
   t0OrigTrkToken = produces<edm::ValueMap<float>>("generalTrackt0");
@@ -566,9 +564,8 @@ void TrackExtenderWithMTDT<TrackCollection>::produce(edm::Event& ev, const edm::
   std::vector<float> etlMatchChi2;
   std::vector<float> btlMatchTimeChi2;
   std::vector<float> etlMatchTimeChi2;
-  std::vector<float> pathLengthsRaw;
-  std::vector<float> tmtdRaw;
-  std::vector<float> sigmatmtdRaw;
+  std::vector<int> npixBarrel;
+  std::vector<int> npixEndcap;
   std::vector<float> pOrigTrkRaw;
   std::vector<float> betaOrigTrkRaw;
   std::vector<float> t0OrigTrkRaw;
@@ -721,9 +718,6 @@ void TrackExtenderWithMTDT<TrackCollection>::produce(edm::Event& ev, const edm::
         etlMatchChi2.push_back(mETL.hit ? mETL.estChi2 : -1);
         btlMatchTimeChi2.push_back(mBTL.hit ? mBTL.timeChi2 : -1);
         etlMatchTimeChi2.push_back(mETL.hit ? mETL.timeChi2 : -1);
-        pathLengthsRaw.push_back(pathLength);
-        tmtdRaw.push_back(tmtd);
-        sigmatmtdRaw.push_back(sigmatmtd);
         pathLengthMap = pathLength;
         tmtdMap = tmtd;
         sigmatmtdMap = sigmatmtd;
@@ -738,6 +732,8 @@ void TrackExtenderWithMTDT<TrackCollection>::produce(edm::Event& ev, const edm::
         for (unsigned ihit = hitsstart; ihit < hitsend; ++ihit) {
           backtrack.appendHitPattern((*outhits)[ihit], ttopo);
         }
+        npixBarrel.push_back(backtrack.hitPattern().numberOfValidPixelBarrelHits());
+        npixEndcap.push_back(backtrack.hitPattern().numberOfValidPixelEndcapHits());
       } else {
         LogTrace("TrackExtenderWithMTD") << "Error in the MTD track refitting. This should not happen";
       }
@@ -751,6 +747,16 @@ void TrackExtenderWithMTDT<TrackCollection>::produce(edm::Event& ev, const edm::
     tmtdOrigTrkRaw.push_back(tmtdMap);
     sigmatmtdOrigTrkRaw.push_back(sigmatmtdMap);
     assocOrigTrkRaw.push_back(iMap);
+
+    if ( iMap == -1 ) {
+      btlMatchChi2.push_back(-1.);
+      etlMatchChi2.push_back(-1.);
+      btlMatchTimeChi2.push_back(-1.);
+      etlMatchTimeChi2.push_back(-1.);
+      npixBarrel.push_back(-1.);
+      npixEndcap.push_back(-1.);
+    }
+
     ++itrack;
   }
 
@@ -758,13 +764,12 @@ void TrackExtenderWithMTDT<TrackCollection>::produce(edm::Event& ev, const edm::
   ev.put(std::move(extras));
   ev.put(std::move(outhits));
 
-  fillValueMap(ev, outTrksHandle, btlMatchChi2, btlMatchChi2Token);
-  fillValueMap(ev, outTrksHandle, etlMatchChi2, etlMatchChi2Token);
-  fillValueMap(ev, outTrksHandle, btlMatchTimeChi2, btlMatchTimeChi2Token);
-  fillValueMap(ev, outTrksHandle, etlMatchTimeChi2, etlMatchTimeChi2Token);
-  fillValueMap(ev, outTrksHandle, pathLengthsRaw, pathLengthToken);
-  fillValueMap(ev, outTrksHandle, tmtdRaw, tmtdToken);
-  fillValueMap(ev, outTrksHandle, sigmatmtdRaw, sigmatmtdToken);
+  fillValueMap(ev, tracksH, btlMatchChi2, btlMatchChi2Token);
+  fillValueMap(ev, tracksH, etlMatchChi2, etlMatchChi2Token);
+  fillValueMap(ev, tracksH, btlMatchTimeChi2, btlMatchTimeChi2Token);
+  fillValueMap(ev, tracksH, etlMatchTimeChi2, etlMatchTimeChi2Token);
+  fillValueMap(ev, tracksH, npixBarrel, npixBarrelToken);
+  fillValueMap(ev, tracksH, npixEndcap, npixEndcapToken);
   fillValueMap(ev, tracksH, pOrigTrkRaw, pOrigTrkToken);
   fillValueMap(ev, tracksH, betaOrigTrkRaw, betaOrigTrkToken);
   fillValueMap(ev, tracksH, t0OrigTrkRaw, t0OrigTrkToken);

--- a/RecoMTD/TrackExtender/plugins/TrackExtenderWithMTD.cc
+++ b/RecoMTD/TrackExtender/plugins/TrackExtenderWithMTD.cc
@@ -748,7 +748,7 @@ void TrackExtenderWithMTDT<TrackCollection>::produce(edm::Event& ev, const edm::
     sigmatmtdOrigTrkRaw.push_back(sigmatmtdMap);
     assocOrigTrkRaw.push_back(iMap);
 
-    if ( iMap == -1 ) {
+    if (iMap == -1) {
       btlMatchChi2.push_back(-1.);
       etlMatchChi2.push_back(-1.);
       btlMatchTimeChi2.push_back(-1.);

--- a/Validation/MtdValidation/plugins/MtdTracksValidation.cc
+++ b/Validation/MtdValidation/plugins/MtdTracksValidation.cc
@@ -169,7 +169,7 @@ void MtdTracksValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
     index++;
 
     if (trackAssoc[trackref] == -1) {
-      LogWarning("mtdTracks") << "Extended track not associated";
+      LogInfo("mtdTracks") << "Extended track not associated";
       continue;
     }
 

--- a/Validation/MtdValidation/plugins/MtdTracksValidation.cc
+++ b/Validation/MtdValidation/plugins/MtdTracksValidation.cc
@@ -179,8 +179,8 @@ void MtdTracksValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
     if (track.pt() < trackMinPt_)
       continue;
 
-    meTracktmtd_->Fill(tMtd[mtdTrackref]);
-    if (std::round(SigmatMtd[mtdTrackref] - Sigmat0Pid[trackref]) != 0) {
+    meTracktmtd_->Fill(tMtd[trackref]);
+    if (std::round(SigmatMtd[trackref] - Sigmat0Pid[trackref]) != 0) {
       LogWarning("mtdTracks") << "TimeError associated to refitted track is different from TimeError stored in tofPID "
                                  "sigmat0 ValueMap: this should not happen";
     }
@@ -194,7 +194,7 @@ void MtdTracksValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
     meTrackSigmat0SafePid_->Fill(Sigmat0Safe[trackref]);
     meTrackMVAQual_->Fill(mtdQualMVA[trackref]);
 
-    meTrackPathLenghtvsEta_->Fill(std::abs(track.eta()), pathLength[mtdTrackref]);
+    meTrackPathLenghtvsEta_->Fill(std::abs(track.eta()), pathLength[trackref]);
 
     if (std::abs(track.eta()) < trackMinEta_) {
       // --- all BTL tracks (with and without hit in MTD) ---
@@ -397,13 +397,13 @@ void MtdTracksValidation::fillDescriptions(edm::ConfigurationDescriptions& descr
   desc.add<edm::InputTag>("inputTagG", edm::InputTag("generalTracks"));
   desc.add<edm::InputTag>("inputTagT", edm::InputTag("trackExtenderWithMTD"));
   desc.add<edm::InputTag>("inputTagV", edm::InputTag("offlinePrimaryVertices4D"));
-  desc.add<edm::InputTag>("tmtd", edm::InputTag("trackExtenderWithMTD:tmtd"));
-  desc.add<edm::InputTag>("sigmatmtd", edm::InputTag("trackExtenderWithMTD:sigmatmtd"));
+  desc.add<edm::InputTag>("tmtd", edm::InputTag("trackExtenderWithMTD:generalTracktmtd"));
+  desc.add<edm::InputTag>("sigmatmtd", edm::InputTag("trackExtenderWithMTD:generalTracksigmatmtd"));
   desc.add<edm::InputTag>("t0Src", edm::InputTag("trackExtenderWithMTD:generalTrackt0"));
   desc.add<edm::InputTag>("sigmat0Src", edm::InputTag("trackExtenderWithMTD:generalTracksigmat0"));
   desc.add<edm::InputTag>("trackAssocSrc", edm::InputTag("trackExtenderWithMTD:generalTrackassoc"))
       ->setComment("Association between General and MTD Extended tracks");
-  desc.add<edm::InputTag>("pathLengthSrc", edm::InputTag("trackExtenderWithMTD:pathLength"));
+  desc.add<edm::InputTag>("pathLengthSrc", edm::InputTag("trackExtenderWithMTD:generalTrackPathLength"));
   desc.add<edm::InputTag>("t0SafePID", edm::InputTag("tofPID:t0safe"));
   desc.add<edm::InputTag>("sigmat0SafePID", edm::InputTag("tofPID:sigmat0safe"));
   desc.add<edm::InputTag>("sigmat0PID", edm::InputTag("tofPID:sigmat0"));


### PR DESCRIPTION
#### PR description:

Revision of the AODSIM event content of MTD, reducing effectively the output size for PU 200 by ~ 1/3. The ```ValueMap```s kept in the events all refer now to the associated ```generalTrack```, and two more are added to allow the MVA quality flag calculation to be performed without the need of a saved ```recoTrackExtras```.
See [this presentation at the MTD DPG meeting](https://indico.cern.ch/event/1049998/contributions/4411647/attachments/2266668/3848600/MTDEventContent_20210618.pdf) for further details.

#### PR validation:

Test wf. 34634.0 runs smoothly, the update of the output is as expected, and the DQM comparison with the existing workflow does not show differences (as of CMSSW_12_0_0_pre2).