### PR TITLE
Use python3 to correct pick sqlalchemy and ROOT

### DIFF
--- a/Alignment/MillePedeAlignmentAlgorithm/scripts/mps_prepare_input_db.py
+++ b/Alignment/MillePedeAlignmentAlgorithm/scripts/mps_prepare_input_db.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 import argparse

--- a/Alignment/OfflineValidation/scripts/validateAlignments.py
+++ b/Alignment/OfflineValidation/scripts/validateAlignments.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #test execute: export CMSSW_BASE=/tmp/CMSSW && ./validateAlignments.py -c defaultCRAFTValidation.ini,test.ini -n -N test
 from __future__ import print_function
 from future.utils import lmap


### PR DESCRIPTION
few unit tests failed for https://github.com/cms-sw/cmsdist/pull/7106  due to python2 cleanup for sqlalchemy and ROOT. The Pr should fix  3 of these unit test.
```
src/Alignment/MillePedeAlignmentAlgorithm/test/test_MpsWorkFlow
src/Alignment/MillePedeAlignmentAlgorithm/test/test_PrepareInputDb
src/Alignment/OfflineValidation/test/testAlignmentOfflineValidation
```