### PR TITLE
HCAL: move data-specific SeverityLevel customization(s) to Reconstruction_Data_cff.py

### DIFF
--- a/Configuration/DataProcessing/python/RecoTLR.py
+++ b/Configuration/DataProcessing/python/RecoTLR.py
@@ -19,24 +19,14 @@ def _overridesFor50ns(process):
 # post-era customizations
 # these are here instead of generating Data-specific eras
 ##############################################################################
-def _hcalCustoms25ns(process):
-    import RecoLocalCalo.HcalRecAlgos.RemoveAddSevLevel as HcalRemoveAddSevLevel
-    HcalRemoveAddSevLevel.AddFlag(process.hcalRecAlgos,"HFDigiTime",8)
-    HcalRemoveAddSevLevel.AddFlag(process.hcalRecAlgos,"HBHEFlatNoise",8)
-    return process
 
 def customisePostEra_Run2_25ns(process):
-    _hcalCustoms25ns(process)
     return process
 
 def customisePostEra_Run2_2016(process):
-    _hcalCustoms25ns(process)
     return process
 
 def customisePostEra_Run2_2017(process):
-    import RecoLocalCalo.HcalRecAlgos.RemoveAddSevLevel as HcalRemoveAddSevLevel
-    HcalRemoveAddSevLevel.AddFlag(process.hcalRecAlgos,"HBHEFlatNoise",8)
-    HcalRemoveAddSevLevel.RemoveFlag(process.hcalRecAlgos,"HFDigiTime")
     return process
 
 def customisePostEra_Run2_2017_express_trackingOnly(process):
@@ -89,23 +79,15 @@ def customisePostEra_Run2_2018_pp_on_AA_express_trackingOnly(process):
     return process
 
 # Run3 equivalents
-def _hcalCustomsRun3(process):
-    import RecoLocalCalo.HcalRecAlgos.RemoveAddSevLevel as HcalRemoveAddSevLevel
-    HcalRemoveAddSevLevel.AddFlag(process.hcalRecAlgos,"HBHENegativeNoise",8)
-    return process
 
 def customisePostEra_Run3(process):
     #start with a repeat of 2018
     customisePostEra_Run2_2018(process)
-    #add Run3 HCAL setting
-    _hcalCustomsRun3(process)
     return process
 
 def customisePostEra_Run3_express_trackingOnly(process):
     #start with a repeat of 2018
     customisePostEra_Run2_2018_express_trackingOnly(process)
-    #add Run3 HCAL setting
-    _hcalCustomsRun3(process)
     return process
 
 ##############################################################################
@@ -213,8 +195,6 @@ def customiseDataRun2Common_withStage1(process):
 # common+ "25ns" Use this for data daking starting from runs in 2015C (>= 253256 )
 def customiseDataRun2Common_25ns(process):
     process = customiseDataRun2Common_withStage1(process)
-
-    _hcalCustoms25ns(process)
 
     from SLHCUpgradeSimulations.Configuration.postLS1Customs import customise_DQM_25ns
     if hasattr(process,'dqmoffline_step'):

--- a/Configuration/StandardSequences/python/Reconstruction_Data_cff.py
+++ b/Configuration/StandardSequences/python/Reconstruction_Data_cff.py
@@ -16,11 +16,38 @@ for qTest in particleFlowRecHitHF.producers[0].qualityTests:
         qTest.cleaningThresholds.append(30.)
         qTest.flags.append('HFDigi')
              
-
+#--- Initial (Run1) HCAL data-specific flags customization
 import RecoLocalCalo.HcalRecAlgos.RemoveAddSevLevel as HcalRemoveAddSevLevel
 HcalRemoveAddSevLevel.AddFlag(hcalRecAlgos,"HFDigiTime",11,verbose=False)
 HcalRemoveAddSevLevel.AddFlag(hcalRecAlgos,"HBHEFlatNoise",12)
 HcalRemoveAddSevLevel.AddFlag(hcalRecAlgos,"HBHENegativeNoise",12)
+
+#--- Subsequent era-wise HCAL data flags custimizations ---------------------
+
+#--- run2_25ns_specific HCAL data flags customization
+#---    "HFDigiTime", "HBHEFlatNoise"  -> 8
+from Configuration.Eras.Modifier_run2_25ns_specific_cff import run2_25ns_specific
+def _modName(algos):
+   HcalRemoveAddSevLevel.AddFlag(algos,"HBHEFlatNoise",8)
+run2_25ns_specific.toModify(hcalRecAlgos, _modName)
+def _modName(algos):
+   HcalRemoveAddSevLevel.AddFlag(algos,"HFDigiTime",8)
+run2_25ns_specific.toModify(hcalRecAlgos, _modName)
+
+#--- Run2_2017 HCAL data flags customization
+#---     "HFDigiTime" to be removed
+from Configuration.Eras.Modifier_run2_HCAL_2017_cff import run2_HCAL_2017
+def _modName(algos):
+   HcalRemoveAddSevLevel.RemoveFlag(algos,"HFDigiTime")  
+run2_HCAL_2017.toModify(hcalRecAlgos, _modName)
+
+#--- Run3 HCAL data flags customization (bringing in sync with MC setting)
+#---    "HBHENegativeNoise" -> 8
+from Configuration.Eras.Modifier_run3_HB_cff import run3_HB
+def _modName(algos):
+   HcalRemoveAddSevLevel.AddFlag(algos,"HBHENegativeNoise",8)
+run3_HB.toModify(hcalRecAlgos, _modName)
+
 
 CSCHaloData.ExpectedBX = cms.int32(3)
 

