### PR TITLE
Fix MessageLogger format outside modules

### DIFF
--- a/FWCore/MessageService/plugins/MessageLogger.cc
+++ b/FWCore/MessageService/plugins/MessageLogger.cc
@@ -88,7 +88,7 @@ namespace {
     auto e = fill_buffer(buffer.begin(), buffer.end(), std::forward<T>(t)...);
     assert(e < buffer.end());
     *e = 0;
-    return std::string_view(buffer.begin(), e - buffer.begin() + 1);
+    return std::string_view(buffer.begin(), e - buffer.begin());
   }
 
 }  // namespace

--- a/FWCore/MessageService/test/u33_cfg.py
+++ b/FWCore/MessageService/test/u33_cfg.py
@@ -6,6 +6,10 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("TEST")
 
+process.TestService = cms.Service("TestService",
+  printTestMessageLoggerErrors = cms.untracked.bool(True)
+)
+
 import FWCore.Framework.test.cmsExceptionsFatal_cff
 process.options = FWCore.Framework.test.cmsExceptionsFatal_cff.options
 

--- a/FWCore/MessageService/test/unit_test_outputs/u33_all.log
+++ b/FWCore/MessageService/test/unit_test_outputs/u33_all.log
@@ -4,17 +4,26 @@ T1 beginJob warning with identifier 11 event 0
 %MSG-w cat_BJ:  UTC_V1:ssm_1b@beginJob pre-events
 T1 beginJob warning with identifier 12 event 0
 %MSG
+%MSG-e TestMessageLogger:  BeginProcessBlock pre-events
+test message from TestService::preBeginProcessBlock
+%MSG
 %MSG-i cat_BPB:  UTC_V1:ssm_1a@beginProcessBlock pre-events
 T1 beginProcessBlock info with identifier 11 event 0
 %MSG
 %MSG-i cat_BPB:  UTC_V1:ssm_1b@beginProcessBlock pre-events
 T1 beginProcessBlock info with identifier 12 event 0
 %MSG
+%MSG-e TestMessageLogger:  PreGlobalBeginRun Run: 1
+test message from TestService::preGlobalBeginRun
+%MSG
 %MSG-i cat_BR:  UTC_V1:ssm_1a@beginRun Run: 1
 T1 beginRun info with identifier 11 event 0
 %MSG
 %MSG-i cat_BR:  UTC_V1:ssm_1b@beginRun Run: 1
 T1 beginRun info with identifier 12 event 0
+%MSG
+%MSG-e TestMessageLogger:  PreGlobalBeginLumi Run: 1 Lumi: 1
+test message from TestService::preGlobalBeginLumi
 %MSG
 %MSG-w cat_BL:  UTC_V1:ssm_1a@beginLumi Run: 1 Lumi: 1
 T1 beginLumi warning with identifier 11 event 0
@@ -90,6 +99,15 @@ T1 analyze warning with identifier 22 event 1
 %MSG-i cat_A:  UTC_V2:ssm_2b Run: 1 Event: 2
 T1 analyze info with identifier 22 event 1
 %MSG
+%MSG-e TestMessageLogger:  PreGlobalEndLumi Run: 1 Lumi: 1
+test message from TestService::preGlobalEndLumi
+%MSG
+%MSG-e TestMessageLogger:  PreGlobalEndRun End Run: 1
+test message from TestService::preGlobalEndRun
+%MSG
+%MSG-e TestMessageLogger:  EndProcessBlock post-events
+test message from TestService::preEndProcessBlock
+%MSG
 %MSG-i cat_EPB:  UTC_V1:ssm_1a@endProcessBlock post-events
 T1 endProcessBlock info with identifier 11 event 2
 %MSG
@@ -121,10 +139,16 @@ MessageLogger Summary
    16 cat_BJ               -w UTC_V1:ssm_1b@be                       1        1
    17 cat_BL               -w UTC_V1:ssm_1a@be                       1        1
    18 cat_BL               -w UTC_V1:ssm_1b@be                       1        1
-   19 cat_A                -e UTC_V1:ssm_1a                          2        2
-   20 cat_A                -e UTC_V1:ssm_1b                          2        2
-   21 cat_A                -e UTC_V2:ssm_2a                          2        2
-   22 cat_A                -e UTC_V2:ssm_2b                          2        2
+   19 TestMessageLogger    -e BeginProcessBloc                       1        1
+   20 TestMessageLogger    -e EndProcessBlock                        1        1
+   21 TestMessageLogger    -e PreGlobalBeginLu                       1        1
+   22 TestMessageLogger    -e PreGlobalBeginRu                       1        1
+   23 TestMessageLogger    -e PreGlobalEndLumi                       1        1
+   24 TestMessageLogger    -e PreGlobalEndRun                        1        1
+   25 cat_A                -e UTC_V1:ssm_1a                          2        2
+   26 cat_A                -e UTC_V1:ssm_1b                          2        2
+   27 cat_A                -e UTC_V2:ssm_2a                          2        2
+   28 cat_A                -e UTC_V2:ssm_2b                          2        2
 
  type    category    Examples: run/evt        run/evt          run/evt
  ---- -------------------- ---------------- ---------------- ----------------
@@ -146,16 +170,22 @@ MessageLogger Summary
    16 cat_BJ               pre-events                        
    17 cat_BL               Run: 1 Lumi: 1                    
    18 cat_BL               Run: 1 Lumi: 1                    
