### PR TITLE
[DD4hep] Add support for Assembly tags in XML and for creating DB payload

### DIFF
--- a/DetectorDescription/DDCMS/data/testLogicalParts.xml
+++ b/DetectorDescription/DDCMS/data/testLogicalParts.xml
@@ -126,7 +126,14 @@
       <rMaterial name="testMaterials:Air"/>
       <rSolid name="testSolids:extrudedpgon"/>
     </LogicalPart>
-
+    <LogicalPart name="assembly1">
+      <rMaterial name="testMaterials:Air"/>
+      <rSolid name="testSolids:assembly1"/>
+    </LogicalPart>
+    <LogicalPart name="assembly2">
+      <rMaterial name="testMaterials:Air"/>
+      <rSolid name="testSolids:assembly2"/>
+    </LogicalPart>
     <LogicalPart name="V_1101" category="unspecified">
       <rSolid name="testSolids:V_1101"/>
       <rMaterial name="materials:Air"/>

--- a/DetectorDescription/DDCMS/data/testPosParts.xml
+++ b/DetectorDescription/DDCMS/data/testPosParts.xml
@@ -184,5 +184,40 @@
       <rParent name="testLogicalParts:MotherOfAllBoxes"/>
       <rChild name="testLogicalParts:ZStopSpace"/>
     </PosPart>
+    <PosPart copyNumber="1">
+      <rParent name="testLogicalParts:assembly1"/>
+      <rChild name="testLogicalParts:V_1101"/>
+      <Translation z="-8.9*cm" y="5.9*cm" x="0."/>
+    </PosPart>
+    <PosPart copyNumber="2">
+      <rParent name="testLogicalParts:assembly1"/>
+      <rChild name="testLogicalParts:V_1101"/>
+      <Translation z="-8.9*cm" y="5.9*cm" x="0."/>
+      <rReflectionRotation name="testRotations:ReflectionY"/>
+    </PosPart>
+    <PosPart copyNumber="20">
+      <rParent name="testLogicalParts:assembly2"/>
+      <rChild name="testLogicalParts:torus"/>
+      <Translation z="-8.9*cm" y="5.9*cm" x="0."/>
+      <rRotation name="testRotations:z30"/>
+    </PosPart>
+    <PosPart copyNumber="21">
+      <rParent name="testLogicalParts:assembly2"/>
+      <rChild name="testLogicalParts:etube"/>
+      <Translation z="-2.9*cm" y="1.9*cm" x="0."/>
+      <rRotation name="testRotations:z30"/>
+    </PosPart>
+    <PosPart copyNumber="1">
+      <rParent name="testLogicalParts:MotherOfAllBoxes"/>
+      <rChild name="testLogicalParts:assembly1"/>
+      <Translation z="-2.9*cm" y="1.9*cm" x="0."/>
+      <rRotation name="testRotations:z30"/>
+    </PosPart>
+    <PosPart copyNumber="1">
+      <rParent name="testLogicalParts:MotherOfAllBoxes"/>
+      <rChild name="testLogicalParts:assembly2"/>
+      <Translation z="-2.9*cm" y="1.9*cm" x="0.5*cm"/>
+      <rRotation name="testRotations:z30"/>
+    </PosPart>
   </PosPartSection>
 </DDDefinition>

--- a/DetectorDescription/DDCMS/data/testSolids.xml
+++ b/DetectorDescription/DDCMS/data/testSolids.xml
@@ -57,6 +57,8 @@
     <TruncTubs name="trunctubs1" zHalf="50*cm" rMin="20*cm" rMax="40*cm" startPhi="0*deg" deltaPhi="90*deg" cutAtStart="25*cm" cutAtDelta="35*cm" cutInside="true"/>
     <TruncTubs name="trunctubs2" rMin="6.9551*m" rMax="9*m" cutAtStart="6.9551*m" cutAtDelta="7.20045*m" cutInside="true" startPhi="0*deg" deltaPhi="15*deg" zHalf="6.57005*m"/>
     <ShapelessSolid name="momma"/>
+    <Assembly name="assembly1"/>
+    <Assembly name="assembly2"/>
     <Box name="MotherOfAllBoxes" dx="10*m" dy="10*m" dz="10*m"/>
     <Torus name="torus" innerRadius="7.5*cm" outerRadius="10*cm" torusRadius="30*cm" startPhi="0*deg" deltaPhi="360*deg"/>
     <SubtractionSolid name="subsolid" firstSolid="cone2" secondSolid="cone2hole"/>

