### PR TITLE
Remove 50ns-labeled dynamic inefficiency payload usage from SiPixelDigitizer

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -2,29 +2,27 @@ autoCond = {
 
     ### NEW KEYS ###
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run1
-    'run1_design'                  : '113X_mcRun1_design_v3',
+    'run1_design'                  : '120X_mcRun1_design_v1',
     # GlobalTag for MC production (pp collisions) with realistic alignment and calibrations for Run1
-    'run1_mc'                      : '113X_mcRun1_realistic_v3',
+    'run1_mc'                      : '120X_mcRun1_realistic_v1',
     # GlobalTag for MC production (Heavy Ions collisions) with realistic alignment and calibrations for Run1
-    'run1_mc_hi'                   : '113X_mcRun1_HeavyIon_v3',
-    # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run1
-    'run1_mc_pa'                   : '113X_mcRun1_pA_v3',
+    'run1_mc_hi'                   : '120X_mcRun1_HeavyIon_v1',
     # GlobalTag for MC production with pessimistic alignment and calibrations for Run2
-    'run2_mc_50ns'                 : '113X_mcRun2_startup_v3',
+    'run2_mc_50ns'                 : '120X_mcRun2_startup_v1',
     # GlobalTag for MC production (2015 L1 Trigger Stage1) with startup-like alignment and calibrations for Run2, L1 trigger in Stage1 mode
-    'run2_mc_l1stage1'             : '113X_mcRun2_asymptotic_l1stage1_v4',
+    'run2_mc_l1stage1'             : '120X_mcRun2_asymptotic_l1stage1_v1',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run2
-    'run2_design'                  : '113X_mcRun2_design_v4',
+    'run2_design'                  : '120X_mcRun2_design_v1',
     #GlobalTag for MC production with optimistic alignment and calibrations for 2016, prior to VFP change
-    'run2_mc_pre_vfp'              : '120X_mcRun2_asymptotic_preVFP_v1',
+    'run2_mc_pre_vfp'              : '120X_mcRun2_asymptotic_preVFP_v2',
     #GlobalTag for MC production with optimistic alignment and calibrations for 2016, after VFP change
-    'run2_mc'                      : '120X_mcRun2_asymptotic_v1',
+    'run2_mc'                      : '120X_mcRun2_asymptotic_v2',
     # GlobalTag for MC production (cosmics) with starup-like alignment and calibrations for Run2, Strip tracker in peak mode
-    'run2_mc_cosmics'              : '113X_mcRun2cosmics_asymptotic_deco_v4',
+    'run2_mc_cosmics'              : '120X_mcRun2cosmics_asymptotic_deco_v1',
     # GlobalTag for MC production (Heavy Ions collisions) with optimistic alignment and calibrations for Run2
-    'run2_mc_hi'                   : '113X_mcRun2_HeavyIon_v4',
+    'run2_mc_hi'                   : '120X_mcRun2_HeavyIon_v1',
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2
-    'run2_mc_pa'                   : '113X_mcRun2_pA_v4',
+    'run2_mc_pa'                   : '120X_mcRun2_pA_v1',
     # GlobalTag for Run2 data reprocessing
     'run2_data'                    : '120X_dataRun2_v2',
     # GlobalTag for Run2 data 2018B relvals only: HEM-15-16 fail
@@ -42,41 +40,41 @@ autoCond = {
     # GlobalTag for Run3 data relvals
     'run3_data_prompt'             : '113X_dataRun3_Prompt_v3',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,~0-centred beamspot)
-    'phase1_2017_design'           : '113X_mc2017_design_v5',
+    'phase1_2017_design'           : '120X_mc2017_design_v1',
     # GlobalTag for MC production with realistic conditions for Phase1 2017 detector
-    'phase1_2017_realistic'        : '113X_mc2017_realistic_v5',
+    'phase1_2017_realistic'        : '120X_mc2017_realistic_v1',
     # GlobalTag for MC production with realistic conditions for Phase1 2017 detector, for PP reference run
-    'phase1_2017_realistic_ppref'  :  '120X_mc2017_realistic_forppRef5TeV_v1',
+    'phase1_2017_realistic_ppref'  :  '120X_mc2017_realistic_forppRef5TeV_v2',
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in DECO mode
-    'phase1_2017_cosmics'          : '113X_mc2017cosmics_realistic_deco_v5',
+    'phase1_2017_cosmics'          : '120X_mc2017cosmics_realistic_deco_v1',
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in PEAK mode
-    'phase1_2017_cosmics_peak'     : '113X_mc2017cosmics_realistic_peak_v5',
+    'phase1_2017_cosmics_peak'     : '120X_mc2017cosmics_realistic_peak_v1',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for full Phase1 2018 (and 0,0,0-centred beamspot)
-    'phase1_2018_design'           : '113X_upgrade2018_design_v5',
+    'phase1_2018_design'           : '120X_upgrade2018_design_v1',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector
-    'phase1_2018_realistic'        : '113X_upgrade2018_realistic_v5',
+    'phase1_2018_realistic'        : '120X_upgrade2018_realistic_v1',
     # GlobalTag for MC production with realistic run-dependent (RD) conditions for full Phase1 2018 detector
-    'phase1_2018_realistic_rd'     : '113X_upgrade2018_realistic_RD_v4',
+    'phase1_2018_realistic_rd'     : '113X_upgrade2018_realistic_RD_v5',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector for Heavy Ion
-    'phase1_2018_realistic_hi'     : '113X_upgrade2018_realistic_HI_v5',
+    'phase1_2018_realistic_hi'     : '120X_upgrade2018_realistic_HI_v1',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector: HEM-15-16 fail
-    'phase1_2018_realistic_HEfail' : '113X_upgrade2018_realistic_HEfail_v5',
+    'phase1_2018_realistic_HEfail' : '120X_upgrade2018_realistic_HEfail_v1',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in DECO mode
-    'phase1_2018_cosmics'          : '113X_upgrade2018cosmics_realistic_deco_v5',
+    'phase1_2018_cosmics'          : '120X_upgrade2018cosmics_realistic_deco_v1',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in PEAK mode
-    'phase1_2018_cosmics_peak'     : '113X_upgrade2018cosmics_realistic_peak_v5',
+    'phase1_2018_cosmics_peak'     : '120X_upgrade2018cosmics_realistic_peak_v1',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2021
-    'phase1_2021_design'           : '120X_mcRun3_2021_design_v2', # GT containing design conditions for Phase1 2021
+    'phase1_2021_design'           : '120X_mcRun3_2021_design_v3', # GT containing design conditions for Phase1 2021
     # GlobalTag for MC production with realistic conditions for Phase1 2021
-    'phase1_2021_realistic'        : '120X_mcRun3_2021_realistic_v3', # GT containing realistic conditions for Phase1 2021
+    'phase1_2021_realistic'        : '120X_mcRun3_2021_realistic_v4', # GT containing realistic conditions for Phase1 2021
     # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2021,  Strip tracker in DECO mode
-    'phase1_2021_cosmics'          : '120X_mcRun3_2021cosmics_realistic_deco_v2',
+    'phase1_2021_cosmics'          : '120X_mcRun3_2021cosmics_realistic_deco_v3',
     # GlobalTag for MC production with realistic conditions for Phase1 2021 detector for Heavy Ion
-    'phase1_2021_realistic_hi'     : '120X_mcRun3_2021_realistic_HI_v2',
+    'phase1_2021_realistic_hi'     : '120X_mcRun3_2021_realistic_HI_v3',
     # GlobalTag for MC production with realistic conditions for Phase1 2023
-    'phase1_2023_realistic'        : '120X_mcRun3_2023_realistic_v3', # GT containing realistic conditions for Phase1 2023
+    'phase1_2023_realistic'        : '120X_mcRun3_2023_realistic_v4', # GT containing realistic conditions for Phase1 2023
     # GlobalTag for MC production with realistic conditions for Phase1 2024
-    'phase1_2024_realistic'        : '120X_mcRun3_2024_realistic_v3', # GT containing realistic conditions for Phase1 2024
+    'phase1_2024_realistic'        : '120X_mcRun3_2024_realistic_v4', # GT containing realistic conditions for Phase1 2024
     # GlobalTag for MC production with realistic conditions for Phase2
     'phase2_realistic'             : '113X_mcRun4_realistic_v7'
 }
