### PR TITLE
[DQM] Set assertLegacySafe to False

### DIFF
--- a/DQMServices/Core/README.md
+++ b/DQMServices/Core/README.md
@@ -97,7 +97,7 @@ Actions on the `DQMStore` are usually indirect and done via the `IBooker` and `I
 
 The behavior of the `DQMStore` is not affected by any configuration options (this differs from earlier implementations, where multiple _modes_ existed). Yet, there are a few options that can be set:
 - There are two options to control per-lumi saving (`saveByLumi` in the `DQMStore`) and harvesting (`reScope` in `DQMRootSource`). Both can be expressed in terms of _Scope_, see later. These options do not affect what the `DQMStore` itself does: `saveByLumi` affects the default scope and is passed down to the booking code in the DQM modules, while `reScope` is handled in the input sources.
-- Another option, `assertLegacySafe`, only adds assertions to make sure no operations that would be unsafe in the presence of legacy modules sneak in. It does not affect the behaviour.It is enabled by default, but should be disabled in production RECO jobs where concurrent lumisections are expected.
+- Another option, `assertLegacySafe`, only adds assertions to make sure no operations that would be unsafe in the presence of legacy modules sneak in. It does not affect the behaviour. It is disabled by default and indeed it should be kept disabled in production RECO jobs where concurrent lumisections are expected.
 - The `verbose` option should not affect the behavior. Setting it to a value of at least 4 will enable printing a backtrace for every booking call.
 - The `trackME` option is a tool for debugging. When it is set, the `DQMStore` will log all life cycle events affecting MEs matching this name. This does not include things done to the ME (like filling -- the `DQMStore` is not involved there), but it does include creation, reset, recycling, and saving of MEs.
     

--- a/DQMServices/Core/python/DQMStore_cfi.py
+++ b/DQMServices/Core/python/DQMStore_cfi.py
@@ -9,7 +9,9 @@ DQMStore = cms.Service("DQMStore",
     #Following list has no effect if saveByLumi is False
     MEsToSave = cms.untracked.vstring(nanoDQMIO_perLSoutput.MEsToSave),  
     trackME = cms.untracked.string(""),
-
+    #Legacy code should be out. Suggested on:
+    #https://github.com/cms-sw/cmssw/pull/34231#issuecomment-874789622
+    assertLegacySafe  = cms.untracked.bool(False),
     # UNUSED: historical HLT configs expect this option to be present, so it
     # remains here, even though the DQMStore does not use it any more.
     enableMultiThread = cms.untracked.bool(True)


### PR DESCRIPTION
#### PR description:

As suggested in https://github.com/cms-sw/cmssw/pull/34231#issuecomment-874789622   assertLegacySafe parameter in DQMStore can be moved to False.  The option existed to support some DQM code that did not work with concurrent lumis, but this should not be the case at present

#### PR validation:

runTheMatrix.py -l limited -i all --ibeos 