### PR TITLE
Edit PFMultiLinksTC to store refs

### DIFF
--- a/DataFormats/ParticleFlowReco/interface/PFBlockElement.h
+++ b/DataFormats/ParticleFlowReco/interface/PFBlockElement.h
@@ -121,7 +121,7 @@ namespace reco {
       else
         return false;  // no multilinks_ for the specified type
     }
-    const PFMultilinksType& getMultilinks(Type type) const { return multilinks_.at(type).linkedClusters; }
+    const PFMultilinksType& getMultilinks(Type type) const { return multilinks_.at(type).linkedPFObjects; }
     // ! Glowinski & Gouzevitch
 
     /// do we have a valid time information

--- a/DataFormats/ParticleFlowReco/interface/PFMultilinksTC.h
+++ b/DataFormats/ParticleFlowReco/interface/PFMultilinksTC.h
@@ -4,6 +4,8 @@
 // Done by Glowinski & Gouzevitch
 
 #include <vector>
+#include "DataFormats/ParticleFlowReco/interface/PFRecTrackFwd.h"
+#include "DataFormats/ParticleFlowReco/interface/PFClusterFwd.h"
 
 namespace reco {
 

--- a/DataFormats/ParticleFlowReco/interface/PFMultilinksTC.h
+++ b/DataFormats/ParticleFlowReco/interface/PFMultilinksTC.h
@@ -10,7 +10,16 @@ namespace reco {
   /// \brief Abstract This class is used by the KDTree Track / Ecal Cluster
   /// linker to store all found links.
   ///
-  typedef std::vector<std::pair<double, double> > PFMultilinksType;
+  struct PFMultilink {
+    PFMultilink ( const reco::PFClusterRef & clusterref ) : 
+    trackRef(), clusterRef(clusterref) {}
+    PFMultilink ( const reco::PFRecTrackRef & trackref ) :
+    trackRef(trackref), clusterRef() {}
+    reco::PFRecTrackRef trackRef;
+    reco::PFClusterRef clusterRef;
+  };
+  /// collection of PFSuperCluster objects
+  typedef std::vector<PFMultilink> PFMultilinksType;
   class PFMultiLinksTC {
   public:
     bool isValid;

--- a/DataFormats/ParticleFlowReco/interface/PFMultilinksTC.h
+++ b/DataFormats/ParticleFlowReco/interface/PFMultilinksTC.h
@@ -11,10 +11,8 @@ namespace reco {
   /// linker to store all found links.
   ///
   struct PFMultilink {
-    PFMultilink ( const reco::PFClusterRef & clusterref ) : 
-    trackRef(), clusterRef(clusterref) {}
-    PFMultilink ( const reco::PFRecTrackRef & trackref ) :
-    trackRef(trackref), clusterRef() {}
+    PFMultilink(const reco::PFClusterRef& clusterref) : trackRef(), clusterRef(clusterref) {}
+    PFMultilink(const reco::PFRecTrackRef& trackref) : trackRef(trackref), clusterRef() {}
     reco::PFRecTrackRef trackRef;
     reco::PFClusterRef clusterRef;
   };
@@ -23,7 +21,7 @@ namespace reco {
   class PFMultiLinksTC {
   public:
     bool isValid;
-    PFMultilinksType linkedClusters;
+    PFMultilinksType linkedPFObjects;
 
   public:
     PFMultiLinksTC(bool isvalid = false) : isValid(isvalid) {}

--- a/DataFormats/ParticleFlowReco/src/classes_def_2.xml
+++ b/DataFormats/ParticleFlowReco/src/classes_def_2.xml
@@ -287,7 +287,7 @@
   <!-- // Glowinski & Gouzevitch -->
   <class name="reco::PFMultiLinksTC"> 
     <field name="isValid" transient="true"/>
-    <field name="linkedClusters" transient="true"/>
+    <field name="linkedPFObjects" transient="true"/>
   </class>
 
   <class name="std::vector<reco::RecoPFClusterRefCandidate>"/>

--- a/RecoParticleFlow/PFProducer/plugins/kdtrees/KDTreeLinkerPSEcal.cc
+++ b/RecoParticleFlow/PFProducer/plugins/kdtrees/KDTreeLinkerPSEcal.cc
@@ -238,11 +238,10 @@ void KDTreeLinkerPSEcal::updatePFBlockEltWithLinks() {
     reco::PFMultiLinksTC multitracks(true);
 
     for (const auto &ecalElt : ecalEltSet) {
-      double clusterphi = ecalElt->clusterRef()->positionREP().phi();
-      double clustereta = ecalElt->clusterRef()->positionREP().eta();
 
-      multitracks.linkedClusters.push_back(std::make_pair(clusterphi, clustereta));
-
+      reco::PFMultilink multiLink( ecalElt->clusterRef() );
+      multitracks.linkedClusters.push_back(multiLink);
+      
       // We set the multilinks flag of the ECAL element (for links to PS) to true. It will allow us to
       // use it in an optimized way in prefilter
       ecalElt->setIsValidMultilinks(true, _targetType);

--- a/RecoParticleFlow/PFProducer/plugins/kdtrees/KDTreeLinkerPSEcal.cc
+++ b/RecoParticleFlow/PFProducer/plugins/kdtrees/KDTreeLinkerPSEcal.cc
@@ -238,10 +238,9 @@ void KDTreeLinkerPSEcal::updatePFBlockEltWithLinks() {
     reco::PFMultiLinksTC multitracks(true);
 
     for (const auto &ecalElt : ecalEltSet) {
+      reco::PFMultilink multiLink(ecalElt->clusterRef());
+      multitracks.linkedPFObjects.push_back(multiLink);
 
-      reco::PFMultilink multiLink( ecalElt->clusterRef() );
-      multitracks.linkedClusters.push_back(multiLink);
-      
       // We set the multilinks flag of the ECAL element (for links to PS) to true. It will allow us to
       // use it in an optimized way in prefilter
       ecalElt->setIsValidMultilinks(true, _targetType);

--- a/RecoParticleFlow/PFProducer/plugins/kdtrees/KDTreeLinkerTrackEcal.cc
+++ b/RecoParticleFlow/PFProducer/plugins/kdtrees/KDTreeLinkerTrackEcal.cc
@@ -246,11 +246,9 @@ void KDTreeLinkerTrackEcal::updatePFBlockEltWithLinks() {
 
     for (const auto &trackElt : trackEltSet) {
       const reco::PFRecTrackRef &trackref = trackElt->trackRefPF();
-      const reco::PFTrajectoryPoint &atECAL = trackref->extrapolatedPoint(reco::PFTrajectoryPoint::ECALShowerMax);
-      double tracketa = atECAL.positionREP().eta();
-      double trackphi = atECAL.positionREP().phi();
 
-      multitracks.linkedClusters.push_back(std::make_pair(trackphi, tracketa));
+      reco::PFMultilink multiLink( trackref );
+      multitracks.linkedClusters.push_back(multiLink);
 
       // We set the multilinks flag of the track (for links to ECAL) to true. It will allow us to
       // use it in an optimized way in prefilter

--- a/RecoParticleFlow/PFProducer/plugins/kdtrees/KDTreeLinkerTrackEcal.cc
+++ b/RecoParticleFlow/PFProducer/plugins/kdtrees/KDTreeLinkerTrackEcal.cc
@@ -247,8 +247,8 @@ void KDTreeLinkerTrackEcal::updatePFBlockEltWithLinks() {
     for (const auto &trackElt : trackEltSet) {
       const reco::PFRecTrackRef &trackref = trackElt->trackRefPF();
 
-      reco::PFMultilink multiLink( trackref );
-      multitracks.linkedClusters.push_back(multiLink);
+      reco::PFMultilink multiLink(trackref);
+      multitracks.linkedPFObjects.push_back(multiLink);
 
       // We set the multilinks flag of the track (for links to ECAL) to true. It will allow us to
       // use it in an optimized way in prefilter

--- a/RecoParticleFlow/PFProducer/plugins/kdtrees/KDTreeLinkerTrackHcal.cc
+++ b/RecoParticleFlow/PFProducer/plugins/kdtrees/KDTreeLinkerTrackHcal.cc
@@ -256,9 +256,8 @@ void KDTreeLinkerTrackHcal::updatePFBlockEltWithLinks() {
     // No restriction on the number of HCAL links per track or isLinkedToDisplacedVertex
     if (nMaxHcalLinksPerTrack_ < 0. || trackElt->isLinkedToDisplacedVertex()) {
       for (const auto& hcalElt : hcalEltSet) {
-        double clusterphi = hcalElt->clusterRef()->positionREP().phi();
-        double clustereta = hcalElt->clusterRef()->positionREP().eta();
-        multitracks.linkedClusters.push_back(std::make_pair(clusterphi, clustereta));
+	reco::PFMultilink multiLink( hcalElt->clusterRef() );
+	multitracks.linkedClusters.push_back(multiLink);
 
         // We set the multilinks flag of the track (for links to ECAL) to true. It will allow us to
         // use it in an optimized way in prefilter
@@ -316,10 +315,8 @@ void KDTreeLinkerTrackHcal::updatePFBlockEltWithLinks() {
       // Fill multitracks
       for (auto i : sort_indexes(vDist)) {
         const BlockEltSet::iterator hcalEltIt = std::next(hcalEltSet.begin(), i);
-        double clusterphi = (*hcalEltIt)->clusterRef()->positionREP().phi();
-        double clustereta = (*hcalEltIt)->clusterRef()->positionREP().eta();
-        multitracks.linkedClusters.push_back(std::make_pair(clusterphi, clustereta));
-
+	reco::PFMultilink multiLink( (*hcalEltIt)->clusterRef() );
+	multitracks.linkedClusters.push_back(multiLink);
         // We set the multilinks flag of the track (for links to ECAL) to true. It will allow us to
         // use it in an optimized way in prefilter
         (*hcalEltIt)->setIsValidMultilinks(true, _targetType);

--- a/RecoParticleFlow/PFProducer/plugins/kdtrees/KDTreeLinkerTrackHcal.cc
+++ b/RecoParticleFlow/PFProducer/plugins/kdtrees/KDTreeLinkerTrackHcal.cc
@@ -256,8 +256,8 @@ void KDTreeLinkerTrackHcal::updatePFBlockEltWithLinks() {
     // No restriction on the number of HCAL links per track or isLinkedToDisplacedVertex
     if (nMaxHcalLinksPerTrack_ < 0. || trackElt->isLinkedToDisplacedVertex()) {
       for (const auto& hcalElt : hcalEltSet) {
-	reco::PFMultilink multiLink( hcalElt->clusterRef() );
-	multitracks.linkedClusters.push_back(multiLink);
+        reco::PFMultilink multiLink(hcalElt->clusterRef());
+        multitracks.linkedPFObjects.push_back(multiLink);
 
         // We set the multilinks flag of the track (for links to ECAL) to true. It will allow us to
         // use it in an optimized way in prefilter
@@ -315,13 +315,13 @@ void KDTreeLinkerTrackHcal::updatePFBlockEltWithLinks() {
       // Fill multitracks
       for (auto i : sort_indexes(vDist)) {
         const BlockEltSet::iterator hcalEltIt = std::next(hcalEltSet.begin(), i);
-	reco::PFMultilink multiLink( (*hcalEltIt)->clusterRef() );
-	multitracks.linkedClusters.push_back(multiLink);
+        reco::PFMultilink multiLink((*hcalEltIt)->clusterRef());
+        multitracks.linkedPFObjects.push_back(multiLink);
         // We set the multilinks flag of the track (for links to ECAL) to true. It will allow us to
         // use it in an optimized way in prefilter
         (*hcalEltIt)->setIsValidMultilinks(true, _targetType);
 
-        if (multitracks.linkedClusters.size() >= (unsigned)nMaxHcalLinksPerTrack_)
+        if (multitracks.linkedPFObjects.size() >= (unsigned)nMaxHcalLinksPerTrack_)
           break;
       }
     }

--- a/RecoParticleFlow/PFProducer/plugins/linkers/PreshowerAndECALLinker.cc
+++ b/RecoParticleFlow/PFProducer/plugins/linkers/PreshowerAndECALLinker.cc
@@ -58,16 +58,13 @@ double PreshowerAndECALLinker::testLink(const reco::PFBlockElement* elem1, const
   // Glowinski & Gouzevitch
   if (useKDTree_ && pselem->isMultilinksValide(ecalelem->type())) {  // KDTree algo
     const reco::PFMultilinksType& multilinks = pselem->getMultilinks(ecalelem->type());
-    const reco::PFCluster::REPPoint& ecalreppos = ecalref->positionREP();
     const math::XYZPoint& ecalxyzpos = ecalref->position();
     const math::XYZPoint& psxyzpos = psref->position();
-    const double ecalPhi = ecalreppos.Phi();
-    const double ecalEta = ecalreppos.Eta();
 
     // Check if the link PS/Ecal exist
     reco::PFMultilinksType::const_iterator mlit = multilinks.begin();
     for (; mlit != multilinks.end(); ++mlit)
-      if ((mlit->first == ecalPhi) && (mlit->second == ecalEta))
+      if (mlit->clusterRef == ecalref )
         break;
 
     // If the link exist, we fill dist and linktest.

--- a/RecoParticleFlow/PFProducer/plugins/linkers/PreshowerAndECALLinker.cc
+++ b/RecoParticleFlow/PFProducer/plugins/linkers/PreshowerAndECALLinker.cc
@@ -64,7 +64,7 @@ double PreshowerAndECALLinker::testLink(const reco::PFBlockElement* elem1, const
     // Check if the link PS/Ecal exist
     reco::PFMultilinksType::const_iterator mlit = multilinks.begin();
     for (; mlit != multilinks.end(); ++mlit)
-      if (mlit->clusterRef == ecalref )
+      if (mlit->clusterRef == ecalref)
         break;
 
     // If the link exist, we fill dist and linktest.

--- a/RecoParticleFlow/PFProducer/plugins/linkers/TrackAndECALLinker.cc
+++ b/RecoParticleFlow/PFProducer/plugins/linkers/TrackAndECALLinker.cc
@@ -61,11 +61,10 @@ double TrackAndECALLinker::testLink(const reco::PFBlockElement* elem1, const rec
     const reco::PFMultilinksType& multilinks = ecalelem->getMultilinks(tkelem->type());
     const double tracketa = tkAtECAL.positionREP().Eta();
     const double trackphi = tkAtECAL.positionREP().Phi();
-
     // Check if the link Track/Ecal exist
     reco::PFMultilinksType::const_iterator mlit = multilinks.begin();
     for (; mlit != multilinks.end(); ++mlit)
-      if ((mlit->first == trackphi) && (mlit->second == tracketa))
+      if (mlit->trackRef == trackref)
         break;
 
     // If the link exist, we fill dist and linktest.

--- a/RecoParticleFlow/PFProducer/plugins/linkers/TrackAndHCALLinker.cc
+++ b/RecoParticleFlow/PFProducer/plugins/linkers/TrackAndHCALLinker.cc
@@ -117,8 +117,8 @@ double TrackAndHCALLinker::testLink(const reco::PFBlockElement* elem1, const rec
           edm::LogWarning("TrackHCALLinker ")
               << "Special case of linking with track hitting HCAL and looping back in the tracker ";
         } else {
-          dist =
-	    LinkByRecHit::computeDist(hcalreppos.Eta(), hcalreppos.Phi(), tkreppos.Eta() + 0.1 * dHEta, tkreppos.Phi() + 0.1 * dHPhi);
+          dist = LinkByRecHit::computeDist(
+              hcalreppos.Eta(), hcalreppos.Phi(), tkreppos.Eta() + 0.1 * dHEta, tkreppos.Phi() + 0.1 * dHPhi);
         }
       }  // checkExit_
     }    // multilinks

--- a/RecoParticleFlow/PFProducer/plugins/linkers/TrackAndHCALLinker.cc
+++ b/RecoParticleFlow/PFProducer/plugins/linkers/TrackAndHCALLinker.cc
@@ -93,13 +93,11 @@ double TrackAndHCALLinker::testLink(const reco::PFBlockElement* elem1, const rec
   // Glowinski & Gouzevitch
   if (useKDTree_ && tkelem->isMultilinksValide(hcalelem->type())) {  //KDTree Algo
     const reco::PFMultilinksType& multilinks = tkelem->getMultilinks(hcalelem->type());
-    const double hcalphi = hcalreppos.Phi();
-    const double hcaleta = hcalreppos.Eta();
 
     // Check if the link Track/Hcal exist
     reco::PFMultilinksType::const_iterator mlit = multilinks.begin();
     for (; mlit != multilinks.end(); ++mlit)
-      if ((mlit->first == hcalphi) && (mlit->second == hcaleta))
+      if (mlit->clusterRef == clusterref)
         break;
 
     // If the link exist, we fill dist and linktest.
@@ -107,7 +105,7 @@ double TrackAndHCALLinker::testLink(const reco::PFBlockElement* elem1, const rec
     if (mlit != multilinks.end()) {
       // when checkExit_ is false
       if (!checkExit_) {
-        dist = LinkByRecHit::computeDist(hcaleta, hcalphi, tkreppos.Eta(), tkreppos.Phi());
+        dist = LinkByRecHit::computeDist(hcalreppos.Eta(), hcalreppos.Phi(), tkreppos.Eta(), tkreppos.Phi());
       }
       // when checkExit_ is true
       else {
@@ -115,12 +113,12 @@ double TrackAndHCALLinker::testLink(const reco::PFBlockElement* elem1, const rec
         //In this case calculate the distance based on the first crossing since
         //the looper will probably never make it to the endcap
         if (dRHCALEx < tkAtHCALEnt.position().R()) {
-          dist = LinkByRecHit::computeDist(hcaleta, hcalphi, tkreppos.Eta(), tkreppos.Phi());
+          dist = LinkByRecHit::computeDist(hcalreppos.Eta(), hcalreppos.Phi(), tkreppos.Eta(), tkreppos.Phi());
           edm::LogWarning("TrackHCALLinker ")
               << "Special case of linking with track hitting HCAL and looping back in the tracker ";
         } else {
           dist =
-              LinkByRecHit::computeDist(hcaleta, hcalphi, tkreppos.Eta() + 0.1 * dHEta, tkreppos.Phi() + 0.1 * dHPhi);
+	    LinkByRecHit::computeDist(hcalreppos.Eta(), hcalreppos.Phi(), tkreppos.Eta() + 0.1 * dHEta, tkreppos.Phi() + 0.1 * dHPhi);
         }
       }  // checkExit_
     }    // multilinks


### PR DESCRIPTION
#### PR description:

As mentioned in issue #31280, we switch PFMultiLinksTC to store a ref instead of the ref's eta and phi values to make the linking safer.
No changes are expected in the output.

#### PR validation:

Checked that the packedPFCandidates four vector values matched exactly in step4_inMINIAODSIM.py produced by the 250202.181_TTbar_13UP18+TTbar_13UP18INPUT+PREMIXUP18_PU25+DIGIPRMXLOCALUP18_PU25+RECOPRMXUP18_PU25+HARVESTUP18_PU25/ workflow.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:
NA

@rappoccio @hatakeyamak @marksan87 @bendavid 