### PR TITLE
CondTools/SiStrip: use python3

### DIFF
--- a/CondTools/SiStrip/scripts/SiStripDAQPopCon.py
+++ b/CondTools/SiStrip/scripts/SiStripDAQPopCon.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 '''Script that runs a single O2O for SiStrip DAQ.
 @author: Huilin Qu
 '''

--- a/CondTools/SiStrip/scripts/SiStripDCSPopCon.py
+++ b/CondTools/SiStrip/scripts/SiStripDCSPopCon.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 '''Script that runs SiStrip DCS O2O.
 @author: Huilin Qu
 '''

--- a/CondTools/SiStrip/scripts/o2oRun_SiStripDAQ.py
+++ b/CondTools/SiStrip/scripts/o2oRun_SiStripDAQ.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 '''
 Main Script to run all SiStrip DAQ O2Os at the same time.
 @author: Huilin Qu

--- a/CondTools/SiStrip/scripts/o2oRun_SiStripDCS.py
+++ b/CondTools/SiStrip/scripts/o2oRun_SiStripDCS.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 '''
 Top level script to run SiStrip DCS O2O.
 @author: Huilin Qu


### PR DESCRIPTION
This is needed in order to drop the next set of python2 based modules ( https://github.com/cms-sw/cmsdist/pull/7112 )
These are technical changes and should not break any thing as unit tests are working in PY3 IBs where `python` is `python3`.