### PR TITLE
Introduce L1TMuonBarrelKalmanParams and Record

### DIFF
--- a/CondCore/L1TPlugins/src/UpgradeRecords2.cc
+++ b/CondCore/L1TPlugins/src/UpgradeRecords2.cc
@@ -19,9 +19,10 @@
 #include "CondFormats/DataRecord/interface/L1TMuonOverlapParamsO2ORcd.h"
 
 #include "CondFormats/L1TObjects/interface/L1TMuonBarrelParams.h"
-#include "CondFormats/L1TObjects/interface/L1TMuonBarrelKalmanParams.h"
 #include "CondFormats/DataRecord/interface/L1TMuonBarrelParamsRcd.h"
 #include "CondFormats/DataRecord/interface/L1TMuonBarrelParamsO2ORcd.h"
+#include "CondFormats/L1TObjects/interface/L1TMuonBarrelKalmanParams.h"
+#include "CondFormats/DataRecord/interface/L1TMuonBarrelKalmanParamsRcd.h"
 
 #include "CondFormats/L1TObjects/interface/L1TMuonGlobalParams.h"
 #include "CondFormats/DataRecord/interface/L1TMuonGlobalParamsRcd.h"

--- a/CondCore/L1TPlugins/src/UpgradeRecords2.cc
+++ b/CondCore/L1TPlugins/src/UpgradeRecords2.cc
@@ -19,6 +19,7 @@
 #include "CondFormats/DataRecord/interface/L1TMuonOverlapParamsO2ORcd.h"
 
 #include "CondFormats/L1TObjects/interface/L1TMuonBarrelParams.h"
+#include "CondFormats/L1TObjects/interface/L1TMuonBarrelKalmanParams.h"
 #include "CondFormats/DataRecord/interface/L1TMuonBarrelParamsRcd.h"
 #include "CondFormats/DataRecord/interface/L1TMuonBarrelParamsO2ORcd.h"
 
@@ -32,6 +33,7 @@ REGISTER_PLUGIN(L1TMuonEndCapParamsRcd, L1TMuonEndCapParams);
 REGISTER_PLUGIN(L1TMuonEndCapForestRcd, L1TMuonEndCapForest);
 REGISTER_PLUGIN(L1TMuonOverlapParamsRcd, L1TMuonOverlapParams);
 REGISTER_PLUGIN(L1TMuonBarrelParamsRcd, L1TMuonBarrelParams);
+REGISTER_PLUGIN(L1TMuonBarrelKalmanParamsRcd, L1TMuonBarrelKalmanParams);
 REGISTER_PLUGIN(L1TMuonGlobalParamsRcd, L1TMuonGlobalParams);
 
 REGISTER_PLUGIN(L1TMuonEndCapParamsO2ORcd, L1TMuonEndCapParams);

--- a/CondFormats/DataRecord/interface/L1TMuonBarrelKalmanParamsRcd.h
+++ b/CondFormats/DataRecord/interface/L1TMuonBarrelKalmanParamsRcd.h
@@ -1,0 +1,16 @@
+#ifndef L1TBMTFKalmanParamsRcd_L1TBMTFKalmanParamsRcd_h
+#define L1TBMTFKalmanParamsRcd_L1TBMTFKalmanParamsRcd_h
+// -*- C++ -*-
+//
+// Class  :     L1TMuonBarrelKalmanParamsRcd
+//
+// Author:      Panos Katsoulis
+// Created:
+//
+
+#include "FWCore/Framework/interface/EventSetupRecordImplementation.h"
+
+class L1TMuonBarrelKalmanParamsRcd
+    : public edm::eventsetup::EventSetupRecordImplementation<L1TMuonBarrelKalmanParamsRcd> {};
+
+#endif

--- a/CondFormats/DataRecord/interface/L1TMuonBarrelParamsRcd.h
+++ b/CondFormats/DataRecord/interface/L1TMuonBarrelParamsRcd.h
@@ -5,11 +5,15 @@
 // Class  :     L1TMuonBarrelParamsRcd
 //
 // Author:      Giannis Flouris
+// Kalman Mod:  Panos Katsoulis
 // Created:
 //
 
 #include "FWCore/Framework/interface/EventSetupRecordImplementation.h"
 
 class L1TMuonBarrelParamsRcd : public edm::eventsetup::EventSetupRecordImplementation<L1TMuonBarrelParamsRcd> {};
+
+class L1TMuonBarrelKalmanParamsRcd :
+public edm::eventsetup::EventSetupRecordImplementation<L1TMuonBarrelKalmanParamsRcd> {};
 
 #endif

--- a/CondFormats/DataRecord/interface/L1TMuonBarrelParamsRcd.h
+++ b/CondFormats/DataRecord/interface/L1TMuonBarrelParamsRcd.h
@@ -13,7 +13,7 @@
 
 class L1TMuonBarrelParamsRcd : public edm::eventsetup::EventSetupRecordImplementation<L1TMuonBarrelParamsRcd> {};
 
-class L1TMuonBarrelKalmanParamsRcd
-    : public edm::eventsetup::EventSetupRecordImplementation<L1TMuonBarrelKalmanParamsRcd> {};
+class L1TMuonBarrelKalmanParamsRcd :
+public edm::eventsetup::EventSetupRecordImplementation<L1TMuonBarrelKalmanParamsRcd> {};
 
 #endif

--- a/CondFormats/DataRecord/interface/L1TMuonBarrelParamsRcd.h
+++ b/CondFormats/DataRecord/interface/L1TMuonBarrelParamsRcd.h
@@ -13,7 +13,4 @@
 
 class L1TMuonBarrelParamsRcd : public edm::eventsetup::EventSetupRecordImplementation<L1TMuonBarrelParamsRcd> {};
 
-class L1TMuonBarrelKalmanParamsRcd :
-public edm::eventsetup::EventSetupRecordImplementation<L1TMuonBarrelKalmanParamsRcd> {};
-
 #endif

--- a/CondFormats/DataRecord/interface/L1TMuonBarrelParamsRcd.h
+++ b/CondFormats/DataRecord/interface/L1TMuonBarrelParamsRcd.h
@@ -13,7 +13,7 @@
 
 class L1TMuonBarrelParamsRcd : public edm::eventsetup::EventSetupRecordImplementation<L1TMuonBarrelParamsRcd> {};
 
