### PR TITLE
Migrate to esConsumes `Alignment/CommonAlignmentMonitor`

### DIFF
--- a/Alignment/CommonAlignmentMonitor/interface/AlignmentMonitorBase.h
+++ b/Alignment/CommonAlignmentMonitor/interface/AlignmentMonitorBase.h
@@ -36,6 +36,7 @@
 #include "TH2F.h"
 #include "TProfile.h"
 #include "TTree.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 
 // forward declarations
 
@@ -45,7 +46,7 @@ public:
   typedef std::vector<ConstTrajTrackPair> ConstTrajTrackPairCollection;
 
   /// Constructor
-  AlignmentMonitorBase(const edm::ParameterSet &cfg, std::string name);
+  AlignmentMonitorBase(const edm::ParameterSet &cfg, const edm::ConsumesCollector &iC, std::string name);
 
   /// Destructor
   virtual ~AlignmentMonitorBase() {}

--- a/Alignment/CommonAlignmentMonitor/interface/AlignmentMonitorPluginFactory.h
+++ b/Alignment/CommonAlignmentMonitor/interface/AlignmentMonitorPluginFactory.h
@@ -27,7 +27,8 @@ namespace edm {
   class ParameterSet;
 }
 
-typedef edmplugin::PluginFactory<AlignmentMonitorBase*(const edm::ParameterSet&)> AlignmentMonitorPluginFactory;
+typedef edmplugin::PluginFactory<AlignmentMonitorBase*(const edm::ParameterSet&, edm::ConsumesCollector&)>
+    AlignmentMonitorPluginFactory;
 
 // // Forward declaration
 // namespace edm { class ParameterSet; }

