### PR TITLE
Update the TTTrack_TrackWord DataFormat

### DIFF
--- a/Calibration/EcalAlCaRecoProducers/plugins/BuildFile.xml
+++ b/Calibration/EcalAlCaRecoProducers/plugins/BuildFile.xml
@@ -7,6 +7,7 @@
 <use name="DataFormats/EgammaCandidates"/>
 <use name="DataFormats/RecoCandidate"/>
 <use name="DataFormats/TrackReco"/>
+<use name="DataFormats/HLTReco"/>
 <use name="FWCore/Framework"/>
 <use name="FWCore/MessageLogger"/>
 <use name="FWCore/ParameterSet"/>

--- a/DQMOffline/EGamma/plugins/BuildFile.xml
+++ b/DQMOffline/EGamma/plugins/BuildFile.xml
@@ -12,6 +12,7 @@
 <use name="clhep"/>
 <use name="CommonTools/Statistics"/>
 <use name="CommonTools/UtilAlgos"/>
+<use name="TrackingTools/TrajectoryState"/>
 <use name="root"/>
 <use name="roofit"/>
 <use name="boost"/>

--- a/DataFormats/L1TrackTrigger/BuildFile.xml
+++ b/DataFormats/L1TrackTrigger/BuildFile.xml
@@ -7,6 +7,7 @@
 <use name="DataFormats/TrackerCommon"/>
 <use name="FWCore/MessageLogger"/>
 <use name="FWCore/Utilities"/>
+<use name="hls"/>
 <export>
   <lib name="1"/>
 </export>

--- a/DataFormats/L1TrackTrigger/interface/TTTrack.h
+++ b/DataFormats/L1TrackTrigger/interface/TTTrack.h
@@ -148,9 +148,12 @@ public:
   double chi2XY() const;
   double chi2XYRed() const;
 
-  /// Stub Pt consistency
+  /// Stub Pt consistency (i.e. stub bend chi2/dof)
   double stubPtConsistency() const;
   void setStubPtConsistency(double aPtConsistency);
+  double chi2BendRed() { return stubPtConsistency(); }
+  void setChi2BendRed(double aChi2BendRed) { setStubPtConsistency(aChi2BendRed); }
+  double chi2Bend() { return chi2BendRed() * theStubRefs.size(); }
 
   void setFitParNo(unsigned int aFitParNo);
   int nFitPars() const { return theNumFitPars_; }
@@ -429,16 +432,27 @@ void TTTrack<T>::setTrackWordBits() {
     return;
   }
 
-  unsigned int sparebits = 0;
+  unsigned int valid = true;
+  unsigned int mvaQuality = 0;
+  unsigned int mvaOther = 0;
 
   // missing conversion of global phi to difference from sector center phi
 
   if (theChi2_Z_ < 0) {
-    setTrackWord(theMomentum_, thePOCA_, theRInv_, theChi2_, 0, theStubPtConsistency_, theHitPattern_, sparebits);
+    setTrackWord(
+        valid, theMomentum_, thePOCA_, theRInv_, chi2Red(), 0, chi2BendRed(), theHitPattern_, mvaQuality, mvaOther);
 
   } else {
-    setTrackWord(
-        theMomentum_, thePOCA_, theRInv_, theChi2_XY_, theChi2_Z_, theStubPtConsistency_, theHitPattern_, sparebits);
+    setTrackWord(valid,
+                 theMomentum_,
+                 thePOCA_,
+                 theRInv_,
+                 chi2XYRed(),
+                 chi2ZRed(),
+                 chi2BendRed(),
+                 theHitPattern_,
+                 mvaQuality,
+                 mvaOther);
   }
   return;
 }

--- a/DataFormats/L1TrackTrigger/interface/TTTrack.h
+++ b/DataFormats/L1TrackTrigger/interface/TTTrack.h
@@ -149,6 +149,8 @@ public:
   double chi2XYRed() const;
 
   /// Stub Pt consistency (i.e. stub bend chi2/dof)
+  /// Note: The "stubPtConsistency" names are historic and people are encouraged
+  ///       to adopt the "chi2Bend" names.
   double stubPtConsistency() const;
   void setStubPtConsistency(double aPtConsistency);
   double chi2BendRed() { return stubPtConsistency(); }

--- a/DataFormats/L1TrackTrigger/interface/TTTrack_TrackWord.h
+++ b/DataFormats/L1TrackTrigger/interface/TTTrack_TrackWord.h
@@ -32,12 +32,12 @@ public:
     kMVAOtherSize = 6,    // Space for two specialized MVA selections
     kMVAQualitySize = 3,  // Width of track quality MVA
     kHitPatternSize = 7,  // Width of the hit pattern for stubs
-    kBendChi2Size = 3,    // Width of the Bend-Chi2
+    kBendChi2Size = 3,    // Width of the bend-chi2/dof
     kD0Size = 13,         // Width of D0
-    kChi2RZSize = 4,      // Width of Chi2 for r-z
+    kChi2RZSize = 4,      // Width of chi2/dof for r-z
     kZ0Size = 12,         // Width of z-position (40cm / 0.1)
     kTanlSize = 16,       // Width of tan(lambda)
-    kChi2RPhiSize = 4,    // Width of Chi2 for r-phi
+    kChi2RPhiSize = 4,    // Width of chi2/dof for r-phi
     kPhiSize = 12,        // Width of phi
     kRinvSize = 15,       // Width of Rinv
     kValidSize = 1,       // Valid bit

--- a/DataFormats/L1TrackTrigger/interface/TTTrack_TrackWord.h
+++ b/DataFormats/L1TrackTrigger/interface/TTTrack_TrackWord.h
@@ -1,244 +1,286 @@
+#ifndef L1_TRACK_TRIGGER_TRACK_WORD_H
+#define L1_TRACK_TRIGGER_TRACK_WORD_H
+
 ////////
 //
 // class to store the 96-bit track word produced by the L1 Track Trigger.  Intended to be inherited by L1 TTTrack.
 // packing scheme given below.
 //
-// author: Mike Hildreth
-// date:   April 9, 2019
+// author:      Mike Hildreth
+// modified by: Alexx Perloff
+// created:     April 9, 2019
+// modified:    March 9, 2021
 //
 ///////
 
-#ifndef L1_TRACK_TRIGGER_TRACK_WORD_H
-#define L1_TRACK_TRIGGER_TRACK_WORD_H
-
-#include <iostream>
-#include <string>
 #include "DataFormats/GeometryVector/interface/GlobalVector.h"
 #include "DataFormats/GeometryVector/interface/GlobalPoint.h"
 