--- a/DetectorDescription/DDCMS/interface/DDDetector.h
+++ b/DetectorDescription/DDCMS/interface/DDDetector.h
@@ -2,6 +2,7 @@
 #define DetectorDescription_DDCMS_DDDetector_h
 
 #include "DetectorDescription/DDCMS/interface/DDVectorRegistry.h"
+#include "DetectorDescription/DDCMS/interface/DDParsingContext.h"
 #include <DD4hep/Detector.h>
 #include <DD4hep/SpecParRegistry.h>
 #include <string>
@@ -11,7 +12,7 @@ class TGeoManager;
 namespace cms {
   class DDDetector {
   public:
-    explicit DDDetector(const std::string&, const std::string&, bool bigXML = false);
+    explicit DDDetector(const std::string&, const std::string&, bool bigXML = false, bool makePayload = false);
     DDDetector() = delete;
 
     cms::DDVectorsMap const& vectors() const { return m_vectors; }
@@ -33,6 +34,8 @@ namespace cms {
     dd4hep::DetElement findElement(const std::string&) const;
 
     dd4hep::Detector const* description() const { return m_description; }
+
+    DDParsingContext* m_context;
 
   private:
     void process(const std::string&);

--- a/DetectorDescription/DDCMS/interface/DDNamespace.h
+++ b/DetectorDescription/DDCMS/interface/DDNamespace.h
@@ -10,6 +10,12 @@
 
 namespace cms {
 
+  namespace rotation_utils {
+    std::string rotHash(const Double_t* rot);
+    std::string rotHash(const dd4hep::Rotation3D& rot);
+    double roundBinary(double value);
+  }  // namespace rotation_utils
+
   class DDParsingContext;
   using DDVectorsMap = std::unordered_map<std::string, std::vector<double>>;
 
@@ -57,9 +63,11 @@ namespace cms {
     dd4hep::Solid addSolidNS(const std::string& name, dd4hep::Solid solid) const;
 
     dd4hep::Assembly assembly(const std::string& name) const;
-    dd4hep::Assembly addAssembly(dd4hep::Assembly asmb) const;
+    dd4hep::Assembly addAssembly(dd4hep::Assembly asmb, bool addSolid = true) const;
+    dd4hep::Assembly addAssemblySolid(dd4hep::Assembly assembly) const;
 
     dd4hep::Volume volume(const std::string& name, bool exc = true) const;
+    dd4hep::Volume* getVolPtr(const std::string& name) const;
     dd4hep::Volume addVolume(dd4hep::Volume vol) const;
     dd4hep::Volume addVolumeNS(dd4hep::Volume vol) const;
 

--- a/DetectorDescription/DDCMS/interface/DDParsingContext.h
+++ b/DetectorDescription/DDCMS/interface/DDParsingContext.h
@@ -6,22 +6,30 @@
 #include <string>
 #include <variant>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 namespace cms {
 
   class DDParsingContext {
   public:
-    DDParsingContext(dd4hep::Detector& det) : description(det) {
+    DDParsingContext(dd4hep::Detector& det, bool makePayloadArg = false)
+        : makePayload(makePayloadArg), description(det) {
       assemblies.reserve(100);
+      assemblySolids.reserve(100);
       rotations.reserve(3000);
       shapes.reserve(4000);
       volumes.reserve(3000);
+      volPtrs.reserve(3000);
       unresolvedMaterials.reserve(300);
       unresolvedVectors.reserve(300);
       unresolvedShapes.reserve(1000);
 
       namespaces.emplace_back("");
+      if (makePayload) {
+        rotRevMap.reserve(3000);
+        allCompMaterials.reserve(400);
+      }
     }
 
     DDParsingContext() = delete;
@@ -64,16 +72,21 @@ namespace cms {
     bool debug_namespaces = false;
     bool debug_algorithms = false;
     bool debug_specpars = false;
+    bool makePayload = false;
 
     dd4hep::Detector& description;
 
     std::unordered_map<std::string, dd4hep::Assembly> assemblies;
+    std::unordered_set<std::string> assemblySolids;
     std::unordered_map<std::string, dd4hep::Rotation3D> rotations;
+    std::unordered_map<std::string, std::string> rotRevMap;
     std::unordered_map<std::string, dd4hep::Solid> shapes;
     std::unordered_map<std::string, dd4hep::Volume> volumes;
+    std::unordered_map<std::string, dd4hep::Volume*> volPtrs;
     std::vector<std::string> namespaces;
 
     std::unordered_map<std::string, std::vector<CompositeMaterial>> unresolvedMaterials;
+    std::unordered_map<std::string, std::pair<double, std::vector<CompositeMaterial>>> allCompMaterials;
     std::unordered_map<std::string, std::vector<std::string>> unresolvedVectors;
     std::unordered_map<std::string,
                        std::variant<BooleanShape<dd4hep::UnionSolid>,

--- a/DetectorDescription/DDCMS/interface/DDSolidShapes.h
+++ b/DetectorDescription/DDCMS/interface/DDSolidShapes.h
@@ -92,9 +92,11 @@ namespace cms {
     ddcuttubs = 18,
     ddextrudedpolygon = 19,
     ddtrd1 = 20,
+    ddtrd2 = 21,
+    ddassembly = 22
   };
 
-  const std::array<const cms::dd::NameValuePair<DDSolidShape>, 19> DDSolidShapeMap{
+  const std::array<const cms::dd::NameValuePair<DDSolidShape>, 21> DDSolidShapeMap{
       {{DDSolidShape::dd_not_init, "Solid not initialized"},
        {DDSolidShape::ddbox, "Box"},
        {DDSolidShape::ddtubs, "Tube"},
@@ -113,9 +115,11 @@ namespace cms {
        {DDSolidShape::ddellipticaltube, "EllipticalTube"},
        {DDSolidShape::ddcuttubs, "CutTube"},
        {DDSolidShape::ddextrudedpolygon, "ExtrudedPolygon"},
-       {DDSolidShape::ddtrd1, "Trd1"}}};
+       {DDSolidShape::ddtrd1, "Trd1"},
+       {DDSolidShape::ddtrd2, "Trd2"},
+       {DDSolidShape::ddassembly, "Assembly"}}};
 
-  const std::array<const cms::dd::ValuePair<LegacySolidShape, cms::DDSolidShape>, 20> LegacySolidShapeMap{
+  const std::array<const cms::dd::ValuePair<LegacySolidShape, cms::DDSolidShape>, 21> LegacySolidShapeMap{
       {{LegacySolidShape::dd_not_init, cms::DDSolidShape::dd_not_init},
        {LegacySolidShape::ddbox, cms::DDSolidShape::ddbox},
        {LegacySolidShape::ddtubs, cms::DDSolidShape::ddtubs},
@@ -135,7 +139,8 @@ namespace cms {
        {LegacySolidShape::ddsphere, cms::DDSolidShape::ddsphere},
        {LegacySolidShape::ddellipticaltube, cms::DDSolidShape::ddellipticaltube},
        {LegacySolidShape::ddcuttubs, cms::DDSolidShape::ddcuttubs},
-       {LegacySolidShape::ddextrudedpolygon, cms::DDSolidShape::ddextrudedpolygon}}};
+       {LegacySolidShape::ddextrudedpolygon, cms::DDSolidShape::ddextrudedpolygon},
+       {LegacySolidShape::ddassembly, cms::DDSolidShape::ddassembly}}};
 
 }  // namespace cms
 

--- a/DetectorDescription/DDCMS/plugins/DDDetectorESProducer.cc
+++ b/DetectorDescription/DDCMS/plugins/DDDetectorESProducer.cc
@@ -59,6 +59,7 @@ private:
   const string confGeomXMLFiles_;
   const string rootDDName_;
   const string label_;
+  const bool makePayload_;
   edm::ESGetToken<FileBlob, MFGeometryFileRcd> mfToken_;
   edm::ESGetToken<FileBlob, GeometryFileRcd> geomToken_;
 };
@@ -68,7 +69,8 @@ DDDetectorESProducer::DDDetectorESProducer(const ParameterSet& iConfig)
       appendToDataLabel_(iConfig.getParameter<string>("appendToDataLabel")),
       confGeomXMLFiles_(fromDB_ ? "none" : iConfig.getParameter<FileInPath>("confGeomXMLFiles").fullPath()),
       rootDDName_(iConfig.getParameter<string>("rootDDName")),
-      label_(iConfig.getParameter<string>("label")) {
+      label_(iConfig.getParameter<string>("label")),
+      makePayload_(iConfig.getParameter<bool>("makePayload")) {
   usesResources({edm::ESSharedResourceNames::kDD4Hep});
   if (rootDDName_ == "MagneticFieldVolumes:MAGF" || rootDDName_ == "cmsMagneticField:MAGF") {
     auto c = setWhatProduced(this,
@@ -96,12 +98,14 @@ void DDDetectorESProducer::fillDescriptions(ConfigurationDescriptions& descripti
   desc.add<string>("rootDDName", "cms:OCMS");
   desc.add<string>("label", "");
   desc.add<bool>("fromDB", false);
+  desc.add<bool>("makePayload", false);
   descriptions.add("DDDetectorESProducer", desc);
 
   edm::ParameterSetDescription descDB;
   descDB.add<string>("rootDDName", "cms:OCMS");
   descDB.add<string>("label", "Extended");
   descDB.add<bool>("fromDB", true);
+  descDB.add<bool>("makePayload", false);
   descriptions.add("DDDetectorESProducerFromDB", descDB);
 }
 
@@ -131,13 +135,13 @@ DDDetectorESProducer::ReturnType DDDetectorESProducer::produceGeom(const IdealGe
 
     return make_unique<cms::DDDetector>(label_, string(tb->begin(), tb->end()), true);
   } else {
-    return make_unique<DDDetector>(appendToDataLabel_, confGeomXMLFiles_);
+    return make_unique<DDDetector>(appendToDataLabel_, confGeomXMLFiles_, false, makePayload_);
   }
 }
 
 DDDetectorESProducer::ReturnType DDDetectorESProducer::produce() {
   LogVerbatim("Geometry") << "DDDetectorESProducer::Produce " << appendToDataLabel_;
-  return make_unique<DDDetector>(appendToDataLabel_, confGeomXMLFiles_);
+  return make_unique<DDDetector>(appendToDataLabel_, confGeomXMLFiles_, false, makePayload_);
 }
 
 DEFINE_FWK_EVENTSETUP_SOURCE(DDDetectorESProducer);

--- a/DetectorDescription/DDCMS/src/DDFilteredView.cc
+++ b/DetectorDescription/DDCMS/src/DDFilteredView.cc
@@ -552,6 +552,9 @@ const std::vector<double> DDFilteredView::parameters() const {
 
 const cms::DDSolidShape DDFilteredView::shape() const {
   assert(node_);
+  if ((volume().volume())->IsAssembly()) {
+    return (cms::DDSolidShape::ddbox);  // Return dummy box
+  }
   return cms::dd::value(cms::DDSolidShapeMap, std::string(node_->GetVolume()->GetShape()->GetTitle()));
 }
 
@@ -859,7 +862,13 @@ std::string_view DDFilteredView::fullName() const {
   return (node_ == nullptr ? std::string_view() : (volume().volume().name()));
 }
 
-dd4hep::Solid DDFilteredView::solid() const { return (volume().volume().solid()); }
+dd4hep::Solid DDFilteredView::solid() const {
+  if ((volume().volume())->IsAssembly()) {
+    std::string solName(name());
+    return (dd4hep::Box(solName, 1., 1., 1.));
+  }
+  return (volume().volume().solid());
+}
 
 unsigned short DDFilteredView::copyNum() const { return (volume().copyNumber()); }
 

--- a/DetectorDescription/DDCMS/src/DDNamespace.cc
+++ b/DetectorDescription/DDCMS/src/DDNamespace.cc
@@ -1,5 +1,6 @@
 #include "DetectorDescription/DDCMS/interface/DDNamespace.h"
 #include "DetectorDescription/DDCMS/interface/DDParsingContext.h"
+#include "DataFormats/Math/interface/Rounding.h"
 #include "DD4hep/Path.h"
 #include "DD4hep/Printout.h"
 #include "XML/XML.h"
@@ -10,6 +11,35 @@
 
 using namespace std;
 using namespace cms;
+
+double cms::rotation_utils::roundBinary(double value) {
+  value = cms_rounding::roundIfNear0(value);
+  static constexpr double roundingVal = 1 << 14;
+  value = (round(value * roundingVal) / roundingVal);
+  // Set -0 to 0
+  return (cms_rounding::roundIfNear0(value));
+}
+
+std::string cms::rotation_utils::rotHash(const Double_t* rot) {
+  std::string hashVal;
+  for (int row = 0; row <= 2; ++row) {
+    for (int col = 0; col <= 2; ++col) {
+      hashVal += std::to_string(roundBinary(rot[(3 * row) + col]));
+    }
+  }
+  return (hashVal);
+}
+
+std::string cms::rotation_utils::rotHash(const dd4hep::Rotation3D& rot) {
+  std::string hashVal;
+  std::vector<double> matrix;
+  matrix.assign(9, 0.);
+  rot.GetComponents(matrix.begin());
+  for (double val : matrix) {
+    hashVal += std::to_string(roundBinary(val));
+  }
+  return (hashVal);
+}
 
 DDNamespace::DDNamespace(DDParsingContext* context, xml_h element) : m_context(context) {
   dd4hep::Path path(xml_handler_t::system_path(element));
@@ -120,6 +150,10 @@ dd4hep::Material DDNamespace::material(const string& name) const {
 void DDNamespace::addRotation(const string& name, const dd4hep::Rotation3D& rot) const {
   string n = prepend(name);
   m_context->rotations[n] = rot;
+  if (m_context->makePayload) {
+    string hashVal = cms::rotation_utils::rotHash(rot);
+    m_context->rotRevMap[hashVal] = n;
+  }
 }
 
 const dd4hep::Rotation3D& DDNamespace::rotation(const string& name) const {
@@ -148,6 +182,7 @@ dd4hep::Volume DDNamespace::addVolumeNS(dd4hep::Volume vol) const {
   dd4hep::Material m = vol.material();
   vol->SetName(n.c_str());
   m_context->volumes[n] = vol;
+  m_context->volPtrs[n] = &(m_context->volumes[n]);
   const char* solidName = "Invalid solid";
   if (s.isValid())         // Protect against seg fault
     solidName = s.name();  // If Solid is not valid, s.name() will seg fault.
@@ -161,12 +196,12 @@ dd4hep::Volume DDNamespace::addVolumeNS(dd4hep::Volume vol) const {
   return vol;
 }
 
-/// Add rotation matrix to current namespace
 dd4hep::Volume DDNamespace::addVolume(dd4hep::Volume vol) const {
   string n = prepend(vol.name());
   dd4hep::Solid s = vol.solid();
   dd4hep::Material m = vol.material();
   m_context->volumes[n] = vol;
+  m_context->volPtrs[n] = &(m_context->volumes[n]);
   const char* solidName = "Invalid solid";
   if (s.isValid())         // Protect against seg fault
     solidName = s.name();  // If Solid is not valid, s.name() will seg fault.
@@ -181,11 +216,23 @@ dd4hep::Volume DDNamespace::addVolume(dd4hep::Volume vol) const {
   return vol;
 }
 
-dd4hep::Assembly DDNamespace::addAssembly(dd4hep::Assembly assembly) const {
+dd4hep::Assembly DDNamespace::addAssembly(dd4hep::Assembly assembly, bool addSolid) const {
   string n = assembly.name();
   m_context->assemblies[n] = assembly;
+  m_context->volPtrs[n] = &(m_context->assemblies[n]);
+  if (addSolid) {  // In algorithms, Assembly solids are not added separately, so add it here
+    m_context->assemblySolids.emplace(n);
+  }
   dd4hep::printout(
-      m_context->debug_volumes ? dd4hep::ALWAYS : dd4hep::DEBUG, "DD4CMS", "+++ Add assembly:%-38s", assembly.name());
+      m_context->debug_volumes ? dd4hep::ALWAYS : dd4hep::DEBUG, "DD4CMS", "+++ Add assembly: %-38s", n.c_str());
+  return assembly;
+}
+
+dd4hep::Assembly DDNamespace::addAssemblySolid(dd4hep::Assembly assembly) const {
+  string n = prepend(assembly.name());
+  m_context->assemblySolids.emplace(n);
+  dd4hep::printout(
+      m_context->debug_volumes ? dd4hep::ALWAYS : dd4hep::DEBUG, "DD4CMS", "+++ Add assembly solid: %-38s", n.c_str());
   return assembly;
 }
 
@@ -214,6 +261,19 @@ dd4hep::Volume DDNamespace::volume(const string& name, bool exc) const {
   }
   if (exc) {
     throw runtime_error("Unknown volume identifier:" + name);
+  }
+  return nullptr;
+}
+
+dd4hep::Volume* DDNamespace::getVolPtr(const string& name) const {
+  auto i = m_context->volPtrs.find(name);
+  if (i != m_context->volPtrs.end()) {
+    return (*i).second;
+  }
+  if (name.front() == NAMESPACE_SEP) {
+    i = m_context->volPtrs.find(name.substr(1, name.size()));
+    if (i != m_context->volPtrs.end())
+      return (*i).second;
   }
   return nullptr;
 }

--- a/DetectorDescription/DDCMS/test/DDSolidLegacyShapes.cppunit.cc
+++ b/DetectorDescription/DDCMS/test/DDSolidLegacyShapes.cppunit.cc
@@ -77,6 +77,9 @@ void testDDSolidLegacyShapes::checkDDSolidLegacyShapes() {
   LegacySolidShape legacyShapeless = cms::dd::value(cms::LegacySolidShapeMap, cms::DDSolidShape::ddshapeless);
   CPPUNIT_ASSERT(legacyShapeless == LegacySolidShape::ddshapeless);
 
+  LegacySolidShape legacyAssembly = cms::dd::value(cms::LegacySolidShapeMap, cms::DDSolidShape::ddassembly);
+  CPPUNIT_ASSERT(legacyAssembly == LegacySolidShape::ddassembly);
+
   LegacySolidShape legacyPseudotrap = cms::dd::value(cms::LegacySolidShapeMap, cms::DDSolidShape::ddpseudotrap);
   CPPUNIT_ASSERT(legacyPseudotrap == LegacySolidShape::ddpseudotrap);
 
@@ -96,8 +99,8 @@ void testDDSolidLegacyShapes::checkDDSolidLegacyShapes() {
       cms::dd::value(cms::LegacySolidShapeMap, cms::DDSolidShape::ddextrudedpolygon);
   CPPUNIT_ASSERT(legacyExtrudedpolygon == LegacySolidShape::ddextrudedpolygon);
 
-  int ids[] = {0,  0,  1,  1,  2,  2,  3,  3,  4,  4,  5,  5,  7,  5,  6,  6,  8,  6,  9,  9,
-               10, 10, 11, 11, 12, 12, 13, 13, 14, 14, 15, 15, 16, 16, 17, 17, 18, 18, 19, 19};
+  int ids[] = {0,  0,  1,  1,  2,  2,  3,  3,  4,  4,  5,  5,  7,  5,  6,  6,  8,  6,  9,  9,  10,
+               10, 11, 11, 12, 12, 13, 13, 14, 14, 15, 15, 16, 16, 17, 17, 18, 18, 19, 19, 20, 22};
   int i = 0;
   for (const auto it : LegacySolidShapeMap) {
     CPPUNIT_ASSERT(static_cast<int>(it.value) == ids[i++]);


### PR DESCRIPTION
Up to now, our DD4hep code has supported Assemblies being used in algorithms but did not support explicit Assembly definitions in XML. This PR  provides support for Assembly definitions in XML.

This PR is required for PR #34343 to be able to run.

Secondly, it also provides support for the tool from PR #34111 for creating the DD4hep ideal geometry description DB payload. This PR is required for #34111 to work.

The new Assembly XML syntax is simple. In the Solids section, Assemblies are defined merely with a name:
```
 <Assembly name="assembly1"/>
```
Then in the Logical Part section, an Assembly is treated like any other Logical Part. Its material should be "Air", but the material is never actually used. The PosPart placement of Assemblies is just like that of other Logical Parts.

#### PR validation:

This PR has been put through the following tests:
* DD4hep simulation reading from XML (wf 11634.911)
* DD4hep simulation reading the ideal geometry description(with Assemblies) from an Sqlite DB (modified wf 11634.911)
* DB payload creation tool (PR 34111) reading the ideal geometry description (stress test, only done for testing purposes)
* Unit tests

No backport will be done.
