### PR TITLE
[Backport] Track-gen matching passing through TrackingParticle (11_2_X)

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_standard.py
+++ b/Configuration/PyReleaseValidation/python/relval_standard.py
@@ -35,7 +35,7 @@ workflows.addOverride(1303.17,overridesEv5)
 workflows[1302.18] = ['', ['ProdTTbar_13UP18','DIGIUP18PROD1','RECOPRODUP18','MINIAODMCUP18','NANOPRODUP18']]
 #workflows[1303.18] = ['', ['ProdQCD_Pt_3000_3500_13UP18','DIGIUP18PROD1','RECOPRODUP18']]
 workflows[1304.18] = ['', ['ProdZEE_13UP18','DIGIUP18PROD1','RECOPRODUP18','MINIAODMCUP18','NANOPRODUP18']]
-workflows[1304.182] = ['', ['ProdZEE_13UP18','DIGIUP18PROD1','RECOPRODUP18bParking','MINIAODMCUP18bParking']]
+workflows[1304.182] = ['', ['ProdZEE_13UP18','DIGIUP18PROD1bParking','RECOPRODUP18bParking','MINIAODMCUP18bParking']]
 #workflows.addOverride(1303.17,overridesEv5)
 
 #####Prod2018 with concurrentlumi

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -1671,6 +1671,7 @@ steps['DIGIUP18ml']=merge([concurrentLumis,step2Upg2018Defaults])
 steps['DIGIUP17PROD1']=merge([{'-s':'DIGI,L1,DIGI2RAW,HLT:@relval2017','--eventcontent':'RAWSIM','--datatier':'GEN-SIM-RAW'},step2Upg2017Defaults])
 steps['DIGIUP18PROD1']=merge([{'-s':'DIGI,L1,DIGI2RAW,HLT:@relval2018','--eventcontent':'RAWSIM','--datatier':'GEN-SIM-RAW'},step2Upg2018Defaults])
 steps['DIGIUP18PROD1ml']=merge([concurrentLumis,steps['DIGIUP18PROD1']])
+steps['DIGIUP18PROD1bParking']=merge([{'-s':'DIGI,L1,DIGI2RAW,HLT:@relval2018','--eventcontent':'RAWSIM','--datatier':'GEN-SIM-RAW','--era' :'Run2_2018,bParking'},step2Upg2018Defaults])
 steps['DIGIUP17_PU25']=merge([PU25UP17,step2Upg2017Defaults])
 steps['DIGIUP18_PU25']=merge([PU25UP18,step2Upg2018Defaults])
 

--- a/Configuration/StandardSequences/python/Digi_cff.py
+++ b/Configuration/StandardSequences/python/Digi_cff.py
@@ -29,6 +29,8 @@ from SimPPS.Configuration.SimPPS_cff import *
 #
 from SimGeneral.Configuration.SimGeneral_cff import *
 
+from SimTracker.Configuration.SimTrackerLinks_cff import *
+
 # add updating the GEN information by default
 from Configuration.StandardSequences.Generator_cff import *
 from GeneratorInterface.Core.generatorSmeared_cfi import *
