### PR TITLE
RFC: [DQM] First prototype of nanoDQMIO with single LS granularity

### DIFF
--- a/DQMServices/Core/interface/DQMStore.h
+++ b/DQMServices/Core/interface/DQMStore.h
@@ -715,6 +715,7 @@ namespace dqm {
 
       // Book MEs by lumi by default whenever possible.
       bool doSaveByLumi_;
+      std::vector<std::string> MEsToSave_; //just if perLS is ON
 
       // if non-empty, debugTrackME calls will log some information whenever a
       // ME path contains this string.

--- a/DQMServices/Core/interface/DQMStore.h
+++ b/DQMServices/Core/interface/DQMStore.h
@@ -715,7 +715,7 @@ namespace dqm {
 
       // Book MEs by lumi by default whenever possible.
       bool doSaveByLumi_;
-      std::vector<std::string> MEsToSave_; //just if perLS is ON
+      std::vector<std::string> MEsToSave_;  //just if perLS is ON
 
       // if non-empty, debugTrackME calls will log some information whenever a
       // ME path contains this string.

--- a/DQMServices/Core/python/DQMStore_cfi.py
+++ b/DQMServices/Core/python/DQMStore_cfi.py
@@ -4,8 +4,9 @@ DQMStore = cms.Service("DQMStore",
     verbose = cms.untracked.int32(0),
     # similar to LSBasedMode but for offline. Explicitly sets LumiFLag on all
     # MEs/modules that allow it (canSaveByLumi)
-    saveByLumi = cms.untracked.bool(False),
-    trackME = cms.untracked.string(""),
+    saveByLumi = cms.untracked.bool(True),
+    MEsToSave = cms.untracked.vstring('Muons/MuonRecoAnalyzer/','Muons/MuonIdDQM/GlobalMuons/hDT1Pullx'),
+    trackME = cms.untracked.string("Muons/MuonRecoAnalyzer/Res_TkSta_theta"),
 
     # UNUSED: historical HLT configs expect this option to be present, so it
     # remains here, even though the DQMStore does not use it any more.

--- a/DQMServices/Core/python/DQMStore_cfi.py
+++ b/DQMServices/Core/python/DQMStore_cfi.py
@@ -5,10 +5,10 @@ DQMStore = cms.Service("DQMStore",
     verbose = cms.untracked.int32(0),
     # similar to LSBasedMode but for offline. Explicitly sets LumiFLag on all
     # MEs/modules that allow it (canSaveByLumi)
-    saveByLumi = cms.untracked.bool(True),
+    saveByLumi = cms.untracked.bool(False),
     #Following list has no effect if saveByLumi is False
     MEsToSave = cms.untracked.vstring(nanoDQMIO_perLSoutput.MEsToSave),  
-    trackME = cms.untracked.string("Muons/MuonRecoAnalyzer/Res_TkSta_theta"),
+    trackME = cms.untracked.string(""),
 
     # UNUSED: historical HLT configs expect this option to be present, so it
     # remains here, even though the DQMStore does not use it any more.

--- a/DQMServices/Core/python/DQMStore_cfi.py
+++ b/DQMServices/Core/python/DQMStore_cfi.py
@@ -1,11 +1,13 @@
 import FWCore.ParameterSet.Config as cms
+from DQMServices.Core.nanoDQMIO_perLSoutput_cff import *
 
 DQMStore = cms.Service("DQMStore",
     verbose = cms.untracked.int32(0),
     # similar to LSBasedMode but for offline. Explicitly sets LumiFLag on all
     # MEs/modules that allow it (canSaveByLumi)
     saveByLumi = cms.untracked.bool(True),
-    MEsToSave = cms.untracked.vstring('Muons/MuonRecoAnalyzer/','Muons/MuonIdDQM/GlobalMuons/hDT1Pullx'),
+    #Following list has no effect if saveByLumi is False
+    MEsToSave = cms.untracked.vstring(nanoDQMIO_perLSoutput.MEsToSave),  
     trackME = cms.untracked.string("Muons/MuonRecoAnalyzer/Res_TkSta_theta"),
 
     # UNUSED: historical HLT configs expect this option to be present, so it

--- a/DQMServices/Core/python/nanoDQMIO_perLSoutput_cff.py
+++ b/DQMServices/Core/python/nanoDQMIO_perLSoutput_cff.py
@@ -1,0 +1,26 @@
+import FWCore.ParameterSet.Config as cms
+
+#Example version list of MEs to save with singel Luminosity Granularity
+#in the nanoDQMIO reduced version of DQMIO data Tier
+#It needs process.DQMStore.saveByLumi = cms.untracked.bool(True)
+#to make effect in the MEs saved by DQMStore
+#DQMIO with per Lumisection data, are a special kind of DQM files 
+#containing almost the full set of DQM Monitor Elements (MEs) saved 
+#with single lumisection time granularity. 
+#Saying "almost" we refer to the fact that only Monitor Elements 
+#produced in DQM Step1 are saved, 
+#while those produced in the Harvesting step are not, 
+#even if they could be obtained with some ad-hoc harvesting on Step1 data
+#Hence, DQM Step2 (HARVESTING DQM) should not follow when saveByLumi is True
+#since most DQM Harvesting modules expect perRun output
+#https://twiki.cern.ch/twiki/bin/view/CMS/PerLsDQMIO
+
+nanoDQMIO_perLSoutput = cms.PSet(
+      MEsToSave = cms.untracked.vstring(*( #Using tuple to avoid python limit of 255 arguments
+                                           #as suggested in:
+                #https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuidePoolInputSources#Example_3_More_than_255_input_fi
+              'Muons/MuonRecoAnalyzer/',               #Folder and its subfolders
+              'Muons/MuonIdDQM/GlobalMuons/hDT1Pullx'  #particular ME
+              )
+      )
+)

--- a/DQMServices/Core/src/DQMStore.cc
+++ b/DQMServices/Core/src/DQMStore.cc
@@ -650,7 +650,7 @@ namespace dqm::implementation {
              ipath != store_->MEsToSave_.end();
              ++ipath) {
           std::string name = (*it)->getFullname();
-          if (name.find(*ipath->) != std::string::npos) {
+          if (name.find(*ipath) != std::string::npos) {
             saveIt = true;
             //std::cout<<name<<" compared to"<<ipath->data()<<std::endl;
             break;

--- a/DQMServices/Core/src/DQMStore.cc
+++ b/DQMServices/Core/src/DQMStore.cc
@@ -645,22 +645,25 @@ namespace dqm::implementation {
 
     // rfind can be used as a prefix match.
     while (it != meset.end() && (*it)->getFullname().rfind(path_str, 0) == 0) {
-      if(store_->doSaveByLumi_ && not store_->MEsToSave_.empty()){
-        for (std::vector<std::string>::const_iterator ipath = store_->MEsToSave_.begin(); 
-                                           ipath !=  store_->MEsToSave_.end(); ++ipath) {
+      if (store_->doSaveByLumi_ && not store_->MEsToSave_.empty()) {
+        for (std::vector<std::string>::const_iterator ipath = store_->MEsToSave_.begin();
+             ipath != store_->MEsToSave_.end();
+             ++ipath) {
           std::string name = (*it)->getFullname();
-          if(name.find(ipath->data()) != std::string::npos){ 
-             saveIt = true; 
-             //std::cout<<name<<" compared to"<<ipath->data()<<std::endl;
-             break;}
+          if (name.find(*ipath->) != std::string::npos) {
+            saveIt = true;
+            //std::cout<<name<<" compared to"<<ipath->data()<<std::endl;
+            break;
+          }
           saveIt = false;
         }
-      }      
-   
+      }
+
       store_->debugTrackME("getAllContents (run/lumi match)", nullptr, *it);
       if (saveIt) {
-           out.push_back(*it);
-           if (store_->doSaveByLumi_) store_->debugTrackME("getAllContents (run/lumi saved)", nullptr, *it);
+        out.push_back(*it);
+        if (store_->doSaveByLumi_)
+          store_->debugTrackME("getAllContents (run/lumi saved)", nullptr, *it);
       }
       ++it;
     }
@@ -737,7 +740,7 @@ namespace dqm::implementation {
     verbose_ = pset.getUntrackedParameter<int>("verbose", 0);
     assertLegacySafe_ = pset.getUntrackedParameter<bool>("assertLegacySafe", true);
     doSaveByLumi_ = pset.getUntrackedParameter<bool>("saveByLumi", false);
-    MEsToSave_ = pset.getUntrackedParameter<std::vector<std::string>>("MEsToSave",std::vector<std::string>());
+    MEsToSave_ = pset.getUntrackedParameter<std::vector<std::string>>("MEsToSave", std::vector<std::string>());
     trackME_ = pset.getUntrackedParameter<std::string>("trackME", "");
 
     // Set lumi and run for legacy booking.

--- a/DQMServices/Core/src/DQMStore.cc
+++ b/DQMServices/Core/src/DQMStore.cc
@@ -639,10 +639,29 @@ namespace dqm::implementation {
     auto path_str = path.getFullname();
     auto const& meset = store_->globalMEs_[edm::LuminosityBlockID(runNumber, lumi)];
     auto it = meset.lower_bound(path);
+
+    // decide if the ME should be save din DQMIO based on the list provided
+    bool saveIt = true;
+
     // rfind can be used as a prefix match.
     while (it != meset.end() && (*it)->getFullname().rfind(path_str, 0) == 0) {
+      if(store_->doSaveByLumi_ && not store_->MEsToSave_.empty()){
+        for (std::vector<std::string>::const_iterator ipath = store_->MEsToSave_.begin(); 
+                                           ipath !=  store_->MEsToSave_.end(); ++ipath) {
+          std::string name = (*it)->getFullname();
+          if(name.find(ipath->data()) != std::string::npos){ 
+             saveIt = true; 
+             //std::cout<<name<<" compared to"<<ipath->data()<<std::endl;
+             break;}
+          saveIt = false;
+        }
+      }      
+   
       store_->debugTrackME("getAllContents (run/lumi match)", nullptr, *it);
-      out.push_back(*it);
+      if (saveIt) {
+           out.push_back(*it);
+           if (store_->doSaveByLumi_) store_->debugTrackME("getAllContents (run/lumi saved)", nullptr, *it);
+      }
       ++it;
     }
     return out;
@@ -718,6 +737,7 @@ namespace dqm::implementation {
     verbose_ = pset.getUntrackedParameter<int>("verbose", 0);
     assertLegacySafe_ = pset.getUntrackedParameter<bool>("assertLegacySafe", true);
     doSaveByLumi_ = pset.getUntrackedParameter<bool>("saveByLumi", false);
+    MEsToSave_ = pset.getUntrackedParameter<std::vector<std::string>>("MEsToSave",std::vector<std::string>());
     trackME_ = pset.getUntrackedParameter<std::string>("trackME", "");
 
     // Set lumi and run for legacy booking.


### PR DESCRIPTION
#### PR description:

This PR is a first prototype to filter out a dedicated list of MEs in DQMStore in order to save them with single LS granularity, in order to have a perLS data Tier called nanoDQMIO with reduced output size, and which will run only on the selected PDs used for DC.

This will provide a reduced data Tier with perLS information (nanoDQMIO) in contraposition to the usual DQMIO data Tier which contains perRun information for every single ME created at DQM step and which is used for harvesting in order to produce DQM root legacy files uploaded to the DQM GUI for visual inspection.

The new nanoDQMIO data format will enhance future ML4DC/DQM studies as well as any study of trends vs LS for subsystems. The new DQM GUI has been designed to host also DQM root legacy files with single LS granularity, which in the end would need to be produced from this new nanoDQMIO datasets.

More info in the evolving twiki: https://twiki.cern.ch/twiki/bin/view/CMS/PerLsDQMIO#nanoDQMIO_data_Tier

#### PR validation:

Currently being tested with all the runTheMatrix flavours and in discussion with O&C