### PR TITLE
Migrate ECAL DQMOffline codes to ESConsumes 

### DIFF
--- a/DQMOffline/Ecal/interface/EcalPileUpDepMonitor.h
+++ b/DQMOffline/Ecal/interface/EcalPileUpDepMonitor.h
@@ -15,6 +15,10 @@
 
 #include "Geometry/CaloGeometry/interface/CaloGeometry.h"
 #include "Geometry/CaloTopology/interface/CaloTopology.h"
+#include "Geometry/Records/interface/CaloTopologyRecord.h"
+#include "Geometry/CaloGeometry/interface/CaloCellGeometry.h"
+#include "Geometry/Records/interface/CaloGeometryRecord.h"
+
 
 #include "DataFormats/CaloRecHit/interface/CaloCluster.h"
 #include "DataFormats/Common/interface/View.h"
@@ -85,8 +89,8 @@ private:
   MonitorElement *r9_EB;
   MonitorElement *r9_EE;
 
-  edm::ESHandle<CaloGeometry> geomH;
-  edm::ESHandle<CaloTopology> caloTop;
+  edm::ESGetToken<CaloGeometry, CaloGeometryRecord> geomH;
+  edm::ESGetToken<CaloTopology, CaloTopologyRecord> caloTop;
 
   edm::EDGetTokenT<reco::VertexCollection> VertexCollection_;  // vertex collection
 

--- a/DQMOffline/Ecal/interface/EcalPileUpDepMonitor.h
+++ b/DQMOffline/Ecal/interface/EcalPileUpDepMonitor.h
@@ -19,7 +19,6 @@
 #include "Geometry/CaloGeometry/interface/CaloCellGeometry.h"
 #include "Geometry/Records/interface/CaloGeometryRecord.h"
 
-
 #include "DataFormats/CaloRecHit/interface/CaloCluster.h"
 #include "DataFormats/Common/interface/View.h"
 #include "DataFormats/EcalRecHit/interface/EcalRecHitCollections.h"

--- a/DQMOffline/Ecal/plugins/ECALMultifitAnalyzer_HI.cc
+++ b/DQMOffline/Ecal/plugins/ECALMultifitAnalyzer_HI.cc
@@ -67,6 +67,7 @@ private:
   edm::EDGetTokenT<reco::CaloJetCollection> caloJetToken_;
   edm::EDGetTokenT<EcalRecHitCollection> RecHitCollection_EB_;
   edm::EDGetTokenT<EcalRecHitCollection> RecHitCollection_EE_;
+  edm::ESGetToken<CaloGeometry, CaloGeometryRecord> geomH;
 
   double mRechitEnergyThreshold;
   double mRecoPhotonPtThreshold;
@@ -105,12 +106,12 @@ private:
 // constructors and destructor
 //
 ECALMultifitAnalyzer_HI::ECALMultifitAnalyzer_HI(const edm::ParameterSet &iConfig)
-    :
-
+    : 
       recoPhotonsCollection_(consumes<std::vector<reco::Photon>>(iConfig.getParameter<edm::InputTag>("recoPhotonSrc"))),
       caloJetToken_(consumes<reco::CaloJetCollection>(iConfig.getParameter<edm::InputTag>("recoJetSrc"))),
       RecHitCollection_EB_(consumes<EcalRecHitCollection>(iConfig.getParameter<edm::InputTag>("RecHitCollection_EB"))),
       RecHitCollection_EE_(consumes<EcalRecHitCollection>(iConfig.getParameter<edm::InputTag>("RecHitCollection_EE"))),
+      geomH(esConsumes()),
       mRechitEnergyThreshold(iConfig.getParameter<double>("rechitEnergyThreshold")),
       mRecoPhotonPtThreshold(iConfig.getParameter<double>("recoPhotonPtThreshold")),
       mRecoJetPtThreshold(iConfig.getParameter<double>("recoJetPtThreshold")),
