### PR TITLE
trackingNtuple updates from mkFit/LST developments

### DIFF
--- a/CommonTools/RecoAlgos/plugins/TrackSimpleMerger.cc
+++ b/CommonTools/RecoAlgos/plugins/TrackSimpleMerger.cc
@@ -1,0 +1,8 @@
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "CommonTools/UtilAlgos/interface/Merger.h"
+#include "DataFormats/TrackReco/interface/Track.h"
+#include "DataFormats/TrackReco/interface/TrackFwd.h"
+
+typedef Merger<reco::TrackCollection> TrackSimpleMerger;
+
+DEFINE_FWK_MODULE(TrackSimpleMerger);

--- a/Validation/RecoTrack/plugins/TrackingNtuple.cc
+++ b/Validation/RecoTrack/plugins/TrackingNtuple.cc
@@ -3048,6 +3048,10 @@ void TrackingNtuple::fillSeeds(const edm::Event& iEvent,
     label.ReplaceAll("seedTracks", "");
     label.ReplaceAll("Seeds", "");
     label.ReplaceAll("muonSeeded", "muonSeededStep");
+    //for HLT seeds
+    label.ReplaceAll("FromPixelTracks", "");
+    label.ReplaceAll("PFLowPixel", "");
+    label.ReplaceAll("hltDoubletRecovery", "pixelPairStep");//random choice
     int algo = reco::TrackBase::algoByName(label.Data());
 
     edm::ProductID id = seedTracks[0].seedRef().id();

--- a/Validation/RecoTrack/plugins/TrackingNtuple.cc
+++ b/Validation/RecoTrack/plugins/TrackingNtuple.cc
@@ -1091,6 +1091,8 @@ private:
   std::vector<float>
       pix_radL;  //http://cmslxr.fnal.gov/lxr/source/DataFormats/GeometrySurface/interface/MediumProperties.h
   std::vector<float> pix_bbxi;
+  std::vector<int> pix_clustSizeCol;
+  std::vector<int> pix_clustSizeRow;
   ////////////////////
   // strip hits
   // (first) index runs through hits
@@ -1115,6 +1117,7 @@ private:
       str_radL;  //http://cmslxr.fnal.gov/lxr/source/DataFormats/GeometrySurface/interface/MediumProperties.h
   std::vector<float> str_bbxi;
   std::vector<float> str_chargePerCM;
+  std::vector<int> str_clustSize;
   ////////////////////
   // strip matched hits
   // (first) index runs through hits
@@ -1136,6 +1139,8 @@ private:
       glu_radL;  //http://cmslxr.fnal.gov/lxr/source/DataFormats/GeometrySurface/interface/MediumProperties.h
   std::vector<float> glu_bbxi;
   std::vector<float> glu_chargePerCM ;
+  std::vector<int> glu_clustSizeMono;
+  std::vector<int> glu_clustSizeStereo;
   ////////////////////
   // phase2 Outer Tracker hits
   // (first) index runs through hits
@@ -1560,6 +1565,8 @@ TrackingNtuple::TrackingNtuple(const edm::ParameterSet& iConfig)
     t->Branch("pix_zx", &pix_zx);
     t->Branch("pix_radL", &pix_radL);
     t->Branch("pix_bbxi", &pix_bbxi);
+    t->Branch("pix_clustSizeCol", &pix_clustSizeCol);
+    t->Branch("pix_clustSizeRow", &pix_clustSizeRow);
     //strips
     if (includeStripHits_) {
       t->Branch("str_isBarrel", &str_isBarrel);
@@ -1588,6 +1595,7 @@ TrackingNtuple::TrackingNtuple(const edm::ParameterSet& iConfig)
       t->Branch("str_radL", &str_radL);
       t->Branch("str_bbxi", &str_bbxi);
       t->Branch("str_chargePerCM", &str_chargePerCM);
+      t->Branch("str_clustSize", &str_clustSize);
       //matched hits
       t->Branch("glu_isBarrel", &glu_isBarrel);
       glu_detId.book("glu", t);
@@ -1608,6 +1616,8 @@ TrackingNtuple::TrackingNtuple(const edm::ParameterSet& iConfig)
       t->Branch("glu_radL", &glu_radL);
       t->Branch("glu_bbxi", &glu_bbxi);
       t->Branch("glu_chargePerCM", &glu_chargePerCM);
+      t->Branch("glu_clustSizeMono", &glu_clustSizeMono);
+      t->Branch("glu_clustSizeStereo", &glu_clustSizeStereo);
     }
     //phase2 OT
     if (includePhase2OTHits_) {
@@ -1929,6 +1939,8 @@ void TrackingNtuple::clearVariables() {
   pix_zx.clear();
   pix_radL.clear();
   pix_bbxi.clear();
+  pix_clustSizeCol.clear();
+  pix_clustSizeRow.clear();
   //strips
   str_isBarrel.clear();
   str_detId.clear();
@@ -1950,6 +1962,7 @@ void TrackingNtuple::clearVariables() {
   str_radL.clear();
   str_bbxi.clear();
   str_chargePerCM.clear();
+  str_clustSize.clear();
   //matched hits
   glu_isBarrel.clear();
   glu_detId.clear();
@@ -1968,6 +1981,8 @@ void TrackingNtuple::clearVariables() {
   glu_radL.clear();
   glu_bbxi.clear();
   glu_chargePerCM.clear();
+  glu_clustSizeMono.clear();
+  glu_clustSizeStereo.clear();
   //phase2 OT
   ph2_isBarrel.clear();
   ph2_detId.clear();
@@ -2725,6 +2740,8 @@ void TrackingNtuple::fillPixelHits(const edm::Event& iEvent,
       pix_zx.push_back(ttrh->globalPositionError().czx());
       pix_radL.push_back(ttrh->surface()->mediumProperties().radLen());
       pix_bbxi.push_back(ttrh->surface()->mediumProperties().xi());
+      pix_clustSizeCol.push_back(hit->cluster()->sizeY());
+      pix_clustSizeRow.push_back(hit->cluster()->sizeX());
 
       LogTrace("TrackingNtuple") << "pixHit cluster=" << key << " subdId=" << hitId.subdetId() << " lay=" << lay
                                  << " rawId=" << hitId.rawId() << " pos =" << ttrh->globalPosition();
@@ -2795,6 +2812,7 @@ void TrackingNtuple::fillStripRphiStereoHits(const edm::Event& iEvent,
   str_radL.resize(totalStripHits);
   str_bbxi.resize(totalStripHits);
   str_chargePerCM.resize(totalStripHits);
+  str_clustSize.resize(totalStripHits);
 
   auto fill = [&](const SiStripRecHit2DCollection& hits, const char* name) {
     for (const auto& detset : hits) {
@@ -2820,6 +2838,7 @@ void TrackingNtuple::fillStripRphiStereoHits(const edm::Event& iEvent,
         str_radL[key] = ttrh->surface()->mediumProperties().radLen();
         str_bbxi[key] = ttrh->surface()->mediumProperties().xi();
         str_chargePerCM[key] = siStripClusterTools::chargePerCM(hitId,hit.firstClusterRef().stripCluster());
+        str_clustSize[key] = hit.cluster()->amplitudes().size();
         LogTrace("TrackingNtuple") << name << " cluster=" << key << " subdId=" << hitId.subdetId() << " lay=" << lay
                                    << " rawId=" << hitId.rawId() << " pos =" << ttrh->globalPosition();
 
@@ -2885,6 +2904,8 @@ size_t TrackingNtuple::addStripMatchedHit(const SiStripMatchedRecHit2D& hit,
   glu_radL.push_back(ttrh->surface()->mediumProperties().radLen());
   glu_bbxi.push_back(ttrh->surface()->mediumProperties().xi());
   glu_chargePerCM.push_back(siStripClusterTools::chargePerCM(hitId,hit.firstClusterRef().stripCluster()));
+  glu_clustSizeMono.push_back(hit.monoHit().cluster()->amplitudes().size());
+  glu_clustSizeStereo.push_back(hit.stereoHit().cluster()->amplitudes().size());
   LogTrace("TrackingNtuple") << "stripMatchedHit"
                              << " cluster0=" << hit.stereoHit().cluster().key()
                              << " cluster1=" << hit.monoHit().cluster().key() << " subdId=" << hitId.subdetId()

--- a/Validation/RecoTrack/plugins/TrackingNtuple.cc
+++ b/Validation/RecoTrack/plugins/TrackingNtuple.cc
@@ -55,6 +55,7 @@
 #include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
 
 #include "DataFormats/SiPixelDetId/interface/PixelChannelIdentifier.h"
+#include "DataFormats/SiStripCluster/interface/SiStripClusterTools.h"
 #include "DataFormats/TrackerRecHit2D/interface/SiPixelRecHitCollection.h"
 #include "DataFormats/TrackerRecHit2D/interface/SiStripRecHit1D.h"
 #include "DataFormats/TrackerRecHit2D/interface/SiStripRecHit2DCollection.h"
@@ -1113,6 +1114,7 @@ private:
   std::vector<float>
       str_radL;  //http://cmslxr.fnal.gov/lxr/source/DataFormats/GeometrySurface/interface/MediumProperties.h
   std::vector<float> str_bbxi;
+  std::vector<float> str_chargePerCM;
   ////////////////////
   // strip matched hits
   // (first) index runs through hits
@@ -1133,6 +1135,7 @@ private:
   std::vector<float>
       glu_radL;  //http://cmslxr.fnal.gov/lxr/source/DataFormats/GeometrySurface/interface/MediumProperties.h
   std::vector<float> glu_bbxi;
+  std::vector<float> glu_chargePerCM ;
   ////////////////////
   // phase2 Outer Tracker hits
   // (first) index runs through hits
@@ -1584,6 +1587,7 @@ TrackingNtuple::TrackingNtuple(const edm::ParameterSet& iConfig)
       t->Branch("str_zx", &str_zx);
       t->Branch("str_radL", &str_radL);
       t->Branch("str_bbxi", &str_bbxi);
+      t->Branch("str_chargePerCM", &str_chargePerCM);
       //matched hits
       t->Branch("glu_isBarrel", &glu_isBarrel);
       glu_detId.book("glu", t);
@@ -1603,6 +1607,7 @@ TrackingNtuple::TrackingNtuple(const edm::ParameterSet& iConfig)
       t->Branch("glu_zx", &glu_zx);
       t->Branch("glu_radL", &glu_radL);
       t->Branch("glu_bbxi", &glu_bbxi);
+      t->Branch("glu_chargePerCM", &glu_chargePerCM);
     }
     //phase2 OT
     if (includePhase2OTHits_) {
@@ -1944,6 +1949,7 @@ void TrackingNtuple::clearVariables() {
   str_zx.clear();
   str_radL.clear();
   str_bbxi.clear();
+  str_chargePerCM.clear();
   //matched hits
   glu_isBarrel.clear();
   glu_detId.clear();
@@ -1961,6 +1967,7 @@ void TrackingNtuple::clearVariables() {
   glu_zx.clear();
   glu_radL.clear();
   glu_bbxi.clear();
+  glu_chargePerCM.clear();
   //phase2 OT
   ph2_isBarrel.clear();
   ph2_detId.clear();
@@ -2785,6 +2792,7 @@ void TrackingNtuple::fillStripRphiStereoHits(const edm::Event& iEvent,
   str_chargeFraction.resize(totalStripHits);
   str_radL.resize(totalStripHits);
   str_bbxi.resize(totalStripHits);
+  str_chargePerCM.resize(totalStripHits);
 
   auto fill = [&](const SiStripRecHit2DCollection& hits, const char* name) {
     for (const auto& detset : hits) {
@@ -2811,6 +2819,7 @@ void TrackingNtuple::fillStripRphiStereoHits(const edm::Event& iEvent,
         str_chargeFraction[key] = simHitData.chargeFraction;
         str_radL[key] = ttrh->surface()->mediumProperties().radLen();
         str_bbxi[key] = ttrh->surface()->mediumProperties().xi();
+        str_chargePerCM[key] = siStripClusterTools::chargePerCM(hitId,hit.firstClusterRef().stripCluster());
         LogTrace("TrackingNtuple") << name << " cluster=" << key << " subdId=" << hitId.subdetId() << " lay=" << lay
                                    << " rawId=" << hitId.rawId() << " pos =" << ttrh->globalPosition();
 
@@ -2874,6 +2883,7 @@ size_t TrackingNtuple::addStripMatchedHit(const SiStripMatchedRecHit2D& hit,
   glu_zx.push_back(ttrh->globalPositionError().czx());
   glu_radL.push_back(ttrh->surface()->mediumProperties().radLen());
   glu_bbxi.push_back(ttrh->surface()->mediumProperties().xi());
+  glu_chargePerCM.push_back(siStripClusterTools::chargePerCM(hitId,hit->firstClusterRef().stripCluster()));
   LogTrace("TrackingNtuple") << "stripMatchedHit"
                              << " cluster0=" << hit.stereoHit().cluster().key()
                              << " cluster1=" << hit.monoHit().cluster().key() << " subdId=" << hitId.subdetId()

--- a/Validation/RecoTrack/plugins/TrackingNtuple.cc
+++ b/Validation/RecoTrack/plugins/TrackingNtuple.cc
@@ -1512,7 +1512,6 @@ TrackingNtuple::TrackingNtuple(const edm::ParameterSet& iConfig)
     t->Branch("pix_zx", &pix_zx);
     t->Branch("pix_radL", &pix_radL);
     t->Branch("pix_bbxi", &pix_bbxi);
-    t->Branch("pix_bbxi", &pix_bbxi);
     //strips
     if (includeStripHits_) {
       t->Branch("str_isBarrel", &str_isBarrel);

--- a/Validation/RecoTrack/plugins/TrackingNtuple.cc
+++ b/Validation/RecoTrack/plugins/TrackingNtuple.cc
@@ -2405,6 +2405,21 @@ TrackingNtuple::SimHitData TrackingNtuple::matchCluster(
                                     SimHitTPAssociationProducer::simHitTPAssociationListGreater);
       bool foundSimHit = false;
       bool foundElectron = false;
+      int foundElectrons = 0;
+      int foundNonElectrons = 0;
+      edm::ProductID simHitID;
+      for(auto ip = range.first; ip != range.second; ++ip) {
+        TrackPSimHitRef TPhit = ip->second;
+        DetId dId = DetId(TPhit->detUnitId());
+        if (dId.rawId()==hitId.rawId()) {
+          // skip electron SimHits for non-electron TPs also here
+          if(std::abs(TPhit->particleType()) == 11 && std::abs(trackingParticle->pdgId()) != 11) {
+	    foundElectrons++;
+          } else {
+	    foundNonElectrons++;
+	  }
+        }
+      }
       for (auto ip = range.first; ip != range.second; ++ip) {
         TrackPSimHitRef TPhit = ip->second;
         DetId dId = DetId(TPhit->detUnitId());
@@ -2413,6 +2428,7 @@ TrackingNtuple::SimHitData TrackingNtuple::matchCluster(
           if (std::abs(TPhit->particleType()) == 11 && std::abs(trackingParticle->pdgId()) != 11) {
             foundElectron = true;
             if (!keepEleSimHits_) continue;
+	    if (foundNonElectrons > 0) continue;//prioritize: skip electrons if non-electrons are present
           }
 
           foundSimHit = true;

--- a/Validation/RecoTrack/plugins/TrackingNtuple.cc
+++ b/Validation/RecoTrack/plugins/TrackingNtuple.cc
@@ -661,6 +661,7 @@ private:
   const bool includeAllHits_;
   const bool includeMVA_;
   const bool includeTrackingParticles_;
+  const bool includeOOT_;
 
   HistoryBase tracer_;
 
@@ -1302,7 +1303,8 @@ TrackingNtuple::TrackingNtuple(const edm::ParameterSet& iConfig)
       includeSeeds_(iConfig.getUntrackedParameter<bool>("includeSeeds")),
       includeAllHits_(iConfig.getUntrackedParameter<bool>("includeAllHits")),
       includeMVA_(iConfig.getUntrackedParameter<bool>("includeMVA")),
-      includeTrackingParticles_(iConfig.getUntrackedParameter<bool>("includeTrackingParticles")) {
+      includeTrackingParticles_(iConfig.getUntrackedParameter<bool>("includeTrackingParticles")),
+      includeOOT_(iConfig.getUntrackedParameter<bool>("includeOOT")) {
   if (includeSeeds_) {
     seedTokens_ =
         edm::vector_transform(iConfig.getUntrackedParameter<std::vector<edm::InputTag>>("seedTracks"),
@@ -2043,7 +2045,7 @@ void TrackingNtuple::analyze(const edm::Event& iEvent, const edm::EventSetup& iS
   TrackingVertexRefKeyToIndex tvKeyToIndex;
   for (size_t i = 0; i < tvs.size(); ++i) {
     const TrackingVertex& v = tvs[i];
-    if (v.eventId().bunchCrossing() != 0)  // Ignore OOTPU; would be better to not to hardcode?
+    if (!includeOOT_ && v.eventId().bunchCrossing() != 0)  // Ignore OOTPU
       continue;
     tvKeyToIndex[i] = tvRefs.size();
     tvRefs.push_back(TrackingVertexRef(htv, i));
@@ -2287,7 +2289,7 @@ TrackingNtuple::SimHitData TrackingNtuple::matchCluster(
       HitSimType type = HitSimType::OOTPileup;
       if (bx == 0) {
         type = (event == 0 ? HitSimType::Signal : HitSimType::ITPileup);
-      }
+      } else type = HitSimType::OOTPileup;
       ret.type = static_cast<HitSimType>(std::min(static_cast<int>(ret.type), static_cast<int>(type)));
 
       // Limit to only input TrackingParticles (usually signal+ITPU)
@@ -3677,6 +3679,7 @@ void TrackingNtuple::fillDescriptions(edm::ConfigurationDescriptions& descriptio
   desc.addUntracked<bool>("includeAllHits", false);
   desc.addUntracked<bool>("includeMVA", true);
   desc.addUntracked<bool>("includeTrackingParticles", true);
+  desc.addUntracked<bool>("includeOOT", false);
   descriptions.add("trackingNtuple", desc);
 }
 

--- a/Validation/RecoTrack/plugins/TrackingNtuple.cc
+++ b/Validation/RecoTrack/plugins/TrackingNtuple.cc
@@ -658,6 +658,7 @@ private:
   edm::EDGetTokenT<edm::ValueMap<unsigned int>> tpNPixelLayersToken_;
   edm::EDGetTokenT<edm::ValueMap<unsigned int>> tpNStripStereoLayersToken_;
   const bool includeSeeds_;
+  const bool addSeedCartesianCov_;
   const bool includeAllHits_;
   const bool includeMVA_;
   const bool includeTrackingParticles_;
@@ -1215,6 +1216,27 @@ private:
   std::vector<float> see_stateTrajGlbPx;
   std::vector<float> see_stateTrajGlbPy;
   std::vector<float> see_stateTrajGlbPz;
+  std::vector<float> see_stateCcov00;
+  std::vector<float> see_stateCcov01;
+  std::vector<float> see_stateCcov02;
+  std::vector<float> see_stateCcov03;
+  std::vector<float> see_stateCcov04;
+  std::vector<float> see_stateCcov05;
+  std::vector<float> see_stateCcov11;
+  std::vector<float> see_stateCcov12;
+  std::vector<float> see_stateCcov13;
+  std::vector<float> see_stateCcov14;
+  std::vector<float> see_stateCcov15;
+  std::vector<float> see_stateCcov22;
+  std::vector<float> see_stateCcov23;
+  std::vector<float> see_stateCcov24;
+  std::vector<float> see_stateCcov25;
+  std::vector<float> see_stateCcov33;
+  std::vector<float> see_stateCcov34;
+  std::vector<float> see_stateCcov35;
+  std::vector<float> see_stateCcov44;
+  std::vector<float> see_stateCcov45;
+  std::vector<float> see_stateCcov55;
   std::vector<int> see_q;
   std::vector<unsigned int> see_nValid;
   std::vector<unsigned int> see_nPixel;
@@ -1312,6 +1334,7 @@ TrackingNtuple::TrackingNtuple(const edm::ParameterSet& iConfig)
       tpNStripStereoLayersToken_(consumes<edm::ValueMap<unsigned int>>(
           iConfig.getUntrackedParameter<edm::InputTag>("trackingParticleNstripstereolayers"))),
       includeSeeds_(iConfig.getUntrackedParameter<bool>("includeSeeds")),
+      addSeedCartesianCov_(iConfig.getUntrackedParameter<bool>("addSeedCartesianCov")),
       includeAllHits_(iConfig.getUntrackedParameter<bool>("includeAllHits")),
       includeMVA_(iConfig.getUntrackedParameter<bool>("includeMVA")),
       includeTrackingParticles_(iConfig.getUntrackedParameter<bool>("includeTrackingParticles")),
@@ -1660,6 +1683,29 @@ TrackingNtuple::TrackingNtuple(const edm::ParameterSet& iConfig)
     t->Branch("see_stateTrajGlbPx", &see_stateTrajGlbPx);
     t->Branch("see_stateTrajGlbPy", &see_stateTrajGlbPy);
     t->Branch("see_stateTrajGlbPz", &see_stateTrajGlbPz);
+    if (addSeedCartesianCov_){
+      t->Branch("see_stateCcov00", &see_stateCcov00);
+      t->Branch("see_stateCcov01", &see_stateCcov01);
+      t->Branch("see_stateCcov02", &see_stateCcov02);
+      t->Branch("see_stateCcov03", &see_stateCcov03);
+      t->Branch("see_stateCcov04", &see_stateCcov04);
+      t->Branch("see_stateCcov05", &see_stateCcov05);
+      t->Branch("see_stateCcov11", &see_stateCcov11);
+      t->Branch("see_stateCcov12", &see_stateCcov12);
+      t->Branch("see_stateCcov13", &see_stateCcov13);
+      t->Branch("see_stateCcov14", &see_stateCcov14);
+      t->Branch("see_stateCcov15", &see_stateCcov15);
+      t->Branch("see_stateCcov22", &see_stateCcov22);
+      t->Branch("see_stateCcov23", &see_stateCcov23);
+      t->Branch("see_stateCcov24", &see_stateCcov24);
+      t->Branch("see_stateCcov25", &see_stateCcov25);
+      t->Branch("see_stateCcov33", &see_stateCcov33);
+      t->Branch("see_stateCcov34", &see_stateCcov34);
+      t->Branch("see_stateCcov35", &see_stateCcov35);
+      t->Branch("see_stateCcov44", &see_stateCcov44);
+      t->Branch("see_stateCcov45", &see_stateCcov45);
+      t->Branch("see_stateCcov55", &see_stateCcov55);
+    }
     t->Branch("see_q", &see_q);
     t->Branch("see_nValid", &see_nValid);
     t->Branch("see_nPixel", &see_nPixel);
@@ -1973,6 +2019,27 @@ void TrackingNtuple::clearVariables() {
   see_stateTrajGlbPx.clear();
   see_stateTrajGlbPy.clear();
   see_stateTrajGlbPz.clear();
+  see_stateCcov00.clear();
+  see_stateCcov01.clear();
+  see_stateCcov02.clear();
+  see_stateCcov03.clear();
+  see_stateCcov04.clear();
+  see_stateCcov05.clear();
+  see_stateCcov11.clear();
+  see_stateCcov12.clear();
+  see_stateCcov13.clear();
+  see_stateCcov14.clear();
+  see_stateCcov15.clear();
+  see_stateCcov22.clear();
+  see_stateCcov23.clear();
+  see_stateCcov24.clear();
+  see_stateCcov25.clear();
+  see_stateCcov33.clear();
+  see_stateCcov34.clear();
+  see_stateCcov35.clear();
+  see_stateCcov44.clear();
+  see_stateCcov45.clear();
+  see_stateCcov55.clear();
   see_q.clear();
   see_nValid.clear();
   see_nPixel.clear();
@@ -2953,6 +3020,30 @@ void TrackingNtuple::fillSeeds(const edm::Event& iEvent,
       see_stateTrajGlbPx.push_back(stateGlobal.momentum().x());
       see_stateTrajGlbPy.push_back(stateGlobal.momentum().y());
       see_stateTrajGlbPz.push_back(stateGlobal.momentum().z());
+      if (addSeedCartesianCov_){
+	auto const& stateCcov = tsos.cartesianError().matrix();
+	see_stateCcov00.push_back( stateCcov[0][0] );
+	see_stateCcov01.push_back( stateCcov[0][1] );
+	see_stateCcov02.push_back( stateCcov[0][2] );
+	see_stateCcov03.push_back( stateCcov[0][3] );
+	see_stateCcov04.push_back( stateCcov[0][4] );
+	see_stateCcov05.push_back( stateCcov[0][5] );
+	see_stateCcov11.push_back( stateCcov[1][1] );
+	see_stateCcov12.push_back( stateCcov[1][2] );
+	see_stateCcov13.push_back( stateCcov[1][3] );
+	see_stateCcov14.push_back( stateCcov[1][4] );
+	see_stateCcov15.push_back( stateCcov[1][5] );
+	see_stateCcov22.push_back( stateCcov[2][2] );
+	see_stateCcov23.push_back( stateCcov[2][3] );
+	see_stateCcov24.push_back( stateCcov[2][4] );
+	see_stateCcov25.push_back( stateCcov[2][5] );
+	see_stateCcov33.push_back( stateCcov[3][3] );
+	see_stateCcov34.push_back( stateCcov[3][4] );
+	see_stateCcov35.push_back( stateCcov[3][5] );
+	see_stateCcov44.push_back( stateCcov[4][4] );
+	see_stateCcov45.push_back( stateCcov[4][5] );
+	see_stateCcov55.push_back( stateCcov[5][5] );
+      }
 
       see_trkIdx.push_back(-1);  // to be set correctly in fillTracks
       if (includeTrackingParticles_) {
@@ -3728,6 +3819,7 @@ void TrackingNtuple::fillDescriptions(edm::ConfigurationDescriptions& descriptio
   desc.addUntracked<std::string>("TTRHBuilder", "WithTrackAngle");
   desc.addUntracked<std::string>("parametersDefiner", "LhcParametersDefinerForTP");
   desc.addUntracked<bool>("includeSeeds", false);
+  desc.addUntracked<bool>("addSeedCartesianCov", false);
   desc.addUntracked<bool>("includeAllHits", false);
   desc.addUntracked<bool>("includeMVA", true);
   desc.addUntracked<bool>("includeTrackingParticles", true);

--- a/Validation/RecoTrack/plugins/TrackingNtuple.cc
+++ b/Validation/RecoTrack/plugins/TrackingNtuple.cc
@@ -663,6 +663,7 @@ private:
   const bool includeTrackingParticles_;
   const bool includeOOT_;
   const bool keepEleSimHits_;
+  const bool saveSimHitsP3_;
 
   HistoryBase tracer_;
 
@@ -1165,6 +1166,9 @@ private:
   std::vector<float> simhit_x;
   std::vector<float> simhit_y;
   std::vector<float> simhit_z;
+  std::vector<float> simhit_px;
+  std::vector<float> simhit_py;
+  std::vector<float> simhit_pz;
   std::vector<int> simhit_particle;
   std::vector<short> simhit_process;
   std::vector<float> simhit_eloss;
@@ -1306,7 +1310,8 @@ TrackingNtuple::TrackingNtuple(const edm::ParameterSet& iConfig)
       includeMVA_(iConfig.getUntrackedParameter<bool>("includeMVA")),
       includeTrackingParticles_(iConfig.getUntrackedParameter<bool>("includeTrackingParticles")),
       includeOOT_(iConfig.getUntrackedParameter<bool>("includeOOT")),
-      keepEleSimHits_(iConfig.getUntrackedParameter<bool>("keepEleSimHits")) {
+      keepEleSimHits_(iConfig.getUntrackedParameter<bool>("keepEleSimHits")),
+      saveSimHitsP3_(iConfig.getUntrackedParameter<bool>("saveSimHitsP3")) {
   if (includeSeeds_) {
     seedTokens_ =
         edm::vector_transform(iConfig.getUntrackedParameter<std::vector<edm::InputTag>>("seedTracks"),
@@ -1599,6 +1604,11 @@ TrackingNtuple::TrackingNtuple(const edm::ParameterSet& iConfig)
       t->Branch("simhit_x", &simhit_x);
       t->Branch("simhit_y", &simhit_y);
       t->Branch("simhit_z", &simhit_z);
+      if (saveSimHitsP3_){
+        t->Branch("simhit_px", &simhit_px);
+        t->Branch("simhit_py", &simhit_py);
+        t->Branch("simhit_pz", &simhit_pz);
+      }
       t->Branch("simhit_particle", &simhit_particle);
       t->Branch("simhit_process", &simhit_process);
       t->Branch("simhit_eloss", &simhit_eloss);
@@ -1905,6 +1915,9 @@ void TrackingNtuple::clearVariables() {
   simhit_x.clear();
   simhit_y.clear();
   simhit_z.clear();
+  simhit_px.clear();
+  simhit_py.clear();
+  simhit_pz.clear();
   simhit_particle.clear();
   simhit_process.clear();
   simhit_eloss.clear();
@@ -2464,6 +2477,12 @@ void TrackingNtuple::fillSimHits(const TrackerGeometry& tracker,
     simhit_x.push_back(pos.x());
     simhit_y.push_back(pos.y());
     simhit_z.push_back(pos.z());
+    if (saveSimHitsP3_){
+      const auto mom = det->surface().toGlobal(simhit.momentumAtEntry());
+      simhit_px.push_back(mom.x());
+      simhit_py.push_back(mom.y());
+      simhit_pz.push_back(mom.z());
+    }
     simhit_particle.push_back(simhit.particleType());
     simhit_process.push_back(simhit.processType());
     simhit_eloss.push_back(simhit.energyLoss());
@@ -3682,6 +3701,7 @@ void TrackingNtuple::fillDescriptions(edm::ConfigurationDescriptions& descriptio
   desc.addUntracked<bool>("includeTrackingParticles", true);
   desc.addUntracked<bool>("includeOOT", false);
   desc.addUntracked<bool>("keepEleSimHits", false);
+  desc.addUntracked<bool>("saveSimHitsP3", false);
   descriptions.add("trackingNtuple", desc);
 }
 

--- a/Validation/RecoTrack/plugins/TrackingNtuple.cc
+++ b/Validation/RecoTrack/plugins/TrackingNtuple.cc
@@ -671,7 +671,7 @@ private:
   std::string builderName_;
   std::string parametersDefinerName_;
   const bool includeSeeds_;
-  const bool addSeedCartesianCov_;
+  const bool addSeedCurvCov_;
   const bool includeAllHits_;
   const bool includeMVA_;
   const bool includeTrackingParticles_;
@@ -1244,27 +1244,7 @@ private:
   std::vector<float> see_stateTrajGlbPx;
   std::vector<float> see_stateTrajGlbPy;
   std::vector<float> see_stateTrajGlbPz;
-  std::vector<float> see_stateCcov00;
-  std::vector<float> see_stateCcov01;
-  std::vector<float> see_stateCcov02;
-  std::vector<float> see_stateCcov03;
-  std::vector<float> see_stateCcov04;
-  std::vector<float> see_stateCcov05;
-  std::vector<float> see_stateCcov11;
-  std::vector<float> see_stateCcov12;
-  std::vector<float> see_stateCcov13;
-  std::vector<float> see_stateCcov14;
-  std::vector<float> see_stateCcov15;
-  std::vector<float> see_stateCcov22;
-  std::vector<float> see_stateCcov23;
-  std::vector<float> see_stateCcov24;
-  std::vector<float> see_stateCcov25;
-  std::vector<float> see_stateCcov33;
-  std::vector<float> see_stateCcov34;
-  std::vector<float> see_stateCcov35;
-  std::vector<float> see_stateCcov44;
-  std::vector<float> see_stateCcov45;
-  std::vector<float> see_stateCcov55;
+  std::vector<std::vector<float>> see_stateCurvCov;
   std::vector<int> see_q;
   std::vector<unsigned int> see_nValid;
   std::vector<unsigned int> see_nPixel;
@@ -1362,7 +1342,7 @@ TrackingNtuple::TrackingNtuple(const edm::ParameterSet& iConfig)
       tpNStripStereoLayersToken_(consumes<edm::ValueMap<unsigned int>>(
           iConfig.getUntrackedParameter<edm::InputTag>("trackingParticleNstripstereolayers"))),
       includeSeeds_(iConfig.getUntrackedParameter<bool>("includeSeeds")),
-      addSeedCartesianCov_(iConfig.getUntrackedParameter<bool>("addSeedCartesianCov")),
+      addSeedCurvCov_(iConfig.getUntrackedParameter<bool>("addSeedCurvCov")),
       includeAllHits_(iConfig.getUntrackedParameter<bool>("includeAllHits")),
       includeMVA_(iConfig.getUntrackedParameter<bool>("includeMVA")),
       includeTrackingParticles_(iConfig.getUntrackedParameter<bool>("includeTrackingParticles")),
@@ -1745,28 +1725,8 @@ TrackingNtuple::TrackingNtuple(const edm::ParameterSet& iConfig)
     t->Branch("see_stateTrajGlbPx", &see_stateTrajGlbPx);
     t->Branch("see_stateTrajGlbPy", &see_stateTrajGlbPy);
     t->Branch("see_stateTrajGlbPz", &see_stateTrajGlbPz);
-    if (addSeedCartesianCov_) {
-      t->Branch("see_stateCcov00", &see_stateCcov00);
-      t->Branch("see_stateCcov01", &see_stateCcov01);
-      t->Branch("see_stateCcov02", &see_stateCcov02);
-      t->Branch("see_stateCcov03", &see_stateCcov03);
-      t->Branch("see_stateCcov04", &see_stateCcov04);
-      t->Branch("see_stateCcov05", &see_stateCcov05);
-      t->Branch("see_stateCcov11", &see_stateCcov11);
-      t->Branch("see_stateCcov12", &see_stateCcov12);
-      t->Branch("see_stateCcov13", &see_stateCcov13);
-      t->Branch("see_stateCcov14", &see_stateCcov14);
-      t->Branch("see_stateCcov15", &see_stateCcov15);
-      t->Branch("see_stateCcov22", &see_stateCcov22);
-      t->Branch("see_stateCcov23", &see_stateCcov23);
-      t->Branch("see_stateCcov24", &see_stateCcov24);
-      t->Branch("see_stateCcov25", &see_stateCcov25);
-      t->Branch("see_stateCcov33", &see_stateCcov33);
-      t->Branch("see_stateCcov34", &see_stateCcov34);
-      t->Branch("see_stateCcov35", &see_stateCcov35);
-      t->Branch("see_stateCcov44", &see_stateCcov44);
-      t->Branch("see_stateCcov45", &see_stateCcov45);
-      t->Branch("see_stateCcov55", &see_stateCcov55);
+    if (addSeedCurvCov_) {
+      t->Branch("see_stateCurvCov", &see_stateCurvCov);
     }
     t->Branch("see_q", &see_q);
     t->Branch("see_nValid", &see_nValid);
@@ -2095,27 +2055,7 @@ void TrackingNtuple::clearVariables() {
   see_stateTrajGlbPx.clear();
   see_stateTrajGlbPy.clear();
   see_stateTrajGlbPz.clear();
-  see_stateCcov00.clear();
-  see_stateCcov01.clear();
-  see_stateCcov02.clear();
-  see_stateCcov03.clear();
-  see_stateCcov04.clear();
-  see_stateCcov05.clear();
-  see_stateCcov11.clear();
-  see_stateCcov12.clear();
-  see_stateCcov13.clear();
-  see_stateCcov14.clear();
-  see_stateCcov15.clear();
-  see_stateCcov22.clear();
-  see_stateCcov23.clear();
-  see_stateCcov24.clear();
-  see_stateCcov25.clear();
-  see_stateCcov33.clear();
-  see_stateCcov34.clear();
-  see_stateCcov35.clear();
-  see_stateCcov44.clear();
-  see_stateCcov45.clear();
-  see_stateCcov55.clear();
+  see_stateCurvCov.clear();
   see_q.clear();
   see_nValid.clear();
   see_nPixel.clear();
@@ -3260,29 +3200,13 @@ void TrackingNtuple::fillSeeds(const edm::Event& iEvent,
       see_stateTrajGlbPx.push_back(stateGlobal.momentum().x());
       see_stateTrajGlbPy.push_back(stateGlobal.momentum().y());
       see_stateTrajGlbPz.push_back(stateGlobal.momentum().z());
-      if (addSeedCartesianCov_) {
-        auto const& stateCcov = tsos.cartesianError().matrix();
-        see_stateCcov00.push_back(stateCcov[0][0]);
-        see_stateCcov01.push_back(stateCcov[0][1]);
-        see_stateCcov02.push_back(stateCcov[0][2]);
-        see_stateCcov03.push_back(stateCcov[0][3]);
-        see_stateCcov04.push_back(stateCcov[0][4]);
-        see_stateCcov05.push_back(stateCcov[0][5]);
-        see_stateCcov11.push_back(stateCcov[1][1]);
-        see_stateCcov12.push_back(stateCcov[1][2]);
-        see_stateCcov13.push_back(stateCcov[1][3]);
-        see_stateCcov14.push_back(stateCcov[1][4]);
-        see_stateCcov15.push_back(stateCcov[1][5]);
-        see_stateCcov22.push_back(stateCcov[2][2]);
-        see_stateCcov23.push_back(stateCcov[2][3]);
-        see_stateCcov24.push_back(stateCcov[2][4]);
-        see_stateCcov25.push_back(stateCcov[2][5]);
-        see_stateCcov33.push_back(stateCcov[3][3]);
-        see_stateCcov34.push_back(stateCcov[3][4]);
-        see_stateCcov35.push_back(stateCcov[3][5]);
-        see_stateCcov44.push_back(stateCcov[4][4]);
-        see_stateCcov45.push_back(stateCcov[4][5]);
-        see_stateCcov55.push_back(stateCcov[5][5]);
+      if (addSeedCurvCov_) {
+        auto const& stateCcov = tsos.curvilinearError().matrix();
+        std::vector<float> cov(15);
+        auto covP = cov.begin();
+        for (auto const val : stateCcov)
+          *(covP++) = val;  //row-major
+        see_stateCurvCov.push_back(std::move(cov));
       }
 
       see_trkIdx.push_back(-1);  // to be set correctly in fillTracks
@@ -4081,7 +4005,7 @@ void TrackingNtuple::fillDescriptions(edm::ConfigurationDescriptions& descriptio
   desc.addUntracked<std::string>("TTRHBuilder", "WithTrackAngle");
   desc.addUntracked<std::string>("parametersDefiner", "LhcParametersDefinerForTP");
   desc.addUntracked<bool>("includeSeeds", false);
-  desc.addUntracked<bool>("addSeedCartesianCov", false);
+  desc.addUntracked<bool>("addSeedCurvCov", false);
   desc.addUntracked<bool>("includeAllHits", false);
   desc.addUntracked<bool>("includeMVA", true);
   desc.addUntracked<bool>("includeTrackingParticles", true);

--- a/Validation/RecoTrack/plugins/TrackingNtuple.cc
+++ b/Validation/RecoTrack/plugins/TrackingNtuple.cc
@@ -1151,7 +1151,7 @@ private:
   std::vector<float>
       glu_radL;  //http://cmslxr.fnal.gov/lxr/source/DataFormats/GeometrySurface/interface/MediumProperties.h
   std::vector<float> glu_bbxi;
-  std::vector<float> glu_chargePerCM ;
+  std::vector<float> glu_chargePerCM;
   std::vector<int> glu_clustSizeMono;
   std::vector<int> glu_clustSizeStereo;
   std::vector<uint64_t> glu_usedMaskMono;
@@ -1161,10 +1161,10 @@ private:
   // (first) index runs through hits
   std::vector<short> ph2_isBarrel;
   DetIdPhase2OT ph2_detId;
-  std::vector<std::vector<int>> ph2_trkIdx;     // second index runs through tracks containing this hit
-  std::vector<std::vector<int>> ph2_seeIdx;     // second index runs through seeds containing this hit
-  std::vector<std::vector<int>> ph2_simHitIdx;  // second index runs through SimHits inducing this hit
-  std::vector<std::vector<float>> ph2_xySignificance; // second index runs through SimHits inducing this hit
+  std::vector<std::vector<int>> ph2_trkIdx;            // second index runs through tracks containing this hit
+  std::vector<std::vector<int>> ph2_seeIdx;            // second index runs through seeds containing this hit
+  std::vector<std::vector<int>> ph2_simHitIdx;         // second index runs through SimHits inducing this hit
+  std::vector<std::vector<float>> ph2_xySignificance;  // second index runs through SimHits inducing this hit
   //std::vector<std::vector<float>> ph2_chargeFraction; // Not supported at the moment for Phase2
   std::vector<unsigned short> ph2_simType;
   std::vector<float> ph2_x;
@@ -1400,11 +1400,12 @@ TrackingNtuple::TrackingNtuple(const edm::ParameterSet& iConfig)
     for (auto const& mask : maskVPset) {
       auto index = mask.getUntrackedParameter<unsigned int>("index");
       assert(index < 64);
-      pixelUseMaskTokens_.emplace_back(index, consumes<PixelMaskContainer>(mask.getUntrackedParameter<edm::InputTag>("src")));
+      pixelUseMaskTokens_.emplace_back(index,
+                                       consumes<PixelMaskContainer>(mask.getUntrackedParameter<edm::InputTag>("src")));
       if (includeStripHits_)
-        stripUseMaskTokens_.emplace_back(index, consumes<StripMaskContainer>(mask.getUntrackedParameter<edm::InputTag>("src")));
+        stripUseMaskTokens_.emplace_back(
+            index, consumes<StripMaskContainer>(mask.getUntrackedParameter<edm::InputTag>("src")));
     }
-
   }
 
   const bool tpRef = iConfig.getUntrackedParameter<bool>("trackingParticlesRef");
@@ -1694,7 +1695,7 @@ TrackingNtuple::TrackingNtuple(const edm::ParameterSet& iConfig)
       t->Branch("simhit_x", &simhit_x);
       t->Branch("simhit_y", &simhit_y);
       t->Branch("simhit_z", &simhit_z);
-      if (saveSimHitsP3_){
+      if (saveSimHitsP3_) {
         t->Branch("simhit_px", &simhit_px);
         t->Branch("simhit_py", &simhit_py);
         t->Branch("simhit_pz", &simhit_pz);
@@ -1744,7 +1745,7 @@ TrackingNtuple::TrackingNtuple(const edm::ParameterSet& iConfig)
     t->Branch("see_stateTrajGlbPx", &see_stateTrajGlbPx);
     t->Branch("see_stateTrajGlbPy", &see_stateTrajGlbPy);
     t->Branch("see_stateTrajGlbPz", &see_stateTrajGlbPz);
-    if (addSeedCartesianCov_){
+    if (addSeedCartesianCov_) {
       t->Branch("see_stateCcov00", &see_stateCcov00);
       t->Branch("see_stateCcov01", &see_stateCcov01);
       t->Branch("see_stateCcov02", &see_stateCcov02);
@@ -2451,9 +2452,9 @@ TrackingNtuple::SimHitData TrackingNtuple::matchCluster(
   else
     simTrackIdToChargeFraction = chargeFraction(GetCluster<SimLink>::call(cluster), hitId, digiSimLinks);
 
-  float h_x=0, h_y=0;
-  float h_xx=0, h_xy=0, h_yy=0;
-  if (simHitBySignificance_){
+  float h_x = 0, h_y = 0;
+  float h_xx = 0, h_xy = 0, h_yy = 0;
+  if (simHitBySignificance_) {
     h_x = ttrh->localPosition().x();
     h_y = ttrh->localPosition().y();
     h_xx = ttrh->localPositionError().xx();
@@ -2473,7 +2474,8 @@ TrackingNtuple::SimHitData TrackingNtuple::matchCluster(
       HitSimType type = HitSimType::OOTPileup;
       if (bx == 0) {
         type = (event == 0 ? HitSimType::Signal : HitSimType::ITPileup);
-      } else type = HitSimType::OOTPileup;
+      } else
+        type = HitSimType::OOTPileup;
       ret.type = static_cast<HitSimType>(std::min(static_cast<int>(ret.type), static_cast<int>(type)));
 
       // Limit to only input TrackingParticles (usually signal+ITPU)
@@ -2492,56 +2494,57 @@ TrackingNtuple::SimHitData TrackingNtuple::matchCluster(
       bool foundElectron = false;
       int foundElectrons = 0;
       int foundNonElectrons = 0;
-      for(auto ip = range.first; ip != range.second; ++ip) {
+      for (auto ip = range.first; ip != range.second; ++ip) {
         TrackPSimHitRef TPhit = ip->second;
         DetId dId = DetId(TPhit->detUnitId());
-        if (dId.rawId()==hitId.rawId()) {
+        if (dId.rawId() == hitId.rawId()) {
           // skip electron SimHits for non-electron TPs also here
-          if(std::abs(TPhit->particleType()) == 11 && std::abs(trackingParticle->pdgId()) != 11) {
-	    foundElectrons++;
+          if (std::abs(TPhit->particleType()) == 11 && std::abs(trackingParticle->pdgId()) != 11) {
+            foundElectrons++;
           } else {
-	    foundNonElectrons++;
-	  }
+            foundNonElectrons++;
+          }
         }
       }
 
       float minSignificance = 1e12;
-      if (simHitBySignificance_){//save the best matching hit
-	
+      if (simHitBySignificance_) {  //save the best matching hit
+
         int simHitKey = -1;
         edm::ProductID simHitID;
-	for(auto ip = range.first; ip != range.second; ++ip) {
-	  TrackPSimHitRef TPhit = ip->second;
-	  DetId dId = DetId(TPhit->detUnitId());
-	  if (dId.rawId()==hitId.rawId()) {
-	    // skip electron SimHits for non-electron TPs also here
-	    if(std::abs(TPhit->particleType()) == 11 && std::abs(trackingParticle->pdgId()) != 11) {
-	      foundElectron = true;
-	      if (!keepEleSimHits_) continue;
-	    }
-	    
-	    float sx = TPhit->localPosition().x();
-	    float sy = TPhit->localPosition().y();
-	    float dx = sx - h_x;
-	    float dy = sy - h_y;
-	    float sig = (dx*dx*h_yy - 2*dx*dy*h_xy + dy*dy*h_xx)/(h_xx*h_yy - h_xy*h_xy);
-	    
-	    if (sig < minSignificance){
-	      minSignificance = sig;
+        for (auto ip = range.first; ip != range.second; ++ip) {
+          TrackPSimHitRef TPhit = ip->second;
+          DetId dId = DetId(TPhit->detUnitId());
+          if (dId.rawId() == hitId.rawId()) {
+            // skip electron SimHits for non-electron TPs also here
+            if (std::abs(TPhit->particleType()) == 11 && std::abs(trackingParticle->pdgId()) != 11) {
+              foundElectron = true;
+              if (!keepEleSimHits_)
+                continue;
+            }
+
+            float sx = TPhit->localPosition().x();
+            float sy = TPhit->localPosition().y();
+            float dx = sx - h_x;
+            float dy = sy - h_y;
+            float sig = (dx * dx * h_yy - 2 * dx * dy * h_xy + dy * dy * h_xx) / (h_xx * h_yy - h_xy * h_xy);
+
+            if (sig < minSignificance) {
+              minSignificance = sig;
               foundSimHit = true;
-	      simHitKey = TPhit.key();
-	      simHitID = TPhit.id();
-	    }
-	  }
-	}//loop over matching hits
+              simHitKey = TPhit.key();
+              simHitID = TPhit.id();
+            }
+          }
+        }  //loop over matching hits
 
         auto simHitIndex = simHitRefKeyToIndex.at(std::make_pair(simHitKey, simHitID));
         ret.matchingSimHit.push_back(simHitIndex);
 
         double chargeFraction = 0.;
-        for(const SimTrack& simtrk: trackingParticle->g4Tracks()) {
+        for (const SimTrack& simtrk : trackingParticle->g4Tracks()) {
           auto found = simTrackIdToChargeFraction.find(simtrk.trackId());
-          if(found != simTrackIdToChargeFraction.end()) {
+          if (found != simTrackIdToChargeFraction.end()) {
             chargeFraction += found->second;
           }
         }
@@ -2554,8 +2557,8 @@ TrackingNtuple::SimHitData TrackingNtuple::matchCluster(
 
         simhit_hitIdx[simHitIndex].push_back(clusterKey);
         simhit_hitType[simHitIndex].push_back(static_cast<int>(hitType));
-	
-      } else {//save all matching hits
+
+      } else {  //save all matching hits
         for (auto ip = range.first; ip != range.second; ++ip) {
           TrackPSimHitRef TPhit = ip->second;
           DetId dId = DetId(TPhit->detUnitId());
@@ -2563,17 +2566,19 @@ TrackingNtuple::SimHitData TrackingNtuple::matchCluster(
             // skip electron SimHits for non-electron TPs also here
             if (std::abs(TPhit->particleType()) == 11 && std::abs(trackingParticle->pdgId()) != 11) {
               foundElectron = true;
-              if (!keepEleSimHits_) continue;
-              if (foundNonElectrons > 0) continue;//prioritize: skip electrons if non-electrons are present
+              if (!keepEleSimHits_)
+                continue;
+              if (foundNonElectrons > 0)
+                continue;  //prioritize: skip electrons if non-electrons are present
             }
-            
+
             foundSimHit = true;
             auto simHitKey = TPhit.key();
             auto simHitID = TPhit.id();
-            
+
             auto simHitIndex = simHitRefKeyToIndex.at(std::make_pair(simHitKey, simHitID));
             ret.matchingSimHit.push_back(simHitIndex);
-            
+
             double chargeFraction = 0.;
             for (const SimTrack& simtrk : trackingParticle->g4Tracks()) {
               auto found = simTrackIdToChargeFraction.find(simtrk.trackId());
@@ -2583,17 +2588,17 @@ TrackingNtuple::SimHitData TrackingNtuple::matchCluster(
             }
             ret.xySignificance.push_back(minSignificance);
             ret.chargeFraction.push_back(chargeFraction);
-            
+
             // only for debug prints
             ret.bunchCrossing.push_back(bx);
             ret.event.push_back(event);
-            
+
             simhit_hitIdx[simHitIndex].push_back(clusterKey);
             simhit_hitType[simHitIndex].push_back(static_cast<int>(hitType));
           }
         }
-      }//if/else simHitBySignificance_
-      if(!foundSimHit) {
+      }  //if/else simHitBySignificance_
+      if (!foundSimHit) {
         // In case we didn't find a simhit because of filtered-out
         // electron SimHit, just ignore the missing SimHit.
         if (foundElectron && !keepEleSimHits_)
@@ -2617,7 +2622,7 @@ TrackingNtuple::SimHitData TrackingNtuple::matchCluster(
       }
     }
   }
-  
+
   return ret;
 }
 
@@ -2718,7 +2723,7 @@ void TrackingNtuple::fillSimHits(const TrackerGeometry& tracker,
     simhit_x.push_back(pos.x());
     simhit_y.push_back(pos.y());
     simhit_z.push_back(pos.z());
-    if (saveSimHitsP3_){
+    if (saveSimHitsP3_) {
       const auto mom = det->surface().toGlobal(simhit.momentumAtEntry());
       simhit_px.push_back(mom.x());
       simhit_py.push_back(mom.y());
@@ -2755,7 +2760,7 @@ void TrackingNtuple::fillPixelHits(const edm::Event& iEvent,
     iEvent.getByToken(itoken.second, aH);
     pixelMasks.emplace_back(1 << itoken.first, aH.product());
   }
-  auto pixUsedMask = [&pixelMasks] (size_t key) {
+  auto pixUsedMask = [&pixelMasks](size_t key) {
     uint64_t mask = 0;
     for (auto const& m : pixelMasks) {
       if (m.second->mask(key))
@@ -2844,7 +2849,7 @@ void TrackingNtuple::fillStripRphiStereoHits(const edm::Event& iEvent,
     iEvent.getByToken(itoken.second, aH);
     stripMasks.emplace_back(1 << itoken.first, aH.product());
   }
-  auto strUsedMask = [&stripMasks] (size_t key) {
+  auto strUsedMask = [&stripMasks](size_t key) {
     uint64_t mask = 0;
     for (auto const& m : stripMasks) {
       if (m.second->mask(key))
@@ -2906,7 +2911,7 @@ void TrackingNtuple::fillStripRphiStereoHits(const edm::Event& iEvent,
         str_zx[key] = ttrh->globalPositionError().czx();
         str_radL[key] = ttrh->surface()->mediumProperties().radLen();
         str_bbxi[key] = ttrh->surface()->mediumProperties().xi();
-        str_chargePerCM[key] = siStripClusterTools::chargePerCM(hitId,hit.firstClusterRef().stripCluster());
+        str_chargePerCM[key] = siStripClusterTools::chargePerCM(hitId, hit.firstClusterRef().stripCluster());
         str_clustSize[key] = hit.cluster()->amplitudes().size();
         str_usedMask[key] = strUsedMask(key);
         LogTrace("TrackingNtuple") << name << " cluster=" << key << " subdId=" << hitId.subdetId() << " lay=" << lay
@@ -2954,7 +2959,7 @@ size_t TrackingNtuple::addStripMatchedHit(const SiStripMatchedRecHit2D& hit,
                                           const TrackerTopology& tTopo,
                                           const std::vector<std::pair<uint64_t, StripMaskContainer const*>>& stripMasks,
                                           std::vector<std::pair<int, int>>& monoStereoClusterList) {
-  auto strUsedMask = [&stripMasks] (size_t key) {
+  auto strUsedMask = [&stripMasks](size_t key) {
     uint64_t mask = 0;
     for (auto const& m : stripMasks) {
       if (m.second->mask(key))
@@ -2983,7 +2988,7 @@ size_t TrackingNtuple::addStripMatchedHit(const SiStripMatchedRecHit2D& hit,
   glu_zx.push_back(ttrh->globalPositionError().czx());
   glu_radL.push_back(ttrh->surface()->mediumProperties().radLen());
   glu_bbxi.push_back(ttrh->surface()->mediumProperties().xi());
-  glu_chargePerCM.push_back(siStripClusterTools::chargePerCM(hitId,hit.firstClusterRef().stripCluster()));
+  glu_chargePerCM.push_back(siStripClusterTools::chargePerCM(hitId, hit.firstClusterRef().stripCluster()));
   glu_clustSizeMono.push_back(hit.monoHit().cluster()->amplitudes().size());
   glu_clustSizeStereo.push_back(hit.stereoHit().cluster()->amplitudes().size());
   glu_usedMaskMono.push_back(strUsedMask(hit.monoHit().cluster().key()));
@@ -3011,7 +3016,7 @@ void TrackingNtuple::fillStripMatchedHits(const edm::Event& iEvent,
   iEvent.getByToken(stripMatchedRecHitToken_, matchedHits);
   for (auto it = matchedHits->begin(); it != matchedHits->end(); it++) {
     for (auto hit = it->begin(); hit != it->end(); hit++) {
-      addStripMatchedHit(*hit, theTTRHBuilder, tTopo, monoStereoClusterList);
+      addStripMatchedHit(*hit, theTTRHBuilder, tTopo, stripMasks, monoStereoClusterList);
     }
   }
 }
@@ -3149,7 +3154,7 @@ void TrackingNtuple::fillSeeds(const edm::Event& iEvent,
     //for HLT seeds
     label.ReplaceAll("FromPixelTracks", "");
     label.ReplaceAll("PFLowPixel", "");
-    label.ReplaceAll("hltDoubletRecovery", "pixelPairStep");//random choice
+    label.ReplaceAll("hltDoubletRecovery", "pixelPairStep");  //random choice
     int algo = reco::TrackBase::algoByName(label.Data());
 
     edm::ProductID id = seedTracks[0].seedRef().id();
@@ -3244,10 +3249,10 @@ void TrackingNtuple::fillSeeds(const edm::Event& iEvent,
       see_stateTrajPy.push_back(mom.y());
       see_stateTrajPz.push_back(mom.z());
 
-      ///the following is useful for analysis in global coords at seed hit surface      
-      TransientTrackingRecHit::RecHitPointer lastRecHit = theTTRHBuilder.build(&*(seed.recHits().second-1));
-      TrajectoryStateOnSurface tsos = trajectoryStateTransform::transientState(seed.startingState(),
-                                                                               lastRecHit->surface(), &theMF);
+      ///the following is useful for analysis in global coords at seed hit surface
+      TransientTrackingRecHit::RecHitPointer lastRecHit = theTTRHBuilder.build(&*(seed.recHits().end() - 1));
+      TrajectoryStateOnSurface tsos =
+          trajectoryStateTransform::transientState(seed.startingState(), lastRecHit->surface(), &theMF);
       auto const& stateGlobal = tsos.globalParameters();
       see_stateTrajGlbX.push_back(stateGlobal.position().x());
       see_stateTrajGlbY.push_back(stateGlobal.position().y());
@@ -3255,29 +3260,29 @@ void TrackingNtuple::fillSeeds(const edm::Event& iEvent,
       see_stateTrajGlbPx.push_back(stateGlobal.momentum().x());
       see_stateTrajGlbPy.push_back(stateGlobal.momentum().y());
       see_stateTrajGlbPz.push_back(stateGlobal.momentum().z());
-      if (addSeedCartesianCov_){
-	auto const& stateCcov = tsos.cartesianError().matrix();
-	see_stateCcov00.push_back( stateCcov[0][0] );
-	see_stateCcov01.push_back( stateCcov[0][1] );
-	see_stateCcov02.push_back( stateCcov[0][2] );
-	see_stateCcov03.push_back( stateCcov[0][3] );
-	see_stateCcov04.push_back( stateCcov[0][4] );
-	see_stateCcov05.push_back( stateCcov[0][5] );
-	see_stateCcov11.push_back( stateCcov[1][1] );
-	see_stateCcov12.push_back( stateCcov[1][2] );
-	see_stateCcov13.push_back( stateCcov[1][3] );
-	see_stateCcov14.push_back( stateCcov[1][4] );
-	see_stateCcov15.push_back( stateCcov[1][5] );
-	see_stateCcov22.push_back( stateCcov[2][2] );
-	see_stateCcov23.push_back( stateCcov[2][3] );
-	see_stateCcov24.push_back( stateCcov[2][4] );
-	see_stateCcov25.push_back( stateCcov[2][5] );
-	see_stateCcov33.push_back( stateCcov[3][3] );
-	see_stateCcov34.push_back( stateCcov[3][4] );
-	see_stateCcov35.push_back( stateCcov[3][5] );
-	see_stateCcov44.push_back( stateCcov[4][4] );
-	see_stateCcov45.push_back( stateCcov[4][5] );
-	see_stateCcov55.push_back( stateCcov[5][5] );
+      if (addSeedCartesianCov_) {
+        auto const& stateCcov = tsos.cartesianError().matrix();
+        see_stateCcov00.push_back(stateCcov[0][0]);
+        see_stateCcov01.push_back(stateCcov[0][1]);
+        see_stateCcov02.push_back(stateCcov[0][2]);
+        see_stateCcov03.push_back(stateCcov[0][3]);
+        see_stateCcov04.push_back(stateCcov[0][4]);
+        see_stateCcov05.push_back(stateCcov[0][5]);
+        see_stateCcov11.push_back(stateCcov[1][1]);
+        see_stateCcov12.push_back(stateCcov[1][2]);
+        see_stateCcov13.push_back(stateCcov[1][3]);
+        see_stateCcov14.push_back(stateCcov[1][4]);
+        see_stateCcov15.push_back(stateCcov[1][5]);
+        see_stateCcov22.push_back(stateCcov[2][2]);
+        see_stateCcov23.push_back(stateCcov[2][3]);
+        see_stateCcov24.push_back(stateCcov[2][4]);
+        see_stateCcov25.push_back(stateCcov[2][5]);
+        see_stateCcov33.push_back(stateCcov[3][3]);
+        see_stateCcov34.push_back(stateCcov[3][4]);
+        see_stateCcov35.push_back(stateCcov[3][5]);
+        see_stateCcov44.push_back(stateCcov[4][4]);
+        see_stateCcov45.push_back(stateCcov[4][5]);
+        see_stateCcov55.push_back(stateCcov[5][5]);
       }
 
       see_trkIdx.push_back(-1);  // to be set correctly in fillTracks
@@ -4034,10 +4039,10 @@ void TrackingNtuple::fillDescriptions(edm::ConfigurationDescriptions& descriptio
   cMaskDesc.addUntracked<unsigned int>("index");
   cMaskDesc.addUntracked<edm::InputTag>("src");
   std::vector<edm::ParameterSet> cMasks;
-  auto addMask = [&cMasks](reco::Track::TrackAlgorithm algo){
+  auto addMask = [&cMasks](reco::Track::TrackAlgorithm algo) {
     edm::ParameterSet ps;
     ps.addUntrackedParameter<unsigned int>("index", static_cast<unsigned int>(algo));
-    ps.addUntrackedParameter<edm::InputTag>("src", {reco::Track::algoName(algo)+"Clusters"});
+    ps.addUntrackedParameter<edm::InputTag>("src", {reco::Track::algoName(algo) + "Clusters"});
     cMasks.push_back(ps);
   };
   addMask(reco::Track::detachedQuadStep);

--- a/Validation/RecoTrack/plugins/TrackingNtuple.cc
+++ b/Validation/RecoTrack/plugins/TrackingNtuple.cc
@@ -32,6 +32,7 @@
 #include "CommonTools/UtilAlgos/interface/TFileService.h"
 #include "CommonTools/Utils/interface/DynArray.h"
 #include "DataFormats/Provenance/interface/ProductID.h"
+#include "DataFormats/Common/interface/ContainerMask.h"
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/transform.h"
@@ -490,6 +491,9 @@ private:
   using MVACollection = std::vector<float>;
   using QualityMaskCollection = std::vector<unsigned char>;
 
+  using PixelMaskContainer = edm::ContainerMask<edmNew::DetSetVector<SiPixelCluster>>;
+  using StripMaskContainer = edm::ContainerMask<edmNew::DetSetVector<SiStripCluster>>;
+
   struct TPHitIndex {
     TPHitIndex(unsigned int tp = 0, unsigned int simHit = 0, float to = 0, unsigned int id = 0)
         : tpKey(tp), simHitIdx(simHit), tof(to), detId(id) {}
@@ -538,6 +542,7 @@ private:
   size_t addStripMatchedHit(const SiStripMatchedRecHit2D& hit,
                             const TransientTrackingRecHitBuilder& theTTRHBuilder,
                             const TrackerTopology& tTopo,
+                            const std::vector<std::pair<uint64_t, StripMaskContainer const*>>& stripMasks,
                             std::vector<std::pair<int, int>>& monoStereoClusterList);
 
   void fillPhase2OTHits(const edm::Event& iEvent,
@@ -659,6 +664,12 @@ private:
   edm::EDGetTokenT<edm::ValueMap<unsigned int>> tpNLayersToken_;
   edm::EDGetTokenT<edm::ValueMap<unsigned int>> tpNPixelLayersToken_;
   edm::EDGetTokenT<edm::ValueMap<unsigned int>> tpNStripStereoLayersToken_;
+
+  std::vector<std::pair<unsigned int, edm::EDGetTokenT<PixelMaskContainer>>> pixelUseMaskTokens_;
+  std::vector<std::pair<unsigned int, edm::EDGetTokenT<StripMaskContainer>>> stripUseMaskTokens_;
+
+  std::string builderName_;
+  std::string parametersDefinerName_;
   const bool includeSeeds_;
   const bool addSeedCartesianCov_;
   const bool includeAllHits_;
@@ -1093,6 +1104,7 @@ private:
   std::vector<float> pix_bbxi;
   std::vector<int> pix_clustSizeCol;
   std::vector<int> pix_clustSizeRow;
+  std::vector<uint64_t> pix_usedMask;
   ////////////////////
   // strip hits
   // (first) index runs through hits
@@ -1118,6 +1130,7 @@ private:
   std::vector<float> str_bbxi;
   std::vector<float> str_chargePerCM;
   std::vector<int> str_clustSize;
+  std::vector<uint64_t> str_usedMask;
   ////////////////////
   // strip matched hits
   // (first) index runs through hits
@@ -1141,6 +1154,8 @@ private:
   std::vector<float> glu_chargePerCM ;
   std::vector<int> glu_clustSizeMono;
   std::vector<int> glu_clustSizeStereo;
+  std::vector<uint64_t> glu_usedMaskMono;
+  std::vector<uint64_t> glu_usedMaskStereo;
   ////////////////////
   // phase2 Outer Tracker hits
   // (first) index runs through hits
@@ -1150,7 +1165,7 @@ private:
   std::vector<std::vector<int>> ph2_seeIdx;     // second index runs through seeds containing this hit
   std::vector<std::vector<int>> ph2_simHitIdx;  // second index runs through SimHits inducing this hit
   std::vector<std::vector<float>> ph2_xySignificance; // second index runs through SimHits inducing this hit
-  //std::vector<std::vector<float> > ph2_chargeFraction; // Not supported at the moment for Phase2
+  //std::vector<std::vector<float>> ph2_chargeFraction; // Not supported at the moment for Phase2
   std::vector<unsigned short> ph2_simType;
   std::vector<float> ph2_x;
   std::vector<float> ph2_y;
@@ -1378,6 +1393,18 @@ TrackingNtuple::TrackingNtuple(const edm::ParameterSet& iConfig)
       throw cms::Exception("Configuration")
           << "Neither stripDigiSimLink or phase2OTSimLink are set, please set either one.";
     }
+
+    auto const& maskVPset = iConfig.getUntrackedParameterSetVector("clusterMasks");
+    pixelUseMaskTokens_.reserve(maskVPset.size());
+    stripUseMaskTokens_.reserve(maskVPset.size());
+    for (auto const& mask : maskVPset) {
+      auto index = mask.getUntrackedParameter<unsigned int>("index");
+      assert(index < 64);
+      pixelUseMaskTokens_.emplace_back(index, consumes<PixelMaskContainer>(mask.getUntrackedParameter<edm::InputTag>("src")));
+      if (includeStripHits_)
+        stripUseMaskTokens_.emplace_back(index, consumes<StripMaskContainer>(mask.getUntrackedParameter<edm::InputTag>("src")));
+    }
+
   }
 
   const bool tpRef = iConfig.getUntrackedParameter<bool>("trackingParticlesRef");
@@ -1567,6 +1594,7 @@ TrackingNtuple::TrackingNtuple(const edm::ParameterSet& iConfig)
     t->Branch("pix_bbxi", &pix_bbxi);
     t->Branch("pix_clustSizeCol", &pix_clustSizeCol);
     t->Branch("pix_clustSizeRow", &pix_clustSizeRow);
+    t->Branch("pix_usedMask", &pix_usedMask);
     //strips
     if (includeStripHits_) {
       t->Branch("str_isBarrel", &str_isBarrel);
@@ -1596,6 +1624,7 @@ TrackingNtuple::TrackingNtuple(const edm::ParameterSet& iConfig)
       t->Branch("str_bbxi", &str_bbxi);
       t->Branch("str_chargePerCM", &str_chargePerCM);
       t->Branch("str_clustSize", &str_clustSize);
+      t->Branch("str_usedMask", &str_usedMask);
       //matched hits
       t->Branch("glu_isBarrel", &glu_isBarrel);
       glu_detId.book("glu", t);
@@ -1618,6 +1647,8 @@ TrackingNtuple::TrackingNtuple(const edm::ParameterSet& iConfig)
       t->Branch("glu_chargePerCM", &glu_chargePerCM);
       t->Branch("glu_clustSizeMono", &glu_clustSizeMono);
       t->Branch("glu_clustSizeStereo", &glu_clustSizeStereo);
+      t->Branch("glu_usedMaskMono", &glu_usedMaskMono);
+      t->Branch("glu_usedMaskStereo", &glu_usedMaskStereo);
     }
     //phase2 OT
     if (includePhase2OTHits_) {
@@ -1941,6 +1972,7 @@ void TrackingNtuple::clearVariables() {
   pix_bbxi.clear();
   pix_clustSizeCol.clear();
   pix_clustSizeRow.clear();
+  pix_usedMask.clear();
   //strips
   str_isBarrel.clear();
   str_detId.clear();
@@ -1963,6 +1995,7 @@ void TrackingNtuple::clearVariables() {
   str_bbxi.clear();
   str_chargePerCM.clear();
   str_clustSize.clear();
+  str_usedMask.clear();
   //matched hits
   glu_isBarrel.clear();
   glu_detId.clear();
@@ -1983,6 +2016,8 @@ void TrackingNtuple::clearVariables() {
   glu_chargePerCM.clear();
   glu_clustSizeMono.clear();
   glu_clustSizeStereo.clear();
+  glu_usedMaskMono.clear();
+  glu_usedMaskStereo.clear();
   //phase2 OT
   ph2_isBarrel.clear();
   ph2_detId.clear();
@@ -2713,6 +2748,22 @@ void TrackingNtuple::fillPixelHits(const edm::Event& iEvent,
                                    const TrackerTopology& tTopo,
                                    const SimHitRefKeyToIndex& simHitRefKeyToIndex,
                                    std::set<edm::ProductID>& hitProductIds) {
+  std::vector<std::pair<uint64_t, PixelMaskContainer const*>> pixelMasks;
+  pixelMasks.reserve(pixelUseMaskTokens_.size());
+  for (const auto& itoken : pixelUseMaskTokens_) {
+    edm::Handle<PixelMaskContainer> aH;
+    iEvent.getByToken(itoken.second, aH);
+    pixelMasks.emplace_back(1 << itoken.first, aH.product());
+  }
+  auto pixUsedMask = [&pixelMasks] (size_t key) {
+    uint64_t mask = 0;
+    for (auto const& m : pixelMasks) {
+      if (m.second->mask(key))
+        mask |= m.first;
+    }
+    return mask;
+  };
+
   edm::Handle<SiPixelRecHitCollection> pixelHits;
   iEvent.getByToken(pixelRecHitToken_, pixelHits);
   for (auto it = pixelHits->begin(); it != pixelHits->end(); it++) {
@@ -2742,6 +2793,7 @@ void TrackingNtuple::fillPixelHits(const edm::Event& iEvent,
       pix_bbxi.push_back(ttrh->surface()->mediumProperties().xi());
       pix_clustSizeCol.push_back(hit->cluster()->sizeY());
       pix_clustSizeRow.push_back(hit->cluster()->sizeX());
+      pix_usedMask.push_back(pixUsedMask(hit->firstClusterRef().key()));
 
       LogTrace("TrackingNtuple") << "pixHit cluster=" << key << " subdId=" << hitId.subdetId() << " lay=" << lay
                                  << " rawId=" << hitId.rawId() << " pos =" << ttrh->globalPosition();
@@ -2785,6 +2837,22 @@ void TrackingNtuple::fillStripRphiStereoHits(const edm::Event& iEvent,
                                              const TrackerTopology& tTopo,
                                              const SimHitRefKeyToIndex& simHitRefKeyToIndex,
                                              std::set<edm::ProductID>& hitProductIds) {
+  std::vector<std::pair<uint64_t, StripMaskContainer const*>> stripMasks;
+  stripMasks.reserve(stripUseMaskTokens_.size());
+  for (const auto& itoken : stripUseMaskTokens_) {
+    edm::Handle<StripMaskContainer> aH;
+    iEvent.getByToken(itoken.second, aH);
+    stripMasks.emplace_back(1 << itoken.first, aH.product());
+  }
+  auto strUsedMask = [&stripMasks] (size_t key) {
+    uint64_t mask = 0;
+    for (auto const& m : stripMasks) {
+      if (m.second->mask(key))
+        mask |= m.first;
+    }
+    return mask;
+  };
+
   //index strip hit branches by cluster index
   edm::Handle<SiStripRecHit2DCollection> rphiHits;
   iEvent.getByToken(stripRphiRecHitToken_, rphiHits);
@@ -2813,6 +2881,7 @@ void TrackingNtuple::fillStripRphiStereoHits(const edm::Event& iEvent,
   str_bbxi.resize(totalStripHits);
   str_chargePerCM.resize(totalStripHits);
   str_clustSize.resize(totalStripHits);
+  str_usedMask.resize(totalStripHits);
 
   auto fill = [&](const SiStripRecHit2DCollection& hits, const char* name) {
     for (const auto& detset : hits) {
@@ -2839,6 +2908,7 @@ void TrackingNtuple::fillStripRphiStereoHits(const edm::Event& iEvent,
         str_bbxi[key] = ttrh->surface()->mediumProperties().xi();
         str_chargePerCM[key] = siStripClusterTools::chargePerCM(hitId,hit.firstClusterRef().stripCluster());
         str_clustSize[key] = hit.cluster()->amplitudes().size();
+        str_usedMask[key] = strUsedMask(key);
         LogTrace("TrackingNtuple") << name << " cluster=" << key << " subdId=" << hitId.subdetId() << " lay=" << lay
                                    << " rawId=" << hitId.rawId() << " pos =" << ttrh->globalPosition();
 
@@ -2882,7 +2952,17 @@ void TrackingNtuple::fillStripRphiStereoHits(const edm::Event& iEvent,
 size_t TrackingNtuple::addStripMatchedHit(const SiStripMatchedRecHit2D& hit,
                                           const TransientTrackingRecHitBuilder& theTTRHBuilder,
                                           const TrackerTopology& tTopo,
+                                          const std::vector<std::pair<uint64_t, StripMaskContainer const*>>& stripMasks,
                                           std::vector<std::pair<int, int>>& monoStereoClusterList) {
+  auto strUsedMask = [&stripMasks] (size_t key) {
+    uint64_t mask = 0;
+    for (auto const& m : stripMasks) {
+      if (m.second->mask(key))
+        mask |= m.first;
+    }
+    return mask;
+  };
+
   TransientTrackingRecHit::RecHitPointer ttrh = theTTRHBuilder.build(&hit);
   const auto hitId = hit.geographicalId();
   const int lay = tTopo.layer(hitId);
@@ -2906,6 +2986,8 @@ size_t TrackingNtuple::addStripMatchedHit(const SiStripMatchedRecHit2D& hit,
   glu_chargePerCM.push_back(siStripClusterTools::chargePerCM(hitId,hit.firstClusterRef().stripCluster()));
   glu_clustSizeMono.push_back(hit.monoHit().cluster()->amplitudes().size());
   glu_clustSizeStereo.push_back(hit.stereoHit().cluster()->amplitudes().size());
+  glu_usedMaskMono.push_back(strUsedMask(hit.monoHit().cluster().key()));
+  glu_usedMaskStereo.push_back(strUsedMask(hit.stereoHit().cluster().key()));
   LogTrace("TrackingNtuple") << "stripMatchedHit"
                              << " cluster0=" << hit.stereoHit().cluster().key()
                              << " cluster1=" << hit.monoHit().cluster().key() << " subdId=" << hitId.subdetId()
@@ -2917,6 +2999,14 @@ void TrackingNtuple::fillStripMatchedHits(const edm::Event& iEvent,
                                           const TransientTrackingRecHitBuilder& theTTRHBuilder,
                                           const TrackerTopology& tTopo,
                                           std::vector<std::pair<int, int>>& monoStereoClusterList) {
+  std::vector<std::pair<uint64_t, StripMaskContainer const*>> stripMasks;
+  stripMasks.reserve(stripUseMaskTokens_.size());
+  for (const auto& itoken : stripUseMaskTokens_) {
+    edm::Handle<StripMaskContainer> aH;
+    iEvent.getByToken(itoken.second, aH);
+    stripMasks.emplace_back(1 << itoken.first, aH.product());
+  }
+
   edm::Handle<SiStripMatchedRecHit2DCollection> matchedHits;
   iEvent.getByToken(stripMatchedRecHitToken_, matchedHits);
   for (auto it = matchedHits->begin(); it != matchedHits->end(); it++) {
@@ -3033,6 +3123,14 @@ void TrackingNtuple::fillSeeds(const edm::Event& iEvent,
       throw cms::Exception("LogicError") << "Got " << seedTracks.size() << " seeds, but " << seedStopInfos.size()
                                          << " seed stopping infos for collections " << labels.module << ", "
                                          << labels2.module;
+    }
+
+    std::vector<std::pair<uint64_t, StripMaskContainer const*>> stripMasks;
+    stripMasks.reserve(stripUseMaskTokens_.size());
+    for (const auto& itoken : stripUseMaskTokens_) {
+      edm::Handle<StripMaskContainer> aH;
+      iEvent.getByToken(itoken.second, aH);
+      stripMasks.emplace_back(1 << itoken.first, aH.product());
     }
 
     // The associator interfaces really need to be fixed...
@@ -3244,7 +3342,7 @@ void TrackingNtuple::fillSeeds(const edm::Event& iEvent,
               // SiStripMatchedRecHit2DCollection, e.g. via muon
               // outside-in seeds (or anything taking hits from
               // MeasurementTrackerEvent). So let's add them here.
-              gluedIndex = addStripMatchedHit(*matchedHit, theTTRHBuilder, tTopo, monoStereoClusterList);
+              gluedIndex = addStripMatchedHit(*matchedHit, theTTRHBuilder, tTopo, stripMasks, monoStereoClusterList);
             }
 
             if (includeAllHits_)
@@ -3931,6 +4029,28 @@ void TrackingNtuple::fillDescriptions(edm::ConfigurationDescriptions& descriptio
                                  edm::InputTag("muonSeededTrackCandidatesOutIn")});
   desc.addUntracked<edm::InputTag>("tracks", edm::InputTag("generalTracks"));
   desc.addUntracked<std::vector<std::string>>("trackMVAs", std::vector<std::string>{{"generalTracks"}});
+
+  edm::ParameterSetDescription cMaskDesc;
+  cMaskDesc.addUntracked<unsigned int>("index");
+  cMaskDesc.addUntracked<edm::InputTag>("src");
+  std::vector<edm::ParameterSet> cMasks;
+  auto addMask = [&cMasks](reco::Track::TrackAlgorithm algo){
+    edm::ParameterSet ps;
+    ps.addUntrackedParameter<unsigned int>("index", static_cast<unsigned int>(algo));
+    ps.addUntrackedParameter<edm::InputTag>("src", {reco::Track::algoName(algo)+"Clusters"});
+    cMasks.push_back(ps);
+  };
+  addMask(reco::Track::detachedQuadStep);
+  addMask(reco::Track::highPtTripletStep);
+  addMask(reco::Track::detachedTripletStep);
+  addMask(reco::Track::lowPtQuadStep);
+  addMask(reco::Track::lowPtTripletStep);
+  addMask(reco::Track::mixedTripletStep);
+  addMask(reco::Track::pixelLessStep);
+  addMask(reco::Track::pixelPairStep);
+  addMask(reco::Track::tobTecStep);
+  desc.addVPSetUntracked("clusterMasks", cMaskDesc, cMasks);
+
   desc.addUntracked<edm::InputTag>("trackingParticles", edm::InputTag("mix", "MergedTrackTruth"));
   desc.addUntracked<bool>("trackingParticlesRef", false);
   desc.addUntracked<edm::InputTag>("clusterTPMap", edm::InputTag("tpClusterProducer"));

--- a/Validation/RecoTrack/python/customiseTrackingNtuple.py
+++ b/Validation/RecoTrack/python/customiseTrackingNtuple.py
@@ -148,6 +148,6 @@ def extendedContent(process):
     process.trackingNtuple.keepEleSimHits = True
 
     process.trackingNtuple.saveSimHitsP3 = True
-    process.trackingNtuple.addSeedCartesianCov = True
+    process.trackingNtuple.addSeedCurvCov = True
 
     return process

--- a/Validation/RecoTrack/python/customiseTrackingNtuple.py
+++ b/Validation/RecoTrack/python/customiseTrackingNtuple.py
@@ -113,7 +113,7 @@ def customiseTrackingNtupleHLT(process):
         #make sure that all iter tracking is done before running the ntuple-related modules
         process.trackingNtupleSequence.insert(0,process.hltMergedTracks)
 
-    process.trackingNtuple.tracks = "hltIter0PFlowCtfWithMaterialTracks"
+    process.trackingNtuple.tracks = "hltMergedTracks"
     process.trackingNtuple.seedTracks = _seedSelectors
     process.trackingNtuple.trackCandidates = _candidatesProducers
     process.trackingNtuple.clusterTPMap = "hltTPClusterProducer"
@@ -127,8 +127,15 @@ def customiseTrackingNtupleHLT(process):
     process.trackingNtuple.TTRHBuilder = "hltESPTTRHBWithTrackAngle"
     process.trackingNtuple.parametersDefiner = "hltLhcParametersDefinerForTP"
     process.trackingNtuple.includeMVA = False
+
+    return process
+
+def extendedContent(process):
+    process.trackingParticlesIntime.intimeOnly = False
+    process.trackingNtuple.includeOOT = True
+    process.trackingNtuple.keepEleSimHits = True
+
     process.trackingNtuple.saveSimHitsP3 = True
     process.trackingNtuple.addSeedCartesianCov = True
 
-    process.trackingNtupleSequence
     return process

--- a/Validation/RecoTrack/python/customiseTrackingNtuple.py
+++ b/Validation/RecoTrack/python/customiseTrackingNtuple.py
@@ -8,15 +8,19 @@ def _label(tag):
         t = cms.InputTag(tag)
     return t.getModuleLabel()+t.getProductInstanceLabel()
 
-def customiseTrackingNtuple(process):
+def customiseTrackingNtupleTool(process, isRECO = True):
     process.load("Validation.RecoTrack.trackingNtuple_cff")
     process.TFileService = cms.Service("TFileService",
         fileName = cms.string('trackingNtuple.root')
     )
 
     if process.trackingNtuple.includeSeeds.value():
-        if not hasattr(process, "reconstruction_step"):
-            raise Exception("TrackingNtuple includeSeeds=True needs reconstruction which is missing")
+        if isRECO:
+            if not hasattr(process, "reconstruction_step"):
+                raise Exception("TrackingNtuple includeSeeds=True needs reconstruction which is missing")
+        else: #assumes HLT with PF iter
+            if not hasattr(process, "HLTIterativeTrackingIter02"):
+                raise Exception("TrackingNtuple includeSeeds=True needs HLTIterativeTrackingIter02 which is missing")
 
     # Replace validation_step with ntuplePath
     if not hasattr(process, "validation_step"):
@@ -27,7 +31,21 @@ def customiseTrackingNtuple(process):
     usePileupSimHits = hasattr(process, "mix") and hasattr(process.mix, "input") and len(process.mix.input.fileNames) > 0
 #    process.eda = cms.EDAnalyzer("EventContentAnalyzer")
 
+    if not isRECO:
+        if not hasattr(process,"hltMultiTrackValidation"):
+            process.load("Validation.RecoTrack.HLTmultiTrackValidator_cff")
+        process.trackingNtupleSequence = process.hltMultiTrackValidation.copy()
+        import RecoLocalTracker.SiStripRecHitConverter.SiStripRecHitConverter_cfi as SiStripRecHitConverter_cfi
+        process.hltSiStripRecHits = SiStripRecHitConverter_cfi.siStripMatchedRecHits.clone(
+            ClusterProducer = "hltSiStripRawToClustersFacility",
+            StripCPE = "hltESPStripCPEfromTrackAngle:hltESPStripCPEfromTrackAngle"
+        )
+        process.trackingNtupleSequence.insert(0,process.trackingParticlesIntime+process.simHitTPAssocProducer)
+        process.trackingNtupleSequence.remove(process.hltTrackValidator)
+        process.trackingNtupleSequence += process.hltSiStripRecHits + process.trackingNtuple
+
     ntuplePath = cms.Path(process.trackingNtupleSequence)
+
     if process.trackingNtuple.includeAllHits and process.trackingNtuple.includeTrackingParticles and usePileupSimHits:
         ntuplePath.insert(0, cms.SequencePlaceholder("mix"))
 
@@ -61,4 +79,56 @@ def customiseTrackingNtuple(process):
             path.remove(outputModule)
         
 
+    return process
+
+def customiseTrackingNtuple(process):
+    customiseTrackingNtupleTool(process, isRECO = True)
+    return process
+
+def customiseTrackingNtupleHLT(process):
+    import Validation.RecoTrack.TrackValidation_cff as _TrackValidation_cff
+    _seedProducers = [
+        "hltIter0PFLowPixelSeedsFromPixelTracks",
+        "hltIter1PFLowPixelSeedsFromPixelTracks",
+        "hltIter2PFlowPixelSeeds",
+        "hltDoubletRecoveryPFlowPixelSeeds"
+    ]
+    _candidatesProducers = [ 
+        "hltIter0PFlowCkfTrackCandidates",
+        "hltIter1PFlowCkfTrackCandidates",
+        "hltIter2PFlowCkfTrackCandidates",
+        "hltDoubletRecoveryPFlowCkfTrackCandidates"
+    ]
+    (_seedSelectors, _tmpTask) = _TrackValidation_cff._addSeedToTrackProducers(_seedProducers, globals())
+    _seedSelectorsTask = cms.Task()
+    for modName in _seedSelectors:
+        if not hasattr(process, modName):
+            setattr(process,modName, globals()[modName].clone(beamSpot = "hltOnlineBeamSpot"))
+        _seedSelectorsTask.add(getattr(process, modName))
+
+    customiseTrackingNtupleTool(process, isRECO = False)
+
+    process.trackingNtupleSequence.insert(0,cms.Sequence(_seedSelectorsTask))
+    if process.hltSiStripRawToClustersFacility.onDemand.value():
+        #make sure that all iter tracking is done before running the ntuple-related modules
+        process.trackingNtupleSequence.insert(0,process.hltMergedTracks)
+
+    process.trackingNtuple.tracks = "hltIter0PFlowCtfWithMaterialTracks"
+    process.trackingNtuple.seedTracks = _seedSelectors
+    process.trackingNtuple.trackCandidates = _candidatesProducers
+    process.trackingNtuple.clusterTPMap = "hltTPClusterProducer"
+    process.trackingNtuple.trackAssociator = "hltTrackAssociatorByHits"
+    process.trackingNtuple.beamSpot = "hltOnlineBeamSpot"
+    process.trackingNtuple.pixelRecHits = "hltSiPixelRecHits"
+    process.trackingNtuple.stripRphiRecHits = "hltSiStripRecHits:rphiRecHit"
+    process.trackingNtuple.stripStereoRecHits = "hltSiStripRecHits:stereoRecHit"
+    process.trackingNtuple.stripMatchedRecHits = "hltSiStripRecHits:matchedRecHit"
+    process.trackingNtuple.vertices = "hltPixelVertices"
+    process.trackingNtuple.TTRHBuilder = "hltESPTTRHBWithTrackAngle"
+    process.trackingNtuple.parametersDefiner = "hltLhcParametersDefinerForTP"
+    process.trackingNtuple.includeMVA = False
+    process.trackingNtuple.saveSimHitsP3 = True
+    process.trackingNtuple.addSeedCartesianCov = True
+
+    process.trackingNtupleSequence
     return process


### PR DESCRIPTION
these updates accumulated over a couple of years in the mkFit and line-segment tracking (LST) developments.
The default trackingNtuple logic should be the same (aside for a few added branches).

Summary of changes relative to the upstream in TrackingNtuple
- optional for simhits info:
    - can add OOT hits with `includeOOT`
    - can keep (secondary) electron simhits with `keepEleSimHits`
    - can save simhit momentum px,py,pz with `saveSimHitsP3`
    - can enable saving only the closest simhit based on significance sorting with `simHitBySignificance`
- optional for seed details:
    - can save Curvilinear 5x5 covariance with `addSeedCurvCov` in a row-major vector of size 15
- added by default:
    - bitmask of cluster masking used per iteration; configurable via `clusterMasks`
    - cluster charge per CM
    - cluster size 
    - seed state parameters in global coordinates (x,y,z and px,py,pz)
- config tools now have `customiseTrackingNtupleHLT` to be able to run on HLT tracking

Also, add `TrackSimpleMerger` which can concatenate a set of reco::Track collections.
