### PR TITLE
CPU optimization in muonisolation::TrackSelector: postpone eta/phi computation until needed

### DIFF
--- a/RecoMuon/MuonIsolation/plugins/TrackSelector.cc
+++ b/RecoMuon/MuonIsolation/plugins/TrackSelector.cc
@@ -9,7 +9,6 @@ TrackSelector::result_type TrackSelector::operator()(const TrackSelector::input_
   static const std::string metname = "MuonIsolation|TrackSelector";
   result_type result;
   for (auto const& tk : tracks) {
-
     //! pick/read variables in order to cut down on unnecessary calls
     //! someone will have some fun reading the log if Debug is on
     //! the biggest reason is the numberOfValidHits call (the rest are not as costly)

--- a/RecoMuon/MuonIsolation/plugins/TrackSelector.cc
+++ b/RecoMuon/MuonIsolation/plugins/TrackSelector.cc
@@ -8,6 +8,7 @@ using namespace reco;
 TrackSelector::result_type TrackSelector::operator()(const TrackSelector::input_type& tracks) const {
   static const std::string metname = "MuonIsolation|TrackSelector";
   result_type result;
+  auto const dr2Max = thePars.drMax*thePars.drMax;
   for (auto const& tk : tracks) {
     //! pick/read variables in order to cut down on unnecessary calls
     //! someone will have some fun reading the log if Debug is on
@@ -32,7 +33,7 @@ TrackSelector::result_type TrackSelector::operator()(const TrackSelector::input_
       continue;
     float tEta = tk.eta();
     float tPhi = tk.phi();
-    if (thePars.dir.deltaR(reco::isodeposit::Direction(tEta, tPhi)) > thePars.drMax)
+    if (thePars.dir.deltaR2(reco::isodeposit::Direction(tEta, tPhi)) > dr2Max)
       continue;
 
     //! skip if min Hits == 0; assumes any track has at least one valid hit

--- a/RecoMuon/MuonIsolation/plugins/TrackSelector.cc
+++ b/RecoMuon/MuonIsolation/plugins/TrackSelector.cc
@@ -9,25 +9,6 @@ TrackSelector::result_type TrackSelector::operator()(const TrackSelector::input_
   static const std::string metname = "MuonIsolation|TrackSelector";
   result_type result;
   for (auto const& tk : tracks) {
-    //     float tZ = tk.vz();
-    //     float tD0 = fabs(tk.d0());
-    //     float tD0Cor = fabs(tk.dxy(thePars.beamPoint));
-    //     float tEta = tk.eta();
-    //     float tPhi = tk.phi();
-    //     unsigned int tHits = tk.numberOfValidHits();
-    //     float tChi2Ndof = tk.normalizedChi2();
-    //     float tChi2Prob = ChiSquaredProbability(tk.chi2(), tk.ndof());
-    //     float tPt = tk.pt();
-
-    //     LogTrace(metname)<<"Tk vz: "<<tZ
-    // 		     <<",  d0: "<<tD0
-    // 		     <<",  d0wrtBeam: "<<tD0Cor
-    // 		     <<", eta: "<<tEta
-    // 		     <<", phi: "<<tPhi
-    // 		     <<", nHits: "<<tHits
-    // 		     <<", chi2Norm: "<<tChi2Ndof
-    // 		     <<", chi2Prob: "<<tChi2Prob
-    // 		     <<std::endl;
 
     //! pick/read variables in order to cut down on unnecessary calls
     //! someone will have some fun reading the log if Debug is on
@@ -37,11 +18,9 @@ TrackSelector::result_type TrackSelector::operator()(const TrackSelector::input_
     float tPt = tk.pt();
     float tD0 = fabs(tk.d0());
     float tD0Cor = fabs(tk.dxy(thePars.beamPoint));
-    float tEta = tk.eta();
-    float tPhi = tk.phi();
     float tChi2Ndof = tk.normalizedChi2();
     LogTrace(metname) << "Tk vz: " << tZ << ",  pt: " << tPt << ",  d0: " << tD0 << ",  d0wrtBeam: " << tD0Cor
-                      << ", eta: " << tEta << ", phi: " << tPhi << ", chi2Norm: " << tChi2Ndof;
+                      << ", eta: " << tk.eta() << ", phi: " << tk.phi() << ", chi2Norm: " << tChi2Ndof;
     //! access to the remaining vars is slow
 
     if (!thePars.zRange.inside(tZ))
@@ -50,9 +29,11 @@ TrackSelector::result_type TrackSelector::operator()(const TrackSelector::input_
       continue;
     if (!thePars.rRange.inside(tD0Cor))
       continue;
-    if (thePars.dir.deltaR(reco::isodeposit::Direction(tEta, tPhi)) > thePars.drMax)
-      continue;
     if (tChi2Ndof > thePars.chi2NdofMax)
+      continue;
+    float tEta = tk.eta();
+    float tPhi = tk.phi();
+    if (thePars.dir.deltaR(reco::isodeposit::Direction(tEta, tPhi)) > thePars.drMax)
       continue;
 
     //! skip if min Hits == 0; assumes any track has at least one valid hit

--- a/RecoMuon/MuonIsolation/plugins/TrackSelector.cc
+++ b/RecoMuon/MuonIsolation/plugins/TrackSelector.cc
@@ -8,7 +8,7 @@ using namespace reco;
 TrackSelector::result_type TrackSelector::operator()(const TrackSelector::input_type& tracks) const {
   static const std::string metname = "MuonIsolation|TrackSelector";
   result_type result;
-  auto const dr2Max = thePars.drMax*thePars.drMax;
+  auto const dr2Max = thePars.drMax * thePars.drMax;
   for (auto const& tk : tracks) {
     //! pick/read variables in order to cut down on unnecessary calls
     //! someone will have some fun reading the log if Debug is on


### PR DESCRIPTION
based on https://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre3/23434.21/step3/cpu_endjob/1249

a small downside is that the debug/trace variant will be a bit slower.