### PR TITLE
add protection against missing cast to Phase2TrackerRecHit1D in Phase2OTValidateTrackingRecHit

### DIFF
--- a/Validation/SiTrackerPhase2V/plugins/Phase2OTValidateTrackingRecHit.cc
+++ b/Validation/SiTrackerPhase2V/plugins/Phase2OTValidateTrackingRecHit.cc
@@ -158,6 +158,11 @@ void Phase2OTValidateTrackingRecHit::fillOTHistos(const edm::Event& iEvent,
       }
       //GetSimHits
       const Phase2TrackerRecHit1D* rechit = dynamic_cast<const Phase2TrackerRecHit1D*>(hit);
+      if (!rechit) {
+        edm::LogError("Phase2OTValidateTrackingRecHit")
+            << "Cannot cast tracking rechit to Phase2TrackerRecHit1D!" << std::endl;
+        continue;
+      }
       const std::vector<SimHitIdpr>& matchedId = associateRecHit.associateHitId(*rechit);
       const PSimHit* simhitClosest = nullptr;
       LocalPoint lp = rechit->localPosition();


### PR DESCRIPTION
resolves https://github.com/cms-sw/cmssw/issues/34177

#### PR description:

Trivial: add additional protection against issue explained in https://github.com/cms-sw/cmssw/issues/34177#issue-924857416

#### PR validation:

Tested in `CMSSW_12_0_X_2021-06-20-230` in which wf 23234.9 used to fail before  #34175 was integrated, at the affected workflow run, logging the error message.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Not a backport, no backport needed.
