### PR TITLE
Improve MessageLogger Context  Handling for ProcessBlock Transitions

### DIFF
--- a/FWCore/MessageService/plugins/MessageLogger.h
+++ b/FWCore/MessageService/plugins/MessageLogger.h
@@ -166,6 +166,7 @@ namespace edm {
       std::vector<std::array<char, 64>> transitionInfoCache_;
       unsigned int lumiInfoBegin_ = 0;
       unsigned int runInfoBegin_ = 0;
+      unsigned int processBlockInfoBegin_ = 0;
 
       std::set<std::string> debugEnabledModules_;
       std::map<std::string, messagelogger::ELseverityLevel> suppression_levels_;

--- a/FWCore/MessageService/test/unit_test_outputs/u33_all.log
+++ b/FWCore/MessageService/test/unit_test_outputs/u33_all.log
@@ -4,7 +4,7 @@ T1 beginJob warning with identifier 11 event 0
 %MSG-w cat_BJ:  UTC_V1:ssm_1b@beginJob pre-events
 T1 beginJob warning with identifier 12 event 0
 %MSG
-%MSG-e TestMessageLogger:  BeginProcessBlock pre-events
+%MSG-e TestMessageLogger:  PreBeginProcessBlock pre-events
 test message from TestService::preBeginProcessBlock
 %MSG
 %MSG-i cat_BPB:  UTC_V1:ssm_1a@beginProcessBlock pre-events
@@ -105,7 +105,7 @@ test message from TestService::preGlobalEndLumi
 %MSG-e TestMessageLogger:  PreGlobalEndRun End Run: 1
 test message from TestService::preGlobalEndRun
 %MSG
-%MSG-e TestMessageLogger:  EndProcessBlock post-events
+%MSG-e TestMessageLogger:  PreEndProcessBlock post-events
 test message from TestService::preEndProcessBlock
 %MSG
 %MSG-i cat_EPB:  UTC_V1:ssm_1a@endProcessBlock post-events
@@ -139,8 +139,8 @@ MessageLogger Summary
    16 cat_BJ               -w UTC_V1:ssm_1b@be                       1        1
    17 cat_BL               -w UTC_V1:ssm_1a@be                       1        1
    18 cat_BL               -w UTC_V1:ssm_1b@be                       1        1
-   19 TestMessageLogger    -e BeginProcessBloc                       1        1
-   20 TestMessageLogger    -e EndProcessBlock                        1        1
+   19 TestMessageLogger    -e PreBeginProcessB                       1        1
+   20 TestMessageLogger    -e PreEndProcessBlo                       1        1
    21 TestMessageLogger    -e PreGlobalBeginLu                       1        1
    22 TestMessageLogger    -e PreGlobalBeginRu                       1        1
    23 TestMessageLogger    -e PreGlobalEndLumi                       1        1


### PR DESCRIPTION
#### PR description:

Affects only MessageLogger context strings during ProcessBlock transitions.

Change the MessageLogger code so that it handles the ProcessBlock case in a manner as close as possible to the way it is handled for Runs. Before this it was more similar to the way beginJob was handled. 

The main practical difference is that this can now properly deal with the case where a module ProcessBlock function goes into a wait that could allow other TBB tasks to run and another module runs its ProcessBlock transition before execution goes back to the original module and we want the context to be reset again for the original module. This does not currently happen anywhere, but it is possible. Logically the code is also cleaner and easier to understand if it is the same as in the Run case.

#### PR validation:

Relies on existing tests. One unit test is updated because of a minor change to make the context string more similar to that used for Runs.
