### PR TITLE
Updates of the TP reconstruction algorithm to fix the TP energy saturation effect

### DIFF
--- a/SimCalorimetry/HcalTrigPrimAlgos/interface/HcalTriggerPrimitiveAlgo.h
+++ b/SimCalorimetry/HcalTrigPrimAlgos/interface/HcalTriggerPrimitiveAlgo.h
@@ -82,6 +82,9 @@ public:
   void setRCTScaleShift(int);
 
   void setUpgradeFlags(bool hb, bool he, bool hf);
+
+  void setFixSaturationFlag(bool fix_saturation);
+
   void overrideParameters(const edm::ParameterSet& ps);
 
 private:
@@ -103,7 +106,7 @@ private:
   /// adds the actual digis
   void analyze(IntegerCaloSamples& samples, HcalTriggerPrimitiveDigi& result);
   // 2017 and later: QIE11
-  void analyzeQIE11(IntegerCaloSamples& samples, HcalTriggerPrimitiveDigi& result, const HcalFinegrainBit& fg_algo);
+  void analyzeQIE11(IntegerCaloSamples& samples, std::vector<bool> sample_saturation, HcalTriggerPrimitiveDigi& result, const HcalFinegrainBit& fg_algo);
   // Version 0: RCT
   void analyzeHF(IntegerCaloSamples& samples, HcalTriggerPrimitiveDigi& result, const int hf_lumi_shift);
   // Version 1: 1x1
@@ -156,6 +159,10 @@ private:
   typedef std::map<HcalTrigTowerDetId, IntegerCaloSamples> SumMap;
   SumMap theSumMap;
 
