### PR TITLE
Validation: migrate packages for esConsumes

### DIFF
--- a/Validation/GlobalDigis/interface/GlobalDigisAnalyzer.h
+++ b/Validation/GlobalDigis/interface/GlobalDigisAnalyzer.h
@@ -93,7 +93,6 @@
 #include "SimDataFormats/CrossingFrame/interface/MixCollection.h"
 
 #include <cstdlib>
-#include <iostream>
 #include <map>
 #include <memory>
 #include <string>
@@ -103,7 +102,8 @@
 #include "TString.h"
 
 class PGlobalDigi;
-
+class TrackerTopology;
+class TrackerTopologyRcd;
 class GlobalDigisAnalyzer : public DQMEDAnalyzer {
 public:
   typedef std::vector<float> FloatVector;
@@ -156,6 +156,10 @@ private:
   edm::InputTag ECalEBSrc_;
   edm::InputTag ECalEESrc_;
   edm::InputTag ECalESSrc_;
+  edm::ESGetToken<EcalADCToGeVConstant, EcalADCToGeVConstantRcd> ecalADCtoGevToken_;
+  edm::ESGetToken<RPCGeometry, MuonGeometryRecord> rpcGeomToken_;
+  edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> tTopoToken_;
+  edm::ESGetToken<HcalDbService, HcalDbRecord> hcaldbToken_;
 
   std::map<int, double, std::less<int>> ECalgainConv_;
   double ECalbarrelADCtoGeV_;

--- a/Validation/GlobalDigis/interface/GlobalDigisProducer.h
+++ b/Validation/GlobalDigis/interface/GlobalDigisProducer.h
@@ -12,7 +12,7 @@
 
 // framework & common header files
 #include "DataFormats/Common/interface/Handle.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/one/EDProducer.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
@@ -100,7 +100,7 @@
 class PGlobalDigi;
 class TrackerTopology;
 class TrackerTopologyRcd;
-class GlobalDigisProducer : public edm::EDProducer {
+class GlobalDigisProducer : public edm::one::EDProducer<> {
 public:
   typedef std::vector<float> FloatVector;
   typedef std::vector<double> DoubleVector;

--- a/Validation/GlobalDigis/interface/GlobalDigisProducer.h
+++ b/Validation/GlobalDigis/interface/GlobalDigisProducer.h
@@ -90,7 +90,6 @@
 //#include <CLHEP/Units/SystemOfUnits.h>
 
 #include <cstdlib>
-#include <iostream>
 #include <map>
 #include <memory>
 #include <string>
@@ -99,7 +98,8 @@
 #include "TString.h"
 
 class PGlobalDigi;
-
+class TrackerTopology;
+class TrackerTopologyRcd;
 class GlobalDigisProducer : public edm::EDProducer {
 public:
   typedef std::vector<float> FloatVector;
@@ -174,6 +174,9 @@ private:
   edm::InputTag HCalSrc_;
   edm::InputTag HCalDigi_;
 
+  edm::ESGetToken<EcalADCToGeVConstant, EcalADCToGeVConstantRcd> ecalADCtoGevToken_;
+  edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> tTopoToken_;
+  edm::ESGetToken<HcalDbService, HcalDbRecord> hcaldbToken_;
   // Tracker info
   // SiStrip
 

--- a/Validation/GlobalDigis/src/GlobalDigisAnalyzer.cc
+++ b/Validation/GlobalDigis/src/GlobalDigisAnalyzer.cc
@@ -1076,12 +1076,8 @@ void GlobalDigisAnalyzer::fillHCal(const edm::Event &iEvent, const edm::EventSet
 
 void GlobalDigisAnalyzer::fillTrk(const edm::Event &iEvent, const edm::EventSetup &iSetup) {
   // Retrieve tracker topology from geometry
-  edm::ESHandle<TrackerTopology> tTopoHandle;
-  iSetup.get<TrackerTopologyRcd>().get(tTopoHandle);
-  const TrackerTopology *const tTopo = tTopoHandle.product();
-
+  const TrackerTopology *const tTopo = &iSetup.getData(tTopoToken_);
   std::string MsgLoggerCat = "GlobalDigisAnalyzer_fillTrk";
-
   TString eventout;
   if (verbosity > 0)
     eventout = "\nGathering info:";

--- a/Validation/GlobalDigis/src/GlobalDigisAnalyzer.cc
+++ b/Validation/GlobalDigis/src/GlobalDigisAnalyzer.cc
@@ -828,7 +828,7 @@ void GlobalDigisAnalyzer::fillHCal(const edm::Event &iEvent, const edm::EventSet
     eventout = "\nGathering info:";
 
   // get calibration info
-  const auto& HCalconditions = iSetup.getHandle(hcaldbToken_);
+  const auto &HCalconditions = iSetup.getHandle(hcaldbToken_);
   if (!HCalconditions.isValid()) {
     edm::LogWarning(MsgLoggerCat) << "Unable to find HCalconditions in event!";
     return;
@@ -1455,7 +1455,7 @@ void GlobalDigisAnalyzer::fillMuon(const edm::Event &iEvent, const edm::EventSet
 
   // get RPC information
   // Get the RPC Geometry
-  const auto& rpcGeom = iSetup.getHandle(rpcGeomToken_);
+  const auto &rpcGeom = iSetup.getHandle(rpcGeomToken_);
   if (!rpcGeom.isValid()) {
     edm::LogWarning(MsgLoggerCat) << "Unable to find RPCGeometryRecord in event!";
     return;

--- a/Validation/GlobalDigis/src/GlobalDigisAnalyzer.cc
+++ b/Validation/GlobalDigis/src/GlobalDigisAnalyzer.cc
@@ -70,6 +70,12 @@ GlobalDigisAnalyzer::GlobalDigisAnalyzer(const edm::ParameterSet &iPSet)
 
   RPCSimHit_Token_ =
       consumes<edm::PSimHitContainer>(edm::InputTag(std::string("g4SimHits"), std::string("MuonRPCHits")));
+
+  ecalADCtoGevToken_ = esConsumes();
+  rpcGeomToken_ = esConsumes();
+  tTopoToken_ = esConsumes();
+  hcaldbToken_ = esConsumes();
+
   // use value of first digit to determine default output level (inclusive)
   // 0 is none, 1 is basic, 2 is fill output, 3 is gather output
   verbosity %= 10;
@@ -426,9 +432,7 @@ void GlobalDigisAnalyzer::analyze(const edm::Event &iEvent, const edm::EventSetu
 
   // THIS BLOCK MIGRATED HERE FROM beginJob:
   // setup calorimeter constants from service
-  edm::ESHandle<EcalADCToGeVConstant> pAgc;
-  iSetup.get<EcalADCToGeVConstantRcd>().get(pAgc);
-  const EcalADCToGeVConstant *agc = pAgc.product();
+  const EcalADCToGeVConstant *agc = &iSetup.getData(ecalADCtoGevToken_);
   ECalbarrelADCtoGeV_ = agc->getEBValue();
   ECalendcapADCtoGeV_ = agc->getEEValue();
   if (verbosity >= 0) {
@@ -824,8 +828,7 @@ void GlobalDigisAnalyzer::fillHCal(const edm::Event &iEvent, const edm::EventSet
     eventout = "\nGathering info:";
 
   // get calibration info
-  edm::ESHandle<HcalDbService> HCalconditions;
-  iSetup.get<HcalDbRecord>().get(HCalconditions);
+  const auto& HCalconditions = iSetup.getHandle(hcaldbToken_);
   if (!HCalconditions.isValid()) {
     edm::LogWarning(MsgLoggerCat) << "Unable to find HCalconditions in event!";
     return;
@@ -1456,8 +1459,7 @@ void GlobalDigisAnalyzer::fillMuon(const edm::Event &iEvent, const edm::EventSet
 
   // get RPC information
   // Get the RPC Geometry
-  edm::ESHandle<RPCGeometry> rpcGeom;
-  iSetup.get<MuonGeometryRecord>().get(rpcGeom);
+  const auto& rpcGeom = iSetup.getHandle(rpcGeomToken_);
   if (!rpcGeom.isValid()) {
     edm::LogWarning(MsgLoggerCat) << "Unable to find RPCGeometryRecord in event!";
     return;

--- a/Validation/GlobalDigis/src/GlobalDigisProducer.cc
+++ b/Validation/GlobalDigis/src/GlobalDigisProducer.cc
@@ -618,7 +618,7 @@ void GlobalDigisProducer::fillHCal(edm::Event &iEvent, const edm::EventSetup &iS
     eventout = "\nGathering info:";
 
   // get calibration info
-  const auto& HCalconditions =   iSetup.getHandle(hcaldbToken_);
+  const auto &HCalconditions = iSetup.getHandle(hcaldbToken_);
   if (!HCalconditions.isValid()) {
     edm::LogWarning(MsgLoggerCat) << "Unable to find HCalconditions in event!";
     return;

--- a/Validation/GlobalDigis/src/GlobalDigisProducer.cc
+++ b/Validation/GlobalDigis/src/GlobalDigisProducer.cc
@@ -64,6 +64,9 @@ GlobalDigisProducer::GlobalDigisProducer(const edm::ParameterSet &iPSet)
   ESHits_Token_ =
       consumes<CrossingFrame<PCaloHit>>(edm::InputTag(std::string("mix"), std::string("preshowerHitsName")));
 
+  ecalADCtoGevToken_ = esConsumes();
+  tTopoToken_ = esConsumes();
+  hcaldbToken_ = esConsumes();
   // use value of first digit to determine default output level (inclusive)
   // 0 is none, 1 is basic, 2 is fill output, 3 is gather output
   verbosity %= 10;
@@ -111,11 +114,6 @@ GlobalDigisProducer::~GlobalDigisProducer() {}
 void GlobalDigisProducer::beginJob(void) {
   std::string MsgLoggerCat = "GlobalDigisProducer_beginJob";
 
-  //   // setup calorimeter constants from service
-  //   edm::ESHandle<EcalADCToGeVConstant> pAgc;
-  //   iSetup.get<EcalADCToGeVConstantRcd>().get(pAgc);
-  //   const EcalADCToGeVConstant* agc = pAgc.product();
-
   EcalMGPAGainRatio *defaultRatios = new EcalMGPAGainRatio();
 
   ECalgainConv_[0] = 0.;
@@ -124,9 +122,6 @@ void GlobalDigisProducer::beginJob(void) {
   ECalgainConv_[3] = ECalgainConv_[2] * (defaultRatios->gain6Over1());
 
   delete defaultRatios;
-
-  //   ECalbarrelADCtoGeV_ = agc->getEBValue();
-  //   ECalendcapADCtoGeV_ = agc->getEEValue();
 
   if (verbosity >= 0) {
     edm::LogInfo(MsgLoggerCat) << "Modified Calorimeter gain constants: g0 = " << ECalgainConv_[0]
@@ -157,9 +152,7 @@ void GlobalDigisProducer::produce(edm::Event &iEvent, const edm::EventSetup &iSe
 
   // THIS BLOCK MIGRATED HERE FROM beginJob:
   // setup calorimeter constants from service
-  edm::ESHandle<EcalADCToGeVConstant> pAgc;
-  iSetup.get<EcalADCToGeVConstantRcd>().get(pAgc);
-  const EcalADCToGeVConstant *agc = pAgc.product();
+  const EcalADCToGeVConstant *agc = &iSetup.getData(ecalADCtoGevToken_);
   ECalbarrelADCtoGeV_ = agc->getEBValue();
   ECalendcapADCtoGeV_ = agc->getEEValue();
   if (verbosity >= 0) {
@@ -625,8 +618,7 @@ void GlobalDigisProducer::fillHCal(edm::Event &iEvent, const edm::EventSetup &iS
     eventout = "\nGathering info:";
 
   // get calibration info
-  edm::ESHandle<HcalDbService> HCalconditions;
-  iSetup.get<HcalDbRecord>().get(HCalconditions);
+  const auto& HCalconditions =   iSetup.getHandle(hcaldbToken_);
   if (!HCalconditions.isValid()) {
     edm::LogWarning(MsgLoggerCat) << "Unable to find HCalconditions in event!";
     return;
@@ -876,9 +868,7 @@ void GlobalDigisProducer::storeHCal(PGlobalDigi &product) {
 
 void GlobalDigisProducer::fillTrk(edm::Event &iEvent, const edm::EventSetup &iSetup) {
   // Retrieve tracker topology from geometry
-  edm::ESHandle<TrackerTopology> tTopoHandle;
-  iSetup.get<TrackerTopologyRcd>().get(tTopoHandle);
-  const TrackerTopology *const tTopo = tTopoHandle.product();
+  const TrackerTopology *const tTopo = &iSetup.getData(tTopoToken_);
 
   std::string MsgLoggerCat = "GlobalDigisProducer_fillTrk";
 

--- a/Validation/GlobalHits/interface/GlobalHitsAnalyzer.h
+++ b/Validation/GlobalHits/interface/GlobalHitsAnalyzer.h
@@ -152,7 +152,6 @@ private:
   edm::ESGetToken<CaloGeometry, CaloGeometryRecord> caloGeomToken_;
   edm::ESGetToken<HcalDDDRecConstants, HcalRecNumberingRecord> hcaldddRecToken_;
 
-
   // Electromagnetic info
   // ECal info
   MonitorElement *meCaloEcal[2];

--- a/Validation/GlobalHits/interface/GlobalHitsAnalyzer.h
+++ b/Validation/GlobalHits/interface/GlobalHitsAnalyzer.h
@@ -62,7 +62,6 @@
 #include "DataFormats/Math/interface/LorentzVector.h"
 
 #include <cstdlib>
-#include <iostream>
 #include <memory>
 #include <string>
 #include <vector>
@@ -70,6 +69,9 @@
 #include "DQMServices/Core/interface/DQMEDAnalyzer.h"
 #include "TString.h"
 
+class HcalDDDRecConstants;
+class CaloGeometryRecord;
+class HcalRecNumberingRecord;
 class GlobalHitsAnalyzer : public DQMEDAnalyzer {
 public:
   // typedef std::vector<float> FloatVector;
@@ -142,6 +144,14 @@ private:
   edm::InputTag G4TrkSrc_;
   edm::EDGetTokenT<edm::SimVertexContainer> G4VtxSrc_Token_;
   edm::EDGetTokenT<edm::SimTrackContainer> G4TrkSrc_Token_;
+
+  edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> tGeomToken_;
+  edm::ESGetToken<CSCGeometry, MuonGeometryRecord> cscGeomToken_;
+  edm::ESGetToken<DTGeometry, MuonGeometryRecord> dtGeomToken_;
+  edm::ESGetToken<RPCGeometry, MuonGeometryRecord> rpcGeomToken_;
+  edm::ESGetToken<CaloGeometry, CaloGeometryRecord> caloGeomToken_;
+  edm::ESGetToken<HcalDDDRecConstants, HcalRecNumberingRecord> hcaldddRecToken_;
+
 
   // Electromagnetic info
   // ECal info

--- a/Validation/GlobalHits/interface/GlobalHitsProdHist.h
+++ b/Validation/GlobalHits/interface/GlobalHitsProdHist.h
@@ -121,6 +121,11 @@ private:
   edm::EDGetTokenT<edm::SimVertexContainer> G4VtxSrc_Token_;
   edm::EDGetTokenT<edm::SimTrackContainer> G4TrkSrc_Token_;
 
+  edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> tGeomToken_;
+  edm::ESGetToken<CSCGeometry, MuonGeometryRecord> cscGeomToken_;
+  edm::ESGetToken<DTGeometry, MuonGeometryRecord> dtGeomToken_;
+  edm::ESGetToken<RPCGeometry, MuonGeometryRecord> rpcGeomToken_;
+  edm::ESGetToken<CaloGeometry, CaloGeometryRecord> caloGeomToken_;
   // Electromagnetic info
   // ECal info
   TH1F *hCaloEcal[2];

--- a/Validation/GlobalHits/interface/GlobalHitsProducer.h
+++ b/Validation/GlobalHits/interface/GlobalHitsProducer.h
@@ -71,7 +71,7 @@
 #include "TString.h"
 
 class PGlobalSimHit;
-
+class CaloGeometryRecord;
 class GlobalHitsProducer : public edm::EDProducer {
 public:
   typedef std::vector<float> FloatVector;
@@ -123,6 +123,11 @@ private:
   edm::EDGetTokenT<edm::SimVertexContainer> G4VtxSrc_Token_;
   edm::EDGetTokenT<edm::SimTrackContainer> G4TrkSrc_Token_;
 
+  edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> tGeomToken_;
+  edm::ESGetToken<CSCGeometry, MuonGeometryRecord> cscGeomToken_;
+  edm::ESGetToken<DTGeometry, MuonGeometryRecord> dtGeomToken_;
+  edm::ESGetToken<RPCGeometry, MuonGeometryRecord> rpcGeomToken_;
+  edm::ESGetToken<CaloGeometry, CaloGeometryRecord> caloGeomToken_;
   // Electromagnetic info
   // ECal info
   FloatVector ECalE;

--- a/Validation/GlobalHits/interface/GlobalHitsProducer.h
+++ b/Validation/GlobalHits/interface/GlobalHitsProducer.h
@@ -14,7 +14,7 @@
 #include "DataFormats/Common/interface/Handle.h"
 #include "DataFormats/DetId/interface/DetId.h"
 #include "DataFormats/Provenance/interface/Provenance.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/one/EDProducer.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
@@ -72,7 +72,7 @@
 
 class PGlobalSimHit;
 class CaloGeometryRecord;
-class GlobalHitsProducer : public edm::EDProducer {
+class GlobalHitsProducer : public edm::one::EDProducer<> {
 public:
   typedef std::vector<float> FloatVector;
 

--- a/Validation/GlobalHits/src/GlobalHitsAnalyzer.cc
+++ b/Validation/GlobalHits/src/GlobalHitsAnalyzer.cc
@@ -26,6 +26,12 @@ GlobalHitsAnalyzer::GlobalHitsAnalyzer(const edm::ParameterSet &iPSet)
       testNumber(false),
       G4VtxSrc_Token_(consumes<edm::SimVertexContainer>((iPSet.getParameter<edm::InputTag>("G4VtxSrc")))),
       G4TrkSrc_Token_(consumes<edm::SimTrackContainer>(iPSet.getParameter<edm::InputTag>("G4TrkSrc"))),
+      tGeomToken_(esConsumes()),
+      cscGeomToken_(esConsumes()),
+      dtGeomToken_(esConsumes()),
+      rpcGeomToken_(esConsumes()),
+      caloGeomToken_(esConsumes()),
+      hcaldddRecToken_(esConsumes()),
       count(0) {
   consumesMany<edm::HepMCProduct>();
   std::string MsgLoggerCat = "GlobalHitsAnalyzer_GlobalHitsAnalyzer";
@@ -911,8 +917,7 @@ void GlobalHitsAnalyzer::fillTrk(const edm::Event &iEvent, const edm::EventSetup
     eventout = "\nGathering info:";
 
   // access the tracker geometry
-  edm::ESHandle<TrackerGeometry> theTrackerGeometry;
-  iSetup.get<TrackerDigiGeometryRecord>().get(theTrackerGeometry);
+  const auto & theTrackerGeometry = iSetup.getHandle(tGeomToken_);
   if (!theTrackerGeometry.isValid()) {
     edm::LogWarning(MsgLoggerCat) << "Unable to find TrackerDigiGeometryRecord in event!";
     return;
@@ -1284,8 +1289,7 @@ void GlobalHitsAnalyzer::fillMuon(const edm::Event &iEvent, const edm::EventSetu
   // access the CSC Muon
   ///////////////////////
   // access the CSC Muon geometry
-  edm::ESHandle<CSCGeometry> theCSCGeometry;
-  iSetup.get<MuonGeometryRecord>().get(theCSCGeometry);
+  const auto& theCSCGeometry = iSetup.getHandle(cscGeomToken_);
   if (!theCSCGeometry.isValid()) {
     edm::LogWarning(MsgLoggerCat) << "Unable to find MuonGeometryRecord for the CSCGeometry in event!";
     return;
@@ -1357,8 +1361,7 @@ void GlobalHitsAnalyzer::fillMuon(const edm::Event &iEvent, const edm::EventSetu
   // access the DT Muon
   /////////////////////
   // access the DT Muon geometry
-  edm::ESHandle<DTGeometry> theDTGeometry;
-  iSetup.get<MuonGeometryRecord>().get(theDTGeometry);
+  const auto& theDTGeometry = iSetup.getHandle(dtGeomToken_);
   if (!theDTGeometry.isValid()) {
     edm::LogWarning(MsgLoggerCat) << "Unable to find MuonGeometryRecord for the DTGeometry in event!";
     return;
@@ -1434,8 +1437,7 @@ void GlobalHitsAnalyzer::fillMuon(const edm::Event &iEvent, const edm::EventSetu
   // access the RPC Muon
   ///////////////////////
   // access the RPC Muon geometry
-  edm::ESHandle<RPCGeometry> theRPCGeometry;
-  iSetup.get<MuonGeometryRecord>().get(theRPCGeometry);
+  const auto& theRPCGeometry = iSetup.getHandle(rpcGeomToken_);
   if (!theRPCGeometry.isValid()) {
     edm::LogWarning(MsgLoggerCat) << "Unable to find MuonGeometryRecord for the RPCGeometry in event!";
     return;
@@ -1555,8 +1557,7 @@ void GlobalHitsAnalyzer::fillECal(const edm::Event &iEvent, const edm::EventSetu
     eventout = "\nGathering info:";
 
   // access the calorimeter geometry
-  edm::ESHandle<CaloGeometry> theCaloGeometry;
-  iSetup.get<CaloGeometryRecord>().get(theCaloGeometry);
+  const auto& theCaloGeometry = iSetup.getHandle(caloGeomToken_);
   if (!theCaloGeometry.isValid()) {
     edm::LogWarning(MsgLoggerCat) << "Unable to find CaloGeometryRecord in event!";
     return;
@@ -1728,17 +1729,14 @@ void GlobalHitsAnalyzer::fillHCal(const edm::Event &iEvent, const edm::EventSetu
     eventout = "\nGathering info:";
 
   // access the calorimeter geometry
-  edm::ESHandle<CaloGeometry> theCaloGeometry;
-  iSetup.get<CaloGeometryRecord>().get(theCaloGeometry);
+  const auto& theCaloGeometry = iSetup.getHandle(caloGeomToken_);
   if (!theCaloGeometry.isValid()) {
     edm::LogWarning(MsgLoggerCat) << "Unable to find CaloGeometryRecord in event!";
     return;
   }
   const CaloGeometry &theCalo(*theCaloGeometry);
 
-  edm::ESHandle<HcalDDDRecConstants> pHRNDC;
-  iSetup.get<HcalRecNumberingRecord>().get(pHRNDC);
-  const HcalDDDRecConstants *hcons = &(*pHRNDC);
+  const HcalDDDRecConstants *hcons = &iSetup.getData(hcaldddRecToken_);
 
   // iterator to access containers
   edm::PCaloHitContainer::const_iterator itHit;

--- a/Validation/GlobalHits/src/GlobalHitsAnalyzer.cc
+++ b/Validation/GlobalHits/src/GlobalHitsAnalyzer.cc
@@ -917,7 +917,7 @@ void GlobalHitsAnalyzer::fillTrk(const edm::Event &iEvent, const edm::EventSetup
     eventout = "\nGathering info:";
 
   // access the tracker geometry
-  const auto & theTrackerGeometry = iSetup.getHandle(tGeomToken_);
+  const auto &theTrackerGeometry = iSetup.getHandle(tGeomToken_);
   if (!theTrackerGeometry.isValid()) {
     edm::LogWarning(MsgLoggerCat) << "Unable to find TrackerDigiGeometryRecord in event!";
     return;
@@ -1289,7 +1289,7 @@ void GlobalHitsAnalyzer::fillMuon(const edm::Event &iEvent, const edm::EventSetu
   // access the CSC Muon
   ///////////////////////
   // access the CSC Muon geometry
-  const auto& theCSCGeometry = iSetup.getHandle(cscGeomToken_);
+  const auto &theCSCGeometry = iSetup.getHandle(cscGeomToken_);
   if (!theCSCGeometry.isValid()) {
     edm::LogWarning(MsgLoggerCat) << "Unable to find MuonGeometryRecord for the CSCGeometry in event!";
     return;
@@ -1361,7 +1361,7 @@ void GlobalHitsAnalyzer::fillMuon(const edm::Event &iEvent, const edm::EventSetu
   // access the DT Muon
   /////////////////////
   // access the DT Muon geometry
-  const auto& theDTGeometry = iSetup.getHandle(dtGeomToken_);
+  const auto &theDTGeometry = iSetup.getHandle(dtGeomToken_);
   if (!theDTGeometry.isValid()) {
     edm::LogWarning(MsgLoggerCat) << "Unable to find MuonGeometryRecord for the DTGeometry in event!";
     return;
@@ -1437,7 +1437,7 @@ void GlobalHitsAnalyzer::fillMuon(const edm::Event &iEvent, const edm::EventSetu
   // access the RPC Muon
   ///////////////////////
   // access the RPC Muon geometry
-  const auto& theRPCGeometry = iSetup.getHandle(rpcGeomToken_);
+  const auto &theRPCGeometry = iSetup.getHandle(rpcGeomToken_);
   if (!theRPCGeometry.isValid()) {
     edm::LogWarning(MsgLoggerCat) << "Unable to find MuonGeometryRecord for the RPCGeometry in event!";
     return;
@@ -1557,7 +1557,7 @@ void GlobalHitsAnalyzer::fillECal(const edm::Event &iEvent, const edm::EventSetu
     eventout = "\nGathering info:";
 
   // access the calorimeter geometry
-  const auto& theCaloGeometry = iSetup.getHandle(caloGeomToken_);
+  const auto &theCaloGeometry = iSetup.getHandle(caloGeomToken_);
   if (!theCaloGeometry.isValid()) {
     edm::LogWarning(MsgLoggerCat) << "Unable to find CaloGeometryRecord in event!";
     return;
@@ -1729,7 +1729,7 @@ void GlobalHitsAnalyzer::fillHCal(const edm::Event &iEvent, const edm::EventSetu
     eventout = "\nGathering info:";
 
   // access the calorimeter geometry
-  const auto& theCaloGeometry = iSetup.getHandle(caloGeomToken_);
+  const auto &theCaloGeometry = iSetup.getHandle(caloGeomToken_);
   if (!theCaloGeometry.isValid()) {
     edm::LogWarning(MsgLoggerCat) << "Unable to find CaloGeometryRecord in event!";
     return;

--- a/Validation/GlobalHits/src/GlobalHitsProdHist.cc
+++ b/Validation/GlobalHits/src/GlobalHitsProdHist.cc
@@ -854,7 +854,7 @@ void GlobalHitsProdHist::fillTrk(edm::Event &iEvent, const edm::EventSetup &iSet
     eventout = "\nGathering info:";
 
   // access the tracker geometry
-  const auto& theTrackerGeometry = iSetup.getHandle(tGeomToken_);
+  const auto &theTrackerGeometry = iSetup.getHandle(tGeomToken_);
   if (!theTrackerGeometry.isValid()) {
     edm::LogWarning(MsgLoggerCat) << "Unable to find TrackerDigiGeometryRecord in event!";
     return;
@@ -1214,7 +1214,7 @@ void GlobalHitsProdHist::fillMuon(edm::Event &iEvent, const edm::EventSetup &iSe
   // access the CSC Muon
   ///////////////////////
   // access the CSC Muon geometry
-  const auto& theCSCGeometry = iSetup.getHandle(cscGeomToken_);
+  const auto &theCSCGeometry = iSetup.getHandle(cscGeomToken_);
   if (!theCSCGeometry.isValid()) {
     edm::LogWarning(MsgLoggerCat) << "Unable to find MuonGeometryRecord for the CSCGeometry in event!";
     return;
@@ -1283,7 +1283,7 @@ void GlobalHitsProdHist::fillMuon(edm::Event &iEvent, const edm::EventSetup &iSe
   // access the DT Muon
   /////////////////////
   // access the DT Muon geometry
-  const auto& theDTGeometry = iSetup.getHandle(dtGeomToken_);
+  const auto &theDTGeometry = iSetup.getHandle(dtGeomToken_);
   if (!theDTGeometry.isValid()) {
     edm::LogWarning(MsgLoggerCat) << "Unable to find MuonGeometryRecord for the DTGeometry in event!";
     return;
@@ -1357,7 +1357,7 @@ void GlobalHitsProdHist::fillMuon(edm::Event &iEvent, const edm::EventSetup &iSe
   // access the RPC Muon
   ///////////////////////
   // access the RPC Muon geometry
-  const auto& theRPCGeometry = iSetup.getHandle(rpcGeomToken_);
+  const auto &theRPCGeometry = iSetup.getHandle(rpcGeomToken_);
   if (!theRPCGeometry.isValid()) {
     edm::LogWarning(MsgLoggerCat) << "Unable to find MuonGeometryRecord for the RPCGeometry in event!";
     return;
@@ -1474,7 +1474,7 @@ void GlobalHitsProdHist::fillECal(edm::Event &iEvent, const edm::EventSetup &iSe
     eventout = "\nGathering info:";
 
   // access the calorimeter geometry
-  const auto& theCaloGeometry = iSetup.getHandle(caloGeomToken_);
+  const auto &theCaloGeometry = iSetup.getHandle(caloGeomToken_);
   if (!theCaloGeometry.isValid()) {
     edm::LogWarning(MsgLoggerCat) << "Unable to find CaloGeometryRecord in event!";
     return;
@@ -1642,7 +1642,7 @@ void GlobalHitsProdHist::fillHCal(edm::Event &iEvent, const edm::EventSetup &iSe
     eventout = "\nGathering info:";
 
   // access the calorimeter geometry
-  const auto& theCaloGeometry =iSetup.getHandle(caloGeomToken_);
+  const auto &theCaloGeometry = iSetup.getHandle(caloGeomToken_);
   if (!theCaloGeometry.isValid()) {
     edm::LogWarning(MsgLoggerCat) << "Unable to find CaloGeometryRecord in event!";
     return;

--- a/Validation/GlobalHits/src/GlobalHitsProdHist.cc
+++ b/Validation/GlobalHits/src/GlobalHitsProdHist.cc
@@ -18,6 +18,11 @@ GlobalHitsProdHist::GlobalHitsProdHist(const edm::ParameterSet &iPSet)
       printProvenanceInfo(false),
       G4VtxSrc_Token_(consumes<edm::SimVertexContainer>((iPSet.getParameter<edm::InputTag>("G4VtxSrc")))),
       G4TrkSrc_Token_(consumes<edm::SimTrackContainer>(iPSet.getParameter<edm::InputTag>("G4TrkSrc"))),
+      tGeomToken_(esConsumes()),
+      cscGeomToken_(esConsumes()),
+      dtGeomToken_(esConsumes()),
+      rpcGeomToken_(esConsumes()),
+      caloGeomToken_(esConsumes()),
       count(0) {
   std::string MsgLoggerCat = "GlobalHitsProdHist_GlobalHitsProdHist";
 
@@ -849,8 +854,7 @@ void GlobalHitsProdHist::fillTrk(edm::Event &iEvent, const edm::EventSetup &iSet
     eventout = "\nGathering info:";
 
   // access the tracker geometry
-  edm::ESHandle<TrackerGeometry> theTrackerGeometry;
-  iSetup.get<TrackerDigiGeometryRecord>().get(theTrackerGeometry);
+  const auto& theTrackerGeometry = iSetup.getHandle(tGeomToken_);
   if (!theTrackerGeometry.isValid()) {
     edm::LogWarning(MsgLoggerCat) << "Unable to find TrackerDigiGeometryRecord in event!";
     return;
@@ -1210,8 +1214,7 @@ void GlobalHitsProdHist::fillMuon(edm::Event &iEvent, const edm::EventSetup &iSe
   // access the CSC Muon
   ///////////////////////
   // access the CSC Muon geometry
-  edm::ESHandle<CSCGeometry> theCSCGeometry;
-  iSetup.get<MuonGeometryRecord>().get(theCSCGeometry);
+  const auto& theCSCGeometry = iSetup.getHandle(cscGeomToken_);
   if (!theCSCGeometry.isValid()) {
     edm::LogWarning(MsgLoggerCat) << "Unable to find MuonGeometryRecord for the CSCGeometry in event!";
     return;
@@ -1280,8 +1283,7 @@ void GlobalHitsProdHist::fillMuon(edm::Event &iEvent, const edm::EventSetup &iSe
   // access the DT Muon
   /////////////////////
   // access the DT Muon geometry
-  edm::ESHandle<DTGeometry> theDTGeometry;
-  iSetup.get<MuonGeometryRecord>().get(theDTGeometry);
+  const auto& theDTGeometry = iSetup.getHandle(dtGeomToken_);
   if (!theDTGeometry.isValid()) {
     edm::LogWarning(MsgLoggerCat) << "Unable to find MuonGeometryRecord for the DTGeometry in event!";
     return;
@@ -1355,8 +1357,7 @@ void GlobalHitsProdHist::fillMuon(edm::Event &iEvent, const edm::EventSetup &iSe
   // access the RPC Muon
   ///////////////////////
   // access the RPC Muon geometry
-  edm::ESHandle<RPCGeometry> theRPCGeometry;
-  iSetup.get<MuonGeometryRecord>().get(theRPCGeometry);
+  const auto& theRPCGeometry = iSetup.getHandle(rpcGeomToken_);
   if (!theRPCGeometry.isValid()) {
     edm::LogWarning(MsgLoggerCat) << "Unable to find MuonGeometryRecord for the RPCGeometry in event!";
     return;
@@ -1473,8 +1474,7 @@ void GlobalHitsProdHist::fillECal(edm::Event &iEvent, const edm::EventSetup &iSe
     eventout = "\nGathering info:";
 
   // access the calorimeter geometry
-  edm::ESHandle<CaloGeometry> theCaloGeometry;
-  iSetup.get<CaloGeometryRecord>().get(theCaloGeometry);
+  const auto& theCaloGeometry = iSetup.getHandle(caloGeomToken_);
   if (!theCaloGeometry.isValid()) {
     edm::LogWarning(MsgLoggerCat) << "Unable to find CaloGeometryRecord in event!";
     return;
@@ -1642,8 +1642,7 @@ void GlobalHitsProdHist::fillHCal(edm::Event &iEvent, const edm::EventSetup &iSe
     eventout = "\nGathering info:";
 
   // access the calorimeter geometry
-  edm::ESHandle<CaloGeometry> theCaloGeometry;
-  iSetup.get<CaloGeometryRecord>().get(theCaloGeometry);
+  const auto& theCaloGeometry =iSetup.getHandle(caloGeomToken_);
   if (!theCaloGeometry.isValid()) {
     edm::LogWarning(MsgLoggerCat) << "Unable to find CaloGeometryRecord in event!";
     return;

--- a/Validation/GlobalHits/src/GlobalHitsProducer.cc
+++ b/Validation/GlobalHits/src/GlobalHitsProducer.cc
@@ -388,7 +388,7 @@ void GlobalHitsProducer::fillTrk(edm::Event &iEvent, const edm::EventSetup &iSet
     eventout = "\nGathering info:";
 
   // access the tracker geometry
-  const auto& theTrackerGeometry = iSetup.getHandle(tGeomToken_);
+  const auto &theTrackerGeometry = iSetup.getHandle(tGeomToken_);
   if (!theTrackerGeometry.isValid()) {
     edm::LogWarning(MsgLoggerCat) << "Unable to find TrackerDigiGeometryRecord in event!";
     return;
@@ -781,7 +781,7 @@ void GlobalHitsProducer::fillMuon(edm::Event &iEvent, const edm::EventSetup &iSe
   // access the CSC Muon
   ///////////////////////
   // access the CSC Muon geometry
-  const auto& theCSCGeometry = iSetup.getHandle(cscGeomToken_);
+  const auto &theCSCGeometry = iSetup.getHandle(cscGeomToken_);
   if (!theCSCGeometry.isValid()) {
     edm::LogWarning(MsgLoggerCat) << "Unable to find MuonGeometryRecord for the CSCGeometry in event!";
     return;
@@ -843,7 +843,7 @@ void GlobalHitsProducer::fillMuon(edm::Event &iEvent, const edm::EventSetup &iSe
   // access the DT Muon
   /////////////////////
   // access the DT Muon geometry
-  const auto& theDTGeometry = iSetup.getHandle(dtGeomToken_);
+  const auto &theDTGeometry = iSetup.getHandle(dtGeomToken_);
   if (!theDTGeometry.isValid()) {
     edm::LogWarning(MsgLoggerCat) << "Unable to find MuonGeometryRecord for the DTGeometry in event!";
     return;
@@ -910,7 +910,7 @@ void GlobalHitsProducer::fillMuon(edm::Event &iEvent, const edm::EventSetup &iSe
   // access the RPC Muon
   ///////////////////////
   // access the RPC Muon geometry
-  const auto& theRPCGeometry = iSetup.getHandle(rpcGeomToken_);
+  const auto &theRPCGeometry = iSetup.getHandle(rpcGeomToken_);
   if (!theRPCGeometry.isValid()) {
     edm::LogWarning(MsgLoggerCat) << "Unable to find MuonGeometryRecord for the RPCGeometry in event!";
     return;
@@ -1073,7 +1073,7 @@ void GlobalHitsProducer::fillECal(edm::Event &iEvent, const edm::EventSetup &iSe
     eventout = "\nGathering info:";
 
   // access the calorimeter geometry
-  const auto& theCaloGeometry = iSetup.getHandle(caloGeomToken_);
+  const auto &theCaloGeometry = iSetup.getHandle(caloGeomToken_);
   if (!theCaloGeometry.isValid()) {
     edm::LogWarning(MsgLoggerCat) << "Unable to find CaloGeometryRecord in event!";
     return;
@@ -1256,7 +1256,7 @@ void GlobalHitsProducer::fillHCal(edm::Event &iEvent, const edm::EventSetup &iSe
     eventout = "\nGathering info:";
 
   // access the calorimeter geometry
-  const auto& theCaloGeometry = iSetup.getHandle(caloGeomToken_);
+  const auto &theCaloGeometry = iSetup.getHandle(caloGeomToken_);
   if (!theCaloGeometry.isValid()) {
     edm::LogWarning(MsgLoggerCat) << "Unable to find CaloGeometryRecord in event!";
     return;

--- a/Validation/GlobalHits/src/GlobalHitsProducer.cc
+++ b/Validation/GlobalHits/src/GlobalHitsProducer.cc
@@ -20,12 +20,11 @@ GlobalHitsProducer::GlobalHitsProducer(const edm::ParameterSet &iPSet)
       nRawGenPart(0),
       G4VtxSrc_Token_(consumes<edm::SimVertexContainer>((iPSet.getParameter<edm::InputTag>("G4VtxSrc")))),
       G4TrkSrc_Token_(consumes<edm::SimTrackContainer>(iPSet.getParameter<edm::InputTag>("G4TrkSrc"))),
-      // ECalEBSrc_(""), ECalEESrc_(""), ECalESSrc_(""), HCalSrc_(""),
-      // PxlBrlLowSrc_(""), PxlBrlHighSrc_(""), PxlFwdLowSrc_(""),
-      // PxlFwdHighSrc_(""), SiTIBLowSrc_(""), SiTIBHighSrc_(""),
-      // SiTOBLowSrc_(""), SiTOBHighSrc_(""), SiTIDLowSrc_(""),
-      // SiTIDHighSrc_(""), SiTECLowSrc_(""), SiTECHighSrc_(""),
-      // MuonDtSrc_(""), MuonCscSrc_(""), MuonRpcSrc_(""),
+      tGeomToken_(esConsumes()),
+      cscGeomToken_(esConsumes()),
+      dtGeomToken_(esConsumes()),
+      rpcGeomToken_(esConsumes()),
+      caloGeomToken_(esConsumes()),
       count(0) {
   std::string MsgLoggerCat = "GlobalHitsProducer_GlobalHitsProducer";
 
@@ -389,8 +388,7 @@ void GlobalHitsProducer::fillTrk(edm::Event &iEvent, const edm::EventSetup &iSet
     eventout = "\nGathering info:";
 
   // access the tracker geometry
-  edm::ESHandle<TrackerGeometry> theTrackerGeometry;
-  iSetup.get<TrackerDigiGeometryRecord>().get(theTrackerGeometry);
+  const auto& theTrackerGeometry = iSetup.getHandle(tGeomToken_);
   if (!theTrackerGeometry.isValid()) {
     edm::LogWarning(MsgLoggerCat) << "Unable to find TrackerDigiGeometryRecord in event!";
     return;
@@ -783,8 +781,7 @@ void GlobalHitsProducer::fillMuon(edm::Event &iEvent, const edm::EventSetup &iSe
   // access the CSC Muon
   ///////////////////////
   // access the CSC Muon geometry
-  edm::ESHandle<CSCGeometry> theCSCGeometry;
-  iSetup.get<MuonGeometryRecord>().get(theCSCGeometry);
+  const auto& theCSCGeometry = iSetup.getHandle(cscGeomToken_);
   if (!theCSCGeometry.isValid()) {
     edm::LogWarning(MsgLoggerCat) << "Unable to find MuonGeometryRecord for the CSCGeometry in event!";
     return;
@@ -846,8 +843,7 @@ void GlobalHitsProducer::fillMuon(edm::Event &iEvent, const edm::EventSetup &iSe
   // access the DT Muon
   /////////////////////
   // access the DT Muon geometry
-  edm::ESHandle<DTGeometry> theDTGeometry;
-  iSetup.get<MuonGeometryRecord>().get(theDTGeometry);
+  const auto& theDTGeometry = iSetup.getHandle(dtGeomToken_);
   if (!theDTGeometry.isValid()) {
     edm::LogWarning(MsgLoggerCat) << "Unable to find MuonGeometryRecord for the DTGeometry in event!";
     return;
@@ -914,8 +910,7 @@ void GlobalHitsProducer::fillMuon(edm::Event &iEvent, const edm::EventSetup &iSe
   // access the RPC Muon
   ///////////////////////
   // access the RPC Muon geometry
-  edm::ESHandle<RPCGeometry> theRPCGeometry;
-  iSetup.get<MuonGeometryRecord>().get(theRPCGeometry);
+  const auto& theRPCGeometry = iSetup.getHandle(rpcGeomToken_);
   if (!theRPCGeometry.isValid()) {
     edm::LogWarning(MsgLoggerCat) << "Unable to find MuonGeometryRecord for the RPCGeometry in event!";
     return;
@@ -1078,8 +1073,7 @@ void GlobalHitsProducer::fillECal(edm::Event &iEvent, const edm::EventSetup &iSe
     eventout = "\nGathering info:";
 
   // access the calorimeter geometry
-  edm::ESHandle<CaloGeometry> theCaloGeometry;
-  iSetup.get<CaloGeometryRecord>().get(theCaloGeometry);
+  const auto& theCaloGeometry = iSetup.getHandle(caloGeomToken_);
   if (!theCaloGeometry.isValid()) {
     edm::LogWarning(MsgLoggerCat) << "Unable to find CaloGeometryRecord in event!";
     return;
@@ -1262,8 +1256,7 @@ void GlobalHitsProducer::fillHCal(edm::Event &iEvent, const edm::EventSetup &iSe
     eventout = "\nGathering info:";
 
   // access the calorimeter geometry
-  edm::ESHandle<CaloGeometry> theCaloGeometry;
-  iSetup.get<CaloGeometryRecord>().get(theCaloGeometry);
+  const auto& theCaloGeometry = iSetup.getHandle(caloGeomToken_);
   if (!theCaloGeometry.isValid()) {
     edm::LogWarning(MsgLoggerCat) << "Unable to find CaloGeometryRecord in event!";
     return;

--- a/Validation/GlobalRecHits/interface/GlobalRecHitsAnalyzer.h
+++ b/Validation/GlobalRecHits/interface/GlobalRecHitsAnalyzer.h
@@ -192,7 +192,7 @@ private:
   edm::EDGetTokenT<CrossingFrame<PCaloHit>> EBHits_Token_;
   edm::EDGetTokenT<CrossingFrame<PCaloHit>> EEHits_Token_;
   edm::EDGetTokenT<CrossingFrame<PCaloHit>> ESHits_Token_;
-  
+
   // HCal info
 
   MonitorElement *mehHcaln[4];

--- a/Validation/GlobalRecHits/interface/GlobalRecHitsAnalyzer.h
+++ b/Validation/GlobalRecHits/interface/GlobalRecHitsAnalyzer.h
@@ -126,7 +126,6 @@
 #include "Geometry/CommonDetUnit/interface/GeomDetType.h"
 #include "Geometry/CommonDetUnit/interface/GeomDet.h"
 
-#include <iostream>
 #include <cstdlib>
 #include <string>
 #include <memory>
@@ -136,6 +135,9 @@
 
 #include "TString.h"
 #include "DQMServices/Core/interface/DQMEDAnalyzer.h"
+
+class CaloGeometryRecord;
+class TrackerTopology;
 
 class GlobalRecHitsAnalyzer : public DQMEDAnalyzer {
 public:
@@ -190,7 +192,7 @@ private:
   edm::EDGetTokenT<CrossingFrame<PCaloHit>> EBHits_Token_;
   edm::EDGetTokenT<CrossingFrame<PCaloHit>> EEHits_Token_;
   edm::EDGetTokenT<CrossingFrame<PCaloHit>> ESHits_Token_;
-
+  
   // HCal info
 
   MonitorElement *mehHcaln[4];
@@ -282,6 +284,13 @@ private:
   edm::InputTag MuRPCSimSrc_;
   edm::EDGetTokenT<RPCRecHitCollection> MuRPCSrc_Token_;
   edm::EDGetTokenT<edm::PSimHitContainer> MuRPCSimSrc_Token_;
+
+  edm::ESGetToken<CaloGeometry, CaloGeometryRecord> caloGeomToken_;
+  edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> tTopoToken_;
+  edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> tGeomToken_;
+  edm::ESGetToken<DTGeometry, MuonGeometryRecord> dtGeomToken_;
+  edm::ESGetToken<CSCGeometry, MuonGeometryRecord> cscGeomToken_;
+  edm::ESGetToken<RPCGeometry, MuonGeometryRecord> rpcGeomToken_;
 
   // private statistics information
   unsigned int count;

--- a/Validation/GlobalRecHits/interface/GlobalRecHitsProducer.h
+++ b/Validation/GlobalRecHits/interface/GlobalRecHitsProducer.h
@@ -144,7 +144,8 @@
 #include "TString.h"
 
 class PGlobalRecHit;
-
+class CaloGeometryRecord;
+class TrackerTopology;
 class GlobalRecHitsProducer : public edm::EDProducer {
 public:
   typedef std::vector<float> FloatVector;
@@ -332,6 +333,13 @@ private:
   edm::InputTag MuRPCSimSrc_;
   edm::EDGetTokenT<RPCRecHitCollection> MuRPCSrc_Token_;
   edm::EDGetTokenT<edm::PSimHitContainer> MuRPCSimSrc_Token_;
+
+  edm::ESGetToken<CaloGeometry, CaloGeometryRecord> caloGeomToken_;
+  edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> tTopoToken_;
+  edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> tGeomToken_;
+  edm::ESGetToken<DTGeometry, MuonGeometryRecord> dtGeomToken_;
+  edm::ESGetToken<CSCGeometry, MuonGeometryRecord> cscGeomToken_;
+  edm::ESGetToken<RPCGeometry, MuonGeometryRecord> rpcGeomToken_;
 
   // private statistics information
   unsigned int count;

--- a/Validation/GlobalRecHits/interface/GlobalRecHitsProducer.h
+++ b/Validation/GlobalRecHits/interface/GlobalRecHitsProducer.h
@@ -11,7 +11,7 @@
  */
 
 // framework & common header files
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/one/EDProducer.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
@@ -146,7 +146,7 @@
 class PGlobalRecHit;
 class CaloGeometryRecord;
 class TrackerTopology;
-class GlobalRecHitsProducer : public edm::EDProducer {
+class GlobalRecHitsProducer : public edm::one::EDProducer<> {
 public:
   typedef std::vector<float> FloatVector;
   typedef std::vector<double> DoubleVector;

--- a/Validation/GlobalRecHits/src/GlobalRecHitsAnalyzer.cc
+++ b/Validation/GlobalRecHits/src/GlobalRecHitsAnalyzer.cc
@@ -21,6 +21,12 @@ GlobalRecHitsAnalyzer::GlobalRecHitsAnalyzer(const edm::ParameterSet& iPSet)
       getAllProvenances(false),
       printProvenanceInfo(false),
       trackerHitAssociatorConfig_(iPSet, consumesCollector()),
+      caloGeomToken_(esConsumes()),
+      tTopoToken_(esConsumes()),
+      tGeomToken_(esConsumes()),
+      dtGeomToken_(esConsumes()),
+      cscGeomToken_(esConsumes()),
+      rpcGeomToken_(esConsumes()),
       count(0) {
   consumesMany<edm::SortedCollection<HBHERecHit, edm::StrictWeakOrdering<HBHERecHit>>>();
   consumesMany<edm::SortedCollection<HFRecHit, edm::StrictWeakOrdering<HFRecHit>>>();
@@ -558,8 +564,7 @@ void GlobalRecHitsAnalyzer::fillHCal(const edm::Event& iEvent, const edm::EventS
     eventout = "\nGathering info:";
 
   // get geometry
-  edm::ESHandle<CaloGeometry> geometry;
-  iSetup.get<CaloGeometryRecord>().get(geometry);
+  const auto& geometry = iSetup.getHandle(caloGeomToken_);
   if (!geometry.isValid()) {
     edm::LogWarning(MsgLoggerCat) << "Unable to find CaloGeometry in event!";
     return;
@@ -821,12 +826,8 @@ void GlobalRecHitsAnalyzer::fillHCal(const edm::Event& iEvent, const edm::EventS
 
 void GlobalRecHitsAnalyzer::fillTrk(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
   //Retrieve tracker topology from geometry
-  edm::ESHandle<TrackerTopology> tTopoHandle;
-  iSetup.get<TrackerTopologyRcd>().get(tTopoHandle);
-  const TrackerTopology* const tTopo = tTopoHandle.product();
-
+  const TrackerTopology* const tTopo = &iSetup.getData(tTopoToken_);
   std::string MsgLoggerCat = "GlobalRecHitsAnalyzer_fillTrk";
-
   TString eventout;
   if (verbosity > 0)
     eventout = "\nGathering info:";
@@ -842,19 +843,18 @@ void GlobalRecHitsAnalyzer::fillTrk(const edm::Event& iEvent, const edm::EventSe
 
   TrackerHitAssociator associate(iEvent, trackerHitAssociatorConfig_);
 
-  edm::ESHandle<TrackerGeometry> pDD;
-  iSetup.get<TrackerDigiGeometryRecord>().get(pDD);
-  if (!pDD.isValid()) {
+  const auto& tGeomHandle = iSetup.getHandle(tGeomToken_);
+  if (!tGeomHandle.isValid()) {
     edm::LogWarning(MsgLoggerCat) << "Unable to find TrackerDigiGeometry in event!";
     return;
   }
-  const TrackerGeometry& tracker(*pDD);
+  const TrackerGeometry& tracker(*tGeomHandle);
 
   if (validstrip) {
     int nStripBrl = 0, nStripFwd = 0;
 
     // loop over det units
-    for (TrackerGeometry::DetContainer::const_iterator it = pDD->dets().begin(); it != pDD->dets().end(); ++it) {
+    for (TrackerGeometry::DetContainer::const_iterator it = tGeomHandle->dets().begin(); it != tGeomHandle->dets().end(); ++it) {
       uint32_t myid = ((*it)->geographicalId()).rawId();
       DetId detid = ((*it)->geographicalId());
 
@@ -1044,18 +1044,10 @@ void GlobalRecHitsAnalyzer::fillTrk(const edm::Event& iEvent, const edm::EventSe
     validpixel = false;
   }
 
-  //Get event setup
-  edm::ESHandle<TrackerGeometry> geom;
-  iSetup.get<TrackerDigiGeometryRecord>().get(geom);
-  if (!geom.isValid()) {
-    edm::LogWarning(MsgLoggerCat) << "Unable to find TrackerDigiGeometry in event!";
-    return;
-  }
-
   if (validpixel) {
     int nPxlBrl = 0, nPxlFwd = 0;
     //iterate over detunits
-    for (TrackerGeometry::DetContainer::const_iterator it = geom->dets().begin(); it != geom->dets().end(); ++it) {
+    for (TrackerGeometry::DetContainer::const_iterator it = tGeomHandle->dets().begin(); it != tGeomHandle->dets().end(); ++it) {
       uint32_t myid = ((*it)->geographicalId()).rawId();
       DetId detId = ((*it)->geographicalId());
       int subid = detId.subdetId();
@@ -1188,8 +1180,7 @@ void GlobalRecHitsAnalyzer::fillMuon(const edm::Event& iEvent, const edm::EventS
     eventout = "\nGathering info:";
 
   // get DT information
-  edm::ESHandle<DTGeometry> dtGeom;
-  iSetup.get<MuonGeometryRecord>().get(dtGeom);
+  const auto& dtGeom = iSetup.getHandle(dtGeomToken_);
   if (!dtGeom.isValid()) {
     edm::LogWarning(MsgLoggerCat) << "Unable to find DTMuonGeometryRecord in event!";
     return;
@@ -1247,8 +1238,7 @@ void GlobalRecHitsAnalyzer::fillMuon(const edm::Event& iEvent, const edm::EventS
   }
 
   // get geometry
-  edm::ESHandle<CSCGeometry> hGeom;
-  iSetup.get<MuonGeometryRecord>().get(hGeom);
+  const auto& hGeom = iSetup.getHandle(cscGeomToken_);
   if (!hGeom.isValid()) {
     edm::LogWarning(MsgLoggerCat) << "Unable to find CSCMuonGeometryRecord in event!";
     return;
@@ -1299,9 +1289,7 @@ void GlobalRecHitsAnalyzer::fillMuon(const edm::Event& iEvent, const edm::EventS
   // get RPC information
   std::map<double, int> mapsim, maprec;
   std::map<int, double> nmapsim, nmaprec;
-
-  edm::ESHandle<RPCGeometry> rpcGeom;
-  iSetup.get<MuonGeometryRecord>().get(rpcGeom);
+  const auto& rpcGeom = iSetup.getHandle(rpcGeomToken_);
   if (!rpcGeom.isValid()) {
     edm::LogWarning(MsgLoggerCat) << "Unable to find RPCMuonGeometryRecord in event!";
     return;

--- a/Validation/GlobalRecHits/src/GlobalRecHitsAnalyzer.cc
+++ b/Validation/GlobalRecHits/src/GlobalRecHitsAnalyzer.cc
@@ -854,7 +854,9 @@ void GlobalRecHitsAnalyzer::fillTrk(const edm::Event& iEvent, const edm::EventSe
     int nStripBrl = 0, nStripFwd = 0;
 
     // loop over det units
-    for (TrackerGeometry::DetContainer::const_iterator it = tGeomHandle->dets().begin(); it != tGeomHandle->dets().end(); ++it) {
+    for (TrackerGeometry::DetContainer::const_iterator it = tGeomHandle->dets().begin();
+         it != tGeomHandle->dets().end();
+         ++it) {
       uint32_t myid = ((*it)->geographicalId()).rawId();
       DetId detid = ((*it)->geographicalId());
 
@@ -1047,7 +1049,9 @@ void GlobalRecHitsAnalyzer::fillTrk(const edm::Event& iEvent, const edm::EventSe
   if (validpixel) {
     int nPxlBrl = 0, nPxlFwd = 0;
     //iterate over detunits
-    for (TrackerGeometry::DetContainer::const_iterator it = tGeomHandle->dets().begin(); it != tGeomHandle->dets().end(); ++it) {
+    for (TrackerGeometry::DetContainer::const_iterator it = tGeomHandle->dets().begin();
+         it != tGeomHandle->dets().end();
+         ++it) {
       uint32_t myid = ((*it)->geographicalId()).rawId();
       DetId detId = ((*it)->geographicalId());
       int subid = detId.subdetId();

--- a/Validation/GlobalRecHits/src/GlobalRecHitsProducer.cc
+++ b/Validation/GlobalRecHits/src/GlobalRecHitsProducer.cc
@@ -806,7 +806,8 @@ void GlobalRecHitsProducer::storeHCal(PGlobalRecHit& product) {
 
 void GlobalRecHitsProducer::fillTrk(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   //Retrieve tracker topology from geometry
-  const TrackerTopology* const tTopo = &iSetup.getData(tTopoToken_);;
+  const TrackerTopology* const tTopo = &iSetup.getData(tTopoToken_);
+  ;
   std::string MsgLoggerCat = "GlobalRecHitsProducer_fillTrk";
   TString eventout;
   if (verbosity > 0)
@@ -832,7 +833,8 @@ void GlobalRecHitsProducer::fillTrk(edm::Event& iEvent, const edm::EventSetup& i
   int nStripBrl = 0, nStripFwd = 0;
 
   // loop over det units
-  for (TrackerGeometry::DetContainer::const_iterator it = tGeomHandle->dets().begin(); it != tGeomHandle->dets().end(); ++it) {
+  for (TrackerGeometry::DetContainer::const_iterator it = tGeomHandle->dets().begin(); it != tGeomHandle->dets().end();
+       ++it) {
     uint32_t myid = ((*it)->geographicalId()).rawId();
     DetId detid = ((*it)->geographicalId());
 
@@ -1045,7 +1047,8 @@ void GlobalRecHitsProducer::fillTrk(edm::Event& iEvent, const edm::EventSetup& i
 
   int nPxlBrl = 0, nPxlFwd = 0;
   //iterate over detunits
-  for (TrackerGeometry::DetContainer::const_iterator it = tGeomHandle->dets().begin(); it != tGeomHandle->dets().end(); ++it) {
+  for (TrackerGeometry::DetContainer::const_iterator it = tGeomHandle->dets().begin(); it != tGeomHandle->dets().end();
+       ++it) {
     uint32_t myid = ((*it)->geographicalId()).rawId();
     DetId detId = ((*it)->geographicalId());
     int subid = detId.subdetId();

--- a/Validation/GlobalRecHits/src/GlobalRecHitsProducer.cc
+++ b/Validation/GlobalRecHits/src/GlobalRecHitsProducer.cc
@@ -19,6 +19,12 @@ GlobalRecHitsProducer::GlobalRecHitsProducer(const edm::ParameterSet& iPSet)
       getAllProvenances(false),
       printProvenanceInfo(false),
       trackerHitAssociatorConfig_(iPSet, consumesCollector()),
+      caloGeomToken_(esConsumes()),
+      tTopoToken_(esConsumes()),
+      tGeomToken_(esConsumes()),
+      dtGeomToken_(esConsumes()),
+      cscGeomToken_(esConsumes()),
+      rpcGeomToken_(esConsumes()),
       count(0) {
   std::string MsgLoggerCat = "GlobalRecHitsProducer_GlobalRecHitsProducer";
 
@@ -462,8 +468,7 @@ void GlobalRecHitsProducer::fillHCal(edm::Event& iEvent, const edm::EventSetup& 
     eventout = "\nGathering info:";
 
   // get geometry
-  edm::ESHandle<CaloGeometry> geometry;
-  iSetup.get<CaloGeometryRecord>().get(geometry);
+  const auto& geometry = iSetup.getHandle(caloGeomToken_);
   if (!geometry.isValid()) {
     edm::LogWarning(MsgLoggerCat) << "Unable to find CaloGeometry in event!";
     return;
@@ -801,12 +806,8 @@ void GlobalRecHitsProducer::storeHCal(PGlobalRecHit& product) {
 
 void GlobalRecHitsProducer::fillTrk(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   //Retrieve tracker topology from geometry
-  edm::ESHandle<TrackerTopology> tTopoHandle;
-  iSetup.get<TrackerTopologyRcd>().get(tTopoHandle);
-  const TrackerTopology* const tTopo = tTopoHandle.product();
-
+  const TrackerTopology* const tTopo = &iSetup.getData(tTopoToken_);;
   std::string MsgLoggerCat = "GlobalRecHitsProducer_fillTrk";
-
   TString eventout;
   if (verbosity > 0)
     eventout = "\nGathering info:";
@@ -821,18 +822,17 @@ void GlobalRecHitsProducer::fillTrk(edm::Event& iEvent, const edm::EventSetup& i
 
   TrackerHitAssociator associate(iEvent, trackerHitAssociatorConfig_);
 
-  edm::ESHandle<TrackerGeometry> pDD;
-  iSetup.get<TrackerDigiGeometryRecord>().get(pDD);
-  if (!pDD.isValid()) {
+  const auto& tGeomHandle = iSetup.getHandle(tGeomToken_);
+  if (!tGeomHandle.isValid()) {
     edm::LogWarning(MsgLoggerCat) << "Unable to find TrackerDigiGeometry in event!";
     return;
   }
-  const TrackerGeometry& tracker(*pDD);
+  const TrackerGeometry& tracker(*tGeomHandle);
 
   int nStripBrl = 0, nStripFwd = 0;
 
   // loop over det units
-  for (TrackerGeometry::DetContainer::const_iterator it = pDD->dets().begin(); it != pDD->dets().end(); ++it) {
+  for (TrackerGeometry::DetContainer::const_iterator it = tGeomHandle->dets().begin(); it != tGeomHandle->dets().end(); ++it) {
     uint32_t myid = ((*it)->geographicalId()).rawId();
     DetId detid = ((*it)->geographicalId());
 
@@ -1043,18 +1043,9 @@ void GlobalRecHitsProducer::fillTrk(edm::Event& iEvent, const edm::EventSetup& i
     return;
   }
 
-  //Get event setup
-  edm::ESHandle<TrackerGeometry> geom;
-  iSetup.get<TrackerDigiGeometryRecord>().get(geom);
-  if (!geom.isValid()) {
-    edm::LogWarning(MsgLoggerCat) << "Unable to find TrackerDigiGeometry in event!";
-    return;
-  }
-  //const TrackerGeometry& theTracker(*geom);
-
   int nPxlBrl = 0, nPxlFwd = 0;
   //iterate over detunits
-  for (TrackerGeometry::DetContainer::const_iterator it = geom->dets().begin(); it != geom->dets().end(); ++it) {
+  for (TrackerGeometry::DetContainer::const_iterator it = tGeomHandle->dets().begin(); it != tGeomHandle->dets().end(); ++it) {
     uint32_t myid = ((*it)->geographicalId()).rawId();
     DetId detId = ((*it)->geographicalId());
     int subid = detId.subdetId();
@@ -1578,8 +1569,7 @@ void GlobalRecHitsProducer::fillMuon(edm::Event& iEvent, const edm::EventSetup& 
     eventout = "\nGathering info:";
 
   // get DT information
-  edm::ESHandle<DTGeometry> dtGeom;
-  iSetup.get<MuonGeometryRecord>().get(dtGeom);
+  const auto& dtGeom = iSetup.getHandle(dtGeomToken_);
   if (!dtGeom.isValid()) {
     edm::LogWarning(MsgLoggerCat) << "Unable to find DTMuonGeometryRecord in event!";
     return;
@@ -1636,8 +1626,7 @@ void GlobalRecHitsProducer::fillMuon(edm::Event& iEvent, const edm::EventSetup& 
   }
 
   // get geometry
-  edm::ESHandle<CSCGeometry> hGeom;
-  iSetup.get<MuonGeometryRecord>().get(hGeom);
+  const auto& hGeom = iSetup.getHandle(cscGeomToken_);
   if (!hGeom.isValid()) {
     edm::LogWarning(MsgLoggerCat) << "Unable to find CSCMuonGeometryRecord in event!";
     return;
@@ -1684,8 +1673,7 @@ void GlobalRecHitsProducer::fillMuon(edm::Event& iEvent, const edm::EventSetup& 
   std::map<double, int> mapsim, maprec;
   std::map<int, double> nmapsim, nmaprec;
 
-  edm::ESHandle<RPCGeometry> rpcGeom;
-  iSetup.get<MuonGeometryRecord>().get(rpcGeom);
+  const auto& rpcGeom = iSetup.getHandle(rpcGeomToken_);
   if (!rpcGeom.isValid()) {
     edm::LogWarning(MsgLoggerCat) << "Unable to find RPCMuonGeometryRecord in event!";
     return;

--- a/Validation/MuonRPCGeometry/plugins/RPCGeometryServTest.cc
+++ b/Validation/MuonRPCGeometry/plugins/RPCGeometryServTest.cc
@@ -5,26 +5,15 @@
 
 #include <memory>
 #include <fstream>
-#include "FWCore/Framework/interface/Frameworkfwd.h"
-
-#include "FWCore/Framework/interface/EDAnalyzer.h"
-#include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/Framework/interface/ESHandle.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
-
 #include "Geometry/RPCGeometry/interface/RPCGeometry.h"
 #include "Geometry/RPCGeometry/interface/RPCGeomServ.h"
 #include "Geometry/Records/interface/MuonGeometryRecord.h"
 #include "Geometry/CommonTopologies/interface/RectangularStripTopology.h"
 #include "Geometry/CommonTopologies/interface/TrapezoidalStripTopology.h"
-
 #include "Validation/MuonRPCGeometry/plugins/RPCGeometryServTest.h"
 
-#include <string>
 #include <cmath>
 #include <vector>
-#include <map>
 #include <iomanip>
 #include <set>
 
@@ -33,13 +22,13 @@ using namespace std;
 RPCGeometryServTest::RPCGeometryServTest(const edm::ParameterSet& iConfig)
     : dashedLineWidth_(104), dashedLine_(std::string(dashedLineWidth_, '-')), myName_("RPCGeometryServTest") {
   std::cout << "======================== Opening output file" << std::endl;
+  rpcGeomToken_ = esConsumes();
 }
 
 RPCGeometryServTest::~RPCGeometryServTest() {}
 
 void RPCGeometryServTest::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
-  edm::ESHandle<RPCGeometry> pDD;
-  iSetup.get<MuonGeometryRecord>().get(pDD);
+  const auto& pDD = iSetup.getHandle(rpcGeomToken_);
 
   std::cout << myName() << ": Analyzer..." << std::endl;
   std::cout << "start " << dashedLine_ << std::endl;

--- a/Validation/MuonRPCGeometry/plugins/RPCGeometryServTest.h
+++ b/Validation/MuonRPCGeometry/plugins/RPCGeometryServTest.h
@@ -3,7 +3,7 @@
  *  \author M. Maggi - INFN Bari
  */
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/ESHandle.h"
@@ -13,7 +13,7 @@
 
 class RPCGeometry;
 class MuonGeometryRecord;
-class RPCGeometryServTest : public edm::EDAnalyzer {
+class RPCGeometryServTest : public edm::one::EDAnalyzer<> {
 public:
   RPCGeometryServTest(const edm::ParameterSet& pset);
 

--- a/Validation/MuonRPCGeometry/plugins/RPCGeometryServTest.h
+++ b/Validation/MuonRPCGeometry/plugins/RPCGeometryServTest.h
@@ -2,30 +2,17 @@
  *
  *  \author M. Maggi - INFN Bari
  */
-
-#include <memory>
-#include <fstream>
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-
 #include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-
-#include "Geometry/RPCGeometry/interface/RPCGeometry.h"
-#include "Geometry/RPCGeometry/interface/RPCGeomServ.h"
-#include "Geometry/Records/interface/MuonGeometryRecord.h"
-#include "Geometry/CommonTopologies/interface/RectangularStripTopology.h"
-#include "Geometry/CommonTopologies/interface/TrapezoidalStripTopology.h"
-
 #include <string>
-#include <cmath>
-#include <vector>
 #include <map>
-#include <iomanip>
-#include <set>
 
+class RPCGeometry;
+class MuonGeometryRecord;
 class RPCGeometryServTest : public edm::EDAnalyzer {
 public:
   RPCGeometryServTest(const edm::ParameterSet& pset);
@@ -43,4 +30,5 @@ private:
   std::map<int, std::pair<double, double> > barzranges;
   std::map<int, std::pair<double, double> > forRranges;
   std::map<int, std::pair<double, double> > bacRranges;
+  edm::ESGetToken<RPCGeometry, MuonGeometryRecord> rpcGeomToken_;
 };

--- a/Validation/RecoB/plugins/BDHadronTrackMonitoringAnalyzer.cc
+++ b/Validation/RecoB/plugins/BDHadronTrackMonitoringAnalyzer.cc
@@ -38,7 +38,7 @@ BDHadronTrackMonitoringAnalyzer::BDHadronTrackMonitoringAnalyzer(const edm::Para
   TrackCollectionTag_ = consumes<reco::TrackCollection>(TrackSrc_);
   PrimaryVertexColl_ = consumes<reco::VertexCollection>(PVSrc_);
   clusterTPMapToken_ = consumes<ClusterTPAssociation>(ClusterTPMapSrc_);
-  ttrackToken_ = esConsumes();
+  ttrackToken_ = esConsumes(edm::ESInputTag("", "TransientTrackBuilder"));
   // TrkHistCat = {"BCWeakDecay", "BWeakDecay", "CWeakDecay", "PU", "Other",
   // "Fake"};
 }

--- a/Validation/RecoB/plugins/BDHadronTrackMonitoringAnalyzer.cc
+++ b/Validation/RecoB/plugins/BDHadronTrackMonitoringAnalyzer.cc
@@ -38,6 +38,7 @@ BDHadronTrackMonitoringAnalyzer::BDHadronTrackMonitoringAnalyzer(const edm::Para
   TrackCollectionTag_ = consumes<reco::TrackCollection>(TrackSrc_);
   PrimaryVertexColl_ = consumes<reco::VertexCollection>(PVSrc_);
   clusterTPMapToken_ = consumes<ClusterTPAssociation>(ClusterTPMapSrc_);
+  ttrackToken_ = esConsumes();
   // TrkHistCat = {"BCWeakDecay", "BWeakDecay", "CWeakDecay", "PU", "Other",
   // "Fake"};
 }
@@ -213,9 +214,9 @@ void BDHadronTrackMonitoringAnalyzer::analyze(const edm::Event &iEvent, const ed
   iEvent.getByToken(clusterTPMapToken_, pCluster2TPListH);
   const ClusterTPAssociation &clusterToTPMap = *pCluster2TPListH;
 
-  edm::ESHandle<TransientTrackBuilder> trackBuilder;
-  iSetup.get<TransientTrackRecord>().get("TransientTrackBuilder", trackBuilder);
-
+  //edm::ESHandle<TransientTrackBuilder> 
+  const auto& trackBuilder = iSetup.getHandle(ttrackToken_);
+  
   classifier_.newEvent(iEvent, iSetup);
 
   // -----Primary Vertex-----

--- a/Validation/RecoB/plugins/BDHadronTrackMonitoringAnalyzer.cc
+++ b/Validation/RecoB/plugins/BDHadronTrackMonitoringAnalyzer.cc
@@ -214,9 +214,9 @@ void BDHadronTrackMonitoringAnalyzer::analyze(const edm::Event &iEvent, const ed
   iEvent.getByToken(clusterTPMapToken_, pCluster2TPListH);
   const ClusterTPAssociation &clusterToTPMap = *pCluster2TPListH;
 
-  //edm::ESHandle<TransientTrackBuilder> 
-  const auto& trackBuilder = iSetup.getHandle(ttrackToken_);
-  
+  //edm::ESHandle<TransientTrackBuilder>
+  const auto &trackBuilder = iSetup.getHandle(ttrackToken_);
+
   classifier_.newEvent(iEvent, iSetup);
 
   // -----Primary Vertex-----

--- a/Validation/RecoB/plugins/BDHadronTrackMonitoringAnalyzer.h
+++ b/Validation/RecoB/plugins/BDHadronTrackMonitoringAnalyzer.h
@@ -77,7 +77,7 @@ private:
   edm::EDGetTokenT<reco::TrackCollection> TrackCollectionTag_;
   edm::EDGetTokenT<reco::VertexCollection> PrimaryVertexColl_;
   edm::EDGetTokenT<ClusterTPAssociation> clusterTPMapToken_;
-
+  edm::ESGetToken<TransientTrackBuilder, TransientTrackRecord> ttrackToken_;
   // TrackClassifier
   TrackClassifier classifier_;
 

--- a/Validation/RecoHI/plugins/HitPixelLayersTPSelector.h
+++ b/Validation/RecoHI/plugins/HitPixelLayersTPSelector.h
@@ -43,7 +43,7 @@ public:
         primaryOnly_(iConfig.getParameter<bool>("primaryOnly")),
         tpStatusBased_(iConfig.getParameter<bool>("tpStatusBased")),
         pdgId_(iConfig.getParameter<std::vector<int> >("pdgId")),
-        tTopoToken_(iC.esConsumes()) {};
+        tTopoToken_(iC.esConsumes()){};
 
   // select object from a collection and
   // possibly event content

--- a/Validation/RecoHI/plugins/HitPixelLayersTPSelector.h
+++ b/Validation/RecoHI/plugins/HitPixelLayersTPSelector.h
@@ -42,16 +42,15 @@ public:
         chargedOnly_(iConfig.getParameter<bool>("chargedOnly")),
         primaryOnly_(iConfig.getParameter<bool>("primaryOnly")),
         tpStatusBased_(iConfig.getParameter<bool>("tpStatusBased")),
-        pdgId_(iConfig.getParameter<std::vector<int> >("pdgId")){};
+        pdgId_(iConfig.getParameter<std::vector<int> >("pdgId")),
+        tTopoToken_(iC.esConsumes()) {};
 
   // select object from a collection and
   // possibly event content
   void select(const edm::Handle<collection>& TPCH, const edm::Event& iEvent, const edm::EventSetup& iSetup) {
     selected_.clear();
     //Retrieve tracker topology from geometry
-    edm::ESHandle<TrackerTopology> tTopoHand;
-    iSetup.get<TrackerTopologyRcd>().get(tTopoHand);
-    const TrackerTopology* tTopo = tTopoHand.product();
+    const TrackerTopology* tTopo = &iSetup.getData(tTopoToken_);
 
     const collection& tpc = *(TPCH.product());
 
@@ -131,6 +130,7 @@ public:
   bool primaryOnly_;
   bool tpStatusBased_;
   std::vector<int> pdgId_;
+  edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> tTopoToken_;
 };
 
 #endif

--- a/Validation/RecoParticleFlow/plugins/PFAnalysisNtuplizer.cc
+++ b/Validation/RecoParticleFlow/plugins/PFAnalysisNtuplizer.cc
@@ -267,6 +267,8 @@ private:
 
   edm::ESGetToken<CaloGeometry, CaloGeometryRecord> geometryToken_;
   edm::ESGetToken<HcalTopology, HcalRecNumberingRecord> topologyToken_;
+  edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> magFieldToken_;
+  edm::ESGetToken<HcalDDDRecConstants, HcalRecNumberingRecord> hcalDDDrecToken_;
 
   CaloGeometry* geom;
   HcalTopology* hcal_topo;
@@ -289,6 +291,8 @@ PFAnalysis::PFAnalysis(const edm::ParameterSet& iConfig) {
 
   geometryToken_ = esConsumes<CaloGeometry, CaloGeometryRecord>(edm::ESInputTag{});
   topologyToken_ = esConsumes<HcalTopology, HcalRecNumberingRecord>(edm::ESInputTag{});
+  magFieldToken_ = esConsumes<edm::Transition::BeginRun>();
+  hcalDDDrecToken_ = esConsumes<edm::Transition::BeginRun>();
 
   usesResource(TFileService::kSharedResource);
   edm::Service<TFileService> fs;
@@ -1114,14 +1118,8 @@ void PFAnalysis::associateClusterToSimCluster(const vector<ElementWithIndex>& al
 }
 
 void PFAnalysis::beginRun(edm::Run const& iEvent, edm::EventSetup const& es) {
-  edm::ESHandle<MagneticField> magfield;
-  es.get<IdealMagneticFieldRecord>().get(magfield);
-
-  edm::ESHandle<HcalDDDRecConstants> pHRNDC;
-  es.get<HcalRecNumberingRecord>().get(pHRNDC);
-  hcons = &(*pHRNDC);
-
-  aField_ = &(*magfield);
+  hcons = &es.getData(hcalDDDrecToken_);
+  aField_ = &es.getData(magFieldToken_);
 }
 
 void PFAnalysis::endRun(edm::Run const& iEvent, edm::EventSetup const&) {}


### PR DESCRIPTION
#### PR description:
Part of #31061. Migrates validation packages to use esConsumes.

#### PR validation:
Code compiles.
#### if this PR is a backport please specify the original PR and why you need to backport that PR:
NA