### PR TITLE
DQM: migrate modules to esConsumes

### DIFF
--- a/DQM/EcalPreshowerMonitorModule/interface/ESDaqInfoTask.h
+++ b/DQM/EcalPreshowerMonitorModule/interface/ESDaqInfoTask.h
@@ -37,7 +37,7 @@ protected:
 
 private:
   DQMStore* dqmStore_;
-
+  edm::ESGetToken<RunInfo, RunInfoRcd> runInfoToken_;
   std::string prefixME_;
 
   bool mergeRuns_;

--- a/DQM/EcalPreshowerMonitorModule/interface/ESTimingTask.h
+++ b/DQM/EcalPreshowerMonitorModule/interface/ESTimingTask.h
@@ -35,7 +35,7 @@ private:
   MonitorElement *hTiming_[2][2];
   MonitorElement *h2DTiming_;
 
-  edm::ESGetToken<ESGain, ESGainRcd>  esgainToken_; 
+  edm::ESGetToken<ESGain, ESGainRcd> esgainToken_;
   edm::ESHandle<ESGain> esgain_;
 
   TF1 *fit_;

--- a/DQM/EcalPreshowerMonitorModule/interface/ESTimingTask.h
+++ b/DQM/EcalPreshowerMonitorModule/interface/ESTimingTask.h
@@ -35,6 +35,7 @@ private:
   MonitorElement *hTiming_[2][2];
   MonitorElement *h2DTiming_;
 
+  edm::ESGetToken<ESGain, ESGainRcd>  esgainToken_; 
   edm::ESHandle<ESGain> esgain_;
 
   TF1 *fit_;