+  typedef std::map<HcalTrigTowerDetId, std::vector<bool>> SatMap;
+  SatMap theSatMap;
+
+
   struct HFDetails {
     IntegerCaloSamples long_fiber;
     IntegerCaloSamples short_fiber;
@@ -203,6 +210,8 @@ private:
   bool upgrade_he_ = false;
   bool upgrade_hf_ = false;
 
+  bool fix_saturation_ = false;
+
   edm::ParameterSet override_parameters_;
 
   bool override_adc_hf_ = false;
@@ -243,6 +252,7 @@ void HcalTriggerPrimitiveAlgo::run(const HcalTPGCoder* incoder,
   conditions_ = conditions;
 
   theSumMap.clear();
+  theSatMap.clear();
   theTowerMapFGSum.clear();
   HF_Veto.clear();
   fgMap_.clear();
@@ -286,13 +296,17 @@ void HcalTriggerPrimitiveAlgo::run(const HcalTPGCoder* incoder,
       if (fgMap_.find(item.first) != fgMap_.end()) {
         analyze(item.second, result.back());
       } else if (fgUpgradeMap_.find(item.first) != fgUpgradeMap_.end()) {
-        analyzeQIE11(item.second, result.back(), fg_algo);
+        SatMap::iterator item_sat = theSatMap.find(detId);
+
+        if (item_sat == theSatMap.end()) analyzeQIE11(item.second, std::vector<bool>(), result.back(), fg_algo);
+        else analyzeQIE11(item.second, item_sat->second, result.back(), fg_algo);
       }
     }
   }
 
   // Free up some memory
   theSumMap.clear();
+  theSatMap.clear();
   theTowerMapFGSum.clear();
   HF_Veto.clear();
   fgMap_.clear();

--- a/SimCalorimetry/HcalTrigPrimAlgos/src/HcalTriggerPrimitiveAlgo.cc
+++ b/SimCalorimetry/HcalTrigPrimAlgos/src/HcalTriggerPrimitiveAlgo.cc
@@ -76,6 +76,10 @@ void HcalTriggerPrimitiveAlgo::setUpgradeFlags(bool hb, bool he, bool hf) {
   upgrade_hf_ = hf;
 }
 
+void HcalTriggerPrimitiveAlgo::setFixSaturationFlag(bool fix_saturation) {
+  fix_saturation_ = fix_saturation;
+}
+
 void HcalTriggerPrimitiveAlgo::overrideParameters(const edm::ParameterSet& ps) {
   override_parameters_ = ps;
 
@@ -100,6 +104,7 @@ void HcalTriggerPrimitiveAlgo::addSignal(const HBHEDataFrame& frame) {
   IntegerCaloSamples samples1(ids[0], int(frame.size()));
 
   samples1.setPresamples(frame.presamples());
+//  std::cout<<"ieta: "<<frame.id().ieta()<<", "<<frame.id().iphi()<<", "<<frame.id().depth()<<std::endl;
   incoder_->adc2Linear(frame, samples1);
 
   std::vector<bool> msb;
@@ -278,12 +283,36 @@ void HcalTriggerPrimitiveAlgo::addSignal(const QIE11DataFrame& frame) {
 void HcalTriggerPrimitiveAlgo::addSignal(const IntegerCaloSamples& samples) {
   HcalTrigTowerDetId id(samples.id());
   SumMap::iterator itr = theSumMap.find(id);
+
   if (itr == theSumMap.end()) {
     theSumMap.insert(std::make_pair(id, samples));
   } else {
     // wish CaloSamples had a +=
     for (int i = 0; i < samples.size(); ++i) {
       (itr->second)[i] += samples[i];
+    }
+  }
+
+  // if fix_saturation == true, keep track of tower with saturated input LUT
+  if (fix_saturation_){
+    SatMap::iterator itr_sat = theSatMap.find(id);
+
+    assert((itr == theSumMap.end()) == (itr_sat == theSatMap.end()));
+
+    if (itr_sat == theSatMap.end()){ 
+      vector<bool> check_sat;
+      for (int i = 0; i < samples.size(); ++i) {
+        if (samples[i] >= 0x3ff){
+          check_sat.push_back(true);
+        }
+        else check_sat.push_back(false);
+      }
+      theSatMap.insert(std::make_pair(id, check_sat));
+
+    }else{
+      for (int i = 0; i < samples.size(); ++i) {
+        if (samples[i] >= 0x3ff) (itr_sat->second)[i] = true; 
+      }
     }
   }
 }
@@ -371,6 +400,7 @@ void HcalTriggerPrimitiveAlgo::analyze(IntegerCaloSamples& samples, HcalTriggerP
 }
 
 void HcalTriggerPrimitiveAlgo::analyzeQIE11(IntegerCaloSamples& samples,
+                                            vector<bool> sample_saturation,
                                             HcalTriggerPrimitiveDigi& result,
                                             const HcalFinegrainBit& fg_algo) {
   HcalDetId detId(samples.id());
@@ -398,15 +428,22 @@ void HcalTriggerPrimitiveAlgo::analyzeQIE11(IntegerCaloSamples& samples,
   IntegerCaloSamples sum(samples.id(), samples.size());
 
   std::vector<HcalTrigTowerDetId> ids = theTrigTowerGeometry->towerIds(detId);
+
+  // keep track of tower with saturated energy and force the total TP saturated
+  bool force_saturation[samples.size()] = {false};
+
   //slide algo window
   for (unsigned int ibin = 0; ibin < dgSamples - shrink; ++ibin) {
     int algosumvalue = 0;
+    bool check_sat =  false;
     for (unsigned int i = 0; i < filterSamples; i++) {
       //add up value * scale factor
       // In addition, divide by two in the 10 degree phi segmentation region
       // to mimic 5 degree segmentation for the trigger
       unsigned int sample = samples[ibin + i];
-      if (sample > QIE11_MAX_LINEARIZATION_ET)
+      if (fix_saturation_ && (sample_saturation.size() > ibin + i))
+        check_sat = (sample_saturation[ibin+i] | (sample > QIE11_MAX_LINEARIZATION_ET));
+      else if (sample > QIE11_MAX_LINEARIZATION_ET)
         sample = QIE11_MAX_LINEARIZATION_ET;
 
       // Usually use a segmentation factor of 1.0 but for ieta >= 21 use 0.5
@@ -426,6 +463,8 @@ void HcalTriggerPrimitiveAlgo::analyzeQIE11(IntegerCaloSamples& samples,
     //else if (algosumvalue>QIE11_LINEARIZATION_ET) sum[ibin]=QIE11_LINEARIZATION_ET;
     else
       sum[ibin] = algosumvalue;  //assign value to sum[]
+
+    if (check_sat) force_saturation[ibin] = true;
   }
 
   std::vector<int> finegrain(tpSamples, false);
@@ -448,6 +487,8 @@ void HcalTriggerPrimitiveAlgo::analyzeQIE11(IntegerCaloSamples& samples,
 
     if (isPeak) {
       output[ibin] = std::min<unsigned int>(sum[idx], QIE11_MAX_LINEARIZATION_ET);
+      if (fix_saturation_ && force_saturation[idx]) output[ibin] = QIE11_MAX_LINEARIZATION_ET;
+
     } else {
       // Not a peak
       output[ibin] = 0;

--- a/SimCalorimetry/HcalTrigPrimProducers/python/hcaltpdigi_cfi.py
+++ b/SimCalorimetry/HcalTrigPrimProducers/python/hcaltpdigi_cfi.py
@@ -4,6 +4,7 @@ from CalibCalorimetry.CaloTPG.CaloTPGTranscoder_cfi import tpScales
 from Configuration.Eras.Modifier_run2_HE_2017_cff import run2_HE_2017
 from Configuration.Eras.Modifier_run2_HF_2017_cff import run2_HF_2017
 from Configuration.Eras.Modifier_run3_HB_cff import run3_HB
+from Configuration.Eras.Modifier_run3_common_cff import run3_common
 
 LSParameter =cms.untracked.PSet(
 HcalFeatureHFEMBit= cms.bool(False),
@@ -66,6 +67,7 @@ simHcalTriggerPrimitiveDigis = cms.EDProducer("HcalTrigPrimDigiProducer",
     upgradeHB = cms.bool(False),
     upgradeHE = cms.bool(False),
 
+    applySaturationFix = cms.bool(False), # Apply the TP energy saturation fix for Peak Finder Algorithm only for Run3 
     # parameters = cms.untracked.PSet(
     #     FGVersionHBHE=cms.uint32(0),
     #     TDCMask=cms.uint64(0xFFFFFFFFFFFFFFFF),
@@ -96,4 +98,6 @@ run2_HF_2017.toModify(simHcalTriggerPrimitiveDigis,
 )
 run2_HF_2017.toModify(tpScales.HF, NCTShift=cms.int32(2))
 run3_HB.toModify(simHcalTriggerPrimitiveDigis, upgradeHB=cms.bool(True))
+run3_common.toModify(simHcalTriggerPrimitiveDigis, applySaturationFix=cms.bool(True))
+
 run3_HB.toModify(tpScales.HBHE, LSBQIE11Overlap=cms.double(1/16.))

--- a/SimCalorimetry/HcalTrigPrimProducers/src/HcalTrigPrimDigiProducer.cc
+++ b/SimCalorimetry/HcalTrigPrimProducers/src/HcalTrigPrimDigiProducer.cc
@@ -46,6 +46,7 @@ HcalTrigPrimDigiProducer::HcalTrigPrimDigiProducer(const edm::ParameterSet& ps)
   }
   theAlgo_.setUpgradeFlags(upgrades[0], upgrades[1], upgrades[2]);
   theAlgo_.setWeightsQIE11(ps.getParameter<edm::ParameterSet>("weightsQIE11"));
+  theAlgo_.setFixSaturationFlag(ps.getParameter<bool>("applySaturationFix"));
 
   HFEMB_ = false;
   if (ps.exists("LSConfig")) {


### PR DESCRIPTION
#### PR description:

This PR updates the Trigger Primitive(TP) reconstruction algorithm to fix the effect that the saturation in the input LUT makes the total TP energy underestimated. To fix the saturation effect, the total energy of TPs is forced to be saturated when the saturation in the input LUT is found before the sum over depths and the peak finder algorithm. This is achieved in the implementation by having the map of saturated towers in `HcalTriggerPrimitiveAlgo` and check the saturation after the peak finder algorithm, to make the TP energy saturated if the saturation is found at the input level. This PR is only applicable for a Run3 condition and can be toggled off by the parameter `applySaturationFix` in `simHcalTriggerPrimitiveDigis`.  The detailed motivation and effect of changes of this PR are presented in [presentation by Taeun Kwon](https://indico.cern.ch/event/1049943/contributions/4416052/attachments/2268682/3852452/CMSWEEK_Commissioning_1TS_Scheme.pdf) from slide 14 to 21

<!-- Please replace this text with a description of the feature proposed or problem addressed, specifying:
  - what changes are expected in the output if any, 
  - what other PRs or externals it depends upon if any,
  - link to any additional material useful to provide a documentation for this PR (slides, JIRA tickets, related pull requestes, hypernews, TWiki or Indico pages)  -->

#### PR validation:

<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->

A basic technical test was performed: `runTheMatrix.py -l limited -i all --ibeos`

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This PR is not a backport and shouldn't be backported.

<!-- Please replace this text with any link to  -->
