### PR TITLE
Run3-trk06 Add a script for dumping Geometry defined using dd4hep

### DIFF
--- a/Geometry/TrackerCommonData/test/python/dumpTrackerDD4Hep_cfg.py
+++ b/Geometry/TrackerCommonData/test/python/dumpTrackerDD4Hep_cfg.py
@@ -1,0 +1,31 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("DUMP")
+
+process.load('FWCore.MessageService.MessageLogger_cfi')
+process.MessageLogger.cerr.FwkReport.reportEvery = 5
+
+if 'MessageLogger' in process.__dict__:
+    process.MessageLogger.PixelGeom=dict()
+    process.MessageLogger.TIBGeom=dict()
+    process.MessageLogger.TIDGeom=dict()
+    process.MessageLogger.TOBGeom=dict()
+    process.MessageLogger.TECGeom=dict()
+
+process.source = cms.Source("EmptySource")
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(1)
+)
+
+process.DDDetectorESProducer = cms.ESSource("DDDetectorESProducer",
+                                            confGeomXMLFiles = cms.FileInPath('Geometry/CMSCommonData/data/dd4hep/cmsExtendedGeometry2026D77.xml'),
+                                            appendToDataLabel = cms.string('DDCMS2026D77')
+                                            )
+
+process.dump = cms.EDAnalyzer("DDTestDumpFile",
+                              outputFileName = cms.untracked.string('cms2026D77.root'),
+                              DDDetector = cms.ESInputTag('','DDCMS2026D77')
+                              )
+
+process.p = cms.Path(process.dump)


### PR DESCRIPTION
#### PR description:

Add a script for dumping Geometry defined using dd4hep (helps in finding warnings/errors recognized by dd4hep)

#### PR validation:

Tested by running the example on 2 scenarios 2026D77 (which passes) and 2026D80 (which fails)

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Nothing special