### PR TITLE
Use gain dependent ToT thresholds for HGC digitization

### DIFF
--- a/SimCalorimetry/HGCalSimAlgos/interface/HGCalSiNoiseMap.h
+++ b/SimCalorimetry/HGCalSimAlgos/interface/HGCalSiNoiseMap.h
@@ -102,6 +102,7 @@ public:
   std::vector<double> &getMaxADCPerGain() { return chargeAtFullScaleADCPerGain_; }
   double getENCpad(double ileak);
   void setCachedOp(bool flag) { activateCachedOp_ = flag; }
+  double getTDCOnsetAuto(uint32_t gainIdx);
 
   inline void setENCCommonNoiseSubScale(double val) { encCommonNoiseSub_ = val; }
 

--- a/SimCalorimetry/HGCalSimAlgos/interface/HGCalSiNoiseMap.icc
+++ b/SimCalorimetry/HGCalSimAlgos/interface/HGCalSiNoiseMap.icc
@@ -94,10 +94,9 @@ double HGCalSiNoiseMap<T>::getENCpad(double ileak) {
 
 //
 template <typename T>
-double HGCalSiNoiseMap<T>::getTDCOnsetAuto(uint32_t gainIdx)
-{
+double HGCalSiNoiseMap<T>::getTDCOnsetAuto(uint32_t gainIdx) {
   if (gainIdx < 3) {
-      return chargeAtFullScaleADCPerGain_[gainIdx];
+    return chargeAtFullScaleADCPerGain_[gainIdx];
   }
 
   return -1;

--- a/SimCalorimetry/HGCalSimAlgos/interface/HGCalSiNoiseMap.icc
+++ b/SimCalorimetry/HGCalSimAlgos/interface/HGCalSiNoiseMap.icc
@@ -94,6 +94,17 @@ double HGCalSiNoiseMap<T>::getENCpad(double ileak) {
 
 //
 template <typename T>
+double HGCalSiNoiseMap<T>::getTDCOnsetAuto(uint32_t gainIdx)
+{
+  if (gainIdx < 3) {
+      return chargeAtFullScaleADCPerGain_[gainIdx];
+  }
+
+  return -1;
+}
+
+//
+template <typename T>
 void HGCalSiNoiseMap<T>::setGeometry(const CaloSubdetectorGeometry *hgcGeom, GainRange_t gain, int aimMIPtoADC) {
   //call base class method
   HGCalRadiationMap::setGeometry(hgcGeom);

--- a/SimCalorimetry/HGCalSimAlgos/interface/HGCalSiNoiseMap.icc
+++ b/SimCalorimetry/HGCalSimAlgos/interface/HGCalSiNoiseMap.icc
@@ -96,7 +96,7 @@ double HGCalSiNoiseMap<T>::getENCpad(double ileak) {
 template <typename T>
 double HGCalSiNoiseMap<T>::getTDCOnsetAuto(uint32_t gainIdx) {
   if (gainIdx < 3) {
-    return chargeAtFullScaleADCPerGain_[gainIdx] -1e-6;
+    return chargeAtFullScaleADCPerGain_[gainIdx] - 1e-6;
   }
 
   return -1;

--- a/SimCalorimetry/HGCalSimAlgos/interface/HGCalSiNoiseMap.icc
+++ b/SimCalorimetry/HGCalSimAlgos/interface/HGCalSiNoiseMap.icc
@@ -96,7 +96,7 @@ double HGCalSiNoiseMap<T>::getENCpad(double ileak) {
 template <typename T>
 double HGCalSiNoiseMap<T>::getTDCOnsetAuto(uint32_t gainIdx) {
   if (gainIdx < 3) {
-    return chargeAtFullScaleADCPerGain_[gainIdx];
+    return chargeAtFullScaleADCPerGain_[gainIdx] -1e-6;
   }
 
   return -1;

--- a/SimCalorimetry/HGCalSimProducers/interface/HGCFEElectronics.h
+++ b/SimCalorimetry/HGCalSimProducers/interface/HGCFEElectronics.h
@@ -51,7 +51,8 @@ public:
         break;
       }
       case WITHTOT: {
-        runShaperWithToT(dataFrame, chargeColl, toa, engine, thrADC, lsbADC, gainIdx, maxADC, thickness, tdcOnsetAuto, adcPulse);
+        runShaperWithToT(
+            dataFrame, chargeColl, toa, engine, thrADC, lsbADC, gainIdx, maxADC, thickness, tdcOnsetAuto, adcPulse);
         break;
       }
       default: {
@@ -140,7 +141,8 @@ public:
                         float maxADC,
                         int thickness,
                         float tdcOnsetAuto) {
-    runShaperWithToT(dataFrame, chargeColl, toa, engine, thrADC, lsbADC, gainIdx, maxADC, thickness, tdcOnsetAuto, adcPulse_);
+    runShaperWithToT(
+        dataFrame, chargeColl, toa, engine, thrADC, lsbADC, gainIdx, maxADC, thickness, tdcOnsetAuto, adcPulse_);
   }
 
   /**

--- a/SimCalorimetry/HGCalSimProducers/interface/HGCFEElectronics.h
+++ b/SimCalorimetry/HGCalSimProducers/interface/HGCFEElectronics.h
@@ -43,14 +43,15 @@ public:
                         float lsbADC = -1,
                         uint32_t gainIdx = 0,
                         float maxADC = -1,
-                        int thickness = 1) {
+                        int thickness = 1,
+                        float tdcOnsetAuto = -1) {
     switch (fwVersion_) {
       case SIMPLE: {
         runSimpleShaper(dataFrame, chargeColl, thrADC, lsbADC, gainIdx, maxADC, adcPulse);
         break;
       }
       case WITHTOT: {
-        runShaperWithToT(dataFrame, chargeColl, toa, engine, thrADC, lsbADC, gainIdx, maxADC, thickness, adcPulse);
+        runShaperWithToT(dataFrame, chargeColl, toa, engine, thrADC, lsbADC, gainIdx, maxADC, thickness, tdcOnsetAuto, adcPulse);
         break;
       }
       default: {
@@ -127,6 +128,7 @@ public:
                         uint32_t gainIdx,
                         float maxADC,
                         int thickness,
+                        float tdcOnsetAuto,
                         const hgc_digi::FEADCPulseShape& adcPulse);
   void runShaperWithToT(DFr& dataFrame,
                         hgc::HGCSimHitData& chargeColl,
@@ -136,8 +138,9 @@ public:
                         float lsbADC,
                         uint32_t gainIdx,
                         float maxADC,
-                        int thickness) {
-    runShaperWithToT(dataFrame, chargeColl, toa, engine, thrADC, lsbADC, gainIdx, maxADC, thickness, adcPulse_);
+                        int thickness,
+                        float tdcOnsetAuto) {
+    runShaperWithToT(dataFrame, chargeColl, toa, engine, thrADC, lsbADC, gainIdx, maxADC, thickness, tdcOnsetAuto, adcPulse_);
   }
 
   /**

--- a/SimCalorimetry/HGCalSimProducers/plugins/HGCDigitizerBase.cc
+++ b/SimCalorimetry/HGCalSimProducers/plugins/HGCDigitizerBase.cc
@@ -144,6 +144,7 @@ void HGCDigitizerBase::runSimple(std::unique_ptr<HGCDigitizerBase::DColl>& coll,
     uint32_t gainIdx = 0;
     std::array<float, 6>& adcPulse = myFEelectronics_->getDefaultADCPulse();
 
+    double tdcOnsetAuto = -1;
     if (scaleByDose_) {
       if (id.det() == DetId::Forward && id.subdetId() == ForwardSubdetector::HFNose) {
         HGCalSiNoiseMap<HFNoseDetId>::SiCellOpCharacteristicsCore siop = scalHFNose_.getSiCellOpCharacteristicsCore(id);
@@ -154,6 +155,7 @@ void HGCDigitizerBase::runSimple(std::unique_ptr<HGCDigitizerBase::DColl>& coll,
         maxADC = scalHFNose_.getMaxADCPerGain()[gain];
         adcPulse = scalHFNose_.adcPulseForGain(gain);
         gainIdx = siop.gain;
+        tdcOnsetAuto = scal_.getTDCOnsetAuto(gainIdx);
         if (thresholdFollowsMIP_)
           thrADC = siop.thrADC;
       } else {
@@ -165,6 +167,7 @@ void HGCDigitizerBase::runSimple(std::unique_ptr<HGCDigitizerBase::DColl>& coll,
         maxADC = scal_.getMaxADCPerGain()[gain];
         adcPulse = scal_.adcPulseForGain(gain);
         gainIdx = siop.gain;
+        tdcOnsetAuto = scal_.getTDCOnsetAuto(gainIdx);
         if (thresholdFollowsMIP_)
           thrADC = siop.thrADC;
       }
@@ -205,7 +208,7 @@ void HGCDigitizerBase::runSimple(std::unique_ptr<HGCDigitizerBase::DColl>& coll,
     DFr rawDataFrame(id);
     int thickness = cell.thickness > 0 ? cell.thickness : 1;
     myFEelectronics_->runShaper(
-        rawDataFrame, chargeColl, toa, adcPulse, engine, thrADC, lsbADC, gainIdx, maxADC, thickness);
+        rawDataFrame, chargeColl, toa, adcPulse, engine, thrADC, lsbADC, gainIdx, maxADC, thickness, tdcOnsetAuto);
 
     //update the output according to the final shape
     updateOutput(coll, rawDataFrame);

--- a/SimCalorimetry/HGCalSimProducers/src/HGCFEElectronics.cc
+++ b/SimCalorimetry/HGCalSimProducers/src/HGCFEElectronics.cc
@@ -257,7 +257,7 @@ void HGCFEElectronics<DFr>::runShaperWithToT(DFr& dataFrame,
     if (busyFlags[it])
       continue;
 
-    if (tdcOnsetAuto < 0)  {
+    if (tdcOnsetAuto < 0) {
       tdcOnsetAuto = tdcOnset_fC_;
     }
     //if below TDC onset will be handled by SARS ADC later

--- a/SimCalorimetry/HGCalSimProducers/src/HGCFEElectronics.cc
+++ b/SimCalorimetry/HGCalSimProducers/src/HGCFEElectronics.cc
@@ -213,6 +213,7 @@ void HGCFEElectronics<DFr>::runShaperWithToT(DFr& dataFrame,
                                              uint32_t gainIdx,
                                              float maxADC,
                                              int thickness,
+                                             float tdcOnsetAuto,
                                              const hgc_digi::FEADCPulseShape& adcPulse) {
   busyFlags.fill(false);
   totFlags.fill(false);
@@ -256,9 +257,12 @@ void HGCFEElectronics<DFr>::runShaperWithToT(DFr& dataFrame,
     if (busyFlags[it])
       continue;
 
+    if (tdcOnsetAuto < 0)  {
+      tdcOnsetAuto = tdcOnset_fC_;
+    }
     //if below TDC onset will be handled by SARS ADC later
     float charge = chargeColl[it];
-    if (charge < tdcOnset_fC_) {
+    if (charge < tdcOnsetAuto) {
       debug = false;
       continue;
     }
@@ -362,7 +366,7 @@ void HGCFEElectronics<DFr>::runShaperWithToT(DFr& dataFrame,
       if (toaMode_ == WEIGHTEDBYE)
         finalToA /= totalCharge;
     }
-    newCharge[it] = (totalCharge - tdcOnset_fC_);
+    newCharge[it] = (totalCharge - tdcOnsetAuto);
 
     if (debug)
       edm::LogVerbatim("HGCFE") << "\t Final busy estimate=" << integTime << " ns = " << busyBxs << " bxs" << std::endl
@@ -372,9 +376,9 @@ void HGCFEElectronics<DFr>::runShaperWithToT(DFr& dataFrame,
     //last fC (tdcOnset) are dissipated trough pulse
     if (it + busyBxs < (int)(newCharge.size())) {
       const float deltaT2nextBx((busyBxs * 25 - integTime));
-      const float tdcOnsetLeakage(tdcOnset_fC_ * vdt::fast_expf(-deltaT2nextBx / tdcChargeDrainParameterisation_[11]));
+      const float tdcOnsetLeakage(tdcOnsetAuto * vdt::fast_expf(-deltaT2nextBx / tdcChargeDrainParameterisation_[11]));
       if (debug)
-        edm::LogVerbatim("HGCFE") << "\t Leaking remainder of TDC onset " << tdcOnset_fC_ << " fC, to be dissipated in "
+        edm::LogVerbatim("HGCFE") << "\t Leaking remainder of TDC onset " << tdcOnsetAuto << " fC, to be dissipated in "
                                   << deltaT2nextBx << " DeltaT/tau=" << deltaT2nextBx << " / "
                                   << tdcChargeDrainParameterisation_[11] << " ns, adds " << tdcOnsetLeakage << " fC @ "
                                   << it + busyBxs << " bx (first free bx)" << std::endl;


### PR DESCRIPTION
#### PR description:
The time-over-threshold mode is enabled depending on the gain parameter applied for the sensor. See [1] for the impact of changes.

[1] : https://indico.cern.ch/event/1049055/contributions/4409458/attachments/2265641/3846729/210616_HGC_DPG_dynamic_ADC_TOT.pdf
#### PR validation:

Passed WF 23234.103 in 12_0_0_pre3.

@pfs 