### PR TITLE
Migrate module configuration in RecoEgamma{EgammaIsolationAlgos} to use default cfipython

### DIFF
--- a/RecoEgamma/EgammaIsolationAlgos/python/egmElectronIsolationPUPPI_cff.py
+++ b/RecoEgamma/EgammaIsolationAlgos/python/egmElectronIsolationPUPPI_cff.py
@@ -1,4 +1,5 @@
 import FWCore.ParameterSet.Config as cms
+import PhysicsTools.IsolationAlgos.CITKPFIsolationSumProducerForPUPPI_cfi as _mod
 
 IsoConeDefinitions = cms.VPSet(
         cms.PSet( isolationAlgo = cms.string('ElectronPFIsolationWithConeVeto'), 
@@ -21,23 +22,23 @@ IsoConeDefinitions = cms.VPSet(
                   miniAODVertexCodes = cms.vuint32(2,3) )
         )
 
-egmElectronIsolationAODPUPPI = cms.EDProducer( "CITKPFIsolationSumProducerForPUPPI",
-                srcToIsolate = cms.InputTag("gedGsfElectrons"),
-                srcForIsolationCone = cms.InputTag(''),
+egmElectronIsolationAODPUPPI = _mod.CITKPFIsolationSumProducerForPUPPI.clone(
+                srcToIsolate = "gedGsfElectrons",
+                srcForIsolationCone = '',
                 isolationConeDefinitions = IsoConeDefinitions
 )
 
-egmElectronIsolationMiniAODPUPPI = cms.EDProducer( "CITKPFIsolationSumProducerForPUPPI",
-                srcToIsolate = cms.InputTag("slimmedElectrons"),
-                srcForIsolationCone = cms.InputTag('packedPFCandidates'),
-                puppiValueMap = cms.InputTag(''),
+egmElectronIsolationMiniAODPUPPI = _mod.CITKPFIsolationSumProducerForPUPPI.clone(
+                srcToIsolate = "slimmedElectrons",
+                srcForIsolationCone = 'packedPFCandidates',
+                puppiValueMap = '',
                 isolationConeDefinitions = IsoConeDefinitions
 )
 
-egmElectronIsolationMiniAODPUPPINoLeptons = cms.EDProducer( "CITKPFIsolationSumProducerForPUPPI",
-                srcToIsolate = cms.InputTag("slimmedElectrons"),
-                srcForIsolationCone = cms.InputTag('packedPFCandidates'),
-                puppiValueMap = cms.InputTag(''),
-                usePUPPINoLepton = cms.bool(True),
+egmElectronIsolationMiniAODPUPPINoLeptons = _mod.CITKPFIsolationSumProducerForPUPPI.clone(
+                srcToIsolate = "slimmedElectrons",
+                srcForIsolationCone = 'packedPFCandidates',
+                puppiValueMap = '',
+                usePUPPINoLepton = True,
                 isolationConeDefinitions = IsoConeDefinitions
 )

--- a/RecoEgamma/EgammaIsolationAlgos/python/egmPhotonIsolationAOD_cff.py
+++ b/RecoEgamma/EgammaIsolationAlgos/python/egmPhotonIsolationAOD_cff.py
@@ -3,11 +3,11 @@ import FWCore.ParameterSet.Config as cms
 from CommonTools.ParticleFlow.pfNoPileUpIso_cff import pfPileUpIso, pfNoPileUpIso, pfNoPileUpIsoTask
 from RecoEgamma.EgammaIsolationAlgos.egmIsoConeDefinitions_cfi import IsoConeDefinitions as _IsoConeDefinitions
 from RecoEgamma.EgammaIsolationAlgos.egmIsolationDefinitions_cff import pfNoPileUpCandidates
+import PhysicsTools.IsolationAlgos.CITKPFIsolationSumProducer_cfi as _mod
 
-
-egmPhotonIsolation = cms.EDProducer( "CITKPFIsolationSumProducer",
-                                     srcToIsolate = cms.InputTag("gedPhotons"),
-                                     srcForIsolationCone = cms.InputTag('pfNoPileUpCandidates'),
+egmPhotonIsolation = _mod.CITKPFIsolationSumProducer.clone(
+                                     srcToIsolate = "gedPhotons",
+                                     srcForIsolationCone = 'pfNoPileUpCandidates',
                                      isolationConeDefinitions = _IsoConeDefinitions
                                      )	
 

--- a/RecoEgamma/EgammaIsolationAlgos/python/egmPhotonIsolationMiniAOD_cff.py
+++ b/RecoEgamma/EgammaIsolationAlgos/python/egmPhotonIsolationMiniAOD_cff.py
@@ -1,10 +1,11 @@
 import FWCore.ParameterSet.Config as cms
 
 from RecoEgamma.EgammaIsolationAlgos.egmIsoConeDefinitions_cfi import IsoConeDefinitions as _IsoConeDefinitions
+import PhysicsTools.IsolationAlgos.CITKPFIsolationSumProducer_cfi as _mod
 
-egmPhotonIsolation = cms.EDProducer( "CITKPFIsolationSumProducer",
-                                     srcToIsolate = cms.InputTag("slimmedPhotons"),
-                                     srcForIsolationCone = cms.InputTag('packedPFCandidates'),
+egmPhotonIsolation = _mod.CITKPFIsolationSumProducer.clone(
+                                     srcToIsolate = "slimmedPhotons",
+                                     srcForIsolationCone = 'packedPFCandidates',
                                      isolationConeDefinitions = _IsoConeDefinitions
                                      )	
 

--- a/RecoEgamma/EgammaIsolationAlgos/python/egmPhotonIsolationPUPPI_cff.py
+++ b/RecoEgamma/EgammaIsolationAlgos/python/egmPhotonIsolationPUPPI_cff.py
@@ -29,7 +29,6 @@ IsoConeDefinitions = cms.VPSet(cms.PSet( isolationAlgo = cms.string('PhotonPFIso
 egmPhotonIsolationAODPUPPI = _mod.CITKPFIsolationSumProducerForPUPPI.clone(
 			  srcToIsolate = "gedPhotons",
 			  srcForIsolationCone = 'particleFlow',
-                          puppiValueMap = 'puppi',
 			  isolationConeDefinitions = IsoConeDefinitions
 )
 

--- a/RecoEgamma/EgammaIsolationAlgos/python/egmPhotonIsolationPUPPI_cff.py
+++ b/RecoEgamma/EgammaIsolationAlgos/python/egmPhotonIsolationPUPPI_cff.py
@@ -1,4 +1,5 @@
 import FWCore.ParameterSet.Config as cms
+import PhysicsTools.IsolationAlgos.CITKPFIsolationSumProducerForPUPPI_cfi as _mod
 
 IsoConeDefinitions = cms.VPSet(cms.PSet( isolationAlgo = cms.string('PhotonPFIsolationWithMapBasedVeto'),
                                       coneSize = cms.double(0.3),
@@ -25,15 +26,15 @@ IsoConeDefinitions = cms.VPSet(cms.PSet( isolationAlgo = cms.string('PhotonPFIso
     )
 
 
-egmPhotonIsolationAODPUPPI = cms.EDProducer( "CITKPFIsolationSumProducerForPUPPI",
-			  srcToIsolate = cms.InputTag("gedPhotons"),
-			  srcForIsolationCone = cms.InputTag('particleFlow'),
-                          puppiValueMap = cms.InputTag('puppi'),
+egmPhotonIsolationAODPUPPI = _mod.CITKPFIsolationSumProducerForPUPPI.clone(
+			  srcToIsolate = "gedPhotons",
+			  srcForIsolationCone = 'particleFlow',
+                          puppiValueMap = 'puppi',
 			  isolationConeDefinitions = IsoConeDefinitions
 )
 
 egmPhotonIsolationMiniAODPUPPI = egmPhotonIsolationAODPUPPI.clone(
-    srcForIsolationCone = "packedPFCandidates",
-    srcToIsolate        = "slimmedPhotons",
-    puppiValueMap       = ''
+                          srcForIsolationCone = "packedPFCandidates",
+                          srcToIsolate        = "slimmedPhotons",
+                          puppiValueMap       = ''
 )

--- a/RecoEgamma/EgammaIsolationAlgos/python/pfClusterIsolation_cfi.py
+++ b/RecoEgamma/EgammaIsolationAlgos/python/pfClusterIsolation_cfi.py
@@ -6,26 +6,10 @@ import RecoEgamma.EgammaIsolationAlgos.egammaHcalPFClusterIsolationProducerRecoP
 
 electronEcalPFClusterIsolationProducer = _mod_Ecalele.egammaEcalPFClusterIsolationProducerRecoGsfElectron.clone(
                                                       candidateProducer = 'gedGsfElectronsTmp',
-                                                      pfClusterProducer = 'particleFlowClusterECAL',
-                                                      drMax = 0.3,
-                                                      drVetoBarrel = 0,
-                                                      drVetoEndcap = 0,
-                                                      etaStripBarrel = 0,
-                                                      etaStripEndcap = 0,
-                                                      energyBarrel = 0,
-                                                      energyEndcap = 0
                                                       )
 
 photonEcalPFClusterIsolationProducer = _mod_Ecalpho.egammaEcalPFClusterIsolationProducerRecoPhoton.clone(
                                                       candidateProducer = 'gedPhotonsTmp',
-                                                      pfClusterProducer = 'particleFlowClusterECAL',
-                                                      drMax = 0.3,
-                                                      drVetoBarrel = 0,
-                                                      drVetoEndcap = 0,
-                                                      etaStripBarrel = 0,
-                                                      etaStripEndcap = 0,
-                                                      energyBarrel = 0,
-                                                      energyEndcap = 0
                                                       )
 
 ootPhotonEcalPFClusterIsolationProducer = photonEcalPFClusterIsolationProducer.clone(
@@ -35,28 +19,10 @@ ootPhotonEcalPFClusterIsolationProducer = photonEcalPFClusterIsolationProducer.c
 
 electronHcalPFClusterIsolationProducer = _mod_Hcalele.egammaHcalPFClusterIsolationProducerRecoGsfElectron.clone( 
                                                       candidateProducer = 'gedGsfElectronsTmp',
-                                                      pfClusterProducerHCAL = 'particleFlowClusterHCAL',
-                                                      useHF = False,
-                                                      drMax = 0.3,
-                                                      drVetoBarrel = 0,
-                                                      drVetoEndcap = 0,
-                                                      etaStripBarrel = 0,
-                                                      etaStripEndcap = 0,
-                                                      energyBarrel = 0,
-                                                      energyEndcap = 0
                                                       )
 
 photonHcalPFClusterIsolationProducer = _mod_Hcalpho.egammaHcalPFClusterIsolationProducerRecoPhoton.clone( 
                                                       candidateProducer = 'gedPhotonsTmp',
-                                                      pfClusterProducerHCAL = 'particleFlowClusterHCAL',
-                                                      useHF = False,
-                                                      drMax = 0.3,
-                                                      drVetoBarrel = 0,
-                                                      drVetoEndcap = 0,
-                                                      etaStripBarrel = 0,
-                                                      etaStripEndcap = 0,
-                                                      energyBarrel = 0,
-                                                      energyEndcap = 0
                                                       )
 
 ootPhotonHcalPFClusterIsolationProducer = photonHcalPFClusterIsolationProducer.clone(

--- a/RecoEgamma/EgammaIsolationAlgos/python/pfClusterIsolation_cfi.py
+++ b/RecoEgamma/EgammaIsolationAlgos/python/pfClusterIsolation_cfi.py
@@ -1,57 +1,62 @@
 import FWCore.ParameterSet.Config as cms
+import RecoEgamma.EgammaIsolationAlgos.egammaEcalPFClusterIsolationProducerRecoGsfElectron_cfi as _mod_Ecalele
+import RecoEgamma.EgammaIsolationAlgos.egammaEcalPFClusterIsolationProducerRecoPhoton_cfi as _mod_Ecalpho  
+import RecoEgamma.EgammaIsolationAlgos.egammaHcalPFClusterIsolationProducerRecoGsfElectron_cfi as _mod_Hcalele
+import RecoEgamma.EgammaIsolationAlgos.egammaHcalPFClusterIsolationProducerRecoPhoton_cfi as _mod_Hcalpho
 
-electronEcalPFClusterIsolationProducer = cms.EDProducer('ElectronEcalPFClusterIsolationProducer',
-                                                        candidateProducer = cms.InputTag('gedGsfElectronsTmp'),
-                                                        pfClusterProducer = cms.InputTag('particleFlowClusterECAL'),
-                                                        drMax = cms.double(0.3),
-                                                        drVetoBarrel = cms.double(0),
-                                                        drVetoEndcap = cms.double(0),
-                                                        etaStripBarrel = cms.double(0),
-                                                        etaStripEndcap = cms.double(0),
-                                                        energyBarrel = cms.double(0),
-                                                        energyEndcap = cms.double(0)
-                                                        )
+electronEcalPFClusterIsolationProducer = _mod_Ecalele.egammaEcalPFClusterIsolationProducerRecoGsfElectron.clone(
+                                                      candidateProducer = 'gedGsfElectronsTmp',
+                                                      pfClusterProducer = 'particleFlowClusterECAL',
+                                                      drMax = 0.3,
+                                                      drVetoBarrel = 0,
+                                                      drVetoEndcap = 0,
+                                                      etaStripBarrel = 0,
+                                                      etaStripEndcap = 0,
+                                                      energyBarrel = 0,
+                                                      energyEndcap = 0
+                                                      )
 
-photonEcalPFClusterIsolationProducer = cms.EDProducer('PhotonEcalPFClusterIsolationProducer',
-                                                      candidateProducer = cms.InputTag('gedPhotonsTmp'),
-                                                      pfClusterProducer = cms.InputTag('particleFlowClusterECAL'),
-                                                      drMax = cms.double(0.3),
-                                                      drVetoBarrel = cms.double(0),
-                                                      drVetoEndcap = cms.double(0),
-                                                      etaStripBarrel = cms.double(0),
-                                                      etaStripEndcap = cms.double(0),
-                                                      energyBarrel = cms.double(0),
-                                                      energyEndcap = cms.double(0)
+photonEcalPFClusterIsolationProducer = _mod_Ecalpho.egammaEcalPFClusterIsolationProducerRecoPhoton.clone(
+                                                      candidateProducer = 'gedPhotonsTmp',
+                                                      pfClusterProducer = 'particleFlowClusterECAL',
+                                                      drMax = 0.3,
+                                                      drVetoBarrel = 0,
+                                                      drVetoEndcap = 0,
+                                                      etaStripBarrel = 0,
+                                                      etaStripEndcap = 0,
+                                                      energyBarrel = 0,
+                                                      energyEndcap = 0
                                                       )
 
 ootPhotonEcalPFClusterIsolationProducer = photonEcalPFClusterIsolationProducer.clone(
     candidateProducer = 'ootPhotonsTmp',
     pfClusterProducer = 'particleFlowClusterOOTECAL'
 )
-electronHcalPFClusterIsolationProducer = cms.EDProducer('ElectronHcalPFClusterIsolationProducer',
-                                                        candidateProducer = cms.InputTag('gedGsfElectronsTmp'),
-                                                        pfClusterProducerHCAL = cms.InputTag('particleFlowClusterHCAL'),
-                                                        useHF = cms.bool(False),
-                                                        drMax = cms.double(0.3),
-                                                        drVetoBarrel = cms.double(0),
-                                                        drVetoEndcap = cms.double(0),
-                                                        etaStripBarrel = cms.double(0),
-                                                        etaStripEndcap = cms.double(0),
-                                                        energyBarrel = cms.double(0),
-                                                        energyEndcap = cms.double(0)
-                                                        )
 
-photonHcalPFClusterIsolationProducer = cms.EDProducer('PhotonHcalPFClusterIsolationProducer',
-                                                      candidateProducer = cms.InputTag('gedPhotonsTmp'),
-                                                      pfClusterProducerHCAL = cms.InputTag('particleFlowClusterHCAL'),
-                                                      useHF = cms.bool(False),
-                                                      drMax = cms.double(0.3),
-                                                      drVetoBarrel = cms.double(0),
-                                                      drVetoEndcap = cms.double(0),
-                                                      etaStripBarrel = cms.double(0),
-                                                      etaStripEndcap = cms.double(0),
-                                                      energyBarrel = cms.double(0),
-                                                      energyEndcap = cms.double(0)
+electronHcalPFClusterIsolationProducer = _mod_Hcalele.egammaHcalPFClusterIsolationProducerRecoGsfElectron.clone( 
+                                                      candidateProducer = 'gedGsfElectronsTmp',
+                                                      pfClusterProducerHCAL = 'particleFlowClusterHCAL',
+                                                      useHF = False,
+                                                      drMax = 0.3,
+                                                      drVetoBarrel = 0,
+                                                      drVetoEndcap = 0,
+                                                      etaStripBarrel = 0,
+                                                      etaStripEndcap = 0,
+                                                      energyBarrel = 0,
+                                                      energyEndcap = 0
+                                                      )
+
+photonHcalPFClusterIsolationProducer = _mod_Hcalpho.egammaHcalPFClusterIsolationProducerRecoPhoton.clone( 
+                                                      candidateProducer = 'gedPhotonsTmp',
+                                                      pfClusterProducerHCAL = 'particleFlowClusterHCAL',
+                                                      useHF = False,
+                                                      drMax = 0.3,
+                                                      drVetoBarrel = 0,
+                                                      drVetoEndcap = 0,
+                                                      etaStripBarrel = 0,
+                                                      etaStripEndcap = 0,
+                                                      energyBarrel = 0,
+                                                      energyEndcap = 0
                                                       )
 
 ootPhotonHcalPFClusterIsolationProducer = photonHcalPFClusterIsolationProducer.clone(


### PR DESCRIPTION
#### PR description: 
Optimization of the python configurations: Improve maintainability by cleaning up the duplicated and cloning from the default/reference configurations. (The previous PRs : [PR#33207](https://github.com/cms-sw/cmssw/pull/33207), [PR#33307](https://github.com/cms-sw/cmssw/pull/33307), [PR#33352](https://github.com/cms-sw/cmssw/pull/33352), [PR#33543](https://github.com/cms-sw/cmssw/pull/33543),  [PR#33563](https://github.com/cms-sw/cmssw/pull/33563),  [PR#33671](https://github.com/cms-sw/cmssw/pull/33671), [PR#34007](https://github.com/cms-sw/cmssw/pull/34007), [PR#34091](https://github.com/cms-sw/cmssw/pull/34091), [PR#34009](https://github.com/cms-sw/cmssw/pull/34009), [PR#34155](https://github.com/cms-sw/cmssw/pull/34155))
 
In this PR, 5 files changed.  
        modified:   RecoEgamma/EgammaIsolationAlgos/python/egmElectronIsolationPUPPI_cff.py
        modified:   RecoEgamma/EgammaIsolationAlgos/python/egmPhotonIsolationAOD_cff.py
        modified:   RecoEgamma/EgammaIsolationAlgos/python/egmPhotonIsolationMiniAOD_cff.py
        modified:   RecoEgamma/EgammaIsolationAlgos/python/egmPhotonIsolationPUPPI_cff.py
        modified:   RecoEgamma/EgammaIsolationAlgos/python/pfClusterIsolation_cfi.py

commit 1 : Replace explicit configuration with a reference from cfipython/. (migrating EDProducer("type", .. -> typeDefaylt.clone() ) and Remove the type specifications already presented in cfipython/fillDescriptions reference for improved syntax safety.
commit 2 : Remove the duplicated parameters that are exactly the same value in cfipython reference.

#### PR validation:
Event Content comparison check was also done and there is no change with these updates.
Tested in CMSSW_12_0_X, the basic test all passed in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html).