### PR TITLE
Allow HcalPulseContainment timePhase definition as in SIM

### DIFF
--- a/CalibCalorimetry/HcalAlgos/interface/HcalPulseContainmentCorrection.h
+++ b/CalibCalorimetry/HcalAlgos/interface/HcalPulseContainmentCorrection.h
@@ -16,11 +16,13 @@ class HcalPulseContainmentCorrection {
 public:
   HcalPulseContainmentCorrection(int num_samples,
                                  float fixedphase_ns,
+                                 bool phaseAsInSim,
                                  float max_fracerror,
                                  const HcalTimeSlew* hcalTimeSlew_delay);
   HcalPulseContainmentCorrection(const HcalPulseShape* shape,
                                  int num_samples,
                                  float fixedphase_ns,
+                                 bool phaseAsInSim,
                                  float max_fracerror,
                                  const HcalTimeSlew* hcalTimeSlew_delay);
   double getCorrection(double fc_ampl) const;

--- a/CalibCalorimetry/HcalAlgos/interface/HcalPulseContainmentManager.h
+++ b/CalibCalorimetry/HcalAlgos/interface/HcalPulseContainmentManager.h
@@ -10,9 +10,9 @@
 class HcalPulseContainmentManager {
 public:
   // for callers not calling beginRun(EventSetup)
-  HcalPulseContainmentManager(float max_fracerror);
+  HcalPulseContainmentManager(float max_fracerror, bool phaseAsInSim);
   // for callers calling beginRun(EventSetup)
-  HcalPulseContainmentManager(float max_fracerror, edm::ConsumesCollector iC);
+  HcalPulseContainmentManager(float max_fracerror, bool phaseAsInSim, edm::ConsumesCollector iC);
   double correction(const HcalDetId& detId, int toAdd, float fixedphase_ns, double fc_ampl);
   const HcalPulseContainmentCorrection* get(const HcalDetId& detId, int toAdd, float fixedphase_ns);
 
@@ -38,6 +38,7 @@ private:
   HcalPulseShapes shapes_;
   float fixedphase_ns_;
   float max_fracerror_;
+  bool phaseAsInSim_;
   const edm::ESGetToken<HcalTimeSlew, HcalTimeSlewRecord> delayToken_;
 
   const HcalTimeSlew* hcalTimeSlew_delay_;

--- a/CalibCalorimetry/HcalAlgos/plugins/HcalPulseContainmentTest.cc
+++ b/CalibCalorimetry/HcalAlgos/plugins/HcalPulseContainmentTest.cc
@@ -64,10 +64,13 @@ void HcalPulseContainmentTest::analyze(const edm::Event& iEvent, const edm::Even
   // HB and HE have the same shape here
   double corr4 = manager->correction(he1, 4, fixedphase_ns, fc);
   assert(corr4 == corr1);
-  std::cout << corr1 << " " << corr2 << " " << corr3 << " " << corr4 << " " << std::endl;
+  edm::LogPrint("HcalPulseContainmentTest") << corr1 << " " << corr2 << " " << corr3 << " " << corr4;
   // test 1TS correction at high energy
   double corr5 = manager->correction(hb1, 1, fixedphase_ns, 100000.);
-  std::cout << corr5 << std::endl;
+  edm::LogPrint("HcalPulseContainmentTest") << corr5;
+  // test 2TS correction at high energy
+  double corr6 = manager->correction(hb1, 2, fixedphase_ns, 100000.);
+  edm::LogPrint("HcalPulseContainmentTest") << corr6;
 }
 
 //define this as a plug-in

--- a/CalibCalorimetry/HcalAlgos/plugins/HcalPulseContainmentTest.cc
+++ b/CalibCalorimetry/HcalAlgos/plugins/HcalPulseContainmentTest.cc
@@ -48,7 +48,7 @@ void HcalPulseContainmentTest::analyze(const edm::Event& iEvent, const edm::Even
   float fixedphase_ns = 6.0;
   float max_fracerror = 0.02;
   std::unique_ptr<HcalPulseContainmentManager> manager;
-  manager = std::make_unique<HcalPulseContainmentManager>(max_fracerror);
+  manager = std::make_unique<HcalPulseContainmentManager>(max_fracerror, true);
   manager->setTimeSlew(hcalTimeSlew_delay_);
 
   HcalDetId hb1(HcalBarrel, 1, 1, 1);
@@ -65,6 +65,9 @@ void HcalPulseContainmentTest::analyze(const edm::Event& iEvent, const edm::Even
   double corr4 = manager->correction(he1, 4, fixedphase_ns, fc);
   assert(corr4 == corr1);
   std::cout << corr1 << " " << corr2 << " " << corr3 << " " << corr4 << " " << std::endl;
+  // test 1TS correction at high energy
+  double corr5 = manager->correction(hb1, 1, fixedphase_ns, 100000.);
+  std::cout << corr5 << std::endl;
 }
 
 //define this as a plug-in

--- a/CalibCalorimetry/HcalAlgos/src/HcalPulseContainmentAlgo.cc
+++ b/CalibCalorimetry/HcalAlgos/src/HcalPulseContainmentAlgo.cc
@@ -54,7 +54,7 @@ void HcalPulseContainmentAlgo::init(int num_samples) {
 #if 0
     char s[80];
     sprintf (s, "%7.3f %8.5f %8.5f\n", tmin, bin0val, bin1val);
-    std::cout << s << std::endl;
+    edm::LogPrint("HcalPulseContainmentAlgo") << s;
 #endif
 
     if (bin1val > bin0val) {
@@ -63,7 +63,7 @@ void HcalPulseContainmentAlgo::init(int num_samples) {
     }
   }
 #if 0
-  std::cout << "time0shiftns_ = " << time0shiftns_ << std::endl;
+  edm::LogPrint("HcalPulseContainmentAlgo") << "time0shiftns_ = " << time0shiftns_;
 #endif
 }
 
@@ -75,14 +75,14 @@ std::pair<double, double> HcalPulseContainmentAlgo::calcpair(double truefc) {
     tmin = fixedphasens_ - timeslew_ns;
   } else {  // Run 2: timePhase opposite to SIM, time0shift
     double shift_ns = fixedphasens_ - time0shiftns_ + timeslew_ns;
-    //std::cout << "SHIFT " << fixedphasens_ << " " << time0shiftns_ << " " << timeslew_ns << std::endl;
+    //edm::LogPrint("HcalPulseContainmentAlgo") << "SHIFT " << fixedphasens_ << " " << time0shiftns_ << " " << timeslew_ns;
     tmin = -shift_ns;
   }
   double tmax = tmin + integrationwindowns_;
 
   //double integral  = shape_.integrate( tmin, tmax );
   double integral = integrator_(tmin, tmax);
-  //std::cout << "INTEGRAL " << integral << " " << truefc << " " << tmin << " "  << tmax << std::endl;
+  //edm::LogPrint("HcalPulseContainmentAlgo") << "INTEGRAL " << integral << " " << truefc << " " << tmin << " "  << tmax;
   double corfactor = 1.0 / integral;
   double recofc = (double)truefc * integral;
 
@@ -90,7 +90,7 @@ std::pair<double, double> HcalPulseContainmentAlgo::calcpair(double truefc) {
   char s[80];
   sprintf (s, "%8.2f %8.4f %8.4f %8.5f %8.5f %8.5f ",
 	   truefc, tmin, tmax, integral, corfactor, recofc);
-  std::cout << s << std::endl;
+  edm::LogPrint("HcalPulseContainmentAlgo") << s;
 #endif
 
   std::pair<double, double> thepair(recofc, corfactor);

--- a/CalibCalorimetry/HcalAlgos/src/HcalPulseContainmentAlgo.cc
+++ b/CalibCalorimetry/HcalAlgos/src/HcalPulseContainmentAlgo.cc
@@ -25,7 +25,10 @@ HcalPulseContainmentAlgo::HcalPulseContainmentAlgo(const HcalPulseShape* shape,
                                                    double fixedphase_ns,
                                                    bool phaseAsInSim,
                                                    const HcalTimeSlew* hcalTimeSlew_delay)
-    : fixedphasens_(fixedphase_ns), phaseAsInSim_(phaseAsInSim), integrator_(shape), hcalTimeSlew_delay_(hcalTimeSlew_delay) {
+    : fixedphasens_(fixedphase_ns),
+      phaseAsInSim_(phaseAsInSim),
+      integrator_(shape),
+      hcalTimeSlew_delay_(hcalTimeSlew_delay) {
   init(num_samples);
 }
 
@@ -68,10 +71,9 @@ std::pair<double, double> HcalPulseContainmentAlgo::calcpair(double truefc) {
   double timeslew_ns = hcalTimeSlew_delay_->delay(std::max(0.0, (double)truefc), HcalTimeSlew::Medium);
 
   double tmin = 0;
-  if (phaseAsInSim_) { // timePhase as in hcalSimParameters, no time0shift
+  if (phaseAsInSim_) {  // timePhase as in hcalSimParameters, no time0shift
     tmin = fixedphasens_ - timeslew_ns;
-  }
-  else { // Run 2: timePhase opposite to SIM, time0shift
+  } else {  // Run 2: timePhase opposite to SIM, time0shift
     double shift_ns = fixedphasens_ - time0shiftns_ + timeslew_ns;
     //std::cout << "SHIFT " << fixedphasens_ << " " << time0shiftns_ << " " << timeslew_ns << std::endl;
     tmin = -shift_ns;

--- a/CalibCalorimetry/HcalAlgos/src/HcalPulseContainmentAlgo.cc
+++ b/CalibCalorimetry/HcalAlgos/src/HcalPulseContainmentAlgo.cc
@@ -11,8 +11,10 @@
 //
 HcalPulseContainmentAlgo::HcalPulseContainmentAlgo(int num_samples,
                                                    double fixedphase_ns,
+                                                   bool phaseAsInSim,
                                                    const HcalTimeSlew* hcalTimeSlew_delay)
     : fixedphasens_(fixedphase_ns),
+      phaseAsInSim_(phaseAsInSim),
       integrator_(&(HcalPulseShapes().hbShape())),
       hcalTimeSlew_delay_(hcalTimeSlew_delay) {
   init(num_samples);
@@ -21,8 +23,9 @@ HcalPulseContainmentAlgo::HcalPulseContainmentAlgo(int num_samples,
 HcalPulseContainmentAlgo::HcalPulseContainmentAlgo(const HcalPulseShape* shape,
                                                    int num_samples,
                                                    double fixedphase_ns,
+                                                   bool phaseAsInSim,
                                                    const HcalTimeSlew* hcalTimeSlew_delay)
-    : fixedphasens_(fixedphase_ns), integrator_(shape), hcalTimeSlew_delay_(hcalTimeSlew_delay) {
+    : fixedphasens_(fixedphase_ns), phaseAsInSim_(phaseAsInSim), integrator_(shape), hcalTimeSlew_delay_(hcalTimeSlew_delay) {
   init(num_samples);
 }
 
@@ -48,7 +51,7 @@ void HcalPulseContainmentAlgo::init(int num_samples) {
 #if 0
     char s[80];
     sprintf (s, "%7.3f %8.5f %8.5f\n", tmin, bin0val, bin1val);
-    cout << s;
+    std::cout << s << std::endl;
 #endif
 
     if (bin1val > bin0val) {
@@ -56,18 +59,23 @@ void HcalPulseContainmentAlgo::init(int num_samples) {
       break;
     }
   }
-
 #if 0
-  cout << "time0shiftns_ = " << time0shiftns_ << endl;
+  std::cout << "time0shiftns_ = " << time0shiftns_ << std::endl;
 #endif
 }
 
 std::pair<double, double> HcalPulseContainmentAlgo::calcpair(double truefc) {
   double timeslew_ns = hcalTimeSlew_delay_->delay(std::max(0.0, (double)truefc), HcalTimeSlew::Medium);
 
-  double shift_ns = fixedphasens_ - time0shiftns_ + timeslew_ns;
-  //std::cout << "SHIFT " << fixedphasens_ << " " << time0shiftns_ << " " << timeslew_ns << std::endl;
-  double tmin = -shift_ns;
+  double tmin = 0;
+  if (phaseAsInSim_) { // timePhase as in hcalSimParameters, no time0shift
+    tmin = fixedphasens_ - timeslew_ns;
+  }
+  else { // Run 2: timePhase opposite to SIM, time0shift
+    double shift_ns = fixedphasens_ - time0shiftns_ + timeslew_ns;
+    //std::cout << "SHIFT " << fixedphasens_ << " " << time0shiftns_ << " " << timeslew_ns << std::endl;
+    tmin = -shift_ns;
+  }
   double tmax = tmin + integrationwindowns_;
 
   //double integral  = shape_.integrate( tmin, tmax );
@@ -80,7 +88,7 @@ std::pair<double, double> HcalPulseContainmentAlgo::calcpair(double truefc) {
   char s[80];
   sprintf (s, "%8.2f %8.4f %8.4f %8.5f %8.5f %8.5f ",
 	   truefc, tmin, tmax, integral, corfactor, recofc);
-  cout << s;
+  std::cout << s << std::endl;
 #endif
 
   std::pair<double, double> thepair(recofc, corfactor);

--- a/CalibCalorimetry/HcalAlgos/src/HcalPulseContainmentAlgo.h
+++ b/CalibCalorimetry/HcalAlgos/src/HcalPulseContainmentAlgo.h
@@ -11,8 +11,9 @@ public:
   HcalPulseContainmentAlgo(const HcalPulseShape* shape,
                            int num_samples,
                            double fixedphase_ns,
+                           bool phaseAsInSim,
                            const HcalTimeSlew* hcalTimeSlew_delay);
-  HcalPulseContainmentAlgo(int num_samples, double fixedphase_ns, const HcalTimeSlew* hcalTimeSlew_delay);
+  HcalPulseContainmentAlgo(int num_samples, double fixedphase_ns, bool phaseAsInSim, const HcalTimeSlew* hcalTimeSlew_delay);
   std::pair<double, double> calcpair(double);
 
 private:
@@ -20,6 +21,7 @@ private:
   double fixedphasens_;
   double integrationwindowns_;
   double time0shiftns_;
+  bool phaseAsInSim_;
   HcalShapeIntegrator integrator_;
   const HcalTimeSlew* hcalTimeSlew_delay_;
 };

--- a/CalibCalorimetry/HcalAlgos/src/HcalPulseContainmentAlgo.h
+++ b/CalibCalorimetry/HcalAlgos/src/HcalPulseContainmentAlgo.h
@@ -13,7 +13,10 @@ public:
                            double fixedphase_ns,
                            bool phaseAsInSim,
                            const HcalTimeSlew* hcalTimeSlew_delay);
-  HcalPulseContainmentAlgo(int num_samples, double fixedphase_ns, bool phaseAsInSim, const HcalTimeSlew* hcalTimeSlew_delay);
+  HcalPulseContainmentAlgo(int num_samples,
+                           double fixedphase_ns,
+                           bool phaseAsInSim,
+                           const HcalTimeSlew* hcalTimeSlew_delay);
   std::pair<double, double> calcpair(double);
 
 private:

--- a/CalibCalorimetry/HcalAlgos/src/HcalPulseContainmentCorrection.cc
+++ b/CalibCalorimetry/HcalAlgos/src/HcalPulseContainmentCorrection.cc
@@ -16,9 +16,10 @@
 //
 HcalPulseContainmentCorrection::HcalPulseContainmentCorrection(int num_samples,
                                                                float fixedphase_ns,
+                                                               bool phaseAsInSim,
                                                                float max_fracerror,
                                                                const HcalTimeSlew* hcalTimeSlew_delay) {
-  HcalPulseContainmentAlgo corFalgo(num_samples, (double)fixedphase_ns, hcalTimeSlew_delay);
+  HcalPulseContainmentAlgo corFalgo(num_samples, (double)fixedphase_ns, phaseAsInSim, hcalTimeSlew_delay);
 
   // Generate lookup map for the correction function, never exceeding
   // a maximum fractional error for lookups.
@@ -37,9 +38,10 @@ HcalPulseContainmentCorrection::HcalPulseContainmentCorrection(int num_samples,
 HcalPulseContainmentCorrection::HcalPulseContainmentCorrection(const HcalPulseShape* shape,
                                                                int num_samples,
                                                                float fixedphase_ns,
+                                                               bool phaseAsInSim,
                                                                float max_fracerror,
                                                                const HcalTimeSlew* hcalTimeSlew_delay) {
-  HcalPulseContainmentAlgo corFalgo(shape, num_samples, (double)fixedphase_ns, hcalTimeSlew_delay);
+  HcalPulseContainmentAlgo corFalgo(shape, num_samples, (double)fixedphase_ns, phaseAsInSim, hcalTimeSlew_delay);
   genlkupmap<HcalPulseContainmentAlgo>(1.0,
                                        200000.0f,      // generation domain
                                        max_fracerror,  // maximum fractional error

--- a/CalibCalorimetry/HcalAlgos/src/HcalPulseContainmentManager.cc
+++ b/CalibCalorimetry/HcalAlgos/src/HcalPulseContainmentManager.cc
@@ -3,15 +3,16 @@
 #include "FWCore/Framework/interface/EventSetup.h"
 #include <iostream>
 
-HcalPulseContainmentManager::HcalPulseContainmentManager(float max_fracerror)
-    : entries_(), shapes_(), max_fracerror_(max_fracerror) {
+HcalPulseContainmentManager::HcalPulseContainmentManager(float max_fracerror, bool phaseAsInSim)
+    : entries_(), shapes_(), max_fracerror_(max_fracerror), phaseAsInSim_(phaseAsInSim) {
   hcalTimeSlew_delay_ = nullptr;
 }
 
-HcalPulseContainmentManager::HcalPulseContainmentManager(float max_fracerror, edm::ConsumesCollector iC)
+HcalPulseContainmentManager::HcalPulseContainmentManager(float max_fracerror, bool phaseAsInSim, edm::ConsumesCollector iC)
     : entries_(),
       shapes_(iC),
       max_fracerror_(max_fracerror),
+      phaseAsInSim_(phaseAsInSim),
       delayToken_(iC.esConsumes<edm::Transition::BeginRun>(edm::ESInputTag("", "HBHE"))) {}
 
 void HcalPulseContainmentManager::beginRun(edm::EventSetup const& es) {
@@ -75,7 +76,7 @@ const HcalPulseContainmentCorrection* HcalPulseContainmentManager::get(const Hca
       toAdd,
       fixedphase_ns,
       shape,
-      HcalPulseContainmentCorrection(shape, toAdd, fixedphase_ns, max_fracerror_, hcalTimeSlew_delay_));
+      HcalPulseContainmentCorrection(shape, toAdd, fixedphase_ns, phaseAsInSim_, max_fracerror_, hcalTimeSlew_delay_));
   entries_.push_back(entry);
   return &(entries_.back().correction_);
 }

--- a/CalibCalorimetry/HcalAlgos/src/HcalPulseContainmentManager.cc
+++ b/CalibCalorimetry/HcalAlgos/src/HcalPulseContainmentManager.cc
@@ -8,7 +8,9 @@ HcalPulseContainmentManager::HcalPulseContainmentManager(float max_fracerror, bo
   hcalTimeSlew_delay_ = nullptr;
 }
 
-HcalPulseContainmentManager::HcalPulseContainmentManager(float max_fracerror, bool phaseAsInSim, edm::ConsumesCollector iC)
+HcalPulseContainmentManager::HcalPulseContainmentManager(float max_fracerror,
+                                                         bool phaseAsInSim,
+                                                         edm::ConsumesCollector iC)
     : entries_(),
       shapes_(iC),
       max_fracerror_(max_fracerror),

--- a/CalibCalorimetry/HcalTPGAlgos/src/HcaluLUTTPGCoder.cc
+++ b/CalibCalorimetry/HcalTPGAlgos/src/HcaluLUTTPGCoder.cc
@@ -81,7 +81,7 @@ void HcaluLUTTPGCoder::init(const HcalTopology* top, const HcalTimeSlew* delay) 
   linearLSB_QIE8_ = 1.;
   linearLSB_QIE11_ = 1.;
   linearLSB_QIE11Overlap_ = 1.;
-  pulseCorr_ = std::make_unique<HcalPulseContainmentManager>(MaximumFractionalError);
+  pulseCorr_ = std::make_unique<HcalPulseContainmentManager>(MaximumFractionalError, false);
   firstHBEta_ = topo_->firstHBRing();
   lastHBEta_ = topo_->lastHBRing();
   nHBEta_ = (lastHBEta_ - firstHBEta_ + 1);

--- a/RecoLocalCalo/HcalRecAlgos/src/HcalSimpleRecAlgo.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/HcalSimpleRecAlgo.cc
@@ -29,7 +29,7 @@ HcalSimpleRecAlgo::HcalSimpleRecAlgo(bool correctForTimeslew,
       setLeakCorrection_(false),
       puCorrMethod_(0) {
   hcalTimeSlew_delay_ = nullptr;
-  pulseCorr_ = std::make_unique<HcalPulseContainmentManager>(MaximumFractionalError, iC);
+  pulseCorr_ = std::make_unique<HcalPulseContainmentManager>(MaximumFractionalError, false, iC);
 }
 
 void HcalSimpleRecAlgo::beginRun(edm::EventSetup const& es) {

--- a/RecoLocalCalo/HcalRecAlgos/src/SimpleHBHEPhase1Algo.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/SimpleHBHEPhase1Algo.cc
@@ -30,7 +30,7 @@ SimpleHBHEPhase1Algo::SimpleHBHEPhase1Algo(const int firstSampleShift,
                                            std::unique_ptr<MahiFit> mahi,
                                            edm::ConsumesCollector iC)
     : delayToken_(iC.esConsumes<edm::Transition::BeginRun>(edm::ESInputTag("", "HBHE"))),
-      pulseCorr_(PulseContainmentFractionalError, iC),
+      pulseCorr_(PulseContainmentFractionalError, false, iC),
       firstSampleShift_(firstSampleShift),
       samplesToAdd_(samplesToAdd),
       phaseNS_(phaseNS),

--- a/RecoLocalCalo/HcalRecAlgos/src/ZdcSimpleRecAlgo.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/ZdcSimpleRecAlgo.cc
@@ -21,7 +21,7 @@ ZdcSimpleRecAlgo::ZdcSimpleRecAlgo(int recoMethod) : recoMethod_(recoMethod), co
 void ZdcSimpleRecAlgo::initPulseCorr(int toadd, const HcalTimeSlew* hcalTimeSlew_delay) {
   if (correctForPulse_) {
     pulseCorr_ =
-        std::make_unique<HcalPulseContainmentCorrection>(toadd, phaseNS_, MaximumFractionalError, hcalTimeSlew_delay);
+        std::make_unique<HcalPulseContainmentCorrection>(toadd, phaseNS_, false, MaximumFractionalError, hcalTimeSlew_delay);
   }
 }
 //static float timeshift_ns_zdc(float wpksamp);

--- a/RecoLocalCalo/HcalRecAlgos/src/ZdcSimpleRecAlgo.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/ZdcSimpleRecAlgo.cc
@@ -20,8 +20,8 @@ ZdcSimpleRecAlgo::ZdcSimpleRecAlgo(int recoMethod) : recoMethod_(recoMethod), co
 
 void ZdcSimpleRecAlgo::initPulseCorr(int toadd, const HcalTimeSlew* hcalTimeSlew_delay) {
   if (correctForPulse_) {
-    pulseCorr_ =
-        std::make_unique<HcalPulseContainmentCorrection>(toadd, phaseNS_, false, MaximumFractionalError, hcalTimeSlew_delay);
+    pulseCorr_ = std::make_unique<HcalPulseContainmentCorrection>(
+        toadd, phaseNS_, false, MaximumFractionalError, hcalTimeSlew_delay);
   }
 }
 //static float timeshift_ns_zdc(float wpksamp);


### PR DESCRIPTION
#### PR description:

We found that the containment correction is too large when used to correct the charge from a single time slice with default parameters. It turns out that the old algorithm has some additional shift (time0shift) and reversed behaviour of the timePhase parameter wrt simulation.
This PR allows for timePhase definition in HcalPulseContainment similar to SIM step, i.e., shift goes in the same direction so that parameters can be synchronized.

* So far, the change is only activated in the HcalPulseContainmentTest
  * NB: this falls back to the default pulse shape right now, as it cannot connect to the HcalDbService. Needs to be migrated to esConsumes? Tests were done with hard-coded reco shape 208, however
* It will be applied to PF1' scheme within HcaluLUTTPGCoder in a later PR
* Application in M0 and ZDC reco to be discussed

#### PR validation:

Containment correction for a single TS is now calculated within 6 - 31 ns of the pulse shape, similar to first TS in simulation.
The correction is the correct 1.56 instead of 2.18 for large pulses (see https://its.cern.ch/jira/browse/HCALDPG-18).

