### PR TITLE
Fix uppermost bin edge handling in non-linear lookup of JEC bins

### DIFF
--- a/CondFormats/JetMETObjects/src/JetCorrectorParametersHelper.cc
+++ b/CondFormats/JetMETObjects/src/JetCorrectorParametersHelper.cc
@@ -132,7 +132,7 @@ bool JetCorrectorParametersHelper::binBoundChecks(unsigned dim,
                                                   const float& value,
                                                   const float& min,
                                                   const float& max) const {
-  if (value < min || value > max)
+  if (value < min || value >= max)
     return false;
   else
     return true;


### PR DESCRIPTION
#### PR description:

Addresses the issue raised in 
https://github.com/cms-sw/cmssw/issues/34381

Expected change:
only affects the uppermost bin edge (e.g. often 5.191 in eta-binned JEC), now excluding it from the evaluation instead of including it. Should restore the previous behavior of the linear look-up and aligns with the correctionlib lookup used in 
https://github.com/cms-jet/JECDatabase/tree/master/scripts/JEC2JSON

#### PR validation:

Ran local tests on consistency between new "JSON corrections" and cmssw. Now get full consistency over a scan of input parameters including bin-boundaries, out-of-range, etc. cases.
