### PR TITLE
[DQM] Add dqmPerLSsaving modifier

### DIFF
--- a/Configuration/ProcessModifiers/python/dqmPerLSsaving_cff.py
+++ b/Configuration/ProcessModifiers/python/dqmPerLSsaving_cff.py
@@ -1,4 +1,4 @@
 import FWCore.ParameterSet.Config as cms
 
 # This modifier sets the perLS saving in process.DQMStore.saveByLumi for nanoDQMIO
-perLSsaving = cms.Modifier()
+dqmPerLSsaving = cms.Modifier()

--- a/Configuration/ProcessModifiers/python/perLSsaving_cff.py
+++ b/Configuration/ProcessModifiers/python/perLSsaving_cff.py
@@ -1,0 +1,4 @@
+import FWCore.ParameterSet.Config as cms
+
+# This modifier sets the perLS saving in process.DQMStore.saveByLumi for nanoDQMIO
+perLSsaving = cms.Modifier()

--- a/DQM/BeamMonitor/python/AlcaBeamMonitorHeavyIons_cff.py
+++ b/DQM/BeamMonitor/python/AlcaBeamMonitorHeavyIons_cff.py
@@ -8,8 +8,8 @@ AlcaBeamMonitor.BeamFitter.TrackCollection = 'hiGeneralTracks'
 AlcaBeamMonitor.BeamFitter.TrackQuality    = ['highPurity']
 AlcaBeamMonitor.PVFitter.VertexCollection  = 'hiSelectedVertex'
 #Check if perLSsaving is enabled to mask MEs vs LS
-from Configuration.ProcessModifiers.perLSsaving_cff import perLSsaving
-perLSsaving.toModify(AlcaBeamMonitor, perLSsaving=True)
+from Configuration.ProcessModifiers.dqmPerLSsaving_cff import dqmPerLSsaving
+dqmPerLSsaving.toModify(AlcaBeamMonitor, perLSsaving=True)
 
 import RecoVertex.BeamSpotProducer.BeamSpotOnline_cfi
 scalerBeamSpot = RecoVertex.BeamSpotProducer.BeamSpotOnline_cfi.onlineBeamSpotProducer.clone()

--- a/DQM/BeamMonitor/python/AlcaBeamMonitorHeavyIons_cff.py
+++ b/DQM/BeamMonitor/python/AlcaBeamMonitorHeavyIons_cff.py
@@ -8,9 +8,9 @@ AlcaBeamMonitor.BeamFitter.TrackCollection = 'hiGeneralTracks'
 AlcaBeamMonitor.BeamFitter.TrackQuality    = ['highPurity']
 AlcaBeamMonitor.PVFitter.VertexCollection  = 'hiSelectedVertex'
 #Check if perLSsaving is enabled to mask MEs vs LS
-from DQMServices.Core.DQMStore_cfi import DQMStore
-if(DQMStore.saveByLumi):
-      AlcaBeamMonitor.perLSsaving=True
+from Configuration.ProcessModifiers.perLSsaving_cff import perLSsaving
+perLSsaving.toModify(AlcaBeamMonitor, perLSsaving=True)
+
 import RecoVertex.BeamSpotProducer.BeamSpotOnline_cfi
 scalerBeamSpot = RecoVertex.BeamSpotProducer.BeamSpotOnline_cfi.onlineBeamSpotProducer.clone()
 alcaBeamMonitor = cms.Sequence( scalerBeamSpot*AlcaBeamMonitor )

--- a/DQM/BeamMonitor/python/AlcaBeamMonitor_cff.py
+++ b/DQM/BeamMonitor/python/AlcaBeamMonitor_cff.py
@@ -2,8 +2,8 @@ import FWCore.ParameterSet.Config as cms
 
 from DQM.BeamMonitor.AlcaBeamMonitor_cfi import *
 #Check if perLSsaving is enabled to mask MEs vs LS
