### PR TITLE
update track-weight map of 4D primary vertices w/o BS constraint

### DIFF
--- a/RecoVertex/PrimaryVertexProducer/plugins/PrimaryVertexProducer.cc
+++ b/RecoVertex/PrimaryVertexProducer/plugins/PrimaryVertexProducer.cc
@@ -242,35 +242,20 @@ void PrimaryVertexProducer::produce(edm::Event& iEvent, const edm::EventSetup& i
       }
 
       TransientVertex v;
-      if (algorithm->useBeamConstraint && validBS && ((*iclus).size() > 1)) {
+      if (algorithm->useBeamConstraint && validBS && (iclus->size() > 1)) {
         v = algorithm->fitter->vertex(*iclus, beamSpot);
-
-        if (f4D) {
-          if (v.isValid()) {
-            auto err = v.positionError().matrix4D();
-            err(3, 3) = vartime;
-            auto trkWeightMap3d = v.weightMap();  // copy the 3d-fit weights
-            v = TransientVertex(
-                v.position(), meantime, err, v.originalTracks(), v.totalChiSquared(), v.degreesOfFreedom());
-            v.weightMap(trkWeightMap3d);
-          }
-        }
-
-      } else if (!(algorithm->useBeamConstraint) && ((*iclus).size() > 1)) {
+      } else if (!(algorithm->useBeamConstraint) && (iclus->size() > 1)) {
         v = algorithm->fitter->vertex(*iclus);
-
-        if (f4D) {
-          if (v.isValid()) {
-            auto err = v.positionError().matrix4D();
-            err(3, 3) = vartime;
-            auto trkWeightMap3d = v.weightMap();  // copy the 3d-fit weights
-            v = TransientVertex(
-                v.position(), meantime, err, v.originalTracks(), v.totalChiSquared(), v.degreesOfFreedom());
-            v.weightMap(trkWeightMap3d);
-          }
-        }
-
       }  // else: no fit ==> v.isValid()=False
+
+      // 4D vertices: add timing information
+      if (f4D and v.isValid()) {
+        auto err = v.positionError().matrix4D();
+        err(3, 3) = vartime;
+        auto trkWeightMap3d = v.weightMap();  // copy the 3d-fit weights
+        v = TransientVertex(v.position(), meantime, err, v.originalTracks(), v.totalChiSquared(), v.degreesOfFreedom());
+        v.weightMap(trkWeightMap3d);
+      }
 
       if (fVerbose) {
         if (v.isValid()) {

--- a/RecoVertex/PrimaryVertexProducer/plugins/PrimaryVertexProducer.cc
+++ b/RecoVertex/PrimaryVertexProducer/plugins/PrimaryVertexProducer.cc
@@ -248,11 +248,11 @@ void PrimaryVertexProducer::produce(edm::Event& iEvent, const edm::EventSetup& i
         if (f4D) {
           if (v.isValid()) {
             auto err = v.positionError().matrix4D();
-            auto trkweightMap3d = v.weightMap();  // copy the 3 fit weights
             err(3, 3) = vartime;
+            auto trkWeightMap3d = v.weightMap();  // copy the 3d-fit weights
             v = TransientVertex(
                 v.position(), meantime, err, v.originalTracks(), v.totalChiSquared(), v.degreesOfFreedom());
-            v.weightMap(trkweightMap3d);
+            v.weightMap(trkWeightMap3d);
           }
         }
 
@@ -263,8 +263,10 @@ void PrimaryVertexProducer::produce(edm::Event& iEvent, const edm::EventSetup& i
           if (v.isValid()) {
             auto err = v.positionError().matrix4D();
             err(3, 3) = vartime;
+            auto trkWeightMap3d = v.weightMap();  // copy the 3d-fit weights
             v = TransientVertex(
                 v.position(), meantime, err, v.originalTracks(), v.totalChiSquared(), v.degreesOfFreedom());
+            v.weightMap(trkWeightMap3d);
           }
         }
 


### PR DESCRIPTION
#### PR description:

This PR updates the map of track weights for the collection of 4D vertices without BS constraint.

Without this fix, for 4D vertices without BS constraint the method `trackWeight` would return 1 (instead of a weight between 0 and 1) for tracks assigned to a given vertex (for BS-constrained 4D vertices, no change is necessary, as their track-weight maps are already filled correctly).

Spotted by @werdmann.

Unclear if any changes in the outputs are to be expected (depends, for example, on whether any workflow uses the `trackWeight` method with 4D vertices).

#### PR validation:

Private tests (verified on a few events that the track-weight map for 4D BS-unconstrained vertices is updated as expected).

#### If this PR is a backport, please specify the original PR and why you need to backport that PR:

N/A
