### PR TITLE
Get MagneticField in RunManagerMTWorker::beginRun() instead of produce()

### DIFF
--- a/SimG4Core/Application/src/RunManagerMTWorker.cc
+++ b/SimG4Core/Application/src/RunManagerMTWorker.cc
@@ -226,6 +226,9 @@ void RunManagerMTWorker::beginRun(edm::EventSetup const& es) {
   for (auto& maker : m_sdMakers) {
     maker.second->beginRun(es);
   }
+  if (m_pUseMagneticField) {
+    m_pMagField = &es.getData(m_MagField);
+  }
 }
 
 void RunManagerMTWorker::endRun() {
@@ -312,7 +315,6 @@ void RunManagerMTWorker::initializeG4(RunManagerMT* runManagerMaster, const edm:
   if (m_pUseMagneticField) {
     const GlobalPoint g(0.f, 0.f, 0.f);
 
-    m_pMagField = &es.getData(m_MagField);
     sim::FieldBuilder fieldBuilder(m_pMagField, m_pField);
 
     CMSFieldManager* fieldManager = new CMSFieldManager();


### PR DESCRIPTION
#### PR description:

Given that the ESGetToken is declared such that MagneticField is consumed in beginRun, the product must be read from EventSetup always there. Alternative would be to have two tokens (one for beginRun and another for produce), but always reading in beginRun is simpler and along the planned evolution of this code.

This should fix the random test failures reported in https://github.com/cms-sw/cmssw/pull/34338#issuecomment-879413553

Resolves https://github.com/makortel/framework/issues/188

#### PR validation:

None (edited in GitHub editor).