### PR TITLE
Migrate EDModules in RecoTauTag/RecoTau to esConsumes

### DIFF
--- a/RecoTauTag/RecoTau/interface/AntiElectronDeadECAL.h
+++ b/RecoTauTag/RecoTau/interface/AntiElectronDeadECAL.h
@@ -22,12 +22,14 @@
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/ESWatcher.h"
+#include "CondFormats/EcalObjects/interface/EcalChannelStatus.h"
 #include "DataFormats/Candidate/interface/Candidate.h"
 #include "RecoTauTag/RecoTau/interface/PositionAtECalEntranceComputer.h"
 
 #include <vector>
 #include <string>
 
+class EcalTrigTowerConstituentsMap;
 class EcalChannelStatusRcd;
 class CaloGeometryRecord;
 class IdealGeometryRecord;
@@ -46,6 +48,9 @@ private:
   const double dR2_;
   const bool extrapolateToECalEntrance_;
   const int verbosity_;
+  const edm::ESGetToken<EcalChannelStatus, EcalChannelStatusRcd> channelStatusToken_;
+  const edm::ESGetToken<CaloGeometry, CaloGeometryRecord> caloGeometryToken_;
+  const edm::ESGetToken<EcalTrigTowerConstituentsMap, IdealGeometryRecord> ttMapToken_;
 
   PositionAtECalEntranceComputer positionAtECalEntrance_;
 

--- a/RecoTauTag/RecoTau/interface/AntiElectronIDMVA6.h
+++ b/RecoTauTag/RecoTau/interface/AntiElectronIDMVA6.h
@@ -34,6 +34,8 @@
 
 #include <vector>
 
