### PR TITLE
fix allocation/deallocation mismatch issue in ASAN

### DIFF
--- a/PhysicsTools/MVAComputer/src/AtomicId.cc
+++ b/PhysicsTools/MVAComputer/src/AtomicId.cc
@@ -30,7 +30,7 @@ namespace {  // anonymous
 
 IdCache::~IdCache() {
   for (std::multiset<const char *, StringLess>::iterator iter = idSet.begin(); iter != idSet.end(); iter++)
-    stringAllocator.deallocate(const_cast<char *>(*iter), std::strlen(*iter)+1);
+    stringAllocator.deallocate(const_cast<char *>(*iter), std::strlen(*iter) + 1);
 }
 
 const char *IdCache::findOrInsert(const char *string) throw() {

--- a/PhysicsTools/MVAComputer/src/AtomicId.cc
+++ b/PhysicsTools/MVAComputer/src/AtomicId.cc
@@ -30,7 +30,7 @@ namespace {  // anonymous
 
 IdCache::~IdCache() {
   for (std::multiset<const char *, StringLess>::iterator iter = idSet.begin(); iter != idSet.end(); iter++)
-    stringAllocator.deallocate(const_cast<char *>(*iter), std::strlen(*iter));
+    stringAllocator.deallocate(const_cast<char *>(*iter), std::strlen(*iter)+1);
 }
 
 const char *IdCache::findOrInsert(const char *string) throw() {


### PR DESCRIPTION
We moved ASAN IBs to use GCC10 and got build error [a]. Looks like we are allocating `strlen()+1` ( https://github.com/cms-sw/cmssw/blob/master/PhysicsTools/MVAComputer/src/AtomicId.cc#L43 ) but deallocating `strlen()` only (https://github.com/cms-sw/cmssw/blob/master/PhysicsTools/MVAComputer/src/AtomicId.cc#L33 ). This PR proposes to use `strlen()+1` for deallocation too. 

Local tests with ASAN build shows no errors. 

[a] https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/slc7_amd64_gcc10/CMSSW_12_0_ASAN_X_2021-06-23-2300/RecoBTag/CTagging
```
==31351==ERROR: AddressSanitizer: new-delete-type-mismatch on 0x602000027ef0 in thread T0:
  object passed to delete has wrong type:
  size of the allocated type:   8 bytes;
  size of the deallocated type: 7 bytes.
    #0 0x2b0cc4a881f7 in operator delete(void*, unsigned long) ../../../../libsanitizer/asan/asan_new_delete.cpp:172
    #1 0x2b0ccf73d144 in (anonymous namespace)::IdCache::~IdCache() (CMSSW_12_0_ASAN_X_2021-06-23-2300/lib/slc7_amd64_gcc10/libPhysicsToolsMVAComputer.so+0x22144)
    #2 0x2b0cc7802d38 in __run_exit_handlers (/lib64/libc.so.6+0x39d38)
    #3 0x2b0cc7802d86 in exit (/lib64/libc.so.6+0x39d86)
    #4 0x2b0cc77eb55b in __libc_start_main (/lib64/libc.so.6+0x2255b)
    #5 0x40bb98  (CMSSW_12_0_ASAN_X_2021-06-23-2300/bin/slc7_amd64_gcc10/edmWriteConfigs+0x40bb98)
```