### PR TITLE
Make new HF Shower Library the default for Run3

### DIFF
--- a/Configuration/Eras/python/Era_Run3_cff.py
+++ b/Configuration/Eras/python/Era_Run3_cff.py
@@ -4,10 +4,11 @@ from Configuration.Eras.Era_Run2_2018_cff import Run2_2018
 from Configuration.Eras.Modifier_run3_common_cff import run3_common
 from Configuration.Eras.Modifier_run3_GEM_cff import run3_GEM
 from Configuration.Eras.Modifier_run3_HB_cff import run3_HB
+from Configuration.Eras.Modifier_run3_HFSL_cff import run3_HFSL
 from Configuration.Eras.Modifier_run2_GEM_2017_cff import run2_GEM_2017
 from Configuration.Eras.Modifier_stage2L1Trigger_2021_cff import stage2L1Trigger_2021
 from Configuration.Eras.Modifier_ctpps_2018_cff import ctpps_2018
 from Configuration.Eras.Modifier_ctpps_2021_cff import ctpps_2021
 
-Run3 = cms.ModifierChain(Run2_2018.copyAndExclude([run2_GEM_2017, ctpps_2018]), run3_common, run3_GEM, run3_HB, stage2L1Trigger_2021, ctpps_2021)
+Run3 = cms.ModifierChain(Run2_2018.copyAndExclude([run2_GEM_2017, ctpps_2018]), run3_common, run3_GEM, run3_HB, run3_HFSL, stage2L1Trigger_2021, ctpps_2021)
 

--- a/Configuration/StandardSequences/python/Eras.py
+++ b/Configuration/StandardSequences/python/Eras.py
@@ -60,7 +60,7 @@ class Eras (object):
                            'peripheralPbPb', 'pA_2016',
                            'run2_HE_2017', 'stage2L1Trigger', 'stage2L1Trigger_2017', 'stage2L1Trigger_2018', 'stage2L1Trigger_2021',
                            'run2_HF_2017', 'run2_HCAL_2017', 'run2_HEPlan1_2017', 'run2_HB_2018','run2_HE_2018', 
-                           'run3_HB', 'run3_common', 'run3_RPC',
+                           'run3_HB', 'run3_HFSL', 'run3_common', 'run3_RPC',
                            'phase1Pixel', 'run3_GEM', 'run2_GEM_2017',
                            'run2_CSC_2018',
                            'phase2_common', 'phase2_tracker',

--- a/SimCalorimetry/HcalSimProducers/python/hcalSimParameters_cfi.py
+++ b/SimCalorimetry/HcalSimProducers/python/hcalSimParameters_cfi.py
@@ -179,7 +179,13 @@ run3_common.toModify( hcalSimParameters,
     he = dict(
                readoutFrameSize = cms.int32(10), 
                binOfMaximum     = cms.int32(6)
-              )
+              ),
+    hf1 = dict( samplingFactor = 0.35,
+                timePhase = -6.0 
+               ),
+    hf2 = dict( samplingFactor = 0.35,
+                timePhase = -7.0
+               )
 ) 
 
 

--- a/SimG4CMS/ShowerLibraryProducer/interface/HcalForwardLibWriter.h
+++ b/SimG4CMS/ShowerLibraryProducer/interface/HcalForwardLibWriter.h
@@ -43,6 +43,8 @@ private:
   int nshowers;
   int bsize;
   int splitlevel;
+  int compressionAlgo;
+  int compressionLevel;
 
   TFile* theFile;
   TTree* theTree;

--- a/SimG4CMS/ShowerLibraryProducer/plugins/HcalForwardLibWriter.cc
+++ b/SimG4CMS/ShowerLibraryProducer/plugins/HcalForwardLibWriter.cc
@@ -10,6 +10,8 @@ HcalForwardLibWriter::HcalForwardLibWriter(const edm::ParameterSet& iConfig) {
   nshowers = theParms.getParameter<int>("Nshowers");
   bsize = theParms.getParameter<int>("BufSize");
   splitlevel = theParms.getParameter<int>("SplitLevel");
+  compressionAlgo = theParms.getParameter<int>("CompressionAlgo");
+  compressionLevel = theParms.getParameter<int>("CompressionLevel");
 
   std::string pName = fp.fullPath();
   if (pName.find('.') == 0)
@@ -18,6 +20,9 @@ HcalForwardLibWriter::HcalForwardLibWriter(const edm::ParameterSet& iConfig) {
   readUserData();
 
   fs->file().cd();
+  fs->file().SetCompressionAlgorithm(compressionAlgo);
+  fs->file().SetCompressionLevel(compressionLevel);
+
   LibTree = new TTree("HFSimHits", "HFSimHits");
 
   //https://root.cern/root/html534/TTree.html

--- a/SimG4CMS/ShowerLibraryProducer/python/writelibraryfile_cfg.py
+++ b/SimG4CMS/ShowerLibraryProducer/python/writelibraryfile_cfg.py
@@ -15,7 +15,9 @@ process.photon = cms.EDAnalyzer('HcalForwardLibWriter',
 	Nbins = cms.int32(16),
 	Nshowers = cms.int32(10000),
         BufSize = cms.int32(1),
-        SplitLevel = cms.int32(2)
+        SplitLevel = cms.int32(2),
+        CompressionAlgo = cms.int32(4),
+        CompressionLevel = cms.int32(4)
     )
 )
 


### PR DESCRIPTION
#### PR description:

Presentation at Simulation meeting on July 16 (updated on July 26) 
https://indico.cern.ch/event/1060045/contributions/4455234/attachments/2282906/3888021/Status_newHF_SL_S.A.July16_2021.pdf

Uses earlier implemented (in preparatory PR   https://github.com/cms-sw/cmssw/pull/34432)  modifier "run3_HFSL". 
The library file itself has been added to cmsdist several days ago https://github.com/cms-sw/cmsdist/pull/7162
In addtion, _standalone_ HF Shower Library assembly code/config is updated in this PR.

#### PR validation:

Some results available in the aforementioned presentation.
Technical test:  
        runTheMatrix.py -l limited 
OK     
