### PR TITLE
Re-enable suppression of CSC digis without matching pretriggers and triggers

### DIFF
--- a/DQM/CSCMonitorModule/test/dqm_repacker_test.py
+++ b/DQM/CSCMonitorModule/test/dqm_repacker_test.py
@@ -197,7 +197,7 @@ process.cscpacker = cms.EDProducer("CSCDigiToRawModule",
 )
 
 process.cscpacker.usePreTriggers = cms.untracked.bool(False)
-process.cscpacker.useFormatVersion = cms.untracked.uint32(2013)
+process.cscpacker.formatVersion = cms.untracked.uint32(2013)
 
 #----------------------------
 # Event Source

--- a/EventFilter/CSCRawToDigi/interface/CSCDigiToRaw.h
+++ b/EventFilter/CSCRawToDigi/interface/CSCDigiToRaw.h
@@ -41,9 +41,7 @@ public:
                         const GEMPadDigiClusterCollection* padDigiClusters,
                         FEDRawDataCollection& fed_buffers,
                         const CSCChamberMap* theMapping,
-                        const edm::EventID& eid,
-                        uint16_t theFormatVersion = 2005,
-                        bool packEverything = false) const;
+                        const edm::EventID& eid) const;
 
 private:
   struct FindEventDataInfo {
@@ -59,17 +57,12 @@ private:
   void add(const CSCStripDigiCollection& stripDigis,
            const CSCCLCTPreTriggerCollection* preTriggers,
            const CSCCLCTPreTriggerDigiCollection* preTriggerDigis,
-           FindEventDataInfo&,
-           bool packEverything) const;
-  void add(const CSCWireDigiCollection& wireDigis,
-           const CSCALCTDigiCollection& alctDigis,
-           FindEventDataInfo&,
-           bool packEverything) const;
+           FindEventDataInfo&) const;
+  void add(const CSCWireDigiCollection& wireDigis, const CSCALCTDigiCollection& alctDigis, FindEventDataInfo&) const;
   // may require CLCTs to read out comparators.  Doesn't add CLCTs.
   void add(const CSCComparatorDigiCollection& comparatorDigis,
            const CSCCLCTDigiCollection& clctDigis,
-           FindEventDataInfo&,
-           bool packEverything) const;
+           FindEventDataInfo&) const;
   void add(const CSCALCTDigiCollection& alctDigis, FindEventDataInfo&) const;
   void add(const CSCCLCTDigiCollection& clctDigis, FindEventDataInfo&) const;
   void add(const CSCCorrelatedLCTDigiCollection& corrLCTDigis, FindEventDataInfo&) const;
@@ -84,6 +77,10 @@ private:
   const int clctWindowMax_;
   const int preTriggerWindowMin_;
   const int preTriggerWindowMax_;
+
+  uint16_t formatVersion_;
+  bool packEverything_;
+  bool usePreTriggers_;
 };
 
 #endif

--- a/EventFilter/CSCRawToDigi/python/cscPacker_cfi.py
+++ b/EventFilter/CSCRawToDigi/python/cscPacker_cfi.py
@@ -15,7 +15,7 @@ run2_common.toModify( cscpacker,
                       packEverything = True)
 
 ## in Run-3 pack again the digis according to (pre)triggers
-from Configuration.Eras.Modifier_run2_common_cff import run2_common
+from Configuration.Eras.Modifier_run2_common_cff import run3_common
 run3_common.toModify( cscpacker,
                       usePreTriggers = True,
                       packEverything = False)

--- a/EventFilter/CSCRawToDigi/python/cscPacker_cfi.py
+++ b/EventFilter/CSCRawToDigi/python/cscPacker_cfi.py
@@ -14,8 +14,13 @@ run2_common.toModify( cscpacker,
                       usePreTriggers = False,
                       packEverything = True)
 
-## in Run-3 include GEMs, and pack again the digis according to (pre)triggers
+## in Run-3 pack again the digis according to (pre)triggers
+from Configuration.Eras.Modifier_run2_common_cff import run2_common
+run3_common.toModify( cscpacker,
+                      usePreTriggers = True,
+                      packEverything = False)
+
+## in Run-3 scenarios with GEM: pack GEM clusters
 from Configuration.Eras.Modifier_run3_GEM_cff import run3_GEM
 run3_GEM.toModify( cscpacker,
-                   usePreTriggers = True,
-                   packEverything = False)
+                   useGEMs = True)

