### PR TITLE
PatAlgos: use python3 in unit test

### DIFF
--- a/PhysicsTools/PatAlgos/test/miniAOD/example_fwlite_checkJets.py
+++ b/PhysicsTools/PatAlgos/test/miniAOD/example_fwlite_checkJets.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 
 from __future__ import print_function
 import ROOT

--- a/PhysicsTools/PatAlgos/test/runtests.sh
+++ b/PhysicsTools/PatAlgos/test/runtests.sh
@@ -6,7 +6,7 @@ for file in ${CMSSW_BASE}/src/PhysicsTools/PatAlgos/python/tools/*.py
 do
     bn=`basename $file`
     if [ "$bn" != "__init__.py" ]; then
-        python "$file" || die "unit tests for $bn failed" $?
+        python3 "$file" || die "unit tests for $bn failed" $?
     fi
 done
 


### PR DESCRIPTION
This is needed in order to drop the next set of python2 based modules ( https://github.com/cms-sw/cmsdist/pull/7112 ).
These are technical changes and should not break any thing as unit tests are working in PY3 IBs where `python` is `python3`.