### PR TITLE
Use RooMinimizer instead of RooMinuit after ROOT deprecation for RooMunuit

### DIFF
--- a/MuonAnalysis/MomentumScaleCalibration/test/Macros/RooFit/FitWithRooFit.cc
+++ b/MuonAnalysis/MomentumScaleCalibration/test/Macros/RooFit/FitWithRooFit.cc
@@ -23,10 +23,9 @@
 #include "RooPolynomial.h"
 #include "RooCBShape.h"
 #include "RooChi2Var.h"
-#include "RooMinuit.h"
+#include "RooFitLegacy/RooMinuit.h"
 #include "RooBreitWigner.h"
 #include "RooFFTConvPdf.h"
-
 
 /**
  * This macro allows to use RooFit to perform a fit on a TH1 histogram. <br>
@@ -46,56 +45,72 @@
  * The methods names after the variables return the fit result.
  */
 
-namespace
-{
+namespace {
   typedef std::pair<RooRealVar, RooDataHist*> rooPair;
 }
 
-class FitWithRooFit
-{
+class FitWithRooFit {
 public:
-
-  FitWithRooFit() :
-    useChi2_(false),
-    mean_(0), mean2_(0), mean3_(0),
-    sigma_(0), sigma2_(0), sigma3_(0),
-    gamma_(0), gaussFrac_(0), gaussFrac2_(0),
-    expCoeffa0_(0), expCoeffa1_(0), expCoeffa2_(0), fsig_(0),
-    a0_(0), a1_(0), a2_(0), a3_(0), a4_(0), a5_(0), a6_(0),
-    alpha_(0), n_(0), fGCB_(0)
-  {}
+  FitWithRooFit()
+      : useChi2_(false),
+        mean_(0),
+        mean2_(0),
+        mean3_(0),
+        sigma_(0),
+        sigma2_(0),
+        sigma3_(0),
+        gamma_(0),
+        gaussFrac_(0),
+        gaussFrac2_(0),
+        expCoeffa0_(0),
+        expCoeffa1_(0),
+        expCoeffa2_(0),
+        fsig_(0),
+        a0_(0),
+        a1_(0),
+        a2_(0),
+        a3_(0),
+        a4_(0),
+        a5_(0),
+        a6_(0),
+        alpha_(0),
+        n_(0),
+        fGCB_(0) {}
 
   // Import TH1 histogram into a RooDataHist
-  rooPair importTH1(TH1 * histo, const double & inputXmin, const double & inputXmax)
-  {
+  rooPair importTH1(TH1* histo, const double& inputXmin, const double& inputXmax) {
     double xMin = inputXmin;
     double xMax = inputXmax;
-    if( (xMin == xMax) && xMin == 0 ) {
+    if ((xMin == xMax) && xMin == 0) {
       xMin = histo->GetXaxis()->GetXmin();
       xMax = histo->GetXaxis()->GetXmax();
     }
     // Declare observable x
     RooRealVar x("x", "x", xMin, xMax);
     // Create a binned dataset that imports contents of TH1 and associates its contents to observable 'x'
-    return( std::make_pair(x, new RooDataHist("dh","dh",x,RooFit::Import(*histo))) );
+    return (std::make_pair(x, new RooDataHist("dh", "dh", x, RooFit::Import(*histo))));
   }
 
   // Plot and fit a RooDataHist fitting signal and background
-  void fit(TH1 * histo, const TString signalType, const TString backgroundType, const double & xMin = 0., const double & xMax = 0., bool sumW2Error = false)
-  {
+  void fit(TH1* histo,
+           const TString signalType,
+           const TString backgroundType,
+           const double& xMin = 0.,
+           const double& xMax = 0.,
+           bool sumW2Error = false) {
     reinitializeParameters();
 
     rooPair imported = importTH1(histo, xMin, xMax);
     RooRealVar x(imported.first);
-    RooDataHist * dh = imported.second;
+    RooDataHist* dh = imported.second;
 
     // Make plot of binned dataset showing Poisson error bars (RooFit default)
     RooPlot* frame = x.frame(RooFit::Title("Imported TH1 with Poisson error bars"));
-    frame->SetName(TString(histo->GetName())+"_frame");
+    frame->SetName(TString(histo->GetName()) + "_frame");
     dh->plotOn(frame);
 
     // Build the composite model
-    RooAbsPdf * model = buildModel(&x, signalType, backgroundType);
+    RooAbsPdf* model = buildModel(&x, signalType, backgroundType);
 
     RooChi2Var chi2("chi2", "chi2", *model, *dh, RooFit::DataError(RooAbsData::SumW2));
 
@@ -103,8 +118,10 @@ public:
     // -----------------------
     // Fit with likelihood
     if (!useChi2_) {
-      if (sumW2Error) model->fitTo(*dh, RooFit::Save(), RooFit::SumW2Error(kTRUE));
-      else model->fitTo(*dh);
+      if (sumW2Error)
+        model->fitTo(*dh, RooFit::Save(), RooFit::SumW2Error(kTRUE));
+      else
+        model->fitTo(*dh);
     }
     // Fit with chi^2
     else {
@@ -118,7 +135,7 @@ public:
     model->plotOn(frame, RooFit::Components(backgroundType), RooFit::LineStyle(kDotted), RooFit::LineColor(kRed));
     model->paramOn(frame, RooFit::Label("fit result"), RooFit::Format("NEU", RooFit::AutoPrecision(2)));
 
-    // TODO: fix next lines to get the prob(chi2) (ndof should be dynamically set according to the choosen pdf) 
+    // TODO: fix next lines to get the prob(chi2) (ndof should be dynamically set according to the choosen pdf)
     // double chi2 = xframe.chiSquare("model","data",ndof);
     // double ndoff = xframeGetNbinsX();
     // double chi2prob = TMath::Prob(chi2,ndoff);
@@ -135,13 +152,12 @@ public:
     model->plotOn(frame2, RooFit::Components(backgroundType), RooFit::LineColor(kRed));
     model->paramOn(frame2, RooFit::Label("fit result"), RooFit::Format("NEU", RooFit::AutoPrecision(2)));
 
-
     // Please note that error bars shown (Poisson or SumW2) are for visualization only, the are NOT used
     // in a maximum likelihood fit
     //
-    // A (binned) ML fit will ALWAYS assume the Poisson error interpretation of data (the mathematical definition 
+    // A (binned) ML fit will ALWAYS assume the Poisson error interpretation of data (the mathematical definition
     // of likelihood does not take any external definition of errors). Data with non-unit weights can only be correctly
-    // fitted with a chi^2 fit (see rf602_chi2fit.C) 
+    // fitted with a chi^2 fit (see rf602_chi2fit.C)
 
     // Draw all frames on a canvas
     // if( canvas == 0 ) {
@@ -156,470 +172,542 @@ public:
   }
 
   // Initialization methods for all the parameters
-  void initMean(const double & value, const double & min, const double & max, const TString & name = "mean", const TString & title = "mean")
-  {
-    if( mean_ != 0 ) delete mean_;
+  void initMean(const double& value,
+                const double& min,
+                const double& max,
+                const TString& name = "mean",
+                const TString& title = "mean") {
+    if (mean_ != 0)
+      delete mean_;
     mean_ = new RooRealVar(name, title, value, min, max);
     initVal_mean = value;
   }
-  void initMean2(const double & value, const double & min, const double & max, const TString & name = "mean2", const TString & title = "mean2")
-  {
-    if( mean2_ != 0 ) delete mean2_;
+  void initMean2(const double& value,
+                 const double& min,
+                 const double& max,
+                 const TString& name = "mean2",
+                 const TString& title = "mean2") {
+    if (mean2_ != 0)
+      delete mean2_;
     mean2_ = new RooRealVar(name, title, value, min, max);
     initVal_mean2 = value;
   }
-  void initMean3(const double & value, const double & min, const double & max, const TString & name = "mean3", const TString & title = "mean3")
-  {
-    if( mean3_ != 0 ) delete mean3_;
+  void initMean3(const double& value,
+                 const double& min,
+                 const double& max,
+                 const TString& name = "mean3",
+                 const TString& title = "mean3") {
+    if (mean3_ != 0)
+      delete mean3_;
     mean3_ = new RooRealVar(name, title, value, min, max);
     initVal_mean3 = value;
   }
-  void initSigma(const double & value, const double & min, const double & max, const TString & name = "sigma", const TString & title = "sigma")
-  {
-    if( sigma_ != 0 ) delete sigma_;
+  void initSigma(const double& value,
+                 const double& min,
+                 const double& max,
+                 const TString& name = "sigma",
+                 const TString& title = "sigma") {
+    if (sigma_ != 0)
+      delete sigma_;
     sigma_ = new RooRealVar(name, title, value, min, max);
     initVal_sigma = value;
   }
-  void initSigma2(const double & value, const double & min, const double & max, const TString & name = "sigma2", const TString & title = "sigma2")
-  {
-    if( sigma2_ != 0 ) delete sigma2_;
+  void initSigma2(const double& value,
+                  const double& min,
+                  const double& max,
+                  const TString& name = "sigma2",
+                  const TString& title = "sigma2") {
+    if (sigma2_ != 0)
+      delete sigma2_;
     sigma2_ = new RooRealVar(name, title, value, min, max);
     initVal_sigma2 = value;
   }
-  void initSigma3(const double & value, const double & min, const double & max, const TString & name = "sigma3", const TString & title = "sigma3")
-  {
-    if( sigma3_ != 0 ) delete sigma3_;
+  void initSigma3(const double& value,
+                  const double& min,
+                  const double& max,
+                  const TString& name = "sigma3",
+                  const TString& title = "sigma3") {
+    if (sigma3_ != 0)
+      delete sigma3_;
     sigma3_ = new RooRealVar(name, title, value, min, max);
     initVal_sigma3 = value;
   }
-  void initGamma(const double & value, const double & min, const double & max, const TString & name = "gamma", const TString & title = "gamma")
-  {
-    if( gamma_ != 0 ) delete gamma_;
+  void initGamma(const double& value,
+                 const double& min,
+                 const double& max,
+                 const TString& name = "gamma",
+                 const TString& title = "gamma") {
+    if (gamma_ != 0)
+      delete gamma_;
     gamma_ = new RooRealVar(name, title, value, min, max);
     initVal_gamma = value;
   }
-  void initGaussFrac(const double & value, const double & min, const double & max, const TString & name = "GaussFrac", const TString & title = "GaussFrac")
-  {
-    if( gaussFrac_ != 0 ) delete gaussFrac_;
+  void initGaussFrac(const double& value,
+                     const double& min,
+                     const double& max,
+                     const TString& name = "GaussFrac",
+                     const TString& title = "GaussFrac") {
+    if (gaussFrac_ != 0)
+      delete gaussFrac_;
     gaussFrac_ = new RooRealVar(name, title, value, min, max);
     initVal_gaussFrac = value;
   }
-  void initGaussFrac2(const double & value, const double & min, const double & max, const TString & name = "GaussFrac2", const TString & title = "GaussFrac2")
-  {
-    if( gaussFrac2_ != 0 ) delete gaussFrac2_;
+  void initGaussFrac2(const double& value,
+                      const double& min,
+                      const double& max,
+                      const TString& name = "GaussFrac2",
+                      const TString& title = "GaussFrac2") {
+    if (gaussFrac2_ != 0)
+      delete gaussFrac2_;
     gaussFrac2_ = new RooRealVar(name, title, value, min, max);
     initVal_gaussFrac2 = value;
   }
-  void initExpCoeffA0(const double & value, const double & min, const double & max, const TString & name = "expCoeffa0", const TString & title = "expCoeffa0")
-  {
-    if( expCoeffa0_ != 0 ) delete expCoeffa0_;
+  void initExpCoeffA0(const double& value,
+                      const double& min,
+                      const double& max,
+                      const TString& name = "expCoeffa0",
+                      const TString& title = "expCoeffa0") {
+    if (expCoeffa0_ != 0)
+      delete expCoeffa0_;
     expCoeffa0_ = new RooRealVar(name, title, value, min, max);
     initVal_expCoeffa0 = value;
   }
-  void initExpCoeffA1(const double & value, const double & min, const double & max, const TString & name = "expCoeffa1", const TString & title = "expCoeffa1")
-  {
-    if( expCoeffa1_ != 0 ) delete expCoeffa1_;
+  void initExpCoeffA1(const double& value,
+                      const double& min,
+                      const double& max,
+                      const TString& name = "expCoeffa1",
+                      const TString& title = "expCoeffa1") {
+    if (expCoeffa1_ != 0)
+      delete expCoeffa1_;
     expCoeffa1_ = new RooRealVar(name, title, value, min, max);
     initVal_expCoeffa1 = value;
   }
-  void initExpCoeffA2(const double & value, const double & min, const double & max, const TString & name = "expCoeffa2", const TString & title = "expCoeffa2")
-  {
-    if( expCoeffa2_ != 0 ) delete expCoeffa2_;
+  void initExpCoeffA2(const double& value,
+                      const double& min,
+                      const double& max,
+                      const TString& name = "expCoeffa2",
+                      const TString& title = "expCoeffa2") {
+    if (expCoeffa2_ != 0)
+      delete expCoeffa2_;
     expCoeffa2_ = new RooRealVar(name, title, value, min, max);
     initVal_expCoeffa2 = value;
   }
-  void initFsig(const double & value, const double & min, const double & max, const TString & name = "fsig", const TString & title = "signal fraction")
-  {
-    if( fsig_ != 0 ) delete fsig_;
+  void initFsig(const double& value,
+                const double& min,
+                const double& max,
+                const TString& name = "fsig",
+                const TString& title = "signal fraction") {
+    if (fsig_ != 0)
+      delete fsig_;
     fsig_ = new RooRealVar(name, title, value, min, max);
     initVal_fsig = value;
   }
-  void initA0(const double & value, const double & min, const double & max, const TString & name = "a0", const TString & title = "a0")
-  {
-    if( a0_ != 0 ) delete a0_;
+  void initA0(const double& value,
+              const double& min,
+              const double& max,
+              const TString& name = "a0",
+              const TString& title = "a0") {
+    if (a0_ != 0)
+      delete a0_;
     a0_ = new RooRealVar(name, title, value, min, max);
     initVal_a0 = value;
   }
-  void initA1(const double & value, const double & min, const double & max, const TString & name = "a1", const TString & title = "a1")
-  {
-    if( a1_ != 0 ) delete a1_;
+  void initA1(const double& value,
+              const double& min,
+              const double& max,
+              const TString& name = "a1",
+              const TString& title = "a1") {
+    if (a1_ != 0)
+      delete a1_;
     a1_ = new RooRealVar(name, title, value, min, max);
     initVal_a1 = value;
   }
-  void initA2(const double & value, const double & min, const double & max, const TString & name = "a2", const TString & title = "a2")
-  {
-    if( a2_ != 0 ) delete a2_;
+  void initA2(const double& value,
+              const double& min,
+              const double& max,
+              const TString& name = "a2",
+              const TString& title = "a2") {
+    if (a2_ != 0)
+      delete a2_;
     a2_ = new RooRealVar(name, title, value, min, max);
     initVal_a2 = value;
   }
-  void initA3(const double & value, const double & min, const double & max, const TString & name = "a3", const TString & title = "a3")
-  {
-    if( a3_ != 0 ) delete a3_;
+  void initA3(const double& value,
+              const double& min,
+              const double& max,
+              const TString& name = "a3",
+              const TString& title = "a3") {
+    if (a3_ != 0)
+      delete a3_;
     a3_ = new RooRealVar(name, title, value, min, max);
     initVal_a3 = value;
   }
-  void initA4(const double & value, const double & min, const double & max, const TString & name = "a4", const TString & title = "a4")
-  {
-    if( a4_ != 0 ) delete a4_;
+  void initA4(const double& value,
+              const double& min,
+              const double& max,
+              const TString& name = "a4",
+              const TString& title = "a4") {
+    if (a4_ != 0)
+      delete a4_;
     a4_ = new RooRealVar(name, title, value, min, max);
     initVal_a4 = value;
   }
-  void initA5(const double & value, const double & min, const double & max, const TString & name = "a5", const TString & title = "a5")
-  {
-    if( a5_ != 0 ) delete a5_;
+  void initA5(const double& value,
+              const double& min,
+              const double& max,
+              const TString& name = "a5",
+              const TString& title = "a5") {
+    if (a5_ != 0)
+      delete a5_;
     a5_ = new RooRealVar(name, title, value, min, max);
     initVal_a5 = value;
   }
-  void initA6(const double & value, const double & min, const double & max, const TString & name = "a6", const TString & title = "a6")
-  {
-    if( a6_ != 0 ) delete a6_;
+  void initA6(const double& value,
+              const double& min,
+              const double& max,
+              const TString& name = "a6",
+              const TString& title = "a6") {
+    if (a6_ != 0)
+      delete a6_;
     a6_ = new RooRealVar(name, title, value, min, max);
     initVal_a6 = value;
   }
-  void initAlpha(const double & value, const double & min, const double & max, const TString & name = "alpha", const TString & title = "alpha")
-  {
-    if( alpha_ != 0 ) delete alpha_;
+  void initAlpha(const double& value,
+                 const double& min,
+                 const double& max,
+                 const TString& name = "alpha",
+                 const TString& title = "alpha") {
+    if (alpha_ != 0)
+      delete alpha_;
     alpha_ = new RooRealVar(name, title, value, min, max);
     initVal_alpha = value;
   }
-  void initN(const double & value, const double & min, const double & max, const TString & name = "n", const TString & title = "n")
-  {
-    if( n_ != 0 ) delete n_;
+  void initN(const double& value,
+             const double& min,
+             const double& max,
+             const TString& name = "n",
+             const TString& title = "n") {
+    if (n_ != 0)
+      delete n_;
     n_ = new RooRealVar(name, title, value, min, max);
     initVal_n = value;
   }
-  void initFGCB(const double & value, const double & min, const double & max, const TString & name = "fGCB", const TString & title = "fGCB")
-  {
-    if( fGCB_ != 0 ) delete fGCB_;
+  void initFGCB(const double& value,
+                const double& min,
+                const double& max,
+                const TString& name = "fGCB",
+                const TString& title = "fGCB") {
+    if (fGCB_ != 0)
+      delete fGCB_;
     fGCB_ = new RooRealVar(name, title, value, min, max);
     initVal_fGCB = value;
   }
 
-  void reinitializeParameters(){
-    if (mean_!=0) mean_->setVal(initVal_mean);
-    if (mean2_!=0) mean2_->setVal(initVal_mean2);
-    if (mean3_!=0) mean3_->setVal(initVal_mean3);
-    if (sigma_!=0) sigma_->setVal(initVal_sigma);
-    if (sigma2_!=0) sigma2_->setVal(initVal_sigma2);
-    if (sigma3_!=0) sigma3_->setVal(initVal_sigma3);
-    if (gamma_!=0) gamma_->setVal(initVal_gamma);
-    if (gaussFrac_!=0) gaussFrac_->setVal(initVal_gaussFrac);
-    if (gaussFrac2_!=0) gaussFrac2_->setVal(initVal_gaussFrac2);
-    if (expCoeffa0_!=0) expCoeffa0_->setVal(initVal_expCoeffa0);
-    if (expCoeffa1_!=0) expCoeffa1_->setVal(initVal_expCoeffa1);
-    if (expCoeffa2_!=0) expCoeffa2_->setVal(initVal_expCoeffa2);
-    if (fsig_!=0) fsig_->setVal(initVal_fsig);
-    if (a0_!=0) a0_->setVal(initVal_a0);
-    if (a1_!=0) a1_->setVal(initVal_a1);
-    if (a2_!=0) a2_->setVal(initVal_a2);
-    if (a3_!=0) a3_->setVal(initVal_a3);
-    if (a4_!=0) a4_->setVal(initVal_a4);
-    if (a5_!=0) a5_->setVal(initVal_a5);
-    if (a6_!=0) a6_->setVal(initVal_a6);
-    if (alpha_!=0) alpha_->setVal(initVal_alpha);
-    if (n_!=0) n_->setVal(initVal_n);
-    if (fGCB_!=0) fGCB_->setVal(initVal_fGCB);
+  void reinitializeParameters() {
+    if (mean_ != 0)
+      mean_->setVal(initVal_mean);
+    if (mean2_ != 0)
+      mean2_->setVal(initVal_mean2);
+    if (mean3_ != 0)
+      mean3_->setVal(initVal_mean3);
+    if (sigma_ != 0)
+      sigma_->setVal(initVal_sigma);
+    if (sigma2_ != 0)
+      sigma2_->setVal(initVal_sigma2);
+    if (sigma3_ != 0)
+      sigma3_->setVal(initVal_sigma3);
+    if (gamma_ != 0)
+      gamma_->setVal(initVal_gamma);
+    if (gaussFrac_ != 0)
+      gaussFrac_->setVal(initVal_gaussFrac);
+    if (gaussFrac2_ != 0)
+      gaussFrac2_->setVal(initVal_gaussFrac2);
+    if (expCoeffa0_ != 0)
+      expCoeffa0_->setVal(initVal_expCoeffa0);
+    if (expCoeffa1_ != 0)
+      expCoeffa1_->setVal(initVal_expCoeffa1);
+    if (expCoeffa2_ != 0)
+      expCoeffa2_->setVal(initVal_expCoeffa2);
+    if (fsig_ != 0)
+      fsig_->setVal(initVal_fsig);
+    if (a0_ != 0)
+      a0_->setVal(initVal_a0);
+    if (a1_ != 0)
+      a1_->setVal(initVal_a1);
+    if (a2_ != 0)
+      a2_->setVal(initVal_a2);
+    if (a3_ != 0)
+      a3_->setVal(initVal_a3);
+    if (a4_ != 0)
+      a4_->setVal(initVal_a4);
+    if (a5_ != 0)
+      a5_->setVal(initVal_a5);
+    if (a6_ != 0)
+      a6_->setVal(initVal_a6);
+    if (alpha_ != 0)
+      alpha_->setVal(initVal_alpha);
+    if (n_ != 0)
+      n_->setVal(initVal_n);
+    if (fGCB_ != 0)
+      fGCB_->setVal(initVal_fGCB);
   }
 
-  inline RooRealVar* mean()
-  {
-    return mean_;
-  }
-  inline RooRealVar* mean2()
-  {
-    return mean2_;
-  }
-  inline RooRealVar* mean3()
-  {
-    return mean3_;
-  }
-  inline RooRealVar* sigma()
-  {
-    return sigma_;
-  }
-  inline RooRealVar* sigma2()
-  {
-    return sigma2_;
-  }
-  inline RooRealVar* sigma3()
-  {
-    return sigma3_;
-  }
-  inline RooRealVar* gamma()
-  {
-    return gamma_;
-  }
-  inline RooRealVar* gaussFrac()
-  {
-    return gaussFrac_;
-  }
-  inline RooRealVar* gaussFrac2()
-  {
-    return gaussFrac2_;
-  }
-  inline RooRealVar* expCoeffa0()
-  {
-    return expCoeffa0_;
-  }
-  inline RooRealVar* expCoeffa1()
-  {
-    return expCoeffa1_;
-  }
-  inline RooRealVar* expCoeffa2()
-  {
-    return expCoeffa2_;
-  }
-  inline RooRealVar* fsig()
-  {
-    return fsig_;
-  }
-  inline RooRealVar* a0()
-  {
-    return a0_;
-  }
-  inline RooRealVar* a1()
-  {
-    return a1_;
-  }
-  inline RooRealVar* a2()
-  {
-    return a2_;
-  }
-  inline RooRealVar* a3()
-  {
-    return a3_;
-  }
-  inline RooRealVar* a4()
-  {
-    return a4_;
-  }
-  inline RooRealVar* a5()
-  {
-    return a5_;
-  }
-  inline RooRealVar* a6()
-  {
-    return a6_;
-  }
-  inline RooRealVar* alpha()
-  {
-    return alpha_;
-  }
-  inline RooRealVar* n()
-  {
-    return n_;
-  }
-  inline RooRealVar* fGCB()
-  {
-    return fGCB_;
-  }
+  inline RooRealVar* mean() { return mean_; }
+  inline RooRealVar* mean2() { return mean2_; }
+  inline RooRealVar* mean3() { return mean3_; }
+  inline RooRealVar* sigma() { return sigma_; }
+  inline RooRealVar* sigma2() { return sigma2_; }
+  inline RooRealVar* sigma3() { return sigma3_; }
+  inline RooRealVar* gamma() { return gamma_; }
+  inline RooRealVar* gaussFrac() { return gaussFrac_; }
+  inline RooRealVar* gaussFrac2() { return gaussFrac2_; }
+  inline RooRealVar* expCoeffa0() { return expCoeffa0_; }
+  inline RooRealVar* expCoeffa1() { return expCoeffa1_; }
+  inline RooRealVar* expCoeffa2() { return expCoeffa2_; }
+  inline RooRealVar* fsig() { return fsig_; }
+  inline RooRealVar* a0() { return a0_; }
+  inline RooRealVar* a1() { return a1_; }
+  inline RooRealVar* a2() { return a2_; }
+  inline RooRealVar* a3() { return a3_; }
+  inline RooRealVar* a4() { return a4_; }
+  inline RooRealVar* a5() { return a5_; }
+  inline RooRealVar* a6() { return a6_; }
+  inline RooRealVar* alpha() { return alpha_; }
+  inline RooRealVar* n() { return n_; }
+  inline RooRealVar* fGCB() { return fGCB_; }
 
   /// Build the model for the specified signal type
-  RooAbsPdf * buildSignalModel(RooRealVar* x, const TString & signalType)
-  {
-    RooAbsPdf * signal = 0;
-    if( signalType == "gaussian" ) {
+  RooAbsPdf* buildSignalModel(RooRealVar* x, const TString& signalType) {
+    RooAbsPdf* signal = 0;
+    if (signalType == "gaussian") {
       // Fit a Gaussian p.d.f to the data
-      if( (mean_ == 0) || (sigma_ == 0) ) {
-	std::cout << "Error: one or more parameters are not initialized. Please be sure to initialize mean and sigma" << std::endl;
-	exit(1);
+      if ((mean_ == 0) || (sigma_ == 0)) {
+        std::cout << "Error: one or more parameters are not initialized. Please be sure to initialize mean and sigma"
+                  << std::endl;
+        exit(1);
       }
-      signal = new RooGaussian("gauss","gauss",*x,*mean_,*sigma_);
-    }
-    else if( signalType == "doubleGaussian" ) {
+      signal = new RooGaussian("gauss", "gauss", *x, *mean_, *sigma_);
+    } else if (signalType == "doubleGaussian") {
       // Fit with double gaussian
-      if( (mean_ == 0) || (sigma_ == 0) || (sigma2_ == 0) ) {
-	std::cout << "Error: one or more parameters are not initialized. Please be sure to initialize mean, sigma and sigma2" << std::endl;
-	exit(1);
+      if ((mean_ == 0) || (sigma_ == 0) || (sigma2_ == 0)) {
+        std::cout
+            << "Error: one or more parameters are not initialized. Please be sure to initialize mean, sigma and sigma2"
+            << std::endl;
+        exit(1);
       }
-      RooGaussModel * gaussModel = new RooGaussModel("gaussModel","gaussModel",*x,*mean_,*sigma_);
-      RooGaussModel * gaussModel2 = new RooGaussModel("gaussModel2","gaussModel2",*x,*mean_,*sigma2_);
+      RooGaussModel* gaussModel = new RooGaussModel("gaussModel", "gaussModel", *x, *mean_, *sigma_);
+      RooGaussModel* gaussModel2 = new RooGaussModel("gaussModel2", "gaussModel2", *x, *mean_, *sigma2_);
       signal = new RooAddModel("doubleGaussian", "double gaussian", RooArgList(*gaussModel, *gaussModel2), *gaussFrac_);
-    }
-    else if( signalType == "tripleGaussian" ) {
+    } else if (signalType == "tripleGaussian") {
       // Fit with triple gaussian
-      if( (mean_ == 0) || (mean2_ == 0) || (mean3_ == 0) || (sigma_ == 0) || (sigma2_ == 0) || (sigma3_ == 0) ) {
-	std::cout << "Error: one or more parameters are not initialized. Please be sure to initialize mean, mean2, mean3, sigma, sigma2, sigma3" << std::endl;
-	exit(1);
+      if ((mean_ == 0) || (mean2_ == 0) || (mean3_ == 0) || (sigma_ == 0) || (sigma2_ == 0) || (sigma3_ == 0)) {
+        std::cout << "Error: one or more parameters are not initialized. Please be sure to initialize mean, mean2, "
+                     "mean3, sigma, sigma2, sigma3"
+                  << std::endl;
+        exit(1);
       }
-      RooGaussModel * gaussModel = new RooGaussModel("gaussModel","gaussModel",*x,*mean_,*sigma_);
-      RooGaussModel * gaussModel2 = new RooGaussModel("gaussModel2","gaussModel2",*x,*mean2_,*sigma2_);
-      RooGaussModel * gaussModel3 = new RooGaussModel("gaussModel3","gaussModel3",*x,*mean3_,*sigma3_);
-      signal = new RooAddModel("tripleGaussian", "triple gaussian", RooArgList(*gaussModel, *gaussModel2, *gaussModel3), RooArgList(*gaussFrac_,*gaussFrac2_));
-    }
-    else if( signalType == "breitWigner" ) {
+      RooGaussModel* gaussModel = new RooGaussModel("gaussModel", "gaussModel", *x, *mean_, *sigma_);
+      RooGaussModel* gaussModel2 = new RooGaussModel("gaussModel2", "gaussModel2", *x, *mean2_, *sigma2_);
+      RooGaussModel* gaussModel3 = new RooGaussModel("gaussModel3", "gaussModel3", *x, *mean3_, *sigma3_);
+      signal = new RooAddModel("tripleGaussian",
+                               "triple gaussian",
+                               RooArgList(*gaussModel, *gaussModel2, *gaussModel3),
+                               RooArgList(*gaussFrac_, *gaussFrac2_));
+    } else if (signalType == "breitWigner") {
       // Fit a Breit-Wigner
-      if( (mean_ == 0) || (gamma_ == 0) ) {
-	std::cout << "Error: one or more parameters are not initialized. Please be sure to initialize mean and gamma" << std::endl;
-	exit(1);
+      if ((mean_ == 0) || (gamma_ == 0)) {
+        std::cout << "Error: one or more parameters are not initialized. Please be sure to initialize mean and gamma"
+                  << std::endl;
+        exit(1);
       }
       signal = new RooBreitWigner("breiWign", "breitWign", *x, *mean_, *gamma_);
-    }
-    else if( signalType == "relBreitWigner" ) {
+    } else if (signalType == "relBreitWigner") {
       // Fit a relativistic Breit-Wigner
-      if( (mean_ == 0) || (gamma_ == 0) ) {
-	std::cout << "Error: one or more parameters are not initialized. Please be sure to initialize mean and gamma" << std::endl;
-	exit(1);
+      if ((mean_ == 0) || (gamma_ == 0)) {
+        std::cout << "Error: one or more parameters are not initialized. Please be sure to initialize mean and gamma"
+                  << std::endl;
+        exit(1);
       }
-      signal = new RooGenericPdf ("Relativistic Breit-Wigner","RBW","@0/(pow(@0*@0 - @1*@1,2) + @2*@2*@0*@0*@0*@0/(@1*@1))",RooArgList(*x,*mean_,*gamma_));
-    }
-    else if( signalType == "voigtian" ) {
+      signal = new RooGenericPdf("Relativistic Breit-Wigner",
+                                 "RBW",
+                                 "@0/(pow(@0*@0 - @1*@1,2) + @2*@2*@0*@0*@0*@0/(@1*@1))",
+                                 RooArgList(*x, *mean_, *gamma_));
+    } else if (signalType == "voigtian") {
       // Fit a Voigtian
-      if( (mean_ == 0) || (sigma_ == 0) || (gamma_ == 0) ) {
-	std::cout << "Error: one or more parameters are not initialized. Please be sure to initialize mean, sigma and gamma" << std::endl;
-	exit(1);
+      if ((mean_ == 0) || (sigma_ == 0) || (gamma_ == 0)) {
+        std::cout
+            << "Error: one or more parameters are not initialized. Please be sure to initialize mean, sigma and gamma"
+            << std::endl;
+        exit(1);
       }
       signal = new RooVoigtian("voigt", "voigt", *x, *mean_, *gamma_, *sigma_);
-    }
-    else if( signalType == "crystalBall" ) {
+    } else if (signalType == "crystalBall") {
       // Fit a CrystalBall
-      if( (mean_ == 0) || (sigma_ == 0) || (alpha_ == 0) || (n_ == 0) ) {
-	std::cout << "Error: one or more parameters are not initialized. Please be sure to initialize mean, sigma, alpha and n" << std::endl;
-	exit(1);
+      if ((mean_ == 0) || (sigma_ == 0) || (alpha_ == 0) || (n_ == 0)) {
+        std::cout << "Error: one or more parameters are not initialized. Please be sure to initialize mean, sigma, "
+                     "alpha and n"
+                  << std::endl;
+        exit(1);
       }
       signal = new RooCBShape("crystalBall", "crystalBall", *x, *mean_, *sigma_, *alpha_, *n_);
-    }
-    else if( signalType == "breitWignerTimesCB" ) {
+    } else if (signalType == "breitWignerTimesCB") {
       // Fit a Breit Wigner convoluted with a CrystalBall
-      if( (mean_ == 0) || (mean2_==0 )|| (sigma_ == 0) || (gamma_==0) || (alpha_ == 0) || (n_ == 0) ) {
-	std::cout << "Error: one or more parameters are not initialized. Please be sure to initialize mean, mean2, sigma, gamma, alpha and n" << std::endl;
-	exit(1);
+      if ((mean_ == 0) || (mean2_ == 0) || (sigma_ == 0) || (gamma_ == 0) || (alpha_ == 0) || (n_ == 0)) {
+        std::cout << "Error: one or more parameters are not initialized. Please be sure to initialize mean, mean2, "
+                     "sigma, gamma, alpha and n"
+                  << std::endl;
+        exit(1);
       }
       RooAbsPdf* bw = new RooBreitWigner("breiWigner", "breitWigner", *x, *mean_, *gamma_);
       RooAbsPdf* cb = new RooCBShape("crystalBall", "crystalBall", *x, *mean2_, *sigma_, *alpha_, *n_);
-      signal = new RooFFTConvPdf("breitWignerTimesCB","breitWignerTimesCB",*x, *bw, *cb);
-    }
-    else if( signalType == "relBreitWignerTimesCB" ) {
+      signal = new RooFFTConvPdf("breitWignerTimesCB", "breitWignerTimesCB", *x, *bw, *cb);
+    } else if (signalType == "relBreitWignerTimesCB") {
       // Fit a relativistic Breit Wigner convoluted with a CrystalBall
-      if( (mean_ == 0) || (mean2_==0 )|| (sigma_ == 0) || (gamma_==0) || (alpha_ == 0) || (n_ == 0) ) {
-	std::cout << "Error: one or more parameters are not initialized. Please be sure to initialize mean, mean2, sigma, gamma, alpha and n" << std::endl;
-	exit(1);
+      if ((mean_ == 0) || (mean2_ == 0) || (sigma_ == 0) || (gamma_ == 0) || (alpha_ == 0) || (n_ == 0)) {
+        std::cout << "Error: one or more parameters are not initialized. Please be sure to initialize mean, mean2, "
+                     "sigma, gamma, alpha and n"
+                  << std::endl;
+        exit(1);
       }
-      RooGenericPdf *bw = new RooGenericPdf("Relativistic Breit-Wigner","RBW","@0/(pow(@0*@0 - @1*@1,2) + @2*@2*@0*@0*@0*@0/(@1*@1))", RooArgList(*x,*mean_,*gamma_));
+      RooGenericPdf* bw = new RooGenericPdf("Relativistic Breit-Wigner",
+                                            "RBW",
+                                            "@0/(pow(@0*@0 - @1*@1,2) + @2*@2*@0*@0*@0*@0/(@1*@1))",
+                                            RooArgList(*x, *mean_, *gamma_));
       RooAbsPdf* cb = new RooCBShape("crystalBall", "crystalBall", *x, *mean2_, *sigma_, *alpha_, *n_);
-      signal = new RooFFTConvPdf("relBreitWignerTimesCB","relBreitWignerTimesCB",*x, *bw, *cb);
-    }
-    else if( signalType == "gaussianPlusCrystalBall" ) {
+      signal = new RooFFTConvPdf("relBreitWignerTimesCB", "relBreitWignerTimesCB", *x, *bw, *cb);
+    } else if (signalType == "gaussianPlusCrystalBall") {
       // Fit a Gaussian + CrystalBall with the same mean
-      if( (mean_ == 0) || (sigma_ == 0) || (alpha_ == 0) || (n_ == 0) || (sigma2_ == 0) || (fGCB_ == 0) ) {
-	std::cout << "Error: one or more parameters are not initialized. Please be sure to initialize mean, sigma, sigma2, alpha, n and fGCB" << std::endl;
-	exit(1);
+      if ((mean_ == 0) || (sigma_ == 0) || (alpha_ == 0) || (n_ == 0) || (sigma2_ == 0) || (fGCB_ == 0)) {
+        std::cout << "Error: one or more parameters are not initialized. Please be sure to initialize mean, sigma, "
+                     "sigma2, alpha, n and fGCB"
+                  << std::endl;
+        exit(1);
       }
-      RooAbsPdf * tempCB = new RooCBShape("crystalBall", "crystalBall", *x, *mean_, *sigma_, *alpha_, *n_);
-      RooAbsPdf * tempGaussian = new RooGaussian("gauss", "gauss", *x, *mean_, *sigma2_);
+      RooAbsPdf* tempCB = new RooCBShape("crystalBall", "crystalBall", *x, *mean_, *sigma_, *alpha_, *n_);
+      RooAbsPdf* tempGaussian = new RooGaussian("gauss", "gauss", *x, *mean_, *sigma2_);
 
-      signal = new RooAddPdf("gaussianPlusCrystalBall", "gaussianPlusCrystalBall", RooArgList(*tempCB, *tempGaussian), *fGCB_);
-    }
-    else if( signalType == "voigtianPlusCrystalBall" ) {
+      signal = new RooAddPdf(
+          "gaussianPlusCrystalBall", "gaussianPlusCrystalBall", RooArgList(*tempCB, *tempGaussian), *fGCB_);
+    } else if (signalType == "voigtianPlusCrystalBall") {
       // Fit a Voigtian + CrystalBall with the same mean
-      if( (mean_ == 0) || (sigma_ == 0) || (gamma_ == 0) || (alpha_ == 0) || (n_ == 0) || (sigma2_ == 0) || (fGCB_ == 0) ) {
-	std::cout << "Error: one or more parameters are not initialized. Please be sure to initialize mean, gamma, sigma, sigma2, alpha, n and fGCB" << std::endl;
-	exit(1);
+      if ((mean_ == 0) || (sigma_ == 0) || (gamma_ == 0) || (alpha_ == 0) || (n_ == 0) || (sigma2_ == 0) ||
+          (fGCB_ == 0)) {
+        std::cout << "Error: one or more parameters are not initialized. Please be sure to initialize mean, gamma, "
+                     "sigma, sigma2, alpha, n and fGCB"
+                  << std::endl;
+        exit(1);
       }
-      RooAbsPdf * tempVoigt = new RooVoigtian("voigt", "voigt", *x, *mean_, *gamma_, *sigma_);
-      RooAbsPdf * tempCB = new RooCBShape("crystalBall", "crystalBall", *x, *mean_, *sigma2_, *alpha_, *n_);
+      RooAbsPdf* tempVoigt = new RooVoigtian("voigt", "voigt", *x, *mean_, *gamma_, *sigma_);
+      RooAbsPdf* tempCB = new RooCBShape("crystalBall", "crystalBall", *x, *mean_, *sigma2_, *alpha_, *n_);
 
-      signal = new RooAddPdf("voigtianPlusCrystalBall", "voigtianPlusCrystalBall", RooArgList(*tempCB, *tempVoigt), *fGCB_);
-    }
-    else if( signalType == "breitWignerPlusCrystalBall" ) {
+      signal =
+          new RooAddPdf("voigtianPlusCrystalBall", "voigtianPlusCrystalBall", RooArgList(*tempCB, *tempVoigt), *fGCB_);
+    } else if (signalType == "breitWignerPlusCrystalBall") {
       // Fit a Breit-Wigner + CrystalBall with the same mean
-      if( (mean_ == 0) || (gamma_ == 0) || (alpha_ == 0) || (n_ == 0) || (sigma2_ == 0) || (fGCB_ == 0) ) {
-	std::cout << "Error: one or more parameters are not initialized. Please be sure to initialize mean, gamma, sigma, alpha, n and fGCB" << std::endl;
-	exit(1);
+      if ((mean_ == 0) || (gamma_ == 0) || (alpha_ == 0) || (n_ == 0) || (sigma2_ == 0) || (fGCB_ == 0)) {
+        std::cout << "Error: one or more parameters are not initialized. Please be sure to initialize mean, gamma, "
+                     "sigma, alpha, n and fGCB"
+                  << std::endl;
+        exit(1);
       }
-      RooAbsPdf * tempBW = new RooBreitWigner("breitWign", "breitWign", *x, *mean_, *gamma_);
-      RooAbsPdf * tempCB = new RooCBShape("crystalBall", "crystalBall", *x, *mean_, *sigma2_, *alpha_, *n_);
+      RooAbsPdf* tempBW = new RooBreitWigner("breitWign", "breitWign", *x, *mean_, *gamma_);
+      RooAbsPdf* tempCB = new RooCBShape("crystalBall", "crystalBall", *x, *mean_, *sigma2_, *alpha_, *n_);
 
-      signal = new RooAddPdf("breitWignerPlusCrystalBall", "breitWignerPlusCrystalBall", RooArgList(*tempCB, *tempBW), *fGCB_);
+      signal = new RooAddPdf(
+          "breitWignerPlusCrystalBall", "breitWignerPlusCrystalBall", RooArgList(*tempCB, *tempBW), *fGCB_);
     }
 
-    else if( signalType != "" ) {
+    else if (signalType != "") {
       std::cout << "Unknown signal function: " << signalType << ". Signal will not be in the model" << std::endl;
     }
     return signal;
   }
 
   /// Build the model for the specified background type
-  RooAbsPdf * buildBackgroundModel(RooRealVar* x, const TString & backgroundType)
-  {
-    RooAbsPdf * background = 0;
-    if( backgroundType == "exponential" ) {
+  RooAbsPdf* buildBackgroundModel(RooRealVar* x, const TString& backgroundType) {
+    RooAbsPdf* background = 0;
+    if (backgroundType == "exponential") {
       // Add an exponential for the background
-      if( (expCoeffa1_ == 0) || (fsig_ == 0) ) {
-	std::cout << "Error: one or more parameters are not initialized. Please be sure to initialize expCoeffa1 and fsig" << std::endl;
-	exit(1);
+      if ((expCoeffa1_ == 0) || (fsig_ == 0)) {
+        std::cout
+            << "Error: one or more parameters are not initialized. Please be sure to initialize expCoeffa1 and fsig"
+            << std::endl;
+        exit(1);
       }
       background = new RooExponential("exponential", "exponential", *x, *expCoeffa1_);
     }
 
-    if( backgroundType == "exponentialpol" ) {
+    if (backgroundType == "exponentialpol") {
       // Add an exponential for the background
-      if( (expCoeffa0_ == 0) ||  (expCoeffa1_ == 0) || (expCoeffa2_ == 0) || (fsig_ == 0) ) {
-	std::cout << "Error: one or more parameters are not initialized. Please be sure to initialize expCoeff and fsig" << std::endl;
-	exit(1);
+      if ((expCoeffa0_ == 0) || (expCoeffa1_ == 0) || (expCoeffa2_ == 0) || (fsig_ == 0)) {
+        std::cout << "Error: one or more parameters are not initialized. Please be sure to initialize expCoeff and fsig"
+                  << std::endl;
+        exit(1);
       }
-      background = new RooGenericPdf("exponential","exponential","TMath::Exp(@1+@2*@0+@3*@0*@0)",RooArgList(*x, *expCoeffa0_, *expCoeffa1_, *expCoeffa2_));
+      background = new RooGenericPdf("exponential",
+                                     "exponential",
+                                     "TMath::Exp(@1+@2*@0+@3*@0*@0)",
+                                     RooArgList(*x, *expCoeffa0_, *expCoeffa1_, *expCoeffa2_));
     }
 
-    else if( backgroundType == "chebychev0" ) {
+    else if (backgroundType == "chebychev0") {
       // Add a linear background
-      if( a0_ == 0 ) {
-	std::cout << "Error: one or more parameters are not initialized. Please be sure to initialize a0" << std::endl;
-	exit(1);
+      if (a0_ == 0) {
+        std::cout << "Error: one or more parameters are not initialized. Please be sure to initialize a0" << std::endl;
+        exit(1);
       }
       background = new RooChebychev("chebychev0", "chebychev0", *x, *a0_);
-    }
-    else if( backgroundType == "chebychev1" ) {
+    } else if (backgroundType == "chebychev1") {
       // Add a 2nd order chebychev polynomial background
-      if( (a0_ == 0) || (a1_ == 0) ) {
-	std::cout << "Error: one or more parameters are not initialized. Please be sure to initialize a0 and a1" << std::endl;
-	exit(1);
+      if ((a0_ == 0) || (a1_ == 0)) {
+        std::cout << "Error: one or more parameters are not initialized. Please be sure to initialize a0 and a1"
+                  << std::endl;
+        exit(1);
       }
       background = new RooChebychev("chebychev1", "chebychev1", *x, RooArgList(*a0_, *a1_));
-    }
-    else if( backgroundType == "chebychev3" ) {
+    } else if (backgroundType == "chebychev3") {
       // Add a 3rd order chebychev polynomial background
-      if( (a0_ == 0) || (a1_ == 0) || (a2_ == 0) || (a3_ == 0) ) {
-	std::cout << "Error: one or more parameters are not initialized. Please be sure to initialize a0, a1, a2 and a3" << std::endl;
-	exit(1);
+      if ((a0_ == 0) || (a1_ == 0) || (a2_ == 0) || (a3_ == 0)) {
+        std::cout << "Error: one or more parameters are not initialized. Please be sure to initialize a0, a1, a2 and a3"
+                  << std::endl;
+        exit(1);
       }
-      background = new RooChebychev("3rdOrderPol", "3rdOrderPol", *x, RooArgList(*a0_,*a1_,*a2_,*a3_));
+      background = new RooChebychev("3rdOrderPol", "3rdOrderPol", *x, RooArgList(*a0_, *a1_, *a2_, *a3_));
     }
 
-    else if( backgroundType == "chebychev6" ) {
+    else if (backgroundType == "chebychev6") {
       // Add a 6th order chebychev polynomial background
-      if( (a0_ == 0) || (a1_ == 0) || (a2_ == 0) || (a3_ == 0) || (a4_ == 0) || (a5_ == 0) || (a6_ == 0) ) {
-	std::cout << "Error: one or more parameters are not initialized. Please be sure to initialize a0, a1, a2, a3, a4, a5 and a6" << std::endl;
-	exit(1);
+      if ((a0_ == 0) || (a1_ == 0) || (a2_ == 0) || (a3_ == 0) || (a4_ == 0) || (a5_ == 0) || (a6_ == 0)) {
+        std::cout << "Error: one or more parameters are not initialized. Please be sure to initialize a0, a1, a2, a3, "
+                     "a4, a5 and a6"
+                  << std::endl;
+        exit(1);
       }
-      background = new RooChebychev("6thOrderPol", "6thOrderPol", *x, RooArgList(*a0_,*a1_,*a2_,*a3_,*a4_,*a5_,*a6_));
+      background =
+          new RooChebychev("6thOrderPol", "6thOrderPol", *x, RooArgList(*a0_, *a1_, *a2_, *a3_, *a4_, *a5_, *a6_));
     }
 
     return background;
   }
 
   /// Build the model to fit
-  RooAbsPdf * buildModel(RooRealVar* x, const TString & signalType, const TString & backgroundType)
-  {
-    RooAbsPdf * model = 0;
+  RooAbsPdf* buildModel(RooRealVar* x, const TString& signalType, const TString& backgroundType) {
+    RooAbsPdf* model = 0;
 
-    RooAbsPdf * signal = buildSignalModel(x, signalType);
-    RooAbsPdf * background = buildBackgroundModel(x, backgroundType);
+    RooAbsPdf* signal = buildSignalModel(x, signalType);
+    RooAbsPdf* background = buildBackgroundModel(x, backgroundType);
 
-    if( (signal != 0) && (background != 0) ) {
+    if ((signal != 0) && (background != 0)) {
       // Combine signal and background pdfs
       std::cout << "Building model with signal and backgound" << std::endl;
       model = new RooAddPdf("model", "model", RooArgList(*signal, *background), *fsig_);
-    }
-    else if( signal != 0 ) {
+    } else if (signal != 0) {
       std::cout << "Building model with signal" << std::endl;
       model = signal;
-    }
-    else if( background != 0 ) {
+    } else if (background != 0) {
       std::cout << "Building model with backgound" << std::endl;
       model = background;
-    }
-    else {
+    } else {
       std::cout << "Nothing to fit" << std::endl;
       exit(0);
     }
@@ -629,7 +717,6 @@ public:
   bool useChi2_;
 
 protected:
-
   // Declare all variables
   RooRealVar* mean_;
   RooRealVar* mean2_;
@@ -679,7 +766,6 @@ protected:
   double initVal_alpha;
   double initVal_n;
   double initVal_fGCB;
-
 };
 
 #endif

--- a/MuonAnalysis/MomentumScaleCalibration/test/Macros/RooFit/FitWithRooFit.cc
+++ b/MuonAnalysis/MomentumScaleCalibration/test/Macros/RooFit/FitWithRooFit.cc
@@ -23,7 +23,7 @@
 #include "RooPolynomial.h"
 #include "RooCBShape.h"
 #include "RooChi2Var.h"
-#include "RooFitLegacy/RooMinuit.h"
+#include "RooMinimizer.h"
 #include "RooBreitWigner.h"
 #include "RooFFTConvPdf.h"
 
@@ -126,7 +126,7 @@ public:
     // Fit with chi^2
     else {
       std::cout << "FITTING WITH CHI^2" << std::endl;
-      RooMinuit m(chi2);
+      RooMinimizer m(chi2);
       m.migrad();
       m.hesse();
       // RooFitResult* r_chi2_wgt = m.save();

--- a/PhysicsTools/TagAndProbe/src/TagProbeFitter.cc
+++ b/PhysicsTools/TagAndProbe/src/TagProbeFitter.cc
@@ -33,7 +33,6 @@
 #include "RooLinkedListIter.h"
 #include "RooMappedCategory.h"
 #include "RooMinimizer.h"
-#include "RooFitLegacy/RooMinuit.h"
 #include "RooMsgService.h"
 #include "RooMultiCategory.h"
 #include "RooNLLVar.h"
@@ -584,9 +583,8 @@ void TagProbeFitter::doFitEfficiency(RooWorkspace* w, string pdfName, RooRealVar
   RooAbsReal* simNLL = w->pdf("simPdf")->createNLL(*data, Extended(true), NumCPU(numCPU));
 
   RooMinimizer minimizer(*simNLL);  // we are going to use this for 'scan'
-  RooMinuit minuit(*simNLL);
-  minuit.setStrategy(1);
-  minuit.setProfile(true);
+  minimizer.setStrategy(1);
+  minimizer.setProfile(true);
   RooProfileLL profileLL("simPdfNLL", "", *simNLL, *w->var("efficiency"));
 
   //******* The block of code below is to make the fit converge faster.
@@ -618,8 +616,8 @@ void TagProbeFitter::doFitEfficiency(RooWorkspace* w, string pdfName, RooRealVar
       varFixer(w, true);
       //do fit
       minimizer.minimize("Minuit2", "Scan");
-      minuit.migrad();
-      minuit.hesse();
+      minimizer.migrad();
+      minimizer.hesse();
       //minuit.minos();
       //w->pdf("simPdf")->fitTo(*data, Save(true), Extended(true), NumCPU(numCPU), Strategy(2),
       //PrintLevel(quiet?-1:1), PrintEvalErrors(quiet?-1:1), Warnings(!quiet));
@@ -627,8 +625,8 @@ void TagProbeFitter::doFitEfficiency(RooWorkspace* w, string pdfName, RooRealVar
       varFixer(w, false);
       //do fit
       minimizer.minimize("Minuit2", "Scan");
-      minuit.migrad();
-      minuit.hesse();
+      minimizer.migrad();
+      minimizer.hesse();
       //minuit.minos();
       //w->pdf("simPdf")->fitTo(*data, Save(true), Extended(true), NumCPU(numCPU), Strategy(2),
       //PrintLevel(quiet?-1:1), PrintEvalErrors(quiet?-1:1), Warnings(!quiet));
@@ -643,8 +641,8 @@ void TagProbeFitter::doFitEfficiency(RooWorkspace* w, string pdfName, RooRealVar
 
     //do fit
     minimizer.minimize("Minuit2", "Scan");
-    minuit.migrad();
-    minuit.hesse();
+    minimizer.migrad();
+    minimizer.hesse();
     // initialize the profile likelihood
     profileLL.getVal();
     RooMinimizer* profMinuit = profileLL.minimizer();
@@ -665,8 +663,8 @@ void TagProbeFitter::doFitEfficiency(RooWorkspace* w, string pdfName, RooRealVar
 
     //do fit
     minimizer.minimize("Minuit2", "Scan");
-    minuit.migrad();
-    minuit.hesse();
+    minimizer.migrad();
+    minimizer.hesse();
     res.reset(w->pdf("simPdf")->fitTo(*data,
                                       Save(true),
                                       Extended(true),

--- a/PhysicsTools/TagAndProbe/src/TagProbeFitter.cc
+++ b/PhysicsTools/TagAndProbe/src/TagProbeFitter.cc
@@ -33,7 +33,7 @@
 #include "RooLinkedListIter.h"
 #include "RooMappedCategory.h"
 #include "RooMinimizer.h"
-#include "RooMinuit.h"
+#include "RooFitLegacy/RooMinuit.h"
 #include "RooMsgService.h"
 #include "RooMultiCategory.h"
 #include "RooNLLVar.h"

--- a/PhysicsTools/TagAndProbe/test/utilities/ElectronTagAndProbeFitter.C
+++ b/PhysicsTools/TagAndProbe/test/utilities/ElectronTagAndProbeFitter.C
@@ -27,7 +27,6 @@
 #include "RooGaussian.h"
 #include "RooNLLVar.h"
 #include "RooConstVar.h"
-#include "RooFitLegacy/RooMinuit.h"
 #include "RooFitResult.h"
 #include "RooExponential.h"
 #include "RooFFTConvPdf.h"

--- a/PhysicsTools/TagAndProbe/test/utilities/ElectronTagAndProbeFitter.C
+++ b/PhysicsTools/TagAndProbe/test/utilities/ElectronTagAndProbeFitter.C
@@ -4,15 +4,14 @@
 //________________________________________________________________________________________________
 
 #if !defined(__CINT__) || defined(__MAKECINT__)
-#include <TROOT.h>                  // access to gROOT, entry point to ROOT system
-#include <TSystem.h>                // interface to OS
-#include <TStyle.h>                 // class to handle ROOT plotting style
-#include <TCanvas.h>                // class for drawing
-#include <TBenchmark.h>             // class to track macro running statistics
-#include <iostream>                 // standard I/O
+#include <TROOT.h>       // access to gROOT, entry point to ROOT system
+#include <TSystem.h>     // interface to OS
+#include <TStyle.h>      // class to handle ROOT plotting style
+#include <TCanvas.h>     // class for drawing
+#include <TBenchmark.h>  // class to track macro running statistics
+#include <iostream>      // standard I/O
 #include <iomanip>
 #include <fstream>
-
 
 // RooFit headers
 #include "RooRealVar.h"
@@ -28,7 +27,7 @@
 #include "RooGaussian.h"
 #include "RooNLLVar.h"
 #include "RooConstVar.h"
-#include "RooMinuit.h"
+#include "RooFitLegacy/RooMinuit.h"
 #include "RooFitResult.h"
 #include "RooExponential.h"
 #include "RooFFTConvPdf.h"
@@ -40,49 +39,43 @@
 
 #endif
 
-#define LUMINOSITY 2.88 //(in pb^-1)
+#define LUMINOSITY 2.88  //(in pb^-1)
 #define NBINSPASS 60
 #define NBINSFAIL 24
 
 ofstream effTextFile("efficiency.txt");
 
-
-
-double ErrorInProduct(double x, double errx, double y, 
-                      double erry, double corr) {
-   double xFrErr = errx/x;
-   double yFrErr = erry/y;
-   return sqrt(pow(xFrErr,2) + pow(yFrErr,2) + 2.0*corr*xFrErr*yFrErr)*x*y;
+double ErrorInProduct(double x, double errx, double y, double erry, double corr) {
+  double xFrErr = errx / x;
+  double yFrErr = erry / y;
+  return sqrt(pow(xFrErr, 2) + pow(yFrErr, 2) + 2.0 * corr * xFrErr * yFrErr) * x * y;
 }
 
+RooRealVar* LoadParameters(string filename, string label, string parname) {
+  RooRealVar* newVar = 0;
 
-RooRealVar* LoadParameters(string filename, string label, string parname )
-{
-
-  RooRealVar *newVar = 0;
-
-  // now read in the parameters from the file.  Stored in the file as                                                                                                  
-  // parameter manager   |   name   | initial val  | min  | max  | step                                                                                                
+  // now read in the parameters from the file.  Stored in the file as
+  // parameter manager   |   name   | initial val  | min  | max  | step
   fstream parameter_file(filename.c_str(), ios::in);
-  if (! parameter_file) {
+  if (!parameter_file) {
     cout << "Error:  Couldn't open parameters file " << filename << endl;
     return false;
   }
-  
+
   string name;
   string category;
   double initial_val, min, max, step;
-  
+
   char c;
   Bool_t foundPar = kFALSE;
   while (true) {
-    
-    // skip white spaces and look for a #                                                                                                                              
-    while(parameter_file.get(c)) {
-      if      (isspace(c) || c == '\n')
+    // skip white spaces and look for a #
+    while (parameter_file.get(c)) {
+      if (isspace(c) || c == '\n')
         continue;
       else if (c == '#')
-        while (c != '\n') parameter_file.get(c);
+        while (c != '\n')
+          parameter_file.get(c);
       else {
         parameter_file.putback(c);
         break;
@@ -90,21 +83,21 @@ RooRealVar* LoadParameters(string filename, string label, string parname )
     }
     if (parameter_file.fail())
       break;
-    
+
     parameter_file >> category >> name >> initial_val >> min >> max >> step;
     if (parameter_file.fail())
       break;
-    
+
     if (category == label && parname == name) {
-      // create a new fit parameter         
-      newVar = new RooRealVar(name.c_str(),name.c_str(),initial_val,min, max);
+      // create a new fit parameter
+      newVar = new RooRealVar(name.c_str(), name.c_str(), initial_val, min, max);
       if (step == 0) {
-        newVar->setConstant(kTRUE);  
+        newVar->setConstant(kTRUE);
       }
-      
+
       break;
     }
-  } //end while loop
+  }  //end while loop
 
   if (!newVar) {
     cout << "Could not load parameter " << parname << " from file " << filename << " , category " << label << endl;
@@ -114,10 +107,7 @@ RooRealVar* LoadParameters(string filename, string label, string parname )
   return newVar;
 }
 
-
-void PrintParameter(RooRealVar *var, string label, string name) {
-
-
+void PrintParameter(RooRealVar* var, string label, string name) {
   cout.width(50);
   cout << left << label;
   cout.width(40);
@@ -136,72 +126,68 @@ void PrintParameter(RooRealVar *var, string label, string name) {
     cout << left << scientific << 1.0;
   }
   cout << endl;
-  
 }
 
-
-
-
-
-
-void performFit(string inputDir, string inputParameterFile, string label,
-                string PassInputDataFilename, string FailInputDataFilename, 
-                string PassSignalTemplateHistName, string FailSignalTemplateHistName)
-{
-
+void performFit(string inputDir,
+                string inputParameterFile,
+                string label,
+                string PassInputDataFilename,
+                string FailInputDataFilename,
+                string PassSignalTemplateHistName,
+                string FailSignalTemplateHistName) {
   gBenchmark->Start("fitZCat");
 
   //--------------------------------------------------------------------------------------------------------------
-  // Settings 
+  // Settings
   //==============================================================================================================
-  
-  const Double_t mlow  = 60;
+
+  const Double_t mlow = 60;
   const Double_t mhigh = 120;
-  const Int_t    nbins = 24;
+  const Int_t nbins = 24;
 
   TString effType = inputDir;
 
   // The fit variable - lepton invariant mass
-  RooRealVar* rooMass_ = new RooRealVar("Mass","m_{ee}",mlow, mhigh, "GeV/c^{2}");
+  RooRealVar* rooMass_ = new RooRealVar("Mass", "m_{ee}", mlow, mhigh, "GeV/c^{2}");
   RooRealVar Mass = *rooMass_;
   Mass.setBins(nbins);
 
   // Make the category variable that defines the two fits,
   // namely whether the probe passes or fails the eff criteria.
-  RooCategory sample("sample","") ;
-  sample.defineType("Pass", 1) ;
-  sample.defineType("Fail", 2) ; 
+  RooCategory sample("sample", "");
+  sample.defineType("Pass", 1);
+  sample.defineType("Fail", 2);
 
+  RooDataSet* dataPass = RooDataSet::read((inputDir + PassInputDataFilename).c_str(), RooArgList(Mass));
+  RooDataSet* dataFail = RooDataSet::read((inputDir + FailInputDataFilename).c_str(), RooArgList(Mass));
 
-  RooDataSet *dataPass  = RooDataSet::read((inputDir+PassInputDataFilename).c_str(),RooArgList(Mass));
-  RooDataSet *dataFail  = RooDataSet::read((inputDir+FailInputDataFilename).c_str(),RooArgList(Mass));
-
-  RooDataSet *dataCombined = new RooDataSet("dataCombined","dataCombined", RooArgList(Mass), RooFit::Index(sample), 
-                                            RooFit::Import("Pass",*dataPass),
-                                            RooFit::Import("Fail",*dataFail));
-
-
+  RooDataSet* dataCombined = new RooDataSet("dataCombined",
+                                            "dataCombined",
+                                            RooArgList(Mass),
+                                            RooFit::Index(sample),
+                                            RooFit::Import("Pass", *dataPass),
+                                            RooFit::Import("Fail", *dataFail));
 
   //*********************************************************************************************
   //Define Free Parameters
   //*********************************************************************************************
-  RooRealVar* ParNumSignal =  LoadParameters(inputParameterFile, label,"ParNumSignal");
-  RooRealVar* ParNumBkgPass =  LoadParameters(inputParameterFile, label,"ParNumBkgPass");
-  RooRealVar* ParNumBkgFail =  LoadParameters(inputParameterFile, label, "ParNumBkgFail");
-  RooRealVar* ParEfficiency  = LoadParameters(inputParameterFile, label, "ParEfficiency");
-  RooRealVar* ParPassBackgroundExpCoefficient = LoadParameters(inputParameterFile, label, "ParPassBackgroundExpCoefficient");
-  RooRealVar* ParFailBackgroundExpCoefficient = LoadParameters(inputParameterFile, label, "ParFailBackgroundExpCoefficient");
+  RooRealVar* ParNumSignal = LoadParameters(inputParameterFile, label, "ParNumSignal");
+  RooRealVar* ParNumBkgPass = LoadParameters(inputParameterFile, label, "ParNumBkgPass");
+  RooRealVar* ParNumBkgFail = LoadParameters(inputParameterFile, label, "ParNumBkgFail");
+  RooRealVar* ParEfficiency = LoadParameters(inputParameterFile, label, "ParEfficiency");
+  RooRealVar* ParPassBackgroundExpCoefficient =
+      LoadParameters(inputParameterFile, label, "ParPassBackgroundExpCoefficient");
+  RooRealVar* ParFailBackgroundExpCoefficient =
+      LoadParameters(inputParameterFile, label, "ParFailBackgroundExpCoefficient");
   RooRealVar* ParPassSignalMassShift = LoadParameters(inputParameterFile, label, "ParPassSignalMassShift");
   RooRealVar* ParFailSignalMassShift = LoadParameters(inputParameterFile, label, "ParFailSignalMassShift");
   RooRealVar* ParPassSignalResolution = LoadParameters(inputParameterFile, label, "ParPassSignalResolution");
   RooRealVar* ParFailSignalResolution = LoadParameters(inputParameterFile, label, "ParFailSignalResolution");
 
-
-
-// new RooRealVar  ("ParPassSignalMassShift","ParPassSignalMassShift",-2.6079e-02,-10.0, 10.0);   //ParPassSignalMassShift->setConstant(kTRUE);  
-//   RooRealVar* ParFailSignalMassShift = new RooRealVar  ("ParFailSignalMassShift","ParFailSignalMassShift",7.2230e-01,-10.0, 10.0);   //ParFailSignalMassShift->setConstant(kTRUE);  
-//   RooRealVar* ParPassSignalResolution = new RooRealVar ("ParPassSignalResolution","ParPassSignalResolution",6.9723e-01,0.0, 10.0);     ParPassSignalResolution->setConstant(kTRUE);  
-//   RooRealVar* ParFailSignalResolution = new RooRealVar ("ParFailSignalResolution","ParFailSignalResolution",1.6412e+00,0.0, 10.0);     ParFailSignalResolution->setConstant(kTRUE);  
+  // new RooRealVar  ("ParPassSignalMassShift","ParPassSignalMassShift",-2.6079e-02,-10.0, 10.0);   //ParPassSignalMassShift->setConstant(kTRUE);
+  //   RooRealVar* ParFailSignalMassShift = new RooRealVar  ("ParFailSignalMassShift","ParFailSignalMassShift",7.2230e-01,-10.0, 10.0);   //ParFailSignalMassShift->setConstant(kTRUE);
+  //   RooRealVar* ParPassSignalResolution = new RooRealVar ("ParPassSignalResolution","ParPassSignalResolution",6.9723e-01,0.0, 10.0);     ParPassSignalResolution->setConstant(kTRUE);
+  //   RooRealVar* ParFailSignalResolution = new RooRealVar ("ParFailSignalResolution","ParFailSignalResolution",1.6412e+00,0.0, 10.0);     ParFailSignalResolution->setConstant(kTRUE);
 
   //*********************************************************************************************
   //
@@ -209,219 +195,215 @@ void performFit(string inputDir, string inputParameterFile, string label,
   //
   //*********************************************************************************************
 
-  TFile *Zeelineshape_file =  new TFile("res/photonEfffromZee.dflag1.eT1.2.gT40.mt15.root", "READ");
-  TH1* histTemplatePass = (TH1D*) Zeelineshape_file->Get(PassSignalTemplateHistName.c_str());
-  TH1* histTemplateFail = (TH1D*) Zeelineshape_file->Get(FailSignalTemplateHistName.c_str());
+  TFile* Zeelineshape_file = new TFile("res/photonEfffromZee.dflag1.eT1.2.gT40.mt15.root", "READ");
+  TH1* histTemplatePass = (TH1D*)Zeelineshape_file->Get(PassSignalTemplateHistName.c_str());
+  TH1* histTemplateFail = (TH1D*)Zeelineshape_file->Get(FailSignalTemplateHistName.c_str());
 
-  //Introduce mass shift coordinate transformation 
-//   RooFormulaVar PassShiftedMass("PassShiftedMass","@0-@1",RooArgList(Mass,*ParPassSignalMassShift));
-//   RooFormulaVar FailShiftedMass("FailShiftedMass","@0-@1",RooArgList(Mass,*ParFailSignalMassShift));
+  //Introduce mass shift coordinate transformation
+  //   RooFormulaVar PassShiftedMass("PassShiftedMass","@0-@1",RooArgList(Mass,*ParPassSignalMassShift));
+  //   RooFormulaVar FailShiftedMass("FailShiftedMass","@0-@1",RooArgList(Mass,*ParFailSignalMassShift));
 
-  RooGaussian  *PassSignalResolutionFunction =  new RooGaussian("PassSignalResolutionFunction","PassSignalResolutionFunction",Mass,*ParPassSignalMassShift,*ParPassSignalResolution);
-  RooGaussian  *FailSignalResolutionFunction =  new RooGaussian("FailSignalResolutionFunction","FailSignalResolutionFunction",Mass,*ParFailSignalMassShift,*ParFailSignalResolution);
+  RooGaussian* PassSignalResolutionFunction = new RooGaussian("PassSignalResolutionFunction",
+                                                              "PassSignalResolutionFunction",
+                                                              Mass,
+                                                              *ParPassSignalMassShift,
+                                                              *ParPassSignalResolution);
+  RooGaussian* FailSignalResolutionFunction = new RooGaussian("FailSignalResolutionFunction",
+                                                              "FailSignalResolutionFunction",
+                                                              Mass,
+                                                              *ParFailSignalMassShift,
+                                                              *ParFailSignalResolution);
 
+  RooDataHist* dataHistPass = new RooDataHist("dataHistPass", "dataHistPass", RooArgSet(Mass), histTemplatePass);
+  RooDataHist* dataHistFail = new RooDataHist("dataHistFail", "dataHistFail", RooArgSet(Mass), histTemplateFail);
+  RooHistPdf* signalShapePassTemplatePdf =
+      new RooHistPdf("signalShapePassTemplatePdf", "signalShapePassTemplatePdf", Mass, *dataHistPass, 1);
+  RooHistPdf* signalShapeFailTemplatePdf =
+      new RooHistPdf("signalShapeFailTemplatePdf", "signalShapeFailTemplatePdf", Mass, *dataHistFail, 1);
 
-  RooDataHist* dataHistPass = new RooDataHist("dataHistPass","dataHistPass", RooArgSet(Mass), histTemplatePass);
-  RooDataHist* dataHistFail = new RooDataHist("dataHistFail","dataHistFail", RooArgSet(Mass), histTemplateFail);
-  RooHistPdf* signalShapePassTemplatePdf = new RooHistPdf("signalShapePassTemplatePdf", "signalShapePassTemplatePdf", Mass, *dataHistPass, 1);
-  RooHistPdf* signalShapeFailTemplatePdf = new RooHistPdf("signalShapeFailTemplatePdf", "signalShapeFailTemplatePdf", Mass, *dataHistFail, 1);
+  RooFFTConvPdf* signalShapePassPdf = new RooFFTConvPdf(
+      "signalShapePassPdf", "signalShapePassPdf", Mass, *signalShapePassTemplatePdf, *PassSignalResolutionFunction, 2);
+  RooFFTConvPdf* signalShapeFailPdf = new RooFFTConvPdf(
+      "signalShapeFailPdf", "signalShapeFailPdf", Mass, *signalShapeFailTemplatePdf, *FailSignalResolutionFunction, 2);
 
-  RooFFTConvPdf* signalShapePassPdf = new RooFFTConvPdf("signalShapePassPdf","signalShapePassPdf"  , Mass, *signalShapePassTemplatePdf,*PassSignalResolutionFunction,2);
-  RooFFTConvPdf* signalShapeFailPdf = new RooFFTConvPdf("signalShapeFailPdf","signalShapeFailPdf"  , Mass, *signalShapeFailTemplatePdf,*FailSignalResolutionFunction,2);
-
-
-  // Now define some efficiency/yield variables  
-  RooFormulaVar* NumSignalPass = new RooFormulaVar("NumSignalPass", "ParEfficiency*ParNumSignal", RooArgList(*ParEfficiency,*ParNumSignal));
-  RooFormulaVar* NumSignalFail = new RooFormulaVar("NumSignalFail", "(1.0-ParEfficiency)*ParNumSignal", RooArgList(*ParEfficiency,*ParNumSignal));
-
+  // Now define some efficiency/yield variables
+  RooFormulaVar* NumSignalPass =
+      new RooFormulaVar("NumSignalPass", "ParEfficiency*ParNumSignal", RooArgList(*ParEfficiency, *ParNumSignal));
+  RooFormulaVar* NumSignalFail =
+      new RooFormulaVar("NumSignalFail", "(1.0-ParEfficiency)*ParNumSignal", RooArgList(*ParEfficiency, *ParNumSignal));
 
   //*********************************************************************************************
   //
   // Create Background PDFs
   //
   //*********************************************************************************************
-  RooExponential* bkgPassPdf = new RooExponential("bkgPassPdf","bkgPassPdf",Mass, *ParPassBackgroundExpCoefficient);
-  RooExponential* bkgFailPdf = new RooExponential("bkgFailPdf","bkgFailPdf",Mass, *ParFailBackgroundExpCoefficient);
+  RooExponential* bkgPassPdf = new RooExponential("bkgPassPdf", "bkgPassPdf", Mass, *ParPassBackgroundExpCoefficient);
+  RooExponential* bkgFailPdf = new RooExponential("bkgFailPdf", "bkgFailPdf", Mass, *ParFailBackgroundExpCoefficient);
 
-
- //*********************************************************************************************
+  //*********************************************************************************************
   //
   // Create Total PDFs
   //
   //*********************************************************************************************
-  RooAddPdf pdfPass("pdfPass","pdfPass",RooArgList(*signalShapePassPdf,*bkgPassPdf), RooArgList(*NumSignalPass,*ParNumBkgPass));
-  RooAddPdf pdfFail("pdfFail","pdfFail",RooArgList(*signalShapeFailPdf,*bkgFailPdf), RooArgList(*NumSignalFail,*ParNumBkgFail));
+  RooAddPdf pdfPass(
+      "pdfPass", "pdfPass", RooArgList(*signalShapePassPdf, *bkgPassPdf), RooArgList(*NumSignalPass, *ParNumBkgPass));
+  RooAddPdf pdfFail(
+      "pdfFail", "pdfFail", RooArgList(*signalShapeFailPdf, *bkgFailPdf), RooArgList(*NumSignalFail, *ParNumBkgFail));
 
   // PDF for simultaneous fit
-   RooSimultaneous totalPdf("totalPdf","totalPdf", sample);
-   totalPdf.addPdf(pdfPass,"Pass");
-//    totalPdf.Print();
-   totalPdf.addPdf(pdfFail,"Fail");
-   totalPdf.Print();
+  RooSimultaneous totalPdf("totalPdf", "totalPdf", sample);
+  totalPdf.addPdf(pdfPass, "Pass");
+  //    totalPdf.Print();
+  totalPdf.addPdf(pdfFail, "Fail");
+  totalPdf.Print();
 
-
-   //*********************************************************************************************
+  //*********************************************************************************************
   //
   // Perform Fit
   //
   //*********************************************************************************************
-   RooFitResult *fitResult = 0;
+  RooFitResult* fitResult = 0;
 
-  // ********* Fix with Migrad first ********** //  
-   fitResult = totalPdf.fitTo(*dataCombined, RooFit::Save(true), 
-                              RooFit::Extended(true), RooFit::PrintLevel(-1));
-   fitResult->Print("v");
+  // ********* Fix with Migrad first ********** //
+  fitResult = totalPdf.fitTo(*dataCombined, RooFit::Save(true), RooFit::Extended(true), RooFit::PrintLevel(-1));
+  fitResult->Print("v");
 
+  //   // ********* Fit With Minos ********** //
+  //    fitResult = totalPdf.fitTo(*dataCombined, RooFit::Save(true),
+  //                               RooFit::Extended(true), RooFit::PrintLevel(-1), RooFit::Minos());
+  //    fitResult->Print("v");
 
-//   // ********* Fit With Minos ********** //  
-//    fitResult = totalPdf.fitTo(*dataCombined, RooFit::Save(true), 
-//                               RooFit::Extended(true), RooFit::PrintLevel(-1), RooFit::Minos());
-//    fitResult->Print("v");
+  //   // ********* Fix Mass Shift and Fit For Resolution ********** //
+  //    ParPassSignalMassShift->setConstant(kTRUE);
+  //    ParFailSignalMassShift->setConstant(kTRUE);
+  //    ParPassSignalResolution->setConstant(kFALSE);
+  //    ParFailSignalResolution->setConstant(kFALSE);
+  //    fitResult = totalPdf.fitTo(*dataCombined, RooFit::Save(true),
+  //    RooFit::Extended(true), RooFit::PrintLevel(-1));
+  //    fitResult->Print("v");
 
-
-
-
-//   // ********* Fix Mass Shift and Fit For Resolution ********** //  
-//    ParPassSignalMassShift->setConstant(kTRUE); 
-//    ParFailSignalMassShift->setConstant(kTRUE); 
-//    ParPassSignalResolution->setConstant(kFALSE); 
-//    ParFailSignalResolution->setConstant(kFALSE); 
-//    fitResult = totalPdf.fitTo(*dataCombined, RooFit::Save(true), 
-//    RooFit::Extended(true), RooFit::PrintLevel(-1));
-//    fitResult->Print("v");
-
-
-//   // ********* Do Final Fit ********** //  
-//    ParPassSignalMassShift->setConstant(kFALSE); 
-//    ParFailSignalMassShift->setConstant(kFALSE); 
-//    ParPassSignalResolution->setConstant(kTRUE); 
-//    ParFailSignalResolution->setConstant(kTRUE); 
-//    fitResult = totalPdf.fitTo(*dataCombined, RooFit::Save(true), 
-//                                             RooFit::Extended(true), RooFit::PrintLevel(-1));
-//    fitResult->Print("v");
-
-
-
-
+  //   // ********* Do Final Fit ********** //
+  //    ParPassSignalMassShift->setConstant(kFALSE);
+  //    ParFailSignalMassShift->setConstant(kFALSE);
+  //    ParPassSignalResolution->setConstant(kTRUE);
+  //    ParFailSignalResolution->setConstant(kTRUE);
+  //    fitResult = totalPdf.fitTo(*dataCombined, RooFit::Save(true),
+  //                                             RooFit::Extended(true), RooFit::PrintLevel(-1));
+  //    fitResult->Print("v");
 
   double nSignalPass = NumSignalPass->getVal();
-  double nSignalFail    = NumSignalFail->getVal();
+  double nSignalFail = NumSignalFail->getVal();
   double denominator = nSignalPass + nSignalFail;
 
   printf("\nFit results:\n");
-  if( fitResult->status() != 0 ){
-    std::cout<<"ERROR: BAD FIT STATUS"<<std::endl;
+  if (fitResult->status() != 0) {
+    std::cout << "ERROR: BAD FIT STATUS" << std::endl;
   }
 
-  printf("    Efficiency = %.4f +- %.4f\n", 
-	 ParEfficiency->getVal(), ParEfficiency->getPropagatedError(*fitResult));  
+  printf("    Efficiency = %.4f +- %.4f\n", ParEfficiency->getVal(), ParEfficiency->getPropagatedError(*fitResult));
   cout << "Signal Pass: " << nSignalPass << endl;
   cout << "Signal Fail: " << nSignalFail << endl;
 
   cout << "*********************************************************************\n";
   cout << "Final Parameters\n";
   cout << "*********************************************************************\n";
-  PrintParameter(ParNumSignal, label,"ParNumSignal");
-  PrintParameter(ParNumBkgPass, label,"ParNumBkgPass");
+  PrintParameter(ParNumSignal, label, "ParNumSignal");
+  PrintParameter(ParNumBkgPass, label, "ParNumBkgPass");
   PrintParameter(ParNumBkgFail, label, "ParNumBkgFail");
-  PrintParameter(ParEfficiency  , label, "ParEfficiency");
-  PrintParameter(ParPassBackgroundExpCoefficient , label, "ParPassBackgroundExpCoefficient");
-  PrintParameter(ParFailBackgroundExpCoefficient , label, "ParFailBackgroundExpCoefficient");
-  PrintParameter(ParPassSignalMassShift , label, "ParPassSignalMassShift");
-  PrintParameter(ParFailSignalMassShift , label, "ParFailSignalMassShift");
-  PrintParameter(ParPassSignalResolution , label, "ParPassSignalResolution");
-  PrintParameter(ParFailSignalResolution , label, "ParFailSignalResolution");
+  PrintParameter(ParEfficiency, label, "ParEfficiency");
+  PrintParameter(ParPassBackgroundExpCoefficient, label, "ParPassBackgroundExpCoefficient");
+  PrintParameter(ParFailBackgroundExpCoefficient, label, "ParFailBackgroundExpCoefficient");
+  PrintParameter(ParPassSignalMassShift, label, "ParPassSignalMassShift");
+  PrintParameter(ParFailSignalMassShift, label, "ParFailSignalMassShift");
+  PrintParameter(ParPassSignalResolution, label, "ParPassSignalResolution");
+  PrintParameter(ParFailSignalResolution, label, "ParFailSignalResolution");
   cout << endl << endl;
 
-
   //--------------------------------------------------------------------------------------------------------------
-  // Make plots 
-  //==============================================================================================================  
-  TFile *canvasFile = new TFile("Efficiency_FitResults.root", "UPDATE");
-
+  // Make plots
+  //==============================================================================================================
+  TFile* canvasFile = new TFile("Efficiency_FitResults.root", "UPDATE");
 
   RooAbsData::ErrorType errorType = RooAbsData::Poisson;
 
   Mass.setBins(NBINSPASS);
-  TString cname = TString((label+"_Pass").c_str());
-  TCanvas *c = new TCanvas(cname,cname,800,600);
+  TString cname = TString((label + "_Pass").c_str());
+  TCanvas* c = new TCanvas(cname, cname, 800, 600);
   RooPlot* frame1 = Mass.frame();
   frame1->SetMinimum(0);
-  dataPass->plotOn(frame1,RooFit::DataError(errorType));
-  pdfPass.plotOn(frame1,RooFit::ProjWData(*dataPass), 
-  RooFit::Components(*bkgPassPdf),RooFit::LineColor(kRed));
-  pdfPass.plotOn(frame1,RooFit::ProjWData(*dataPass));
+  dataPass->plotOn(frame1, RooFit::DataError(errorType));
+  pdfPass.plotOn(frame1, RooFit::ProjWData(*dataPass), RooFit::Components(*bkgPassPdf), RooFit::LineColor(kRed));
+  pdfPass.plotOn(frame1, RooFit::ProjWData(*dataPass));
   frame1->Draw("e0");
-  
-  TPaveText *plotlabel = new TPaveText(0.23,0.87,0.43,0.92,"NDC");
-   plotlabel->SetTextColor(kBlack);
-   plotlabel->SetFillColor(kWhite);
-   plotlabel->SetBorderSize(0);
-   plotlabel->SetTextAlign(12);
-   plotlabel->SetTextSize(0.03);
-   plotlabel->AddText("CMS Preliminary 2010");
-  TPaveText *plotlabel2 = new TPaveText(0.23,0.82,0.43,0.87,"NDC");
-   plotlabel2->SetTextColor(kBlack);
-   plotlabel2->SetFillColor(kWhite);
-   plotlabel2->SetBorderSize(0);
-   plotlabel2->SetTextAlign(12);
-   plotlabel2->SetTextSize(0.03);
-   plotlabel2->AddText("#sqrt{s} = 7 TeV");
-  TPaveText *plotlabel3 = new TPaveText(0.23,0.75,0.43,0.80,"NDC");
-   plotlabel3->SetTextColor(kBlack);
-   plotlabel3->SetFillColor(kWhite);
-   plotlabel3->SetBorderSize(0);
-   plotlabel3->SetTextAlign(12);
-   plotlabel3->SetTextSize(0.03);
+
+  TPaveText* plotlabel = new TPaveText(0.23, 0.87, 0.43, 0.92, "NDC");
+  plotlabel->SetTextColor(kBlack);
+  plotlabel->SetFillColor(kWhite);
+  plotlabel->SetBorderSize(0);
+  plotlabel->SetTextAlign(12);
+  plotlabel->SetTextSize(0.03);
+  plotlabel->AddText("CMS Preliminary 2010");
+  TPaveText* plotlabel2 = new TPaveText(0.23, 0.82, 0.43, 0.87, "NDC");
+  plotlabel2->SetTextColor(kBlack);
+  plotlabel2->SetFillColor(kWhite);
+  plotlabel2->SetBorderSize(0);
+  plotlabel2->SetTextAlign(12);
+  plotlabel2->SetTextSize(0.03);
+  plotlabel2->AddText("#sqrt{s} = 7 TeV");
+  TPaveText* plotlabel3 = new TPaveText(0.23, 0.75, 0.43, 0.80, "NDC");
+  plotlabel3->SetTextColor(kBlack);
+  plotlabel3->SetFillColor(kWhite);
+  plotlabel3->SetBorderSize(0);
+  plotlabel3->SetTextAlign(12);
+  plotlabel3->SetTextSize(0.03);
   char temp[100];
   sprintf(temp, "%.4f", LUMINOSITY);
-  plotlabel3->AddText((string("#int#font[12]{L}dt = ") + 
-  temp + string(" pb^{ -1}")).c_str());
-  TPaveText *plotlabel4 = new TPaveText(0.6,0.82,0.8,0.87,"NDC");
-   plotlabel4->SetTextColor(kBlack);
-   plotlabel4->SetFillColor(kWhite);
-   plotlabel4->SetBorderSize(0);
-   plotlabel4->SetTextAlign(12);
-   plotlabel4->SetTextSize(0.03);
-   double nsig = ParNumSignal->getVal();
-   double nErr = ParNumSignal->getError();
-   double e = ParEfficiency->getVal();
-   double eErr = ParEfficiency->getError();
-   double corr = fitResult->correlation(*ParEfficiency, *ParNumSignal);
-   double err = ErrorInProduct(nsig, nErr, e, eErr, corr);
-   sprintf(temp, "Signal = %.2f #pm %.2f", NumSignalPass->getVal(), err);
-   plotlabel4->AddText(temp);
-   TPaveText *plotlabel5 = new TPaveText(0.6,0.77,0.8,0.82,"NDC");
-   plotlabel5->SetTextColor(kBlack);
-   plotlabel5->SetFillColor(kWhite);
-   plotlabel5->SetBorderSize(0);
-   plotlabel5->SetTextAlign(12);
-   plotlabel5->SetTextSize(0.03);
-   sprintf(temp, "Bkg = %.2f #pm %.2f", ParNumBkgPass->getVal(), ParNumBkgPass->getError());
-   plotlabel5->AddText(temp);
-   TPaveText *plotlabel6 = new TPaveText(0.6,0.87,0.8,0.92,"NDC");
-   plotlabel6->SetTextColor(kBlack);
-   plotlabel6->SetFillColor(kWhite);
-   plotlabel6->SetBorderSize(0);
-   plotlabel6->SetTextAlign(12);
-   plotlabel6->SetTextSize(0.03);
-   plotlabel6->AddText("Passing probes");
-   TPaveText *plotlabel7 = new TPaveText(0.6,0.72,0.8,0.77,"NDC");
-   plotlabel7->SetTextColor(kBlack);
-   plotlabel7->SetFillColor(kWhite);
-   plotlabel7->SetBorderSize(0);
-   plotlabel7->SetTextAlign(12);
-   plotlabel7->SetTextSize(0.03); 
-   sprintf(temp, "Eff = %.3f #pm %.3f", ParEfficiency->getVal(), ParEfficiency->getErrorHi());
-   plotlabel7->AddText(temp);
-   TPaveText *plotlabel8 = new TPaveText(0.6,0.72,0.8,0.66,"NDC");
-   plotlabel8->SetTextColor(kBlack);
-   plotlabel8->SetFillColor(kWhite);
-   plotlabel8->SetBorderSize(0);
-   plotlabel8->SetTextAlign(12);
-   plotlabel8->SetTextSize(0.03);
-   sprintf(temp, "#chi^{2}/DOF = %.3f", frame1->chiSquare());
-   plotlabel8->AddText(temp);
+  plotlabel3->AddText((string("#int#font[12]{L}dt = ") + temp + string(" pb^{ -1}")).c_str());
+  TPaveText* plotlabel4 = new TPaveText(0.6, 0.82, 0.8, 0.87, "NDC");
+  plotlabel4->SetTextColor(kBlack);
+  plotlabel4->SetFillColor(kWhite);
+  plotlabel4->SetBorderSize(0);
+  plotlabel4->SetTextAlign(12);
+  plotlabel4->SetTextSize(0.03);
+  double nsig = ParNumSignal->getVal();
+  double nErr = ParNumSignal->getError();
+  double e = ParEfficiency->getVal();
+  double eErr = ParEfficiency->getError();
+  double corr = fitResult->correlation(*ParEfficiency, *ParNumSignal);
+  double err = ErrorInProduct(nsig, nErr, e, eErr, corr);
+  sprintf(temp, "Signal = %.2f #pm %.2f", NumSignalPass->getVal(), err);
+  plotlabel4->AddText(temp);
+  TPaveText* plotlabel5 = new TPaveText(0.6, 0.77, 0.8, 0.82, "NDC");
+  plotlabel5->SetTextColor(kBlack);
+  plotlabel5->SetFillColor(kWhite);
+  plotlabel5->SetBorderSize(0);
+  plotlabel5->SetTextAlign(12);
+  plotlabel5->SetTextSize(0.03);
+  sprintf(temp, "Bkg = %.2f #pm %.2f", ParNumBkgPass->getVal(), ParNumBkgPass->getError());
+  plotlabel5->AddText(temp);
+  TPaveText* plotlabel6 = new TPaveText(0.6, 0.87, 0.8, 0.92, "NDC");
+  plotlabel6->SetTextColor(kBlack);
+  plotlabel6->SetFillColor(kWhite);
+  plotlabel6->SetBorderSize(0);
+  plotlabel6->SetTextAlign(12);
+  plotlabel6->SetTextSize(0.03);
+  plotlabel6->AddText("Passing probes");
+  TPaveText* plotlabel7 = new TPaveText(0.6, 0.72, 0.8, 0.77, "NDC");
+  plotlabel7->SetTextColor(kBlack);
+  plotlabel7->SetFillColor(kWhite);
+  plotlabel7->SetBorderSize(0);
+  plotlabel7->SetTextAlign(12);
+  plotlabel7->SetTextSize(0.03);
+  sprintf(temp, "Eff = %.3f #pm %.3f", ParEfficiency->getVal(), ParEfficiency->getErrorHi());
+  plotlabel7->AddText(temp);
+  TPaveText* plotlabel8 = new TPaveText(0.6, 0.72, 0.8, 0.66, "NDC");
+  plotlabel8->SetTextColor(kBlack);
+  plotlabel8->SetFillColor(kWhite);
+  plotlabel8->SetBorderSize(0);
+  plotlabel8->SetTextAlign(12);
+  plotlabel8->SetTextSize(0.03);
+  sprintf(temp, "#chi^{2}/DOF = %.3f", frame1->chiSquare());
+  plotlabel8->AddText(temp);
 
   plotlabel4->Draw();
   plotlabel5->Draw();
@@ -429,314 +411,274 @@ void performFit(string inputDir, string inputParameterFile, string label,
   plotlabel7->Draw();
   plotlabel8->Draw();
 
-//   c->SaveAs( cname + TString(".eps"));
-  c->SaveAs( cname + TString(".gif"));
+  //   c->SaveAs( cname + TString(".eps"));
+  c->SaveAs(cname + TString(".gif"));
   canvasFile->WriteTObject(c, c->GetName(), "WriteDelete");
 
- 
   Mass.setBins(NBINSFAIL);
-  cname = TString((label+"_Fail").c_str());
-  TCanvas* c2 = new TCanvas(cname,cname,800,600);
+  cname = TString((label + "_Fail").c_str());
+  TCanvas* c2 = new TCanvas(cname, cname, 800, 600);
   RooPlot* frame2 = Mass.frame();
   frame2->SetMinimum(0);
-  dataFail->plotOn(frame2,RooFit::DataError(errorType));
-  pdfFail.plotOn(frame2,RooFit::ProjWData(*dataFail), 
-  RooFit::Components(*bkgFailPdf),RooFit::LineColor(kRed));
-  pdfFail.plotOn(frame2,RooFit::ProjWData(*dataFail));
+  dataFail->plotOn(frame2, RooFit::DataError(errorType));
+  pdfFail.plotOn(frame2, RooFit::ProjWData(*dataFail), RooFit::Components(*bkgFailPdf), RooFit::LineColor(kRed));
+  pdfFail.plotOn(frame2, RooFit::ProjWData(*dataFail));
   frame2->Draw("e0");
 
-  plotlabel = new TPaveText(0.23,0.87,0.43,0.92,"NDC");
-   plotlabel->SetTextColor(kBlack);
-   plotlabel->SetFillColor(kWhite);
-   plotlabel->SetBorderSize(0);
-   plotlabel->SetTextAlign(12);
-   plotlabel->SetTextSize(0.03);
-   plotlabel->AddText("CMS Preliminary 2010");
- plotlabel2 = new TPaveText(0.23,0.82,0.43,0.87,"NDC");
-   plotlabel2->SetTextColor(kBlack);
-   plotlabel2->SetFillColor(kWhite);
-   plotlabel2->SetBorderSize(0);
-   plotlabel2->SetTextAlign(12);
-   plotlabel2->SetTextSize(0.03);
-   plotlabel2->AddText("#sqrt{s} = 7 TeV");
-  plotlabel3 = new TPaveText(0.23,0.75,0.43,0.80,"NDC");
-   plotlabel3->SetTextColor(kBlack);
-   plotlabel3->SetFillColor(kWhite);
-   plotlabel3->SetBorderSize(0);
-   plotlabel3->SetTextAlign(12);
-   plotlabel3->SetTextSize(0.03);
-   sprintf(temp, "%.4f", LUMINOSITY);
-   plotlabel3->AddText((string("#int#font[12]{L}dt = ") + 
-                        temp + string(" pb^{ -1}")).c_str());
-   plotlabel4 = new TPaveText(0.6,0.82,0.8,0.87,"NDC");
-   plotlabel4->SetTextColor(kBlack);
-   plotlabel4->SetFillColor(kWhite);
-   plotlabel4->SetBorderSize(0);
-   plotlabel4->SetTextAlign(12);
-   plotlabel4->SetTextSize(0.03);
-   err = ErrorInProduct(nsig, nErr, 1.0-e, eErr, corr);
-   sprintf(temp, "Signal = %.2f #pm %.2f", NumSignalFail->getVal(), err);
-   plotlabel4->AddText(temp);
-   plotlabel5 = new TPaveText(0.6,0.77,0.8,0.82,"NDC");
-   plotlabel5->SetTextColor(kBlack);
-   plotlabel5->SetFillColor(kWhite);
-   plotlabel5->SetBorderSize(0);
-   plotlabel5->SetTextAlign(12);
-   plotlabel5->SetTextSize(0.03);
-   sprintf(temp, "Bkg = %.2f #pm %.2f", ParNumBkgFail->getVal(), ParNumBkgFail->getError());
-   plotlabel5->AddText(temp);
-   plotlabel6 = new TPaveText(0.6,0.87,0.8,0.92,"NDC");
-   plotlabel6->SetTextColor(kBlack);
-   plotlabel6->SetFillColor(kWhite);
-   plotlabel6->SetBorderSize(0);
-   plotlabel6->SetTextAlign(12);
-   plotlabel6->SetTextSize(0.03);
-   plotlabel6->AddText("Failing probes");
-   plotlabel7 = new TPaveText(0.6,0.72,0.8,0.77,"NDC");
-   plotlabel7->SetTextColor(kBlack);
-   plotlabel7->SetFillColor(kWhite);
-   plotlabel7->SetBorderSize(0);
-   plotlabel7->SetTextAlign(12);
-   plotlabel7->SetTextSize(0.03);
-   sprintf(temp, "Eff = %.3f #pm %.3f", ParEfficiency->getVal(), ParEfficiency->getErrorHi(), ParEfficiency->getErrorLo());
-   plotlabel7->AddText(temp);
-   plotlabel8 = new TPaveText(0.6,0.72,0.8,0.66,"NDC");
-   plotlabel8->SetTextColor(kBlack);
-   plotlabel8->SetFillColor(kWhite);
-   plotlabel8->SetBorderSize(0);
-   plotlabel8->SetTextAlign(12);
-   plotlabel8->SetTextSize(0.03);
-   sprintf(temp, "#chi^{2}/DOF = %.3f", frame2->chiSquare());
-   plotlabel8->AddText(temp);
+  plotlabel = new TPaveText(0.23, 0.87, 0.43, 0.92, "NDC");
+  plotlabel->SetTextColor(kBlack);
+  plotlabel->SetFillColor(kWhite);
+  plotlabel->SetBorderSize(0);
+  plotlabel->SetTextAlign(12);
+  plotlabel->SetTextSize(0.03);
+  plotlabel->AddText("CMS Preliminary 2010");
+  plotlabel2 = new TPaveText(0.23, 0.82, 0.43, 0.87, "NDC");
+  plotlabel2->SetTextColor(kBlack);
+  plotlabel2->SetFillColor(kWhite);
+  plotlabel2->SetBorderSize(0);
+  plotlabel2->SetTextAlign(12);
+  plotlabel2->SetTextSize(0.03);
+  plotlabel2->AddText("#sqrt{s} = 7 TeV");
+  plotlabel3 = new TPaveText(0.23, 0.75, 0.43, 0.80, "NDC");
+  plotlabel3->SetTextColor(kBlack);
+  plotlabel3->SetFillColor(kWhite);
+  plotlabel3->SetBorderSize(0);
+  plotlabel3->SetTextAlign(12);
+  plotlabel3->SetTextSize(0.03);
+  sprintf(temp, "%.4f", LUMINOSITY);
+  plotlabel3->AddText((string("#int#font[12]{L}dt = ") + temp + string(" pb^{ -1}")).c_str());
+  plotlabel4 = new TPaveText(0.6, 0.82, 0.8, 0.87, "NDC");
+  plotlabel4->SetTextColor(kBlack);
+  plotlabel4->SetFillColor(kWhite);
+  plotlabel4->SetBorderSize(0);
+  plotlabel4->SetTextAlign(12);
+  plotlabel4->SetTextSize(0.03);
+  err = ErrorInProduct(nsig, nErr, 1.0 - e, eErr, corr);
+  sprintf(temp, "Signal = %.2f #pm %.2f", NumSignalFail->getVal(), err);
+  plotlabel4->AddText(temp);
+  plotlabel5 = new TPaveText(0.6, 0.77, 0.8, 0.82, "NDC");
+  plotlabel5->SetTextColor(kBlack);
+  plotlabel5->SetFillColor(kWhite);
+  plotlabel5->SetBorderSize(0);
+  plotlabel5->SetTextAlign(12);
+  plotlabel5->SetTextSize(0.03);
+  sprintf(temp, "Bkg = %.2f #pm %.2f", ParNumBkgFail->getVal(), ParNumBkgFail->getError());
+  plotlabel5->AddText(temp);
+  plotlabel6 = new TPaveText(0.6, 0.87, 0.8, 0.92, "NDC");
+  plotlabel6->SetTextColor(kBlack);
+  plotlabel6->SetFillColor(kWhite);
+  plotlabel6->SetBorderSize(0);
+  plotlabel6->SetTextAlign(12);
+  plotlabel6->SetTextSize(0.03);
+  plotlabel6->AddText("Failing probes");
+  plotlabel7 = new TPaveText(0.6, 0.72, 0.8, 0.77, "NDC");
+  plotlabel7->SetTextColor(kBlack);
+  plotlabel7->SetFillColor(kWhite);
+  plotlabel7->SetBorderSize(0);
+  plotlabel7->SetTextAlign(12);
+  plotlabel7->SetTextSize(0.03);
+  sprintf(
+      temp, "Eff = %.3f #pm %.3f", ParEfficiency->getVal(), ParEfficiency->getErrorHi(), ParEfficiency->getErrorLo());
+  plotlabel7->AddText(temp);
+  plotlabel8 = new TPaveText(0.6, 0.72, 0.8, 0.66, "NDC");
+  plotlabel8->SetTextColor(kBlack);
+  plotlabel8->SetFillColor(kWhite);
+  plotlabel8->SetBorderSize(0);
+  plotlabel8->SetTextAlign(12);
+  plotlabel8->SetTextSize(0.03);
+  sprintf(temp, "#chi^{2}/DOF = %.3f", frame2->chiSquare());
+  plotlabel8->AddText(temp);
 
-//   plotlabel->Draw();
-//   plotlabel2->Draw();
-//   plotlabel3->Draw();
+  //   plotlabel->Draw();
+  //   plotlabel2->Draw();
+  //   plotlabel3->Draw();
   plotlabel4->Draw();
   plotlabel5->Draw();
   plotlabel6->Draw();
   plotlabel7->Draw();
   plotlabel8->Draw();
 
-  c2->SaveAs( cname + TString(".gif"));
-//   c2->SaveAs( cname + TString(".eps"));
-//   c2->SaveAs( cname + TString(".root"));
+  c2->SaveAs(cname + TString(".gif"));
+  //   c2->SaveAs( cname + TString(".eps"));
+  //   c2->SaveAs( cname + TString(".root"));
   canvasFile->WriteTObject(c2, c2->GetName(), "WriteDelete");
 
   canvasFile->Close();
 
-  
   effTextFile.width(40);
   effTextFile << label;
   effTextFile.width(20);
-  effTextFile  << setiosflags(ios::fixed) << setprecision(4) << left << ParEfficiency->getVal() ;
+  effTextFile << setiosflags(ios::fixed) << setprecision(4) << left << ParEfficiency->getVal();
   effTextFile.width(20);
-  effTextFile  << left << ParEfficiency->getErrorHi();
+  effTextFile << left << ParEfficiency->getErrorHi();
   effTextFile.width(20);
-  effTextFile  << left << ParEfficiency->getErrorLo();
+  effTextFile << left << ParEfficiency->getErrorLo();
   effTextFile.width(14);
-  effTextFile  << setiosflags(ios::fixed) << setprecision(2) << left << nSignalPass ;
+  effTextFile << setiosflags(ios::fixed) << setprecision(2) << left << nSignalPass;
   effTextFile.width(14);
   effTextFile << left << nSignalFail << endl;
+}
 
-} 
-
-
-
-
-void ElectronTagAndProbeFitter(){
-
-
-
-
-// //////////////////////////////////////////////////////////
+void ElectronTagAndProbeFitter() {
+  // //////////////////////////////////////////////////////////
   effTextFile.width(40);
   effTextFile << left << "Type";
   effTextFile.width(20);
-  effTextFile  << left << "Efficiency" ;
+  effTextFile << left << "Efficiency";
   effTextFile.width(20);
-  effTextFile  << left << " Uncertainty(+) ";
+  effTextFile << left << " Uncertainty(+) ";
   effTextFile.width(20);
-  effTextFile  << left << " Uncertainty(-) ";
+  effTextFile << left << " Uncertainty(-) ";
   effTextFile.width(14);
-  effTextFile  << left << "NPass" ;
+  effTextFile << left << "NPass";
   effTextFile.width(14);
   effTextFile << left << "NFail" << endl;
 
-// //////////////////////////////////////////////////////////
+  // //////////////////////////////////////////////////////////
 
+  // //////////////////////////////////////////////////////////
+  //   //  Super cluster --> gsfElectron efficiency
+  // //////////////////////////////////////////////////////////
 
+  //**************
+  //User Pass Template For Fail Sample - TPTree
+  //**************
+  //       performFit("EfficiencyFitter/input/Data_36_09122010_TP_TagWP80/", "EfficiencyFitter/results/Parameters.txt", "Efficiency_SCToReco", "Mass_TagPlusSCPassReco_Data_36", "Mass_TagPlusSCFailReco_Data_36", "Mass_TagPlusSCPassReco", "Mass_TagPlusSCPassReco" );
+  //     performFit("EfficiencyFitter/input/Data_36_09122010_TP_TagWP80/", "EfficiencyFitter/results/Parameters.txt", "Efficiency_SCToReco_EB", "Mass_TagPlusSCPassReco_EB_Pt20ToInf_Data_36", "Mass_TagPlusSCFailReco_EB_Pt20ToInf_Data_36", "Mass_TagPlusSCPassReco_EB_Pt20ToInf", "Mass_TagPlusSCPassReco_EB_Pt20ToInf" );
+  //       performFit("EfficiencyFitter/input/Data_36_09122010_TP_TagWP80/", "EfficiencyFitter/results/Parameters.txt", "Efficiency_SCToReco_EE", "Mass_TagPlusSCPassReco_EE_Pt20ToInf_Data_36", "Mass_TagPlusSCFailReco_EE_Pt20ToInf_Data_36", "Mass_TagPlusSCPassReco_EE_Pt20ToInf", "Mass_TagPlusSCPassReco_EE_Pt20ToInf" );
+  //     performFit("EfficiencyFitter/input/Data_36_09122010_TP_TagWP80/", "EfficiencyFitter/results/Parameters.txt", "Efficiency_SCToReco_EB_Minus", "Mass_TagPlusSCPassReco_EB_Pt20ToInf_Data_36_Minus", "Mass_TagPlusSCFailReco_EB_Pt20ToInf_Data_36_Minus", "Mass_TagPlusSCPassReco_EB_Pt20ToInf", "Mass_TagPlusSCPassReco_EB_Pt20ToInf" );
+  //     performFit("EfficiencyFitter/input/Data_36_09122010_TP_TagWP80/", "EfficiencyFitter/results/Parameters.txt", "Efficiency_SCToReco_EE_Minus", "Mass_TagPlusSCPassReco_EE_Pt20ToInf_Data_36_Minus", "Mass_TagPlusSCFailReco_EE_Pt20ToInf_Data_36_Minus", "Mass_TagPlusSCPassReco_EE_Pt20ToInf", "Mass_TagPlusSCPassReco_EE_Pt20ToInf" );
+  //     performFit("EfficiencyFitter/input/Data_36_09122010_TP_TagWP80/", "EfficiencyFitter/results/Parameters.txt", "Efficiency_SCToReco_EB_Plus", "Mass_TagPlusSCPassReco_EB_Pt20ToInf_Data_36_Plus", "Mass_TagPlusSCFailReco_EB_Pt20ToInf_Data_36_Plus", "Mass_TagPlusSCPassReco_EB_Pt20ToInf", "Mass_TagPlusSCPassReco_EB_Pt20ToInf" );
+  //     performFit("EfficiencyFitter/input/Data_36_09122010_TP_TagWP80/", "EfficiencyFitter/results/Parameters.txt", "Efficiency_SCToReco_EE_Plus", "Mass_TagPlusSCPassReco_EE_Pt20ToInf_Data_36_Plus", "Mass_TagPlusSCFailReco_EE_Pt20ToInf_Data_36_Plus", "Mass_TagPlusSCPassReco_EE_Pt20ToInf", "Mass_TagPlusSCPassReco_EE_Pt20ToInf" );
 
-// //////////////////////////////////////////////////////////
-//   //  Super cluster --> gsfElectron efficiency
-// //////////////////////////////////////////////////////////
+  //**************
+  //User Fail Template For Fail Sample - TPTree
+  //**************
+  //      performFit("EfficiencyFitter/input/Data_36_09122010_TP_TagWP80/", "EfficiencyFitter/results/Parameters.txt", "Efficiency_SCToReco", "Mass_TagPlusSCPassReco_Data_36", "Mass_TagPlusSCFailReco_Data_36", "Mass_TagPlusSCPassReco", "Mass_TagPlusSCFailReco" );
+  //      performFit("EfficiencyFitter/input/Data_36_09122010_TP_TagWP80/", "EfficiencyFitter/results/Parameters.txt", "Efficiency_SCToReco_EB", "Mass_TagPlusSCPassReco_EB_Pt20ToInf_Data_36", "Mass_TagPlusSCFailReco_EB_Pt20ToInf_Data_36", "Mass_TagPlusSCPassReco_EB_Pt20ToInf", "Mass_TagPlusSCFailReco_EB_Pt20ToInf" );
+  //      performFit("EfficiencyFitter/input/Data_36_09122010_TP_TagWP80/", "EfficiencyFitter/results/Parameters.txt", "Efficiency_SCToReco_EE", "Mass_TagPlusSCPassReco_EE_Pt20ToInf_Data_36", "Mass_TagPlusSCFailReco_EE_Pt20ToInf_Data_36", "Mass_TagPlusSCPassReco_EE_Pt20ToInf", "Mass_TagPlusSCFailReco_EE_Pt20ToInf" );
+  //     performFit("EfficiencyFitter/input/Data_36_09122010_TP_TagWP80/", "EfficiencyFitter/results/Parameters.txt", "Efficiency_SCToReco_EB_Minus", "Mass_TagPlusSCPassReco_EB_Pt20ToInf_Data_36_Minus", "Mass_TagPlusSCFailReco_EB_Pt20ToInf_Data_36_Minus", "Mass_TagPlusSCPassReco_EB_Pt20ToInf", "Mass_TagPlusSCFailReco_EB_Pt20ToInf" );
+  //     performFit("EfficiencyFitter/input/Data_36_09122010_TP_TagWP80/", "EfficiencyFitter/results/Parameters.txt", "Efficiency_SCToReco_EE_Minus", "Mass_TagPlusSCPassReco_EE_Pt20ToInf_Data_36_Minus", "Mass_TagPlusSCFailReco_EE_Pt20ToInf_Data_36_Minus", "Mass_TagPlusSCPassReco_EE_Pt20ToInf", "Mass_TagPlusSCFailReco_EE_Pt20ToInf" );
+  //     performFit("EfficiencyFitter/input/Data_36_09122010_TP_TagWP80/", "EfficiencyFitter/results/Parameters.txt", "Efficiency_SCToReco_EB_Plus", "Mass_TagPlusSCPassReco_EB_Pt20ToInf_Data_36_Plus", "Mass_TagPlusSCFailReco_EB_Pt20ToInf_Data_36_Plus", "Mass_TagPlusSCPassReco_EB_Pt20ToInf", "Mass_TagPlusSCFailReco_EB_Pt20ToInf" );
+  //     performFit("EfficiencyFitter/input/Data_36_09122010_TP_TagWP80/", "EfficiencyFitter/results/Parameters.txt", "Efficiency_SCToReco_EE_Plus", "Mass_TagPlusSCPassReco_EE_Pt20ToInf_Data_36_Plus", "Mass_TagPlusSCFailReco_EE_Pt20ToInf_Data_36_Plus", "Mass_TagPlusSCPassReco_EE_Pt20ToInf", "Mass_TagPlusSCFailReco_EE_Pt20ToInf" );
 
-//**************
-//User Pass Template For Fail Sample - TPTree
-//**************
-//       performFit("EfficiencyFitter/input/Data_36_09122010_TP_TagWP80/", "EfficiencyFitter/results/Parameters.txt", "Efficiency_SCToReco", "Mass_TagPlusSCPassReco_Data_36", "Mass_TagPlusSCFailReco_Data_36", "Mass_TagPlusSCPassReco", "Mass_TagPlusSCPassReco" );
-//     performFit("EfficiencyFitter/input/Data_36_09122010_TP_TagWP80/", "EfficiencyFitter/results/Parameters.txt", "Efficiency_SCToReco_EB", "Mass_TagPlusSCPassReco_EB_Pt20ToInf_Data_36", "Mass_TagPlusSCFailReco_EB_Pt20ToInf_Data_36", "Mass_TagPlusSCPassReco_EB_Pt20ToInf", "Mass_TagPlusSCPassReco_EB_Pt20ToInf" );
-//       performFit("EfficiencyFitter/input/Data_36_09122010_TP_TagWP80/", "EfficiencyFitter/results/Parameters.txt", "Efficiency_SCToReco_EE", "Mass_TagPlusSCPassReco_EE_Pt20ToInf_Data_36", "Mass_TagPlusSCFailReco_EE_Pt20ToInf_Data_36", "Mass_TagPlusSCPassReco_EE_Pt20ToInf", "Mass_TagPlusSCPassReco_EE_Pt20ToInf" );
-//     performFit("EfficiencyFitter/input/Data_36_09122010_TP_TagWP80/", "EfficiencyFitter/results/Parameters.txt", "Efficiency_SCToReco_EB_Minus", "Mass_TagPlusSCPassReco_EB_Pt20ToInf_Data_36_Minus", "Mass_TagPlusSCFailReco_EB_Pt20ToInf_Data_36_Minus", "Mass_TagPlusSCPassReco_EB_Pt20ToInf", "Mass_TagPlusSCPassReco_EB_Pt20ToInf" );
-//     performFit("EfficiencyFitter/input/Data_36_09122010_TP_TagWP80/", "EfficiencyFitter/results/Parameters.txt", "Efficiency_SCToReco_EE_Minus", "Mass_TagPlusSCPassReco_EE_Pt20ToInf_Data_36_Minus", "Mass_TagPlusSCFailReco_EE_Pt20ToInf_Data_36_Minus", "Mass_TagPlusSCPassReco_EE_Pt20ToInf", "Mass_TagPlusSCPassReco_EE_Pt20ToInf" );
-//     performFit("EfficiencyFitter/input/Data_36_09122010_TP_TagWP80/", "EfficiencyFitter/results/Parameters.txt", "Efficiency_SCToReco_EB_Plus", "Mass_TagPlusSCPassReco_EB_Pt20ToInf_Data_36_Plus", "Mass_TagPlusSCFailReco_EB_Pt20ToInf_Data_36_Plus", "Mass_TagPlusSCPassReco_EB_Pt20ToInf", "Mass_TagPlusSCPassReco_EB_Pt20ToInf" );
-//     performFit("EfficiencyFitter/input/Data_36_09122010_TP_TagWP80/", "EfficiencyFitter/results/Parameters.txt", "Efficiency_SCToReco_EE_Plus", "Mass_TagPlusSCPassReco_EE_Pt20ToInf_Data_36_Plus", "Mass_TagPlusSCFailReco_EE_Pt20ToInf_Data_36_Plus", "Mass_TagPlusSCPassReco_EE_Pt20ToInf", "Mass_TagPlusSCPassReco_EE_Pt20ToInf" ); 
+  //**************
+  //Impose WP95 Iso Cut on Photon probes - TPTree  SYstematics
+  //**************
+  //     performFit("EfficiencyFitter/input/Data_36_09122010_TP_TagWP80_WithPhotonIsoCut/", "EfficiencyFitter/results/Parameters.txt", "Efficiency_SCToReco", "Mass_TagPlusSCPassReco_Data_36", "Mass_TagPlusSCFailReco_Data_36", "Mass_TagPlusSCPassReco", "Mass_TagPlusSCFailReco" );
+  //     performFit("EfficiencyFitter/input/Data_36_09122010_TP_TagWP80_WithPhotonIsoCut/", "EfficiencyFitter/results/Parameters.txt", "Efficiency_SCToReco_EB", "Mass_TagPlusSCPassReco_EB_Pt20ToInf_Data_36", "Mass_TagPlusSCFailReco_EB_Pt20ToInf_Data_36", "Mass_TagPlusSCPassReco_EB_Pt20ToInf", "Mass_TagPlusSCFailReco_EB_Pt20ToInf" );
+  //     performFit("EfficiencyFitter/input/Data_36_09122010_TP_TagWP80_WithPhotonIsoCut/", "EfficiencyFitter/results/Parameters.txt", "Efficiency_SCToReco_EE", "Mass_TagPlusSCPassReco_EE_Pt20ToInf_Data_36", "Mass_TagPlusSCFailReco_EE_Pt20ToInf_Data_36", "Mass_TagPlusSCPassReco_EE_Pt20ToInf", "Mass_TagPlusSCFailReco_EE_Pt20ToInf" );
 
+  //**************
+  //Impose WP95 Iso Cut on Photon probes - BAMBU
+  //**************
+  //      performFit("EfficiencyFitter/input/Data_36_09122010_TagWP80/", "EfficiencyFitter/results/Parameters.txt", "Efficiency_SCToReco", "Mass_TagPlusSCPassReco_Data_36", "Mass_TagPlusSCFailReco_Data_36", "Mass_TagPlusSCPassReco", "Mass_TagPlusSCFailReco" );
+  //      performFit("EfficiencyFitter/input/Data_36_09122010_TagWP80/", "EfficiencyFitter/results/Parameters.txt", "Efficiency_SCToReco_EB", "Mass_TagPlusSCPassReco_EB_Pt20ToInf_Data_36", "Mass_TagPlusSCFailReco_EB_Pt20ToInf_Data_36", "Mass_TagPlusSCPassReco_EB_Pt20ToInf", "Mass_TagPlusSCFailReco_EB_Pt20ToInf" );
+  //      performFit("EfficiencyFitter/input/Data_36_09122010_TagWP80/", "EfficiencyFitter/results/Parameters.txt", "Efficiency_SCToReco_EE", "Mass_TagPlusSCPassReco_EE_Pt20ToInf_Data_36", "Mass_TagPlusSCFailReco_EE_Pt20ToInf_Data_36", "Mass_TagPlusSCPassReco_EE_Pt20ToInf", "Mass_TagPlusSCFailReco_EE_Pt20ToInf" );
+  //     performFit("EfficiencyFitter/input/Data_36_09122010_TagWP80/", "EfficiencyFitter/results/Parameters.txt", "Efficiency_SCToReco_EB_Minus", "Mass_TagPlusSCPassReco_EB_Pt20ToInf_Data_36_Minus", "Mass_TagPlusSCFailReco_EB_Pt20ToInf_Data_36_Minus", "Mass_TagPlusSCPassReco_EB_Pt20ToInf", "Mass_TagPlusSCFailReco_EB_Pt20ToInf" );
+  //     performFit("EfficiencyFitter/input/Data_36_09122010_TagWP80/", "EfficiencyFitter/results/Parameters.txt", "Efficiency_SCToReco_EE_Minus", "Mass_TagPlusSCPassReco_EE_Pt20ToInf_Data_36_Minus", "Mass_TagPlusSCFailReco_EE_Pt20ToInf_Data_36_Minus", "Mass_TagPlusSCPassReco_EE_Pt20ToInf", "Mass_TagPlusSCFailReco_EE_Pt20ToInf" );
+  //     performFit("EfficiencyFitter/input/Data_36_09122010_TagWP80/", "EfficiencyFitter/results/Parameters.txt", "Efficiency_SCToReco_EB_Plus", "Mass_TagPlusSCPassReco_EB_Pt20ToInf_Data_36_Plus", "Mass_TagPlusSCFailReco_EB_Pt20ToInf_Data_36_Plus", "Mass_TagPlusSCPassReco_EB_Pt20ToInf", "Mass_TagPlusSCFailReco_EB_Pt20ToInf" );
+  //     performFit("EfficiencyFitter/input/Data_36_09122010_TagWP80/", "EfficiencyFitter/results/Parameters.txt", "Efficiency_SCToReco_EE_Plus", "Mass_TagPlusSCPassReco_EE_Pt20ToInf_Data_36_Plus", "Mass_TagPlusSCFailReco_EE_Pt20ToInf_Data_36_Plus", "Mass_TagPlusSCPassReco_EE_Pt20ToInf", "Mass_TagPlusSCFailReco_EE_Pt20ToInf" );
 
-//**************
-//User Fail Template For Fail Sample - TPTree
-//**************
-//      performFit("EfficiencyFitter/input/Data_36_09122010_TP_TagWP80/", "EfficiencyFitter/results/Parameters.txt", "Efficiency_SCToReco", "Mass_TagPlusSCPassReco_Data_36", "Mass_TagPlusSCFailReco_Data_36", "Mass_TagPlusSCPassReco", "Mass_TagPlusSCFailReco" );
-//      performFit("EfficiencyFitter/input/Data_36_09122010_TP_TagWP80/", "EfficiencyFitter/results/Parameters.txt", "Efficiency_SCToReco_EB", "Mass_TagPlusSCPassReco_EB_Pt20ToInf_Data_36", "Mass_TagPlusSCFailReco_EB_Pt20ToInf_Data_36", "Mass_TagPlusSCPassReco_EB_Pt20ToInf", "Mass_TagPlusSCFailReco_EB_Pt20ToInf" );
-//      performFit("EfficiencyFitter/input/Data_36_09122010_TP_TagWP80/", "EfficiencyFitter/results/Parameters.txt", "Efficiency_SCToReco_EE", "Mass_TagPlusSCPassReco_EE_Pt20ToInf_Data_36", "Mass_TagPlusSCFailReco_EE_Pt20ToInf_Data_36", "Mass_TagPlusSCPassReco_EE_Pt20ToInf", "Mass_TagPlusSCFailReco_EE_Pt20ToInf" );
-//     performFit("EfficiencyFitter/input/Data_36_09122010_TP_TagWP80/", "EfficiencyFitter/results/Parameters.txt", "Efficiency_SCToReco_EB_Minus", "Mass_TagPlusSCPassReco_EB_Pt20ToInf_Data_36_Minus", "Mass_TagPlusSCFailReco_EB_Pt20ToInf_Data_36_Minus", "Mass_TagPlusSCPassReco_EB_Pt20ToInf", "Mass_TagPlusSCFailReco_EB_Pt20ToInf" );
-//     performFit("EfficiencyFitter/input/Data_36_09122010_TP_TagWP80/", "EfficiencyFitter/results/Parameters.txt", "Efficiency_SCToReco_EE_Minus", "Mass_TagPlusSCPassReco_EE_Pt20ToInf_Data_36_Minus", "Mass_TagPlusSCFailReco_EE_Pt20ToInf_Data_36_Minus", "Mass_TagPlusSCPassReco_EE_Pt20ToInf", "Mass_TagPlusSCFailReco_EE_Pt20ToInf" );
-//     performFit("EfficiencyFitter/input/Data_36_09122010_TP_TagWP80/", "EfficiencyFitter/results/Parameters.txt", "Efficiency_SCToReco_EB_Plus", "Mass_TagPlusSCPassReco_EB_Pt20ToInf_Data_36_Plus", "Mass_TagPlusSCFailReco_EB_Pt20ToInf_Data_36_Plus", "Mass_TagPlusSCPassReco_EB_Pt20ToInf", "Mass_TagPlusSCFailReco_EB_Pt20ToInf" );
-//     performFit("EfficiencyFitter/input/Data_36_09122010_TP_TagWP80/", "EfficiencyFitter/results/Parameters.txt", "Efficiency_SCToReco_EE_Plus", "Mass_TagPlusSCPassReco_EE_Pt20ToInf_Data_36_Plus", "Mass_TagPlusSCFailReco_EE_Pt20ToInf_Data_36_Plus", "Mass_TagPlusSCPassReco_EE_Pt20ToInf", "Mass_TagPlusSCFailReco_EE_Pt20ToInf" );
+  // //////////////////////////////////////////////////////////
+  //   //  gsfElectron --> WP-95 selection efficiency
+  // //////////////////////////////////////////////////////////
 
-//**************
-//Impose WP95 Iso Cut on Photon probes - TPTree  SYstematics
-//**************
-//     performFit("EfficiencyFitter/input/Data_36_09122010_TP_TagWP80_WithPhotonIsoCut/", "EfficiencyFitter/results/Parameters.txt", "Efficiency_SCToReco", "Mass_TagPlusSCPassReco_Data_36", "Mass_TagPlusSCFailReco_Data_36", "Mass_TagPlusSCPassReco", "Mass_TagPlusSCFailReco" );
-//     performFit("EfficiencyFitter/input/Data_36_09122010_TP_TagWP80_WithPhotonIsoCut/", "EfficiencyFitter/results/Parameters.txt", "Efficiency_SCToReco_EB", "Mass_TagPlusSCPassReco_EB_Pt20ToInf_Data_36", "Mass_TagPlusSCFailReco_EB_Pt20ToInf_Data_36", "Mass_TagPlusSCPassReco_EB_Pt20ToInf", "Mass_TagPlusSCFailReco_EB_Pt20ToInf" );
-//     performFit("EfficiencyFitter/input/Data_36_09122010_TP_TagWP80_WithPhotonIsoCut/", "EfficiencyFitter/results/Parameters.txt", "Efficiency_SCToReco_EE", "Mass_TagPlusSCPassReco_EE_Pt20ToInf_Data_36", "Mass_TagPlusSCFailReco_EE_Pt20ToInf_Data_36", "Mass_TagPlusSCPassReco_EE_Pt20ToInf", "Mass_TagPlusSCFailReco_EE_Pt20ToInf" );
+  //**************
+  //TAG 80 - TPTree
+  //**************
+  //    performFit("EfficiencyFitter/input/Data_36_09122010_TP_TagWP80/", "EfficiencyFitter/results/Parameters.txt", "Efficiency_RecoToVBTF95", "Mass_TagPlusRecoPassVBTF95IdIso_Data_36", "Mass_TagPlusRecoFailVBTF95IdIso_Data_36", "Mass_TagPlusRecoPassVBTF95IdIso", "Mass_TagPlusRecoFailVBTF95IdIso" );
+  //     performFit("EfficiencyFitter/input/Data_36_09122010_TP_TagWP80/", "EfficiencyFitter/results/Parameters.txt", "Efficiency_RecoToVBTF95_EB", "Mass_TagPlusRecoPassVBTF95IdIso_EB_Pt20ToInf_Data_36", "Mass_TagPlusRecoFailVBTF95IdIso_EB_Pt20ToInf_Data_36", "Mass_TagPlusRecoPassVBTF95IdIso_EB_Pt20ToInf", "Mass_TagPlusRecoFailVBTF95IdIso_EB_Pt20ToInf" );
+  //     performFit("EfficiencyFitter/input/Data_36_09122010_TP_TagWP80/", "EfficiencyFitter/results/Parameters.txt", "Efficiency_RecoToVBTF95_EE", "Mass_TagPlusRecoPassVBTF95IdIso_EE_Pt20ToInf_Data_36", "Mass_TagPlusRecoFailVBTF95IdIso_EE_Pt20ToInf_Data_36", "Mass_TagPlusRecoPassVBTF95IdIso_EE_Pt20ToInf", "Mass_TagPlusRecoFailVBTF95IdIso_EE_Pt20ToInf" );
+  //     performFit("EfficiencyFitter/input/Data_36_09122010_TP_TagWP80/", "EfficiencyFitter/results/Parameters.txt", "Efficiency_RecoToVBTF95_EB_Minus", "Mass_TagPlusRecoPassVBTF95IdIso_EB_Pt20ToInf_Data_36_Minus", "Mass_TagPlusRecoFailVBTF95IdIso_EB_Pt20ToInf_Data_36_Minus", "Mass_TagPlusRecoPassVBTF95IdIso_EB_Pt20ToInf", "Mass_TagPlusRecoFailVBTF95IdIso_EB_Pt20ToInf" );
+  //     performFit("EfficiencyFitter/input/Data_36_09122010_TP_TagWP80/", "EfficiencyFitter/results/Parameters.txt", "Efficiency_RecoToVBTF95_EE_Minus", "Mass_TagPlusRecoPassVBTF95IdIso_EE_Pt20ToInf_Data_36_Minus", "Mass_TagPlusRecoFailVBTF95IdIso_EE_Pt20ToInf_Data_36_Minus", "Mass_TagPlusRecoPassVBTF95IdIso_EE_Pt20ToInf", "Mass_TagPlusRecoFailVBTF95IdIso_EE_Pt20ToInf" );
+  //     performFit("EfficiencyFitter/input/Data_36_09122010_TP_TagWP80/", "EfficiencyFitter/results/Parameters.txt", "Efficiency_RecoToVBTF95_EB_Plus", "Mass_TagPlusRecoPassVBTF95IdIso_EB_Pt20ToInf_Data_36_Plus", "Mass_TagPlusRecoFailVBTF95IdIso_EB_Pt20ToInf_Data_36_Plus", "Mass_TagPlusRecoPassVBTF95IdIso_EB_Pt20ToInf", "Mass_TagPlusRecoFailVBTF95IdIso_EB_Pt20ToInf" );
+  //     performFit("EfficiencyFitter/input/Data_36_09122010_TP_TagWP80/", "EfficiencyFitter/results/Parameters.txt", "Efficiency_RecoToVBTF95_EE_Plus", "Mass_TagPlusRecoPassVBTF95IdIso_EE_Pt20ToInf_Data_36_Plus", "Mass_TagPlusRecoFailVBTF95IdIso_EE_Pt20ToInf_Data_36_Plus", "Mass_TagPlusRecoPassVBTF95IdIso_EE_Pt20ToInf", "Mass_TagPlusRecoFailVBTF95IdIso_EE_Pt20ToInf" );
 
+  //**************
+  //TAG 80 - BAMBU
+  //**************
+  //    performFit("EfficiencyFitter/input/Data_36_09122010_TagWP80/", "EfficiencyFitter/results/Parameters.txt", "Efficiency_RecoToVBTF95", "Mass_TagPlusRecoPassVBTF95IdIso_Data_36", "Mass_TagPlusRecoFailVBTF95IdIso_Data_36", "Mass_TagPlusRecoPassVBTF95IdIso", "Mass_TagPlusRecoFailVBTF95IdIso" );
+  //     performFit("EfficiencyFitter/input/Data_36_09122010_TagWP80/", "EfficiencyFitter/results/Parameters.txt", "Efficiency_RecoToVBTF95_EB", "Mass_TagPlusRecoPassVBTF95IdIso_EB_Pt20ToInf_Data_36", "Mass_TagPlusRecoFailVBTF95IdIso_EB_Pt20ToInf_Data_36", "Mass_TagPlusRecoPassVBTF95IdIso_EB_Pt20ToInf", "Mass_TagPlusRecoFailVBTF95IdIso_EB_Pt20ToInf" );
+  //     performFit("EfficiencyFitter/input/Data_36_09122010_TagWP80/", "EfficiencyFitter/results/Parameters.txt", "Efficiency_RecoToVBTF95_EE", "Mass_TagPlusRecoPassVBTF95IdIso_EE_Pt20ToInf_Data_36", "Mass_TagPlusRecoFailVBTF95IdIso_EE_Pt20ToInf_Data_36", "Mass_TagPlusRecoPassVBTF95IdIso_EE_Pt20ToInf", "Mass_TagPlusRecoFailVBTF95IdIso_EE_Pt20ToInf" );
+  //     performFit("EfficiencyFitter/input/Data_36_09122010_TagWP80/", "EfficiencyFitter/results/Parameters.txt", "Efficiency_RecoToVBTF95_EB_Minus", "Mass_TagPlusRecoPassVBTF95IdIso_EB_Pt20ToInf_Data_36_Minus", "Mass_TagPlusRecoFailVBTF95IdIso_EB_Pt20ToInf_Data_36_Minus", "Mass_TagPlusRecoPassVBTF95IdIso_EB_Pt20ToInf", "Mass_TagPlusRecoFailVBTF95IdIso_EB_Pt20ToInf" );
+  //     performFit("EfficiencyFitter/input/Data_36_09122010_TagWP80/", "EfficiencyFitter/results/Parameters.txt", "Efficiency_RecoToVBTF95_EE_Minus", "Mass_TagPlusRecoPassVBTF95IdIso_EE_Pt20ToInf_Data_36_Minus", "Mass_TagPlusRecoFailVBTF95IdIso_EE_Pt20ToInf_Data_36_Minus", "Mass_TagPlusRecoPassVBTF95IdIso_EE_Pt20ToInf", "Mass_TagPlusRecoFailVBTF95IdIso_EE_Pt20ToInf" );
+  //     performFit("EfficiencyFitter/input/Data_36_09122010_TagWP80/", "EfficiencyFitter/results/Parameters.txt", "Efficiency_RecoToVBTF95_EB_Plus", "Mass_TagPlusRecoPassVBTF95IdIso_EB_Pt20ToInf_Data_36_Plus", "Mass_TagPlusRecoFailVBTF95IdIso_EB_Pt20ToInf_Data_36_Plus", "Mass_TagPlusRecoPassVBTF95IdIso_EB_Pt20ToInf", "Mass_TagPlusRecoFailVBTF95IdIso_EB_Pt20ToInf" );
+  //     performFit("EfficiencyFitter/input/Data_36_09122010_TagWP80/", "EfficiencyFitter/results/Parameters.txt", "Efficiency_RecoToVBTF95_EE_Plus", "Mass_TagPlusRecoPassVBTF95IdIso_EE_Pt20ToInf_Data_36_Plus", "Mass_TagPlusRecoFailVBTF95IdIso_EE_Pt20ToInf_Data_36_Plus", "Mass_TagPlusRecoPassVBTF95IdIso_EE_Pt20ToInf", "Mass_TagPlusRecoFailVBTF95IdIso_EE_Pt20ToInf" );
 
+  // //**************
+  // //TAG 95 - BAMBU
+  // //**************
+  //    performFit("EfficiencyFitter/input/Data_36_09122010_TagWP95/", "EfficiencyFitter/results/Parameters.txt", "Efficiency_RecoToVBTF95", "Mass_TagPlusRecoPassVBTF95IdIso_Data_36", "Mass_TagPlusRecoFailVBTF95IdIso_Data_36", "Mass_TagPlusRecoPassVBTF95IdIso", "Mass_TagPlusRecoFailVBTF95IdIso" );
+  //     performFit("EfficiencyFitter/input/Data_36_09122010_TagWP95/", "EfficiencyFitter/results/Parameters.txt", "Efficiency_RecoToVBTF95_EB", "Mass_TagPlusRecoPassVBTF95IdIso_EB_Pt20ToInf_Data_36", "Mass_TagPlusRecoFailVBTF95IdIso_EB_Pt20ToInf_Data_36", "Mass_TagPlusRecoPassVBTF95IdIso_EB_Pt20ToInf", "Mass_TagPlusRecoFailVBTF95IdIso_EB_Pt20ToInf" );
+  //     performFit("EfficiencyFitter/input/Data_36_09122010_TagWP95/", "EfficiencyFitter/results/Parameters.txt", "Efficiency_RecoToVBTF95_EE", "Mass_TagPlusRecoPassVBTF95IdIso_EE_Pt20ToInf_Data_36", "Mass_TagPlusRecoFailVBTF95IdIso_EE_Pt20ToInf_Data_36", "Mass_TagPlusRecoPassVBTF95IdIso_EE_Pt20ToInf", "Mass_TagPlusRecoFailVBTF95IdIso_EE_Pt20ToInf" );
+  //     performFit("EfficiencyFitter/input/Data_36_09122010_TagWP95/", "EfficiencyFitter/results/Parameters.txt", "Efficiency_RecoToVBTF95_EB_Minus", "Mass_TagPlusRecoPassVBTF95IdIso_EB_Pt20ToInf_Data_36_Minus", "Mass_TagPlusRecoFailVBTF95IdIso_EB_Pt20ToInf_Data_36_Minus", "Mass_TagPlusRecoPassVBTF95IdIso_EB_Pt20ToInf", "Mass_TagPlusRecoFailVBTF95IdIso_EB_Pt20ToInf" );
+  //     performFit("EfficiencyFitter/input/Data_36_09122010_TagWP95/", "EfficiencyFitter/results/Parameters.txt", "Efficiency_RecoToVBTF95_EE_Minus", "Mass_TagPlusRecoPassVBTF95IdIso_EE_Pt20ToInf_Data_36_Minus", "Mass_TagPlusRecoFailVBTF95IdIso_EE_Pt20ToInf_Data_36_Minus", "Mass_TagPlusRecoPassVBTF95IdIso_EE_Pt20ToInf", "Mass_TagPlusRecoFailVBTF95IdIso_EE_Pt20ToInf" );
+  //     performFit("EfficiencyFitter/input/Data_36_09122010_TagWP95/", "EfficiencyFitter/results/Parameters.txt", "Efficiency_RecoToVBTF95_EB_Plus", "Mass_TagPlusRecoPassVBTF95IdIso_EB_Pt20ToInf_Data_36_Plus", "Mass_TagPlusRecoFailVBTF95IdIso_EB_Pt20ToInf_Data_36_Plus", "Mass_TagPlusRecoPassVBTF95IdIso_EB_Pt20ToInf", "Mass_TagPlusRecoFailVBTF95IdIso_EB_Pt20ToInf" );
+  //     performFit("EfficiencyFitter/input/Data_36_09122010_TagWP95/", "EfficiencyFitter/results/Parameters.txt", "Efficiency_RecoToVBTF95_EE_Plus", "Mass_TagPlusRecoPassVBTF95IdIso_EE_Pt20ToInf_Data_36_Plus", "Mass_TagPlusRecoFailVBTF95IdIso_EE_Pt20ToInf_Data_36_Plus", "Mass_TagPlusRecoPassVBTF95IdIso_EE_Pt20ToInf", "Mass_TagPlusRecoFailVBTF95IdIso_EE_Pt20ToInf" );
 
+  //**************
+  //TAG 60 - BAMBU
+  //**************
+  //    performFit("EfficiencyFitter/input/Data_36_09122010_TagWP60/", "EfficiencyFitter/results/Parameters.txt", "Efficiency_RecoToVBTF95", "Mass_TagPlusRecoPassVBTF95IdIso_Data_36", "Mass_TagPlusRecoFailVBTF95IdIso_Data_36", "Mass_TagPlusRecoPassVBTF95IdIso", "Mass_TagPlusRecoFailVBTF95IdIso" );
+  //     performFit("EfficiencyFitter/input/Data_36_09122010_TagWP60/", "EfficiencyFitter/results/Parameters.txt", "Efficiency_RecoToVBTF95_EB", "Mass_TagPlusRecoPassVBTF95IdIso_EB_Pt20ToInf_Data_36", "Mass_TagPlusRecoFailVBTF95IdIso_EB_Pt20ToInf_Data_36", "Mass_TagPlusRecoPassVBTF95IdIso_EB_Pt20ToInf", "Mass_TagPlusRecoFailVBTF95IdIso_EB_Pt20ToInf" );
+  //     performFit("EfficiencyFitter/input/Data_36_09122010_TagWP60/", "EfficiencyFitter/results/Parameters.txt", "Efficiency_RecoToVBTF95_EE", "Mass_TagPlusRecoPassVBTF95IdIso_EE_Pt20ToInf_Data_36", "Mass_TagPlusRecoFailVBTF95IdIso_EE_Pt20ToInf_Data_36", "Mass_TagPlusRecoPassVBTF95IdIso_EE_Pt20ToInf", "Mass_TagPlusRecoFailVBTF95IdIso_EE_Pt20ToInf" );
+  //     performFit("EfficiencyFitter/input/Data_36_09122010_TagWP60/", "EfficiencyFitter/results/Parameters.txt", "Efficiency_RecoToVBTF95_EB_Minus", "Mass_TagPlusRecoPassVBTF95IdIso_EB_Pt20ToInf_Data_36_Minus", "Mass_TagPlusRecoFailVBTF95IdIso_EB_Pt20ToInf_Data_36_Minus", "Mass_TagPlusRecoPassVBTF95IdIso_EB_Pt20ToInf", "Mass_TagPlusRecoFailVBTF95IdIso_EB_Pt20ToInf" );
+  //     performFit("EfficiencyFitter/input/Data_36_09122010_TagWP60/", "EfficiencyFitter/results/Parameters.txt", "Efficiency_RecoToVBTF95_EE_Minus", "Mass_TagPlusRecoPassVBTF95IdIso_EE_Pt20ToInf_Data_36_Minus", "Mass_TagPlusRecoFailVBTF95IdIso_EE_Pt20ToInf_Data_36_Minus", "Mass_TagPlusRecoPassVBTF95IdIso_EE_Pt20ToInf", "Mass_TagPlusRecoFailVBTF95IdIso_EE_Pt20ToInf" );
+  //     performFit("EfficiencyFitter/input/Data_36_09122010_TagWP60/", "EfficiencyFitter/results/Parameters.txt", "Efficiency_RecoToVBTF95_EB_Plus", "Mass_TagPlusRecoPassVBTF95IdIso_EB_Pt20ToInf_Data_36_Plus", "Mass_TagPlusRecoFailVBTF95IdIso_EB_Pt20ToInf_Data_36_Plus", "Mass_TagPlusRecoPassVBTF95IdIso_EB_Pt20ToInf", "Mass_TagPlusRecoFailVBTF95IdIso_EB_Pt20ToInf" );
+  //     performFit("EfficiencyFitter/input/Data_36_09122010_TagWP60/", "EfficiencyFitter/results/Parameters.txt", "Efficiency_RecoToVBTF95_EE_Plus", "Mass_TagPlusRecoPassVBTF95IdIso_EE_Pt20ToInf_Data_36_Plus", "Mass_TagPlusRecoFailVBTF95IdIso_EE_Pt20ToInf_Data_36_Plus", "Mass_TagPlusRecoPassVBTF95IdIso_EE_Pt20ToInf", "Mass_TagPlusRecoFailVBTF95IdIso_EE_Pt20ToInf" );
 
+  //       performFit("EfficiencyFitter/input/Data_36_09122010_JW_TagWP80/", "EfficiencyFitter/results/Parameters.txt", "Efficiency_RecoToVBTF95_EB", "Mass_TagPlusRecoPassVBTF95IdIso_EB_Pt20ToInf_Data_36", "Mass_TagPlusRecoFailVBTF95IdIso_EB_Pt20ToInf_Data_36", "Mass_TagPlusRecoPassVBTF95IdIso_EB_Pt20ToInf", "Mass_TagPlusRecoFailVBTF95IdIso_EB_Pt20ToInf" );
+  //       performFit("EfficiencyFitter/input/Data_36_09122010_JW_TagWP80/", "EfficiencyFitter/results/Parameters.txt", "Efficiency_RecoToVBTF95_EE", "Mass_TagPlusRecoPassVBTF95IdIso_EE_Pt20ToInf_Data_36", "Mass_TagPlusRecoFailVBTF95IdIso_EE_Pt20ToInf_Data_36", "Mass_TagPlusRecoPassVBTF95IdIso_EE_Pt20ToInf", "Mass_TagPlusRecoFailVBTF95IdIso_EE_Pt20ToInf" );
 
-//**************
-//Impose WP95 Iso Cut on Photon probes - BAMBU
-//**************
-//      performFit("EfficiencyFitter/input/Data_36_09122010_TagWP80/", "EfficiencyFitter/results/Parameters.txt", "Efficiency_SCToReco", "Mass_TagPlusSCPassReco_Data_36", "Mass_TagPlusSCFailReco_Data_36", "Mass_TagPlusSCPassReco", "Mass_TagPlusSCFailReco" );
-//      performFit("EfficiencyFitter/input/Data_36_09122010_TagWP80/", "EfficiencyFitter/results/Parameters.txt", "Efficiency_SCToReco_EB", "Mass_TagPlusSCPassReco_EB_Pt20ToInf_Data_36", "Mass_TagPlusSCFailReco_EB_Pt20ToInf_Data_36", "Mass_TagPlusSCPassReco_EB_Pt20ToInf", "Mass_TagPlusSCFailReco_EB_Pt20ToInf" );
-//      performFit("EfficiencyFitter/input/Data_36_09122010_TagWP80/", "EfficiencyFitter/results/Parameters.txt", "Efficiency_SCToReco_EE", "Mass_TagPlusSCPassReco_EE_Pt20ToInf_Data_36", "Mass_TagPlusSCFailReco_EE_Pt20ToInf_Data_36", "Mass_TagPlusSCPassReco_EE_Pt20ToInf", "Mass_TagPlusSCFailReco_EE_Pt20ToInf" );
-//     performFit("EfficiencyFitter/input/Data_36_09122010_TagWP80/", "EfficiencyFitter/results/Parameters.txt", "Efficiency_SCToReco_EB_Minus", "Mass_TagPlusSCPassReco_EB_Pt20ToInf_Data_36_Minus", "Mass_TagPlusSCFailReco_EB_Pt20ToInf_Data_36_Minus", "Mass_TagPlusSCPassReco_EB_Pt20ToInf", "Mass_TagPlusSCFailReco_EB_Pt20ToInf" );
-//     performFit("EfficiencyFitter/input/Data_36_09122010_TagWP80/", "EfficiencyFitter/results/Parameters.txt", "Efficiency_SCToReco_EE_Minus", "Mass_TagPlusSCPassReco_EE_Pt20ToInf_Data_36_Minus", "Mass_TagPlusSCFailReco_EE_Pt20ToInf_Data_36_Minus", "Mass_TagPlusSCPassReco_EE_Pt20ToInf", "Mass_TagPlusSCFailReco_EE_Pt20ToInf" );
-//     performFit("EfficiencyFitter/input/Data_36_09122010_TagWP80/", "EfficiencyFitter/results/Parameters.txt", "Efficiency_SCToReco_EB_Plus", "Mass_TagPlusSCPassReco_EB_Pt20ToInf_Data_36_Plus", "Mass_TagPlusSCFailReco_EB_Pt20ToInf_Data_36_Plus", "Mass_TagPlusSCPassReco_EB_Pt20ToInf", "Mass_TagPlusSCFailReco_EB_Pt20ToInf" );
-//     performFit("EfficiencyFitter/input/Data_36_09122010_TagWP80/", "EfficiencyFitter/results/Parameters.txt", "Efficiency_SCToReco_EE_Plus", "Mass_TagPlusSCPassReco_EE_Pt20ToInf_Data_36_Plus", "Mass_TagPlusSCFailReco_EE_Pt20ToInf_Data_36_Plus", "Mass_TagPlusSCPassReco_EE_Pt20ToInf", "Mass_TagPlusSCFailReco_EE_Pt20ToInf" );
+  cout << "########################################" << endl;
 
+  // // //////////////////////////////////////////////////////////
+  // //   //  gsfElectron --> WP-80 selection efficiency
+  // // //////////////////////////////////////////////////////////
 
+  //**************
+  //TAG 80 - TP
+  //**************
+  //     performFit("EfficiencyFitter/input/Data_36_09122010_TP_TagWP80/", "EfficiencyFitter/results/Parameters.txt", "Efficiency_RecoToVBTF80", "Mass_TagPlusRecoPassVBTF80IdIso_Data_36", "Mass_TagPlusRecoFailVBTF80IdIso_Data_36", "Mass_TagPlusRecoPassVBTF80IdIso", "Mass_TagPlusRecoFailVBTF80IdIso" );
+  //     performFit("EfficiencyFitter/input/Data_36_09122010_TP_TagWP80/", "EfficiencyFitter/results/Parameters.txt", "Efficiency_RecoToVBTF80_EB", "Mass_TagPlusRecoPassVBTF80IdIso_EB_Pt20ToInf_Data_36", "Mass_TagPlusRecoFailVBTF80IdIso_EB_Pt20ToInf_Data_36", "Mass_TagPlusRecoPassVBTF80IdIso_EB_Pt20ToInf", "Mass_TagPlusRecoFailVBTF80IdIso_EB_Pt20ToInf" );
+  //     performFit("EfficiencyFitter/input/Data_36_09122010_TP_TagWP80/", "EfficiencyFitter/results/Parameters.txt", "Efficiency_RecoToVBTF80_EE", "Mass_TagPlusRecoPassVBTF80IdIso_EE_Pt20ToInf_Data_36", "Mass_TagPlusRecoFailVBTF80IdIso_EE_Pt20ToInf_Data_36", "Mass_TagPlusRecoPassVBTF80IdIso_EE_Pt20ToInf", "Mass_TagPlusRecoFailVBTF80IdIso_EE_Pt20ToInf" );
+  //     performFit("EfficiencyFitter/input/Data_36_09122010_TP_TagWP80/", "EfficiencyFitter/results/Parameters.txt", "Efficiency_RecoToVBTF80_EB_Minus", "Mass_TagPlusRecoPassVBTF80IdIso_EB_Pt20ToInf_Data_36_Minus", "Mass_TagPlusRecoFailVBTF80IdIso_EB_Pt20ToInf_Data_36_Minus", "Mass_TagPlusRecoPassVBTF80IdIso_EB_Pt20ToInf", "Mass_TagPlusRecoFailVBTF80IdIso_EB_Pt20ToInf" );
+  //     performFit("EfficiencyFitter/input/Data_36_09122010_TP_TagWP80/", "EfficiencyFitter/results/Parameters.txt", "Efficiency_RecoToVBTF80_EE_Minus", "Mass_TagPlusRecoPassVBTF80IdIso_EE_Pt20ToInf_Data_36_Minus", "Mass_TagPlusRecoFailVBTF80IdIso_EE_Pt20ToInf_Data_36_Minus", "Mass_TagPlusRecoPassVBTF80IdIso_EE_Pt20ToInf", "Mass_TagPlusRecoFailVBTF80IdIso_EE_Pt20ToInf" );
+  //     performFit("EfficiencyFitter/input/Data_36_09122010_TP_TagWP80/", "EfficiencyFitter/results/Parameters.txt", "Efficiency_RecoToVBTF80_EB_Plus", "Mass_TagPlusRecoPassVBTF80IdIso_EB_Pt20ToInf_Data_36_Plus", "Mass_TagPlusRecoFailVBTF80IdIso_EB_Pt20ToInf_Data_36_Plus", "Mass_TagPlusRecoPassVBTF80IdIso_EB_Pt20ToInf", "Mass_TagPlusRecoFailVBTF80IdIso_EB_Pt20ToInf" );
+  //     performFit("EfficiencyFitter/input/Data_36_09122010_TP_TagWP80/", "EfficiencyFitter/results/Parameters.txt", "Efficiency_RecoToVBTF80_EE_Plus", "Mass_TagPlusRecoPassVBTF80IdIso_EE_Pt20ToInf_Data_36_Plus", "Mass_TagPlusRecoFailVBTF80IdIso_EE_Pt20ToInf_Data_36_Plus", "Mass_TagPlusRecoPassVBTF80IdIso_EE_Pt20ToInf", "Mass_TagPlusRecoFailVBTF80IdIso_EE_Pt20ToInf" );
 
-// //////////////////////////////////////////////////////////
-//   //  gsfElectron --> WP-95 selection efficiency
-// //////////////////////////////////////////////////////////
+  //**************
+  //TAG 80 - BAMBU
+  //**************
 
-//**************
-//TAG 80 - TPTree
-//**************
-//    performFit("EfficiencyFitter/input/Data_36_09122010_TP_TagWP80/", "EfficiencyFitter/results/Parameters.txt", "Efficiency_RecoToVBTF95", "Mass_TagPlusRecoPassVBTF95IdIso_Data_36", "Mass_TagPlusRecoFailVBTF95IdIso_Data_36", "Mass_TagPlusRecoPassVBTF95IdIso", "Mass_TagPlusRecoFailVBTF95IdIso" );
-//     performFit("EfficiencyFitter/input/Data_36_09122010_TP_TagWP80/", "EfficiencyFitter/results/Parameters.txt", "Efficiency_RecoToVBTF95_EB", "Mass_TagPlusRecoPassVBTF95IdIso_EB_Pt20ToInf_Data_36", "Mass_TagPlusRecoFailVBTF95IdIso_EB_Pt20ToInf_Data_36", "Mass_TagPlusRecoPassVBTF95IdIso_EB_Pt20ToInf", "Mass_TagPlusRecoFailVBTF95IdIso_EB_Pt20ToInf" );
-//     performFit("EfficiencyFitter/input/Data_36_09122010_TP_TagWP80/", "EfficiencyFitter/results/Parameters.txt", "Efficiency_RecoToVBTF95_EE", "Mass_TagPlusRecoPassVBTF95IdIso_EE_Pt20ToInf_Data_36", "Mass_TagPlusRecoFailVBTF95IdIso_EE_Pt20ToInf_Data_36", "Mass_TagPlusRecoPassVBTF95IdIso_EE_Pt20ToInf", "Mass_TagPlusRecoFailVBTF95IdIso_EE_Pt20ToInf" );
-//     performFit("EfficiencyFitter/input/Data_36_09122010_TP_TagWP80/", "EfficiencyFitter/results/Parameters.txt", "Efficiency_RecoToVBTF95_EB_Minus", "Mass_TagPlusRecoPassVBTF95IdIso_EB_Pt20ToInf_Data_36_Minus", "Mass_TagPlusRecoFailVBTF95IdIso_EB_Pt20ToInf_Data_36_Minus", "Mass_TagPlusRecoPassVBTF95IdIso_EB_Pt20ToInf", "Mass_TagPlusRecoFailVBTF95IdIso_EB_Pt20ToInf" );
-//     performFit("EfficiencyFitter/input/Data_36_09122010_TP_TagWP80/", "EfficiencyFitter/results/Parameters.txt", "Efficiency_RecoToVBTF95_EE_Minus", "Mass_TagPlusRecoPassVBTF95IdIso_EE_Pt20ToInf_Data_36_Minus", "Mass_TagPlusRecoFailVBTF95IdIso_EE_Pt20ToInf_Data_36_Minus", "Mass_TagPlusRecoPassVBTF95IdIso_EE_Pt20ToInf", "Mass_TagPlusRecoFailVBTF95IdIso_EE_Pt20ToInf" );
-//     performFit("EfficiencyFitter/input/Data_36_09122010_TP_TagWP80/", "EfficiencyFitter/results/Parameters.txt", "Efficiency_RecoToVBTF95_EB_Plus", "Mass_TagPlusRecoPassVBTF95IdIso_EB_Pt20ToInf_Data_36_Plus", "Mass_TagPlusRecoFailVBTF95IdIso_EB_Pt20ToInf_Data_36_Plus", "Mass_TagPlusRecoPassVBTF95IdIso_EB_Pt20ToInf", "Mass_TagPlusRecoFailVBTF95IdIso_EB_Pt20ToInf" );
-//     performFit("EfficiencyFitter/input/Data_36_09122010_TP_TagWP80/", "EfficiencyFitter/results/Parameters.txt", "Efficiency_RecoToVBTF95_EE_Plus", "Mass_TagPlusRecoPassVBTF95IdIso_EE_Pt20ToInf_Data_36_Plus", "Mass_TagPlusRecoFailVBTF95IdIso_EE_Pt20ToInf_Data_36_Plus", "Mass_TagPlusRecoPassVBTF95IdIso_EE_Pt20ToInf", "Mass_TagPlusRecoFailVBTF95IdIso_EE_Pt20ToInf" );
+  //     performFit("EfficiencyFitter/input/Data_36_09122010_TagWP80/", "EfficiencyFitter/results/Parameters.txt", "Efficiency_RecoToVBTF80", "Mass_TagPlusRecoPassVBTF80IdIso_Data_36", "Mass_TagPlusRecoFailVBTF80IdIso_Data_36", "Mass_TagPlusRecoPassVBTF80IdIso", "Mass_TagPlusRecoFailVBTF80IdIso" );
+  //     performFit("EfficiencyFitter/input/Data_36_09122010_TagWP80/", "EfficiencyFitter/results/Parameters.txt", "Efficiency_RecoToVBTF80_EB", "Mass_TagPlusRecoPassVBTF80IdIso_EB_Pt20ToInf_Data_36", "Mass_TagPlusRecoFailVBTF80IdIso_EB_Pt20ToInf_Data_36", "Mass_TagPlusRecoPassVBTF80IdIso_EB_Pt20ToInf", "Mass_TagPlusRecoFailVBTF80IdIso_EB_Pt20ToInf" );
+  //     performFit("EfficiencyFitter/input/Data_36_09122010_TagWP80/", "EfficiencyFitter/results/Parameters.txt", "Efficiency_RecoToVBTF80_EE", "Mass_TagPlusRecoPassVBTF80IdIso_EE_Pt20ToInf_Data_36", "Mass_TagPlusRecoFailVBTF80IdIso_EE_Pt20ToInf_Data_36", "Mass_TagPlusRecoPassVBTF80IdIso_EE_Pt20ToInf", "Mass_TagPlusRecoFailVBTF80IdIso_EE_Pt20ToInf" );
+  //     performFit("EfficiencyFitter/input/Data_36_09122010_TagWP80/", "EfficiencyFitter/results/Parameters.txt", "Efficiency_RecoToVBTF80_EB_Minus", "Mass_TagPlusRecoPassVBTF80IdIso_EB_Pt20ToInf_Data_36_Minus", "Mass_TagPlusRecoFailVBTF80IdIso_EB_Pt20ToInf_Data_36_Minus", "Mass_TagPlusRecoPassVBTF80IdIso_EB_Pt20ToInf", "Mass_TagPlusRecoFailVBTF80IdIso_EB_Pt20ToInf" );
+  //     performFit("EfficiencyFitter/input/Data_36_09122010_TagWP80/", "EfficiencyFitter/results/Parameters.txt", "Efficiency_RecoToVBTF80_EE_Minus", "Mass_TagPlusRecoPassVBTF80IdIso_EE_Pt20ToInf_Data_36_Minus", "Mass_TagPlusRecoFailVBTF80IdIso_EE_Pt20ToInf_Data_36_Minus", "Mass_TagPlusRecoPassVBTF80IdIso_EE_Pt20ToInf", "Mass_TagPlusRecoFailVBTF80IdIso_EE_Pt20ToInf" );
+  //     performFit("EfficiencyFitter/input/Data_36_09122010_TagWP80/", "EfficiencyFitter/results/Parameters.txt", "Efficiency_RecoToVBTF80_EB_Plus", "Mass_TagPlusRecoPassVBTF80IdIso_EB_Pt20ToInf_Data_36_Plus", "Mass_TagPlusRecoFailVBTF80IdIso_EB_Pt20ToInf_Data_36_Plus", "Mass_TagPlusRecoPassVBTF80IdIso_EB_Pt20ToInf", "Mass_TagPlusRecoFailVBTF80IdIso_EB_Pt20ToInf" );
+  //     performFit("EfficiencyFitter/input/Data_36_09122010_TagWP80/", "EfficiencyFitter/results/Parameters.txt", "Efficiency_RecoToVBTF80_EE_Plus", "Mass_TagPlusRecoPassVBTF80IdIso_EE_Pt20ToInf_Data_36_Plus", "Mass_TagPlusRecoFailVBTF80IdIso_EE_Pt20ToInf_Data_36_Plus", "Mass_TagPlusRecoPassVBTF80IdIso_EE_Pt20ToInf", "Mass_TagPlusRecoFailVBTF80IdIso_EE_Pt20ToInf" );
 
-//**************
-//TAG 80 - BAMBU
-//**************
-//    performFit("EfficiencyFitter/input/Data_36_09122010_TagWP80/", "EfficiencyFitter/results/Parameters.txt", "Efficiency_RecoToVBTF95", "Mass_TagPlusRecoPassVBTF95IdIso_Data_36", "Mass_TagPlusRecoFailVBTF95IdIso_Data_36", "Mass_TagPlusRecoPassVBTF95IdIso", "Mass_TagPlusRecoFailVBTF95IdIso" );
-//     performFit("EfficiencyFitter/input/Data_36_09122010_TagWP80/", "EfficiencyFitter/results/Parameters.txt", "Efficiency_RecoToVBTF95_EB", "Mass_TagPlusRecoPassVBTF95IdIso_EB_Pt20ToInf_Data_36", "Mass_TagPlusRecoFailVBTF95IdIso_EB_Pt20ToInf_Data_36", "Mass_TagPlusRecoPassVBTF95IdIso_EB_Pt20ToInf", "Mass_TagPlusRecoFailVBTF95IdIso_EB_Pt20ToInf" );
-//     performFit("EfficiencyFitter/input/Data_36_09122010_TagWP80/", "EfficiencyFitter/results/Parameters.txt", "Efficiency_RecoToVBTF95_EE", "Mass_TagPlusRecoPassVBTF95IdIso_EE_Pt20ToInf_Data_36", "Mass_TagPlusRecoFailVBTF95IdIso_EE_Pt20ToInf_Data_36", "Mass_TagPlusRecoPassVBTF95IdIso_EE_Pt20ToInf", "Mass_TagPlusRecoFailVBTF95IdIso_EE_Pt20ToInf" );
-//     performFit("EfficiencyFitter/input/Data_36_09122010_TagWP80/", "EfficiencyFitter/results/Parameters.txt", "Efficiency_RecoToVBTF95_EB_Minus", "Mass_TagPlusRecoPassVBTF95IdIso_EB_Pt20ToInf_Data_36_Minus", "Mass_TagPlusRecoFailVBTF95IdIso_EB_Pt20ToInf_Data_36_Minus", "Mass_TagPlusRecoPassVBTF95IdIso_EB_Pt20ToInf", "Mass_TagPlusRecoFailVBTF95IdIso_EB_Pt20ToInf" );
-//     performFit("EfficiencyFitter/input/Data_36_09122010_TagWP80/", "EfficiencyFitter/results/Parameters.txt", "Efficiency_RecoToVBTF95_EE_Minus", "Mass_TagPlusRecoPassVBTF95IdIso_EE_Pt20ToInf_Data_36_Minus", "Mass_TagPlusRecoFailVBTF95IdIso_EE_Pt20ToInf_Data_36_Minus", "Mass_TagPlusRecoPassVBTF95IdIso_EE_Pt20ToInf", "Mass_TagPlusRecoFailVBTF95IdIso_EE_Pt20ToInf" );
-//     performFit("EfficiencyFitter/input/Data_36_09122010_TagWP80/", "EfficiencyFitter/results/Parameters.txt", "Efficiency_RecoToVBTF95_EB_Plus", "Mass_TagPlusRecoPassVBTF95IdIso_EB_Pt20ToInf_Data_36_Plus", "Mass_TagPlusRecoFailVBTF95IdIso_EB_Pt20ToInf_Data_36_Plus", "Mass_TagPlusRecoPassVBTF95IdIso_EB_Pt20ToInf", "Mass_TagPlusRecoFailVBTF95IdIso_EB_Pt20ToInf" );
-//     performFit("EfficiencyFitter/input/Data_36_09122010_TagWP80/", "EfficiencyFitter/results/Parameters.txt", "Efficiency_RecoToVBTF95_EE_Plus", "Mass_TagPlusRecoPassVBTF95IdIso_EE_Pt20ToInf_Data_36_Plus", "Mass_TagPlusRecoFailVBTF95IdIso_EE_Pt20ToInf_Data_36_Plus", "Mass_TagPlusRecoPassVBTF95IdIso_EE_Pt20ToInf", "Mass_TagPlusRecoFailVBTF95IdIso_EE_Pt20ToInf" );
+  performFit("res/",
+             "results/Parameters.txt",
+             "Efficiency_Photon",
+             "photonEfffromZee.passbar.dflag1.eT1.2.gT40.mt15.ptbin0.txt",
+             "photonEfffromZee.failbar.dflag1.eT1.2.gT40.mt15.ptbin0.txt",
+             "hh_Meg_barrel_mc_pt_0",
+             "hh_Megf_barrel_mc_pt_0");
 
+  // // //////////////////////////////////////////////////////////
+  // //   //   WP-95 --> HLT triggering efficiency
+  // // //////////////////////////////////////////////////////////
 
-// //**************
-// //TAG 95 - BAMBU
-// //**************
-//    performFit("EfficiencyFitter/input/Data_36_09122010_TagWP95/", "EfficiencyFitter/results/Parameters.txt", "Efficiency_RecoToVBTF95", "Mass_TagPlusRecoPassVBTF95IdIso_Data_36", "Mass_TagPlusRecoFailVBTF95IdIso_Data_36", "Mass_TagPlusRecoPassVBTF95IdIso", "Mass_TagPlusRecoFailVBTF95IdIso" );
-//     performFit("EfficiencyFitter/input/Data_36_09122010_TagWP95/", "EfficiencyFitter/results/Parameters.txt", "Efficiency_RecoToVBTF95_EB", "Mass_TagPlusRecoPassVBTF95IdIso_EB_Pt20ToInf_Data_36", "Mass_TagPlusRecoFailVBTF95IdIso_EB_Pt20ToInf_Data_36", "Mass_TagPlusRecoPassVBTF95IdIso_EB_Pt20ToInf", "Mass_TagPlusRecoFailVBTF95IdIso_EB_Pt20ToInf" );
-//     performFit("EfficiencyFitter/input/Data_36_09122010_TagWP95/", "EfficiencyFitter/results/Parameters.txt", "Efficiency_RecoToVBTF95_EE", "Mass_TagPlusRecoPassVBTF95IdIso_EE_Pt20ToInf_Data_36", "Mass_TagPlusRecoFailVBTF95IdIso_EE_Pt20ToInf_Data_36", "Mass_TagPlusRecoPassVBTF95IdIso_EE_Pt20ToInf", "Mass_TagPlusRecoFailVBTF95IdIso_EE_Pt20ToInf" );
-//     performFit("EfficiencyFitter/input/Data_36_09122010_TagWP95/", "EfficiencyFitter/results/Parameters.txt", "Efficiency_RecoToVBTF95_EB_Minus", "Mass_TagPlusRecoPassVBTF95IdIso_EB_Pt20ToInf_Data_36_Minus", "Mass_TagPlusRecoFailVBTF95IdIso_EB_Pt20ToInf_Data_36_Minus", "Mass_TagPlusRecoPassVBTF95IdIso_EB_Pt20ToInf", "Mass_TagPlusRecoFailVBTF95IdIso_EB_Pt20ToInf" );
-//     performFit("EfficiencyFitter/input/Data_36_09122010_TagWP95/", "EfficiencyFitter/results/Parameters.txt", "Efficiency_RecoToVBTF95_EE_Minus", "Mass_TagPlusRecoPassVBTF95IdIso_EE_Pt20ToInf_Data_36_Minus", "Mass_TagPlusRecoFailVBTF95IdIso_EE_Pt20ToInf_Data_36_Minus", "Mass_TagPlusRecoPassVBTF95IdIso_EE_Pt20ToInf", "Mass_TagPlusRecoFailVBTF95IdIso_EE_Pt20ToInf" );
-//     performFit("EfficiencyFitter/input/Data_36_09122010_TagWP95/", "EfficiencyFitter/results/Parameters.txt", "Efficiency_RecoToVBTF95_EB_Plus", "Mass_TagPlusRecoPassVBTF95IdIso_EB_Pt20ToInf_Data_36_Plus", "Mass_TagPlusRecoFailVBTF95IdIso_EB_Pt20ToInf_Data_36_Plus", "Mass_TagPlusRecoPassVBTF95IdIso_EB_Pt20ToInf", "Mass_TagPlusRecoFailVBTF95IdIso_EB_Pt20ToInf" );
-//     performFit("EfficiencyFitter/input/Data_36_09122010_TagWP95/", "EfficiencyFitter/results/Parameters.txt", "Efficiency_RecoToVBTF95_EE_Plus", "Mass_TagPlusRecoPassVBTF95IdIso_EE_Pt20ToInf_Data_36_Plus", "Mass_TagPlusRecoFailVBTF95IdIso_EE_Pt20ToInf_Data_36_Plus", "Mass_TagPlusRecoPassVBTF95IdIso_EE_Pt20ToInf", "Mass_TagPlusRecoFailVBTF95IdIso_EE_Pt20ToInf" );
+  //    cout << "########################################" << endl;
 
-//**************
-//TAG 60 - BAMBU
-//**************
-//    performFit("EfficiencyFitter/input/Data_36_09122010_TagWP60/", "EfficiencyFitter/results/Parameters.txt", "Efficiency_RecoToVBTF95", "Mass_TagPlusRecoPassVBTF95IdIso_Data_36", "Mass_TagPlusRecoFailVBTF95IdIso_Data_36", "Mass_TagPlusRecoPassVBTF95IdIso", "Mass_TagPlusRecoFailVBTF95IdIso" );
-//     performFit("EfficiencyFitter/input/Data_36_09122010_TagWP60/", "EfficiencyFitter/results/Parameters.txt", "Efficiency_RecoToVBTF95_EB", "Mass_TagPlusRecoPassVBTF95IdIso_EB_Pt20ToInf_Data_36", "Mass_TagPlusRecoFailVBTF95IdIso_EB_Pt20ToInf_Data_36", "Mass_TagPlusRecoPassVBTF95IdIso_EB_Pt20ToInf", "Mass_TagPlusRecoFailVBTF95IdIso_EB_Pt20ToInf" );
-//     performFit("EfficiencyFitter/input/Data_36_09122010_TagWP60/", "EfficiencyFitter/results/Parameters.txt", "Efficiency_RecoToVBTF95_EE", "Mass_TagPlusRecoPassVBTF95IdIso_EE_Pt20ToInf_Data_36", "Mass_TagPlusRecoFailVBTF95IdIso_EE_Pt20ToInf_Data_36", "Mass_TagPlusRecoPassVBTF95IdIso_EE_Pt20ToInf", "Mass_TagPlusRecoFailVBTF95IdIso_EE_Pt20ToInf" );
-//     performFit("EfficiencyFitter/input/Data_36_09122010_TagWP60/", "EfficiencyFitter/results/Parameters.txt", "Efficiency_RecoToVBTF95_EB_Minus", "Mass_TagPlusRecoPassVBTF95IdIso_EB_Pt20ToInf_Data_36_Minus", "Mass_TagPlusRecoFailVBTF95IdIso_EB_Pt20ToInf_Data_36_Minus", "Mass_TagPlusRecoPassVBTF95IdIso_EB_Pt20ToInf", "Mass_TagPlusRecoFailVBTF95IdIso_EB_Pt20ToInf" );
-//     performFit("EfficiencyFitter/input/Data_36_09122010_TagWP60/", "EfficiencyFitter/results/Parameters.txt", "Efficiency_RecoToVBTF95_EE_Minus", "Mass_TagPlusRecoPassVBTF95IdIso_EE_Pt20ToInf_Data_36_Minus", "Mass_TagPlusRecoFailVBTF95IdIso_EE_Pt20ToInf_Data_36_Minus", "Mass_TagPlusRecoPassVBTF95IdIso_EE_Pt20ToInf", "Mass_TagPlusRecoFailVBTF95IdIso_EE_Pt20ToInf" );
-//     performFit("EfficiencyFitter/input/Data_36_09122010_TagWP60/", "EfficiencyFitter/results/Parameters.txt", "Efficiency_RecoToVBTF95_EB_Plus", "Mass_TagPlusRecoPassVBTF95IdIso_EB_Pt20ToInf_Data_36_Plus", "Mass_TagPlusRecoFailVBTF95IdIso_EB_Pt20ToInf_Data_36_Plus", "Mass_TagPlusRecoPassVBTF95IdIso_EB_Pt20ToInf", "Mass_TagPlusRecoFailVBTF95IdIso_EB_Pt20ToInf" );
-//     performFit("EfficiencyFitter/input/Data_36_09122010_TagWP60/", "EfficiencyFitter/results/Parameters.txt", "Efficiency_RecoToVBTF95_EE_Plus", "Mass_TagPlusRecoPassVBTF95IdIso_EE_Pt20ToInf_Data_36_Plus", "Mass_TagPlusRecoFailVBTF95IdIso_EE_Pt20ToInf_Data_36_Plus", "Mass_TagPlusRecoPassVBTF95IdIso_EE_Pt20ToInf", "Mass_TagPlusRecoFailVBTF95IdIso_EE_Pt20ToInf" );
+  // // //////////////////////////////////////////////////////////
+  // //   //   WP-80 --> HLT triggering efficiency
+  // // //////////////////////////////////////////////////////////
 
+  //    cout << "########################################" << endl;
 
-
-
-
-//       performFit("EfficiencyFitter/input/Data_36_09122010_JW_TagWP80/", "EfficiencyFitter/results/Parameters.txt", "Efficiency_RecoToVBTF95_EB", "Mass_TagPlusRecoPassVBTF95IdIso_EB_Pt20ToInf_Data_36", "Mass_TagPlusRecoFailVBTF95IdIso_EB_Pt20ToInf_Data_36", "Mass_TagPlusRecoPassVBTF95IdIso_EB_Pt20ToInf", "Mass_TagPlusRecoFailVBTF95IdIso_EB_Pt20ToInf" );
-//       performFit("EfficiencyFitter/input/Data_36_09122010_JW_TagWP80/", "EfficiencyFitter/results/Parameters.txt", "Efficiency_RecoToVBTF95_EE", "Mass_TagPlusRecoPassVBTF95IdIso_EE_Pt20ToInf_Data_36", "Mass_TagPlusRecoFailVBTF95IdIso_EE_Pt20ToInf_Data_36", "Mass_TagPlusRecoPassVBTF95IdIso_EE_Pt20ToInf", "Mass_TagPlusRecoFailVBTF95IdIso_EE_Pt20ToInf" );
-
-   cout << "########################################" << endl;
-
-
-
-// // //////////////////////////////////////////////////////////
-// //   //  gsfElectron --> WP-80 selection efficiency
-// // //////////////////////////////////////////////////////////
-
-//**************
-//TAG 80 - TP
-//**************
-//     performFit("EfficiencyFitter/input/Data_36_09122010_TP_TagWP80/", "EfficiencyFitter/results/Parameters.txt", "Efficiency_RecoToVBTF80", "Mass_TagPlusRecoPassVBTF80IdIso_Data_36", "Mass_TagPlusRecoFailVBTF80IdIso_Data_36", "Mass_TagPlusRecoPassVBTF80IdIso", "Mass_TagPlusRecoFailVBTF80IdIso" );
-//     performFit("EfficiencyFitter/input/Data_36_09122010_TP_TagWP80/", "EfficiencyFitter/results/Parameters.txt", "Efficiency_RecoToVBTF80_EB", "Mass_TagPlusRecoPassVBTF80IdIso_EB_Pt20ToInf_Data_36", "Mass_TagPlusRecoFailVBTF80IdIso_EB_Pt20ToInf_Data_36", "Mass_TagPlusRecoPassVBTF80IdIso_EB_Pt20ToInf", "Mass_TagPlusRecoFailVBTF80IdIso_EB_Pt20ToInf" );
-//     performFit("EfficiencyFitter/input/Data_36_09122010_TP_TagWP80/", "EfficiencyFitter/results/Parameters.txt", "Efficiency_RecoToVBTF80_EE", "Mass_TagPlusRecoPassVBTF80IdIso_EE_Pt20ToInf_Data_36", "Mass_TagPlusRecoFailVBTF80IdIso_EE_Pt20ToInf_Data_36", "Mass_TagPlusRecoPassVBTF80IdIso_EE_Pt20ToInf", "Mass_TagPlusRecoFailVBTF80IdIso_EE_Pt20ToInf" );
-//     performFit("EfficiencyFitter/input/Data_36_09122010_TP_TagWP80/", "EfficiencyFitter/results/Parameters.txt", "Efficiency_RecoToVBTF80_EB_Minus", "Mass_TagPlusRecoPassVBTF80IdIso_EB_Pt20ToInf_Data_36_Minus", "Mass_TagPlusRecoFailVBTF80IdIso_EB_Pt20ToInf_Data_36_Minus", "Mass_TagPlusRecoPassVBTF80IdIso_EB_Pt20ToInf", "Mass_TagPlusRecoFailVBTF80IdIso_EB_Pt20ToInf" );
-//     performFit("EfficiencyFitter/input/Data_36_09122010_TP_TagWP80/", "EfficiencyFitter/results/Parameters.txt", "Efficiency_RecoToVBTF80_EE_Minus", "Mass_TagPlusRecoPassVBTF80IdIso_EE_Pt20ToInf_Data_36_Minus", "Mass_TagPlusRecoFailVBTF80IdIso_EE_Pt20ToInf_Data_36_Minus", "Mass_TagPlusRecoPassVBTF80IdIso_EE_Pt20ToInf", "Mass_TagPlusRecoFailVBTF80IdIso_EE_Pt20ToInf" );
-//     performFit("EfficiencyFitter/input/Data_36_09122010_TP_TagWP80/", "EfficiencyFitter/results/Parameters.txt", "Efficiency_RecoToVBTF80_EB_Plus", "Mass_TagPlusRecoPassVBTF80IdIso_EB_Pt20ToInf_Data_36_Plus", "Mass_TagPlusRecoFailVBTF80IdIso_EB_Pt20ToInf_Data_36_Plus", "Mass_TagPlusRecoPassVBTF80IdIso_EB_Pt20ToInf", "Mass_TagPlusRecoFailVBTF80IdIso_EB_Pt20ToInf" );
-//     performFit("EfficiencyFitter/input/Data_36_09122010_TP_TagWP80/", "EfficiencyFitter/results/Parameters.txt", "Efficiency_RecoToVBTF80_EE_Plus", "Mass_TagPlusRecoPassVBTF80IdIso_EE_Pt20ToInf_Data_36_Plus", "Mass_TagPlusRecoFailVBTF80IdIso_EE_Pt20ToInf_Data_36_Plus", "Mass_TagPlusRecoPassVBTF80IdIso_EE_Pt20ToInf", "Mass_TagPlusRecoFailVBTF80IdIso_EE_Pt20ToInf" );
-
-
-
-//**************
-//TAG 80 - BAMBU
-//**************
-
-//     performFit("EfficiencyFitter/input/Data_36_09122010_TagWP80/", "EfficiencyFitter/results/Parameters.txt", "Efficiency_RecoToVBTF80", "Mass_TagPlusRecoPassVBTF80IdIso_Data_36", "Mass_TagPlusRecoFailVBTF80IdIso_Data_36", "Mass_TagPlusRecoPassVBTF80IdIso", "Mass_TagPlusRecoFailVBTF80IdIso" );
-//     performFit("EfficiencyFitter/input/Data_36_09122010_TagWP80/", "EfficiencyFitter/results/Parameters.txt", "Efficiency_RecoToVBTF80_EB", "Mass_TagPlusRecoPassVBTF80IdIso_EB_Pt20ToInf_Data_36", "Mass_TagPlusRecoFailVBTF80IdIso_EB_Pt20ToInf_Data_36", "Mass_TagPlusRecoPassVBTF80IdIso_EB_Pt20ToInf", "Mass_TagPlusRecoFailVBTF80IdIso_EB_Pt20ToInf" );
-//     performFit("EfficiencyFitter/input/Data_36_09122010_TagWP80/", "EfficiencyFitter/results/Parameters.txt", "Efficiency_RecoToVBTF80_EE", "Mass_TagPlusRecoPassVBTF80IdIso_EE_Pt20ToInf_Data_36", "Mass_TagPlusRecoFailVBTF80IdIso_EE_Pt20ToInf_Data_36", "Mass_TagPlusRecoPassVBTF80IdIso_EE_Pt20ToInf", "Mass_TagPlusRecoFailVBTF80IdIso_EE_Pt20ToInf" );
-//     performFit("EfficiencyFitter/input/Data_36_09122010_TagWP80/", "EfficiencyFitter/results/Parameters.txt", "Efficiency_RecoToVBTF80_EB_Minus", "Mass_TagPlusRecoPassVBTF80IdIso_EB_Pt20ToInf_Data_36_Minus", "Mass_TagPlusRecoFailVBTF80IdIso_EB_Pt20ToInf_Data_36_Minus", "Mass_TagPlusRecoPassVBTF80IdIso_EB_Pt20ToInf", "Mass_TagPlusRecoFailVBTF80IdIso_EB_Pt20ToInf" );
-//     performFit("EfficiencyFitter/input/Data_36_09122010_TagWP80/", "EfficiencyFitter/results/Parameters.txt", "Efficiency_RecoToVBTF80_EE_Minus", "Mass_TagPlusRecoPassVBTF80IdIso_EE_Pt20ToInf_Data_36_Minus", "Mass_TagPlusRecoFailVBTF80IdIso_EE_Pt20ToInf_Data_36_Minus", "Mass_TagPlusRecoPassVBTF80IdIso_EE_Pt20ToInf", "Mass_TagPlusRecoFailVBTF80IdIso_EE_Pt20ToInf" );
-//     performFit("EfficiencyFitter/input/Data_36_09122010_TagWP80/", "EfficiencyFitter/results/Parameters.txt", "Efficiency_RecoToVBTF80_EB_Plus", "Mass_TagPlusRecoPassVBTF80IdIso_EB_Pt20ToInf_Data_36_Plus", "Mass_TagPlusRecoFailVBTF80IdIso_EB_Pt20ToInf_Data_36_Plus", "Mass_TagPlusRecoPassVBTF80IdIso_EB_Pt20ToInf", "Mass_TagPlusRecoFailVBTF80IdIso_EB_Pt20ToInf" );
-//     performFit("EfficiencyFitter/input/Data_36_09122010_TagWP80/", "EfficiencyFitter/results/Parameters.txt", "Efficiency_RecoToVBTF80_EE_Plus", "Mass_TagPlusRecoPassVBTF80IdIso_EE_Pt20ToInf_Data_36_Plus", "Mass_TagPlusRecoFailVBTF80IdIso_EE_Pt20ToInf_Data_36_Plus", "Mass_TagPlusRecoPassVBTF80IdIso_EE_Pt20ToInf", "Mass_TagPlusRecoFailVBTF80IdIso_EE_Pt20ToInf" );
-
-
-
-
-
-   performFit("res/", "results/Parameters.txt", "Efficiency_Photon", "photonEfffromZee.passbar.dflag1.eT1.2.gT40.mt15.ptbin0.txt", "photonEfffromZee.failbar.dflag1.eT1.2.gT40.mt15.ptbin0.txt", "hh_Meg_barrel_mc_pt_0", "hh_Megf_barrel_mc_pt_0" );
-
-
-
-
-
-
-// // //////////////////////////////////////////////////////////
-// //   //   WP-95 --> HLT triggering efficiency
-// // //////////////////////////////////////////////////////////
-
-
-
-//    cout << "########################################" << endl;
-
-
-
-
-// // //////////////////////////////////////////////////////////
-// //   //   WP-80 --> HLT triggering efficiency
-// // //////////////////////////////////////////////////////////
-
- 
-//    cout << "########################################" << endl;
-
-   effTextFile.close();
+  effTextFile.close();
 }
-
-

--- a/PhysicsTools/TagAndProbe/test/utilities/ZeeBkgFit.C
+++ b/PhysicsTools/TagAndProbe/test/utilities/ZeeBkgFit.C
@@ -25,7 +25,6 @@
 #include "RooGaussian.h"
 #include "RooNLLVar.h"
 #include "RooConstVar.h"
-#include "RooFitLegacy/RooMinuit.h"
 #include "RooFitResult.h"
 #include "RooExponential.h"
 #include "RooFFTConvPdf.h"

--- a/PhysicsTools/TagAndProbe/test/utilities/ZeeBkgFit.C
+++ b/PhysicsTools/TagAndProbe/test/utilities/ZeeBkgFit.C
@@ -4,13 +4,12 @@
 //________________________________________________________________________________________________
 
 #if !defined(__CINT__) || defined(__MAKECINT__)
-#include <TROOT.h>                  // access to gROOT, entry point to ROOT system
-#include <TSystem.h>                // interface to OS
-#include <TStyle.h>                 // class to handle ROOT plotting style
-#include <TCanvas.h>                // class for drawing
-#include <TBenchmark.h>             // class to track macro running statistics
-#include <iostream>                 // standard I/O
-
+#include <TROOT.h>       // access to gROOT, entry point to ROOT system
+#include <TSystem.h>     // interface to OS
+#include <TStyle.h>      // class to handle ROOT plotting style
+#include <TCanvas.h>     // class for drawing
+#include <TBenchmark.h>  // class to track macro running statistics
+#include <iostream>      // standard I/O
 
 // RooFit headers
 #include "RooRealVar.h"
@@ -26,7 +25,7 @@
 #include "RooGaussian.h"
 #include "RooNLLVar.h"
 #include "RooConstVar.h"
-#include "RooMinuit.h"
+#include "RooFitLegacy/RooMinuit.h"
 #include "RooFitResult.h"
 #include "RooExponential.h"
 #include "RooFFTConvPdf.h"
@@ -36,92 +35,97 @@
 #include "TPaveText.h"
 #include "RooPlot.h"
 
-
 #endif
 
-#define LUMINOSITY 2.88 //(in pb^-1)
+#define LUMINOSITY 2.88  //(in pb^-1)
 #define NBINSPASS 24
 #define NBINSFAIL 24
 
-
 using namespace RooFit;
 
-double ErrorInProduct(double x, double errx, double y, 
-                      double erry, double corr) {
-   double xFrErr = errx/x;
-   double yFrErr = erry/y;
-   return sqrt(pow(xFrErr,2) + pow(yFrErr,2) + 2.0*corr*xFrErr*yFrErr)*x*y;
+double ErrorInProduct(double x, double errx, double y, double erry, double corr) {
+  double xFrErr = errx / x;
+  double yFrErr = erry / y;
+  return sqrt(pow(xFrErr, 2) + pow(yFrErr, 2) + 2.0 * corr * xFrErr * yFrErr) * x * y;
 }
-
-
 
 //=== MAIN MACRO =================================================================================================
 
 void performFit(string inputDir,
-                string OSInputDataFilename, string SSInputDataFilename, 
-                string OSSignalTemplateHistName, string SSSignalTemplateHistName ) {
+                string OSInputDataFilename,
+                string SSInputDataFilename,
+                string OSSignalTemplateHistName,
+                string SSSignalTemplateHistName) {
   gBenchmark->Start("fitZCat");
 
   //--------------------------------------------------------------------------------------------------------------
-  // Settings 
+  // Settings
   //==============================================================================================================
-  
-  const Double_t mlow  = 60;
+
+  const Double_t mlow = 60;
   const Double_t mhigh = 120;
-  const Int_t    nbins = 20;
-  
+  const Int_t nbins = 20;
+
   // Which fit parameters to set constant
   // MuTrk
-  Bool_t cBgA1MuTrk    = kFALSE;
-  Bool_t cBgA2MuTrk    = kTRUE;
+  Bool_t cBgA1MuTrk = kFALSE;
+  Bool_t cBgA2MuTrk = kTRUE;
   Bool_t cBgAlphaMuTrk = kFALSE;
   // MuMuNoIso
-  Bool_t cBgA1MuMuNoIso    = kFALSE;
+  Bool_t cBgA1MuMuNoIso = kFALSE;
   Bool_t cBgAlphaMuMuNoIso = kFALSE;
   // MuSta
-  Bool_t cBgA1MuSta    = kFALSE;
+  Bool_t cBgA1MuSta = kFALSE;
   Bool_t cBgAlphaMuSta = kFALSE;
-  
+
   //--------------------------------------------------------------------------------------------------------------
-  // Main analysis code 
+  // Main analysis code
   //==============================================================================================================
-  RooRealVar mass("mass","mass",mlow,mhigh);
+  RooRealVar mass("mass", "mass", mlow, mhigh);
   mass.setBins(nbins);
-  
+
   //
   // Prepare data for the fits
   //
   char datname[100];
-  RooDataSet *dataOS  = RooDataSet::read((inputDir+OSInputDataFilename).c_str(),RooArgList(mass));
-  RooDataSet *dataSS  = RooDataSet::read((inputDir+SSInputDataFilename).c_str(),RooArgList(mass));
+  RooDataSet* dataOS = RooDataSet::read((inputDir + OSInputDataFilename).c_str(), RooArgList(mass));
+  RooDataSet* dataSS = RooDataSet::read((inputDir + SSInputDataFilename).c_str(), RooArgList(mass));
 
   //Define categories
-  RooCategory sample("sample","") ;
-  sample.defineType("OS", 1) ;
-  sample.defineType("SS", 2) ; 
+  RooCategory sample("sample", "");
+  sample.defineType("OS", 1);
+  sample.defineType("SS", 2);
 
-  RooDataSet *dataCombined = new RooDataSet("dataCombined","dataCombined",RooArgList(mass), Index(sample), 
-                                            Import("OS",*dataOS),
-                                            Import("SS",*dataSS));
-
+  RooDataSet* dataCombined = new RooDataSet(
+      "dataCombined", "dataCombined", RooArgList(mass), Index(sample), Import("OS", *dataOS), Import("SS", *dataSS));
 
   //*********************************************************************************************
   //Define Free Parameters
   //*********************************************************************************************
 
-  RooRealVar* ParNumSignalOS = new RooRealVar  ("ParNumSignalOS","ParNumSignalOS", 1000.0, 0.0, 10000000.0);   
-  RooRealVar* ParNumSignalSS = new RooRealVar  ("ParNumSignalSS","ParNumSignalSS", 100.0, 0.0, 10000000.0);   
-  RooRealVar* ParNumBkgOS = new RooRealVar  ("ParNumBkgOS","ParNumBkgOS", 10.0, 0.0, 10000000.0);   
-  RooRealVar* ParNumBkgSS = new RooRealVar  ("ParNumBkgSS","ParNumBkgSS", 1.0, 0.0, 10000000.0);   
+  RooRealVar* ParNumSignalOS = new RooRealVar("ParNumSignalOS", "ParNumSignalOS", 1000.0, 0.0, 10000000.0);
+  RooRealVar* ParNumSignalSS = new RooRealVar("ParNumSignalSS", "ParNumSignalSS", 100.0, 0.0, 10000000.0);
+  RooRealVar* ParNumBkgOS = new RooRealVar("ParNumBkgOS", "ParNumBkgOS", 10.0, 0.0, 10000000.0);
+  RooRealVar* ParNumBkgSS = new RooRealVar("ParNumBkgSS", "ParNumBkgSS", 1.0, 0.0, 10000000.0);
 
-  RooRealVar* ParOSBackgroundExpCoefficient = new RooRealVar ("ParOSBackgroundExpCoefficient","ParOSBackgroundExpCoefficient",-0.01,-1.0, 1.0);   //ParOSBackgroundExpCoefficient.setConstant(kTRUE);  
-  RooRealVar* ParSSBackgroundExpCoefficient = new RooRealVar ("ParSSBackgroundExpCoefficient","ParSSBackgroundExpCoefficient",-0.01,-1.0, 1.0);   //ParSSBackgroundExpCoefficient.setConstant(kTRUE);  
-  RooRealVar* ParOSSignalMassShift = new RooRealVar  ("ParOSSignalMassShift","ParOSSignalMassShift",0.0, -10.0, 10.0);   ParOSSignalMassShift->setConstant(kTRUE);  
-  RooRealVar* ParSSSignalMassShift = new RooRealVar  ("ParSSSignalMassShift","ParSSSignalMassShift",0.0, -10.0, 10.0);   ParSSSignalMassShift->setConstant(kTRUE);  
-  RooRealVar* ParOSSignalResolution = new RooRealVar ("ParOSSignalResolution","ParOSSignalResolution",1.0, 0.0, 10.0);   //ParOSSignalResolution.setConstant(kTRUE);  
-  RooRealVar* ParSSSignalResolution = new RooRealVar ("ParSSSignalResolution","ParSSSignalResolution",1.0, 0.0, 10.0);   //ParSSSignalResolution.setConstant(kTRUE);  
-
-
+  RooRealVar* ParOSBackgroundExpCoefficient = new RooRealVar("ParOSBackgroundExpCoefficient",
+                                                             "ParOSBackgroundExpCoefficient",
+                                                             -0.01,
+                                                             -1.0,
+                                                             1.0);  //ParOSBackgroundExpCoefficient.setConstant(kTRUE);
+  RooRealVar* ParSSBackgroundExpCoefficient = new RooRealVar("ParSSBackgroundExpCoefficient",
+                                                             "ParSSBackgroundExpCoefficient",
+                                                             -0.01,
+                                                             -1.0,
+                                                             1.0);  //ParSSBackgroundExpCoefficient.setConstant(kTRUE);
+  RooRealVar* ParOSSignalMassShift = new RooRealVar("ParOSSignalMassShift", "ParOSSignalMassShift", 0.0, -10.0, 10.0);
+  ParOSSignalMassShift->setConstant(kTRUE);
+  RooRealVar* ParSSSignalMassShift = new RooRealVar("ParSSSignalMassShift", "ParSSSignalMassShift", 0.0, -10.0, 10.0);
+  ParSSSignalMassShift->setConstant(kTRUE);
+  RooRealVar* ParOSSignalResolution = new RooRealVar(
+      "ParOSSignalResolution", "ParOSSignalResolution", 1.0, 0.0, 10.0);  //ParOSSignalResolution.setConstant(kTRUE);
+  RooRealVar* ParSSSignalResolution = new RooRealVar(
+      "ParSSSignalResolution", "ParSSSignalResolution", 1.0, 0.0, 10.0);  //ParSSSignalResolution.setConstant(kTRUE);
 
   //*********************************************************************************************
   //
@@ -129,64 +133,67 @@ void performFit(string inputDir,
   //
   //*********************************************************************************************
   //Load histogram templates
-  TFile *Zeelineshape_file =  new TFile("ZMassLineshape_SSOS.root", "READ");
-  TH1* histTemplateOS = (TH1D*) Zeelineshape_file->Get(OSSignalTemplateHistName.c_str());
-  TH1* histTemplateSS = (TH1D*) Zeelineshape_file->Get(SSSignalTemplateHistName.c_str());
+  TFile* Zeelineshape_file = new TFile("ZMassLineshape_SSOS.root", "READ");
+  TH1* histTemplateOS = (TH1D*)Zeelineshape_file->Get(OSSignalTemplateHistName.c_str());
+  TH1* histTemplateSS = (TH1D*)Zeelineshape_file->Get(SSSignalTemplateHistName.c_str());
 
-  //Introduce mass shift coordinate transformation 
-  RooFormulaVar OSShiftedMass("OSShiftedMass","@0-@1",RooArgList(mass,*ParOSSignalMassShift));
-  RooFormulaVar SSShiftedMass("SSShiftedMass","@0-@1",RooArgList(mass,*ParSSSignalMassShift));
+  //Introduce mass shift coordinate transformation
+  RooFormulaVar OSShiftedMass("OSShiftedMass", "@0-@1", RooArgList(mass, *ParOSSignalMassShift));
+  RooFormulaVar SSShiftedMass("SSShiftedMass", "@0-@1", RooArgList(mass, *ParSSSignalMassShift));
 
-  RooDataHist* dataHistOS = new RooDataHist("dataHistOS","dataHistOS", RooArgSet(mass), histTemplateOS);
-  RooDataHist* dataHistSS = new RooDataHist("dataHistSS","dataHistSS", RooArgSet(mass), histTemplateSS);
+  RooDataHist* dataHistOS = new RooDataHist("dataHistOS", "dataHistOS", RooArgSet(mass), histTemplateOS);
+  RooDataHist* dataHistSS = new RooDataHist("dataHistSS", "dataHistSS", RooArgSet(mass), histTemplateSS);
 
-  RooGaussian  *OSSignalResolution    =  new RooGaussian("OSSignalResolution","OSSignalResolution",mass,*ParOSSignalMassShift,*ParOSSignalResolution);
-  RooGaussian  *SSSignalResolution    =  new RooGaussian("SSSignalResolution","SSSignalResolution",mass,*ParSSSignalMassShift,*ParSSSignalResolution);
+  RooGaussian* OSSignalResolution =
+      new RooGaussian("OSSignalResolution", "OSSignalResolution", mass, *ParOSSignalMassShift, *ParOSSignalResolution);
+  RooGaussian* SSSignalResolution =
+      new RooGaussian("SSSignalResolution", "SSSignalResolution", mass, *ParSSSignalMassShift, *ParSSSignalResolution);
 
-  RooHistPdf* OSSignalShapeTemplatePdf = new RooHistPdf("OSSignalShapeTemplatePdf", "OSSignalShapeTemplatePdf", RooArgSet(mass), *dataHistOS, 1);
-  RooHistPdf* SSSignalShapeTemplatePdf = new RooHistPdf("SSSignalShapeTemplatePdf", "SSSignalShapeTemplatePdf", RooArgSet(mass), *dataHistSS, 1);
+  RooHistPdf* OSSignalShapeTemplatePdf =
+      new RooHistPdf("OSSignalShapeTemplatePdf", "OSSignalShapeTemplatePdf", RooArgSet(mass), *dataHistOS, 1);
+  RooHistPdf* SSSignalShapeTemplatePdf =
+      new RooHistPdf("SSSignalShapeTemplatePdf", "SSSignalShapeTemplatePdf", RooArgSet(mass), *dataHistSS, 1);
 
-  RooFFTConvPdf* signalShapeOSPdf = new RooFFTConvPdf("signalShapeOSPdf","signalShapeOSPdf"  , mass, *OSSignalShapeTemplatePdf,*OSSignalResolution,2);
-  RooFFTConvPdf* signalShapeSSPdf = new RooFFTConvPdf("signalShapeSSPdf","signalShapeSSPdf"  , mass, *SSSignalShapeTemplatePdf,*SSSignalResolution,2);
+  RooFFTConvPdf* signalShapeOSPdf = new RooFFTConvPdf(
+      "signalShapeOSPdf", "signalShapeOSPdf", mass, *OSSignalShapeTemplatePdf, *OSSignalResolution, 2);
+  RooFFTConvPdf* signalShapeSSPdf = new RooFFTConvPdf(
+      "signalShapeSSPdf", "signalShapeSSPdf", mass, *SSSignalShapeTemplatePdf, *SSSignalResolution, 2);
 
-
-
-  
   //*********************************************************************************************
   //
   // Create Background PDFs
   //
   //*********************************************************************************************
-  RooExponential* bkgOSPdf = new RooExponential("bkgOSPdf","bkgOSPdf",mass, *ParOSBackgroundExpCoefficient);
-  RooExponential* bkgSSPdf = new RooExponential("bkgSSPdf","bkgSSPdf",mass, *ParSSBackgroundExpCoefficient);
+  RooExponential* bkgOSPdf = new RooExponential("bkgOSPdf", "bkgOSPdf", mass, *ParOSBackgroundExpCoefficient);
+  RooExponential* bkgSSPdf = new RooExponential("bkgSSPdf", "bkgSSPdf", mass, *ParSSBackgroundExpCoefficient);
 
-  
   //*********************************************************************************************
   //
   // Create Total PDFs
   //
   //*********************************************************************************************
-  RooAddPdf pdfOS("pdfOS","pdfOS",RooArgList(*signalShapeOSPdf,*bkgOSPdf), RooArgList(*ParNumSignalOS,*ParNumBkgOS));
-  RooAddPdf pdfSS("pdfSS","pdfSS",RooArgList(*signalShapeSSPdf,*bkgSSPdf), RooArgList(*ParNumSignalSS,*ParNumBkgSS));
+  RooAddPdf pdfOS(
+      "pdfOS", "pdfOS", RooArgList(*signalShapeOSPdf, *bkgOSPdf), RooArgList(*ParNumSignalOS, *ParNumBkgOS));
+  RooAddPdf pdfSS(
+      "pdfSS", "pdfSS", RooArgList(*signalShapeSSPdf, *bkgSSPdf), RooArgList(*ParNumSignalSS, *ParNumBkgSS));
 
- 
   // PDF for simultaneous fit
-  RooSimultaneous pdfTotal("pdfTotal","pdfTotal",sample);
-  pdfTotal.addPdf(pdfOS,    "pdfOS");
-  pdfTotal.addPdf(pdfSS,    "pdfSS");
+  RooSimultaneous pdfTotal("pdfTotal", "pdfTotal", sample);
+  pdfTotal.addPdf(pdfOS, "pdfOS");
+  pdfTotal.addPdf(pdfSS, "pdfSS");
   pdfTotal.Print();
-			     
+
   //
   // Define likelihood, add constraints, and run the fit
   //
-  RooFitResult *fitResult = pdfTotal.fitTo(*dataCombined, RooFit::Save(true), 
-                                           RooFit::Extended(true), RooFit::PrintLevel(-1));
+  RooFitResult* fitResult =
+      pdfTotal.fitTo(*dataCombined, RooFit::Save(true), RooFit::Extended(true), RooFit::PrintLevel(-1));
   fitResult->Print("v");
 
-  double nSignalOS    = ParNumSignalOS->getVal();
-  double nSignalSS    = ParNumSignalSS->getVal();
-  double nBkgOS       = ParNumBkgOS->getVal();
-  double nBkgSS       = ParNumBkgSS->getVal();
+  double nSignalOS = ParNumSignalOS->getVal();
+  double nSignalSS = ParNumSignalSS->getVal();
+  double nBkgOS = ParNumBkgOS->getVal();
+  double nBkgSS = ParNumBkgSS->getVal();
 
   printf("\nFit results:\n");
   cout << "Signal OS: " << nSignalOS << endl;
@@ -194,141 +201,132 @@ void performFit(string inputDir,
   cout << "Signal SS: " << nSignalSS << endl;
   cout << "Bkg SS: " << nBkgSS << endl;
 
-	 
-	   
   //--------------------------------------------------------------------------------------------------------------
-  // Make plots 
-  //==============================================================================================================  
+  // Make plots
+  //==============================================================================================================
   RooAbsData::ErrorType errorType = RooAbsData::Poisson;
 
   TString cname = TString("fit_OS");
-  TCanvas *c = new TCanvas(cname,cname,800,600);
+  TCanvas* c = new TCanvas(cname, cname, 800, 600);
   RooPlot* frame1 = mass.frame();
   frame1->SetMinimum(0);
-  dataOS->plotOn(frame1,RooFit::DataError(errorType));
-  pdfOS.plotOn(frame1,RooFit::ProjWData(*dataOS), 
-  RooFit::Components(*bkgOSPdf),RooFit::LineColor(kRed));
-  pdfOS.plotOn(frame1,RooFit::ProjWData(*dataOS));
+  dataOS->plotOn(frame1, RooFit::DataError(errorType));
+  pdfOS.plotOn(frame1, RooFit::ProjWData(*dataOS), RooFit::Components(*bkgOSPdf), RooFit::LineColor(kRed));
+  pdfOS.plotOn(frame1, RooFit::ProjWData(*dataOS));
   frame1->Draw("e0");
-  
-  TPaveText *plotlabel = new TPaveText(0.23,0.87,0.43,0.92,"NDC");
-   plotlabel->SetTextColor(kBlack);
-   plotlabel->SetFillColor(kWhite);
-   plotlabel->SetBorderSize(0);
-   plotlabel->SetTextAlign(12);
-   plotlabel->SetTextSize(0.03);
-   plotlabel->AddText("CMS Preliminary 2010");
-  TPaveText *plotlabel2 = new TPaveText(0.23,0.82,0.43,0.87,"NDC");
-   plotlabel2->SetTextColor(kBlack);
-   plotlabel2->SetFillColor(kWhite);
-   plotlabel2->SetBorderSize(0);
-   plotlabel2->SetTextAlign(12);
-   plotlabel2->SetTextSize(0.03);
-   plotlabel2->AddText("#sqrt{s} = 7 TeV");
-  TPaveText *plotlabel3 = new TPaveText(0.23,0.75,0.43,0.80,"NDC");
-   plotlabel3->SetTextColor(kBlack);
-   plotlabel3->SetFillColor(kWhite);
-   plotlabel3->SetBorderSize(0);
-   plotlabel3->SetTextAlign(12);
-   plotlabel3->SetTextSize(0.03);
+
+  TPaveText* plotlabel = new TPaveText(0.23, 0.87, 0.43, 0.92, "NDC");
+  plotlabel->SetTextColor(kBlack);
+  plotlabel->SetFillColor(kWhite);
+  plotlabel->SetBorderSize(0);
+  plotlabel->SetTextAlign(12);
+  plotlabel->SetTextSize(0.03);
+  plotlabel->AddText("CMS Preliminary 2010");
+  TPaveText* plotlabel2 = new TPaveText(0.23, 0.82, 0.43, 0.87, "NDC");
+  plotlabel2->SetTextColor(kBlack);
+  plotlabel2->SetFillColor(kWhite);
+  plotlabel2->SetBorderSize(0);
+  plotlabel2->SetTextAlign(12);
+  plotlabel2->SetTextSize(0.03);
+  plotlabel2->AddText("#sqrt{s} = 7 TeV");
+  TPaveText* plotlabel3 = new TPaveText(0.23, 0.75, 0.43, 0.80, "NDC");
+  plotlabel3->SetTextColor(kBlack);
+  plotlabel3->SetFillColor(kWhite);
+  plotlabel3->SetBorderSize(0);
+  plotlabel3->SetTextAlign(12);
+  plotlabel3->SetTextSize(0.03);
   char temp[100];
   sprintf(temp, "%.4f", LUMINOSITY);
-  plotlabel3->AddText((string("#int#font[12]{L}dt = ") + 
-  temp + string(" pb^{ -1}")).c_str());
-  TPaveText *plotlabel4 = new TPaveText(0.6,0.82,0.8,0.87,"NDC");
-   plotlabel4->SetTextColor(kBlack);
-   plotlabel4->SetFillColor(kWhite);
-   plotlabel4->SetBorderSize(0);
-   plotlabel4->SetTextAlign(12);
-   plotlabel4->SetTextSize(0.03);
-   sprintf(temp, "Signal = %.2f #pm %.2f", ParNumSignalOS->getVal(), ParNumSignalOS->getError());
-   plotlabel4->AddText(temp);
-  TPaveText *plotlabel5 = new TPaveText(0.6,0.77,0.8,0.82,"NDC");
-   plotlabel5->SetTextColor(kBlack);
-   plotlabel5->SetFillColor(kWhite);
-   plotlabel5->SetBorderSize(0);
-   plotlabel5->SetTextAlign(12);
-   plotlabel5->SetTextSize(0.03);
-   sprintf(temp, "Bkg = %.2f #pm %.2f", ParNumBkgOS->getVal(), ParNumBkgOS->getError());
-   plotlabel5->AddText(temp);
+  plotlabel3->AddText((string("#int#font[12]{L}dt = ") + temp + string(" pb^{ -1}")).c_str());
+  TPaveText* plotlabel4 = new TPaveText(0.6, 0.82, 0.8, 0.87, "NDC");
+  plotlabel4->SetTextColor(kBlack);
+  plotlabel4->SetFillColor(kWhite);
+  plotlabel4->SetBorderSize(0);
+  plotlabel4->SetTextAlign(12);
+  plotlabel4->SetTextSize(0.03);
+  sprintf(temp, "Signal = %.2f #pm %.2f", ParNumSignalOS->getVal(), ParNumSignalOS->getError());
+  plotlabel4->AddText(temp);
+  TPaveText* plotlabel5 = new TPaveText(0.6, 0.77, 0.8, 0.82, "NDC");
+  plotlabel5->SetTextColor(kBlack);
+  plotlabel5->SetFillColor(kWhite);
+  plotlabel5->SetBorderSize(0);
+  plotlabel5->SetTextAlign(12);
+  plotlabel5->SetTextSize(0.03);
+  sprintf(temp, "Bkg = %.2f #pm %.2f", ParNumBkgOS->getVal(), ParNumBkgOS->getError());
+  plotlabel5->AddText(temp);
   plotlabel4->Draw();
   plotlabel5->Draw();
 
-//   c->SaveAs( cname + TString(".eps"));
-  c->SaveAs( cname + TString(".gif"));
+  //   c->SaveAs( cname + TString(".eps"));
+  c->SaveAs(cname + TString(".gif"));
   delete c;
 
-
   cname = TString("fit_SS");
-  TCanvas* c2 = new TCanvas(cname,cname,500,500);
+  TCanvas* c2 = new TCanvas(cname, cname, 500, 500);
   RooPlot* frame2 = mass.frame();
   frame2->SetMinimum(0);
-  dataSS->plotOn(frame2,RooFit::DataError(errorType));
-  pdfSS.plotOn(frame2,RooFit::ProjWData(*dataSS), 
-  RooFit::Components(*bkgSSPdf),RooFit::LineColor(kRed));
-  pdfSS.plotOn(frame2,RooFit::ProjWData(*dataSS));
+  dataSS->plotOn(frame2, RooFit::DataError(errorType));
+  pdfSS.plotOn(frame2, RooFit::ProjWData(*dataSS), RooFit::Components(*bkgSSPdf), RooFit::LineColor(kRed));
+  pdfSS.plotOn(frame2, RooFit::ProjWData(*dataSS));
   frame2->Draw("e0");
 
-  plotlabel = new TPaveText(0.23,0.87,0.43,0.92,"NDC");
-   plotlabel->SetTextColor(kBlack);
-   plotlabel->SetFillColor(kWhite);
-   plotlabel->SetBorderSize(0);
-   plotlabel->SetTextAlign(12);
-   plotlabel->SetTextSize(0.03);
-   plotlabel->AddText("CMS Preliminary 2010");
- plotlabel2 = new TPaveText(0.23,0.82,0.43,0.87,"NDC");
-   plotlabel2->SetTextColor(kBlack);
-   plotlabel2->SetFillColor(kWhite);
-   plotlabel2->SetBorderSize(0);
-   plotlabel2->SetTextAlign(12);
-   plotlabel2->SetTextSize(0.03);
-   plotlabel2->AddText("#sqrt{s} = 7 TeV");
-  plotlabel3 = new TPaveText(0.23,0.75,0.43,0.80,"NDC");
-   plotlabel3->SetTextColor(kBlack);
-   plotlabel3->SetFillColor(kWhite);
-   plotlabel3->SetBorderSize(0);
-   plotlabel3->SetTextAlign(12);
-   plotlabel3->SetTextSize(0.03);
-   sprintf(temp, "%.4f", LUMINOSITY);
-   plotlabel3->AddText((string("#int#font[12]{L}dt = ") + 
-                        temp + string(" pb^{ -1}")).c_str());
-   plotlabel4 = new TPaveText(0.6,0.82,0.8,0.87,"NDC");
-   plotlabel4->SetTextColor(kBlack);
-   plotlabel4->SetFillColor(kWhite);
-   plotlabel4->SetBorderSize(0);
-   plotlabel4->SetTextAlign(12);
-   plotlabel4->SetTextSize(0.03);
-   sprintf(temp, "Signal = %.2f #pm %.2f", ParNumSignalSS->getVal(), ParNumSignalSS->getError());
-   plotlabel4->AddText(temp);
-   plotlabel5 = new TPaveText(0.6,0.77,0.8,0.82,"NDC");
-   plotlabel5->SetTextColor(kBlack);
-   plotlabel5->SetFillColor(kWhite);
-   plotlabel5->SetBorderSize(0);
-   plotlabel5->SetTextAlign(12);
-   plotlabel5->SetTextSize(0.03);
-   sprintf(temp, "Bkg = %.2f #pm %.2f", ParNumBkgSS->getVal(), ParNumBkgSS->getError());
-   plotlabel5->AddText(temp);
+  plotlabel = new TPaveText(0.23, 0.87, 0.43, 0.92, "NDC");
+  plotlabel->SetTextColor(kBlack);
+  plotlabel->SetFillColor(kWhite);
+  plotlabel->SetBorderSize(0);
+  plotlabel->SetTextAlign(12);
+  plotlabel->SetTextSize(0.03);
+  plotlabel->AddText("CMS Preliminary 2010");
+  plotlabel2 = new TPaveText(0.23, 0.82, 0.43, 0.87, "NDC");
+  plotlabel2->SetTextColor(kBlack);
+  plotlabel2->SetFillColor(kWhite);
+  plotlabel2->SetBorderSize(0);
+  plotlabel2->SetTextAlign(12);
+  plotlabel2->SetTextSize(0.03);
+  plotlabel2->AddText("#sqrt{s} = 7 TeV");
+  plotlabel3 = new TPaveText(0.23, 0.75, 0.43, 0.80, "NDC");
+  plotlabel3->SetTextColor(kBlack);
+  plotlabel3->SetFillColor(kWhite);
+  plotlabel3->SetBorderSize(0);
+  plotlabel3->SetTextAlign(12);
+  plotlabel3->SetTextSize(0.03);
+  sprintf(temp, "%.4f", LUMINOSITY);
+  plotlabel3->AddText((string("#int#font[12]{L}dt = ") + temp + string(" pb^{ -1}")).c_str());
+  plotlabel4 = new TPaveText(0.6, 0.82, 0.8, 0.87, "NDC");
+  plotlabel4->SetTextColor(kBlack);
+  plotlabel4->SetFillColor(kWhite);
+  plotlabel4->SetBorderSize(0);
+  plotlabel4->SetTextAlign(12);
+  plotlabel4->SetTextSize(0.03);
+  sprintf(temp, "Signal = %.2f #pm %.2f", ParNumSignalSS->getVal(), ParNumSignalSS->getError());
+  plotlabel4->AddText(temp);
+  plotlabel5 = new TPaveText(0.6, 0.77, 0.8, 0.82, "NDC");
+  plotlabel5->SetTextColor(kBlack);
+  plotlabel5->SetFillColor(kWhite);
+  plotlabel5->SetBorderSize(0);
+  plotlabel5->SetTextAlign(12);
+  plotlabel5->SetTextSize(0.03);
+  sprintf(temp, "Bkg = %.2f #pm %.2f", ParNumBkgSS->getVal(), ParNumBkgSS->getError());
+  plotlabel5->AddText(temp);
 
-
-//   plotlabel->Draw();
-//   plotlabel2->Draw();
-//   plotlabel3->Draw();
+  //   plotlabel->Draw();
+  //   plotlabel2->Draw();
+  //   plotlabel3->Draw();
   plotlabel4->Draw();
   plotlabel5->Draw();
 
-  c2->SaveAs( cname + TString(".eps"));
-  c2->SaveAs( cname + TString(".gif"));
-  c2->SaveAs( cname + TString(".root"));
+  c2->SaveAs(cname + TString(".eps"));
+  c2->SaveAs(cname + TString(".gif"));
+  c2->SaveAs(cname + TString(".root"));
   delete c2;
-
 
   gBenchmark->Show("fitZCat");
 }
 
-
 void ZeeBkgFit() {
-
-      performFit("MitFitter/inputs/BkgFit/", "M_VBTF95PlusVBTF95_OS", "M_VBTF95PlusVBTF95_SS", "Mass_WP95WP95_OppositeSign", "Mass_WP95WP95_SameSign" );
-
-
+  performFit("MitFitter/inputs/BkgFit/",
+             "M_VBTF95PlusVBTF95_OS",
+             "M_VBTF95PlusVBTF95_SS",
+             "Mass_WP95WP95_OppositeSign",
+             "Mass_WP95WP95_SameSign");
 }

--- a/PhysicsTools/TagAndProbe/test/utilities/fitZCat.C
+++ b/PhysicsTools/TagAndProbe/test/utilities/fitZCat.C
@@ -4,13 +4,12 @@
 //________________________________________________________________________________________________
 
 #if !defined(__CINT__) || defined(__MAKECINT__)
-#include <TROOT.h>                  // access to gROOT, entry point to ROOT system
-#include <TSystem.h>                // interface to OS
-#include <TStyle.h>                 // class to handle ROOT plotting style
-#include <TCanvas.h>                // class for drawing
-#include <TBenchmark.h>             // class to track macro running statistics
-#include <iostream>                 // standard I/O
-
+#include <TROOT.h>       // access to gROOT, entry point to ROOT system
+#include <TSystem.h>     // interface to OS
+#include <TStyle.h>      // class to handle ROOT plotting style
+#include <TCanvas.h>     // class for drawing
+#include <TBenchmark.h>  // class to track macro running statistics
+#include <iostream>      // standard I/O
 
 // RooFit headers
 #include "RooRealVar.h"
@@ -26,101 +25,111 @@
 #include "RooGaussian.h"
 #include "RooNLLVar.h"
 #include "RooConstVar.h"
-#include "RooMinuit.h"
+#include "RooFitLegacy/RooMinuit.h"
 #include "RooFitResult.h"
 #include "RooExponential.h"
-
 
 #include "TFile.h"
 #include "TH1D.h"
 #include "TPaveText.h"
 #include "RooPlot.h"
 
-
 #endif
 
-#define LUMINOSITY 2.88 //(in pb^-1)
+#define LUMINOSITY 2.88  //(in pb^-1)
 #define NBINSPASS 24
 #define NBINSFAIL 24
 
-
 using namespace RooFit;
 
-double ErrorInProduct(double x, double errx, double y, 
-                      double erry, double corr) {
-   double xFrErr = errx/x;
-   double yFrErr = erry/y;
-   return sqrt(pow(xFrErr,2) + pow(yFrErr,2) + 2.0*corr*xFrErr*yFrErr)*x*y;
+double ErrorInProduct(double x, double errx, double y, double erry, double corr) {
+  double xFrErr = errx / x;
+  double yFrErr = erry / y;
+  return sqrt(pow(xFrErr, 2) + pow(yFrErr, 2) + 2.0 * corr * xFrErr * yFrErr) * x * y;
 }
-
-
 
 //=== MAIN MACRO =================================================================================================
 
 void performFit(string inputDir,
-                string PassInputDataFilename, string FailInputDataFilename, 
-                string PassSignalTemplateHistName, string FailSignalTemplateHistName ) {
+                string PassInputDataFilename,
+                string FailInputDataFilename,
+                string PassSignalTemplateHistName,
+                string FailSignalTemplateHistName) {
   gBenchmark->Start("fitZCat");
 
   //--------------------------------------------------------------------------------------------------------------
-  // Settings 
+  // Settings
   //==============================================================================================================
-  
-  const Double_t mlow  = 60;
+
+  const Double_t mlow = 60;
   const Double_t mhigh = 120;
-  const Int_t    nbins = 20;
-  
+  const Int_t nbins = 20;
+
   // Which fit parameters to set constant
   // MuTrk
-  Bool_t cBgA1MuTrk    = kFALSE;
-  Bool_t cBgA2MuTrk    = kTRUE;
+  Bool_t cBgA1MuTrk = kFALSE;
+  Bool_t cBgA2MuTrk = kTRUE;
   Bool_t cBgAlphaMuTrk = kFALSE;
   // MuMuNoIso
-  Bool_t cBgA1MuMuNoIso    = kFALSE;
+  Bool_t cBgA1MuMuNoIso = kFALSE;
   Bool_t cBgAlphaMuMuNoIso = kFALSE;
   // MuSta
-  Bool_t cBgA1MuSta    = kFALSE;
+  Bool_t cBgA1MuSta = kFALSE;
   Bool_t cBgAlphaMuSta = kFALSE;
-  
+
   //--------------------------------------------------------------------------------------------------------------
-  // Main analysis code 
+  // Main analysis code
   //==============================================================================================================
-  RooRealVar mass("mass","mass",mlow,mhigh);
+  RooRealVar mass("mass", "mass", mlow, mhigh);
   mass.setBins(nbins);
-  
+
   //
   // Prepare data for the fits
   //
   //Define categories
-  RooCategory sample("sample","") ;
-  sample.defineType("Pass", 1) ;
-  sample.defineType("Fail", 2) ; 
+  RooCategory sample("sample", "");
+  sample.defineType("Pass", 1);
+  sample.defineType("Fail", 2);
 
   char datname[100];
-  RooDataSet *dataPass  = RooDataSet::read((inputDir+PassInputDataFilename).c_str(),RooArgList(mass));
-  RooDataSet *dataFail  = RooDataSet::read((inputDir+FailInputDataFilename).c_str(),RooArgList(mass));
+  RooDataSet* dataPass = RooDataSet::read((inputDir + PassInputDataFilename).c_str(), RooArgList(mass));
+  RooDataSet* dataFail = RooDataSet::read((inputDir + FailInputDataFilename).c_str(), RooArgList(mass));
 
-  RooDataSet *dataCombined = new RooDataSet("dataCombined","dataCombined",RooArgList(mass), Index(sample), 
-                                            Import("Pass",*dataPass),
-                                            Import("Fail",*dataFail));
-
+  RooDataSet* dataCombined = new RooDataSet("dataCombined",
+                                            "dataCombined",
+                                            RooArgList(mass),
+                                            Index(sample),
+                                            Import("Pass", *dataPass),
+                                            Import("Fail", *dataFail));
 
   //*********************************************************************************************
   //Define Free Parameters
   //*********************************************************************************************
-  RooRealVar* ParEfficiency = new RooRealVar("ParEfficiency","ParEfficiency",0.9, 0.0, 1.0);   
-  RooRealVar* ParNumSignal = new RooRealVar  ("ParNumSignal","ParNumSignal", 4000.0, 0.0, 100000.0);   
-  RooRealVar* ParNumBkgPass = new RooRealVar  ("ParNumBkgPass","ParNumBkgPass", 1000.0, 0.0, 10000000.0);   
-  RooRealVar* ParNumBkgFail = new RooRealVar  ("ParNumBkgFail","ParNumBkgFail", 1000.0, 0.0, 10000000.0);   
+  RooRealVar* ParEfficiency = new RooRealVar("ParEfficiency", "ParEfficiency", 0.9, 0.0, 1.0);
+  RooRealVar* ParNumSignal = new RooRealVar("ParNumSignal", "ParNumSignal", 4000.0, 0.0, 100000.0);
+  RooRealVar* ParNumBkgPass = new RooRealVar("ParNumBkgPass", "ParNumBkgPass", 1000.0, 0.0, 10000000.0);
+  RooRealVar* ParNumBkgFail = new RooRealVar("ParNumBkgFail", "ParNumBkgFail", 1000.0, 0.0, 10000000.0);
 
-  RooRealVar* ParPassBackgroundExpCoefficient = new RooRealVar ("ParPassBackgroundExpCoefficient","ParPassBackgroundExpCoefficient",-0.2,-1.0, 0.0);   //ParPassBackgroundExpCoefficient.setConstant(kTRUE);  
-  RooRealVar* ParFailBackgroundExpCoefficient = new RooRealVar ("ParFailBackgroundExpCoefficient","ParFailBackgroundExpCoefficient",-0.2,-1.0, 0.0);   //ParFailBackgroundExpCoefficient.setConstant(kTRUE);  
-  RooRealVar* ParPassSignalMassShift = new RooRealVar  ("ParPassSignalMassShift","ParPassSignalMassShift",-10.0, 10.0);   //ParPassSignalMassShift.setConstant(kTRUE);  
-  RooRealVar* ParFailSignalMassShift = new RooRealVar  ("ParFailSignalMassShift","ParFailSignalMassShift",-10.0, 10.0);   //ParFailSignalMassShift.setConstant(kTRUE);  
-  RooRealVar* ParPassSignalResolution = new RooRealVar ("ParPassSignalResolution","ParPassSignalResolution",0.0, 10.0);   //ParPassSignalResolution.setConstant(kTRUE);  
-  RooRealVar* ParFailSignalResolution = new RooRealVar ("ParFailSignalResolution","ParFailSignalResolution",0.0, 10.0);   //ParFailSignalResolution.setConstant(kTRUE);  
-
-
+  RooRealVar* ParPassBackgroundExpCoefficient =
+      new RooRealVar("ParPassBackgroundExpCoefficient",
+                     "ParPassBackgroundExpCoefficient",
+                     -0.2,
+                     -1.0,
+                     0.0);  //ParPassBackgroundExpCoefficient.setConstant(kTRUE);
+  RooRealVar* ParFailBackgroundExpCoefficient =
+      new RooRealVar("ParFailBackgroundExpCoefficient",
+                     "ParFailBackgroundExpCoefficient",
+                     -0.2,
+                     -1.0,
+                     0.0);  //ParFailBackgroundExpCoefficient.setConstant(kTRUE);
+  RooRealVar* ParPassSignalMassShift = new RooRealVar(
+      "ParPassSignalMassShift", "ParPassSignalMassShift", -10.0, 10.0);  //ParPassSignalMassShift.setConstant(kTRUE);
+  RooRealVar* ParFailSignalMassShift = new RooRealVar(
+      "ParFailSignalMassShift", "ParFailSignalMassShift", -10.0, 10.0);  //ParFailSignalMassShift.setConstant(kTRUE);
+  RooRealVar* ParPassSignalResolution = new RooRealVar(
+      "ParPassSignalResolution", "ParPassSignalResolution", 0.0, 10.0);  //ParPassSignalResolution.setConstant(kTRUE);
+  RooRealVar* ParFailSignalResolution = new RooRealVar(
+      "ParFailSignalResolution", "ParFailSignalResolution", 0.0, 10.0);  //ParFailSignalResolution.setConstant(kTRUE);
 
   //*********************************************************************************************
   //
@@ -128,239 +137,232 @@ void performFit(string inputDir,
   //
   //*********************************************************************************************
   //Load histogram templates
-  TFile *Zeelineshape_file =  new TFile("MitFitter/templates/60To120Range/ZMassLineshape.root", "READ");
-  TH1* histTemplatePass = (TH1D*) Zeelineshape_file->Get(PassSignalTemplateHistName.c_str());
-  TH1* histTemplateFail = (TH1D*) Zeelineshape_file->Get(FailSignalTemplateHistName.c_str());
+  TFile* Zeelineshape_file = new TFile("MitFitter/templates/60To120Range/ZMassLineshape.root", "READ");
+  TH1* histTemplatePass = (TH1D*)Zeelineshape_file->Get(PassSignalTemplateHistName.c_str());
+  TH1* histTemplateFail = (TH1D*)Zeelineshape_file->Get(FailSignalTemplateHistName.c_str());
 
-  //Introduce mass shift coordinate transformation 
-  RooFormulaVar PassShiftedMass("PassShiftedMass","@0-@1",RooArgList(mass,*ParPassSignalMassShift));
-  RooFormulaVar FailShiftedMass("FailShiftedMass","@0-@1",RooArgList(mass,*ParFailSignalMassShift));
+  //Introduce mass shift coordinate transformation
+  RooFormulaVar PassShiftedMass("PassShiftedMass", "@0-@1", RooArgList(mass, *ParPassSignalMassShift));
+  RooFormulaVar FailShiftedMass("FailShiftedMass", "@0-@1", RooArgList(mass, *ParFailSignalMassShift));
 
-  RooDataHist* dataHistPass = new RooDataHist("dataHistPass","dataHistPass", RooArgSet(mass), histTemplatePass);
-  RooDataHist* dataHistFail = new RooDataHist("dataHistFail","dataHistFail", RooArgSet(mass), histTemplateFail);
+  RooDataHist* dataHistPass = new RooDataHist("dataHistPass", "dataHistPass", RooArgSet(mass), histTemplatePass);
+  RooDataHist* dataHistFail = new RooDataHist("dataHistFail", "dataHistFail", RooArgSet(mass), histTemplateFail);
   RooHistPdf* signalShapePassPdf = new RooHistPdf("signalShapePassPdf", "signalShapePassPdf", mass, *dataHistPass, 1);
   RooHistPdf* signalShapeFailPdf = new RooHistPdf("signalShapeFailPdf", "signalShapeFailPdf", mass, *dataHistFail, 1);
 
-  RooFormulaVar* NumSignalPass = new RooFormulaVar("NumSignalPass", "ParEfficiency*ParNumSignal", RooArgList(*ParEfficiency,*ParNumSignal));
-  RooFormulaVar* NumSignalFail = new RooFormulaVar("NumSignalFail", "(1.0-ParEfficiency)*ParNumSignal", RooArgList(*ParEfficiency,*ParNumSignal));
+  RooFormulaVar* NumSignalPass =
+      new RooFormulaVar("NumSignalPass", "ParEfficiency*ParNumSignal", RooArgList(*ParEfficiency, *ParNumSignal));
+  RooFormulaVar* NumSignalFail =
+      new RooFormulaVar("NumSignalFail", "(1.0-ParEfficiency)*ParNumSignal", RooArgList(*ParEfficiency, *ParNumSignal));
 
-  
   //*********************************************************************************************
   //
   // Create Background PDFs
   //
   //*********************************************************************************************
-  RooExponential* bkgPassPdf = new RooExponential("bkgPassPdf","bkgPassPdf",mass, *ParPassBackgroundExpCoefficient);
-  RooExponential* bkgFailPdf = new RooExponential("bkgFailPdf","bkgFailPdf",mass, *ParFailBackgroundExpCoefficient);
+  RooExponential* bkgPassPdf = new RooExponential("bkgPassPdf", "bkgPassPdf", mass, *ParPassBackgroundExpCoefficient);
+  RooExponential* bkgFailPdf = new RooExponential("bkgFailPdf", "bkgFailPdf", mass, *ParFailBackgroundExpCoefficient);
 
-  
   //*********************************************************************************************
   //
   // Create Total PDFs
   //
   //*********************************************************************************************
-  RooAddPdf pdfPass("pdfPass","pdfPass",RooArgList(*signalShapePassPdf,*bkgPassPdf), RooArgList(*NumSignalPass,*ParNumBkgPass));
-  RooAddPdf pdfFail("pdfFail","pdfFail",RooArgList(*signalShapeFailPdf,*bkgFailPdf), RooArgList(*NumSignalFail,*ParNumBkgFail));
+  RooAddPdf pdfPass(
+      "pdfPass", "pdfPass", RooArgList(*signalShapePassPdf, *bkgPassPdf), RooArgList(*NumSignalPass, *ParNumBkgPass));
+  RooAddPdf pdfFail(
+      "pdfFail", "pdfFail", RooArgList(*signalShapeFailPdf, *bkgFailPdf), RooArgList(*NumSignalFail, *ParNumBkgFail));
 
- 
   // PDF for simultaneous fit
-  RooSimultaneous pdfTotal("pdfTotal","pdfTotal",sample);
-  pdfTotal.addPdf(pdfPass,    "pdfPass");
-  pdfTotal.addPdf(pdfFail,    "pdfFail");
+  RooSimultaneous pdfTotal("pdfTotal", "pdfTotal", sample);
+  pdfTotal.addPdf(pdfPass, "pdfPass");
+  pdfTotal.addPdf(pdfFail, "pdfFail");
   pdfTotal.Print();
-			     
+
   //
   // Define likelihood, add constraints, and run the fit
   //
-  RooFitResult *fitResult = pdfTotal.fitTo(*dataCombined, RooFit::Save(true), 
-                                           RooFit::Extended(true), RooFit::PrintLevel(-1));
+  RooFitResult* fitResult =
+      pdfTotal.fitTo(*dataCombined, RooFit::Save(true), RooFit::Extended(true), RooFit::PrintLevel(-1));
   fitResult->Print("v");
 
   double nSignalPass = NumSignalPass->getVal();
-  double nSignalFail    = NumSignalFail->getVal();
+  double nSignalFail = NumSignalFail->getVal();
 
   printf("\nFit results:\n");
-  printf("    Efficiency = %.4f +- %.4f\n", 
-	 ParEfficiency->getVal(), ParEfficiency->getPropagatedError(*fitResult));  
+  printf("    Efficiency = %.4f +- %.4f\n", ParEfficiency->getVal(), ParEfficiency->getPropagatedError(*fitResult));
   cout << "Signal Pass: " << nSignalPass << endl;
   cout << "Signal Fail: " << nSignalFail << endl;
 
-	 
-	   
   //--------------------------------------------------------------------------------------------------------------
-  // Make plots 
-  //==============================================================================================================  
+  // Make plots
+  //==============================================================================================================
   RooAbsData::ErrorType errorType = RooAbsData::Poisson;
 
   TString cname = TString("fit_Pass");
-  TCanvas *c = new TCanvas(cname,cname,800,600);
+  TCanvas* c = new TCanvas(cname, cname, 800, 600);
   RooPlot* frame1 = mass.frame();
   frame1->SetMinimum(0);
-  dataPass->plotOn(frame1,RooFit::DataError(errorType));
-  pdfPass.plotOn(frame1,RooFit::ProjWData(*dataPass), 
-  RooFit::Components(*bkgPassPdf),RooFit::LineColor(kRed));
-  pdfPass.plotOn(frame1,RooFit::ProjWData(*dataPass));
+  dataPass->plotOn(frame1, RooFit::DataError(errorType));
+  pdfPass.plotOn(frame1, RooFit::ProjWData(*dataPass), RooFit::Components(*bkgPassPdf), RooFit::LineColor(kRed));
+  pdfPass.plotOn(frame1, RooFit::ProjWData(*dataPass));
   frame1->Draw("e0");
-  
-  TPaveText *plotlabel = new TPaveText(0.23,0.87,0.43,0.92,"NDC");
-   plotlabel->SetTextColor(kBlack);
-   plotlabel->SetFillColor(kWhite);
-   plotlabel->SetBorderSize(0);
-   plotlabel->SetTextAlign(12);
-   plotlabel->SetTextSize(0.03);
-   plotlabel->AddText("CMS Preliminary 2010");
-  TPaveText *plotlabel2 = new TPaveText(0.23,0.82,0.43,0.87,"NDC");
-   plotlabel2->SetTextColor(kBlack);
-   plotlabel2->SetFillColor(kWhite);
-   plotlabel2->SetBorderSize(0);
-   plotlabel2->SetTextAlign(12);
-   plotlabel2->SetTextSize(0.03);
-   plotlabel2->AddText("#sqrt{s} = 7 TeV");
-  TPaveText *plotlabel3 = new TPaveText(0.23,0.75,0.43,0.80,"NDC");
-   plotlabel3->SetTextColor(kBlack);
-   plotlabel3->SetFillColor(kWhite);
-   plotlabel3->SetBorderSize(0);
-   plotlabel3->SetTextAlign(12);
-   plotlabel3->SetTextSize(0.03);
+
+  TPaveText* plotlabel = new TPaveText(0.23, 0.87, 0.43, 0.92, "NDC");
+  plotlabel->SetTextColor(kBlack);
+  plotlabel->SetFillColor(kWhite);
+  plotlabel->SetBorderSize(0);
+  plotlabel->SetTextAlign(12);
+  plotlabel->SetTextSize(0.03);
+  plotlabel->AddText("CMS Preliminary 2010");
+  TPaveText* plotlabel2 = new TPaveText(0.23, 0.82, 0.43, 0.87, "NDC");
+  plotlabel2->SetTextColor(kBlack);
+  plotlabel2->SetFillColor(kWhite);
+  plotlabel2->SetBorderSize(0);
+  plotlabel2->SetTextAlign(12);
+  plotlabel2->SetTextSize(0.03);
+  plotlabel2->AddText("#sqrt{s} = 7 TeV");
+  TPaveText* plotlabel3 = new TPaveText(0.23, 0.75, 0.43, 0.80, "NDC");
+  plotlabel3->SetTextColor(kBlack);
+  plotlabel3->SetFillColor(kWhite);
+  plotlabel3->SetBorderSize(0);
+  plotlabel3->SetTextAlign(12);
+  plotlabel3->SetTextSize(0.03);
   char temp[100];
   sprintf(temp, "%.4f", LUMINOSITY);
-  plotlabel3->AddText((string("#int#font[12]{L}dt = ") + 
-  temp + string(" pb^{ -1}")).c_str());
-  TPaveText *plotlabel4 = new TPaveText(0.6,0.82,0.8,0.87,"NDC");
-   plotlabel4->SetTextColor(kBlack);
-   plotlabel4->SetFillColor(kWhite);
-   plotlabel4->SetBorderSize(0);
-   plotlabel4->SetTextAlign(12);
-   plotlabel4->SetTextSize(0.03);
-   double nsig = ParNumSignal->getVal();
-   double nErr = ParNumSignal->getError();
-   double e = ParEfficiency->getVal();
-   double eErr = ParEfficiency->getError();
-   double corr = fitResult->correlation(*ParEfficiency, *ParNumSignal);
-   double err = ErrorInProduct(nsig, nErr, e, eErr, corr);
-   sprintf(temp, "Signal = %.2f #pm %.2f", NumSignalPass->getVal(), err);
-   plotlabel4->AddText(temp);
-  TPaveText *plotlabel5 = new TPaveText(0.6,0.77,0.8,0.82,"NDC");
-   plotlabel5->SetTextColor(kBlack);
-   plotlabel5->SetFillColor(kWhite);
-   plotlabel5->SetBorderSize(0);
-   plotlabel5->SetTextAlign(12);
-   plotlabel5->SetTextSize(0.03);
-   sprintf(temp, "Bkg = %.2f #pm %.2f", ParNumBkgPass->getVal(), ParNumBkgPass->getError());
-   plotlabel5->AddText(temp);
-  TPaveText *plotlabel6 = new TPaveText(0.6,0.87,0.8,0.92,"NDC");
-   plotlabel6->SetTextColor(kBlack);
-   plotlabel6->SetFillColor(kWhite);
-   plotlabel6->SetBorderSize(0);
-   plotlabel6->SetTextAlign(12);
-   plotlabel6->SetTextSize(0.03);
-   plotlabel6->AddText("Passing probes");
-  TPaveText *plotlabel7 = new TPaveText(0.6,0.72,0.8,0.77,"NDC");
-   plotlabel7->SetTextColor(kBlack);
-   plotlabel7->SetFillColor(kWhite);
-   plotlabel7->SetBorderSize(0);
-   plotlabel7->SetTextAlign(12);
-   plotlabel7->SetTextSize(0.03); 
-   sprintf(temp, "Eff = %.3f #pm %.3f", ParEfficiency->getVal(), ParEfficiency->getErrorHi());
-   plotlabel7->AddText(temp);
+  plotlabel3->AddText((string("#int#font[12]{L}dt = ") + temp + string(" pb^{ -1}")).c_str());
+  TPaveText* plotlabel4 = new TPaveText(0.6, 0.82, 0.8, 0.87, "NDC");
+  plotlabel4->SetTextColor(kBlack);
+  plotlabel4->SetFillColor(kWhite);
+  plotlabel4->SetBorderSize(0);
+  plotlabel4->SetTextAlign(12);
+  plotlabel4->SetTextSize(0.03);
+  double nsig = ParNumSignal->getVal();
+  double nErr = ParNumSignal->getError();
+  double e = ParEfficiency->getVal();
+  double eErr = ParEfficiency->getError();
+  double corr = fitResult->correlation(*ParEfficiency, *ParNumSignal);
+  double err = ErrorInProduct(nsig, nErr, e, eErr, corr);
+  sprintf(temp, "Signal = %.2f #pm %.2f", NumSignalPass->getVal(), err);
+  plotlabel4->AddText(temp);
+  TPaveText* plotlabel5 = new TPaveText(0.6, 0.77, 0.8, 0.82, "NDC");
+  plotlabel5->SetTextColor(kBlack);
+  plotlabel5->SetFillColor(kWhite);
+  plotlabel5->SetBorderSize(0);
+  plotlabel5->SetTextAlign(12);
+  plotlabel5->SetTextSize(0.03);
+  sprintf(temp, "Bkg = %.2f #pm %.2f", ParNumBkgPass->getVal(), ParNumBkgPass->getError());
+  plotlabel5->AddText(temp);
+  TPaveText* plotlabel6 = new TPaveText(0.6, 0.87, 0.8, 0.92, "NDC");
+  plotlabel6->SetTextColor(kBlack);
+  plotlabel6->SetFillColor(kWhite);
+  plotlabel6->SetBorderSize(0);
+  plotlabel6->SetTextAlign(12);
+  plotlabel6->SetTextSize(0.03);
+  plotlabel6->AddText("Passing probes");
+  TPaveText* plotlabel7 = new TPaveText(0.6, 0.72, 0.8, 0.77, "NDC");
+  plotlabel7->SetTextColor(kBlack);
+  plotlabel7->SetFillColor(kWhite);
+  plotlabel7->SetBorderSize(0);
+  plotlabel7->SetTextAlign(12);
+  plotlabel7->SetTextSize(0.03);
+  sprintf(temp, "Eff = %.3f #pm %.3f", ParEfficiency->getVal(), ParEfficiency->getErrorHi());
+  plotlabel7->AddText(temp);
 
   plotlabel4->Draw();
   plotlabel5->Draw();
   plotlabel6->Draw();
   plotlabel7->Draw();
 
-//   c->SaveAs( cname + TString(".eps"));
-  c->SaveAs( cname + TString(".gif"));
+  //   c->SaveAs( cname + TString(".eps"));
+  c->SaveAs(cname + TString(".gif"));
   delete c;
 
-
   cname = TString("fit_Fail");
-  TCanvas* c2 = new TCanvas(cname,cname,500,500);
+  TCanvas* c2 = new TCanvas(cname, cname, 500, 500);
   RooPlot* frame2 = mass.frame();
   frame2->SetMinimum(0);
-  dataFail->plotOn(frame2,RooFit::DataError(errorType));
-  pdfFail.plotOn(frame2,RooFit::ProjWData(*dataFail), 
-  RooFit::Components(*bkgFailPdf),RooFit::LineColor(kRed));
-  pdfFail.plotOn(frame2,RooFit::ProjWData(*dataFail));
+  dataFail->plotOn(frame2, RooFit::DataError(errorType));
+  pdfFail.plotOn(frame2, RooFit::ProjWData(*dataFail), RooFit::Components(*bkgFailPdf), RooFit::LineColor(kRed));
+  pdfFail.plotOn(frame2, RooFit::ProjWData(*dataFail));
   frame2->Draw("e0");
 
-  plotlabel = new TPaveText(0.23,0.87,0.43,0.92,"NDC");
-   plotlabel->SetTextColor(kBlack);
-   plotlabel->SetFillColor(kWhite);
-   plotlabel->SetBorderSize(0);
-   plotlabel->SetTextAlign(12);
-   plotlabel->SetTextSize(0.03);
-   plotlabel->AddText("CMS Preliminary 2010");
- plotlabel2 = new TPaveText(0.23,0.82,0.43,0.87,"NDC");
-   plotlabel2->SetTextColor(kBlack);
-   plotlabel2->SetFillColor(kWhite);
-   plotlabel2->SetBorderSize(0);
-   plotlabel2->SetTextAlign(12);
-   plotlabel2->SetTextSize(0.03);
-   plotlabel2->AddText("#sqrt{s} = 7 TeV");
-  plotlabel3 = new TPaveText(0.23,0.75,0.43,0.80,"NDC");
-   plotlabel3->SetTextColor(kBlack);
-   plotlabel3->SetFillColor(kWhite);
-   plotlabel3->SetBorderSize(0);
-   plotlabel3->SetTextAlign(12);
-   plotlabel3->SetTextSize(0.03);
-   sprintf(temp, "%.4f", LUMINOSITY);
-   plotlabel3->AddText((string("#int#font[12]{L}dt = ") + 
-                        temp + string(" pb^{ -1}")).c_str());
-   plotlabel4 = new TPaveText(0.6,0.82,0.8,0.87,"NDC");
-   plotlabel4->SetTextColor(kBlack);
-   plotlabel4->SetFillColor(kWhite);
-   plotlabel4->SetBorderSize(0);
-   plotlabel4->SetTextAlign(12);
-   plotlabel4->SetTextSize(0.03);
-   err = ErrorInProduct(nsig, nErr, 1.0-e, eErr, corr);
-   sprintf(temp, "Signal = %.2f #pm %.2f", NumSignalFail->getVal(), err);
-   plotlabel4->AddText(temp);
-   plotlabel5 = new TPaveText(0.6,0.77,0.8,0.82,"NDC");
-   plotlabel5->SetTextColor(kBlack);
-   plotlabel5->SetFillColor(kWhite);
-   plotlabel5->SetBorderSize(0);
-   plotlabel5->SetTextAlign(12);
-   plotlabel5->SetTextSize(0.03);
-   sprintf(temp, "Bkg = %.2f #pm %.2f", ParNumBkgFail->getVal(), ParNumBkgFail->getError());
-   plotlabel5->AddText(temp);
-   plotlabel6 = new TPaveText(0.6,0.87,0.8,0.92,"NDC");
-   plotlabel6->SetTextColor(kBlack);
-   plotlabel6->SetFillColor(kWhite);
-   plotlabel6->SetBorderSize(0);
-   plotlabel6->SetTextAlign(12);
-   plotlabel6->SetTextSize(0.03);
-   plotlabel6->AddText("Failing probes");
-   plotlabel7 = new TPaveText(0.6,0.72,0.8,0.77,"NDC");
-   plotlabel7->SetTextColor(kBlack);
-   plotlabel7->SetFillColor(kWhite);
-   plotlabel7->SetBorderSize(0);
-   plotlabel7->SetTextAlign(12);
-   plotlabel7->SetTextSize(0.03);
-   sprintf(temp, "Eff = %.3f #pm %.3f", ParEfficiency->getVal(), ParEfficiency->getErrorHi(), ParEfficiency->getErrorLo());
-   plotlabel7->AddText(temp);
+  plotlabel = new TPaveText(0.23, 0.87, 0.43, 0.92, "NDC");
+  plotlabel->SetTextColor(kBlack);
+  plotlabel->SetFillColor(kWhite);
+  plotlabel->SetBorderSize(0);
+  plotlabel->SetTextAlign(12);
+  plotlabel->SetTextSize(0.03);
+  plotlabel->AddText("CMS Preliminary 2010");
+  plotlabel2 = new TPaveText(0.23, 0.82, 0.43, 0.87, "NDC");
+  plotlabel2->SetTextColor(kBlack);
+  plotlabel2->SetFillColor(kWhite);
+  plotlabel2->SetBorderSize(0);
+  plotlabel2->SetTextAlign(12);
+  plotlabel2->SetTextSize(0.03);
+  plotlabel2->AddText("#sqrt{s} = 7 TeV");
+  plotlabel3 = new TPaveText(0.23, 0.75, 0.43, 0.80, "NDC");
+  plotlabel3->SetTextColor(kBlack);
+  plotlabel3->SetFillColor(kWhite);
+  plotlabel3->SetBorderSize(0);
+  plotlabel3->SetTextAlign(12);
+  plotlabel3->SetTextSize(0.03);
+  sprintf(temp, "%.4f", LUMINOSITY);
+  plotlabel3->AddText((string("#int#font[12]{L}dt = ") + temp + string(" pb^{ -1}")).c_str());
+  plotlabel4 = new TPaveText(0.6, 0.82, 0.8, 0.87, "NDC");
+  plotlabel4->SetTextColor(kBlack);
+  plotlabel4->SetFillColor(kWhite);
+  plotlabel4->SetBorderSize(0);
+  plotlabel4->SetTextAlign(12);
+  plotlabel4->SetTextSize(0.03);
+  err = ErrorInProduct(nsig, nErr, 1.0 - e, eErr, corr);
+  sprintf(temp, "Signal = %.2f #pm %.2f", NumSignalFail->getVal(), err);
+  plotlabel4->AddText(temp);
+  plotlabel5 = new TPaveText(0.6, 0.77, 0.8, 0.82, "NDC");
+  plotlabel5->SetTextColor(kBlack);
+  plotlabel5->SetFillColor(kWhite);
+  plotlabel5->SetBorderSize(0);
+  plotlabel5->SetTextAlign(12);
+  plotlabel5->SetTextSize(0.03);
+  sprintf(temp, "Bkg = %.2f #pm %.2f", ParNumBkgFail->getVal(), ParNumBkgFail->getError());
+  plotlabel5->AddText(temp);
+  plotlabel6 = new TPaveText(0.6, 0.87, 0.8, 0.92, "NDC");
+  plotlabel6->SetTextColor(kBlack);
+  plotlabel6->SetFillColor(kWhite);
+  plotlabel6->SetBorderSize(0);
+  plotlabel6->SetTextAlign(12);
+  plotlabel6->SetTextSize(0.03);
+  plotlabel6->AddText("Failing probes");
+  plotlabel7 = new TPaveText(0.6, 0.72, 0.8, 0.77, "NDC");
+  plotlabel7->SetTextColor(kBlack);
+  plotlabel7->SetFillColor(kWhite);
+  plotlabel7->SetBorderSize(0);
+  plotlabel7->SetTextAlign(12);
+  plotlabel7->SetTextSize(0.03);
+  sprintf(
+      temp, "Eff = %.3f #pm %.3f", ParEfficiency->getVal(), ParEfficiency->getErrorHi(), ParEfficiency->getErrorLo());
+  plotlabel7->AddText(temp);
 
-//   plotlabel->Draw();
-//   plotlabel2->Draw();
-//   plotlabel3->Draw();
+  //   plotlabel->Draw();
+  //   plotlabel2->Draw();
+  //   plotlabel3->Draw();
   plotlabel4->Draw();
   plotlabel5->Draw();
   plotlabel6->Draw();
   plotlabel7->Draw();
 
-  c2->SaveAs( cname + TString(".eps"));
-  c2->SaveAs( cname + TString(".gif"));
-  c2->SaveAs( cname + TString(".root"));
+  c2->SaveAs(cname + TString(".eps"));
+  c2->SaveAs(cname + TString(".gif"));
+  c2->SaveAs(cname + TString(".root"));
   delete c2;
-
 
   gBenchmark->Show("fitZCat");
 }
 
-
 void fitZCat() {
-
-      performFit("EfficiencyFitter/input/Data_36_09122010_TP_TagWP80/", "Mass_TagPlusRecoPassVBTF95IdIso_EB_Pt20ToInf_Data_36", "Mass_TagPlusRecoFailVBTF95IdIso_EB_Pt20ToInf_Data_36", "Mass_TagPlusRecoPassVBTF95IdIso_EB_Pt20ToInf", "Mass_TagPlusRecoFailVBTF95IdIso_EB_Pt20ToInf" );
-
-
+  performFit("EfficiencyFitter/input/Data_36_09122010_TP_TagWP80/",
+             "Mass_TagPlusRecoPassVBTF95IdIso_EB_Pt20ToInf_Data_36",
+             "Mass_TagPlusRecoFailVBTF95IdIso_EB_Pt20ToInf_Data_36",
+             "Mass_TagPlusRecoPassVBTF95IdIso_EB_Pt20ToInf",
+             "Mass_TagPlusRecoFailVBTF95IdIso_EB_Pt20ToInf");
 }

--- a/PhysicsTools/TagAndProbe/test/utilities/fitZCat.C
+++ b/PhysicsTools/TagAndProbe/test/utilities/fitZCat.C
@@ -25,7 +25,6 @@
 #include "RooGaussian.h"
 #include "RooNLLVar.h"
 #include "RooConstVar.h"
-#include "RooFitLegacy/RooMinuit.h"
 #include "RooFitResult.h"
 #include "RooExponential.h"
 


### PR DESCRIPTION
#### PR description:

ROOT has changed the RooMinuit usage in here:
https://github.com/root-project/root/pull/8369
here:
https://github.com/root-project/root/pull/8596
and here:
https://github.com/root-project/root/pull/8567
suggesting to use RooMinimizer
https://github.com/root-project/root/blob/master/roofit/roofitcore/inc/RooMinuit.h


#### PR validation:

PhysicsTools/TagAndProbe is building
