### PR TITLE
Updates on GEM onlineDQM due to the updates of DAQ dataformat

### DIFF
--- a/DQM/GEM/interface/GEMDAQStatusSource.h
+++ b/DQM/GEM/interface/GEMDAQStatusSource.h
@@ -1,0 +1,86 @@
+#ifndef DQM_GEM_INTERFACE_GEMDAQStatusSource_h
+#define DQM_GEM_INTERFACE_GEMDAQStatusSource_h
+
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/PluginManager/interface/ModuleDef.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+#include "DQMServices/Core/interface/DQMEDAnalyzer.h"
+#include "DQMServices/Core/interface/DQMStore.h"
+#include "DQMServices/Core/interface/MonitorElement.h"
+
+#include "Validation/MuonGEMHits/interface/GEMValidationUtils.h"
+
+#include "DataFormats/GEMDigi/interface/GEMDigiCollection.h"
+#include "DataFormats/GEMDigi/interface/GEMVFATStatusCollection.h"
+#include "DataFormats/GEMDigi/interface/GEMOHStatusCollection.h"
+#include "DataFormats/GEMDigi/interface/GEMAMCStatusCollection.h"
+#include "DataFormats/GEMDigi/interface/GEMAMC13StatusCollection.h"
+
+#include "DQM/GEM/interface/GEMDQMBase.h"
+
+#include <string>
+
+//----------------------------------------------------------------------------------------------------
+
+class GEMDAQStatusSource : public GEMDQMBase {
+public:
+  explicit GEMDAQStatusSource(const edm::ParameterSet &cfg);
+  ~GEMDAQStatusSource() override{};
+  static void fillDescriptions(edm::ConfigurationDescriptions &descriptions);
+
+protected:
+  void dqmBeginRun(edm::Run const &, edm::EventSetup const &) override{};
+  void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
+  void analyze(edm::Event const &e, edm::EventSetup const &eSetup) override;
+
+  void FillWithRiseErr(MonitorElement *h, Int_t nX, Int_t nY, Bool_t &bErr) {
+    h->Fill(nX, nY);
+    bErr = true;
+  };
+
+private:
+  int ProcessWithMEMap3(BookingHelper &bh, ME3IdsKey key) override;
+  int ProcessWithMEMap3WithChamber(BookingHelper &bh, ME4IdsKey key) override;
+
+  void SetLabelAMC13Status(MonitorElement *h2Status);
+  void SetLabelAMCStatus(MonitorElement *h2Status);
+  void SetLabelOHStatus(MonitorElement *h2Status);
+  void SetLabelVFATStatus(MonitorElement *h2Status);
+
+  edm::EDGetToken tagVFAT_;
+  edm::EDGetToken tagOH_;
+  edm::EDGetToken tagAMC_;
+  edm::EDGetToken tagAMC13_;
+
+  MonitorElement *h2AMC13Status_;
+  MonitorElement *h2AMCStatusPos_;
+  MonitorElement *h2AMCStatusNeg_;
+
+  MEMap3Inf mapStatusOH_;
+  MEMap3Inf mapStatusVFAT_;
+
+  MEMap3Inf mapStatusWarnVFATPerLayer_;
+  MEMap3Inf mapStatusErrVFATPerLayer_;
+  MEMap4Inf mapStatusVFATPerCh_;
+
+  MonitorElement *h2SummaryStatusWarning;
+  MonitorElement *h2SummaryStatusError;
+
+  Int_t nBXMin_, nBXMax_;
+
+  std::map<UInt_t, int> mapFEDIdToRe_;
+  Int_t nAMCSlots_;
+
+  int nBitAMC13_ = 10;
+  int nBitAMC_ = 12;
+  int nBitOH_ = 17;
+  int nBitVFAT_ = 7;
+};
+
+#endif  // DQM_GEM_INTERFACE_GEMDAQStatusSource_h

--- a/DQM/GEM/interface/GEMDQMBase.h
+++ b/DQM/GEM/interface/GEMDQMBase.h
@@ -261,6 +261,10 @@ public:
       return 0;
     };
 
