### PR TITLE
Include new PPS geometry tag and Hcal MC tag in GTs

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -26,13 +26,13 @@ autoCond = {
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2
     'run2_mc_pa'                   : '113X_mcRun2_pA_v4',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'                    : '120X_dataRun2_v1',
+    'run2_data'                    : '120X_dataRun2_v2',
     # GlobalTag for Run2 data 2018B relvals only: HEM-15-16 fail
-    'run2_data_HEfail'             : '113X_dataRun2_HEfail_v6',
+    'run2_data_HEfail'             : '120X_dataRun2_HEfail_v1',
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
-    'run2_data_relval'             : '120X_dataRun2_relval_v1',
+    'run2_data_relval'             : '120X_dataRun2_relval_v2',
     # GlobalTag for Run2 HI data
-    'run2_data_promptlike_hi'      : '113X_dataRun2_PromptLike_HI_v6',
+    'run2_data_promptlike_hi'      : '120X_dataRun2_PromptLike_HI_v1',
     # GlobalTag for Run3 HLT: it points to the online GT
     'run3_hlt'                     : '113X_dataRun3_HLT_v2',
     # GlobalTag with fixed snapshot time for Run2 HLT RelVals: customizations to run with fixed L1 Menu
@@ -66,17 +66,17 @@ autoCond = {
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in PEAK mode
     'phase1_2018_cosmics_peak'     : '113X_upgrade2018cosmics_realistic_peak_v5',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2021
-    'phase1_2021_design'           : '120X_mcRun3_2021_design_v1', # GT containing design conditions for Phase1 2021
+    'phase1_2021_design'           : '120X_mcRun3_2021_design_v2', # GT containing design conditions for Phase1 2021
     # GlobalTag for MC production with realistic conditions for Phase1 2021
-    'phase1_2021_realistic'        : '120X_mcRun3_2021_realistic_v1', # GT containing realistic conditions for Phase1 2021
+    'phase1_2021_realistic'        : '120X_mcRun3_2021_realistic_v2', # GT containing realistic conditions for Phase1 2021
     # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2021,  Strip tracker in DECO mode
-    'phase1_2021_cosmics'          : '120X_mcRun3_2021cosmics_realistic_deco_v1',
+    'phase1_2021_cosmics'          : '120X_mcRun3_2021cosmics_realistic_deco_v2',
     # GlobalTag for MC production with realistic conditions for Phase1 2021 detector for Heavy Ion
-    'phase1_2021_realistic_hi'     : '120X_mcRun3_2021_realistic_HI_v1',
+    'phase1_2021_realistic_hi'     : '120X_mcRun3_2021_realistic_HI_v2',
     # GlobalTag for MC production with realistic conditions for Phase1 2023
-    'phase1_2023_realistic'        : '120X_mcRun3_2023_realistic_v1', # GT containing realistic conditions for Phase1 2023
+    'phase1_2023_realistic'        : '120X_mcRun3_2023_realistic_v2', # GT containing realistic conditions for Phase1 2023
     # GlobalTag for MC production with realistic conditions for Phase1 2024
-    'phase1_2024_realistic'        : '120X_mcRun3_2024_realistic_v1', # GT containing realistic conditions for Phase1 2024
+    'phase1_2024_realistic'        : '120X_mcRun3_2024_realistic_v2', # GT containing realistic conditions for Phase1 2024
     # GlobalTag for MC production with realistic conditions for Phase2
     'phase2_realistic'             : '113X_mcRun4_realistic_v7'
 }


### PR DESCRIPTION
#### PR description:

This PR is to update GTs with two new tags:

PPS new geometry tag (in Run-2 data and Run-3 MC GTs), PPSRECO_Geometry_120YV1, as requested in https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/4412.html and presented at https://indico.cern.ch/event/1048769/#5-pps-reco-geometry

Hcal new MC tag (in mcRun3 GTs), HcalRespCorrs_2021_v2.0_mc, as requested in https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/4414.html

The GT differences are shown below.

**Offline data**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/120X_dataRun2_v1/120X_dataRun2_v2

**Offline data (HEM failure)**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/113X_dataRun2_HEfail_v6/120X_dataRun2_HEfail_v1

**Offline data relval**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/120X_dataRun2_relval_v1/120X_dataRun2_relval_v2

**Prompt-like HI data**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/113X_dataRun2_PromptLike_HI_v6/120X_dataRun2_PromptLike_HI_v1

**2021 design**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/120X_mcRun3_2021_design_v1/120X_mcRun3_2021_design_v2

**2021 realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/120X_mcRun3_2021_realistic_v1/120X_mcRun3_2021_realistic_v2

**2021 cosmics**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/120X_mcRun3_2021cosmics_realistic_deco_v1/120X_mcRun3_2021cosmics_realistic_deco_v2

**2021 heavy ion**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/120X_mcRun3_2021_realistic_HI_v1/120X_mcRun3_2021_realistic_HI_v2

**2023 realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/120X_mcRun3_2023_realistic_v1/120X_mcRun3_2023_realistic_v2

**2024 realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/120X_mcRun3_2024_realistic_v1/120X_mcRun3_2024_realistic_v2



#### PR validation:

runTheMatrix.py -j8 -l limited,138.1,138.2,11925 --ibeos

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

It is not a backport and no backport is expected.
