### PR TITLE
Fix DBG IBs build erros

### DIFF
--- a/SimG4CMS/Forward/src/CastorSD.cc
+++ b/SimG4CMS/Forward/src/CastorSD.cc
@@ -252,6 +252,9 @@ double CastorSD::getEnergyDeposit(const G4Step* aStep) {
         }
       }
     }
+#ifdef EDM_ML_DEBUG
+    edm::LogVerbatim("ForwardSim") << "variant" << variant;
+#endif
 
     // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 


### PR DESCRIPTION
https://github.com/cms-sw/cmssw/pull/34507 caused a build error for DBG IBs. This PR proposed to print the un-used `variant` variable.

tested locally and it builds in DBG IB dev area