### PR TITLE
Add new plots to ECAL Offline DQM with Pedestal and Laser transparency correction from the Database

### DIFF
--- a/DQM/EcalMonitorTasks/interface/OccupancyTask.h
+++ b/DQM/EcalMonitorTasks/interface/OccupancyTask.h
@@ -6,6 +6,10 @@
 #include "DataFormats/EcalRawData/interface/EcalRawDataCollections.h"
 #include "DataFormats/EcalDigi/interface/EcalDigiCollections.h"
 #include "DataFormats/EcalRecHit/interface/EcalRecHitCollections.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "CalibCalorimetry/EcalLaserCorrection/interface/EcalLaserDbRecord.h"
+#include "CalibCalorimetry/EcalLaserCorrection/interface/EcalLaserDbService.h"
+#include "DataFormats/Provenance/interface/Timestamp.h"
 
 namespace ecaldqm {
   class OccupancyTask : public DQWorkerTask {
@@ -16,7 +20,7 @@ namespace ecaldqm {
     bool filterRunType(short const*) override;
 
     void beginEvent(edm::Event const&, edm::EventSetup const&, bool const&, bool&) override;
-
+    void beginRun(edm::Run const&, edm::EventSetup const&) override;
     bool analyze(void const*, Collections) override;
 
     void runOnRawData(EcalRawDataCollection const&);
@@ -24,12 +28,14 @@ namespace ecaldqm {
     void runOnDigis(DigiCollection const&, Collections);
     void runOnTPDigis(EcalTrigPrimDigiCollection const&);
     void runOnRecHits(EcalRecHitCollection const&, Collections);
-
+    void setEventTime(const edm::TimeValue_t& iTime);
   private:
     void setParams(edm::ParameterSet const&) override;
-
+    edm::ESHandle<EcalLaserDbService> laser;
+    bool FillLaser = false;
     float recHitThreshold_;
     float tpThreshold_;
+    edm::TimeValue_t m_iTime;
   };
 
   inline bool OccupancyTask::analyze(void const* _p, Collections _collection) {

--- a/DQM/EcalMonitorTasks/interface/OccupancyTask.h
+++ b/DQM/EcalMonitorTasks/interface/OccupancyTask.h
@@ -29,6 +29,7 @@ namespace ecaldqm {
     void runOnTPDigis(EcalTrigPrimDigiCollection const&);
     void runOnRecHits(EcalRecHitCollection const&, Collections);
     void setEventTime(const edm::TimeValue_t& iTime);
+
   private:
     void setParams(edm::ParameterSet const&) override;
     edm::ESHandle<EcalLaserDbService> laser;

--- a/DQM/EcalMonitorTasks/interface/OccupancyTask.h
+++ b/DQM/EcalMonitorTasks/interface/OccupancyTask.h
@@ -10,6 +10,7 @@
 #include "CalibCalorimetry/EcalLaserCorrection/interface/EcalLaserDbRecord.h"
 #include "CalibCalorimetry/EcalLaserCorrection/interface/EcalLaserDbService.h"
 #include "DataFormats/Provenance/interface/Timestamp.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 
 namespace ecaldqm {
   class OccupancyTask : public DQWorkerTask {
@@ -29,10 +30,11 @@ namespace ecaldqm {
     void runOnTPDigis(EcalTrigPrimDigiCollection const&);
     void runOnRecHits(EcalRecHitCollection const&, Collections);
     void setEventTime(const edm::TimeValue_t& iTime);
+    void setTokens(edm::ConsumesCollector&) override;
 
   private:
     void setParams(edm::ParameterSet const&) override;
-    edm::ESHandle<EcalLaserDbService> laser;
+    edm::ESGetToken<EcalLaserDbService, EcalLaserDbRecord> lasertoken_;
     bool FillLaser = false;
     float recHitThreshold_;
     float tpThreshold_;

--- a/DQM/EcalMonitorTasks/interface/PresampleTask.h
+++ b/DQM/EcalMonitorTasks/interface/PresampleTask.h
@@ -5,6 +5,9 @@
 
 #include "DataFormats/EcalDigi/interface/EcalDigiCollections.h"
 #include "DataFormats/EcalDigi/interface/EcalDataFrame.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "CondFormats/EcalObjects/interface/EcalPedestals.h"
+#include "CondFormats/DataRecord/interface/EcalPedestalsRcd.h"
 
 namespace ecaldqm {
   class PresampleTask : public DQWorkerTask {
@@ -14,6 +17,7 @@ namespace ecaldqm {
 
     bool filterRunType(short const*) override;
 
+    void beginRun(edm::Run const&, edm::EventSetup const&) override;
     void beginEvent(edm::Event const&, edm::EventSetup const&, bool const&, bool&) override;
     bool analyze(void const*, Collections) override;
 
@@ -27,6 +31,9 @@ namespace ecaldqm {
     int pulseMaxPosition_;
     int nSamples_;
     MESet* mePedestalByLS;
+    bool FillPedestal = false;
+    edm::ESHandle<EcalPedestals> pPeds;
+
   };
 
   inline bool PresampleTask::analyze(void const* _p, Collections _collection) {

--- a/DQM/EcalMonitorTasks/interface/PresampleTask.h
+++ b/DQM/EcalMonitorTasks/interface/PresampleTask.h
@@ -8,6 +8,7 @@
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "CondFormats/EcalObjects/interface/EcalPedestals.h"
 #include "CondFormats/DataRecord/interface/EcalPedestalsRcd.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 
 namespace ecaldqm {
   class PresampleTask : public DQWorkerTask {
@@ -23,16 +24,16 @@ namespace ecaldqm {
 
     template <typename DigiCollection>
     void runOnDigis(DigiCollection const&);
+    void setTokens(edm::ConsumesCollector&) override;
 
   private:
     void setParams(edm::ParameterSet const&) override;
-
+    edm::ESGetToken<EcalPedestals, EcalPedestalsRcd> Pedtoken_;
     bool doPulseMaxCheck_;
     int pulseMaxPosition_;
     int nSamples_;
     MESet* mePedestalByLS;
     bool FillPedestal = false;
-    edm::ESHandle<EcalPedestals> pPeds;
   };
 
   inline bool PresampleTask::analyze(void const* _p, Collections _collection) {

--- a/DQM/EcalMonitorTasks/interface/PresampleTask.h
+++ b/DQM/EcalMonitorTasks/interface/PresampleTask.h
@@ -33,7 +33,6 @@ namespace ecaldqm {
     MESet* mePedestalByLS;
     bool FillPedestal = false;
     edm::ESHandle<EcalPedestals> pPeds;
-
   };
 
   inline bool PresampleTask::analyze(void const* _p, Collections _collection) {

--- a/DQM/EcalMonitorTasks/python/OccupancyTask_cfi.py
+++ b/DQM/EcalMonitorTasks/python/OccupancyTask_cfi.py
@@ -232,7 +232,18 @@ ecalOccupancyTask = cms.untracked.PSet(
             btype = cms.untracked.string('User'),
             path = cms.untracked.string('%(subdet)s/%(prefix)sOccupancyTask/%(prefix)sOT rec hit thr occupancy z+(far) - z-(near)'),
             description = cms.untracked.string('Filtered rechit occupancy difference.')
+        ),
+	LaserCorrProjEta = cms.untracked.PSet(
+            path = cms.untracked.string('Ecal/Trends/%(prefix)sOT Laser Transparency correction from DB %(suffix)s eta projection'),
+            kind = cms.untracked.string('TProfile'),
+	    yaxis = cms.untracked.PSet(
+		title= cms.untracked.string('Laser transparency correction')
+	    ),
+            otype = cms.untracked.string('Ecal3P'),
+            btype = cms.untracked.string('ProjEta'),
+            description = cms.untracked.string('Projection of average laser transparency correction from DB.')
         )
+
 #        TPDigiProjPhi = cms.untracked.PSet(
 #            path = cms.untracked.string('%(subdet)s/%(prefix)sOccupancyTask/%(prefix)sOT TP digi occupancy%(suffix)s projection phi'),
 #            kind = cms.untracked.string('TH1F'),

--- a/DQM/EcalMonitorTasks/python/PresampleTask_cfi.py
+++ b/DQM/EcalMonitorTasks/python/PresampleTask_cfi.py
@@ -20,6 +20,38 @@ ecalPresampleTask = cms.untracked.PSet(
             otype = cms.untracked.string('SM'),
             btype = cms.untracked.string('Crystal'),
             description = cms.untracked.string('2D distribution of mean presample value for "current" LS.')
-        )
-    )
+        ),
+  	PedestalProjEtaG1 = cms.untracked.PSet(
+            path = cms.untracked.string('Ecal/Trends/%(prefix)sOT Pedestal RMS values from DB %(suffix)s eta projection Gain1'),
+            kind = cms.untracked.string('TProfile'),
+	    yaxis = cms.untracked.PSet(
+	    	title = cms.untracked.string('Pedestal RMS') 
+	    ), 
+            otype = cms.untracked.string('Ecal3P'),
+            btype = cms.untracked.string('ProjEta'),
+            description = cms.untracked.string('Projection of Pedestal rms values from DB')
+       ),
+       PedestalProjEtaG6 = cms.untracked.PSet(
+            path = cms.untracked.string('Ecal/Trends/%(prefix)sOT Pedestal RMS values from DB %(suffix)s eta projection Gain6'),
+            kind = cms.untracked.string('TProfile'),
+	    yaxis = cms.untracked.PSet(
+                title = cms.untracked.string('Pedestal RMS') 
+            ),
+            otype = cms.untracked.string('Ecal3P'),
+            btype = cms.untracked.string('ProjEta'),
+            description = cms.untracked.string('Projection of Pedestal rms values from DB')
+       ),
+
+      PedestalProjEtaG12 = cms.untracked.PSet(
+            path = cms.untracked.string('Ecal/Trends/%(prefix)sOT Pedestal RMS values from DB %(suffix)s eta projection Gain12'),
+            kind = cms.untracked.string('TProfile'),
+	    yaxis = cms.untracked.PSet(
+                title = cms.untracked.string('Pedestal RMS') 
+            ),
+            otype = cms.untracked.string('Ecal3P'),
+            btype = cms.untracked.string('ProjEta'),
+            description = cms.untracked.string('Projection of Pedestal rms values from DB')
+       )
+
+  )
 )

--- a/DQM/EcalMonitorTasks/src/OccupancyTask.cc
+++ b/DQM/EcalMonitorTasks/src/OccupancyTask.cc
@@ -23,54 +23,49 @@ namespace ecaldqm {
 
     return false;
   }
-  
-   void OccupancyTask::beginRun(edm::Run const&, edm::EventSetup const& _es)
-   {
-   
+
+  void OccupancyTask::beginRun(edm::Run const&, edm::EventSetup const& _es) {
     _es.get<EcalLaserDbRecord>().get(laser);
     FillLaser = true;
-	
-   }
-  void OccupancyTask::setEventTime(const edm::TimeValue_t& iTime) {
-      m_iTime = iTime;
   }
+  void OccupancyTask::setEventTime(const edm::TimeValue_t& iTime) { m_iTime = iTime; }
   void OccupancyTask::beginEvent(edm::Event const& _evt,
                                  edm::EventSetup const& _es,
                                  bool const& ByLumiResetSwitch,
-                                 bool&) {	
+                                 bool&) {
     if (ByLumiResetSwitch) {
       MEs_.at("DigiAllByLumi").reset(GetElectronicsMap());
       MEs_.at("TPDigiThrAllByLumi").reset(GetElectronicsMap());
       MEs_.at("RecHitThrAllByLumi").reset(GetElectronicsMap());
     }
     MESet& meLaserCorrProjEta(MEs_.at("LaserCorrProjEta"));
-   if (FillLaser){
-    for ( int i = 0; i < EBDetId::kSizeForDenseIndexing; i++ ) { 
-        if ( !EBDetId::validDenseIndex(i) ) continue;
-        EBDetId ebid( EBDetId::unhashIndex(i) );
-   	 	
- 	const edm::Timestamp& evtTimeStamp = edm::Timestamp(m_iTime);
- 
-        float lasercalib = 1.;
-        lasercalib = laser->getLaserCorrection( ebid, evtTimeStamp);
-        meLaserCorrProjEta.fill(getEcalDQMSetupObjects(), ebid, lasercalib);
-
-    }
-     
-      for ( int i = 0; i < EEDetId::kSizeForDenseIndexing; i++ ) { 
-        if ( !EEDetId::validDenseIndex(i) ) continue;
-        EEDetId eeid( EEDetId::unhashIndex(i) );
+    if (FillLaser) {
+      for (int i = 0; i < EBDetId::kSizeForDenseIndexing; i++) {
+        if (!EBDetId::validDenseIndex(i))
+          continue;
+        EBDetId ebid(EBDetId::unhashIndex(i));
 
         const edm::Timestamp& evtTimeStamp = edm::Timestamp(m_iTime);
 
         float lasercalib = 1.;
-        lasercalib = laser->getLaserCorrection( eeid, evtTimeStamp);
+        lasercalib = laser->getLaserCorrection(ebid, evtTimeStamp);
+        meLaserCorrProjEta.fill(getEcalDQMSetupObjects(), ebid, lasercalib);
+      }
+
+      for (int i = 0; i < EEDetId::kSizeForDenseIndexing; i++) {
+        if (!EEDetId::validDenseIndex(i))
+          continue;
+        EEDetId eeid(EEDetId::unhashIndex(i));
+
+        const edm::Timestamp& evtTimeStamp = edm::Timestamp(m_iTime);
+
+        float lasercalib = 1.;
+        lasercalib = laser->getLaserCorrection(eeid, evtTimeStamp);
         meLaserCorrProjEta.fill(getEcalDQMSetupObjects(), eeid, lasercalib);
-    
+      }
+      FillLaser = false;
     }
-     FillLaser = false;
-  } 
-}
+  }
 
   void OccupancyTask::runOnRawData(EcalRawDataCollection const& _dcchs) {
     MESet& meDCC(MEs_.at("DCC"));

--- a/DQM/EcalMonitorTasks/src/PresampleTask.cc
+++ b/DQM/EcalMonitorTasks/src/PresampleTask.cc
@@ -29,12 +29,10 @@ namespace ecaldqm {
     return false;
   }
 
-void PresampleTask::beginRun(edm::Run const&, edm::EventSetup const& _es)
-   {
+  void PresampleTask::beginRun(edm::Run const&, edm::EventSetup const& _es) {
     _es.get<EcalPedestalsRcd>().get(pPeds);
     FillPedestal = true;
-   }
-
+  }
 
   void PresampleTask::beginEvent(edm::Event const& _evt,
                                  edm::EventSetup const& _es,
@@ -53,33 +51,34 @@ void PresampleTask::beginRun(edm::Run const&, edm::EventSetup const& _es)
     MESet& mePedestalProjEtaG6(MEs_.at("PedestalProjEtaG6"));
     MESet& mePedestalProjEtaG12(MEs_.at("PedestalProjEtaG12"));
 
-   if (FillPedestal){
-     const EcalPedestals* myped = pPeds.product();
+    if (FillPedestal) {
+      const EcalPedestals* myped = pPeds.product();
 
-     for ( int i = 0; i < EBDetId::kSizeForDenseIndexing; i++ ) {
-        if ( !EBDetId::validDenseIndex(i) ) continue;
-        EBDetId ebid( EBDetId::unhashIndex(i) );
+      for (int i = 0; i < EBDetId::kSizeForDenseIndexing; i++) {
+        if (!EBDetId::validDenseIndex(i))
+          continue;
+        EBDetId ebid(EBDetId::unhashIndex(i));
         EcalPedestals::const_iterator it = myped->find(ebid.rawId());
         if (it != myped->end()) {
-         mePedestalProjEtaG1.fill(getEcalDQMSetupObjects(), ebid, (*it).rms_x1);
-         mePedestalProjEtaG6.fill(getEcalDQMSetupObjects(), ebid, (*it).rms_x6);
-	 mePedestalProjEtaG12.fill(getEcalDQMSetupObjects(), ebid, (*it).rms_x12);
-        } 
-     }
-     for ( int i = 0; i < EEDetId::kSizeForDenseIndexing; i++ ) {
-        if ( !EEDetId::validDenseIndex(i) ) continue;
-        EEDetId eeid( EEDetId::unhashIndex(i) );
+          mePedestalProjEtaG1.fill(getEcalDQMSetupObjects(), ebid, (*it).rms_x1);
+          mePedestalProjEtaG6.fill(getEcalDQMSetupObjects(), ebid, (*it).rms_x6);
+          mePedestalProjEtaG12.fill(getEcalDQMSetupObjects(), ebid, (*it).rms_x12);
+        }
+      }
+      for (int i = 0; i < EEDetId::kSizeForDenseIndexing; i++) {
+        if (!EEDetId::validDenseIndex(i))
+          continue;
+        EEDetId eeid(EEDetId::unhashIndex(i));
         EcalPedestals::const_iterator it = myped->find(eeid.rawId());
         if (it != myped->end()) {
-         mePedestalProjEtaG1.fill(getEcalDQMSetupObjects(), eeid, (*it).rms_x1);
-         mePedestalProjEtaG6.fill(getEcalDQMSetupObjects(), eeid, (*it).rms_x6);
-         mePedestalProjEtaG12.fill(getEcalDQMSetupObjects(), eeid, (*it).rms_x12);
-        } 
-     }
+          mePedestalProjEtaG1.fill(getEcalDQMSetupObjects(), eeid, (*it).rms_x1);
+          mePedestalProjEtaG6.fill(getEcalDQMSetupObjects(), eeid, (*it).rms_x6);
+          mePedestalProjEtaG12.fill(getEcalDQMSetupObjects(), eeid, (*it).rms_x12);
+        }
+      }
 
-     FillPedestal = false;
-  }
-
+      FillPedestal = false;
+    }
   }
 
   template <typename DigiCollection>

--- a/DQM/EcalMonitorTasks/src/PresampleTask.cc
+++ b/DQM/EcalMonitorTasks/src/PresampleTask.cc
@@ -16,6 +16,7 @@ namespace ecaldqm {
     pulseMaxPosition_ = _params.getUntrackedParameter<int>("pulseMaxPosition");
     nSamples_ = _params.getUntrackedParameter<int>("nSamples");
   }
+  void PresampleTask::setTokens(edm::ConsumesCollector& _collector) { Pedtoken_ = _collector.esConsumes(); }
 
   bool PresampleTask::filterRunType(short const* _runType) {
     for (int iFED(0); iFED < nDCC; iFED++) {
@@ -29,10 +30,7 @@ namespace ecaldqm {
     return false;
   }
 
-  void PresampleTask::beginRun(edm::Run const&, edm::EventSetup const& _es) {
-    _es.get<EcalPedestalsRcd>().get(pPeds);
-    FillPedestal = true;
-  }
+  void PresampleTask::beginRun(edm::Run const&, edm::EventSetup const& _es) { FillPedestal = true; }
 
   void PresampleTask::beginEvent(edm::Event const& _evt,
                                  edm::EventSetup const& _es,
@@ -52,7 +50,7 @@ namespace ecaldqm {
     MESet& mePedestalProjEtaG12(MEs_.at("PedestalProjEtaG12"));
 
     if (FillPedestal) {
-      const EcalPedestals* myped = pPeds.product();
+      const EcalPedestals* myped = &_es.getData(Pedtoken_);
 
       for (int i = 0; i < EBDetId::kSizeForDenseIndexing; i++) {
         if (!EBDetId::validDenseIndex(i))


### PR DESCRIPTION
#### PR description:

At the request of the ECAL DPG, new plots are added to the Offline DQM workflow, involving pedestal RMS values and laser transparency correction of crystals, read from the database directly, as functions of eta.
These plots would be useful in general for Offline DQM and also crucial in understanding if the conditions loaded by CMSSW changes from one run to the other in RelVal MC validation.

#### PR validation:

The code changes were validated by running the DQM relval workflow 136.874 using the runTheMatrix script
`runTheMatrix.py -l 136.874 --ibeos`

The resultant DQM output file was examined by uploading it to an Offline DQM test GUI and confirming the new plots.
The plots were also approved by the ECAL DPG team.


#### Backport:
A backport PR to CMSSW_11_3_X has been created here: https://github.com/cms-sw/cmssw/pull/34341