### PR TITLE
[HGCAL] Validation - Purity and efficiency

### DIFF
--- a/Validation/HGCalValidation/interface/HGVHistoProducerAlgo.h
+++ b/Validation/HGCalValidation/interface/HGVHistoProducerAlgo.h
@@ -372,6 +372,7 @@ private:
   int nintScore_;
   double minSharedEneFrac_, maxSharedEneFrac_;
   int nintSharedEneFrac_;
+  double minTSTSharedEneFracEfficiency_;
   double minTSTSharedEneFrac_, maxTSTSharedEneFrac_;
   int nintTSTSharedEneFrac_;
   double minTotNsimClsperthick_, maxTotNsimClsperthick_;

--- a/Validation/HGCalValidation/interface/HGVHistoProducerAlgo.h
+++ b/Validation/HGCalValidation/interface/HGVHistoProducerAlgo.h
@@ -156,6 +156,8 @@ struct HGVHistoProducerAlgoHistograms {
   std::vector<dqm::reco::MonitorElement*> h_sharedenergy_caloparticle2trackster_vs_phi;
   std::vector<dqm::reco::MonitorElement*> h_denom_trackster_eta;
   std::vector<dqm::reco::MonitorElement*> h_denom_trackster_phi;
+  std::vector<dqm::reco::MonitorElement*> h_numEff_caloparticle_eta;
+  std::vector<dqm::reco::MonitorElement*> h_numEff_caloparticle_phi;
   std::vector<dqm::reco::MonitorElement*> h_num_caloparticle_eta;
   std::vector<dqm::reco::MonitorElement*> h_num_caloparticle_phi;
   std::vector<dqm::reco::MonitorElement*> h_numDup_trackster_eta;

--- a/Validation/HGCalValidation/python/HGVHistoProducerAlgoBlock_cfi.py
+++ b/Validation/HGCalValidation/python/HGVHistoProducerAlgoBlock_cfi.py
@@ -77,6 +77,7 @@ HGVHistoProducerAlgoBlock = cms.PSet(
     minSharedEneFrac = cms.double(0.),
     maxSharedEneFrac = cms.double(1.),
     nintSharedEneFrac = cms.int32(100),
+    minTSTSharedEneFracEfficiency = cms.double(0.5),
 
     #Same as above for tracksters
     minTSTSharedEneFrac = cms.double(0.),

--- a/Validation/HGCalValidation/python/PostProcessorHGCAL_cfi.py
+++ b/Validation/HGCalValidation/python/PostProcessorHGCAL_cfi.py
@@ -47,6 +47,8 @@ postProcessorHGCALsimclusters= DQMEDHarvester('DQMGenericClient',
 
 eff_tracksters = ["purity_eta 'Trackster Purity vs #eta' Num_CaloParticle_Eta Denom_CaloParticle_Eta"]
 eff_tracksters.extend(["purity_phi 'Trackster Purity vs #phi' Num_CaloParticle_Phi Denom_CaloParticle_Phi"])
+eff_tracksters.extend(["effic_eta 'Trackster Efficiency vs #eta' NumEff_CaloParticle_Eta Denom_CaloParticle_Eta"])
+eff_tracksters.extend(["effic_phi 'Trackster Efficiency vs #phi' NumEff_CaloParticle_Phi Denom_CaloParticle_Phi"])
 eff_tracksters.extend(["duplicate_eta 'Trackster Duplicate(Split) Rate vs #eta' NumDup_Trackster_Eta Denom_Trackster_Eta"])
 eff_tracksters.extend(["duplicate_phi 'Trackster Duplicate(Split) Rate vs #phi' NumDup_Trackster_Phi Denom_Trackster_Phi"])
 eff_tracksters.extend(["fake_eta 'Trackster Fake Rate vs #eta' Num_Trackster_Eta Denom_Trackster_Eta fake"])

--- a/Validation/HGCalValidation/python/PostProcessorHGCAL_cfi.py
+++ b/Validation/HGCalValidation/python/PostProcessorHGCAL_cfi.py
@@ -45,8 +45,8 @@ postProcessorHGCALsimclusters= DQMEDHarvester('DQMGenericClient',
     outputFileName = cms.untracked.string(""),
     verbose = cms.untracked.uint32(4))
 
-eff_tracksters = ["effic_eta 'Trackster Efficiency vs #eta' Num_CaloParticle_Eta Denom_CaloParticle_Eta"]
-eff_tracksters.extend(["effic_phi 'Trackster Efficiency vs #phi' Num_CaloParticle_Phi Denom_CaloParticle_Phi"])
+eff_tracksters = ["purity_eta 'Trackster Purity vs #eta' Num_CaloParticle_Eta Denom_CaloParticle_Eta"]
+eff_tracksters.extend(["purity_phi 'Trackster Purity vs #phi' Num_CaloParticle_Phi Denom_CaloParticle_Phi"])
 eff_tracksters.extend(["duplicate_eta 'Trackster Duplicate(Split) Rate vs #eta' NumDup_Trackster_Eta Denom_Trackster_Eta"])
 eff_tracksters.extend(["duplicate_phi 'Trackster Duplicate(Split) Rate vs #phi' NumDup_Trackster_Phi Denom_Trackster_Phi"])
 eff_tracksters.extend(["fake_eta 'Trackster Fake Rate vs #eta' Num_Trackster_Eta Denom_Trackster_Eta fake"])

--- a/Validation/HGCalValidation/python/hgcalPlots.py
+++ b/Validation/HGCalValidation/python/hgcalPlots.py
@@ -1638,6 +1638,11 @@ _effplots.extend([Plot("effic_phi", xtitle="", **_common_eff)])
 _effplots.extend([Plot("globalEfficiencies", xtitle="", **_common_eff)])
 _efficiencies = PlotGroup("Efficiencies", _effplots, ncols=3)
 
+_common_purity = {"stat": False, "legend": False, "xbinlabelsize": 14, "xbinlabeloption": "d", "ymin": 0.0, "ymax": 1.1}
+_purityplots = [Plot("purity_eta", xtitle="", **_common_purity)]
+_purityplots.extend([Plot("purity_phi", xtitle="", **_common_purity)])
+_purityplots.extend([Plot("globalEfficiencies", xtitle="", **_common_purity)])
+_purities = PlotGroup("Purities", _purityplots, ncols=3)
 
 _common_dup = {"stat": False, "legend": False, "xbinlabelsize": 14, "xbinlabeloption": "d", "ymin": 0.0, "ymax": 1.1}
 _dupplots = [Plot("duplicate_eta", xtitle="", **_common_dup)]
@@ -2427,6 +2432,7 @@ def _hgcalFolders(lastDirName="hgcalLayerClusters"):
 
 _trackstersAllPlots = [
   _efficiencies,
+  _purities,
   _duplicates,
   _fakes,
   _merges,

--- a/Validation/HGCalValidation/python/hgcalPlots.py
+++ b/Validation/HGCalValidation/python/hgcalPlots.py
@@ -1708,7 +1708,7 @@ _multiplicityOfLCinTST_plots.extend([Plot("multiplicityOfLCinTST_vs_layercluster
                                 drawCommand = "colz text45", normalizeToNumberOfEvents = True, **_common)])
 _multiplicityOfLCinTST_plots.extend([Plot("multiplicityOfLCinTST_vs_layercluster_zminus", xtitle="Layer Cluster multiplicity in Tracksters", ytitle = "Layer Number", 
                                 drawCommand = "colz text45", normalizeToNumberOfEvents = True, **_common)])
-_multiplicityOfLCinTST = PlotGroup("MultiplcityofLCinTST", _multiplicityOfLCinTST_plots, ncols=2)
+_multiplicityOfLCinTST = PlotGroup("MultiplicityofLCinTST", _multiplicityOfLCinTST_plots, ncols=2)
 
 _common = {"stat": True, "drawStyle": "hist", "staty": 0.65}
 #--------------------------------------------------------------------------------------------

--- a/Validation/HGCalValidation/src/HGVHistoProducerAlgo.cc
+++ b/Validation/HGCalValidation/src/HGVHistoProducerAlgo.cc
@@ -1050,7 +1050,7 @@ void HGVHistoProducerAlgo::bookTracksterHistos(DQMStore::IBooker& ibook, Histogr
                         maxPhi_,
                         minTSTSharedEneFrac_,
                         maxTSTSharedEneFrac_));
-  histograms.h_num_caloparticle_eta.push_back(ibook.book1D(
+  histograms.h_numEff_caloparticle_eta.push_back(ibook.book1D(
       "NumEff_CaloParticle_Eta", "Num Efficiency CaloParticle Eta per Trackster", nintEta_, minEta_, maxEta_));
   histograms.h_num_caloparticle_eta.push_back(
       ibook.book1D("Num_CaloParticle_Eta", "Num Purity CaloParticle Eta per Trackster", nintEta_, minEta_, maxEta_));
@@ -1058,7 +1058,7 @@ void HGVHistoProducerAlgo::bookTracksterHistos(DQMStore::IBooker& ibook, Histogr
       ibook.book1D("NumDup_Trackster_Eta", "Num Purity Duplicate Trackster vs Eta", nintEta_, minEta_, maxEta_));
   histograms.h_denom_caloparticle_eta.push_back(
       ibook.book1D("Denom_CaloParticle_Eta", "Denom CaloParticle Eta per Trackster", nintEta_, minEta_, maxEta_));
-  histograms.h_num_caloparticle_phi.push_back(ibook.book1D(
+  histograms.h_numEff_caloparticle_phi.push_back(ibook.book1D(
       "NumEff_CaloParticle_Phi", "Num Efficiency CaloParticle Phi per Trackster", nintPhi_, minPhi_, maxPhi_));
   histograms.h_num_caloparticle_phi.push_back(
       ibook.book1D("Num_CaloParticle_Phi", "Num Purity CaloParticle Phi per Trackster", nintPhi_, minPhi_, maxPhi_));
@@ -2821,8 +2821,8 @@ void HGVHistoProducerAlgo::tracksters_to_CaloParticles(const Histograms& histogr
       // Fill the numerator for the efficiency calculation. The efficiency is computed by considering the energy shared between a Trackster and a _corresponding_ caloParticle. The threshold is configurable via python.
       if (!cp_considered_efficient && tstSharedEnergyFrac[cpId][tstId] >= minTSTSharedEneFracEfficiency_) {
         cp_considered_efficient = true;
-        histograms.h_num_caloparticle_eta[count]->Fill(cP[cpId].g4Tracks()[0].momentum().eta());
-        histograms.h_num_caloparticle_phi[count]->Fill(cP[cpId].g4Tracks()[0].momentum().phi());
+        histograms.h_numEff_caloparticle_eta[count]->Fill(cP[cpId].g4Tracks()[0].momentum().eta());
+        histograms.h_numEff_caloparticle_phi[count]->Fill(cP[cpId].g4Tracks()[0].momentum().phi());
       }
     }  //end of loop through Tracksters
 

--- a/Validation/HGCalValidation/src/HGVHistoProducerAlgo.cc
+++ b/Validation/HGCalValidation/src/HGVHistoProducerAlgo.cc
@@ -1055,7 +1055,7 @@ void HGVHistoProducerAlgo::bookTracksterHistos(DQMStore::IBooker& ibook, Histogr
   histograms.h_num_caloparticle_eta.push_back(
       ibook.book1D("Num_CaloParticle_Eta", "Num Purity CaloParticle Eta per Trackster", nintEta_, minEta_, maxEta_));
   histograms.h_numDup_trackster_eta.push_back(
-      ibook.book1D("NumDup_Trackster_Eta", "Num Purity Duplicate Trackster vs Eta", nintEta_, minEta_, maxEta_));
+      ibook.book1D("NumDup_Trackster_Eta", "Num Duplicate Trackster vs Eta", nintEta_, minEta_, maxEta_));
   histograms.h_denom_caloparticle_eta.push_back(
       ibook.book1D("Denom_CaloParticle_Eta", "Denom CaloParticle Eta per Trackster", nintEta_, minEta_, maxEta_));
   histograms.h_numEff_caloparticle_phi.push_back(ibook.book1D(
@@ -1063,7 +1063,7 @@ void HGVHistoProducerAlgo::bookTracksterHistos(DQMStore::IBooker& ibook, Histogr
   histograms.h_num_caloparticle_phi.push_back(
       ibook.book1D("Num_CaloParticle_Phi", "Num Purity CaloParticle Phi per Trackster", nintPhi_, minPhi_, maxPhi_));
   histograms.h_numDup_trackster_phi.push_back(
-      ibook.book1D("NumDup_Trackster_Phi", "Num Purity Duplicate Trackster vs Phi", nintPhi_, minPhi_, maxPhi_));
+      ibook.book1D("NumDup_Trackster_Phi", "Num Duplicate Trackster vs Phi", nintPhi_, minPhi_, maxPhi_));
   histograms.h_denom_caloparticle_phi.push_back(
       ibook.book1D("Denom_CaloParticle_Phi", "Denom CaloParticle Phi per Trackster", nintPhi_, minPhi_, maxPhi_));
 

--- a/Validation/HGCalValidation/src/HGVHistoProducerAlgo.cc
+++ b/Validation/HGCalValidation/src/HGVHistoProducerAlgo.cc
@@ -1049,12 +1049,16 @@ void HGVHistoProducerAlgo::bookTracksterHistos(DQMStore::IBooker& ibook, Histogr
                         maxPhi_,
                         minTSTSharedEneFrac_,
                         maxTSTSharedEneFrac_));
+  histograms.h_num_caloparticle_eta.push_back(ibook.book1D(
+      "NumEff_CaloParticle_Eta", "Num Efficiency CaloParticle Eta per Trackster", nintEta_, minEta_, maxEta_));
   histograms.h_num_caloparticle_eta.push_back(
       ibook.book1D("Num_CaloParticle_Eta", "Num Purity CaloParticle Eta per Trackster", nintEta_, minEta_, maxEta_));
   histograms.h_numDup_trackster_eta.push_back(
       ibook.book1D("NumDup_Trackster_Eta", "Num Purity Duplicate Trackster vs Eta", nintEta_, minEta_, maxEta_));
   histograms.h_denom_caloparticle_eta.push_back(
       ibook.book1D("Denom_CaloParticle_Eta", "Denom CaloParticle Eta per Trackster", nintEta_, minEta_, maxEta_));
+  histograms.h_num_caloparticle_phi.push_back(ibook.book1D(
+      "NumEff_CaloParticle_Phi", "Num Efficiency CaloParticle Phi per Trackster", nintPhi_, minPhi_, maxPhi_));
   histograms.h_num_caloparticle_phi.push_back(
       ibook.book1D("Num_CaloParticle_Phi", "Num Purity CaloParticle Phi per Trackster", nintPhi_, minPhi_, maxPhi_));
   histograms.h_numDup_trackster_phi.push_back(
@@ -2424,15 +2428,14 @@ void HGVHistoProducerAlgo::tracksters_to_CaloParticles(const Histograms& histogr
     std::vector<int> hitsToCaloParticleId(numberOfHitsInTST);
     //Det id of the first hit just to make the lcLayerId variable
     //which maps the layers in -z: 0->51 and in +z: 52->103
-    const auto firstHitDetId = tst_hitsAndFractions[0].first;
-    int lcLayerId =
-        recHitTools_->getLayerWithOffset(firstHitDetId) + layers * ((recHitTools_->zside(firstHitDetId) + 1) >> 1) - 1;
 
     //Loop through the hits of the trackster under study
     for (unsigned int hitId = 0; hitId < numberOfHitsInTST; hitId++) {
       const auto rh_detid = tst_hitsAndFractions[hitId].first;
       const auto rhFraction = tst_hitsAndFractions[hitId].second;
 
+      const int lcLayerId =
+          recHitTools_->getLayerWithOffset(rh_detid) + layers * ((recHitTools_->zside(rh_detid) + 1) >> 1) - 1;
       //Since the hit is belonging to the layer cluster, it must also be in the rechits map.
       std::unordered_map<DetId, const HGCRecHit*>::const_iterator itcheck = hitMap.find(rh_detid);
       const HGCRecHit* hit = itcheck->second;
@@ -2748,9 +2751,15 @@ void HGVHistoProducerAlgo::tracksters_to_CaloParticles(const Histograms& histogr
           }
           lcPair.second.second += (tstFraction - cpFraction) * (tstFraction - cpFraction) * hitEnergyWeight;
           LogDebug("HGCalValidator") << "TracksterId:\t" << tracksterId << "\t"
-                                     << "tstfraction,cpfraction:\t" << tstFraction << ", " << cpFraction << "\t"
+                                     << "cpId:\t" << cpId << "\t"
+                                     << "Layer: " << layerId << '\t' << "tstfraction,cpfraction:\t" << tstFraction
+                                     << ", " << cpFraction << "\t"
                                      << "hitEnergyWeight:\t" << hitEnergyWeight << "\t"
-                                     << "currect score numerator:\t" << lcPair.second.second << "\n";
+                                     << "added delta:\t"
+                                     << (tstFraction - cpFraction) * (tstFraction - cpFraction) * hitEnergyWeight
+                                     << "\t"
+                                     << "currect score numerator:\t" << lcPair.second.second << "\t"
+                                     << "shared Energy:\t" << lcPair.second.first << '\n';
         }
       }  //end of loop through sim hits of current calo particle
 
@@ -2785,6 +2794,11 @@ void HGVHistoProducerAlgo::tracksters_to_CaloParticles(const Histograms& histogr
     //Loop through related Tracksters here
     //Will switch to vector for access because it is faster
     std::vector<int> cpId_tstId_related_vec(cpId_tstId_related.begin(), cpId_tstId_related.end());
+    // In case the threshold to associate a CaloParticle to a Trackster is
+    // below 50%, there could be cases in which the CP is linked to more than
+    // one tracksters, leading to efficiencies >1. This boolean is used to
+    // avoid "over counting".
+    bool cp_considered_efficient = false;
     for (unsigned int i = 0; i < cpId_tstId_related_vec.size(); ++i) {
       auto tstId = cpId_tstId_related_vec[i];
       //Now time for the denominator
@@ -2794,6 +2808,7 @@ void HGVHistoProducerAlgo::tracksters_to_CaloParticles(const Histograms& histogr
       LogDebug("HGCalValidator") << "CP Id: \t" << cpId << "\t TST id: \t" << tstId << "\t score \t"  //
                                  << score3d[cpId][tstId] << "\t"
                                  << "invCPEnergyWeight \t" << invCPEnergyWeight << "\t"
+                                 << "Trackste energy: \t" << tracksters[tstId].raw_energy() << "\t"
                                  << "shared energy:\t" << tstSharedEnergy[cpId][tstId] << "\t"
                                  << "shared energy fraction:\t" << tstSharedEnergyFrac[cpId][tstId] << "\n";
 
@@ -2802,6 +2817,12 @@ void HGVHistoProducerAlgo::tracksters_to_CaloParticles(const Histograms& histogr
       histograms.h_sharedenergy_caloparticle2trackster[count]->Fill(tstSharedEnergyFrac[cpId][tstId]);
       histograms.h_energy_vs_score_caloparticle2trackster[count]->Fill(score3d[cpId][tstId],
                                                                        tstSharedEnergyFrac[cpId][tstId]);
+      // Fill the numerator for the efficiency calculation. The efficiency is computed by considering the energy shared between a Trackster and a _corresponding_ caloParticle. The threshold is configurable via python.
+      if (!cp_considered_efficient && tstSharedEnergyFrac[cpId][tstId] >= 0.5) {
+        cp_considered_efficient = true;
+        histograms.h_num_caloparticle_eta[count]->Fill(cP[cpId].g4Tracks()[0].momentum().eta());
+        histograms.h_num_caloparticle_phi[count]->Fill(cP[cpId].g4Tracks()[0].momentum().phi());
+      }
     }  //end of loop through Tracksters
 
     auto is_assoc = [&](const auto& v) -> bool { return v < ScoreCutCPtoTSTEffDup_; };
@@ -2818,6 +2839,10 @@ void HGVHistoProducerAlgo::tracksters_to_CaloParticles(const Histograms& histogr
           cP[cpId].g4Tracks()[0].momentum().eta(), tracksters[bestTstId].raw_energy() / CPenergy);
       histograms.h_sharedenergy_caloparticle2trackster_vs_phi[count]->Fill(
           cP[cpId].g4Tracks()[0].momentum().phi(), tracksters[bestTstId].raw_energy() / CPenergy);
+      LogDebug("HGCalValidator") << count << " " << cP[cpId].g4Tracks()[0].momentum().eta() << " "
+                                 << cP[cpId].g4Tracks()[0].momentum().phi() << " " << tracksters[bestTstId].raw_energy()
+                                 << " " << CPenergy << " " << (tracksters[bestTstId].raw_energy() / CPenergy) << " "
+                                 << tstSharedEnergyFrac[cpId][bestTstId] << '\n';
       histograms.h_sharedenergy_caloparticle2trackster_assoc[count]->Fill(tstSharedEnergyFrac[cpId][bestTstId]);
     }
     if (assocDup >= 2) {

--- a/Validation/HGCalValidation/src/HGVHistoProducerAlgo.cc
+++ b/Validation/HGCalValidation/src/HGVHistoProducerAlgo.cc
@@ -1050,15 +1050,15 @@ void HGVHistoProducerAlgo::bookTracksterHistos(DQMStore::IBooker& ibook, Histogr
                         minTSTSharedEneFrac_,
                         maxTSTSharedEneFrac_));
   histograms.h_num_caloparticle_eta.push_back(
-      ibook.book1D("Num_CaloParticle_Eta", "Num CaloParticle Eta per Trackster", nintEta_, minEta_, maxEta_));
+      ibook.book1D("Num_CaloParticle_Eta", "Num Purity CaloParticle Eta per Trackster", nintEta_, minEta_, maxEta_));
   histograms.h_numDup_trackster_eta.push_back(
-      ibook.book1D("NumDup_Trackster_Eta", "Num Duplicate Trackster vs Eta", nintEta_, minEta_, maxEta_));
+      ibook.book1D("NumDup_Trackster_Eta", "Num Purity Duplicate Trackster vs Eta", nintEta_, minEta_, maxEta_));
   histograms.h_denom_caloparticle_eta.push_back(
       ibook.book1D("Denom_CaloParticle_Eta", "Denom CaloParticle Eta per Trackster", nintEta_, minEta_, maxEta_));
   histograms.h_num_caloparticle_phi.push_back(
-      ibook.book1D("Num_CaloParticle_Phi", "Num CaloParticle Phi per Trackster", nintPhi_, minPhi_, maxPhi_));
+      ibook.book1D("Num_CaloParticle_Phi", "Num Purity CaloParticle Phi per Trackster", nintPhi_, minPhi_, maxPhi_));
   histograms.h_numDup_trackster_phi.push_back(
-      ibook.book1D("NumDup_Trackster_Phi", "Num Duplicate Trackster vs Phi", nintPhi_, minPhi_, maxPhi_));
+      ibook.book1D("NumDup_Trackster_Phi", "Num Purity Duplicate Trackster vs Phi", nintPhi_, minPhi_, maxPhi_));
   histograms.h_denom_caloparticle_phi.push_back(
       ibook.book1D("Denom_CaloParticle_Phi", "Denom CaloParticle Phi per Trackster", nintPhi_, minPhi_, maxPhi_));
 

--- a/Validation/HGCalValidation/src/HGVHistoProducerAlgo.cc
+++ b/Validation/HGCalValidation/src/HGVHistoProducerAlgo.cc
@@ -96,6 +96,7 @@ HGVHistoProducerAlgo::HGVHistoProducerAlgo(const edm::ParameterSet& pset)
       minSharedEneFrac_(pset.getParameter<double>("minSharedEneFrac")),
       maxSharedEneFrac_(pset.getParameter<double>("maxSharedEneFrac")),
       nintSharedEneFrac_(pset.getParameter<int>("nintSharedEneFrac")),
+      minTSTSharedEneFracEfficiency_(pset.getParameter<double>("minTSTSharedEneFracEfficiency")),
 
       //Same as above for Tracksters
       minTSTSharedEneFrac_(pset.getParameter<double>("minTSTSharedEneFrac")),
@@ -2818,7 +2819,7 @@ void HGVHistoProducerAlgo::tracksters_to_CaloParticles(const Histograms& histogr
       histograms.h_energy_vs_score_caloparticle2trackster[count]->Fill(score3d[cpId][tstId],
                                                                        tstSharedEnergyFrac[cpId][tstId]);
       // Fill the numerator for the efficiency calculation. The efficiency is computed by considering the energy shared between a Trackster and a _corresponding_ caloParticle. The threshold is configurable via python.
-      if (!cp_considered_efficient && tstSharedEnergyFrac[cpId][tstId] >= 0.5) {
+      if (!cp_considered_efficient && tstSharedEnergyFrac[cpId][tstId] >= minTSTSharedEneFracEfficiency_) {
         cp_considered_efficient = true;
         histograms.h_num_caloparticle_eta[count]->Fill(cP[cpId].g4Tracks()[0].momentum().eta());
         histograms.h_num_caloparticle_phi[count]->Fill(cP[cpId].g4Tracks()[0].momentum().phi());


### PR DESCRIPTION
#### PR description:

In this PR, we rename what was called efficiency to purity. 
Now we define a caloparticle to be efficient if at least 50% of its energy was reconstructed by a trackster. 

This PR also fixes a bug in the calculation of the shared energy per layer, where the layer Id did not change in the loop. 


#### PR validation:

PR was validated on different pattern recognitions and different wfs: 

e.g. wf `34693.0`: https://fpantale.web.cern.ch/fpantale/purityPR/plots1_Tracksters.html

or CLUE3D https://indico.cern.ch/event/1049055/contributions/4410257/attachments/2265568/3846599/20210616_HGCAL_DPG_CLUE3D_MR.pdf

@rovere @apsallid @lecriste @ebrondol @cseez @pfs FYI