### PR TITLE
Run3-gem62F Use of alternative ESGetToken initialization for DDD/DD4Hep in Muon/HGCal

### DIFF
--- a/Geometry/HGCalCommonData/plugins/HGCalParametersESModule.cc
+++ b/Geometry/HGCalCommonData/plugins/HGCalParametersESModule.cc
@@ -43,8 +43,10 @@ HGCalParametersESModule::HGCalParametersESModule(const edm::ParameterSet& iC) {
                                 << namet_ << " and fromDD4Hep flag " << fromDD4Hep_;
 #endif
   auto cc = setWhatProduced(this, namex_);
-  cpvTokenDDD_ = cc.consumes<DDCompactView>(edm::ESInputTag());
-  cpvTokenDD4Hep_ = cc.consumesFrom<cms::DDCompactView, IdealGeometryRecord>(edm::ESInputTag());
+  if (fromDD4Hep_)
+    cpvTokenDD4Hep_ = cc.consumesFrom<cms::DDCompactView, IdealGeometryRecord>(edm::ESInputTag());
+  else
+    cpvTokenDDD_ = cc.consumes<DDCompactView>(edm::ESInputTag());
 }
 
 void HGCalParametersESModule::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {

--- a/Geometry/MuonNumbering/plugins/MuonGeometryConstantsESModule.cc
+++ b/Geometry/MuonNumbering/plugins/MuonGeometryConstantsESModule.cc
@@ -32,8 +32,10 @@ private:
 MuonGeometryConstantsESModule::MuonGeometryConstantsESModule(const edm::ParameterSet& ps) {
   fromDD4Hep_ = ps.getParameter<bool>("fromDD4Hep");
   auto cc = setWhatProduced(this);
-  cpvTokenDD4Hep_ = cc.consumesFrom<cms::DDCompactView, IdealGeometryRecord>(edm::ESInputTag());
-  cpvTokenDDD_ = cc.consumesFrom<DDCompactView, IdealGeometryRecord>(edm::ESInputTag());
+  if (fromDD4Hep_)
+    cpvTokenDD4Hep_ = cc.consumesFrom<cms::DDCompactView, IdealGeometryRecord>(edm::ESInputTag());
+  else
+    cpvTokenDDD_ = cc.consumesFrom<DDCompactView, IdealGeometryRecord>(edm::ESInputTag());
 
 #ifdef EDM_ML_DEBUG
   edm::LogVerbatim("Geometry") << "MuonGeometryConstantsESModule::MuonGeometryConstantsESModule called with dd4hep: "


### PR DESCRIPTION
#### PR description:

Use of alternative ESGetToken initialization for DDD/DD4Hep in Muon/HGCal

#### PR validation:

Use runTheMatrix test workflows

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Nothing special