### PR TITLE
modified the various (ES)producers for express stream and HLT

### DIFF
--- a/RecoVertex/BeamSpotProducer/plugins/BeamSpotOnlineProducer.cc
+++ b/RecoVertex/BeamSpotProducer/plugins/BeamSpotOnlineProducer.cc
@@ -182,7 +182,7 @@ void BeamSpotOnlineProducer::produce(Event& iEvent, const EventSetup& iSetup) {
         fallBackToDB = true;
       }
       double r2 = spotOnline.x() * spotOnline.x() + spotOnline.y() * spotOnline.y();
-      if (fabs(spotOnline.z()) >= theMaxZ || r2 >= theMaxR2) {
+      if (std::abs(spotOnline.z()) >= theMaxZ || r2 >= theMaxR2) {
         if (shoutMODE) {
           edm::LogError("BeamSpotFromDB")
               << "Online Beam Spot producer falls back to DB value because the scaler values are too big to be true :"

--- a/RecoVertex/BeamSpotProducer/plugins/BeamSpotOnlineProducer.cc
+++ b/RecoVertex/BeamSpotProducer/plugins/BeamSpotOnlineProducer.cc
@@ -96,8 +96,8 @@ void BeamSpotOnlineProducer::produce(Event& iEvent, const EventSetup& iSetup) {
     shoutMODE = true;
   }
   bool fallBackToDB = false;
-  if (useTransientRecord_) {    
-    auto const& spotDB = iSetup.getData(beamTransientToken_);        
+  if (useTransientRecord_) {
+    auto const& spotDB = iSetup.getData(beamTransientToken_);
     if (spotDB.GetBeamType() != 2) {
       if (shoutMODE) {
         edm::LogWarning("BeamSpotFromDB")
@@ -141,7 +141,6 @@ void BeamSpotOnlineProducer::produce(Event& iEvent, const EventSetup& iSetup) {
 
     // product is a reco::BeamSpot object
     auto result = std::make_unique<reco::BeamSpot>();
-    
 
     if (!handleScaler->empty()) {
       // get one element
@@ -165,8 +164,8 @@ void BeamSpotOnlineProducer::produce(Event& iEvent, const EventSetup& iSetup) {
       if (theSetSigmaZ > 0)
         sigmaZ = theSetSigmaZ;
 
-      aSpot = reco::BeamSpot(apoint, sigmaZ, spotOnline.dxdz(), f * spotOnline.dydz(), spotOnline.width_x(), matrix);      
-      
+      aSpot = reco::BeamSpot(apoint, sigmaZ, spotOnline.dxdz(), f * spotOnline.dydz(), spotOnline.width_x(), matrix);
+
       aSpot.setBeamWidthY(spotOnline.width_y());
       aSpot.setEmittanceX(0.);
       aSpot.setEmittanceY(0.);
@@ -181,7 +180,7 @@ void BeamSpotOnlineProducer::produce(Event& iEvent, const EventSetup& iSetup) {
               << "Online Beam Spot producer falls back to DB value because the scaler values are zero ";
         }
         fallBackToDB = true;
-      }      
+      }
       double r2 = spotOnline.x() * spotOnline.x() + spotOnline.y() * spotOnline.y();
       if (fabs(spotOnline.z()) >= theMaxZ || r2 >= theMaxR2) {
         if (shoutMODE) {
@@ -190,7 +189,7 @@ void BeamSpotOnlineProducer::produce(Event& iEvent, const EventSetup& iSetup) {
               << spotOnline.x() << " " << spotOnline.y() << " " << spotOnline.z();
         }
         fallBackToDB = true;
-      }      
+      }
     } else {
       //empty online beamspot collection: FED data was empty
       //the error should probably have been send at unpacker level
@@ -220,7 +219,7 @@ void BeamSpotOnlineProducer::produce(Event& iEvent, const EventSetup& iSetup) {
     aSpot.setbetaStar(spotDB->GetBetaStar());
     aSpot.setType(reco::BeamSpot::Tracker);
   }
-  
+
   *result = aSpot;
 
   iEvent.put(std::move(result));

--- a/RecoVertex/BeamSpotProducer/plugins/BeamSpotOnlineProducer.cc
+++ b/RecoVertex/BeamSpotProducer/plugins/BeamSpotOnlineProducer.cc
@@ -5,6 +5,7 @@
 
 
  author: Francisco Yumiceva, Fermilab (yumiceva@fnal.gov)
+ modified by: Simone Gennai, INFN MIB
 
 
 ________________________________________________________________**/
@@ -15,6 +16,9 @@ ________________________________________________________________**/
 #include "DataFormats/Scalers/interface/BeamSpotOnline.h"
 #include "CondFormats/BeamSpotObjects/interface/BeamSpotObjects.h"
 #include "CondFormats/DataRecord/interface/BeamSpotObjectsRcd.h"
+#include "CondFormats/DataRecord/interface/BeamSpotTransientObjectsRcd.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
@@ -31,13 +35,17 @@ public:
   /// produce a beam spot class
   void produce(edm::Event& iEvent, const edm::EventSetup& iSetup) override;
 
+  ///Fill descriptor
+  static void fillDescriptions(edm::ConfigurationDescriptions& iDesc);
 private:
   const bool changeFrame_;
   const double theMaxZ, theSetSigmaZ;
   double theMaxR2;
+  const bool useTransientRecord_;
   const edm::EDGetTokenT<BeamSpotOnlineCollection> scalerToken_;
   const edm::EDGetTokenT<L1GlobalTriggerEvmReadoutRecord> l1GtEvmReadoutRecordToken_;
   const edm::ESGetToken<BeamSpotObjects, BeamSpotObjectsRcd> beamToken_;
+  const edm::ESGetToken<BeamSpotObjects, BeamSpotTransientObjectsRcd> beamTransientToken_;
 
   const unsigned int theBeamShoutMode;
 };
@@ -48,17 +56,35 @@ BeamSpotOnlineProducer::BeamSpotOnlineProducer(const ParameterSet& iconf)
     : changeFrame_(iconf.getParameter<bool>("changeToCMSCoordinates")),
       theMaxZ(iconf.getParameter<double>("maxZ")),
       theSetSigmaZ(iconf.getParameter<double>("setSigmaZ")),
+      useTransientRecord_(iconf.getParameter<bool>("useTransientRecord")),
       scalerToken_(consumes<BeamSpotOnlineCollection>(iconf.getParameter<InputTag>("src"))),
       l1GtEvmReadoutRecordToken_(consumes<L1GlobalTriggerEvmReadoutRecord>(iconf.getParameter<InputTag>("gtEvmLabel"))),
-      beamToken_(esConsumes<BeamSpotObjects, BeamSpotObjectsRcd>()),
+      beamToken_(esConsumes<BeamSpotObjects, BeamSpotObjectsRcd>()),      
+      beamTransientToken_(esConsumes<BeamSpotObjects, BeamSpotTransientObjectsRcd>()),      
       theBeamShoutMode(iconf.getUntrackedParameter<unsigned int>("beamMode", 11)) {
   theMaxR2 = iconf.getParameter<double>("maxRadius");
   theMaxR2 *= theMaxR2;
-
+  
   produces<reco::BeamSpot>();
 }
 
+void BeamSpotOnlineProducer::fillDescriptions(edm::ConfigurationDescriptions& iDesc) {
+  edm::ParameterSetDescription ps;
+  ps.add<bool>("changeToCMSCoordinates",false);
+  ps.add<double>("maxZ",40.);
+  ps.add<double>("setSigmaZ",-1.);
+  ps.addUntracked<unsigned int>("beamMode", 11);
+  ps.add<InputTag>("src",InputTag("hltScalersRawToDigi"));
+  ps.add<InputTag>("gtEvmLabel",InputTag(""));
+  ps.add<double>("maxRadius",2.0);
+  ps.add<bool>("useTransientRecord",true);
+  iDesc.addWithDefaultLabel(ps);
+}
+
 void BeamSpotOnlineProducer::produce(Event& iEvent, const EventSetup& iSetup) {
+  // product is a reco::BeamSpot object
+  auto result = std::make_unique<reco::BeamSpot>();
+  reco::BeamSpot aSpot;
   //shout MODE only in stable beam
   bool shoutMODE = false;
   edm::Handle<L1GlobalTriggerEvmReadoutRecord> gtEvmReadoutRecord;
@@ -66,76 +92,108 @@ void BeamSpotOnlineProducer::produce(Event& iEvent, const EventSetup& iSetup) {
     if (gtEvmReadoutRecord->gtfeWord().beamMode() == theBeamShoutMode)
       shoutMODE = true;
   } else {
-    shoutMODE = true;
+      shoutMODE = true;
   }
-
-  // get scalar collection
-  Handle<BeamSpotOnlineCollection> handleScaler;
-  iEvent.getByToken(scalerToken_, handleScaler);
-
-  // beam spot scalar object
-  BeamSpotOnline spotOnline;
-
-  // product is a reco::BeamSpot object
-  auto result = std::make_unique<reco::BeamSpot>();
-
-  reco::BeamSpot aSpot;
-
   bool fallBackToDB = false;
-  if (!handleScaler->empty()) {
-    // get one element
-    spotOnline = *(handleScaler->begin());
+  if (useTransientRecord_){
+      auto const& spotDB = iSetup.getData(beamTransientToken_);  
 
-    // in case we need to switch to LHC reference frame
-    // ignore for the moment rotations, and translations
-    double f = 1.;
-    if (changeFrame_)
-      f = -1.;
+      if (spotDB.GetBeamType() != 2){            
+       if (shoutMODE) {
+          edm::LogWarning("BeamSpotFromDB")
+              << "Online Beam Spot producer falls back to DB value because the ESProducer returned a fake beamspot ";
+        }
+        fallBackToDB = true;
+      }else{
+        // translate from BeamSpotObjects to reco::BeamSpot
+        reco::BeamSpot::Point apoint(spotDB.GetX(), spotDB.GetY(), spotDB.GetZ());
 
-    reco::BeamSpot::Point apoint(f * spotOnline.x(), spotOnline.y(), f * spotOnline.z());
+        reco::BeamSpot::CovarianceMatrix matrix;
+        for (int i = 0; i < 7; ++i) {
+          for (int j = 0; j < 7; ++j) {
+            matrix(i, j) = spotDB.GetCovariance(i, j);
+          }
+        }
+        double sigmaZ = spotDB.GetSigmaZ();
+        if (theSetSigmaZ > 0)
+          sigmaZ = theSetSigmaZ;
 
-    reco::BeamSpot::CovarianceMatrix matrix;
-    matrix(0, 0) = spotOnline.err_x() * spotOnline.err_x();
-    matrix(1, 1) = spotOnline.err_y() * spotOnline.err_y();
-    matrix(2, 2) = spotOnline.err_z() * spotOnline.err_z();
-    matrix(3, 3) = spotOnline.err_sigma_z() * spotOnline.err_sigma_z();
+        // this assume beam width same in x and y
+        aSpot = reco::BeamSpot(
+            apoint, sigmaZ, spotDB.Getdxdz(), spotDB.Getdydz(), spotDB.GetBeamWidthX(), matrix);
+            aSpot.setBeamWidthY(spotDB.GetBeamWidthY());
+            aSpot.setEmittanceX(spotDB.GetEmittanceX());
+            aSpot.setEmittanceY(spotDB.GetEmittanceY());
+            aSpot.setbetaStar(spotDB.GetBetaStar());
+            aSpot.setType(reco::BeamSpot::Tracker);
+      }   
+  }else{   
+    // get scalar collection
+    Handle<BeamSpotOnlineCollection> handleScaler;
+    iEvent.getByToken(scalerToken_, handleScaler);
 
-    double sigmaZ = spotOnline.sigma_z();
-    if (theSetSigmaZ > 0)
-      sigmaZ = theSetSigmaZ;
+    // beam spot scalar object
+    BeamSpotOnline spotOnline;
 
-    aSpot = reco::BeamSpot(apoint, sigmaZ, spotOnline.dxdz(), f * spotOnline.dydz(), spotOnline.width_x(), matrix);
+    // product is a reco::BeamSpot object
+    auto result = std::make_unique<reco::BeamSpot>();
 
-    aSpot.setBeamWidthY(spotOnline.width_y());
-    aSpot.setEmittanceX(0.);
-    aSpot.setEmittanceY(0.);
-    aSpot.setbetaStar(0.);
-    aSpot.setType(reco::BeamSpot::LHC);  // flag value from scalars
+    reco::BeamSpot aSpot;
 
-    // check if we have a valid beam spot fit result from online DQM
-    if (spotOnline.x() == 0 && spotOnline.y() == 0 && spotOnline.z() == 0 && spotOnline.width_x() == 0 &&
-        spotOnline.width_y() == 0) {
-      if (shoutMODE) {
-        edm::LogWarning("BeamSpotFromDB")
-            << "Online Beam Spot producer falls back to DB value because the scaler values are zero ";
+    if (!handleScaler->empty()) {
+      // get one element
+      spotOnline = *(handleScaler->begin());
+
+      // in case we need to switch to LHC reference frame
+      // ignore for the moment rotations, and translations
+      double f = 1.;
+      if (changeFrame_)
+        f = -1.;
+
+      reco::BeamSpot::Point apoint(f * spotOnline.x(), spotOnline.y(), f * spotOnline.z());
+
+      reco::BeamSpot::CovarianceMatrix matrix;
+      matrix(0, 0) = spotOnline.err_x() * spotOnline.err_x();
+      matrix(1, 1) = spotOnline.err_y() * spotOnline.err_y();
+      matrix(2, 2) = spotOnline.err_z() * spotOnline.err_z();
+      matrix(3, 3) = spotOnline.err_sigma_z() * spotOnline.err_sigma_z();
+
+      double sigmaZ = spotOnline.sigma_z();
+      if (theSetSigmaZ > 0)
+        sigmaZ = theSetSigmaZ;
+
+      aSpot = reco::BeamSpot(apoint, sigmaZ, spotOnline.dxdz(), f * spotOnline.dydz(), spotOnline.width_x(), matrix);
+
+      aSpot.setBeamWidthY(spotOnline.width_y());
+      aSpot.setEmittanceX(0.);
+      aSpot.setEmittanceY(0.);
+      aSpot.setbetaStar(0.);
+      aSpot.setType(reco::BeamSpot::LHC);  // flag value from scalars
+
+      // check if we have a valid beam spot fit result from online DQM
+      if (spotOnline.x() == 0 && spotOnline.y() == 0 && spotOnline.z() == 0 && spotOnline.width_x() == 0 &&
+          spotOnline.width_y() == 0) {
+        if (shoutMODE) {
+          edm::LogWarning("BeamSpotFromDB")
+              << "Online Beam Spot producer falls back to DB value because the scaler values are zero ";
+        }
+        fallBackToDB = true;
       }
+      double r2 = spotOnline.x() * spotOnline.x() + spotOnline.y() * spotOnline.y();
+      if (fabs(spotOnline.z()) >= theMaxZ || r2 >= theMaxR2) {
+        if (shoutMODE) {
+          edm::LogError("BeamSpotFromDB")
+              << "Online Beam Spot producer falls back to DB value because the scaler values are too big to be true :"
+              << spotOnline.x() << " " << spotOnline.y() << " " << spotOnline.z();
+        }
+        fallBackToDB = true;
+      }
+    } else {
+      //empty online beamspot collection: FED data was empty
+      //the error should probably have been send at unpacker level
       fallBackToDB = true;
     }
-    double r2 = spotOnline.x() * spotOnline.x() + spotOnline.y() * spotOnline.y();
-    if (fabs(spotOnline.z()) >= theMaxZ || r2 >= theMaxR2) {
-      if (shoutMODE) {
-        edm::LogError("BeamSpotFromDB")
-            << "Online Beam Spot producer falls back to DB value because the scaler values are too big to be true :"
-            << spotOnline.x() << " " << spotOnline.y() << " " << spotOnline.z();
-      }
-      fallBackToDB = true;
-    }
-  } else {
-    //empty online beamspot collection: FED data was empty
-    //the error should probably have been send at unpacker level
-    fallBackToDB = true;
   }
-
   if (fallBackToDB) {
     edm::ESHandle<BeamSpotObjects> beamhandle = iSetup.getHandle(beamToken_);
     const BeamSpotObjects* spotDB = beamhandle.product();
@@ -159,7 +217,6 @@ void BeamSpotOnlineProducer::produce(Event& iEvent, const EventSetup& iSetup) {
     aSpot.setbetaStar(spotDB->GetBetaStar());
     aSpot.setType(reco::BeamSpot::Tracker);
   }
-
   *result = aSpot;
 
   iEvent.put(std::move(result));

--- a/RecoVertex/BeamSpotProducer/plugins/BeamSpotOnlineProducer.cc
+++ b/RecoVertex/BeamSpotProducer/plugins/BeamSpotOnlineProducer.cc
@@ -96,9 +96,8 @@ void BeamSpotOnlineProducer::produce(Event& iEvent, const EventSetup& iSetup) {
     shoutMODE = true;
   }
   bool fallBackToDB = false;
-  if (useTransientRecord_) {
-    auto const& spotDB = iSetup.getData(beamTransientToken_);
-
+  if (useTransientRecord_) {    
+    auto const& spotDB = iSetup.getData(beamTransientToken_);        
     if (spotDB.GetBeamType() != 2) {
       if (shoutMODE) {
         edm::LogWarning("BeamSpotFromDB")
@@ -142,8 +141,7 @@ void BeamSpotOnlineProducer::produce(Event& iEvent, const EventSetup& iSetup) {
 
     // product is a reco::BeamSpot object
     auto result = std::make_unique<reco::BeamSpot>();
-
-    reco::BeamSpot aSpot;
+    
 
     if (!handleScaler->empty()) {
       // get one element
@@ -167,8 +165,8 @@ void BeamSpotOnlineProducer::produce(Event& iEvent, const EventSetup& iSetup) {
       if (theSetSigmaZ > 0)
         sigmaZ = theSetSigmaZ;
 
-      aSpot = reco::BeamSpot(apoint, sigmaZ, spotOnline.dxdz(), f * spotOnline.dydz(), spotOnline.width_x(), matrix);
-
+      aSpot = reco::BeamSpot(apoint, sigmaZ, spotOnline.dxdz(), f * spotOnline.dydz(), spotOnline.width_x(), matrix);      
+      
       aSpot.setBeamWidthY(spotOnline.width_y());
       aSpot.setEmittanceX(0.);
       aSpot.setEmittanceY(0.);
@@ -183,7 +181,7 @@ void BeamSpotOnlineProducer::produce(Event& iEvent, const EventSetup& iSetup) {
               << "Online Beam Spot producer falls back to DB value because the scaler values are zero ";
         }
         fallBackToDB = true;
-      }
+      }      
       double r2 = spotOnline.x() * spotOnline.x() + spotOnline.y() * spotOnline.y();
       if (fabs(spotOnline.z()) >= theMaxZ || r2 >= theMaxR2) {
         if (shoutMODE) {
@@ -192,7 +190,7 @@ void BeamSpotOnlineProducer::produce(Event& iEvent, const EventSetup& iSetup) {
               << spotOnline.x() << " " << spotOnline.y() << " " << spotOnline.z();
         }
         fallBackToDB = true;
-      }
+      }      
     } else {
       //empty online beamspot collection: FED data was empty
       //the error should probably have been send at unpacker level
@@ -222,6 +220,7 @@ void BeamSpotOnlineProducer::produce(Event& iEvent, const EventSetup& iSetup) {
     aSpot.setbetaStar(spotDB->GetBetaStar());
     aSpot.setType(reco::BeamSpot::Tracker);
   }
+  
   *result = aSpot;
 
   iEvent.put(std::move(result));

--- a/RecoVertex/BeamSpotProducer/plugins/BeamSpotOnlineProducer.cc
+++ b/RecoVertex/BeamSpotProducer/plugins/BeamSpotOnlineProducer.cc
@@ -78,7 +78,7 @@ void BeamSpotOnlineProducer::fillDescriptions(edm::ConfigurationDescriptions& iD
   ps.add<InputTag>("src", InputTag("hltScalersRawToDigi"));
   ps.add<InputTag>("gtEvmLabel", InputTag(""));
   ps.add<double>("maxRadius", 2.0);
-  ps.add<bool>("useTransientRecord", true);
+  ps.add<bool>("useTransientRecord", false);
   iDesc.addWithDefaultLabel(ps);
 }
 
@@ -106,7 +106,6 @@ void BeamSpotOnlineProducer::produce(Event& iEvent, const EventSetup& iSetup) {
       }
       fallBackToDB = true;
     } else {
-      
       // translate from BeamSpotObjects to reco::BeamSpot
       // in case we need to switch to LHC reference frame
       // ignore for the moment rotations, and translations

--- a/RecoVertex/BeamSpotProducer/plugins/OnlineBeamSpotESProducer.cc
+++ b/RecoVertex/BeamSpotProducer/plugins/OnlineBeamSpotESProducer.cc
@@ -42,7 +42,7 @@ OnlineBeamSpotESProducer::OnlineBeamSpotESProducer(const edm::ParameterSet& p) {
   fakeBS_.SetBeamWidthX(0.1);
   fakeBS_.SetBeamWidthY(0.1);
   fakeBS_.SetSigmaZ(15.);
-  fakeBS_.SetPosition(0., 0., 0.);
+  fakeBS_.SetPosition(0.0001, 0.0001, 0.0001);
   fakeBS_.SetType(-1);
 
   bsHLTToken_ = cc.consumesFrom<BeamSpotOnlineObjects, BeamSpotOnlineHLTObjectsRcd>();
@@ -56,19 +56,19 @@ void OnlineBeamSpotESProducer::fillDescriptions(edm::ConfigurationDescriptions& 
 
 const BeamSpotOnlineObjects* OnlineBeamSpotESProducer::compareBS(const BeamSpotOnlineObjects* bs1,
                                                                  const BeamSpotOnlineObjects* bs2) {
-  //Random logic so far ...
-  if (bs1->GetSigmaZ() - 0.0001 < bs2->GetSigmaZ()) {  //just temporary for debugging
-    if (bs1->GetSigmaZ() > 5.) {
+  //Random logic so far ...  
+  if (bs1->GetSigmaZ() - 0.0001 > bs2->GetSigmaZ()) {  //just temporary for debugging
+    if (bs1->GetSigmaZ() > 2.5) {
       return bs1;
     } else {
-      return bs2;
+      return NULL;
     }
 
   } else {
-    if (bs2->GetSigmaZ() > 5.) {
+    if (bs2->GetSigmaZ() > 2.5) {
       return bs2;
     } else {
-      return bs1;
+      return NULL;
     }
   }
 }
@@ -88,7 +88,11 @@ std::shared_ptr<const BeamSpotObjects> OnlineBeamSpotESProducer::produce(const B
   } else {
     best = &hltRec->get(bsHLTToken_);
   }
-  return std::shared_ptr<const BeamSpotObjects>(best, edm::do_nothing_deleter());
+  if (best){
+    return std::shared_ptr<const BeamSpotObjects>(best, edm::do_nothing_deleter());
+  }else{
+    return std::shared_ptr<const BeamSpotObjects>(&fakeBS_, edm::do_nothing_deleter());
+  }
 };
 
 DEFINE_FWK_EVENTSETUP_MODULE(OnlineBeamSpotESProducer);

--- a/RecoVertex/BeamSpotProducer/plugins/OnlineBeamSpotESProducer.cc
+++ b/RecoVertex/BeamSpotProducer/plugins/OnlineBeamSpotESProducer.cc
@@ -56,19 +56,19 @@ void OnlineBeamSpotESProducer::fillDescriptions(edm::ConfigurationDescriptions& 
 
 const BeamSpotOnlineObjects* OnlineBeamSpotESProducer::compareBS(const BeamSpotOnlineObjects* bs1,
                                                                  const BeamSpotOnlineObjects* bs2) {
-  //Random logic so far ...  
+  //Random logic so far ...
   if (bs1->GetSigmaZ() - 0.0001 > bs2->GetSigmaZ()) {  //just temporary for debugging
     if (bs1->GetSigmaZ() > 2.5) {
       return bs1;
     } else {
-      return NULL;
+      return nullptr;
     }
 
   } else {
     if (bs2->GetSigmaZ() > 2.5) {
       return bs2;
     } else {
-      return NULL;
+      return nullptr;
     }
   }
 }
@@ -88,9 +88,9 @@ std::shared_ptr<const BeamSpotObjects> OnlineBeamSpotESProducer::produce(const B
   } else {
     best = &hltRec->get(bsHLTToken_);
   }
-  if (best){
+  if (best) {
     return std::shared_ptr<const BeamSpotObjects>(best, edm::do_nothing_deleter());
-  }else{
+  } else {
     return std::shared_ptr<const BeamSpotObjects>(&fakeBS_, edm::do_nothing_deleter());
   }
 };

--- a/RecoVertex/BeamSpotProducer/python/BeamSpotOnline_cff.py
+++ b/RecoVertex/BeamSpotProducer/python/BeamSpotOnline_cff.py
@@ -3,6 +3,7 @@ import FWCore.ParameterSet.Config as cms
 from RecoVertex.BeamSpotProducer.BeamSpotOnline_cfi import *
 
 #scalers = cms.EDProducer('ScalersRawToDigi')
+BeamSpotESProducer = cms.ESProducer("OnlineBeamSpotESProducer")
 
 onlineBeamSpot = cms.Sequence( onlineBeamSpotProducer )
 

--- a/RecoVertex/BeamSpotProducer/python/BeamSpotOnline_cff.py
+++ b/RecoVertex/BeamSpotProducer/python/BeamSpotOnline_cff.py
@@ -5,5 +5,8 @@ from RecoVertex.BeamSpotProducer.BeamSpotOnline_cfi import *
 #scalers = cms.EDProducer('ScalersRawToDigi')
 BeamSpotESProducer = cms.ESProducer("OnlineBeamSpotESProducer")
 
+from Configuration.Eras.Modifier_run3_common_cff import run3_common
+run3_common.toModify(onlineBeamSpotProducer, useTransientRecord = True)
+
 onlineBeamSpot = cms.Sequence( onlineBeamSpotProducer )
 

--- a/RecoVertex/BeamSpotProducer/python/BeamSpotOnline_cfi.py
+++ b/RecoVertex/BeamSpotProducer/python/BeamSpotOnline_cfi.py
@@ -6,6 +6,7 @@ onlineBeamSpotProducer = cms.EDProducer('BeamSpotOnlineProducer',
                                         maxZ = cms.double(40),
                                         maxRadius = cms.double(2),
                                         setSigmaZ = cms.double(-1), #negative value disables it.
-                                        gtEvmLabel = cms.InputTag('gtEvmDigis')
+                                        gtEvmLabel = cms.InputTag('gtEvmDigis'),
+                                        useTransientRecord = cms.bool(True)
 )
 

--- a/RecoVertex/BeamSpotProducer/python/BeamSpotOnline_cfi.py
+++ b/RecoVertex/BeamSpotProducer/python/BeamSpotOnline_cfi.py
@@ -7,6 +7,6 @@ onlineBeamSpotProducer = cms.EDProducer('BeamSpotOnlineProducer',
                                         maxRadius = cms.double(2),
                                         setSigmaZ = cms.double(-1), #negative value disables it.
                                         gtEvmLabel = cms.InputTag('gtEvmDigis'),
-                                        useTransientRecord = cms.bool(True)
+                                        useTransientRecord = cms.bool(False)
 )
 

--- a/RecoVertex/BeamSpotProducer/test/test_scalars.py
+++ b/RecoVertex/BeamSpotProducer/test/test_scalars.py
@@ -1,6 +1,7 @@
 import FWCore.ParameterSet.Config as cms
+from Configuration.Eras.Era_Run3_cff import Run3
 
-process = cms.Process("DumpDTRaw")
+process = cms.Process("DumpDTRaw",Run3)
 
 process.source = cms.Source("PoolSource",
                             fileNames = cms.untracked.vstring(

--- a/RecoVertex/BeamSpotProducer/test/test_scalars.py
+++ b/RecoVertex/BeamSpotProducer/test/test_scalars.py
@@ -4,61 +4,8 @@ process = cms.Process("DumpDTRaw")
 
 process.source = cms.Source("PoolSource",
                             fileNames = cms.untracked.vstring(
-    #'/store/data/BeamCommissioning09/RandomTriggers/RAW/v1/000/123/576/4AD8F322-B4E1-DE11-BFF2-0030487A322E.root'
-    
-#    '/store/data/Commissioning10/MinimumBias/RAW/v4/000/132/606/E69C1903-B740-DF11-BC4E-0030487CD178.root',
-#    '/store/data/Commissioning10/MinimumBias/RAW/v4/000/132/606/D6C81B03-B740-DF11-B467-0030487CD76A.root',
-#    '/store/data/Commissioning10/MinimumBias/RAW/v4/000/132/646/E6614FE2-1D41-DF11-BEE0-000423D98EA8.root',
-    #'/store/data/Commissioning10/MinimumBias/RAW/v4/000/132/646/DC9311B9-2041-DF11-ABB4-0030487CD840.root',
-    #'/store/data/Commissioning10/MinimumBias/RAW/v4/000/132/646/C8583EB8-2041-DF11-9029-000423D98EA8.root',
-    #'/store/data/Commissioning10/MinimumBias/RAW/v4/000/132/646/9EC8C779-2141-DF11-AE46-001D09F24303.root',
-    #'/store/data/Commissioning10/MinimumBias/RAW/v4/000/132/646/78153729-2241-DF11-AF93-001D09F248F8.root',
-    #'/store/data/Commissioning10/MinimumBias/RAW/v4/000/132/646/6AFBB204-2041-DF11-A936-001D09F28EA3.root',
-    #'/store/data/Commissioning10/MinimumBias/RAW/v4/000/132/646/543F6704-2041-DF11-9CE8-001D09F24934.root',
-    #'/store/data/Commissioning10/MinimumBias/RAW/v4/000/132/646/506F022F-2941-DF11-ABDD-000423D99AAE.root',
-    #'/store/data/Commissioning10/MinimumBias/RAW/v4/000/132/646/4E397E08-2041-DF11-B0CD-001D09F2447F.root',
-    #'/store/data/Commissioning10/MinimumBias/RAW/v4/000/132/646/42E3717A-2141-DF11-973E-001D09F24DA8.root',
-    #'/store/data/Commissioning10/MinimumBias/RAW/v4/000/132/646/32375894-1E41-DF11-9413-000423D99896.root',
-    #'/store/data/Commissioning10/MinimumBias/RAW/v4/000/132/646/20EDEDE7-1D41-DF11-B358-000423D9890C.root',
-    #'/store/data/Commissioning10/MinimumBias/RAW/v4/000/132/646/0A5C557E-2141-DF11-9861-00151796CD80.root',
-    #'/store/data/Commissioning10/MinimumBias/RAW/v4/000/132/646/0046AE7C-2141-DF11-9784-0030487C8CB6.root'
-
-#	'/store/data/Commissioning10/MinimumBias/RAW/v4/000/132/659/FEC5118A-7D41-DF11-8A3F-001D09F2305C.root',
-#	'/store/data/Commissioning10/MinimumBias/RAW/v4/000/132/659/EE97865A-8541-DF11-BE6D-001D09F28F0C.root',
-#	'/store/data/Commissioning10/MinimumBias/RAW/v4/000/132/659/C06A61E8-7741-DF11-8298-0019B9F581C9.root',
-#	'/store/data/Commissioning10/MinimumBias/RAW/v4/000/132/659/A40E9BA3-7841-DF11-B367-000423D990CC.root',
-#	'/store/data/Commissioning10/MinimumBias/RAW/v4/000/132/659/96AD316B-7A41-DF11-BC54-001D09F276CF.root',
-#	'/store/data/Commissioning10/MinimumBias/RAW/v4/000/132/659/8C49426A-7941-DF11-A11A-0030487C90EE.root',
-#	'/store/data/Commissioning10/MinimumBias/RAW/v4/000/132/659/86961539-7741-DF11-A191-001D09F29619.root',
-#	'/store/data/Commissioning10/MinimumBias/RAW/v4/000/132/659/3C747220-7C41-DF11-A1C1-001617E30E2C.root',
-#	'/store/data/Commissioning10/MinimumBias/RAW/v4/000/132/659/06005386-7B41-DF11-BEA0-001D09F23A84.root',
-	
-#	'/store/data/Commissioning10/MinimumBias/RAW/v4/000/133/321/62B90803-1349-DF11-A72F-001D09F24259.root',
-#	'/store/data/Commissioning10/MinimumBias/RAW/v4/000/133/321/58384B68-1449-DF11-A86A-001D09F2462D.root',
-#	'/store/data/Commissioning10/MinimumBias/RAW/v4/000/133/321/542018B8-1349-DF11-B470-001D09F23D1D.root',
-#	'/store/data/Commissioning10/MinimumBias/RAW/v4/000/133/321/3E4C594F-2049-DF11-B00A-001617E30E28.root',
-#	'/store/data/Commissioning10/MinimumBias/RAW/v4/000/133/321/3CBA15DC-1549-DF11-89A8-001D09F24F65.root',
-#	'/store/data/Commissioning10/MinimumBias/RAW/v4/000/133/321/3CA30CAA-1249-DF11-BD4D-0030487C6A66.root',
-
-    '/store/data/Commissioning10/MinimumBias/RAW/v4/000/133/239/A6F9EAC4-5448-DF11-8CBB-0030487C90D4.root',
-    '/store/data/Commissioning10/MinimumBias/RAW/v4/000/133/239/92103C17-5448-DF11-AB9F-000423D99614.root'
-    
-	
-    #'/store/data/Commissioning10/MinimumBias/RAW/v4/000/132/660/FE8930BC-8141-DF11-87E1-00304879FA4A.root',
-    #'/store/data/Commissioning10/MinimumBias/RAW/v4/000/132/661/E049CAC1-8141-DF11-B252-000423D944F0.root',
-    #'/store/data/Commissioning10/MinimumBias/RAW/v4/000/132/661/C68552CC-8141-DF11-88A5-001D09F295A1.root',
-    #'/store/data/Commissioning10/MinimumBias/RAW/v4/000/132/661/BA987D67-8241-DF11-95BA-000423D98834.root',
-    #'/store/data/Commissioning10/MinimumBias/RAW/v4/000/132/661/BA7A7268-8241-DF11-AC43-001D09F244DE.root',
-    #'/store/data/Commissioning10/MinimumBias/RAW/v4/000/132/661/B8B9F029-8341-DF11-9B1D-000423D6B358.root',
-    #'/store/data/Commissioning10/MinimumBias/RAW/v4/000/132/661/B49AD6E8-8341-DF11-A31E-001D09F29849.root',
-    #'/store/data/Commissioning10/MinimumBias/RAW/v4/000/132/661/B4635158-8041-DF11-879E-003048D3750A.root',
-    #'/store/data/Commissioning10/MinimumBias/RAW/v4/000/132/661/88F11FE8-8341-DF11-9650-0019B9F70468.root',
-    #'/store/data/Commissioning10/MinimumBias/RAW/v4/000/132/661/523338C4-8841-DF11-9F23-000423D6CA6E.root',
-    #'/store/data/Commissioning10/MinimumBias/RAW/v4/000/132/661/2812F357-8041-DF11-9C37-000423D6CA72.root',
-    #'/store/data/Commissioning10/MinimumBias/RAW/v4/000/132/661/1A6FC029-8341-DF11-8D57-000423D6C8EE.root',
-    #'/store/data/Commissioning10/MinimumBias/RAW/v4/000/132/661/164A3C69-8241-DF11-863C-001D09F244BB.root',
-    #'/store/data/Commissioning10/MinimumBias/RAW/v4/000/132/661/00DBB206-8041-DF11-8C5B-0019DB29C5FC.root'
-    
+    "file:/eos/cms/store/data/Commissioning2021/Cosmics/RAW/v1/000/342/218/00000/fdaf9009-dfd8-4774-9246-556088e65e9b.root",
+    "file:/eos/cms/store/data/Commissioning2021/Cosmics/RAW/v1/000/342/094/00000/7e88d2e8-6632-40f0-a1ca-4350adf60182.root"
     ),
                             skipEvents = cms.untracked.uint32(0) )
 
@@ -70,20 +17,30 @@ process.source = cms.Source("PoolSource",
 process.maxEvents = cms.untracked.PSet(
         input = cms.untracked.int32(-1)
 )        
-
 process.load("CondCore.DBCommon.CondDBSetup_cfi")
+
+from Configuration.AlCa.GlobalTag import GlobalTag as customiseGlobalTag
+process.GlobalTag = customiseGlobalTag(globaltag = "auto:run3_hlt_GRun")
  
 process.BeamSpotDBSource = cms.ESSource("PoolDBESSource",
                                         process.CondDBSetup,
-                                        toGet = cms.VPSet(cms.PSet(
-    record = cms.string('BeamSpotObjectsRcd'),
-    tag = cms.string('BeamSpotObjects_2009_v11_offline'))),
-                                        #connect = cms.string('sqlite_file:EarlyCollision.db')
-connect = cms.string('frontier://FrontierProd/CMS_COND_31X_BEAMSPOT')
+                                        toGet = cms.VPSet(
+                                            cms.PSet(
+                                                record = cms.string('BeamSpotOnlineLegacyObjectsRcd'),
+                                                tag = cms.string("BeamSpotOnlineTestLegacy"),
+                                                refreshTime = cms.uint64(1)
+
+                                            ),
+                                            cms.PSet(
+                                                record = cms.string('BeamSpotOnlineHLTObjectsRcd'),
+                                                tag = cms.string('BeamSpotOnlineTestHLT'),
+                                                refreshTime = cms.uint64(1)
+                                               )
+
+                                ),
+                                        connect = cms.string('oracle://cms_orcon_prod/CMS_CONDITIONS')
+
 )
-process.es_prefer_beamspot = cms.ESPrefer("PoolDBESSource","BeamSpotDBSource")
-
-
 process.MessageLogger = cms.Service("MessageLogger",
     cerr = cms.untracked.PSet(
         enable = cms.untracked.bool(False)
@@ -97,11 +54,12 @@ process.MessageLogger = cms.Service("MessageLogger",
 process.scalersRawToDigi = cms.EDProducer('ScalersRawToDigi')
 
 process.load("RecoVertex.BeamSpotProducer.BeamSpotOnline_cff")
+#process.onlineBeamSpotProducer.useTransientRecord = cms.bool(False)
 
 process.out = cms.OutputModule( "PoolOutputModule",
-                                fileName = cms.untracked.string( '/uscmst1b_scratch/lpc1/cmsroc/yumiceva/tmp/onlineBeamSpotwithDB3.root' ),
+                                fileName = cms.untracked.string( 'onlineBeamSpotwithDB3.root' ),
                                 outputCommands = cms.untracked.vstring(
-    "keep *"
+    "keep *_*_*_DumpDTRaw"
     )
                                 )
 

--- a/RecoVertex/BeamSpotProducer/test/test_scalars.py
+++ b/RecoVertex/BeamSpotProducer/test/test_scalars.py
@@ -38,8 +38,8 @@ process.BeamSpotDBSource = cms.ESSource("PoolDBESSource",
                                                )
 
                                 ),
-                                        connect = cms.string('oracle://cms_orcon_prod/CMS_CONDITIONS')
-
+                                        #connect = cms.string('oracle://cms_orcon_prod/CMS_CONDITIONS')
+                                        connect = cms.string('frontier://FrontierProd/CMS_CONDITIONS')
 )
 process.MessageLogger = cms.Service("MessageLogger",
     cerr = cms.untracked.PSet(


### PR DESCRIPTION
I have modified the Online BS Producers to take the values from the transient record produced in the related ESProducer.
This is intended for HLT and express stream reconstruction for Run3. There is a new parameter that if set to False, it would revert back to Run2 code.

A second PR on a ERA modifier configuration will follow.


#### PR validation:

I have checked the behavior of the code using the test_scalers.py script modified accordingly