### PR TITLE
[DD4hep] Enable Run 3 DD4hep workflows to read geometry from DB

### DIFF
--- a/Configuration/Applications/python/ConfigBuilder.py
+++ b/Configuration/Applications/python/ConfigBuilder.py
@@ -763,7 +763,9 @@ class ConfigBuilder(object):
                 if ('SIM' in self.stepMap or 'reSIM' in self.stepMap) and not self._options.fast:
                     self.loadAndRemember(self.SimGeometryCFF)
                     if self.geometryDBLabel:
-                        self.executeAndRemember('process.XMLFromDBSource.label = cms.string("%s")'%(self.geometryDBLabel))
+                        self.executeAndRemember('if hasattr(process, "XMLFromDBSource"): process.XMLFromDBSource.label="%s"'%(self.geometryDBLabel))
+                        self.executeAndRemember('if hasattr(process, "DDDetectorESProducerFromDB"): process.DDDetectorESProducerFromDB.label="%s"'%(self.geometryDBLabel))
+
         except ImportError:
             print("Geometry option",self._options.geometry,"unknown.")
             raise

--- a/Configuration/Geometry/python/GeometryDD4hepSimDB_cff.py
+++ b/Configuration/Geometry/python/GeometryDD4hepSimDB_cff.py
@@ -1,0 +1,26 @@
+import FWCore.ParameterSet.Config as cms
+
+#
+# Geometry master configuration
+#
+# Ideal geometry, needed for simulation
+
+DDSpecParRegistryESProducer = cms.ESProducer("DDSpecParRegistryESProducer",
+                                             appendToDataLabel = cms.string('')
+)
+
+DDVectorRegistryESProducer = cms.ESProducer("DDVectorRegistryESProducer",
+                                            appendToDataLabel = cms.string(''))
+
+DDCompactViewESProducer = cms.ESProducer("DDCompactViewESProducer",
+                                         appendToDataLabel = cms.string('')
+)
+
+from DetectorDescription.DDCMS.DDDetectorESProducerFromDB_cfi import *
+
+from Geometry.TrackerNumberingBuilder.trackerNumberingGeometryDB_cfi import *
+
+from Geometry.EcalCommonData.ecalSimulationParameters_cff   import *
+from Geometry.HcalCommonData.hcalSimDBConstants_cff         import *
+
+from Geometry.MuonNumbering.muonGeometryConstants_cff       import *

--- a/Configuration/Geometry/python/GeometryDD4hepSimDB_cff.py
+++ b/Configuration/Geometry/python/GeometryDD4hepSimDB_cff.py
@@ -24,3 +24,4 @@ from Geometry.EcalCommonData.ecalSimulationParameters_cff   import *
 from Geometry.HcalCommonData.hcalSimDBConstants_cff         import *
 
 from Geometry.MuonNumbering.muonGeometryConstants_cff       import *
+from Geometry.MuonNumbering.muonOffsetESProducer_cff        import *

--- a/Configuration/Geometry/python/GeometryDDDSimDB_cff.py
+++ b/Configuration/Geometry/python/GeometryDDDSimDB_cff.py
@@ -1,0 +1,15 @@
+import FWCore.ParameterSet.Config as cms
+
+#
+# Geometry master configuration
+#
+# Ideal geometry, needed for simulation
+from GeometryReaders.XMLIdealGeometryESSource.cmsGeometryDB_cff import *
+from Geometry.MuonNumbering.muonNumberingInitialization_cfi import *
+from Geometry.TrackerNumberingBuilder.trackerNumberingGeometryDB_cfi import *
+from Geometry.EcalCommonData.ecalSimulationParameters_cff   import *
+from Geometry.HcalCommonData.hcalSimulationParameters_cfi   import *
+from Geometry.HcalCommonData.hcalDDDSimConstants_cfi        import *
+from Geometry.HcalCommonData.hcalSimulationConstants_cfi    import *
+from Geometry.HcalCommonData.caloSimulationParameters_cff   import *
+from Geometry.MuonNumbering.muonGeometryConstants_cff       import *

--- a/Configuration/Geometry/python/GeometryRecoDB_cff.py
+++ b/Configuration/Geometry/python/GeometryRecoDB_cff.py
@@ -17,8 +17,7 @@ from Geometry.CaloEventSetup.AlignedCaloGeometryDBReader_cfi import *
 from Geometry.CaloEventSetup.EcalTrigTowerConstituents_cfi import *
 from Geometry.EcalMapping.EcalMapping_cfi import *
 from Geometry.EcalMapping.EcalMappingRecord_cfi import *
-from Geometry.HcalCommonData.hcalDDDSimConstants_cfi import *
-from Geometry.HcalCommonData.hcalDDDRecConstants_cfi import *
+from Geometry.HcalCommonData.hcalDBConstants_cff import *
 from Geometry.HcalEventSetup.hcalTopologyIdeal_cfi import *
 
 #  Alignment

