### PR TITLE
Migrate ED modules to use esConsumes in Validation/RecoMuon

### DIFF
--- a/Validation/RecoMuon/plugins/MuonTrackValidator.cc
+++ b/Validation/RecoMuon/plugins/MuonTrackValidator.cc
@@ -374,7 +374,7 @@ void MuonTrackValidator::analyze(const edm::Event& event, const edm::EventSetup&
   std::unique_ptr<ParametersDefinerForTP> Cosmic_parametersDefinerTP;
 
   if (parametersDefiner == "LhcParametersDefinerForTP") {
-    auto Lhc_parametersDefinerTP = setup.getHandle(tpDefinerEsToken);
+    Lhc_parametersDefinerTP = setup.getHandle(tpDefinerEsToken);
 
     // PileupSummaryInfo is contained only in collision events
     event.getByToken(pileupinfo_Token, puinfoH);
@@ -388,7 +388,7 @@ void MuonTrackValidator::analyze(const edm::Event& event, const edm::EventSetup&
 
   } else if (parametersDefiner == "CosmicParametersDefinerForTP") {
     //setup.get<TrackAssociatorRecord>().get(parametersDefiner, _Cosmic_parametersDefinerTP);
-    auto _Cosmic_parametersDefinerTP = setup.getHandle(cosmictpDefinerEsToken);
+    _Cosmic_parametersDefinerTP = setup.getHandle(cosmictpDefinerEsToken);
 
     //Since we modify the object, we must clone it
     Cosmic_parametersDefinerTP = _Cosmic_parametersDefinerTP->clone();

--- a/Validation/RecoMuon/plugins/MuonTrackValidator.cc
+++ b/Validation/RecoMuon/plugins/MuonTrackValidator.cc
@@ -370,10 +370,11 @@ void MuonTrackValidator::analyze(const edm::Event& event, const edm::EventSetup&
   int PU_NumInteractions(-1);
 
   edm::ESHandle<ParametersDefinerForTP> Lhc_parametersDefinerTP;
+  edm::ESHandle<CosmicParametersDefinerForTP> _Cosmic_parametersDefinerTP;
   std::unique_ptr<ParametersDefinerForTP> Cosmic_parametersDefinerTP;
 
   if (parametersDefiner == "LhcParametersDefinerForTP") {
-    setup.get<TrackAssociatorRecord>().get(parametersDefiner, Lhc_parametersDefinerTP);
+    auto Lhc_parametersDefinerTP = setup.getHandle(tpDefinerEsToken);
 
     // PileupSummaryInfo is contained only in collision events
     event.getByToken(pileupinfo_Token, puinfoH);
@@ -386,8 +387,8 @@ void MuonTrackValidator::analyze(const edm::Event& event, const edm::EventSetup&
     }
 
   } else if (parametersDefiner == "CosmicParametersDefinerForTP") {
-    edm::ESHandle<CosmicParametersDefinerForTP> _Cosmic_parametersDefinerTP;
-    setup.get<TrackAssociatorRecord>().get(parametersDefiner, _Cosmic_parametersDefinerTP);
+    //setup.get<TrackAssociatorRecord>().get(parametersDefiner, _Cosmic_parametersDefinerTP);
+    auto _Cosmic_parametersDefinerTP = setup.getHandle(cosmictpDefinerEsToken);
 
     //Since we modify the object, we must clone it
     Cosmic_parametersDefinerTP = _Cosmic_parametersDefinerTP->clone();

--- a/Validation/RecoMuon/plugins/MuonTrackValidator.h
+++ b/Validation/RecoMuon/plugins/MuonTrackValidator.h
@@ -14,10 +14,24 @@
 #include "SimDataFormats/Associations/interface/TrackAssociation.h"
 #include "DQMServices/Core/interface/DQMEDAnalyzer.h"
 
+#include "SimTracker/Records/interface/TrackAssociatorRecord.h"
+#include "SimTracker/TrackAssociation/interface/ParametersDefinerForTP.h"
+#include "SimTracker/TrackAssociation/interface/CosmicParametersDefinerForTP.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
+
 class MuonTrackValidator : public DQMEDAnalyzer, protected MuonTrackValidatorBase {
 public:
   /// Constructor
-  MuonTrackValidator(const edm::ParameterSet& pset) : MuonTrackValidatorBase(pset) {
+  MuonTrackValidator(const edm::ParameterSet& pset)
+      : MuonTrackValidatorBase(pset),
+        tpDefinerEsToken(
+            esConsumes<ParametersDefinerForTP, TrackAssociatorRecord>(edm::ESInputTag("", parametersDefiner))),
+        cosmictpDefinerEsToken(
+            esConsumes<CosmicParametersDefinerForTP, TrackAssociatorRecord>(edm::ESInputTag("", parametersDefiner))) {
     dirName_ = pset.getParameter<std::string>("dirName");
     associatormap = pset.getParameter<edm::InputTag>("associatormap");
     UseAssociators = pset.getParameter<bool>("UseAssociators");
@@ -152,6 +166,9 @@ private:
   edm::EDGetTokenT<reco::SimToRecoCollection> simToRecoCollection_Token;
   edm::EDGetTokenT<reco::RecoToSimCollection> recoToSimCollection_Token;
   edm::EDGetTokenT<SimHitTPAssociationProducer::SimHitTPAssociationList> _simHitTpMapTag;
+
+  const edm::ESGetToken<ParametersDefinerForTP, TrackAssociatorRecord> tpDefinerEsToken;
+  const edm::ESGetToken<CosmicParametersDefinerForTP, TrackAssociatorRecord> cosmictpDefinerEsToken;
 
   bool UseAssociators;
   bool useGEMs_;


### PR DESCRIPTION
Migrate ED modules to use esConsumes, for the Validation/RecoMuon

It has been tested in 1330.0, 1321.0 and 5.1 samples under the release CMSSW_12_0_X_2021-07-04-2300