### PR TITLE
Finalize migration to esConsumes of `Alignment/TrackerAlignment` and `Alignment/SurveyAnalysis`

### DIFF
--- a/Alignment/SurveyAnalysis/interface/SurveyInputBase.h
+++ b/Alignment/SurveyAnalysis/interface/SurveyInputBase.h
@@ -10,11 +10,11 @@
  *  \author Chung Khim Lae
  */
 
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 
 class Alignable;
 
-class SurveyInputBase : public edm::EDAnalyzer {
+class SurveyInputBase : public edm::one::EDAnalyzer<> {
 public:
   ~SurveyInputBase() override;
 

--- a/Alignment/SurveyAnalysis/plugins/CreateSurveyRcds.h
+++ b/Alignment/SurveyAnalysis/plugins/CreateSurveyRcds.h
@@ -13,7 +13,20 @@
 
 #include "Alignment/SurveyAnalysis/interface/SurveyInputBase.h"
 #include "Alignment/SurveyAnalysis/interface/SurveyInputTextReader.h"
-#include "FWCore/Framework/interface/ESHandle.h"
+
+#include "Geometry/Records/interface/IdealGeometryRecord.h"
+#include "Geometry/Records/interface/TrackerTopologyRcd.h"
+
+#include "CondFormats/GeometryObjects/interface/PTrackerParameters.h"
+#include "Geometry/Records/interface/PTrackerParametersRcd.h"
+
+#include "Alignment/CommonAlignment/interface/SurveyDet.h"
+#include "Alignment/TrackerAlignment/interface/AlignableTracker.h"
+
+#include "CondFormats/Alignment/interface/Alignments.h"
+#include "CondFormats/AlignmentRecord/interface/TrackerAlignmentRcd.h"
+#include "CondFormats/Alignment/interface/AlignmentErrorsExtended.h"
+#include "CondFormats/AlignmentRecord/interface/TrackerAlignmentErrorExtendedRcd.h"
 
 class AlignableSurface;
 class Alignments;
@@ -36,6 +49,13 @@ private:
   /// default values for survey uncertainty
   AlgebraicVector getStructureErrors(int, int);
 
+  // es tokens
+  const edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> tTopoToken_;
+  const edm::ESGetToken<GeometricDet, IdealGeometryRecord> geomDetToken_;
+  const edm::ESGetToken<PTrackerParameters, PTrackerParametersRcd> ptpToken_;
+  const edm::ESGetToken<Alignments, TrackerAlignmentRcd> aliToken_;
+  const edm::ESGetToken<AlignmentErrorsExtended, TrackerAlignmentErrorExtendedRcd> aliErrToken_;
+
   std::string m_inputGeom;
   double m_inputSimpleMis;
   bool m_generatedRandom;
@@ -44,8 +64,6 @@ private:
   SurveyInputTextReader::MapType uIdMap;
 
   std::string textFileName;
-
-  edm::ESHandle<Alignments> alignments;
 };
 
 #endif

--- a/Alignment/SurveyAnalysis/plugins/DTSurveyConvert.cc
+++ b/Alignment/SurveyAnalysis/plugins/DTSurveyConvert.cc
@@ -3,15 +3,10 @@
 #include "Alignment/MuonAlignment/interface/MuonAlignment.h"
 #include "Alignment/SurveyAnalysis/interface/DTSurvey.h"
 #include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
-// #include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "Geometry/DTGeometry/interface/DTGeometry.h"
-#include "Geometry/Records/interface/MuonGeometryRecord.h"
-
 #include "Alignment/SurveyAnalysis/plugins/DTSurveyConvert.h"
 
-DTSurveyConvert::DTSurveyConvert(const edm::ParameterSet &iConfig) {
+DTSurveyConvert::DTSurveyConvert(const edm::ParameterSet &iConfig) : muonGeoToken_(esConsumes()) {
   //now do what ever initialization is needed
   nameWheel_m2 = iConfig.getUntrackedParameter<std::string>("nameWheel_m2");
   nameWheel_m1 = iConfig.getUntrackedParameter<std::string>("nameWheel_m1");
@@ -37,8 +32,7 @@ DTSurveyConvert::DTSurveyConvert(const edm::ParameterSet &iConfig) {
 
 // ------------ method called to for each event  ------------
 void DTSurveyConvert::analyze(const edm::Event &, const edm::EventSetup &iSetup) {
-  edm::ESHandle<DTGeometry> pDD;
-  iSetup.get<MuonGeometryRecord>().get(pDD);
+  const DTGeometry *pDD = &iSetup.getData(muonGeoToken_);
 
   std::ofstream outFile(outputFileName.c_str());
 

--- a/Alignment/SurveyAnalysis/plugins/DTSurveyConvert.h
+++ b/Alignment/SurveyAnalysis/plugins/DTSurveyConvert.h
@@ -19,16 +19,21 @@
 //
 //
 
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
+#include "Geometry/DTGeometry/interface/DTGeometry.h"
+#include "Geometry/Records/interface/MuonGeometryRecord.h"
 
 class DTSurvey;
 
-class DTSurveyConvert : public edm::EDAnalyzer {
+class DTSurveyConvert : public edm::one::EDAnalyzer<> {
 public:
   explicit DTSurveyConvert(const edm::ParameterSet &);
 
 private:
   void analyze(const edm::Event &, const edm::EventSetup &) override;
+
+  const edm::ESGetToken<DTGeometry, MuonGeometryRecord> muonGeoToken_;
+
   std::vector<DTSurvey *> wheelList;
   std::string nameWheel_m2;
   std::string nameWheel_m1;

--- a/Alignment/SurveyAnalysis/plugins/SurveyDBUploader.h
+++ b/Alignment/SurveyAnalysis/plugins/SurveyDBUploader.h
@@ -17,14 +17,14 @@
  *  \author Chung Khim Lae
  */
 
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 
 class Alignable;
 class Alignments;
 class AlignTransform;
 struct SurveyErrors;
 
-class SurveyDBUploader : public edm::EDAnalyzer {
+class SurveyDBUploader : public edm::one::EDAnalyzer<> {
   typedef AlignTransform SurveyValue;
   typedef Alignments SurveyValues;
 

--- a/Alignment/SurveyAnalysis/plugins/SurveyDataConverter.cc
+++ b/Alignment/SurveyAnalysis/plugins/SurveyDataConverter.cc
@@ -1,6 +1,7 @@
 
 // Framework
 #include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h" 
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
@@ -17,8 +18,16 @@
 //__________________________________________________________________________________________________
 SurveyDataConverter::SurveyDataConverter(const edm::ParameterSet& iConfig) : theParameterSet(iConfig) {}
 
+//SurveyDataConverter::SurveyDataConverter(const edm::EventSetup& setup, edm::ConsumesCollector iC) :
+//ttopoToken_(iC.esConsumes<TrackerTopology, TrackerTopologyRcd, edm::Transition::BeginRun>())
+//{
+//  const TrackerTopology* const tTopo = &setup.getData(ttopoToken_);
+//
+//}
+
 //__________________________________________________________________________________________________
-void SurveyDataConverter::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
+void SurveyDataConverter::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) 
+{
   //Retrieve tracker topology from geometry
   edm::ESHandle<TrackerTopology> tTopoHandle;
   iSetup.get<TrackerTopologyRcd>().get(tTopoHandle);
@@ -50,8 +59,10 @@ void SurveyDataConverter::analyze(const edm::Event& iEvent, const edm::EventSetu
   const MapType& mapIdToInfo = dataReader.detIdMap();
   std::cout << "DATA HAS BEEN READ INTO THE MAP" << std::endl;
   std::cout << "DATA HAS BEEN CONVERTED IN ALIGNABLE COORDINATES" << std::endl;
+  edm::ConsumesCollector iC = consumesCollector();
+  TrackerAlignment tr_align(iSetup, iC);
+  //TrackerAlignment tr_align(iSetup);
 
-  TrackerAlignment tr_align(iSetup);
   if (applycoarseinfo)
     this->applyCoarseSurveyInfo(tr_align);
   if (applyfineinfo)

--- a/Alignment/SurveyAnalysis/plugins/SurveyDataConverter.cc
+++ b/Alignment/SurveyAnalysis/plugins/SurveyDataConverter.cc
@@ -1,7 +1,7 @@
 
 // Framework
 #include "FWCore/Framework/interface/ESHandle.h"
-#include "FWCore/Framework/interface/ConsumesCollector.h" 
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
@@ -16,22 +16,13 @@
 #include "Geometry/Records/interface/TrackerTopologyRcd.h"
 
 //__________________________________________________________________________________________________
-SurveyDataConverter::SurveyDataConverter(const edm::ParameterSet& iConfig) : theParameterSet(iConfig) {}
-
-//SurveyDataConverter::SurveyDataConverter(const edm::EventSetup& setup, edm::ConsumesCollector iC) :
-//ttopoToken_(iC.esConsumes<TrackerTopology, TrackerTopologyRcd, edm::Transition::BeginRun>())
-//{
-//  const TrackerTopology* const tTopo = &setup.getData(ttopoToken_);
-//
-//}
-
+SurveyDataConverter::SurveyDataConverter(const edm::ParameterSet& iConfig)
+    : topoToken(esConsumes()), ttrackerGeometryToken(esConsumes()), theParameterSet(iConfig) {}
 //__________________________________________________________________________________________________
-void SurveyDataConverter::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) 
-{
+void SurveyDataConverter::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
   //Retrieve tracker topology from geometry
-  edm::ESHandle<TrackerTopology> tTopoHandle;
-  iSetup.get<TrackerTopologyRcd>().get(tTopoHandle);
-  const TrackerTopology* const tTopo = tTopoHandle.product();
+  const TrackerTopology* const tTopo = &iSetup.getData(topoToken);
+  const TrackerGeometry* const tGeom = &iSetup.getData(ttrackerGeometryToken);
 
   edm::LogInfo("SurveyDataConverter") << "Analyzer called";
   applyfineinfo = theParameterSet.getParameter<bool>("applyFineInfo");
@@ -59,9 +50,7 @@ void SurveyDataConverter::analyze(const edm::Event& iEvent, const edm::EventSetu
   const MapType& mapIdToInfo = dataReader.detIdMap();
   std::cout << "DATA HAS BEEN READ INTO THE MAP" << std::endl;
   std::cout << "DATA HAS BEEN CONVERTED IN ALIGNABLE COORDINATES" << std::endl;
-  edm::ConsumesCollector iC = consumesCollector();
-  TrackerAlignment tr_align(iSetup, iC);
-  //TrackerAlignment tr_align(iSetup);
+  TrackerAlignment tr_align(tTopo, tGeom);
 
   if (applycoarseinfo)
     this->applyCoarseSurveyInfo(tr_align);

--- a/Alignment/SurveyAnalysis/plugins/SurveyDataConverter.h
+++ b/Alignment/SurveyAnalysis/plugins/SurveyDataConverter.h
@@ -32,8 +32,7 @@ class SurveyDataConverter : public edm::EDAnalyzer {
 
 public:
   explicit SurveyDataConverter(const edm::ParameterSet& iConfig);
-//  SurveyDataConverter(edm::EventSetup& setup, edm::ConsumesCollector);
-  void analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)override; 
+  void analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) override;
   void endJob() override{};
 
 private:
@@ -48,6 +47,8 @@ private:
 
   void applyAPEs(TrackerAlignment& tr_align);
 
+  const edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> topoToken;
+  const edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> ttrackerGeometryToken;
   edm::ParameterSet theParameterSet;
   edm::ParameterSet MisalignScenario;
 

--- a/Alignment/SurveyAnalysis/plugins/SurveyDataConverter.h
+++ b/Alignment/SurveyAnalysis/plugins/SurveyDataConverter.h
@@ -19,12 +19,11 @@
 //
 
 #include "Alignment/SurveyAnalysis/interface/SurveyDataReader.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "Alignment/TrackerAlignment/interface/TrackerAlignment.h"
-#include "FWCore/Framework/interface/ConsumesCollector.h"
 
-class SurveyDataConverter : public edm::EDAnalyzer {
+class SurveyDataConverter : public edm::one::EDAnalyzer<> {
   typedef SurveyDataReader::MapType MapType;
   typedef SurveyDataReader::PairType PairType;
   typedef SurveyDataReader::MapTypeOr MapTypeOr;

--- a/Alignment/SurveyAnalysis/plugins/SurveyDataConverter.h
+++ b/Alignment/SurveyAnalysis/plugins/SurveyDataConverter.h
@@ -22,6 +22,7 @@
 #include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "Alignment/TrackerAlignment/interface/TrackerAlignment.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 
 class SurveyDataConverter : public edm::EDAnalyzer {
   typedef SurveyDataReader::MapType MapType;
@@ -31,8 +32,8 @@ class SurveyDataConverter : public edm::EDAnalyzer {
 
 public:
   explicit SurveyDataConverter(const edm::ParameterSet& iConfig);
-
-  void analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) override;
+//  SurveyDataConverter(edm::EventSetup& setup, edm::ConsumesCollector);
+  void analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)override; 
   void endJob() override{};
 
 private:

--- a/Alignment/SurveyAnalysis/plugins/SurveyInputCSCfromPins.h
+++ b/Alignment/SurveyAnalysis/plugins/SurveyInputCSCfromPins.h
@@ -12,6 +12,8 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "Alignment/SurveyAnalysis/interface/SurveyInputBase.h"
 #include "CondFormats/Alignment/interface/Definitions.h"
+#include "Geometry/DTGeometry/interface/DTGeometry.h"
+#include "Geometry/Records/interface/MuonGeometryRecord.h"
 
 class SurveyInputCSCfromPins : public SurveyInputBase {
 public:
@@ -43,6 +45,10 @@ private:
               double &dy_phix);
 
   void fillAllRecords(Alignable *ali);
+
+  const edm::ESGetToken<DTGeometry, MuonGeometryRecord> DTGeoToken_;
+  const edm::ESGetToken<CSCGeometry, MuonGeometryRecord> CSCGeoToken_;
+  const edm::ESGetToken<GEMGeometry, MuonGeometryRecord> GEMGeoToken_;
 
   std::string m_pinPositions;
   std::string m_rootFile;

--- a/Alignment/SurveyAnalysis/plugins/SurveyInputTrackerFromDB.h
+++ b/Alignment/SurveyAnalysis/plugins/SurveyInputTrackerFromDB.h
@@ -27,6 +27,10 @@ public:
 private:
   SurveyInputTextReader::MapType uIdMap;
 
+  const edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> tTopoToken_;
+  const edm::ESGetToken<GeometricDet, IdealGeometryRecord> geomDetToken_;
+  const edm::ESGetToken<PTrackerParameters, PTrackerParametersRcd> ptpToken_;
+
   std::string textFileName;
 
   /// Add survey info to an alignable

--- a/Alignment/SurveyAnalysis/plugins/SurveyMisalignmentInput.cc
+++ b/Alignment/SurveyAnalysis/plugins/SurveyMisalignmentInput.cc
@@ -17,27 +17,25 @@
 #include "Alignment/SurveyAnalysis/plugins/SurveyMisalignmentInput.h"
 
 SurveyMisalignmentInput::SurveyMisalignmentInput(const edm::ParameterSet& cfg)
-    : textFileName(cfg.getParameter<std::string>("textFileName")) {}
+    : tTopoToken_(esConsumes()),
+      geomDetToken_(esConsumes()),
+      ptpToken_(esConsumes()),
+      aliToken_(esConsumes()),
+      textFileName(cfg.getParameter<std::string>("textFileName")) {}
 
 void SurveyMisalignmentInput::analyze(const edm::Event&, const edm::EventSetup& setup) {
   if (theFirstEvent) {
     //Retrieve tracker topology from geometry
-    edm::ESHandle<TrackerTopology> tTopoHandle;
-    setup.get<TrackerTopologyRcd>().get(tTopoHandle);
-    const TrackerTopology* const tTopo = tTopoHandle.product();
-
-    edm::ESHandle<GeometricDet> geom;
-    setup.get<IdealGeometryRecord>().get(geom);
-
-    edm::ESHandle<PTrackerParameters> ptp;
-    setup.get<PTrackerParametersRcd>().get(ptp);
-    TrackerGeometry* tracker = TrackerGeomBuilderFromGeometricDet().build(&*geom, *ptp, tTopo);
+    const TrackerTopology* const tTopo = &setup.getData(tTopoToken_);
+    const GeometricDet* geom = &setup.getData(geomDetToken_);
+    const PTrackerParameters& ptp = setup.getData(ptpToken_);
+    TrackerGeometry* tracker = TrackerGeomBuilderFromGeometricDet().build(geom, ptp, tTopo);
 
     addComponent(new AlignableTracker(tracker, tTopo));
 
     edm::LogInfo("SurveyMisalignmentInput") << "Starting!";
     // Retrieve alignment[Error]s from DBase
-    setup.get<TrackerAlignmentRcd>().get(alignments);
+    alignments = setup.getHandle(aliToken_);
 
     //Get map from textreader
     SurveyInputTextReader dataReader;

--- a/Alignment/SurveyAnalysis/plugins/SurveyMisalignmentInput.h
+++ b/Alignment/SurveyAnalysis/plugins/SurveyMisalignmentInput.h
@@ -26,6 +26,11 @@ public:
   void analyze(const edm::Event&, const edm::EventSetup&) override;
 
 private:
+  const edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> tTopoToken_;
+  const edm::ESGetToken<GeometricDet, IdealGeometryRecord> geomDetToken_;
+  const edm::ESGetToken<PTrackerParameters, PTrackerParametersRcd> ptpToken_;
+  const edm::ESGetToken<Alignments, TrackerAlignmentRcd> aliToken_;
+
   SurveyInputTextReader::MapType uIdMap;
 
   std::string textFileName;

--- a/Alignment/SurveyAnalysis/test/run-converter_cfg.py
+++ b/Alignment/SurveyAnalysis/test/run-converter_cfg.py
@@ -3,18 +3,9 @@ import FWCore.ParameterSet.Config as cms
 process = cms.Process("DATACONVERTER")
 
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
-#process.load('CondCore.CondDB.CondDB_cfi')
+process.GlobalTag.globaltag = 'auto:phase1_2021_realistic'
 
 process.load("Configuration.Geometry.GeometryDB_cff")
-
-#process.load("Geometry.CMSCommonData.cmsIdealGeometryXML_cfi")
-
-#process.load("Geometry.TrackerGeometryBuilder.trackerGeometry_cfi")
-
-#process.load("Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cfi")
-
-#process.load("CondCore.DBCommon.CondDBSetup_cfi")
-
 process.load("Alignment.SurveyAnalysis.SurveyInfoScenario_cff")
 
 process.MessageLogger = cms.Service("MessageLogger",
@@ -43,37 +34,19 @@ process.source = cms.Source("EmptySource",
     numberEventsInRun = cms.untracked.uint32(1),
     firstRun = cms.untracked.uint32(1)
 )
-import CalibTracker.Configuration.Common.PoolDBESSource_cfi
 
-process.conditionsInTrackerAlignmentRcd = CalibTracker.Configuration.Common.PoolDBESSource_cfi.poolDBESSource.clone(
-     connect = cms.string('sqlite_file:/afs/cern.ch/cms/CAF/CMSALCA/ALCA_TRACKERALIGN/data/commonValidation/vbotta/misalignments/check/CMSSW_11_0_0_pre13/src/Alignment/TrackerAlignment/test/geometry_MisalignmentScenario_BPIXModulesHB1_PhiYGlob_Min30umrad_from105X_upgrade2018_design_v3.db'),
-     toGet = cms.VPSet(cms.PSet(record = cms.string('TrackerAlignmentRcd'),
-                               tag = cms.string('Alignments')
-        # ),cms.PSet(record = cms.string('TrackerTopologyRcd'),
-        #                       tag = cms.string('Alignments')
-                               )
-                      )
-    )
-process.prefer_conditionsInTrackerAlignmentRcd = cms.ESPrefer("PoolDBESSource", "conditionsInTrackerAlignmentRcd")
-
-
-#process.PoolDBOutputService = cms.Service("PoolDBOutputService",
-#    process.CondDBSetup,
-#    toPut = cms.VPSet(cms.PSet(
-#        record = cms.string('TrackerAlignmentRcd'),
-#        tag = cms.string('TibTidTecAllSurvey_v2')
-#    ), 
-#        cms.PSet(
-#            record = cms.string('TrackerAlignmentErrorExtendedRcd'),
-#            tag = cms.string('TibTidTecAllSurveyAPE_v2')
-##        ),
-##        cms.PSet(
-##        record = cms.string('TrackerTopologyRcd'),
-##        tag = cms.string('TibTidTecAllSurveyAPE_v2')
-#        )),
-#
-#   connect = cms.string('sqlite_file:TibTidTecAllSurvey.db')                                     
-#)
+process.load("CondCore.CondDB.CondDB_cfi")
+process.CondDB.connect = cms.string('sqlite_file:TibTidTecAllSurvey.db')
+process.PoolDBOutputService = cms.Service("PoolDBOutputService",
+                                          process.CondDB,
+                                          toPut = cms.VPSet(cms.PSet(record = cms.string('TrackerAlignmentRcd'),
+                                                                     tag = cms.string('TibTidTecAllSurvey_v2')
+                                                                     ), 
+                                                            cms.PSet(record = cms.string('TrackerAlignmentErrorExtendedRcd'),
+                                                                     tag = cms.string('TibTidTecAllSurveyAPE_v2')
+                                                                     ),
+                                                           )
+                                          )
 
 
 process.mydataconverter = cms.EDAnalyzer("SurveyDataConverter",
@@ -97,7 +70,4 @@ process.mydataconverter = cms.EDAnalyzer("SurveyDataConverter",
 
 process.p = cms.Path(process.mydataconverter)
 # process.ep = cms.EndPath(process.print)
-#process.GlobalTag.globaltag = 'IDEAL'
 
-process.GlobalTag.globaltag = '120X_mcRun3_2021_design_Queue'
-#process.GlobalTag.globaltag = '105X_upgrade2018_design_v3'

--- a/Alignment/SurveyAnalysis/test/run-converter_cfg.py
+++ b/Alignment/SurveyAnalysis/test/run-converter_cfg.py
@@ -3,13 +3,17 @@ import FWCore.ParameterSet.Config as cms
 process = cms.Process("DATACONVERTER")
 
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
-process.load("Geometry.CMSCommonData.cmsIdealGeometryXML_cfi")
+#process.load('CondCore.CondDB.CondDB_cfi')
 
-process.load("Geometry.TrackerGeometryBuilder.trackerGeometry_cfi")
+process.load("Configuration.Geometry.GeometryDB_cff")
 
-process.load("Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cfi")
+#process.load("Geometry.CMSCommonData.cmsIdealGeometryXML_cfi")
 
-process.load("CondCore.DBCommon.CondDBSetup_cfi")
+#process.load("Geometry.TrackerGeometryBuilder.trackerGeometry_cfi")
+
+#process.load("Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cfi")
+
+#process.load("CondCore.DBCommon.CondDBSetup_cfi")
 
 process.load("Alignment.SurveyAnalysis.SurveyInfoScenario_cff")
 
@@ -39,19 +43,38 @@ process.source = cms.Source("EmptySource",
     numberEventsInRun = cms.untracked.uint32(1),
     firstRun = cms.untracked.uint32(1)
 )
+import CalibTracker.Configuration.Common.PoolDBESSource_cfi
 
-process.PoolDBOutputService = cms.Service("PoolDBOutputService",
-    process.CondDBSetup,
-    toPut = cms.VPSet(cms.PSet(
-        record = cms.string('TrackerAlignmentRcd'),
-        tag = cms.string('TibTidTecAllSurvey_v2')
-    ), 
-        cms.PSet(
-            record = cms.string('TrackerAlignmentErrorExtendedRcd'),
-            tag = cms.string('TibTidTecAllSurveyAPE_v2')
-        )),
-   connect = cms.string('sqlite_file:TibTidTecAllSurvey.db')                                     
-)
+process.conditionsInTrackerAlignmentRcd = CalibTracker.Configuration.Common.PoolDBESSource_cfi.poolDBESSource.clone(
+     connect = cms.string('sqlite_file:/afs/cern.ch/cms/CAF/CMSALCA/ALCA_TRACKERALIGN/data/commonValidation/vbotta/misalignments/check/CMSSW_11_0_0_pre13/src/Alignment/TrackerAlignment/test/geometry_MisalignmentScenario_BPIXModulesHB1_PhiYGlob_Min30umrad_from105X_upgrade2018_design_v3.db'),
+     toGet = cms.VPSet(cms.PSet(record = cms.string('TrackerAlignmentRcd'),
+                               tag = cms.string('Alignments')
+        # ),cms.PSet(record = cms.string('TrackerTopologyRcd'),
+        #                       tag = cms.string('Alignments')
+                               )
+                      )
+    )
+process.prefer_conditionsInTrackerAlignmentRcd = cms.ESPrefer("PoolDBESSource", "conditionsInTrackerAlignmentRcd")
+
+
+#process.PoolDBOutputService = cms.Service("PoolDBOutputService",
+#    process.CondDBSetup,
+#    toPut = cms.VPSet(cms.PSet(
+#        record = cms.string('TrackerAlignmentRcd'),
+#        tag = cms.string('TibTidTecAllSurvey_v2')
+#    ), 
+#        cms.PSet(
+#            record = cms.string('TrackerAlignmentErrorExtendedRcd'),
+#            tag = cms.string('TibTidTecAllSurveyAPE_v2')
+##        ),
+##        cms.PSet(
+##        record = cms.string('TrackerTopologyRcd'),
+##        tag = cms.string('TibTidTecAllSurveyAPE_v2')
+#        )),
+#
+#   connect = cms.string('sqlite_file:TibTidTecAllSurvey.db')                                     
+#)
+
 
 process.mydataconverter = cms.EDAnalyzer("SurveyDataConverter",
     applyFineInfo = cms.bool(True),
@@ -60,8 +83,8 @@ process.mydataconverter = cms.EDAnalyzer("SurveyDataConverter",
     ),
     applyErrors = cms.bool(True),
     textFileNames = cms.PSet(
-        forTID = cms.untracked.string('../data/GetTibSurvey/TIDNewSurvey.dat'),
-        forTIB = cms.untracked.string('../data/GetTibSurvey/TIBNewSurvey.dat')
+        forTID = cms.untracked.string('./TIDSurvey.dat'),
+        forTIB = cms.untracked.string('./TIBSurvey.dat')
     ),
     applyCoarseInfo = cms.bool(True),                                  
     TOBerrors = cms.vdouble(0.014, 0.05, 0.02, 0.003),
@@ -74,4 +97,7 @@ process.mydataconverter = cms.EDAnalyzer("SurveyDataConverter",
 
 process.p = cms.Path(process.mydataconverter)
 # process.ep = cms.EndPath(process.print)
-process.GlobalTag.globaltag = 'IDEAL_V9::All'
+#process.GlobalTag.globaltag = 'IDEAL'
+
+process.GlobalTag.globaltag = '120X_mcRun3_2021_design_Queue'
+#process.GlobalTag.globaltag = '105X_upgrade2018_design_v3'

--- a/Alignment/TrackerAlignment/interface/TrackerAlignment.h
+++ b/Alignment/TrackerAlignment/interface/TrackerAlignment.h
@@ -18,9 +18,8 @@ class TrackerTopology;
 
 class TrackerAlignment {
 public:
-  
-  TrackerAlignment(const edm::EventSetup& setup, edm::ConsumesCollector);
-//TrackerAlignment(const edm::EventSetup& setup);// {return TrackerAlignment(const edm::EventSetup& setup, edm::ConsumesCollector);}
+  TrackerAlignment(const TrackerTopology* tTopo, const TrackerGeometry* tGeom);
+
   ~TrackerAlignment();
 
   AlignableTracker* getAlignableTracker() { return theAlignableTracker; }
@@ -49,9 +48,6 @@ public:
 
 private:
   AlignableTracker* theAlignableTracker;
-  const edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> ttopoToken_;
-  const edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> ttrackerGeometryToken_;
-
   std::string theAlignRecordName, theErrorRecordName;
 };
 #endif  //TrackerAlignment_H

--- a/Alignment/TrackerAlignment/interface/TrackerAlignment.h
+++ b/Alignment/TrackerAlignment/interface/TrackerAlignment.h
@@ -11,10 +11,14 @@
 #include "FWCore/Framework/interface/EventSetup.h"
 
 #include "Alignment/TrackerAlignment/interface/AlignableTracker.h"
+#include "Geometry/Records/interface/TrackerTopologyRcd.h"
+#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
+class TrackerTopology;
 
 class TrackerAlignment {
 public:
-  TrackerAlignment(const edm::EventSetup& setup);
+  TrackerAlignment(const edm::EventSetup& setup, edm::ConsumesCollector);
 
   ~TrackerAlignment();
 
@@ -44,6 +48,8 @@ public:
 
 private:
   AlignableTracker* theAlignableTracker;
+  const edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> ttopoToken_;
+  const edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> ttrackerGeometryToken_;
 
   std::string theAlignRecordName, theErrorRecordName;
 };

--- a/Alignment/TrackerAlignment/interface/TrackerAlignment.h
+++ b/Alignment/TrackerAlignment/interface/TrackerAlignment.h
@@ -18,8 +18,9 @@ class TrackerTopology;
 
 class TrackerAlignment {
 public:
+  
   TrackerAlignment(const edm::EventSetup& setup, edm::ConsumesCollector);
-
+//TrackerAlignment(const edm::EventSetup& setup);// {return TrackerAlignment(const edm::EventSetup& setup, edm::ConsumesCollector);}
   ~TrackerAlignment();
 
   AlignableTracker* getAlignableTracker() { return theAlignableTracker; }

--- a/Alignment/TrackerAlignment/src/TrackerAlignment.cc
+++ b/Alignment/TrackerAlignment/src/TrackerAlignment.cc
@@ -17,14 +17,8 @@
 
 //__________________________________________________________________
 //
-TrackerAlignment::TrackerAlignment(const edm::EventSetup& setup, edm::ConsumesCollector iC)
-    : ttopoToken_(iC.esConsumes<TrackerTopology, TrackerTopologyRcd, edm::Transition::BeginRun>()),
-      ttrackerGeometryToken_(iC.esConsumes<TrackerGeometry, TrackerDigiGeometryRecord, edm::Transition::BeginRun>()),
-      theAlignRecordName("TrackerAlignmentRcd"),
-      theErrorRecordName("TrackerAlignmentErrorExtendedRcd") {
-  const TrackerTopology* const tTopo = &setup.getData(ttopoToken_);
-
-  const TrackerGeometry* const tGeom = &setup.getData(ttrackerGeometryToken_);
+TrackerAlignment::TrackerAlignment(const TrackerTopology* tTopo, const TrackerGeometry* tGeom)
+    : theAlignRecordName("TrackerAlignmentRcd"), theErrorRecordName("TrackerAlignmentErrorExtendedRcd") {
   theAlignableTracker = new AlignableTracker(tGeom, tTopo);
 }
 

--- a/Alignment/TrackerAlignment/src/TrackerAlignment.cc
+++ b/Alignment/TrackerAlignment/src/TrackerAlignment.cc
@@ -1,6 +1,6 @@
 // Framework
 #include "FWCore/Framework/interface/ESHandle.h"
-
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 // Conditions database
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "CondCore/DBOutputService/interface/PoolDBOutputService.h"
@@ -17,16 +17,20 @@
 
 //__________________________________________________________________
 //
-TrackerAlignment::TrackerAlignment(const edm::EventSetup& setup)
-    : theAlignRecordName("TrackerAlignmentRcd"), theErrorRecordName("TrackerAlignmentErrorExtendedRcd") {
+TrackerAlignment::TrackerAlignment(const edm::EventSetup& setup, edm::ConsumesCollector iC)
+    : ttopoToken_(iC.esConsumes<TrackerTopology, TrackerTopologyRcd,edm::Transition::BeginRun>()),ttrackerGeometryToken_(iC.esConsumes<TrackerGeometry, TrackerDigiGeometryRecord,edm::Transition::BeginRun>()),theAlignRecordName("TrackerAlignmentRcd"), theErrorRecordName("TrackerAlignmentErrorExtendedRcd"){
   //Retrieve tracker topology from geometry
-  edm::ESHandle<TrackerTopology> tTopoHandle;
-  setup.get<TrackerTopologyRcd>().get(tTopoHandle);
-  const TrackerTopology* const tTopo = tTopoHandle.product();
+//  edm::ESHandle<TrackerTopology> tTopoHandle;
+//  setup.get<TrackerTopologyRcd>().get(tTopoHandle);
+//  const TrackerTopology* const tTopo = tTopoHandle.product();
+const TrackerTopology* const tTopo = &setup.getData(ttopoToken_);
 
-  edm::ESHandle<TrackerGeometry> trackerGeometry;
-  setup.get<TrackerDigiGeometryRecord>().get(trackerGeometry);
-  theAlignableTracker = new AlignableTracker(&(*trackerGeometry), tTopo);
+
+//  edm::ESHandle<TrackerGeometry> trackerGeometry;
+//  setup.get<TrackerDigiGeometryRecord>().get(trackerGeometry);
+//  theAlignableTracker = new AlignableTracker(&(*trackerGeometry), tTopo);
+const TrackerGeometry* const tGeom = &setup.getData(ttrackerGeometryToken_); 
+    theAlignableTracker = new AlignableTracker(tGeom, tTopo);
 }
 
 //__________________________________________________________________

--- a/Alignment/TrackerAlignment/src/TrackerAlignment.cc
+++ b/Alignment/TrackerAlignment/src/TrackerAlignment.cc
@@ -19,16 +19,9 @@
 //
 TrackerAlignment::TrackerAlignment(const edm::EventSetup& setup, edm::ConsumesCollector iC)
     : ttopoToken_(iC.esConsumes<TrackerTopology, TrackerTopologyRcd,edm::Transition::BeginRun>()),ttrackerGeometryToken_(iC.esConsumes<TrackerGeometry, TrackerDigiGeometryRecord,edm::Transition::BeginRun>()),theAlignRecordName("TrackerAlignmentRcd"), theErrorRecordName("TrackerAlignmentErrorExtendedRcd"){
-  //Retrieve tracker topology from geometry
-//  edm::ESHandle<TrackerTopology> tTopoHandle;
-//  setup.get<TrackerTopologyRcd>().get(tTopoHandle);
-//  const TrackerTopology* const tTopo = tTopoHandle.product();
 const TrackerTopology* const tTopo = &setup.getData(ttopoToken_);
 
 
-//  edm::ESHandle<TrackerGeometry> trackerGeometry;
-//  setup.get<TrackerDigiGeometryRecord>().get(trackerGeometry);
-//  theAlignableTracker = new AlignableTracker(&(*trackerGeometry), tTopo);
 const TrackerGeometry* const tGeom = &setup.getData(ttrackerGeometryToken_); 
     theAlignableTracker = new AlignableTracker(tGeom, tTopo);
 }

--- a/Alignment/TrackerAlignment/src/TrackerAlignment.cc
+++ b/Alignment/TrackerAlignment/src/TrackerAlignment.cc
@@ -18,12 +18,14 @@
 //__________________________________________________________________
 //
 TrackerAlignment::TrackerAlignment(const edm::EventSetup& setup, edm::ConsumesCollector iC)
-    : ttopoToken_(iC.esConsumes<TrackerTopology, TrackerTopologyRcd,edm::Transition::BeginRun>()),ttrackerGeometryToken_(iC.esConsumes<TrackerGeometry, TrackerDigiGeometryRecord,edm::Transition::BeginRun>()),theAlignRecordName("TrackerAlignmentRcd"), theErrorRecordName("TrackerAlignmentErrorExtendedRcd"){
-const TrackerTopology* const tTopo = &setup.getData(ttopoToken_);
+    : ttopoToken_(iC.esConsumes<TrackerTopology, TrackerTopologyRcd, edm::Transition::BeginRun>()),
+      ttrackerGeometryToken_(iC.esConsumes<TrackerGeometry, TrackerDigiGeometryRecord, edm::Transition::BeginRun>()),
+      theAlignRecordName("TrackerAlignmentRcd"),
+      theErrorRecordName("TrackerAlignmentErrorExtendedRcd") {
+  const TrackerTopology* const tTopo = &setup.getData(ttopoToken_);
 
-
-const TrackerGeometry* const tGeom = &setup.getData(ttrackerGeometryToken_); 
-    theAlignableTracker = new AlignableTracker(tGeom, tTopo);
+  const TrackerGeometry* const tGeom = &setup.getData(ttrackerGeometryToken_);
+  theAlignableTracker = new AlignableTracker(tGeom, tTopo);
 }
 
 //__________________________________________________________________


### PR DESCRIPTION
#### PR description:

The main goal of this PR is to finalize the migration to `esConsumes` for the packages `Alignment/TrackerAlignment` and `Alignment/SurveyAnalysis`. I profit of it to modernize some of the legacy `edm::EDAnalyzer`s to become thread-efficient.
This is part of issue #31061.
Part of the changes have been performed by @bbilin.

#### PR validation:

The code compiles.
The changes in `Alignment/TrackerAlignment` have been tested explicitly by running the code in `Alignment/SurveyAnalysis/test/run-converter_cfg.py`.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This PR is not a backport and not backport will be needed.

