### PR TITLE
Access RunIndex from RunForOutput

### DIFF
--- a/FWCore/Framework/interface/RunForOutput.h
+++ b/FWCore/Framework/interface/RunForOutput.h
@@ -58,7 +58,7 @@ namespace edm {
     Timestamp const& endTime() const { return aux_.endTime(); }
     MergeableRunProductMetadata const* mergeableRunProductMetadata() const { return mergeableRunProductMetadata_; }
 
-    /**\return Reusable index which can be used to separate data for different simultaneous LuminosityBlocks.
+    /**\return Reusable index which can be used to separate data for different simultaneous Runs.
      */
     RunIndex index() const;
 

--- a/FWCore/Framework/interface/RunForOutput.h
+++ b/FWCore/Framework/interface/RunForOutput.h
@@ -22,6 +22,7 @@ For its usage, see "FWCore/Framework/interface/PrincipalGetAdapter.h"
 #include "FWCore/Framework/interface/OccurrenceForOutput.h"
 #include "FWCore/Framework/interface/PrincipalGetAdapter.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Utilities/interface/RunIndex.h"
 
 #include <memory>
 #include <string>
@@ -56,6 +57,10 @@ namespace edm {
     Timestamp const& beginTime() const { return aux_.beginTime(); }
     Timestamp const& endTime() const { return aux_.endTime(); }
     MergeableRunProductMetadata const* mergeableRunProductMetadata() const { return mergeableRunProductMetadata_; }
+
+    /**\return Reusable index which can be used to separate data for different simultaneous LuminosityBlocks.
+     */
+    RunIndex index() const;
 
   private:
     friend class edmtest::TestOutputModule;  // For testing

--- a/FWCore/Framework/src/RunForOutput.cc
+++ b/FWCore/Framework/src/RunForOutput.cc
@@ -26,4 +26,9 @@ namespace edm {
   RunForOutput::~RunForOutput() {}
 
   RunPrincipal const& RunForOutput::runPrincipal() const { return dynamic_cast<RunPrincipal const&>(principal()); }
+
+  /**\return Reusable index which can be used to separate data for different simultaneous LuminosityBlocks.
+   */
+  RunIndex RunForOutput::index() const { return runPrincipal().index(); }
+
 }  // namespace edm

--- a/FWCore/Framework/src/RunForOutput.cc
+++ b/FWCore/Framework/src/RunForOutput.cc
@@ -27,7 +27,7 @@ namespace edm {
 
   RunPrincipal const& RunForOutput::runPrincipal() const { return dynamic_cast<RunPrincipal const&>(principal()); }
 
-  /**\return Reusable index which can be used to separate data for different simultaneous LuminosityBlocks.
+  /**\return Reusable index which can be used to separate data for different simultaneous Runs.
    */
   RunIndex RunForOutput::index() const { return runPrincipal().index(); }
 


### PR DESCRIPTION
#### PR description:

This adds the index() method to RunForOutput. This is needed to allow use of run caches in OutputModules

#### PR validation:

The code compiles and does allow use of RunCache from a global OutputModule.