### PR TITLE
Avoid rerunning particlelevel producer in NanoAOD

### DIFF
--- a/GeneratorInterface/RivetInterface/interface/RivetAnalysis.h
+++ b/GeneratorInterface/RivetInterface/interface/RivetAnalysis.h
@@ -33,6 +33,7 @@ namespace Rivet {
     bool _usePromptFinalStates;
     bool _excludePromptLeptonsFromJetClustering;
     bool _excludeNeutrinosFromJetClustering;
+    bool _doJetClustering;
 
     double _particleMinPt, _particleMaxEta;
     double _lepConeSize, _lepMinPt, _lepMaxEta;
@@ -51,6 +52,7 @@ namespace Rivet {
           _usePromptFinalStates(pset.getParameter<bool>("usePromptFinalStates")),
           _excludePromptLeptonsFromJetClustering(pset.getParameter<bool>("excludePromptLeptonsFromJetClustering")),
           _excludeNeutrinosFromJetClustering(pset.getParameter<bool>("excludeNeutrinosFromJetClustering")),
+          _doJetClustering(pset.getParameter<bool>("doJetClustering")),
 
           _particleMinPt(pset.getParameter<double>("particleMinPt")),
           _particleMaxEta(pset.getParameter<double>("particleMaxEta")),
@@ -194,8 +196,10 @@ namespace Rivet {
         _photons.push_back(photon);
       }
 
-      _jets = apply<FastJets>(event, "Jets").jetsByPt(jet_cut);
-      _fatjets = apply<FastJets>(event, "FatJets").jetsByPt(fatjet_cut);
+      if (_doJetClustering) {
+        _jets = apply<FastJets>(event, "Jets").jetsByPt(jet_cut);
+        _fatjets = apply<FastJets>(event, "FatJets").jetsByPt(fatjet_cut);
+      }
       _neutrinos = apply<FinalState>(event, "Neutrinos").particlesByPt();
       _met = apply<MissingMomentum>(event, "MET").missingMomentum().p3();
 

--- a/GeneratorInterface/RivetInterface/python/particleLevel_cfi.py
+++ b/GeneratorInterface/RivetInterface/python/particleLevel_cfi.py
@@ -6,6 +6,7 @@ particleLevel = cms.EDProducer("ParticleLevelProducer",
     usePromptFinalStates = cms.bool(True), # for leptons, photons, neutrinos
     excludePromptLeptonsFromJetClustering = cms.bool(True),
     excludeNeutrinosFromJetClustering = cms.bool(True),
+    doJetClustering = cms.bool(True),
     
     particleMinPt  = cms.double(0.),
     particleMaxEta = cms.double(5.), # HF range. Maximum 6.0 on MiniAOD

--- a/PhysicsTools/NanoAOD/plugins/GenJetGenPartMerger.cc
+++ b/PhysicsTools/NanoAOD/plugins/GenJetGenPartMerger.cc
@@ -84,9 +84,9 @@ void GenJetGenPartMerger::produce(edm::Event& iEvent, const edm::EventSetup& iSe
   for (unsigned int ijet = 0; ijet < jetHandle->size(); ++ijet) {
     auto jet = jetHandle->at(ijet);
     if (cut_(jet)) {
-        merged->push_back(reco::GenJet(jet));
-        reco::GenJetRef jetRef(jetHandle, ijet);
-        hasTauAncValues.push_back((*tauAncHandle)[jetRef]);
+      merged->push_back(reco::GenJet(jet));
+      reco::GenJetRef jetRef(jetHandle, ijet);
+      hasTauAncValues.push_back((*tauAncHandle)[jetRef]);
     }
   }
 

--- a/PhysicsTools/NanoAOD/plugins/GenJetGenPartMerger.cc
+++ b/PhysicsTools/NanoAOD/plugins/GenJetGenPartMerger.cc
@@ -16,6 +16,8 @@
 #include "DataFormats/HepMCCandidate/interface/GenParticle.h"
 
 #include "DataFormats/Common/interface/ValueMap.h"
+#include "CommonTools/Utils/interface/StringCutObjectSelector.h"
+#include "CommonTools/Utils/interface/StringObjectFunction.h"
 
 //
 // class declaration
@@ -33,6 +35,7 @@ private:
 
   const edm::EDGetTokenT<reco::GenJetCollection> jetToken_;
   const edm::EDGetTokenT<reco::GenParticleCollection> partToken_;
+  const StringCutObjectSelector<reco::Candidate> cut_;
   const edm::EDGetTokenT<edm::ValueMap<bool>> tauAncToken_;
 };
 
@@ -50,6 +53,7 @@ private:
 GenJetGenPartMerger::GenJetGenPartMerger(const edm::ParameterSet& iConfig)
     : jetToken_(consumes<reco::GenJetCollection>(iConfig.getParameter<edm::InputTag>("srcJet"))),
       partToken_(consumes<reco::GenParticleCollection>(iConfig.getParameter<edm::InputTag>("srcPart"))),
+      cut_(iConfig.getParameter<std::string>("cut")),
       tauAncToken_(consumes<edm::ValueMap<bool>>(iConfig.getParameter<edm::InputTag>("hasTauAnc"))) {
   produces<reco::GenJetCollection>("merged");
   produces<edm::ValueMap<bool>>("hasTauAnc");
@@ -79,9 +83,11 @@ void GenJetGenPartMerger::produce(edm::Event& iEvent, const edm::EventSetup& iSe
 
   for (unsigned int ijet = 0; ijet < jetHandle->size(); ++ijet) {
     auto jet = jetHandle->at(ijet);
-    merged->push_back(reco::GenJet(jet));
-    reco::GenJetRef jetRef(jetHandle, ijet);
-    hasTauAncValues.push_back((*tauAncHandle)[jetRef]);
+    if (cut_(jet)) {
+        merged->push_back(reco::GenJet(jet));
+        reco::GenJetRef jetRef(jetHandle, ijet);
+        hasTauAncValues.push_back((*tauAncHandle)[jetRef]);
+    }
   }
 
   for (auto& part : *partHandle) {

--- a/PhysicsTools/NanoAOD/python/electrons_cff.py
+++ b/PhysicsTools/NanoAOD/python/electrons_cff.py
@@ -483,7 +483,7 @@ tautaggerForMatching = cms.EDProducer("GenJetTauTaggerProducer",
 matchingElecPhoton = cms.EDProducer("GenJetGenPartMerger",
                                     srcJet =cms.InputTag("particleLevel:leptons"),
                                     srcPart=cms.InputTag("particleLevel:photons"),
-                                    cut = "pt > 3",
+                                    cut = cms.string("pt > 3"),
                                     hasTauAnc=cms.InputTag("tautaggerForMatching"),
 )
 electronsMCMatchForTableAlt = cms.EDProducer("GenJetMatcherDRPtByDR",  # cut on deltaR, deltaPt/Pt; pick best by deltaR

--- a/PhysicsTools/NanoAOD/python/electrons_cff.py
+++ b/PhysicsTools/NanoAOD/python/electrons_cff.py
@@ -475,19 +475,15 @@ run2_miniAOD_80XLegacy.toModify(electronTable.variables,
 
 )
 #############electron Table END#####################
-from PhysicsTools.NanoAOD.particlelevel_cff import particleLevel
-particleLevelForMatching = particleLevel.clone(
-    lepMinPt    = cms.double(3.),
-    phoMinPt = cms.double(3),
-)
-#as above should be cloned from @ PhysicsTools/NanoAOD/python/particlelevel_cff.py
+# Depends on particlelevel producer run in particlelevel_cff
 tautaggerForMatching = cms.EDProducer("GenJetTauTaggerProducer",
-                                      src = cms.InputTag('particleLevelForMatching:leptons')
+                                      src = cms.InputTag('particleLevel:leptons')
 )
-##PhysicsTools/NanoAOD/plugins/GenJetGenPartMerger.cc##this class misses fillDescription#TODO
+ ##PhysicsTools/NanoAOD/plugins/GenJetGenPartMerger.cc##this class misses fillDescription#TODO
 matchingElecPhoton = cms.EDProducer("GenJetGenPartMerger",
-                                    srcJet =cms.InputTag("particleLevelForMatching:leptons"),
-                                    srcPart=cms.InputTag("particleLevelForMatching:photons"),
+                                    srcJet =cms.InputTag("particleLevel:leptons"),
+                                    srcPart=cms.InputTag("particleLevel:photons"),
+                                    cut = "pt > 3",
                                     hasTauAnc=cms.InputTag("tautaggerForMatching"),
 )
 electronsMCMatchForTableAlt = cms.EDProducer("GenJetMatcherDRPtByDR",  # cut on deltaR, deltaPt/Pt; pick best by deltaR
@@ -527,7 +523,7 @@ electronMCTable = cms.EDProducer("CandMCMatchTableProducer",
 
 electronSequence = cms.Sequence(bitmapVIDForEle + bitmapVIDForEleHEEP + isoForEle + ptRatioRelForEle + seedGainEle + slimmedElectronsWithUserData + finalElectrons)
 electronTables = cms.Sequence (electronMVATTH + electronTable)
-electronMC = cms.Sequence(particleLevelForMatching + tautaggerForMatching + matchingElecPhoton + electronsMCMatchForTable + electronsMCMatchForTableAlt + electronMCTable)
+electronMC = cms.Sequence(tautaggerForMatching + matchingElecPhoton + electronsMCMatchForTable + electronsMCMatchForTableAlt + electronMCTable)
 
 #for NANO from reminAOD, no need to run slimmedElectronsUpdated, other modules of electron sequence will run on slimmedElectrons
 for modifier in run2_miniAOD_80XLegacy,run2_nanoAOD_94XMiniAODv1,run2_nanoAOD_94XMiniAODv2,run2_nanoAOD_94X2016,run2_nanoAOD_102Xv1,run2_nanoAOD_106Xv1:

--- a/PhysicsTools/NanoAOD/python/lowPtElectrons_cff.py
+++ b/PhysicsTools/NanoAOD/python/lowPtElectrons_cff.py
@@ -122,17 +122,6 @@ lowPtElectronTable = cms.EDProducer(
 # electronTable (MC)
 ################################################################################
 
-from PhysicsTools.NanoAOD.particlelevel_cff import particleLevel
-particleLevelForMatchingLowPt = particleLevel.clone(
-    lepMinPt = cms.double(1.),
-    phoMinPt = cms.double(1),
-)
-
-tautaggerForMatchingLowPt = cms.EDProducer(
-    "GenJetTauTaggerProducer",
-    src = cms.InputTag('particleLevelForMatchingLowPt:leptons')
-)
-
 matchingLowPtElecPhoton = cms.EDProducer(
     "GenJetGenPartMerger",
     srcJet =cms.InputTag("particleLevelForMatchingLowPt:leptons"),

--- a/PhysicsTools/NanoAOD/python/lowPtElectrons_cff.py
+++ b/PhysicsTools/NanoAOD/python/lowPtElectrons_cff.py
@@ -122,11 +122,13 @@ lowPtElectronTable = cms.EDProducer(
 # electronTable (MC)
 ################################################################################
 
+# Depends on tautaggerForMatching being run in electrons_cff
 matchingLowPtElecPhoton = cms.EDProducer(
     "GenJetGenPartMerger",
-    srcJet =cms.InputTag("particleLevelForMatchingLowPt:leptons"),
-    srcPart=cms.InputTag("particleLevelForMatchingLowPt:photons"),
-    hasTauAnc=cms.InputTag("tautaggerForMatchingLowPt"),
+    srcJet =cms.InputTag("particleLevel:leptons"),
+    srcPart=cms.InputTag("particleLevel:photons"),
+    cut = cms.string(""),
+    hasTauAnc=cms.InputTag("tautaggerForMatching"),
 )
 
 lowPtElectronsMCMatchForTableAlt = cms.EDProducer(
@@ -181,9 +183,7 @@ lowPtElectronSequence = cms.Sequence(modifiedLowPtElectrons
                                      +finalLowPtElectrons)
 lowPtElectronTables = cms.Sequence(lowPtElectronTable)
 lowPtElectronMC = cms.Sequence(
-    particleLevelForMatchingLowPt
-    +tautaggerForMatchingLowPt
-    +matchingLowPtElecPhoton
+    matchingLowPtElecPhoton
     +lowPtElectronsMCMatchForTable
     +lowPtElectronsMCMatchForTableAlt
     +lowPtElectronMCTable)

--- a/PhysicsTools/NanoAOD/python/particlelevel_cff.py
+++ b/PhysicsTools/NanoAOD/python/particlelevel_cff.py
@@ -26,6 +26,7 @@ genParticles2HepMCHiggsVtx = cms.EDProducer("GenParticles2HepMCConverter",
 particleLevel = cms.EDProducer("ParticleLevelProducer",
     src = cms.InputTag("genParticles2HepMC:unsmeared"),
     
+    doJetClustering = cms.bool(False), # Not needed as Rivet jets aren't used currently
     usePromptFinalStates = cms.bool(True), # for leptons, photons, neutrinos
     excludePromptLeptonsFromJetClustering = cms.bool(False),
     excludeNeutrinosFromJetClustering = cms.bool(True),

--- a/PhysicsTools/NanoAOD/python/particlelevel_cff.py
+++ b/PhysicsTools/NanoAOD/python/particlelevel_cff.py
@@ -34,7 +34,7 @@ particleLevel = cms.EDProducer("ParticleLevelProducer",
     particleMaxEta = cms.double(5.), # HF range. Maximum 6.0 on MiniAOD
     
     lepConeSize = cms.double(0.1), # for photon dressing
-    lepMinPt    = cms.double(15.),
+    lepMinPt    = cms.double(1.),
     lepMaxEta   = cms.double(2.5),
     
     jetConeSize = cms.double(0.4),
@@ -47,7 +47,7 @@ particleLevel = cms.EDProducer("ParticleLevelProducer",
 
     phoIsoConeSize = cms.double(0.4),
     phoMaxRelIso = cms.double(0.5),
-    phoMinPt = cms.double(10),
+    phoMinPt = cms.double(1.),
     phoMaxEta = cms.double(2.5),
 )
 
@@ -61,7 +61,7 @@ rivetProducerHTXS = cms.EDProducer('HTXSRivetProducer',
 ##################### Tables for final output and docs ##########################
 rivetLeptonTable = cms.EDProducer("SimpleCandidateFlatTableProducer",
     src = cms.InputTag("particleLevel:leptons"),
-    cut = cms.string(""),
+    cut = cms.string("pt > 15"),
     name= cms.string("GenDressedLepton"),
     doc = cms.string("Dressed leptons from Rivet-based ParticleLevelProducer"),
     singleton = cms.bool(False), # the number of entries is variable
@@ -77,7 +77,7 @@ rivetLeptonTable = cms.EDProducer("SimpleCandidateFlatTableProducer",
 
 rivetPhotonTable = cms.EDProducer("SimpleCandidateFlatTableProducer",
     src = cms.InputTag("particleLevel:photons"),
-    cut = cms.string(""),
+    cut = cms.string("pt > 10"),
     name= cms.string("GenIsolatedPhoton"),
     doc = cms.string("Isolated photons from Rivet-based ParticleLevelProducer"),
     singleton = cms.bool(False), # the number of entries is variable


### PR DESCRIPTION
Previously Rivet particle level producer was run separately to build collections for different kinematic criteria needed in matching. Now just run once with loose cuts, then apply selections before matching and in the RivetTable. Also exploit the changes in #34575 to speed up by not running jet clustering. @mseidel42 