### PR TITLE
[Backport] Make stop/sbottom R-hadrons use the cloud model

### DIFF
--- a/SimG4Core/CustomPhysics/interface/CustomPDGParser.h
+++ b/SimG4Core/CustomPhysics/interface/CustomPDGParser.h
@@ -5,7 +5,7 @@
 
 class CustomPDGParser {
 public:
-  static bool s_isRHadron(int pdg);
+  static bool s_isgluinoHadron(int pdg);
   static bool s_isstopHadron(int pdg);
   static bool s_issbottomHadron(int pdg);
   static bool s_isSLepton(int pdg);

--- a/SimG4Core/CustomPhysics/src/CustomPDGParser.cc
+++ b/SimG4Core/CustomPhysics/src/CustomPDGParser.cc
@@ -7,7 +7,8 @@
 
 }*/
 
-bool CustomPDGParser::s_isRHadron(int pdg) {
+// check for R-hadron with gluino content
+bool CustomPDGParser::s_isgluinoHadron(int pdg) {
   int pdgAbs = abs(pdg);
   return ((pdgAbs % 100000 / 10000 == 9) || (pdgAbs % 10000 / 1000 == 9) || s_isRGlueball(pdg));
 }

--- a/SimG4Core/CustomPhysics/src/CustomParticleFactory.cc
+++ b/SimG4Core/CustomPhysics/src/CustomParticleFactory.cc
@@ -100,7 +100,7 @@ void CustomParticleFactory::addCustomParticle(int pdgCode, double mass, const st
   G4double spectatormass = 0.0;
   G4ParticleDefinition *spectator = nullptr;
   //////////////////////
-  if (CustomPDGParser::s_isRHadron(pdgCode)) {
+  if (CustomPDGParser::s_isgluinoHadron(pdgCode)) {
     pType = "rhadron";
   }
   if (CustomPDGParser::s_isSLepton(pdgCode)) {
@@ -261,7 +261,7 @@ void CustomParticleFactory::getMassTable(std::ifstream *configFile) {
 
     edm::LogInfo("SimG4CoreCustomPhysics")
         << "CustomParticleFactory: Calling addCustomParticle for pdgId: " << pdgId << ", mass " << mass << " GeV  "
-        << name << ", isRHadron: " << CustomPDGParser::s_isRHadron(pdgId)
+        << name << ", isgluinoHadron: " << CustomPDGParser::s_isgluinoHadron(pdgId)
         << ", isstopHadron: " << CustomPDGParser::s_isstopHadron(pdgId);
     addCustomParticle(pdgId, mass, name);
 
@@ -275,7 +275,7 @@ void CustomParticleFactory::getMassTable(std::ifstream *configFile) {
           << " pdgId= " << pdgId << ", pdgIdPartner= " << pdgIdPartner << " " << aParticle->GetParticleName();
     }
 
-    if (aParticle && !CustomPDGParser::s_isRHadron(pdgId) && !CustomPDGParser::s_isstopHadron(pdgId) &&
+    if (aParticle && !CustomPDGParser::s_isgluinoHadron(pdgId) && !CustomPDGParser::s_isstopHadron(pdgId) &&
         pdgId != 1000006 && pdgId != -1000006 && pdgId != 25 && pdgId != 35 && pdgId != 36 && pdgId != 37) {
       int sign = aParticle->GetAntiPDGEncoding() / pdgIdPartner;
       edm::LogInfo("SimG4CoreCustomPhysics")

--- a/SimG4Core/CustomPhysics/src/CustomPhysicsList.cc
+++ b/SimG4Core/CustomPhysics/src/CustomPhysicsList.cc
@@ -66,7 +66,10 @@ void CustomPhysicsList::ConstructProcess() {
           ph->RegisterProcess(new G4hMultipleScattering, particle);
           ph->RegisterProcess(new G4hIonisation, particle);
         }
-        if (cp->GetCloud() && fHadronicInteraction && CustomPDGParser::s_isRHadron(particle->GetPDGEncoding())) {
+        if (cp->GetCloud() && fHadronicInteraction &&
+            (CustomPDGParser::s_isgluinoHadron(particle->GetPDGEncoding()) ||
+             (CustomPDGParser::s_isstopHadron(particle->GetPDGEncoding())) ||
+             (CustomPDGParser::s_issbottomHadron(particle->GetPDGEncoding())))) {
           edm::LogVerbatim("SimG4CoreCustomPhysics")
               << "CustomPhysicsList: " << particle->GetParticleName()
               << " CloudMass= " << cp->GetCloud()->GetPDGMass() / GeV

--- a/SimG4Core/CustomPhysics/src/CustomPhysicsListSS.cc
+++ b/SimG4Core/CustomPhysics/src/CustomPhysicsListSS.cc
@@ -65,7 +65,10 @@ void CustomPhysicsListSS::ConstructProcess() {
           ph->RegisterProcess(new G4CoulombScattering, particle);
           ph->RegisterProcess(new G4hIonisation, particle);
         }
-        if (cp->GetCloud() && fHadronicInteraction && CustomPDGParser::s_isRHadron(particle->GetPDGEncoding())) {
+        if (cp->GetCloud() && fHadronicInteraction &&
+            (CustomPDGParser::s_isgluinoHadron(particle->GetPDGEncoding()) ||
+             (CustomPDGParser::s_isstopHadron(particle->GetPDGEncoding())) ||
+             (CustomPDGParser::s_issbottomHadron(particle->GetPDGEncoding())))) {
           edm::LogVerbatim("SimG4CoreCustomPhysics")
               << "CustomPhysicsListSS: " << particle->GetParticleName()
               << " CloudMass= " << cp->GetCloud()->GetPDGMass() / GeV


### PR DESCRIPTION
#### PR description:
See description in https://github.com/cms-sw/cmssw/pull/34459

#### if this PR is a backport please specify the original PR and why you need to backport that PR:
This is a backport of https://github.com/cms-sw/cmssw/pull/34459
and needed for MC production for HSCP particle simulations in UL

cc @tadams16 @carolinecollard