+class GBRWrapperRcd;
+
 namespace antiElecIDMVA6_blocks {
   struct TauVars {
     float pt = 0;
@@ -176,6 +178,19 @@ private:
   std::string mvaName_NoEleMatch_wGwoGSF_VFEC_;
   std::string mvaName_woGwGSF_VFEC_;
   std::string mvaName_wGwGSF_VFEC_;
+
+  edm::ESGetToken<GBRForest, GBRWrapperRcd> mvaToken_NoEleMatch_woGwoGSF_BL_;
+  edm::ESGetToken<GBRForest, GBRWrapperRcd> mvaToken_NoEleMatch_wGwoGSF_BL_;
+  edm::ESGetToken<GBRForest, GBRWrapperRcd> mvaToken_woGwGSF_BL_;
+  edm::ESGetToken<GBRForest, GBRWrapperRcd> mvaToken_wGwGSF_BL_;
+  edm::ESGetToken<GBRForest, GBRWrapperRcd> mvaToken_NoEleMatch_woGwoGSF_EC_;
+  edm::ESGetToken<GBRForest, GBRWrapperRcd> mvaToken_NoEleMatch_wGwoGSF_EC_;
+  edm::ESGetToken<GBRForest, GBRWrapperRcd> mvaToken_woGwGSF_EC_;
+  edm::ESGetToken<GBRForest, GBRWrapperRcd> mvaToken_wGwGSF_EC_;
+  edm::ESGetToken<GBRForest, GBRWrapperRcd> mvaToken_NoEleMatch_woGwoGSF_VFEC_;
+  edm::ESGetToken<GBRForest, GBRWrapperRcd> mvaToken_NoEleMatch_wGwoGSF_VFEC_;
+  edm::ESGetToken<GBRForest, GBRWrapperRcd> mvaToken_woGwGSF_VFEC_;
+  edm::ESGetToken<GBRForest, GBRWrapperRcd> mvaToken_wGwGSF_VFEC_;
 
   bool usePhiAtEcalEntranceExtrapolation_;
 

--- a/RecoTauTag/RecoTau/interface/TauDiscriminationProducerBase.h
+++ b/RecoTauTag/RecoTau/interface/TauDiscriminationProducerBase.h
@@ -31,7 +31,6 @@
  */
 
 #include "FWCore/Framework/interface/stream/EDProducer.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"

--- a/RecoTauTag/RecoTau/plugins/PATTauDiscriminationByMVAIsolationRun2.cc
+++ b/RecoTauTag/RecoTau/plugins/PATTauDiscriminationByMVAIsolationRun2.cc
@@ -37,7 +37,6 @@
 
 #include "CondFormats/GBRForest/interface/GBRForest.h"
 #include "CondFormats/DataRecord/interface/GBRWrapperRcd.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 
 #include <TFile.h>
 
@@ -65,12 +64,6 @@ namespace {
 
     return mva;
   }
-
-  const GBRForest* loadMVAfromDB(const edm::EventSetup& es, const std::string& mvaName) {
-    edm::ESHandle<GBRForest> mva;
-    es.get<GBRWrapperRcd>().get(mvaName, mva);
-    return mva.product();
-  }
 }  // namespace
 
 namespace reco {
@@ -87,6 +80,8 @@ namespace reco {
         loadMVAfromDB_ = cfg.getParameter<bool>("loadMVAfromDB");
         if (!loadMVAfromDB_) {
           inputFileName_ = cfg.getParameter<edm::FileInPath>("inputFileName");
+        } else {
+          mvaToken_ = esConsumes(edm::ESInputTag{"", mvaName_});
         }
         std::string mvaOpt_string = cfg.getParameter<std::string>("mvaOpt");
         if (mvaOpt_string == "oldDMwoLT")
@@ -155,6 +150,7 @@ namespace reco {
       std::string moduleLabel_;
 
       std::string mvaName_;
+      edm::ESGetToken<GBRForest, GBRWrapperRcd> mvaToken_;
       bool loadMVAfromDB_;
       edm::FileInPath inputFileName_;
       const GBRForest* mvaReader_;
@@ -176,7 +172,7 @@ namespace reco {
     void PATTauDiscriminationByMVAIsolationRun2::beginEvent(const edm::Event& evt, const edm::EventSetup& es) {
       if (!mvaReader_) {
         if (loadMVAfromDB_) {
-          mvaReader_ = loadMVAfromDB(es, mvaName_);
+          mvaReader_ = &es.getData(mvaToken_);
         } else {
           mvaReader_ = loadMVAfromFile(inputFileName_, mvaName_, inputFilesToDelete_);
         }

--- a/RecoTauTag/RecoTau/plugins/PFRecoTauChargedHadronFromGenericTrackPlugin.cc
+++ b/RecoTauTag/RecoTau/plugins/PFRecoTauChargedHadronFromGenericTrackPlugin.cc
@@ -17,7 +17,6 @@
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "MagneticField/Engine/interface/MagneticField.h"
 #include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
 
@@ -74,6 +73,7 @@ namespace reco {
 
       edm::InputTag srcTracks_;
       edm::EDGetTokenT<std::vector<TrackClass> > Tracks_token;
+      const edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> magneticFieldToken_;
       double dRcone_;
       bool dRconeLimitedToJetArea_;
 
@@ -96,7 +96,8 @@ namespace reco {
         const edm::ParameterSet& pset, edm::ConsumesCollector&& iC)
         : PFRecoTauChargedHadronBuilderPlugin(pset, std::move(iC)),
           vertexAssociator_(pset.getParameter<edm::ParameterSet>("qualityCuts"), std::move(iC)),
-          qcuts_(nullptr) {
+          qcuts_(nullptr),
+          magneticFieldToken_(iC.esConsumes()) {
       edm::ParameterSet qcuts_pset = pset.getParameterSet("qualityCuts").getParameterSet("signalQualityCuts");
       qcuts_ = new RecoTauQualityCuts(qcuts_pset);
 
@@ -121,10 +122,7 @@ namespace reco {
     void PFRecoTauChargedHadronFromGenericTrackPlugin<TrackClass>::beginEvent() {
       vertexAssociator_.setEvent(*this->evt());
 
-      edm::ESHandle<MagneticField> magneticField;
-      const edm::EventSetup* evtSetup(this->evtSetup());
-      evtSetup->get<IdealMagneticFieldRecord>().get(magneticField);
-      magneticFieldStrength_ = magneticField->inTesla(GlobalPoint(0., 0., 0.));
+      magneticFieldStrength_ = evtSetup()->getData(magneticFieldToken_).inTesla(GlobalPoint(0., 0., 0.));
     }
 
     template <>

--- a/RecoTauTag/RecoTau/plugins/PFRecoTauChargedHadronFromPFCandidatePlugin.cc
+++ b/RecoTauTag/RecoTau/plugins/PFRecoTauChargedHadronFromPFCandidatePlugin.cc
@@ -25,7 +25,6 @@
 #include "DataFormats/Math/interface/deltaR.h"
 #include "DataFormats/Common/interface/RefToPtr.h"
 
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "MagneticField/Engine/interface/MagneticField.h"
 #include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
@@ -75,6 +74,7 @@ namespace reco {
       double minMergeGammaEt_;
       double minMergeChargedHadronPt_;
 
+      const edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> bFieldToken_;
       double bField_;
 
       int verbosity_;
@@ -84,7 +84,8 @@ namespace reco {
         const edm::ParameterSet& pset, edm::ConsumesCollector&& iC)
         : PFRecoTauChargedHadronBuilderPlugin(pset, std::move(iC)),
           vertexAssociator_(pset.getParameter<edm::ParameterSet>("qualityCuts"), std::move(iC)),
-          qcuts_(nullptr) {
+          qcuts_(nullptr),
+          bFieldToken_(iC.esConsumes()) {
       edm::ParameterSet qcuts_pset = pset.getParameterSet("qualityCuts").getParameterSet("signalQualityCuts");
       qcuts_ = new RecoTauQualityCuts(qcuts_pset);
 
@@ -115,9 +116,7 @@ namespace reco {
     void PFRecoTauChargedHadronFromPFCandidatePlugin::beginEvent() {
       vertexAssociator_.setEvent(*evt());
 
-      edm::ESHandle<MagneticField> pSetup;
-      evtSetup()->get<IdealMagneticFieldRecord>().get(pSetup);
-      bField_ = pSetup->inTesla(GlobalPoint(0, 0, 0)).z();
+      bField_ = evtSetup()->getData(bFieldToken_).inTesla(GlobalPoint(0, 0, 0)).z();
     }
 
     namespace {

--- a/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationByMVAIsolationRun2.cc
+++ b/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationByMVAIsolationRun2.cc
@@ -32,7 +32,6 @@
 
 #include "CondFormats/GBRForest/interface/GBRForest.h"
 #include "CondFormats/DataRecord/interface/GBRWrapperRcd.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 
 #include <TFile.h>
 
@@ -60,12 +59,6 @@ namespace {
 
     return mva;
   }
-
-  const GBRForest* loadMVAfromDB(const edm::EventSetup& es, const std::string& mvaName) {
-    edm::ESHandle<GBRForest> mva;
-    es.get<GBRWrapperRcd>().get(mvaName, mva);
-    return mva.product();
-  }
 }  // namespace
 
 namespace reco {
@@ -82,6 +75,8 @@ namespace reco {
         loadMVAfromDB_ = cfg.getParameter<bool>("loadMVAfromDB");
         if (!loadMVAfromDB_) {
           inputFileName_ = cfg.getParameter<edm::FileInPath>("inputFileName");
+        } else {
+          mvaToken_ = esConsumes(edm::ESInputTag{"", mvaName_});
         }
         std::string mvaOpt_string = cfg.getParameter<std::string>("mvaOpt");
         if (mvaOpt_string == "oldDMwoLT")
@@ -147,6 +142,7 @@ namespace reco {
       std::string moduleLabel_;
 
       std::string mvaName_;
+      edm::ESGetToken<GBRForest, GBRWrapperRcd> mvaToken_;
       bool loadMVAfromDB_;
       edm::FileInPath inputFileName_;
       const GBRForest* mvaReader_;
@@ -178,7 +174,7 @@ namespace reco {
     void PFRecoTauDiscriminationByMVAIsolationRun2::beginEvent(const edm::Event& evt, const edm::EventSetup& es) {
       if (!mvaReader_) {
         if (loadMVAfromDB_) {
-          mvaReader_ = loadMVAfromDB(es, mvaName_);
+          mvaReader_ = &es.getData(mvaToken_);
         } else {
           mvaReader_ = loadMVAfromFile(inputFileName_, mvaName_, inputFilesToDelete_);
         }

--- a/RecoTauTag/RecoTau/plugins/PFRecoTauTagInfoProducer.cc
+++ b/RecoTauTag/RecoTau/plugins/PFRecoTauTagInfoProducer.cc
@@ -13,7 +13,6 @@
 #include "RecoTauTag/RecoTau/interface/PFRecoTauTagInfoAlgorithm.h"
 
 #include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"

--- a/RecoTauTag/RecoTau/plugins/RecoTauCleaner.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauCleaner.cc
@@ -20,7 +20,6 @@
 
 #include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 

--- a/RecoTauTag/RecoTau/plugins/RecoTauEnergyRecoveryPlugin2.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauEnergyRecoveryPlugin2.cc
@@ -26,8 +26,6 @@
 #include "DataFormats/VertexReco/interface/VertexFwd.h"
 #include "RecoTauTag/RecoTau/interface/RecoTauQualityCuts.h"
 
-#include "FWCore/Framework/interface/ESHandle.h"
-
 #include "DataFormats/Math/interface/deltaR.h"
 
 #include <algorithm>

--- a/RecoTauTag/RecoTau/plugins/RecoTauGenericJetRegionProducer.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauGenericJetRegionProducer.cc
@@ -21,7 +21,6 @@
 
 #include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/makeRefToBaseProdFrom.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"

--- a/RecoTauTag/RecoTau/plugins/RecoTauImpactParameterSignificancePlugin.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauImpactParameterSignificancePlugin.cc
@@ -18,7 +18,6 @@
 #include "DataFormats/VertexReco/interface/Vertex.h"
 #include "DataFormats/VertexReco/interface/VertexFwd.h"
 
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "TrackingTools/TransientTrack/interface/TransientTrackBuilder.h"
 
 #include "TrackingTools/IPTools/interface/IPTools.h"
@@ -36,6 +35,7 @@ namespace reco {
       void beginEvent() override;
 
     private:
+      const edm::ESGetToken<TransientTrackBuilder, TransientTrackRecord> transTrackBuilderToken_;
       RecoTauVertexAssociator vertexAssociator_;
       const TransientTrackBuilder* builder_;
     };
@@ -43,14 +43,13 @@ namespace reco {
     RecoTauImpactParameterSignificancePlugin ::RecoTauImpactParameterSignificancePlugin(const edm::ParameterSet& pset,
                                                                                         edm::ConsumesCollector&& iC)
         : RecoTauModifierPlugin(pset, std::move(iC)),
+          transTrackBuilderToken_(iC.esConsumes(edm::ESInputTag{"", "TransientTrackBuilder"})),
           vertexAssociator_(pset.getParameter<edm::ParameterSet>("qualityCuts"), std::move(iC)) {}
 
     void RecoTauImpactParameterSignificancePlugin::beginEvent() {
       vertexAssociator_.setEvent(*evt());
       // Get tranisent track builder.
-      edm::ESHandle<TransientTrackBuilder> myTransientTrackBuilder;
-      evtSetup()->get<TransientTrackRecord>().get("TransientTrackBuilder", myTransientTrackBuilder);
-      builder_ = myTransientTrackBuilder.product();
+      builder_ = &evtSetup()->getData(transTrackBuilderToken_);
     }
 
     namespace {

--- a/RecoTauTag/RecoTau/plugins/RecoTauPiZeroProducer.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauPiZeroProducer.cc
@@ -19,7 +19,6 @@
 
 #include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"

--- a/RecoTauTag/RecoTau/plugins/RecoTauPileUpVertexSelector.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauPileUpVertexSelector.cc
@@ -7,7 +7,6 @@
 
 #include "FWCore/Framework/interface/stream/EDFilter.h"
 #include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"

--- a/RecoTauTag/RecoTau/plugins/RecoTauProducer.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauProducer.cc
@@ -23,7 +23,6 @@
 
 #include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include <FWCore/ParameterSet/interface/ConfigurationDescriptions.h>

--- a/RecoTauTag/RecoTau/src/AntiElectronDeadECAL.cc
+++ b/RecoTauTag/RecoTau/src/AntiElectronDeadECAL.cc
@@ -77,24 +77,10 @@ void AntiElectronDeadECAL::updateBadTowers(const edm::EventSetup& es) {
   std::map<uint32_t, unsigned> nBadCrystals, maxStatus;
   std::map<uint32_t, double> sumEta, sumPhi;
 
-  loopXtals<EBDetId>(nBadCrystals,
-                     maxStatus,
-                     sumEta,
-                     sumPhi,
-                     &channelStatus,
-                     &caloGeometry,
-                     &ttMap,
-                     minStatus_,
-                     statusMask_);
-  loopXtals<EEDetId>(nBadCrystals,
-                     maxStatus,
-                     sumEta,
-                     sumPhi,
-                     &channelStatus,
-                     &caloGeometry,
-                     &ttMap,
-                     minStatus_,
-                     statusMask_);
+  loopXtals<EBDetId>(
+      nBadCrystals, maxStatus, sumEta, sumPhi, &channelStatus, &caloGeometry, &ttMap, minStatus_, statusMask_);
+  loopXtals<EEDetId>(
+      nBadCrystals, maxStatus, sumEta, sumPhi, &channelStatus, &caloGeometry, &ttMap, minStatus_, statusMask_);
 
   badTowers_.clear();
   for (auto it : nBadCrystals) {

--- a/RecoTauTag/RecoTau/src/AntiElectronDeadECAL.cc
+++ b/RecoTauTag/RecoTau/src/AntiElectronDeadECAL.cc
@@ -1,8 +1,6 @@
 #include "RecoTauTag/RecoTau/interface/AntiElectronDeadECAL.h"
 
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "CondFormats/DataRecord/interface/EcalChannelStatusRcd.h"
-#include "CondFormats/EcalObjects/interface/EcalChannelStatus.h"
 #include "Geometry/Records/interface/CaloGeometryRecord.h"
 #include "Geometry/CaloGeometry/interface/CaloGeometry.h"
 #include "Geometry/CaloTopology/interface/EcalTrigTowerConstituentsMap.h"
@@ -20,6 +18,9 @@ AntiElectronDeadECAL::AntiElectronDeadECAL(const edm::ParameterSet& cfg, edm::Co
       dR2_(std::pow(cfg.getParameter<double>("dR"), 2)),
       extrapolateToECalEntrance_(cfg.getParameter<bool>("extrapolateToECalEntrance")),
       verbosity_(cfg.getParameter<int>("verbosity")),
+      channelStatusToken_(cc.esConsumes()),
+      caloGeometryToken_(cc.esConsumes()),
+      ttMapToken_(cc.esConsumes()),
       positionAtECalEntrance_(PositionAtECalEntranceComputer(cc)),
       isFirstEvent_(true) {}
 
@@ -69,14 +70,9 @@ void AntiElectronDeadECAL::updateBadTowers(const edm::EventSetup& es) {
       !idealGeometryWatcher_.check(es))
     return;
 
-  edm::ESHandle<EcalChannelStatus> channelStatus;
-  es.get<EcalChannelStatusRcd>().get(channelStatus);
-
-  edm::ESHandle<CaloGeometry> caloGeometry;
-  es.get<CaloGeometryRecord>().get(caloGeometry);
-
-  edm::ESHandle<EcalTrigTowerConstituentsMap> ttMap;
-  es.get<IdealGeometryRecord>().get(ttMap);
+  auto const& channelStatus = es.getData(channelStatusToken_);
+  auto const& caloGeometry = es.getData(caloGeometryToken_);
+  auto const& ttMap = es.getData(ttMapToken_);
 
   std::map<uint32_t, unsigned> nBadCrystals, maxStatus;
   std::map<uint32_t, double> sumEta, sumPhi;
@@ -85,18 +81,18 @@ void AntiElectronDeadECAL::updateBadTowers(const edm::EventSetup& es) {
                      maxStatus,
                      sumEta,
                      sumPhi,
-                     channelStatus.product(),
-                     caloGeometry.product(),
-                     ttMap.product(),
+                     &channelStatus,
+                     &caloGeometry,
+                     &ttMap,
                      minStatus_,
                      statusMask_);
   loopXtals<EEDetId>(nBadCrystals,
                      maxStatus,
                      sumEta,
                      sumPhi,
-                     channelStatus.product(),
-                     caloGeometry.product(),
-                     ttMap.product(),
+                     &channelStatus,
+                     &caloGeometry,
+                     &ttMap,
                      minStatus_,
                      statusMask_);
 

--- a/RecoTauTag/RecoTau/src/AntiElectronIDMVA6.cc
+++ b/RecoTauTag/RecoTau/src/AntiElectronIDMVA6.cc
@@ -9,7 +9,6 @@
 #include "DataFormats/MuonReco/interface/Muon.h"
 
 #include "CondFormats/DataRecord/interface/GBRWrapperRcd.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 
 #include <TFile.h>
 #include <array>
@@ -73,6 +72,22 @@ AntiElectronIDMVA6<TauType, ElectronType>::AntiElectronIDMVA6(const edm::Paramet
     mvaName_NoEleMatch_wGwoGSF_VFEC_ = cfg.getParameter<std::string>("mvaName_NoEleMatch_wGwoGSF_VFEC");
     mvaName_woGwGSF_VFEC_ = cfg.getParameter<std::string>("mvaName_woGwGSF_VFEC");
     mvaName_wGwGSF_VFEC_ = cfg.getParameter<std::string>("mvaName_wGwGSF_VFEC");
+  }
+  if (loadMVAfromDB_) {
+    mvaToken_NoEleMatch_woGwoGSF_BL_ = cc.esConsumes(edm::ESInputTag{"", mvaName_NoEleMatch_woGwoGSF_BL_});
+    mvaToken_NoEleMatch_wGwoGSF_BL_ = cc.esConsumes(edm::ESInputTag{"", mvaName_NoEleMatch_wGwoGSF_BL_});
+    mvaToken_woGwGSF_BL_ = cc.esConsumes(edm::ESInputTag{"", mvaName_woGwGSF_BL_});
+    mvaToken_wGwGSF_BL_ = cc.esConsumes(edm::ESInputTag{"", mvaName_wGwGSF_BL_});
+    mvaToken_NoEleMatch_woGwoGSF_EC_ = cc.esConsumes(edm::ESInputTag{"", mvaName_NoEleMatch_woGwoGSF_EC_});
+    mvaToken_NoEleMatch_wGwoGSF_EC_ = cc.esConsumes(edm::ESInputTag{"", mvaName_NoEleMatch_wGwoGSF_EC_});
+    mvaToken_woGwGSF_EC_ = cc.esConsumes(edm::ESInputTag{"", mvaName_woGwGSF_EC_});
+    mvaToken_wGwGSF_EC_ = cc.esConsumes(edm::ESInputTag{"", mvaName_wGwGSF_EC_});
+    if (isPhase2_) {
+      mvaToken_NoEleMatch_woGwoGSF_VFEC_ = cc.esConsumes(edm::ESInputTag{"", mvaName_NoEleMatch_woGwoGSF_VFEC_});
+      mvaToken_NoEleMatch_wGwoGSF_VFEC_ = cc.esConsumes(edm::ESInputTag{"", mvaName_NoEleMatch_wGwoGSF_VFEC_});
+      mvaToken_woGwGSF_VFEC_ = cc.esConsumes(edm::ESInputTag{"", mvaName_woGwGSF_VFEC_});
+      mvaToken_wGwGSF_VFEC_ = cc.esConsumes(edm::ESInputTag{"", mvaName_wGwGSF_VFEC_});
+    }
   }
   usePhiAtEcalEntranceExtrapolation_ = cfg.getParameter<bool>("usePhiAtEcalEntranceExtrapolation");
 
@@ -145,31 +160,25 @@ namespace {
 
     return mva;
   }
-
-  const GBRForest* loadMVAfromDB(const edm::EventSetup& es, const std::string& mvaName) {
-    edm::ESHandle<GBRForest> mva;
-    es.get<GBRWrapperRcd>().get(mvaName, mva);
-    return mva.product();
-  }
 }  // namespace
 
 template <class TauType, class ElectronType>
 void AntiElectronIDMVA6<TauType, ElectronType>::beginEvent(const edm::Event& evt, const edm::EventSetup& es) {
   if (!isInitialized_) {
     if (loadMVAfromDB_) {
-      mva_NoEleMatch_woGwoGSF_BL_ = loadMVAfromDB(es, mvaName_NoEleMatch_woGwoGSF_BL_);
-      mva_NoEleMatch_wGwoGSF_BL_ = loadMVAfromDB(es, mvaName_NoEleMatch_wGwoGSF_BL_);
-      mva_woGwGSF_BL_ = loadMVAfromDB(es, mvaName_woGwGSF_BL_);
-      mva_wGwGSF_BL_ = loadMVAfromDB(es, mvaName_wGwGSF_BL_);
-      mva_NoEleMatch_woGwoGSF_EC_ = loadMVAfromDB(es, mvaName_NoEleMatch_woGwoGSF_EC_);
-      mva_NoEleMatch_wGwoGSF_EC_ = loadMVAfromDB(es, mvaName_NoEleMatch_wGwoGSF_EC_);
-      mva_woGwGSF_EC_ = loadMVAfromDB(es, mvaName_woGwGSF_EC_);
-      mva_wGwGSF_EC_ = loadMVAfromDB(es, mvaName_wGwGSF_EC_);
+      mva_NoEleMatch_woGwoGSF_BL_ = &es.getData(mvaToken_NoEleMatch_woGwoGSF_BL_);
+      mva_NoEleMatch_wGwoGSF_BL_ = &es.getData(mvaToken_NoEleMatch_wGwoGSF_BL_);
+      mva_woGwGSF_BL_ = &es.getData(mvaToken_woGwGSF_BL_);
+      mva_wGwGSF_BL_ = &es.getData(mvaToken_wGwGSF_BL_);
+      mva_NoEleMatch_woGwoGSF_EC_ = &es.getData(mvaToken_NoEleMatch_woGwoGSF_EC_);
+      mva_NoEleMatch_wGwoGSF_EC_ = &es.getData(mvaToken_NoEleMatch_wGwoGSF_EC_);
+      mva_woGwGSF_EC_ = &es.getData(mvaToken_woGwGSF_EC_);
+      mva_wGwGSF_EC_ = &es.getData(mvaToken_wGwGSF_EC_);
       if (isPhase2_) {
-        mva_NoEleMatch_woGwoGSF_VFEC_ = loadMVAfromDB(es, mvaName_NoEleMatch_woGwoGSF_VFEC_);
-        mva_NoEleMatch_wGwoGSF_VFEC_ = loadMVAfromDB(es, mvaName_NoEleMatch_wGwoGSF_VFEC_);
-        mva_woGwGSF_VFEC_ = loadMVAfromDB(es, mvaName_woGwGSF_VFEC_);
-        mva_wGwGSF_VFEC_ = loadMVAfromDB(es, mvaName_wGwGSF_VFEC_);
+        mva_NoEleMatch_woGwoGSF_VFEC_ = &es.getData(mvaToken_NoEleMatch_woGwoGSF_VFEC_);
+        mva_NoEleMatch_wGwoGSF_VFEC_ = &es.getData(mvaToken_NoEleMatch_wGwoGSF_VFEC_);
+        mva_woGwGSF_VFEC_ = &es.getData(mvaToken_woGwGSF_VFEC_);
+        mva_wGwGSF_VFEC_ = &es.getData(mvaToken_wGwGSF_VFEC_);
       }
     } else {
       if (inputFileName_.location() == edm::FileInPath::Unknown)


### PR DESCRIPTION
#### PR description:

Part of #31061. I happened to look into these while we were updating the script producing the runTheMatrix-filtered list of EDModules that need to be migrated, and these looked straightforward-enough to migrate quickly. (and by the time we managed to get the script to handle properly the few "problematic" ones here, I had done majority of the work).

I intentionally left `TauDiscriminationAgainstCaloMuon` out because it looked like dead code (e.g. not using consumes for event data, nothing else in CMSSW referring to it).

Resolves https://github.com/makortel/framework/issues/191.


#### PR validation:

Code compiles