### PR TITLE
Migrate ECAL DQM codes to ESConsumes

### DIFF
--- a/DQM/EcalCommon/interface/DQWorker.h
+++ b/DQM/EcalCommon/interface/DQWorker.h
@@ -17,6 +17,13 @@
 #include "Geometry/CaloTopology/interface/EcalTrigTowerConstituentsMap.h"
 #include "Geometry/EcalMapping/interface/EcalElectronicsMapping.h"
 
+#include "Geometry/EcalMapping/interface/EcalMappingRcd.h"
+#include "Geometry/Records/interface/CaloGeometryRecord.h"
+#include "Geometry/Records/interface/CaloTopologyRecord.h"
+#include "Geometry/Records/interface/IdealGeometryRecord.h"
+
+#include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "FWCore/Framework/interface/ESHandle.h"
 namespace edm {
   class Run;
   class LuminosityBlock;
@@ -24,6 +31,7 @@ namespace edm {
   class EventSetup;
   class ParameterSet;
   class ParameterSetDescription;
+  class ConsumesCollector;
 }  // namespace edm
 
 namespace ecaldqm {
@@ -40,8 +48,7 @@ namespace ecaldqm {
       edm::LuminosityBlockNumber_t iLumi;
       edm::EventNumber_t iEvt;
       Timestamp() : now(0), iRun(0), iLumi(0), iEvt(0) {}
-    };
-
+    }; 
   protected:
     typedef dqm::legacy::DQMStore DQMStore;
     typedef dqm::legacy::MonitorElement MonitorElement;
@@ -51,13 +58,14 @@ namespace ecaldqm {
 
     virtual void setME(edm::ParameterSet const &);
     virtual void setSource(edm::ParameterSet const &) {}  // for clients
-    virtual void setParams(edm::ParameterSet const &) {}
+    virtual void setParams(edm::ParameterSet const &) {} 
 
   public:
-    DQWorker();
+    DQWorker(); 
     virtual ~DQWorker() noexcept(false);
 
     static void fillDescriptions(edm::ParameterSetDescription &_desc);
+    void setToken(edm::ConsumesCollector&) ; 
 
     virtual void beginRun(edm::Run const &, edm::EventSetup const &) {}
     virtual void endRun(edm::Run const &, edm::EventSetup const &) {}
@@ -67,7 +75,7 @@ namespace ecaldqm {
 
     virtual void bookMEs(DQMStore::IBooker &);
     virtual void releaseMEs();
-
+    
     // old ecaldqmGetSetupObjects (old global vars)
     // These are objects obtained from EventSetup and stored
     // inside each module (which inherit from DQWorker).
@@ -82,18 +90,24 @@ namespace ecaldqm {
     // which leads to poor multi-threading performance.
     // Original issue here:
     // https://github.com/cms-sw/cmssw/issues/28858
+   
     void setSetupObjects(edm::EventSetup const &);
     EcalElectronicsMapping const *GetElectronicsMap();
     EcalTrigTowerConstituentsMap const *GetTrigTowerMap();
     CaloGeometry const *GetGeometry();
     CaloTopology const *GetTopology();
     EcalDQMSetupObjects const getEcalDQMSetupObjects();
-
+    
+    edm::ESGetToken<EcalElectronicsMapping, EcalMappingRcd> elecMapHandle;
+    edm::ESGetToken<EcalTrigTowerConstituentsMap, IdealGeometryRecord> ttMapHandle;
+    edm::ESGetToken<CaloGeometry, CaloGeometryRecord> geomHandle;
+    edm::ESGetToken<CaloTopology, CaloTopologyRecord> topoHandle; 
+   
     void setTime(time_t _t) { timestamp_.now = _t; }
     void setRunNumber(edm::RunNumber_t _r) { timestamp_.iRun = _r; }
     void setLumiNumber(edm::LuminosityBlockNumber_t _l) { timestamp_.iLumi = _l; }
-    void setEventNumber(edm::EventNumber_t _e) { timestamp_.iEvt = _e; }
-
+    void setEventNumber(edm::EventNumber_t _e) { timestamp_.iEvt = _e; } 
+  
     std::string const &getName() const { return name_; }
     bool onlineMode() const { return onlineMode_; }
 

--- a/DQM/EcalCommon/interface/DQWorker.h
+++ b/DQM/EcalCommon/interface/DQWorker.h
@@ -48,7 +48,8 @@ namespace ecaldqm {
       edm::LuminosityBlockNumber_t iLumi;
       edm::EventNumber_t iEvt;
       Timestamp() : now(0), iRun(0), iLumi(0), iEvt(0) {}
-    }; 
+    };
+
   protected:
     typedef dqm::legacy::DQMStore DQMStore;
     typedef dqm::legacy::MonitorElement MonitorElement;
@@ -58,14 +59,14 @@ namespace ecaldqm {
 
     virtual void setME(edm::ParameterSet const &);
     virtual void setSource(edm::ParameterSet const &) {}  // for clients
-    virtual void setParams(edm::ParameterSet const &) {} 
+    virtual void setParams(edm::ParameterSet const &) {}
 
   public:
-    DQWorker(); 
+    DQWorker();
     virtual ~DQWorker() noexcept(false);
 
     static void fillDescriptions(edm::ParameterSetDescription &_desc);
-    void setToken(edm::ConsumesCollector&) ; 
+    void setTokens(edm::ConsumesCollector &);
 
     virtual void beginRun(edm::Run const &, edm::EventSetup const &) {}
     virtual void endRun(edm::Run const &, edm::EventSetup const &) {}
@@ -75,7 +76,7 @@ namespace ecaldqm {
 
     virtual void bookMEs(DQMStore::IBooker &);
     virtual void releaseMEs();
-    
+
     // old ecaldqmGetSetupObjects (old global vars)
     // These are objects obtained from EventSetup and stored
     // inside each module (which inherit from DQWorker).
@@ -90,24 +91,30 @@ namespace ecaldqm {
     // which leads to poor multi-threading performance.
     // Original issue here:
     // https://github.com/cms-sw/cmssw/issues/28858
-   
+
     void setSetupObjects(edm::EventSetup const &);
+    void setSetupObjectsEndLumi(edm::EventSetup const &);
     EcalElectronicsMapping const *GetElectronicsMap();
     EcalTrigTowerConstituentsMap const *GetTrigTowerMap();
     CaloGeometry const *GetGeometry();
     CaloTopology const *GetTopology();
     EcalDQMSetupObjects const getEcalDQMSetupObjects();
-    
+
     edm::ESGetToken<EcalElectronicsMapping, EcalMappingRcd> elecMapHandle;
     edm::ESGetToken<EcalTrigTowerConstituentsMap, IdealGeometryRecord> ttMapHandle;
     edm::ESGetToken<CaloGeometry, CaloGeometryRecord> geomHandle;
-    edm::ESGetToken<CaloTopology, CaloTopologyRecord> topoHandle; 
-   
+    edm::ESGetToken<CaloTopology, CaloTopologyRecord> topoHandle;
+
+    edm::ESGetToken<EcalElectronicsMapping, EcalMappingRcd> elecMapHandleEndLumi;
+    edm::ESGetToken<EcalTrigTowerConstituentsMap, IdealGeometryRecord> ttMapHandleEndLumi;
+    edm::ESGetToken<CaloGeometry, CaloGeometryRecord> geomHandleEndLumi;
+    edm::ESGetToken<CaloTopology, CaloTopologyRecord> topoHandleEndLumi;
+
     void setTime(time_t _t) { timestamp_.now = _t; }
     void setRunNumber(edm::RunNumber_t _r) { timestamp_.iRun = _r; }
     void setLumiNumber(edm::LuminosityBlockNumber_t _l) { timestamp_.iLumi = _l; }
-    void setEventNumber(edm::EventNumber_t _e) { timestamp_.iEvt = _e; } 
-  
+    void setEventNumber(edm::EventNumber_t _e) { timestamp_.iEvt = _e; }
+
     std::string const &getName() const { return name_; }
     bool onlineMode() const { return onlineMode_; }
 

--- a/DQM/EcalCommon/interface/EcalDQMonitor.h
+++ b/DQM/EcalCommon/interface/EcalDQMonitor.h
@@ -14,7 +14,6 @@ namespace edm {
   class Run;
   class LuminosityBlock;
   class EventSetup;
-  //class ConsumesCollector;
 }  // namespace edm
 
 namespace ecaldqm {
@@ -29,7 +28,7 @@ namespace ecaldqm {
     virtual ~EcalDQMonitor() noexcept(false);
 
     static void fillDescriptions(edm::ParameterSetDescription &);
-    //edm::ConsumesCollector& collector;
+
   protected:
     void ecaldqmBeginRun(edm::Run const &, edm::EventSetup const &);
     void ecaldqmEndRun(edm::Run const &, edm::EventSetup const &);

--- a/DQM/EcalCommon/interface/EcalDQMonitor.h
+++ b/DQM/EcalCommon/interface/EcalDQMonitor.h
@@ -14,6 +14,7 @@ namespace edm {
   class Run;
   class LuminosityBlock;
   class EventSetup;
+  //class ConsumesCollector;
 }  // namespace edm
 
 namespace ecaldqm {
@@ -28,7 +29,7 @@ namespace ecaldqm {
     virtual ~EcalDQMonitor() noexcept(false);
 
     static void fillDescriptions(edm::ParameterSetDescription &);
-
+    //edm::ConsumesCollector& collector;
   protected:
     void ecaldqmBeginRun(edm::Run const &, edm::EventSetup const &);
     void ecaldqmEndRun(edm::Run const &, edm::EventSetup const &);

--- a/DQM/EcalCommon/plugins/EcalMEFormatter.cc
+++ b/DQM/EcalCommon/plugins/EcalMEFormatter.cc
@@ -10,13 +10,11 @@
 #include <limits>
 
 EcalMEFormatter::EcalMEFormatter(edm::ParameterSet const &_ps) : DQMEDHarvester(), ecaldqm::DQWorker() {
-  //edm::ConsumesCollector collector(consumesCollector()); 
-  initialize("EcalMEFormatter", _ps);//, collector);
+  initialize("EcalMEFormatter", _ps);
+  edm::ConsumesCollector collector(consumesCollector());
+  setTokens(collector);
   setME(_ps.getUntrackedParameterSet("MEs"));
   verbosity_ = _ps.getUntrackedParameter<int>("verbosity", 0);
-  //edm::ConsumesCollector collector(consumesCollector());
-  //DQWorker *worker;//(workerFactories_.at(_name)());
-  //worker->setTokens(collector); 
 }
 
 /*static*/
@@ -32,7 +30,7 @@ void EcalMEFormatter::dqmEndLuminosityBlock(DQMStore::IBooker &,
                                             DQMStore::IGetter &_igetter,
                                             edm::LuminosityBlock const &,
                                             edm::EventSetup const &_es) {
-  setSetupObjects(_es);
+  setSetupObjectsEndLumi(_es);
   format_(_igetter, true);
 }
 

--- a/DQM/EcalCommon/plugins/EcalMEFormatter.cc
+++ b/DQM/EcalCommon/plugins/EcalMEFormatter.cc
@@ -10,9 +10,13 @@
 #include <limits>
 
 EcalMEFormatter::EcalMEFormatter(edm::ParameterSet const &_ps) : DQMEDHarvester(), ecaldqm::DQWorker() {
-  initialize("EcalMEFormatter", _ps);
+  //edm::ConsumesCollector collector(consumesCollector()); 
+  initialize("EcalMEFormatter", _ps);//, collector);
   setME(_ps.getUntrackedParameterSet("MEs"));
   verbosity_ = _ps.getUntrackedParameter<int>("verbosity", 0);
+  //edm::ConsumesCollector collector(consumesCollector());
+  //DQWorker *worker;//(workerFactories_.at(_name)());
+  //worker->setTokens(collector); 
 }
 
 /*static*/

--- a/DQM/EcalCommon/src/EcalDQMonitor.cc
+++ b/DQM/EcalCommon/src/EcalDQMonitor.cc
@@ -14,17 +14,21 @@
 #include "Geometry/Records/interface/CaloTopologyRecord.h"
 #include "Geometry/Records/interface/IdealGeometryRecord.h"
 
+#include "FWCore/Framework/interface/ConsumesCollector.h"
+
 #include <ctime>
 #include <sstream>
 
 namespace ecaldqm {
   EcalDQMonitor::EcalDQMonitor(edm::ParameterSet const &_ps)
       : workers_(),
+        //collector(),
         moduleName_(_ps.getUntrackedParameter<std::string>("moduleName")),
-        verbosity_(_ps.getUntrackedParameter<int>("verbosity")) {
+        verbosity_(_ps.getUntrackedParameter<int>("verbosity")){
     std::vector<std::string> workerNames(_ps.getUntrackedParameter<std::vector<std::string>>("workers"));
     edm::ParameterSet const &workerParams(_ps.getUntrackedParameterSet("workerParameters"));
     edm::ParameterSet const &commonParams(_ps.getUntrackedParameterSet("commonParameters"));
+    //edm::ConsumesCollector collector(consumesCollector());
 
     std::for_each(workerNames.begin(), workerNames.end(), [&](std::string const &name) {
       if (verbosity_ > 0)
@@ -34,6 +38,7 @@ namespace ecaldqm {
             name, verbosity_, commonParams, workerParams.getUntrackedParameterSet(name)));
         if (worker->onlineMode())
           worker->setTime(time(nullptr));
+	 // worker->setTokens(collector);}
         workers_.push_back(worker);
       } catch (std::exception &) {
         edm::LogError("EcalDQM") << "Worker " << name << " not defined";

--- a/DQM/EcalCommon/src/EcalDQMonitor.cc
+++ b/DQM/EcalCommon/src/EcalDQMonitor.cc
@@ -22,13 +22,11 @@
 namespace ecaldqm {
   EcalDQMonitor::EcalDQMonitor(edm::ParameterSet const &_ps)
       : workers_(),
-        //collector(),
         moduleName_(_ps.getUntrackedParameter<std::string>("moduleName")),
-        verbosity_(_ps.getUntrackedParameter<int>("verbosity")){
+        verbosity_(_ps.getUntrackedParameter<int>("verbosity")) {
     std::vector<std::string> workerNames(_ps.getUntrackedParameter<std::vector<std::string>>("workers"));
     edm::ParameterSet const &workerParams(_ps.getUntrackedParameterSet("workerParameters"));
     edm::ParameterSet const &commonParams(_ps.getUntrackedParameterSet("commonParameters"));
-    //edm::ConsumesCollector collector(consumesCollector());
 
     std::for_each(workerNames.begin(), workerNames.end(), [&](std::string const &name) {
       if (verbosity_ > 0)
@@ -38,7 +36,6 @@ namespace ecaldqm {
             name, verbosity_, commonParams, workerParams.getUntrackedParameterSet(name)));
         if (worker->onlineMode())
           worker->setTime(time(nullptr));
-	 // worker->setTokens(collector);}
         workers_.push_back(worker);
       } catch (std::exception &) {
         edm::LogError("EcalDQM") << "Worker " << name << " not defined";

--- a/DQM/EcalMonitorClient/interface/DQWorkerClient.h
+++ b/DQM/EcalMonitorClient/interface/DQWorkerClient.h
@@ -7,7 +7,7 @@
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 
 class DetId;
-namespace edm { 
+namespace edm {
   class ConsumesCollector;
 }  // namespace edm
 
@@ -36,7 +36,6 @@ namespace ecaldqm {
     virtual void resetMEs();
     virtual void producePlots(ProcessType) = 0;
 
-    //edm::ConsumesCollector collector(consumesCollector()); 
     // mechanisms to register EDGetTokens for any additional objects used internally
     virtual void setTokens(edm::ConsumesCollector&) {}
 

--- a/DQM/EcalMonitorClient/interface/DQWorkerClient.h
+++ b/DQM/EcalMonitorClient/interface/DQWorkerClient.h
@@ -4,8 +4,12 @@
 #include <utility>
 
 #include "DQM/EcalCommon/interface/DQWorker.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 
 class DetId;
+namespace edm { 
+  class ConsumesCollector;
+}  // namespace edm
 
 namespace ecaldqm {
   class StatusManager;
@@ -31,6 +35,10 @@ namespace ecaldqm {
     bool runsOn(ProcessType _type) const { return _type == kJob || hasLumiPlots_; }
     virtual void resetMEs();
     virtual void producePlots(ProcessType) = 0;
+
+    //edm::ConsumesCollector collector(consumesCollector()); 
+    // mechanisms to register EDGetTokens for any additional objects used internally
+    virtual void setTokens(edm::ConsumesCollector&) {}
 
     void setStatusManager(StatusManager const& _manager) { statusManager_ = &_manager; }
 

--- a/DQM/EcalMonitorClient/interface/EcalDQMonitorClient.h
+++ b/DQM/EcalMonitorClient/interface/EcalDQMonitorClient.h
@@ -6,10 +6,15 @@
 #include "DQM/EcalCommon/interface/StatusManager.h"
 
 #include "DQM/EcalMonitorClient/interface/DQWorkerClient.h"
+#include "CondFormats/EcalObjects/interface/EcalDQMChannelStatus.h"
+#include "CondFormats/EcalObjects/interface/EcalDQMTowerStatus.h"
+#include "CondFormats/DataRecord/interface/EcalDQMChannelStatusRcd.h"
+#include "CondFormats/DataRecord/interface/EcalDQMTowerStatusRcd.h"
+
 
 class EcalDQMonitorClient : public DQMEDHarvester, public ecaldqm::EcalDQMonitor {
 public:
-  EcalDQMonitorClient(edm::ParameterSet const&);
+  EcalDQMonitorClient(edm::ParameterSet const&);//, edm::ConsumesCollector& );
   ~EcalDQMonitorClient() override;
 
   static void fillDescriptions(edm::ConfigurationDescriptions&);
@@ -27,8 +32,10 @@ private:
 
   unsigned eventCycleLength_;
   unsigned iEvt_;
-
+  edm::ESGetToken<EcalDQMChannelStatus, EcalDQMChannelStatusRcd> cStHndl;
+  edm::ESGetToken<EcalDQMTowerStatus, EcalDQMTowerStatusRcd> tStHndl;
   ecaldqm::StatusManager statusManager_;
+
 };
 
 #endif

--- a/DQM/EcalMonitorClient/interface/EcalDQMonitorClient.h
+++ b/DQM/EcalMonitorClient/interface/EcalDQMonitorClient.h
@@ -11,10 +11,9 @@
 #include "CondFormats/DataRecord/interface/EcalDQMChannelStatusRcd.h"
 #include "CondFormats/DataRecord/interface/EcalDQMTowerStatusRcd.h"
 
-
 class EcalDQMonitorClient : public DQMEDHarvester, public ecaldqm::EcalDQMonitor {
 public:
-  EcalDQMonitorClient(edm::ParameterSet const&);//, edm::ConsumesCollector& );
+  EcalDQMonitorClient(edm::ParameterSet const&);
   ~EcalDQMonitorClient() override;
 
   static void fillDescriptions(edm::ConfigurationDescriptions&);
@@ -35,7 +34,6 @@ private:
   edm::ESGetToken<EcalDQMChannelStatus, EcalDQMChannelStatusRcd> cStHndl;
   edm::ESGetToken<EcalDQMTowerStatus, EcalDQMTowerStatusRcd> tStHndl;
   ecaldqm::StatusManager statusManager_;
-
 };
 
 #endif

--- a/DQM/EcalMonitorClient/interface/IntegrityClient.h
+++ b/DQM/EcalMonitorClient/interface/IntegrityClient.h
@@ -2,13 +2,15 @@
 #define IntegrityClient_H
 
 #include "DQWorkerClient.h"
-
+#include "DQMServices/Core/interface/DQMEDHarvester.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "CondFormats/EcalObjects/interface/EcalChannelStatus.h"
+#include "CondFormats/DataRecord/interface/EcalChannelStatusRcd.h"
+//#include "FWCore/Framework/interface/ConsumesCollector.h"
 
 namespace ecaldqm {
-  class IntegrityClient : public DQWorkerClient {
+  class IntegrityClient :  public DQWorkerClient {
   public:
     IntegrityClient();
     ~IntegrityClient() override {}
@@ -17,8 +19,10 @@ namespace ecaldqm {
     void endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
 
   private:
-    void setParams(edm::ParameterSet const&) override;
-    edm::ESHandle<EcalChannelStatus> chStatus;
+    void setParams(edm::ParameterSet const&) override; 
+    edm::ESGetToken<EcalChannelStatus, EcalChannelStatusRcd> chStatusToken;
+    const EcalChannelStatus* chStatus;
+    void setTokens(edm::ConsumesCollector&) ;
 
     float errFractionThreshold_;
   };

--- a/DQM/EcalMonitorClient/interface/IntegrityClient.h
+++ b/DQM/EcalMonitorClient/interface/IntegrityClient.h
@@ -2,15 +2,13 @@
 #define IntegrityClient_H
 
 #include "DQWorkerClient.h"
-#include "DQMServices/Core/interface/DQMEDHarvester.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "CondFormats/EcalObjects/interface/EcalChannelStatus.h"
 #include "CondFormats/DataRecord/interface/EcalChannelStatusRcd.h"
-//#include "FWCore/Framework/interface/ConsumesCollector.h"
 
 namespace ecaldqm {
-  class IntegrityClient :  public DQWorkerClient {
+  class IntegrityClient : public DQWorkerClient {
   public:
     IntegrityClient();
     ~IntegrityClient() override {}
@@ -19,10 +17,10 @@ namespace ecaldqm {
     void endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
 
   private:
-    void setParams(edm::ParameterSet const&) override; 
+    void setParams(edm::ParameterSet const&) override;
     edm::ESGetToken<EcalChannelStatus, EcalChannelStatusRcd> chStatusToken;
     const EcalChannelStatus* chStatus;
-    void setTokens(edm::ConsumesCollector&) ;
+    void setTokens(edm::ConsumesCollector&);
 
     float errFractionThreshold_;
   };

--- a/DQM/EcalMonitorClient/interface/IntegrityClient.h
+++ b/DQM/EcalMonitorClient/interface/IntegrityClient.h
@@ -20,7 +20,7 @@ namespace ecaldqm {
     void setParams(edm::ParameterSet const&) override;
     edm::ESGetToken<EcalChannelStatus, EcalChannelStatusRcd> chStatusToken;
     const EcalChannelStatus* chStatus;
-    void setTokens(edm::ConsumesCollector&);
+    void setTokens(edm::ConsumesCollector&) override;
 
     float errFractionThreshold_;
   };

--- a/DQM/EcalMonitorClient/interface/TowerStatusTask.h
+++ b/DQM/EcalMonitorClient/interface/TowerStatusTask.h
@@ -25,13 +25,12 @@ namespace ecaldqm {
     void producePlotsTask_(float const*, std::string const&);
     edm::ESGetToken<EcalDAQTowerStatus, EcalDAQTowerStatusRcd> daqHndlToken;
     edm::ESGetToken<EcalDCSTowerStatus, EcalDCSTowerStatusRcd> dcsHndlToken;
-    void setTokens(edm::ConsumesCollector&) ;
+    void setTokens(edm::ConsumesCollector&);
 
     bool doDAQInfo_;
     bool doDCSInfo_;
     float daqStatus_[nDCC];
     float dcsStatus_[nDCC];
-
   };
 
 }  // namespace ecaldqm

--- a/DQM/EcalMonitorClient/interface/TowerStatusTask.h
+++ b/DQM/EcalMonitorClient/interface/TowerStatusTask.h
@@ -25,7 +25,7 @@ namespace ecaldqm {
     void producePlotsTask_(float const*, std::string const&);
     edm::ESGetToken<EcalDAQTowerStatus, EcalDAQTowerStatusRcd> daqHndlToken;
     edm::ESGetToken<EcalDCSTowerStatus, EcalDCSTowerStatusRcd> dcsHndlToken;
-    void setTokens(edm::ConsumesCollector&);
+    void setTokens(edm::ConsumesCollector&) override;
 
     bool doDAQInfo_;
     bool doDCSInfo_;

--- a/DQM/EcalMonitorClient/interface/TowerStatusTask.h
+++ b/DQM/EcalMonitorClient/interface/TowerStatusTask.h
@@ -4,6 +4,10 @@
 #include "DQWorkerClient.h"
 
 #include "DQM/EcalCommon/interface/EcalDQMCommonUtils.h"
+#include "CondFormats/EcalObjects/interface/EcalDAQTowerStatus.h"
+#include "CondFormats/DataRecord/interface/EcalDAQTowerStatusRcd.h"
+#include "CondFormats/EcalObjects/interface/EcalDCSTowerStatus.h"
+#include "CondFormats/DataRecord/interface/EcalDCSTowerStatusRcd.h"
 
 namespace ecaldqm {
 
@@ -19,11 +23,15 @@ namespace ecaldqm {
   private:
     void setParams(edm::ParameterSet const&) override;
     void producePlotsTask_(float const*, std::string const&);
+    edm::ESGetToken<EcalDAQTowerStatus, EcalDAQTowerStatusRcd> daqHndlToken;
+    edm::ESGetToken<EcalDCSTowerStatus, EcalDCSTowerStatusRcd> dcsHndlToken;
+    void setTokens(edm::ConsumesCollector&) ;
 
     bool doDAQInfo_;
     bool doDCSInfo_;
     float daqStatus_[nDCC];
     float dcsStatus_[nDCC];
+
   };
 
 }  // namespace ecaldqm

--- a/DQM/EcalMonitorClient/plugins/EcalDQMonitorClient.cc
+++ b/DQM/EcalMonitorClient/plugins/EcalDQMonitorClient.cc
@@ -16,22 +16,20 @@
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
-#include "CondFormats/EcalObjects/interface/EcalDQMChannelStatus.h"
-#include "CondFormats/EcalObjects/interface/EcalDQMTowerStatus.h"
-#include "CondFormats/DataRecord/interface/EcalDQMChannelStatusRcd.h"
-#include "CondFormats/DataRecord/interface/EcalDQMTowerStatusRcd.h"
-
 #include <ctime>
 #include <fstream>
 
 EcalDQMonitorClient::EcalDQMonitorClient(edm::ParameterSet const& _ps)
-    : DQMEDHarvester(), ecaldqm::EcalDQMonitor(_ps), iEvt_(0), statusManager_() {
+    : DQMEDHarvester(), ecaldqm::EcalDQMonitor(_ps), iEvt_(0), cStHndl(esConsumes<edm::Transition::BeginRun>()), tStHndl(esConsumes<edm::Transition::BeginRun>()), statusManager_() {
+  edm::ConsumesCollector collector(consumesCollector());
   executeOnWorkers_(
-      [this](ecaldqm::DQWorker* worker) {
+      [this, &collector](ecaldqm::DQWorker* worker) {
         ecaldqm::DQWorkerClient* client(dynamic_cast<ecaldqm::DQWorkerClient*>(worker));
         if (!client)
           throw cms::Exception("InvalidConfiguration") << "Non-client DQWorker " << worker->getName() << " passed";
         client->setStatusManager(this->statusManager_);
+	client->setTokens(collector);
+	//worker->setTokens(collector);
       },
       "initialization");
 
@@ -64,19 +62,20 @@ void EcalDQMonitorClient::fillDescriptions(edm::ConfigurationDescriptions& _desc
 }
 
 void EcalDQMonitorClient::beginRun(edm::Run const& _run, edm::EventSetup const& _es) {
-  executeOnWorkers_([&_es](ecaldqm::DQWorker* worker) { worker->setSetupObjects(_es); },
+  edm::ConsumesCollector iC(consumesCollector());
+  executeOnWorkers_([&_es, &iC](ecaldqm::DQWorker* worker) { 
+		    worker->setToken(iC); 
+		    worker->setSetupObjects(_es); },
                     "ecaldqmGetSetupObjects",
                     "Getting EventSetup Objects");
 
   if (_es.find(edm::eventsetup::EventSetupRecordKey::makeKey<EcalDQMChannelStatusRcd>()) &&
       _es.find(edm::eventsetup::EventSetupRecordKey::makeKey<EcalDQMTowerStatusRcd>())) {
-    edm::ESHandle<EcalDQMChannelStatus> cStHndl;
-    _es.get<EcalDQMChannelStatusRcd>().get(cStHndl);
+     
+    const EcalDQMChannelStatus* ChStatus =  &_es.getData(cStHndl); 
+    const EcalDQMTowerStatus* TStatus = &_es.getData(tStHndl);
 
-    edm::ESHandle<EcalDQMTowerStatus> tStHndl;
-    _es.get<EcalDQMTowerStatusRcd>().get(tStHndl);
-
-    statusManager_.readFromObj(*cStHndl, *tStHndl);
+    statusManager_.readFromObj(*ChStatus, *TStatus);
   }
 
   ecaldqmBeginRun(_run, _es);

--- a/DQM/EcalMonitorClient/src/IntegrityClient.cc
+++ b/DQM/EcalMonitorClient/src/IntegrityClient.cc
@@ -6,7 +6,6 @@
 
 #include "DataFormats/EcalDetId/interface/EBDetId.h"
 #include "DataFormats/EcalDetId/interface/EEDetId.h"
-#include "CondFormats/DataRecord/interface/EcalChannelStatusRcd.h"
 
 #include "DQM/EcalCommon/interface/EcalDQMCommonUtils.h"
 
@@ -20,10 +19,14 @@ namespace ecaldqm {
     errFractionThreshold_ = _params.getUntrackedParameter<double>("errFractionThreshold");
   }
 
+  void IntegrityClient::setTokens(edm::ConsumesCollector& _collector) { 
+    chStatusToken = _collector.esConsumes<edm::Transition::EndLuminosityBlock>(); 
+  }
+  
   // Check Channel Status Record at every endLumi
   // Used to fill Channel Status Map MEs
-  void IntegrityClient::endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const& _es) {
-    _es.get<EcalChannelStatusRcd>().get(chStatus);
+  void IntegrityClient::endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const& _es) { 
+   chStatus = &_es.getData(chStatusToken);
   }
 
   void IntegrityClient::producePlots(ProcessType) {

--- a/DQM/EcalMonitorClient/src/IntegrityClient.cc
+++ b/DQM/EcalMonitorClient/src/IntegrityClient.cc
@@ -19,14 +19,14 @@ namespace ecaldqm {
     errFractionThreshold_ = _params.getUntrackedParameter<double>("errFractionThreshold");
   }
 
-  void IntegrityClient::setTokens(edm::ConsumesCollector& _collector) { 
-    chStatusToken = _collector.esConsumes<edm::Transition::EndLuminosityBlock>(); 
+  void IntegrityClient::setTokens(edm::ConsumesCollector& _collector) {
+    chStatusToken = _collector.esConsumes<edm::Transition::EndLuminosityBlock>();
   }
-  
+
   // Check Channel Status Record at every endLumi
   // Used to fill Channel Status Map MEs
-  void IntegrityClient::endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const& _es) { 
-   chStatus = &_es.getData(chStatusToken);
+  void IntegrityClient::endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const& _es) {
+    chStatus = &_es.getData(chStatusToken);
   }
 
   void IntegrityClient::producePlots(ProcessType) {

--- a/DQM/EcalMonitorClient/src/TowerStatusTask.cc
+++ b/DQM/EcalMonitorClient/src/TowerStatusTask.cc
@@ -5,11 +5,6 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
-#include "CondFormats/EcalObjects/interface/EcalDAQTowerStatus.h"
-#include "CondFormats/DataRecord/interface/EcalDAQTowerStatusRcd.h"
-#include "CondFormats/EcalObjects/interface/EcalDCSTowerStatus.h"
-#include "CondFormats/DataRecord/interface/EcalDCSTowerStatusRcd.h"
-
 #include "DataFormats/EcalDetId/interface/EcalTrigTowerDetId.h"
 #include "DataFormats/EcalDetId/interface/EcalScDetId.h"
 #include "DataFormats/EcalDetId/interface/EBDetId.h"
@@ -40,13 +35,18 @@ namespace ecaldqm {
       throw cms::Exception("InvalidConfiguration") << "Nothing to do in TowerStatusTask";
   }
 
+  void TowerStatusTask::setTokens(edm::ConsumesCollector& _collector) {
+    daqHndlToken = _collector.esConsumes<edm::Transition::EndLuminosityBlock>();
+    dcsHndlToken = _collector.esConsumes<edm::Transition::EndLuminosityBlock>();	
+  }
+
   void TowerStatusTask::endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const& _es) {
     if (doDAQInfo_) {
       std::fill_n(daqStatus_, nDCC, 1.);
-
-      edm::ESHandle<EcalDAQTowerStatus> daqHndl;
-      _es.get<EcalDAQTowerStatusRcd>().get(daqHndl);
-      if (daqHndl.isValid()) {
+ 
+      const EcalDAQTowerStatus* daqHndl= &_es.getData(daqHndlToken);
+      auto daqhandle = _es.getHandle(daqHndlToken);
+      if (daqhandle.isValid()) {
         for (unsigned id(0); id < EcalTrigTowerDetId::kEBTotalTowers; id++) {
           if (daqHndl->barrel(id).getStatusCode() != 0) {
             EcalTrigTowerDetId ttid(EcalTrigTowerDetId::detIdFromDenseIndex(id));
@@ -67,9 +67,9 @@ namespace ecaldqm {
     if (doDCSInfo_) {
       std::fill_n(dcsStatus_, nDCC, 1.);
 
-      edm::ESHandle<EcalDCSTowerStatus> dcsHndl;
-      _es.get<EcalDCSTowerStatusRcd>().get(dcsHndl);
-      if (dcsHndl.isValid()) {
+      const EcalDCSTowerStatus* dcsHndl = &_es.getData(dcsHndlToken);
+      auto dcshandle = _es.getHandle(dcsHndlToken);
+      if (dcshandle.isValid()) {
         for (unsigned id(0); id < EcalTrigTowerDetId::kEBTotalTowers; id++) {
           if (dcsHndl->barrel(id).getStatusCode() != 0) {
             EcalTrigTowerDetId ttid(EcalTrigTowerDetId::detIdFromDenseIndex(id));

--- a/DQM/EcalMonitorClient/src/TowerStatusTask.cc
+++ b/DQM/EcalMonitorClient/src/TowerStatusTask.cc
@@ -37,14 +37,14 @@ namespace ecaldqm {
 
   void TowerStatusTask::setTokens(edm::ConsumesCollector& _collector) {
     daqHndlToken = _collector.esConsumes<edm::Transition::EndLuminosityBlock>();
-    dcsHndlToken = _collector.esConsumes<edm::Transition::EndLuminosityBlock>();	
+    dcsHndlToken = _collector.esConsumes<edm::Transition::EndLuminosityBlock>();
   }
 
   void TowerStatusTask::endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const& _es) {
     if (doDAQInfo_) {
       std::fill_n(daqStatus_, nDCC, 1.);
- 
-      const EcalDAQTowerStatus* daqHndl= &_es.getData(daqHndlToken);
+
+      const EcalDAQTowerStatus* daqHndl = &_es.getData(daqHndlToken);
       auto daqhandle = _es.getHandle(daqHndlToken);
       if (daqhandle.isValid()) {
         for (unsigned id(0); id < EcalTrigTowerDetId::kEBTotalTowers; id++) {

--- a/DQM/EcalMonitorTasks/interface/ClusterTask.h
+++ b/DQM/EcalMonitorTasks/interface/ClusterTask.h
@@ -13,7 +13,9 @@
 
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "FWCore/Utilities/interface/EDGetToken.h"
-
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "CondFormats/L1TObjects/interface/L1GtTriggerMenu.h"
+#include "CondFormats/DataRecord/interface/L1GtTriggerMenuRcd.h"
 #include <bitset>
 
 namespace ecaldqm {
@@ -57,6 +59,7 @@ namespace ecaldqm {
     edm::InputTag L1MuGMTReadoutCollectionTag_;
     edm::EDGetTokenT<L1GlobalTriggerReadoutRecord> L1GlobalTriggerReadoutRecordToken_;
     edm::EDGetTokenT<L1MuGMTReadoutCollection> L1MuGMTReadoutCollectionToken_;
+    edm::ESGetToken<L1GtTriggerMenu, L1GtTriggerMenuRcd> menuRcd;
   };
 
   inline bool ClusterTask::analyze(void const* _p, Collections _collection) {

--- a/DQM/EcalMonitorTasks/interface/EcalFEDMonitor.h
+++ b/DQM/EcalMonitorTasks/interface/EcalFEDMonitor.h
@@ -21,8 +21,6 @@
 
 #include "DQM/EcalCommon/interface/EcalDQMCommonUtils.h"
 
-#include "Geometry/EcalMapping/interface/EcalElectronicsMapping.h"
-
 #include <iostream>
 
 // Making the class templated temporarily, until HLT sequence can be fixed (is using EBHltTask and EEHltTask currently)
@@ -55,6 +53,7 @@ private:
   edm::EDGetTokenT<EEDetIdCollection> eeGainSwitchErrorsToken_;
   edm::EDGetTokenT<EcalElectronicsIdCollection> towerIdErrorsToken_;
   edm::EDGetTokenT<EcalElectronicsIdCollection> blockSizeErrorsToken_;
+  edm::ESGetToken<EcalElectronicsMapping, EcalMappingRcd> elecMapHandle;
 
   std::vector<MonitorElement *> MEs_;
 };

--- a/DQM/EcalMonitorTasks/interface/SelectiveReadoutTask.h
+++ b/DQM/EcalMonitorTasks/interface/SelectiveReadoutTask.h
@@ -10,6 +10,8 @@
 #include "DataFormats/EcalDigi/interface/EcalDigiCollections.h"
 #include "DataFormats/EcalDetId/interface/EcalTrigTowerDetId.h"
 #include "DataFormats/EcalDetId/interface/EcalScDetId.h"
+#include "CondFormats/EcalObjects/interface/EcalSRSettings.h"
+#include "CondFormats/DataRecord/interface/EcalSRSettingsRcd.h"
 
 class EcalTrigTowerConstituentsMap;
 
@@ -33,6 +35,7 @@ namespace ecaldqm {
     void runOnSrFlags(SRFlagCollection const&, Collections);
     template <typename DigiCollection>
     void runOnDigis(DigiCollection const&, Collections);
+    void setTokens(edm::ConsumesCollector&) override;
 
     enum Constants {
       nFIRTaps = 6,
@@ -51,6 +54,7 @@ namespace ecaldqm {
 
     std::set<std::pair<int, int> > suppressed_;
     std::vector<short> flags_;
+    edm::ESGetToken<EcalSRSettings, EcalSRSettingsRcd> hSr;
   };
 
   inline bool SelectiveReadoutTask::analyze(void const* _p, Collections _collection) {

--- a/DQM/EcalMonitorTasks/interface/TrigPrimTask.h
+++ b/DQM/EcalMonitorTasks/interface/TrigPrimTask.h
@@ -13,6 +13,8 @@
 
 #include "CondFormats/EcalObjects/interface/EcalTPGTowerStatus.h"
 #include "CondFormats/EcalObjects/interface/EcalTPGStripStatus.h"
+#include "CondFormats/DataRecord/interface/EcalTPGTowerStatusRcd.h"
+#include "CondFormats/DataRecord/interface/EcalTPGStripStatusRcd.h"
 
 namespace ecaldqm {
 
@@ -56,9 +58,14 @@ namespace ecaldqm {
 
     std::map<uint32_t, unsigned> towerReadouts_;
 
-    edm::ESHandle<EcalTPGTowerStatus> TTStatusRcd;
-    edm::ESHandle<EcalTPGStripStatus> StripStatusRcd;
-
+    //edm::ESHandle<EcalTPGTowerStatus> TTStatusRcd;
+    //edm::ESHandle<EcalTPGStripStatus> StripStatusRcd;
+    
+    edm::ESGetToken<EcalTPGTowerStatus, EcalTPGTowerStatusRcd> TTStatusRcd_;
+    edm::ESGetToken<EcalTPGStripStatus, EcalTPGStripStatusRcd> StripStatusRcd_;
+    const EcalTPGTowerStatus* TTStatus;
+    const EcalTPGStripStatus* StripStatus;
+ 
     edm::InputTag lhcStatusInfoCollectionTag_;
     edm::EDGetTokenT<TCDSRecord> lhcStatusInfoRecordToken_;
   };

--- a/DQM/EcalMonitorTasks/interface/TrigPrimTask.h
+++ b/DQM/EcalMonitorTasks/interface/TrigPrimTask.h
@@ -58,14 +58,11 @@ namespace ecaldqm {
 
     std::map<uint32_t, unsigned> towerReadouts_;
 
-    //edm::ESHandle<EcalTPGTowerStatus> TTStatusRcd;
-    //edm::ESHandle<EcalTPGStripStatus> StripStatusRcd;
-    
     edm::ESGetToken<EcalTPGTowerStatus, EcalTPGTowerStatusRcd> TTStatusRcd_;
     edm::ESGetToken<EcalTPGStripStatus, EcalTPGStripStatusRcd> StripStatusRcd_;
     const EcalTPGTowerStatus* TTStatus;
     const EcalTPGStripStatus* StripStatus;
- 
+
     edm::InputTag lhcStatusInfoCollectionTag_;
     edm::EDGetTokenT<TCDSRecord> lhcStatusInfoRecordToken_;
   };

--- a/DQM/EcalMonitorTasks/plugins/EcalDQMonitorTask.cc
+++ b/DQM/EcalMonitorTasks/plugins/EcalDQMonitorTask.cc
@@ -47,7 +47,7 @@ EcalDQMonitorTask::EcalDQMonitorTask(edm::ParameterSet const& _ps)
           if (task->analyze(nullptr, ecaldqm::Collections(iCol)))  // "dry run" mode
             hasTaskToRun.set(iCol);
         }
-
+        worker->setTokens(collector);
         task->setTokens(collector);
       },
       "initialization");

--- a/DQM/EcalMonitorTasks/plugins/EcalFEDMonitor.cc
+++ b/DQM/EcalMonitorTasks/plugins/EcalFEDMonitor.cc
@@ -16,6 +16,7 @@ EcalFEDMonitorTemp<SUBDET>::EcalFEDMonitorTemp(edm::ParameterSet const& _ps)
           consumes<EcalElectronicsIdCollection>(_ps.getParameter<edm::InputTag>("EcalElectronicsIdCollection1"))),
       blockSizeErrorsToken_(
           consumes<EcalElectronicsIdCollection>(_ps.getParameter<edm::InputTag>("EcalElectronicsIdCollection2"))),
+      elecMapHandle(esConsumes<edm::Transition::BeginRun>()),
       MEs_(nMEs, nullptr) {
   if (_ps.existsAs<edm::InputTag>("EBDetIdCollection1"))
     ebGainErrorsToken_ = consumes<EBDetIdCollection>(_ps.getParameter<edm::InputTag>("EBDetIdCollection1"));
@@ -29,7 +30,6 @@ EcalFEDMonitorTemp<SUBDET>::EcalFEDMonitorTemp(edm::ParameterSet const& _ps)
     ebGainSwitchErrorsToken_ = consumes<EBDetIdCollection>(_ps.getParameter<edm::InputTag>("EBDetIdCollection3"));
   if (_ps.existsAs<edm::InputTag>("EEDetIdCollection3"))
     eeGainSwitchErrorsToken_ = consumes<EEDetIdCollection>(_ps.getParameter<edm::InputTag>("EEDetIdCollection3"));
-  elecMapHandle= esConsumes();//<EcalElectronicsMapping,EcalMappingRcd>();
 }
 
 template <int SUBDET>
@@ -227,9 +227,7 @@ void EcalFEDMonitorTemp<SUBDET>::analyze(edm::Event const& _evt, edm::EventSetup
 
 template <int SUBDET>
 void EcalFEDMonitorTemp<SUBDET>::setElectronicsMap(edm::EventSetup const& _es) {
-  //edm::ESHandle<EcalElectronicsMapping> elecMapHandle;
-  //_es.get<EcalMappingRcd>().get(elecMapHandle);
-  electronicsMap = &_es.getData(elecMapHandle);//.product();
+  electronicsMap = &_es.getData(elecMapHandle);
 }
 
 template <int SUBDET>

--- a/DQM/EcalMonitorTasks/plugins/EcalFEDMonitor.cc
+++ b/DQM/EcalMonitorTasks/plugins/EcalFEDMonitor.cc
@@ -29,6 +29,7 @@ EcalFEDMonitorTemp<SUBDET>::EcalFEDMonitorTemp(edm::ParameterSet const& _ps)
     ebGainSwitchErrorsToken_ = consumes<EBDetIdCollection>(_ps.getParameter<edm::InputTag>("EBDetIdCollection3"));
   if (_ps.existsAs<edm::InputTag>("EEDetIdCollection3"))
     eeGainSwitchErrorsToken_ = consumes<EEDetIdCollection>(_ps.getParameter<edm::InputTag>("EEDetIdCollection3"));
+  elecMapHandle= esConsumes();//<EcalElectronicsMapping,EcalMappingRcd>();
 }
 
 template <int SUBDET>
@@ -226,9 +227,9 @@ void EcalFEDMonitorTemp<SUBDET>::analyze(edm::Event const& _evt, edm::EventSetup
 
 template <int SUBDET>
 void EcalFEDMonitorTemp<SUBDET>::setElectronicsMap(edm::EventSetup const& _es) {
-  edm::ESHandle<EcalElectronicsMapping> elecMapHandle;
-  _es.get<EcalMappingRcd>().get(elecMapHandle);
-  electronicsMap = elecMapHandle.product();
+  //edm::ESHandle<EcalElectronicsMapping> elecMapHandle;
+  //_es.get<EcalMappingRcd>().get(elecMapHandle);
+  electronicsMap = &_es.getData(elecMapHandle);//.product();
 }
 
 template <int SUBDET>

--- a/DQM/EcalMonitorTasks/src/ClusterTask.cc
+++ b/DQM/EcalMonitorTasks/src/ClusterTask.cc
@@ -9,9 +9,6 @@
 #include "DataFormats/EcalDetId/interface/EcalSubdetector.h"
 #include "DataFormats/GeometryVector/interface/GlobalPoint.h"
 #include "DataFormats/L1GlobalTrigger/interface/L1GtPsbWord.h"
-#include "CondFormats/L1TObjects/interface/L1GtTriggerMenu.h"
-#include "CondFormats/DataRecord/interface/L1GtTriggerMenuRcd.h"
-
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
@@ -68,7 +65,7 @@ namespace ecaldqm {
       trigTypeToME_[iT] = occupancy.getIndex(repl);
     }
   }
-
+  
   void ClusterTask::addDependencies(DependencySet& _dependencies) {
     _dependencies.push_back(Dependency(kEBSuperCluster, kEBRecHit));
     _dependencies.push_back(Dependency(kEESuperCluster, kEERecHit));
@@ -87,9 +84,8 @@ namespace ecaldqm {
     DecisionWord const& dWord(l1GTHndl->decisionWord());
 
     //Ecal
-    edm::ESHandle<L1GtTriggerMenu> menuRcd;
-    _es.get<L1GtTriggerMenuRcd>().get(menuRcd);
-    L1GtTriggerMenu const* menu(menuRcd.product());
+
+    L1GtTriggerMenu const* menu(&_es.getData(menuRcd));
 
     if (!dWord.empty()) {  //protect against no L1GT in run
       for (unsigned iT(0); iT != egTriggerAlgos_.size(); ++iT) {
@@ -521,6 +517,7 @@ namespace ecaldqm {
     L1GlobalTriggerReadoutRecordToken_ =
         _collector.consumes<L1GlobalTriggerReadoutRecord>(L1GlobalTriggerReadoutRecordTag_);
     L1MuGMTReadoutCollectionToken_ = _collector.consumes<L1MuGMTReadoutCollection>(L1MuGMTReadoutCollectionTag_);
+    menuRcd  = _collector.esConsumes();
   }
 
   DEFINE_ECALDQM_WORKER(ClusterTask);

--- a/DQM/EcalMonitorTasks/src/ClusterTask.cc
+++ b/DQM/EcalMonitorTasks/src/ClusterTask.cc
@@ -65,7 +65,7 @@ namespace ecaldqm {
       trigTypeToME_[iT] = occupancy.getIndex(repl);
     }
   }
-  
+
   void ClusterTask::addDependencies(DependencySet& _dependencies) {
     _dependencies.push_back(Dependency(kEBSuperCluster, kEBRecHit));
     _dependencies.push_back(Dependency(kEESuperCluster, kEERecHit));
@@ -517,7 +517,7 @@ namespace ecaldqm {
     L1GlobalTriggerReadoutRecordToken_ =
         _collector.consumes<L1GlobalTriggerReadoutRecord>(L1GlobalTriggerReadoutRecordTag_);
     L1MuGMTReadoutCollectionToken_ = _collector.consumes<L1MuGMTReadoutCollection>(L1MuGMTReadoutCollectionTag_);
-    menuRcd  = _collector.esConsumes();
+    menuRcd = _collector.esConsumes();
   }
 
   DEFINE_ECALDQM_WORKER(ClusterTask);

--- a/DQM/EcalMonitorTasks/src/SelectiveReadoutTask.cc
+++ b/DQM/EcalMonitorTasks/src/SelectiveReadoutTask.cc
@@ -31,8 +31,10 @@ namespace ecaldqm {
       setFIRWeights_(normWeights);
     }
   }
-  
-  void SelectiveReadoutTask::setTokens(edm::ConsumesCollector& _collector) { hSr = _collector.esConsumes<edm::Transition::BeginRun>(); }
+
+  void SelectiveReadoutTask::setTokens(edm::ConsumesCollector& _collector) {
+    hSr = _collector.esConsumes<edm::Transition::BeginRun>();
+  }
 
   void SelectiveReadoutTask::addDependencies(DependencySet& _dependencies) {
     _dependencies.push_back(Dependency(kEBDigi, kEcalRawData, kEBSrFlag));
@@ -43,7 +45,7 @@ namespace ecaldqm {
     using namespace std;
 
     if (useCondDb_) {
-      auto const& vSr =  &_es.getData(hSr);
+      auto const& vSr = &_es.getData(hSr);
       vector<vector<float> > weights(vSr->dccNormalizedWeights_);
       if (weights.size() == 1) {
         vector<double> normWeights;

--- a/DQM/EcalMonitorTasks/src/SelectiveReadoutTask.cc
+++ b/DQM/EcalMonitorTasks/src/SelectiveReadoutTask.cc
@@ -3,10 +3,6 @@
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
-#include "CondFormats/EcalObjects/interface/EcalSRSettings.h"
-#include "CondFormats/DataRecord/interface/EcalSRSettingsRcd.h"
-#include "CondFormats/DataRecord/interface/EcalChannelStatusRcd.h"
-
 #include "Geometry/CaloTopology/interface/EcalTrigTowerConstituentsMap.h"
 #include "Geometry/Records/interface/IdealGeometryRecord.h"
 
@@ -14,6 +10,7 @@
 
 #include "DQM/EcalCommon/interface/FEFlags.h"
 #include "DQM/EcalCommon/interface/EcalDQMCommonUtils.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 
 namespace ecaldqm {
 
@@ -34,6 +31,8 @@ namespace ecaldqm {
       setFIRWeights_(normWeights);
     }
   }
+  
+  void SelectiveReadoutTask::setTokens(edm::ConsumesCollector& _collector) { hSr = _collector.esConsumes<edm::Transition::BeginRun>(); }
 
   void SelectiveReadoutTask::addDependencies(DependencySet& _dependencies) {
     _dependencies.push_back(Dependency(kEBDigi, kEcalRawData, kEBSrFlag));
@@ -44,10 +43,8 @@ namespace ecaldqm {
     using namespace std;
 
     if (useCondDb_) {
-      edm::ESHandle<EcalSRSettings> hSr;
-      _es.get<EcalSRSettingsRcd>().get(hSr);
-
-      vector<vector<float> > weights(hSr->dccNormalizedWeights_);
+      auto const& vSr =  &_es.getData(hSr);
+      vector<vector<float> > weights(vSr->dccNormalizedWeights_);
       if (weights.size() == 1) {
         vector<double> normWeights;
         for (vector<float>::iterator it(weights[0].begin()); it != weights[0].end(); it++)

--- a/DQM/EcalMonitorTasks/src/TrigPrimTask.cc
+++ b/DQM/EcalMonitorTasks/src/TrigPrimTask.cc
@@ -7,9 +7,6 @@
 #include "FWCore/Common/interface/TriggerResultsByName.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
-//#include "CondFormats/DataRecord/interface/EcalTPGTowerStatusRcd.h"
-//#include "CondFormats/DataRecord/interface/EcalTPGStripStatusRcd.h"
-
 #include <iomanip>
 
 namespace ecaldqm {
@@ -27,7 +24,6 @@ namespace ecaldqm {
         bxBinFine_(0.),
         towerReadouts_(),
         lhcStatusInfoCollectionTag_() {}
-	//TTStatusRcd_(collector.esConsumes<edm::Transition::BeginRun>()) {}
 
   void TrigPrimTask::setParams(edm::ParameterSet const& _params) {
     runOnEmul_ = _params.getUntrackedParameter<bool>("runOnEmul");
@@ -54,10 +50,8 @@ namespace ecaldqm {
     // Read-in Status records:
     // Status records stay constant over run so they are read-in only once here
     // but filled by LS in runOnRealTPs() because MEs are not yet booked at beginRun()
-    //_es.get<EcalTPGTowerStatusRcd>().get(TTStatusRcd);
-    //_es.get<EcalTPGStripStatusRcd>().get(StripStatusRcd);
-      TTStatus = &_es.getData(TTStatusRcd_);
-      StripStatus = &_es.getData(StripStatusRcd_);
+    TTStatus = &_es.getData(TTStatusRcd_);
+    StripStatus = &_es.getData(StripStatusRcd_);
   }
 
   void TrigPrimTask::beginEvent(edm::Event const& _evt,
@@ -97,14 +91,7 @@ namespace ecaldqm {
         std::upper_bound(bxBinEdgesFine_.begin(), bxBinEdgesFine_.end(), _evt.bunchCrossing()));
     bxBinFine_ = static_cast<int>(pBinFine - bxBinEdgesFine_.begin()) - 0.5;
 
-    //edm::ESHandle<EcalTPGTowerStatus> TTStatusRcd_;
-    //_es.get<EcalTPGTowerStatusRcd>().get(TTStatusRcd_);
-    //const EcalTPGTowerStatus* TTStatus = &_es.getData(TTStatusRcd_);
     const EcalTPGTowerStatusMap& towerMap = TTStatus->getMap();
-
-    //edm::ESHandle<EcalTPGStripStatus> StripStatusRcd_;
-    //_es.get<EcalTPGStripStatusRcd>().get(StripStatusRcd_);
-    //const EcalTPGStripStatus* StripStatus = &_es.getData(StripStatusRcd_);
     const EcalTPGStripStatusMap& stripMap = StripStatus->getMap();
 
     MESet& meTTMaskMap(MEs_.at("TTMaskMap"));
@@ -192,7 +179,7 @@ namespace ecaldqm {
   void TrigPrimTask::setTokens(edm::ConsumesCollector& _collector) {
     lhcStatusInfoRecordToken_ = _collector.consumes<TCDSRecord>(lhcStatusInfoCollectionTag_);
     TTStatusRcd_ = _collector.esConsumes<edm::Transition::BeginRun>();
-    StripStatusRcd_ = _collector.esConsumes<edm::Transition::BeginRun>(); 
+    StripStatusRcd_ = _collector.esConsumes<edm::Transition::BeginRun>();
   }
 
   void TrigPrimTask::runOnRealTPs(EcalTrigPrimDigiCollection const& _tps) {
@@ -274,7 +261,6 @@ namespace ecaldqm {
     MESet& meTTMaskMapAll(MEs_.at("TTMaskMapAll"));
 
     // Fill from TT Status Rcd
-    //const EcalTPGTowerStatus* TTStatus(&_es.getData(TTStatusRcd).product());
     const EcalTPGTowerStatusMap& TTStatusMap(TTStatus->getMap());
     for (EcalTPGTowerStatusMap::const_iterator ttItr(TTStatusMap.begin()); ttItr != TTStatusMap.end(); ++ttItr) {
       const EcalTrigTowerDetId ttid(ttItr->first);
@@ -283,7 +269,6 @@ namespace ecaldqm {
     }                                                                     // TTs
 
     // Fill from Strip Status Rcd
-    //const EcalTPGStripStatus* StripStatus(StripStatusRcd.product());
     const EcalTPGStripStatusMap& StripStatusMap(StripStatus->getMap());
     for (EcalTPGStripStatusMap::const_iterator stItr(StripStatusMap.begin()); stItr != StripStatusMap.end(); ++stItr) {
       const EcalTriggerElectronicsId stid(stItr->first);

--- a/DQM/EcalMonitorTasks/src/TrigPrimTask.cc
+++ b/DQM/EcalMonitorTasks/src/TrigPrimTask.cc
@@ -7,8 +7,8 @@
 #include "FWCore/Common/interface/TriggerResultsByName.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
-#include "CondFormats/DataRecord/interface/EcalTPGTowerStatusRcd.h"
-#include "CondFormats/DataRecord/interface/EcalTPGStripStatusRcd.h"
+//#include "CondFormats/DataRecord/interface/EcalTPGTowerStatusRcd.h"
+//#include "CondFormats/DataRecord/interface/EcalTPGStripStatusRcd.h"
 
 #include <iomanip>
 
@@ -27,6 +27,7 @@ namespace ecaldqm {
         bxBinFine_(0.),
         towerReadouts_(),
         lhcStatusInfoCollectionTag_() {}
+	//TTStatusRcd_(collector.esConsumes<edm::Transition::BeginRun>()) {}
 
   void TrigPrimTask::setParams(edm::ParameterSet const& _params) {
     runOnEmul_ = _params.getUntrackedParameter<bool>("runOnEmul");
@@ -53,8 +54,10 @@ namespace ecaldqm {
     // Read-in Status records:
     // Status records stay constant over run so they are read-in only once here
     // but filled by LS in runOnRealTPs() because MEs are not yet booked at beginRun()
-    _es.get<EcalTPGTowerStatusRcd>().get(TTStatusRcd);
-    _es.get<EcalTPGStripStatusRcd>().get(StripStatusRcd);
+    //_es.get<EcalTPGTowerStatusRcd>().get(TTStatusRcd);
+    //_es.get<EcalTPGStripStatusRcd>().get(StripStatusRcd);
+      TTStatus = &_es.getData(TTStatusRcd_);
+      StripStatus = &_es.getData(StripStatusRcd_);
   }
 
   void TrigPrimTask::beginEvent(edm::Event const& _evt,
@@ -94,14 +97,14 @@ namespace ecaldqm {
         std::upper_bound(bxBinEdgesFine_.begin(), bxBinEdgesFine_.end(), _evt.bunchCrossing()));
     bxBinFine_ = static_cast<int>(pBinFine - bxBinEdgesFine_.begin()) - 0.5;
 
-    edm::ESHandle<EcalTPGTowerStatus> TTStatusRcd_;
-    _es.get<EcalTPGTowerStatusRcd>().get(TTStatusRcd_);
-    const EcalTPGTowerStatus* TTStatus = TTStatusRcd_.product();
+    //edm::ESHandle<EcalTPGTowerStatus> TTStatusRcd_;
+    //_es.get<EcalTPGTowerStatusRcd>().get(TTStatusRcd_);
+    //const EcalTPGTowerStatus* TTStatus = &_es.getData(TTStatusRcd_);
     const EcalTPGTowerStatusMap& towerMap = TTStatus->getMap();
 
-    edm::ESHandle<EcalTPGStripStatus> StripStatusRcd_;
-    _es.get<EcalTPGStripStatusRcd>().get(StripStatusRcd_);
-    const EcalTPGStripStatus* StripStatus = StripStatusRcd_.product();
+    //edm::ESHandle<EcalTPGStripStatus> StripStatusRcd_;
+    //_es.get<EcalTPGStripStatusRcd>().get(StripStatusRcd_);
+    //const EcalTPGStripStatus* StripStatus = &_es.getData(StripStatusRcd_);
     const EcalTPGStripStatusMap& stripMap = StripStatus->getMap();
 
     MESet& meTTMaskMap(MEs_.at("TTMaskMap"));
@@ -188,6 +191,8 @@ namespace ecaldqm {
 
   void TrigPrimTask::setTokens(edm::ConsumesCollector& _collector) {
     lhcStatusInfoRecordToken_ = _collector.consumes<TCDSRecord>(lhcStatusInfoCollectionTag_);
+    TTStatusRcd_ = _collector.esConsumes<edm::Transition::BeginRun>();
+    StripStatusRcd_ = _collector.esConsumes<edm::Transition::BeginRun>(); 
   }
 
   void TrigPrimTask::runOnRealTPs(EcalTrigPrimDigiCollection const& _tps) {
@@ -269,7 +274,7 @@ namespace ecaldqm {
     MESet& meTTMaskMapAll(MEs_.at("TTMaskMapAll"));
 
     // Fill from TT Status Rcd
-    const EcalTPGTowerStatus* TTStatus(TTStatusRcd.product());
+    //const EcalTPGTowerStatus* TTStatus(&_es.getData(TTStatusRcd).product());
     const EcalTPGTowerStatusMap& TTStatusMap(TTStatus->getMap());
     for (EcalTPGTowerStatusMap::const_iterator ttItr(TTStatusMap.begin()); ttItr != TTStatusMap.end(); ++ttItr) {
       const EcalTrigTowerDetId ttid(ttItr->first);
@@ -278,7 +283,7 @@ namespace ecaldqm {
     }                                                                     // TTs
 
     // Fill from Strip Status Rcd
-    const EcalTPGStripStatus* StripStatus(StripStatusRcd.product());
+    //const EcalTPGStripStatus* StripStatus(StripStatusRcd.product());
     const EcalTPGStripStatusMap& StripStatusMap(StripStatus->getMap());
     for (EcalTPGStripStatusMap::const_iterator stItr(StripStatusMap.begin()); stItr != StripStatusMap.end(); ++stItr) {
       const EcalTriggerElectronicsId stid(stItr->first);


### PR DESCRIPTION
#### PR description:
This PR addresses the migration of ECAL DQM/* codes to use esConsumes as mentioned here: https://github.com/cms-sw/cmssw/issues/31061


#### PR validation:
Validation done by running `scram build checker` where the warnings with respect to the ESConsumes go away and also validated by running the relval workflow 136.874 using the runTheMatrix script
`runTheMatrix.py -l 136.874 --ibeos`

#### if this PR is a backport please specify the original PR and why you need to backport that PR:
N/A
