### PR TITLE
Update BeamSpotOnline tags for CRUZET [11_3_X]

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -34,11 +34,11 @@ autoCond = {
     # GlobalTag for Run2 HI data
     'run2_data_promptlike_hi'      : '113X_dataRun2_PromptLike_HI_v6',
     # GlobalTag for Run3 HLT: it points to the online GT
-    'run3_hlt'                     : '113X_dataRun3_HLT_Candidate_2021_07_02_14_05_25',
+    'run3_hlt'                     : '113X_dataRun3_HLT_v3',
     # GlobalTag with fixed snapshot time for Run2 HLT RelVals: customizations to run with fixed L1 Menu
     'run2_hlt_relval'              : '113X_dataRun2_HLT_relval_v2',
     # GlobalTag for Run3 data relvals (express GT)
-    'run3_data_express'            : '113X_dataRun3_Express_Candidate_2021_07_02_14_38_40',
+    'run3_data_express'            : '113X_dataRun3_Express_v4',
     # GlobalTag for Run3 data relvals
     'run3_data_prompt'             : '113X_dataRun3_Prompt_v3',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,~0-centred beamspot)

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -34,11 +34,11 @@ autoCond = {
     # GlobalTag for Run2 HI data
     'run2_data_promptlike_hi'      : '113X_dataRun2_PromptLike_HI_v6',
     # GlobalTag for Run3 HLT: it points to the online GT
-    'run3_hlt'                     : '113X_dataRun3_HLT_v2',
+    'run3_hlt'                     : '113X_dataRun3_HLT_Candidate_2021_07_02_14_05_25',
     # GlobalTag with fixed snapshot time for Run2 HLT RelVals: customizations to run with fixed L1 Menu
     'run2_hlt_relval'              : '113X_dataRun2_HLT_relval_v2',
     # GlobalTag for Run3 data relvals (express GT)
-    'run3_data_express'            : '113X_dataRun3_Express_v3',
+    'run3_data_express'            : '113X_dataRun3_Express_Candidate_2021_07_02_14_38_40',
     # GlobalTag for Run3 data relvals
     'run3_data_prompt'             : '113X_dataRun3_Prompt_v3',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,~0-centred beamspot)

--- a/DQM/Integration/python/clients/beam_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/beam_dqm_sourceclient-live_cfg.py
@@ -4,8 +4,8 @@ import FWCore.ParameterSet.Config as cms
 # Define here the BeamSpotOnline record name,
 # it will be used both in BeamMonitor setup and in payload creation/upload
 BSOnlineRecordName = 'BeamSpotOnlineLegacyObjectsRcd'
-BSOnlineTag = 'BeamSpotOnlineTestLegacy'
-BSOnlineJobName = 'BeamSpotOnlineTestLegacy'
+BSOnlineTag = 'BeamSpotOnlineLegacy'
+BSOnlineJobName = 'BeamSpotOnlineLegacy'
 BSOnlineOmsServiceUrl = 'http://cmsoms-services.cms:9949/urn:xdaq-application:lid=100/getRunAndLumiSection'
 useLockRecords = True
 

--- a/DQM/Integration/python/clients/beamfake_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/beamfake_dqm_sourceclient-live_cfg.py
@@ -5,8 +5,8 @@ import time
 # Define here the BeamSpotOnline record name,
 # it will be used both in FakeBeamMonitor setup and in payload creation/upload
 BSOnlineRecordName = 'BeamSpotOnlineLegacyObjectsRcd'
-BSOnlineTag = 'BeamSpotOnlineTestLegacy'
-BSOnlineJobName = 'BeamSpotOnlineTestLegacy'
+BSOnlineTag = 'BeamSpotOnlineLegacy'
+BSOnlineJobName = 'BeamSpotOnlineLegacy'
 BSOnlineOmsServiceUrl = 'http://cmsoms-services.cms:9949/urn:xdaq-application:lid=100/getRunAndLumiSection'
 useLockRecords = True
 import sys

--- a/DQM/Integration/python/clients/beamhlt_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/beamhlt_dqm_sourceclient-live_cfg.py
@@ -4,8 +4,8 @@ import FWCore.ParameterSet.Config as cms
 # Define once the BeamSpotOnline record name,
 # will be used both in BeamMonitor setup and in payload creation/upload
 BSOnlineRecordName = 'BeamSpotOnlineHLTObjectsRcd'
-BSOnlineTag = 'BeamSpotOnlineTestHLT'
-BSOnlineJobName = 'BeamSpotOnlineTestHLT'
+BSOnlineTag = 'BeamSpotOnlineHLT'
+BSOnlineJobName = 'BeamSpotOnlineHLT'
 BSOnlineOmsServiceUrl = 'http://cmsoms-services.cms:9949/urn:xdaq-application:lid=100/getRunAndLumiSection'
 useLockRecords = True
 

