### PR TITLE
support global::OutputModule<ExternalWork>

### DIFF
--- a/FWCore/Framework/interface/global/OutputModuleBase.h
+++ b/FWCore/Framework/interface/global/OutputModuleBase.h
@@ -132,6 +132,10 @@ namespace edm {
       void doEndStream(StreamID id) { doEndStream_(id); }
 
       bool doEvent(EventTransitionInfo const&, ActivityRegistry*, ModuleCallingContext const*);
+      void doAcquire(EventTransitionInfo const&,
+                     ActivityRegistry*,
+                     ModuleCallingContext const*,
+                     WaitingTaskWithArenaHolder&);
       //For now this is a placeholder
       /*virtual*/ void preActionBeforeRunEventAsync(WaitingTaskHolder iTask,
                                                     ModuleCallingContext const& iModuleCallingContext,
@@ -264,10 +268,11 @@ namespace edm {
       virtual void doEndLuminosityBlockSummary_(LuminosityBlockForOutput const&, EventSetup const&) {}
       virtual void doRespondToOpenInputFile_(FileBlock const&) {}
       virtual void doRespondToCloseInputFile_(FileBlock const&) {}
+      virtual void doAcquire_(StreamID, EventForOutput const&, WaitingTaskWithArenaHolder&) {}
 
       virtual void setProcessesWithSelectedMergeableRunProducts(std::set<std::string> const&) {}
 
-      bool hasAcquire() const { return false; }
+      virtual bool hasAcquire() const { return false; }
       bool hasAccumulator() const { return false; }
 
       void keepThisBranch(BranchDescription const& desc,

--- a/FWCore/Framework/interface/global/outputmoduleAbilityToImplementor.h
+++ b/FWCore/Framework/interface/global/outputmoduleAbilityToImplementor.h
@@ -131,6 +131,24 @@ namespace edm {
       };
 
       template <typename T>
+      class ExternalWork : public virtual T {
+      public:
+        ExternalWork(edm::ParameterSet const& iPSet) : OutputModuleBase(iPSet) {}
+        ExternalWork(ExternalWork const&) = delete;
+        ExternalWork& operator=(ExternalWork const&) = delete;
+        ~ExternalWork() noexcept(false) override{};
+
+      private:
+        bool hasAcquire() const override { return true; }
+
+        void doAcquire_(StreamID id, EventForOutput const& event, WaitingTaskWithArenaHolder& holder) final {
+          acquire(id, event, holder);
+        }
+
+        virtual void acquire(StreamID, EventForOutput const&, WaitingTaskWithArenaHolder) const = 0;
+      };
+
+      template <typename T>
       struct AbilityToImplementor;
 
       template <>
@@ -151,6 +169,11 @@ namespace edm {
       template <typename C>
       struct AbilityToImplementor<edm::StreamCache<C>> {
         typedef edm::global::outputmodule::StreamCacheHolder<edm::global::OutputModuleBase, C> Type;
+      };
+
+      template <>
+      struct AbilityToImplementor<edm::ExternalWork> {
+        typedef edm::global::outputmodule::ExternalWork<edm::global::OutputModuleBase> Type;
       };
 
     }  // namespace outputmodule

--- a/FWCore/Framework/src/WorkerT.cc
+++ b/FWCore/Framework/src/WorkerT.cc
@@ -248,6 +248,13 @@ namespace edm {
   }
 
   template <>
+  inline void WorkerT<global::OutputModuleBase>::implDoAcquire(EventTransitionInfo const& info,
+                                                               ModuleCallingContext const* mcc,
+                                                               WaitingTaskWithArenaHolder& holder) {
+    module_->doAcquire(info, activityRegistry(), mcc, holder);
+  }
+
+  template <>
   inline void WorkerT<stream::EDProducerAdaptorBase>::implDoAcquire(EventTransitionInfo const& info,
                                                                     ModuleCallingContext const* mcc,
                                                                     WaitingTaskWithArenaHolder& holder) {

--- a/FWCore/Framework/src/global/OutputModuleBase.cc
+++ b/FWCore/Framework/src/global/OutputModuleBase.cc
@@ -30,6 +30,7 @@
 #include "FWCore/Framework/interface/TriggerNamesService.h"
 #include "FWCore/Framework/src/EventSignalsSentry.h"
 #include "FWCore/Framework/src/PreallocationConfiguration.h"
+#include "FWCore/Framework/src/EventAcquireSignalsSentry.h"
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
@@ -274,6 +275,16 @@ namespace edm {
         }
       }
       return true;
+    }
+
+    void OutputModuleBase::doAcquire(EventTransitionInfo const& info,
+                                     ActivityRegistry* act,
+                                     ModuleCallingContext const* mcc,
+                                     WaitingTaskWithArenaHolder& holder) {
+      EventForOutput e(info, moduleDescription_, mcc);
+      e.setConsumer(this);
+      EventAcquireSignalsSentry sentry(act, mcc);
+      this->doAcquire_(e.streamID(), e, holder);
     }
 
     bool OutputModuleBase::doBeginRun(RunTransitionInfo const& info, ModuleCallingContext const* mcc) {

--- a/FWCore/Framework/test/BuildFile.xml
+++ b/FWCore/Framework/test/BuildFile.xml
@@ -395,3 +395,4 @@
 <test name="testFWCoreFrameworkNonEventOrdering" command="test_non_event_ordering.sh"/>
 <test name="testFWCoreFramework1ThreadESPrefetch" command="run_test_1_thread_es_prefetching.sh"/>
 <test name="testFWCoreFrameworkModuleDeletion" command="run_module_delete_tests.sh"/>
+<test name="testFWCoreFrameworkExternalWorkOutputModule" command="cmsRun ${LOCALTOP}/src/FWCore/Framework/test/testExternalWorkGlobalOutputModule_cfg.py"/>

--- a/FWCore/Framework/test/testExternalWorkGlobalOutputModule_cfg.py
+++ b/FWCore/Framework/test/testExternalWorkGlobalOutputModule_cfg.py
@@ -1,0 +1,50 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("PROD")
+
+import FWCore.Framework.test.cmsExceptionsFatalOption_cff
+process.options = cms.untracked.PSet(
+    wantSummary = cms.untracked.bool(True),
+    Rethrow = FWCore.Framework.test.cmsExceptionsFatalOption_cff.Rethrow
+)
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(99)
+)
+
+process.source = cms.Source("EmptySource")
+
+process.f1 = cms.EDFilter("TestFilterModule",
+    acceptValue = cms.untracked.int32(30),
+    onlyOne = cms.untracked.bool(True)
+)
+
+process.outp = cms.OutputModule("ExternalWorkSewerModule",
+                                shouldPass = cms.int32(3),
+    name = cms.string('for_p'),
+    SelectEvents = cms.untracked.PSet(
+        SelectEvents = cms.vstring('p') 
+    )
+)
+
+process.outNone = cms.OutputModule("ExternalWorkSewerModule",
+    shouldPass = cms.int32(99),
+    name = cms.string('for_none')
+)
+
+process.outpempty = cms.OutputModule("ExternalWorkSewerModule",
+    shouldPass = cms.int32(99),
+    name = cms.string('pEmpty'),
+    SelectEvents = cms.untracked.PSet(
+        SelectEvents = cms.vstring('pEmpty')
+    )
+)
+
+process.pEmpty = cms.Path()
+process.p = cms.Path(process.f1)
+
+process.e1 = cms.EndPath(process.outp)
+process.e2 = cms.EndPath(process.outNone)
+process.e3 = cms.EndPath(process.outpempty)
+
+


### PR DESCRIPTION
#### PR description:

Extend the framework to allow edm::global::OutputModule<edm::ExternalWork> to function.

#### PR validation:

Newly added unit test passes. Also tested with a not-yet-committed OutputModule which uses the facility.