### PR TITLE
[HGCAL] Fill regressed energy for SimTracksters

### DIFF
--- a/RecoHGCal/TICL/plugins/TrackstersFromSimClustersProducer.cc
+++ b/RecoHGCal/TICL/plugins/TrackstersFromSimClustersProducer.cc
@@ -166,7 +166,8 @@ void TrackstersFromSimClustersProducer::produce(edm::Event& evt, const edm::Even
         }
       }
       tmpTrackster.setIdProbability(tracksterParticleTypeFromPdgId(cp.pdgId(), cp.charge()), 1.f);
-
+      float energyAtBoundary = cp.g4Tracks()[0].getMomentumAtBoundary().energy();
+      tmpTrackster.setRegressedEnergy(energyAtBoundary);
       tmpTrackster.setSeed(key.id(), cpIndex);
       result->emplace_back(tmpTrackster);
     } else {
@@ -196,6 +197,8 @@ void TrackstersFromSimClustersProducer::produce(edm::Event& evt, const edm::Even
           }
         }
         tmpTrackster.setIdProbability(tracksterParticleTypeFromPdgId(sc.pdgId(), sc.charge()), 1.f);
+        float energyAtBoundary = sc.g4Tracks()[0].getMomentumAtBoundary().energy();
+        tmpTrackster.setRegressedEnergy(energyAtBoundary);
         tmpTrackster.setSeed(scRef.id(), simClusterIndex);
         result->emplace_back(tmpTrackster);
       }


### PR DESCRIPTION
#### PR description:
This PR fills the regressed energy for HGCAL SimTracksters with the energy of the associated simTrack at the CALO boundary. 
#### PR validation:

It was tested with wf `34693.0_CloseByParticleGun+2026D76`

Regressed energy, once empty are now filled
![simtrackster_regressed_energy](https://user-images.githubusercontent.com/6595715/123767615-e6f77280-d8c7-11eb-9d51-cc6fa0e2100a.png)

@cseez @rovere @pfs 