### PR TITLE
Moved OutputFile to edm::streamer namespace

### DIFF
--- a/IOPool/Streamer/interface/StreamerFileIO.h
+++ b/IOPool/Streamer/interface/StreamerFileIO.h
@@ -13,38 +13,38 @@ Class representing Output (Streamer) file.
 #include <string>
 
 //-------------------------------------------------------
-
-class OutputFile
-/**
+namespace edm::streamer {
+  class OutputFile
+  /**
   Class representing Output (Streamer) file.
   */
-{
-public:
-  explicit OutputFile(const std::string& name);
-  /**
+  {
+  public:
+    explicit OutputFile(const std::string& name);
+    /**
       CTOR, takes file path name as argument
      */
-  ~OutputFile();
+    ~OutputFile();
 
-  bool write(const char* ptr, size_t n);
+    bool write(const char* ptr, size_t n);
 
-  std::string fileName() const { return filename_; }
-  uint64 current_offset() const { return current_offset_; }
-  uint32 adler32() const { return (adlerb_ << 16) | adlera_; }
+    std::string fileName() const { return filename_; }
+    uint64 current_offset() const { return current_offset_; }
+    uint32 adler32() const { return (adlerb_ << 16) | adlera_; }
 
-  void set_do_adler(bool v) { do_adler_ = v; }
-  void set_current_offset(uint64 v) { current_offset_ = v; }
-  void close();
+    void set_do_adler(bool v) { do_adler_ = v; }
+    void set_current_offset(uint64 v) { current_offset_ = v; }
+    void close();
 
-private:
-  uint64 current_offset_; /** Location of current ioptr */
+  private:
+    uint64 current_offset_; /** Location of current ioptr */
 
-  bool do_adler_;
-  uint32 adlera_;
-  uint32 adlerb_;
+    bool do_adler_;
+    uint32 adlera_;
+    uint32 adlerb_;
 
-  edm::propagate_const<std::shared_ptr<std::ofstream>> ost_;
-  std::string filename_;
-};
-
+    edm::propagate_const<std::shared_ptr<std::ofstream>> ost_;
+    std::string filename_;
+  };
+}  // namespace edm::streamer
 #endif

--- a/IOPool/Streamer/interface/StreamerOutputFile.h
+++ b/IOPool/Streamer/interface/StreamerOutputFile.h
@@ -61,7 +61,7 @@ private:
   void writeStart(const InitMsgView& inview);
 
 private:
-  edm::propagate_const<std::shared_ptr<OutputFile>> streamerfile_;
+  edm::propagate_const<std::shared_ptr<edm::streamer::OutputFile>> streamerfile_;
 };
 
 #endif

--- a/IOPool/Streamer/src/StreamerFileIO.cc
+++ b/IOPool/Streamer/src/StreamerFileIO.cc
@@ -4,6 +4,7 @@
 #include "FWCore/Utilities/interface/Adler32Calculator.h"
 #include "FWCore/Utilities/interface/Exception.h"
 
+using namespace edm::streamer;
 OutputFile::OutputFile(const std::string& name)
     : current_offset_(1),
       do_adler_(false),

--- a/IOPool/Streamer/src/StreamerFileIO.cc
+++ b/IOPool/Streamer/src/StreamerFileIO.cc
@@ -4,31 +4,32 @@
 #include "FWCore/Utilities/interface/Adler32Calculator.h"
 #include "FWCore/Utilities/interface/Exception.h"
 
-using namespace edm::streamer;
-OutputFile::OutputFile(const std::string& name)
-    : current_offset_(1),
-      do_adler_(false),
-      adlera_(1),
-      adlerb_(0),
-      ost_(new std::ofstream(name.c_str(), std::ios_base::binary | std::ios_base::out)),
-      filename_(name) {
-  if (!ost_->is_open()) {
-    throw cms::Exception("OutputFile", "OutputFile") << "Error Opening Output File: " << name << "\n";
+namespace edm::streamer {
+  OutputFile::OutputFile(const std::string& name)
+      : current_offset_(1),
+        do_adler_(false),
+        adlera_(1),
+        adlerb_(0),
+        ost_(new std::ofstream(name.c_str(), std::ios_base::binary | std::ios_base::out)),
+        filename_(name) {
+    if (!ost_->is_open()) {
+      throw cms::Exception("OutputFile", "OutputFile") << "Error Opening Output File: " << name << "\n";
+    }
+    ost_->rdbuf()->pubsetbuf(nullptr, 0);
   }
-  ost_->rdbuf()->pubsetbuf(nullptr, 0);
-}
 
-OutputFile::~OutputFile() { ost_->close(); }
+  OutputFile::~OutputFile() { ost_->close(); }
 
-bool OutputFile::write(const char* ptr, size_t n) {
-  ost_->write(ptr, n);
-  if (!ost_->fail()) {
-    current_offset_ += (uint64)(n);
-    if (do_adler_)
-      cms::Adler32(ptr, n, adlera_, adlerb_);
-    return false;
+  bool OutputFile::write(const char* ptr, size_t n) {
+    ost_->write(ptr, n);
+    if (!ost_->fail()) {
+      current_offset_ += (uint64)(n);
+      if (do_adler_)
+        cms::Adler32(ptr, n, adlera_, adlerb_);
+      return false;
+    }
+    return true;
   }
-  return true;
-}
 
-void OutputFile::close() { ost_->close(); }
+  void OutputFile::close() { ost_->close(); }
+}  // namespace edm::streamer

--- a/IOPool/Streamer/src/StreamerOutputFile.cc
+++ b/IOPool/Streamer/src/StreamerOutputFile.cc
@@ -3,7 +3,7 @@
 
 StreamerOutputFile::~StreamerOutputFile() {}
 
-StreamerOutputFile::StreamerOutputFile(const std::string& name) : streamerfile_(new OutputFile(name)) {
+StreamerOutputFile::StreamerOutputFile(const std::string& name) : streamerfile_(new edm::streamer::OutputFile(name)) {
   streamerfile_->set_do_adler(true);
 }
 

--- a/IOPool/Streamer/src/StreamerOutputFile.cc
+++ b/IOPool/Streamer/src/StreamerOutputFile.cc
@@ -3,7 +3,8 @@
 
 StreamerOutputFile::~StreamerOutputFile() {}
 
-StreamerOutputFile::StreamerOutputFile(const std::string& name) : streamerfile_(new edm::streamer::OutputFile(name)) {
+StreamerOutputFile::StreamerOutputFile(const std::string& name)
+    : streamerfile_(std::make_shared<edm::streamer::OutputFile>(name)) {
   streamerfile_->set_do_adler(true);
 }
 


### PR DESCRIPTION
#### PR description:
OutputFile is too generic of a name to be in the global namespace.

#### PR validation:

Code compiles.