--- a/Configuration/Geometry/python/GeometrySimDB_cff.py
+++ b/Configuration/Geometry/python/GeometrySimDB_cff.py
@@ -4,12 +4,14 @@ import FWCore.ParameterSet.Config as cms
 # Geometry master configuration
 #
 # Ideal geometry, needed for simulation
-from GeometryReaders.XMLIdealGeometryESSource.cmsGeometryDB_cff import *
-from Geometry.MuonNumbering.muonNumberingInitialization_cfi import *
-from Geometry.TrackerNumberingBuilder.trackerNumberingGeometryDB_cfi import *
-from Geometry.EcalCommonData.ecalSimulationParameters_cff   import *
-from Geometry.HcalCommonData.hcalSimulationParameters_cfi   import *
-from Geometry.HcalCommonData.hcalDDDSimConstants_cfi        import *
-from Geometry.HcalCommonData.hcalSimulationConstants_cfi    import *
-from Geometry.HcalCommonData.caloSimulationParameters_cff   import *
-from Geometry.MuonNumbering.muonGeometryConstants_cff       import *
+
+from Configuration.ProcessModifiers.dd4hep_cff import dd4hep
+
+def _loadSimGeomDBDDD(process) :
+    process.load('Configuration.Geometry.GeometryDDDSimDB_cff')
+
+def _loadSimGeomDBDD4hep(process) :
+    process.load('Configuration.Geometry.GeometryDD4hepSimDB_cff')
+
+modifyGeometryConfiguration = (~dd4hep).makeProcessModifier(_loadSimGeomDBDDD)
+modifyGeometryConfiguration_dd4hep = dd4hep.makeProcessModifier(_loadSimGeomDBDD4hep)

--- a/DetectorDescription/DDCMS/plugins/DDDetectorESProducer.cc
+++ b/DetectorDescription/DDCMS/plugins/DDDetectorESProducer.cc
@@ -79,8 +79,7 @@ DDDetectorESProducer::DDDetectorESProducer(const ParameterSet& iConfig)
     }
     findingRecord<IdealMagneticFieldRecord>();
   } else {
-    auto c = setWhatProduced(
-        this, &DDDetectorESProducer::produceGeom, edm::es::Label(iConfig.getParameter<std::string>("@module_label")));
+    auto c = setWhatProduced(this, &DDDetectorESProducer::produceGeom);
     if (fromDB_) {
       geomToken_ = c.consumes(edm::ESInputTag("", label_));
     }

--- a/DetectorDescription/DDCMS/src/ES_DDDetector.cc
+++ b/DetectorDescription/DDCMS/src/ES_DDDetector.cc
@@ -8,7 +8,7 @@
 
 using namespace cms;
 
-TYPELOOKUP_DATA_REG(DDCompactView);
+TYPELOOKUP_DATA_REG(cms::DDCompactView);
 TYPELOOKUP_DATA_REG(DDDetector);
 TYPELOOKUP_DATA_REG(dd4hep::SpecParRegistry);
 TYPELOOKUP_DATA_REG(DDVectorRegistry);

--- a/Geometry/HcalCommonData/python/hcalSimDBConstants_cff.py
+++ b/Geometry/HcalCommonData/python/hcalSimDBConstants_cff.py
@@ -1,0 +1,8 @@
+import FWCore.ParameterSet.Config as cms
+
+from Geometry.HcalCommonData.hcalSimulationParameters_cff   import *
+from Geometry.HcalCommonData.hcalSimulationConstants_cfi    import *
+from Geometry.HcalCommonData.hcalDBConstants_cff            import *
+from Geometry.HcalCommonData.caloSimulationParameters_cff   import *
+from Geometry.HcalCommonData.hcalDDDSimConstants_cfi        import *
+from Geometry.HcalCommonData.hcalDDDRecConstants_cfi        import *


### PR DESCRIPTION
Up to now, DD4hep workflows have read geometry from XML files. This PR provides the capability for a DD4hep workflow to be configured to read geometry from the DB. Note that the DD4hep ideal geometry description DB payload is not completely finished (see PR #34111), but this PR was tested with a preliminary version of the payload to see that DD4hep simulation could read and process it.

Further steps are still needed:
1. PR 34111 needs to be completed (it is very close).
2. The DD4hep Run 3 ideal geometry description DB payload needs to be uploaded to the DB.
3. A DD4hep workflow that reads geometry from the DB needs to be defined.
4. That new DD4hep workflow needs to be added to the PR and IB tests.

For non-DD4hep workflows, changes were kept to a minimum to ensure that existing workflows would not be altered. The new file `GeometryDDDSimDB_cff.py` to be used by existing DDD workflows is identical to the original `GeometrySimDB_cff.py` that was used by these workflows previously.

The `hcalSimDBConstants_cff.py` file in this PR is from recently merged PR #34267.

This PR was tested with unit tests, workflow 11634.0, PR tests, and modified workflow 11634.911 that read from the DB.