### PR TITLE
ECAL esConsumes migrations in EventFilter and RecoLocalCalo

### DIFF
--- a/EventFilter/EcalRawToDigi/plugins/EcalRegionCablingESProducer.cc
+++ b/EventFilter/EcalRawToDigi/plugins/EcalRegionCablingESProducer.cc
@@ -1,16 +1,14 @@
 #include "EventFilter/EcalRawToDigi/plugins/EcalRegionCablingESProducer.h"
 
-EcalRegionCablingESProducer::EcalRegionCablingESProducer(const edm::ParameterSet& iConfig) {
-  conf_ = iConfig;
-  setWhatProduced(this);
+EcalRegionCablingESProducer::EcalRegionCablingESProducer(const edm::ParameterSet& iConfig) : conf_(iConfig) {
+  auto cc = setWhatProduced(this);
+  esEcalElectronicsMappingToken_ = cc.consumesFrom<EcalElectronicsMapping, EcalMappingRcd>();
 }
 
 EcalRegionCablingESProducer::~EcalRegionCablingESProducer() {}
 
 EcalRegionCablingESProducer::ReturnType EcalRegionCablingESProducer::produce(const EcalRegionCablingRecord& iRecord) {
-  using namespace edm::es;
-  edm::ESHandle<EcalElectronicsMapping> mapping;
-  iRecord.getRecord<EcalMappingRcd>().get(mapping);
+  edm::ESHandle<EcalElectronicsMapping> mapping = iRecord.getHandle(esEcalElectronicsMappingToken_);
 
   return std::make_unique<EcalRegionCabling>(conf_, mapping.product());
 }

--- a/EventFilter/EcalRawToDigi/plugins/EcalRegionCablingESProducer.h
+++ b/EventFilter/EcalRawToDigi/plugins/EcalRegionCablingESProducer.h
@@ -24,6 +24,7 @@
 // user include files
 #include "FWCore/Framework/interface/ESProducer.h"
 #include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Utilities/interface/ESGetToken.h"
 
 #include "EventFilter/EcalRawToDigi/interface/EcalRegionCablingRecord.h"
 #include "EventFilter/EcalRawToDigi/interface/EcalRegionCabling.h"
@@ -39,5 +40,7 @@ public:
 
 private:
   edm::ParameterSet conf_;
+
+  edm::ESGetToken<EcalElectronicsMapping, EcalMappingRcd> esEcalElectronicsMappingToken_;
 };
 #endif

--- a/RecoLocalCalo/EcalRecProducers/plugins/EcalRecHitProducerGPU.cc
+++ b/RecoLocalCalo/EcalRecProducers/plugins/EcalRecHitProducerGPU.cc
@@ -74,14 +74,7 @@ private:
   edm::ESGetToken<EcalRecHitParametersGPU, JobConfigurationGPURecord> tokenRecHitParameters_;
 
   // conditions handles
-  edm::ESHandle<EcalRechitADCToGeVConstantGPU> ADCToGeVConstantHandle_;
   edm::ESHandle<EcalIntercalibConstantsGPU> IntercalibConstantsHandle_;
-  edm::ESHandle<EcalRechitChannelStatusGPU> ChannelStatusHandle_;
-
-  edm::ESHandle<EcalLaserAPDPNRatiosGPU> LaserAPDPNRatiosHandle_;
-  edm::ESHandle<EcalLaserAPDPNRatiosRefGPU> LaserAPDPNRatiosRefHandle_;
-  edm::ESHandle<EcalLaserAlphasGPU> LaserAlphasHandle_;
-  edm::ESHandle<EcalLinearCorrectionsGPU> LinearCorrectionsHandle_;
   edm::ESHandle<EcalRecHitParametersGPU> recHitParametersHandle_;
 
   // Associate reco flagbit (outer vector) to many db status flags (inner vector)
