### PR TITLE
[Backport] - GEM unpacker - updated DAQ dataformat and new DAQ status collections

### DIFF
--- a/CondFormats/GEMObjects/interface/GEMROMapping.h
+++ b/CondFormats/GEMObjects/interface/GEMROMapping.h
@@ -16,7 +16,7 @@ public:
     bool operator==(const sectorEC& r) const {
       if (fedId == r.fedId) {
         return amcNum == r.amcNum;
-        } else {
+      } else {
         return false;
       }
     }
@@ -100,7 +100,7 @@ public:
 
   bool isValidChipID(const vfatEC& r) const { return vfatMap_.find(r) != vfatMap_.end(); }
   bool isValidChamber(const chamEC& r) const { return chamberMap_.find(r) != chamberMap_.end(); }
-  
+
   bool isValidAMC(const sectorEC& r) const { return std::find(amcVec_.begin(), amcVec_.end(), r) != amcVec_.end(); }
 
   void add(sectorEC e) { amcVec_.push_back(e); }

--- a/CondFormats/GEMObjects/interface/GEMROMapping.h
+++ b/CondFormats/GEMObjects/interface/GEMROMapping.h
@@ -3,9 +3,25 @@
 #include "DataFormats/MuonDetId/interface/GEMDetId.h"
 #include <map>
 #include <vector>
