### PR TITLE
Make stop/sbottom R-hadrons use the cloud model

### DIFF
--- a/SimG4Core/CustomPhysics/interface/CustomPDGParser.h
+++ b/SimG4Core/CustomPhysics/interface/CustomPDGParser.h
@@ -5,7 +5,7 @@
 
 class CustomPDGParser {
 public:
-  static bool s_isRHadron(int pdg);
+  static bool s_isgluinoHadron(int pdg);
   static bool s_isstopHadron(int pdg);
   static bool s_issbottomHadron(int pdg);
   static bool s_isSLepton(int pdg);

--- a/SimG4Core/CustomPhysics/src/CustomPDGParser.cc
+++ b/SimG4Core/CustomPhysics/src/CustomPDGParser.cc
@@ -1,7 +1,8 @@
 #include <SimG4Core/CustomPhysics/interface/CustomPDGParser.h>
 #include <cstdlib>
 
-bool CustomPDGParser::s_isRHadron(int pdg) {
+// check for R-hadron with gluino content
+bool CustomPDGParser::s_isgluinoHadron(int pdg) {
   int pdgAbs = abs(pdg);
   return ((pdgAbs % 100000 / 10000 == 9) || (pdgAbs % 10000 / 1000 == 9) || s_isRGlueball(pdg));
 }

--- a/SimG4Core/CustomPhysics/src/CustomParticleFactory.cc
+++ b/SimG4Core/CustomPhysics/src/CustomParticleFactory.cc
@@ -111,7 +111,7 @@ void CustomParticleFactory::addCustomParticle(int pdgCode, double mass, const st
   G4double spectatormass = 0.0;
   G4ParticleDefinition *spectator = nullptr;
   //////////////////////
-  if (CustomPDGParser::s_isRHadron(pdgCode)) {
+  if (CustomPDGParser::s_isgluinoHadron(pdgCode)) {
     pType = "rhadron";
   }
   if (CustomPDGParser::s_isSLepton(pdgCode)) {
@@ -272,7 +272,7 @@ void CustomParticleFactory::getMassTable(std::ifstream *configFile) {
 
     edm::LogInfo("SimG4CoreCustomPhysics")
         << "CustomParticleFactory: Calling addCustomParticle for pdgId: " << pdgId << ", mass " << mass << " GeV  "
-        << name << ", isRHadron: " << CustomPDGParser::s_isRHadron(pdgId)
+        << name << ", isgluinoHadron: " << CustomPDGParser::s_isgluinoHadron(pdgId)
         << ", isstopHadron: " << CustomPDGParser::s_isstopHadron(pdgId)
         << ", isSIMP: " << CustomPDGParser::s_isSIMP(pdgId);
     addCustomParticle(pdgId, mass, name);
@@ -287,7 +287,7 @@ void CustomParticleFactory::getMassTable(std::ifstream *configFile) {
           << " pdgId= " << pdgId << ", pdgIdPartner= " << pdgIdPartner << " " << aParticle->GetParticleName();
     }
 
-    if (aParticle && !CustomPDGParser::s_isRHadron(pdgId) && !CustomPDGParser::s_isstopHadron(pdgId) &&
+    if (aParticle && !CustomPDGParser::s_isgluinoHadron(pdgId) && !CustomPDGParser::s_isstopHadron(pdgId) &&
         !CustomPDGParser::s_isSIMP(pdgId) && pdgId != 1000006 && pdgId != -1000006 && pdgId != 25 && pdgId != 35 &&
         pdgId != 36 && pdgId != 37) {
       int sign = aParticle->GetAntiPDGEncoding() / pdgIdPartner;

--- a/SimG4Core/CustomPhysics/src/CustomPhysicsList.cc
+++ b/SimG4Core/CustomPhysics/src/CustomPhysicsList.cc
@@ -81,7 +81,10 @@ void CustomPhysicsList::ConstructProcess() {
           ph->RegisterProcess(new G4hMultipleScattering, particle);
           ph->RegisterProcess(new G4hIonisation, particle);
         }
-        if (cp->GetCloud() && fHadronicInteraction && (CustomPDGParser::s_isgluinoHadron(particle->GetPDGEncoding())||(CustomPDGParser::s_isstopHadron(particle->GetPDGEncoding()))||(CustomPDGParser::s_issbottomHadron(particle->GetPDGEncoding())))) {
+        if (cp->GetCloud() && fHadronicInteraction &&
+            (CustomPDGParser::s_isgluinoHadron(particle->GetPDGEncoding()) ||
+             (CustomPDGParser::s_isstopHadron(particle->GetPDGEncoding())) ||
+             (CustomPDGParser::s_issbottomHadron(particle->GetPDGEncoding())))) {
           edm::LogVerbatim("SimG4CoreCustomPhysics")
               << "CustomPhysicsList: " << particle->GetParticleName()
               << " CloudMass= " << cp->GetCloud()->GetPDGMass() / GeV

--- a/SimG4Core/CustomPhysics/src/CustomPhysicsList.cc
+++ b/SimG4Core/CustomPhysics/src/CustomPhysicsList.cc
@@ -81,7 +81,7 @@ void CustomPhysicsList::ConstructProcess() {
           ph->RegisterProcess(new G4hMultipleScattering, particle);
           ph->RegisterProcess(new G4hIonisation, particle);
         }
-        if (cp->GetCloud() && fHadronicInteraction && CustomPDGParser::s_isRHadron(particle->GetPDGEncoding())) {
+        if (cp->GetCloud() && fHadronicInteraction && (CustomPDGParser::s_isgluinoHadron(particle->GetPDGEncoding())||(CustomPDGParser::s_isstopHadron(particle->GetPDGEncoding()))||(CustomPDGParser::s_issbottomHadron(particle->GetPDGEncoding())))) {
           edm::LogVerbatim("SimG4CoreCustomPhysics")
               << "CustomPhysicsList: " << particle->GetParticleName()
               << " CloudMass= " << cp->GetCloud()->GetPDGMass() / GeV

--- a/SimG4Core/CustomPhysics/src/CustomPhysicsListSS.cc
+++ b/SimG4Core/CustomPhysics/src/CustomPhysicsListSS.cc
@@ -67,7 +67,7 @@ void CustomPhysicsListSS::ConstructProcess() {
           ph->RegisterProcess(new G4CoulombScattering, particle);
           ph->RegisterProcess(new G4hIonisation, particle);
         }
-        if (cp->GetCloud() && fHadronicInteraction && CustomPDGParser::s_isRHadron(particle->GetPDGEncoding())) {
+        if (cp->GetCloud() && fHadronicInteraction && (CustomPDGParser::s_isgluinoHadron(particle->GetPDGEncoding())||(CustomPDGParser::s_isstopHadron(particle->GetPDGEncoding()))||(CustomPDGParser::s_issbottomHadron(particle->GetPDGEncoding())))) {
           edm::LogVerbatim("SimG4CoreCustomPhysics")
               << "CustomPhysicsListSS: " << particle->GetParticleName()
               << " CloudMass= " << cp->GetCloud()->GetPDGMass() / GeV

--- a/SimG4Core/CustomPhysics/src/CustomPhysicsListSS.cc
+++ b/SimG4Core/CustomPhysics/src/CustomPhysicsListSS.cc
@@ -67,7 +67,10 @@ void CustomPhysicsListSS::ConstructProcess() {
           ph->RegisterProcess(new G4CoulombScattering, particle);
           ph->RegisterProcess(new G4hIonisation, particle);
         }
-        if (cp->GetCloud() && fHadronicInteraction && (CustomPDGParser::s_isgluinoHadron(particle->GetPDGEncoding())||(CustomPDGParser::s_isstopHadron(particle->GetPDGEncoding()))||(CustomPDGParser::s_issbottomHadron(particle->GetPDGEncoding())))) {
+        if (cp->GetCloud() && fHadronicInteraction &&
+            (CustomPDGParser::s_isgluinoHadron(particle->GetPDGEncoding()) ||
+             (CustomPDGParser::s_isstopHadron(particle->GetPDGEncoding())) ||
+             (CustomPDGParser::s_issbottomHadron(particle->GetPDGEncoding())))) {
           edm::LogVerbatim("SimG4CoreCustomPhysics")
               << "CustomPhysicsListSS: " << particle->GetParticleName()
               << " CloudMass= " << cp->GetCloud()->GetPDGMass() / GeV


### PR DESCRIPTION
#### PR description:

This PR fixes a bug, namely that the stop/sbottom R-hadrons were not added in CustomPhysicsList from CMSSW_8_0_X, so they do not use the cloud model. Fix can be easily done by renaming is_Rhadron() to s_isgluinoHadron to reflect what the code is really doing and add the stop and sbottom to the CustomPhysicsList.
More details
https://indico.cern.ch/event/1012481/contributions/4248900/attachments/2198166/3716919/SlidesMCTests20210226.pdf
and
https://indico.cern.ch/event/963050/contributions/4051179/attachments/2116681/3565085/SlidesMCDebug20201006.pdf

#### PR validation:

Code compiles, physics validation done in the talks linked above

#### if this PR is a backport please specify the original PR and why you need to backport that PR:
This is not a backport, but a backport is planned

cc: @tadams16 @carolinecollard 
