### PR TITLE
Update cppCommentSkipper.py

### DIFF
--- a/Utilities/ReleaseScripts/python/commentSkipper/cppCommentSkipper.py
+++ b/Utilities/ReleaseScripts/python/commentSkipper/cppCommentSkipper.py
@@ -32,27 +32,27 @@ def filterFile(file): #ifstream& input)
                     j += 1
                 #comment //  why !commentStage? because, can be a variant of this example: /*....//.....*/
                 elif not commentStage and (lines[i][j+1] == '/'):
-                    lines[i] = string.replace(lines[i], lines[i][j:],'\n', 1)
+                    lines[i] = lines[i].replace(lines[i][j:],'\n', 1)
                     break
             #char "
             elif char == '"':
                 if not commentStage:
-                    next = string.find(lines[i][j+1:], '"') #next "
-                    lines[i] = string.replace(lines[i], lines[i][j:j+next+2], '', 1) # clear string in ""
+                    next = lines[i][j+1:].find('"') #next "
+                    lines[i] = lines[i].replace(lines[i][j:j+next+2], '', 1) # clear string in ""
             #char '
             elif char == '\'':
                 if not commentStage:
-                    next = string.find(lines[i][j+1:], '\'') #next '
-                    lines[i] = string.replace(lines[i], lines[i][j:j+next+2], '', 1) # clear string in ''
+                    next = lines[i][j+1:].find('\'') #next '
+                    lines[i] = lines[i].replace(lines[i][j:j+next+2], '', 1) # clear string in ''
             #char *
             elif char == '*':
                 if (commentStage and (lines[i][j+1] == '/')):
                     commentStage = False;
                     if commentStartLine != i:
-                        lines[i] = string.replace(lines[i], lines[i][:j+2],'', 1) # comment */ [..code]
+                        lines[i] = lines[i].replace(lines[i][:j+2],'', 1) # comment */ [..code]
                         j = -1 #because of j+=1 at the end
                     else:
-                        lines[i] = string.replace(lines[i], lines[i][commentStartColumn:j+2], '', 1) # [code..] /*comment*/ [.. code]
+                        lines[i] = lines[i].replace(lines[i][commentStartColumn:j+2], '', 1) # [code..] /*comment*/ [.. code]
                         j = commentStartColumn - 1 #because of j+=1 at the ends
             if j != len(lines[i]) - 1:
                 j += 1


### PR DESCRIPTION
#### PR description:

Change `string.find(foo, bar)` into `foo.find(bar)`, `string.replace(foo, bar, baz, n)` into `foo.replace(bar, baz, n)`. The new syntax was already present in 2.7 series, and was removed in 3.x

Saw an error message in this log: https://cmssdt.cern.ch/jenkins/job/ib-run-pr-tests/17008/console
```
13:37:18 + cmsCodeRulesChecker.py -s /data/cmsbld/jenkins/workspace/ib-run-pr-tests/codeRules -r 1,3
13:37:19 Traceback (most recent call last):
13:37:19   File "/data/cmsbld/jenkins/workspace/ib-run-pr-tests/CMSSW_12_0_X_2021-07-19-1100/bin/slc7_amd64_gcc900/cmsCodeRulesChecker.py", line 220, in <module>
13:37:19     result = runRules(ruleNumbers, checkPath)
13:37:19   File "/data/cmsbld/jenkins/workspace/ib-run-pr-tests/CMSSW_12_0_X_2021-07-19-1100/bin/slc7_amd64_gcc900/cmsCodeRulesChecker.py", line 89, in runRules
13:37:19     filesLinesList = skipper(filesLinesList)
13:37:19   File "/data/cmsbld/jenkins/workspace/ib-run-pr-tests/CMSSW_12_0_X_2021-07-19-1100/python/Utilities/ReleaseScripts/commentSkipper/commentSkipper.py", line 21, in filter
13:37:19     fileList = cppCommentSkipper.filterFiles(fileList)
13:37:19   File "/data/cmsbld/jenkins/workspace/ib-run-pr-tests/CMSSW_12_0_X_2021-07-19-1100/python/Utilities/ReleaseScripts/commentSkipper/cppCommentSkipper.py", line 11, in filterFiles
13:37:19     files.append((file, filterFile(file)))
13:37:19   File "/data/cmsbld/jenkins/workspace/ib-run-pr-tests/CMSSW_12_0_X_2021-07-19-1100/python/Utilities/ReleaseScripts/commentSkipper/cppCommentSkipper.py", line 35, in filterFile
13:37:19     lines[i] = string.replace(lines[i], lines[i][j:],'\n', 1)
13:37:19 AttributeError: module 'string' has no attribute 'replace'
```