@@ -115,8 +113,6 @@ autoCond['mc']               = ( autoCond['run1_design'] )
 autoCond['startup']          = ( autoCond['run1_mc'] )
     # GlobalTag for MC production of Heavy Ions events with realistic alignment and calibrations
 autoCond['starthi']          = ( autoCond['run1_mc_hi'] )
-    # GlobalTag for MC production of p-Pb events with realistic alignment and calibrations
-autoCond['startpa']          = ( autoCond['run1_mc_pa'] )
     # GlobalTag for data reprocessing
 autoCond['com10']            = ( autoCond['run1_data'] )
     # GlobalTag for running HLT on recent data: it points to the online GT (remove the snapshot!)

--- a/SimTracker/SiPixelDigitizer/plugins/PreMixingSiPixelWorker.cc
+++ b/SimTracker/SiPixelDigitizer/plugins/PreMixingSiPixelWorker.cc
@@ -265,7 +265,8 @@ void PreMixingSiPixelWorker::put(edm::Event& e,
 
   // Load inefficiency constants (1st pass), set pileup information.
   if (firstFinalizeEvent_) {
-    digitizer_.init_DynIneffDB(iSetup, bs);
+    //    digitizer_.init_DynIneffDB(iSetup, bs);
+    digitizer_.init_DynIneffDB(iSetup);
     firstFinalizeEvent_ = false;
   }
 

--- a/SimTracker/SiPixelDigitizer/plugins/PreMixingSiPixelWorker.cc
+++ b/SimTracker/SiPixelDigitizer/plugins/PreMixingSiPixelWorker.cc
@@ -265,7 +265,6 @@ void PreMixingSiPixelWorker::put(edm::Event& e,
 
   // Load inefficiency constants (1st pass), set pileup information.
   if (firstFinalizeEvent_) {
-    //    digitizer_.init_DynIneffDB(iSetup, bs);
     digitizer_.init_DynIneffDB(iSetup);
     firstFinalizeEvent_ = false;
   }

--- a/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizer.cc
+++ b/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizer.cc
@@ -250,8 +250,9 @@ namespace cms {
     std::vector<edm::DetSet<PixelDigiSimLink> > theDigiLinkVector;
 
     if (firstFinalizeEvent_) {
-      const unsigned int bunchspace = PileupInfo_->getMix_bunchSpacing();
-      _pixeldigialgo->init_DynIneffDB(iSetup, bunchspace);
+      //      const unsigned int bunchspace = PileupInfo_->getMix_bunchSpacing();
+      //      _pixeldigialgo->init_DynIneffDB(iSetup, bunchspace);
+      _pixeldigialgo->init_DynIneffDB(iSetup);
       firstFinalizeEvent_ = false;
     }
     _pixeldigialgo->calculateInstlumiFactor(PileupInfo_.get());

--- a/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizer.cc
+++ b/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizer.cc
@@ -250,8 +250,6 @@ namespace cms {
     std::vector<edm::DetSet<PixelDigiSimLink> > theDigiLinkVector;
 
     if (firstFinalizeEvent_) {
-      //      const unsigned int bunchspace = PileupInfo_->getMix_bunchSpacing();
-      //      _pixeldigialgo->init_DynIneffDB(iSetup, bunchspace);
       _pixeldigialgo->init_DynIneffDB(iSetup);
       firstFinalizeEvent_ = false;
     }

--- a/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizerAlgorithm.cc
+++ b/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizerAlgorithm.cc
@@ -329,7 +329,6 @@ SiPixelDigitizerAlgorithm::SiPixelDigitizerAlgorithm(const edm::ParameterSet& co
     // invent something new (similar to mayConsume in the ESProducer
     // side). So for now, let's consume both payloads.
     SiPixelDynamicInefficiencyToken_ = iC.esConsumes();
-    SiPixelDynamicInefficiencyToken50ns_ = iC.esConsumes(edm::ESInputTag("", "50ns"));
   }
   if (KillBadFEDChannels) {
     scenarioProbabilityToken_ = iC.esConsumes();
@@ -596,12 +595,12 @@ SiPixelDigitizerAlgorithm::PixelEfficiencies::PixelEfficiencies(const edm::Param
 }
 
 // Read DynIneff Scale factors from DB
-void SiPixelDigitizerAlgorithm::init_DynIneffDB(const edm::EventSetup& es, const unsigned int& bunchspace) {
+//void SiPixelDigitizerAlgorithm::init_DynIneffDB(const edm::EventSetup& es, const unsigned int& bunchspace) {
+void SiPixelDigitizerAlgorithm::init_DynIneffDB(const edm::EventSetup& es) {
+  LogDebug("PixelDigitizer ") << " In SiPixelDigitizerAlgorithm::init_DynIneffDB " << AddPixelInefficiency << "  "
+                              << pixelEfficiencies_.FromConfig << "\n";
   if (AddPixelInefficiency && !pixelEfficiencies_.FromConfig) {
-    if (bunchspace == 50)
-      SiPixelDynamicInefficiency_ = &es.getData(SiPixelDynamicInefficiencyToken50ns_);
-    else
-      SiPixelDynamicInefficiency_ = &es.getData(SiPixelDynamicInefficiencyToken_);
+    SiPixelDynamicInefficiency_ = &es.getData(SiPixelDynamicInefficiencyToken_);
     pixelEfficiencies_.init_from_db(geom_, SiPixelDynamicInefficiency_);
   }
 }
@@ -631,8 +630,12 @@ void SiPixelDigitizerAlgorithm::PixelEfficiencies::init_from_db(
   // ROC level inefficiency for phase 1 (disentangle scale factors for big and std size pixels)
   std::map<uint32_t, double> PixelGeomFactorsDB;
 
+  LogDebug("PixelDigitizer ") << " Check PixelEfficiencies -- PixelGeomFactorsDBIn "
+                              << "\n";
   if (geom->isThere(GeomDetEnumerators::P1PXB) || geom->isThere(GeomDetEnumerators::P1PXEC)) {
     for (auto db_factor : PixelGeomFactorsDBIn) {
+      LogDebug("PixelDigitizer ") << "      db_factor  " << db_factor.first << "  " << db_factor.second << "\n";
+
       int shift = DetId(db_factor.first).subdetId() == static_cast<int>(PixelSubdetector::PixelBarrel) ? BPixRocIdShift
                                                                                                        : FPixRocIdShift;
       unsigned int rocMask = rocIdMaskBits << shift;
@@ -664,27 +667,47 @@ void SiPixelDigitizerAlgorithm::PixelEfficiencies::init_from_db(
     PixelGeomFactorsDB = PixelGeomFactorsDBIn;
   }
 
+  LogDebug("PixelDigitizer ")
+      << " Check PixelEfficiencies -- Loop on all modules and store module level geometrical scale factors  "
+      << "\n";
   // Loop on all modules, store module level geometrical scale factors
   for (const auto& it_module : geom->detUnits()) {
     if (dynamic_cast<PixelGeomDetUnit const*>(it_module) == nullptr)
       continue;
     const DetId detid = it_module->geographicalId();
     uint32_t rawid = detid.rawId();
-    for (auto db_factor : PixelGeomFactorsDB)
+    for (auto db_factor : PixelGeomFactorsDB) {
+      LogDebug("PixelDigitizer ") << "      db_factor PixelGeomFactorsDB  " << db_factor.first << "  "
+                                  << db_factor.second << "\n";
       if (matches(detid, DetId(db_factor.first), DetIdmasks))
         PixelGeomFactors[rawid] *= db_factor.second;
-    for (auto db_factor : ColGeomFactorsDB)
+    }
+    for (auto db_factor : ColGeomFactorsDB) {
+      LogDebug("PixelDigitizer ") << "      db_factor ColGeomFactorsDB  " << db_factor.first << "  " << db_factor.second
+                                  << "\n";
       if (matches(detid, DetId(db_factor.first), DetIdmasks))
         ColGeomFactors[rawid] *= db_factor.second;
-    for (auto db_factor : ChipGeomFactorsDB)
+    }
+    for (auto db_factor : ChipGeomFactorsDB) {
+      LogDebug("PixelDigitizer ") << "      db_factor ChipGeomFactorsDB  " << db_factor.first << "  "
+                                  << db_factor.second << "\n";
       if (matches(detid, DetId(db_factor.first), DetIdmasks))
         ChipGeomFactors[rawid] *= db_factor.second;
+    }
   }
 
   // piluep scale factors are calculated once per event
   // therefore vector index is stored in a map for each module that matches to a db_id
   size_t i = 0;
+  LogDebug("PixelDigitizer ") << " Check PixelEfficiencies -- PUFactors "
+                              << "\n";
   for (const auto& factor : PUFactors) {
+    //
+    LogDebug("PixelDigitizer ") << "      factor  " << factor.first << "  " << factor.second.size() << "\n";
+    for (size_t i = 0, n = factor.second.size(); i < n; i++) {
+      LogDebug("PixelDigitizer ") << "     print factor.second for " << i << "   " << factor.second[i] << "\n";
+    }
+    //
     const DetId db_id = DetId(factor.first);
     for (const auto& it_module : geom->detUnits()) {
       if (dynamic_cast<PixelGeomDetUnit const*>(it_module) == nullptr)

--- a/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizerAlgorithm.cc
+++ b/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizerAlgorithm.cc
@@ -595,7 +595,6 @@ SiPixelDigitizerAlgorithm::PixelEfficiencies::PixelEfficiencies(const edm::Param
 }
 
 // Read DynIneff Scale factors from DB
-//void SiPixelDigitizerAlgorithm::init_DynIneffDB(const edm::EventSetup& es, const unsigned int& bunchspace) {
 void SiPixelDigitizerAlgorithm::init_DynIneffDB(const edm::EventSetup& es) {
   LogDebug("PixelDigitizer ") << " In SiPixelDigitizerAlgorithm::init_DynIneffDB " << AddPixelInefficiency << "  "
                               << pixelEfficiencies_.FromConfig << "\n";

--- a/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizerAlgorithm.h
+++ b/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizerAlgorithm.h
@@ -78,7 +78,7 @@ public:
                 const TrackerTopology* tTopo,
                 CLHEP::HepRandomEngine*);
   void calculateInstlumiFactor(PileupMixingContent* puInfo);
-  void init_DynIneffDB(const edm::EventSetup&, const unsigned int&);
+  void init_DynIneffDB(const edm::EventSetup&);
   std::unique_ptr<PixelFEDChannelCollection> chooseScenario(PileupMixingContent* puInfo, CLHEP::HepRandomEngine*);
 
   // for premixing
@@ -162,7 +162,6 @@ private:
 
   // Get Dynamic Inefficiency scale factors from DB
   edm::ESGetToken<SiPixelDynamicInefficiency, SiPixelDynamicInefficiencyRcd> SiPixelDynamicInefficiencyToken_;
-  edm::ESGetToken<SiPixelDynamicInefficiency, SiPixelDynamicInefficiencyRcd> SiPixelDynamicInefficiencyToken50ns_;
   const SiPixelDynamicInefficiency* SiPixelDynamicInefficiency_ = nullptr;
 
   // For BadFEDChannel simulation


### PR DESCRIPTION
#### PR description:

**First part of the PR :** 

Removal of the code lines related to the 50ns labeled dynamic inefficiency for Pixels, in view of removing the payload 			
      SiPixelDynamicInefficiencyRcd | 50ns | SiPixelDynamicInefficiency_13TeV_50ns_v2_mc
from the Global Tag, as discussed during the Pixel Offline Meeting of July 14 (https://indico.cern.ch/event/1000813/#11-removal-of-50ns-labeled-dyn).

I have made some checks in the SiPixelDigitizerAlgorithm::PixelEfficiencies::init_from_db function,
and verified that the code before and after my modifications delivers exactly the same SiPixelDynamicInefficiency information. 

**Second  part of the PR (Global Tag changes):** 

In case when the simulations require 50 ns bunch spacing the previously labeled (50 ns specific) payload is used. Code changes and validation can be found in the PR34502 [2]. The differences of the new and old GTs can be found in [3].

This PR contains the removal of the unused key run1_mc_pa as well.

[1] https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/4431.html
[2] #34502
[3] https://docs.google.com/spreadsheets/d/1FlABJmzWOrxKaNSUD_N980GQeO9ecYj4C8xXcl4IMNE/edit?usp=sharing

PR validation:
runTheMatrix.py -l limited,140.0,200.0,202.0,203.0,204.0,205.0,4001.0,4006.0,4007.0,4008.0,11634.0,12434.0,12834.0,1325.516,50200.0,7.22,145.0,281.0,10424.0,7.21,11224.0,250200.182,11024.2,7.4,12034.0,7.23,159.0,12834.0,7.24 --ibeos -j8

Private validation under
https://indico.cern.ch/event/1000813/contributions/4447059/attachments/2281939/3880637/20210714_PixelMeeting_DynEffCheck.pdf

plus wf25.0 and wf9.0 were tested
https://tvami.web.cern.ch/tvami/projects/PixelOffline/DynEffValidation/wf25/?match=ffic

https://tvami.web.cern.ch/tvami/projects/PixelOffline/DynEffValidation/wf9/?match=ffic

and show no significant changes.
