### PR TITLE
Migrate module config in RecoHI to use default cfipython

### DIFF
--- a/RecoHI/HiJetAlgos/python/IterativeConePu5Jets_PbPb_cff.py
+++ b/RecoHI/HiJetAlgos/python/IterativeConePu5Jets_PbPb_cff.py
@@ -18,18 +18,17 @@ caloTowers = cms.EDProducer("CaloTowerCandidateCreator",
     minimumEt = cms.double(0.0),
     et = cms.double(0.0)
 )
+import RecoJets.JetProducers.FastjetJetProducer_cfi as _mod
 
-iterativeConePu5CaloJets = cms.EDProducer("FastjetJetProducer",
-                                          CaloJetParameters,
-                                          AnomalousCellParameters,
-                                          jetAlgorithm = cms.string("IterativeCone"),
-                                          rParam       = cms.double(0.5),
-                                          )
-
-iterativeConePu5CaloJets.doPUOffsetCorr = True
-iterativeConePu5CaloJets.doPVCorrection = False
-iterativeConePu5CaloJets.jetPtMin = 10
-
+iterativeConePu5CaloJets = _mod.FastjetJetProducer.clone(
+    CaloJetParameters,
+    AnomalousCellParameters,
+    jetAlgorithm = "IterativeCone",
+    rParam       = 0.5,
+    doPUOffsetCorr = True,
+    doPVCorrection = False,
+    jetPtMin = 10
+)
 
 # REPLACE with UP-TO-DATE Corrections
 #MCJetCorJetIconePu5 = cms.EDProducer("CaloJetCorrectionProducer",

--- a/RecoHI/HiTracking/python/HILowPtConformalPixelTracks_cfi.py
+++ b/RecoHI/HiTracking/python/HILowPtConformalPixelTracks_cfi.py
@@ -23,27 +23,19 @@ hiConformalPixelTracksHitTriplets = _pixelTripletHLTEDProducer.clone(
     produceSeedingHitSets = True,
 )
 
+import RecoPixelVertexing.PixelTrackFitting.pixelTracks_cfi as _mod
 # Pixel tracks
-hiConformalPixelTracks = cms.EDProducer("PixelTrackProducer",
-                                        
-                                        #passLabel  = cms.string('Pixel triplet low-pt tracks with vertex constraint'),
-                                        
-                                        # Ordered Hits
-                                        SeedingHitSets = cms.InputTag("hiConformalPixelTracksHitTriplets"),
-                                        
-                                        # Fitter
-                                        Fitter = cms.InputTag('pixelFitterByConformalMappingAndLine'),
-                                        
-                                        # Filter
-                                        Filter = cms.InputTag("hiConformalPixelFilter"),
-                                        
-                                        # Cleaner
-                                        Cleaner = cms.string("trackCleaner")
-                                        )
-
-
-
-
+hiConformalPixelTracks = _mod.pixelTracks.clone(
+    #passLabel  = 'Pixel triplet low-pt tracks with vertex constraint',
+    # Ordered Hits
+    SeedingHitSets = "hiConformalPixelTracksHitTriplets",
+    # Fitter
+    Fitter = 'pixelFitterByConformalMappingAndLine',
+    # Filter
+    Filter = "hiConformalPixelFilter",   
+    # Cleaner
+    Cleaner = "trackCleaner"
+)
 
 ###Pixel Tracking -  PhaseI geometry
 

--- a/RecoHI/HiTracking/python/HIPixel3PrimTracks_cfi.py
+++ b/RecoHI/HiTracking/python/HIPixel3PrimTracks_cfi.py
@@ -53,22 +53,19 @@ hiPixel3PrimTracksHitQuadrupletsCA = _caHitQuadrupletEDProducer.clone(
     CAPhiCut   = 0.2,
 ) 
 
+import RecoPixelVertexing.PixelTrackFitting.pixelTracks_cfi as _mod 
+
 # Pixel tracks
