### PR TITLE
[ASAN] Fix one definition rules violations

### DIFF
--- a/GeneratorInterface/Core/interface/FortranCallback.h
+++ b/GeneratorInterface/Core/interface/FortranCallback.h
@@ -43,17 +43,9 @@ namespace gen {
 
   // --** Implementation **---
 
-  FortranCallback* FortranCallback::fInstance = nullptr;
-
   inline FortranCallback::FortranCallback()
       //   : fPartonLevel(0)
       : fRunBlock(nullptr), fEventBlock(nullptr), fIterationsPerEvent(0) {}
-
-  inline FortranCallback* FortranCallback::getInstance() {
-    if (fInstance == nullptr)
-      fInstance = new FortranCallback;
-    return fInstance;
-  }
 
   inline void FortranCallback::fillHeader() {
     if (fRunBlock == nullptr)

--- a/GeneratorInterface/Core/src/FortranCallback.cc
+++ b/GeneratorInterface/Core/src/FortranCallback.cc
@@ -1,0 +1,11 @@
+#include "GeneratorInterface/Core/interface/FortranCallback.h"
+namespace gen {
+
+  FortranCallback* FortranCallback::fInstance = nullptr;
+
+  FortranCallback* FortranCallback::getInstance() {
+    if (fInstance == nullptr)
+      fInstance = new gen::FortranCallback;
+    return fInstance;
+  }
+};

--- a/GeneratorInterface/Core/src/FortranCallback.cc
+++ b/GeneratorInterface/Core/src/FortranCallback.cc
@@ -8,4 +8,4 @@ namespace gen {
       fInstance = new gen::FortranCallback;
     return fInstance;
   }
-};
+};  // namespace gen

--- a/GeneratorInterface/ExhumeInterface/src/ExhumeHadronizer.cc
+++ b/GeneratorInterface/ExhumeInterface/src/ExhumeHadronizer.cc
@@ -24,7 +24,7 @@
 #include <string>
 #include <sstream>
 
-HepMC::IO_HEPEVT conv;
+HepMC::IO_HEPEVT exhume_conv;
 
 namespace gen {
   extern "C" {
@@ -158,7 +158,7 @@ namespace gen {
     exhumeEvent_->Generate();
     exhumeProcess_->Hadronise();
 
-    event().reset(conv.read_next_event());
+    event().reset(exhume_conv.read_next_event());
 
     return true;
   }

--- a/GeneratorInterface/Pythia6Interface/plugins/Pythia6Hadronizer.cc
+++ b/GeneratorInterface/Pythia6Interface/plugins/Pythia6Hadronizer.cc
@@ -21,7 +21,7 @@
 
 #include "GeneratorInterface/PartonShowerVeto/interface/JetMatching.h"
 
-HepMC::IO_HEPEVT conv;
+HepMC::IO_HEPEVT pythia6_conv;
 
 #include "HepPID/ParticleIDTranslations.hh"
 
@@ -431,7 +431,7 @@ namespace gen {
     }
 
     call_pyhepc(1);
-    event().reset(conv.read_next_event());
+    event().reset(pythia6_conv.read_next_event());
 
     // this is to deal with post-gen tools & residualDecay() that may reuse PYJETS
     //
@@ -496,7 +496,7 @@ namespace gen {
     }
 
     call_pyhepc(1);
-    event().reset(conv.read_next_event());
+    event().reset(pythia6_conv.read_next_event());
 
     // this is to deal with post-gen tools and/or residualDecay(), that may reuse PYJETS
     //


### PR DESCRIPTION
GCC 10 ASAN IBs failed due to `One Definition Rule` violations

- `gen::FortranCallback::fInstance` is defined in the header file `GeneratorInterface/Core/interface/FortranCallback.h`. This PR proposes to define it in a `cc` file
```
==13090==ERROR: AddressSanitizer: odr-violation (0x2b5fe7583ac0):
  [1] size=8 'fInstance' CMSSW_12_0_ASAN_X_2021-06-25-2300/src/GeneratorInterface/Core/interface/FortranCallback.h:46:20
  [2] size=8 'fInstance' CMSSW_12_0_ASAN_X_2021-06-25-2300/src/GeneratorInterface/Core/interface/FortranCallback.h:46:20
These globals were registered at these points:
  [1]:
    #0 0x2b5f3ab95f70 in __asan_register_globals ../../../../libsanitizer/asan/asan_globals.cpp:341
    #1 0x2b5f3a94a9c2 in _dl_init_internal (/lib64/ld-linux-x86-64.so.2+0xf9c2)
    #2 0x7ffd95da3fbe  (<unknown module>)

  [2]:
    #0 0x2b5f3ab95f70 in __asan_register_globals ../../../../libsanitizer/asan/asan_globals.cpp:341
    #1 0x2b5f3a94a9c2 in _dl_init_internal (/lib64/ld-linux-x86-64.so.2+0xf9c2)
    #2 0x7ffd95da3fbe  (<unknown module>)

==13090==HINT: if you don't care about these errors you may set ASAN_OPTIONS=detect_odr_violation=0
```

- `HepMC::IO_HEPEVT conv;` is defined twice . I propose to just use different variables names. Feel free to propose a better solution.
```
==20119==ERROR: AddressSanitizer: odr-violation (0x7f68b1caaa60):
  [1] size=16 'conv' GeneratorInterface/Pythia6Interface/plugins/Pythia6Hadronizer.cc:24:18
  [2] size=16 'conv' GeneratorInterface/ExhumeInterface/src/ExhumeHadronizer.cc:27:18
These globals were registered at these points:
  [1]:
    #0 0x7f68c0f61f70 in __asan_register_globals ../../../../libsanitizer/asan/asan_globals.cpp:341
    #1 0x7f68c19029c2 in _dl_init_internal (/lib64/ld-linux-x86-64.so.2+0xf9c2)
    #2 0x7ffd278c7c70  (<unknown module>)

  [2]:
    #0 0x7f68c0f61f70 in __asan_register_globals ../../../../libsanitizer/asan/asan_globals.cpp:341
    #1 0x7f68c19029c2 in _dl_init_internal (/lib64/ld-linux-x86-64.so.2+0xf9c2)
    #2 0x7ffd278c7c70  (<unknown module>)

==20119==HINT: if you don't care about these errors you may set ASAN_OPTIONS=detect_odr_violation=0
```