### PR TITLE
Turn off GEM [un]packer in phase2

### DIFF
--- a/Configuration/StandardSequences/python/DigiToRaw_cff.py
+++ b/Configuration/StandardSequences/python/DigiToRaw_cff.py
@@ -47,7 +47,8 @@ from Configuration.Eras.Modifier_run2_GEM_2017_cff import run2_GEM_2017
 run2_GEM_2017.toReplaceWith(DigiToRawTask, _gem_DigiToRawTask)
 
 from Configuration.Eras.Modifier_run3_GEM_cff import run3_GEM
-run3_GEM.toReplaceWith(DigiToRawTask, _gem_DigiToRawTask)
+from Configuration.Eras.Modifier_phase2_GEM_cff import phase2_GEM
+(run3_GEM & ~phase2_GEM).toReplaceWith(DigiToRawTask, _gem_DigiToRawTask)
 
 from Configuration.Eras.Modifier_phase2_muon_cff import phase2_muon
 phase2_muon.toReplaceWith(DigiToRawTask, DigiToRawTask.copyAndExclude([rpcpacker]))

--- a/Configuration/StandardSequences/python/RawToDigi_cff.py
+++ b/Configuration/StandardSequences/python/RawToDigi_cff.py
@@ -110,7 +110,8 @@ from Configuration.Eras.Modifier_run2_GEM_2017_cff import run2_GEM_2017
 run2_GEM_2017.toReplaceWith(RawToDigiTask, _gem_RawToDigiTask)
 
 from Configuration.Eras.Modifier_run3_GEM_cff import run3_GEM
-run3_GEM.toReplaceWith(RawToDigiTask, _gem_RawToDigiTask)
+from Configuration.Eras.Modifier_phase2_GEM_cff import phase2_GEM
+(run3_GEM & ~phase2_GEM).toReplaceWith(RawToDigiTask, _gem_RawToDigiTask)
 
 from EventFilter.HGCalRawToDigi.HGCalRawToDigi_cfi import *
 _hgcal_RawToDigiTask = RawToDigiTask.copy()

--- a/RecoLocalMuon/GEMRecHit/python/gemRecHits_cfi.py
+++ b/RecoLocalMuon/GEMRecHit/python/gemRecHits_cfi.py
@@ -11,4 +11,4 @@ gemRecHits = gemRecHitsDef.clone(
     )
 
 from Configuration.Eras.Modifier_phase2_GEM_cff import phase2_GEM
-phase2_GEM.toModify(gemRecHits, gemDigiLabel = cms.InputTag("simMuonGEMDigis"))
+phase2_GEM.toModify(gemRecHits, gemDigiLabel = "simMuonGEMDigis")

--- a/RecoLocalMuon/GEMRecHit/python/gemRecHits_cfi.py
+++ b/RecoLocalMuon/GEMRecHit/python/gemRecHits_cfi.py
@@ -9,3 +9,6 @@ gemRecHits = gemRecHitsDef.clone(
     #maskFile = cms.FileInPath("RecoLocalMuon/GEMRecHit/data/maskedStrips.txt"),
     #deadFile = cms.FileInPath("RecoLocalMuon/GEMRecHit/data/deadStrips.txt")
     )
+
+from Configuration.Eras.Modifier_phase2_GEM_cff import phase2_GEM
+phase2_GEM.toModify(gemRecHits, gemDigiLabel = cms.InputTag("simMuonGEMDigis"))

--- a/Validation/MuonGEMDigis/python/muonGEMDigiPSet.py
+++ b/Validation/MuonGEMDigis/python/muonGEMDigiPSet.py
@@ -41,3 +41,6 @@ muonGEMDigiPSet = cms.PSet(
         maxBX = cms.int32(0),
     ),
 )
+
+from Configuration.Eras.Modifier_phase2_GEM_cff import phase2_GEM
+phase2_GEM.toModify(muonGEMDigiPSet.gemUnpackedStripDigi, inputTag = cms.InputTag("simMuonGEMDigis"))

--- a/Validation/MuonGEMDigis/python/muonGEMDigiPSet.py
+++ b/Validation/MuonGEMDigis/python/muonGEMDigiPSet.py
@@ -43,4 +43,4 @@ muonGEMDigiPSet = cms.PSet(
 )
 
 from Configuration.Eras.Modifier_phase2_GEM_cff import phase2_GEM
-phase2_GEM.toModify(muonGEMDigiPSet.gemUnpackedStripDigi, inputTag = cms.InputTag("simMuonGEMDigis"))
+phase2_GEM.toModify(muonGEMDigiPSet.gemUnpackedStripDigi, inputTag = "simMuonGEMDigis")


### PR DESCRIPTION
#### PR description:

The digi packer/unpacker format for GEM in Phase2 is not yet developed. So, we are turning off the packer for GEM in phase 2 simulations.

<!-- Please replace this text with a description of the feature proposed or problem addressed, specifying:
  - what changes are expected in the output if any, 
  - what other PRs or externals it depends upon if any,
  - link to any additional material useful to provide a documentation for this PR (slides, JIRA tickets, related pull requestes, hypernews, TWiki or Indico pages)  -->

#### PR validation:

Checked that run3 and phase2 workflows still run and the GEM digi distributions are the same. Checked that the relevant modules are turned off in the process schedule.

<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

<!-- Please replace this text with any link to  -->

@jshlee 