### PR TITLE
MTD Validation: SIM clusters

### DIFF
--- a/Validation/MtdValidation/plugins/BtlLocalRecoValidation.cc
+++ b/Validation/MtdValidation/plugins/BtlLocalRecoValidation.cc
@@ -341,6 +341,9 @@ void BtlLocalRecoValidation::analyze(const edm::Event& iEvent, const edm::EventS
         for (const auto& recHit : *btlRecHitsHandle) {
           BTLDetId hitId(recHit.id().rawId());
 
+          if (m_btlSimHits.count(hitId.rawId()) == 0)
+            continue;
+
           // Check the hit position
           if (hitId.mtdSide() != cluId.mtdSide() || hitId.mtdRR() != cluId.mtdRR() || recHit.row() != hit_row ||
               recHit.column() != hit_col)
@@ -396,13 +399,13 @@ void BtlLocalRecoValidation::analyze(const edm::Event& iEvent, const edm::EventS
           meCluXRes_->Fill(x_res);
           meCluYRes_->Fill(y_res);
           meCluZRes_->Fill(z_res);
+
+          meCluYXLocal_->Fill(local_point.x(), local_point.y());
+          meCluYXLocalSim_->Fill(cluLocalPosSIM.x(), cluLocalPosSIM.y());
         }
 
         meCluTPullvsEta_->Fill(std::abs(cluGlobalPosSIM.eta()), time_res / cluster.timeError());
         meCluTPullvsE_->Fill(cluEneSIM, time_res / cluster.timeError());
-
-        meCluYXLocal_->Fill(local_point.x(), local_point.y());
-        meCluYXLocalSim_->Fill(cluLocalPosSIM.x(), cluLocalPosSIM.y());
 
       }  // if ( cluTimeSIM > 0. &&  cluEneSIM > 0. )
 
@@ -612,23 +615,23 @@ void BtlLocalRecoValidation::bookHistograms(DQMStore::IBooker& ibook,
     meCluXRes_ = ibook.book1D("BtlCluXRes", "BTL cluster X resolution;X_{RECO}-X_{SIM} [cm]", 100, -3.1, 3.1);
     meCluYRes_ = ibook.book1D("BtlCluYRes", "BTL cluster Y resolution;Y_{RECO}-Y_{SIM} [cm]", 100, -3.1, 3.1);
     meCluZRes_ = ibook.book1D("BtlCluZRes", "BTL cluster Z resolution;Z_{RECO}-Z_{SIM} [cm]", 100, -0.2, 0.2);
+    meCluYXLocal_ = ibook.book2D("BtlCluYXLocal",
+                                 "BTL cluster local Y vs X;X^{local}_{RECO} [cm];Y^{local}_{RECO} [cm]",
+                                 200,
+                                 -9.5,
+                                 9.5,
+                                 200,
+                                 -2.8,
+                                 2.8);
+    meCluYXLocalSim_ = ibook.book2D("BtlCluYXLocalSim",
+                                    "BTL cluster local Y vs X;X^{local}_{SIM} [cm];Y^{local}_{SIM} [cm]",
+                                    200,
+                                    -9.5,
+                                    9.5,
+                                    200,
+                                    -2.8,
+                                    2.8);
   }
-  meCluYXLocal_ = ibook.book2D("BtlCluYXLocal",
-                               "BTL cluster local Y vs X;X^{local}_{RECO} [cm];Y^{local}_{RECO} [cm]",
-                               200,
-                               -9.5,
-                               9.5,
-                               200,
-                               -2.8,
-                               2.8);
-  meCluYXLocalSim_ = ibook.book2D("BtlCluYXLocalSim",
-                                  "BTL cluster local Y vs X;X^{local}_{SIM} [cm];Y^{local}_{SIM} [cm]",
-                                  200,
-                                  -9.5,
-                                  9.5,
-                                  200,
-                                  -2.8,
-                                  2.8);
 
   // --- UncalibratedRecHits histograms
 

--- a/Validation/MtdValidation/plugins/BtlLocalRecoValidation.cc
+++ b/Validation/MtdValidation/plugins/BtlLocalRecoValidation.cc
@@ -131,6 +131,11 @@ private:
   MonitorElement* meCluEnergyRes_;
   MonitorElement* meCluTPullvsE_;
   MonitorElement* meCluTPullvsEta_;
+  MonitorElement* meCluXRes_;
+  MonitorElement* meCluYRes_;
+  MonitorElement* meCluZRes_;
+  MonitorElement* meCluYXLocal_;
+  MonitorElement* meCluYXLocalSim_;
 
   // --- UncalibratedRecHits histograms
 
@@ -374,12 +379,21 @@ void BtlLocalRecoValidation::analyze(const edm::Event& iEvent, const edm::EventS
 
         float time_res = cluster.time() - cluTimeSIM;
         float energy_res = cluster.energy() - cluEneSIM;
+        float x_res = global_point.x() - cluGlobalPosSIM.x();
+        float y_res = global_point.y() - cluGlobalPosSIM.y();
+        float z_res = global_point.z() - cluGlobalPosSIM.z();
 
         meCluTimeRes_->Fill(time_res);
         meCluEnergyRes_->Fill(energy_res);
+        meCluXRes_->Fill(x_res);
+        meCluYRes_->Fill(y_res);
+        meCluZRes_->Fill(z_res);
 
         meCluTPullvsEta_->Fill(std::abs(cluGlobalPosSIM.eta()), time_res / cluster.timeError());
         meCluTPullvsE_->Fill(cluEneSIM, time_res / cluster.timeError());
+
+        meCluYXLocal_->Fill(local_point.x(), local_point.y());
+        meCluYXLocalSim_->Fill(cluLocalPosSIM.x(), cluLocalPosSIM.y());
 
       }  // if ( cluTimeSIM > 0. &&  cluEneSIM > 0. )
 
@@ -543,10 +557,10 @@ void BtlLocalRecoValidation::bookHistograms(DQMStore::IBooker& ibook,
       5.,
       "S");
   meTPullvsE_ = ibook.bookProfile(
-      "BtlTPullvsE", "BTL time pull vs E;E_{SIM} [MeV];T_{RECO}-T_{SIM}/#sigma_{T_{RECO}}", 20, 0., 20., -5., 5., "S");
+      "BtlTPullvsE", "BTL time pull vs E;E_{SIM} [MeV];(T_{RECO}-T_{SIM})/#sigma_{T_{RECO}}", 20, 0., 20., -5., 5., "S");
   meTPullvsEta_ = ibook.bookProfile("BtlTPullvsEta",
-                                    "BTL time pull vs #eta;|#eta_{RECO}|;T_{RECO}-T_{SIM}/#sigma_{T_{RECO}}",
-                                    32,
+                                    "BTL time pull vs #eta;|#eta_{RECO}|;(T_{RECO}-T_{SIM})/#sigma_{T_{RECO}}",
+                                    30,
                                     0,
                                     1.55,
                                     -5.,
@@ -564,21 +578,41 @@ void BtlLocalRecoValidation::bookHistograms(DQMStore::IBooker& ibook,
   meCluTimeRes_ = ibook.book1D("BtlCluTimeRes", "BTL cluster time resolution;T_{RECO}-T_{SIM}", 100, -0.5, 0.5);
   meCluEnergyRes_ = ibook.book1D("BtlCluEnergyRes", "BTL cluster energy resolution;E_{RECO}-E_{SIM}", 100, -0.5, 0.5);
   meCluTPullvsE_ = ibook.bookProfile("BtlCluTPullvsE",
-                                     "BTL cluster time pull vs E;E_{SIM} [MeV];T_{RECO}-T_{SIM}/#sigma_{T_{RECO}}",
+                                     "BTL cluster time pull vs E;E_{SIM} [MeV];(T_{RECO}-T_{SIM})/#sigma_{T_{RECO}}",
                                      20,
                                      0.,
                                      20.,
                                      -5.,
                                      5.,
                                      "S");
-  meCluTPullvsEta_ = ibook.bookProfile("BtlCluTPullvsEta",
-                                       "BTL cluster time pull vs #eta;|#eta_{RECO}|;T_{RECO}-T_{SIM}/#sigma_{T_{RECO}}",
-                                       32,
-                                       0,
-                                       1.55,
-                                       -5.,
-                                       5.,
-                                       "S");
+  meCluTPullvsEta_ =
+      ibook.bookProfile("BtlCluTPullvsEta",
+                        "BTL cluster time pull vs #eta;|#eta_{RECO}|;(T_{RECO}-T_{SIM})/#sigma_{T_{RECO}}",
+                        30,
+                        0,
+                        1.55,
+                        -5.,
+                        5.,
+                        "S");
+  meCluXRes_ = ibook.book1D("BtlCluXRes", "BTL cluster X resolution;X_{RECO}-X_{SIM} [cm]", 100, -3.1, 3.1);
+  meCluYRes_ = ibook.book1D("BtlCluYRes", "BTL cluster Y resolution;Y_{RECO}-Y_{SIM} [cm]", 100, -3.1, 3.1);
+  meCluZRes_ = ibook.book1D("BtlCluZRes", "BTL cluster Z resolution;Z_{RECO}-Z_{SIM} [cm]", 100, -0.2, 0.2);
+  meCluYXLocal_ = ibook.book2D("BtlCluYXLocal",
+                               "BTL cluster local Y vs X;X^{local}_{RECO} [cm];Y^{local}_{RECO} [cm]",
+                               200,
+                               -9.5,
+                               9.5,
+                               200,
+                               -2.8,
+                               2.8);
+  meCluYXLocalSim_ = ibook.book2D("BtlCluYXLocalSim",
+                                  "BTL cluster local Y vs X;X^{local}_{SIM} [cm];Y^{local}_{SIM} [cm]",
+                                  200,
+                                  -9.5,
+                                  9.5,
+                                  200,
+                                  -2.8,
+                                  2.8);
 
   // --- UncalibratedRecHits histograms
 

--- a/Validation/MtdValidation/plugins/BtlLocalRecoValidation.cc
+++ b/Validation/MtdValidation/plugins/BtlLocalRecoValidation.cc
@@ -307,7 +307,6 @@ void BtlLocalRecoValidation::analyze(const edm::Event& iEvent, const edm::EventS
       const RectangularMTDTopology& topo = static_cast<const RectangularMTDTopology&>(topoproxy.specificTopology());
 
       Local3DPoint local_point(cluster.x() * topo.pitch().first, cluster.y() * topo.pitch().second, 0.);
-      local_point = topo.pixelToModuleLocalPoint(local_point, cluId.row(topo.nrows()), cluId.column(topo.ncolumns()));
       const auto& global_point = genericDet->toGlobal(local_point);
 
       meCluEnergy_->Fill(cluster.energy());

--- a/Validation/MtdValidation/plugins/EtlLocalRecoValidation.cc
+++ b/Validation/MtdValidation/plugins/EtlLocalRecoValidation.cc
@@ -407,6 +407,9 @@ void EtlLocalRecoValidation::analyze(const edm::Event& iEvent, const edm::EventS
         for (const auto& recHit : *etlRecHitsHandle) {
           ETLDetId hitId(recHit.id().rawId());
 
+          if (m_etlSimHits[idet].count(hitId.rawId()) == 0)
+            continue;
+
           // Check the hit position
           if (hitId.zside() != cluId.zside() || hitId.mtdRR() != cluId.mtdRR() || hitId.module() != cluId.module() ||
               recHit.row() != hit_row || recHit.column() != hit_col)
@@ -458,8 +461,10 @@ void EtlLocalRecoValidation::analyze(const edm::Event& iEvent, const edm::EventS
         meCluTPullvsEta_[iside]->Fill(cluGlobalPosSIM.eta(), time_res / cluster.timeError());
         meCluTPullvsE_[iside]->Fill(cluEneSIM, time_res / cluster.timeError());
 
-        meCluYXLocal_[iside]->Fill(local_point.x(), local_point.y());
-        meCluYXLocalSim_[iside]->Fill(cluLocalPosSIM.x(), cluLocalPosSIM.y());
+        if (LocalPosDebug_) {
+          meCluYXLocal_[iside]->Fill(local_point.x(), local_point.y());
+          meCluYXLocalSim_[iside]->Fill(cluLocalPosSIM.x(), cluLocalPosSIM.y());
+        }
 
       }  // if ( cluTimeSIM > 0. &&  cluEneSIM > 0. )
 
@@ -956,38 +961,40 @@ void EtlLocalRecoValidation::bookHistograms(DQMStore::IBooker& ibook,
       ibook.book1D("EtlCluZResZneg", "ETL cluster Z resolution (-Z);Z_{RECO}-Z_{SIM} [cm]", 100, -0.003, 0.003);
   meCluZRes_[1] =
       ibook.book1D("EtlCluZResZpos", "ETL cluster Z resolution (+Z);Z_{RECO}-Z_{SIM} [cm]", 100, -0.003, 0.003);
-  meCluYXLocal_[0] = ibook.book2D("EtlCluYXLocalZneg",
-                                  "ETL cluster local Y vs X (-Z);X^{local}_{RECO} [cm];Y^{local}_{RECO} [cm]",
-                                  100,
-                                  -2.2,
-                                  2.2,
-                                  100,
-                                  -1.1,
-                                  1.1);
-  meCluYXLocal_[1] = ibook.book2D("EtlCluYXLocalZpos",
-                                  "ETL cluster local Y vs X (+Z);X^{local}_{RECO} [cm];Y^{local}_{RECO} [cm]",
-                                  100,
-                                  -2.2,
-                                  2.2,
-                                  100,
-                                  -1.1,
-                                  1.1);
-  meCluYXLocalSim_[0] = ibook.book2D("EtlCluYXLocalSimZneg",
-                                     "ETL cluster local Y vs X (-Z);X^{local}_{SIM} [cm];Y^{local}_{SIM} [cm]",
-                                     200,
-                                     -2.2,
-                                     2.2,
-                                     200,
-                                     -1.1,
-                                     1.1);
-  meCluYXLocalSim_[1] = ibook.book2D("EtlCluYXLocalSimZpos",
-                                     "ETL cluster local Y vs X (+Z);X^{local}_{SIM} [cm];Y^{local}_{SIM} [cm]",
-                                     200,
-                                     -2.2,
-                                     2.2,
-                                     200,
-                                     -1.1,
-                                     1.1);
+  if (LocalPosDebug_) {
+    meCluYXLocal_[0] = ibook.book2D("EtlCluYXLocalZneg",
+                                    "ETL cluster local Y vs X (-Z);X^{local}_{RECO} [cm];Y^{local}_{RECO} [cm]",
+                                    100,
+                                    -2.2,
+                                    2.2,
+                                    100,
+                                    -1.1,
+                                    1.1);
+    meCluYXLocal_[1] = ibook.book2D("EtlCluYXLocalZpos",
+                                    "ETL cluster local Y vs X (+Z);X^{local}_{RECO} [cm];Y^{local}_{RECO} [cm]",
+                                    100,
+                                    -2.2,
+                                    2.2,
+                                    100,
+                                    -1.1,
+                                    1.1);
+    meCluYXLocalSim_[0] = ibook.book2D("EtlCluYXLocalSimZneg",
+                                       "ETL cluster local Y vs X (-Z);X^{local}_{SIM} [cm];Y^{local}_{SIM} [cm]",
+                                       200,
+                                       -2.2,
+                                       2.2,
+                                       200,
+                                       -1.1,
+                                       1.1);
+    meCluYXLocalSim_[1] = ibook.book2D("EtlCluYXLocalSimZpos",
+                                       "ETL cluster local Y vs X (+Z);X^{local}_{SIM} [cm];Y^{local}_{SIM} [cm]",
+                                       200,
+                                       -2.2,
+                                       2.2,
+                                       200,
+                                       -1.1,
+                                       1.1);
+  }
 
   // --- UncalibratedRecHits histograms
 

--- a/Validation/MtdValidation/plugins/EtlLocalRecoValidation.cc
+++ b/Validation/MtdValidation/plugins/EtlLocalRecoValidation.cc
@@ -117,6 +117,11 @@ private:
   MonitorElement* meCluEnergyRes_[2];
   MonitorElement* meCluTPullvsE_[2];
   MonitorElement* meCluTPullvsEta_[2];
+  MonitorElement* meCluXRes_[2];
+  MonitorElement* meCluYRes_[2];
+  MonitorElement* meCluZRes_[2];
+  MonitorElement* meCluYXLocal_[2];
+  MonitorElement* meCluYXLocalSim_[2];
 
   // --- UncalibratedRecHits histograms
 
@@ -440,12 +445,21 @@ void EtlLocalRecoValidation::analyze(const edm::Event& iEvent, const edm::EventS
 
         float time_res = cluster.time() - cluTimeSIM;
         float energy_res = cluster.energy() - cluEneSIM;
+        float x_res = global_point.x() - cluGlobalPosSIM.x();
+        float y_res = global_point.y() - cluGlobalPosSIM.y();
+        float z_res = global_point.z() - cluGlobalPosSIM.z();
 
         meCluTimeRes_[iside]->Fill(time_res);
         meCluEnergyRes_[iside]->Fill(energy_res);
+        meCluXRes_[iside]->Fill(x_res);
+        meCluYRes_[iside]->Fill(y_res);
+        meCluZRes_[iside]->Fill(z_res);
 
-        meCluTPullvsEta_[iside]->Fill(std::abs(cluGlobalPosSIM.eta()), time_res / cluster.timeError());
+        meCluTPullvsEta_[iside]->Fill(cluGlobalPosSIM.eta(), time_res / cluster.timeError());
         meCluTPullvsE_[iside]->Fill(cluEneSIM, time_res / cluster.timeError());
+
+        meCluYXLocal_[iside]->Fill(local_point.x(), local_point.y());
+        meCluYXLocalSim_[iside]->Fill(cluLocalPosSIM.x(), cluLocalPosSIM.y());
 
       }  // if ( cluTimeSIM > 0. &&  cluEneSIM > 0. )
 
@@ -795,9 +809,9 @@ void EtlLocalRecoValidation::bookHistograms(DQMStore::IBooker& ibook,
                                       0.,
                                       100.);
   meTPullvsE_ = ibook.bookProfile(
-      "EtlTPullvsE", "ETL time pull vs E;E_{SIM} [MeV];T_{RECO}-T_{SIM}/#sigma_{T_{RECO}}", 20, 0., 2., -5., 5., "S");
+      "EtlTPullvsE", "ETL time pull vs E;E_{SIM} [MeV];(T_{RECO}-T_{SIM})/#sigma_{T_{RECO}}", 20, 0., 2., -5., 5., "S");
   meTPullvsEta_ = ibook.bookProfile("EtlTPullvsEta",
-                                    "ETL time pull vs #eta;|#eta_{RECO}|;T_{RECO}-T_{SIM}/#sigma_{T_{RECO}}",
+                                    "ETL time pull vs #eta;|#eta_{RECO}|;(T_{RECO}-T_{SIM})/#sigma_{T_{RECO}}",
                                     26,
                                     1.65,
                                     3.0,
@@ -900,40 +914,80 @@ void EtlLocalRecoValidation::bookHistograms(DQMStore::IBooker& ibook,
 
   meCluTPullvsE_[0] =
       ibook.bookProfile("EtlCluTPullvsEZneg",
-                        "ETL cluster time pull vs E (-Z);E_{SIM} [MeV];T_{RECO}-T_{SIM}/#sigma_{T_{RECO}}",
-                        20,
+                        "ETL cluster time pull vs E (-Z);E_{SIM} [MeV];(T_{RECO}-T_{SIM})/#sigma_{T_{RECO}}",
+                        25,
                         0.,
-                        20.,
+                        0.5,
                         -5.,
                         5.,
                         "S");
   meCluTPullvsE_[1] =
       ibook.bookProfile("EtlCluTPullvsEZpos",
-                        "ETL cluster time pull vs E (+Z);E_{SIM} [MeV];T_{RECO}-T_{SIM}/#sigma_{T_{RECO}}",
-                        20,
+                        "ETL cluster time pull vs E (+Z);E_{SIM} [MeV];(T_{RECO}-T_{SIM})/#sigma_{T_{RECO}}",
+                        25,
                         0.,
-                        20.,
+                        0.5,
                         -5.,
                         5.,
                         "S");
   meCluTPullvsEta_[0] =
       ibook.bookProfile("EtlCluTPullvsEtaZneg",
-                        "ETL cluster time pull vs #eta (-Z);|#eta_{RECO}|;T_{RECO}-T_{SIM}/#sigma_{T_{RECO}}",
-                        32,
-                        0,
-                        1.55,
+                        "ETL cluster time pull vs #eta (-Z);|#eta_{RECO}|;(T_{RECO}-T_{SIM})/#sigma_{T_{RECO}}",
+                        30,
+                        -3.,
+                        -1.65,
                         -5.,
                         5.,
                         "S");
   meCluTPullvsEta_[1] =
       ibook.bookProfile("EtlCluTPullvsEtaZpos",
-                        "ETL cluster time pull vs #eta (+Z);|#eta_{RECO}|;T_{RECO}-T_{SIM}/#sigma_{T_{RECO}}",
-                        32,
-                        0,
-                        1.55,
+                        "ETL cluster time pull vs #eta (+Z);|#eta_{RECO}|;(T_{RECO}-T_{SIM})/#sigma_{T_{RECO}}",
+                        30,
+                        1.65,
+                        3.,
                         -5.,
                         5.,
                         "S");
+  meCluXRes_[0] = ibook.book1D("EtlCluXResZneg", "ETL cluster X resolution (-Z);X_{RECO}-X_{SIM} [cm]", 100, -0.1, 0.1);
+  meCluXRes_[1] = ibook.book1D("EtlCluXResZpos", "ETL cluster X resolution (+Z);X_{RECO}-X_{SIM} [cm]", 100, -0.1, 0.1);
+  meCluYRes_[0] = ibook.book1D("EtlCluYResZneg", "ETL cluster Y resolution (-Z);Y_{RECO}-Y_{SIM} [cm]", 100, -0.1, 0.1);
+  meCluYRes_[1] = ibook.book1D("EtlCluYResZpos", "ETL cluster Y resolution (+Z);Y_{RECO}-Y_{SIM} [cm]", 100, -0.1, 0.1);
+  meCluZRes_[0] =
+      ibook.book1D("EtlCluZResZneg", "ETL cluster Z resolution (-Z);Z_{RECO}-Z_{SIM} [cm]", 100, -0.003, 0.003);
+  meCluZRes_[1] =
+      ibook.book1D("EtlCluZResZpos", "ETL cluster Z resolution (+Z);Z_{RECO}-Z_{SIM} [cm]", 100, -0.003, 0.003);
+  meCluYXLocal_[0] = ibook.book2D("EtlCluYXLocalZneg",
+                                  "ETL cluster local Y vs X (-Z);X^{local}_{RECO} [cm];Y^{local}_{RECO} [cm]",
+                                  100,
+                                  -2.2,
+                                  2.2,
+                                  100,
+                                  -1.1,
+                                  1.1);
+  meCluYXLocal_[1] = ibook.book2D("EtlCluYXLocalZpos",
+                                  "ETL cluster local Y vs X (+Z);X^{local}_{RECO} [cm];Y^{local}_{RECO} [cm]",
+                                  100,
+                                  -2.2,
+                                  2.2,
+                                  100,
+                                  -1.1,
+                                  1.1);
+  meCluYXLocalSim_[0] = ibook.book2D("EtlCluYXLocalSimZneg",
+                                     "ETL cluster local Y vs X (-Z);X^{local}_{SIM} [cm];Y^{local}_{SIM} [cm]",
+                                     200,
+                                     -2.2,
+                                     2.2,
+                                     200,
+                                     -1.1,
+                                     1.1);
+  meCluYXLocalSim_[1] = ibook.book2D("EtlCluYXLocalSimZpos",
+                                     "ETL cluster local Y vs X (+Z);X^{local}_{SIM} [cm];Y^{local}_{SIM} [cm]",
+                                     200,
+                                     -2.2,
+                                     2.2,
+                                     200,
+                                     -1.1,
+                                     1.1);
 
   // --- UncalibratedRecHits histograms
 

--- a/Validation/MtdValidation/plugins/EtlLocalRecoValidation.cc
+++ b/Validation/MtdValidation/plugins/EtlLocalRecoValidation.cc
@@ -33,7 +33,8 @@
 
 #include "Geometry/Records/interface/MTDDigiGeometryRecord.h"
 #include "Geometry/MTDGeometryBuilder/interface/MTDGeometry.h"
-#include "Geometry/CommonTopologies/interface/PixelTopology.h"
+#include "Geometry/MTDGeometryBuilder/interface/ProxyMTDTopology.h"
+#include "Geometry/MTDGeometryBuilder/interface/RectangularMTDTopology.h"
 #include "Geometry/MTDNumberingBuilder/interface/MTDTopology.h"
 #include "Geometry/MTDCommonData/interface/MTDTopologyMode.h"
 
@@ -111,6 +112,11 @@ private:
   MonitorElement* meEnergyRes_;
   MonitorElement* meTPullvsE_;
   MonitorElement* meTPullvsEta_;
+
+  MonitorElement* meCluTimeRes_[2];
+  MonitorElement* meCluEnergyRes_[2];
+  MonitorElement* meCluTPullvsE_[2];
+  MonitorElement* meCluTPullvsEta_[2];
 
   // --- UncalibratedRecHits histograms
 
@@ -222,7 +228,8 @@ void EtlLocalRecoValidation::analyze(const edm::Event& iEvent, const edm::EventS
     if (thedet == nullptr)
       throw cms::Exception("EtlLocalRecoValidation") << "GeographicalID: " << std::hex << geoId.rawId() << " ("
                                                      << detId.rawId() << ") is invalid!" << std::dec << std::endl;
-    const PixelTopology& topo = static_cast<const PixelTopology&>(thedet->topology());
+    const ProxyMTDTopology& topoproxy = static_cast<const ProxyMTDTopology&>(thedet->topology());
+    const RectangularMTDTopology& topo = static_cast<const RectangularMTDTopology&>(topoproxy.specificTopology());
 
     Local3DPoint local_point(topo.localX(recHit.row()), topo.localY(recHit.column()), 0.);
     const auto& global_point = thedet->toGlobal(local_point);
@@ -335,8 +342,8 @@ void EtlLocalRecoValidation::analyze(const edm::Event& iEvent, const edm::EventS
         throw cms::Exception("EtlLocalRecoValidation")
             << "GeographicalID: " << std::hex << cluId << " is invalid!" << std::dec << std::endl;
       }
-
-      const PixelTopology& topo = static_cast<const PixelTopology&>(genericDet->topology());
+      const ProxyMTDTopology& topoproxy = static_cast<const ProxyMTDTopology&>(genericDet->topology());
+      const RectangularMTDTopology& topo = static_cast<const RectangularMTDTopology&>(topoproxy.specificTopology());
 
       Local3DPoint local_point(topo.localX(cluster.x()), topo.localY(cluster.y()), 0.);
       const auto& global_point = genericDet->toGlobal(local_point);
@@ -377,8 +384,74 @@ void EtlLocalRecoValidation::analyze(const edm::Event& iEvent, const edm::EventS
       meCluEta_[idet]->Fill(global_point.eta());
       meCluOccupancy_[idet]->Fill(global_point.x(), global_point.y(), weight);
       meCluHits_[idet]->Fill(cluster.size());
-    }
-  }
+
+      // --- Get the SIM hits associated to the cluster and calculate
+      //     the cluster SIM energy, time and position
+
+      double cluEneSIM = 0.;
+      double cluTimeSIM = 0.;
+      double cluLocXSIM = 0.;
+      double cluLocYSIM = 0.;
+      double cluLocZSIM = 0.;
+
+      for (int ihit = 0; ihit < cluster.size(); ++ihit) {
+        int hit_row = cluster.minHitRow() + cluster.hitOffset()[ihit * 2];
+        int hit_col = cluster.minHitCol() + cluster.hitOffset()[ihit * 2 + 1];
+
+        // Match the RECO hit to the corresponding SIM hit
+        for (const auto& recHit : *etlRecHitsHandle) {
+          ETLDetId hitId(recHit.id().rawId());
+
+          // Check the hit position
+          if (hitId.zside() != cluId.zside() || hitId.mtdRR() != cluId.mtdRR() || hitId.module() != cluId.module() ||
+              recHit.row() != hit_row || recHit.column() != hit_col)
+            continue;
+
+          // Check the hit energy and time
+          if (recHit.energy() != cluster.hitENERGY()[ihit] || recHit.time() != cluster.hitTIME()[ihit])
+            continue;
+
+          // SIM hit's position in the module reference frame
+          Local3DPoint local_point_sim(convertMmToCm(m_etlSimHits[idet][recHit.id().rawId()].x_local),
+                                       convertMmToCm(m_etlSimHits[idet][recHit.id().rawId()].y_local),
+                                       convertMmToCm(m_etlSimHits[idet][recHit.id().rawId()].z_local));
+
+          // Calculate the SIM cluster's position in the module reference frame
+          cluLocXSIM += local_point_sim.x() * m_etlSimHits[idet][recHit.id().rawId()].energy;
+          cluLocYSIM += local_point_sim.y() * m_etlSimHits[idet][recHit.id().rawId()].energy;
+          cluLocZSIM += local_point_sim.z() * m_etlSimHits[idet][recHit.id().rawId()].energy;
+
+          // Calculate the SIM cluster energy and time
+          cluEneSIM += m_etlSimHits[idet][recHit.id().rawId()].energy;
+          cluTimeSIM += m_etlSimHits[idet][recHit.id().rawId()].time * m_etlSimHits[idet][recHit.id().rawId()].energy;
+
+        }  // recHit loop
+
+      }  // ihit loop
+
+      // --- Fill the cluster resolution histograms
+      if (cluTimeSIM > 0. && cluEneSIM > 0.) {
+        int iside = (cluId.zside() == -1 ? 0 : 1);
+
+        cluTimeSIM /= cluEneSIM;
+
+        Local3DPoint cluLocalPosSIM(cluLocXSIM / cluEneSIM, cluLocYSIM / cluEneSIM, cluLocZSIM / cluEneSIM);
+        const auto& cluGlobalPosSIM = genericDet->toGlobal(cluLocalPosSIM);
+
+        float time_res = cluster.time() - cluTimeSIM;
+        float energy_res = cluster.energy() - cluEneSIM;
+
+        meCluTimeRes_[iside]->Fill(time_res);
+        meCluEnergyRes_[iside]->Fill(energy_res);
+
+        meCluTPullvsEta_[iside]->Fill(std::abs(cluGlobalPosSIM.eta()), time_res / cluster.timeError());
+        meCluTPullvsE_[iside]->Fill(cluEneSIM, time_res / cluster.timeError());
+
+      }  // if ( cluTimeSIM > 0. &&  cluEneSIM > 0. )
+
+    }  // cluster loop
+
+  }  // DetSetClu loop
 
   // --- Loop over the ETL Uncalibrated RECO hits
   if (uncalibRecHitsPlots_) {
@@ -398,7 +471,9 @@ void EtlLocalRecoValidation::analyze(const edm::Event& iEvent, const edm::EventS
       if (thedet == nullptr)
         throw cms::Exception("EtlLocalRecoValidation") << "GeographicalID: " << std::hex << geoId.rawId() << " ("
                                                        << detId.rawId() << ") is invalid!" << std::dec << std::endl;
-      const PixelTopology& topo = static_cast<const PixelTopology&>(thedet->topology());
+
+      const ProxyMTDTopology& topoproxy = static_cast<const ProxyMTDTopology&>(thedet->topology());
+      const RectangularMTDTopology& topo = static_cast<const RectangularMTDTopology&>(topoproxy.specificTopology());
 
       Local3DPoint local_point(topo.localX(uRecHit.row()), topo.localY(uRecHit.column()), 0.);
       const auto& global_point = thedet->toGlobal(local_point);
@@ -813,6 +888,52 @@ void EtlLocalRecoValidation::bookHistograms(DQMStore::IBooker& ibook,
                                     100,
                                     -150,
                                     150);
+
+  meCluTimeRes_[0] =
+      ibook.book1D("EtlCluTimeResZneg", "ETL cluster time resolution (-Z);T_{RECO}-T_{SIM}", 100, -0.5, 0.5);
+  meCluTimeRes_[1] =
+      ibook.book1D("EtlCluTimeResZpos", "ETL cluster time resolution (+Z);T_{RECO}-T_{SIM}", 100, -0.5, 0.5);
+  meCluEnergyRes_[0] =
+      ibook.book1D("EtlCluEnergyResZneg", "ETL cluster energy resolution (-Z);E_{RECO}-E_{SIM}", 100, -0.5, 0.5);
+  meCluEnergyRes_[1] =
+      ibook.book1D("EtlCluEnergyResZpos", "ETL cluster energy resolution (+Z);E_{RECO}-E_{SIM}", 100, -0.5, 0.5);
+
+  meCluTPullvsE_[0] =
+      ibook.bookProfile("EtlCluTPullvsEZneg",
+                        "ETL cluster time pull vs E (-Z);E_{SIM} [MeV];T_{RECO}-T_{SIM}/#sigma_{T_{RECO}}",
+                        20,
+                        0.,
+                        20.,
+                        -5.,
+                        5.,
+                        "S");
+  meCluTPullvsE_[1] =
+      ibook.bookProfile("EtlCluTPullvsEZpos",
+                        "ETL cluster time pull vs E (+Z);E_{SIM} [MeV];T_{RECO}-T_{SIM}/#sigma_{T_{RECO}}",
+                        20,
+                        0.,
+                        20.,
+                        -5.,
+                        5.,
+                        "S");
+  meCluTPullvsEta_[0] =
+      ibook.bookProfile("EtlCluTPullvsEtaZneg",
+                        "ETL cluster time pull vs #eta (-Z);|#eta_{RECO}|;T_{RECO}-T_{SIM}/#sigma_{T_{RECO}}",
+                        32,
+                        0,
+                        1.55,
+                        -5.,
+                        5.,
+                        "S");
+  meCluTPullvsEta_[1] =
+      ibook.bookProfile("EtlCluTPullvsEtaZpos",
+                        "ETL cluster time pull vs #eta (+Z);|#eta_{RECO}|;T_{RECO}-T_{SIM}/#sigma_{T_{RECO}}",
+                        32,
+                        0,
+                        1.55,
+                        -5.,
+                        5.,
+                        "S");
 
   // --- UncalibratedRecHits histograms
 

--- a/Validation/MtdValidation/plugins/EtlLocalRecoValidation.cc
+++ b/Validation/MtdValidation/plugins/EtlLocalRecoValidation.cc
@@ -904,9 +904,9 @@ void EtlLocalRecoValidation::bookHistograms(DQMStore::IBooker& ibook,
                                     150);
 
   meCluTimeRes_[0] =
-      ibook.book1D("EtlCluTimeResZneg", "ETL cluster time resolution (-Z);T_{RECO}-T_{SIM}", 100, -0.5, 0.5);
+      ibook.book1D("EtlCluTimeResZneg", "ETL cluster time resolution (-Z);T_{RECO}-T_{SIM} [ns]", 100, -0.5, 0.5);
   meCluTimeRes_[1] =
-      ibook.book1D("EtlCluTimeResZpos", "ETL cluster time resolution (+Z);T_{RECO}-T_{SIM}", 100, -0.5, 0.5);
+      ibook.book1D("EtlCluTimeResZpos", "ETL cluster time resolution (+Z);T_{RECO}-T_{SIM} [MeV]", 100, -0.5, 0.5);
   meCluEnergyRes_[0] =
       ibook.book1D("EtlCluEnergyResZneg", "ETL cluster energy resolution (-Z);E_{RECO}-E_{SIM}", 100, -0.5, 0.5);
   meCluEnergyRes_[1] =


### PR DESCRIPTION
#### PR description:

This PR builds the SIM clusters associated to the reconstructed BTL and ETL clusters and fills new monitoring histograms with:
- time, energy and position resolutions for BTL and ETL clusters;
- cluster time pulls vs energy and eta;
- Y vs X of the cluster local coordinates.

(@fabiocos , @parbol , @gsorrentino18 )

#### PR validation:

The new code has been validated with the TTbar WFs 34634.0 and 34834.0 with CMSSW_12_0_X_2021-06-21-1100.

--------------------------------------------------------------------------------------

**current code**

step 3 (WF 34634.0)

MemoryReport> Peak virtual size 6372.39 Mbytes
 Key events increasing vsize: 
[0] run: 0 lumi: 0 event: 0  vsize = 0 deltaVsize = 0 rss = 0 delta = 0
[1] run: 1 lumi: 1 event: 1  vsize = 6372.34 deltaVsize = 0 rss = 3253.47 delta = 0
[2] run: 1 lumi: 1 event: 2  vsize = 6372.39 deltaVsize = 0.046875 rss = 3338.56 delta = 85.0898
[8] run: 1 lumi: 1 event: 8  vsize = 6372.39 deltaVsize = 0.0078125 rss = 3397.37 delta = 58.8047
[0] run: 0 lumi: 0 event: 0  vsize = 0 deltaVsize = 0 rss = 0 delta = 0
[10] run: 1 lumi: 1 event: 10  vsize = 6372.39 deltaVsize = 0 rss = 3408.45 delta = 11.0859
[9] run: 1 lumi: 1 event: 9  vsize = 6372.39 deltaVsize = 0 rss = 3405.04 delta = 7.66797
[8] run: 1 lumi: 1 event: 8  vsize = 6372.39 deltaVsize = 0.0078125 rss = 3397.37 delta = 58.8047
TimeReport> Time report complete in 281.325 seconds
 Time Summary: 
 - Min event:   2.63794
 - Max event:   17.0326
 - Avg event:   5.85748
 - Total loop:  122.119
 - Total init:  154.509
 - Total job:   281.325
 - EventSetup Lock:   0
 - EventSetup Get:   0
 Event Throughput: 0.0818873 ev/s
 CPU Summary: 
 - Total loop:  115.4
 - Total init:  156.349
 - Total extra: 0
 - Total job:   275.98
 Processing Summary: 
 - Number of Events:  10
 - Number of Global Begin Lumi Calls:  1
 - Number of Global Begin Run Calls: 1

step 3 (WF 34834.0)

 MemoryReport> Peak virtual size 10830.3 Mbytes
 Key events increasing vsize: 
[0] run: 0 lumi: 0 event: 0  vsize = 0 deltaVsize = 0 rss = 0 delta = 0
[1] run: 1 lumi: 1 event: 1  vsize = 9805.86 deltaVsize = 0 rss = 7058.96 delta = 0
[2] run: 1 lumi: 1 event: 2  vsize = 10830.3 deltaVsize = 1024.49 rss = 7500.25 delta = 441.285
[0] run: 0 lumi: 0 event: 0  vsize = 0 deltaVsize = 0 rss = 0 delta = 0
[0] run: 0 lumi: 0 event: 0  vsize = 0 deltaVsize = 0 rss = 0 delta = 0
[4] run: 1 lumi: 1 event: 4  vsize = 10830.3 deltaVsize = 0 rss = 7134.74 delta = -365.512
[3] run: 1 lumi: 1 event: 3  vsize = 10830.3 deltaVsize = 0 rss = 7416.19 delta = -84.0586
[2] run: 1 lumi: 1 event: 2  vsize = 10830.3 deltaVsize = 1024.49 rss = 7500.25 delta = 441.285
TimeReport> Time report complete in 2298.29 seconds
 Time Summary: 
 - Min event:   141.309
 - Max event:   332.148
 - Avg event:   186.191
 - Total loop:  2040.3
 - Total init:  252.703
 - Total job:   2298.29
 - EventSetup Lock:   0
 - EventSetup Get:   0
 Event Throughput: 0.00490124 ev/s
 CPU Summary: 
 - Total loop:  1494.69
 - Total init:  102.663
 - Total extra: 0
 - Total job:   1602.19
 Processing Summary: 
 - Number of Events:  10
 - Number of Global Begin Lumi Calls:  1
 - Number of Global Begin Run Calls: 1

--------------------------------------------------------------------------------------

**new code**

step 3 (WF 34634.0)

MemoryReport> Peak virtual size 6374.41 Mbytes
 Key events increasing vsize: 
[0] run: 0 lumi: 0 event: 0  vsize = 0 deltaVsize = 0 rss = 0 delta = 0
[1] run: 1 lumi: 1 event: 1  vsize = 6374.36 deltaVsize = 0 rss = 3375.52 delta = 0
[2] run: 1 lumi: 1 event: 2  vsize = 6374.41 deltaVsize = 0.046875 rss = 3448.57 delta = 73.0586
[8] run: 1 lumi: 1 event: 8  vsize = 6374.41 deltaVsize = 0.0078125 rss = 3500.94 delta = 52.3633
[0] run: 0 lumi: 0 event: 0  vsize = 0 deltaVsize = 0 rss = 0 delta = 0
[10] run: 1 lumi: 1 event: 10  vsize = 6374.41 deltaVsize = 0 rss = 3509.6 delta = 8.66016
[9] run: 1 lumi: 1 event: 9  vsize = 6374.41 deltaVsize = 0 rss = 3513.95 delta = 13.0078
[8] run: 1 lumi: 1 event: 8  vsize = 6374.41 deltaVsize = 0.0078125 rss = 3500.94 delta = 52.3633
TimeReport> Time report complete in 219.515 seconds
 Time Summary: 
 - Min event:   2.40397
 - Max event:   16.8583
 - Avg event:   5.15732
 - Total loop:  106.134
 - Total init:  109.03
 - Total job:   219.515
 - EventSetup Lock:   0
 - EventSetup Get:   0
 Event Throughput: 0.0942203 ev/s
 CPU Summary: 
 - Total loop:  100.611
 - Total init:  135.833
 - Total extra: 0
 - Total job:   240.449
 Processing Summary: 
 - Number of Events:  10
 - Number of Global Begin Lumi Calls:  1
 - Number of Global Begin Run Calls: 1

step 3 (WF 34834.0)

MemoryReport> Peak virtual size 10829.4 Mbytes
 Key events increasing vsize: 
[0] run: 0 lumi: 0 event: 0  vsize = 0 deltaVsize = 0 rss = 0 delta = 0
[1] run: 1 lumi: 1 event: 1  vsize = 9804.88 deltaVsize = 0 rss = 6334.34 delta = 0
[2] run: 1 lumi: 1 event: 2  vsize = 10829.4 deltaVsize = 1024.49 rss = 6906.25 delta = 571.91
[0] run: 0 lumi: 0 event: 0  vsize = 0 deltaVsize = 0 rss = 0 delta = 0
[0] run: 0 lumi: 0 event: 0  vsize = 0 deltaVsize = 0 rss = 0 delta = 0
[4] run: 1 lumi: 1 event: 4  vsize = 10829.4 deltaVsize = 0 rss = 6600.7 delta = -305.551
[3] run: 1 lumi: 1 event: 3  vsize = 10829.4 deltaVsize = 0 rss = 6856.95 delta = -49.3008
[2] run: 1 lumi: 1 event: 2  vsize = 10829.4 deltaVsize = 1024.49 rss = 6906.25 delta = 571.91
TimeReport> Time report complete in 2217.3 seconds
 Time Summary: 
 - Min event:   143.84
 - Max event:   377.531
 - Avg event:   193.618
 - Total loop:  2092.58
 - Total init:  119.324
 - Total job:   2217.3
 - EventSetup Lock:   0
 - EventSetup Get:   0
 Event Throughput: 0.00477879 ev/s
 CPU Summary: 
 - Total loop:  1516.13
 - Total init:  96.4185
 - Total extra: 0
 - Total job:   1617.48
 Processing Summary: 
 - Number of Events:  10
 - Number of Global Begin Lumi Calls:  1
 - Number of Global Begin Run Calls: 1

--------------------------------------------------------------------------------------

**DQM file size**
current:
1129.74 KiB      MTD/ETL
239.63 KiB       MTD/BTL

new:
1535.33 KiB      MTD/ETL
560.66 KiB       MTD/BTL
