### PR TITLE
Remove #define EDM_ML_DEBUG from XtalDedxAnalysis

### DIFF
--- a/SimG4CMS/CherenkovAnalysis/plugins/XtalDedxAnalysis.cc
+++ b/SimG4CMS/CherenkovAnalysis/plugins/XtalDedxAnalysis.cc
@@ -31,8 +31,6 @@
 #include <TH1F.h>
 #include <TH1I.h>
 
-#define EDM_ML_DEBUG
-
 class XtalDedxAnalysis : public edm::one::EDAnalyzer<edm::one::SharedResources> {
 public:
   explicit XtalDedxAnalysis(const edm::ParameterSet &);


### PR DESCRIPTION
#### PR description:

Fixes DBG build warning about re-definition of `EDM_ML_DEBUG`. Production code should not define the macro anyway.

#### PR validation:

None