### PR TITLE
Adding LUT approach for PackedCandidates

### DIFF
--- a/DataFormats/PatCandidates/interface/PackedCandidate.h
+++ b/DataFormats/PatCandidates/interface/PackedCandidate.h
@@ -667,7 +667,7 @@ namespace pat {
                                 unsigned int nPixelHits) {
       covarianceVersion_ = covarianceVersion;
       covarianceSchema_ = covSchema;
-      packedHits_ = (nHits & trackPixelHitsMask) | (nPixelHits << trackStripHitsShift);
+      packedHits_ = (nPixelHits & trackPixelHitsMask) | ( ((nHits-nPixelHits) & trackStripHitsMask) << trackStripHitsShift);
     }
 
     int numberOfPixelHits() const { return (packedHits_ & trackPixelHitsMask) + pixelLayersWithMeasurement(); }

--- a/DataFormats/PatCandidates/interface/PackedCandidate.h
+++ b/DataFormats/PatCandidates/interface/PackedCandidate.h
@@ -661,8 +661,10 @@ namespace pat {
       setTrackProperties(tk, tk.covariance(), quality, covarianceVersion);
     }
 
-    void setTrackPropertiesLite(unsigned int covSchema, unsigned int covarianceVersion, unsigned int nHits, unsigned int nPixelHits)
-    {
+    void setTrackPropertiesLite(unsigned int covSchema,
+                                unsigned int covarianceVersion,
+                                unsigned int nHits,
+                                unsigned int nPixelHits) {
       covarianceVersion_ = covarianceVersion;
       covarianceSchema_ = covSchema;
       packedHits_ = (nHits & trackPixelHitsMask) | (nPixelHits << trackStripHitsShift);

--- a/DataFormats/PatCandidates/interface/PackedCandidate.h
+++ b/DataFormats/PatCandidates/interface/PackedCandidate.h
@@ -661,6 +661,13 @@ namespace pat {
       setTrackProperties(tk, tk.covariance(), quality, covarianceVersion);
     }
 
+    void setTrackPropertiesLite(unsigned int covSchema, unsigned int covarianceVersion, unsigned int nHits, unsigned int nPixelHits)
+    {
+      covarianceVersion_ = covarianceVersion;
+      covarianceSchema_ = covSchema;
+      packedHits_ = (nHits & trackPixelHitsMask) | (nPixelHits << trackStripHitsShift);
+    }
+
     int numberOfPixelHits() const { return (packedHits_ & trackPixelHitsMask) + pixelLayersWithMeasurement(); }
     int numberOfHits() const {
       return (packedHits_ >> trackStripHitsShift) + stripLayersWithMeasurement() + numberOfPixelHits();

--- a/DataFormats/PatCandidates/interface/PackedCandidate.h
+++ b/DataFormats/PatCandidates/interface/PackedCandidate.h
@@ -667,7 +667,8 @@ namespace pat {
                                 unsigned int nPixelHits) {
       covarianceVersion_ = covarianceVersion;
       covarianceSchema_ = covSchema;
-      packedHits_ = (nPixelHits & trackPixelHitsMask) | ( ((nHits-nPixelHits) & trackStripHitsMask) << trackStripHitsShift);
+      packedHits_ =
+          (nPixelHits & trackPixelHitsMask) | (((nHits - nPixelHits) & trackStripHitsMask) << trackStripHitsShift);
     }
 
     int numberOfPixelHits() const { return (packedHits_ & trackPixelHitsMask) + pixelLayersWithMeasurement(); }
@@ -799,7 +800,7 @@ namespace pat {
     bool hasTrackDetails() const { return (packedHits_ != 0 || packedLayers_ != 0); }
     /// Return true if the original candidate had a track associated
     /// even if the PackedCandidate has no track
-    bool fromTrackCandidate() const { return (packedDz_ != 0 || (packedDxy_ != 0 && packedDxy_ != 32768) ); }
+    bool fromTrackCandidate() const { return (packedDz_ != 0 || (packedDxy_ != 0 && packedDxy_ != 32768)); }
     /// true if the track had the highPurity quality bit
     bool trackHighPurity() const { return (qualityFlags_ & trackHighPurityMask) >> trackHighPurityShift; }
     /// set to true if the track had the highPurity quality bit

--- a/DataFormats/PatCandidates/interface/PackedCandidate.h
+++ b/DataFormats/PatCandidates/interface/PackedCandidate.h
@@ -751,6 +751,7 @@ namespace pat {
       maybeUnpackBoth();
       return dxy_;
     }
+
     /// dz with respect to the PV[ipv]
     virtual float dz(size_t ipv = 0) const {
       maybeUnpackBoth();
@@ -761,6 +762,7 @@ namespace pat {
       maybeUnpackBoth();
       return dz_;
     }
+
     /// dxy with respect to another point
     virtual float dxy(const Point &p) const;
     /// dz  with respect to another point
@@ -795,7 +797,9 @@ namespace pat {
     }
     /// Return true if a bestTrack can be extracted from this Candidate
     bool hasTrackDetails() const { return (packedHits_ != 0 || packedLayers_ != 0); }
-
+    /// Return true if the original candidate had a track associated
+    /// even if the PackedCandidate has no track
+    bool fromTrackCandidate() const { return (packedDz_ != 0 || packedDxy_ != 0); }
     /// true if the track had the highPurity quality bit
     bool trackHighPurity() const { return (qualityFlags_ & trackHighPurityMask) >> trackHighPurityShift; }
     /// set to true if the track had the highPurity quality bit

--- a/DataFormats/PatCandidates/interface/PackedCandidate.h
+++ b/DataFormats/PatCandidates/interface/PackedCandidate.h
@@ -799,7 +799,7 @@ namespace pat {
     bool hasTrackDetails() const { return (packedHits_ != 0 || packedLayers_ != 0); }
     /// Return true if the original candidate had a track associated
     /// even if the PackedCandidate has no track
-    bool fromTrackCandidate() const { return (packedDz_ != 0 || packedDxy_ != 0); }
+    bool fromTrackCandidate() const { return (packedDz_ != 0 || (packedDxy_ != 0 && packedDxy_ != 32768) ); }
     /// true if the track had the highPurity quality bit
     bool trackHighPurity() const { return (qualityFlags_ & trackHighPurityMask) >> trackHighPurityShift; }
     /// set to true if the track had the highPurity quality bit

--- a/PhysicsTools/PatUtils/plugins/LUTPackedCandidatesProducer.cc
+++ b/PhysicsTools/PatUtils/plugins/LUTPackedCandidatesProducer.cc
@@ -36,7 +36,6 @@ LUTPackedCandidatesProducer::LUTPackedCandidatesProducer(const edm::ParameterSet
       covVersion_(iConfig.getParameter<unsigned int>("covVersion")),
       nHits_(iConfig.getParameter<unsigned int>("nHits")),
       nPixelHits_(iConfig.getParameter<unsigned int>("nPixelHits")) {
-
   outputCandidates_ = produces<pat::PackedCandidateCollection>("");
 }
 
@@ -56,7 +55,7 @@ void LUTPackedCandidatesProducer::produce(edm::StreamID, edm::Event &iEvent, con
       output.back().setTrackPropertiesLite(covSchema_, covVersion_, nHits_, nPixelHits_);
   }
 
-  iEvent.emplace(outputCandidates_,std::move(output));
+  iEvent.emplace(outputCandidates_, std::move(output));
 };
 
 void LUTPackedCandidatesProducer::fillDescriptions(edm::ConfigurationDescriptions &descriptions) {

--- a/PhysicsTools/PatUtils/plugins/LUTPackedCandidatesProducer.cc
+++ b/PhysicsTools/PatUtils/plugins/LUTPackedCandidatesProducer.cc
@@ -11,55 +11,48 @@
 
 class LUTPackedCandidatesProducer : public edm::global::EDProducer<> {
 public:
-  explicit LUTPackedCandidatesProducer(const edm::ParameterSet&);
+  explicit LUTPackedCandidatesProducer(const edm::ParameterSet &);
   ~LUTPackedCandidatesProducer() override;
-
 
   void produce(edm::StreamID, edm::Event &, const edm::EventSetup &) const override;
 
 private:
-
   const edm::EDGetTokenT<pat::PackedCandidateCollection> inputCandidates_;
 
   const unsigned int covSchema_;
   const unsigned int covarianceVersion_;
   const unsigned int nHits_;
   const unsigned int nPixelHits_;
-
 };
 
 //____________________________________________________________________________||
-LUTPackedCandidatesProducer::LUTPackedCandidatesProducer(const edm::ParameterSet& iConfig)
-      :
-      inputCandidates_(consumes<pat::PackedCandidateCollection>(iConfig.getParameter<edm::InputTag>("inputCandidates"))),
+LUTPackedCandidatesProducer::LUTPackedCandidatesProducer(const edm::ParameterSet &iConfig)
+    : inputCandidates_(
+          consumes<pat::PackedCandidateCollection>(iConfig.getParameter<edm::InputTag>("inputCandidates"))),
       covSchema_(iConfig.getParameter<unsigned int>("covSchema")),
       covarianceVersion_(iConfig.getParameter<unsigned int>("covarianceVersion")),
       nHits_(iConfig.getParameter<unsigned int>("nHits")),
-      nPixelHits_(iConfig.getParameter<unsigned int>("nPixelHits"))
-      {
-        produces<pat::PackedCandidateCollection>("");
-    }
-
+      nPixelHits_(iConfig.getParameter<unsigned int>("nPixelHits")) {
+  produces<pat::PackedCandidateCollection>("");
+}
 
 LUTPackedCandidatesProducer::~LUTPackedCandidatesProducer() {}
 
 void LUTPackedCandidatesProducer::produce(edm::StreamID, edm::Event &iEvent, const edm::EventSetup &iSetup) const {
+  edm::Handle<pat::PackedCandidateCollection> packedCandidates;
+  iEvent.getByToken(inputCandidates_, packedCandidates);
 
-    edm::Handle<pat::PackedCandidateCollection> packedCandidates;
-    iEvent.getByToken(inputCandidates_, packedCandidates);
-s
-    auto output = std::make_unique<pat::PackedCandidateCollection>();
+  auto output = std::make_unique<pat::PackedCandidateCollection>();
 
-    for (unsigned int ic = 0, nc = packedCandidates->size(); ic < nc; ++ic) {
+  for (unsigned int ic = 0, nc = packedCandidates->size(); ic < nc; ++ic) {
+    const pat::PackedCandidate &cand = (*packedCandidates)[ic];
+    output->push_back(pat::PackedCandidate(cand));
 
-      const pat::PackedCandidate &cand = (*packedCandidates)[ic];
-      output->push_back(pat::PackedCandidate(cand));
+    if (!output->back().hasTrackDetails())
+      output->back().setTrackPropertiesLite(covSchema_, covarianceVersion_, nHits_, nPixelHits_);
+  }
 
-      if(!output->back().hasTrackDetails())
-        output->back().setTrackPropertiesLite(covSchema_,covarianceVersion_,nHits_,nPixelHits_);
-    }
-
-    iEvent.put(std::move(output));
+  iEvent.put(std::move(output));
 };
 
 //____________________________________________________________________________||

--- a/PhysicsTools/PatUtils/plugins/LUTPackedCandidatesProducer.cc
+++ b/PhysicsTools/PatUtils/plugins/LUTPackedCandidatesProducer.cc
@@ -2,8 +2,10 @@
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "FWCore/Framework/interface/global/EDProducer.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 
 #include "DataFormats/PatCandidates/interface/PackedCandidate.h"
 
@@ -15,12 +17,13 @@ public:
   ~LUTPackedCandidatesProducer() override;
 
   void produce(edm::StreamID, edm::Event &, const edm::EventSetup &) const override;
+  static void fillDescriptions(edm::ConfigurationDescriptions &descriptions);
 
 private:
   const edm::EDGetTokenT<pat::PackedCandidateCollection> inputCandidates_;
 
   const unsigned int covSchema_;
-  const unsigned int covarianceVersion_;
+  const unsigned int covVersion_;
   const unsigned int nHits_;
   const unsigned int nPixelHits_;
 };
@@ -30,7 +33,7 @@ LUTPackedCandidatesProducer::LUTPackedCandidatesProducer(const edm::ParameterSet
     : inputCandidates_(
           consumes<pat::PackedCandidateCollection>(iConfig.getParameter<edm::InputTag>("inputCandidates"))),
       covSchema_(iConfig.getParameter<unsigned int>("covSchema")),
-      covarianceVersion_(iConfig.getParameter<unsigned int>("covarianceVersion")),
+      covVersion_(iConfig.getParameter<unsigned int>("covVersion")),
       nHits_(iConfig.getParameter<unsigned int>("nHits")),
       nPixelHits_(iConfig.getParameter<unsigned int>("nPixelHits")) {
   produces<pat::PackedCandidateCollection>("");
@@ -49,11 +52,23 @@ void LUTPackedCandidatesProducer::produce(edm::StreamID, edm::Event &iEvent, con
     output->push_back(pat::PackedCandidate(cand));
 
     if (!output->back().hasTrackDetails())
-      output->back().setTrackPropertiesLite(covSchema_, covarianceVersion_, nHits_, nPixelHits_);
+      output->back().setTrackPropertiesLite(covSchema_, covVersion_, nHits_, nPixelHits_);
   }
 
   iEvent.put(std::move(output));
 };
+
+void LUTPackedCandidatesProducer::fillDescriptions(edm::ConfigurationDescriptions &descriptions) {
+  edm::ParameterSetDescription desc;
+
+  desc.add<edm::InputTag>("inputCandidates", edm::InputTag("packedPFCandidates"));
+  desc.add<unsigned int>("covSchema", 523);
+  desc.add<unsigned int>("covVersion", 1);
+  desc.add<unsigned int>("nHits", 8);
+  desc.add<unsigned int>("nPixelHits", 3);
+
+  descriptions.addWithDefaultLabel(desc);
+}
 
 //____________________________________________________________________________||
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/PhysicsTools/PatUtils/plugins/LUTPackedCandidatesProducer.cc
+++ b/PhysicsTools/PatUtils/plugins/LUTPackedCandidatesProducer.cc
@@ -51,7 +51,7 @@ void LUTPackedCandidatesProducer::produce(edm::StreamID, edm::Event &iEvent, con
     const pat::PackedCandidate &cand = (*packedCandidates)[ic];
     output->push_back(pat::PackedCandidate(cand));
 
-    if (!output->back().hasTrackDetails())
+    if (!output->back().hasTrackDetails() && output->back().covarianceVersion() == int(covVersion_))
       output->back().setTrackPropertiesLite(covSchema_, covVersion_, nHits_, nPixelHits_);
   }
 

--- a/PhysicsTools/PatUtils/plugins/LUTPackedCandidatesProducer.cc
+++ b/PhysicsTools/PatUtils/plugins/LUTPackedCandidatesProducer.cc
@@ -1,0 +1,67 @@
+#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
+
+#include "DataFormats/PatCandidates/interface/PackedCandidate.h"
+
+#include <vector>
+
+class LUTPackedCandidatesProducer : public edm::global::EDProducer<> {
+public:
+  explicit LUTPackedCandidatesProducer(const edm::ParameterSet&);
+  ~LUTPackedCandidatesProducer() override;
+
+
+  void produce(edm::StreamID, edm::Event &, const edm::EventSetup &) const override;
+
+private:
+
+  const edm::EDGetTokenT<pat::PackedCandidateCollection> inputCandidates_;
+
+  const unsigned int covSchema_;
+  const unsigned int covarianceVersion_;
+  const unsigned int nHits_;
+  const unsigned int nPixelHits_;
+
+};
+
+//____________________________________________________________________________||
+LUTPackedCandidatesProducer::LUTPackedCandidatesProducer(const edm::ParameterSet& iConfig)
+      :
+      inputCandidates_(consumes<pat::PackedCandidateCollection>(iConfig.getParameter<edm::InputTag>("inputCandidates"))),
+      covSchema_(iConfig.getParameter<unsigned int>("covSchema")),
+      covarianceVersion_(iConfig.getParameter<unsigned int>("covarianceVersion")),
+      nHits_(iConfig.getParameter<unsigned int>("nHits")),
+      nPixelHits_(iConfig.getParameter<unsigned int>("nPixelHits"))
+      {
+        produces<pat::PackedCandidateCollection>("");
+    }
+
+
+LUTPackedCandidatesProducer::~LUTPackedCandidatesProducer() {}
+
+void LUTPackedCandidatesProducer::produce(edm::StreamID, edm::Event &iEvent, const edm::EventSetup &iSetup) const {
+
+    edm::Handle<pat::PackedCandidateCollection> packedCandidates;
+    iEvent.getByToken(inputCandidates_, packedCandidates);
+s
+    auto output = std::make_unique<pat::PackedCandidateCollection>();
+
+    for (unsigned int ic = 0, nc = packedCandidates->size(); ic < nc; ++ic) {
+
+      const pat::PackedCandidate &cand = (*packedCandidates)[ic];
+      output->push_back(pat::PackedCandidate(cand));
+
+      if(!output->back().hasTrackDetails())
+        output->back().setTrackPropertiesLite(covSchema_,covarianceVersion_,nHits_,nPixelHits_);
+    }
+
+    iEvent.put(std::move(output));
+};
+
+//____________________________________________________________________________||
+#include "FWCore/Framework/interface/MakerMacros.h"
+DEFINE_FWK_MODULE(LUTPackedCandidatesProducer);

--- a/PhysicsTools/PatUtils/plugins/PackedCandidatesTrackLiteModifier.cc
+++ b/PhysicsTools/PatUtils/plugins/PackedCandidatesTrackLiteModifier.cc
@@ -59,7 +59,7 @@ void PackedCandidatesTrackLiteModifier::fillDescriptions(edm::ConfigurationDescr
   edm::ParameterSetDescription desc;
 
   desc.add<edm::InputTag>("inputCandidates", edm::InputTag("packedPFCandidates"));
-  desc.add<unsigned int>("covSchema", 523);
+  desc.add<unsigned int>("covSchema", 1025);
   desc.add<unsigned int>("covVersion", 1);
   desc.add<unsigned int>("nHits", 8);
   desc.add<unsigned int>("nPixelHits", 3);

--- a/PhysicsTools/PatUtils/plugins/PackedCandidatesTrackLiteModifier.cc
+++ b/PhysicsTools/PatUtils/plugins/PackedCandidatesTrackLiteModifier.cc
@@ -36,19 +36,19 @@ PackedCandidatesTrackLiteModifier::PackedCandidatesTrackLiteModifier(const edm::
       covSchema_(iConfig.getParameter<unsigned int>("covSchema")),
       covVersion_(iConfig.getParameter<unsigned int>("covVersion")),
       nHits_(iConfig.getParameter<unsigned int>("nHits")),
-      nPixelHits_(iConfig.getParameter<unsigned int>("nPixelHits")) {
-}
+      nPixelHits_(iConfig.getParameter<unsigned int>("nPixelHits")) {}
 
-void PackedCandidatesTrackLiteModifier::produce(edm::StreamID, edm::Event &iEvent, const edm::EventSetup &iSetup) const {
-
-  auto const& packedCandidates = iEvent.get(inputCandidates_);
+void PackedCandidatesTrackLiteModifier::produce(edm::StreamID,
+                                                edm::Event &iEvent,
+                                                const edm::EventSetup &iSetup) const {
+  auto const &packedCandidates = iEvent.get(inputCandidates_);
 
   pat::PackedCandidateCollection output;
   output.reserve(packedCandidates.size());
-  for (auto const& cand: packedCandidates) {
+  for (auto const &cand : packedCandidates) {
     output.push_back(pat::PackedCandidate(cand));
 
-    if (!output.back().hasTrackDetails() && output.back().covarianceVersion() == int(covVersion_))
+    if (!output.back().hasTrackDetails() && output.back().fromTrackCandidate())
       output.back().setTrackPropertiesLite(covSchema_, covVersion_, nHits_, nPixelHits_);
   }
 


### PR DESCRIPTION
#### PR description:

This PR adds `setTrackPropertiesLite` to  `PackedCandidate`   to set custom track properties when no track is associated to the candidate. The `LUTPackedCandidatesProducer` uses this method to produce a new collection from the original `packedPFCandidates` in miniAODs.  Further discussion in https://github.com/cms-sw/cmssw/pull/33622. 

This PR would need https://github.com/cms-data/DataFormats-PatCandidates/pull/2 to be integrated to properly run.