+    int SetLabelForIEta(K key, Int_t nAxis, Int_t nNumBin = -1) {
+      return SetLabelForChambers(key, nAxis, nNumBin);
+    };
+
     int SetLabelForVFATs(K key, Int_t nNumEtaPartitions, Int_t nAxis, Int_t nNumBin = -1) {
       if (nNumBin <= 0) {
         if (nAxis == 1)

--- a/DQM/GEM/interface/GEMDQMBase.h
+++ b/DQM/GEM/interface/GEMDQMBase.h
@@ -280,8 +280,9 @@ public:
     int bookND(BookingHelper &bh, K key) {
       if (!bOperating_)
         return 0;
-      if ( bIsProfile_ ) {
-        mapHist[key] = bh.bookProfile2D(strName_, strTitle_, nBinsX_, dXL_, dXH_, nBinsY_, dYL_, dYH_, dZL_, dZH_, strTitleX_, strTitleY_);
+      if (bIsProfile_) {
+        mapHist[key] = bh.bookProfile2D(
+            strName_, strTitle_, nBinsX_, dXL_, dXH_, nBinsY_, dYL_, dYH_, dZL_, dZH_, strTitleX_, strTitleY_);
       } else if (nBinsY_ > 0 && nBinsX_ > 0) {
         mapHist[key] = bh.book2D(strName_, strTitle_, nBinsX_, dXL_, dXH_, nBinsY_, dYL_, dYH_, strTitleX_, strTitleY_);
         return 0;
@@ -298,7 +299,8 @@ public:
 
     dqm::impl::MonitorElement *FindHist(K key) {
       if (mapHist.find(key) == mapHist.end()) {
-        std::cout << "WARNING: Cannot find the histogram corresponing to the given key" << std::endl;  // FIXME: It's about sending a message
+        std::cout << "WARNING: Cannot find the histogram corresponing to the given key"
+                  << std::endl;  // FIXME: It's about sending a message
         return nullptr;
       }
       return mapHist[key];
@@ -324,9 +326,7 @@ public:
       return 0;
     };
 
-    int SetLabelForIEta(K key, Int_t nAxis, Int_t nNumBin = -1) {
-      return SetLabelForChambers(key, nAxis, nNumBin);
-    };
+    int SetLabelForIEta(K key, Int_t nAxis, Int_t nNumBin = -1) { return SetLabelForChambers(key, nAxis, nNumBin); };
 
     int SetLabelForVFATs(K key, Int_t nNumEtaPartitions, Int_t nAxis, Int_t nNumBin = -1) {
       if (!bOperating_)
@@ -437,7 +437,7 @@ public:
     Int_t nLayer_;             // the layer
     Int_t nNumChambers_;       // the number of chambers in the current station
     Int_t nNumEtaPartitions_;  // the number of eta partitions of the chambers
-    Int_t nMaxVFAT_;   // the number of all VFATs in each chamber (= # of VFATs in eta partition * nNumEtaPartitions_)
+    Int_t nMaxVFAT_;  // the number of all VFATs in each chamber (= # of VFATs in eta partition * nNumEtaPartitions_)
     Int_t nNumDigi_;  // the number of digis of each VFAT
   };
 
@@ -451,12 +451,12 @@ protected:
   int readRadiusEtaPartition(int nRegion, int nStation);
 
   int GenerateMEPerChamber(DQMStore::IBooker &ibooker);
-  virtual int ProcessWithMEMap2(BookingHelper &bh, ME2IdsKey key) { return 0; };             // must be overrided
-  virtual int ProcessWithMEMap2WithEta(BookingHelper &bh, ME3IdsKey key) { return 0; };             // must be overrided
-  virtual int ProcessWithMEMap2AbsReWithEta(BookingHelper &bh, ME3IdsKey key) { return 0; };             // must be overrided
-  virtual int ProcessWithMEMap3(BookingHelper &bh, ME3IdsKey key) { return 0; };             // must be overrided
-  virtual int ProcessWithMEMap4(BookingHelper &bh, ME4IdsKey key) { return 0; };             // must be overrided
-  virtual int ProcessWithMEMap3WithChamber(BookingHelper &bh, ME4IdsKey key) { return 0; };  // must be overrided
+  virtual int ProcessWithMEMap2(BookingHelper &bh, ME2IdsKey key) { return 0; };              // must be overrided
+  virtual int ProcessWithMEMap2WithEta(BookingHelper &bh, ME3IdsKey key) { return 0; };       // must be overrided
+  virtual int ProcessWithMEMap2AbsReWithEta(BookingHelper &bh, ME3IdsKey key) { return 0; };  // must be overrided
+  virtual int ProcessWithMEMap3(BookingHelper &bh, ME3IdsKey key) { return 0; };              // must be overrided
+  virtual int ProcessWithMEMap4(BookingHelper &bh, ME4IdsKey key) { return 0; };              // must be overrided
+  virtual int ProcessWithMEMap3WithChamber(BookingHelper &bh, ME4IdsKey key) { return 0; };   // must be overrided
 
   int keyToRegion(ME2IdsKey key) { return std::get<0>(key); };
   int keyToRegion(ME3IdsKey key) { return std::get<0>(key); };
@@ -544,11 +544,11 @@ inline int GEMDQMBase::getVFATNumber(const int station, const int ieta, const in
 }
 
 inline int GEMDQMBase::getVFATNumberGE11(const int station, const int ieta, const int vfat_phi) {
-  return vfat_phi * nNumEtaPartitionGE11_ + (8 - ieta);
+  return vfat_phi * nNumEtaPartitionGE11_ + (nNumEtaPartitionGE11_ - ieta);
 }
 
 inline int GEMDQMBase::getVFATNumberByDigi(const int station, const int ieta, const int digi) {
-  const int vfat_phi = (digi % GEMeMap::maxChan_) ? digi / GEMeMap::maxChan_ : digi / GEMeMap::maxChan_ - 1;
+  const int vfat_phi = digi / GEMeMap::maxChan_;
   return getVFATNumber(station, ieta, vfat_phi);
 }
 

--- a/DQM/GEM/interface/GEMDQMBase.h
+++ b/DQM/GEM/interface/GEMDQMBase.h
@@ -174,8 +174,8 @@ public:
 
     Bool_t isOperating() { return bOperating_; };
     void SetOperating(Bool_t bOperating) { bOperating_ = bOperating; };
-    void turnOn() { bOperating_ = true; };
-    void turnOff() { bOperating_ = false; };
+    void TurnOn() { bOperating_ = true; };
+    void TurnOff() { bOperating_ = false; };
 
     TString GetName() { return strName_; };
     void SetName(TString strName) { strName_ = strName; };
@@ -244,6 +244,8 @@ public:
     };
 
     int SetLabelForChambers(K key, Int_t nAxis, Int_t nNumBin = -1) {
+      if (!bOperating_)
+        return 0;
       if (nNumBin <= 0) {
         if (nAxis == 1)
           nNumBin = nBinsX_;
@@ -266,6 +268,8 @@ public:
     };
 
     int SetLabelForVFATs(K key, Int_t nNumEtaPartitions, Int_t nAxis, Int_t nNumBin = -1) {
+      if (!bOperating_)
+        return 0;
       if (nNumBin <= 0) {
         if (nAxis == 1)
           nNumBin = nBinsX_;
@@ -350,19 +354,19 @@ public:
                   Int_t nNumChambers,
                   Int_t nNumEtaPartitions,
                   Int_t nMaxVFAT,
-                  Int_t nNumStrip)
+                  Int_t nNumDigi)
         : nRegion_(nRegion),
           nStation_(nStation),
           nLayer_(nLayer),
           nNumChambers_(nNumChambers),
           nNumEtaPartitions_(nNumEtaPartitions),
           nMaxVFAT_(nMaxVFAT),
-          nNumStrip_(nNumStrip){};
+          nNumDigi_(nNumDigi){};
 
     bool operator==(const MEStationInfo &other) const {
       return (nRegion_ == other.nRegion_ && nStation_ == other.nStation_ && nLayer_ == other.nLayer_ &&
               nNumChambers_ == other.nNumChambers_ && nNumEtaPartitions_ == other.nNumEtaPartitions_ &&
-              nMaxVFAT_ == other.nMaxVFAT_ && nNumStrip_ == other.nNumStrip_);
+              nMaxVFAT_ == other.nMaxVFAT_ && nNumDigi_ == other.nNumDigi_);
     };
 
     Int_t nRegion_;            // the region index
@@ -371,7 +375,7 @@ public:
     Int_t nNumChambers_;       // the number of chambers in the current station
     Int_t nNumEtaPartitions_;  // the number of eta partitions of the chambers
     Int_t nMaxVFAT_;   // the number of all VFATs in each chamber (= # of VFATs in eta partition * nNumEtaPartitions_)
-    Int_t nNumStrip_;  // the number of strips of each VFAT
+    Int_t nNumDigi_;  // the number of digis of each VFAT
   };
 
 public:
@@ -422,7 +426,7 @@ protected:
   int getNumEtaPartitions(const GEMStation *);
   inline int getVFATNumber(const int, const int, const int);
   inline int getVFATNumberGE11(const int, const int, const int);
-  inline int getVFATNumberByStrip(const int, const int, const int);
+  inline int getVFATNumberByDigi(const int, const int, const int);
   inline int getIEtaFromVFAT(const int station, const int vfat);
   inline int getIEtaFromVFATGE11(const int vfat);
   inline int getMaxVFAT(const int);
@@ -480,8 +484,8 @@ inline int GEMDQMBase::getVFATNumberGE11(const int station, const int ieta, cons
   return vfat_phi * nNumEtaPartitionGE11_ + (8 - ieta);
 }
 
-inline int GEMDQMBase::getVFATNumberByStrip(const int station, const int ieta, const int strip) {
-  const int vfat_phi = (strip % GEMeMap::maxChan_) ? strip / GEMeMap::maxChan_ : strip / GEMeMap::maxChan_ - 1;
+inline int GEMDQMBase::getVFATNumberByDigi(const int station, const int ieta, const int digi) {
+  const int vfat_phi = (digi % GEMeMap::maxChan_) ? digi / GEMeMap::maxChan_ : digi / GEMeMap::maxChan_ - 1;
   return getVFATNumber(station, ieta, vfat_phi);
 }
 

--- a/DQM/GEM/interface/GEMDQMBase.h
+++ b/DQM/GEM/interface/GEMDQMBase.h
@@ -237,7 +237,7 @@ public:
 
     dqm::impl::MonitorElement *FindHist(K key) {
       if (mapHist.find(key) == mapHist.end()) {
-        std::cout << "" << std::endl;  // FIXME: It's about sending a message
+        std::cout << "WARNING: Cannot find the histogram corresponing to the given key" << std::endl;  // FIXME: It's about sending a message
         return nullptr;
       }
       return mapHist[key];
@@ -287,20 +287,20 @@ public:
       if (hist == nullptr)
         return -999;
       hist->Fill(x);
-      return 0;
+      return 1;
     };
 
-    int Fill(K key, Double_t x, Double_t y) {
+    int Fill(K key, Double_t x, Double_t y, Double_t w = 1.0) {
       if (!bOperating_)
         return 0;
       dqm::impl::MonitorElement *hist = FindHist(key);
       if (hist == nullptr)
         return -999;
-      hist->Fill(x, y);
-      return 0;
+      hist->Fill(x, y, w);
+      return 1;
     };
 
-    int FillBits(K key, Double_t x, UInt_t bits) {
+    int FillBits(K key, Double_t x, UInt_t bits, Double_t w = 1.0) {
       if (!bOperating_)
         return 0;
       dqm::impl::MonitorElement *hist = FindHist(key);
@@ -312,11 +312,11 @@ public:
       UInt_t unMask = 0x1;
       for (Int_t i = 1; i <= nBinsY_; i++) {
         if ((unMask & bits) != 0)
-          hist->Fill(x, i);
+          hist->Fill(x, i, w);
         unMask <<= 1;
       }
 
-      return 0;
+      return 1;
     };
 
   private:
@@ -381,6 +381,8 @@ protected:
 
   int GenerateMEPerChamber(DQMStore::IBooker &ibooker);
   virtual int ProcessWithMEMap2(BookingHelper &bh, ME2IdsKey key) { return 0; };             // must be overrided
+  virtual int ProcessWithMEMap2WithEta(BookingHelper &bh, ME3IdsKey key) { return 0; };             // must be overrided
+  virtual int ProcessWithMEMap2AbsReWithEta(BookingHelper &bh, ME3IdsKey key) { return 0; };             // must be overrided
   virtual int ProcessWithMEMap3(BookingHelper &bh, ME3IdsKey key) { return 0; };             // must be overrided
   virtual int ProcessWithMEMap4(BookingHelper &bh, ME4IdsKey key) { return 0; };             // must be overrided
   virtual int ProcessWithMEMap3WithChamber(BookingHelper &bh, ME4IdsKey key) { return 0; };  // must be overrided
@@ -394,7 +396,13 @@ protected:
   int keyToLayer(ME3IdsKey key) { return std::get<2>(key); };
   int keyToLayer(ME4IdsKey key) { return std::get<2>(key); };
   int keyToChamber(ME4IdsKey key) { return std::get<3>(key); };
+  int keyToIEta(ME3IdsKey key) { return std::get<2>(key); };
   int keyToIEta(ME4IdsKey key) { return std::get<3>(key); };
+
+  ME2IdsKey key3Tokey2(ME3IdsKey key) {
+    auto keyNew = ME2IdsKey{keyToRegion(key), keyToStation(key)};
+    return keyNew;
+  };
 
   ME3IdsKey key4Tokey3(ME4IdsKey key) {
     auto keyNew = ME3IdsKey{keyToRegion(key), keyToStation(key), keyToLayer(key)};
@@ -423,6 +431,8 @@ protected:
   std::vector<GEMChamber> gemChambers_;
 
   std::map<ME2IdsKey, bool> MEMap2Check_;
+  std::map<ME3IdsKey, bool> MEMap2WithEtaCheck_;
+  std::map<ME3IdsKey, bool> MEMap2AbsReWithEtaCheck_;
   std::map<ME3IdsKey, bool> MEMap3Check_;
   std::map<ME4IdsKey, bool> MEMap3WithChCheck_;
   std::map<ME4IdsKey, bool> MEMap4Check_;

--- a/DQM/GEM/interface/GEMDQMBase.h
+++ b/DQM/GEM/interface/GEMDQMBase.h
@@ -104,7 +104,12 @@ public:
 
     MEMapInfT(
         GEMDQMBase *pDQMBase, TString strName, TString strTitle, TString strTitleX = "", TString strTitleY = "Entries")
-        : pDQMBase_(pDQMBase), strName_(strName), strTitle_(strTitle), strTitleX_(strTitleX), strTitleY_(strTitleY){};
+        : pDQMBase_(pDQMBase),
+          strName_(strName),
+          strTitle_(strTitle),
+          strTitleX_(strTitleX),
+          strTitleY_(strTitleY),
+          log_category_own_(pDQMBase->log_category_){};
 
     MEMapInfT(GEMDQMBase *pDQMBase,
               TString strName,
@@ -124,7 +129,8 @@ public:
           nBinsX_(nBinsX),
           dXL_(dXL),
           dXH_(dXH),
-          nBinsY_(-1){};
+          nBinsY_(-1),
+          log_category_own_(pDQMBase->log_category_){};
 
     MEMapInfT(GEMDQMBase *pDQMBase,
               TString strName,
@@ -140,7 +146,8 @@ public:
           bOperating_(true),
           bIsProfile_(false),
           nBinsX_(-1),
-          nBinsY_(-1) {
+          nBinsY_(-1),
+          log_category_own_(pDQMBase->log_category_) {
       for (Int_t i = 0; i < (Int_t)x_binning.size(); i++)
         x_binning_.push_back(x_binning[i]);
     };
@@ -170,7 +177,8 @@ public:
           dYL_(dYL),
           dYH_(dYH),
           dZL_(0),
-          dZH_(1024){};
+          dZH_(1024),
+          log_category_own_(pDQMBase->log_category_){};
 
     MEMapInfT(GEMDQMBase *pDQMBase,  // For TProfile2D
               TString strName,
@@ -199,7 +207,8 @@ public:
           dYL_(dYL),
           dYH_(dYH),
           dZL_(dZL),
-          dZH_(dZH){};
+          dZH_(dZH),
+          log_category_own_(pDQMBase->log_category_){};
 
     //MEMapInfT(GEMDQMBase *pDQMBase,
     //          TString strName,
@@ -219,7 +228,8 @@ public:
     //      dXH_(dXH),
     //      nBinsY_(nBinsY),
     //      dYL_(dYL),
-    //      dYH_(dYH){};
+    //      dYH_(dYH),
+    //      log_category_own_(pDQMBase->log_category_){};
 
     ~MEMapInfT(){};
 
@@ -299,9 +309,8 @@ public:
 
     dqm::impl::MonitorElement *FindHist(K key) {
       if (mapHist.find(key) == mapHist.end()) {
-        std::cout << "WARNING: Cannot find the histogram corresponing to the given key"
-                  << std::endl;  // FIXME: It's about sending a message
-        return nullptr;
+        edm::LogError(log_category_own_)
+            << "WARNING: Cannot find the histogram corresponing to the given key\n";  // FIXME: It's about sending a message
       }
       return mapHist[key];
     };
@@ -402,6 +411,8 @@ public:
     Int_t nBinsY_;
     Double_t dYL_, dYH_;
     Double_t dZL_, dZH_;
+
+    std::string log_category_own_;
   };
 
   typedef MEMapInfT<MEMap2Ids, ME2IdsKey> MEMap2Inf;
@@ -444,6 +455,8 @@ public:
 public:
   explicit GEMDQMBase(const edm::ParameterSet &cfg);
   ~GEMDQMBase() override{};
+
+  std::string log_category_;
 
 protected:
   int initGeometry(edm::EventSetup const &iSetup);
@@ -494,8 +507,6 @@ protected:
   inline int getIEtaFromVFATGE11(const int vfat);
   inline int getMaxVFAT(const int);
   inline int getDetOccXBin(const int, const int, const int);
-
-  std::string log_category_;
 
   const GEMGeometry *GEMGeometry_;
 

--- a/DQM/GEM/interface/GEMDigiSource.h
+++ b/DQM/GEM/interface/GEMDigiSource.h
@@ -55,7 +55,7 @@ private:
 
   MEMap4Inf mapDigiOccPerCh_;
 
-  MonitorElement *h2SummaryOcc, *h2SummaryMal;
+  MonitorElement *h2SummaryOcc_;
 
   Int_t nBXMin_, nBXMax_;
 

--- a/DQM/GEM/interface/GEMDigiSource.h
+++ b/DQM/GEM/interface/GEMDigiSource.h
@@ -1,0 +1,66 @@
+#ifndef DQM_GEM_INTERFACE_GEMDigiSource_h
+#define DQM_GEM_INTERFACE_GEMDigiSource_h
+
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/PluginManager/interface/ModuleDef.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+#include "DQMServices/Core/interface/DQMEDAnalyzer.h"
+#include "DQMServices/Core/interface/DQMEDAnalyzer.h"
+#include "DQMServices/Core/interface/DQMStore.h"
+#include "DQMServices/Core/interface/MonitorElement.h"
+
+#include "Validation/MuonGEMHits/interface/GEMValidationUtils.h"
+
+#include "DataFormats/GEMDigi/interface/GEMDigiCollection.h"
+
+#include "DataFormats/Scalers/interface/LumiScalers.h"
+
+#include "DQM/GEM/interface/GEMDQMBase.h"
+
+#include <string>
+
+//----------------------------------------------------------------------------------------------------
+
+class GEMDigiSource : public GEMDQMBase {
+public:
+  explicit GEMDigiSource(const edm::ParameterSet& cfg);
+  ~GEMDigiSource() override{};
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+protected:
+  void dqmBeginRun(edm::Run const&, edm::EventSetup const&) override{};
+  void bookHistograms(DQMStore::IBooker&, edm::Run const&, edm::EventSetup const&) override;
+  void analyze(edm::Event const& e, edm::EventSetup const& eSetup) override;
+
+private:
+  int ProcessWithMEMap2WithEta(BookingHelper& bh, ME3IdsKey key) override;
+  int ProcessWithMEMap3(BookingHelper& bh, ME3IdsKey key) override;
+  int ProcessWithMEMap3WithChamber(BookingHelper& bh, ME4IdsKey key) override;
+
+  edm::EDGetToken tagDigi_;
+
+  edm::EDGetTokenT<LumiScalersCollection> lumiScalers_;
+
+  MEMap3Inf mapTotalDigi_layer_;
+  MEMap3Inf mapDigiOcc_ieta_;
+  MEMap3Inf mapDigiOcc_phi_;
+  MEMap3Inf mapTotalDigiPerEvt_;
+  MEMap3Inf mapBX_iEta_;
+
+  MEMap4Inf mapDigiOccPerCh_;
+
+  MonitorElement *h2SummaryOcc, *h2SummaryMal;
+
+  Int_t nBXMin_, nBXMax_;
+
+  Bool_t bModeRelVal_;
+};
+
+
+#endif  // DQM_GEM_INTERFACE_GEMDigiSource_h

--- a/DQM/GEM/interface/GEMDigiSource.h
+++ b/DQM/GEM/interface/GEMDigiSource.h
@@ -50,7 +50,8 @@ private:
   MEMap3Inf mapTotalDigi_layer_;
   MEMap3Inf mapDigiOcc_ieta_;
   MEMap3Inf mapDigiOcc_phi_;
-  MEMap3Inf mapTotalDigiPerEvt_;
+  MEMap3Inf mapTotalDigiPerEvtLayer_;
+  MEMap3Inf mapTotalDigiPerEvtIEta_;
   MEMap3Inf mapBX_iEta_;
 
   MEMap4Inf mapDigiOccPerCh_;

--- a/DQM/GEM/interface/GEMDigiSource.h
+++ b/DQM/GEM/interface/GEMDigiSource.h
@@ -56,12 +56,11 @@ private:
 
   MEMap4Inf mapDigiOccPerCh_;
 
-  MonitorElement *h2SummaryOcc_;
+  MonitorElement* h2SummaryOcc_;
 
   Int_t nBXMin_, nBXMax_;
 
   Bool_t bModeRelVal_;
 };
-
 
 #endif  // DQM_GEM_INTERFACE_GEMDigiSource_h

--- a/DQM/GEM/interface/GEMRecHitSource.h
+++ b/DQM/GEM/interface/GEMRecHitSource.h
@@ -1,0 +1,71 @@
+#ifndef DQM_GEM_INTERFACE_GEMRecHitSource_h
+#define DQM_GEM_INTERFACE_GEMRecHitSource_h
+
+#include "DQM/GEM/interface/GEMDQMBase.h"
+
+#include "DataFormats/GEMRecHit/interface/GEMRecHit.h"
+#include "DataFormats/GEMRecHit/interface/GEMRecHitCollection.h"
+#include "DataFormats/GEMDigi/interface/GEMDigiCollection.h"
+
+#include <string>
+
+//----------------------------------------------------------------------------------------------------
+
+class GEMRecHitSource : public GEMDQMBase {
+public:
+  explicit GEMRecHitSource(const edm::ParameterSet& cfg);
+  ~GEMRecHitSource() override{};
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+  typedef std::map<ME4IdsKey, std::map<Int_t, Int_t>> ME5map;
+
+protected:
+  void dqmBeginRun(edm::Run const&, edm::EventSetup const&) override{};
+  void bookHistograms(DQMStore::IBooker&, edm::Run const&, edm::EventSetup const&) override;
+  void analyze(edm::Event const& e, edm::EventSetup const& eSetup) override;
+
+private:
+  int ProcessWithMEMap2WithEta(BookingHelper& bh, ME3IdsKey key) override;
+  int ProcessWithMEMap2AbsReWithEta(BookingHelper& bh, ME3IdsKey key) override;
+  int ProcessWithMEMap3(BookingHelper& bh, ME3IdsKey key) override;
+  int ProcessWithMEMap3WithChamber(BookingHelper& bh, ME4IdsKey key) override;
+  
+  void InitKey5MultiMap(ME5map &map, ME4IdsKey key1, Int_t key2) {
+    if (map.find(key1) == map.end()) map[key1][key2] = 0;
+    else if (map[key1].find(key2) == map[key1].end()) map[key1][key2] = 0;
+  };
+
+  edm::EDGetToken tagRecHit_;
+
+  int nIdxFirstDigi_;
+  int nClusterSizeBinNum_;
+
+  MEMap3Inf mapTotalRecHit_layer_;
+  MEMap3Inf mapRecHitWheel_layer_;
+  MEMap3Inf mapRecHitOcc_ieta_;
+  MEMap3Inf mapRecHitOcc_phi_;
+  MEMap3Inf mapTotalRecHitPerEvtLayer_;
+  MEMap3Inf mapTotalRecHitPerEvtIEta_;
+  //MEMap4Inf mapCLSRecHit_ieta_;
+  MEMap3Inf mapCLSRecHit_ieta_;
+  MEMap3Inf mapCLSNumberAve_;
+  MEMap3Inf mapCLSNumberOv5_;
+  MEMap3Inf mapCLSAverage_;
+  MEMap3Inf mapCLSOver5_;
+
+  MEMap4Inf mapCLSPerCh_;
+
+  Int_t nCLSMax_;
+  Float_t fRadiusMin_;
+  Float_t fRadiusMax_;
+
+  std::unordered_map<UInt_t, MonitorElement*> recHitME_;
+  std::unordered_map<UInt_t, MonitorElement*> VFAT_vs_ClusterSize_;
+  std::unordered_map<UInt_t, MonitorElement*> DigisFired_vs_eta_;
+  std::unordered_map<UInt_t, MonitorElement*> rh_vs_eta_;
+  std::unordered_map<UInt_t, MonitorElement*> recGlobalPos;
+
+  Bool_t bModeRelVal_;
+};
+
+#endif  // DQM_GEM_INTERFACE_GEMRecHitSource_h

--- a/DQM/GEM/interface/GEMRecHitSource.h
+++ b/DQM/GEM/interface/GEMRecHitSource.h
@@ -17,8 +17,6 @@ public:
   ~GEMRecHitSource() override{};
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
-  typedef std::map<ME4IdsKey, std::map<Int_t, Int_t>> ME5map;
-
 protected:
   void dqmBeginRun(edm::Run const&, edm::EventSetup const&) override{};
   void bookHistograms(DQMStore::IBooker&, edm::Run const&, edm::EventSetup const&) override;
@@ -29,11 +27,6 @@ private:
   int ProcessWithMEMap2AbsReWithEta(BookingHelper& bh, ME3IdsKey key) override;
   int ProcessWithMEMap3(BookingHelper& bh, ME3IdsKey key) override;
   int ProcessWithMEMap3WithChamber(BookingHelper& bh, ME4IdsKey key) override;
-  
-  void InitKey5MultiMap(ME5map &map, ME4IdsKey key1, Int_t key2) {
-    if (map.find(key1) == map.end()) map[key1][key2] = 0;
-    else if (map[key1].find(key2) == map[key1].end()) map[key1][key2] = 0;
-  };
 
   edm::EDGetToken tagRecHit_;
 
@@ -46,10 +39,7 @@ private:
   MEMap3Inf mapRecHitOcc_phi_;
   MEMap3Inf mapTotalRecHitPerEvtLayer_;
   MEMap3Inf mapTotalRecHitPerEvtIEta_;
-  //MEMap4Inf mapCLSRecHit_ieta_;
   MEMap3Inf mapCLSRecHit_ieta_;
-  MEMap3Inf mapCLSNumberAve_;
-  MEMap3Inf mapCLSNumberOv5_;
   MEMap3Inf mapCLSAverage_;
   MEMap3Inf mapCLSOver5_;
 

--- a/DQM/GEM/plugins/GEMDAQStatusSource.cc
+++ b/DQM/GEM/plugins/GEMDAQStatusSource.cc
@@ -129,7 +129,7 @@ void GEMDAQStatusSource::bookHistograms(DQMStore::IBooker &ibooker, edm::Run con
   SetLabelAMCStatus(h2AMCStatusPos_);
 
   mapStatusOH_ =
-      MEMap3Inf(this, "oh_status", "OctoHybrid Status", 36, 0.5, 36.5, nBitOH_, 0.5, nBitOH_ + 0.5, "Chamber");
+      MEMap3Inf(this, "oh_status", "OptoHybrid Status", 36, 0.5, 36.5, nBitOH_, 0.5, nBitOH_ + 0.5, "Chamber");
   mapStatusVFAT_ =
       MEMap3Inf(this, "vfat_status", "VFAT Status", 24, -0.5, 24 - 0.5, nBitVFAT_, 0.5, nBitVFAT_ + 0.5, "VFAT");
 

--- a/DQM/GEM/plugins/GEMDAQStatusSource.cc
+++ b/DQM/GEM/plugins/GEMDAQStatusSource.cc
@@ -329,8 +329,7 @@ void GEMDAQStatusSource::analyze(edm::Event const &event, edm::EventSetup const 
     const GEMVFATStatusCollection::Range &range = (*vfatIt).second;
 
     for (auto vfatStat = range.first; vfatStat != range.second; ++vfatStat) {
-      // NOTE: nIdxVFAT starts from 1
-      Int_t nIdxVFAT = getVFATNumber(gid.station(), gid.ieta(), vfatStat->vfatPosition()) + 1;
+      Int_t nIdxVFAT = getVFATNumber(gid.station(), gid.ieta(), vfatStat->vfatPosition());
 
       GEMVFATStatus::Warnings warnings{vfatStat->warnings()};
       if (warnings.basicOFW)   mapStatusVFAT_.Fill(key3, nIdxVFAT, 2);

--- a/DQM/GEM/plugins/GEMDAQStatusSource.cc
+++ b/DQM/GEM/plugins/GEMDAQStatusSource.cc
@@ -401,29 +401,28 @@ void GEMDAQStatusSource::analyze(edm::Event const &event, edm::EventSetup const 
 
     const GEMOHStatusCollection::Range &range = (*ohIt).second;
     for (auto OHStatus = range.first; OHStatus != range.second; ++OHStatus) {
-      Bool_t bWarn = false;
-      Bool_t bErr  = false;
-
       GEMOHStatus::Warnings warnings{OHStatus->warnings()};
-      if (warnings.EvtNF)       bWarn = mapStatusOH_.Fill(key3, gid.chamber(), 2) > 0;
-      if (warnings.InNF)        bWarn = mapStatusOH_.Fill(key3, gid.chamber(), 3) > 0;
-      if (warnings.L1aNF)       bWarn = mapStatusOH_.Fill(key3, gid.chamber(), 4) > 0;
-      if (warnings.EvtSzW)      bWarn = mapStatusOH_.Fill(key3, gid.chamber(), 5) > 0;
-      if (warnings.InValidVFAT) bWarn = mapStatusOH_.Fill(key3, gid.chamber(), 6) > 0;
+      if (warnings.EvtNF)       mapStatusOH_.Fill(key3, gid.chamber(), 2);
+      if (warnings.InNF)        mapStatusOH_.Fill(key3, gid.chamber(), 3);
+      if (warnings.L1aNF)       mapStatusOH_.Fill(key3, gid.chamber(), 4);
+      if (warnings.EvtSzW)      mapStatusOH_.Fill(key3, gid.chamber(), 5);
+      if (warnings.InValidVFAT) mapStatusOH_.Fill(key3, gid.chamber(), 6);
 
       GEMOHStatus::Errors errors{OHStatus->errors()};
-      if (errors.EvtF)         bErr = mapStatusOH_.Fill(key3, gid.chamber(),  7) > 0;
-      if (errors.InF)          bErr = mapStatusOH_.Fill(key3, gid.chamber(),  8) > 0;
-      if (errors.L1aF)         bErr = mapStatusOH_.Fill(key3, gid.chamber(),  9) > 0;
-      if (errors.EvtSzOFW)     bErr = mapStatusOH_.Fill(key3, gid.chamber(), 10) > 0;
-      if (errors.Inv)          bErr = mapStatusOH_.Fill(key3, gid.chamber(), 11) > 0;
-      if (errors.OOScAvV)      bErr = mapStatusOH_.Fill(key3, gid.chamber(), 12) > 0;
-      if (errors.OOScVvV)      bErr = mapStatusOH_.Fill(key3, gid.chamber(), 13) > 0;
-      if (errors.BxmAvV)       bErr = mapStatusOH_.Fill(key3, gid.chamber(), 14) > 0;
-      if (errors.BxmVvV)       bErr = mapStatusOH_.Fill(key3, gid.chamber(), 15) > 0;
-      if (errors.InUfw)        bErr = mapStatusOH_.Fill(key3, gid.chamber(), 16) > 0;
-      if (errors.badVFatCount) bErr = mapStatusOH_.Fill(key3, gid.chamber(), 17) > 0;
+      if (errors.EvtF)         mapStatusOH_.Fill(key3, gid.chamber(),  7);
+      if (errors.InF)          mapStatusOH_.Fill(key3, gid.chamber(),  8);
+      if (errors.L1aF)         mapStatusOH_.Fill(key3, gid.chamber(),  9);
+      if (errors.EvtSzOFW)     mapStatusOH_.Fill(key3, gid.chamber(), 10);
+      if (errors.Inv)          mapStatusOH_.Fill(key3, gid.chamber(), 11);
+      if (errors.OOScAvV)      mapStatusOH_.Fill(key3, gid.chamber(), 12);
+      if (errors.OOScVvV)      mapStatusOH_.Fill(key3, gid.chamber(), 13);
+      if (errors.BxmAvV)       mapStatusOH_.Fill(key3, gid.chamber(), 14);
+      if (errors.BxmVvV)       mapStatusOH_.Fill(key3, gid.chamber(), 15);
+      if (errors.InUfw)        mapStatusOH_.Fill(key3, gid.chamber(), 16);
+      if (errors.badVFatCount) mapStatusOH_.Fill(key3, gid.chamber(), 17);
 
+      Bool_t bWarn = warnings.wcodes != 0;
+      Bool_t bErr  = errors.codes != 0;
       if (!bWarn && !bErr) mapStatusOH_.Fill(key3, gid.chamber(), 1);
       if (bWarn) mapChamberWarning[key4] = false;
       if (bErr)  mapChamberError[key4] = false;
@@ -439,25 +438,25 @@ void GEMDAQStatusSource::analyze(edm::Event const &event, edm::EventSetup const 
     for (auto vfatStat = range.first; vfatStat != range.second; ++vfatStat) {
       // NOTE: nIdxVFAT starts from 1
       Int_t nIdxVFAT = getVFATNumber(gid.station(), gid.ieta(), vfatStat->vfatPosition()) + 1;
-      Bool_t bWarn = false;
-      Bool_t bErr  = false;
 
       GEMVFATStatus::Warnings warnings{vfatStat->warnings()};
-      if (warnings.basicOFW)   bWarn = mapStatusVFAT_.Fill(key3, nIdxVFAT, 2);
-      if (warnings.zeroSupOFW) bWarn = mapStatusVFAT_.Fill(key3, nIdxVFAT, 3);
-      if (warnings.basicOFW)   bWarn = mapStatusVFATPerCh_.Fill(key4Ch, nIdxVFAT, 2);
-      if (warnings.zeroSupOFW) bWarn = mapStatusVFATPerCh_.Fill(key4Ch, nIdxVFAT, 3);
+      if (warnings.basicOFW)   mapStatusVFAT_.Fill(key3, nIdxVFAT, 2);
+      if (warnings.zeroSupOFW) mapStatusVFAT_.Fill(key3, nIdxVFAT, 3);
+      if (warnings.basicOFW)   mapStatusVFATPerCh_.Fill(key4Ch, nIdxVFAT, 2);
+      if (warnings.zeroSupOFW) mapStatusVFATPerCh_.Fill(key4Ch, nIdxVFAT, 3);
 
       GEMVFATStatus::Errors errors{(uint8_t)vfatStat->errors()};
-      if (errors.vc)            bErr = mapStatusVFAT_.Fill(key3, nIdxVFAT, 4);
-      if (errors.InValidHeader) bErr = mapStatusVFAT_.Fill(key3, nIdxVFAT, 5);
-      if (errors.EC)            bErr = mapStatusVFAT_.Fill(key3, nIdxVFAT, 6);
-      if (errors.BC)            bErr = mapStatusVFAT_.Fill(key3, nIdxVFAT, 7);
-      if (errors.vc)            bErr = mapStatusVFATPerCh_.Fill(key4Ch, nIdxVFAT, 4);
-      if (errors.InValidHeader) bErr = mapStatusVFATPerCh_.Fill(key4Ch, nIdxVFAT, 5);
-      if (errors.EC)            bErr = mapStatusVFATPerCh_.Fill(key4Ch, nIdxVFAT, 6);
-      if (errors.BC)            bErr = mapStatusVFATPerCh_.Fill(key4Ch, nIdxVFAT, 7);
+      if (errors.vc)            mapStatusVFAT_.Fill(key3, nIdxVFAT, 4);
+      if (errors.InValidHeader) mapStatusVFAT_.Fill(key3, nIdxVFAT, 5);
+      if (errors.EC)            mapStatusVFAT_.Fill(key3, nIdxVFAT, 6);
+      if (errors.BC)            mapStatusVFAT_.Fill(key3, nIdxVFAT, 7);
+      if (errors.vc)            mapStatusVFATPerCh_.Fill(key4Ch, nIdxVFAT, 4);
+      if (errors.InValidHeader) mapStatusVFATPerCh_.Fill(key4Ch, nIdxVFAT, 5);
+      if (errors.EC)            mapStatusVFATPerCh_.Fill(key4Ch, nIdxVFAT, 6);
+      if (errors.BC)            mapStatusVFATPerCh_.Fill(key4Ch, nIdxVFAT, 7);
 
+      Bool_t bWarn = warnings.wcodes != 0;
+      Bool_t bErr  = errors.codes != 0;
       if (!bWarn && !bErr) mapStatusVFAT_.Fill(key3, nIdxVFAT, 1);
       if (!bWarn && !bErr) mapStatusVFATPerCh_.Fill(key4Ch, nIdxVFAT, 1);
       if (bWarn) mapChamberWarning[key4Ch] = false;

--- a/DQM/GEM/plugins/GEMDAQStatusSource.cc
+++ b/DQM/GEM/plugins/GEMDAQStatusSource.cc
@@ -105,7 +105,7 @@ void GEMDAQStatusSource::bookHistograms(DQMStore::IBooker &ibooker, edm::Run con
   ibooker.cd();
   ibooker.setCurrentFolder("GEM/DAQStatus");
 
-  h2AMC13Status_ = ibooker.book2D("amc13_statusflag",
+  h2AMC13Status_ = ibooker.book2D("amc13_status",
                                   "AMC13 Status;AMC13;",
                                   2,
                                   0.5,
@@ -113,16 +113,16 @@ void GEMDAQStatusSource::bookHistograms(DQMStore::IBooker &ibooker, edm::Run con
                                   nBitAMC13_,
                                   0.5,
                                   nBitAMC13_ + 0.5);
-  h2AMCStatusPos_ = ibooker.book2D("amc_statusflagPos",
-                                   "AMC Status GE11-P;AMC slot;",
+  h2AMCStatusNeg_ = ibooker.book2D("amc_status_GE11-N",
+                                   "AMC Status GE11-N;AMC slot;",
                                    nAMCSlots_,
                                    -0.5,
                                    nAMCSlots_ - 0.5,
                                    nBitAMC_,
                                    0.5,
                                    nBitAMC_ + 0.5);
-  h2AMCStatusNeg_ = ibooker.book2D("amc_statusflagNeg",
-                                   "AMC Status GE11-N;AMC slot;",
+  h2AMCStatusPos_ = ibooker.book2D("amc_status_GE11-P",
+                                   "AMC Status GE11-P;AMC slot;",
                                    nAMCSlots_,
                                    -0.5,
                                    nAMCSlots_ - 0.5,
@@ -131,8 +131,8 @@ void GEMDAQStatusSource::bookHistograms(DQMStore::IBooker &ibooker, edm::Run con
                                    nBitAMC_ + 0.5);
 
   SetLabelAMC13Status(h2AMC13Status_);
-  SetLabelAMCStatus(h2AMCStatusPos_);
   SetLabelAMCStatus(h2AMCStatusNeg_);
+  SetLabelAMCStatus(h2AMCStatusPos_);
 
   mapStatusOH_ =
       MEMap3Inf(this, "oh_status", "OctoHybrid Status", 36, 0.5, 36.5, nBitOH_, 0.5, nBitOH_ + 0.5, "Chamber");
@@ -140,19 +140,19 @@ void GEMDAQStatusSource::bookHistograms(DQMStore::IBooker &ibooker, edm::Run con
       MEMap3Inf(this, "vfat_status", "VFAT Status", 24, 0.5, 24.5, nBitVFAT_, 0.5, nBitVFAT_ + 0.5, "VFAT");
 
   mapStatusWarnVFATPerLayer_ = MEMap3Inf(
-      this, "vfat_statusWarnSum", "VFAT reporting errors/warnings", 36, 0.5, 36.5, 24, 0.5, 24.5, "Chamber", "VFAT");
+      this, "vfat_statusWarnSum", "VFAT reporting warnings", 36, 0.5, 36.5, 24, 0.5, 24.5, "Chamber", "VFAT");
   mapStatusErrVFATPerLayer_ = MEMap3Inf(
-      this, "vfat_statusErrSum", "VFAT reporting errors/warnings", 36, 0.5, 36.5, 24, 0.5, 24.5, "Chamber", "VFAT");
+      this, "vfat_statusErrSum", "VFAT reporting errors", 36, 0.5, 36.5, 24, 0.5, 24.5, "Chamber", "VFAT");
   mapStatusVFATPerCh_ =
       MEMap4Inf(this, "vfat_status", "VFAT Status", 24, 0.5, 24.5, nBitVFAT_, 0.5, nBitVFAT_ + 0.5, "VFAT");
 
   GenerateMEPerChamber(ibooker);
 
-  h2SummaryStatusWarning = CreateSummaryHist(ibooker, "summaryStatusWarning");
-  h2SummaryStatusError   = CreateSummaryHist(ibooker, "summaryStatusError");
+  h2SummaryStatusWarning = CreateSummaryHist(ibooker, "chamberWarnings");
+  h2SummaryStatusError   = CreateSummaryHist(ibooker, "chamberErrors");
 
-  h2SummaryStatusWarning->setTitle("Chambers with OH or VFAT errors");
-  h2SummaryStatusError->setTitle("Chambers with OH or VFAT warnings");
+  h2SummaryStatusWarning->setTitle("Summary of OH or VFAT warnings of each chambers");
+  h2SummaryStatusError->setTitle("Summary of OH or VFAT errors of each chambers");
 }
 
 int GEMDAQStatusSource::ProcessWithMEMap3(BookingHelper &bh, ME3IdsKey key) {

--- a/DQM/GEM/plugins/GEMDAQStatusSource.cc
+++ b/DQM/GEM/plugins/GEMDAQStatusSource.cc
@@ -86,8 +86,8 @@ void GEMDAQStatusSource::SetLabelVFATStatus(MonitorElement *h2Status) {
   h2Status->setBinLabel(unBinPos++, "Zero-sup overflow", 2);
   h2Status->setBinLabel(unBinPos++, "VFAT CRC error", 2);
   h2Status->setBinLabel(unBinPos++, "Invalid header", 2);
-  h2Status->setBinLabel(unBinPos++, "No match AMC EC", 2);
-  h2Status->setBinLabel(unBinPos++, "No match AMC BC", 2);
+  h2Status->setBinLabel(unBinPos++, "AMC EC mismatch", 2);
+  h2Status->setBinLabel(unBinPos++, "AMC BC mismatch", 2);
 }
 
 void GEMDAQStatusSource::bookHistograms(DQMStore::IBooker &ibooker, edm::Run const &, edm::EventSetup const &iSetup) {
@@ -137,14 +137,14 @@ void GEMDAQStatusSource::bookHistograms(DQMStore::IBooker &ibooker, edm::Run con
   mapStatusOH_ =
       MEMap3Inf(this, "oh_status", "OctoHybrid Status", 36, 0.5, 36.5, nBitOH_, 0.5, nBitOH_ + 0.5, "Chamber");
   mapStatusVFAT_ =
-      MEMap3Inf(this, "vfat_status", "VFAT Status", 24, 0.5, 24.5, nBitVFAT_, 0.5, nBitVFAT_ + 0.5, "VFAT");
+      MEMap3Inf(this, "vfat_status", "VFAT Status", 24, -0.5, 24 - 0.5, nBitVFAT_, 0.5, nBitVFAT_ + 0.5, "VFAT");
 
   mapStatusWarnVFATPerLayer_ = MEMap3Inf(
-      this, "vfat_statusWarnSum", "VFAT reporting warnings", 36, 0.5, 36.5, 24, 0.5, 24.5, "Chamber", "VFAT");
+      this, "vfat_statusWarnSum", "VFAT reporting warnings", 36, 0.5, 36.5, 24, -0.5, 24 - 0.5, "Chamber", "VFAT");
   mapStatusErrVFATPerLayer_ = MEMap3Inf(
-      this, "vfat_statusErrSum", "VFAT reporting errors", 36, 0.5, 36.5, 24, 0.5, 24.5, "Chamber", "VFAT");
+      this, "vfat_statusErrSum", "VFAT reporting errors", 36, 0.5, 36.5, 24, -0.5, 24 - 0.5, "Chamber", "VFAT");
   mapStatusVFATPerCh_ =
-      MEMap4Inf(this, "vfat_status", "VFAT Status", 24, 0.5, 24.5, nBitVFAT_, 0.5, nBitVFAT_ + 0.5, "VFAT");
+      MEMap4Inf(this, "vfat_status", "VFAT Status", 24, -0.5, 24 - 0.5, nBitVFAT_, 0.5, nBitVFAT_ + 0.5, "VFAT");
 
   GenerateMEPerChamber(ibooker);
 
@@ -165,18 +165,18 @@ int GEMDAQStatusSource::ProcessWithMEMap3(BookingHelper &bh, ME3IdsKey key) {
   SetLabelOHStatus(mapStatusOH_.FindHist(key));
 
   mapStatusWarnVFATPerLayer_.SetBinConfX(stationInfo.nNumChambers_);
-  mapStatusWarnVFATPerLayer_.SetBinConfY(stationInfo.nMaxVFAT_);
+  mapStatusWarnVFATPerLayer_.SetBinConfY(stationInfo.nMaxVFAT_, -0.5);
   mapStatusWarnVFATPerLayer_.bookND(bh, key);
   mapStatusWarnVFATPerLayer_.SetLabelForChambers(key, 1);
   mapStatusWarnVFATPerLayer_.SetLabelForVFATs(key, stationInfo.nNumEtaPartitions_, 2);
 
   mapStatusErrVFATPerLayer_.SetBinConfX(stationInfo.nNumChambers_);
-  mapStatusErrVFATPerLayer_.SetBinConfY(stationInfo.nMaxVFAT_);
+  mapStatusErrVFATPerLayer_.SetBinConfY(stationInfo.nMaxVFAT_, -0.5);
   mapStatusErrVFATPerLayer_.bookND(bh, key);
   mapStatusErrVFATPerLayer_.SetLabelForChambers(key, 1);
   mapStatusErrVFATPerLayer_.SetLabelForVFATs(key, stationInfo.nNumEtaPartitions_, 2);
 
-  mapStatusVFAT_.SetBinConfX(stationInfo.nMaxVFAT_);
+  mapStatusVFAT_.SetBinConfX(stationInfo.nMaxVFAT_, -0.5);
   mapStatusVFAT_.bookND(bh, key);
   mapStatusVFAT_.SetLabelForVFATs(key, stationInfo.nNumEtaPartitions_, 1);
 
@@ -189,7 +189,7 @@ int GEMDAQStatusSource::ProcessWithMEMap3WithChamber(BookingHelper &bh, ME4IdsKe
   ME3IdsKey key3 = key4Tokey3(key);
   MEStationInfo &stationInfo = mapStationInfo_[key3];
 
-  mapStatusVFATPerCh_.SetBinConfX(stationInfo.nMaxVFAT_);
+  mapStatusVFATPerCh_.SetBinConfX(stationInfo.nMaxVFAT_, -0.5);
   mapStatusVFATPerCh_.bookND(bh, key);
   mapStatusVFATPerCh_.SetLabelForVFATs(key, stationInfo.nNumEtaPartitions_, 1);
   SetLabelVFATStatus(mapStatusVFATPerCh_.FindHist(key));

--- a/DQM/GEM/plugins/GEMDAQStatusSource.cc
+++ b/DQM/GEM/plugins/GEMDAQStatusSource.cc
@@ -105,14 +105,8 @@ void GEMDAQStatusSource::bookHistograms(DQMStore::IBooker &ibooker, edm::Run con
   ibooker.cd();
   ibooker.setCurrentFolder("GEM/DAQStatus");
 
-  h2AMC13Status_ = ibooker.book2D("amc13_status",
-                                  "AMC13 Status;AMC13;",
-                                  2,
-                                  0.5,
-                                  2.5,
-                                  nBitAMC13_,
-                                  0.5,
-                                  nBitAMC13_ + 0.5);
+  h2AMC13Status_ =
+      ibooker.book2D("amc13_status", "AMC13 Status;AMC13;", 2, 0.5, 2.5, nBitAMC13_, 0.5, nBitAMC13_ + 0.5);
   h2AMCStatusNeg_ = ibooker.book2D("amc_status_GE11-N",
                                    "AMC Status GE11-N;AMC slot;",
                                    nAMCSlots_,
@@ -149,7 +143,7 @@ void GEMDAQStatusSource::bookHistograms(DQMStore::IBooker &ibooker, edm::Run con
   GenerateMEPerChamber(ibooker);
 
   h2SummaryStatusWarning = CreateSummaryHist(ibooker, "chamberWarnings");
-  h2SummaryStatusError   = CreateSummaryHist(ibooker, "chamberErrors");
+  h2SummaryStatusError = CreateSummaryHist(ibooker, "chamberErrors");
 
   h2SummaryStatusWarning->setTitle("Summary of OH or VFAT warnings of each chambers");
   h2SummaryStatusError->setTitle("Summary of OH or VFAT errors of each chambers");
@@ -207,12 +201,13 @@ void GEMDAQStatusSource::analyze(edm::Event const &event, edm::EventSetup const 
   event.getByToken(tagOH_, gemOH);
   event.getByToken(tagAMC_, gemAMC);
   event.getByToken(tagAMC13_, gemAMC13);
-  
+
   for (auto amc13It = gemAMC13->begin(); amc13It != gemAMC13->end(); ++amc13It) {
     int fedId = (*amc13It).first;
-    if (mapFEDIdToRe_.find(fedId) == mapFEDIdToRe_.end()) continue;
+    if (mapFEDIdToRe_.find(fedId) == mapFEDIdToRe_.end())
+      continue;
     int nXBin = 0;
-    if (mapFEDIdToRe_[fedId] < 0 ) {
+    if (mapFEDIdToRe_[fedId] < 0) {
       nXBin = 1;
     } else if (mapFEDIdToRe_[fedId] > 0) {
       nXBin = 2;
@@ -224,22 +219,32 @@ void GEMDAQStatusSource::analyze(edm::Event const &event, edm::EventSetup const 
     const auto &range = (*amc13It).second;
     for (auto amc13 = range.first; amc13 != range.second; ++amc13) {
       Bool_t bWarn = false;
-      Bool_t bErr  = false;
+      Bool_t bErr = false;
 
       GEMAMC13Status::Warnings warnings{amc13->warnings()};
-      if (warnings.InValidAMC) FillWithRiseErr(h2AMC13Status_, nXBin, 2, bWarn);
+      if (warnings.InValidAMC)
+        FillWithRiseErr(h2AMC13Status_, nXBin, 2, bWarn);
 
       GEMAMC13Status::Errors errors{amc13->errors()};
-      if (errors.InValidSize)        FillWithRiseErr(h2AMC13Status_, nXBin,  3, bErr);
-      if (errors.failTrailerCheck)   FillWithRiseErr(h2AMC13Status_, nXBin,  4, bErr);
-      if (errors.failFragmentLength) FillWithRiseErr(h2AMC13Status_, nXBin,  5, bErr);
-      if (errors.failTrailerMatch)   FillWithRiseErr(h2AMC13Status_, nXBin,  6, bErr);
-      if (errors.moreTrailers)       FillWithRiseErr(h2AMC13Status_, nXBin,  7, bErr);
-      if (errors.crcModified)        FillWithRiseErr(h2AMC13Status_, nXBin,  8, bErr);
-      if (errors.slinkError)         FillWithRiseErr(h2AMC13Status_, nXBin,  9, bErr);
-      if (errors.wrongFedId)         FillWithRiseErr(h2AMC13Status_, nXBin, 10, bErr);
+      if (errors.InValidSize)
+        FillWithRiseErr(h2AMC13Status_, nXBin, 3, bErr);
+      if (errors.failTrailerCheck)
+        FillWithRiseErr(h2AMC13Status_, nXBin, 4, bErr);
+      if (errors.failFragmentLength)
+        FillWithRiseErr(h2AMC13Status_, nXBin, 5, bErr);
+      if (errors.failTrailerMatch)
+        FillWithRiseErr(h2AMC13Status_, nXBin, 6, bErr);
+      if (errors.moreTrailers)
+        FillWithRiseErr(h2AMC13Status_, nXBin, 7, bErr);
+      if (errors.crcModified)
+        FillWithRiseErr(h2AMC13Status_, nXBin, 8, bErr);
+      if (errors.slinkError)
+        FillWithRiseErr(h2AMC13Status_, nXBin, 9, bErr);
+      if (errors.wrongFedId)
+        FillWithRiseErr(h2AMC13Status_, nXBin, 10, bErr);
 
-      if (!bWarn && !bErr) h2AMC13Status_->Fill(nXBin, 1);
+      if (!bWarn && !bErr)
+        h2AMC13Status_->Fill(nXBin, 1);
     }
   }
 
@@ -247,7 +252,8 @@ void GEMDAQStatusSource::analyze(edm::Event const &event, edm::EventSetup const 
 
   for (auto amcIt = gemAMC->begin(); amcIt != gemAMC->end(); ++amcIt) {
     int fedId = (*amcIt).first;
-    if (mapFEDIdToRe_.find(fedId) == mapFEDIdToRe_.end()) continue;
+    if (mapFEDIdToRe_.find(fedId) == mapFEDIdToRe_.end())
+      continue;
     if (mapFEDIdToRe_[fedId] < 0) {
       h2AMCStatus = h2AMCStatusNeg_;
     } else if (mapFEDIdToRe_[fedId] > 0) {
@@ -260,26 +266,38 @@ void GEMDAQStatusSource::analyze(edm::Event const &event, edm::EventSetup const 
     const GEMAMCStatusCollection::Range &range = (*amcIt).second;
     for (auto amc = range.first; amc != range.second; ++amc) {
       Bool_t bWarn = false;
-      Bool_t bErr  = false;
+      Bool_t bErr = false;
 
       Int_t nAMCNum = amc->amcNumber();
 
       GEMAMCStatus::Warnings warnings{amc->warnings()};
-      if (warnings.InValidOH)    FillWithRiseErr(h2AMCStatus, nAMCNum, 2, bWarn);
-      if (warnings.backPressure) FillWithRiseErr(h2AMCStatus, nAMCNum, 3, bWarn);
+      if (warnings.InValidOH)
+        FillWithRiseErr(h2AMCStatus, nAMCNum, 2, bWarn);
+      if (warnings.backPressure)
+        FillWithRiseErr(h2AMCStatus, nAMCNum, 3, bWarn);
 
       GEMAMCStatus::Errors errors{amc->errors()};
-      if (errors.badEC)          FillWithRiseErr(h2AMCStatus, nAMCNum,  4, bErr);
-      if (errors.badBC)          FillWithRiseErr(h2AMCStatus, nAMCNum,  5, bErr);
-      if (errors.badOC)          FillWithRiseErr(h2AMCStatus, nAMCNum,  6, bErr);
-      if (errors.badRunType)     FillWithRiseErr(h2AMCStatus, nAMCNum,  7, bErr);
-      if (errors.badCRC)         FillWithRiseErr(h2AMCStatus, nAMCNum,  8, bErr);
-      if (errors.MMCMlocked)     FillWithRiseErr(h2AMCStatus, nAMCNum,  9, bErr);
-      if (errors.DAQclocklocked) FillWithRiseErr(h2AMCStatus, nAMCNum, 10, bErr);
-      if (errors.DAQnotReday)    FillWithRiseErr(h2AMCStatus, nAMCNum, 11, bErr);
-      if (errors.BC0locked)      FillWithRiseErr(h2AMCStatus, nAMCNum, 12, bErr);
+      if (errors.badEC)
+        FillWithRiseErr(h2AMCStatus, nAMCNum, 4, bErr);
+      if (errors.badBC)
+        FillWithRiseErr(h2AMCStatus, nAMCNum, 5, bErr);
+      if (errors.badOC)
+        FillWithRiseErr(h2AMCStatus, nAMCNum, 6, bErr);
+      if (errors.badRunType)
+        FillWithRiseErr(h2AMCStatus, nAMCNum, 7, bErr);
+      if (errors.badCRC)
+        FillWithRiseErr(h2AMCStatus, nAMCNum, 8, bErr);
+      if (errors.MMCMlocked)
+        FillWithRiseErr(h2AMCStatus, nAMCNum, 9, bErr);
+      if (errors.DAQclocklocked)
+        FillWithRiseErr(h2AMCStatus, nAMCNum, 10, bErr);
+      if (errors.DAQnotReday)
+        FillWithRiseErr(h2AMCStatus, nAMCNum, 11, bErr);
+      if (errors.BC0locked)
+        FillWithRiseErr(h2AMCStatus, nAMCNum, 12, bErr);
 
-      if (!bWarn && !bErr) h2AMCStatus->Fill(nAMCNum, 1);
+      if (!bWarn && !bErr)
+        h2AMCStatus->Fill(nAMCNum, 1);
     }
   }
 
@@ -295,30 +313,49 @@ void GEMDAQStatusSource::analyze(edm::Event const &event, edm::EventSetup const 
     const GEMOHStatusCollection::Range &range = (*ohIt).second;
     for (auto OHStatus = range.first; OHStatus != range.second; ++OHStatus) {
       GEMOHStatus::Warnings warnings{OHStatus->warnings()};
-      if (warnings.EvtNF)       mapStatusOH_.Fill(key3, gid.chamber(), 2);
-      if (warnings.InNF)        mapStatusOH_.Fill(key3, gid.chamber(), 3);
-      if (warnings.L1aNF)       mapStatusOH_.Fill(key3, gid.chamber(), 4);
-      if (warnings.EvtSzW)      mapStatusOH_.Fill(key3, gid.chamber(), 5);
-      if (warnings.InValidVFAT) mapStatusOH_.Fill(key3, gid.chamber(), 6);
+      if (warnings.EvtNF)
+        mapStatusOH_.Fill(key3, gid.chamber(), 2);
+      if (warnings.InNF)
+        mapStatusOH_.Fill(key3, gid.chamber(), 3);
+      if (warnings.L1aNF)
+        mapStatusOH_.Fill(key3, gid.chamber(), 4);
+      if (warnings.EvtSzW)
+        mapStatusOH_.Fill(key3, gid.chamber(), 5);
+      if (warnings.InValidVFAT)
+        mapStatusOH_.Fill(key3, gid.chamber(), 6);
 
       GEMOHStatus::Errors errors{OHStatus->errors()};
-      if (errors.EvtF)         mapStatusOH_.Fill(key3, gid.chamber(),  7);
-      if (errors.InF)          mapStatusOH_.Fill(key3, gid.chamber(),  8);
-      if (errors.L1aF)         mapStatusOH_.Fill(key3, gid.chamber(),  9);
-      if (errors.EvtSzOFW)     mapStatusOH_.Fill(key3, gid.chamber(), 10);
-      if (errors.Inv)          mapStatusOH_.Fill(key3, gid.chamber(), 11);
-      if (errors.OOScAvV)      mapStatusOH_.Fill(key3, gid.chamber(), 12);
-      if (errors.OOScVvV)      mapStatusOH_.Fill(key3, gid.chamber(), 13);
-      if (errors.BxmAvV)       mapStatusOH_.Fill(key3, gid.chamber(), 14);
-      if (errors.BxmVvV)       mapStatusOH_.Fill(key3, gid.chamber(), 15);
-      if (errors.InUfw)        mapStatusOH_.Fill(key3, gid.chamber(), 16);
-      if (errors.badVFatCount) mapStatusOH_.Fill(key3, gid.chamber(), 17);
+      if (errors.EvtF)
+        mapStatusOH_.Fill(key3, gid.chamber(), 7);
+      if (errors.InF)
+        mapStatusOH_.Fill(key3, gid.chamber(), 8);
+      if (errors.L1aF)
+        mapStatusOH_.Fill(key3, gid.chamber(), 9);
+      if (errors.EvtSzOFW)
+        mapStatusOH_.Fill(key3, gid.chamber(), 10);
+      if (errors.Inv)
+        mapStatusOH_.Fill(key3, gid.chamber(), 11);
+      if (errors.OOScAvV)
+        mapStatusOH_.Fill(key3, gid.chamber(), 12);
+      if (errors.OOScVvV)
+        mapStatusOH_.Fill(key3, gid.chamber(), 13);
+      if (errors.BxmAvV)
+        mapStatusOH_.Fill(key3, gid.chamber(), 14);
+      if (errors.BxmVvV)
+        mapStatusOH_.Fill(key3, gid.chamber(), 15);
+      if (errors.InUfw)
+        mapStatusOH_.Fill(key3, gid.chamber(), 16);
+      if (errors.badVFatCount)
+        mapStatusOH_.Fill(key3, gid.chamber(), 17);
 
       Bool_t bWarn = warnings.wcodes != 0;
-      Bool_t bErr  = errors.codes != 0;
-      if (!bWarn && !bErr) mapStatusOH_.Fill(key3, gid.chamber(), 1);
-      if (bWarn) mapChamberWarning[key4] = false;
-      if (bErr)  mapChamberError[key4] = false;
+      Bool_t bErr = errors.codes != 0;
+      if (!bWarn && !bErr)
+        mapStatusOH_.Fill(key3, gid.chamber(), 1);
+      if (bWarn)
+        mapChamberWarning[key4] = false;
+      if (bErr)
+        mapChamberError[key4] = false;
     }
   }
 
@@ -332,29 +369,47 @@ void GEMDAQStatusSource::analyze(edm::Event const &event, edm::EventSetup const 
       Int_t nIdxVFAT = getVFATNumber(gid.station(), gid.ieta(), vfatStat->vfatPosition());
 
       GEMVFATStatus::Warnings warnings{vfatStat->warnings()};
-      if (warnings.basicOFW)   mapStatusVFAT_.Fill(key3, nIdxVFAT, 2);
-      if (warnings.zeroSupOFW) mapStatusVFAT_.Fill(key3, nIdxVFAT, 3);
-      if (warnings.basicOFW)   mapStatusVFATPerCh_.Fill(key4Ch, nIdxVFAT, 2);
-      if (warnings.zeroSupOFW) mapStatusVFATPerCh_.Fill(key4Ch, nIdxVFAT, 3);
+      if (warnings.basicOFW)
+        mapStatusVFAT_.Fill(key3, nIdxVFAT, 2);
+      if (warnings.zeroSupOFW)
+        mapStatusVFAT_.Fill(key3, nIdxVFAT, 3);
+      if (warnings.basicOFW)
+        mapStatusVFATPerCh_.Fill(key4Ch, nIdxVFAT, 2);
+      if (warnings.zeroSupOFW)
+        mapStatusVFATPerCh_.Fill(key4Ch, nIdxVFAT, 3);
 
       GEMVFATStatus::Errors errors{(uint8_t)vfatStat->errors()};
-      if (errors.vc)            mapStatusVFAT_.Fill(key3, nIdxVFAT, 4);
-      if (errors.InValidHeader) mapStatusVFAT_.Fill(key3, nIdxVFAT, 5);
-      if (errors.EC)            mapStatusVFAT_.Fill(key3, nIdxVFAT, 6);
-      if (errors.BC)            mapStatusVFAT_.Fill(key3, nIdxVFAT, 7);
-      if (errors.vc)            mapStatusVFATPerCh_.Fill(key4Ch, nIdxVFAT, 4);
-      if (errors.InValidHeader) mapStatusVFATPerCh_.Fill(key4Ch, nIdxVFAT, 5);
-      if (errors.EC)            mapStatusVFATPerCh_.Fill(key4Ch, nIdxVFAT, 6);
-      if (errors.BC)            mapStatusVFATPerCh_.Fill(key4Ch, nIdxVFAT, 7);
+      if (errors.vc)
+        mapStatusVFAT_.Fill(key3, nIdxVFAT, 4);
+      if (errors.InValidHeader)
+        mapStatusVFAT_.Fill(key3, nIdxVFAT, 5);
+      if (errors.EC)
+        mapStatusVFAT_.Fill(key3, nIdxVFAT, 6);
+      if (errors.BC)
+        mapStatusVFAT_.Fill(key3, nIdxVFAT, 7);
+      if (errors.vc)
+        mapStatusVFATPerCh_.Fill(key4Ch, nIdxVFAT, 4);
+      if (errors.InValidHeader)
+        mapStatusVFATPerCh_.Fill(key4Ch, nIdxVFAT, 5);
+      if (errors.EC)
+        mapStatusVFATPerCh_.Fill(key4Ch, nIdxVFAT, 6);
+      if (errors.BC)
+        mapStatusVFATPerCh_.Fill(key4Ch, nIdxVFAT, 7);
 
       Bool_t bWarn = warnings.wcodes != 0;
-      Bool_t bErr  = errors.codes != 0;
-      if (!bWarn && !bErr) mapStatusVFAT_.Fill(key3, nIdxVFAT, 1);
-      if (!bWarn && !bErr) mapStatusVFATPerCh_.Fill(key4Ch, nIdxVFAT, 1);
-      if (bWarn) mapChamberWarning[key4Ch] = false;
-      if (bErr)  mapChamberError[key4Ch] = false;
-      if (bWarn) mapStatusWarnVFATPerLayer_.Fill(key3, gid.chamber(), nIdxVFAT);
-      if (bErr)  mapStatusErrVFATPerLayer_.Fill(key3, gid.chamber(), nIdxVFAT);
+      Bool_t bErr = errors.codes != 0;
+      if (!bWarn && !bErr)
+        mapStatusVFAT_.Fill(key3, nIdxVFAT, 1);
+      if (!bWarn && !bErr)
+        mapStatusVFATPerCh_.Fill(key4Ch, nIdxVFAT, 1);
+      if (bWarn)
+        mapChamberWarning[key4Ch] = false;
+      if (bErr)
+        mapChamberError[key4Ch] = false;
+      if (bWarn)
+        mapStatusWarnVFATPerLayer_.Fill(key3, gid.chamber(), nIdxVFAT);
+      if (bErr)
+        mapStatusErrVFATPerLayer_.Fill(key3, gid.chamber(), nIdxVFAT);
     }
   }
 

--- a/DQM/GEM/plugins/GEMDQMHarvester.cc
+++ b/DQM/GEM/plugins/GEMDQMHarvester.cc
@@ -145,6 +145,7 @@ void GEMDQMHarvester::createSummaryHist(edm::Service<DQMStore> &store,
   h2Sum = store->book2D("reportSummaryMap", "", nBinX, 0.5, nBinX + 0.5, nBinY, 0.5, nBinY + 0.5);
   h2Sum->setTitle("Summary plot");
   h2Sum->setXTitle("Chamber");
+  h2Sum->setYTitle("Layer");
 
   listLayers.clear();
   for (Int_t i = 1; i <= nBinX; i++)
@@ -166,7 +167,7 @@ void GEMDQMHarvester::createSummaryVFAT(edm::Service<DQMStore> &store,
   //store->setCurrentFolder(strDirSummary_);
 
   Int_t nBinX = h2Src->getNbinsX(), nBinY = h2Src->getNbinsY();
-  h2Sum = store->book2D("vfat_statusSummary" + strSuffix, "", nBinX, 0.5, nBinX + 0.5, nBinY, 0.5, nBinY + 0.5);
+  h2Sum = store->book2D("vfat_statusSummary" + strSuffix, "", nBinX, 0.5, nBinX + 0.5, nBinY, -0.5, nBinY - 0.5);
   copyLabels(h2Src, h2Sum);
 }
 

--- a/DQM/GEM/plugins/GEMDQMHarvester.cc
+++ b/DQM/GEM/plugins/GEMDQMHarvester.cc
@@ -91,7 +91,7 @@ void GEMDQMHarvester::drawSummaryHistogram(edm::Service<DQMStore> &store) {
   std::string strSrcStatusW = "GEM/DAQStatus/summaryStatusWarning";
   std::string strSrcStatusE = "GEM/DAQStatus/summaryStatusError";
 
-  std::string strSrcVFATOcc = "GEM/Digis/digi_det";
+  std::string strSrcVFATOcc = "GEM/Digis/det";
   std::string strSrcVFATStatusW = "GEM/DAQStatus/vfat_statusWarnSum";
   std::string strSrcVFATStatusE = "GEM/DAQStatus/vfat_statusErrSum";
 
@@ -212,20 +212,22 @@ Float_t GEMDQMHarvester::refineSummaryHistogram(MonitorElement *h2Sum,
 }
 
 void GEMDQMHarvester::synthesisCLSPlots(edm::Service<DQMStore> &store) {
-  std::string strHeadSrcCLSNum = "GEM/RecHits/rechitNumber";
-  std::string strHeadSrcCLSAve = "GEM/RecHits/rechit_average_pre";
-  std::string strHeadSrcCLSOv5 = "GEM/RecHits/rechit_over5_pre";
+  std::string strHeadSrcCLSNumAve = "GEM/RecHits/rechitNumberAve";
+  std::string strHeadSrcCLSNumOv5 = "GEM/RecHits/rechitNumberOv5";
+  std::string strHeadSrcCLSAve    = "GEM/RecHits/rechit_average_pre";
+  std::string strHeadSrcCLSOv5    = "GEM/RecHits/rechit_over5_pre";
 
   std::string strHeadDstCLSAve = "rechit_average";
   std::string strHeadDstCLSOv5 = "rechit_over5";
 
   for (const auto &strSuffix : listLayer_) {
-    MonitorElement *h2SrcCLSNum = store->get(strHeadSrcCLSNum + strSuffix);
-    MonitorElement *h2SrcCLSAve = store->get(strHeadSrcCLSAve + strSuffix);
-    MonitorElement *h2SrcCLSOv5 = store->get(strHeadSrcCLSOv5 + strSuffix);
-    if (h2SrcCLSNum == nullptr || h2SrcCLSAve == nullptr || h2SrcCLSOv5 == nullptr)
+    MonitorElement *h2SrcCLSNumAve = store->get(strHeadSrcCLSNumAve + strSuffix);
+    MonitorElement *h2SrcCLSNumOv5 = store->get(strHeadSrcCLSNumOv5 + strSuffix);
+    MonitorElement *h2SrcCLSAve    = store->get(strHeadSrcCLSAve    + strSuffix);
+    MonitorElement *h2SrcCLSOv5    = store->get(strHeadSrcCLSOv5    + strSuffix);
+    if (h2SrcCLSNumAve == nullptr || h2SrcCLSNumOv5 == nullptr || h2SrcCLSAve == nullptr || h2SrcCLSOv5 == nullptr)
       continue;
-    Int_t nBinX = h2SrcCLSNum->getNbinsX(), nBinY = h2SrcCLSNum->getNbinsY();
+    Int_t nBinX = h2SrcCLSNumAve->getNbinsX(), nBinY = h2SrcCLSNumAve->getNbinsY();
     //store->setCurrentFolder(strDirRecHit_);
     //store->setCurrentFolder(strDirSummary_);
     MonitorElement *h2Ave = store->book2D(strHeadDstCLSAve + strSuffix, "", nBinX, 0.5, nBinX + 0.5, nBinY, 0.5, nBinY + 0.5);
@@ -234,9 +236,15 @@ void GEMDQMHarvester::synthesisCLSPlots(edm::Service<DQMStore> &store) {
     copyLabels(h2SrcCLSOv5, h2Ov5);
     for (Int_t j = 1; j <= nBinY; j++) {
       for (Int_t i = 1; i <= nBinX; i++) {
-        Int_t nNum = h2SrcCLSNum->getBinContent(i, j);
+        Int_t nNum = h2SrcCLSNumAve->getBinContent(i, j);
         if (nNum <= 0) continue;
         h2Ave->setBinContent(i, j, h2SrcCLSAve->getBinContent(i, j) / nNum);
+      }
+    }
+    for (Int_t j = 1; j <= nBinY; j++) {
+      for (Int_t i = 1; i <= nBinX; i++) {
+        Int_t nNum = h2SrcCLSNumOv5->getBinContent(i, j);
+        if (nNum <= 0) continue;
         h2Ov5->setBinContent(i, j, h2SrcCLSOv5->getBinContent(i, j) / nNum);
       }
     }

--- a/DQM/GEM/plugins/GEMDQMHarvester.cc
+++ b/DQM/GEM/plugins/GEMDQMHarvester.cc
@@ -45,10 +45,10 @@ protected:
                          std::string strSuffix,
                          MonitorElement *&h2Sum);
   Float_t refineSummaryHistogram(MonitorElement *h2Sum,
-                              MonitorElement *h2SrcOcc,
-                              MonitorElement *h2SrcStatusE,
-                              MonitorElement *h2SrcStatusW = nullptr,
-                              Bool_t bVarXBin = false);
+                                 MonitorElement *h2SrcOcc,
+                                 MonitorElement *h2SrcStatusE,
+                                 MonitorElement *h2SrcStatusW = nullptr,
+                                 Bool_t bVarXBin = false);
 
   Float_t fReportSummary_;
   std::string strOutFile_;
@@ -173,10 +173,10 @@ void GEMDQMHarvester::createSummaryVFAT(edm::Service<DQMStore> &store,
 
 // FIXME: Need more study about how to summarize
 Float_t GEMDQMHarvester::refineSummaryHistogram(MonitorElement *h2Sum,
-                                             MonitorElement *h2SrcOcc,
-                                             MonitorElement *h2SrcStatusE,
-                                             MonitorElement *h2SrcStatusW,
-                                             Bool_t bVarXBin) {
+                                                MonitorElement *h2SrcOcc,
+                                                MonitorElement *h2SrcStatusE,
+                                                MonitorElement *h2SrcStatusW,
+                                                Bool_t bVarXBin) {
   Int_t nBinY = h2Sum->getNbinsY();
   Int_t nAllBin = 0, nFineBin = 0;
   for (Int_t j = 1; j <= nBinY; j++) {
@@ -188,7 +188,7 @@ Float_t GEMDQMHarvester::refineSummaryHistogram(MonitorElement *h2Sum,
     for (Int_t i = 1; i <= nBinX; i++) {
       Float_t fOcc = h2SrcOcc->getBinContent(i, j);
       Float_t fStatusWarn = (h2SrcStatusW != nullptr ? h2SrcStatusW->getBinContent(i, j) : 0.0);
-      Float_t fStatusErr  = h2SrcStatusE->getBinContent(i, j);
+      Float_t fStatusErr = h2SrcStatusE->getBinContent(i, j);
 
       Float_t fRes = 0;
       if (fStatusErr > 0)
@@ -205,7 +205,7 @@ Float_t GEMDQMHarvester::refineSummaryHistogram(MonitorElement *h2Sum,
     }
   }
 
-  return ( (Float_t)nFineBin ) / nAllBin;
+  return ((Float_t)nFineBin) / nAllBin;
 }
 
 DEFINE_FWK_MODULE(GEMDQMHarvester);

--- a/DQM/GEM/plugins/GEMDQMHarvester.cc
+++ b/DQM/GEM/plugins/GEMDQMHarvester.cc
@@ -66,7 +66,7 @@ GEMDQMHarvester::GEMDQMHarvester(const edm::ParameterSet &cfg) {
   fReportSummary_ = -1.0;
   strOutFile_ = cfg.getParameter<std::string>("fromFile");
   strDirSummary_ = "GEM/EventInfo";
-  strDirRecHit_ = "GEM/recHit";
+  strDirRecHit_ = "GEM/RecHits";
   strDirStatus_ = "GEM/DAQStatus";
 }
 
@@ -86,12 +86,12 @@ void GEMDQMHarvester::dqmEndLuminosityBlock(DQMStore::IBooker &,
 }
 
 void GEMDQMHarvester::drawSummaryHistogram(edm::Service<DQMStore> &store) {
-  std::string strSrcDigiOcc = "GEM/digi/summaryOccDigi";
-  std::string strSrcDigiMal = "GEM/digi/summaryMalfuncDigi";
+  std::string strSrcDigiOcc = "GEM/Digis/summaryOccDigi";
+  std::string strSrcDigiMal = "GEM/Digis/summaryMalfuncDigi";
   std::string strSrcStatusW = "GEM/DAQStatus/summaryStatusWarning";
   std::string strSrcStatusE = "GEM/DAQStatus/summaryStatusError";
 
-  std::string strSrcVFATOcc = "GEM/digi/digi_det";
+  std::string strSrcVFATOcc = "GEM/Digis/digi_det";
   std::string strSrcVFATStatusW = "GEM/DAQStatus/vfat_statusWarnSum";
   std::string strSrcVFATStatusE = "GEM/DAQStatus/vfat_statusErrSum";
 
@@ -212,9 +212,9 @@ Float_t GEMDQMHarvester::refineSummaryHistogram(MonitorElement *h2Sum,
 }
 
 void GEMDQMHarvester::synthesisCLSPlots(edm::Service<DQMStore> &store) {
-  std::string strHeadSrcCLSNum = "GEM/recHit/rechitNumber";
-  std::string strHeadSrcCLSAve = "GEM/recHit/rechit_average_pre";
-  std::string strHeadSrcCLSOv5 = "GEM/recHit/rechit_over5_pre";
+  std::string strHeadSrcCLSNum = "GEM/RecHits/rechitNumber";
+  std::string strHeadSrcCLSAve = "GEM/RecHits/rechit_average_pre";
+  std::string strHeadSrcCLSOv5 = "GEM/RecHits/rechit_over5_pre";
 
   std::string strHeadDstCLSAve = "rechit_average";
   std::string strHeadDstCLSOv5 = "rechit_over5";

--- a/DQM/GEM/plugins/GEMDQMHarvester.cc
+++ b/DQM/GEM/plugins/GEMDQMHarvester.cc
@@ -35,6 +35,7 @@ protected:
   void dqmEndJob(DQMStore::IBooker &, DQMStore::IGetter &) override{};  // Cannot use; it is called after dqmSaver
 
   void drawSummaryHistogram(edm::Service<DQMStore> &store);
+  void copyLabels(MonitorElement *h2Src, MonitorElement *h2Dst);
   void createSummaryHist(edm::Service<DQMStore> &store,
                          MonitorElement *h2Src,
                          MonitorElement *&h2Sum,
@@ -43,23 +44,29 @@ protected:
                          MonitorElement *h2Src,
                          std::string strSuffix,
                          MonitorElement *&h2Sum);
-  void refineSummaryHistogram(MonitorElement *h2Sum,
+  Float_t refineSummaryHistogram(MonitorElement *h2Sum,
                               MonitorElement *h2SrcOcc,
-                              MonitorElement *h2SrcCStatus,
+                              MonitorElement *h2SrcStatusE,
+                              MonitorElement *h2SrcStatusW = nullptr,
                               MonitorElement *h2SrcMal = nullptr,
                               Bool_t bVarXBin = false);
+  void synthesisCLSPlots(edm::Service<DQMStore> &store);
 
   Float_t fReportSummary_;
   std::string strOutFile_;
 
   std::string strDirSummary_;
+  std::string strDirRecHit_;
   std::string strDirStatus_;
+
+  std::vector<std::string> listLayer_;
 };
 
 GEMDQMHarvester::GEMDQMHarvester(const edm::ParameterSet &cfg) {
   fReportSummary_ = -1.0;
   strOutFile_ = cfg.getParameter<std::string>("fromFile");
   strDirSummary_ = "GEM/EventInfo";
+  strDirRecHit_ = "GEM/recHit";
   strDirStatus_ = "GEM/DAQStatus";
 }
 
@@ -75,50 +82,68 @@ void GEMDQMHarvester::dqmEndLuminosityBlock(DQMStore::IBooker &,
                                             edm::EventSetup const &) {
   edm::Service<DQMStore> store;
   drawSummaryHistogram(store);
+  synthesisCLSPlots(store);
 }
 
 void GEMDQMHarvester::drawSummaryHistogram(edm::Service<DQMStore> &store) {
   std::string strSrcDigiOcc = "GEM/digi/summaryOccDigi";
   std::string strSrcDigiMal = "GEM/digi/summaryMalfuncDigi";
-  std::string strSrcCStatus = "GEM/DAQStatus/summaryStatus";
+  std::string strSrcStatusW = "GEM/DAQStatus/summaryStatusWarning";
+  std::string strSrcStatusE = "GEM/DAQStatus/summaryStatusError";
 
   std::string strSrcVFATOcc = "GEM/digi/digi_det";
-  std::string strSrcVFATStatus = "GEM/DAQStatus/vfat_statusSum";
+  std::string strSrcVFATStatusW = "GEM/DAQStatus/vfat_statusWarnSum";
+  std::string strSrcVFATStatusE = "GEM/DAQStatus/vfat_statusErrSum";
 
   store->setCurrentFolder(strDirSummary_);
 
   MonitorElement *h2SrcDigiOcc = store->get(strSrcDigiOcc);
   MonitorElement *h2SrcDigiMal = store->get(strSrcDigiMal);
-  MonitorElement *h2SrcCStatus = store->get(strSrcCStatus);
+  MonitorElement *h2SrcStatusW = store->get(strSrcStatusW);
+  MonitorElement *h2SrcStatusE = store->get(strSrcStatusE);
 
-  if (h2SrcDigiOcc != nullptr && h2SrcDigiMal != nullptr && h2SrcCStatus != nullptr) {
+  if (h2SrcDigiOcc != nullptr && h2SrcDigiMal != nullptr && h2SrcStatusW != nullptr && h2SrcStatusE != nullptr) {
     MonitorElement *h2Sum = nullptr;
-    std::vector<std::string> listLayer;
-    createSummaryHist(store, h2SrcCStatus, h2Sum, listLayer);
-    refineSummaryHistogram(h2Sum, h2SrcDigiOcc, h2SrcCStatus, h2SrcDigiMal, true);
+    createSummaryHist(store, h2SrcStatusE, h2Sum, listLayer_);
+    fReportSummary_ = refineSummaryHistogram(h2Sum, h2SrcDigiOcc, h2SrcStatusE, h2SrcStatusW, h2SrcDigiMal, true);
 
-    for (const auto &strSuffix : listLayer) {
+    for (const auto &strSuffix : listLayer_) {
       MonitorElement *h2SrcVFATOcc = store->get(strSrcVFATOcc + strSuffix);
-      MonitorElement *h2SrcVFATStatus = store->get(strSrcVFATStatus + strSuffix);
-      if (h2SrcVFATOcc == nullptr || h2SrcVFATStatus == nullptr)
+      MonitorElement *h2SrcVFATStatusW = store->get(strSrcVFATStatusW + strSuffix);
+      MonitorElement *h2SrcVFATStatusE = store->get(strSrcVFATStatusE + strSuffix);
+      if (h2SrcVFATOcc == nullptr || h2SrcVFATStatusW == nullptr || h2SrcVFATStatusE == nullptr)
         continue;
       MonitorElement *h2SumVFAT = nullptr;
-      createSummaryVFAT(store, h2SrcVFATStatus, strSuffix, h2SumVFAT);
-      refineSummaryHistogram(h2SumVFAT, h2SrcVFATOcc, h2SrcVFATStatus);
-      h2SumVFAT->setTitle(h2SrcVFATStatus->getTitle());
-      h2SumVFAT->setXTitle(h2SrcVFATStatus->getAxisTitle(1));
-      h2SumVFAT->setYTitle(h2SrcVFATStatus->getAxisTitle(2));
+      createSummaryVFAT(store, h2SrcVFATStatusE, strSuffix, h2SumVFAT);
+      refineSummaryHistogram(h2SumVFAT, h2SrcVFATOcc, h2SrcVFATStatusE, h2SrcVFATStatusW);
+      h2SumVFAT->setTitle(h2SrcVFATStatusE->getTitle());
+      h2SumVFAT->setXTitle(h2SrcVFATStatusE->getAxisTitle(1));
+      h2SumVFAT->setYTitle(h2SrcVFATStatusE->getAxisTitle(2));
     }
   }
 
   store->bookFloat("reportSummary")->Fill(fReportSummary_);
 }
 
+void GEMDQMHarvester::copyLabels(MonitorElement *h2Src, MonitorElement *h2Dst) {
+  Int_t nBinX = h2Src->getNbinsX(), nBinY = h2Src->getNbinsY();
+
+  for (Int_t i = 1; i <= nBinX; i++) {
+    h2Dst->setBinLabel(i, h2Src->getTH2F()->GetXaxis()->GetBinLabel(i), 1);
+  }
+  for (Int_t i = 1; i <= nBinY; i++) {
+    h2Dst->setBinLabel(i, h2Src->getTH2F()->GetYaxis()->GetBinLabel(i), 2);
+  }
+  h2Dst->setTitle(h2Src->getTitle());
+  h2Dst->setXTitle(h2Src->getAxisTitle(1));
+  h2Dst->setYTitle(h2Src->getAxisTitle(2));
+}
+
 void GEMDQMHarvester::createSummaryHist(edm::Service<DQMStore> &store,
                                         MonitorElement *h2Src,
                                         MonitorElement *&h2Sum,
                                         std::vector<std::string> &listLayers) {
-  store->setCurrentFolder(strDirSummary_);
+  //store->setCurrentFolder(strDirSummary_);
 
   Int_t nBinX = h2Src->getNbinsX(), nBinY = h2Src->getNbinsY();
   h2Sum = store->book2D("reportSummaryMap", "", nBinX, 0.5, nBinX + 0.5, nBinY, 0.5, nBinY + 0.5);
@@ -139,24 +164,23 @@ void GEMDQMHarvester::createSummaryVFAT(edm::Service<DQMStore> &store,
                                         MonitorElement *h2Src,
                                         std::string strSuffix,
                                         MonitorElement *&h2Sum) {
-  store->setCurrentFolder(strDirStatus_);
+  //store->setCurrentFolder(strDirStatus_);
+  //store->setCurrentFolder(strDirSummary_);
 
   Int_t nBinX = h2Src->getNbinsX(), nBinY = h2Src->getNbinsY();
   h2Sum = store->book2D("vfat_statusSummary" + strSuffix, "", nBinX, 0.5, nBinX + 0.5, nBinY, 0.5, nBinY + 0.5);
-
-  for (Int_t i = 1; i <= nBinX; i++)
-    h2Sum->setBinLabel(i, h2Src->getTH2F()->GetXaxis()->GetBinLabel(i), 1);
-  for (Int_t i = 1; i <= nBinY; i++)
-    h2Sum->setBinLabel(i, h2Src->getTH2F()->GetYaxis()->GetBinLabel(i), 2);
+  copyLabels(h2Src, h2Sum);
 }
 
 // FIXME: Need more study about how to summarize
-void GEMDQMHarvester::refineSummaryHistogram(MonitorElement *h2Sum,
+Float_t GEMDQMHarvester::refineSummaryHistogram(MonitorElement *h2Sum,
                                              MonitorElement *h2SrcOcc,
-                                             MonitorElement *h2SrcCStatus,
+                                             MonitorElement *h2SrcStatusE,
+                                             MonitorElement *h2SrcStatusW,
                                              MonitorElement *h2SrcMal,
                                              Bool_t bVarXBin) {
   Int_t nBinY = h2Sum->getNbinsY();
+  Int_t nAllBin = 0, nFineBin = 0;
   for (Int_t j = 1; j <= nBinY; j++) {
     Int_t nBinX = h2Sum->getNbinsX();
     if (bVarXBin) {
@@ -165,16 +189,56 @@ void GEMDQMHarvester::refineSummaryHistogram(MonitorElement *h2Sum,
     }
     for (Int_t i = 1; i <= nBinX; i++) {
       Float_t fOcc = h2SrcOcc->getBinContent(i, j);
-      Float_t fStatus = h2SrcCStatus->getBinContent(i, j);
+      Float_t fStatusWarn = (h2SrcStatusW != nullptr ? h2SrcStatusW->getBinContent(i, j) : 0.0);
+      Float_t fStatusErr  = h2SrcStatusE->getBinContent(i, j);
       Float_t fMal = (h2SrcMal != nullptr ? h2SrcMal->getBinContent(i, j) : 0.0);
 
       Float_t fRes = 0;
-      if (fStatus > 0 || fMal > 0)
+      if (fStatusErr > 0 || fMal > 0)
         fRes = 2;
-      else if (fOcc > 0)
+      else if (fStatusWarn > 0)
+        fRes = 3;
+      else if (fOcc > 0) {
         fRes = 1;
+        nFineBin++;
+      }
 
       h2Sum->setBinContent(i, j, fRes);
+      nAllBin++;
+    }
+  }
+
+  return ( (Float_t)nFineBin ) / nAllBin;
+}
+
+void GEMDQMHarvester::synthesisCLSPlots(edm::Service<DQMStore> &store) {
+  std::string strHeadSrcCLSNum = "GEM/recHit/rechitNumber";
+  std::string strHeadSrcCLSAve = "GEM/recHit/rechit_average_pre";
+  std::string strHeadSrcCLSOv5 = "GEM/recHit/rechit_over5_pre";
+
+  std::string strHeadDstCLSAve = "rechit_average";
+  std::string strHeadDstCLSOv5 = "rechit_over5";
+
+  for (const auto &strSuffix : listLayer_) {
+    MonitorElement *h2SrcCLSNum = store->get(strHeadSrcCLSNum + strSuffix);
+    MonitorElement *h2SrcCLSAve = store->get(strHeadSrcCLSAve + strSuffix);
+    MonitorElement *h2SrcCLSOv5 = store->get(strHeadSrcCLSOv5 + strSuffix);
+    if (h2SrcCLSNum == nullptr || h2SrcCLSAve == nullptr || h2SrcCLSOv5 == nullptr)
+      continue;
+    Int_t nBinX = h2SrcCLSNum->getNbinsX(), nBinY = h2SrcCLSNum->getNbinsY();
+    //store->setCurrentFolder(strDirRecHit_);
+    //store->setCurrentFolder(strDirSummary_);
+    MonitorElement *h2Ave = store->book2D(strHeadDstCLSAve + strSuffix, "", nBinX, 0.5, nBinX + 0.5, nBinY, 0.5, nBinY + 0.5);
+    MonitorElement *h2Ov5 = store->book2D(strHeadDstCLSOv5 + strSuffix, "", nBinX, 0.5, nBinX + 0.5, nBinY, 0.5, nBinY + 0.5);
+    copyLabels(h2SrcCLSAve, h2Ave);
+    copyLabels(h2SrcCLSOv5, h2Ov5);
+    for (Int_t j = 1; j <= nBinY; j++) {
+      for (Int_t i = 1; i <= nBinX; i++) {
+        Int_t nNum = h2SrcCLSNum->getBinContent(i, j);
+        if (nNum <= 0) continue;
+        h2Ave->setBinContent(i, j, h2SrcCLSAve->getBinContent(i, j) / nNum);
+        h2Ov5->setBinContent(i, j, h2SrcCLSOv5->getBinContent(i, j) / nNum);
+      }
     }
   }
 }

--- a/DQM/GEM/plugins/GEMDigiSource.cc
+++ b/DQM/GEM/plugins/GEMDigiSource.cc
@@ -132,7 +132,7 @@ int GEMDigiSource::ProcessWithMEMap3(BookingHelper& bh, ME3IdsKey key) {
 
   mapStripOcc_ieta_.SetBinConfX(stationInfo.nNumEtaPartitions_);
   mapStripOcc_ieta_.bookND(bh, key);
-  mapTotalDigi_layer_.SetLabelForChambers(key, 1);  // For eta partitions
+  mapTotalDigi_layer_.SetLabelForIEta(key, 1);
 
   mapStripOcc_phi_.bookND(bh, key);
   mapTotalStripPerEvt_.bookND(bh, key);
@@ -150,7 +150,7 @@ int GEMDigiSource::ProcessWithMEMap3WithChamber(BookingHelper& bh, ME4IdsKey key
   mapStripOccPerCh_.SetBinConfX(nNumCh * nNumVFATPerRoll);
   mapStripOccPerCh_.SetBinConfY(stationInfo.nNumEtaPartitions_);
   mapStripOccPerCh_.bookND(bh, key);
-  mapStripOccPerCh_.SetLabelForChambers(key, 2);  // For eta partitions
+  mapStripOccPerCh_.SetLabelForIEta(key, 2);
 
   return 0;
 }

--- a/DQM/GEM/plugins/GEMDigiSource.cc
+++ b/DQM/GEM/plugins/GEMDigiSource.cc
@@ -28,39 +28,31 @@ void GEMDigiSource::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const&, 
   nBXMax_ = 10;
 
   mapTotalDigi_layer_ = MEMap3Inf(this, "det", "Digi Occupancy", 36, 0.5, 36.5, 24, -0.5, 24 - 0.5, "Chamber", "VFAT");
-  mapDigiOcc_ieta_ = MEMap3Inf(
-      this, "occ_ieta", "Digi iEta Occupancy", 8, 0.5, 8.5, "iEta", "Number of fired digis");
-  mapDigiOcc_phi_ = MEMap3Inf(this,
-                               "occ_phi",
-                               "Digi Phi Occupancy",
-                               108,
-                               -5,
-                               355,
-                               "#phi (degree)",
-                               "Number of fired digis");
+  mapDigiOcc_ieta_ = MEMap3Inf(this, "occ_ieta", "Digi iEta Occupancy", 8, 0.5, 8.5, "iEta", "Number of fired digis");
+  mapDigiOcc_phi_ =
+      MEMap3Inf(this, "occ_phi", "Digi Phi Occupancy", 108, -5, 355, "#phi (degree)", "Number of fired digis");
   mapTotalDigiPerEvtLayer_ = MEMap3Inf(this,
-                                  "digis_per_layer",
-                                  "Total number of digis per event for each layers",
-                                  50,
-                                  -0.5,
-                                  99.5,
-                                  "Number of fired digis",
-                                  "Events");
+                                       "digis_per_layer",
+                                       "Total number of digis per event for each layers",
+                                       50,
+                                       -0.5,
+                                       99.5,
+                                       "Number of fired digis",
+                                       "Events");
   mapTotalDigiPerEvtIEta_ = MEMap3Inf(this,
-                                  "digis_per_ieta",
-                                  "Total number of digis per event for each eta partitions",
-                                  50,
-                                  -0.5,
-                                  99.5,
-                                  "Number of fired digis",
-                                  "Events");
-  
-  mapBX_iEta_ =
-      MEMap3Inf(this, "bx", "Digi Bunch Crossing", 21, nBXMin_ - 0.5, nBXMax_ + 0.5, "Bunch crossing");
+                                      "digis_per_ieta",
+                                      "Total number of digis per event for each eta partitions",
+                                      50,
+                                      -0.5,
+                                      99.5,
+                                      "Number of fired digis",
+                                      "Events");
 
-  mapDigiOccPerCh_ = MEMap4Inf(this, "occ", "Digi Occupancy", 1, 0.5, 1.5, 1, 0.5, 1.5, "Digi", "iEta");
+  mapBX_iEta_ = MEMap3Inf(this, "bx", "Digi Bunch Crossing", 21, nBXMin_ - 0.5, nBXMax_ + 0.5, "Bunch crossing");
 
-  if ( bModeRelVal_ ) {
+  mapDigiOccPerCh_ = MEMap4Inf(this, "occ", "Digi Occupancy", 1, -0.5, 1.5, 1, 0.5, 1.5, "Digi", "iEta");
+
+  if (bModeRelVal_) {
     mapTotalDigi_layer_.TurnOff();
     mapDigiOccPerCh_.TurnOff();
   }
@@ -70,7 +62,7 @@ void GEMDigiSource::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const&, 
   GenerateMEPerChamber(ibooker);
 
   h2SummaryOcc_ = nullptr;
-  if ( !bModeRelVal_ ) {
+  if (!bModeRelVal_) {
     h2SummaryOcc_ = CreateSummaryHist(ibooker, "summaryOccDigi");
     h2SummaryOcc_->setTitle("Summary of occupancy on chambers");
     h2SummaryOcc_->setXTitle("Chamber");
@@ -169,7 +161,8 @@ void GEMDigiSource::analyze(edm::Event const& event, edm::EventSetup const& even
         }
 
         // Occupancy on a chamber
-        if ( h2SummaryOcc_ ) h2SummaryOcc_->Fill(gid.chamber(), mapStationToIdx_[key3]);
+        if (h2SummaryOcc_)
+          h2SummaryOcc_->Fill(gid.chamber(), mapStationToIdx_[key3]);
 
         bTagVFAT[nIdxVFAT] = true;
       }

--- a/DQM/GEM/plugins/GEMDigiSource.cc
+++ b/DQM/GEM/plugins/GEMDigiSource.cc
@@ -1,61 +1,4 @@
-#include "FWCore/Framework/interface/ESHandle.h"
-#include "FWCore/Framework/interface/MakerMacros.h"
-#include "FWCore/PluginManager/interface/ModuleDef.h"
-#include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/Utilities/interface/InputTag.h"
-#include "FWCore/MessageLogger/interface/MessageLogger.h"
-
-#include "DQMServices/Core/interface/DQMEDAnalyzer.h"
-#include "DQMServices/Core/interface/DQMEDAnalyzer.h"
-#include "DQMServices/Core/interface/DQMStore.h"
-#include "DQMServices/Core/interface/MonitorElement.h"
-
-#include "Validation/MuonGEMHits/interface/GEMValidationUtils.h"
-
-#include "DataFormats/GEMDigi/interface/GEMDigiCollection.h"
-
-#include "DataFormats/Scalers/interface/LumiScalers.h"
-
-#include "DQM/GEM/interface/GEMDQMBase.h"
-
-#include <string>
-
-//----------------------------------------------------------------------------------------------------
-
-class GEMDigiSource : public GEMDQMBase {
-public:
-  explicit GEMDigiSource(const edm::ParameterSet& cfg);
-  ~GEMDigiSource() override{};
-  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
-
-protected:
-  void dqmBeginRun(edm::Run const&, edm::EventSetup const&) override{};
-  void bookHistograms(DQMStore::IBooker&, edm::Run const&, edm::EventSetup const&) override;
-  void analyze(edm::Event const& e, edm::EventSetup const& eSetup) override;
-
-private:
-  int ProcessWithMEMap2WithEta(BookingHelper& bh, ME3IdsKey key) override;
-  int ProcessWithMEMap3(BookingHelper& bh, ME3IdsKey key) override;
-  int ProcessWithMEMap3WithChamber(BookingHelper& bh, ME4IdsKey key) override;
-
-  edm::EDGetToken tagDigi_;
-
-  edm::EDGetTokenT<LumiScalersCollection> lumiScalers_;
-
-  MEMap3Inf mapTotalDigi_layer_;
-  MEMap3Inf mapStripOcc_ieta_;
-  MEMap3Inf mapStripOcc_phi_;
-  MEMap3Inf mapTotalStripPerEvt_;
-  MEMap3Inf mapBX_iEta_;
-
-  MEMap4Inf mapStripOccPerCh_;
-
-  MonitorElement *h2SummaryOcc, *h2SummaryMal;
-
-  Int_t nBXMin_, nBXMax_;
-};
+#include "DQM/GEM/interface/GEMDigiSource.h"
 
 using namespace std;
 using namespace edm;
@@ -64,12 +7,14 @@ GEMDigiSource::GEMDigiSource(const edm::ParameterSet& cfg) : GEMDQMBase(cfg) {
   tagDigi_ = consumes<GEMDigiCollection>(cfg.getParameter<edm::InputTag>("digisInputLabel"));
   lumiScalers_ = consumes<LumiScalersCollection>(
       cfg.getUntrackedParameter<edm::InputTag>("lumiCollection", edm::InputTag("scalersRawToDigi")));
+  bModeRelVal_ = cfg.getParameter<bool>("modeRelVal");
 }
 
 void GEMDigiSource::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
   desc.add<edm::InputTag>("digisInputLabel", edm::InputTag("muonGEMDigis", ""));
   desc.addUntracked<std::string>("logCategory", "GEMDigiSource");
+  desc.add<bool>("modeRelVal", false);
   descriptions.add("GEMDigiSource", desc);
 }
 
@@ -82,37 +27,46 @@ void GEMDigiSource::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const&, 
   nBXMin_ = -10;
   nBXMax_ = 10;
 
-  mapTotalDigi_layer_ = MEMap3Inf(this, "digi_det", "Digi Occupancy", 36, 0.5, 36.5, 24, 0.5, 24.5, "Chamber", "VFAT");
-  mapStripOcc_ieta_ = MEMap3Inf(
-      this, "strip_ieta_occ", "Strip Digi Occupancy per eta partition", 8, 0.5, 8.5, "iEta", "Number of fired strips");
-  mapStripOcc_phi_ = MEMap3Inf(this,
-                               "strip_phi_occ",
-                               "Strip Digi Phi (degree) Occupancy ",
+  mapTotalDigi_layer_ = MEMap3Inf(this, "det", "Digi Occupancy", 36, 0.5, 36.5, 24, 0.5, 24.5, "Chamber", "VFAT");
+  mapDigiOcc_ieta_ = MEMap3Inf(
+      this, "occ_ieta", "Digi Occupancy per eta partition", 8, 0.5, 8.5, "iEta", "Number of fired digis");
+  mapDigiOcc_phi_ = MEMap3Inf(this,
+                               "occ_phi",
+                               "Digi Phi (degree) Occupancy",
                                108,
                                -5,
                                355,
                                "#phi (degree)",
-                               "Number of fired strips");
-  mapTotalStripPerEvt_ = MEMap3Inf(this,
-                                   "total_strips_per_event",
-                                   "Total number of strip digis per event for each layers ",
+                               "Number of fired digis");
+  mapTotalDigiPerEvt_ = MEMap3Inf(this,
+                                   "total_digis_per_event",
+                                   "Total number of digis per event for each layers",
                                    50,
                                    -0.5,
                                    99.5,
-                                   "Number of fired strips",
+                                   "Number of fired digis",
                                    "Events");
   
   mapBX_iEta_ =
-      MEMap3Inf(this, "bx", "Strip Digi Bunch Crossing ", 21, nBXMin_ - 0.5, nBXMax_ + 0.5, "Bunch crossing");
+      MEMap3Inf(this, "bx", "Digi Bunch Crossing", 21, nBXMin_ - 0.5, nBXMax_ + 0.5, "Bunch crossing");
 
-  mapStripOccPerCh_ = MEMap4Inf(this, "strip_occ", "Strip Digi Occupancy ", 1, 0.5, 1.5, 1, 0.5, 1.5, "Strip", "iEta");
+  mapDigiOccPerCh_ = MEMap4Inf(this, "occ", "Digi Occupancy", 1, 0.5, 1.5, 1, 0.5, 1.5, "Digi", "iEta");
+
+  if ( bModeRelVal_ ) {
+    mapTotalDigi_layer_.TurnOff();
+    mapDigiOccPerCh_.TurnOff();
+  }
 
   ibooker.cd();
   ibooker.setCurrentFolder("GEM/Digis");
   GenerateMEPerChamber(ibooker);
 
-  h2SummaryOcc = CreateSummaryHist(ibooker, "summaryOccDigi");
-  h2SummaryMal = CreateSummaryHist(ibooker, "summaryMalfuncDigi");
+  h2SummaryOcc = nullptr;
+  h2SummaryMal = nullptr;
+  if ( !bModeRelVal_ ) {
+    h2SummaryOcc = CreateSummaryHist(ibooker, "summaryOccDigi");
+    h2SummaryMal = CreateSummaryHist(ibooker, "summaryMalfuncDigi");
+  }
 }
 
 int GEMDigiSource::ProcessWithMEMap2WithEta(BookingHelper& bh, ME3IdsKey key) {
@@ -130,12 +84,12 @@ int GEMDigiSource::ProcessWithMEMap3(BookingHelper& bh, ME3IdsKey key) {
   mapTotalDigi_layer_.SetLabelForChambers(key, 1);
   mapTotalDigi_layer_.SetLabelForVFATs(key, stationInfo.nNumEtaPartitions_, 2);
 
-  mapStripOcc_ieta_.SetBinConfX(stationInfo.nNumEtaPartitions_);
-  mapStripOcc_ieta_.bookND(bh, key);
+  mapDigiOcc_ieta_.SetBinConfX(stationInfo.nNumEtaPartitions_);
+  mapDigiOcc_ieta_.bookND(bh, key);
   mapTotalDigi_layer_.SetLabelForIEta(key, 1);
 
-  mapStripOcc_phi_.bookND(bh, key);
-  mapTotalStripPerEvt_.bookND(bh, key);
+  mapDigiOcc_phi_.bookND(bh, key);
+  mapTotalDigiPerEvt_.bookND(bh, key);
 
   return 0;
 }
@@ -144,13 +98,13 @@ int GEMDigiSource::ProcessWithMEMap3WithChamber(BookingHelper& bh, ME4IdsKey key
   ME3IdsKey key3 = key4Tokey3(key);
   MEStationInfo& stationInfo = mapStationInfo_[key3];
 
-  int nNumVFATPerRoll = stationInfo.nMaxVFAT_ / stationInfo.nNumEtaPartitions_;
-  int nNumCh = stationInfo.nNumStrip_;
+  int nNumVFATPerEta = stationInfo.nMaxVFAT_ / stationInfo.nNumEtaPartitions_;
+  int nNumCh = stationInfo.nNumDigi_;
 
-  mapStripOccPerCh_.SetBinConfX(nNumCh * nNumVFATPerRoll);
-  mapStripOccPerCh_.SetBinConfY(stationInfo.nNumEtaPartitions_);
-  mapStripOccPerCh_.bookND(bh, key);
-  mapStripOccPerCh_.SetLabelForIEta(key, 2);
+  mapDigiOccPerCh_.SetBinConfX(nNumCh * nNumVFATPerEta);
+  mapDigiOccPerCh_.SetBinConfY(stationInfo.nNumEtaPartitions_);
+  mapDigiOccPerCh_.bookND(bh, key);
+  mapDigiOccPerCh_.SetLabelForIEta(key, 2);
 
   return 0;
 }
@@ -161,7 +115,7 @@ void GEMDigiSource::analyze(edm::Event const& event, edm::EventSetup const& even
   edm::Handle<LumiScalersCollection> lumiScalers;
   event.getByToken(lumiScalers_, lumiScalers);
 
-  std::map<ME3IdsKey, Int_t> total_strip_layer;
+  std::map<ME3IdsKey, Int_t> total_digi_layer;
   for (const auto& ch : gemChambers_) {
     GEMDetId gid = ch.id();
     ME2IdsKey key2{gid.region(), gid.station()};
@@ -170,30 +124,30 @@ void GEMDigiSource::analyze(edm::Event const& event, edm::EventSetup const& even
     std::map<Int_t, bool> bTagVFAT;
     bTagVFAT.clear();
     const BoundPlane& surface = GEMGeometry_->idToDet(gid)->surface();
-    if (total_strip_layer.find(key3) == total_strip_layer.end())
-      total_strip_layer[key3] = 0;
+    if (total_digi_layer.find(key3) == total_digi_layer.end())
+      total_digi_layer[key3] = 0;
     for (auto iEta : ch.etaPartitions()) {
       GEMDetId eId = iEta->id();
       ME3IdsKey key3IEta{gid.region(), gid.station(), eId.ieta()};
       const auto& digis_in_det = gemDigis->get(eId);
       for (auto d = digis_in_det.first; d != digis_in_det.second; ++d) {
         // Filling of digi occupancy
-        Int_t nIdxVFAT = getVFATNumberByStrip(gid.station(), eId.ieta(), d->strip());
+        Int_t nIdxVFAT = getVFATNumberByDigi(gid.station(), eId.ieta(), d->strip());
         mapTotalDigi_layer_.Fill(key3, gid.chamber(), nIdxVFAT + 1);
 
-        // Filling of strip
-        mapStripOcc_ieta_.Fill(key3, eId.ieta());  // Roll
+        // Filling of digi
+        mapDigiOcc_ieta_.Fill(key3, eId.ieta());  // Eta (partition)
 
-        GlobalPoint strip_global_pos = surface.toGlobal(iEta->centreOfStrip(d->strip()));
-        Float_t fPhiDeg = ((Float_t)strip_global_pos.phi()) * 180.0 / 3.141592;
+        GlobalPoint digi_global_pos = surface.toGlobal(iEta->centreOfStrip(d->strip()));
+        Float_t fPhiDeg = ((Float_t)digi_global_pos.phi()) * 180.0 / 3.141592;
         if (fPhiDeg < -5.0)
           fPhiDeg += 360.0;
-        mapStripOcc_phi_.Fill(key3, fPhiDeg);  // Phi
+        mapDigiOcc_phi_.Fill(key3, fPhiDeg);  // Phi
 
-        mapStripOccPerCh_.Fill(key4Ch, d->strip(), eId.ieta());  // Per chamber
+        mapDigiOccPerCh_.Fill(key4Ch, d->strip(), eId.ieta());  // Per chamber
 
-        // For total strips
-        total_strip_layer[key3]++;
+        // For total digis
+        total_digi_layer[key3]++;
 
         // Filling of bx
         Int_t nBX = std::min(std::max((Int_t)d->bx(), nBXMin_), nBXMax_);  // For under/overflow
@@ -202,14 +156,14 @@ void GEMDigiSource::analyze(edm::Event const& event, edm::EventSetup const& even
         }
 
         // Occupancy on a chamber
-        h2SummaryOcc->Fill(gid.chamber(), mapStationToIdx_[key3]);
+        if ( h2SummaryOcc ) h2SummaryOcc->Fill(gid.chamber(), mapStationToIdx_[key3]);
 
         bTagVFAT[nIdxVFAT] = true;
       }
     }
   }
-  for (auto [key, num_total_strip] : total_strip_layer)
-    mapTotalStripPerEvt_.Fill(key, num_total_strip);
+  for (auto [key, num_total_digi] : total_digi_layer)
+    mapTotalDigiPerEvt_.Fill(key, num_total_digi);
 }
 
 DEFINE_FWK_MODULE(GEMDigiSource);

--- a/DQM/GEM/plugins/GEMDigiSource.cc
+++ b/DQM/GEM/plugins/GEMDigiSource.cc
@@ -29,23 +29,23 @@ void GEMDigiSource::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const&, 
 
   mapTotalDigi_layer_ = MEMap3Inf(this, "det", "Digi Occupancy", 36, 0.5, 36.5, 24, 0.5, 24.5, "Chamber", "VFAT");
   mapDigiOcc_ieta_ = MEMap3Inf(
-      this, "occ_ieta", "Digi Occupancy per eta partition", 8, 0.5, 8.5, "iEta", "Number of fired digis");
+      this, "occ_ieta", "Digi iEta Occupancy", 8, 0.5, 8.5, "iEta", "Number of fired digis");
   mapDigiOcc_phi_ = MEMap3Inf(this,
                                "occ_phi",
-                               "Digi Phi (degree) Occupancy",
+                               "Digi Phi Occupancy",
                                108,
                                -5,
                                355,
                                "#phi (degree)",
                                "Number of fired digis");
   mapTotalDigiPerEvt_ = MEMap3Inf(this,
-                                   "total_digis_per_event",
-                                   "Total number of digis per event for each layers",
-                                   50,
-                                   -0.5,
-                                   99.5,
-                                   "Number of fired digis",
-                                   "Events");
+                                  "digis_per_layer",
+                                  "Total number of digis per event for each layers",
+                                  50,
+                                  -0.5,
+                                  99.5,
+                                  "Number of fired digis",
+                                  "Events");
   
   mapBX_iEta_ =
       MEMap3Inf(this, "bx", "Digi Bunch Crossing", 21, nBXMin_ - 0.5, nBXMax_ + 0.5, "Bunch crossing");
@@ -61,11 +61,11 @@ void GEMDigiSource::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const&, 
   ibooker.setCurrentFolder("GEM/Digis");
   GenerateMEPerChamber(ibooker);
 
-  h2SummaryOcc = nullptr;
-  h2SummaryMal = nullptr;
+  h2SummaryOcc_ = nullptr;
   if ( !bModeRelVal_ ) {
-    h2SummaryOcc = CreateSummaryHist(ibooker, "summaryOccDigi");
-    h2SummaryMal = CreateSummaryHist(ibooker, "summaryMalfuncDigi");
+    h2SummaryOcc_ = CreateSummaryHist(ibooker, "summaryOccDigi");
+    h2SummaryOcc_->setTitle("Summary of occupancy on chambers");
+    h2SummaryOcc_->setXTitle("Chamber");
   }
 }
 
@@ -156,7 +156,7 @@ void GEMDigiSource::analyze(edm::Event const& event, edm::EventSetup const& even
         }
 
         // Occupancy on a chamber
-        if ( h2SummaryOcc ) h2SummaryOcc->Fill(gid.chamber(), mapStationToIdx_[key3]);
+        if ( h2SummaryOcc_ ) h2SummaryOcc_->Fill(gid.chamber(), mapStationToIdx_[key3]);
 
         bTagVFAT[nIdxVFAT] = true;
       }

--- a/DQM/GEM/plugins/GEMDigiSource.cc
+++ b/DQM/GEM/plugins/GEMDigiSource.cc
@@ -48,11 +48,9 @@ private:
   MEMap3Inf mapStripOcc_ieta_;
   MEMap3Inf mapStripOcc_phi_;
   MEMap3Inf mapTotalStripPerEvt_;
-  //MEMap3Inf mapBX_layer_;
   MEMap3Inf mapBX_iEta_;
 
   MEMap4Inf mapStripOccPerCh_;
-  MEMap4Inf mapBXPerCh_;
 
   MonitorElement *h2SummaryOcc, *h2SummaryMal;
 
@@ -104,26 +102,13 @@ void GEMDigiSource::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const&, 
                                    "Number of fired strips",
                                    "Events");
   
-  //mapBX_layer_ =
-  //    MEMap3Inf(this, "bx", "Strip Digi Bunch Crossing ", 21, nBXMin_ - 0.5, nBXMax_ + 0.5, "Bunch crossing");
   mapBX_iEta_ =
       MEMap3Inf(this, "bx", "Strip Digi Bunch Crossing ", 21, nBXMin_ - 0.5, nBXMax_ + 0.5, "Bunch crossing");
 
   mapStripOccPerCh_ = MEMap4Inf(this, "strip_occ", "Strip Digi Occupancy ", 1, 0.5, 1.5, 1, 0.5, 1.5, "Strip", "iEta");
-  mapBXPerCh_ = MEMap4Inf(this,
-                          "bx_ch",
-                          "Strip Digi Bunch Crossing ",
-                          21,
-                          nBXMin_ - 0.5,
-                          nBXMax_ + 0.5,
-                          1,
-                          0.5,
-                          1.5,
-                          "Bunch crossing",
-                          "VFAT");
 
   ibooker.cd();
-  ibooker.setCurrentFolder("GEM/digi");
+  ibooker.setCurrentFolder("GEM/Digis");
   GenerateMEPerChamber(ibooker);
 
   h2SummaryOcc = CreateSummaryHist(ibooker, "summaryOccDigi");
@@ -151,7 +136,6 @@ int GEMDigiSource::ProcessWithMEMap3(BookingHelper& bh, ME3IdsKey key) {
 
   mapStripOcc_phi_.bookND(bh, key);
   mapTotalStripPerEvt_.bookND(bh, key);
-  //mapBX_layer_.bookND(bh, key);
 
   return 0;
 }
@@ -167,10 +151,6 @@ int GEMDigiSource::ProcessWithMEMap3WithChamber(BookingHelper& bh, ME4IdsKey key
   mapStripOccPerCh_.SetBinConfY(stationInfo.nNumEtaPartitions_);
   mapStripOccPerCh_.bookND(bh, key);
   mapStripOccPerCh_.SetLabelForChambers(key, 2);  // For eta partitions
-
-  mapBXPerCh_.SetBinConfY(stationInfo.nMaxVFAT_);
-  mapBXPerCh_.bookND(bh, key);
-  mapBXPerCh_.SetLabelForVFATs(key, stationInfo.nNumEtaPartitions_, 2);
 
   return 0;
 }
@@ -218,9 +198,7 @@ void GEMDigiSource::analyze(edm::Event const& event, edm::EventSetup const& even
         // Filling of bx
         Int_t nBX = std::min(std::max((Int_t)d->bx(), nBXMin_), nBXMax_);  // For under/overflow
         if (bTagVFAT.find(nIdxVFAT) == bTagVFAT.end()) {
-          //mapBX_layer_.Fill(key3, nBX);
           mapBX_iEta_.Fill(key3IEta, nBX);
-          mapBXPerCh_.Fill(key4Ch, nBX, nIdxVFAT);
         }
 
         // Occupancy on a chamber

--- a/DQM/GEM/plugins/GEMRecHitSource.cc
+++ b/DQM/GEM/plugins/GEMRecHitSource.cc
@@ -1,70 +1,4 @@
-#include "DQM/GEM/interface/GEMDQMBase.h"
-
-#include "DataFormats/GEMRecHit/interface/GEMRecHit.h"
-#include "DataFormats/GEMRecHit/interface/GEMRecHitCollection.h"
-#include "DataFormats/GEMDigi/interface/GEMDigiCollection.h"
-
-#include <string>
-
-//----------------------------------------------------------------------------------------------------
-
-class GEMRecHitSource : public GEMDQMBase {
-public:
-  explicit GEMRecHitSource(const edm::ParameterSet& cfg);
-  ~GEMRecHitSource() override{};
-  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
-
-  typedef std::map<ME4IdsKey, std::map<Int_t, Int_t>> ME5map;
-
-protected:
-  void dqmBeginRun(edm::Run const&, edm::EventSetup const&) override{};
-  void bookHistograms(DQMStore::IBooker&, edm::Run const&, edm::EventSetup const&) override;
-  void analyze(edm::Event const& e, edm::EventSetup const& eSetup) override;
-
-private:
-  int ProcessWithMEMap2WithEta(BookingHelper& bh, ME3IdsKey key) override;
-  int ProcessWithMEMap2AbsReWithEta(BookingHelper& bh, ME3IdsKey key) override;
-  int ProcessWithMEMap3(BookingHelper& bh, ME3IdsKey key) override;
-  int ProcessWithMEMap4(BookingHelper& bh, ME4IdsKey key) override;
-  int ProcessWithMEMap3WithChamber(BookingHelper& bh, ME4IdsKey key) override;
-  
-  void InitKey5MultiMap(ME5map &map, ME4IdsKey key1, Int_t key2) {
-    if (map.find(key1) == map.end()) map[key1][key2] = 0;
-    else if (map[key1].find(key2) == map[key1].end()) map[key1][key2] = 0;
-  };
-
-  edm::EDGetToken tagRecHit_;
-
-  float fGlobXMin_, fGlobXMax_;
-  float fGlobYMin_, fGlobYMax_;
-
-  int nIdxFirstStrip_;
-  int nClusterSizeBinNum_;
-
-  MEMap3Inf mapTotalRecHit_layer_;
-  MEMap3Inf mapRecHitWheel_layer_;
-  MEMap3Inf mapRecHitOcc_ieta_;
-  MEMap3Inf mapRecHitOcc_phi_;
-  MEMap3Inf mapTotalRecHitPerEvtLayer_;
-  MEMap3Inf mapTotalRecHitPerEvtIEta_;
-  //MEMap4Inf mapCLSRecHit_ieta_;
-  MEMap3Inf mapCLSRecHit_ieta_;
-  MEMap3Inf mapCLSNumber_;
-  MEMap3Inf mapCLSAverage_;
-  MEMap3Inf mapCLSOver5_;
-
-  MEMap4Inf mapCLSPerCh_;
-
-  Int_t nCLSMax_;
-  Float_t fRadiusMin_;
-  Float_t fRadiusMax_;
-
-  std::unordered_map<UInt_t, MonitorElement*> recHitME_;
-  std::unordered_map<UInt_t, MonitorElement*> VFAT_vs_ClusterSize_;
-  std::unordered_map<UInt_t, MonitorElement*> StripsFired_vs_eta_;
-  std::unordered_map<UInt_t, MonitorElement*> rh_vs_eta_;
-  std::unordered_map<UInt_t, MonitorElement*> recGlobalPos;
-};
+#include "DQM/GEM/interface/GEMRecHitSource.h"
 
 using namespace std;
 using namespace edm;
@@ -72,26 +6,18 @@ using namespace edm;
 GEMRecHitSource::GEMRecHitSource(const edm::ParameterSet& cfg) : GEMDQMBase(cfg) {
   tagRecHit_ = consumes<GEMRecHitCollection>(cfg.getParameter<edm::InputTag>("recHitsInputLabel"));
 
-  nIdxFirstStrip_ = cfg.getParameter<int>("idxFirstStrip");
+  nIdxFirstDigi_ = cfg.getParameter<int>("idxFirstDigi");
   nClusterSizeBinNum_ = cfg.getParameter<int>("ClusterSizeBinNum");
-
-  fGlobXMin_ = cfg.getParameter<double>("global_x_bound_min");
-  fGlobXMax_ = cfg.getParameter<double>("global_x_bound_max");
-  fGlobYMin_ = cfg.getParameter<double>("global_y_bound_min");
-  fGlobYMax_ = cfg.getParameter<double>("global_y_bound_max");
+  bModeRelVal_ = cfg.getParameter<bool>("modeRelVal");
 }
 
 void GEMRecHitSource::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
   desc.add<edm::InputTag>("recHitsInputLabel", edm::InputTag("gemRecHits", ""));
 
-  desc.add<int>("idxFirstStrip", 0);
+  desc.add<int>("idxFirstDigi", 0);
   desc.add<int>("ClusterSizeBinNum", 9);
-
-  desc.add<double>("global_x_bound_min", -350);
-  desc.add<double>("global_x_bound_max", 350);
-  desc.add<double>("global_y_bound_min", -260);
-  desc.add<double>("global_y_bound_max", 260);
+  desc.add<bool>("modeRelVal", false);
 
   desc.addUntracked<std::string>("logCategory", "GEMRecHitSource");
 
@@ -116,39 +42,88 @@ void GEMRecHitSource::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const&
   float radL = 355.0 / 180 * 3.141592;
 
   mapTotalRecHit_layer_ =
-      MEMap3Inf(this, "rechit_det", "Rec. Hit Occupancy", 36, 0.5, 36.5, 8, 0.5, 8.5, "Chamber", "iEta");
+      MEMap3Inf(this, "det", "RecHit Occupancy", 36, 0.5, 36.5, 8, 0.5, 8.5, "Chamber", "iEta");
   mapRecHitWheel_layer_ =
-      MEMap3Inf(this, "rechit_wheel", "Rec. Hit Wheel Occupancy", 108, radS, radL, 8, fRadiusMin_, fRadiusMax_, "", "");
+      MEMap3Inf(this, "wheel", "RecHit Wheel Occupancy", 108, radS, radL, 8, fRadiusMin_, fRadiusMax_, "", "");
   mapRecHitOcc_ieta_ = MEMap3Inf(
-      this, "rechit_ieta_occ", "RecHit Digi Occupancy per eta partition", 8, 0.5, 8.5, "iEta", "Number of recHits");
+      this, "occ_ieta", "RecHit Digi Occupancy per eta partition", 8, 0.5, 8.5, "iEta", "Number of RecHits");
   mapRecHitOcc_phi_ = MEMap3Inf(
-      this, "rechit_phi_occ", "RecHit Digi Phi (degree) Occupancy ", 108, -5, 355, "#phi (degree)", "Number of recHits");
+      this, "occ_phi", "RecHit Digi Phi (degree) Occupancy", 108, -5, 355, "#phi (degree)", "Number of RecHits");
   mapTotalRecHitPerEvtLayer_ = MEMap3Inf(this,
                                          "total_rechit_per_event",
-                                         "Total number of rec. hits per event for each layers ",
+                                         "Total number of RecHits per event for each layers",
                                          50,
                                          -0.5,
                                          99.5,
-                                         "Number of recHits",
+                                         "Number of RecHits",
                                          "Events");
   mapTotalRecHitPerEvtIEta_ = MEMap3Inf(this,
                                         "total_rechit_per_event",
-                                        "Total number of rec. hits per event for each eta partitions ",
+                                        "Total number of RecHits per event for each eta partitions",
                                         50,
                                         -0.5,
                                         99.5,
-                                        "Number of recHits",
+                                        "Number of RecHits",
                                         "Events");
-  //mapCLSRecHit_ieta_ = MEMap4Inf(
-  //    this, "cls", "Cluster size of rec. hits", nCLSMax_, 0.5, nCLSMax_ + 0.5, "Cluster size", "Number of recHits");
   mapCLSRecHit_ieta_ = MEMap3Inf(
-      this, "cls", "Cluster size of rec. hits", nCLSMax_, 0.5, nCLSMax_ + 0.5, "Cluster size", "Number of recHits");
-  mapCLSNumber_  = MEMap3Inf(this, "rechitNumber", "", 36, 0.5, 36.5, 8, 0.5, 8.5, "Chamber", "iEta");
-  mapCLSAverage_ = MEMap3Inf(this, "rechit_average_pre", "", 36, 0.5, 36.5, 8, 0.5, 8.5, "Chamber", "iEta");
-  mapCLSOver5_   = MEMap3Inf(this, "rechit_over5_pre", "", 36, 0.5, 36.5, 8, 0.5, 8.5, "Chamber", "iEta");
+      this, "cls", "Cluster size of RecHits", nCLSMax_, 0.5, nCLSMax_ + 0.5, "Cluster size", "Number of RecHits");
+  mapCLSNumberAve_ = MEMap3Inf(this, 
+                               "rechitNumberAve", 
+                               "Number of RecHits as a function of chambers vs iEta", 
+                               36, 
+                               0.5, 
+                               36.5, 
+                               8, 
+                               0.5, 
+                               8.5, 
+                               "Chamber", 
+                               "iEta");
+  mapCLSNumberOv5_ = MEMap3Inf(this, 
+                               "rechitNumberOv5", 
+                               "Number of RecHits with cluster size>5 as a function of chambers vs iEta", 
+                               36, 
+                               0.5, 
+                               36.5, 
+                               8, 
+                               0.5, 
+                               8.5, 
+                               "Chamber", 
+                               "iEta");
+  mapCLSAverage_   = MEMap3Inf(this, 
+                               "rechit_average_pre", 
+                               "Average of Cluster Sizes", 
+                               36, 
+                               0.5, 
+                               36.5, 
+                               8, 
+                               0.5, 
+                               8.5, 
+                               "Chamber", 
+                               "iEta");
+  mapCLSOver5_     = MEMap3Inf(this, 
+                               "rechit_over5_pre", 
+                               "Average of Cluster Sizes (> 5)", 
+                               36, 
+                               0.5, 
+                               36.5, 
+                               8, 
+                               0.5, 
+                               8.5, 
+                               "Chamber", 
+                               "iEta");
 
   mapCLSPerCh_ = MEMap4Inf(
-      this, "cls", "Cluster size of rec. hits", nCLSMax_, 0.5, nCLSMax_ + 0.5, 1, 0.5, 1.5, "Cluster size", "iEta");
+      this, "cls", "Cluster size of RecHits", nCLSMax_, 0.5, nCLSMax_ + 0.5, 1, 0.5, 1.5, "Cluster size", "iEta");
+
+  if ( bModeRelVal_ ) {
+    mapTotalRecHit_layer_.TurnOff();
+    mapRecHitWheel_layer_.TurnOff();
+    mapCLSNumberAve_.TurnOff();
+    mapCLSNumberOv5_.TurnOff();
+    mapCLSAverage_.TurnOff();
+    mapCLSOver5_.TurnOff();
+    mapCLSPerCh_.TurnOff();
+  }
 
   GenerateMEPerChamber(ibooker);
 }
@@ -189,19 +164,14 @@ int GEMRecHitSource::ProcessWithMEMap3(BookingHelper& bh, ME3IdsKey key) {
   mapTotalRecHitPerEvtLayer_.bookND(bh, key);
   mapTotalRecHitPerEvtIEta_.bookND(bh, key);
 
-  mapCLSNumber_.bookND(bh, key);
+  mapCLSNumberAve_.bookND(bh, key);
+  mapCLSNumberOv5_.bookND(bh, key);
   mapCLSAverage_.bookND(bh, key);
   mapCLSOver5_.bookND(bh, key);
   mapCLSAverage_.SetLabelForChambers(key, 1);
   mapCLSAverage_.SetLabelForIEta(key, 2);
   mapCLSOver5_.SetLabelForChambers(key, 1);
   mapCLSOver5_.SetLabelForIEta(key, 2);
-
-  return 0;
-}
-
-int GEMRecHitSource::ProcessWithMEMap4(BookingHelper& bh, ME4IdsKey key) {
-  //mapCLSRecHit_ieta_.bookND(bh, key);
 
   return 0;
 }
@@ -221,13 +191,14 @@ void GEMRecHitSource::analyze(edm::Event const& event, edm::EventSetup const& ev
   edm::Handle<GEMRecHitCollection> gemRecHits;
   event.getByToken(this->tagRecHit_, gemRecHits);
   if (!gemRecHits.isValid()) {
-    edm::LogError(log_category_) << "GEM recHit is not valid.\n";
+    edm::LogError(log_category_) << "GEM RecHit is not valid.\n";
     return;
   }
 
   std::map<ME3IdsKey, Int_t> total_rechit_layer;
   std::map<ME3IdsKey, Int_t> total_rechit_iEta;
-  ME5map mapCLSNumber;
+  ME5map mapCLSNumberAve;
+  ME5map mapCLSNumberOv5;
   ME5map mapCLSAverage;
   ME5map mapCLSOver5;
 
@@ -244,48 +215,52 @@ void GEMRecHitSource::analyze(edm::Event const& event, edm::EventSetup const& ev
       ME4IdsKey key4IEta{gid.region(), gid.station(), gid.layer(), eId.ieta()};
 
       if (total_rechit_layer.find(key3) == total_rechit_layer.end()) total_rechit_layer[key3] = 0;
-      InitKey5MultiMap(mapCLSNumber,  key4IEta, chamber);
-      InitKey5MultiMap(mapCLSAverage, key4IEta, chamber);
-      InitKey5MultiMap(mapCLSOver5,   key4IEta, chamber);
+      InitKey5MultiMap(mapCLSNumberAve, key4IEta, chamber);
+      InitKey5MultiMap(mapCLSNumberOv5, key4IEta, chamber);
+      InitKey5MultiMap(mapCLSAverage,   key4IEta, chamber);
+      InitKey5MultiMap(mapCLSOver5,     key4IEta, chamber);
 
       const auto& recHitsRange = gemRecHits->get(eId);
       auto gemRecHit = recHitsRange.first;
-      Int_t nNumRecHit = 0;
+      Int_t nNumRecHitAve = 0, nNumRecHitOv5 = 0;
       for (auto hit = gemRecHit; hit != recHitsRange.second; ++hit) {
         GlobalPoint recHitGP = GEMGeometry_->idToDet(hit->gemId())->surface().toGlobal(hit->localPosition());
         Float_t fPhi = recHitGP.phi();
         if (fPhi < -5.0 / 180.0 * 3.141592)
           fPhi += 2 * 3.141592;
 
-        // Filling of recHit occupancy
+        // Filling of RecHit occupancy
         mapTotalRecHit_layer_.Fill(key3, chamber, eId.ieta());
 
         // Filling of wheel occupancy
         Float_t fR = fRadiusMin_ + (fRadiusMax_ - fRadiusMin_) * (eId.ieta() - 0.5) / stationInfo.nNumEtaPartitions_;
         mapRecHitWheel_layer_.Fill(key3, fPhi, fR);
 
-        // Filling of strip (iEta)
+        // Filling of RecHit (iEta)
         mapRecHitOcc_ieta_.Fill(key3, eId.ieta());
 
-        // Filling of strip (phi)
+        // Filling of RecHit (phi)
         Float_t fPhiDeg = fPhi * 180.0 / 3.141592;
         mapRecHitOcc_phi_.Fill(key3, fPhiDeg);
 
-        // For total recHits
+        // For total RecHits
         total_rechit_layer[key3]++;
         total_rechit_iEta[key3IEta]++;
 
         // Filling of cluster size (CLS)
         Int_t nCLS = hit->clusterSize();
         Int_t nCLSCutOff = std::min(nCLS, nCLSMax_);  // For overflow
-        //mapCLSRecHit_ieta_.Fill(key4IEta, nCLS);
         mapCLSRecHit_ieta_.Fill(key3AbsReIEta, nCLSCutOff);
         mapCLSPerCh_.Fill(key4Ch, eId.ieta(), nCLSCutOff);
         mapCLSAverage[key4IEta][chamber] += nCLS;
-        if ( nCLS > 5 ) mapCLSOver5[key4IEta][chamber] += nCLS;
-        nNumRecHit++;
+        nNumRecHitAve++;
+        if ( nCLS > 5 ) {
+          mapCLSOver5[key4IEta][chamber] += nCLS;
+          nNumRecHitOv5++;
+        }
       }
-      mapCLSNumber[key4IEta][chamber] = nNumRecHit;
+      mapCLSNumberAve[key4IEta][chamber] = nNumRecHitAve;
+      mapCLSNumberOv5[key4IEta][chamber] = nNumRecHitOv5;
     }
   }
   for (auto [key, num_total_rechit] : total_rechit_layer) {
@@ -294,13 +269,20 @@ void GEMRecHitSource::analyze(edm::Event const& event, edm::EventSetup const& ev
   for (auto [key, num_total_rechit] : total_rechit_iEta) {
     mapTotalRecHitPerEvtIEta_.Fill(key, num_total_rechit);
   }
-  for (auto [key, mapSub] : mapCLSNumber) {
+  for (auto [key, mapSub] : mapCLSNumberAve) {
     for (auto [chamber, nNumRecHit] : mapSub) {
       auto key3 = key4Tokey3(key);
       auto ieta = keyToIEta(key);
-      mapCLSNumber_.Fill(key3,  chamber, ieta, nNumRecHit);
+      mapCLSNumberAve_.Fill(key3, chamber, ieta, nNumRecHit);
       mapCLSAverage_.Fill(key3, chamber, ieta, mapCLSAverage[key][chamber]);
-      mapCLSOver5_.Fill(key3,   chamber, ieta, mapCLSOver5[key][chamber]);
+    }
+  }
+  for (auto [key, mapSub] : mapCLSNumberOv5) {
+    for (auto [chamber, nNumRecHit] : mapSub) {
+      auto key3 = key4Tokey3(key);
+      auto ieta = keyToIEta(key);
+      mapCLSNumberOv5_.Fill(key3, chamber, ieta, nNumRecHit);
+      mapCLSOver5_.Fill(key3, chamber, ieta, mapCLSOver5[key][chamber]);
     }
   }
 }

--- a/DQM/GEM/plugins/GEMRecHitSource.cc
+++ b/DQM/GEM/plugins/GEMRecHitSource.cc
@@ -41,14 +41,12 @@ void GEMRecHitSource::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const&
   float radS = -5.0 / 180 * 3.141592;
   float radL = 355.0 / 180 * 3.141592;
 
-  mapTotalRecHit_layer_ =
-      MEMap3Inf(this, "det", "RecHit Occupancy", 36, 0.5, 36.5, 8, 0.5, 8.5, "Chamber", "iEta");
-  mapRecHitWheel_layer_ =
-      MEMap3Inf(this, "rphi_occ", "RecHit R-Phi Occupancy", 108, radS, radL, 8, fRadiusMin_, fRadiusMax_, "#phi (rad)", "R [cm]");
-  mapRecHitOcc_ieta_ = MEMap3Inf(
-      this, "occ_ieta", "RecHit iEta Occupancy", 8, 0.5, 8.5, "iEta", "Number of RecHits");
-  mapRecHitOcc_phi_ = MEMap3Inf(
-      this, "occ_phi", "RecHit Phi Occupancy", 108, -5, 355, "#phi (degree)", "Number of RecHits");
+  mapTotalRecHit_layer_ = MEMap3Inf(this, "det", "RecHit Occupancy", 36, 0.5, 36.5, 8, 0.5, 8.5, "Chamber", "iEta");
+  mapRecHitWheel_layer_ = MEMap3Inf(
+      this, "rphi_occ", "RecHit R-Phi Occupancy", 108, radS, radL, 8, fRadiusMin_, fRadiusMax_, "#phi (rad)", "R [cm]");
+  mapRecHitOcc_ieta_ = MEMap3Inf(this, "occ_ieta", "RecHit iEta Occupancy", 8, 0.5, 8.5, "iEta", "Number of RecHits");
+  mapRecHitOcc_phi_ =
+      MEMap3Inf(this, "occ_phi", "RecHit Phi Occupancy", 108, -5, 355, "#phi (degree)", "Number of RecHits");
   mapTotalRecHitPerEvtLayer_ = MEMap3Inf(this,
                                          "rechits_per_layer",
                                          "Total number of RecHits per event for each layers",
@@ -67,35 +65,26 @@ void GEMRecHitSource::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const&
                                         "Events");
   mapCLSRecHit_ieta_ = MEMap3Inf(
       this, "cls", "Cluster size of RecHits", nCLSMax_, 0.5, nCLSMax_ + 0.5, "Cluster size", "Number of RecHits");
-  mapCLSAverage_ = MEMap3Inf(this,   // TProfile2D
-                             "rechit_average", 
-                             "Average of Cluster Sizes", 
-                             36, 
-                             0.5, 
-                             36.5, 
-                             8, 
-                             0.5, 
-                             8.5, 
-                             0, 
+  mapCLSAverage_ = MEMap3Inf(this,  // TProfile2D
+                             "rechit_average",
+                             "Average of Cluster Sizes",
+                             36,
+                             0.5,
+                             36.5,
+                             8,
+                             0.5,
+                             8.5,
+                             0,
                              400,  // For satefy, larger than 384
-                             "Chamber", 
+                             "Chamber",
                              "iEta");
-  mapCLSOver5_   = MEMap3Inf(this, 
-                             "largeCls_occ", 
-                             "Occupancy of Large Clusters (>5)", 
-                             36, 
-                             0.5, 
-                             36.5, 
-                             8, 
-                             0.5, 
-                             8.5, 
-                             "Chamber", 
-                             "iEta");
+  mapCLSOver5_ = MEMap3Inf(
+      this, "largeCls_occ", "Occupancy of Large Clusters (>5)", 36, 0.5, 36.5, 8, 0.5, 8.5, "Chamber", "iEta");
 
   mapCLSPerCh_ = MEMap4Inf(
       this, "cls", "Cluster size of RecHits", nCLSMax_, 0.5, nCLSMax_ + 0.5, 1, 0.5, 1.5, "Cluster size", "iEta");
 
-  if ( bModeRelVal_ ) {
+  if (bModeRelVal_) {
     mapTotalRecHit_layer_.TurnOff();
     mapRecHitWheel_layer_.TurnOff();
     mapCLSAverage_.TurnOff();
@@ -187,7 +176,8 @@ void GEMRecHitSource::analyze(edm::Event const& event, edm::EventSetup const& ev
       ME3IdsKey key3AbsReIEta{std::abs(gid.region()), gid.station(), eId.ieta()};
       ME4IdsKey key4IEta{gid.region(), gid.station(), gid.layer(), eId.ieta()};
 
-      if (total_rechit_layer.find(key3) == total_rechit_layer.end()) total_rechit_layer[key3] = 0;
+      if (total_rechit_layer.find(key3) == total_rechit_layer.end())
+        total_rechit_layer[key3] = 0;
 
       const auto& recHitsRange = gemRecHits->get(eId);
       auto gemRecHit = recHitsRange.first;
@@ -221,7 +211,8 @@ void GEMRecHitSource::analyze(edm::Event const& event, edm::EventSetup const& ev
         mapCLSRecHit_ieta_.Fill(key3AbsReIEta, nCLSCutOff);
         mapCLSPerCh_.Fill(key4Ch, eId.ieta(), nCLSCutOff);
         mapCLSAverage_.Fill(key3, (Double_t)chamber, (Double_t)eId.ieta(), nCLS);
-        if ( nCLS > 5 ) mapCLSOver5[key4IEta][chamber] = true;
+        if (nCLS > 5)
+          mapCLSOver5[key4IEta][chamber] = true;
       }
     }
   }

--- a/DQM/GEM/plugins/GEMRecHitSource.cc
+++ b/DQM/GEM/plugins/GEMRecHitSource.cc
@@ -209,7 +209,7 @@ void GEMRecHitSource::analyze(edm::Event const& event, edm::EventSetup const& ev
         Int_t nCLS = hit->clusterSize();
         Int_t nCLSCutOff = std::min(nCLS, nCLSMax_);  // For overflow
         mapCLSRecHit_ieta_.Fill(key3AbsReIEta, nCLSCutOff);
-        mapCLSPerCh_.Fill(key4Ch, eId.ieta(), nCLSCutOff);
+        mapCLSPerCh_.Fill(key4Ch, nCLSCutOff, eId.ieta());
         mapCLSAverage_.Fill(key3, (Double_t)chamber, (Double_t)eId.ieta(), nCLS);
         if (nCLS > 5)
           mapCLSOver5[key4IEta][chamber] = true;

--- a/DQM/GEM/plugins/GEMRecHitSource.cc
+++ b/DQM/GEM/plugins/GEMRecHitSource.cc
@@ -174,7 +174,7 @@ int GEMRecHitSource::ProcessWithMEMap3(BookingHelper& bh, ME3IdsKey key) {
   mapTotalRecHit_layer_.SetBinConfY(stationInfo.nNumEtaPartitions_);
   mapTotalRecHit_layer_.bookND(bh, key);
   mapTotalRecHit_layer_.SetLabelForChambers(key, 1);
-  mapTotalRecHit_layer_.SetLabelForChambers(key, 2);  // No worries, it's same as the eta partition labelling
+  mapTotalRecHit_layer_.SetLabelForIEta(key, 2);
 
   mapRecHitWheel_layer_.SetBinLowEdgeX(-0.088344);  // FIXME: It could be different for other stations...
   mapRecHitWheel_layer_.SetBinHighEdgeX(-0.088344 + 2 * 3.141592);
@@ -192,6 +192,10 @@ int GEMRecHitSource::ProcessWithMEMap3(BookingHelper& bh, ME3IdsKey key) {
   mapCLSNumber_.bookND(bh, key);
   mapCLSAverage_.bookND(bh, key);
   mapCLSOver5_.bookND(bh, key);
+  mapCLSAverage_.SetLabelForChambers(key, 1);
+  mapCLSAverage_.SetLabelForIEta(key, 2);
+  mapCLSOver5_.SetLabelForChambers(key, 1);
+  mapCLSOver5_.SetLabelForIEta(key, 2);
 
   return 0;
 }
@@ -208,7 +212,7 @@ int GEMRecHitSource::ProcessWithMEMap3WithChamber(BookingHelper& bh, ME4IdsKey k
 
   mapCLSPerCh_.SetBinConfY(stationInfo.nNumEtaPartitions_);
   mapCLSPerCh_.bookND(bh, key);
-  mapCLSPerCh_.SetLabelForChambers(key, 2);  // For eta partitions
+  mapCLSPerCh_.SetLabelForIEta(key, 2);
 
   return 0;
 }

--- a/DQM/GEM/plugins/GEMRecHitSource.cc
+++ b/DQM/GEM/plugins/GEMRecHitSource.cc
@@ -14,15 +14,24 @@ public:
   ~GEMRecHitSource() override{};
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
+  typedef std::map<ME4IdsKey, std::map<Int_t, Int_t>> ME5map;
+
 protected:
   void dqmBeginRun(edm::Run const&, edm::EventSetup const&) override{};
   void bookHistograms(DQMStore::IBooker&, edm::Run const&, edm::EventSetup const&) override;
   void analyze(edm::Event const& e, edm::EventSetup const& eSetup) override;
 
 private:
+  int ProcessWithMEMap2WithEta(BookingHelper& bh, ME3IdsKey key) override;
+  int ProcessWithMEMap2AbsReWithEta(BookingHelper& bh, ME3IdsKey key) override;
   int ProcessWithMEMap3(BookingHelper& bh, ME3IdsKey key) override;
   int ProcessWithMEMap4(BookingHelper& bh, ME4IdsKey key) override;
   int ProcessWithMEMap3WithChamber(BookingHelper& bh, ME4IdsKey key) override;
+  
+  void InitKey5MultiMap(ME5map &map, ME4IdsKey key1, Int_t key2) {
+    if (map.find(key1) == map.end()) map[key1][key2] = 0;
+    else if (map[key1].find(key2) == map[key1].end()) map[key1][key2] = 0;
+  };
 
   edm::EDGetToken tagRecHit_;
 
@@ -36,8 +45,13 @@ private:
   MEMap3Inf mapRecHitWheel_layer_;
   MEMap3Inf mapRecHitOcc_ieta_;
   MEMap3Inf mapRecHitOcc_phi_;
-  MEMap3Inf mapTotalRecHitPerEvt_;
-  MEMap4Inf mapCLSRecHit_ieta_;
+  MEMap3Inf mapTotalRecHitPerEvtLayer_;
+  MEMap3Inf mapTotalRecHitPerEvtIEta_;
+  //MEMap4Inf mapCLSRecHit_ieta_;
+  MEMap3Inf mapCLSRecHit_ieta_;
+  MEMap3Inf mapCLSNumber_;
+  MEMap3Inf mapCLSAverage_;
+  MEMap3Inf mapCLSOver5_;
 
   MEMap4Inf mapCLSPerCh_;
 
@@ -109,21 +123,46 @@ void GEMRecHitSource::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const&
       this, "rechit_ieta_occ", "RecHit Digi Occupancy per eta partition", 8, 0.5, 8.5, "iEta", "Number of recHits");
   mapRecHitOcc_phi_ = MEMap3Inf(
       this, "rechit_phi_occ", "RecHit Digi Phi (degree) Occupancy ", 108, -5, 355, "#phi (degree)", "Number of recHits");
-  mapTotalRecHitPerEvt_ = MEMap3Inf(this,
-                                    "total_rechit_per_event",
-                                    "Total number of rec. hits per event for each layers ",
-                                    50,
-                                    -0.5,
-                                    99.5,
-                                    "Number of recHits",
-                                    "Events");
-  mapCLSRecHit_ieta_ = MEMap4Inf(
+  mapTotalRecHitPerEvtLayer_ = MEMap3Inf(this,
+                                         "total_rechit_per_event",
+                                         "Total number of rec. hits per event for each layers ",
+                                         50,
+                                         -0.5,
+                                         99.5,
+                                         "Number of recHits",
+                                         "Events");
+  mapTotalRecHitPerEvtIEta_ = MEMap3Inf(this,
+                                        "total_rechit_per_event",
+                                        "Total number of rec. hits per event for each eta partitions ",
+                                        50,
+                                        -0.5,
+                                        99.5,
+                                        "Number of recHits",
+                                        "Events");
+  //mapCLSRecHit_ieta_ = MEMap4Inf(
+  //    this, "cls", "Cluster size of rec. hits", nCLSMax_, 0.5, nCLSMax_ + 0.5, "Cluster size", "Number of recHits");
+  mapCLSRecHit_ieta_ = MEMap3Inf(
       this, "cls", "Cluster size of rec. hits", nCLSMax_, 0.5, nCLSMax_ + 0.5, "Cluster size", "Number of recHits");
+  mapCLSNumber_  = MEMap3Inf(this, "rechitNumber", "", 36, 0.5, 36.5, 8, 0.5, 8.5, "Chamber", "iEta");
+  mapCLSAverage_ = MEMap3Inf(this, "rechit_average_pre", "", 36, 0.5, 36.5, 8, 0.5, 8.5, "Chamber", "iEta");
+  mapCLSOver5_   = MEMap3Inf(this, "rechit_over5_pre", "", 36, 0.5, 36.5, 8, 0.5, 8.5, "Chamber", "iEta");
 
   mapCLSPerCh_ = MEMap4Inf(
       this, "cls", "Cluster size of rec. hits", nCLSMax_, 0.5, nCLSMax_ + 0.5, 1, 0.5, 1.5, "Cluster size", "iEta");
 
   GenerateMEPerChamber(ibooker);
+}
+
+int GEMRecHitSource::ProcessWithMEMap2WithEta(BookingHelper& bh, ME3IdsKey key) {
+  mapTotalRecHitPerEvtIEta_.bookND(bh, key);
+
+  return 0;
+}
+
+int GEMRecHitSource::ProcessWithMEMap2AbsReWithEta(BookingHelper& bh, ME3IdsKey key) {
+  mapCLSRecHit_ieta_.bookND(bh, key);
+
+  return 0;
 }
 
 int GEMRecHitSource::ProcessWithMEMap3(BookingHelper& bh, ME3IdsKey key) {
@@ -147,13 +186,18 @@ int GEMRecHitSource::ProcessWithMEMap3(BookingHelper& bh, ME3IdsKey key) {
   mapRecHitOcc_ieta_.bookND(bh, key);
 
   mapRecHitOcc_phi_.bookND(bh, key);
-  mapTotalRecHitPerEvt_.bookND(bh, key);
+  mapTotalRecHitPerEvtLayer_.bookND(bh, key);
+  mapTotalRecHitPerEvtIEta_.bookND(bh, key);
+
+  mapCLSNumber_.bookND(bh, key);
+  mapCLSAverage_.bookND(bh, key);
+  mapCLSOver5_.bookND(bh, key);
 
   return 0;
 }
 
 int GEMRecHitSource::ProcessWithMEMap4(BookingHelper& bh, ME4IdsKey key) {
-  mapCLSRecHit_ieta_.bookND(bh, key);
+  //mapCLSRecHit_ieta_.bookND(bh, key);
 
   return 0;
 }
@@ -176,36 +220,48 @@ void GEMRecHitSource::analyze(edm::Event const& event, edm::EventSetup const& ev
     edm::LogError(log_category_) << "GEM recHit is not valid.\n";
     return;
   }
+
   std::map<ME3IdsKey, Int_t> total_rechit_layer;
+  std::map<ME3IdsKey, Int_t> total_rechit_iEta;
+  ME5map mapCLSNumber;
+  ME5map mapCLSAverage;
+  ME5map mapCLSOver5;
+
   for (const auto& ch : gemChambers_) {
     GEMDetId gid = ch.id();
+    auto chamber = gid.chamber();
     ME3IdsKey key3{gid.region(), gid.station(), gid.layer()};
     ME4IdsKey key4Ch{gid.region(), gid.station(), gid.layer(), gid.chamber()};
     MEStationInfo& stationInfo = mapStationInfo_[key3];
     for (auto ieta : ch.etaPartitions()) {
-      GEMDetId rId = ieta->id();
-      ME4IdsKey key4iEta{gid.region(), gid.station(), gid.layer(), rId.ieta()};
-      if (total_rechit_layer.find(key3) == total_rechit_layer.end())
-        total_rechit_layer[key3] = 0;
-      const auto& recHitsRange = gemRecHits->get(rId);
+      GEMDetId eId = ieta->id();
+      ME3IdsKey key3IEta{gid.region(), gid.station(), eId.ieta()};
+      ME3IdsKey key3AbsReIEta{std::abs(gid.region()), gid.station(), eId.ieta()};
+      ME4IdsKey key4IEta{gid.region(), gid.station(), gid.layer(), eId.ieta()};
+
+      if (total_rechit_layer.find(key3) == total_rechit_layer.end()) total_rechit_layer[key3] = 0;
+      InitKey5MultiMap(mapCLSNumber,  key4IEta, chamber);
+      InitKey5MultiMap(mapCLSAverage, key4IEta, chamber);
+      InitKey5MultiMap(mapCLSOver5,   key4IEta, chamber);
+
+      const auto& recHitsRange = gemRecHits->get(eId);
       auto gemRecHit = recHitsRange.first;
+      Int_t nNumRecHit = 0;
       for (auto hit = gemRecHit; hit != recHitsRange.second; ++hit) {
         GlobalPoint recHitGP = GEMGeometry_->idToDet(hit->gemId())->surface().toGlobal(hit->localPosition());
         Float_t fPhi = recHitGP.phi();
         if (fPhi < -5.0 / 180.0 * 3.141592)
           fPhi += 2 * 3.141592;
 
-        // Filling of digi occupancy
-        mapTotalRecHit_layer_.Fill(key3, gid.chamber(), rId.ieta());
+        // Filling of recHit occupancy
+        mapTotalRecHit_layer_.Fill(key3, chamber, eId.ieta());
 
         // Filling of wheel occupancy
-        Float_t fR = fRadiusMin_ + (fRadiusMax_ - fRadiusMin_) * (rId.ieta() - 0.5) / stationInfo.nNumEtaPartitions_;
-        if (!(fRadiusMin_ <= fR && fR <= fRadiusMax_ && -0.08726 <= fPhi && fPhi <= 6.196))
-          std::cout << fR << ", " << fPhi << std::endl;
+        Float_t fR = fRadiusMin_ + (fRadiusMax_ - fRadiusMin_) * (eId.ieta() - 0.5) / stationInfo.nNumEtaPartitions_;
         mapRecHitWheel_layer_.Fill(key3, fPhi, fR);
 
         // Filling of strip (iEta)
-        mapRecHitOcc_ieta_.Fill(key3, rId.ieta());
+        mapRecHitOcc_ieta_.Fill(key3, eId.ieta());
 
         // Filling of strip (phi)
         Float_t fPhiDeg = fPhi * 180.0 / 3.141592;
@@ -213,16 +269,36 @@ void GEMRecHitSource::analyze(edm::Event const& event, edm::EventSetup const& ev
 
         // For total recHits
         total_rechit_layer[key3]++;
+        total_rechit_iEta[key3IEta]++;
 
         // Filling of cluster size (CLS)
-        Int_t nCLS = std::min(hit->clusterSize(), nCLSMax_);  // For overflow
-        mapCLSRecHit_ieta_.Fill(key4iEta, nCLS);
-        mapCLSPerCh_.Fill(key4Ch, rId.ieta(), nCLS);
+        Int_t nCLS = hit->clusterSize();
+        Int_t nCLSCutOff = std::min(nCLS, nCLSMax_);  // For overflow
+        //mapCLSRecHit_ieta_.Fill(key4IEta, nCLS);
+        mapCLSRecHit_ieta_.Fill(key3AbsReIEta, nCLSCutOff);
+        mapCLSPerCh_.Fill(key4Ch, eId.ieta(), nCLSCutOff);
+        mapCLSAverage[key4IEta][chamber] += nCLS;
+        if ( nCLS > 5 ) mapCLSOver5[key4IEta][chamber] += nCLS;
+        nNumRecHit++;
       }
+      mapCLSNumber[key4IEta][chamber] = nNumRecHit;
     }
   }
-  for (auto [key, num_total_rechit] : total_rechit_layer)
-    mapTotalRecHitPerEvt_.Fill(key, num_total_rechit);
+  for (auto [key, num_total_rechit] : total_rechit_layer) {
+    mapTotalRecHitPerEvtLayer_.Fill(key, num_total_rechit);
+  }
+  for (auto [key, num_total_rechit] : total_rechit_iEta) {
+    mapTotalRecHitPerEvtIEta_.Fill(key, num_total_rechit);
+  }
+  for (auto [key, mapSub] : mapCLSNumber) {
+    for (auto [chamber, nNumRecHit] : mapSub) {
+      auto key3 = key4Tokey3(key);
+      auto ieta = keyToIEta(key);
+      mapCLSNumber_.Fill(key3,  chamber, ieta, nNumRecHit);
+      mapCLSAverage_.Fill(key3, chamber, ieta, mapCLSAverage[key][chamber]);
+      mapCLSOver5_.Fill(key3,   chamber, ieta, mapCLSOver5[key][chamber]);
+    }
+  }
 }
 
 DEFINE_FWK_MODULE(GEMRecHitSource);

--- a/DQM/GEM/plugins/GEMRecHitSource.cc
+++ b/DQM/GEM/plugins/GEMRecHitSource.cc
@@ -107,7 +107,7 @@ void GEMRecHitSource::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const&
   loadChambers();
 
   ibooker.cd();
-  ibooker.setCurrentFolder("GEM/recHit");
+  ibooker.setCurrentFolder("GEM/RecHits");
 
   nCLSMax_ = 10;
   fRadiusMin_ = 120.0;

--- a/DQM/GEM/plugins/GEMRecHitSource.cc
+++ b/DQM/GEM/plugins/GEMRecHitSource.cc
@@ -44,7 +44,7 @@ void GEMRecHitSource::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const&
   mapTotalRecHit_layer_ =
       MEMap3Inf(this, "det", "RecHit Occupancy", 36, 0.5, 36.5, 8, 0.5, 8.5, "Chamber", "iEta");
   mapRecHitWheel_layer_ =
-      MEMap3Inf(this, "rphi_occ", "RecHit R-Phi Occupancy", 108, radS, radL, 8, fRadiusMin_, fRadiusMax_, "", "");
+      MEMap3Inf(this, "rphi_occ", "RecHit R-Phi Occupancy", 108, radS, radL, 8, fRadiusMin_, fRadiusMax_, "#phi (rad)", "R [cm]");
   mapRecHitOcc_ieta_ = MEMap3Inf(
       this, "occ_ieta", "RecHit iEta Occupancy", 8, 0.5, 8.5, "iEta", "Number of RecHits");
   mapRecHitOcc_phi_ = MEMap3Inf(
@@ -82,7 +82,7 @@ void GEMRecHitSource::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const&
                              "iEta");
   mapCLSOver5_   = MEMap3Inf(this, 
                              "largeCls_occ", 
-                             "iEta vs Chamber if cluster is bigger than 5", 
+                             "Occupancy of Large Clusters (>5)", 
                              36, 
                              0.5, 
                              36.5, 
@@ -137,6 +137,7 @@ int GEMRecHitSource::ProcessWithMEMap3(BookingHelper& bh, ME3IdsKey key) {
 
   mapRecHitOcc_ieta_.SetBinConfX(stationInfo.nNumEtaPartitions_);
   mapRecHitOcc_ieta_.bookND(bh, key);
+  mapRecHitOcc_ieta_.SetLabelForIEta(key, 1);
 
   mapRecHitOcc_phi_.bookND(bh, key);
   mapTotalRecHitPerEvtLayer_.bookND(bh, key);

--- a/DQM/GEM/python/GEMDQM_cff.py
+++ b/DQM/GEM/python/GEMDQM_cff.py
@@ -11,3 +11,8 @@ GEMDQM = cms.Sequence(
   *GEMDAQStatusSource
   +GEMDQMHarvester
 )
+
+GEMDQMForRelval = cms.Sequence(
+  GEMDigiSource
+  *GEMRecHitSource
+)

--- a/DQM/GEM/src/GEMDQMBase.cc
+++ b/DQM/GEM/src/GEMDQMBase.cc
@@ -141,10 +141,10 @@ dqm::impl::MonitorElement* GEMDQMBase::CreateSummaryHist(DQMStore::IBooker& iboo
     auto key = listLayers[i - 1];
     auto strInfo = GEMUtils::getSuffixName(key);  // NOTE: It starts with '_'
     auto region = keyToRegion(key);
-    auto label = Form("GE%i%i-%c-L%i;%s",
+    auto label = Form("GE%i%i-%cL%i;%s",
                       std::abs(region),
                       keyToStation(key),
-                      (region > 0 ? 'P' : 'N'),
+                      (region > 0 ? 'P' : 'M'),
                       keyToLayer(key),
                       strInfo.Data());
     h2Res->setBinLabel(i, label, 2);
@@ -182,8 +182,11 @@ int GEMDQMBase::GenerateMEPerChamber(DQMStore::IBooker& ibooker) {
       MEMap3Check_[key3] = true;
     }
     if (!MEMap3WithChCheck_[key3WithChamber]) {
-      auto strSuffixName = GEMUtils::getSuffixName(key2) + Form("-%02i-L%i", gid.chamber(), gid.layer());
-      auto strSuffixTitle = GEMUtils::getSuffixTitle(key2) + Form("-%02i-L%i", gid.chamber(), gid.layer());
+      Int_t nCh = gid.chamber();
+      Int_t nLa = gid.layer();
+      char cLS = (nCh % 2 == 0 ? 'L' : 'S');  // FIXME: Is it general enough?
+      auto strSuffixName = GEMUtils::getSuffixName(key2) + Form("-%02iL%i-%c", nCh, nLa, cLS);
+      auto strSuffixTitle = GEMUtils::getSuffixTitle(key2) + Form("-%02iL%i-%c", nCh, nLa, cLS);
       BookingHelper bh3Ch(ibooker, strSuffixName, strSuffixTitle);
       ProcessWithMEMap3WithChamber(bh3Ch, key3WithChamber);
       MEMap3WithChCheck_[key3WithChamber] = true;

--- a/DQM/GEM/src/GEMDQMBase.cc
+++ b/DQM/GEM/src/GEMDQMBase.cc
@@ -176,7 +176,7 @@ int GEMDQMBase::GenerateMEPerChamber(DQMStore::IBooker& ibooker) {
     }
     if (!MEMap3WithChCheck_[key3WithChamber]) {
       auto strSuffixName = GEMUtils::getSuffixName(key2) + Form("-%02i-L%i", gid.chamber(), gid.layer());
-      auto strSuffixTitle = GEMUtils::getSuffixTitle(key3) + Form(" Chamber %02i", gid.chamber());
+      auto strSuffixTitle = GEMUtils::getSuffixTitle(key2) + Form("-%02i-L%i", gid.chamber(), gid.layer());
       BookingHelper bh3Ch(ibooker, strSuffixName, strSuffixTitle);
       ProcessWithMEMap3WithChamber(bh3Ch, key3WithChamber);
       MEMap3WithChCheck_[key3WithChamber] = true;
@@ -187,22 +187,22 @@ int GEMDQMBase::GenerateMEPerChamber(DQMStore::IBooker& ibooker) {
       ME3IdsKey key2WithEta{gid.region(), gid.station(), eId.ieta()};
       ME3IdsKey key2AbsReWithEta{std::abs(gid.region()), gid.station(), eId.ieta()};
       if (!MEMap4Check_[key4]) {
-        auto strSuffixName = GEMUtils::getSuffixName(key3) + Form("_ieta%02i", eId.ieta());
-        auto strSuffixTitle = GEMUtils::getSuffixTitle(key3) + Form(" iEta %02i", eId.ieta());
+        auto strSuffixName = GEMUtils::getSuffixName(key3) + Form("-E%02i", eId.ieta());
+        auto strSuffixTitle = GEMUtils::getSuffixTitle(key3) + Form("-E%02i", eId.ieta());
         BookingHelper bh4(ibooker, strSuffixName, strSuffixTitle);
         ProcessWithMEMap4(bh4, key4);
         MEMap4Check_[key4] = true;
       }
       if (!MEMap2WithEtaCheck_[key2WithEta]) {
-        auto strSuffixName = GEMUtils::getSuffixName(key2) + Form("_ieta%02i", eId.ieta());
-        auto strSuffixTitle = GEMUtils::getSuffixTitle(key2) + Form(" iEta %02i", eId.ieta());
+        auto strSuffixName = GEMUtils::getSuffixName(key2) + Form("-E%02i", eId.ieta());
+        auto strSuffixTitle = GEMUtils::getSuffixTitle(key2) + Form("-E%02i", eId.ieta());
         BookingHelper bh3(ibooker, strSuffixName, strSuffixTitle);
         ProcessWithMEMap2WithEta(bh3, key2WithEta);
         MEMap2WithEtaCheck_[key2WithEta] = true;
       }
       if (!MEMap2AbsReWithEtaCheck_[key2AbsReWithEta]) {
-        auto strSuffixName = Form("_GE%i%i_ieta%02i", std::abs(gid.region()), gid.station(), eId.ieta());
-        auto strSuffixTitle = Form("_GE%i%i iEta %02i", std::abs(gid.region()), gid.station(), eId.ieta());
+        auto strSuffixName = Form("_GE%i%i-E%02i", std::abs(gid.region()), gid.station(), eId.ieta());
+        auto strSuffixTitle = Form(" GE%i%i-E%02i", std::abs(gid.region()), gid.station(), eId.ieta());
         BookingHelper bh3(ibooker, strSuffixName, strSuffixTitle);
         ProcessWithMEMap2AbsReWithEta(bh3, key2AbsReWithEta);
         MEMap2AbsReWithEtaCheck_[key2AbsReWithEta] = true;

--- a/DQM/GEM/src/GEMDQMBase.cc
+++ b/DQM/GEM/src/GEMDQMBase.cc
@@ -78,14 +78,14 @@ int GEMDQMBase::loadChambers() {
       const int max_vfat = getMaxVFAT(station->station());  // the number of VFATs per GEMEtaPartition
       const int num_etas = getNumEtaPartitions(station);    // the number of eta partitions per GEMChamber
       const int num_vfat = num_etas * max_vfat;             // the number of VFATs per GEMChamber
-      const int num_strip = GEMeMap::maxChan_;              // the number of strips (channels) per VFAT
+      const int num_digi = GEMeMap::maxChan_;               // the number of digis (channels) per VFAT
 
       nMaxNumCh_ = std::max(nMaxNumCh_, num_superchambers);
 
       for (int layer_number = 1; layer_number <= num_layers; layer_number++) {
         ME3IdsKey key3(region_number, station_number, layer_number);
-        mapStationInfo_[key3] = MEStationInfo(
-            region_number, station_number, layer_number, num_superchambers, num_etas, num_vfat, num_strip);
+        mapStationInfo_[key3] =
+            MEStationInfo(region_number, station_number, layer_number, num_superchambers, num_etas, num_vfat, num_digi);
       }
     }
   }
@@ -141,7 +141,12 @@ dqm::impl::MonitorElement* GEMDQMBase::CreateSummaryHist(DQMStore::IBooker& iboo
     auto key = listLayers[i - 1];
     auto strInfo = GEMUtils::getSuffixName(key);  // NOTE: It starts with '_'
     auto region = keyToRegion(key);
-    auto label = Form("GE%i%i-%c-L%i;%s", std::abs(region), keyToStation(key), (region > 0 ? 'P' : 'N'), keyToLayer(key), strInfo.Data());
+    auto label = Form("GE%i%i-%c-L%i;%s",
+                      std::abs(region),
+                      keyToStation(key),
+                      (region > 0 ? 'P' : 'N'),
+                      keyToLayer(key),
+                      strInfo.Data());
     h2Res->setBinLabel(i, label, 2);
     Int_t nNumCh = mapStationInfo_[key].nNumChambers_;
     h2Res->setBinContent(0, i, nNumCh);

--- a/DQM/GEM/src/GEMDQMBase.cc
+++ b/DQM/GEM/src/GEMDQMBase.cc
@@ -129,6 +129,8 @@ dqm::impl::MonitorElement* GEMDQMBase::CreateSummaryHist(DQMStore::IBooker& iboo
 
   auto h2Res =
       ibooker.book2D(strName, "", nMaxNumCh_, 0.5, nMaxNumCh_ + 0.5, listLayers.size(), 0.5, listLayers.size() + 0.5);
+  h2Res->setXTitle("Chamber");
+  h2Res->setYTitle("Layer");
 
   if (h2Res == nullptr)
     return nullptr;

--- a/DQM/Integration/python/clients/gem_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/gem_dqm_sourceclient-live_cfg.py
@@ -36,7 +36,7 @@ if (process.runType.getRunType() == process.runType.hi_run):
   process.muonGEMDigis.InputLabel = cms.InputTag("rawDataRepacker")
 
 process.muonGEMDigis.useDBEMap = True
-process.muonGEMDigis.unPackStatusDigis = True
+process.muonGEMDigis.keepDAQStatus = True
 
 process.path = cms.Path(
   process.muonGEMDigis *

--- a/Validation/MuonGEMHits/interface/GEMValidationUtils.h
+++ b/Validation/MuonGEMHits/interface/GEMValidationUtils.h
@@ -28,7 +28,7 @@ namespace GEMUtils {
   TString getSuffixName(Int_t region_id);
   TString getSuffixName(Int_t region_id, Int_t station_id);
   TString getSuffixName(Int_t region_id, Int_t station_id, Int_t layer_id);
-  TString getSuffixName(Int_t region_id, Int_t station_id, Int_t layer_id, Int_t roll_id);
+  TString getSuffixName(Int_t region_id, Int_t station_id, Int_t layer_id, Int_t eta_id);
 
   TString getSuffixName(const ME2IdsKey& key);
   TString getSuffixName(const ME3IdsKey& key);
@@ -37,7 +37,7 @@ namespace GEMUtils {
   TString getSuffixTitle(Int_t region_id);
   TString getSuffixTitle(Int_t region_id, Int_t station_id);
   TString getSuffixTitle(Int_t region_id, Int_t station_id, Int_t layer_id);
-  TString getSuffixTitle(Int_t region_id, Int_t station_id, Int_t layer_id, Int_t roll_id);
+  TString getSuffixTitle(Int_t region_id, Int_t station_id, Int_t layer_id, Int_t eta_id);
 
   TString getSuffixTitle(const ME2IdsKey& key);
   TString getSuffixTitle(const ME3IdsKey& key);

--- a/Validation/MuonGEMHits/src/GEMValidationUtils.cc
+++ b/Validation/MuonGEMHits/src/GEMValidationUtils.cc
@@ -12,8 +12,8 @@ TString GEMUtils::getSuffixName(Int_t region_id, Int_t station_id, Int_t layer_i
   return TString::Format("_GE%.2d-%c-L%d", station_id * 10 + 1, (region_id > 0 ? 'P' : 'N'), layer_id);
 }
 
-TString GEMUtils::getSuffixName(Int_t region_id, Int_t station_id, Int_t layer_id, Int_t roll_id) {
-  return TString::Format("_GE%.2d-%c-L%d-iEta%d", station_id * 10 + 1, (region_id > 0 ? 'P' : 'N'), layer_id, roll_id);
+TString GEMUtils::getSuffixName(Int_t region_id, Int_t station_id, Int_t layer_id, Int_t eta_id) {
+  return TString::Format("_GE%.2d-%c-L%d-E%d", station_id * 10 + 1, (region_id > 0 ? 'P' : 'N'), layer_id, eta_id);
 }
 
 TString GEMUtils::getSuffixName(const ME2IdsKey& key) {
@@ -27,8 +27,8 @@ TString GEMUtils::getSuffixName(const ME3IdsKey& key) {
 }
 
 TString GEMUtils::getSuffixName(const ME4IdsKey& key) {
-  auto [region_id, station_id, layer_id, roll_id] = key;
-  return getSuffixName(region_id, station_id, layer_id, roll_id);
+  auto [region_id, station_id, layer_id, eta_id] = key;
+  return getSuffixName(region_id, station_id, layer_id, eta_id);
 }
 
 TString GEMUtils::getSuffixTitle(Int_t region_id) { return TString::Format(" Region %+d", region_id); }
@@ -38,11 +38,11 @@ TString GEMUtils::getSuffixTitle(Int_t region_id, Int_t station_id) {
 }
 
 TString GEMUtils::getSuffixTitle(Int_t region_id, Int_t station_id, Int_t layer_id) {
-  return TString::Format(" GE%.2d-%c Layer %d", station_id * 10 + 1, (region_id > 0 ? 'P' : 'N'), layer_id);
+  return TString::Format(" GE%.2d-%c-L%d", station_id * 10 + 1, (region_id > 0 ? 'P' : 'N'), layer_id);
 }
 
-TString GEMUtils::getSuffixTitle(Int_t region_id, Int_t station_id, Int_t layer_id, Int_t roll_id) {
-  return TString::Format(" GE%.2d-%c Layer %d iEta %d", station_id * 10 + 1, (region_id > 0 ? 'P' : 'N'), layer_id, roll_id);
+TString GEMUtils::getSuffixTitle(Int_t region_id, Int_t station_id, Int_t layer_id, Int_t eta_id) {
+  return TString::Format(" GE%.2d-%c-L%d-E%d", station_id * 10 + 1, (region_id > 0 ? 'P' : 'N'), layer_id, eta_id);
 }
 
 TString GEMUtils::getSuffixTitle(const ME2IdsKey& key) {
@@ -56,6 +56,6 @@ TString GEMUtils::getSuffixTitle(const ME3IdsKey& key) {
 }
 
 TString GEMUtils::getSuffixTitle(const ME4IdsKey& key) {
-  auto [region_id, station_id, layer_id, roll_id] = key;
-  return getSuffixTitle(region_id, station_id, layer_id, roll_id);
+  auto [region_id, station_id, layer_id, eta_id] = key;
+  return getSuffixTitle(region_id, station_id, layer_id, eta_id);
 }

--- a/Validation/MuonGEMHits/src/GEMValidationUtils.cc
+++ b/Validation/MuonGEMHits/src/GEMValidationUtils.cc
@@ -5,15 +5,15 @@
 TString GEMUtils::getSuffixName(Int_t region_id) { return TString::Format("_Re%+d", region_id); }
 
 TString GEMUtils::getSuffixName(Int_t region_id, Int_t station_id) {
-  return TString::Format("_GE%+.2d", region_id * (station_id * 10 + 1));
+  return TString::Format("_GE%.2d-%c", station_id * 10 + 1, (region_id > 0 ? 'P' : 'N'));
 }
 
 TString GEMUtils::getSuffixName(Int_t region_id, Int_t station_id, Int_t layer_id) {
-  return TString::Format("_GE%+.2d_L%d", region_id * (station_id * 10 + 1), layer_id);
+  return TString::Format("_GE%.2d-%c-L%d", station_id * 10 + 1, (region_id > 0 ? 'P' : 'N'), layer_id);
 }
 
 TString GEMUtils::getSuffixName(Int_t region_id, Int_t station_id, Int_t layer_id, Int_t roll_id) {
-  return TString::Format("_GE%+.2d_L%d_iEta%d", region_id * (station_id * 10 + 1), layer_id, roll_id);
+  return TString::Format("_GE%.2d-%c-L%d-iEta%d", station_id * 10 + 1, (region_id > 0 ? 'P' : 'N'), layer_id, roll_id);
 }
 
 TString GEMUtils::getSuffixName(const ME2IdsKey& key) {

--- a/Validation/MuonGEMHits/src/GEMValidationUtils.cc
+++ b/Validation/MuonGEMHits/src/GEMValidationUtils.cc
@@ -5,15 +5,15 @@
 TString GEMUtils::getSuffixName(Int_t region_id) { return TString::Format("_Re%+d", region_id); }
 
 TString GEMUtils::getSuffixName(Int_t region_id, Int_t station_id) {
-  return TString::Format("_GE%.2d-%c", station_id * 10 + 1, (region_id > 0 ? 'P' : 'N'));
+  return TString::Format("_GE%.2d-%c", station_id * 10 + 1, (region_id > 0 ? 'P' : 'M'));
 }
 
 TString GEMUtils::getSuffixName(Int_t region_id, Int_t station_id, Int_t layer_id) {
-  return TString::Format("_GE%.2d-%c-L%d", station_id * 10 + 1, (region_id > 0 ? 'P' : 'N'), layer_id);
+  return TString::Format("_GE%.2d-%c-L%d", station_id * 10 + 1, (region_id > 0 ? 'P' : 'M'), layer_id);
 }
 
 TString GEMUtils::getSuffixName(Int_t region_id, Int_t station_id, Int_t layer_id, Int_t eta_id) {
-  return TString::Format("_GE%.2d-%c-L%d-E%d", station_id * 10 + 1, (region_id > 0 ? 'P' : 'N'), layer_id, eta_id);
+  return TString::Format("_GE%.2d-%c-L%d-E%d", station_id * 10 + 1, (region_id > 0 ? 'P' : 'M'), layer_id, eta_id);
 }
 
 TString GEMUtils::getSuffixName(const ME2IdsKey& key) {
@@ -34,15 +34,15 @@ TString GEMUtils::getSuffixName(const ME4IdsKey& key) {
 TString GEMUtils::getSuffixTitle(Int_t region_id) { return TString::Format(" Region %+d", region_id); }
 
 TString GEMUtils::getSuffixTitle(Int_t region_id, Int_t station_id) {
-  return TString::Format(" GE%.2d-%c", station_id * 10 + 1, (region_id > 0 ? 'P' : 'N'));
+  return TString::Format(" GE%.2d-%c", station_id * 10 + 1, (region_id > 0 ? 'P' : 'M'));
 }
 
 TString GEMUtils::getSuffixTitle(Int_t region_id, Int_t station_id, Int_t layer_id) {
-  return TString::Format(" GE%.2d-%c-L%d", station_id * 10 + 1, (region_id > 0 ? 'P' : 'N'), layer_id);
+  return TString::Format(" GE%.2d-%c-L%d", station_id * 10 + 1, (region_id > 0 ? 'P' : 'M'), layer_id);
 }
 
 TString GEMUtils::getSuffixTitle(Int_t region_id, Int_t station_id, Int_t layer_id, Int_t eta_id) {
-  return TString::Format(" GE%.2d-%c-L%d-E%d", station_id * 10 + 1, (region_id > 0 ? 'P' : 'N'), layer_id, eta_id);
+  return TString::Format(" GE%.2d-%c-L%d-E%d", station_id * 10 + 1, (region_id > 0 ? 'P' : 'M'), layer_id, eta_id);
 }
 
 TString GEMUtils::getSuffixTitle(const ME2IdsKey& key) {

--- a/Validation/MuonGEMHits/src/GEMValidationUtils.cc
+++ b/Validation/MuonGEMHits/src/GEMValidationUtils.cc
@@ -34,15 +34,15 @@ TString GEMUtils::getSuffixName(const ME4IdsKey& key) {
 TString GEMUtils::getSuffixTitle(Int_t region_id) { return TString::Format(" Region %+d", region_id); }
 
 TString GEMUtils::getSuffixTitle(Int_t region_id, Int_t station_id) {
-  return TString::Format(" GE%+.2d", region_id * (station_id * 10 + 1));
+  return TString::Format(" GE%.2d-%c", station_id * 10 + 1, (region_id > 0 ? 'P' : 'N'));
 }
 
 TString GEMUtils::getSuffixTitle(Int_t region_id, Int_t station_id, Int_t layer_id) {
-  return TString::Format(" GE%+.2d Layer %d", region_id * (station_id * 10 + 1), layer_id);
+  return TString::Format(" GE%.2d-%c Layer %d", station_id * 10 + 1, (region_id > 0 ? 'P' : 'N'), layer_id);
 }
 
 TString GEMUtils::getSuffixTitle(Int_t region_id, Int_t station_id, Int_t layer_id, Int_t roll_id) {
-  return TString::Format(" GE%+.2d Layer %d iEta %d", region_id * (station_id * 10 + 1), layer_id, roll_id);
+  return TString::Format(" GE%.2d-%c Layer %d iEta %d", station_id * 10 + 1, (region_id > 0 ? 'P' : 'N'), layer_id, roll_id);
 }
 
 TString GEMUtils::getSuffixTitle(const ME2IdsKey& key) {


### PR DESCRIPTION
#### PR description:
Since lots of stuffs in DAQ dataformat have been changed in https://github.com/cms-sw/cmssw/pull/34504, the GEM onlineDQM has to be changed to adjust it. This PR is for it.

Also many of plots are rearranged, and new plots are added, which are plots of the average cluster sizes, etc..

We also have a plan to make a backport of this update, for the DAQ dataformat (see https://github.com/cms-sw/cmssw/pull/34585), into CMSSW_11_3_X for current cosmic runs.

#### PR validation:
Test are done and one can check again by `runTheMatrix` workflows

#### if this PR is a backport please specify the original PR and why you need to backport that PR:
To CMSSW_11_3_X to be deployed on current cosmic runs

@jshlee @watson-ij @hyunyong 