### PR TITLE
Fix isData when neither --data nor --mc is used

### DIFF
--- a/Configuration/Applications/python/cmsDriverOptions.py
+++ b/Configuration/Applications/python/cmsDriverOptions.py
@@ -233,6 +233,7 @@ def OptionsFromItems(items):
             print('We have determined that this is simulation (if not, rerun cmsDriver.py with --data)')
         else:
             print('We have determined that this is real data (if not, rerun cmsDriver.py with --mc)')
+            options.isData=True
 
     if options.profile:
         if options.profile and options.prefix:


### PR DESCRIPTION
#### PR description:
When neither `--data` nor `--mc` is used, cmsDriver will consider if the job should be data or MC using
https://github.com/cms-sw/cmssw/blob/CMSSW_12_0_0_pre3/Configuration/Applications/python/cmsDriverOptions.py#L214-L235
and then print out.

However, when it considers a job as data, `options.isData` is not set. Some config, i.e. NanoAOD,
https://github.com/cms-sw/cmssw/blob/CMSSW_12_0_0_pre3/Configuration/Applications/python/ConfigBuilder.py#L1705
will need `options.isData` to be defined. If not MC customization will be picked.

This bug was shown in the NanoV9 pilot sample,
https://cms-unified.web.cern.ch/cms-unified/report/pdmvserv_Run2018C_JetHT_UL2018_MiniAODv2_NanoAODv9_pilot_210617_171408_1560
with a config file in
https://cmsweb.cern.ch/couchdb/reqmgr_config_cache/5dabb3c8610cca5485ccc25118fc5c8c/configFile
shows
`from PhysicsTools.NanoAOD.nano_cff import nanoAOD_customizeMC ` 
is used, instead of data.

#### PR validation:
Run cmsDriver without --mc, --data, and see if it picks up the proper NanoAOD:
`cmsDriver.py RECO --conditions 106X_dataRun2_v35 --customise Configuration/DataProcessing/Utils.addMonitoring --datatier NANOAOD --era Run2_2018,run2_nanoAOD_106Xv2 --eventcontent NANOEDMAOD --filein placeholder.root --fileout file:ReReco-Run2018C-JetHT-UL2018_MiniAODv2_NanoAODv9_pilot-00001.root --nThreads 2 --no_exec --python_filename ReReco-Run2018C-JetHT-UL2018_MiniAODv2_NanoAODv9_pilot-00001_0_cfg.py --scenario pp --step NANO`
will give
```
We have determined that this is real data (if not, rerun cmsDriver.py with --mc)
....
customising the process with nanoAOD_customizeData from PhysicsTools/NanoAOD/nano_cff
```
This is correct. Before, it picked up MC customization.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:
Backport to 10_6
