### PR TITLE
Build files cleaning

### DIFF
--- a/CalibTracker/SiStripESProducers/BuildFile.xml
+++ b/CalibTracker/SiStripESProducers/BuildFile.xml
@@ -1,11 +1,9 @@
-<use name="CalibFormats/SiStripObjects"/>
 <use name="CondFormats/DataRecord"/>
 <use name="CondFormats/SiStripObjects"/>
 <use name="DataFormats/SiStripCommon"/>
 <use name="FWCore/Framework"/>
 <use name="FWCore/MessageLogger"/>
 <use name="FWCore/ParameterSet"/>
-<use name="DQMServices/Core"/>
 <use name="boost"/>
 <export>
   <lib name="1"/>

--- a/CalibTracker/SiStripESProducers/plugins/BuildFile.xml
+++ b/CalibTracker/SiStripESProducers/plugins/BuildFile.xml
@@ -1,4 +1,5 @@
 <library file="fake/*.cc" name="CalibTrackerSiStripFakeESProducersPlugins">
+  <use name="CalibFormats/SiStripObjects"/>
   <use name="CalibTracker/Records"/>
   <use name="CalibTracker/SiStripCommon"/>
   <use name="CalibTracker/SiStripESProducers"/>
@@ -8,6 +9,7 @@
 </library>
 
 <library file="real/*.cc" name="CalibTrackerSiStripRealESProducersPlugins">
+  <use name="CalibFormats/SiStripObjects"/>
   <use name="CalibTracker/Records"/>
   <use name="CalibTracker/SiStripCommon"/>
   <use name="CalibTracker/SiStripESProducers"/>
@@ -16,6 +18,7 @@
 </library>
 
 <library file="geom/*.cc" name="CalibTrackerSiStripGeomESProducersPlugins">
+  <use name="CalibFormats/SiStripObjects"/>
   <use name="CalibTracker/Records"/>
   <use name="CalibTracker/SiStripESProducers"/>
   <use name="Geometry/TrackerGeometryBuilder"/>
@@ -24,6 +27,7 @@
 </library>
 
 <library file="DBWriter/*.cc" name="CalibTrackerSiStripESProducersDBWriterPlugins">
+  <use name="CalibFormats/SiStripObjects"/>
   <use name="CalibTracker/Records"/>
   <use name="CalibTracker/SiStripESProducers"/>
   <use name="CondCore/DBOutputService"/>

--- a/CalibTracker/SiStripQuality/plugins/BuildFile.xml
+++ b/CalibTracker/SiStripQuality/plugins/BuildFile.xml
@@ -8,7 +8,6 @@
 <use name="CondFormats/SiStripObjects"/>
 <use name="CalibFormats/SiStripObjects"/>
 <use name="CalibTracker/Records"/>
-<use name="CalibTracker/SiStripESProducers"/>
 <use name="CalibTracker/SiStripQuality"/>
 <use name="DataFormats/TrackReco"/>
 <use name="DataFormats/TrackerRecHit2D"/>

--- a/DQM/TrackerRemapper/test/BuildFile.xml
+++ b/DQM/TrackerRemapper/test/BuildFile.xml
@@ -1,7 +1,5 @@
 <bin file="test_catch2_*.cc" name="test_catch2_DQM_TRACKERREMAPPER">
-  <use name="FWCore/Common"/>
   <use name="DQM/TrackerRemapper"/>
-  <use name="CalibTracker/StandaloneTrackerTopology"/>
   <use name="CalibTracker/SiPixelESProducers"/>
   <use name="CalibTracker/SiStripCommon"/>
   <use name="rootgraphics"/>

--- a/Geometry/CaloTopology/BuildFile.xml
+++ b/Geometry/CaloTopology/BuildFile.xml
@@ -6,7 +6,6 @@
 <use name="Geometry/CaloGeometry"/>
 <use name="Geometry/HcalCommonData"/>
 <use name="Geometry/HGCalCommonData"/>
-<use name="FWCore/Framework"/>
 <use name="boost"/>
 <export>
   <lib name="1"/>

