### PR TITLE
Add D76 prod-like to relval_2026

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_2026.py
+++ b/Configuration/PyReleaseValidation/python/relval_2026.py
@@ -25,6 +25,7 @@ numWFIB.extend([31434.0]) #2026D68
 numWFIB.extend([32234.0]) #2026D70
 numWFIB.extend([34634.0]) #2026D76
 numWFIB.extend([34834.999]) #2026D76 premixing combined stage1+stage2 (ttbar+PU50 for PR test)
+numWFIB.extend([34634.21,34834.21,34834.9921]) #2026D76 prodlike, prodlike PU, prodlike premix stage1+stage2
 numWFIB.extend([35034.0]) #2026D77
 numWFIB.extend([35434.0]) #2026D78
 numWFIB.extend([35834.0]) #2026D79

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -3262,7 +3262,7 @@ defaultDataSets['2021Design']='CMSSW_11_3_0_pre4-113X_mcRun3_2021_design_v5-v'
 defaultDataSets['2023']='CMSSW_11_3_0_pre4-113X_mcRun3_2023_realistic_v5-v'
 defaultDataSets['2024']='CMSSW_11_3_0_pre4-113X_mcRun3_2024_realistic_v5-v'
 defaultDataSets['2026D49']='CMSSW_11_3_0_pre4-113X_mcRun4_realistic_v4_2026D49noPU_rsb-v'
-defaultDataSets['2026D76']='CMSSW_12_0_0_pre3-113X_mcRun4_realistic_v7_2026D76noPU-v'
+defaultDataSets['2026D76']='CMSSW_11_3_0_pre3-113X_mcRun4_realistic_v3_2026D76noPU-v'
 
 puDataSets = {}
 for key, value in defaultDataSets.items(): puDataSets[key+'PU'] = value

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -3262,7 +3262,7 @@ defaultDataSets['2021Design']='CMSSW_11_3_0_pre4-113X_mcRun3_2021_design_v5-v'
 defaultDataSets['2023']='CMSSW_11_3_0_pre4-113X_mcRun3_2023_realistic_v5-v'
 defaultDataSets['2024']='CMSSW_11_3_0_pre4-113X_mcRun3_2024_realistic_v5-v'
 defaultDataSets['2026D49']='CMSSW_11_3_0_pre4-113X_mcRun4_realistic_v4_2026D49noPU_rsb-v'
-defaultDataSets['2026D76']='CMSSW_11_3_0_pre3-113X_mcRun4_realistic_v3_2026D76noPU-v'
+defaultDataSets['2026D76']='CMSSW_12_0_0_pre3-113X_mcRun4_realistic_v7_2026D76noPU-v'
 
 puDataSets = {}
 for key, value in defaultDataSets.items(): puDataSets[key+'PU'] = value


### PR DESCRIPTION
#### PR description:
This PR is to add D76 prod-like workflows to relval_2026. One of them, 34834.32 is expected to be used for profiling.

#### PR validation:
runTheMatrix.py --what 2026 -l 34634.21,34834.21,34834.9921 --wm init

#### if this PR is a backport please specify the original PR and why you need to backport that PR:
Not a backport, and no need for backport.
