### PR TITLE
Bugfix: pick right jet collection for Type1 PUPPI MET when reapplying JECs

### DIFF
--- a/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
+++ b/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
@@ -1535,7 +1535,7 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
         from PhysicsTools.PatAlgos.producersLayer1.jetUpdater_cff import updatedPatJetCorrFactors
 
         patJetCorrFactorsReapplyJEC = updatedPatJetCorrFactors.clone(
-            src = jetCollection,
+            src = jetCollection if not self._parameters["Puppi"].value else cms.InputTag("slimmedJetsPuppi"),
             levels = ['L1FastJet',
                       'L2Relative',
                       'L3Absolute'],
@@ -1546,7 +1546,7 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
 
         from PhysicsTools.PatAlgos.producersLayer1.jetUpdater_cff import updatedPatJets
         patJetsReapplyJEC = updatedPatJets.clone(
-            jetSource = jetCollection,
+            jetSource = jetCollection if not self._parameters["Puppi"].value else cms.InputTag("slimmedJetsPuppi"),
             jetCorrFactorsSource = cms.VInputTag(cms.InputTag("patJetCorrFactorsReapplyJEC"+postfix))
             )
 


### PR DESCRIPTION
#### PR description:
A difference between 10_6_X and master  was observed by @gouskos @mariadalfonso for the Type1 PUPPI MET in NANOAOD.
After some investigation it looks like the wrong jet collection (CHS jets, instead of PUPPI jets) is used in master while the proper one is used in 106X. 
https://github.com/cms-sw/cmssw/blob/CMSSW_10_6_X/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py#L1564
This PR corrects this

#### PR validation:

It was checked that PUPPI MET agrees between 106X and master in NANOAOD after the fix. 
runTheMatrix was successfully run on two workflows (reMINIAOD and reNANOAOD) 
