### PR TITLE
updating hlt config retrieval tools to access to the dev database & dev converter

### DIFF
--- a/HLTrigger/Configuration/python/Tools/confdbOfflineConverter.py
+++ b/HLTrigger/Configuration/python/Tools/confdbOfflineConverter.py
@@ -33,9 +33,14 @@ class OfflineConverter:
     databases['v1']['adg']     = ( '-t', 'oracle', '-h', 'cmsr1-s.cern.ch',        '-d', 'cms_cond.cern.ch',      '-u', 'cms_hlt_gui_r',     '-s', 'ConvertMe!' )
     databases['v1']['orcoff']  = databases['v1']['adg']         # for backwards compatibility
     databases['v2'] = {}
-    databases['v2']['offline'] = ( '-t', 'oracle', '-h', 'cmsr1-s.cern.ch',        '-d', 'cms_cond.cern.ch',      '-u', 'cms_hlt_gdr_r',     '-s', 'convertMe!' )
-    databases['v2']['online']  = ( '-t', 'oracle', '-h', 'cmsonr1-s.cms',          '-d', 'cms_rcms.cern.ch',      '-u', 'cms_hlt_gdr_r',     '-s', 'convertMe!' )
-    databases['v2']['adg']     = ( '-t', 'oracle', '-h', 'cmsonr1-adg1-s.cern.ch', '-d', 'cms_orcon_adg.cern.ch', '-u', 'cms_hlt_gdr_r',     '-s', 'convertMe!' )
+    databases['v2']['offline'] = ( '-t', 'oracle', '-h', 'cmsr1-s.cern.ch',        '-d', 'cms_cond.cern.ch',      '-u', 'cms_hlt_gdr_r',     '-s', 'ConvertMe!' )
+    databases['v2']['online']  = ( '-t', 'oracle', '-h', 'cmsonr1-s.cms',          '-d', 'cms_rcms.cern.ch',      '-u', 'cms_hlt_gdr_r',     '-s', 'ConvertMe!' )
+    databases['v2']['adg']     = ( '-t', 'oracle', '-h', 'cmsonr1-adg1-s.cern.ch', '-d', 'cms_orcon_adg.cern.ch', '-u', 'cms_hlt_gdr_r',     '-s', 'ConvertMe!' )
+    databases['v2-dev'] = {}
+    databases['v2-dev']['offline'] = ( '-t', 'oracle', '-h', 'cmsr1-s.cern.ch',        '-d', 'cms_cond.cern.ch',      '-u', 'cms_hlt_gdr_r',     '-s', 'convertMe!' )
+    databases['v2-dev']['online']  = ( '-t', 'oracle', '-h', 'cmsonr1-s.cms',          '-d', 'cms_rcms.cern.ch',      '-u', 'cms_hlt_gdr_r',     '-s', 'convertMe!' )
+    databases['v2-dev']['adg']     = ( '-t', 'oracle', '-h', 'cmsonr1-adg1-s.cern.ch', '-d', 'cms_orcon_adg.cern.ch', '-u', 'cms_hlt_gdr_r',     '-s', 'convertMe!' )
+    databases['v2-dev']['dev']     = ( '-t', 'oracle', '-h', 'cmsr1-s.cern.ch',        '-d', 'cms_cond.cern.ch',      '-u', 'cms_hlt_gdrdev_r',  '-s', 'convertMe1!' )
 
 
     @staticmethod
@@ -210,9 +215,15 @@ def main():
         db      = 'offline'
         args.remove('--v2')
 
+    if '--v2-dev' in args:
+        version = 'v2-dev'
+        db      = 'dev'
+        args.remove('--v2-dev')
+
     _dbs = {}
     _dbs['v1'] = [ '--%s' % _db for _db in OfflineConverter.databases['v1'] ] + [ '--runNumber' ]
     _dbs['v2'] = [ '--%s' % _db for _db in OfflineConverter.databases['v2'] ] + [ '--runNumber' ]
+    _dbs['v2-dev'] = [ '--%s' % _db for _db in OfflineConverter.databases['v2-dev'] ] + [ '--runNumber' ]
     _dbargs = set(args) & set(sum(_dbs.values(), []))
 
     if _dbargs:

--- a/HLTrigger/Configuration/python/Tools/options.py
+++ b/HLTrigger/Configuration/python/Tools/options.py
@@ -46,8 +46,8 @@ class ConnectionL1TMenuXml(object):
 
 # type used to store a reference to an HLT configuration
 class ConnectionHLTMenu(object):
-  valid_versions  = 'v1', 'v2'
-  valid_databases = 'online', 'offline', 'adg'
+  valid_versions  = 'v1', 'v2', 'v2-dev'
+  valid_databases = 'online', 'offline', 'adg','dev'
   compatibility   = { 'hltdev': ('v2', 'offline'), 'orcoff': ('v2', 'adg') }
 
   def __init__(self, value):


### PR DESCRIPTION
#### PR description:

This PR upgrades the HLT menu retrieval tools to allow access to the hlt_gdrdev database and also access a dev version of the converter which actually downloads the menu.

example commands
```
hltGetConfiguration v2-dev/adg:/cdaq/cosmic/commissioning2021/MWGR4/Cosmics_GPUTest1_V2/V2  >& onlineMenu.py
hltGetConfiguration v2-dev/dev:/users/sharper/2021/MWGR4_V2/Cosmic_GPUTest_GPUEnabled/V12 >& offlineMenu.py
```

No change in any CMSSW workflow is expected. 

#### PR validation:

menus successfully downloaded using the above commands. 

