### PR TITLE
[DQM] esConsumes migration for Validation package leftovers

### DIFF
--- a/CommonTools/RecoAlgos/interface/CosmicTrackingParticleSelector.h
+++ b/CommonTools/RecoAlgos/interface/CosmicTrackingParticleSelector.h
@@ -71,9 +71,8 @@ public:
         chargedOnly_(cfg.getParameter<bool>("chargedOnly")),
         pdgId_(cfg.getParameter<std::vector<int> >("pdgId")),
         beamSpotToken_(iC.consumes<reco::BeamSpot>(edm::InputTag("offlineBeamSpot"))),
-        trackerDigiGeomToken_(iC.esConsumes<TrackerGeometry, TrackerDigiGeometryRecord>()),
-        globalTrackingGeomToken_(iC.esConsumes<GlobalTrackingGeometry, GlobalTrackingGeometryRecord>()),
-        theMFToken_(iC.esConsumes<MagneticField, IdealMagneticFieldRecord>()) {}
+        globalTrackingGeomToken_(iC.esConsumes()),
+        theMFToken_(iC.esConsumes()) {}
 
   void select(const edm::Handle<collection>& c, const edm::Event& event, const edm::EventSetup& setup) {
     selected_.clear();
@@ -106,10 +105,7 @@ public:
     //if (tpr->pdgId()==pdgId_[it]) testId = true;
     //}
 
-    edm::ESHandle<TrackerGeometry> tracker = iSetup.getHandle(trackerDigiGeomToken_);
     edm::ESHandle<GlobalTrackingGeometry> theGeometry = iSetup.getHandle(globalTrackingGeomToken_);
-
-    edm::ESHandle<MagneticField> theMF = iSetup.getHandle(theMFToken_);
 
     GlobalVector finalGV(0, 0, 0);
     GlobalPoint finalGP(0, 0, 0);
@@ -180,7 +176,7 @@ public:
     if (!found)
       return false;
     else {
-      FreeTrajectoryState ftsAtProduction(finalGP, finalGV, TrackCharge(tpr->charge()), theMF.product());
+      FreeTrajectoryState ftsAtProduction(finalGP, finalGV, TrackCharge(tpr->charge()), &iSetup.getData(theMFToken_));
       TSCBLBuilderNoMaterial tscblBuilder;
       //as in TrackProducerAlgorithm
       TrajectoryStateClosestToBeamLine tsAtClosestApproach = tscblBuilder(ftsAtProduction, *bs);
@@ -217,7 +213,6 @@ private:
   std::vector<int> pdgId_;
   container selected_;
   edm::EDGetTokenT<reco::BeamSpot> beamSpotToken_;
-  edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> trackerDigiGeomToken_;
   edm::ESGetToken<GlobalTrackingGeometry, GlobalTrackingGeometryRecord> globalTrackingGeomToken_;
   edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> theMFToken_;
 

--- a/CommonTools/RecoAlgos/interface/CosmicTrackingParticleSelector.h
+++ b/CommonTools/RecoAlgos/interface/CosmicTrackingParticleSelector.h
@@ -70,7 +70,10 @@ public:
         minHit_(cfg.getParameter<int>("minHit")),
         chargedOnly_(cfg.getParameter<bool>("chargedOnly")),
         pdgId_(cfg.getParameter<std::vector<int> >("pdgId")),
-        beamSpotToken_(iC.consumes<reco::BeamSpot>(edm::InputTag("offlineBeamSpot"))) {}
+        beamSpotToken_(iC.consumes<reco::BeamSpot>(edm::InputTag("offlineBeamSpot"))),
+        trackerDigiGeomToken_(iC.esConsumes<TrackerGeometry, TrackerDigiGeometryRecord>()),
+        globalTrackingGeomToken_(iC.esConsumes<GlobalTrackingGeometry, GlobalTrackingGeometryRecord>()),
+        theMFToken_(iC.esConsumes<MagneticField, IdealMagneticFieldRecord>()){}
 
   void select(const edm::Handle<collection>& c, const edm::Event& event, const edm::EventSetup& setup) {
     selected_.clear();
@@ -103,13 +106,10 @@ public:
     //if (tpr->pdgId()==pdgId_[it]) testId = true;
     //}
 
-    edm::ESHandle<TrackerGeometry> tracker;
-    iSetup.get<TrackerDigiGeometryRecord>().get(tracker);
-    edm::ESHandle<GlobalTrackingGeometry> theGeometry;
-    iSetup.get<GlobalTrackingGeometryRecord>().get(theGeometry);
+    edm::ESHandle<TrackerGeometry> tracker = iSetup.getHandle(trackerDigiGeomToken_);
+    edm::ESHandle<GlobalTrackingGeometry> theGeometry = iSetup.getHandle(globalTrackingGeomToken_);
 
-    edm::ESHandle<MagneticField> theMF;
-    iSetup.get<IdealMagneticFieldRecord>().get(theMF);
+    edm::ESHandle<MagneticField> theMF = iSetup.getHandle(theMFToken_);
 
     GlobalVector finalGV(0, 0, 0);
     GlobalPoint finalGP(0, 0, 0);
@@ -217,6 +217,9 @@ private:
   std::vector<int> pdgId_;
   container selected_;
   edm::EDGetTokenT<reco::BeamSpot> beamSpotToken_;
+  edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> trackerDigiGeomToken_;
+  edm::ESGetToken<GlobalTrackingGeometry, GlobalTrackingGeometryRecord> globalTrackingGeomToken_;
+  edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> theMFToken_;
 
   mutable edm::Handle<SimHitTPAssociationProducer::SimHitTPAssociationList> simHitsTPAssoc;
 };

--- a/CommonTools/RecoAlgos/interface/CosmicTrackingParticleSelector.h
+++ b/CommonTools/RecoAlgos/interface/CosmicTrackingParticleSelector.h
@@ -73,7 +73,7 @@ public:
         beamSpotToken_(iC.consumes<reco::BeamSpot>(edm::InputTag("offlineBeamSpot"))),
         trackerDigiGeomToken_(iC.esConsumes<TrackerGeometry, TrackerDigiGeometryRecord>()),
         globalTrackingGeomToken_(iC.esConsumes<GlobalTrackingGeometry, GlobalTrackingGeometryRecord>()),
-        theMFToken_(iC.esConsumes<MagneticField, IdealMagneticFieldRecord>()){}
+        theMFToken_(iC.esConsumes<MagneticField, IdealMagneticFieldRecord>()) {}
 
   void select(const edm::Handle<collection>& c, const edm::Event& event, const edm::EventSetup& setup) {
     selected_.clear();

--- a/DQM/Physics/interface/TopDQMHelpers.h
+++ b/DQM/Physics/interface/TopDQMHelpers.h
@@ -468,7 +468,7 @@ bool SelectionStep<Object>::select(const edm::Event& event, const edm::EventSetu
 
   // load jet corrector if configured such
   const JetCorrector* corrector = nullptr;
-  if (!jetCorrector_.isInitialized()) {
+  if (!jetCorrector_.isInitialized() && jetCorrector_.hasValidIndex()) {
     // check whether a jet correcto is in the event setup or not
     if (setup.find(edm::eventsetup::EventSetupRecordKey::makeKey<JetCorrectionsRecord>())) {
       corrector = &setup.getData(jetCorrector_);

--- a/DQM/Physics/interface/TopDQMHelpers.h
+++ b/DQM/Physics/interface/TopDQMHelpers.h
@@ -269,7 +269,7 @@ private:
   /// https://twiki.cern.ch/twiki/bin/view/CMS/SimpleCutBasedEleID
   double eidCutValue_;
   /// jet corrector as extra selection type
-  std::string jetCorrector_;
+  edm::EDGetTokenT<JetCorrector> jetCorrector_;
   /// choice for b-tag as extra selection type
   edm::EDGetTokenT<reco::JetTagCollection> btagLabel_;
   /// choice of b-tag working point as extra selection type
@@ -301,7 +301,7 @@ SelectionStep<Object>::SelectionStep(const edm::ParameterSet& cfg, edm::Consumes
     eidCutValue_ = elecId.getParameter<double>("cutValue");
   }
   if (cfg.exists("jetCorrector")) {
-    jetCorrector_ = cfg.getParameter<std::string>("jetCorrector");
+    jetCorrector_ = iC.consumes<JetCorrector>(cfg.getParameter<std::string>("jetCorrector"));
   }
   if (cfg.existsAs<edm::ParameterSet>("jetBTagger")) {
     edm::ParameterSet jetBTagger = cfg.getParameter<edm::ParameterSet>("jetBTagger");
@@ -468,10 +468,13 @@ bool SelectionStep<Object>::select(const edm::Event& event, const edm::EventSetu
 
   // load jet corrector if configured such
   const JetCorrector* corrector = nullptr;
-  if (!jetCorrector_.empty()) {
+  edm::Handle<JetCorrector> correctorH;
+  if (!jetCorrector_.isUninitialized()) {
     // check whether a jet correcto is in the event setup or not
     if (setup.find(edm::eventsetup::EventSetupRecordKey::makeKey<JetCorrectionsRecord>())) {
-      corrector = JetCorrector::getJetCorrector(jetCorrector_, setup);
+      //corrector = setup.getData(jetCorrector_);
+      event.getByToken(jetCorrector_, correctorH);
+      corrector = correctorH.product();
     } else {
       edm::LogVerbatim("TopDQMHelpers") << "\n"
                                         << "---------------------------------------------------------------\n"

--- a/DQM/Physics/src/SingleTopTChannelLeptonDQM.cc
+++ b/DQM/Physics/src/SingleTopTChannelLeptonDQM.cc
@@ -512,12 +512,12 @@ namespace SingleTopTChannelLepton {
     // load jet
     // corrector if configured such
     //  const JetCorrector* corrector = 0;
-    //  if (!jetCorrector_.empty()) {
+    //  if (!jetCorrector_.isInitialized()) {
 
     // check whether a jet correcto is in the event setup or not
     //    if (setup.find(edm::eventsetup::EventSetupRecordKey::makeKey<
     //            JetCorrectionsRecord>())) {
-    //      corrector = JetCorrector::getJetCorrector(jetCorrector_, setup);
+    //      corrector = &setup.getData(jetCorrector_);;
     //    } else {
     //      edm::LogVerbatim("SingleTopTChannelLeptonDQM")
     //          << "\n"

--- a/DQM/Physics/src/SingleTopTChannelLeptonDQM.cc
+++ b/DQM/Physics/src/SingleTopTChannelLeptonDQM.cc
@@ -505,39 +505,39 @@ namespace SingleTopTChannelLepton {
         return;
     }
 
-    edm::Handle<reco::JetCorrector> corrector;
+    /*edm::Handle<reco::JetCorrector> corrector;
     event.getByToken(mJetCorrector, corrector);
     if (!event.getByToken(mJetCorrector, corrector))
-      return;
+      return;*/
     // load jet
     // corrector if configured such
-    //  const JetCorrector* corrector = 0;
-    //  if (!jetCorrector_.isInitialized()) {
+    const JetCorrector* corrector = nullptr;
+    if (!jetCorrector_.isInitialized()) {
 
     // check whether a jet correcto is in the event setup or not
-    //    if (setup.find(edm::eventsetup::EventSetupRecordKey::makeKey<
-    //            JetCorrectionsRecord>())) {
-    //      corrector = &setup.getData(jetCorrector_);;
-    //    } else {
-    //      edm::LogVerbatim("SingleTopTChannelLeptonDQM")
-    //          << "\n"
-    //          << "-----------------------------------------------------------------"
-    //             "-------------------- \n"
-    //          << " No JetCorrectionsRecord available from EventSetup:\n"
-    //          << "  - Jets will not be corrected.\n"
-    //          << "  - If you want to change this add the following lines to your "
-    //             "cfg file:\n"
-    //          << "\n"
-    //          << "  ## load jet corrections\n"
-    //          << "  "
-    //             "process.load(\"JetMETCorrections.Configuration."
-    //             "JetCorrectionServicesAllAlgos_cff\") \n"
-    //          << "  process.prefer(\"ak5CaloL2L3\")\n"
-    //          << "\n"
-    //          << "-----------------------------------------------------------------"
-    //             "-------------------- \n";
-    //    }
-    //}
+        if (setup.find(edm::eventsetup::EventSetupRecordKey::makeKey<
+                JetCorrectionsRecord>())) {
+          corrector = &setup.getData(jetCorrector_);;
+        } else {
+          edm::LogVerbatim("SingleTopTChannelLeptonDQM")
+              << "\n"
+              << "-----------------------------------------------------------------"
+                 "-------------------- \n"
+              << " No JetCorrectionsRecord available from EventSetup:\n"
+              << "  - Jets will not be corrected.\n"
+              << "  - If you want to change this add the following lines to your "
+                 "cfg file:\n"
+              << "\n"
+              << "  ## load jet corrections\n"
+              << "  "
+                 "process.load(\"JetMETCorrections.Configuration."
+                 "JetCorrectionServicesAllAlgos_cff\") \n"
+              << "  process.prefer(\"ak5CaloL2L3\")\n"
+              << "\n"
+              << "-----------------------------------------------------------------"
+                 "-------------------- \n";
+        }
+    }
     // loop jet collection
     std::vector<reco::Jet> correctedJets;
     std::vector<double> JetTagValues;

--- a/DQM/Physics/src/SingleTopTChannelLeptonDQM.cc
+++ b/DQM/Physics/src/SingleTopTChannelLeptonDQM.cc
@@ -513,30 +513,29 @@ namespace SingleTopTChannelLepton {
     // corrector if configured such
     const JetCorrector* corrector = nullptr;
     if (!jetCorrector_.isInitialized()) {
-
-    // check whether a jet correcto is in the event setup or not
-        if (setup.find(edm::eventsetup::EventSetupRecordKey::makeKey<
-                JetCorrectionsRecord>())) {
-          corrector = &setup.getData(jetCorrector_);;
-        } else {
-          edm::LogVerbatim("SingleTopTChannelLeptonDQM")
-              << "\n"
-              << "-----------------------------------------------------------------"
-                 "-------------------- \n"
-              << " No JetCorrectionsRecord available from EventSetup:\n"
-              << "  - Jets will not be corrected.\n"
-              << "  - If you want to change this add the following lines to your "
-                 "cfg file:\n"
-              << "\n"
-              << "  ## load jet corrections\n"
-              << "  "
-                 "process.load(\"JetMETCorrections.Configuration."
-                 "JetCorrectionServicesAllAlgos_cff\") \n"
-              << "  process.prefer(\"ak5CaloL2L3\")\n"
-              << "\n"
-              << "-----------------------------------------------------------------"
-                 "-------------------- \n";
-        }
+      // check whether a jet correcto is in the event setup or not
+      if (setup.find(edm::eventsetup::EventSetupRecordKey::makeKey<JetCorrectionsRecord>())) {
+        corrector = &setup.getData(jetCorrector_);
+        ;
+      } else {
+        edm::LogVerbatim("SingleTopTChannelLeptonDQM")
+            << "\n"
+            << "-----------------------------------------------------------------"
+               "-------------------- \n"
+            << " No JetCorrectionsRecord available from EventSetup:\n"
+            << "  - Jets will not be corrected.\n"
+            << "  - If you want to change this add the following lines to your "
+               "cfg file:\n"
+            << "\n"
+            << "  ## load jet corrections\n"
+            << "  "
+               "process.load(\"JetMETCorrections.Configuration."
+               "JetCorrectionServicesAllAlgos_cff\") \n"
+            << "  process.prefer(\"ak5CaloL2L3\")\n"
+            << "\n"
+            << "-----------------------------------------------------------------"
+               "-------------------- \n";
+      }
     }
     // loop jet collection
     std::vector<reco::Jet> correctedJets;

--- a/DQM/Physics/src/SingleTopTChannelLeptonDQM.h
+++ b/DQM/Physics/src/SingleTopTChannelLeptonDQM.h
@@ -165,7 +165,7 @@ namespace SingleTopTChannelLepton {
     /// extra selection on muons
     std::unique_ptr<StringCutObjectSelector<reco::PFCandidate> > muonSelect_;
     /// jetCorrector
-    std::string jetCorrector_;
+    edm::ESGetToken<JetCorrector, JetCorrectionsRecord> jetCorrector_;
     /// jetID as an extra selection type
     edm::EDGetTokenT<reco::JetIDValueMap> jetIDLabel_;
 

--- a/DQM/Physics/src/SingleTopTChannelLeptonDQM.h
+++ b/DQM/Physics/src/SingleTopTChannelLeptonDQM.h
@@ -133,8 +133,6 @@ namespace SingleTopTChannelLepton {
     /// electronId label
     //    edm::InputTag electronId_;
     edm::EDGetTokenT<edm::ValueMap<float> > electronId_;
-    // Jet corrector
-    edm::EDGetTokenT<reco::JetCorrector> mJetCorrector;
     /// electronId pattern we expect the following pattern:
     ///  0: fails
     ///  1: passes electron ID only

--- a/DQM/Physics/src/SingleTopTChannelLeptonDQM_miniAOD.cc
+++ b/DQM/Physics/src/SingleTopTChannelLeptonDQM_miniAOD.cc
@@ -115,7 +115,7 @@ namespace SingleTopTChannelLepton_miniAOD {
       // jetCorrector is optional; in case it's not found
       // the InputTag will remain empty
       if (jetExtras.existsAs<std::string>("jetCorrector")) {
-        jetCorrector_ = jetExtras.getParameter<std::string>("jetCorrector");
+        jetCorrector_ = iC.esConsumes(edm::ESInputTag("", jetExtras.getParameter<std::string>("jetCorrector")));
       }
       // read jetID information if it exists
       if (jetExtras.existsAs<edm::ParameterSet>("jetID")) {

--- a/DQM/Physics/src/SingleTopTChannelLeptonDQM_miniAOD.h
+++ b/DQM/Physics/src/SingleTopTChannelLeptonDQM_miniAOD.h
@@ -117,7 +117,7 @@ namespace SingleTopTChannelLepton_miniAOD {
     std::unique_ptr<StringCutObjectSelector<pat::Muon> > muonSelect_;
 
     /// jetCorrector
-    std::string jetCorrector_;
+    edm::ESGetToken<JetCorrector, JetCorrectionsRecord> jetCorrector_;
     /// jetID as an extra selection type
     edm::EDGetTokenT<reco::JetIDValueMap> jetIDLabel_;
     /// extra jetID selection on calo jets

--- a/DQM/Physics/src/TopDiLeptonOfflineDQM.cc
+++ b/DQM/Physics/src/TopDiLeptonOfflineDQM.cc
@@ -82,7 +82,7 @@ namespace TopDiLeptonOffline {
       // jetCorrector is optional; in case it's not found
       // the InputTag will remain empty
       if (jetExtras.existsAs<std::string>("jetCorrector")) {
-        jetCorrector_ = jetExtras.getParameter<std::string>("jetCorrector");
+        jetCorrector_ = iC.esConsumes(edm::ESInputTag("", jetExtras.getParameter<std::string>("jetCorrector")));
       }
       // read jetID information if it exists
       if (jetExtras.existsAs<edm::ParameterSet>("jetID")) {
@@ -415,10 +415,10 @@ namespace TopDiLeptonOffline {
   */
 
     const JetCorrector* corrector = nullptr;
-    if (!jetCorrector_.empty()) {
+    if (!jetCorrector_.isInitialized()) {
       // check whether a jet correcto is in the event setup or not
       if (setup.find(edm::eventsetup::EventSetupRecordKey::makeKey<JetCorrectionsRecord>())) {
-        corrector = JetCorrector::getJetCorrector(jetCorrector_, setup);
+        corrector = &setup.getData(jetCorrector_);
       } else {
         edm::LogVerbatim("TopDiLeptonOfflineDQM") << "\n"
                                                   << "-----------------------------------------------------------------"

--- a/DQM/Physics/src/TopDiLeptonOfflineDQM.cc
+++ b/DQM/Physics/src/TopDiLeptonOfflineDQM.cc
@@ -415,7 +415,7 @@ namespace TopDiLeptonOffline {
   */
 
     const JetCorrector* corrector = nullptr;
-    if (!jetCorrector_.isInitialized()) {
+    if (!jetCorrector_.isInitialized() && jetCorrector_.hasValidIndex()) {
       // check whether a jet correcto is in the event setup or not
       if (setup.find(edm::eventsetup::EventSetupRecordKey::makeKey<JetCorrectionsRecord>())) {
         corrector = &setup.getData(jetCorrector_);

--- a/DQM/Physics/src/TopDiLeptonOfflineDQM.h
+++ b/DQM/Physics/src/TopDiLeptonOfflineDQM.h
@@ -159,7 +159,7 @@ namespace TopDiLeptonOffline {
     std::unique_ptr<StringCutObjectSelector<reco::PFCandidate, true> > muonSelect_;
 
     /// jetCorrector
-    std::string jetCorrector_;
+    edm::ESGetToken<JetCorrector, JetCorrectionsRecord> jetCorrector_;
     /// jetID as an extra selection type
     edm::EDGetTokenT<reco::JetIDValueMap> jetIDLabel_;
     /// extra jetID selection on calo jets

--- a/DQM/Physics/src/TopSingleLeptonDQM.cc
+++ b/DQM/Physics/src/TopSingleLeptonDQM.cc
@@ -101,8 +101,8 @@ namespace TopSingleLepton {
       edm::ParameterSet jetExtras = cfg.getParameter<edm::ParameterSet>("jetExtras");
       // jetCorrector is optional; in case it's not found
       // the InputTag will remain empty
-      if (jetExtras.existsAs<edm::InputTag>("jetCorrector")) {
-        mJetCorrector = iC.consumes<reco::JetCorrector>(jetExtras.getParameter<edm::InputTag>("jetCorrector"));
+      if (jetExtras.existsAs<std::string>("jetCorrector")) {
+         jetCorrector_ = iC.esConsumes(edm::ESInputTag("", jetExtras.getParameter<std::string>("jetCorrector")));
       }
       // read jetID information if it exists
       if (jetExtras.existsAs<edm::ParameterSet>("jetID")) {
@@ -516,6 +516,39 @@ namespace TopSingleLepton {
   ------------------------------------------------------------
   */
 
+
+    const JetCorrector* corrector = nullptr;
+    if (!jetCorrector_.isInitialized() && jetCorrector_.hasValidIndex()) {
+    // check whether a jet correcto is in the event setup or not
+          if (setup.find(edm::eventsetup::EventSetupRecordKey::makeKey<JetCorrectionsRecord>())) {
+        corrector = &setup.getData(jetCorrector_);
+      } else {
+        edm::LogVerbatim("TopDiLeptonOfflineDQM") << "\n"
+                                                  << "-----------------------------------------------------------------"
+                                                     "-------------------- \n"
+                                                  << " No JetCorrectionsRecord available from EventSetup:              "
+                                                     "                     \n"
+                                                  << "  - Jets will not be corrected.                                  "
+                                                     "                     \n"
+                                                  << "  - If you want to change this add the following lines to your "
+                                                     "cfg file:              \n"
+                                                  << "                                                                 "
+                                                     "                     \n"
+                                                  << "  ## load jet corrections                                        "
+                                                     "                     \n"
+                                                  << "  "
+                                                     "process.load(\"JetMETCorrections.Configuration."
+                                                     "JetCorrectionServicesAllAlgos_cff\") \n"
+                                                  << "  process.prefer(\"ak5CaloL2L3\")                                "
+                                                     "                     \n"
+                                                  << "                                                                 "
+                                                     "                     \n"
+                                                  << "-----------------------------------------------------------------"
+                                                     "-------------------- \n";
+      }
+    }
+
+
     // check availability of the btaggers
     edm::Handle<reco::JetTagCollection> btagEff, btagPur, btagVtx, btagCSV;
     if (includeBTag_) {
@@ -523,10 +556,6 @@ namespace TopSingleLepton {
         return;
     }
 
-    edm::Handle<reco::JetCorrector> corrector;
-    event.getByToken(mJetCorrector, corrector);
-    if (!event.getByToken(mJetCorrector, corrector))
-      return;
 
     // loop jet collection
     std::vector<reco::Jet> correctedJets;
@@ -545,7 +574,7 @@ namespace TopSingleLepton {
         reco::PFJet sel = dynamic_cast<const reco::PFJet&>(*jet);
         if ((*jetlooseSelection_)(sel))
           isLoose = true;
-        sel.scaleEnergy(corrector->correction(*jet));
+        sel.scaleEnergy(corrector ? corrector->correction(*jet) : 1.);
         if (!(*jetSelection_)(sel))
           continue;
       }
@@ -554,7 +583,7 @@ namespace TopSingleLepton {
       reco::Jet monitorJet = *jet;
 
       ++mult;  // determine jet (no Id) multiplicity
-      monitorJet.scaleEnergy(corrector->correction(*jet));
+      monitorJet.scaleEnergy(corrector ? corrector->correction(*jet) : 1.);
 
       if (isLoose) {  //Loose Id
         unsigned int idx = jet - jets->begin();

--- a/DQM/Physics/src/TopSingleLeptonDQM.cc
+++ b/DQM/Physics/src/TopSingleLeptonDQM.cc
@@ -102,7 +102,7 @@ namespace TopSingleLepton {
       // jetCorrector is optional; in case it's not found
       // the InputTag will remain empty
       if (jetExtras.existsAs<std::string>("jetCorrector")) {
-         jetCorrector_ = iC.esConsumes(edm::ESInputTag("", jetExtras.getParameter<std::string>("jetCorrector")));
+        jetCorrector_ = iC.esConsumes(edm::ESInputTag("", jetExtras.getParameter<std::string>("jetCorrector")));
       }
       // read jetID information if it exists
       if (jetExtras.existsAs<edm::ParameterSet>("jetID")) {
@@ -516,11 +516,10 @@ namespace TopSingleLepton {
   ------------------------------------------------------------
   */
 
-
     const JetCorrector* corrector = nullptr;
     if (!jetCorrector_.isInitialized() && jetCorrector_.hasValidIndex()) {
-    // check whether a jet correcto is in the event setup or not
-          if (setup.find(edm::eventsetup::EventSetupRecordKey::makeKey<JetCorrectionsRecord>())) {
+      // check whether a jet correcto is in the event setup or not
+      if (setup.find(edm::eventsetup::EventSetupRecordKey::makeKey<JetCorrectionsRecord>())) {
         corrector = &setup.getData(jetCorrector_);
       } else {
         edm::LogVerbatim("TopDiLeptonOfflineDQM") << "\n"
@@ -548,14 +547,12 @@ namespace TopSingleLepton {
       }
     }
 
-
     // check availability of the btaggers
     edm::Handle<reco::JetTagCollection> btagEff, btagPur, btagVtx, btagCSV;
     if (includeBTag_) {
       if (!event.getByToken(btagCSV_, btagCSV))
         return;
     }
-
 
     // loop jet collection
     std::vector<reco::Jet> correctedJets;

--- a/DQM/Physics/src/TopSingleLeptonDQM.h
+++ b/DQM/Physics/src/TopSingleLeptonDQM.h
@@ -155,7 +155,7 @@ namespace TopSingleLepton {
     std::unique_ptr<StringCutObjectSelector<reco::PFCandidate> > muonSelect_;
 
     /// jetCorrector
-    std::string jetCorrector_;
+    edm::ESGetToken<JetCorrector, JetCorrectionsRecord> jetCorrector_;
 
     /// jetID as an extra selection type
     edm::EDGetTokenT<reco::JetIDValueMap> jetIDLabel_;

--- a/DQM/Physics/src/TopSingleLeptonDQM_miniAOD.cc
+++ b/DQM/Physics/src/TopSingleLeptonDQM_miniAOD.cc
@@ -115,7 +115,7 @@ namespace TopSingleLepton_miniAOD {
       // jetCorrector is optional; in case it's not found
       // the InputTag will remain empty
       if (jetExtras.existsAs<std::string>("jetCorrector")) {
-        jetCorrector_ = jetExtras.getParameter<std::string>("jetCorrector");
+        jetCorrector_ = iC.esConsumes(edm::ESInputTag("", jetExtras.getParameter<std::string>("jetCorrector")));
       }
       // read jetID information if it exists
       if (jetExtras.existsAs<edm::ParameterSet>("jetID")) {

--- a/DQM/Physics/src/TopSingleLeptonDQM_miniAOD.h
+++ b/DQM/Physics/src/TopSingleLeptonDQM_miniAOD.h
@@ -117,7 +117,7 @@ namespace TopSingleLepton_miniAOD {
     std::unique_ptr<StringCutObjectSelector<pat::Muon> > muonSelect_;
 
     /// jetCorrector
-    std::string jetCorrector_;
+    edm::ESGetToken<JetCorrector, JetCorrectionsRecord> jetCorrector_;
     /// jetID as an extra selection type
     edm::EDGetTokenT<reco::JetIDValueMap> jetIDLabel_;
     /// extra jetID selection on calo jets

--- a/SimTracker/TrackHistory/interface/TrackClassifier.h
+++ b/SimTracker/TrackHistory/interface/TrackClassifier.h
@@ -77,7 +77,7 @@ private:
 
   edm::ESHandle<TransientTrackBuilder> transientTrackBuilder_;
   edm::ESGetToken<TransientTrackBuilder, TransientTrackRecord> transientTrackBuilderToken_;
-  
+
   edm::Handle<reco::BeamSpot> beamSpot_;
 
   const TrackerTopology *tTopo_;

--- a/SimTracker/TrackHistory/interface/TrackClassifier.h
+++ b/SimTracker/TrackHistory/interface/TrackClassifier.h
@@ -69,16 +69,19 @@ private:
   const G4toCMSLegacyProcTypeMap g4toCMSProcMap_;
 
   edm::ESHandle<MagneticField> magneticField_;
+  edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> magneticFieldToken_;
 
   edm::Handle<edm::HepMCProduct> mcInformation_;
 
   edm::ESHandle<ParticleDataTable> particleDataTable_;
 
   edm::ESHandle<TransientTrackBuilder> transientTrackBuilder_;
-
+  edm::ESGetToken<TransientTrackBuilder, TransientTrackRecord> transientTrackBuilderToken_;
+  
   edm::Handle<reco::BeamSpot> beamSpot_;
 
   const TrackerTopology *tTopo_;
+  edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> tTopoHandToken_;
 
   //! Classify all the tracks by their association and reconstruction
   //! information

--- a/SimTracker/TrackHistory/src/TrackClassifier.cc
+++ b/SimTracker/TrackHistory/src/TrackClassifier.cc
@@ -17,7 +17,10 @@ TrackClassifier::TrackClassifier(edm::ParameterSet const &config, edm::ConsumesC
       hepMCLabel_(config.getUntrackedParameter<edm::InputTag>("hepMC")),
       beamSpotLabel_(config.getUntrackedParameter<edm::InputTag>("beamSpot")),
       tracer_(config, std::move(collector)),
-      quality_(config, collector) {
+      quality_(config, collector),
+      magneticFieldToken_(collector.esConsumes<MagneticField, IdealMagneticFieldRecord>()),
+      transientTrackBuilderToken_(collector.esConsumes<TransientTrackBuilder, TransientTrackRecord>()), 
+      tTopoHandToken_(collector.esConsumes<TrackerTopology,TrackerTopologyRcd>()) {
   collector.consumes<edm::HepMCProduct>(hepMCLabel_);
   collector.consumes<reco::BeamSpot>(beamSpotLabel_);
 
@@ -52,7 +55,7 @@ void TrackClassifier::newEvent(edm::Event const &event, edm::EventSetup const &s
   event.getByLabel(hepMCLabel_, mcInformation_);
 
   // Magnetic field
-  setup.get<IdealMagneticFieldRecord>().get(magneticField_);
+  magneticField_ = setup.getHandle(magneticFieldToken_);
 
   // Get the partivle data table
   setup.getData(particleDataTable_);
@@ -61,14 +64,13 @@ void TrackClassifier::newEvent(edm::Event const &event, edm::EventSetup const &s
   event.getByLabel(beamSpotLabel_, beamSpot_);
 
   // Transient track builder
-  setup.get<TransientTrackRecord>().get("TransientTrackBuilder", transientTrackBuilder_);
+  transientTrackBuilder_ = setup.getHandle(transientTrackBuilderToken_);
 
   // Create the list of primary vertices associated to the event
   genPrimaryVertices();
 
   // Retrieve tracker topology from geometry
-  edm::ESHandle<TrackerTopology> tTopoHand;
-  setup.get<TrackerTopologyRcd>().get(tTopoHand);
+  edm::ESHandle<TrackerTopology> tTopoHand = setup.getHandle(tTopoHandToken_);
   tTopo_ = tTopoHand.product();
 }
 

--- a/SimTracker/TrackHistory/src/TrackClassifier.cc
+++ b/SimTracker/TrackHistory/src/TrackClassifier.cc
@@ -70,8 +70,7 @@ void TrackClassifier::newEvent(edm::Event const &event, edm::EventSetup const &s
   genPrimaryVertices();
 
   // Retrieve tracker topology from geometry
-  edm::ESHandle<TrackerTopology> tTopoHand = setup.getHandle(tTopoHandToken_);
-  tTopo_ = tTopoHand.product();
+  tTopo_ = &setup.getData(tTopoHandToken_);
 }
 
 TrackClassifier const &TrackClassifier::evaluate(reco::TrackBaseRef const &track) {

--- a/SimTracker/TrackHistory/src/TrackClassifier.cc
+++ b/SimTracker/TrackHistory/src/TrackClassifier.cc
@@ -19,8 +19,8 @@ TrackClassifier::TrackClassifier(edm::ParameterSet const &config, edm::ConsumesC
       tracer_(config, std::move(collector)),
       quality_(config, collector),
       magneticFieldToken_(collector.esConsumes<MagneticField, IdealMagneticFieldRecord>()),
-      transientTrackBuilderToken_(collector.esConsumes<TransientTrackBuilder, TransientTrackRecord>()), 
-      tTopoHandToken_(collector.esConsumes<TrackerTopology,TrackerTopologyRcd>()) {
+      transientTrackBuilderToken_(collector.esConsumes<TransientTrackBuilder, TransientTrackRecord>()),
+      tTopoHandToken_(collector.esConsumes<TrackerTopology, TrackerTopologyRcd>()) {
   collector.consumes<edm::HepMCProduct>(hepMCLabel_);
   collector.consumes<reco::BeamSpot>(beamSpotLabel_);
 

--- a/Validation/RecoMuon/plugins/MuonTrackValidator.h
+++ b/Validation/RecoMuon/plugins/MuonTrackValidator.h
@@ -66,7 +66,7 @@ public:
     edm::LogVerbatim("MuonTrackValidator") << "constructing MuonTrackValidator: " << pset.dump();
 
     // Declare consumes (also for the base class)
-    bsSrc_Token = consumes<reco::BeamSpot>(bsSrc);
+//    bsSrc_Token = consumes<reco::BeamSpot>(bsSrc);
     if (label_tp_refvector)
       tp_refvector_Token = consumes<TrackingParticleRefVector>(label_tp);
     else

--- a/Validation/RecoMuon/plugins/MuonTrackValidator.h
+++ b/Validation/RecoMuon/plugins/MuonTrackValidator.h
@@ -66,7 +66,7 @@ public:
     edm::LogVerbatim("MuonTrackValidator") << "constructing MuonTrackValidator: " << pset.dump();
 
     // Declare consumes (also for the base class)
-//    bsSrc_Token = consumes<reco::BeamSpot>(bsSrc);
+    bsSrc_Token = consumes<reco::BeamSpot>(bsSrc);
     if (label_tp_refvector)
       tp_refvector_Token = consumes<TrackingParticleRefVector>(label_tp);
     else


### PR DESCRIPTION
#### PR description:
Following comment on https://github.com/cms-sw/cmssw/issues/31061#issuecomment-883816539 and tips by @makortel  (thanks a lot!!) the leftovers from Validation/*  packages in what esConsumes migration refers, are being fixed in this PR

Modules from DQM/Ecal are being migrated by ECAL DPG @abhih1 

#### PR validation:

Code compiles and tested with:
runTheMatrix.py -l limited -i all --ibeos -t 9

