### PR TITLE
use python for FW edm utilities run by scram

### DIFF
--- a/FWCore/Utilities/scripts/edmAddClassVersion
+++ b/FWCore/Utilities/scripts/edmAddClassVersion
@@ -1,4 +1,4 @@
-#!  /usr/bin/env python
+#!  /usr/bin/env python3
 import string, os
 from optparse import OptionParser
 import six

--- a/FWCore/Utilities/scripts/edmCheckClassTransients
+++ b/FWCore/Utilities/scripts/edmCheckClassTransients
@@ -1,4 +1,4 @@
-#!  /usr/bin/env python
+#!  /usr/bin/env python3
 from __future__ import print_function
 import string
 import re

--- a/FWCore/Utilities/scripts/edmCheckClassVersion
+++ b/FWCore/Utilities/scripts/edmCheckClassVersion
@@ -1,4 +1,4 @@
-#!  /usr/bin/env python
+#!  /usr/bin/env python3
 from __future__ import print_function
 from optparse import OptionParser
 import six


### PR DESCRIPTION
Move Framework edm tools to use python3. These tools are used by SCRAM at build time and once we drop the PYTHON27PTH of `root` then build will break. We need to merge these as soon as possible