@@ -198,24 +191,17 @@ void EcalRecHitProducerGPU::acquire(edm::Event const& event,
   // - adt2gev
 
   //
-  ADCToGeVConstantHandle_ = setup.getHandle(tokenADCToGeVConstant_);
   IntercalibConstantsHandle_ = setup.getHandle(tokenIntercalibConstants_);
-  ChannelStatusHandle_ = setup.getHandle(tokenChannelStatus_);
-
-  LaserAPDPNRatiosHandle_ = setup.getHandle(tokenLaserAPDPNRatios_);
-  LaserAPDPNRatiosRefHandle_ = setup.getHandle(tokenLaserAPDPNRatiosRef_);
-  LaserAlphasHandle_ = setup.getHandle(tokenLaserAlphas_);
-  LinearCorrectionsHandle_ = setup.getHandle(tokenLinearCorrections_);
   recHitParametersHandle_ = setup.getHandle(tokenRecHitParameters_);
 
-  auto const& ADCToGeVConstantProduct = ADCToGeVConstantHandle_->getProduct(ctx.stream());
+  auto const& ADCToGeVConstantProduct = setup.getData(tokenADCToGeVConstant_).getProduct(ctx.stream());
   auto const& IntercalibConstantsProduct = IntercalibConstantsHandle_->getProduct(ctx.stream());
-  auto const& ChannelStatusProduct = ChannelStatusHandle_->getProduct(ctx.stream());
+  auto const& ChannelStatusProduct = setup.getData(tokenChannelStatus_).getProduct(ctx.stream());
 
-  auto const& LaserAPDPNRatiosProduct = LaserAPDPNRatiosHandle_->getProduct(ctx.stream());
-  auto const& LaserAPDPNRatiosRefProduct = LaserAPDPNRatiosRefHandle_->getProduct(ctx.stream());
-  auto const& LaserAlphasProduct = LaserAlphasHandle_->getProduct(ctx.stream());
-  auto const& LinearCorrectionsProduct = LinearCorrectionsHandle_->getProduct(ctx.stream());
+  auto const& LaserAPDPNRatiosProduct = setup.getData(tokenLaserAPDPNRatios_).getProduct(ctx.stream());
+  auto const& LaserAPDPNRatiosRefProduct = setup.getData(tokenLaserAPDPNRatiosRef_).getProduct(ctx.stream());
+  auto const& LaserAlphasProduct = setup.getData(tokenLaserAlphas_).getProduct(ctx.stream());
+  auto const& LinearCorrectionsProduct = setup.getData(tokenLinearCorrections_).getProduct(ctx.stream());
   auto const& recHitParametersProduct = recHitParametersHandle_->getProduct(ctx.stream());
 
   // set config ptrs : this is done to avoid changing things downstream

--- a/RecoLocalCalo/EcalRecProducers/plugins/EcalRecHitProducerGPU.cc
+++ b/RecoLocalCalo/EcalRecProducers/plugins/EcalRecHitProducerGPU.cc
@@ -24,6 +24,7 @@
 #include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
+#include "FWCore/Utilities/interface/ESGetToken.h"
 #include "HeterogeneousCore/CUDACore/interface/JobConfigurationGPURecord.h"
 #include "HeterogeneousCore/CUDACore/interface/ScopedContext.h"
 #include "HeterogeneousCore/CUDAServices/interface/CUDAService.h"
@@ -61,6 +62,16 @@ private:
 
   // configuration parameters
   ecal::rechit::ConfigurationParameters configParameters_;
+
+  // conditions tokens
+  edm::ESGetToken<EcalRechitADCToGeVConstantGPU, EcalADCToGeVConstantRcd> tokenADCToGeVConstant_;
+  edm::ESGetToken<EcalIntercalibConstantsGPU, EcalIntercalibConstantsRcd> tokenIntercalibConstants_;
+  edm::ESGetToken<EcalRechitChannelStatusGPU, EcalChannelStatusRcd> tokenChannelStatus_;
+  edm::ESGetToken<EcalLaserAPDPNRatiosGPU, EcalLaserAPDPNRatiosRcd> tokenLaserAPDPNRatios_;
+  edm::ESGetToken<EcalLaserAPDPNRatiosRefGPU, EcalLaserAPDPNRatiosRefRcd> tokenLaserAPDPNRatiosRef_;
+  edm::ESGetToken<EcalLaserAlphasGPU, EcalLaserAlphasRcd> tokenLaserAlphas_;
+  edm::ESGetToken<EcalLinearCorrectionsGPU, EcalLinearCorrectionsRcd> tokenLinearCorrections_;
+  edm::ESGetToken<EcalRecHitParametersGPU, JobConfigurationGPURecord> tokenRecHitParameters_;
 
   // conditions handles
   edm::ESHandle<EcalRechitADCToGeVConstantGPU> ADCToGeVConstantHandle_;
@@ -143,6 +154,16 @@ EcalRecHitProducerGPU::EcalRecHitProducerGPU(const edm::ParameterSet& ps) {
   configParameters_.recoverEEVFE = ps.getParameter<bool>("recoverEEVFE");
   configParameters_.recoverEBFE = ps.getParameter<bool>("recoverEBFE");
   configParameters_.recoverEEFE = ps.getParameter<bool>("recoverEEFE");
+
+  // conditions tokens
+  tokenADCToGeVConstant_ = esConsumes<EcalRechitADCToGeVConstantGPU, EcalADCToGeVConstantRcd>();
+  tokenIntercalibConstants_ = esConsumes<EcalIntercalibConstantsGPU, EcalIntercalibConstantsRcd>();
+  tokenChannelStatus_ = esConsumes<EcalRechitChannelStatusGPU, EcalChannelStatusRcd>();
+  tokenLaserAPDPNRatios_ = esConsumes<EcalLaserAPDPNRatiosGPU, EcalLaserAPDPNRatiosRcd>();
+  tokenLaserAPDPNRatiosRef_ = esConsumes<EcalLaserAPDPNRatiosRefGPU, EcalLaserAPDPNRatiosRefRcd>();
+  tokenLaserAlphas_ = esConsumes<EcalLaserAlphasGPU, EcalLaserAlphasRcd>();
+  tokenLinearCorrections_ = esConsumes<EcalLinearCorrectionsGPU, EcalLinearCorrectionsRcd>();
+  tokenRecHitParameters_ = esConsumes<EcalRecHitParametersGPU, JobConfigurationGPURecord>();
 }
 
 EcalRecHitProducerGPU::~EcalRecHitProducerGPU() {}
@@ -177,15 +198,15 @@ void EcalRecHitProducerGPU::acquire(edm::Event const& event,
   // - adt2gev
 
   //
-  setup.get<EcalADCToGeVConstantRcd>().get(ADCToGeVConstantHandle_);
-  setup.get<EcalIntercalibConstantsRcd>().get(IntercalibConstantsHandle_);
-  setup.get<EcalChannelStatusRcd>().get(ChannelStatusHandle_);
+  ADCToGeVConstantHandle_ = setup.getHandle(tokenADCToGeVConstant_);
+  IntercalibConstantsHandle_ = setup.getHandle(tokenIntercalibConstants_);
+  ChannelStatusHandle_ = setup.getHandle(tokenChannelStatus_);
 
-  setup.get<EcalLaserAPDPNRatiosRcd>().get(LaserAPDPNRatiosHandle_);
-  setup.get<EcalLaserAPDPNRatiosRefRcd>().get(LaserAPDPNRatiosRefHandle_);
-  setup.get<EcalLaserAlphasRcd>().get(LaserAlphasHandle_);
-  setup.get<EcalLinearCorrectionsRcd>().get(LinearCorrectionsHandle_);
-  setup.get<JobConfigurationGPURecord>().get(recHitParametersHandle_);
+  LaserAPDPNRatiosHandle_ = setup.getHandle(tokenLaserAPDPNRatios_);
+  LaserAPDPNRatiosRefHandle_ = setup.getHandle(tokenLaserAPDPNRatiosRef_);
+  LaserAlphasHandle_ = setup.getHandle(tokenLaserAlphas_);
+  LinearCorrectionsHandle_ = setup.getHandle(tokenLinearCorrections_);
+  recHitParametersHandle_ = setup.getHandle(tokenRecHitParameters_);
 
   auto const& ADCToGeVConstantProduct = ADCToGeVConstantHandle_->getProduct(ctx.stream());
   auto const& IntercalibConstantsProduct = IntercalibConstantsHandle_->getProduct(ctx.stream());

--- a/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitWorkerGlobal.h
+++ b/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitWorkerGlobal.h
@@ -15,6 +15,14 @@
 #include "RecoLocalCalo/EcalRecAlgos/interface/EcalUncalibRecHitRatioMethodAlgo.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Utilities/interface/ESGetToken.h"
+#include "CondFormats/DataRecord/interface/EcalGainRatiosRcd.h"
+#include "CondFormats/DataRecord/interface/EcalPedestalsRcd.h"
+#include "CondFormats/DataRecord/interface/EcalWeightXtalGroupsRcd.h"
+#include "CondFormats/DataRecord/interface/EcalTBWeightsRcd.h"
+#include "CondFormats/DataRecord/interface/EcalSampleMaskRcd.h"
+#include "CondFormats/DataRecord/interface/EcalTimeCalibConstantsRcd.h"
+#include "CondFormats/DataRecord/interface/EcalTimeOffsetConstantRcd.h"
+#include "CondFormats/DataRecord/interface/EcalTimeBiasCorrectionsRcd.h"
 #include "CondFormats/EcalObjects/interface/EcalTimeCalibConstants.h"
 #include "CondFormats/EcalObjects/interface/EcalTimeOffsetConstant.h"
 #include "CondFormats/EcalObjects/interface/EcalPedestals.h"
@@ -36,7 +44,6 @@ namespace edm {
 class EcalUncalibRecHitWorkerGlobal : public EcalUncalibRecHitWorkerRunOneDigiBase {
 public:
   EcalUncalibRecHitWorkerGlobal(const edm::ParameterSet&, edm::ConsumesCollector& c);
-  EcalUncalibRecHitWorkerGlobal(const edm::ParameterSet&);
   EcalUncalibRecHitWorkerGlobal() : testbeamEEShape(EEShape(true)), testbeamEBShape(EBShape(true)) { ; }
   ~EcalUncalibRecHitWorkerGlobal() override{};
 
@@ -52,8 +59,10 @@ protected:
   double pedRMSVec[3];
   double gainRatios[3];
 
-  edm::ESHandle<EcalPedestals> peds;
-  edm::ESHandle<EcalGainRatios> gains;
+  edm::ESGetToken<EcalPedestals, EcalPedestalsRcd> tokenPeds_;
+  edm::ESGetToken<EcalGainRatios, EcalGainRatiosRcd> tokenGains_;
+  edm::ESHandle<EcalPedestals> peds_;
+  edm::ESHandle<EcalGainRatios> gains_;
 
   template <class C>
   int isSaturated(const C& digi);
@@ -61,8 +70,10 @@ protected:
   double timeCorrection(float ampli, const std::vector<float>& amplitudeBins, const std::vector<float>& shiftBins);
 
   // weights method
-  edm::ESHandle<EcalWeightXtalGroups> grps;
-  edm::ESHandle<EcalTBWeights> wgts;
+  edm::ESGetToken<EcalWeightXtalGroups, EcalWeightXtalGroupsRcd> tokenGrps_;
+  edm::ESGetToken<EcalTBWeights, EcalTBWeightsRcd> tokenWgts_;
+  edm::ESHandle<EcalWeightXtalGroups> grps_;
+  edm::ESHandle<EcalTBWeights> wgts_;
   const EcalWeightSet::EcalWeightMatrix* weights[2];
   const EcalWeightSet::EcalChi2WeightMatrix* chi2mat[2];
   EcalUncalibRecHitRecWeightsAlgo<EBDataFrame> weightsMethod_barrel_;
@@ -71,6 +82,7 @@ protected:
   EBShape testbeamEBShape;  // can be replaced by simple shape arrays of float in the future
 
   // determie which of the samples must actually be used by ECAL local reco
+  edm::ESGetToken<EcalSampleMask, EcalSampleMaskRcd> tokenSampleMask_;
   edm::ESHandle<EcalSampleMask> sampleMaskHand_;
 
   // ratio method
@@ -100,10 +112,13 @@ protected:
   double amplitudeThreshEE_;
   double ebSpikeThresh_;
 
+  edm::ESGetToken<EcalTimeBiasCorrections, EcalTimeBiasCorrectionsRcd> tokenTimeCorrBias_;
   edm::ESHandle<EcalTimeBiasCorrections> timeCorrBias_;
 
-  edm::ESHandle<EcalTimeCalibConstants> itime;
-  edm::ESHandle<EcalTimeOffsetConstant> offtime;
+  edm::ESGetToken<EcalTimeCalibConstants, EcalTimeCalibConstantsRcd> tokenItime_;
+  edm::ESGetToken<EcalTimeOffsetConstant, EcalTimeOffsetConstantRcd> tokenOfftime_;
+  edm::ESHandle<EcalTimeCalibConstants> itime_;
+  edm::ESHandle<EcalTimeOffsetConstant> offtime_;
   std::vector<double> ebPulseShape_;
   std::vector<double> eePulseShape_;
 

--- a/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitWorkerWeights.h
+++ b/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitWorkerWeights.h
@@ -11,6 +11,11 @@
 #include "RecoLocalCalo/EcalRecProducers/interface/EcalUncalibRecHitWorkerRunOneDigiBase.h"
 #include "RecoLocalCalo/EcalRecAlgos/interface/EcalUncalibRecHitRecWeightsAlgo.h"
 #include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Utilities/interface/ESGetToken.h"
+#include "CondFormats/DataRecord/interface/EcalGainRatiosRcd.h"
+#include "CondFormats/DataRecord/interface/EcalPedestalsRcd.h"
+#include "CondFormats/DataRecord/interface/EcalWeightXtalGroupsRcd.h"
+#include "CondFormats/DataRecord/interface/EcalTBWeightsRcd.h"
 #include "CondFormats/EcalObjects/interface/EcalPedestals.h"
 #include "CondFormats/EcalObjects/interface/EcalGainRatios.h"
 #include "CondFormats/EcalObjects/interface/EcalWeightXtalGroups.h"
@@ -40,10 +45,14 @@ public:
   edm::ParameterSetDescription getAlgoDescription() override;
 
 protected:
-  edm::ESHandle<EcalPedestals> peds;
-  edm::ESHandle<EcalGainRatios> gains;
-  edm::ESHandle<EcalWeightXtalGroups> grps;
-  edm::ESHandle<EcalTBWeights> wgts;
+  edm::ESGetToken<EcalPedestals, EcalPedestalsRcd> tokenPeds_;
+  edm::ESGetToken<EcalGainRatios, EcalGainRatiosRcd> tokenGains_;
+  edm::ESGetToken<EcalWeightXtalGroups, EcalWeightXtalGroupsRcd> tokenGrps_;
+  edm::ESGetToken<EcalTBWeights, EcalTBWeightsRcd> tokenWgts_;
+  edm::ESHandle<EcalPedestals> peds_;
+  edm::ESHandle<EcalGainRatios> gains_;
+  edm::ESHandle<EcalWeightXtalGroups> grps_;
+  edm::ESHandle<EcalTBWeights> wgts_;
 
   double pedVec[3];
   double pedRMSVec[3];


### PR DESCRIPTION
#### PR description:

esConsumes migrations of remaining `EventSetupRecord::get` occurrences in EventFilter/EcalRawToDigi and RecoLocalCalo/EcalRecProducers.

#### PR validation:

Complies and passes 136.874.