### PR TITLE
Cleanup Thread.isAlive() which has been removed in python 3.9 and avbove

### DIFF
--- a/Configuration/PyReleaseValidation/data/runall.py
+++ b/Configuration/PyReleaseValidation/data/runall.py
@@ -133,7 +133,7 @@ def main(argv) :
             for j in range(0,alen):
                 mystat=cdone[j]
                 pingle=clist[j]
-                isA=pingle.isAlive()
+                isA=pingle.is_alive()
                 if ( isA ): i+=1
                 if ( not isA and mystat==0 ): 
                     nfail+=pingle.nfail

--- a/Configuration/PyReleaseValidation/python/MatrixRunner.py
+++ b/Configuration/PyReleaseValidation/python/MatrixRunner.py
@@ -23,7 +23,7 @@ class MatrixRunner(object):
 
         nActive = 0
         for t in self.threadList:
-            if t.isAlive() : nActive += 1
+            if t.is_alive() : nActive += 1
 
         return nActive
 

--- a/DQM/Integration/scripts/XMLcfgfiles/psClasses.py
+++ b/DQM/Integration/scripts/XMLcfgfiles/psClasses.py
@@ -66,7 +66,7 @@ class BuildThread(Thread):
           depsCompleted=False
           deps.BThread.IsComplete.acquire() 
           deps.BThread.IsComplete.wait()
-          #deps.BThread.isAlive() and sys.stdout.write("Wait time exeded %s %s\n" % (deps.LibName,deps.Module))
+          #deps.BThread.is_alive() and sys.stdout.write("Wait time exeded %s %s\n" % (deps.LibName,deps.Module))
           deps.BThread.IsComplete.release()
       
     self.putInServerQueue()

--- a/Utilities/ReleaseScripts/scripts/addOnTests.py
+++ b/Utilities/ReleaseScripts/scripts/addOnTests.py
@@ -77,7 +77,7 @@ class StandardTester(object):
 
         nActive = 0
         for t in self.threadList:
-            if t.isAlive() : nActive += 1
+            if t.is_alive() : nActive += 1
 
         return nActive
 


### PR DESCRIPTION
`AddOnTests` and `Relvals` failed for `Python 3.9` ( DEVEL IBs https://github.com/cms-sw/cmsdist/pull/7111 ) with errors like [a]. `Thread.isAlive()` has been removed from `python 3.9` ( https://bugs.python.org/issue37804 ). This PR replaces `isAlive` with `is_alive` as suggested here https://bugs.python.org/issue35283


[a]
```
  File "/cvmfs/cms-ci.cern.ch/week0/cms-sw/cmsdist/7111/16624/CMSSW_12_0_DEVEL_X_2021-07-07-2300/python/Configuration/PyReleaseValidation/MatrixRunner.py", line 26, in activeThreads
    if t.isAlive() : nActive += 1
AttributeError: 'WorkFlowRunner' object has no attribute 'isAlive'
```