-class L1TMuonBarrelKalmanParamsRcd :
-public edm::eventsetup::EventSetupRecordImplementation<L1TMuonBarrelKalmanParamsRcd> {};
+class L1TMuonBarrelKalmanParamsRcd
+    : public edm::eventsetup::EventSetupRecordImplementation<L1TMuonBarrelKalmanParamsRcd> {};
 
 #endif

--- a/CondFormats/DataRecord/src/L1TMuonBarrelKalmanParamsRcd.cc
+++ b/CondFormats/DataRecord/src/L1TMuonBarrelKalmanParamsRcd.cc
@@ -1,0 +1,12 @@
+// -*- C++ -*-
+//
+// Package:     Subsystem/Package
+// Class  :     L1TMuonBarrelKalmanParamsRcd
+//
+// Author:      Panos Katsoulis
+// Created:
+
+#include "CondFormats/DataRecord/interface/L1TMuonBarrelKalmanParamsRcd.h"
+#include "FWCore/Framework/interface/eventsetuprecord_registration_macro.h"
+
+EVENTSETUP_RECORD_REG(L1TMuonBarrelKalmanParamsRcd);

--- a/CondFormats/DataRecord/src/L1TMuonBarrelParamsRcd.cc
+++ b/CondFormats/DataRecord/src/L1TMuonBarrelParamsRcd.cc
@@ -10,4 +10,3 @@
 #include "FWCore/Framework/interface/eventsetuprecord_registration_macro.h"
 
 EVENTSETUP_RECORD_REG(L1TMuonBarrelParamsRcd);
-EVENTSETUP_RECORD_REG(L1TMuonBarrelKalmanParamsRcd);

--- a/CondFormats/DataRecord/src/L1TMuonBarrelParamsRcd.cc
+++ b/CondFormats/DataRecord/src/L1TMuonBarrelParamsRcd.cc
@@ -10,3 +10,4 @@
 #include "FWCore/Framework/interface/eventsetuprecord_registration_macro.h"
 
 EVENTSETUP_RECORD_REG(L1TMuonBarrelParamsRcd);
+EVENTSETUP_RECORD_REG(L1TMuonBarrelKalmanParamsRcd);

--- a/CondFormats/L1TObjects/interface/L1TMuonBarrelKalmanParams.h
+++ b/CondFormats/L1TObjects/interface/L1TMuonBarrelKalmanParams.h
@@ -31,13 +31,13 @@ public:
     std::string kalmanLUTsPath_;
     unsigned fwVersion_;
     l1t::LUT LUT_;
-    /* std::vector<double> dparams_; */
-    /* std::vector<unsigned> uparams_; */
-    /* std::vector<int> iparams_; */
-    /* std::vector<std::string> sparams_; */
     COND_SERIALIZABLE;
   };
 
+  // for future extention
+  // Kalman TF params as (statically) defined in file
+  // L1Trigger/L1TMuonBarrel/python/simKBmtfDigis_cfi.py
+  // -------
   //enum {
   //  initialK,
   //  initialK2,

--- a/CondFormats/L1TObjects/interface/L1TMuonBarrelKalmanParams.h
+++ b/CondFormats/L1TObjects/interface/L1TMuonBarrelKalmanParams.h
@@ -15,6 +15,7 @@
 #include <vector>
 
 #include "CondFormats/Serialization/interface/Serializable.h"
+#include "CondFormats/L1TObjects/interface/L1MuDTTFMasks.h"
 #include "CondFormats/L1TObjects/interface/LUT.h"
 
 class L1TMuonBarrelKalmanParams {
@@ -34,63 +35,11 @@ public:
     COND_SERIALIZABLE;
   };
 
-  // for future extention
-  // Kalman TF params as (statically) defined in file
-  // L1Trigger/L1TMuonBarrel/python/simKBmtfDigis_cfi.py
-  // -------
-  //enum {
-  //  initialK,
-  //  initialK2,
-  //  eLoss,
-  //  aPhi,
-  //  aPhiB,
-  //  aPhiBNLO,
-  //  bPhi,
-  //  bPhiB,
-  //  phiAt2,
-  //  etaLUT0,
-  //  etaLUT1,
-  //  //generic cuts
-  //  chiSquare,
-  //  chiSquareCutPattern,
-  //  chiSquareCutCurvMax,
-  //  chiSquareCut,
-  //  //vertex cuts
-  //  trackComp,
-  //  trackCompErr1,
-  //  trackCompErr2,
-  //  trackCompCutPattern,
-  //  trackCompCutCurvMax,
-  //  trackCompCut,
-  //  chiSquareCutTight,
-  //  //combos
-  //  combos4,
-  //  combos3,
-  //  combos2,
-  //  combos1,
-  //  //
-  //  useOfflineAlgo,
-  //  // Only for the offline algo -not in firmware -------------------- (possible use in phase2 ???)
-  //  mScatteringPhi,
-  //  mScatteringPhiB,
-  //  pointResolutionPhi,
-  //  pointResolutionPhiB,
-  //  pointResolutionPhiBH,
-  //  pointResolutionPhiBL,
-  //  pointResolutionVertex,
-  //  //
-  //  NUM_CONFIG_PARAMS //to check
-  //};
-
-  // THIS SECTION IS TO BE USED FOR HANDLING THE MASKS
-  // after initial integration with downstream code, a small update will change:
-  //L1MuDTTFMasks l1mudttfmasks;
-  // to this:
-  //L1MuDTTFMasks &      l1mudttfmasks(){return l1mudttfmasks_[0]; }
-
+  L1MuDTTFMasks l1mudttfmasks;
   unsigned version_;
-  std::vector<Node> pnodes_;
 
+  std::vector<Node> pnodes_;
+  std::vector<L1MuDTTFMasks> l1mudttfmasks_;
   COND_SERIALIZABLE;
 };
 #endif

