### PR TITLE
Removed global namespace using from XercesStrUtils.h

### DIFF
--- a/CondFormats/PPSObjects/src/CTPPSRPAlignmentCorrectionsMethods.cc
+++ b/CondFormats/PPSObjects/src/CTPPSRPAlignmentCorrectionsMethods.cc
@@ -30,6 +30,10 @@
 #include <map>
 #include <set>
 
+#ifdef XERCES_CPP_NAMESPACE_USE
+XERCES_CPP_NAMESPACE_USE
+#endif
+
 //----------------------------------------------------------------------------------------------------
 
 /**

--- a/Utilities/Xerces/interface/XercesStrUtils.h
+++ b/Utilities/Xerces/interface/XercesStrUtils.h
@@ -6,12 +6,13 @@
 #include <memory>
 #include <sstream>
 
-#ifdef XERCES_CPP_NAMESPACE_USE
-XERCES_CPP_NAMESPACE_USE
-#endif
-
 namespace cms {
   namespace xerces {
+
+#ifdef XERCES_CPP_NAMESPACE_USE
+    XERCES_CPP_NAMESPACE_USE
+#endif
+
     inline void dispose(XMLCh* ptr) { XMLString::release(&ptr); }
     inline void dispose(char* ptr) { XMLString::release(&ptr); }
 


### PR DESCRIPTION
#### PR description:

Moved the macro for the using directive into the namespace defined in the header.

This was uncovered by the static analyzer.

#### PR validation:

Code compiles after doing a `git cms-checkdeps -a`.

fixes makortel/framework#179