### PR TITLE
MTD Validation: dropped explicit types from the python configuration files

### DIFF
--- a/Validation/MtdValidation/python/btlDigiHits_cfi.py
+++ b/Validation/MtdValidation/python/btlDigiHits_cfi.py
@@ -3,4 +3,4 @@ from Validation.MtdValidation.btlDigiHitsDefault_cfi import btlDigiHitsDefault a
 btlDigiHits = _btlDigiHitsDefault.clone()
 
 from Configuration.ProcessModifiers.premix_stage2_cff import premix_stage2
-premix_stage2.toModify(btlDigiHits, inputTag = cms.InputTag("mixData","FTLBarrel"))
+premix_stage2.toModify(btlDigiHits, inputTag = "mixData:FTLBarrel")

--- a/Validation/MtdValidation/python/etlDigiHits_cfi.py
+++ b/Validation/MtdValidation/python/etlDigiHits_cfi.py
@@ -3,4 +3,4 @@ from Validation.MtdValidation.etlDigiHitsDefault_cfi import etlDigiHitsDefault a
 etlDigiHits = _etlDigiHitsDefault.clone()
 
 from Configuration.ProcessModifiers.premix_stage2_cff import premix_stage2
-premix_stage2.toModify(etlDigiHits, inputTag = cms.InputTag("mixData","FTLEndcap"))
+premix_stage2.toModify(etlDigiHits, inputTag = "mixData:FTLEndcap")


### PR DESCRIPTION
#### PR description:

In compliance with the CMSSW coding guidance, this PR removes the explicit type declaration from the arguments of toModify in two python config files of the MTD validation package.

(@jfernan2 @gsorrentino18 @fabiocos @parbol )

#### PR validation:

The PR code had been tested on the WF 34634 with CMSSW_12_0_0_pre4:
no differences in the DQM histograms.