### PR TITLE
Fixed finecalo performance

### DIFF
--- a/SimG4CMS/Calo/interface/CaloG4Hit.h
+++ b/SimG4CMS/Calo/interface/CaloG4Hit.h
@@ -67,6 +67,7 @@ public:
   double getTimeSlice() const { return hitID.timeSlice(); }
   int getTimeSliceID() const { return hitID.timeSliceID(); }
   uint16_t getDepth() const { return hitID.depth(); }
+  bool isFinecaloTrackID() const { return hitID.isFinecaloTrackID(); }
 
   CaloHitID getID() const { return hitID; }
   void setID(uint32_t i, double d, int j, uint16_t k = 0) { hitID.setID(i, d, j, k); }
@@ -98,8 +99,6 @@ public:
       return (a->getUnitID() < b->getUnitID());
     } else if (a->getDepth() != b->getDepth()) {
       return (a->getDepth() < b->getDepth());
-    } else if (a->getID().fineTrackID() != b->getID().fineTrackID()) {
-      return (a->getID().fineTrackID() < b->getID().fineTrackID());
     } else {
       return (a->getTimeSliceID() < b->getTimeSliceID());
     }
@@ -110,7 +109,7 @@ class CaloG4HitEqual {
 public:
   bool operator()(const CaloG4Hit* a, const CaloG4Hit* b) {
     return (a->getTrackID() == b->getTrackID() && a->getUnitID() == b->getUnitID() && a->getDepth() == b->getDepth() &&
-            a->getTimeSliceID() == b->getTimeSliceID() && a->getID().fineTrackID() == b->getID().fineTrackID());
+            a->getTimeSliceID() == b->getTimeSliceID());
   }
 };
 

--- a/SimG4CMS/Calo/interface/CaloHitID.h
+++ b/SimG4CMS/Calo/interface/CaloHitID.h
@@ -26,9 +26,8 @@ public:
   void reset();
 
   void setTrackID(int trackID) { theTrackID = trackID; }
-  bool hasFineTrackID() const { return theFineTrackID != -1; }
-  void setFineTrackID(int fineTrackID) { theFineTrackID = fineTrackID; }
-  int fineTrackID() const { return hasFineTrackID() ? theFineTrackID : theTrackID; }
+  void markAsFinecaloTrackID(bool flag = true) { isFinecaloTrackID_ = flag; }
+  bool isFinecaloTrackID() const { return isFinecaloTrackID_; }
 
   bool operator==(const CaloHitID&) const;
   bool operator<(const CaloHitID&) const;
@@ -42,7 +41,7 @@ private:
   uint16_t theDepth;
   float timeSliceUnit;
   bool ignoreTrackID;
-  int theFineTrackID;
+  bool isFinecaloTrackID_;
 };
 
 std::ostream& operator<<(std::ostream&, const CaloHitID&);

--- a/SimG4CMS/Calo/interface/CaloSD.h
+++ b/SimG4CMS/Calo/interface/CaloSD.h
@@ -28,6 +28,7 @@
 
 #include <vector>
 #include <map>
+#include <unordered_map>
 #include <memory>
 
 class G4Step;
@@ -85,7 +86,9 @@ protected:
   double getAttenuation(const G4Step* aStep, double birk1, double birk2, double birk3) const;
 
   static std::string printableDecayChain(const std::vector<unsigned int>& decayChain);
-  void hitBookkeepingFineCalo(const G4Step* step, const G4Track* currentTrack, CaloG4Hit* hit);
+  std::string shortreprID(const CaloHitID& ID);
+  std::string shortreprID(const CaloG4Hit* hit);
+  unsigned int findBoundaryCrossingParent(const G4Track* track, bool markParentAsSaveable = true);
 
   void update(const BeginOfRun*) override;
   void update(const BeginOfEvent*) override;
@@ -183,8 +186,10 @@ private:
 
   std::map<CaloHitID, CaloG4Hit*> hitMap;
   std::map<int, TrackWithHistory*> tkMap;
