### PR TITLE
Fix issues with SiPixelQualityMapComparisonBase

### DIFF
--- a/CondCore/SiPixelPlugins/interface/SiPixelGainCalibHelper.h
+++ b/CondCore/SiPixelPlugins/interface/SiPixelGainCalibHelper.h
@@ -38,7 +38,7 @@ namespace gainCalibHelper {
   namespace gainCalibPI {
 
     enum type { t_gain = 0, t_pedestal = 1, t_correlation = 2 };
-    std::array<std::string, 3> t_titles = {{"gain", "pedestal", "correlation"}};
+    static const std::array<std::string, 3> t_titles = {{"gain", "pedestal", "correlation"}};
 
     //===========================================================================
     // helper method to fill the ratio and diff distributions

--- a/CondCore/SiPixelPlugins/plugins/SiPixelQuality_PayloadInspector.cc
+++ b/CondCore/SiPixelPlugins/plugins/SiPixelQuality_PayloadInspector.cc
@@ -14,6 +14,7 @@
 #include "CondCore/SiPixelPlugins/interface/SiPixelPayloadInspectorHelper.h"
 #include "FWCore/ParameterSet/interface/FileInPath.h"
 #include "CalibTracker/StandaloneTrackerTopology/interface/StandaloneTrackerTopology.h"
+#include "CalibTracker/SiPixelESProducers/interface/SiPixelDetInfoFileReader.h"
 
 // the data format of the condition to be inspected
 #include "CondFormats/SiPixelObjects/interface/SiPixelQuality.h"
@@ -39,18 +40,19 @@
 
 namespace {
 
-  //using namespace cond::payloadInspector;
+  using namespace cond::payloadInspector;
+
+  const std::string k_Ph0_geo = "CalibTracker/SiPixelESProducers/data/PixelSkimmedGeometry.txt";
+  const std::string k_Ph1_geo = "SLHCUpgradeSimulations/Geometry/data/PhaseI/PixelSkimmedGeometry_phase1.txt";
 
   /************************************************
     test class
   *************************************************/
 
-  class SiPixelQualityTest
-      : public cond::payloadInspector::Histogram1D<SiPixelQuality, cond::payloadInspector::SINGLE_IOV> {
+  class SiPixelQualityTest : public Histogram1D<SiPixelQuality, SINGLE_IOV> {
   public:
     SiPixelQualityTest()
-        : cond::payloadInspector::Histogram1D<SiPixelQuality, cond::payloadInspector::SINGLE_IOV>(
-              "SiPixelQuality test", "SiPixelQuality test", 10, 0.0, 10.0) {}
+        : Histogram1D<SiPixelQuality, SINGLE_IOV>("SiPixelQuality test", "SiPixelQuality test", 10, 0.0, 10.0) {}
 
     bool fill() override {
       auto tag = PlotBase::getTag<0>();
@@ -79,12 +81,9 @@ namespace {
     summary class
   *************************************************/
 
-  class SiPixelQualityBadRocsSummary
-      : public cond::payloadInspector::PlotImage<SiPixelQuality, cond::payloadInspector::MULTI_IOV, 1> {
+  class SiPixelQualityBadRocsSummary : public PlotImage<SiPixelQuality, MULTI_IOV, 1> {
   public:
-    SiPixelQualityBadRocsSummary()
-        : cond::payloadInspector::PlotImage<SiPixelQuality, cond::payloadInspector::MULTI_IOV, 1>(
-              "SiPixel Quality Summary") {}
+    SiPixelQualityBadRocsSummary() : PlotImage<SiPixelQuality, MULTI_IOV, 1>("SiPixel Quality Summary") {}
 
     bool fill() override {
       auto tag = PlotBase::getTag<0>();
@@ -119,12 +118,10 @@ namespace {
     time history class
   *************************************************/
 
-  class SiPixelQualityBadRocsTimeHistory
-      : public cond::payloadInspector::TimeHistoryPlot<SiPixelQuality, std::pair<double, double> > {
+  class SiPixelQualityBadRocsTimeHistory : public TimeHistoryPlot<SiPixelQuality, std::pair<double, double> > {
   public:
     SiPixelQualityBadRocsTimeHistory()
-        : cond::payloadInspector::TimeHistoryPlot<SiPixelQuality, std::pair<double, double> >("bad ROCs count vs time",
-                                                                                              "bad ROCs count") {}
+        : TimeHistoryPlot<SiPixelQuality, std::pair<double, double> >("bad ROCs count vs time", "bad ROCs count") {}
 
     std::pair<double, double> getFromPayload(SiPixelQuality& payload) override {
       return std::make_pair(extractBadRocCount(payload), 0.);
@@ -148,12 +145,10 @@ namespace {
    occupancy style map whole Pixel
   *************************************************/
   template <SiPixelPI::DetType myType>
-  class SiPixelQualityMap
-      : public cond::payloadInspector::PlotImage<SiPixelQuality, cond::payloadInspector::SINGLE_IOV> {
+  class SiPixelQualityMap : public PlotImage<SiPixelQuality, SINGLE_IOV> {
   public:
     SiPixelQualityMap()
-        : cond::payloadInspector::PlotImage<SiPixelQuality, cond::payloadInspector::SINGLE_IOV>(
-              "SiPixelQuality Pixel Map"),
+        : PlotImage<SiPixelQuality, SINGLE_IOV>("SiPixelQuality Pixel Map"),
           m_trackerTopo{StandaloneTrackerTopology::fromTrackerParametersXMLFile(
               edm::FileInPath("Geometry/TrackerCommonData/data/PhaseI/trackerParameters.xml").fullPath())} {}
 
@@ -166,6 +161,16 @@ namespace {
       Phase1PixelROCMaps theMap("");
 
       auto theDisabledModules = payload->getBadComponentList();
+      if (this->isPhase0(theDisabledModules)) {
+        edm::LogError("SiPixelQuality_PayloadInspector")
+            << "SiPixelQuality maps are not supported for non-Phase1 Pixel geometries !";
+        TCanvas canvas("Canv", "Canv", 1200, 1000);
+        SiPixelPI::displayNotSupported(canvas, 0);
+        std::string fileName(m_imageFileName);
+        canvas.SaveAs(fileName.c_str());
+        return false;
+      }
+
       for (const auto& mod : theDisabledModules) {
         int subid = DetId(mod.DetID).subdetId();
 
@@ -220,6 +225,26 @@ namespace {
   private:
     static constexpr std::array<int, 3> k_height = {{1200, 600, 1600}};
     TrackerTopology m_trackerTopo;
+
+    //_________________________________________________
+    bool isPhase0(std::vector<SiPixelQuality::disabledModuleType> mods) {
+      SiPixelDetInfoFileReader reader = SiPixelDetInfoFileReader(edm::FileInPath(k_Ph0_geo).fullPath());
+      const auto& p0detIds = reader.getAllDetIds();
+
+      std::vector<uint32_t> ownDetIds;
+      std::transform(mods.begin(),
+                     mods.end(),
+                     std::back_inserter(ownDetIds),
+                     [](SiPixelQuality::disabledModuleType d) -> uint32_t { return d.DetID; });
+
+      for (const auto& det : ownDetIds) {
+        // if found at least one phase-0 detId early return
+        if (std::find(p0detIds.begin(), p0detIds.end(), det) != p0detIds.end()) {
+          return true;
+        }
+      }
+      return false;
+    }
   };
 
   using SiPixelBPixQualityMap = SiPixelQualityMap<SiPixelPI::t_barrel>;
@@ -229,19 +254,19 @@ namespace {
   /************************************************
    occupancy style map whole Pixel, difference of payloads
   *************************************************/
-  template <SiPixelPI::DetType myType, cond::payloadInspector::IOVMultiplicity nIOVs, int ntags>
-  class SiPixelQualityMapComparisonBase : public cond::payloadInspector::PlotImage<SiPixelQuality, nIOVs, ntags> {
+  template <SiPixelPI::DetType myType, IOVMultiplicity nIOVs, int ntags>
+  class SiPixelQualityMapComparisonBase : public PlotImage<SiPixelQuality, nIOVs, ntags> {
   public:
     SiPixelQualityMapComparisonBase()
-        : cond::payloadInspector::PlotImage<SiPixelQuality, nIOVs, ntags>(
+        : PlotImage<SiPixelQuality, nIOVs, ntags>(
               Form("SiPixelQuality %s Pixel Map", SiPixelPI::DetNames[myType].c_str())),
           m_trackerTopo{StandaloneTrackerTopology::fromTrackerParametersXMLFile(
               edm::FileInPath("Geometry/TrackerCommonData/data/PhaseI/trackerParameters.xml").fullPath())} {}
 
     bool fill() override {
       // trick to deal with the multi-ioved tag and two tag case at the same time
-      auto theIOVs = cond::payloadInspector::PlotBase::getTag<0>().iovs;
-      auto f_tagname = cond::payloadInspector::PlotBase::getTag<0>().name;
+      auto theIOVs = PlotBase::getTag<0>().iovs;
+      auto f_tagname = PlotBase::getTag<0>().name;
       std::string l_tagname = "";
       auto firstiov = theIOVs.front();
       std::tuple<cond::Time_t, cond::Hash> lastiov;
@@ -250,8 +275,8 @@ namespace {
       assert(this->m_plotAnnotations.ntags < 3);
 
       if (this->m_plotAnnotations.ntags == 2) {
-        auto tag2iovs = cond::payloadInspector::PlotBase::getTag<1>().iovs;
-        l_tagname = cond::payloadInspector::PlotBase::getTag<1>().name;
+        auto tag2iovs = PlotBase::getTag<1>().iovs;
+        l_tagname = PlotBase::getTag<1>().name;
         lastiov = tag2iovs.front();
       } else {
         lastiov = theIOVs.back();
@@ -259,6 +284,16 @@ namespace {
 
       std::shared_ptr<SiPixelQuality> last_payload = this->fetchPayload(std::get<1>(lastiov));
       std::shared_ptr<SiPixelQuality> first_payload = this->fetchPayload(std::get<1>(firstiov));
+
+      if (this->isPhase0(first_payload) || this->isPhase0(last_payload)) {
+        edm::LogError("SiPixelQuality_PayloadInspector")
+            << "SiPixelQuality comparison maps are not supported for non-Phase1 Pixel geometries !";
+        TCanvas canvas("Canv", "Canv", 1200, 1000);
+        SiPixelPI::displayNotSupported(canvas, 0);
+        std::string fileName(this->m_imageFileName);
+        canvas.SaveAs(fileName.c_str());
+        return false;
+      }
 
       Phase1PixelROCMaps theMap("", "#Delta payload A - payload B");
 
@@ -322,6 +357,27 @@ namespace {
     static constexpr std::array<int, 3> k_height = {{1200, 600, 1600}};
     TrackerTopology m_trackerTopo;
 
+    //_________________________________________________
+    bool isPhase0(const std::shared_ptr<SiPixelQuality>& payload) {
+      const auto mods = payload->getBadComponentList();
+      SiPixelDetInfoFileReader reader = SiPixelDetInfoFileReader(edm::FileInPath(k_Ph0_geo).fullPath());
+      const auto& p0detIds = reader.getAllDetIds();
+
+      std::vector<uint32_t> ownDetIds;
+      std::transform(mods.begin(),
+                     mods.end(),
+                     std::back_inserter(ownDetIds),
+                     [](SiPixelQuality::disabledModuleType d) -> uint32_t { return d.DetID; });
+
+      for (const auto& det : ownDetIds) {
+        // if found at least one phase-0 detId early return
+        if (std::find(p0detIds.begin(), p0detIds.end(), det) != p0detIds.end()) {
+          return true;
+        }
+      }
+      return false;
+    }
+
     //____________________________________________________________________________________________
     void fillTheMapFromPayload(Phase1PixelROCMaps& theMap,
                                const std::shared_ptr<SiPixelQuality>& payload,
@@ -343,18 +399,12 @@ namespace {
     }
   };
 
-  using SiPixelBPixQualityMapCompareSingleTag =
-      SiPixelQualityMapComparisonBase<SiPixelPI::t_barrel, cond::payloadInspector::MULTI_IOV, 1>;
-  using SiPixelFPixQualityMapCompareSingleTag =
-      SiPixelQualityMapComparisonBase<SiPixelPI::t_forward, cond::payloadInspector::MULTI_IOV, 1>;
-  using SiPixelFullQualityMapCompareSingleTag =
-      SiPixelQualityMapComparisonBase<SiPixelPI::t_all, cond::payloadInspector::MULTI_IOV, 1>;
-  using SiPixelBPixQualityMapCompareTwoTags =
-      SiPixelQualityMapComparisonBase<SiPixelPI::t_barrel, cond::payloadInspector::SINGLE_IOV, 2>;
-  using SiPixelFPixQualityMapCompareTwoTags =
-      SiPixelQualityMapComparisonBase<SiPixelPI::t_forward, cond::payloadInspector::SINGLE_IOV, 2>;
-  using SiPixelFullQualityMapCompareTwoTags =
-      SiPixelQualityMapComparisonBase<SiPixelPI::t_all, cond::payloadInspector::SINGLE_IOV, 2>;
+  using SiPixelBPixQualityMapCompareSingleTag = SiPixelQualityMapComparisonBase<SiPixelPI::t_barrel, MULTI_IOV, 1>;
+  using SiPixelFPixQualityMapCompareSingleTag = SiPixelQualityMapComparisonBase<SiPixelPI::t_forward, MULTI_IOV, 1>;
+  using SiPixelFullQualityMapCompareSingleTag = SiPixelQualityMapComparisonBase<SiPixelPI::t_all, MULTI_IOV, 1>;
+  using SiPixelBPixQualityMapCompareTwoTags = SiPixelQualityMapComparisonBase<SiPixelPI::t_barrel, SINGLE_IOV, 2>;
+  using SiPixelFPixQualityMapCompareTwoTags = SiPixelQualityMapComparisonBase<SiPixelPI::t_forward, SINGLE_IOV, 2>;
+  using SiPixelFullQualityMapCompareTwoTags = SiPixelQualityMapComparisonBase<SiPixelPI::t_all, SINGLE_IOV, 2>;
 
 }  // namespace
 

--- a/CondCore/SiPixelPlugins/plugins/SiPixelQuality_PayloadInspector.cc
+++ b/CondCore/SiPixelPlugins/plugins/SiPixelQuality_PayloadInspector.cc
@@ -263,12 +263,6 @@ namespace {
 
       Phase1PixelROCMaps theMap("", "#Delta payload A - payload B");
 
-      // first loop on the first payload (newest)
-      fillTheMapFromPayload(theMap, first_payload, false);
-
-      // then loop on the second payload (oldest)
-      fillTheMapFromPayload(theMap, last_payload, true);  // true will subtract
-
       gStyle->SetOptStat(0);
       //=========================
       TCanvas canvas("Summary", "Summary", 1200, k_height[myType]);
@@ -309,6 +303,12 @@ namespace {
           throw cms::Exception("SiPixelQualityMapComparison")
               << "\nERROR: unrecognized Pixel Detector part " << std::endl;
       }
+
+      // first loop on the first payload (newest)
+      fillTheMapFromPayload(theMap, first_payload, false);
+
+      // then loop on the second payload (oldest)
+      fillTheMapFromPayload(theMap, last_payload, true);  // true will subtract
 
       std::string fileName(this->m_imageFileName);
       canvas.SaveAs(fileName.c_str());
@@ -351,11 +351,11 @@ namespace {
   using SiPixelFullQualityMapCompareSingleTag =
       SiPixelQualityMapComparisonBase<SiPixelPI::t_all, cond::payloadInspector::MULTI_IOV, 1>;
   using SiPixelBPixQualityMapCompareTwoTags =
-      SiPixelQualityMapComparisonBase<SiPixelPI::t_barrel, cond::payloadInspector::MULTI_IOV, 2>;
+      SiPixelQualityMapComparisonBase<SiPixelPI::t_barrel, cond::payloadInspector::SINGLE_IOV, 2>;
   using SiPixelFPixQualityMapCompareTwoTags =
-      SiPixelQualityMapComparisonBase<SiPixelPI::t_forward, cond::payloadInspector::MULTI_IOV, 2>;
+      SiPixelQualityMapComparisonBase<SiPixelPI::t_forward, cond::payloadInspector::SINGLE_IOV, 2>;
   using SiPixelFullQualityMapCompareTwoTags =
-      SiPixelQualityMapComparisonBase<SiPixelPI::t_all, cond::payloadInspector::MULTI_IOV, 2>;
+      SiPixelQualityMapComparisonBase<SiPixelPI::t_all, cond::payloadInspector::SINGLE_IOV, 2>;
 
 }  // namespace
 

--- a/CondCore/SiPixelPlugins/plugins/SiPixelQuality_PayloadInspector.cc
+++ b/CondCore/SiPixelPlugins/plugins/SiPixelQuality_PayloadInspector.cc
@@ -101,16 +101,15 @@ namespace {
       }
 
       //=========================
-      TCanvas canvas("Partion summary", "partition summary", 1200, 1000);
-      SiPixelPI::displayNotSupported(canvas, 0);
-      canvas.cd();
-      canvas.SetBottomMargin(0.11);
-      canvas.SetLeftMargin(0.13);
-      canvas.SetRightMargin(0.05);
-      canvas.Modified();
+      TCanvas canv("Partition summary", "partition summary", 1200, 1000);
+      canv.SetBottomMargin(0.11);
+      canv.SetLeftMargin(0.13);
+      canv.SetRightMargin(0.05);
+      canv.cd();
+      SiPixelPI::displayNotSupported(canv, 0);
 
       std::string fileName(m_imageFileName);
-      canvas.SaveAs(fileName.c_str());
+      canv.SaveAs(fileName.c_str());
 
       return true;
     }

--- a/DQM/TrackerRemapper/src/Phase1PixelROCMaps.cc
+++ b/DQM/TrackerRemapper/src/Phase1PixelROCMaps.cc
@@ -363,6 +363,9 @@ void PixelROCMapHelper::dress_plot(TPad*& canv,
     int nb = 256;
     h->SetContour(nb);
     TColor::CreateGradientColorTable(Number, Stops, Red, Green, Blue, nb);
+    // if max == min impose the range to be the same as it was a real diff
+    if (max == min)
+      h->GetZaxis()->SetRangeUser(-1., 1.);
   }
 
   h->SetMarkerSize(0.7);

--- a/DQM/TrackerRemapper/src/Phase1PixelROCMaps.cc
+++ b/DQM/TrackerRemapper/src/Phase1PixelROCMaps.cc
@@ -353,7 +353,7 @@ void PixelROCMapHelper::dress_plot(TPad*& canv,
     double max = h->GetMaximum();
     double min = h->GetMinimum();
     double val_white = 0.;
-    double per_white = (val_white - min) / (max - min);
+    double per_white = (max != min) ? ((val_white - min) / (max - min)) : 0.5;
 
     const int Number = 3;
     double Red[Number] = {0., 1., 1.};

--- a/DQM/TrackerRemapper/test/test_catch2_Phase1PixelROCMaps.cc
+++ b/DQM/TrackerRemapper/test/test_catch2_Phase1PixelROCMaps.cc
@@ -40,6 +40,19 @@ TEST_CASE("Phase1PixelROCMaps testing", "[Phase1PixelROCMaps]") {
   }
 
   //_____________________________________________________________
+  SECTION("Check empty delta plotting") {
+    gStyle->SetOptStat(0);
+    Phase1PixelROCMaps theMap("#Delta", "#Delta");
+    TCanvas c = TCanvas("c", "c", 1200, 1600);
+    theMap.drawMaps(c, "testing empty #Delta");
+    theMap.fillWholeModule(303042564, 1.);
+    theMap.fillWholeModule(344912900, -1.);
+    c.SaveAs("Phase1PixelROCMaps_emptyDelta.png");
+    REQUIRE(theMap.getLayerMaps().size() == 4);
+    REQUIRE(theMap.getRingMaps().size() == 2);
+  }
+
+  //_____________________________________________________________
   SECTION("Check filling whole modules") {
     Phase1PixelROCMaps theMap("");
     gStyle->SetOptStat(0);


### PR DESCRIPTION
#### PR description:

This is a follow-up to PR https://github.com/cms-sw/cmssw/pull/34071. 
Fixes two issues found when displaying plots in the [payload inspector in CondDB](https://cms-conddb.cern.ch/cmsDbBrowser/payload_inspector/Prod): 
   * changes the template arguments for `SiPixel*QualityMapCompareTwoTags` in order to be in single IOV mode; 
   * fix the issue with `Phase1PixelROCMaps` the  in "delta" mode, when an empty map was produced (leading to division by zero); such case is now tested in the unit tests.

#### PR validation:
Tested with the command:

```
getPayloadData.py --plugin pluginSiPixelQuality_PayloadInspector --plot plot_SiPixelBPixQualityMapCompareSingleTag --tag SiPixelQuality_v04_offline --input_params '{}' --time_type Run --iovs '{"start_iov": "319320", "end_iov": "319547"}' --db Prod --test;
```

which was failing before (killed) while now produces:

![abeb896c-647b-4c1e-a110-89333c27306f](https://user-images.githubusercontent.com/5082376/124390252-f3763380-dcea-11eb-8293-8526657b4a57.png)

Also the (augmented) unit test pass.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Not a backport, no backport needed.

