### PR TITLE
Add esConsumes to OmtfPacker and OmtfUnpacker

### DIFF
--- a/EventFilter/L1TRawToDigi/interface/OmtfLinkMappingRpc.h
+++ b/EventFilter/L1TRawToDigi/interface/OmtfLinkMappingRpc.h
@@ -9,11 +9,9 @@
 
 #include "EventFilter/L1TRawToDigi/interface/OmtfEleIndex.h"
 #include "CondFormats/RPCObjects/interface/LinkBoardElectronicIndex.h"
+#include "CondFormats/RPCObjects/interface/RPCAMCLinkMap.h"
 
 class RPCReadOutMapping;
-namespace edm {
-  class EventSetup;
-}
 
 namespace omtf {
 
@@ -33,7 +31,7 @@ namespace omtf {
   public:
     RpcLinkMap() {}
 
-    void init(const edm::EventSetup& es);
+    void init(const RPCAMCLinkMap& es);
 
     void init(const std::string& fName);
 

--- a/EventFilter/L1TRawToDigi/interface/OmtfRpcPacker.h
+++ b/EventFilter/L1TRawToDigi/interface/OmtfRpcPacker.h
@@ -7,6 +7,7 @@
 #include "DataFormats/L1TMuon/interface/OMTF/OmtfDataWord64.h"
 #include "EventFilter/L1TRawToDigi/interface/OmtfLinkMappingRpc.h"
 #include "CondFormats/RPCObjects/interface/RPCReadOutMapping.h"
+#include "CondFormats/RPCObjects/interface/RPCEMap.h"
 
 namespace edm {
   class EventSetup;
@@ -18,12 +19,12 @@ namespace omtf {
   public:
     RpcPacker() {}
 
-    void init(const edm::EventSetup& es);
-    void init(const edm::EventSetup& es, const std::string& connectionFile);
+    void init(const RPCEMap& readoutMapping, const RPCAMCLinkMap& linkMap);
+    void init(const RPCEMap& readoutMapping, const std::string& connectionFile);
     void pack(const RPCDigiCollection* prod, FedAmcRawsMap& raws);
 
   private:
-    void initCabling(const edm::EventSetup& es);
+    void initCabling(const RPCEMap& readoutMapping);
 
     MapLBIndex2EleIndex thePact2Omtf;
     std::unique_ptr<const RPCReadOutMapping> thePactCabling;

--- a/EventFilter/L1TRawToDigi/interface/OmtfRpcUnpacker.h
+++ b/EventFilter/L1TRawToDigi/interface/OmtfRpcUnpacker.h
@@ -8,6 +8,7 @@
 #include "DataFormats/L1TMuon/interface/OMTF/OmtfDataWord64.h"
 #include "EventFilter/L1TRawToDigi/interface/OmtfLinkMappingRpc.h"
 #include "CondFormats/RPCObjects/interface/RPCReadOutMapping.h"
+#include "CondFormats/RPCObjects/interface/RPCEMap.h"
 
 namespace edm {
   class EventSetup;
@@ -22,12 +23,12 @@ namespace omtf {
   public:
     RpcUnpacker() {}
 
-    void init(const edm::EventSetup &es);
-    void init(const edm::EventSetup &es, const std::string &connectionFile);
-    void unpack(int triggerBX, unsigned int fed, unsigned int amc, const RpcDataWord64 &raw, RPCDigiCollection *prod);
+    void init(const RPCEMap& readoutMapping, const RPCAMCLinkMap& linkMap);
+    void init(const RPCEMap& readoutMapping, const std::string& connectionFile);
+    void unpack(int triggerBX, unsigned int fed, unsigned int amc, const RpcDataWord64& raw, RPCDigiCollection* prod);
 
   private:
-    void initCabling(const edm::EventSetup &es);
+    void initCabling(const RPCEMap& readoutMapping);
 
     MapEleIndex2LBIndex theOmtf2Pact;
     std::unique_ptr<const RPCReadOutMapping> thePactCabling;

--- a/EventFilter/L1TRawToDigi/plugins/OmtfPacker.cc
+++ b/EventFilter/L1TRawToDigi/plugins/OmtfPacker.cc
@@ -41,6 +41,10 @@
 #include "EventFilter/L1TRawToDigi/interface/OmtfCscPacker.h"
 #include "EventFilter/L1TRawToDigi/interface/OmtfDtPacker.h"
 
+#include "CondFormats/RPCObjects/interface/RPCEMap.h"
+#include "CondFormats/DataRecord/interface/RPCEMapRcd.h"
+#include "CondFormats/DataRecord/interface/RPCOMTFLinkMapRcd.h"
+
 namespace omtf {
 
   class OmtfPacker : public edm::stream::EDProducer<> {
@@ -108,10 +112,15 @@ namespace omtf {
     // initialise RPC packer
     //
     if (!theSkipRpc) {
+      edm::ESTransientHandle<RPCEMap> readoutMapping;
+      es.get<RPCEMapRcd>().get(readoutMapping);
       if (theConfig.getParameter<bool>("useRpcConnectionFile")) {
-        theRpcPacker.init(es, edm::FileInPath(theConfig.getParameter<std::string>("rpcConnectionFile")).fullPath());
+        theRpcPacker.init(*readoutMapping,
+                          edm::FileInPath(theConfig.getParameter<std::string>("rpcConnectionFile")).fullPath());
       } else {
-        theRpcPacker.init(es);
+        edm::ESHandle<RPCAMCLinkMap> amcMapping;
+        es.get<RPCOMTFLinkMapRcd>().get(amcMapping);
+        theRpcPacker.init(*readoutMapping, *amcMapping);
       }
     }
 

--- a/EventFilter/L1TRawToDigi/plugins/OmtfUnpacker.cc
+++ b/EventFilter/L1TRawToDigi/plugins/OmtfUnpacker.cc
@@ -43,6 +43,10 @@
 #include "EventFilter/L1TRawToDigi/interface/OmtfDtUnpacker.h"
 #include "EventFilter/L1TRawToDigi/interface/OmtfMuonUnpacker.h"
 
+#include "CondFormats/RPCObjects/interface/RPCEMap.h"
+#include "CondFormats/DataRecord/interface/RPCEMapRcd.h"
+#include "CondFormats/DataRecord/interface/RPCOMTFLinkMapRcd.h"
+
 namespace omtf {
 
   class OmtfUnpacker : public edm::stream::EDProducer<> {
@@ -108,10 +112,15 @@ namespace omtf {
     // rpc unpacker
     //
     if (!theSkipRpc) {
+      edm::ESTransientHandle<RPCEMap> readoutMapping;
+      es.get<RPCEMapRcd>().get(readoutMapping);
       if (theConfig.getParameter<bool>("useRpcConnectionFile")) {
-        theRpcUnpacker.init(es, edm::FileInPath(theConfig.getParameter<std::string>("rpcConnectionFile")).fullPath());
+        theRpcUnpacker.init(*readoutMapping,
+                            edm::FileInPath(theConfig.getParameter<std::string>("rpcConnectionFile")).fullPath());
       } else {
-        theRpcUnpacker.init(es);
+        edm::ESHandle<RPCAMCLinkMap> amcMapping;
+        es.get<RPCOMTFLinkMapRcd>().get(amcMapping);
+        theRpcUnpacker.init(*readoutMapping, *amcMapping);
       }
     }
 

--- a/EventFilter/L1TRawToDigi/src/OmtfLinkMappingRpc.cc
+++ b/EventFilter/L1TRawToDigi/src/OmtfLinkMappingRpc.cc
@@ -2,8 +2,6 @@
 
 #include <fstream>
 
-#include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/Framework/interface/ESTransientHandle.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include "CondFormats/RPCObjects/interface/RPCReadOutMapping.h"
@@ -15,7 +13,6 @@
 #include "CondFormats/RPCObjects/interface/TriggerBoardSpec.h"
 #include "CondFormats/RPCObjects/interface/LinkBoardSpec.h"
 
-#include "CondFormats/DataRecord/interface/RPCOMTFLinkMapRcd.h"
 #include "CondFormats/RPCObjects/interface/RPCAMCLinkMap.h"
 
 namespace omtf {
@@ -75,10 +72,8 @@ namespace omtf {
     return pact2omtfs;
   }
 
-  void RpcLinkMap::init(const edm::EventSetup& es) {
-    edm::ESHandle<RPCAMCLinkMap> amcMapping;
-    es.get<RPCOMTFLinkMapRcd>().get(amcMapping);
-    const RPCAMCLinkMap::map_type& amcMap = amcMapping->getMap();
+  void RpcLinkMap::init(const RPCAMCLinkMap& amcMapping) {
+    const RPCAMCLinkMap::map_type& amcMap = amcMapping.getMap();
 
     for (const auto& item : amcMap) {
       unsigned int fedId = item.first.getFED();

--- a/EventFilter/L1TRawToDigi/src/OmtfRpcPacker.cc
+++ b/EventFilter/L1TRawToDigi/src/OmtfRpcPacker.cc
@@ -1,7 +1,5 @@
 #include "EventFilter/L1TRawToDigi/interface/OmtfRpcPacker.h"
 
-#include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/Framework/interface/ESTransientHandle.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include "CondFormats/RPCObjects/interface/RPCReadOutMapping.h"
@@ -9,27 +7,24 @@
 #include "EventFilter/RPCRawToDigi/interface/RPCPackingModule.h"
 #include "EventFilter/RPCRawToDigi/interface/DebugDigisPrintout.h"
 #include "CondFormats/RPCObjects/interface/RPCEMap.h"
-#include "CondFormats/DataRecord/interface/RPCEMapRcd.h"
 #include "EventFilter/L1TRawToDigi/interface/OmtfRpcDataWord64.h"
 
 namespace omtf {
 
-  void RpcPacker::initCabling(const edm::EventSetup& es) {
-    edm::ESTransientHandle<RPCEMap> readoutMapping;
-    es.get<RPCEMapRcd>().get(readoutMapping);
-    thePactCabling.reset(readoutMapping->convert());
+  void RpcPacker::initCabling(const RPCEMap& readoutMapping) {
+    thePactCabling.reset(readoutMapping.convert());
     LogDebug("OmtfPacker") << " Has PACT readout map, VERSION: " << thePactCabling->version() << std::endl;
   }
 
-  void RpcPacker::init(const edm::EventSetup& es) {
-    initCabling(es);
+  void RpcPacker::init(const RPCEMap& readoutMapping, const RPCAMCLinkMap& linkMap) {
+    initCabling(readoutMapping);
     RpcLinkMap omtfLink2Ele;
-    omtfLink2Ele.init(es);
+    omtfLink2Ele.init(linkMap);
     thePact2Omtf = translatePact2Omtf(omtfLink2Ele, thePactCabling.get());
   }
 
-  void RpcPacker::init(const edm::EventSetup& es, const std::string& connectionFile) {
-    initCabling(es);
+  void RpcPacker::init(const RPCEMap& readoutMapping, const std::string& connectionFile) {
+    initCabling(readoutMapping);
     RpcLinkMap omtfLink2Ele;
     omtfLink2Ele.init(connectionFile);
     thePact2Omtf = translatePact2Omtf(omtfLink2Ele, thePactCabling.get());

--- a/EventFilter/L1TRawToDigi/src/OmtfRpcUnpacker.cc
+++ b/EventFilter/L1TRawToDigi/src/OmtfRpcUnpacker.cc
@@ -1,7 +1,5 @@
 #include "EventFilter/L1TRawToDigi/interface/OmtfRpcUnpacker.h"
 
-#include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/Framework/interface/ESTransientHandle.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include "EventFilter/RPCRawToDigi/interface/RPCRecordFormatter.h"
@@ -18,30 +16,28 @@
 
 namespace omtf {
 
-  void RpcUnpacker::initCabling(const edm::EventSetup &es) {
-    edm::ESTransientHandle<RPCEMap> readoutMapping;
-    es.get<RPCEMapRcd>().get(readoutMapping);
-    thePactCabling.reset(readoutMapping->convert());
+  void RpcUnpacker::initCabling(const RPCEMap& readoutMapping) {
+    thePactCabling.reset(readoutMapping.convert());
 
     LogDebug("OmtfUnpacker") << " Has PACT readout map, VERSION: " << thePactCabling->version() << std::endl;
   }
 
-  void RpcUnpacker::init(const edm::EventSetup &es) {
-    initCabling(es);
+  void RpcUnpacker::init(const RPCEMap& readoutMapping, const RPCAMCLinkMap& linkMap) {
+    initCabling(readoutMapping);
     RpcLinkMap omtfLink2Ele;
-    omtfLink2Ele.init(es);
+    omtfLink2Ele.init(linkMap);
     theOmtf2Pact = translateOmtf2Pact(omtfLink2Ele, thePactCabling.get());
   }
 
-  void RpcUnpacker::init(const edm::EventSetup &es, const std::string &connectionFile) {
-    initCabling(es);
+  void RpcUnpacker::init(const RPCEMap& readoutMapping, const std::string& connectionFile) {
+    initCabling(readoutMapping);
     RpcLinkMap omtfLink2Ele;
     omtfLink2Ele.init(connectionFile);
     theOmtf2Pact = translateOmtf2Pact(omtfLink2Ele, thePactCabling.get());
   }
 
   void RpcUnpacker::unpack(
-      int triggerBX, unsigned int fed, unsigned int amc, const RpcDataWord64 &data, RPCDigiCollection *prod) {
+      int triggerBX, unsigned int fed, unsigned int amc, const RpcDataWord64& data, RPCDigiCollection* prod) {
     LogTrace("RpcUnpacker:") << data;
 
     //  EleIndex omtfEle(fedHeader.sourceID(), bh.getAMCNumber()/2+1, data.linkNum());


### PR DESCRIPTION
#### PR description:

- added esConsumes to modules
- modified helpers to not directly use edm::EventSetup

#### PR validation:

Code compiles.