### PR TITLE
make CPEFast to better reproduce Generic (w/o track angle)

### DIFF
--- a/CUDADataFormats/TrackingRecHit/interface/SiPixelHitStatus.h
+++ b/CUDADataFormats/TrackingRecHit/interface/SiPixelHitStatus.h
@@ -5,11 +5,11 @@
 
 // more information on bit fields : https://en.cppreference.com/w/cpp/language/bit_field
 struct SiPixelHitStatus {
-  bool isBigX : 1;    //  ∈[0,1]
-  bool isOneX : 1;    //  ∈[0,1]
-  bool isBigY : 1;    //  ∈[0,1]
-  bool isOneY : 1;    //  ∈[0,1]
-  uint8_t qBin : 3;   //  ∈[0,1,...,7]
+  bool isBigX : 1;   //  ∈[0,1]
+  bool isOneX : 1;   //  ∈[0,1]
+  bool isBigY : 1;   //  ∈[0,1]
+  bool isOneY : 1;   //  ∈[0,1]
+  uint8_t qBin : 3;  //  ∈[0,1,...,7]
 };
 
 #endif

--- a/CUDADataFormats/TrackingRecHit/interface/SiPixelHitStatus.h
+++ b/CUDADataFormats/TrackingRecHit/interface/SiPixelHitStatus.h
@@ -1,0 +1,15 @@
+#ifndef CUDADataFormats_TrackingRecHit_interface_SiPixelHitStatus_H
+#define CUDADataFormats_TrackingRecHit_interface_SiPixelHitStatus_H
+
+#include <cstdint>
+
+// more information on bit fields : https://en.cppreference.com/w/cpp/language/bit_field
+struct SiPixelHitStatus {
+  bool isBigX : 1;    //  ∈[0,1]
+  bool isOneX : 1;    //  ∈[0,1]
+  bool isBigY : 1;    //  ∈[0,1]
+  bool isOneY : 1;    //  ∈[0,1]
+  uint8_t qBin : 3;   //  ∈[0,1,...,7]
+};
+
+#endif

--- a/CUDADataFormats/TrackingRecHit/interface/TrackingRecHit2DHeterogeneous.h
+++ b/CUDADataFormats/TrackingRecHit/interface/TrackingRecHit2DHeterogeneous.h
@@ -14,10 +14,12 @@ public:
 
   TrackingRecHit2DHeterogeneous() = default;
 
-  explicit TrackingRecHit2DHeterogeneous(uint32_t nHits,
-                                         pixelCPEforGPU::ParamsOnGPU const* cpeParams,
-                                         uint32_t const* hitsModuleStart,
-                                         cudaStream_t stream);
+  explicit TrackingRecHit2DHeterogeneous(
+      uint32_t nHits,
+      pixelCPEforGPU::ParamsOnGPU const* cpeParams,
+      uint32_t const* hitsModuleStart,
+      cudaStream_t stream,
+      TrackingRecHit2DHeterogeneous<cms::cudacompat::GPUTraits> const* input = nullptr);
 
   ~TrackingRecHit2DHeterogeneous() = default;
 
@@ -40,6 +42,9 @@ public:
   // only the local coord and detector index
   cms::cuda::host::unique_ptr<float[]> localCoordToHostAsync(cudaStream_t stream) const;
   cms::cuda::host::unique_ptr<uint32_t[]> hitsModuleStartToHostAsync(cudaStream_t stream) const;
+
+  // needs specialization for Host
+  void copyFromGPU(TrackingRecHit2DHeterogeneous<cms::cudacompat::GPUTraits> const* input, cudaStream_t stream);
 
 private:
   static constexpr uint32_t n16 = 4;                 // number of elements in m_store16
@@ -65,20 +70,27 @@ private:
   int16_t* m_iphi;
 };
 
+using TrackingRecHit2DGPU = TrackingRecHit2DHeterogeneous<cms::cudacompat::GPUTraits>;
+using TrackingRecHit2DCUDA = TrackingRecHit2DHeterogeneous<cms::cudacompat::GPUTraits>;
+using TrackingRecHit2DCPU = TrackingRecHit2DHeterogeneous<cms::cudacompat::CPUTraits>;
+using TrackingRecHit2DHost = TrackingRecHit2DHeterogeneous<cms::cudacompat::HostTraits>;
+
 #include "HeterogeneousCore/CUDAUtilities/interface/copyAsync.h"
 #include "HeterogeneousCore/CUDAUtilities/interface/cudaCheck.h"
 
 template <typename Traits>