+#include <algorithm>
 
 class GEMROMapping {
+  // EC electronics corrdinate
+  // DC GEMDetId corrdinate
+  // geb = GEM electronics board == OptoHybrid
 public:
+  struct sectorEC {
+    unsigned int fedId;
+    uint8_t amcNum;
+    bool operator==(const sectorEC& r) const {
+      if (fedId == r.fedId) {
+        return amcNum == r.amcNum;
+        } else {
+        return false;
+      }
+    }
+  };
+
   struct chamEC {
     unsigned int fedId;
     uint8_t amcNum;
@@ -82,17 +98,21 @@ public:
 
   GEMROMapping(){};
 
-  bool isValidChipID(const vfatEC& r) const { return vMapED_.find(r) != vMapED_.end(); }
-  bool isValidChamber(const chamEC& r) const { return chamED_.find(r) != chamED_.end(); }
+  bool isValidChipID(const vfatEC& r) const { return vfatMap_.find(r) != vfatMap_.end(); }
+  bool isValidChamber(const chamEC& r) const { return chamberMap_.find(r) != chamberMap_.end(); }
+  
+  bool isValidAMC(const sectorEC& r) const { return std::find(amcVec_.begin(), amcVec_.end(), r) != amcVec_.end(); }
 
-  const chamDC& chamberPos(const chamEC& r) const { return chamED_.at(r); }
-  void add(chamEC e, chamDC d) { chamED_[e] = d; }
+  void add(sectorEC e) { amcVec_.push_back(e); }
+
+  const chamDC& chamberPos(const chamEC& r) const { return chamberMap_.at(r); }
+  void add(chamEC e, chamDC d) { chamberMap_[e] = d; }
 
   const std::vector<vfatEC> getVfats(const GEMDetId& r) const { return chamVfats_.at(r); }
   void add(GEMDetId e, vfatEC d) { chamVfats_[e].push_back(d); }
 
-  const vfatDC& vfatPos(const vfatEC& r) const { return vMapED_.at(r); }
-  void add(vfatEC e, vfatDC d) { vMapED_[e] = d; }
+  const vfatDC& vfatPos(const vfatEC& r) const { return vfatMap_.at(r); }
+  void add(vfatEC e, vfatDC d) { vfatMap_[e] = d; }
 
   const channelNum& hitPos(const stripNum& s) const { return stChMap_.at(s); }
   const stripNum& hitPos(const channelNum& c) const { return chStMap_.at(c); }
@@ -101,11 +121,14 @@ public:
   void add(stripNum s, channelNum c) { stChMap_[s] = c; }
 
 private:
-  std::map<chamEC, chamDC> chamED_;
+  std::vector<sectorEC> amcVec_;
+
+  // electronics map to GEMDetId chamber
+  std::map<chamEC, chamDC> chamberMap_;
 
   std::map<GEMDetId, std::vector<vfatEC>> chamVfats_;
 
-  std::map<vfatEC, vfatDC> vMapED_;
+  std::map<vfatEC, vfatDC> vfatMap_;
 
   std::map<channelNum, stripNum> chStMap_;
   std::map<stripNum, channelNum> stChMap_;

--- a/CondFormats/GEMObjects/interface/GEMeMap.h
+++ b/CondFormats/GEMObjects/interface/GEMeMap.h
@@ -66,6 +66,9 @@ public:
   static const int maxVFatGE0_ = 12;     // vFat per eta partition, not known yet for ME0
   static const int maxVFatGE11_ = 3;     // vFat per eta partition in GE11
   static const int maxVFatGE21_ = 6;     // vFat per eta partition in GE21
+  static const int maxiEtaIdGE0_ = 8;    // no. eta partitions for GE0
+  static const int maxiEtaIdGE11_ = 8;   // no. eta partitions for GE11
+  static const int maxiEtaIdGE21_ = 16;  // no. eta partitions for GE21
   static const int maxChan_ = 128;       // channels per vFat
 };
 #endif  // GEMeMap_H

--- a/CondFormats/GEMObjects/src/GEMeMap.cc
+++ b/CondFormats/GEMObjects/src/GEMeMap.cc
@@ -15,10 +15,8 @@ void GEMeMap::convert(GEMROMapping& romap) {
   // fed->amc->geb mapping to GEMDetId
   for (auto imap : theChamberMap_) {
     for (unsigned int ix = 0; ix < imap.fedId.size(); ix++) {
-      GEMROMapping::chamEC ec;
-      ec.fedId = imap.fedId[ix];
-      ec.amcNum = imap.amcNum[ix];
-      ec.gebId = imap.gebId[ix];
+      GEMROMapping::chamEC ec{imap.fedId[ix], imap.amcNum[ix], imap.gebId[ix]};
+      GEMROMapping::sectorEC amcEC = {imap.fedId[ix], imap.amcNum[ix]};
 
       GEMROMapping::chamDC dc;
       dc.detId = GEMDetId((imap.gemNum[ix] > 0) ? 1 : -1,
@@ -29,6 +27,8 @@ void GEMeMap::convert(GEMROMapping& romap) {
                           0);
       dc.vfatVer = imap.vfatVer[ix];
       romap.add(ec, dc);
+      if (!romap.isValidAMC(amcEC)) romap.add(amcEC);
+
     }
   }
 

--- a/CondFormats/GEMObjects/src/GEMeMap.cc
+++ b/CondFormats/GEMObjects/src/GEMeMap.cc
@@ -26,8 +26,8 @@ void GEMeMap::convert(GEMROMapping& romap) {
       dc.vfatVer = imap.vfatVer[ix];
       romap.add(ec, dc);
       GEMROMapping::sectorEC amcEC = {imap.fedId[ix], imap.amcNum[ix]};
-      if (!romap.isValidAMC(amcEC)) romap.add(amcEC);
-
+      if (!romap.isValidAMC(amcEC))
+        romap.add(amcEC);
     }
   }
 
@@ -108,7 +108,8 @@ void GEMeMap::convertDummy(GEMROMapping& romap) {
           romap.add(ec, dc);
 
           GEMROMapping::sectorEC amcEC = {fedId, amcNum};
-          if (!romap.isValidAMC(amcEC)) romap.add(amcEC);
+          if (!romap.isValidAMC(amcEC))
+            romap.add(amcEC);
 
           uint16_t chipPos = 0;
           for (int lphi = 0; lphi < maxVFat; ++lphi) {

--- a/CondFormats/GEMObjects/src/GEMeMap.cc
+++ b/CondFormats/GEMObjects/src/GEMeMap.cc
@@ -81,16 +81,20 @@ void GEMeMap::convertDummy(GEMROMapping& romap) {
       uint8_t gebId = 0;
       int maxVFat = 0;
       int maxLayerId = GEMDetId::maxLayerId;
+      int maxiEtaId = 0;
       if (st == 0) {
         maxVFat = maxVFatGE0_;
         fedId = (re == 1 ? FEDNumbering::MINGE0FEDID + 1 : FEDNumbering::MINGE0FEDID);
         maxLayerId = GEMDetId::maxLayerId0;
+        maxiEtaId = maxiEtaIdGE0_;
       } else if (st == 1) {
         maxVFat = maxVFatGE11_;
         fedId = (re == 1 ? FEDNumbering::MINGEMFEDID + 1 : FEDNumbering::MINGEMFEDID);
+        maxiEtaId = maxiEtaIdGE11_;
       } else if (st == 2) {
         maxVFat = maxVFatGE21_;
         fedId = (re == 1 ? FEDNumbering::MINGE21FEDID + 1 : FEDNumbering::MINGE21FEDID);
+        maxiEtaId = maxiEtaIdGE21_;
       }
 
       for (int ch = 1; ch <= GEMDetId::maxChamberId; ++ch) {
@@ -113,14 +117,14 @@ void GEMeMap::convertDummy(GEMROMapping& romap) {
 
           uint16_t chipPos = 0;
           for (int lphi = 0; lphi < maxVFat; ++lphi) {
-            for (int roll = 1; roll <= GEMDetId::maxRollId; ++roll) {
+            for (int ieta = 1; ieta <= maxiEtaId; ++ieta) {
               GEMROMapping::vfatEC vec;
               vec.vfatAdd = chipPos;
               vec.detId = gemId;
 
               GEMROMapping::vfatDC vdc;
               vdc.vfatType = vfatTypeV3_;  // > 10 is vfat v3
-              vdc.detId = GEMDetId(re, 1, st, ly, ch, roll);
+              vdc.detId = GEMDetId(re, 1, st, ly, ch, ieta);
               vdc.localPhi = lphi;
 
               romap.add(vec, vdc);

--- a/CondFormats/GEMObjects/src/GEMeMap.cc
+++ b/CondFormats/GEMObjects/src/GEMeMap.cc
@@ -16,8 +16,6 @@ void GEMeMap::convert(GEMROMapping& romap) {
   for (auto imap : theChamberMap_) {
     for (unsigned int ix = 0; ix < imap.fedId.size(); ix++) {
       GEMROMapping::chamEC ec{imap.fedId[ix], imap.amcNum[ix], imap.gebId[ix]};
-      GEMROMapping::sectorEC amcEC = {imap.fedId[ix], imap.amcNum[ix]};
-
       GEMROMapping::chamDC dc;
       dc.detId = GEMDetId((imap.gemNum[ix] > 0) ? 1 : -1,
                           1,
@@ -27,6 +25,7 @@ void GEMeMap::convert(GEMROMapping& romap) {
                           0);
       dc.vfatVer = imap.vfatVer[ix];
       romap.add(ec, dc);
+      GEMROMapping::sectorEC amcEC = {imap.fedId[ix], imap.amcNum[ix]};
       if (!romap.isValidAMC(amcEC)) romap.add(amcEC);
 
     }
@@ -107,6 +106,9 @@ void GEMeMap::convertDummy(GEMROMapping& romap) {
           dc.detId = gemId;
           dc.vfatVer = vfatVerV3_;
           romap.add(ec, dc);
+
+          GEMROMapping::sectorEC amcEC = {fedId, amcNum};
+          if (!romap.isValidAMC(amcEC)) romap.add(amcEC);
 
           uint16_t chipPos = 0;
           for (int lphi = 0; lphi < maxVFat; ++lphi) {

--- a/DataFormats/GEMDigi/interface/AMC13Event.h
+++ b/DataFormats/GEMDigi/interface/AMC13Event.h
@@ -33,7 +33,8 @@ namespace gem {
       uint64_t bxIdT : 12;  // bx id
       uint64_t lv1IdT : 8;  // level 1 id
       uint64_t blkN : 8;    // block number
-      uint64_t crc32 : 36;  // Overall CRC (first 32 bits)
+      uint64_t : 4;
+      uint64_t crc32 : 32;  // Overall CRC
     };
   };
   union CDFTrailer {

--- a/DataFormats/GEMDigi/interface/AMC13Event.h
+++ b/DataFormats/GEMDigi/interface/AMC13Event.h
@@ -89,21 +89,22 @@ namespace gem {
     void setCDFTrailer(uint32_t EvtLength);
     uint64_t getCDFTrailer() const { return cdft_; }
     uint32_t fragmentLength() const { return CDFTrailer{cdft_}.evtLength; }
-    uint16_t crc() const { return CDFTrailer{cdft_}.crcCDF; }
     uint8_t evtStatus() const { return CDFTrailer{cdft_}.evtStat; }
     uint8_t ttsBits() const { return CDFTrailer{cdft_}.tts; }
 
-    int bxId() const { return (int8_t)CDFHeader{cdfh_}.bxId; }
+    uint16_t bunchCrossing() const { return CDFHeader{cdfh_}.bxId; }
     uint32_t lv1Id() const { return CDFHeader{cdfh_}.lv1Id; }
     uint16_t sourceId() const { return CDFHeader{cdfh_}.sourceId; }
 
-    int orbitNumber() const { return AMC13Header{amc13h_}.orbitN; }
+    uint16_t orbitNumber() const { return AMC13Header{amc13h_}.orbitN; }
     uint8_t nAMC() const { return AMC13Header{amc13h_}.nAMC; }
 
     const std::vector<uint64_t>* getAMCheaders() const { return &amcHeaders_; }
     uint32_t getAMCsize(int i) const { return AMCHeader{amcHeaders_.at(i)}.amcSize; }
     void addAMCheader(uint64_t word);
     void addAMCheader(uint32_t AMC_size, uint8_t Blk_No, uint8_t AMC_No, uint16_t BoardID);
+
+    uint32_t crc() const { return AMC13Trailer{amc13t_}.crc32; }
 
     const std::vector<AMCdata>* getAMCpayloads() const { return &amcs_; }
     void addAMCpayload(const AMCdata& a) { amcs_.push_back(a); }

--- a/DataFormats/GEMDigi/interface/AMCdata.h
+++ b/DataFormats/GEMDigi/interface/AMCdata.h
@@ -68,6 +68,8 @@ namespace gem {
     AMCdata() : amch1_(0), amch2_(0), amct_(0), eh_(0), et_(0){};
     ~AMCdata() { gebd_.clear(); }
 
+    int status();
+
     void setAMCheader1(uint64_t word) { amch1_ = word; }
     void setAMCheader1(uint32_t dataLength, uint16_t bxID, uint32_t l1AID, uint8_t AMCnum);
     uint64_t getAMCheader1() const { return amch1_; }
@@ -87,17 +89,19 @@ namespace gem {
     uint64_t getGEMeventTrailer() const { return et_; }
 
     uint32_t dataLength() const { return AMCTrailer{amct_}.dataLength; }
-    uint16_t bx() const { return AMCheader1{amch1_}.bxID; }
-    uint32_t l1A() const { return AMCheader1{amch1_}.l1AID; }
+    uint16_t bunchCrossing() const { return AMCheader1{amch1_}.bxID; }
+    uint32_t lv1Id() const { return AMCheader1{amch1_}.l1AID; }
     uint8_t amcNum() const { return AMCheader1{amch1_}.AMCnum; }
 
     uint16_t boardId() const { return AMCheader2{amch2_}.boardID; }
-    uint16_t orbitNum() const { return AMCheader2{amch2_}.orbitNum; }
+    uint16_t orbitNumber() const { return AMCheader2{amch2_}.orbitNum; }
     uint8_t param3() const { return AMCheader2{amch2_}.param3; }
     uint8_t param2() const { return AMCheader2{amch2_}.param2; }
     uint8_t param1() const { return AMCheader2{amch2_}.param1; }
     uint8_t runType() const { return AMCheader2{amch2_}.runType; }
     uint8_t formatVer() const { return AMCheader2{amch2_}.formatVer; }
+
+    uint32_t crc() const { return AMCTrailer{amct_}.crc; }
 
     uint16_t ttsState() const { return EventHeader{eh_}.ttsState; }
     uint8_t davCnt() const { return EventHeader{eh_}.davCnt; }

--- a/DataFormats/GEMDigi/interface/AMCdata.h
+++ b/DataFormats/GEMDigi/interface/AMCdata.h
@@ -31,7 +31,8 @@ namespace gem {
     uint64_t word;
     struct {
       uint64_t dataLength : 20;  // Number of 64bit words in this event
-      uint64_t l1AIDT : 12;      // 8bit long GLIB serial number (first 8 bits)
+      uint64_t : 4;
+      uint64_t l1AID : 8;        // L1A number (first 8 bits)
       uint64_t crc : 32;         // CRC added by the AMC13
     };
   };
@@ -101,6 +102,7 @@ namespace gem {
     uint8_t runType() const { return AMCheader2{amch2_}.runType; }
     uint8_t formatVer() const { return AMCheader2{amch2_}.formatVer; }
 
+    uint8_t lv1Idt() const { return AMCTrailer{amct_}.l1AID; }
     uint32_t crc() const { return AMCTrailer{amct_}.crc; }
 
     uint16_t ttsState() const { return EventHeader{eh_}.ttsState; }

--- a/DataFormats/GEMDigi/interface/AMCdata.h
+++ b/DataFormats/GEMDigi/interface/AMCdata.h
@@ -32,8 +32,8 @@ namespace gem {
     struct {
       uint64_t dataLength : 20;  // Number of 64bit words in this event
       uint64_t : 4;
-      uint64_t l1AID : 8;        // L1A number (first 8 bits)
-      uint64_t crc : 32;         // CRC added by the AMC13
+      uint64_t l1AID : 8;  // L1A number (first 8 bits)
+      uint64_t crc : 32;   // CRC added by the AMC13
     };
   };
   union EventHeader {

--- a/DataFormats/GEMDigi/interface/GEBdata.h
+++ b/DataFormats/GEMDigi/interface/GEBdata.h
@@ -4,18 +4,16 @@
 #include <vector>
 
 namespace gem {
-  // Input status 1 bit for each
-  // BX mismatch GLIB OH / BX mismatch GLIB VFAT / OOS GLIB OH / OOS GLIB VFAT / No VFAT marker
-  // Event size warn / L1AFIFO near full / InFIFO near full / EvtFIFO near full / Event size overflow
-  // L1AFIFO full / InFIFO full / EvtFIFO full
+
   union GEBchamberHeader {
     uint64_t word;
     struct {
-      uint64_t BxmVvV : 11;           // 1st bit BX mismatch VFAT vs VFAT
+      uint64_t : 10;                  // unused
+      uint64_t BxmVvV : 1;            // 1st bit BX mismatch VFAT vs VFAT
       uint64_t BxmAvV : 1;            // BX mismatch AMC vs VFAT
-      uint64_t OOScVvV : 1;           // OOS (EC mismatch) VFAT vs VFAT
-      uint64_t OOScAvV : 1;           // OOS (EC mismatch) AMC vs VFAT
-      uint64_t noVFAT : 1;            // No VFAT marker
+      uint64_t OOScVvV : 1;           // Out of Sync (EC mismatch) VFAT vs VFAT
+      uint64_t OOScAvV : 1;           // Out of Sync (EC mismatch) AMC vs VFAT
+      uint64_t Inv : 1;               // Invalid event
       uint64_t EvtSzW : 1;            // Event size warning
       uint64_t L1aNF : 1;             // L1A FIFO near full
       uint64_t InNF : 1;              // Input FIFO near full
@@ -25,20 +23,22 @@ namespace gem {
       uint64_t InF : 1;               // Input FIFO full
       uint64_t EvtF : 1;              // Event FIFO full
       uint64_t VfWdCnt : 12;          // VFAT word count (in number of 64-bit words)
-      uint64_t inputID : 5;           // Input link ID
-      uint64_t zeroSupWordsCnt : 24;  // Number of zero suppressed VFAT 64bit words
+      uint64_t InputID : 5;           // Input link ID
+      uint64_t CALIB_CHAN : 7;        // Calibration channel number
+      uint64_t : 17;                  // unused
     };
   };
+  
   union GEBchamberTrailer {
     uint64_t word;
     struct {
-      uint64_t ecOH : 20;      // OH event counter
-      uint64_t bcOH : 13;      // OH bunch crossing
+      uint64_t ecOH : 20;      // NOT USED - OptoHybrid event counter
+      uint64_t bcOH : 13;      // NOT USED - OptoHybrid bunch crossing
       uint64_t InUfw : 1;      // Input FIFO underflow
-      uint64_t SkD : 1;        // Stuck data
-      uint64_t EvUfw : 1;      // Event FIFO underflow
+      uint64_t SkD : 1;        // NOT USED - Stuck data
+      uint64_t EvUfw : 1;      // NOT USED - Event FIFO underflow
       uint64_t VfWdCntT : 12;  // VFAT word count (in number of 64-bit words)
-      uint64_t crc16 : 16;     // CRC of OH data (currently not available – filled with 0)
+      uint64_t crc16 : 16;     // CRC of OptoHybrid data (currently not available – filled with 0)
     };
   };
 
@@ -52,7 +52,7 @@ namespace gem {
     void setChamberHeader(uint16_t vfatWordCnt, uint8_t inputID) {
       GEBchamberHeader u{0};
       u.VfWdCnt = vfatWordCnt;
-      u.inputID = inputID;
+      u.InputID = inputID;
       ch_ = u.word;
     }
     uint64_t getChamberHeader() const { return ch_; }
@@ -68,30 +68,28 @@ namespace gem {
     }
     uint64_t getChamberTrailer() const { return ct_; }
 
-    uint16_t bxmVvV() const { return GEBchamberHeader{ch_}.BxmVvV; }
-    uint8_t bxmAvV() const { return GEBchamberHeader{ch_}.BxmAvV; }
-    uint8_t oOScVvV() const { return GEBchamberHeader{ch_}.OOScVvV; }
-    uint8_t oOScAvV() const { return GEBchamberHeader{ch_}.OOScAvV; }
-    uint8_t noVFAT() const { return GEBchamberHeader{ch_}.noVFAT; }
-    uint8_t evtSzW() const { return GEBchamberHeader{ch_}.EvtSzW; }
-    uint8_t l1aNF() const { return GEBchamberHeader{ch_}.L1aNF; }
-    uint8_t inNF() const { return GEBchamberHeader{ch_}.InNF; }
-    uint8_t evtNF() const { return GEBchamberHeader{ch_}.EvtNF; }
-    uint8_t evtSzOFW() const { return GEBchamberHeader{ch_}.EvtSzOFW; }
-    uint8_t l1aF() const { return GEBchamberHeader{ch_}.L1aF; }
-    uint8_t inF() const { return GEBchamberHeader{ch_}.InF; }
-    uint8_t evtF() const { return GEBchamberHeader{ch_}.EvtF; }
     uint16_t vfatWordCnt() const { return GEBchamberHeader{ch_}.VfWdCnt; }
-    uint8_t inputID() const { return GEBchamberHeader{ch_}.inputID; }
-    uint32_t zeroSupWordsCnt() const { return GEBchamberHeader{ch_}.zeroSupWordsCnt; }
-
-    uint32_t ecOH() const { return GEBchamberTrailer{ct_}.ecOH; }
-    uint16_t bcOH() const { return GEBchamberTrailer{ct_}.bcOH; }
-    uint8_t inUfw() const { return GEBchamberTrailer{ct_}.InUfw; }
-    uint8_t stuckData() const { return GEBchamberTrailer{ct_}.SkD; }
-    uint8_t evUfw() const { return GEBchamberTrailer{ct_}.EvUfw; }
+    uint8_t inputID() const { return GEBchamberHeader{ch_}.InputID; }
     uint16_t vfatWordCntT() const { return GEBchamberTrailer{ct_}.VfWdCntT; }
-    uint16_t crc() const { return GEBchamberTrailer{ct_}.crc16; }
+
+    bool bxmVvV() const { return GEBchamberHeader{ch_}.BxmVvV; }
+    bool bxmAvV() const { return GEBchamberHeader{ch_}.BxmAvV; }
+    bool oOScVvV() const { return GEBchamberHeader{ch_}.OOScVvV; }
+    bool oOScAvV() const { return GEBchamberHeader{ch_}.OOScAvV; }
+    bool inv() const { return GEBchamberHeader{ch_}.Inv; }
+    bool evtSzW() const { return GEBchamberHeader{ch_}.EvtSzW; }
+    bool l1aNF() const { return GEBchamberHeader{ch_}.L1aNF; }
+    bool inNF() const { return GEBchamberHeader{ch_}.InNF; }
+    bool evtNF() const { return GEBchamberHeader{ch_}.EvtNF; }
+    bool evtSzOFW() const { return GEBchamberHeader{ch_}.EvtSzOFW; }
+    bool l1aF() const { return GEBchamberHeader{ch_}.L1aF; }
+    bool inF() const { return GEBchamberHeader{ch_}.InF; }
+    bool evtF() const { return GEBchamberHeader{ch_}.EvtF; }
+    bool inUfw() const { return GEBchamberTrailer{ct_}.InUfw; }
+    
+    bool noVFAT() const { return 0; } // to be removed
+    bool stuckData() const { return 0; }// to be removed
+    bool evUfw() const { return 0; }// to be removed
 
     //!Adds VFAT data to the vector
     void addVFAT(VFATdata v) { vfatd_.push_back(v); }

--- a/DataFormats/GEMDigi/interface/GEBdata.h
+++ b/DataFormats/GEMDigi/interface/GEBdata.h
@@ -8,27 +8,27 @@ namespace gem {
   union GEBchamberHeader {
     uint64_t word;
     struct {
-      uint64_t : 10;                  // unused
-      uint64_t BxmVvV : 1;            // 1st bit BX mismatch VFAT vs VFAT
-      uint64_t BxmAvV : 1;            // BX mismatch AMC vs VFAT
-      uint64_t OOScVvV : 1;           // Out of Sync (EC mismatch) VFAT vs VFAT
-      uint64_t OOScAvV : 1;           // Out of Sync (EC mismatch) AMC vs VFAT
-      uint64_t Inv : 1;               // Invalid event
-      uint64_t EvtSzW : 1;            // Event size warning
-      uint64_t L1aNF : 1;             // L1A FIFO near full
-      uint64_t InNF : 1;              // Input FIFO near full
-      uint64_t EvtNF : 1;             // Event FIFO near full
-      uint64_t EvtSzOFW : 1;          // Event size overflow
-      uint64_t L1aF : 1;              // L1A FIFO full
-      uint64_t InF : 1;               // Input FIFO full
-      uint64_t EvtF : 1;              // Event FIFO full
-      uint64_t VfWdCnt : 12;          // VFAT word count (in number of 64-bit words)
-      uint64_t InputID : 5;           // Input link ID
-      uint64_t CALIB_CHAN : 7;        // Calibration channel number
-      uint64_t : 17;                  // unused
+      uint64_t : 10;            // unused
+      uint64_t BxmVvV : 1;      // 1st bit BX mismatch VFAT vs VFAT
+      uint64_t BxmAvV : 1;      // BX mismatch AMC vs VFAT
+      uint64_t OOScVvV : 1;     // Out of Sync (EC mismatch) VFAT vs VFAT
+      uint64_t OOScAvV : 1;     // Out of Sync (EC mismatch) AMC vs VFAT
+      uint64_t Inv : 1;         // Invalid event
+      uint64_t EvtSzW : 1;      // Event size warning
+      uint64_t L1aNF : 1;       // L1A FIFO near full
+      uint64_t InNF : 1;        // Input FIFO near full
+      uint64_t EvtNF : 1;       // Event FIFO near full
+      uint64_t EvtSzOFW : 1;    // Event size overflow
+      uint64_t L1aF : 1;        // L1A FIFO full
+      uint64_t InF : 1;         // Input FIFO full
+      uint64_t EvtF : 1;        // Event FIFO full
+      uint64_t VfWdCnt : 12;    // VFAT word count (in number of 64-bit words)
+      uint64_t InputID : 5;     // Input link ID
+      uint64_t CALIB_CHAN : 7;  // Calibration channel number
+      uint64_t : 17;            // unused
     };
   };
-  
+
   union GEBchamberTrailer {
     uint64_t word;
     struct {
@@ -86,10 +86,10 @@ namespace gem {
     bool inF() const { return GEBchamberHeader{ch_}.InF; }
     bool evtF() const { return GEBchamberHeader{ch_}.EvtF; }
     bool inUfw() const { return GEBchamberTrailer{ct_}.InUfw; }
-    
-    bool noVFAT() const { return 0; } // to be removed
-    bool stuckData() const { return 0; }// to be removed
-    bool evUfw() const { return 0; }// to be removed
+
+    bool noVFAT() const { return false; }     // to be removed
+    bool stuckData() const { return false; }  // to be removed
+    bool evUfw() const { return false; }      // to be removed
 
     //!Adds VFAT data to the vector
     void addVFAT(VFATdata v) { vfatd_.push_back(v); }

--- a/DataFormats/GEMDigi/interface/GEMAMC13Status.h
+++ b/DataFormats/GEMDigi/interface/GEMAMC13Status.h
@@ -54,7 +54,6 @@ public:
     warnings_ = warn.wcodes;
   }
 
-  bool isGood() const { return errors_ == 0; }
   bool isBad() const { return errors_ != 0; }
   uint8_t errors() const { return errors_; }
   uint8_t warnings() const { return warnings_; }

--- a/DataFormats/GEMDigi/interface/GEMAMC13Status.h
+++ b/DataFormats/GEMDigi/interface/GEMAMC13Status.h
@@ -63,7 +63,7 @@ private:
   uint8_t warnings_;
 };
 
-std::ostream& operator<<(std::ostream& out, const GEMAMC13Status& status) {
+inline std::ostream& operator<<(std::ostream& out, const GEMAMC13Status& status) {
   out << "GEMAMC13Status errors " << std::bitset<8>(status.errors()) << " warnings "
       << std::bitset<8>(status.warnings());
   return out;

--- a/DataFormats/GEMDigi/interface/GEMAMC13Status.h
+++ b/DataFormats/GEMDigi/interface/GEMAMC13Status.h
@@ -1,0 +1,50 @@
+#ifndef DataFormats_GEMDigi_GEMAMC13Status_h
+#define DataFormats_GEMDigi_GEMAMC13Status_h
+#include "AMC13Event.h"
+#include "AMCdata.h"
+#include "DataFormats/FEDRawData/interface/FEDRawData.h"
+#include "DataFormats/FEDRawData/interface/FEDTrailer.h"
+
+namespace gem {
+
+    class GEMAMC13Status {
+    public:
+
+    union Errors {
+    uint8_t codes;
+    struct {
+      uint8_t InValidSize : 1;
+      uint8_t failTrailerCheck : 1;
+      uint8_t failFragmentLength : 1;
+      uint8_t failTrailerMatch : 1;
+      uint8_t moreTrailers : 1;
+      uint8_t crcModified : 1;
+      uint8_t slinkError : 1;
+      uint8_t wrongFedId : 1;      
+    };
+    };
+
+    GEMAMC13Status(const FEDRawData& fedData) {
+      FEDTrailer trailer(fedData.data() + fedData.size() - FEDTrailer::length);
+      Errors ferror{0};
+      ferror.InValidSize = ( (fedData.size() / sizeof(uint64_t)) < 5);
+      ferror.failTrailerCheck = trailer.check();
+      ferror.failFragmentLength = (trailer.fragmentLength() * sizeof(uint64_t) != fedData.size());
+      ferror.moreTrailers = trailer.moreTrailers();
+      ferror.crcModified = trailer.crcModified();
+      ferror.slinkError = trailer.slinkError();
+      ferror.wrongFedId = trailer.wrongFedId();
+      errors_ = ferror.codes;
+    }
+
+    bool isGood() { return errors_ == 0;}
+    bool isBad() { return errors_ != 0;}
+    uint16_t errors() { return errors_; }
+
+    private:
+
+    uint8_t errors_;
+
+    };
+}
+#endif

--- a/DataFormats/GEMDigi/interface/GEMAMC13Status.h
+++ b/DataFormats/GEMDigi/interface/GEMAMC13Status.h
@@ -5,6 +5,7 @@
 #include "DataFormats/FEDRawData/interface/FEDRawData.h"
 #include "DataFormats/FEDRawData/interface/FEDTrailer.h"
 #include <bitset>
+#include <ostream>
 
 class GEMAMC13Status {
 public:

--- a/DataFormats/GEMDigi/interface/GEMAMC13StatusCollection.h
+++ b/DataFormats/GEMDigi/interface/GEMAMC13StatusCollection.h
@@ -1,0 +1,9 @@
+#ifndef DataFormats_GEMDigi_GEMAMC13StatusCollection_h
+#define DataFormats_GEMDigi_GEMAMC13StatusCollection_h
+
+#include "DataFormats/MuonData/interface/MuonDigiCollection.h"
+#include "DataFormats/GEMDigi/interface/GEMAMC13Status.h"
+
+typedef MuonDigiCollection<uint16_t, GEMAMC13Status> GEMAMC13StatusCollection;
+
+#endif

--- a/DataFormats/GEMDigi/interface/GEMAMCStatus.h
+++ b/DataFormats/GEMDigi/interface/GEMAMCStatus.h
@@ -1,0 +1,65 @@
+#ifndef DataFormats_GEMDigi_GEMAMCStatus_h
+#define DataFormats_GEMDigi_GEMAMCStatus_h
+#include "AMC13Event.h"
+#include "AMCdata.h"
+
+namespace gem {
+
+    class GEMAMCStatus {
+    public:
+    union Errors {
+    uint16_t ecodes;
+    struct {
+      uint16_t InvalidAMC : 1;
+      uint16_t badEC : 1; // event counter
+      uint16_t badBC : 1; // bunch crossing
+      uint16_t badOC : 1; // orbit number
+      uint16_t badRunType : 1;
+      uint16_t badCRC : 1;
+      uint16_t MMCMlocked : 1; 
+      uint16_t DAQclocklocked : 1;
+      uint16_t DAQnotReday : 1;
+      uint16_t BC0locked : 1;
+      uint16_t InvalidAMCSize : 1;
+    };
+    };
+    union Warnings {
+    uint8_t wcodes;
+    struct {
+      uint8_t backPressure : 1;
+    };
+    };
+
+    GEMAMCStatus(const AMC13Event* amc13, const AMCdata& amc, int isValidAMC) {
+        Errors error{0};
+        error.InvalidAMC = !isValidAMC;
+        error.badEC = (amc13->lv1Id() != amc.lv1Id());
+        error.badBC = (amc13->bunchCrossing() != amc.bunchCrossing());
+        error.badRunType = amc.runType() != 0x1; 
+        error.badOC = (amc13->orbitNumber() != amc.orbitNumber());
+        error.badCRC = (amc13->crc() != amc.crc());
+        error.MMCMlocked = !amc.mmcmLocked();
+        error.DAQclocklocked = !amc.daqClockLocked();
+        error.DAQnotReday = !amc.daqReady();
+        error.BC0locked = !amc.bc0locked();
+        //error.InvalidAMCSize = amc13->getAMCsize(i) != amc.dataLength();
+        errors_ = error.ecodes;
+
+        Warnings warn{0};
+        warn.backPressure = amc.backPressure();
+        warnings_ = warn.wcodes;
+    }
+
+    bool isGood() { return errors_ == 0;}
+    bool isBad() { return errors_ != 0;}
+    uint16_t errors() { return errors_; }
+    uint8_t warnings() { return warnings_; }
+
+    private:
+
+    uint16_t errors_;
+    uint8_t warnings_;
+
+    };
+}
+#endif

--- a/DataFormats/GEMDigi/interface/GEMAMCStatus.h
+++ b/DataFormats/GEMDigi/interface/GEMAMCStatus.h
@@ -4,76 +4,74 @@
 #include "AMCdata.h"
 #include <bitset>
 
-    class GEMAMCStatus {
-    public:
-    union Errors {
+class GEMAMCStatus {
+public:
+  union Errors {
     uint16_t ecodes;
     struct {
-      uint16_t badEC : 1; // event counter
-      uint16_t badBC : 1; // bunch crossing
-      uint16_t badOC : 1; // orbit number
+      uint16_t badEC : 1;  // event counter
+      uint16_t badBC : 1;  // bunch crossing
+      uint16_t badOC : 1;  // orbit number
       uint16_t badRunType : 1;
       uint16_t badCRC : 1;
-      uint16_t MMCMlocked : 1; 
+      uint16_t MMCMlocked : 1;
       uint16_t DAQclocklocked : 1;
       uint16_t DAQnotReday : 1;
       uint16_t BC0locked : 1;
       uint16_t InvalidAMCSize : 1;
     };
-    };
-    union Warnings {
+  };
+  union Warnings {
     uint8_t wcodes;
     struct {
       uint8_t InValidOH : 1;
       uint8_t backPressure : 1;
     };
-    };
+  };
 
-    GEMAMCStatus(){}
-    GEMAMCStatus(const gem::AMC13Event* amc13, const gem::AMCdata& amc) {
-        amcNum_ = amc.amcNum();
-        Errors error{0};
-        error.badEC = (amc13->lv1Id() != amc.lv1Id());
-        error.badBC = (amc13->bunchCrossing() != amc.bunchCrossing());
-        error.badRunType = amc.runType() != 0x1; 
-        error.badOC = (amc13->orbitNumber() != amc.orbitNumber());
-        error.badCRC = (amc13->crc() != amc.crc());
-        error.MMCMlocked = !amc.mmcmLocked();
-        error.DAQclocklocked = !amc.daqClockLocked();
-        error.DAQnotReday = !amc.daqReady();
-        error.BC0locked = !amc.bc0locked();
-        //error.InvalidAMCSize = amc13->getAMCsize(i) != amc.dataLength();
-        errors_ = error.ecodes;
+  GEMAMCStatus() {}
+  GEMAMCStatus(const gem::AMC13Event* amc13, const gem::AMCdata& amc) {
+    amcNum_ = amc.amcNum();
+    Errors error{0};
+    error.badEC = (amc13->lv1Id() != amc.lv1Id());
+    error.badBC = (amc13->bunchCrossing() != amc.bunchCrossing());
+    error.badRunType = amc.runType() != 0x1;
+    error.badOC = (amc13->orbitNumber() != amc.orbitNumber());
+    error.badCRC = (amc13->crc() != amc.crc());
+    error.MMCMlocked = !amc.mmcmLocked();
+    error.DAQclocklocked = !amc.daqClockLocked();
+    error.DAQnotReday = !amc.daqReady();
+    error.BC0locked = !amc.bc0locked();
+    //error.InvalidAMCSize = amc13->getAMCsize(i) != amc.dataLength();
+    errors_ = error.ecodes;
 
-        Warnings warn{0};
-        warn.backPressure = amc.backPressure();
-        warnings_ = warn.wcodes;
-    }
+    Warnings warn{0};
+    warn.backPressure = amc.backPressure();
+    warnings_ = warn.wcodes;
+  }
 
-    void inValidOH() {
-      Warnings warn{warnings_};
-      warn.InValidOH = 1;
-      warnings_ = warn.wcodes;
-    }
+  void inValidOH() {
+    Warnings warn{warnings_};
+    warn.InValidOH = 1;
+    warnings_ = warn.wcodes;
+  }
 
-    uint8_t amcNumber() const { return amcNum_; };
-    bool isGood() const { return errors_ == 0;}
-    bool isBad() const { return errors_ != 0;}
-    uint16_t errors() const { return errors_; }
-    uint8_t warnings() const { return warnings_; }
+  uint8_t amcNumber() const { return amcNum_; };
+  bool isGood() const { return errors_ == 0; }
+  bool isBad() const { return errors_ != 0; }
+  uint16_t errors() const { return errors_; }
+  uint8_t warnings() const { return warnings_; }
 
-    private:
+private:
+  uint8_t amcNum_;
+  uint16_t errors_;
+  uint8_t warnings_;
+};
 
-    uint8_t amcNum_;
-    uint16_t errors_;
-    uint8_t warnings_;
-
-    };
-
-    std::ostream& operator<< (std::ostream &out, const GEMAMCStatus &status)
-    {
-      out << "GEMAMCStatus errors " << std::bitset<16>(status.errors()) << " warnings "<< std::bitset<8>(status.warnings());
-      return out;
-    }
+std::ostream& operator<<(std::ostream& out, const GEMAMCStatus& status) {
+  out << "GEMAMCStatus errors " << std::bitset<16>(status.errors()) << " warnings "
+      << std::bitset<8>(status.warnings());
+  return out;
+}
 
 #endif

--- a/DataFormats/GEMDigi/interface/GEMAMCStatus.h
+++ b/DataFormats/GEMDigi/interface/GEMAMCStatus.h
@@ -3,6 +3,7 @@
 #include "AMC13Event.h"
 #include "AMCdata.h"
 #include <bitset>
+#include <ostream>
 
 class GEMAMCStatus {
 public:

--- a/DataFormats/GEMDigi/interface/GEMAMCStatus.h
+++ b/DataFormats/GEMDigi/interface/GEMAMCStatus.h
@@ -37,7 +37,6 @@ public:
     error.badBC = (amc13->bunchCrossing() != amc.bunchCrossing());
     error.badRunType = amc.runType() != 0x1;
     error.badOC = (amc13->orbitNumber() != amc.orbitNumber());
-    error.badCRC = (amc13->crc() != amc.crc());
     error.MMCMlocked = !amc.mmcmLocked();
     error.DAQclocklocked = !amc.daqClockLocked();
     error.DAQnotReday = !amc.daqReady();

--- a/DataFormats/GEMDigi/interface/GEMAMCStatus.h
+++ b/DataFormats/GEMDigi/interface/GEMAMCStatus.h
@@ -19,7 +19,6 @@ public:
       uint16_t DAQclocklocked : 1;
       uint16_t DAQnotReday : 1;
       uint16_t BC0locked : 1;
-      uint16_t InvalidAMCSize : 1;
     };
   };
   union Warnings {
@@ -43,7 +42,6 @@ public:
     error.DAQclocklocked = !amc.daqClockLocked();
     error.DAQnotReday = !amc.daqReady();
     error.BC0locked = !amc.bc0locked();
-    //error.InvalidAMCSize = amc13->getAMCsize(i) != amc.dataLength();
     errors_ = error.ecodes;
 
     Warnings warn{0};
@@ -58,7 +56,6 @@ public:
   }
 
   uint8_t amcNumber() const { return amcNum_; };
-  bool isGood() const { return errors_ == 0; }
   bool isBad() const { return errors_ != 0; }
   uint16_t errors() const { return errors_; }
   uint8_t warnings() const { return warnings_; }

--- a/DataFormats/GEMDigi/interface/GEMAMCStatus.h
+++ b/DataFormats/GEMDigi/interface/GEMAMCStatus.h
@@ -68,7 +68,7 @@ private:
   uint8_t warnings_;
 };
 
-std::ostream& operator<<(std::ostream& out, const GEMAMCStatus& status) {
+inline std::ostream& operator<<(std::ostream& out, const GEMAMCStatus& status) {
   out << "GEMAMCStatus errors " << std::bitset<16>(status.errors()) << " warnings "
       << std::bitset<8>(status.warnings());
   return out;

--- a/DataFormats/GEMDigi/interface/GEMAMCStatusCollection.h
+++ b/DataFormats/GEMDigi/interface/GEMAMCStatusCollection.h
@@ -1,0 +1,9 @@
+#ifndef DataFormats_GEMDigi_GEMAMCStatusCollection_h
+#define DataFormats_GEMDigi_GEMAMCStatusCollection_h
+
+#include "DataFormats/MuonData/interface/MuonDigiCollection.h"
+#include "DataFormats/GEMDigi/interface/GEMAMCStatus.h"
+
+typedef MuonDigiCollection<uint16_t, GEMAMCStatus> GEMAMCStatusCollection;
+
+#endif

--- a/DataFormats/GEMDigi/interface/GEMOHStatus.h
+++ b/DataFormats/GEMDigi/interface/GEMOHStatus.h
@@ -64,7 +64,6 @@ public:
     warnings_ = warn.wcodes;
   }
 
-  bool isGood() const { return errors_ == 0; }
   bool isBad() const { return errors_ != 0; }
   uint16_t errors() const { return errors_; }
   uint8_t warnings() const { return warnings_; }

--- a/DataFormats/GEMDigi/interface/GEMOHStatus.h
+++ b/DataFormats/GEMDigi/interface/GEMOHStatus.h
@@ -1,0 +1,83 @@
+#ifndef DataFormats_GEMDigi_GEMOHStatus_h
+#define DataFormats_GEMDigi_GEMOHStatus_h
+#include "GEBdata.h"
+
+// GEM OptoHyrid status
+namespace gem {
+
+    class GEMOHStatus {
+    public:
+
+    union Errors {
+    uint16_t codes;
+    struct {
+      uint16_t InValidOptoHybrid : 1; // input link not found
+      uint16_t EvtF : 1;              // Event FIFO full
+      uint16_t InF : 1;               // Input FIFO full
+      uint16_t L1aF : 1;              // L1A FIFO full
+      uint16_t EvtSzOFW : 1;          // Event size overflow
+      uint16_t Inv : 1;               // Invalid event
+      uint16_t OOScAvV : 1;           // Out of Sync (EC mismatch) AMC vs VFAT
+      uint16_t OOScVvV : 1;           // Out of Sync (EC mismatch) VFAT vs VFAT
+      uint16_t BxmAvV : 1;            // BX mismatch AMC vs VFAT
+      uint16_t BxmVvV : 1;            // 1st bit BX mismatch VFAT vs VFAT
+      uint16_t InUfw : 1;             // Input FIFO underflow
+      uint16_t badVFatCount : 1;
+    };
+    };
+    union Warnings {
+    uint8_t wcodes;
+    struct {
+      uint8_t EvtNF : 1;             // Event FIFO near full
+      uint8_t InNF : 1;              // Input FIFO near full
+      uint8_t L1aNF : 1;             // L1A FIFO near full
+      uint8_t EvtSzW : 1;            // Event size warning
+    };
+    };
+
+    GEMOHStatus(const GEBdata& oh, bool InValidOH) {
+      Errors error{0};
+      error.InValidOptoHybrid = InValidOH;
+      error.EvtF = oh.evtF();
+      error.InF = oh.inF();
+      error.L1aF = oh.l1aF();
+      error.EvtSzOFW = oh.evtSzOFW();
+      error.Inv = oh.inv();
+      error.OOScAvV = oh.oOScAvV();
+      error.OOScVvV = oh.oOScVvV();
+      error.BxmAvV = oh.bxmAvV();
+      error.BxmVvV = oh.bxmVvV();
+      error.InUfw = oh.inUfw();
+      error.badVFatCount = oh.vfatWordCnt() != oh.vfatWordCntT();
+      errors_ = error.codes;
+      
+      Warnings warn{0};
+      warn.EvtNF = oh.evtNF();
+      warn.InNF = oh.inNF();
+      warn.L1aNF = oh.l1aNF();
+      warn.EvtSzW = oh.evtSzW();
+      warnings_ = warn.wcodes;
+    }
+
+    bool isGood() { return errors_ == 0;}
+    bool isBad() { return errors_ != 0;}
+    uint16_t errors() { return errors_; }
+    uint8_t warnings() { return warnings_; }
+
+    private:
+
+    uint16_t errors_;
+    uint8_t warnings_;
+
+/*
+        // check if Chamber exists.
+        if (!gemROMap->isValidChamber(geb_ec)) {
+          unknownChamber = true;
+          LogDebug("GEMRawToDigiModule") << "InValid: amcNum " << int(amcNum) << " gebId " << int(gebId);
+          continue;
+        }
+*/
+
+    };
+}
+#endif

--- a/DataFormats/GEMDigi/interface/GEMOHStatus.h
+++ b/DataFormats/GEMDigi/interface/GEMOHStatus.h
@@ -4,82 +4,78 @@
 #include <bitset>
 
 // GEM OptoHyrid status
-    class GEMOHStatus {
-    public:
-
-    union Errors {
+class GEMOHStatus {
+public:
+  union Errors {
     uint16_t codes;
     struct {
-      uint16_t EvtF : 1;              // Event FIFO full
-      uint16_t InF : 1;               // Input FIFO full
-      uint16_t L1aF : 1;              // L1A FIFO full
-      uint16_t EvtSzOFW : 1;          // Event size overflow
-      uint16_t Inv : 1;               // Invalid event
-      uint16_t OOScAvV : 1;           // Out of Sync (EC mismatch) AMC vs VFAT
-      uint16_t OOScVvV : 1;           // Out of Sync (EC mismatch) VFAT vs VFAT
-      uint16_t BxmAvV : 1;            // BX mismatch AMC vs VFAT
-      uint16_t BxmVvV : 1;            // 1st bit BX mismatch VFAT vs VFAT
-      uint16_t InUfw : 1;             // Input FIFO underflow
+      uint16_t EvtF : 1;      // Event FIFO full
+      uint16_t InF : 1;       // Input FIFO full
+      uint16_t L1aF : 1;      // L1A FIFO full
+      uint16_t EvtSzOFW : 1;  // Event size overflow
+      uint16_t Inv : 1;       // Invalid event
+      uint16_t OOScAvV : 1;   // Out of Sync (EC mismatch) AMC vs VFAT
+      uint16_t OOScVvV : 1;   // Out of Sync (EC mismatch) VFAT vs VFAT
+      uint16_t BxmAvV : 1;    // BX mismatch AMC vs VFAT
+      uint16_t BxmVvV : 1;    // 1st bit BX mismatch VFAT vs VFAT
+      uint16_t InUfw : 1;     // Input FIFO underflow
       uint16_t badVFatCount : 1;
     };
-    };
-    union Warnings {
+  };
+  union Warnings {
     uint8_t wcodes;
     struct {
-      uint8_t EvtNF : 1;             // Event FIFO near full
-      uint8_t InNF : 1;              // Input FIFO near full
-      uint8_t L1aNF : 1;             // L1A FIFO near full
-      uint8_t EvtSzW : 1;            // Event size warning
+      uint8_t EvtNF : 1;   // Event FIFO near full
+      uint8_t InNF : 1;    // Input FIFO near full
+      uint8_t L1aNF : 1;   // L1A FIFO near full
+      uint8_t EvtSzW : 1;  // Event size warning
       uint8_t InValidVFAT : 1;
     };
-    };
+  };
 
-    GEMOHStatus(){}
-    GEMOHStatus(const gem::GEBdata& oh) {
-      Errors error{0};
-      error.EvtF = oh.evtF();
-      error.InF = oh.inF();
-      error.L1aF = oh.l1aF();
-      error.EvtSzOFW = oh.evtSzOFW();
-      error.Inv = oh.inv();
-      error.OOScAvV = oh.oOScAvV();
-      error.OOScVvV = oh.oOScVvV();
-      error.BxmAvV = oh.bxmAvV();
-      error.BxmVvV = oh.bxmVvV();
-      error.InUfw = oh.inUfw();
-      error.badVFatCount = oh.vfatWordCnt() != oh.vfatWordCntT();
-      errors_ = error.codes;
-      
-      Warnings warn{0};
-      warn.EvtNF = oh.evtNF();
-      warn.InNF = oh.inNF();
-      warn.L1aNF = oh.l1aNF();
-      warn.EvtSzW = oh.evtSzW();
-      warnings_ = warn.wcodes;
-    }
+  GEMOHStatus() {}
+  GEMOHStatus(const gem::GEBdata& oh) {
+    Errors error{0};
+    error.EvtF = oh.evtF();
+    error.InF = oh.inF();
+    error.L1aF = oh.l1aF();
+    error.EvtSzOFW = oh.evtSzOFW();
+    error.Inv = oh.inv();
+    error.OOScAvV = oh.oOScAvV();
+    error.OOScVvV = oh.oOScVvV();
+    error.BxmAvV = oh.bxmAvV();
+    error.BxmVvV = oh.bxmVvV();
+    error.InUfw = oh.inUfw();
+    error.badVFatCount = oh.vfatWordCnt() != oh.vfatWordCntT();
+    errors_ = error.codes;
 
-    void inValidVFAT() {
-      Warnings warn{warnings_};
-      warn.InValidVFAT = 1;
-      warnings_ = warn.wcodes;
-    }
+    Warnings warn{0};
+    warn.EvtNF = oh.evtNF();
+    warn.InNF = oh.inNF();
+    warn.L1aNF = oh.l1aNF();
+    warn.EvtSzW = oh.evtSzW();
+    warnings_ = warn.wcodes;
+  }
 
-    bool isGood() const { return errors_ == 0;}
-    bool isBad() const { return errors_ != 0;}
-    uint16_t errors() const { return errors_; }
-    uint8_t warnings() const { return warnings_; }
+  void inValidVFAT() {
+    Warnings warn{warnings_};
+    warn.InValidVFAT = 1;
+    warnings_ = warn.wcodes;
+  }
 
-    private:
+  bool isGood() const { return errors_ == 0; }
+  bool isBad() const { return errors_ != 0; }
+  uint16_t errors() const { return errors_; }
+  uint8_t warnings() const { return warnings_; }
 
-    uint16_t errors_;
-    uint8_t warnings_;
+private:
+  uint16_t errors_;
+  uint8_t warnings_;
+};
 
-    };
-
-    std::ostream& operator<< (std::ostream &out, const GEMOHStatus &status)
-    {
-      out << "GEMOHStatus errors " << std::bitset<16>(status.errors()) << " warnings "<< std::bitset<8>(status.warnings());
-      return out;
-    }
+std::ostream& operator<<(std::ostream& out, const GEMOHStatus& status) {
+  out << "GEMOHStatus errors " << std::bitset<16>(status.errors()) << " warnings " << std::bitset<8>(status.warnings());
+  return out;
+}
 
 #endif

--- a/DataFormats/GEMDigi/interface/GEMOHStatus.h
+++ b/DataFormats/GEMDigi/interface/GEMOHStatus.h
@@ -1,17 +1,15 @@
 #ifndef DataFormats_GEMDigi_GEMOHStatus_h
 #define DataFormats_GEMDigi_GEMOHStatus_h
 #include "GEBdata.h"
+#include <bitset>
 
 // GEM OptoHyrid status
-namespace gem {
-
     class GEMOHStatus {
     public:
 
     union Errors {
     uint16_t codes;
     struct {
-      uint16_t InValidOptoHybrid : 1; // input link not found
       uint16_t EvtF : 1;              // Event FIFO full
       uint16_t InF : 1;               // Input FIFO full
       uint16_t L1aF : 1;              // L1A FIFO full
@@ -32,12 +30,13 @@ namespace gem {
       uint8_t InNF : 1;              // Input FIFO near full
       uint8_t L1aNF : 1;             // L1A FIFO near full
       uint8_t EvtSzW : 1;            // Event size warning
+      uint8_t InValidVFAT : 1;
     };
     };
 
-    GEMOHStatus(const GEBdata& oh, bool InValidOH) {
+    GEMOHStatus(){}
+    GEMOHStatus(const gem::GEBdata& oh) {
       Errors error{0};
-      error.InValidOptoHybrid = InValidOH;
       error.EvtF = oh.evtF();
       error.InF = oh.inF();
       error.L1aF = oh.l1aF();
@@ -59,25 +58,28 @@ namespace gem {
       warnings_ = warn.wcodes;
     }
 
-    bool isGood() { return errors_ == 0;}
-    bool isBad() { return errors_ != 0;}
-    uint16_t errors() { return errors_; }
-    uint8_t warnings() { return warnings_; }
+    void inValidVFAT() {
+      Warnings warn{warnings_};
+      warn.InValidVFAT = 1;
+      warnings_ = warn.wcodes;
+    }
+
+    bool isGood() const { return errors_ == 0;}
+    bool isBad() const { return errors_ != 0;}
+    uint16_t errors() const { return errors_; }
+    uint8_t warnings() const { return warnings_; }
 
     private:
 
     uint16_t errors_;
     uint8_t warnings_;
 
-/*
-        // check if Chamber exists.
-        if (!gemROMap->isValidChamber(geb_ec)) {
-          unknownChamber = true;
-          LogDebug("GEMRawToDigiModule") << "InValid: amcNum " << int(amcNum) << " gebId " << int(gebId);
-          continue;
-        }
-*/
-
     };
-}
+
+    std::ostream& operator<< (std::ostream &out, const GEMOHStatus &status)
+    {
+      out << "GEMOHStatus errors " << std::bitset<16>(status.errors()) << " warnings "<< std::bitset<8>(status.warnings());
+      return out;
+    }
+
 #endif

--- a/DataFormats/GEMDigi/interface/GEMOHStatus.h
+++ b/DataFormats/GEMDigi/interface/GEMOHStatus.h
@@ -2,6 +2,7 @@
 #define DataFormats_GEMDigi_GEMOHStatus_h
 #include "GEBdata.h"
 #include <bitset>
+#include <ostream>
 
 // GEM OptoHybrid status
 class GEMOHStatus {

--- a/DataFormats/GEMDigi/interface/GEMOHStatus.h
+++ b/DataFormats/GEMDigi/interface/GEMOHStatus.h
@@ -3,7 +3,7 @@
 #include "GEBdata.h"
 #include <bitset>
 
-// GEM OptoHyrid status
+// GEM OptoHybrid status
 class GEMOHStatus {
 public:
   union Errors {

--- a/DataFormats/GEMDigi/interface/GEMOHStatus.h
+++ b/DataFormats/GEMDigi/interface/GEMOHStatus.h
@@ -73,7 +73,7 @@ private:
   uint8_t warnings_;
 };
 
-std::ostream& operator<<(std::ostream& out, const GEMOHStatus& status) {
+inline std::ostream& operator<<(std::ostream& out, const GEMOHStatus& status) {
   out << "GEMOHStatus errors " << std::bitset<16>(status.errors()) << " warnings " << std::bitset<8>(status.warnings());
   return out;
 }

--- a/DataFormats/GEMDigi/interface/GEMOHStatusCollection.h
+++ b/DataFormats/GEMDigi/interface/GEMOHStatusCollection.h
@@ -1,0 +1,10 @@
+#ifndef DataFormats_GEMDigi_GEMOHStatusCollection_h
+#define DataFormats_GEMDigi_GEMOHStatusCollection_h
+
+#include "DataFormats/MuonData/interface/MuonDigiCollection.h"
+#include "DataFormats/MuonDetId/interface/GEMDetId.h"
+#include "DataFormats/GEMDigi/interface/GEMOHStatus.h"
+
+typedef MuonDigiCollection<GEMDetId, GEMOHStatus> GEMOHStatusCollection;
+
+#endif

--- a/DataFormats/GEMDigi/interface/GEMVFATStatus.h
+++ b/DataFormats/GEMDigi/interface/GEMVFATStatus.h
@@ -1,0 +1,65 @@
+#ifndef DataFormats_GEMDigi_GEMVFATStatus_h
+#define DataFormats_GEMDigi_GEMVFATStatus_h
+#include "GEBdata.h"
+
+namespace gem {
+
+    class GEMVFATStatus {
+    public:
+
+    union Errors {
+    uint8_t codes;
+    struct {
+      uint8_t InValidPosition : 1; 
+      uint8_t vc : 1; // VFAT CRC error
+      uint8_t InValidHeader : 1;
+      uint8_t EC : 1; // does not match AMC EC
+      uint8_t BC : 1; // does not match AMC BC
+    };
+    };
+    union Warnings {
+    uint8_t wcodes;
+    struct {
+      uint8_t basicOFW : 1;             // Basic overflow warning
+      uint8_t zeroSupOFW : 1;              // Zero-sup overflow warning
+    };
+    };
+
+    GEMVFATStatus(const AMCdata& amc, const VFATdata& vfat, bool inValidPosition) {
+      Errors error{0};
+      error.InValidPosition = inValidPosition;
+      error.vc = vfat.vc();
+      error.EC = vfat.ec() != amc.lv1Id();
+      error.BC = vfat.bc() != amc.bunchCrossing();
+        
+      Warnings warn{0};
+      if (vfat.header() == 0x1E)
+        warn.basicOFW = 0;
+      else if (vfat.header() == 0x5E)
+        warn.basicOFW = 1;
+      else if (vfat.header() == 0x1A)
+        warn.zeroSupOFW = 0;
+      else if (vfat.header() == 0x56)
+        warn.zeroSupOFW = 1;
+      else 
+        error.InValidHeader = 1;
+        
+      errors_ = error.codes;
+      warnings_ = warn.wcodes;
+
+    }
+
+    bool isGood() { return errors_ == 0;}
+    bool isBad() { return errors_ != 0;}
+    uint8_t errors() { return errors_; }
+    uint8_t warnings() { return warnings_; }
+
+    private:
+
+    uint16_t errors_;
+    uint8_t warnings_;
+
+
+    };
+}
+#endif

--- a/DataFormats/GEMDigi/interface/GEMVFATStatus.h
+++ b/DataFormats/GEMDigi/interface/GEMVFATStatus.h
@@ -3,68 +3,65 @@
 #include "GEBdata.h"
 #include <bitset>
 
-    class GEMVFATStatus {
-    public:
-
-    union Errors {
+class GEMVFATStatus {
+public:
+  union Errors {
     uint8_t codes;
     struct {
-      uint8_t vc : 1; // VFAT CRC error
+      uint8_t vc : 1;  // VFAT CRC error
       uint8_t InValidHeader : 1;
-      uint8_t EC : 1; // does not match AMC EC
-      uint8_t BC : 1; // does not match AMC BC
+      uint8_t EC : 1;  // does not match AMC EC
+      uint8_t BC : 1;  // does not match AMC BC
     };
-    };
-    union Warnings {
+  };
+  union Warnings {
     uint8_t wcodes;
     struct {
-      uint8_t basicOFW : 1;             // Basic overflow warning
-      uint8_t zeroSupOFW : 1;           // Zero-sup overflow warning
+      uint8_t basicOFW : 1;    // Basic overflow warning
+      uint8_t zeroSupOFW : 1;  // Zero-sup overflow warning
     };
-    };
+  };
 
-    GEMVFATStatus(){}
-    GEMVFATStatus(const gem::AMCdata& amc, const gem::VFATdata& vfat, uint16_t position) {
-      Errors error{0};
-      error.vc = vfat.vc();
-      error.EC = vfat.ec() != amc.lv1Idt();
-      error.BC = vfat.bc() != amc.bunchCrossing();
-       
-      Warnings warn{0};
-      if (vfat.header() == 0x1E)
-        warn.basicOFW = 0;
-      else if (vfat.header() == 0x5E)
-        warn.basicOFW = 1;
-      else if (vfat.header() == 0x1A)
-        warn.zeroSupOFW = 0;
-      else if (vfat.header() == 0x56)
-        warn.zeroSupOFW = 1;
-      else 
-        error.InValidHeader = 1;
-        
-      vfatPosition_ = position;
+  GEMVFATStatus() {}
+  GEMVFATStatus(const gem::AMCdata& amc, const gem::VFATdata& vfat, uint16_t position) {
+    Errors error{0};
+    error.vc = vfat.vc();
+    error.EC = vfat.ec() != amc.lv1Idt();
+    error.BC = vfat.bc() != amc.bunchCrossing();
 
-      errors_ = error.codes;
-      warnings_ = warn.wcodes;      
-    }
+    Warnings warn{0};
+    if (vfat.header() == 0x1E)
+      warn.basicOFW = 0;
+    else if (vfat.header() == 0x5E)
+      warn.basicOFW = 1;
+    else if (vfat.header() == 0x1A)
+      warn.zeroSupOFW = 0;
+    else if (vfat.header() == 0x56)
+      warn.zeroSupOFW = 1;
+    else
+      error.InValidHeader = 1;
 
-    uint16_t vfatPosition() const {return vfatPosition_;}
-    bool isGood() const { return errors_ == 0;}
-    bool isBad() const { return errors_ != 0;}
-    uint16_t errors() const { return errors_; }
-    uint8_t warnings() const { return warnings_; }
+    vfatPosition_ = position;
 
-    private:
+    errors_ = error.codes;
+    warnings_ = warn.wcodes;
+  }
 
-    uint16_t vfatPosition_;
-    uint16_t errors_;
-    uint8_t warnings_;
+  uint16_t vfatPosition() const { return vfatPosition_; }
+  bool isGood() const { return errors_ == 0; }
+  bool isBad() const { return errors_ != 0; }
+  uint16_t errors() const { return errors_; }
+  uint8_t warnings() const { return warnings_; }
 
-    };
+private:
+  uint16_t vfatPosition_;
+  uint16_t errors_;
+  uint8_t warnings_;
+};
 
-    std::ostream& operator<< (std::ostream &out, const GEMVFATStatus &status)
-    {
-      out << "GEMVFATStatus errors " << std::bitset<8>(status.errors()) << " warnings "<< std::bitset<8>(status.warnings());
-      return out;
-    }
+std::ostream& operator<<(std::ostream& out, const GEMVFATStatus& status) {
+  out << "GEMVFATStatus errors " << std::bitset<8>(status.errors()) << " warnings "
+      << std::bitset<8>(status.warnings());
+  return out;
+}
 #endif

--- a/DataFormats/GEMDigi/interface/GEMVFATStatus.h
+++ b/DataFormats/GEMDigi/interface/GEMVFATStatus.h
@@ -1,7 +1,9 @@
 #ifndef DataFormats_GEMDigi_GEMVFATStatus_h
 #define DataFormats_GEMDigi_GEMVFATStatus_h
-#include "GEBdata.h"
+#include "AMCdata.h"
+#include "VFATdata.h"
 #include <bitset>
+#include <ostream>
 
 class GEMVFATStatus {
 public:

--- a/DataFormats/GEMDigi/interface/GEMVFATStatus.h
+++ b/DataFormats/GEMDigi/interface/GEMVFATStatus.h
@@ -27,23 +27,25 @@ public:
   GEMVFATStatus() {}
   GEMVFATStatus(const gem::AMCdata& amc, const gem::VFATdata& vfat, uint16_t position, bool readMultiBX) {
     Errors error{0};
-    error.vc = vfat.vc();
+    Warnings warn{0};
+
     error.EC = vfat.ec() != amc.lv1Idt();
     if (!readMultiBX)
       error.BC = vfat.bc() != amc.bunchCrossing();
 
-    Warnings warn{0};
-    if (vfat.header() == 0x1E)
-      warn.basicOFW = 0;
-    else if (vfat.header() == 0x5E)
-      warn.basicOFW = 1;
-    else if (vfat.header() == 0x1A)
-      warn.zeroSupOFW = 0;
-    else if (vfat.header() == 0x56)
-      warn.zeroSupOFW = 1;
-    else
-      error.InValidHeader = 1;
-
+    if (vfat.version() > 2) {
+      error.vc = vfat.vc();
+      if (vfat.header() == 0x1E)
+        warn.basicOFW = 0;
+      else if (vfat.header() == 0x5E)
+        warn.basicOFW = 1;
+      else if (vfat.header() == 0x1A)
+        warn.zeroSupOFW = 0;
+      else if (vfat.header() == 0x56)
+        warn.zeroSupOFW = 1;
+      else
+        error.InValidHeader = 1;
+    }
     vfatPosition_ = position;
 
     errors_ = error.codes;

--- a/DataFormats/GEMDigi/interface/GEMVFATStatus.h
+++ b/DataFormats/GEMDigi/interface/GEMVFATStatus.h
@@ -1,8 +1,7 @@
 #ifndef DataFormats_GEMDigi_GEMVFATStatus_h
 #define DataFormats_GEMDigi_GEMVFATStatus_h
 #include "GEBdata.h"
-
-namespace gem {
+#include <bitset>
 
     class GEMVFATStatus {
     public:
@@ -10,7 +9,6 @@ namespace gem {
     union Errors {
     uint8_t codes;
     struct {
-      uint8_t InValidPosition : 1; 
       uint8_t vc : 1; // VFAT CRC error
       uint8_t InValidHeader : 1;
       uint8_t EC : 1; // does not match AMC EC
@@ -21,17 +19,17 @@ namespace gem {
     uint8_t wcodes;
     struct {
       uint8_t basicOFW : 1;             // Basic overflow warning
-      uint8_t zeroSupOFW : 1;              // Zero-sup overflow warning
+      uint8_t zeroSupOFW : 1;           // Zero-sup overflow warning
     };
     };
 
-    GEMVFATStatus(const AMCdata& amc, const VFATdata& vfat, bool inValidPosition) {
+    GEMVFATStatus(){}
+    GEMVFATStatus(const gem::AMCdata& amc, const gem::VFATdata& vfat, uint16_t position) {
       Errors error{0};
-      error.InValidPosition = inValidPosition;
       error.vc = vfat.vc();
-      error.EC = vfat.ec() != amc.lv1Id();
+      error.EC = vfat.ec() != amc.lv1Idt();
       error.BC = vfat.bc() != amc.bunchCrossing();
-        
+       
       Warnings warn{0};
       if (vfat.header() == 0x1E)
         warn.basicOFW = 0;
@@ -44,22 +42,29 @@ namespace gem {
       else 
         error.InValidHeader = 1;
         
-      errors_ = error.codes;
-      warnings_ = warn.wcodes;
+      vfatPosition_ = position;
 
+      errors_ = error.codes;
+      warnings_ = warn.wcodes;      
     }
 
-    bool isGood() { return errors_ == 0;}
-    bool isBad() { return errors_ != 0;}
-    uint8_t errors() { return errors_; }
-    uint8_t warnings() { return warnings_; }
+    uint16_t vfatPosition() const {return vfatPosition_;}
+    bool isGood() const { return errors_ == 0;}
+    bool isBad() const { return errors_ != 0;}
+    uint16_t errors() const { return errors_; }
+    uint8_t warnings() const { return warnings_; }
 
     private:
 
+    uint16_t vfatPosition_;
     uint16_t errors_;
     uint8_t warnings_;
 
-
     };
-}
+
+    std::ostream& operator<< (std::ostream &out, const GEMVFATStatus &status)
+    {
+      out << "GEMVFATStatus errors " << std::bitset<8>(status.errors()) << " warnings "<< std::bitset<8>(status.warnings());
+      return out;
+    }
 #endif

--- a/DataFormats/GEMDigi/interface/GEMVFATStatus.h
+++ b/DataFormats/GEMDigi/interface/GEMVFATStatus.h
@@ -60,7 +60,7 @@ private:
   uint8_t warnings_;
 };
 
-std::ostream& operator<<(std::ostream& out, const GEMVFATStatus& status) {
+inline std::ostream& operator<<(std::ostream& out, const GEMVFATStatus& status) {
   out << "GEMVFATStatus errors " << std::bitset<8>(status.errors()) << " warnings "
       << std::bitset<8>(status.warnings());
   return out;

--- a/DataFormats/GEMDigi/interface/GEMVFATStatus.h
+++ b/DataFormats/GEMDigi/interface/GEMVFATStatus.h
@@ -23,11 +23,12 @@ public:
   };
 
   GEMVFATStatus() {}
-  GEMVFATStatus(const gem::AMCdata& amc, const gem::VFATdata& vfat, uint16_t position) {
+  GEMVFATStatus(const gem::AMCdata& amc, const gem::VFATdata& vfat, uint16_t position, bool readMultiBX) {
     Errors error{0};
     error.vc = vfat.vc();
     error.EC = vfat.ec() != amc.lv1Idt();
-    error.BC = vfat.bc() != amc.bunchCrossing();
+    if (!readMultiBX)
+      error.BC = vfat.bc() != amc.bunchCrossing();
 
     Warnings warn{0};
     if (vfat.header() == 0x1E)

--- a/DataFormats/GEMDigi/interface/GEMVFATStatus.h
+++ b/DataFormats/GEMDigi/interface/GEMVFATStatus.h
@@ -53,7 +53,6 @@ public:
   }
 
   uint16_t vfatPosition() const { return vfatPosition_; }
-  bool isGood() const { return errors_ == 0; }
   bool isBad() const { return errors_ != 0; }
   uint16_t errors() const { return errors_; }
   uint8_t warnings() const { return warnings_; }

--- a/DataFormats/GEMDigi/interface/GEMVFATStatusCollection.h
+++ b/DataFormats/GEMDigi/interface/GEMVFATStatusCollection.h
@@ -1,0 +1,10 @@
+#ifndef DataFormats_GEMDigi_GEMVFATStatusCollection_h
+#define DataFormats_GEMDigi_GEMVFATStatusCollection_h
+
+#include "DataFormats/MuonData/interface/MuonDigiCollection.h"
+#include "DataFormats/MuonDetId/interface/GEMDetId.h"
+#include "DataFormats/GEMDigi/interface/GEMVFATStatus.h"
+
+typedef MuonDigiCollection<GEMDetId, GEMVFATStatus> GEMVFATStatusCollection;
+
+#endif

--- a/DataFormats/GEMDigi/interface/VFATdata.h
+++ b/DataFormats/GEMDigi/interface/VFATdata.h
@@ -15,8 +15,9 @@ namespace gem {
       uint64_t header : 8;    ///<normally 0x1E. 0x5E indicates that the VFAT3 internal buffer
       // is half-full, so it's like a warning
       uint64_t vc : 1;      /// VFAT CRC Error
-      uint64_t unused : 7;  ///<bits 183:177 are not used, should be 0, bit 176 is 1 if CTP7 detected a CRC mismatch
-      uint64_t pos : 8;     ///<an 8bit value indicating the VFAT position on this GEB (it can be 0 to 23)
+      uint64_t : 7;         // unused
+      uint64_t pos : 5;     ///<an 8bit value indicating the VFAT position on this GEB (it can be 0 to 23)
+      uint64_t : 3;         // unused
     };
     // v2 dataformat
     struct {
@@ -100,8 +101,9 @@ namespace gem {
 
     /// v3
     uint8_t header() const { return VFATfirst{fw_}.header; }
-    uint8_t crcCheck() const { return VFATfirst{fw_}.vc; }
+    bool vc() const { return VFATfirst{fw_}.vc; }
     uint8_t position() const { return VFATfirst{fw_}.pos; }
+    uint8_t crcCheck() const { return VFATfirst{fw_}.vc; } // to be removed
 
     /// v2
     uint8_t b1010() const { return VFATfirst{fw_}.b1010; }

--- a/DataFormats/GEMDigi/interface/VFATdata.h
+++ b/DataFormats/GEMDigi/interface/VFATdata.h
@@ -52,7 +52,7 @@ namespace gem {
     // this constructor only used for packing sim digis
     VFATdata(const int vfatVer,
              const uint16_t BC,
-             const uint8_t EC,
+             const uint32_t EC,
              const uint16_t chipID,
              const uint64_t lsDatas,
              const uint64_t msDatas);

--- a/DataFormats/GEMDigi/interface/VFATdata.h
+++ b/DataFormats/GEMDigi/interface/VFATdata.h
@@ -14,10 +14,10 @@ namespace gem {
       uint64_t ec : 8;        ///<Event Counter, 8 bits
       uint64_t header : 8;    ///<normally 0x1E. 0x5E indicates that the VFAT3 internal buffer
       // is half-full, so it's like a warning
-      uint64_t vc : 1;      /// VFAT CRC Error
-      uint64_t : 7;         // unused
-      uint64_t pos : 5;     ///<an 8bit value indicating the VFAT position on this GEB (it can be 0 to 23)
-      uint64_t : 3;         // unused
+      uint64_t vc : 1;   /// VFAT CRC Error
+      uint64_t : 7;      // unused
+      uint64_t pos : 5;  ///<an 8bit value indicating the VFAT position on this GEB (it can be 0 to 23)
+      uint64_t : 3;      // unused
     };
     // v2 dataformat
     struct {
@@ -103,7 +103,7 @@ namespace gem {
     uint8_t header() const { return VFATfirst{fw_}.header; }
     bool vc() const { return VFATfirst{fw_}.vc; }
     uint8_t position() const { return VFATfirst{fw_}.pos; }
-    uint8_t crcCheck() const { return VFATfirst{fw_}.vc; } // to be removed
+    uint8_t crcCheck() const { return VFATfirst{fw_}.vc; }  // to be removed
 
     /// v2
     uint8_t b1010() const { return VFATfirst{fw_}.b1010; }

--- a/DataFormats/GEMDigi/interface/VFATdata.h
+++ b/DataFormats/GEMDigi/interface/VFATdata.h
@@ -16,8 +16,7 @@ namespace gem {
       // is half-full, so it's like a warning
       uint64_t vc : 1;   /// VFAT CRC Error
       uint64_t : 7;      // unused
-      uint64_t pos : 5;  ///<an 8bit value indicating the VFAT position on this GEB (it can be 0 to 23)
-      uint64_t : 3;      // unused
+      uint64_t pos : 8;  // VFAT position on chamber, 5 used in GE11 but more is needed for phase2
     };
     // v2 dataformat
     struct {

--- a/DataFormats/GEMDigi/src/AMCdata.cc
+++ b/DataFormats/GEMDigi/src/AMCdata.cc
@@ -1,6 +1,6 @@
 #include <cstdint>
 #include "DataFormats/GEMDigi/interface/AMCdata.h"
-
+#include <iostream>
 using namespace gem;
 
 void AMCdata::setAMCheader1(uint32_t dataLength, uint16_t bxID, uint32_t l1AID, uint8_t AMCnum) {
@@ -13,7 +13,7 @@ void AMCdata::setAMCheader1(uint32_t dataLength, uint16_t bxID, uint32_t l1AID, 
 
   AMCTrailer ut{0};
   ut.dataLength = dataLength;
-  ut.l1AIDT = l1AID;
+  ut.l1AID = l1AID;
   amct_ = ut.word;
 }
 

--- a/DataFormats/GEMDigi/src/VFATdata.cc
+++ b/DataFormats/GEMDigi/src/VFATdata.cc
@@ -6,7 +6,7 @@ VFATdata::VFATdata() : ver_(0), phiPos_(0), fw_(0), sw_(0), tw_(0) {}
 
 VFATdata::VFATdata(const int vfatVer,
                    const uint16_t BC,
-                   const uint8_t EC,
+                   const uint32_t EC,
                    const uint16_t chipID,
                    const uint64_t lsDatas,
                    const uint64_t msDatas) {

--- a/DataFormats/GEMDigi/src/classes.h
+++ b/DataFormats/GEMDigi/src/classes.h
@@ -10,6 +10,18 @@
 #include "DataFormats/GEMDigi/interface/GEMCoPadDigi.h"
 #include "DataFormats/GEMDigi/interface/GEMCoPadDigiCollection.h"
 
+#include "DataFormats/GEMDigi/interface/GEMAMC13Status.h"
+#include "DataFormats/GEMDigi/interface/GEMAMC13StatusCollection.h"
+
+#include "DataFormats/GEMDigi/interface/GEMAMCStatus.h"
+#include "DataFormats/GEMDigi/interface/GEMAMCStatusCollection.h"
+
+#include "DataFormats/GEMDigi/interface/GEMOHStatus.h"
+#include "DataFormats/GEMDigi/interface/GEMOHStatusCollection.h"
+
+#include "DataFormats/GEMDigi/interface/GEMVFATStatus.h"
+#include "DataFormats/GEMDigi/interface/GEMVFATStatusCollection.h"
+
 #include "DataFormats/GEMDigi/interface/GEMVfatStatusDigi.h"
 #include "DataFormats/GEMDigi/interface/GEMVfatStatusDigiCollection.h"
 

--- a/DataFormats/GEMDigi/src/classes_def.xml
+++ b/DataFormats/GEMDigi/src/classes_def.xml
@@ -42,8 +42,8 @@
 <class name="MuonDigiCollection<GEMDetId,GEMCoPadDigi>"/>
 <class name="edm::Wrapper<MuonDigiCollection<GEMDetId,GEMCoPadDigi> >" splitLevel="0"/>
 
-<class name="GEMAMC13Status" ClassVersion="-1">
- <version ClassVersion="-1" checksum="3469985462"/>
+<class name="GEMAMC13Status" ClassVersion="3">
+ <version ClassVersion="3" checksum="3469985462"/>
 </class>
 <class name="std::vector<GEMAMC13Status>"/>
 <class name="std::map<uint16_t,std::vector<GEMAMC13Status> >"/>
@@ -51,8 +51,8 @@
 <class name="MuonDigiCollection<uint16_t,GEMAMC13Status>"/>
 <class name="edm::Wrapper<MuonDigiCollection<uint16_t,GEMAMC13Status> >" splitLevel="0"/>
 
-<class name="GEMAMCStatus" ClassVersion="-1">
- <version ClassVersion="-1" checksum="2120084327"/>
+<class name="GEMAMCStatus" ClassVersion="3">
+ <version ClassVersion="3" checksum="2120084327"/>
 </class>
 <class name="std::vector<GEMAMCStatus>"/>
 <class name="std::map<uint16_t,std::vector<GEMAMCStatus> >"/>
@@ -60,8 +60,8 @@
 <class name="MuonDigiCollection<uint16_t,GEMAMCStatus>"/>
 <class name="edm::Wrapper<MuonDigiCollection<uint16_t,GEMAMCStatus> >" splitLevel="0"/>
 
-<class name="GEMOHStatus" ClassVersion="-1">
- <version ClassVersion="-1" checksum="1715607020"/>
+<class name="GEMOHStatus" ClassVersion="3">
+ <version ClassVersion="3" checksum="1715607020"/>
 </class>
 <class name="std::vector<GEMOHStatus>"/>
 <class name="std::map<GEMDetId,std::vector<GEMOHStatus> >"/>
@@ -69,8 +69,8 @@
 <class name="MuonDigiCollection<GEMDetId,GEMOHStatus>"/>
 <class name="edm::Wrapper<MuonDigiCollection<GEMDetId,GEMOHStatus> >" splitLevel="0"/>
 
-<class name="GEMVFATStatus" ClassVersion="-1">
- <version ClassVersion="-1" checksum="2994917778"/>
+<class name="GEMVFATStatus" ClassVersion="3">
+ <version ClassVersion="3" checksum="2994917778"/>
 </class>
 <class name="std::vector<GEMVFATStatus>"/>
 <class name="std::map<GEMDetId,std::vector<GEMVFATStatus> >"/>

--- a/DataFormats/GEMDigi/src/classes_def.xml
+++ b/DataFormats/GEMDigi/src/classes_def.xml
@@ -42,6 +42,42 @@
 <class name="MuonDigiCollection<GEMDetId,GEMCoPadDigi>"/>
 <class name="edm::Wrapper<MuonDigiCollection<GEMDetId,GEMCoPadDigi> >" splitLevel="0"/>
 
+<class name="GEMAMC13Status" ClassVersion="-1">
+ <version ClassVersion="-1" checksum="3469985462"/>
+</class>
+<class name="std::vector<GEMAMC13Status>"/>
+<class name="std::map<uint16_t,std::vector<GEMAMC13Status> >"/>
+<class name="std::pair<uint16_t,std::vector<GEMAMC13Status> >"/>
+<class name="MuonDigiCollection<uint16_t,GEMAMC13Status>"/>
+<class name="edm::Wrapper<MuonDigiCollection<uint16_t,GEMAMC13Status> >" splitLevel="0"/>
+
+<class name="GEMAMCStatus" ClassVersion="-1">
+ <version ClassVersion="-1" checksum="2120084327"/>
+</class>
+<class name="std::vector<GEMAMCStatus>"/>
+<class name="std::map<uint16_t,std::vector<GEMAMCStatus> >"/>
+<class name="std::pair<uint16_t,std::vector<GEMAMCStatus> >"/>
+<class name="MuonDigiCollection<uint16_t,GEMAMCStatus>"/>
+<class name="edm::Wrapper<MuonDigiCollection<uint16_t,GEMAMCStatus> >" splitLevel="0"/>
+
+<class name="GEMOHStatus" ClassVersion="-1">
+ <version ClassVersion="-1" checksum="1715607020"/>
+</class>
+<class name="std::vector<GEMOHStatus>"/>
+<class name="std::map<GEMDetId,std::vector<GEMOHStatus> >"/>
+<class name="std::pair<GEMDetId,std::vector<GEMOHStatus> >"/>
+<class name="MuonDigiCollection<GEMDetId,GEMOHStatus>"/>
+<class name="edm::Wrapper<MuonDigiCollection<GEMDetId,GEMOHStatus> >" splitLevel="0"/>
+
+<class name="GEMVFATStatus" ClassVersion="-1">
+ <version ClassVersion="-1" checksum="2994917778"/>
+</class>
+<class name="std::vector<GEMVFATStatus>"/>
+<class name="std::map<GEMDetId,std::vector<GEMVFATStatus> >"/>
+<class name="std::pair<GEMDetId,std::vector<GEMVFATStatus> >"/>
+<class name="MuonDigiCollection<GEMDetId,GEMVFATStatus>"/>
+<class name="edm::Wrapper<MuonDigiCollection<GEMDetId,GEMVFATStatus> >" splitLevel="0"/>
+
 <class name="GEMVfatStatusDigi" ClassVersion="4">
  <version ClassVersion="4" checksum="1981269550"/>
  <version ClassVersion="3" checksum="569767420"/>

--- a/EventFilter/GEMRawToDigi/plugins/BuildFile.xml
+++ b/EventFilter/GEMRawToDigi/plugins/BuildFile.xml
@@ -1,3 +1,4 @@
+<use name="CommonTools/UtilAlgos"/>
 <use name="CondFormats/DataRecord"/>
 <use name="CondFormats/GEMObjects"/>
 <use name="DataFormats/Common"/>

--- a/EventFilter/GEMRawToDigi/plugins/GEMDigiToRawModule.cc
+++ b/EventFilter/GEMRawToDigi/plugins/GEMDigiToRawModule.cc
@@ -182,7 +182,7 @@ void GEMDigiToRawModule::produce(edm::StreamID iID, edm::Event& iEvent, edm::Eve
               continue;
             // only make vfat with hits
             amcSize += 3;
-            auto vfatData = std::make_unique<VFATdata>(geb_dc.vfatVer, bc, 0, vfatId, lsData, msData);
+            auto vfatData = std::make_unique<VFATdata>(geb_dc.vfatVer, bc, LV1_id, vfatId, lsData, msData);
             gebData->addVFAT(*vfatData);
           }
         }  // end of vfats in GEB

--- a/EventFilter/GEMRawToDigi/plugins/GEMDigiToRawModule.cc
+++ b/EventFilter/GEMRawToDigi/plugins/GEMDigiToRawModule.cc
@@ -173,9 +173,9 @@ void GEMDigiToRawModule::produce(edm::StreamID iID, edm::Event& iEvent, edm::Eve
                 msData |= 1UL << (chMap.chNum - 64);
 
               LogDebug("GEMDigiToRawModule")
-                  << " fed: " << fedId << " amc:" << int(amcNum) << " geb:" << int(gebId)
-                  << " vfat:" << vfat_dc.localPhi << ",type: " << vfat_dc.vfatType << " id:" << gemId
-                  << " ch:" << chMap.chNum << " st:" << digi.strip() << " bx:" << digi.bx();
+                  << "fed: " << fedId << " amc:" << int(amcNum) << " geb:" << int(gebId) << " vfat id:" << int(vfatId)
+                  << ",type:" << vfat_dc.vfatType << " id:" << gemId << " ch:" << chMap.chNum << " st:" << digi.strip()
+                  << " bx:" << digi.bx();
             }
 
             if (!hasDigi)

--- a/EventFilter/GEMRawToDigi/plugins/GEMPackingTester.cc
+++ b/EventFilter/GEMRawToDigi/plugins/GEMPackingTester.cc
@@ -92,9 +92,10 @@ void GEMPackingTester::analyze(const edm::Event& iEvent, const edm::EventSetup& 
           foundDigi = true;
       }
       if (!foundDigi) {
-        cout << "simMuonGEMDigi NOT found " << gemId << " " << digi->strip() << " " << digi->bx() << endl;
+        edm::LogInfo("GEMPackingTester") << "simMuonGEMDigi NOT found " << gemId << " " << digi->strip() << " "
+                                         << digi->bx();
         for (auto unpackeddigi = packed.first; unpackeddigi != packed.second; ++unpackeddigi) {
-          cout << "rec " << unpackeddigi->strip() << " " << unpackeddigi->bx() << endl;
+          edm::LogInfo("GEMPackingTester") << "rec " << unpackeddigi->strip() << " " << unpackeddigi->bx();
         }
       }
     }

--- a/EventFilter/GEMRawToDigi/plugins/GEMPackingTester.cc
+++ b/EventFilter/GEMRawToDigi/plugins/GEMPackingTester.cc
@@ -1,0 +1,129 @@
+#include <memory>
+#include <iostream>
+#include <TTree.h>
+
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "CommonTools/UtilAlgos/interface/TFileService.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "DataFormats/FEDRawData/interface/FEDNumbering.h"
+#include "DataFormats/FEDRawData/interface/FEDRawDataCollection.h"
+#include "DataFormats/FEDRawData/interface/FEDTrailer.h"
+#include "DataFormats/GEMDigi/interface/GEMDigiCollection.h"
+
+using namespace std;
+class GEMPackingTester : public edm::one::EDAnalyzer<edm::one::SharedResources> {
+public:
+  explicit GEMPackingTester(const edm::ParameterSet&);
+  ~GEMPackingTester();
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+private:
+  void beginJob() override;
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
+  void endJob() override;
+
+  edm::EDGetTokenT<FEDRawDataCollection> fedToken_;
+  edm::EDGetTokenT<GEMDigiCollection> gemDigiToken_;
+  edm::EDGetTokenT<GEMDigiCollection> gemSimDigiToken_;
+
+  TTree* tree_;
+  int b_ge0, b_ge1, b_ge2;
+};
+
+GEMPackingTester::GEMPackingTester(const edm::ParameterSet& iConfig)
+    : fedToken_(consumes<FEDRawDataCollection>(iConfig.getParameter<edm::InputTag>("fed"))),
+      gemDigiToken_(consumes<GEMDigiCollection>(iConfig.getParameter<edm::InputTag>("gemDigi"))),
+      gemSimDigiToken_(consumes<GEMDigiCollection>(iConfig.getParameter<edm::InputTag>("gemSimDigi"))) {
+  usesResource("TFileService");
+  edm::Service<TFileService> fs;
+  tree_ = fs->make<TTree>("fed", "fed");
+  tree_->Branch("ge0", &b_ge0, "ge0/I");
+  tree_->Branch("ge1", &b_ge1, "ge1/I");
+  tree_->Branch("ge2", &b_ge2, "ge2/I");
+}
+
+GEMPackingTester::~GEMPackingTester() {}
+
+void GEMPackingTester::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  using namespace edm;
+
+  b_ge0 = 0;
+  b_ge1 = 0;
+  b_ge2 = 0;
+
+  edm::Handle<FEDRawDataCollection> fed_buffers;
+  iEvent.getByToken(fedToken_, fed_buffers);
+  for (unsigned int fedId = FEDNumbering::MINGEMFEDID; fedId <= FEDNumbering::MAXGEMFEDID; ++fedId) {
+    const FEDRawData& fedData = fed_buffers->FEDData(fedId);
+
+    //int nWords = fedData.size() / sizeof(uint64_t);
+    // std::cout << " fedId:" << fedId
+    //           << " fed Size:" << fedData.size()
+    //           << " words:" << nWords
+    //           << std::endl;
+
+    if (fedId == 1473 or fedId == 1474)
+      b_ge0 += fedData.size();
+    if (fedId == 1467 or fedId == 1468)
+      b_ge1 += fedData.size();
+    if (fedId == 1469 or fedId == 1470)
+              b_ge2 += fedData.size();
+  }
+  // std::cout << " ge0:" << b_ge0
+  //           << " ge1:" << b_ge1
+  //           << " ge2:" << b_ge2
+  //           << std::endl;
+
+  edm::Handle<GEMDigiCollection> gemDigis;
+  iEvent.getByToken(gemDigiToken_, gemDigis);
+  edm::Handle<GEMDigiCollection> gemSimDigis;
+  iEvent.getByToken(gemSimDigiToken_, gemSimDigis);
+
+  for (auto const& simDigi : *gemSimDigis) {
+    const GEMDetId& gemId = simDigi.first;
+    const GEMDigiCollection::Range& sim = simDigi.second;
+    const GEMDigiCollection::Range& packed = gemDigis->get(gemId);
+
+    int nsims = 0;
+    for (auto digi = sim.first; digi != sim.second; ++digi) {
+      nsims++;
+    }
+    int npacked = 0;
+    for (auto digi = packed.first; digi != packed.second; ++digi) {
+      npacked++;
+    }
+    if (nsims != npacked) {
+      cout << gemId << endl;
+      for (auto digi = sim.first; digi != sim.second; ++digi) {
+        cout << "sim " << digi->strip() << " " << digi->bx() << endl;
+      }
+      for (auto digi = packed.first; digi != packed.second; ++digi) {
+        cout << "rec " << digi->strip() << " " << digi->bx() << endl;
+      }
+    }
+  }
+
+  tree_->Fill();
+}
+
+void GEMPackingTester::beginJob() {}
+
+void GEMPackingTester::endJob() {}
+
+void GEMPackingTester::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.add<edm::InputTag>("fed", edm::InputTag("rawDataCollector"));
+  desc.add<edm::InputTag>("gemDigi", edm::InputTag("muonGEMDigis"));
+  desc.add<edm::InputTag>("gemSimDigi", edm::InputTag("simMuonGEMDigis"));
+  descriptions.add("GEMPackingTester", desc);
+}
+
+DEFINE_FWK_MODULE(GEMPackingTester);

--- a/EventFilter/GEMRawToDigi/plugins/GEMPackingTester.cc
+++ b/EventFilter/GEMRawToDigi/plugins/GEMPackingTester.cc
@@ -61,10 +61,10 @@ void GEMPackingTester::analyze(const edm::Event& iEvent, const edm::EventSetup& 
   b_ge1 = 0;
   b_ge2 = 0;
 
-  edm::Handle<FEDRawDataCollection> fed_buffers;
-  iEvent.getByToken(fedToken_, fed_buffers);
+  auto const& fed_buffers = iEvent.get(fedToken_);
+
   for (unsigned int fedId = FEDNumbering::MINGEMFEDID; fedId <= FEDNumbering::MAXGEMFEDID; ++fedId) {
-    const FEDRawData& fedData = fed_buffers->FEDData(fedId);
+    const FEDRawData& fedData = fed_buffers.FEDData(fedId);
 
     if (fedId == 1473 or fedId == 1474)
       b_ge0 += fedData.size();
@@ -74,15 +74,13 @@ void GEMPackingTester::analyze(const edm::Event& iEvent, const edm::EventSetup& 
       b_ge2 += fedData.size();
   }
 
-  edm::Handle<GEMDigiCollection> gemDigis;
-  iEvent.getByToken(gemDigiToken_, gemDigis);
-  edm::Handle<GEMDigiCollection> gemSimDigis;
-  iEvent.getByToken(gemSimDigiToken_, gemSimDigis);
+  auto const& gemDigis = iEvent.get(gemDigiToken_);
+  auto const& gemSimDigis = iEvent.get(gemSimDigiToken_);
 
-  for (auto const& simDigi : *gemSimDigis) {
+  for (auto const& simDigi : gemSimDigis) {
     const GEMDetId& gemId = simDigi.first;
     const GEMDigiCollection::Range& sim = simDigi.second;
-    const GEMDigiCollection::Range& packed = gemDigis->get(gemId);
+    const GEMDigiCollection::Range& packed = gemDigis.get(gemId);
 
     for (auto digi = sim.first; digi != sim.second; ++digi) {
       if (!readMultiBX_ && digi->bx() != 0)

--- a/EventFilter/GEMRawToDigi/plugins/GEMPackingTester.cc
+++ b/EventFilter/GEMRawToDigi/plugins/GEMPackingTester.cc
@@ -94,10 +94,12 @@ void GEMPackingTester::analyze(const edm::Event& iEvent, const edm::EventSetup& 
 
     int nsims = 0;
     for (auto digi = sim.first; digi != sim.second; ++digi) {
+      if (digi->bx()==0)
       nsims++;
     }
     int npacked = 0;
     for (auto digi = packed.first; digi != packed.second; ++digi) {
+      if (digi->bx()==0)
       npacked++;
     }
     if (nsims != npacked) {

--- a/EventFilter/GEMRawToDigi/plugins/GEMPackingTester.cc
+++ b/EventFilter/GEMRawToDigi/plugins/GEMPackingTester.cc
@@ -94,11 +94,11 @@ void GEMPackingTester::analyze(const edm::Event& iEvent, const edm::EventSetup& 
 
     int nsims = 0;
     for (auto digi = sim.first; digi != sim.second; ++digi) {
-        nsims++;
+      nsims++;
     }
     int npacked = 0;
     for (auto digi = packed.first; digi != packed.second; ++digi) {
-        npacked++;
+      npacked++;
     }
     if (nsims != npacked) {
       cout << gemId << endl;

--- a/EventFilter/GEMRawToDigi/plugins/GEMPackingTester.cc
+++ b/EventFilter/GEMRawToDigi/plugins/GEMPackingTester.cc
@@ -21,7 +21,7 @@ using namespace std;
 class GEMPackingTester : public edm::one::EDAnalyzer<edm::one::SharedResources> {
 public:
   explicit GEMPackingTester(const edm::ParameterSet&);
-  ~GEMPackingTester();
+  ~GEMPackingTester() override;
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
@@ -75,7 +75,7 @@ void GEMPackingTester::analyze(const edm::Event& iEvent, const edm::EventSetup& 
     if (fedId == 1467 or fedId == 1468)
       b_ge1 += fedData.size();
     if (fedId == 1469 or fedId == 1470)
-              b_ge2 += fedData.size();
+      b_ge2 += fedData.size();
   }
   // std::cout << " ge0:" << b_ge0
   //           << " ge1:" << b_ge1

--- a/EventFilter/GEMRawToDigi/plugins/GEMPackingTester.cc
+++ b/EventFilter/GEMRawToDigi/plugins/GEMPackingTester.cc
@@ -94,13 +94,11 @@ void GEMPackingTester::analyze(const edm::Event& iEvent, const edm::EventSetup& 
 
     int nsims = 0;
     for (auto digi = sim.first; digi != sim.second; ++digi) {
-      if (digi->bx()==0)
-      nsims++;
+        nsims++;
     }
     int npacked = 0;
     for (auto digi = packed.first; digi != packed.second; ++digi) {
-      if (digi->bx()==0)
-      npacked++;
+        npacked++;
     }
     if (nsims != npacked) {
       cout << gemId << endl;

--- a/EventFilter/GEMRawToDigi/plugins/GEMRawToDigiModule.cc
+++ b/EventFilter/GEMRawToDigi/plugins/GEMRawToDigiModule.cc
@@ -11,11 +11,11 @@
 #include "DataFormats/FEDRawData/interface/FEDNumbering.h"
 #include "DataFormats/FEDRawData/interface/FEDRawDataCollection.h"
 #include "DataFormats/FEDRawData/interface/FEDTrailer.h"
+#include "DataFormats/GEMDigi/interface/GEMAMC13StatusCollection.h"
+#include "DataFormats/GEMDigi/interface/GEMAMCStatusCollection.h"
+#include "DataFormats/GEMDigi/interface/GEMOHStatusCollection.h"
+#include "DataFormats/GEMDigi/interface/GEMVFATStatusCollection.h"
 #include "DataFormats/GEMDigi/interface/AMC13Event.h"
-#include "DataFormats/GEMDigi/interface/GEMAMC13Status.h"
-#include "DataFormats/GEMDigi/interface/GEMAMCStatus.h"
-#include "DataFormats/GEMDigi/interface/GEMOHStatus.h"
-#include "DataFormats/GEMDigi/interface/GEMVFATStatus.h"
 #include "DataFormats/GEMDigi/interface/GEMAMC13EventCollection.h"
 #include "DataFormats/GEMDigi/interface/GEMAMCdataCollection.h"
 #include "DataFormats/GEMDigi/interface/GEMDigiCollection.h"
@@ -51,7 +51,7 @@ public:
 private:
   edm::EDGetTokenT<FEDRawDataCollection> fed_token;
   edm::ESGetToken<GEMeMap, GEMeMapRcd> gemEMapToken_;
-  bool useDBEMap_;
+  bool useDBEMap_, keepDAQStatus_;
   bool unPackStatusDigis_;
   std::unique_ptr<GEMRawToDigi> gemRawToDigi_;
 };
@@ -64,10 +64,18 @@ using namespace gem;
 GEMRawToDigiModule::GEMRawToDigiModule(const edm::ParameterSet& pset)
     : fed_token(consumes<FEDRawDataCollection>(pset.getParameter<edm::InputTag>("InputLabel"))),
       useDBEMap_(pset.getParameter<bool>("useDBEMap")),
+      keepDAQStatus_(pset.getParameter<bool>("keepDAQStatus")),
       unPackStatusDigis_(pset.getParameter<bool>("unPackStatusDigis")),
       gemRawToDigi_(std::make_unique<GEMRawToDigi>()) {
   produces<GEMDigiCollection>();
+  if (keepDAQStatus_) {
+    produces<GEMAMC13StatusCollection>("AMC13Status");
+    produces<GEMAMCStatusCollection>("AMCStatus");
+    produces<GEMOHStatusCollection>("OHStatus");
+    produces<GEMVFATStatusCollection>("VFATStatus");
+  }
   if (unPackStatusDigis_) {
+   // to be removed
     produces<GEMVfatStatusDigiCollection>("vfatStatus");
     produces<GEMGEBdataCollection>("gebStatus");
     produces<GEMAMCdataCollection>("AMCdata");
@@ -83,6 +91,7 @@ void GEMRawToDigiModule::fillDescriptions(edm::ConfigurationDescriptions& descri
   desc.add<edm::InputTag>("InputLabel", edm::InputTag("rawDataCollector"));
   desc.add<bool>("useDBEMap", false);
   desc.add<bool>("unPackStatusDigis", false);
+  desc.add<bool>("keepDAQStatus", false);
   descriptions.add("muonGEMDigisDefault", desc);
 }
 
@@ -104,10 +113,17 @@ std::shared_ptr<GEMROMapping> GEMRawToDigiModule::globalBeginRun(edm::Run const&
 
 void GEMRawToDigiModule::produce(edm::StreamID iID, edm::Event& iEvent, edm::EventSetup const& iSetup) const {
   auto outGEMDigis = std::make_unique<GEMDigiCollection>();
-  auto outVFATStatus = std::make_unique<GEMVfatStatusDigiCollection>();
+  auto outAMC13Status = std::make_unique<GEMAMC13StatusCollection>();
+  auto outAMCStatus = std::make_unique<GEMAMCStatusCollection>();
+  auto outOHStatus = std::make_unique<GEMOHStatusCollection>();
+  auto outVFATStatus = std::make_unique<GEMVFATStatusCollection>();
+
+  // to be removed
+  auto outVFATStatusOld = std::make_unique<GEMVfatStatusDigiCollection>();
   auto outGEBStatus = std::make_unique<GEMGEBdataCollection>();
   auto outAMCdata = std::make_unique<GEMAMCdataCollection>();
   auto outAMC13Event = std::make_unique<GEMAMC13EventCollection>();
+
 
   // Take raw from the event
   edm::Handle<FEDRawDataCollection> fed_buffers;
@@ -121,24 +137,39 @@ void GEMRawToDigiModule::produce(edm::StreamID iID, edm::Event& iEvent, edm::Eve
     int nWords = fedData.size() / sizeof(uint64_t);
     LogDebug("GEMRawToDigiModule") << "fedId:" << fedId << " words: " << nWords;
     GEMAMC13Status st_amc13 = GEMAMC13Status(fedData);
-    if (st_amc13.isBad()) continue;
+    
+    if (st_amc13.isBad()){
+      LogDebug("GEMRawToDigiModule") << st_amc13 ;
+      if (keepDAQStatus_) {        
+        outAMC13Status.get()->insertDigi(fedId, st_amc13);
+      }
+      continue;
+    }
 
     const uint64_t* word = reinterpret_cast<const uint64_t*>(fedData.data());
     auto amc13Event = gemRawToDigi_->convertWordToAMC13Event(word);
-
     LogDebug("GEMRawToDigiModule") << "Event bx:" << iEvent.bunchCrossing() << " lv1Id:" << iEvent.id().event()
                                    << " orbitNumber:" << iEvent.orbitNumber();
     LogDebug("GEMRawToDigiModule") << "AMC13 bx:" << amc13Event->bunchCrossing() << " lv1Id:" << int(amc13Event->lv1Id())
                                    << " orbitNumber:" << amc13Event->orbitNumber();
 
-    bool unknownChamber = false, unknownVFat = false, badVfat = false;
-
     // Read AMC data
     for (auto amcData : *(amc13Event->getAMCpayloads())) {
       uint8_t amcNum = amcData.amcNum();
       GEMROMapping::sectorEC amcEC{fedId, amcNum};
-      GEMAMCStatus st_amc = GEMAMCStatus(amc13Event.get(), amcData, gemROMap->isValidAMC(amcEC));
-      if (st_amc.isBad()) continue;
+      if (!gemROMap->isValidAMC(amcEC)) {
+        st_amc13.inValidAMC();
+        continue;
+      }
+
+      GEMAMCStatus st_amc = GEMAMCStatus(amc13Event.get(), amcData);
+      if (st_amc.isBad()){
+        LogDebug("GEMRawToDigiModule") << st_amc ;
+        if (keepDAQStatus_) {
+          outAMCStatus.get()->insertDigi(fedId, st_amc);
+        }
+        continue;
+      }
       
       uint16_t amcBx = amcData.bunchCrossing();
       LogDebug("GEMRawToDigiModule") << "AMC no.:" << int(amcData.amcNum()) << " bx:" << int(amcData.bunchCrossing())
@@ -149,25 +180,47 @@ void GEMRawToDigiModule::produce(edm::StreamID iID, edm::Event& iEvent, edm::Eve
         uint8_t gebId = optoHybrid.inputID();
         GEMROMapping::chamEC geb_ec{fedId, amcNum, gebId};
 
-        GEMOHStatus st_oh = GEMOHStatus(optoHybrid, !gemROMap->isValidChamber(geb_ec));
-        if (st_oh.isBad()) continue;
-
+        bool isValidChamber = gemROMap->isValidChamber(geb_ec);
+        if (!isValidChamber) {
+          st_amc.inValidOH();
+          continue;
+        }
         GEMROMapping::chamDC geb_dc = gemROMap->chamberPos(geb_ec);
         GEMDetId gemChId = geb_dc.detId;
 
+        GEMOHStatus st_oh = GEMOHStatus(optoHybrid);
+        if (st_oh.isBad()){
+        LogDebug("GEMRawToDigiModule") << st_oh ;
+        if (keepDAQStatus_) {
+          outOHStatus.get()->insertDigi(gemChId, st_oh);
+        }
+        }
+
         //Read vfat data
         for (auto vfatData : *optoHybrid.vFATs()) {
+          // set vfat fw version
           vfatData.setVersion(geb_dc.vfatVer);
           uint16_t vfatId = vfatData.vfatId();
           GEMROMapping::vfatEC vfat_ec{vfatId, gemChId};
-
-          GEMVFATStatus st_vfat = GEMVFATStatus(amcData, vfatData, !gemROMap->isValidChipID(vfat_ec));
-          if (st_vfat.isBad()) continue;
+          
+          if (!gemROMap->isValidChipID(vfat_ec)){
+            st_oh.inValidVFAT();
+            continue;
+          }
 
           GEMROMapping::vfatDC vfat_dc = gemROMap->vfatPos(vfat_ec);
-
           vfatData.setPhi(vfat_dc.localPhi);
           GEMDetId gemId = vfat_dc.detId;
+
+          GEMVFATStatus st_vfat = GEMVFATStatus(amcData, vfatData, vfatData.phi());
+          if (st_vfat.isBad()){
+            LogDebug("GEMRawToDigiModule") << st_vfat ;
+            if (keepDAQStatus_) {
+              outVFATStatus.get()->insertDigi(gemId, st_vfat);
+            }
+            continue;
+          }
+
           int bx(vfatData.bc() - amcBx);
 
           for (int chan = 0; chan < VFATdata::nChannels; ++chan) {
@@ -197,19 +250,31 @@ void GEMRawToDigiModule::produce(edm::StreamID iID, edm::Event& iEvent, edm::Eve
 
           }  // end of channel loop
 
-          if (unPackStatusDigis_) {
-            outVFATStatus.get()->insertDigi(gemId, GEMVfatStatusDigi(vfatData));
+          LogDebug("GEMRawToDigiModule") << st_vfat ;
+          if (keepDAQStatus_) {
+            outVFATStatus.get()->insertDigi(gemId, st_vfat);
+          }
+          if (unPackStatusDigis_) {              
+              outVFATStatusOld.get()->insertDigi(gemId, GEMVfatStatusDigi(vfatData));
           }
 
         }  // end of vfat loop
 
+        LogDebug("GEMRawToDigiModule") << st_oh ;
+        if (keepDAQStatus_) {
+          outOHStatus.get()->insertDigi(gemChId, st_oh);
+        }
         if (unPackStatusDigis_) {
-          optoHybrid.clearVFATs();
+          optoHybrid.clearVFATs();          
           outGEBStatus.get()->insertDigi(gemChId.chamberId(), (optoHybrid));
         }
 
-      }  // end of geb loop
-
+      }  // end of optohybrid loop
+      
+      LogDebug("GEMRawToDigiModule") << st_amc ;
+      if (keepDAQStatus_) {
+        outAMCStatus.get()->insertDigi(fedId, st_amc);
+      }
       if (unPackStatusDigis_) {
         amcData.clearGEBs();
         outAMCdata.get()->insertDigi(amcData.boardId(), (amcData));
@@ -217,22 +282,28 @@ void GEMRawToDigiModule::produce(edm::StreamID iID, edm::Event& iEvent, edm::Eve
 
     }  // end of amc loop
 
+    LogDebug("GEMRawToDigiModule") << st_amc13 ;
+      if (keepDAQStatus_) {
+      outAMC13Status.get()->insertDigi(fedId, st_amc13);
+      }
+
     if (unPackStatusDigis_) {
       amc13Event->clearAMCpayloads();
-      outAMC13Event.get()->insertDigi(amc13Event->bunchCrossing(), AMC13Event(*amc13Event));
-    }
-
-    if (unknownChamber || unknownVFat || badVfat) {
-      edm::LogWarning("GEMRawToDigiModule") << "unpacking error: unknown Chamber " << unknownChamber << " unknown VFat "
-                                            << unknownVFat << " bad VFat " << badVfat;
     }
 
   }  // end of amc13Event
 
   iEvent.put(std::move(outGEMDigis));
 
+  if (keepDAQStatus_) {
+    iEvent.put(std::move(outAMC13Status), "AMC13Status");
+    iEvent.put(std::move(outAMCStatus), "AMCStatus");
+    iEvent.put(std::move(outOHStatus), "OHStatus");
+    iEvent.put(std::move(outVFATStatus), "VFATStatus");
+  }
   if (unPackStatusDigis_) {
-    iEvent.put(std::move(outVFATStatus), "vfatStatus");
+   // to be removed
+    iEvent.put(std::move(outVFATStatusOld), "vfatStatus");
     iEvent.put(std::move(outGEBStatus), "gebStatus");
     iEvent.put(std::move(outAMCdata), "AMCdata");
     iEvent.put(std::move(outAMC13Event), "AMC13Event");

--- a/EventFilter/GEMRawToDigi/plugins/GEMRawToDigiModule.cc
+++ b/EventFilter/GEMRawToDigi/plugins/GEMRawToDigiModule.cc
@@ -75,7 +75,7 @@ GEMRawToDigiModule::GEMRawToDigiModule(const edm::ParameterSet& pset)
     produces<GEMVFATStatusCollection>("VFATStatus");
   }
   if (unPackStatusDigis_) {
-   // to be removed
+    // to be removed
     produces<GEMVfatStatusDigiCollection>("vfatStatus");
     produces<GEMGEBdataCollection>("gebStatus");
     produces<GEMAMCdataCollection>("AMCdata");
@@ -124,7 +124,6 @@ void GEMRawToDigiModule::produce(edm::StreamID iID, edm::Event& iEvent, edm::Eve
   auto outAMCdata = std::make_unique<GEMAMCdataCollection>();
   auto outAMC13Event = std::make_unique<GEMAMC13EventCollection>();
 
-
   // Take raw from the event
   edm::Handle<FEDRawDataCollection> fed_buffers;
   iEvent.getByToken(fed_token, fed_buffers);
@@ -137,10 +136,10 @@ void GEMRawToDigiModule::produce(edm::StreamID iID, edm::Event& iEvent, edm::Eve
     int nWords = fedData.size() / sizeof(uint64_t);
     LogDebug("GEMRawToDigiModule") << "fedId:" << fedId << " words: " << nWords;
     GEMAMC13Status st_amc13 = GEMAMC13Status(fedData);
-    
-    if (st_amc13.isBad()){
-      LogDebug("GEMRawToDigiModule") << st_amc13 ;
-      if (keepDAQStatus_) {        
+
+    if (st_amc13.isBad()) {
+      LogDebug("GEMRawToDigiModule") << st_amc13;
+      if (keepDAQStatus_) {
         outAMC13Status.get()->insertDigi(fedId, st_amc13);
       }
       continue;
@@ -150,7 +149,8 @@ void GEMRawToDigiModule::produce(edm::StreamID iID, edm::Event& iEvent, edm::Eve
     auto amc13Event = gemRawToDigi_->convertWordToAMC13Event(word);
     LogDebug("GEMRawToDigiModule") << "Event bx:" << iEvent.bunchCrossing() << " lv1Id:" << iEvent.id().event()
                                    << " orbitNumber:" << iEvent.orbitNumber();
-    LogDebug("GEMRawToDigiModule") << "AMC13 bx:" << amc13Event->bunchCrossing() << " lv1Id:" << int(amc13Event->lv1Id())
+    LogDebug("GEMRawToDigiModule") << "AMC13 bx:" << amc13Event->bunchCrossing()
+                                   << " lv1Id:" << int(amc13Event->lv1Id())
                                    << " orbitNumber:" << amc13Event->orbitNumber();
 
     // Read AMC data
@@ -163,17 +163,18 @@ void GEMRawToDigiModule::produce(edm::StreamID iID, edm::Event& iEvent, edm::Eve
       }
 
       GEMAMCStatus st_amc = GEMAMCStatus(amc13Event.get(), amcData);
-      if (st_amc.isBad()){
-        LogDebug("GEMRawToDigiModule") << st_amc ;
+      if (st_amc.isBad()) {
+        LogDebug("GEMRawToDigiModule") << st_amc;
         if (keepDAQStatus_) {
           outAMCStatus.get()->insertDigi(fedId, st_amc);
         }
         continue;
       }
-      
+
       uint16_t amcBx = amcData.bunchCrossing();
       LogDebug("GEMRawToDigiModule") << "AMC no.:" << int(amcData.amcNum()) << " bx:" << int(amcData.bunchCrossing())
-                                     << " lv1Id:" << int(amcData.lv1Id()) << " orbitNumber:" << int(amcData.orbitNumber());
+                                     << " lv1Id:" << int(amcData.lv1Id())
+                                     << " orbitNumber:" << int(amcData.orbitNumber());
 
       // Read GEB data
       for (auto optoHybrid : *amcData.gebs()) {
@@ -189,11 +190,11 @@ void GEMRawToDigiModule::produce(edm::StreamID iID, edm::Event& iEvent, edm::Eve
         GEMDetId gemChId = geb_dc.detId;
 
         GEMOHStatus st_oh = GEMOHStatus(optoHybrid);
-        if (st_oh.isBad()){
-        LogDebug("GEMRawToDigiModule") << st_oh ;
-        if (keepDAQStatus_) {
-          outOHStatus.get()->insertDigi(gemChId, st_oh);
-        }
+        if (st_oh.isBad()) {
+          LogDebug("GEMRawToDigiModule") << st_oh;
+          if (keepDAQStatus_) {
+            outOHStatus.get()->insertDigi(gemChId, st_oh);
+          }
         }
 
         //Read vfat data
@@ -202,8 +203,8 @@ void GEMRawToDigiModule::produce(edm::StreamID iID, edm::Event& iEvent, edm::Eve
           vfatData.setVersion(geb_dc.vfatVer);
           uint16_t vfatId = vfatData.vfatId();
           GEMROMapping::vfatEC vfat_ec{vfatId, gemChId};
-          
-          if (!gemROMap->isValidChipID(vfat_ec)){
+
+          if (!gemROMap->isValidChipID(vfat_ec)) {
             st_oh.inValidVFAT();
             continue;
           }
@@ -213,8 +214,8 @@ void GEMRawToDigiModule::produce(edm::StreamID iID, edm::Event& iEvent, edm::Eve
           GEMDetId gemId = vfat_dc.detId;
 
           GEMVFATStatus st_vfat = GEMVFATStatus(amcData, vfatData, vfatData.phi());
-          if (st_vfat.isBad()){
-            LogDebug("GEMRawToDigiModule") << st_vfat ;
+          if (st_vfat.isBad()) {
+            LogDebug("GEMRawToDigiModule") << st_vfat;
             if (keepDAQStatus_) {
               outVFATStatus.get()->insertDigi(gemId, st_vfat);
             }
@@ -250,28 +251,25 @@ void GEMRawToDigiModule::produce(edm::StreamID iID, edm::Event& iEvent, edm::Eve
 
           }  // end of channel loop
 
-          LogDebug("GEMRawToDigiModule") << st_vfat ;
           if (keepDAQStatus_) {
             outVFATStatus.get()->insertDigi(gemId, st_vfat);
           }
-          if (unPackStatusDigis_) {              
-              outVFATStatusOld.get()->insertDigi(gemId, GEMVfatStatusDigi(vfatData));
+          if (unPackStatusDigis_) {
+            outVFATStatusOld.get()->insertDigi(gemId, GEMVfatStatusDigi(vfatData));
           }
 
         }  // end of vfat loop
 
-        LogDebug("GEMRawToDigiModule") << st_oh ;
         if (keepDAQStatus_) {
           outOHStatus.get()->insertDigi(gemChId, st_oh);
         }
         if (unPackStatusDigis_) {
-          optoHybrid.clearVFATs();          
+          optoHybrid.clearVFATs();
           outGEBStatus.get()->insertDigi(gemChId.chamberId(), (optoHybrid));
         }
 
       }  // end of optohybrid loop
-      
-      LogDebug("GEMRawToDigiModule") << st_amc ;
+
       if (keepDAQStatus_) {
         outAMCStatus.get()->insertDigi(fedId, st_amc);
       }
@@ -282,10 +280,9 @@ void GEMRawToDigiModule::produce(edm::StreamID iID, edm::Event& iEvent, edm::Eve
 
     }  // end of amc loop
 
-    LogDebug("GEMRawToDigiModule") << st_amc13 ;
-      if (keepDAQStatus_) {
+    if (keepDAQStatus_) {
       outAMC13Status.get()->insertDigi(fedId, st_amc13);
-      }
+    }
 
     if (unPackStatusDigis_) {
       amc13Event->clearAMCpayloads();
@@ -302,7 +299,7 @@ void GEMRawToDigiModule::produce(edm::StreamID iID, edm::Event& iEvent, edm::Eve
     iEvent.put(std::move(outVFATStatus), "VFATStatus");
   }
   if (unPackStatusDigis_) {
-   // to be removed
+    // to be removed
     iEvent.put(std::move(outVFATStatusOld), "vfatStatus");
     iEvent.put(std::move(outGEBStatus), "gebStatus");
     iEvent.put(std::move(outAMCdata), "AMCdata");

--- a/EventFilter/GEMRawToDigi/plugins/GEMRawToDigiModule.cc
+++ b/EventFilter/GEMRawToDigi/plugins/GEMRawToDigiModule.cc
@@ -136,9 +136,8 @@ void GEMRawToDigiModule::produce(edm::StreamID iID, edm::Event& iEvent, edm::Eve
     const FEDRawData& fedData = fed_buffers->FEDData(fedId);
 
     int nWords = fedData.size() / sizeof(uint64_t);
-    //LogDebug("GEMRawToDigiModule") << "fedId:" << fedId << " words: " << nWords;
+    LogDebug("GEMRawToDigiModule") << "fedId:" << fedId << " words: " << nWords;
     GEMAMC13Status st_amc13 = GEMAMC13Status(fedData);
-
     if (st_amc13.isBad()) {
       LogDebug("GEMRawToDigiModule") << st_amc13;
       if (keepDAQStatus_) {

--- a/EventFilter/GEMRawToDigi/plugins/GEMRawToDigiModule.cc
+++ b/EventFilter/GEMRawToDigi/plugins/GEMRawToDigiModule.cc
@@ -244,8 +244,8 @@ void GEMRawToDigiModule::produce(edm::StreamID iID, edm::Event& iEvent, edm::Eve
             GEMDigi digi(stripId, bx);
 
             LogDebug("GEMRawToDigiModule")
-                << " fed: " << fedId << " amc:" << int(amcNum) << " geb:" << int(gebId) << " vfat:" << vfat_dc.localPhi
-                << ",type: " << vfat_dc.vfatType << " id:" << gemId << " ch:" << chMap.chNum << " st:" << digi.strip()
+                << "fed: " << fedId << " amc:" << int(amcNum) << " geb:" << int(gebId) << " vfat id:" << int(vfatId)
+                << ",type:" << vfat_dc.vfatType << " id:" << gemId << " ch:" << chMap.chNum << " st:" << digi.strip()
                 << " bx:" << digi.bx();
 
             outGEMDigis.get()->insertDigi(gemId, digi);

--- a/EventFilter/GEMRawToDigi/plugins/GEMRawToDigiModule.cc
+++ b/EventFilter/GEMRawToDigi/plugins/GEMRawToDigiModule.cc
@@ -137,7 +137,7 @@ void GEMRawToDigiModule::produce(edm::StreamID iID, edm::Event& iEvent, edm::Eve
 
     int nWords = fedData.size() / sizeof(uint64_t);
     LogDebug("GEMRawToDigiModule") << "fedId:" << fedId << " words: " << nWords;
-    GEMAMC13Status st_amc13 = GEMAMC13Status(fedData);
+    GEMAMC13Status st_amc13(fedData);
     if (st_amc13.isBad()) {
       LogDebug("GEMRawToDigiModule") << st_amc13;
       if (keepDAQStatus_) {
@@ -163,7 +163,7 @@ void GEMRawToDigiModule::produce(edm::StreamID iID, edm::Event& iEvent, edm::Eve
         continue;
       }
 
-      GEMAMCStatus st_amc = GEMAMCStatus(amc13Event.get(), amcData);
+      GEMAMCStatus st_amc(amc13Event.get(), amcData);
       if (st_amc.isBad()) {
         LogDebug("GEMRawToDigiModule") << st_amc;
         if (keepDAQStatus_) {
@@ -190,7 +190,7 @@ void GEMRawToDigiModule::produce(edm::StreamID iID, edm::Event& iEvent, edm::Eve
         GEMROMapping::chamDC geb_dc = gemROMap->chamberPos(geb_ec);
         GEMDetId gemChId = geb_dc.detId;
 
-        GEMOHStatus st_oh = GEMOHStatus(optoHybrid);
+        GEMOHStatus st_oh(optoHybrid);
         if (st_oh.isBad()) {
           LogDebug("GEMRawToDigiModule") << st_oh;
           if (keepDAQStatus_) {
@@ -214,7 +214,7 @@ void GEMRawToDigiModule::produce(edm::StreamID iID, edm::Event& iEvent, edm::Eve
           vfatData.setPhi(vfat_dc.localPhi);
           GEMDetId gemId = vfat_dc.detId;
 
-          GEMVFATStatus st_vfat = GEMVFATStatus(amcData, vfatData, vfatData.phi(), readMultiBX_);
+          GEMVFATStatus st_vfat(amcData, vfatData, vfatData.phi(), readMultiBX_);
           if (st_vfat.isBad()) {
             LogDebug("GEMRawToDigiModule") << st_vfat;
             if (keepDAQStatus_) {

--- a/EventFilter/GEMRawToDigi/python/gemPacker_cfi.py
+++ b/EventFilter/GEMRawToDigi/python/gemPacker_cfi.py
@@ -8,3 +8,4 @@ from Configuration.Eras.Modifier_phase2_GEM_cff import phase2_GEM
 
 run2_GEM_2017.toModify(gemPacker, useDBEMap = True)
 run3_GEM.toModify(gemPacker, useDBEMap = True)
+phase2_GEM.toModify(gemPacker, useDBEMap = False)

--- a/EventFilter/GEMRawToDigi/python/gemPacker_cfi.py
+++ b/EventFilter/GEMRawToDigi/python/gemPacker_cfi.py
@@ -8,4 +8,3 @@ from Configuration.Eras.Modifier_phase2_GEM_cff import phase2_GEM
 
 run2_GEM_2017.toModify(gemPacker, useDBEMap = True)
 run3_GEM.toModify(gemPacker, useDBEMap = True)
-phase2_GEM.toModify(gemPacker, useDBEMap = False)

--- a/EventFilter/GEMRawToDigi/python/muonGEMDigis_cfi.py
+++ b/EventFilter/GEMRawToDigi/python/muonGEMDigis_cfi.py
@@ -8,4 +8,3 @@ from Configuration.Eras.Modifier_phase2_GEM_cff import phase2_GEM
 
 run2_GEM_2017.toModify(muonGEMDigis, useDBEMap = True)
 run3_GEM.toModify(muonGEMDigis, useDBEMap = True)
-phase2_GEM.toModify(muonGEMDigis, useDBEMap = False)

--- a/EventFilter/GEMRawToDigi/python/muonGEMDigis_cfi.py
+++ b/EventFilter/GEMRawToDigi/python/muonGEMDigis_cfi.py
@@ -8,3 +8,4 @@ from Configuration.Eras.Modifier_phase2_GEM_cff import phase2_GEM
 
 run2_GEM_2017.toModify(muonGEMDigis, useDBEMap = True)
 run3_GEM.toModify(muonGEMDigis, useDBEMap = True)
+phase2_GEM.toModify(muonGEMDigis, useDBEMap = False, readMultiBX = True)

--- a/EventFilter/GEMRawToDigi/python/muonGEMDigis_cfi.py
+++ b/EventFilter/GEMRawToDigi/python/muonGEMDigis_cfi.py
@@ -6,6 +6,6 @@ from Configuration.Eras.Modifier_run2_GEM_2017_cff import run2_GEM_2017
 from Configuration.Eras.Modifier_run3_GEM_cff import run3_GEM
 from Configuration.Eras.Modifier_phase2_GEM_cff import phase2_GEM
 
-run2_GEM_2017.toModify(muonGEMDigis, useDBEMap = True)
+run2_GEM_2017.toModify(muonGEMDigis, useDBEMap = True, readMultiBX = True)
 run3_GEM.toModify(muonGEMDigis, useDBEMap = True)
 phase2_GEM.toModify(muonGEMDigis, useDBEMap = False, readMultiBX = True)

--- a/EventFilter/GEMRawToDigi/src/GEMRawToDigi.cc
+++ b/EventFilter/GEMRawToDigi/src/GEMRawToDigi.cc
@@ -41,18 +41,12 @@ std::unique_ptr<AMC13Event> GEMRawToDigi::convertWordToAMC13Event(const uint64_t
       }  // end of vfat loop
 
       gebData.setChamberTrailer(*(++word));
-      if (gebData.vfatWordCnt() != gebData.vfatWordCntT()) {
-        vfatError_ = true;
-      }
       amcData.addGEB(gebData);
 
     }  // end of geb loop
 
     amcData.setGEMeventTrailer(*(++word));
     amcData.setAMCTrailer(*(++word));
-    if (amc13Event->getAMCsize(i) != amcData.dataLength()) {
-      amcError_ = true;
-    }
     amc13Event->addAMCpayload(amcData);
 
   }  // end of amc loop

--- a/EventFilter/GEMRawToDigi/test/gemUnPackerTester.py
+++ b/EventFilter/GEMRawToDigi/test/gemUnPackerTester.py
@@ -13,7 +13,7 @@ process.gemPacker.useDBEMap = False
 process.muonGEMDigis.useDBEMap = False
 process.muonGEMDigis.keepDAQStatus = True
 process.muonGEMDigis.readMultiBX = True
-process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(-1))
+process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(100))
 
 process.source = cms.Source("PoolSource",                           
   fileNames = cms.untracked.vstring('file:/store/relval/CMSSW_11_3_0_pre4/RelValZMM_14/GEN-SIM-RECO/PU_113X_mcRun4_realistic_v4_2026D76PU200-v1/00000/028001e8-5c24-48e7-8162-5da736ad7d38.root'),

--- a/EventFilter/GEMRawToDigi/test/gemUnPackerTester.py
+++ b/EventFilter/GEMRawToDigi/test/gemUnPackerTester.py
@@ -1,6 +1,8 @@
 import FWCore.ParameterSet.Config as cms
+from Configuration.Eras.Era_Run3_cff import Run3
+from Configuration.Eras.Era_Phase2C11I13M9_cff import Phase2C11I13M9
 
-process = cms.Process('gemTester')
+process = cms.Process('gemTester', Phase2C11I13M9)
 
 process.load('FWCore.MessageService.MessageLogger_cfi')
 process.load('Configuration.StandardSequences.DigiToRaw_cff')
@@ -13,9 +15,11 @@ process.maxEvents.input = cms.untracked.int32(10)
 
 from Configuration.AlCa.GlobalTag import GlobalTag
 process.GlobalTag = GlobalTag(process.GlobalTag, '113X_mcRun4_realistic_v4', '')
-process.gemPacker.useDBEMap = True
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase2_realistic_T21', '')
 
-process.muonGEMDigis.readMultiBX = True
+#process.gemPacker.useDBEMap = True
+#process.muonGEMDigis.readMultiBX = True
+
 process.muonGEMDigis.useDBEMap = process.gemPacker.useDBEMap
 process.muonGEMDigis.keepDAQStatus = True
 

--- a/EventFilter/GEMRawToDigi/test/gemUnPackerTester.py
+++ b/EventFilter/GEMRawToDigi/test/gemUnPackerTester.py
@@ -1,7 +1,6 @@
 import FWCore.ParameterSet.Config as cms
-from Configuration.Eras.Era_Phase2C11M9_cff import Phase2C11M9
 
-process = cms.Process('gemTester',Phase2C11M9)
+process = cms.Process('gemTester')
 
 process.load('FWCore.MessageService.MessageLogger_cfi')
 process.load('Configuration.StandardSequences.DigiToRaw_cff')
@@ -13,10 +12,12 @@ process.GEMPackingTester.gemDigi = cms.InputTag("muonGEMDigis",'','gemTester')
 process.gemPacker.useDBEMap = False
 process.muonGEMDigis.useDBEMap = False
 process.muonGEMDigis.keepDAQStatus = True
-process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(1))
+process.muonGEMDigis.readMultiBX = True
+process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(-1))
 
 process.source = cms.Source("PoolSource",                           
   fileNames = cms.untracked.vstring('file:/store/relval/CMSSW_11_3_0_pre4/RelValZMM_14/GEN-SIM-RECO/PU_113X_mcRun4_realistic_v4_2026D76PU200-v1/00000/028001e8-5c24-48e7-8162-5da736ad7d38.root'),
+  #fileNames = cms.untracked.vstring('file:/store/express/Commissioning2021/ExpressCosmics/FEVT/Express-v1/000/342/218/00000/00dede46-dcef-4376-94db-5ee88a3a895e.root'),
 )
 
 process.FEVTDEBUGHLToutput = cms.OutputModule("PoolOutputModule",
@@ -25,7 +26,7 @@ process.FEVTDEBUGHLToutput = cms.OutputModule("PoolOutputModule",
         filterName = cms.untracked.string('')
     ),
     fileName = cms.untracked.string('file:muonGEMDigis.root'),
-    outputCommands = cms.untracked.vstring( ('drop *', 'keep *_muonGEMDigis_*_*')),
+    outputCommands = cms.untracked.vstring( ('drop *', 'keep *_muonGEMDigis_*_*', 'keep *_simMuonGEMDigis_*_*')),
     splitLevel = cms.untracked.int32(0)
 )
 process.TFileService = cms.Service('TFileService', fileName = cms.string('gemTester.root') )
@@ -37,4 +38,5 @@ process.MessageLogger.debugModules = ["muonGEMDigis"]
 process.FEVTDEBUGHLToutput_step = cms.EndPath(process.FEVTDEBUGHLToutput)
 
 process.p = cms.Path(process.gemPacker+process.rawDataCollector+process.muonGEMDigis+process.GEMPackingTester)
+#process.p = cms.Path(process.rawDataCollector+process.muonGEMDigis)
 

--- a/EventFilter/GEMRawToDigi/test/gemUnPackerTester.py
+++ b/EventFilter/GEMRawToDigi/test/gemUnPackerTester.py
@@ -10,6 +10,8 @@ process.load('EventFilter.GEMRawToDigi.GEMPackingTester_cfi')
 process.load('Configuration.EventContent.EventContent_cff')
 
 process.GEMPackingTester.gemDigi = cms.InputTag("muonGEMDigis",'','gemTester')
+process.gemPacker.useDBEMap = False
+process.muonGEMDigis.useDBEMap = False
 process.muonGEMDigis.keepDAQStatus = True
 process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(1))
 
@@ -26,7 +28,6 @@ process.FEVTDEBUGHLToutput = cms.OutputModule("PoolOutputModule",
     outputCommands = cms.untracked.vstring( ('drop *', 'keep *_muonGEMDigis_*_*')),
     splitLevel = cms.untracked.int32(0)
 )
-
 process.TFileService = cms.Service('TFileService', fileName = cms.string('gemTester.root') )
 process.rawDataCollector.RawCollectionList = cms.VInputTag(cms.InputTag("gemPacker",'','gemTester'))
 process.MessageLogger.cerr.threshold = "DEBUG"

--- a/EventFilter/GEMRawToDigi/test/gemUnPackerTester.py
+++ b/EventFilter/GEMRawToDigi/test/gemUnPackerTester.py
@@ -1,0 +1,39 @@
+import FWCore.ParameterSet.Config as cms
+from Configuration.Eras.Era_Phase2C11M9_cff import Phase2C11M9
+
+process = cms.Process('gemTester',Phase2C11M9)
+
+process.load('FWCore.MessageService.MessageLogger_cfi')
+process.load('Configuration.StandardSequences.DigiToRaw_cff')
+process.load('Configuration.StandardSequences.RawToDigi_cff')
+process.load('EventFilter.GEMRawToDigi.GEMPackingTester_cfi')
+process.load('Configuration.EventContent.EventContent_cff')
+
+process.GEMPackingTester.gemDigi = cms.InputTag("muonGEMDigis",'','gemTester')
+process.muonGEMDigis.keepDAQStatus = True
+process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(1))
+
+process.source = cms.Source("PoolSource",                           
+  fileNames = cms.untracked.vstring('file:/store/relval/CMSSW_11_3_0_pre4/RelValZMM_14/GEN-SIM-RECO/PU_113X_mcRun4_realistic_v4_2026D76PU200-v1/00000/028001e8-5c24-48e7-8162-5da736ad7d38.root'),
+)
+
+process.FEVTDEBUGHLToutput = cms.OutputModule("PoolOutputModule",
+    dataset = cms.untracked.PSet(
+        dataTier = cms.untracked.string('GEN-SIM-RECO'),
+        filterName = cms.untracked.string('')
+    ),
+    fileName = cms.untracked.string('file:muonGEMDigis.root'),
+    outputCommands = cms.untracked.vstring( ('drop *', 'keep *_muonGEMDigis_*_*')),
+    splitLevel = cms.untracked.int32(0)
+)
+
+process.TFileService = cms.Service('TFileService', fileName = cms.string('gemTester.root') )
+process.rawDataCollector.RawCollectionList = cms.VInputTag(cms.InputTag("gemPacker",'','gemTester'))
+process.MessageLogger.cerr.threshold = "DEBUG"
+#process.MessageLogger.debugModules = ["gemPacker", "muonGEMDigis"]
+process.MessageLogger.debugModules = ["muonGEMDigis"]
+
+process.FEVTDEBUGHLToutput_step = cms.EndPath(process.FEVTDEBUGHLToutput)
+
+process.p = cms.Path(process.gemPacker+process.rawDataCollector+process.muonGEMDigis+process.GEMPackingTester)
+

--- a/EventFilter/GEMRawToDigi/test/gemUnPackerTester.py
+++ b/EventFilter/GEMRawToDigi/test/gemUnPackerTester.py
@@ -10,13 +10,15 @@ process.load('Configuration.EventContent.EventContent_cff')
 
 process.GEMPackingTester.gemDigi = cms.InputTag("muonGEMDigis",'','gemTester')
 process.gemPacker.useDBEMap = False
-process.muonGEMDigis.useDBEMap = False
+process.muonGEMDigis.useDBEMap = process.gemPacker.useDBEMap
 process.muonGEMDigis.keepDAQStatus = True
 process.muonGEMDigis.readMultiBX = True
+process.GEMPackingTester.readMultiBX = process.muonGEMDigis.readMultiBX
 process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(100))
 
 process.source = cms.Source("PoolSource",                           
   fileNames = cms.untracked.vstring('file:/store/relval/CMSSW_11_3_0_pre4/RelValZMM_14/GEN-SIM-RECO/PU_113X_mcRun4_realistic_v4_2026D76PU200-v1/00000/028001e8-5c24-48e7-8162-5da736ad7d38.root'),
+  #fileNames = cms.untracked.vstring('file:/pad/jlee/CMSSW_12_0_0_pre3/src/11634.0_TTbar_14TeV+2021+TTbar_14TeV_TuneCP5_GenSim+Digi+Reco+HARVEST+ALCA/step2.root'),
   #fileNames = cms.untracked.vstring('file:/store/express/Commissioning2021/ExpressCosmics/FEVT/Express-v1/000/342/218/00000/00dede46-dcef-4376-94db-5ee88a3a895e.root'),
 )
 
@@ -32,8 +34,8 @@ process.FEVTDEBUGHLToutput = cms.OutputModule("PoolOutputModule",
 process.TFileService = cms.Service('TFileService', fileName = cms.string('gemTester.root') )
 process.rawDataCollector.RawCollectionList = cms.VInputTag(cms.InputTag("gemPacker",'','gemTester'))
 process.MessageLogger.cerr.threshold = "DEBUG"
-#process.MessageLogger.debugModules = ["gemPacker", "muonGEMDigis"]
-process.MessageLogger.debugModules = ["muonGEMDigis"]
+process.MessageLogger.debugModules = ["gemPacker", "muonGEMDigis"]
+#process.MessageLogger.debugModules = ["muonGEMDigis"]
 
 process.FEVTDEBUGHLToutput_step = cms.EndPath(process.FEVTDEBUGHLToutput)
 

--- a/EventFilter/GEMRawToDigi/test/gemUnPackerTester.py
+++ b/EventFilter/GEMRawToDigi/test/gemUnPackerTester.py
@@ -1,24 +1,29 @@
 import FWCore.ParameterSet.Config as cms
 
-process = cms.Process('gemTester')
+from Configuration.Eras.Era_Run2_2017_cff import Run2_2017
+
+process = cms.Process('gemTester',Run2_2017)
 
 process.load('FWCore.MessageService.MessageLogger_cfi')
 process.load('Configuration.StandardSequences.DigiToRaw_cff')
 process.load('Configuration.StandardSequences.RawToDigi_cff')
 process.load('EventFilter.GEMRawToDigi.GEMPackingTester_cfi')
 process.load('Configuration.EventContent.EventContent_cff')
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase1_2017_realistic', '')
 
 process.GEMPackingTester.gemDigi = cms.InputTag("muonGEMDigis",'','gemTester')
-process.gemPacker.useDBEMap = False
-process.muonGEMDigis.useDBEMap = process.gemPacker.useDBEMap
+#process.gemPacker.useDBEMap = False
+#process.muonGEMDigis.useDBEMap = process.gemPacker.useDBEMap
 process.muonGEMDigis.keepDAQStatus = True
-process.muonGEMDigis.readMultiBX = True
+#process.muonGEMDigis.readMultiBX = False
 process.GEMPackingTester.readMultiBX = process.muonGEMDigis.readMultiBX
 process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(100))
 
 process.source = cms.Source("PoolSource",                           
   fileNames = cms.untracked.vstring('file:/store/relval/CMSSW_11_3_0_pre4/RelValZMM_14/GEN-SIM-RECO/PU_113X_mcRun4_realistic_v4_2026D76PU200-v1/00000/028001e8-5c24-48e7-8162-5da736ad7d38.root'),
-  #fileNames = cms.untracked.vstring('file:/pad/jlee/CMSSW_12_0_0_pre3/src/11634.0_TTbar_14TeV+2021+TTbar_14TeV_TuneCP5_GenSim+Digi+Reco+HARVEST+ALCA/step2.root'),
   #fileNames = cms.untracked.vstring('file:/store/express/Commissioning2021/ExpressCosmics/FEVT/Express-v1/000/342/218/00000/00dede46-dcef-4376-94db-5ee88a3a895e.root'),
 )
 
@@ -42,3 +47,5 @@ process.FEVTDEBUGHLToutput_step = cms.EndPath(process.FEVTDEBUGHLToutput)
 process.p = cms.Path(process.gemPacker+process.rawDataCollector+process.muonGEMDigis+process.GEMPackingTester)
 #process.p = cms.Path(process.rawDataCollector+process.muonGEMDigis)
 
+print 'useDBEMap', process.gemPacker.useDBEMap, process.muonGEMDigis.useDBEMap
+print 'readMultiBX', process.muonGEMDigis.readMultiBX

--- a/EventFilter/GEMRawToDigi/test/gemUnPackerTester.py
+++ b/EventFilter/GEMRawToDigi/test/gemUnPackerTester.py
@@ -1,8 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-from Configuration.Eras.Era_Run2_2017_cff import Run2_2017
-
-process = cms.Process('gemTester',Run2_2017)
+process = cms.Process('gemTester')
 
 process.load('FWCore.MessageService.MessageLogger_cfi')
 process.load('Configuration.StandardSequences.DigiToRaw_cff')
@@ -11,16 +9,18 @@ process.load('EventFilter.GEMRawToDigi.GEMPackingTester_cfi')
 process.load('Configuration.EventContent.EventContent_cff')
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 
+process.maxEvents.input = cms.untracked.int32(10)
+
 from Configuration.AlCa.GlobalTag import GlobalTag
-process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase1_2017_realistic', '')
+process.GlobalTag = GlobalTag(process.GlobalTag, '113X_mcRun4_realistic_v4', '')
+process.gemPacker.useDBEMap = True
+
+process.muonGEMDigis.readMultiBX = True
+process.muonGEMDigis.useDBEMap = process.gemPacker.useDBEMap
+process.muonGEMDigis.keepDAQStatus = True
 
 process.GEMPackingTester.gemDigi = cms.InputTag("muonGEMDigis",'','gemTester')
-#process.gemPacker.useDBEMap = False
-#process.muonGEMDigis.useDBEMap = process.gemPacker.useDBEMap
-process.muonGEMDigis.keepDAQStatus = True
-#process.muonGEMDigis.readMultiBX = False
 process.GEMPackingTester.readMultiBX = process.muonGEMDigis.readMultiBX
-process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(100))
 
 process.source = cms.Source("PoolSource",                           
   fileNames = cms.untracked.vstring('file:/store/relval/CMSSW_11_3_0_pre4/RelValZMM_14/GEN-SIM-RECO/PU_113X_mcRun4_realistic_v4_2026D76PU200-v1/00000/028001e8-5c24-48e7-8162-5da736ad7d38.root'),
@@ -40,12 +40,10 @@ process.TFileService = cms.Service('TFileService', fileName = cms.string('gemTes
 process.rawDataCollector.RawCollectionList = cms.VInputTag(cms.InputTag("gemPacker",'','gemTester'))
 process.MessageLogger.cerr.threshold = "DEBUG"
 process.MessageLogger.debugModules = ["gemPacker", "muonGEMDigis"]
-#process.MessageLogger.debugModules = ["muonGEMDigis"]
 
 process.FEVTDEBUGHLToutput_step = cms.EndPath(process.FEVTDEBUGHLToutput)
 
 process.p = cms.Path(process.gemPacker+process.rawDataCollector+process.muonGEMDigis+process.GEMPackingTester)
-#process.p = cms.Path(process.rawDataCollector+process.muonGEMDigis)
 
 print 'useDBEMap', process.gemPacker.useDBEMap, process.muonGEMDigis.useDBEMap
 print 'readMultiBX', process.muonGEMDigis.readMultiBX


### PR DESCRIPTION
#### PR description:
  - DAQ dataformat is updated to the current version used in P5
  - GEM unpacked is changed to only produce digis when there are not DAQ errors
  - new DAQ status classes that checks for DAQ errors and stores it for OnlineDQM
  - run3 GE1/1 cannot read multi-BX, so by default non zero BX will not be unpacked for run3
  - added multi-BX mode for phase2
  - added plugin that checks if output the packing and unpacking is identical to the original simDigis
  - Discussed in the minutes of https://indico.cern.ch/event/1056074/#32-dpg 
  - Link to presentation at GEM operations (https://indico.cern.ch/event/1058368/contributions/4448079/subcontributions/345162/attachments/2283335/3881798/gem_unpacker_20210719.pdf)

#### PR validation:

Validated with wf 11634.0 and 34611.0

#### Backport
Backport of #34504