### PR TITLE
Migrate module configuration in RecoMET to use default cfipython

### DIFF
--- a/RecoMET/METPUSubtraction/python/mvaPFMET_leptons_cfi.py
+++ b/RecoMET/METPUSubtraction/python/mvaPFMET_leptons_cfi.py
@@ -64,15 +64,13 @@ requireDecayMode = cms.PSet(
 )
 
 from RecoTauTag.Configuration.HPSPFTaus_cff import hpsPFTauDiscriminationByLooseCombinedIsolationDBSumPtCorr3Hits
+import RecoTauTag.RecoTau.pfRecoTauDiscriminationAgainstMuon2_cfi as _mod
 
-hpsPFTauDiscriminationAgainstMuon2 = cms.EDProducer(
-    "PFRecoTauDiscriminationAgainstMuon2",
-    PFTauProducer = cms.InputTag('hpsPFTauProducer'),
+PFTauDiscriminationAgainstMuon2 = _mod.pfRecoTauDiscriminationAgainstMuon2.clone(
+    PFTauProducer = 'hpsPFTauProducer',
     Prediscriminants = requireDecayMode.clone(),
-    discriminatorOption = cms.string('loose'), # available options are: 'loose', 'medium', 'tight'
-    HoPMin = cms.double(0.2)
-
-
+    discriminatorOption = 'loose', # available options are: 'loose', 'medium', 'tight'
+)
 
 hpsPFTauDiscriminationByMVAIsolation = cms.EDProducer(
     "PFRecoTauDiscriminationByMVAIsolation",

--- a/RecoMET/METPUSubtraction/python/mvaPFMET_leptons_cfi.py
+++ b/RecoMET/METPUSubtraction/python/mvaPFMET_leptons_cfi.py
@@ -66,7 +66,7 @@ requireDecayMode = cms.PSet(
 from RecoTauTag.Configuration.HPSPFTaus_cff import hpsPFTauDiscriminationByLooseCombinedIsolationDBSumPtCorr3Hits
 import RecoTauTag.RecoTau.pfRecoTauDiscriminationAgainstMuon2_cfi as _mod
 
-PFTauDiscriminationAgainstMuon2 = _mod.pfRecoTauDiscriminationAgainstMuon2.clone(
+hpsPFTauDiscriminationAgainstMuon2 = _mod.pfRecoTauDiscriminationAgainstMuon2.clone(
     PFTauProducer = 'hpsPFTauProducer',
     Prediscriminants = requireDecayMode.clone(),
     discriminatorOption = 'loose', # available options are: 'loose', 'medium', 'tight'

--- a/RecoMET/METPUSubtraction/python/mvaPFMET_leptons_cfi.py
+++ b/RecoMET/METPUSubtraction/python/mvaPFMET_leptons_cfi.py
@@ -4,100 +4,100 @@ import FWCore.ParameterSet.Config as cms
 isomuons = cms.EDFilter(
     "MuonSelector",
     src = cms.InputTag('muons'),
-    cut = cms.string(    "(isTrackerMuon) && std::abs(eta) < 2.5 && pt > 9.5"+#17. "+
-                         "&& isPFMuon"+
-                         "&& globalTrack.isNonnull"+
-                         "&& innerTrack.hitPattern.numberOfValidPixelHits > 0"+
-                         "&& innerTrack.normalizedChi2 < 10"+
-                         "&& numberOfMatches > 0"+
-                         "&& innerTrack.hitPattern.numberOfValidTrackerHits>5"+
-                         "&& globalTrack.hitPattern.numberOfValidHits>0"+
-                         "&& (pfIsolationR03.sumChargedHadronPt+pfIsolationR03.sumNeutralHadronEt+pfIsolationR03.sumPhotonEt)/pt < 0.3"+
-                         "&& std::abs(innerTrack().dxy)<2.0"
-                         ),
+    cut = cms.string("(isTrackerMuon) && std::abs(eta) < 2.5 && pt > 9.5"+#17. "+
+                     "&& isPFMuon"+
+                     "&& globalTrack.isNonnull"+
+                     "&& innerTrack.hitPattern.numberOfValidPixelHits > 0"+
+                     "&& innerTrack.normalizedChi2 < 10"+
+                     "&& numberOfMatches > 0"+
+                     "&& innerTrack.hitPattern.numberOfValidTrackerHits>5"+
+                     "&& globalTrack.hitPattern.numberOfValidHits>0"+
+                     "&& (pfIsolationR03.sumChargedHadronPt+pfIsolationR03.sumNeutralHadronEt+pfIsolationR03.sumPhotonEt)/pt < 0.3"+
+                     "&& std::abs(innerTrack().dxy)<2.0"
+                     ),
     filter = cms.bool(False)
-    )
+)
 
 
 isoelectrons = cms.EDFilter(
     "GsfElectronSelector",
-            src = cms.InputTag('gsfElectrons'),
-            cut = cms.string(
-            "std::abs(eta) < 2.5 && pt > 9.5"                               +
-            "&& gsfTrack.trackerExpectedHitsInner.numberOfHits == 0"   +
-#            "&& (pfIsolationVariables.chargedHadronIso+pfIsolationVariables.neutralHadronIso)/et     < 0.3"  +
-            "&& (isolationVariables03.tkSumPt)/et              < 0.2"  +
-            "&& ((std::abs(eta) < 1.4442  "                                 +
-            "&& std::abs(deltaEtaSuperClusterTrackAtVtx)            < 0.007"+
-            "&& std::abs(deltaPhiSuperClusterTrackAtVtx)            < 0.8"  +
-            "&& sigmaIetaIeta                                  < 0.01" +
-            "&& hcalOverEcal                                   < 0.15" +
-            "&& std::abs(1./superCluster.energy - 1./p)             < 0.05)"+
-            "|| (std::abs(eta)  > 1.566 "+
-            "&& std::abs(deltaEtaSuperClusterTrackAtVtx)            < 0.009"+
-            "&& std::abs(deltaPhiSuperClusterTrackAtVtx)            < 0.10" +
-            "&& sigmaIetaIeta                                  < 0.03" +
-            "&& hcalOverEcal                                   < 0.10" +
-            "&& std::abs(1./superCluster.energy - 1./p)             < 0.05))" 
-            ),
-        filter = cms.bool(False)
-        )
+    src = cms.InputTag('gsfElectrons'),
+    cut = cms.string("std::abs(eta) < 2.5 && pt > 9.5"                               +
+                     "&& gsfTrack.trackerExpectedHitsInner.numberOfHits == 0"   +
+#                     "&& (pfIsolationVariables.chargedHadronIso+pfIsolationVariables.neutralHadronIso)/et     < 0.3"  +
+                     "&& (isolationVariables03.tkSumPt)/et              < 0.2"  +
+                     "&& ((std::abs(eta) < 1.4442  "                                 +
+                     "&& std::abs(deltaEtaSuperClusterTrackAtVtx)            < 0.007"+
+                     "&& std::abs(deltaPhiSuperClusterTrackAtVtx)            < 0.8"  +
+                     "&& sigmaIetaIeta                                  < 0.01" +
+                     "&& hcalOverEcal                                   < 0.15" +
+                     "&& std::abs(1./superCluster.energy - 1./p)             < 0.05)"+
+                     "|| (std::abs(eta)  > 1.566 "+
+                     "&& std::abs(deltaEtaSuperClusterTrackAtVtx)            < 0.009"+
+                     "&& std::abs(deltaPhiSuperClusterTrackAtVtx)            < 0.10" +
+                     "&& sigmaIetaIeta                                  < 0.03" +
+                     "&& hcalOverEcal                                   < 0.10" +
+                     "&& std::abs(1./superCluster.energy - 1./p)             < 0.05))" 
+                     ),
+    filter = cms.bool(False)
+)
 
 from RecoJets.Configuration.RecoPFJets_cff import kt6PFJets as dummy
 kt6PFJetsForRhoComputationVoronoiMet = dummy.clone(
-        doRhoFastjet = True,
-        voronoiRfact = 0.9
-        )
+    doRhoFastjet = True,
+    voronoiRfact = 0.9
+)
 
 from RecoTauTag.RecoTau.PFRecoTauDiscriminationByHPSSelection_cfi import hpsSelectionDiscriminator
 hpsPFTauDiscriminationByDecayModeFinding = hpsSelectionDiscriminator.clone(
-        PFTauProducer = 'hpsPFTauProducer'
-            )
+    PFTauProducer = 'hpsPFTauProducer'
+)
 
 from RecoTauTag.RecoTau.TauDiscriminatorTools import requireLeadTrack
 # Define decay mode prediscriminant
 requireDecayMode = cms.PSet(
-        BooleanOperator = cms.string("and"),
-            decayMode = cms.PSet(
-            Producer = cms.InputTag('hpsPFTauDiscriminationByDecayModeFinding'),
-                    cut = cms.double(0.5)
-                )
-        )
+    BooleanOperator = cms.string("and"),
+    decayMode = cms.PSet(
+        Producer = cms.InputTag('hpsPFTauDiscriminationByDecayModeFinding'),
+        cut = cms.double(0.5)
+    )
+)
 
 from RecoTauTag.Configuration.HPSPFTaus_cff import hpsPFTauDiscriminationByLooseCombinedIsolationDBSumPtCorr3Hits
 
