### PR TITLE
Use the original GEN module name for ExternalGeneratorFilter in recognizing generator types

### DIFF
--- a/PhysicsTools/JetMCAlgos/plugins/HadronAndPartonSelector.cc
+++ b/PhysicsTools/JetMCAlgos/plugins/HadronAndPartonSelector.cc
@@ -142,6 +142,11 @@ void HadronAndPartonSelector::produce(edm::Event& iEvent, const edm::EventSetup&
     if (genEvtInfoProduct.isValid()) {
       const edm::StableProvenance& prov = iEvent.getStableProvenance(genEvtInfoProduct.id());
       moduleName = edm::moduleName(prov, iEvent.processHistory());
+      if (moduleName == "ExternalGeneratorFilter") {
+        moduleName = edm::parameterSet(prov, iEvent.processHistory()).getParameter<std::string>("@external_type");
+        edm::LogInfo("SpecialModule") << "GEN events are produced by ExternalGeneratorFilter, "
+                                      << "which is a wrapper of the original module: " << moduleName;
+      }
     }
 
     if (moduleName.find("Pythia6") != std::string::npos)

--- a/TopQuarkAnalysis/TopEventProducers/src/TopDecaySubset.cc
+++ b/TopQuarkAnalysis/TopEventProducers/src/TopDecaySubset.cc
@@ -247,6 +247,11 @@ TopDecaySubset::ShowerModel TopDecaySubset::checkShowerModel(edm::Event& event) 
   if (genEvtInfoProduct.isValid()) {
     const edm::StableProvenance& prov = event.getStableProvenance(genEvtInfoProduct.id());
     moduleName = edm::moduleName(prov, event.processHistory());
+    if (moduleName == "ExternalGeneratorFilter") {
+      moduleName = edm::parameterSet(prov, event.processHistory()).getParameter<std::string>("@external_type");
+      edm::LogInfo("SpecialModule") << "GEN events are produced by ExternalGeneratorFilter, "
+                                    << "which is a wrapper of the original module: " << moduleName;
+    }
   }
 
   ShowerModel shower(kStart);


### PR DESCRIPTION
#### PR description:

When the generator type (Pythia8, Herwig7, ...) needs to be recognized from the GEN module name, the use of the `ExternalGeneratorFilter` module may confuse the code because it is a wrapper of the real generator module for use.

In such cases, we set the `moduleName` to the real generator module inside `ExternalGeneratorFilter`.

A backport to 10_6_X is also needed.

#### PR validation:

`HadronAndPartonSelector` is one module that detects the general type with the above method, and is in the sequence of producing NanoAOD/NanoGEN. 

Below test produces the NanoGEN output for process `BTV-RunIISummer20UL17GEN-00002`, using `ExternalGeneratorFilter` as the GEN event module.

```bash
export SCRAM_ARCH=slc7_amd64_gcc900
cmsrel CMSSW_12_0_X_2021-07-09-1100
cd CMSSW_12_0_X_2021-07-09-1100/src
git cms-merge-topic colizz:dev-120X-fixModuleNameAsExternalGenFilter
curl -s -k https://cms-pdmv.cern.ch/mcm/public/restapi/requests/get_fragment/BTV-RunIISummer20UL17GEN-00002 --retry 3 --create-dirs -o Configuration/GenProduction/python/BTV-RunIISummer20UL17GEN-00002-fragment.py
scram b -j8
cd ../..

cmsDriver.py Configuration/GenProduction/python/BTV-RunIISummer20UL17GEN-00002-fragment.py --python_filename BTV-RunIISummer20UL17GEN-00002_1_cfg.py --eventcontent RAWSIM --customise Configuration/DataProcessing/Utils.addMonitoring --datatier GEN --fileout file:BTV-RunIISummer20UL17GEN-00002.root --conditions 112X_mcRun2_asymptotic_v2 --beamspot Realistic25ns13TeVEarly2017Collision --customise_commands='from GeneratorInterface.Core.ExternalGeneratorFilter import ExternalGeneratorFilter; process.generator = ExternalGeneratorFilter(process.generator)' --step GEN --geometry DB:Extended --era Run2_2017 --mc -n 10
cmsDriver.py --python_filename NanoGEN_cfg.py --eventcontent NANOAODSIM --customise Configuration/DataProcessing/Utils.addMonitoring --datatier NANOAODSIM --filein file:BTV-RunIISummer20UL17GEN-00002.root --fileout file:NanoGEN_output.root --conditions 112X_mcRun2_asymptotic_v2 --beamspot Realistic25ns13TeV2016Collision --customise_commands='from PhysicsTools.NanoAOD.nanogen_cff import customizeNanoGEN; process = customizeNanoGEN(process)\nprocess.MessageLogger.cerr.threshold = "INFO"\nprocess.MessageLogger.cerr.SpecialModule = dict()\n' --step NANOGEN --era Run2_2017,run2_nanoAOD_106Xv1 --mc -n -1
```

Checking `%MSG-i SpecialModule` and we validate that the `moduleName` is corrected.
