### PR TITLE
Fix crash in ECAL local reco on GPU if ECAL is not in the run

### DIFF
--- a/EventFilter/EcalRawToDigi/plugins/EcalRawToDigiGPU.cc
+++ b/EventFilter/EcalRawToDigi/plugins/EcalRawToDigiGPU.cc
@@ -134,8 +134,11 @@ void EcalRawToDigiGPU::acquire(edm::Event const& event,
     ++counter;
   }
 
-  ecal::raw::entryPoint(
-      inputCPU, inputGPU, outputGPU_, scratchGPU, outputCPU_, conditions, ctx.stream(), counter, currentCummOffset);
+  // unpack if at least one FED has data
+  if (counter > 0) {
+    ecal::raw::entryPoint(
+        inputCPU, inputGPU, outputGPU_, scratchGPU, outputCPU_, conditions, ctx.stream(), counter, currentCummOffset);
+  }
 }
 
 void EcalRawToDigiGPU::produce(edm::Event& event, edm::EventSetup const& setup) {

--- a/RecoLocalCalo/EcalRecProducers/plugins/EcalRecHitProducerGPU.cc
+++ b/RecoLocalCalo/EcalRecProducers/plugins/EcalRecHitProducerGPU.cc
@@ -164,6 +164,10 @@ void EcalRecHitProducerGPU::acquire(edm::Event const& event,
   neb_ = ebUncalibRecHits.size;
   nee_ = eeUncalibRecHits.size;
 
+  // stop here if there are no uncalibRecHits
+  if (neb_ + nee_ == 0)
+    return;
+
   if ((neb_ > configParameters_.maxNumberHitsEB) || (nee_ > configParameters_.maxNumberHitsEE)) {
     edm::LogError("EcalRecHitProducerGPU")
         << "max number of channels exceeded. See options 'maxNumberHitsEB and maxNumberHitsEE' ";

--- a/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitProducerGPU.cc
+++ b/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitProducerGPU.cc
@@ -207,6 +207,10 @@ void EcalUncalibRecHitProducerGPU::acquire(edm::Event const& event,
   neb_ = ebDigis.size;
   nee_ = eeDigis.size;
 
+  // stop here if there are no digis
+  if (neb_ + nee_ == 0)
+    return;
+
   if ((neb_ > configParameters_.maxNumberHitsEB) || (nee_ > configParameters_.maxNumberHitsEE)) {
     edm::LogError("EcalUncalibRecHitProducerGPU")
         << "max number of channels exceeded. See options 'maxNumberHitsEB and maxNumberHitsEE' ";


### PR DESCRIPTION
#### PR description:

This should fix crashes of the ECAL local reconstruction on GPU if the ECAL is not in the run as described in #34197 
The changes to EcalRecHitProducerGPU.cc were not needed to fix the crash since currently the RecHits are produced on CPU only by default. However, the protection against empty inputs was added nevertheless to avoid the same issue in the future.

#### PR validation:

Processing of run 342110, for which ECAL was not in the run, does not crash anymore with these changes.

