### PR TITLE
Switch PPS reco to use preprocessed geometry from DB

### DIFF
--- a/Geometry/VeryForwardGeometry/python/geometryRPFromDB_cfi.py
+++ b/Geometry/VeryForwardGeometry/python/geometryRPFromDB_cfi.py
@@ -1,15 +1,9 @@
 import FWCore.ParameterSet.Config as cms
 
-XMLIdealGeometryESSource_CTPPS = cms.ESProducer("XMLIdealGeometryESProducer",
-    rootDDName = cms.string('cms:CMSE'),
-    label = cms.string('CTPPS'),
-    appendToDataLabel = cms.string('XMLIdealGeometryESSource_CTPPS')
-)
-
 ctppsGeometryESModule = cms.ESProducer("CTPPSGeometryESModule",
+    fromPreprocessedDB = cms.untracked.bool(True),
     verbosity = cms.untracked.uint32(1),
     isRun2 = cms.bool(False),
-    compactViewTag = cms.string('XMLIdealGeometryESSource_CTPPS')
 )
 
 from Configuration.Eras.Modifier_ctpps_2016_cff import ctpps_2016


### PR DESCRIPTION
#### PR description:

This PR intends to switch the PPS reconstruction to using preprocessed geometry loaded from DB. It complements the changes implemented by PR #33851 and #34218. 

#### PR validation:

The same validation tests used for PR #33851 (described here: https://github.com/cms-sw/cmssw/pull/33851#issue-654000919) were repeated, this time using the GT containing the DB file added through PR #34218. The new validation plots, which look exactly the same as the ones for #33851, are available in:

https://cernbox.cern.ch/index.php/s/M68s1TSLCWURmJP

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Not a backport.

Inform: @fabferro @jan-kaspar 
