### PR TITLE
Introduce `SiPixelDynamicInefficiency` payload inspector

### DIFF
--- a/CalibTracker/SiPixelESProducers/interface/SiPixelDetInfoFileReader.h
+++ b/CalibTracker/SiPixelESProducers/interface/SiPixelDetInfoFileReader.h
@@ -33,6 +33,10 @@ public:
   const std::vector<uint32_t>& getAllDetIds() const;
   const std::pair<int, int>& getDetUnitDimensions(uint32_t detId) const;
 
+  constexpr static char const* const kPh0DefaultFile = "CalibTracker/SiPixelESProducers/data/PixelSkimmedGeometry.txt";
+  constexpr static char const* const kPh1DefaultFile =
+      "SLHCUpgradeSimulations/Geometry/data/PhaseI/PixelSkimmedGeometry_phase1.txt";
+
 private:
   std::ifstream inputFile_;
   //  std::string filePath_;

--- a/CondCore/SiPixelPlugins/README.md
+++ b/CondCore/SiPixelPlugins/README.md
@@ -15,6 +15,7 @@ The available inspectors are:
 | `SiPixelQualityFromDbRcd`             | `SiPixelQuality`                | [SiPixelQuality_PayloadInspector.cc](https://github.com/cms-sw/cmssw/blob/master/CondCore/SiPixelPlugins/plugins/SiPixelQuality_PayloadInspector.cc)                |
 | `SiPixelStatusScenarioProbabilityRcd` | `SiPixelQualityProbabilities`   | [SiPixelQualityProbabilities_PayloadInspector.cc](https://github.com/cms-sw/cmssw/blob/master/CondCore/SiPixelPlugins/plugins/SiPixelQualityProbabilities_PayloadInspector.cc)   |
 | `SiPixelStatusScenariosRcd`           | `SiPixelFEDChannelContainer`    | [SiPixelFEDChannelContainer_PayloadInspector.cc](https://github.com/cms-sw/cmssw/blob/master/CondCore/SiPixelPlugins/plugins/SiPixelFEDChannelContainer_PayloadInspector.cc)    |
+| `SiPixelDynamicInefficiencyRcd`       | `SiPixelDynamicInefficiency`    | [SiPixelDynamicInefficiency_PayloadInspector.cc](https://github.com/cms-sw/cmssw/blob/master/CondCore/SiPixelPlugins/plugins/SiPixelDynamicInefficiency_PayloadInspector.cc)  |
 
 Plots will be shown within the **cmsDbBrowser** [payload inspector](https://cms-conddb.cern.ch/cmsDbBrowser/payload_inspector/Prod) application.
 In the `CondCore/SiPixelPlugins/test` directory a few bash scripts to inspect conditions from command line are available.

--- a/CondCore/SiPixelPlugins/plugins/BuildFile.xml
+++ b/CondCore/SiPixelPlugins/plugins/BuildFile.xml
@@ -75,6 +75,14 @@
   <use name="DQM/TrackerRemapper"/>
 </library>
 
+<library file="SiPixelDynamicInefficiency_PayloadInspector.cc" name="SiPixelDynamicInefficiency_PayloadInspector">
+  <use name="CondCore/SiPixelPlugins"/>
+  <use name="CondCore/Utilities"/>
+  <use name="CondCore/CondDB"/>
+  <use name="DQM/TrackerRemapper"/>
+  <use name="CalibTracker/StandaloneTrackerTopology"/>
+</library>
+
 <library file="plugin.cc" name="CondCoreSiPixelPluginsPlugin">
   <flags EDM_PLUGIN="1"/>
   <use name="CondCore/ESSources"/>

--- a/CondCore/SiPixelPlugins/plugins/SiPixelDynamicInefficiency_PayloadInspector.cc
+++ b/CondCore/SiPixelPlugins/plugins/SiPixelDynamicInefficiency_PayloadInspector.cc
@@ -1,0 +1,386 @@
+/*!
+  \file SiPixelDynamicInefficiency_PayloadInspector
+  \Payload Inspector Plugin for SiPixelDynamicInefficiency
+  \author M. Musich
+  \version $Revision: 1.0 $
+  \date $Date: 2018/10/18 14:48:00 $
+*/
+
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+#include "CondCore/Utilities/interface/PayloadInspectorModule.h"
+#include "CondCore/Utilities/interface/PayloadInspector.h"
+#include "CondCore/CondDB/interface/Time.h"
+#include "CondCore/SiPixelPlugins/interface/SiPixelPayloadInspectorHelper.h"
+#include "FWCore/ParameterSet/interface/FileInPath.h"
+#include "CalibTracker/StandaloneTrackerTopology/interface/StandaloneTrackerTopology.h"
+#include "CalibTracker/SiPixelESProducers/interface/SiPixelDetInfoFileReader.h"
+
+// the data format of the condition to be inspected
+#include "CondFormats/SiPixelObjects/interface/SiPixelDynamicInefficiency.h"
+#include "DataFormats/SiPixelDetId/interface/PixelSubdetector.h"
+#include "DataFormats/DetId/interface/DetId.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "DQM/TrackerRemapper/interface/Phase1PixelROCMaps.h"
+
+#include <memory>
+#include <sstream>
+#include <iostream>
+
+// include ROOT
+#include "TH2F.h"
+#include "TLegend.h"
+#include "TCanvas.h"
+#include "TLine.h"
+#include "TGraph.h"
+#include "TStyle.h"
+#include "TLatex.h"
+#include "TPave.h"
+#include "TPaveStats.h"
+
+namespace {
+
+  using namespace cond::payloadInspector;
+
+  const std::string k_Ph0_geo = "CalibTracker/SiPixelESProducers/data/PixelSkimmedGeometry.txt";
+  const std::string k_Ph1_geo = "SLHCUpgradeSimulations/Geometry/data/PhaseI/PixelSkimmedGeometry_phase1.txt";
+
+  namespace SiPixDynIneff {
+
+    // constants for ROC level simulation for Phase1
+    enum shiftEnumerator { FPixRocIdShift = 3, BPixRocIdShift = 6 };
+    static const int rocIdMaskBits = 0x1F;
+
+    struct packedBadRocFraction {
+      std::vector<int> badRocNumber;
+      std::vector<float> badRocFrac;
+    };
+
+    using BRFractions = std::unordered_map<uint32_t, packedBadRocFraction>;
+
+    //_________________________________________________
+    BRFractions pbrf(std::shared_ptr<SiPixelDynamicInefficiency> payload) {
+      BRFractions f;
+      const std::map<uint32_t, double>& PixelGeomFactorsDBIn = payload->getPixelGeomFactors();
+
+      // first fill
+      for (const auto db_factor : PixelGeomFactorsDBIn) {
+        int subid = DetId(db_factor.first).subdetId();
+        int shift = (subid == static_cast<int>(PixelSubdetector::PixelBarrel)) ? BPixRocIdShift : FPixRocIdShift;
+        unsigned int rocMask = rocIdMaskBits << shift;
+        unsigned int rocId = (((db_factor.first) & rocMask) >> shift);
+        uint32_t rawid = db_factor.first & (~rocMask);
+
+        if (f.find(rawid) == f.end()) {
+          packedBadRocFraction p;
+          f.insert(std::make_pair(rawid, p));
+        }
+
+        if (rocId != 0) {
+          rocId--;
+          double factor = db_factor.second;
+          double badFraction = 1 - factor;
+
+          f.at(rawid).badRocNumber.emplace_back(rocId);
+          f.at(rawid).badRocFrac.emplace_back(badFraction);
+        }
+      }
+      return f;
+    }
+
+    //_________________________________________________
+    bool isPhase0(const BRFractions& fractions) {
+      SiPixelDetInfoFileReader reader = SiPixelDetInfoFileReader(edm::FileInPath(k_Ph0_geo).fullPath());
+      const auto& p0detIds = reader.getAllDetIds();
+      std::vector<uint32_t> ownDetIds;
+
+      std::transform(fractions.begin(),
+                     fractions.end(),
+                     std::back_inserter(ownDetIds),
+                     [](std::pair<uint32_t, packedBadRocFraction> d) -> uint32_t { return d.first; });
+
+      for (const auto& det : ownDetIds) {
+        // if found at least one phase-0 detId early return
+        if (std::find(p0detIds.begin(), p0detIds.end(), det) != p0detIds.end()) {
+          return true;
+        }
+      }
+      return false;
+    }
+  }  // namespace SiPixDynIneff
+
+  /************************************************
+    test class
+  *************************************************/
+
+  class SiPixelDynamicInefficiencyTest : public Histogram1D<SiPixelDynamicInefficiency, SINGLE_IOV> {
+  public:
+    SiPixelDynamicInefficiencyTest()
+        : Histogram1D<SiPixelDynamicInefficiency, SINGLE_IOV>(
+              "SiPixelDynamicInefficiency test", "SiPixelDynamicInefficiency test", 1, 0.0, 1.0) {}
+
+    bool fill() override {
+      auto tag = PlotBase::getTag<0>();
+      for (auto const& iov : tag.iovs) {
+        std::shared_ptr<SiPixelDynamicInefficiency> payload = Base::fetchPayload(std::get<1>(iov));
+        if (payload.get()) {
+          fillWithValue(1.);
+
+          const auto geomFactors = payload->getPixelGeomFactors();
+          for (const auto [ID, value] : geomFactors) {
+            std::cout << ID << " : " << value << std::endl;
+            ;
+          }
+        }  // payload
+      }    // iovs
+      return true;
+    }  // fill
+  };
+
+  /************************************************
+   occupancy style map whole Pixel of inefficient ROCs
+  *************************************************/
+  template <SiPixelPI::DetType myType>
+  class SiPixelIneffROCfromDynIneffMap : public PlotImage<SiPixelDynamicInefficiency, SINGLE_IOV> {
+  public:
+    SiPixelIneffROCfromDynIneffMap()
+        : PlotImage<SiPixelDynamicInefficiency, SINGLE_IOV>("SiPixel Inefficient ROC from Dyn Ineff Pixel Map"),
+          m_trackerTopo{StandaloneTrackerTopology::fromTrackerParametersXMLFile(
+              edm::FileInPath("Geometry/TrackerCommonData/data/PhaseI/trackerParameters.xml").fullPath())} {}
+
+    bool fill() override {
+      auto tag = PlotBase::getTag<0>();
+      auto iov = tag.iovs.front();
+      auto tagname = tag.name;
+      std::shared_ptr<SiPixelDynamicInefficiency> payload = fetchPayload(std::get<1>(iov));
+
+      const auto fr = SiPixDynIneff::pbrf(payload);
+
+      if (SiPixDynIneff::isPhase0(fr)) {
+        edm::LogError("SiPixelDynamicInefficiency_PayloadInspector")
+            << "SiPixelIneffROCfromDynIneff maps are not supported for non-Phase1 Pixel geometries !";
+        TCanvas canvas("Canv", "Canv", 1200, 1000);
+        SiPixelPI::displayNotSupported(canvas, 0);
+        std::string fileName(m_imageFileName);
+        canvas.SaveAs(fileName.c_str());
+        return false;
+      }
+
+      Phase1PixelROCMaps theMap("", "bad pixel fraction in ROC [%]");
+
+      for (const auto& element : fr) {
+        auto rawid = element.first;
+        int subid = DetId(rawid).subdetId();
+        auto packedinfo = element.second;
+        auto badRocs = packedinfo.badRocNumber;
+        auto badRocsF = packedinfo.badRocFrac;
+
+        for (size_t i = 0; i < badRocs.size(); i++) {
+          std::bitset<16> rocToMark;
+          rocToMark.set(badRocs[i]);
+          if ((subid == PixelSubdetector::PixelBarrel && myType == SiPixelPI::t_barrel) ||
+              (subid == PixelSubdetector::PixelEndcap && myType == SiPixelPI::t_forward) ||
+              (myType == SiPixelPI::t_all)) {
+            theMap.fillSelectedRocs(rawid, rocToMark, badRocsF[i] * 100.f);
+          }
+        }
+      }
+
+      gStyle->SetOptStat(0);
+      //=========================
+      TCanvas canvas("Summary", "Summary", 1200, k_height[myType]);
+      canvas.cd();
+
+      auto unpacked = SiPixelPI::unpack(std::get<0>(iov));
+
+      std::string IOVstring = (unpacked.first == 0)
+                                  ? std::to_string(unpacked.second)
+                                  : (std::to_string(unpacked.first) + "," + std::to_string(unpacked.second));
+
+      const auto headerText = fmt::sprintf("#color[4]{%s},  IOV: #color[4]{%s}", tagname, IOVstring);
+
+      switch (myType) {
+        case SiPixelPI::t_barrel:
+          theMap.drawBarrelMaps(canvas, headerText);
+          break;
+        case SiPixelPI::t_forward:
+          theMap.drawForwardMaps(canvas, headerText);
+          break;
+        case SiPixelPI::t_all:
+          theMap.drawMaps(canvas, headerText);
+          break;
+        default:
+          throw cms::Exception("SiPixelIneffROCfromDynIneffMap")
+              << "\nERROR: unrecognized Pixel Detector part " << std::endl;
+      }
+
+      std::string fileName(m_imageFileName);
+      canvas.SaveAs(fileName.c_str());
+#ifdef MMDEBUG
+      canvas.SaveAs("outAll.root");
+#endif
+
+      return true;
+    }
+
+  private:
+    static constexpr std::array<int, 3> k_height = {{1200, 600, 1600}};
+    TrackerTopology m_trackerTopo;
+  };
+
+  using SiPixelBPixIneffROCfromDynIneffMap = SiPixelIneffROCfromDynIneffMap<SiPixelPI::t_barrel>;
+  using SiPixelFPixIneffROCfromDynIneffMap = SiPixelIneffROCfromDynIneffMap<SiPixelPI::t_forward>;
+  using SiPixelFullIneffROCfromDynIneffMap = SiPixelIneffROCfromDynIneffMap<SiPixelPI::t_all>;
+
+  /************************************************
+   occupancy style map whole Pixel, difference of payloads
+  *************************************************/
+  template <SiPixelPI::DetType myType, IOVMultiplicity nIOVs, int ntags>
+  class SiPixelIneffROCComparisonBase : public PlotImage<SiPixelDynamicInefficiency, nIOVs, ntags> {
+  public:
+    SiPixelIneffROCComparisonBase()
+        : PlotImage<SiPixelDynamicInefficiency, nIOVs, ntags>(
+              Form("SiPixelDynamicInefficiency %s Pixel Map", SiPixelPI::DetNames[myType].c_str())),
+          m_trackerTopo{StandaloneTrackerTopology::fromTrackerParametersXMLFile(
+              edm::FileInPath("Geometry/TrackerCommonData/data/PhaseI/trackerParameters.xml").fullPath())} {}
+
+    bool fill() override {
+      // trick to deal with the multi-ioved tag and two tag case at the same time
+      auto theIOVs = PlotBase::getTag<0>().iovs;
+      auto f_tagname = PlotBase::getTag<0>().name;
+      std::string l_tagname = "";
+      auto firstiov = theIOVs.front();
+      std::tuple<cond::Time_t, cond::Hash> lastiov;
+
+      // we don't support (yet) comparison with more than 2 tags
+      assert(this->m_plotAnnotations.ntags < 3);
+
+      if (this->m_plotAnnotations.ntags == 2) {
+        auto tag2iovs = PlotBase::getTag<1>().iovs;
+        l_tagname = PlotBase::getTag<1>().name;
+        lastiov = tag2iovs.front();
+      } else {
+        lastiov = theIOVs.back();
+      }
+
+      std::shared_ptr<SiPixelDynamicInefficiency> last_payload = this->fetchPayload(std::get<1>(lastiov));
+      std::shared_ptr<SiPixelDynamicInefficiency> first_payload = this->fetchPayload(std::get<1>(firstiov));
+
+      const auto fp = SiPixDynIneff::pbrf(last_payload);
+      const auto lp = SiPixDynIneff::pbrf(first_payload);
+
+      if (SiPixDynIneff::isPhase0(fp) || SiPixDynIneff::isPhase0(lp)) {
+        edm::LogError("SiPixelDynamicInefficiency_PayloadInspector")
+            << "SiPixelDynamicInefficiency comparison maps are not supported for non-Phase1 Pixel geometries !";
+        TCanvas canvas("Canv", "Canv", 1200, 1000);
+        SiPixelPI::displayNotSupported(canvas, 0);
+        std::string fileName(this->m_imageFileName);
+        canvas.SaveAs(fileName.c_str());
+        return false;
+      }
+
+      Phase1PixelROCMaps theMap("", "#Delta payload A - payload B");
+
+      gStyle->SetOptStat(0);
+      //=========================
+      TCanvas canvas("Summary", "Summary", 1200, k_height[myType]);
+      canvas.cd();
+
+      auto f_unpacked = SiPixelPI::unpack(std::get<0>(firstiov));
+      auto l_unpacked = SiPixelPI::unpack(std::get<0>(lastiov));
+
+      std::string f_IOVstring = (f_unpacked.first == 0)
+                                    ? std::to_string(f_unpacked.second)
+                                    : (std::to_string(f_unpacked.first) + "," + std::to_string(f_unpacked.second));
+
+      std::string l_IOVstring = (l_unpacked.first == 0)
+                                    ? std::to_string(l_unpacked.second)
+                                    : (std::to_string(l_unpacked.first) + "," + std::to_string(l_unpacked.second));
+
+      std::string headerText;
+
+      if (this->m_plotAnnotations.ntags == 2) {
+        headerText = fmt::sprintf(
+            "#Delta #color[2]{A: %s, %s} - #color[4]{B: %s, %s}", f_tagname, f_IOVstring, l_tagname, l_IOVstring);
+      } else {
+        headerText =
+            fmt::sprintf("%s, #Delta IOV #color[2]{A: %s} - #color[4]{B: %s} ", f_tagname, f_IOVstring, l_IOVstring);
+      }
+
+      switch (myType) {
+        case SiPixelPI::t_barrel:
+          theMap.drawBarrelMaps(canvas, headerText);
+          break;
+        case SiPixelPI::t_forward:
+          theMap.drawForwardMaps(canvas, headerText);
+          break;
+        case SiPixelPI::t_all:
+          theMap.drawMaps(canvas, headerText);
+          break;
+        default:
+          throw cms::Exception("SiPixelDynamicInefficiencyMapComparison")
+              << "\nERROR: unrecognized Pixel Detector part " << std::endl;
+      }
+
+      // first loop on the first payload (newest)
+      fillTheMapFromPayload(theMap, fp, false);
+
+      // then loop on the second payload (oldest)
+      fillTheMapFromPayload(theMap, lp, true);  // true will subtract
+
+      std::string fileName(this->m_imageFileName);
+      canvas.SaveAs(fileName.c_str());
+#ifdef MMDEBUG
+      canvas.SaveAs("outAll.root");
+#endif
+
+      return true;
+    }
+
+  private:
+    static constexpr std::array<int, 3> k_height = {{1200, 600, 1600}};
+    TrackerTopology m_trackerTopo;
+
+    //____________________________________________________________________________________________
+    void fillTheMapFromPayload(Phase1PixelROCMaps& theMap, const SiPixDynIneff::BRFractions& fr, bool subtract) {
+      for (const auto& element : fr) {
+        auto rawid = element.first;
+        int subid = DetId(rawid).subdetId();
+        auto packedinfo = element.second;
+        auto badRocs = packedinfo.badRocNumber;
+        auto badRocsF = packedinfo.badRocFrac;
+
+        for (size_t i = 0; i < badRocs.size(); i++) {
+          std::bitset<16> rocToMark;
+          rocToMark.set(badRocs[i]);
+          if ((subid == PixelSubdetector::PixelBarrel && myType == SiPixelPI::t_barrel) ||
+              (subid == PixelSubdetector::PixelEndcap && myType == SiPixelPI::t_forward) ||
+              (myType == SiPixelPI::t_all)) {
+            theMap.fillSelectedRocs(rawid, rocToMark, badRocsF[i] * 100.f * (subtract ? -1. : 1.));
+          }
+        }
+      }
+    }
+  };
+
+  /*
+  using SiPixelBPixIneffROCsMapCompareSingleTag = SiPixelIneffROCComparisonBase<SiPixelPI::t_barrel, MULTI_IOV, 1>;
+  using SiPixelFPixIneffROCsMapCompareSingleTag = SiPixelIneffROCComparisonBase<SiPixelPI::t_forward, MULTI_IOV, 1>;
+  using SiPixelFullIneffROCsMapCompareSingleTag = SiPixelIneffROCComparisonBase<SiPixelPI::t_all, MULTI_IOV, 1>;
+  */
+  using SiPixelBPixIneffROCsMapCompareTwoTags = SiPixelIneffROCComparisonBase<SiPixelPI::t_barrel, SINGLE_IOV, 2>;
+  using SiPixelFPixIneffROCsMapCompareTwoTags = SiPixelIneffROCComparisonBase<SiPixelPI::t_forward, SINGLE_IOV, 2>;
+  using SiPixelFullIneffROCsMapCompareTwoTags = SiPixelIneffROCComparisonBase<SiPixelPI::t_all, SINGLE_IOV, 2>;
+
+}  // namespace
+
+// Register the classes as boost python plugin
+PAYLOAD_INSPECTOR_MODULE(SiPixelDynamicInefficiency) {
+  PAYLOAD_INSPECTOR_CLASS(SiPixelDynamicInefficiencyTest);
+  PAYLOAD_INSPECTOR_CLASS(SiPixelBPixIneffROCfromDynIneffMap);
+  PAYLOAD_INSPECTOR_CLASS(SiPixelFPixIneffROCfromDynIneffMap);
+  PAYLOAD_INSPECTOR_CLASS(SiPixelFullIneffROCfromDynIneffMap);
+  PAYLOAD_INSPECTOR_CLASS(SiPixelBPixIneffROCsMapCompareTwoTags);
+  PAYLOAD_INSPECTOR_CLASS(SiPixelFPixIneffROCsMapCompareTwoTags);
+  PAYLOAD_INSPECTOR_CLASS(SiPixelFullIneffROCsMapCompareTwoTags);
+}

--- a/CondCore/SiPixelPlugins/plugins/SiPixelDynamicInefficiency_PayloadInspector.cc
+++ b/CondCore/SiPixelPlugins/plugins/SiPixelDynamicInefficiency_PayloadInspector.cc
@@ -41,10 +41,6 @@
 namespace {
 
   using namespace cond::payloadInspector;
-
-  const std::string k_Ph0_geo = "CalibTracker/SiPixelESProducers/data/PixelSkimmedGeometry.txt";
-  const std::string k_Ph1_geo = "SLHCUpgradeSimulations/Geometry/data/PhaseI/PixelSkimmedGeometry_phase1.txt";
-
   namespace SiPixDynIneff {
 
     // constants for ROC level simulation for Phase1
@@ -90,7 +86,8 @@ namespace {
 
     //_________________________________________________
     bool isPhase0(const BRFractions& fractions) {
-      SiPixelDetInfoFileReader reader = SiPixelDetInfoFileReader(edm::FileInPath(k_Ph0_geo).fullPath());
+      SiPixelDetInfoFileReader reader =
+          SiPixelDetInfoFileReader(edm::FileInPath(SiPixelDetInfoFileReader::kPh0DefaultFile).fullPath());
       const auto& p0detIds = reader.getAllDetIds();
       std::vector<uint32_t> ownDetIds;
 
@@ -300,11 +297,10 @@ namespace {
       std::string headerText;
 
       if (this->m_plotAnnotations.ntags == 2) {
-        headerText = fmt::sprintf(
-            "#Delta #color[2]{A: %s, %s} - #color[4]{B: %s, %s}", f_tagname, f_IOVstring, l_tagname, l_IOVstring);
-      } else {
         headerText =
-            fmt::sprintf("%s, #Delta IOV #color[2]{A: %s} - #color[4]{B: %s} ", f_tagname, f_IOVstring, l_IOVstring);
+            fmt::sprintf("#color[2]{A: %s, %s} - #color[4]{B: %s, %s}", f_tagname, f_IOVstring, l_tagname, l_IOVstring);
+      } else {
+        headerText = fmt::sprintf("%s,IOV #color[2]{A: %s} - #color[4]{B: %s} ", f_tagname, f_IOVstring, l_IOVstring);
       }
 
       switch (myType) {
@@ -356,7 +352,7 @@ namespace {
           if ((subid == PixelSubdetector::PixelBarrel && myType == SiPixelPI::t_barrel) ||
               (subid == PixelSubdetector::PixelEndcap && myType == SiPixelPI::t_forward) ||
               (myType == SiPixelPI::t_all)) {
-            theMap.fillSelectedRocs(rawid, rocToMark, badRocsF[i] * 100.f * (subtract ? -1. : 1.));
+            theMap.fillSelectedRocs(rawid, rocToMark, badRocsF[i] * (subtract ? -1. : 1.));
           }
         }
       }

--- a/CondCore/SiPixelPlugins/plugins/SiPixelQuality_PayloadInspector.cc
+++ b/CondCore/SiPixelPlugins/plugins/SiPixelQuality_PayloadInspector.cc
@@ -42,9 +42,6 @@ namespace {
 
   using namespace cond::payloadInspector;
 
-  const std::string k_Ph0_geo = "CalibTracker/SiPixelESProducers/data/PixelSkimmedGeometry.txt";
-  const std::string k_Ph1_geo = "SLHCUpgradeSimulations/Geometry/data/PhaseI/PixelSkimmedGeometry_phase1.txt";
-
   /************************************************
     test class
   *************************************************/
@@ -228,7 +225,8 @@ namespace {
 
     //_________________________________________________
     bool isPhase0(std::vector<SiPixelQuality::disabledModuleType> mods) {
-      SiPixelDetInfoFileReader reader = SiPixelDetInfoFileReader(edm::FileInPath(k_Ph0_geo).fullPath());
+      SiPixelDetInfoFileReader reader =
+          SiPixelDetInfoFileReader(edm::FileInPath(SiPixelDetInfoFileReader::kPh0DefaultFile).fullPath());
       const auto& p0detIds = reader.getAllDetIds();
 
       std::vector<uint32_t> ownDetIds;
@@ -360,7 +358,8 @@ namespace {
     //_________________________________________________
     bool isPhase0(const std::shared_ptr<SiPixelQuality>& payload) {
       const auto mods = payload->getBadComponentList();
-      SiPixelDetInfoFileReader reader = SiPixelDetInfoFileReader(edm::FileInPath(k_Ph0_geo).fullPath());
+      SiPixelDetInfoFileReader reader =
+          SiPixelDetInfoFileReader(edm::FileInPath(SiPixelDetInfoFileReader::kPh0DefaultFile).fullPath());
       const auto& p0detIds = reader.getAllDetIds();
 
       std::vector<uint32_t> ownDetIds;

--- a/CondCore/SiPixelPlugins/test/testSiPixelDynamicInefficiency.sh
+++ b/CondCore/SiPixelPlugins/test/testSiPixelDynamicInefficiency.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+# Save current working dir so img can be outputted there later
+W_DIR=$(pwd);
+# Set SCRAM architecture var
+SCRAM_ARCH=slc7_amd64_gcc900;
+export SCRAM_ARCH;
+source /afs/cern.ch/cms/cmsset_default.sh;
+eval `scram run -sh`;
+# Go back to original working directory
+cd $W_DIR;
+
+if [ -d $W_DIR/plots_DynIneff ]; then
+    rm -fr $W_DIR/plots_DynIneff
+fi
+
+mkdir $W_DIR/plots_DynIneff
+
+# Run get payload data script
+getPayloadData.py \
+    --plugin pluginSiPixelDynamicInefficiency_PayloadInspector \
+    --plot plot_SiPixelDynamicInefficiencyTest \
+    --tag SiPixelDynamicInefficiency_PhaseI_v9 \
+    --time_type Run \
+    --iovs '{"start_iov": "1", "end_iov": "1"}' \
+    --db Prod \
+    --test;
+
+getPayloadData.py \
+    --plugin pluginSiPixelDynamicInefficiency_PayloadInspector \
+    --plot plot_SiPixelBPixIneffROCfromDynIneffMap \
+    --tag SiPixelDynamicInefficiency_PhaseI_v9 \
+    --time_type Run \
+    --iovs '{"start_iov": "1", "end_iov": "1"}' \
+    --db Prod \
+    --test;
+
+mv *.png $W_DIR/plots_DynIneff/SiPixelBPixIneffROCfromDynIneffMap.png
+
+getPayloadData.py \
+    --plugin pluginSiPixelDynamicInefficiency_PayloadInspector \
+    --plot plot_SiPixelFPixIneffROCfromDynIneffMap \
+    --tag SiPixelDynamicInefficiency_PhaseI_v9 \
+    --time_type Run \
+    --iovs '{"start_iov": "1", "end_iov": "1"}' \
+    --db Prod \
+    --test;
+
+mv *.png $W_DIR/plots_DynIneff/SiPixelFPixIneffROCfromDynIneffMap.png
+
+getPayloadData.py \
+    --plugin pluginSiPixelDynamicInefficiency_PayloadInspector \
+    --plot plot_SiPixelFullIneffROCfromDynIneffMap \
+    --tag SiPixelDynamicInefficiency_PhaseI_v9 \
+    --time_type Run \
+    --iovs '{"start_iov": "1", "end_iov": "1"}' \
+    --db Prod \
+    --test;
+
+mv *.png $W_DIR/plots_DynIneff/SiPixelFullIneffROCfromDynIneffMap.png

--- a/CondCore/SiPixelPlugins/test/testSiPixelDynamicInefficiency.sh
+++ b/CondCore/SiPixelPlugins/test/testSiPixelDynamicInefficiency.sh
@@ -57,3 +57,16 @@ getPayloadData.py \
     --test;
 
 mv *.png $W_DIR/plots_DynIneff/SiPixelFullIneffROCfromDynIneffMap.png
+
+getPayloadData.py \
+    --plugin pluginSiPixelDynamicInefficiency_PayloadInspector \
+    --plot plot_SiPixelFullIneffROCsMapCompareTwoTags \
+    --tag SiPixelDynamicInefficiency_PhaseI_Run3Studies_v2 \
+    --tagtwo SiPixelDynamicInefficiency_PhaseI_v9 \
+    --time_type Run \
+    --iovs '{"start_iov": "1", "end_iov": "1"}' \
+    --iovstwo '{"start_iov": "1", "end_iov": "1"}' \
+    --db Prod \
+    --test;
+
+mv *.png $W_DIR/plots_DynIneff/SiPixelFullIneffROCfromDynIneffMapDelta.png

--- a/CondCore/SiPixelPlugins/test/testSiPixelPayloadInspector.cpp
+++ b/CondCore/SiPixelPlugins/test/testSiPixelPayloadInspector.cpp
@@ -7,8 +7,9 @@
 #include "CondCore/SiPixelPlugins/plugins/SiPixelTemplateDBObject_PayloadInspector.cc"
 #include "CondCore/SiPixelPlugins/plugins/SiPixelGenErrorDBObject_PayloadInspector.cc"
 #include "CondCore/SiPixelPlugins/plugins/SiPixelVCal_PayloadInspector.cc"
-#include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "CondCore/SiPixelPlugins/plugins/SiPixelQualityProbabilities_PayloadInspector.cc"
+#include "CondCore/SiPixelPlugins/plugins/SiPixelDynamicInefficiency_PayloadInspector.cc"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/PluginManager/interface/PluginManager.h"
 #include "FWCore/PluginManager/interface/standard.h"
 #include "FWCore/PluginManager/interface/SharedLibrary.h"
@@ -195,11 +196,30 @@ int main(int argc, char** argv) {
   start = boost::lexical_cast<unsigned long long>(1);
   end = boost::lexical_cast<unsigned long long>(1);
 
-  std::cout << "## Exercising SiPixelQualityProbabilities plots " << std::endl;
+  edm::LogPrint("testSiPixelPayloadInspector") << "## Exercising SiPixelQualityProbabilities plots " << std::endl;
 
   SiPixelQualityProbabilitiesScenariosCount histo25;
   histo25.process(connectionString, PI::mk_input(tag, start, end));
-  std::cout << histo25.data() << std::endl;
+  edm::LogPrint("testSiPixelPayloadInspector") << histo25.data() << std::endl;
+
+  // SiPixelDynamicInefficiency
+
+  tag = "SiPixelDynamicInefficiency_PhaseI_v9";
+  start = boost::lexical_cast<unsigned long long>(1);
+  end = boost::lexical_cast<unsigned long long>(1);
+
+  edm::LogPrint("testSiPixelPayloadInspector") << "## Exercising SiPixeDynamicInefficiency plots " << std::endl;
+
+  SiPixelFullIneffROCfromDynIneffMap histo26;
+  histo26.process(connectionString, PI::mk_input(tag, start, end));
+  edm::LogPrint("testSiPixelPayloadInspector") << histo26.data() << std::endl;
+
+  tag2 = "SiPixelDynamicInefficiency_PhaseI_v6";
+  start2 = boost::lexical_cast<unsigned long long>(1);
+
+  SiPixelFullIneffROCsMapCompareTwoTags histo27;
+  histo27.process(connectionString, PI::mk_input(tag, start, start, tag2, start2, start2));
+  edm::LogPrint("testSiPixelPayloadInspector") << histo27.data() << std::endl;
 
   inputs.clear();
 #if PY_MAJOR_VERSION >= 3


### PR DESCRIPTION
#### PR description:

This PR adds a stub of `SiPixelDynamicInefficiency` payload inspector, for the moment only for the mapping of the inefficient ROCs behind broken DC/DC converters, currently included with the `SiPixelDynamicInefficiency`.
More updates will come later.
I profit of this PR to introduce in commit fbece95 default file names for the `SiPixelDetInfoFileReader` similarly to what has been done for Strips in PR https://github.com/cms-sw/cmssw/pull/33888. 

#### PR validation:

The augmented unit test run, 
 
```console
scram b runtests
```

plus private validation, here's an example:

![SiPixelFullIneffROCfromDynIneffMap](https://user-images.githubusercontent.com/5082376/125455091-449fbe34-867d-4f78-91b8-d36d66d9e244.png)

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A

cc:
@tvami @tsusa 