### PR TITLE
Use python3 to for pick up py3 ROOT

### DIFF
--- a/Alignment/OfflineValidation/scripts/submitPVResolutionJobs.py
+++ b/Alignment/OfflineValidation/scripts/submitPVResolutionJobs.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 '''
 Submits per run Primary Vertex Resoltion Alignment validation using the split vertex method,
 usage:

--- a/Alignment/OfflineValidation/scripts/submitPVValidationJobs.py
+++ b/Alignment/OfflineValidation/scripts/submitPVValidationJobs.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 '''Script that submits CMS Tracker Alignment Primary Vertex Validation workflows,
 usage:


### PR DESCRIPTION
With ROOT for python3 only (https://github.com/cms-sw/cmsdist/pull/7106/files#diff-f7675e8ed13f5b85d8cc2cfa4022ca6ab330c2f057a3c97654a365dbfa721ca5 ) one unit test still fails. This change should fix this last failing unit test.