### PR TITLE
ParticleLevelProducer switch for jet clustering

### DIFF
--- a/GeneratorInterface/RivetInterface/interface/RivetAnalysis.h
+++ b/GeneratorInterface/RivetInterface/interface/RivetAnalysis.h
@@ -33,6 +33,7 @@ namespace Rivet {
     bool _usePromptFinalStates;
     bool _excludePromptLeptonsFromJetClustering;
     bool _excludeNeutrinosFromJetClustering;
+    bool _doJetClustering;
 
     double _particleMinPt, _particleMaxEta;
     double _lepConeSize, _lepMinPt, _lepMaxEta;
@@ -51,6 +52,7 @@ namespace Rivet {
           _usePromptFinalStates(pset.getParameter<bool>("usePromptFinalStates")),
           _excludePromptLeptonsFromJetClustering(pset.getParameter<bool>("excludePromptLeptonsFromJetClustering")),
           _excludeNeutrinosFromJetClustering(pset.getParameter<bool>("excludeNeutrinosFromJetClustering")),
+          _doJetClustering(pset.getParameter<bool>("doJetClustering")),
 
           _particleMinPt(pset.getParameter<double>("particleMinPt")),
           _particleMaxEta(pset.getParameter<double>("particleMaxEta")),
@@ -194,8 +196,10 @@ namespace Rivet {
         _photons.push_back(photon);
       }
 
-      _jets = apply<FastJets>(event, "Jets").jetsByPt(jet_cut);
-      _fatjets = apply<FastJets>(event, "FatJets").jetsByPt(fatjet_cut);
+      if (_doJetClustering) {
+        _jets = apply<FastJets>(event, "Jets").jetsByPt(jet_cut);
+        _fatjets = apply<FastJets>(event, "FatJets").jetsByPt(fatjet_cut);
+      }
       _neutrinos = apply<FinalState>(event, "Neutrinos").particlesByPt();
       _met = apply<MissingMomentum>(event, "MET").missingMomentum().p3();
 

--- a/GeneratorInterface/RivetInterface/python/particleLevel_cfi.py
+++ b/GeneratorInterface/RivetInterface/python/particleLevel_cfi.py
@@ -6,6 +6,7 @@ particleLevel = cms.EDProducer("ParticleLevelProducer",
     usePromptFinalStates = cms.bool(True), # for leptons, photons, neutrinos
     excludePromptLeptonsFromJetClustering = cms.bool(True),
     excludeNeutrinosFromJetClustering = cms.bool(True),
+    doJetClustering = cms.bool(True),
     
     particleMinPt  = cms.double(0.),
     particleMaxEta = cms.double(5.), # HF range. Maximum 6.0 on MiniAOD


### PR DESCRIPTION
#### PR description:

Allow for deactivation of jet clustering in ParticleLevelProducer, to speed up NanoAod production (uses GenJets instead of Rivet jets).

#### PR validation:

```
with jet clustering:
TimeReport   0.060156     0.060156     0.060156  particleLevel
without:
TimeReport   0.028903     0.028903     0.028903  particleLevel
```

Dressed leptons in both output files are identical.