-from Configuration.ProcessModifiers.perLSsaving_cff import perLSsaving
-perLSsaving.toModify(AlcaBeamMonitor, perLSsaving=True)
+from Configuration.ProcessModifiers.dqmPerLSsaving_cff import dqmPerLSsaving
+dqmPerLSsaving.toModify(AlcaBeamMonitor, perLSsaving=True)
 
 import RecoVertex.BeamSpotProducer.BeamSpotOnline_cfi
 scalerBeamSpot = RecoVertex.BeamSpotProducer.BeamSpotOnline_cfi.onlineBeamSpotProducer.clone()

--- a/DQM/BeamMonitor/python/AlcaBeamMonitor_cff.py
+++ b/DQM/BeamMonitor/python/AlcaBeamMonitor_cff.py
@@ -2,9 +2,8 @@ import FWCore.ParameterSet.Config as cms
 
 from DQM.BeamMonitor.AlcaBeamMonitor_cfi import *
 #Check if perLSsaving is enabled to mask MEs vs LS
-from DQMServices.Core.DQMStore_cfi import DQMStore
-if(DQMStore.saveByLumi):
-    AlcaBeamMonitor.perLSsaving=True
+from Configuration.ProcessModifiers.perLSsaving_cff import perLSsaving
+perLSsaving.toModify(AlcaBeamMonitor, perLSsaving=True)
 
 import RecoVertex.BeamSpotProducer.BeamSpotOnline_cfi
 scalerBeamSpot = RecoVertex.BeamSpotProducer.BeamSpotOnline_cfi.onlineBeamSpotProducer.clone()

--- a/DQM/CTPPS/python/ctppsDQM_cff.py
+++ b/DQM/CTPPS/python/ctppsDQM_cff.py
@@ -50,11 +50,10 @@ ctppsCommonDQMSourceOffline = ctppsCommonDQMSource.clone(
 )
 
 #Check if perLSsaving is enabled to mask MEs vs LS
