### PR TITLE
Fix SiPixelDigisClustersFromSoA EDM_ML_DEBUG compilation error

### DIFF
--- a/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelDigisClustersFromSoA.cc
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelDigisClustersFromSoA.cc
@@ -114,14 +114,15 @@ void SiPixelDigisClustersFromSoA::produce(edm::StreamID, edm::Event& iEvent, con
       // sort by row (x)
       spc.emplace_back(acluster.isize, acluster.adc, acluster.x, acluster.y, acluster.xmin, acluster.ymin, ic);
       aclusters[ic].clear();
-      std::push_heap(spc.begin(), spc.end(), [](SiPixelCluster const& cl1, SiPixelCluster const& cl2) {
-        return cl1.minPixelRow() < cl2.minPixelRow();
-      });
 #ifdef EDM_ML_DEBUG
       ++totClustersFilled;
+      const auto& cluster{spc.back()};
       LogDebug("SiPixelDigisClustersFromSoA")
           << "putting in this cluster " << ic << " " << cluster.charge() << " " << cluster.pixelADC().size();
 #endif
+      std::push_heap(spc.begin(), spc.end(), [](SiPixelCluster const& cl1, SiPixelCluster const& cl2) {
+        return cl1.minPixelRow() < cl2.minPixelRow();
+      });
     }
     nclus = -1;
     // sort by row (x)


### PR DESCRIPTION
#### PR description:

Debug builds of SiPixelDigisClustersFromSoA with EDM_ML_DEBUG fail with this error:
```
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/ac2bd627c08c7e1e090dbd2c47050702/opt/cmssw/slc7_amd64_gcc900/cms/cmssw/CMSSW_12_0_DBG_X_2021-07-01-2300/src/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelDigisClustersFromSoA.cc: In lambda function:
  /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/ac2bd627c08c7e1e090dbd2c47050702/opt/cmssw/slc7_amd64_gcc900/cms/cmssw/CMSSW_12_0_DBG_X_2021-07-01-2300/src/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelDigisClustersFromSoA.cc:123:57: error: 'cluster' was not declared in this scope; did you mean 'acluster'?
   123 |           << "putting in this cluster " << ic << " " << cluster.charge() << " " << cluster.pixelADC().size();
      |                                                         ^~~~~~~
      |                                                         acluster
```
This PR fixes compilation.  The debug statements were moved wrt `std::push_heap` as after the heap insertion we no longer know which cluster we just added.

#### PR validation:

Reproduced the compilation failure.  Confirmed that with this fix,
```
USER_CXXFLAGS="-g -O3 -DEDM_ML_DEBUG" scram b -j32
```
has no errors.  Trivial technical fix, only affects DBG builds.