### PR TITLE
[Backport to 11_1_X] Allow to suppress ExternalLHEProducer exception if not all events were processed

### DIFF
--- a/GeneratorInterface/LHEInterface/plugins/ExternalLHEProducer.cc
+++ b/GeneratorInterface/LHEInterface/plugins/ExternalLHEProducer.cc
@@ -18,6 +18,7 @@ Implementation:
 
 // system include files
 #include <cstdio>
+#include <cstdlib>
 #include <memory>
 #include <vector>
 #include <string>
@@ -372,10 +373,16 @@ void ExternalLHEProducer::endRunProduce(edm::Run& run, edm::EventSetup const& es
 
   nextEvent();
   if (partonLevel_) {
-    throw edm::Exception(edm::errors::EventGenerationFailure)
-        << "Error in ExternalLHEProducer::endRunProduce().  "
-        << "Event loop is over, but there are still lhe events to process."
-        << "This could happen if lhe file contains more events than requested.  This is never expected to happen.";
+    // VALIDATION_RUN env variable allows to finish event processing early without errors by sending SIGINT
+    if (std::getenv("VALIDATION_RUN") != nullptr) {
+      edm::LogWarning("ExternalLHEProducer")
+          << "Event loop is over, but there are still lhe events to process, ignoring...";
+    } else {
+      throw edm::Exception(edm::errors::EventGenerationFailure)
+          << "Error in ExternalLHEProducer::endRunProduce().  "
+          << "Event loop is over, but there are still lhe events to process."
+          << "This could happen if lhe file contains more events than requested.  This is never expected to happen.";
+    }
   }
 
   reader_.reset();


### PR DESCRIPTION
#### PR description:

This PR enables to suppress an exception thrown by ExternalLHEProducer using a VALIDATION_RUN environment variable.

#### PR validation:

 - `scram b runtests` tests

#### If this PR is a backport please specify the original PR and why you need to backport that PR:

Backport of #33624 including suggestion added with #33674.
Backport is needed in all releases that are still used in Monte Carlo production.
