### PR TITLE
Correct pps sim vtx position

### DIFF
--- a/SimTransport/PPSProtonTransport/python/CommonParameters_cfi.py
+++ b/SimTransport/PPSProtonTransport/python/CommonParameters_cfi.py
@@ -5,7 +5,7 @@ commonParameters = cms.PSet(
                 Verbosity = cms.bool(False),
                 EtaCut     = cms.double(8.2),
                 MomentumCut= cms.double(3000),
-                PPSRegionStart_45 = cms.double(212.45),
-                PPSRegionStart_56 = cms.double(212.45)
+                PPSRegionStart_45 = cms.double(203),
+                PPSRegionStart_56 = cms.double(203)
 )
 

--- a/SimTransport/PPSProtonTransport/src/OpticalFunctionsTransport.cc
+++ b/SimTransport/PPSProtonTransport/src/OpticalFunctionsTransport.cc
@@ -172,10 +172,11 @@ bool OpticalFunctionsTransport::transportProton(const HepMC::GenParticle* in_trk
         << "    proton transported: a_x = " << a_x << " rad, a_y = " << a_y << " rad, b_x = " << b_x
         << " mm, b_y = " << b_y << " mm, z = " << z_scoringPlane << " mm" << std::endl;
   }
-//
-// Project the track back to the starting of PPS region
-   b_x-=(abs(z_scoringPlane)-(double)((z_scoringPlane<0)?fPPSRegionStart_45:fPPSRegionStart_56)*1e3)*a_x; // z_scoringPlane is in mm
-   b_y-=(abs(z_scoringPlane)-(double)((z_scoringPlane<0)?fPPSRegionStart_45:fPPSRegionStart_56)*1e3)*a_y;
+  //
+  // Project the track back to the starting of PPS region
+  b_x -= (abs(z_scoringPlane) - (double)((z_scoringPlane < 0) ? fPPSRegionStart_45 : fPPSRegionStart_56) * 1e3) *
+         a_x;  // z_scoringPlane is in mm
+  b_y -= (abs(z_scoringPlane) - (double)((z_scoringPlane < 0) ? fPPSRegionStart_45 : fPPSRegionStart_56) * 1e3) * a_y;
 
   unsigned int line = in_trk->barcode();
   double px = -p * a_x;

--- a/SimTransport/PPSProtonTransport/src/OpticalFunctionsTransport.cc
+++ b/SimTransport/PPSProtonTransport/src/OpticalFunctionsTransport.cc
@@ -172,6 +172,10 @@ bool OpticalFunctionsTransport::transportProton(const HepMC::GenParticle* in_trk
         << "    proton transported: a_x = " << a_x << " rad, a_y = " << a_y << " rad, b_x = " << b_x
         << " mm, b_y = " << b_y << " mm, z = " << z_scoringPlane << " mm" << std::endl;
   }
+//
+// Project the track back to the starting of PPS region
+   b_x-=(abs(z_scoringPlane)-(double)((z_scoringPlane<0)?fPPSRegionStart_45:fPPSRegionStart_56)*1e3)*a_x; // z_scoringPlane is in mm
+   b_y-=(abs(z_scoringPlane)-(double)((z_scoringPlane<0)?fPPSRegionStart_45:fPPSRegionStart_56)*1e3)*a_y;
 
   unsigned int line = in_trk->barcode();
   double px = -p * a_x;


### PR DESCRIPTION
#### PR description:

Correct the final sim vertex position inside PPS region after the proton propagation since the final position was taken from the optical function but it was skipping the first detector. A straight line projection back to the z=±203m is implemented.

#### PR validation:

All tests ran without any issue

runTheMatrix run for PPS specify workflow only.