+#include <ap_int.h>
+
+#include <algorithm>
+#include <array>
+#include <bitset>
+#include <string>
+#include <vector>
+
 class TTTrack_TrackWord {
 public:
-  // Constructors:
+  // ----------constants, enums and typedefs ---------
+  enum TrackBitWidths {
+    // The sizes of the track word components
+    kMVAOtherSize = 6,    // Space for two specialized MVA selections
+    kMVAQualitySize = 3,  // Width of track quality MVA
+    kHitPatternSize = 7,  // Width of the hit pattern for stubs
+    kBendChi2Size = 3,    // Width of the Bend-Chi2
+    kD0Size = 13,         // Width of D0
+    kChi2RZSize = 4,      // Width of Chi2 for r-z
+    kZ0Size = 12,         // Width of z-position (40cm / 0.1)
+    kTanlSize = 16,       // Width of tan(lambda)
+    kChi2RPhiSize = 4,    // Width of Chi2 for r-phi
+    kPhiSize = 12,        // Width of phi
+    kRinvSize = 15,       // Width of Rinv
+    kValidSize = 1,       // Valid bit
 
+    kTrackWordSize = kValidSize + kRinvSize + kPhiSize + kChi2RPhiSize + kTanlSize + kZ0Size + kChi2RZSize + kD0Size +
+                     kBendChi2Size + kHitPatternSize + kMVAQualitySize +
+                     kMVAOtherSize,  // Width of the track word in bits
+  };
+
+  enum TrackBitLocations {
+    // The location of the least significant bit (LSB) and most significant bit (MSB) in the track word for different fields
+    kMVAOtherLSB = 0,
+    kMVAOtherMSB = kMVAOtherLSB + TrackBitWidths::kMVAOtherSize - 1,
+    kMVAQualityLSB = kMVAOtherMSB + 1,
+    kMVAQualityMSB = kMVAQualityLSB + TrackBitWidths::kMVAQualitySize - 1,
+    kHitPatternLSB = kMVAQualityMSB + 1,
+    kHitPatternMSB = kHitPatternLSB + TrackBitWidths::kHitPatternSize - 1,
+    kBendChi2LSB = kHitPatternMSB + 1,
+    kBendChi2MSB = kBendChi2LSB + TrackBitWidths::kBendChi2Size - 1,
+    kD0LSB = kBendChi2MSB + 1,
+    kD0MSB = kD0LSB + TrackBitWidths::kD0Size - 1,
+    kChi2RZLSB = kD0MSB + 1,
+    kChi2RZMSB = kChi2RZLSB + TrackBitWidths::kChi2RZSize - 1,
+    kZ0LSB = kChi2RZMSB + 1,
+    kZ0MSB = kZ0LSB + TrackBitWidths::kZ0Size - 1,
+    kTanlLSB = kZ0MSB + 1,
+    kTanlMSB = kTanlLSB + TrackBitWidths::kTanlSize - 1,
+    kChi2RPhiLSB = kTanlMSB + 1,
+    kChi2RPhiMSB = kChi2RPhiLSB + TrackBitWidths::kChi2RPhiSize - 1,
+    kPhiLSB = kChi2RPhiMSB + 1,
+    kPhiMSB = kPhiLSB + TrackBitWidths::kPhiSize - 1,
+    kRinvLSB = kPhiMSB + 1,
+    kRinvMSB = kRinvLSB + TrackBitWidths::kRinvSize - 1,
+    kValidLSB = kRinvMSB + 1,
+    kValidMSB = kValidLSB + TrackBitWidths::kValidSize - 1,
+  };
+
+  // Binning constants
+  static constexpr double minRinv = -0.006;
+  static constexpr double minPhi0 = -0.7853981696;  // relative to the center of the sector
+  static constexpr double minTanl = -8.;
+  static constexpr double minZ0 = -20.46912512;
+  static constexpr double minD0 = -16.;
+
+  static constexpr double stepRinv = (2. * std::abs(minRinv)) / (1 << TrackBitWidths::kRinvSize);
+  static constexpr double stepPhi0 = (2. * std::abs(minPhi0)) / (1 << TrackBitWidths::kPhiSize);
+  static constexpr double stepTanL = (1. / (1 << 12));
+  static constexpr double stepZ0 = (2. * std::abs(minZ0)) / (1 << TrackBitWidths::kZ0Size);
+  static constexpr double stepD0 = (1. / (1 << 8));
+
+  // Bin edges for chi2/dof
+  static constexpr std::array<double, 1 << TrackBitWidths::kChi2RPhiSize> chi2RPhiBins = {
+      {0.0, 1.0, 1.5, 2.0, 2.5, 3.0, 3.5, 4.0, 5.0, 6.0, 10.0, 15.0, 20.0, 35.0, 60.0, 200.0}};
+  static constexpr std::array<double, 1 << TrackBitWidths::kChi2RZSize> chi2RZBins = {
+      {0.0, 0.5, 1.0, 1.5, 2.0, 2.5, 3.0, 3.5, 4.0, 4.5, 5.0, 6.0, 8.0, 10.0, 20.0, 50.0}};
+  static constexpr std::array<double, 1 << TrackBitWidths::kBendChi2Size> bendChi2Bins = {
+      {0.0, 0.75, 1.0, 1.5, 2.25, 3.5, 5.0, 20.0}};
+
+  // Track flags
+  typedef ap_uint<TrackBitWidths::kValidSize> valid_t;  // valid bit
+
+  // Track parameters types
+  typedef ap_uint<TrackBitWidths::kRinvSize> rinv_t;  // Track Rinv
+  typedef ap_uint<TrackBitWidths::kPhiSize> phi_t;    // Track phi
+  typedef ap_uint<TrackBitWidths::kTanlSize> tanl_t;  // Track tan(l)
+  typedef ap_uint<TrackBitWidths::kZ0Size> z0_t;      // Track z
+  typedef ap_uint<TrackBitWidths::kD0Size> d0_t;      // D0
+
+  // Track quality types
+  typedef ap_uint<TrackBitWidths::kChi2RPhiSize> chi2rphi_t;      // Chi2 r-phi
+  typedef ap_uint<TrackBitWidths::kChi2RZSize> chi2rz_t;          // Chi2 r-z
+  typedef ap_uint<TrackBitWidths::kBendChi2Size> bendChi2_t;      // Bend-Chi2
+  typedef ap_uint<TrackBitWidths::kHitPatternSize> hit_t;         // Hit mask bits
+  typedef ap_uint<TrackBitWidths::kMVAQualitySize> qualityMVA_t;  // Track quality MVA
+  typedef ap_uint<TrackBitWidths::kMVAOtherSize> otherMVA_t;      // Specialized MVA selection
+
+  // Track word types
+  typedef std::bitset<TrackBitWidths::kTrackWordSize> tkword_bs_t;  // Entire track word;
+  typedef ap_uint<TrackBitWidths::kTrackWordSize> tkword_t;         // Entire track word;
+
+public:
+  // ----------Constructors --------------------------
   TTTrack_TrackWord() {}
-  TTTrack_TrackWord(const GlobalVector& Momentum,
+  TTTrack_TrackWord(unsigned int valid,
+                    const GlobalVector& momentum,
                     const GlobalPoint& POCA,
-                    double Rinv,
-                    double Chi2,  // would be xy chisq if chi2Z is non-zero
-                    double Chi2Z,
-                    double BendChi2,
-                    unsigned int HitPattern,
-                    unsigned int iSpare);
-
-  TTTrack_TrackWord(unsigned int Rinv,
+                    double rInv,
+                    double chi2RPhi,  // would be xy chisq if chi2Z is non-zero
+                    double chi2RZ,
+                    double bendChi2,
+                    unsigned int hitPattern,
+                    unsigned int mvaQuality,
+                    unsigned int mvaOther);
+  TTTrack_TrackWord(unsigned int valid,
+                    unsigned int rInv,
                     unsigned int phi0,
                     unsigned int tanl,
                     unsigned int z0,
                     unsigned int d0,
-                    unsigned int Chi2XY,  // would be total chisq if chi2Z is zero
-                    unsigned int Chi2Z,
-                    unsigned int BendChi2,
-                    unsigned int HitPattern,
-                    unsigned int iSpare);
+                    unsigned int chi2RPhi,  // would be total chisq if chi2Z is zero
+                    unsigned int chi2RZ,
+                    unsigned int bendChi2,
+                    unsigned int hitPattern,
+                    unsigned int mvaQuality,
+                    unsigned int mvaOther);
 
-  void setTrackWord(const GlobalVector& Momentum,
-                    const GlobalPoint& POCA,
-                    double Rinv,
-                    double Chi2XY,  // would be total chisq if chi2Z is zero
-                    double Chi2Z,
-                    double BendChi2,
-                    unsigned int HitPattern,
-                    unsigned int iSpare);
+  // ----------copy constructor ----------------------
+  TTTrack_TrackWord(const TTTrack_TrackWord& word) { trackWord_ = word.trackWord_; }
 
-  void setTrackWord(unsigned int Rinv,
-                    unsigned int phi0,
-                    unsigned int tanl,
-                    unsigned int z0,
-                    unsigned int d0,
-                    unsigned int Chi2XY,  // would be total chisq if chi2Z is zero
-                    unsigned int Chi2Z,
-                    unsigned int BendChi2,
-                    unsigned int HitPattern,
-                    unsigned int iSpare);
-
-  // getters for unpacked and converted values.
-  // These functions return real numbers converted from the digitized quantities using the LSB defined for each.
-
-  float get_iRinv();
-  float get_iphi();
-  float get_itanl();
-  float get_iz0();
-  float get_id0();
-  float get_ichi2XY();
-  float get_ichi2Z();
-  float get_iBendChi2();
-
-  // separate functions for unpacking 96-bit track word
-
-  float unpack_iRinv();
-  float unpack_iphi();
-  float unpack_itanl();
-  float unpack_iz0();
-  float unpack_id0();
-  float unpack_ichi2XY();
-  float unpack_ichi2Z();
-  float unpack_iBendChi2();
-  unsigned int unpack_ispare();
-  unsigned int unpack_hitPattern();
-
-  // getters for packed bits.
-  // These functions return, literally, the packed bits in integer format for each quantity.
-  // Signed quantities have the sign enconded in the left-most bit.
-
-  unsigned int get_hitPattern();
-  unsigned int get_ispare();  // will need a converter(s) when spare bits are defined
-
-  unsigned int get_RinvBits();
-  unsigned int get_phiBits();
-  unsigned int get_tanlBits();
-  unsigned int get_z0Bits();
-  unsigned int get_d0Bits();
-  unsigned int get_chi2XYBits();
-  unsigned int get_chi2ZBits();
-  unsigned int get_BendChi2Bits();
-
-  // copy constructor
-
-  TTTrack_TrackWord(const TTTrack_TrackWord& word) {
-    initialize();
-
-    iRinv = word.iRinv;
-    iphi = word.iphi;
-    itanl = word.itanl;
-    iz0 = word.iz0;
-    id0 = word.id0;
-    ichi2XY = word.ichi2XY;
-    ichi2Z = word.ichi2Z;
-    iBendChi2 = word.iBendChi2;
-    ispare = word.ispare;
-    iHitPattern = word.iHitPattern;
-
-    // three 32-bit packed words
-    TrackWord1 = word.TrackWord1;
-    TrackWord2 = word.TrackWord2;
-    TrackWord3 = word.TrackWord3;
-  }
-
+  // ----------operators -----------------------------
   TTTrack_TrackWord& operator=(const TTTrack_TrackWord& word) {
-    initialize();
-    iRinv = word.iRinv;
-    iphi = word.iphi;
-    itanl = word.itanl;
-    iz0 = word.iz0;
-    id0 = word.id0;
-    ichi2XY = word.ichi2XY;
-    ichi2Z = word.ichi2Z;
-    iBendChi2 = word.iBendChi2;
-    ispare = word.ispare;
-    iHitPattern = word.iHitPattern;
-
-    // three 32-bit packed words
-    TrackWord1 = word.TrackWord1;
-    TrackWord2 = word.TrackWord2;
-    TrackWord3 = word.TrackWord3;
-
+    trackWord_ = word.trackWord_;
     return *this;
   }
 
+  // ----------member functions (getters) ------------
+  // These functions return arbitarary precision unsigned int words (lists of bits) for each quantity
+  // Signed quantities have the sign enconded in the left-most bit.
+  valid_t getValidWord() const { return getTrackWord()(TrackBitLocations::kValidMSB, TrackBitLocations::kValidLSB); }
+  rinv_t getRinvWord() const { return getTrackWord()(TrackBitLocations::kRinvMSB, TrackBitLocations::kRinvLSB); }
+  phi_t getPhiWord() const { return getTrackWord()(TrackBitLocations::kPhiMSB, TrackBitLocations::kPhiLSB); }
+  tanl_t getTanlWord() const { return getTrackWord()(TrackBitLocations::kTanlMSB, TrackBitLocations::kTanlLSB); }
+  z0_t getZ0Word() const { return getTrackWord()(TrackBitLocations::kZ0MSB, TrackBitLocations::kZ0LSB); }
+  d0_t getD0Word() const { return getTrackWord()(TrackBitLocations::kD0MSB, TrackBitLocations::kD0LSB); }
+  chi2rphi_t getChi2RPhiWord() const {
+    return getTrackWord()(TrackBitLocations::kChi2RPhiMSB, TrackBitLocations::kChi2RPhiLSB);
+  }
+  chi2rz_t getChi2RZWord() const {
+    return getTrackWord()(TrackBitLocations::kChi2RZMSB, TrackBitLocations::kChi2RZLSB);
+  }
+  bendChi2_t getBendChi2Word() const {
+    return getTrackWord()(TrackBitLocations::kBendChi2MSB, TrackBitLocations::kBendChi2LSB);
+  }
+  hit_t getHitPatternWord() const {
+    return getTrackWord()(TrackBitLocations::kHitPatternMSB, TrackBitLocations::kHitPatternLSB);
+  }
+  qualityMVA_t getMVAQualityWord() const {
+    return getTrackWord()(TrackBitLocations::kMVAQualityMSB, TrackBitLocations::kMVAQualityLSB);
+  }
+  otherMVA_t getMVAOtherWord() const {
+    return getTrackWord()(TrackBitLocations::kMVAOtherMSB, TrackBitLocations::kMVAOtherLSB);
+  }
+  tkword_t getTrackWord() const { return tkword_t(trackWord_.to_string().c_str(), 2); }
+
+  // These functions return the packed bits in unsigned integer format for each quantity
+  // Signed quantities have the sign enconded in the left-most bit of the pattern using
+  //   a two's complement representation
+  unsigned int getValidBits() const { return getValidWord().to_uint(); }
+  unsigned int getRinvBits() const { return getRinvWord().to_uint(); }
+  unsigned int getPhiBits() const { return getPhiWord().to_uint(); }
+  unsigned int getTanlBits() const { return getTanlWord().to_uint(); }
+  unsigned int getZ0Bits() const { return getZ0Word().to_uint(); }
+  unsigned int getD0Bits() const { return getD0Word().to_uint(); }
+  unsigned int getChi2RPhiBits() const { return getChi2RPhiWord().to_uint(); }
+  unsigned int getChi2RZBits() const { return getChi2RZWord().to_uint(); }
+  unsigned int getBendChi2Bits() const { return getBendChi2Word().to_uint(); }
+  unsigned int getHitPatternBits() const { return getHitPatternWord().to_uint(); }
+  unsigned int getMVAQualityBits() const { return getMVAQualityWord().to_uint(); }
+  unsigned int getMVAOtherBits() const { return getMVAOtherWord().to_uint(); }
+
+  // These functions return the unpacked and converted values
+  // These functions return real numbers converted from the digitized quantities by unpacking the 96-bit track word
+  bool getValid() const { return getValidWord().to_bool(); }
+  double getRinv() const { return unpackSignedValue(getRinvBits(), TrackBitWidths::kRinvSize, stepRinv); }
+  double getPhi() const { return unpackSignedValue(getPhiBits(), TrackBitWidths::kPhiSize, stepPhi0); }
+  double getTanl() const { return unpackSignedValue(getTanlBits(), TrackBitWidths::kTanlSize, stepTanL); }
+  double getZ0() const { return unpackSignedValue(getZ0Bits(), TrackBitWidths::kZ0Size, stepZ0); }
+  double getD0() const { return unpackSignedValue(getD0Bits(), TrackBitWidths::kD0Size, stepD0); }
+  double getChi2RPhi() const { return chi2RPhiBins[getChi2RPhiBits()]; }
+  double getChi2RZ() const { return chi2RZBins[getChi2RZBits()]; }
+  double getBendChi2() const { return bendChi2Bins[getBendChi2Bits()]; }
+  unsigned int getHitPattern() const { return getHitPatternBits(); }
+  unsigned int getMVAQuality() const { return getMVAQualityBits(); }
+  unsigned int getMVAOther() const { return getMVAOtherBits(); }
+
+  // ----------member functions (setters) ------------
+  void setTrackWord(unsigned int valid,
+                    const GlobalVector& momentum,
+                    const GlobalPoint& POCA,
+                    double rInv,
+                    double chi2RPhi,  // would be total chisq if chi2Z is zero
+                    double chi2RZ,
+                    double bendChi2,
+                    unsigned int hitPattern,
+                    unsigned int mvaQuality,
+                    unsigned int mvaOther);
+
+  void setTrackWord(unsigned int valid,
+                    unsigned int rInv,
+                    unsigned int phi0,
+                    unsigned int tanl,
+                    unsigned int z0,
+                    unsigned int d0,
+                    unsigned int chi2RPhi,  // would be total chisq if chi2Z is zero
+                    unsigned int chi2RZ,
+                    unsigned int bendChi2,
+                    unsigned int hitPattern,
+                    unsigned int mvaQuality,
+                    unsigned int mvaOther);
+
+  void setTrackWord(ap_uint<TrackBitWidths::kValidSize> valid,
+                    ap_uint<TrackBitWidths::kRinvSize> rInv,
+                    ap_uint<TrackBitWidths::kPhiSize> phi0,
+                    ap_uint<TrackBitWidths::kTanlSize> tanl,
+                    ap_uint<TrackBitWidths::kZ0Size> z0,
+                    ap_uint<TrackBitWidths::kD0Size> d0,
+                    ap_uint<TrackBitWidths::kChi2RPhiSize> chi2RPhi,  // would be total chisq if chi2Z is zero
+                    ap_uint<TrackBitWidths::kChi2RZSize> chi2RZ,
+                    ap_uint<TrackBitWidths::kBendChi2Size> bendChi2,
+                    ap_uint<TrackBitWidths::kHitPatternSize> hitPattern,
+                    ap_uint<TrackBitWidths::kMVAQualitySize> mvaQuality,
+                    ap_uint<TrackBitWidths::kMVAOtherSize> mvaOther);
+
 private:
-  void initialize();
+  // ----------private member functions --------------
+  unsigned int digitizeSignedValue(double value, unsigned int nBits, double lsb) const {
+    unsigned int digitized_value = std::floor(std::abs(value) / lsb);
+    unsigned int digitized_maximum = (1 << (nBits - 1)) - 1;  // The remove 1 bit from nBits to account for the sign
+    if (digitized_value > digitized_maximum)
+      digitized_value = digitized_maximum;
+    if (value < 0)
+      digitized_value = (1 << nBits) - digitized_value;  // two's complement encoding
+    return digitized_value;
+  }
 
-  unsigned int digitize_Signed(float var, unsigned int maxBit, unsigned int minBit, float lsb);
+  template <typename T>
+  constexpr unsigned int getBin(double value, const T& bins) const {
+    auto up = std::upper_bound(bins.begin(), bins.end(), value);
+    return (up - bins.begin() - 1);
+  }
 
-  float unpack_Signed(unsigned int bits, unsigned int nBits, float lsb);
+  double unpackSignedValue(unsigned int bits, unsigned int nBits, double lsb) const {
+    int isign = 1;
+    unsigned int digitized_maximum = (1 << nBits) - 1;
+    if (bits & (1 << (nBits - 1))) {  // check the sign
+      isign = -1;
+      bits = (1 << (nBits + 1)) - bits;  // if negative, flip everything for two's complement encoding
+    }
+    return (double(bits & digitized_maximum) + 0.5) * lsb * isign;
+  }
 
-  // individual data members (not packed into 96 bits)
-  unsigned int iRinv;
-  unsigned int iphi;
-  unsigned int itanl;
-  unsigned int iz0;
-  unsigned int id0;
-  unsigned int ichi2XY;
-  unsigned int ichi2Z;
-  unsigned int iBendChi2;
-  unsigned int ispare;
-  unsigned int iHitPattern;
-
-  // three 32-bit packed words
-
-  unsigned int TrackWord1;
-  unsigned int TrackWord2;
-  unsigned int TrackWord3;
-
-  // values of least significant bit for digitization
-
-  float valLSBCurv;
-  float valLSBPhi;
-  float valLSBTanl;
-  float valLSBZ0;
-  float valLSBD0;
-
-  float chi2Bins[16];
-  float chi2ZBins[16];
-  float Bchi2Bins[8];
-
-  unsigned int Nchi2;  // both chi2 have same packing
-  unsigned int NBchi2;
-
-  /* bits for packing: 
-  signed quantities (one bit for sign): 
-
-  q/R = 14+1 
-  phi = 11+1  (relative to sector center)
-  tanl = 15+1
-  z0  = 11+1
-  d0  = 12+1                                                                                                                                                      
-
-  unsigned:
-  chi2     = 4  (or chisqXY)
-  BendChi2 = 3
-  hitmask  = 7
-  chi2Z    = 4
-  Spare    = 10 
-
-  */
-
-  // signed quantities: total bits are these values plus one
-  const unsigned int NCurvBits = 14;
-  const unsigned int NPhiBits = 11;
-  const unsigned int NTanlBits = 15;
-  const unsigned int NZ0Bits = 11;
-  const unsigned int ND0Bits = 12;
-
-  // unsigned:
-  const unsigned int NChi2Bits = 4;
-  const unsigned int NBChi2Bits = 3;
-  const unsigned int NHitsBits = 7;
-  const unsigned int NSpareBits = 14;
-
-  // establish binning
-  const float maxCurv = 0.00855;  // 2 GeV pT Rinv is in cm
-  const float maxPhi = 1.026;     // relative to the center of the sector
-  const float maxTanl = 8.0;
-  const float maxZ0 = 30.;
-  const float maxD0 = 15.4;
-
-  // List of offsets and masks.  In principle, all of these could be derived from first
-  // principles given the number of bits. At some future time, we'll do this.
-
-  const unsigned int maskRinv = 0xFFFE0000;
-  const unsigned int maskPhi = 0xFFF00000;
-  const unsigned int maskTanL = 0xFFFF0000;
-  const unsigned int maskD0 = 0x000FFF80;
-  const unsigned int maskZ0 = 0x0000FFF0;
-  const unsigned int maskChi2XY = 0x0000000F;
-  const unsigned int maskChi2Z = 0x00003C00;
-  const unsigned int maskBendChi2 = 0x0001C000;
-  const unsigned int maskHitPat = 0x0000007F;
-  const unsigned int maskSpare = 0x000003FF;
-
-  const unsigned int nWordBits = 32;
-
-};  // end of class def
+  // ----------member data ---------------------------
+  tkword_bs_t trackWord_;
+};
 
 #endif

