### PR TITLE
Fix BeamMonitor names in BeamSpot DQM clients

### DIFF
--- a/DQM/Integration/python/clients/beam_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/beam_dqm_sourceclient-live_cfg.py
@@ -60,10 +60,10 @@ process.hltTriggerTypeFilter = cms.EDFilter("HLTTriggerTypeFilter",
 #----------------------------
 # DQM Live Environment
 process.load("DQM.Integration.config.environment_cfi")
-process.dqmEnv.subSystemFolder = 'BeamMonitor'
-process.dqmSaver.tag           = 'BeamMonitor'
+process.dqmEnv.subSystemFolder = 'BeamMonitorLegacy'
+process.dqmSaver.tag           = 'BeamMonitorLegacy'
 process.dqmSaver.runNumber     = options.runNumber
-process.dqmSaverPB.tag         = 'BeamMonitor'
+process.dqmSaverPB.tag         = 'BeamMonitorLegacy'
 process.dqmSaverPB.runNumber   = options.runNumber
 
 process.dqmEnvPixelLess = process.dqmEnv.clone(

--- a/DQM/Integration/python/clients/beamfake_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/beamfake_dqm_sourceclient-live_cfg.py
@@ -62,10 +62,10 @@ process.hltTriggerTypeFilter = cms.EDFilter("HLTTriggerTypeFilter",
 #----------------------------
 # DQM Live Environment
 process.load("DQM.Integration.config.environment_cfi")
-process.dqmEnv.subSystemFolder = 'FakeBeamMonitor'
-process.dqmSaver.tag           = 'FakeBeamMonitor'
+process.dqmEnv.subSystemFolder = 'FakeBeamMonitorLegacy'
+process.dqmSaver.tag           = 'FakeBeamMonitorLegacy'
 process.dqmSaver.runNumber     = options.runNumber
-process.dqmSaverPB.tag         = 'FakeBeamMonitor'
+process.dqmSaverPB.tag         = 'FakeBeamMonitorLegacy'
 process.dqmSaverPB.runNumber   = options.runNumber
 
 

--- a/DQM/Integration/python/clients/beamhlt_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/beamhlt_dqm_sourceclient-live_cfg.py
@@ -76,10 +76,10 @@ process.hltTriggerTypeFilter = cms.EDFilter("HLTTriggerTypeFilter",
 # DQM Live Environment
 #-----------------------------
 process.load("DQM.Integration.config.environment_cfi")
-process.dqmEnv.subSystemFolder = 'BeamMonitor'
-process.dqmSaver.tag           = 'BeamMonitor'
+process.dqmEnv.subSystemFolder = 'BeamMonitorHLT'
+process.dqmSaver.tag           = 'BeamMonitorHLT'
 process.dqmSaver.runNumber     = options.runNumber
-process.dqmSaverPB.tag         = 'BeamMonitor'
+process.dqmSaverPB.tag         = 'BeamMonitorHLT'
 process.dqmSaverPB.runNumber   = options.runNumber
 
 #-----------------------------

--- a/DQM/Integration/python/clients/beamhltfake_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/beamhltfake_dqm_sourceclient-live_cfg.py
@@ -60,10 +60,10 @@ process.hltTriggerTypeFilter = cms.EDFilter("HLTTriggerTypeFilter",
 # DQM Live Environment
 #-----------------------------
 process.load("DQM.Integration.config.environment_cfi")
-process.dqmEnv.subSystemFolder = 'FakeBeamMonitor'
-process.dqmSaver.tag           = 'FakeBeamMonitor'
+process.dqmEnv.subSystemFolder = 'FakeBeamMonitorHLT'
+process.dqmSaver.tag           = 'FakeBeamMonitorHLT'
 process.dqmSaver.runNumber     = options.runNumber
-process.dqmSaverPB.tag         = 'FakeBeamMonitor'
+process.dqmSaverPB.tag         = 'FakeBeamMonitorHLT'
 process.dqmSaverPB.runNumber   = options.runNumber
 
 #---------------


### PR DESCRIPTION
#### PR description:
This PR fixes the `dqmEnv.subSystemFolder`, `dqmSaver.tag` and `dqmSaverPB.tag` names in the BeamMonitor (and FakeBeamMonitor), so that when running the two clients in parallel the output root files are named differently and no crash should happen in DQM at the file-merging step.

#### PR validation:
I run locally the unit tests to confirm that the output names of the root files are changed as expected.
For example:
```
DQM_V0001_FakeBeamMonitor_R000325283.root   -->   DQM_V0001_FakeBeamMonitorHLT_R000325283.root
```
@jfernan2 I'm not sure how to test the change done for `dqmEnv.subSystemFolder`, any suggestion? 

#### if this PR is a backport please specify the original PR and why you need to backport that PR:
Backported in #34468 