### PR TITLE
 Migrate ED modules to use esConsumes in Validation/MuonIdentification

### DIFF
--- a/Validation/MuonIdentification/interface/MuonIdVal.h
+++ b/Validation/MuonIdentification/interface/MuonIdVal.h
@@ -104,7 +104,11 @@ private:
   edm::Handle<reco::MuonTimeExtraMap> dtMuonTimeExtraValueMapH_;
   edm::Handle<edm::ValueMap<reco::MuonCosmicCompatibility>> muonCosmicCompatibilityValueMapH_;
   edm::Handle<edm::ValueMap<reco::MuonShower>> muonShowerInformationValueMapH_;
+ 
   edm::ESHandle<GlobalTrackingGeometry> geometry_;
+  const edm::ESGetToken<GlobalTrackingGeometry, GlobalTrackingGeometryRecord> trackingGeomToken_;
+
+
 
   // trackerMuon == 0; globalMuon == 1
   // energy deposits

--- a/Validation/MuonIdentification/interface/MuonIdVal.h
+++ b/Validation/MuonIdentification/interface/MuonIdVal.h
@@ -104,11 +104,9 @@ private:
   edm::Handle<reco::MuonTimeExtraMap> dtMuonTimeExtraValueMapH_;
   edm::Handle<edm::ValueMap<reco::MuonCosmicCompatibility>> muonCosmicCompatibilityValueMapH_;
   edm::Handle<edm::ValueMap<reco::MuonShower>> muonShowerInformationValueMapH_;
- 
+
   edm::ESHandle<GlobalTrackingGeometry> geometry_;
   const edm::ESGetToken<GlobalTrackingGeometry, GlobalTrackingGeometryRecord> trackingGeomToken_;
-
-
 
   // trackerMuon == 0; globalMuon == 1
   // energy deposits

--- a/Validation/MuonIdentification/src/MuonIdVal.cc
+++ b/Validation/MuonIdentification/src/MuonIdVal.cc
@@ -1,6 +1,7 @@
 #include "Validation/MuonIdentification/interface/MuonIdVal.h"
 
-MuonIdVal::MuonIdVal(const edm::ParameterSet &ps): trackingGeomToken_(esConsumes<GlobalTrackingGeometry,GlobalTrackingGeometryRecord>())  {
+MuonIdVal::MuonIdVal(const edm::ParameterSet &ps)
+    : trackingGeomToken_(esConsumes<GlobalTrackingGeometry, GlobalTrackingGeometryRecord>()) {
   iConfig = ps;
   inputMuonCollection_ = iConfig.getParameter<edm::InputTag>("inputMuonCollection");
   inputDTRecSegment4DCollection_ = iConfig.getParameter<edm::InputTag>("inputDTRecSegment4DCollection");
@@ -425,8 +426,7 @@ void MuonIdVal::analyze(const edm::Event &iEvent, const edm::EventSetup &iSetup)
   iEvent.getByToken(inputMuonShowerInformationValueMapToken_, muonShowerInformationValueMapH_);
   iEvent.getByToken(inputMuonCosmicCompatibilityValueMapToken_, muonCosmicCompatibilityValueMapH_);
 
-
-  geometry_ = iSetup.getHandle(trackingGeomToken_);  
+  geometry_ = iSetup.getHandle(trackingGeomToken_);
 
   unsigned int muonIdx = 0;
   for (MuonCollection::const_iterator muon = muonCollectionH_->begin(); muon != muonCollectionH_->end(); ++muon) {

--- a/Validation/MuonIdentification/src/MuonIdVal.cc
+++ b/Validation/MuonIdentification/src/MuonIdVal.cc
@@ -1,6 +1,6 @@
 #include "Validation/MuonIdentification/interface/MuonIdVal.h"
 
-MuonIdVal::MuonIdVal(const edm::ParameterSet &ps) {
+MuonIdVal::MuonIdVal(const edm::ParameterSet &ps): trackingGeomToken_(esConsumes<GlobalTrackingGeometry,GlobalTrackingGeometryRecord>())  {
   iConfig = ps;
   inputMuonCollection_ = iConfig.getParameter<edm::InputTag>("inputMuonCollection");
   inputDTRecSegment4DCollection_ = iConfig.getParameter<edm::InputTag>("inputDTRecSegment4DCollection");
@@ -425,7 +425,8 @@ void MuonIdVal::analyze(const edm::Event &iEvent, const edm::EventSetup &iSetup)
   iEvent.getByToken(inputMuonShowerInformationValueMapToken_, muonShowerInformationValueMapH_);
   iEvent.getByToken(inputMuonCosmicCompatibilityValueMapToken_, muonCosmicCompatibilityValueMapH_);
 
-  iSetup.get<GlobalTrackingGeometryRecord>().get(geometry_);
+
+  geometry_ = iSetup.getHandle(trackingGeomToken_);  
 
   unsigned int muonIdx = 0;
   for (MuonCollection::const_iterator muon = muonCollectionH_->begin(); muon != muonCollectionH_->end(); ++muon) {


### PR DESCRIPTION
Migrate ED modules to use esConsumes, for the Validation/MuonIdentification