--- a/EventFilter/CSCRawToDigi/python/cscPacker_cfi.py
+++ b/EventFilter/CSCRawToDigi/python/cscPacker_cfi.py
@@ -10,12 +10,12 @@ cscpacker = cscPackerDef.clone()
 # packer - simply get rid of it
 from Configuration.Eras.Modifier_run2_common_cff import run2_common
 run2_common.toModify( cscpacker,
-                      useFormatVersion = 2013,
+                      formatVersion = 2013,
                       usePreTriggers = False,
                       packEverything = True)
 
-## in Run-3 include GEMs
+## in Run-3 include GEMs, and pack again the digis according to (pre)triggers
 from Configuration.Eras.Modifier_run3_GEM_cff import run3_GEM
 run3_GEM.toModify( cscpacker,
-                   padDigiClusterTag = "simMuonGEMPadDigiClusters",
-                   useGEMs = False)
+                   usePreTriggers = True,
+                   packEverything = False)

--- a/EventFilter/CSCRawToDigi/python/cscPacker_cfi.py
+++ b/EventFilter/CSCRawToDigi/python/cscPacker_cfi.py
@@ -15,7 +15,7 @@ run2_common.toModify( cscpacker,
                       packEverything = True)
 
 ## in Run-3 pack again the digis according to (pre)triggers
-from Configuration.Eras.Modifier_run2_common_cff import run3_common
+from Configuration.Eras.Modifier_run3_common_cff import run3_common
 run3_common.toModify( cscpacker,
                       usePreTriggers = True,
                       packEverything = False)

--- a/EventFilter/CSCRawToDigi/python/cscPacker_cfi.py
+++ b/EventFilter/CSCRawToDigi/python/cscPacker_cfi.py
@@ -4,21 +4,13 @@ import FWCore.ParameterSet.Config as cms
 from EventFilter.CSCRawToDigi.cscPackerDef_cfi import cscPackerDef
 cscpacker = cscPackerDef.clone()
 
-##
-## Make changes for running in Run 2
-##
-# packer - simply get rid of it
+## In Run-2 common: update the format version for new OTMBs in ME1/1
+## Note: in the past, the packing with triggers and pretriggers was disabled
+## for Run-2, Run-3 and Phase-2 scenarios. This should no longer be the case
+## as of CMSSW_12_0_0_pre5
 from Configuration.Eras.Modifier_run2_common_cff import run2_common
 run2_common.toModify( cscpacker,
-                      formatVersion = 2013,
-                      usePreTriggers = False,
-                      packEverything = True)
-
-## in Run-3 pack again the digis according to (pre)triggers
-from Configuration.Eras.Modifier_run3_common_cff import run3_common
-run3_common.toModify( cscpacker,
-                      usePreTriggers = True,
-                      packEverything = False)
+                      formatVersion = 2013)
 
 ## in Run-3 scenarios with GEM: pack GEM clusters
 from Configuration.Eras.Modifier_run3_GEM_cff import run3_GEM

