### PR TITLE
finecalo: No longer count reentries into the calorimeter as boundary crossings

### DIFF
--- a/SimG4CMS/Calo/src/CaloTrkProcessing.cc
+++ b/SimG4CMS/Calo/src/CaloTrkProcessing.cc
@@ -196,20 +196,22 @@ void CaloTrkProcessing::update(const G4Step* aStep) {
   }
 
   if (doFineCalo_) {
-    // Boundary-crossing logic
     int prestepLV = isItCalo(aStep->GetPreStepPoint()->GetTouchable(), fineDetectors_);
     int poststepLV = isItCalo(aStep->GetPostStepPoint()->GetTouchable(), fineDetectors_);
-    if (prestepLV < 0 && poststepLV >= 0
-        // Allow back-scattering and filter it out later; ensure consistency during the SIM step
-        // && std::abs(theTrack->GetStep()->GetPreStepPoint()->GetPosition().z()) < std::abs(theTrack->GetPosition().z())
-    ) {
+
+    // Once per track, determine whether track started in fine volume
+    if (!trkInfo->startedInFineVolumeIsSet())
+      trkInfo->setStartedInFineVolume(prestepLV >= 0);
+
+    // Boundary-crossing logic
+    if (prestepLV < 0 && poststepLV >= 0) {
 #ifdef EDM_ML_DEBUG
-      edm::LogVerbatim("DoFineCalo") << "Entered fine volume " << poststepLV << ":"
-                                     << " Track " << id << " pdgid=" << theTrack->GetDefinition()->GetPDGEncoding()
+      edm::LogVerbatim("DoFineCalo") << "Track " << id << " entered a fine volume:"
+                                     << " pdgid=" << theTrack->GetDefinition()->GetPDGEncoding()
+                                     << " theTrack->GetCurrentStepNumber()=" << theTrack->GetCurrentStepNumber()
                                      << " prestepLV=" << prestepLV << " poststepLV=" << poststepLV
                                      << " GetKineticEnergy[GeV]=" << theTrack->GetKineticEnergy() / CLHEP::GeV
-                                     << " GetVertexKineticEnergy[GeV]="
-                                     << theTrack->GetVertexKineticEnergy() / CLHEP::GeV << " prestepPosition[cm]=("
+                                     << " prestepPosition[cm]=("
                                      << theTrack->GetStep()->GetPreStepPoint()->GetPosition().x() / CLHEP::cm << ","
                                      << theTrack->GetStep()->GetPreStepPoint()->GetPosition().y() / CLHEP::cm << ","
                                      << theTrack->GetStep()->GetPreStepPoint()->GetPosition().z() / CLHEP::cm << ")"
@@ -222,17 +224,33 @@ void CaloTrkProcessing::update(const G4Step* aStep) {
                                      << theTrack->GetPosition().z() / CLHEP::cm << ")"
                                      << " vertex_position[cm]=(" << theTrack->GetVertexPosition().x() / CLHEP::cm << ","
                                      << theTrack->GetVertexPosition().y() / CLHEP::cm << ","
-                                     << theTrack->GetVertexPosition().z() / CLHEP::cm << ")";
+                                     << theTrack->GetVertexPosition().z() / CLHEP::cm << ")"
+                                     << " GetVertexKineticEnergy[GeV]="
+                                     << theTrack->GetVertexKineticEnergy() / CLHEP::GeV;
 #endif
-      trkInfo->setCrossedBoundary(theTrack);
+      if (!trkInfo->startedInFineVolume() && !trkInfo->crossedBoundary()) {
+        trkInfo->setCrossedBoundary(theTrack);
+#ifdef EDM_ML_DEBUG
+        edm::LogVerbatim("DoFineCalo") << "Track " << id << " marked as boundary-crossing; sanity check:"
+                                       << " theTrack->GetTrackID()=" << theTrack->GetTrackID()
+                                       << " trkInfo->crossedBoundary()=" << trkInfo->crossedBoundary();
+#endif
+      }
+#ifdef EDM_ML_DEBUG
+      else {
+        edm::LogVerbatim("DoFineCalo") << "Track " << id << " REENTERED a fine volume;"
+                                       << " not counting this boundary crossing!";
+      }
+#endif
+
     }
 #ifdef EDM_ML_DEBUG
     else if (prestepLV >= 0 && poststepLV < 0) {
-      edm::LogVerbatim("DoFineCalo") << "Exited fine volume " << prestepLV << ":"
-                                     << " Track " << id
+      edm::LogVerbatim("DoFineCalo") << "Track " << id << " exited a fine volume:"
+                                     << " theTrack->GetCurrentStepNumber()=" << theTrack->GetCurrentStepNumber()
+                                     << " prestepLV=" << prestepLV << " poststepLV=" << poststepLV
                                      << " GetKineticEnergy[GeV]=" << theTrack->GetKineticEnergy() / CLHEP::GeV
-                                     << " GetVertexKineticEnergy[GeV]="
-                                     << theTrack->GetVertexKineticEnergy() / CLHEP::GeV << " prestepPosition[cm]=("
+                                     << " prestepPosition[cm]=("
                                      << theTrack->GetStep()->GetPreStepPoint()->GetPosition().x() / CLHEP::cm << ","
                                      << theTrack->GetStep()->GetPreStepPoint()->GetPosition().y() / CLHEP::cm << ","
                                      << theTrack->GetStep()->GetPreStepPoint()->GetPosition().z() / CLHEP::cm << ")"

--- a/SimG4Core/Notification/interface/TrackInformation.h
+++ b/SimG4Core/Notification/interface/TrackInformation.h
@@ -60,7 +60,6 @@ public:
   // Boundary crossing variables
   void setCrossedBoundary(const G4Track *track) {
     crossedBoundary_ = true;
-    idAtBoundary_ = track->GetTrackID();
     positionAtBoundary_ = math::XYZTLorentzVectorF(track->GetPosition().x() / CLHEP::cm,
                                                    track->GetPosition().y() / CLHEP::cm,
                                                    track->GetPosition().z() / CLHEP::cm,
@@ -73,7 +72,12 @@ public:
   bool crossedBoundary() const { return crossedBoundary_; }
   const math::XYZTLorentzVectorF &getPositionAtBoundary() const { return positionAtBoundary_; }
   const math::XYZTLorentzVectorF &getMomentumAtBoundary() const { return momentumAtBoundary_; }
-  int getIDAtBoundary() const { return idAtBoundary_; }
+  bool startedInFineVolume() const { return startedInFineVolume_; }
+  void setStartedInFineVolume(bool flag = true) {
+    startedInFineVolume_ = flag;
+    startedInFineVolumeIsSet_ = true;
+  }
+  bool startedInFineVolumeIsSet() { return startedInFineVolumeIsSet_; }
 
   // Generator information
   int genParticlePID() const { return genParticlePID_; }
@@ -104,9 +108,10 @@ private:
   int idLastVolume_;
   bool caloIDChecked_;
   bool crossedBoundary_;
-  bool idAtBoundary_;
   math::XYZTLorentzVectorF positionAtBoundary_;
   math::XYZTLorentzVectorF momentumAtBoundary_;
+  bool startedInFineVolume_;
+  bool startedInFineVolumeIsSet_;
 
   int genParticlePID_, caloSurfaceParticlePID_;
   double genParticleP_, caloSurfaceParticleP_;
@@ -128,6 +133,8 @@ private:
         idLastVolume_(-1),
         caloIDChecked_(false),
         crossedBoundary_(false),
+        startedInFineVolume_(false),
+        startedInFineVolumeIsSet_(false),
         genParticlePID_(-1),
         caloSurfaceParticlePID_(0),
         genParticleP_(0),


### PR DESCRIPTION
#### PR description:

No longer counts reentries into the calorimeter as boundary crossings. The boundary-crossing position and momentum for tracks that started in the calorimeter or entered before are no longer (over)written.

#### PR validation:

Verified with debug statements in the code.