### PR TITLE
Delete some unused code in the Core packages

### DIFF
--- a/FWCore/Framework/interface/ScheduleItems.h
+++ b/FWCore/Framework/interface/ScheduleItems.h
@@ -48,8 +48,6 @@ namespace edm {
                                            PreallocationConfiguration const& iAllocConfig,
                                            ProcessContext const*);
 
-    void clear();
-
     std::shared_ptr<SignallingProductRegistry const> preg() const { return get_underlying_safe(preg_); }
     std::shared_ptr<SignallingProductRegistry>& preg() { return get_underlying_safe(preg_); }
     std::shared_ptr<BranchIDListHelper const> branchIDListHelper() const {

--- a/FWCore/Framework/interface/moduleAbilities.h
+++ b/FWCore/Framework/interface/moduleAbilities.h
@@ -131,16 +131,12 @@ namespace edm {
   template <module::Abilities ABILITY, typename T, typename... VArgs>
   struct CheckAbility<ABILITY, T, VArgs...> {
     static constexpr bool kHasIt = (T::kAbilities == ABILITY) | CheckAbility<ABILITY, VArgs...>::kHasIt;
-    typedef std::
-        conditional_t<(T::kAbilities == ABILITY), typename T::Type, typename CheckAbility<ABILITY, VArgs...>::Type>
-            Type;
   };
 
   //End of the recursion
   template <module::Abilities ABILITY>
   struct CheckAbility<ABILITY> {
     static constexpr bool kHasIt = false;
-    typedef edm::module::Empty Type;
   };
 
   template <typename... VArgs>

--- a/FWCore/Framework/src/ScheduleItems.cc
+++ b/FWCore/Framework/src/ScheduleItems.cc
@@ -144,13 +144,4 @@ namespace edm {
                                       config,
                                       processContext);
   }
-
-  void ScheduleItems::clear() {
-    // propagate_const<T> has no reset() function
-    actReg_ = nullptr;
-    preg_ = nullptr;
-    branchIDListHelper_ = nullptr;
-    thinnedAssociationsHelper_ = nullptr;
-    processConfiguration_ = nullptr;
-  }
 }  // namespace edm

