### PR TITLE
Protect all TTree::Fill() calls with tbb::this_task_arena::isolate() in DQMRootOutputModule

### DIFF
--- a/DQMServices/FwkIO/plugins/DQMRootOutputModule.cc
+++ b/DQMServices/FwkIO/plugins/DQMRootOutputModule.cc
@@ -27,6 +27,8 @@
 #include "TH2.h"
 #include "TProfile.h"
 
+#include "tbb/task_arena.h"
+
 // user include files
 #include "FWCore/Framework/interface/one/OutputModule.h"
 #include "FWCore/Framework/interface/RunForOutput.h"
@@ -90,7 +92,7 @@ namespace {
       m_bufferPtr = dynamic_cast<T*>(iElement->getRootObject());
       assert(nullptr != m_bufferPtr);
       //std::cout <<"#entries: "<<m_bufferPtr->GetEntries()<<std::endl;
-      m_tree->Fill();
+      tbb::this_task_arena::isolate([&] { m_tree->Fill(); });
     }
 
   private:
@@ -118,7 +120,7 @@ namespace {
       *m_fullNameBufferPtr = iElement->getFullname();
       m_flagBuffer = 0;
       m_buffer = iElement->getIntValue();
-      m_tree->Fill();
+      tbb::this_task_arena::isolate([&] { m_tree->Fill(); });
     }
 
   private:
@@ -143,7 +145,7 @@ namespace {
       *m_fullNameBufferPtr = iElement->getFullname();
       m_flagBuffer = 0;
       m_buffer = iElement->getFloatValue();
-      m_tree->Fill();
+      tbb::this_task_arena::isolate([&] { m_tree->Fill(); });
     }
 
   private:
@@ -169,7 +171,7 @@ namespace {
       *m_fullNameBufferPtr = iElement->getFullname();
       m_flagBuffer = 0;
       m_buffer = iElement->getStringValue();
-      m_tree->Fill();
+      tbb::this_task_arena::isolate([&] { m_tree->Fill(); });
     }
 
   private:
@@ -420,7 +422,7 @@ void DQMRootOutputModule::writeLuminosityBlock(edm::LuminosityBlockForOutput con
       m_type = typeIndex;
       (*it)->getRangeAndReset(m_firstIndex, m_lastIndex);
       storedLumiIndex = true;
-      m_indicesTree->Fill();
+      tbb::this_task_arena::isolate([&] { m_indicesTree->Fill(); });
     }
   }
   if (not storedLumiIndex) {
@@ -429,7 +431,7 @@ void DQMRootOutputModule::writeLuminosityBlock(edm::LuminosityBlockForOutput con
     m_type = kNoTypesStored;
     m_firstIndex = 0;
     m_lastIndex = 0;
-    m_indicesTree->Fill();
+    tbb::this_task_arena::isolate([&] { m_indicesTree->Fill(); });
   }
 
   edm::Service<edm::JobReport> jr;
@@ -474,7 +476,7 @@ void DQMRootOutputModule::writeRun(edm::RunForOutput const& iRun) {
     if ((*it)->wasFilled()) {
       m_type = typeIndex;
       (*it)->getRangeAndReset(m_firstIndex, m_lastIndex);
-      m_indicesTree->Fill();
+      tbb::this_task_arena::isolate([&] { m_indicesTree->Fill(); });
     }
   }
 
@@ -521,7 +523,7 @@ void DQMRootOutputModule::startEndFile() {
       releaseVersion = itPC->releaseVersion();
       passID = itPC->passID();
       parameterSetID = itPC->parameterSetID().compactForm();
-      processHistoryTree->Fill();
+      tbb::this_task_arena::isolate([&] { processHistoryTree->Fill(); });
     }
   }
 
@@ -536,7 +538,7 @@ void DQMRootOutputModule::startEndFile() {
   for (edm::pset::Registry::const_iterator it = psr->begin(), itEnd = psr->end(); it != itEnd; ++it) {
     blob.clear();
     it->second.toString(blob);
-    parameterSetsTree->Fill();
+    tbb::this_task_arena::isolate([&] { parameterSetsTree->Fill(); });
   }
 }
 


### PR DESCRIPTION
#### PR description:

Resolves https://github.com/cms-sw/cmssw/issues/34520. Resolves https://github.com/makortel/framework/issues/194.

#### PR validation:

Code compiles