### PR TITLE
Update the DQMFileSaverOnline tag

### DIFF
--- a/Validation/HGCalValidation/python/hgcalRunEmulatorValidationTPG_cff.py
+++ b/Validation/HGCalValidation/python/hgcalRunEmulatorValidationTPG_cff.py
@@ -18,7 +18,7 @@ from Configuration.StandardSequences.EDMtoMEAtJobEnd_cff import *
 onlineSaver = cms.EDAnalyzer("DQMFileSaverOnline",
     producer = cms.untracked.string('DQM'),
     path = cms.untracked.string('./'),
-    tag = cms.untracked.string('new')
+    tag = cms.untracked.string('validation_HGCAL_TPG')
 )
 
 hgcalTPGRunEmulatorValidation = cms.Sequence(hgcalTriggerPrimitives*hgcalTrigPrimValidation*onlineSaver)


### PR DESCRIPTION
Update the configuration file Validation/HGCalValidation/python/hgcalRunEmulatorValidationTPG_cff.py 
- Change the tag of the DQMFileSaverOnline
- This will update the name of the ROOT file containing the validation data

