### PR TITLE
use integer/floor division in IgProfInfo.py

### DIFF
--- a/Validation/Performance/python/IgProfInfo.py
+++ b/Validation/Performance/python/IgProfInfo.py
@@ -4,7 +4,7 @@ def customise(process):
     #Add the configuration for the Igprof running to dump profile snapshots:
     process.IgProfService = cms.Service("IgProfService",
         reportFirstEvent            = cms.untracked.int32(1),  #Dump first event for baseline studies
-        reportEventInterval         = cms.untracked.int32( ((process.maxEvents.input.value()-1)/2) ), # dump in the middle of the run
+        reportEventInterval         = cms.untracked.int32( ((process.maxEvents.input.value()-1)//2) ), # dump in the middle of the run
         reportToFileAtPostEvent     = cms.untracked.string("| gzip -c > IgProf.%I.gz")
         )
     


### PR DESCRIPTION
triggered by https://github.com/jpata/cms-reco-profiling-web/issues/17#issuecomment-880191831

https://www.python.org/dev/peps/pep-0238/
