### PR TITLE
DQM Pixel Phase 1: Several new Efficiency trend plots

### DIFF
--- a/DQM/SiPixelPhase1Config/python/SiPixelPhase1OfflineDQM_harvesting_cff.py
+++ b/DQM/SiPixelPhase1Config/python/SiPixelPhase1OfflineDQM_harvesting_cff.py
@@ -16,10 +16,12 @@ siPixelPhase1OfflineDQM_harvesting = cms.Sequence(SiPixelPhase1RawDataHarvester
                                                 + SiPixelPhase1SummaryOffline
                                                 + SiPixelBarycenterOffline
                                                 + SiPixelPhase1ResidualsExtra
+                                                + SiPixelPhase1EfficiencyExtras
                                                   )
 
 siPixelPhase1OfflineDQM_harvesting_cosmics = siPixelPhase1OfflineDQM_harvesting.copyAndExclude([
-   SiPixelPhase1TrackEfficiencyHarvester,
+    SiPixelPhase1TrackEfficiencyHarvester,
+    SiPixelPhase1EfficiencyExtras,
 ])
 
 siPixelPhase1OfflineDQM_harvesting_cosmics.replace(RunQTests_offline, RunQTests_cosmics)

--- a/DQM/SiPixelPhase1Config/python/SiPixelPhase1OfflineDQM_source_cff.py
+++ b/DQM/SiPixelPhase1Config/python/SiPixelPhase1OfflineDQM_source_cff.py
@@ -27,6 +27,7 @@ from DQM.SiPixelPhase1Summary.SiPixelBarycenter_cfi import *
 
 from RecoPixelVertexing.PixelLowPtUtilities.ClusterShapeHitFilterESProducer_cfi import *
 from RecoLocalTracker.SiStripClusterizer.SiStripClusterChargeCut_cfi import *
+from DQM.SiPixelPhase1Track.SiPixelPhase1EfficiencyExtras_cfi import *
 
 PerModule.enabled = False
 IsOffline.enabled=True

--- a/DQM/SiPixelPhase1Track/plugins/SiPixelPhase1EfficiencyExtras.cc
+++ b/DQM/SiPixelPhase1Track/plugins/SiPixelPhase1EfficiencyExtras.cc
@@ -21,38 +21,16 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
-#include "FWCore/Framework/interface/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "DataFormats/Common/interface/Handle.h"
-#include "FWCore/Framework/interface/LuminosityBlock.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 // DQM Framework
-#include "DQM/SiPixelCommon/interface/SiPixelFolderOrganizer.h"
 #include "DQMServices/Core/interface/DQMStore.h"
 #include "DQMServices/Core/interface/DQMEDHarvester.h"
-// Geometry
-#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
-#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
-#include "Geometry/CommonDetUnit/interface/PixelGeomDetUnit.h"
-#include "Geometry/CommonTopologies/interface/PixelTopology.h"
-#include "Geometry/Records/interface/TrackerTopologyRcd.h"
-// DataFormats
-#include "DataFormats/DetId/interface/DetId.h"
-#include "DataFormats/SiPixelDetId/interface/PixelSubdetector.h"
-#include "DataFormats/SiPixelDetId/interface/PixelBarrelNameUpgrade.h"
-#include "DataFormats/SiPixelDetId/interface/PixelEndcapNameUpgrade.h"
-//
-#include <string>
-#include <cstdlib>
-#include <iostream>
-#include <fstream>
-#include <sstream>
 
 using namespace std;
 using namespace edm;