@@ -42,7 +44,7 @@ pdigiTask_nogen = cms.Task(generatorSmeared, cms.TaskPlaceholder("randomEngineSt
 # premixing stage2 runs addPileupInfo after PreMixingModule (configured in DataMixerPreMix_cff)
 premix_stage2.toReplaceWith(pdigiTask_nogen, pdigiTask_nogen.copyAndExclude([addPileupInfo]))
 
-pdigiTask = cms.Task(pdigiTask_nogen, fixGenInfoTask)
+pdigiTask = cms.Task(pdigiTask_nogen, fixGenInfoTask, tpPruningTask)
 
 doAllDigi = cms.Sequence(doAllDigiTask)
 pdigi = cms.Sequence(pdigiTask)

--- a/Configuration/StandardSequences/python/RecoSim_cff.py
+++ b/Configuration/StandardSequences/python/RecoSim_cff.py
@@ -1,5 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
 from SimMuon.MCTruth.muonSimClassificationByHits_cff import *
+from SimTracker.TrackAssociation.trackPrunedMCMatchTask_cff import *
 
-recosim = cms.Task( muonSimClassificationByHitsTask )
+recosim = cms.Task( muonSimClassificationByHitsTask, trackPrunedMCMatchTask )

--- a/PhysicsTools/PatAlgos/python/slimming/MicroEventContent_cff.py
+++ b/PhysicsTools/PatAlgos/python/slimming/MicroEventContent_cff.py
@@ -95,6 +95,8 @@ MicroEventContentGEN = cms.PSet(
     outputCommands = cms.untracked.vstring(
         'keep patPackedGenParticles_packedGenParticles_*_*',
         'keep recoGenParticles_prunedGenParticles_*_*',
+        'keep *_packedPFCandidateToGenAssociation_*_*',
+        'keep *_lostTracksToGenAssociation_*_*',
         'keep LHEEventProduct_*_*_*',
         'keep GenFilterInfo_*_*_*',
         'keep GenLumiInfoHeader_generator_*_*',

--- a/PhysicsTools/PatAlgos/python/slimming/genParticleAssociation_cff.py
+++ b/PhysicsTools/PatAlgos/python/slimming/genParticleAssociation_cff.py
@@ -1,0 +1,12 @@
+import FWCore.ParameterSet.Config as cms
+
+packedPFCandidateToGenAssociation = cms.EDProducer("PackedCandidateGenAssociationProducer",
+    trackToGenAssoc = cms.InputTag("prunedTrackMCMatch"),
+)
+
+lostTracksToGenAssociation = cms.EDProducer("PackedCandidateGenAssociationProducer",
+    trackToGenAssoc = cms.InputTag("prunedTrackMCMatch"),
+    trackToPackedCandidatesAssoc = cms.InputTag("lostTracks")
+)
+
+packedCandidateToGenAssociationTask = cms.Task(packedPFCandidateToGenAssociation,lostTracksToGenAssociation)

--- a/PhysicsTools/PatAlgos/python/slimming/slimming_cff.py
+++ b/PhysicsTools/PatAlgos/python/slimming/slimming_cff.py
@@ -7,6 +7,7 @@ from PhysicsTools.PatAlgos.slimming.offlineSlimmedPrimaryVertices_cfi import *
 from PhysicsTools.PatAlgos.slimming.offlineSlimmedPrimaryVertices4D_cfi import *
 from PhysicsTools.PatAlgos.slimming.primaryVertexAssociation_cfi import *
 from PhysicsTools.PatAlgos.slimming.genParticles_cff import *
+from PhysicsTools.PatAlgos.slimming.genParticleAssociation_cff import *
 from PhysicsTools.PatAlgos.slimming.selectedPatTrigger_cfi import *
 from PhysicsTools.PatAlgos.slimming.slimmedPatTrigger_cfi import *
 from PhysicsTools.PatAlgos.slimming.slimmedJets_cfi      import *
@@ -37,6 +38,7 @@ slimmingTask = cms.Task(
     offlineSlimmedPrimaryVertices,
     primaryVertexAssociation,
     genParticlesTask,
+    packedCandidateToGenAssociationTask,
     selectedPatTrigger,
     slimmedPatTrigger,
     slimmedCaloJets,

--- a/PhysicsTools/PatAlgos/python/slimming/slimming_cff.py
+++ b/PhysicsTools/PatAlgos/python/slimming/slimming_cff.py
@@ -38,7 +38,6 @@ slimmingTask = cms.Task(
     offlineSlimmedPrimaryVertices,
     primaryVertexAssociation,
     genParticlesTask,
-    packedCandidateToGenAssociationTask,
     selectedPatTrigger,
     slimmedPatTrigger,
     slimmedCaloJets,
@@ -88,6 +87,10 @@ from RecoHI.HiTracking.miniAODVertexRecovery_cff import offlinePrimaryVerticesRe
 pp_on_AA.toReplaceWith(
     slimmingTask,
     cms.Task(slimmingTask.copy(), offlinePrimaryVerticesRecovery, offlineSlimmedPrimaryVerticesRecovery))
+
+from Configuration.Eras.Modifier_bParking_cff import bParking
+_bParking_slimmingTask = cms.Task(slimmingTask.copy(),packedCandidateToGenAssociationTask)
+bParking.toReplaceWith(slimmingTask,_bParking_slimmingTask)
 
 from Configuration.Eras.Modifier_phase2_timing_cff import phase2_timing
 _phase2_timing_slimmingTask = cms.Task(slimmingTask.copy(),

--- a/PhysicsTools/PatAlgos/python/tools/coreTools.py
+++ b/PhysicsTools/PatAlgos/python/tools/coreTools.py
@@ -193,6 +193,8 @@ class RemoveMCMatching(ConfigToolBase):
             'prunedGenParticles',
             'prunedGenParticlesWithStatusOne',
             'packedGenParticles',
+            'packedPFCandidateToGenAssociation',
+            'lostTracksToGenAssociation',
         ]
         for attr in attrsToDelete:
             if hasattr(process,attr): delattr(process,attr)

--- a/SimTracker/Configuration/python/SimTrackerLinks_cff.py
+++ b/SimTracker/Configuration/python/SimTrackerLinks_cff.py
@@ -4,8 +4,11 @@ from SimTracker.TrackAssociation.trackingParticlePrunerByGen_cfi import *
 from SimTracker.TrackAssociation.digiSimLinkPruner_cfi import *
 
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
+from Configuration.Eras.Modifier_bParking_cff import bParking
 
+tpPruningTask = cms.Task()
 
-tpPruningTask = cms.Task(prunedTrackingParticles,prunedDigiSimLinks)
+_bParking_tpPruningTask = cms.Task(prunedTrackingParticles,prunedDigiSimLinks)
+bParking.toReplaceWith(tpPruningTask,_bParking_tpPruningTask)
 
-fastSim.toModify(tpPruningTask, lambda x: x.remove(prunedDigiSimLinks))
+(fastSim & bParking).toModify(tpPruningTask, lambda x: x.remove(prunedDigiSimLinks))

--- a/SimTracker/Configuration/python/SimTrackerLinks_cff.py
+++ b/SimTracker/Configuration/python/SimTrackerLinks_cff.py
@@ -3,5 +3,9 @@ import FWCore.ParameterSet.Config as cms
 from SimTracker.TrackAssociation.trackingParticlePrunerByGen_cfi import *
 from SimTracker.TrackAssociation.digiSimLinkPruner_cfi import *
 
+from Configuration.Eras.Modifier_fastSim_cff import fastSim
+
 
 tpPruningTask = cms.Task(prunedTrackingParticles,prunedDigiSimLinks)
+
+fastSim.toModify(tpPruningTask, lambda x: x.remove(prunedDigiSimLinks))

--- a/SimTracker/Configuration/python/SimTrackerLinks_cff.py
+++ b/SimTracker/Configuration/python/SimTrackerLinks_cff.py
@@ -1,0 +1,7 @@
+import FWCore.ParameterSet.Config as cms
+
+from SimTracker.TrackAssociation.trackingParticlePrunerByGen_cfi import *
+from SimTracker.TrackAssociation.digiSimLinkPruner_cfi import *
+
+
+tpPruningTask = cms.Task(prunedTrackingParticles,prunedDigiSimLinks)

--- a/SimTracker/Configuration/python/SimTracker_EventContent_cff.py
+++ b/SimTracker/Configuration/python/SimTracker_EventContent_cff.py
@@ -37,15 +37,22 @@ SimTrackerDEBUG = cms.PSet(
 )
 #RAW content 
 SimTrackerRAW = cms.PSet(
-    outputCommands = cms.untracked.vstring('keep *_allTrackMCMatch_*_*')
+    outputCommands = cms.untracked.vstring(
+        'keep *_allTrackMCMatch_*_*',
+        'keep *_prunedTrackingParticles_*_*',
+        'keep *_prunedDigiSimLinks_*_*')
 )
 #RECO content
 SimTrackerRECO = cms.PSet(
-    outputCommands = cms.untracked.vstring('keep *_allTrackMCMatch_*_*')
+    outputCommands = cms.untracked.vstring(
+        'keep *_allTrackMCMatch_*_*',
+        'keep *_prunedTrackMCMatch_*_*')
 )
 #AOD content
 SimTrackerAOD = cms.PSet(
-    outputCommands = cms.untracked.vstring('keep *_allTrackMCMatch_*_*')
+    outputCommands = cms.untracked.vstring(
+        'keep *_allTrackMCMatch_*_*',
+        'keep *_prunedTrackMCMatch_*_*')
 )
 
 # Event content for premixing library

--- a/SimTracker/TrackAssociation/plugins/BuildFile.xml
+++ b/SimTracker/TrackAssociation/plugins/BuildFile.xml
@@ -6,6 +6,7 @@
 <use name="SimDataFormats/TrackerDigiSimLink"/>
 <use name="SimDataFormats/TrackingAnalysis"/>
 <use name="TrackingTools/TransientTrack"/>
+<use name="PhysicsTools/HepMCCandAlgos"/>
 <library name="SimTrackerTrackAssociation_plugins" file="*.cc">
   <flags EDM_PLUGIN="1"/>
 </library>

--- a/SimTracker/TrackAssociation/plugins/DigiSimLinkPruner.cc
+++ b/SimTracker/TrackAssociation/plugins/DigiSimLinkPruner.cc
@@ -33,23 +33,21 @@
 #include "DataFormats/Common/interface/DetSetVector.h"
 #include "SimDataFormats/TrackerDigiSimLink/interface/PixelDigiSimLink.h"
 #include "SimDataFormats/TrackerDigiSimLink/interface/StripDigiSimLink.h"
-#include "SimDataFormats/Track/interface/UniqueSimTrackId.h"
 
 #include <unordered_set>
 
 namespace {
 
   template <typename T>
-  std::vector<edm::DetSet<T>> pruneByTpAssoc(
-      const edm::DetSetVector<T>& simLinkColl,
-      const std::unordered_set<UniqueSimTrackId, UniqueSimTrackIdHash>& selectedIds) {
+  std::vector<edm::DetSet<T>> pruneByTpAssoc(const edm::DetSetVector<T>& simLinkColl,
+                                             const std::set<std::pair<uint32_t, EncodedEventId>>& selectedIds) {
     std::vector<edm::DetSet<T>> linkVector;
 
     for (auto&& detSet : simLinkColl) {
       edm::DetSet<T> newDetSet(detSet.detId());
 
       for (auto&& simLink : detSet) {
-        UniqueSimTrackId trkid(simLink.SimTrackId(), simLink.eventId());
+        std::pair<uint32_t, EncodedEventId> trkid(simLink.SimTrackId(), simLink.eventId());
         if (selectedIds.count(trkid) > 0) {
           newDetSet.push_back(simLink);
         }
@@ -109,7 +107,7 @@ void DigiSimLinkPruner::produce(edm::StreamID, edm::Event& iEvent, const edm::Ev
 
   auto const& tpColl = iEvent.get(trackingParticleToken_);
 
-  std::unordered_set<UniqueSimTrackId, UniqueSimTrackIdHash> selectedIds;
+  std::set<std::pair<uint32_t, EncodedEventId>> selectedIds;
   for (TrackingParticleCollection::size_type itp = 0; itp < tpColl.size(); ++itp) {
     auto const& trackingParticle = tpColl[itp];
 

--- a/SimTracker/TrackAssociation/plugins/DigiSimLinkPruner.cc
+++ b/SimTracker/TrackAssociation/plugins/DigiSimLinkPruner.cc
@@ -5,7 +5,7 @@
 //
 /**\class DigiSimLinkPruner DigiSimLinkPruner.cc SimTracker/TrackAssociation/plugins/DigiSimLinkPruner.cc
 
- Description: [one line class summary]
+ Description: Produce a pruned version of the DigiSimLinks collection based on the association to a collection of TrackingParticles
 
  Implementation:
      [Notes on implementation]
@@ -156,7 +156,7 @@ void DigiSimLinkPruner::fillDescriptions(edm::ConfigurationDescriptions& descrip
   desc.addOptional<edm::InputTag>("stripSimLinkSrc");
   desc.addOptional<edm::InputTag>("phase2OTSimLinkSrc");
 
-  descriptions.add("pruneSimLinkDefault", desc);
+  descriptions.add("digiSimLinkPrunerDefault", desc);
 }
 
 //define this as a plug-in

--- a/SimTracker/TrackAssociation/plugins/MCTrackMatcher.cc
+++ b/SimTracker/TrackAssociation/plugins/MCTrackMatcher.cc
@@ -63,12 +63,12 @@ void MCTrackMatcher::produce(edm::StreamID, Event &evt, const EventSetup &es) co
   evt.getByToken(genParticleInts_, barCodes);
   Handle<GenParticleCollection> genParticles;
   evt.getByToken(genParticles_, genParticles);
-  RecoToSimCollection associations = associator->associateRecoToSim(tracks, trackingParticles);
   unique_ptr<GenParticleMatch> match(new GenParticleMatch(GenParticleRefProd(genParticles)));
   if (not throwOnMissingTPCollection_ and not trackingParticlesFound) {
     evt.put(std::move(match));
     return;
   }
+  RecoToSimCollection associations = associator->associateRecoToSim(tracks, trackingParticles);
   GenParticleMatch::Filler filler(*match);
   size_t n = tracks->size();
   vector<int> indices(n, -1);

--- a/SimTracker/TrackAssociation/plugins/MCTrackMatcher.cc
+++ b/SimTracker/TrackAssociation/plugins/MCTrackMatcher.cc
@@ -31,6 +31,7 @@ private:
   edm::EDGetTokenT<GenParticleCollection> genParticles_;
   edm::EDGetTokenT<std::vector<int>> genParticleInts_;
   edm::EDGetTokenT<TrackingParticleCollection> trackingParticles_;
+  bool throwOnMissingTPCollection_;
   typedef edm::Association<reco::GenParticleCollection> GenParticleMatch;
 };
 
@@ -45,7 +46,8 @@ MCTrackMatcher::MCTrackMatcher(const ParameterSet &p)
       tracks_(consumes<edm::View<reco::Track>>(p.getParameter<InputTag>("tracks"))),
       genParticles_(consumes<GenParticleCollection>(p.getParameter<InputTag>("genParticles"))),
       genParticleInts_(consumes<std::vector<int>>(p.getParameter<InputTag>("genParticles"))),
-      trackingParticles_(consumes<TrackingParticleCollection>(p.getParameter<InputTag>("trackingParticles"))) {
+      trackingParticles_(consumes<TrackingParticleCollection>(p.getParameter<InputTag>("trackingParticles"))),
+      throwOnMissingTPCollection_(p.getParameter<bool>("throwOnMissingTPCollection")) {
   produces<GenParticleMatch>();
 }
 
@@ -56,13 +58,17 @@ void MCTrackMatcher::produce(edm::StreamID, Event &evt, const EventSetup &es) co
   Handle<View<Track>> tracks;
   evt.getByToken(tracks_, tracks);
   Handle<TrackingParticleCollection> trackingParticles;
-  evt.getByToken(trackingParticles_, trackingParticles);
+  auto trackingParticlesFound = evt.getByToken(trackingParticles_, trackingParticles);
   Handle<vector<int>> barCodes;
   evt.getByToken(genParticleInts_, barCodes);
   Handle<GenParticleCollection> genParticles;
   evt.getByToken(genParticles_, genParticles);
   RecoToSimCollection associations = associator->associateRecoToSim(tracks, trackingParticles);
   unique_ptr<GenParticleMatch> match(new GenParticleMatch(GenParticleRefProd(genParticles)));
+  if (not throwOnMissingTPCollection_ and not trackingParticlesFound) {
+    evt.put(std::move(match));
+    return;
+  }
   GenParticleMatch::Filler filler(*match);
   size_t n = tracks->size();
   vector<int> indices(n, -1);

--- a/SimTracker/TrackAssociation/plugins/PackedCandidateGenAssociationProducer.cc
+++ b/SimTracker/TrackAssociation/plugins/PackedCandidateGenAssociationProducer.cc
@@ -70,7 +70,7 @@ void PackedCandidateGenAssociationProducer::produce(edm::StreamID,
                                                     edm::Event& iEvent,
                                                     const edm::EventSetup& iSetup) const {
   using namespace edm;
-  
+
   const auto& trackToPackedCandidatesAssoc = iEvent.get(trackToPcToken_);
   auto pcCollection = trackToPackedCandidatesAssoc.ref();
 
@@ -90,9 +90,9 @@ void PackedCandidateGenAssociationProducer::produce(edm::StreamID,
     iEvent.put(std::move(out));
     return;
   }
-  
+
   const auto& trackToGenAssoc = *trackToGenAssocHandle;
-  
+
   Association<reco::GenParticleCollection>::Filler filler(*out);
 
   std::vector<int> indices(pcCollection->size(), -1);

--- a/SimTracker/TrackAssociation/plugins/PackedCandidateGenAssociationProducer.cc
+++ b/SimTracker/TrackAssociation/plugins/PackedCandidateGenAssociationProducer.cc
@@ -66,7 +66,9 @@ PackedCandidateGenAssociationProducer::PackedCandidateGenAssociationProducer(con
   produces<edm::Association<reco::GenParticleCollection>>();
 }
 
-void PackedCandidateGenAssociationProducer::produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const {
+void PackedCandidateGenAssociationProducer::produce(edm::StreamID,
+                                                    edm::Event& iEvent,
+                                                    const edm::EventSetup& iSetup) const {
   using namespace edm;
 
   const auto& trackToGenAssoc = iEvent.get(trackToGenToken_);

--- a/SimTracker/TrackAssociation/plugins/PackedCandidateGenAssociationProducer.cc
+++ b/SimTracker/TrackAssociation/plugins/PackedCandidateGenAssociationProducer.cc
@@ -124,7 +124,7 @@ void PackedCandidateGenAssociationProducer::fillDescriptions(edm::ConfigurationD
   desc.add<edm::InputTag>("trackToGenAssoc");
   desc.add<edm::InputTag>("tracks", edm::InputTag("generalTracks"));
 
-  descriptions.add("packedCandidatesGenAssociation", desc);
+  descriptions.add("packedCandidatesGenAssociationDefault", desc);
 }
 
 DEFINE_FWK_MODULE(PackedCandidateGenAssociationProducer);

--- a/SimTracker/TrackAssociation/plugins/PackedCandidateGenAssociationProducer.cc
+++ b/SimTracker/TrackAssociation/plugins/PackedCandidateGenAssociationProducer.cc
@@ -34,7 +34,6 @@
 #include "DataFormats/PatCandidates/interface/PackedCandidate.h"
 #include "DataFormats/TrackReco/interface/Track.h"
 
-
 //
 // class declaration
 //
@@ -47,78 +46,80 @@ public:
 
 private:
   void produce(edm::Event&, const edm::EventSetup&) override;
-  
+
   edm::EDGetTokenT<edm::Association<reco::GenParticleCollection>> trackToGenToken_;
   edm::EDGetTokenT<edm::Association<pat::PackedCandidateCollection>> trackToPcToken_;
   edm::EDGetTokenT<edm::Association<reco::GenParticleCollection>> genToPrunedToken_;
   edm::EDGetTokenT<edm::Association<reco::GenParticleCollection>> genToPrunedWSOToken_;
   edm::EDGetTokenT<edm::View<reco::Track>> tracksToken_;
-
 };
 PackedCandidateGenAssociationProducer::PackedCandidateGenAssociationProducer(const edm::ParameterSet& iConfig)
-    : trackToGenToken_(consumes<edm::Association<reco::GenParticleCollection>>(iConfig.getParameter<edm::InputTag>("trackToGenAssoc"))),
-      trackToPcToken_(consumes<edm::Association<pat::PackedCandidateCollection>>(iConfig.getParameter<edm::InputTag>("trackToPackedCandidatesAssoc"))),
-      genToPrunedToken_(consumes<edm::Association<reco::GenParticleCollection>>(iConfig.getParameter<edm::InputTag>("genToPrunedAssoc"))),
-      genToPrunedWSOToken_(consumes<edm::Association<reco::GenParticleCollection>>(iConfig.getParameter<edm::InputTag>("genToPrunedAssocWithStatusOne"))),
-      tracksToken_(consumes<edm::View<reco::Track>>(iConfig.getParameter<edm::InputTag>("tracks")))
-{
+    : trackToGenToken_(consumes<edm::Association<reco::GenParticleCollection>>(
+          iConfig.getParameter<edm::InputTag>("trackToGenAssoc"))),
+      trackToPcToken_(consumes<edm::Association<pat::PackedCandidateCollection>>(
+          iConfig.getParameter<edm::InputTag>("trackToPackedCandidatesAssoc"))),
+      genToPrunedToken_(consumes<edm::Association<reco::GenParticleCollection>>(
+          iConfig.getParameter<edm::InputTag>("genToPrunedAssoc"))),
+      genToPrunedWSOToken_(consumes<edm::Association<reco::GenParticleCollection>>(
+          iConfig.getParameter<edm::InputTag>("genToPrunedAssocWithStatusOne"))),
+      tracksToken_(consumes<edm::View<reco::Track>>(iConfig.getParameter<edm::InputTag>("tracks"))) {
   produces<edm::Association<reco::GenParticleCollection>>();
 }
 
 void PackedCandidateGenAssociationProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   using namespace edm;
-  
+
   edm::Handle<edm::Association<reco::GenParticleCollection>> htrackToGenAssoc;
   iEvent.getByToken(trackToGenToken_, htrackToGenAssoc);
   const auto& trackToGenAssoc = *htrackToGenAssoc;
   auto recoGenCollection = trackToGenAssoc.ref();
-  
+
   edm::Handle<edm::Association<pat::PackedCandidateCollection>> htrackToPackedCandidatesAssoc;
   iEvent.getByToken(trackToPcToken_, htrackToPackedCandidatesAssoc);
   const auto& trackToPackedCandidatesAssoc = *htrackToPackedCandidatesAssoc;
   auto pcCollection = trackToPackedCandidatesAssoc.ref();
-  
+
   edm::Handle<edm::Association<reco::GenParticleCollection>> hgenToPrunedAssoc;
   iEvent.getByToken(genToPrunedToken_, hgenToPrunedAssoc);
   const auto& genToPrunedAssoc = *hgenToPrunedAssoc;
   auto prunedCollection = genToPrunedAssoc.ref();
-  
+
   edm::Handle<edm::Association<reco::GenParticleCollection>> hgenToPrunedAssocWSO;
   iEvent.getByToken(genToPrunedWSOToken_, hgenToPrunedAssocWSO);
   const auto& genToPrunedAssocWSO = *hgenToPrunedAssocWSO;
-  
+
   edm::Handle<edm::View<reco::Track>> htracks;
   iEvent.getByToken(tracksToken_, htracks);
   const auto& tracks = *htracks;
 
   auto out = std::make_unique<edm::Association<reco::GenParticleCollection>>(prunedCollection);
   Association<reco::GenParticleCollection>::Filler filler(*out);
-  
+
   std::vector<int> indices(pcCollection->size(), -1);
-  
+
   for (size_t i = 0; i < tracks.size(); i++) {
     auto track = tracks.refAt(i);
-    
+
     auto pc = trackToPackedCandidatesAssoc[track];
     if (pc.isNull()) {
       continue;
     }
-    
+
     auto gen = trackToGenAssoc[track];
     if (gen.isNull()) {
       continue;
     }
-    
+
     auto newGenWSO = genToPrunedAssocWSO[gen];
     if (newGenWSO.isNull()) {
       continue;
     }
-    
+
     auto newGen = genToPrunedAssoc[newGenWSO];
     if (newGen.isNull()) {
       continue;
     }
-    
+
     indices[pc.index()] = newGen.index();
   }
   filler.insert(pcCollection, indices.begin(), indices.end());
@@ -133,7 +134,7 @@ void PackedCandidateGenAssociationProducer::fillDescriptions(edm::ConfigurationD
   desc.add<edm::InputTag>("trackToPackedCandidatesAssoc", edm::InputTag("packedPFCandidates"));
   desc.add<edm::InputTag>("trackToGenAssoc");
   desc.add<edm::InputTag>("tracks", edm::InputTag("generalTracks"));
-  
+
   descriptions.add("packedCandidatesGenAssociation", desc);
 }
 

--- a/SimTracker/TrackAssociation/plugins/PackedCandidateGenAssociationProducer.cc
+++ b/SimTracker/TrackAssociation/plugins/PackedCandidateGenAssociationProducer.cc
@@ -1,0 +1,140 @@
+// -*- C++ -*-
+//
+// Package:    MyTemporarySubSystem/PackedCandidateGenAssociationProducer
+// Class:      PackedCandidateGenAssociationProducer
+//
+/**\class PackedCandidateGenAssociationProducer PackedCandidateGenAssociationProducer.cc MyTemporarySubSystem/PackedCandidateGenAssociationProducer/plugins/PackedCandidateGenAssociationProducer.cc
+
+ Description: [one line class summary]
+
+ Implementation:
+     [Notes on implementation]
+*/
+//
+// Original Author:  Enrico Lusiani
+//         Created:  Mon, 03 May 2021 13:40:39 GMT
+//
+//
+
+// system include files
+#include <memory>
+
+// user include files
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/StreamID.h"
+
+#include "DataFormats/Common/interface/Association.h"
+#include "DataFormats/HepMCCandidate/interface/GenParticle.h"
+#include "DataFormats/PatCandidates/interface/PackedCandidate.h"
+#include "DataFormats/TrackReco/interface/Track.h"
+
+
+//
+// class declaration
+//
+
+class PackedCandidateGenAssociationProducer : public edm::stream::EDProducer<> {
+public:
+  explicit PackedCandidateGenAssociationProducer(const edm::ParameterSet&);
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+private:
+  void produce(edm::Event&, const edm::EventSetup&) override;
+  
+  edm::EDGetTokenT<edm::Association<reco::GenParticleCollection>> trackToGenToken_;
+  edm::EDGetTokenT<edm::Association<pat::PackedCandidateCollection>> trackToPcToken_;
+  edm::EDGetTokenT<edm::Association<reco::GenParticleCollection>> genToPrunedToken_;
+  edm::EDGetTokenT<edm::Association<reco::GenParticleCollection>> genToPrunedWSOToken_;
+  edm::EDGetTokenT<edm::View<reco::Track>> tracksToken_;
+
+};
+PackedCandidateGenAssociationProducer::PackedCandidateGenAssociationProducer(const edm::ParameterSet& iConfig)
+    : trackToGenToken_(consumes<edm::Association<reco::GenParticleCollection>>(iConfig.getParameter<edm::InputTag>("trackToGenAssoc"))),
+      trackToPcToken_(consumes<edm::Association<pat::PackedCandidateCollection>>(iConfig.getParameter<edm::InputTag>("trackToPackedCandidatesAssoc"))),
+      genToPrunedToken_(consumes<edm::Association<reco::GenParticleCollection>>(iConfig.getParameter<edm::InputTag>("genToPrunedAssoc"))),
+      genToPrunedWSOToken_(consumes<edm::Association<reco::GenParticleCollection>>(iConfig.getParameter<edm::InputTag>("genToPrunedAssocWithStatusOne"))),
+      tracksToken_(consumes<edm::View<reco::Track>>(iConfig.getParameter<edm::InputTag>("tracks")))
+{
+  produces<edm::Association<reco::GenParticleCollection>>();
+}
+
+void PackedCandidateGenAssociationProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  using namespace edm;
+  
+  edm::Handle<edm::Association<reco::GenParticleCollection>> htrackToGenAssoc;
+  iEvent.getByToken(trackToGenToken_, htrackToGenAssoc);
+  const auto& trackToGenAssoc = *htrackToGenAssoc;
+  auto recoGenCollection = trackToGenAssoc.ref();
+  
+  edm::Handle<edm::Association<pat::PackedCandidateCollection>> htrackToPackedCandidatesAssoc;
+  iEvent.getByToken(trackToPcToken_, htrackToPackedCandidatesAssoc);
+  const auto& trackToPackedCandidatesAssoc = *htrackToPackedCandidatesAssoc;
+  auto pcCollection = trackToPackedCandidatesAssoc.ref();
+  
+  edm::Handle<edm::Association<reco::GenParticleCollection>> hgenToPrunedAssoc;
+  iEvent.getByToken(genToPrunedToken_, hgenToPrunedAssoc);
+  const auto& genToPrunedAssoc = *hgenToPrunedAssoc;
+  auto prunedCollection = genToPrunedAssoc.ref();
+  
+  edm::Handle<edm::Association<reco::GenParticleCollection>> hgenToPrunedAssocWSO;
+  iEvent.getByToken(genToPrunedWSOToken_, hgenToPrunedAssocWSO);
+  const auto& genToPrunedAssocWSO = *hgenToPrunedAssocWSO;
+  
+  edm::Handle<edm::View<reco::Track>> htracks;
+  iEvent.getByToken(tracksToken_, htracks);
+  const auto& tracks = *htracks;
+
+  auto out = std::make_unique<edm::Association<reco::GenParticleCollection>>(prunedCollection);
+  Association<reco::GenParticleCollection>::Filler filler(*out);
+  
+  std::vector<int> indices(pcCollection->size(), -1);
+  
+  for (size_t i = 0; i < tracks.size(); i++) {
+    auto track = tracks.refAt(i);
+    
+    auto pc = trackToPackedCandidatesAssoc[track];
+    if (pc.isNull()) {
+      continue;
+    }
+    
+    auto gen = trackToGenAssoc[track];
+    if (gen.isNull()) {
+      continue;
+    }
+    
+    auto newGenWSO = genToPrunedAssocWSO[gen];
+    if (newGenWSO.isNull()) {
+      continue;
+    }
+    
+    auto newGen = genToPrunedAssoc[newGenWSO];
+    if (newGen.isNull()) {
+      continue;
+    }
+    
+    indices[pc.index()] = newGen.index();
+  }
+  filler.insert(pcCollection, indices.begin(), indices.end());
+  filler.fill();
+  iEvent.put(std::move(out));
+}
+
+void PackedCandidateGenAssociationProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.add<edm::InputTag>("genToPrunedAssoc", edm::InputTag("prunedGenParticles"));
+  desc.add<edm::InputTag>("genToPrunedAssocWithStatusOne", edm::InputTag("prunedGenParticlesWithStatusOne"));
+  desc.add<edm::InputTag>("trackToPackedCandidatesAssoc", edm::InputTag("packedPFCandidates"));
+  desc.add<edm::InputTag>("trackToGenAssoc");
+  desc.add<edm::InputTag>("tracks", edm::InputTag("generalTracks"));
+  
+  descriptions.add("packedCandidatesGenAssociation", desc);
+}
+
+DEFINE_FWK_MODULE(PackedCandidateGenAssociationProducer);

--- a/SimTracker/TrackAssociation/plugins/PackedCandidateGenAssociationProducer.cc
+++ b/SimTracker/TrackAssociation/plugins/PackedCandidateGenAssociationProducer.cc
@@ -79,13 +79,15 @@ void PackedCandidateGenAssociationProducer::produce(edm::StreamID,
 
   const auto& genToPrunedAssocWSO = iEvent.get(genToPrunedWSOToken_);
 
-  const auto& tracks = iEvent.get(tracksToken_);
+  auto trackHandle = iEvent.getHandle(tracksToken_);
+  const auto& tracks = *trackHandle;
 
   auto out = std::make_unique<edm::Association<reco::GenParticleCollection>>(prunedCollection);
 
   auto trackToGenAssocHandle = iEvent.getHandle(trackToGenToken_);
-  if (not trackToGenAssocHandle.isValid()) {
+  if (not trackToGenAssocHandle.isValid() or not trackToGenAssocHandle->contains(trackHandle.id())) {
     // not track to gen association available, possibly an old AODSIM, or a missing RECOSIM step
+    // alternatively, the track association may not contain our tracks, as in the case of RECOSIM run on an old RAWSIM
     // early exit with an empty collection to avoid crash
     iEvent.put(std::move(out));
     return;

--- a/SimTracker/TrackAssociation/plugins/SimLinkPruner.cc
+++ b/SimTracker/TrackAssociation/plugins/SimLinkPruner.cc
@@ -1,0 +1,182 @@
+// -*- C++ -*-
+//
+// Package:    SimTracker/SimLinkPruner
+// Class:      SimLinkPruner
+//
+/**\class SimLinkPruner SimLinkPruner.cc SimTracker/SimLinkPruner/plugins/SimLinkPruner.cc
+
+ Description: [one line class summary]
+
+ Implementation:
+     [Notes on implementation]
+*/
+//
+// Original Author:  Enrico Lusiani
+//         Created:  Fri, 14 May 2021 08:46:10 GMT
+//
+//
+
+// system include files
+#include <memory>
+
+// user include files
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/StreamID.h"
+
+#include "SimDataFormats/TrackingAnalysis/interface/TrackingParticle.h"
+#include "DataFormats/Common/interface/DetSetVector.h"
+#include "SimDataFormats/TrackerDigiSimLink/interface/PixelDigiSimLink.h"
+#include "SimDataFormats/TrackerDigiSimLink/interface/StripDigiSimLink.h"
+#include "SimDataFormats/Track/interface/UniqueSimTrackId.h"
+
+#include <unordered_set>
+
+
+namespace {
+
+  template <typename T>
+  std::vector<edm::DetSet<T>> pruneByTpAssoc(const edm::DetSetVector<T>& simLinkColl, const std::unordered_set<UniqueSimTrackId, UniqueSimTrackIdHash>& selectedIds) {
+    std::vector<edm::DetSet<T> > linkVector;
+    
+    for (auto&& detSet: simLinkColl) {
+      edm::DetSet<T> newDetSet(detSet.detId());
+      
+      for (auto&& simLink: detSet) {
+        UniqueSimTrackId trkid(simLink.SimTrackId(), simLink.eventId());
+        if (selectedIds.count(trkid) > 0) {
+          newDetSet.push_back(simLink);
+        }
+      }
+      
+      linkVector.push_back(std::move(newDetSet));
+    }
+    
+    return linkVector;
+  }
+
+}  // namespace
+
+//
+// class declaration
+//
+
+class SimLinkPruner : public edm::stream::EDProducer<> {
+public:
+  explicit SimLinkPruner(const edm::ParameterSet&);
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+private:
+  void produce(edm::Event&, const edm::EventSetup&) override;
+
+  // ----------member data ---------------------------
+  edm::EDGetTokenT<TrackingParticleCollection> trackingParticleToken_;
+  edm::EDGetTokenT<edm::DetSetVector<PixelDigiSimLink> > sipixelSimLinksToken_;
+  edm::EDGetTokenT<edm::DetSetVector<StripDigiSimLink> > sistripSimLinksToken_;
+  edm::EDGetTokenT<edm::DetSetVector<PixelDigiSimLink> > siphase2OTSimLinksToken_;
+  
+};
+
+SimLinkPruner::SimLinkPruner(const edm::ParameterSet& iConfig)
+  : trackingParticleToken_(consumes<TrackingParticleCollection>(iConfig.getParameter<edm::InputTag>("trackingParticles"))),
+    sipixelSimLinksToken_(consumes<edm::DetSetVector<PixelDigiSimLink>>(iConfig.getParameter<edm::InputTag>("pixelSimLinkSrc")))
+{
+  produces<edm::DetSetVector<PixelDigiSimLink> >("siPixel");
+  
+  if (iConfig.existsAs<edm::InputTag>("stripSimLinkSrc")) {
+    sistripSimLinksToken_ = consumes<edm::DetSetVector<StripDigiSimLink> >(iConfig.getParameter<edm::InputTag>("stripSimLinkSrc"));
+    produces<edm::DetSetVector<StripDigiSimLink> >("siStrip");
+  }
+  
+  if (iConfig.existsAs<edm::InputTag>("phase2OTSimLinkSrc")) {
+    siphase2OTSimLinksToken_ = consumes<edm::DetSetVector<PixelDigiSimLink> >(iConfig.getParameter<edm::InputTag>("phase2OTSimLinkSrc"));
+    produces<edm::DetSetVector<PixelDigiSimLink> >("siphase2OT");
+  }
+}
+
+// ------------ method called to produce the data  ------------
+void SimLinkPruner::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  using namespace edm;
+  
+  edm::Handle<TrackingParticleCollection> TPCollectionH;
+
+  iEvent.getByToken(trackingParticleToken_, TPCollectionH);
+  
+  auto const& tpColl = *TPCollectionH.product();
+  
+  std::unordered_set<UniqueSimTrackId, UniqueSimTrackIdHash> selectedIds;
+  for (TrackingParticleCollection::size_type itp = 0; itp < tpColl.size(); ++itp) {
+
+    TrackingParticleRef trackingParticleRef(TPCollectionH, itp);
+
+    auto const& trackingParticle = tpColl[itp];
+
+    // SimTracks inside TrackingParticle
+
+    EncodedEventId eid(trackingParticle.eventId());
+
+    for (auto const& trk : trackingParticle.g4Tracks()) {
+
+      selectedIds.emplace(trk.trackId(), eid);
+
+    }
+
+  }
+  
+  edm::Handle<edm::DetSetVector<PixelDigiSimLink> > siPixelSimLinksH;
+
+  iEvent.getByToken(sipixelSimLinksToken_, siPixelSimLinksH);
+  
+  auto const& sipixelLinkColl = *siPixelSimLinksH.product();
+  
+  auto sipixelLinkVector = pruneByTpAssoc(sipixelLinkColl, selectedIds);
+  
+  auto sipixelOut = std::make_unique<edm::DetSetVector<PixelDigiSimLink>>(sipixelLinkVector);
+  iEvent.put(std::move(sipixelOut), "siPixel");
+  
+  if (not sistripSimLinksToken_.isUninitialized()) {
+    edm::Handle<edm::DetSetVector<StripDigiSimLink> > siStripSimLinksH;
+
+    iEvent.getByToken(sistripSimLinksToken_, siStripSimLinksH);
+    
+    auto const& sistripLinkColl = *siStripSimLinksH.product();
+    
+    auto sistripLinkVector = pruneByTpAssoc(sistripLinkColl, selectedIds);
+    
+    auto sistripOut = std::make_unique<edm::DetSetVector<StripDigiSimLink>>(sistripLinkVector);
+    iEvent.put(std::move(sistripOut), "siStrip");
+  }
+  
+  if (not siphase2OTSimLinksToken_.isUninitialized()) {
+    edm::Handle<edm::DetSetVector<PixelDigiSimLink> > siphase2OTSimLinksH;
+
+    iEvent.getByToken(siphase2OTSimLinksToken_, siphase2OTSimLinksH);
+    
+    auto const& siphase2OTLinkColl = *siphase2OTSimLinksH.product();
+    
+    auto siphase2OTLinkVector = pruneByTpAssoc(siphase2OTLinkColl, selectedIds);
+    
+    auto siphase2OTOut = std::make_unique<edm::DetSetVector<PixelDigiSimLink>>(siphase2OTLinkVector);
+    iEvent.put(std::move(siphase2OTOut), "siphase2OT");
+  }
+}
+
+// ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
+void SimLinkPruner::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.add<edm::InputTag>("trackingParticles", edm::InputTag("mix", "MergedTrackTruth"));
+  desc.add<edm::InputTag>("pixelSimLinkSrc", edm::InputTag("simSiPixelDigis"));
+  desc.addOptional<edm::InputTag>("stripSimLinkSrc");
+  desc.addOptional<edm::InputTag>("phase2OTSimLinkSrc");
+  
+  descriptions.add("pruneSimLinkDefault", desc);
+}
+
+//define this as a plug-in
+DEFINE_FWK_MODULE(SimLinkPruner);

--- a/SimTracker/TrackAssociation/plugins/TrackingParticleSelectorByGen.cc
+++ b/SimTracker/TrackAssociation/plugins/TrackingParticleSelectorByGen.cc
@@ -259,14 +259,12 @@ void TrackingParticleSelectorByGen::produce(edm::Event &iEvent, const edm::Event
     firstEvent_ = false;
   }
 
-  edm::Handle<TrackingParticleCollection> tps;
-  iEvent.getByToken(tpToken_, tps);
+  const auto& tps = iEvent.get(tpToken_);
 
-  edm::Handle<reco::GenParticleCollection> gps;
-  iEvent.getByToken(gpToken_, gps);
+  const auto& gps = iEvent.get(gpToken_);
 
   using namespace ::helper;
-  const size_t n = gps->size();
+  const size_t n = gps.size();
   flags_.clear();
   flags_.resize(n, keepOrDropAll_);
   for (size_t j = 0; j < select_.size(); ++j) {
@@ -274,7 +272,7 @@ void TrackingParticleSelectorByGen::produce(edm::Event &iEvent, const edm::Event
     SelectCode code = sel.second;
     const StringCutObjectSelector<GenParticle> &cut = sel.first;
     for (size_t i = 0; i < n; ++i) {
-      const GenParticle &p = (*gps)[i];
+      const GenParticle &p = gps[i];
       if (cut(p)) {
         int keepOrDrop = keep;
         switch (code.keepOrDrop_) {
@@ -289,7 +287,7 @@ void TrackingParticleSelectorByGen::produce(edm::Event &iEvent, const edm::Event
         std::vector<size_t> allIndicesMo;
         switch (code.daughtersDepth_) {
           case SelectCode::kAll:
-            recursiveFlagDaughters(i, *gps, keepOrDrop, allIndicesDa);
+            recursiveFlagDaughters(i, gps, keepOrDrop, allIndicesDa);
             break;
           case SelectCode::kFirst:
             flagDaughters(p, keepOrDrop);
@@ -298,7 +296,7 @@ void TrackingParticleSelectorByGen::produce(edm::Event &iEvent, const edm::Event
         };
         switch (code.mothersDepth_) {
           case SelectCode::kAll:
-            recursiveFlagMothers(i, *gps, keepOrDrop, allIndicesMo);
+            recursiveFlagMothers(i, gps, keepOrDrop, allIndicesMo);
             break;
           case SelectCode::kFirst:
             flagMothers(p, keepOrDrop);
@@ -312,7 +310,7 @@ void TrackingParticleSelectorByGen::produce(edm::Event &iEvent, const edm::Event
   auto out = std::make_unique<TrackingParticleCollection>();
   out->reserve(n);
 
-  for (auto &&tp : *tps) {
+  for (auto &&tp : tps) {
     auto &associatedGenParticles = tp.genParticles();
 
     bool isSelected = false;

--- a/SimTracker/TrackAssociation/plugins/TrackingParticleSelectorByGen.cc
+++ b/SimTracker/TrackAssociation/plugins/TrackingParticleSelectorByGen.cc
@@ -332,7 +332,7 @@ void TrackingParticleSelectorByGen::fillDescriptions(edm::ConfigurationDescripti
   desc.add<edm::InputTag>("genParticles", edm::InputTag("genParticles"));
   desc.add<vector<string>>("select");
 
-  descriptions.add("selectTPs", desc);
+  descriptions.add("tpSelectorByGenDefault", desc);
 }
 
 //define this as a plug-in

--- a/SimTracker/TrackAssociation/plugins/TrackingParticleSelectorByGen.cc
+++ b/SimTracker/TrackAssociation/plugins/TrackingParticleSelectorByGen.cc
@@ -259,9 +259,9 @@ void TrackingParticleSelectorByGen::produce(edm::Event &iEvent, const edm::Event
     firstEvent_ = false;
   }
 
-  const auto& tps = iEvent.get(tpToken_);
+  const auto &tps = iEvent.get(tpToken_);
 
-  const auto& gps = iEvent.get(gpToken_);
+  const auto &gps = iEvent.get(gpToken_);
 
   using namespace ::helper;
   const size_t n = gps.size();

--- a/SimTracker/TrackAssociation/plugins/TrackingParticleSelectorByGen.cc
+++ b/SimTracker/TrackAssociation/plugins/TrackingParticleSelectorByGen.cc
@@ -1,0 +1,341 @@
+// -*- C++ -*-
+//
+// Package:    SimGeneral/TrackingParticleSelectorByGen
+// Class:      TrackingParticleSelectorByGen
+//
+/**\class TrackingParticleSelectorByGen TrackingParticleSelectorByGen.cc SimGeneral/TrackingParticleSelectorByGen/plugins/TrackingParticleSelectorByGen.cc
+
+ Description: [one line class summary]
+
+ Implementation:
+     [Notes on implementation]
+*/
+//
+// Original Author:  Enrico Lusiani
+//         Created:  Mon, 26 Apr 2021 16:44:34 GMT
+//
+//
+
+// system include files
+#include <memory>
+
+// user include files
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/StreamID.h"
+
+#include "DataFormats/HepMCCandidate/interface/GenParticle.h"
+#include "SimDataFormats/TrackingAnalysis/interface/TrackingParticle.h"
+#include "PhysicsTools/HepMCCandAlgos/interface/PdgEntryReplacer.h"
+#include "CommonTools/Utils/interface/StringCutObjectSelector.h"
+
+
+namespace helper {
+  struct SelectCode {
+    enum KeepOrDrop { kKeep, kDrop };
+    enum FlagDepth { kNone, kFirst, kAll };
+    KeepOrDrop keepOrDrop_;
+    FlagDepth daughtersDepth_, mothersDepth_;
+    bool all_;
+  };
+}  // namespace helper
+
+class TrackingParticleSelectorByGen : public edm::stream::EDProducer<> {
+// a lot of this is copied from GenParticlePruner
+// refactor common parts in a separate class
+public:
+  explicit TrackingParticleSelectorByGen(const edm::ParameterSet&);
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+private:
+  void produce(edm::Event&, const edm::EventSetup&) override;
+  void parse(const std::string &selection, helper::SelectCode &code, std::string &cut) const;
+  void flagDaughters(const reco::GenParticle &, int);
+  void flagMothers(const reco::GenParticle &, int);
+  void recursiveFlagDaughters(size_t, const reco::GenParticleCollection &, int, std::vector<size_t> &);
+  void recursiveFlagMothers(size_t, const reco::GenParticleCollection &, int, std::vector<size_t> &);
+  void getDaughterKeys(std::vector<size_t> &, std::vector<size_t> &, const reco::GenParticleRefVector &) const;
+  void getMotherKeys(std::vector<size_t> &, std::vector<size_t> &, const reco::GenParticleRefVector &) const;
+
+  // ----------member data ---------------------------
+  edm::EDGetTokenT<TrackingParticleCollection> tpToken_;
+  edm::EDGetTokenT<reco::GenParticleCollection> gpToken_;
+  bool firstEvent_;
+  int keepOrDropAll_;
+  std::vector<int> flags_;
+  std::vector<std::string> selection_;
+  std::vector<std::pair<StringCutObjectSelector<reco::GenParticle>, helper::SelectCode>> select_;
+};
+
+using namespace edm;
+using namespace std;
+using namespace reco;
+
+const int keep = 1, drop = -1;
+
+void TrackingParticleSelectorByGen::parse(const std::string &selection, ::helper::SelectCode &code, std::string &cut) const {
+  using namespace ::helper;
+  size_t f = selection.find_first_not_of(' ');
+  size_t n = selection.size();
+  string command;
+  char c;
+  for (; (c = selection[f]) != ' ' && f < n; ++f) {
+    command.push_back(c);
+  }
+  if (command[0] == '+') {
+    command.erase(0, 1);
+    if (command[0] == '+') {
+      command.erase(0, 1);
+      code.mothersDepth_ = SelectCode::kAll;
+    } else {
+      code.mothersDepth_ = SelectCode::kFirst;
+    }
+  } else
+    code.mothersDepth_ = SelectCode::kNone;
+
+  if (command[command.size() - 1] == '+') {
+    command.erase(command.size() - 1);
+    if (command[command.size() - 1] == '+') {
+      command.erase(command.size() - 1);
+      code.daughtersDepth_ = SelectCode::kAll;
+    } else {
+      code.daughtersDepth_ = SelectCode::kFirst;
+    }
+  } else
+    code.daughtersDepth_ = SelectCode::kNone;
+
+  if (command == "keep")
+    code.keepOrDrop_ = SelectCode::kKeep;
+  else if (command == "drop")
+    code.keepOrDrop_ = SelectCode::kDrop;
+  else {
+    throw Exception(errors::Configuration) << "invalid selection command: " << command << "\n" << endl;
+  }
+  for (; f < n; ++f) {
+    if (selection[f] != ' ')
+      break;
+  }
+  cut = string(selection, f);
+  if (cut[0] == '*')
+    cut = string(cut, 0, cut.find_first_of(' '));
+  code.all_ = cut == "*";
+}
+
+TrackingParticleSelectorByGen::TrackingParticleSelectorByGen(const edm::ParameterSet& iConfig)
+    : tpToken_(consumes<TrackingParticleCollection>(iConfig.getParameter<edm::InputTag>("trackingParticles"))),
+      gpToken_(consumes<reco::GenParticleCollection>(iConfig.getParameter<edm::InputTag>("genParticles"))),
+      firstEvent_(true),
+      keepOrDropAll_(drop),
+      selection_(iConfig.getParameter<vector<string>>("select")) {
+      
+  produces<TrackingParticleCollection>();
+}
+
+void TrackingParticleSelectorByGen::flagDaughters(const reco::GenParticle &gen, int keepOrDrop) {
+  const GenParticleRefVector &daughters = gen.daughterRefVector();
+  for (GenParticleRefVector::const_iterator i = daughters.begin(); i != daughters.end(); ++i)
+    flags_[i->key()] = keepOrDrop;
+}
+
+void TrackingParticleSelectorByGen::flagMothers(const reco::GenParticle &gen, int keepOrDrop) {
+  const GenParticleRefVector &mothers = gen.motherRefVector();
+  for (GenParticleRefVector::const_iterator i = mothers.begin(); i != mothers.end(); ++i)
+    flags_[i->key()] = keepOrDrop;
+}
+
+void TrackingParticleSelectorByGen::recursiveFlagDaughters(size_t index,
+                                               const reco::GenParticleCollection &src,
+                                               int keepOrDrop,
+                                               std::vector<size_t> &allIndices) {
+  GenParticleRefVector daughters = src[index].daughterRefVector();
+  // avoid infinite recursion if the daughters are set to "this" particle.
+  size_t cachedIndex = index;
+  for (GenParticleRefVector::const_iterator i = daughters.begin(); i != daughters.end(); ++i) {
+    index = i->key();
+    // To also avoid infinite recursion if a "loop" is found in the daughter list,
+    // check to make sure the index hasn't already been added.
+    if (find(allIndices.begin(), allIndices.end(), index) == allIndices.end()) {
+      allIndices.push_back(index);
+      if (cachedIndex != index) {
+        flags_[index] = keepOrDrop;
+        recursiveFlagDaughters(index, src, keepOrDrop, allIndices);
+      }
+    }
+  }
+}
+
+void TrackingParticleSelectorByGen::recursiveFlagMothers(size_t index,
+                                             const reco::GenParticleCollection &src,
+                                             int keepOrDrop,
+                                             std::vector<size_t> &allIndices) {
+  GenParticleRefVector mothers = src[index].motherRefVector();
+  // avoid infinite recursion if the mothers are set to "this" particle.
+  size_t cachedIndex = index;
+  for (GenParticleRefVector::const_iterator i = mothers.begin(); i != mothers.end(); ++i) {
+    index = i->key();
+    // To also avoid infinite recursion if a "loop" is found in the daughter list,
+    // check to make sure the index hasn't already been added.
+    if (find(allIndices.begin(), allIndices.end(), index) == allIndices.end()) {
+      allIndices.push_back(index);
+      if (cachedIndex != index) {
+        flags_[index] = keepOrDrop;
+        recursiveFlagMothers(index, src, keepOrDrop, allIndices);
+      }
+    }
+  }
+}
+
+void TrackingParticleSelectorByGen::getDaughterKeys(vector<size_t> &daIndxs,
+                                        vector<size_t> &daNewIndxs,
+                                        const GenParticleRefVector &daughters) const {
+  for (GenParticleRefVector::const_iterator j = daughters.begin(); j != daughters.end(); ++j) {
+    GenParticleRef dau = *j;
+    if (find(daIndxs.begin(), daIndxs.end(), dau.key()) == daIndxs.end()) {
+      daIndxs.push_back(dau.key());
+      int idx = flags_[dau.key()];
+      if (idx > 0) {
+        daNewIndxs.push_back(idx);
+      } else {
+        const GenParticleRefVector &daus = dau->daughterRefVector();
+        if (!daus.empty())
+          getDaughterKeys(daIndxs, daNewIndxs, daus);
+      }
+    }
+  }
+}
+
+void TrackingParticleSelectorByGen::getMotherKeys(vector<size_t> &moIndxs,
+                                      vector<size_t> &moNewIndxs,
+                                      const GenParticleRefVector &mothers) const {
+  for (GenParticleRefVector::const_iterator j = mothers.begin(); j != mothers.end(); ++j) {
+    GenParticleRef mom = *j;
+    if (find(moIndxs.begin(), moIndxs.end(), mom.key()) == moIndxs.end()) {
+      moIndxs.push_back(mom.key());
+      int idx = flags_[mom.key()];
+      if (idx >= 0) {
+        moNewIndxs.push_back(idx);
+      } else {
+        const GenParticleRefVector &moms = mom->motherRefVector();
+        if (!moms.empty())
+          getMotherKeys(moIndxs, moNewIndxs, moms);
+      }
+    }
+  }
+}
+
+
+void TrackingParticleSelectorByGen::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  using namespace edm;
+  
+  if (firstEvent_) {
+    PdgEntryReplacer rep(iSetup);
+    for (vector<string>::const_iterator i = selection_.begin(); i != selection_.end(); ++i) {
+      string cut;
+      ::helper::SelectCode code;
+      parse(*i, code, cut);
+      if (code.all_) {
+        if (i != selection_.begin())
+          throw Exception(errors::Configuration)
+              << "selections \"keep *\" and \"drop *\" can be used only as first options. Here used in position # "
+              << (i - selection_.begin()) + 1 << "\n"
+              << endl;
+        switch (code.keepOrDrop_) {
+          case ::helper::SelectCode::kDrop:
+            keepOrDropAll_ = drop;
+            break;
+          case ::helper::SelectCode::kKeep:
+            keepOrDropAll_ = keep;
+        };
+      } else {
+        cut = rep.replace(cut);
+        select_.push_back(make_pair(StringCutObjectSelector<GenParticle>(cut), code));
+      }
+    }
+    firstEvent_ = false;
+  }
+
+  edm::Handle<TrackingParticleCollection> tps;
+  iEvent.getByToken(tpToken_, tps);
+  
+  edm::Handle<reco::GenParticleCollection> gps;
+  iEvent.getByToken(gpToken_, gps);
+  
+  using namespace ::helper;
+  const size_t n = gps->size();
+  flags_.clear();
+  flags_.resize(n, keepOrDropAll_);
+  for (size_t j = 0; j < select_.size(); ++j) {
+    const pair<StringCutObjectSelector<GenParticle>, SelectCode> &sel = select_[j];
+    SelectCode code = sel.second;
+    const StringCutObjectSelector<GenParticle> &cut = sel.first;
+    for (size_t i = 0; i < n; ++i) {
+      const GenParticle &p = (*gps)[i];
+      if (cut(p)) {
+        int keepOrDrop = keep;
+        switch (code.keepOrDrop_) {
+          case SelectCode::kKeep:
+            keepOrDrop = keep;
+            break;
+          case SelectCode::kDrop:
+            keepOrDrop = drop;
+        };
+        flags_[i] = keepOrDrop;
+        std::vector<size_t> allIndicesDa;
+        std::vector<size_t> allIndicesMo;
+        switch (code.daughtersDepth_) {
+          case SelectCode::kAll:
+            recursiveFlagDaughters(i, *gps, keepOrDrop, allIndicesDa);
+            break;
+          case SelectCode::kFirst:
+            flagDaughters(p, keepOrDrop);
+            break;
+          case SelectCode::kNone:;
+        };
+        switch (code.mothersDepth_) {
+          case SelectCode::kAll:
+            recursiveFlagMothers(i, *gps, keepOrDrop, allIndicesMo);
+            break;
+          case SelectCode::kFirst:
+            flagMothers(p, keepOrDrop);
+            break;
+          case SelectCode::kNone:;
+        };
+      }
+    }
+  }
+  
+  auto out = std::make_unique<TrackingParticleCollection>();
+  out->reserve(n);
+  
+  for (auto&& tp: *tps) {
+    auto& associatedGenParticles = tp.genParticles();
+    
+    bool isSelected = false;
+    for (auto&& assocGen: associatedGenParticles) {
+      if (flags_[assocGen.index()] == keep) isSelected = true;
+    }
+    
+    if (isSelected) {
+      out->emplace_back(tp);
+    }
+  }
+  iEvent.put(std::move(out));
+}
+
+void TrackingParticleSelectorByGen::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.add<edm::InputTag>("trackingParticles", edm::InputTag("mix", "MergedTrackTruth"));
+  desc.add<edm::InputTag>("genParticles", edm::InputTag("genParticles"));
+  desc.add<vector<string>>("select");
+  
+  descriptions.add("selectTPs", desc);
+}
+
+//define this as a plug-in
+DEFINE_FWK_MODULE(TrackingParticleSelectorByGen);

--- a/SimTracker/TrackAssociation/plugins/TrackingParticleSelectorByGen.cc
+++ b/SimTracker/TrackAssociation/plugins/TrackingParticleSelectorByGen.cc
@@ -34,7 +34,6 @@
 #include "PhysicsTools/HepMCCandAlgos/interface/PdgEntryReplacer.h"
 #include "CommonTools/Utils/interface/StringCutObjectSelector.h"
 
-
 namespace helper {
   struct SelectCode {
     enum KeepOrDrop { kKeep, kDrop };
@@ -46,15 +45,15 @@ namespace helper {
 }  // namespace helper
 
 class TrackingParticleSelectorByGen : public edm::stream::EDProducer<> {
-// a lot of this is copied from GenParticlePruner
-// refactor common parts in a separate class
+  // a lot of this is copied from GenParticlePruner
+  // refactor common parts in a separate class
 public:
-  explicit TrackingParticleSelectorByGen(const edm::ParameterSet&);
+  explicit TrackingParticleSelectorByGen(const edm::ParameterSet &);
 
-  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+  static void fillDescriptions(edm::ConfigurationDescriptions &descriptions);
 
 private:
-  void produce(edm::Event&, const edm::EventSetup&) override;
+  void produce(edm::Event &, const edm::EventSetup &) override;
   void parse(const std::string &selection, helper::SelectCode &code, std::string &cut) const;
   void flagDaughters(const reco::GenParticle &, int);
   void flagMothers(const reco::GenParticle &, int);
@@ -79,7 +78,9 @@ using namespace reco;
 
 const int keep = 1, drop = -1;
 
-void TrackingParticleSelectorByGen::parse(const std::string &selection, ::helper::SelectCode &code, std::string &cut) const {
+void TrackingParticleSelectorByGen::parse(const std::string &selection,
+                                          ::helper::SelectCode &code,
+                                          std::string &cut) const {
   using namespace ::helper;
   size_t f = selection.find_first_not_of(' ');
   size_t n = selection.size();
@@ -127,13 +128,12 @@ void TrackingParticleSelectorByGen::parse(const std::string &selection, ::helper
   code.all_ = cut == "*";
 }
 
-TrackingParticleSelectorByGen::TrackingParticleSelectorByGen(const edm::ParameterSet& iConfig)
+TrackingParticleSelectorByGen::TrackingParticleSelectorByGen(const edm::ParameterSet &iConfig)
     : tpToken_(consumes<TrackingParticleCollection>(iConfig.getParameter<edm::InputTag>("trackingParticles"))),
       gpToken_(consumes<reco::GenParticleCollection>(iConfig.getParameter<edm::InputTag>("genParticles"))),
       firstEvent_(true),
       keepOrDropAll_(drop),
       selection_(iConfig.getParameter<vector<string>>("select")) {
-      
   produces<TrackingParticleCollection>();
 }
 
@@ -150,9 +150,9 @@ void TrackingParticleSelectorByGen::flagMothers(const reco::GenParticle &gen, in
 }
 
 void TrackingParticleSelectorByGen::recursiveFlagDaughters(size_t index,
-                                               const reco::GenParticleCollection &src,
-                                               int keepOrDrop,
-                                               std::vector<size_t> &allIndices) {
+                                                           const reco::GenParticleCollection &src,
+                                                           int keepOrDrop,
+                                                           std::vector<size_t> &allIndices) {
   GenParticleRefVector daughters = src[index].daughterRefVector();
   // avoid infinite recursion if the daughters are set to "this" particle.
   size_t cachedIndex = index;
@@ -171,9 +171,9 @@ void TrackingParticleSelectorByGen::recursiveFlagDaughters(size_t index,
 }
 
 void TrackingParticleSelectorByGen::recursiveFlagMothers(size_t index,
-                                             const reco::GenParticleCollection &src,
-                                             int keepOrDrop,
-                                             std::vector<size_t> &allIndices) {
+                                                         const reco::GenParticleCollection &src,
+                                                         int keepOrDrop,
+                                                         std::vector<size_t> &allIndices) {
   GenParticleRefVector mothers = src[index].motherRefVector();
   // avoid infinite recursion if the mothers are set to "this" particle.
   size_t cachedIndex = index;
@@ -192,8 +192,8 @@ void TrackingParticleSelectorByGen::recursiveFlagMothers(size_t index,
 }
 
 void TrackingParticleSelectorByGen::getDaughterKeys(vector<size_t> &daIndxs,
-                                        vector<size_t> &daNewIndxs,
-                                        const GenParticleRefVector &daughters) const {
+                                                    vector<size_t> &daNewIndxs,
+                                                    const GenParticleRefVector &daughters) const {
   for (GenParticleRefVector::const_iterator j = daughters.begin(); j != daughters.end(); ++j) {
     GenParticleRef dau = *j;
     if (find(daIndxs.begin(), daIndxs.end(), dau.key()) == daIndxs.end()) {
@@ -211,8 +211,8 @@ void TrackingParticleSelectorByGen::getDaughterKeys(vector<size_t> &daIndxs,
 }
 
 void TrackingParticleSelectorByGen::getMotherKeys(vector<size_t> &moIndxs,
-                                      vector<size_t> &moNewIndxs,
-                                      const GenParticleRefVector &mothers) const {
+                                                  vector<size_t> &moNewIndxs,
+                                                  const GenParticleRefVector &mothers) const {
   for (GenParticleRefVector::const_iterator j = mothers.begin(); j != mothers.end(); ++j) {
     GenParticleRef mom = *j;
     if (find(moIndxs.begin(), moIndxs.end(), mom.key()) == moIndxs.end()) {
@@ -229,10 +229,9 @@ void TrackingParticleSelectorByGen::getMotherKeys(vector<size_t> &moIndxs,
   }
 }
 
-
-void TrackingParticleSelectorByGen::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+void TrackingParticleSelectorByGen::produce(edm::Event &iEvent, const edm::EventSetup &iSetup) {
   using namespace edm;
-  
+
   if (firstEvent_) {
     PdgEntryReplacer rep(iSetup);
     for (vector<string>::const_iterator i = selection_.begin(); i != selection_.end(); ++i) {
@@ -262,10 +261,10 @@ void TrackingParticleSelectorByGen::produce(edm::Event& iEvent, const edm::Event
 
   edm::Handle<TrackingParticleCollection> tps;
   iEvent.getByToken(tpToken_, tps);
-  
+
   edm::Handle<reco::GenParticleCollection> gps;
   iEvent.getByToken(gpToken_, gps);
-  
+
   using namespace ::helper;
   const size_t n = gps->size();
   flags_.clear();
@@ -309,18 +308,19 @@ void TrackingParticleSelectorByGen::produce(edm::Event& iEvent, const edm::Event
       }
     }
   }
-  
+
   auto out = std::make_unique<TrackingParticleCollection>();
   out->reserve(n);
-  
-  for (auto&& tp: *tps) {
-    auto& associatedGenParticles = tp.genParticles();
-    
+
+  for (auto &&tp : *tps) {
+    auto &associatedGenParticles = tp.genParticles();
+
     bool isSelected = false;
-    for (auto&& assocGen: associatedGenParticles) {
-      if (flags_[assocGen.index()] == keep) isSelected = true;
+    for (auto &&assocGen : associatedGenParticles) {
+      if (flags_[assocGen.index()] == keep)
+        isSelected = true;
     }
-    
+
     if (isSelected) {
       out->emplace_back(tp);
     }
@@ -328,12 +328,12 @@ void TrackingParticleSelectorByGen::produce(edm::Event& iEvent, const edm::Event
   iEvent.put(std::move(out));
 }
 
-void TrackingParticleSelectorByGen::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+void TrackingParticleSelectorByGen::fillDescriptions(edm::ConfigurationDescriptions &descriptions) {
   edm::ParameterSetDescription desc;
   desc.add<edm::InputTag>("trackingParticles", edm::InputTag("mix", "MergedTrackTruth"));
   desc.add<edm::InputTag>("genParticles", edm::InputTag("genParticles"));
   desc.add<vector<string>>("select");
-  
+
   descriptions.add("selectTPs", desc);
 }
 

--- a/SimTracker/TrackAssociation/python/digiSimLinkPruner_cfi.py
+++ b/SimTracker/TrackAssociation/python/digiSimLinkPruner_cfi.py
@@ -1,0 +1,18 @@
+import FWCore.ParameterSet.Config as cms
+
+prunedDigiSimLinks = cms.EDProducer("DigiSimLinkPruner",
+    stripSimLinkSrc = cms.InputTag("simSiStripDigis"),
+    trackingParticles = cms.InputTag('prunedTrackingParticles')
+)
+
+_prunedDigiSimLinks_phase2 = cms.EDProducer("DigiSimLinkPruner",
+    pixelSimLinkSrc = cms.InputTag("simSiPixelDigis", "Pixel"),
+    phase2OTSimLinkSrc = cms.InputTag("simSiPixelDigis","Tracker"),
+    trackingParticles = cms.InputTag('prunedTrackingParticles')
+)
+
+from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
+phase2_tracker.toReplaceWith( 
+    prunedDigiSimLinks,
+    _prunedDigiSimLinks_phase2
+)

--- a/SimTracker/TrackAssociation/python/trackMCMatch_cfi.py
+++ b/SimTracker/TrackAssociation/python/trackMCMatch_cfi.py
@@ -4,7 +4,8 @@ trackMCMatch = cms.EDProducer("MCTrackMatcher",
     trackingParticles = cms.InputTag("mix","MergedTrackTruth"),
     tracks = cms.InputTag("generalTracks"),
     genParticles = cms.InputTag("genParticles"),
-    associator = cms.string('TrackAssociatorByHits')
+    associator = cms.string('TrackAssociatorByHits'),
+    throwOnMissingTPCollection = cms.bool(True)
 )
 
 

--- a/SimTracker/TrackAssociation/python/trackPrunedMCMatchTask_cff.py
+++ b/SimTracker/TrackAssociation/python/trackPrunedMCMatchTask_cff.py
@@ -1,0 +1,23 @@
+import FWCore.ParameterSet.Config as cms
+
+from SimTracker.TrackerHitAssociation.tpClusterProducer_cfi import *
+from SimTracker.TrackAssociatorProducers.quickTrackAssociatorByHits_cfi import *
+
+prunedTpClusterProducer = tpClusterProducer.clone(
+    trackingParticleSrc = cms.InputTag("prunedTrackingParticles"),
+    pixelSimLinkSrc = cms.InputTag("prunedDigiSimLinks", "siPixel"),
+    stripSimLinkSrc = cms.InputTag("prunedDigiSimLinks", "siStrip")
+)
+
+quickPrunedTrackAssociatorByHits = quickTrackAssociatorByHits.clone(
+    cluster2TPSrc = "prunedTpClusterProducer"
+)
+
+prunedTrackMCMatch = cms.EDProducer("MCTrackMatcher",
+    trackingParticles = cms.InputTag("prunedTrackingParticles"),
+    tracks = cms.InputTag("generalTracks"),
+    genParticles = cms.InputTag("genParticles"),
+    associator = cms.string('quickPrunedTrackAssociatorByHits')
+)
+
+trackPrunedMCMatchTask = cms.Task(prunedTpClusterProducer,quickPrunedTrackAssociatorByHits,prunedTrackMCMatch)

--- a/SimTracker/TrackAssociation/python/trackPrunedMCMatchTask_cff.py
+++ b/SimTracker/TrackAssociation/python/trackPrunedMCMatchTask_cff.py
@@ -12,6 +12,18 @@ prunedTpClusterProducer = tpClusterProducer.clone(
     throwOnMissingCollections = cms.bool(False)
 )
 
+from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
+_phase2_prunedTpClusterProducer = tpClusterProducer.clone(
+    trackingParticleSrc = cms.InputTag("prunedTrackingParticles"),
+    pixelSimLinkSrc = cms.InputTag("prunedDigiSimLinks", "siPixel"),
+    phase2OTSimLinkSrc = cms.InputTag("prunedDigiSimLinks", "siphase2OT"),
+    throwOnMissingCollections = cms.bool(False)
+)
+phase2_tracker.toReplaceWith( 
+    prunedTpClusterProducer,
+    _phase2_prunedTpClusterProducer
+)
+
 quickPrunedTrackAssociatorByHits = quickTrackAssociatorByHits.clone(
     cluster2TPSrc = "prunedTpClusterProducer"
 )

--- a/SimTracker/TrackAssociation/python/trackPrunedMCMatchTask_cff.py
+++ b/SimTracker/TrackAssociation/python/trackPrunedMCMatchTask_cff.py
@@ -9,7 +9,7 @@ prunedTpClusterProducer = tpClusterProducer.clone(
     trackingParticleSrc = cms.InputTag("prunedTrackingParticles"),
     pixelSimLinkSrc = cms.InputTag("prunedDigiSimLinks", "siPixel"),
     stripSimLinkSrc = cms.InputTag("prunedDigiSimLinks", "siStrip"),
-    throwOnMissingCollections = cms.bool(False)
+    throwOnMissingCollections = cms.bool(True)
 )
 
 from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
@@ -17,7 +17,7 @@ _phase2_prunedTpClusterProducer = tpClusterProducer.clone(
     trackingParticleSrc = cms.InputTag("prunedTrackingParticles"),
     pixelSimLinkSrc = cms.InputTag("prunedDigiSimLinks", "siPixel"),
     phase2OTSimLinkSrc = cms.InputTag("prunedDigiSimLinks", "siphase2OT"),
-    throwOnMissingCollections = cms.bool(False)
+    throwOnMissingCollections = cms.bool(True)
 )
 phase2_tracker.toReplaceWith( 
     prunedTpClusterProducer,
@@ -33,7 +33,7 @@ prunedTrackMCMatch = cms.EDProducer("MCTrackMatcher",
     tracks = cms.InputTag("generalTracks"),
     genParticles = cms.InputTag("genParticles"),
     associator = cms.string('quickPrunedTrackAssociatorByHits'),
-    throwOnMissingTPCollection = cms.bool(False)
+    throwOnMissingTPCollection = cms.bool(True)
 )
 
 trackPrunedMCMatchTask = cms.Task(prunedTpClusterProducer,quickPrunedTrackAssociatorByHits,prunedTrackMCMatch)

--- a/SimTracker/TrackAssociation/python/trackPrunedMCMatchTask_cff.py
+++ b/SimTracker/TrackAssociation/python/trackPrunedMCMatchTask_cff.py
@@ -8,7 +8,8 @@ from Configuration.Eras.Modifier_fastSim_cff import fastSim
 prunedTpClusterProducer = tpClusterProducer.clone(
     trackingParticleSrc = cms.InputTag("prunedTrackingParticles"),
     pixelSimLinkSrc = cms.InputTag("prunedDigiSimLinks", "siPixel"),
-    stripSimLinkSrc = cms.InputTag("prunedDigiSimLinks", "siStrip")
+    stripSimLinkSrc = cms.InputTag("prunedDigiSimLinks", "siStrip"),
+    throwOnMissingCollections = cms.bool(False)
 )
 
 quickPrunedTrackAssociatorByHits = quickTrackAssociatorByHits.clone(
@@ -19,7 +20,8 @@ prunedTrackMCMatch = cms.EDProducer("MCTrackMatcher",
     trackingParticles = cms.InputTag("prunedTrackingParticles"),
     tracks = cms.InputTag("generalTracks"),
     genParticles = cms.InputTag("genParticles"),
-    associator = cms.string('quickPrunedTrackAssociatorByHits')
+    associator = cms.string('quickPrunedTrackAssociatorByHits'),
+    throwOnMissingTPCollection = cms.bool(False)
 )
 
 trackPrunedMCMatchTask = cms.Task(prunedTpClusterProducer,quickPrunedTrackAssociatorByHits,prunedTrackMCMatch)

--- a/SimTracker/TrackAssociation/python/trackPrunedMCMatchTask_cff.py
+++ b/SimTracker/TrackAssociation/python/trackPrunedMCMatchTask_cff.py
@@ -3,6 +3,8 @@ import FWCore.ParameterSet.Config as cms
 from SimTracker.TrackerHitAssociation.tpClusterProducer_cfi import *
 from SimTracker.TrackAssociatorProducers.quickTrackAssociatorByHits_cfi import *
 
+from Configuration.Eras.Modifier_fastSim_cff import fastSim
+
 prunedTpClusterProducer = tpClusterProducer.clone(
     trackingParticleSrc = cms.InputTag("prunedTrackingParticles"),
     pixelSimLinkSrc = cms.InputTag("prunedDigiSimLinks", "siPixel"),
@@ -21,3 +23,14 @@ prunedTrackMCMatch = cms.EDProducer("MCTrackMatcher",
 )
 
 trackPrunedMCMatchTask = cms.Task(prunedTpClusterProducer,quickPrunedTrackAssociatorByHits,prunedTrackMCMatch)
+
+
+
+from Configuration.Eras.Modifier_fastSim_cff import fastSim
+fastSim.toReplaceWith(quickTrackAssociatorByHits, quickPrunedTrackAssociatorByHits.clone(
+    useClusterTPAssociation = cms.bool(False),
+    associateStrip = cms.bool(False),
+    associatePixel = cms.bool(False),
+))
+
+fastSim.toModify(trackPrunedMCMatchTask, lambda x: x.remove(prunedTpClusterProducer))

--- a/SimTracker/TrackAssociation/python/trackPrunedMCMatchTask_cff.py
+++ b/SimTracker/TrackAssociation/python/trackPrunedMCMatchTask_cff.py
@@ -4,6 +4,7 @@ from SimTracker.TrackerHitAssociation.tpClusterProducer_cfi import *
 from SimTracker.TrackAssociatorProducers.quickTrackAssociatorByHits_cfi import *
 
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
+from Configuration.Eras.Modifier_bParking_cff import bParking
 
 prunedTpClusterProducer = tpClusterProducer.clone(
     trackingParticleSrc = cms.InputTag("prunedTrackingParticles"),
@@ -36,15 +37,18 @@ prunedTrackMCMatch = cms.EDProducer("MCTrackMatcher",
     throwOnMissingTPCollection = cms.bool(True)
 )
 
-trackPrunedMCMatchTask = cms.Task(prunedTpClusterProducer,quickPrunedTrackAssociatorByHits,prunedTrackMCMatch)
+trackPrunedMCMatchTask = cms.Task()
+
+_bParking_trackPrunedMCMatchTask = cms.Task(prunedTpClusterProducer,quickPrunedTrackAssociatorByHits,prunedTrackMCMatch)
+bParking.toReplaceWith(trackPrunedMCMatchTask,_bParking_trackPrunedMCMatchTask)
 
 
 
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
-fastSim.toReplaceWith(quickTrackAssociatorByHits, quickPrunedTrackAssociatorByHits.clone(
+(fastSim & bParking).toReplaceWith(quickTrackAssociatorByHits, quickPrunedTrackAssociatorByHits.clone(
     useClusterTPAssociation = cms.bool(False),
     associateStrip = cms.bool(False),
     associatePixel = cms.bool(False),
 ))
 
-fastSim.toModify(trackPrunedMCMatchTask, lambda x: x.remove(prunedTpClusterProducer))
+(fastSim & bParking).toModify(trackPrunedMCMatchTask, lambda x: x.remove(prunedTpClusterProducer))

--- a/SimTracker/TrackAssociation/python/trackingParticlePrunerByGen_cfi.py
+++ b/SimTracker/TrackAssociation/python/trackingParticlePrunerByGen_cfi.py
@@ -1,0 +1,10 @@
+import FWCore.ParameterSet.Config as cms
+
+prunedTrackingParticles = cms.EDProducer("TrackingParticleSelectorByGen",
+    select = cms.vstring(
+        "drop  *", # this is the default
+        "keep++ (400 < abs(pdgId) < 600) || (4000 < abs(pdgId) < 6000)",   # keep decays for BPH studies
+        "drop status != 1",                                                # keep only status == 1
+        "drop charge == 0"
+    )
+)

--- a/SimTracker/TrackerHitAssociation/plugins/ClusterTPAssociationProducer.cc
+++ b/SimTracker/TrackerHitAssociation/plugins/ClusterTPAssociationProducer.cc
@@ -53,6 +53,8 @@ private:
   edm::EDGetTokenT<edmNew::DetSetVector<SiStripCluster> > stripClustersToken_;
   edm::EDGetTokenT<edmNew::DetSetVector<Phase2TrackerCluster1D> > phase2OTClustersToken_;
   edm::EDGetTokenT<TrackingParticleCollection> trackingParticleToken_;
+  bool throwOnMissingCollections_;
+  
 };
 
 ClusterTPAssociationProducer::ClusterTPAssociationProducer(const edm::ParameterSet& cfg)
@@ -69,7 +71,8 @@ ClusterTPAssociationProducer::ClusterTPAssociationProducer(const edm::ParameterS
       phase2OTClustersToken_(consumes<edmNew::DetSetVector<Phase2TrackerCluster1D> >(
           cfg.getParameter<edm::InputTag>("phase2OTClusterSrc"))),
       trackingParticleToken_(
-          consumes<TrackingParticleCollection>(cfg.getParameter<edm::InputTag>("trackingParticleSrc"))) {
+          consumes<TrackingParticleCollection>(cfg.getParameter<edm::InputTag>("trackingParticleSrc"))),
+      throwOnMissingCollections_(cfg.getParameter<bool>("throwOnMissingCollections")) {
   produces<ClusterTPAssociation>();
 }
 
@@ -85,6 +88,7 @@ void ClusterTPAssociationProducer::fillDescriptions(edm::ConfigurationDescriptio
   desc.add<edm::InputTag>("stripClusterSrc", edm::InputTag("siStripClusters"));
   desc.add<edm::InputTag>("phase2OTClusterSrc", edm::InputTag("siPhase2Clusters"));
   desc.add<edm::InputTag>("trackingParticleSrc", edm::InputTag("mix", "MergedTrackTruth"));
+  desc.add<bool>("throwOnMissingCollections", true);
   descriptions.add("tpClusterProducerDefault", desc);
 }
 
@@ -92,15 +96,27 @@ void ClusterTPAssociationProducer::produce(edm::StreamID, edm::Event& iEvent, co
   // Pixel DigiSimLink
   edm::Handle<edm::DetSetVector<PixelDigiSimLink> > sipixelSimLinks;
   //  iEvent.getByLabel(_pixelSimLinkSrc, sipixelSimLinks);
-  iEvent.getByToken(sipixelSimLinksToken_, sipixelSimLinks);
+  auto pixelSimLinksFound = iEvent.getByToken(sipixelSimLinksToken_, sipixelSimLinks);
+  if (not throwOnMissingCollections_ and not pixelSimLinksFound) {
+    auto clusterTPList = std::make_unique<ClusterTPAssociation>();
+    iEvent.put(std::move(clusterTPList));
+  }
 
   // SiStrip DigiSimLink
   edm::Handle<edm::DetSetVector<StripDigiSimLink> > sistripSimLinks;
-  iEvent.getByToken(sistripSimLinksToken_, sistripSimLinks);
+  auto stripSimLinksFound = iEvent.getByToken(sistripSimLinksToken_, sistripSimLinks);
+  if (not throwOnMissingCollections_ and not stripSimLinksFound) {
+    auto clusterTPList = std::make_unique<ClusterTPAssociation>();
+    iEvent.put(std::move(clusterTPList));
+  }
 
   // Phase2 OT DigiSimLink
   edm::Handle<edm::DetSetVector<PixelDigiSimLink> > siphase2OTSimLinks;
-  iEvent.getByToken(siphase2OTSimLinksToken_, siphase2OTSimLinks);
+  auto phase2OTSimLinksFound = iEvent.getByToken(siphase2OTSimLinksToken_, siphase2OTSimLinks);
+  if (not throwOnMissingCollections_ and not phase2OTSimLinksFound) {
+    auto clusterTPList = std::make_unique<ClusterTPAssociation>();
+    iEvent.put(std::move(clusterTPList));
+  }
 
   // Pixel Cluster
   edm::Handle<edmNew::DetSetVector<SiPixelCluster> > pixelClusters;
@@ -116,7 +132,11 @@ void ClusterTPAssociationProducer::produce(edm::StreamID, edm::Event& iEvent, co
 
   // TrackingParticle
   edm::Handle<TrackingParticleCollection> TPCollectionH;
-  iEvent.getByToken(trackingParticleToken_, TPCollectionH);
+  auto tpFound = iEvent.getByToken(trackingParticleToken_, TPCollectionH);
+  if (not throwOnMissingCollections_ and not tpFound) {
+    auto clusterTPList = std::make_unique<ClusterTPAssociation>();
+    iEvent.put(std::move(clusterTPList));
+  }
 
   auto clusterTPList = std::make_unique<ClusterTPAssociation>(TPCollectionH);
 

--- a/SimTracker/TrackerHitAssociation/plugins/ClusterTPAssociationProducer.cc
+++ b/SimTracker/TrackerHitAssociation/plugins/ClusterTPAssociationProducer.cc
@@ -111,6 +111,7 @@ void ClusterTPAssociationProducer::produce(edm::StreamID, edm::Event& iEvent, co
   if (not throwOnMissingCollections_ and foundPixelClusters and not pixelSimLinksFound) {
     auto clusterTPList = std::make_unique<ClusterTPAssociation>();
     iEvent.put(std::move(clusterTPList));
+    return;
   }
 
   // SiStrip DigiSimLink
@@ -119,6 +120,7 @@ void ClusterTPAssociationProducer::produce(edm::StreamID, edm::Event& iEvent, co
   if (not throwOnMissingCollections_ and foundStripClusters and not stripSimLinksFound) {
     auto clusterTPList = std::make_unique<ClusterTPAssociation>();
     iEvent.put(std::move(clusterTPList));
+    return;
   }
 
   // Phase2 OT DigiSimLink
@@ -127,6 +129,7 @@ void ClusterTPAssociationProducer::produce(edm::StreamID, edm::Event& iEvent, co
   if (not throwOnMissingCollections_ and foundPhase2OTClusters and not phase2OTSimLinksFound) {
     auto clusterTPList = std::make_unique<ClusterTPAssociation>();
     iEvent.put(std::move(clusterTPList));
+    return;
   }
 
   // TrackingParticle
@@ -135,6 +138,7 @@ void ClusterTPAssociationProducer::produce(edm::StreamID, edm::Event& iEvent, co
   if (not throwOnMissingCollections_ and not tpFound) {
     auto clusterTPList = std::make_unique<ClusterTPAssociation>();
     iEvent.put(std::move(clusterTPList));
+    return;
   }
 
   auto clusterTPList = std::make_unique<ClusterTPAssociation>(TPCollectionH);

--- a/SimTracker/TrackerHitAssociation/plugins/ClusterTPAssociationProducer.cc
+++ b/SimTracker/TrackerHitAssociation/plugins/ClusterTPAssociationProducer.cc
@@ -92,31 +92,6 @@ void ClusterTPAssociationProducer::fillDescriptions(edm::ConfigurationDescriptio
 }
 
 void ClusterTPAssociationProducer::produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& es) const {
-  // Pixel DigiSimLink
-  edm::Handle<edm::DetSetVector<PixelDigiSimLink> > sipixelSimLinks;
-  //  iEvent.getByLabel(_pixelSimLinkSrc, sipixelSimLinks);
-  auto pixelSimLinksFound = iEvent.getByToken(sipixelSimLinksToken_, sipixelSimLinks);
-  if (not throwOnMissingCollections_ and not pixelSimLinksFound) {
-    auto clusterTPList = std::make_unique<ClusterTPAssociation>();
-    iEvent.put(std::move(clusterTPList));
-  }
-
-  // SiStrip DigiSimLink
-  edm::Handle<edm::DetSetVector<StripDigiSimLink> > sistripSimLinks;
-  auto stripSimLinksFound = iEvent.getByToken(sistripSimLinksToken_, sistripSimLinks);
-  if (not throwOnMissingCollections_ and not stripSimLinksFound) {
-    auto clusterTPList = std::make_unique<ClusterTPAssociation>();
-    iEvent.put(std::move(clusterTPList));
-  }
-
-  // Phase2 OT DigiSimLink
-  edm::Handle<edm::DetSetVector<PixelDigiSimLink> > siphase2OTSimLinks;
-  auto phase2OTSimLinksFound = iEvent.getByToken(siphase2OTSimLinksToken_, siphase2OTSimLinks);
-  if (not throwOnMissingCollections_ and not phase2OTSimLinksFound) {
-    auto clusterTPList = std::make_unique<ClusterTPAssociation>();
-    iEvent.put(std::move(clusterTPList));
-  }
-
   // Pixel Cluster
   edm::Handle<edmNew::DetSetVector<SiPixelCluster> > pixelClusters;
   bool foundPixelClusters = iEvent.getByToken(pixelClustersToken_, pixelClusters);
@@ -128,6 +103,31 @@ void ClusterTPAssociationProducer::produce(edm::StreamID, edm::Event& iEvent, co
   // Phase2 Cluster
   edm::Handle<edmNew::DetSetVector<Phase2TrackerCluster1D> > phase2OTClusters;
   bool foundPhase2OTClusters = iEvent.getByToken(phase2OTClustersToken_, phase2OTClusters);
+
+  // Pixel DigiSimLink
+  edm::Handle<edm::DetSetVector<PixelDigiSimLink> > sipixelSimLinks;
+  //  iEvent.getByLabel(_pixelSimLinkSrc, sipixelSimLinks);
+  auto pixelSimLinksFound = iEvent.getByToken(sipixelSimLinksToken_, sipixelSimLinks);
+  if (not throwOnMissingCollections_ and foundPixelClusters and not pixelSimLinksFound) {
+    auto clusterTPList = std::make_unique<ClusterTPAssociation>();
+    iEvent.put(std::move(clusterTPList));
+  }
+
+  // SiStrip DigiSimLink
+  edm::Handle<edm::DetSetVector<StripDigiSimLink> > sistripSimLinks;
+  auto stripSimLinksFound = iEvent.getByToken(sistripSimLinksToken_, sistripSimLinks);
+  if (not throwOnMissingCollections_ and foundStripClusters and not stripSimLinksFound) {
+    auto clusterTPList = std::make_unique<ClusterTPAssociation>();
+    iEvent.put(std::move(clusterTPList));
+  }
+
+  // Phase2 OT DigiSimLink
+  edm::Handle<edm::DetSetVector<PixelDigiSimLink> > siphase2OTSimLinks;
+  auto phase2OTSimLinksFound = iEvent.getByToken(siphase2OTSimLinksToken_, siphase2OTSimLinks);
+  if (not throwOnMissingCollections_ and foundPhase2OTClusters and not phase2OTSimLinksFound) {
+    auto clusterTPList = std::make_unique<ClusterTPAssociation>();
+    iEvent.put(std::move(clusterTPList));
+  }
 
   // TrackingParticle
   edm::Handle<TrackingParticleCollection> TPCollectionH;

--- a/SimTracker/TrackerHitAssociation/plugins/ClusterTPAssociationProducer.cc
+++ b/SimTracker/TrackerHitAssociation/plugins/ClusterTPAssociationProducer.cc
@@ -54,7 +54,6 @@ private:
   edm::EDGetTokenT<edmNew::DetSetVector<Phase2TrackerCluster1D> > phase2OTClustersToken_;
   edm::EDGetTokenT<TrackingParticleCollection> trackingParticleToken_;
   bool throwOnMissingCollections_;
-  
 };
 
 ClusterTPAssociationProducer::ClusterTPAssociationProducer(const edm::ParameterSet& cfg)


### PR DESCRIPTION
#### PR description:
This PR adds a way to match `generalTracks` (in AOD) and `packedPFCandidates` and `lostTracks` (in miniAOD) to a subset of  `genParticles`, using association by hit on `TrackingParticles`.
The association is performed on step3 and just replicated in the miniAOD.
Since the track association by hit needs both `TrackingParticles` and `SimLink` for pixel and strips and the `SimLink` collections are not available in RAWSIM, two plugins are created to be run in step2 to add two pruned collections and avoid adding the all the `SimLink`, which have a non negligible size.

The changes contained are:
* a plugin for pruning `TrackingParticles` in step2 based on their association to specific `GenParticles`. The genParticle selection is taken from the `GenParticlePruner` class and can be configured.
* a plugin for pruning `SimLink` collections based on the `SimTrack` association to a `TrackingParticle`
* a plugin for adding an association between `PackedCandidates` and `GenParticles` based on an existing association between tracks and `GenParticles`
* Needed configuration changes to add this to standard sequences, gated behind the bParking modifier
* bugfix from #34113 

No plugin is needed for association between tracks and `GenParticles` through `TrackingParticle` as it is already present in CMSSW (`MCTrackMatcher`).

#### PR validation:
On a B+->Psi2SK sample (one of the possible targets for this PR) we registered this increases in size, timing and memory

  | Size | Timing | Memory
-- | -- | -- | --
RAWSIM | +0.05% | +0.08% | +5MB
RECOSIM | < +0.01% | +0.07% | +2MB
AODSIM | +0.06% |   |  
MINIAODSIM | +0.4% | +0.08% | +400kB


#### if this PR is a backport please specify the original PR and why you need to backport that PR:
Backport of #33774  and #34113 for an Hackaton for GNN tracking