### PR TITLE
Fix `SiPixelVCal` Payload Inspector

### DIFF
--- a/CondCore/SiPixelPlugins/test/testSiPixelVCal.sh
+++ b/CondCore/SiPixelPlugins/test/testSiPixelVCal.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+# Save current working dir so img can be outputted there later
+W_DIR=$(pwd);
+# Set SCRAM architecture var
+SCRAM_ARCH=slc7_amd64_gcc900;
+export SCRAM_ARCH;
+source /afs/cern.ch/cms/cmsset_default.sh;
+eval `scram run -sh`;
+# Go back to original working directory
+cd $W_DIR;
+# Run get payload data script
+if [ -d $W_DIR/plots_VCal ]; then
+    rm -fr $W_DIR/plots_VCal
+fi
+
+mkdir $W_DIR/plots_VCal
+
+TAGA=SiPixelVCal_v1
+TAGB=SiPixelVCal_phase1_2021_v0
+
+## start with single tag plots
+
+singleTagPlots=(SiPixelVCalValues SiPixelVCalSlopeValuesBarrel SiPixelVCalSlopeValuesEndcap SiPixelVCalOffsetValuesBarrel SiPixelVCalOffsetValuesEndcap)
+
+for i in "${singleTagPlots[@]}"
+do
+    echo "Processing: $i plot"
+
+    getPayloadData.py  \
+	--plugin pluginSiPixelVCal_PayloadInspector \
+	--plot plot_${i} \
+	--tag $TAGA \
+	--time_type Run \
+	--iovs '{"start_iov": "1", "end_iov": "1"}' \
+	--db Prep \
+	--test;
+
+    mv *.png $W_DIR/plots_VCal/${i}.png
+done
+
+twoTagPlots=(SiPixelVCalSlopesBarrelCompareTwoTags SiPixelVCalOffsetsBarrelCompareTwoTags SiPixelVCalSlopesEndcapCompareTwoTags SiPixelVCalOffsetsEndcapCompareTwoTags SiPixelVCalSlopesComparisonTwoTags SiPixelVCalOffsetsComparisonTwoTags) 
+
+for j in "${twoTagPlots[@]}"
+do
+    echo "Processing: $j plot"
+
+    getPayloadData.py  \
+	--plugin pluginSiPixelVCal_PayloadInspector \
+	--plot plot_${j} \
+	--tag $TAGA \
+	--tagtwo $TAGB \
+	--time_type Run \
+	--iovs '{"start_iov": "1", "end_iov": "1"}' \
+	--iovstwo '{"start_iov": "1", "end_iov": "1"}' \
+	--db Prep \
+	--test;
+
+    mv *.png $W_DIR/plots_VCal/${j}.png
+done


### PR DESCRIPTION
#### PR description:

The  `SiPixelVCal` payload inspector was never used for lack of uploaded payloads. Now that the commissioning procedures for the Pixel gain calibration for Run-3 have started few bugs hindering the correct display of conditions at the  [payload inspector in CondDB](https://cms-conddb.cern.ch/cmsDbBrowser/payload_inspector/Prod) were found. These are fixed in this PR (b8f074a).
I profit to:
   * introduce a test script for this condition object in commit: 9000fd6 
   * complete the migration of `SiPixelLorentzAngle_PayloadInspector` to use class templates from #29622 in commit: 9e4545b 

#### PR validation:

Several standalone tests (outputs available [here](http://musich.web.cern.ch/musich/display/plots_VCal/)) plus  `scramv1 b runtests`  passed

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

NA
