### PR TITLE
Run3-gex80B Use of alternative ESGetToken initialization for DDD/DD4Hep in Tracker

### DIFF
--- a/Geometry/TrackerGeometryBuilder/plugins/TrackerParametersESModule.cc
+++ b/Geometry/TrackerGeometryBuilder/plugins/TrackerParametersESModule.cc
@@ -40,8 +40,10 @@ private:
 TrackerParametersESModule::TrackerParametersESModule(const edm::ParameterSet& ps) {
   fromDD4Hep_ = ps.getParameter<bool>("fromDD4Hep");
   auto cc = setWhatProduced(this);
-  cpvTokenDD4Hep_ = cc.consumesFrom<cms::DDCompactView, IdealGeometryRecord>(edm::ESInputTag());
-  cpvTokenDDD_ = cc.consumesFrom<DDCompactView, IdealGeometryRecord>(edm::ESInputTag());
+  if (fromDD4Hep_)
+    cpvTokenDD4Hep_ = cc.consumesFrom<cms::DDCompactView, IdealGeometryRecord>(edm::ESInputTag());
+  else
+    cpvTokenDDD_ = cc.consumesFrom<DDCompactView, IdealGeometryRecord>(edm::ESInputTag());
 
 #ifdef EDM_ML_DEBUG
   edm::LogVerbatim("TrackerGeom") << "TrackerParametersESModule::TrackerParametersESModule called with dd4hep: "


### PR DESCRIPTION
#### PR description:

Use of alternative ESGetToken initialization for DDD/DD4Hep in Tracker

#### PR validation:

Use the runTheMatrix test workflows

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Nothing special