### PR TITLE
enforce memory order to avoid crash on Ampere

### DIFF
--- a/RecoPixelVertexing/PixelTriplets/plugins/GPUCACell.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/GPUCACell.h
@@ -69,6 +69,7 @@ public:
       auto i = cellNeighbors.extend();  // maybe wasted....
       if (i > 0) {
         cellNeighbors[i].reset();
+        __threadfence();
 #ifdef __CUDACC__
         auto zero = (PtrAsInt)(&cellNeighbors[0]);
         atomicCAS((PtrAsInt*)(&theOuterNeighbors),
@@ -89,6 +90,7 @@ public:
       auto i = cellTracks.extend();  // maybe wasted....
       if (i > 0) {
         cellTracks[i].reset();
+        __threadfence();
 #ifdef __CUDACC__
         auto zero = (PtrAsInt)(&cellTracks[0]);
         atomicCAS((PtrAsInt*)(&theTracks), zero, (PtrAsInt)(&cellTracks[i]));  // if fails we cannot give "i" back...


### PR DESCRIPTION
title says all.
very technical.
no regression expected (but no crash on A100)

```
[innocent@workergpu53 patatrack-scripts]$ ./benchmark ../pixelraw/gpuBench.py
2 CPUs:
  0: Intel(R) Xeon(R) Platinum 8268 CPU @ 2.90GHz (24 cores, 24 threads)
  1: Intel(R) Xeon(R) Platinum 8268 CPU @ 2.90GHz (24 cores, 24 threads)

1 visible NVIDIA GPUs:
  0: A100-PCIE-40GB (UUID: GPU-c60c7fb1-8112-8f34-7cbf-e3cef8cd2c12)

Warming up

Running 4 times over 4600 events with 4 jobs, each with 8 threads, 8 streams and 1 GPUs
  1303.3 ±   0.5 ev/s (4400 events, 97.6% overlap)
  1308.7 ±   0.8 ev/s (4400 events, 97.8% overlap)
  1288.4 ±   1.0 ev/s (4400 events, 98.0% overlap)
  1304.9 ±   1.0 ev/s (4400 events, 99.2% overlap)
 --------------------
  1301.3 ±   8.9 ev/s

[innocent@workergpu53 patatrack-scripts]$ ./benchmark ../pixelraw/quadBench.py
2 CPUs:
  0: Intel(R) Xeon(R) Platinum 8268 CPU @ 2.90GHz (24 cores, 24 threads)
  1: Intel(R) Xeon(R) Platinum 8268 CPU @ 2.90GHz (24 cores, 24 threads)

1 visible NVIDIA GPUs:
  0: A100-PCIE-40GB (UUID: GPU-c60c7fb1-8112-8f34-7cbf-e3cef8cd2c12)

Warming up

Running 4 times over 4600 events with 4 jobs, each with 8 threads, 8 streams and 1 GPUs
  2424.2 ±   2.8 ev/s (4400 events, 98.2% overlap)
  2428.2 ±   3.2 ev/s (4400 events, 98.4% overlap)
  2403.7 ±   2.5 ev/s (4400 events, 95.3% overlap)
  2422.7 ±   4.6 ev/s (4400 events, 96.8% overlap)
 --------------------
  2419.7 ±  10.9 ev/s
```