### PR TITLE
Fix needed due to catch2 update

### DIFF
--- a/DQM/TrackerRemapper/test/test_catch2_SiStripTkMaps.cc
+++ b/DQM/TrackerRemapper/test/test_catch2_SiStripTkMaps.cc
@@ -15,7 +15,7 @@ TEST_CASE("SiStripTkMaps testing", "[SiStripTkMaps]") {
     theMap.bookMap("testing SiStripTkMaps", "counts");
     SiStripDetInfoFileReader reader_ = SiStripDetInfoFileReader(edm::FileInPath(k_geo).fullPath());
     const std::map<uint32_t, SiStripDetInfoFileReader::DetInfo>& DetInfos = reader_.getAllData();
-    int count = 0;
+    unsigned int count = 0;
     for (const auto& it : DetInfos) {
       count++;
       theMap.fill(it.first, count);


### PR DESCRIPTION
This is needed to avoid the build error due to `catch2` external update.

[a] https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/slc7_amd64_gcc900/CMSSW_12_0_X_2021-06-23-1600/DQM/TrackerRemapper
```
DQM/TrackerRemapper/test/test_catch2_SiStripTkMaps.cc:29:30: error: comparison of integer expressions of different signedness: 'std::vector<unsigned int>::size_type' {aka 'long unsigned int'} and 'int' [-Werror=sign-compare]
    29 |     REQUIRE(filledIds.size() == count);
      |             ~~~~~~~~~~~~~~~~~^~~~~~~~
```