### PR TITLE
DataProcessing: use python3 in unit test

### DIFF
--- a/Configuration/DataProcessing/test/run_CfgTest.sh
+++ b/Configuration/DataProcessing/test/run_CfgTest.sh
@@ -8,7 +8,7 @@
 # Pass in name and status
 function die { echo $1: status $2 ;  exit $2; }
 
-function runTest { echo $1 ; python $1 || die "Failure for configuration: $1" $?; }
+function runTest { echo $1 ; python3 $1 || die "Failure for configuration: $1" $?; }
 
 
 runTest "${LOCAL_TEST_DIR}/RunRepack.py --select-events HLT:path1,HLT:path2 --lfn /store/whatever"


### PR DESCRIPTION
This is needed in order to drop the next set of python2 based modules ( https://github.com/cms-sw/cmsdist/pull/7112 ).
These are technical changes and should not break any thing as unit tests are working in PY3 IBs where `python` is `python3`.