### PR TITLE
Fix the MadGraph5 LO multithread utility

### DIFF
--- a/GeneratorInterface/LHEInterface/data/run_generic_tarball_cvmfs_madgraphLO_multithread.sh
+++ b/GeneratorInterface/LHEInterface/data/run_generic_tarball_cvmfs_madgraphLO_multithread.sh
@@ -130,8 +130,13 @@ EOF
  
      def launch(self, nb_event, seed):
 EOF
+    fi
 
-        # fix another "readonly" mode issue related to proper handle of the integration grid, as identified in: https://answers.launchpad.net/mg5amcnlo/+question/696856
+    # fix another "readonly" mode issue related to proper handle of the integration grid,
+    # as identified in: https://answers.launchpad.net/mg5amcnlo/+question/696856
+    # this is fixed since 2.9.4 and 3.1.1, so we add a patch if MG is lower then these versions
+    if [[ ( ${MGVersion[0]} -eq 2 ) && ( ${MGVersion[1]} -lt 9 || ( ${MGVersion[1]} -eq 9 && ${MGVersion[2]} -le 3 ) ) ]] || \
+       [[ ( ${MGVersion[0]} -eq 3 ) && ( ${MGVersion[1]} -lt 1 || ( ${MGVersion[1]} -eq 1 && ${MGVersion[2]} -le 0 ) ) ]]; then 
         patch process/madevent/bin/internal/gen_ximprove.py << EOF
 === modified file 'madgraph/interface/gen_ximprove.py'
 --- madgraph/interface/gen_ximprove.py

--- a/GeneratorInterface/LHEInterface/data/run_generic_tarball_cvmfs_madgraphLO_multithread.sh
+++ b/GeneratorInterface/LHEInterface/data/run_generic_tarball_cvmfs_madgraphLO_multithread.sh
@@ -130,6 +130,22 @@ EOF
  
      def launch(self, nb_event, seed):
 EOF
+
+        # fix another "readonly" mode issue related to proper handle of the integration grid, as identified in: https://answers.launchpad.net/mg5amcnlo/+question/696856
+        patch process/madevent/bin/internal/gen_ximprove.py << EOF
+=== modified file 'madgraph/interface/gen_ximprove.py'
+--- madgraph/interface/gen_ximprove.py
++++ madgraph/interface/gen_ximprove.py
+@@ -1903,5 +1903,8 @@ class gen_ximprove_gridpack(gen_ximprove_v4):
+                     'packet': None,
+                     }
++            if self.readonly:
++                basedir = pjoin(os.path.dirname(__file__), '..','..','SubProcesses', info['P_dir'], info['directory'])
++                info['base_directory'] = basedir
+
+
+             jobs.append(info)
+EOF
     fi
     
     # fix another multi-thread related bug for MG 2.6.1 only

--- a/GeneratorInterface/LHEInterface/data/runcmsgrid_LO_support_multithread.patch
+++ b/GeneratorInterface/LHEInterface/data/runcmsgrid_LO_support_multithread.patch
@@ -45,7 +45,7 @@
 @@ -98,1 +134,1 @@
 -  ./run.sh $submitting_event $run_random_seed
 +  ../process/run.sh $submitting_event $run_random_seed
-@@ -124,3 +160,53 @@
+@@ -124,3 +160,58 @@
 +cd $LHEWORKDIR
 +
 +} ### end of function
@@ -67,6 +67,11 @@
 +    nevt_per_thread[$(( $ncpu-1 ))]=$(( $nevt - ($ncpu-1)*$nevt_ave ))
 +
 +    cd $LHEWORKDIR
++
++    # first do restore_data from the gridpack (necessary for the readonly mode)
++    cd process/madevent
++    ./bin/internal/restore_data default
++    cd ../..
 +
 +    # make the gridpack directory read-only to enable the multi-threading feature
 +    if fs listacl &>/dev/null; then
@@ -90,7 +95,7 @@
 +    cd process
 +
 +    # merge files produced in different threads
-+    cp /cvmfs/cms.cern.ch/phys_generator/gridpacks/lhe_merger/merge.pl ./
++    curl -s -L -o merge.pl https://raw.githubusercontent.com/cms-sw/genproductions/master/bin/MadGraph5_aMCatNLO/Utilities/merge.pl
 +    chmod 755 merge.pl
 +    ./merge.pl ../thread*/events.lhe.gz events.lhe.gz banner.txt
 +    rm -r ../thread* banner.txt;


### PR DESCRIPTION
#### PR description:

The MadGraph5 LO multithread feature is a part of the GEN multithread utilities (it is not used in official production).
In this PR we fix several spotted issues for the MG LO multithread feature:

- apply a patch to MadGraph5 for the "readonly" gridpack mode, identified in https://answers.launchpad.net/mg5amcnlo/+question/696856 ;
- do "restore_data" manually as required by the "readonly" mode;
- use a corrected LHE merging script.

A backport to 10_6_X is also needed.

#### PR validation:

In the recent GEN efforts to validate on multiple multithreading modules, this utility has been tested on the LHE step produced by MG5 LO, for ~100 recent UL16/17 processes on McM.
Physics results are consistent between the default generator configuration and with the MG5 LO multithread feature applied. Please see plots in the [link](https://coli.web.cern.ch/coli/validation/mt-v2/LHE/nanoplot/). See [here](https://twiki.cern.ch/twiki/bin/view/CMSPublic/WorkBookGenMultithread#Internal_multithreading_for_MG5) for the configuration to activate this utility.
