### PR TITLE
[DQM] Make nanoDQMIO work

### DIFF
--- a/DQM/BeamMonitor/plugins/AlcaBeamMonitor.cc
+++ b/DQM/BeamMonitor/plugins/AlcaBeamMonitor.cc
@@ -56,8 +56,10 @@ AlcaBeamMonitor::AlcaBeamMonitor(const ParameterSet& ps)
   varNamesV_.push_back("sigmaY");
   varNamesV_.push_back("sigmaZ");
 
+  if (!perLSsaving_){
   histoByCategoryNames_.insert(pair<string, string>("run", "Coordinate"));
   histoByCategoryNames_.insert(pair<string, string>("run", "PrimaryVertex fit-DataBase"));
+  }
   histoByCategoryNames_.insert(pair<string, string>("run", "PrimaryVertex fit-BeamFit"));
   histoByCategoryNames_.insert(pair<string, string>("run", "PrimaryVertex fit-Scalers"));
   histoByCategoryNames_.insert(pair<string, string>("run", "PrimaryVertex-DataBase"));

--- a/DQM/BeamMonitor/plugins/AlcaBeamMonitor.cc
+++ b/DQM/BeamMonitor/plugins/AlcaBeamMonitor.cc
@@ -56,17 +56,15 @@ AlcaBeamMonitor::AlcaBeamMonitor(const ParameterSet& ps)
   varNamesV_.push_back("sigmaY");
   varNamesV_.push_back("sigmaZ");
 