--- a/L1Trigger/L1TTrackMatch/plugins/BuildFile.xml
+++ b/L1Trigger/L1TTrackMatch/plugins/BuildFile.xml
@@ -3,9 +3,6 @@
 <use   name="Geometry/TrackerGeometryBuilder"/>
 <use   name="Geometry/Records"/>
 <use   name="L1Trigger/L1TTrackMatch"/>
-<use   name="L1Trigger/TrackTrigger"/>
-<use   name="PhysicsTools/UtilAlgos"/>
-<use   name="SimGeneral/HepPDTRecord"/>
 <use   name="SimDataFormats/GeneratorProducts"/>
 <use   name="SimTracker/TrackTriggerAssociation"/>
 <use   name="DataFormats/L1TrackTrigger"/>

--- a/RecoEgamma/EgammaIsolationAlgos/BuildFile.xml
+++ b/RecoEgamma/EgammaIsolationAlgos/BuildFile.xml
@@ -3,7 +3,6 @@
 <use name="FWCore/MessageLogger"/>
 <use name="Geometry/CaloGeometry"/>
 <use name="Geometry/CaloTopology"/>
-<use name="RecoCaloTools/Selectors" source_only="1"/>
 <use name="DataFormats/Candidate"/>
 <use name="DataFormats/RecoCandidate"/>
 <use name="DataFormats/ParticleFlowReco"/>

--- a/RecoMuon/L2MuonProducer/plugins/BuildFile.xml
+++ b/RecoMuon/L2MuonProducer/plugins/BuildFile.xml
@@ -6,7 +6,6 @@
   <use name="FWCore/Framework"/>
   <use name="FWCore/MessageLogger"/>
   <use name="FWCore/ParameterSet"/>
-  <use name="FWCore/PluginManager"/>
   <use name="RecoMuon/StandAloneTrackFinder"/>
   <use name="RecoMuon/TrackingTools"/>
   <use name="TrackingTools/PatternTools"/>

--- a/SimG4Core/Application/BuildFile.xml
+++ b/SimG4Core/Application/BuildFile.xml
@@ -1,4 +1,3 @@
-<use name="DataFormats/Common"/>
 <use name="SimDataFormats/GeneratorProducts"/>
 <use name="SimDataFormats/Forward"/>
 <use name="SimG4Core/Generators"/>

--- a/Validation/CaloTowers/BuildFile.xml
+++ b/Validation/CaloTowers/BuildFile.xml
@@ -2,7 +2,6 @@
 <use name="FWCore/Framework"/>
 <use name="FWCore/ParameterSet"/>
 <use name="DQMServices/Core"/>
-<use name="boost"/>
 <use name="root"/>
 <use name="DataFormats/Common"/>
 <use name="DataFormats/HcalDetId"/>

--- a/Validation/CheckOverlap/BuildFile.xml
+++ b/Validation/CheckOverlap/BuildFile.xml
@@ -4,4 +4,3 @@
 <use name="Geometry/Records"/>
 <use name="FWCore/ParameterSet"/>
 <use name="geant4core"/>
-<use name="boost"/>

--- a/Validation/EcalHits/BuildFile.xml
+++ b/Validation/EcalHits/BuildFile.xml
@@ -1,6 +1,5 @@
 <use name="root"/>
 <use name="geant4core"/>
-<use name="boost"/>
 <use name="FWCore/ParameterSet"/>
 <use name="SimG4Core/Watcher"/>
 <use name="SimG4CMS/Calo"/>

--- a/Validation/EcalRecHits/BuildFile.xml
+++ b/Validation/EcalRecHits/BuildFile.xml
@@ -9,6 +9,5 @@
 <use name="DataFormats/EcalDetId"/>
 <use name="FWCore/Framework"/>
 <use name="DQMServices/Core"/>
-<use name="boost"/>
 <use name="root"/>
 <flags EDM_PLUGIN="1"/>

--- a/Validation/Geometry/BuildFile.xml
+++ b/Validation/Geometry/BuildFile.xml
@@ -1,7 +1,6 @@
 <use name="root"/>
 <use name="dd4hep"/>
 <use name="geant4core"/>
