### PR TITLE
Add esConsumes for code using TransientTrack::setES

### DIFF
--- a/Alignment/ReferenceTrajectories/plugins/TwoBodyDecayTrajectoryFactory.cc
+++ b/Alignment/ReferenceTrajectories/plugins/TwoBodyDecayTrajectoryFactory.cc
@@ -7,7 +7,7 @@
 #include "Alignment/ReferenceTrajectories/interface/TrajectoryFactoryPlugin.h"
 
 #include "TrackingTools/TransientTrack/interface/TransientTrack.h"
-
+#include "Geometry/Records/interface/GlobalTrackingGeometryRecord.h"
 #include "Geometry/CommonDetUnit/interface/TrackerGeomDet.h"
 
 #include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
@@ -93,15 +93,18 @@ const TrajectoryFactoryBase::ReferenceTrajectoryCollection TwoBodyDecayTrajector
   edm::ESHandle<MagneticField> magneticField;
   setup.get<IdealMagneticFieldRecord>().get(magneticField);
 
+  edm::ESHandle<GlobalTrackingGeometry> trackingGeometry;
+  setup.get<GlobalTrackingGeometryRecord>().get(trackingGeometry);
+
   if (tracks.size() == 2) {
     // produce transient tracks from persistent tracks
     std::vector<reco::TransientTrack> transientTracks(2);
 
     transientTracks[0] = reco::TransientTrack(*tracks[0].second, magneticField.product());
-    transientTracks[0].setES(setup);
+    transientTracks[0].setTrackingGeometry(trackingGeometry);
 
     transientTracks[1] = reco::TransientTrack(*tracks[1].second, magneticField.product());
-    transientTracks[1].setES(setup);
+    transientTracks[1].setTrackingGeometry(trackingGeometry);
 
     // estimate the decay parameters
     VirtualMeasurement vm(thePrimaryMass, thePrimaryWidth, theSecondaryMass, beamSpot);
@@ -131,6 +134,9 @@ const TrajectoryFactoryBase::ReferenceTrajectoryCollection TwoBodyDecayTrajector
   edm::ESHandle<MagneticField> magneticField;
   setup.get<IdealMagneticFieldRecord>().get(magneticField);
 
+  edm::ESHandle<GlobalTrackingGeometry> trackingGeometry;
+  setup.get<GlobalTrackingGeometryRecord>().get(trackingGeometry);
+
   if (tracks.size() == 2 && external.size() == 2) {
     if (external[0].isValid() && external[1].isValid())  // Include external estimates
     {
@@ -138,10 +144,10 @@ const TrajectoryFactoryBase::ReferenceTrajectoryCollection TwoBodyDecayTrajector
       std::vector<reco::TransientTrack> transientTracks(2);
 
       transientTracks[0] = reco::TransientTrack(*tracks[0].second, magneticField.product());
-      transientTracks[0].setES(setup);
+      transientTracks[0].setTrackingGeometry(trackingGeometry);
 
       transientTracks[1] = reco::TransientTrack(*tracks[1].second, magneticField.product());
-      transientTracks[1].setES(setup);
+      transientTracks[1].setTrackingGeometry(trackingGeometry);
 
       // estimate the decay parameters. the transient tracks are not really associated to the
       // the external tsos, but this is o.k., because the only information retrieved from them

--- a/CommonTools/RecoUtils/interface/PFCand_AssoMapAlgos.h
+++ b/CommonTools/RecoUtils/interface/PFCand_AssoMapAlgos.h
@@ -48,15 +48,13 @@ public:
 
   //create the pf candidate to vertex association and the inverse map
   std::pair<std::unique_ptr<PFCandToVertexAssMap>, std::unique_ptr<VertexToPFCandAssMap>> createMappings(
-      edm::Handle<reco::PFCandidateCollection> pfCandH, const edm::EventSetup& iSetup);
+      edm::Handle<reco::PFCandidateCollection> pfCandH);
 
   //create the pf candidate to vertex association map
-  std::unique_ptr<PFCandToVertexAssMap> CreatePFCandToVertexMap(edm::Handle<reco::PFCandidateCollection>,
-                                                                const edm::EventSetup&);
+  std::unique_ptr<PFCandToVertexAssMap> CreatePFCandToVertexMap(edm::Handle<reco::PFCandidateCollection>);
 
   //create the vertex to pf candidate association map
-  std::unique_ptr<VertexToPFCandAssMap> CreateVertexToPFCandMap(edm::Handle<reco::PFCandidateCollection>,
-                                                                const edm::EventSetup&);
+  std::unique_ptr<VertexToPFCandAssMap> CreateVertexToPFCandMap(edm::Handle<reco::PFCandidateCollection>);
 
   //function to sort the vertices in the AssociationMap by the sum of (pT - pT_Error)**2
   std::unique_ptr<PFCandToVertexAssMap> SortPFCandAssociationMap(PFCandToVertexAssMap*,
@@ -77,6 +75,7 @@ private:
   edm::Handle<reco::BeamSpot> beamspotH;
 
   edm::ESHandle<MagneticField> bFieldH;
+  edm::ESHandle<GlobalTrackingGeometry> trackingGeometryH;
 };
 
 #endif

--- a/CommonTools/RecoUtils/interface/PFCand_AssoMapAlgos.h
+++ b/CommonTools/RecoUtils/interface/PFCand_AssoMapAlgos.h
@@ -16,6 +16,7 @@
 
 #include "DataFormats/ParticleFlowCandidate/interface/PFCandidate.h"
 #include "DataFormats/ParticleFlowCandidate/interface/PFCandidateFwd.h"
+#include "Geometry/Records/interface/GlobalTrackingGeometryRecord.h"
 
 namespace edm {
   class EDProductGetter;
@@ -74,7 +75,9 @@ private:
   edm::EDGetTokenT<reco::BeamSpot> token_BeamSpot_;
   edm::Handle<reco::BeamSpot> beamspotH;
 
+  const edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> token_bField_;
   edm::ESHandle<MagneticField> bFieldH;
+  const edm::ESGetToken<GlobalTrackingGeometry, GlobalTrackingGeometryRecord> token_TrackingGeometry_;
   edm::ESHandle<GlobalTrackingGeometry> trackingGeometryH;
 };
 

--- a/CommonTools/RecoUtils/interface/PF_PU_AssoMapAlgos.h
+++ b/CommonTools/RecoUtils/interface/PF_PU_AssoMapAlgos.h
@@ -93,15 +93,13 @@ public:
 
   //create the track-to-vertex and vertex-to-track maps in one go
   std::pair<std::unique_ptr<TrackToVertexAssMap>, std::unique_ptr<VertexToTrackAssMap>> createMappings(
-      edm::Handle<reco::TrackCollection> trkcollH, const edm::EventSetup& iSetup);
+      edm::Handle<reco::TrackCollection> trkcollH);
 
   //create the track to vertex association map
-  std::unique_ptr<TrackToVertexAssMap> CreateTrackToVertexMap(edm::Handle<reco::TrackCollection>,
-                                                              const edm::EventSetup&);
+  std::unique_ptr<TrackToVertexAssMap> CreateTrackToVertexMap(edm::Handle<reco::TrackCollection>);
 
   //create the vertex to track association map
-  std::unique_ptr<VertexToTrackAssMap> CreateVertexToTrackMap(edm::Handle<reco::TrackCollection>,
-                                                              const edm::EventSetup&);
+  std::unique_ptr<VertexToTrackAssMap> CreateVertexToTrackMap(edm::Handle<reco::TrackCollection>);
 
   //function to sort the vertices in the AssociationMap by the sum of (pT - pT_Error)**2
   std::unique_ptr<TrackToVertexAssMap> SortAssociationMap(TrackToVertexAssMap*, edm::Handle<reco::TrackCollection>);
@@ -119,7 +117,7 @@ protected:
   VertexStepPair FindAssociation(const reco::TrackRef&,
                                  const std::vector<reco::VertexRef>&,
                                  edm::ESHandle<MagneticField>,
-                                 const edm::EventSetup&,
+                                 edm::ESHandle<GlobalTrackingGeometry>,
                                  edm::Handle<reco::BeamSpot>,
                                  int);
 
@@ -149,7 +147,7 @@ private:
   static reco::VertexRef FindConversionVertex(const reco::TrackRef,
                                               const reco::Conversion&,
                                               edm::ESHandle<MagneticField>,
-                                              const edm::EventSetup&,
+                                              edm::ESHandle<GlobalTrackingGeometry>,
                                               edm::Handle<reco::BeamSpot>,
                                               const std::vector<reco::VertexRef>&,
                                               double);
@@ -171,7 +169,7 @@ private:
   static reco::VertexRef FindV0Vertex(const reco::TrackRef,
                                       const reco::VertexCompositeCandidate&,
                                       edm::ESHandle<MagneticField>,
-                                      const edm::EventSetup&,
+                                      edm::ESHandle<GlobalTrackingGeometry>,
                                       edm::Handle<reco::BeamSpot>,
                                       const std::vector<reco::VertexRef>&,
                                       double);
@@ -187,7 +185,7 @@ private:
   static reco::VertexRef FindNIVertex(const reco::TrackRef,
                                       const reco::PFDisplacedVertex&,
                                       edm::ESHandle<MagneticField>,
-                                      const edm::EventSetup&,
+                                      edm::ESHandle<GlobalTrackingGeometry>,
                                       edm::Handle<reco::BeamSpot>,
                                       const std::vector<reco::VertexRef>&,
                                       double);
@@ -207,6 +205,7 @@ private:
   edm::Handle<reco::BeamSpot> beamspotH;
 
   edm::ESHandle<MagneticField> bFieldH;
+  edm::ESHandle<GlobalTrackingGeometry> trackingGeometryH;
 
   bool input_doReassociation_;
   bool cleanedColls_;

--- a/CommonTools/RecoUtils/interface/PF_PU_AssoMapAlgos.h
+++ b/CommonTools/RecoUtils/interface/PF_PU_AssoMapAlgos.h
@@ -45,6 +45,7 @@
 #include "DataFormats/BeamSpot/interface/BeamSpot.h"
 
 #include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
+#include "Geometry/Records/interface/GlobalTrackingGeometryRecord.h"
 
 //
 // constants, enums and typedefs
@@ -204,7 +205,9 @@ private:
   edm::EDGetTokenT<reco::BeamSpot> token_BeamSpot_;
   edm::Handle<reco::BeamSpot> beamspotH;
 
+  const edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> token_bField_;
   edm::ESHandle<MagneticField> bFieldH;
+  const edm::ESGetToken<GlobalTrackingGeometry, GlobalTrackingGeometryRecord> token_TrackingGeometry_;
   edm::ESHandle<GlobalTrackingGeometry> trackingGeometryH;
 
   bool input_doReassociation_;

--- a/CommonTools/RecoUtils/plugins/PFCand_AssoMap.cc
+++ b/CommonTools/RecoUtils/plugins/PFCand_AssoMap.cc
@@ -78,7 +78,7 @@ void PFCand_AssoMap::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) 
   PFCand_AssoMapAlgos::GetInputCollections(iEvent, iSetup);
 
   if (asstype == "PFCandsToVertex" || asstype == "VertexToPFCands" || asstype == "Both") {
-    auto mappings = createMappings(pfCandH, iSetup);
+    auto mappings = createMappings(pfCandH);
     if (asstype == "PFCandsToVertex" || asstype == "Both") {
       iEvent.put(SortPFCandAssociationMap(&(*mappings.first), &iEvent.productGetter()));
     }

--- a/CommonTools/RecoUtils/plugins/PF_PU_AssoMap.cc
+++ b/CommonTools/RecoUtils/plugins/PF_PU_AssoMap.cc
@@ -73,7 +73,7 @@ void PF_PU_AssoMap::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   PF_PU_AssoMapAlgos::GetInputCollections(iEvent, iSetup);
 
   if (asstype == "TracksToVertex" || asstype == "VertexToTracks" || asstype == "Both") {
-    auto mappings = createMappings(trkcollH, iSetup);
+    auto mappings = createMappings(trkcollH);
     if (asstype == "TracksToVertex" || asstype == "Both") {
       iEvent.put(SortAssociationMap(&(*mappings.first), trkcollH));
     }

--- a/CommonTools/RecoUtils/src/PFCand_AssoMapAlgos.cc
+++ b/CommonTools/RecoUtils/src/PFCand_AssoMapAlgos.cc
@@ -2,7 +2,6 @@
 #include "CommonTools/RecoUtils/interface/PFCand_AssoMapAlgos.h"
 
 #include "TrackingTools/IPTools/interface/IPTools.h"
-#include "Geometry/Records/interface/GlobalTrackingGeometryRecord.h"
 
 using namespace edm;
 using namespace std;
@@ -13,7 +12,7 @@ using namespace reco;
 /*************************************************************************************/
 
 PFCand_AssoMapAlgos::PFCand_AssoMapAlgos(const edm::ParameterSet& iConfig, edm::ConsumesCollector&& iC)
-    : PF_PU_AssoMapAlgos(iConfig, iC) {
+    : PF_PU_AssoMapAlgos(iConfig, iC), token_bField_(iC.esConsumes()), token_TrackingGeometry_(iC.esConsumes()) {
   input_MaxNumAssociations_ = iConfig.getParameter<int>("MaxNumberOfAssociations");
 
   token_VertexCollection_ = iC.consumes<VertexCollection>(iConfig.getParameter<InputTag>("VertexCollection"));
@@ -34,8 +33,8 @@ void PFCand_AssoMapAlgos::GetInputCollections(edm::Event& iEvent, const edm::Eve
   //get the input vertex collection
   iEvent.getByToken(token_VertexCollection_, vtxcollH);
 
-  iSetup.get<IdealMagneticFieldRecord>().get(bFieldH);
-  iSetup.get<GlobalTrackingGeometryRecord>().get(trackingGeometryH);
+  bFieldH = iSetup.getHandle(token_bField_);
+  trackingGeometryH = iSetup.getHandle(token_TrackingGeometry_);
 }
 
 /*************************************************************************************/

--- a/CommonTools/RecoUtils/src/PFCand_AssoMapAlgos.cc
+++ b/CommonTools/RecoUtils/src/PFCand_AssoMapAlgos.cc
@@ -2,6 +2,7 @@
 #include "CommonTools/RecoUtils/interface/PFCand_AssoMapAlgos.h"
 
 #include "TrackingTools/IPTools/interface/IPTools.h"
+#include "Geometry/Records/interface/GlobalTrackingGeometryRecord.h"
 
 using namespace edm;
 using namespace std;
@@ -77,7 +78,9 @@ PFCand_AssoMapAlgos::createMappings(edm::Handle<reco::PFCandidateCollection> pfC
     } else {
       TransientTrack transtrk(PFCtrackref, &(*bFieldH));
       transtrk.setBeamSpot(*beamspotH);
-      transtrk.setES(iSetup);
+      edm::ESHandle<GlobalTrackingGeometry> trackingGeometry;
+      iSetup.get<GlobalTrackingGeometryRecord>().get(trackingGeometry);
+      transtrk.setTrackingGeometry(trackingGeometry);
 
       for (int assoc_ite = 0; assoc_ite < input_MaxNumAssociations_; ++assoc_ite) {
         VertexStepPair assocVtx = FindAssociation(PFCtrackref, vtxColl_help, bFieldH, iSetup, beamspotH, assoc_ite);

--- a/CommonTools/RecoUtils/src/PF_PU_AssoMapAlgos.cc
+++ b/CommonTools/RecoUtils/src/PF_PU_AssoMapAlgos.cc
@@ -25,7 +25,12 @@ using namespace reco;
 /*************************************************************************************/
 
 PF_PU_AssoMapAlgos::PF_PU_AssoMapAlgos(const edm::ParameterSet& iConfig, edm::ConsumesCollector& iC)
-    : maxNumWarnings_(3), numWarnings_(0) {
+    : token_bField_(iC.esConsumes()),
+      token_TrackingGeometry_(iC.esConsumes()),
+      maxNumWarnings_(3),
+      numWarnings_(0)
+
+{
   input_MaxNumAssociations_ = iConfig.getParameter<int>("MaxNumberOfAssociations");
 
   token_VertexCollection_ = iC.consumes<VertexCollection>(iConfig.getParameter<InputTag>("VertexCollection"));
@@ -93,8 +98,8 @@ void PF_PU_AssoMapAlgos::GetInputCollections(edm::Event& iEvent, const edm::Even
   //get the input vertex collection
   iEvent.getByToken(token_VertexCollection_, vtxcollH);
 
-  iSetup.get<IdealMagneticFieldRecord>().get(bFieldH);
-  iSetup.get<GlobalTrackingGeometryRecord>().get(trackingGeometryH);
+  bFieldH = iSetup.getHandle(token_bField_);
+  trackingGeometryH = iSetup.getHandle(token_TrackingGeometry_);
 }
 
 /*************************************************************************************/

--- a/CommonTools/RecoUtils/src/PF_PU_AssoMapAlgos.cc
+++ b/CommonTools/RecoUtils/src/PF_PU_AssoMapAlgos.cc
@@ -14,6 +14,7 @@
 
 #include "TrackingTools/IPTools/interface/IPTools.h"
 #include "CommonTools/Egamma/interface/ConversionTools.h"
+#include "Geometry/Records/interface/GlobalTrackingGeometryRecord.h"
 
 using namespace edm;
 using namespace std;
@@ -116,7 +117,9 @@ PF_PU_AssoMapAlgos::createMappings(edm::Handle<reco::TrackCollection> trkcollH, 
 
     TransientTrack transtrk(trackref, &(*bFieldH));
     transtrk.setBeamSpot(*beamspotH);
-    transtrk.setES(iSetup);
+    edm::ESHandle<GlobalTrackingGeometry> trackingGeometry;
+    iSetup.get<GlobalTrackingGeometryRecord>().get(trackingGeometry);
+    transtrk.setTrackingGeometry(trackingGeometry);
 
     if (input_MaxNumAssociations_ > 1)
       vtxColl_help = CreateVertexVector(vtxcollH);
@@ -421,7 +424,9 @@ VertexRef PF_PU_AssoMapAlgos::FindConversionVertex(const reco::TrackRef trackref
 
   TransientTrack transpho(photon, &(*bfH));
   transpho.setBeamSpot(*bsH);
-  transpho.setES(iSetup);
+  edm::ESHandle<GlobalTrackingGeometry> trackingGeometry;
+  iSetup.get<GlobalTrackingGeometryRecord>().get(trackingGeometry);
+  transpho.setTrackingGeometry(trackingGeometry);
 
   return FindClosest3D(transpho, vtxcollV, tWeight);
 }
@@ -577,7 +582,9 @@ VertexRef PF_PU_AssoMapAlgos::FindV0Vertex(const TrackRef trackref,
 
   TransientTrack transV0(V0, &(*bFieldH));
   transV0.setBeamSpot(*bsH);
-  transV0.setES(iSetup);
+  edm::ESHandle<GlobalTrackingGeometry> trackingGeometry;
+  iSetup.get<GlobalTrackingGeometryRecord>().get(trackingGeometry);
+  transV0.setTrackingGeometry(trackingGeometry);
 
   return FindClosest3D(transV0, vtxcollV, tWeight);
 }
@@ -654,6 +661,8 @@ VertexRef PF_PU_AssoMapAlgos::FindNIVertex(const TrackRef trackref,
                                            double tWeight) {
   TrackCollection refittedTracks = displVtx.refittedTracks();
 
+  edm::ESHandle<GlobalTrackingGeometry> trackingGeometry;
+  iSetup.get<GlobalTrackingGeometryRecord>().get(trackingGeometry);
   if ((displVtx.isTherePrimaryTracks()) || (displVtx.isThereMergedTracks())) {
     for (TrackCollection::const_iterator trkcoll_ite = refittedTracks.begin(); trkcoll_ite != refittedTracks.end();
          trkcoll_ite++) {
@@ -668,7 +677,7 @@ VertexRef PF_PU_AssoMapAlgos::FindNIVertex(const TrackRef trackref,
 
         TransientTrack transIncom(*retrackbaseref, &(*bFieldH));
         transIncom.setBeamSpot(*bsH);
-        transIncom.setES(iSetup);
+        transIncom.setTrackingGeometry(trackingGeometry);
 
         return FindClosest3D(transIncom, vtxcollV, tWeight);
       }
@@ -684,7 +693,7 @@ VertexRef PF_PU_AssoMapAlgos::FindNIVertex(const TrackRef trackref,
 
   TransientTrack transIncom(incom, &(*bFieldH));
   transIncom.setBeamSpot(*bsH);
-  transIncom.setES(iSetup);
+  transIncom.setTrackingGeometry(trackingGeometry);
 
   return FindClosest3D(transIncom, vtxcollV, tWeight);
 }
@@ -777,6 +786,8 @@ VertexStepPair PF_PU_AssoMapAlgos::FindAssociation(const reco::TrackRef& trackre
 
 finalStep:
 
+  edm::ESHandle<GlobalTrackingGeometry> trackingGeometry;
+  iSetup.get<GlobalTrackingGeometryRecord>().get(trackingGeometry);
   switch (input_FinalAssociation_) {
     case 1: {
       // closest in z
@@ -788,7 +799,7 @@ finalStep:
       // closest in 3D
       TransientTrack transtrk(trackref, &(*bfH));
       transtrk.setBeamSpot(*bsH);
-      transtrk.setES(iSetup);
+      transtrk.setTrackingGeometry(trackingGeometry);
 
       foundVertex = FindClosest3D(transtrk, vtxColl, input_nTrack_);
       break;

--- a/RecoTracker/TrackProducer/plugins/TwoBodyDecayConstraintProducer.cc
+++ b/RecoTracker/TrackProducer/plugins/TwoBodyDecayConstraintProducer.cc
@@ -16,6 +16,7 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 
+#include "Geometry/Records/interface/GlobalTrackingGeometryRecord.h"
 #include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
 
 #include "DataFormats/TrackReco/interface/Track.h"
@@ -104,6 +105,9 @@ void TwoBodyDecayConstraintProducer::produce(edm::StreamID streamid,
   ESHandle<MagneticField> magField;
   iSetup.get<IdealMagneticFieldRecord>().get(magField);
 
+  edm::ESHandle<GlobalTrackingGeometry> trackingGeometry;
+  iSetup.get<GlobalTrackingGeometryRecord>().get(trackingGeometry);
+
   edm::RefProd<std::vector<TrackParamConstraint> > rPairs =
       iEvent.getRefBeforePut<std::vector<TrackParamConstraint> >();
   std::unique_ptr<std::vector<TrackParamConstraint> > pairs(new std::vector<TrackParamConstraint>);
@@ -117,9 +121,9 @@ void TwoBodyDecayConstraintProducer::produce(edm::StreamID streamid,
     /// Get transient tracks from track collection
     std::vector<reco::TransientTrack> ttracks(2);
     ttracks[0] = reco::TransientTrack(reco::TrackRef(trackColl, 0), magField.product());
-    ttracks[0].setES(iSetup);
+    ttracks[0].setTrackingGeometry(trackingGeometry);
     ttracks[1] = reco::TransientTrack(reco::TrackRef(trackColl, 1), magField.product());
-    ttracks[1].setES(iSetup);
+    ttracks[1].setTrackingGeometry(trackingGeometry);
 
     /// Fit the TBD
     TwoBodyDecay tbd = tbdFitter_.estimate(ttracks, vm);

--- a/RecoTracker/TrackProducer/plugins/TwoBodyDecayMomConstraintProducer.cc
+++ b/RecoTracker/TrackProducer/plugins/TwoBodyDecayMomConstraintProducer.cc
@@ -16,6 +16,7 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 
+#include "Geometry/Records/interface/GlobalTrackingGeometryRecord.h"
 #include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
 
 #include "DataFormats/TrackReco/interface/Track.h"
@@ -117,6 +118,9 @@ void TwoBodyDecayMomConstraintProducer::produce(edm::StreamID streamid,
   ESHandle<MagneticField> magField;
   iSetup.get<IdealMagneticFieldRecord>().get(magField);
 
+  edm::ESHandle<GlobalTrackingGeometry> trackingGeometry;
+  iSetup.get<GlobalTrackingGeometryRecord>().get(trackingGeometry);
+
   edm::RefProd<std::vector<MomentumConstraint> > rPairs = iEvent.getRefBeforePut<std::vector<MomentumConstraint> >();
   std::unique_ptr<std::vector<MomentumConstraint> > pairs(new std::vector<MomentumConstraint>);
   std::unique_ptr<TrackMomConstraintAssociationCollection> output(
@@ -129,9 +133,9 @@ void TwoBodyDecayMomConstraintProducer::produce(edm::StreamID streamid,
     /// Get transient tracks from track collection
     std::vector<reco::TransientTrack> ttracks(2);
     ttracks[0] = reco::TransientTrack(reco::TrackRef(trackColl, 0), magField.product());
-    ttracks[0].setES(iSetup);
+    ttracks[0].setTrackingGeometry(trackingGeometry);
     ttracks[1] = reco::TransientTrack(reco::TrackRef(trackColl, 1), magField.product());
-    ttracks[1].setES(iSetup);
+    ttracks[1].setTrackingGeometry(trackingGeometry);
 
     /// Fit the TBD
     TwoBodyDecay tbd = tbdFitter_.estimate(ttracks, vm);

--- a/TrackingTools/TransientTrack/interface/BasicTransientTrack.h
+++ b/TrackingTools/TransientTrack/interface/BasicTransientTrack.h
@@ -10,7 +10,6 @@
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
 #include "TrackingTools/TrajectoryState/interface/TrajectoryStateOnSurface.h"
 #include "TrackingTools/TrajectoryState/interface/TrajectoryStateClosestToPoint.h"
-#include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "Geometry/CommonDetUnit/interface/GlobalTrackingGeometry.h"
 #include "DataFormats/BeamSpot/interface/BeamSpot.h"
@@ -26,8 +25,6 @@ namespace reco {
 
   public:
     virtual ~BasicTransientTrack() {}
-
-    virtual void setES(const edm::EventSetup& es) = 0;
 
     virtual void setTrackingGeometry(const edm::ESHandle<GlobalTrackingGeometry>& tg) = 0;
 

--- a/TrackingTools/TransientTrack/interface/CandidatePtrTransientTrack.h
+++ b/TrackingTools/TransientTrack/interface/CandidatePtrTransientTrack.h
@@ -40,8 +40,6 @@ namespace reco {
 
     CandidatePtrTransientTrack& operator=(const CandidatePtrTransientTrack& tt);
 
-    void setES(const edm::EventSetup&) override;
-
     void setTrackingGeometry(const edm::ESHandle<GlobalTrackingGeometry>&) override;
 
     void setBeamSpot(const reco::BeamSpot& beamSpot) override;

--- a/TrackingTools/TransientTrack/interface/GsfTransientTrack.h
+++ b/TrackingTools/TransientTrack/interface/GsfTransientTrack.h
@@ -47,8 +47,6 @@ namespace reco {
 
     GsfTransientTrack& operator=(const GsfTransientTrack& tt);
 
-    void setES(const edm::EventSetup&) override;
-
     void setTrackingGeometry(const edm::ESHandle<GlobalTrackingGeometry>&) override;
 
     void setBeamSpot(const reco::BeamSpot& beamSpot) override;

--- a/TrackingTools/TransientTrack/interface/TrackTransientTrack.h
+++ b/TrackingTools/TransientTrack/interface/TrackTransientTrack.h
@@ -47,8 +47,6 @@ namespace reco {
 
     TrackTransientTrack& operator=(const TrackTransientTrack& tt);
 
-    void setES(const edm::EventSetup&) override;
-
     void setTrackingGeometry(const edm::ESHandle<GlobalTrackingGeometry>&) override;
 
     void setBeamSpot(const reco::BeamSpot& beamSpot) override;

--- a/TrackingTools/TransientTrack/interface/TransientTrack.h
+++ b/TrackingTools/TransientTrack/interface/TransientTrack.h
@@ -75,8 +75,6 @@ namespace reco {
                    const MagneticField* field,
                    const edm::ESHandle<GlobalTrackingGeometry>& trackingGeometry);
 
-    void setES(const edm::EventSetup& es) { sharedData().setES(es); }
-
     void setTrackingGeometry(const edm::ESHandle<GlobalTrackingGeometry>& tg) { sharedData().setTrackingGeometry(tg); }
 
     void setBeamSpot(const reco::BeamSpot& beamSpot) { sharedData().setBeamSpot(beamSpot); }

--- a/TrackingTools/TransientTrack/interface/TransientTrackFromFTS.h
+++ b/TrackingTools/TransientTrack/interface/TransientTrackFromFTS.h
@@ -31,8 +31,6 @@ namespace reco {
 
     TransientTrackFromFTS& operator=(const TransientTrackFromFTS& tt);
 
-    void setES(const edm::EventSetup&) override;
-
     void setTrackingGeometry(const edm::ESHandle<GlobalTrackingGeometry>&) override;
 
     void setBeamSpot(const reco::BeamSpot& beamSpot) override;

--- a/TrackingTools/TransientTrack/src/CandidatePtrTransientTrack.cc
+++ b/TrackingTools/TransientTrack/src/CandidatePtrTransientTrack.cc
@@ -116,10 +116,6 @@ CandidatePtrTransientTrack::CandidatePtrTransientTrack(const CandidatePtrTransie
   }
 }
 
-void CandidatePtrTransientTrack::setES(const edm::EventSetup& setup) {
-  setup.get<GlobalTrackingGeometryRecord>().get(theTrackingGeometry);
-}
-
 void CandidatePtrTransientTrack::setTrackingGeometry(const edm::ESHandle<GlobalTrackingGeometry>& tg) {
   theTrackingGeometry = tg;
 }

--- a/TrackingTools/TransientTrack/src/GsfTransientTrack.cc
+++ b/TrackingTools/TransientTrack/src/GsfTransientTrack.cc
@@ -175,10 +175,6 @@ GsfTransientTrack::GsfTransientTrack(const GsfTransientTrack& tt)
   }
 }
 
-void GsfTransientTrack::setES(const edm::EventSetup& setup) {
-  setup.get<GlobalTrackingGeometryRecord>().get(theTrackingGeometry);
-}
-
 void GsfTransientTrack::setTrackingGeometry(const edm::ESHandle<GlobalTrackingGeometry>& tg) {
   theTrackingGeometry = tg;
 }

--- a/TrackingTools/TransientTrack/src/TrackTransientTrack.cc
+++ b/TrackingTools/TransientTrack/src/TrackTransientTrack.cc
@@ -181,10 +181,6 @@ TrackTransientTrack::TrackTransientTrack(const TrackTransientTrack& tt)
   }
 }
 
-void TrackTransientTrack::setES(const edm::EventSetup& setup) {
-  setup.get<GlobalTrackingGeometryRecord>().get(theTrackingGeometry);
-}
-
 void TrackTransientTrack::setTrackingGeometry(const edm::ESHandle<GlobalTrackingGeometry>& tg) {
   theTrackingGeometry = tg;
 }

--- a/TrackingTools/TransientTrack/src/TransientTrackFromFTS.cc
+++ b/TrackingTools/TransientTrack/src/TransientTrackFromFTS.cc
@@ -88,10 +88,6 @@ TransientTrackFromFTS::TransientTrackFromFTS(const TransientTrackFromFTS& tt)
   }
 }
 
-void TransientTrackFromFTS::setES(const edm::EventSetup& setup) {
-  setup.get<GlobalTrackingGeometryRecord>().get(theTrackingGeometry);
-}
-
 void TransientTrackFromFTS::setTrackingGeometry(const edm::ESHandle<GlobalTrackingGeometry>& tg) {
   theTrackingGeometry = tg;
 }


### PR DESCRIPTION
#### PR description:

-removed the function TransientTrack::setES
-replaced all calls to TransientTrack::setES with TransientTrack::setTrackingGeometry which leave the object in the same state
-call esConsumes for code that had easy access to that function and used TransientTrack::setES

#### PR validation:

Code compiles.