### PR TITLE
Cast indexFor to unsigned for size comparison

### DIFF
--- a/CondFormats/EcalObjects/test/EcalPulseSymmCovariance_catch2.cc
+++ b/CondFormats/EcalObjects/test/EcalPulseSymmCovariance_catch2.cc
@@ -42,7 +42,7 @@ TEST_CASE("EcalPulseSymmCovariance testing", "[EcalPulseSymmCovariance]") {
   SECTION("Check bounds") {
     for (int i = 0; i < EcalPulseShape::TEMPLATESAMPLES; ++i) {
       for (int j = 0; j < EcalPulseShape::TEMPLATESAMPLES; ++j) {
-        REQUIRE(cov.indexFor(i, j) < std::size(cov.covval));
+        REQUIRE((unsigned)cov.indexFor(i, j) < std::size(cov.covval));
       }
     }
   }

--- a/FWCore/Framework/test/test_catch2notTP_ESRecordsToProxyIndices.cc
+++ b/FWCore/Framework/test/test_catch2notTP_ESRecordsToProxyIndices.cc
@@ -84,7 +84,7 @@ TEST_CASE("test ESRecordsToProxyIndices", "[ESRecordsToProxyIndices]") {
       index = 0;
       auto it = pr.second.second.begin();
       for (auto const& dk : pr.second.first) {
-        REQUIRE(index == r2pi.indexInRecord(pr.first, dk).value());
+        REQUIRE(index == (unsigned)r2pi.indexInRecord(pr.first, dk).value());
         REQUIRE(*it == r2pi.component(pr.first, dk));
         ++index;
         ++it;


### PR DESCRIPTION
#### PR description:

Adjustment for catch2 2.13.6 
It seems that `indexFor` was returning unsigned before and does int now and it's compared with int in both cases

#### PR validation:

All packages which use the catch2 external compile, hope I picked them all

