### PR TITLE
Remove 0 t 2d template warning backport

### DIFF
--- a/CalibTracker/SiPixelESProducers/plugins/SiPixel2DTemplateDBObjectESProducer.cc
+++ b/CalibTracker/SiPixelESProducers/plugins/SiPixel2DTemplateDBObjectESProducer.cc
@@ -59,7 +59,8 @@ std::shared_ptr<const SiPixel2DTemplateDBObject> SiPixel2DTemplateDBObjectESProd
 
   const auto& dbobject = iRecord.get(dbToken_);
 
-  if (std::fabs(theMagField - dbobject.sVector()[22]) > 0.1)
+  if ( (theMagField > 0.1) && (std::fabs(theMagField - dbobject.sVector()[22]) > 0.1))
+      //2D templates not actually used at 0T, so don't print warning
     edm::LogWarning("UnexpectedMagneticFieldUsingNonIdealPixel2DTemplate")
         << "Magnetic field is " << theMagField << " Template Magnetic field is " << dbobject.sVector()[22];
 

--- a/CalibTracker/SiPixelESProducers/plugins/SiPixel2DTemplateDBObjectESProducer.cc
+++ b/CalibTracker/SiPixelESProducers/plugins/SiPixel2DTemplateDBObjectESProducer.cc
@@ -59,8 +59,8 @@ std::shared_ptr<const SiPixel2DTemplateDBObject> SiPixel2DTemplateDBObjectESProd
 
   const auto& dbobject = iRecord.get(dbToken_);
 
-  if ( (theMagField > 0.1) && (std::fabs(theMagField - dbobject.sVector()[22]) > 0.1))
-      //2D templates not actually used at 0T, so don't print warning
+  if ((theMagField > 0.1) && (std::fabs(theMagField - dbobject.sVector()[22]) > 0.1))
+    //2D templates not actually used at 0T, so don't print warning
     edm::LogWarning("UnexpectedMagneticFieldUsingNonIdealPixel2DTemplate")
         << "Magnetic field is " << theMagField << " Template Magnetic field is " << dbobject.sVector()[22];
 


### PR DESCRIPTION
Backport of #34390 to 11_3_X. Needed because CRUZET data is taking in 11_3_X and we would like to fix this error message for CRUZET