-hiPixel3PrimTracks = cms.EDProducer("PixelTrackProducer",
-
-    passLabel  = cms.string('Pixel triplet primary tracks with vertex constraint'),
-
+hiPixel3PrimTracks = _mod.pixelTracks.clone(
+    passLabel  = 'Pixel triplet primary tracks with vertex constraint',
     # Ordered Hits
-    SeedingHitSets = cms.InputTag("hiPixel3PrimTracksHitTriplets"),
-	
+    SeedingHitSets = "hiPixel3PrimTracksHitTriplets",
     # Fitter
-    Fitter = cms.InputTag("pixelFitterByHelixProjections"),
-	
+    Fitter = "pixelFitterByHelixProjections",
     # Filter
-    Filter = cms.InputTag("hiFilter"),
-	
+    Filter = "hiFilter",
     # Cleaner
-    Cleaner = cms.string("trackCleaner")
+    Cleaner = "trackCleaner"
 )
 trackingPhase1.toModify(hiPixel3PrimTracks,
     SeedingHitSets = "hiPixel3PrimTracksHitQuadrupletsCA",

--- a/RecoHI/HiTracking/python/HIPixel3ProtoTracks_cfi.py
+++ b/RecoHI/HiTracking/python/HIPixel3ProtoTracks_cfi.py
@@ -24,22 +24,19 @@ hiPixel3ProtoTracksHitTriplets = _pixelTripletHLTEDProducer.clone(
     produceSeedingHitSets = True,
 )
 
-# Pixel tracks
-hiPixel3ProtoTracks = cms.EDProducer( "PixelTrackProducer",
+import RecoPixelVertexing.PixelTrackFitting.pixelTracks_cfi as _mod
 
-    passLabel  = cms.string('Pixel triplet tracks for vertexing'),
-	
+# Pixel tracks
+hiPixel3ProtoTracks = _mod.pixelTracks.clone( 
+    passLabel  = 'Pixel triplet tracks for vertexing',
     # Ordered Hits
-    SeedingHitSets = cms.InputTag("hiPixel3ProtoTracksHitTriplets"),
-	
+    SeedingHitSets = "hiPixel3ProtoTracksHitTriplets",
     # Fitter
-    Fitter = cms.InputTag("pixelFitterByHelixProjections"),
-	
+    Fitter = "pixelFitterByHelixProjections",
     # Filter
-    Filter = cms.InputTag("hiProtoTrackFilter"),
-	
+    Filter = "hiProtoTrackFilter",
     # Cleaner
-    Cleaner = cms.string("pixelTrackCleanerBySharedHits")
+    Cleaner = "pixelTrackCleanerBySharedHits"
 )
 
 hiPixel3ProtoTracksTask = cms.Task(

--- a/RecoHI/HiTracking/python/HIPixelAdaptiveVertex_cfi.py
+++ b/RecoHI/HiTracking/python/HIPixelAdaptiveVertex_cfi.py
@@ -22,11 +22,14 @@ hiPixelAdaptiveVertex = _mod.primaryVertexProducer.clone(
             zSeparation = cms.double(1.0)       ## 1 cm max separation between clusters
         )
     ),
-    vertexCollections = {
-        0: dict(
-        label = '',
-        chi2cutoff = 3.0,
-        maxDistanceToBeam = 0.1
+    vertexCollections = cms.VPSet(
+      cms.PSet(
+        label = cms.string(''),
+        chi2cutoff = cms.double(3.0),
+        algorithm = cms.string('AdaptiveVertexFitter'),
+        useBeamConstraint = cms.bool(False),
+        maxDistanceToBeam = cms.double(0.1),
+        minNdof  = cms.double(0.0)
         )
-    }
+      )
 )

--- a/RecoHI/HiTracking/python/HIPixelAdaptiveVertex_cfi.py
+++ b/RecoHI/HiTracking/python/HIPixelAdaptiveVertex_cfi.py
@@ -1,37 +1,32 @@
 import FWCore.ParameterSet.Config as cms
+import RecoVertex.PrimaryVertexProducer.primaryVertexProducer_cfi as _mod
 
-hiPixelAdaptiveVertex = cms.EDProducer("PrimaryVertexProducer",
-    verbose = cms.untracked.bool(False),
-    TkFilterParameters = cms.PSet(
-        algorithm = cms.string('filterWithThreshold'),
-        maxNormalizedChi2 = cms.double(5.0),
-        minSiliconLayersWithHits = cms.int32(0), ## >=0 (was 5 for generalTracks)
-        minPixelLayersWithHits = cms.int32(2),   ## >=2 (was 2 for generalTracks)
-        maxD0Significance = cms.double(3.0),     ## keep most primary tracks (was 5.0)
-        minPt = cms.double(0.0),                 ## better for softish events
-        maxEta = cms.double(100.),
-        trackQuality = cms.string("any"),
-        numTracksThreshold = cms.int32(2)
+hiPixelAdaptiveVertex = _mod.primaryVertexProducer.clone(
+    verbose = False,
+    TkFilterParameters = dict(
+        algorithm = 'filterWithThreshold',
+        maxNormalizedChi2 = 5.0,
+        minSiliconLayersWithHits = 0, ## >=0 (was 5 for generalTracks)
+        minPixelLayersWithHits = 2,   ## >=2 (was 2 for generalTracks)
+        maxD0Significance = 3.0,     ## keep most primary tracks (was 5.0)
+        minPt = 0.0,                 ## better for softish events
+        maxEta = 100.,
+        numTracksThreshold = 2
     ),
-    beamSpotLabel = cms.InputTag("offlineBeamSpot"),
     # label of tracks to be used
-    TrackLabel = cms.InputTag("hiSelectedProtoTracks"),
+    TrackLabel = "hiSelectedProtoTracks",
     # clustering
-    TkClusParameters = cms.PSet(
-        algorithm = cms.string("gap"),
+    TkClusParameters = dict(
+        algorithm = "gap",
         TkGapClusParameters = cms.PSet(
-            zSeparation = cms.double(1.0)        ## 1 cm max separation between clusters
+            zSeparation = cms.double(1.0)       ## 1 cm max separation between clusters
         )
     ),
-    vertexCollections = cms.VPSet(
-      cms.PSet(
-        label = cms.string(''),
-        chi2cutoff = cms.double(3.0),
-        algorithm = cms.string('AdaptiveVertexFitter'),
-        useBeamConstraint = cms.bool(False),
-        maxDistanceToBeam = cms.double(0.1),
-        minNdof  = cms.double(0.0)
+    vertexCollections = {
+        0: dict(
+        label = '',
+        chi2cutoff = 3.0,
+        maxDistanceToBeam = 0.1
         )
-      )
+    }
 )
-

--- a/RecoHI/HiTracking/python/hiDetachedQuadStep_cff.py
+++ b/RecoHI/HiTracking/python/hiDetachedQuadStep_cff.py
@@ -83,21 +83,19 @@ hiDetachedQuadStepPixelTracksFilter = hiFilter.clone(
     tipMax = 1.0,
     ptMin = 0.95, #seeding region is 0.3
 )
-hiDetachedQuadStepPixelTracks = cms.EDProducer("PixelTrackProducer",
 
-    passLabel  = cms.string('Pixel detached tracks with vertex constraint'),
+import RecoPixelVertexing.PixelTrackFitting.pixelTracks_cfi as _mod
 
+hiDetachedQuadStepPixelTracks = _mod.pixelTracks.clone(
+    passLabel  = 'Pixel detached tracks with vertex constraint',
     # Ordered Hits
-    SeedingHitSets = cms.InputTag("hiDetachedQuadStepTracksHitQuadrupletsCA"),
-	
+    SeedingHitSets = "hiDetachedQuadStepTracksHitQuadrupletsCA",
     # Fitter
-    Fitter = cms.InputTag("pixelFitterByHelixProjections"),
-	
+    Fitter = "pixelFitterByHelixProjections",
     # Filter
-    Filter = cms.InputTag("hiDetachedQuadStepPixelTracksFilter"),
-	
+    Filter = "hiDetachedQuadStepPixelTracksFilter",
     # Cleaner
-    Cleaner = cms.string("trackCleaner")
+    Cleaner = "trackCleaner"
 )
 
 

--- a/RecoHI/HiTracking/python/hiDetachedTripletStep_cff.py
+++ b/RecoHI/HiTracking/python/hiDetachedTripletStep_cff.py
@@ -100,31 +100,29 @@ hiDetachedTripletStepPixelTracksFilter = hiFilter.clone(
     tipMax = 1.0,
     ptMin = 0.95,
 )
-hiDetachedTripletStepPixelTracks = cms.EDProducer("PixelTrackProducer",
 
-    passLabel  = cms.string('Pixel detached tracks with vertex constraint'),
+import RecoPixelVertexing.PixelTrackFitting.pixelTracks_cfi as _mod
 
+hiDetachedTripletStepPixelTracks = _mod.pixelTracks.clone(
+    passLabel  = 'Pixel detached tracks with vertex constraint',
     # Ordered Hits
-    SeedingHitSets = cms.InputTag("hiDetachedTripletStepTracksHitTriplets"),
-	
+    SeedingHitSets = "hiDetachedTripletStepTracksHitTriplets",
     # Fitter
-    Fitter = cms.InputTag("pixelFitterByHelixProjections"),
-	
+    Fitter = "pixelFitterByHelixProjections",
     # Filter
-    Filter = cms.InputTag("hiDetachedTripletStepPixelTracksFilter"),
-	
+    Filter = "hiDetachedTripletStepPixelTracksFilter",
     # Cleaner
-    Cleaner = cms.string("trackCleaner")
+    Cleaner = "trackCleaner"
 )
 trackingPhase1.toModify(hiDetachedTripletStepPixelTracks,
-    SeedingHitSets = cms.InputTag("hiDetachedTripletStepTracksHitTripletsCA")
+    SeedingHitSets = "hiDetachedTripletStepTracksHitTripletsCA"
 )
 
 
 import RecoPixelVertexing.PixelLowPtUtilities.TrackSeeds_cfi
 hiDetachedTripletStepSeeds = RecoPixelVertexing.PixelLowPtUtilities.TrackSeeds_cfi.pixelTrackSeeds.clone(
         InputCollection = 'hiDetachedTripletStepPixelTracks'
-  )
+)
 
 # QUALITY CUTS DURING TRACK BUILDING
 import TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff

--- a/RecoHI/HiTracking/python/hiHighPtTripletStep_cff.py
+++ b/RecoHI/HiTracking/python/hiHighPtTripletStep_cff.py
@@ -82,23 +82,20 @@ hiHighPtTripletStepPixelTracksFilter = hiFilter.clone(
     tipMax = 1.0,
     ptMin = 1.0, #seeding region is 0.6
 )
-hiHighPtTripletStepPixelTracks = cms.EDProducer("PixelTrackProducer",
 
-    passLabel  = cms.string('Pixel detached tracks with vertex constraint'),
+import RecoPixelVertexing.PixelTrackFitting.pixelTracks_cfi as _mod
 
+hiHighPtTripletStepPixelTracks = _mod.pixelTracks.clone(
+    passLabel  = 'Pixel detached tracks with vertex constraint',
     # Ordered Hits
-    SeedingHitSets = cms.InputTag("hiHighPtTripletStepTracksHitTripletsCA"),
-	
+    SeedingHitSets = "hiHighPtTripletStepTracksHitTripletsCA",
     # Fitter
-    Fitter = cms.InputTag("pixelFitterByHelixProjections"),
-	
+    Fitter = "pixelFitterByHelixProjections",
     # Filter
-    Filter = cms.InputTag("hiHighPtTripletStepPixelTracksFilter"),
-	
+    Filter = "hiHighPtTripletStepPixelTracksFilter",
     # Cleaner
-    Cleaner = cms.string("trackCleaner")
+    Cleaner = "trackCleaner"
 )
-
 
 import RecoPixelVertexing.PixelLowPtUtilities.TrackSeeds_cfi
 hiHighPtTripletStepSeeds = RecoPixelVertexing.PixelLowPtUtilities.TrackSeeds_cfi.pixelTrackSeeds.clone(

--- a/RecoHI/HiTracking/python/hiJetCoreRegionalStep_cff.py
+++ b/RecoHI/HiTracking/python/hiJetCoreRegionalStep_cff.py
@@ -21,29 +21,34 @@ hiFirstStepGoodPrimaryVertices = cms.EDFilter("PrimaryVertexObjectFilter",
      src=cms.InputTag('hiSelectedPixelVertex')
 )
 
+import RecoTracker.TkSeedingLayers.seedingLayersEDProducer_cfi as _mod
+
 # SEEDING LAYERS
-hiJetCoreRegionalStepSeedLayers = cms.EDProducer("SeedingLayersEDProducer",
-    layerList = cms.vstring('BPix1+BPix2+BPix3', 
-    'BPix1+BPix2+FPix1_pos', 
-    'BPix1+BPix2+FPix1_neg', 
-    'BPix1+FPix1_pos+FPix2_pos', 
-    'BPix1+FPix1_neg+FPix2_neg',
-    'BPix1+BPix2+TIB1', 
-    'BPix1+BPix3+TIB1', 
-    'BPix2+BPix3+TIB1', 
-),
-    TIB = cms.PSet(
+hiJetCoreRegionalStepSeedLayers = _mod.seedingLayersEDProducer.clone(
+    layerList = ['BPix1+BPix2+BPix3', 
+                 'BPix1+BPix2+FPix1_pos', 
+                 'BPix1+BPix2+FPix1_neg', 
+                 'BPix1+FPix1_pos+FPix2_pos', 
+                 'BPix1+FPix1_neg+FPix2_neg',
+                 'BPix1+BPix2+TIB1', 
+                 'BPix1+BPix3+TIB1', 
+                 'BPix2+BPix3+TIB1', 
+                ],
+    TIB = dict(
         matchedRecHits = cms.InputTag("siStripMatchedRecHits","matchedRecHit"),
-        TTRHBuilder = cms.string('WithTrackAngle'), clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutNone'))
+        TTRHBuilder = cms.string('WithTrackAngle'), 
+        clusterChargeCut = cms.PSet(
+            refToPSet_ = cms.string('SiStripClusterChargeCutNone')
+        )
     ),
-    BPix = cms.PSet(
+    BPix = dict(
         useErrorsFromParam = cms.bool(True),
         hitErrorRPhi = cms.double(0.0027),
         hitErrorRZ = cms.double(0.006),
         TTRHBuilder = cms.string('WithTrackAngle'),
         HitProducer = cms.string('siPixelRecHits'),
     ),
-    FPix = cms.PSet(
+    FPix = dict(
         useErrorsFromParam = cms.bool(True),
         hitErrorRPhi = cms.double(0.0051),
         hitErrorRZ = cms.double(0.0036),

--- a/RecoHI/HiTracking/python/hiLowPtQuadStep_cff.py
+++ b/RecoHI/HiTracking/python/hiLowPtQuadStep_cff.py
@@ -85,21 +85,19 @@ hiLowPtQuadStepPixelTracksFilter = hiFilter.clone(
     tipMax = 1.0,
     ptMin = 0.4, #seeding region is 0.3
 )
-hiLowPtQuadStepPixelTracks = cms.EDProducer("PixelTrackProducer",
 
-    passLabel  = cms.string('Pixel detached tracks with vertex constraint'),
+import RecoPixelVertexing.PixelTrackFitting.pixelTracks_cfi as _mod
 
+hiLowPtQuadStepPixelTracks = _mod.pixelTracks.clone(
+    passLabel  = 'Pixel detached tracks with vertex constraint',
     # Ordered Hits
-    SeedingHitSets = cms.InputTag("hiLowPtQuadStepTracksHitQuadrupletsCA"),
-	
+    SeedingHitSets = "hiLowPtQuadStepTracksHitQuadrupletsCA",
     # Fitter
-    Fitter = cms.InputTag("pixelFitterByHelixProjections"),
-	
+    Fitter = "pixelFitterByHelixProjections",
     # Filter
-    Filter = cms.InputTag("hiLowPtQuadStepPixelTracksFilter"),
-	
+    Filter = "hiLowPtQuadStepPixelTracksFilter",
     # Cleaner
-    Cleaner = cms.string("trackCleaner")
+    Cleaner = "trackCleaner"
 )
 
 

--- a/RecoHI/HiTracking/python/hiLowPtTripletStep_cff.py
+++ b/RecoHI/HiTracking/python/hiLowPtTripletStep_cff.py
@@ -92,25 +92,23 @@ hiLowPtTripletStepPixelTracksFilter = hiFilter.clone(
     lipMax = 0,
     ptMin = 0.4,
 )
-hiLowPtTripletStepPixelTracks = cms.EDProducer("PixelTrackProducer",
 
-    passLabel  = cms.string('Pixel primary tracks with vertex constraint'),
+import RecoPixelVertexing.PixelTrackFitting.pixelTracks_cfi as _mod
 
+hiLowPtTripletStepPixelTracks = _mod.pixelTracks.clone(
+    passLabel  = 'Pixel primary tracks with vertex constraint',
     # Ordered Hits
-    SeedingHitSets = cms.InputTag("hiLowPtTripletStepTracksHitTriplets"),
-	
+    SeedingHitSets = "hiLowPtTripletStepTracksHitTriplets",
     # Fitter
-    Fitter = cms.InputTag("pixelFitterByHelixProjections"),
-	
+    Fitter = "pixelFitterByHelixProjections",
     # Filter
-    Filter = cms.InputTag("hiLowPtTripletStepPixelTracksFilter"),
-	
+    Filter = "hiLowPtTripletStepPixelTracksFilter",
     # Cleaner
-    Cleaner = cms.string("trackCleaner")
+    Cleaner = "trackCleaner"
 )
 from Configuration.Eras.Modifier_trackingPhase1_cff import trackingPhase1
 trackingPhase1.toModify(hiLowPtTripletStepPixelTracks,
-    SeedingHitSets = cms.InputTag("hiLowPtTripletStepTracksHitTripletsCA")
+    SeedingHitSets = "hiLowPtTripletStepTracksHitTripletsCA"
 )
 
 


### PR DESCRIPTION
#### PR description: 
Optimization of the python configurations: Improve maintainability by cleaning up the duplicated and cloning from the default/reference configurations. (The previous PRs : [PR#33207](https://github.com/cms-sw/cmssw/pull/33207), [PR#33307](https://github.com/cms-sw/cmssw/pull/33307), [PR#33352](https://github.com/cms-sw/cmssw/pull/33352), [PR#33543](https://github.com/cms-sw/cmssw/pull/33543),  [PR#33563](https://github.com/cms-sw/cmssw/pull/33563),  [PR#33671](https://github.com/cms-sw/cmssw/pull/33671), [PR#34007](https://github.com/cms-sw/cmssw/pull/34007), [PR#34091](https://github.com/cms-sw/cmssw/pull/34091), [PR#34009](https://github.com/cms-sw/cmssw/pull/34009), [PR#34155](https://github.com/cms-sw/cmssw/pull/34155), [PR#34371](https://github.com/cms-sw/cmssw/pull/34371))
Updates:
-  Replace explicit configuration with a reference from cfipython. (migrating EDProducer("type", .. -> typeDefaylt.clone() ) 
- Remove the type specifications already presented in cfipython/fillDescriptions reference for improved syntax safety.
- Remove the duplicated parameters that are exactly the same value in cfipython reference.
 
In this PR, 11 files were changed.  
_1) clone pixelTracks module from cfipython/​RecoPixelVertexing/​PixelTrackFitting/​pixelTracks_cfi.py_

        modified:   RecoHI/HiJetAlgos/python/IterativeConePu5Jets_PbPb_cff.py
        modified:   RecoHI/HiTracking/python/HILowPtConformalPixelTracks_cfi.py
        modified:   RecoHI/HiTracking/python/HIPixel3PrimTracks_cfi.py
        modified:   RecoHI/HiTracking/python/HIPixel3ProtoTracks_cfi.py
        modified:   RecoHI/HiTracking/python/HIPixelAdaptiveVertex_cfi.py
        modified:   RecoHI/HiTracking/python/hiDetachedQuadStep_cff.py
        modified:   RecoHI/HiTracking/python/hiDetachedTripletStep_cff.py
        modified:   RecoHI/HiTracking/python/hiHighPtTripletStep_cff.py

_2) clone seedingLayersEDProducer module from cfipython/​RecoTracker/​TkSeedingLayers/​seedingLayersEDProducer_cfi.py_ 

        modified:   RecoHI/HiTracking/python/hiJetCoreRegionalStep_cff.py


_3) clone primaryVertexProducer module from cfipython/​RecoVertex/​PrimaryVertexProducer/​primaryVertexProducer_cfi.py_ 

        modified:   RecoHI/HiTracking/python/hiLowPtQuadStep_cff.py

_4) clone FastjetJetProducer module from cfipython/​RecoJets/​JetProducers/​FastjetJetProducer_cfi.py_	

        modified:   RecoHI/HiTracking/python/hiLowPtTripletStep_cff.py



#### PR validation:
Event Content comparison check was also done and there is no change with these updates.
Tested in CMSSW_12_0_X, the basic test all passed in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html).