--- a/DQM/SiPixelPhase1Track/plugins/SiPixelPhase1EfficiencyExtras.cc
+++ b/DQM/SiPixelPhase1Track/plugins/SiPixelPhase1EfficiencyExtras.cc
@@ -1,0 +1,268 @@
+// -*- C++ -*-
+//
+// Package:    SiPixelPhase1EfficiencyExtras
+// Class:      SiPixelPhase1EfficiencyExtras
+//
+/**\class 
+
+ Description: Create the Phase 1 extra efficiency trend plots
+
+ Implementation:
+     <Notes on implementation>
+*/
+//
+// Original Author:  Jack Sisson, Julie Hogan
+//         Created:  7 July, 2021
+//
+//
+
+// Framework
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "DataFormats/Common/interface/Handle.h"
+#include "FWCore/Framework/interface/LuminosityBlock.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+// DQM Framework
+#include "DQM/SiPixelCommon/interface/SiPixelFolderOrganizer.h"
+#include "DQMServices/Core/interface/DQMStore.h"
+#include "DQMServices/Core/interface/DQMEDHarvester.h"
+// Geometry
+#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
+#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
+#include "Geometry/CommonDetUnit/interface/PixelGeomDetUnit.h"
+#include "Geometry/CommonTopologies/interface/PixelTopology.h"
+#include "Geometry/Records/interface/TrackerTopologyRcd.h"
+// DataFormats
+#include "DataFormats/DetId/interface/DetId.h"
+#include "DataFormats/SiPixelDetId/interface/PixelSubdetector.h"
+#include "DataFormats/SiPixelDetId/interface/PixelBarrelNameUpgrade.h"
+#include "DataFormats/SiPixelDetId/interface/PixelEndcapNameUpgrade.h"
+//
+#include <string>
+#include <cstdlib>
+#include <iostream>
+#include <fstream>
+#include <sstream>
+
+using namespace std;
+using namespace edm;
+
+class SiPixelPhase1EfficiencyExtras : public DQMEDHarvester {
+public:
+  explicit SiPixelPhase1EfficiencyExtras(const edm::ParameterSet& conf);
+  ~SiPixelPhase1EfficiencyExtras() override;
+
+protected:
+  void beginRun(edm::Run const& run, edm::EventSetup const& eSetup) override;
+
+  void dqmEndJob(DQMStore::IBooker& iBooker, DQMStore::IGetter& iGetter) override;
+
+  std::string effFolderName_;
+  std::string vtxFolderName_;
+  std::string instLumiFolderName_;
+
+private:
+  edm::ParameterSet conf_;
+};
+
+SiPixelPhase1EfficiencyExtras::SiPixelPhase1EfficiencyExtras(const edm::ParameterSet& iConfig) : conf_(iConfig) {
+  LogInfo("PixelDQM") << "SiPixelPhase1EfficiencyExtras::SiPixelPhase1EfficiencyExtras: Hello!" << endl;
+  effFolderName_ = conf_.getParameter<std::string>("EffFolderName");
+  vtxFolderName_ = conf_.getParameter<std::string>("VtxFolderName");
+  instLumiFolderName_ = conf_.getParameter<std::string>("InstLumiFolderName");
+}
+
+SiPixelPhase1EfficiencyExtras::~SiPixelPhase1EfficiencyExtras() {
+  // do anything here that needs to be done at desctruction time
+  // (e.g. close files, deallocate resources etc.)
+  LogInfo("PixelDQM") << "SiPixelPhase1EfficiencyExtras::~SiPixelPhase1EfficiencyExtras: Destructor" << endl;
+}
+
+void SiPixelPhase1EfficiencyExtras::beginRun(edm::Run const& run, edm::EventSetup const& eSetup) {}
+
+//------------------------------------------------------------------
+// Method called for every event
+//------------------------------------------------------------------
+void SiPixelPhase1EfficiencyExtras::dqmEndJob(DQMStore::IBooker& iBooker, DQMStore::IGetter& iGetter) {
+  iBooker.setCurrentFolder(effFolderName_);
+
+  //Get the existing histos
+  MonitorElement* vtx_v_lumi = iGetter.get(vtxFolderName_ + "/NumberOfGoodPVtxVsLS_GenTk");
+
+  MonitorElement* scalLumi_v_lumi = iGetter.get(instLumiFolderName_ + "/lumiVsLS");
+
+  MonitorElement* eff_v_lumi_forward =
+      iGetter.get(effFolderName_ + "/hitefficiency_per_Lumisection_per_PXDisk_PXForward");
+
+  MonitorElement* eff_v_lumi_barrel =
+      iGetter.get(effFolderName_ + "/hitefficiency_per_Lumisection_per_PXLayer_PXBarrel");
+
+  //set up some booleans that will tell us which graphs to create
+  bool createNvtx = true;
+  bool createInstLumi = true;
+
+  //check which of the MEs exist and respond appropriately
+  if (!eff_v_lumi_forward) {
+    edm::LogWarning("SiPixelPhase1EfficiencyExtras")
+        << "no hitefficiency_per_Lumisection_per_PXDisk_PXForward ME is available in " << effFolderName_ << std::endl;
+    return;
+  }
+  if (!eff_v_lumi_barrel) {
+    edm::LogWarning("SiPixelPhase1EfficiencyExtras")
+        << "no hitefficiency_per_Lumisection_per_PXLayer_PXBarrel ME is available in " << effFolderName_ << std::endl;
+    return;
+  }
+  if (!vtx_v_lumi) {
+    edm::LogWarning("SiPixelPhase1EfficiencyExtras")
+        << "no NumberOfGoodPVtxVsLS_GenTK ME is available in " << vtxFolderName_ << std::endl;
+    createNvtx = false;
+  }
+  if (!scalLumi_v_lumi) {
+    edm::LogWarning("SiPixelPhase1EfficiencyExtras")
+        << "no lumiVsLS ME is available in " << instLumiFolderName_ << std::endl;
+    createInstLumi = false;
+  }
+
+  //If the existing MEs are empty, set the boolean to skip booking
+  if (vtx_v_lumi && vtx_v_lumi->getEntries() == 0)
+    createNvtx = false;
+  if (scalLumi_v_lumi && scalLumi_v_lumi->getEntries() == 0)
+    createInstLumi = false;
+
+  double eff = 0.0;
+
+  //Will pass if nvtx ME exists and is not empty
+  if (createNvtx) {
+    //Book new histos
+    MonitorElement* eff_v_vtx_barrel =
+        iBooker.book2D("hitefficiency_per_meanNvtx_per_PXLayer_PXBarrel",
+                       "hitefficiency_per_meanNvtx_per_PXLayer_PXBarrel; meanNvtx; PXLayer",
+                       500,
+                       0,
+                       100,
+                       3,
+                       .5,
+                       3.5);
+
+    MonitorElement* eff_v_vtx_forward =
+        iBooker.book2D("hitefficiency_per_meanNvtx_per_PXDisk_PXForward",
+                       "hitefficiency_per_meanNvtx_per_PXDisk_PXForward; meanNvtx; PXDisk",
+                       500,
+                       0,
+                       100,
+                       7,
+                       -3.5,
+                       3.5);
+
+    //initialize variables
+    int numLumiNvtx = int(vtx_v_lumi->getNbinsX());
+    double nvtx = 0.0;
+    int binNumVtx = 0;
+
+    //For loop to loop through lumisections
+    for (int iLumi = 1; iLumi < numLumiNvtx - 1; iLumi++) {
+      //get the meanNvtx for each lumi
+      nvtx = vtx_v_lumi->getBinContent(iLumi);
+
+      //Filter out useless iterations
+      if (nvtx != 0) {
+        //Grab the bin number for the nvtx
+        binNumVtx = eff_v_vtx_barrel->getTH2F()->FindBin(nvtx);
+
+        //loop through the layers
+        for (int iLayer = 1; iLayer < 8; iLayer++) {
+          //get the eff at the lumisection and layer
+          eff = eff_v_lumi_forward->getBinContent(iLumi - 1, iLayer);
+
+          //set the efficiency in the new histo
+          eff_v_vtx_forward->setBinContent(binNumVtx, iLayer, eff);
+        }
+
+        //loop through the layers
+        for (int iLayer = 1; iLayer < 5; iLayer++) {
+          //get the efficiency for each lumi at each layer
+          eff = eff_v_lumi_barrel->getBinContent(iLumi - 1, iLayer);
+
+          //set the efficiency
+          eff_v_vtx_barrel->setBinContent(binNumVtx, iLayer, eff);
+        }
+      }
+    }
+  }
+  // Will pass if InstLumi ME exists and is not empty
+  if (createInstLumi) {
+    //Get the max value of inst lumi for plot
+    int yMax2 = scalLumi_v_lumi->getTProfile()->GetMaximum();
+    yMax2 = yMax2 + yMax2 * .1;
+
+    //Book new histos
+    MonitorElement* eff_v_scalLumi_barrel =
+        iBooker.book2D("hitefficiency_per_scalLumi_per_PXLayer_PXBarrel",
+                       "hitefficiency_per_scalLumi_per_PXLayer_PXBarrel; scal inst lumi E30; PXLayer",
+                       500,
+                       0,
+                       yMax2,
+                       3,
+                       .5,
+                       3.5);
+
+    MonitorElement* eff_v_scalLumi_forward =
+        iBooker.book2D("hitefficiency_per_scalLumi_per_PXDisk_PXForward",
+                       "hitefficiency_per_scalLumi_per_PXDisk_PXForward; scal inst lumi E30; PXDisk",
+                       500,
+                       0,
+                       yMax2,
+                       7,
+                       -3.5,
+                       3.5);
+
+    //initialize variables
+    int numLumiScal = int(scalLumi_v_lumi->getNbinsX());
+    double scalLumi = 0.0;
+    int binNumScal = 0;
+
+    //For loop to loop through lumisections
+    for (int iLumi = 1; iLumi < numLumiScal - 1; iLumi++) {
+      //get the inst lumi for each lumi
+      scalLumi = scalLumi_v_lumi->getBinContent(iLumi);
+
+      //Filter out useless iterations
+      if (scalLumi != 0) {
+        //Grab the bin number for the inst lumi
+        binNumScal = eff_v_scalLumi_barrel->getTH2F()->FindBin(scalLumi);
+
+        //loop through the layers
+        for (int iLayer = 1; iLayer < 8; iLayer++) {
+          //get the eff at the lumisection and layer
+          eff = eff_v_lumi_forward->getBinContent(iLumi - 1, iLayer);
+
+          //set the efficiency in the new histo
+          eff_v_scalLumi_forward->setBinContent(binNumScal, iLayer, eff);
+        }
+
+        //loop through the layers
+        for (int iLayer = 1; iLayer < 5; iLayer++) {
+          //get the eff at the lumisection and layer
+          eff = eff_v_lumi_barrel->getBinContent(iLumi - 1, iLayer);
+
+          //set the efficiency in the new histo
+          eff_v_scalLumi_barrel->setBinContent(binNumScal, iLayer, eff);
+        }
+      }
+    }
+  } else
+    return;
+}
+
+//define this as a plug-in
+DEFINE_FWK_MODULE(SiPixelPhase1EfficiencyExtras);

