### PR TITLE
Fixing missing comma in trackingPlots

### DIFF
--- a/Validation/RecoTrack/python/plotting/trackingPlots.py
+++ b/Validation/RecoTrack/python/plotting/trackingPlots.py
@@ -1458,7 +1458,7 @@ _iterations = [
                        "initialStepHitTripletsPreSplitting",
                        "initialStepHitQuadrupletsPreSplitting",
                        "initialStepSeedsPreSplitting"],
-              building=["initialStepTrackCandidatesPreSplitting"
+              building=["initialStepTrackCandidatesPreSplitting",
                         "initialStepTrackCandidatesMkFitSeedsPreSplitting",
                         "initialStepTrackCandidatesMkFitPreSplitting"],
               fit=["initialStepTracksPreSplitting"],


### PR DESCRIPTION
#### PR description:
Small technical fix to feature introduced in PR #34198 (in trackingPlots.py), causing tracking timing validation plots to be incorrect for InitialStepPreSplitting.

#### PR validation:
Workflows 11634.0, 11634.7

