### PR TITLE
Added esConsumes to L1TTwinMuxProducer

### DIFF
--- a/L1Trigger/L1TTwinMux/interface/AlignTrackSegments.h
+++ b/L1Trigger/L1TTwinMux/interface/AlignTrackSegments.h
@@ -14,26 +14,13 @@
 #define L1T_TwinMux_AlignTrackSegments_H
 
 #include "DataFormats/L1DTTrackFinder/interface/L1MuDTChambPhContainer.h"
-#include "DataFormats/L1DTTrackFinder/interface/L1MuDTChambThContainer.h"
-
-#include "CondFormats/L1TObjects/interface/L1TTwinMuxParams.h"
-#include "CondFormats/DataRecord/interface/L1TTwinMuxParamsRcd.h"
-
-#include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
-#include "FWCore/Framework/interface/Event.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/Framework/interface/ESHandle.h"
-#include "FWCore/Framework/interface/EventSetup.h"
-
-#include <iostream>
 
 class AlignTrackSegments {
 public:
   AlignTrackSegments(L1MuDTChambPhContainer inphiDigis);
   ~AlignTrackSegments(){};
 
-  void run(const edm::EventSetup& c);
+  void run();
 
   ///Return Output PhContainer
   const L1MuDTChambPhContainer& getDTContainer() { return m_dt_tsshifted; }

--- a/L1Trigger/L1TTwinMux/interface/DTLowQMatching.h
+++ b/L1Trigger/L1TTwinMux/interface/DTLowQMatching.h
@@ -33,9 +33,7 @@ class DTLowQMatching {
 public:
   DTLowQMatching(L1MuDTChambPhContainer const*, L1MuDTChambPhContainer const&);
 
-  void run(const edm::EventSetup& c);
-
-  edm::ESHandle<L1TTwinMuxParams> tmParamsHandle;
+  void run(const L1TTwinMuxParams&);
 
   static int noRPCHits(L1MuDTChambPhContainer inCon, int bx, int wh, int sec, int st);
 

--- a/L1Trigger/L1TTwinMux/interface/DTRPCBxCorrection.h
+++ b/L1Trigger/L1TTwinMux/interface/DTRPCBxCorrection.h
@@ -17,15 +17,7 @@
 #include "DataFormats/L1DTTrackFinder/interface/L1MuDTChambThContainer.h"
 
 #include "CondFormats/L1TObjects/interface/L1TTwinMuxParams.h"
-#include "CondFormats/DataRecord/interface/L1TTwinMuxParamsRcd.h"
 #include "L1Trigger/L1TTwinMux/interface/L1MuTMChambPhContainer.h"
-
-#include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
-#include "FWCore/Framework/interface/Event.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/Framework/interface/ESHandle.h"
-#include "FWCore/Framework/interface/EventSetup.h"
 
 #include <iostream>
 
@@ -34,9 +26,7 @@ public:
   DTRPCBxCorrection(L1MuDTChambPhContainer, L1MuDTChambPhContainer);
   ~DTRPCBxCorrection(){};
 
-  void run(const edm::EventSetup& c);
-
-  edm::ESHandle<L1TTwinMuxParams> tmParamsHandle;
+  void run(const L1TTwinMuxParams&);
 
   ///Return Output PhContainer
   L1MuDTChambPhContainer getDTContainer() { return m_dt_tsshifted; }

--- a/L1Trigger/L1TTwinMux/interface/IOPrinter.h
+++ b/L1Trigger/L1TTwinMux/interface/IOPrinter.h
@@ -31,11 +31,8 @@ public:
   void run(edm::Handle<L1MuDTChambPhContainer>,
            const L1MuDTChambPhContainer&,
            edm::Handle<RPCDigiCollection>,
-           const edm::EventSetup&);
-  void run(L1MuDTChambPhContainer const*,
-           const L1MuDTChambPhContainer&,
-           RPCDigiCollection const*,
-           const edm::EventSetup&);
+           const RPCGeometry&);
+  void run(L1MuDTChambPhContainer const*, const L1MuDTChambPhContainer&, RPCDigiCollection const*, const RPCGeometry&);
 };
 
 #endif

--- a/L1Trigger/L1TTwinMux/interface/L1TTwinMuxAlgorithm.h
+++ b/L1Trigger/L1TTwinMux/interface/L1TTwinMuxAlgorithm.h
@@ -17,18 +17,12 @@
 #include "DataFormats/L1DTTrackFinder/interface/L1MuDTChambThContainer.h"
 #include "DataFormats/RPCDigi/interface/RPCDigiCollection.h"
 
