### PR TITLE
Fixes needed for UBSAN IBs: null destination pointer

### DIFF
--- a/CalibCalorimetry/EcalCorrelatedNoiseAnalysisAlgos/src/TEcnaGui.cc
+++ b/CalibCalorimetry/EcalCorrelatedNoiseAnalysisAlgos/src/TEcnaGui.cc
@@ -8442,21 +8442,15 @@ void TEcnaGui::InitKeys() {
 }
 
 void TEcnaGui::DisplayInEntryField(TGTextEntry* StringOfField, Int_t& value) {
-  char* f_in = new char[20];
-  fCnew++;
+  char f_in[20];
   sprintf(f_in, "%d", value);
   StringOfField->SetText(f_in);
-  delete[] f_in;
-  fCdelete++;
 }
 
 void TEcnaGui::DisplayInEntryField(TGTextEntry* StringOfField, Double_t& value) {
-  char* f_in = new char[20];
-  fCnew++;
+  char f_in[20];
   sprintf(f_in, "%g", value);
   StringOfField->SetText(f_in);
-  delete[] f_in;
-  fCdelete++;
 }
 void TEcnaGui::DisplayInEntryField(TGTextEntry* StringOfField, const TString& value) {
   //StringOfField->Insert(value);


### PR DESCRIPTION
UBSAN IBs failed to build with error
```
  CalibCalorimetry/EcalCorrelatedNoiseAnalysisAlgos/src/TEcnaGui.cc:8447:10: error: null destination pointer [-Werror=format-overflow=]
  8447 |   sprintf(f_in, "%d", value);
      |   ~~~~~~~^~~~~~~~~~~~~~~~~~~
  CalibCalorimetry/EcalCorrelatedNoiseAnalysisAlgos/src/TEcnaGui.cc:8456:10: error: null destination pointer [-Werror=format-overflow=]
  8456 |   sprintf(f_in, "%g", value);
      |   ~~~~~~~^~~~~~~~~~~~~~~~~~~
```

I think allocated memory is used without first checking if it is properly allocated or not e.g. adding a condition to check if `f_in != nullptr` also fixes the UBSAN build error. But I think there is no need to allocate/deallocate memory in tis case.