### PR TITLE
Extend the external process wait time for ExternalGeneratorFilter

### DIFF
--- a/GeneratorInterface/Core/python/ExternalGeneratorFilter.py
+++ b/GeneratorInterface/Core/python/ExternalGeneratorFilter.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
 class ExternalGeneratorFilter(cms.EDFilter):
-    def __init__(self, prod, _external_process_waitTime_ = cms.untracked.uint32(60), _external_process_verbose_ = cms.untracked.bool(False),
+    def __init__(self, prod, _external_process_waitTime_ = cms.untracked.uint32(300), _external_process_verbose_ = cms.untracked.bool(False),
                  _external_process_components_ = cms.vstring()):
         self.__dict__['_external_process_verbose_']=_external_process_verbose_
         self.__dict__['_external_process_waitTime_']=_external_process_waitTime_


### PR DESCRIPTION
#### PR description:

Based on the discussion from GEN and PPD, We extend the external process wait time for `ExternalGeneratorFilter` from 60s to 300s.

The reason is that we still randomly encounter the problem issued in https://github.com/cms-sw/cmssw/issues/31426 in the real production, i.e., the external process takes more than 60s to produce a single GEN event, causing the timeout.
By switching to 300s, one shortcoming is that the controller instance may need more time (300s) to recognize the worker instance (generator) is terminated, if it really happens. This is tolerated compared with the aforementioned issue.

A backport to 10_6_X is also needed.

#### PR validation:

Validated on GEN process with `ExternalGeneratorFilter` and see that the max wait time has changed as expected.
