### PR TITLE
CMSCommonData: use python3 in unit test

### DIFF
--- a/Geometry/CMSCommonData/test/run_DOMCount.py
+++ b/Geometry/CMSCommonData/test/run_DOMCount.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 
 from __future__ import print_function
 from FWCore.ParameterSet.pfnInPath import pfnInPath

--- a/Geometry/CMSCommonData/test/run_DOMCount.sh
+++ b/Geometry/CMSCommonData/test/run_DOMCount.sh
@@ -40,7 +40,7 @@ cfiFiles="${cfiFiles} Geometry/CMSCommonData/cmsExtendedGeometryXML_cfi"
 cfiFiles="${cfiFiles} Geometry/CMSCommonData/cmsExtendedGeometryZeroMaterialXML_cfi"
 
 # automatically retrieve active phase 2 geometries
-read -a DETS <<< $(python -c 'from Configuration.Geometry.dict2026Geometry import detectorVersionDict; print " ".join(sorted([x[1] for x in detectorVersionDict.items()]))')
+read -a DETS <<< $(python3 -c 'from Configuration.Geometry.dict2026Geometry import detectorVersionDict; print " ".join(sorted([x[1] for x in detectorVersionDict.items()]))')
 for DET in ${DETS[@]}; do
 	cfiFiles="${cfiFiles} Geometry/CMSCommonData/cmsExtendedGeometry2026${DET}XML_cfi"
 done


### PR DESCRIPTION
This is needed in order to drop the next set of python2 based modules ( https://github.com/cms-sw/cmsdist/pull/7112 )
These are technical changes and should not break any thing as unit tests are working in PY3 IBs where `python` is `python3`.