### PR TITLE
Speed up Patatrack CA

### DIFF
--- a/HeterogeneousCore/CUDAUtilities/interface/cudaCompat.h
+++ b/HeterogeneousCore/CUDAUtilities/interface/cudaCompat.h
@@ -52,11 +52,10 @@ namespace cms {
       return ret;
     }
 
-   template <typename T1, typename T2>
+    template <typename T1, typename T2>
     T1 atomicInc_block(T1* a, T2 b) {
-      return atomicInc(a,b);
+      return atomicInc(a, b);
     }
-
 
     template <typename T1, typename T2>
     T1 atomicAdd(T1* a, T2 b) {
@@ -65,11 +64,10 @@ namespace cms {
       return ret;
     }
 
-   template <typename T1, typename T2>
+    template <typename T1, typename T2>
     T1 atomicAdd_block(T1* a, T2 b) {
-      return atomicAdd(a,b);
+      return atomicAdd(a, b);
     }
-
 
     template <typename T1, typename T2>
     T1 atomicSub(T1* a, T2 b) {
@@ -78,11 +76,10 @@ namespace cms {
       return ret;
     }
 
-   template <typename T1, typename T2>
+    template <typename T1, typename T2>
     T1 atomicSub_block(T1* a, T2 b) {
-      return atomicSub(a,b);
+      return atomicSub(a, b);
     }
-
 
     template <typename T1, typename T2>
     T1 atomicMin(T1* a, T2 b) {
@@ -91,9 +88,9 @@ namespace cms {
       return ret;
     }
 
-   template <typename T1, typename T2>
+    template <typename T1, typename T2>
     T1 atomicMin_block(T1* a, T2 b) {
-      return atomicMin(a,b);
+      return atomicMin(a, b);
     }
 
     template <typename T1, typename T2>
@@ -103,11 +100,10 @@ namespace cms {
       return ret;
     }
 
-   template <typename T1, typename T2>
+    template <typename T1, typename T2>
     T1 atomicMax_block(T1* a, T2 b) {
-      return atomicMax(a,b);
+      return atomicMax(a, b);
     }
-
 
     inline void __syncthreads() {}
     inline void __threadfence() {}

--- a/HeterogeneousCore/CUDAUtilities/interface/cudaCompat.h
+++ b/HeterogeneousCore/CUDAUtilities/interface/cudaCompat.h
@@ -40,12 +40,23 @@ namespace cms {
     }
 
     template <typename T1, typename T2>
+    T1 atomicCAS_block(T1* address, T1 compare, T2 val) {
+      return atomicCAS(address, compare, val);
+    }
+
+    template <typename T1, typename T2>
     T1 atomicInc(T1* a, T2 b) {
       auto ret = *a;
       if ((*a) < T1(b))
         (*a)++;
       return ret;
     }
+
+   template <typename T1, typename T2>
+    T1 atomicInc_block(T1* a, T2 b) {
+      return atomicInc(a,b);
+    }
+
 
     template <typename T1, typename T2>
     T1 atomicAdd(T1* a, T2 b) {
@@ -54,6 +65,12 @@ namespace cms {
       return ret;
     }
 
+   template <typename T1, typename T2>
+    T1 atomicAdd_block(T1* a, T2 b) {
+      return atomicAdd(a,b);
+    }
+
+
     template <typename T1, typename T2>
     T1 atomicSub(T1* a, T2 b) {
       auto ret = *a;
@@ -61,18 +78,36 @@ namespace cms {
       return ret;
     }
 
+   template <typename T1, typename T2>
+    T1 atomicSub_block(T1* a, T2 b) {
+      return atomicSub(a,b);
+    }
+
+
     template <typename T1, typename T2>
     T1 atomicMin(T1* a, T2 b) {
       auto ret = *a;
       *a = std::min(*a, T1(b));
       return ret;
     }
+
+   template <typename T1, typename T2>
+    T1 atomicMin_block(T1* a, T2 b) {
+      return atomicMin(a,b);
+    }
+
     template <typename T1, typename T2>
     T1 atomicMax(T1* a, T2 b) {
       auto ret = *a;
       *a = std::max(*a, T1(b));
       return ret;
     }
+
+   template <typename T1, typename T2>
+    T1 atomicMax_block(T1* a, T2 b) {
+      return atomicMax(a,b);
+    }
+
 
     inline void __syncthreads() {}
     inline void __threadfence() {}

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/gpuClustering.h
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/gpuClustering.h
@@ -218,12 +218,13 @@ namespace gpuClustering {
               auto l = nn[k][kk];
               auto m = l + firstPixel;
               assert(m != i);
-              auto old = atomicMin(&clusterId[m], clusterId[i]);
+              auto old = atomicMin_block(&clusterId[m], clusterId[i]);
+              // do we need memory fence?
               if (old != clusterId[i]) {
                 // end the loop only if no changes were applied
                 more = true;
               }
-              atomicMin(&clusterId[i], old);
+              atomicMin_block(&clusterId[i], old);
             }  // nnloop
           }    // pixel loop
         }

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernelsImpl.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernelsImpl.h
@@ -350,7 +350,9 @@ __global__ void kernel_find_ntuplets(GPUCACell::Hits const *__restrict__ hhp,
     auto const &thisCell = cells[idx];
     if (thisCell.isKilled())
       continue;  // cut by earlyFishbone
-
+    // we require at least three hits...
+    if (thisCell.outerNeighbors().empty())
+      continue;
     auto pid = thisCell.layerPairId();
     auto doit = minHitsPerNtuplet > 3 ? pid < 3 : pid < 8 || pid > 12;
     if (doit) {

--- a/RecoPixelVertexing/PixelVertexFinding/plugins/gpuFitVertices.h
+++ b/RecoPixelVertexing/PixelVertexFinding/plugins/gpuFitVertices.h
@@ -63,8 +63,8 @@ namespace gpuVertexFinder {
       assert(iv[i] >= 0);
       assert(iv[i] < int(foundClusters));
       auto w = 1.f / ezt2[i];
-      atomicAdd(&zv[iv[i]], zt[i] * w);
-      atomicAdd(&wv[iv[i]], w);
+      atomicAdd_block(&zv[iv[i]], zt[i] * w);
+      atomicAdd_block(&wv[iv[i]], w);
     }
 
     __syncthreads();
@@ -87,8 +87,8 @@ namespace gpuVertexFinder {
         iv[i] = 9999;
         continue;
       }
-      atomicAdd(&chi2[iv[i]], c2);
-      atomicAdd(&nn[iv[i]], 1);
+      atomicAdd_block(&chi2[iv[i]], c2);
+      atomicAdd_block(&nn[iv[i]], 1);
     }
     __syncthreads();
     for (auto i = threadIdx.x; i < foundClusters; i += blockDim.x)

--- a/RecoPixelVertexing/PixelVertexFinding/plugins/gpuSortByPt2.h
+++ b/RecoPixelVertexing/PixelVertexFinding/plugins/gpuSortByPt2.h
@@ -46,7 +46,7 @@ namespace gpuVertexFinder {
     for (auto i = threadIdx.x; i < nt; i += blockDim.x) {
       if (iv[i] > 9990)
         continue;
-      atomicAdd(&ptv2[iv[i]], ptt2[i]);
+      atomicAdd_block(&ptv2[iv[i]], ptt2[i]);
     }
     __syncthreads();
 

--- a/RecoPixelVertexing/PixelVertexFinding/plugins/gpuVertexFinder.cc
+++ b/RecoPixelVertexing/PixelVertexFinding/plugins/gpuVertexFinder.cc
@@ -128,7 +128,7 @@ namespace gpuVertexFinder {
 
 #ifdef __CUDACC__
     // Running too many thread lead to problems when printf is enabled.
-    constexpr int maxThreadsForPrint = 1024 - 256;
+    constexpr int maxThreadsForPrint = 1024 - 128;
     constexpr int numBlocks = 1024;
     constexpr int threadsPerBlock = 128;
 


### PR DESCRIPTION
Release
```
           Type  Time(%)      Time     Calls       Avg       Min       Max  Name
 GPU activities:   14.58%  642.29ms      5000  128.46us  6.1120us  340.77us  kernel_find_ntuplets(TrackingRecHit2DSOAView const *, GPUCACell*, unsigned int const *, cms::cuda::SimpleVector<cms$
                   13.03%  573.68ms      5000  114.74us  16.704us  618.75us  gpuClustering::findClus(unsigned short const *, unsigned short const *, unsigned short const *, unsigned int const $
                    9.25%  407.24ms     10000  40.724us  2.5600us  204.64us  void kernel_BLFit<int=4>(cms::cuda::OneToManyAssoc<unsigned short, int=8, int=24576> const *, double, TrackSoAHeter$
                    8.82%  388.30ms      5000  77.659us  6.5590us  245.57us  gpuVertexFinder::vertexFinderOneKernel(ZVertexSoA*, gpuVertexFinder::WorkSpace*, int, float, float, float)
                    7.89%  347.50ms      5000  69.499us  9.1200us  316.80us  gpuPixelDoublets::getDoubletsFromHisto(GPUCACell*, unsigned int*, cms::cuda::SimpleVector<cms::cuda::VecArray<unsig$
                    5.09%  223.98ms      5000  44.795us  3.3280us  209.54us  gpuPixelDoublets::fishbone(TrackingRecHit2DSOAView const *, GPUCACell*, unsigned int const *, cms::cuda::VecArray<u$
                    5.03%  221.56ms      5000  44.311us  20.544us  174.02us  kernel_connect(cms::cuda::AtomicPairCounter*, cms::cuda::AtomicPairCounter*, TrackingRecHit2DSOAView const *, GPUCA$
                    3.99%  175.88ms      5000  35.176us  9.8230us  161.92us  gpuPixelRecHits::getHits(pixelCPEforGPU::ParamsOnGPU const *, BeamSpotPOD const *, SiPixelDigisCUDA::DeviceConstVie$
                    3.96%  174.45ms     35010  4.9820us  1.0240us  635.20us  [CUDA memcpy HtoD]
```

This PR

```
          Type  Time(%)      Time     Calls       Avg       Min       Max  Name
 GPU activities:   13.63%  558.73ms      5000  111.75us  15.072us  663.13us  gpuClustering::findClus(unsigned short const *, unsigned short const *, unsigned short const *, unsigned int const $
                    9.98%  409.10ms      5000  81.820us  6.0480us  193.79us  kernel_find_ntuplets(TrackingRecHit2DSOAView const *, GPUCACell*, unsigned int const *, cms::cuda::SimpleVector<cms$
                    9.86%  404.24ms     10000  40.424us  2.5600us  111.68us  void kernel_BLFit<int=4>(cms::cuda::OneToManyAssoc<unsigned short, int=8, int=24576> const *, double, TrackSoAHeter$
                    9.41%  385.77ms      5000  77.153us  6.7520us  146.88us  gpuVertexFinder::vertexFinderOneKernel(ZVertexSoA*, gpuVertexFinder::WorkSpace*, int, float, float, float)
                    8.32%  341.18ms      5000  68.235us  8.8960us  211.33us  gpuPixelDoublets::getDoubletsFromHisto(GPUCACell*, unsigned int*, cms::cuda::SimpleVector<cms::cuda::VecArray<unsig$
                    5.43%  222.45ms      5000  44.490us  3.3280us  119.14us  gpuPixelDoublets::fishbone(TrackingRecHit2DSOAView const *, GPUCACell*, unsigned int const *, cms::cuda::VecArray<u$
                    5.36%  219.69ms      5000  43.937us  20.480us  168.96us  kernel_connect(cms::cuda::AtomicPairCounter*, cms::cuda::AtomicPairCounter*, TrackingRecHit2DSOAView const *, GPUCA$
                    4.16%  170.61ms      5000  34.121us  10.367us  97.888us  gpuPixelRecHits::getHits(pixelCPEforGPU::ParamsOnGPU const *, BeamSpotPOD const *, SiPixelDigisCUDA::DeviceConstVie$
                    4.16%  170.50ms     35010  4.8700us  1.0240us  595.10us  [CUDA memcpy HtoD]
                    3.32%  135.98ms     15000  9.0650us  4.5760us  54.048us  void cms::cuda::multiBlockPrefixScan<unsigned int>(unsigned int const *, cms::cuda::multiBlockPrefixScan<unsigned i$
```


Throughput (triplets on T4)

release
  702.0 ±   1.6 ev/s
this PR
   752.4 ±   1.4 ev/s
only the first commit
  750.5 ±   1.2 ev/s

Purely technical. no regression expected. no regression observed



