### PR TITLE
DQM : migrate modules for esConumes part 2

### DIFF
--- a/DQM/BeamMonitor/plugins/BeamConditionsMonitor.cc
+++ b/DQM/BeamMonitor/plugins/BeamConditionsMonitor.cc
@@ -29,7 +29,7 @@ BeamConditionsMonitor::BeamConditionsMonitor(const ParameterSet& ps) : countEvt_
   monitorName_ = parameters_.getUntrackedParameter<string>("monitorName", "YourSubsystemName");
   bsSrc_ = parameters_.getUntrackedParameter<InputTag>("beamSpot");
   debug_ = parameters_.getUntrackedParameter<bool>("Debug");
-
+  beamSpotToken_ = esConsumes();
   dbe_ = Service<DQMStore>().operator->();
 
   if (!monitorName_.empty())
@@ -66,9 +66,7 @@ void BeamConditionsMonitor::beginLuminosityBlock(const LuminosityBlock& lumiSeg,
 // ----------------------------------------------------------
 void BeamConditionsMonitor::analyze(const Event& iEvent, const EventSetup& iSetup) {
   countEvt_++;
-  ESHandle<BeamSpotObjects> beamhandle;
-  iSetup.get<BeamSpotObjectsRcd>().get(beamhandle);
-  condBeamSpot = *beamhandle;
+  condBeamSpot = iSetup.getData(beamSpotToken_);
 }
 
 //--------------------------------------------------------

--- a/DQM/BeamMonitor/plugins/BeamConditionsMonitor.h
+++ b/DQM/BeamMonitor/plugins/BeamConditionsMonitor.h
@@ -22,7 +22,7 @@
 //
 // class declaration
 //
-
+class BeamSpotObjectsRcd;
 class BeamConditionsMonitor : public edm::EDAnalyzer {
 public:
   BeamConditionsMonitor(const edm::ParameterSet&);
@@ -56,6 +56,7 @@ private:
   edm::ParameterSet parameters_;
   std::string monitorName_;
   edm::InputTag bsSrc_;  // beam spot
+  edm::ESGetToken<BeamSpotObjects, BeamSpotObjectsRcd> beamSpotToken_;
   bool debug_;
 
   DQMStore* dbe_;

--- a/DQM/Physics/src/ExoticaDQM.cc
+++ b/DQM/Physics/src/ExoticaDQM.cc
@@ -57,6 +57,7 @@ ExoticaDQM::ExoticaDQM(const edm::ParameterSet& ps) {
 
   JetCorrectorToken_ = consumes<reco::JetCorrector>(ps.getParameter<edm::InputTag>("jetCorrector"));
 
+  magFieldToken_ = esConsumes();
   //Cuts - MultiJets
   jetID = new reco::helper::JetIDHelper(ps.getParameter<ParameterSet>("JetIDParams"), consumesCollector());
 
@@ -797,14 +798,13 @@ GlobalVector ExoticaDQM::getGenParticleTrajectoryAtBeamline(const edm::EventSetu
   //=== approach to the beam-line.
 
   // Get the magnetic field
-  edm::ESHandle<MagneticField> theMagField;
-  iSetup.get<IdealMagneticFieldRecord>().get(theMagField);
+  const MagneticField* theMagField = &iSetup.getData(magFieldToken_);
 
   // Make FreeTrajectoryState of this gen particle
   FreeTrajectoryState fts(GlobalPoint(gen->vx(), gen->vy(), gen->vz()),
                           GlobalVector(gen->px(), gen->py(), gen->pz()),
                           gen->charge(),
-                          theMagField.product());
+                          theMagField);
 
   // Get trajectory closest to beam line
   TSCBLBuilderNoMaterial tscblBuilder;

--- a/DQM/Physics/src/ExoticaDQM.h
+++ b/DQM/Physics/src/ExoticaDQM.h
@@ -195,6 +195,9 @@ private:
   edm::EDGetTokenT<reco::GenParticleCollection> GenParticleToken_;
   edm::Handle<reco::GenParticleCollection> GenCollection_;
 
+  //ES tokens
+  edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> magFieldToken_;
+
   ///////////////////////////
   // Parameters
   ///////////////////////////

--- a/DQM/Physics/src/QcdLowPtDQM.cc
+++ b/DQM/Physics/src/QcdLowPtDQM.cc
@@ -45,7 +45,9 @@ bool compareTracklets(const QcdLowPtDQM::Tracklet &a, const QcdLowPtDQM::Trackle
 
 //--------------------------------------------------------------------------------------------------
 QcdLowPtDQM::QcdLowPtDQM(const ParameterSet &parameters)
-    : hltResName_(parameters.getUntrackedParameter<string>("hltTrgResults", "TriggerResults")),
+    : tkGeomToken_(esConsumes()),
+      tTopoToken_(esConsumes()),
+      hltResName_(parameters.getUntrackedParameter<string>("hltTrgResults", "TriggerResults")),
       pixelName_(parameters.getUntrackedParameter<string>("pixelRecHits", "siPixelRecHits")),
       clusterVtxName_(parameters.getUntrackedParameter<string>("clusterVertices", "")),
       ZVCut_(parameters.getUntrackedParameter<double>("ZVertexCut", 10)),
@@ -690,9 +692,7 @@ void QcdLowPtDQM::analyze(const Event &iEvent, const EventSetup &iSetup) {
   // Analyze the given event.
 
   // get tracker geometry
-  ESHandle<TrackerGeometry> trackerHandle;
-  iSetup.get<TrackerDigiGeometryRecord>().get(trackerHandle);
-  tgeo_ = trackerHandle.product();
+  tgeo_ = &iSetup.getData(tkGeomToken_);
   if (!tgeo_) {
     print(3,
           "QcdLowPtDQM::analyze -- Could not obtain pointer to "
@@ -1058,9 +1058,7 @@ void QcdLowPtDQM::fillPixels(const Event &iEvent, const edm::EventSetup &iSetup)
   }
 
   // Retrieve tracker topology from geometry
-  edm::ESHandle<TrackerTopology> tTopoHandle;
-  iSetup.get<TrackerTopologyRcd>().get(tTopoHandle);
-  const TrackerTopology *const tTopo = tTopoHandle.product();
+  const TrackerTopology *const tTopo = &iSetup.getData(tTopoToken_);
 
   const SiPixelRecHitCollection *hits = hRecHits.product();
   for (SiPixelRecHitCollection::DataContainer::const_iterator hit = hits->data().begin(), end = hits->data().end();

--- a/DQM/Physics/src/QcdLowPtDQM.h
+++ b/DQM/Physics/src/QcdLowPtDQM.h
@@ -220,8 +220,8 @@ private:
   double vertexZFromClusters(const std::vector<Pixel> &pix) const;
   void yieldAlphaHistogram(int which = 12);
 
-  edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord>  tkGeomToken_;
-  edm::ESGetToken<TrackerTopology, TrackerTopologyRcd>  tTopoToken_;
+  edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> tkGeomToken_;
+  edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> tTopoToken_;
   std::string hltResName_;                    // HLT trigger results name
   std::vector<std::string> hltProcNames_;     // HLT process name(s)
   std::vector<std::string> hltTrgNames_;      // HLT trigger name(s)

--- a/DQM/Physics/src/QcdLowPtDQM.h
+++ b/DQM/Physics/src/QcdLowPtDQM.h
@@ -15,6 +15,9 @@
 #include <vector>
 
 class TrackerGeometry;
+class TrackerDigiGeometryRecord;
+class TrackerTopology;
+class TrackerTopologyRcd;
 class TH1F;
 class TH2F;
 class TH3F;
@@ -217,6 +220,8 @@ private:
   double vertexZFromClusters(const std::vector<Pixel> &pix) const;
   void yieldAlphaHistogram(int which = 12);
 
+  edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord>  tkGeomToken_;
+  edm::ESGetToken<TrackerTopology, TrackerTopologyRcd>  tTopoToken_;
   std::string hltResName_;                    // HLT trigger results name
   std::vector<std::string> hltProcNames_;     // HLT process name(s)
   std::vector<std::string> hltTrgNames_;      // HLT trigger name(s)

--- a/DQM/PhysicsObjectsMonitoring/interface/PhysicsObjectsMonitor.h
+++ b/DQM/PhysicsObjectsMonitoring/interface/PhysicsObjectsMonitor.h
@@ -26,6 +26,8 @@ namespace edm {
 class TFile;
 class TH1F;
 class TH2F;
+class MagneticField;
+class IdealMagneticFieldRecord;
 
 class PhysicsObjectsMonitor : public DQMEDAnalyzer {
 public:
@@ -65,5 +67,6 @@ private:
 
   // define Token(-s)
   edm::EDGetTokenT<reco::TrackCollection> theSTAMuonToken_;
+  edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> magFiledToken_;
 };
 #endif

--- a/DQM/PhysicsObjectsMonitoring/src/PhysicsObjectsMonitor.cc
+++ b/DQM/PhysicsObjectsMonitoring/src/PhysicsObjectsMonitor.cc
@@ -32,7 +32,7 @@ PhysicsObjectsMonitor::PhysicsObjectsMonitor(const ParameterSet &pset) {
   theSTAMuonLabel = pset.getUntrackedParameter<string>("StandAloneTrackCollectionLabel");
   theSeedCollectionLabel = pset.getUntrackedParameter<string>("MuonSeedCollectionLabel");
   theDataType = pset.getUntrackedParameter<string>("DataType");
-
+  magFiledToken_ = esConsumes();
   if (theDataType != "RealData" && theDataType != "SimData")
     edm::LogInfo("PhysicsObjectsMonitor") << "Error in Data Type!!" << endl;
 
@@ -80,8 +80,7 @@ void PhysicsObjectsMonitor::analyze(const Event &event, const EventSetup &eventS
   Handle<reco::TrackCollection> staTracks;
   event.getByToken(theSTAMuonToken_, staTracks);
 
-  ESHandle<MagneticField> theMGField;
-  eventSetup.get<IdealMagneticFieldRecord>().get(theMGField);
+  const auto& theMGField = eventSetup.getHandle(magFiledToken_);
 
   double recPt = 0.;
   double simPt = 0.;

--- a/DQM/PhysicsObjectsMonitoring/src/PhysicsObjectsMonitor.cc
+++ b/DQM/PhysicsObjectsMonitoring/src/PhysicsObjectsMonitor.cc
@@ -80,7 +80,7 @@ void PhysicsObjectsMonitor::analyze(const Event &event, const EventSetup &eventS
   Handle<reco::TrackCollection> staTracks;
   event.getByToken(theSTAMuonToken_, staTracks);
 
-  const auto& theMGField = eventSetup.getHandle(magFiledToken_);
+  const auto &theMGField = eventSetup.getHandle(magFiledToken_);
 
   double recPt = 0.;
   double simPt = 0.;

--- a/DQM/PixelLumi/plugins/PixelLumiDQM.cc
+++ b/DQM/PixelLumi/plugins/PixelLumiDQM.cc
@@ -47,6 +47,7 @@ const unsigned int PixelLumiDQM::lastBunchCrossing;
 PixelLumiDQM::PixelLumiDQM(const edm::ParameterSet &iConfig)
     : fPixelClusterLabel(consumes<edmNew::DetSetVector<SiPixelCluster>>(
           iConfig.getUntrackedParameter<edm::InputTag>("pixelClusterLabel", edm::InputTag("siPixelClusters")))),
+      tkGeomToken_(esConsumes()),
       fIncludePixelClusterInfo(iConfig.getUntrackedParameter<bool>("includePixelClusterInfo", true)),
       fIncludePixelQualCheckHistos(iConfig.getUntrackedParameter<bool>("includePixelQualCheckHistos", true)),
       fResetIntervalInLumiSections(iConfig.getUntrackedParameter<int>("resetEveryNLumiSections", 1)),
@@ -98,12 +99,9 @@ void PixelLumiDQM::analyze(const edm::Event &iEvent, const edm::EventSetup &iSet
   std::map<int, PixelClusterCount>::iterator it = fNumPixelClusters.find(fBXNo);
   if (it == fNumPixelClusters.end())
     fNumPixelClusters[fBXNo] = PixelClusterCount();
-
+  // Find tracker geometry.
+  const TrackerGeometry *trackerGeo = &iSetup.getData(tkGeomToken_);
   if (fIncludePixelClusterInfo) {
-    // Find tracker geometry.
-    edm::ESHandle<TrackerGeometry> trackerGeo;
-    iSetup.get<TrackerDigiGeometryRecord>().get(trackerGeo);
-
     // Find pixel clusters.
     edm::Handle<edmNew::DetSetVector<SiPixelCluster>> pixelClusters;
     iEvent.getByToken(fPixelClusterLabel, pixelClusters);
@@ -170,10 +168,6 @@ void PixelLumiDQM::analyze(const edm::Event &iEvent, const edm::EventSetup &iSet
 
   // Fill some pixel cluster quality check histograms if requested.
   if (fIncludePixelQualCheckHistos) {
-    // Find tracker geometry.
-    edm::ESHandle<TrackerGeometry> trackerGeo;
-    iSetup.get<TrackerDigiGeometryRecord>().get(trackerGeo);
-
     // Find pixel clusters.
     edm::Handle<edmNew::DetSetVector<SiPixelCluster>> pixelClusters;
     iEvent.getByToken(fPixelClusterLabel, pixelClusters);

--- a/DQM/PixelLumi/plugins/PixelLumiDQM.h
+++ b/DQM/PixelLumi/plugins/PixelLumiDQM.h
@@ -36,7 +36,8 @@
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 
 class ConfigurationDescriptions;
-
+class TrackerGeometry;
+class TrackerDigiGeometryRecord;
 class PixelLumiDQM : public DQMOneEDAnalyzer<edm::one::WatchLuminosityBlocks> {
 public:
   explicit PixelLumiDQM(const edm::ParameterSet &);
@@ -112,6 +113,7 @@ private:
   };
 
   edm::EDGetTokenT<edmNew::DetSetVector<SiPixelCluster>> fPixelClusterLabel;
+  edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> tkGeomToken_;
 
   UInt_t fRunNo;
   UInt_t fEvtNo;

--- a/DQMOffline/JetMET/interface/BeamHaloAnalyzer.h
+++ b/DQMOffline/JetMET/interface/BeamHaloAnalyzer.h
@@ -134,8 +134,6 @@
 #include "TLegend.h"
 
 //Standard C++ classes
-#include <iostream>
-#include <ostream>
 #include <string>
 #include <map>
 #include <vector>
@@ -186,8 +184,10 @@ private:
   edm::EDGetTokenT<reco::HcalHaloData> IT_HcalHaloData;
   edm::EDGetTokenT<reco::GlobalHaloData> IT_GlobalHaloData;
   edm::EDGetTokenT<reco::BeamHaloSummary> IT_BeamHaloSummary;
-
   edm::EDGetTokenT<reco::MuonTimeExtraMap> IT_CSCTimeMapToken;
+
+  edm::ESGetToken<CSCGeometry, MuonGeometryRecord> cscGeomToken_;
+  edm::ESGetToken<CaloGeometry, CaloGeometryRecord> caloGeomToken_;
 
   //Output File
   std::string OutputFileName;

--- a/DQMOffline/JetMET/interface/BeamHaloAnalyzer.h
+++ b/DQMOffline/JetMET/interface/BeamHaloAnalyzer.h
@@ -187,7 +187,6 @@ private:
   edm::EDGetTokenT<reco::MuonTimeExtraMap> IT_CSCTimeMapToken;
 
   edm::ESGetToken<CSCGeometry, MuonGeometryRecord> cscGeomToken_;
-  edm::ESGetToken<CaloGeometry, CaloGeometryRecord> caloGeomToken_;
 
   //Output File
   std::string OutputFileName;

--- a/DQMOffline/JetMET/interface/ECALRecHitAnalyzer.h
+++ b/DQMOffline/JetMET/interface/ECALRecHitAnalyzer.h
@@ -68,6 +68,7 @@ class DetId;
 //class HcalTopology;
 class CaloGeometry;
 class CaloSubdetectorGeometry;
+class CaloGeometryRecord;
 //class CaloTowerConstituentsMap;
 //class CaloRecHit;
 
@@ -92,7 +93,8 @@ private:
   // Inputs from Configuration
   edm::EDGetTokenT<EBRecHitCollection> EBRecHitsLabel_;
   edm::EDGetTokenT<EERecHitCollection> EERecHitsLabel_;
-
+  edm::ESGetToken<CaloGeometry, CaloGeometryRecord> caloGeomToken_;
+  const CaloGeometry* caloGeom_;
   bool debug_;
   bool finebinning_;
   std::string FolderName_;

--- a/DQMOffline/JetMET/interface/HCALRecHitAnalyzer.h
+++ b/DQMOffline/JetMET/interface/HCALRecHitAnalyzer.h
@@ -21,7 +21,8 @@
 
 #include <string>
 #include <map>
-
+class CaloGeometry;
+class CaloGeometryRecord;
 class HCALRecHitAnalyzer : public DQMEDAnalyzer {
 public:
   explicit HCALRecHitAnalyzer(const edm::ParameterSet&);
@@ -37,6 +38,7 @@ private:
   edm::EDGetTokenT<HBHERecHitCollection> hBHERecHitsLabel_;
   edm::EDGetTokenT<HFRecHitCollection> hFRecHitsLabel_;
   edm::EDGetTokenT<HORecHitCollection> hORecHitsLabel_;
+  edm::ESGetToken<CaloGeometry, CaloGeometryRecord> caloGeomToken_;
   bool debug_;
   bool finebinning_;
   std::string FolderName_;

--- a/DQMOffline/JetMET/interface/JetAnalyzer.h
+++ b/DQMOffline/JetMET/interface/JetAnalyzer.h
@@ -131,6 +131,7 @@ private:
 
   edm::InputTag inputJetIDValueMap;
   edm::EDGetTokenT<edm::ValueMap<reco::JetID>> jetID_ValueMapToken_;
+  edm::ESGetToken<L1GtTriggerMenu, L1GtTriggerMenuRcd> l1gtTrigMenuToken_;
 
   //Cleaning parameters
   edm::ParameterSet cleaningParameters_;

--- a/DQMOffline/JetMET/interface/METAnalyzer.h
+++ b/DQMOffline/JetMET/interface/METAnalyzer.h
@@ -201,6 +201,8 @@ private:
   edm::InputTag inputJetIDValueMap;
   edm::EDGetTokenT<edm::ValueMap<reco::JetID>> jetID_ValueMapToken_;
 
+  edm::ESGetToken<L1GtTriggerMenu, L1GtTriggerMenuRcd> l1gtTrigMenuToken_;
+
   JetIDSelectionFunctor jetIDFunctorLoose;
   PFJetIDSelectionFunctor pfjetIDFunctorLoose;
 

--- a/DQMOffline/JetMET/src/BeamHaloAnalyzer.cc
+++ b/DQMOffline/JetMET/src/BeamHaloAnalyzer.cc
@@ -1,6 +1,5 @@
 #include "DQMOffline/JetMET/interface/BeamHaloAnalyzer.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
-
 //author : Ronny Remington, University of Florida
 //date : 11/11/09
 
@@ -60,6 +59,9 @@ BeamHaloAnalyzer::BeamHaloAnalyzer(const edm::ParameterSet& iConfig) {
   IT_HcalHaloData = consumes<reco::HcalHaloData>(iConfig.getParameter<edm::InputTag>("HcalHaloDataLabel"));
   IT_GlobalHaloData = consumes<reco::GlobalHaloData>(iConfig.getParameter<edm::InputTag>("GlobalHaloDataLabel"));
   IT_BeamHaloSummary = consumes<BeamHaloSummary>(iConfig.getParameter<edm::InputTag>("BeamHaloSummaryLabel"));
+
+  cscGeomToken_ = esConsumes();
+  caloGeomToken_ = esConsumes();
 
   edm::InputTag CosmicSAMuonLabel = iConfig.getParameter<edm::InputTag>("CosmicStandAloneMuonLabel");
   IT_CSCTimeMapToken = consumes<reco::MuonTimeExtraMap>(edm::InputTag(CosmicSAMuonLabel.label(), std::string("csc")));
@@ -326,13 +328,9 @@ void BeamHaloAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& 
   edm::RunNumber_t Run = iEvent.run();
 
   //Get CSC Geometry
-  edm::ESHandle<CSCGeometry> TheCSCGeometry;
-  iSetup.get<MuonGeometryRecord>().get(TheCSCGeometry);
-
+  const auto& TheCSCGeometry = iSetup.getHandle(cscGeomToken_);
   //Get CaloGeometry
-  edm::ESHandle<CaloGeometry> TheCaloGeometry;
-  iSetup.get<CaloGeometryRecord>().get(TheCaloGeometry);
-
+  const auto& TheCaloGeometry = iSetup.getHandle(caloGeomToken_);
   //Get Stand-alone Muons from Cosmic Muon Reconstruction
   edm::Handle<reco::MuonCollection> TheCosmics;
   iEvent.getByToken(IT_CosmicStandAloneMuon, TheCosmics);

--- a/DQMOffline/JetMET/src/BeamHaloAnalyzer.cc
+++ b/DQMOffline/JetMET/src/BeamHaloAnalyzer.cc
@@ -61,7 +61,6 @@ BeamHaloAnalyzer::BeamHaloAnalyzer(const edm::ParameterSet& iConfig) {
   IT_BeamHaloSummary = consumes<BeamHaloSummary>(iConfig.getParameter<edm::InputTag>("BeamHaloSummaryLabel"));
 
   cscGeomToken_ = esConsumes();
-  caloGeomToken_ = esConsumes();
 
   edm::InputTag CosmicSAMuonLabel = iConfig.getParameter<edm::InputTag>("CosmicStandAloneMuonLabel");
   IT_CSCTimeMapToken = consumes<reco::MuonTimeExtraMap>(edm::InputTag(CosmicSAMuonLabel.label(), std::string("csc")));
@@ -329,8 +328,7 @@ void BeamHaloAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& 
 
   //Get CSC Geometry
   const auto& TheCSCGeometry = iSetup.getHandle(cscGeomToken_);
-  //Get CaloGeometry
-  const auto& TheCaloGeometry = iSetup.getHandle(caloGeomToken_);
+  //Note - removed getting calogeometry since it was unused
   //Get Stand-alone Muons from Cosmic Muon Reconstruction
   edm::Handle<reco::MuonCollection> TheCosmics;
   iEvent.getByToken(IT_CosmicStandAloneMuon, TheCosmics);

--- a/DQMOffline/JetMET/src/ECALRecHitAnalyzer.cc
+++ b/DQMOffline/JetMET/src/ECALRecHitAnalyzer.cc
@@ -16,6 +16,7 @@ ECALRecHitAnalyzer::ECALRecHitAnalyzer(const edm::ParameterSet& iConfig) {
   // Retrieve Information from the Configuration File
   EBRecHitsLabel_ = consumes<EBRecHitCollection>(iConfig.getParameter<edm::InputTag>("EBRecHitsLabel"));
   EERecHitsLabel_ = consumes<EERecHitCollection>(iConfig.getParameter<edm::InputTag>("EERecHitsLabel"));
+  caloGeomToken_ = esConsumes<edm::Transition::BeginRun>();
   FolderName_ = iConfig.getUntrackedParameter<std::string>("FolderName");
   debug_ = iConfig.getParameter<bool>("Debug");
   //  EBRecHitsLabel_= consumes<EcalRecHitCollection>(edm::InputTag(EBRecHitsLabel_));
@@ -24,6 +25,7 @@ ECALRecHitAnalyzer::ECALRecHitAnalyzer(const edm::ParameterSet& iConfig) {
 
 void ECALRecHitAnalyzer::dqmbeginRun(const edm::Run& iRun, const edm::EventSetup& iSetup) {
   CurrentEvent = -1;
+  caloGeom_ = &iSetup.getData(caloGeomToken_);
   // Fill the geometry histograms
   FillGeometry(iSetup);
 }
@@ -196,13 +198,9 @@ void ECALRecHitAnalyzer::bookHistograms(DQMStore::IBooker& ibooker, edm::Run con
 void ECALRecHitAnalyzer::FillGeometry(const edm::EventSetup& iSetup) {
   // Fill geometry histograms
   using namespace edm;
-  //int b=0;
-  edm::ESHandle<CaloGeometry> pG;
-  iSetup.get<CaloGeometryRecord>().get(pG);
-  const CaloGeometry cG = *pG;
-
+  //const auto& cG = iSetup.getData(caloGeomToken_);
   //----Fill Ecal Barrel----//
-  const CaloSubdetectorGeometry* EBgeom = cG.getSubdetectorGeometry(DetId::Ecal, 1);
+  const CaloSubdetectorGeometry* EBgeom = caloGeom_->getSubdetectorGeometry(DetId::Ecal, 1);
   int n = 0;
   std::vector<DetId> EBids = EBgeom->getValidDetIds(DetId::Ecal, 1);
   for (std::vector<DetId>::iterator i = EBids.begin(); i != EBids.end(); i++) {
@@ -225,7 +223,7 @@ void ECALRecHitAnalyzer::FillGeometry(const edm::EventSetup& iSetup) {
     DEBUG(" ");
   }
   //----Fill Ecal Endcap----------//
-  const CaloSubdetectorGeometry* EEgeom = cG.getSubdetectorGeometry(DetId::Ecal, 2);
+  const CaloSubdetectorGeometry* EEgeom = caloGeom_->getSubdetectorGeometry(DetId::Ecal, 2);
   n = 0;
   std::vector<DetId> EEids = EEgeom->getValidDetIds(DetId::Ecal, 2);
   for (std::vector<DetId>::iterator i = EEids.begin(); i != EEids.end(); i++) {
@@ -308,9 +306,6 @@ void ECALRecHitAnalyzer::WriteECALRecHits(const edm::Event& iEvent, const edm::E
   iEvent.getByToken(EERecHitsLabel_, EERecHits);
   DEBUG("Got ECALRecHits");
 
-  edm::ESHandle<CaloGeometry> pG;
-  iSetup.get<CaloGeometryRecord>().get(pG);
-  const CaloGeometry cG = *pG;
   //const CaloSubdetectorGeometry* EBgeom=cG.getSubdetectorGeometry(DetId::Ecal,1);
   //const CaloSubdetectorGeometry* EEgeom=cG.getSubdetectorGeometry(DetId::Ecal,2);
   DEBUG("Got Geometry");

--- a/DQMOffline/JetMET/src/HCALRecHitAnalyzer.cc
+++ b/DQMOffline/JetMET/src/HCALRecHitAnalyzer.cc
@@ -54,7 +54,7 @@ HCALRecHitAnalyzer::HCALRecHitAnalyzer(const edm::ParameterSet& iConfig) {
   hBHERecHitsLabel_ = consumes<HBHERecHitCollection>(iConfig.getParameter<edm::InputTag>("HBHERecHitsLabel"));
   hORecHitsLabel_ = consumes<HORecHitCollection>(iConfig.getParameter<edm::InputTag>("HORecHitsLabel"));
   hFRecHitsLabel_ = consumes<HFRecHitCollection>(iConfig.getParameter<edm::InputTag>("HFRecHitsLabel"));
-
+  caloGeomToken_ = esConsumes<edm::Transition::BeginRun>();
   debug_ = iConfig.getParameter<bool>("Debug");
   finebinning_ = iConfig.getUntrackedParameter<bool>("FineBinning");
   FolderName_ = iConfig.getUntrackedParameter<std::string>("FolderName");
@@ -239,8 +239,7 @@ void HCALRecHitAnalyzer::FillGeometry(const edm::EventSetup& iSetup) {
   // Retrieve!
   // ==========================================================
 
-  edm::ESHandle<CaloGeometry> pG;
-  iSetup.get<CaloGeometryRecord>().get(pG);
+  const auto& pG = iSetup.getHandle(caloGeomToken_);
 
   if (!pG.isValid()) {
     edm::LogInfo("OutputInfo") << "Failed to retrieve an Event Setup Handle, Aborting Task "

--- a/DQMOffline/JetMET/src/JetAnalyzer.cc
+++ b/DQMOffline/JetMET/src/JetAnalyzer.cc
@@ -260,6 +260,8 @@ JetAnalyzer::JetAnalyzer(const edm::ParameterSet& pSet)
   ptThresholdUnc_ = parameters_.getParameter<double>("ptThresholdUnc");
   asymmetryThirdJetCut_ = parameters_.getParameter<double>("asymmetryThirdJetCut");
   balanceThirdJetCut_ = parameters_.getParameter<double>("balanceThirdJetCut");
+
+  l1gtTrigMenuToken_ = esConsumes<edm::Transition::BeginRun>();
 }
 
 // ***********************************************************
@@ -2233,9 +2235,7 @@ void JetAnalyzer::dqmBeginRun(const edm::Run& iRun, const edm::EventSetup& iSetu
     }
   }
 
-  edm::ESHandle<L1GtTriggerMenu> menuRcd;
-  iSetup.get<L1GtTriggerMenuRcd>().get(menuRcd);
-  const L1GtTriggerMenu* menu = menuRcd.product();
+  const L1GtTriggerMenu* menu = &iSetup.getData(l1gtTrigMenuToken_);
   for (CItAlgo techTrig = menu->gtTechnicalTriggerMap().begin(); techTrig != menu->gtTechnicalTriggerMap().end();
        ++techTrig) {
     if ((techTrig->second).algoName() == m_l1algoname_) {

--- a/DQMOffline/JetMET/src/METAnalyzer.cc
+++ b/DQMOffline/JetMET/src/METAnalyzer.cc
@@ -181,6 +181,8 @@ METAnalyzer::METAnalyzer(const edm::ParameterSet& pSet) {
   verbose_ = parameters.getParameter<int>("verbose");
 
   FolderName_ = parameters.getUntrackedParameter<std::string>("FolderName");
+
+  l1gtTrigMenuToken_ = esConsumes<edm::Transition::BeginRun>();
 }
 
 // ***********************************************************
@@ -1178,9 +1180,7 @@ void METAnalyzer::bookMonitorElement(std::string DirName,
 
 // ***********************************************************
 void METAnalyzer::dqmBeginRun(const edm::Run& iRun, const edm::EventSetup& iSetup) {
-  edm::ESHandle<L1GtTriggerMenu> menuRcd;
-  iSetup.get<L1GtTriggerMenuRcd>().get(menuRcd);
-  const L1GtTriggerMenu* menu = menuRcd.product();
+  const L1GtTriggerMenu* menu = &iSetup.getData(l1gtTrigMenuToken_);
   for (CItAlgo techTrig = menu->gtTechnicalTriggerMap().begin(); techTrig != menu->gtTechnicalTriggerMap().end();
        ++techTrig) {
     if ((techTrig->second).algoName() == m_l1algoname_) {


### PR DESCRIPTION
#### PR description:
Part of #31061. Following up from #34208 to migrate more DQM packages for esConsumes.

#### PR validation:
Code compiles and static analyzer checks do no show the Eventsetup get warnings.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:
NA