### PR TITLE
fix for ndof of 4D primary vertices

### DIFF
--- a/RecoVertex/PrimaryVertexProducer/plugins/PrimaryVertexProducer.cc
+++ b/RecoVertex/PrimaryVertexProducer/plugins/PrimaryVertexProducer.cc
@@ -250,7 +250,8 @@ void PrimaryVertexProducer::produce(edm::Event& iEvent, const edm::EventSetup& i
             auto err = v.positionError().matrix4D();
             auto trkweightMap3d = v.weightMap();  // copy the 3 fit weights
             err(3, 3) = vartime;
-            v = TransientVertex(v.position(), meantime, err, v.originalTracks(), v.totalChiSquared());
+            v = TransientVertex(
+                v.position(), meantime, err, v.originalTracks(), v.totalChiSquared(), v.degreesOfFreedom());
             v.weightMap(trkweightMap3d);
           }
         }
@@ -262,7 +263,8 @@ void PrimaryVertexProducer::produce(edm::Event& iEvent, const edm::EventSetup& i
           if (v.isValid()) {
             auto err = v.positionError().matrix4D();
             err(3, 3) = vartime;
-            v = TransientVertex(v.position(), meantime, err, v.originalTracks(), v.totalChiSquared());
+            v = TransientVertex(
+                v.position(), meantime, err, v.originalTracks(), v.totalChiSquared(), v.degreesOfFreedom());
           }
         }
 


### PR DESCRIPTION
#### PR description:

This PR modifies the `ndof` value assigned to 4D vertices.

@werdmann noticed that, for 4D vertices, this value is currently an integer [*], while it should (to the best of my knowledge) be a float, as for 3D vertices.

No changes expected in the outputs, except for anything that depends on the `ndof` value of 4D vertices.

[*] It is currently an integer because, for 4D vertices, it is calculated [here](https://github.com/cms-sw/cmssw/blob/6d2f66057131baacc2fcbdd203588c41c885b42c/RecoVertex/VertexPrimitives/src/TransientVertex.cc#L52).

#### PR validation:

Private tests (checked on a few events that the `ndof` value for 4D vertices is updated correctly after these changes).

#### If this PR is a backport, please specify the original PR and why you need to backport that PR:

N/A