### PR TITLE
Reserve one bit for flagging individual pixels

### DIFF
--- a/DataFormats/SiPixelDetId/interface/PixelChannelIdentifier.h
+++ b/DataFormats/SiPixelDetId/interface/PixelChannelIdentifier.h
@@ -13,17 +13,17 @@ namespace pixelchanelidentifierimpl {
     using PackedDigiType = unsigned int;
 
     // Constructor: pre-computes masks and shifts from field widths
-    constexpr Packing(unsigned int row_w, unsigned int column_w, unsigned int time_w, unsigned int adc_w)
+    constexpr Packing(unsigned int row_w, unsigned int column_w, unsigned int flag_w, unsigned int adc_w)
         : row_width(row_w),
           column_width(column_w),
           adc_width(adc_w),
           row_shift(0),
           column_shift(row_shift + row_w),
-          time_shift(column_shift + column_w),
-          adc_shift(time_shift + time_w),
+          flag_shift(column_shift + column_w),
+          adc_shift(flag_shift + flag_w),
           row_mask(~(~0U << row_w)),
           column_mask(~(~0U << column_w)),
-          time_mask(~(~0U << time_w)),
+          flag_mask(~(~0U << flag_w)),
           adc_mask(~(~0U << adc_w)),
           rowcol_mask(~(~0U << (column_w + row_w))),
           max_row(row_mask),
@@ -36,12 +36,12 @@ namespace pixelchanelidentifierimpl {
 
     const int row_shift;
     const int column_shift;
-    const int time_shift;
+    const int flag_shift;
     const int adc_shift;
 
     const PackedDigiType row_mask;
     const PackedDigiType column_mask;
-    const PackedDigiType time_mask;
+    const PackedDigiType flag_mask;
     const PackedDigiType adc_mask;
     const PackedDigiType rowcol_mask;
 
@@ -69,7 +69,7 @@ public:
 public:
   constexpr static Packing packing() { return Packing(8, 9, 4, 11); }
 
-  constexpr static Packing thePacking = {11, 11, 0, 10};
+  constexpr static Packing thePacking = {11, 10, 0, 10};
 };
 
 #endif

--- a/DataFormats/SiPixelDigi/interface/PixelDigi.h
+++ b/DataFormats/SiPixelDigi/interface/PixelDigi.h
@@ -19,6 +19,7 @@ public:
   explicit PixelDigi(PackedDigiType packed_value) : theData(packed_value) {}
 
   PixelDigi(int row, int col, int adc) { init(row, col, adc); }
+  PixelDigi(int row, int col, int adc, int flag) { init(row, col, adc, flag); }
 
   PixelDigi(int chan, int adc) {
     std::pair<int, int> rc = channelToPixel(chan);
@@ -27,7 +28,7 @@ public:
 
   PixelDigi() : theData(0) {}
 
-  void init(int row, int col, int adc) {
+  void init(int row, int col, int adc, int flag = 0) {
 #ifdef FIXME_DEBUG
     // This check is for the maximal row or col number that can be packed
     // in a PixelDigi. The actual number of rows or columns in a detector
@@ -45,7 +46,8 @@ public:
 
     theData = (row << PixelChannelIdentifier::thePacking.row_shift) |
               (col << PixelChannelIdentifier::thePacking.column_shift) |
-              (adc << PixelChannelIdentifier::thePacking.adc_shift);
+              (adc << PixelChannelIdentifier::thePacking.adc_shift) |
+              (flag << PixelChannelIdentifier::thePacking.flag_shift);
   }
 
   // Access to digi information
@@ -56,7 +58,9 @@ public:
     return (theData >> PixelChannelIdentifier::thePacking.column_shift) &
            PixelChannelIdentifier::thePacking.column_mask;
   }
-  //int time() const    {return (theData >> PixelChannelIdentifier::thePacking.time_shift) & PixelChannelIdentifier::thePacking.time_mask;}
+  int flag() const {
+    return (theData >> PixelChannelIdentifier::thePacking.flag_shift) & PixelChannelIdentifier::thePacking.flag_mask;
+  }
   unsigned short adc() const {
     return (theData >> PixelChannelIdentifier::thePacking.adc_shift) & PixelChannelIdentifier::thePacking.adc_mask;
   }


### PR DESCRIPTION
#### PR description:

Change Pixel Digi Packing to reserve one bit for flagging individual pixels (needed for the foreseen PR concerning Pixel Digi Morphing).

Pixel Digi Packing was changed in https://github.com/cms-sw/cmssw/pull/14470 to have indexes spanning the full module in case of small pixels (Phase II InnerPixel). In that PR packing was changed from (8, 9, 4, 11) ->  (11, 11, 0, 10) /(row, col, time, adc) which can accommodate 2048x2048 pixels (row x column), 
row = 11bits -> 2^11 = 2048, col = 11bits -> 2^11 = 2048.

With this PR the packing changes from  (11, 11, 0, 10) ->  (11, 10, 0, 10), reducing row x column to 2048x1024.    However, this would fit all Phase II use cases (both for 25x100 μm2  and  50x50 μm2) as there are max 1354 (rows)*434 (cols) in the case of 2x2 rectangular pixel layout.

No changes are expected. 

#### PR validation:

No failure when running runTheMatrix.py.

@emiglior, @mmusich , @veszpv 