### PR TITLE
Moved using namespace within PyBind11 function

### DIFF
--- a/FWCore/PyDevParameterSet/src/PyBind11Module.h
+++ b/FWCore/PyDevParameterSet/src/PyBind11Module.h
@@ -32,9 +32,8 @@
 
 #include <pybind11/pybind11.h>
 
-using namespace cmspython3;
-
 PYBIND11_MODULE(libFWCorePyDevParameterSet, m) {
+  using namespace cmspython3;
   pybind11::register_exception_translator([](std::exception_ptr p) {
     try {
       if (p)


### PR DESCRIPTION
#### PR description:

This fixes a static analyzer warning about using namespace declaration in headers.

#### PR validation:

code compiles.

fixes makortel/framework#179