### PR TITLE
Use std:: functions instead of TMath:: functions in RecoEgamma

### DIFF
--- a/RecoEgamma/EgammaElectronAlgos/src/ElectronEnergyCorrector.cc
+++ b/RecoEgamma/EgammaElectronAlgos/src/ElectronEnergyCorrector.cc
@@ -4,7 +4,6 @@
 #include "RecoEcal/EgammaCoreTools/interface/EcalClusterFunctionBaseClass.h"
 #include "DataFormats/EcalDetId/interface/EcalSubdetector.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
-#include "TMath.h"
 
 /****************************************************************************
  *
@@ -73,18 +72,18 @@ namespace {
     float rightEta[nBinsEta] = {0.25, 0.42, 0.77, 0.91, 1.01, 1.13, etaCrackMin, 1.653, 1.8, 2.0, 2.2, 2.3, 2.4, 2.5};
 
     // eta = 0
-    if (TMath::Abs(eta) < leftEta[0]) {
+    if (std::abs(eta) < leftEta[0]) {
       eta = 0.02;
     }
 
     // outside acceptance
-    if (TMath::Abs(eta) >= rightEta[nBinsEta - 1]) {
+    if (std::abs(eta) >= rightEta[nBinsEta - 1]) {
       eta = 2.49;
-    }  //if (DBG) std::cout << " WARNING [applyScCorrections]: TMath::Abs(eta)  >=  rightEta[nBinsEta-1] " << std::endl;}
+    }  //if (DBG) std::cout << " WARNING [applyScCorrections]: std::abs(eta)  >=  rightEta[nBinsEta-1] " << std::endl;}
 
     int tmpEta = -1;
     for (int iEta = 0; iEta < nBinsEta; ++iEta) {
-      if (leftEta[iEta] <= TMath::Abs(eta) && TMath::Abs(eta) < rightEta[iEta]) {
+      if (leftEta[iEta] <= std::abs(eta) && std::abs(eta) < rightEta[iEta]) {
         tmpEta = iEta;
       }
     }
@@ -168,7 +167,7 @@ namespace {
     {
       float tmpInter = 1;
       for (int iEta = 0; iEta < nBinsEta - 1; ++iEta) {
-        if (rightEta[iEta] <= TMath::Abs(eta) && TMath::Abs(eta) < leftEta[iEta + 1]) {
+        if (rightEta[iEta] <= std::abs(eta) && std::abs(eta) < leftEta[iEta + 1]) {
           if (sigmaPhiSigmaEta >= sigmaPhiSigmaEtaFit[cl]) {
             tmpInter =
                 (par0[iEta][cl] + sigmaPhiSigmaEta * par1[iEta][cl] +
@@ -323,7 +322,7 @@ float egamma::classBasedElectronEnergy(reco::GsfElectron const& electron,
                   0,
                   elClass);
 
-  float et = energy * TMath::Sin(2 * TMath::ATan(TMath::Exp(-electron.superCluster()->eta()))) / corr;
+  float et = energy * std::sin(2 * std::atan(std::exp(-electron.superCluster()->eta()))) / corr;
 
   if (electron.isEB()) {
     corr2 = corr * fEt(et, 0, elClass);

--- a/RecoEgamma/EgammaElectronAlgos/src/EnergyUncertaintyElectronSpecific.cc
+++ b/RecoEgamma/EgammaElectronAlgos/src/EnergyUncertaintyElectronSpecific.cc
@@ -7,10 +7,10 @@ namespace {
     double et = energy / cosh(eta);
 
     constexpr int nBinsEta = 5;
-    constexpr Double_t EtaBins[nBinsEta + 1] = {0.0, 0.4, 0.8, 1.5, 2.0, 2.5};
+    constexpr double EtaBins[nBinsEta + 1] = {0.0, 0.4, 0.8, 1.5, 2.0, 2.5};
 
     constexpr int nBinsBrem = 6;
-    constexpr Double_t BremBins[nBinsBrem + 1] = {0.8, 1.0, 1.1, 1.2, 1.3, 1.5, 8.0};
+    constexpr double BremBins[nBinsBrem + 1] = {0.8, 1.0, 1.1, 1.2, 1.3, 1.5, 8.0};
 
     constexpr float par0[nBinsEta][nBinsBrem] = {
         {0.00567891, 0.0065673, 0.00574742, 0.00542964, 0.00523293, 0.00547518},
@@ -93,10 +93,10 @@ namespace {
     const double et = energy / cosh(eta);
 
     constexpr int nBinsEta = 4;
-    constexpr Double_t EtaBins[nBinsEta + 1] = {0.0, 0.8, 1.5, 2.0, 2.5};
+    constexpr double EtaBins[nBinsEta + 1] = {0.0, 0.8, 1.5, 2.0, 2.5};
 
     constexpr int nBinsBrem = 1;
-    constexpr Double_t BremBins[nBinsBrem + 1] = {0.8, 8.0};
+    constexpr double BremBins[nBinsBrem + 1] = {0.8, 8.0};
 
     constexpr float par0[nBinsEta][nBinsBrem] = {{0.00593389}, {0.00266954}, {0.00500623}, {0.00841038}};
 
@@ -155,10 +155,10 @@ namespace {
     const double et = energy / cosh(eta);
 
     constexpr int nBinsEta = 4;
-    constexpr Double_t EtaBins[nBinsEta + 1] = {0.0, 0.7, 1.3, 1.8, 2.5};
+    constexpr double EtaBins[nBinsEta + 1] = {0.0, 0.7, 1.3, 1.8, 2.5};
 
     constexpr int nBinsBrem = 1;
-    constexpr Double_t BremBins[nBinsBrem + 1] = {0.8, 8.0};
+    constexpr double BremBins[nBinsBrem + 1] = {0.8, 8.0};
 
     constexpr float par0[nBinsEta][nBinsBrem] = {{0.00601311}, {0.0059814}, {0.00953032}, {0.00728618}};
 
@@ -218,10 +218,10 @@ namespace {
     const double et = energy / cosh(eta);
 
     constexpr int nBinsEta = 4;
-    constexpr Double_t EtaBins[nBinsEta + 1] = {0.0, 0.8, 1.2, 1.7, 2.5};
+    constexpr double EtaBins[nBinsEta + 1] = {0.0, 0.8, 1.2, 1.7, 2.5};
 
     constexpr int nBinsBrem = 5;
-    constexpr Double_t BremBins[nBinsBrem + 1] = {0.8, 1.8, 2.2, 3.0, 4.0, 8.0};
+    constexpr double BremBins[nBinsBrem + 1] = {0.8, 1.8, 2.2, 3.0, 4.0, 8.0};
 
     constexpr float par0[nBinsEta][nBinsBrem] = {{0.0049351, 0.00566155, 0.0051397, 0.00468481, 0.00444475},
 
@@ -305,10 +305,10 @@ namespace {
     const double et = energy / cosh(eta);
 
     constexpr int nBinsEta = 5;
-    constexpr Double_t EtaBins[nBinsEta + 1] = {0.0, 0.42, 0.78, 1.2, 1.52, 1.65};
+    constexpr double EtaBins[nBinsEta + 1] = {0.0, 0.42, 0.78, 1.2, 1.52, 1.65};
 
     constexpr int nBinsBrem = 6;
-    constexpr Double_t BremBins[nBinsBrem + 1] = {0.8, 1.2, 1.5, 2.1, 3., 4, 8.0};
+    constexpr double BremBins[nBinsBrem + 1] = {0.8, 1.2, 1.5, 2.1, 3., 4, 8.0};
 
     constexpr float par0[nBinsEta][nBinsBrem] = {
         {0.0139815, 0.00550839, 0.0108292, 0.00596201, -0.00498136, 0.000621696},

--- a/RecoEgamma/EgammaPhotonAlgos/src/EnergyUncertaintyPhotonSpecific.cc
+++ b/RecoEgamma/EgammaPhotonAlgos/src/EnergyUncertaintyPhotonSpecific.cc
@@ -1,5 +1,4 @@
 #include "RecoEgamma/EgammaPhotonAlgos/interface/EnergyUncertaintyPhotonSpecific.h"
-#include "TMath.h"
 
 #include <iostream>
 
@@ -205,7 +204,7 @@ double EnergyUncertaintyPhotonSpecific::computePhotonEnergyUncertainty_lowR9(dou
 
   int iEtaSl = -1;
   for (int iEta = 0; iEta < nBinsEta; ++iEta) {
-    if (EtaBins[iEta] <= TMath::Abs(eta) && TMath::Abs(eta) < EtaBins[iEta + 1]) {
+    if (EtaBins[iEta] <= std::abs(eta) && std::abs(eta) < EtaBins[iEta + 1]) {
       iEtaSl = iEta;
     }
   }
@@ -217,7 +216,7 @@ double EnergyUncertaintyPhotonSpecific::computePhotonEnergyUncertainty_lowR9(dou
     }
   }
 
-  if (TMath::Abs(eta) > 2.5)
+  if (std::abs(eta) > 2.5)
     iEtaSl = nBinsEta - 1;
   if (brem < BremBins[0])
     iBremSl = 0;
@@ -435,7 +434,7 @@ double EnergyUncertaintyPhotonSpecific::computePhotonEnergyUncertainty_highR9(do
 
   int iEtaSl = -1;
   for (int iEta = 0; iEta < nBinsEta; ++iEta) {
-    if (EtaBins[iEta] <= TMath::Abs(eta) && TMath::Abs(eta) < EtaBins[iEta + 1]) {
+    if (EtaBins[iEta] <= std::abs(eta) && std::abs(eta) < EtaBins[iEta + 1]) {
       iEtaSl = iEta;
     }
   }
@@ -447,7 +446,7 @@ double EnergyUncertaintyPhotonSpecific::computePhotonEnergyUncertainty_highR9(do
     }
   }
 
-  if (TMath::Abs(eta) > 2.5)
+  if (std::abs(eta) > 2.5)
     iEtaSl = nBinsEta - 1;
   if (brem < BremBins[0])
     iBremSl = 0;

--- a/RecoEgamma/EgammaTools/src/EGEnergyCorrector.cc
+++ b/RecoEgamma/EgammaTools/src/EGEnergyCorrector.cc
@@ -208,10 +208,10 @@ std::pair<double, double> EGEnergyCorrector::CorrectedEnergyWithError(const Phot
     fVals[57] = biphi;      //crystal iphi
     fVals[58] = bieta % 5;  //submodule boundary eta symmetry
     fVals[59] = biphi % 2;  //submodule boundary phi symmetry
-    fVals[60] = (TMath::Abs(bieta) <= 25) * (bieta % 25) +
-                (TMath::Abs(bieta) > 25) *
-                    ((bieta - 25 * TMath::Abs(bieta) / bieta) % 20);  //module boundary eta approximate symmetry
-    fVals[61] = biphi % 20;                                           //module boundary phi symmetry
+    fVals[60] = (std::abs(bieta) <= 25) * (bieta % 25) +
+                (std::abs(bieta) > 25) *
+                    ((bieta - 25 * std::abs(bieta) / bieta) % 20);  //module boundary eta approximate symmetry
+    fVals[61] = biphi % 20;                                         //module boundary phi symmetry
     fVals[62] = betacry;  //local coordinates with respect to closest crystal center at nominal shower depth
     fVals[63] = bphicry;
 
@@ -226,8 +226,8 @@ std::pair<double, double> EGEnergyCorrector::CorrectedEnergyWithError(const Phot
     fVals[65] = hasbc2 ? bc2iphi : 0.;
     fVals[66] = hasbc2 ? bc2ieta % 5 : 0.;
     fVals[67] = hasbc2 ? bc2iphi % 2 : 0.;
-    fVals[68] = hasbc2 ? (TMath::Abs(bc2ieta) <= 25) * (bc2ieta % 25) +
-                             (TMath::Abs(bc2ieta) > 25) * ((bc2ieta - 25 * TMath::Abs(bc2ieta) / bc2ieta) % 20)
+    fVals[68] = hasbc2 ? (std::abs(bc2ieta) <= 25) * (bc2ieta % 25) +
+                             (std::abs(bc2ieta) > 25) * ((bc2ieta - 25 * std::abs(bc2ieta) / bc2ieta) % 20)
                        : 0.;
     fVals[69] = hasbc2 ? bc2iphi % 20 : 0.;
     fVals[70] = hasbc2 ? bc2etacry : 0.;
@@ -339,10 +339,10 @@ std::pair<double, double> EGEnergyCorrector::CorrectedEnergyWithErrorV3(const Ph
     fVals[31] = biphi;      //crystal iphi
     fVals[32] = bieta % 5;  //submodule boundary eta symmetry
     fVals[33] = biphi % 2;  //submodule boundary phi symmetry
-    fVals[34] = (TMath::Abs(bieta) <= 25) * (bieta % 25) +
-                (TMath::Abs(bieta) > 25) *
-                    ((bieta - 25 * TMath::Abs(bieta) / bieta) % 20);  //module boundary eta approximate symmetry
-    fVals[35] = biphi % 20;                                           //module boundary phi symmetry
+    fVals[34] = (std::abs(bieta) <= 25) * (bieta % 25) +
+                (std::abs(bieta) > 25) *
+                    ((bieta - 25 * std::abs(bieta) / bieta) % 20);  //module boundary eta approximate symmetry
+    fVals[35] = biphi % 20;                                         //module boundary phi symmetry
     fVals[36] = betacry;  //local coordinates with respect to closest crystal center at nominal shower depth
     fVals[37] = bphicry;
 
@@ -379,7 +379,7 @@ std::pair<double, double> EGEnergyCorrector::CorrectedEnergyWithErrorV3(const Ph
       fVals[6] = 1.00002 * s->phiWidth() - 0.000371;        //phiwidth
       fVals[14] = fVals[3] * s->rawEnergy() / b->energy();  //compute consistent e3x3/eseed after r9 rescaling
       if (fVals[15] <= 1.0)  // rescale e5x5/eseed only if value is <=1.0, don't allow scaled values to exceed 1.0
-        fVals[15] = TMath::Min(1.0, 1.0022 * p.e5x5() / b->energy());
+        fVals[15] = std::min(1.0, 1.0022 * p.e5x5() / b->energy());
 
       fVals[4] =
           fVals[15] * b->energy() / s->rawEnergy();  // compute consistent e5x5()/rawEnergy() after e5x5/eseed resacling
@@ -400,12 +400,12 @@ std::pair<double, double> EGEnergyCorrector::CorrectedEnergyWithErrorV3(const Ph
       fVals[29] = 1.09 * be2x5right / b->energy();
 
     } else {
-      fVals[3] = 1.0086 * p.r9() - 0.0007;                             //r9
-      fVals[4] = TMath::Min(1.0, 1.0022 * p.e5x5() / s->rawEnergy());  //e5x5/rawenergy
-      fVals[5] = 0.903254 * s->etaWidth() + 0.001346;                  //etawidth
-      fVals[6] = 0.99992 * s->phiWidth() + 4.8e-07;                    //phiwidth
+      fVals[3] = 1.0086 * p.r9() - 0.0007;                           //r9
+      fVals[4] = std::min(1.0, 1.0022 * p.e5x5() / s->rawEnergy());  //e5x5/rawenergy
+      fVals[5] = 0.903254 * s->etaWidth() + 0.001346;                //etawidth
+      fVals[6] = 0.99992 * s->phiWidth() + 4.8e-07;                  //phiwidth
       fVals[13] =
-          TMath::Min(1.0, 1.0022 * b->energy() / s->rawEnergy());  //eseed/rawenergy (practically equivalent to e5x5)
+          std::min(1.0, 1.0022 * b->energy() / s->rawEnergy());  //eseed/rawenergy (practically equivalent to e5x5)
 
       fVals[14] = fVals[3] * s->rawEnergy() / b->energy();  //compute consistent e3x3/eseed after r9 rescaling
 

--- a/RecoEgamma/EgammaTools/src/EGEnergyCorrector.cc
+++ b/RecoEgamma/EgammaTools/src/EGEnergyCorrector.cc
@@ -83,7 +83,7 @@ std::pair<double, double> EGEnergyCorrector::CorrectedEnergyWithError(const Phot
 
   //highest energy basic cluster excluding seed basic cluster
   CaloClusterPtr b2;
-  Double_t ebcmax = -99.;
+  double ebcmax = -99.;
   for (reco::CaloCluster_iterator bit = s->clustersBegin(); bit != s->clustersEnd(); ++bit) {
     const CaloClusterPtr bc = *bit;
     if (bc->energy() > ebcmax && bc != b) {
@@ -94,7 +94,7 @@ std::pair<double, double> EGEnergyCorrector::CorrectedEnergyWithError(const Phot
 
   //lowest energy basic cluster excluding seed (for pileup mitigation)
   CaloClusterPtr bclast;
-  Double_t ebcmin = 1e6;
+  double ebcmin = 1e6;
   for (reco::CaloCluster_iterator bit = s->clustersBegin(); bit != s->clustersEnd(); ++bit) {
     const CaloClusterPtr bc = *bit;
     if (bc->energy() < ebcmin && bc != b) {
@@ -114,10 +114,10 @@ std::pair<double, double> EGEnergyCorrector::CorrectedEnergyWithError(const Phot
     }
   }
 
-  Bool_t isbarrel = b->hitsAndFractions().at(0).first.subdetId() == EcalBarrel;
-  Bool_t hasbc2 = b2.isNonnull() && b2->energy() > 0.;
-  Bool_t hasbclast = bclast.isNonnull() && bclast->energy() > 0.;
-  Bool_t hasbclast2 = bclast2.isNonnull() && bclast2->energy() > 0.;
+  bool isbarrel = b->hitsAndFractions().at(0).first.subdetId() == EcalBarrel;
+  bool hasbc2 = b2.isNonnull() && b2->energy() > 0.;
+  bool hasbclast = bclast.isNonnull() && bclast->energy() > 0.;
+  bool hasbclast2 = bclast2.isNonnull() && bclast2->energy() > 0.;
 
   if (isbarrel) {
     //basic supercluster variables
@@ -246,8 +246,8 @@ std::pair<double, double> EGEnergyCorrector::CorrectedEnergyWithError(const Phot
     fVals[7] = vtxcol.size();
   }
 
-  const Double_t varscale = 1.253;
-  Double_t den;
+  const double varscale = 1.253;
+  double den;
   const GBRForest *reader;
   const GBRForest *readervar;
   if (isbarrel) {
@@ -260,8 +260,8 @@ std::pair<double, double> EGEnergyCorrector::CorrectedEnergyWithError(const Phot
     readervar = fReadereevariance;
   }
 
-  Double_t ecor = reader->GetResponse(fVals.data()) * den;
-  Double_t ecorerr = readervar->GetResponse(fVals.data()) * den * varscale;
+  double ecor = reader->GetResponse(fVals.data()) * den;
+  double ecorerr = readervar->GetResponse(fVals.data()) * den * varscale;
 
   //printf("ecor = %5f, ecorerr = %5f\n",ecor,ecorerr);
 
@@ -278,7 +278,7 @@ std::pair<double, double> EGEnergyCorrector::CorrectedEnergyWithErrorV3(const Ph
   const SuperClusterRef s = p.superCluster();
   const CaloClusterPtr b = s->seed();  //seed  basic cluster
 
-  Bool_t isbarrel = b->hitsAndFractions().at(0).first.subdetId() == EcalBarrel;
+  bool isbarrel = b->hitsAndFractions().at(0).first.subdetId() == EcalBarrel;
 
   //basic supercluster variables
   fVals[0] = s->rawEnergy();
@@ -356,7 +356,7 @@ std::pair<double, double> EGEnergyCorrector::CorrectedEnergyWithErrorV3(const Ph
   //   }
   //   else for (int i=0; i<31; ++i) printf("%i: %5f\n",i,fVals[i]);
 
-  Double_t den;
+  double den;
   const GBRForest *reader;
   const GBRForest *readervar;
   if (isbarrel) {
@@ -369,7 +369,7 @@ std::pair<double, double> EGEnergyCorrector::CorrectedEnergyWithErrorV3(const Ph
     readervar = fReadereevariance;
   }
 
-  Double_t ecor = reader->GetResponse(fVals.data()) * den;
+  double ecor = reader->GetResponse(fVals.data()) * den;
 
   //apply shower shape rescaling - for Monte Carlo only, and only for calculation of energy uncertainty
   if (applyRescale) {
@@ -425,7 +425,7 @@ std::pair<double, double> EGEnergyCorrector::CorrectedEnergyWithErrorV3(const Ph
     }
   }
 
-  Double_t ecorerr = readervar->GetResponse(fVals.data()) * den;
+  double ecorerr = readervar->GetResponse(fVals.data()) * den;
 
   //printf("ecor = %5f, ecorerr = %5f\n",ecor,ecorerr);
 

--- a/RecoEgamma/EgammaTools/src/EcalClusterLocal.cc
+++ b/RecoEgamma/EgammaTools/src/EcalClusterLocal.cc
@@ -6,7 +6,6 @@
 #include "Geometry/CaloGeometry/interface/CaloSubdetectorGeometry.h"
 #include "DataFormats/Math/interface/deltaR.h"
 #include "DataFormats/CaloRecHit/interface/CaloCluster.h"
-#include "TMath.h"
 #include "TVector2.h"
 
 namespace egammaTools {
@@ -25,7 +24,7 @@ namespace egammaTools {
         caloGeometry.getSubdetectorGeometry(DetId::Ecal, EcalBarrel);  //EcalBarrel = 1
 
     const math::XYZPoint &position_ = bclus.position();
-    double Theta = -position_.theta() + 0.5 * TMath::Pi();
+    double Theta = -position_.theta() + 0.5 * M_PI;
     double Eta = position_.eta();
     double Phi = TVector2::Phi_mpi_pi(position_.phi());
 
@@ -69,14 +68,14 @@ namespace egammaTools {
     GlobalPoint center_pos = cpyr->getPosition(depth);
 
     double PhiCentr = TVector2::Phi_mpi_pi(center_pos.phi());
-    double PhiWidth = (TMath::Pi() / 180.);
+    double PhiWidth = (M_PI / 180.);
     phicry = (TVector2::Phi_mpi_pi(Phi - PhiCentr)) / PhiWidth;
     //Some flips to take into account ECAL barrel symmetries:
     if (ieta < 0)
       phicry *= -1.;
 
-    double ThetaCentr = -center_pos.theta() + 0.5 * TMath::Pi();
-    double ThetaWidth = (TMath::Pi() / 180.) * TMath::Cos(ThetaCentr);
+    double ThetaCentr = -center_pos.theta() + 0.5 * M_PI;
+    double ThetaWidth = (M_PI / 180.) * std::cos(ThetaCentr);
     etacry = (Theta - ThetaCentr) / ThetaWidth;
     //flip to take into account ECAL barrel symmetries:
     if (ieta < 0)
@@ -99,7 +98,7 @@ namespace egammaTools {
         caloGeometry.getSubdetectorGeometry(DetId::Ecal, EcalEndcap);  //EcalBarrel = 1
 
     const math::XYZPoint &position_ = bclus.position();
-    //double Theta = -position_.theta()+0.5*TMath::Pi();
+    //double Theta = -position_.theta()+0.5*M_PI;
     double Eta = position_.eta();
     double Phi = TVector2::Phi_mpi_pi(position_.phi());
     double X = position_.x();
@@ -110,7 +109,7 @@ namespace egammaTools {
     const float X0 = 0.89;
     float T0 = 1.2;
     //different T0 value if outside of preshower coverage
-    if (TMath::Abs(bclus.eta()) < 1.653)
+    if (std::abs(bclus.eta()) < 1.653)
       T0 = 3.1;
 
     double depth = X0 * (T0 + log(bclus.energy()));

--- a/RecoEgamma/Examples/plugins/GsfElectronDataAnalyzer.cc
+++ b/RecoEgamma/Examples/plugins/GsfElectronDataAnalyzer.cc
@@ -40,7 +40,6 @@
 
 #include "CLHEP/Units/GlobalPhysicalConstants.h"
 
-#include "TMath.h"
 #include "TFile.h"
 #include "TH1F.h"
 #include "TH1I.h"
@@ -1993,8 +1992,8 @@ void GsfElectronDataAnalyzer::analyze(const edm::Event &iEvent, const edm::Event
     if (!gsfIter->ecalDrivenSeed() && gsfIter->trackerDrivenSeed())
       sclRef = gsfIter->parentSuperCluster();
     histSclEn_->Fill(sclRef->energy());
-    double R = TMath::Sqrt(sclRef->x() * sclRef->x() + sclRef->y() * sclRef->y() + sclRef->z() * sclRef->z());
-    double Rt = TMath::Sqrt(sclRef->x() * sclRef->x() + sclRef->y() * sclRef->y());
+    double R = std::sqrt(sclRef->x() * sclRef->x() + sclRef->y() * sclRef->y() + sclRef->z() * sclRef->z());
+    double Rt = std::sqrt(sclRef->x() * sclRef->x() + sclRef->y() * sclRef->y());
     histSclEt_->Fill(sclRef->energy() * (Rt / R));
     histSclEtVsEta_->Fill(sclRef->eta(), sclRef->energy() * (Rt / R));
     histSclEtVsPhi_->Fill(sclRef->phi(), sclRef->energy() * (Rt / R));

--- a/RecoEgamma/Examples/plugins/GsfElectronFakeAnalyzer.cc
+++ b/RecoEgamma/Examples/plugins/GsfElectronFakeAnalyzer.cc
@@ -39,7 +39,6 @@
 
 #include "CLHEP/Units/GlobalPhysicalConstants.h"
 
-#include "TMath.h"
 #include "TFile.h"
 #include "TH1F.h"
 #include "TH1I.h"
@@ -2273,8 +2272,8 @@ void GsfElectronFakeAnalyzer::analyze(const edm::Event &iEvent, const edm::Event
       if (!bestGsfElectron.ecalDrivenSeed() && bestGsfElectron.trackerDrivenSeed())
         sclRef = bestGsfElectron.parentSuperCluster();
       histSclEn_->Fill(sclRef->energy());
-      double R = TMath::Sqrt(sclRef->x() * sclRef->x() + sclRef->y() * sclRef->y() + sclRef->z() * sclRef->z());
-      double Rt = TMath::Sqrt(sclRef->x() * sclRef->x() + sclRef->y() * sclRef->y());
+      double R = std::sqrt(sclRef->x() * sclRef->x() + sclRef->y() * sclRef->y() + sclRef->z() * sclRef->z());
+      double Rt = std::sqrt(sclRef->x() * sclRef->x() + sclRef->y() * sclRef->y());
       histSclEt_->Fill(sclRef->energy() * (Rt / R));
       histSclEtVsEta_->Fill(sclRef->eta(), sclRef->energy() * (Rt / R));
       histSclEtVsPhi_->Fill(sclRef->phi(), sclRef->energy() * (Rt / R));

--- a/RecoEgamma/Examples/plugins/GsfElectronMCAnalyzer.cc
+++ b/RecoEgamma/Examples/plugins/GsfElectronMCAnalyzer.cc
@@ -37,7 +37,6 @@
 
 #include "CLHEP/Units/GlobalPhysicalConstants.h"
 
-#include "TMath.h"
 #include "TFile.h"
 #include "TH1F.h"
 #include "TH1I.h"
@@ -3166,8 +3165,8 @@ void GsfElectronMCAnalyzer::analyze(const edm::Event &iEvent, const edm::EventSe
           if (!bestGsfElectron.ecalDrivenSeed() && bestGsfElectron.trackerDrivenSeed())
             sclRef = bestGsfElectron.parentSuperCluster();
           histSclEn_->Fill(sclRef->energy());
-          double R = TMath::Sqrt(sclRef->x() * sclRef->x() + sclRef->y() * sclRef->y() + sclRef->z() * sclRef->z());
-          double Rt = TMath::Sqrt(sclRef->x() * sclRef->x() + sclRef->y() * sclRef->y());
+          double R = std::sqrt(sclRef->x() * sclRef->x() + sclRef->y() * sclRef->y() + sclRef->z() * sclRef->z());
+          double Rt = std::sqrt(sclRef->x() * sclRef->x() + sclRef->y() * sclRef->y());
           histSclEt_->Fill(sclRef->energy() * (Rt / R));
           histSclEtVsEta_->Fill(sclRef->eta(), sclRef->energy() * (Rt / R));
           histSclEtVsPhi_->Fill(sclRef->phi(), sclRef->energy() * (Rt / R));

--- a/RecoEgamma/Examples/plugins/GsfElectronMCFakeAnalyzer.cc
+++ b/RecoEgamma/Examples/plugins/GsfElectronMCFakeAnalyzer.cc
@@ -38,7 +38,6 @@
 
 #include "CLHEP/Units/GlobalPhysicalConstants.h"
 
-#include "TMath.h"
 #include "TFile.h"
 #include "TH1F.h"
 #include "TH1I.h"
@@ -2259,8 +2258,8 @@ void GsfElectronMCFakeAnalyzer::analyze(const edm::Event &iEvent, const edm::Eve
       if (!bestGsfElectron.ecalDrivenSeed() && bestGsfElectron.trackerDrivenSeed())
         sclRef = bestGsfElectron.parentSuperCluster();
       histSclEn_->Fill(sclRef->energy());
-      double R = TMath::Sqrt(sclRef->x() * sclRef->x() + sclRef->y() * sclRef->y() + sclRef->z() * sclRef->z());
-      double Rt = TMath::Sqrt(sclRef->x() * sclRef->x() + sclRef->y() * sclRef->y());
+      double R = std::sqrt(sclRef->x() * sclRef->x() + sclRef->y() * sclRef->y() + sclRef->z() * sclRef->z());
+      double Rt = std::sqrt(sclRef->x() * sclRef->x() + sclRef->y() * sclRef->y());
       histSclEt_->Fill(sclRef->energy() * (Rt / R));
       histSclEtVsEta_->Fill(sclRef->eta(), sclRef->energy() * (Rt / R));
       histSclEtVsPhi_->Fill(sclRef->phi(), sclRef->energy() * (Rt / R));

--- a/RecoEgamma/Examples/plugins/MCPhotonAnalyzer.cc
+++ b/RecoEgamma/Examples/plugins/MCPhotonAnalyzer.cc
@@ -348,19 +348,19 @@ void MCPhotonAnalyzer::analyze(const edm::Event& e, const edm::EventSetup&) {
 }
 
 void MCPhotonAnalyzer::endJob() {
-  Double_t s1 = 0;
-  Double_t s2 = 0;
-  Double_t s3 = 0;
-  Double_t s4 = 0;
+  double s1 = 0;
+  double s2 = 0;
+  double s3 = 0;
+  double s4 = 0;
   int e1 = 0;
   int e2 = 0;
   int e3 = 0;
   int e4 = 0;
 
-  Double_t nTotEta1 = h_MCPhoEta1_->GetEntries();
-  Double_t nTotEta2 = h_MCPhoEta2_->GetEntries();
-  Double_t nTotEta3 = h_MCPhoEta3_->GetEntries();
-  Double_t nTotEta4 = h_MCPhoEta4_->GetEntries();
+  double nTotEta1 = h_MCPhoEta1_->GetEntries();
+  double nTotEta2 = h_MCPhoEta2_->GetEntries();
+  double nTotEta3 = h_MCPhoEta3_->GetEntries();
+  double nTotEta4 = h_MCPhoEta4_->GetEntries();
 
   for (int i = 1; i <= 120; ++i) {
     e1 = (int)h_MCConvPhoREta1_->GetBinContent(i);

--- a/RecoEgamma/Examples/plugins/PatPhotonSimpleAnalyzer.cc
+++ b/RecoEgamma/Examples/plugins/PatPhotonSimpleAnalyzer.cc
@@ -26,7 +26,6 @@
 
 #include "TFile.h"
 #include "TH1.h"
-#include "TMath.h"
 #include "TTree.h"
 
 #include <memory>
@@ -174,13 +173,13 @@ void PatPhotonSimpleAnalyzer::beginJob() {
   // Photon Histograms
   h_photonEt_ = new TH1F("photonEt", "Photon E_{T}", 200, 0, 200);
   h_photonEta_ = new TH1F("photonEta", "Photon #eta", 200, -4, 4);
-  h_photonPhi_ = new TH1F("photonPhi", "Photon #phi", 200, -1. * TMath::Pi(), TMath::Pi());
+  h_photonPhi_ = new TH1F("photonPhi", "Photon #phi", 200, -1. * M_PI, M_PI);
   h_hadoverem_ = new TH1F("photonHoverE", "Hadronic over EM", 200, 0, 1);
 
   // Photon's SuperCluster Histograms
   h_photonScEt_ = new TH1F("photonScEt", "Photon SuperCluster E_{T}", 200, 0, 200);
   h_photonScEta_ = new TH1F("photonScEta", "Photon #eta", 200, -4, 4);
-  h_photonScPhi_ = new TH1F("photonScPhi", "Photon #phi", 200, -1. * TMath::Pi(), TMath::Pi());
+  h_photonScPhi_ = new TH1F("photonScPhi", "Photon #phi", 200, -1. * M_PI, M_PI);
   h_photonScEtaWidth_ = new TH1F("photonScEtaWidth", "#eta-width", 100, 0, .1);
 
   // Composite or Other Histograms

--- a/RecoEgamma/Examples/plugins/SimplePi0DiscAnalyzer.cc
+++ b/RecoEgamma/Examples/plugins/SimplePi0DiscAnalyzer.cc
@@ -32,7 +32,6 @@
 
 #include "CLHEP/Units/PhysicalConstants.h"
 
-#include "TMath.h"
 #include "TFile.h"
 #include "TH1F.h"
 #include "TH1I.h"

--- a/RecoEgamma/Examples/test/eleValidation.C
+++ b/RecoEgamma/Examples/test/eleValidation.C
@@ -232,8 +232,8 @@
   TCanvas *c_absetaEff = new TCanvas("absetaEff","absetaEff");
   c_absetaEff->cd();
   for (int ibin=1; ibin<h_ele_absetaEff->GetNbinsX(); ibin++) {
-    Double_t binContent = h_ele_absetaEff->GetBinContent(ibin);
-    Double_t error2 = binContent*(1.-binContent)/h_simAbsEta->GetBinContent(ibin);
+    double binContent = h_ele_absetaEff->GetBinContent(ibin);
+    double error2 = binContent*(1.-binContent)/h_simAbsEta->GetBinContent(ibin);
     //h_ele_absetaEff->SetBinError(ibin,sqrt(error2));
     std::cout << "ibin " << ibin << " efficiency " << binContent << " error " <<  sqrt(error2) <<
     std::endl;

--- a/RecoEgamma/Examples/test/eleValidation.C
+++ b/RecoEgamma/Examples/test/eleValidation.C
@@ -1,21 +1,20 @@
 {
-
   // style
-  
+
   gROOT->Reset();
 
   // style:
-  TStyle *tdrStyle = new TStyle("tdrStyle","Style for P-TDR");
-  
+  TStyle *tdrStyle = new TStyle("tdrStyle", "Style for P-TDR");
+
   //For the canvas:
   tdrStyle->SetCanvasBorderMode(0);
   tdrStyle->SetCanvasColor(kWhite);
-  tdrStyle->SetCanvasDefH(600); 
+  tdrStyle->SetCanvasDefH(600);
   //Height of canvas
-  tdrStyle->SetCanvasDefW(800); //Width of canvas
-  tdrStyle->SetCanvasDefX(0);   //POsition on screen
+  tdrStyle->SetCanvasDefW(800);  //Width of canvas
+  tdrStyle->SetCanvasDefX(0);    //POsition on screen
   tdrStyle->SetCanvasDefY(0);
-  
+
   // For the Pad:
   tdrStyle->SetPadBorderMode(0);
   // tdrStyle->SetPadBorderSize(Width_t size = 1);
@@ -25,7 +24,7 @@
   tdrStyle->SetGridColor(0);
   tdrStyle->SetGridStyle(3);
   tdrStyle->SetGridWidth(1);
-  
+
   //For the frame:
   tdrStyle->SetFrameBorderMode(0);
   tdrStyle->SetFrameBorderSize(1);
@@ -34,7 +33,7 @@
   tdrStyle->SetFrameLineColor(1);
   tdrStyle->SetFrameLineStyle(1);
   tdrStyle->SetFrameLineWidth(1);
-  
+
   // For the histo:
   tdrStyle->SetHistLineColor(1);
   tdrStyle->SetHistLineStyle(0);
@@ -43,8 +42,7 @@
   //tdrStyle->SetErrorMarker(20);
   tdrStyle->SetErrorX(0.);
   tdrStyle->SetMarkerStyle(8);
-  
-  
+
   // For the statistics box:
   tdrStyle->SetOptFile(0);
   //tdrStyle->SetOptStat(1);
@@ -57,10 +55,10 @@
   //tdrStyle->SetStatBorderSize(1);
   //tdrStyle->SetStatH(.1);
   //tdrStyle->SetStatW(.15);
-  
+
   //  tdrStyle->SetStatX(.9);
   // tdrStyle->SetStatY(.9);
-  
+
   // For the Global title:
   tdrStyle->SetOptTitle(0);
   tdrStyle->SetTitleFont(42);
@@ -68,7 +66,7 @@
   tdrStyle->SetTitleTextColor(1);
   tdrStyle->SetTitleFillColor(10);
   tdrStyle->SetTitleFontSize(0.05);
-  
+
   // For the axis titles:
   tdrStyle->SetTitleColor(1, "XYZ");
   tdrStyle->SetTitleFont(42, "XYZ");
@@ -78,15 +76,15 @@
   // tdrStyle->SetTitleYOffset(1.25);
   //tdrStyle->SetTitleXOffset(0.5);
   tdrStyle->SetTitleYOffset(1.0);
-  
+
   // For the axis labels:
   tdrStyle->SetLabelColor(1, "XYZ");
   tdrStyle->SetLabelFont(42, "XYZ");
   tdrStyle->SetLabelOffset(0.007, "XYZ");
-  
+
   //tdrStyle->SetLabelSize(0.05, "XYZ");
   tdrStyle->SetLabelSize(0.04, "XYZ");
-  
+
   // For the axis:
   tdrStyle->SetAxisColor(1, "XYZ");
   tdrStyle->SetStripDecimals(kTRUE);
@@ -96,424 +94,426 @@
   tdrStyle->SetPadTickY(1);
   // // Postscript options:
   //   //tdrStyle->SetPaperSize(20.,20.);
-  
-  // CC style  
+
+  // CC style
   tdrStyle->SetTitleXOffset(0.8);
   tdrStyle->SetTitleYOffset(0.8);
   tdrStyle->SetLabelOffset(0.005, "XYZ");
   tdrStyle->SetTitleSize(0.07, "XYZ");
-  tdrStyle->SetTitleFont(22,"X");
-  tdrStyle->SetTitleFont(22,"Y");
-//  tdrStyle->SetPadBottomMargin(0.2);
-//  tdrStyle->SetPadLeftMargin(0.2);
+  tdrStyle->SetTitleFont(22, "X");
+  tdrStyle->SetTitleFont(22, "Y");
+  //  tdrStyle->SetPadBottomMargin(0.2);
+  //  tdrStyle->SetPadLeftMargin(0.2);
   tdrStyle->SetPadBottomMargin(0.13);
   tdrStyle->SetPadLeftMargin(0.15);
-//  tdrStyle->SetHistLineWidth(3);
+  //  tdrStyle->SetHistLineWidth(3);
   tdrStyle->SetHistLineWidth(2);
-  
-  tdrStyle->cd(); 
-  
+
+  tdrStyle->cd();
+
   gROOT->ForceStyle();
-  
+
   // output figures: file type suffix
   char suffix[] = "gif";
   // output figures: directory
   char outDir[] = "./analysisPreselLowLumiPUBugfix";
   // temp variables
   char str[128];
-  
-  bool out = true;
-//  bool out = false;
-  
-//  bool pause = true;
-  bool pause = false;
-  
-  TFile hist("gsfElectronHistos_DiEle-Pt5To100_rereco131_LowLumiPU_bugfix.root");
-  
-  // electron quantities
-  TH1F *h_ele_PoPtrue   = (TH1F*)hist.Get("h_ele_PoPtrue"); 
-  TH1F *h_ele_EtaMnEtaTrue   = (TH1F*)hist.Get("h_ele_EtaMnEtaTrue"); 
-  TH1F *h_ele_PhiMnPhiTrue   = (TH1F*)hist.Get("h_ele_PhiMnPhiTrue"); 
-  TH1F *h_ele_vertexP   = (TH1F*)hist.Get("h_ele_vertexP"); 
-  TH1F *h_ele_vertexPt   = (TH1F*)hist.Get("h_ele_vertexPt"); 
-  TH1F *h_ele_outerP_mode   = (TH1F*)hist.Get("h_ele_outerP_mode"); 
-  TH1F *h_ele_outerPt_mode   = (TH1F*)hist.Get("h_ele_outerPt_mode"); 
-  TH1F *h_ele_vertexZ   = (TH1F*)hist.Get("h_ele_vertexZ"); 
 
-  TCanvas *c_PoPtrue = new TCanvas("PoPtrue","PoPtrue");
+  bool out = true;
+  //  bool out = false;
+
+  //  bool pause = true;
+  bool pause = false;
+
+  TFile hist("gsfElectronHistos_DiEle-Pt5To100_rereco131_LowLumiPU_bugfix.root");
+
+  // electron quantities
+  TH1F *h_ele_PoPtrue = (TH1F *)hist.Get("h_ele_PoPtrue");
+  TH1F *h_ele_EtaMnEtaTrue = (TH1F *)hist.Get("h_ele_EtaMnEtaTrue");
+  TH1F *h_ele_PhiMnPhiTrue = (TH1F *)hist.Get("h_ele_PhiMnPhiTrue");
+  TH1F *h_ele_vertexP = (TH1F *)hist.Get("h_ele_vertexP");
+  TH1F *h_ele_vertexPt = (TH1F *)hist.Get("h_ele_vertexPt");
+  TH1F *h_ele_outerP_mode = (TH1F *)hist.Get("h_ele_outerP_mode");
+  TH1F *h_ele_outerPt_mode = (TH1F *)hist.Get("h_ele_outerPt_mode");
+  TH1F *h_ele_vertexZ = (TH1F *)hist.Get("h_ele_vertexZ");
+
+  TCanvas *c_PoPtrue = new TCanvas("PoPtrue", "PoPtrue");
   c_PoPtrue->cd();
-  h_ele_PoPtrue->Draw();   
-  h_ele_PoPtrue->GetXaxis()->SetTitle("p_{rec}/p_{true}");  
-  h_ele_PoPtrue->GetYaxis()->SetTitle("Events");  
+  h_ele_PoPtrue->Draw();
+  h_ele_PoPtrue->GetXaxis()->SetTitle("p_{rec}/p_{true}");
+  h_ele_PoPtrue->GetYaxis()->SetTitle("Events");
   if (out) {
-    snprintf(str, 128,"%s/PoPtrue.%s",outDir,suffix);
+    snprintf(str, 128, "%s/PoPtrue.%s", outDir, suffix);
     gPad->Print(str);
   }
- 
-  TCanvas *c_EtaMnEtaTrue = new TCanvas("EtaMnEtaTrue","EtaMnEtaTrue");
+
+  TCanvas *c_EtaMnEtaTrue = new TCanvas("EtaMnEtaTrue", "EtaMnEtaTrue");
   c_EtaMnEtaTrue->cd();
-  h_ele_EtaMnEtaTrue->Draw();   
-  h_ele_EtaMnEtaTrue->GetXaxis()->SetTitle("#eta_{rec}-#eta_{true}");  
-  h_ele_EtaMnEtaTrue->GetYaxis()->SetTitle("Events");  
+  h_ele_EtaMnEtaTrue->Draw();
+  h_ele_EtaMnEtaTrue->GetXaxis()->SetTitle("#eta_{rec}-#eta_{true}");
+  h_ele_EtaMnEtaTrue->GetYaxis()->SetTitle("Events");
   if (out) {
-    snprintf(str, 128,"%s/EtaMnEtaTrue.%s",outDir,suffix);
+    snprintf(str, 128, "%s/EtaMnEtaTrue.%s", outDir, suffix);
     gPad->Print(str);
   }
- 
-  TCanvas *c_PhiMnPhiTrue = new TCanvas("PhiMnPhiTrue","PhiMnPhiTrue");
+
+  TCanvas *c_PhiMnPhiTrue = new TCanvas("PhiMnPhiTrue", "PhiMnPhiTrue");
   c_PhiMnPhiTrue->cd();
-  h_ele_PhiMnPhiTrue->Draw(); 
-  h_ele_PhiMnPhiTrue->GetXaxis()->SetTitle("#phi_{rec}-#phi_{true}");  
-  h_ele_PhiMnPhiTrue->GetYaxis()->SetTitle("Events");  
+  h_ele_PhiMnPhiTrue->Draw();
+  h_ele_PhiMnPhiTrue->GetXaxis()->SetTitle("#phi_{rec}-#phi_{true}");
+  h_ele_PhiMnPhiTrue->GetYaxis()->SetTitle("Events");
   if (out) {
-    snprintf(str, 128,"%s/PhiMnPhiTrue.%s",outDir,suffix);
+    snprintf(str, 128, "%s/PhiMnPhiTrue.%s", outDir, suffix);
     gPad->Print(str);
   }
-   
-  TCanvas *c_vertexP = new TCanvas("vertexP","vertexP");
+
+  TCanvas *c_vertexP = new TCanvas("vertexP", "vertexP");
   c_vertexP->cd();
-  h_ele_vertexP->Draw(); 
-  h_ele_vertexP->GetXaxis()->SetTitle("p_{vertex}");  
-  h_ele_vertexP->GetYaxis()->SetTitle("Events");  
+  h_ele_vertexP->Draw();
+  h_ele_vertexP->GetXaxis()->SetTitle("p_{vertex}");
+  h_ele_vertexP->GetYaxis()->SetTitle("Events");
   if (out) {
-    snprintf(str, 128,"%s/vertexP.%s",outDir,suffix);
+    snprintf(str, 128, "%s/vertexP.%s", outDir, suffix);
     gPad->Print(str);
   }
-   
-  TCanvas *c_vertexPt = new TCanvas("vertexPt","vertexPt");
+
+  TCanvas *c_vertexPt = new TCanvas("vertexPt", "vertexPt");
   c_vertexPt->cd();
-  h_ele_vertexPt->Draw(); 
-  h_ele_vertexPt->GetXaxis()->SetTitle("p_{T} from vertex");  
-  h_ele_vertexPt->GetYaxis()->SetTitle("Events");  
+  h_ele_vertexPt->Draw();
+  h_ele_vertexPt->GetXaxis()->SetTitle("p_{T} from vertex");
+  h_ele_vertexPt->GetYaxis()->SetTitle("Events");
   if (out) {
-    snprintf(str, 128,"%s/vertexPt.%s",outDir,suffix);
+    snprintf(str, 128, "%s/vertexPt.%s", outDir, suffix);
     gPad->Print(str);
   }
-   
-  TCanvas *c_outerP_mode = new TCanvas("outerP_mode","outerP_mode");
+
+  TCanvas *c_outerP_mode = new TCanvas("outerP_mode", "outerP_mode");
   c_outerP_mode->cd();
-  h_ele_outerP_mode->Draw(); 
-  h_ele_outerP_mode->GetXaxis()->SetTitle("p from out, mode");  
-  h_ele_outerP_mode->GetYaxis()->SetTitle("Events");  
+  h_ele_outerP_mode->Draw();
+  h_ele_outerP_mode->GetXaxis()->SetTitle("p from out, mode");
+  h_ele_outerP_mode->GetYaxis()->SetTitle("Events");
   if (out) {
-    snprintf(str, 128,"%s/outerP_mode.%s",outDir,suffix);
+    snprintf(str, 128, "%s/outerP_mode.%s", outDir, suffix);
     gPad->Print(str);
   }
-   
-  TCanvas *c_outerPt_mode = new TCanvas("outerPt_mode","outerPt_mode");
+
+  TCanvas *c_outerPt_mode = new TCanvas("outerPt_mode", "outerPt_mode");
   c_outerPt_mode->cd();
-  h_ele_outerPt_mode->Draw(); 
-  h_ele_outerPt_mode->GetXaxis()->SetTitle("p_{T} from out, mode");  
-  h_ele_outerPt_mode->GetYaxis()->SetTitle("Events");  
+  h_ele_outerPt_mode->Draw();
+  h_ele_outerPt_mode->GetXaxis()->SetTitle("p_{T} from out, mode");
+  h_ele_outerPt_mode->GetYaxis()->SetTitle("Events");
   if (out) {
-    snprintf(str, 128,"%s/outerPt_mode.%s",outDir,suffix);
+    snprintf(str, 128, "%s/outerPt_mode.%s", outDir, suffix);
     gPad->Print(str);
   }
-   
-  TCanvas *c_vertexZ = new TCanvas("vertexZ","vertexZ");
+
+  TCanvas *c_vertexZ = new TCanvas("vertexZ", "vertexZ");
   c_vertexZ->cd();
-  h_ele_vertexZ->Draw(); 
-  h_ele_vertexZ->GetXaxis()->SetTitle("z_{rec}");  
-  h_ele_vertexZ->GetYaxis()->SetTitle("Events");  
+  h_ele_vertexZ->Draw();
+  h_ele_vertexZ->GetXaxis()->SetTitle("z_{rec}");
+  h_ele_vertexZ->GetYaxis()->SetTitle("Events");
   if (out) {
-    snprintf(str, 128,"%s/vertexZ.%s",outDir,suffix);
+    snprintf(str, 128, "%s/vertexZ.%s", outDir, suffix);
     gPad->Print(str);
   }
-  if (pause) c_vertexZ->WaitPrimitive();  
+  if (pause)
+    c_vertexZ->WaitPrimitive();
 
   // efficiency
-  TH1F *h_ele_absetaEff   = (TH1F*)hist.Get("h_ele_absetaEff"); 
-  TH1F *h_simAbsEta   = (TH1F*)hist.Get("h_mc_abseta"); 
-  TH1F *h_ele_etaEff   = (TH1F*)hist.Get("h_ele_etaEff"); 
-  TH1F *h_simEta   = (TH1F*)hist.Get("h_mc_eta"); 
-  TH1F *h_ele_ptEff   = (TH1F*)hist.Get("h_ele_ptEff"); 
-  TH1F *h_simPt   = (TH1F*)hist.Get("h_smc_Pt"); 
-  
-  TCanvas *c_absetaEff = new TCanvas("absetaEff","absetaEff");
+  TH1F *h_ele_absetaEff = (TH1F *)hist.Get("h_ele_absetaEff");
+  TH1F *h_simAbsEta = (TH1F *)hist.Get("h_mc_abseta");
+  TH1F *h_ele_etaEff = (TH1F *)hist.Get("h_ele_etaEff");
+  TH1F *h_simEta = (TH1F *)hist.Get("h_mc_eta");
+  TH1F *h_ele_ptEff = (TH1F *)hist.Get("h_ele_ptEff");
+  TH1F *h_simPt = (TH1F *)hist.Get("h_smc_Pt");
+
+  TCanvas *c_absetaEff = new TCanvas("absetaEff", "absetaEff");
   c_absetaEff->cd();
-  for (int ibin=1; ibin<h_ele_absetaEff->GetNbinsX(); ibin++) {
+  for (int ibin = 1; ibin < h_ele_absetaEff->GetNbinsX(); ibin++) {
     double binContent = h_ele_absetaEff->GetBinContent(ibin);
-    double error2 = binContent*(1.-binContent)/h_simAbsEta->GetBinContent(ibin);
+    double error2 = binContent * (1. - binContent) / h_simAbsEta->GetBinContent(ibin);
     //h_ele_absetaEff->SetBinError(ibin,sqrt(error2));
-    std::cout << "ibin " << ibin << " efficiency " << binContent << " error " <<  sqrt(error2) <<
-    std::endl;
+    std::cout << "ibin " << ibin << " efficiency " << binContent << " error " << sqrt(error2) << std::endl;
   }
   h_ele_absetaEff->SetMarkerStyle(21);
-  h_ele_absetaEff->SetMinimum(0.0);  
-  h_ele_absetaEff->SetMaximum(1.0);  
-  h_ele_absetaEff->Draw("");  
-  //h_ele_absetaEff->Draw("SEP");  
-  h_ele_absetaEff->GetXaxis()->SetTitle("|#eta|");  
-  h_ele_absetaEff->GetYaxis()->SetTitle("Efficiency");  
+  h_ele_absetaEff->SetMinimum(0.0);
+  h_ele_absetaEff->SetMaximum(1.0);
+  h_ele_absetaEff->Draw("");
+  //h_ele_absetaEff->Draw("SEP");
+  h_ele_absetaEff->GetXaxis()->SetTitle("|#eta|");
+  h_ele_absetaEff->GetYaxis()->SetTitle("Efficiency");
   if (out) {
-    snprintf(str, 128,"%s/absetaEff.%s",outDir,suffix);
+    snprintf(str, 128, "%s/absetaEff.%s", outDir, suffix);
     gPad->Print(str);
   }
-   
-  TCanvas *c_etaEff = new TCanvas("etaEff","etaEff");
+
+  TCanvas *c_etaEff = new TCanvas("etaEff", "etaEff");
   c_etaEff->cd();
   h_ele_etaEff->SetMarkerStyle(21);
-  h_ele_etaEff->SetMinimum(0.0);  
-  h_ele_etaEff->SetMaximum(1.0);  
-  h_ele_etaEff->Draw("");  
-  h_ele_etaEff->GetXaxis()->SetTitle("#eta");  
-  h_ele_etaEff->GetYaxis()->SetTitle("Efficiency");  
+  h_ele_etaEff->SetMinimum(0.0);
+  h_ele_etaEff->SetMaximum(1.0);
+  h_ele_etaEff->Draw("");
+  h_ele_etaEff->GetXaxis()->SetTitle("#eta");
+  h_ele_etaEff->GetYaxis()->SetTitle("Efficiency");
   if (out) {
-    snprintf(str, 128,"%s/etaEff.%s",outDir,suffix);
+    snprintf(str, 128, "%s/etaEff.%s", outDir, suffix);
     gPad->Print(str);
   }
-   
-  TCanvas *c_ptEff = new TCanvas("ptEff","ptEff");
+
+  TCanvas *c_ptEff = new TCanvas("ptEff", "ptEff");
   c_ptEff->cd();
   h_ele_ptEff->SetMarkerStyle(21);
-  h_ele_ptEff->SetMinimum(0.0);  
-  h_ele_ptEff->SetMaximum(1.0);  
-  h_ele_ptEff->Draw("");  
-  h_ele_ptEff->GetXaxis()->SetTitle("p_{T} (GeV/c)");  
-  h_ele_ptEff->GetYaxis()->SetTitle("Efficiency");  
+  h_ele_ptEff->SetMinimum(0.0);
+  h_ele_ptEff->SetMaximum(1.0);
+  h_ele_ptEff->Draw("");
+  h_ele_ptEff->GetXaxis()->SetTitle("p_{T} (GeV/c)");
+  h_ele_ptEff->GetYaxis()->SetTitle("Efficiency");
   if (out) {
-    snprintf(str, 128,"%s/ptEff.%s",outDir,suffix);
+    snprintf(str, 128, "%s/ptEff.%s", outDir, suffix);
     gPad->Print(str);
   }
-  if (pause) c_ptEff->WaitPrimitive();  
-    
+  if (pause)
+    c_ptEff->WaitPrimitive();
+
   // match
-  TH1F *h_ele_EoP   = (TH1F*)hist.Get("h_ele_EoP"); 
-  TH1F *h_ele_EoPout   = (TH1F*)hist.Get("h_ele_EoPout"); 
-  TH1F *h_ele_EseedOP   = (TH1F*)hist.Get("h_ele_EseedOP"); 
-  TH1F *h_ele_EeleOPout   = (TH1F*)hist.Get("h_ele_EeleOPout"); 
-  TH1F *h_ele_dEtaCl_propOut   = (TH1F*)hist.Get("h_ele_dEtaCl_propOut"); 
-  TH1F *h_ele_dEtaSc_propVtx   = (TH1F*)hist.Get("h_ele_dEtaSc_propVtx"); 
-  TH1F *h_ele_dPhiCl_propOut   = (TH1F*)hist.Get("h_ele_dPhiCl_propOut"); 
-  TH1F *h_ele_dPhiSc_propVtx   = (TH1F*)hist.Get("h_ele_dPhiSc_propVtx"); 
-  TH1F *h_ele_dEtaEleCl_propOut   = (TH1F*)hist.Get("h_ele_dEtaEleCl_propOut"); 
-  TH1F *h_ele_dPhiEleCl_propOut   = (TH1F*)hist.Get("h_ele_dPhiEleCl_propOut"); 
-  TH1F *h_ele_HoE   = (TH1F*)hist.Get("h_ele_HoE"); 
-  
-  TCanvas *c_EoP = new TCanvas("EoP","EoP");
+  TH1F *h_ele_EoP = (TH1F *)hist.Get("h_ele_EoP");
+  TH1F *h_ele_EoPout = (TH1F *)hist.Get("h_ele_EoPout");
+  TH1F *h_ele_EseedOP = (TH1F *)hist.Get("h_ele_EseedOP");
+  TH1F *h_ele_EeleOPout = (TH1F *)hist.Get("h_ele_EeleOPout");
+  TH1F *h_ele_dEtaCl_propOut = (TH1F *)hist.Get("h_ele_dEtaCl_propOut");
+  TH1F *h_ele_dEtaSc_propVtx = (TH1F *)hist.Get("h_ele_dEtaSc_propVtx");
+  TH1F *h_ele_dPhiCl_propOut = (TH1F *)hist.Get("h_ele_dPhiCl_propOut");
+  TH1F *h_ele_dPhiSc_propVtx = (TH1F *)hist.Get("h_ele_dPhiSc_propVtx");
+  TH1F *h_ele_dEtaEleCl_propOut = (TH1F *)hist.Get("h_ele_dEtaEleCl_propOut");
+  TH1F *h_ele_dPhiEleCl_propOut = (TH1F *)hist.Get("h_ele_dPhiEleCl_propOut");
+  TH1F *h_ele_HoE = (TH1F *)hist.Get("h_ele_HoE");
+
+  TCanvas *c_EoP = new TCanvas("EoP", "EoP");
   c_EoP->cd();
-  h_ele_EoP->Draw(); 
-  h_ele_EoP->GetXaxis()->SetTitle("E/p");  
-  h_ele_EoP->GetYaxis()->SetTitle("Events");  
+  h_ele_EoP->Draw();
+  h_ele_EoP->GetXaxis()->SetTitle("E/p");
+  h_ele_EoP->GetYaxis()->SetTitle("Events");
   if (out) {
-    snprintf(str, 128,"%s/EoP.%s",outDir,suffix);
+    snprintf(str, 128, "%s/EoP.%s", outDir, suffix);
     gPad->Print(str);
   }
-  
-  TCanvas *c_EoPout = new TCanvas("EoPout","EoPout");
+
+  TCanvas *c_EoPout = new TCanvas("EoPout", "EoPout");
   c_EoPout->cd();
-  h_ele_EoPout->Draw(); 
-  h_ele_EoP->GetXaxis()->SetTitle("E_{seed}/p_{pout}");  
-  h_ele_EoP->GetYaxis()->SetTitle("Events");  
+  h_ele_EoPout->Draw();
+  h_ele_EoP->GetXaxis()->SetTitle("E_{seed}/p_{pout}");
+  h_ele_EoP->GetYaxis()->SetTitle("Events");
   if (out) {
-    snprintf(str, 128,"%s/EoPout.%s",outDir,suffix);
+    snprintf(str, 128, "%s/EoPout.%s", outDir, suffix);
     gPad->Print(str);
   }
-   
-  TCanvas *c_EeleOPout = new TCanvas("EeleOPout","EeleOPout");
+
+  TCanvas *c_EeleOPout = new TCanvas("EeleOPout", "EeleOPout");
   c_EeleOPout->cd();
-  h_ele_EeleOPout->Draw(); 
-  h_ele_EeleOPout->GetXaxis()->SetTitle("E_{ele}/p_{pout}");  
-  h_ele_EeleoPout->GetYaxis()->SetTitle("Events");  
+  h_ele_EeleOPout->Draw();
+  h_ele_EeleOPout->GetXaxis()->SetTitle("E_{ele}/p_{pout}");
+  h_ele_EeleoPout->GetYaxis()->SetTitle("Events");
   if (out) {
-    snprintf(str, 128,"%s/EeleOPout.%s",outDir,suffix);
+    snprintf(str, 128, "%s/EeleOPout.%s", outDir, suffix);
     gPad->Print(str);
   }
-   
-  TCanvas *c_EseedOP = new TCanvas("EseedOP","EseedOP");
+
+  TCanvas *c_EseedOP = new TCanvas("EseedOP", "EseedOP");
   c_EseedOP->cd();
-  h_ele_EseedOP->Draw(); 
-  h_ele_EseedoP->GetXaxis()->SetTitle("E_{seed}/p");  
-  h_ele_EseedOP->GetYaxis()->SetTitle("Events");  
+  h_ele_EseedOP->Draw();
+  h_ele_EseedoP->GetXaxis()->SetTitle("E_{seed}/p");
+  h_ele_EseedOP->GetYaxis()->SetTitle("Events");
   if (out) {
-    snprintf(str, 128,"%s/EseedOP.%s",outDir,suffix);
+    snprintf(str, 128, "%s/EseedOP.%s", outDir, suffix);
     gPad->Print(str);
   }
-  
-  TCanvas *c_dEtaCl_propOut = new TCanvas("dEtaCl_propOut","dEtaCl_propOut");
+
+  TCanvas *c_dEtaCl_propOut = new TCanvas("dEtaCl_propOut", "dEtaCl_propOut");
   c_dEtaCl_propOut->cd();
-  h_ele_dEtaCl_propOut->Draw(); 
-  h_ele_dEtaCl_propOut->GetXaxis()->SetTitle("#eta_{seed}-#eta_{tk, extrp. from out}");  
-  h_ele_dEtaCl_propOut->GetYaxis()->SetTitle("Events");  
+  h_ele_dEtaCl_propOut->Draw();
+  h_ele_dEtaCl_propOut->GetXaxis()->SetTitle("#eta_{seed}-#eta_{tk, extrp. from out}");
+  h_ele_dEtaCl_propOut->GetYaxis()->SetTitle("Events");
   if (out) {
-    snprintf(str, 128,"%s/dEtaCl_propOut.%s",outDir,suffix);
+    snprintf(str, 128, "%s/dEtaCl_propOut.%s", outDir, suffix);
     gPad->Print(str);
   }
-   
-  TCanvas *c_dEtaEleCl_propOut = new TCanvas("dEtaEleCl_propOut","dEtaEleCl_propOut");
+
+  TCanvas *c_dEtaEleCl_propOut = new TCanvas("dEtaEleCl_propOut", "dEtaEleCl_propOut");
   c_dEtaEleCl_propOut->cd();
-  h_ele_dEtaEleCl_propOut->Draw(); 
-  h_ele_dEtaEleCl_propOut->GetXaxis()->SetTitle("#eta_{ele}-#eta_{tk, extrp. from out}");  
-  h_ele_dEtaEleCl_propOut->GetYaxis()->SetTitle("Events");  
+  h_ele_dEtaEleCl_propOut->Draw();
+  h_ele_dEtaEleCl_propOut->GetXaxis()->SetTitle("#eta_{ele}-#eta_{tk, extrp. from out}");
+  h_ele_dEtaEleCl_propOut->GetYaxis()->SetTitle("Events");
   if (out) {
-    snprintf(str, 128,"%s/dEtaEleCl_propOut.%s",outDir,suffix);
+    snprintf(str, 128, "%s/dEtaEleCl_propOut.%s", outDir, suffix);
     gPad->Print(str);
   }
-   
-  TCanvas *c_dEtaSc_propVtx = new TCanvas("dEtaSc_propVtx","dEtaSc_propVtx");
+
+  TCanvas *c_dEtaSc_propVtx = new TCanvas("dEtaSc_propVtx", "dEtaSc_propVtx");
   c_dEtaSc_propVtx->cd();
-  h_ele_dEtaSc_propVtx->Draw(); 
-  h_ele_dEtaSc_propVtx->GetXaxis()->SetTitle("#eta_{sc}-#eta_{tk, extrp. from vtx}");  
-  h_ele_dEtaSc_propVtx->GetYaxis()->SetTitle("Events");  
+  h_ele_dEtaSc_propVtx->Draw();
+  h_ele_dEtaSc_propVtx->GetXaxis()->SetTitle("#eta_{sc}-#eta_{tk, extrp. from vtx}");
+  h_ele_dEtaSc_propVtx->GetYaxis()->SetTitle("Events");
   if (out) {
-    snprintf(str, 128,"%s/dEtaSc_propVtx.%s",outDir,suffix);
+    snprintf(str, 128, "%s/dEtaSc_propVtx.%s", outDir, suffix);
     gPad->Print(str);
   }
-   
-  TCanvas *c_dPhiCl_propOut = new TCanvas("dPhiCl_propOut","dPhiCl_propOut");
+
+  TCanvas *c_dPhiCl_propOut = new TCanvas("dPhiCl_propOut", "dPhiCl_propOut");
   c_dPhiCl_propOut->cd();
-  h_ele_dPhiCl_propOut->Draw(); 
-  h_ele_dPhiCl_propOut->GetXaxis()->SetTitle("#phi_{seed}-#phi_{tk, extrp. from out}");  
-  h_ele_dPhiCl_propOut->GetYaxis()->SetTitle("Events");  
+  h_ele_dPhiCl_propOut->Draw();
+  h_ele_dPhiCl_propOut->GetXaxis()->SetTitle("#phi_{seed}-#phi_{tk, extrp. from out}");
+  h_ele_dPhiCl_propOut->GetYaxis()->SetTitle("Events");
   if (out) {
-    snprintf(str, 128,"%s/dPhiCl_propOut.%s",outDir,suffix);
+    snprintf(str, 128, "%s/dPhiCl_propOut.%s", outDir, suffix);
     gPad->Print(str);
   }
-   
-  TCanvas *c_dPhiEleCl_propOut = new TCanvas("dPhiEleCl_propOut","dPhiEleCl_propOut");
+
+  TCanvas *c_dPhiEleCl_propOut = new TCanvas("dPhiEleCl_propOut", "dPhiEleCl_propOut");
   c_dPhiEleCl_propOut->cd();
-  h_ele_dPhiEleCl_propOut->Draw(); 
-  h_ele_dPhiEleCl_propOut->GetXaxis()->SetTitle("#phi_{ele}-#phi_{tk, extrp. from out}");  
-  h_ele_dPhiEleCl_propOut->GetYaxis()->SetTitle("Events");  
+  h_ele_dPhiEleCl_propOut->Draw();
+  h_ele_dPhiEleCl_propOut->GetXaxis()->SetTitle("#phi_{ele}-#phi_{tk, extrp. from out}");
+  h_ele_dPhiEleCl_propOut->GetYaxis()->SetTitle("Events");
   if (out) {
-    snprintf(str, 128,"%s/dPhiEleCl_propOut.%s",outDir,suffix);
+    snprintf(str, 128, "%s/dPhiEleCl_propOut.%s", outDir, suffix);
     gPad->Print(str);
   }
-   
-  TCanvas *c_dPhiSc_propVtx = new TCanvas("dPhiSc_propVtx","dPhiSc_propVtx");
+
+  TCanvas *c_dPhiSc_propVtx = new TCanvas("dPhiSc_propVtx", "dPhiSc_propVtx");
   c_dPhiSc_propVtx->cd();
-  h_ele_dPhiSc_propVtx->Draw(); 
-  h_ele_dPhiSc_propVtx->GetXaxis()->SetTitle("#phi_{sc}-#phi_{tk, extrp. from vtx}");  
-  h_ele_dPhiSc_propVtx->GetYaxis()->SetTitle("Events");  
+  h_ele_dPhiSc_propVtx->Draw();
+  h_ele_dPhiSc_propVtx->GetXaxis()->SetTitle("#phi_{sc}-#phi_{tk, extrp. from vtx}");
+  h_ele_dPhiSc_propVtx->GetYaxis()->SetTitle("Events");
   if (out) {
-    snprintf(str, 128,"%s/dPhiSc_propVtx.%s",outDir,suffix);
+    snprintf(str, 128, "%s/dPhiSc_propVtx.%s", outDir, suffix);
     gPad->Print(str);
   }
-   
-  TCanvas *c_HoE = new TCanvas("HoE","HoE");
+
+  TCanvas *c_HoE = new TCanvas("HoE", "HoE");
   c_HoE->cd();
-  h_ele_HoE->Draw(); 
-  h_ele_HoE->GetXaxis()->SetTitle("H/E");  
-  h_ele_HoE->GetYaxis()->SetTitle("Events");  
+  h_ele_HoE->Draw();
+  h_ele_HoE->GetXaxis()->SetTitle("H/E");
+  h_ele_HoE->GetYaxis()->SetTitle("Events");
   if (out) {
-    snprintf(str, 128,"%s/HoE.%s",outDir,suffix);
+    snprintf(str, 128, "%s/HoE.%s", outDir, suffix);
     gPad->Print(str);
   }
-  if (pause) c_HoE->WaitPrimitive();  
-   
+  if (pause)
+    c_HoE->WaitPrimitive();
+
   // track
-  TH1F *h_ele_chi2   = (TH1F*)hist.Get("h_ele_chi2"); 
-  TH1F *h_ele_foundHits   = (TH1F*)hist.Get("h_ele_foundHits"); 
-  TH1F *h_ele_lostHits   = (TH1F*)hist.Get("h_ele_lostHits"); 
-  TH1F *h_ele_ambiguousTracks   = (TH1F*)hist.Get("h_ele_ambiguousTracks"); 
-  
-  TCanvas *c_chi2 = new TCanvas("chi2","chi2");
+  TH1F *h_ele_chi2 = (TH1F *)hist.Get("h_ele_chi2");
+  TH1F *h_ele_foundHits = (TH1F *)hist.Get("h_ele_foundHits");
+  TH1F *h_ele_lostHits = (TH1F *)hist.Get("h_ele_lostHits");
+  TH1F *h_ele_ambiguousTracks = (TH1F *)hist.Get("h_ele_ambiguousTracks");
+
+  TCanvas *c_chi2 = new TCanvas("chi2", "chi2");
   c_chi2->cd();
-  h_ele_chi2->Draw(); 
-  h_ele_chi2->GetXaxis()->SetTitle("track #Chi^{2}");  
-  h_ele_chi2->GetYaxis()->SetTitle("Events");  
+  h_ele_chi2->Draw();
+  h_ele_chi2->GetXaxis()->SetTitle("track #Chi^{2}");
+  h_ele_chi2->GetYaxis()->SetTitle("Events");
   if (out) {
-    snprintf(str, 128,"%s/chi2.%s",outDir,suffix);
+    snprintf(str, 128, "%s/chi2.%s", outDir, suffix);
     gPad->Print(str);
   }
-   
-  TCanvas *c_foundHits = new TCanvas("foundHits","foundHits");
+
+  TCanvas *c_foundHits = new TCanvas("foundHits", "foundHits");
   c_foundHits->cd();
-  h_ele_foundHits->Draw(); 
-  h_ele_foundHits->GetXaxis()->SetTitle("# hits");  
-  h_ele_foundHits->GetYaxis()->SetTitle("Events");  
+  h_ele_foundHits->Draw();
+  h_ele_foundHits->GetXaxis()->SetTitle("# hits");
+  h_ele_foundHits->GetYaxis()->SetTitle("Events");
   if (out) {
-    snprintf(str, 128,"%s/foundHits.%s",outDir,suffix);
+    snprintf(str, 128, "%s/foundHits.%s", outDir, suffix);
     gPad->Print(str);
   }
-   
-  TCanvas *c_lostHits = new TCanvas("lostHits","lostHits");
+
+  TCanvas *c_lostHits = new TCanvas("lostHits", "lostHits");
   c_lostHits->cd();
-  h_ele_lostHits->Draw(); 
-  h_ele_lostHits->GetXaxis()->SetTitle("# lost hits");  
-  h_ele_lostHits->GetYaxis()->SetTitle("Events");  
+  h_ele_lostHits->Draw();
+  h_ele_lostHits->GetXaxis()->SetTitle("# lost hits");
+  h_ele_lostHits->GetYaxis()->SetTitle("Events");
   if (out) {
-    snprintf(str, 128,"%s/lostHits.%s",outDir,suffix);
+    snprintf(str, 128, "%s/lostHits.%s", outDir, suffix);
     gPad->Print(str);
   }
-  TCanvas *c_ambiguousTracks = new TCanvas("ambiguousTracks","ambiguousTracks");
+  TCanvas *c_ambiguousTracks = new TCanvas("ambiguousTracks", "ambiguousTracks");
   c_ambiguousTracks->cd();
-  h_ele_ambiguousTracks->Draw(); 
-  h_ele_ambiguousTracks->GetXaxis()->SetTitle("# ambiguous tracks");  
-  h_ele_ambiguousTracks->GetYaxis()->SetTitle("Events");  
+  h_ele_ambiguousTracks->Draw();
+  h_ele_ambiguousTracks->GetXaxis()->SetTitle("# ambiguous tracks");
+  h_ele_ambiguousTracks->GetYaxis()->SetTitle("Events");
   if (out) {
-    snprintf(str, 128,"%s/ambiguousTracks.%s",outDir,suffix);
+    snprintf(str, 128, "%s/ambiguousTracks.%s", outDir, suffix);
     gPad->Print(str);
   }
-   
-  if (pause) c_lostHits->WaitPrimitive();  
-     
+
+  if (pause)
+    c_lostHits->WaitPrimitive();
+
   // classes
-  TH1F *h_ele_PinMnPout_mode   = (TH1F*)hist.Get("h_ele_PinMnPout"); 
-  TH1F *h_ele_classes   = (TH1F*)hist.Get("h_ele_classes"); 
-  TH1F *h_ele_eta_bbremFrac   = (TH1F*)hist.Get("h_ele_eta_bbremFrac"); 
-  TH1F *h_ele_eta_goldenFrac   = (TH1F*)hist.Get("h_ele_eta_goldenFrac"); 
-  TH1F *h_ele_eta_narrowFrac   = (TH1F*)hist.Get("h_ele_eta_narrowFrac"); 
-  TH1F *h_ele_eta_showerFrac   = (TH1F*)hist.Get("h_ele_eta_showerFrac"); 
-  
-  TCanvas *c_PinMnPout_mode = new TCanvas("PinMnPout_mode","PinMnPout_mode");
+  TH1F *h_ele_PinMnPout_mode = (TH1F *)hist.Get("h_ele_PinMnPout");
+  TH1F *h_ele_classes = (TH1F *)hist.Get("h_ele_classes");
+  TH1F *h_ele_eta_bbremFrac = (TH1F *)hist.Get("h_ele_eta_bbremFrac");
+  TH1F *h_ele_eta_goldenFrac = (TH1F *)hist.Get("h_ele_eta_goldenFrac");
+  TH1F *h_ele_eta_narrowFrac = (TH1F *)hist.Get("h_ele_eta_narrowFrac");
+  TH1F *h_ele_eta_showerFrac = (TH1F *)hist.Get("h_ele_eta_showerFrac");
+
+  TCanvas *c_PinMnPout_mode = new TCanvas("PinMnPout_mode", "PinMnPout_mode");
   c_PinMnPout_mode->cd();
-  h_ele_PinMnPout_mode->Draw(); 
-  h_ele_PinMnPout_mode->GetXaxis()->SetTitle("P_{in} - p_{out} (GeV/c)");  
-  h_ele_PinMnPout_mode->GetYaxis()->SetTitle("Events");  
+  h_ele_PinMnPout_mode->Draw();
+  h_ele_PinMnPout_mode->GetXaxis()->SetTitle("P_{in} - p_{out} (GeV/c)");
+  h_ele_PinMnPout_mode->GetYaxis()->SetTitle("Events");
   if (out) {
-    snprintf(str, 128,"%s/PinMnPout_mode.%s",outDir,suffix);
+    snprintf(str, 128, "%s/PinMnPout_mode.%s", outDir, suffix);
     gPad->Print(str);
   }
-   
-  TCanvas *c_classes = new TCanvas("classes","classes");
+
+  TCanvas *c_classes = new TCanvas("classes", "classes");
   c_classes->cd();
-  h_ele_classes->Draw(); 
-  h_ele_classes->GetXaxis()->SetTitle("Class id");  
-  h_ele_classes->GetYaxis()->SetTitle("Events");  
+  h_ele_classes->Draw();
+  h_ele_classes->GetXaxis()->SetTitle("Class id");
+  h_ele_classes->GetYaxis()->SetTitle("Events");
   if (out) {
-    snprintf(str, 128,"%s/classes.%s",outDir,suffix);
+    snprintf(str, 128, "%s/classes.%s", outDir, suffix);
     gPad->Print(str);
   }
-   
-  TCanvas *c_eta_bbremFrac = new TCanvas("eta_bbremFrac","eta_bbremFrac");
+
+  TCanvas *c_eta_bbremFrac = new TCanvas("eta_bbremFrac", "eta_bbremFrac");
   c_eta_bbremFrac->cd();
-  h_ele_eta_bbremFrac->Draw(); 
-  h_ele_eta_bbremFrac->GetXaxis()->SetTitle("|#eta|");  
-  h_ele_eta_bbremFrac->GetYaxis()->SetTitle("Fraction of bbrem");  
+  h_ele_eta_bbremFrac->Draw();
+  h_ele_eta_bbremFrac->GetXaxis()->SetTitle("|#eta|");
+  h_ele_eta_bbremFrac->GetYaxis()->SetTitle("Fraction of bbrem");
   if (out) {
-    snprintf(str, 128,"%s/eta_bbremFrac.%s",outDir,suffix);
+    snprintf(str, 128, "%s/eta_bbremFrac.%s", outDir, suffix);
     gPad->Print(str);
   }
-   
-  TCanvas *c_eta_goldenFrac = new TCanvas("eta_goldenFrac","eta_goldenFrac");
+
+  TCanvas *c_eta_goldenFrac = new TCanvas("eta_goldenFrac", "eta_goldenFrac");
   c_eta_goldenFrac->cd();
-  h_ele_eta_goldenFrac->Draw(); 
-  h_ele_eta_goldenFrac->GetXaxis()->SetTitle("|#eta|");  
-  h_ele_eta_goldenFrac->GetYaxis()->SetTitle("Fraction of golden");  
+  h_ele_eta_goldenFrac->Draw();
+  h_ele_eta_goldenFrac->GetXaxis()->SetTitle("|#eta|");
+  h_ele_eta_goldenFrac->GetYaxis()->SetTitle("Fraction of golden");
   if (out) {
-    snprintf(str, 128,"%s/eta_goldenFrac.%s",outDir,suffix);
+    snprintf(str, 128, "%s/eta_goldenFrac.%s", outDir, suffix);
     gPad->Print(str);
   }
-   
-  TCanvas *c_eta_narrowFrac = new TCanvas("eta_narrowFrac","eta_narrowFrac");
+
+  TCanvas *c_eta_narrowFrac = new TCanvas("eta_narrowFrac", "eta_narrowFrac");
   c_eta_narrowFrac->cd();
-  h_ele_eta_narrowFrac->Draw(); 
-  h_ele_eta_narrowFrac->GetXaxis()->SetTitle("|#eta|");  
-  h_ele_eta_narrowFrac->GetYaxis()->SetTitle("Fraction of narrow");  
+  h_ele_eta_narrowFrac->Draw();
+  h_ele_eta_narrowFrac->GetXaxis()->SetTitle("|#eta|");
+  h_ele_eta_narrowFrac->GetYaxis()->SetTitle("Fraction of narrow");
   if (out) {
-    snprintf(str, 128,"%s/eta_narrowFrac.%s",outDir,suffix);
+    snprintf(str, 128, "%s/eta_narrowFrac.%s", outDir, suffix);
     gPad->Print(str);
   }
-   
-  TCanvas *c_eta_showerFrac = new TCanvas("eta_showerFrac","eta_showerFrac");
+
+  TCanvas *c_eta_showerFrac = new TCanvas("eta_showerFrac", "eta_showerFrac");
   c_eta_showerFrac->cd();
-  h_ele_eta_showerFrac->Draw(); 
-  h_ele_eta_showerFrac->GetXaxis()->SetTitle("|#eta|");  
-  h_ele_eta_showerFrac->GetYaxis()->SetTitle("Fraction of showering");  
+  h_ele_eta_showerFrac->Draw();
+  h_ele_eta_showerFrac->GetXaxis()->SetTitle("|#eta|");
+  h_ele_eta_showerFrac->GetYaxis()->SetTitle("Fraction of showering");
   if (out) {
-    snprintf(str, 128,"%s/eta_showerFrac.%s",outDir,suffix);
+    snprintf(str, 128, "%s/eta_showerFrac.%s", outDir, suffix);
     gPad->Print(str);
   }
-   
 }

--- a/RecoEgamma/Examples/test/newvalidation.C
+++ b/RecoEgamma/Examples/test/newvalidation.C
@@ -1,317 +1,290 @@
 {
+  TString DBS_SAMPLE = gSystem->Getenv("DBS_SAMPLE");
 
-TString DBS_SAMPLE = gSystem->Getenv("DBS_SAMPLE") ;
+  TString val_ref_file_name = gSystem->Getenv("VAL_REF_FILE");
+  TString val_new_file_name = gSystem->Getenv("VAL_NEW_FILE");
+  TString val_ref_release = gSystem->Getenv("VAL_REF_RELEASE");
+  TString val_new_release = gSystem->Getenv("VAL_NEW_RELEASE");
+  TString val_analyzer = gSystem->Getenv("VAL_ANALYZER");
 
-TString val_ref_file_name = gSystem->Getenv("VAL_REF_FILE") ;
-TString val_new_file_name = gSystem->Getenv("VAL_NEW_FILE") ;
-TString val_ref_release = gSystem->Getenv("VAL_REF_RELEASE") ;
-TString val_new_release = gSystem->Getenv("VAL_NEW_RELEASE") ;
-TString val_analyzer = gSystem->Getenv("VAL_ANALYZER") ;
+  TString val_web = gSystem->Getenv("VAL_WEB");
+  TString val_web_sub_dir = gSystem->Getenv("VAL_WEB_SUB_DIR");
+  TString val_web_url = gSystem->Getenv("VAL_WEB_URL");
 
-TString val_web = gSystem->Getenv("VAL_WEB") ;
-TString val_web_sub_dir = gSystem->Getenv("VAL_WEB_SUB_DIR") ;
-TString val_web_url = gSystem->Getenv("VAL_WEB_URL") ;
+  std::string val_web_path =
+      val_web + "/" + val_new_release + "/Electrons/vs" + val_ref_release + "/" + val_web_sub_dir;
+  std::string histos_path = val_web_path + "/histos.txt";
+  std::string index_path = val_web_path + "/index.html";
 
-std::string val_web_path = val_web+"/"+val_new_release+"/Electrons/vs"+val_ref_release+"/"+val_web_sub_dir ;
-std::string histos_path = val_web_path+"/histos.txt" ;
-std::string index_path = val_web_path+"/index.html" ;
+  // style:
+  TStyle *eleStyle = new TStyle("eleStyle", "Style for electron validation");
+  eleStyle->SetCanvasBorderMode(0);
+  eleStyle->SetCanvasColor(kWhite);
+  eleStyle->SetCanvasDefH(600);
+  eleStyle->SetCanvasDefW(800);
+  eleStyle->SetCanvasDefX(0);
+  eleStyle->SetCanvasDefY(0);
+  eleStyle->SetPadBorderMode(0);
+  eleStyle->SetPadColor(kWhite);
+  eleStyle->SetPadGridX(false);
+  eleStyle->SetPadGridY(false);
+  eleStyle->SetGridColor(0);
+  eleStyle->SetGridStyle(3);
+  eleStyle->SetGridWidth(1);
+  eleStyle->SetOptStat(1);
+  eleStyle->SetPadTickX(1);
+  eleStyle->SetPadTickY(1);
+  eleStyle->SetHistLineColor(1);
+  eleStyle->SetHistLineStyle(0);
+  eleStyle->SetHistLineWidth(2);
+  eleStyle->SetEndErrorSize(2);
+  eleStyle->SetErrorX(0.);
+  eleStyle->SetOptStat(1);
+  eleStyle->SetTitleColor(1, "XYZ");
+  eleStyle->SetTitleFont(42, "XYZ");
+  eleStyle->SetTitleXOffset(1.0);
+  eleStyle->SetTitleYOffset(1.0);
+  eleStyle->SetLabelOffset(0.005, "XYZ");
+  eleStyle->SetTitleSize(0.05, "XYZ");
+  eleStyle->SetTitleFont(22, "X");
+  eleStyle->SetTitleFont(22, "Y");
+  eleStyle->SetHistLineWidth(2);
+  eleStyle->SetPadBottomMargin(0.13);
+  eleStyle->SetPadLeftMargin(0.15);
+  eleStyle->SetMarkerStyle(21);
+  eleStyle->SetMarkerSize(0.8);
 
-// style:
-TStyle *eleStyle = new TStyle("eleStyle","Style for electron validation");
-eleStyle->SetCanvasBorderMode(0);
-eleStyle->SetCanvasColor(kWhite);
-eleStyle->SetCanvasDefH(600);
-eleStyle->SetCanvasDefW(800);
-eleStyle->SetCanvasDefX(0);
-eleStyle->SetCanvasDefY(0);
-eleStyle->SetPadBorderMode(0);
-eleStyle->SetPadColor(kWhite);
-eleStyle->SetPadGridX(false);
-eleStyle->SetPadGridY(false);
-eleStyle->SetGridColor(0);
-eleStyle->SetGridStyle(3);
-eleStyle->SetGridWidth(1);
-eleStyle->SetOptStat(1);
-eleStyle->SetPadTickX(1);
-eleStyle->SetPadTickY(1);
-eleStyle->SetHistLineColor(1);
-eleStyle->SetHistLineStyle(0);
-eleStyle->SetHistLineWidth(2);
-eleStyle->SetEndErrorSize(2);
-eleStyle->SetErrorX(0.);
-eleStyle->SetOptStat(1);
-eleStyle->SetTitleColor(1, "XYZ");
-eleStyle->SetTitleFont(42, "XYZ");
-eleStyle->SetTitleXOffset(1.0);
-eleStyle->SetTitleYOffset(1.0);
-eleStyle->SetLabelOffset(0.005, "XYZ");
-eleStyle->SetTitleSize(0.05, "XYZ");
-eleStyle->SetTitleFont(22,"X");
-eleStyle->SetTitleFont(22,"Y");
-eleStyle->SetHistLineWidth(2);
-eleStyle->SetPadBottomMargin(0.13);
-eleStyle->SetPadLeftMargin(0.15);
-eleStyle->SetMarkerStyle(21);
-eleStyle->SetMarkerSize(0.8);
+  eleStyle->cd();
 
-eleStyle->cd();
+  gROOT->ForceStyle();
 
-gROOT->ForceStyle();
+  std::cout << "ref file: " << val_ref_file_name << std::endl;
+  TString val_ref_file_url;
+  TFile *file_old = 0;
+  if (val_ref_file_name != "") {
+    file_old = TFile::Open(val_ref_file_name);
+    if ((file_old != 0) && (val_ref_file_name.BeginsWith(val_web) == kTRUE)) {
+      val_ref_file_url = val_ref_file_name;
+      val_ref_file_url.Remove(0, val_web.Length());
+      val_ref_file_url.Prepend(val_web_url);
+    }
+  }
+  std::cout << "ref url: " << val_ref_file_url << std::endl;
 
-std::cout<<"ref file: "<<val_ref_file_name<<std::endl ;
-TString val_ref_file_url ;
-TFile * file_old = 0 ;
-if ( val_ref_file_name != "" )
- {
-  file_old = TFile::Open(val_ref_file_name) ;
-  if ((file_old!=0)&&(val_ref_file_name.BeginsWith(val_web)==kTRUE))
-   {
-    val_ref_file_url = val_ref_file_name ;
-	val_ref_file_url.Remove(0,val_web.Length()) ;
-	val_ref_file_url.Prepend(val_web_url) ;
-   }
- }
-std::cout<<"ref url: "<<val_ref_file_url<<std::endl ;
+  std::cout << "new file: " << val_new_file_name << std::endl;
+  TString val_new_file_url;
+  TFile *file_new = 0;
+  if (val_new_file_name != "") {
+    file_new = TFile::Open(val_new_file_name);
+    if ((file_new != 0) && (val_new_file_name.BeginsWith(val_web) == kTRUE)) {
+      val_new_file_url = val_new_file_name;
+      val_new_file_url.Remove(0, val_web.Length());
+      val_new_file_url.Prepend(val_web_url);
+    }
+  }
+  std::cout << "new url: " << val_new_file_url << std::endl;
 
-std::cout<<"new file: "<<val_new_file_name<<std::endl ;
-TString val_new_file_url ;
-TFile * file_new = 0 ;
-if ( val_new_file_name != "" )
- {
-  file_new = TFile::Open(val_new_file_name) ;
-  if ((file_new!=0)&&(val_new_file_name.BeginsWith(val_web)==kTRUE))
-   {
-    val_new_file_url = val_new_file_name ;
-	val_new_file_url.Remove(0,val_web.Length()) ;
-	val_new_file_url.Prepend(val_web_url) ;
-   }
- }
-std::cout<<"new url: "<<val_new_file_url<<std::endl ;
+  TCanvas *canvas;
+  TH1 *histo_old, *histo_new;
+  double nold, nnew;
 
-TCanvas * canvas ;
-TH1 * histo_old, * histo_new ;
-double nold, nnew ;
+  std::cout << "index path: " << index_path << std::endl;
+  std::ofstream web_page(index_path.c_str());
 
-std::cout<<"index path: "<<index_path<<std::endl ;
-std::ofstream web_page(index_path.c_str()) ;
+  web_page << "<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 3.2 Final//EN\">\n"
+           << "<html>\n"
+           << "<head>\n"
+           << "<meta http-equiv=\"content-type\" content=\"text/html; charset=UTF-8\" />\n"
+           << "<title>" << val_new_release << " vs " << val_ref_release << " / " << DBS_SAMPLE << "</title>\n"
+           << "</head>\n"
+           << "<h1><a href=\"../\">" << val_new_release << " vs " << val_ref_release << "</a> / " << DBS_SAMPLE
+           << "</h1>\n";
 
-web_page
-  <<"<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 3.2 Final//EN\">\n"
-  <<"<html>\n"
-  <<"<head>\n"
-  <<"<meta http-equiv=\"content-type\" content=\"text/html; charset=UTF-8\" />\n"
-  <<"<title>"<<val_new_release<<" vs "<<val_ref_release<<" / "<<DBS_SAMPLE<<"</title>\n"
-  <<"</head>\n"
-  <<"<h1><a href=\"../\">"<<val_new_release<<" vs "<<val_ref_release<<"</a> / "<<DBS_SAMPLE<<"</h1>\n" ;
+  web_page << "<p>";
+  if (file_old == 0) {
+    web_page << "In all plots below"
+             << ", there was no " << val_ref_release << " histograms to compare with"
+             << ", and the <a href=\"" << val_new_file_url << "\">" << val_new_release << " histograms</a> are in red"
+             << ".";
+  } else {
+    web_page << "In all plots below"
+             << ", the <a href=\"" << val_new_file_url << "\">" << val_new_release << " histograms</a> are in red"
+             << ", and the <a href=\"" << val_ref_file_url << "\">" << val_ref_release << " histograms</a> are in blue"
+             << ".";
+  }
+  web_page << " They were made using analyzer "
+           << "<a href=\"http://cmslxr.fnal.gov/lxr/source/RecoEgamma/Examples/plugins/" << val_analyzer << ".cc\">"
+           << "RecoEgamma/Examples/plugins/" << val_analyzer << ".cc"
+           << "</a> and configuration "
+           << "<a href=\"http://cmslxr.fnal.gov/lxr/source/RecoEgamma/Examples/test/" << val_analyzer << "_cfg.py\">"
+           << "RecoEgamma/Examples/test/" << val_analyzer << "_cfg.py"
+           << "</a>, with dataset " << DBS_SAMPLE << " as input.";
+  web_page << " Some more details"
+           << ": <a href=\"newvalidation.C\">script</a> used to make the plots"
+           << ", <a href=\"histos.txt\">specification</a> of histograms"
+           << ", <a href=\"gifs/\">images</a> of histograms"
+           << ".";
+  web_page << "</p>\n";
 
-web_page<<"<p>" ;
-if (file_old==0)
- {
-  web_page
-	 <<"In all plots below"
-	 <<", there was no "<<val_ref_release<<" histograms to compare with"
-     <<", and the <a href=\""<<val_new_file_url<<"\">"<<val_new_release<<" histograms</a> are in red"
-	 <<"." ;
- }
-else
- {
-  web_page
-	 <<"In all plots below"
-     <<", the <a href=\""<<val_new_file_url<<"\">"<<val_new_release<<" histograms</a> are in red"
-	 <<", and the <a href=\""<<val_ref_file_url<<"\">"<<val_ref_release<<" histograms</a> are in blue"
-	 <<"." ;
- }
-web_page
-  <<" They were made using analyzer "
-  <<"<a href=\"http://cmslxr.fnal.gov/lxr/source/RecoEgamma/Examples/plugins/"<<val_analyzer<<".cc\">"
-  <<"RecoEgamma/Examples/plugins/"<<val_analyzer<<".cc"
-  <<"</a> and configuration "
-  <<"<a href=\"http://cmslxr.fnal.gov/lxr/source/RecoEgamma/Examples/test/"<<val_analyzer<<"_cfg.py\">"
-  <<"RecoEgamma/Examples/test/"<<val_analyzer<<"_cfg.py"
-  <<"</a>, with dataset "<<DBS_SAMPLE<<" as input." ;
-web_page
-  <<" Some more details"
-  <<": <a href=\"newvalidation.C\">script</a> used to make the plots"
-  <<", <a href=\"histos.txt\">specification</a> of histograms"
-  <<", <a href=\"gifs/\">images</a> of histograms"
-  <<"." ;
-web_page<<"</p>\n" ;
+  std::string histo_name, gif_name, gif_path, canvas_name;
+  TString short_histo_name;
+  int scaled, log, err;
+  int divide;
+  std::string num, denom, cat;
+  int eol;  // end of line
+  int eoc;  // enf of category
 
-std::string histo_name, gif_name, gif_path, canvas_name ;
-TString short_histo_name ;
-int scaled, log, err ;
-int divide;
-std::string num, denom, cat ;
-int eol ; // end of line
-int eoc ; // enf of category
+  std::cout << "histos path: " << histos_path << std::endl;
+  std::ifstream histo_file1(histos_path.c_str());
+  if (!histo_file1) {
+    std::cout << "no histos file !" << std::endl;
+  }
+  web_page << "<br><table border=\"1\" cellpadding=\"5\" width=\"100%\">"
+           << "<tr valign=\"top\"><td width=\"20%\">\n";
+  int cat_num = 0;
 
-std::cout<<"histos path: "<<histos_path<<std::endl ;
-std::ifstream histo_file1(histos_path.c_str()) ;
-if (!histo_file1)
- { std::cout<<"no histos file !"<<std::endl ; }
-web_page
-  <<"<br><table border=\"1\" cellpadding=\"5\" width=\"100%\">"
-  <<"<tr valign=\"top\"><td width=\"20%\">\n" ;
-int cat_num = 0 ;
+  cat = "";
+  do {
+    std::getline(histo_file1, cat);
+  } while (cat.empty() && histo_file1);
 
-cat = "" ;
-do
- {
-  std::getline(histo_file1,cat) ;
- } while (cat.empty()&&histo_file1) ;
- 
-web_page<<"<b>"<<cat<<"</b><br><br>" ;
+  web_page << "<b>" << cat << "</b><br><br>";
 
-while (histo_file1>>histo_name>>scaled>>log>>err>>divide>>num>>denom>>eol>>eoc)
- {
-  short_histo_name = histo_name ;
-  short_histo_name.Remove(0,2) ;
-  web_page<<"<a href=\"#"<<short_histo_name<<"\">"<<short_histo_name<<"</a><br>\n" ;
-  if (eoc)
-   {
-	cat_num++ ;
-    if ((cat_num%5)==0)
-	 { web_page<<"<br></td></tr>\n<tr valign=\"top\"><td width=\"20%\">" ; }
-	else
-     { web_page<<"<br></td><td width=\"20%\">\n" ; }
-	cat = "" ;
-    do
-     {
-      std::getline(histo_file1,cat) ;
-     } while (cat.empty()) ;
-    web_page<<"<b>"<<cat<<"</b><br><br>" ;
-   }
- }
-web_page<<"<br></td></tr></table>\n" ;
-histo_file1.close() ;
+  while (histo_file1 >> histo_name >> scaled >> log >> err >> divide >> num >> denom >> eol >> eoc) {
+    short_histo_name = histo_name;
+    short_histo_name.Remove(0, 2);
+    web_page << "<a href=\"#" << short_histo_name << "\">" << short_histo_name << "</a><br>\n";
+    if (eoc) {
+      cat_num++;
+      if ((cat_num % 5) == 0) {
+        web_page << "<br></td></tr>\n<tr valign=\"top\"><td width=\"20%\">";
+      } else {
+        web_page << "<br></td><td width=\"20%\">\n";
+      }
+      cat = "";
+      do {
+        std::getline(histo_file1, cat);
+      } while (cat.empty());
+      web_page << "<b>" << cat << "</b><br><br>";
+    }
+  }
+  web_page << "<br></td></tr></table>\n";
+  histo_file1.close();
 
-web_page<<"<br><br><table cellpadding=\"5\"><tr valign=\"top\"><td>\n" ;
-std::ifstream histo_file2(histos_path.c_str()) ;
+  web_page << "<br><br><table cellpadding=\"5\"><tr valign=\"top\"><td>\n";
+  std::ifstream histo_file2(histos_path.c_str());
 
-cat = "" ;
-do
- {
-  std::getline(histo_file2,cat) ;
- } while (cat.empty()) ;
- 
-while (histo_file2>>histo_name>>scaled>>log>>err>>divide>>num>>denom>>eol>>eoc)
- {
-  gif_name = "gifs/"+histo_name+".gif" ;
-  gif_path = val_web_path+"/"+gif_name ;
-  canvas_name = std::string("c")+histo_name ;
-  canvas = new TCanvas(canvas_name.c_str()) ;
-  canvas->SetFillColor(10) ;
-  short_histo_name = histo_name ;
-  short_histo_name.Remove(0,2) ;
+  cat = "";
+  do {
+    std::getline(histo_file2, cat);
+  } while (cat.empty());
 
-  web_page<<"<a id=\""<<short_histo_name<<"\" name=\""<<short_histo_name<<"\"></a>" ;
+  while (histo_file2 >> histo_name >> scaled >> log >> err >> divide >> num >> denom >> eol >> eoc) {
+    gif_name = "gifs/" + histo_name + ".gif";
+    gif_path = val_web_path + "/" + gif_name;
+    canvas_name = std::string("c") + histo_name;
+    canvas = new TCanvas(canvas_name.c_str());
+    canvas->SetFillColor(10);
+    short_histo_name = histo_name;
+    short_histo_name.Remove(0, 2);
 
-  if ( file_old != 0 )
-   {
-    histo_old = (TH1 *)file_old->Get(histo_name.c_str()) ;
-    if (histo_old!=0)
-     {
-      histo_old->SetLineColor(4) ;
-      histo_old->SetLineWidth(3) ;
-      if (divide==0)
-       { histo_old->Draw("hist") ; }
-	  else
-       {
-	    // special for efficiencies
-	    TH1F *h_num = (TH1F *)file_old->Get(num.c_str()) ;
-        TH1F *h_res = (TH1F*)h_num->Clone("res");
-        h_res->Reset();
-	    TH1F *h_denom = (TH1F *)file_old->Get(denom.c_str()) ;
-        std::cout << "DIVIDING "<< num.c_str() << " by " << denom.c_str() << std::endl;
-	    h_res->Divide(h_num,h_denom,1,1,"b");
+    web_page << "<a id=\"" << short_histo_name << "\" name=\"" << short_histo_name << "\"></a>";
+
+    if (file_old != 0) {
+      histo_old = (TH1 *)file_old->Get(histo_name.c_str());
+      if (histo_old != 0) {
+        histo_old->SetLineColor(4);
+        histo_old->SetLineWidth(3);
+        if (divide == 0) {
+          histo_old->Draw("hist");
+        } else {
+          // special for efficiencies
+          TH1F *h_num = (TH1F *)file_old->Get(num.c_str());
+          TH1F *h_res = (TH1F *)h_num->Clone("res");
+          h_res->Reset();
+          TH1F *h_denom = (TH1F *)file_old->Get(denom.c_str());
+          std::cout << "DIVIDING " << num.c_str() << " by " << denom.c_str() << std::endl;
+          h_res->Divide(h_num, h_denom, 1, 1, "b");
+          h_res->GetXaxis()->SetTitle(h_num->GetXaxis()->GetTitle());
+          h_res->GetYaxis()->SetTitle(h_num->GetYaxis()->GetTitle());
+          h_res->SetLineColor(4);
+          h_res->SetLineWidth(3);
+          h_res->Draw("hist");
+        }
+      } else {
+        web_page << "No <b>" << histo_name << "</b> for " << val_ref_release << ".<br>";
+      }
+    }
+
+    gErrorIgnoreLevel = kWarning;
+    histo_new = (TH1 *)file_new->Get(histo_name.c_str());
+    if (histo_new != 0) {
+      if (log == 1)
+        canvas->SetLogy(1);
+      histo_new->SetLineColor(2);
+      histo_new->SetMarkerColor(2);
+      histo_new->SetLineWidth(3);
+      if ((scaled == 1) && (file_old != 0) && (histo_old != 0) && (histo_new->GetEntries() != 0)) {
+        if (histo_old != 0)
+          histo_new->Scale(histo_old->GetEntries() / histo_new->GetEntries());
+      }
+      if (divide == 0) {
+        if (err == 1) {
+          if (histo_old != 0)
+            histo_new->Draw("same E1 P");
+          else
+            histo_new->Draw("E1 P");
+        } else {
+          if (histo_old != 0)
+            histo_new->Draw("same hist");
+          else
+            histo_new->Draw("hist");
+        }
+      } else {
+        // special for efficiencies
+        TH1F *h_num = (TH1 *)file_new->Get(num.c_str());
+        TH1F *h_res = (TH1F *)h_num->Clone("res");
+        TH1F *h_denom = (TH1 *)file_new->Get(denom.c_str());
+        h_res->Divide(h_num, h_denom, 1, 1, "b");
         h_res->GetXaxis()->SetTitle(h_num->GetXaxis()->GetTitle());
         h_res->GetYaxis()->SetTitle(h_num->GetYaxis()->GetTitle());
-        h_res->SetLineColor(4) ;
-        h_res->SetLineWidth(3) ;
-        h_res ->Draw("hist") ;
-       }
-     }
-    else
-     {
-      web_page<<"No <b>"<<histo_name<<"</b> for "<<val_ref_release<<".<br>" ;
-     }
-   }
+        h_res->SetLineColor(2);
+        h_res->SetMarkerColor(2);
+        h_res->SetLineWidth(3);
+        if (err == 1)
+          h_res->Draw("same E1 P");
+        else
+          h_res->Draw("same hist");
+      }
+      std::cout << histo_name << " has " << histo_new->GetEffectiveEntries() << " entries"
+                << " of mean value " << histo_new->GetMean() << std::endl;
+      canvas->SaveAs(gif_path.c_str());
+      web_page << "<img class=\"image\" width=\"500\" src=\"" << gif_name << "\"><br>";
+    } else if ((file_old != 0) && (histo_old != 0)) {
+      std::cout << histo_name << " NOT FOUND" << std::endl;
+      web_page << "<br>(no such histo for " << val_new_release << ")";
+      canvas->SaveAs(gif_path.c_str());
+      web_page << "<img class=\"image\" width=\"500\" src=\"" << gif_name << "\"><br>";
+    } else {
+      web_page << "No <b>" << histo_name << "</b> for " << val_new_release << ".<br>";
+    }
+    if (eol) {
+      web_page << "</td></tr>\n<tr valign=\"top\"><td>";
+    } else {
+      web_page << "</td><td>";
+    }
+    if (eoc) {
+      cat = "";
+      do {
+        std::getline(histo_file2, cat);
+      } while (cat.empty());
+    }
+  }
+  histo_file2.close();
+  web_page << "</td></tr></table>\n";
 
-  gErrorIgnoreLevel = kWarning ;
-  histo_new = (TH1 *)file_new->Get(histo_name.c_str()) ;
-  if (histo_new!=0)
-   {
-    if (log==1) canvas->SetLogy(1);
-    histo_new->SetLineColor(2) ;
-    histo_new->SetMarkerColor(2) ;
-    histo_new->SetLineWidth(3) ;
-    if ((scaled==1)&&(file_old!=0)&&(histo_old!=0)&&(histo_new->GetEntries()!=0))
-     { if (histo_old!=0) histo_new->Scale(histo_old->GetEntries()/histo_new->GetEntries()) ; }
-    if (divide==0)
-     {
-      if (err==1)
-       {
-        if (histo_old!=0) histo_new->Draw("same E1 P") ;
-        else histo_new->Draw("E1 P") ;
-       }
-      else
-       {
-        if (histo_old!=0) histo_new->Draw("same hist") ;
-        else histo_new->Draw("hist") ;
-       }
-     }
-	else
-     {
-      // special for efficiencies
-      TH1F *h_num = (TH1 *)file_new->Get(num.c_str()) ;
-      TH1F *h_res = (TH1F*)h_num->Clone("res");
-      TH1F *h_denom = (TH1 *)file_new->Get(denom.c_str()) ;
-      h_res->Divide(h_num,h_denom,1,1,"b");
-      h_res->GetXaxis()->SetTitle(h_num->GetXaxis()->GetTitle());
-      h_res->GetYaxis()->SetTitle(h_num->GetYaxis()->GetTitle());
-      h_res->SetLineColor(2) ;
-      h_res->SetMarkerColor(2) ;
-      h_res->SetLineWidth(3) ;
-      if (err==1) h_res ->Draw("same E1 P") ;
-      else  h_res ->Draw("same hist") ;
-     }
-    std::cout<<histo_name
-      <<" has "<<histo_new->GetEffectiveEntries()<<" entries"
-      <<" of mean value "<<histo_new->GetMean()
-      <<std::endl ;
-    canvas->SaveAs(gif_path.c_str()) ;
-	web_page<<"<img class=\"image\" width=\"500\" src=\""<<gif_name<<"\"><br>" ;
-   }
-  else if ((file_old!=0)&&(histo_old!=0))
-   {
-    std::cout<<histo_name<<" NOT FOUND"<<std::endl ;
-    web_page<<"<br>(no such histo for "<<val_new_release<<")" ;
-    canvas->SaveAs(gif_path.c_str()) ;
-	web_page<<"<img class=\"image\" width=\"500\" src=\""<<gif_name<<"\"><br>" ;
-   }
-  else
-   {
-    web_page<<"No <b>"<<histo_name<<"</b> for "<<val_new_release<<".<br>" ;
-   }
-  if (eol)
-   { web_page<<"</td></tr>\n<tr valign=\"top\"><td>" ; }
-  else
-   { web_page<<"</td><td>" ; }
-  if (eoc)
-   {
-	cat = "" ;
-    do
-     {
-      std::getline(histo_file2,cat) ;
-     } while (cat.empty()) ;
-   }
- }
-histo_file2.close() ;
-web_page<<"</td></tr></table>\n" ;
+  // cumulated efficiencies
 
-// cumulated efficiencies
-
-web_page<<"\n</html>"<<std::endl ;
-web_page.close() ;
-
+  web_page << "\n</html>" << std::endl;
+  web_page.close();
 }

--- a/RecoEgamma/Examples/test/newvalidation.C
+++ b/RecoEgamma/Examples/test/newvalidation.C
@@ -90,7 +90,7 @@ std::cout<<"new url: "<<val_new_file_url<<std::endl ;
 
 TCanvas * canvas ;
 TH1 * histo_old, * histo_new ;
-Double_t nold, nnew ;
+double nold, nnew ;
 
 std::cout<<"index path: "<<index_path<<std::endl ;
 std::ofstream web_page(index_path.c_str()) ;

--- a/RecoEgamma/Examples/test/validation.csh
+++ b/RecoEgamma/Examples/test/validation.csh
@@ -464,7 +464,7 @@ TCanvas *c$i = new TCanvas("c$i");
 c$i->SetFillColor(10);
 file_old->cd();
 TH1F *h_old = (TH1F*)file_old->Get("$i");
-Double_t nold;
+double nold;
 if (h_old) {
 $i->SetLineColor(4);
 $i->SetLineWidth(3);
@@ -477,7 +477,7 @@ nold=$i->GetEntries();
 file_new->cd();
 TH1F *h_new = (TH1F*)file_new->Get("$i");
 if (h_new) {
-Double_t nnew;
+double nnew;
 nnew=$i->GetEntries();
 $i->SetLineColor(2);
 $i->SetLineWidth(3);

--- a/RecoEgamma/PhotonIdentification/plugins/PhotonIDProducer.cc
+++ b/RecoEgamma/PhotonIdentification/plugins/PhotonIDProducer.cc
@@ -13,9 +13,9 @@ PhotonIDProducer::PhotonIDProducer(const edm::ParameterSet& conf) : conf_(conf) 
   doCutBased_ = conf_.getParameter<bool>("doCutBased");
   cutBasedAlgo_ = new CutBasedPhotonIDAlgo();
   cutBasedAlgo_->setup(conf);
-  produces<edm::ValueMap<Bool_t>>(photonCutBasedIDLooseLabel_);
-  produces<edm::ValueMap<Bool_t>>(photonCutBasedIDTightLabel_);
-  produces<edm::ValueMap<Bool_t>>(photonCutBasedIDLooseEMLabel_);
+  produces<edm::ValueMap<bool>>(photonCutBasedIDLooseLabel_);
+  produces<edm::ValueMap<bool>>(photonCutBasedIDTightLabel_);
+  produces<edm::ValueMap<bool>>(photonCutBasedIDLooseEMLabel_);
 }
 
 PhotonIDProducer::~PhotonIDProducer() {
@@ -30,9 +30,9 @@ void PhotonIDProducer::produce(edm::Event& e, const edm::EventSetup& c) {
 
   // Loop over photons and calculate photon ID using specified technique(s)
   reco::PhotonCollection::const_iterator photon;
-  std::vector<Bool_t> Loose;
-  std::vector<Bool_t> Tight;
-  std::vector<Bool_t> LooseEM;
+  std::vector<bool> Loose;
+  std::vector<bool> Tight;
+  std::vector<bool> LooseEM;
   for (photon = (*photons).begin(); photon != (*photons).end(); ++photon) {
     bool LooseQual;
     bool TightQual;
@@ -46,22 +46,22 @@ void PhotonIDProducer::produce(edm::Event& e, const edm::EventSetup& c) {
     Tight.push_back(TightQual);
   }
 
-  auto outlooseEM = std::make_unique<edm::ValueMap<Bool_t>>();
-  edm::ValueMap<Bool_t>::Filler fillerlooseEM(*outlooseEM);
+  auto outlooseEM = std::make_unique<edm::ValueMap<bool>>();
+  edm::ValueMap<bool>::Filler fillerlooseEM(*outlooseEM);
   fillerlooseEM.insert(photons, LooseEM.begin(), LooseEM.end());
   fillerlooseEM.fill();
   // and put it into the event
   e.put(std::move(outlooseEM), photonCutBasedIDLooseEMLabel_);
 
-  auto outloose = std::make_unique<edm::ValueMap<Bool_t>>();
-  edm::ValueMap<Bool_t>::Filler fillerloose(*outloose);
+  auto outloose = std::make_unique<edm::ValueMap<bool>>();
+  edm::ValueMap<bool>::Filler fillerloose(*outloose);
   fillerloose.insert(photons, Loose.begin(), Loose.end());
   fillerloose.fill();
   // and put it into the event
   e.put(std::move(outloose), photonCutBasedIDLooseLabel_);
 
-  auto outtight = std::make_unique<edm::ValueMap<Bool_t>>();
-  edm::ValueMap<Bool_t>::Filler fillertight(*outtight);
+  auto outtight = std::make_unique<edm::ValueMap<bool>>();
+  edm::ValueMap<bool>::Filler fillertight(*outtight);
   fillertight.insert(photons, Tight.begin(), Tight.end());
   fillertight.fill();
   // and put it into the event

--- a/RecoEgamma/PhotonIdentification/plugins/PhotonIDSimpleAnalyzer.cc
+++ b/RecoEgamma/PhotonIdentification/plugins/PhotonIDSimpleAnalyzer.cc
@@ -46,7 +46,6 @@
 #include "TH1F.h"
 #include "TH2F.h"
 #include "TFile.h"
-#include "TMath.h"
 #include "TTree.h"
 
 // system include files
@@ -213,13 +212,13 @@ void PhotonIDSimpleAnalyzer::beginJob() {
   // Photon Histograms
   h_photonEt_ = new TH1F("photonEt", "Photon E_{T}", 200, 0, 200);
   h_photonEta_ = new TH1F("photonEta", "Photon #eta", 800, -4, 4);
-  h_photonPhi_ = new TH1F("photonPhi", "Photon #phi", 628, -1. * TMath::Pi(), TMath::Pi());
+  h_photonPhi_ = new TH1F("photonPhi", "Photon #phi", 628, -1. * M_PI, M_PI);
   h_hadoverem_ = new TH1F("photonHoverE", "Hadronic over EM", 200, 0, 1);
 
   // Photon's SuperCluster Histograms
   h_photonScEt_ = new TH1F("photonScEt", "Photon SuperCluster E_{T}", 200, 0, 200);
   h_photonScEta_ = new TH1F("photonScEta", "Photon #eta", 800, -4, 4);
-  h_photonScPhi_ = new TH1F("photonScPhi", "Photon #phi", 628, -1. * TMath::Pi(), TMath::Pi());
+  h_photonScPhi_ = new TH1F("photonScPhi", "Photon #phi", 628, -1. * M_PI, M_PI);
   h_photonScEtaWidth_ = new TH1F("photonScEtaWidth", "#eta-width", 100, 0, .1);
 
   // Composite or Other Histograms

--- a/RecoEgamma/PhotonIdentification/plugins/PhotonIDSimpleAnalyzer.cc
+++ b/RecoEgamma/PhotonIdentification/plugins/PhotonIDSimpleAnalyzer.cc
@@ -249,9 +249,9 @@ void PhotonIDSimpleAnalyzer::analyze(const edm::Event& evt, const edm::EventSetu
   Handle<reco::PhotonCollection> photonColl;
   evt.getByLabel("photons", "", photonColl);
 
-  Handle<edm::ValueMap<Bool_t> > loosePhotonQual;
+  Handle<edm::ValueMap<bool> > loosePhotonQual;
   evt.getByLabel("PhotonIDProd", "PhotonCutBasedIDLoose", loosePhotonQual);
-  Handle<edm::ValueMap<Bool_t> > looseEMQual;
+  Handle<edm::ValueMap<bool> > looseEMQual;
   evt.getByLabel("PhotonIDProd", "PhotonCutBasedIDLooseEM", looseEMQual);
   // grab PhotonId objects
   //   Handle<reco::PhotonIDAssociationCollection> photonIDMapColl;
@@ -259,8 +259,8 @@ void PhotonIDSimpleAnalyzer::analyze(const edm::Event& evt, const edm::EventSetu
 
   // create reference to the object types we are interested in
   const reco::PhotonCollection* photons = photonColl.product();
-  const edm::ValueMap<Bool_t>* phoMap = loosePhotonQual.product();
-  const edm::ValueMap<Bool_t>* lEMMap = looseEMQual.product();
+  const edm::ValueMap<bool>* phoMap = loosePhotonQual.product();
+  const edm::ValueMap<bool>* lEMMap = looseEMQual.product();
   int photonCounter = 0;
   int idxpho = 0;
   reco::PhotonCollection::const_iterator pho;
@@ -272,9 +272,9 @@ void PhotonIDSimpleAnalyzer::analyze(const edm::Event& evt, const edm::EventSetu
 
     float photonEt = pho->et();
     float superClusterEt = (pho->superCluster()->energy()) / (cosh(pho->superCluster()->position().eta()));
-    Bool_t LoosePhotonQu = (*phoMap)[photonref];
+    bool LoosePhotonQu = (*phoMap)[photonref];
     h_nPassingPho_->Fill(LoosePhotonQu);
-    Bool_t LooseEMQu = (*lEMMap)[photonref];
+    bool LooseEMQu = (*lEMMap)[photonref];
     h_nPassEM_->Fill(LooseEMQu);
     // Only store photon candidates (SuperClusters) that pass some simple cuts
     bool passCuts = (photonEt > minPhotonEt_) && (fabs(pho->eta()) > minPhotonAbsEta_) &&

--- a/RecoEgamma/PhotonIdentification/plugins/PhotonMVAEstimator.cc
+++ b/RecoEgamma/PhotonIdentification/plugins/PhotonMVAEstimator.cc
@@ -126,7 +126,7 @@ float PhotonMVAEstimator::mvaValue(const reco::Candidate* candPtr,
     // for endcap MVA only in 2016
     double eA = effectiveAreas_->getEffectiveArea(std::abs(phoPtr->superCluster()->eta()));
     double phoIsoCorr = vars[10] - eA * (double)vars[9] - phoIsoPtScalingCoeff_.at(1) * phoPtr->pt();
-    vars[10] = TMath::Max(phoIsoCorr, phoIsoCutoff_);
+    vars[10] = std::max(phoIsoCorr, phoIsoCutoff_);
   }
 
   if (isDebug()) {

--- a/RecoEgamma/PhotonIdentification/src/PhotonIsolationCalculator.cc
+++ b/RecoEgamma/PhotonIdentification/src/PhotonIsolationCalculator.cc
@@ -29,8 +29,6 @@
 
 #include "RecoLocalCalo/EcalRecAlgos/interface/EcalSeverityLevelAlgoRcd.h"
 
-#include <TMath.h>
-
 void PhotonIsolationCalculator::setup(const edm::ParameterSet& conf,
                                       std::vector<int> const& flagsEB,
                                       std::vector<int> const& flagsEE,

--- a/RecoEgamma/PhotonIdentification/src/PhotonMIPHaloTagger.cc
+++ b/RecoEgamma/PhotonIdentification/src/PhotonMIPHaloTagger.cc
@@ -12,8 +12,6 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "RecoEcal/EgammaCoreTools/interface/EcalClusterTools.h"
 
-#include <TMath.h>
-
 void PhotonMIPHaloTagger::setup(const edm::ParameterSet& conf, edm::ConsumesCollector&& iC) {
   EBecalCollection_ = iC.consumes<EcalRecHitCollection>(conf.getParameter<edm::InputTag>("barrelEcalRecHitCollection"));
   EEecalCollection_ = iC.consumes<EcalRecHitCollection>(conf.getParameter<edm::InputTag>("endcapEcalRecHitCollection"));
@@ -138,7 +136,7 @@ std::vector<double> PhotonMIPHaloTagger::GetMipTrailFit(const reco::Photon* phot
       ietacell++;
 
     //Exclude all cells within +/- 5 ieta of seed cell
-    if (TMath::Abs(ietacell - seedIEta) >= 5 && it->energy() > 0.) {
+    if (std::abs(ietacell - seedIEta) >= 5 && it->energy() > 0.) {
       delt_ieta = ietacell - seedIEta;
       delt_iphi = iphicell - seedIPhi;
 
@@ -234,8 +232,8 @@ std::vector<double> PhotonMIPHaloTagger::GetMipTrailFit(const reco::Photon* phot
       double res = 1.0 * iphi_cell[j] - a1 - b1 * ieta_cell[j];
       double res_sq = res * res;
 
-      if (TMath::Abs(res) > highest_res) {
-        highest_res = TMath::Abs(res);
+      if (std::abs(res) > highest_res) {
+        highest_res = std::abs(res);
         highres_index = j;
       }
 


### PR DESCRIPTION
#### PR description:

I think the standard library math functions should be used unless there is a specific reason to use something else.

RecoEgamma already uses the standard library functions for the most part, this PR is replacing the remaining TMath functions.

#### PR validation:

CMSSW compiles.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

No backport indended.