--- a/Alignment/CommonAlignmentMonitor/plugins/AlignmentMonitorAsAnalyzer.cc
+++ b/Alignment/CommonAlignmentMonitor/plugins/AlignmentMonitorAsAnalyzer.cc
@@ -132,11 +132,12 @@ AlignmentMonitorAsAnalyzer::AlignmentMonitorAsAnalyzer(const edm::ParameterSet& 
       esTokenCSCAPE_(esConsumes()),
       esTokenGEMAl_(esConsumes()),
       esTokenGEMAPE_(esConsumes()) {
+  edm::ConsumesCollector consumeCollector = consumesCollector();
   std::vector<std::string> monitors = iConfig.getUntrackedParameter<std::vector<std::string>>("monitors");
 
   for (auto const& mon : monitors) {
-    m_monitors.emplace_back(
-        AlignmentMonitorPluginFactory::get()->create(mon, iConfig.getUntrackedParameter<edm::ParameterSet>(mon)));
+    m_monitors.emplace_back(AlignmentMonitorPluginFactory::get()->create(
+        mon, iConfig.getUntrackedParameter<edm::ParameterSet>(mon), consumeCollector));
   }
 }
 

--- a/Alignment/CommonAlignmentMonitor/plugins/AlignmentMonitorAsAnalyzer.cc
+++ b/Alignment/CommonAlignmentMonitor/plugins/AlignmentMonitorAsAnalyzer.cc
@@ -3,7 +3,7 @@
 // Package:    AlignmentMonitorAsAnalyzer
 // Class:      AlignmentMonitorAsAnalyzer
 //
-/**\class AlignmentMonitorAsAnalyzer AlignmentMonitorAsAnalyzer.cc Dummy/AlignmentMonitorAsAnalyzer/src/AlignmentMonitorAsAnalyzer.cc
+/**\class AlignmentMonitorAsAnalyzer AlignmentMonitorAsAnalyzer.cc Alignment/CommonAlignmentMonitor/src/AlignmentMonitorAsAnalyzer.cc
 
  Description: <one line class summary>
 
@@ -22,7 +22,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/Framework/interface/ESHandle.h"
@@ -62,7 +62,7 @@
 // class decleration
 //
 
-class AlignmentMonitorAsAnalyzer : public edm::EDAnalyzer {
+class AlignmentMonitorAsAnalyzer : public edm::one::EDAnalyzer<> {
 public:
   explicit AlignmentMonitorAsAnalyzer(const edm::ParameterSet&);
   ~AlignmentMonitorAsAnalyzer() override = default;
@@ -84,16 +84,22 @@ private:
   std::unique_ptr<AlignmentParameterStore> m_alignmentParameterStore;
 
   std::vector<std::unique_ptr<AlignmentMonitorBase>> m_monitors;
-  edm::ESGetToken<DTGeometry, MuonGeometryRecord> esTokenDT_;
-  edm::ESGetToken<CSCGeometry, MuonGeometryRecord> esTokenCSC_;
-  edm::ESGetToken<GEMGeometry, MuonGeometryRecord> esTokenGEM_;
-  edm::ESGetToken<Alignments, GlobalPositionRcd> esTokenGPR_;
-  edm::ESGetToken<Alignments, DTAlignmentRcd> esTokenDTAl_;
-  edm::ESGetToken<AlignmentErrorsExtended, DTAlignmentErrorExtendedRcd> esTokenDTAPE_;
-  edm::ESGetToken<Alignments, CSCAlignmentRcd> esTokenCSCAl_;
-  edm::ESGetToken<AlignmentErrorsExtended, CSCAlignmentErrorExtendedRcd> esTokenCSCAPE_;
-  edm::ESGetToken<Alignments, GEMAlignmentRcd> esTokenGEMAl_;
-  edm::ESGetToken<AlignmentErrorsExtended, GEMAlignmentErrorExtendedRcd> esTokenGEMAPE_;
+
+  const edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> esTokenTTopo_;
+  const edm::ESGetToken<GeometricDet, IdealGeometryRecord> esTokenGeomDet_;
+  const edm::ESGetToken<PTrackerParameters, PTrackerParametersRcd> esTokenPTP_;
+  const edm::ESGetToken<DTGeometry, MuonGeometryRecord> esTokenDT_;
+  const edm::ESGetToken<CSCGeometry, MuonGeometryRecord> esTokenCSC_;
+  const edm::ESGetToken<GEMGeometry, MuonGeometryRecord> esTokenGEM_;
+  const edm::ESGetToken<Alignments, GlobalPositionRcd> esTokenGPR_;
+  const edm::ESGetToken<Alignments, TrackerAlignmentRcd> esTokenTkAl_;
+  const edm::ESGetToken<AlignmentErrorsExtended, TrackerAlignmentErrorExtendedRcd> esTokenTkAPE_;
+  const edm::ESGetToken<Alignments, DTAlignmentRcd> esTokenDTAl_;
+  const edm::ESGetToken<AlignmentErrorsExtended, DTAlignmentErrorExtendedRcd> esTokenDTAPE_;
+  const edm::ESGetToken<Alignments, CSCAlignmentRcd> esTokenCSCAl_;
+  const edm::ESGetToken<AlignmentErrorsExtended, CSCAlignmentErrorExtendedRcd> esTokenCSCAPE_;
+  const edm::ESGetToken<Alignments, GEMAlignmentRcd> esTokenGEMAl_;
+  const edm::ESGetToken<AlignmentErrorsExtended, GEMAlignmentErrorExtendedRcd> esTokenGEMAPE_;
   bool m_firstEvent;
 };
 
@@ -111,9 +117,21 @@ private:
 AlignmentMonitorAsAnalyzer::AlignmentMonitorAsAnalyzer(const edm::ParameterSet& iConfig)
     : m_tjTag(iConfig.getParameter<edm::InputTag>("tjTkAssociationMapTag")),
       m_aliParamStoreCfg(iConfig.getParameter<edm::ParameterSet>("ParameterStore")),
+      esTokenTTopo_(esConsumes()),
+      esTokenGeomDet_(esConsumes()),
+      esTokenPTP_(esConsumes()),
       esTokenDT_(esConsumes(edm::ESInputTag("", "idealForAlignmentMonitorAsAnalyzer"))),
       esTokenCSC_(esConsumes(edm::ESInputTag("", "idealForAlignmentMonitorAsAnalyzer"))),
-      esTokenGEM_(esConsumes(edm::ESInputTag("", "idealForAlignmentMonitorAsAnalyzer"))) {
+      esTokenGEM_(esConsumes(edm::ESInputTag("", "idealForAlignmentMonitorAsAnalyzer"))),
+      esTokenGPR_(esConsumes()),
+      esTokenTkAl_(esConsumes()),
+      esTokenTkAPE_(esConsumes()),
+      esTokenDTAl_(esConsumes()),
+      esTokenDTAPE_(esConsumes()),
+      esTokenCSCAl_(esConsumes()),
+      esTokenCSCAPE_(esConsumes()),
+      esTokenGEMAl_(esConsumes()),
+      esTokenGEMAPE_(esConsumes()) {
   std::vector<std::string> monitors = iConfig.getUntrackedParameter<std::vector<std::string>>("monitors");
 
   for (auto const& mon : monitors) {
@@ -129,37 +147,29 @@ AlignmentMonitorAsAnalyzer::AlignmentMonitorAsAnalyzer(const edm::ParameterSet& 
 // ------------ method called to for each event  ------------
 void AlignmentMonitorAsAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
   //Retrieve tracker topology from geometry
-  edm::ESHandle<TrackerTopology> tTopoHandle;
-  iSetup.get<TrackerTopologyRcd>().get(tTopoHandle);
-  const TrackerTopology* const tTopo = tTopoHandle.product();
+  const TrackerTopology* const tTopo = &iSetup.getData(esTokenTTopo_);
 
   if (m_firstEvent) {
     GeometryAligner aligner;
 
-    edm::ESHandle<GeometricDet> theGeometricDet;
-    iSetup.get<IdealGeometryRecord>().get(theGeometricDet);
-    edm::ESHandle<PTrackerParameters> ptp;
-    iSetup.get<PTrackerParametersRcd>().get(ptp);
+    const GeometricDet* geom = &iSetup.getData(esTokenGeomDet_);
+    const PTrackerParameters& ptp = iSetup.getData(esTokenPTP_);
     TrackerGeomBuilderFromGeometricDet trackerBuilder;
-    std::shared_ptr<TrackerGeometry> theTracker(trackerBuilder.build(&(*theGeometricDet), *ptp, tTopo));
+    std::shared_ptr<TrackerGeometry> theTracker(trackerBuilder.build(geom, ptp, tTopo));
 
     edm::ESHandle<DTGeometry> theMuonDT = iSetup.getHandle(esTokenDT_);
     edm::ESHandle<CSCGeometry> theMuonCSC = iSetup.getHandle(esTokenCSC_);
     edm::ESHandle<GEMGeometry> theMuonGEM = iSetup.getHandle(esTokenGEM_);
-
     edm::ESHandle<Alignments> globalPositionRcd = iSetup.getHandle(esTokenGPR_);
 
-    edm::ESHandle<Alignments> alignments;
-    iSetup.get<TrackerAlignmentRcd>().get(alignments);
-    edm::ESHandle<AlignmentErrorsExtended> alignmentErrors;
-    iSetup.get<TrackerAlignmentErrorExtendedRcd>().get(alignmentErrors);
+    const Alignments* alignments = &iSetup.getData(esTokenTkAl_);
+    const AlignmentErrorsExtended* alignmentErrors = &iSetup.getData(esTokenTkAPE_);
     aligner.applyAlignments<TrackerGeometry>(&(*theTracker),
-                                             &(*alignments),
-                                             &(*alignmentErrors),
+                                             alignments,
+                                             alignmentErrors,
                                              align::DetectorGlobalPosition(*globalPositionRcd, DetId(DetId::Tracker)));
 
     edm::ESHandle<Alignments> dtAlignments = iSetup.getHandle(esTokenDTAl_);
-    ;
     edm::ESHandle<AlignmentErrorsExtended> dtAlignmentErrorsExtended = iSetup.getHandle(esTokenDTAPE_);
     aligner.applyAlignments<DTGeometry>(&(*theMuonDT),
                                         &(*dtAlignments),

--- a/Alignment/CommonAlignmentMonitor/plugins/AlignmentMonitorGeneric.cc
+++ b/Alignment/CommonAlignmentMonitor/plugins/AlignmentMonitorGeneric.cc
@@ -8,8 +8,8 @@
 
 #include <TString.h>
 
-AlignmentMonitorGeneric::AlignmentMonitorGeneric(const edm::ParameterSet& cfg)
-    : AlignmentMonitorBase(cfg, "AlignmentMonitorGeneric") {}
+AlignmentMonitorGeneric::AlignmentMonitorGeneric(const edm::ParameterSet& cfg, edm::ConsumesCollector iC)
+    : AlignmentMonitorBase(cfg, iC, "AlignmentMonitorGeneric") {}
 
 void AlignmentMonitorGeneric::book() {
   std::vector<std::string> residNames;  // names of residual histograms

--- a/Alignment/CommonAlignmentMonitor/plugins/AlignmentMonitorGeneric.h
+++ b/Alignment/CommonAlignmentMonitor/plugins/AlignmentMonitorGeneric.h
@@ -29,7 +29,7 @@ class AlignmentMonitorGeneric : public AlignmentMonitorBase {
   typedef std::vector<TH1F*> Hist1Ds;
 
 public:
-  AlignmentMonitorGeneric(const edm::ParameterSet&);
+  AlignmentMonitorGeneric(const edm::ParameterSet&, edm::ConsumesCollector iC);
 
   void book() override;
 

--- a/Alignment/CommonAlignmentMonitor/plugins/AlignmentMonitorMuonResiduals.cc
+++ b/Alignment/CommonAlignmentMonitor/plugins/AlignmentMonitorMuonResiduals.cc
@@ -33,7 +33,7 @@
 
 class AlignmentMonitorMuonResiduals : public AlignmentMonitorBase {
 public:
-  AlignmentMonitorMuonResiduals(const edm::ParameterSet &cfg);
+  AlignmentMonitorMuonResiduals(const edm::ParameterSet &cfg, edm::ConsumesCollector iC);
   ~AlignmentMonitorMuonResiduals() override{};
 
   void book() override;
@@ -145,8 +145,8 @@ private:
 // member functions
 //
 
-AlignmentMonitorMuonResiduals::AlignmentMonitorMuonResiduals(const edm::ParameterSet &cfg)
-    : AlignmentMonitorBase(cfg, "AlignmentMonitorMuonResiduals") {
+AlignmentMonitorMuonResiduals::AlignmentMonitorMuonResiduals(const edm::ParameterSet &cfg, edm::ConsumesCollector iC)
+    : AlignmentMonitorBase(cfg, iC, "AlignmentMonitorMuonResiduals") {
   xresid_bins = cfg.getParameter<unsigned int>("xresid_bins");
   xmean_bins = cfg.getParameter<unsigned int>("xmean_bins");
   xstdev_bins = cfg.getParameter<unsigned int>("xstdev_bins");

--- a/Alignment/CommonAlignmentMonitor/plugins/AlignmentMonitorMuonVsCurvature.cc
+++ b/Alignment/CommonAlignmentMonitor/plugins/AlignmentMonitorMuonVsCurvature.cc
@@ -33,7 +33,7 @@
 
 class AlignmentMonitorMuonVsCurvature : public AlignmentMonitorBase {
 public:
-  AlignmentMonitorMuonVsCurvature(const edm::ParameterSet &cfg);
+  AlignmentMonitorMuonVsCurvature(const edm::ParameterSet &cfg, edm::ConsumesCollector iC);
   ~AlignmentMonitorMuonVsCurvature() override {}
 
   void book() override;
@@ -44,6 +44,13 @@ public:
   void processMuonResidualsFromTrack(MuonResidualsFromTrack &mrft, const Trajectory *traj = nullptr);
 
 private:
+  // es token
+  const edm::ESGetToken<GlobalTrackingGeometry, GlobalTrackingGeometryRecord> m_esTokenGBTGeom;
+  const edm::ESGetToken<DetIdAssociator, DetIdAssociatorRecord> m_esTokenDetId;
+  const edm::ESGetToken<Propagator, TrackingComponentsRecord> m_esTokenProp;
+  const edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> m_esTokenMF;
+
+  // parameters
   edm::InputTag m_muonCollectionTag;
   double m_minTrackPt;
   double m_minTrackP;
@@ -74,8 +81,13 @@ private:
   TH1F *th1f_trackerRedChi2Diff;
 };
 
-AlignmentMonitorMuonVsCurvature::AlignmentMonitorMuonVsCurvature(const edm::ParameterSet &cfg)
-    : AlignmentMonitorBase(cfg, "AlignmentMonitorMuonVsCurvature"),
+AlignmentMonitorMuonVsCurvature::AlignmentMonitorMuonVsCurvature(const edm::ParameterSet &cfg,
+                                                                 edm::ConsumesCollector iC)
+    : AlignmentMonitorBase(cfg, iC, "AlignmentMonitorMuonVsCurvature"),
+      m_esTokenGBTGeom(iC.esConsumes()),
+      m_esTokenDetId(iC.esConsumes(edm::ESInputTag("", "MuonDetIdAssociator"))),
+      m_esTokenProp(iC.esConsumes(edm::ESInputTag("", "SteppingHelixPropagatorAny"))),
+      m_esTokenMF(iC.esConsumes()),
       m_muonCollectionTag(cfg.getParameter<edm::InputTag>("muonCollectionTag")),
       m_minTrackPt(cfg.getParameter<double>("minTrackPt")),
       m_minTrackP(cfg.getParameter<double>("minTrackP")),
@@ -182,20 +194,13 @@ void AlignmentMonitorMuonVsCurvature::book() {
 void AlignmentMonitorMuonVsCurvature::event(const edm::Event &iEvent,
                                             const edm::EventSetup &iSetup,
                                             const ConstTrajTrackPairCollection &trajtracks) {
-  edm::ESHandle<GlobalTrackingGeometry> globalGeometry;
-  iSetup.get<GlobalTrackingGeometryRecord>().get(globalGeometry);
-
   edm::Handle<reco::BeamSpot> beamSpot;
   iEvent.getByLabel(m_beamSpotTag, beamSpot);
 
-  edm::ESHandle<DetIdAssociator> muonDetIdAssociator_;
-  iSetup.get<DetIdAssociatorRecord>().get("MuonDetIdAssociator", muonDetIdAssociator_);
-
-  edm::ESHandle<Propagator> prop;
-  iSetup.get<TrackingComponentsRecord>().get("SteppingHelixPropagatorAny", prop);
-
-  edm::ESHandle<MagneticField> magneticField;
-  iSetup.get<IdealMagneticFieldRecord>().get(magneticField);
+  const GlobalTrackingGeometry *globalGeometry = &iSetup.getData(m_esTokenGBTGeom);
+  const DetIdAssociator *muonDetIdAssociator_ = &iSetup.getData(m_esTokenDetId);
+  const Propagator *prop = &iSetup.getData(m_esTokenProp);
+  const MagneticField *magneticField = &iSetup.getData(m_esTokenMF);
 
   if (m_muonCollectionTag.label().empty())  // use trajectories
   {

--- a/Alignment/CommonAlignmentMonitor/plugins/AlignmentMonitorSegmentDifferences.cc
+++ b/Alignment/CommonAlignmentMonitor/plugins/AlignmentMonitorSegmentDifferences.cc
@@ -33,7 +33,7 @@
 
 class AlignmentMonitorSegmentDifferences : public AlignmentMonitorBase {
 public:
-  AlignmentMonitorSegmentDifferences(const edm::ParameterSet &cfg);
+  AlignmentMonitorSegmentDifferences(const edm::ParameterSet &cfg, edm::ConsumesCollector iC);
   ~AlignmentMonitorSegmentDifferences() override {}
 
   void book() override;
@@ -44,6 +44,13 @@ public:
   void processMuonResidualsFromTrack(MuonResidualsFromTrack &mrft);
 
 private:
+  // es token
+  const edm::ESGetToken<GlobalTrackingGeometry, GlobalTrackingGeometryRecord> m_esTokenGBTGeom;
+  const edm::ESGetToken<DetIdAssociator, DetIdAssociatorRecord> m_esTokenDetId;
+  const edm::ESGetToken<Propagator, TrackingComponentsRecord> m_esTokenProp;
+  const edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> m_esTokenMF;
+
+  // parameters
   edm::InputTag m_muonCollectionTag;
   double m_minTrackPt;
   double m_minTrackP;
@@ -107,8 +114,13 @@ private:
 // member functions
 //
 
-AlignmentMonitorSegmentDifferences::AlignmentMonitorSegmentDifferences(const edm::ParameterSet &cfg)
-    : AlignmentMonitorBase(cfg, "AlignmentMonitorSegmentDifferences"),
+AlignmentMonitorSegmentDifferences::AlignmentMonitorSegmentDifferences(const edm::ParameterSet &cfg,
+                                                                       edm::ConsumesCollector iC)
+    : AlignmentMonitorBase(cfg, iC, "AlignmentMonitorSegmentDifferences"),
+      m_esTokenGBTGeom(iC.esConsumes()),
+      m_esTokenDetId(iC.esConsumes(edm::ESInputTag("", "MuonDetIdAssociator"))),
+      m_esTokenProp(iC.esConsumes(edm::ESInputTag("", "SteppingHelixPropagatorAny"))),
+      m_esTokenMF(iC.esConsumes()),
       m_muonCollectionTag(cfg.getParameter<edm::InputTag>("muonCollectionTag")),
       m_minTrackPt(cfg.getParameter<double>("minTrackPt")),
       m_minTrackP(cfg.getParameter<double>("minTrackP")),
@@ -357,20 +369,13 @@ void AlignmentMonitorSegmentDifferences::book() {
 void AlignmentMonitorSegmentDifferences::event(const edm::Event &iEvent,
                                                const edm::EventSetup &iSetup,
                                                const ConstTrajTrackPairCollection &trajtracks) {
-  edm::ESHandle<GlobalTrackingGeometry> globalGeometry;
-  iSetup.get<GlobalTrackingGeometryRecord>().get(globalGeometry);
-
   edm::Handle<reco::BeamSpot> beamSpot;
   iEvent.getByLabel(m_beamSpotTag, beamSpot);
 
-  edm::ESHandle<DetIdAssociator> muonDetIdAssociator_;
-  iSetup.get<DetIdAssociatorRecord>().get("MuonDetIdAssociator", muonDetIdAssociator_);
-
-  edm::ESHandle<Propagator> prop;
-  iSetup.get<TrackingComponentsRecord>().get("SteppingHelixPropagatorAny", prop);
-
-  edm::ESHandle<MagneticField> magneticField;
-  iSetup.get<IdealMagneticFieldRecord>().get(magneticField);
+  const GlobalTrackingGeometry *globalGeometry = &iSetup.getData(m_esTokenGBTGeom);
+  const DetIdAssociator *muonDetIdAssociator_ = &iSetup.getData(m_esTokenDetId);
+  const Propagator *prop = &iSetup.getData(m_esTokenProp);
+  const MagneticField *magneticField = &iSetup.getData(m_esTokenMF);
 
   if (m_muonCollectionTag.label().empty())  // use trajectories
   {

--- a/Alignment/CommonAlignmentMonitor/plugins/AlignmentMonitorSurvey.cc
+++ b/Alignment/CommonAlignmentMonitor/plugins/AlignmentMonitorSurvey.cc
@@ -4,8 +4,8 @@
 
 #include "Alignment/CommonAlignmentMonitor/plugins/AlignmentMonitorSurvey.h"
 
-AlignmentMonitorSurvey::AlignmentMonitorSurvey(const edm::ParameterSet& cfg)
-    : AlignmentMonitorBase(cfg, "AlignmentMonitorSurvey"),
+AlignmentMonitorSurvey::AlignmentMonitorSurvey(const edm::ParameterSet& cfg, edm::ConsumesCollector iC)
+    : AlignmentMonitorBase(cfg, iC, "AlignmentMonitorSurvey"),
       levelNames_(cfg.getUntrackedParameter<std::vector<std::string> >("surveyResiduals")) {}
 
 void AlignmentMonitorSurvey::book() {

--- a/Alignment/CommonAlignmentMonitor/plugins/AlignmentMonitorSurvey.h
+++ b/Alignment/CommonAlignmentMonitor/plugins/AlignmentMonitorSurvey.h
@@ -20,7 +20,7 @@
 
 class AlignmentMonitorSurvey : public AlignmentMonitorBase {
 public:
-  AlignmentMonitorSurvey(const edm::ParameterSet&);
+  AlignmentMonitorSurvey(const edm::ParameterSet&, edm::ConsumesCollector);
 
   void book() override;
 

--- a/Alignment/CommonAlignmentMonitor/plugins/AlignmentMonitorTemplate.cc
+++ b/Alignment/CommonAlignmentMonitor/plugins/AlignmentMonitorTemplate.cc
@@ -27,7 +27,8 @@
 
 class AlignmentMonitorTemplate : public AlignmentMonitorBase {
 public:
-  AlignmentMonitorTemplate(const edm::ParameterSet& cfg) : AlignmentMonitorBase(cfg, "AlignmentMonitorTemplate"){};
+  AlignmentMonitorTemplate(const edm::ParameterSet& cfg, edm::ConsumesCollector iC)
+      : AlignmentMonitorBase(cfg, iC, "AlignmentMonitorTemplate"){};
   ~AlignmentMonitorTemplate() override{};
 
   void book() override;

--- a/Alignment/CommonAlignmentMonitor/plugins/AlignmentMonitorTracksFromTrajectories.cc
+++ b/Alignment/CommonAlignmentMonitor/plugins/AlignmentMonitorTracksFromTrajectories.cc
@@ -2,7 +2,7 @@
 //
 // Package:     CommonAlignmentProducer
 // Class  :     AlignmentMonitorTracksFromTrajectories
-// 
+//
 // Implementation:
 //     <Notes on implementation>
 //
@@ -12,12 +12,12 @@
 
 // system include files
 #include "Alignment/CommonAlignmentMonitor/interface/AlignmentMonitorPluginFactory.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h" 
-#include "FWCore/Utilities/interface/InputTag.h" 
-#include "TrackingTools/TrajectoryState/interface/FreeTrajectoryState.h" 
-#include "DataFormats/GeometrySurface/interface/Surface.h" 
-#include "TH1.h" 
-#include "TObject.h" 
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "TrackingTools/TrajectoryState/interface/FreeTrajectoryState.h"
+#include "DataFormats/GeometrySurface/interface/Surface.h"
+#include "TH1.h"
+#include "TObject.h"
 #include "Alignment/CommonAlignmentMonitor/interface/AlignmentMonitorBase.h"
 
 #include "RecoMuon/TrackingTools/interface/MuonServiceProxy.h"
@@ -28,43 +28,43 @@
 
 // user include files
 
-// 
+//
 // class definition
-// 
+//
 
-class AlignmentMonitorTracksFromTrajectories: public AlignmentMonitorBase {
-   public:
-      AlignmentMonitorTracksFromTrajectories(const edm::ParameterSet& cfg);
-      ~AlignmentMonitorTracksFromTrajectories() {};
+class AlignmentMonitorTracksFromTrajectories : public AlignmentMonitorBase {
+public:
+  AlignmentMonitorTracksFromTrajectories(const edm::ParameterSet &cfg, edm::ConsumesCollector iC);
+  ~AlignmentMonitorTracksFromTrajectories(){};
 
-      void book();
-      void event(const edm::Event &iEvent, const edm::EventSetup &iSetup, const ConstTrajTrackPairCollection& iTrajTracks);
-      void afterAlignment();
+  void book();
+  void event(const edm::Event &iEvent, const edm::EventSetup &iSetup, const ConstTrajTrackPairCollection &iTrajTracks);
+  void afterAlignment();
 
-   private:
-      MuonServiceProxy *theMuonServiceProxy;
-      MuonUpdatorAtVertex *theMuonUpdatorAtVertex;
-      bool m_vertexConstraint;
-      edm::InputTag m_beamSpot;
+private:
+  MuonServiceProxy *theMuonServiceProxy;
+  MuonUpdatorAtVertex *theMuonUpdatorAtVertex;
+  bool m_vertexConstraint;
+  edm::InputTag m_beamSpot;
 
-      TH1F *m_diMuon_Z;
-      TH1F *m_diMuon_Zforward;
-      TH1F *m_diMuon_Zbarrel;
-      TH1F *m_diMuon_Zbackward;
-      TH1F *m_diMuon_Ups;
-      TH1F *m_diMuon_Jpsi;
-      TH1F *m_diMuon_log;
-      TH1F *m_chi2_100;
-      TH1F *m_chi2_10000;
-      TH1F *m_chi2_1000000;
-      TH1F *m_chi2_log;
-      TH1F *m_chi2DOF_5;
-      TH1F *m_chi2DOF_100;
-      TH1F *m_chi2DOF_1000;
-      TH1F *m_chi2DOF_log;
-      TH1F *m_chi2_improvement;
-      TH1F *m_chi2DOF_improvement;
-      TH1F *m_pt[36];
+  TH1F *m_diMuon_Z;
+  TH1F *m_diMuon_Zforward;
+  TH1F *m_diMuon_Zbarrel;
+  TH1F *m_diMuon_Zbackward;
+  TH1F *m_diMuon_Ups;
+  TH1F *m_diMuon_Jpsi;
+  TH1F *m_diMuon_log;
+  TH1F *m_chi2_100;
+  TH1F *m_chi2_10000;
+  TH1F *m_chi2_1000000;
+  TH1F *m_chi2_log;
+  TH1F *m_chi2DOF_5;
+  TH1F *m_chi2DOF_100;
+  TH1F *m_chi2DOF_1000;
+  TH1F *m_chi2DOF_log;
+  TH1F *m_chi2_improvement;
+  TH1F *m_chi2DOF_improvement;
+  TH1F *m_pt[36];
 };
 
 //
@@ -96,13 +96,14 @@ class AlignmentMonitorTracksFromTrajectories: public AlignmentMonitorBase {
 //   return *this;
 // }
 
-AlignmentMonitorTracksFromTrajectories::AlignmentMonitorTracksFromTrajectories(const edm::ParameterSet& cfg)
-   : AlignmentMonitorBase(cfg, "AlignmentMonitorTracksFromTrajectories")
-   , m_vertexConstraint(cfg.getParameter<bool>("vertexConstraint"))
-   , m_beamSpot(cfg.getParameter<edm::InputTag>("beamSpot"))
-{
-   theMuonServiceProxy = new MuonServiceProxy(cfg.getParameter<edm::ParameterSet>("ServiceParameters"));
-   theMuonUpdatorAtVertex = new MuonUpdatorAtVertex(cfg.getParameter<edm::ParameterSet>("MuonUpdatorAtVertexParameters"), theMuonServiceProxy);
+AlignmentMonitorTracksFromTrajectories::AlignmentMonitorTracksFromTrajectories(const edm::ParameterSet &cfg,
+                                                                               edm::ConsumesCollector iC)
+    : AlignmentMonitorBase(cfg, iC, "AlignmentMonitorTracksFromTrajectories"),
+      m_vertexConstraint(cfg.getParameter<bool>("vertexConstraint")),
+      m_beamSpot(cfg.getParameter<edm::InputTag>("beamSpot")) {
+  theMuonServiceProxy = new MuonServiceProxy(cfg.getParameter<edm::ParameterSet>("ServiceParameters"));
+  theMuonUpdatorAtVertex = new MuonUpdatorAtVertex(cfg.getParameter<edm::ParameterSet>("MuonUpdatorAtVertexParameters"),
+                                                   theMuonServiceProxy);
 }
 
 //
@@ -114,154 +115,161 @@ AlignmentMonitorTracksFromTrajectories::AlignmentMonitorTracksFromTrajectories(c
 //////////////////////////////////////////////////////////////////////
 
 void AlignmentMonitorTracksFromTrajectories::book() {
-   m_diMuon_Z = book1D("/iterN/", "diMuon_Z", "Di-muon mass (GeV)", 200, 90. - 50., 90. + 50.);
-   m_diMuon_Zforward = book1D("/iterN/", "diMuon_Zforward", "Di-muon mass (GeV) eta > 1.4", 200, 90. - 50., 90. + 50.);
-   m_diMuon_Zbarrel = book1D("/iterN/", "diMuon_Zbarrel", "Di-muon mass (GeV) -1.4 < eta < 1.4", 200, 90. - 50., 90. + 50.);
-   m_diMuon_Zbackward = book1D("/iterN/", "diMuon_Zbackward", "Di-muon mass (GeV) eta < -1.4", 200, 90. - 50., 90. + 50.);
-   m_diMuon_Ups = book1D("/iterN/", "diMuon_Ups", "Di-muon mass (GeV)", 200, 9. - 3., 9. + 3.);
-   m_diMuon_Jpsi = book1D("/iterN/", "diMuon_Jpsi", "Di-muon mass (GeV)", 200, 3. - 1., 3. + 1.);
-   m_diMuon_log = book1D("/iterN/", "diMuon_log", "Di-muon mass (log GeV)", 300, 0, 3);
-   m_chi2_100 = book1D("/iterN/", "m_chi2_100", "Track chi^2", 100, 0, 100);
-   m_chi2_10000 = book1D("/iterN/", "m_chi2_10000", "Track chi^2", 100, 0, 10000);
-   m_chi2_1000000 = book1D("/iterN/", "m_chi2_1000000", "Track chi^2", 100, 1, 1000000);
-   m_chi2_log = book1D("/iterN/", "m_chi2_log", "Log track chi^2", 100, -3, 7);
-   m_chi2DOF_5 = book1D("/iterN/", "m_chi2DOF_5", "Track chi^2/nDOF", 100, 0, 5);
-   m_chi2DOF_100 = book1D("/iterN/", "m_chi2DOF_100", "Track chi^2/nDOF", 100, 0, 100);
-   m_chi2DOF_1000 = book1D("/iterN/", "m_chi2DOF_1000", "Track chi^2/nDOF", 100, 0, 1000);
-   m_chi2DOF_log = book1D("/iterN/", "m_chi2DOF_log", "Log track chi^2/nDOF", 100, -3, 7);
-   m_chi2_improvement = book1D("/iterN/", "m_chi2_improvement", "Track-by-track chi^2/original chi^2", 100, 0., 10.);
-   m_chi2DOF_improvement = book1D("/iterN/", "m_chi2DOF_improvement", "Track-by-track (chi^2/DOF)/(original chi^2/original DOF)", 100, 0., 10.);
-   for (int i = 0;  i < 36;  i++) {
-      char name[100], title[100];
-      snprintf(name, sizeof(name), "m_pt_phi%d", i);
-      snprintf(title, sizeof(title), "Track pt (GeV) in phi bin %d/36", i);
-      m_pt[i] = book1D("/iterN/", name, title, 100, 0, 100);
-   }
+  m_diMuon_Z = book1D("/iterN/", "diMuon_Z", "Di-muon mass (GeV)", 200, 90. - 50., 90. + 50.);
+  m_diMuon_Zforward = book1D("/iterN/", "diMuon_Zforward", "Di-muon mass (GeV) eta > 1.4", 200, 90. - 50., 90. + 50.);
+  m_diMuon_Zbarrel =
+      book1D("/iterN/", "diMuon_Zbarrel", "Di-muon mass (GeV) -1.4 < eta < 1.4", 200, 90. - 50., 90. + 50.);
+  m_diMuon_Zbackward =
+      book1D("/iterN/", "diMuon_Zbackward", "Di-muon mass (GeV) eta < -1.4", 200, 90. - 50., 90. + 50.);
+  m_diMuon_Ups = book1D("/iterN/", "diMuon_Ups", "Di-muon mass (GeV)", 200, 9. - 3., 9. + 3.);
+  m_diMuon_Jpsi = book1D("/iterN/", "diMuon_Jpsi", "Di-muon mass (GeV)", 200, 3. - 1., 3. + 1.);
+  m_diMuon_log = book1D("/iterN/", "diMuon_log", "Di-muon mass (log GeV)", 300, 0, 3);
+  m_chi2_100 = book1D("/iterN/", "m_chi2_100", "Track chi^2", 100, 0, 100);
+  m_chi2_10000 = book1D("/iterN/", "m_chi2_10000", "Track chi^2", 100, 0, 10000);
+  m_chi2_1000000 = book1D("/iterN/", "m_chi2_1000000", "Track chi^2", 100, 1, 1000000);
+  m_chi2_log = book1D("/iterN/", "m_chi2_log", "Log track chi^2", 100, -3, 7);
+  m_chi2DOF_5 = book1D("/iterN/", "m_chi2DOF_5", "Track chi^2/nDOF", 100, 0, 5);
+  m_chi2DOF_100 = book1D("/iterN/", "m_chi2DOF_100", "Track chi^2/nDOF", 100, 0, 100);
+  m_chi2DOF_1000 = book1D("/iterN/", "m_chi2DOF_1000", "Track chi^2/nDOF", 100, 0, 1000);
+  m_chi2DOF_log = book1D("/iterN/", "m_chi2DOF_log", "Log track chi^2/nDOF", 100, -3, 7);
+  m_chi2_improvement = book1D("/iterN/", "m_chi2_improvement", "Track-by-track chi^2/original chi^2", 100, 0., 10.);
+  m_chi2DOF_improvement = book1D(
+      "/iterN/", "m_chi2DOF_improvement", "Track-by-track (chi^2/DOF)/(original chi^2/original DOF)", 100, 0., 10.);
+  for (int i = 0; i < 36; i++) {
+    char name[100], title[100];
+    snprintf(name, sizeof(name), "m_pt_phi%d", i);
+    snprintf(title, sizeof(title), "Track pt (GeV) in phi bin %d/36", i);
+    m_pt[i] = book1D("/iterN/", name, title, 100, 0, 100);
+  }
 }
 
 //////////////////////////////////////////////////////////////////////
 // event()
 //////////////////////////////////////////////////////////////////////
 
-void AlignmentMonitorTracksFromTrajectories::event(const edm::Event &iEvent, const edm::EventSetup &iSetup, const ConstTrajTrackPairCollection& tracks) {
-   theMuonServiceProxy->update(iSetup);
+void AlignmentMonitorTracksFromTrajectories::event(const edm::Event &iEvent,
+                                                   const edm::EventSetup &iSetup,
+                                                   const ConstTrajTrackPairCollection &tracks) {
+  theMuonServiceProxy->update(iSetup);
 
-   edm::Handle<reco::BeamSpot> beamSpot;
-   iEvent.getByLabel(m_beamSpot, beamSpot);
+  edm::Handle<reco::BeamSpot> beamSpot;
+  iEvent.getByLabel(m_beamSpot, beamSpot);
 
-   GlobalVector p1, p2;
-   double e1 = 0.;
-   double e2 = 0.;
+  GlobalVector p1, p2;
+  double e1 = 0.;
+  double e2 = 0.;
 
-   for (ConstTrajTrackPairCollection::const_iterator it = tracks.begin();  it != tracks.end();  ++it) {
-      const Trajectory *traj = it->first;
-      const reco::Track *track = it->second;
+  for (ConstTrajTrackPairCollection::const_iterator it = tracks.begin(); it != tracks.end(); ++it) {
+    const Trajectory *traj = it->first;
+    const reco::Track *track = it->second;
 
-      int nDOF = 0;
-      TrajectoryStateOnSurface closestTSOS;
-      double closest = 10000.;
+    int nDOF = 0;
+    TrajectoryStateOnSurface closestTSOS;
+    double closest = 10000.;
 
-      std::vector<TrajectoryMeasurement> measurements = traj->measurements();
-      for (std::vector<TrajectoryMeasurement>::const_iterator im = measurements.begin();  im != measurements.end();  ++im) {
-	 const TrajectoryMeasurement meas = *im;
-	 const TransientTrackingRecHit* hit = &(*meas.recHit());
-//	 const DetId id = hit->geographicalId();
+    std::vector<TrajectoryMeasurement> measurements = traj->measurements();
+    for (std::vector<TrajectoryMeasurement>::const_iterator im = measurements.begin(); im != measurements.end(); ++im) {
+      const TrajectoryMeasurement meas = *im;
+      const TransientTrackingRecHit *hit = &(*meas.recHit());
+      //	 const DetId id = hit->geographicalId();
 
-	 nDOF += hit->dimension();
+      nDOF += hit->dimension();
 
-	 TrajectoryStateOnSurface TSOS = meas.backwardPredictedState();
-	 GlobalPoint where = TSOS.surface().toGlobal(LocalPoint(0,0,0));
+      TrajectoryStateOnSurface TSOS = meas.backwardPredictedState();
+      GlobalPoint where = TSOS.surface().toGlobal(LocalPoint(0, 0, 0));
 
-	 if (where.mag() < closest) {
-	    closest = where.mag();
-	    closestTSOS = TSOS;
-	 }
+      if (where.mag() < closest) {
+        closest = where.mag();
+        closestTSOS = TSOS;
+      }
 
-      } // end loop over measurements
-      nDOF -= 5;
+    }  // end loop over measurements
+    nDOF -= 5;
 
-      if (closest != 10000.) {
-	 std::pair<bool, FreeTrajectoryState> state;
+    if (closest != 10000.) {
+      std::pair<bool, FreeTrajectoryState> state;
 
-	 if (m_vertexConstraint) {
-	    state = theMuonUpdatorAtVertex->propagateWithUpdate(closestTSOS, *beamSpot);
-	    // add in chi^2 contribution from vertex contratint?
-	 }
-	 else {
- 	    state = theMuonUpdatorAtVertex->propagate(closestTSOS, *beamSpot);
-	 }
+      if (m_vertexConstraint) {
+        state = theMuonUpdatorAtVertex->propagateWithUpdate(closestTSOS, *beamSpot);
+        // add in chi^2 contribution from vertex contratint?
+      } else {
+        state = theMuonUpdatorAtVertex->propagate(closestTSOS, *beamSpot);
+      }
 
-	 if (state.first) {
-	    double chi2 = traj->chiSquared();
-	    double chi2DOF = chi2 / double(nDOF);
+      if (state.first) {
+        double chi2 = traj->chiSquared();
+        double chi2DOF = chi2 / double(nDOF);
 
-	    m_chi2_100->Fill(chi2);
-	    m_chi2_10000->Fill(chi2);
-	    m_chi2_1000000->Fill(chi2);
-	    m_chi2_log->Fill(log10(chi2));
+        m_chi2_100->Fill(chi2);
+        m_chi2_10000->Fill(chi2);
+        m_chi2_1000000->Fill(chi2);
+        m_chi2_log->Fill(log10(chi2));
 
-	    m_chi2DOF_5->Fill(chi2DOF);
-	    m_chi2DOF_100->Fill(chi2DOF);
-	    m_chi2DOF_1000->Fill(chi2DOF);
-	    m_chi2DOF_log->Fill(log10(chi2DOF));
-	    m_chi2_improvement->Fill(chi2 / track->chi2());
-	    m_chi2DOF_improvement->Fill(chi2DOF / track->normalizedChi2());
+        m_chi2DOF_5->Fill(chi2DOF);
+        m_chi2DOF_100->Fill(chi2DOF);
+        m_chi2DOF_1000->Fill(chi2DOF);
+        m_chi2DOF_log->Fill(log10(chi2DOF));
+        m_chi2_improvement->Fill(chi2 / track->chi2());
+        m_chi2DOF_improvement->Fill(chi2DOF / track->normalizedChi2());
 
-	    GlobalVector momentum = state.second.momentum();
-	    double energy = momentum.mag();
+        GlobalVector momentum = state.second.momentum();
+        double energy = momentum.mag();
 
-	    if (energy > e1) {
-	       e2 = e1;
-	       e1 = energy;
-	       p2 = p1;
-	       p1 = momentum;
-	    }
-	    else if (energy > e2) {
-	       e2 = energy;
-	       p2 = momentum;
-	    }
+        if (energy > e1) {
+          e2 = e1;
+          e1 = energy;
+          p2 = p1;
+          p1 = momentum;
+        } else if (energy > e2) {
+          e2 = energy;
+          p2 = momentum;
+        }
 
-	    double pt = momentum.perp();
-	    double phi = momentum.phi();
-	    while (phi < -M_PI) phi += 2.* M_PI;
-	    while (phi > M_PI) phi -= 2.* M_PI;
-	    
-	    double phibin = (phi + M_PI) / (2. * M_PI) * 36.;
+        double pt = momentum.perp();
+        double phi = momentum.phi();
+        while (phi < -M_PI)
+          phi += 2. * M_PI;
+        while (phi > M_PI)
+          phi -= 2. * M_PI;
 
-	    for (int i = 0;  i < 36;  i++) {
-	       if (phibin < i+1) {
-		  m_pt[i]->Fill(pt);
-		  break;
-	       }
-	    }
+        double phibin = (phi + M_PI) / (2. * M_PI) * 36.;
 
-	 } // end if propagate was successful
-      } // end if we have a closest TSOS
-   } // end loop over tracks
+        for (int i = 0; i < 36; i++) {
+          if (phibin < i + 1) {
+            m_pt[i]->Fill(pt);
+            break;
+          }
+        }
 
-   if (e1 > 0.  &&  e2 > 0.) {
-      double energy_tot = e1 + e2;
-      GlobalVector momentum_tot = p1 + p2;
-      double mass = sqrt(energy_tot*energy_tot - momentum_tot.mag2());
-      double eta = momentum_tot.eta();
+      }  // end if propagate was successful
+    }    // end if we have a closest TSOS
+  }      // end loop over tracks
 
-      m_diMuon_Z->Fill(mass);
-      if (eta > 1.4) m_diMuon_Zforward->Fill(mass);
-      else if (eta > -1.4) m_diMuon_Zbarrel->Fill(mass);
-      else m_diMuon_Zbackward->Fill(mass);
+  if (e1 > 0. && e2 > 0.) {
+    double energy_tot = e1 + e2;
+    GlobalVector momentum_tot = p1 + p2;
+    double mass = sqrt(energy_tot * energy_tot - momentum_tot.mag2());
+    double eta = momentum_tot.eta();
 
-      m_diMuon_Ups->Fill(mass);
-      m_diMuon_Jpsi->Fill(mass);
-      m_diMuon_log->Fill(log10(mass));
-   } // end if we have two tracks
+    m_diMuon_Z->Fill(mass);
+    if (eta > 1.4)
+      m_diMuon_Zforward->Fill(mass);
+    else if (eta > -1.4)
+      m_diMuon_Zbarrel->Fill(mass);
+    else
+      m_diMuon_Zbackward->Fill(mass);
+
+    m_diMuon_Ups->Fill(mass);
+    m_diMuon_Jpsi->Fill(mass);
+    m_diMuon_log->Fill(log10(mass));
+  }  // end if we have two tracks
 }
 
 //////////////////////////////////////////////////////////////////////
 // afterAlignment()
 //////////////////////////////////////////////////////////////////////
 
-void AlignmentMonitorTracksFromTrajectories::afterAlignment() {
-}
+void AlignmentMonitorTracksFromTrajectories::afterAlignment() {}
 
 //
 // const member functions
@@ -275,4 +283,6 @@ void AlignmentMonitorTracksFromTrajectories::afterAlignment() {
 // SEAL definitions
 //
 
-DEFINE_EDM_PLUGIN(AlignmentMonitorPluginFactory, AlignmentMonitorTracksFromTrajectories, "AlignmentMonitorTracksFromTrajectories");
+DEFINE_EDM_PLUGIN(AlignmentMonitorPluginFactory,
+                  AlignmentMonitorTracksFromTrajectories,
+                  "AlignmentMonitorTracksFromTrajectories");

--- a/Alignment/CommonAlignmentMonitor/plugins/AlignmentStats.h
+++ b/Alignment/CommonAlignmentMonitor/plugins/AlignmentStats.h
@@ -1,7 +1,7 @@
 #ifndef CommonAlignmentMonitor_AlignmentStats_H
 #define CommonAlignmentMonitor_AlignmentStats_H
 
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/EventPrincipal.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
@@ -25,7 +25,7 @@
 
 //using namespace edm;
 
-class AlignmentStats : public edm::EDAnalyzer {
+class AlignmentStats : public edm::one::EDAnalyzer<> {
 public:
   AlignmentStats(const edm::ParameterSet &iConfig);
   ~AlignmentStats() override;
@@ -34,6 +34,10 @@ public:
   void endJob() override;
 
 private:
+  // esToken
+  const edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> esTokenTTopo_;
+  const edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> esTokenTkGeo_;
+
   //////inputs from config file
   edm::InputTag src_;
   edm::InputTag overlapAM_;
@@ -59,9 +63,8 @@ private:
   DetHitMap hitmap_;
   DetHitMap overlapmap_;
 
-  //  edm::ESHandle<TrackerGeometry> trackerGeometry_;
-  const TrackerGeometry *trackerGeometry_;
-  const TrackerTopology *trackerTopology_;
+  std::unique_ptr<TrackerTopology> trackerTopology_;
+  std::unique_ptr<TrackerGeometry> trackerGeometry_;
 };
 
 #endif

--- a/Alignment/CommonAlignmentMonitor/plugins/TrackerToMuonPropagator.cc
+++ b/Alignment/CommonAlignmentMonitor/plugins/TrackerToMuonPropagator.cc
@@ -22,7 +22,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -59,15 +59,13 @@
 // class decleration
 //
 
-class TrackerToMuonPropagator : public edm::EDProducer {
+class TrackerToMuonPropagator : public edm::stream::EDProducer<> {
 public:
   explicit TrackerToMuonPropagator(const edm::ParameterSet&);
   ~TrackerToMuonPropagator() override;
 
 private:
-  void beginJob() override;
   void produce(edm::Event&, const edm::EventSetup&) override;
-  void endJob() override;
 
   // ----------member data ---------------------------
 
@@ -266,12 +264,6 @@ void TrackerToMuonPropagator::produce(edm::Event& iEvent, const edm::EventSetup&
   // and put it in the Event, also
   iEvent.put(std::move(trajTrackMap));
 }
-
-// ------------ method called once each job just before starting event loop  ------------
-void TrackerToMuonPropagator::beginJob() {}
-
-// ------------ method called once each job just after ending the event loop  ------------
-void TrackerToMuonPropagator::endJob() {}
 
 //define this as a plug-in
 DEFINE_FWK_MODULE(TrackerToMuonPropagator);

--- a/Alignment/CommonAlignmentMonitor/plugins/TrackerToMuonPropagator.cc
+++ b/Alignment/CommonAlignmentMonitor/plugins/TrackerToMuonPropagator.cc
@@ -71,8 +71,15 @@ private:
 
   // ----------member data ---------------------------
 
+  // es tokens
+  const edm::ESGetToken<Propagator, TrackingComponentsRecord> m_esTokenProp;
+  const edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> m_esTokenTk;
+  const edm::ESGetToken<DTGeometry, MuonGeometryRecord> m_esTokenDT;
+  const edm::ESGetToken<CSCGeometry, MuonGeometryRecord> m_esTokenCSC;
+  const edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> m_esTokenMF;
+  const edm::ESGetToken<GlobalTrackingGeometry, GlobalTrackingGeometryRecord> m_esTokenGTGeo;
+
   edm::InputTag m_globalMuons, m_globalMuonTracks;
-  std::string m_propagator;
 
   bool m_refitTracker;
   TrackTransformer* m_trackTransformer;
@@ -89,10 +96,15 @@ private:
 //
 // constructors and destructor
 //
-TrackerToMuonPropagator::TrackerToMuonPropagator(const edm::ParameterSet& iConfig) {
+TrackerToMuonPropagator::TrackerToMuonPropagator(const edm::ParameterSet& iConfig)
+    : m_esTokenProp(esConsumes(edm::ESInputTag("", iConfig.getParameter<std::string>("propagator")))),
+      m_esTokenTk(esConsumes()),
+      m_esTokenDT(esConsumes()),
+      m_esTokenCSC(esConsumes()),
+      m_esTokenMF(esConsumes()),
+      m_esTokenGTGeo(esConsumes()) {
   m_globalMuons = iConfig.getParameter<edm::InputTag>("globalMuons");
   m_globalMuonTracks = iConfig.getParameter<edm::InputTag>("globalMuonTracks");
-  m_propagator = iConfig.getParameter<std::string>("propagator");
   m_refitTracker = iConfig.getParameter<bool>("refitTrackerTrack");
   if (m_refitTracker) {
     m_trackTransformer = new TrackTransformer(iConfig.getParameter<edm::ParameterSet>("trackerTrackTransformer"));
@@ -123,23 +135,12 @@ void TrackerToMuonPropagator::produce(edm::Event& iEvent, const edm::EventSetup&
   edm::Handle<reco::TrackCollection> globalMuonTracks;
   iEvent.getByLabel(m_globalMuonTracks, globalMuonTracks);
 
-  edm::ESHandle<Propagator> propagator;
-  iSetup.get<TrackingComponentsRecord>().get(m_propagator, propagator);
-
-  edm::ESHandle<TrackerGeometry> trackerGeometry;
-  iSetup.get<TrackerDigiGeometryRecord>().get(trackerGeometry);
-
-  edm::ESHandle<DTGeometry> dtGeometry;
-  iSetup.get<MuonGeometryRecord>().get(dtGeometry);
-
-  edm::ESHandle<CSCGeometry> cscGeometry;
-  iSetup.get<MuonGeometryRecord>().get(cscGeometry);
-
-  edm::ESHandle<MagneticField> magneticField;
-  iSetup.get<IdealMagneticFieldRecord>().get(magneticField);
-
-  edm::ESHandle<GlobalTrackingGeometry> globalGeometry;
-  iSetup.get<GlobalTrackingGeometryRecord>().get(globalGeometry);
+  const Propagator* propagator = &iSetup.getData(m_esTokenProp);
+  const TrackerGeometry* trackerGeometry = &iSetup.getData(m_esTokenTk);
+  const DTGeometry* dtGeometry = &iSetup.getData(m_esTokenDT);
+  const CSCGeometry* cscGeometry = &iSetup.getData(m_esTokenCSC);
+  const MagneticField* magneticField = &iSetup.getData(m_esTokenMF);
+  const GlobalTrackingGeometry* globalGeometry = &iSetup.getData(m_esTokenGTGeo);
 
   // Create these factories once per event
 
@@ -193,7 +194,7 @@ void TrackerToMuonPropagator::produce(edm::Event& iEvent, const edm::EventSetup&
       outerDetId = DetId(globalMuon->track()->outerDetId());
 
       // construct the information necessary to make a TrajectoryStateOnSurface
-      GlobalTrajectoryParameters globalTrajParams(outerPosition, outerMomentum, charge, &(*magneticField));
+      GlobalTrajectoryParameters globalTrajParams(outerPosition, outerMomentum, charge, magneticField);
       CurvilinearTrajectoryError curviError(outerStateCovariance);
       FreeTrajectoryState tracker_state(globalTrajParams, curviError);
 

--- a/Alignment/CommonAlignmentMonitor/src/AlignmentMonitorBase.cc
+++ b/Alignment/CommonAlignmentMonitor/src/AlignmentMonitorBase.cc
@@ -17,7 +17,9 @@
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "CommonTools/UtilAlgos/interface/TFileService.h"
 
-AlignmentMonitorBase::AlignmentMonitorBase(const edm::ParameterSet &cfg, std::string name)
+AlignmentMonitorBase::AlignmentMonitorBase(const edm::ParameterSet &cfg,
+                                           const edm::ConsumesCollector &iC,
+                                           std::string name)
     : m_beamSpotTag(cfg.getUntrackedParameter<edm::InputTag>("beamSpotTag", edm::InputTag("offlineBeamSpot"))),
       m_iteration(0),
       mp_tracker(nullptr),

--- a/Alignment/CommonAlignmentProducer/interface/AlignmentProducerBase.h
+++ b/Alignment/CommonAlignmentProducer/interface/AlignmentProducerBase.h
@@ -138,7 +138,7 @@ private:
   void createAlignmentAlgorithm(edm::ConsumesCollector&);
 
   /// Creates the monitors
-  void createMonitors();
+  void createMonitors(edm::ConsumesCollector&);
 
   /// Creates the calibrations
   void createCalibrations();

--- a/Alignment/CommonAlignmentProducer/src/AlignmentProducerBase.cc
+++ b/Alignment/CommonAlignmentProducer/src/AlignmentProducerBase.cc
@@ -92,7 +92,7 @@ AlignmentProducerBase::AlignmentProducerBase(const edm::ParameterSet& config, ed
   }
 
   createAlignmentAlgorithm(iC);
-  createMonitors();
+  createMonitors(iC);
   createCalibrations();
 }
 
@@ -287,12 +287,12 @@ void AlignmentProducerBase::createAlignmentAlgorithm(edm::ConsumesCollector& iC)
 }
 
 //------------------------------------------------------------------------------
-void AlignmentProducerBase::createMonitors() {
+void AlignmentProducerBase::createMonitors(edm::ConsumesCollector& iC) {
   const auto& monitorConfig = config_.getParameter<edm::ParameterSet>("monitorConfig");
   auto monitors = monitorConfig.getUntrackedParameter<std::vector<std::string> >("monitors");
   for (const auto& miter : monitors) {
     monitors_.emplace_back(
-        AlignmentMonitorPluginFactory::get()->create(miter, monitorConfig.getUntrackedParameterSet(miter)));
+        AlignmentMonitorPluginFactory::get()->create(miter, monitorConfig.getUntrackedParameterSet(miter), iC));
   }
 }
 


### PR DESCRIPTION
#### PR description:

The main goal of this PR is to finalize the migration to esConsumes for the package `Alignment/CommonAlignmentMonitor`. 
I profit of it to modernize some of the legacy `edm::EDProducer`s to become thread-efficient.
This is part of issue #31061.
As a not the code in `Alignment/CommonAlignmentMonitor/plugins/AlignmentMonitorTracksFromTrajectories.cc` seems heavily changed, though I didn't modify much that file. Most of the differences come from code-formatting (which is a prerequisite to pass integration tests).

#### PR validation:

The code compiles.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This PR is not a backport and not backport will be needed.