+#include "Geometry/RPCGeometry/interface/RPCGeometry.h"
+
 #include "CondFormats/L1TObjects/interface/L1TTwinMuxParams.h"
-#include "CondFormats/DataRecord/interface/L1TTwinMuxParamsRcd.h"
 #include "L1Trigger/L1TTwinMux/interface/L1MuTMChambPhContainer.h"
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
-#include "FWCore/Framework/interface/Event.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/Framework/interface/ESHandle.h"
-#include "FWCore/Framework/interface/EventSetup.h"
-
-#include <iostream>
 
 class L1TTwinMuxAlgorithm {
 public:
@@ -38,17 +32,14 @@ public:
   void run(edm::Handle<L1MuDTChambPhContainer> phiDigis,
            edm::Handle<L1MuDTChambThContainer> thetaDigis,
            edm::Handle<RPCDigiCollection> rpcDigis,
-           const edm::EventSetup& c);
+           const L1TTwinMuxParams&,
+           const RPCGeometry&);
 
   ///Return Output PhContainer
   L1MuDTChambPhContainer get_ph_tm_output() { return m_tm_phi_output; }
 
 private:
-  int radialAngle(RPCDetId, const edm::EventSetup&, int);
   ///Output PhContainer
   L1MuDTChambPhContainer m_tm_phi_output;
-
-  ///Event Setup Handler
-  edm::ESHandle<L1TTwinMuxParams> tmParamsHandle;
 };
 #endif

--- a/L1Trigger/L1TTwinMux/interface/RPCHitCleaner.h
+++ b/L1Trigger/L1TTwinMux/interface/RPCHitCleaner.h
@@ -14,23 +14,11 @@
 
 #include "DataFormats/RPCDigi/interface/RPCDigiCollection.h"
 