@@ -125,9 +126,7 @@ ECALMultifitAnalyzer_HI::ECALMultifitAnalyzer_HI(const edm::ParameterSet &iConfi
 void ECALMultifitAnalyzer_HI::analyze(const edm::Event &iEvent, const edm::EventSetup &iSetup) {
   using namespace edm;
 
-  edm::ESHandle<CaloGeometry> geomH;
-  iSetup.get<CaloGeometryRecord>().get(geomH);
-  const CaloGeometry *geom = geomH.product();
+  const CaloGeometry *geom = &iSetup.getData(geomH);
 
   Handle<std::vector<reco::Photon>> recoPhotonsHandle;
   iEvent.getByToken(recoPhotonsCollection_, recoPhotonsHandle);

--- a/DQMOffline/Ecal/plugins/ECALMultifitAnalyzer_HI.cc
+++ b/DQMOffline/Ecal/plugins/ECALMultifitAnalyzer_HI.cc
@@ -106,8 +106,7 @@ private:
 // constructors and destructor
 //
 ECALMultifitAnalyzer_HI::ECALMultifitAnalyzer_HI(const edm::ParameterSet &iConfig)
-    : 
-      recoPhotonsCollection_(consumes<std::vector<reco::Photon>>(iConfig.getParameter<edm::InputTag>("recoPhotonSrc"))),
+    : recoPhotonsCollection_(consumes<std::vector<reco::Photon>>(iConfig.getParameter<edm::InputTag>("recoPhotonSrc"))),
       caloJetToken_(consumes<reco::CaloJetCollection>(iConfig.getParameter<edm::InputTag>("recoJetSrc"))),
       RecHitCollection_EB_(consumes<EcalRecHitCollection>(iConfig.getParameter<edm::InputTag>("RecHitCollection_EB"))),
       RecHitCollection_EE_(consumes<EcalRecHitCollection>(iConfig.getParameter<edm::InputTag>("RecHitCollection_EE"))),

--- a/DQMOffline/Ecal/plugins/EcalPileUpDepMonitor.cc
+++ b/DQMOffline/Ecal/plugins/EcalPileUpDepMonitor.cc
@@ -14,10 +14,6 @@
 #include "DataFormats/GeometryVector/interface/GlobalPoint.h"
 #include "DataFormats/VertexReco/interface/Vertex.h"
 
-#include "Geometry/Records/interface/CaloTopologyRecord.h"
-#include "Geometry/CaloGeometry/interface/CaloCellGeometry.h"
-#include "Geometry/Records/interface/CaloGeometryRecord.h"
-
 #include "RecoEcal/EgammaCoreTools/interface/EcalClusterTools.h"
 
 #include "FWCore/Framework/interface/Event.h"
@@ -30,7 +26,9 @@
 
 // Framework
 
-EcalPileUpDepMonitor::EcalPileUpDepMonitor(const edm::ParameterSet &ps) {
+EcalPileUpDepMonitor::EcalPileUpDepMonitor(const edm::ParameterSet &ps) 
+  :geomH(esConsumes()),
+   caloTop(esConsumes()) {
   VertexCollection_ = consumes<reco::VertexCollection>(ps.getParameter<edm::InputTag>("VertexCollection"));
 
   if (ps.existsAs<edm::InputTag>("basicClusterCollection") &&
@@ -58,9 +56,6 @@ EcalPileUpDepMonitor::~EcalPileUpDepMonitor() {}
 void EcalPileUpDepMonitor::bookHistograms(DQMStore::IBooker &ibooker,
                                           edm::Run const &,
                                           edm::EventSetup const &eventSetup) {
-  eventSetup.get<CaloGeometryRecord>().get(geomH);
-  eventSetup.get<CaloTopologyRecord>().get(caloTop);
-
   ibooker.cd();
   ibooker.setCurrentFolder("Ecal/EcalPileUpDepMonitor");
 
@@ -229,8 +224,8 @@ void EcalPileUpDepMonitor::bookHistograms(DQMStore::IBooker &ibooker,
   recHitEtEE->setAxisTitle("Events", 2);
 }
 
-void EcalPileUpDepMonitor::analyze(const edm::Event &e, const edm::EventSetup &) {
-  const CaloGeometry *geom = geomH.product();
+void EcalPileUpDepMonitor::analyze(const edm::Event &e, const edm::EventSetup &es) {
+  const CaloGeometry *geom = &es.getData(geomH);
   // Vertex collection:
   //-----------------------------------------
   edm::Handle<reco::VertexCollection> PVCollection_h;
@@ -336,7 +331,7 @@ void EcalPileUpDepMonitor::analyze(const edm::Event &e, const edm::EventSetup &)
 
     // get sigma eta_eta etc
 
-    CaloTopology const *p_topology = caloTop.product();  // get calo topology
+    CaloTopology const *p_topology = &es.getData(caloTop);  // get calo topology
     const EcalRecHitCollection *eeRecHits = RecHitsEE.product();
 
     reco::BasicCluster const &seedCluster(*itSC->seed());
@@ -379,7 +374,7 @@ void EcalPileUpDepMonitor::analyze(const edm::Event &e, const edm::EventSetup &)
 
     // sigma ietaieta etc
 
-    CaloTopology const *p_topology = caloTop.product();  // get calo topology
+    CaloTopology const *p_topology = &es.getData(caloTop);  // get calo topology
     const EcalRecHitCollection *ebRecHits = RecHitsEB.product();
 
     reco::BasicCluster const &seedCluster(*itSC->seed());

--- a/DQMOffline/Ecal/plugins/EcalPileUpDepMonitor.cc
+++ b/DQMOffline/Ecal/plugins/EcalPileUpDepMonitor.cc
@@ -26,9 +26,7 @@
 
 // Framework
 
-EcalPileUpDepMonitor::EcalPileUpDepMonitor(const edm::ParameterSet &ps) 
-  :geomH(esConsumes()),
-   caloTop(esConsumes()) {
+EcalPileUpDepMonitor::EcalPileUpDepMonitor(const edm::ParameterSet &ps) : geomH(esConsumes()), caloTop(esConsumes()) {
   VertexCollection_ = consumes<reco::VertexCollection>(ps.getParameter<edm::InputTag>("VertexCollection"));
 
   if (ps.existsAs<edm::InputTag>("basicClusterCollection") &&


### PR DESCRIPTION
#### PR description:

This PR addresses the migration of DQMOffline/Ecal codes to use esConsumes as mentioned here: #31061

#### PR validation:
Validation done by running `scram build checker` where the warnings with respect to the ESConsumes go away and also validated by running the relval workflow 136.874 using the runTheMatrix script
`runTheMatrix.py -l 136.874 --ibeos`

#### if this PR is a backport please specify the original PR and why you need to backport that PR:
N/A
