### PR TITLE
Created GlobalEvFOutputModule

### DIFF
--- a/EventFilter/Utilities/interface/DataPoint.h
+++ b/EventFilter/Utilities/interface/DataPoint.h
@@ -68,13 +68,15 @@ namespace jsoncollector {
     void snapStreamAtomic(unsigned int lumi, unsigned int streamID);
 
     //set to track a variable
-    void trackMonitorable(JsonMonitorable* monitorable, bool NAifZeroUpdates);
+    void trackMonitorable(JsonMonitorable const* monitorable, bool NAifZeroUpdates);
 
     //set to track a vector of variables
-    void trackVectorUInt(std::string const& name, std::vector<unsigned int>* monvec, bool NAifZeroUpdates);
+    void trackVectorUInt(std::string const& name, std::vector<unsigned int> const* monvec, bool NAifZeroUpdates);
 
     //set to track a vector of atomic variables with guaranteed collection
-    void trackVectorUIntAtomic(std::string const& name, std::vector<AtomicMonUInt*>* monvec, bool NAifZeroUpdates);
+    void trackVectorUIntAtomic(std::string const& name,
+                               std::vector<AtomicMonUInt*> const* monvec,
+                               bool NAifZeroUpdates);
 
     //variable not found by the service, but want to output something to JSON
     void trackDummy(std::string const& name, bool setNAifZeroUpdates) {
@@ -106,7 +108,7 @@ namespace jsoncollector {
     //this parameter sets location where we can find hwo many bins are needed for histogram
     void setNBins(unsigned int* nBins) { nBinsPtr_ = nBins; }
 
-    std::string const& getName() { return name_; }
+    std::string const& getName() const { return name_; }
 
     void updateDefinition(std::string const& definition) { definition_ = definition; }
 
@@ -123,7 +125,7 @@ namespace jsoncollector {
 
     std::vector<MonPtrMap> streamDataMaps_;
     MonPtrMap globalDataMap_;
-    void* tracked_ = nullptr;
+    void const* tracked_ = nullptr;
 
     //stream lumi block position
     std::vector<unsigned int>* streamLumisPtr_ = nullptr;

--- a/EventFilter/Utilities/interface/DataPointDefinition.h
+++ b/EventFilter/Utilities/interface/DataPointDefinition.h
@@ -41,8 +41,8 @@ namespace jsoncollector {
     /**
    * Returns a LegendItem object ref at the specified index
    */
-    std::vector<std::string> const& getNames() { return varNames_; }
-    std::vector<std::string> const& getOperations() { return opNames_; }
+    std::vector<std::string> const& getNames() const { return varNames_; }
+    std::vector<std::string> const& getOperations() const { return opNames_; }
 
     /**
    * Loads a DataPointDefinition from a specified reference
@@ -55,9 +55,10 @@ namespace jsoncollector {
 
     void addLegendItem(std::string const& name, std::string const& type, std::string const& operation);
 
-    OperationType getOperationFor(unsigned int index);
+    OperationType getOperationFor(unsigned int index) const;
 
     std::string& getDefFilePath() { return defFilePath_; }
+    std::string const& getDefFilePath() const { return defFilePath_; }
     //void populateMonConfig(std::vector<JsonMonConfig>& monConfig);
 
     //known JSON operation names

--- a/EventFilter/Utilities/interface/FastMonitor.h
+++ b/EventFilter/Utilities/interface/FastMonitor.h
@@ -23,7 +23,7 @@ namespace jsoncollector {
                 bool strictChecking,
                 bool useSource = true,
                 bool useDefinition = true);
-    FastMonitor(DataPointDefinition* dpd, bool strictChecking, bool useSource = true, bool useDefinition = true);
+    FastMonitor(DataPointDefinition const* dpd, bool strictChecking, bool useSource = true, bool useDefinition = true);
 
     virtual ~FastMonitor();
 
@@ -104,8 +104,8 @@ namespace jsoncollector {
     unsigned int nStreams_;
 
     std::string sourceInfo_;
-    DataPointDefinition* dpd_;
-    DataPointDefinition* dpdFast_;
+    DataPointDefinition const* dpd_;
+    DataPointDefinition const* dpdFast_;
     bool deleteDef_ = false;
     bool deleteDefFast_ = false;
 

--- a/EventFilter/Utilities/interface/JsonMonitorable.h
+++ b/EventFilter/Utilities/interface/JsonMonitorable.h
@@ -33,11 +33,11 @@ namespace jsoncollector {
 
     unsigned int getUpdates() { return updates_; }
 
-    bool getNotSame() { return notSame_; }
+    bool getNotSame() const { return notSame_; }
 
     virtual void setName(std::string name) { name_ = name; }
 
-    virtual std::string& getName() { return name_; }
+    virtual std::string const& getName() const { return name_; }
 
   protected:
     std::string name_;
@@ -86,6 +86,7 @@ namespace jsoncollector {
       notSame_ = false;
     }
     long& value() { return theVar_; }
+    long value() const { return theVar_; }
 
     void update(long sth) {
       theVar_ = sth;
@@ -126,6 +127,7 @@ namespace jsoncollector {
       notSame_ = false;
     }
     double& value() { return theVar_; }
+    double value() const { return theVar_; }
     void update(double sth) {
       theVar_ = sth;
       if (updates_ && theVar_ != sth)
@@ -155,6 +157,7 @@ namespace jsoncollector {
       notSame_ = false;
     }
     std::string& value() { return theVar_; }
+    std::string const& value() const { return theVar_; }
     void concatenate(std::string const& added) {
       if (!updates_)
         theVar_ = added;
@@ -219,13 +222,14 @@ namespace jsoncollector {
       histo_.reserve(expectedSize_);
       updates_ = 0;
     }
-    void operator=(std::vector<T>& sth) { histo_ = sth; }
+    void operator=(std::vector<T> const& sth) { histo_ = sth; }
 
     std::vector<T>& value() { return histo_; }
+    std::vector<T> const& value() const { return histo_; }
 
-    unsigned int getExpectedSize() { return expectedSize_; }
+    unsigned int getExpectedSize() const { return expectedSize_; }
 
-    unsigned int getMaxUpdates() { return maxUpdates_; }
+    unsigned int getMaxUpdates() const { return maxUpdates_; }
 
     void setMaxUpdates(unsigned int maxUpdates) {
       maxUpdates_ = maxUpdates;
@@ -240,7 +244,7 @@ namespace jsoncollector {
         histo_.reserve(expectedSize_);
     }
 
-    unsigned int getSize() { return histo_.size(); }
+    unsigned int getSize() const { return histo_.size(); }
 
     void update(T val) {
       if (maxUpdates_ && updates_ >= maxUpdates_)

--- a/EventFilter/Utilities/plugins/GlobalEvFOutputModule.cc
+++ b/EventFilter/Utilities/plugins/GlobalEvFOutputModule.cc
@@ -97,23 +97,23 @@ namespace evf {
   class GlobalEvFOutputModule : public GlobalEvFOutputModuleType {
   public:
     explicit GlobalEvFOutputModule(edm::ParameterSet const& ps);
-    ~GlobalEvFOutputModule();
+    ~GlobalEvFOutputModule() override;
     static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
   private:
-    std::unique_ptr<edm::StreamerOutputModuleCommon> beginStream(edm::StreamID) const;
+    std::unique_ptr<edm::StreamerOutputModuleCommon> beginStream(edm::StreamID) const override;
 
-    std::shared_ptr<GlobalEvFOutputJSONWriter> globalBeginRun(edm::RunForOutput const& run) const;
-    void write(edm::EventForOutput const& e);
+    std::shared_ptr<GlobalEvFOutputJSONWriter> globalBeginRun(edm::RunForOutput const& run) const override;
+    void write(edm::EventForOutput const& e) override;
 
     //pure in parent class but unused here
-    void writeLuminosityBlock(edm::LuminosityBlockForOutput const&) {}
-    void writeRun(edm::RunForOutput const&) {}
-    void globalEndRun(edm::RunForOutput const&) const {}
+    void writeLuminosityBlock(edm::LuminosityBlockForOutput const&) override {}
+    void writeRun(edm::RunForOutput const&) override {}
+    void globalEndRun(edm::RunForOutput const&) const override {}
 
     std::shared_ptr<GlobalEvFOutputEventWriter> globalBeginLuminosityBlock(
-        edm::LuminosityBlockForOutput const& iLB) const;
-    void globalEndLuminosityBlock(edm::LuminosityBlockForOutput const& iLB) const;
+        edm::LuminosityBlockForOutput const& iLB) const override;
+    void globalEndLuminosityBlock(edm::LuminosityBlockForOutput const& iLB) const override;
 
     Trig getTriggerResults(edm::EDGetTokenT<edm::TriggerResults> const& token, edm::EventForOutput const& e) const;
 

--- a/EventFilter/Utilities/plugins/GlobalEvFOutputModule.cc
+++ b/EventFilter/Utilities/plugins/GlobalEvFOutputModule.cc
@@ -1,0 +1,395 @@
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "EventFilter/Utilities/interface/FastMonitoringService.h"
+#include "EventFilter/Utilities/interface/EvFDaqDirector.h"
+
+#include "EventFilter/Utilities/interface/JSONSerializer.h"
+#include "EventFilter/Utilities/interface/FileIO.h"
+#include "FWCore/Utilities/interface/Adler32Calculator.h"
+
+#include "FWCore/Framework/interface/EventForOutput.h"
+#include "FWCore/Framework/interface/RunForOutput.h"
+#include "FWCore/Framework/interface/LuminosityBlockForOutput.h"
+#include "FWCore/Framework/interface/LuminosityBlock.h"
+
+#include "IOPool/Streamer/interface/InitMsgBuilder.h"
+#include "IOPool/Streamer/interface/EventMsgBuilder.h"
+
+#include "IOPool/Streamer/interface/StreamerOutputFile.h"
+#include "FWCore/Framework/interface/global/OutputModule.h"
+//#include "FWCore/Framework/interface/one/OutputModule.h"
+#include "IOPool/Streamer/interface/StreamerOutputModuleCommon.h"
+#include "FWCore/Utilities/interface/EDGetToken.h"
+#include "DataFormats/Streamer/interface/StreamedProducts.h"
+
+#include "EventFilter/Utilities/interface/JsonMonitorable.h"
+#include "EventFilter/Utilities/interface/FastMonitor.h"
+
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include <sys/stat.h>
+#include <filesystem>
+#include <mutex>
+#include <boost/algorithm/string.hpp>
+
+typedef edm::detail::TriggerResultsBasedEventSelector::handle_t Trig;
+
+namespace evf {
+
+  class FastMonitoringService;
+
+  class GlobalEvFOutputEventWriter {
+  public:
+    explicit GlobalEvFOutputEventWriter(std::string const& filePath)
+        : filePath_(filePath), accepted_(0), stream_writer_events_(new StreamerOutputFile(filePath)) {}
+
+    ~GlobalEvFOutputEventWriter() {}
+
+    void close() { stream_writer_events_->close(); }
+
+    void doOutputEvent(EventMsgBuilder const& msg) {
+      EventMsgView eview(msg.startAddress());
+      std::lock_guard<std::mutex> g(mutex_);
+      stream_writer_events_->write(eview);
+      incAccepted();
+    }
+
+    uint32 get_adler32() const { return stream_writer_events_->adler32(); }
+
+    std::string const& getFilePath() const { return filePath_; }
+
+    unsigned long getAccepted() const { return accepted_; }
+    void incAccepted() { accepted_++; }
+
+  private:
+    std::string filePath_;
+    std::atomic<unsigned long> accepted_;
+    edm::propagate_const<std::unique_ptr<StreamerOutputFile>> stream_writer_events_;
+    std::mutex mutex_;
+  };
+
+  class GlobalEvFOutputJSONWriter {
+  public:
+    GlobalEvFOutputJSONWriter(std::string const& streamLabel);
+
+    jsoncollector::IntJ processed_;
+    jsoncollector::IntJ accepted_;
+    jsoncollector::IntJ errorEvents_;
+    jsoncollector::IntJ retCodeMask_;
+    jsoncollector::StringJ filelist_;
+    jsoncollector::IntJ filesize_;
+    jsoncollector::StringJ inputFiles_;
+    jsoncollector::IntJ fileAdler32_;
+    jsoncollector::StringJ transferDestination_;
+    jsoncollector::StringJ mergeType_;
+    jsoncollector::IntJ hltErrorEvents_;
+    std::shared_ptr<jsoncollector::FastMonitor> jsonMonitor_;
+    jsoncollector::DataPointDefinition outJsonDef_;
+    std::mutex mutex_;
+  };
+
+  typedef edm::global::OutputModule<edm::RunCache<GlobalEvFOutputJSONWriter>,
+                                    edm::LuminosityBlockCache<evf::GlobalEvFOutputEventWriter>,
+                                    edm::StreamCache<edm::StreamerOutputModuleCommon>>
+      GlobalEvFOutputModuleType;
+
+  class GlobalEvFOutputModule : public GlobalEvFOutputModuleType {
+  public:
+    explicit GlobalEvFOutputModule(edm::ParameterSet const& ps);
+    ~GlobalEvFOutputModule();
+    static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+  private:
+    std::unique_ptr<edm::StreamerOutputModuleCommon> beginStream(edm::StreamID) const;
+
+    std::shared_ptr<GlobalEvFOutputJSONWriter> globalBeginRun(edm::RunForOutput const& run) const;
+    void write(edm::EventForOutput const& e);
+
+    //pure in parent class but unused here
+    void writeLuminosityBlock(edm::LuminosityBlockForOutput const&) {}
+    void writeRun(edm::RunForOutput const&) {}
+    void globalEndRun(edm::RunForOutput const&) const {}
+
+    std::shared_ptr<GlobalEvFOutputEventWriter> globalBeginLuminosityBlock(
+        edm::LuminosityBlockForOutput const& iLB) const;
+    void globalEndLuminosityBlock(edm::LuminosityBlockForOutput const& iLB) const;
+
+    Trig getTriggerResults(edm::EDGetTokenT<edm::TriggerResults> const& token, edm::EventForOutput const& e) const;
+
+    edm::ParameterSet const& ps_;
+    std::string streamLabel_;
+    edm::EDGetTokenT<edm::TriggerResults> trToken_;
+    edm::EDGetTokenT<edm::SendJobHeader::ParameterSetMap> psetToken_;
+
+    evf::FastMonitoringService* fms_;
+
+    //std::unique_ptr<evf::GlobalEvFOutputJSONWriter> jsonWriter_;
+
+  };  //end-of-class-def
+
+  GlobalEvFOutputJSONWriter::GlobalEvFOutputJSONWriter(std::string const& streamLabel)
+      : processed_(0),
+        accepted_(0),
+        errorEvents_(0),
+        retCodeMask_(0),
+        filelist_(),
+        filesize_(0),
+        inputFiles_(),
+        fileAdler32_(1),
+        hltErrorEvents_(0) {
+    transferDestination_ = edm::Service<evf::EvFDaqDirector>()->getStreamDestinations(streamLabel);
+    mergeType_ = edm::Service<evf::EvFDaqDirector>()->getStreamMergeType(streamLabel, evf::MergeTypeDAT);
+
+    std::string baseRunDir = edm::Service<evf::EvFDaqDirector>()->baseRunDir();
+    LogDebug("GlobalEvFOutputModule") << "writing .dat files to -: " << baseRunDir;
+
+    edm::Service<evf::EvFDaqDirector>()->createRunOpendirMaybe();
+
+    processed_.setName("Processed");
+    accepted_.setName("Accepted");
+    errorEvents_.setName("ErrorEvents");
+    retCodeMask_.setName("ReturnCodeMask");
+    filelist_.setName("Filelist");
+    filesize_.setName("Filesize");
+    inputFiles_.setName("InputFiles");
+    fileAdler32_.setName("FileAdler32");
+    transferDestination_.setName("TransferDestination");
+    mergeType_.setName("MergeType");
+    hltErrorEvents_.setName("HLTErrorEvents");
+
+    outJsonDef_.setDefaultGroup("data");
+    outJsonDef_.addLegendItem("Processed", "integer", jsoncollector::DataPointDefinition::SUM);
+    outJsonDef_.addLegendItem("Accepted", "integer", jsoncollector::DataPointDefinition::SUM);
+    outJsonDef_.addLegendItem("ErrorEvents", "integer", jsoncollector::DataPointDefinition::SUM);
+    outJsonDef_.addLegendItem("ReturnCodeMask", "integer", jsoncollector::DataPointDefinition::BINARYOR);
+    outJsonDef_.addLegendItem("Filelist", "string", jsoncollector::DataPointDefinition::MERGE);
+    outJsonDef_.addLegendItem("Filesize", "integer", jsoncollector::DataPointDefinition::SUM);
+    outJsonDef_.addLegendItem("InputFiles", "string", jsoncollector::DataPointDefinition::CAT);
+    outJsonDef_.addLegendItem("FileAdler32", "integer", jsoncollector::DataPointDefinition::ADLER32);
+    outJsonDef_.addLegendItem("TransferDestination", "string", jsoncollector::DataPointDefinition::SAME);
+    outJsonDef_.addLegendItem("MergeType", "string", jsoncollector::DataPointDefinition::SAME);
+    outJsonDef_.addLegendItem("HLTErrorEvents", "integer", jsoncollector::DataPointDefinition::SUM);
+
+    std::stringstream tmpss, ss;
+    tmpss << baseRunDir << "/open/"
+          << "output_" << getpid() << ".jsd";
+    ss << baseRunDir << "/"
+       << "output_" << getpid() << ".jsd";
+    std::string outTmpJsonDefName = tmpss.str();
+    std::string outJsonDefName = ss.str();
+
+    edm::Service<evf::EvFDaqDirector>()->lockInitLock();
+    struct stat fstat;
+    if (stat(outJsonDefName.c_str(), &fstat) != 0) {  //file does not exist
+      LogDebug("GlobalEvFOutputModule") << "writing output definition file -: " << outJsonDefName;
+      std::string content;
+      jsoncollector::JSONSerializer::serialize(&outJsonDef_, content);
+      jsoncollector::FileIO::writeStringToFile(outTmpJsonDefName, content);
+      std::filesystem::rename(outTmpJsonDefName, outJsonDefName);
+    }
+    edm::Service<evf::EvFDaqDirector>()->unlockInitLock();
+
+    jsonMonitor_.reset(new jsoncollector::FastMonitor(&outJsonDef_, true));
+    jsonMonitor_->setDefPath(outJsonDefName);
+    jsonMonitor_->registerGlobalMonitorable(&processed_, false);
+    jsonMonitor_->registerGlobalMonitorable(&accepted_, false);
+    jsonMonitor_->registerGlobalMonitorable(&errorEvents_, false);
+    jsonMonitor_->registerGlobalMonitorable(&retCodeMask_, false);
+    jsonMonitor_->registerGlobalMonitorable(&filelist_, false);
+    jsonMonitor_->registerGlobalMonitorable(&filesize_, false);
+    jsonMonitor_->registerGlobalMonitorable(&inputFiles_, false);
+    jsonMonitor_->registerGlobalMonitorable(&fileAdler32_, false);
+    jsonMonitor_->registerGlobalMonitorable(&transferDestination_, false);
+    jsonMonitor_->registerGlobalMonitorable(&mergeType_, false);
+    jsonMonitor_->registerGlobalMonitorable(&hltErrorEvents_, false);
+    jsonMonitor_->commit(nullptr);
+  }
+
+  GlobalEvFOutputModule::GlobalEvFOutputModule(edm::ParameterSet const& ps)
+      : edm::global::OutputModuleBase(ps),
+        GlobalEvFOutputModuleType(ps),
+        ps_(ps),
+        streamLabel_(ps.getParameter<std::string>("@module_label")),
+        trToken_(consumes<edm::TriggerResults>(edm::InputTag("TriggerResults"))),
+        psetToken_(consumes<edm::SendJobHeader::ParameterSetMap, edm::InRun>(
+            ps.getUntrackedParameter<edm::InputTag>("psetMap"))) {
+    //replace hltOutoputA with stream if the HLT menu uses this convention
+    std::string testPrefix = "hltOutput";
+    if (streamLabel_.find(testPrefix) == 0)
+      streamLabel_ = std::string("stream") + streamLabel_.substr(testPrefix.size());
+
+    if (streamLabel_.find('_') != std::string::npos) {
+      throw cms::Exception("GlobalEvFOutputModule")
+          << "Underscore character is reserved can not be used for stream names in "
+             "FFF, but was detected in stream name -: "
+          << streamLabel_;
+    }
+
+    std::string streamLabelLow = streamLabel_;
+    boost::algorithm::to_lower(streamLabelLow);
+    auto streampos = streamLabelLow.rfind("stream");
+    if (streampos != 0 && streampos != std::string::npos)
+      throw cms::Exception("GlobalEvFOutputModule")
+          << "stream (case-insensitive) sequence was found in stream suffix. This is reserved and can not be used for "
+             "names in FFF based HLT, but was detected in stream name";
+
+    fms_ = (evf::FastMonitoringService*)(edm::Service<evf::MicroStateService>().operator->());
+  }
+
+  GlobalEvFOutputModule::~GlobalEvFOutputModule() {}
+
+  void GlobalEvFOutputModule::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+    edm::ParameterSetDescription desc;
+    edm::StreamerOutputModuleCommon::fillDescription(desc);
+    GlobalEvFOutputModuleType::fillDescription(desc);
+    desc.addUntracked<edm::InputTag>("psetMap", {"hltPSetMap"})
+        ->setComment("Optionally allow the map of ParameterSets to be calculated externally.");
+    descriptions.add("globalEvfOutputModule", desc);
+  }
+
+  std::unique_ptr<edm::StreamerOutputModuleCommon> GlobalEvFOutputModule::beginStream(edm::StreamID) const {
+    return std::make_unique<edm::StreamerOutputModuleCommon>(ps_, &keptProducts()[edm::InEvent]);
+  }
+
+  std::shared_ptr<GlobalEvFOutputJSONWriter> GlobalEvFOutputModule::globalBeginRun(edm::RunForOutput const& run) const {
+    //create run Cache holding JSON file writer and variables
+    auto jsonWriter = std::make_unique<GlobalEvFOutputJSONWriter>(streamLabel_);
+
+    edm::StreamerOutputModuleCommon streamerCommon(ps_, &keptProducts()[edm::InEvent]);
+
+    //output INI file (non-const). This doesn't require globalBeginRun to be finished
+    const std::string openIniFileName = edm::Service<evf::EvFDaqDirector>()->getOpenInitFilePath(streamLabel_);
+    edm::LogInfo("GlobalEvFOutputModule") << "beginRun init stream -: " << openIniFileName;
+
+    StreamerOutputFile stream_writer_preamble(openIniFileName);
+    uint32 preamble_adler32 = 1;
+    edm::BranchIDLists const* bidlPtr = branchIDLists();
+
+    auto psetMapHandle = run.getHandle(psetToken_);
+
+    std::unique_ptr<InitMsgBuilder> init_message =
+        streamerCommon.serializeRegistry(*streamerCommon.getSerializerBuffer(),
+                                         *bidlPtr,
+                                         *thinnedAssociationsHelper(),
+                                         OutputModule::processName(),
+                                         description().moduleLabel(),
+                                         moduleDescription().mainParameterSetID(),
+                                         psetMapHandle.isValid() ? psetMapHandle.product() : nullptr);
+
+    //Let us turn it into a View
+    InitMsgView view(init_message->startAddress());
+
+    //output header
+    stream_writer_preamble.write(view);
+    preamble_adler32 = stream_writer_preamble.adler32();
+    stream_writer_preamble.close();
+
+    struct stat istat;
+    stat(openIniFileName.c_str(), &istat);
+    //read back file to check integrity of what was written
+    off_t readInput = 0;
+    uint32_t adlera = 1, adlerb = 0;
+    FILE* src = fopen(openIniFileName.c_str(), "r");
+
+    //allocate buffer to write INI file
+    std::unique_ptr<unsigned char[]> outBuf = std::make_unique<unsigned char[]>(1024 * 1024);
+    while (readInput < istat.st_size) {
+      size_t toRead = readInput + 1024 * 1024 < istat.st_size ? 1024 * 1024 : istat.st_size - readInput;
+      fread(outBuf.get(), toRead, 1, src);
+      cms::Adler32(const_cast<const char*>(reinterpret_cast<char*>(outBuf.get())), toRead, adlera, adlerb);
+      readInput += toRead;
+    }
+    fclose(src);
+
+    //clear serialization buffers
+    streamerCommon.getSerializerBuffer()->clearHeaderBuffer();
+
+    //free output buffer needed only for the file write
+    outBuf.reset();
+
+    uint32_t adler32c = (adlerb << 16) | adlera;
+    if (adler32c != preamble_adler32) {
+      throw cms::Exception("GlobalEvFOutputModule") << "Checksum mismatch of ini file -: " << openIniFileName
+                                                    << " expected:" << preamble_adler32 << " obtained:" << adler32c;
+    } else {
+      LogDebug("GlobalEvFOutputModule") << "Ini file checksum -: " << streamLabel_ << " " << adler32c;
+      std::filesystem::rename(openIniFileName, edm::Service<evf::EvFDaqDirector>()->getInitFilePath(streamLabel_));
+    }
+
+    return jsonWriter;
+  }
+
+  Trig GlobalEvFOutputModule::getTriggerResults(edm::EDGetTokenT<edm::TriggerResults> const& token,
+                                                edm::EventForOutput const& e) const {
+    Trig result;
+    e.getByToken<edm::TriggerResults>(token, result);
+    return result;
+  }
+
+  std::shared_ptr<GlobalEvFOutputEventWriter> GlobalEvFOutputModule::globalBeginLuminosityBlock(
+      edm::LuminosityBlockForOutput const& iLB) const {
+    auto openDatFilePath = edm::Service<evf::EvFDaqDirector>()->getOpenDatFilePath(iLB.luminosityBlock(), streamLabel_);
+
+    return std::make_shared<GlobalEvFOutputEventWriter>(openDatFilePath);
+  }
+
+  void GlobalEvFOutputModule::write(edm::EventForOutput const& e) {
+    edm::Handle<edm::TriggerResults> const& triggerResults = getTriggerResults(trToken_, e);
+
+    //auto lumiWriter = const_cast<GlobalEvFOutputEventWriter*>(luminosityBlockCache(e.getLuminosityBlock().index() ));
+    auto streamerCommon = streamCache(e.streamID());
+    std::unique_ptr<EventMsgBuilder> msg =
+        streamerCommon->serializeEvent(*streamerCommon->getSerializerBuffer(), e, triggerResults, selectorConfig());
+    {
+      auto lumiWriter = luminosityBlockCache(e.getLuminosityBlock().index());
+      const_cast<evf::GlobalEvFOutputEventWriter*>(lumiWriter)
+          ->doOutputEvent(*msg);  //msg is written and discarded at this point
+    }
+  }
+
+  void GlobalEvFOutputModule::globalEndLuminosityBlock(edm::LuminosityBlockForOutput const& iLB) const {
+    auto lumiWriter = luminosityBlockCache(iLB.index());
+    //close dat file
+    const_cast<evf::GlobalEvFOutputEventWriter*>(lumiWriter)->close();
+
+    auto jsonWriter = const_cast<GlobalEvFOutputJSONWriter*>(runCache(iLB.getRun().index()));
+
+    std::lock_guard<std::mutex> guard(jsonWriter->mutex_);
+    jsonWriter->fileAdler32_.value() = lumiWriter->get_adler32();
+    jsonWriter->accepted_.value() = lumiWriter->getAccepted();
+
+    bool abortFlag = false;
+    jsonWriter->processed_.value() = fms_->getEventsProcessedForLumi(iLB.luminosityBlock(), &abortFlag);
+    if (abortFlag) {
+      edm::LogInfo("GlobalEvFOutputModule") << "Abort flag has been set. Output is suppressed";
+      return;
+    }
+
+    if (jsonWriter->processed_.value() != 0) {
+      struct stat istat;
+      std::filesystem::path openDatFilePath = lumiWriter->getFilePath();
+      stat(openDatFilePath.string().c_str(), &istat);
+      jsonWriter->filesize_ = istat.st_size;
+      std::filesystem::rename(openDatFilePath.string().c_str(),
+                              edm::Service<evf::EvFDaqDirector>()->getDatFilePath(iLB.luminosityBlock(), streamLabel_));
+      jsonWriter->filelist_ = openDatFilePath.filename().string();
+    } else {
+      //remove empty file when no event processing has occurred
+      remove(lumiWriter->getFilePath().c_str());
+      jsonWriter->filesize_ = 0;
+      jsonWriter->filelist_ = "";
+      jsonWriter->fileAdler32_.value() = -1;  //no files in signed long
+    }
+
+    //produce JSON file
+    jsonWriter->jsonMonitor_->snap(iLB.luminosityBlock());
+    const std::string outputJsonNameStream =
+        edm::Service<evf::EvFDaqDirector>()->getOutputJsonFilePath(iLB.luminosityBlock(), streamLabel_);
+    jsonWriter->jsonMonitor_->outputFullJSON(outputJsonNameStream, iLB.luminosityBlock());
+  }
+
+}  // namespace evf
+
+using namespace evf;
+DEFINE_FWK_MODULE(GlobalEvFOutputModule);

--- a/EventFilter/Utilities/src/DataPointDefinition.cc
+++ b/EventFilter/Utilities/src/DataPointDefinition.cc
@@ -75,7 +75,7 @@ bool DataPointDefinition::isPopulated() const {
   return false;
 }
 
-OperationType DataPointDefinition::getOperationFor(unsigned int index) {
+OperationType DataPointDefinition::getOperationFor(unsigned int index) const {
   OperationType opType = OPUNKNOWN;
   if (opNames_.at(index) == DataPointDefinition::SUM)
     opType = OPSUM;

--- a/EventFilter/Utilities/src/FastMonitor.cc
+++ b/EventFilter/Utilities/src/FastMonitor.cc
@@ -32,11 +32,12 @@ FastMonitor::FastMonitor(
     getHostAndPID(sourceInfo_);
 
   //load definition file
-  dpd_ = new DataPointDefinition();
-  DataPointDefinition::getDataPointDefinitionFor(defPath_, dpd_, &defGroup);
+  auto temp = new DataPointDefinition();
+  DataPointDefinition::getDataPointDefinitionFor(defPath_, temp, &defGroup);
+  dpd_ = temp;
 }
 
-FastMonitor::FastMonitor(DataPointDefinition* dpd, bool strictChecking, bool useSource, bool useDefinition)
+FastMonitor::FastMonitor(DataPointDefinition const* dpd, bool strictChecking, bool useSource, bool useDefinition)
     : strictChecking_(strictChecking), useSource_(useSource), useDefinition_(useDefinition), nStreams_(1), dpd_(dpd) {
   //get host and PID info
   if (useSource)
@@ -55,8 +56,9 @@ FastMonitor::~FastMonitor() {
 void FastMonitor::addFastPathDefinition(std::string const& defPathFast, std::string const defGroupFast, bool strict) {
   haveFastPath_ = true;
   defPathFast_ = defPathFast;
-  dpdFast_ = new DataPointDefinition();
-  DataPointDefinition::getDataPointDefinitionFor(defPathFast_, dpdFast_, &defGroupFast);
+  auto temp = new DataPointDefinition();
+  DataPointDefinition::getDataPointDefinitionFor(defPathFast_, temp, &defGroupFast);
+  dpdFast_ = temp;
   fastPathStrictChecking_ = strict;
   deleteDefFast_ = true;
 }


### PR DESCRIPTION
#### PR description:

- The GlobalEvFOutputModule creates the same file format as EvFOutputModule but allows concurrent processing of the different cmsRun streams. This allows substantially better thread scaling.
- To make it easier to reason about the change, some code in EventFilter/Utilities had its _const correctness_ improved.

#### PR validation:
Code compiles and a locally run test program runs fine. 

No checks were made on the contents of the created file.

resolves makortel/framework#190