-<use name="boost"/>
 <use name="FWCore/Framework"/>
 <use name="FWCore/ParameterSet"/>
 <use name="FWCore/MessageLogger"/>

--- a/Validation/HcalDigis/BuildFile.xml
+++ b/Validation/HcalDigis/BuildFile.xml
@@ -1,5 +1,4 @@
 <flags EDM_PLUGIN="1"/>
-<use name="boost"/>
 <use name="FWCore/Framework"/>
 <use name="FWCore/ParameterSet"/>
 <use name="Geometry/HcalTowerAlgo"/>

--- a/Validation/HcalHits/BuildFile.xml
+++ b/Validation/HcalHits/BuildFile.xml
@@ -14,6 +14,5 @@
 <use name="SimG4Core/Watcher"/>
 <use name="geant4core"/>
 <use name="hepmc"/>
-<use name="boost"/>
 <use name="rootmath"/>
 <flags EDM_PLUGIN="1"/>

--- a/Validation/HcalHits/plugins/BuildFile.xml
+++ b/Validation/HcalHits/plugins/BuildFile.xml
@@ -9,7 +9,6 @@
 <use name="SimDataFormats/CaloHit"/>
 <use name="SimDataFormats/ValidationFormats"/>
 <use name="geant4core"/>
-<use name="boost"/>
 <use name="hepmc"/>
 <use name="clhep"/>
 <use name="root"/>

--- a/Validation/HcalRecHits/BuildFile.xml
+++ b/Validation/HcalRecHits/BuildFile.xml
@@ -2,7 +2,6 @@
 <use name="FWCore/Framework"/>
 <use name="FWCore/ParameterSet"/>
 <use name="DQMServices/Core"/>
-<use name="boost"/>
 <use name="root"/>
 <use name="DataFormats/Common"/>
 <use name="DataFormats/HcalDetId"/>

--- a/Validation/HcalRecHits/test/BuildFile.xml
+++ b/Validation/HcalRecHits/test/BuildFile.xml
@@ -8,7 +8,6 @@
 <use name="Geometry/Records"/>
 <use name="SimDataFormats/CaloHit"/>
 <use name="SimDataFormats/CaloTest"/>
-<use name="boost"/>
 <use name="root"/>
 <flags EDM_PLUGIN="1"/>
 <library file="*.cc" name="testValidationHcalRecHits">

--- a/Validation/MuonGEMHits/BuildFile.xml
+++ b/Validation/MuonGEMHits/BuildFile.xml
@@ -1,4 +1,3 @@
-<use name="boost"/>
 <use name="FWCore/Framework"/>
 <use name="FWCore/MessageLogger"/>
 <use name="FWCore/ParameterSet"/>

--- a/Validation/MuonGEMRecHits/BuildFile.xml
+++ b/Validation/MuonGEMRecHits/BuildFile.xml
@@ -1,4 +1,3 @@
-<use name="boost"/>
 <use name="DataFormats/GEMRecHit"/>
 <use name="FWCore/Framework"/>
 <use name="FWCore/ParameterSet"/>

--- a/Validation/MuonME0Validation/BuildFile.xml
+++ b/Validation/MuonME0Validation/BuildFile.xml
@@ -1,4 +1,3 @@
-<use name="boost"/>
 <use name="DataFormats/GEMDigi"/>
 <use name="DataFormats/GEMRecHit"/>
 <use name="DataFormats/Scalers"/>

--- a/Validation/RecoB/plugins/BuildFile.xml
+++ b/Validation/RecoB/plugins/BuildFile.xml
@@ -14,7 +14,6 @@
 <use name="DQMOffline/RecoB"/>
 <use name="Validation/RecoB"/>
 <use name="DataFormats/PatCandidates"/>
-<use name="boost"/>
 <use name="clhep"/>
 <use name="rootcore"/>
 <use name="root"/>