--- a/DQM/Integration/python/clients/beamhltfake_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/beamhltfake_dqm_sourceclient-live_cfg.py
@@ -4,8 +4,8 @@ import FWCore.ParameterSet.Config as cms
 # Define here the BeamSpotOnline record name,
 # it will be used both in FakeBeamMonitor setup and in payload creation/upload
 BSOnlineRecordName = 'BeamSpotOnlineHLTObjectsRcd'
-BSOnlineTag = 'BeamSpotOnlineTestHLT'
-BSOnlineJobName = 'BeamSpotOnlineTestHLT'
+BSOnlineTag = 'BeamSpotOnlineHLT'
+BSOnlineJobName = 'BeamSpotOnlineHLT'
 BSOnlineOmsServiceUrl = 'http://cmsoms-services.cms:9949/urn:xdaq-application:lid=100/getRunAndLumiSection'
 useLockRecords = True
 

--- a/DQM/Integration/python/clients/onlinebeammonitor_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/onlinebeammonitor_dqm_sourceclient-live_cfg.py
@@ -117,28 +117,8 @@ else:
 
 #ESProducer
 process.load("CondCore.CondDB.CondDB_cfi")
-process.BeamSpotDBSource = cms.ESSource("PoolDBESSource",
-                      process.CondDB,
-                      toGet = cms.VPSet(
-                            cms.PSet(
-                                record = cms.string('BeamSpotOnlineLegacyObjectsRcd'),
-                                tag = cms.string("BeamSpotOnlineTestLegacy"),
-                                refreshTime = cms.uint64(1)
-                            ),
-                            cms.PSet(
-                                record = cms.string('BeamSpotOnlineHLTObjectsRcd'),
-                                tag = cms.string("BeamSpotOnlineTestHLT"),
-                                refreshTime = cms.uint64(1)
-
-                            ),
-                      )
-
-)
 process.BeamSpotESProducer = cms.ESProducer("OnlineBeamSpotESProducer")
-#if unitTest == True:
-process.BeamSpotDBSource.connect = cms.string('frontier://FrontierProd/CMS_CONDITIONS')
-#else:
-#  process.BeamSpotDBSource.connect = cms.string('oracle://cms_orcon_prod/CMS_CONDITIONS')
+
 #-----------------------------
 # DQM Live Environment
 #-----------------------------


### PR DESCRIPTION
#### PR description:
This PR updates the BeamSpotOnline tags to the "production" version (i.e. removed the word `Test` from the tag name)
to be used at HLT and in Express for CRUZET onwards:
- udpated names of the tags in the DQM online clients that write the payloads
- removed the ESSource in the `onlinebeammonitor` DQM client (avaid crash from multiple sources)
- add to `autoCond.py` HLT and Express candidate GTs which contain the new tags:
  - [BeamSpotOnlineHLT](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/tags/BeamSpotOnlineHLT)
  - [BeamSpotOnlineLegacy](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/tags/BeamSpotOnlineLegacy)

As agreed with TRK DPG and POG (FYI @mtosi @mmusich) for now the tags only contain one payload with `since = 1` and with a "fakeBS":

```
 Beam type    = -1
       X0     = 0.0001 +/- 0 [cm]
       Y0     = 0.0001 +/- 0 [cm]
       Z0     = 0.0001 +/- 0 [cm]
 Sigma Z0     = 15 +/- 0 [cm]
 dxdz         = 0 +/- 0 [radians]
 dydz         = 0 +/- 0 [radians]
 Beam Width X = 0.1 +/- 0 [cm]
 Beam Width Y = 0.1 +/- 0 [cm]
 Emittance X  = 0 [cm]
 Emittance Y  = 0 [cm]
 Beta star    = 0 [cm]
 Last Lumi    = 1
 Last Run     = 1
 Last Fill    = 0
```

The GT diffs are as follow:
HLT: https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/113X_dataRun3_HLT_Candidate_2021_07_02_14_05_25/113X_dataRun3_HLT_v2
Express: https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/113X_dataRun3_Express_Candidate_2021_07_02_14_38_40/113X_dataRun3_Express_v3

**IMPORTANT NOTE**
This PR is needed to DQM in order to test the candidates, once both DQM and HLT confirm the candidates are fine they will be turned into versioned GTs and I will update this PR. This is needed for CRUZET.
FYI @qliphy @silviodonato @amassiro @boudoul 

**-EDIT-**
DQM and HLT validated the candidates ([HN message](https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/4421.html)), so I made the versioned GTs for CRUZET by copying the candidates:
HLT: [113X_dataRun3_HLT_v3](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/113X_dataRun3_HLT_v3)
Express: [113X_dataRun3_Express_v4](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/113X_dataRun3_Express_v4)
The new diffs are:
**Run 3 data HLT**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/113X_dataRun3_HLT_v2/113X_dataRun3_HLT_v3

**Run 3 data (express)**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/113X_dataRun3_Express_v3/113X_dataRun3_Express_v4


#### PR validation:
Tested with:
```
runTheMatrix.py -l 138.2 --ibeos -j 8
addOnTests.py -j 8
```

#### Back/Forward-port:
This will be forward-ported to master.
