### PR TITLE
Use std::bind in place of boost:bind

### DIFF
--- a/CondCore/CondDB/plugins/RelationalAuthenticationService.cc
+++ b/CondCore/CondDB/plugins/RelationalAuthenticationService.cc
@@ -16,7 +16,6 @@
 #include <memory>
 #include <sys/stat.h>
 
-#include <boost/bind/bind.hpp>
 
 #include "CoralBase/MessageStream.h"
 
@@ -24,9 +23,9 @@ cond::RelationalAuthenticationService::RelationalAuthenticationService::Relation
     const std::string& key)
     : coral::Service(key), m_authenticationPath(""), m_db(), m_cache(), m_callbackID(0) {
   boost::function1<void, std::string> cb(
-      boost::bind(&cond::RelationalAuthenticationService::RelationalAuthenticationService::setAuthenticationPath,
+      std::bind(&cond::RelationalAuthenticationService::RelationalAuthenticationService::setAuthenticationPath,
                   this,
-                  boost::placeholders::_1));
+                  std::placeholders::_1));
 
   coral::Property* pm = dynamic_cast<coral::Property*>(
       coral::Context::instance().PropertyManager().property(auth::COND_AUTH_PATH_PROPERTY));

--- a/CondCore/CondDB/plugins/XMLAuthenticationService.cc
+++ b/CondCore/CondDB/plugins/XMLAuthenticationService.cc
@@ -24,7 +24,6 @@
 #include <memory>
 #include <sys/stat.h>
 
-#include <boost/bind.hpp>
 #include "CoralBase/MessageStream.h"
 
 constexpr char XML_AUTHENTICATION_FILE[] = "authentication.xml";
@@ -78,7 +77,7 @@ const coral::IAuthenticationCredentials& cond::XMLAuthenticationService::DataSou
 cond::XMLAuthenticationService::XMLAuthenticationService::XMLAuthenticationService(const std::string& key)
     : coral::Service(key), m_isInitialized(false), m_inputFileName(""), m_data(), m_mutexLock(), m_callbackID(0) {
   boost::function1<void, std::string> cb(
-      boost::bind(&cond::XMLAuthenticationService::XMLAuthenticationService::setAuthenticationPath, this, _1));
+      std::bind(&cond::XMLAuthenticationService::XMLAuthenticationService::setAuthenticationPath, this, std::placeholders::_1));
 
   coral::Property* pm = dynamic_cast<coral::Property*>(
       coral::Context::instance().PropertyManager().property(auth::COND_AUTH_PATH_PROPERTY));

--- a/CondCore/Utilities/src/CondDBTools.cc
+++ b/CondCore/Utilities/src/CondDBTools.cc
@@ -5,7 +5,7 @@
 #include "CondCore/CondDB/src/DbCore.h"
 //
 #include <boost/regex.hpp>