--- a/CondFormats/L1TObjects/interface/L1TMuonBarrelKalmanParams.h
+++ b/CondFormats/L1TObjects/interface/L1TMuonBarrelKalmanParams.h
@@ -1,0 +1,96 @@
+///
+/// \class L1TMuonBarrelKalmanParams
+///
+/// Description: Placeholder for Kalman BMTF parameters
+///
+///
+/// \author: Panos Katsoulis
+///
+
+#ifndef L1TBMTFKalmanParams_h
+#define L1TBMTFKalmanParams_h
+
+#include <memory>
+#include <iostream>
+#include <vector>
+
+#include "CondFormats/Serialization/interface/Serializable.h"
+#include "CondFormats/L1TObjects/interface/LUT.h"
+
+class L1TMuonBarrelKalmanParams {
+public:
+  L1TMuonBarrelKalmanParams();
+  ~L1TMuonBarrelKalmanParams() {}
+
+  enum { Version = 1 };
+  enum { CONFIG = 0, NUM_BMTF_PARAM_NODES = 2 };
+
+  class Node {
+  public:
+    std::string type_;
+    std::string kalmanLUTsPath_;
+    unsigned fwVersion_;
+    l1t::LUT LUT_;
+    /* std::vector<double> dparams_; */
+    /* std::vector<unsigned> uparams_; */
+    /* std::vector<int> iparams_; */
+    /* std::vector<std::string> sparams_; */
+    COND_SERIALIZABLE;
+  };
+
+  //enum {
+  //  initialK,
+  //  initialK2,
+  //  eLoss,
+  //  aPhi,
+  //  aPhiB,
+  //  aPhiBNLO,
+  //  bPhi,
+  //  bPhiB,
+  //  phiAt2,
+  //  etaLUT0,
+  //  etaLUT1,
+  //  //generic cuts
+  //  chiSquare,
+  //  chiSquareCutPattern,
+  //  chiSquareCutCurvMax,
+  //  chiSquareCut,
+  //  //vertex cuts
+  //  trackComp,
+  //  trackCompErr1,
+  //  trackCompErr2,
+  //  trackCompCutPattern,
+  //  trackCompCutCurvMax,
+  //  trackCompCut,
+  //  chiSquareCutTight,
+  //  //combos
+  //  combos4,
+  //  combos3,
+  //  combos2,
+  //  combos1,
+  //  //
+  //  useOfflineAlgo,
+  //  // Only for the offline algo -not in firmware -------------------- (possible use in phase2 ???)
+  //  mScatteringPhi,
+  //  mScatteringPhiB,
+  //  pointResolutionPhi,
+  //  pointResolutionPhiB,
+  //  pointResolutionPhiBH,
+  //  pointResolutionPhiBL,
+  //  pointResolutionVertex,
+  //  //
+  //  NUM_CONFIG_PARAMS //to check
+  //};
+
+  // THIS SECTION IS TO BE USED FOR HANDLING THE MASKS
+  // after initial integration with downstream code, a small update will change:
+  //L1MuDTTFMasks l1mudttfmasks;
+  // to this:
+  //L1MuDTTFMasks &      l1mudttfmasks(){return l1mudttfmasks_[0]; }
+
+  unsigned version_;
+  std::vector<Node> pnodes_;
+
+  COND_SERIALIZABLE;
+};
+#endif

--- a/CondFormats/L1TObjects/src/L1TMuonBarrelKalmanParams.cc
+++ b/CondFormats/L1TObjects/src/L1TMuonBarrelKalmanParams.cc
@@ -1,9 +1,6 @@
 #include "CondFormats/L1TObjects/interface/L1TMuonBarrelKalmanParams.h"
 
