### PR TITLE
Moving condition DB tools to python3

### DIFF
--- a/CondCore/CondDB/plugins/BuildFile.xml
+++ b/CondCore/CondDB/plugins/BuildFile.xml
@@ -5,8 +5,9 @@
 
 <library file="CondDBPyBind11Wrappers.cc" name="CondDBPyBind11Interface">
   <use name="CondCore/CondDB"/>
+  <flags EDM_PLUGIN="0"/>
   <use name="py3-pybind11"/>
-  <use name="python"/>
+  <use name="python3"/>
 </library>                                                                                                                                                                    
 
 <library file="XMLAuthenticationService.cc" name="CondCoreCondDBXMLAuthenticationService">

--- a/CondCore/CondDB/plugins/CondDBPyBind11Wrappers.cc
+++ b/CondCore/CondDB/plugins/CondDBPyBind11Wrappers.cc
@@ -29,7 +29,7 @@ namespace cond {
 
 namespace py = pybind11;
 
-PYBIND11_MODULE(pluginCondDBPyBind11Interface, m) {
+PYBIND11_MODULE(libCondDBPyBind11Interface, m) {
   m.def("get_credentials_from_db", &cond::getDbCredentials, "Get db credentials for a connection string");
   m.attr("default_role") = pybind11::int_(int(cond::auth::DEFAULT_ROLE));
   m.attr("reader_role") = pybind11::int_(int(cond::auth::READER_ROLE));

--- a/CondCore/Utilities/python/conddblib.py
+++ b/CondCore/Utilities/python/conddblib.py
@@ -571,7 +571,7 @@ def connect(url, authPath=None, verbose=0, as_admin=False):
                     else:
                         explicit_auth =True
                 else:
-                    import pluginCondDBPyBind11Interface as auth
+                    import libCondDBPyBind11Interface as auth
                     role_code = auth.reader_role
                     if url.username == dbwriter_user_name:
                         role_code = auth.writer_role

--- a/CondCore/Utilities/python/credentials.py
+++ b/CondCore/Utilities/python/credentials.py
@@ -57,7 +57,7 @@ def get_credentials_for_schema( service, schema, role, authPath=None ):
             raise Exception(msg)
         return params
     else:
-        import pluginCondDBPyBind11Interface as credential_db
+        import libCondDBPyBind11Interface as credential_db
         roles_map = { reader_role: credential_db.reader_role, writer_role: credential_db.writer_role, admin_role: credential_db.admin_role }
         connection_string = 'oracle://%s/%s'%(service.lower(),schema.upper())
         logging.debug('Looking up db credentials for %s in credential store' %connection_string )

--- a/CondCore/Utilities/python/o2olib.py
+++ b/CondCore/Utilities/python/o2olib.py
@@ -401,7 +401,7 @@ class O2ORunMgr(object):
             pipe = subprocess.Popen( command, shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT )
             out = ''
             for line in iter(pipe.stdout.readline, ''):
-                if args.verbose>=1:
+                if args.verbose is not None and args.verbose>=1:
                     sys.stdout.write(line)
                     sys.stdout.flush()
                 out += line

--- a/CondCore/Utilities/scripts/conddb
+++ b/CondCore/Utilities/scripts/conddb
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 '''CMS Conditions DB command-line tool.
 '''
 from __future__ import print_function

--- a/CondCore/Utilities/scripts/conddb_version_mgr.py
+++ b/CondCore/Utilities/scripts/conddb_version_mgr.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from __future__ import print_function
 import cx_Oracle
@@ -467,7 +467,7 @@ def main():
     parser_show_version.set_defaults(func=tool.show_tag_boost_version,accessType='r')
     args = parser.parse_args()
     tool.args = args
-    if args.verbose >=1:
+    if args.verbose is not None and args.verbose >=1:
         tool.logger.setLevel(logging.DEBUG)
         tool.connect()
         return args.func()

--- a/CondCore/Utilities/scripts/o2o
+++ b/CondCore/Utilities/scripts/o2o
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 '''
 '''

--- a/CondCore/Utilities/scripts/o2oRun.py
+++ b/CondCore/Utilities/scripts/o2oRun.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 '''
 '''
 


### PR DESCRIPTION
Moving to python3:
- conddb tools
- conddb_version_mgr
- o2o tools

Local integration tests are ok.  