### PR TITLE
RelMon: use python3

### DIFF
--- a/Utilities/RelMon/scripts/ValidationMatrix.py
+++ b/Utilities/RelMon/scripts/ValidationMatrix.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 ################################################################################
 # RelMon: a tool for automatic Release Comparison                              
 # https://twiki.cern.ch/twiki/bin/view/CMSPublic/RelMon

--- a/Utilities/RelMon/scripts/ValidationMatrix_v2.py
+++ b/Utilities/RelMon/scripts/ValidationMatrix_v2.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 """
 The script compares two releases, generates SQLite3 database file with release
 comparison information.

--- a/Utilities/RelMon/scripts/compare_using_db.py
+++ b/Utilities/RelMon/scripts/compare_using_db.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 ################################################################################
 # RelMon: a tool for automatic Release Comparison                              
 # https://twiki.cern.ch/twiki/bin/view/CMSPublic/RelMon

--- a/Utilities/RelMon/scripts/compare_using_files.py
+++ b/Utilities/RelMon/scripts/compare_using_files.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 ################################################################################
 # https://twiki.cern.ch/twiki/bin/view/CMSPublic/RelMon
 #

--- a/Utilities/RelMon/scripts/compare_using_files_v2.py
+++ b/Utilities/RelMon/scripts/compare_using_files_v2.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 """
 The script compares two ROOT files and fills specified database file with
 comparison information.

--- a/Utilities/RelMon/scripts/dir2webdir.py
+++ b/Utilities/RelMon/scripts/dir2webdir.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 ################################################################################
 # RelMon: a tool for automatic Release Comparison                              
 # https://twiki.cern.ch/twiki/bin/view/CMSPublic/RelMon

--- a/Utilities/RelMon/scripts/dqm_diff.py
+++ b/Utilities/RelMon/scripts/dqm_diff.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 '''
 Script prints out histogram names that are in one ROOT file but not in another.
 

--- a/Utilities/RelMon/scripts/fetchall_from_DQM.py
+++ b/Utilities/RelMon/scripts/fetchall_from_DQM.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 ################################################################################
 # RelMon: a tool for automatic Release Comparison
 # https://twiki.cern.ch/twiki/bin/view/CMSPublic/RelMon

--- a/Utilities/RelMon/scripts/fetchall_from_DQM_v2.py
+++ b/Utilities/RelMon/scripts/fetchall_from_DQM_v2.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 '''
 Script fetches files matching specified RegExps from DQM GUI.
 

--- a/Utilities/RelMon/scripts/relmon_authenticated_wget.py
+++ b/Utilities/RelMon/scripts/relmon_authenticated_wget.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 ################################################################################
 # RelMon: a tool for automatic Release Comparison                              
 # https://twiki.cern.ch/twiki/bin/view/CMSPublic/RelMon

--- a/Utilities/RelMon/scripts/relmon_rootfiles_spy.py
+++ b/Utilities/RelMon/scripts/relmon_rootfiles_spy.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 ################################################################################
 # RelMon: a tool for automatic Release Comparison                              
 # https://twiki.cern.ch/twiki/bin/view/CMSPublic/RelMon


### PR DESCRIPTION
Release comparison are broken as py2 ROOT has been removed ( https://github.com/cms-sw/cmssw/pull/34338#issuecomment-877651086 )