--- a/DataFormats/L1TrackTrigger/src/TTTrack_TrackWord.cc
+++ b/DataFormats/L1TrackTrigger/src/TTTrack_TrackWord.cc
@@ -4,419 +4,175 @@
 // packing scheme given below.
 //
 // author: Mike Hildreth
-// date:   April 9, 2019
+// modified by: Alexx Perloff
+// created:     April 9, 2019
+// modified:    March 9, 2021
 //
 ///////
 
 #include "DataFormats/L1TrackTrigger/interface/TTTrack_TrackWord.h"
-#include <iostream>
-#include <bitset>
-#include <string>
 
 //Constructor - turn track parameters into 96-bit word
-
-TTTrack_TrackWord::TTTrack_TrackWord(const GlobalVector& Momentum,
+TTTrack_TrackWord::TTTrack_TrackWord(unsigned int valid,
+                                     const GlobalVector& momentum,
                                      const GlobalPoint& POCA,
-                                     double theRinv,
-                                     double theChi2XY,
-                                     double theChi2Z,
-                                     double theBendChi2,
-                                     unsigned int theHitPattern,
-                                     unsigned int iSpare) {
-  setTrackWord(Momentum, POCA, theRinv, theChi2XY, theChi2Z, theBendChi2, theHitPattern, iSpare);
+                                     double rInv,
+                                     double chi2RPhi,  // would be xy chisq if chi2Z is non-zero
+                                     double chi2RZ,
+                                     double bendChi2,
+                                     unsigned int hitPattern,
+                                     unsigned int mvaQuality,
+                                     unsigned int mvaOther) {
+  setTrackWord(valid, momentum, POCA, rInv, chi2RPhi, chi2RZ, bendChi2, hitPattern, mvaQuality, mvaOther);
 }
 
-TTTrack_TrackWord::TTTrack_TrackWord(unsigned int theRinv,
+TTTrack_TrackWord::TTTrack_TrackWord(unsigned int valid,
+                                     unsigned int rInv,
                                      unsigned int phi0,
                                      unsigned int tanl,
                                      unsigned int z0,
                                      unsigned int d0,
-                                     unsigned int theChi2XY,
-                                     unsigned int theChi2Z,
-                                     unsigned int theBendChi2,
-                                     unsigned int theHitPattern,
-                                     unsigned int iSpare)
-    : iRinv(theRinv),
-      iphi(phi0),
-      itanl(tanl),
-      iz0(z0),
-      id0(d0),
-      ichi2XY(theChi2XY),      //revert to other packing?  Or will be unpacked wrong
-      ichi2Z(theChi2Z),        //revert to other packing?  Or will be unpacked wrong
-      iBendChi2(theBendChi2),  // revert to ogher packing? Or will be unpacked wrong
-      ispare(iSpare),
-      iHitPattern(theHitPattern) {
-  initialize();
+                                     unsigned int chi2RPhi,  // would be total chisq if chi2Z is zero
+                                     unsigned int chi2RZ,
+                                     unsigned int bendChi2,
+                                     unsigned int hitPattern,
+                                     unsigned int mvaQuality,
+                                     unsigned int mvaOther) {
+  setTrackWord(valid, rInv, phi0, tanl, z0, d0, chi2RPhi, chi2RZ, bendChi2, hitPattern, mvaQuality, mvaOther);
 }
 
-// one for already-digitized values:
-
-void TTTrack_TrackWord::setTrackWord(unsigned int theRinv,
-                                     unsigned int phi0,
-                                     unsigned int tanl,
-                                     unsigned int z0,
-                                     unsigned int d0,
-                                     unsigned int theChi2XY,
-                                     unsigned int theChi2Z,
-                                     unsigned int theBendChi2,
-                                     unsigned int theHitPattern,
-                                     unsigned int iSpare) {
-  iRinv = theRinv;
-  iphi = phi0;
-  itanl = tanl;
-  iz0 = z0;
-  id0 = d0;
-  ichi2XY = theChi2XY;      //revert to other packing?  Or will be unpacked wrong
-  ichi2Z = theChi2Z;        //revert to other packing?  Or will be unpacked wrong
-  iBendChi2 = theBendChi2;  // revert to ogher packing? Or will be unpacked wrong
-  ispare = iSpare;
-  iHitPattern = theHitPattern;
-
-  initialize();
-}
-
-// one for floats:
-void TTTrack_TrackWord::setTrackWord(const GlobalVector& Momentum,
+// A setter for the floating point values
+void TTTrack_TrackWord::setTrackWord(unsigned int valid,
+                                     const GlobalVector& momentum,
                                      const GlobalPoint& POCA,
-                                     double theRinv,
-                                     double theChi2XY,
-                                     double theChi2Z,
-                                     double theBendChi2,
-                                     unsigned int theHitPattern,
-                                     unsigned int iSpare) {
-  initialize();
-
+                                     double rInv,
+                                     double chi2RPhi,  // would be total chisq if chi2Z is zero
+                                     double chi2RZ,
+                                     double bendChi2,
+                                     unsigned int hitPattern,
+                                     unsigned int mvaQuality,
+                                     unsigned int mvaOther) {
   // first, derive quantities to be packed
-
-  float rPhi = Momentum.phi();  // this needs to be phi relative to center of sector ****
-  float rTanl = Momentum.z() / Momentum.perp();
+  float rPhi = momentum.phi();  // this needs to be phi relative to center of sector ****
+  float rTanl = momentum.z() / momentum.perp();
   float rZ0 = POCA.z();
   float rD0 = POCA.perp();
 
-  // bin, convert to integers, and pack
+  // bin and convert to integers
+  valid_t valid_ = valid;
+  rinv_t rInv_ = digitizeSignedValue(rInv, TrackBitWidths::kRinvSize, stepRinv);
+  phi_t phi0_ = digitizeSignedValue(rPhi, TrackBitWidths::kPhiSize, stepPhi0);
+  tanl_t tanl_ = digitizeSignedValue(rTanl, TrackBitWidths::kTanlSize, stepTanL);
+  z0_t z0_ = digitizeSignedValue(rZ0, TrackBitWidths::kZ0Size, stepZ0);
+  d0_t d0_ = digitizeSignedValue(rD0, TrackBitWidths::kD0Size, stepD0);
+  chi2rphi_t chi2RPhi_ = getBin(chi2RPhi, chi2RPhiBins);
+  chi2rz_t chi2RZ_ = getBin(chi2RZ, chi2RZBins);
+  bendChi2_t bendChi2_ = getBin(bendChi2, bendChi2Bins);
+  hit_t hitPattern_ = hitPattern;
+  qualityMVA_t mvaQuality_ = mvaQuality;
+  otherMVA_t mvaOther_ = mvaOther;
 
-  unsigned int seg1, seg2, seg3, seg4;
+  // pack the track word
+  //trackWord = ( mvaOther_, mvaQuality_, hitPattern_, bendChi2_, chi2RZ_, chi2RPhi_, d0_, z0_, tanl_, phi0_, rInv_, valid_ );
+  setTrackWord(
+      valid_, rInv_, phi0_, tanl_, z0_, d0_, chi2RPhi_, chi2RZ_, bendChi2_, hitPattern_, mvaQuality_, mvaOther_);
+}
 
-  //tanl
-  itanl = digitize_Signed(rTanl, NTanlBits, 0, valLSBTanl);
+// A setter for already-digitized values
+void TTTrack_TrackWord::setTrackWord(unsigned int valid,
+                                     unsigned int rInv,
+                                     unsigned int phi0,
+                                     unsigned int tanl,
+                                     unsigned int z0,
+                                     unsigned int d0,
+                                     unsigned int chi2RPhi,  // would be total chisq if chi2Z is zero
+                                     unsigned int chi2RZ,
+                                     unsigned int bendChi2,
+                                     unsigned int hitPattern,
+                                     unsigned int mvaQuality,
+                                     unsigned int mvaOther) {
+  // bin and convert to integers
+  valid_t valid_ = valid;
+  rinv_t rInv_ = rInv;
+  phi_t phi0_ = phi0;
+  tanl_t tanl_ = tanl;
+  z0_t z0_ = z0;
+  d0_t d0_ = d0;
+  chi2rphi_t chi2RPhi_ = chi2RPhi;
+  chi2rz_t chi2RZ_ = chi2RZ;
+  bendChi2_t bendChi2_ = bendChi2;
+  hit_t hitPattern_ = hitPattern;
+  qualityMVA_t mvaQuality_ = mvaQuality;
+  otherMVA_t mvaOther_ = mvaOther;
 
-  //z0
-  iz0 = digitize_Signed(rZ0, NZ0Bits, 0, valLSBZ0);
+  // pack the track word
+  //trackWord = ( otherMVA_t(mvaOther), qualityMVA_t(mvaQuality), hit_t(hitPattern),
+  //              bendChi2_t(bendChi2), chi2rz_t(chi2RZ), chi2rphi_t(chi2RPhi),
+  //              d0_t(d0), z0_t(z0), tanl_t(tanl), phi_t(phi0), rinv_t(rInv), valid_t(valid) );
+  setTrackWord(
+      valid_, rInv_, phi0_, tanl_, z0_, d0_, chi2RPhi_, chi2RZ_, bendChi2_, hitPattern_, mvaQuality_, mvaOther_);
+}
 
-  //chi2 has non-linear bins
-  ichi2XY = 0;
-  for (unsigned int ibin = 0; ibin < Nchi2; ++ibin) {
-    ichi2XY = ibin;
-    if (theChi2XY < chi2Bins[ibin])
-      break;
+void TTTrack_TrackWord::setTrackWord(
+    ap_uint<TrackBitWidths::kValidSize> valid,
+    ap_uint<TrackBitWidths::kRinvSize> rInv,
+    ap_uint<TrackBitWidths::kPhiSize> phi0,
+    ap_uint<TrackBitWidths::kTanlSize> tanl,
+    ap_uint<TrackBitWidths::kZ0Size> z0,
+    ap_uint<TrackBitWidths::kD0Size> d0,
+    ap_uint<TrackBitWidths::kChi2RPhiSize> chi2RPhi,  // would be total chisq if chi2Z is zero
+    ap_uint<TrackBitWidths::kChi2RZSize> chi2RZ,
+    ap_uint<TrackBitWidths::kBendChi2Size> bendChi2,
+    ap_uint<TrackBitWidths::kHitPatternSize> hitPattern,
+    ap_uint<TrackBitWidths::kMVAQualitySize> mvaQuality,
+    ap_uint<TrackBitWidths::kMVAOtherSize> mvaOther) {
+  // pack the track word
+  unsigned int offset = 0;
+  for (unsigned int b = offset; b < (offset + TrackBitWidths::kMVAOtherSize); b++) {
+    trackWord_.set(b, mvaOther[b - offset]);
   }
-
-  //chi2Z has non-linear bins
-  ichi2Z = 0;
-  for (unsigned int ibin = 0; ibin < Nchi2; ++ibin) {
-    ichi2Z = ibin;
-    if (theChi2Z < chi2ZBins[ibin])
-      break;
+  offset += TrackBitWidths::kMVAOtherSize;
+  for (unsigned int b = offset; b < (offset + TrackBitWidths::kMVAQualitySize); b++) {
+    trackWord_.set(b, mvaQuality[b - offset]);
   }
-
-  //phi
-  iphi = digitize_Signed(rPhi, NPhiBits, 0, valLSBPhi);
-
-  //d0
-  id0 = digitize_Signed(rD0, ND0Bits, 0, valLSBD0);
-
-  //Rinv
-  iRinv = digitize_Signed(theRinv, NCurvBits, 0, valLSBCurv);
-
-  //bend chi2 - non-linear bins
-  iBendChi2 = 0;
-  for (unsigned int ibin = 0; ibin < NBchi2; ++ibin) {
-    iBendChi2 = ibin;
-    if (theBendChi2 < Bchi2Bins[ibin])
-      break;
+  offset += TrackBitWidths::kMVAQualitySize;
+  for (unsigned int b = offset; b < (offset + TrackBitWidths::kHitPatternSize); b++) {
+    trackWord_.set(b, hitPattern[b - offset]);
   }
-
-  ispare = iSpare;
-
-  // spare bits
-  if (ispare > 0x3FFF)
-    ispare = 0x3FFF;
-
-  iHitPattern = theHitPattern;
-
-  //set bits
-  /*
-    Current packing scheme. Any changes here ripple everywhere!
-    
-    uint word1 = 16 (tanl) + 12 (z0) + 4 (chi2) = 32 bits
-    uint word2 = 12 (phi) + 13 (d0) + 7 (hitPattern) = 32 bits
-    uint word3 = 15 (pT) + 3 (bend chi2) + 14 (spare/TMVA) = 32 bits
-   */
-
-  //now pack bits; leave hardcoded for now as am example of how this could work
-
-  seg1 = (itanl << (nWordBits - (NTanlBits + 1)));          // extra bit or bits is for sign //16
-  seg2 = (iz0 << (nWordBits - (NTanlBits + NZ0Bits + 2)));  //4
-  seg3 = ichi2XY;
-
-  //set bits
-
-  TrackWord1 = seg1 + seg2 + seg3;
-
-  //second 32-bit word
-
-  seg1 = (iphi << (nWordBits - (NPhiBits + 1)));           //20
-  seg2 = (id0 << (nWordBits - (NPhiBits + ND0Bits + 2)));  //7
-
-  //HitMask
-  seg3 = theHitPattern;
-
-  //set bits
-
-  TrackWord2 = seg1 + seg2 + seg3;
-
-  //third 32-bit word
-
-  seg1 = (iRinv << (nWordBits - (NCurvBits + 1)));                            //17
-  seg2 = (iBendChi2 << (nWordBits - (NCurvBits + NBChi2Bits + 1)));           //14
-  seg3 = (ichi2Z << (nWordBits - (NCurvBits + NBChi2Bits + NChi2Bits + 1)));  //10
-  seg4 = ispare;
-
-  TrackWord3 = seg1 + seg2 + seg3 + seg4;
-}
-// unpack
-
-float TTTrack_TrackWord::unpack_itanl() {
-  unsigned int bits = (TrackWord1 & maskTanL) >> (nWordBits - (NTanlBits + 1));  //16
-  float unpTanl = unpack_Signed(bits, NTanlBits, valLSBTanl);
-  return unpTanl;
-}
-
-float TTTrack_TrackWord::get_itanl() {
-  float unpTanl = unpack_Signed(itanl, NTanlBits, valLSBTanl);
-  return unpTanl;
-}
-
-unsigned int TTTrack_TrackWord::get_tanlBits() {
-  //unsigned int bits =  (TrackWord1 & 0xFFFF0000) >> 16;
-  return itanl;
-}
-
-float TTTrack_TrackWord::unpack_iz0() {
-  unsigned int bits = (TrackWord1 & maskZ0) >> (nWordBits - (NTanlBits + NZ0Bits + 2));  //4
-  float unpZ0 = unpack_Signed(bits, NZ0Bits, valLSBZ0);
-  return unpZ0;
-}
-
-float TTTrack_TrackWord::get_iz0() {
-  float unpZ0 = unpack_Signed(iz0, NZ0Bits, valLSBZ0);
-  return unpZ0;
-}
-
-unsigned int TTTrack_TrackWord::get_z0Bits() {
-  //unsigned int bits =   (TrackWord1 & 0x0000FFF0) >> 4;
-  return iz0;
-}
-
-float TTTrack_TrackWord::unpack_ichi2XY() {
-  unsigned int bits = (TrackWord1 & maskChi2XY);
-  float unpChi2 = chi2Bins[bits];
-  return unpChi2;
-}
-
-float TTTrack_TrackWord::get_ichi2XY() {
-  float unpChi2 = chi2Bins[ichi2XY];
-  return unpChi2;
-}
-
-unsigned int TTTrack_TrackWord::get_chi2XYBits() {
-  //unsigned int bits = (TrackWord1 & 0x0000000F);
-  return ichi2XY;
-}
-
-float TTTrack_TrackWord::unpack_iphi() {
-  unsigned int bits = (TrackWord2 & maskPhi) >> (nWordBits - (NPhiBits + 1));  //20
-  float unpPhi = unpack_Signed(bits, NPhiBits, valLSBPhi);
-  return unpPhi;
-}
-
-float TTTrack_TrackWord::get_iphi() {
-  float unpPhi = unpack_Signed(iphi, NPhiBits, valLSBPhi);
-  return unpPhi;
-}
-
-unsigned int TTTrack_TrackWord::get_phiBits() {
-  //unsigned int bits =   (TrackWord2 & 0xFFF00000) >> 20;
-  return iphi;
-}
-
-float TTTrack_TrackWord::unpack_id0() {
-  unsigned int bits = (TrackWord2 & maskD0) >> (nWordBits - (NPhiBits + ND0Bits + 2));  //7
-  float unpD0 = unpack_Signed(bits, ND0Bits, valLSBD0);
-  return unpD0;
-}
-
-float TTTrack_TrackWord::get_id0() {
-  float unpD0 = unpack_Signed(id0, ND0Bits, valLSBD0);
-  return unpD0;
-}
-
-unsigned int TTTrack_TrackWord::get_d0Bits() {
-  //  unsigned int bits =   (TrackWord2 & 0x000FFF80) >> 7;
-  return id0;
-}
-
-unsigned int TTTrack_TrackWord::unpack_hitPattern() {
-  unsigned int bits = (TrackWord2 & maskHitPat);
-  return bits;
-}
-
-unsigned int TTTrack_TrackWord::get_hitPattern() { return iHitPattern; }
-
-float TTTrack_TrackWord::unpack_iRinv() {
-  unsigned int bits = (TrackWord3 & maskRinv) >> (nWordBits - (NCurvBits + 1));  //17
-  float unpCurv = unpack_Signed(bits, NCurvBits, valLSBCurv);
-  return unpCurv;
-}
-
-float TTTrack_TrackWord::get_iRinv() {
-  float unpCurv = unpack_Signed(iRinv, NCurvBits, valLSBCurv);
-  return unpCurv;
-}
-
-float TTTrack_TrackWord::unpack_iBendChi2() {
-  unsigned int bits = (TrackWord3 & maskBendChi2) >> (nWordBits - (NCurvBits + NBChi2Bits + 1));  //14
-  float unpBChi2 = Bchi2Bins[bits];
-  return unpBChi2;
-}
-
-float TTTrack_TrackWord::get_iBendChi2() {
-  float unpBChi2 = Bchi2Bins[iBendChi2];
-  return unpBChi2;
-}
-
-unsigned int TTTrack_TrackWord::get_BendChi2Bits() {
-  unsigned int bits = (TrackWord3 & maskBendChi2) >> (nWordBits - (NCurvBits + NBChi2Bits + 1));  //14
-  return bits;
-}
-
-float TTTrack_TrackWord::unpack_ichi2Z() {
-  unsigned int bits = (TrackWord3 & maskChi2Z) >> (nWordBits - (NCurvBits + NBChi2Bits + NChi2Bits + 1));  //10
-  float unpChi2Z = chi2ZBins[bits];
-  return unpChi2Z;
-}
-
-float TTTrack_TrackWord::get_ichi2Z() {
-  float unpChi2Z = chi2ZBins[ichi2Z];
-  return unpChi2Z;
-}
-
-unsigned int TTTrack_TrackWord::unpack_ispare() {
-  unsigned int bits = (TrackWord3 & maskSpare);
-  return bits;
-}
-
-unsigned int TTTrack_TrackWord::get_ispare() { return ispare; }
-
-unsigned int TTTrack_TrackWord::digitize_Signed(float var, unsigned int maxBit, unsigned int minBit, float lsb) {
-  unsigned int nBits = (maxBit - minBit + 1);
-  unsigned int myVar = std::floor(fabs(var) / lsb);
-  unsigned int maxVal = (1 << (nBits - 1)) - 1;
-  if (myVar > maxVal)
-    myVar = maxVal;
-  if (var < 0)
-    myVar = (1 << nBits) - myVar;  // two's complement encoding
-  unsigned int seg = myVar;
-  return seg;
-}
-
-float TTTrack_TrackWord::unpack_Signed(unsigned int bits, unsigned int nBits, float lsb) {
-  int isign = 1;
-  unsigned int maxVal = (1 << nBits) - 1;
-  if (bits & (1 << nBits)) {  //check sign
-    isign = -1;
-    bits = (1 << (nBits + 1)) - bits;  // if negative, flip everything for two's complement encoding
+  offset += TrackBitWidths::kHitPatternSize;
+  for (unsigned int b = offset; b < (offset + TrackBitWidths::kBendChi2Size); b++) {
+    trackWord_.set(b, bendChi2[b - offset]);
   }
-  float unpacked = (float(bits & maxVal) + 0.5) * lsb;
-  unpacked = isign * unpacked;
-  return unpacked;
+  offset += TrackBitWidths::kBendChi2Size;
+  for (unsigned int b = offset; b < (offset + TrackBitWidths::kD0Size); b++) {
+    trackWord_.set(b, d0[b - offset]);
+  }
+  offset += TrackBitWidths::kD0Size;
+  for (unsigned int b = offset; b < (offset + TrackBitWidths::kChi2RZSize); b++) {
+    trackWord_.set(b, chi2RZ[b - offset]);
+  }
+  offset += TrackBitWidths::kChi2RZSize;
+  for (unsigned int b = offset; b < (offset + TrackBitWidths::kZ0Size); b++) {
+    trackWord_.set(b, z0[b - offset]);
+  }
+  offset += TrackBitWidths::kZ0Size;
+  for (unsigned int b = offset; b < (offset + TrackBitWidths::kTanlSize); b++) {
+    trackWord_.set(b, tanl[b - offset]);
+  }
+  offset += TrackBitWidths::kTanlSize;
+  for (unsigned int b = offset; b < (offset + TrackBitWidths::kChi2RPhiSize); b++) {
+    trackWord_.set(b, chi2RPhi[b - offset]);
+  }
+  offset += TrackBitWidths::kChi2RPhiSize;
+  for (unsigned int b = offset; b < (offset + TrackBitWidths::kPhiSize); b++) {
+    trackWord_.set(b, phi0[b - offset]);
+  }
+  offset += TrackBitWidths::kPhiSize;
+  for (unsigned int b = offset; b < (offset + TrackBitWidths::kRinvSize); b++) {
+    trackWord_.set(b, rInv[b - offset]);
+  }
+  offset += TrackBitWidths::kRinvSize;
+  for (unsigned int b = offset; b < offset + TrackBitWidths::kValidSize; b++) {
+    trackWord_.set(b, valid[b - offset]);
+  }
 }
-
-void TTTrack_TrackWord::initialize() {
-  /* bits for packing, constants defined in TTTrack_TrackWord.h :
-
-  signed quantities (one bit for sign):
-  
-  q/R = 14+1
-  phi = 11+1  (relative to sector center)
-  tanl = 15+1
-  z0  = 11+1
-  d0  = 12+1
-
-  unsigned:
-
-  chi2     = 4
-  BendChi2 = 3
-  hitPattern  = 7
-  Spare    = 10
-  chi2Z    = 4
-
-  */
-
-  // define bits, 1<<N = 2^N
-
-  unsigned int CurvBins = (1 << NCurvBits);
-  unsigned int phiBins = (1 << NPhiBits);
-  unsigned int tanlBins = (1 << NTanlBits);
-  unsigned int z0Bins = (1 << NZ0Bits);
-  unsigned int d0Bins = (1 << ND0Bits);
-
-  Nchi2 = (1 << NChi2Bits);
-  NBchi2 = (1 << NBChi2Bits);
-
-  valLSBCurv = maxCurv / float(CurvBins);
-  valLSBPhi = maxPhi / float(phiBins);
-  valLSBTanl = maxTanl / float(tanlBins);
-  valLSBZ0 = maxZ0 / float(z0Bins);
-  valLSBD0 = maxD0 / float(d0Bins);
-
-  chi2Bins[0] = 0.25;
-  chi2Bins[1] = 0.5;
-  chi2Bins[2] = 1.0;
-  chi2Bins[3] = 2.;
-  chi2Bins[4] = 3.;
-  chi2Bins[5] = 5.;
-  chi2Bins[6] = 7.;
-  chi2Bins[7] = 10.;
-  chi2Bins[8] = 20.;
-  chi2Bins[9] = 40.;
-  chi2Bins[10] = 100.;
-  chi2Bins[11] = 200.;
-  chi2Bins[12] = 500.;
-  chi2Bins[13] = 1000.;
-  chi2Bins[14] = 3000.;
-
-  chi2ZBins[0] = 0.25;
-  chi2ZBins[1] = 0.5;
-  chi2ZBins[2] = 1.0;
-  chi2ZBins[3] = 2.;
-  chi2ZBins[4] = 3.;
-  chi2ZBins[5] = 5.;
-  chi2ZBins[6] = 7.;
-  chi2ZBins[7] = 10.;
-  chi2ZBins[8] = 20.;
-  chi2ZBins[9] = 40.;
-  chi2ZBins[10] = 100.;
-  chi2ZBins[11] = 200.;
-  chi2ZBins[12] = 500.;
-  chi2ZBins[13] = 1000.;
-  chi2ZBins[14] = 3000.;
-
-  Bchi2Bins[0] = 0.5;
-  Bchi2Bins[1] = 1.25;
-  Bchi2Bins[2] = 2.0;
-  Bchi2Bins[3] = 3.0;
-  Bchi2Bins[4] = 5.0;
-  Bchi2Bins[5] = 10.;
-  Bchi2Bins[6] = 50.;
-};

--- a/DataFormats/L1TrackTrigger/src/classes_def.xml
+++ b/DataFormats/L1TrackTrigger/src/classes_def.xml
@@ -20,7 +20,17 @@
   <class name="vector<TTCluster<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>,Phase2TrackerDigi,edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > > >" />
   <class name="vector<TTStub<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>,Phase2TrackerDigi,edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > > >" />
   <class name="vector<TTTrack<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>,Phase2TrackerDigi,edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > > >" />
-  <class name="TTTrack_TrackWord"/>
+  <class name="TTTrack_TrackWord" ClassVersion="4">
+   <version ClassVersion="4" checksum="133238749"/>
+   <version ClassVersion="3" checksum="4186150061"/>
+   <ioread sourceClass = "TTTrack_TrackWord" version="[-3]" targetClass="TTTrack_TrackWord"
+    source="unsigned int iRinv; unsigned int iphi; unsigned int itanl; unsigned int iz0; unsigned int id0; unsigned int ichi2XY; unsigned int ichi2Z; unsigned int iBendChi2; unsigned int ispare; unsigned int iHitPattern;" target="">
+    <![CDATA[
+      TTTrack_TrackWord tmp(1, onfile.iRinv, onfile.iphi, onfile.itanl, onfile.iz0, onfile.id0, onfile.ichi2XY, onfile.ichi2Z, onfile.iBendChi2, onfile.iHitPattern, 0, 0);
+      *newObj=tmp;
+    ]]>
+   </ioread>
+  </class>
   <class name="std::vector<TTTrack_TrackWord>"/>
   <class name="edm::Wrapper<std::vector<TTTrack_TrackWord> >"/>
   <class name="edm::Ptr<TTTrack<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>,Phase2TrackerDigi,edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > > >" /> 

--- a/HLTrigger/Muon/test/BuildFile.xml
+++ b/HLTrigger/Muon/test/BuildFile.xml
@@ -1,6 +1,7 @@
 <use name="FWCore/Framework"/>
 <use name="FWCore/ParameterSet"/>
 <use name="DataFormats/Common"/>
+<use name="DataFormats/HLTReco"/>
 <use name="SimDataFormats/GeneratorProducts"/>
 <use name="DataFormats/RecoCandidate"/>
 <use name="root"/>


### PR DESCRIPTION
#### PR description:

This PR will update the TTTrack and TTTrack_TrackWord classes to correspond to the latest definitions in the corresponding [Phase 2 L1Trigger interface document](https://www.overleaf.com/read/ddsnkprgjmnp). The specifications have been agreed upon by the track trigger and the L1Trigger project leads. 

#### PR validation:

After forming a branch with just the changes we want (see backport specifications for more details), the ability to compile the code was checked by doing:
```bash
cmsrel CMSSW_12_0_X_2021-07-19-1100
cd CMSSW_12_0_X_2021-07-19-1100/src
cmsenv
git-cms-init
git-cms-checkout-topic aperloff:CMSSW_12_0_X-TrackWordUpdate
scram b -j 8
```

I also re-ran the code checks and code format checks using:
```bash
scram build code-checks
scram build code-format
```

To confirm that the code runs I used:
```bash
scram b runtests
runTheMatrix.py -l limited -i all --ibeos
```

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

These changes were previously integrated into the cms-l1t-offline fork of CMSSW and are being ported over to this repo. This PR includes portions of https://github.com/cms-l1t-offline/cmssw/pull/896 and https://github.com/cms-l1t-offline/cmssw/pull/902. The backport was created manually due to the complexity of the Git history in cms-l1t-offline.

@tomalin @skinnari @emacdonald16 @rekovic @cecilecaillol