### PR TITLE
Remove 2D pixel template B field warning for 0T

### DIFF
--- a/CalibTracker/SiPixelESProducers/plugins/SiPixel2DTemplateDBObjectESProducer.cc
+++ b/CalibTracker/SiPixelESProducers/plugins/SiPixel2DTemplateDBObjectESProducer.cc
@@ -59,7 +59,8 @@ std::shared_ptr<const SiPixel2DTemplateDBObject> SiPixel2DTemplateDBObjectESProd
 
   const auto& dbobject = iRecord.get(dbToken_);
 
-  if (std::fabs(theMagField - dbobject.sVector()[22]) > 0.1)
+  if ( (theMagField > 0.1) && (std::fabs(theMagField - dbobject.sVector()[22]) > 0.1))
+      //2D templates not actually used at 0T, so don't print warning
     edm::LogWarning("UnexpectedMagneticFieldUsingNonIdealPixel2DTemplate")
         << "Magnetic field is " << theMagField << " Template Magnetic field is " << dbobject.sVector()[22];
 

--- a/CalibTracker/SiPixelESProducers/plugins/SiPixel2DTemplateDBObjectESProducer.cc
+++ b/CalibTracker/SiPixelESProducers/plugins/SiPixel2DTemplateDBObjectESProducer.cc
@@ -59,8 +59,8 @@ std::shared_ptr<const SiPixel2DTemplateDBObject> SiPixel2DTemplateDBObjectESProd
 
   const auto& dbobject = iRecord.get(dbToken_);
 
-  if ( (theMagField > 0.1) && (std::fabs(theMagField - dbobject.sVector()[22]) > 0.1))
-      //2D templates not actually used at 0T, so don't print warning
+  if ((theMagField > 0.1) && (std::fabs(theMagField - dbobject.sVector()[22]) > 0.1))
+    //2D templates not actually used at 0T, so don't print warning
     edm::LogWarning("UnexpectedMagneticFieldUsingNonIdealPixel2DTemplate")
         << "Magnetic field is " << theMagField << " Template Magnetic field is " << dbobject.sVector()[22];
 


### PR DESCRIPTION
This is a small PR to remove the UnexpectedMagneticField warning for the 2D pixel templates on 0T. The 2D templates are never used for 0T (see [here](https://github.com/cms-sw/cmssw/blob/master/RecoLocalTracker/SiPixelRecHits/src/PixelCPEClusterRepair.cc#L109-L112) ) so there is no need to print the warning. 

This addresses issue #31956. 

@mmusich @tvami @ferencek @tsusa 