+  std::unordered_map<unsigned int, unsigned int> boundaryCrossingParentMap_;
   std::vector<std::unique_ptr<CaloG4Hit>> reusehit;
   std::vector<Detector> fineDetectors_;
+  bool doFineCaloThisStep_;
 };
 
 #endif  // SimG4CMS_CaloSD_h

--- a/SimG4CMS/Calo/src/CaloHitID.cc
+++ b/SimG4CMS/Calo/src/CaloHitID.cc
@@ -7,7 +7,7 @@
 #include <iomanip>
 
 CaloHitID::CaloHitID(uint32_t unitID, double timeSlice, int trackID, uint16_t depth, float tSlice, bool ignoreTkID)
-    : timeSliceUnit(tSlice), ignoreTrackID(ignoreTkID), theFineTrackID(-1) {
+    : timeSliceUnit(tSlice), ignoreTrackID(ignoreTkID), isFinecaloTrackID_(false) {
   setID(unitID, timeSlice, trackID, depth);
 }
 
@@ -21,7 +21,7 @@ CaloHitID::CaloHitID(const CaloHitID& id) {
   theDepth = id.theDepth;
   timeSliceUnit = id.timeSliceUnit;
   ignoreTrackID = id.ignoreTrackID;
-  theFineTrackID = id.theFineTrackID;
+  isFinecaloTrackID_ = id.isFinecaloTrackID_;
 }
 
 const CaloHitID& CaloHitID::operator=(const CaloHitID& id) {
@@ -32,7 +32,7 @@ const CaloHitID& CaloHitID::operator=(const CaloHitID& id) {
   theDepth = id.theDepth;
   timeSliceUnit = id.timeSliceUnit;
   ignoreTrackID = id.ignoreTrackID;
-  theFineTrackID = id.theFineTrackID;
+  isFinecaloTrackID_ = id.isFinecaloTrackID_;
   return *this;
 }
 
@@ -52,12 +52,12 @@ void CaloHitID::reset() {
   theTrackID = -2;
   theTimeSliceID = (int)(theTimeSlice / timeSliceUnit);
   theDepth = 0;
-  theFineTrackID = -1;
+  isFinecaloTrackID_ = false;
 }
 
 bool CaloHitID::operator==(const CaloHitID& id) const {
   return ((theUnitID == id.unitID()) && (theTrackID == id.trackID() || ignoreTrackID) &&
-          (theTimeSliceID == id.timeSliceID()) && (theDepth == id.depth()) && (fineTrackID() == id.fineTrackID()))
+          (theTimeSliceID == id.timeSliceID()) && (theDepth == id.depth()))
              ? true
              : false;
 }
@@ -65,8 +65,6 @@ bool CaloHitID::operator==(const CaloHitID& id) const {
 bool CaloHitID::operator<(const CaloHitID& id) const {
   if (theTrackID != id.trackID()) {
     return (theTrackID > id.trackID());
-  } else if (fineTrackID() != id.fineTrackID()) {
-    return (fineTrackID() > id.fineTrackID());
   } else if (theUnitID != id.unitID()) {
     return (theUnitID > id.unitID());
   } else if (theDepth != id.depth()) {
@@ -79,8 +77,6 @@ bool CaloHitID::operator<(const CaloHitID& id) const {
 bool CaloHitID::operator>(const CaloHitID& id) const {
   if (theTrackID != id.trackID()) {
     return (theTrackID < id.trackID());
-  } else if (fineTrackID() != id.fineTrackID()) {
-    return (fineTrackID() < id.fineTrackID());
   } else if (theUnitID != id.unitID()) {
     return (theUnitID < id.unitID());
   } else if (theDepth != id.depth()) {
@@ -93,7 +89,5 @@ bool CaloHitID::operator>(const CaloHitID& id) const {
 std::ostream& operator<<(std::ostream& os, const CaloHitID& id) {
   os << "UnitID 0x" << std::hex << id.unitID() << std::dec << " Depth " << std::setw(6) << id.depth() << " Time "
      << std::setw(6) << id.timeSlice() << " TrackID " << std::setw(8) << id.trackID();
-  if (id.hasFineTrackID())
-    os << " fineTrackID " << id.fineTrackID();
   return os;
 }

--- a/SimG4CMS/Calo/src/CaloSD.cc
+++ b/SimG4CMS/Calo/src/CaloSD.cc
@@ -31,7 +31,7 @@
 #include <memory>
 #include <sstream>
 
-//#define EDM_ML_DEBUG
+// #define EDM_ML_DEBUG
 
 CaloSD::CaloSD(const std::string& name,
                const SensitiveDetectorCatalog& clg,
@@ -116,6 +116,7 @@ CaloSD::CaloSD(const std::string& name,
                               << eminHitD / CLHEP::MeV << " MeV (for nonzero depths);\n        Time Slice Unit "
                               << timeSlice << "\nIgnore TrackID Flag " << ignoreTrackID << " doFineCalo flag "
                               << doFineCalo_ << "\nBeam Position " << beamZ / CLHEP::cm << " cm";
+  if(doFineCalo_) edm::LogVerbatim("DoFineCalo") << "Using finecalo v2";
 
   // Treat fine calorimeters
   edm::LogVerbatim("CaloSim") << "CaloSD: Have a possibility of " << fineNames.size() << " fine calorimeters of which "
@@ -168,6 +169,10 @@ G4bool CaloSD::ProcessHits(G4Step* aStep, G4TouchableHistory*) {
                               << " Eprestep= " << aStep->GetPreStepPoint()->GetKineticEnergy()
                               << " step= " << aStep->GetStepLength() << " Edep= " << aStep->GetTotalEnergyDeposit();
 #endif
+
+  // Class variable to determine whether finecalo rules should apply for this step
+  doFineCaloThisStep_ = (doFineCalo_ && isItFineCalo(aStep->GetPreStepPoint()->GetTouchable()));
+
   // apply shower library or parameterisation
   if (isParameterized) {
     if (getFromLibrary(aStep)) {
@@ -213,6 +218,10 @@ G4bool CaloSD::ProcessHits(G4Step* aStep, G4TouchableHistory*) {
 
   double energy = getEnergyDeposit(aStep);
   if (energy > 0.0) {
+    if (doFineCaloThisStep_) {
+      currentID.setID(unitID, time, findBoundaryCrossingParent(theTrack), depth);
+      currentID.markAsFinecaloTrackID();
+    }
     if (G4TrackToParticleID::isGammaElectronPositron(theTrack)) {
       edepositEM = energy;
     } else {
@@ -232,7 +241,7 @@ G4bool CaloSD::ProcessHits(G4Step* aStep, G4TouchableHistory*) {
       currentHit = createNewHit(aStep, aStep->GetTrack());
     } else {
 #ifdef EDM_ML_DEBUG
-      edm::LogVerbatim("DoFineCalo") << "Not creating new hit, only updating currentHit " << currentHit->getUnitID();
+      edm::LogVerbatim("DoFineCalo") << "Not creating new hit, only updating " << shortreprID(currentHit);
 #endif
     }
     return true;
@@ -444,11 +453,11 @@ bool CaloSD::checkHit() {
 
 int CaloSD::getNumberOfHits() { return theHC->entries(); }
 
+/*
+Takes a vector of ints (representing trackIDs), and returns a formatted string
+for debugging purposes
+*/
 std::string CaloSD::printableDecayChain(const std::vector<unsigned int>& decayChain) {
-  /*
-  Takes a vector of ints (representing trackIDs), and returns a formatted string
-  for debugging purposes
-  */
   std::stringstream ss;
   for (long unsigned int i = 0; i < decayChain.size(); i++) {
     if (i > 0)
@@ -458,111 +467,91 @@ std::string CaloSD::printableDecayChain(const std::vector<unsigned int>& decayCh
   return ss.str();
 }
 
-void CaloSD::hitBookkeepingFineCalo(const G4Step* step, const G4Track* currentTrack, CaloG4Hit* hit) {
-  /*
-  Performs bookkeeping: Determines what trackIDs are to be recorded for the hit (typically some
-  some parent trackID), and also sets the right flags on either the TrackInformation object or 
-  the TrackWithHistory object to make sure the right track is saved to the SimTrack collection.
+/* Very short representation of a CaloHitID */
+std::string CaloSD::shortreprID(const CaloHitID& ID) {
+  std::stringstream ss;
+  ss << GetName() << "/" << ID.unitID() << "/trk" << ID.trackID() << "/d" << ID.depth() << "/time" << ID.timeSliceID();
+  if (ID.isFinecaloTrackID())
+    ss << "/FC";
+  return ss.str();
+}
 
-  `currentTrack` is the track that is currently being processed by Geant
-  */
-  TrackInformation* trkInfo = cmsTrackInformation(currentTrack);
-  // Copy the  class's currentID so we can freely modify it without influencing
-  // hits created later in possibly non-fine detectors by the same track
-  CaloHitID hitID = currentID;
-  // First check if the current currentTrack passes criteria
-  if (trkInfo->crossedBoundary()) {
+/* As above, but with a hit as input */
+std::string CaloSD::shortreprID(const CaloG4Hit* hit) { return shortreprID(hit->getID()); }
+
+/*
+Finds the boundary-crossing parent of a track, and stores it in the CaloSD's map
+*/
+unsigned int CaloSD::findBoundaryCrossingParent(const G4Track* track, bool markAsSaveable) {
+  TrackInformation* trkInfo = cmsTrackInformation(track);
+  unsigned int id = track->GetTrackID();
+  // First see if this track is already in the map
+  auto it = boundaryCrossingParentMap_.find(id);
+  if (it != boundaryCrossingParentMap_.end()) {
 #ifdef EDM_ML_DEBUG
-    edm::LogVerbatim("DoFineCalo") << "currentTrack " << currentTrack->GetTrackID()
-                                   << " itself has crossedBoundary=" << trkInfo->crossedBoundary()
-                                   << " ; recording it for hit " << hit->getUnitID();
+    edm::LogVerbatim("DoFineCalo") << "Track " << id << " parent already cached: " << it->second;
 #endif
-    hitID.setFineTrackID(currentTrack->GetTrackID());
-    hit->setID(hitID);  // Actually overwrite the ID for the hit
+    return it->second;
+  }
+  // Then see if the track itself crosses the boundary
+  else if (trkInfo->crossedBoundary()) {
+#ifdef EDM_ML_DEBUG
+    edm::LogVerbatim("DoFineCalo") << "Track " << id << " crosses boundary itself";
+#endif
+    boundaryCrossingParentMap_[id] = id;
     trkInfo->storeTrack(true);
-    return;
+    return id;
   }
-  // currentTrack itself does not pass thresholds / does not cross boundary; go through its history to find a track that does
-  TrackWithHistory* recordTrackWithHistory;
-  // Keep track of decay chain of this track for debugging purposes
-  std::vector<unsigned int> decayChain;
-  decayChain.push_back(currentTrack->GetTrackID());
-  // Find the first parent of this track that passes the required criteria
-  // Start from first parent
-  unsigned int recordTrackID = currentTrack->GetParentID();
+  // Else, traverse the history of the track
+  std::vector<unsigned int> decayChain{id};
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("DoFineCalo") << "Trying to find the first parent of hit " << hit->getUnitID()
-                                 << " that passes saving criterion (crosses boundary or specific criterion)"
-                                 << "; starting with first parent track " << recordTrackID;
+  edm::LogVerbatim("DoFineCalo") << "Track " << id << ": Traversing history to find boundary-crossing parent";
 #endif
-  // Check whether this first parent actually exists
-  if (recordTrackID <= 0) {
-    // Track ID 0 is not a track;
-    // This means the current currentTrack has no parent, but apparently it also didn't fit saving criteria
-    throw cms::Exception("Unknown", "CaloSD") << "ERROR: Track " << currentTrack->GetTrackID()
-                                              << " has no parent, does not fit saving criteria, but left hit "
-                                              << hit->getUnitID() << "; recording it but it's weird!";
-  }
-  // Start progressing through the track's history
+  unsigned int parentID = track->GetParentID();
   while (true) {
-    // Record the decay chain for debugging purposes
-    decayChain.push_back(recordTrackID);
-    recordTrackWithHistory = m_trackManager->getTrackByID(recordTrackID);
-    if (recordTrackID < (unsigned int)hitID.trackID()) {
-      // A parent of the currentTrack has a lower trackID than the current
-      // hitID.trackID(). This means the current hitID.trackID() does not point
-      // to the earliest ancestor of the currentTrack.
-      // The current hitID.trackID() might not be a saved track yet, but the
-      // ancestor is *always* a saved track.
-      // Fix this by overwriting the hitID's track ID.
-#ifdef EDM_ML_DEBUG
-      edm::LogVerbatim("DoFineCalo") << "History-tracking progressed to track " << recordTrackID
-                                     << ", which is an earlier ancestor than current primary " << hitID.trackID()
-                                     << "; overwriting it.";
-#endif
-      hitID.setTrackID(recordTrackID);
-    }
-    // Check if this parent fits the boundary-crossing criteria
-    if (recordTrackWithHistory->crossedBoundary() && recordTrackWithHistory->getIDAtBoundary() == (int)recordTrackID) {
-#ifdef EDM_ML_DEBUG
-      edm::LogVerbatim("DoFineCalo") << "Recording track " << recordTrackID << " as source of hit " << hit->getUnitID()
-                                     << "; crossed boundary at pos=("
-                                     << recordTrackWithHistory->getPositionAtBoundary().x() << ","
-                                     << recordTrackWithHistory->getPositionAtBoundary().y() << ","
-                                     << recordTrackWithHistory->getPositionAtBoundary().z() << ")"
-                                     << " mom=(" << recordTrackWithHistory->getMomentumAtBoundary().x() << ","
-                                     << recordTrackWithHistory->getMomentumAtBoundary().y() << ","
-                                     << recordTrackWithHistory->getMomentumAtBoundary().z() << ","
-                                     << recordTrackWithHistory->getMomentumAtBoundary().e() << ")"
-                                     << " id@boundary=" << recordTrackWithHistory->getIDAtBoundary()
-                                     << "; decayChain: " << printableDecayChain(decayChain);
-#endif
-      break;
-    }
-    // This parent track did not fit criteria - go to the next parent
-#ifdef EDM_ML_DEBUG
-    edm::LogVerbatim("DoFineCalo") << "Track " << recordTrackID << " did not cross the boundary or fit other criteria";
-#endif
-    recordTrackID = recordTrackWithHistory->parentID();
-    if (recordTrackID <= 0) {
-      // Track ID 0 is not a track;
-      // This means that no parent of the currentTrack fitted the criteria
+    if (parentID == 0)
       throw cms::Exception("Unknown", "CaloSD")
-          << "Hit " << hit->getUnitID() << " does not have any parent track that passes the criteria!"
-          << " decayChain so far: " << printableDecayChain(decayChain);
-    }
-  }
-  // Parentage traversal done - do the bookeeping for the found ancestor track
-  recordTrackWithHistory->save();
-  hitID.setFineTrackID(recordTrackID);
-  hit->setID(hitID);  // Actually overwrite the ID for the hit
+          << "Hit end of parentage for track " << id << " without finding a boundary-crossing parent";
+    // First check if this ancestor is already in the map
+    auto it = boundaryCrossingParentMap_.find(parentID);
+    if (it != boundaryCrossingParentMap_.end()) {
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("DoFineCalo") << "Stored the following bookeeping for hit " << hit->getUnitID()
-                                 << " hitID.trackID()=" << hitID.trackID()
-                                 << " hitID.fineTrackID()=" << hitID.fineTrackID()
-                                 << " recordTrackWithHistory->trackID()=" << recordTrackWithHistory->trackID()
-                                 << " recordTrackWithHistory->saved()=" << recordTrackWithHistory->saved();
+      edm::LogVerbatim("DoFineCalo") << "  Track " << parentID
+                                     << " boundary-crossing parent already cached: " << it->second;
 #endif
+      // Store this parent also for the rest of the traversed decay chain
+      for (auto ancestorID : decayChain)
+        boundaryCrossingParentMap_[ancestorID] = it->second;
+#ifdef EDM_ML_DEBUG
+      // In debug mode, still build the rest of the decay chain for debugging
+      decayChain.push_back(parentID);
+      while (parentID != it->second) {
+        parentID = m_trackManager->getTrackByID(parentID, true)->parentID();
+        decayChain.push_back(parentID);
+      }
+      edm::LogVerbatim("DoFineCalo") << "  Full decay chain: " << printableDecayChain(decayChain);
+#endif
+      return it->second;
+    }
+    // If not, get this parent from the track manager (expensive)
+    TrackWithHistory* parentTrack = m_trackManager->getTrackByID(parentID, true);
+    if (parentTrack->crossedBoundary()) {
+      if (markAsSaveable)
+        parentTrack->save();
+      decayChain.push_back(parentID);
+      // Record this boundary crossing parent for all traversed ancestors
+      for (auto ancestorID : decayChain)
+        boundaryCrossingParentMap_[ancestorID] = parentID;
+#ifdef EDM_ML_DEBUG
+      edm::LogVerbatim("DoFineCalo") << "  Found boundary-crossing ancestor " << parentID << " for track " << id
+                                     << "; decay chain: " << printableDecayChain(decayChain);
+#endif
+      return parentID;
+    }
+    // Next iteration
+    decayChain.push_back(parentID);
+    parentID = parentTrack->parentID();
+  }
 }
 
 CaloG4Hit* CaloSD::createNewHit(const G4Step* aStep, const G4Track* theTrack) {
@@ -598,30 +587,15 @@ CaloG4Hit* CaloSD::createNewHit(const G4Step* aStep, const G4Track* theTrack) {
   storeHit(aHit);
   TrackInformation* trkInfo = cmsTrackInformation(theTrack);
 
-  bool currentlyInsideFineVolume = !doFineCalo_ ? false : isItFineCalo(aStep->GetPostStepPoint()->GetTouchable());
-
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("DoFineCalo") << "Creating new hit " << aHit->getUnitID() << " using "
-                                 << (currentlyInsideFineVolume ? "FINECALO" : "normal CaloSD")
-                                 << "; currentID.trackID=" << currentID.trackID()
-                                 << " currentID.fineTrackID=" << currentID.fineTrackID()
-                                 << " isItFineCalo(aStep->GetPostStepPoint()->GetTouchable())="
-                                 << isItFineCalo(aStep->GetPostStepPoint()->GetTouchable())
-                                 << " isItFineCalo(aStep->GetPreStepPoint()->GetTouchable())="
-                                 << isItFineCalo(aStep->GetPreStepPoint()->GetTouchable())
-                                 << " theTrack=" << theTrack->GetTrackID() << " ("
-                                 << " parentTrackId=" << theTrack->GetParentID()
-                                 << " getIDonCaloSurface=" << trkInfo->getIDonCaloSurface() << ")"
-                                 << " primIDSaved=" << primIDSaved;
+  if (doFineCaloThisStep_)
+    edm::LogVerbatim("DoFineCalo") << "New hit " << shortreprID(aHit) << " using finecalo;"
+                                   << " isItFineCalo(post)=" << isItFineCalo(aStep->GetPostStepPoint()->GetTouchable())
+                                   << " isItFineCalo(pre)=" << isItFineCalo(aStep->GetPreStepPoint()->GetTouchable());
 #endif
 
-  // If fine calo is activated for the current volume, perform track/hit
-  // saving logic for fineCalo
-  if (currentlyInsideFineVolume) {
-    hitBookkeepingFineCalo(aStep, theTrack, aHit);
-  }
   // 'Traditional', non-fine history bookkeeping
-  else {
+  if (!doFineCaloThisStep_) {
     double etrack = 0;
     if (currentID.trackID() == primIDSaved) {  // The track is saved; nothing to be done
     } else if (currentID.trackID() == theTrack->GetTrackID()) {
@@ -795,6 +769,7 @@ void CaloSD::update(const ::EndOfEvent*) {
   std::vector<std::unique_ptr<CaloG4Hit>>().swap(reusehit);
   if (useMap)
     hitMap.erase(hitMap.begin(), hitMap.end());
+  boundaryCrossingParentMap_.clear();
 }
 
 void CaloSD::clearHits() {
@@ -902,26 +877,22 @@ bool CaloSD::saveHit(CaloG4Hit* aHit) {
   if (corrTOFBeam)
     time += correctT;
 
-  // Do track bookkeeping a little differently for fine tracking
-  if (doFineCalo_ && aHit->getID().hasFineTrackID()) {
-    tkID = aHit->getID().fineTrackID();
+  // More strict bookkeeping for finecalo
+  if (doFineCalo_ && aHit->isFinecaloTrackID()) {
 #ifdef EDM_ML_DEBUG
-    edm::LogVerbatim("DoFineCalo") << "Saving hit " << aHit->getUnitID() << " with trackID=" << tkID;
+    edm::LogVerbatim("DoFineCalo") << "Saving hit " << shortreprID(aHit);
 #endif
-    // Check if the track is actually in the trackManager
-    if (m_trackManager) {
-      if (!m_trackManager->trackExists(tkID)) {
-        ok = false;
-        throw cms::Exception("Unknown", "CaloSD")
-            << "aHit " << aHit->getUnitID() << " has fine trackID " << tkID << ", which is NOT IN THE TRACK MANAGER";
-      }
-    } else {
-      ok = false;
-      throw cms::Exception("Unknown", "CaloSD") << "m_trackManager not set, saveHit ok=false!";
-    }
-    // Take the aHit-information and move it to the actual PCaloHitContainer
-    slave.get()->processHits(
-        aHit->getUnitID(), aHit->getEM() / CLHEP::GeV, aHit->getHadr() / CLHEP::GeV, time, tkID, aHit->getDepth());
+    if (!m_trackManager)
+      throw cms::Exception("Unknown", "CaloSD") << "m_trackManager not set, needed for finecalo!";
+    if (!m_trackManager->trackExists(aHit->getTrackID()))
+      throw cms::Exception("Unknown", "CaloSD")
+          << "Error on hit " << shortreprID(aHit) << ": Parent track not in track manager";
+    slave.get()->processHits(aHit->getUnitID(),
+                             aHit->getEM() / CLHEP::GeV,
+                             aHit->getHadr() / CLHEP::GeV,
+                             time,
+                             aHit->getTrackID(),
+                             aHit->getDepth());
   }
   // Regular, not-fine way:
   else {
@@ -939,8 +910,7 @@ bool CaloSD::saveHit(CaloG4Hit* aHit) {
       ok = false;
     }
 #ifdef EDM_ML_DEBUG
-    edm::LogVerbatim("DoFineCalo") << "Saving hit " << aHit->getUnitID() << " with trackID=" << tkID
-                                   << " (no fineTrackID)";
+    edm::LogVerbatim("DoFineCalo") << "Saving hit " << shortreprID(aHit) << " with trackID=" << tkID;
 #endif
     slave.get()->processHits(
         aHit->getUnitID(), aHit->getEM() / CLHEP::GeV, aHit->getHadr() / CLHEP::GeV, time, tkID, aHit->getDepth());

--- a/SimG4CMS/Calo/src/CaloSD.cc
+++ b/SimG4CMS/Calo/src/CaloSD.cc
@@ -116,7 +116,8 @@ CaloSD::CaloSD(const std::string& name,
                               << eminHitD / CLHEP::MeV << " MeV (for nonzero depths);\n        Time Slice Unit "
                               << timeSlice << "\nIgnore TrackID Flag " << ignoreTrackID << " doFineCalo flag "
                               << doFineCalo_ << "\nBeam Position " << beamZ / CLHEP::cm << " cm";
-  if(doFineCalo_) edm::LogVerbatim("DoFineCalo") << "Using finecalo v2";
+  if (doFineCalo_)
+    edm::LogVerbatim("DoFineCalo") << "Using finecalo v2";
 
   // Treat fine calorimeters
   edm::LogVerbatim("CaloSim") << "CaloSD: Have a possibility of " << fineNames.size() << " fine calorimeters of which "

--- a/SimG4CMS/Calo/src/CaloTrkProcessing.cc
+++ b/SimG4CMS/Calo/src/CaloTrkProcessing.cc
@@ -16,7 +16,7 @@
 #include "DD4hep/Filter.h"
 
 #include <sstream>
-//#define EDM_ML_DEBUG
+// #define EDM_ML_DEBUG
 
 CaloTrkProcessing::CaloTrkProcessing(const std::string& name,
                                      const CaloSimulationParameters& csps,
@@ -275,7 +275,8 @@ void CaloTrkProcessing::update(const G4Step* aStep) {
           trkInfo->setIDonCaloSurface(
               id, ical, inside, theTrack->GetDefinition()->GetPDGEncoding(), theTrack->GetMomentum().mag());
           trkInfo->setCaloIDChecked(true);
-          trkInfo->setCrossedBoundary(theTrack);
+          if (!doFineCalo_)
+            trkInfo->setCrossedBoundary(theTrack);
           lastTrackID_ = id;
           if (theTrack->GetKineticEnergy() / CLHEP::MeV > eMin_)
             trkInfo->putInHistory();


### PR DESCRIPTION
#### PR description:

This patch streamlines the finecalo patch ([PR 32673)](https://github.com/cms-sw/cmssw/pull/32673).

  - The lookups of the boundary-crossing parent of a track are no longer done in the `createNewHit` method of CaloSD, but only once per track.
  - Boundary-crossing parent lookups are also cached in a map in CaloSD, which leads to a lot less lookups. (A 'lookup' consists of traversing the track history via the SimTrackManager, which is expensive.)
  - Some needless attributes from the CaloHitID classes are removed again.
  - Fixed a bug where in very rare cases hits would still be assigned to the primary rather than the boundary crossing parent.
  - Line 309 in CaloTrkProcessing.cc (introduced in [PR 33056](https://github.com/cms-sw/cmssw/pull/33056)) is disabled for finecalo, as it changes the behavior of finecalo.

The CPU time needed per event is about 20% more than default CMSSW (hard to quantify the exact time difference due to slightly varying usage of the compute nodes I am using). This is a significant improvement w.r.t. to the finecalo patch 1, which was anywhere between 100% and 500% slower depending on the simulated event topology (it used to scale with the depth of the decay tree - the cache reduces the complexity of the algorithm immensely).

Plot of the RSS as a function of time (orange = this patch, green = the previous patch, blue = default CMSSW):

<img width="599" alt="rss_over_time_ttbar" src="https://user-images.githubusercontent.com/11268158/126683112-c3903491-c307-49d4-8d38-9ed01a01d08e.png">

#### PR validation:

I checked event displays of ttbar and of a tau gun, and it looks in order.
