### PR TITLE
fix unit test: download file in tmp area and add the path in PYTHONPATH

### DIFF
--- a/GeneratorInterface/Pythia8Interface/test/test_Pythia8ConcurrentGeneratorFilter_WZ_TuneCP5_13TeV-pythia8.sh
+++ b/GeneratorInterface/Pythia8Interface/test/test_Pythia8ConcurrentGeneratorFilter_WZ_TuneCP5_13TeV-pythia8.sh
@@ -1,11 +1,13 @@
 #!/bin/bash -ex
-curl -s -k https://cms-pdmv.cern.ch/mcm/public/restapi/requests/get_fragment/BTV-RunIISummer20UL17GEN-00002 --retry 3 --create-dirs -o ${LOCALTOP}/src/GeneratorInterface/Pythia8Interface/python/BTV-RunIISummer20UL17GEN-00002-fragment.py
 
-cd ${LOCALTOP}/src
+cd ${LOCALTOP}
+curl -s -k https://cms-pdmv.cern.ch/mcm/public/restapi/requests/get_fragment/BTV-RunIISummer20UL17GEN-00002 --retry 3 --create-dirs -o ${LOCALTOP}/tmp/GIP8/BTV-RunIISummer20UL17GEN-00002-fragment.py
+touch ${LOCALTOP}/tmp/GIP8/__init__.py
+export PYTHONPATH="${LOCALTOP}/tmp${PYTHONPATH:+:$PYTHONPATH}"
 
-cmsDriver.py GeneratorInterface/Pythia8Interface/python/BTV-RunIISummer20UL17GEN-00002-fragment.py --python_filename test_BTV-RunIISummer20UL17GEN-00002_1_cfg.py --eventcontent RAWSIM --customise Configuration/DataProcessing/Utils.addMonitoring --datatier GEN --fileout file:test_BTV-RunIISummer20UL17GEN-00002.root --conditions auto:run2_mc --beamspot Realistic25ns13TeVEarly2017Collision --customise_commands process.source.numberEventsInLuminosityBlock="cms.untracked.uint32(10)" --step GEN --geometry DB:Extended --era Run2_2017 --no_exec --mc -n 50 --nThreads 4 --nConcurrentLumis 0
+cmsDriver.py GIP8/BTV-RunIISummer20UL17GEN-00002-fragment.py --python_filename test_BTV-RunIISummer20UL17GEN-00002_1_cfg.py --eventcontent RAWSIM --customise Configuration/DataProcessing/Utils.addMonitoring --datatier GEN --fileout file:test_BTV-RunIISummer20UL17GEN-00002.root --conditions auto:run2_mc --beamspot Realistic25ns13TeVEarly2017Collision --customise_commands process.source.numberEventsInLuminosityBlock="cms.untracked.uint32(10)" --step GEN --geometry DB:Extended --era Run2_2017 --no_exec --mc -n 50 --nThreads 4 --nConcurrentLumis 0
 
 sed -i "s/Pythia8GeneratorFilter/Pythia8ConcurrentGeneratorFilter/g" test_BTV-RunIISummer20UL17GEN-00002_1_cfg.py
 
 cmsRun test_BTV-RunIISummer20UL17GEN-00002_1_cfg.py
-rm ${LOCALTOP}/src/GeneratorInterface/Pythia8Interface/python/BTV-RunIISummer20UL17GEN-00002-fragment.py
+rm -rf ${LOCALTOP}/tmp/GIP8


### PR DESCRIPTION
Unit test fixed by https://github.com/cms-sw/cmssw/pull/34185 works locally but in IB tests it fails as in IB area we do not run `scram build python` so newly download file in `GeneratorInterface/Pythia8Interface/python` is not visible to python. In this PR , I propse to download the file in tmp directory and explicitly add that directory in PYTHONPATH. This should avoid the error message we are now getting in IB

```
Loading generator fragment from GeneratorInterface.Pythia8Interface.BTV-RunIISummer20UL17GEN-00002-fragment
Traceback (most recent call last):
  File "CMSSW_12_0_X_2021-06-21-1100/bin/slc7_amd64_gcc900/cmsDriver.py", line 56, in <module>
    run()
  File "CMSSW_12_0_X_2021-06-21-1100/bin/slc7_amd64_gcc900/cmsDriver.py", line 28, in run
    configBuilder.prepare()
  File "CMSSW_12_0_X_2021-06-21-1100/python/Configuration/Applications/ConfigBuilder.py", line 2157, in prepare
    self.addStandardSequences()
  File "CMSSW_12_0_X_2021-06-21-1100/python/Configuration/Applications/ConfigBuilder.py", line 783, in addStandardSequences
    getattr(self,"prepare_"+stepName)(sequence = getattr(self,stepName+"DefaultSeq"))
  File "CMSSW_12_0_X_2021-06-21-1100/python/Configuration/Applications/ConfigBuilder.py", line 1363, in prepare_GEN
    raise Exception("Neither gen fragment of input files provided: this is an inconsistent GEN step configuration")
Exception: Neither gen fragment of input files provided: this is an inconsistent GEN step configuration
```