### PR TITLE
Added scintillator information to RecHitTools

### DIFF
--- a/RecoLocalCalo/HGCalRecAlgos/interface/RecHitTools.h
+++ b/RecoLocalCalo/HGCalRecAlgos/interface/RecHitTools.h
@@ -37,7 +37,7 @@ namespace hgcal {
     std::float_t getRadiusToSide(const DetId&) const;
     int getSiThickIndex(const DetId&) const;
 
-    void getScintDEtaDPhi(const DetId&, std::float_t& deta, std::float_t& dphi) const;
+    std::pair<float, float> getScintDEtaDPhi(const DetId&) const;
 
     unsigned int getLayer(DetId::Detector type, bool nose = false) const;
     unsigned int getLayer(ForwardSubdetector type) const;

--- a/RecoLocalCalo/HGCalRecAlgos/interface/RecHitTools.h
+++ b/RecoLocalCalo/HGCalRecAlgos/interface/RecHitTools.h
@@ -37,6 +37,8 @@ namespace hgcal {
     std::float_t getRadiusToSide(const DetId&) const;
     int getSiThickIndex(const DetId&) const;
 
+    void getScintDEtaDPhi(const DetId&, std::float_t& deta, std::float_t& dphi) const;
+
     unsigned int getLayer(DetId::Detector type, bool nose = false) const;
     unsigned int getLayer(ForwardSubdetector type) const;
     unsigned int getLayer(const DetId&) const;
@@ -47,6 +49,7 @@ namespace hgcal {
     bool isHalfCell(const DetId&) const;
 
     bool isSilicon(const DetId&) const;
+    bool isScintillator(const DetId&) const;
 
     bool isOnlySilicon(const unsigned int layer) const;
 

--- a/RecoLocalCalo/HGCalRecAlgos/src/RecHitTools.cc
+++ b/RecoLocalCalo/HGCalRecAlgos/src/RecHitTools.cc
@@ -219,23 +219,14 @@ int RecHitTools::getSiThickIndex(const DetId& id) const {
   return thickIndex;
 }
 
-
-
-void RecHitTools::getScintDEtaDPhi(const DetId &id, std::float_t &deta,
-        std::float_t &dphi) const {
-    if (!isScintillator(id)) {
-        LogDebug("getScintDEtaDPhi::InvalidSintDetid") << "det id: " << std::hex
-                                                              << id.rawId()
-                                                              << std::dec << ":"
-                                                              << id.det()
-                                                              << " is not HGCal scintillator!";
-        deta = 0;
-        dphi = 0;
-        return;
-    }
-    auto geom = static_cast<const HGCalGeometry*>(getSubdetectorGeometry(id));
-    dphi = geom->getGeometry(id)->phiSpan();
-    deta = geom->getGeometry(id)->etaSpan();
+std::pair<float, float> RecHitTools::getScintDEtaDPhi(const DetId& id) const {
+  if (!isScintillator(id)) {
+    LogDebug("getScintDEtaDPhi::InvalidSintDetid")
+        << "det id: " << std::hex << id.rawId() << std::dec << ":" << id.det() << " is not HGCal scintillator!";
+    return std::pair<float, float>(0., 0.);
+  }
+  auto geom = static_cast<const HGCalGeometry*>(getSubdetectorGeometry(id));
+  return std::pair<float, float>(geom->getGeometry(id)->etaSpan(), geom->getGeometry(id)->phiSpan());
 }
 
 std::float_t RecHitTools::getRadiusToSide(const DetId& id) const {

--- a/RecoLocalCalo/HGCalRecAlgos/src/RecHitTools.cc
+++ b/RecoLocalCalo/HGCalRecAlgos/src/RecHitTools.cc
@@ -427,9 +427,7 @@ bool RecHitTools::isSilicon(const DetId& id) const {
           (id.det() == DetId::Forward && id.subdetId() == static_cast<int>(HFNose)));
 }
 
-bool RecHitTools::isScintillator(const DetId& id) const{
-    return id.det() == DetId::HGCalHSc;
-}
+bool RecHitTools::isScintillator(const DetId& id) const { return id.det() == DetId::HGCalHSc; }
 
 bool RecHitTools::isOnlySilicon(const unsigned int layer) const {
   // HFnose TODO

--- a/RecoLocalCalo/HGCalRecAlgos/src/RecHitTools.cc
+++ b/RecoLocalCalo/HGCalRecAlgos/src/RecHitTools.cc
@@ -221,12 +221,12 @@ int RecHitTools::getSiThickIndex(const DetId& id) const {
 
 std::pair<float, float> RecHitTools::getScintDEtaDPhi(const DetId& id) const {
   if (!isScintillator(id)) {
-    LogDebug("getScintDEtaDPhi::InvalidSintDetid")
+    LogDebug("getScintDEtaDPhi::InvalidScintDetid")
         << "det id: " << std::hex << id.rawId() << std::dec << ":" << id.det() << " is not HGCal scintillator!";
-    return std::pair<float, float>(0., 0.);
+    return {0.f, 0.f};
   }
-  auto geom = static_cast<const HGCalGeometry*>(getSubdetectorGeometry(id));
-  return std::pair<float, float>(geom->getGeometry(id)->etaSpan(), geom->getGeometry(id)->phiSpan());
+  auto cellGeom = getSubdetectorGeometry(id)->getGeometry(id);
+  return {cellGeom->etaSpan(), cellGeom->phiSpan()};
 }
 
 std::float_t RecHitTools::getRadiusToSide(const DetId& id) const {

--- a/RecoLocalCalo/HGCalRecAlgos/src/RecHitTools.cc
+++ b/RecoLocalCalo/HGCalRecAlgos/src/RecHitTools.cc
@@ -219,6 +219,25 @@ int RecHitTools::getSiThickIndex(const DetId& id) const {
   return thickIndex;
 }
 
+
+
+void RecHitTools::getScintDEtaDPhi(const DetId &id, std::float_t &deta,
+        std::float_t &dphi) const {
+    if (!isScintillator(id)) {
+        LogDebug("getScintDEtaDPhi::InvalidSintDetid") << "det id: " << std::hex
+                                                              << id.rawId()
+                                                              << std::dec << ":"
+                                                              << id.det()
+                                                              << " is not HGCal scintillator!";
+        deta = 0;
+        dphi = 0;
+        return;
+    }
+    auto geom = static_cast<const HGCalGeometry*>(getSubdetectorGeometry(id));
+    dphi = geom->getGeometry(id)->phiSpan();
+    deta = geom->getGeometry(id)->etaSpan();
+}
+
 std::float_t RecHitTools::getRadiusToSide(const DetId& id) const {
   auto geom = getSubdetectorGeometry(id);
   std::float_t size(std::numeric_limits<std::float_t>::max());
@@ -415,6 +434,10 @@ bool RecHitTools::isHalfCell(const DetId& id) const {
 bool RecHitTools::isSilicon(const DetId& id) const {
   return (id.det() == DetId::HGCalEE || id.det() == DetId::HGCalHSi ||
           (id.det() == DetId::Forward && id.subdetId() == static_cast<int>(HFNose)));
+}
+
+bool RecHitTools::isScintillator(const DetId& id) const{
+    return id.det() == DetId::HGCalHSc;
 }
 
 bool RecHitTools::isOnlySilicon(const unsigned int layer) const {


### PR DESCRIPTION
#### PR description:

This PR implements a new feature for the RecHitTools to conveniently access the size of individual HGCAL scintillator cells through their detID. While in the current geometry the size is constant for all cells, this implementation avoids hard-coding the size and is transparent w.r.t. geometry changes.
This feature is useful to study shower densities on truth level, and possibly for studying clustering algorithms.

The addition was discussed in the HGCAL DPG meeting: https://indico.cern.ch/event/1055901/ 

#### PR validation:

The code has been validated to produce the right sizes in eta and phi. It is also stable against wrong detID inputs.
Since it implements a new feature, there are no downstream dependencies.
