### PR TITLE
Pixel Local GPU reco crash on copy fix

### DIFF
--- a/RecoLocalTracker/SiPixelRecHits/plugins/SiPixelRecHitFromCUDA.cc
+++ b/RecoLocalTracker/SiPixelRecHits/plugins/SiPixelRecHitFromCUDA.cc
@@ -85,15 +85,19 @@ void SiPixelRecHitFromCUDA::acquire(edm::Event const& iEvent,
 void SiPixelRecHitFromCUDA::produce(edm::Event& iEvent, edm::EventSetup const& es) {
   // allocate a buffer for the indices of the clusters
   auto hmsp = std::make_unique<uint32_t[]>(gpuClustering::maxNumModules + 1);
+
+  SiPixelRecHitCollection output;
+  output.reserve(gpuClustering::maxNumModules, nHits_);
+
+  if (0 == nHits_) {
+    iEvent.emplace(rechitsPutToken_, std::move(output));
+    iEvent.emplace(hostPutToken_, std::move(hmsp));
+    return;
+  }
+
   std::copy(hitsModuleStart_.get(), hitsModuleStart_.get() + gpuClustering::maxNumModules + 1, hmsp.get());
   // wrap the buffer in a HostProduct, and move it to the Event, without reallocating the buffer or affecting hitsModuleStart
   iEvent.emplace(hostPutToken_, std::move(hmsp));
-
-  SiPixelRecHitCollection output;
-  if (0 == nHits_) {
-    iEvent.emplace(rechitsPutToken_, std::move(output));
-    return;
-  }
 
   auto xl = store32_.get();
   auto yl = xl + nHits_;


### PR DESCRIPTION
#### PR description:

Fix for #34496.

Solution by @VinInn.

In short:

Reconstruction with an empty pixel detector in `/RecoLocalTracker/SiPixelRecHits/plugins/SiPixelRecHitFromCUDA.cc`, failed on

```cpp
std::copy(hitsModuleStart_.get(), hitsModuleStart_.get() + gpuClustering::maxNumModules + 1, hmsp.get());
```

#### PR validation:

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

<!-- Please replace this text with any link to  -->