### PR TITLE
Make PixelDigi conversion to legacy optional

### DIFF
--- a/DataFormats/Common/interface/DetSetVectorNew.h
+++ b/DataFormats/Common/interface/DetSetVectorNew.h
@@ -212,6 +212,7 @@ namespace edmNew {
         static DetSetVector<T>::Item d;
         return d;
       }
+
       FastFiller(DetSetVector<T>& iv, id_type id, bool isaveEmpty = false)
           : m_v(iv), m_item(m_v.ready() ? m_v.push_back(id) : dummy()), m_saveEmpty(isaveEmpty) {
         if (m_v.onDemand())
@@ -271,12 +272,21 @@ namespace edmNew {
       DataIter begin() { return m_v.m_data.begin() + m_item.offset; }
       DataIter end() { return begin() + size(); }
 
+      template <typename... Args>
+      void emplace_back(Args&&... args) {
+        checkCapacityExausted();
+         m_v.m_data.emplace_back(args...);
+        ++m_v.m_dataSize;
+        m_item.size++;
+      }
+
       void push_back(data_type const& d) {
         checkCapacityExausted();
         m_v.m_data.push_back(d);
         ++m_v.m_dataSize;
         m_item.size++;
       }
+
       void push_back(data_type&& d) {
         checkCapacityExausted();
         m_v.m_data.push_back(std::move(d));
@@ -355,6 +365,9 @@ namespace edmNew {
       data_type& operator[](size_type i) { return m_lv[i]; }
       DataIter begin() { return m_lv.begin(); }
       DataIter end() { return m_lv.end(); }
+
+      template <typename... Args>
+      void emplace_back(Args&&... args) {m_lv.emplace_back(args...); }
 
       void push_back(data_type const& d) { m_lv.push_back(d); }
       void push_back(data_type&& d) { m_lv.push_back(std::move(d)); }

--- a/DataFormats/Common/interface/DetSetVectorNew.h
+++ b/DataFormats/Common/interface/DetSetVectorNew.h
@@ -275,7 +275,7 @@ namespace edmNew {
       template <typename... Args>
       void emplace_back(Args&&... args) {
         checkCapacityExausted();
-         m_v.m_data.emplace_back(args...);
+        m_v.m_data.emplace_back(args...);
         ++m_v.m_dataSize;
         m_item.size++;
       }
@@ -367,7 +367,9 @@ namespace edmNew {
       DataIter end() { return m_lv.end(); }
 
       template <typename... Args>
-      void emplace_back(Args&&... args) {m_lv.emplace_back(args...); }
+      void emplace_back(Args&&... args) {
+        m_lv.emplace_back(args...);
+      }
 
       void push_back(data_type const& d) { m_lv.push_back(d); }
       void push_back(data_type&& d) { m_lv.push_back(std::move(d)); }

--- a/DataFormats/SiPixelCluster/interface/SiPixelCluster.h
+++ b/DataFormats/SiPixelCluster/interface/SiPixelCluster.h
@@ -81,10 +81,9 @@ public:
   SiPixelCluster() = default;
   ~SiPixelCluster() = default;
   SiPixelCluster(SiPixelCluster const&) = default;
-  SiPixelCluster(SiPixelCluster &&) = default;
+  SiPixelCluster(SiPixelCluster&&) = default;
   SiPixelCluster& operator=(SiPixelCluster const&) = default;
-  SiPixelCluster& operator=(SiPixelCluster &&) = default;
-
+  SiPixelCluster& operator=(SiPixelCluster&&) = default;
 
   SiPixelCluster(unsigned int isize,
                  uint16_t const* adcs,

--- a/DataFormats/SiPixelCluster/interface/SiPixelCluster.h
+++ b/DataFormats/SiPixelCluster/interface/SiPixelCluster.h
@@ -27,6 +27,7 @@ class PixelDigi;
 
 class SiPixelCluster {
 public:
+  // FIXME make it POD
   class Pixel {
   public:
     constexpr Pixel() : x(0), y(0), adc(0) {}  // for root
@@ -37,6 +38,7 @@ public:
   };
 
   //--- Integer shift in x and y directions.
+  // FIXME make    it POD
   class Shift {
   public:
     constexpr Shift(int dx, int dy) : dx_(dx), dy_(dy) {}
@@ -50,6 +52,7 @@ public:
   };
 
   //--- Position of a SiPixel
+  // FIXME make    it POD
   class PixelPos {
   public:
     constexpr PixelPos() : row_(0), col_(0) {}
@@ -76,6 +79,12 @@ public:
    */
 
   SiPixelCluster() = default;
+  ~SiPixelCluster() = default;
+  SiPixelCluster(SiPixelCluster const&) = default;
+  SiPixelCluster(SiPixelCluster &&) = default;
+  SiPixelCluster& operator=(SiPixelCluster const&) = default;
+  SiPixelCluster& operator=(SiPixelCluster &&) = default;
+
 
   SiPixelCluster(unsigned int isize,
                  uint16_t const* adcs,
@@ -87,7 +96,7 @@ public:
       : thePixelOffset(2 * isize), thePixelADC(adcs, adcs + isize), theOriginalClusterId(id) {
     uint16_t maxCol = 0;
     uint16_t maxRow = 0;
-    for (unsigned int i = 0; i != isize; ++i) {
+    for (unsigned int i = 0; i < isize; ++i) {
       uint16_t xoffset = xpos[i] - xmin;
       uint16_t yoffset = ypos[i] - ymin;
       thePixelOffset[i * 2] = std::min(uint16_t(MAXSPAN), xoffset);

--- a/DataFormats/VertexReco/interface/Vertex.h
+++ b/DataFormats/VertexReco/interface/Vertex.h
@@ -75,16 +75,17 @@ namespace reco {
     /// For a primary vertex, it could simply be the beam line.
     bool isFake() const { return (chi2_ == 0 && ndof_ == 0 && tracks_.empty()); }
     /// reserve space for the tracks
-    void reserve(int size, bool refitAsWell=false) { 
-        tracks_.reserve(size);
-        if(refitAsWell) refittedTracks_.reserve(size);
-        weights_.reserve(size);
+    void reserve(int size, bool refitAsWell = false) {
+      tracks_.reserve(size);
+      if (refitAsWell)
+        refittedTracks_.reserve(size);
+      weights_.reserve(size);
     }
     /// add a reference to a Track
-    template<typename Ref>
+    template <typename Ref>
     void add(Ref const &r, float w = 1.0) {
-        tracks_.emplace_back(r);
-        weights_.emplace_back(w * 255.f);
+      tracks_.emplace_back(r);
+      weights_.emplace_back(w * 255.f);
     }
     /// add the original a Track(reference) and the smoothed Track
     void add(const TrackBaseRef &r, const Track &refTrack, float w = 1.0);

--- a/DataFormats/VertexReco/interface/Vertex.h
+++ b/DataFormats/VertexReco/interface/Vertex.h
@@ -103,7 +103,7 @@ namespace reco {
       return 0;
     }
     // track collections
-    auto const & tracks() const { return tracks_;}
+    auto const &tracks() const { return tracks_; }
     /// first iterator over tracks
     trackRef_iterator tracks_begin() const { return tracks_.begin(); }
     /// last iterator over tracks

--- a/DataFormats/VertexReco/interface/Vertex.h
+++ b/DataFormats/VertexReco/interface/Vertex.h
@@ -102,12 +102,14 @@ namespace reco {
       }
       return 0;
     }
+    // track collections
+    auto const & tracks() const { return tracks_;}
     /// first iterator over tracks
-    trackRef_iterator tracks_begin() const;
+    trackRef_iterator tracks_begin() const { return tracks_.begin(); }
     /// last iterator over tracks
-    trackRef_iterator tracks_end() const;
+    trackRef_iterator tracks_end() const { return tracks_.end(); }
     /// number of tracks
-    size_t tracksSize() const;
+    size_t tracksSize() const { return tracks_.size(); }
     /// python friendly track getting
     const TrackBaseRef &trackRefAt(size_t idx) const { return tracks_[idx]; }
     /// chi-squares

--- a/DataFormats/VertexReco/interface/Vertex.h
+++ b/DataFormats/VertexReco/interface/Vertex.h
@@ -74,8 +74,18 @@ namespace reco {
     /// fit with tracks.
     /// For a primary vertex, it could simply be the beam line.
     bool isFake() const { return (chi2_ == 0 && ndof_ == 0 && tracks_.empty()); }
+    /// reserve space for the tracks
+    void reserve(int size, bool refitAsWell=false) { 
+        tracks_.reserve(size);
+        if(refitAsWell) refittedTracks_.reserve(size);
+        weights_.reserve(size);
+    }
     /// add a reference to a Track
-    void add(const TrackBaseRef &r, float w = 1.0);
+    template<typename Ref>
+    void add(Ref const &r, float w = 1.0) {
+        tracks_.emplace_back(r);
+        weights_.emplace_back(w * 255.f);
+    }
     /// add the original a Track(reference) and the smoothed Track
     void add(const TrackBaseRef &r, const Track &refTrack, float w = 1.0);
     void removeTracks();

--- a/DataFormats/VertexReco/src/Vertex.cc
+++ b/DataFormats/VertexReco/src/Vertex.cc
@@ -76,11 +76,6 @@ Vertex::trackRef_iterator Vertex::tracks_end() const {
   // return weights_.keys().end();
 }
 
-void Vertex::add(const TrackBaseRef& r, float w) {
-  tracks_.push_back(r);
-  weights_.push_back(w * 255);
-}
-
 void Vertex::add(const TrackBaseRef& r, const Track& refTrack, float w) {
   tracks_.push_back(r);
   refittedTracks_.push_back(refTrack);

--- a/DataFormats/VertexReco/src/Vertex.cc
+++ b/DataFormats/VertexReco/src/Vertex.cc
@@ -66,16 +66,6 @@ void Vertex::fill(Error4D& err) const {
       err(i, j) = covariance_[idx++];
 }
 
-size_t Vertex::tracksSize() const { return weights_.size(); }
-
-Vertex::trackRef_iterator Vertex::tracks_begin() const { return tracks_.begin(); }
-
-Vertex::trackRef_iterator Vertex::tracks_end() const {
-  //   if ( !(tracks_.size() ) ) createTracks();
-  return tracks_.end();
-  // return weights_.keys().end();
-}
-
 void Vertex::add(const TrackBaseRef& r, const Track& refTrack, float w) {
   tracks_.push_back(r);
   refittedTracks_.push_back(refTrack);

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelDigisClustersFromSoA.cc
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelDigisClustersFromSoA.cc
@@ -41,7 +41,6 @@ private:
 
   const bool produceDigis_;
   const bool storeDigis_;
-
 };
 
 SiPixelDigisClustersFromSoA::SiPixelDigisClustersFromSoA(const edm::ParameterSet& iConfig)
@@ -51,10 +50,9 @@ SiPixelDigisClustersFromSoA::SiPixelDigisClustersFromSoA(const edm::ParameterSet
       clusterThresholds_{iConfig.getParameter<int>("clusterThreshold_layer1"),
                          iConfig.getParameter<int>("clusterThreshold_otherLayers")},
       produceDigis_(iConfig.getParameter<bool>("produceDigis")),
-      storeDigis_(iConfig.getParameter<bool>("produceDigis")&iConfig.getParameter<bool>("storeDigis"))
-{
-   if (produceDigis_) 
-      digiPutToken_ = produces<edm::DetSetVector<PixelDigi>>();
+      storeDigis_(iConfig.getParameter<bool>("produceDigis") & iConfig.getParameter<bool>("storeDigis")) {
+  if (produceDigis_)
+    digiPutToken_ = produces<edm::DetSetVector<PixelDigi>>();
 }
 
 void SiPixelDigisClustersFromSoA::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
@@ -62,8 +60,8 @@ void SiPixelDigisClustersFromSoA::fillDescriptions(edm::ConfigurationDescription
   desc.add<edm::InputTag>("src", edm::InputTag("siPixelDigisSoA"));
   desc.add<int>("clusterThreshold_layer1", kSiPixelClusterThresholdsDefaultPhase1.layer1);
   desc.add<int>("clusterThreshold_otherLayers", kSiPixelClusterThresholdsDefaultPhase1.otherLayers);
-  desc.add<bool>("produceDigis",true);
-  desc.add<bool>("storeDigis",true);
+  desc.add<bool>("produceDigis", true);
+  desc.add<bool>("storeDigis", true);
   descriptions.addWithDefaultLabel(desc);
 }
 
@@ -80,9 +78,8 @@ void SiPixelDigisClustersFromSoA::produce(edm::StreamID, edm::Event& iEvent, con
   auto outputClusters = std::make_unique<SiPixelClusterCollectionNew>();
   outputClusters->reserve(gpuClustering::maxNumModules, nDigis / 2);
 
-
   edm::DetSet<PixelDigi>* detDigis = nullptr;
-  uint32_t  detId = 0;
+  uint32_t detId = 0;
   for (uint32_t i = 0; i < nDigis; i++) {
     if (digis.pdigi(i) == 0)
       continue;
@@ -94,7 +91,6 @@ void SiPixelDigisClustersFromSoA::produce(edm::StreamID, edm::Event& iEvent, con
     }
     break;
   }
-
 
   int32_t nclus = -1;
   PixelClusterizerBase::AccretionCluster aclusters[gpuClustering::maxNumClustersPerModules];
@@ -157,13 +153,15 @@ void SiPixelDigisClustersFromSoA::produce(edm::StreamID, edm::Event& iEvent, con
         if ((*detDigis).empty())
           (*detDigis).data.reserve(64);  // avoid the first relocations
         else {
-          edm::LogWarning("SiPixelDigisClustersFromSoA") << "Problem det present twice in input! " << (*detDigis).detId();
+          edm::LogWarning("SiPixelDigisClustersFromSoA")
+              << "Problem det present twice in input! " << (*detDigis).detId();
         }
       }
     }
     PixelDigi dig(digis.pdigi(i));
-    if (storeDigis_) (*detDigis).data.emplace_back(dig);
-    // fill clusters
+    if (storeDigis_)
+      (*detDigis).data.emplace_back(dig);
+      // fill clusters
 #ifdef EDM_ML_DEBUG
     assert(digis.clus(i) >= 0);
     assert(digis.clus(i) < gpuClustering::maxNumClustersPerModules);
@@ -176,14 +174,15 @@ void SiPixelDigisClustersFromSoA::produce(edm::StreamID, edm::Event& iEvent, con
   }
 
   // fill final clusters
-  if (detId>0)
+  if (detId > 0)
     fillClusters(detId);
 
 #ifdef EDM_ML_DEBUG
   LogDebug("SiPixelDigisClustersFromSoA") << "filled " << totClustersFilled << " clusters";
 #endif
 
-  if (produceDigis_) iEvent.put(digiPutToken_, std::move(collection));
+  if (produceDigis_)
+    iEvent.put(digiPutToken_, std::move(collection));
   iEvent.put(clusterPutToken_, std::move(outputClusters));
 }
 

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelDigisClustersFromSoA.cc
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelDigisClustersFromSoA.cc
@@ -38,21 +38,32 @@ private:
   edm::EDPutTokenT<SiPixelClusterCollectionNew> clusterPutToken_;
 
   const SiPixelClusterThresholds clusterThresholds_;  // Cluster threshold in electrons
+
+  const bool produceDigis_;
+  const bool storeDigis_;
+
 };
 
 SiPixelDigisClustersFromSoA::SiPixelDigisClustersFromSoA(const edm::ParameterSet& iConfig)
     : topoToken_(esConsumes()),
       digiGetToken_(consumes<SiPixelDigisSoA>(iConfig.getParameter<edm::InputTag>("src"))),
-      digiPutToken_(produces<edm::DetSetVector<PixelDigi>>()),
       clusterPutToken_(produces<SiPixelClusterCollectionNew>()),
       clusterThresholds_{iConfig.getParameter<int>("clusterThreshold_layer1"),
-                         iConfig.getParameter<int>("clusterThreshold_otherLayers")} {}
+                         iConfig.getParameter<int>("clusterThreshold_otherLayers")},
+      produceDigis_(iConfig.getParameter<bool>("produceDigis")),
+      storeDigis_(iConfig.getParameter<bool>("produceDigis")&iConfig.getParameter<bool>("storeDigis"))
+{
+   if (produceDigis_) 
+      digiPutToken_ = produces<edm::DetSetVector<PixelDigi>>();
+}
 
 void SiPixelDigisClustersFromSoA::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
   desc.add<edm::InputTag>("src", edm::InputTag("siPixelDigisSoA"));
   desc.add<int>("clusterThreshold_layer1", kSiPixelClusterThresholdsDefaultPhase1.layer1);
   desc.add<int>("clusterThreshold_otherLayers", kSiPixelClusterThresholdsDefaultPhase1.otherLayers);
+  desc.add<bool>("produceDigis",true);
+  desc.add<bool>("storeDigis",true);
   descriptions.addWithDefaultLabel(desc);
 }
 
@@ -61,20 +72,29 @@ void SiPixelDigisClustersFromSoA::produce(edm::StreamID, edm::Event& iEvent, con
   const uint32_t nDigis = digis.size();
   const auto& ttopo = iSetup.getData(topoToken_);
 
-  auto collection = std::make_unique<edm::DetSetVector<PixelDigi>>();
-  collection->reserve(gpuClustering::maxNumModules);
+  std::unique_ptr<edm::DetSetVector<PixelDigi>> collection;
+  if (produceDigis_)
+    collection = std::make_unique<edm::DetSetVector<PixelDigi>>();
+  if (storeDigis_)
+    collection->reserve(gpuClustering::maxNumModules);
   auto outputClusters = std::make_unique<SiPixelClusterCollectionNew>();
   outputClusters->reserve(gpuClustering::maxNumModules, nDigis / 2);
 
+
   edm::DetSet<PixelDigi>* detDigis = nullptr;
+  uint32_t  detId = 0;
   for (uint32_t i = 0; i < nDigis; i++) {
     if (digis.pdigi(i) == 0)
       continue;
-    detDigis = &collection->find_or_insert(digis.rawIdArr(i));
-    if ((*detDigis).empty())
-      (*detDigis).data.reserve(64);  // avoid the first relocations
+    detId = digis.rawIdArr(i);
+    if (storeDigis_) {
+      detDigis = &collection->find_or_insert(detId);
+      if ((*detDigis).empty())
+        (*detDigis).data.reserve(64);  // avoid the first relocations
+    }
     break;
   }
+
 
   int32_t nclus = -1;
   PixelClusterizerBase::AccretionCluster aclusters[gpuClustering::maxNumClustersPerModules];
@@ -125,20 +145,24 @@ void SiPixelDigisClustersFromSoA::produce(edm::StreamID, edm::Event& iEvent, con
 #ifdef EDM_ML_DEBUG
     assert(digis.rawIdArr(i) > 109999);
 #endif
-    if ((*detDigis).detId() != digis.rawIdArr(i)) {
-      fillClusters((*detDigis).detId());
+    if (detId != digis.rawIdArr(i)) {
+      // new module
+      fillClusters(detId);
 #ifdef EDM_ML_DEBUG
       assert(nclus == -1);
 #endif
-      detDigis = &collection->find_or_insert(digis.rawIdArr(i));
-      if ((*detDigis).empty())
-        (*detDigis).data.reserve(64);  // avoid the first relocations
-      else {
-        edm::LogWarning("SiPixelDigisClustersFromSoA") << "Problem det present twice in input! " << (*detDigis).detId();
+      detId = digis.rawIdArr(i);
+      if (storeDigis_) {
+        detDigis = &collection->find_or_insert(detId);
+        if ((*detDigis).empty())
+          (*detDigis).data.reserve(64);  // avoid the first relocations
+        else {
+          edm::LogWarning("SiPixelDigisClustersFromSoA") << "Problem det present twice in input! " << (*detDigis).detId();
+        }
       }
     }
-    (*detDigis).data.emplace_back(digis.pdigi(i));
-    auto dig = (*detDigis).data.back();
+    PixelDigi dig(digis.pdigi(i));
+    if (storeDigis_) (*detDigis).data.emplace_back(dig);
     // fill clusters
 #ifdef EDM_ML_DEBUG
     assert(digis.clus(i) >= 0);
@@ -152,13 +176,14 @@ void SiPixelDigisClustersFromSoA::produce(edm::StreamID, edm::Event& iEvent, con
   }
 
   // fill final clusters
-  if (detDigis)
-    fillClusters((*detDigis).detId());
+  if (detId>0)
+    fillClusters(detId);
+
 #ifdef EDM_ML_DEBUG
   LogDebug("SiPixelDigisClustersFromSoA") << "filled " << totClustersFilled << " clusters";
 #endif
 
-  iEvent.put(digiPutToken_, std::move(collection));
+  if (produceDigis_) iEvent.put(digiPutToken_, std::move(collection));
   iEvent.put(clusterPutToken_, std::move(outputClusters));
 }
 

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelDigisClustersFromSoA.cc
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelDigisClustersFromSoA.cc
@@ -111,18 +111,16 @@ void SiPixelDigisClustersFromSoA::produce(edm::StreamID, edm::Event& iEvent, con
         edm::LogWarning("SiPixelDigisClustersFromSoA") << "cluster below charge Threshold "
                                                        << "Layer/DetId/clusId " << layer << '/' << detId << '/' << ic
                                                        << " size/charge " << acluster.isize << '/' << acluster.charge;
-      SiPixelCluster cluster(acluster.isize, acluster.adc, acluster.x, acluster.y, acluster.xmin, acluster.ymin, ic);
+      // sort by row (x)
+      spc.emplace_back(acluster.isize, acluster.adc, acluster.x, acluster.y, acluster.xmin, acluster.ymin, ic);
       aclusters[ic].clear();
+      std::push_heap(spc.begin(), spc.end(), [](SiPixelCluster const& cl1, SiPixelCluster const& cl2) {
+        return cl1.minPixelRow() < cl2.minPixelRow();});
 #ifdef EDM_ML_DEBUG
       ++totClustersFilled;
       LogDebug("SiPixelDigisClustersFromSoA")
           << "putting in this cluster " << ic << " " << cluster.charge() << " " << cluster.pixelADC().size();
 #endif
-      // sort by row (x)
-      spc.push_back(std::move(cluster));
-      std::push_heap(spc.begin(), spc.end(), [](SiPixelCluster const& cl1, SiPixelCluster const& cl2) {
-        return cl1.minPixelRow() < cl2.minPixelRow();
-      });
     }
     nclus = -1;
     // sort by row (x)

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelDigisClustersFromSoA.cc
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelDigisClustersFromSoA.cc
@@ -115,7 +115,8 @@ void SiPixelDigisClustersFromSoA::produce(edm::StreamID, edm::Event& iEvent, con
       spc.emplace_back(acluster.isize, acluster.adc, acluster.x, acluster.y, acluster.xmin, acluster.ymin, ic);
       aclusters[ic].clear();
       std::push_heap(spc.begin(), spc.end(), [](SiPixelCluster const& cl1, SiPixelCluster const& cl2) {
-        return cl1.minPixelRow() < cl2.minPixelRow();});
+        return cl1.minPixelRow() < cl2.minPixelRow();
+      });
 #ifdef EDM_ML_DEBUG
       ++totClustersFilled;
       LogDebug("SiPixelDigisClustersFromSoA")

--- a/RecoLocalTracker/SiPixelRecHits/plugins/SiPixelRecHitFromCUDA.cc
+++ b/RecoLocalTracker/SiPixelRecHits/plugins/SiPixelRecHitFromCUDA.cc
@@ -94,6 +94,7 @@ void SiPixelRecHitFromCUDA::produce(edm::Event& iEvent, edm::EventSetup const& e
     iEvent.emplace(rechitsPutToken_, std::move(output));
     return;
   }
+  output.reserve(gpuClustering::maxNumModules,nHits_);
 
   auto xl = store32_.get();
   auto yl = xl + nHits_;

--- a/RecoLocalTracker/SiPixelRecHits/plugins/SiPixelRecHitFromCUDA.cc
+++ b/RecoLocalTracker/SiPixelRecHits/plugins/SiPixelRecHitFromCUDA.cc
@@ -94,7 +94,7 @@ void SiPixelRecHitFromCUDA::produce(edm::Event& iEvent, edm::EventSetup const& e
     iEvent.emplace(rechitsPutToken_, std::move(output));
     return;
   }
-  output.reserve(gpuClustering::maxNumModules,nHits_);
+  output.reserve(gpuClustering::maxNumModules, nHits_);
 
   auto xl = store32_.get();
   auto yl = xl + nHits_;

--- a/RecoLocalTracker/SiPixelRecHits/plugins/SiPixelRecHitFromCUDA.cc
+++ b/RecoLocalTracker/SiPixelRecHits/plugins/SiPixelRecHitFromCUDA.cc
@@ -163,10 +163,7 @@ void SiPixelRecHitFromCUDA::produce(edm::Event& iEvent, edm::EventSetup const& e
       // Create a persistent edm::Ref to the cluster
       edm::Ref<edmNew::DetSetVector<SiPixelCluster>, SiPixelCluster> cluster = edmNew::makeRefTo(hclusters, &clust);
       // Make a RecHit and add it to the DetSet
-      SiPixelRecHit hit(lp, le, rqw, *genericDet, cluster);
-      //
-      // Now save it =================
-      recHitsOnDetUnit.push_back(hit);
+      recHitsOnDetUnit.emplace_back(lp, le, rqw, *genericDet, cluster);
       // =============================
 
       LogDebug("SiPixelRecHitFromCUDA") << "cluster " << numberOfClusters << " at " << lp << ' ' << le;

--- a/RecoPixelVertexing/PixelVertexFinding/plugins/PixelVertexProducerFromSoA.cc
+++ b/RecoPixelVertexing/PixelVertexFinding/plugins/PixelVertexProducerFromSoA.cc
@@ -69,6 +69,7 @@ void PixelVertexProducerFromSoA::produce(edm::StreamID streamID, edm::Event &iEv
 
   float x0 = 0, y0 = 0, z0 = 0, dxdz = 0, dydz = 0;
   std::vector<int32_t> itrk;
+  itrk.reserve(64); // avoid first relocations
   if (!bsHandle.isValid()) {
     edm::LogWarning("PixelVertexProducer") << "No beamspot found. returning vertexes with (0,0,Z) ";
   } else {
@@ -89,7 +90,7 @@ void PixelVertexProducerFromSoA::produce(edm::StreamID streamID, edm::Event &iEv
             << " from " << indToEdm.size() << " tracks" << std::endl;
 #endif  // PIXVERTEX_DEBUG_PRODUCE
 
-  std::set<uint16_t> uind;  // fort verifing index consistency
+  std::set<uint16_t> uind;  // for verifing index consistency
   for (int j = nv - 1; j >= 0; --j) {
     auto i = soa.sortInd[j];  // on gpu sorted in ascending order....
     assert(i < nv);
@@ -120,6 +121,7 @@ void PixelVertexProducerFromSoA::produce(edm::StreamID streamID, edm::Event &iEv
     }  // remove outliers
     (*vertexes).emplace_back(reco::Vertex::Point(x, y, z), err, soa.chi2[i], soa.ndof[i], nt);
     auto &v = (*vertexes).back();
+    v.reserve(itrk.size());
     for (auto it : itrk) {
       assert(it < int(indToEdm.size()));
       auto k = indToEdm[it];
@@ -128,7 +130,7 @@ void PixelVertexProducerFromSoA::produce(edm::StreamID streamID, edm::Event &iEv
         continue;
       }
       auto tk = reco::TrackRef(tracksHandle, k);
-      v.add(reco::TrackBaseRef(tk));
+      v.add(tk);
     }
     itrk.clear();
   }

--- a/RecoPixelVertexing/PixelVertexFinding/plugins/PixelVertexProducerFromSoA.cc
+++ b/RecoPixelVertexing/PixelVertexFinding/plugins/PixelVertexProducerFromSoA.cc
@@ -69,7 +69,7 @@ void PixelVertexProducerFromSoA::produce(edm::StreamID streamID, edm::Event &iEv
 
   float x0 = 0, y0 = 0, z0 = 0, dxdz = 0, dydz = 0;
   std::vector<int32_t> itrk;
-  itrk.reserve(64); // avoid first relocations
+  itrk.reserve(64);  // avoid first relocations
   if (!bsHandle.isValid()) {
     edm::LogWarning("PixelVertexProducer") << "No beamspot found. returning vertexes with (0,0,Z) ";
   } else {


### PR DESCRIPTION
Pixel Digi and Cluster conversion to legacy is the most time consuming part of Patatrack workflow.
PIxel Digis are not consumed by any reco producer: only validation and DQM.

Here we introduce the ability to not produce Digis collections

setting
```
process.siPixelDigisClustersPreSplitting.produceDigis = False
```
will not produce the digi collection
setting
```
process.siPixelDigisClustersPreSplitting.storeDigis = False
```
will produce an empty digi collection


performance

release
```
TimeReport   0.016412     0.016412     0.016412  siPixelDigisClustersPreSplitting
```

this PR with ```storeDigis = False```
```
TimeReport   0.012385     0.012385     0.012385  siPixelDigisClustersPreSplitting
```

corresponding to a global 15% increase in throughput.

at the moment the option 
```
process.siPixelDigisClustersPreSplitting.produceDigis = False
```
does not work out of the box as it is not "Heterogeneous compatible"
(on CPU we run the legacy localreco)
and will produce the error

```
----- Begin Fatal Exception 26-Jun-2021 17:48:54 CEST-----------------------
An exception of category 'Configuration' occurred while
   [0] Constructing the EventProcessor
Exception Message:
EDAlias parameter set mismatch
There are no products of type 'PixelDigiedmDetSetVector'
with module label 'siPixelDigisClustersPreSplitting'.
----- End Fatal Exception -------------------------------------------------
```

took the opportunity to improve performances in few other places.


Purely technical, no regression expected. (option is off by default)