-#include "CondFormats/L1TObjects/interface/L1TTwinMuxParams.h"
-#include "CondFormats/DataRecord/interface/L1TTwinMuxParamsRcd.h"
-
-#include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
-#include "FWCore/Framework/interface/Event.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/Framework/interface/ESHandle.h"
-#include "FWCore/Framework/interface/EventSetup.h"
-
-#include <iostream>
-
 class RPCHitCleaner {
 public:
   RPCHitCleaner(RPCDigiCollection const& inrpcDigis);
 
-  void run(const edm::EventSetup& c);
+  void run();
 
   ///Return Output RPCCollection
   RPCDigiCollection const& getRPCCollection() { return m_outrpcDigis; }

--- a/L1Trigger/L1TTwinMux/interface/RPCtoDTTranslator.h
+++ b/L1Trigger/L1TTwinMux/interface/RPCtoDTTranslator.h
@@ -16,32 +16,24 @@
 #include "DataFormats/L1DTTrackFinder/interface/L1MuDTChambThContainer.h"
 #include "DataFormats/RPCDigi/interface/RPCDigiCollection.h"
 
-#include "CondFormats/L1TObjects/interface/L1TTwinMuxParams.h"
-#include "CondFormats/DataRecord/interface/L1TTwinMuxParamsRcd.h"
+#include "Geometry/RPCGeometry/interface/RPCGeometry.h"
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
-#include "FWCore/Framework/interface/Event.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/Framework/interface/ESHandle.h"
-#include "FWCore/Framework/interface/EventSetup.h"
-
-#include <iostream>
 
 class RPCtoDTTranslator {
 public:
   RPCtoDTTranslator(const RPCDigiCollection& inrpcDigis);
 
-  void run(const edm::EventSetup& c);
+  void run(const RPCGeometry&);
 
   ///Return Output PhContainer
   L1MuDTChambPhContainer const& getDTContainer() const { return m_rpcdt_translated; }
   L1MuDTChambPhContainer const& getDTRPCHitsContainer() const { return m_rpchitsdt_translated; }
 
-  static int radialAngle(RPCDetId, const edm::EventSetup&, int);
+  static int radialAngle(RPCDetId, const RPCGeometry&, int);
   static int bendingAngle(int, int, int);
   //static int bendingAngle(int);
-  static int localX(RPCDetId, const edm::EventSetup&, int);
+  static int localX(RPCDetId, const RPCGeometry&, int);
   static int localXX(int, int, int);
 
 private:

--- a/L1Trigger/L1TTwinMux/plugins/L1TTwinMuxProducer.cc
+++ b/L1Trigger/L1TTwinMux/plugins/L1TTwinMuxProducer.cc
@@ -13,10 +13,13 @@
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
-#include <FWCore/Framework/interface/ConsumesCollector.h>
-#include <FWCore/ParameterSet/interface/ParameterSet.h>
+#include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Utilities/interface/ESGetToken.h"
+
+#include "CondFormats/DataRecord/interface/L1TTwinMuxParamsRcd.h"
+#include "Geometry/Records/interface/MuonGeometryRecord.h"
 
 #include "L1Trigger/L1TTwinMux/interface/L1TTwinMuxAlgorithm.h"
 
@@ -35,32 +38,29 @@ public:
   void produce(edm::Event& e, const edm::EventSetup& c) override;
 
 private:
-  //L1TTwinMuxAlgorithm *  m_l1tma;
-  //  std::unique_ptr<L1TTwinMuxAlgorithm> m_l1tma(new L1TTwinMuxAlgorithm());
-  edm::EDGetToken m_dtdigi, m_dtthetadigi, m_rpcsource;
+  const edm::EDGetTokenT<L1MuDTChambPhContainer> m_dtdigi;
+  const edm::EDGetTokenT<L1MuDTChambThContainer> m_dtthetadigi;
+  const edm::EDGetTokenT<RPCDigiCollection> m_rpcsource;
   ///Event Setup Handler
-  edm::ESHandle<L1TTwinMuxParams> tmParamsHandle;
-  edm::ESGetToken<L1TTwinMuxParams, L1TTwinMuxParamsRcd> m_tmParamsToken;
+  const edm::ESGetToken<L1TTwinMuxParams, L1TTwinMuxParamsRcd> m_tmParamsToken;
+  const edm::ESGetToken<RPCGeometry, MuonGeometryRecord> m_rpcGeometryToken;
+
+  const edm::EDPutTokenT<L1MuDTChambPhContainer> m_phContainerToken;
+  const edm::EDPutTokenT<L1MuDTChambThContainer> m_thContainerToken;
 };
 
-L1TTwinMuxProducer::L1TTwinMuxProducer(const edm::ParameterSet& pset) {
-  //m_l1tma = new L1TTwinMuxAlgorithm();
-  // std::unique_ptr<L1TTwinMuxAlgorithm> m_l1tma(new L1TTwinMuxAlgorithm());
-
-  m_dtdigi = consumes<L1MuDTChambPhContainer>(pset.getParameter<edm::InputTag>("DTDigi_Source"));
-  m_dtthetadigi = consumes<L1MuDTChambThContainer>(pset.getParameter<edm::InputTag>("DTThetaDigi_Source"));
-  m_rpcsource = consumes<RPCDigiCollection>(pset.getParameter<edm::InputTag>("RPC_Source"));
-  m_tmParamsToken = esConsumes<L1TTwinMuxParams, L1TTwinMuxParamsRcd>();
-
-  produces<L1MuDTChambPhContainer>();
-  produces<L1MuDTChambThContainer>();
-}
+L1TTwinMuxProducer::L1TTwinMuxProducer(const edm::ParameterSet& pset)
+    : m_dtdigi(consumes(pset.getParameter<edm::InputTag>("DTDigi_Source"))),
+      m_dtthetadigi(consumes(pset.getParameter<edm::InputTag>("DTThetaDigi_Source"))),
+      m_rpcsource(consumes(pset.getParameter<edm::InputTag>("RPC_Source"))),
+      m_tmParamsToken(esConsumes()),
+      m_rpcGeometryToken(esConsumes()),
+      m_phContainerToken(produces<L1MuDTChambPhContainer>()),
+      m_thContainerToken(produces<L1MuDTChambThContainer>()) {}
 
 void L1TTwinMuxProducer::produce(edm::Event& e, const edm::EventSetup& c) {
-  std::unique_ptr<L1TTwinMuxAlgorithm> m_l1tma(new L1TTwinMuxAlgorithm());
   ///Check consistency of the paramters
-  tmParamsHandle = c.getHandle(m_tmParamsToken);
-  const L1TTwinMuxParams& tmParams = *tmParamsHandle.product();
+  auto const& tmParams = c.getData(m_tmParamsToken);
 
   ///Only RPC: the emulator's output consist from rpc->dy primitives only
   bool onlyRPC = tmParams.get_UseOnlyRPC();
@@ -73,29 +73,27 @@ void L1TTwinMuxProducer::produce(edm::Event& e, const edm::EventSetup& c) {
   }
   ///---Check consistency of the paramters
 
-  edm::Handle<L1MuDTChambPhContainer> phiDigis;
-  edm::Handle<L1MuDTChambThContainer> thetaDigis;
-  e.getByToken(m_dtdigi, phiDigis);
-  e.getByToken(m_dtthetadigi, thetaDigis);
+  edm::Handle<L1MuDTChambPhContainer> phiDigis = e.getHandle(m_dtdigi);
+  edm::Handle<L1MuDTChambThContainer> thetaDigis = e.getHandle(m_dtthetadigi);
 
-  edm::Handle<RPCDigiCollection> rpcDigis;
-  e.getByToken(m_rpcsource, rpcDigis);
+  edm::Handle<RPCDigiCollection> rpcDigis = e.getHandle(m_rpcsource);
 
   if (!phiDigis.isValid()) {
     edm::LogWarning("Inconsistent digis") << "input DT phi digis not valid";
   }
 
-  //std::unique_ptr<L1MuDTChambPhContainer> l1ttmp(new L1MuDTChambPhContainer);
-  auto l1ttmp = std::make_unique<L1MuDTChambPhContainer>();
-  m_l1tma->run(phiDigis, thetaDigis, rpcDigis, c);
-  *l1ttmp = m_l1tma->get_ph_tm_output();
-  //null transfer of theta digis
-  auto l1ttmth = std::make_unique<L1MuDTChambThContainer>();
-  const std::vector<L1MuDTChambThDigi>* theta = thetaDigis->getContainer();
-  l1ttmth->setContainer(*theta);
+  auto const& rpcGeometry = c.getData(m_rpcGeometryToken);
 
-  e.put(std::move(l1ttmp));
-  e.put(std::move(l1ttmth));
+  L1TTwinMuxAlgorithm l1tma;
+  l1tma.run(phiDigis, thetaDigis, rpcDigis, tmParams, rpcGeometry);
+  auto l1ttmp = l1tma.get_ph_tm_output();
+  //null transfer of theta digis
+  L1MuDTChambThContainer l1ttmth;
+  const std::vector<L1MuDTChambThDigi>* theta = thetaDigis->getContainer();
+  l1ttmth.setContainer(*theta);
+
+  e.emplace(m_phContainerToken, std::move(l1ttmp));
+  e.emplace(m_thContainerToken, std::move(l1ttmth));
 }
 
 DEFINE_FWK_MODULE(L1TTwinMuxProducer);

--- a/L1Trigger/L1TTwinMux/plugins/L1TTwinMuxProducer.cc
+++ b/L1Trigger/L1TTwinMux/plugins/L1TTwinMuxProducer.cc
@@ -15,7 +15,7 @@
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
 #include "FWCore/Utilities/interface/ESGetToken.h"
 
 #include "CondFormats/DataRecord/interface/L1TTwinMuxParamsRcd.h"
@@ -29,13 +29,11 @@
 
 using namespace std;
 
-//class L1TTwinMuxProducer: public edm::one::EDProducer<edm::one::SharedResources>
-//class L1TTwinMuxProducer: public edm::EDProducer
-class L1TTwinMuxProducer : public edm::stream::EDProducer<> {
+class L1TTwinMuxProducer : public edm::global::EDProducer<> {
 public:
   L1TTwinMuxProducer(const edm::ParameterSet& pset);
   ~L1TTwinMuxProducer() override {}
-  void produce(edm::Event& e, const edm::EventSetup& c) override;
+  void produce(edm::StreamID, edm::Event& e, const edm::EventSetup& c) const override;
 
 private:
   const edm::EDGetTokenT<L1MuDTChambPhContainer> m_dtdigi;
@@ -58,7 +56,7 @@ L1TTwinMuxProducer::L1TTwinMuxProducer(const edm::ParameterSet& pset)
       m_phContainerToken(produces<L1MuDTChambPhContainer>()),
       m_thContainerToken(produces<L1MuDTChambThContainer>()) {}
 
-void L1TTwinMuxProducer::produce(edm::Event& e, const edm::EventSetup& c) {
+void L1TTwinMuxProducer::produce(edm::StreamID, edm::Event& e, const edm::EventSetup& c) const {
   ///Check consistency of the paramters
   auto const& tmParams = c.getData(m_tmParamsToken);
 

--- a/L1Trigger/L1TTwinMux/src/AlignTrackSegments.cc
+++ b/L1Trigger/L1TTwinMux/src/AlignTrackSegments.cc
@@ -22,7 +22,7 @@ AlignTrackSegments::AlignTrackSegments(L1MuDTChambPhContainer inm_phiDigis)
           //   m_phiDigis = inm_phiDigis;
       };
 
-void AlignTrackSegments::run(const edm::EventSetup& c) {
+void AlignTrackSegments::run() {
   std::vector<L1MuDTChambPhDigi> l1ttma_out;
 
   for (int bx = -3; bx <= 3; bx++) {

--- a/L1Trigger/L1TTwinMux/src/DTLowQMatching.cc
+++ b/L1Trigger/L1TTwinMux/src/DTLowQMatching.cc
@@ -26,11 +26,7 @@ DTLowQMatching::DTLowQMatching(L1MuDTChambPhContainer const* inphiDTDigis, L1MuD
           // m_phiRPCDigis=inphiRPCDigis;
       };
 
-void DTLowQMatching::run(const edm::EventSetup& c) {
-  const L1TTwinMuxParamsRcd& tmParamsRcd = c.get<L1TTwinMuxParamsRcd>();
-  tmParamsRcd.get(tmParamsHandle);
-  const L1TTwinMuxParams& tmParams = *tmParamsHandle.product();
-
+void DTLowQMatching::run(const L1TTwinMuxParams& tmParams) {
   m_DphiWindow = tmParams.get_DphiWindowBxShift();
 
   Matching(0);

--- a/L1Trigger/L1TTwinMux/src/DTRPCBxCorrection.cc
+++ b/L1Trigger/L1TTwinMux/src/DTRPCBxCorrection.cc
@@ -12,6 +12,7 @@
 #include <iostream>
 #include <iomanip>
 #include <iterator>
+#include <algorithm>
 
 #include "L1Trigger/L1TTwinMux/interface/DTRPCBxCorrection.h"
 #include "L1Trigger/L1TTwinMux/interface/L1MuTMChambPhContainer.h"
@@ -25,11 +26,7 @@ DTRPCBxCorrection::DTRPCBxCorrection(L1MuDTChambPhContainer inphiDTDigis, L1MuDT
           //  m_phiRPCDigis=inphiRPCDigis;
       };
 
-void DTRPCBxCorrection::run(const edm::EventSetup& c) {
-  const L1TTwinMuxParamsRcd& tmParamsRcd = c.get<L1TTwinMuxParamsRcd>();
-  tmParamsRcd.get(tmParamsHandle);
-  const L1TTwinMuxParams& tmParams = *tmParamsHandle.product();
-
+void DTRPCBxCorrection::run(const L1TTwinMuxParams& tmParams) {
   m_QualityLimit = tmParams.get_USERPCBXFORDTBELOWQUALITY();
   m_DphiWindow = tmParams.get_DphiWindowBxShift();
 

--- a/L1Trigger/L1TTwinMux/src/IOPrinter.cc
+++ b/L1Trigger/L1TTwinMux/src/IOPrinter.cc
@@ -11,13 +11,14 @@
 //--------------------------------------------------
 #include "L1Trigger/L1TTwinMux/interface/IOPrinter.h"
 #include "L1Trigger/L1TTwinMux/interface/L1MuTMChambPhContainer.h"
+#include "DataFormats/Common/interface/Handle.h"
 
 using namespace std;
 
 void IOPrinter::run(edm::Handle<L1MuDTChambPhContainer> inphiDigis,
                     const L1MuDTChambPhContainer& outphiDigis,
                     edm::Handle<RPCDigiCollection> rpcDigis,
-                    const edm::EventSetup& c) {
+                    const RPCGeometry& rpcGeometry) {
   cout << "======================================================" << endl;
   int bx = 0, wheel = 0, sector = 0, station = 1;
 
@@ -58,8 +59,8 @@ void IOPrinter::run(edm::Handle<L1MuDTChambPhContainer> inphiDigis,
     for (auto digi = (*chamber).second.first; digi != (*chamber).second.second; ++digi) {
       RPCDigi digi_out(digi->strip(), digi->bx());
       //if(digi->bx()!=0) continue;
-      int phi = RPCtoDTTranslator::radialAngle(detid, c, digi->strip()) << 2;
-      float localx = RPCtoDTTranslator::localX(detid, c, digi->strip());
+      int phi = RPCtoDTTranslator::radialAngle(detid, rpcGeometry, digi->strip()) << 2;
+      float localx = RPCtoDTTranslator::localX(detid, rpcGeometry, digi->strip());
       cout << digi->bx() << "\t" << detid.ring() << "\t" << detid.sector() - 1 << "\t" << detid.station() << "\t"
            << detid.roll() << "\t" << detid.layer() << "\t" << digi->strip() << "\t" << phi << "\t" << localx << endl;
     }  ///for digicout
@@ -98,7 +99,7 @@ void IOPrinter::run(edm::Handle<L1MuDTChambPhContainer> inphiDigis,
 void IOPrinter::run(L1MuDTChambPhContainer const* inphiDigis,
                     const L1MuDTChambPhContainer& outphiDigis,
                     RPCDigiCollection const* rpcDigis,
-                    const edm::EventSetup& c) {
+                    const RPCGeometry& rpcGeometry) {
   cout << "======================================================" << endl;
   int bx = 0, wheel = 0, sector = 0, station = 1;
   L1MuTMChambPhContainer inphiDigis_tm;
@@ -137,8 +138,8 @@ void IOPrinter::run(L1MuDTChambPhContainer const* inphiDigis,
     for (auto digi = (*chamber).second.first; digi != (*chamber).second.second; ++digi) {
       RPCDigi digi_out(digi->strip(), digi->bx());
       //if(digi->bx()!=0) continue;
-      int phi = RPCtoDTTranslator::radialAngle(detid, c, digi->strip()) << 2;
-      float localx = RPCtoDTTranslator::localX(detid, c, digi->strip());
+      int phi = RPCtoDTTranslator::radialAngle(detid, rpcGeometry, digi->strip()) << 2;
+      float localx = RPCtoDTTranslator::localX(detid, rpcGeometry, digi->strip());
       cout << digi->bx() << "\t" << detid.ring() << "\t" << detid.sector() - 1 << "\t" << detid.station() << "\t"
            << detid.roll() << "\t" << detid.layer() << "\t" << digi->strip() << "\t" << phi << "\t" << localx << endl;
     }  ///for digicout

--- a/L1Trigger/L1TTwinMux/src/RPCHitCleaner.cc
+++ b/L1Trigger/L1TTwinMux/src/RPCHitCleaner.cc
@@ -48,7 +48,7 @@ namespace {
   };
 }  // namespace
 
-void RPCHitCleaner::run(const edm::EventSetup& c) {
+void RPCHitCleaner::run() {
   std::map<detId_Ext, int> hits;
   vector<int> vcluster_size;
   std::map<RPCDetId, int> bx_hits;

--- a/L1Trigger/L1TTwinMux/src/RPCtoDTTranslator.cc
+++ b/L1Trigger/L1TTwinMux/src/RPCtoDTTranslator.cc
@@ -68,7 +68,7 @@ namespace {
   };
 }  // namespace
 
-void RPCtoDTTranslator::run(const edm::EventSetup& c) {
+void RPCtoDTTranslator::run(const RPCGeometry& rpcGeometry) {
   std::vector<L1MuDTChambPhDigi> l1ttma_out;
   std::vector<L1MuDTChambPhDigi> l1ttma_hits_out;
 
@@ -169,14 +169,14 @@ void RPCtoDTTranslator::run(const edm::EventSetup& c) {
         for (unsigned int l1 = 0; l1 < vrpc_hit_layer1.size(); l1++) {
           RPCHitCleaner::detId_Ext tmp{vrpc_hit_layer1[l1].detid, vrpc_hit_layer1[l1].bx, vrpc_hit_layer1[l1].strip};
           int id = hits[tmp];
-          int phi1 = radialAngle(vrpc_hit_layer1[l1].detid, c, vrpc_hit_layer1[l1].strip);
+          int phi1 = radialAngle(vrpc_hit_layer1[l1].detid, rpcGeometry, vrpc_hit_layer1[l1].strip);
           if (vcluster_size[id] == 2 && itr1 == 0) {
             itr1++;
             continue;
           }
           if (vcluster_size[id] == 2 && itr1 == 1) {
             itr1 = 0;
-            phi1 = phi1 + (radialAngle(vrpc_hit_layer1[l1 - 1].detid, c, vrpc_hit_layer1[l1 - 1].strip));
+            phi1 = phi1 + (radialAngle(vrpc_hit_layer1[l1 - 1].detid, rpcGeometry, vrpc_hit_layer1[l1 - 1].strip));
             phi1 /= 2;
           }
           int itr2 = 0;
@@ -198,10 +198,10 @@ void RPCtoDTTranslator::run(const edm::EventSetup& c) {
             }
 
             //int phi1 = radialAngle(vrpc_hit_layer1[l1].detid, c, vrpc_hit_layer1[l1].strip) ;
-            int phi2 = radialAngle(vrpc_hit_layer2[l2].detid, c, vrpc_hit_layer2[l2].strip);
+            int phi2 = radialAngle(vrpc_hit_layer2[l2].detid, rpcGeometry, vrpc_hit_layer2[l2].strip);
             if (vcluster_size[id] == 2 && itr2 == 1) {
               itr2 = 0;
-              phi2 = phi2 + (radialAngle(vrpc_hit_layer2[l2 - 1].detid, c, vrpc_hit_layer2[l2 - 1].strip));
+              phi2 = phi2 + (radialAngle(vrpc_hit_layer2[l2 - 1].detid, rpcGeometry, vrpc_hit_layer2[l2 - 1].strip));
               phi2 /= 2;
             }
             int average = ((phi1 + phi2) / 2) << 2;  //10-bit->12-bit
@@ -213,8 +213,8 @@ void RPCtoDTTranslator::run(const edm::EventSetup& c) {
             int xin = localXX((phi1 << 2), 1, vrpc_hit_layer1[l1].station);
             int xout = localXX((phi2 << 2), 2, vrpc_hit_layer2[l2].station);
             if (vcluster_size[id] == 2 && itr2 == 1) {
-              int phi1_n1 = radialAngle(vrpc_hit_layer1[l1 - 1].detid, c, vrpc_hit_layer1[l1 - 1].strip);
-              int phi2_n1 = radialAngle(vrpc_hit_layer2[l2 - 1].detid, c, vrpc_hit_layer2[l2 - 1].strip);
+              int phi1_n1 = radialAngle(vrpc_hit_layer1[l1 - 1].detid, rpcGeometry, vrpc_hit_layer1[l1 - 1].strip);
+              int phi2_n1 = radialAngle(vrpc_hit_layer2[l2 - 1].detid, rpcGeometry, vrpc_hit_layer2[l2 - 1].strip);
               xin += localXX((phi1_n1 << 2), 1, vrpc_hit_layer1[l1].station);
               xout += localXX((phi2_n1 << 2), 2, vrpc_hit_layer2[l2].station);
               xin /= 2;
@@ -250,11 +250,11 @@ void RPCtoDTTranslator::run(const edm::EventSetup& c) {
             itr1++;
             continue;
           }
-          int phi2 = radialAngle(vrpc_hit_layer1[l1].detid, c, vrpc_hit_layer1[l1].strip);
+          int phi2 = radialAngle(vrpc_hit_layer1[l1].detid, rpcGeometry, vrpc_hit_layer1[l1].strip);
           phi2 = phi2 << 2;
           if (vcluster_size[id] == 2 && itr1 == 1) {
             itr1 = 0;
-            phi2 = phi2 + (radialAngle(vrpc_hit_layer1[l1 - 1].detid, c, vrpc_hit_layer1[l1 - 1].strip) << 2);
+            phi2 = phi2 + (radialAngle(vrpc_hit_layer1[l1 - 1].detid, rpcGeometry, vrpc_hit_layer1[l1 - 1].strip) << 2);
             phi2 /= 2;
           }
 
@@ -274,11 +274,11 @@ void RPCtoDTTranslator::run(const edm::EventSetup& c) {
             itr1++;
             continue;
           }
-          int phi2 = radialAngle(vrpc_hit_layer2[l2].detid, c, vrpc_hit_layer2[l2].strip);
+          int phi2 = radialAngle(vrpc_hit_layer2[l2].detid, rpcGeometry, vrpc_hit_layer2[l2].strip);
           phi2 = phi2 << 2;
           if (vcluster_size[id] == 2 && itr1 == 1) {
             itr1 = 0;
-            phi2 = phi2 + (radialAngle(vrpc_hit_layer2[l2 - 1].detid, c, vrpc_hit_layer2[l2 - 1].strip) << 2);
+            phi2 = phi2 + (radialAngle(vrpc_hit_layer2[l2 - 1].detid, rpcGeometry, vrpc_hit_layer2[l2 - 1].strip) << 2);
             phi2 /= 2;
           }
           l1ttma_hits_out.emplace_back(
@@ -298,11 +298,11 @@ void RPCtoDTTranslator::run(const edm::EventSetup& c) {
             itr1++;
             continue;
           }
-          int phi2 = radialAngle(vrpc_hit_st3[l1].detid, c, vrpc_hit_st3[l1].strip);
+          int phi2 = radialAngle(vrpc_hit_st3[l1].detid, rpcGeometry, vrpc_hit_st3[l1].strip);
           phi2 = phi2 << 2;
           if (vcluster_size[id] == 2 && itr1 == 1) {
             itr1 = 0;
-            phi2 = phi2 + (radialAngle(vrpc_hit_st3[l1 - 1].detid, c, vrpc_hit_st3[l1 - 1].strip) << 2);
+            phi2 = phi2 + (radialAngle(vrpc_hit_st3[l1 - 1].detid, rpcGeometry, vrpc_hit_st3[l1 - 1].strip) << 2);
             phi2 /= 2;
           }
           l1ttma_hits_out.emplace_back(
@@ -322,11 +322,11 @@ void RPCtoDTTranslator::run(const edm::EventSetup& c) {
             itr1++;
             continue;
           }
-          int phi2 = radialAngle(vrpc_hit_st4[l1].detid, c, vrpc_hit_st4[l1].strip);
+          int phi2 = radialAngle(vrpc_hit_st4[l1].detid, rpcGeometry, vrpc_hit_st4[l1].strip);
           phi2 = phi2 << 2;
           if (vcluster_size[id] == 2 && itr1 == 1) {
             itr1 = 0;
-            phi2 = phi2 + (radialAngle(vrpc_hit_st4[l1 - 1].detid, c, vrpc_hit_st4[l1 - 1].strip) << 2);
+            phi2 = phi2 + (radialAngle(vrpc_hit_st4[l1 - 1].detid, rpcGeometry, vrpc_hit_st4[l1 - 1].strip) << 2);
             phi2 /= 2;
           }
           l1ttma_hits_out.emplace_back(
@@ -346,13 +346,11 @@ void RPCtoDTTranslator::run(const edm::EventSetup& c) {
 }
 
 ///function - will be replaced by LUTs(?)
-int RPCtoDTTranslator::radialAngle(RPCDetId detid, const edm::EventSetup& c, int strip) {
+int RPCtoDTTranslator::radialAngle(RPCDetId detid, const RPCGeometry& rpcGeometry, int strip) {
   int radialAngle;
   // from phiGlobal to radialAngle of the primitive in sector sec in [1..12] <- RPC scheme
-  edm::ESHandle<RPCGeometry> rpcGeometry;
-  c.get<MuonGeometryRecord>().get(rpcGeometry);
 
-  const RPCRoll* roll = rpcGeometry->roll(detid);
+  const RPCRoll* roll = rpcGeometry.roll(detid);
   GlobalPoint stripPosition = roll->toGlobal(roll->centreOfStrip(strip));
 
   double globalphi = stripPosition.phi();
@@ -369,11 +367,8 @@ int RPCtoDTTranslator::radialAngle(RPCDetId detid, const edm::EventSetup& c, int
 }
 
 ///function - will be replaced by LUTs(?)
-int RPCtoDTTranslator::localX(RPCDetId detid, const edm::EventSetup& c, int strip) {
-  edm::ESHandle<RPCGeometry> rpcGeometry;
-  c.get<MuonGeometryRecord>().get(rpcGeometry);
-
-  const RPCRoll* roll = rpcGeometry->roll(detid);
+int RPCtoDTTranslator::localX(RPCDetId detid, const RPCGeometry& rpcGeometry, int strip) {
+  const RPCRoll* roll = rpcGeometry.roll(detid);
 
   ///Orientaion of RPCs
   GlobalPoint p1cmPRG = roll->toGlobal(LocalPoint(1, 0, 0));


### PR DESCRIPTION
#### PR description:

- Added esConsumes to L1TTwinMuxProducer
- Modernized code
- Made L1TTwinMuxProducer a global module
- Modified helper classes to no longer take an `edm::EventSetup` as an argument and instead directly take the data products they need.

#### PR validation:

Code compiles. This is just a refactoring and should not cause any changes to results.