-from DQMServices.Core.DQMStore_cfi import DQMStore
-if(DQMStore.saveByLumi):
-    ctppsDiamondDQMSource.perLSsaving=True
-    totemTimingDQMSource.perLSsaving=True
-    ctppsCommonDQMSourceOffline.perLSsaving=True
+from Configuration.ProcessModifiers.perLSsaving_cff import perLSsaving
+perLSsaving.toModify(ctppsDiamondDQMSource, perLSsaving=True)
+perLSsaving.toModify(totemTimingDQMSource, perLSsaving=True)
+perLSsaving.toModify(ctppsCommonDQMSourceOffline, perLSsaving=True)
 
 _ctppsDQMOfflineSource = cms.Sequence(
   ctppsPixelDQMOfflineSource

--- a/DQM/CTPPS/python/ctppsDQM_cff.py
+++ b/DQM/CTPPS/python/ctppsDQM_cff.py
@@ -50,10 +50,10 @@ ctppsCommonDQMSourceOffline = ctppsCommonDQMSource.clone(
 )
 
 #Check if perLSsaving is enabled to mask MEs vs LS
-from Configuration.ProcessModifiers.perLSsaving_cff import perLSsaving
-perLSsaving.toModify(ctppsDiamondDQMSource, perLSsaving=True)
-perLSsaving.toModify(totemTimingDQMSource, perLSsaving=True)
-perLSsaving.toModify(ctppsCommonDQMSourceOffline, perLSsaving=True)
+from Configuration.ProcessModifiers.dqmPerLSsaving_cff import dqmPerLSsaving
+dqmPerLSsaving.toModify(ctppsDiamondDQMSource, perLSsaving=True)
+dqmPerLSsaving.toModify(totemTimingDQMSource, perLSsaving=True)
+dqmPerLSsaving.toModify(ctppsCommonDQMSourceOffline, perLSsaving=True)
 
 _ctppsDQMOfflineSource = cms.Sequence(
   ctppsPixelDQMOfflineSource

--- a/DQM/EcalPreshowerMonitorModule/python/es_dqm_source_offline_cff.py
+++ b/DQM/EcalPreshowerMonitorModule/python/es_dqm_source_offline_cff.py
@@ -3,9 +3,9 @@ import FWCore.ParameterSet.Config as cms
 from DQM.EcalPreshowerMonitorModule.ESRawDataTask_cfi import *
 from DQM.EcalPreshowerMonitorModule.ESIntegrityTask_cfi import *
 #Check if perLSsaving is enabled to mask MEs vs LS
-from DQMServices.Core.DQMStore_cfi import DQMStore
-if(not DQMStore.saveByLumi):
-    ecalPreshowerIntegrityTask.DoLumiAnalysis = True
+from Configuration.ProcessModifiers.perLSsaving_cff import perLSsaving
+perLSsaving.toModify(ecalPreshowerIntegrityTask, DoLumiAnalysis = False)
+
 from DQM.EcalPreshowerMonitorModule.ESFEDIntegrityTask_cfi import *
 from DQM.EcalPreshowerMonitorModule.ESOccupancyTask_cfi import *
 from DQM.EcalPreshowerMonitorModule.ESTrendTask_cfi import *

--- a/DQM/EcalPreshowerMonitorModule/python/es_dqm_source_offline_cff.py
+++ b/DQM/EcalPreshowerMonitorModule/python/es_dqm_source_offline_cff.py
@@ -2,6 +2,8 @@ import FWCore.ParameterSet.Config as cms
 
 from DQM.EcalPreshowerMonitorModule.ESRawDataTask_cfi import *
 from DQM.EcalPreshowerMonitorModule.ESIntegrityTask_cfi import *
+ecalPreshowerIntegrityTask.DoLumiAnalysis = True
+
 #Check if perLSsaving is enabled to mask MEs vs LS
 from Configuration.ProcessModifiers.dqmPerLSsaving_cff import dqmPerLSsaving
 dqmPerLSsaving.toModify(ecalPreshowerIntegrityTask, DoLumiAnalysis = False)

--- a/DQM/EcalPreshowerMonitorModule/python/es_dqm_source_offline_cff.py
+++ b/DQM/EcalPreshowerMonitorModule/python/es_dqm_source_offline_cff.py
@@ -3,8 +3,8 @@ import FWCore.ParameterSet.Config as cms
 from DQM.EcalPreshowerMonitorModule.ESRawDataTask_cfi import *
 from DQM.EcalPreshowerMonitorModule.ESIntegrityTask_cfi import *
 #Check if perLSsaving is enabled to mask MEs vs LS
-from Configuration.ProcessModifiers.perLSsaving_cff import perLSsaving
-perLSsaving.toModify(ecalPreshowerIntegrityTask, DoLumiAnalysis = False)
+from Configuration.ProcessModifiers.dqmPerLSsaving_cff import dqmPerLSsaving
+dqmPerLSsaving.toModify(ecalPreshowerIntegrityTask, DoLumiAnalysis = False)
 
 from DQM.EcalPreshowerMonitorModule.ESFEDIntegrityTask_cfi import *
 from DQM.EcalPreshowerMonitorModule.ESOccupancyTask_cfi import *

--- a/DQM/L1TMonitor/python/L1TEmulatorMonitor_cff.py
+++ b/DQM/L1TMonitor/python/L1TEmulatorMonitor_cff.py
@@ -38,8 +38,8 @@ from DQM.L1TMonitor.L1TdeStage1Layer2_cfi import *
 
 from DQM.L1TMonitor.L1TdeRCT_cfi import *
 #Check if perLSsaving is enabled to mask MEs vs LS
-from Configuration.ProcessModifiers.perLSsaving_cff import perLSsaving
-perLSsaving.toModify(l1TdeRCT, perLSsaving=True)
+from Configuration.ProcessModifiers.dqmPerLSsaving_cff import dqmPerLSsaving
+dqmPerLSsaving.toModify(l1TdeRCT, perLSsaving=True)
 
 l1TdeRCTRun1 = l1TdeRCT.clone()
 l1TdeRCT.rctSourceData = 'caloStage1Digis'

--- a/DQM/L1TMonitor/python/L1TEmulatorMonitor_cff.py
+++ b/DQM/L1TMonitor/python/L1TEmulatorMonitor_cff.py
@@ -38,9 +38,8 @@ from DQM.L1TMonitor.L1TdeStage1Layer2_cfi import *
 
 from DQM.L1TMonitor.L1TdeRCT_cfi import *
 #Check if perLSsaving is enabled to mask MEs vs LS
-from DQMServices.Core.DQMStore_cfi import DQMStore
-if(DQMStore.saveByLumi):
-    l1TdeRCT.perLSsaving=True
+from Configuration.ProcessModifiers.perLSsaving_cff import perLSsaving
+perLSsaving.toModify(l1TdeRCT, perLSsaving=True)
 
 l1TdeRCTRun1 = l1TdeRCT.clone()
 l1TdeRCT.rctSourceData = 'caloStage1Digis'

--- a/DQM/SiPixelCommon/python/SiPixelOfflineDQM_source_cff.py
+++ b/DQM/SiPixelCommon/python/SiPixelOfflineDQM_source_cff.py
@@ -116,9 +116,8 @@ dqmInfo = DQMEDAnalyzer('DQMEventInfo',
 )
 
 #Check if perLSsaving is enabled to mask MEs vs LS
-from DQMServices.Core.DQMStore_cfi import DQMStore
-if(DQMStore.saveByLumi):
-    SiPixelDigiSource.perLSsaving=True
+from Configuration.ProcessModifiers.perLSsaving_cff import perLSsaving
+perLSsaving.toModify(SiPixelDigiSource, perLSsaving=True)
 
 #FED integrity
 from DQM.SiPixelMonitorRawData.SiPixelMonitorHLT_cfi import *

--- a/DQM/SiPixelCommon/python/SiPixelOfflineDQM_source_cff.py
+++ b/DQM/SiPixelCommon/python/SiPixelOfflineDQM_source_cff.py
@@ -116,8 +116,8 @@ dqmInfo = DQMEDAnalyzer('DQMEventInfo',
 )
 
 #Check if perLSsaving is enabled to mask MEs vs LS
-from Configuration.ProcessModifiers.perLSsaving_cff import perLSsaving
-perLSsaving.toModify(SiPixelDigiSource, perLSsaving=True)
+from Configuration.ProcessModifiers.dqmPerLSsaving_cff import dqmPerLSsaving
+dqmPerLSsaving.toModify(SiPixelDigiSource, perLSsaving=True)
 
 #FED integrity
 from DQM.SiPixelMonitorRawData.SiPixelMonitorHLT_cfi import *

--- a/DQMOffline/Configuration/python/ALCARECOHcalCalDQMHI_cff.py
+++ b/DQMOffline/Configuration/python/ALCARECOHcalCalDQMHI_cff.py
@@ -7,7 +7,7 @@ import DQMOffline.CalibCalo.MonitorHcalIsolatedBunchAlCaReco_cfi
 import DQMOffline.CalibCalo.MonitorHOAlCaRecoStream_cfi
 
 #Check if perLSsaving is enabled to mask MEs vs LS
-from Configuration.ProcessModifiers.perLSsavin_cff import dqmPerLSsaving
+from Configuration.ProcessModifiers.dqmPerLSsaving_cff import dqmPerLSsaving
 dqmPerLSsaving.toModify(DQMOffline.CalibCalo.MonitorAlCaHcalPhisym_cfi.HcalPhiSymMon, perLSsaving=True)
 
 ALCARECOHcalCalPhisymDQM =  DQMOffline.CalibCalo.MonitorAlCaHcalPhisym_cfi.HcalPhiSymMon.clone()

--- a/DQMOffline/Configuration/python/ALCARECOHcalCalDQMHI_cff.py
+++ b/DQMOffline/Configuration/python/ALCARECOHcalCalDQMHI_cff.py
@@ -7,9 +7,8 @@ import DQMOffline.CalibCalo.MonitorHcalIsolatedBunchAlCaReco_cfi
 import DQMOffline.CalibCalo.MonitorHOAlCaRecoStream_cfi
 
 #Check if perLSsaving is enabled to mask MEs vs LS
-from DQMServices.Core.DQMStore_cfi import DQMStore
-if(DQMStore.saveByLumi):
-    DQMOffline.CalibCalo.MonitorAlCaHcalPhisym_cfi.HcalPhiSymMon.perLSsaving=True
+from Configuration.ProcessModifiers.perLSsavin_cff import perLSsaving
+perLSsaving.toModify(DQMOffline.CalibCalo.MonitorAlCaHcalPhisym_cfi.HcalPhiSymMon, perLSsaving=True)
 
 ALCARECOHcalCalPhisymDQM =  DQMOffline.CalibCalo.MonitorAlCaHcalPhisym_cfi.HcalPhiSymMon.clone()
 

--- a/DQMOffline/Configuration/python/ALCARECOHcalCalDQMHI_cff.py
+++ b/DQMOffline/Configuration/python/ALCARECOHcalCalDQMHI_cff.py
@@ -7,8 +7,8 @@ import DQMOffline.CalibCalo.MonitorHcalIsolatedBunchAlCaReco_cfi
 import DQMOffline.CalibCalo.MonitorHOAlCaRecoStream_cfi
 
 #Check if perLSsaving is enabled to mask MEs vs LS
-from Configuration.ProcessModifiers.perLSsavin_cff import perLSsaving
-perLSsaving.toModify(DQMOffline.CalibCalo.MonitorAlCaHcalPhisym_cfi.HcalPhiSymMon, perLSsaving=True)
+from Configuration.ProcessModifiers.perLSsavin_cff import dqmPerLSsaving
+dqmPerLSsaving.toModify(DQMOffline.CalibCalo.MonitorAlCaHcalPhisym_cfi.HcalPhiSymMon, perLSsaving=True)
 
 ALCARECOHcalCalPhisymDQM =  DQMOffline.CalibCalo.MonitorAlCaHcalPhisym_cfi.HcalPhiSymMon.clone()
 

--- a/DQMOffline/Configuration/python/ALCARECOHcalCalDQM_cff.py
+++ b/DQMOffline/Configuration/python/ALCARECOHcalCalDQM_cff.py
@@ -7,9 +7,8 @@ import DQMOffline.CalibCalo.MonitorHcalIsolatedBunchAlCaReco_cfi
 import DQMOffline.CalibCalo.MonitorHOAlCaRecoStream_cfi
 
 #Check if perLSsaving is enabled to mask MEs vs LS
-from DQMServices.Core.DQMStore_cfi import DQMStore
-if(DQMStore.saveByLumi):
-    DQMOffline.CalibCalo.MonitorAlCaHcalPhisym_cfi.HcalPhiSymMon.perLSsaving=True
+from Configuration.ProcessModifiers.perLSsaving_cff import perLSsaving
+perLSsaving.toModify(DQMOffline.CalibCalo.MonitorAlCaHcalPhisym_cfi.HcalPhiSymMon, perLSsaving=True)
 
 ALCARECOHcalCalPhisymDQM =  DQMOffline.CalibCalo.MonitorAlCaHcalPhisym_cfi.HcalPhiSymMon.clone()
 

--- a/DQMOffline/Configuration/python/ALCARECOHcalCalDQM_cff.py
+++ b/DQMOffline/Configuration/python/ALCARECOHcalCalDQM_cff.py
@@ -7,8 +7,8 @@ import DQMOffline.CalibCalo.MonitorHcalIsolatedBunchAlCaReco_cfi
 import DQMOffline.CalibCalo.MonitorHOAlCaRecoStream_cfi
 
 #Check if perLSsaving is enabled to mask MEs vs LS
-from Configuration.ProcessModifiers.perLSsaving_cff import perLSsaving
-perLSsaving.toModify(DQMOffline.CalibCalo.MonitorAlCaHcalPhisym_cfi.HcalPhiSymMon, perLSsaving=True)
+from Configuration.ProcessModifiers.dqmPerLSsaving_cff import dqmPerLSsaving
+dqmPerLSsaving.toModify(DQMOffline.CalibCalo.MonitorAlCaHcalPhisym_cfi.HcalPhiSymMon, perLSsaving=True)
 
 ALCARECOHcalCalPhisymDQM =  DQMOffline.CalibCalo.MonitorAlCaHcalPhisym_cfi.HcalPhiSymMon.clone()
 

--- a/DQMOffline/Trigger/python/DQMOffline_Trigger_cff.py
+++ b/DQMOffline/Trigger/python/DQMOffline_Trigger_cff.py
@@ -72,9 +72,8 @@ from DQMOffline.Trigger.HiggsMonitoring_cff import *
 # photon jet
 from DQMOffline.Trigger.HigPhotonJetHLTOfflineSource_cfi import * # ?!?!?!
 #Check if perLSsaving is enabled to mask MEs vs LS
-from DQMServices.Core.DQMStore_cfi import DQMStore
-if(DQMStore.saveByLumi):
-   higPhotonJetHLTOfflineSource.perLSsaving=True
+from Configuration.ProcessModifiers.perLSsaving_cff import perLSsaving
+perLSsaving.toModify(higPhotonJetHLTOfflineSource, perLSsaving=True)
 # SMP
 from DQMOffline.Trigger.StandardModelMonitoring_cff import *
 

--- a/DQMOffline/Trigger/python/DQMOffline_Trigger_cff.py
+++ b/DQMOffline/Trigger/python/DQMOffline_Trigger_cff.py
@@ -72,8 +72,8 @@ from DQMOffline.Trigger.HiggsMonitoring_cff import *
 # photon jet
 from DQMOffline.Trigger.HigPhotonJetHLTOfflineSource_cfi import * # ?!?!?!
 #Check if perLSsaving is enabled to mask MEs vs LS
-from Configuration.ProcessModifiers.perLSsaving_cff import perLSsaving
-perLSsaving.toModify(higPhotonJetHLTOfflineSource, perLSsaving=True)
+from Configuration.ProcessModifiers.dqmPerLSsaving_cff import dqmPerLSsaving
+dqmPerLSsaving.toModify(higPhotonJetHLTOfflineSource, perLSsaving=True)
 # SMP
 from DQMOffline.Trigger.StandardModelMonitoring_cff import *
 


### PR DESCRIPTION
#### PR description:
After the creation of pseudo data-Tier nanoDQMIO in:
https://github.com/cms-sw/cmssw/pull/34220 
and
https://github.com/cms-sw/cmssw/pull/34301
It was suggested by @makortel (Thank you!!!) to use a Modifier instead ( https://github.com/cms-sw/cmssw/pull/34301#discussion_r668365442)

This PR introduces the dqmPerLSsaving Modifier and files which need to make use of it

So now in addition to
--customise_commands=process.DQMStore.saveByLumi = cms.untracked.bool(True)
one must set
--procModifiers=dqmPerLSsaving
at cmsDriver.py config

https://twiki.cern.ch/twiki/bin/view/CMS/PerLsDQMIO#nanoDQMIO_data_Tier

No changes expected in this PR since perLSsaving reamins switched off by default.

#### PR validation:

Tested locally with wfs 1000.0,4.22,4.17,18.0,136.858,4.37,136.8862,136.727,136.7801 with an equivalent config to this:

cmsDriver.py step2 -s DQM--datatier DQMIO --eventcontent DQM --data --customise_commands="process.DQMStore.saveByLumi = cms.untracked.bool(True)" --procModifiers=dqmPerLSsaving