--- a/DQM/EcalPreshowerMonitorModule/src/ESDaqInfoTask.cc
+++ b/DQM/EcalPreshowerMonitorModule/src/ESDaqInfoTask.cc
@@ -28,7 +28,7 @@ using namespace std;
 
 ESDaqInfoTask::ESDaqInfoTask(const ParameterSet& ps) {
   dqmStore_ = Service<DQMStore>().operator->();
-
+  runInfoToken_ = esConsumes<edm::Transition::BeginLuminosityBlock>();
   prefixME_ = ps.getUntrackedParameter<string>("prefixME", "");
 
   mergeRuns_ = ps.getUntrackedParameter<bool>("mergeRuns", false);
@@ -117,8 +117,8 @@ void ESDaqInfoTask::beginLuminosityBlock(const edm::LuminosityBlock& lumiBlock, 
   }
 
   if (auto runInfoRec = iSetup.tryToGet<RunInfoRcd>()) {
-    edm::ESHandle<RunInfo> sumFED;
-    runInfoRec->get(sumFED);
+
+    const auto& sumFED = runInfoRec->getHandle(runInfoToken_);
 
     std::vector<int> FedsInIds = sumFED->m_fed_in;
 

--- a/DQM/EcalPreshowerMonitorModule/src/ESDaqInfoTask.cc
+++ b/DQM/EcalPreshowerMonitorModule/src/ESDaqInfoTask.cc
@@ -117,7 +117,6 @@ void ESDaqInfoTask::beginLuminosityBlock(const edm::LuminosityBlock& lumiBlock, 
   }
 
   if (auto runInfoRec = iSetup.tryToGet<RunInfoRcd>()) {
-
     const auto& sumFED = runInfoRec->getHandle(runInfoToken_);
 
     std::vector<int> FedsInIds = sumFED->m_fed_in;

--- a/DQM/EcalPreshowerMonitorModule/src/ESTimingTask.cc
+++ b/DQM/EcalPreshowerMonitorModule/src/ESTimingTask.cc
@@ -39,7 +39,7 @@ double fitf(double* x, double* par) {
 ESTimingTask::ESTimingTask(const edm::ParameterSet& ps) {
   digilabel_ = consumes<ESDigiCollection>(ps.getParameter<InputTag>("DigiLabel"));
   prefixME_ = ps.getUntrackedParameter<string>("prefixME", "EcalPreshower");
-
+  esgainToken_ = esConsumes();
   eCount_ = 0;
 
   fit_ = new TF1("fitShape", fitf, -200, 200, 4);
@@ -171,8 +171,7 @@ void ESTimingTask::analyze(const edm::Event& e, const edm::EventSetup& iSetup) {
 }
 
 void ESTimingTask::set(const edm::EventSetup& es) {
-  es.get<ESGainRcd>().get(esgain_);
-  const ESGain* gain = esgain_.product();
+  const ESGain* gain = &es.getData(esgainToken_);
 
   int ESGain = (int)gain->getESGain();
 

--- a/DQM/GEM/interface/GEMDQMBase.h
+++ b/DQM/GEM/interface/GEMDQMBase.h
@@ -419,6 +419,7 @@ protected:
   std::string log_category_;
 
   const GEMGeometry *GEMGeometry_;
+  edm::ESGetToken<GEMGeometry, MuonGeometryRecord> geomToken_;
 
   std::vector<GEMChamber> gemChambers_;
 

--- a/DQM/GEM/src/GEMDQMBase.cc
+++ b/DQM/GEM/src/GEMDQMBase.cc
@@ -4,9 +4,7 @@
 using namespace std;
 using namespace edm;
 
-GEMDQMBase::GEMDQMBase(const edm::ParameterSet& cfg) :
-  geomToken_(esConsumes<edm::Transition::BeginRun>())
-{
+GEMDQMBase::GEMDQMBase(const edm::ParameterSet& cfg) : geomToken_(esConsumes<edm::Transition::BeginRun>()) {
   log_category_ = cfg.getUntrackedParameter<std::string>("logCategory");
 
   nNumEtaPartitionGE0_ = 0;

--- a/DQM/GEM/src/GEMDQMBase.cc
+++ b/DQM/GEM/src/GEMDQMBase.cc
@@ -4,7 +4,9 @@
 using namespace std;
 using namespace edm;
 
-GEMDQMBase::GEMDQMBase(const edm::ParameterSet& cfg) {
+GEMDQMBase::GEMDQMBase(const edm::ParameterSet& cfg) :
+  geomToken_(esConsumes<edm::Transition::BeginRun>())
+{
   log_category_ = cfg.getUntrackedParameter<std::string>("logCategory");
 
   nNumEtaPartitionGE0_ = 0;
@@ -15,9 +17,9 @@ GEMDQMBase::GEMDQMBase(const edm::ParameterSet& cfg) {
 int GEMDQMBase::initGeometry(edm::EventSetup const& iSetup) {
   GEMGeometry_ = nullptr;
   try {
-    edm::ESHandle<GEMGeometry> hGeom;
-    iSetup.get<MuonGeometryRecord>().get(hGeom);
-    GEMGeometry_ = &*hGeom;
+    //edm::ESHandle<GEMGeometry> hGeom;
+    //iSetup.get<MuonGeometryRecord>().get(hGeom);
+    GEMGeometry_ = &iSetup.getData(geomToken_);
   } catch (edm::eventsetup::NoProxyException<GEMGeometry>& e) {
     edm::LogError(log_category_) << "+++ Error : GEM geometry is unavailable on event loop. +++\n";
     return -1;

--- a/DQM/L1TMonitor/interface/L1GtHwValidation.h
+++ b/DQM/L1TMonitor/interface/L1GtHwValidation.h
@@ -50,6 +50,7 @@ class L1GtTriggerMenu;
 class L1GtPrescaleFactors;
 class L1GtTriggerMask;
 class L1GtPrescaleFactorsTechTrigRcd;
+class L1GtPrescaleFactorsAlgoTrigRcd;
 class L1GtTriggerMenuRcd;
 class L1GtTriggerMaskTechTrigRcd;
 class L1GtTriggerMaskAlgoTrigRcd;
@@ -270,7 +271,8 @@ private:
   edm::EDGetTokenT<L1GlobalTriggerReadoutRecord> m_l1GtEmulDaqInputToken_;
   edm::EDGetTokenT<L1GlobalTriggerEvmReadoutRecord> m_l1GtDataEvmInputToken_;
   edm::EDGetTokenT<L1GlobalTriggerEvmReadoutRecord> m_l1GtEmulEvmInputToken_;
-  edm::ESGetToken<L1GtPrescaleFactors, L1GtPrescaleFactorsTechTrigRcd> l1gtPrescaleToken_;
+  edm::ESGetToken<L1GtPrescaleFactors, L1GtPrescaleFactorsTechTrigRcd> l1gtPrescaleTechToken_;
+  edm::ESGetToken<L1GtPrescaleFactors, L1GtPrescaleFactorsAlgoTrigRcd> l1gtPrescaleAlgoToken_;
   edm::ESGetToken<L1GtTriggerMenu, L1GtTriggerMenuRcd> l1gtTrigmenuToken_;
   edm::ESGetToken<L1GtTriggerMask, L1GtTriggerMaskTechTrigRcd> l1gtTrigmaskTechToken_;
   edm::ESGetToken<L1GtTriggerMask, L1GtTriggerMaskAlgoTrigRcd> l1gtTrigmaskAlgoToken_;

--- a/DQM/L1TMonitor/interface/L1GtHwValidation.h
+++ b/DQM/L1TMonitor/interface/L1GtHwValidation.h
@@ -49,7 +49,10 @@ class L1TcsWord;
 class L1GtTriggerMenu;
 class L1GtPrescaleFactors;
 class L1GtTriggerMask;
-
+class L1GtPrescaleFactorsTechTrigRcd;
+class L1GtTriggerMenuRcd;
+class L1GtTriggerMaskTechTrigRcd;
+class L1GtTriggerMaskAlgoTrigRcd;
 // class declaration
 
 class L1GtHwValidation : public DQMEDAnalyzer {
@@ -267,6 +270,10 @@ private:
   edm::EDGetTokenT<L1GlobalTriggerReadoutRecord> m_l1GtEmulDaqInputToken_;
   edm::EDGetTokenT<L1GlobalTriggerEvmReadoutRecord> m_l1GtDataEvmInputToken_;
   edm::EDGetTokenT<L1GlobalTriggerEvmReadoutRecord> m_l1GtEmulEvmInputToken_;
+  edm::ESGetToken<L1GtPrescaleFactors, L1GtPrescaleFactorsTechTrigRcd> l1gtPrescaleToken_;
+  edm::ESGetToken<L1GtTriggerMenu, L1GtTriggerMenuRcd> l1gtTrigmenuToken_;
+  edm::ESGetToken<L1GtTriggerMask, L1GtTriggerMaskTechTrigRcd> l1gtTrigmaskTechToken_;
+  edm::ESGetToken<L1GtTriggerMask, L1GtTriggerMaskAlgoTrigRcd> l1gtTrigmaskAlgoToken_;
 };
 
 #endif /*DQM_L1TMonitor_L1GtHwValidation_h*/

--- a/DQM/L1TMonitor/interface/L1TBPTX.h
+++ b/DQM/L1TMonitor/interface/L1TBPTX.h
@@ -66,6 +66,12 @@ private:
   std::map<std::pair<int, int>, double> m_lsTechRate;
 };
 
+class L1GtTriggerMenu;
+class L1GtTriggerMenuRcd;
+class L1GtPrescaleFactors;
+class L1GtPrescaleFactorsAlgoTrigRcd;
+class L1GtPrescaleFactorsTechTrigRcd;
+
 class L1TBPTX : public DQMOneEDAnalyzer<edm::one::WatchLuminosityBlocks> {
 public:
   enum BeamMode {
@@ -173,6 +179,9 @@ private:
   edm::EDGetTokenT<Level1TriggerScalersCollection> m_scalersSource;  // Where to get L1 Scalers
   edm::EDGetTokenT<L1GlobalTriggerEvmReadoutRecord> m_l1GtEvmSource;
   edm::EDGetTokenT<L1GlobalTriggerReadoutRecord> m_l1GtDataDaqInputTag;
+  edm::ESGetToken<L1GtTriggerMenu, L1GtTriggerMenuRcd> l1gtMenuToken_;
+  edm::ESGetToken<L1GtPrescaleFactors, L1GtPrescaleFactorsAlgoTrigRcd> l1GtPfAlgoToken_;
+  edm::ESGetToken<L1GtPrescaleFactors, L1GtPrescaleFactorsTechTrigRcd> l1GtPfTechToken_;
 };
 
 #endif

--- a/DQM/L1TMonitor/interface/L1TCSCTF.h
+++ b/DQM/L1TMonitor/interface/L1TCSCTF.h
@@ -188,6 +188,8 @@ private:
   edm::EDGetTokenT<L1CSCTrackCollection> tracksToken_;
   edm::EDGetTokenT<CSCTriggerContainer<csctf::TrackStub> > dtStubsToken_;
   edm::EDGetTokenT<L1CSCTrackCollection> mbtracksToken_;
+  edm::ESGetToken<L1MuTriggerScales, L1MuTriggerScalesRcd> l1muTscalesToken_;
+  edm::ESGetToken<L1MuTriggerPtScale, L1MuTriggerPtScaleRcd> ptscalesToken_;
 };
 
 #endif

--- a/DQM/L1TMonitor/interface/L1TGMT.h
+++ b/DQM/L1TMonitor/interface/L1TGMT.h
@@ -38,6 +38,10 @@
 //
 // class decleration
 //
+class L1MuTriggerScales;
+class L1MuTriggerScalesRcd;
+class L1MuTriggerPtScale;
+class L1MuTriggerPtScaleRcd;
 
 class L1TGMT : public DQMEDAnalyzer {
 public:
@@ -99,6 +103,8 @@ private:
   const bool verbose_;
   std::ofstream logFile_;
   const edm::EDGetTokenT<L1MuGMTReadoutCollection> gmtSource_;
+  edm::ESGetToken<L1MuTriggerScales, L1MuTriggerScalesRcd> l1muTrigscaleToken_;
+  edm::ESGetToken<L1MuTriggerPtScale, L1MuTriggerPtScaleRcd> l1TrigptscaleToken_;
 
   int bxnum_old_;  // bx of previous event
   int obnum_old_;  // orbit of previous event

--- a/DQM/L1TMonitor/interface/L1TGT.h
+++ b/DQM/L1TMonitor/interface/L1TGT.h
@@ -97,6 +97,7 @@ private:
 
   /// input tag for L1 GT EVM readout record
   edm::EDGetTokenT<L1GlobalTriggerEvmReadoutRecord> gtEvmSource_;
+  edm::ESGetToken<L1GtTriggerMenu, L1GtTriggerMenuRcd> l1gtTrigmenuToken_;
 
   /// switches to choose the running of various methods
   bool m_runInEventLoop;

--- a/DQM/L1TMonitor/interface/L1TRPCTPG.h
+++ b/DQM/L1TMonitor/interface/L1TRPCTPG.h
@@ -90,6 +90,7 @@ private:
   edm::EDGetTokenT<RPCDigiCollection> rpctpgSource_token_;
   edm::InputTag rpctfSource_;
   edm::EDGetTokenT<L1MuGMTReadoutCollection> rpctfSource_token_;
+  edm::ESGetToken<RPCGeometry, MuonGeometryRecord> rpcgeomToken_;
 };
 
 #endif

--- a/DQM/L1TMonitor/interface/L1TdeRCT.h
+++ b/DQM/L1TMonitor/interface/L1TdeRCT.h
@@ -267,8 +267,8 @@ private:
   edm::EDGetTokenT<EcalTrigPrimDigiCollection> ecalTPGData_;
   edm::EDGetTokenT<HcalTrigPrimDigiCollection> hcalTPGData_;
   edm::EDGetTokenT<L1GlobalTriggerReadoutRecord> gtDigisLabel_;
-  edm::ESGetToken<RunInfo,RunInfoRcd> runInfoToken_;
-  edm::ESGetToken<RunInfo,RunInfoRcd> runInfolumiToken_;
+  edm::ESGetToken<RunInfo, RunInfoRcd> runInfoToken_;
+  edm::ESGetToken<RunInfo, RunInfoRcd> runInfolumiToken_;
   std::string gtEGAlgoName_;  // name of algo to determine EG trigger threshold
   int doubleThreshold_;       // value of ET at which to make 2-D eff plot
 

--- a/DQM/L1TMonitor/interface/L1TdeRCT.h
+++ b/DQM/L1TMonitor/interface/L1TdeRCT.h
@@ -38,6 +38,8 @@
 
 #include "DQMServices/Core/interface/DQMOneEDAnalyzer.h"
 
+class RunInfoRcd;
+class RunInfo;
 // Trigger Headers
 //
 // class declaration
@@ -63,7 +65,7 @@ protected:
   std::shared_ptr<l1tderct::Empty> globalBeginLuminosityBlock(const edm::LuminosityBlock&,
                                                               const edm::EventSetup&) const override;
   void globalEndLuminosityBlock(const edm::LuminosityBlock&, const edm::EventSetup&) final {}
-  void readFEDVector(MonitorElement*, const edm::EventSetup&) const;
+  void readFEDVector(MonitorElement*, const edm::EventSetup&, const bool isLumitransition = true) const;
 
 private:
   // ----------member data ---------------------------
@@ -265,6 +267,8 @@ private:
   edm::EDGetTokenT<EcalTrigPrimDigiCollection> ecalTPGData_;
   edm::EDGetTokenT<HcalTrigPrimDigiCollection> hcalTPGData_;
   edm::EDGetTokenT<L1GlobalTriggerReadoutRecord> gtDigisLabel_;
+  edm::ESGetToken<RunInfo,RunInfoRcd> runInfoToken_;
+  edm::ESGetToken<RunInfo,RunInfoRcd> runInfolumiToken_;
   std::string gtEGAlgoName_;  // name of algo to determine EG trigger threshold
   int doubleThreshold_;       // value of ET at which to make 2-D eff plot
 

--- a/DQM/L1TMonitor/src/L1GtHwValidation.cc
+++ b/DQM/L1TMonitor/src/L1GtHwValidation.cc
@@ -134,6 +134,10 @@ L1GtHwValidation::L1GtHwValidation(const edm::ParameterSet& paramSet)
       consumes<L1GlobalTriggerEvmReadoutRecord>(paramSet.getParameter<edm::InputTag>("L1GtDataEvmInputTag"));
   m_l1GtEmulEvmInputToken_ =
       consumes<L1GlobalTriggerEvmReadoutRecord>(paramSet.getParameter<edm::InputTag>("L1GtEmulEvmInputTag"));
+  l1gtPrescaleToken_ = esConsumes<edm::Transition::BeginRun>();
+  l1gtTrigmenuToken_ = esConsumes<edm::Transition::BeginRun>();
+  l1gtTrigmaskTechToken_ = esConsumes<edm::Transition::BeginRun>();
+  l1gtTrigmaskAlgoToken_ = esConsumes<edm::Transition::BeginRun>();
 }
 
 // destructor
@@ -652,9 +656,7 @@ void L1GtHwValidation::bookHistograms(DQMStore::IBooker& ibooker,
   unsigned long long l1GtMenuCacheID = evSetup.get<L1GtTriggerMenuRcd>().cacheIdentifier();
 
   if (m_l1GtMenuCacheID != l1GtMenuCacheID) {
-    edm::ESHandle<L1GtTriggerMenu> l1GtMenu;
-    evSetup.get<L1GtTriggerMenuRcd>().get(l1GtMenu);
-    m_l1GtMenu = l1GtMenu.product();
+    m_l1GtMenu = &evSetup.getData(l1gtTrigmenuToken_);
 
     // compute the list of algorithms excluded from the computing of the agreement flag
     m_excludedAlgoList.clear();
@@ -764,9 +766,7 @@ void L1GtHwValidation::bookHistograms(DQMStore::IBooker& ibooker,
   unsigned long long l1GtPfTechCacheID = evSetup.get<L1GtPrescaleFactorsTechTrigRcd>().cacheIdentifier();
 
   if (m_l1GtPfTechCacheID != l1GtPfTechCacheID) {
-    edm::ESHandle<L1GtPrescaleFactors> l1GtPfTech;
-    evSetup.get<L1GtPrescaleFactorsTechTrigRcd>().get(l1GtPfTech);
-    m_l1GtPfTech = l1GtPfTech.product();
+    m_l1GtPfTech = &evSetup.getData(l1gtPrescaleToken_);
 
     m_prescaleFactorsTechTrig = &(m_l1GtPfTech->gtPrescaleFactors());
 
@@ -779,9 +779,7 @@ void L1GtHwValidation::bookHistograms(DQMStore::IBooker& ibooker,
   unsigned long long l1GtTmAlgoCacheID = evSetup.get<L1GtTriggerMaskAlgoTrigRcd>().cacheIdentifier();
 
   if (m_l1GtTmAlgoCacheID != l1GtTmAlgoCacheID) {
-    edm::ESHandle<L1GtTriggerMask> l1GtTmAlgo;
-    evSetup.get<L1GtTriggerMaskAlgoTrigRcd>().get(l1GtTmAlgo);
-    m_l1GtTmAlgo = l1GtTmAlgo.product();
+    m_l1GtTmAlgo = &evSetup.getData(l1gtTrigmaskAlgoToken_);
 
     m_triggerMaskAlgoTrig = m_l1GtTmAlgo->gtTriggerMask();
 
@@ -791,9 +789,7 @@ void L1GtHwValidation::bookHistograms(DQMStore::IBooker& ibooker,
   unsigned long long l1GtTmTechCacheID = evSetup.get<L1GtTriggerMaskTechTrigRcd>().cacheIdentifier();
 
   if (m_l1GtTmTechCacheID != l1GtTmTechCacheID) {
-    edm::ESHandle<L1GtTriggerMask> l1GtTmTech;
-    evSetup.get<L1GtTriggerMaskTechTrigRcd>().get(l1GtTmTech);
-    m_l1GtTmTech = l1GtTmTech.product();
+    m_l1GtTmTech = &evSetup.getData(l1gtTrigmaskTechToken_);
 
     m_triggerMaskTechTrig = m_l1GtTmTech->gtTriggerMask();
 

--- a/DQM/L1TMonitor/src/L1GtHwValidation.cc
+++ b/DQM/L1TMonitor/src/L1GtHwValidation.cc
@@ -134,7 +134,8 @@ L1GtHwValidation::L1GtHwValidation(const edm::ParameterSet& paramSet)
       consumes<L1GlobalTriggerEvmReadoutRecord>(paramSet.getParameter<edm::InputTag>("L1GtDataEvmInputTag"));
   m_l1GtEmulEvmInputToken_ =
       consumes<L1GlobalTriggerEvmReadoutRecord>(paramSet.getParameter<edm::InputTag>("L1GtEmulEvmInputTag"));
-  l1gtPrescaleToken_ = esConsumes<edm::Transition::BeginRun>();
+  l1gtPrescaleTechToken_ = esConsumes<edm::Transition::BeginRun>();
+  l1gtPrescaleAlgoToken_ = esConsumes<edm::Transition::BeginRun>();
   l1gtTrigmenuToken_ = esConsumes<edm::Transition::BeginRun>();
   l1gtTrigmaskTechToken_ = esConsumes<edm::Transition::BeginRun>();
   l1gtTrigmaskAlgoToken_ = esConsumes<edm::Transition::BeginRun>();
@@ -754,9 +755,7 @@ void L1GtHwValidation::bookHistograms(DQMStore::IBooker& ibooker,
   unsigned long long l1GtPfAlgoCacheID = evSetup.get<L1GtPrescaleFactorsAlgoTrigRcd>().cacheIdentifier();
 
   if (m_l1GtPfAlgoCacheID != l1GtPfAlgoCacheID) {
-    edm::ESHandle<L1GtPrescaleFactors> l1GtPfAlgo;
-    evSetup.get<L1GtPrescaleFactorsAlgoTrigRcd>().get(l1GtPfAlgo);
-    m_l1GtPfAlgo = l1GtPfAlgo.product();
+    m_l1GtPfAlgo = &evSetup.getData(l1gtPrescaleAlgoToken_);
 
     m_prescaleFactorsAlgoTrig = &(m_l1GtPfAlgo->gtPrescaleFactors());
 
@@ -766,7 +765,7 @@ void L1GtHwValidation::bookHistograms(DQMStore::IBooker& ibooker,
   unsigned long long l1GtPfTechCacheID = evSetup.get<L1GtPrescaleFactorsTechTrigRcd>().cacheIdentifier();
 
   if (m_l1GtPfTechCacheID != l1GtPfTechCacheID) {
-    m_l1GtPfTech = &evSetup.getData(l1gtPrescaleToken_);
+    m_l1GtPfTech = &evSetup.getData(l1gtPrescaleTechToken_);
 
     m_prescaleFactorsTechTrig = &(m_l1GtPfTech->gtPrescaleFactors());
 

--- a/DQM/L1TMonitor/src/L1TBPTX.cc
+++ b/DQM/L1TMonitor/src/L1TBPTX.cc
@@ -37,6 +37,9 @@ L1TBPTX::L1TBPTX(const ParameterSet& pset) {
   m_scalersSource = consumes<Level1TriggerScalersCollection>(pset.getParameter<InputTag>("inputTagScalersResults"));
   m_l1GtDataDaqInputTag = consumes<L1GlobalTriggerReadoutRecord>(pset.getParameter<InputTag>("inputTagL1GtDataDaq"));
   m_l1GtEvmSource = consumes<L1GlobalTriggerEvmReadoutRecord>(pset.getParameter<InputTag>("inputTagtEvmSource"));
+  l1gtMenuToken_ = esConsumes<edm::Transition::BeginRun>();
+  l1GtPfAlgoToken_ = esConsumes<edm::Transition::BeginRun>();
+  l1GtPfTechToken_ = esConsumes<edm::Transition::BeginRun>();
   m_verbose = pset.getUntrackedParameter<bool>("verbose", false);
   //  m_refPrescaleSet      = pset.getParameter         <int>     ("refPrescaleSet");
 
@@ -82,9 +85,7 @@ void L1TBPTX::bookHistograms(DQMStore::IBooker& ibooker, const edm::Run& iRun, c
   m_currentLS = 0;
 
   // Getting Trigger menu from GT
-  ESHandle<L1GtTriggerMenu> menuRcd;
-  iSetup.get<L1GtTriggerMenuRcd>().get(menuRcd);
-  const L1GtTriggerMenu* menu = menuRcd.product();
+  const L1GtTriggerMenu* menu = &iSetup.getData(l1gtMenuToken_);
 
   // Filling Alias-Bit Map
   for (CItAlgo algo = menu->gtAlgorithmAliasMap().begin(); algo != menu->gtAlgorithmAliasMap().end(); ++algo) {
@@ -185,11 +186,8 @@ void L1TBPTX::bookHistograms(DQMStore::IBooker& ibooker, const edm::Run& iRun, c
 
   //_____________________________________________________________________
   // Getting the prescale columns definition for this run
-  ESHandle<L1GtPrescaleFactors> l1GtPfAlgo;
-  ESHandle<L1GtPrescaleFactors> l1GtPfTech;
-
-  iSetup.get<L1GtPrescaleFactorsAlgoTrigRcd>().get(l1GtPfAlgo);
-  iSetup.get<L1GtPrescaleFactorsTechTrigRcd>().get(l1GtPfTech);
+  const auto& l1GtPfAlgo = iSetup.getHandle(l1GtPfAlgoToken_);
+  const auto& l1GtPfTech = iSetup.getHandle(l1GtPfTechToken_);
 
   if (l1GtPfAlgo.isValid()) {
     const L1GtPrescaleFactors* m_l1GtPfAlgo = l1GtPfAlgo.product();

--- a/DQM/L1TMonitor/src/L1TCSCTF.cc
+++ b/DQM/L1TMonitor/src/L1TCSCTF.cc
@@ -27,7 +27,8 @@ L1TCSCTF::L1TCSCTF(const ParameterSet& ps)
       lctProducer(ps.getParameter<InputTag>("lctProducer")),
       trackProducer(ps.getParameter<InputTag>("trackProducer")),
       statusProducer(ps.getParameter<InputTag>("statusProducer")),
-      mbProducer(ps.getParameter<InputTag>("mbProducer")) {
+      mbProducer(ps.getParameter<InputTag>("mbProducer")),
+      l1muTscalesToken_(esConsumes()) {
   // verbosity switch
   verbose_ = ps.getUntrackedParameter<bool>("verbose", false);
 
@@ -653,12 +654,9 @@ void L1TCSCTF::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const&, edm::
 void L1TCSCTF::analyze(const Event& e, const EventSetup& c) {
   if (c.get<L1MuTriggerScalesRcd>().cacheIdentifier() != m_scalesCacheID ||
       c.get<L1MuTriggerPtScaleRcd>().cacheIdentifier() != m_ptScaleCacheID) {
-    edm::ESHandle<L1MuTriggerScales> scales;
-    c.get<L1MuTriggerScalesRcd>().get(scales);
-    ts = scales.product();
-    edm::ESHandle<L1MuTriggerPtScale> ptscales;
-    c.get<L1MuTriggerPtScaleRcd>().get(ptscales);
-    tpts = ptscales.product();
+    ts = &c.getData(l1muTscalesToken_);
+    tpts = &c.getData(ptscalesToken_);
+
     m_scalesCacheID = c.get<L1MuTriggerScalesRcd>().cacheIdentifier();
     m_ptScaleCacheID = c.get<L1MuTriggerPtScaleRcd>().cacheIdentifier();
 
@@ -930,8 +928,8 @@ void L1TCSCTF::analyze(const Event& e, const EventSetup& c) {
   }
 
   if (lctProducer.label() != "null") {
-    edm::ESHandle<CSCGeometry> pDD;
-    c.get<MuonGeometryRecord>().get(pDD);
+    //edm::ESHandle<CSCGeometry> pDD;
+    //c.get<MuonGeometryRecord>().get(pDD);
 
     edm::Handle<CSCCorrelatedLCTDigiCollection> corrlcts;
     e.getByToken(corrlctsToken_, corrlcts);

--- a/DQM/L1TMonitor/src/L1TCSCTF.cc
+++ b/DQM/L1TMonitor/src/L1TCSCTF.cc
@@ -28,7 +28,8 @@ L1TCSCTF::L1TCSCTF(const ParameterSet& ps)
       trackProducer(ps.getParameter<InputTag>("trackProducer")),
       statusProducer(ps.getParameter<InputTag>("statusProducer")),
       mbProducer(ps.getParameter<InputTag>("mbProducer")),
-      l1muTscalesToken_(esConsumes()) {
+      l1muTscalesToken_(esConsumes()),
+      ptscalesToken_(esConsumes()) {
   // verbosity switch
   verbose_ = ps.getUntrackedParameter<bool>("verbose", false);
 

--- a/DQM/L1TMonitor/src/L1TGMT.cc
+++ b/DQM/L1TMonitor/src/L1TGMT.cc
@@ -29,6 +29,8 @@ L1TGMT::L1TGMT(const ParameterSet& ps)
       trsrc_old_(0) {
   if (verbose_)
     cout << "L1TGMT: constructor...." << endl;
+  l1muTrigscaleToken_ = esConsumes<edm::Transition::BeginRun>();
+  l1TrigptscaleToken_ = esConsumes<edm::Transition::BeginRun>();
 }
 
 L1TGMT::~L1TGMT() {}
@@ -239,13 +241,8 @@ double L1TGMT::phiconv_(float phi) {
 void L1TGMT::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const&, edm::EventSetup const& c) {
   std::string subs[5] = {"DTTF", "RPCb", "CSCTF", "RPCf", "GMT"};
 
-  edm::ESHandle<L1MuTriggerScales> trigscales_h;
-  c.get<L1MuTriggerScalesRcd>().get(trigscales_h);
-  const L1MuTriggerScales* scales = trigscales_h.product();
-
-  edm::ESHandle<L1MuTriggerPtScale> trigptscale_h;
-  c.get<L1MuTriggerPtScaleRcd>().get(trigptscale_h);
-  const L1MuTriggerPtScale* scalept = trigptscale_h.product();
+  const L1MuTriggerScales* scales = &c.getData(l1muTrigscaleToken_);
+  const L1MuTriggerPtScale* scalept = &c.getData(l1TrigptscaleToken_);
 
   ibooker.setCurrentFolder("L1T/L1TGMT");
 

--- a/DQM/L1TMonitor/src/L1TGT.cc
+++ b/DQM/L1TMonitor/src/L1TGT.cc
@@ -27,6 +27,7 @@ L1TGT::L1TGT(const edm::ParameterSet& ps)
       preGps_(0ULL),
       preOrb_(0ULL) {
   m_histFolder = ps.getUntrackedParameter<std::string>("HistFolder", "L1T/L1TGT");
+  l1gtTrigmenuToken_ = esConsumes<edm::Transition::BeginRun>();
 }
 
 L1TGT::~L1TGT() {
@@ -274,10 +275,10 @@ void L1TGT::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const&, edm::Eve
 
   //--------book AlgoBits/TechBits vs Bx Histogram-----------
 
-  edm::ESHandle<L1GtTriggerMenu> menuRcd;
-  evSetup.get<L1GtTriggerMenuRcd>().get(menuRcd);
-
-  const L1GtTriggerMenu* menu = menuRcd.product();
+  //edm::ESHandle<L1GtTriggerMenu> menuRcd;
+  //evSetup.get<L1GtTriggerMenuRcd>().get(menuRcd);
+  //menuRcd.product();
+  const L1GtTriggerMenu* menu = &evSetup.getData(l1gtTrigmenuToken_);
 
   h_L1AlgoBX1 = ibooker.book2D("h_L1AlgoBX1", "L1 Algo Trigger BX (algo bit 0 to 31)", 32, -0.5, 31.5, 5, -2.5, 2.5);
   h_L1AlgoBX2 = ibooker.book2D("h_L1AlgoBX2", "L1 Algo Trigger BX (algo bit 32 to 63)", 32, 31.5, 63.5, 5, -2.5, 2.5);

--- a/DQM/L1TMonitor/src/L1TRPCTPG.cc
+++ b/DQM/L1TMonitor/src/L1TRPCTPG.cc
@@ -30,6 +30,7 @@ L1TRPCTPG::L1TRPCTPG(const ParameterSet& ps)
   if (disable) {
     outputFile_ = "";
   }
+  rpcgeomToken_ = esConsumes();
 }
 
 L1TRPCTPG::~L1TRPCTPG() {}
@@ -64,8 +65,7 @@ void L1TRPCTPG::analyze(const Event& e, const EventSetup& c) {
     cout << "L1TRPCTPG: analyze...." << endl;
 
   /// RPC Geometry
-  edm::ESHandle<RPCGeometry> rpcGeo;
-  c.get<MuonGeometryRecord>().get(rpcGeo);
+  const auto& rpcGeo = c.getHandle(rpcgeomToken_);
   if (!rpcGeo.isValid()) {
     edm::LogInfo("DataNotFound") << "can't find RPCGeometry" << endl;
     return;

--- a/DQM/L1TMonitor/src/L1TdeRCT.cc
+++ b/DQM/L1TMonitor/src/L1TdeRCT.cc
@@ -2091,7 +2091,7 @@ void L1TdeRCT::readFEDVector(MonitorElement* histogram, const edm::EventSetup& e
   // adding fed mask into channel mask
   //edm::ESHandle<RunInfo> sum;
   //es.get<RunInfoRcd>().get(sum);
-  const auto& sum = isLumitransition ? es.getHandle(runInfolumiToken_) :  es.getHandle(runInfoToken_);
+  const auto& sum = isLumitransition ? es.getHandle(runInfolumiToken_) : es.getHandle(runInfoToken_);
   const RunInfo* summary = sum.product();
 
   std::vector<int> caloFeds;  // pare down the feds to the intresting ones

--- a/DQM/L1TMonitor/src/L1TdeRCT.cc
+++ b/DQM/L1TMonitor/src/L1TdeRCT.cc
@@ -85,6 +85,8 @@ L1TdeRCT::L1TdeRCT(const ParameterSet& ps)
       ecalTPGData_(consumes<EcalTrigPrimDigiCollection>(ps.getParameter<InputTag>("ecalTPGData"))),
       hcalTPGData_(consumes<HcalTrigPrimDigiCollection>(ps.getParameter<InputTag>("hcalTPGData"))),
       gtDigisLabel_(consumes<L1GlobalTriggerReadoutRecord>(ps.getParameter<InputTag>("gtDigisLabel"))),
+      runInfoToken_(esConsumes<edm::Transition::BeginRun>()),
+      runInfolumiToken_(esConsumes<edm::Transition::BeginLuminosityBlock>()),
       gtEGAlgoName_(ps.getParameter<std::string>("gtEGAlgoName")),
       doubleThreshold_(ps.getParameter<int>("doubleThreshold")),
       filterTriggerType_(ps.getParameter<int>("filterTriggerType")),
@@ -2076,7 +2078,7 @@ void L1TdeRCT::bookHistograms(DQMStore::IBooker& ibooker, const edm::Run& run, c
   notrigCount = 0;
   trigCount = 0;
 
-  readFEDVector(fedVectorMonitorRUN_, es);
+  readFEDVector(fedVectorMonitorRUN_, es, false);
 }
 
 std::shared_ptr<l1tderct::Empty> L1TdeRCT::globalBeginLuminosityBlock(const edm::LuminosityBlock& ls,
@@ -2085,10 +2087,11 @@ std::shared_ptr<l1tderct::Empty> L1TdeRCT::globalBeginLuminosityBlock(const edm:
   return std::shared_ptr<l1tderct::Empty>();
 }
 
-void L1TdeRCT::readFEDVector(MonitorElement* histogram, const edm::EventSetup& es) const {
+void L1TdeRCT::readFEDVector(MonitorElement* histogram, const edm::EventSetup& es, const bool isLumitransition) const {
   // adding fed mask into channel mask
-  edm::ESHandle<RunInfo> sum;
-  es.get<RunInfoRcd>().get(sum);
+  //edm::ESHandle<RunInfo> sum;
+  //es.get<RunInfoRcd>().get(sum);
+  const auto& sum = isLumitransition ? es.getHandle(runInfolumiToken_) :  es.getHandle(runInfoToken_);
   const RunInfo* summary = sum.product();
 
   std::vector<int> caloFeds;  // pare down the feds to the intresting ones

--- a/DQMOffline/CalibCalo/src/DQMSourcePi0.cc
+++ b/DQMOffline/CalibCalo/src/DQMSourcePi0.cc
@@ -53,6 +53,8 @@ DQMSourcePi0::DQMSourcePi0(const edm::ParameterSet &ps) : eventCounter_(0) {
       consumes<EcalRecHitCollection>(ps.getUntrackedParameter<edm::InputTag>("AlCaStreamEEpi0Tag"));
   productMonitoredEEeta_ =
       consumes<EcalRecHitCollection>(ps.getUntrackedParameter<edm::InputTag>("AlCaStreamEEetaTag"));
+  caloTopoToken_ = esConsumes();
+  caloGeomToken_ = esConsumes();
 
   isMonEBpi0_ = ps.getUntrackedParameter<bool>("isMonEBpi0", false);
   isMonEBeta_ = ps.getUntrackedParameter<bool>("isMonEBeta", false);
@@ -307,8 +309,7 @@ void DQMSourcePi0::analyze(const Event &iEvent, const EventSetup &iSetup) {
     return;
   eventCounter_++;
 
-  edm::ESHandle<CaloTopology> theCaloTopology;
-  iSetup.get<CaloTopologyRecord>().get(theCaloTopology);
+  auto const& theCaloTopology = iSetup.getHandle(caloTopoToken_);
 
   std::vector<EcalRecHit> seeds;
   seeds.clear();
@@ -335,8 +336,9 @@ void DQMSourcePi0::analyze(const Event &iEvent, const EventSetup &iSetup) {
 
   // Initialize the Position Calc
 
-  edm::ESHandle<CaloGeometry> geoHandle;
-  iSetup.get<CaloGeometryRecord>().get(geoHandle);
+  //edm::ESHandle<CaloGeometry> geoHandle;
+  //iSetup.get<CaloGeometryRecord>().get(geoHandle);
+  const auto& geoHandle = iSetup.getHandle(caloGeomToken_);
   const CaloSubdetectorGeometry *geometry_p = geoHandle->getSubdetectorGeometry(DetId::Ecal, EcalBarrel);
   const CaloSubdetectorGeometry *geometryEE_p = geoHandle->getSubdetectorGeometry(DetId::Ecal, EcalEndcap);
   const CaloSubdetectorGeometry *geometryES_p = geoHandle->getSubdetectorGeometry(DetId::Ecal, EcalPreshower);

--- a/DQMOffline/CalibCalo/src/DQMSourcePi0.cc
+++ b/DQMOffline/CalibCalo/src/DQMSourcePi0.cc
@@ -309,7 +309,7 @@ void DQMSourcePi0::analyze(const Event &iEvent, const EventSetup &iSetup) {
     return;
   eventCounter_++;
 
-  auto const& theCaloTopology = iSetup.getHandle(caloTopoToken_);
+  auto const &theCaloTopology = iSetup.getHandle(caloTopoToken_);
 
   std::vector<EcalRecHit> seeds;
   seeds.clear();
@@ -338,7 +338,7 @@ void DQMSourcePi0::analyze(const Event &iEvent, const EventSetup &iSetup) {
 
   //edm::ESHandle<CaloGeometry> geoHandle;
   //iSetup.get<CaloGeometryRecord>().get(geoHandle);
-  const auto& geoHandle = iSetup.getHandle(caloGeomToken_);
+  const auto &geoHandle = iSetup.getHandle(caloGeomToken_);
   const CaloSubdetectorGeometry *geometry_p = geoHandle->getSubdetectorGeometry(DetId::Ecal, EcalBarrel);
   const CaloSubdetectorGeometry *geometryEE_p = geoHandle->getSubdetectorGeometry(DetId::Ecal, EcalEndcap);
   const CaloSubdetectorGeometry *geometryES_p = geoHandle->getSubdetectorGeometry(DetId::Ecal, EcalPreshower);

--- a/DQMOffline/CalibCalo/src/DQMSourcePi0.h
+++ b/DQMOffline/CalibCalo/src/DQMSourcePi0.h
@@ -207,6 +207,9 @@ private:
   edm::EDGetTokenT<EcalRecHitCollection> productMonitoredEEpi0_;
   edm::EDGetTokenT<EcalRecHitCollection> productMonitoredEEeta_;
 
+  edm::ESGetToken<CaloTopology, CaloTopologyRecord> caloTopoToken_;
+  edm::ESGetToken<CaloGeometry, CaloGeometryRecord> caloGeomToken_;
+
   int gammaCandEtaSize_;
   int gammaCandPhiSize_;
 

--- a/DQMOffline/L1Trigger/interface/L1TTauOffline.h
+++ b/DQMOffline/L1Trigger/interface/L1TTauOffline.h
@@ -130,6 +130,7 @@ private:
   // variables from config file
   edm::EDGetTokenT<reco::PFTauCollection> theTauCollection_;
   edm::EDGetTokenT<reco::TauDiscriminatorContainer> AntiMuInputTag_;
+  edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> mFieldToken_;
   std::string AntiMuWP_;
   int AntiMuWPIndex_;
   edm::EDGetTokenT<reco::TauDiscriminatorContainer> AntiEleInputTag_;

--- a/DQMOffline/L1Trigger/src/L1TTauOffline.cc
+++ b/DQMOffline/L1Trigger/src/L1TTauOffline.cc
@@ -111,6 +111,7 @@ L1TTauOffline::L1TTauOffline(const edm::ParameterSet& ps)
       h_efficiencyNonIsoTauET_EB_EE_total_() {
   edm::LogInfo("L1TTauOffline") << "Constructor "
                                 << "L1TTauOffline::L1TTauOffline " << std::endl;
+  mFieldToken_ = esConsumes();
 }
 
 //
@@ -236,7 +237,8 @@ void L1TTauOffline::analyze(edm::Event const& e, edm::EventSetup const& eSetup) 
     return;
   }
 
-  eSetup.get<IdealMagneticFieldRecord>().get(m_BField);
+  m_BField = eSetup.getHandle(mFieldToken_);
+
   const reco::Vertex primaryVertex = getPrimaryVertex(vertex, beamSpot);
 
   getTightMuons(muons, mets, primaryVertex, trigEvent);

--- a/DQMOffline/Trigger/interface/EgHLTOffHelper.h
+++ b/DQMOffline/Trigger/interface/EgHLTOffHelper.h
@@ -79,11 +79,10 @@ namespace egHLT {
     edm::EDGetTokenT<edm::TriggerResults> trigResultsToken;
     edm::EDGetTokenT<reco::VertexCollection> vertexToken;
 
-    edm::ESGetToken<CaloGeometry,CaloGeometryRecord> caloGeomToken_;
-    edm::ESGetToken<CaloTopology,CaloTopologyRecord> caloTopoToken_;
-    edm::ESGetToken<MagneticField,IdealMagneticFieldRecord> magFieldToken_;
-    edm::ESGetToken<EcalSeverityLevelAlgo,EcalSeverityLevelAlgoRcd> ecalSeverityToken_;
-    
+    edm::ESGetToken<CaloGeometry, CaloGeometryRecord> caloGeomToken_;
+    edm::ESGetToken<CaloTopology, CaloTopologyRecord> caloTopoToken_;
+    edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> magFieldToken_;
+    edm::ESGetToken<EcalSeverityLevelAlgo, EcalSeverityLevelAlgoRcd> ecalSeverityToken_;
 
     edm::ESHandle<CaloGeometry> caloGeom_;
     edm::ESHandle<CaloTopology> caloTopology_;

--- a/DQMOffline/Trigger/interface/EgHLTOffHelper.h
+++ b/DQMOffline/Trigger/interface/EgHLTOffHelper.h
@@ -52,6 +52,7 @@
 class EgammaHLTTrackIsolation;
 class HLTConfigProvider;
 class EcalSeverityLevelAlgo;
+class EcalSeverityLevelAlgoRcd;
 
 namespace egHLT {
 
@@ -77,6 +78,12 @@ namespace egHLT {
     edm::EDGetTokenT<CaloTowerCollection> caloTowersToken;
     edm::EDGetTokenT<edm::TriggerResults> trigResultsToken;
     edm::EDGetTokenT<reco::VertexCollection> vertexToken;
+
+    edm::ESGetToken<CaloGeometry,CaloGeometryRecord> caloGeomToken_;
+    edm::ESGetToken<CaloTopology,CaloTopologyRecord> caloTopoToken_;
+    edm::ESGetToken<MagneticField,IdealMagneticFieldRecord> magFieldToken_;
+    edm::ESGetToken<EcalSeverityLevelAlgo,EcalSeverityLevelAlgoRcd> ecalSeverityToken_;
+    
 
     edm::ESHandle<CaloGeometry> caloGeom_;
     edm::ESHandle<CaloTopology> caloTopology_;

--- a/DQMOffline/Trigger/src/EgHLTOffHelper.cc
+++ b/DQMOffline/Trigger/src/EgHLTOffHelper.cc
@@ -4,6 +4,7 @@
 #include "DataFormats/DetId/interface/DetId.h"
 #include "DataFormats/JetReco/interface/CaloJetCollection.h"
 #include "FWCore/Common/interface/TriggerNames.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 
 #include "RecoEcal/EgammaCoreTools/interface/EcalClusterTools.h"
 
@@ -46,6 +47,11 @@ void OffHelper::setup(const edm::ParameterSet& conf, edm::ConsumesCollector&& iC
   caloTowersToken = iC.consumes<CaloTowerCollection>(conf.getParameter<edm::InputTag>("CaloTowers"));
   trigResultsToken = iC.consumes<edm::TriggerResults>(conf.getParameter<edm::InputTag>("TrigResults"));
   vertexToken = iC.consumes<reco::VertexCollection>(conf.getParameter<edm::InputTag>("VertexCollection"));
+
+  caloGeomToken_ = iC.esConsumes();
+  caloTopoToken_ = iC.esConsumes();
+  magFieldToken_ = iC.esConsumes();
+  ecalSeverityToken_ = iC.esConsumes();
 
   eleCuts_.setup(conf.getParameter<edm::ParameterSet>("eleCuts"));
   eleLooseCuts_.setup(conf.getParameter<edm::ParameterSet>("eleLooseCuts"));
@@ -169,14 +175,14 @@ int OffHelper::makeOffEvt(const edm::Event& edmEvent,
 
 int OffHelper::getHandles(const edm::Event& event, const edm::EventSetup& setup) {
   try {
-    setup.get<CaloGeometryRecord>().get(caloGeom_);
-    setup.get<CaloTopologyRecord>().get(caloTopology_);
-    //setup.get<EcalSeverityLevelAlgoRcd>().get(ecalSeverityLevel_);
+    caloGeom_ = setup.getHandle(caloGeomToken_);
+    caloTopology_ = setup.getHandle(caloTopoToken_);
+    //ecalSeverityLevel_ = setup.getHandle(ecalSeverityToken_);
   } catch (cms::Exception& iException) {
     return errCodes::Geom;
   }
   try {
-    setup.get<IdealMagneticFieldRecord>().get(magField_);
+    magField_ = setup.getHandle(magFieldToken_);
   } catch (cms::Exception& iException) {
     return errCodes::MagField;
   }


### PR DESCRIPTION
#### PR description:
Part of #31061. This PR addresses some of the DQM modules mentioned in the static analyzer report of CMSSW_12_0_X_2021-06-20-2300.
#### PR validation:
Compiles and local static analyzer checks do not show Event setup get warnings.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:
NA