--- a/Validation/RecoMuon/plugins/BuildFile.xml
+++ b/Validation/RecoMuon/plugins/BuildFile.xml
@@ -2,7 +2,6 @@
 <use name="FWCore/Framework"/>
 <use name="DataFormats/TrackReco"/>
 <use name="clhep"/>
-<use name="boost"/>
 <use name="DQMServices/Core"/>
 <use name="FWCore/ParameterSet"/>
 <use name="MagneticField/Records"/>

--- a/Validation/RecoPixelVertexing/test/BuildFile.xml
+++ b/Validation/RecoPixelVertexing/test/BuildFile.xml
@@ -1,4 +1,3 @@
-<use name="boost"/>
 <use name="root"/>
 <use name="FWCore/Framework"/>
 <use name="FWCore/ParameterSet"/>

--- a/Validation/RecoTrack/plugins/BuildFile.xml
+++ b/Validation/RecoTrack/plugins/BuildFile.xml
@@ -4,7 +4,6 @@
 <use name="DataFormats/Common"/>
 <use name="DataFormats/TrackReco"/>
 <use name="clhep"/>
-<use name="boost"/>
 <use name="SimDataFormats/TrackerDigiSimLink"/>
 <use name="FWCore/ParameterSet"/>
 <use name="Geometry/TrackerGeometryBuilder"/>

--- a/Validation/RecoVertex/BuildFile.xml
+++ b/Validation/RecoVertex/BuildFile.xml
@@ -26,7 +26,6 @@
 <use name="CommonTools/TriggerUtils"/>
 <use name="CommonTools/UtilAlgos"/>
 <use name="clhep"/>
-<use name="boost"/>
 <use name="hepmc"/>
 <use name="RecoVertex/PrimaryVertexProducer"/>
 <use name="RecoVertex/VertexTools"/>

--- a/Validation/SiTrackerPhase2V/plugins/BuildFile.xml
+++ b/Validation/SiTrackerPhase2V/plugins/BuildFile.xml
@@ -18,6 +18,5 @@
 <use name="DQMServices/Core"/>
 <use name="DQM/SiTrackerPhase2"/>
 <use name="Validation/SiTrackerPhase2V"/>
-<use name="boost_system"/>
 <use name="rootcling"/>
 <flags EDM_PLUGIN="1"/>

--- a/Validation/TrackerDigis/plugins/BuildFile.xml
+++ b/Validation/TrackerDigis/plugins/BuildFile.xml
@@ -5,7 +5,6 @@
 <use name="Geometry/Records"/>
 <use name="RecoTracker/Record"/>
 <use name="RecoTracker/TkDetLayers"/>
-<use name="boost"/>
 <use name="root"/>
 <library file="*.cc" name="ValidationTrackerDigisPlugins">
   <flags EDM_PLUGIN="1"/>

--- a/Validation/TrackerRecHits/BuildFile.xml
+++ b/Validation/TrackerRecHits/BuildFile.xml
@@ -7,6 +7,5 @@
 <use name="CalibFormats/SiStripObjects"/>
 <use name="Geometry/TrackerGeometryBuilder"/>
 <use name="Geometry/Records"/>
-<use name="boost"/>
 <use name="root"/>
 <flags EDM_PLUGIN="1"/>

--- a/Validation/TrackingMCTruth/plugins/BuildFile.xml
+++ b/Validation/TrackingMCTruth/plugins/BuildFile.xml
@@ -3,7 +3,6 @@
 <use name="SimDataFormats/TrackingAnalysis"/>
 <use name="SimDataFormats/Track"/>
 <use name="SimDataFormats/GeneratorProducts"/>
-<use name="boost"/>
 <use name="root"/>
 <use name="clhep"/>
 <library file="*.cc" name="ValidationTrackingMCTruthPlugins">


### PR DESCRIPTION
#### PR description:

Another quick BuildFile cleaning PR in the style of many before (for example https://github.com/cms-sw/cmssw/pull/34191).

This PR cleans unnecessary includes from CMSSW BuildFiles that were recently added for 12_0_0_pre4. Furthermore, unused boost dependencies are removed from the Validation subsystem.

#### PR validation:

CMSSW compiles.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

No backport intended.