### PR TITLE
Always download the packages.json file

### DIFF
--- a/Utilities/StaticAnalyzers/scripts/create_statics_esd_reports.sh
+++ b/Utilities/StaticAnalyzers/scripts/create_statics_esd_reports.sh
@@ -50,7 +50,7 @@ if [ ! -f ./callgraph.py ]
    cp -pv ${CMSSW_BASE}/src/Utilities/StaticAnalyzers/scripts/callgraph.py .
    cp -pv ${CMSSW_BASE}/src/Utilities/StaticAnalyzers/scripts/module_to_package.yaml .
    cp -pv ${CMSSW_BASE}/src/Utilities/StaticAnalyzers/scripts/modules_in_ib.yaml .
-   curl -OL https://raw.githubusercontent.com/fwyzard/circles/master/web/groups/packages.json
 fi
+curl -OL https://raw.githubusercontent.com/fwyzard/circles/master/web/groups/packages.json
 touch eventsetuprecord-get-all.txt eventsetuprecord-get.txt
 ./callgraph.py 2>&1 | tee eventsetuprecord-get.txt


### PR DESCRIPTION
This file was not downloaded because callgraph.py was copied in the driver script that calls this script.

@smuzaffar @makortel 

This fix is needed to make the ESR::get report work.