### PR TITLE
Added esConsumes to helpers in L1Trigger/L1TMuon* packages

### DIFF
--- a/L1Trigger/L1TMuon/interface/GeometryTranslator.h
+++ b/L1Trigger/L1TMuon/interface/GeometryTranslator.h
@@ -19,11 +19,14 @@
 
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "DataFormats/GeometryVector/interface/GlobalPoint.h"
+#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
+#include "Geometry/Records/interface/MuonGeometryRecord.h"
 
 // Forward declarations
 namespace edm {
   class EventSetup;
-}
+  class ConsumesCollector;
+}  // namespace edm
 
 class DTGeometry;
 class CSCGeometry;
@@ -40,7 +43,7 @@ namespace L1TMuon {
 
   class GeometryTranslator {
   public:
-    GeometryTranslator();
+    GeometryTranslator(edm::ConsumesCollector);
     ~GeometryTranslator();
 
     double calculateGlobalEta(const TriggerPrimitive&) const;
@@ -67,8 +70,15 @@ namespace L1TMuon {
     edm::ESHandle<GEMGeometry> _geogem;
     edm::ESHandle<ME0Geometry> _geome0;
 
+    edm::ESGetToken<DTGeometry, MuonGeometryRecord> geodtToken_;
+    edm::ESGetToken<CSCGeometry, MuonGeometryRecord> geocscToken_;
+    edm::ESGetToken<RPCGeometry, MuonGeometryRecord> georpcToken_;
+    edm::ESGetToken<GEMGeometry, MuonGeometryRecord> geogemToken_;
+    edm::ESGetToken<ME0Geometry, MuonGeometryRecord> geome0Token_;
+
     unsigned long long _magfield_cache_id;
     edm::ESHandle<MagneticField> _magfield;
+    edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> magfieldToken_;
 
     GlobalPoint getME0SpecificPoint(const TriggerPrimitive&) const;
     double calcME0SpecificEta(const TriggerPrimitive&) const;

--- a/L1Trigger/L1TMuon/src/GeometryTranslator.cc
+++ b/L1Trigger/L1TMuon/src/GeometryTranslator.cc
@@ -1,6 +1,7 @@
 #include "L1Trigger/L1TMuon/interface/GeometryTranslator.h"
 
 #include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 
 #include "Geometry/Records/interface/MuonGeometryRecord.h"
 #include "Geometry/DTGeometry/interface/DTGeometry.h"
@@ -21,7 +22,15 @@
 
 using namespace L1TMuon;
 
-GeometryTranslator::GeometryTranslator() : _geom_cache_id(0ULL), _magfield_cache_id(0ULL) {}
+GeometryTranslator::GeometryTranslator(edm::ConsumesCollector iC)
+    : _geom_cache_id(0ULL),
+      geodtToken_(iC.esConsumes()),
+      geocscToken_(iC.esConsumes()),
+      georpcToken_(iC.esConsumes()),
+      geogemToken_(iC.esConsumes()),
+      geome0Token_(iC.esConsumes()),
+      _magfield_cache_id(0ULL),
+      magfieldToken_(iC.esConsumes()) {}
 
 GeometryTranslator::~GeometryTranslator() {}
 
@@ -123,18 +132,18 @@ void GeometryTranslator::checkAndUpdateGeometry(const edm::EventSetup& es) {
   const MuonGeometryRecord& geom = es.get<MuonGeometryRecord>();
   unsigned long long geomid = geom.cacheIdentifier();
   if (_geom_cache_id != geomid) {
-    geom.get(_geodt);
-    geom.get(_geocsc);
-    geom.get(_georpc);
-    geom.get(_geogem);
-    geom.get(_geome0);
+    _geodt = geom.getHandle(geodtToken_);
+    _geocsc = geom.getHandle(geocscToken_);
+    _georpc = geom.getHandle(georpcToken_);
+    _geogem = geom.getHandle(geogemToken_);
+    _geome0 = geom.getHandle(geome0Token_);
     _geom_cache_id = geomid;
   }
 
   const IdealMagneticFieldRecord& magfield = es.get<IdealMagneticFieldRecord>();
   unsigned long long magfieldid = magfield.cacheIdentifier();
   if (_magfield_cache_id != magfieldid) {
-    magfield.get(_magfield);
+    _magfield = magfield.getHandle(magfieldToken_);
     _magfield_cache_id = magfieldid;
   }
 }

--- a/L1Trigger/L1TMuonEndCap/interface/ConditionHelper.h
+++ b/L1Trigger/L1TMuonEndCap/interface/ConditionHelper.h
@@ -2,23 +2,26 @@
 #define L1TMuonEndCap_ConditionHelper_h
 
 #include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Utilities/interface/ESGetToken.h"
 
 // forwards
 namespace edm {
-  class Event;
   class EventSetup;
+  class ConsumesCollector;
 }  // namespace edm
 
 class L1TMuonEndCapParams;
 class L1TMuonEndCapForest;
+class L1TMuonEndCapParamsRcd;
+class L1TMuonEndCapForestRcd;
 
 // class declaration
 class ConditionHelper {
 public:
-  ConditionHelper();
+  ConditionHelper(edm::ConsumesCollector);
   ~ConditionHelper();
 
-  void checkAndUpdateConditions(const edm::Event& iEvent, const edm::EventSetup& iSetup);
+  void checkAndUpdateConditions(const edm::EventSetup& iSetup);
 
   const L1TMuonEndCapParams* getParams() const { return params_.product(); }
   const L1TMuonEndCapForest* getForest() const { return forest_.product(); }
@@ -36,7 +39,9 @@ private:
   unsigned long long params_cache_id_;
   unsigned long long forest_cache_id_;
 
+  edm::ESGetToken<L1TMuonEndCapParams, L1TMuonEndCapParamsRcd> paramsToken_;
   edm::ESHandle<L1TMuonEndCapParams> params_;
+  edm::ESGetToken<L1TMuonEndCapForest, L1TMuonEndCapForestRcd> forestToken_;
   edm::ESHandle<L1TMuonEndCapForest> forest_;
 };
 

--- a/L1Trigger/L1TMuonEndCap/interface/EMTFSetup.h
+++ b/L1Trigger/L1TMuonEndCap/interface/EMTFSetup.h
@@ -19,7 +19,7 @@
 
 class EMTFSetup {
 public:
-  explicit EMTFSetup(const edm::ParameterSet& iConfig);
+  explicit EMTFSetup(const edm::ParameterSet& iConfig, edm::ConsumesCollector iCollector);
   ~EMTFSetup();
 
   // Check and update geometry, conditions, versions, sp LUTs, and pt assignment engine

--- a/L1Trigger/L1TMuonEndCap/src/ConditionHelper.cc
+++ b/L1Trigger/L1TMuonEndCap/src/ConditionHelper.cc
@@ -1,6 +1,7 @@
 #include "L1Trigger/L1TMuonEndCap/interface/ConditionHelper.h"
 
 #include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 
 #include "CondFormats/L1TObjects/interface/L1TMuonEndCapParams.h"
 #include "CondFormats/DataRecord/interface/L1TMuonEndCapParamsRcd.h"
@@ -10,18 +11,19 @@
 
 #include "L1Trigger/L1TMuonEndCap/interface/PtAssignmentEngine.h"
 
-ConditionHelper::ConditionHelper() : params_cache_id_(0ULL), forest_cache_id_(0ULL) {}
+ConditionHelper::ConditionHelper(edm::ConsumesCollector iC)
+    : params_cache_id_(0ULL), forest_cache_id_(0ULL), paramsToken_(iC.esConsumes()), forestToken_(iC.esConsumes()) {}
 
 ConditionHelper::~ConditionHelper() {}
 
-void ConditionHelper::checkAndUpdateConditions(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
+void ConditionHelper::checkAndUpdateConditions(const edm::EventSetup& iSetup) {
   bool new_params = false;
   bool new_forests = false;
 
   // Pull configuration from the EventSetup
   auto params_setup = iSetup.get<L1TMuonEndCapParamsRcd>();
   if (params_setup.cacheIdentifier() != params_cache_id_) {
-    params_setup.get(params_);
+    params_ = params_setup.getHandle(paramsToken_);
 
     // with the magic above you can use params_->fwVersion to change emulator's behavior
     // ...
@@ -34,7 +36,7 @@ void ConditionHelper::checkAndUpdateConditions(const edm::Event& iEvent, const e
   // Pull pt LUT from the EventSetup
   auto forest_setup = iSetup.get<L1TMuonEndCapForestRcd>();
   if (forest_setup.cacheIdentifier() != forest_cache_id_) {
-    forest_setup.get(forest_);
+    forest_ = forest_setup.getHandle(forestToken_);
 
     // at this point we want to reload the newly pulled pT LUT
     // ...

--- a/L1Trigger/L1TMuonEndCap/src/EMTFSetup.cc
+++ b/L1Trigger/L1TMuonEndCap/src/EMTFSetup.cc
@@ -3,13 +3,14 @@
 #include "L1Trigger/L1TMuonEndCap/interface/EMTFSetup.h"
 
 #include "FWCore/Utilities/interface/Exception.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 
 #include "L1Trigger/L1TMuonEndCap/interface/PtAssignmentEngine2016.h"
 #include "L1Trigger/L1TMuonEndCap/interface/PtAssignmentEngine2017.h"
 
-EMTFSetup::EMTFSetup(const edm::ParameterSet& iConfig)
-    : geometry_translator_(),
-      condition_helper_(),
+EMTFSetup::EMTFSetup(const edm::ParameterSet& iConfig, edm::ConsumesCollector iCollector)
+    : geometry_translator_(iCollector),
+      condition_helper_(iCollector),
       version_control_(iConfig),
       sector_processor_lut_(),
       pt_assign_engine_(nullptr),
@@ -42,7 +43,7 @@ void EMTFSetup::reload(const edm::Event& iEvent, const edm::EventSetup& iSetup) 
   geometry_translator_.checkAndUpdateGeometry(iSetup);
 
   // Get the conditions, primarily the firmware version and the BDT forests
-  condition_helper_.checkAndUpdateConditions(iEvent, iSetup);
+  condition_helper_.checkAndUpdateConditions(iSetup);
 
   // Set version numbers
   fw_ver_ = condition_helper_.get_fw_version();

--- a/L1Trigger/L1TMuonEndCap/src/TrackFinder.cc
+++ b/L1Trigger/L1TMuonEndCap/src/TrackFinder.cc
@@ -4,7 +4,7 @@
 #include <sstream>
 
 TrackFinder::TrackFinder(const edm::ParameterSet& iConfig, edm::ConsumesCollector&& iConsumes)
-    : setup_(iConfig),
+    : setup_(iConfig, iConsumes),
       sector_processors_(),
       tokenDTPhi_(iConsumes.consumes<emtf::DTTag::digi_collection>(iConfig.getParameter<edm::InputTag>("DTPhiInput"))),
       tokenDTTheta_(

--- a/L1Trigger/L1TMuonEndCap/test/tools/MakeAngleLUT.cc
+++ b/L1Trigger/L1TMuonEndCap/test/tools/MakeAngleLUT.cc
@@ -20,6 +20,7 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 
 #include "Geometry/DTGeometry/interface/DTGeometry.h"
 #include "Geometry/CSCGeometry/interface/CSCGeometry.h"
@@ -73,7 +74,7 @@ private:
 
 // _____________________________________________________________________________
 MakeAngleLUT::MakeAngleLUT(const edm::ParameterSet& iConfig)
-    : geometry_translator_(),
+    : geometry_translator_(consumesCollector()),
       config_(iConfig),
       verbose_(iConfig.getUntrackedParameter<int>("verbosity")),
       outfile_(iConfig.getParameter<std::string>("outfile")),


### PR DESCRIPTION
#### PR description:

L1TMuonEndCapTrackProducer is used in the IBs and needed the helpers it used to make use of esConsumes.

#### PR validation:

Code compiles.