### PR TITLE
DetectorDescription: use python3 in unit test

### DIFF
--- a/DetectorDescription/RegressionTest/test/run_DDErrorReport.py
+++ b/DetectorDescription/RegressionTest/test/run_DDErrorReport.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 
 import FWCore.ParameterSet.Config as cms
 import sys


### PR DESCRIPTION
This is needed in order to drop the next set of python2 based modules ( https://github.com/cms-sw/cmsdist/pull/7112 )
These are technical changes and should not break any thing as unit tests are working in PY3 IBs where `python` is `python3`.