-TrackingRecHit2DHeterogeneous<Traits>::TrackingRecHit2DHeterogeneous(uint32_t nHits,
-                                                                     pixelCPEforGPU::ParamsOnGPU const* cpeParams,
-                                                                     uint32_t const* hitsModuleStart,
-                                                                     cudaStream_t stream)
+TrackingRecHit2DHeterogeneous<Traits>::TrackingRecHit2DHeterogeneous(
+    uint32_t nHits,
+    pixelCPEforGPU::ParamsOnGPU const* cpeParams,
+    uint32_t const* hitsModuleStart,
+    cudaStream_t stream,
+    TrackingRecHit2DHeterogeneous<cms::cudacompat::GPUTraits> const* input)
     : m_nHits(nHits), m_hitsModuleStart(hitsModuleStart) {
   auto view = Traits::template make_host_unique<TrackingRecHit2DSOAView>(stream);
 
   view->m_nHits = nHits;
-  m_view = Traits::template make_device_unique<TrackingRecHit2DSOAView>(stream);
-  m_AverageGeometryStore = Traits::template make_device_unique<TrackingRecHit2DSOAView::AverageGeometry>(stream);
+  m_view = Traits::template make_unique<TrackingRecHit2DSOAView>(stream);  // leave it on host and pass it by value?
+  m_AverageGeometryStore = Traits::template make_unique<TrackingRecHit2DSOAView::AverageGeometry>(stream);
   view->m_averageGeometry = m_AverageGeometryStore.get();
   view->m_cpeParams = cpeParams;
   view->m_hitsModuleStart = hitsModuleStart;
@@ -98,15 +110,21 @@ TrackingRecHit2DHeterogeneous<Traits>::TrackingRecHit2DHeterogeneous(uint32_t nH
   // if ordering is relevant they may have to be stored phi-ordered by layer or so
   // this will break 1to1 correspondence with cluster and module locality
   // so unless proven VERY inefficient we keep it ordered as generated
-  m_store16 = Traits::template make_device_unique<uint16_t[]>(nHits * n16, stream);
-  m_store32 =
-      Traits::template make_device_unique<float[]>(nHits * n32 + phase1PixelTopology::numberOfLayers + 1, stream);
-  m_PhiBinnerStore = Traits::template make_device_unique<TrackingRecHit2DSOAView::PhiBinner>(stream);
+
+  // host copy is "reduced"  (to be reviewed at some point)
+  if constexpr (std::is_same<Traits, cms::cudacompat::HostTraits>::value) {
+    // it has to compile for ALL cases
+    copyFromGPU(input, stream);
+  } else {
+    assert(input == nullptr);
+    m_store16 = Traits::template make_unique<uint16_t[]>(nHits * n16, stream);
+    m_store32 = Traits::template make_unique<float[]>(nHits * n32 + phase1PixelTopology::numberOfLayers + 1, stream);
+    m_PhiBinnerStore = Traits::template make_unique<TrackingRecHit2DSOAView::PhiBinner>(stream);
+  }
 
   static_assert(sizeof(TrackingRecHit2DSOAView::hindex_type) == sizeof(float));
   static_assert(sizeof(TrackingRecHit2DSOAView::hindex_type) == sizeof(TrackingRecHit2DSOAView::PhiBinner::index_type));
 
-  auto get16 = [&](int i) { return m_store16.get() + i * nHits; };
   auto get32 = [&](int i) { return m_store32.get() + i * nHits; };
 
   // copy all the pointers
@@ -118,20 +136,25 @@ TrackingRecHit2DHeterogeneous<Traits>::TrackingRecHit2DHeterogeneous(uint32_t nH
   view->m_yl = get32(1);
   view->m_xerr = get32(2);
   view->m_yerr = get32(3);
+  view->m_chargeAndStatus = reinterpret_cast<uint32_t*>(get32(4));
 
-  view->m_xg = get32(4);
-  view->m_yg = get32(5);
-  view->m_zg = get32(6);
-  view->m_rg = get32(7);
+  if constexpr (!std::is_same<Traits, cms::cudacompat::HostTraits>::value) {
+    assert(input == nullptr);
+    view->m_xg = get32(5);
+    view->m_yg = get32(6);
+    view->m_zg = get32(7);
+    view->m_rg = get32(8);
 
-  m_iphi = view->m_iphi = reinterpret_cast<int16_t*>(get16(0));
+    auto get16 = [&](int i) { return m_store16.get() + i * nHits; };
+    m_iphi = view->m_iphi = reinterpret_cast<int16_t*>(get16(1));
 
-  view->m_charge = reinterpret_cast<int32_t*>(get32(8));
-  view->m_xsize = reinterpret_cast<int16_t*>(get16(2));
-  view->m_ysize = reinterpret_cast<int16_t*>(get16(3));
-  view->m_detInd = get16(1);
+    view->m_xsize = reinterpret_cast<int16_t*>(get16(2));
+    view->m_ysize = reinterpret_cast<int16_t*>(get16(3));
+    view->m_detInd = get16(0);
 
-  m_hitsLayerStart = view->m_hitsLayerStart = reinterpret_cast<uint32_t*>(get32(n32));
+    m_phiBinner = view->m_phiBinner = m_PhiBinnerStore.get();
+    m_hitsLayerStart = view->m_hitsLayerStart = reinterpret_cast<uint32_t*>(get32(n32));
+  }
 
   // transfer view
   if constexpr (std::is_same<Traits, cms::cudacompat::GPUTraits>::value) {

--- a/CUDADataFormats/TrackingRecHit/interface/TrackingRecHit2DReduced.h
+++ b/CUDADataFormats/TrackingRecHit/interface/TrackingRecHit2DReduced.h
@@ -1,0 +1,52 @@
+#ifndef CUDADataFormats_TrackingRecHit_interface_TrackingRecHit2DReduced_h
+#define CUDADataFormats_TrackingRecHit_interface_TrackingRecHit2DReduced_h
+
+#include "CUDADataFormats/TrackingRecHit/interface/TrackingRecHit2DSOAView.h"
+#include "CUDADataFormats/Common/interface/HostProduct.h"
+
+// a reduced (in content and therefore in size) version to be used on CPU for Legacy reconstruction
+class TrackingRecHit2DReduced {
+public:
+  using HLPstorage = HostProduct<float[]>;
+  using HIDstorage = HostProduct<uint16_t[]>;
+
+  template <typename UP32, typename UP16>
+  TrackingRecHit2DReduced(UP32&& istore32, UP16&& istore16, int nhits)
+      : m_store32(std::move(istore32)), m_store16(std::move(istore16)), m_nHits(nhits) {
+    auto get32 = [&](int i) { return const_cast<float*>(m_store32.get()) + i * nhits; };
+
+    // copy all the pointers (better be in sync with the producer store)
+
+    m_view.m_xl = get32(0);
+    m_view.m_yl = get32(1);
+    m_view.m_xerr = get32(2);
+    m_view.m_yerr = get32(3);
+    m_view.m_chargeAndStatus = reinterpret_cast<uint32_t*>(get32(4));
+    m_view.m_detInd = const_cast<uint16_t*>(m_store16.get());
+  }
+
+  // view only!
+  TrackingRecHit2DReduced(TrackingRecHit2DSOAView const& iview, int nhits) : m_view(iview), m_nHits(nhits) {}
+
+  TrackingRecHit2DReduced() = default;
+  ~TrackingRecHit2DReduced() = default;
+
+  TrackingRecHit2DReduced(const TrackingRecHit2DReduced&) = delete;
+  TrackingRecHit2DReduced& operator=(const TrackingRecHit2DReduced&) = delete;
+  TrackingRecHit2DReduced(TrackingRecHit2DReduced&&) = default;
+  TrackingRecHit2DReduced& operator=(TrackingRecHit2DReduced&&) = default;
+
+  TrackingRecHit2DSOAView& view() { return m_view; }
+  TrackingRecHit2DSOAView const& view() const { return m_view; }
+
+  auto nHits() const { return m_nHits; }
+
+  TrackingRecHit2DSOAView m_view;
+
+  HLPstorage m_store32;
+  HIDstorage m_store16;
+
+  int m_nHits;
+};
+
+#endif

--- a/CUDADataFormats/TrackingRecHit/interface/TrackingRecHit2DReduced.h
+++ b/CUDADataFormats/TrackingRecHit/interface/TrackingRecHit2DReduced.h
@@ -41,6 +41,7 @@ public:
 
   auto nHits() const { return m_nHits; }
 
+private:
   TrackingRecHit2DSOAView m_view;
 
   HLPstorage m_store32;

--- a/CUDADataFormats/TrackingRecHit/interface/TrackingRecHit2DSOAView.h
+++ b/CUDADataFormats/TrackingRecHit/interface/TrackingRecHit2DSOAView.h
@@ -7,6 +7,7 @@
 #include "HeterogeneousCore/CUDAUtilities/interface/HistoContainer.h"
 #include "HeterogeneousCore/CUDAUtilities/interface/cudaCompat.h"
 #include "Geometry/TrackerGeometryBuilder/interface/phase1PixelTopology.h"
+#include "CUDADataFormats/TrackingRecHit/interface/SiPixelHitStatus.h"
 
 namespace pixelCPEforGPU {
   struct ParamsOnGPU;
@@ -14,6 +15,9 @@ namespace pixelCPEforGPU {
 
 class TrackingRecHit2DSOAView {
 public:
+  using Status = SiPixelHitStatus;
+  static_assert(sizeof(Status) == sizeof(uint8_t));
+
   using hindex_type = uint32_t;  // if above is <=2^32
 
   using PhiBinner = cms::cuda::HistoContainer<int16_t, 128, -1, 8 * sizeof(int16_t), hindex_type, 10>;
@@ -22,6 +26,7 @@ public:
 
   template <typename>
   friend class TrackingRecHit2DHeterogeneous;
+  friend class TrackingRecHit2DReduced;
 
   __device__ __forceinline__ uint32_t nHits() const { return m_nHits; }
 
@@ -47,8 +52,19 @@ public:
   __device__ __forceinline__ int16_t& iphi(int i) { return m_iphi[i]; }
   __device__ __forceinline__ int16_t iphi(int i) const { return __ldg(m_iphi + i); }
 
-  __device__ __forceinline__ int32_t& charge(int i) { return m_charge[i]; }
-  __device__ __forceinline__ int32_t charge(int i) const { return __ldg(m_charge + i); }
+  __device__ __forceinline__ void setChargeAndStatus(int i, uint32_t ich, Status is) {
+    // static_assert(0xffffff == chargeMask());
+    ich = std::min(ich, chargeMask());
+    uint32_t w = *reinterpret_cast<uint8_t*>(&is);
+    ich |= (w << 24);
+    m_chargeAndStatus[i] = ich;
+  }
+
+  __device__ __forceinline__ Status status(int i) const {
+    uint8_t w = __ldg(m_chargeAndStatus + i) >> 24;
+    return *reinterpret_cast<Status*>(&w);
+  }
+
   __device__ __forceinline__ int16_t& clusterSizeX(int i) { return m_xsize[i]; }
   __device__ __forceinline__ int16_t clusterSizeX(int i) const { return __ldg(m_xsize + i); }
   __device__ __forceinline__ int16_t& clusterSizeY(int i) { return m_ysize[i]; }
@@ -79,7 +95,8 @@ private:
   int16_t* m_iphi;
 
   // cluster properties
-  int32_t* m_charge;
+  static constexpr uint32_t chargeMask() { return (1 << 24) - 1; }
+  uint32_t* m_chargeAndStatus;
   int16_t* m_xsize;
   int16_t* m_ysize;
   uint16_t* m_detInd;

--- a/CUDADataFormats/TrackingRecHit/interface/TrackingRecHit2DSOAView.h
+++ b/CUDADataFormats/TrackingRecHit/interface/TrackingRecHit2DSOAView.h
@@ -53,7 +53,6 @@ public:
   __device__ __forceinline__ int16_t iphi(int i) const { return __ldg(m_iphi + i); }
 
   __device__ __forceinline__ void setChargeAndStatus(int i, uint32_t ich, Status is) {
-    // static_assert(0xffffff == chargeMask());
     ich = std::min(ich, chargeMask());
     uint32_t w = *reinterpret_cast<uint8_t*>(&is);
     ich |= (w << 24);

--- a/CUDADataFormats/TrackingRecHit/src/TrackingRecHit2DHeterogeneous.cc
+++ b/CUDADataFormats/TrackingRecHit/src/TrackingRecHit2DHeterogeneous.cc
@@ -6,15 +6,22 @@
 
 template <>
 cms::cuda::host::unique_ptr<float[]> TrackingRecHit2DCUDA::localCoordToHostAsync(cudaStream_t stream) const {
-  auto ret = cms::cuda::make_host_unique<float[]>(4 * nHits(), stream);
-  cms::cuda::copyAsync(ret, m_store32, 4 * nHits(), stream);
+  auto ret = cms::cuda::make_host_unique<float[]>(5 * nHits(), stream);
+  cms::cuda::copyAsync(ret, m_store32, 5 * nHits(), stream);
   return ret;
 }
 
 template <>
-cms::cuda::host::unique_ptr<uint32_t[]> TrackingRecHit2DCUDA::hitsModuleStartToHostAsync(cudaStream_t stream) const {
+cms::cuda::host::unique_ptr<uint32_t[]> TrackingRecHit2DGPU::hitsModuleStartToHostAsync(cudaStream_t stream) const {
   auto ret = cms::cuda::make_host_unique<uint32_t[]>(gpuClustering::maxNumModules + 1, stream);
   cudaCheck(cudaMemcpyAsync(
       ret.get(), m_hitsModuleStart, sizeof(uint32_t) * (gpuClustering::maxNumModules + 1), cudaMemcpyDefault, stream));
   return ret;
+}
+
+// the only specialization needed
+template <>
+void TrackingRecHit2DHost::copyFromGPU(TrackingRecHit2DGPU const* input, cudaStream_t stream) {
+  assert(input);
+  m_store32 = input->localCoordToHostAsync(stream);
 }

--- a/CUDADataFormats/TrackingRecHit/src/classes.h
+++ b/CUDADataFormats/TrackingRecHit/src/classes.h
@@ -3,6 +3,7 @@
 
 #include "CUDADataFormats/Common/interface/Product.h"
 #include "CUDADataFormats/TrackingRecHit/interface/TrackingRecHit2DHeterogeneous.h"
+#include "CUDADataFormats/TrackingRecHit/interface/TrackingRecHit2DReduced.h"
 #include "DataFormats/Common/interface/Wrapper.h"
 
 #endif  // CUDADataFormats_SiPixelCluster_src_classes_h

--- a/CUDADataFormats/TrackingRecHit/src/classes_def.xml
+++ b/CUDADataFormats/TrackingRecHit/src/classes_def.xml
@@ -1,8 +1,10 @@
 <lcgdict>
   <class name="TrackingRecHit2DCPU" persistent="false"/>
-  <class name="TrackingRecHit2DHost" persistent="false"/>
-  <class name="cms::cuda::Product<TrackingRecHit2DGPU>" persistent="false"/>
   <class name="edm::Wrapper<TrackingRecHit2DCPU>" persistent="false"/>
+  <class name="TrackingRecHit2DHost" persistent="false"/>
   <class name="edm::Wrapper<TrackingRecHit2DHost>" persistent="false"/>
+  <class name="cms::cuda::Product<TrackingRecHit2DGPU>" persistent="false"/>
   <class name="edm::Wrapper<cms::cuda::Product<TrackingRecHit2DGPU>>" persistent="false"/>
+  <class name="TrackingRecHit2DReduced" persistent="false"/>
+  <class name="edm::Wrapper<TrackingRecHit2DReduced>" persistent="false"/>
 </lcgdict>

--- a/CUDADataFormats/TrackingRecHit/test/TrackingRecHit2DCUDA_t.cpp
+++ b/CUDADataFormats/TrackingRecHit/test/TrackingRecHit2DCUDA_t.cpp
@@ -15,12 +15,17 @@ int main() {
   cudaStream_t stream;
   cudaCheck(cudaStreamCreateWithFlags(&stream, cudaStreamNonBlocking));
 
+  auto nHits = 200;
   // inner scope to deallocate memory before destroying the stream
   {
-    auto nHits = 200;
     TrackingRecHit2DCUDA tkhit(nHits, nullptr, nullptr, stream);
 
     testTrackingRecHit2D::runKernels(tkhit.view());
+
+    TrackingRecHit2DHost tkhitH(nHits, nullptr, nullptr, stream, &tkhit);
+    cudaStreamSynchronize(stream);
+    assert(tkhitH.view());
+    assert(tkhitH.view()->nHits() == nHits);
   }
 
   cudaCheck(cudaStreamDestroy(stream));

--- a/CUDADataFormats/TrackingRecHit/test/TrackingRecHit2DCUDA_t.cpp
+++ b/CUDADataFormats/TrackingRecHit/test/TrackingRecHit2DCUDA_t.cpp
@@ -25,7 +25,7 @@ int main() {
     TrackingRecHit2DHost tkhitH(nHits, nullptr, nullptr, stream, &tkhit);
     cudaStreamSynchronize(stream);
     assert(tkhitH.view());
-    assert(tkhitH.view()->nHits() == nHits);
+    assert(tkhitH.view()->nHits() == unsigned(nHits));
   }
 
   cudaCheck(cudaStreamDestroy(stream));

--- a/RecoLocalTracker/SiPixelRecHits/interface/pixelCPEforGPU.h
+++ b/RecoLocalTracker/SiPixelRecHits/interface/pixelCPEforGPU.h
@@ -103,7 +103,7 @@ namespace pixelCPEforGPU {
     int16_t xsize[N];  // (*8) clipped at 127 if negative is edge....
     int16_t ysize[N];
 
-    Status status;
+    Status status[N];
   };
 
   constexpr int32_t MaxHitsInIter = gpuClustering::maxHitsInIter();
@@ -347,11 +347,11 @@ namespace pixelCPEforGPU {
         break;
     assert(bin < 5);
 
-    cp.status.qBin = 4 - bin;
-    cp.status.isOneX = isOneX;
-    cp.status.isBigX = (isOneX & isBigX) | isEdgeX;
-    cp.status.isOneY = isOneY;
-    cp.status.isBigY = (isOneY & isBigY) | isEdgeY;
+    cp.status[ic].qBin = 4 - bin;
+    cp.status[ic].isOneX = isOneX;
+    cp.status[ic].isBigX = (isOneX & isBigX) | isEdgeX;
+    cp.status[ic].isOneY = isOneY;
+    cp.status[ic].isBigY = (isOneY & isBigY) | isEdgeY;
 
     auto xoff = 81.f * comParams.thePitchX;
     int jx = std::min(15, std::max(0, int(16.f * (cp.xpos[ic] + xoff) / (162.f * comParams.thePitchX))));

--- a/RecoLocalTracker/SiPixelRecHits/interface/pixelCPEforGPU.h
+++ b/RecoLocalTracker/SiPixelRecHits/interface/pixelCPEforGPU.h
@@ -41,7 +41,7 @@ namespace pixelCPEforGPU {
 
     float x0, y0, z0;  // the vertex in the local coord of the detector
 
-    // float apeX, apexY;  // ape^2
+    float apeX, apeY;  // ape^2
     uint8_t sx2, sy1, sy2;
     uint8_t sigmax[16], sigmax1[16], sigmay[16];  // in micron
     float xfact[5], yfact[5];

--- a/RecoLocalTracker/SiPixelRecHits/interface/pixelCPEforGPU.h
+++ b/RecoLocalTracker/SiPixelRecHits/interface/pixelCPEforGPU.h
@@ -10,9 +10,11 @@
 #include "DataFormats/GeometrySurface/interface/SOARotation.h"
 #include "Geometry/TrackerGeometryBuilder/interface/phase1PixelTopology.h"
 #include "HeterogeneousCore/CUDAUtilities/interface/cudaCompat.h"
+#include "CUDADataFormats/TrackingRecHit/interface/SiPixelHitStatus.h"
 
 namespace pixelCPEforGPU {
 
+  using Status = SiPixelHitStatus;
   using Frame = SOAFrame<float>;
   using Rotation = SOARotation<float>;
 
@@ -39,7 +41,11 @@ namespace pixelCPEforGPU {
 
     float x0, y0, z0;  // the vertex in the local coord of the detector
 
-    float sx[3], sy[3];  // the errors...
+    // float apeX, apexY;  // ape^2
+    uint8_t sx2, sy1, sy2;
+    uint8_t sigmax[16], sigmax1[16], sigmay[16];  // in micron
+    float xfact[5], yfact[5];
+    int minCh[5];
 
     Frame frame;
   };
@@ -94,8 +100,10 @@ namespace pixelCPEforGPU {
     float xerr[N];
     float yerr[N];
 
-    int16_t xsize[N];  // clipped at 127 if negative is edge....
+    int16_t xsize[N];  // (*8) clipped at 127 if negative is edge....
     int16_t ysize[N];
+
+    Status status;
   };
 
   constexpr int32_t MaxHitsInIter = gpuClustering::maxHitsInIter();
@@ -206,8 +214,8 @@ namespace pixelCPEforGPU {
     if (phase1PixelTopology::isBigPixY(cp.maxCol[ic]))
       ++ysize;
 
-    int unbalanceX = 8. * std::abs(float(cp.q_f_X[ic] - cp.q_l_X[ic])) / float(cp.q_f_X[ic] + cp.q_l_X[ic]);
-    int unbalanceY = 8. * std::abs(float(cp.q_f_Y[ic] - cp.q_l_Y[ic])) / float(cp.q_f_Y[ic] + cp.q_l_Y[ic]);
+    int unbalanceX = 8.f * std::abs(float(cp.q_f_X[ic] - cp.q_l_X[ic])) / float(cp.q_f_X[ic] + cp.q_l_X[ic]);
+    int unbalanceY = 8.f * std::abs(float(cp.q_f_Y[ic] - cp.q_l_Y[ic])) / float(cp.q_f_Y[ic] + cp.q_l_Y[ic]);
     xsize = 8 * xsize - unbalanceX;
     ysize = 8 * ysize - unbalanceY;
 
@@ -285,8 +293,8 @@ namespace pixelCPEforGPU {
     auto sy = cp.maxCol[ic] - cp.minCol[ic];
 
     // is edgy ?
-    bool isEdgeX = cp.minRow[ic] == 0 or cp.maxRow[ic] == phase1PixelTopology::lastRowInModule;
-    bool isEdgeY = cp.minCol[ic] == 0 or cp.maxCol[ic] == phase1PixelTopology::lastColInModule;
+    bool isEdgeX = cp.xsize[ic] < 1;
+    bool isEdgeY = cp.ysize[ic] < 1;
     // is one and big?
     bool isBig1X = (0 == sx) && phase1PixelTopology::isBigPixX(cp.minRow[ic]);
     bool isBig1Y = (0 == sy) && phase1PixelTopology::isBigPixY(cp.minCol[ic]);
@@ -323,19 +331,42 @@ namespace pixelCPEforGPU {
     auto sx = cp.maxRow[ic] - cp.minRow[ic];
     auto sy = cp.maxCol[ic] - cp.minCol[ic];
 
-    // is edgy ?
-    bool isEdgeX = cp.minRow[ic] == 0 or cp.maxRow[ic] == phase1PixelTopology::lastRowInModule;
-    bool isEdgeY = cp.minCol[ic] == 0 or cp.maxCol[ic] == phase1PixelTopology::lastColInModule;
+    // is edgy ?  (size is set negative: see above)
+    bool isEdgeX = cp.xsize[ic] < 1;
+    bool isEdgeY = cp.ysize[ic] < 1;
     // is one and big?
-    uint32_t ix = (0 == sx);
-    uint32_t iy = (0 == sy);
-    ix += (0 == sx) && phase1PixelTopology::isBigPixX(cp.minRow[ic]);
-    iy += (0 == sy) && phase1PixelTopology::isBigPixY(cp.minCol[ic]);
+    bool isOneX = (0 == sx);
+    bool isOneY = (0 == sy);
+    bool isBigX = phase1PixelTopology::isBigPixX(cp.minRow[ic]);
+    bool isBigY = phase1PixelTopology::isBigPixY(cp.minCol[ic]);
 
-    if (not isEdgeX)
-      cp.xerr[ic] = detParams.sx[ix];
-    if (not isEdgeY)
-      cp.yerr[ic] = detParams.sy[iy];
+    auto ch = cp.charge[ic];
+    auto bin = 0;
+    for (; bin < 4; ++bin)
+      if (ch < detParams.minCh[bin + 1])
+        break;
+    assert(bin < 5);
+
+    cp.status.qBin = 4 - bin;
+    cp.status.isOneX = isOneX;
+    cp.status.isBigX = (isOneX & isBigX) | isEdgeX;
+    cp.status.isOneY = isOneY;
+    cp.status.isBigY = (isOneY & isBigY) | isEdgeY;
+
+    auto xoff = 81.f * comParams.thePitchX;
+    int jx = std::min(15, std::max(0, int(16.f * (cp.xpos[ic] + xoff) / (162.f * comParams.thePitchX))));
+
+    auto toCM = [](uint8_t x) { return float(x) * 1.e-4; };
+
+    if (not isEdgeX) {
+      cp.xerr[ic] = isOneX ? toCM(isBigX ? detParams.sx2 : detParams.sigmax1[jx])
+                           : detParams.xfact[bin] * toCM(detParams.sigmax[jx]);
+    }
+
+    auto ey = cp.ysize[ic] > 8 ? detParams.sigmay[std::min(cp.ysize[ic] - 9, 15)] : detParams.sy1;
+    if (not isEdgeY) {
+      cp.yerr[ic] = isOneY ? toCM(isBigY ? detParams.sy2 : detParams.sy1) : detParams.yfact[bin] * toCM(ey);
+    }
   }
 
 }  // namespace pixelCPEforGPU

--- a/RecoLocalTracker/SiPixelRecHits/interface/pixelCPEforGPU.h
+++ b/RecoLocalTracker/SiPixelRecHits/interface/pixelCPEforGPU.h
@@ -354,7 +354,7 @@ namespace pixelCPEforGPU {
     cp.status[ic].isBigY = (isOneY & isBigY) | isEdgeY;
 
     auto xoff = 81.f * comParams.thePitchX;
-    int jx = std::min(15, std::max(0, int(16.f * (cp.xpos[ic] + xoff) / (162.f * comParams.thePitchX))));
+    int jx = std::min(15, std::max(0, int(16.f * (cp.xpos[ic] + xoff) / (2 * xoff))));
 
     auto toCM = [](uint8_t x) { return float(x) * 1.e-4; };
 

--- a/RecoLocalTracker/SiPixelRecHits/interface/pixelCPEforGPU.h
+++ b/RecoLocalTracker/SiPixelRecHits/interface/pixelCPEforGPU.h
@@ -41,7 +41,7 @@ namespace pixelCPEforGPU {
 
     float x0, y0, z0;  // the vertex in the local coord of the detector
 
-    float apeX, apeY;  // ape^2
+    float apeXX, apeYY;  // ape^2
     uint8_t sx2, sy1, sy2;
     uint8_t sigmax[16], sigmax1[16], sigmay[16];  // in micron
     float xfact[5], yfact[5];

--- a/RecoLocalTracker/SiPixelRecHits/plugins/gpuPixelRecHits.h
+++ b/RecoLocalTracker/SiPixelRecHits/plugins/gpuPixelRecHits.h
@@ -146,8 +146,9 @@ namespace gpuPixelRecHits {
         assert(cl < MaxHitsInIter);
         auto x = digis.xx(i);
         auto y = digis.yy(i);
-        auto ch = std::min(digis.adc(i), pixmx);
+        auto ch = digis.adc(i);
         atomicAdd(&clusParams.charge[cl], ch);
+        ch = std::min(ch, pixmx);
         if (clusParams.minRow[cl] == x)
           atomicAdd(&clusParams.q_f_X[cl], ch);
         if (clusParams.maxRow[cl] == x)

--- a/RecoLocalTracker/SiPixelRecHits/plugins/gpuPixelRecHits.h
+++ b/RecoLocalTracker/SiPixelRecHits/plugins/gpuPixelRecHits.h
@@ -174,7 +174,7 @@ namespace gpuPixelRecHits {
         pixelCPEforGPU::errorFromDB(cpeParams->commonParams(), cpeParams->detParams(me), clusParams, ic);
 
         // store it
-        hits.charge(h) = clusParams.charge[ic];
+        hits.setChargeAndStatus(h, clusParams.charge[ic], clusParams.status[ic]);
         hits.detectorIndex(h) = me;
 
         float xl, yl;

--- a/RecoLocalTracker/SiPixelRecHits/plugins/gpuPixelRecHits.h
+++ b/RecoLocalTracker/SiPixelRecHits/plugins/gpuPixelRecHits.h
@@ -184,8 +184,8 @@ namespace gpuPixelRecHits {
         hits.clusterSizeX(h) = clusParams.xsize[ic];
         hits.clusterSizeY(h) = clusParams.ysize[ic];
 
-        hits.xerrLocal(h) = clusParams.xerr[ic] * clusParams.xerr[ic];
-        hits.yerrLocal(h) = clusParams.yerr[ic] * clusParams.yerr[ic];
+        hits.xerrLocal(h) = clusParams.xerr[ic] * clusParams.xerr[ic] + cpeParams->detParams(me).apeX;
+        hits.yerrLocal(h) = clusParams.yerr[ic] * clusParams.yerr[ic] + cpeParams->detParams(me).apeY;
 
         // keep it local for computations
         float xg, yg, zg;

--- a/RecoLocalTracker/SiPixelRecHits/plugins/gpuPixelRecHits.h
+++ b/RecoLocalTracker/SiPixelRecHits/plugins/gpuPixelRecHits.h
@@ -184,8 +184,8 @@ namespace gpuPixelRecHits {
         hits.clusterSizeX(h) = clusParams.xsize[ic];
         hits.clusterSizeY(h) = clusParams.ysize[ic];
 
-        hits.xerrLocal(h) = clusParams.xerr[ic] * clusParams.xerr[ic] + cpeParams->detParams(me).apeX;
-        hits.yerrLocal(h) = clusParams.yerr[ic] * clusParams.yerr[ic] + cpeParams->detParams(me).apeY;
+        hits.xerrLocal(h) = clusParams.xerr[ic] * clusParams.xerr[ic] + cpeParams->detParams(me).apeXX;
+        hits.yerrLocal(h) = clusParams.yerr[ic] * clusParams.yerr[ic] + cpeParams->detParams(me).apeYY;
 
         // keep it local for computations
         float xg, yg, zg;

--- a/RecoLocalTracker/SiPixelRecHits/src/PixelCPEFast.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/PixelCPEFast.cc
@@ -194,7 +194,7 @@ void PixelCPEFast::fillParamsForGpu() {
 
     g.pixmx = std::max(0, cp.pixmx);
     g.sx2 = toMicron(cp.sx2);
-    g.sy1 = toMicron(cp.sy1);
+    g.sy1 = std::max(21, toMicron(cp.sy1));  // for some angles sy1 is very small
     g.sy2 = std::max(55, toMicron(cp.sy2));  // sometimes sy2 is smaller than others (due to angle?)
 
     // sample xerr as function of position

--- a/RecoLocalTracker/SiPixelRecHits/src/PixelCPEFast.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/PixelCPEFast.cc
@@ -167,17 +167,10 @@ void PixelCPEFast::fillParamsForGpu() {
     if (lape.invalid())
       lape = LocalError();  // zero....
 
-    auto apeX = lape.xx();
-    auto apeY = lape.yy();
+    g.apeX = lape.xx();
+    g.apeY = lape.yy();
 
-    auto toMicronX = [&](float x) {
-      x = std::sqrt(x * x + apeX);
-      return std::min(511, int(x * 1.e4f + 0.5f));
-    };
-    auto toMicronY = [&](float x) {
-      x = std::sqrt(x * x + apeY);
-      return std::min(511, int(x * 1.e4f + 0.5f));
-    };
+    auto toMicron = [&](float x) { return std::min(511, int(x * 1.e4f + 0.5f)); };
 
     {
       // average angle
@@ -200,9 +193,9 @@ void PixelCPEFast::fillParamsForGpu() {
 #endif  // EDM_ML_DEBUG
 
     g.pixmx = std::max(0, cp.pixmx);
-    g.sx2 = toMicronX(cp.sx2);
-    g.sy1 = toMicronY(cp.sy1);
-    g.sy2 = std::max(55, toMicronY(cp.sy2));
+    g.sx2 = toMicron(cp.sx2);
+    g.sy1 = toMicron(cp.sy1);
+    g.sy2 = std::max(55, toMicron(cp.sy2));  // sometimes sy2 is smaller than others (due to angle?)
 
     // sample xerr as function of position
     auto xoff = -81.f * commonParamsGPU_.thePitchX;
@@ -215,8 +208,8 @@ void PixelCPEFast::fillParamsForGpu() {
       cp.cotbeta = gvy * gvz;
       cp.cotalpha = gvx * gvz;
       errorFromTemplates(p, cp, 20000.f);
-      g.sigmax[ix] = toMicronX(cp.sigmax);
-      g.sigmax1[ix] = toMicronX(cp.sx1);
+      g.sigmax[ix] = toMicron(cp.sigmax);
+      g.sigmax1[ix] = toMicron(cp.sx1);
 #ifdef EDM_ML_DEBUG
       LogDebug("PixelCPEFast") << "sigmax vs x " << i << ' ' << x << ' ' << cp.cotalpha << ' ' << int(g.sigmax[ix])
                                << ' ' << int(g.sigmax1[ix]) << ' ' << 10000.f * cp.sigmay << std::endl;
@@ -289,13 +282,12 @@ void PixelCPEFast::fillParamsForGpu() {
       // cp.cotalpha = ys*100.f/(8.f*285.f);
       cp.cotbeta = std::copysign(ys * 150.f / (8.f * 285.f), aveCB);
       errorFromTemplates(p, cp, 20000.f);
-      g.sigmay[iy] = toMicronY(cp.sigmay);
+      g.sigmay[iy] = toMicron(cp.sigmay);
 #ifdef EDM_ML_DEBUG
       LogDebug("PixelCPEFast") << "sigmax/sigmay " << i << ' ' << (ys + 4.f) / 8.f << ' ' << cp.cotalpha << '/'
                                << cp.cotbeta << ' ' << 10000.f * cp.sigmax << '/' << int(g.sigmay[iy]) << std::endl;
 #endif  // EDM_ML_DEBUG
     }
-
   }  // loop over det
 
   // compute ladder baricenter (only in global z) for the barrel

--- a/RecoLocalTracker/SiPixelRecHits/src/PixelCPEFast.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/PixelCPEFast.cc
@@ -198,10 +198,10 @@ void PixelCPEFast::fillParamsForGpu() {
     g.sy2 = std::max(55, toMicron(cp.sy2));  // sometimes sy2 is smaller than others (due to angle?)
 
     // sample xerr as function of position
-    auto xoff = -81.f * commonParamsGPU_.thePitchX;
+    auto const xoff = -81.f * commonParamsGPU_.thePitchX;
 
     for (int ix = 0; ix < 16; ++ix) {
-      auto x = xoff + (0.5f + float(ix)) * 162.f * commonParamsGPU_.thePitchX / 16.f;
+      auto x = xoff * (1.f - (0.5f + float(ix)) / 8.f);
       auto gvx = p.theOrigin.x() - x;
       auto gvy = p.theOrigin.y();
       auto gvz = 1.f / p.theOrigin.z();

--- a/RecoLocalTracker/SiPixelRecHits/src/PixelCPEFast.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/PixelCPEFast.cc
@@ -215,9 +215,9 @@ void PixelCPEFast::fillParamsForGpu() {
     }
 #ifdef EDM_ML_DEBUG
     // sample yerr as function of position
-    auto yoff = -54 * 4.f * commonParamsGPU_.thePitchY;
+    auto const yoff = -54 * 4.f * commonParamsGPU_.thePitchY;
     for (int ix = 0; ix < 16; ++ix) {
-      auto y = yoff + (0.5f + float(ix)) * 432.f * commonParamsGPU_.thePitchY / 16.f;
+      auto y = yoff * (1.f - (0.5f + float(ix)) / 8.f);
       auto gvx = p.theOrigin.x() + 40.f * commonParamsGPU_.thePitchY;
       auto gvy = p.theOrigin.y() - y;
       auto gvz = 1.f / p.theOrigin.z();

--- a/RecoLocalTracker/SiPixelRecHits/src/PixelCPEFast.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/PixelCPEFast.cc
@@ -167,8 +167,8 @@ void PixelCPEFast::fillParamsForGpu() {
     if (lape.invalid())
       lape = LocalError();  // zero....
 
-    g.apeX = lape.xx();
-    g.apeY = lape.yy();
+    g.apeXX = lape.xx();
+    g.apeYY = lape.yy();
 
     auto toMicron = [&](float x) { return std::min(511, int(x * 1.e4f + 0.5f)); };
 

--- a/RecoLocalTracker/SiPixelRecHits/src/PixelCPEFast.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/PixelCPEFast.cc
@@ -210,10 +210,8 @@ void PixelCPEFast::fillParamsForGpu() {
       errorFromTemplates(p, cp, 20000.f);
       g.sigmax[ix] = toMicron(cp.sigmax);
       g.sigmax1[ix] = toMicron(cp.sx1);
-#ifdef EDM_ML_DEBUG
       LogDebug("PixelCPEFast") << "sigmax vs x " << i << ' ' << x << ' ' << cp.cotalpha << ' ' << int(g.sigmax[ix])
                                << ' ' << int(g.sigmax1[ix]) << ' ' << 10000.f * cp.sigmay << std::endl;
-#endif  // EDM_ML_DEBUG
     }
 #ifdef EDM_ML_DEBUG
     // sample yerr as function of position
@@ -283,10 +281,8 @@ void PixelCPEFast::fillParamsForGpu() {
       cp.cotbeta = std::copysign(ys * 150.f / (8.f * 285.f), aveCB);
       errorFromTemplates(p, cp, 20000.f);
       g.sigmay[iy] = toMicron(cp.sigmay);
-#ifdef EDM_ML_DEBUG
       LogDebug("PixelCPEFast") << "sigmax/sigmay " << i << ' ' << (ys + 4.f) / 8.f << ' ' << cp.cotalpha << '/'
                                << cp.cotbeta << ' ' << 10000.f * cp.sigmax << '/' << int(g.sigmay[iy]) << std::endl;
-#endif  // EDM_ML_DEBUG
     }
   }  // loop over det
 
@@ -327,7 +323,6 @@ void PixelCPEFast::fillParamsForGpu() {
   aveGeom.endCapZ[0] -= 1.5f;
   aveGeom.endCapZ[1] += 1.5f;
 
-#ifdef EDM_ML_DEBUG
   for (int jl = 0, nl = phase1PixelTopology::numberOfLaddersInBarrel; jl < nl; ++jl) {
     LogDebug("PixelCPEFast") << jl << ':' << aveGeom.ladderR[jl] << '/'
                              << std::sqrt(aveGeom.ladderX[jl] * aveGeom.ladderX[jl] +
@@ -336,7 +331,6 @@ void PixelCPEFast::fillParamsForGpu() {
                              << aveGeom.ladderMaxZ[jl] << '\n';
   }
   LogDebug("PixelCPEFast") << aveGeom.endCapZ[0] << ' ' << aveGeom.endCapZ[1];
-#endif  // EDM_ML_DEBUG
 
   // fill Layer and ladders geometry
   memcpy(layerGeometry_.layerStart, phase1PixelTopology::layerStart, sizeof(phase1PixelTopology::layerStart));

--- a/RecoPixelVertexing/PixelTriplets/plugins/BrokenLineFitOnGPU.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/BrokenLineFitOnGPU.h
@@ -75,12 +75,41 @@ __global__ void kernel_BLFastFit(Tuples const *__restrict__ foundNtuplets,
 
     // Prepare data structure
     auto const *hitId = foundNtuplets->begin(tkid);
+
+    // #define YERR_FROM_DC
+#ifdef YERR_FROM_DC
+    // try to compute more precise error in y
+    auto dx = hhp->xGlobal(hitId[hitsInFit - 1]) - hhp->xGlobal(hitId[0]);
+    auto dy = hhp->yGlobal(hitId[hitsInFit - 1]) - hhp->yGlobal(hitId[0]);
+    auto dz = hhp->zGlobal(hitId[hitsInFit - 1]) - hhp->zGlobal(hitId[0]);
+    float ux, uy, uz;
+#endif
     for (unsigned int i = 0; i < hitsInFit; ++i) {
       auto hit = hitId[i];
       float ge[6];
+#ifdef YERR_FROM_DC
+      auto const &dp = hhp->cpeParams().detParams(hhp->detectorIndex(hit));
+      auto status = hhp->status(hit);
+      int qbin = 4 - status.qBin;
+      assert(qbin >= 0 && qbin < 5);
+      bool nok = (status.isBigY | status.isOneY);
+      // compute cotanbeta and use it to recompute error
+      dp.frame.rotation().multiply(dx, dy, dz, ux, uy, uz);
+      auto cb = std::abs(uy / uz);
+      int bin = int(cb * (285.f / 150.f) * 8.f) - 4;
+      bin = std::max(0, std::min(15, bin));
+      float yerr = dp.sigmay[bin] * 1.e-4f;
+      yerr *= dp.yfact[qbin];  // inflate
+      yerr *= yerr;
+      yerr += dp.apeY;
+      yerr = nok ? hhp->yerrLocal(hit) : yerr;
+      dp.frame.toGlobal(hhp->xerrLocal(hit), 0, yerr, ge);
+#else
       hhp->cpeParams()
           .detParams(hhp->detectorIndex(hit))
           .frame.toGlobal(hhp->xerrLocal(hit), 0, hhp->yerrLocal(hit), ge);
+#endif
+
 #ifdef BL_DUMP_HITS
       if (dump) {
         printf("Hit global: %d: %d hits.col(%d) << %f,%f,%f\n",

--- a/RecoPixelVertexing/PixelTriplets/plugins/BrokenLineFitOnGPU.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/BrokenLineFitOnGPU.h
@@ -101,7 +101,7 @@ __global__ void kernel_BLFastFit(Tuples const *__restrict__ foundNtuplets,
       float yerr = dp.sigmay[bin] * 1.e-4f;
       yerr *= dp.yfact[qbin];  // inflate
       yerr *= yerr;
-      yerr += dp.apeY;
+      yerr += dp.apeYY;
       yerr = nok ? hhp->yerrLocal(hit) : yerr;
       dp.frame.toGlobal(hhp->xerrLocal(hit), 0, yerr, ge);
 #else

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernelsImpl.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernelsImpl.h
@@ -447,14 +447,12 @@ __global__ void kernel_classifyTracks(HitContainer const *__restrict__ tuples,
     quality[it] = pixelTrack::Quality::strict;
 
     // compute a pT-dependent chi2 cut
-    // default parameters:
-    //   - chi2MaxPt = 10 GeV
-    //   - chi2Coeff = { 0.68177776, 0.74609577, -0.08035491, 0.00315399 }
-    //   - chi2Scale = 30 for broken line fit, 45 for Riemann fit
+
     // (see CAHitNtupletGeneratorGPU.cc)
-    float pt = std::min<float>(tracks->pt(it), cuts.chi2MaxPt);
-    float chi2Cut = cuts.chi2Scale *
-                    (cuts.chi2Coeff[0] + pt * (cuts.chi2Coeff[1] + pt * (cuts.chi2Coeff[2] + pt * cuts.chi2Coeff[3])));
+    //float pt = std::min<float>(tracks->pt(it), cuts.chi2MaxPt);
+    //float chi2Cut = cuts.chi2Scale *
+    //                (cuts.chi2Coeff[0] + pt * (cuts.chi2Coeff[1] + pt * (cuts.chi2Coeff[2] + pt * cuts.chi2Coeff[3])));
+    float chi2Cut = cuts.chi2Scale;
     // above number were for Quads not normalized so for the time being just multiple by ndof for Quads  (triplets to be understood)
     if (3.f * tracks->chi2(it) >= chi2Cut) {
 #ifdef NTUPLE_FIT_DEBUG

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorOnGPU.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorOnGPU.cc
@@ -163,9 +163,9 @@ void CAHitNtupletGeneratorOnGPU::fillDescriptions(edm::ParameterSetDescription& 
   trackQualityCuts.add<double>("chi2MaxPt", 10.)->setComment("max pT used to determine the pT-dependent chi2 cut");
   trackQualityCuts.add<std::vector<double>>("chi2Coeff", {1., 0., 0., 0.})
       ->setComment("Polynomial coefficients to derive the pT-dependent chi2 cut");
-  trackQualityCuts.add<double>("chi2Scale", 16.)
+  trackQualityCuts.add<double>("chi2Scale", 25.)
       ->setComment(
-          "Factor to multiply the pT-dependent chi2 cut (currently: 16 for the broken line fit, - for the Riemann "
+          "Factor to multiply the pT-dependent chi2 cut (currently: 25 for the broken line fit, - for the Riemann "
           "fit)");
   trackQualityCuts.add<double>("tripletMinPt", 0.5)->setComment("Min pT for triplets, in GeV");
   trackQualityCuts.add<double>("tripletMaxTip", 0.3)->setComment("Max |Tip| for triplets, in cm");

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorOnGPU.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorOnGPU.cc
@@ -161,11 +161,11 @@ void CAHitNtupletGeneratorOnGPU::fillDescriptions(edm::ParameterSetDescription& 
 
   edm::ParameterSetDescription trackQualityCuts;
   trackQualityCuts.add<double>("chi2MaxPt", 10.)->setComment("max pT used to determine the pT-dependent chi2 cut");
-  trackQualityCuts.add<std::vector<double>>("chi2Coeff", {0.68177776, 0.74609577, -0.08035491, 0.00315399})
+  trackQualityCuts.add<std::vector<double>>("chi2Coeff", {1., 0., 0., 0.})
       ->setComment("Polynomial coefficients to derive the pT-dependent chi2 cut");
-  trackQualityCuts.add<double>("chi2Scale", 30.)
+  trackQualityCuts.add<double>("chi2Scale", 16.)
       ->setComment(
-          "Factor to multiply the pT-dependent chi2 cut (currently: 30 for the broken line fit, 45 for the Riemann "
+          "Factor to multiply the pT-dependent chi2 cut (currently: 16 for the broken line fit, - for the Riemann "
           "fit)");
   trackQualityCuts.add<double>("tripletMinPt", 0.5)->setComment("Min pT for triplets, in GeV");
   trackQualityCuts.add<double>("tripletMaxTip", 0.3)->setComment("Max |Tip| for triplets, in cm");


### PR DESCRIPTION
#### PR description:

##### By @VinInn at [cms-patatrack/cmssw #528](https://github.com/cms-patatrack/cmssw/pull/528)

This PR improves the error estimation in CPEFast used on GPU providing a simple and fast parameterization in terms of charge, position in x and size in y.

The result is very close to what CPEGeneric provides w/o track-angle (actually a bit more accurate thanks to the estimation of the y-error using the cluster size in y (itself improved with information from the charge unbalance).

It includes also code to recompute y-error using the track-able prior to fit (off by default)

The main effect is a reduction and flattening of the chi2 and a reduction of the tails of the pulls.
Given this improvements I have (for the the being) simplified the cut in chi2 to a single value.

In my opinion further tuning of eff vs fakerate shall be implemented elsewhere (eventually in client code)
It would be also useful to test it against some Simulation with "realistic" APE (such those in the "Legacy Reprocessing")

#### PR validation:

At http://aczirkos.web.cern.ch/aczirkos/cpefast_wo_track_angle_10_06_2021/new/

### Summary

`plots/plots_pixel_pixelHP/effandfakePtEtaPhi`
![effandfakePtEtaPhi (1)-1](https://user-images.githubusercontent.com/33939088/123966562-d58c9400-d9b5-11eb-9448-0795d1f871d2.png)


## Prerequisites
Run on a GPU equipped machine. This validation was run on the cmg-gpu1080 machine, [see this website for more information](https://patatrack.web.cern.ch/patatrack/private/systems/cmg-gpu1080.html).

### before
Benchmark release:
`CMSSW_12_0_X_2021-06-22-2300`

### after

branch [cpefast_wo_track_angle_30_06_2021](https://github.com/czangela/cmssw/tree/cpefast_wo_track_angle_30_06_2021)

The validation compares these two versions, which have the labels before and after in the plots.

## Validation
### 2018

#### Dataset, filelist:
```sh
das_client --limit 0 --query "file dataset=/RelValTTbar_13/CMSSW_11_2_0_pre7-PU25ns_112X_upgrade2018_realistic_v3-v1/GEN-SIM-DIGI-RAW" > files.txt
```
#### Steps 3 and 4
```sh
# step3
cmsDriver.py step3  --conditions auto:phase1_2018_realistic -n 1000 --era Run2_2018 --eventcontent RECOSIM,DQM --procModifiers pixelNtupletFit,gpu -s RAW2DIGI:RawToDigi_pixelOnly,RECO:reconstruction_pixelTrackingOnly,VALIDATION:@pixelTrackingOnlyValidation,DQM:@pixelTrackingOnlyDQM --datatier GEN-SIM-RECO,DQMIO --geometry DB:Extended --filein filelist:files.txt  --fileout file:step3.root --nThreads=8 > step3.log  2>&1

# step4
cmsDriver.py step4  --conditions auto:phase1_2018_realistic -s HARVESTING:@trackingOnlyValidation+@pixelTrackingOnlyDQM --scenario pp --filetype DQM --geometry DB:Extended --era Run2_2018 --mc  -n 1000 --filein file:step3_inDQM.root --fileout file:step4.root  > step4.log  2>&1
```

### 2021

#### Dataset, filelist:
```sh
das_client --limit 0 --query "file dataset=/RelValTTbar_14TeV/CMSSW_12_0_0_pre2-PU_113X_mcRun3_2021_realistic_v10-v1/GEN-SIM-DIGI-RAW" > files.txt
```
#### Steps 3 and 4
```sh
# step3
cmsDriver.py step3 --conditions auto:phase1_2021_realistic -n 1000 --era Run3 --eventcontent RECOSIM,DQM --procModifiers pixelNtupletFit,gpu -s RAW2DIGI:RawToDigi_pixelOnly,RECO:reconstruction_pixelTrackingOnly,VALIDATION:@pixelTrackingOnlyValidation,DQM:@pixelTrackingOnlyDQM --datatier GEN-SIM-RECO,DQMIO --geometry DB:Extended --filein filelist:files.txt --nThreads=8 > step3.log 2>&1

# step4
cmsDriver.py step4  --conditions auto:phase1_2021_realistic -s HARVESTING:@trackingOnlyValidation+@pixelTrackingOnlyDQM --scenario pp --filetype DQM --geometry DB:Extended --era Run3 --mc  -n 1000  --filein file:step3_RAW2DIGI_RECO_VALIDATION_DQM_inDQM.root --fileout file:step4.root > step4.log 2>&1
```

### 2024

#### Dataset, filelist:
```sh
das_client --limit 0 --query "file dataset=/RelValTTbar_14TeV/CMSSW_11_3_0-PU_113X_mcRun3_2024_realistic_v8_rsb-v1/GEN-SIM-DIGI-RAW" > files.txt
```
#### Steps 3 and 4
```sh
# step3
cmsDriver.py step3 --conditions auto:phase1_2024_realistic -n 1000 --era Run3 --eventcontent RECOSIM,DQM --procModifiers pixelNtupletFit,gpu -s RAW2DIGI:RawToDigi_pixelOnly,RECO:reconstruction_pixelTrackingOnly,VALIDATION:@pixelTrackingOnlyValidation,DQM:@pixelTrackingOnlyDQM --datatier GEN-SIM-RECO,DQMIO --geometry DB:Extended --filein filelist:files.txt --nThreads=8 > step3.log 2>&1

# step4
cmsDriver.py step4  --conditions auto:phase1_2024_realistic -s HARVESTING:@trackingOnlyValidation+@pixelTrackingOnlyDQM --scenario pp --filetype DQM --geometry DB:Extended --era Run3 --mc  -n 1000  --filein file:step3_RAW2DIGI_RECO_VALIDATION_DQM_inDQM.root --fileout file:step4.root > step4.log 2>&1
```

## Compare DQM files
Use http://musich.web.cern.ch/musich/forAdinda/multi_loopAndPlot.C

Open interactive root session and compile file

```sh
root -b
.L multi_LoopAndPlot.C++
multi_loopAndPlot("file1.root=before,file2.root=after,false)
```

MTV:
```sh
makeTrackValidationPlots.py before.root after.root
```

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

