### PR TITLE
[ASAN] Fix for ODR violation

### DIFF
--- a/GeneratorInterface/HydjetInterface/src/HydjetHadronizer.cc
+++ b/GeneratorInterface/HydjetInterface/src/HydjetHadronizer.cc
@@ -37,8 +37,6 @@ using namespace edm;
 using namespace std;
 using namespace gen;
 
-HepMC::IO_HEPEVT hepevtio;
-
 namespace {
   int convertStatus(int st) {
     if (st <= 0)

--- a/GeneratorInterface/PyquenInterface/src/PyquenHadronizer.cc
+++ b/GeneratorInterface/PyquenInterface/src/PyquenHadronizer.cc
@@ -24,7 +24,7 @@ using namespace gen;
 using namespace edm;
 using namespace std;
 
-HepMC::IO_HEPEVT hepevtio;
+HepMC::IO_HEPEVT pyquen_hepevtio;
 
 const std::vector<std::string> PyquenHadronizer::theSharedResources = {edm::SharedResourceNames::kPythia6,
                                                                        gen::FortranInstance::kFortranInstance};
@@ -212,8 +212,8 @@ bool PyquenHadronizer::generatePartonsAndHadronize() {
   call_pyhepc(1);
 
   // event information
-  // hepevtio.set_trust_mothers_before_daughters(true);
-  HepMC::GenEvent* evt = hepevtio.read_next_event();
+  // pyquen_hepevtio.set_trust_mothers_before_daughters(true);
+  HepMC::GenEvent* evt = pyquen_hepevtio.read_next_event();
 
   evt->set_signal_process_id(pypars.msti[0]);  // type of the process
   evt->set_event_scale(pypars.pari[16]);       // Q^2


### PR DESCRIPTION
To fix the ASAN IBs One Definition Rules violations
```
==24946==ERROR: AddressSanitizer: odr-violation (0x7f32280ffc80):
  [1] size=16 'hepevtio' GeneratorInterface/PyquenInterface/src/PyquenHadronizer.cc:27:18
  [2] size=16 'hepevtio' GeneratorInterface/CascadeInterface/plugins/Cascade2Hadronizer.cc:19:18
```
```
==9506==ERROR: AddressSanitizer: odr-violation (0x7f6296b76100):
  [1] size=16 'hepevtio' GeneratorInterface/HydjetInterface/src/HydjetHadronizer.cc:40:18
  [2] size=16 'hepevtio' GeneratorInterface/CascadeInterface/plugins/Cascade2Hadronizer.cc:19:18
```