-   19 cat_A                1/1              1/2              
-   20 cat_A                1/1              1/2              
-   21 cat_A                1/1              1/2              
-   22 cat_A                1/1              1/2              
+   19 TestMessageLogger    pre-events                        
+   20 TestMessageLogger    post-events                       
+   21 TestMessageLogger    Run: 1 Lumi: 1                    
+   22 TestMessageLogger    Run: 1                            
+   23 TestMessageLogger    Run: 1 Lumi: 1                    
+   24 TestMessageLogger    End Run: 1                        
+   25 cat_A                1/1              1/2              
+   26 cat_A                1/1              1/2              
+   27 cat_A                1/1              1/2              
+   28 cat_A                1/1              1/2              
 
 Severity    # Occurrences   Total Occurrences
 --------    -------------   -----------------
 Info                   12                  12
 FwkInfo                 2                   2
 Warning                12                  12
-Error                   8                   8
+Error                  14                  14
 
 dropped waiting message count 0

--- a/FWCore/Services/plugins/TestService.cc
+++ b/FWCore/Services/plugins/TestService.cc
@@ -1,0 +1,108 @@
+// -*- C++ -*-
+//
+// Package:     Services
+// Class  :     TestService
+//
+// Implementation:
+//     <Notes on implementation>
+//
+// Original Author:  W. David Dagenhart
+//         Created:  14 July 2021
+
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/ServiceRegistry/interface/ActivityRegistry.h"
+#include "FWCore/ServiceRegistry/interface/GlobalContext.h"
+#include "FWCore/ServiceRegistry/interface/ServiceMaker.h"
+
+namespace edm {
+  namespace service {
+
+    class TestService {
+    public:
+      TestService(const ParameterSet&, ActivityRegistry&);
+
+      static void fillDescriptions(edm::ConfigurationDescriptions&);
+
+      void preBeginProcessBlock(GlobalContext const&);
+
+      void preEndProcessBlock(GlobalContext const&);
+
+      void preGlobalBeginRun(GlobalContext const&);
+
+      void preGlobalEndRun(GlobalContext const&);
+
+      void preGlobalBeginLumi(GlobalContext const&);
+
+      void preGlobalEndLumi(GlobalContext const&);
+
+    private:
+      bool printTestMessageLoggerErrors_;
+    };
+  }  // namespace service
+}  // namespace edm
+
+using namespace edm::service;
+
+TestService::TestService(ParameterSet const& iPS, ActivityRegistry& iRegistry)
+    : printTestMessageLoggerErrors_(iPS.getUntrackedParameter<bool>("printTestMessageLoggerErrors")) {
+  iRegistry.watchPreBeginProcessBlock(this, &TestService::preBeginProcessBlock);
+
+  iRegistry.watchPreEndProcessBlock(this, &TestService::preEndProcessBlock);
+
+  iRegistry.watchPreGlobalBeginRun(this, &TestService::preGlobalBeginRun);
+
+  iRegistry.watchPreGlobalEndRun(this, &TestService::preGlobalEndRun);
+
+  iRegistry.watchPreGlobalBeginLumi(this, &TestService::preGlobalBeginLumi);
+
+  iRegistry.watchPreGlobalEndLumi(this, &TestService::preGlobalEndLumi);
+}
+
+void TestService::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.addUntracked<bool>("printTestMessageLoggerErrors", false)
+      ->setComment("Prints MessageLogger errors to test formatting of such messages when printed from Services");
+  descriptions.add("TestService", desc);
+}
+
+void TestService::preBeginProcessBlock(GlobalContext const&) {
+  if (printTestMessageLoggerErrors_) {
+    edm::LogError("TestMessageLogger") << "test message from TestService::preBeginProcessBlock";
+  }
+}
+
+void TestService::preEndProcessBlock(GlobalContext const&) {
+  if (printTestMessageLoggerErrors_) {
+    edm::LogError("TestMessageLogger") << "test message from TestService::preEndProcessBlock";
+  }
+}
+
+void TestService::preGlobalBeginRun(GlobalContext const&) {
+  if (printTestMessageLoggerErrors_) {
+    edm::LogError("TestMessageLogger") << "test message from TestService::preGlobalBeginRun";
+  }
+}
+
+void TestService::preGlobalEndRun(GlobalContext const&) {
+  if (printTestMessageLoggerErrors_) {
+    edm::LogError("TestMessageLogger") << "test message from TestService::preGlobalEndRun";
+  }
+}
+
+void TestService::preGlobalBeginLumi(GlobalContext const& gc) {
+  if (printTestMessageLoggerErrors_) {
+    edm::LogError("TestMessageLogger") << "test message from TestService::preGlobalBeginLumi";
+  }
+}
+
+void TestService::preGlobalEndLumi(GlobalContext const& gc) {
+  if (printTestMessageLoggerErrors_) {
+    edm::LogError("TestMessageLogger") << "test message from TestService::preGlobalEndLumi";
+  }
+}
+
+using edm::service::TestService;
+DEFINE_FWK_SERVICE(TestService);


### PR DESCRIPTION
#### PR description:

In some unusual contexts, the MessageLogger is printing an extra invisible character (a C style string terminator) at the end of the context part of MessageLogger printout. This occurs in non-Module contexts (some of them, not all) like in some Service transitions and directly in Framework code. This removes that extra character.

#### PR validation:

An existing unit test is extended to cover this case.
