### PR TITLE
fix SiPixelDigisClustersFromSoA for DBG IBs

### DIFF
--- a/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelDigisClustersFromSoA.cc
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelDigisClustersFromSoA.cc
@@ -113,15 +113,15 @@ void SiPixelDigisClustersFromSoA::produce(edm::StreamID, edm::Event& iEvent, con
                                                        << " size/charge " << acluster.isize << '/' << acluster.charge;
       // sort by row (x)
       spc.emplace_back(acluster.isize, acluster.adc, acluster.x, acluster.y, acluster.xmin, acluster.ymin, ic);
+#ifdef EDM_ML_DEBUG
+      ++totClustersFilled;
+      LogDebug("SiPixelDigisClustersFromSoA")
+          << "putting in this cluster " << ic << " " << acluster.charge << " " << acluster.isize;
+#endif
       aclusters[ic].clear();
       std::push_heap(spc.begin(), spc.end(), [](SiPixelCluster const& cl1, SiPixelCluster const& cl2) {
         return cl1.minPixelRow() < cl2.minPixelRow();
       });
-#ifdef EDM_ML_DEBUG
-      ++totClustersFilled;
-      LogDebug("SiPixelDigisClustersFromSoA")
-          << "putting in this cluster " << ic << " " << cluster.charge() << " " << cluster.pixelADC().size();
-#endif
     }
     nclus = -1;
     // sort by row (x)


### PR DESCRIPTION
#### PR description:

Title says it all, address comment: https://github.com/cms-sw/cmssw/pull/34259#discussion_r662756961

#### PR validation:

Now it compiles with ` -DEDM_ML_DEBUG`

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Not a backport, no backport needed.
