### PR TITLE
[Tracker Alignment] Add di-electron vertex validation

### DIFF
--- a/Alignment/OfflineValidation/interface/DiLeptonVertexHelpers.h
+++ b/Alignment/OfflineValidation/interface/DiLeptonVertexHelpers.h
@@ -8,6 +8,7 @@
 #include "TLorentzVector.h"
 #include "CommonTools/UtilAlgos/interface/TFileService.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 namespace DiLeptonHelp {
 
@@ -21,17 +22,17 @@ namespace DiLeptonHelp {
     unsigned int eventsAfterEta;
     unsigned int eventsAfterVtx;
     unsigned int eventsAfterDist;
-    
+
   public:
     void printCounts() {
-      std::cout << " Total Events: " << eventsTotal << "\n"
-		<< " After multiplicity: " << eventsAfterMult << "\n"
-		<< " After pT cut: " << eventsAfterPt << "\n"
-		<< " After eta cut: " << eventsAfterEta << "\n"
-		<< " After Vtx: " << eventsAfterVtx << "\n"
-		<< " After VtxDist: " << eventsAfterDist << std::endl;
+      edm::LogPrint("DileptonHelp::Counts") << " Total Events: " << eventsTotal << "\n"
+                                            << " After multiplicity: " << eventsAfterMult << "\n"
+                                            << " After pT cut: " << eventsAfterPt << "\n"
+                                            << " After eta cut: " << eventsAfterEta << "\n"
+                                            << " After Vtx: " << eventsAfterVtx << "\n"
+                                            << " After VtxDist: " << eventsAfterDist << std::endl;
     }
-    
+
     void zeroAll() {
       eventsTotal = 0;
       eventsAfterMult = 0;
@@ -42,97 +43,110 @@ namespace DiLeptonHelp {
     }
   };
 
+  enum flavour { MM = 0, EE = 1, UNDEF = -1 };
+
   //
   // Ancillary class for plotting
   //
   class PlotsVsKinematics {
   public:
-    PlotsVsKinematics() : m_name(""), m_title(""), m_ytitle(""), m_isBooked(false) {}
-    
+    PlotsVsKinematics(flavour FLAV) : m_name(""), m_title(""), m_ytitle(""), m_isBooked(false), m_flav(FLAV) {}
+
     //________________________________________________________________________________//
     // overloaded constructor
-    PlotsVsKinematics(const std::string& name, const std::string& tt, const std::string& ytt)
-      : m_name(name), m_title(tt), m_ytitle(ytt), m_isBooked(false) {}
-    
+    PlotsVsKinematics(flavour FLAV, const std::string& name, const std::string& tt, const std::string& ytt)
+        : m_name(name), m_title(tt), m_ytitle(ytt), m_isBooked(false), m_flav(FLAV) {
+      if (m_flav < 0) {
+        edm::LogError("PlotsVsKinematics") << "The initialization flavour is not correct!" << std::endl;
+      }
+    }
+
     ~PlotsVsKinematics() = default;
-    
+
     //________________________________________________________________________________//
     inline void bookFromPSet(const TFileDirectory& fs, const edm::ParameterSet& hpar) {
       std::string namePostfix;
       std::string titlePostfix;
       float xmin, xmax;
-      
-      for (const auto& xAx : axisChoices) {
-	switch (xAx) {
-        case xAxis::Z_PHI:
-          xmin = -M_PI;
-          xmax = M_PI;
-          namePostfix = "MuMuPhi";
-          titlePostfix = "#mu#mu pair #phi;#mu^{+}#mu^{-} #phi";
-          break;
-        case xAxis::Z_ETA:
-          xmin = -3.5;
-          xmax = 3.5;
-          namePostfix = "MuMuEta";
-          titlePostfix = "#mu#mu pair #eta;#mu^{+}#mu^{-} #eta";
-          break;
-        case xAxis::MP_PHI:
-          xmin = -M_PI;
-          xmax = M_PI;
-          namePostfix = "MuPlusPhi";
-          titlePostfix = "#mu^{+} #phi;#mu^{+} #phi [rad]";
-          break;
-        case xAxis::MP_ETA:
-          xmin = -2.4;
-          xmax = 2.4;
-          namePostfix = "MuPlusEta";
-          titlePostfix = "#mu^{+} #eta;#mu^{+} #eta";
-          break;
-        case xAxis::MM_PHI:
-          xmin = -M_PI;
-          xmax = M_PI;
-          namePostfix = "MuMinusPhi";
-          titlePostfix = "#mu^{-} #phi;#mu^{-} #phi [rad]";
-          break;
-        case xAxis::MM_ETA:
-          xmin = -2.4;
-          xmax = 2.4;
-          namePostfix = "MuMinusEta";
-          titlePostfix = "#mu^{-} #eta;#mu^{+} #eta";
-          break;
-        default:
-          throw cms::Exception("LogicalError") << " there is not such Axis choice as " << xAx;
-	}
-	
-	const auto& h2name = fmt::sprintf("%sVs%s", hpar.getParameter<std::string>("name"), namePostfix);
-	const auto& h2title = fmt::sprintf("%s vs %s;%s% s",
-					   hpar.getParameter<std::string>("title"),
-					   titlePostfix,
-					   hpar.getParameter<std::string>("title"),
-					   hpar.getParameter<std::string>("yUnits"));
 
-	m_h2_map[xAx] = fs.make<TH2F>(h2name.c_str(),
-				      h2title.c_str(),
-				      hpar.getParameter<int32_t>("NxBins"),
-				      xmin,
-				      xmax,
-				      hpar.getParameter<int32_t>("NyBins"),
-				      hpar.getParameter<double>("ymin"),
-				      hpar.getParameter<double>("ymax"));
+      std::string sed = (m_flav ? "e" : "#mu");
+
+      for (const auto& xAx : axisChoices) {
+        switch (xAx) {
+          case xAxis::Z_PHI:
+            xmin = -M_PI;
+            xmax = M_PI;
+            namePostfix = m_flav ? "EEPhi" : "MMPhi";
+            titlePostfix = fmt::sprintf("%s%s pair #phi;%s^{+}%s^{-} #phi", sed, sed, sed, sed);
+            break;
+          case xAxis::Z_ETA:
+            xmin = -3.5;
+            xmax = 3.5;
+            namePostfix = m_flav ? "EEEta" : "MuMuEta";
+            titlePostfix = fmt::sprintf("%s%s pair #eta;%s^{+}%s^{-} #eta", sed, sed, sed, sed);
+            break;
+          case xAxis::LP_PHI:
+            xmin = -M_PI;
+            xmax = M_PI;
+            namePostfix = m_flav ? "EPlusPhi" : "MuPlusPhi";
+            titlePostfix = fmt::sprintf("%s^{+} #phi;%s^{+} #phi [rad]", sed, sed);
+            break;
+          case xAxis::LP_ETA:
+            xmin = -2.4;
+            xmax = 2.4;
+            namePostfix = m_flav ? "EPlusEta" : "MuPlusEta";
+            titlePostfix = fmt::sprintf("%s^{+} #eta;%s^{+} #eta", sed, sed);
+            break;
+          case xAxis::LM_PHI:
+            xmin = -M_PI;
+            xmax = M_PI;
+            namePostfix = m_flav ? "EMinusPhi" : "MuMinusPhi";
+            titlePostfix = fmt::sprintf("%s^{-} #phi;%s^{-} #phi [rad]", sed, sed);
+            break;
+          case xAxis::LM_ETA:
+            xmin = -2.4;
+            xmax = 2.4;
+            namePostfix = m_flav ? "EMinusEta" : "MuMinusEta";
+            titlePostfix = fmt::sprintf("%s^{-} #eta;%s^{+} #eta", sed, sed);
+            break;
+          default:
+            throw cms::Exception("LogicalError") << " there is not such Axis choice as " << xAx;
+        }
+
+        const auto& h2name = fmt::sprintf("%sVs%s", hpar.getParameter<std::string>("name"), namePostfix);
+        const auto& h2title = fmt::sprintf("%s vs %s;%s% s",
+                                           hpar.getParameter<std::string>("title"),
+                                           titlePostfix,
+                                           hpar.getParameter<std::string>("title"),
+                                           hpar.getParameter<std::string>("yUnits"));
+
+        m_h2_map[xAx] = fs.make<TH2F>(h2name.c_str(),
+                                      h2title.c_str(),
+                                      hpar.getParameter<int32_t>("NxBins"),
+                                      xmin,
+                                      xmax,
+                                      hpar.getParameter<int32_t>("NyBins"),
+                                      hpar.getParameter<double>("ymin"),
+                                      hpar.getParameter<double>("ymax"));
       }
 
       // flip the is booked bit
       m_isBooked = true;
     }
-    
+
     //________________________________________________________________________________//
-    inline void bookPlots(TFileDirectory& fs, const float valmin, const float valmax, const int nxbins, const int nybins) {
+    inline void bookPlots(
+        TFileDirectory& fs, const float valmin, const float valmax, const int nxbins, const int nybins) {
       if (m_name.empty() && m_title.empty() && m_ytitle.empty()) {
-	edm::LogError("PlotsVsKinematics")
-          << "In" << __FUNCTION__ << "," << __LINE__
-          << "trying to book plots without the right constructor being called!" << std::endl;
-	return;
+        edm::LogError("PlotsVsKinematics")
+            << "In" << __FUNCTION__ << "," << __LINE__
+            << "trying to book plots without the right constructor being called!" << std::endl;
+        return;
       }
+
+      std::string dilep = (m_flav ? "e^{+}e^{-}" : "#mu^{+}#mu^{-}");
+      std::string lep = (m_flav ? "e^{+}" : "#mu^{+}");
+      std::string lem = (m_flav ? "e^{-}" : "#mu^{-}");
 
       static constexpr float maxMuEta = 2.4;
       static constexpr float maxMuMuEta = 3.5;
@@ -140,68 +154,69 @@ namespace DiLeptonHelp {
 
       // clang-format off
       m_h2_map[xAxis::Z_ETA] = fs.make<TH2F>(fmt::sprintf("%sVsMuMuEta", m_name).c_str(),
-					   fmt::sprintf("%s vs #mu#mu pair #eta;#mu^{+}#mu^{-} #eta;%s", m_title, m_ytitle).c_str(),
+					     fmt::sprintf("%s vs %s pair #eta;%s #eta;%s", m_title, dilep, dilep, m_ytitle).c_str(),
 					     nxbins, -M_PI, M_PI,
 					     nybins, valmin, valmax);
       
       m_h2_map[xAxis::Z_PHI] = fs.make<TH2F>(fmt::sprintf("%sVsMuMuPhi", m_name).c_str(),
-					     fmt::sprintf("%s vs #mu#mu pair #phi;#mu^{+}#mu^{-} #phi [rad];%s", m_title, m_ytitle).c_str(),
+					     fmt::sprintf("%s vs %s pair #phi;%s #phi [rad];%s", m_title, dilep, dilep, m_ytitle).c_str(),
 					     nxbins, -maxMuMuEta, maxMuMuEta,
 					     nybins, valmin, valmax);
       
-      m_h2_map[xAxis::MP_ETA] = fs.make<TH2F>(fmt::sprintf("%sVsMuPlusEta", m_name).c_str(),
-					      fmt::sprintf("%s vs #mu^{+} #eta;#mu^{+} #eta;%s", m_title, m_ytitle).c_str(),
+      m_h2_map[xAxis::LP_ETA] = fs.make<TH2F>(fmt::sprintf("%sVsMuPlusEta", m_name).c_str(),
+					      fmt::sprintf("%s vs %s #eta;%s #eta;%s", m_title, lep, lep, m_ytitle).c_str(),
 					      nxbins, -maxMuEta, maxMuEta,
 					      nybins, valmin, valmax);
       
-      m_h2_map[xAxis::MP_PHI] = fs.make<TH2F>(fmt::sprintf("%sVsMuPlusPhi", m_name).c_str(),
-					      fmt::sprintf("%s vs #mu^{+} #phi;#mu^{+} #phi [rad];%s", m_title, m_ytitle).c_str(),
+      m_h2_map[xAxis::LP_PHI] = fs.make<TH2F>(fmt::sprintf("%sVsMuPlusPhi", m_name).c_str(),
+					      fmt::sprintf("%s vs %s #phi;%s #phi [rad];%s", m_title, lep, lep, m_ytitle).c_str(),
 					      nxbins, -M_PI, M_PI,
 					      nybins, valmin, valmax);
       
-      m_h2_map[xAxis::MM_ETA] = fs.make<TH2F>(fmt::sprintf("%sVsMuMinusEta", m_name).c_str(),
-					      fmt::sprintf("%s vs #mu^{-} #eta;#mu^{-} #eta;%s", m_title, m_ytitle).c_str(),
+      m_h2_map[xAxis::LM_ETA] = fs.make<TH2F>(fmt::sprintf("%sVsMuMinusEta", m_name).c_str(),
+					      fmt::sprintf("%s vs %s #eta;%s #eta;%s", m_title, lem, lem, m_ytitle).c_str(),
 					      nxbins, -maxMuEta, maxMuEta,
 					      nybins, valmin, valmax);
       
-      m_h2_map[xAxis::MM_PHI] = fs.make<TH2F>(fmt::sprintf("%sVsMuMinusPhi", m_name).c_str(),
-					      fmt::sprintf("%s vs #mu^{-} #phi;#mu^{-} #phi [rad];%s", m_title, m_ytitle).c_str(),
+      m_h2_map[xAxis::LM_PHI] = fs.make<TH2F>(fmt::sprintf("%sVsMuMinusPhi", m_name).c_str(),
+					      fmt::sprintf("%s vs %s #phi;%s #phi [rad];%s", m_title, lem, lem,  m_ytitle).c_str(),
 					      nxbins, -M_PI, M_PI,
 					      nybins, valmin, valmax);
       // clang-format on
-      
+
       // flip the is booked bit
       m_isBooked = true;
     }
-    
+
     //________________________________________________________________________________//
     inline void fillPlots(const float val, const std::pair<TLorentzVector, TLorentzVector>& momenta) {
       if (!m_isBooked) {
-	edm::LogError("PlotsVsKinematics")
-          << "In" << __FUNCTION__ << "," << __LINE__ << "trying to fill a plot not booked!" << std::endl;
-	return;
+        edm::LogError("PlotsVsKinematics")
+            << "In" << __FUNCTION__ << "," << __LINE__ << "trying to fill a plot not booked!" << std::endl;
+        return;
       }
-      
+
       m_h2_map[xAxis::Z_ETA]->Fill((momenta.first + momenta.second).Eta(), val);
       m_h2_map[xAxis::Z_PHI]->Fill((momenta.first + momenta.second).Phi(), val);
-      m_h2_map[xAxis::MP_ETA]->Fill((momenta.first).Eta(), val);
-      m_h2_map[xAxis::MP_PHI]->Fill((momenta.first).Phi(), val);
-      m_h2_map[xAxis::MM_ETA]->Fill((momenta.second).Eta(), val);
-      m_h2_map[xAxis::MM_PHI]->Fill((momenta.second).Phi(), val);
+      m_h2_map[xAxis::LP_ETA]->Fill((momenta.first).Eta(), val);
+      m_h2_map[xAxis::LP_PHI]->Fill((momenta.first).Phi(), val);
+      m_h2_map[xAxis::LM_ETA]->Fill((momenta.second).Eta(), val);
+      m_h2_map[xAxis::LM_PHI]->Fill((momenta.second).Phi(), val);
     }
-    
+
   private:
-    enum xAxis { Z_PHI, Z_ETA, MP_PHI, MP_ETA, MM_PHI, MM_ETA };
+    enum xAxis { Z_PHI, Z_ETA, LP_PHI, LP_ETA, LM_PHI, LM_ETA };
     const std::vector<xAxis> axisChoices = {
-      xAxis::Z_PHI, xAxis::Z_ETA, xAxis::MP_PHI, xAxis::MP_ETA, xAxis::MM_PHI, xAxis::MM_ETA};
+        xAxis::Z_PHI, xAxis::Z_ETA, xAxis::LP_PHI, xAxis::LP_ETA, xAxis::LM_PHI, xAxis::LM_ETA};
 
     const std::string m_name;
     const std::string m_title;
     const std::string m_ytitle;
 
     bool m_isBooked;
+    flavour m_flav;
 
     std::map<xAxis, TH2F*> m_h2_map;
   };
-} 
+}  // namespace DiLeptonHelp
 #endif

--- a/Alignment/OfflineValidation/interface/DiLeptonVertexHelpers.h
+++ b/Alignment/OfflineValidation/interface/DiLeptonVertexHelpers.h
@@ -1,0 +1,207 @@
+#ifndef Alignment_OfflineValidation_DiLeptonVertexHelpers_h
+#define Alignment_OfflineValidation_DiLeptonVertexHelpers_h
+
+#include <vector>
+#include <string>
+#include <fmt/printf.h>
+#include "TH2F.h"
+#include "TLorentzVector.h"
+#include "CommonTools/UtilAlgos/interface/TFileService.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+namespace DiLeptonHelp {
+
+  //
+  // Ancillary struct for counting
+  //
+  struct Counts {
+    unsigned int eventsTotal;
+    unsigned int eventsAfterMult;
+    unsigned int eventsAfterPt;
+    unsigned int eventsAfterEta;
+    unsigned int eventsAfterVtx;
+    unsigned int eventsAfterDist;
+    
+  public:
+    void printCounts() {
+      std::cout << " Total Events: " << eventsTotal << "\n"
+		<< " After multiplicity: " << eventsAfterMult << "\n"
+		<< " After pT cut: " << eventsAfterPt << "\n"
+		<< " After eta cut: " << eventsAfterEta << "\n"
+		<< " After Vtx: " << eventsAfterVtx << "\n"
+		<< " After VtxDist: " << eventsAfterDist << std::endl;
+    }
+    
+    void zeroAll() {
+      eventsTotal = 0;
+      eventsAfterMult = 0;
+      eventsAfterPt = 0;
+      eventsAfterEta = 0;
+      eventsAfterVtx = 0;
+      eventsAfterDist = 0;
+    }
+  };
+
+  //
+  // Ancillary class for plotting
+  //
+  class PlotsVsKinematics {
+  public:
+    PlotsVsKinematics() : m_name(""), m_title(""), m_ytitle(""), m_isBooked(false) {}
+    
+    //________________________________________________________________________________//
+    // overloaded constructor
+    PlotsVsKinematics(const std::string& name, const std::string& tt, const std::string& ytt)
+      : m_name(name), m_title(tt), m_ytitle(ytt), m_isBooked(false) {}
+    
+    ~PlotsVsKinematics() = default;
+    
+    //________________________________________________________________________________//
+    inline void bookFromPSet(const TFileDirectory& fs, const edm::ParameterSet& hpar) {
+      std::string namePostfix;
+      std::string titlePostfix;
+      float xmin, xmax;
+      
+      for (const auto& xAx : axisChoices) {
+	switch (xAx) {
+        case xAxis::Z_PHI:
+          xmin = -M_PI;
+          xmax = M_PI;
+          namePostfix = "MuMuPhi";
+          titlePostfix = "#mu#mu pair #phi;#mu^{+}#mu^{-} #phi";
+          break;
+        case xAxis::Z_ETA:
+          xmin = -3.5;
+          xmax = 3.5;
+          namePostfix = "MuMuEta";
+          titlePostfix = "#mu#mu pair #eta;#mu^{+}#mu^{-} #eta";
+          break;
+        case xAxis::MP_PHI:
+          xmin = -M_PI;
+          xmax = M_PI;
+          namePostfix = "MuPlusPhi";
+          titlePostfix = "#mu^{+} #phi;#mu^{+} #phi [rad]";
+          break;
+        case xAxis::MP_ETA:
+          xmin = -2.4;
+          xmax = 2.4;
+          namePostfix = "MuPlusEta";
+          titlePostfix = "#mu^{+} #eta;#mu^{+} #eta";
+          break;
+        case xAxis::MM_PHI:
+          xmin = -M_PI;
+          xmax = M_PI;
+          namePostfix = "MuMinusPhi";
+          titlePostfix = "#mu^{-} #phi;#mu^{-} #phi [rad]";
+          break;
+        case xAxis::MM_ETA:
+          xmin = -2.4;
+          xmax = 2.4;
+          namePostfix = "MuMinusEta";
+          titlePostfix = "#mu^{-} #eta;#mu^{+} #eta";
+          break;
+        default:
+          throw cms::Exception("LogicalError") << " there is not such Axis choice as " << xAx;
+	}
+	
+	const auto& h2name = fmt::sprintf("%sVs%s", hpar.getParameter<std::string>("name"), namePostfix);
+	const auto& h2title = fmt::sprintf("%s vs %s;%s% s",
+					   hpar.getParameter<std::string>("title"),
+					   titlePostfix,
+					   hpar.getParameter<std::string>("title"),
+					   hpar.getParameter<std::string>("yUnits"));
+
+	m_h2_map[xAx] = fs.make<TH2F>(h2name.c_str(),
+				      h2title.c_str(),
+				      hpar.getParameter<int32_t>("NxBins"),
+				      xmin,
+				      xmax,
+				      hpar.getParameter<int32_t>("NyBins"),
+				      hpar.getParameter<double>("ymin"),
+				      hpar.getParameter<double>("ymax"));
+      }
+
+      // flip the is booked bit
+      m_isBooked = true;
+    }
+    
+    //________________________________________________________________________________//
+    inline void bookPlots(TFileDirectory& fs, const float valmin, const float valmax, const int nxbins, const int nybins) {
+      if (m_name.empty() && m_title.empty() && m_ytitle.empty()) {
+	edm::LogError("PlotsVsKinematics")
+          << "In" << __FUNCTION__ << "," << __LINE__
+          << "trying to book plots without the right constructor being called!" << std::endl;
+	return;
+      }
+
+      static constexpr float maxMuEta = 2.4;
+      static constexpr float maxMuMuEta = 3.5;
+      TH1F::SetDefaultSumw2(kTRUE);
+
+      // clang-format off
+      m_h2_map[xAxis::Z_ETA] = fs.make<TH2F>(fmt::sprintf("%sVsMuMuEta", m_name).c_str(),
+					   fmt::sprintf("%s vs #mu#mu pair #eta;#mu^{+}#mu^{-} #eta;%s", m_title, m_ytitle).c_str(),
+					     nxbins, -M_PI, M_PI,
+					     nybins, valmin, valmax);
+      
+      m_h2_map[xAxis::Z_PHI] = fs.make<TH2F>(fmt::sprintf("%sVsMuMuPhi", m_name).c_str(),
+					     fmt::sprintf("%s vs #mu#mu pair #phi;#mu^{+}#mu^{-} #phi [rad];%s", m_title, m_ytitle).c_str(),
+					     nxbins, -maxMuMuEta, maxMuMuEta,
+					     nybins, valmin, valmax);
+      
+      m_h2_map[xAxis::MP_ETA] = fs.make<TH2F>(fmt::sprintf("%sVsMuPlusEta", m_name).c_str(),
+					      fmt::sprintf("%s vs #mu^{+} #eta;#mu^{+} #eta;%s", m_title, m_ytitle).c_str(),
+					      nxbins, -maxMuEta, maxMuEta,
+					      nybins, valmin, valmax);
+      
+      m_h2_map[xAxis::MP_PHI] = fs.make<TH2F>(fmt::sprintf("%sVsMuPlusPhi", m_name).c_str(),
+					      fmt::sprintf("%s vs #mu^{+} #phi;#mu^{+} #phi [rad];%s", m_title, m_ytitle).c_str(),
+					      nxbins, -M_PI, M_PI,
+					      nybins, valmin, valmax);
+      
+      m_h2_map[xAxis::MM_ETA] = fs.make<TH2F>(fmt::sprintf("%sVsMuMinusEta", m_name).c_str(),
+					      fmt::sprintf("%s vs #mu^{-} #eta;#mu^{-} #eta;%s", m_title, m_ytitle).c_str(),
+					      nxbins, -maxMuEta, maxMuEta,
+					      nybins, valmin, valmax);
+      
+      m_h2_map[xAxis::MM_PHI] = fs.make<TH2F>(fmt::sprintf("%sVsMuMinusPhi", m_name).c_str(),
+					      fmt::sprintf("%s vs #mu^{-} #phi;#mu^{-} #phi [rad];%s", m_title, m_ytitle).c_str(),
+					      nxbins, -M_PI, M_PI,
+					      nybins, valmin, valmax);
+      // clang-format on
+      
+      // flip the is booked bit
+      m_isBooked = true;
+    }
+    
+    //________________________________________________________________________________//
+    inline void fillPlots(const float val, const std::pair<TLorentzVector, TLorentzVector>& momenta) {
+      if (!m_isBooked) {
+	edm::LogError("PlotsVsKinematics")
+          << "In" << __FUNCTION__ << "," << __LINE__ << "trying to fill a plot not booked!" << std::endl;
+	return;
+      }
+      
+      m_h2_map[xAxis::Z_ETA]->Fill((momenta.first + momenta.second).Eta(), val);
+      m_h2_map[xAxis::Z_PHI]->Fill((momenta.first + momenta.second).Phi(), val);
+      m_h2_map[xAxis::MP_ETA]->Fill((momenta.first).Eta(), val);
+      m_h2_map[xAxis::MP_PHI]->Fill((momenta.first).Phi(), val);
+      m_h2_map[xAxis::MM_ETA]->Fill((momenta.second).Eta(), val);
+      m_h2_map[xAxis::MM_PHI]->Fill((momenta.second).Phi(), val);
+    }
+    
+  private:
+    enum xAxis { Z_PHI, Z_ETA, MP_PHI, MP_ETA, MM_PHI, MM_ETA };
+    const std::vector<xAxis> axisChoices = {
+      xAxis::Z_PHI, xAxis::Z_ETA, xAxis::MP_PHI, xAxis::MP_ETA, xAxis::MM_PHI, xAxis::MM_ETA};
+
+    const std::string m_name;
+    const std::string m_title;
+    const std::string m_ytitle;
+
+    bool m_isBooked;
+
+    std::map<xAxis, TH2F*> m_h2_map;
+  };
+} 
+#endif

--- a/Alignment/OfflineValidation/interface/DiLeptonVertexHelpers.h
+++ b/Alignment/OfflineValidation/interface/DiLeptonVertexHelpers.h
@@ -25,12 +25,12 @@ namespace DiLeptonHelp {
 
   public:
     void printCounts() {
-      edm::LogPrint("DileptonHelp::Counts") << " Total Events: " << eventsTotal << "\n"
-                                            << " After multiplicity: " << eventsAfterMult << "\n"
-                                            << " After pT cut: " << eventsAfterPt << "\n"
-                                            << " After eta cut: " << eventsAfterEta << "\n"
-                                            << " After Vtx: " << eventsAfterVtx << "\n"
-                                            << " After VtxDist: " << eventsAfterDist << std::endl;
+      edm::LogInfo("DiLeptonHelpCounts") << " Total Events: " << eventsTotal << "\n"
+                                         << " After multiplicity: " << eventsAfterMult << "\n"
+                                         << " After pT cut: " << eventsAfterPt << "\n"
+                                         << " After eta cut: " << eventsAfterEta << "\n"
+                                         << " After Vtx: " << eventsAfterVtx << "\n"
+                                         << " After VtxDist: " << eventsAfterDist << std::endl;
     }
 
     void zeroAll() {

--- a/Alignment/OfflineValidation/plugins/DiElectronVertexValidation.cc
+++ b/Alignment/OfflineValidation/plugins/DiElectronVertexValidation.cc
@@ -1,0 +1,410 @@
+// -*- C++ -*-
+//
+// Package:    Alignment/OfflineValidation
+// Class:      DiElectronVertexValidation
+//
+/**\class DiElectronVertexValidation DiElectronVertexValidation.cc Alignment/OfflineValidation/plugins/DiElectronVertexValidation.cc
+
+ Description: [one line class summary]
+
+ Implementation:
+     [Notes on implementation]
+*/
+//
+// Original Author:  Marco Musich
+//         Created:  Thu, 13 May 2021 10:24:07 GMT
+//
+//
+
+// system include files
+#include <memory>
+
+// user include files
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+
+// electrons
+#include "DataFormats/EgammaCandidates/interface/GsfElectronFwd.h"
+#include "DataFormats/EgammaCandidates/interface/GsfElectron.h"
+#include "DataFormats/EgammaCandidates/interface/GsfElectronCore.h"
+#include "DataFormats/ParticleFlowReco/interface/GsfPFRecTrack.h"
+#include "DataFormats/GsfTrackReco/interface/GsfTrack.h"
+
+// tracks
+#include "DataFormats/TrackReco/interface/Track.h"
+#include "DataFormats/TrackReco/interface/TrackFwd.h"
+#include "RecoVertex/VertexPrimitives/interface/TransientVertex.h"
+#include "RecoVertex/KalmanVertexFit/interface/KalmanVertexFitter.h"
+#include "TrackingTools/TransientTrack/interface/TransientTrackBuilder.h"
+#include "TrackingTools/Records/interface/TransientTrackRecord.h"
+
+// vertices
+#include "RecoVertex/VertexTools/interface/VertexDistanceXY.h"
+#include "RecoVertex/VertexTools/interface/VertexDistance3D.h"
+
+// TFileService
+#include "CommonTools/UtilAlgos/interface/TFileService.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+
+// utilities
+#include "DataFormats/Math/interface/deltaR.h"
+#include "Alignment/OfflineValidation/interface/DiLeptonVertexHelpers.h"
+
+// ROOT
+#include "TLorentzVector.h"
+#include "TH1F.h"
+#include "TH2F.h"
+
+//
+// class declaration
+//
+class DiElectronVertexValidation : public edm::one::EDAnalyzer<edm::one::SharedResources> {
+public:
+  explicit DiElectronVertexValidation(const edm::ParameterSet&);
+  ~DiElectronVertexValidation() override;
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+private:
+  void beginJob() override;
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
+  void endJob() override;
+  bool passLooseSelection(const reco::GsfElectron& electron);
+
+  // ----------member data ---------------------------
+  DiLeptonHelp::Counts myCounts;
+  std::vector<double> pTthresholds_;
+  float maxSVdist_;
+
+  const edm::ESGetToken<TransientTrackBuilder, TransientTrackRecord> ttbESToken_;
+  edm::EDGetTokenT<reco::GsfElectronCollection>
+      electronsToken_;  //used to select what electrons to read from configuration
+  edm::EDGetTokenT<reco::GsfTrackCollection>
+      gsfTracksToken_;                                    //used to select what tracks to read from configuration file
+  edm::EDGetTokenT<reco::VertexCollection> vertexToken_;  //used to select what vertices to read from configuration file
+
+  TH1F* hSVProb_;
+  TH1F* hSVDist_;
+  TH1F* hGSFMult_;
+  TH1F* hGSFMultAftPt_;
+  TH1F* hGSF0Pt_;
+  TH1F* hGSF0Eta_;
+  TH1F* hGSF1Pt_;
+  TH1F* hGSF1Eta_;
+  TH1F* hSVDistSig_;
+  TH1F* hSVDist3D_;
+  TH1F* hSVDist3DSig_;
+  TH1F* hCosPhi_;
+  TH1F* hCosPhi3D_;
+  TH1F* hTrackInvMass_;
+  TH1F* hInvMass_;
+  TH1I* hClosestVtxIndex_;
+  TH1F* hCutFlow_;
+};
+
+//
+// constants, enums and typedefs
+//
+
+static constexpr float cmToum = 10e4;
+static constexpr float emass2 = 0.0005109990615 * 0.0005109990615;  //e mass squared  (GeV^2/c^4)
+
+//
+// constructors and destructor
+//
+DiElectronVertexValidation::DiElectronVertexValidation(const edm::ParameterSet& iConfig)
+    : pTthresholds_(iConfig.getParameter<std::vector<double>>("pTThresholds")),
+      maxSVdist_(iConfig.getParameter<double>("maxSVdist")),
+      ttbESToken_(esConsumes(edm::ESInputTag("", "TransientTrackBuilder"))),
+      electronsToken_(consumes<reco::GsfElectronCollection>(iConfig.getParameter<edm::InputTag>("electrons"))),
+      gsfTracksToken_(consumes<reco::GsfTrackCollection>(iConfig.getParameter<edm::InputTag>("gsfTracks"))),
+      vertexToken_(consumes<reco::VertexCollection>(iConfig.getParameter<edm::InputTag>("vertices"))) {
+  usesResource(TFileService::kSharedResource);
+}
+
+DiElectronVertexValidation::~DiElectronVertexValidation() {}
+
+//
+// member functions
+//
+
+// ------------ method called for each event  ------------
+void DiElectronVertexValidation::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  using namespace edm;
+
+  myCounts.eventsTotal++;
+
+  std::vector<const reco::GsfElectron*> myGoodGsfElectrons;
+
+  int totGsfCounter = 0;
+  for (const auto& gsfEle : iEvent.get(electronsToken_)) {
+    totGsfCounter++;
+    if (gsfEle.pt() > pTthresholds_[1] && passLooseSelection(gsfEle)) {
+      myGoodGsfElectrons.emplace_back(&gsfEle);
+    }
+  }
+
+  hGSFMult_->Fill(totGsfCounter);
+
+  std::sort(myGoodGsfElectrons.begin(),
+            myGoodGsfElectrons.end(),
+            [](const reco::GsfElectron*& lhs, const reco::GsfElectron*& rhs) { return lhs->pt() > rhs->pt(); });
+
+  hGSFMultAftPt_->Fill(myGoodGsfElectrons.size());
+
+  // reject if there's no Z
+  if (myGoodGsfElectrons.size() < 2)
+    return;
+
+  myCounts.eventsAfterMult++;
+
+  if ((myGoodGsfElectrons[0]->pt()) < pTthresholds_[0] || (myGoodGsfElectrons[1]->pt() < pTthresholds_[1]))
+    return;
+
+  myCounts.eventsAfterPt++;
+
+  if (myGoodGsfElectrons[0]->charge() * myGoodGsfElectrons[1]->charge() > 0)
+    return;
+
+  if (std::max(std::abs(myGoodGsfElectrons[0]->eta()), std::abs(myGoodGsfElectrons[1]->eta())) > 2.4)
+    return;
+
+  myCounts.eventsAfterEta++;
+
+  const auto& ele1 = myGoodGsfElectrons[1]->p4();
+  const auto& ele0 = myGoodGsfElectrons[0]->p4();
+  const auto& mother = ele1 + ele0;
+
+  float invMass = mother.M();
+  hInvMass_->Fill(invMass);
+
+  // just copy the top two muons
+  std::vector<const reco::GsfElectron*> theZElectronVector;
+  theZElectronVector.reserve(2);
+  theZElectronVector.emplace_back(myGoodGsfElectrons[1]);
+  theZElectronVector.emplace_back(myGoodGsfElectrons[0]);
+
+  // do the matching of Z muons with inner tracks
+
+  std::vector<const reco::GsfTrack*> myGoodGsfTracks;
+
+  unsigned int i = 0;
+  for (const auto& electron : theZElectronVector) {
+    i++;
+    float minD = 1000.;
+    const reco::GsfTrack* theMatch = nullptr;
+    for (const auto& track : iEvent.get(gsfTracksToken_)) {
+      float D = ::deltaR(electron->gsfTrack()->eta(), electron->gsfTrack()->phi(), track.eta(), track.phi());
+      if (D < minD) {
+        minD = D;
+        theMatch = &track;
+      }
+    }
+    myGoodGsfTracks.emplace_back(theMatch);
+  }
+
+  hGSF0Pt_->Fill(myGoodGsfTracks[0]->pt());
+  hGSF0Eta_->Fill(myGoodGsfTracks[0]->eta());
+  hGSF1Pt_->Fill(myGoodGsfTracks[1]->pt());
+  hGSF1Eta_->Fill(myGoodGsfTracks[1]->eta());
+
+  const TransientTrackBuilder* theB = &iSetup.getData(ttbESToken_);
+  TransientVertex aTransVtx;
+  std::vector<reco::TransientTrack> tks;
+
+  std::vector<const reco::GsfTrack*> myTracks;
+  myTracks.emplace_back(myGoodGsfTracks[0]);
+  myTracks.emplace_back(myGoodGsfTracks[1]);
+
+  if (myTracks.size() != 2)
+    return;
+
+  const auto& e1 = myTracks[1]->momentum();
+  const auto& e0 = myTracks[0]->momentum();
+  const auto& ditrack = e1 + e0;
+
+  TLorentzVector p4_e1(e1.x(), e1.y(), e1.z(), sqrt(e1.mag2() + emass2));
+  TLorentzVector p4_e0(e0.x(), e0.y(), e0.z(), sqrt(e0.mag2() + emass2));
+
+  const auto& Zp4 = p4_e1 + p4_e0;
+  float track_invMass = Zp4.M();
+  hTrackInvMass_->Fill(track_invMass);
+
+  math::XYZPoint ZpT(ditrack.x(), ditrack.y(), 0);
+  math::XYZPoint Zp(ditrack.x(), ditrack.y(), ditrack.z());
+
+  for (const auto& track : myTracks) {
+    reco::TransientTrack trajectory = theB->build(track);
+    tks.push_back(trajectory);
+  }
+
+  KalmanVertexFitter kalman(true);
+  aTransVtx = kalman.vertex(tks);
+
+  double SVProb = TMath::Prob(aTransVtx.totalChiSquared(), (int)aTransVtx.degreesOfFreedom());
+  hSVProb_->Fill(SVProb);
+
+  if (!aTransVtx.isValid())
+    return;
+
+  myCounts.eventsAfterVtx++;
+
+  // get collection of reconstructed vertices from event
+  edm::Handle<reco::VertexCollection> vertexHandle = iEvent.getHandle(vertexToken_);
+
+  math::XYZPoint mainVtx(0, 0, 0);
+  reco::Vertex TheMainVtx;  // = vertexHandle.product()->front();
+
+  VertexDistanceXY vertTool;
+  VertexDistance3D vertTool3D;
+
+  if (vertexHandle.isValid()) {
+    const reco::VertexCollection* vertices = vertexHandle.product();
+    float minD = 9999.;
+    int closestVtxIndex = 0;
+    int counter = 0;
+    for (const auto& vtx : *vertices) {
+      double dist3D = vertTool3D.distance(aTransVtx, vtx).value();
+      if (dist3D < minD) {
+        minD = dist3D;
+        closestVtxIndex = counter;
+      }
+      counter++;
+    }
+    if ((*vertices).at(closestVtxIndex).isValid()) {
+      hClosestVtxIndex_->Fill(closestVtxIndex);
+      TheMainVtx = (*vertices).at(closestVtxIndex);
+      mainVtx.SetXYZ(TheMainVtx.position().x(), TheMainVtx.position().y(), TheMainVtx.position().z());
+    }
+  }
+
+  const math::XYZPoint myVertex(aTransVtx.position().x(), aTransVtx.position().y(), aTransVtx.position().z());
+  const math::XYZPoint deltaVtx(mainVtx.x() - myVertex.x(), mainVtx.y() - myVertex.y(), mainVtx.z() - myVertex.z());
+
+  if (TheMainVtx.isValid()) {
+    // Z Vertex distance in the xy plane
+    double distance = vertTool.distance(aTransVtx, TheMainVtx).value();
+    double dist_err = vertTool.distance(aTransVtx, TheMainVtx).error();
+
+    hSVDist_->Fill(distance * cmToum);
+    hSVDistSig_->Fill(distance / dist_err);
+
+    // Z Vertex distance in 3D
+    double distance3D = vertTool3D.distance(aTransVtx, TheMainVtx).value();
+    double dist3D_err = vertTool3D.distance(aTransVtx, TheMainVtx).error();
+
+    hSVDist3D_->Fill(distance3D * cmToum);
+    hSVDist3DSig_->Fill(distance3D / dist3D_err);
+
+    // cut on the PV - SV distance
+    if (distance * cmToum < maxSVdist_) {
+      myCounts.eventsAfterDist++;
+
+      double cosphi = (ZpT.x() * deltaVtx.x() + ZpT.y() * deltaVtx.y()) /
+                      (sqrt(ZpT.x() * ZpT.x() + ZpT.y() * ZpT.y()) *
+                       sqrt(deltaVtx.x() * deltaVtx.x() + deltaVtx.y() * deltaVtx.y()));
+
+      double cosphi3D = (Zp.x() * deltaVtx.x() + Zp.y() * deltaVtx.y() + Zp.z() * deltaVtx.z()) /
+                        (sqrt(Zp.x() * Zp.x() + Zp.y() * Zp.y() + Zp.z() * Zp.z()) *
+                         sqrt(deltaVtx.x() * deltaVtx.x() + deltaVtx.y() * deltaVtx.y() + deltaVtx.z() * deltaVtx.z()));
+
+      hCosPhi_->Fill(cosphi);
+      hCosPhi3D_->Fill(cosphi3D);
+    }
+  }
+}
+
+bool DiElectronVertexValidation::passLooseSelection(const reco::GsfElectron& el) {
+  float dEtaln = fabs(el.deltaEtaSuperClusterTrackAtVtx());
+  float dPhiln = fabs(el.deltaPhiSuperClusterTrackAtVtx());
+  float sigmaletaleta = el.full5x5_sigmaIetaIeta();
+  float hem = el.hadronicOverEm();
+  double resol = fabs((1 / el.ecalEnergy()) - (el.eSuperClusterOverP() / el.ecalEnergy()));
+  double mHits = el.gsfTrack()->hitPattern().numberOfAllHits(reco::HitPattern::MISSING_INNER_HITS);
+  bool barrel = (fabs(el.superCluster()->eta()) <= 1.479);
+  bool endcap = (!barrel && fabs(el.superCluster()->eta()) < 2.5);
+
+  // loose electron ID
+
+  if (barrel && dEtaln < 0.00477 && dPhiln < 0.222 && sigmaletaleta < 0.011 && hem < 0.298 && resol < 0.241 &&
+      mHits <= 1)
+    return true;
+  if (endcap && dEtaln < 0.00868 && dPhiln < 0.213 && sigmaletaleta < 0.0314 && hem < 0.101 && resol < 0.14 &&
+      mHits <= 1)
+    return true;
+
+  return false;
+}
+
+// ------------ method called once each job just before starting event loop  ------------
+void DiElectronVertexValidation::beginJob() {
+  // please remove this method if not needed
+  edm::Service<TFileService> fs;
+
+  // clang-format off
+  TH1F::SetDefaultSumw2(kTRUE);
+  
+  hGSFMult_= fs->make<TH1F>("GSFMult", ";# gsf tracks;N. events", 20, 0., 20.);
+  hGSFMultAftPt_= fs->make<TH1F>("GSFMultAftPt", ";# gsf tracks;N. events", 20, 0., 20.);
+  hGSF0Pt_=  fs->make<TH1F>("GSF0Pt", ";leading GSF track p_{T};N. GSF tracks", 100, 0., 100.);
+  hGSF0Eta_= fs->make<TH1F>("GSF0Eta", ";leading GSF track #eta;N. GSF tracks", 50, -2.5, 2.5);
+  hGSF1Pt_=  fs->make<TH1F>("GSF1Pt", ";sub-leading GSF track p_{T};N. GSF tracks", 100, 0., 100.);
+  hGSF1Eta_= fs->make<TH1F>("GSF1Eta", ";sub-leading GSF track #eta;N. GSF tracks", 50, -2.5, 2.5);
+
+  hSVProb_ = fs->make<TH1F>("VtxProb", ";ZV vertex probability;N(e^{+}e^{-} pairs)", 100, 0., 1.);
+
+  hSVDist_ = fs->make<TH1F>("VtxDist", ";PV-ZV xy distance [#mum];N(e^{+}e^{-} pairs)", 100, 0., 1000.);
+  hSVDistSig_ = fs->make<TH1F>("VtxDistSig", ";PV-ZV xy distance signficance;N(e^{+}e^{-} pairs)", 100, 0., 5.);
+
+  hSVDist3D_ = fs->make<TH1F>("VtxDist3D", ";PV-ZV 3D distance [#mum];N(e^{+}e^{-} pairs)", 100, 0., 1000.);
+  hSVDist3DSig_ = fs->make<TH1F>("VtxDist3DSig", ";PV-ZV 3D distance signficance;N(e^{+}e^{-} pairs)", 100, 0., 5.);
+
+  hCosPhi_ = fs->make<TH1F>("CosPhi", ";cos(#phi_{xy});N(ee pairs)", 50, -1., 1.);
+  hCosPhi3D_ = fs->make<TH1F>("CosPhi3D", ";cos(#phi_{3D});N(ee pairs)", 50, -1., 1.);
+  hTrackInvMass_ = fs->make<TH1F>("TkTkInvMass", ";M(tk,tk) [GeV];N(tk tk pairs)", 70., 50., 120.);
+  hInvMass_ = fs->make<TH1F>("InvMass", ";M(#mu#mu) [GeV];N(#mu#mu pairs)", 70., 50., 120.);
+
+  hClosestVtxIndex_ = fs->make<TH1I>("ClosestVtxIndex", ";closest vertex index;N(tk tk pairs)", 20, -0.5, 19.5);
+
+  hCutFlow_ = fs->make<TH1F>("hCutFlow","cut flow;cut step;events left",6,-0.5,5.5);
+  std::string names[6]={"Total","Mult.",">pT","<eta","hasVtx","VtxDist"};
+  for(unsigned int i=0;i<6;i++){
+    hCutFlow_->GetXaxis()->SetBinLabel(i+1,names[i].c_str());
+  }
+
+  myCounts.zeroAll();
+}
+
+// ------------ method called once each job just after ending the event loop  ------------
+void DiElectronVertexValidation::endJob() {
+  // please remove this method if not needed
+  myCounts.printCounts();
+
+  hCutFlow_->SetBinContent(1,myCounts.eventsTotal);
+  hCutFlow_->SetBinContent(2,myCounts.eventsAfterMult);
+  hCutFlow_->SetBinContent(3,myCounts.eventsAfterPt);
+  hCutFlow_->SetBinContent(4,myCounts.eventsAfterEta);
+  hCutFlow_->SetBinContent(5,myCounts.eventsAfterVtx);
+  hCutFlow_->SetBinContent(6,myCounts.eventsAfterDist);
+
+}
+
+// ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
+void DiElectronVertexValidation::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.add<edm::InputTag>("gsfTracks",edm::InputTag("electronGsfTracks"));
+  desc.add<edm::InputTag>("vertices", edm::InputTag("offlinePrimaryVertices"));
+  desc.add<edm::InputTag>("electrons", edm::InputTag("gedGsfElectrons"));
+  desc.add<std::vector<double>>("pTThresholds", {25., 15.});
+  desc.add<double>("maxSVdist", 50.);
+  descriptions.addWithDefaultLabel(desc);
+}
+
+//define this as a plug-in
+DEFINE_FWK_MODULE(DiElectronVertexValidation);

--- a/Alignment/OfflineValidation/plugins/DiElectronVertexValidation.cc
+++ b/Alignment/OfflineValidation/plugins/DiElectronVertexValidation.cc
@@ -67,7 +67,7 @@
 class DiElectronVertexValidation : public edm::one::EDAnalyzer<edm::one::SharedResources> {
 public:
   explicit DiElectronVertexValidation(const edm::ParameterSet&);
-  ~DiElectronVertexValidation();
+  ~DiElectronVertexValidation() override;
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
@@ -165,7 +165,6 @@ DiElectronVertexValidation::DiElectronVertexValidation(const edm::ParameterSet& 
     edm::LogInfo("DiElectronVertexValidation") << " Threshold: " << thr << " ";
   }
   edm::LogInfo("DiElectronVertexValidation") << "Max SV distance: " << maxSVdist_ << " ";
-
 }
 
 DiElectronVertexValidation::~DiElectronVertexValidation() = default;

--- a/Alignment/OfflineValidation/plugins/DiMuonVertexValidation.cc
+++ b/Alignment/OfflineValidation/plugins/DiMuonVertexValidation.cc
@@ -106,14 +106,14 @@ private:
 
   // 2D maps
 
-  DiLeptonHelp::PlotsVsKinematics CosPhiPlots = DiLeptonHelp::PlotsVsKinematics();
-  DiLeptonHelp::PlotsVsKinematics CosPhi3DPlots = DiLeptonHelp::PlotsVsKinematics();
-  DiLeptonHelp::PlotsVsKinematics VtxProbPlots = DiLeptonHelp::PlotsVsKinematics();
-  DiLeptonHelp::PlotsVsKinematics VtxDistPlots = DiLeptonHelp::PlotsVsKinematics();
-  DiLeptonHelp::PlotsVsKinematics VtxDist3DPlots = DiLeptonHelp::PlotsVsKinematics();
-  DiLeptonHelp::PlotsVsKinematics VtxDistSigPlots = DiLeptonHelp::PlotsVsKinematics();
-  DiLeptonHelp::PlotsVsKinematics VtxDist3DSigPlots = DiLeptonHelp::PlotsVsKinematics();
-  DiLeptonHelp::PlotsVsKinematics ZMassPlots = DiLeptonHelp::PlotsVsKinematics();
+  DiLeptonHelp::PlotsVsKinematics CosPhiPlots = DiLeptonHelp::PlotsVsKinematics(DiLeptonHelp::MM);
+  DiLeptonHelp::PlotsVsKinematics CosPhi3DPlots = DiLeptonHelp::PlotsVsKinematics(DiLeptonHelp::MM);
+  DiLeptonHelp::PlotsVsKinematics VtxProbPlots = DiLeptonHelp::PlotsVsKinematics(DiLeptonHelp::MM);
+  DiLeptonHelp::PlotsVsKinematics VtxDistPlots = DiLeptonHelp::PlotsVsKinematics(DiLeptonHelp::MM);
+  DiLeptonHelp::PlotsVsKinematics VtxDist3DPlots = DiLeptonHelp::PlotsVsKinematics(DiLeptonHelp::MM);
+  DiLeptonHelp::PlotsVsKinematics VtxDistSigPlots = DiLeptonHelp::PlotsVsKinematics(DiLeptonHelp::MM);
+  DiLeptonHelp::PlotsVsKinematics VtxDist3DSigPlots = DiLeptonHelp::PlotsVsKinematics(DiLeptonHelp::MM);
+  DiLeptonHelp::PlotsVsKinematics ZMassPlots = DiLeptonHelp::PlotsVsKinematics(DiLeptonHelp::MM);
 
   const edm::ESGetToken<TransientTrackBuilder, TransientTrackRecord> ttbESToken_;
 

--- a/Alignment/OfflineValidation/plugins/DiMuonVertexValidation.cc
+++ b/Alignment/OfflineValidation/plugins/DiMuonVertexValidation.cc
@@ -17,7 +17,6 @@
 // system include files
 #include <memory>
 #include <utility>
-#include <fmt/printf.h>
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
@@ -33,6 +32,7 @@
 #include "DataFormats/MuonReco/interface/MuonSelectors.h"
 
 // utils
+#include "Alignment/OfflineValidation/interface/DiLeptonVertexHelpers.h"
 #include "DataFormats/Math/interface/deltaR.h"
 #include "TLorentzVector.h"
 
@@ -55,168 +55,6 @@
 #include "TH2F.h"
 
 //#define LogDebug(X) std::cout << X <<
-
-//
-// Ancillary class for plotting
-//
-class PlotsVsDiMuKinematics {
-public:
-  PlotsVsDiMuKinematics() : m_name(""), m_title(""), m_ytitle(""), m_isBooked(false) {}
-
-  //________________________________________________________________________________//
-  // overloaded constructor
-  PlotsVsDiMuKinematics(const std::string& name, const std::string& tt, const std::string& ytt)
-      : m_name(name), m_title(tt), m_ytitle(ytt), m_isBooked(false) {}
-
-  ~PlotsVsDiMuKinematics() = default;
-
-  //________________________________________________________________________________//
-  void bookFromPSet(const TFileDirectory& fs, const edm::ParameterSet& hpar) {
-    std::string namePostfix;
-    std::string titlePostfix;
-    float xmin, xmax;
-
-    for (const auto& xAx : axisChoices) {
-      switch (xAx) {
-        case xAxis::Z_PHI:
-          xmin = -M_PI;
-          xmax = M_PI;
-          namePostfix = "MuMuPhi";
-          titlePostfix = "#mu#mu pair #phi;#mu^{+}#mu^{-} #phi";
-          break;
-        case xAxis::Z_ETA:
-          xmin = -3.5;
-          xmax = 3.5;
-          namePostfix = "MuMuEta";
-          titlePostfix = "#mu#mu pair #eta;#mu^{+}#mu^{-} #eta";
-          break;
-        case xAxis::MP_PHI:
-          xmin = -M_PI;
-          xmax = M_PI;
-          namePostfix = "MuPlusPhi";
-          titlePostfix = "#mu^{+} #phi;#mu^{+} #phi [rad]";
-          break;
-        case xAxis::MP_ETA:
-          xmin = -2.4;
-          xmax = 2.4;
-          namePostfix = "MuPlusEta";
-          titlePostfix = "#mu^{+} #eta;#mu^{+} #eta";
-          break;
-        case xAxis::MM_PHI:
-          xmin = -M_PI;
-          xmax = M_PI;
-          namePostfix = "MuMinusPhi";
-          titlePostfix = "#mu^{-} #phi;#mu^{-} #phi [rad]";
-          break;
-        case xAxis::MM_ETA:
-          xmin = -2.4;
-          xmax = 2.4;
-          namePostfix = "MuMinusEta";
-          titlePostfix = "#mu^{-} #eta;#mu^{+} #eta";
-          break;
-        default:
-          throw cms::Exception("LogicalError") << " there is not such Axis choice as " << xAx;
-      }
-
-      const auto& h2name = fmt::sprintf("%sVs%s", hpar.getParameter<std::string>("name"), namePostfix);
-      const auto& h2title = fmt::sprintf("%s vs %s;%s% s",
-                                         hpar.getParameter<std::string>("title"),
-                                         titlePostfix,
-                                         hpar.getParameter<std::string>("title"),
-                                         hpar.getParameter<std::string>("yUnits"));
-
-      m_h2_map[xAx] = fs.make<TH2F>(h2name.c_str(),
-                                    h2title.c_str(),
-                                    hpar.getParameter<int32_t>("NxBins"),
-                                    xmin,
-                                    xmax,
-                                    hpar.getParameter<int32_t>("NyBins"),
-                                    hpar.getParameter<double>("ymin"),
-                                    hpar.getParameter<double>("ymax"));
-    }
-
-    // flip the is booked bit
-    m_isBooked = true;
-  }
-
-  //________________________________________________________________________________//
-  void bookPlots(TFileDirectory& fs, const float valmin, const float valmax, const int nxbins, const int nybins) {
-    if (m_name.empty() && m_title.empty() && m_ytitle.empty()) {
-      edm::LogError("PlotsVsDiMuKinematics")
-          << "In" << __FUNCTION__ << "," << __LINE__
-          << "trying to book plots without the right constructor being called!" << std::endl;
-      return;
-    }
-
-    static constexpr float maxMuEta = 2.4;
-    static constexpr float maxMuMuEta = 3.5;
-    TH1F::SetDefaultSumw2(kTRUE);
-
-    // clang-format off
-    m_h2_map[xAxis::Z_ETA] = fs.make<TH2F>(fmt::sprintf("%sVsMuMuEta", m_name).c_str(),
-					   fmt::sprintf("%s vs #mu#mu pair #eta;#mu^{+}#mu^{-} #eta;%s", m_title, m_ytitle).c_str(),
-					   nxbins, -M_PI, M_PI,
-					   nybins, valmin, valmax);
-
-    m_h2_map[xAxis::Z_PHI] = fs.make<TH2F>(fmt::sprintf("%sVsMuMuPhi", m_name).c_str(),
-					   fmt::sprintf("%s vs #mu#mu pair #phi;#mu^{+}#mu^{-} #phi [rad];%s", m_title, m_ytitle).c_str(),
-					   nxbins, -maxMuMuEta, maxMuMuEta,
-					   nybins, valmin, valmax);
-
-    m_h2_map[xAxis::MP_ETA] = fs.make<TH2F>(fmt::sprintf("%sVsMuPlusEta", m_name).c_str(),
-					    fmt::sprintf("%s vs #mu^{+} #eta;#mu^{+} #eta;%s", m_title, m_ytitle).c_str(),
-					    nxbins, -maxMuEta, maxMuEta,
-					    nybins, valmin, valmax);
-
-    m_h2_map[xAxis::MP_PHI] = fs.make<TH2F>(fmt::sprintf("%sVsMuPlusPhi", m_name).c_str(),
-					    fmt::sprintf("%s vs #mu^{+} #phi;#mu^{+} #phi [rad];%s", m_title, m_ytitle).c_str(),
-					    nxbins, -M_PI, M_PI,
-					    nybins, valmin, valmax);
-
-    m_h2_map[xAxis::MM_ETA] = fs.make<TH2F>(fmt::sprintf("%sVsMuMinusEta", m_name).c_str(),
-					    fmt::sprintf("%s vs #mu^{-} #eta;#mu^{-} #eta;%s", m_title, m_ytitle).c_str(),
-					    nxbins, -maxMuEta, maxMuEta,
-					    nybins, valmin, valmax);
-
-    m_h2_map[xAxis::MM_PHI] = fs.make<TH2F>(fmt::sprintf("%sVsMuMinusPhi", m_name).c_str(),
-					    fmt::sprintf("%s vs #mu^{-} #phi;#mu^{-} #phi [rad];%s", m_title, m_ytitle).c_str(),
-					    nxbins, -M_PI, M_PI,
-					    nybins, valmin, valmax);
-    // clang-format on
-
-    // flip the is booked bit
-    m_isBooked = true;
-  }
-
-  //________________________________________________________________________________//
-  void fillPlots(const float val, const std::pair<TLorentzVector, TLorentzVector>& momenta) {
-    if (!m_isBooked) {
-      edm::LogError("PlotsVsDiMuKinematics")
-          << "In" << __FUNCTION__ << "," << __LINE__ << "trying to fill a plot not booked!" << std::endl;
-      return;
-    }
-
-    m_h2_map[xAxis::Z_ETA]->Fill((momenta.first + momenta.second).Eta(), val);
-    m_h2_map[xAxis::Z_PHI]->Fill((momenta.first + momenta.second).Phi(), val);
-    m_h2_map[xAxis::MP_ETA]->Fill((momenta.first).Eta(), val);
-    m_h2_map[xAxis::MP_PHI]->Fill((momenta.first).Phi(), val);
-    m_h2_map[xAxis::MM_ETA]->Fill((momenta.second).Eta(), val);
-    m_h2_map[xAxis::MM_PHI]->Fill((momenta.second).Phi(), val);
-  }
-
-private:
-  enum xAxis { Z_PHI, Z_ETA, MP_PHI, MP_ETA, MM_PHI, MM_ETA };
-  const std::vector<xAxis> axisChoices = {
-      xAxis::Z_PHI, xAxis::Z_ETA, xAxis::MP_PHI, xAxis::MP_ETA, xAxis::MM_PHI, xAxis::MM_ETA};
-
-  const std::string m_name;
-  const std::string m_title;
-  const std::string m_ytitle;
-
-  bool m_isBooked;
-
-  std::map<xAxis, TH2F*> m_h2_map;
-};
 
 //
 // class declaration
@@ -268,14 +106,14 @@ private:
 
   // 2D maps
 
-  PlotsVsDiMuKinematics CosPhiPlots = PlotsVsDiMuKinematics();
-  PlotsVsDiMuKinematics CosPhi3DPlots = PlotsVsDiMuKinematics();
-  PlotsVsDiMuKinematics VtxProbPlots = PlotsVsDiMuKinematics();
-  PlotsVsDiMuKinematics VtxDistPlots = PlotsVsDiMuKinematics();
-  PlotsVsDiMuKinematics VtxDist3DPlots = PlotsVsDiMuKinematics();
-  PlotsVsDiMuKinematics VtxDistSigPlots = PlotsVsDiMuKinematics();
-  PlotsVsDiMuKinematics VtxDist3DSigPlots = PlotsVsDiMuKinematics();
-  PlotsVsDiMuKinematics ZMassPlots = PlotsVsDiMuKinematics();
+  DiLeptonHelp::PlotsVsKinematics CosPhiPlots = DiLeptonHelp::PlotsVsKinematics();
+  DiLeptonHelp::PlotsVsKinematics CosPhi3DPlots = DiLeptonHelp::PlotsVsKinematics();
+  DiLeptonHelp::PlotsVsKinematics VtxProbPlots = DiLeptonHelp::PlotsVsKinematics();
+  DiLeptonHelp::PlotsVsKinematics VtxDistPlots = DiLeptonHelp::PlotsVsKinematics();
+  DiLeptonHelp::PlotsVsKinematics VtxDist3DPlots = DiLeptonHelp::PlotsVsKinematics();
+  DiLeptonHelp::PlotsVsKinematics VtxDistSigPlots = DiLeptonHelp::PlotsVsKinematics();
+  DiLeptonHelp::PlotsVsKinematics VtxDist3DSigPlots = DiLeptonHelp::PlotsVsKinematics();
+  DiLeptonHelp::PlotsVsKinematics ZMassPlots = DiLeptonHelp::PlotsVsKinematics();
 
   const edm::ESGetToken<TransientTrackBuilder, TransientTrackRecord> ttbESToken_;
 

--- a/Alignment/OfflineValidation/test/DiElectronVertexValidation_cfg.py
+++ b/Alignment/OfflineValidation/test/DiElectronVertexValidation_cfg.py
@@ -56,7 +56,7 @@ options.register ('myseed',
                   "seed number")
 
 options.register ('myfile',
-                  'root://cms-xrd-global.cern.ch//store/relval/CMSSW_10_6_1/RelValZMM_13/GEN-SIM-RECO/PU25ns_106X_mc2017_realistic_v6_HS-v1/10000/44690279-DDF3-0D43-B92D-F5CB57EF7E6A.root', # default value
+                  'root://cms-xrd-global.cern.ch//store/relval/CMSSW_10_6_1/RelValZEE_13/GEN-SIM-RECO/PU25ns_106X_mc2017_realistic_v6_HS-v1/10000/B3F7544E-F34D-9D42-B897-21820FDE0331.root',
                   VarParsing.VarParsing.multiplicity.singleton,
                   VarParsing.VarParsing.varType.string,
                   "file name")
@@ -79,7 +79,7 @@ if(options.FileList):
     print("FileList:           ", options.FileList)
 else:
     print("inputFile:          ", options.myfile)
-print("outputFile:         ", "DiMuonVertexValidation_{fname}_{fseed}.root".format(fname = options.outputName,fseed=options.myseed))
+print("outputFile:         ", "DiElectronVertexValidation_{fname}_{fseed}.root".format(fname = options.outputName,fseed=options.myseed))
 print("era:                ", options.era)
 print("conditionGT:        ", options.GlobalTag)
 print("conditionOverwrite: ", options.records)
@@ -142,25 +142,10 @@ from Configuration.AlCa.GlobalTag import GlobalTag
 process.GlobalTag = GlobalTag(process.GlobalTag, options.GlobalTag, '')
 process.GlobalTag.toGet = cms.VPSet(*records)
 
-'''
-process.GlobalTag.toGet = cms.VPSet(
-    cms.PSet(record = cms.string("TrackerAlignmentRcd"),
-             tag = cms.string("TrackerAlignment_Upgrade2017_design_v4"),
-             #tag = cms.string("TrackerAlignment_2017_ultralegacymc_v1"),
-             connect = cms.string("frontier://FrontierProd/CMS_CONDITIONS")
-         ),
-    cms.PSet(record = cms.string("TrackerAlignmentErrorExtendedRcd"),
-             tag = cms.string("TrackerAlignmentErrorsExtended_Upgrade2017_design_v0"),
-             #tag = cms.string("TrackerAlignmentExtendedErrors_2017_ultralegacymc_v1"),
-             connect = cms.string("frontier://FrontierProd/CMS_CONDITIONS")
-         )
-)
-'''
-
 process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(options.maxEvents) )
 
 #process.load('FWCore.MessageService.MessageLogger_cfi')
-#process.MessageLogger.cerr.FwkReport.reportEvery = 1
+#process.MessageLogger.cerr.FwkReport.reportEvery = 1000
 
 ###################################################################
 # Messages
@@ -168,8 +153,9 @@ process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(options.maxE
 process.load('FWCore.MessageService.MessageLogger_cfi')   
 process.MessageLogger.cerr.enable = False
 process.MessageLogger.TrackRefitter=dict()
+process.MessageLogger.GsfTrackRefitter=dict()
 process.MessageLogger.PrimaryVertexProducer=dict()
-process.MessageLogger.DiMuonVertexValidation=dict()
+process.MessageLogger.DiElectronVertexValidation=dict()
 process.MessageLogger.DiLeptonHelpCounts=dict()
 process.MessageLogger.PlotsVsKinematics=dict()
 process.MessageLogger.cout = cms.untracked.PSet(
@@ -177,9 +163,9 @@ process.MessageLogger.cout = cms.untracked.PSet(
     threshold = cms.untracked.string("INFO"),
     default   = cms.untracked.PSet(limit = cms.untracked.int32(0)),                       
     FwkReport = cms.untracked.PSet(limit = cms.untracked.int32(-1),
-                                   reportEvery = cms.untracked.int32(100)
+                                   reportEvery = cms.untracked.int32(1000)
                                    ),                                                      
-    DiMuonVertexValidation = cms.untracked.PSet( limit = cms.untracked.int32(-1)),
+    DiElectronVertexValidation = cms.untracked.PSet( limit = cms.untracked.int32(-1)),
     DiLeptonHelpCounts = cms.untracked.PSet( limit = cms.untracked.int32(-1)),
     enableStatistics = cms.untracked.bool(True)
     )
@@ -195,9 +181,7 @@ else:
     readFiles = cms.untracked.vstring([options.myfile])
 
 process.source = cms.Source("PoolSource",
-                            fileNames = readFiles,
-                            #skipEvents = cms.untracked.uint32(45000)
-)
+                            fileNames = readFiles)
 
 ###################################################################
 # TransientTrack from https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideTransientTracks
@@ -219,10 +203,26 @@ process.load("RecoTracker.TrackProducer.TrackRefitters_cff")
 import RecoTracker.TrackProducer.TrackRefitters_cff
 process.TrackRefitter = RecoTracker.TrackProducer.TrackRefitter_cfi.TrackRefitter.clone()
 process.TrackRefitter.src = "generalTracks"
-#process.TrackRefitter.src = "ALCARECOTkAlDiMuonVertexTracks"
 process.TrackRefitter.TrajectoryInEvent = True
 process.TrackRefitter.NavigationSchool = ''
 process.TrackRefitter.TTRHBuilder = "WithAngleAndTemplate"
+
+####################################################################
+# Load  electron configuration files
+####################################################################
+process.load("TrackingTools.GsfTracking.GsfElectronFit_cff")
+
+####################################################################
+# GSF Track Refitter
+####################################################################
+process.load("TrackingTools.GsfTracking.fwdGsfElectronPropagator_cff")
+process.load("RecoTracker.TrackProducer.GsfTrackRefitter_cff")
+process.GsfTrackRefitter = RecoTracker.TrackProducer.GsfTrackRefitter_cff.GsfTrackRefitter.clone()
+process.GsfTrackRefitter.src = cms.InputTag('electronGsfTracks')  
+process.GsfTrackRefitter.TrajectoryInEvent = True
+process.GsfTrackRefitter.AlgorithmName = cms.string('gsf')
+#process.GsfTrackRefitter.NavigationSchool = ''
+#process.GsfTrackRefitter.TTRHBuilder = "WithAngleAndTemplate"
 
 ####################################################################
 # Sequence
@@ -230,7 +230,8 @@ process.TrackRefitter.TTRHBuilder = "WithAngleAndTemplate"
 process.seqTrackselRefit = cms.Sequence(process.offlineBeamSpot*
                                         # in case NavigatioSchool is set !=''
                                         #process.MeasurementTrackerEvent*
-                                        process.TrackRefitter)
+                                        process.TrackRefitter*
+                                        process.GsfTrackRefitter)
 
 ####################################################################
 # Re-do vertices
@@ -242,16 +243,11 @@ process.offlinePrimaryVerticesFromRefittedTrks.TrackLabel = cms.InputTag("TrackR
 ####################################################################
 # Output file
 ####################################################################
-process.TFileService = cms.Service("TFileService",fileName=cms.string("DiMuonVertexValidation_"+options.outputName+"_"+options.myseed+".root"))
+process.TFileService = cms.Service("TFileService",fileName=cms.string("DiElectronVertexValidation_"+options.outputName+"_"+options.myseed+".root"))
 
 # Additional output definition
-process.analysis = cms.EDAnalyzer("DiMuonVertexValidation",
-                                  useReco = cms.bool(True),
-                                  ## the two parameters below are mutually exclusive,
-                                  ## depending if RECO or ALCARECO is used
-                                  muons  = cms.InputTag('muons'),
-                                  #muonTracks = cms.InputTag('ALCARECOTkAlDiMuon'),
-                                  tracks = cms.InputTag('TrackRefitter'),
+process.analysis = cms.EDAnalyzer("DiElectronVertexValidation",
+                                  gsfTracks = cms.InputTag('GsfTrackRefitter'),
                                   vertices = cms.InputTag('offlinePrimaryVerticesFromRefittedTrks'))
 
 ####################################################################
@@ -259,5 +255,4 @@ process.analysis = cms.EDAnalyzer("DiMuonVertexValidation",
 ####################################################################
 process.p = cms.Path(process.seqTrackselRefit                        +
                      process.offlinePrimaryVerticesFromRefittedTrks  +
-                     process.analysis
-                     )
+                     process.analysis)

--- a/Alignment/OfflineValidation/test/DiMuonVertexValidation_cfg.py
+++ b/Alignment/OfflineValidation/test/DiMuonVertexValidation_cfg.py
@@ -160,22 +160,27 @@ process.GlobalTag.toGet = cms.VPSet(
 process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(options.maxEvents) )
 
 #process.load('FWCore.MessageService.MessageLogger_cfi')
-#process.MessageLogger.cerr.FwkReport.reportEvery = 1000
+#process.MessageLogger.cerr.FwkReport.reportEvery = 1
 
 ###################################################################
 # Messages
 ###################################################################
 process.load('FWCore.MessageService.MessageLogger_cfi')   
 process.MessageLogger.cerr.enable = False
-process.MessageLogger.DiMuonVertexValidation=dict()  
+process.MessageLogger.TrackRefitter=dict()
+process.MessageLogger.offlinePrimaryVerticesFromRefittedTrks=dict()
+process.MessageLogger.DiMuonVertexValidation=dict()
+process.MessageLogger.DiLeptonHelpCounts=dict()
+process.MessageLogger.PlotsVsKinematics=dict()
 process.MessageLogger.cout = cms.untracked.PSet(
     enable = cms.untracked.bool(True),
     threshold = cms.untracked.string("INFO"),
     default   = cms.untracked.PSet(limit = cms.untracked.int32(0)),                       
     FwkReport = cms.untracked.PSet(limit = cms.untracked.int32(-1),
-                                   reportEvery = cms.untracked.int32(1000)
+                                   reportEvery = cms.untracked.int32(100)
                                    ),                                                      
     DiMuonVertexValidation = cms.untracked.PSet( limit = cms.untracked.int32(-1)),
+    DiLeptonHelpCounts = cms.untracked.PSet( limit = cms.untracked.int32(-1)),
     enableStatistics = cms.untracked.bool(True)
     )
 
@@ -214,6 +219,7 @@ process.load("RecoTracker.TrackProducer.TrackRefitters_cff")
 import RecoTracker.TrackProducer.TrackRefitters_cff
 process.TrackRefitter = RecoTracker.TrackProducer.TrackRefitter_cfi.TrackRefitter.clone()
 process.TrackRefitter.src = "generalTracks"
+#process.TrackRefitter.src = "ALCARECOTkAlDiMuonVertexTracks"
 process.TrackRefitter.TrajectoryInEvent = True
 process.TrackRefitter.NavigationSchool = ''
 process.TrackRefitter.TTRHBuilder = "WithAngleAndTemplate"
@@ -240,8 +246,11 @@ process.TFileService = cms.Service("TFileService",fileName=cms.string("DiMuonVer
 
 # Additional output definition
 process.analysis = cms.EDAnalyzer("DiMuonVertexValidation",
+                                  useReco = cms.bool(True),
+                                  ## the two parameters below are mutually exclusive,
+                                  ## depending if RECO or ALCARECO is used
                                   muons  = cms.InputTag('muons'),
-                                  #tracks = cms.InputTag('generalTracks'),
+                                  #muonTracks = cms.InputTag('ALCARECOTkAlDiMuon'),
                                   tracks = cms.InputTag('TrackRefitter'),
                                   vertices = cms.InputTag('offlinePrimaryVerticesFromRefittedTrks'))
 
@@ -250,4 +259,5 @@ process.analysis = cms.EDAnalyzer("DiMuonVertexValidation",
 ####################################################################
 process.p = cms.Path(process.seqTrackselRefit                        +
                      process.offlinePrimaryVerticesFromRefittedTrks  +
-                     process.analysis)
+                     process.analysis
+                     )


### PR DESCRIPTION
#### PR description:

This is a follow-up of PR https://github.com/cms-sw/cmssw/pull/33709.
Adds a new plugin `DiElectronVertexValidation`plugin which closely follows the analysis done in `DiMuonVertexValidation`. 
To avoid code duplication, common classes and methods are moved in the separate `DiLeptonVertexHelpers`file.
In commit  2fe25ea the possibility to run on the ALCARECO files produced with the new producer `ALCARECOTkAlDiMuonAndVertex` introduced in PR https://github.com/cms-sw/cmssw/pull/33770, as opposed to plain RECO files, has been added.
A complete configuration example is provided, but the interlace of the new plugin with the all-in-one tool was not implemented as there is anyway an improved version of the framework that is being worked up right now and should land into cmssw in the near future.
Once that's available the analysis will be included there.

#### PR validation:

Standalone private tests.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Not a backport, no backport needed.