-#include <boost/bind.hpp>
+
 #include <memory>
 
 namespace cond {

--- a/DataFormats/EcalDigi/test/EcalDigi_t.cpp
+++ b/DataFormats/EcalDigi/test/EcalDigi_t.cpp
@@ -173,7 +173,7 @@ namespace {
     }
 
     //    std::for_each(frames.begin(),frames.end(),
-    //		  boost::bind(verifyId,boost::bind(&edm::DataFrame::id,_1)));
+    //		  std::bind(verifyId,std::bind(&edm::DataFrame::id, std::placeholders::_1)));
     // same as above....
     for (int n = 0; n < int(frames.size()); ++n) {
       edm::DataFrame df = frames[n];

--- a/Fireworks/Core/src/FWCompositeParameter.cc
+++ b/Fireworks/Core/src/FWCompositeParameter.cc
@@ -78,7 +78,7 @@ void FWCompositeParameter::addTo(FWConfiguration& oTo) const {
     (*it)->addTo(conf);
   }
   //   std::for_each(begin(), end(),
-  //                 boost::bind(&FWParameterBase::addTo,_1,conf));
+  //                 std::bind(&FWParameterBase::addTo, std::placeholders::_1,conf));
 
   oTo.addKeyValue(name(), conf, true);
 }

--- a/Fireworks/Core/src/FWISpyView.cc
+++ b/Fireworks/Core/src/FWISpyView.cc
@@ -11,7 +11,6 @@
 //
 
 // system include files
-#include <boost/bind.hpp>
 
 // user include files
 #include "TGLViewer.h"

--- a/Fireworks/Core/test/unittest_changemanager.cc
+++ b/Fireworks/Core/test/unittest_changemanager.cc
@@ -12,7 +12,6 @@
 
 // system include files
 #include <boost/test/auto_unit_test.hpp>
-#include <boost/bind.hpp>
 #include <boost/test/test_tools.hpp>
 
 #include "TClass.h"
@@ -96,8 +95,8 @@ BOOST_AUTO_TEST_CASE(changemanager) {
   //NOTE: have to pass a pointer to the listener else the bind will
   // create a copy of the listener and the original one will never
   // 'hear' any signal
-  item.changed_.connect(boost::bind(&Listener::listen, &listener, _1));
-  item.itemChanged_.connect(boost::bind(&ItemListener::listen, &iListener, _1));
+  item.changed_.connect(std::bind(&Listener::listen, &listener, std::placeholders::_1));
+  item.itemChanged_.connect(std::bind(&ItemListener::listen, &iListener, std::placeholders::_1));
 
   BOOST_CHECK(listener.nHeard_ == 0);
   BOOST_CHECK(iListener.nHeard_ == 0);

--- a/Fireworks/Core/test/unittest_eventitemsmanager.cc
+++ b/Fireworks/Core/test/unittest_eventitemsmanager.cc
@@ -12,7 +12,6 @@
 
 // system include files
 #include <boost/test/auto_unit_test.hpp>
-#include <boost/bind.hpp>
 #include <boost/test/test_tools.hpp>
 #include "TClass.h"
 
@@ -62,7 +61,7 @@ BOOST_AUTO_TEST_CASE(eventitemmanager) {
   //NOTE: have to pass a pointer to the listener else the bind will
   // create a copy of the listener and the original one will never
   // 'hear' any signal
-  eim.newItem_.connect(boost::bind(&Listener::newItem, &listener, _1));
+  eim.newItem_.connect(std::bind(&Listener::newItem, &listener, std::placeholders::_1));
 
   TClass* cls = TClass::GetClass("std::vector<reco::Track>");
   assert(0 != cls);

--- a/Fireworks/Core/test/unittest_parameters.cc
+++ b/Fireworks/Core/test/unittest_parameters.cc
@@ -13,7 +13,6 @@
 // system include files
 #include <boost/test/auto_unit_test.hpp>
 #include <boost/test/test_tools.hpp>
-#include <boost/bind.hpp>
 #include <stdexcept>
 #include <iostream>
 
@@ -26,8 +25,8 @@
 namespace {
   struct Test : public FWParameterizable {
     Test()
-        : m_double(this, "double", boost::bind(&Test::doubleChanged, this, _1)),
-          m_long(this, "long", boost::bind(&Test::longChanged, this, _1)),
+        : m_double(this, "double", std::bind(&Test::doubleChanged, this, std::placeholders::_1)),
+          m_long(this, "long", std::bind(&Test::longChanged, this, std::placeholders::_1)),
           m_wasChanged(false) {}
 
     void doubleChanged(double iValue) {

--- a/Fireworks/Core/test/unittest_selectionmanager.cc
+++ b/Fireworks/Core/test/unittest_selectionmanager.cc
@@ -12,7 +12,7 @@
 
 // system include files
 //#include <boost/test/auto_unit_test.hpp>
-#include <boost/bind.hpp>
+
 #define BOOST_TEST_DYN_LINK
 #define BOOST_TEST_MAIN
 #include <boost/test/unit_test.hpp>
@@ -81,7 +81,7 @@ BOOST_AUTO_TEST_CASE(selectionmanager) {
   //NOTE: have to pass a pointer to the listener else the bind will
   // create a copy of the listener and the original one will never
   // 'hear' any signal
-  sm.selectionChanged_.connect(boost::bind(&Listener::listen, &listener, _1));
+  sm.selectionChanged_.connect(std::bind(&Listener::listen, &listener, std::placeholders::_1));
 
   reco::TrackCollection fVector;
   fVector.push_back(reco::Track());

--- a/GeneratorInterface/LHEInterface/plugins/LH5Source.cc
+++ b/GeneratorInterface/LHEInterface/plugins/LH5Source.cc
@@ -4,7 +4,6 @@
 #include <string>
 #include <memory>
 
-#include <boost/bind.hpp>
 
 #include "FWCore/Framework/interface/InputSourceMacros.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -148,13 +147,13 @@ void LH5Source::readEvent_(edm::EventPrincipal& eventPrincipal) {
   }
   std::for_each(partonLevel_->weights().begin(),
                 partonLevel_->weights().end(),
-                boost::bind(&LHEEventProduct::addWeight, product.get(), _1));
+                std::bind(&LHEEventProduct::addWeight, product.get(), std::placeholders::_1));
   product->setScales(partonLevel_->scales());
   product->setNpLO(partonLevel_->npLO());
   product->setNpNLO(partonLevel_->npNLO());
   std::for_each(partonLevel_->getComments().begin(),
                 partonLevel_->getComments().end(),
-                boost::bind(&LHEEventProduct::addComment, product.get(), _1));
+                std::bind(&LHEEventProduct::addComment, product.get(), std::placeholders::_1));
 
   std::unique_ptr<edm::WrapperBase> edp(new edm::Wrapper<LHEEventProduct>(std::move(product)));
   eventPrincipal.put(lheProvenanceHelper_.eventProductBranchDescription_,

--- a/GeneratorInterface/MCatNLOInterface/plugins/MCatNLOSource.cc
+++ b/GeneratorInterface/MCatNLOInterface/plugins/MCatNLOSource.cc
@@ -7,7 +7,6 @@
 #include <sstream>
 #include <string>
 
-#include <boost/bind.hpp>
 
 #include "FWCore/Framework/interface/InputSourceMacros.h"
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/GeneratorInterface/Pythia6Interface/src/Pythia6Service.cc
+++ b/GeneratorInterface/Pythia6Interface/src/Pythia6Service.cc
@@ -7,7 +7,7 @@
 #include <string>
 #include <set>
 
-#include <boost/bind.hpp>
+
 #include <boost/algorithm/string/classification.hpp>
 #include <boost/algorithm/string/split.hpp>
 #include <filesystem>

--- a/PerfTools/Callgrind/test/ProfilerServiceTest.cppunit.cc
+++ b/PerfTools/Callgrind/test/ProfilerServiceTest.cppunit.cc
@@ -4,7 +4,7 @@
 #include "FWCore/ServiceRegistry/interface/ActivityRegistry.h"
 
 #include <boost/ref.hpp>
-#include <boost/bind.hpp>
+
 
 #include <limits>
 #include <vector>

--- a/RecoLocalTracker/SiPixelRecHits/src/VVIObj.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/VVIObj.cc
@@ -20,7 +20,7 @@
 
 #include <cmath>
 #include <algorithm>
-#include <boost/bind.hpp>
+
 
 namespace VVIObjDetails {
   void sincosint(double x, double& sint, double& cint);  //! Private version of the cosine and sine integral

--- a/SimMuon/CSCDigitizer/src/CSCStripElectronicsSim.cc
+++ b/SimMuon/CSCDigitizer/src/CSCStripElectronicsSim.cc
@@ -14,7 +14,6 @@
 #include "CLHEP/Units/GlobalPhysicalConstants.h"
 #include "CLHEP/Units/GlobalSystemOfUnits.h"
 
-#include "boost/bind.hpp"
 #include <cassert>
 #include <list>
 

--- a/Validation/MuonRPCGeometry/test/RPCHistos.cc
+++ b/Validation/MuonRPCGeometry/test/RPCHistos.cc
@@ -11,7 +11,6 @@
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "L1Trigger/RPCTrigger/interface/RPCConst.h"
 #include "FWCore/Utilities/interface/Exception.h"
-//#include "boost/bind.hpp"
 
 const double ptRanges[RPCConst::m_PT_CODE_MAX+2]= {
                         0.0, 0.01,  


### PR DESCRIPTION
#### PR description:

In this case we can use std::bind instead of boost::bind

#### PR validation:

Passed on basic runTheMatrix test.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:
@vgvassilev @davidlange6
