### PR TITLE
GenParticles2HepMCConverter esConsumes

### DIFF
--- a/GeneratorInterface/RivetInterface/plugins/GenParticles2HepMCConverter.cc
+++ b/GeneratorInterface/RivetInterface/plugins/GenParticles2HepMCConverter.cc
@@ -36,7 +36,7 @@ private:
   edm::EDGetTokenT<reco::CandidateView> genParticlesToken_;
   edm::EDGetTokenT<GenEventInfoProduct> genEventInfoToken_;
   edm::EDGetTokenT<GenRunInfoProduct> genRunInfoToken_;
-  edm::ESHandle<ParticleDataTable> pTable_;
+  edm::ESGetToken<HepPDT::ParticleDataTable, PDTRecord> pTable_;
 
   std::vector<int> signalParticlePdgIds_;
   const double cmEnergy_;
@@ -59,6 +59,7 @@ GenParticles2HepMCConverter::GenParticles2HepMCConverter(const edm::ParameterSet
   genParticlesToken_ = consumes<reco::CandidateView>(pset.getParameter<edm::InputTag>("genParticles"));
   genEventInfoToken_ = consumes<GenEventInfoProduct>(pset.getParameter<edm::InputTag>("genEventInfo"));
   genRunInfoToken_ = consumes<GenRunInfoProduct, edm::InRun>(pset.getParameter<edm::InputTag>("genEventInfo"));
+  pTable_ = esConsumes<HepPDT::ParticleDataTable, PDTRecord>();
   signalParticlePdgIds_ = pset.getParameter<std::vector<int>>("signalParticlePdgIds");
 
   produces<edm::HepMCProduct>("unsmeared");
@@ -78,7 +79,7 @@ void GenParticles2HepMCConverter::produce(edm::Event& event, const edm::EventSet
   edm::Handle<GenEventInfoProduct> genEventInfoHandle;
   event.getByToken(genEventInfoToken_, genEventInfoHandle);
 
-  eventSetup.getData(pTable_);
+  auto const& pTableData = eventSetup.getData(pTable_);
 
   HepMC::GenEvent* hepmc_event = new HepMC::GenEvent();
   hepmc_event->set_event_number(event.id().event());
@@ -114,8 +115,8 @@ void GenParticles2HepMCConverter::produce(edm::Event& event, const edm::EventSet
 
     // Assign particle's generated mass from the standard particle data table
     double particleMass;
-    if (pTable_->particle(p->pdgId()))
-      particleMass = pTable_->particle(p->pdgId())->mass();
+    if (pTableData.particle(p->pdgId()))
+      particleMass = pTableData.particle(p->pdgId())->mass();
     else
       particleMass = p->mass();
 

--- a/GeneratorInterface/RivetInterface/test/runRivetAnalyzerMiniAOD_cfg.py
+++ b/GeneratorInterface/RivetInterface/test/runRivetAnalyzerMiniAOD_cfg.py
@@ -16,10 +16,7 @@ process.maxEvents = cms.untracked.PSet(
 # Input source
 process.source = cms.Source("PoolSource",
     fileNames = cms.untracked.vstring(
-        #'/store/relval/CMSSW_10_6_0/RelValTTbar_13/MINIAODSIM/PUpmx25ns_106X_upgrade2018_realistic_v4-v1/10000/DB4F12C2-3B53-4247-A1C3-BEB74F177362.root',
-        #'/store/mc/RunIIAutumn18MiniAOD/TTJets_SingleLeptFromTbar_TuneCP5_13TeV-madgraphMLM-pythia8/MINIAODSIM/102X_upgrade2018_realistic_v15-v1/00000/0126270E-DB20-FB42-A2B6-CE59183BEB12.root',
-        '/store/mc/RunIIAutumn18MiniAOD/TT_noSC_TuneCP5_13TeV-powheg-pythia8/MINIAODSIM/102X_upgrade2018_realistic_v15-v1/60000/26D8AE17-B828-C948-A961-A785C6CB71CE.root',
-        #'/store/mc/RunIIAutumn18MiniAOD/W2JetsToLNu_TuneCP5_13TeV-madgraphMLM-pythia8/MINIAODSIM/102X_upgrade2018_realistic_v15-v1/120000/1A3A8B55-3655-114D-B933-DA41260548F4.root',
+        '/store/mc/RunIIAutumn18MiniAOD/TTJets_SingleLeptFromTbar_TuneCP5_13TeV-madgraphMLM-pythia8/MINIAODSIM/102X_upgrade2018_realistic_v15-v1/00000/0126270E-DB20-FB42-A2B6-CE59183BEB12.root',
     ),
 )
 
@@ -28,7 +25,7 @@ process.options = cms.untracked.PSet()
 process.genParticles2HepMC.genParticles = cms.InputTag("mergedGenParticles")
 process.rivetAnalyzer.HepMCCollection = cms.InputTag("genParticles2HepMC:unsmeared")
 
-process.rivetAnalyzer.AnalysisNames = cms.vstring('CMS_2013_I1224539_DIJET', 'MC_TTBAR', 'CMS_2018_I1662081')
+process.rivetAnalyzer.AnalysisNames = cms.vstring('MC_TTBAR', 'CMS_2018_I1662081')
 process.rivetAnalyzer.OutputFile = cms.string('mcfile.yoda')
 process.rivetAnalyzer.useLHEweights = True
 


### PR DESCRIPTION
#### PR description:

esConsumes migration for GenParticles2HepMCConverter, as asked for in https://github.com/cms-sw/cmssw/issues/31061

#### PR validation:

`GeneratorInterface/RivetInterface/test/runRivetAnalyzerMiniAOD_cfg.py` runs and produces normal output file.

