### PR TITLE
Improve MessageLogger context handling

### DIFF
--- a/FWCore/MessageService/plugins/MessageLogger.cc
+++ b/FWCore/MessageService/plugins/MessageLogger.cc
@@ -342,11 +342,19 @@ namespace edm {
         } else if (tran == GlobalContext::Transition::kBeginRun or tran == GlobalContext::Transition::kEndRun) {
           establishModule(
               runInfoBegin_ + globalContext->runIndex(), iModContext, s_globalTransitionNames[static_cast<int>(tran)]);
-        } else {
-          assert(tran == GlobalContext::Transition::kBeginProcessBlock ||
-                 tran == GlobalContext::Transition::kAccessInputProcessBlock ||
-                 tran == GlobalContext::Transition::kEndProcessBlock);
+        } else if (tran == GlobalContext::Transition::kBeginProcessBlock ||
+                   tran == GlobalContext::Transition::kAccessInputProcessBlock ||
+                   tran == GlobalContext::Transition::kEndProcessBlock) {
           establishModule(processBlockInfoBegin_, iModContext, s_globalTransitionNames[static_cast<int>(tran)]);
+        } else {
+          MessageDrop* messageDrop = MessageDrop::instance();
+          messageDrop->streamID = std::numeric_limits<unsigned int>::max();
+          messageDrop->setSinglet("unknown context");
+          MessageDrop::instance()->runEvent = "";
+          messageDrop->debugEnabled = nonModule_debugEnabled;
+          messageDrop->infoEnabled = nonModule_infoEnabled;
+          messageDrop->warningEnabled = nonModule_warningEnabled;
+          messageDrop->errorEnabled = nonModule_errorEnabled;
         }
       } else {
         auto stream = iModContext.getStreamContext();
@@ -465,11 +473,19 @@ namespace edm {
           } else if (tran == GlobalContext::Transition::kBeginRun or tran == GlobalContext::Transition::kEndRun) {
             establishModule(
                 runInfoBegin_ + globalContext->runIndex(), *previous, s_globalTransitionNames[static_cast<int>(tran)]);
-          } else {
-            assert(tran == GlobalContext::Transition::kBeginProcessBlock ||
-                   tran == GlobalContext::Transition::kAccessInputProcessBlock ||
-                   tran == GlobalContext::Transition::kEndProcessBlock);
+          } else if (tran == GlobalContext::Transition::kBeginProcessBlock ||
+                     tran == GlobalContext::Transition::kAccessInputProcessBlock ||
+                     tran == GlobalContext::Transition::kEndProcessBlock) {
             establishModule(processBlockInfoBegin_, *previous, s_globalTransitionNames[static_cast<int>(tran)]);
+          } else {
+            MessageDrop* messageDrop = MessageDrop::instance();
+            messageDrop->streamID = std::numeric_limits<unsigned int>::max();
+            messageDrop->setSinglet("unknown context");
+            MessageDrop::instance()->runEvent = "";
+            messageDrop->debugEnabled = nonModule_debugEnabled;
+            messageDrop->infoEnabled = nonModule_infoEnabled;
+            messageDrop->warningEnabled = nonModule_warningEnabled;
+            messageDrop->errorEnabled = nonModule_errorEnabled;
           }
         } else {
           auto stream = previous->getStreamContext();


### PR DESCRIPTION
#### PR description:

Remove assertions recently added in pull request #34506 that caused problems documented in issue #34520. Even if the asserts uncovered a real problem, using the MessageLogger context system to test for this is probably not the best design. It was not my original intent. I thought it was just paranoid protection against something that couldn't happen.

Instead of asserting, the MessageLogger context will go into an "unknown state". The context line will print "unknown context" in the spot where the context normally goes.

This only affects the context printed in a MessageLogger message. It only affects it in the unusual case where one module ends, there was a previous module running/waiting when it started, the context for the previous module is not in one of the normally expected states.

This is a limited fix intended to address only the recent assert failure referenced above. Practically speaking, this is probably good enough, but as I implemented this I noticed there are issues in this part of the code which I did not try to fix. We might want to follow this up with more improvements.

MessageLogger is using thread locals and the ActivityRegistry to keep track of which module is currently running. Concurrent tasks and waits inside of module level transition functions could be problematic for this design. It worked perfectly before concurrency. We've discussed similar issues before. I think Chris has brought this up more than once.

We do not and have not ever set the context for the module transitions writeLumi, writeRun, and writeProcessBlock. I have not added support for that here. The specific case where the assert failed was related to writeLumi. This is something we could fix in the future although I've never noticed MessageLogger messages being printed in those contexts...

The other two possible GlobalContext states that might have caused those asserts to fail are kBeginJob and kEndJob. Those are handled in a different way which also could be problematic if those methods ever have sub transition function concurrency/waits in the future.

#### PR validation:

Relies on existing unit tests. This change only affects the response to behavior that should really not be happening.