--- a/IOPool/Input/src/RootDelayedReader.cc
+++ b/IOPool/Input/src/RootDelayedReader.cc
@@ -24,8 +24,6 @@ namespace edm {
       : tree_(tree),
         filePtr_(filePtr),
         nextReader_(),
-        resourceAcquirer_(inputType == InputType::Primary ? new SharedResourcesAcquirer()
-                                                          : static_cast<SharedResourcesAcquirer*>(nullptr)),
         inputType_(inputType),
         wrapperBaseTClass_(TClass::GetClass("edm::WrapperBase")) {
     if (inputType == InputType::Primary) {

--- a/IOPool/Input/src/RootTree.cc
+++ b/IOPool/Input/src/RootTree.cc
@@ -145,8 +145,6 @@ namespace edm {
       //we want the new branch name for the JobReport
       branchNames_.push_back(prod.branchName());
     }
-    TTree* provTree = (metaTree_ != nullptr ? metaTree_ : tree_);
-    info.provenanceBranch_ = provTree->GetBranch(oldBranchName.c_str());
     branches_.insert(prod.branchID(), info);
   }
 

--- a/IOPool/Input/src/RootTree.h
+++ b/IOPool/Input/src/RootTree.h
@@ -63,22 +63,10 @@ namespace edm {
     };
 
     class BranchMap {
-      enum {
-        kKeys,
-        kInfos,
-      };
-
     public:
       void reserve(size_t iSize) { map_.reserve(iSize); }
       void insert(edm::BranchID const& iKey, BranchInfo const& iInfo) { map_.emplace(iKey.id(), iInfo); }
       BranchInfo const* find(BranchID const& iKey) const {
-        auto itFound = map_.find(iKey.id());
-        if (itFound == map_.end()) {
-          return nullptr;
-        }
-        return &itFound->second;
-      }
-      BranchInfo* find(BranchID const& iKey) {
         auto itFound = map_.find(iKey.id());
         if (itFound == map_.end()) {
           return nullptr;
@@ -124,7 +112,6 @@ namespace edm {
 
     bool next() { return ++entryNumber_ < entries_; }
     bool nextWithCache();
-    bool previous() { return --entryNumber_ >= 0; }
     bool current() const { return entryNumber_ < entries_ && entryNumber_ >= 0; }
     bool current(EntryNumber entry) const { return entry < entries_ && entry >= 0; }
     void rewind() { entryNumber_ = 0; }
@@ -142,16 +129,6 @@ namespace edm {
     void fillAux(T*& pAux) {
       auxBranch_->SetAddress(&pAux);
       getEntry(auxBranch_, entryNumber_);
-    }
-    template <typename T>
-    void fillBranchEntryMeta(TBranch* branch, T*& pbuf) {
-      if (metaTree_ != nullptr) {
-        // Metadata was in separate tree.  Not cached.
-        branch->SetAddress(&pbuf);
-        roottree::getEntry(branch, entryNumber_);
-      } else {
-        fillBranchEntry<T>(branch, pbuf);
-      }
     }
 
     template <typename T>
@@ -242,7 +219,6 @@ namespace edm {
     TBranch* branchEntryInfoBranch_;  //backwards compatibility
     // below for backward compatibility
     TTree* infoTree_;        // backward compatibility
-    TBranch* statusBranch_;  // backward compatibility
   };
 }  // namespace edm
 #endif

--- a/IOPool/Input/src/RootTree.h
+++ b/IOPool/Input/src/RootTree.h
@@ -53,12 +53,10 @@ namespace edm {
       BranchInfo(BranchDescription const& prod)
           : branchDescription_(prod),
             productBranch_(nullptr),
-            provenanceBranch_(nullptr),
             classCache_(nullptr),
             offsetToWrapperBase_(0) {}
       BranchDescription const branchDescription_;
       TBranch* productBranch_;
-      TBranch* provenanceBranch_;  // For backward compatibility
       //All access to a ROOT file is serialized
       CMS_SA_ALLOW mutable TClass* classCache_;
       CMS_SA_ALLOW mutable Int_t offsetToWrapperBase_;

--- a/IOPool/Input/src/RootTree.h
+++ b/IOPool/Input/src/RootTree.h
@@ -51,10 +51,7 @@ namespace edm {
     typedef IndexIntoFile::EntryNumber_t EntryNumber;
     struct BranchInfo {
       BranchInfo(BranchDescription const& prod)
-          : branchDescription_(prod),
-            productBranch_(nullptr),
-            classCache_(nullptr),
-            offsetToWrapperBase_(0) {}
+          : branchDescription_(prod), productBranch_(nullptr), classCache_(nullptr), offsetToWrapperBase_(0) {}
       BranchDescription const branchDescription_;
       TBranch* productBranch_;
       //All access to a ROOT file is serialized
@@ -218,7 +215,7 @@ namespace edm {
 
     TBranch* branchEntryInfoBranch_;  //backwards compatibility
     // below for backward compatibility
-    TTree* infoTree_;        // backward compatibility
+    TTree* infoTree_;  // backward compatibility
   };
 }  // namespace edm
 #endif

--- a/IOPool/Output/interface/PoolOutputModule.h
+++ b/IOPool/Output/interface/PoolOutputModule.h
@@ -87,11 +87,7 @@ namespace edm {
         std::shared_ptr<std::map<std::string, int>> treeMap_;
       };
 
-      OutputItem();
-
       explicit OutputItem(BranchDescription const* bd, EDGetToken const& token, int splitLevel, int basketSize);
-
-      ~OutputItem() {}
 
       BranchID branchID() const { return branchDescription_->branchID(); }
       std::string const& branchName() const { return branchDescription_->branchName(); }

--- a/IOPool/Output/src/PoolOutputModule.cc
+++ b/IOPool/Output/src/PoolOutputModule.cc
@@ -119,13 +119,6 @@ namespace edm {
 
   PoolOutputModule::AuxItem::AuxItem() : basketSize_(BranchDescription::invalidBasketSize) {}
 
-  PoolOutputModule::OutputItem::OutputItem()
-      : branchDescription_(nullptr),
-        token_(),
-        product_(nullptr),
-        splitLevel_(BranchDescription::invalidSplitLevel),
-        basketSize_(BranchDescription::invalidBasketSize) {}
-
   PoolOutputModule::OutputItem::OutputItem(BranchDescription const* bd,
                                            EDGetToken const& token,
                                            int splitLevel,


### PR DESCRIPTION
#### PR description:

Deletes several fragments of unused code in Core packages (plus a little from "scram b code-format").

I noticed this unused code while preparing the ProcessBlock Persistence pull request, although they are unrelated to ProcessBlock. It would be nice to get these trivial changes merged quickly so I can rebase the ProcessBlock pull request on top of them.

#### PR validation:

Relies on existing unit tests. The fact that it compiles is likely sufficient to test this as it only deletes things.
