### PR TITLE
esConsumes in CondTools/CTPPS

### DIFF
--- a/CondTools/CTPPS/plugins/CTPPSPixGainCalibsESAnalyzer.cc
+++ b/CondTools/CTPPS/plugins/CTPPSPixGainCalibsESAnalyzer.cc
@@ -16,8 +16,7 @@ class CTPPSPixGainCalibsESAnalyzer : public edm::one::EDAnalyzer<> {
 public:
   explicit CTPPSPixGainCalibsESAnalyzer(edm::ParameterSet const& p)
       : m_outfilename(p.getUntrackedParameter<std::string>("outputrootfile", "output.root")),
-      tokenCalibration_( esConsumes<CTPPSPixelGainCalibrations, CTPPSPixelGainCalibrationsRcd>() )
-  {
+        tokenCalibration_(esConsumes<CTPPSPixelGainCalibrations, CTPPSPixelGainCalibrationsRcd>()) {
     setReadablePlaneNames();
   }
   explicit CTPPSPixGainCalibsESAnalyzer(int i) {

--- a/CondTools/CTPPS/plugins/CTPPSPixGainCalibsESAnalyzer.cc
+++ b/CondTools/CTPPS/plugins/CTPPSPixGainCalibsESAnalyzer.cc
@@ -15,8 +15,9 @@
 class CTPPSPixGainCalibsESAnalyzer : public edm::one::EDAnalyzer<> {
 public:
   explicit CTPPSPixGainCalibsESAnalyzer(edm::ParameterSet const& p)
-      : m_outfilename(p.getUntrackedParameter<std::string>("outputrootfile", "output.root")) {
-    //    std::cout<<"CTPPSPixGainCalibsESAnalyzer"<<std::endl;
+      : m_outfilename(p.getUntrackedParameter<std::string>("outputrootfile", "output.root")),
+      tokenCalibration_( esConsumes<CTPPSPixelGainCalibrations, CTPPSPixelGainCalibrationsRcd>() )
+  {
     setReadablePlaneNames();
   }
   explicit CTPPSPixGainCalibsESAnalyzer(int i) {
@@ -32,6 +33,8 @@ public:
 private:
   std::map<uint32_t, std::string> detId_readable;
   std::string m_outfilename;
+
+  edm::ESGetToken<CTPPSPixelGainCalibrations, CTPPSPixelGainCalibrationsRcd> tokenCalibration_;
 };
 
 void CTPPSPixGainCalibsESAnalyzer::setReadablePlaneNames() {
@@ -73,9 +76,8 @@ void CTPPSPixGainCalibsESAnalyzer::analyze(const edm::Event& e, const edm::Event
                                               << "\" does not exist ";
   }
   //this part gets the handle of the event source and the record (i.e. the Database)
-  edm::ESHandle<CTPPSPixelGainCalibrations> calhandle;
+  edm::ESHandle<CTPPSPixelGainCalibrations> calhandle = context.getHandle(tokenCalibration_);
   edm::LogPrint("CTPPSPixGainCalibsReader") << "got eshandle";
-  context.get<CTPPSPixelGainCalibrationsRcd>().get(calhandle);
   edm::LogPrint("CTPPSPixGainCalibsReader") << "got context";
   const CTPPSPixelGainCalibrations* pPixelGainCalibrations = calhandle.product();
   edm::LogPrint("CTPPSPixGainCalibsReader") << "got CTPPSPixelGainCalibrations* ";

--- a/CondTools/CTPPS/plugins/CTPPSPixelDAQMappingAnalyzer.cc
+++ b/CondTools/CTPPS/plugins/CTPPSPixelDAQMappingAnalyzer.cc
@@ -28,9 +28,8 @@ public:
       : label_(iConfig.getUntrackedParameter<string>("label", "RPix")),
         daqmappingiov_(iConfig.getParameter<unsigned long long>("daqmappingiov")),
         analysismaskiov_(iConfig.getParameter<unsigned long long>("analysismaskiov")),
-        tokenMapping_( esConsumes<CTPPSPixelDAQMapping, CTPPSPixelDAQMappingRcd>(edm::ESInputTag("", label_)) ),
-        tokenMask_( esConsumes<CTPPSPixelAnalysisMask, CTPPSPixelAnalysisMaskRcd>(edm::ESInputTag("", label_)) )
-  {}
+        tokenMapping_(esConsumes<CTPPSPixelDAQMapping, CTPPSPixelDAQMappingRcd>(edm::ESInputTag("", label_))),
+        tokenMask_(esConsumes<CTPPSPixelAnalysisMask, CTPPSPixelAnalysisMaskRcd>(edm::ESInputTag("", label_))) {}
   explicit CTPPSPixelDAQMappingAnalyzer(int i) {}
   ~CTPPSPixelDAQMappingAnalyzer() override {}
   void analyze(const edm::Event& e, const edm::EventSetup& c) override;

--- a/CondTools/CTPPS/plugins/CTPPSPixelDAQMappingAnalyzer.cc
+++ b/CondTools/CTPPS/plugins/CTPPSPixelDAQMappingAnalyzer.cc
@@ -21,10 +21,16 @@ public:
   cond::Time_t daqmappingiov_;
   cond::Time_t analysismaskiov_;
 
+  edm::ESGetToken<CTPPSPixelDAQMapping, CTPPSPixelDAQMappingRcd> tokenMapping_;
+  edm::ESGetToken<CTPPSPixelAnalysisMask, CTPPSPixelAnalysisMaskRcd> tokenMask_;
+
   explicit CTPPSPixelDAQMappingAnalyzer(edm::ParameterSet const& iConfig)
       : label_(iConfig.getUntrackedParameter<string>("label", "RPix")),
         daqmappingiov_(iConfig.getParameter<unsigned long long>("daqmappingiov")),
-        analysismaskiov_(iConfig.getParameter<unsigned long long>("analysismaskiov")) {}
+        analysismaskiov_(iConfig.getParameter<unsigned long long>("analysismaskiov")),
+        tokenMapping_( esConsumes<CTPPSPixelDAQMapping, CTPPSPixelDAQMappingRcd>(edm::ESInputTag("", label_)) ),
+        tokenMask_( esConsumes<CTPPSPixelAnalysisMask, CTPPSPixelAnalysisMaskRcd>(edm::ESInputTag("", label_)) )
+  {}
   explicit CTPPSPixelDAQMappingAnalyzer(int i) {}
   ~CTPPSPixelDAQMappingAnalyzer() override {}
   void analyze(const edm::Event& e, const edm::EventSetup& c) override;
@@ -41,8 +47,7 @@ void CTPPSPixelDAQMappingAnalyzer::analyze(const edm::Event& e, const edm::Event
 
   //this part gets the handle of the event source and the record (i.e. the Database)
   if (e.id().run() == daqmappingiov_) {
-    ESHandle<CTPPSPixelDAQMapping> mapping;
-    context.get<CTPPSPixelDAQMappingRcd>().get("RPix", mapping);
+    ESHandle<CTPPSPixelDAQMapping> mapping = context.getHandle(tokenMapping_);
 
     // print mapping
     /*printf("* DAQ mapping\n");
@@ -58,8 +63,7 @@ void CTPPSPixelDAQMappingAnalyzer::analyze(const edm::Event& e, const edm::Event
 
   if (e.id().run() == analysismaskiov_) {
     // get analysis mask to mask channels
-    ESHandle<CTPPSPixelAnalysisMask> analysisMask;
-    context.get<CTPPSPixelAnalysisMaskRcd>().get(label_, analysisMask);
+    ESHandle<CTPPSPixelAnalysisMask> analysisMask = context.getHandle(tokenMask_);
 
     // print mask
     /*printf("* mask\n");

--- a/CondTools/CTPPS/plugins/CTPPSRPAlignmentInfoReader.cc
+++ b/CondTools/CTPPS/plugins/CTPPSRPAlignmentInfoReader.cc
@@ -24,7 +24,7 @@ public:
   edm::ESGetToken<CTPPSRPAlignmentCorrectionsData, CTPPSRPAlignmentCorrectionsDataRcd> tokenAlignmentsIdeal_;
   edm::ESGetToken<CTPPSRPAlignmentCorrectionsData, RPRealAlignmentRecord> tokenAlignmentsReal_;
   edm::ESGetToken<CTPPSRPAlignmentCorrectionsData, RPMisalignedAlignmentRecord> tokenAlignmentsMisaligned_;
-  
+
   explicit CTPPSRPAlignmentInfoReader(edm::ParameterSet const& iConfig);
 
   explicit CTPPSRPAlignmentInfoReader(int i) {}
@@ -35,10 +35,8 @@ public:
 
 //----------------------------------------------------------------------------------------------------
 
-CTPPSRPAlignmentInfoReader::CTPPSRPAlignmentInfoReader(edm::ParameterSet const& iConfig) :
-      iov_(iConfig.getParameter<unsigned long long>("iov")),
-        record_(iConfig.getParameter<string>("record"))
-{
+CTPPSRPAlignmentInfoReader::CTPPSRPAlignmentInfoReader(edm::ParameterSet const& iConfig)
+    : iov_(iConfig.getParameter<unsigned long long>("iov")), record_(iConfig.getParameter<string>("record")) {
   if (strcmp(record_.c_str(), "CTPPSRPAlignmentCorrectionsDataRcd") == 0) {
     tokenAlignmentsIdeal_ = esConsumes<CTPPSRPAlignmentCorrectionsData, CTPPSRPAlignmentCorrectionsDataRcd>();
   } else if (strcmp(record_.c_str(), "RPRealAlignmentRecord") == 0) {
@@ -47,7 +45,6 @@ CTPPSRPAlignmentInfoReader::CTPPSRPAlignmentInfoReader(edm::ParameterSet const& 
     tokenAlignmentsMisaligned_ = esConsumes<CTPPSRPAlignmentCorrectionsData, RPMisalignedAlignmentRecord>();
   }
 }
-
 
 //----------------------------------------------------------------------------------------------------
 

--- a/CondTools/CTPPS/plugins/CTPPSRPAlignmentInfoReader.cc
+++ b/CondTools/CTPPS/plugins/CTPPSRPAlignmentInfoReader.cc
@@ -21,32 +21,55 @@ public:
   cond::Time_t iov_;
   std::string record_;
 
-  explicit CTPPSRPAlignmentInfoReader(edm::ParameterSet const& iConfig)
-      : iov_(iConfig.getParameter<unsigned long long>("iov")), record_(iConfig.getParameter<string>("record")) {}
+  edm::ESGetToken<CTPPSRPAlignmentCorrectionsData, CTPPSRPAlignmentCorrectionsDataRcd> tokenAlignmentsIdeal_;
+  edm::ESGetToken<CTPPSRPAlignmentCorrectionsData, RPRealAlignmentRecord> tokenAlignmentsReal_;
+  edm::ESGetToken<CTPPSRPAlignmentCorrectionsData, RPMisalignedAlignmentRecord> tokenAlignmentsMisaligned_;
+  
+  explicit CTPPSRPAlignmentInfoReader(edm::ParameterSet const& iConfig);
+
   explicit CTPPSRPAlignmentInfoReader(int i) {}
   ~CTPPSRPAlignmentInfoReader() override {}
   void analyze(const edm::Event& e, const edm::EventSetup& c) override;
   void printInfo(const CTPPSRPAlignmentCorrectionsData& alignments, const edm::Event& event);
 };
 
+//----------------------------------------------------------------------------------------------------
+
+CTPPSRPAlignmentInfoReader::CTPPSRPAlignmentInfoReader(edm::ParameterSet const& iConfig) :
+      iov_(iConfig.getParameter<unsigned long long>("iov")),
+        record_(iConfig.getParameter<string>("record"))
+{
+  if (strcmp(record_.c_str(), "CTPPSRPAlignmentCorrectionsDataRcd") == 0) {
+    tokenAlignmentsIdeal_ = esConsumes<CTPPSRPAlignmentCorrectionsData, CTPPSRPAlignmentCorrectionsDataRcd>();
+  } else if (strcmp(record_.c_str(), "RPRealAlignmentRecord") == 0) {
+    tokenAlignmentsReal_ = esConsumes<CTPPSRPAlignmentCorrectionsData, RPRealAlignmentRecord>();
+  } else {
+    tokenAlignmentsMisaligned_ = esConsumes<CTPPSRPAlignmentCorrectionsData, RPMisalignedAlignmentRecord>();
+  }
+}
+
+
+//----------------------------------------------------------------------------------------------------
+
 void CTPPSRPAlignmentInfoReader::analyze(const edm::Event& e, const edm::EventSetup& context) {
   using namespace edm;
 
   //this part gets the handle of the event source and the record (i.e. the Database)
   if (e.id().run() == iov_) {
-    ESHandle<CTPPSRPAlignmentCorrectionsData> alignments;
+    ESHandle<CTPPSRPAlignmentCorrectionsData> hAlignments;
+
     if (strcmp(record_.c_str(), "CTPPSRPAlignmentCorrectionsDataRcd") == 0) {
-      context.get<CTPPSRPAlignmentCorrectionsDataRcd>().get(alignments);
+      hAlignments = context.getHandle(tokenAlignmentsIdeal_);
     } else if (strcmp(record_.c_str(), "RPRealAlignmentRecord") == 0) {
-      context.get<RPRealAlignmentRecord>().get(alignments);
+      hAlignments = context.getHandle(tokenAlignmentsReal_);
     } else {
-      context.get<RPMisalignedAlignmentRecord>().get(alignments);
+      hAlignments = context.getHandle(tokenAlignmentsMisaligned_);
     }
 
     //std::cout
     edm::LogPrint("CTPPSRPAlignmentInfoReader")
         << "New alignments found in run=" << e.id().run() << ", event=" << e.id().event() << ":\n"
-        << *alignments;
+        << *hAlignments;
   }
 }
 

--- a/CondTools/CTPPS/plugins/PPSTimingCalibrationAnalyzer.cc
+++ b/CondTools/CTPPS/plugins/PPSTimingCalibrationAnalyzer.cc
@@ -26,9 +26,8 @@
 
 class PPSTimingCalibrationAnalyzer : public edm::one::EDAnalyzer<> {
 public:
-  explicit PPSTimingCalibrationAnalyzer(const edm::ParameterSet&) :
-    tokenCalibration_( esConsumes<PPSTimingCalibration, PPSTimingCalibrationRcd>() )
-  {}
+  explicit PPSTimingCalibrationAnalyzer(const edm::ParameterSet&)
+      : tokenCalibration_(esConsumes<PPSTimingCalibration, PPSTimingCalibrationRcd>()) {}
 
 private:
   void beginJob() override {}

--- a/CondTools/CTPPS/plugins/PPSTimingCalibrationAnalyzer.cc
+++ b/CondTools/CTPPS/plugins/PPSTimingCalibrationAnalyzer.cc
@@ -26,7 +26,9 @@
 
 class PPSTimingCalibrationAnalyzer : public edm::one::EDAnalyzer<> {
 public:
-  explicit PPSTimingCalibrationAnalyzer(const edm::ParameterSet&) {}
+  explicit PPSTimingCalibrationAnalyzer(const edm::ParameterSet&) :
+    tokenCalibration_( esConsumes<PPSTimingCalibration, PPSTimingCalibrationRcd>() )
+  {}
 
 private:
   void beginJob() override {}
@@ -34,15 +36,14 @@ private:
   void endJob() override {}
 
   edm::ESWatcher<PPSTimingCalibrationRcd> calibWatcher_;
+
+  edm::ESGetToken<PPSTimingCalibration, PPSTimingCalibrationRcd> tokenCalibration_;
 };
 
 void PPSTimingCalibrationAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
   // get timing calibration parameters
-  edm::ESHandle<PPSTimingCalibration> hTimingCalib;
   if (calibWatcher_.check(iSetup)) {
-    iSetup.get<PPSTimingCalibrationRcd>().get(hTimingCalib);
-
-    edm::LogInfo("PPSTimingCalibrationAnalyzer") << "Calibrations retrieved:\n" << *hTimingCalib;
+    edm::LogInfo("PPSTimingCalibrationAnalyzer") << "Calibrations retrieved:\n" << iSetup.getData(tokenCalibration_);
   }
 }
 

--- a/CondTools/CTPPS/plugins/PPSTimingCalibrationWriter.cc
+++ b/CondTools/CTPPS/plugins/PPSTimingCalibrationWriter.cc
@@ -25,9 +25,8 @@
 
 class PPSTimingCalibrationWriter : public edm::one::EDAnalyzer<> {
 public:
-  explicit PPSTimingCalibrationWriter(const edm::ParameterSet&) :
-    tokenCalibration_( esConsumes<PPSTimingCalibration, PPSTimingCalibrationRcd>() )
-  {}
+  explicit PPSTimingCalibrationWriter(const edm::ParameterSet&)
+      : tokenCalibration_(esConsumes<PPSTimingCalibration, PPSTimingCalibrationRcd>()) {}
 
 private:
   void beginJob() override {}

--- a/CondTools/CTPPS/plugins/PPSTimingCalibrationWriter.cc
+++ b/CondTools/CTPPS/plugins/PPSTimingCalibrationWriter.cc
@@ -25,18 +25,21 @@
 
 class PPSTimingCalibrationWriter : public edm::one::EDAnalyzer<> {
 public:
-  explicit PPSTimingCalibrationWriter(const edm::ParameterSet&) {}
+  explicit PPSTimingCalibrationWriter(const edm::ParameterSet&) :
+    tokenCalibration_( esConsumes<PPSTimingCalibration, PPSTimingCalibrationRcd>() )
+  {}
 
 private:
   void beginJob() override {}
   void analyze(const edm::Event&, const edm::EventSetup&) override;
   void endJob() override {}
+
+  edm::ESGetToken<PPSTimingCalibration, PPSTimingCalibrationRcd> tokenCalibration_;
 };
 
 void PPSTimingCalibrationWriter::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
   // get timing calibration parameters
-  edm::ESHandle<PPSTimingCalibration> hTimingCalib;
-  iSetup.get<PPSTimingCalibrationRcd>().get(hTimingCalib);
+  edm::ESHandle<PPSTimingCalibration> hTimingCalib = iSetup.getHandle(tokenCalibration_);
 
   // store the calibration into a DB object
   edm::Service<cond::service::PoolDBOutputService> poolDbService;

--- a/CondTools/CTPPS/plugins/RetrieveCTPPSBeamParameters.cc
+++ b/CondTools/CTPPS/plugins/RetrieveCTPPSBeamParameters.cc
@@ -33,10 +33,9 @@
 
 class RetrieveCTPPSBeamParameters : public edm::one::EDAnalyzer<> {
 public:
-  explicit RetrieveCTPPSBeamParameters(const edm::ParameterSet &ps) :
-    label_(ps.getParameter<std::string>("label")),
-    tokenBeamParameters_( esConsumes<CTPPSBeamParameters, CTPPSBeamParametersRcd>( edm::ESInputTag("", label_) ) )
-  {}
+  explicit RetrieveCTPPSBeamParameters(const edm::ParameterSet& ps)
+      : label_(ps.getParameter<std::string>("label")),
+        tokenBeamParameters_(esConsumes<CTPPSBeamParameters, CTPPSBeamParametersRcd>(edm::ESInputTag("", label_))) {}
 
   ~RetrieveCTPPSBeamParameters() override = default;
 

--- a/CondTools/CTPPS/plugins/RetrieveCTPPSBeamParameters.cc
+++ b/CondTools/CTPPS/plugins/RetrieveCTPPSBeamParameters.cc
@@ -33,25 +33,24 @@
 
 class RetrieveCTPPSBeamParameters : public edm::one::EDAnalyzer<> {
 public:
-  explicit RetrieveCTPPSBeamParameters(const edm::ParameterSet&);
+  explicit RetrieveCTPPSBeamParameters(const edm::ParameterSet &ps) :
+    label_(ps.getParameter<std::string>("label")),
+    tokenBeamParameters_( esConsumes<CTPPSBeamParameters, CTPPSBeamParametersRcd>( edm::ESInputTag("", label_) ) )
+  {}
+
   ~RetrieveCTPPSBeamParameters() override = default;
 
 private:
   void analyze(const edm::Event&, const edm::EventSetup&) override;
   std::string label_;
+
+  edm::ESGetToken<CTPPSBeamParameters, CTPPSBeamParametersRcd> tokenBeamParameters_;
 };
 
 //---------------------------------------------------------------------------------------
 
-RetrieveCTPPSBeamParameters::RetrieveCTPPSBeamParameters(const edm::ParameterSet& iConfig) {}
-
 void RetrieveCTPPSBeamParameters::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
-  edm::ESHandle<CTPPSBeamParameters> pSetup;
-  iSetup.get<CTPPSBeamParametersRcd>().get(label_, pSetup);
-
-  const CTPPSBeamParameters* pInfo = pSetup.product();
-
-  edm::LogInfo("CTPPSBeamParameters") << "\n" << *pInfo << "\n";
+  edm::LogInfo("CTPPSBeamParameters") << "\n" << iSetup.getData(tokenBeamParameters_) << "\n";
 }
 
 DEFINE_FWK_MODULE(RetrieveCTPPSBeamParameters);

--- a/CondTools/CTPPS/plugins/WriteCTPPSBeamParameters.cc
+++ b/CondTools/CTPPS/plugins/WriteCTPPSBeamParameters.cc
@@ -35,9 +35,8 @@
 
 class WriteCTPPSBeamParameters : public edm::one::EDAnalyzer<> {
 public:
-  WriteCTPPSBeamParameters(const edm::ParameterSet&) :
-    tokenBeamParameters_( esConsumes<CTPPSBeamParameters, CTPPSBeamParametersRcd>() )
-  {}
+  WriteCTPPSBeamParameters(const edm::ParameterSet&)
+      : tokenBeamParameters_(esConsumes<CTPPSBeamParameters, CTPPSBeamParametersRcd>()) {}
 
   ~WriteCTPPSBeamParameters() override = default;
 

--- a/CondTools/CTPPS/plugins/WriteCTPPSBeamParameters.cc
+++ b/CondTools/CTPPS/plugins/WriteCTPPSBeamParameters.cc
@@ -35,18 +35,22 @@
 
 class WriteCTPPSBeamParameters : public edm::one::EDAnalyzer<> {
 public:
-  WriteCTPPSBeamParameters(const edm::ParameterSet&) {}
+  WriteCTPPSBeamParameters(const edm::ParameterSet&) :
+    tokenBeamParameters_( esConsumes<CTPPSBeamParameters, CTPPSBeamParametersRcd>() )
+  {}
+
   ~WriteCTPPSBeamParameters() override = default;
 
 private:
   void analyze(const edm::Event&, const edm::EventSetup&) override;
+
+  edm::ESGetToken<CTPPSBeamParameters, CTPPSBeamParametersRcd> tokenBeamParameters_;
 };
 
 //---------------------------------------------------------------------------------------
 
 void WriteCTPPSBeamParameters::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
-  edm::ESHandle<CTPPSBeamParameters> bp;
-  iSetup.get<CTPPSBeamParametersRcd>().get(bp);
+  edm::ESHandle<CTPPSBeamParameters> bp = iSetup.getHandle(tokenBeamParameters_);
 
   // Pointer for the conditions data object
   const CTPPSBeamParameters* p = bp.product();

--- a/CondTools/CTPPS/src/CTPPSRPAlignmentInfoAnalyzer.cc
+++ b/CondTools/CTPPS/src/CTPPSRPAlignmentInfoAnalyzer.cc
@@ -58,10 +58,8 @@ using namespace edm;
 
 //----------------------------------------------------------------------------------------------------
 
-CTPPSRPAlignmentInfoAnalyzer::CTPPSRPAlignmentInfoAnalyzer(const edm::ParameterSet& iConfig) :
-  record_(iConfig.getParameter<string>("record")),
-  iov_(iConfig.getParameter<unsigned long long>("iov"))
-{
+CTPPSRPAlignmentInfoAnalyzer::CTPPSRPAlignmentInfoAnalyzer(const edm::ParameterSet& iConfig)
+    : record_(iConfig.getParameter<string>("record")), iov_(iConfig.getParameter<unsigned long long>("iov")) {
   if (strcmp(record_.c_str(), "CTPPSRPAlignmentCorrectionsDataRcd") == 0) {
     tokenAlignmentIdeal_ = esConsumes<CTPPSRPAlignmentCorrectionsData, CTPPSRPAlignmentCorrectionsDataRcd>();
   } else if (strcmp(record_.c_str(), "RPRealAlignmentRecord") == 0) {
@@ -84,11 +82,11 @@ void CTPPSRPAlignmentInfoAnalyzer::analyze(const edm::Event& iEvent, const edm::
     alignments = iSetup.getHandle(tokenAlignmentMisaligned_);
   }
 
-    const CTPPSRPAlignmentCorrectionsData* pCTPPSRPAlignmentCorrectionsData = alignments.product();
-    edm::Service<cond::service::PoolDBOutputService> poolDbService;
-    if (poolDbService.isAvailable()) {
-      poolDbService->writeOne(pCTPPSRPAlignmentCorrectionsData, iov_, record_);
-    }
+  const CTPPSRPAlignmentCorrectionsData* pCTPPSRPAlignmentCorrectionsData = alignments.product();
+  edm::Service<cond::service::PoolDBOutputService> poolDbService;
+  if (poolDbService.isAvailable()) {
+    poolDbService->writeOne(pCTPPSRPAlignmentCorrectionsData, iov_, record_);
+  }
 }
 
 //----------------------------------------------------------------------------------------------------

--- a/CondTools/CTPPS/src/CTPPSRPAlignmentInfoAnalyzer.cc
+++ b/CondTools/CTPPS/src/CTPPSRPAlignmentInfoAnalyzer.cc
@@ -9,6 +9,7 @@
 
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Utilities/interface/ESGetToken.h"
 #include "FWCore/Utilities/interface/Exception.h"
 #include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
@@ -40,10 +41,13 @@ private:
   void analyze(const edm::Event& e, const edm::EventSetup& es) override;
 
   void printInfo(const CTPPSRPAlignmentCorrectionsData& alignments, const edm::Event& event) const;
-  edm::ESWatcher<CTPPSRPAlignmentCorrectionsDataRcd> watcherAlignments_;
 
-  cond::Time_t iov_;
+  edm::ESGetToken<CTPPSRPAlignmentCorrectionsData, CTPPSRPAlignmentCorrectionsDataRcd> tokenAlignmentIdeal_;
+  edm::ESGetToken<CTPPSRPAlignmentCorrectionsData, RPRealAlignmentRecord> tokenAlignmentReal_;
+  edm::ESGetToken<CTPPSRPAlignmentCorrectionsData, RPMisalignedAlignmentRecord> tokenAlignmentMisaligned_;
+
   std::string record_;
+  cond::Time_t iov_;
 };
 
 //----------------------------------------------------------------------------------------------------
@@ -54,30 +58,37 @@ using namespace edm;
 
 //----------------------------------------------------------------------------------------------------
 
-CTPPSRPAlignmentInfoAnalyzer::CTPPSRPAlignmentInfoAnalyzer(const edm::ParameterSet& iConfig) {
-  record_ = iConfig.getParameter<string>("record");
-  iov_ = iConfig.getParameter<unsigned long long>("iov");
+CTPPSRPAlignmentInfoAnalyzer::CTPPSRPAlignmentInfoAnalyzer(const edm::ParameterSet& iConfig) :
+  record_(iConfig.getParameter<string>("record")),
+  iov_(iConfig.getParameter<unsigned long long>("iov"))
+{
+  if (strcmp(record_.c_str(), "CTPPSRPAlignmentCorrectionsDataRcd") == 0) {
+    tokenAlignmentIdeal_ = esConsumes<CTPPSRPAlignmentCorrectionsData, CTPPSRPAlignmentCorrectionsDataRcd>();
+  } else if (strcmp(record_.c_str(), "RPRealAlignmentRecord") == 0) {
+    tokenAlignmentReal_ = esConsumes<CTPPSRPAlignmentCorrectionsData, RPRealAlignmentRecord>();
+  } else {
+    tokenAlignmentMisaligned_ = esConsumes<CTPPSRPAlignmentCorrectionsData, RPMisalignedAlignmentRecord>();
+  }
 }
 
 //----------------------------------------------------------------------------------------------------
 
 void CTPPSRPAlignmentInfoAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
   edm::ESHandle<CTPPSRPAlignmentCorrectionsData> alignments;
-  if (watcherAlignments_.check(iSetup)) {
-    if (strcmp(record_.c_str(), "CTPPSRPAlignmentCorrectionsDataRcd") == 0) {
-      iSetup.get<CTPPSRPAlignmentCorrectionsDataRcd>().get(alignments);
-    } else if (strcmp(record_.c_str(), "RPRealAlignmentRecord") == 0) {
-      iSetup.get<RPRealAlignmentRecord>().get(alignments);
-    } else {
-      iSetup.get<RPMisalignedAlignmentRecord>().get(alignments);
-    }
+
+  if (strcmp(record_.c_str(), "CTPPSRPAlignmentCorrectionsDataRcd") == 0) {
+    alignments = iSetup.getHandle(tokenAlignmentIdeal_);
+  } else if (strcmp(record_.c_str(), "RPRealAlignmentRecord") == 0) {
+    alignments = iSetup.getHandle(tokenAlignmentReal_);
+  } else {
+    alignments = iSetup.getHandle(tokenAlignmentMisaligned_);
+  }
+
     const CTPPSRPAlignmentCorrectionsData* pCTPPSRPAlignmentCorrectionsData = alignments.product();
     edm::Service<cond::service::PoolDBOutputService> poolDbService;
     if (poolDbService.isAvailable()) {
       poolDbService->writeOne(pCTPPSRPAlignmentCorrectionsData, iov_, record_);
     }
-  }
-  return;
 }
 
 //----------------------------------------------------------------------------------------------------

--- a/CondTools/CTPPS/src/WriteCTPPSPixelAnalysisMask.cc
+++ b/CondTools/CTPPS/src/WriteCTPPSPixelAnalysisMask.cc
@@ -55,8 +55,7 @@ WriteCTPPSPixelAnalysisMask::WriteCTPPSPixelAnalysisMask(const edm::ParameterSet
     : analysismaskiov_(ps.getParameter<unsigned long long>("analysismaskiov")),
       record_(ps.getParameter<string>("record")),
       label_(ps.getParameter<string>("label")),
-      tokenAnalysisMask_( esConsumes<CTPPSPixelAnalysisMask, CTPPSPixelAnalysisMaskRcd>(edm::ESInputTag("", label_)) )
-{}
+      tokenAnalysisMask_(esConsumes<CTPPSPixelAnalysisMask, CTPPSPixelAnalysisMaskRcd>(edm::ESInputTag("", label_))) {}
 
 void WriteCTPPSPixelAnalysisMask::analyze(const edm::Event &, edm::EventSetup const &es) {
   // get analysis mask to mask channels

--- a/CondTools/CTPPS/src/WriteCTPPSPixelAnalysisMask.cc
+++ b/CondTools/CTPPS/src/WriteCTPPSPixelAnalysisMask.cc
@@ -42,6 +42,8 @@ private:
   cond::Time_t analysismaskiov_;
   std::string record_;
   std::string label_;
+
+  edm::ESGetToken<CTPPSPixelAnalysisMask, CTPPSPixelAnalysisMaskRcd> tokenAnalysisMask_;
 };
 
 using namespace std;
@@ -52,12 +54,13 @@ using namespace edm;
 WriteCTPPSPixelAnalysisMask::WriteCTPPSPixelAnalysisMask(const edm::ParameterSet &ps)
     : analysismaskiov_(ps.getParameter<unsigned long long>("analysismaskiov")),
       record_(ps.getParameter<string>("record")),
-      label_(ps.getParameter<string>("label")) {}
+      label_(ps.getParameter<string>("label")),
+      tokenAnalysisMask_( esConsumes<CTPPSPixelAnalysisMask, CTPPSPixelAnalysisMaskRcd>(edm::ESInputTag("", label_)) )
+{}
 
 void WriteCTPPSPixelAnalysisMask::analyze(const edm::Event &, edm::EventSetup const &es) {
   // get analysis mask to mask channels
-  ESHandle<CTPPSPixelAnalysisMask> analysisMask;
-  es.get<CTPPSPixelAnalysisMaskRcd>().get(label_, analysisMask);
+  ESHandle<CTPPSPixelAnalysisMask> hAnalysisMask = es.getHandle(tokenAnalysisMask_);
 
   /*// print analysisMask
   printf("* mask\n");
@@ -68,7 +71,7 @@ void WriteCTPPSPixelAnalysisMask::analyze(const edm::Event &, edm::EventSetup co
   */
 
   // Write Analysis Mask to sqlite file:
-  const CTPPSPixelAnalysisMask *pCTPPSPixelAnalysisMask = analysisMask.product();  // Analysis Mask
+  const CTPPSPixelAnalysisMask *pCTPPSPixelAnalysisMask = hAnalysisMask.product();  // Analysis Mask
   edm::Service<cond::service::PoolDBOutputService> poolDbService;
   if (poolDbService.isAvailable()) {
     poolDbService->writeOne(pCTPPSPixelAnalysisMask, analysismaskiov_, /*m_record*/ record_);

--- a/CondTools/CTPPS/src/WriteCTPPSPixelDAQMapping.cc
+++ b/CondTools/CTPPS/src/WriteCTPPSPixelDAQMapping.cc
@@ -56,8 +56,7 @@ WriteCTPPSPixelDAQMapping::WriteCTPPSPixelDAQMapping(const edm::ParameterSet &ps
     : daqmappingiov_(ps.getParameter<unsigned long long>("daqmappingiov")),
       record_(ps.getParameter<string>("record")),
       label_(ps.getParameter<string>("label")),
-      tokenMapping_( esConsumes<CTPPSPixelDAQMapping, CTPPSPixelDAQMappingRcd>(edm::ESInputTag("", label_)) )
-{}
+      tokenMapping_(esConsumes<CTPPSPixelDAQMapping, CTPPSPixelDAQMappingRcd>(edm::ESInputTag("", label_))) {}
 
 void WriteCTPPSPixelDAQMapping::analyze(const edm::Event &, edm::EventSetup const &es) {
   // get DAQ mapping

--- a/CondTools/CTPPS/src/WriteCTPPSPixelDAQMapping.cc
+++ b/CondTools/CTPPS/src/WriteCTPPSPixelDAQMapping.cc
@@ -24,6 +24,7 @@
 #include "CondFormats/DataRecord/interface/CTPPSPixelAnalysisMaskRcd.h"
 #include "CondFormats/PPSObjects/interface/CTPPSPixelDAQMapping.h"
 #include "CondFormats/PPSObjects/interface/CTPPSPixelAnalysisMask.h"
+#include "FWCore/Utilities/interface/ESInputTag.h"
 
 #include <cstdint>
 
@@ -42,6 +43,8 @@ private:
   cond::Time_t daqmappingiov_;
   std::string record_;
   std::string label_;
+
+  edm::ESGetToken<CTPPSPixelDAQMapping, CTPPSPixelDAQMappingRcd> tokenMapping_;
 };
 
 using namespace std;
@@ -52,12 +55,13 @@ using namespace edm;
 WriteCTPPSPixelDAQMapping::WriteCTPPSPixelDAQMapping(const edm::ParameterSet &ps)
     : daqmappingiov_(ps.getParameter<unsigned long long>("daqmappingiov")),
       record_(ps.getParameter<string>("record")),
-      label_(ps.getParameter<string>("label")) {}
+      label_(ps.getParameter<string>("label")),
+      tokenMapping_( esConsumes<CTPPSPixelDAQMapping, CTPPSPixelDAQMappingRcd>(edm::ESInputTag("", label_)) )
+{}
 
 void WriteCTPPSPixelDAQMapping::analyze(const edm::Event &, edm::EventSetup const &es) {
   // get DAQ mapping
-  edm::ESHandle<CTPPSPixelDAQMapping> mapping;
-  es.get<CTPPSPixelDAQMappingRcd>().get(label_, mapping);
+  edm::ESHandle<CTPPSPixelDAQMapping> hMapping = es.getHandle(tokenMapping_);
 
   // print mapping
   /*printf("* DAQ mapping\n");
@@ -66,7 +70,7 @@ void WriteCTPPSPixelDAQMapping::analyze(const edm::Event &, edm::EventSetup cons
   */
 
   // Write DAQ Mapping to sqlite file:
-  const CTPPSPixelDAQMapping *pCTPPSPixelDAQMapping = mapping.product();  // DAQ Mapping
+  const CTPPSPixelDAQMapping *pCTPPSPixelDAQMapping = hMapping.product();  // DAQ Mapping
   edm::Service<cond::service::PoolDBOutputService> poolDbService;
   if (poolDbService.isAvailable()) {
     poolDbService->writeOne(pCTPPSPixelDAQMapping, daqmappingiov_, /*m_record*/ record_);

--- a/CondTools/CTPPS/test/write-ctpps-pixel-analysismask_cfg.py
+++ b/CondTools/CTPPS/test/write-ctpps-pixel-analysismask_cfg.py
@@ -15,7 +15,7 @@ process.source = cms.Source("EmptyIOVSource",
 #)
 
 # load a mapping
-process.load("CondFormats.PPSObjects.CTPPSPixelDAQMappingESSourceXML_cfi")
+process.load("CalibPPS.ESProducers.CTPPSPixelDAQMappingESSourceXML_cfi")
 
 #Database output service
 process.load("CondCore.CondDB.CondDB_cfi")

--- a/CondTools/CTPPS/test/write-ctpps-pixel-daqmap_cfg.py
+++ b/CondTools/CTPPS/test/write-ctpps-pixel-daqmap_cfg.py
@@ -15,7 +15,7 @@ process.source = cms.Source("EmptyIOVSource",
 #)
 
 # load a mapping
-process.load("CondFormats.PPSObjects.CTPPSPixelDAQMappingESSourceXML_cfi")
+process.load("CalibPPS.ESProducers.CTPPSPixelDAQMappingESSourceXML_cfi")
 
 #Database output service
 process.load("CondCore.CondDB.CondDB_cfi")

--- a/CondTools/CTPPS/test/write-ctpps-rpalignmentcorrectionsdata_cfg.py
+++ b/CondTools/CTPPS/test/write-ctpps-rpalignmentcorrectionsdata_cfg.py
@@ -13,10 +13,9 @@ process.source = cms.Source("EmptyIOVSource",
 
 # load the alignment xml file
 process.load("CalibPPS.ESProducers.ctppsRPAlignmentCorrectionsDataESSourceXML_cfi")
-#process.ctppsRPAlignmentCorrectionsDataESSourceXML.XMLFile = cms.string("CalibPPS.ESProducers/xml/sample_alignment_corrections.xml")
-process.ctppsRPAlignmentCorrectionsDataESSourceXML.RealFiles = cms.vstring("CalibPPS.ESProducers/xml/sample_alignment_corrections.xml")
-process.ctppsRPAlignmentCorrectionsDataESSourceXML.MeasuredFiles = cms.vstring("CalibPPS.ESProducers/xml/sample_alignment_corrections.xml")
-process.ctppsRPAlignmentCorrectionsDataESSourceXML.MisalignedFiles = cms.vstring("CalibPPS.ESProducers/xml/sample_alignment_corrections.xml")
+process.ctppsRPAlignmentCorrectionsDataESSourceXML.RealFiles = cms.vstring("CondFormats/PPSObjects/xml/sample_alignment_corrections.xml")
+process.ctppsRPAlignmentCorrectionsDataESSourceXML.MeasuredFiles = cms.vstring("CondFormats/PPSObjects/xml/sample_alignment_corrections.xml")
+process.ctppsRPAlignmentCorrectionsDataESSourceXML.MisalignedFiles = cms.vstring("CondFormats/PPSObjects/xml/sample_alignment_corrections.xml")
 
 
 #Database output service

--- a/CondTools/CTPPS/test/write-ctpps-rpalignmentcorrectionsdata_cfg.py
+++ b/CondTools/CTPPS/test/write-ctpps-rpalignmentcorrectionsdata_cfg.py
@@ -12,11 +12,11 @@ process.source = cms.Source("EmptyIOVSource",
 
 
 # load the alignment xml file
-process.load("CondFormats.PPSObjects.ctppsRPAlignmentCorrectionsDataESSourceXML_cfi")
-#process.ctppsRPAlignmentCorrectionsDataESSourceXML.XMLFile = cms.string("CondFormats/PPSObjects/xml/sample_alignment_corrections.xml")
-process.ctppsRPAlignmentCorrectionsDataESSourceXML.RealFiles = cms.vstring("CondFormats/PPSObjects/xml/sample_alignment_corrections.xml")
-process.ctppsRPAlignmentCorrectionsDataESSourceXML.MeasuredFiles = cms.vstring("CondFormats/PPSObjects/xml/sample_alignment_corrections.xml")
-process.ctppsRPAlignmentCorrectionsDataESSourceXML.MisalignedFiles = cms.vstring("CondFormats/PPSObjects/xml/sample_alignment_corrections.xml")
+process.load("CalibPPS.ESProducers.ctppsRPAlignmentCorrectionsDataESSourceXML_cfi")
+#process.ctppsRPAlignmentCorrectionsDataESSourceXML.XMLFile = cms.string("CalibPPS.ESProducers/xml/sample_alignment_corrections.xml")
+process.ctppsRPAlignmentCorrectionsDataESSourceXML.RealFiles = cms.vstring("CalibPPS.ESProducers/xml/sample_alignment_corrections.xml")
+process.ctppsRPAlignmentCorrectionsDataESSourceXML.MeasuredFiles = cms.vstring("CalibPPS.ESProducers/xml/sample_alignment_corrections.xml")
+process.ctppsRPAlignmentCorrectionsDataESSourceXML.MisalignedFiles = cms.vstring("CalibPPS.ESProducers/xml/sample_alignment_corrections.xml")
 
 
 #Database output service

--- a/CondTools/CTPPS/test/write-ctpps-rpmisalignedalignment_cfg.py
+++ b/CondTools/CTPPS/test/write-ctpps-rpmisalignedalignment_cfg.py
@@ -12,10 +12,10 @@ process.source = cms.Source("EmptyIOVSource",
 
 
 # load the alignment xml file
-process.load("CondFormats.PPSObjects.ctppsRPAlignmentCorrectionsDataESSourceXML_cfi")
-process.ctppsRPAlignmentCorrectionsDataESSourceXML.RealFiles = cms.vstring("CondFormats/PPSObjects/xml/sample_alignment_corrections.xml")
-process.ctppsRPAlignmentCorrectionsDataESSourceXML.MeasuredFiles = cms.vstring("CondFormats/PPSObjects/xml/sample_alignment_corrections.xml")
-process.ctppsRPAlignmentCorrectionsDataESSourceXML.MisalignedFiles = cms.vstring("CondFormats/PPSObjects/xml/sample_alignment_corrections.xml")
+process.load("CalibPPS.ESProducers.ctppsRPAlignmentCorrectionsDataESSourceXML_cfi")
+process.ctppsRPAlignmentCorrectionsDataESSourceXML.RealFiles = cms.vstring("CalibPPS.ESProducers/xml/sample_alignment_corrections.xml")
+process.ctppsRPAlignmentCorrectionsDataESSourceXML.MeasuredFiles = cms.vstring("CalibPPS.ESProducers/xml/sample_alignment_corrections.xml")
+process.ctppsRPAlignmentCorrectionsDataESSourceXML.MisalignedFiles = cms.vstring("CalibPPS.ESProducers/xml/sample_alignment_corrections.xml")
 
 
 #Database output service

--- a/CondTools/CTPPS/test/write-ctpps-rpmisalignedalignment_cfg.py
+++ b/CondTools/CTPPS/test/write-ctpps-rpmisalignedalignment_cfg.py
@@ -13,9 +13,9 @@ process.source = cms.Source("EmptyIOVSource",
 
 # load the alignment xml file
 process.load("CalibPPS.ESProducers.ctppsRPAlignmentCorrectionsDataESSourceXML_cfi")
-process.ctppsRPAlignmentCorrectionsDataESSourceXML.RealFiles = cms.vstring("CalibPPS.ESProducers/xml/sample_alignment_corrections.xml")
-process.ctppsRPAlignmentCorrectionsDataESSourceXML.MeasuredFiles = cms.vstring("CalibPPS.ESProducers/xml/sample_alignment_corrections.xml")
-process.ctppsRPAlignmentCorrectionsDataESSourceXML.MisalignedFiles = cms.vstring("CalibPPS.ESProducers/xml/sample_alignment_corrections.xml")
+process.ctppsRPAlignmentCorrectionsDataESSourceXML.RealFiles = cms.vstring("CondFormats/PPSObjects/xml/sample_alignment_corrections.xml")
+process.ctppsRPAlignmentCorrectionsDataESSourceXML.MeasuredFiles = cms.vstring("CondFormats/PPSObjects/xml/sample_alignment_corrections.xml")
+process.ctppsRPAlignmentCorrectionsDataESSourceXML.MisalignedFiles = cms.vstring("CondFormats/PPSObjects/xml/sample_alignment_corrections.xml")
 
 
 #Database output service

--- a/CondTools/CTPPS/test/write-ctpps-rprealalignment_cfg.py
+++ b/CondTools/CTPPS/test/write-ctpps-rprealalignment_cfg.py
@@ -13,10 +13,10 @@ process.source = cms.Source("EmptyIOVSource",
 
 # load the alignment xml file
 process.load("CalibPPS.ESProducers.ctppsRPAlignmentCorrectionsDataESSourceXML_cfi")
-#process.ctppsRPAlignmentCorrectionsDataESSourceXML.XMLFile = cms.string("CalibPPS.ESProducers/xml/sample_alignment_corrections.xml")
-process.ctppsRPAlignmentCorrectionsDataESSourceXML.RealFiles = cms.vstring("CalibPPS.ESProducers/xml/sample_alignment_corrections.xml")
-process.ctppsRPAlignmentCorrectionsDataESSourceXML.MeasuredFiles = cms.vstring("CalibPPS.ESProducers/xml/sample_alignment_corrections.xml")
-process.ctppsRPAlignmentCorrectionsDataESSourceXML.MisalignedFiles = cms.vstring("CalibPPS.ESProducers/xml/sample_alignment_corrections.xml")
+#process.ctppsRPAlignmentCorrectionsDataESSourceXML.XMLFile = cms.string("CondFormats/PPSObjects/xml/sample_alignment_corrections.xml")
+process.ctppsRPAlignmentCorrectionsDataESSourceXML.RealFiles = cms.vstring("CondFormats/PPSObjects/xml/sample_alignment_corrections.xml")
+process.ctppsRPAlignmentCorrectionsDataESSourceXML.MeasuredFiles = cms.vstring("CondFormats/PPSObjects/xml/sample_alignment_corrections.xml")
+process.ctppsRPAlignmentCorrectionsDataESSourceXML.MisalignedFiles = cms.vstring("CondFormats/PPSObjects/xml/sample_alignment_corrections.xml")
 
 
 #Database output service

--- a/CondTools/CTPPS/test/write-ctpps-rprealalignment_cfg.py
+++ b/CondTools/CTPPS/test/write-ctpps-rprealalignment_cfg.py
@@ -12,11 +12,11 @@ process.source = cms.Source("EmptyIOVSource",
 
 
 # load the alignment xml file
-process.load("CondFormats.PPSObjects.ctppsRPAlignmentCorrectionsDataESSourceXML_cfi")
-#process.ctppsRPAlignmentCorrectionsDataESSourceXML.XMLFile = cms.string("CondFormats/PPSObjects/xml/sample_alignment_corrections.xml")
-process.ctppsRPAlignmentCorrectionsDataESSourceXML.RealFiles = cms.vstring("CondFormats/PPSObjects/xml/sample_alignment_corrections.xml")
-process.ctppsRPAlignmentCorrectionsDataESSourceXML.MeasuredFiles = cms.vstring("CondFormats/PPSObjects/xml/sample_alignment_corrections.xml")
-process.ctppsRPAlignmentCorrectionsDataESSourceXML.MisalignedFiles = cms.vstring("CondFormats/PPSObjects/xml/sample_alignment_corrections.xml")
+process.load("CalibPPS.ESProducers.ctppsRPAlignmentCorrectionsDataESSourceXML_cfi")
+#process.ctppsRPAlignmentCorrectionsDataESSourceXML.XMLFile = cms.string("CalibPPS.ESProducers/xml/sample_alignment_corrections.xml")
+process.ctppsRPAlignmentCorrectionsDataESSourceXML.RealFiles = cms.vstring("CalibPPS.ESProducers/xml/sample_alignment_corrections.xml")
+process.ctppsRPAlignmentCorrectionsDataESSourceXML.MeasuredFiles = cms.vstring("CalibPPS.ESProducers/xml/sample_alignment_corrections.xml")
+process.ctppsRPAlignmentCorrectionsDataESSourceXML.MisalignedFiles = cms.vstring("CalibPPS.ESProducers/xml/sample_alignment_corrections.xml")
 
 
 #Database output service

--- a/CondTools/CTPPS/test/write-ctpps-rprealalignment_singletest.py
+++ b/CondTools/CTPPS/test/write-ctpps-rprealalignment_singletest.py
@@ -16,16 +16,16 @@ process.source = cms.Source("EmptyIOVSource",
 
 
 # load the alignment xml file
-process.load("CondFormats.PPSObjects.ctppsRPAlignmentCorrectionsDataESSourceXML_cfi")
-#process.ctppsRPAlignmentCorrectionsDataESSourceXML.XMLFile = cms.string("CondFormats/PPSObjects/xml/sample_alignment_corrections.xml")
-#process.ctppsRPAlignmentCorrectionsDataESSourceXML.RealFiles = cms.vstring("CondFormats/PPSObjects/xml/sample_alignment_corrections.xml")
+process.load("CalibPPS.ESProducers.ctppsRPAlignmentCorrectionsDataESSourceXML_cfi")
+#process.ctppsRPAlignmentCorrectionsDataESSourceXML.XMLFile = cms.string("CalibPPS.ESProducers/xml/sample_alignment_corrections.xml")
+#process.ctppsRPAlignmentCorrectionsDataESSourceXML.RealFiles = cms.vstring("CalibPPS.ESProducers/xml/sample_alignment_corrections.xml")
 process.ctppsRPAlignmentCorrectionsDataESSourceXML.RealFiles = cms.vstring(
     "CondTools/CTPPS/test/RPixGeometryCorrections.xml",
     "CondTools/CTPPS/test/largeXMLmanipulations/real_alignment_iov"+str(startrun)+".xml"
     )
 
-process.ctppsRPAlignmentCorrectionsDataESSourceXML.MeasuredFiles = cms.vstring("CondFormats/PPSObjects/xml/sample_alignment_corrections.xml")
-process.ctppsRPAlignmentCorrectionsDataESSourceXML.MisalignedFiles = cms.vstring("CondFormats/PPSObjects/xml/sample_alignment_corrections.xml")
+process.ctppsRPAlignmentCorrectionsDataESSourceXML.MeasuredFiles = cms.vstring("CalibPPS.ESProducers/xml/sample_alignment_corrections.xml")
+process.ctppsRPAlignmentCorrectionsDataESSourceXML.MisalignedFiles = cms.vstring("CalibPPS.ESProducers/xml/sample_alignment_corrections.xml")
 
 
 #Database output service

--- a/CondTools/CTPPS/test/write-ctpps-rprealalignment_singletest.py
+++ b/CondTools/CTPPS/test/write-ctpps-rprealalignment_singletest.py
@@ -17,15 +17,14 @@ process.source = cms.Source("EmptyIOVSource",
 
 # load the alignment xml file
 process.load("CalibPPS.ESProducers.ctppsRPAlignmentCorrectionsDataESSourceXML_cfi")
-#process.ctppsRPAlignmentCorrectionsDataESSourceXML.XMLFile = cms.string("CalibPPS.ESProducers/xml/sample_alignment_corrections.xml")
-#process.ctppsRPAlignmentCorrectionsDataESSourceXML.RealFiles = cms.vstring("CalibPPS.ESProducers/xml/sample_alignment_corrections.xml")
-process.ctppsRPAlignmentCorrectionsDataESSourceXML.RealFiles = cms.vstring(
-    "CondTools/CTPPS/test/RPixGeometryCorrections.xml",
-    "CondTools/CTPPS/test/largeXMLmanipulations/real_alignment_iov"+str(startrun)+".xml"
-    )
+process.ctppsRPAlignmentCorrectionsDataESSourceXML.RealFiles = cms.vstring("CondFormats/PPSObjects/xml/sample_alignment_corrections.xml")
+#process.ctppsRPAlignmentCorrectionsDataESSourceXML.RealFiles = cms.vstring(
+#    "CondTools/CTPPS/test/RPixGeometryCorrections.xml",
+#    "CondTools/CTPPS/test/largeXMLmanipulations/real_alignment_iov"+str(startrun)+".xml"
+#    )
 
-process.ctppsRPAlignmentCorrectionsDataESSourceXML.MeasuredFiles = cms.vstring("CalibPPS.ESProducers/xml/sample_alignment_corrections.xml")
-process.ctppsRPAlignmentCorrectionsDataESSourceXML.MisalignedFiles = cms.vstring("CalibPPS.ESProducers/xml/sample_alignment_corrections.xml")
+process.ctppsRPAlignmentCorrectionsDataESSourceXML.MeasuredFiles = cms.vstring("CondFormats/PPSObjects/xml/sample_alignment_corrections.xml")
+process.ctppsRPAlignmentCorrectionsDataESSourceXML.MisalignedFiles = cms.vstring("CondFormats/PPSObjects/xml/sample_alignment_corrections.xml")
 
 
 #Database output service

--- a/CondTools/CTPPS/test/write-ctpps-rprealalignment_table_cfg.py
+++ b/CondTools/CTPPS/test/write-ctpps-rprealalignment_table_cfg.py
@@ -20,15 +20,15 @@ process.source = cms.Source("EmptyIOVSource",
 )
 
 # load the alignment xml file
-process.load("CondFormats.PPSObjects.ctppsRPAlignmentCorrectionsDataESSourceXML_cfi")
-#process.ctppsRPAlignmentCorrectionsDataESSourceXML.XMLFile = cms.string("CondFormats/PPSObjects/xml/sample_alignment_corrections.xml")
+process.load("CalibPPS.ESProducers.ctppsRPAlignmentCorrectionsDataESSourceXML_cfi")
+#process.ctppsRPAlignmentCorrectionsDataESSourceXML.XMLFile = cms.string("CalibPPS.ESProducers/xml/sample_alignment_corrections.xml")
 process.ctppsRPAlignmentCorrectionsDataESSourceXML.RealFiles = cms.vstring(
-    #"CondFormats/PPSObjects/xml/sample_alignment_corrections.xml"
+    #"CalibPPS.ESProducers/xml/sample_alignment_corrections.xml"
     "CondTools/CTPPS/test/RPixGeometryCorrections.xml",
     "CondTools/CTPPS/test/"+subdir+"real_alignment_iov"+startrun+".xml"
     )
-process.ctppsRPAlignmentCorrectionsDataESSourceXML.MeasuredFiles = cms.vstring("CondFormats/PPSObjects/xml/sample_alignment_corrections.xml")
-process.ctppsRPAlignmentCorrectionsDataESSourceXML.MisalignedFiles = cms.vstring("CondFormats/PPSObjects/xml/sample_alignment_corrections.xml")
+process.ctppsRPAlignmentCorrectionsDataESSourceXML.MeasuredFiles = cms.vstring("CalibPPS.ESProducers/xml/sample_alignment_corrections.xml")
+process.ctppsRPAlignmentCorrectionsDataESSourceXML.MisalignedFiles = cms.vstring("CalibPPS.ESProducers/xml/sample_alignment_corrections.xml")
 
 
 #Database output service

--- a/CondTools/CTPPS/test/write-ctpps-rprealalignment_table_cfg.py
+++ b/CondTools/CTPPS/test/write-ctpps-rprealalignment_table_cfg.py
@@ -21,14 +21,14 @@ process.source = cms.Source("EmptyIOVSource",
 
 # load the alignment xml file
 process.load("CalibPPS.ESProducers.ctppsRPAlignmentCorrectionsDataESSourceXML_cfi")
-#process.ctppsRPAlignmentCorrectionsDataESSourceXML.XMLFile = cms.string("CalibPPS.ESProducers/xml/sample_alignment_corrections.xml")
+#process.ctppsRPAlignmentCorrectionsDataESSourceXML.XMLFile = cms.string("CondFormats/PPSObjects/xml/sample_alignment_corrections.xml")
 process.ctppsRPAlignmentCorrectionsDataESSourceXML.RealFiles = cms.vstring(
-    #"CalibPPS.ESProducers/xml/sample_alignment_corrections.xml"
-    "CondTools/CTPPS/test/RPixGeometryCorrections.xml",
-    "CondTools/CTPPS/test/"+subdir+"real_alignment_iov"+startrun+".xml"
+    "CondFormats/PPSObjects/xml/sample_alignment_corrections.xml"
+    #"CondTools/CTPPS/test/RPixGeometryCorrections.xml",
+    #"CondTools/CTPPS/test/"+subdir+"real_alignment_iov"+startrun+".xml"
     )
-process.ctppsRPAlignmentCorrectionsDataESSourceXML.MeasuredFiles = cms.vstring("CalibPPS.ESProducers/xml/sample_alignment_corrections.xml")
-process.ctppsRPAlignmentCorrectionsDataESSourceXML.MisalignedFiles = cms.vstring("CalibPPS.ESProducers/xml/sample_alignment_corrections.xml")
+process.ctppsRPAlignmentCorrectionsDataESSourceXML.MeasuredFiles = cms.vstring("CondFormats/PPSObjects/xml/sample_alignment_corrections.xml")
+process.ctppsRPAlignmentCorrectionsDataESSourceXML.MisalignedFiles = cms.vstring("CondFormats/PPSObjects/xml/sample_alignment_corrections.xml")
 
 
 #Database output service

--- a/CondTools/CTPPS/test/write-ctpps-rprealalignment_table_test.py
+++ b/CondTools/CTPPS/test/write-ctpps-rprealalignment_table_test.py
@@ -20,14 +20,14 @@ process.source = cms.Source("EmptyIOVSource",
 )
 
 # load the alignment xml file
-process.load("CondFormats.PPSObjects.ctppsRPAlignmentCorrectionsDataESSourceXML_cfi")
-#process.ctppsRPAlignmentCorrectionsDataESSourceXML.XMLFile = cms.string("CondFormats/PPSObjects/xml/sample_alignment_corrections.xml")
+process.load("CalibPPS.ESProducers.ctppsRPAlignmentCorrectionsDataESSourceXML_cfi")
+#process.ctppsRPAlignmentCorrectionsDataESSourceXML.XMLFile = cms.string("CalibPPS.ESProducers/xml/sample_alignment_corrections.xml")
 process.ctppsRPAlignmentCorrectionsDataESSourceXML.RealFiles = cms.vstring(
-    #"CondFormats/PPSObjects/xml/sample_alignment_corrections.xml"
+    #"CalibPPS.ESProducers/xml/sample_alignment_corrections.xml"
     "CondTools/CTPPS/test/largeXMLmanipulations/real_alignment_iov303832.xml"
     )
-process.ctppsRPAlignmentCorrectionsDataESSourceXML.MeasuredFiles = cms.vstring("CondFormats/PPSObjects/xml/sample_alignment_corrections.xml")
-process.ctppsRPAlignmentCorrectionsDataESSourceXML.MisalignedFiles = cms.vstring("CondFormats/PPSObjects/xml/sample_alignment_corrections.xml")
+process.ctppsRPAlignmentCorrectionsDataESSourceXML.MeasuredFiles = cms.vstring("CalibPPS.ESProducers/xml/sample_alignment_corrections.xml")
+process.ctppsRPAlignmentCorrectionsDataESSourceXML.MisalignedFiles = cms.vstring("CalibPPS.ESProducers/xml/sample_alignment_corrections.xml")
 
 
 #Database output service

--- a/CondTools/CTPPS/test/write-ctpps-rprealalignment_table_test.py
+++ b/CondTools/CTPPS/test/write-ctpps-rprealalignment_table_test.py
@@ -21,13 +21,13 @@ process.source = cms.Source("EmptyIOVSource",
 
 # load the alignment xml file
 process.load("CalibPPS.ESProducers.ctppsRPAlignmentCorrectionsDataESSourceXML_cfi")
-#process.ctppsRPAlignmentCorrectionsDataESSourceXML.XMLFile = cms.string("CalibPPS.ESProducers/xml/sample_alignment_corrections.xml")
+#process.ctppsRPAlignmentCorrectionsDataESSourceXML.XMLFile = cms.string("CondFormats/PPSObjects/xml/sample_alignment_corrections.xml")
 process.ctppsRPAlignmentCorrectionsDataESSourceXML.RealFiles = cms.vstring(
-    #"CalibPPS.ESProducers/xml/sample_alignment_corrections.xml"
-    "CondTools/CTPPS/test/largeXMLmanipulations/real_alignment_iov303832.xml"
+    "CondFormats/PPSObjects/xml/sample_alignment_corrections.xml"
+    #"CondTools/CTPPS/test/largeXMLmanipulations/real_alignment_iov303832.xml"
     )
-process.ctppsRPAlignmentCorrectionsDataESSourceXML.MeasuredFiles = cms.vstring("CalibPPS.ESProducers/xml/sample_alignment_corrections.xml")
-process.ctppsRPAlignmentCorrectionsDataESSourceXML.MisalignedFiles = cms.vstring("CalibPPS.ESProducers/xml/sample_alignment_corrections.xml")
+process.ctppsRPAlignmentCorrectionsDataESSourceXML.MeasuredFiles = cms.vstring("CondFormats/PPSObjects/xml/sample_alignment_corrections.xml")
+process.ctppsRPAlignmentCorrectionsDataESSourceXML.MisalignedFiles = cms.vstring("CondFormats/PPSObjects/xml/sample_alignment_corrections.xml")
 
 
 #Database output service


### PR DESCRIPTION
#### PR description:

As a follow up of https://github.com/cms-sw/cmssw/issues/31061, this PR makes the modules in CondTools/CTPPS use the esConsumes mechanism.

This is a technical PR, no difference in test results is expected.

#### PR validation:

Comparison before (blue) vs. after the PR (red dashed)
 * for "direct simulation" [dirsim_cmp.pdf](https://github.com/cms-sw/cmssw/files/6776718/dirsim_cmp.pdf)
 * for reconstruction [reco_cmp.pdf](https://github.com/cms-sw/cmssw/files/6776719/reco_cmp.pdf)

show no differences - as expected.

