### PR TITLE
Add a Pythia8 gun for displaced particles (flat in Pt and Dxy) [backport of #33832 to 10_6_X]

### DIFF
--- a/GeneratorInterface/Pythia8Interface/plugins/Py8PtAndDxyGun.cc
+++ b/GeneratorInterface/Pythia8Interface/plugins/Py8PtAndDxyGun.cc
@@ -1,0 +1,183 @@
+#include <memory>
+
+#include "GeneratorInterface/Core/interface/GeneratorFilter.h"
+#include "GeneratorInterface/ExternalDecays/interface/ExternalDecayDriver.h"
+
+#include "GeneratorInterface/Pythia8Interface/interface/Py8GunBase.h"
+
+namespace gen {
+
+  class Py8PtAndDxyGun : public Py8GunBase {
+  public:
+    Py8PtAndDxyGun(edm::ParameterSet const&);
+    ~Py8PtAndDxyGun() override {}
+
+    bool generatePartonsAndHadronize() override;
+    const char* classname() const override;
+
+  private:
+    // PtAndDxyGun particle(s) characteristics
+    double fMinEta;
+    double fMaxEta;
+    double fMinPt;
+    double fMaxPt;
+    bool fAddAntiParticle;
+    double dxyMin_;
+    double dxyMax_;
+    double lxyMax_;
+    double lzMax_;
+    double ConeRadius_;
+    double ConeH_;
+    double DistanceToAPEX_;
+  };
+
+  // implementation
+  //
+  Py8PtAndDxyGun::Py8PtAndDxyGun(edm::ParameterSet const& ps) : Py8GunBase(ps) {
+    // ParameterSet defpset ;
+    edm::ParameterSet pgun_params = ps.getParameter<edm::ParameterSet>("PGunParameters");  // , defpset ) ;
+    fMinEta = pgun_params.getParameter<double>("MinEta");                                  // ,-2.2);
+    fMaxEta = pgun_params.getParameter<double>("MaxEta");                                  // , 2.2);
+    fMinPt = pgun_params.getParameter<double>("MinPt");                                    // ,  0.);
+    fMaxPt = pgun_params.getParameter<double>("MaxPt");                                    // ,  0.);
+    fAddAntiParticle = pgun_params.getParameter<bool>("AddAntiParticle");                  //, false) ;
+    dxyMin_ = pgun_params.getParameter<double>("dxyMin");
+    dxyMax_ = pgun_params.getParameter<double>("dxyMax");
+    lxyMax_ = pgun_params.getParameter<double>("LxyMax");
+    lzMax_ = pgun_params.getParameter<double>("LzMax");
+    ConeRadius_ = pgun_params.getParameter<double>("ConeRadius");
+    ConeH_ = pgun_params.getParameter<double>("ConeH");
+    DistanceToAPEX_ = pgun_params.getParameter<double>("DistanceToAPEX");
+  }
+
+  bool Py8PtAndDxyGun::generatePartonsAndHadronize() {
+    fMasterGen->event.reset();
+
+    for (size_t i = 0; i < fPartIDs.size(); i++) {
+      int particleID = fPartIDs[i];  // this is PDG - need to convert to Py8 ???
+
+      double phi = 0;
+      double dxy = 0;
+      double pt = 0;
+      double eta = 0;
+      double px = 0;
+      double py = 0;
+      double pz = 0;
+      double mass = 0;
+      double ee = 0;
+      double vx = 0;
+      double vy = 0;
+      double vz = 0;
+      double lxy = 0;
+
+      bool passLoop = false;
+      while (not passLoop) {
+        bool passLxy = false;
+        bool passLz = false;
+
+        phi = (fMaxPhi - fMinPhi) * randomEngine().flat() + fMinPhi;
+        dxy = (dxyMax_ - dxyMin_) * randomEngine().flat() + dxyMin_;
+        float dxysign = randomEngine().flat() - 0.5;
+        if (dxysign < 0)
+          dxy = -dxy;
+
+        pt = (fMaxPt - fMinPt) * randomEngine().flat() + fMinPt;
+        px = pt * cos(phi);
+        py = pt * sin(phi);
+
+        for (int i = 0; i < 10000; i++) {
+          vx = 2 * lxyMax_ * randomEngine().flat() - lxyMax_;
+          vy = (pt * dxy + vx * py) / px;
+          lxy = sqrt(vx * vx + vy * vy);
+          if (lxy < std::abs(lxyMax_) and (vx * px + vy * py) > 0) {
+            passLxy = true;
+            break;
+          }
+        }
+
+        eta = (fMaxEta - fMinEta) * randomEngine().flat() + fMinEta;
+        double the = 2. * atan(exp(-eta));
+
+        mass = (fMasterGen->particleData).m0(particleID);
+
+        double pp = pt / sin(the);  // sqrt( ee*ee - mass*mass );
+        ee = sqrt(pp * pp + mass * mass);
+
+        pz = pp * cos(the);
+
+        float ConeTheta = ConeRadius_ / ConeH_;
+        for (int j = 0; j < 100; j++) {
+          vz = lzMax_ * randomEngine().flat();  // this is abs(vz)
+          float v0 = vz - DistanceToAPEX_;
+          if (v0 <= 0 or lxy * lxy / (ConeTheta * ConeTheta) > v0 * v0) {
+            passLz = true;
+            break;
+          }
+        }
+        if (pz < 0)
+          vz = -vz;
+        passLoop = (passLxy and passLz);
+
+        if (passLoop)
+          break;
+      }
+
+      float time = sqrt(vx * vx + vy * vy + vz * vz);
+
+      if (!((fMasterGen->particleData).isParticle(particleID))) {
+        particleID = std::abs(particleID);
+      }
+      if (1 <= std::abs(particleID) && std::abs(particleID) <= 6)  // quarks
+        (fMasterGen->event).append(particleID, 23, 101, 0, px, py, pz, ee, mass);
+      else if (std::abs(particleID) == 21)  // gluons
+        (fMasterGen->event).append(21, 23, 101, 102, px, py, pz, ee, mass);
+      // other
+      else {
+        (fMasterGen->event).append(particleID, 1, 0, 0, px, py, pz, ee, mass);
+        int eventSize = (fMasterGen->event).size() - 1;
+        // -log(flat) = exponential distribution
+        double tauTmp = -(fMasterGen->event)[eventSize].tau0() * log(randomEngine().flat());
+        (fMasterGen->event)[eventSize].tau(tauTmp);
+      }
+      (fMasterGen->event).back().vProd(vx, vy, vz, time);
+
+      // Here also need to add anti-particle (if any)
+      // otherwise just add a 2nd particle of the same type
+      // (for example, gamma)
+      //
+      if (fAddAntiParticle) {
+        if (1 <= std::abs(particleID) && std::abs(particleID) <= 6) {  // quarks
+          (fMasterGen->event).append(-particleID, 23, 0, 101, -px, -py, -pz, ee, mass);
+        } else if (std::abs(particleID) == 21) {  // gluons
+          (fMasterGen->event).append(21, 23, 102, 101, -px, -py, -pz, ee, mass);
+        } else {
+          if ((fMasterGen->particleData).isParticle(-particleID)) {
+            (fMasterGen->event).append(-particleID, 1, 0, 0, -px, -py, -pz, ee, mass);
+          } else {
+            (fMasterGen->event).append(particleID, 1, 0, 0, -px, -py, -pz, ee, mass);
+          }
+          int eventSize = (fMasterGen->event).size() - 1;
+          // -log(flat) = exponential distribution
+          double tauTmp = -(fMasterGen->event)[eventSize].tau0() * log(randomEngine().flat());
+          (fMasterGen->event)[eventSize].tau(tauTmp);
+        }
+        (fMasterGen->event).back().vProd(-vx, -vy, -vz, time);
+      }
+    }
+
+    if (!fMasterGen->next())
+      return false;
+    evtGenDecay();
+
+    event() = std::make_unique<HepMC::GenEvent>();
+    return toHepMC.fill_next_event(fMasterGen->event, event().get());
+  }
+
+  const char* Py8PtAndDxyGun::classname() const { return "Py8PtAndDxyGun"; }
+
+  typedef edm::GeneratorFilter<gen::Py8PtAndDxyGun, gen::ExternalDecayDriver> Pythia8PtAndDxyGun;
+
+}  // namespace gen
+
+using gen::Pythia8PtAndDxyGun;
+DEFINE_FWK_MODULE(Pythia8PtAndDxyGun);

--- a/GeneratorInterface/Pythia8Interface/plugins/Py8PtAndDxyGun.cc
+++ b/GeneratorInterface/Pythia8Interface/plugins/Py8PtAndDxyGun.cc
@@ -22,13 +22,13 @@ namespace gen {
     double fMinPt;
     double fMaxPt;
     bool fAddAntiParticle;
-    double dxyMin_;
-    double dxyMax_;
-    double lxyMax_;
-    double lzMax_;
-    double ConeRadius_;
-    double ConeH_;
-    double DistanceToAPEX_;
+    double fDxyMin;
+    double fDxyMax;
+    double fLxyMax;
+    double fLzMax;
+    double fConeRadius;
+    double fConeH;
+    double fDistanceToAPEX;
   };
 
   // implementation
@@ -41,13 +41,13 @@ namespace gen {
     fMinPt = pgun_params.getParameter<double>("MinPt");                                    // ,  0.);
     fMaxPt = pgun_params.getParameter<double>("MaxPt");                                    // ,  0.);
     fAddAntiParticle = pgun_params.getParameter<bool>("AddAntiParticle");                  //, false) ;
-    dxyMin_ = pgun_params.getParameter<double>("dxyMin");
-    dxyMax_ = pgun_params.getParameter<double>("dxyMax");
-    lxyMax_ = pgun_params.getParameter<double>("LxyMax");
-    lzMax_ = pgun_params.getParameter<double>("LzMax");
-    ConeRadius_ = pgun_params.getParameter<double>("ConeRadius");
-    ConeH_ = pgun_params.getParameter<double>("ConeH");
-    DistanceToAPEX_ = pgun_params.getParameter<double>("DistanceToAPEX");
+    fDxyMin = pgun_params.getParameter<double>("dxyMin");
+    fDxyMax = pgun_params.getParameter<double>("dxyMax");
+    fLxyMax = pgun_params.getParameter<double>("LxyMax");
+    fLzMax = pgun_params.getParameter<double>("LzMax");
+    fConeRadius = pgun_params.getParameter<double>("ConeRadius");
+    fConeH = pgun_params.getParameter<double>("ConeH");
+    fDistanceToAPEX = pgun_params.getParameter<double>("DistanceToAPEX");
   }
 
   bool Py8PtAndDxyGun::generatePartonsAndHadronize() {
@@ -71,12 +71,12 @@ namespace gen {
       double lxy = 0;
 
       bool passLoop = false;
-      while (not passLoop) {
+      while (!passLoop) {
         bool passLxy = false;
         bool passLz = false;
 
         phi = (fMaxPhi - fMinPhi) * randomEngine().flat() + fMinPhi;
-        dxy = (dxyMax_ - dxyMin_) * randomEngine().flat() + dxyMin_;
+        dxy = (fDxyMax - fDxyMin) * randomEngine().flat() + fDxyMin;
         float dxysign = randomEngine().flat() - 0.5;
         if (dxysign < 0)
           dxy = -dxy;
@@ -86,37 +86,37 @@ namespace gen {
         py = pt * sin(phi);
 
         for (int i = 0; i < 10000; i++) {
-          vx = 2 * lxyMax_ * randomEngine().flat() - lxyMax_;
+          vx = 2 * fLxyMax * randomEngine().flat() - fLxyMax;
           vy = (pt * dxy + vx * py) / px;
           lxy = sqrt(vx * vx + vy * vy);
-          if (lxy < std::abs(lxyMax_) and (vx * px + vy * py) > 0) {
+          if (lxy < std::abs(fLxyMax) && (vx * px + vy * py) > 0) {
             passLxy = true;
             break;
           }
         }
 
         eta = (fMaxEta - fMinEta) * randomEngine().flat() + fMinEta;
-        double the = 2. * atan(exp(-eta));
+        double theta = 2. * atan(exp(-eta));
 
         mass = (fMasterGen->particleData).m0(particleID);
 
-        double pp = pt / sin(the);  // sqrt( ee*ee - mass*mass );
+        double pp = pt / sin(theta);  // sqrt( ee*ee - mass*mass );
         ee = sqrt(pp * pp + mass * mass);
 
-        pz = pp * cos(the);
+        pz = pp * cos(theta);
 
-        float ConeTheta = ConeRadius_ / ConeH_;
+        float coneTheta = fConeRadius / fConeH;
         for (int j = 0; j < 100; j++) {
-          vz = lzMax_ * randomEngine().flat();  // this is abs(vz)
-          float v0 = vz - DistanceToAPEX_;
-          if (v0 <= 0 or lxy * lxy / (ConeTheta * ConeTheta) > v0 * v0) {
+          vz = fLzMax * randomEngine().flat();  // this is abs(vz)
+          float v0 = vz - fDistanceToAPEX;
+          if (v0 <= 0 || lxy * lxy / (coneTheta * coneTheta) > v0 * v0) {
             passLz = true;
             break;
           }
         }
         if (pz < 0)
           vz = -vz;
-        passLoop = (passLxy and passLz);
+        passLoop = (passLxy && passLz);
 
         if (passLoop)
           break;

--- a/GeneratorInterface/Pythia8Interface/test/Py8PtAndDxyGun_displacedTaus_cfg.py
+++ b/GeneratorInterface/Pythia8Interface/test/Py8PtAndDxyGun_displacedTaus_cfg.py
@@ -1,0 +1,74 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("TEST")
+
+process.load("FWCore.Framework.test.cmsExceptionsFatal_cff")
+process.load("SimGeneral.HepPDTESSource.pythiapdt_cfi")
+
+process.source = cms.Source("EmptySource")
+
+process.generator = cms.EDFilter("Pythia8PtAndDxyGun",
+
+    maxEventsToPrint = cms.untracked.int32(1),
+    pythiaPylistVerbosity = cms.untracked.int32(1),
+    pythiaHepMCVerbosity = cms.untracked.bool(True),
+
+    PGunParameters = cms.PSet(
+        ParticleID = cms.vint32(15),
+        AddAntiParticle = cms.bool(True),
+        MinPt = cms.double(15.0),
+        MaxPt = cms.double(300.0),
+        MinEta = cms.double(-2.5),
+        MaxEta = cms.double(2.5),
+        MinPhi = cms.double(-3.14159265359),
+        MaxPhi = cms.double(3.14159265359),
+        LxyMax = cms.double(850.0),#make sure most tau generated within 3 outermost tracker layers, Gauss distribution
+        LzMax = cms.double(2100.0),#make sure most taus generated within 3 outemost tracker layers, Gauss distribution
+        ConeRadius = cms.double(1000.0),
+        ConeH = cms.double(3000.0),
+        DistanceToAPEX = cms.double(850.0),
+        dxyMin = cms.double(0.0),
+        dxyMax = cms.double(500.0)
+    ),
+
+    Verbosity = cms.untracked.int32(0), ## set to 1 (or greater)  for printouts
+    psethack = cms.string('displaced taus'),
+    firstRun = cms.untracked.uint32(1),
+
+    PythiaParameters = cms.PSet(
+        parameterSets = cms.vstring()  
+    )
+)
+
+process.load("FWCore.MessageLogger.MessageLogger_cfi")
+process.MessageLogger = cms.Service("MessageLogger",
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        default = cms.untracked.PSet(
+            limit = cms.untracked.int32(2)
+        ),
+        enable = cms.untracked.bool(True)
+    )
+)
+
+process.RandomNumberGeneratorService = cms.Service("RandomNumberGeneratorService",
+    generator = cms.PSet(
+        initialSeed = cms.untracked.uint32(123456789),
+        engineName = cms.untracked.string('HepJamesRandom')
+    )
+)
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(10)
+)
+
+process.GENoutput = cms.OutputModule("PoolOutputModule",
+    fileName = cms.untracked.string('Py8PtAndDxyGun_displacedTaus.root')
+)
+
+process.p = cms.Path(process.generator)
+process.outpath = cms.EndPath(process.GENoutput)
+
+process.schedule = cms.Schedule(process.p, process.outpath)

--- a/GeneratorInterface/Pythia8Interface/test/Py8PtAndDxyGun_displacedTaus_cfg.py
+++ b/GeneratorInterface/Pythia8Interface/test/Py8PtAndDxyGun_displacedTaus_cfg.py
@@ -42,15 +42,12 @@ process.generator = cms.EDFilter("Pythia8PtAndDxyGun",
 
 process.load("FWCore.MessageLogger.MessageLogger_cfi")
 process.MessageLogger = cms.Service("MessageLogger",
-    cerr = cms.untracked.PSet(
-        enable = cms.untracked.bool(False)
-    ),
     cout = cms.untracked.PSet(
         default = cms.untracked.PSet(
             limit = cms.untracked.int32(2)
-        ),
-        enable = cms.untracked.bool(True)
-    )
+        )
+    ),
+    destinations = cms.untracked.vstring('cout')
 )
 
 process.RandomNumberGeneratorService = cms.Service("RandomNumberGeneratorService",


### PR DESCRIPTION
#### PR description:

As title says: the PR adds a Pythia8 gun for displaced particles which are generated flat in Pt and Dxy in ranges provided by a user. This new gun enables generation of displaced unstable particles which is not possible with already existing [FlatRandomPtAndDxyGunProducer](https://github.com/cms-sw/cmssw/blob/master/IOMC/ParticleGuns/src/FlatRandomPtAndDxyGunProducer.cc).

Technically, the PR migrates an algorithm present in the [FlatRandomPtAndDxyGunProducer](https://github.com/cms-sw/cmssw/blob/master/IOMC/ParticleGuns/src/FlatRandomPtAndDxyGunProducer.cc) to a new module based on a generic Py8 gun ([Py8GunBase](https://github.com/cms-sw/cmssw/blob/master/GeneratorInterface/Pythia8Interface/interface/Py8GunBase.h)).

Backport of #33832

#### PR validation:

It was validated with a custom workflow that the newly added module behaves as expected. Test configuration (GeneratorInterface/Pythia8Interface/test/Py8PtAndDxyGun_displacedTaus_cfg.py) is part of this PR.
The change does not affect any existing workflows by construction (a new "generator source" added).

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Backport of #33832 for a MC UL sample production.