### PR TITLE
[HGCal Trigger] Fix bug in auto-encoder trigger cell normalization

### DIFF
--- a/L1Trigger/L1THGCal/src/concentrator/HGCalConcentratorAutoEncoderImpl.cc
+++ b/L1Trigger/L1THGCal/src/concentrator/HGCalConcentratorAutoEncoderImpl.cc
@@ -262,8 +262,6 @@ void HGCalConcentratorAutoEncoderImpl::select(unsigned nLinks,
     int layer = id.layer();
     int waferU = id.waferU();
     int waferV = id.waferV();
-    int cellU = id.triggerCellU();
-    int cellV = id.triggerCellV();
 
     //use first TC to find mipPt conversions to Et and ADC
     float mipPtToEt_conv = trigCellVecInput[0].et() / trigCellVecInput[0].mipPt();
@@ -271,8 +269,8 @@ void HGCalConcentratorAutoEncoderImpl::select(unsigned nLinks,
 
     for (int i = 0; i < nTriggerCells_; i++) {
       if (ae_outputArray[i] > 0) {
-        cellU = ae_outputCellU_[i];
-        cellV = ae_outputCellV_[i];
+        int cellU = ae_outputCellU_[i];
+        int cellV = ae_outputCellV_[i];
 
         HGCalTriggerDetId id(subdet, zp, type, layer, waferU, waferV, cellU, cellV);
 


### PR DESCRIPTION
#### PR description:
Fixes a bug in the normalization of the trigger cells after decoding network. Modules were effectively being scaled to the MSB of the module sum, instead of preserving the total module sum.

Associated internal PR and review:
- PFCal-dev#473

#### PR validation:
Private tests in `L1Trigger/L1THGCalUtilities/test`:
```
cmsRun testHGCalL1T_RelValV11_cfg.py
cmsRun testHGCalL1T_multialgo_V11_cfg.py
```
Tested D49, D60 and D68 workflows
```
runTheMatrix.py -w upgrade -l 23234.0 --maxSteps=2 
runTheMatrix.py -w upgrade -l 28234.0 --maxSteps=2 
runTheMatrix.py -w upgrade -l 31434.0 --maxSteps=2
```
---
@dnoonan08 FYI
