### PR TITLE
DRAFT: nano: adaptation to run in Prompt

### DIFF
--- a/Configuration/Eras/python/Modifier_run3_nanoAOD_devel_cff.py
+++ b/Configuration/Eras/python/Modifier_run3_nanoAOD_devel_cff.py
@@ -1,0 +1,3 @@
+import FWCore.ParameterSet.Config as cms
+
+run3_nanoAOD_devel = cms.Modifier()

--- a/Configuration/StandardSequences/python/Eras.py
+++ b/Configuration/StandardSequences/python/Eras.py
@@ -72,7 +72,7 @@ class Eras (object):
                            'trackingLowPU', 'trackingPhase1', 'ctpps', 'ctpps_2016', 'ctpps_2017', 'ctpps_2018', 'ctpps_2021', 'trackingPhase2PU140','highBetaStar_2018',
                            'tracker_apv_vfp30_2016', 'pf_badHcalMitigationOff', 'run2_miniAOD_80XLegacy','run2_miniAOD_94XFall17', 'run2_nanoAOD_92X',
                            'run2_nanoAOD_94XMiniAODv1', 'run2_nanoAOD_94XMiniAODv2', 'run2_nanoAOD_94X2016',
-                           'run2_miniAOD_devel', 'run2_nanoAOD_102Xv1', 'run2_nanoAOD_106Xv1', 'run2_nanoAOD_106Xv2',
+                           'run2_miniAOD_devel', 'run2_nanoAOD_102Xv1', 'run2_nanoAOD_106Xv1', 'run2_nanoAOD_106Xv2', 'run3_nanoAOD_devel',
                            'hcalHardcodeConditions', 'hcalSkipPacker',
                            'run2_HLTconditions_2016','run2_HLTconditions_2017','run2_HLTconditions_2018',
                            'bParking']

--- a/PhysicsTools/NanoAOD/python/boostedTaus_cff.py
+++ b/PhysicsTools/NanoAOD/python/boostedTaus_cff.py
@@ -79,8 +79,3 @@ _modifiers = (run2_miniAOD_80XLegacy | run2_nanoAOD_92X | run2_nanoAOD_94XMiniAO
 (_modifiers).toReplaceWith(boostedTauTask,cms.Task())
 (_modifiers).toReplaceWith(boostedTauTablesTask,cms.Task())
 (_modifiers).toReplaceWith(boostedTauMCTask,cms.Task())
-
-# TEMPORARY for Run3 and run2_nanoAOD_106Xv2
-(run3_nanoAOD_devel | run2_nanoAOD_106Xv2).toReplaceWith(boostedTauTask,cms.Task())
-(run3_nanoAOD_devel | run2_nanoAOD_106Xv2).toReplaceWith(boostedTauTablesTask,cms.Task())
-(run3_nanoAOD_devel | run2_nanoAOD_106Xv2).toReplaceWith(boostedTauMCTask,cms.Task())

--- a/PhysicsTools/NanoAOD/python/boostedTaus_cff.py
+++ b/PhysicsTools/NanoAOD/python/boostedTaus_cff.py
@@ -70,5 +70,6 @@ boostedTauMCTable = tauMCTable.clone(
 
 boostedTauSequence = cms.Sequence(finalBoostedTaus)
 boostedTauTables = cms.Sequence(boostedTauTable)
-boostedTauMC = cms.Sequence(boostedTausMCMatchLepTauForTable + boostedTausMCMatchHadTauForTable + boostedTauMCTable)
 
+boostedTauMCTask = cms.Task(boostedTausMCMatchLepTauForTable,boostedTausMCMatchHadTauForTable,boostedTauMCTable)
+boostedTauMC = cms.Sequence(boostedTauMCTask)

--- a/PhysicsTools/NanoAOD/python/boostedTaus_cff.py
+++ b/PhysicsTools/NanoAOD/python/boostedTaus_cff.py
@@ -69,15 +69,18 @@ boostedTauMCTable = tauMCTable.clone(
 )
 
 
-boostedTauSequence = cms.Sequence(finalBoostedTaus)
-boostedTauTables = cms.Sequence(boostedTauTable)
-
+boostedTauTask = cms.Task(finalBoostedTaus)
+boostedTauTablesTask = cms.Task(boostedTauTable)
 boostedTauMCTask = cms.Task(boostedTausMCMatchLepTauForTable,boostedTausMCMatchHadTauForTable,boostedTauMCTable)
-boostedTauMC = cms.Sequence(boostedTauMCTask)
 
 #remove boosted tau from previous eras
 _modifiers = (run2_miniAOD_80XLegacy | run2_nanoAOD_92X | run2_nanoAOD_94XMiniAODv1 | run2_nanoAOD_94X2016 | run2_nanoAOD_94XMiniAODv2 | run2_nanoAOD_102Xv1 | run2_nanoAOD_106Xv1)
 
-(_modifiers).toReplaceWith(boostedTauSequence,cms.Sequence())
-(_modifiers).toReplaceWith(boostedTauTables,cms.Sequence())
-(_modifiers).toReplaceWith(boostedTauMC,cms.Sequence())
+(_modifiers).toReplaceWith(boostedTauTask,cms.Task())
+(_modifiers).toReplaceWith(boostedTauTablesTask,cms.Task())
+(_modifiers).toReplaceWith(boostedTauMCTask,cms.Task())
+
+# TEMPORARY for Run3 and run2_nanoAOD_106Xv2
+(run3_nanoAOD_devel | run2_nanoAOD_106Xv2).toReplaceWith(boostedTauTask,cms.Task())
+(run3_nanoAOD_devel | run2_nanoAOD_106Xv2).toReplaceWith(boostedTauTablesTask,cms.Task())
+(run3_nanoAOD_devel | run2_nanoAOD_106Xv2).toReplaceWith(boostedTauMCTask,cms.Task())

--- a/PhysicsTools/NanoAOD/python/boostedTaus_cff.py
+++ b/PhysicsTools/NanoAOD/python/boostedTaus_cff.py
@@ -1,5 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 from PhysicsTools.NanoAOD.common_cff import *
+from PhysicsTools.NanoAOD.nano_eras_cff import *
 
 ##################### Import reusable funtions and objects from std taus ########
 from PhysicsTools.NanoAOD.taus_cff import _tauId2WPMask,_tauId5WPMask,_tauId7WPMask,tausMCMatchLepTauForTable,tausMCMatchHadTauForTable,tauMCTable
@@ -73,3 +74,10 @@ boostedTauTables = cms.Sequence(boostedTauTable)
 
 boostedTauMCTask = cms.Task(boostedTausMCMatchLepTauForTable,boostedTausMCMatchHadTauForTable,boostedTauMCTable)
 boostedTauMC = cms.Sequence(boostedTauMCTask)
+
+#remove boosted tau from previous eras
+_modifiers = (run2_miniAOD_80XLegacy | run2_nanoAOD_92X | run2_nanoAOD_94XMiniAODv1 | run2_nanoAOD_94X2016 | run2_nanoAOD_94XMiniAODv2 | run2_nanoAOD_102Xv1 | run2_nanoAOD_106Xv1)
+
+(_modifiers).toReplaceWith(boostedTauSequence,cms.Sequence())
+(_modifiers).toReplaceWith(boostedTauTables,cms.Sequence())
+(_modifiers).toReplaceWith(boostedTauMC,cms.Sequence())

--- a/PhysicsTools/NanoAOD/python/btagWeightTable_cff.py
+++ b/PhysicsTools/NanoAOD/python/btagWeightTable_cff.py
@@ -1,0 +1,41 @@
+import FWCore.ParameterSet.Config as cms
+from PhysicsTools.NanoAOD.common_cff import *
+from PhysicsTools.NanoAOD.nano_eras_cff import *
+
+
+btagSFdir="PhysicsTools/NanoAOD/data/btagSF/"
+
+btagWeightTable = cms.EDProducer("BTagSFProducer",
+    src = cms.InputTag("linkedObjects","jets"),
+    cut = cms.string("pt > 25. && abs(eta) < 2.5"),
+    discNames = cms.vstring(
+        "pfCombinedInclusiveSecondaryVertexV2BJetTags",
+        "pfDeepCSVJetTags:probb+pfDeepCSVJetTags:probbb",       #if multiple MiniAOD branches need to be summed up (e.g., DeepCSV b+bb), separate them using '+' delimiter
+        "pfCombinedMVAV2BJetTags"
+    ),
+    discShortNames = cms.vstring(
+        "CSVV2",
+        "DeepCSVB",
+        "CMVA"
+    ),
+    weightFiles = cms.vstring(                                  #default settings are for 2017 94X. toModify function is called later for other eras.
+        btagSFdir+"CSVv2_94XSF_V2_B_F.csv",
+        btagSFdir+"DeepCSV_94XSF_V2_B_F.csv",
+        "unavailable"                                           #if SFs for an algorithm in an era is unavailable, the corresponding branch will not be stored
+    ),
+    operatingPoints = cms.vstring("3","3","3"),                 #loose = 0, medium = 1, tight = 2, reshaping = 3
+    measurementTypesB = cms.vstring("iterativefit","iterativefit","iterativefit"),     #e.g. "comb", "incl", "ttbar", "iterativefit"
+    measurementTypesC = cms.vstring("iterativefit","iterativefit","iterativefit"),
+    measurementTypesUDSG = cms.vstring("iterativefit","iterativefit","iterativefit"),
+    sysTypes = cms.vstring("central","central","central")
+)
+
+for modifier in run2_miniAOD_80XLegacy, run2_nanoAOD_94X2016: # to be updated when SF for Summer16MiniAODv3 MC will be available
+    modifier.toModify(btagWeightTable,
+        cut = cms.string("pt > 25. && abs(eta) < 2.4"),             #80X corresponds to 2016, |eta| < 2.4
+        weightFiles = cms.vstring(                                  #80X corresponds to 2016 SFs
+            btagSFdir+"CSVv2_Moriond17_B_H.csv",
+            "unavailable",
+            btagSFdir+"cMVAv2_Moriond17_B_H.csv"
+        )
+    )

--- a/PhysicsTools/NanoAOD/python/btagWeightTable_cff.py
+++ b/PhysicsTools/NanoAOD/python/btagWeightTable_cff.py
@@ -39,3 +39,5 @@ for modifier in run2_miniAOD_80XLegacy, run2_nanoAOD_94X2016: # to be updated wh
             btagSFdir+"cMVAv2_Moriond17_B_H.csv"
         )
     )
+
+btagWeightTableTask = cms.Task(btagWeightTable)

--- a/PhysicsTools/NanoAOD/python/electrons_cff.py
+++ b/PhysicsTools/NanoAOD/python/electrons_cff.py
@@ -215,7 +215,6 @@ slimmedElectronsWithUserData = cms.EDProducer("PATElectronUserDataEmbedder",
 
     ),
     userIntFromBools = cms.PSet(
-
         mvaFall17V1Iso_WP90 = cms.InputTag("egmGsfElectronIDs:mvaEleID-Fall17-iso-V1-wp90"),
         mvaFall17V1Iso_WP80 = cms.InputTag("egmGsfElectronIDs:mvaEleID-Fall17-iso-V1-wp80"),
         mvaFall17V1Iso_WPL = cms.InputTag("egmGsfElectronIDs:mvaEleID-Fall17-iso-V1-wpLoose"),
@@ -412,19 +411,9 @@ for modifier in run2_nanoAOD_94XMiniAODv1,run2_nanoAOD_94XMiniAODv2,run2_miniAOD
         dEsigmaUp=Var("userFloat('ecalTrkEnergyPostCorrNew')-userFloat('energySigmaUpNew')", float, doc="ecal energy smearing value shifted 1 sigma up", precision=8),
         dEsigmaDown=Var("userFloat('ecalTrkEnergyPostCorrNew')-userFloat('energySigmaDownNew')", float,  doc="ecal energy smearing value shifted 1 sigma up", precision=8),
 
-)
-##Keeping the possibilty of using V1 working points in older eras
-(run2_nanoAOD_92X | run2_nanoAOD_94XMiniAODv1 | run2_nanoAOD_94XMiniAODv2 | run2_nanoAOD_94X2016 | run2_nanoAOD_102Xv1).toModify(electronTable.variables,
-        mvaFall17V1Iso = Var("userFloat('mvaFall17V1Iso')",float,doc="MVA Iso ID V1 score"),
-        mvaFall17V1Iso_WP80 = Var("userInt('mvaFall17V1Iso_WP80')",bool,doc="MVA Iso ID V1 WP80"),
-        mvaFall17V1Iso_WP90 = Var("userInt('mvaFall17V1Iso_WP90')",bool,doc="MVA Iso ID V1 WP90"),
-        mvaFall17V1Iso_WPL = Var("userInt('mvaFall17V1Iso_WPL')",bool,doc="MVA Iso ID V1 loose WP"),
-        mvaFall17V1noIso = Var("userFloat('mvaFall17V1noIso')",float,doc="MVA noIso ID V1 score"),
-        mvaFall17V1noIso_WP80 = Var("userInt('mvaFall17V1noIso_WP80')",bool,doc="MVA noIso ID V1 WP80"),
-        mvaFall17V1noIso_WP90 = Var("userInt('mvaFall17V1noIso_WP90')",bool,doc="MVA noIso ID V1 WP90"),
-        mvaFall17V1noIso_WPL = Var("userInt('mvaFall17V1noIso_WPL')",bool,doc="MVA noIso ID V1 loose WP"),
         cutBased_Fall17_V1 = Var("userInt('cutbasedID_Fall17_V1_veto')+userInt('cutbasedID_Fall17_V1_loose')+userInt('cutbasedID_Fall17_V1_medium')+userInt('cutbasedID_Fall17_V1_tight')",int,doc="cut-based ID Fall17 V1 (0:fail, 1:veto, 2:loose, 3:medium, 4:tight)"),
-)
+    )
+
 #the94X miniAOD V2 had a bug in the scale and smearing for electrons in the E/p comb
 #therefore we redo it but but we need use a new name for the userFloat as we cant override existing userfloats
 # scale and smearing only when available#ONLY needed for this era
@@ -527,20 +516,47 @@ electronMCTable = cms.EDProducer("CandMCMatchTableProducer",
     genparticles     = cms.InputTag("finalGenParticles"), 
 )
 
-electronTask = cms.Task(bitmapVIDForEle,bitmapVIDForEleHEEP,isoForEle,ptRatioRelForEle,seedGainEle,slimmedElectronsWithUserData,finalElectrons)
+electronTask = cms.Task(bitmapVIDForEle,bitmapVIDForEleHEEP,isoForEle,ptRatioRelForEle,seedGainEle,calibratedPatElectronsNano,slimmedElectronsWithUserData,finalElectrons)
 electronTablesTask = cms.Task(electronMVATTH,electronTable)
 electronMCTask = cms.Task(particleLevelForMatching,tautaggerForMatching,matchingElecPhoton,electronsMCMatchForTable,electronsMCMatchForTableAlt,electronMCTable)
-# temporary keep to all replacement below
-electronSequence = cms.Sequence(bitmapVIDForEle + bitmapVIDForEleHEEP + isoForEle + ptRatioRelForEle + seedGainEle + slimmedElectronsWithUserData + finalElectrons)
 