--- a/EventFilter/CSCRawToDigi/src/CSCDigiToRaw.cc
+++ b/EventFilter/CSCRawToDigi/src/CSCDigiToRaw.cc
@@ -161,7 +161,7 @@ void CSCDigiToRaw::add(const CSCStripDigiCollection& stripDigis,
     const bool usePreTriggers = usePreTriggers_ and preTriggers != nullptr;
     if (!usePreTriggers || packEverything_ ||
         (usePreTriggers && cscd2r::accept(cscDetId,
-                                          *preTriggers,
+                                          *preTriggerDigis,
                                           preTriggerWindowMin_,
                                           preTriggerWindowMax_,
                                           CSCConstants::CLCT_CENTRAL_BX,

--- a/EventFilter/CSCRawToDigi/src/CSCDigiToRaw.cc
+++ b/EventFilter/CSCRawToDigi/src/CSCDigiToRaw.cc
@@ -36,10 +36,10 @@ namespace cscd2r {
   }
 
   template <typename LCTCollection>
-  bool accept(const CSCDetId& cscId, const LCTCollection& lcts, int bxMin, int bxMax, bool me1abCheck = false) {
+  bool accept(
+      const CSCDetId& cscId, const LCTCollection& lcts, int bxMin, int bxMax, int nominalBX, bool me1abCheck = false) {
     if (bxMin == -999)
       return true;
-    int nominalBX = 6;
     CSCDetId chamberId = chamberID(cscId);
     typename LCTCollection::Range lctRange = lcts.get(chamberId);
     bool result = false;
@@ -71,10 +71,14 @@ namespace cscd2r {
 
   // need to specialize for pretriggers, since they don't have a getBX()
   template <>
-  bool accept(const CSCDetId& cscId, const CSCCLCTPreTriggerCollection& lcts, int bxMin, int bxMax, bool me1abCheck) {
+  bool accept(const CSCDetId& cscId,
+              const CSCCLCTPreTriggerCollection& lcts,
+              int bxMin,
+              int bxMax,
+              int nominalBX,
+              bool me1abCheck) {
     if (bxMin == -999)
       return true;
-    int nominalBX = 6;
     CSCDetId chamberId = chamberID(cscId);
     CSCCLCTPreTriggerCollection::Range lctRange = lcts.get(chamberId);
     bool result = false;
@@ -108,7 +112,13 @@ CSCDigiToRaw::CSCDigiToRaw(const edm::ParameterSet& pset)
       clctWindowMin_(pset.getParameter<int>("clctWindowMin")),
       clctWindowMax_(pset.getParameter<int>("clctWindowMax")),
       preTriggerWindowMin_(pset.getParameter<int>("preTriggerWindowMin")),
-      preTriggerWindowMax_(pset.getParameter<int>("preTriggerWindowMax")) {}
+      preTriggerWindowMax_(pset.getParameter<int>("preTriggerWindowMax")),
+      // pre-LS1 - '2005'. post-LS1 - '2013'
+      formatVersion_(pset.getParameter<unsigned>("formatVersion")),
+      // don't check for consistency with trig primitives
+      // overrides usePreTriggers
+      packEverything_(pset.getParameter<bool>("packEverything")),
+      usePreTriggers_(pset.getParameter<bool>("usePreTriggers")) {}
 
 CSCEventData& CSCDigiToRaw::findEventData(const CSCDetId& cscDetId, FindEventDataInfo& info) const {
   CSCDetId chamberId = cscd2r::chamberID(cscDetId);
@@ -140,18 +150,22 @@ CSCEventData& CSCDigiToRaw::findEventData(const CSCDetId& cscDetId, FindEventDat
 void CSCDigiToRaw::add(const CSCStripDigiCollection& stripDigis,
                        const CSCCLCTPreTriggerCollection* preTriggers,
                        const CSCCLCTPreTriggerDigiCollection* preTriggerDigis,
-                       FindEventDataInfo& fedInfo,
-                       bool packEverything) const {  //iterate over chambers with strip digis in them
+                       FindEventDataInfo& fedInfo) const {
+  //iterate over chambers with strip digis in them
   for (CSCStripDigiCollection::DigiRangeIterator j = stripDigis.begin(); j != stripDigis.end(); ++j) {
     CSCDetId cscDetId = (*j).first;
     // only digitize if there are pre-triggers
 
     bool me1abCheck = fedInfo.formatVersion_ == 2013;
-    /* !!! Testing. Uncomment for production */
-    const bool usePreTriggers = preTriggers != nullptr;
-    if (!usePreTriggers || packEverything ||
-        (usePreTriggers &&
-         cscd2r::accept(cscDetId, *preTriggers, preTriggerWindowMin_, preTriggerWindowMax_, me1abCheck))) {
+    // pretrigger flag must be set and the pretrigger collection must be nonzero!
+    const bool usePreTriggers = usePreTriggers_ and preTriggers != nullptr;
+    if (!usePreTriggers || packEverything_ ||
+        (usePreTriggers && cscd2r::accept(cscDetId,
+                                          *preTriggers,
+                                          preTriggerWindowMin_,
+                                          preTriggerWindowMax_,
+                                          CSCConstants::CLCT_CENTRAL_BX,
+                                          me1abCheck))) {
       bool me1a = (cscDetId.station() == 1) && (cscDetId.ring() == 4);
       bool zplus = (cscDetId.endcap() == 1);
       bool me1b = (cscDetId.station() == 1) && (cscDetId.ring() == 1);
@@ -197,13 +211,14 @@ void CSCDigiToRaw::add(const CSCStripDigiCollection& stripDigis,
 
 void CSCDigiToRaw::add(const CSCWireDigiCollection& wireDigis,
                        const CSCALCTDigiCollection& alctDigis,
-                       FindEventDataInfo& fedInfo,
-                       bool packEverything) const {
+                       FindEventDataInfo& fedInfo) const {
   add(alctDigis, fedInfo);
   for (CSCWireDigiCollection::DigiRangeIterator j = wireDigis.begin(); j != wireDigis.end(); ++j) {
     CSCDetId cscDetId = (*j).first;
     bool me1abCheck = fedInfo.formatVersion_ == 2013;
-    if (packEverything || cscd2r::accept(cscDetId, alctDigis, alctWindowMin_, alctWindowMax_, me1abCheck)) {
+    if (packEverything_ ||
+        cscd2r::accept(
+            cscDetId, alctDigis, alctWindowMin_, alctWindowMax_, CSCConstants::ALCT_CENTRAL_BX, me1abCheck)) {
       CSCEventData& cscData = findEventData(cscDetId, fedInfo);
       std::vector<CSCWireDigi>::const_iterator digiItr = (*j).second.first;
       std::vector<CSCWireDigi>::const_iterator last = (*j).second.second;
@@ -216,14 +231,15 @@ void CSCDigiToRaw::add(const CSCWireDigiCollection& wireDigis,
 
 void CSCDigiToRaw::add(const CSCComparatorDigiCollection& comparatorDigis,
                        const CSCCLCTDigiCollection& clctDigis,
-                       FindEventDataInfo& fedInfo,
-                       bool packEverything) const {
+                       FindEventDataInfo& fedInfo) const {
   add(clctDigis, fedInfo);
   for (auto const& j : comparatorDigis) {
     CSCDetId cscDetId = j.first;
     CSCEventData& cscData = findEventData(cscDetId, fedInfo);
     bool me1abCheck = fedInfo.formatVersion_ == 2013;
-    if (packEverything || cscd2r::accept(cscDetId, clctDigis, clctWindowMin_, clctWindowMax_, me1abCheck)) {
+    if (packEverything_ ||
+        cscd2r::accept(
+            cscDetId, clctDigis, clctWindowMin_, clctWindowMax_, CSCConstants::CLCT_CENTRAL_BX, me1abCheck)) {
       bool me1a = (cscDetId.station() == 1) && (cscDetId.ring() == 4);
 
       /*
@@ -366,17 +382,13 @@ void CSCDigiToRaw::createFedBuffers(const CSCStripDigiCollection& stripDigis,
                                     const GEMPadDigiClusterCollection* gemPadDigiClusters,
                                     FEDRawDataCollection& fed_buffers,
                                     const CSCChamberMap* mapping,
-                                    const EventID& eid,
-                                    uint16_t format_version,
-                                    bool packEverything) const {
-  //bits of code from ORCA/Muon/METBFormatter - thanks, Rick:)!
-
+                                    const EventID& eid) const {
   //get fed object from fed_buffers
   // make a map from the index of a chamber to the event data from it
-  FindEventDataInfo fedInfo{mapping, format_version};
-  add(stripDigis, preTriggers, preTriggerDigis, fedInfo, packEverything);
-  add(wireDigis, alctDigis, fedInfo, packEverything);
-  add(comparatorDigis, clctDigis, fedInfo, packEverything);
+  FindEventDataInfo fedInfo{mapping, formatVersion_};
+  add(stripDigis, preTriggers, preTriggerDigis, fedInfo);
+  add(wireDigis, alctDigis, fedInfo);
+  add(comparatorDigis, clctDigis, fedInfo);
   add(correlatedLCTDigis, fedInfo);
 
   // Starting Run-3, the CSC DAQ will pack/unpack CSC showers
@@ -417,7 +429,7 @@ void CSCDigiToRaw::createFedBuffers(const CSCStripDigiCollection& stripDigis,
           int dduSlot = mapping->dduSlot(chamberItr->first);
           int dduInput = mapping->dduInput(chamberItr->first);
           int dmbId = mapping->dmb(chamberItr->first);
-          dccMapItr->second.addChamber(chamberItr->second, dduId, dduSlot, dduInput, dmbId, format_version);
+          dccMapItr->second.addChamber(chamberItr->second, dduId, dduSlot, dduInput, dmbId, formatVersion_);
         }
       }
     }
@@ -438,7 +450,7 @@ void CSCDigiToRaw::createFedBuffers(const CSCStripDigiCollection& stripDigis,
     }
   }
   /// Handle post-LS1 format data
-  else if (format_version == 2013) {
+  else if (formatVersion_ == 2013) {
     std::map<int, CSCDDUEventData> dduMap;
     unsigned int ddu_fmt_version = 0x7;  /// 2013 Format
     const unsigned postLS1_map[] = {841, 842, 843, 844, 845, 846, 847, 848, 849, 831, 832, 833,
@@ -490,7 +502,7 @@ void CSCDigiToRaw::createFedBuffers(const CSCStripDigiCollection& stripDigis,
           int dduInput = mapping->dduInput(chamberItr->first);
           int dmbId = mapping->dmb(chamberItr->first);
           // int crateId  = mapping->crate(chamberItr->first);
-          dduMapItr->second.add(chamberItr->second, dmbId, dduInput, format_version);
+          dduMapItr->second.add(chamberItr->second, dmbId, dduInput, formatVersion_);
         }
       }
     }

--- a/SLHCUpgradeSimulations/Configuration/python/muonCustoms.py
+++ b/SLHCUpgradeSimulations/Configuration/python/muonCustoms.py
@@ -169,7 +169,7 @@ def customise_csc_L1Emulator_sim(process):
 def customise_csc_Packer(process):
     """Use 2013 a.k.a. post-LS1 version
     """
-    process.cscpacker.useFormatVersion = cms.uint32(2013)
+    process.cscpacker.formatVersion = cms.uint32(2013)
     process.cscpacker.usePreTriggers = cms.bool(False)
     process.cscpacker.packEverything = cms.bool(True)
     return process


### PR DESCRIPTION
#### PR description:

This PR should re-enable CSC digi packing with pretriggers and triggers. This was disabled in Run-2. In this minimal version packing of comparator digis is done in the entire chamber with a single pretrigger.

#### PR validation:

Ran ```runTheMatrix.py -l muonmc```

```
5.1_TTbar+TTbarFS+HARVESTFS Step0-PASSED Step1-PASSED  - time date Fri Jul  9 19:58:47 2021-date Fri Jul  9 19:50:39 2021; exit: 0 0
20.0_SingleMuPt10+SingleMuPt10+DIGI+RECO+HARVEST Step0-PASSED Step1-PASSED Step2-PASSED Step3-PASSED  - time date Fri Jul  9 20:01:01 2021-date Fri Jul  9 19:50:39 2021; exit: 0 0 0 0
21.0_SingleMuPt100+SingleMuPt100+DIGI+RECO+HARVEST Step0-PASSED Step1-PASSED Step2-PASSED Step3-PASSED  - time date Fri Jul  9 20:00:42 2021-date Fri Jul  9 19:50:40 2021; exit: 0 0 0 0
22.0_SingleMuPt1000+SingleMuPt1000+DIGI+RECO+HARVEST Step0-PASSED Step1-PASSED Step2-PASSED Step3-PASSED  - time date Fri Jul  9 20:03:16 2021-date Fri Jul  9 19:50:40 2021; exit: 0 0 0 0
23.0_JpsiMM+JpsiMM+DIGI+RECO+HARVEST Step0-PASSED Step1-PASSED Step2-PASSED Step3-PASSED  - time date Fri Jul  9 20:08:09 2021-date Fri Jul  9 19:58:48 2021; exit: 0 0 0 0
25.0_TTbar+TTbar+DIGI+RECOAlCaCalo+HARVEST+ALCATT Step0-PASSED Step1-PASSED Step2-PASSED Step3-PASSED Step4-PASSED  - time date Fri Jul  9 20:16:28 2021-date Fri Jul  9 20:00:42 2021; exit: 0 0 0 0 0
30.0_ZMM+ZMM+DIGI+RECO+HARVEST Step0-PASSED Step1-PASSED Step2-PASSED Step3-PASSED  - time date Fri Jul  9 20:09:14 2021-date Fri Jul  9 20:01:01 2021; exit: 0 0 0 0
124.4_SinglePiPt10+SinglePiPt10FS Step0-PASSED  - time date Fri Jul  9 20:06:18 2021-date Fri Jul  9 20:03:17 2021; exit: 0
124.5_SinglePiPt100+SinglePiPt100FS Step0-PASSED  - time date Fri Jul  9 20:09:31 2021-date Fri Jul  9 20:06:19 2021; exit: 0
9 7 6 6 1 tests passed, 0 0 0 0 0 failed
```

In the DQM plots we should see a slight decrease of CSC digis after packing-unpacking due to requirement of triggers/pretriggers.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)

@barvic @ptcox 