### PR TITLE
Update TMB matching parameters for CSC trigger primitives

### DIFF
--- a/L1Trigger/CSCTriggerPrimitives/python/params/alctParams.py
+++ b/L1Trigger/CSCTriggerPrimitives/python/params/alctParams.py
@@ -2,16 +2,30 @@ import FWCore.ParameterSet.Config as cms
 
 # Parameters for ALCT processors: 2007 and later
 alctPhase1 = cms.PSet(
+    # total number of time bins in the DAQ readout
     alctFifoTbins   = cms.uint32(16),
     alctFifoPretrig = cms.uint32(10),
+    # time that is required for the electrons to drift to the
+    # anode wires. 15ns drift time --> 45 ns is 3 sigma for the delay
+    # this corresponds to 2bx
     alctDriftDelay  = cms.uint32(2),
+    # min. number of layers hit for pre-trigger
     alctNplanesHitPretrig = cms.uint32(3),
+    # min. number of layers hit for trigger
     alctNplanesHitPattern = cms.uint32(4),
+    # min. number of layers hit for pre-trigger
     alctNplanesHitAccelPretrig = cms.uint32(3),
+    # min. number of layers hit for trigger
     alctNplanesHitAccelPattern = cms.uint32(4),
+    # 0: both collision and accelerator tracks
+    # 1: only accelerator tracks
+    # 2: only collision tracks
+    # 3: prefer accelerator tracks
     alctTrigMode       = cms.uint32(2),
+    # preference to collision/accelerator tracks
     alctAccelMode      = cms.uint32(0),
-    alctL1aWindowWidth = cms.uint32(7),
+    # L1Accept window width, in 25 ns bins
+     alctL1aWindowWidth = cms.uint32(7),
     verbosity = cms.int32(0),
 
     # Configure early_tbins instead of hardcoding it
@@ -20,8 +34,8 @@ alctPhase1 = cms.PSet(
     # Use narrow pattern mask for ring 1 chambers
     alctNarrowMaskForR1 = cms.bool(False),
 
-    # configured, not hardcoded, hit persistency
-    alctHitPersist  = cms.uint32(6),
+    # duration of signal pulse, in 25 ns bins
+   alctHitPersist  = cms.uint32(6),
 
     # configure, not hardcode, up to how many BXs in the past
     # ghost cancellation in neighboring WGs may happen

--- a/L1Trigger/CSCTriggerPrimitives/python/params/clctParams.py
+++ b/L1Trigger/CSCTriggerPrimitives/python/params/clctParams.py
@@ -2,13 +2,23 @@ import FWCore.ParameterSet.Config as cms
 
 # Parameters for CLCT processors: 2007 and later
 clctPhase1 = cms.PSet(
+    # total number of time bins in the DAQ readout
     clctFifoTbins   = cms.uint32(12),
+    # start time of cathode raw hits in DAQ readout
     clctFifoPretrig = cms.uint32(7),
+    # duration of signal pulse, in 25 ns bins
     clctHitPersist  = cms.uint32(4),
+    # time that is required for the electrons to drift to the
+    # cathode strips. 15ns drift time --> 45 ns is 3 sigma for the delay
+    # this corresponds to 2bx
     clctDriftDelay  = cms.uint32(2),
+    # min. number of layers hit for pre-trigger
     clctNplanesHitPretrig = cms.uint32(3),
+    # min. number of layers hit for trigger
     clctNplanesHitPattern = cms.uint32(4),
+    # lower threshold on pattern id
     clctPidThreshPretrig  = cms.uint32(2),
+    # region of busy key strips
     clctMinSeparation     = cms.uint32(10),
 
     # Turns on algorithms of localized dead-time zones:
@@ -27,26 +37,21 @@ clctPhase2 = clctPhase1.clone(
     clctMinSeparation     = 5,
 
     # Turns on algorithms of localized dead-time zones:
-    useDeadTimeZoning = cms.bool(True),
+    useDeadTimeZoning = True,
 
     # Width (in #HS) of a fixed dead zone around a key HS:
     clctStateMachineZone = cms.uint32(4),
 
-    # Enables the algo which instead of using the fixed dead zone width,
-    # varies it depending on the width of a triggered CLCT pattern
-    # (if True, the clctStateMachineZone is ignored):
-    useDynamicStateMachineZone = cms.bool(False),
-
     # Pretrigger HS +- clctPretriggerTriggerZone sets the trigger matching zone
     # which defines how far from pretrigger HS the TMB may look for a trigger HS
     # (it becomes important to do so with localized dead-time zoning):
-    # not implemented yet, 2018-10-18, Tao
+    # not implemented yet, 2018-10-18, Tao Huang
     clctPretriggerTriggerZone = cms.uint32(224),
 
     # whether to store the "corrected" CLCT stub time
     # (currently it is median time of all hits in a pattern) into the CSCCLCTDigi bx,
     # and temporary store the regular "key layer hit" time into the CSCCLCTDigi fullBX:
-    # not feasible --Tao
+    # not feasible in firmware -- Tao Huang
     clctUseCorrectedBx = cms.bool(False),
 )
 

--- a/L1Trigger/CSCTriggerPrimitives/python/params/tmbParams.py
+++ b/L1Trigger/CSCTriggerPrimitives/python/params/tmbParams.py
@@ -1,10 +1,15 @@
 import FWCore.ParameterSet.Config as cms
 
 tmbPhase1 = cms.PSet(
+    # block the ME1/a LCTs
     mpcBlockMe1a    = cms.uint32(0),
+    # allow ALCT-only LCTs
     alctTrigEnable  = cms.uint32(0),
+    # allow CLCT-only LCTs
     clctTrigEnable  = cms.uint32(0),
+    # allow ALCT-CLCT correlated LCTs (default)
     matchTrigEnable = cms.uint32(1),
+    # matching window for the trigger
     matchTrigWindowSize = cms.uint32(7),
 
     # array with the preferred delta BX values for the candidate CLCTs
@@ -35,7 +40,7 @@ tmbPhase1 = cms.PSet(
 
     # For ALCT-centric matching, whether to drop CLCTs that were matched
     # to ALCTs in this BX, and not use them in the following BX
-    tmbDropUsedClcts = cms.bool(False),
+    tmbDropUsedClcts = cms.bool(True),
 
     # True: allow construction of unphysical LCTs
     # in ME11 for which WG and HS do not intersect.
@@ -52,6 +57,8 @@ tmbPhase1 = cms.PSet(
 tmbPhase2 = tmbPhase1.clone(
     # reduce ALCT-CLCT matching window size from 7 to 5
     matchTrigWindowSize = 5,
+    # LCTs found in the window [6, 7, 8, 9, 10] are good
+    tmbL1aWindowSize = 5,
     matchEarliestClctOnly = False,
     tmbDropUsedClcts = False,
     # 0 = default "non-X-BX" sorting algorithm,

--- a/L1Trigger/CSCTriggerPrimitives/python/params/tmbParams.py
+++ b/L1Trigger/CSCTriggerPrimitives/python/params/tmbParams.py
@@ -35,7 +35,8 @@ tmbPhase1 = cms.PSet(
     tmbReadoutEarliest2 = cms.bool(True),
 
     # For ALCT-centric matching in ME11, break after finding
-    # the first BX with matching CLCT
+    # the first BX with matching CLCT. Should always be set to True
+    # when using the preferred BX windows
     matchEarliestClctOnly = cms.bool(True),
 
     # For ALCT-centric matching, whether to drop CLCTs that were matched
@@ -59,7 +60,6 @@ tmbPhase2 = tmbPhase1.clone(
     matchTrigWindowSize = 5,
     # LCTs found in the window [6, 7, 8, 9, 10] are good
     tmbL1aWindowSize = 5,
-    matchEarliestClctOnly = False,
     tmbDropUsedClcts = False,
     # 0 = default "non-X-BX" sorting algorithm,
     #     where the first BX with match goes first

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCCathodeLCTProcessor.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCCathodeLCTProcessor.cc
@@ -681,14 +681,6 @@ std::vector<CSCCLCTDigi> CSCCathodeLCTProcessor::findLCTs(
             // set the hit collection
             thisLCT.setHits(compHits);
 
-            // do the CCLUT procedures
-            if (runCCLUT_) {
-              cclut_->run(thisLCT, numCFEBs_);
-            }
-
-            // purge the comparator digi collection from the obsolete "65535" entries...
-            cleanComparatorContainer(thisLCT);
-
             // useful debugging
             if (infoV > 1) {
               LogTrace("CSCCathodeLCTProcessor") << " Final selection: ilct " << ilct << " " << thisLCT << std::endl;
@@ -734,6 +726,19 @@ std::vector<CSCCLCTDigi> CSCCathodeLCTProcessor::findLCTs(
     else {
       start_bx = first_bx + 1;  // no dead time
     }
+  }
+
+  // comparator digi cleaning + optional CCLUT
+  for (auto& thisLCT : lctList) {
+
+    // do the CCLUT procedures
+    if (runCCLUT_) {
+      cclut_->run(thisLCT, numCFEBs_);
+    }
+
+    // purge the comparator digi collection from the obsolete "65535" entries...
+    // this is always done
+    cleanComparatorContainer(thisLCT);
   }
 
   return lctList;

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCCathodeLCTProcessor.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCCathodeLCTProcessor.cc
@@ -730,7 +730,6 @@ std::vector<CSCCLCTDigi> CSCCathodeLCTProcessor::findLCTs(
 
   // comparator digi cleaning + optional CCLUT
   for (auto& thisLCT : lctList) {
-
     // do the CCLUT procedures
     if (runCCLUT_) {
       cclut_->run(thisLCT, numCFEBs_);

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCUpgradeCathodeLCTProcessor.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCUpgradeCathodeLCTProcessor.cc
@@ -156,8 +156,6 @@ std::vector<CSCCLCTDigi> CSCUpgradeCathodeLCTProcessor::findLCTs(
     }
   }
 
-  std::vector<CSCCLCTDigi> lctListBX;
-
   PulseArray pulse;
 
   // Fire half-strip one-shots for hit_persist bx's (4 bx's by default).
@@ -171,7 +169,6 @@ std::vector<CSCCLCTDigi> CSCUpgradeCathodeLCTProcessor::findLCTs(
   // Allow for more than one pass over the hits in the time window.
   // Do search in every BX
   while (start_bx < stop_bx) {
-    lctListBX.clear();
 
     // All half-strip pattern envelopes are evaluated simultaneously, on every clock cycle.
     int first_bx = 999;
@@ -344,17 +341,8 @@ std::vector<CSCCLCTDigi> CSCUpgradeCathodeLCTProcessor::findLCTs(
             // set the hit collection
             thisLCT.setHits(compHits);
 
-            // do the CCLUT procedures
-            if (runCCLUT_) {
-              cclut_->run(thisLCT, numCFEBs_);
-            }
-
-            // purge the comparator digi collection from the obsolete "65535" entries...
-            cleanComparatorContainer(thisLCT);
-
             // put the CLCT into the collection
             lctList.push_back(thisLCT);
-            lctListBX.push_back(thisLCT);
           }
         }
 
@@ -363,6 +351,19 @@ std::vector<CSCCLCTDigi> CSCUpgradeCathodeLCTProcessor::findLCTs(
     // The pattern finder runs continuously, so another pre-trigger
     // could occur already at the next bx.
     start_bx = first_bx + 1;
+  }
+
+  // comparator digi cleaning + optional CCLUT
+  for (auto& thisLCT : lctList) {
+
+    // do the CCLUT procedures
+    if (runCCLUT_) {
+      cclut_->run(thisLCT, numCFEBs_);
+    }
+
+    // purge the comparator digi collection from the obsolete "65535" entries...
+    // this is always done
+    cleanComparatorContainer(thisLCT);
   }
 
   return lctList;

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCUpgradeCathodeLCTProcessor.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCUpgradeCathodeLCTProcessor.cc
@@ -169,7 +169,6 @@ std::vector<CSCCLCTDigi> CSCUpgradeCathodeLCTProcessor::findLCTs(
   // Allow for more than one pass over the hits in the time window.
   // Do search in every BX
   while (start_bx < stop_bx) {
-
     // All half-strip pattern envelopes are evaluated simultaneously, on every clock cycle.
     int first_bx = 999;
 
@@ -355,7 +354,6 @@ std::vector<CSCCLCTDigi> CSCUpgradeCathodeLCTProcessor::findLCTs(
 
   // comparator digi cleaning + optional CCLUT
   for (auto& thisLCT : lctList) {
-
     // do the CCLUT procedures
     if (runCCLUT_) {
       cclut_->run(thisLCT, numCFEBs_);

--- a/L1Trigger/CSCTriggerPrimitives/test/CSCTriggerPrimitivesAnalyzer.cc
+++ b/L1Trigger/CSCTriggerPrimitives/test/CSCTriggerPrimitivesAnalyzer.cc
@@ -238,7 +238,7 @@ void CSCTriggerPrimitivesAnalyzer::makePlot(TH1F *dataMon,
   dataMon->SetMarkerStyle(kPlus);
   dataMon->SetMarkerSize(3);
   // add 50% to make sure the legend does not overlap with the histograms
-  dataMon->SetMaximum(dataMon->GetBinContent(dataMon->GetMaximumBin()) * 1.5);
+  dataMon->SetMaximum(dataMon->GetBinContent(dataMon->GetMaximumBin()) * 1.6);
   dataMon->Draw("histp");
   dataMon->GetXaxis()->SetLabelSize(0.05);
   dataMon->GetYaxis()->SetLabelSize(0.05);
@@ -246,9 +246,9 @@ void CSCTriggerPrimitivesAnalyzer::makePlot(TH1F *dataMon,
   dataMon->GetYaxis()->SetTitleSize(0.05);
   emulMon->SetLineColor(kRed);
   emulMon->Draw("histsame");
-  auto legend = new TLegend(0.7, 0.7, 0.9, 0.9);
-  legend->AddEntry(dataMon, "Data", "p");
-  legend->AddEntry(emulMon, "Emulator", "l");
+  auto legend = new TLegend(0.6, 0.7, 0.9, 0.9);
+  legend->AddEntry(dataMon, TString("Data (" + std::to_string((int)dataMon->GetEntries()) + ")"), "p");
+  legend->AddEntry(emulMon, TString("Emulator (" + std::to_string((int)emulMon->GetEntries()) + ")"), "l");
   legend->Draw();
 
   c1->cd(2);

--- a/L1Trigger/CSCTriggerPrimitives/test/runCSCTriggerPrimitiveAnalyzer_cfg.py
+++ b/L1Trigger/CSCTriggerPrimitives/test/runCSCTriggerPrimitiveAnalyzer_cfg.py
@@ -21,6 +21,9 @@ options.parseArguments()
 if options.B904Setup and options.B904RunNumber == "YYMMDD_HHMMSS":
     sys.exit("B904 setup was selected. Please provide a valid Run Number")
 
+if (not options.B904Setup) and int(options.runNumber) == 0:
+    sys.exit("Please provide a valid CMS Run Number")
+
 process = cms.Process("ANALYSIS", Run3)
 process.load("FWCore.MessageService.MessageLogger_cfi")
 

--- a/L1Trigger/CSCTriggerPrimitives/test/runCSCTriggerPrimitiveProducer_cfg.py
+++ b/L1Trigger/CSCTriggerPrimitives/test/runCSCTriggerPrimitiveProducer_cfg.py
@@ -15,6 +15,7 @@ options.register ("runME11ILT", False, VarParsing.multiplicity.singleton, VarPar
 options.register ("saveEdmOutput", True, VarParsing.multiplicity.singleton, VarParsing.varType.bool)
 options.register ("preTriggerAnalysis", False, VarParsing.multiplicity.singleton, VarParsing.varType.bool)
 options.register ("dropNonMuonCollections", True, VarParsing.multiplicity.singleton, VarParsing.varType.bool)
+options.register ("dqmOutputFile", "step_DQM.root", VarParsing.multiplicity.singleton, VarParsing.varType.string)
 options.parseArguments()
 
 process_era = Run3
@@ -123,7 +124,7 @@ process.DQMoutput = cms.OutputModule("DQMRootOutputModule",
         dataTier = cms.untracked.string('DQMIO'),
         filterName = cms.untracked.string('')
     ),
-    fileName = cms.untracked.string('file:step_DQM.root'),
+    fileName = cms.untracked.string('file:{}'.format(options.dqmOutputFile)),
     outputCommands = process.DQMEventContent.outputCommands,
     splitLevel = cms.untracked.int32(0)
 )


### PR DESCRIPTION
#### PR description:

Three parameters I forgot to update in #34245. 

* In Run-2 we only match an ALCT to the first CLCT (`matchEarliestClctOnly`). With the introduction of the preferred BX windows, we now also do this in Run-3 and Phase-2.
* `tmbDropUsedClcts` was mistakenly set to False for Run-2. That should be True. But it is False for Run-3 and Phase-2; CLCTs can be reused.
* L1A window size for Run-3 OTMBs (` tmbL1aWindowSize`) is 5 BX wide, not 7.

#### PR validation:

Code was tested on 10k events of B904 cosmic data (to test Run-3 algorithm).

[DataVsEmulatorComparison_20210701.pdf](https://github.com/cms-sw/cmssw/files/6751900/DataVsEmulatorComparison_20210701.pdf)

It was also tested on 26k events of 2018D ZeroBias data Run 322022 (to test Run-2 algorithm). Chambers ME+1/1/9, ME+1/1/10 and ME+1/1/11 were excluded in this comparison because we had loaded prototype Phase-2 firmware on those chambers.

[CSC_dataVsEmul_CMS_Run_322022_20210701_prefix.pdf](https://github.com/cms-sw/cmssw/files/6751898/CSC_dataVsEmul_CMS_Run_322022_20210701_prefix.pdf)

[CSC_dataVsEmul_CMS_Run_322022_20210701_postfix.pdf](https://github.com/cms-sw/cmssw/files/6751897/CSC_dataVsEmul_CMS_Run_322022_20210701_postfix.pdf)

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
