### PR TITLE
introduce `uploadConditions.py` unit test

### DIFF
--- a/CondCore/Utilities/test/BuildFile.xml
+++ b/CondCore/Utilities/test/BuildFile.xml
@@ -13,3 +13,7 @@
 </bin>
 
 <test name="testGetPayloadData" command="test_getPayloadData.sh"/>
+
+<test name="testUploadConditions" command="test_uploadConditions.sh">
+  <flags PRE_TEST="testBasicPayload"/>
+</test>

--- a/CondCore/Utilities/test/test_uploadConditions.sh
+++ b/CondCore/Utilities/test/test_uploadConditions.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+check_for_success() {
+    "${@}" && echo -e "\n ---> Passed test of '${@}'\n\n" || exit 1
+}
+
+check_for_failure() {
+    "${@}" && exit 1 || echo -e "\n ---> Passed test of '${@}'\n\n"
+}
+
+function die { echo $1: status $2; exit $2; }
+
+########################################
+# Test help function
+########################################
+check_for_success uploadConditions.py --help
+
+########################################
+# Test wizard
+########################################
+if test -f "BasicPayload_v0_ref.txt"; then
+    rm -f BasicPayload_v0_ref.txt
+fi
+cat <<EOF >> BasicPayload_v0_ref.txt
+{
+    "destinationDatabase": "oracle://cms_orcoff_prep/CMS_CONDITIONS", 
+    "destinationTags": {
+        "BasicPayload_v0": {}
+    }, 
+    "inputTag": "BasicPayload_v0", 
+    "since": 1, 
+    "userText": "uploadConditions unit test"
+}
+EOF
+
+echo "Content of the directory is:" `ls -lh . | grep db`
+echo -ne '\n\n'
+
+if test -f "BasicPayload_v0.txt"; then
+   rm -f BasicPayload_v0.txt
+fi
+
+# this is expected to fail given lack of credentials
+check_for_failure uploadConditions.py BasicPayload_v0.db <<EOF
+y
+0
+oracle://cms_orcoff_prep/CMS_CONDITIONS
+1
+uploadConditions unit test
+BasicPayload_v0
+`echo -ne '\n'`
+y
+test
+test
+EOF
+
+# test that the metadata created with the wizard corresponds to the reference one
+diff -w BasicPayload_v0.txt BasicPayload_v0_ref.txt || die 'failed comparing metadata with reference' $?


### PR DESCRIPTION
#### PR description:

As suggested in https://github.com/cms-sw/cmssw/issues/34349#issuecomment-874714003 provide unit test coverage for  `uploadConditions.py`. 
As the tool currently doesn't allow to upload to a local file, we check for failure when uploading to a fake service.

#### PR validation:

running the unit test with `scram b runtests_testUploadConditions`

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A
