### PR TITLE
fix comparison: filter() in py3 does not return list

### DIFF
--- a/Utilities/RelMon/python/dqm_interfaces.py
+++ b/Utilities/RelMon/python/dqm_interfaces.py
@@ -714,7 +714,7 @@ class DirWalkerFile(object):
             #print  self.ls().keys()
             first_run_dir = ""
             try:
-                first_run_dir = filter(lambda k: "Run " in k, self.ls().keys())[0]
+                first_run_dir = list(filter(lambda k: "Run " in k, self.ls().keys()))[0]
             except:
                 print("\nRundir not there: Is this a generic rootfile?\n")
             rundir=first_run_dir


### PR DESCRIPTION
Fixes #34445
Since we moved to py3, the filter() ( https://docs.python.org/3/library/functions.html#filter ) does not return a list but an iterator. 