--- a/DQM/SiPixelPhase1Track/python/SiPixelPhase1EfficiencyExtras_cfi.py
+++ b/DQM/SiPixelPhase1Track/python/SiPixelPhase1EfficiencyExtras_cfi.py
@@ -1,0 +1,9 @@
+import FWCore.ParameterSet.Config as cms
+from DQMServices.Core.DQMEDHarvester import DQMEDHarvester
+
+
+SiPixelPhase1EfficiencyExtras = DQMEDHarvester("SiPixelPhase1EfficiencyExtras",
+                                     EffFolderName = cms.string('PixelPhase1/Tracks/'),
+                                     VtxFolderName = cms.string('Tracking/TrackParameters/generalTracks/GeneralProperties/'),
+				     InstLumiFolderName = cms.string('HLT/LumiMonitoring/')
+)

--- a/DQM/SiPixelPhase1Track/python/SiPixelPhase1TrackEfficiency_cfi.py
+++ b/DQM/SiPixelPhase1Track/python/SiPixelPhase1TrackEfficiency_cfi.py
@@ -74,9 +74,8 @@ SiPixelPhase1TrackEfficiencyEfficiency = SiPixelPhase1TrackEfficiencyValid.clone
   xlabel = "#valid/(#valid+#missing)",
   dimensions = 1,
   specs = VPSet(
-    #2D profile maps per layer
     StandardSpecification2DProfile,
-
+    
     #profiles per layer and shell
     Specification(PerLadder).groupBy("PXBarrel/Shell/PXLayer/SignedLadder")
                             .reduce("MEAN")
@@ -94,9 +93,20 @@ SiPixelPhase1TrackEfficiencyEfficiency = SiPixelPhase1TrackEfficiencyValid.clone
     Specification().groupBy("PXForward/PXDisk")
                    .reduce("MEAN")
                    .groupBy("PXForward", "EXTEND_X")
-                   .save()
+                   .save(),
 
-    #StandardSpecificationPixelmapProfile    
+    Specification(PerLayer2D)
+			.groupBy("PXBarrel/PXLayer/Lumisection")
+			.groupBy("PXBarrel/PXLayer", "EXTEND_X")
+                        .groupBy("PXBarrel", "EXTEND_Y")
+                        .reduce("MEAN")
+                        .save(),
+    Specification(PerLayer2D)
+			.groupBy("PXForward/PXDisk/Lumisection")
+                        .groupBy("PXForward/PXDisk", "EXTEND_X")
+                        .groupBy("PXForward", "EXTEND_Y")
+                        .reduce("MEAN")
+                        .save(),
   )
 )
 


### PR DESCRIPTION

Additions to DQM/SiPixelPhase1
Added new trend plots:
 * Efficiency vs LS: Barrel & Endcap -- new specification in SiPixelPhase1Track
 * Efficiency vs Mean number of vertices: Barrel & Endcap -- new DQMEDHarvester in SiPixelPhase1Track
 * Efficiency vs Instantaneous Luminosity: Barrel & Endcap -- new DQMEDHarvester in SiPixelPhase1Track

Related talks:
https://indico.cern.ch/event/1000808/contributions/4355849/attachments/2241277/3800219/TrackerDQM5_7_21.pdf
https://indico.cern.ch/event/934813/contributions/4103234/attachments/2142978/3611403/PixelEfficiencyTrendPlots_111320.pdf

Tested with runTheMatrix.py -l 136.892
Tested missing lumiVsLS protection with fake HLT runTheMatrix