### PR TITLE
Add esConsumes to MuonTrajectoryBuilder inheriting classes

### DIFF
--- a/RecoMuon/CosmicMuonProducer/interface/GlobalCosmicMuonTrajectoryBuilder.h
+++ b/RecoMuon/CosmicMuonProducer/interface/GlobalCosmicMuonTrajectoryBuilder.h
@@ -22,6 +22,7 @@
 #include "RecoMuon/CosmicMuonProducer/interface/CosmicMuonSmoother.h"
 #include "TrackingTools/TransientTrackingRecHit/interface/TransientTrackingRecHitBuilder.h"
 #include "RecoMuon/GlobalTrackingTools/interface/GlobalMuonTrackMatcher.h"
+#include "TrackingTools/Records/interface/TransientRecHitRecord.h"
 
 namespace edm {
   class ParameterSet;
@@ -87,10 +88,10 @@ private:
   std::string thePropagatorName;
   edm::EDGetTokenT<reco::TrackCollection> theTkTrackToken;
 
-  std::string theTrackerRecHitBuilderName;
+  const edm::ESGetToken<TransientTrackingRecHitBuilder, TransientRecHitRecord> theTrackerRecHitBuilderToken;
   edm::ESHandle<TransientTrackingRecHitBuilder> theTrackerRecHitBuilder;
 
-  std::string theMuonRecHitBuilderName;
+  const edm::ESGetToken<TransientTrackingRecHitBuilder, TransientRecHitRecord> theMuonRecHitBuilderToken;
   edm::ESHandle<TransientTrackingRecHitBuilder> theMuonRecHitBuilder;
 
   edm::Handle<reco::TrackCollection> theTrackerTracks;

--- a/RecoMuon/CosmicMuonProducer/src/GlobalCosmicMuonTrajectoryBuilder.cc
+++ b/RecoMuon/CosmicMuonProducer/src/GlobalCosmicMuonTrajectoryBuilder.cc
@@ -16,7 +16,6 @@
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
 #include "DataFormats/TrackReco/interface/TrackExtraFwd.h"
 #include "TrackingTools/TrajectoryState/interface/TrajectoryStateTransform.h"
-#include "TrackingTools/Records/interface/TransientRecHitRecord.h"
 #include "TrackingTools/TransientTrackingRecHit/interface/TransientTrackingRecHitBuilder.h"
 #include "TrackingTools/GeomPropagators/interface/StateOnTrackerBound.h"
 #include "DataFormats/Math/interface/deltaPhi.h"
@@ -30,7 +29,10 @@ using namespace edm;
 GlobalCosmicMuonTrajectoryBuilder::GlobalCosmicMuonTrajectoryBuilder(const edm::ParameterSet& par,
                                                                      const MuonServiceProxy* service,
                                                                      edm::ConsumesCollector& iC)
-    : theService(service) {
+    : theService(service),
+      theTrackerRecHitBuilderToken(
+          iC.esConsumes(edm::ESInputTag("", par.getParameter<string>("TrackerRecHitBuilder")))),
+      theMuonRecHitBuilderToken(iC.esConsumes(edm::ESInputTag("", par.getParameter<string>("MuonRecHitBuilder")))) {
   ParameterSet smootherPSet = par.getParameter<ParameterSet>("SmootherParameters");
   theSmoother = new CosmicMuonSmoother(smootherPSet, theService);
 
@@ -39,8 +41,6 @@ GlobalCosmicMuonTrajectoryBuilder::GlobalCosmicMuonTrajectoryBuilder(const edm::
 
   theTkTrackToken = iC.consumes<reco::TrackCollection>(par.getParameter<InputTag>("TkTrackCollectionLabel"));
 
-  theTrackerRecHitBuilderName = par.getParameter<string>("TrackerRecHitBuilder");
-  theMuonRecHitBuilderName = par.getParameter<string>("MuonRecHitBuilder");
   thePropagatorName = par.getParameter<string>("Propagator");
   category_ = "Muon|RecoMuon|CosmicMuon|GlobalCosmicMuonTrajectoryBuilder";
 }
@@ -74,8 +74,8 @@ void GlobalCosmicMuonTrajectoryBuilder::setEvent(const edm::Event& event) {
   //      tkTrajsAvailable = false;
   //  }
 
-  theService->eventSetup().get<TransientRecHitRecord>().get(theTrackerRecHitBuilderName, theTrackerRecHitBuilder);
-  theService->eventSetup().get<TransientRecHitRecord>().get(theMuonRecHitBuilderName, theMuonRecHitBuilder);
+  theTrackerRecHitBuilder = theService->eventSetup().getHandle(theTrackerRecHitBuilderToken);
+  theMuonRecHitBuilder = theService->eventSetup().getHandle(theMuonRecHitBuilderToken);
 }
 
 //

--- a/RecoMuon/StandAloneTrackFinder/interface/StandAloneMuonRefitter.h
+++ b/RecoMuon/StandAloneTrackFinder/interface/StandAloneMuonRefitter.h
@@ -9,11 +9,14 @@
  */
 
 #include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Utilities/interface/ESGetToken.h"
 #include "TrackingTools/PatternTools/interface/Trajectory.h"
+#include "TrackingTools/TrackFitters/interface/TrajectoryFitter.h"
 
 namespace edm {
   class ParameterSet;
-}
+  class ConsumesCollector;
+}  // namespace edm
 class MuonServiceProxy;
 class TrajectoryFitter;
 class Trajectory;
@@ -24,7 +27,7 @@ public:
 
 public:
   /// Constructor
-  StandAloneMuonRefitter(const edm::ParameterSet& par, const MuonServiceProxy* service);
+  StandAloneMuonRefitter(const edm::ParameterSet& par, edm::ConsumesCollector col, const MuonServiceProxy* service);
 
   /// Destructor
   virtual ~StandAloneMuonRefitter();
@@ -38,8 +41,8 @@ public:
 protected:
 private:
   const MuonServiceProxy* theService;
+  const edm::ESGetToken<TrajectoryFitter, TrajectoryFitter::Record> theFitterToken;
   edm::ESHandle<TrajectoryFitter> theFitter;
-  std::string theFitterName;
   unsigned int theNumberOfIterations;
   bool isForceAllIterations;
   double theMaxFractionOfLostHits;

--- a/RecoMuon/StandAloneTrackFinder/src/StandAloneMuonRefitter.cc
+++ b/RecoMuon/StandAloneTrackFinder/src/StandAloneMuonRefitter.cc
@@ -9,21 +9,21 @@
 
 #include "RecoMuon/TrackingTools/interface/MuonServiceProxy.h"
 
-#include "TrackingTools/TrackFitters/interface/TrajectoryFitter.h"
-
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "TrackingTools/Records/interface/TrackingComponentsRecord.h"
 
 using namespace edm;
 using namespace std;
 
-StandAloneMuonRefitter::StandAloneMuonRefitter(const ParameterSet& par, const MuonServiceProxy* service)
-    : theService(service) {
+StandAloneMuonRefitter::StandAloneMuonRefitter(const ParameterSet& par,
+                                               edm::ConsumesCollector col,
+                                               const MuonServiceProxy* service)
+    : theService(service), theFitterToken(col.esConsumes(edm::ESInputTag("", par.getParameter<string>("FitterName")))) {
   LogDebug("Muon|RecoMuon|StandAloneMuonRefitter") << "Constructor called." << endl;
 
-  theFitterName = par.getParameter<string>("FitterName");
   theNumberOfIterations = par.getParameter<unsigned int>("NumberOfIterations");
   isForceAllIterations = par.getParameter<bool>("ForceAllIterations");
   theMaxFractionOfLostHits = par.getParameter<double>("MaxFractionOfLostHits");
@@ -39,7 +39,7 @@ StandAloneMuonRefitter::~StandAloneMuonRefitter() {
 
 /// Refit
 StandAloneMuonRefitter::RefitResult StandAloneMuonRefitter::singleRefit(const Trajectory& trajectory) {
-  theService->eventSetup().get<TrajectoryFitter::Record>().get(theFitterName, theFitter);
+  theFitter = theService->eventSetup().getHandle(theFitterToken);
 
   vector<Trajectory> refitted;
 

--- a/RecoMuon/StandAloneTrackFinder/src/StandAloneTrajectoryBuilder.cc
+++ b/RecoMuon/StandAloneTrackFinder/src/StandAloneTrajectoryBuilder.cc
@@ -95,7 +95,7 @@ StandAloneMuonTrajectoryBuilder::StandAloneMuonTrajectoryBuilder(const Parameter
   if (doRefit) {
     // The outward-inward fitter (starts from theBWFilter innermost state)
     ParameterSet refitterPSet = par.getParameter<ParameterSet>("RefitterParameters");
-    theRefitter = new StandAloneMuonRefitter(refitterPSet, theService);
+    theRefitter = new StandAloneMuonRefitter(refitterPSet, iC, theService);
   }
 
   // The seed transformer (used to refit the seed and get the seed transient state)


### PR DESCRIPTION
#### PR description:

Based on static analyzer report, changed those classes inheriting from MuonTrajectoryBuilder which were obtaining data from the EventSetup.

#### PR validation:

Code compiles.