-hpsPFTauDiscriminationAgainstMuon2 = cms.EDProducer("PFRecoTauDiscriminationAgainstMuon2",
-                                                         PFTauProducer = cms.InputTag('hpsPFTauProducer'),
-                                                         Prediscriminants = requireDecayMode.clone(),
-                                                         discriminatorOption = cms.string('loose'), # available options are: 'loose', 'medium', 'tight'
-                                                         HoPMin = cms.double(0.2)
-                                                     )
+hpsPFTauDiscriminationAgainstMuon2 = cms.EDProducer(
+    "PFRecoTauDiscriminationAgainstMuon2",
+    PFTauProducer = cms.InputTag('hpsPFTauProducer'),
+    Prediscriminants = requireDecayMode.clone(),
+    discriminatorOption = cms.string('loose'), # available options are: 'loose', 'medium', 'tight'
+    HoPMin = cms.double(0.2)
+
 
 
 hpsPFTauDiscriminationByMVAIsolation = cms.EDProducer(
     "PFRecoTauDiscriminationByMVAIsolation",
-            PFTauProducer = cms.InputTag('hpsPFTauProducer'),
-            rhoProducer = cms.InputTag('kt6PFJetsForRhoComputationVoronoiMet','rho'),
-            Prediscriminants = requireDecayMode.clone(),
-            gbrfFilePath = cms.FileInPath('RecoTauTag/RecoTau/data/gbrfTauIso_v2.root'),
-            returnMVA = cms.bool(False),
-            mvaMin = cms.double(0.8),
-            )
+    PFTauProducer = cms.InputTag('hpsPFTauProducer'),
+    rhoProducer = cms.InputTag('kt6PFJetsForRhoComputationVoronoiMet','rho'),
+    Prediscriminants = requireDecayMode.clone(),
+    gbrfFilePath = cms.FileInPath('RecoTauTag/RecoTau/data/gbrfTauIso_v2.root'),
+    returnMVA = cms.bool(False),
+    mvaMin = cms.double(0.8),
+)
 
 isotaus = cms.EDFilter(
     "PFTauSelector",
     src = cms.InputTag('hpsPFTauProducer'),
     BooleanOperator = cms.string("and"),
     discriminators = cms.VPSet(
-    cms.PSet( discriminator=cms.InputTag("hpsPFTauDiscriminationByDecayModeFinding"),       selectionCut=cms.double(0.5)),
-    #cms.PSet( discriminator=cms.InputTag("hpsPFTauDiscriminationByMVAIsolation"),           selectionCut=cms.double(0.5)),
-    cms.PSet( discriminator=cms.InputTag("hpsPFTauDiscriminationByLooseCombinedIsolationDBSumPtCorr3Hits"),           selectionCut=cms.double(0.5)),
-    cms.PSet( discriminator=cms.InputTag("hpsPFTauDiscriminationByLooseElectronRejection"), selectionCut=cms.double(0.5)),
-    cms.PSet( discriminator=cms.InputTag("hpsPFTauDiscriminationAgainstMuon2"),             selectionCut=cms.double(0.5)) 
+        cms.PSet( discriminator=cms.InputTag("hpsPFTauDiscriminationByDecayModeFinding"),       selectionCut=cms.double(0.5)),
+        #cms.PSet( discriminator=cms.InputTag("hpsPFTauDiscriminationByMVAIsolation"),           selectionCut=cms.double(0.5)),
+        cms.PSet( discriminator=cms.InputTag("hpsPFTauDiscriminationByLooseCombinedIsolationDBSumPtCorr3Hits"),           selectionCut=cms.double(0.5)),
+        cms.PSet( discriminator=cms.InputTag("hpsPFTauDiscriminationByLooseElectronRejection"), selectionCut=cms.double(0.5)),
+        cms.PSet( discriminator=cms.InputTag("hpsPFTauDiscriminationAgainstMuon2"),             selectionCut=cms.double(0.5)) 
     ),
     cut = cms.string("std::abs(eta) < 2.3 && pt > 19.0 "),
     filter = cms.bool(False)
-    )
+)
 
 isomuonTask     = cms.Task(isomuons)
 isomuonseq      = cms.Sequence(isomuonsTask)


### PR DESCRIPTION
#### PR description: 
Optimization of the python configurations: Improve maintainability by cleaning up the duplicated and cloning from the default/reference configurations. (The previous PRs : #33207, #33307, #33352, #33543, #33563, #33671, #34007, #34091, #34009, #34155, #34371, #34480, #34543 )
 
In this PR, 1 file changed.  
        modified:   RecoMET/METPUSubtraction/python/mvaPFMET_leptons_cfi.py

Update
- Replace explicit configuration with a reference from cfipython/. (migrating EDProducer("type", .. -> typeDefaylt.clone() ) 
- Remove the type specifications already presented in cfipython/fillDescriptions reference for improved syntax safety.
- Remove the duplicated parameters that are exactly the same value in cfipython reference.

#### PR validation:
Event Content comparison check was also done and there is no change with these updates.
Tested in CMSSW_12_0_X, the basic test all passed in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html).