### PR TITLE
Fix in the MPA stub building code

### DIFF
--- a/L1Trigger/TrackTrigger/plugins/TTStubBuilder.cc
+++ b/L1Trigger/TrackTrigger/plugins/TTStubBuilder.cc
@@ -209,16 +209,16 @@ void TTStubBuilder<Ref_Phase2TrackerDigi_>::produce(edm::Event& iEvent, const ed
       }    /// End of loop over upper clusters
 
       /// Here tempOutput stores all the stubs from this lower cluster
-      /// Check if there is need to store only one (if only one already, skip this step)
+      /// Check if there is need to store only one or two (2S/PS modules cases) (if only one already, skip this step)
       if (ForbidMultipleStubs && tempOutput.size() > 1 + static_cast<unsigned int>(isPS)) {
-        /// If so, sort the stubs by bend and keep only the first one (smallest bend)
+        /// If so, sort the stubs by bend and keep only the first one (2S case) or the first pair (PS case) (smallest |bend|)
         std::sort(tempOutput.begin(), tempOutput.end(), TTStubBuilder<Ref_Phase2TrackerDigi_>::SortStubsBend);
 
         /// Get to the second element (the switch above ensures there are min 2)
         typename std::vector<TTStub<Ref_Phase2TrackerDigi_>>::iterator tempIter = tempOutput.begin();
         ++tempIter;
-
-        /// tempIter points now to the second element
+        if (isPS) ++tempIter; // PS module case
+        /// tempIter points now to the second or third element (2S/PS)
 
         /// Delete all-but-the first one from tempOutput
         tempOutput.erase(tempIter, tempOutput.end());

--- a/L1Trigger/TrackTrigger/plugins/TTStubBuilder.cc
+++ b/L1Trigger/TrackTrigger/plugins/TTStubBuilder.cc
@@ -218,7 +218,7 @@ void TTStubBuilder<Ref_Phase2TrackerDigi_>::produce(edm::Event& iEvent, const ed
         typename std::vector<TTStub<Ref_Phase2TrackerDigi_>>::iterator tempIter = tempOutput.begin();
         ++tempIter;
         if (isPS) 
-          ++tempIter; // PS module case
+          ++tempIter;  // PS module case
         /// tempIter points now to the second or third element (2S/PS)
 
         /// Delete all-but-the first one from tempOutput

--- a/L1Trigger/TrackTrigger/plugins/TTStubBuilder.cc
+++ b/L1Trigger/TrackTrigger/plugins/TTStubBuilder.cc
@@ -218,7 +218,7 @@ void TTStubBuilder<Ref_Phase2TrackerDigi_>::produce(edm::Event& iEvent, const ed
         typename std::vector<TTStub<Ref_Phase2TrackerDigi_>>::iterator tempIter = tempOutput.begin();
         ++tempIter;
         if (isPS) 
-            ++tempIter; // PS module case
+          ++tempIter; // PS module case
         /// tempIter points now to the second or third element (2S/PS)
 
         /// Delete all-but-the first one from tempOutput

--- a/L1Trigger/TrackTrigger/plugins/TTStubBuilder.cc
+++ b/L1Trigger/TrackTrigger/plugins/TTStubBuilder.cc
@@ -217,7 +217,7 @@ void TTStubBuilder<Ref_Phase2TrackerDigi_>::produce(edm::Event& iEvent, const ed
         /// Get to the second element (the switch above ensures there are min 2)
         typename std::vector<TTStub<Ref_Phase2TrackerDigi_>>::iterator tempIter = tempOutput.begin();
         ++tempIter;
-        if (isPS) 
+        if (isPS)
           ++tempIter;  // PS module case
         /// tempIter points now to the second or third element (2S/PS)
 

--- a/L1Trigger/TrackTrigger/plugins/TTStubBuilder.cc
+++ b/L1Trigger/TrackTrigger/plugins/TTStubBuilder.cc
@@ -217,7 +217,8 @@ void TTStubBuilder<Ref_Phase2TrackerDigi_>::produce(edm::Event& iEvent, const ed
         /// Get to the second element (the switch above ensures there are min 2)
         typename std::vector<TTStub<Ref_Phase2TrackerDigi_>>::iterator tempIter = tempOutput.begin();
         ++tempIter;
-        if (isPS) ++tempIter; // PS module case
+        if (isPS) 
+            ++tempIter; // PS module case
         /// tempIter points now to the second or third element (2S/PS)
 
         /// Delete all-but-the first one from tempOutput

--- a/L1Trigger/TrackTrigger/plugins/TTStubBuilder.cc
+++ b/L1Trigger/TrackTrigger/plugins/TTStubBuilder.cc
@@ -210,7 +210,7 @@ void TTStubBuilder<Ref_Phase2TrackerDigi_>::produce(edm::Event& iEvent, const ed
 
       /// Here tempOutput stores all the stubs from this lower cluster
       /// Check if there is need to store only one (if only one already, skip this step)
-      if (ForbidMultipleStubs && tempOutput.size() > 1+static_cast<unsigned int>(isPS)) {
+      if (ForbidMultipleStubs && tempOutput.size() > 1 + static_cast<unsigned int>(isPS)) {
         /// If so, sort the stubs by bend and keep only the first one (smallest bend)
         std::sort(tempOutput.begin(), tempOutput.end(), TTStubBuilder<Ref_Phase2TrackerDigi_>::SortStubsBend);
 

--- a/L1Trigger/TrackTrigger/plugins/TTStubBuilder.cc
+++ b/L1Trigger/TrackTrigger/plugins/TTStubBuilder.cc
@@ -210,7 +210,7 @@ void TTStubBuilder<Ref_Phase2TrackerDigi_>::produce(edm::Event& iEvent, const ed
 
       /// Here tempOutput stores all the stubs from this lower cluster
       /// Check if there is need to store only one (if only one already, skip this step)
-      if (ForbidMultipleStubs && tempOutput.size() > 1) {
+      if (ForbidMultipleStubs && tempOutput.size() > 1+static_cast<unsigned int>(isPS)) {
         /// If so, sort the stubs by bend and keep only the first one (smallest bend)
         std::sort(tempOutput.begin(), tempOutput.end(), TTStubBuilder<Ref_Phase2TrackerDigi_>::SortStubsBend);
 


### PR DESCRIPTION
#### PR description:

This PR implements a fix in the stub building code of the L1Trigger/TrackTrigger package. Only one file is affected (TTStubBuilder.cc), and one line in this file. The PS modules can build up to 2 stubs per seed. It was set to one until now. So this is a very minor change (1->2)

#### PR validation:

The code change was tested with a private CMSSW version. As expected a small increase of the stub rate was observed in the PS module (less than 5% in any cases @ PU200). 
