### PR TITLE
Make order of canDeleteEarly, and LogErrorHarvester includeModules and excludeModules deterministic

### DIFF
--- a/Configuration/StandardSequences/python/ReconstructionCosmics_cff.py
+++ b/Configuration/StandardSequences/python/ReconstructionCosmics_cff.py
@@ -80,7 +80,7 @@ reconstructionCosmics         = cms.Sequence(reconstructionCosmicsTask)
 #logErrorHarvester should only wait for items produced in the reconstructionCosmics sequence
 _modulesInReconstruction = list()
 reconstructionCosmics.visit(cms.ModuleNamesFromGlobalsVisitor(globals(),_modulesInReconstruction))
-logErrorHarvester.includeModules = cms.untracked.vstring(set(_modulesInReconstruction))
+logErrorHarvester.includeModules = cms.untracked.vstring(sorted(set(_modulesInReconstruction)))
 
 reconstructionCosmics_HcalNZSTask = cms.Task(localReconstructionCosmics_HcalNZSTask,
                                              beamhaloTracksTask,

--- a/Configuration/StandardSequences/python/Reconstruction_cff.py
+++ b/Configuration/StandardSequences/python/Reconstruction_cff.py
@@ -206,7 +206,7 @@ reconstruction         = cms.Sequence(reconstructionTask)
 #logErrorHarvester should only wait for items produced in the reconstruction sequence
 _modulesInReconstruction = list()
 reconstructionTask.visit(cms.ModuleNamesFromGlobalsVisitor(globals(),_modulesInReconstruction))
-logErrorHarvester.includeModules = cms.untracked.vstring(set(_modulesInReconstruction))
+logErrorHarvester.includeModules = cms.untracked.vstring(sorted(set(_modulesInReconstruction)))
 
 reconstruction_trackingOnlyTask = cms.Task(localrecoTask,globalreco_trackingTask)
 #calo parts removed as long as tracking is not running jetCore in phase2

--- a/Configuration/StandardSequences/python/earlyDeleteSettings_cff.py
+++ b/Configuration/StandardSequences/python/earlyDeleteSettings_cff.py
@@ -55,7 +55,8 @@ def customiseEarlyDelete(process):
     for branches in six.itervalues(products):
         for branch in branches:
             branchSet.add(branch)
-    process.options.canDeleteEarly.extend(list(branchSet))
+    branchList = sorted(branchSet)
+    process.options.canDeleteEarly.extend(branchList)
 
     # LogErrorHarvester should not wait for deleted items
     for prod in six.itervalues(process.producers_()):
@@ -63,7 +64,7 @@ def customiseEarlyDelete(process):
             if not hasattr(prod,'excludeModules'):
                 prod.excludeModules = cms.untracked.vstring()
             t = prod.excludeModules.value()
-            t.extend([b.split('_')[1] for b in branchSet])
+            t.extend([b.split('_')[1] for b in branchList])
             prod.excludeModules = t
 
     # Find the consumers

--- a/FWCore/Modules/python/logErrorHarvester_cff.py
+++ b/FWCore/Modules/python/logErrorHarvester_cff.py
@@ -35,7 +35,7 @@ def customiseLogErrorHarvesterUsingOutputCommands(process):
         toExclude = includeMods.difference(modulesFromAllOutput)
         if hasattr(process.logErrorHarvester,"excludeModules"):
             toExclude = toExclude.union(set(process.logErrorHarvester.excludeModules.value()))
-        process.logErrorHarvester.excludeModules = cms.untracked.vstring(*toExclude)
+        process.logErrorHarvester.excludeModules = cms.untracked.vstring(sorted(toExclude))
     else:
-        process.logErrorHarvester.includeModules = cms.untracked.vstring(*modulesFromAllOutput)
+        process.logErrorHarvester.includeModules = cms.untracked.vstring(sorted(modulesFromAllOutput))
     return process


### PR DESCRIPTION
#### PR description:

This PR makes the order of lists for `canDeleteEarly` parameter set in `customiseEarlyDelete()`, and the `LogErrorHarvester` `includeModules` and `excludeModules` parameters deterministic. This should make diffs of `edmConfigDump` outputs easier to interpret. These were spotted by @slava77 in https://github.com/cms-sw/cmssw/pull/34409.

Resolves https://github.com/makortel/framework/issues/183

#### PR validation:

Tested repeating `edmConfigDump` for RECO configuration of 4.53 that these configuration parameters did not change.
