### PR TITLE
fix `test_getPayloadData` in case there've been recent changes in the plugins definitions

### DIFF
--- a/CondCore/Utilities/test/test_getPayloadData.sh
+++ b/CondCore/Utilities/test/test_getPayloadData.sh
@@ -9,10 +9,12 @@ check_for_failure() {
 }
 
 check_for_full(){
-    count=`echo ${@} | python3 -c 'import json,sys;print(len(json.load(sys.stdin)["cond::BasicPayload"]))'`
-    if [[ $count -gt 1 ]] 
+    count=`echo ${@} | python3 -c 'import json,sys;data=json.load(sys.stdin);print(len(data.keys()))'`
+    echo $count
+    if [[ $count -gt 0 ]]
     then 
-	echo -e "\n ---> passed getPayloadData.py --discover test : found $count entries"
+	entries=`echo ${@} | python3 -c 'import json,sys;data=json.load(sys.stdin);print(list(data.keys()))'`
+	echo -e "\n ---> passed getPayloadData.py --discover test : found $count entries: $entries"
     else 
 	echo -e "getPayloadData.py --discover test not passed... found no entries"
 	exit 1


### PR DESCRIPTION
fixes https://github.com/cms-sw/cmssw/issues/34512

#### PR description:

Addresses https://github.com/cms-sw/cmssw/issues/34512#issuecomment-881266037 by not looking for a specific key in the returned json file, but just checking if the length is not 0.

#### PR validation:

```console
scram b runtests 
```

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A