### PR TITLE
sort or order btags in python configuration

### DIFF
--- a/PhysicsTools/PatAlgos/python/tools/jetTools.py
+++ b/PhysicsTools/PatAlgos/python/tools/jetTools.py
@@ -242,12 +242,13 @@ def setupBTagging(process, jetSource, pfCandidates, explicitJTA, pvSource, svSou
 
     ## expand the btagDiscriminators to remove the meta taggers and substitute the equivalent sources
     discriminators = set(btagDiscriminators)
-    present_meta = discriminators.intersection(set(supportedMetaDiscr.keys()))
-    discriminators -= present_meta
-    for meta_tagger in present_meta:
+    present_metaSet = discriminators.intersection(set(supportedMetaDiscr.keys()))
+    discriminators -= present_metaSet
+    for meta_tagger in present_metaSet:
         for src in supportedMetaDiscr[meta_tagger]:
             discriminators.add(src)
-    btagDiscriminators = list(discriminators)
+    present_meta = sorted(present_metaSet)
+    btagDiscriminators = sorted(discriminators)
 
     ## expand tagInfos to what is explicitly required by user + implicit
     ## requirements that come in from one or the other discriminator

--- a/RecoBTag/ONNXRuntime/python/pfMassIndependentDeepDoubleXV2JetTags_cff.py
+++ b/RecoBTag/ONNXRuntime/python/pfMassIndependentDeepDoubleXV2JetTags_cff.py
@@ -6,18 +6,18 @@ from .pfDeepDoubleCvBJetTags_cfi import pfDeepDoubleCvBJetTags
 
 pfMassIndependentDeepDoubleBvLV2JetTags = pfDeepDoubleBvLJetTags.clone(
     model_path="RecoBTag/Combined/data/DeepDoubleX/102X/V02/BvL.onnx",
-    input_names={"input_1", "input_2", "input_3", "input_4"},
+    input_names=["input_1", "input_2", "input_3", "input_4"],
     version="V2",
 )
 
 pfMassIndependentDeepDoubleCvLV2JetTags = pfDeepDoubleCvLJetTags.clone(
     model_path="RecoBTag/Combined/data/DeepDoubleX/102X/V02/CvL.onnx",
-    input_names={"input_1", "input_2", "input_3", "input_4"},
+    input_names=["input_1", "input_2", "input_3", "input_4"],
     version="V2",
 )
 
 pfMassIndependentDeepDoubleCvBV2JetTags = pfDeepDoubleCvBJetTags.clone(
     model_path="RecoBTag/Combined/data/DeepDoubleX/102X/V02/CvB.onnx",
-    input_names={"input_1", "input_2", "input_3", "input_4"},
+    input_names=["input_1", "input_2", "input_3", "input_4"],
     version="V2",
 )


### PR DESCRIPTION
this was triggered by observed non-repeatable btag comparison plots https://github.com/cms-sw/cmsdist/pull/7112#issuecomment-876589924

apparently the difference originates from python `set` being not ordered (not repeatable either)

I found two places based on config dumps of 136.88811 and 136.874 
- setupBTagging where the patJets discriminatorSources (and related) are defined using python set
- DeepDoubleX : here the clone parameters were using a set display `{ }` (instead of a more common list display `[ ]` that we use in other python configs


@makortel 
the order of the following is not repeatable; This may complicate the edmConfigDump-based comparisons:
- `canDeleteEarly` 
- `logErrorHarvester.excludeModules` and `.includeModules`
