### PR TITLE
ParameterSet: Use python3 to run tests

### DIFF
--- a/FWCore/ParameterSet/test/runPythonTests.sh
+++ b/FWCore/ParameterSet/test/runPythonTests.sh
@@ -8,6 +8,6 @@ do
   bn=`basename $file`
   if [ "$bn" != "__init__.py" ]; then
      bnm=${bn%.*} 
-     python -m FWCore.ParameterSet."$bnm" || die "unit tests for $bn failed" $?
+     python3 -m FWCore.ParameterSet."$bnm" || die "unit tests for $bn failed" $?
   fi
 done


### PR DESCRIPTION
This is needed in order to drop the next set of python2 based modules ( cms-sw/cmsdist#7112 ).
These are technical changes and should not break any thing as unit tests are working in PY3 IBs where python is python3.