-  if (!perLSsaving_){
-  histoByCategoryNames_.insert(pair<string, string>("run", "Coordinate"));
-  histoByCategoryNames_.insert(pair<string, string>("run", "PrimaryVertex fit-DataBase"));
-  }
-  histoByCategoryNames_.insert(pair<string, string>("run", "PrimaryVertex fit-BeamFit"));
-  histoByCategoryNames_.insert(pair<string, string>("run", "PrimaryVertex fit-Scalers"));
-  histoByCategoryNames_.insert(pair<string, string>("run", "PrimaryVertex-DataBase"));
-  histoByCategoryNames_.insert(pair<string, string>("run", "PrimaryVertex-BeamFit"));
-  histoByCategoryNames_.insert(pair<string, string>("run", "PrimaryVertex-Scalers"));
-
   if (!perLSsaving_) {
+    histoByCategoryNames_.insert(pair<string, string>("run", "Coordinate"));
+    histoByCategoryNames_.insert(pair<string, string>("run", "PrimaryVertex fit-DataBase"));
+    histoByCategoryNames_.insert(pair<string, string>("run", "PrimaryVertex fit-BeamFit"));
+    histoByCategoryNames_.insert(pair<string, string>("run", "PrimaryVertex fit-Scalers"));
+    histoByCategoryNames_.insert(pair<string, string>("run", "PrimaryVertex-DataBase"));
+    histoByCategoryNames_.insert(pair<string, string>("run", "PrimaryVertex-BeamFit"));
+    histoByCategoryNames_.insert(pair<string, string>("run", "PrimaryVertex-Scalers"));
+
     histoByCategoryNames_.insert(pair<string, string>("lumi", "Lumibased BeamSpotFit"));
     histoByCategoryNames_.insert(pair<string, string>("lumi", "Lumibased PrimaryVertex"));
     histoByCategoryNames_.insert(pair<string, string>("lumi", "Lumibased DataBase"));

--- a/DQM/BeamMonitor/plugins/AlcaBeamMonitor.cc
+++ b/DQM/BeamMonitor/plugins/AlcaBeamMonitor.cc
@@ -34,6 +34,7 @@ AlcaBeamMonitor::AlcaBeamMonitor(const ParameterSet& ps)
       trackLabel_(consumes<reco::TrackCollection>(ps.getUntrackedParameter<InputTag>("TrackLabel"))),
       scalerLabel_(consumes<BeamSpot>(ps.getUntrackedParameter<InputTag>("ScalerLabel"))),
       beamSpotToken_(esConsumes<edm::Transition::BeginLuminosityBlock>()),
+      perLSsaving_(ps.getUntrackedParameter<bool>("perLSsaving", false)),
       numberOfValuesToSave_(0) {
   if (!monitorName_.empty())
     monitorName_ = monitorName_ + "/";
@@ -63,15 +64,17 @@ AlcaBeamMonitor::AlcaBeamMonitor(const ParameterSet& ps)
   histoByCategoryNames_.insert(pair<string, string>("run", "PrimaryVertex-BeamFit"));
   histoByCategoryNames_.insert(pair<string, string>("run", "PrimaryVertex-Scalers"));
 
-  histoByCategoryNames_.insert(pair<string, string>("lumi", "Lumibased BeamSpotFit"));
-  histoByCategoryNames_.insert(pair<string, string>("lumi", "Lumibased PrimaryVertex"));
-  histoByCategoryNames_.insert(pair<string, string>("lumi", "Lumibased DataBase"));
-  histoByCategoryNames_.insert(pair<string, string>("lumi", "Lumibased Scalers"));
-  histoByCategoryNames_.insert(pair<string, string>("lumi", "Lumibased PrimaryVertex-DataBase fit"));
-  histoByCategoryNames_.insert(pair<string, string>("lumi", "Lumibased PrimaryVertex-Scalers fit"));
-  histoByCategoryNames_.insert(pair<string, string>("validation", "Lumibased Scalers-DataBase fit"));
-  histoByCategoryNames_.insert(pair<string, string>("validation", "Lumibased PrimaryVertex-DataBase"));
-  histoByCategoryNames_.insert(pair<string, string>("validation", "Lumibased PrimaryVertex-Scalers"));
+  if (!perLSsaving_) {
+    histoByCategoryNames_.insert(pair<string, string>("lumi", "Lumibased BeamSpotFit"));
+    histoByCategoryNames_.insert(pair<string, string>("lumi", "Lumibased PrimaryVertex"));
+    histoByCategoryNames_.insert(pair<string, string>("lumi", "Lumibased DataBase"));
+    histoByCategoryNames_.insert(pair<string, string>("lumi", "Lumibased Scalers"));
+    histoByCategoryNames_.insert(pair<string, string>("lumi", "Lumibased PrimaryVertex-DataBase fit"));
+    histoByCategoryNames_.insert(pair<string, string>("lumi", "Lumibased PrimaryVertex-Scalers fit"));
+    histoByCategoryNames_.insert(pair<string, string>("validation", "Lumibased Scalers-DataBase fit"));
+    histoByCategoryNames_.insert(pair<string, string>("validation", "Lumibased PrimaryVertex-DataBase"));
+    histoByCategoryNames_.insert(pair<string, string>("validation", "Lumibased PrimaryVertex-Scalers"));
+  }
 
   for (vector<string>::iterator itV = varNamesV_.begin(); itV != varNamesV_.end(); itV++) {
     for (multimap<string, string>::iterator itM = histoByCategoryNames_.begin(); itM != histoByCategoryNames_.end();
@@ -88,6 +91,7 @@ void AlcaBeamMonitor::fillDescriptions(edm::ConfigurationDescriptions& iDesc) {
   ps.addUntracked<edm::InputTag>("PrimaryVertexLabel");
   ps.addUntracked<edm::InputTag>("TrackLabel");
   ps.addUntracked<edm::InputTag>("ScalerLabel");
+  ps.addUntracked<bool>("perLSsaving");
 
   BeamFitter::fillDescription(ps);
   PVFitter::fillDescription(ps);

--- a/DQM/BeamMonitor/plugins/AlcaBeamMonitor.h
+++ b/DQM/BeamMonitor/plugins/AlcaBeamMonitor.h
@@ -59,6 +59,7 @@ private:
   const edm::EDGetTokenT<reco::TrackCollection> trackLabel_;
   const edm::EDGetTokenT<reco::BeamSpot> scalerLabel_;
   const edm::ESGetToken<BeamSpotObjects, BeamSpotObjectsRcd> beamSpotToken_;
+  bool perLSsaving_;  //to avoid nanoDQMIO crashing, driven by  DQMServices/Core/python/DQMStore_cfi.py
 
   //Service variables
   int numberOfValuesToSave_;

--- a/DQM/BeamMonitor/python/AlcaBeamMonitorHeavyIons_cff.py
+++ b/DQM/BeamMonitor/python/AlcaBeamMonitorHeavyIons_cff.py
@@ -9,7 +9,7 @@ AlcaBeamMonitor.BeamFitter.TrackQuality    = ['highPurity']
 AlcaBeamMonitor.PVFitter.VertexCollection  = 'hiSelectedVertex'
 #Check if perLSsaving is enabled to mask MEs vs LS
 from DQMServices.Core.DQMStore_cfi import DQMStore
-if(DQMstore.saveByLumi):
+if(DQMStore.saveByLumi):
       AlcaBeamMonitor.perLSsaving=True
 import RecoVertex.BeamSpotProducer.BeamSpotOnline_cfi
 scalerBeamSpot = RecoVertex.BeamSpotProducer.BeamSpotOnline_cfi.onlineBeamSpotProducer.clone()

--- a/DQM/BeamMonitor/python/AlcaBeamMonitorHeavyIons_cff.py
+++ b/DQM/BeamMonitor/python/AlcaBeamMonitorHeavyIons_cff.py
@@ -8,7 +8,7 @@ AlcaBeamMonitor.BeamFitter.TrackCollection = 'hiGeneralTracks'
 AlcaBeamMonitor.BeamFitter.TrackQuality    = ['highPurity']
 AlcaBeamMonitor.PVFitter.VertexCollection  = 'hiSelectedVertex'
 #Check if perLSsaving is enabled to mask MEs vs LS
-fromm DQMServices.Core.DQMStore_cfi import DQMStore
+from DQMServices.Core.DQMStore_cfi import DQMStore
 if(DQMstore.saveByLumi):
       AlcaBeamMonitor.perLSsaving=True
 import RecoVertex.BeamSpotProducer.BeamSpotOnline_cfi

--- a/DQM/BeamMonitor/python/AlcaBeamMonitorHeavyIons_cff.py
+++ b/DQM/BeamMonitor/python/AlcaBeamMonitorHeavyIons_cff.py
@@ -8,6 +8,7 @@ AlcaBeamMonitor.BeamFitter.TrackCollection = 'hiGeneralTracks'
 AlcaBeamMonitor.BeamFitter.TrackQuality    = ['highPurity']
 AlcaBeamMonitor.PVFitter.VertexCollection  = 'hiSelectedVertex'
 #Check if perLSsaving is enabled to mask MEs vs LS
+fromm DQMServices.Core.DQMStore_cfi import DQMStore
 if(DQMstore.saveByLumi):
       AlcaBeamMonitor.perLSsaving=True
 import RecoVertex.BeamSpotProducer.BeamSpotOnline_cfi

--- a/DQM/BeamMonitor/python/AlcaBeamMonitorHeavyIons_cff.py
+++ b/DQM/BeamMonitor/python/AlcaBeamMonitorHeavyIons_cff.py
@@ -7,7 +7,9 @@ AlcaBeamMonitor.TrackLabel         = 'hiGeneralTracks'
 AlcaBeamMonitor.BeamFitter.TrackCollection = 'hiGeneralTracks'
 AlcaBeamMonitor.BeamFitter.TrackQuality    = ['highPurity']
 AlcaBeamMonitor.PVFitter.VertexCollection  = 'hiSelectedVertex'
-
+#Check if perLSsaving is enabled to mask MEs vs LS
+if(DQMstore.saveByLumi):
+      AlcaBeamMonitor.perLSsaving=True
 import RecoVertex.BeamSpotProducer.BeamSpotOnline_cfi
 scalerBeamSpot = RecoVertex.BeamSpotProducer.BeamSpotOnline_cfi.onlineBeamSpotProducer.clone()
 alcaBeamMonitor = cms.Sequence( scalerBeamSpot*AlcaBeamMonitor )

--- a/DQM/BeamMonitor/python/AlcaBeamMonitor_cff.py
+++ b/DQM/BeamMonitor/python/AlcaBeamMonitor_cff.py
@@ -1,7 +1,14 @@
 import FWCore.ParameterSet.Config as cms
 
 from DQM.BeamMonitor.AlcaBeamMonitor_cfi import *
+#Check if perLSsaving is enabled to mask MEs vs LS
+from DQMServices.Core.DQMStore_cfi import DQMStore
+if(DQMStore.saveByLumi):
+    AlcaBeamMonitor.perLSsaving=True
+
 import RecoVertex.BeamSpotProducer.BeamSpotOnline_cfi
 scalerBeamSpot = RecoVertex.BeamSpotProducer.BeamSpotOnline_cfi.onlineBeamSpotProducer.clone()
+
 alcaBeamMonitor = cms.Sequence( scalerBeamSpot*AlcaBeamMonitor )
+
 

--- a/DQM/BeamMonitor/python/AlcaBeamMonitor_cfi.py
+++ b/DQM/BeamMonitor/python/AlcaBeamMonitor_cfi.py
@@ -4,6 +4,7 @@ from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
 AlcaBeamMonitor = DQMEDAnalyzer('AlcaBeamMonitor',
                                  MonitorName        = cms.untracked.string('AlcaBeamMonitor'),
                                  PrimaryVertexLabel = cms.untracked.InputTag('offlinePrimaryVertices'),
+                                 perLSsaving        = cms.untracked.bool(False), #driven by DQMServices/Core/python/DQMStore_cfi.py
                                  #TrackLabel         = cms.untracked.InputTag('ALCARECOTkAlMinBias'),
                                  TrackLabel         = cms.untracked.InputTag('generalTracks'),
                                  ScalerLabel        = cms.untracked.InputTag('scalerBeamSpot'),

--- a/DQM/CTPPS/plugins/CTPPSCommonDQMSource.cc
+++ b/DQM/CTPPS/plugins/CTPPSCommonDQMSource.cc
@@ -124,14 +124,14 @@ void CTPPSCommonDQMSource::GlobalPlots::Init(DQMStore::IBooker &ibooker) {
      2 -> warning
      3 -> ok
   */
-  /*  RPState = ibooker.book2D("rpstate per LS",
+    RPState = ibooker.book2D("rpstate per LS",
                            "RP State per Lumisection;Luminosity Section;",
                            MAX_LUMIS,
                            0,
                            MAX_LUMIS,
                            MAX_VBINS,
                            0.,
-                           MAX_VBINS);*/
+                           MAX_VBINS);
   {
     TH2F *hist = RPState->getTH2F();
     hist->SetCanExtend(TH1::kAllAxes);

--- a/DQM/CTPPS/plugins/CTPPSCommonDQMSource.cc
+++ b/DQM/CTPPS/plugins/CTPPSCommonDQMSource.cc
@@ -52,6 +52,7 @@ private:
   const edm::EDGetTokenT<std::vector<reco::ForwardProton>> tokenRecoProtons;
 
   bool makeProtonRecoPlots_;
+  bool perLSsaving_;  //to avoid nanoDQMIO crashing, driven by  DQMServices/Core/python/DQMStore_cfi.py
 
   int currentLS;
   int endLS;
@@ -123,14 +124,14 @@ void CTPPSCommonDQMSource::GlobalPlots::Init(DQMStore::IBooker &ibooker) {
      2 -> warning
      3 -> ok
   */
-  RPState = ibooker.book2D("rpstate per LS",
+  /*  RPState = ibooker.book2D("rpstate per LS",
                            "RP State per Lumisection;Luminosity Section;",
                            MAX_LUMIS,
                            0,
                            MAX_LUMIS,
                            MAX_VBINS,
                            0.,
-                           MAX_VBINS);
+                           MAX_VBINS);*/
   {
     TH2F *hist = RPState->getTH2F();
     hist->SetCanExtend(TH1::kAllAxes);
@@ -287,7 +288,8 @@ CTPPSCommonDQMSource::CTPPSCommonDQMSource(const edm::ParameterSet &ps)
       ctppsRecordToken(consumes<CTPPSRecord>(ps.getUntrackedParameter<edm::InputTag>("ctppsmetadata"))),
       tokenLocalTrackLite(consumes<vector<CTPPSLocalTrackLite>>(ps.getParameter<edm::InputTag>("tagLocalTrackLite"))),
       tokenRecoProtons(consumes<std::vector<reco::ForwardProton>>(ps.getParameter<InputTag>("tagRecoProtons"))),
-      makeProtonRecoPlots_(ps.getParameter<bool>("makeProtonRecoPlots")) {
+      makeProtonRecoPlots_(ps.getParameter<bool>("makeProtonRecoPlots")),
+      perLSsaving_(ps.getUntrackedParameter<bool>("perLSsaving", false)) {
   currentLS = 0;
   endLS = 0;
   rpstate.clear();
@@ -545,8 +547,10 @@ std::shared_ptr<std::vector<int>> CTPPSCommonDQMSource::globalBeginLuminosityBlo
 void CTPPSCommonDQMSource::globalEndLuminosityBlock(const edm::LuminosityBlock &iLumi, const edm::EventSetup &c) {
   auto const &rpstate = *luminosityBlockCache(iLumi.index());
   auto currentLS = iLumi.id().luminosityBlock();
-  for (std::vector<int>::size_type i = 0; i < rpstate.size(); i++)
-    globalPlots.RPState->setBinContent(currentLS, i + 1, rpstate[i]);
+  if (!perLSsaving_) {
+    for (std::vector<int>::size_type i = 0; i < rpstate.size(); i++)
+      globalPlots.RPState->setBinContent(currentLS, i + 1, rpstate[i]);
+  }
 }
 
 //----------------------------------------------------------------------------------------------------

--- a/DQM/CTPPS/plugins/CTPPSCommonDQMSource.cc
+++ b/DQM/CTPPS/plugins/CTPPSCommonDQMSource.cc
@@ -124,7 +124,7 @@ void CTPPSCommonDQMSource::GlobalPlots::Init(DQMStore::IBooker &ibooker) {
      2 -> warning
      3 -> ok
   */
-    RPState = ibooker.book2D("rpstate per LS",
+  RPState = ibooker.book2D("rpstate per LS",
                            "RP State per Lumisection;Luminosity Section;",
                            MAX_LUMIS,
                            0,

--- a/DQM/CTPPS/plugins/CTPPSDiamondDQMSource.cc
+++ b/DQM/CTPPS/plugins/CTPPSDiamondDQMSource.cc
@@ -556,9 +556,11 @@ std::shared_ptr<dds::Cache> CTPPSDiamondDQMSource::globalBeginLuminosityBlock(co
                                                                               const edm::EventSetup&) const {
   auto d = std::make_shared<dds::Cache>();
   d->hitDistribution2dMap.reserve(potPlots_.size());
+  if(!perLSsaving_){
   for (auto& plot : potPlots_)
     d->hitDistribution2dMap[plot.first] =
         std::unique_ptr<TH2F>(static_cast<TH2F*>(plot.second.hitDistribution2d_lumisection->getTH2F()->Clone()));
+  }
   return d;
 }
 
@@ -749,12 +751,14 @@ void CTPPSDiamondDQMSource::analyze(const edm::Event& event, const edm::EventSet
           hitHistoTmp->Fill(detId.plane() + UFSDShift, hitHistoTmpYAxis->GetBinCenter(startBin + i));
         }
 
+        if(!perLSsaving_){ 
         hitHistoTmp = lumiCache->hitDistribution2dMap[detId_pot].get();
         hitHistoTmpYAxis = hitHistoTmp->GetYaxis();
         startBin = hitHistoTmpYAxis->FindBin(rechit.x() - horizontalShiftOfDiamond_ - 0.5 * rechit.xWidth());
         numOfBins = rechit.xWidth() * INV_DISPLAY_RESOLUTION_FOR_HITS_MM;
         for (int i = 0; i < numOfBins; ++i) {
           hitHistoTmp->Fill(detId.plane() + UFSDShift, hitHistoTmpYAxis->GetBinCenter(startBin + i));
+        }
         }
       }
 

--- a/DQM/CTPPS/plugins/CTPPSDiamondDQMSource.cc
+++ b/DQM/CTPPS/plugins/CTPPSDiamondDQMSource.cc
@@ -258,14 +258,14 @@ CTPPSDiamondDQMSource::PotPlots::PotPlots(DQMStore::IBooker& ibooker, unsigned i
                                      19. * INV_DISPLAY_RESOLUTION_FOR_HITS_MM,
                                      -0.5,
                                      18.5);
-  /*  hitDistribution2d_lumisection = ibooker.book2D("hits in planes lumisection",
+  hitDistribution2d_lumisection = ibooker.book2D("hits in planes lumisection",
                                                  title + " hits in planes in the last lumisection;plane number;x (mm)",
                                                  10,
                                                  -0.5,
                                                  4.5,
                                                  19. * INV_DISPLAY_RESOLUTION_FOR_HITS_MM,
                                                  -0.5,
-                                                 18.5);*/
+                                                 18.5);
   hitDistribution2dOOT = ibooker.book2D("hits with OOT in planes",
                                         title + " hits with OOT in planes;plane number + 0.25 OOT;x (mm)",
                                         17,
@@ -556,9 +556,9 @@ std::shared_ptr<dds::Cache> CTPPSDiamondDQMSource::globalBeginLuminosityBlock(co
                                                                               const edm::EventSetup&) const {
   auto d = std::make_shared<dds::Cache>();
   d->hitDistribution2dMap.reserve(potPlots_.size());
-  //  for (auto& plot : potPlots_)
-  //    d->hitDistribution2dMap[plot.first] =
-  //        std::unique_ptr<TH2F>(static_cast<TH2F*>(plot.second.hitDistribution2d_lumisection->getTH2F()->Clone()));
+  for (auto& plot : potPlots_)
+    d->hitDistribution2dMap[plot.first] =
+          std::unique_ptr<TH2F>(static_cast<TH2F*>(plot.second.hitDistribution2d_lumisection->getTH2F()->Clone()));
   return d;
 }
 
@@ -1135,7 +1135,7 @@ void CTPPSDiamondDQMSource::globalEndLuminosityBlock(const edm::LuminosityBlock&
     for (auto& plot : potPlots_) {
       *(plot.second.hitDistribution2d_lumisection->getTH2F()) = *(lumiCache->hitDistribution2dMap[plot.first]);
     }
-  }
+  
   for (auto& plot : channelPlots_) {
     auto hitsCounterPerLumisection = lumiCache->hitsCounterMap[plot.first];
     if (hitsCounterPerLumisection != 0) {
@@ -1171,7 +1171,6 @@ void CTPPSDiamondDQMSource::globalEndLuminosityBlock(const edm::LuminosityBlock&
       }
     }
   }
-
   // Efficiencies of single channels
   for (auto& plot : potPlots_) {
     plot.second.EfficiencyOfChannelsInPot->Reset();
@@ -1198,6 +1197,7 @@ void CTPPSDiamondDQMSource::globalEndLuminosityBlock(const edm::LuminosityBlock&
 
     hitHistoTmp->Divide(&(plot.second.pixelTracksMapWithDiamonds), &(potPlots_[detId_pot].pixelTracksMap));
   }
+ }//perLSsaving
 }
 
 //----------------------------------------------------------------------------------------------------

--- a/DQM/CTPPS/plugins/CTPPSDiamondDQMSource.cc
+++ b/DQM/CTPPS/plugins/CTPPSDiamondDQMSource.cc
@@ -556,10 +556,10 @@ std::shared_ptr<dds::Cache> CTPPSDiamondDQMSource::globalBeginLuminosityBlock(co
                                                                               const edm::EventSetup&) const {
   auto d = std::make_shared<dds::Cache>();
   d->hitDistribution2dMap.reserve(potPlots_.size());
-  if(!perLSsaving_){
-  for (auto& plot : potPlots_)
-    d->hitDistribution2dMap[plot.first] =
-        std::unique_ptr<TH2F>(static_cast<TH2F*>(plot.second.hitDistribution2d_lumisection->getTH2F()->Clone()));
+  if (!perLSsaving_) {
+    for (auto& plot : potPlots_)
+      d->hitDistribution2dMap[plot.first] =
+          std::unique_ptr<TH2F>(static_cast<TH2F*>(plot.second.hitDistribution2d_lumisection->getTH2F()->Clone()));
   }
   return d;
 }
@@ -751,14 +751,14 @@ void CTPPSDiamondDQMSource::analyze(const edm::Event& event, const edm::EventSet
           hitHistoTmp->Fill(detId.plane() + UFSDShift, hitHistoTmpYAxis->GetBinCenter(startBin + i));
         }
 
-        if(!perLSsaving_){ 
-        hitHistoTmp = lumiCache->hitDistribution2dMap[detId_pot].get();
-        hitHistoTmpYAxis = hitHistoTmp->GetYaxis();
-        startBin = hitHistoTmpYAxis->FindBin(rechit.x() - horizontalShiftOfDiamond_ - 0.5 * rechit.xWidth());
-        numOfBins = rechit.xWidth() * INV_DISPLAY_RESOLUTION_FOR_HITS_MM;
-        for (int i = 0; i < numOfBins; ++i) {
-          hitHistoTmp->Fill(detId.plane() + UFSDShift, hitHistoTmpYAxis->GetBinCenter(startBin + i));
-        }
+        if (!perLSsaving_) {
+          hitHistoTmp = lumiCache->hitDistribution2dMap[detId_pot].get();
+          hitHistoTmpYAxis = hitHistoTmp->GetYaxis();
+          startBin = hitHistoTmpYAxis->FindBin(rechit.x() - horizontalShiftOfDiamond_ - 0.5 * rechit.xWidth());
+          numOfBins = rechit.xWidth() * INV_DISPLAY_RESOLUTION_FOR_HITS_MM;
+          for (int i = 0; i < numOfBins; ++i) {
+            hitHistoTmp->Fill(detId.plane() + UFSDShift, hitHistoTmpYAxis->GetBinCenter(startBin + i));
+          }
         }
       }
 

--- a/DQM/CTPPS/plugins/TotemTimingDQMSource.cc
+++ b/DQM/CTPPS/plugins/TotemTimingDQMSource.cc
@@ -741,47 +741,47 @@ void TotemTimingDQMSource::analyze(const edm::Event &event, const edm::EventSetu
 void TotemTimingDQMSource::globalEndLuminosityBlock(const edm::LuminosityBlock &iLumi, const edm::EventSetup &) {
   auto lumiCache = luminosityBlockCache(iLumi.index());
   if (!perLSsaving_) {
-   for (auto &plot : potPlots_) {
-     *(plot.second.hitDistribution2d_lumisection->getTH2F()) = *(lumiCache->hitDistribution2dMap[plot.first]);
-   }
+    for (auto &plot : potPlots_) {
+      *(plot.second.hitDistribution2d_lumisection->getTH2F()) = *(lumiCache->hitDistribution2dMap[plot.first]);
+    }
 
-  globalPlot_.digiSentPercentage->Reset();
-  TH2F *hitHistoGlobalTmp = globalPlot_.digiSentPercentage->getTH2F();
-  for (auto &plot : potPlots_) {
-    TH2F *hitHistoTmp = plot.second.digiSentPercentage->getTH2F();
-    TH2F *histoSent = plot.second.digiSent->getTH2F();
-    TH2F *histoAll = plot.second.digiAll->getTH2F();
+    globalPlot_.digiSentPercentage->Reset();
+    TH2F *hitHistoGlobalTmp = globalPlot_.digiSentPercentage->getTH2F();
+    for (auto &plot : potPlots_) {
+      TH2F *hitHistoTmp = plot.second.digiSentPercentage->getTH2F();
+      TH2F *histoSent = plot.second.digiSent->getTH2F();
+      TH2F *histoAll = plot.second.digiAll->getTH2F();
 
-    hitHistoTmp->Divide(histoSent, histoAll);
-    hitHistoTmp->Scale(100);
-    hitHistoGlobalTmp->Add(hitHistoTmp, 1);
+      hitHistoTmp->Divide(histoSent, histoAll);
+      hitHistoTmp->Scale(100);
+      hitHistoGlobalTmp->Add(hitHistoTmp, 1);
 
-    plot.second.baseline->Reset();
-    plot.second.noiseRMS->Reset();
-    plot.second.meanAmplitude->Reset();
-    plot.second.cellOfMax->Reset();
-    plot.second.hitRate->Reset();
-    TotemTimingDetId rpId(plot.first);
-    for (auto &chPlot : channelPlots_) {
-      TotemTimingDetId chId(chPlot.first);
-      if (chId.arm() == rpId.arm() && chId.rp() == rpId.rp()) {
-        plot.second.baseline->Fill(chId.plane(), chId.channel(), chPlot.second.noiseSamples->getTH1F()->GetMean());
-        plot.second.noiseRMS->Fill(chId.plane(), chId.channel(), chPlot.second.noiseSamples->getTH1F()->GetRMS());
-        plot.second.meanAmplitude->Fill(chId.plane(), chId.channel(), chPlot.second.amplitude->getTH1F()->GetMean());
-        plot.second.cellOfMax->Fill(chId.plane(), chId.channel(), chPlot.second.cellOfMax->getTH1F()->GetMean());
-        auto hitsCounterPerLumisection = lumiCache->hitsCounterMap[chPlot.first];
-        plot.second.hitRate->Fill(chId.plane(), chId.channel(), (double)hitsCounterPerLumisection * HIT_RATE_FACTOR);
+      plot.second.baseline->Reset();
+      plot.second.noiseRMS->Reset();
+      plot.second.meanAmplitude->Reset();
+      plot.second.cellOfMax->Reset();
+      plot.second.hitRate->Reset();
+      TotemTimingDetId rpId(plot.first);
+      for (auto &chPlot : channelPlots_) {
+        TotemTimingDetId chId(chPlot.first);
+        if (chId.arm() == rpId.arm() && chId.rp() == rpId.rp()) {
+          plot.second.baseline->Fill(chId.plane(), chId.channel(), chPlot.second.noiseSamples->getTH1F()->GetMean());
+          plot.second.noiseRMS->Fill(chId.plane(), chId.channel(), chPlot.second.noiseSamples->getTH1F()->GetRMS());
+          plot.second.meanAmplitude->Fill(chId.plane(), chId.channel(), chPlot.second.amplitude->getTH1F()->GetMean());
+          plot.second.cellOfMax->Fill(chId.plane(), chId.channel(), chPlot.second.cellOfMax->getTH1F()->GetMean());
+          auto hitsCounterPerLumisection = lumiCache->hitsCounterMap[chPlot.first];
+          plot.second.hitRate->Fill(chId.plane(), chId.channel(), (double)hitsCounterPerLumisection * HIT_RATE_FACTOR);
+        }
+      }
+    }
+
+    for (auto &plot : channelPlots_) {
+      auto hitsCounterPerLumisection = lumiCache->hitsCounterMap[plot.first];
+      if (hitsCounterPerLumisection != 0) {
+        plot.second.hitRate->Fill((double)hitsCounterPerLumisection * HIT_RATE_FACTOR);
       }
     }
   }
-
-  for (auto &plot : channelPlots_) {
-    auto hitsCounterPerLumisection = lumiCache->hitsCounterMap[plot.first];
-    if (hitsCounterPerLumisection != 0) {
-      plot.second.hitRate->Fill((double)hitsCounterPerLumisection * HIT_RATE_FACTOR);
-    }
-  }
- }
 }
 
 DEFINE_FWK_MODULE(TotemTimingDQMSource);

--- a/DQM/CTPPS/plugins/TotemTimingDQMSource.cc
+++ b/DQM/CTPPS/plugins/TotemTimingDQMSource.cc
@@ -741,10 +741,9 @@ void TotemTimingDQMSource::analyze(const edm::Event &event, const edm::EventSetu
 void TotemTimingDQMSource::globalEndLuminosityBlock(const edm::LuminosityBlock &iLumi, const edm::EventSetup &) {
   auto lumiCache = luminosityBlockCache(iLumi.index());
   if (!perLSsaving_) {
-    for (auto &plot : potPlots_) {
-      *(plot.second.hitDistribution2d_lumisection->getTH2F()) = *(lumiCache->hitDistribution2dMap[plot.first]);
-    }
-  }
+   for (auto &plot : potPlots_) {
+     *(plot.second.hitDistribution2d_lumisection->getTH2F()) = *(lumiCache->hitDistribution2dMap[plot.first]);
+   }
 
   globalPlot_.digiSentPercentage->Reset();
   TH2F *hitHistoGlobalTmp = globalPlot_.digiSentPercentage->getTH2F();
@@ -782,6 +781,7 @@ void TotemTimingDQMSource::globalEndLuminosityBlock(const edm::LuminosityBlock &
       plot.second.hitRate->Fill((double)hitsCounterPerLumisection * HIT_RATE_FACTOR);
     }
   }
+ }
 }
 
 DEFINE_FWK_MODULE(TotemTimingDQMSource);

--- a/DQM/CTPPS/python/ctppsCommonDQMSource_cfi.py
+++ b/DQM/CTPPS/python/ctppsCommonDQMSource_cfi.py
@@ -9,5 +9,7 @@ ctppsCommonDQMSource = DQMEDAnalyzer('CTPPSCommonDQMSource',
 
     makeProtonRecoPlots = cms.bool(True),
 
+    perLSsaving = cms.untracked.bool(False), #driven by DQMServices/Core/python/DQMStore_cfi.py
+
     verbosity = cms.untracked.uint32(0),
 )

--- a/DQM/CTPPS/python/ctppsDQM_cff.py
+++ b/DQM/CTPPS/python/ctppsDQM_cff.py
@@ -49,6 +49,13 @@ ctppsCommonDQMSourceOffline = ctppsCommonDQMSource.clone(
   makeProtonRecoPlots = True
 )
 
+#Check if perLSsaving is enabled to mask MEs vs LS
+from DQMServices.Core.DQMStore_cfi import DQMStore
+if(DQMStore.saveByLumi):
+    ctppsDiamondDQMSource.perLSsaving=True
+    totemTimingDQMSource.perLSsaving=True
+    ctppsCommonDQMSourceOffline.perLSsaving=True
+
 _ctppsDQMOfflineSource = cms.Sequence(
   ctppsPixelDQMOfflineSource
   + ctppsDiamondDQMSource

--- a/DQM/CTPPS/python/ctppsDiamondDQMSource_cfi.py
+++ b/DQM/CTPPS/python/ctppsDiamondDQMSource_cfi.py
@@ -33,6 +33,8 @@ ctppsDiamondDQMSource = DQMEDAnalyzer('CTPPSDiamondDQMSource',
             centralOOT = cms.int32(0),
         ),
     ),
+
+    perLSsaving = cms.untracked.bool(False), #driven by DQMServices/Core/python/DQMStore_cfi.py
   
     verbosity = cms.untracked.uint32(10),
 )

--- a/DQM/CTPPS/python/totemTimingDQMSource_cfi.py
+++ b/DQM/CTPPS/python/totemTimingDQMSource_cfi.py
@@ -12,5 +12,7 @@ totemTimingDQMSource = DQMEDAnalyzer('TotemTimingDQMSource',
     maximumStripAngleForTomography = cms.double(1),
     samplesForNoise = cms.untracked.uint32(6),
 
+    perLSsaving = cms.untracked.bool(False), #driven by DQMServices/Core/python/DQMStore_cfi.py
+
     verbosity = cms.untracked.uint32(10),
 )

--- a/DQM/EcalPreshowerMonitorModule/python/es_dqm_source_offline_cff.py
+++ b/DQM/EcalPreshowerMonitorModule/python/es_dqm_source_offline_cff.py
@@ -2,7 +2,10 @@ import FWCore.ParameterSet.Config as cms
 
 from DQM.EcalPreshowerMonitorModule.ESRawDataTask_cfi import *
 from DQM.EcalPreshowerMonitorModule.ESIntegrityTask_cfi import *
-ecalPreshowerIntegrityTask.DoLumiAnalysis = True
+#Check if perLSsaving is enabled to mask MEs vs LS
+from DQMServices.Core.DQMStore_cfi import DQMStore
+if(not DQMStore.saveByLumi):
+    ecalPreshowerIntegrityTask.DoLumiAnalysis = True
 from DQM.EcalPreshowerMonitorModule.ESFEDIntegrityTask_cfi import *
 from DQM.EcalPreshowerMonitorModule.ESOccupancyTask_cfi import *
 from DQM.EcalPreshowerMonitorModule.ESTrendTask_cfi import *

--- a/DQM/L1TMonitor/interface/L1TdeRCT.h
+++ b/DQM/L1TMonitor/interface/L1TdeRCT.h
@@ -255,6 +255,7 @@ private:
   std::string histFolder_;  // base dqm folder
   bool verbose_;
   bool singlechannelhistos_;
+  bool perLSsaving_; //to avoid nanoDQMIO crashing, driven by  DQMServices/Core/python/DQMStore_cfi.py
 
   edm::EDGetTokenT<L1CaloRegionCollection> rctSourceEmul_rgnEmul_;
   edm::EDGetTokenT<L1CaloEmCollection> rctSourceEmul_emEmul_;

--- a/DQM/L1TMonitor/interface/L1TdeRCT.h
+++ b/DQM/L1TMonitor/interface/L1TdeRCT.h
@@ -255,7 +255,7 @@ private:
   std::string histFolder_;  // base dqm folder
   bool verbose_;
   bool singlechannelhistos_;
-  bool perLSsaving_; //to avoid nanoDQMIO crashing, driven by  DQMServices/Core/python/DQMStore_cfi.py
+  bool perLSsaving_;  //to avoid nanoDQMIO crashing, driven by  DQMServices/Core/python/DQMStore_cfi.py
 
   edm::EDGetTokenT<L1CaloRegionCollection> rctSourceEmul_rgnEmul_;
   edm::EDGetTokenT<L1CaloEmCollection> rctSourceEmul_emEmul_;

--- a/DQM/L1TMonitor/python/L1TEmulatorMonitor_cff.py
+++ b/DQM/L1TMonitor/python/L1TEmulatorMonitor_cff.py
@@ -37,6 +37,11 @@ from DQM.L1TMonitor.L1TdeGCT_cfi import *
 from DQM.L1TMonitor.L1TdeStage1Layer2_cfi import *
 
 from DQM.L1TMonitor.L1TdeRCT_cfi import *
+#Check if perLSsaving is enabled to mask MEs vs LS
+from DQMServices.Core.DQMStore_cfi import DQMStore
+if(DQMStore.saveByLumi):
+    l1TdeRCT.perLSsaving=True
+
 l1TdeRCTRun1 = l1TdeRCT.clone()
 l1TdeRCT.rctSourceData = 'caloStage1Digis'
 #l1TdeRCT.gctSourceData = 'caloStage1Digis'

--- a/DQM/L1TMonitor/python/L1TdeRCT_cfi.py
+++ b/DQM/L1TMonitor/python/L1TdeRCT_cfi.py
@@ -6,6 +6,7 @@ l1TdeRCT = DQMEDAnalyzer('L1TdeRCT',
     HistFolder = cms.untracked.string('L1TEMU/L1TdeRCT'),
     verbose = cms.untracked.bool(False),
     DQMStore = cms.untracked.bool(True),
+    perLSsaving = cms.untracked.bool(False), #driven by DQMServices/Core/python/DQMStore_cfi.py
     singlechannelhistos = cms.untracked.bool(False),
     ecalTPGData = cms.InputTag("ecalDigis","EcalTriggerPrimitives"),
     rctSourceEmul = cms.InputTag("valRctDigis"),

--- a/DQM/L1TMonitor/src/L1TdeRCT.cc
+++ b/DQM/L1TMonitor/src/L1TdeRCT.cc
@@ -1961,18 +1961,22 @@ void L1TdeRCT::bookHistograms(DQMStore::IBooker& ibooker, const edm::Run& run, c
 
   ibooker.setCurrentFolder(histFolder_ + "/DBData");
   fedVectorMonitorRUN_ = ibooker.book2D("rctFedVectorMonitorRUN", "FED Vector Monitor Per Run", 108, 0, 108, 2, 0, 2);
-  if(!perLSsaving_) fedVectorMonitorLS_ = ibooker.book2D("rctFedVectorMonitorLS", "FED Vector Monitor Per LS", 108, 0, 108, 2, 0, 2);
+  if (!perLSsaving_)
+    fedVectorMonitorLS_ = ibooker.book2D("rctFedVectorMonitorLS", "FED Vector Monitor Per LS", 108, 0, 108, 2, 0, 2);
 
   for (unsigned int i = 0; i < 108; ++i) {
     char fed[10];
     sprintf(fed, "%d", crateFED[i]);
     fedVectorMonitorRUN_->setBinLabel(i + 1, fed);
-    if(!perLSsaving_) fedVectorMonitorLS_->setBinLabel(i + 1, fed);
+    if (!perLSsaving_)
+      fedVectorMonitorLS_->setBinLabel(i + 1, fed);
   }
   fedVectorMonitorRUN_->getTH2F()->GetYaxis()->SetBinLabel(1, "OUT");
   fedVectorMonitorRUN_->getTH2F()->GetYaxis()->SetBinLabel(2, "IN");
-  if(!perLSsaving_) {fedVectorMonitorLS_->getTH2F()->GetYaxis()->SetBinLabel(1, "OUT");
-                     fedVectorMonitorLS_->getTH2F()->GetYaxis()->SetBinLabel(2, "IN");}
+  if (!perLSsaving_) {
+    fedVectorMonitorLS_->getTH2F()->GetYaxis()->SetBinLabel(1, "OUT");
+    fedVectorMonitorLS_->getTH2F()->GetYaxis()->SetBinLabel(2, "IN");
+  }
 
   // for single channels
 
@@ -2083,7 +2087,8 @@ void L1TdeRCT::bookHistograms(DQMStore::IBooker& ibooker, const edm::Run& run, c
 
 std::shared_ptr<l1tderct::Empty> L1TdeRCT::globalBeginLuminosityBlock(const edm::LuminosityBlock& ls,
                                                                       const edm::EventSetup& es) const {
-  if(!perLSsaving_) readFEDVector(fedVectorMonitorLS_, es);
+  if (!perLSsaving_)
+    readFEDVector(fedVectorMonitorLS_, es);
   return std::shared_ptr<l1tderct::Empty>();
 }
 

--- a/DQM/L1TMonitor/src/L1TdeRCT.cc
+++ b/DQM/L1TMonitor/src/L1TdeRCT.cc
@@ -92,6 +92,8 @@ L1TdeRCT::L1TdeRCT(const ParameterSet& ps)
       dataInputTagName_(ps.getParameter<InputTag>("rctSourceData").label()) {
   singlechannelhistos_ = ps.getUntrackedParameter<bool>("singlechannelhistos", false);
 
+  perLSsaving_ = (ps.getUntrackedParameter<bool>("perLSsaving", false));
+
   if (singlechannelhistos_)
     if (verbose_)
       std::cout << "L1TdeRCT: single channels histos ON" << std::endl;
@@ -1959,18 +1961,18 @@ void L1TdeRCT::bookHistograms(DQMStore::IBooker& ibooker, const edm::Run& run, c
 
   ibooker.setCurrentFolder(histFolder_ + "/DBData");
   fedVectorMonitorRUN_ = ibooker.book2D("rctFedVectorMonitorRUN", "FED Vector Monitor Per Run", 108, 0, 108, 2, 0, 2);
-  fedVectorMonitorLS_ = ibooker.book2D("rctFedVectorMonitorLS", "FED Vector Monitor Per LS", 108, 0, 108, 2, 0, 2);
+  if(!perLSsaving_) fedVectorMonitorLS_ = ibooker.book2D("rctFedVectorMonitorLS", "FED Vector Monitor Per LS", 108, 0, 108, 2, 0, 2);
 
   for (unsigned int i = 0; i < 108; ++i) {
     char fed[10];
     sprintf(fed, "%d", crateFED[i]);
     fedVectorMonitorRUN_->setBinLabel(i + 1, fed);
-    fedVectorMonitorLS_->setBinLabel(i + 1, fed);
+    if(!perLSsaving_) fedVectorMonitorLS_->setBinLabel(i + 1, fed);
   }
   fedVectorMonitorRUN_->getTH2F()->GetYaxis()->SetBinLabel(1, "OUT");
   fedVectorMonitorRUN_->getTH2F()->GetYaxis()->SetBinLabel(2, "IN");
-  fedVectorMonitorLS_->getTH2F()->GetYaxis()->SetBinLabel(1, "OUT");
-  fedVectorMonitorLS_->getTH2F()->GetYaxis()->SetBinLabel(2, "IN");
+  if(!perLSsaving_) {fedVectorMonitorLS_->getTH2F()->GetYaxis()->SetBinLabel(1, "OUT");
+                     fedVectorMonitorLS_->getTH2F()->GetYaxis()->SetBinLabel(2, "IN");}
 
   // for single channels
 
@@ -2081,7 +2083,7 @@ void L1TdeRCT::bookHistograms(DQMStore::IBooker& ibooker, const edm::Run& run, c
 
 std::shared_ptr<l1tderct::Empty> L1TdeRCT::globalBeginLuminosityBlock(const edm::LuminosityBlock& ls,
                                                                       const edm::EventSetup& es) const {
-  readFEDVector(fedVectorMonitorLS_, es);
+  if(!perLSsaving_) readFEDVector(fedVectorMonitorLS_, es);
   return std::shared_ptr<l1tderct::Empty>();
 }
 

--- a/DQM/SiPixelCommon/python/SiPixelOfflineDQM_source_cff.py
+++ b/DQM/SiPixelCommon/python/SiPixelOfflineDQM_source_cff.py
@@ -115,6 +115,11 @@ dqmInfo = DQMEDAnalyzer('DQMEventInfo',
     subSystemFolder = cms.untracked.string('Pixel')
 )
 
+#Check if perLSsaving is enabled to mask MEs vs LS
+from DQMServices.Core.DQMStore_cfi import DQMStore
+if(DQMStore.saveByLumi):
+    SiPixelDigiSource.perLSsaving=True
+
 #FED integrity
 from DQM.SiPixelMonitorRawData.SiPixelMonitorHLT_cfi import *
 

--- a/DQM/SiPixelMonitorDigi/interface/SiPixelDigiSource.h
+++ b/DQM/SiPixelMonitorDigi/interface/SiPixelDigiSource.h
@@ -57,7 +57,7 @@ private:
   bool isPIB;
   bool slowDown;
   bool modOn;
-  bool perLSsaving; //to avoid nanoDQMIO crashing, driven by  DQMServices/Core/python/DQMStore_cfi.py
+  bool perLSsaving;  //to avoid nanoDQMIO crashing, driven by  DQMServices/Core/python/DQMStore_cfi.py
   bool twoDimOn;
   bool twoDimModOn;
   bool twoDimOnlyLayDisk;

--- a/DQM/SiPixelMonitorDigi/interface/SiPixelDigiSource.h
+++ b/DQM/SiPixelMonitorDigi/interface/SiPixelDigiSource.h
@@ -57,6 +57,7 @@ private:
   bool isPIB;
   bool slowDown;
   bool modOn;
+  bool perLSsaving; //to avoid nanoDQMIO crashing, driven by  DQMServices/Core/python/DQMStore_cfi.py
   bool twoDimOn;
   bool twoDimModOn;
   bool twoDimOnlyLayDisk;

--- a/DQM/SiPixelMonitorDigi/python/SiPixelMonitorDigi_cfi.py
+++ b/DQM/SiPixelMonitorDigi/python/SiPixelMonitorDigi_cfi.py
@@ -13,6 +13,7 @@ SiPixelDigiSource = DQMEDAnalyzer('SiPixelDigiSource',
     isPIB = cms.untracked.bool(False),
     slowDown = cms.untracked.bool(False),
     modOn = cms.untracked.bool(True),
+    perLSsaving = cms.untracked.bool(False), #driven by DQMServices/Core/python/DQMStore_cfi.py
     twoDimOn = cms.untracked.bool(True),	
     twoDimModOn = cms.untracked.bool(True),     
     #allows to have no twoD plots on Mod level (but possibly on other levels),

--- a/DQM/SiPixelMonitorDigi/src/SiPixelDigiSource.cc
+++ b/DQM/SiPixelMonitorDigi/src/SiPixelDigiSource.cc
@@ -50,6 +50,7 @@ SiPixelDigiSource::SiPixelDigiSource(const edm::ParameterSet& iConfig)
       isPIB(conf_.getUntrackedParameter<bool>("isPIB", false)),
       slowDown(conf_.getUntrackedParameter<bool>("slowDown", false)),
       modOn(conf_.getUntrackedParameter<bool>("modOn", true)),
+      perLSsaving(conf_.getUntrackedParameter<bool>("perLSsaving", false)),
       twoDimOn(conf_.getUntrackedParameter<bool>("twoDimOn", true)),
       twoDimModOn(conf_.getUntrackedParameter<bool>("twoDimModOn", true)),
       twoDimOnlyLayDisk(conf_.getUntrackedParameter<bool>("twoDimOnlyLayDisk", false)),
@@ -1254,7 +1255,7 @@ void SiPixelDigiSource::bookMEs(DQMStore::IBooker& iBooker, const edm::EventSetu
         0.,
         3200.);
   }
-  if (!modOn) {
+  if (!modOn && !perLSsaving) {
     averageDigiOccupancy = iBooker.book1D(
         "averageDigiOccupancy", title7, 40, -0.5, 39.5);  //Book as TH1 for offline to ensure thread-safe behaviour
     avgfedDigiOccvsLumi = iBooker.book2D("avgfedDigiOccvsLumi", title8, 3200, 0., 3200., 40, -0.5, 39.5);

--- a/DQMOffline/CalibCalo/python/MonitorAlCaHcalPhisym_cfi.py
+++ b/DQMOffline/CalibCalo/python/MonitorAlCaHcalPhisym_cfi.py
@@ -22,6 +22,8 @@ HcalPhiSymMon = DQMEDAnalyzer('DQMHcalPhiSymAlCaReco',
     # File to save 
     SaveToFile = cms.untracked.bool(False),
     FileName = cms.untracked.string('MonitorAlCaHcalPhiSym.root'),
+    #driven by DQMServices/Core/python/DQMStore_cfi.py
+    perLSsaving = cms.untracked.bool(False), 
     # DQM folder to write to
     FolderName = cms.untracked.string('AlCaReco/HcalPhiSym')
 )

--- a/DQMOffline/CalibCalo/src/DQMHcalPhiSymAlCaReco.cc
+++ b/DQMOffline/CalibCalo/src/DQMHcalPhiSymAlCaReco.cc
@@ -62,6 +62,8 @@ DQMHcalPhiSymAlCaReco::DQMHcalPhiSymAlCaReco(const edm::ParameterSet &ps) : even
   saveToFile_ = ps.getUntrackedParameter<bool>("SaveToFile", false);
   fileName_ = ps.getUntrackedParameter<string>("FileName", "MonitorAlCaHcalPhiSym.root");
 
+  perLSsaving_ = (ps.getUntrackedParameter<bool>("perLSsaving", false));
+
   // histogram parameters
 
   // Distribution of rechits in iPhi, iEta
@@ -441,7 +443,7 @@ void DQMHcalPhiSymAlCaReco::analyze(const Event &iEvent, const EventSetup &iSetu
 //--------------------------------------------------------
 void DQMHcalPhiSymAlCaReco::dqmEndRun(const Run &r, const EventSetup &context) {
   // Keep Variances
-  if (eventCounter_ > 0) {
+  if (eventCounter_ > 0 && !perLSsaving_) {
     for (int k = 0; k <= hiDistr_x_nbin_; k++) {
       for (int j = 0; j <= hiDistr_y_nbin_; j++) {
         // First moment

--- a/DQMOffline/CalibCalo/src/DQMHcalPhiSymAlCaReco.h
+++ b/DQMOffline/CalibCalo/src/DQMHcalPhiSymAlCaReco.h
@@ -69,6 +69,8 @@ private:
   double ihbhe_size_;
   double ihf_size_;
 
+  bool perLSsaving_;  //to avoid nanoDQMIO crashing, driven by  DQMServices/Core/python/DQMStore_cfi.py
+
   /// object to monitor
 
   edm::EDGetTokenT<HBHERecHitCollection> hbherecoMB;

--- a/DQMOffline/Configuration/python/ALCARECOHcalCalDQMHI_cff.py
+++ b/DQMOffline/Configuration/python/ALCARECOHcalCalDQMHI_cff.py
@@ -6,6 +6,10 @@ import DQMOffline.CalibCalo.MonitorHcalIsoTrackAlCaReco_cfi
 import DQMOffline.CalibCalo.MonitorHcalIsolatedBunchAlCaReco_cfi
 import DQMOffline.CalibCalo.MonitorHOAlCaRecoStream_cfi
 
+#Check if perLSsaving is enabled to mask MEs vs LS
+from DQMServices.Core.DQMStore_cfi import DQMStore
+if(DQMStore.saveByLumi):
+    DQMOffline.CalibCalo.MonitorAlCaHcalPhisym_cfi.HcalPhiSymMon.perLSsaving=True
 
 ALCARECOHcalCalPhisymDQM =  DQMOffline.CalibCalo.MonitorAlCaHcalPhisym_cfi.HcalPhiSymMon.clone()
 

--- a/DQMOffline/Configuration/python/ALCARECOHcalCalDQM_cff.py
+++ b/DQMOffline/Configuration/python/ALCARECOHcalCalDQM_cff.py
@@ -6,6 +6,10 @@ import DQMOffline.CalibCalo.MonitorHcalIsoTrackAlCaReco_cfi
 import DQMOffline.CalibCalo.MonitorHcalIsolatedBunchAlCaReco_cfi
 import DQMOffline.CalibCalo.MonitorHOAlCaRecoStream_cfi
 
+#Check if perLSsaving is enabled to mask MEs vs LS
+from DQMServices.Core.DQMStore_cfi import DQMStore
+if(DQMStore.saveByLumi):
+    DQMOffline.CalibCalo.MonitorAlCaHcalPhisym_cfi.HcalPhiSymMon.perLSsaving=True
 
 ALCARECOHcalCalPhisymDQM =  DQMOffline.CalibCalo.MonitorAlCaHcalPhisym_cfi.HcalPhiSymMon.clone()
 

--- a/DQMOffline/Trigger/plugins/HigPhotonJetHLTOfflineSource.cc
+++ b/DQMOffline/Trigger/plugins/HigPhotonJetHLTOfflineSource.cc
@@ -61,6 +61,7 @@ private:
   std::string dirname_;
   bool verbose_;
   bool triggerAccept_;
+  bool perLSsaving_;  //to avoid nanoDQMIO crashing, driven by  DQMServices/Core/python/DQMStore_cfi.py
 
   edm::EDGetTokenT<edm::TriggerResults> triggerResultsToken_;
   edm::EDGetTokenT<reco::VertexCollection> pvToken_;
@@ -109,6 +110,7 @@ HigPhotonJetHLTOfflineSource::HigPhotonJetHLTOfflineSource(const edm::ParameterS
   hltProcessName_ = pset.getParameter<std::string>("hltProcessName");
   hltPathsToCheck_ = pset.getParameter<std::vector<std::string>>("hltPathsToCheck");
   verbose_ = pset.getUntrackedParameter<bool>("verbose", false);
+  perLSsaving_ = pset.getUntrackedParameter<bool>("perLSsaving", false);
   triggerAccept_ = pset.getUntrackedParameter<bool>("triggerAccept", true);
   triggerResultsToken_ = consumes<edm::TriggerResults>(pset.getParameter<edm::InputTag>("triggerResultsToken"));
   dirname_ = pset.getUntrackedParameter<std::string>("dirname", std::string("HLT/Higgs/PhotonJet/"));
@@ -327,13 +329,15 @@ void HigPhotonJetHLTOfflineSource::analyze(const edm::Event& iEvent, const edm::
 
 void HigPhotonJetHLTOfflineSource::dqmEndRun(const edm::Run& iRun, const edm::EventSetup& iSetup) {
   // Normalize to the total number of events in the run
-  TH2F* h = trigvsnvtx_->getTH2F();
-  double integral = h->Integral();
-  double norm = (integral > 0.) ? evtsrun_ * hltPathsToCheck_.size() / integral : 1.;
-  h->Scale(norm);
-  if (verbose_) {
-    std::cout << "xshi:: endRun total number of events: " << evtsrun_ << ", integral = " << h->Integral()
-              << ", norm = " << norm << std::endl;
+  if (!perLSsaving_) {
+    TH2F* h = trigvsnvtx_->getTH2F();
+    double integral = h->Integral();
+    double norm = (integral > 0.) ? evtsrun_ * hltPathsToCheck_.size() / integral : 1.;
+    h->Scale(norm);
+    if (verbose_) {
+      std::cout << "xshi:: endRun total number of events: " << evtsrun_ << ", integral = " << h->Integral()
+                << ", norm = " << norm << std::endl;
+    }
   }
 }
 

--- a/DQMOffline/Trigger/python/DQMOffline_Trigger_cff.py
+++ b/DQMOffline/Trigger/python/DQMOffline_Trigger_cff.py
@@ -71,7 +71,10 @@ from DQMOffline.Trigger.HILowLumiHLTOfflineSource_cfi import *
 from DQMOffline.Trigger.HiggsMonitoring_cff import *
 # photon jet
 from DQMOffline.Trigger.HigPhotonJetHLTOfflineSource_cfi import * # ?!?!?!
-
+#Check if perLSsaving is enabled to mask MEs vs LS
+from DQMServices.Core.DQMStore_cfi import DQMStore
+if(DQMStore.saveByLumi):
+   higPhotonJetHLTOfflineSource.perLSsaving=True
 # SMP
 from DQMOffline.Trigger.StandardModelMonitoring_cff import *
 

--- a/DQMOffline/Trigger/python/HigPhotonJetHLTOfflineSource_cfi.py
+++ b/DQMOffline/Trigger/python/HigPhotonJetHLTOfflineSource_cfi.py
@@ -29,6 +29,7 @@ higPhotonJetHLTOfflineSource = DQMEDAnalyzer(
 #    dirname = cms.untracked.string("HLT/Higgs/PhotonJet"), 
     dirname = cms.untracked.string("HLT/HIG/PhotonJet"), 
     verbose = cms.untracked.bool(False), # default: False
+    perLSsaving = cms.untracked.bool(False), #driven by DQMServices/Core/python/DQMStore_cfi.py
     triggerAccept = cms.untracked.bool(True), # default: True 
     triggerResultsToken = cms.InputTag("TriggerResults","","HLT"),
     pvToken = cms.InputTag("offlinePrimaryVertices"),

--- a/DQMServices/Core/python/DQMStore_cfi.py
+++ b/DQMServices/Core/python/DQMStore_cfi.py
@@ -5,7 +5,7 @@ DQMStore = cms.Service("DQMStore",
     verbose = cms.untracked.int32(0),
     # similar to LSBasedMode but for offline. Explicitly sets LumiFLag on all
     # MEs/modules that allow it (canSaveByLumi)
-    saveByLumi = cms.untracked.bool(False),
+    saveByLumi = cms.untracked.bool(True),
     #Following list has no effect if saveByLumi is False
     MEsToSave = cms.untracked.vstring(nanoDQMIO_perLSoutput.MEsToSave),  
     trackME = cms.untracked.string(""),

--- a/DQMServices/Core/python/DQMStore_cfi.py
+++ b/DQMServices/Core/python/DQMStore_cfi.py
@@ -5,7 +5,7 @@ DQMStore = cms.Service("DQMStore",
     verbose = cms.untracked.int32(0),
     # similar to LSBasedMode but for offline. Explicitly sets LumiFLag on all
     # MEs/modules that allow it (canSaveByLumi)
-    saveByLumi = cms.untracked.bool(True),
+    saveByLumi = cms.untracked.bool(False),
     #Following list has no effect if saveByLumi is False
     MEsToSave = cms.untracked.vstring(nanoDQMIO_perLSoutput.MEsToSave),  
     trackME = cms.untracked.string(""),


### PR DESCRIPTION
#### PR description:

During the testing of https://github.com/cms-sw/cmssw/pull/34220 , which introduces a new pseudo data Tier based on DQMIO format but selecting a dedicated list of MEs with single Lumisection granularity, some MEs across several subsystems were crashing offline workflows since they construct plots for quantities vs LS at the end of runs. These plots, despite being perfectly valid in Offline DQM, cannot be saved with single LS granularity. Hence, this PR tries to disable them when the option 
saveByLumi is enabled in DQMServices/Core/python/DQMStore_cfi.py propagating this situation with an untracked parameter to the corresponding DQM subsystem module.

This solution keeps the usual working functionality in DQM (per Run saving) leaving the modules untouched while preventing crashes in MEs which cannot be saved on a LS by LS basis. I am open to any other suggestion on how to deal in this situation though.

Crash message without this PR when perLS is enabled is: 
"Error is ME not backed by any data"
from:
https://github.com/cms-sw/cmssw/blob/6d2f66057131baacc2fcbdd203588c41c885b42c/DQMServices/Core/interface/MonitorElement.h#L157

Info about nanoDQMIO format: https://twiki.cern.ch/twiki/bin/view/CMS/PerLsDQMIO

MEs which were crashing when perLS was enabled without this PR: https://docs.google.com/spreadsheets/d/1pDiBf00T033obPki35FG_hJipDbXp0Z0JhtIHtn_8Mo/edit?usp=sharing

#### PR validation:

runTheMatrix.py -l all  with  --customise_commands=process.DQMStore.saveByLumi = True