--- a/Configuration/StandardSequences/python/Reconstruction_Data_cff.py
+++ b/Configuration/StandardSequences/python/Reconstruction_Data_cff.py
@@ -27,8 +27,6 @@ HcalRemoveAddSevLevel.AddFlag(hcalRecAlgos,"HBHENegativeNoise",12)
 from Configuration.Eras.Modifier_run2_25ns_specific_cff import run2_25ns_specific
 def _modName(algos):
    HcalRemoveAddSevLevel.AddFlag(algos,"HBHEFlatNoise",8)
-run2_25ns_specific.toModify(hcalRecAlgos, _modName)
-def _modName(algos):
    HcalRemoveAddSevLevel.AddFlag(algos,"HFDigiTime",8)
 run2_25ns_specific.toModify(hcalRecAlgos, _modName)
 
@@ -37,6 +35,7 @@ def _modName(algos):
    HcalRemoveAddSevLevel.RemoveFlag(algos,"HFDigiTime")  
 run2_HCAL_2017.toModify(hcalRecAlgos, _modName)
 
+#--- NB: MC and data get back in sync for >= Run3  ------------------------
 from Configuration.Eras.Modifier_run3_HB_cff import run3_HB
 def _modName(algos):
    HcalRemoveAddSevLevel.AddFlag(algos,"HBHENegativeNoise",8)

--- a/Configuration/StandardSequences/python/Reconstruction_Data_cff.py
+++ b/Configuration/StandardSequences/python/Reconstruction_Data_cff.py
@@ -22,10 +22,8 @@ HcalRemoveAddSevLevel.AddFlag(hcalRecAlgos,"HFDigiTime",11,verbose=False)
 HcalRemoveAddSevLevel.AddFlag(hcalRecAlgos,"HBHEFlatNoise",12)
 HcalRemoveAddSevLevel.AddFlag(hcalRecAlgos,"HBHENegativeNoise",12)
 
-#--- Subsequent era-wise HCAL data flags custimizations ---------------------
+#--- Subsequent era-wise HCAL data-specific flags customization 
 
-#--- run2_25ns_specific HCAL data flags customization
-#---    "HFDigiTime", "HBHEFlatNoise"  -> 8
 from Configuration.Eras.Modifier_run2_25ns_specific_cff import run2_25ns_specific
 def _modName(algos):
    HcalRemoveAddSevLevel.AddFlag(algos,"HBHEFlatNoise",8)
@@ -34,15 +32,11 @@ def _modName(algos):
    HcalRemoveAddSevLevel.AddFlag(algos,"HFDigiTime",8)
 run2_25ns_specific.toModify(hcalRecAlgos, _modName)
 
-#--- Run2_2017 HCAL data flags customization
-#---     "HFDigiTime" to be removed
 from Configuration.Eras.Modifier_run2_HCAL_2017_cff import run2_HCAL_2017
 def _modName(algos):
    HcalRemoveAddSevLevel.RemoveFlag(algos,"HFDigiTime")  
 run2_HCAL_2017.toModify(hcalRecAlgos, _modName)
 
-#--- Run3 HCAL data flags customization (bringing in sync with MC setting)
-#---    "HBHENegativeNoise" -> 8
 from Configuration.Eras.Modifier_run3_HB_cff import run3_HB
 def _modName(algos):
    HcalRemoveAddSevLevel.AddFlag(algos,"HBHENegativeNoise",8)


### PR DESCRIPTION
#### PR description:

Suggested by @slava77  in (issue) https://github.com/cms-sw/cmssw/issues/27767
re-arrangement of HCAL _data_-specific SeverityLevel settings (of RecHits flags) : 
move the relevant stuff from RecoTLR_cff.py customization snippets 
to Reconstruction_Data_cff.py appropriate era/modifiers. 
**NB:**  data settings are now in sync with the MC ones for >=Run3 
(First they were synchronized yet in RecoTLR_cff.py in  https://github.com/cms-sw/cmssw/pull/33520 by @hatakeyamak )

#### PR validation:

runTheMatrix.py -l limited --ibeos --useInput all 

Checked explicitly that SeverityLevel groups stayed unchanged w/wo this PR in  
 (1) 136.731_RunSinglePh2016B
 (2) 136.793_RunDoubleEG2017C
 (3) 136.874_RunEGamma2018C
 