### PR TITLE
fix incomplete esconsumes migration

### DIFF
--- a/SimMuon/CSCDigitizer/src/CSCDigiProducer.cc
+++ b/SimMuon/CSCDigitizer/src/CSCDigiProducer.cc
@@ -88,7 +88,6 @@ void CSCDigiProducer::produce(edm::Event &ev, const edm::EventSetup &eventSetup)
 
     // set the particle table
     edm::ESHandle<ParticleDataTable> pdt = eventSetup.getHandle(pdt_Token);
-    eventSetup.getData(pdt);
     theDigitizer.setParticleDataTable(&*pdt);
 
     theStripConditions->initializeEvent(eventSetup);


### PR DESCRIPTION
#### PR description:

<!-- It seems whoever did the earlier migration to use esConsumes left one statement which should have been removed from CSCDigiProducer. This removes it.
  -->

#### PR validation:

<!-- I tested that the CSC digitization still works without it. The residual statement must have effectively been a no-op. -->