-#### TEMPORARY Run3
-(~run3_nanoAOD_devel | run3_nanoAOD_devel).toModify(finalElectrons,src = cms.InputTag("slimmedElectrons"))
-(~run3_nanoAOD_devel | run3_nanoAOD_devel).toReplaceWith(electronTask, cms.Task(finalElectrons))
-(~run3_nanoAOD_devel | run3_nanoAOD_devel).toReplaceWith(electronTablesTask, cms.Task(electronTable))
-(~run3_nanoAOD_devel | run3_nanoAOD_devel).toModify(electronTable, variables = cms.PSet(CandVars))
-(~run3_nanoAOD_devel | run3_nanoAOD_devel).toModify(electronTable, externalVariables = None)
+## TEMPORARY
+## OFF because not able to re-run the VID
+(run3_nanoAOD_devel | ~run3_nanoAOD_devel).toReplaceWith(electronTask, electronTask.copyAndExclude([bitmapVIDForEle,bitmapVIDForEleHEEP]))
+(run3_nanoAOD_devel | ~run3_nanoAOD_devel).toModify(slimmedElectronsWithUserData, userIntFromBools = cms.PSet())
+(run3_nanoAOD_devel | ~run3_nanoAOD_devel).toModify(slimmedElectronsWithUserData.userInts,
+                                                    VIDNestedWPBitmap = None,
+                                                    VIDNestedWPBitmapHEEP = None)
+(run3_nanoAOD_devel | ~run3_nanoAOD_devel).toModify(slimmedElectronsWithUserData.userFloats,
+                                                    mvaFall17V1Iso = None,
+                                                    mvaFall17V1noIso = None,
+                                                    mvaFall17V2Iso = None,
+                                                    mvaFall17V2noIso = None,
+)
+(run3_nanoAOD_devel | ~run3_nanoAOD_devel).toModify(electronTable.variables,
+                                                    mvaFall17V2Iso = None,
+                                                    mvaFall17V2Iso_WP80 = None,
+                                                    mvaFall17V2Iso_WP90 = None,
+                                                    mvaFall17V2Iso_WPL = None,
+                                                    mvaFall17V2noIso = None,
+                                                    mvaFall17V2noIso_WP80 = None,
+                                                    mvaFall17V2noIso_WP90 = None,
+                                                    mvaFall17V2noIso_WPL = None,
+                                                    vidNestedWPBitmapHEEP = None,
+                                                    vidNestedWPBitmap = None,
+                                                    cutBased = None,
+                                                    cutBased_HEEP = None,
+                                                )
 
-#for NANO from reminAOD, no need to run slimmedElectronsUpdated, other modules of electron sequence will run on slimmedElectrons
+(run3_nanoAOD_devel | ~run3_nanoAOD_devel).toReplaceWith(electronTablesTask, electronTablesTask.copyAndExclude([electronMVATTH]))
+(run3_nanoAOD_devel | ~run3_nanoAOD_devel).toModify(electronTable, externalVariables = None)
+
+(run2_nanoAOD_94XMiniAODv1 | run2_nanoAOD_94XMiniAODv2 | run2_miniAOD_80XLegacy | run2_nanoAOD_102Xv1 | run2_nanoAOD_106Xv1 | run2_nanoAOD_106Xv2 | run2_nanoAOD_94X2016).toModify(electronTable.variables, cutBased_Fall17_V1 = None,
+)
+
+##### end TEMPORARY Run3
+
+##for NANO from reminAOD, no need to run slimmedElectronsUpdated, other modules of electron sequence will run on slimmedElectrons
 for modifier in run2_miniAOD_80XLegacy,run2_nanoAOD_94XMiniAODv1,run2_nanoAOD_94XMiniAODv2,run2_nanoAOD_94X2016,run2_nanoAOD_102Xv1,run2_nanoAOD_106Xv1:
     modifier.toModify(bitmapVIDForEle, src = "slimmedElectronsUpdated")
     modifier.toModify(bitmapVIDForEleSpring15, src = "slimmedElectronsUpdated")
@@ -552,21 +568,23 @@ for modifier in run2_miniAOD_80XLegacy,run2_nanoAOD_94XMiniAODv1,run2_nanoAOD_94
     modifier.toModify(slimmedElectronsWithUserData, src = "slimmedElectronsUpdated")
     modifier.toModify(calibratedPatElectronsNano, src = "slimmedElectronsUpdated")
     ###this sequence should run for all eras except run2_nanoAOD_106Xv2 which should run the electronSequence as above
-    _withULAndUpdate_sequence = cms.Sequence(slimmedElectronsUpdated + electronSequence.copy())
-    modifier.toReplaceWith(electronSequence, _withULAndUpdate_sequence)
-    
+    _withULAndUpdate_Task = cms.Task(slimmedElectronsUpdated)
+    _withULAndUpdate_Task.add(electronTask.copy())
+    modifier.toReplaceWith(electronTask, _withULAndUpdate_Task)
+
+
 from RecoEgamma.ElectronIdentification.heepIdVarValueMapProducer_cfi import heepIDVarValueMaps
-_updateTo106X_sequence =cms.Sequence(heepIDVarValueMaps + slimmedElectronsTo106X)
+_withTo106XAndUpdate_Task = cms.Task(heepIDVarValueMaps,slimmedElectronsTo106X)
+_withTo106XAndUpdate_Task.add(electronTask.copy())
 heepIDVarValueMaps.dataFormat = 2
-_withTo106XAndUpdate_sequence = cms.Sequence(_updateTo106X_sequence + electronSequence.copy())
+for modifier in run2_nanoAOD_94XMiniAODv2, run2_nanoAOD_94X2016, run2_nanoAOD_102Xv1, run2_nanoAOD_94XMiniAODv1:
+    modifier.toReplaceWith(electronTask, _withTo106XAndUpdate_Task )
 
 for modifier in run2_miniAOD_80XLegacy, run2_nanoAOD_94X2016:
-    _withTo106XAndUpdateAnd80XLegacyScale_sequence = _withTo106XAndUpdate_sequence.copy()
-    _withTo106XAndUpdateAnd80XLegacyScale_sequence.replace(slimmedElectronsWithUserData, bitmapVIDForEleSpring15 +bitmapVIDForEleSum16 + slimmedElectronsWithUserData)
-    modifier.toReplaceWith(electronSequence, _withTo106XAndUpdateAnd80XLegacyScale_sequence)
+    _withTo106XAndUpdateAnd80XLegacyScale_Task = _withTo106XAndUpdate_Task.copy()
+#    _withTo106XAndUpdateAnd80XLegacyScale_sequence.Task(slimmedElectronsWithUserData, bitmapVIDForEleSpring15 +bitmapVIDForEleSum16 + slimmedElectronsWithUserData)
+    modifier.toReplaceWith(electronTask, _withTo106XAndUpdateAnd80XLegacyScale_Task)
 
-_withTo106XAndUpdateAnd94XScale_sequence = _withTo106XAndUpdate_sequence.copy()
+_withTo106XAndUpdateAnd94XScale_Task = _withTo106XAndUpdate_Task.copy()
 for modifier in run2_nanoAOD_94XMiniAODv1, run2_nanoAOD_94XMiniAODv2,run2_nanoAOD_102Xv1:
-    modifier.toReplaceWith(electronSequence, _withTo106XAndUpdate_sequence)
-
-electronSequence.replace(slimmedElectronsWithUserData,calibratedPatElectronsNano + slimmedElectronsWithUserData)
+    modifier.toReplaceWith(electronTask, _withTo106XAndUpdate_Task)

--- a/PhysicsTools/NanoAOD/python/electrons_cff.py
+++ b/PhysicsTools/NanoAOD/python/electrons_cff.py
@@ -527,17 +527,18 @@ electronMCTable = cms.EDProducer("CandMCMatchTableProducer",
     genparticles     = cms.InputTag("finalGenParticles"), 
 )
 
+electronTask = cms.Task(bitmapVIDForEle,bitmapVIDForEleHEEP,isoForEle,ptRatioRelForEle,seedGainEle,slimmedElectronsWithUserData,finalElectrons)
+electronTablesTask = cms.Task(electronMVATTH,electronTable)
+electronMCTask = cms.Task(particleLevelForMatching,tautaggerForMatching,matchingElecPhoton,electronsMCMatchForTable,electronsMCMatchForTableAlt,electronMCTable)
+# temporary keep to all replacement below
 electronSequence = cms.Sequence(bitmapVIDForEle + bitmapVIDForEleHEEP + isoForEle + ptRatioRelForEle + seedGainEle + slimmedElectronsWithUserData + finalElectrons)
-electronTables = cms.Sequence (electronMVATTH + electronTable)
-electronMC = cms.Sequence(particleLevelForMatching + tautaggerForMatching + matchingElecPhoton + electronsMCMatchForTable + electronsMCMatchForTableAlt + electronMCTable)
 
 #### TEMPORARY Run3
-(run3_nanoAOD_devel).toModify(finalElectrons,src = cms.InputTag("slimmedElectrons"))
-(run3_nanoAOD_devel).toReplaceWith(electronSequence, cms.Sequence(finalElectrons))
-(run3_nanoAOD_devel).toReplaceWith(electronTables, cms.Sequence(electronTable))
-(run3_nanoAOD_devel).toModify(electronTable, variables = cms.PSet(CandVars))
-(run3_nanoAOD_devel).toModify(electronTable, externalVariables = None)
-
+(~run3_nanoAOD_devel | run3_nanoAOD_devel).toModify(finalElectrons,src = cms.InputTag("slimmedElectrons"))
+(~run3_nanoAOD_devel | run3_nanoAOD_devel).toReplaceWith(electronTask, cms.Task(finalElectrons))
+(~run3_nanoAOD_devel | run3_nanoAOD_devel).toReplaceWith(electronTablesTask, cms.Task(electronTable))
+(~run3_nanoAOD_devel | run3_nanoAOD_devel).toModify(electronTable, variables = cms.PSet(CandVars))
+(~run3_nanoAOD_devel | run3_nanoAOD_devel).toModify(electronTable, externalVariables = None)
 
 #for NANO from reminAOD, no need to run slimmedElectronsUpdated, other modules of electron sequence will run on slimmedElectrons
 for modifier in run2_miniAOD_80XLegacy,run2_nanoAOD_94XMiniAODv1,run2_nanoAOD_94XMiniAODv2,run2_nanoAOD_94X2016,run2_nanoAOD_102Xv1,run2_nanoAOD_106Xv1:

--- a/PhysicsTools/NanoAOD/python/electrons_cff.py
+++ b/PhysicsTools/NanoAOD/python/electrons_cff.py
@@ -36,6 +36,7 @@ run2_miniAOD_80XLegacy.toModify( slimmedElectronsUpdated, computeMiniIso = True 
 ##modify the past eras
 for modifier in run2_miniAOD_80XLegacy,run2_nanoAOD_94X2016,run2_nanoAOD_94XMiniAODv1,run2_nanoAOD_94XMiniAODv2,run2_nanoAOD_102Xv1:
     modifier.toModify(slimmedElectronsUpdated, src = cms.InputTag("slimmedElectronsTo106X"))
+
 ############################FOR bitmapVIDForEle main defn#############################
 electron_id_modules_WorkingPoints_nanoAOD = cms.PSet(
     modules = cms.vstring(
@@ -398,6 +399,7 @@ electronTable = cms.EDProducer("SimpleCandidateFlatTableProducer",
     ),
 )
 
+
 #for technical reasons
 for modifier in run2_nanoAOD_94XMiniAODv1,run2_nanoAOD_94XMiniAODv2,run2_miniAOD_80XLegacy,run2_nanoAOD_102Xv1,run2_nanoAOD_106Xv1,run2_nanoAOD_106Xv2:
     modifier.toModify(electronTable.variables,            
@@ -528,6 +530,14 @@ electronMCTable = cms.EDProducer("CandMCMatchTableProducer",
 electronSequence = cms.Sequence(bitmapVIDForEle + bitmapVIDForEleHEEP + isoForEle + ptRatioRelForEle + seedGainEle + slimmedElectronsWithUserData + finalElectrons)
 electronTables = cms.Sequence (electronMVATTH + electronTable)
 electronMC = cms.Sequence(particleLevelForMatching + tautaggerForMatching + matchingElecPhoton + electronsMCMatchForTable + electronsMCMatchForTableAlt + electronMCTable)
+
+#### TEMPORARY Run3
+(run3_nanoAOD_devel).toModify(finalElectrons,src = cms.InputTag("slimmedElectrons"))
+(run3_nanoAOD_devel).toReplaceWith(electronSequence, cms.Sequence(finalElectrons))
+(run3_nanoAOD_devel).toReplaceWith(electronTables, cms.Sequence(electronTable))
+(run3_nanoAOD_devel).toModify(electronTable, variables = cms.PSet(CandVars))
+(run3_nanoAOD_devel).toModify(electronTable, externalVariables = None)
+
 
 #for NANO from reminAOD, no need to run slimmedElectronsUpdated, other modules of electron sequence will run on slimmedElectrons
 for modifier in run2_miniAOD_80XLegacy,run2_nanoAOD_94XMiniAODv1,run2_nanoAOD_94XMiniAODv2,run2_nanoAOD_94X2016,run2_nanoAOD_102Xv1,run2_nanoAOD_106Xv1:

--- a/PhysicsTools/NanoAOD/python/extraflags_cff.py
+++ b/PhysicsTools/NanoAOD/python/extraflags_cff.py
@@ -1,5 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 from PhysicsTools.NanoAOD.common_cff import *
+from PhysicsTools.NanoAOD.nano_eras_cff import *
 
 # Bad/clone muon filters - tagging mode to keep the event
 from RecoMET.METFilters.badGlobalMuonTaggersMiniAOD_cff import badGlobalMuonTaggerMAOD, cloneGlobalMuonTaggerMAOD
@@ -37,12 +38,27 @@ extraFlagsTable = cms.EDProducer("GlobalVariablesTableProducer",
     )
 )
 
-extraFlagsProducersTask = cms.Task(badGlobalMuonTagger,cloneGlobalMuonTagger,BadPFMuonTagger,BadChargedCandidateTagger)
-extraFlagsProducers = cms.Sequence(extraFlagsProducersTask)
-
 from RecoMET.METFilters.ecalBadCalibFilter_cfi import *
 ecalBadCalibFilterNanoTagger = ecalBadCalibFilter.clone(
     taggingMode = cms.bool(True)
 )
 
-extraFlagsProducers102x = cms.Sequence(ecalBadCalibFilterNanoTagger)
+# modify extraFlagsTable to store ecalBadCalibFilter decision which is re-run with updated bad crystal list for 2017 and 2018 samples
+for modifier in run2_nanoAOD_94XMiniAODv1, run2_nanoAOD_94XMiniAODv2, run2_nanoAOD_102Xv1:
+    modifier.toModify(extraFlagsTable, variables= cms.PSet())
+    modifier.toModify(extraFlagsTable, variables = dict(Flag_ecalBadCalibFilterV2 = ExtVar(cms.InputTag("ecalBadCalibFilterNanoTagger"), bool, doc = "Bad ECAL calib flag (updatedxtal list)")))
+
+
+# empty task as default
+extraFlagsProducersTask = cms.Task()
+extraFlagsTableTask = cms.Task()
+
+## those need to be added only for some specific eras
+extraFlagsProducersTask_80x = cms.Task(badGlobalMuonTagger,cloneGlobalMuonTagger,BadPFMuonTagger,BadChargedCandidateTagger)
+extraFlagsProducersTask_102x = cms.Task(ecalBadCalibFilterNanoTagger)
+
+run2_miniAOD_80XLegacy.toReplaceWith(extraFlagsProducersTask, extraFlagsProducersTask_80x)
+run2_miniAOD_80XLegacy.toReplaceWith(extraFlagsTableTask, cms.Task(extraFlagsTable))
+
+(run2_nanoAOD_94XMiniAODv1 | run2_nanoAOD_94XMiniAODv2 | run2_nanoAOD_102Xv1).toReplaceWith(extraFlagsProducersTask, extraFlagsProducersTask_102x)
+(run2_nanoAOD_94XMiniAODv1 | run2_nanoAOD_94XMiniAODv2 | run2_nanoAOD_102Xv1).toReplaceWith(extraFlagsTableTask, cms.Task(extraFlagsTable))

--- a/PhysicsTools/NanoAOD/python/extraflags_cff.py
+++ b/PhysicsTools/NanoAOD/python/extraflags_cff.py
@@ -37,7 +37,8 @@ extraFlagsTable = cms.EDProducer("GlobalVariablesTableProducer",
     )
 )
 
-extraFlagsProducers = cms.Sequence(badGlobalMuonTagger + cloneGlobalMuonTagger + BadPFMuonTagger + BadChargedCandidateTagger)
+extraFlagsProducersTask = cms.Task(badGlobalMuonTagger,cloneGlobalMuonTagger,BadPFMuonTagger,BadChargedCandidateTagger)
+extraFlagsProducers = cms.Sequence(extraFlagsProducersTask)
 
 from RecoMET.METFilters.ecalBadCalibFilter_cfi import *
 ecalBadCalibFilterNanoTagger = ecalBadCalibFilter.clone(

--- a/PhysicsTools/NanoAOD/python/genVertex_cff.py
+++ b/PhysicsTools/NanoAOD/python/genVertex_cff.py
@@ -10,7 +10,7 @@ genVertexTable = cms.EDProducer("SimpleXYZPointFlatTableProducer",
     singleton = cms.bool(True), 
     extension = cms.bool(False), 
     variables = cms.PSet(
-         x  = Var("X", float, doc="gen vertex x", precision=10),
+         x = Var("X", float, doc="gen vertex x", precision=10),
          y = Var("Y", float, doc="gen vertex y", precision=10),
          z = Var("Z", float, doc="gen vertex z", precision=16),
     ) 
@@ -27,7 +27,5 @@ genVertexT0Table = cms.EDProducer("GlobalVariablesTableProducer",
 genVertexTablesTask = cms.Task(genVertexTable,genVertexT0Table)
 
 # GenVertex only stored in newer MiniAOD
-(run2_nanoAOD_92X | run2_miniAOD_80XLegacy | run2_nanoAOD_94X2016 | run2_nanoAOD_94X2016 | \
-    run2_nanoAOD_94XMiniAODv1 | run2_nanoAOD_94XMiniAODv2 | \
-    run2_nanoAOD_102Xv1).toReplaceWith(genVertexTablesTask,cms.Task(genVertexTable))
+(run2_nanoAOD_92X | run2_miniAOD_80XLegacy | run2_nanoAOD_94X2016 | run2_nanoAOD_94XMiniAODv1 | run2_nanoAOD_94XMiniAODv2 | run2_nanoAOD_102Xv1).toReplaceWith(genVertexTablesTask,cms.Task())    
 

--- a/PhysicsTools/NanoAOD/python/genVertex_cff.py
+++ b/PhysicsTools/NanoAOD/python/genVertex_cff.py
@@ -26,6 +26,7 @@ genVertexT0Table = cms.EDProducer("GlobalVariablesTableProducer",
 
 genVertexTablesTask = cms.Task(genVertexTable,genVertexT0Table)
 
+# GenVertex only stored in newer MiniAOD
 (run2_nanoAOD_92X | run2_miniAOD_80XLegacy | run2_nanoAOD_94X2016 | run2_nanoAOD_94X2016 | \
     run2_nanoAOD_94XMiniAODv1 | run2_nanoAOD_94XMiniAODv2 | \
     run2_nanoAOD_102Xv1).toReplaceWith(genVertexTablesTask,cms.Task(genVertexTable))

--- a/PhysicsTools/NanoAOD/python/genVertex_cff.py
+++ b/PhysicsTools/NanoAOD/python/genVertex_cff.py
@@ -23,4 +23,5 @@ genVertexT0Table = cms.EDProducer("GlobalVariablesTableProducer",
     )
 )
 
-genVertexTables = cms.Sequence(genVertexTable+genVertexT0Table)
+genVertexTablesTask = cms.Task(genVertexTable,genVertexT0Table)
+genVertexTables = cms.Sequence(genVertexTablesTask)

--- a/PhysicsTools/NanoAOD/python/genVertex_cff.py
+++ b/PhysicsTools/NanoAOD/python/genVertex_cff.py
@@ -30,5 +30,3 @@ genVertexTablesTask = cms.Task(genVertexTable,genVertexT0Table)
     run2_nanoAOD_94XMiniAODv1 | run2_nanoAOD_94XMiniAODv2 | \
     run2_nanoAOD_102Xv1).toReplaceWith(genVertexTablesTask,cms.Task(genVertexTable))
 
-genVertexTables = cms.Sequence(genVertexTablesTask)
-

--- a/PhysicsTools/NanoAOD/python/genVertex_cff.py
+++ b/PhysicsTools/NanoAOD/python/genVertex_cff.py
@@ -1,5 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 from PhysicsTools.NanoAOD.common_cff import Var,ExtVar
+from PhysicsTools.NanoAOD.nano_eras_cff import *
 
 genVertexTable = cms.EDProducer("SimpleXYZPointFlatTableProducer",
     src = cms.InputTag("genParticles:xyz0"),
@@ -24,4 +25,10 @@ genVertexT0Table = cms.EDProducer("GlobalVariablesTableProducer",
 )
 
 genVertexTablesTask = cms.Task(genVertexTable,genVertexT0Table)
+
+(run2_nanoAOD_92X | run2_miniAOD_80XLegacy | run2_nanoAOD_94X2016 | run2_nanoAOD_94X2016 | \
+    run2_nanoAOD_94XMiniAODv1 | run2_nanoAOD_94XMiniAODv2 | \
+    run2_nanoAOD_102Xv1).toReplaceWith(genVertexTablesTask,cms.Task(genVertexTable))
+
 genVertexTables = cms.Sequence(genVertexTablesTask)
+

--- a/PhysicsTools/NanoAOD/python/genWeightsTable_cfi.py
+++ b/PhysicsTools/NanoAOD/python/genWeightsTable_cfi.py
@@ -26,3 +26,5 @@ genWeightsTable = cms.EDProducer("GenWeightsTableProducer",
     keepAllPSWeights = cms.bool(False),
     debug = cms.untracked.bool(False),
 )
+
+genWeightsTableTask = cms.Task(genWeightsTable)

--- a/PhysicsTools/NanoAOD/python/genparticles_cff.py
+++ b/PhysicsTools/NanoAOD/python/genparticles_cff.py
@@ -81,5 +81,5 @@ genParticleTable = cms.EDProducer("SimpleCandidateFlatTableProducer",
     )
 )
 
-genParticleSequence = cms.Sequence(finalGenParticles)
-genParticleTables = cms.Sequence(genParticleTable)
+genParticleTask = cms.Task(finalGenParticles)
+genParticleTablesTask = cms.Task(genParticleTable)

--- a/PhysicsTools/NanoAOD/python/globals_cff.py
+++ b/PhysicsTools/NanoAOD/python/globals_cff.py
@@ -38,5 +38,5 @@ genTable  = cms.EDProducer("SimpleGenEventFlatTableProducer",
         ),
 )
 
-globalTables = cms.Sequence(rhoTable)
-globalTablesMC = cms.Sequence(puTable+genTable)
+globalTablesTask = cms.Task(rhoTable)
+globalTablesMCTask = cms.Task(puTable,genTable)

--- a/PhysicsTools/NanoAOD/python/isotracks_cff.py
+++ b/PhysicsTools/NanoAOD/python/isotracks_cff.py
@@ -1,5 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 from PhysicsTools.NanoAOD.common_cff import *
+from PhysicsTools.NanoAOD.nano_eras_cff import *
 
 finalIsolatedTracks = cms.EDProducer("IsolatedTrackCleaner",
     tracks = cms.InputTag("isolatedTracks"),
@@ -53,3 +54,5 @@ isoTrackTask = cms.Task(finalIsolatedTracks,isoForIsoTk,isFromLostTrackForIsoTk)
 isoTrackSequence = cms.Sequence(isoTrackTask)
 isoTrackTables = cms.Sequence(isoTrackTable)
 
+run2_miniAOD_80XLegacy.toReplaceWith(isoTrackSequence, cms.Sequence())
+run2_miniAOD_80XLegacy.toReplaceWith(isoTrackTables,cms.Sequence())

--- a/PhysicsTools/NanoAOD/python/isotracks_cff.py
+++ b/PhysicsTools/NanoAOD/python/isotracks_cff.py
@@ -50,9 +50,7 @@ isoTrackTable = cms.EDProducer("SimpleCandidateFlatTableProducer",
 )
 
 isoTrackTask = cms.Task(finalIsolatedTracks,isoForIsoTk,isFromLostTrackForIsoTk)
+isoTrackTablesTask = cms.Task(isoTrackTable)
 
-isoTrackSequence = cms.Sequence(isoTrackTask)
-isoTrackTables = cms.Sequence(isoTrackTable)
-
-run2_miniAOD_80XLegacy.toReplaceWith(isoTrackSequence, cms.Sequence())
-run2_miniAOD_80XLegacy.toReplaceWith(isoTrackTables,cms.Sequence())
+run2_miniAOD_80XLegacy.toReplaceWith(isoTrackTask, cms.Task())
+run2_miniAOD_80XLegacy.toReplaceWith(isoTrackTablesTask,cms.Task())

--- a/PhysicsTools/NanoAOD/python/isotracks_cff.py
+++ b/PhysicsTools/NanoAOD/python/isotracks_cff.py
@@ -48,6 +48,8 @@ isoTrackTable = cms.EDProducer("SimpleCandidateFlatTableProducer",
     ),
 )
 
-isoTrackSequence = cms.Sequence(finalIsolatedTracks + isoForIsoTk + isFromLostTrackForIsoTk)
+isoTrackTask = cms.Task(finalIsolatedTracks,isoForIsoTk,isFromLostTrackForIsoTk)
+
+isoTrackSequence = cms.Sequence(isoTrackTask)
 isoTrackTables = cms.Sequence(isoTrackTable)
 

--- a/PhysicsTools/NanoAOD/python/jets_cff.py
+++ b/PhysicsTools/NanoAOD/python/jets_cff.py
@@ -611,7 +611,7 @@ genJetTable = cms.EDProducer("SimpleCandidateFlatTableProducer",
 	#anything else?
     )
 )
-patJetPartons = cms.EDProducer('HadronAndPartonSelector',
+patJetPartonsNano = cms.EDProducer('HadronAndPartonSelector',
     src = cms.InputTag("generator"),
     particles = cms.InputTag("prunedGenParticles"),
     partonMode = cms.string("Auto"),
@@ -619,10 +619,10 @@ patJetPartons = cms.EDProducer('HadronAndPartonSelector',
 )
 genJetFlavourAssociation = cms.EDProducer("JetFlavourClustering",
     jets = genJetTable.src,
-    bHadrons = cms.InputTag("patJetPartons","bHadrons"),
-    cHadrons = cms.InputTag("patJetPartons","cHadrons"),
-    partons = cms.InputTag("patJetPartons","physicsPartons"),
-    leptons = cms.InputTag("patJetPartons","leptons"),
+    bHadrons = cms.InputTag("patJetPartonsNano","bHadrons"),
+    cHadrons = cms.InputTag("patJetPartonsNano","cHadrons"),
+    partons = cms.InputTag("patJetPartonsNano","physicsPartons"),
+    leptons = cms.InputTag("patJetPartonsNano","leptons"),
     jetAlgorithm = cms.string("AntiKt"),
     rParam = cms.double(0.4),
     ghostRescaling = cms.double(1e-18),
@@ -649,10 +649,10 @@ genJetAK8Table = cms.EDProducer("SimpleCandidateFlatTableProducer",
 )
 genJetAK8FlavourAssociation = cms.EDProducer("JetFlavourClustering",
     jets = genJetAK8Table.src,
-    bHadrons = cms.InputTag("patJetPartons","bHadrons"),
-    cHadrons = cms.InputTag("patJetPartons","cHadrons"),
-    partons = cms.InputTag("patJetPartons","physicsPartons"),
-    leptons = cms.InputTag("patJetPartons","leptons"),
+    bHadrons = cms.InputTag("patJetPartonsNano","bHadrons"),
+    cHadrons = cms.InputTag("patJetPartonsNano","cHadrons"),
+    partons = cms.InputTag("patJetPartonsNano","physicsPartons"),
+    leptons = cms.InputTag("patJetPartonsNano","leptons"),
     jetAlgorithm = cms.string("AntiKt"),
     rParam = cms.double(0.8),
     ghostRescaling = cms.double(1e-18),
@@ -757,7 +757,7 @@ jetLepSequence = cms.Sequence(lepInJetVars)
 jetTables = cms.Sequence(bjetNN+cjetNN+jetTable+fatJetTable+subJetTable+saJetTable+saTable)
 
 #MC only producers and tables
-jetMC = cms.Sequence(jetMCTable+genJetTable+patJetPartons+genJetFlavourTable+genJetAK8Table+genJetAK8FlavourAssociation+genJetAK8FlavourTable+fatJetMCTable+genSubJetAK8Table+subjetMCTable)
+jetMC = cms.Sequence(jetMCTable+genJetTable+patJetPartonsNano+genJetFlavourTable+genJetAK8Table+genJetAK8FlavourAssociation+genJetAK8FlavourTable+fatJetMCTable+genSubJetAK8Table+subjetMCTable)
 _jetMC_pre94X = jetMC.copy()
 _jetMC_pre94X.insert(_jetMC_pre94X.index(genJetFlavourTable),genJetFlavourAssociation)
 _jetMC_pre94X.remove(genSubJetAK8Table)

--- a/PhysicsTools/NanoAOD/python/jets_cff.py
+++ b/PhysicsTools/NanoAOD/python/jets_cff.py
@@ -753,6 +753,7 @@ for modifier in run2_miniAOD_80XLegacy, run2_nanoAOD_94X2016, run2_nanoAOD_94XMi
   modifier.toModify( jetTable.variables, hfsigmaPhiPhi = Var("userFloat('hfsigmaPhiPhi')",float,doc="sigmaPhiPhi for HF jets (noise discriminating variable)",precision=10))
   modifier.toModify( jetTable.variables, hfcentralEtaStripSize = Var("userInt('hfcentralEtaStripSize')", int, doc="eta size of the central tower strip in HF (noise discriminating variable) "))
   modifier.toModify( jetTable.variables, hfadjacentEtaStripsSize = Var("userInt('hfadjacentEtaStripsSize')", int, doc="eta size of the strips next to the central tower strip in HF (noise discriminating variable) "))
+  modifier.toModify(jetUserDataTask, jetUserDataTask.add(hfJetShowerShapeforNanoAOD))
 
 
 ################################################################################
@@ -760,7 +761,7 @@ for modifier in run2_miniAOD_80XLegacy, run2_nanoAOD_94X2016, run2_nanoAOD_94XMi
 ################################################################################
 
 #before cross linking
-jetTask = cms.Task(jetCorrFactorsNano,updatedJets,jetUserDataTask,updatedJetsWithUserData,hfJetShowerShapeforNanoAOD,jetCorrFactorsAK8,updatedJetsAK8,jetAK8UserDataTask,updatedJetsAK8WithUserData,softActivityTask,finalJets,finalJetsAK8)
+jetTask = cms.Task(jetCorrFactorsNano,updatedJets,jetUserDataTask,updatedJetsWithUserData,jetCorrFactorsAK8,updatedJetsAK8,jetAK8UserDataTask,updatedJetsAK8WithUserData,softActivityTask,finalJets,finalJetsAK8)
 
 #after lepton collections have been run
 jetLepTask = cms.Task(lepInJetVars)
@@ -770,7 +771,7 @@ jetTablesTask = cms.Task(bjetNN,cjetNN,jetTable,fatJetTable,subJetTable,saJetTab
 (run3_nanoAOD_devel).toReplaceWith(jetTablesTask, jetTablesTask.copyAndExclude([bjetNN,cjetNN]))
 
 #MC only producers and tables
-jetMCTaskak4 = cms.Task(jetMCTable,genJetTable,patJetPartonsNano,genJetFlavourTable,genJetAK8Table,genJetAK8FlavourAssociation,genJetAK8FlavourTable,fatJetMCTable,genSubJetAK8Table,subjetMCTable)
+jetMCTaskak4 = cms.Task(jetMCTable,genJetTable,patJetPartonsNano,genJetFlavourTable)
 jetMCTaskak8 = cms.Task(genJetAK8Table,genJetAK8FlavourAssociation,genJetAK8FlavourTable,fatJetMCTable,genSubJetAK8Table,subjetMCTable)
 jetMCTask = jetMCTaskak4.copy()
 jetMCTask.add(jetMCTaskak8)

--- a/PhysicsTools/NanoAOD/python/jets_cff.py
+++ b/PhysicsTools/NanoAOD/python/jets_cff.py
@@ -1,9 +1,8 @@
 import FWCore.ParameterSet.Config as cms
-
 from PhysicsTools.NanoAOD.nano_eras_cff import *
-from  PhysicsTools.NanoAOD.common_cff import *
-from RecoJets.JetProducers.ak4PFJetsBetaStar_cfi import *
+from PhysicsTools.NanoAOD.common_cff import *
 
+from RecoJets.JetProducers.ak4PFJetsBetaStar_cfi import *
 
 ##################### User floats producers, selectors ##########################
 from RecoJets.JetProducers.ak4PFJets_cfi import ak4PFJets
@@ -103,6 +102,7 @@ tightJetIdLepVetoAK8 = cms.EDProducer("PatJetIDValueMapProducer",
 			  ),
                           src = cms.InputTag("updatedJetsAK8")
 )
+
 run2_jme_2016.toModify( tightJetIdAK8.filterParams, version = "RUN2UL16PUPPI" )
 run2_jme_2016.toModify( tightJetIdLepVetoAK8.filterParams, version = "RUN2UL16PUPPI" )
 for modifier in run2_miniAOD_80XLegacy, run2_nanoAOD_94X2016:
@@ -498,6 +498,7 @@ fatJetTable = cms.EDProducer("SimpleCandidateFlatTableProducer",
         electronIdx3SJ = ExtVar(cms.InputTag("lepInJetVars:eleIdx3SJ"),int,doc="index of electron matched to jet"),
     )
 )
+
 ### Era dependent customization
 for modifier in run2_miniAOD_80XLegacy, run2_nanoAOD_94X2016, run2_nanoAOD_94XMiniAODv1, run2_nanoAOD_94XMiniAODv2, run2_nanoAOD_102Xv1, run2_nanoAOD_106Xv1:
   modifier.toModify( fatJetTable.variables.n2b1, expr = cms.string("userFloat('ak8PFJetsPuppiSoftDropValueMap:nb1AK8PuppiSoftDropN2')"),)
@@ -715,7 +716,6 @@ run2_miniAOD_80XLegacy.toModify( genJetFlavourTable, jetFlavourInfos = cms.Input
 from RecoJets.JetProducers.QGTagger_cfi import  QGTagger
 qgtagger=QGTagger.clone(srcJets="updatedJets",srcVertexCollection="offlineSlimmedPrimaryVertices")
 
-
 from RecoJets.JetProducers.PileupJetID_cfi import pileupJetId, _chsalgos_94x, _chsalgos_102x, _chsalgos_106X_UL16, _chsalgos_106X_UL16APV, _chsalgos_106X_UL17, _chsalgos_106X_UL18
 pileupJetId94X=pileupJetId.clone(jets="updatedJets",algos = cms.VPSet(_chsalgos_94x),inputIsCorrected=True,applyJec=False,vertexes="offlineSlimmedPrimaryVertices")
 pileupJetId102X=pileupJetId.clone(jets="updatedJets",algos = cms.VPSet(_chsalgos_102x),inputIsCorrected=True,applyJec=False,vertexes="offlineSlimmedPrimaryVertices")
@@ -725,14 +725,16 @@ pileupJetId106XUL17=pileupJetId.clone(jets="updatedJets",algos = cms.VPSet(_chsa
 pileupJetId106XUL18=pileupJetId.clone(jets="updatedJets",algos = cms.VPSet(_chsalgos_106X_UL18),inputIsCorrected=True,applyJec=False,vertexes="offlineSlimmedPrimaryVertices")
 
 #before cross linking
-jetSequence = cms.Sequence(jetCorrFactorsNano+updatedJets+tightJetId+tightJetIdLepVeto+bJetVars+qgtagger+jercVars+pileupJetId94X+pileupJetId102X+pileupJetId106XUL16+pileupJetId106XUL16APV+pileupJetId106XUL17+pileupJetId106XUL18+updatedJetsWithUserData+jetCorrFactorsAK8+updatedJetsAK8+tightJetIdAK8+tightJetIdLepVetoAK8+updatedJetsAK8WithUserData+chsForSATkJets+softActivityJets+softActivityJets2+softActivityJets5+softActivityJets10+finalJets+finalJetsAK8)
+jetUserDataTask = cms.Task(bJetVars, qgtagger, jercVars, tightJetId, tightJetIdLepVeto, pileupJetId94X, pileupJetId102X, pileupJetId106XUL16,pileupJetId106XUL16APV,pileupJetId106XUL17,pileupJetId106XUL18)
 
+jetAK8UserDataTask = cms.Task(tightJetIdAK8,tightJetIdLepVetoAK8)
 
-_jetSequence_2016 = jetSequence.copy()
-_jetSequence_2016.insert(_jetSequence_2016.index(tightJetId), looseJetId)
-_jetSequence_2016.insert(_jetSequence_2016.index(tightJetIdAK8), looseJetIdAK8)
+_jetUserDataTask2016 = jetUserDataTask.copy()
+_jetUserDataTask2016.add(looseJetId,looseJetIdAK8)
 for modifier in run2_miniAOD_80XLegacy, run2_nanoAOD_94X2016:
-  modifier.toReplaceWith(jetSequence, _jetSequence_2016)
+  modifier.toReplaceWith(jetUserDataTask,_jetUserDataTask2016)
+
+softActivityTask = cms.Task(chsForSATkJets,softActivityJets,softActivityJets2,softActivityJets5,softActivityJets10) 
 
 #HF shower shape recomputation
 #Only run if needed (i.e. if default MINIAOD info is missing or outdated because of new JECs...)
@@ -751,24 +753,32 @@ for modifier in run2_miniAOD_80XLegacy, run2_nanoAOD_94X2016, run2_nanoAOD_94XMi
   modifier.toModify( jetTable.variables, hfsigmaPhiPhi = Var("userFloat('hfsigmaPhiPhi')",float,doc="sigmaPhiPhi for HF jets (noise discriminating variable)",precision=10))
   modifier.toModify( jetTable.variables, hfcentralEtaStripSize = Var("userInt('hfcentralEtaStripSize')", int, doc="eta size of the central tower strip in HF (noise discriminating variable) "))
   modifier.toModify( jetTable.variables, hfadjacentEtaStripsSize = Var("userInt('hfadjacentEtaStripsSize')", int, doc="eta size of the strips next to the central tower strip in HF (noise discriminating variable) "))
-  _jetSequence_rerunHFshowershape = jetSequence.copy()
-  _jetSequence_rerunHFshowershape.insert(_jetSequence_rerunHFshowershape.index(updatedJetsWithUserData), hfJetShowerShapeforNanoAOD)
-  modifier.toReplaceWith(jetSequence, _jetSequence_rerunHFshowershape)
 
+
+################################################################################
+# Tasks
+################################################################################
+
+#before cross linking
+jetTask = cms.Task(jetCorrFactorsNano,updatedJets,jetUserDataTask,updatedJetsWithUserData,hfJetShowerShapeforNanoAOD,jetCorrFactorsAK8,updatedJetsAK8,jetAK8UserDataTask,updatedJetsAK8WithUserData,softActivityTask,finalJets,finalJetsAK8)
 
 #after lepton collections have been run
-jetLepSequence = cms.Sequence(lepInJetVars)
+jetLepTask = cms.Task(lepInJetVars)
 
 #after cross linkining
-jetTables = cms.Sequence(bjetNN+cjetNN+jetTable+fatJetTable+subJetTable+saJetTable+saTable)
-
-(run3_nanoAOD_devel).toReplaceWith(jetTables, jetTables.copyAndExclude([bjetNN,cjetNN]))
+jetTablesTask = cms.Task(bjetNN,cjetNN,jetTable,fatJetTable,subJetTable,saJetTable,saTable)
+(run3_nanoAOD_devel).toReplaceWith(jetTablesTask, jetTablesTask.copyAndExclude([bjetNN,cjetNN]))
 
 #MC only producers and tables
-jetMC = cms.Sequence(jetMCTable+genJetTable+patJetPartonsNano+genJetFlavourTable+genJetAK8Table+genJetAK8FlavourAssociation+genJetAK8FlavourTable+fatJetMCTable+genSubJetAK8Table+subjetMCTable)
-_jetMC_pre94X = jetMC.copy()
-_jetMC_pre94X.insert(_jetMC_pre94X.index(genJetFlavourTable),genJetFlavourAssociation)
-_jetMC_pre94X.remove(genSubJetAK8Table)
-run2_miniAOD_80XLegacy.toReplaceWith(jetMC, _jetMC_pre94X)
+jetMCTaskak4 = cms.Task(jetMCTable,genJetTable,patJetPartonsNano,genJetFlavourTable,genJetAK8Table,genJetAK8FlavourAssociation,genJetAK8FlavourTable,fatJetMCTable,genSubJetAK8Table,subjetMCTable)
+jetMCTaskak8 = cms.Task(genJetAK8Table,genJetAK8FlavourAssociation,genJetAK8FlavourTable,fatJetMCTable,genSubJetAK8Table,subjetMCTable)
+jetMCTask = jetMCTaskak4.copy()
+jetMCTask.add(jetMCTaskak8)
+
+_jetMC_pre94XTask = jetMCTaskak4.copy()
+_jetMC_pre94XTask.add(genJetFlavourAssociation)
+_jetMC_pre94XTask.add(jetMCTaskak8)
+_jetMC_pre94XTask.copyAndExclude([genSubJetAK8Table])
+run2_miniAOD_80XLegacy.toReplaceWith(jetMCTask, _jetMC_pre94XTask)
 
 

--- a/PhysicsTools/NanoAOD/python/jets_cff.py
+++ b/PhysicsTools/NanoAOD/python/jets_cff.py
@@ -207,7 +207,6 @@ lepInJetVars = cms.EDProducer("LepInJetProducer",
 ##################### Tables for final output and docs ##########################
 
 
-
 jetTable = cms.EDProducer("SimpleCandidateFlatTableProducer",
     src = cms.InputTag("linkedObjects","jets"),
     cut = cms.string(""), #we should not filter on cross linked collections
@@ -254,6 +253,13 @@ jetTable = cms.EDProducer("SimpleCandidateFlatTableProducer",
         muEF = Var("muonEnergyFraction()", float, doc="muon Energy Fraction", precision= 6),
         chFPV0EF = Var("userFloat('chFPV0EF')", float, doc="charged fromPV==0 Energy Fraction (energy excluded from CHS jets). Previously called betastar.", precision= 6),
     )
+)
+
+run3_nanoAOD_devel.toModify(jetTable.externalVariables,
+                            bRegCorr = None,
+                            bRegRes  = None,
+                            cRegCorr = None,
+                            cRegRes  = None
 )
 
 #jets are not as precise as muons
@@ -755,6 +761,8 @@ jetLepSequence = cms.Sequence(lepInJetVars)
 
 #after cross linkining
 jetTables = cms.Sequence(bjetNN+cjetNN+jetTable+fatJetTable+subJetTable+saJetTable+saTable)
+
+(run3_nanoAOD_devel).toReplaceWith(jetTables, jetTables.copyAndExclude([bjetNN,cjetNN]))
 
 #MC only producers and tables
 jetMC = cms.Sequence(jetMCTable+genJetTable+patJetPartonsNano+genJetFlavourTable+genJetAK8Table+genJetAK8FlavourAssociation+genJetAK8FlavourTable+fatJetMCTable+genSubJetAK8Table+subjetMCTable)

--- a/PhysicsTools/NanoAOD/python/lowPtElectrons_cff.py
+++ b/PhysicsTools/NanoAOD/python/lowPtElectrons_cff.py
@@ -184,20 +184,26 @@ lowPtElectronMCTable = cms.EDProducer(
 # Sequences
 ################################################################################
 
-lowPtElectronSequence = cms.Sequence(modifiedLowPtElectrons
-                                     +updatedLowPtElectrons
-                                     +lowPtPATElectronID
-                                     +isoForLowPtEle
-                                     +updatedLowPtElectronsWithUserData
-                                     +finalLowPtElectrons)
+lowPtElectronTask = cms.Task(modifiedLowPtElectrons,
+                             updatedLowPtElectrons,
+                             lowPtPATElectronID,
+                             isoForLowPtEle,
+                             updatedLowPtElectronsWithUserData,
+                             finalLowPtElectrons)
+lowPtElectronSequence = cms.Sequence(lowPtElectronTask)
+
 lowPtElectronTables = cms.Sequence(lowPtElectronTable)
+
+lowPtElectronMCTask = cms.Task(
+    particleLevelForMatchingLowPt,
+    tautaggerForMatchingLowPt,
+    matchingLowPtElecPhoton,
+    lowPtElectronsMCMatchForTable,
+    lowPtElectronsMCMatchForTableAlt,
+    lowPtElectronMCTable)
+
 lowPtElectronMC = cms.Sequence(
-    particleLevelForMatchingLowPt
-    +tautaggerForMatchingLowPt
-    +matchingLowPtElecPhoton
-    +lowPtElectronsMCMatchForTable
-    +lowPtElectronsMCMatchForTableAlt
-    +lowPtElectronMCTable)
+    lowPtElectronMCTask)
 
 ################################################################################
 # Modifiers

--- a/PhysicsTools/NanoAOD/python/lowPtElectrons_cff.py
+++ b/PhysicsTools/NanoAOD/python/lowPtElectrons_cff.py
@@ -181,7 +181,7 @@ lowPtElectronMCTable = cms.EDProducer(
 )
 
 ################################################################################
-# Sequences
+# Tasks
 ################################################################################
 
 lowPtElectronTask = cms.Task(modifiedLowPtElectrons,
@@ -190,9 +190,8 @@ lowPtElectronTask = cms.Task(modifiedLowPtElectrons,
                              isoForLowPtEle,
                              updatedLowPtElectronsWithUserData,
                              finalLowPtElectrons)
-lowPtElectronSequence = cms.Sequence(lowPtElectronTask)
 
-lowPtElectronTables = cms.Sequence(lowPtElectronTable)
+lowPtElectronTablesTask = cms.Task(lowPtElectronTable)
 
 lowPtElectronMCTask = cms.Task(
     particleLevelForMatchingLowPt,
@@ -201,9 +200,6 @@ lowPtElectronMCTask = cms.Task(
     lowPtElectronsMCMatchForTable,
     lowPtElectronsMCMatchForTableAlt,
     lowPtElectronMCTable)
-
-lowPtElectronMC = cms.Sequence(
-    lowPtElectronMCTask)
 
 ################################################################################
 # Modifiers
@@ -215,6 +211,6 @@ _modifiers = ( run2_miniAOD_80XLegacy |
                run2_nanoAOD_94X2016 |
                run2_nanoAOD_102Xv1 |
                run2_nanoAOD_106Xv1 )
-(_modifiers).toReplaceWith(lowPtElectronSequence,cms.Sequence())
-(_modifiers).toReplaceWith(lowPtElectronTables,cms.Sequence())
-(_modifiers).toReplaceWith(lowPtElectronMC,cms.Sequence())
+(_modifiers).toReplaceWith(lowPtElectronTask,cms.Task())
+(_modifiers).toReplaceWith(lowPtElectronTablesTask,cms.Task())
+(_modifiers).toReplaceWith(lowPtElectronMCTask,cms.Task())

--- a/PhysicsTools/NanoAOD/python/met_cff.py
+++ b/PhysicsTools/NanoAOD/python/met_cff.py
@@ -158,7 +158,11 @@ metMCTable = cms.EDProducer("SimpleCandidateFlatTableProducer",
 )
 
 
-metTablesTask = cms.Task( metTable,rawMetTable,caloMetTable,puppiMetTable,rawPuppiMetTable,tkMetTable,chsMetTable,deepMetResolutionTuneTable,deepMetResponseTuneTable)
+metTablesTask = cms.Task( metTable,rawMetTable,caloMetTable,puppiMetTable,rawPuppiMetTable,tkMetTable,chsMetTable
+#TEMPORARY 
+#,deepMetResolutionTuneTable,deepMetResponseTuneTable
+)
+
 
 #TEMPORARY
 #_withFixEE2017_task = metTablesTask .copy()

--- a/PhysicsTools/NanoAOD/python/met_cff.py
+++ b/PhysicsTools/NanoAOD/python/met_cff.py
@@ -160,8 +160,9 @@ metMCTable = cms.EDProducer("SimpleCandidateFlatTableProducer",
 
 metTablesTask = cms.Task( metTable,rawMetTable,caloMetTable,puppiMetTable,rawPuppiMetTable,tkMetTable,chsMetTable,deepMetResolutionTuneTable,deepMetResponseTuneTable)
 
-_withFixEE2017_task = metTablesTask .copy()
-_withFixEE2017_task.add(metFixEE2017Table)
-for modifier in run2_nanoAOD_94XMiniAODv1, run2_nanoAOD_94XMiniAODv2:
-    modifier.toReplaceWith(metTablesTask,_withFixEE2017_task) # only in old miniAOD, the new ones will come from the UL rereco
+#TEMPORARY
+#_withFixEE2017_task = metTablesTask .copy()
+#_withFixEE2017_task.add(metFixEE2017Table)
+#for modifier in run2_nanoAOD_94XMiniAODv1, run2_nanoAOD_94XMiniAODv2:
+#    modifier.toReplaceWith(metTablesTask,_withFixEE2017_task) # only in old miniAOD, the new ones will come from the UL rereco
 

--- a/PhysicsTools/NanoAOD/python/met_cff.py
+++ b/PhysicsTools/NanoAOD/python/met_cff.py
@@ -158,11 +158,12 @@ metMCTable = cms.EDProducer("SimpleCandidateFlatTableProducer",
 )
 
 
+metTablesTask = cms.Task( metTable,rawMetTable,caloMetTable,puppiMetTable,rawPuppiMetTable,tkMetTable,chsMetTable,deepMetResolutionTuneTable,deepMetResponseTuneTable)
+metTables = cms.Sequence(metTablesTask)
 
-metTables = cms.Sequence( metTable + rawMetTable + caloMetTable + puppiMetTable + rawPuppiMetTable+ tkMetTable + chsMetTable)
-deepMetTables = cms.Sequence( deepMetResolutionTuneTable + deepMetResponseTuneTable )
 _withFixEE2017_sequence = cms.Sequence(metTables.copy() + metFixEE2017Table)
 for modifier in run2_nanoAOD_94XMiniAODv1, run2_nanoAOD_94XMiniAODv2:
     modifier.toReplaceWith(metTables,_withFixEE2017_sequence) # only in old miniAOD, the new ones will come from the UL rereco
+
 metMC = cms.Sequence( metMCTable )
 

--- a/PhysicsTools/NanoAOD/python/met_cff.py
+++ b/PhysicsTools/NanoAOD/python/met_cff.py
@@ -159,11 +159,9 @@ metMCTable = cms.EDProducer("SimpleCandidateFlatTableProducer",
 
 
 metTablesTask = cms.Task( metTable,rawMetTable,caloMetTable,puppiMetTable,rawPuppiMetTable,tkMetTable,chsMetTable,deepMetResolutionTuneTable,deepMetResponseTuneTable)
-metTables = cms.Sequence(metTablesTask)
 
-_withFixEE2017_sequence = cms.Sequence(metTables.copy() + metFixEE2017Table)
+_withFixEE2017_task = metTablesTask .copy()
+_withFixEE2017_task.add(metFixEE2017Table)
 for modifier in run2_nanoAOD_94XMiniAODv1, run2_nanoAOD_94XMiniAODv2:
-    modifier.toReplaceWith(metTables,_withFixEE2017_sequence) # only in old miniAOD, the new ones will come from the UL rereco
-
-metMC = cms.Sequence( metMCTable )
+    modifier.toReplaceWith(metTablesTask,_withFixEE2017_task) # only in old miniAOD, the new ones will come from the UL rereco
 

--- a/PhysicsTools/NanoAOD/python/muons_cff.py
+++ b/PhysicsTools/NanoAOD/python/muons_cff.py
@@ -203,10 +203,5 @@ muonMCTable = cms.EDProducer("CandMCMatchTableProducer",
 )
 
 muonTask = cms.Task(slimmedMuonsUpdated,isoForMu,ptRatioRelForMu,slimmedMuonsWithUserData,finalMuons,finalLooseMuons )
-muonSequence = cms.Sequence(muonTask)
-
 muonMCTask = cms.Task(muonsMCMatchForTable,muonMCTable)
-muonMC = cms.Sequence(muonMCTask)
-
 muonTablesTask = cms.Task(muonFSRphotons,muonFSRassociation,muonMVATTH,muonMVALowPt,muonTable,fsrTable)
-muonTables = cms.Sequence(muonTablesTask)

--- a/PhysicsTools/NanoAOD/python/muons_cff.py
+++ b/PhysicsTools/NanoAOD/python/muons_cff.py
@@ -202,7 +202,11 @@ muonMCTable = cms.EDProducer("CandMCMatchTableProducer",
     docString = cms.string("MC matching to status==1 muons"),
 )
 
-muonSequence = cms.Sequence(slimmedMuonsUpdated+isoForMu + ptRatioRelForMu + slimmedMuonsWithUserData + finalMuons + finalLooseMuons )
-muonMC = cms.Sequence(muonsMCMatchForTable + muonMCTable)
-muonTables = cms.Sequence(muonFSRphotons + muonFSRassociation + muonMVATTH + muonMVALowPt + muonTable + fsrTable)
+muonTask = cms.Task(slimmedMuonsUpdated,isoForMu,ptRatioRelForMu,slimmedMuonsWithUserData,finalMuons,finalLooseMuons )
+muonSequence = cms.Sequence(muonTask)
 
+muonMCTask = cms.Task(muonsMCMatchForTable,muonMCTable)
+muonMC = cms.Sequence(muonMCTask)
+
+muonTablesTask = cms.Task(muonFSRphotons,muonFSRassociation,muonMVATTH,muonMVALowPt,muonTable,fsrTable)
+muonTables = cms.Sequence(muonTablesTask)

--- a/PhysicsTools/NanoAOD/python/nanoDQM_cff.py
+++ b/PhysicsTools/NanoAOD/python/nanoDQM_cff.py
@@ -44,7 +44,6 @@ _tauPlotsPreV9.extend([
                 Plot1D('rawMVAoldDMdR032017v2', 'rawMVAoldDMdR032017v2', 20, -1, 1, 'byIsolationMVArun2v1DBdR03oldDMwLT raw output discriminator (2017v2)')
 ])
 
-from Configuration.Eras.Modifier_run2_nanoAOD_106Xv1_cff import run2_nanoAOD_106Xv1
 (run2_nanoAOD_92X | run2_nanoAOD_94XMiniAODv1 | run2_nanoAOD_94XMiniAODv2 | run2_nanoAOD_94X2016 | run2_nanoAOD_102Xv1 | run2_nanoAOD_106Xv1).toModify(nanoDQM.vplots.Tau, plots = _tauPlotsPreV9)
 
 #TEMPORARY

--- a/PhysicsTools/NanoAOD/python/nanoDQM_cff.py
+++ b/PhysicsTools/NanoAOD/python/nanoDQM_cff.py
@@ -51,14 +51,15 @@ from Configuration.Eras.Modifier_run2_nanoAOD_102Xv1_cff import run2_nanoAOD_102
 from Configuration.Eras.Modifier_run2_nanoAOD_106Xv1_cff import run2_nanoAOD_106Xv1
 (run2_nanoAOD_92X | run2_nanoAOD_94XMiniAODv1 | run2_nanoAOD_94XMiniAODv2 | run2_nanoAOD_94X2016 | run2_nanoAOD_102Xv1 | run2_nanoAOD_106Xv1).toModify(nanoDQM.vplots.Tau, plots = _tauPlotsPreV9)
 
-_METFixEE2017_DQMentry = nanoDQM.vplots.MET.clone()
-_METFixEE2017_plots = cms.VPSet()
-for plot in _METFixEE2017_DQMentry.plots:
-    if plot.name.value().find("fiducial")>-1: continue
-    _METFixEE2017_plots.append(plot)
-_METFixEE2017_DQMentry.plots = _METFixEE2017_plots
-for modifier in run2_nanoAOD_94XMiniAODv1, run2_nanoAOD_94XMiniAODv2:
-    modifier.toModify(nanoDQM.vplots, METFixEE2017 = _METFixEE2017_DQMentry)
+#TEMPORARY
+#_METFixEE2017_DQMentry = nanoDQM.vplots.MET.clone()
+#_METFixEE2017_plots = cms.VPSet()
+#for plot in _METFixEE2017_DQMentry.plots:
+#    if plot.name.value().find("fiducial")>-1: continue
+#    _METFixEE2017_plots.append(plot)
+#_METFixEE2017_DQMentry.plots = _METFixEE2017_plots
+#for modifier in run2_nanoAOD_94XMiniAODv1, run2_nanoAOD_94XMiniAODv2:
+#    modifier.toModify(nanoDQM.vplots, METFixEE2017 = _METFixEE2017_DQMentry)
 
 _Electron_plots_2016 = copy.deepcopy(nanoDQM.vplots.Electron.plots)
 _Electron_plots_2016.append(Plot1D('cutBased_HLTPreSel', 'cutBased_HLTPreSel', 2, -0.5, 1.5, 'cut-based HLT pre-selection ID'))

--- a/PhysicsTools/NanoAOD/python/nanoDQM_cff.py
+++ b/PhysicsTools/NanoAOD/python/nanoDQM_cff.py
@@ -106,19 +106,17 @@ run2_miniAOD_80XLegacy.toModify(nanoDQM.vplots.Flag, plots = _Flag_plots_80x)
 
 run2_miniAOD_80XLegacy.toModify(nanoDQM.vplots, IsoTrack = None)
 
+(~run3_nanoAOD_devel | run3_nanoAOD_devel).toModify(nanoDQM.vplots, Electron = None)
 
 ## MC
 nanoDQMMC = nanoDQM.clone()
-nanoDQMMC.vplots.Electron.sels.Prompt = cms.string("genPartFlav == 1")
+#nanoDQMMC.vplots.Electron.sels.Prompt = cms.string("genPartFlav == 1")
 nanoDQMMC.vplots.LowPtElectron.sels.Prompt = cms.string("genPartFlav == 1")
 nanoDQMMC.vplots.Muon.sels.Prompt = cms.string("genPartFlav == 1")
 nanoDQMMC.vplots.Photon.sels.Prompt = cms.string("genPartFlav == 1")
 nanoDQMMC.vplots.Tau.sels.Prompt = cms.string("genPartFlav == 5")
 nanoDQMMC.vplots.Jet.sels.Prompt = cms.string("genJetIdx != 1")
 nanoDQMMC.vplots.Jet.sels.PromptB = cms.string("genJetIdx != 1 && hadronFlavour == 5")
-
-(~run3_nanoAOD_devel | run3_nanoAOD_devel).toModify(nanoDQM.vplots, Electron = None)
-
 
 from DQMServices.Core.DQMQualityTester import DQMQualityTester
 nanoDQMQTester = DQMQualityTester(

--- a/PhysicsTools/NanoAOD/python/nanoDQM_cff.py
+++ b/PhysicsTools/NanoAOD/python/nanoDQM_cff.py
@@ -43,11 +43,7 @@ _tauPlotsPreV9.extend([
                 Plot1D('rawMVAoldDM2017v2', 'rawMVAoldDM2017v2', 20, -1, 1, 'byIsolationMVArun2v1DBoldDMwLT raw output discriminator (2017v2)'),
                 Plot1D('rawMVAoldDMdR032017v2', 'rawMVAoldDMdR032017v2', 20, -1, 1, 'byIsolationMVArun2v1DBdR03oldDMwLT raw output discriminator (2017v2)')
 ])
-from Configuration.Eras.Modifier_run2_nanoAOD_92X_cff import run2_nanoAOD_92X
-from Configuration.Eras.Modifier_run2_nanoAOD_94XMiniAODv1_cff import run2_nanoAOD_94XMiniAODv1
-from Configuration.Eras.Modifier_run2_nanoAOD_94XMiniAODv2_cff import run2_nanoAOD_94XMiniAODv2
-from Configuration.Eras.Modifier_run2_nanoAOD_94X2016_cff import run2_nanoAOD_94X2016
-from Configuration.Eras.Modifier_run2_nanoAOD_102Xv1_cff import run2_nanoAOD_102Xv1
+
 from Configuration.Eras.Modifier_run2_nanoAOD_106Xv1_cff import run2_nanoAOD_106Xv1
 (run2_nanoAOD_92X | run2_nanoAOD_94XMiniAODv1 | run2_nanoAOD_94XMiniAODv2 | run2_nanoAOD_94X2016 | run2_nanoAOD_102Xv1 | run2_nanoAOD_106Xv1).toModify(nanoDQM.vplots.Tau, plots = _tauPlotsPreV9)
 

--- a/PhysicsTools/NanoAOD/python/nanoDQM_cff.py
+++ b/PhysicsTools/NanoAOD/python/nanoDQM_cff.py
@@ -105,6 +105,7 @@ run2_miniAOD_80XLegacy.toModify(nanoDQM.vplots.Flag, plots = _Flag_plots_80x)
 
 run2_miniAOD_80XLegacy.toModify(nanoDQM.vplots, IsoTrack = None)
 
+
 ## MC
 nanoDQMMC = nanoDQM.clone()
 nanoDQMMC.vplots.Electron.sels.Prompt = cms.string("genPartFlav == 1")
@@ -114,6 +115,9 @@ nanoDQMMC.vplots.Photon.sels.Prompt = cms.string("genPartFlav == 1")
 nanoDQMMC.vplots.Tau.sels.Prompt = cms.string("genPartFlav == 5")
 nanoDQMMC.vplots.Jet.sels.Prompt = cms.string("genJetIdx != 1")
 nanoDQMMC.vplots.Jet.sels.PromptB = cms.string("genJetIdx != 1 && hadronFlavour == 5")
+
+(~run3_nanoAOD_devel | run3_nanoAOD_devel).toModify(nanoDQM.vplots, Electron = None)
+
 
 from DQMServices.Core.DQMQualityTester import DQMQualityTester
 nanoDQMQTester = DQMQualityTester(

--- a/PhysicsTools/NanoAOD/python/nano_cff.py
+++ b/PhysicsTools/NanoAOD/python/nano_cff.py
@@ -97,8 +97,12 @@ def nanoAOD_addTauIds(process):
     tauIdEmbedder = tauIdConfig.TauIDEmbedder(process, debug = False, updatedTauName = updatedTauName,
             toKeep = [ "deepTau2017v2p1" ])
     tauIdEmbedder.runTauID()
-    process.patTauMVAIDsSeq.insert(process.patTauMVAIDsSeq.index(getattr(process, updatedTauName)),
-                                   process.rerunMvaIsolationSequence)
+
+    _tauTask = patTauMVAIDsTask.copy()
+    _tauTask.add(process.rerunMvaIsolationTask)
+    _tauTask.add(finalTaus)
+    process.tauTask = _tauTask.copy()
+
     return process
 
 def nanoAOD_addBoostedTauIds(process):
@@ -108,12 +112,13 @@ def nanoAOD_addBoostedTauIds(process):
                                                      updatedTauName = updatedBoostedTauName,
                                                      postfix="Boosted",
                                                      toKeep = [ "2017v2", "dR0p32017v2", "newDM2017v2","againstEle2018",])
-    boostedTauIdEmbedder.runTauID()
-    process.boostedTauSequence.insert(process.boostedTauSequence.index(process.finalBoostedTaus),
-                                      process.rerunMvaIsolationSequenceBoosted)
 
-    process.boostedTauSequence.insert(process.boostedTauSequence.index(process.finalBoostedTaus),
-                                      getattr(process, updatedBoostedTauName))
+    boostedTauIdEmbedder.runTauID()
+    _boostedTauTask = process.rerunMvaIsolationTaskBoosted.copy()
+    _boostedTauTask.add(getattr(process, updatedBoostedTauName))
+    _boostedTauTask.add(process.finalBoostedTaus)
+
+    process.boostedTauTask = _boostedTauTask.copy()
 
     return process
  
@@ -373,8 +378,8 @@ def nanoAOD_customizeCommon(process):
                                      addParticleNetMass=nanoAOD_addDeepInfoAK8_switch.nanoAOD_addParticleNetMass_switch,
                                      jecPayload=nanoAOD_addDeepInfoAK8_switch.jecPayload)
 
-#    (run2_nanoAOD_94XMiniAODv1 | run2_nanoAOD_94X2016 | run2_nanoAOD_94XMiniAODv2 | run2_nanoAOD_102Xv1 | run2_nanoAOD_106Xv1).toModify(process, lambda p : nanoAOD_addTauIds(p))
-#    (~(run2_nanoAOD_94XMiniAODv1 | run2_nanoAOD_94X2016 | run2_nanoAOD_94XMiniAODv2 | run2_nanoAOD_102Xv1 | run2_nanoAOD_106Xv1)).toModify(process, lambda p : nanoAOD_addBoostedTauIds(p))
+    (run2_nanoAOD_94XMiniAODv1 | run2_nanoAOD_94X2016 | run2_nanoAOD_94XMiniAODv2 | run2_nanoAOD_102Xv1 | run2_nanoAOD_106Xv1).toModify(process, lambda p : nanoAOD_addTauIds(p))
+    (~(run2_nanoAOD_94XMiniAODv1 | run2_nanoAOD_94X2016 | run2_nanoAOD_94XMiniAODv2 | run2_nanoAOD_102Xv1 | run2_nanoAOD_106Xv1)).toModify(process, lambda p : nanoAOD_addBoostedTauIds(p))
     return process
 
 def nanoAOD_customizeData(process):

--- a/PhysicsTools/NanoAOD/python/nano_cff.py
+++ b/PhysicsTools/NanoAOD/python/nano_cff.py
@@ -348,7 +348,7 @@ def nanoAOD_customizeCommon(process):
         nanoAOD_addDeepDoubleX_switch = cms.untracked.bool(False),
         nanoAOD_addDeepDoubleXV2_switch = cms.untracked.bool(False),
         nanoAOD_addParticleNet_switch = cms.untracked.bool(False),
-        nanoAOD_addParticleNetMass_switch = cms.untracked.bool(True),
+        nanoAOD_addParticleNetMass_switch = cms.untracked.bool(False),
         jecPayload = cms.untracked.string('AK8PFPuppi')
         )
     # deepAK8 should not run on 80X, that contains ak8PFJetsCHS jets
@@ -362,13 +362,21 @@ def nanoAOD_customizeCommon(process):
         nanoAOD_addDeepDoubleX_switch = True,
         nanoAOD_addDeepDoubleXV2_switch = True,
         nanoAOD_addParticleNet_switch = True,
+        nanoAOD_addParticleNetMass_switch = True,
         )
     # for 106Xv1: only needs to run ParticleNet and DDXV2; DeepAK8, DeepDoubleX are already in MiniAOD
     run2_nanoAOD_106Xv1.toModify(
         nanoAOD_addDeepInfoAK8_switch,
         nanoAOD_addDeepDoubleXV2_switch = True,
         nanoAOD_addParticleNet_switch = True,
+        nanoAOD_addParticleNetMass_switch = True,
         )
+
+    run2_nanoAOD_106Xv2.toModify(
+        nanoAOD_addDeepInfoAK8_switch,
+        nanoAOD_addParticleNetMass_switch = True,
+    )
+
     process = nanoAOD_addDeepInfoAK8(process,
                                      addDeepBTag=nanoAOD_addDeepInfoAK8_switch.nanoAOD_addDeepBTag_switch,
                                      addDeepBoostedJet=nanoAOD_addDeepInfoAK8_switch.nanoAOD_addDeepBoostedJet_switch,

--- a/PhysicsTools/NanoAOD/python/nano_cff.py
+++ b/PhysicsTools/NanoAOD/python/nano_cff.py
@@ -366,11 +366,12 @@ def nanoAOD_runMETfixEE2017(process,isData):
 
 def nanoAOD_customizeCommon(process):
 
-    makePuppiesFromMiniAOD(process,True)
-    process.puppiNoLep.useExistingWeights = True
-    process.puppi.useExistingWeights = True
+    (~run3_nanoAOD_devel).toModify(process, lambda p: makePuppiesFromMiniAOD(process,True))
+    (~run3_nanoAOD_devel).toModify(process.puppiNoLep,useExistingWeights = True)
+    (~run3_nanoAOD_devel).toModify(process.puppi,useExistingWeights = True)
     run2_nanoAOD_106Xv1.toModify(process.puppiNoLep, useExistingWeights = False)
     run2_nanoAOD_106Xv1.toModify(process.puppi, useExistingWeights = False)
+
     process = nanoAOD_activateVID(process)
     nanoAOD_addDeepInfo_switch = cms.PSet(
         nanoAOD_addDeepBTag_switch = cms.untracked.bool(False),
@@ -424,8 +425,8 @@ def nanoAOD_customizeCommon(process):
 def nanoAOD_customizeData(process):
     process = nanoAOD_customizeCommon(process)
     process = nanoAOD_recalibrateMETs(process,isData=True)
-    process = nanoAOD_rebuildPuppiMETs(process,isData=True)
     process = nanoAOD_seqDeepMETs(process,isData=True)
+    (~run3_nanoAOD_devel).toModify(process, lambda p: nanoAOD_rebuildPuppiMETs(process,isData=True))
     for modifier in run2_nanoAOD_94XMiniAODv1, run2_nanoAOD_94XMiniAODv2:
         modifier.toModify(process, lambda p: nanoAOD_runMETfixEE2017(p,isData=True))
     return process
@@ -433,8 +434,8 @@ def nanoAOD_customizeData(process):
 def nanoAOD_customizeMC(process):
     process = nanoAOD_customizeCommon(process)
     process = nanoAOD_recalibrateMETs(process,isData=False)
-    process = nanoAOD_rebuildPuppiMETs(process,isData=False)
     process = nanoAOD_seqDeepMETs(process,isData=False)
+    (~run3_nanoAOD_devel).toModify(process, lambda p: nanoAOD_rebuildPuppiMETs(process,isData=False))
     for modifier in run2_nanoAOD_94XMiniAODv1, run2_nanoAOD_94XMiniAODv2:
         modifier.toModify(process, lambda p: nanoAOD_runMETfixEE2017(p,isData=False))
     return process

--- a/PhysicsTools/NanoAOD/python/nano_eras_cff.py
+++ b/PhysicsTools/NanoAOD/python/nano_eras_cff.py
@@ -20,3 +20,4 @@ from Configuration.Eras.Modifier_run2_nanoAOD_106Xv1_cff import run2_nanoAOD_106
 from Configuration.Eras.Modifier_run2_nanoAOD_106Xv2_cff import run2_nanoAOD_106Xv2
 from Configuration.Eras.Modifier_tracker_apv_vfp30_2016_cff import tracker_apv_vfp30_2016
 
+from Configuration.Eras.Modifier_run3_nanoAOD_devel_cff import run3_nanoAOD_devel

--- a/PhysicsTools/NanoAOD/python/nanogen_cff.py
+++ b/PhysicsTools/NanoAOD/python/nanogen_cff.py
@@ -4,11 +4,9 @@ from PhysicsTools.NanoAOD.globals_cff import genTable
 from PhysicsTools.NanoAOD.met_cff import metMCTable
 from PhysicsTools.NanoAOD.genparticles_cff import *
 from PhysicsTools.NanoAOD.particlelevel_cff import *
-from PhysicsTools.NanoAOD.lheInfoTable_cfi import *
 from PhysicsTools.NanoAOD.genWeightsTable_cfi import *
 from PhysicsTools.NanoAOD.genVertex_cff import *
 from PhysicsTools.NanoAOD.common_cff import Var,CandVars
-from PhysicsTools.NanoAOD.nano_eras_cff import *
 
 nanoMetadata = cms.EDProducer("UniqueStringProducer",
     strings = cms.PSet(
@@ -20,19 +18,19 @@ nanogenSequence = cms.Sequence(
     nanoMetadata+
     particleLevel+
     genJetTable+
-    patJetPartons+
+    patJetPartonsNano+
     genJetFlavourAssociation+
     genJetFlavourTable+
     genJetAK8Table+
     genJetAK8FlavourAssociation+
     genJetAK8FlavourTable+
-    genTauSequence+
+    cms.Sequence(genTauTask)+
     genTable+
-    genParticleTables+
-    genVertexTables+
+    cms.Sequence(genParticleTablesTask)+
+    cms.Sequence(genVertexTablesTask)+
     tautagger+
     rivetProducerHTXS+
-    particleLevelTables+
+    cms.Sequence(particleLevelTablesTask)+
     metMCTable+
     genWeightsTable+
     lheInfoTable
@@ -62,10 +60,6 @@ def customizeNanoGENFromMini(process):
     process.nanogenSequence.insert(0, process.genParticles2HepMC)
     process.nanogenSequence.insert(0, process.mergedGenParticles)
 
-    (run2_nanoAOD_92X | run2_miniAOD_80XLegacy | run2_nanoAOD_94X2016 | run2_nanoAOD_94X2016 | \
-        run2_nanoAOD_94XMiniAODv1 | run2_nanoAOD_94XMiniAODv2 | \
-        run2_nanoAOD_102Xv1).toReplaceWith(nanogenSequence, nanogenSequence.copyAndExclude([genVertexTable, genVertexT0Table]))
-
     process.metMCTable.src = "slimmedMETs"
     process.metMCTable.variables.pt = Var("genMET.pt", float, doc="pt")
     process.metMCTable.variables.phi = Var("genMET.phi", float, doc="phi")
@@ -73,7 +67,7 @@ def customizeNanoGENFromMini(process):
 
     process.rivetProducerHTXS.HepMCCollection = "genParticles2HepMCHiggsVtx:unsmeared"
     process.genParticleTable.src = "prunedGenParticles"
-    process.patJetPartons.particles = "prunedGenParticles"
+    process.patJetPartonsNano.particles = "prunedGenParticles"
     process.particleLevel.src = "genParticles2HepMC:unsmeared"
 
     process.genJetTable.src = "slimmedGenJets"
@@ -91,7 +85,7 @@ def customizeNanoGEN(process):
 
     process.rivetProducerHTXS.HepMCCollection = "generatorSmeared"
     process.genParticleTable.src = "genParticles"
-    process.patJetPartons.particles = "genParticles"
+    process.patJetPartonsNano.particles = "genParticles"
     process.particleLevel.src = "generatorSmeared"
 
     process.genJetTable.src = "ak4GenJets"

--- a/PhysicsTools/NanoAOD/python/particlelevel_cff.py
+++ b/PhysicsTools/NanoAOD/python/particlelevel_cff.py
@@ -175,8 +175,5 @@ lheInfoTable = cms.EDProducer("LHETablesProducer",
     storeLHEParticles = cms.bool(True)
 )
 
-particleLevelSequenceTask = cms.Task(mergedGenParticles,genParticles2HepMC,particleLevel,tautagger,genParticles2HepMCHiggsVtx,rivetProducerHTXS)
+particleLevelTask = cms.Task(mergedGenParticles,genParticles2HepMC,particleLevel,tautagger,genParticles2HepMCHiggsVtx,rivetProducerHTXS)
 particleLevelTablesTask = cms.Task(rivetLeptonTable,rivetPhotonTable,rivetMetTable,HTXSCategoryTable,lheInfoTable)
-
-particleLevelSequence = cms.Sequence(particleLevelSequenceTask)
-particleLevelTables = cms.Sequence(particleLevelTablesTask)

--- a/PhysicsTools/NanoAOD/python/particlelevel_cff.py
+++ b/PhysicsTools/NanoAOD/python/particlelevel_cff.py
@@ -170,5 +170,8 @@ HTXSCategoryTable = cms.EDProducer("SimpleHTXSFlatTableProducer",
 )
 
 
-particleLevelSequence = cms.Sequence(mergedGenParticles + genParticles2HepMC + particleLevel + tautagger + genParticles2HepMCHiggsVtx + rivetProducerHTXS)
-particleLevelTables = cms.Sequence(rivetLeptonTable + rivetPhotonTable + rivetMetTable + HTXSCategoryTable)
+particleLevelSequenceTask = cms.Task(mergedGenParticles,genParticles2HepMC,particleLevel,tautagger,genParticles2HepMCHiggsVtx,rivetProducerHTXS)
+particleLevelTablesTask = cms.Task(rivetLeptonTable,rivetPhotonTable,rivetMetTable,HTXSCategoryTable)
+
+particleLevelSequence = cms.Sequence(particleLevelSequenceTask)
+particleLevelTables = cms.Sequence(particleLevelTablesTask)

--- a/PhysicsTools/NanoAOD/python/particlelevel_cff.py
+++ b/PhysicsTools/NanoAOD/python/particlelevel_cff.py
@@ -169,9 +169,14 @@ HTXSCategoryTable = cms.EDProducer("SimpleHTXSFlatTableProducer",
    )
 )
 
+lheInfoTable = cms.EDProducer("LHETablesProducer",
+    lheInfo = cms.VInputTag(cms.InputTag("externalLHEProducer"), cms.InputTag("source")),
+    precision = cms.int32(14),
+    storeLHEParticles = cms.bool(True)
+)
 
 particleLevelSequenceTask = cms.Task(mergedGenParticles,genParticles2HepMC,particleLevel,tautagger,genParticles2HepMCHiggsVtx,rivetProducerHTXS)
-particleLevelTablesTask = cms.Task(rivetLeptonTable,rivetPhotonTable,rivetMetTable,HTXSCategoryTable)
+particleLevelTablesTask = cms.Task(rivetLeptonTable,rivetPhotonTable,rivetMetTable,HTXSCategoryTable,lheInfoTable)
 
 particleLevelSequence = cms.Sequence(particleLevelSequenceTask)
 particleLevelTables = cms.Sequence(particleLevelTablesTask)

--- a/PhysicsTools/NanoAOD/python/photons_cff.py
+++ b/PhysicsTools/NanoAOD/python/photons_cff.py
@@ -325,6 +325,12 @@ photonSequence = cms.Sequence(
 photonTables = cms.Sequence ( photonTable)
 photonMC = cms.Sequence(photonsMCMatchForTable + photonMCTable)
 
+#### TEMPORARY Run3
+(run3_nanoAOD_devel).toModify(finalPhotons,src = cms.InputTag("slimmedPhotons"))
+(run3_nanoAOD_devel).toReplaceWith(photonSequence, cms.Sequence(finalPhotons))
+(run3_nanoAOD_devel).toModify(photonTable, variables = cms.PSet(CandVars))
+
+
 from RecoEgamma.EgammaIsolationAlgos.egmPhotonIsolationMiniAOD_cff import egmPhotonIsolation
 from RecoEgamma.PhotonIdentification.photonIDValueMapProducer_cff import photonIDValueMapProducer
 

--- a/PhysicsTools/NanoAOD/python/photons_cff.py
+++ b/PhysicsTools/NanoAOD/python/photons_cff.py
@@ -313,23 +313,24 @@ for modifier in run2_nanoAOD_94X2016,:
                       dEsigmaDown=Var("userFloat('ecalEnergyPostCorr') - userFloat('energySigmaDown')", float,  doc="ecal energy smearing value shifted 1 sigma up", precision=8),
     )
 
-photonSequence = cms.Sequence(
-        bitmapVIDForPho + \
-        bitmapVIDForPhoSpring16V2p2 + \
-        isoForPho + \
-        seedGainPho + \
-        slimmedPhotonsWithUserData + \
+photonTask = cms.Task(
+        bitmapVIDForPho,
+        bitmapVIDForPhoSpring16V2p2,
+        isoForPho,
+        seedGainPho,
+        slimmedPhotonsWithUserData,
         finalPhotons
 )
 
-photonTables = cms.Sequence ( photonTable)
-photonMC = cms.Sequence(photonsMCMatchForTable + photonMCTable)
+photonTablesTask = cms.Task(photonTable)
+photonMCTask = cms.Task(photonsMCMatchForTable,photonMCTable)
+
+photonSequence = cms.Sequence(photonTablesTask)
 
 #### TEMPORARY Run3
-(run3_nanoAOD_devel).toModify(finalPhotons,src = cms.InputTag("slimmedPhotons"))
-(run3_nanoAOD_devel).toReplaceWith(photonSequence, cms.Sequence(finalPhotons))
-(run3_nanoAOD_devel).toModify(photonTable, variables = cms.PSet(CandVars))
-
+(run3_nanoAOD_devel | ~run3_nanoAOD_devel).toModify(finalPhotons,src = cms.InputTag("slimmedPhotons"))
+(run3_nanoAOD_devel | ~run3_nanoAOD_devel).toReplaceWith(photonTask, cms.Task(finalPhotons))
+(run3_nanoAOD_devel | ~run3_nanoAOD_devel).toModify(photonTable, variables = cms.PSet(CandVars))
 
 from RecoEgamma.EgammaIsolationAlgos.egmPhotonIsolationMiniAOD_cff import egmPhotonIsolation
 from RecoEgamma.PhotonIdentification.photonIDValueMapProducer_cff import photonIDValueMapProducer

--- a/PhysicsTools/NanoAOD/python/protons_cff.py
+++ b/PhysicsTools/NanoAOD/python/protons_cff.py
@@ -1,10 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 from PhysicsTools.NanoAOD.common_cff import *
-from Configuration.Eras.Modifier_run2_miniAOD_80XLegacy_cff import run2_miniAOD_80XLegacy
-from Configuration.Eras.Modifier_run2_nanoAOD_94XMiniAODv1_cff import run2_nanoAOD_94XMiniAODv1
-from Configuration.Eras.Modifier_run2_nanoAOD_94XMiniAODv2_cff import run2_nanoAOD_94XMiniAODv2
-from Configuration.Eras.Modifier_run2_nanoAOD_94X2016_cff import run2_nanoAOD_94X2016
-from Configuration.Eras.Modifier_run2_nanoAOD_102Xv1_cff import run2_nanoAOD_102Xv1
+from PhysicsTools.NanoAOD.nano_eras_cff import *
 from RecoPPS.ProtonReconstruction.ppsFilteredProtonProducer_cfi import *
 
 singleRPProtons = True
@@ -61,13 +57,9 @@ singleRPTable = cms.EDProducer("SimpleProtonTrackFlatTableProducer",
     ),
 )
 
-protonTables = cms.Sequence(    
-    filteredProtons
-    +protonTable
-    +multiRPTable
-)
-
-if singleRPProtons: protonTables.insert(protonTables.index(multiRPTable),singleRPTable)
+protonTablesTask = cms.Task(filteredProtons,protonTable,multiRPTable)
+if singleRPProtons: protonTablesTask.add(singleRPTable)
+protonTables = cms.Sequence(protonTablesTask)
 
 for modifier in run2_miniAOD_80XLegacy, run2_nanoAOD_94XMiniAODv1, run2_nanoAOD_94XMiniAODv2, run2_nanoAOD_94X2016, run2_nanoAOD_102Xv1:
     modifier.toReplaceWith(protonTables, cms.Sequence())

--- a/PhysicsTools/NanoAOD/python/protons_cff.py
+++ b/PhysicsTools/NanoAOD/python/protons_cff.py
@@ -59,7 +59,6 @@ singleRPTable = cms.EDProducer("SimpleProtonTrackFlatTableProducer",
 
 protonTablesTask = cms.Task(filteredProtons,protonTable,multiRPTable)
 if singleRPProtons: protonTablesTask.add(singleRPTable)
-protonTables = cms.Sequence(protonTablesTask)
 
 for modifier in run2_miniAOD_80XLegacy, run2_nanoAOD_94XMiniAODv1, run2_nanoAOD_94XMiniAODv2, run2_nanoAOD_94X2016, run2_nanoAOD_102Xv1:
-    modifier.toReplaceWith(protonTables, cms.Sequence())
+    modifier.toReplaceWith(protonTablesTask, cms.Task())

--- a/PhysicsTools/NanoAOD/python/taus_cff.py
+++ b/PhysicsTools/NanoAOD/python/taus_cff.py
@@ -246,7 +246,6 @@ tauMCTable = cms.EDProducer("CandMCMatchTableProducer",
 )
 
 
-patTauMVAIDsSeq = cms.Sequence(patTauMVAIDsTask)
 tauTask = cms.Task( patTauMVAIDsTask,finalTaus)
 
 run2_miniAOD_80XLegacy.toReplaceWith(tauTask, cms.Task(finalTaus))
@@ -255,11 +254,3 @@ tauTablesTask = cms.Task(tauTable)
 
 genTauTask = cms.Task(tauGenJetsForNano,tauGenJetsSelectorAllHadronsForNano,genVisTaus,genVisTauTable)
 tauMCTask = cms.Task(genTauTask,tausMCMatchLepTauForTable,tausMCMatchHadTauForTable,tauMCTable)
-
-
-run3_nanoAOD_devel.toModify(finalTaus,
-                            src = cms.InputTag("slimmedTaus"),
-                            cut =  cms.string("pt > 18")
-)
-
-run3_nanoAOD_devel.toReplaceWith(tauTask, cms.Task(finalTaus))

--- a/PhysicsTools/NanoAOD/python/taus_cff.py
+++ b/PhysicsTools/NanoAOD/python/taus_cff.py
@@ -246,6 +246,7 @@ tauMCTable = cms.EDProducer("CandMCMatchTableProducer",
 )
 
 
+patTauMVAIDsSeq = cms.Sequence(patTauMVAIDsTask)
 tauTask = cms.Task( patTauMVAIDsTask,finalTaus)
 
 run2_miniAOD_80XLegacy.toReplaceWith(tauTask, cms.Task(finalTaus))
@@ -254,3 +255,11 @@ tauTablesTask = cms.Task(tauTable)
 
 genTauTask = cms.Task(tauGenJetsForNano,tauGenJetsSelectorAllHadronsForNano,genVisTaus,genVisTauTable)
 tauMCTask = cms.Task(genTauTask,tausMCMatchLepTauForTable,tausMCMatchHadTauForTable,tauMCTable)
+
+
+run3_nanoAOD_devel.toModify(finalTaus,
+                            src = cms.InputTag("slimmedTaus"),
+                            cut =  cms.string("pt > 18")
+)
+
+run3_nanoAOD_devel.toReplaceWith(tauTask, cms.Task(finalTaus))

--- a/PhysicsTools/NanoAOD/python/taus_cff.py
+++ b/PhysicsTools/NanoAOD/python/taus_cff.py
@@ -250,6 +250,9 @@ tauSequence = cms.Sequence(patTauMVAIDsSeq + finalTaus)
 _tauSequence80X =  cms.Sequence(finalTaus)
 run2_miniAOD_80XLegacy.toReplaceWith(tauSequence,_tauSequence80X)
 tauTables = cms.Sequence(tauTable)
-genTauSequence = cms.Sequence(tauGenJetsForNano + tauGenJetsSelectorAllHadronsForNano + genVisTaus + genVisTauTable)
-tauMC = cms.Sequence(genTauSequence + tausMCMatchLepTauForTable + tausMCMatchHadTauForTable + tauMCTable)
 
+genTauTask = cms.Task(tauGenJetsForNano,tauGenJetsSelectorAllHadronsForNano,genVisTaus,genVisTauTable)
+tauMCTask = cms.Task(genTauTask,tausMCMatchLepTauForTable,tausMCMatchHadTauForTable,tauMCTable)
+
+genTauSequence = cms.Sequence(genTauTask)
+tauMC = cms.Sequence(tauMCTask)

--- a/PhysicsTools/NanoAOD/python/taus_cff.py
+++ b/PhysicsTools/NanoAOD/python/taus_cff.py
@@ -246,13 +246,11 @@ tauMCTable = cms.EDProducer("CandMCMatchTableProducer",
 )
 
 
-tauSequence = cms.Sequence(patTauMVAIDsSeq + finalTaus)
-_tauSequence80X =  cms.Sequence(finalTaus)
-run2_miniAOD_80XLegacy.toReplaceWith(tauSequence,_tauSequence80X)
-tauTables = cms.Sequence(tauTable)
+tauTask = cms.Task( patTauMVAIDsTask,finalTaus)
+
+run2_miniAOD_80XLegacy.toReplaceWith(tauTask, cms.Task(finalTaus))
+
+tauTablesTask = cms.Task(tauTable)
 
 genTauTask = cms.Task(tauGenJetsForNano,tauGenJetsSelectorAllHadronsForNano,genVisTaus,genVisTauTable)
 tauMCTask = cms.Task(genTauTask,tausMCMatchLepTauForTable,tausMCMatchHadTauForTable,tauMCTable)
-
-genTauSequence = cms.Sequence(genTauTask)
-tauMC = cms.Sequence(tauMCTask)

--- a/PhysicsTools/NanoAOD/python/taus_updatedMVAIds_cff.py
+++ b/PhysicsTools/NanoAOD/python/taus_updatedMVAIds_cff.py
@@ -44,9 +44,9 @@ patTauDiscriminationByIsolationMVArun2v1DBoldDMwLT = patDiscriminationByIsolatio
    )
 )
 # MVAIso DBoldDM Seqeunce
-patTauDiscriminationByIsolationMVArun2v1DBoldDMwLTSeq = cms.Sequence(
-    patTauDiscriminationByIsolationMVArun2v1DBoldDMwLTraw
-    + patTauDiscriminationByIsolationMVArun2v1DBoldDMwLT
+patTauDiscriminationByIsolationMVArun2v1DBoldDMwLTTask = cms.Task(
+    patTauDiscriminationByIsolationMVArun2v1DBoldDMwLTraw,
+    patTauDiscriminationByIsolationMVArun2v1DBoldDMwLT
 )
 ## DBnewDM
 # Raw
@@ -67,9 +67,9 @@ patTauDiscriminationByIsolationMVArun2v1DBnewDMwLT = patTauDiscriminationByIsola
    )
 )
 # MVAIso DBnewDM Seqeunce
-patTauDiscriminationByIsolationMVArun2v1DBnewDMwLTSeq = cms.Sequence(
-    patTauDiscriminationByIsolationMVArun2v1DBnewDMwLTraw
-    + patTauDiscriminationByIsolationMVArun2v1DBnewDMwLT
+patTauDiscriminationByIsolationMVArun2v1DBnewDMwLTTask = cms.Task(
+    patTauDiscriminationByIsolationMVArun2v1DBnewDMwLTraw,
+    patTauDiscriminationByIsolationMVArun2v1DBnewDMwLT
 )
 ## DBoldDMdR0p3
 # Raw
@@ -95,9 +95,9 @@ patTauDiscriminationByIsolationMVArun2v1DBoldDMdR0p3wLT = patTauDiscriminationBy
    )
 )
 # MVAIso DBoldDMdR0p3 Seqeunce
-patTauDiscriminationByIsolationMVArun2v1DBoldDMdR0p3wLTSeq = cms.Sequence(
-    patTauDiscriminationByIsolationMVArun2v1DBoldDMdR0p3wLTraw
-    + patTauDiscriminationByIsolationMVArun2v1DBoldDMdR0p3wLT
+patTauDiscriminationByIsolationMVArun2v1DBoldDMdR0p3wLTTask = cms.Task(
+    patTauDiscriminationByIsolationMVArun2v1DBoldDMdR0p3wLTraw,
+    patTauDiscriminationByIsolationMVArun2v1DBoldDMdR0p3wLT
 )
 ### MVAIso 2017v1 for Nano on top of MiniAODv1
 ## DBoldDM
@@ -128,9 +128,9 @@ patTauDiscriminationByIsolationMVArun2v1DBoldDMwLT2017v1 = patTauDiscriminationB
    )
 )
 # MVAIso DBoldDM Seqeunce
-patTauDiscriminationByIsolationMVArun2v1DBoldDMwLT2017v1Seq = cms.Sequence(
-    patTauDiscriminationByIsolationMVArun2v1DBoldDMwLTraw2017v1
-    + patTauDiscriminationByIsolationMVArun2v1DBoldDMwLT2017v1
+patTauDiscriminationByIsolationMVArun2v1DBoldDMwLT2017v1Task = cms.Task(
+    patTauDiscriminationByIsolationMVArun2v1DBoldDMwLTraw2017v1,
+    patTauDiscriminationByIsolationMVArun2v1DBoldDMwLT2017v1
 )
 ### MVAIso 2015 for Nano on top of MiniAODv2
 ## DBoldDM
@@ -160,9 +160,9 @@ patTauDiscriminationByIsolationMVArun2v1DBoldDMwLT2015 = patTauDiscriminationByI
    )
 )
 # MVAIso DBoldDM Seqeunce
-patTauDiscriminationByIsolationMVArun2v1DBoldDMwLT2015Seq = cms.Sequence(
-    patTauDiscriminationByIsolationMVArun2v1DBoldDMwLTraw2015
-    + patTauDiscriminationByIsolationMVArun2v1DBoldDMwLT2015
+patTauDiscriminationByIsolationMVArun2v1DBoldDMwLT2015Task = cms.Task(
+    patTauDiscriminationByIsolationMVArun2v1DBoldDMwLTraw2015,
+    patTauDiscriminationByIsolationMVArun2v1DBoldDMwLT2015
 )
 
 
@@ -282,35 +282,35 @@ patTauDiscriminationByElectronRejectionMVA62015 = patTauDiscriminationByElectron
 for m in patTauDiscriminationByElectronRejectionMVA62015.mapping:
     m.cut = m.cut.value().replace(antiElectronDiscrMVA6_version, antiElectronDiscrMVA6v1_version + "_gbr")
 ### Put all anti-e tau-IDs into a sequence
-_patTauDiscriminationByElectronRejection2018Seq = cms.Sequence(
-    patTauDiscriminationByElectronRejectionMVA62018Raw
-    +patTauDiscriminationByElectronRejectionMVA62018
+_patTauDiscriminationByElectronRejection2018Task = cms.Task(
+    patTauDiscriminationByElectronRejectionMVA62018Raw,
+    patTauDiscriminationByElectronRejectionMVA62018
 )
-_patTauDiscriminationByElectronRejection2015Seq = cms.Sequence(
-    patTauDiscriminationByElectronRejectionMVA62015Raw
-    +patTauDiscriminationByElectronRejectionMVA62015
+_patTauDiscriminationByElectronRejection2015Task = cms.Task(
+    patTauDiscriminationByElectronRejectionMVA62015Raw,
+    patTauDiscriminationByElectronRejectionMVA62015
 )
-patTauDiscriminationByElectronRejectionSeq = _patTauDiscriminationByElectronRejection2015Seq.copy()
+patTauDiscriminationByElectronRejectionTask = _patTauDiscriminationByElectronRejection2015Task.copy()
 for era in [run2_nanoAOD_92X,run2_nanoAOD_94XMiniAODv1,run2_nanoAOD_94XMiniAODv2,\
             run2_nanoAOD_94X2016,run2_nanoAOD_102Xv1,run2_nanoAOD_106Xv1]:
-    era.toReplaceWith(patTauDiscriminationByElectronRejectionSeq,
-                      _patTauDiscriminationByElectronRejection2018Seq)
+    era.toReplaceWith(patTauDiscriminationByElectronRejectionTask,
+                      _patTauDiscriminationByElectronRejection2018Task)
 
 
 ### put all new MVA tau-Id stuff to one Sequence
-_patTauMVAIDsSeq2017v2 = cms.Sequence(
-    patTauDiscriminationByIsolationMVArun2v1DBoldDMwLTSeq
-    +patTauDiscriminationByIsolationMVArun2v1DBnewDMwLTSeq
-    +patTauDiscriminationByIsolationMVArun2v1DBoldDMdR0p3wLTSeq
-    +patTauDiscriminationByElectronRejectionSeq
+_patTauMVAIDsTask2017v2 = cms.Task(
+    patTauDiscriminationByIsolationMVArun2v1DBoldDMwLTTask,
+    patTauDiscriminationByIsolationMVArun2v1DBnewDMwLTTask,
+    patTauDiscriminationByIsolationMVArun2v1DBoldDMdR0p3wLTTask,
+    patTauDiscriminationByElectronRejectionTask
 )
-patTauMVAIDsSeq = _patTauMVAIDsSeq2017v2.copy()
-patTauMVAIDsSeq += patTauDiscriminationByIsolationMVArun2v1DBoldDMwLT2015Seq
+patTauMVAIDsTask = _patTauMVAIDsTask2017v2.copy()
+patTauMVAIDsTask.add(patTauDiscriminationByIsolationMVArun2v1DBoldDMwLT2015Task)
 
-_patTauMVAIDsSeqWith2017v1 = _patTauMVAIDsSeq2017v2.copy()
-_patTauMVAIDsSeqWith2017v1 += patTauDiscriminationByIsolationMVArun2v1DBoldDMwLT2017v1Seq
+_patTauMVAIDsTaskWith2017v1 = _patTauMVAIDsTask2017v2.copy()
+_patTauMVAIDsTaskWith2017v1.add(patTauDiscriminationByIsolationMVArun2v1DBoldDMwLT2017v1Task)
 for era in [run2_nanoAOD_94XMiniAODv1,]:
-    era.toReplaceWith(patTauMVAIDsSeq,_patTauMVAIDsSeqWith2017v1)
+    era.toReplaceWith(patTauMVAIDsTask,_patTauMVAIDsTaskWith2017v1)
 
 # embed new MVA tau-Ids into new tau collection
 def tauIDMVAinputs(module, wp):
@@ -421,8 +421,8 @@ patTauDiscriminationAgainstElectronDeadECALForNano = patTauDiscriminationAgainst
     PATTauProducer = 'slimmedTaus',
     Prediscriminants = noPrediscriminants
 )
-_patTauMVAIDsSeqWithAntiEdeadECal = patTauMVAIDsSeq.copy()
-_patTauMVAIDsSeqWithAntiEdeadECal += patTauDiscriminationAgainstElectronDeadECALForNano
+_patTauMVAIDsTaskWithAntiEdeadECal = patTauMVAIDsTask.copy()
+_patTauMVAIDsTaskWithAntiEdeadECal.add(patTauDiscriminationAgainstElectronDeadECALForNano)
 _tauIDSourcesWithAntiEdeadECal = cms.PSet(
     slimmedTausUpdated.tauIDSources.clone(),
     againstElectronDeadECALForNano = cms.PSet(
@@ -430,14 +430,16 @@ _tauIDSourcesWithAntiEdeadECal = cms.PSet(
         workingPointIndex = cms.int32(-99)
     )
 )
+
 for era in [run2_miniAOD_80XLegacy,run2_nanoAOD_92X,run2_nanoAOD_94XMiniAODv1,\
             run2_nanoAOD_94XMiniAODv2,run2_nanoAOD_94X2016,run2_nanoAOD_102Xv1,\
             run2_nanoAOD_106Xv1]:
-    era.toReplaceWith(patTauMVAIDsSeq,_patTauMVAIDsSeqWithAntiEdeadECal)
+    era.toReplaceWith(patTauMVAIDsTask,_patTauMVAIDsTaskWithAntiEdeadECal)
     era.toModify(slimmedTausUpdated,
                  tauIDSources = _tauIDSourcesWithAntiEdeadECal
     )
 
 
-patTauMVAIDsSeq += slimmedTausUpdated
+patTauMVAIDsTask.add(slimmedTausUpdated)
 
+patTauMVAIDsSeq = cms.Sequence(patTauMVAIDsTask)

--- a/PhysicsTools/NanoAOD/python/triggerObjects_cff.py
+++ b/PhysicsTools/NanoAOD/python/triggerObjects_cff.py
@@ -250,8 +250,18 @@ l1PreFiringEventWeightTable = cms.EDProducer("GlobalVariablesTableProducer",
     )
 )
 
-triggerObjectTables = cms.Sequence( unpackedPatTrigger + triggerObjectTable )
+l1bits=cms.EDProducer("L1TriggerResultsConverter",
+                      src=cms.InputTag("gtStage2Digis"),
+                      legacyL1=cms.bool(False),
+                      storeUnprefireableBit=cms.bool(True),
+                      src_ext=cms.InputTag("gtStage2Digis"))
 
-_triggerObjectTables_withL1PreFiring = triggerObjectTables.copy()
-_triggerObjectTables_withL1PreFiring.replace(triggerObjectTable, prefiringweight + l1PreFiringEventWeightTable + triggerObjectTable)
-(run2_HLTconditions_2016 | run2_HLTconditions_2017 | run2_HLTconditions_2018).toReplaceWith(triggerObjectTables, _triggerObjectTables_withL1PreFiring)
+triggerObjectTablesTask = cms.Task( unpackedPatTrigger,triggerObjectTable,l1bits)
+
+_triggerObjectTablesTask_withL1PreFiring = triggerObjectTablesTask.copy()
+_triggerObjectTablesTask_withL1PreFiring.add(prefiringweight,l1PreFiringEventWeightTable)
+(run2_HLTconditions_2016 | run2_HLTconditions_2017 | run2_HLTconditions_2018).toReplaceWith(triggerObjectTablesTask,_triggerObjectTablesTask_withL1PreFiring)
+
+triggerObjectTables = cms.Sequence( triggerObjectTablesTask )
+
+(run2_miniAOD_80XLegacy | run2_nanoAOD_94X2016 | run2_nanoAOD_94XMiniAODv1 | run2_nanoAOD_94XMiniAODv2 | run2_nanoAOD_102Xv1).toModify(l1bits, storeUnprefireableBit=False)

--- a/PhysicsTools/NanoAOD/python/triggerObjects_cff.py
+++ b/PhysicsTools/NanoAOD/python/triggerObjects_cff.py
@@ -262,6 +262,4 @@ _triggerObjectTablesTask_withL1PreFiring = triggerObjectTablesTask.copy()
 _triggerObjectTablesTask_withL1PreFiring.add(prefiringweight,l1PreFiringEventWeightTable)
 (run2_HLTconditions_2016 | run2_HLTconditions_2017 | run2_HLTconditions_2018).toReplaceWith(triggerObjectTablesTask,_triggerObjectTablesTask_withL1PreFiring)
 
-triggerObjectTables = cms.Sequence( triggerObjectTablesTask )
-
 (run2_miniAOD_80XLegacy | run2_nanoAOD_94X2016 | run2_nanoAOD_94XMiniAODv1 | run2_nanoAOD_94XMiniAODv2 | run2_nanoAOD_102Xv1).toModify(l1bits, storeUnprefireableBit=False)

--- a/PhysicsTools/NanoAOD/python/ttbarCategorization_cff.py
+++ b/PhysicsTools/NanoAOD/python/ttbarCategorization_cff.py
@@ -42,6 +42,5 @@ ttbarCategoryTable = cms.EDProducer("GlobalVariablesTableProducer",
                                         genTtbarId = ExtVar( cms.InputTag("categorizeGenTtbar:genTtbarId"), "int", doc = "ttbar categorization")
                                     )
 )
-
+ttbarCategoryTableTask = cms.Task(ttbarCategoryTable)
 ttbarCatMCProducersTask = cms.Task(matchGenBHadron,matchGenCHadron,categorizeGenTtbar)
-ttbarCatMCProducers = cms.Sequence(ttbarCatMCProducersTask)

--- a/PhysicsTools/NanoAOD/python/ttbarCategorization_cff.py
+++ b/PhysicsTools/NanoAOD/python/ttbarCategorization_cff.py
@@ -43,4 +43,5 @@ ttbarCategoryTable = cms.EDProducer("GlobalVariablesTableProducer",
                                     )
 )
 
-ttbarCatMCProducers = cms.Sequence(matchGenBHadron + matchGenCHadron + categorizeGenTtbar)
+ttbarCatMCProducersTask = cms.Task(matchGenBHadron,matchGenCHadron,categorizeGenTtbar)
+ttbarCatMCProducers = cms.Sequence(ttbarCatMCProducersTask)

--- a/PhysicsTools/NanoAOD/python/vertices_cff.py
+++ b/PhysicsTools/NanoAOD/python/vertices_cff.py
@@ -41,5 +41,5 @@ svCandidateTable.variables.phi.precision=12
 #before cross linking
 vertexSequence = cms.Sequence()
 #after cross linkining
-vertexTables = cms.Sequence( vertexTable+svCandidateTable)
-
+vertexTablesTask = cms.Task( vertexTable,svCandidateTable )
+vertexTables = cms.Sequence( vertexTablesTask )

--- a/PhysicsTools/NanoAOD/python/vertices_cff.py
+++ b/PhysicsTools/NanoAOD/python/vertices_cff.py
@@ -39,7 +39,6 @@ svCandidateTable.variables.phi.precision=12
 
 
 #before cross linking
-vertexSequence = cms.Sequence()
+vertexTask = cms.Task()
 #after cross linkining
 vertexTablesTask = cms.Task( vertexTable,svCandidateTable )
-vertexTables = cms.Sequence( vertexTablesTask )


### PR DESCRIPTION
This draft PR: attempt to update the nano sequence to run together with mini (reco + DQM)
* replaced all the Sequence with Task (this is needed otherwise we have "ScheduleExecutionFailure"
very long list of modules with order problems here ~ http://dalfonso.web.cern.ch/dalfonso/orderingModulesNano.txt)
* moved some customisation from nano_cff to each object

For the moment: photon/electron//METrecalibration are dummy
These objects recycle sequence used for miniAOD called from inside the nano_cff.py
I will need to follow with EGM/JME POGS
run3_nanoAOD_devel at the end should not be used as the master version should be able to run straigh on the newer nano.

TESTED so far:
1)  nanoGen (porting complete) wf 546 works

2) 106Xv2 (i.e. nanoV9) wf 136.8523 runs

3) cmsDriver.py step3 --conditions auto:phase1_2021_realistic -s RAW2DIGI,L1Reco,RECO,RECOSIM,EI,PAT,NANO,VALIDATION:@standardValidation+@miniAODValidation,DQM:@standardDQM+@ExtraHLT+@miniAODDQM --datatier GEN-SIM-RECO,MINIAODSIM,NANOAODSIM,DQMIO -n 10 --geometry DB:Extended --era Run3,run3_nanoAOD_devel --eventcontent RECOSIM,MINIAODSIM,NANOEDMAODSIM,DQM --filein file:step2.root --fileout file:step3.root

runs with step2 from wf 11634.0

4) previous eras fails tested because of the shortcut  in photon/electron/tau/boostedtau/METrecalibration 
136.8521 (102Xv1)
136.7952 (94Xv2)

5) JMEnano will stop working:
JME sequences too customs and need to by updated by JME
https://github.com/cms-sw/cmssw/blob/master/PhysicsTools/NanoAOD/python/custom_jme_cff.py

