### PR TITLE
Introduce `conddb` script unit tests

### DIFF
--- a/CondCore/Utilities/scripts/conddb
+++ b/CondCore/Utilities/scripts/conddb
@@ -1044,11 +1044,12 @@ def diffGlobalTagsAtRun_(args):
         if(int(args.testRunNumber)<0):
             raise Exception("Run %s (default) can't be matched with an existing run in the database. \n\t\t Please specify a run with the option --run." % args.testRunNumber)
 
-        bestRun = session.query(RUNINFO.run_number, RUNINFO.start_time, RUNINFO.end_time).filter(RUNINFO.run_number == int(args.testRunNumber)).first()
-        if bestRun is None:
-            raise Exception("Run %s can't be matched with an existing run in the database." % args.testRunNumber)
+        if(int(args.testRunNumber)!=1):
+            bestRun = session.query(RUNINFO.run_number, RUNINFO.start_time, RUNINFO.end_time).filter(RUNINFO.run_number == int(args.testRunNumber)).first()
+            if bestRun is None:
+                raise Exception("Run %s can't be matched with an existing run in the database." % args.testRunNumber)
 
-        print("Run",args.testRunNumber," |Start time",bestRun[1]," |End time",bestRun[2],".")
+            print("Run",args.testRunNumber," |Start time",bestRun[1]," |End time",bestRun[2],".")
 
     ####################################
     # Get the Global Tag snapshots

--- a/CondCore/Utilities/test/BuildFile.xml
+++ b/CondCore/Utilities/test/BuildFile.xml
@@ -14,6 +14,11 @@
 
 <test name="testGetPayloadData" command="test_getPayloadData.sh"/>
 
+
 <test name="testUploadConditions" command="test_uploadConditions.sh">
   <flags PRE_TEST="testBasicPayload"/>
+</test>
+
+<test name="test_conddb" command="test_conddb.sh">
+ <flags PRE_TEST="testBasicPayload"/>
 </test>

--- a/CondCore/Utilities/test/test_conddb.sh
+++ b/CondCore/Utilities/test/test_conddb.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+function die { echo $1: status $2; exit $2; }
+
+echo "===========> testing conddb --help"
+conddb --help || die 'failed conddb --help' $?
+echo -ne '\n\n'
+
+echo "===========> testing conddb search"
+conddb search 4b97f78682aac6254bbcba54cedbde468202bf5b || die 'failed conddb search' $?
+echo -ne '\n\n'
+
+echo "===========> testing conddb listParentTags"
+conddb listParentTags 4b97f78682aac6254bbcba54cedbde468202bf5b || die 'failed conddb listParentTags' $?
+echo -ne '\n\n'
+
+echo "===========> testing conddb list"
+conddb list SiPixelQuality_phase1_2021_v1 || die 'failed conddb list' $?
+echo -ne '\n\n'
+
+echo "===========> testing conddb copy"
+conddb --yes --db pro copy SiPixelQuality_phase1_2021_v1 --destdb myfile.db  || die 'failed conddb copy' $?
+echo -ne '\n\n'
+
+echo "===========> testing conddb listTags"
+conddb --db BasicPayload_v0.db listTags || die 'failed conddb listTags' $?
+echo -ne '\n\n'
+
+echo "===========> testing conddb list on local sqlite file"
+conddb --db BasicPayload_v0.db list BasicPayload_v0 || die 'failed conddb list on local sqlite file' $?
+echo -ne '\n\n'
+
+echo "===========> testing conddb listGTsForTag"
+conddb listGTsForTag SiPixelQuality_phase1_2021_v1  || die 'failed conddb listGTsForTag' $?
+echo -ne '\n\n'
+
+echo "===========> testing conddb diff"
+conddb diff 120X_mcRun3_2021_realistic_v1 120X_mcRun3_2021_realistic_Candidate_2021_06_09_14_33_50  || die 'conddb diff' $?
+echo -ne '\n\n'
+
+echo "===========> testing conddb diffGlobalTagsAtRun"
+conddb diffGlobalTagsAtRun -R 120X_mcRun3_2021_realistic_v1 -T 120X_mcRun3_2021_realistic_Candidate_2021_06_09_14_33_50 --run 1 || die 'conddb diffGlobalTagsAtRun' $?
+echo -ne '\n\n'
+
+echo "===========> testing conddb dump"
+conddb dump 4b97f78682aac6254bbcba54cedbde468202bf5b || die 'failed comparing metadata with reference' $?
+echo -ne '\n\n'
+
+#conddb showFCSR || die 'failed conddb showFCSR' $?  # the FCSR is not always a real run...


### PR DESCRIPTION
#### PR description:

This is inspired from https://github.com/cms-sw/cmssw/issues/34378.
In commit 0daa900 a unit test to check basic functionalities of the `conddb` script is added.
In commit 2927fc9 a protection for `conddb diffGlobalTagsAtRun` is added, in order not go in error if it's run=1 (that's MC)

#### PR validation:

The newly introduced unit test passes:
```
scram b runtests_test_conddb
```

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A
