### PR TITLE
[ASAN] Fix duplicate definition of hjRandomEngine

### DIFF
--- a/GeneratorInterface/Hydjet2Interface/interface/Hydjet2Hadronizer.h
+++ b/GeneratorInterface/Hydjet2Interface/interface/Hydjet2Hadronizer.h
@@ -52,7 +52,7 @@ namespace CLHEP {
   class RandGauss;
 }  // namespace CLHEP
 
-CLHEP::HepRandomEngine* hjRandomEngine;
+extern CLHEP::HepRandomEngine* hjRandomEngine;
 
 namespace HepMC {
   class GenEvent;

--- a/GeneratorInterface/Hydjet2Interface/src/Hydjet2Hadronizer.cc
+++ b/GeneratorInterface/Hydjet2Interface/src/Hydjet2Hadronizer.cc
@@ -76,6 +76,8 @@
 
 #include "GeneratorInterface/Hydjet2Interface/interface/HYJET_COMMONS.h"
 
+CLHEP::HepRandomEngine* hjRandomEngine;
+
 extern "C" void hyevnt_();
 extern "C" void myini_();
 


### PR DESCRIPTION
This should fix the `One Defintion Rule` issue reported by ASAN IBs [a]

[a] https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/slc7_amd64_gcc10/CMSSW_12_0_ASAN_X_2021-06-23-2300/GeneratorInterface/Hydjet2Interface
```
==24804==ERROR: AddressSanitizer: odr-violation (0x2b372a4d58a0):
  [1] size=8 'hjRandomEngine' CMSSW_12_0_ASAN_X_2021-06-23-2300/src/GeneratorInterface/Hydjet2Interface/interface/Hydjet2Hadronizer.h:55:25
  [2] size=8 'hjRandomEngine' CMSSW_12_0_ASAN_X_2021-06-23-2300/src/GeneratorInterface/Hydjet2Interface/interface/RandArrayFunction.h:8:32
These globals were registered at these points:
  [1]:
    #0 0x2b37228d3f70 in __asan_register_globals ../../../../libsanitizer/asan/asan_globals.cpp:341
    #1 0x2b37226889c2 in _dl_init_internal (/lib64/ld-linux-x86-64.so.2+0xf9c2)
    #2 0x7fff51a1eed3  (<unknown module>)

  [2]:
    #0 0x2b37228d3f70 in __asan_register_globals ../../../../libsanitizer/asan/asan_globals.cpp:341
    #1 0x2b37226889c2 in _dl_init_internal (/lib64/ld-linux-x86-64.so.2+0xf9c2)
    #2 0x7fff51a1eed3  (<unknown module>)
```