### PR TITLE
Add esConsumes to RecoMuon/MuonIsolation

### DIFF
--- a/RecoMuon/MuonIsolation/plugins/CaloExtractor.h
+++ b/RecoMuon/MuonIsolation/plugins/CaloExtractor.h
@@ -15,6 +15,11 @@
 
 #include "DataFormats/GeometryVector/interface/GlobalPoint.h"
 
+#include "MagneticField/Engine/interface/MagneticField.h"
+#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
+#include "Geometry/CaloGeometry/interface/CaloGeometry.h"
+#include "Geometry/Records/interface/CaloGeometryRecord.h"
+
 namespace muonisolation {
 
   class CaloExtractor : public reco::isodeposit::IsoDepositExtractor {
@@ -39,6 +44,9 @@ namespace muonisolation {
 
     // Label of deposit
     std::string theDepositLabel;
+
+    const edm::ESGetToken<CaloGeometry, CaloGeometryRecord> theCaloGeomToken;
+    const edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> theFieldToken;
 
     // Cone cuts and thresholds
     double theWeight_E;

--- a/RecoMuon/MuonIsolation/plugins/JetExtractor.cc
+++ b/RecoMuon/MuonIsolation/plugins/JetExtractor.cc
@@ -24,6 +24,8 @@ using namespace reco;
 using namespace muonisolation;
 using reco::isodeposit::Direction;
 
+JetExtractor::JetExtractor() {}
+
 JetExtractor::JetExtractor(const ParameterSet& par, edm::ConsumesCollector&& iC)
     : theJetCollectionToken(iC.consumes<CaloJetCollection>(par.getParameter<edm::InputTag>("JetCollectionLabel"))),
       thePropagatorName(par.getParameter<std::string>("PropagatorName")),
@@ -36,22 +38,15 @@ JetExtractor::JetExtractor(const ParameterSet& par, edm::ConsumesCollector&& iC)
       theAssociator(nullptr),
       thePrintTimeReport(par.getUntrackedParameter<bool>("PrintTimeReport")) {
   ParameterSet serviceParameters = par.getParameter<ParameterSet>("ServiceParameters");
-  theService = new MuonServiceProxy(serviceParameters, edm::ConsumesCollector(iC));
+  theService = std::make_unique<MuonServiceProxy>(serviceParameters, edm::ConsumesCollector(iC));
 
   //  theAssociatorParameters = new TrackAssociatorParameters(par.getParameter<edm::ParameterSet>("TrackAssociatorParameters"), iC_);
-  theAssociatorParameters = new TrackAssociatorParameters();
+  theAssociatorParameters = std::make_unique<TrackAssociatorParameters>();
   theAssociatorParameters->loadParameters(par.getParameter<edm::ParameterSet>("TrackAssociatorParameters"), iC);
-  theAssociator = new TrackDetectorAssociator();
+  theAssociator = std::make_unique<TrackDetectorAssociator>();
 }
 
-JetExtractor::~JetExtractor() {
-  if (theAssociatorParameters)
-    delete theAssociatorParameters;
-  if (theService)
-    delete theService;
-  if (theAssociator)
-    delete theAssociator;
-}
+JetExtractor::~JetExtractor() {}
 
 void JetExtractor::fillVetos(const edm::Event& event, const edm::EventSetup& eventSetup, const TrackCollection& muons) {
   //   LogWarning("JetExtractor")

--- a/RecoMuon/MuonIsolation/plugins/JetExtractor.cc
+++ b/RecoMuon/MuonIsolation/plugins/JetExtractor.cc
@@ -10,11 +10,6 @@
 #include "DataFormats/EcalDetId/interface/EcalSubdetector.h"
 #include "DataFormats/HcalDetId/interface/HcalSubdetector.h"
 
-#include "MagneticField/Engine/interface/MagneticField.h"
-#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
-#include "Geometry/Records/interface/IdealGeometryRecord.h"
-#include "TrackingTools/Records/interface/TrackingComponentsRecord.h"
-
 #include "RecoMuon/TrackingTools/interface/MuonServiceProxy.h"
 
 #include "TrackingTools/TransientTrack/interface/TransientTrack.h"
@@ -32,6 +27,7 @@ using reco::isodeposit::Direction;
 JetExtractor::JetExtractor(const ParameterSet& par, edm::ConsumesCollector&& iC)
     : theJetCollectionToken(iC.consumes<CaloJetCollection>(par.getParameter<edm::InputTag>("JetCollectionLabel"))),
       thePropagatorName(par.getParameter<std::string>("PropagatorName")),
+      theFieldToken(iC.esConsumes()),
       theThreshold(par.getParameter<double>("Threshold")),
       theDR_Veto(par.getParameter<double>("DR_Veto")),
       theDR_Max(par.getParameter<double>("DR_Max")),
@@ -72,10 +68,9 @@ IsoDeposit JetExtractor::deposit(const Event& event, const EventSetup& eventSetu
 
   IsoDeposit depJet(muonDir);
 
-  edm::ESHandle<MagneticField> bField;
-  eventSetup.get<IdealMagneticFieldRecord>().get(bField);
+  auto const& bField = eventSetup.getData(theFieldToken);
 
-  reco::TransientTrack tMuon(muon, &*bField);
+  reco::TransientTrack tMuon(muon, &bField);
   FreeTrajectoryState iFTS = tMuon.initialFreeState();
   TrackDetMatchInfo mInfo = theAssociator->associate(event, eventSetup, iFTS, *theAssociatorParameters);
 

--- a/RecoMuon/MuonIsolation/plugins/JetExtractor.h
+++ b/RecoMuon/MuonIsolation/plugins/JetExtractor.h
@@ -25,6 +25,9 @@
 
 #include "DataFormats/GeometryVector/interface/GlobalPoint.h"
 
+#include "MagneticField/Engine/interface/MagneticField.h"
+#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
+
 class TrackAssociatorParameters;
 class TrackDetectorAssociator;
 class MuonServiceProxy;
@@ -47,6 +50,8 @@ namespace muonisolation {
     edm::EDGetTokenT<reco::CaloJetCollection> theJetCollectionToken;
 
     std::string thePropagatorName;
+
+    edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> theFieldToken;
 
     // Cone cuts and thresholds
     double theThreshold;

--- a/RecoMuon/MuonIsolation/plugins/JetExtractor.h
+++ b/RecoMuon/MuonIsolation/plugins/JetExtractor.h
@@ -36,7 +36,7 @@ namespace muonisolation {
 
   class JetExtractor : public reco::isodeposit::IsoDepositExtractor {
   public:
-    JetExtractor(){};
+    JetExtractor();
     JetExtractor(const edm::ParameterSet& par, edm::ConsumesCollector&& iC);
 
     ~JetExtractor() override;
@@ -62,10 +62,10 @@ namespace muonisolation {
     bool theExcludeMuonVeto;
 
     //! the event setup proxy, it takes care the services update
-    MuonServiceProxy* theService;
+    std::unique_ptr<MuonServiceProxy> theService;
 
-    TrackAssociatorParameters* theAssociatorParameters;
-    TrackDetectorAssociator* theAssociator;
+    std::unique_ptr<TrackAssociatorParameters> theAssociatorParameters;
+    std::unique_ptr<TrackDetectorAssociator> theAssociator;
 
     bool thePrintTimeReport;
   };

--- a/RecoMuon/MuonIsolation/plugins/PixelTrackExtractor.h
+++ b/RecoMuon/MuonIsolation/plugins/PixelTrackExtractor.h
@@ -12,6 +12,8 @@
 #include "PhysicsTools/IsolationAlgos/interface/IsoDepositExtractor.h"
 #include "DataFormats/Common/interface/View.h"
 #include "DataFormats/TrackReco/interface/Track.h"
+#include "MagneticField/Engine/interface/MagneticField.h"
+#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
 
 namespace muonisolation {
 
@@ -39,6 +41,7 @@ namespace muonisolation {
 
   private:
     // Parameter set
+    edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> theFieldToken;
     edm::EDGetTokenT<reco::TrackCollection> theTrackCollectionToken;  //! Track Collection Token
     std::string theDepositLabel;                                      //! name for deposit
     double theDiff_r;                                                 //! transverse distance to vertex


### PR DESCRIPTION
#### PR description:

- Added esConsumes to all classes inheriting from reco::isodeposit::IsoDepositExtractor in this package

#### PR validation:

Code compiles.