-L1TMuonBarrelKalmanParams::L1TMuonBarrelKalmanParams()
-  : pnodes_(NUM_BMTF_PARAM_NODES),
-    l1mudttfmasks_(1)
-{
+L1TMuonBarrelKalmanParams::L1TMuonBarrelKalmanParams() : pnodes_(NUM_BMTF_PARAM_NODES), l1mudttfmasks_(1) {
   version_ = Version;
   pnodes_[CONFIG].type_ = "unspecified";
   pnodes_[CONFIG].fwVersion_ = 0;  //default to recognize a RCD that is not filled

--- a/CondFormats/L1TObjects/src/L1TMuonBarrelKalmanParams.cc
+++ b/CondFormats/L1TObjects/src/L1TMuonBarrelKalmanParams.cc
@@ -1,7 +1,8 @@
 #include "CondFormats/L1TObjects/interface/L1TMuonBarrelKalmanParams.h"
 
 L1TMuonBarrelKalmanParams::L1TMuonBarrelKalmanParams()
-    : pnodes_(NUM_BMTF_PARAM_NODES)  //, l1mudttfmasks_(1) // auto masking (future)
+  : pnodes_(NUM_BMTF_PARAM_NODES),
+    l1mudttfmasks_(1)
 {
   version_ = Version;
   pnodes_[CONFIG].type_ = "unspecified";

--- a/CondFormats/L1TObjects/src/L1TMuonBarrelKalmanParams.cc
+++ b/CondFormats/L1TObjects/src/L1TMuonBarrelKalmanParams.cc
@@ -1,0 +1,11 @@
+#include "CondFormats/L1TObjects/interface/L1TMuonBarrelKalmanParams.h"
+
+L1TMuonBarrelKalmanParams::L1TMuonBarrelKalmanParams()
+  : pnodes_(NUM_BMTF_PARAM_NODES)//, l1mudttfmasks_(1)
+{
+  version_ = Version;
+  pnodes_[CONFIG].type_ = "unspecified";
+  pnodes_[CONFIG].fwVersion_ = 0; //default to recognize a RCD that is not filled
+  // pnodes_[CONFIG].sparams_.clear();
+  // pnodes_[CONFIG].iparams_.resize(NUM_CONFIG_PARAMS);
+}

--- a/CondFormats/L1TObjects/src/L1TMuonBarrelKalmanParams.cc
+++ b/CondFormats/L1TObjects/src/L1TMuonBarrelKalmanParams.cc
@@ -1,11 +1,11 @@
 #include "CondFormats/L1TObjects/interface/L1TMuonBarrelKalmanParams.h"
 
 L1TMuonBarrelKalmanParams::L1TMuonBarrelKalmanParams()
-  : pnodes_(NUM_BMTF_PARAM_NODES)//, l1mudttfmasks_(1)
+    : pnodes_(NUM_BMTF_PARAM_NODES)  //, l1mudttfmasks_(1)
 {
   version_ = Version;
   pnodes_[CONFIG].type_ = "unspecified";
-  pnodes_[CONFIG].fwVersion_ = 0; //default to recognize a RCD that is not filled
+  pnodes_[CONFIG].fwVersion_ = 0;  //default to recognize a RCD that is not filled
   // pnodes_[CONFIG].sparams_.clear();
   // pnodes_[CONFIG].iparams_.resize(NUM_CONFIG_PARAMS);
 }

--- a/CondFormats/L1TObjects/src/L1TMuonBarrelKalmanParams.cc
+++ b/CondFormats/L1TObjects/src/L1TMuonBarrelKalmanParams.cc
@@ -1,11 +1,9 @@
 #include "CondFormats/L1TObjects/interface/L1TMuonBarrelKalmanParams.h"
 
 L1TMuonBarrelKalmanParams::L1TMuonBarrelKalmanParams()
-    : pnodes_(NUM_BMTF_PARAM_NODES)  //, l1mudttfmasks_(1)
+    : pnodes_(NUM_BMTF_PARAM_NODES)  //, l1mudttfmasks_(1) // auto masking (future)
 {
   version_ = Version;
   pnodes_[CONFIG].type_ = "unspecified";
   pnodes_[CONFIG].fwVersion_ = 0;  //default to recognize a RCD that is not filled
-  // pnodes_[CONFIG].sparams_.clear();
-  // pnodes_[CONFIG].iparams_.resize(NUM_CONFIG_PARAMS);
 }

--- a/CondFormats/L1TObjects/src/T_EventSetup_L1TMuonBarrelParams.cc
+++ b/CondFormats/L1TObjects/src/T_EventSetup_L1TMuonBarrelParams.cc
@@ -1,4 +1,6 @@
 #include "CondFormats/L1TObjects/interface/L1TMuonBarrelParams.h"
+#include "CondFormats/L1TObjects/interface/L1TMuonBarrelKalmanParams.h"
 #include "FWCore/Utilities/interface/typelookup.h"
 
 TYPELOOKUP_DATA_REG(L1TMuonBarrelParams);
+TYPELOOKUP_DATA_REG(L1TMuonBarrelKalmanParams);

--- a/CondFormats/L1TObjects/src/classes.h
+++ b/CondFormats/L1TObjects/src/classes.h
@@ -53,6 +53,7 @@
 #include "CondFormats/L1TObjects/interface/L1TMuonOverlapParams.h"
 #include "CondFormats/L1TObjects/interface/L1TMuonGlobalParams.h"
 #include "CondFormats/L1TObjects/interface/L1TMuonBarrelParams.h"
+#include "CondFormats/L1TObjects/interface/L1TMuonBarrelKalmanParams.h"
 #include "CondFormats/L1TObjects/interface/L1TMuonEndCapParams.h"
 #include "CondFormats/L1TObjects/interface/L1TMuonEndCapForest.h"
 
@@ -103,6 +104,8 @@ namespace CondFormats_L1TObjects {
 
     L1TMuonBarrelParams dummy18;
     std::vector<L1TMuonBarrelParams::Node> dummy18a;
+    L1TMuonBarrelKalmanParams dummy18b;
+    std::vector<L1TMuonBarrelKalmanParams::Node> dummy18c;
 
     L1TMuonEndCapParams dummy19;
 

--- a/CondFormats/L1TObjects/src/classes_def.xml
+++ b/CondFormats/L1TObjects/src/classes_def.xml
@@ -53,6 +53,7 @@
     <field name="sparams_" mapping="blob"/>
     <field name="uparams_" mapping="blob"/>
   </class>
+
   <class name="std::vector<L1TMuonBarrelParams::Node>"/>
   <class name="L1TMuonBarrelParams">
     <field name="pnodes_" mapping="blob"/>    
@@ -74,6 +75,13 @@
     <field name="eta_lut_" mapping="blob"/>
     <field name="ext_lut_" mapping="blob"/>
   </class>
+
+  <class name="L1TMuonBarrelKalmanParams">
+    <field name="pnodes_" mapping="blob"/>    
+  </class>
+  <class name="std::vector<L1TMuonBarrelKalmanParams::Node>"/>
+  <!-- <class name="std::vector<L1TMuonBarrelKalmanParams::LUT>"/> -->
+
   <class name="L1MuScale"/>
   <class name="L1MuBinnedScale">
     <field name="m_Scale" mapping="blob" />

--- a/L1Trigger/L1TMuonBarrel/plugins/L1TMuonBarrelKalmanParamsESProducer.cc
+++ b/L1Trigger/L1TMuonBarrel/plugins/L1TMuonBarrelKalmanParamsESProducer.cc
@@ -1,0 +1,83 @@
+// -*- C++ -*-
+//
+// Class:      L1TMuonBarrelKalmanParamsESProducer
+//
+// Original Author (of the base file):  Giannis Flouris
+// Kalman Mod & clean up:  Panos Katsoulis
+//         Created:
+//
+//
+
+// system include files
+#include <memory>
+
+// user include files
+#include "FWCore/Framework/interface/ModuleFactory.h"
+#include "FWCore/Framework/interface/ESProducer.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/ESProducts.h"
+
+#include "CondFormats/L1TObjects/interface/L1TMuonBarrelKalmanParams.h" //changed
+#include "CondFormats/DataRecord/interface/L1TMuonBarrelParamsRcd.h" //changed
+#include "L1Trigger/L1TMuon/interface/MicroGMTLUTFactories.h"
+
+#include "FWCore/ParameterSet/interface/FileInPath.h"
+
+#include "L1Trigger/L1TCommon/interface/XmlConfigParser.h"
+#include "L1Trigger/L1TCommon/interface/TriggerSystem.h"
+#include "L1Trigger/L1TCommon/interface/Parameter.h"
+#include "L1Trigger/L1TCommon/interface/Mask.h"
+
+#include "L1Trigger/L1TMuonBarrel/interface/L1TMuonBarrelParamsHelper.h" //to check
+
+// class declaration
+//
+// typedef std::map<short, short, std::less<short> > LUT;
+
+class L1TMuonBarrelKalmanParamsESProducer : public edm::ESProducer {
+public:
+  L1TMuonBarrelKalmanParamsESProducer(const edm::ParameterSet&);
+  ~L1TMuonBarrelKalmanParamsESProducer() override;
+
+  using ReturnType = std::unique_ptr<L1TMuonBarrelKalmanParams>;
+  ReturnType produce(const L1TMuonBarrelKalmanParamsRcd&);
+
+private:
+  L1TMuonBarrelKalmanParams kalman_params;
+};
+
+//
+// constants, enums and typedefs
+//
+
+//
+// static data member definitions
+//
+
+//
+// constructors and destructor
+//
+L1TMuonBarrelKalmanParamsESProducer::L1TMuonBarrelKalmanParamsESProducer(const edm::ParameterSet& iConfig) {
+  // the following line is needed to tell the framework what data is being produced
+  setWhatProduced(this); //???
+
+  // basic configurables needed (now set static)
+  kalman_params.pnodes_[kalman_params.CONFIG].fwVersion_ = iConfig.getParameter<unsigned>("fwVersion");
+
+  // the LUTs
+  kalman_params.pnodes_[kalman_params.CONFIG].kalmanLUTsPath_ = iConfig.getParameter<std::string>("LUTsPath");
+}
+
+L1TMuonBarrelKalmanParamsESProducer::~L1TMuonBarrelKalmanParamsESProducer() {}
+
+//
+// member functions
+//
+
+// ------------ method called to produce the data  ------------
+L1TMuonBarrelKalmanParamsESProducer::ReturnType L1TMuonBarrelKalmanParamsESProducer::produce(const L1TMuonBarrelKalmanParamsRcd& iRecord) {
+  return std::make_unique<L1TMuonBarrelKalmanParams>(kalman_params);
+}
+
+//define this as a plug-in
+DEFINE_FWK_EVENTSETUP_MODULE(L1TMuonBarrelKalmanParamsESProducer);

--- a/L1Trigger/L1TMuonBarrel/plugins/L1TMuonBarrelKalmanParamsESProducer.cc
+++ b/L1Trigger/L1TMuonBarrel/plugins/L1TMuonBarrelKalmanParamsESProducer.cc
@@ -17,8 +17,8 @@
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/ESProducts.h"
 
-#include "CondFormats/L1TObjects/interface/L1TMuonBarrelKalmanParams.h" //changed
-#include "CondFormats/DataRecord/interface/L1TMuonBarrelParamsRcd.h" //changed
+#include "CondFormats/L1TObjects/interface/L1TMuonBarrelKalmanParams.h"
+#include "CondFormats/DataRecord/interface/L1TMuonBarrelParamsRcd.h"
 #include "L1Trigger/L1TMuon/interface/MicroGMTLUTFactories.h"
 
 #include "FWCore/ParameterSet/interface/FileInPath.h"
@@ -28,7 +28,7 @@
 #include "L1Trigger/L1TCommon/interface/Parameter.h"
 #include "L1Trigger/L1TCommon/interface/Mask.h"
 
-#include "L1Trigger/L1TMuonBarrel/interface/L1TMuonBarrelParamsHelper.h" //to check
+#include "L1Trigger/L1TMuonBarrel/interface/L1TMuonBarrelParamsHelper.h"
 
 // class declaration
 //
@@ -59,7 +59,7 @@ private:
 //
 L1TMuonBarrelKalmanParamsESProducer::L1TMuonBarrelKalmanParamsESProducer(const edm::ParameterSet& iConfig) {
   // the following line is needed to tell the framework what data is being produced
-  setWhatProduced(this); //???
+  setWhatProduced(this);
 
   // basic configurables needed (now set static)
   kalman_params.pnodes_[kalman_params.CONFIG].fwVersion_ = iConfig.getParameter<unsigned>("fwVersion");
@@ -75,7 +75,8 @@ L1TMuonBarrelKalmanParamsESProducer::~L1TMuonBarrelKalmanParamsESProducer() {}
 //
 
 // ------------ method called to produce the data  ------------
-L1TMuonBarrelKalmanParamsESProducer::ReturnType L1TMuonBarrelKalmanParamsESProducer::produce(const L1TMuonBarrelKalmanParamsRcd& iRecord) {
+L1TMuonBarrelKalmanParamsESProducer::ReturnType L1TMuonBarrelKalmanParamsESProducer::produce(
+    const L1TMuonBarrelKalmanParamsRcd& iRecord) {
   return std::make_unique<L1TMuonBarrelKalmanParams>(kalman_params);
 }
 

--- a/L1Trigger/L1TMuonBarrel/plugins/L1TMuonBarrelKalmanParamsESProducer.cc
+++ b/L1Trigger/L1TMuonBarrel/plugins/L1TMuonBarrelKalmanParamsESProducer.cc
@@ -14,25 +14,17 @@
 // user include files
 #include "FWCore/Framework/interface/ModuleFactory.h"
 #include "FWCore/Framework/interface/ESProducer.h"
-#include "FWCore/Framework/interface/ESHandle.h"
-#include "FWCore/Framework/interface/ESProducts.h"
 
 #include "CondFormats/L1TObjects/interface/L1TMuonBarrelKalmanParams.h"
-#include "CondFormats/DataRecord/interface/L1TMuonBarrelParamsRcd.h"
-#include "L1Trigger/L1TMuon/interface/MicroGMTLUTFactories.h"
+#include "CondFormats/DataRecord/interface/L1TMuonBarrelKalmanParamsRcd.h"
 
-#include "FWCore/ParameterSet/interface/FileInPath.h"
-
-#include "L1Trigger/L1TCommon/interface/XmlConfigParser.h"
-#include "L1Trigger/L1TCommon/interface/TriggerSystem.h"
-#include "L1Trigger/L1TCommon/interface/Parameter.h"
-#include "L1Trigger/L1TCommon/interface/Mask.h"
-
-#include "L1Trigger/L1TMuonBarrel/interface/L1TMuonBarrelParamsHelper.h"
+// for future, LUTs implementaion
+//#include "L1Trigger/L1TMuon/interface/MicroGMTLUTFactories.h"
+// for future, masks
+//#include "L1Trigger/L1TCommon/interface/Mask.h"
 
 // class declaration
 //
-// typedef std::map<short, short, std::less<short> > LUT;
 
 class L1TMuonBarrelKalmanParamsESProducer : public edm::ESProducer {
 public:

--- a/L1Trigger/L1TMuonBarrel/python/fakeBmtfParams_cff.py
+++ b/L1Trigger/L1TMuonBarrel/python/fakeBmtfParams_cff.py
@@ -14,7 +14,8 @@ bmbtfParamsSource = cms.ESSource(
     firstValid = cms.vuint32(1)
 )
 
-fakeBmtfParams = cms.ESProducer('L1TMuonBarrelParamsESProducer',
+fakeBmtfParams = cms.ESProducer(
+    'L1TMuonBarrelParamsESProducer',
     configFromXML = cms.bool(False),
     hwXmlFile = cms.string('L1Trigger/L1TMuonBarell/test/BMTF_HW.xml'),
     topCfgXmlFile = cms.string('L1Trigger/L1TMuonBarell/test/bmtf_top_config_p5.xml'),

--- a/L1Trigger/L1TMuonBarrel/python/staticKBmtfParams_cff.py
+++ b/L1Trigger/L1TMuonBarrel/python/staticKBmtfParams_cff.py
@@ -1,0 +1,14 @@
+import FWCore.ParameterSet.Config as cms
+
+kalmanParamsSource = cms.ESSource(
+    "EmptyESSource",
+    recordName = cms.string('L1TMuonBarrelKalmanParamsRcd'),
+    iovIsRunNotTime = cms.bool(True),
+    firstValid = cms.vuint32(1)
+)
+
+staticKBmtfParams = cms.ESProducer(
+    'L1TMuonBarrelKalmanParamsESProducer',
+    fwVersion = cms.uint32(0x95030160),
+    LUTsPath = cms.string("L1Trigger/L1TMuon/data/bmtf_luts/kalmanLUTs_v302.root")
+)

--- a/L1TriggerConfig/Utilities/src/L1TMuonBarrelKalmanParamsViewer.cc
+++ b/L1TriggerConfig/Utilities/src/L1TMuonBarrelKalmanParamsViewer.cc
@@ -9,7 +9,7 @@
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 
-#include "CondFormats/DataRecord/interface/L1TMuonBarrelParamsRcd.h"
+#include "CondFormats/DataRecord/interface/L1TMuonBarrelKalmanParamsRcd.h"
 #include "CondFormats/L1TObjects/interface/L1TMuonBarrelKalmanParams.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "CondCore/DBOutputService/interface/PoolDBOutputService.h"

--- a/L1TriggerConfig/Utilities/src/L1TMuonBarrelKalmanParamsViewer.cc
+++ b/L1TriggerConfig/Utilities/src/L1TMuonBarrelKalmanParamsViewer.cc
@@ -1,0 +1,77 @@
+#include <iomanip>
+#include <iostream>
+
+#include "FWCore/Framework/interface/EDAnalyzer.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+
+#include "CondFormats/DataRecord/interface/L1TMuonBarrelParamsRcd.h"
+#include "CondFormats/L1TObjects/interface/L1TMuonBarrelKalmanParams.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "CondCore/DBOutputService/interface/PoolDBOutputService.h"
+#include "CondCore/CondDB/interface/Session.h"
+
+#include <iostream>
+using namespace std;
+
+class L1TMuonBarrelKalmanParamsViewer : public edm::EDAnalyzer {
+private:
+  std::string hash(void *buf, size_t len) const;
+
+public:
+  void analyze(const edm::Event &, const edm::EventSetup &) override;
+
+  L1TMuonBarrelKalmanParamsViewer(const edm::ParameterSet &) {};
+  ~L1TMuonBarrelKalmanParamsViewer(void) override {}
+};
+
+#include <openssl/sha.h>
+#include <cmath>
+#include <iostream>
+using namespace std;
+
+std::string L1TMuonBarrelKalmanParamsViewer::hash(void *buf, size_t len) const {
+  char tmp[SHA_DIGEST_LENGTH * 2 + 1];
+  bzero(tmp, sizeof(tmp));
+  SHA_CTX ctx;
+  if (!SHA1_Init(&ctx))
+    throw cms::Exception("L1TMuonBarrelKalmanParamsViewer::hash") << "SHA1 initialization error";
+
+  if (!SHA1_Update(&ctx, buf, len))
+    throw cms::Exception("L1TMuonBarrelKalmanParamsViewer::hash") << "SHA1 processing error";
+
+  unsigned char hash[SHA_DIGEST_LENGTH];
+  if (!SHA1_Final(hash, &ctx))
+    throw cms::Exception("L1TMuonBarrelKalmanParamsViewer::hash") << "SHA1 finalization error";
+
+  // re-write bytes in hex
+  for (unsigned int i = 0; i < 20; i++)
+    ::sprintf(&tmp[i * 2], "%02x", hash[i]);
+
+  tmp[20 * 2] = 0;
+  return std::string(tmp);
+}
+
+void L1TMuonBarrelKalmanParamsViewer::analyze(const edm::Event &iEvent, const edm::EventSetup &evSetup) {
+  edm::ESHandle<L1TMuonBarrelKalmanParams> handle1;
+  evSetup.get<L1TMuonBarrelKalmanParamsRcd>().get(handle1);
+  std::shared_ptr<L1TMuonBarrelKalmanParams> ptr(new L1TMuonBarrelKalmanParams(*(handle1.product())));
+
+  // Get the nodes and print out
+  auto pnodes = ptr->pnodes_[ptr->CONFIG];
+  cout << "version    : " << ptr->version_ << endl;
+  cout << "fwVersion : " << hex << pnodes.fwVersion_ << dec << endl;
+  cout << "LUTsPath   : " << pnodes.kalmanLUTsPath_ << endl;
+
+  // typedef std::map<short, short, std::less<short> > LUT;
+}
+
+#include "FWCore/PluginManager/interface/ModuleDef.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/ModuleFactory.h"
+
+DEFINE_FWK_MODULE(L1TMuonBarrelKalmanParamsViewer);

--- a/L1TriggerConfig/Utilities/src/L1TMuonBarrelKalmanParamsViewer.cc
+++ b/L1TriggerConfig/Utilities/src/L1TMuonBarrelKalmanParamsViewer.cc
@@ -25,7 +25,7 @@ private:
 public:
   void analyze(const edm::Event &, const edm::EventSetup &) override;
 
-  L1TMuonBarrelKalmanParamsViewer(const edm::ParameterSet &) {};
+  L1TMuonBarrelKalmanParamsViewer(const edm::ParameterSet &){};
   ~L1TMuonBarrelKalmanParamsViewer(void) override {}
 };
 
@@ -64,7 +64,7 @@ void L1TMuonBarrelKalmanParamsViewer::analyze(const edm::Event &iEvent, const ed
   // Get the nodes and print out
   auto pnodes = ptr->pnodes_[ptr->CONFIG];
   cout << "version    : " << ptr->version_ << endl;
-  cout << "fwVersion : " << hex << pnodes.fwVersion_ << dec << endl;
+  cout << "fwVersion  : " << hex << pnodes.fwVersion_ << dec << endl;
   cout << "LUTsPath   : " << pnodes.kalmanLUTsPath_ << endl;
 
   // typedef std::map<short, short, std::less<short> > LUT;

--- a/L1TriggerConfig/Utilities/src/L1TMuonBarrelParamsWriter.cc
+++ b/L1TriggerConfig/Utilities/src/L1TMuonBarrelParamsWriter.cc
@@ -9,8 +9,9 @@
 #include "FWCore/Framework/interface/ESHandle.h"
 
 #include "CondFormats/DataRecord/interface/L1TMuonBarrelParamsO2ORcd.h"
-#include "CondFormats/DataRecord/interface/L1TMuonBarrelParamsRcd.h"
+#include "CondFormats/DataRecord/interface/L1TMuonBarrelParamsRcd.h" // includes both Old-Phase1 and Kalman Rcds
 #include "CondFormats/L1TObjects/interface/L1TMuonBarrelParams.h"
+#include "CondFormats/L1TObjects/interface/L1TMuonBarrelKalmanParams.h"
 
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "CondCore/DBOutputService/interface/PoolDBOutputService.h"
@@ -30,19 +31,24 @@ public:
 
 void L1TMuonBarrelParamsWriter::analyze(const edm::Event& iEvent, const edm::EventSetup& evSetup) {
   edm::ESHandle<L1TMuonBarrelParams> handle1;
+  edm::ESHandle<L1TMuonBarrelKalmanParams> handle2;
 
   if (isO2Opayload)
     evSetup.get<L1TMuonBarrelParamsO2ORcd>().get(handle1);
-  else
+  else {
     evSetup.get<L1TMuonBarrelParamsRcd>().get(handle1);
+    evSetup.get<L1TMuonBarrelKalmanParamsRcd>().get(handle2);
+  }
 
   std::shared_ptr<L1TMuonBarrelParams> ptr1(new L1TMuonBarrelParams(*(handle1.product())));
+  std::shared_ptr<L1TMuonBarrelKalmanParams> ptr2(new L1TMuonBarrelKalmanParams(*(handle2.product())));
 
   edm::Service<cond::service::PoolDBOutputService> poolDb;
   if (poolDb.isAvailable()) {
     cond::Time_t firstSinceTime = poolDb->beginOfTime();
-    poolDb->writeOne(
-        ptr1.get(), firstSinceTime, (isO2Opayload ? "L1TMuonBarrelParamsO2ORcd" : "L1TMuonBarrelParamsRcd"));
+    poolDb->writeOne( ptr1.get(), firstSinceTime, (isO2Opayload ? "L1TMuonBarrelParamsO2ORcd" : "L1TMuonBarrelParamsRcd") );
+    if (not isO2Opayload)
+      poolDb->writeOne( ptr2.get(), firstSinceTime, ("L1TMuonBarrelKalmanParamsRcd") );
   }
 }
 

--- a/L1TriggerConfig/Utilities/src/L1TMuonBarrelParamsWriter.cc
+++ b/L1TriggerConfig/Utilities/src/L1TMuonBarrelParamsWriter.cc
@@ -9,8 +9,9 @@
 #include "FWCore/Framework/interface/ESHandle.h"
 
 #include "CondFormats/DataRecord/interface/L1TMuonBarrelParamsO2ORcd.h"
-#include "CondFormats/DataRecord/interface/L1TMuonBarrelParamsRcd.h"  // includes both Old-Phase1 and Kalman Rcds
+#include "CondFormats/DataRecord/interface/L1TMuonBarrelParamsRcd.h"
 #include "CondFormats/L1TObjects/interface/L1TMuonBarrelParams.h"
+#include "CondFormats/DataRecord/interface/L1TMuonBarrelKalmanParamsRcd.h"
 #include "CondFormats/L1TObjects/interface/L1TMuonBarrelKalmanParams.h"
 
 #include "FWCore/ServiceRegistry/interface/Service.h"

--- a/L1TriggerConfig/Utilities/src/L1TMuonBarrelParamsWriter.cc
+++ b/L1TriggerConfig/Utilities/src/L1TMuonBarrelParamsWriter.cc
@@ -9,7 +9,7 @@
 #include "FWCore/Framework/interface/ESHandle.h"
 
 #include "CondFormats/DataRecord/interface/L1TMuonBarrelParamsO2ORcd.h"
-#include "CondFormats/DataRecord/interface/L1TMuonBarrelParamsRcd.h" // includes both Old-Phase1 and Kalman Rcds
+#include "CondFormats/DataRecord/interface/L1TMuonBarrelParamsRcd.h"  // includes both Old-Phase1 and Kalman Rcds
 #include "CondFormats/L1TObjects/interface/L1TMuonBarrelParams.h"
 #include "CondFormats/L1TObjects/interface/L1TMuonBarrelKalmanParams.h"
 
@@ -46,9 +46,10 @@ void L1TMuonBarrelParamsWriter::analyze(const edm::Event& iEvent, const edm::Eve
   edm::Service<cond::service::PoolDBOutputService> poolDb;
   if (poolDb.isAvailable()) {
     cond::Time_t firstSinceTime = poolDb->beginOfTime();
-    poolDb->writeOne( ptr1.get(), firstSinceTime, (isO2Opayload ? "L1TMuonBarrelParamsO2ORcd" : "L1TMuonBarrelParamsRcd") );
+    poolDb->writeOne(
+        ptr1.get(), firstSinceTime, (isO2Opayload ? "L1TMuonBarrelParamsO2ORcd" : "L1TMuonBarrelParamsRcd"));
     if (not isO2Opayload)
-      poolDb->writeOne( ptr2.get(), firstSinceTime, ("L1TMuonBarrelKalmanParamsRcd") );
+      poolDb->writeOne(ptr2.get(), firstSinceTime, ("L1TMuonBarrelKalmanParamsRcd"));
   }
 }
 

--- a/L1TriggerConfig/Utilities/test/uploadBmtfParams.py
+++ b/L1TriggerConfig/Utilities/test/uploadBmtfParams.py
@@ -6,16 +6,22 @@ process.MessageLogger.cout.enable = cms.untracked.bool(True)
 process.MessageLogger.cout.threshold = cms.untracked.string('DEBUG')
 process.MessageLogger.debugModules = cms.untracked.vstring('*')
 
-process.source = cms.Source("EmptySource", firstRun = cms.untracked.uint32(3))
+process.source = cms.Source("EmptySource", firstRun = cms.untracked.uint32(10))
 process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(1) )
 
 process.load("L1Trigger.L1TMuonBarrel.fakeBmtfParams_cff")
+process.load("L1Trigger.L1TMuonBarrel.staticKBmtfParams_cff")
 
+##this is general code for getting rcds and datas loaded to the ESSetup
 process.getter = cms.EDAnalyzer("EventSetupRecordDataGetter",
    toGet = cms.VPSet(
        cms.PSet(
            record = cms.string('L1TMuonBarrelParamsRcd'),
            data   = cms.vstring('L1TMuonBarrelParams')
+       ),
+       cms.PSet(
+           record = cms.string('L1TMuonBarrelKalmanParamsRcd'),
+           data = cms.vstring('L1TMuonBarrelKalmanParams')
        )
    ),
    verbose = cms.untracked.bool(True)
@@ -30,13 +36,18 @@ outputDB = cms.Service("PoolDBOutputService",
                            cms.PSet(
                                record = cms.string('L1TMuonBarrelParamsRcd'),
                                tag = cms.string('L1TMuonBarrelParamsPrototype_Stage2v0_hlt')
+                           ),
+                           cms.PSet(
+                               record = cms.string('L1TMuonBarrelKalmanParamsRcd'),
+                               tag = cms.string('L1TMuonBarrelKalmanParamsPrototype_Stage2v0_hlt')
                            )
                        )
 )
 outputDB.DBParameters.authenticationPath = '.'
 process.add_(outputDB)
 
-process.l1bpw = cms.EDAnalyzer("L1TMuonBarrelParamsWriter", isO2Opayload = cms.untracked.bool(False))
+process.l1bpw = cms.EDAnalyzer("L1TMuonBarrelParamsWriter",
+                               isO2Opayload = cms.untracked.bool(False))
 
 process.p = cms.Path(process.getter + process.l1bpw)
 

--- a/L1TriggerConfig/Utilities/test/uploadBmtfParams.py
+++ b/L1TriggerConfig/Utilities/test/uploadBmtfParams.py
@@ -9,6 +9,7 @@ process.MessageLogger.debugModules = cms.untracked.vstring('*')
 process.source = cms.Source("EmptySource", firstRun = cms.untracked.uint32(10))
 process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(1) )
 
+## these lines load ESProducers to be run outside the path (automatically)
 process.load("L1Trigger.L1TMuonBarrel.fakeBmtfParams_cff")
 process.load("L1Trigger.L1TMuonBarrel.staticKBmtfParams_cff")
 
@@ -50,4 +51,3 @@ process.l1bpw = cms.EDAnalyzer("L1TMuonBarrelParamsWriter",
                                isO2Opayload = cms.untracked.bool(False))
 
 process.p = cms.Path(process.getter + process.l1bpw)
-

--- a/L1TriggerConfig/Utilities/test/viewKBmtfParams.py
+++ b/L1TriggerConfig/Utilities/test/viewKBmtfParams.py
@@ -1,0 +1,66 @@
+from __future__ import print_function
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("tester")
+process.load("FWCore.MessageLogger.MessageLogger_cfi")
+process.MessageLogger.cout.enable = cms.untracked.bool(True)
+process.MessageLogger.cout.threshold = cms.untracked.string('DEBUG')
+process.MessageLogger.debugModules = cms.untracked.vstring('*')
+
+import FWCore.ParameterSet.VarParsing as VarParsing
+options = VarParsing.VarParsing()
+options.register('db',
+                 'sqlite:l1config.db',
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.string,
+                 "Source DB: prod/prep/static:.../sqlite:..."
+)
+options.register('run',
+                 1,
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.int,
+                 "Run (IOV)"
+)
+options.register('tag',
+                 'L1TMuonBarrelKalmanParamsPrototype_Stage2v0_hlt',
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.string,
+                 "Tag for selecting the Rcd from db"
+)
+
+options.parseArguments()
+
+if "static" in options.db :
+    process.load("L1Trigger.L1TMuonBarrel.staticKBmtfParams_cff")
+else :
+    if   options.db == "prod" :
+        sourceDB = "frontier://FrontierProd/CMS_CONDITIONS"
+    elif options.db == "prep" :
+        sourceDB = "frontier://FrontierPrep/CMS_CONDITIONS"
+    elif "sqlite" in options.db :
+        sourceDB = options.db
+    else :
+        print("Unknown input DB: ", options.db, " should be static:.../prod/prep/sqlite:...")
+        exit(0)
+
+    from CondCore.CondDB.CondDB_cfi import CondDB
+    CondDB.connect = cms.string(sourceDB)
+    process.l1conddb = cms.ESSource("PoolDBESSource",
+       CondDB,
+       toGet   = cms.VPSet(
+            cms.PSet(
+                 record = cms.string('L1TMuonBarrelKalmanParamsRcd'),
+                 tag = cms.string(options.tag)
+            )
+       )
+   )
+
+process.source = cms.Source("EmptySource", firstRun = cms.untracked.uint32(options.run))
+process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(1) )
+
+process.l1bkpv = cms.EDAnalyzer("L1TMuonBarrelKalmanParamsViewer",
+)
+
+process.p = cms.Path(process.l1bkpv)
+
+print(process.es_sources.viewitems())


### PR DESCRIPTION
- Description
This PR introduces new Records and Objects required for implementing a primary "configuration from CondDB" for the L1 Kalman Barrel Emulator. There will be a follow up with the second part of development but this is the bare minimum for testing during the upcoming CRAFT and MWGRs.
The object L1TMuonBarrelKalmanParams holds some (not all yet) of the parameters required by the emulator.
(a static version of these params can be found here [1])
To be discussed during [2]

- Validation
This code is validated locally, wrote and read to a local sqlite file

- No Backport Needed

[1] https://github.com/cms-sw/cmssw/blob/master/L1Trigger/L1TMuonBarrel/python/simKBmtfDigis_cfi.py
[2] https://indico.cern.ch/event/1060075/#11-introduce-l1tmuonbarrelkalm