### PR TITLE
Migrate ECAL Validation codes to ESConsumes

### DIFF
--- a/Validation/EcalClusters/interface/ContainmentCorrectionAnalyzer.h
+++ b/Validation/EcalClusters/interface/ContainmentCorrectionAnalyzer.h
@@ -66,6 +66,7 @@ private:
   edm::EDGetTokenT<reco::SuperClusterCollection> EndcapSuperClusterCollection_;
   edm::EDGetTokenT<EcalRecHitCollection> reducedBarrelRecHitCollection_;
   edm::EDGetTokenT<EcalRecHitCollection> reducedEndcapRecHitCollection_;
+  edm::ESGetToken<CaloTopology, CaloTopologyRecord> pTopologyToken;
 
   int nMCphotons;
   std::vector<float> mcEnergy, mcEta, mcPhi, mcPt;

--- a/Validation/EcalClusters/interface/ContainmentCorrectionAnalyzer.h
+++ b/Validation/EcalClusters/interface/ContainmentCorrectionAnalyzer.h
@@ -5,7 +5,7 @@
 #include <memory>
 
 // user include files
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
@@ -45,7 +45,7 @@ class TFile;
 
 class EcalSimPhotonMCTruth;
 
-class ContainmentCorrectionAnalyzer : public edm::EDAnalyzer {
+class ContainmentCorrectionAnalyzer : public edm::one::EDAnalyzer<> {
 public:
   explicit ContainmentCorrectionAnalyzer(const edm::ParameterSet &);
   ~ContainmentCorrectionAnalyzer() override;

--- a/Validation/EcalClusters/src/ContainmentCorrectionAnalyzer.cc
+++ b/Validation/EcalClusters/src/ContainmentCorrectionAnalyzer.cc
@@ -8,7 +8,7 @@ using namespace edm;
 using namespace std;
 using namespace reco;
 
-ContainmentCorrectionAnalyzer::ContainmentCorrectionAnalyzer(const ParameterSet &ps) {
+ContainmentCorrectionAnalyzer::ContainmentCorrectionAnalyzer(const ParameterSet &ps) : pTopologyToken(esConsumes()) {
   BarrelSuperClusterCollection_ =
       consumes<reco::SuperClusterCollection>(ps.getParameter<InputTag>("BarrelSuperClusterCollection"));
   EndcapSuperClusterCollection_ =
@@ -111,10 +111,9 @@ void ContainmentCorrectionAnalyzer::analyze(const Event &evt, const EventSetup &
   }
 
   const CaloTopology *topology = nullptr;
-  ESHandle<CaloTopology> pTopology;
-  es.get<CaloTopologyRecord>().get(pTopology);
+  auto pTopology = es.getHandle(pTopologyToken);
   if (pTopology.isValid())
-    topology = pTopology.product();
+    topology = &es.getData(pTopologyToken);
 
   std::vector<EcalSimPhotonMCTruth> photons = findMcTruth(theSimTracks, theSimVertexes);
 

--- a/Validation/EcalDigis/interface/EcalBarrelDigisValidation.h
+++ b/Validation/EcalDigis/interface/EcalBarrelDigisValidation.h
@@ -31,6 +31,9 @@
 #include <map>
 #include "DQMServices/Core/interface/DQMEDAnalyzer.h"
 
+#include <Validation/EcalDigis/interface/EcalBarrelDigisValidation.h>
+#include "CalibCalorimetry/EcalTrivialCondModules/interface/EcalTrivialConditionRetriever.h"
+
 class EcalBarrelDigisValidation : public DQMEDAnalyzer {
   typedef std::map<uint32_t, float, std::less<uint32_t> > MapType;
 
@@ -55,7 +58,7 @@ private:
   std::string outputFile_;
 
   edm::EDGetTokenT<EBDigiCollection> EBdigiCollection_;
-
+  edm::ESGetToken<EcalADCToGeVConstant, EcalADCToGeVConstantRcd> pAgc;
   std::map<int, double, std::less<int> > gainConv_;
 
   double barrelADCtoGeV_;

--- a/Validation/EcalDigis/interface/EcalDigisValidation.h
+++ b/Validation/EcalDigis/interface/EcalDigisValidation.h
@@ -37,6 +37,8 @@
 #include "DataFormats/EcalDigi/interface/EcalDigiCollections.h"
 #include "SimDataFormats/CrossingFrame/interface/CrossingFrame.h"
 #include "SimDataFormats/CrossingFrame/interface/MixCollection.h"
+#include <Validation/EcalDigis/interface/EcalDigisValidation.h>
+#include "CalibCalorimetry/EcalTrivialCondModules/interface/EcalTrivialConditionRetriever.h"
 
 #include <iostream>
 #include <fstream>
@@ -75,6 +77,7 @@ private:
   edm::EDGetTokenT<EBDigiCollection> EBdigiCollectionToken_;
   edm::EDGetTokenT<EEDigiCollection> EEdigiCollectionToken_;
   edm::EDGetTokenT<ESDigiCollection> ESdigiCollectionToken_;
+  edm::ESGetToken<EcalADCToGeVConstant, EcalADCToGeVConstantRcd> pAgc;
 
   edm::EDGetTokenT<CrossingFrame<PCaloHit> > crossingFramePCaloHitEBToken_, crossingFramePCaloHitEEToken_,
       crossingFramePCaloHitESToken_;

--- a/Validation/EcalDigis/interface/EcalEndcapDigisValidation.h
+++ b/Validation/EcalDigis/interface/EcalEndcapDigisValidation.h
@@ -25,6 +25,9 @@
 #include "DataFormats/EcalDigi/interface/EEDataFrame.h"
 #include "DataFormats/EcalDigi/interface/EcalDigiCollections.h"
 
+#include <Validation/EcalDigis/interface/EcalEndcapDigisValidation.h>
+#include "CalibCalorimetry/EcalTrivialCondModules/interface/EcalTrivialConditionRetriever.h"
+
 #include <iostream>
 #include <fstream>
 #include <vector>
@@ -56,6 +59,7 @@ private:
   std::string outputFile_;
 
   edm::EDGetTokenT<EEDigiCollection> EEdigiCollectionToken_;
+  edm::ESGetToken<EcalADCToGeVConstant, EcalADCToGeVConstantRcd> pAgc;
 
   std::map<int, double, std::less<int> > gainConv_;
 

--- a/Validation/EcalDigis/interface/EcalMixingModuleValidation.h
+++ b/Validation/EcalDigis/interface/EcalMixingModuleValidation.h
@@ -55,6 +55,9 @@
 #include "CondFormats/ESObjects/interface/ESPedestals.h"
 #include "CondFormats/DataRecord/interface/ESPedestalsRcd.h"
 #include "CondFormats/ESObjects/interface/ESIntercalibConstants.h"
+#include <Validation/EcalDigis/interface/EcalBarrelDigisValidation.h>
+#include "CalibCalorimetry/EcalTrivialCondModules/interface/EcalTrivialConditionRetriever.h"
+#include "Geometry/Records/interface/CaloGeometryRecord.h"
 
 #include <iostream>
 #include <fstream>
@@ -106,9 +109,16 @@ private:
   edm::EDGetTokenT<EBDigiCollection> EBdigiCollectionToken_;
   edm::EDGetTokenT<EEDigiCollection> EEdigiCollectionToken_;
   edm::EDGetTokenT<ESDigiCollection> ESdigiCollectionToken_;
-
   edm::EDGetTokenT<CrossingFrame<PCaloHit> > crossingFramePCaloHitEBToken_, crossingFramePCaloHitEEToken_,
       crossingFramePCaloHitESToken_;
+
+  edm::ESGetToken<EcalADCToGeVConstant, EcalADCToGeVConstantRcd> pAgc;
+  edm::ESGetToken<ESGain, ESGainRcd> esgain_;
+  edm::ESGetToken<ESMIPToGeVConstant, ESMIPToGeVConstantRcd> esMIPToGeV_;
+  edm::ESGetToken<ESPedestals, ESPedestalsRcd> esPedestals_;
+  edm::ESGetToken<ESIntercalibConstants, ESIntercalibConstantsRcd> esMIPs_;
+  edm::ESGetToken<EcalPedestals, EcalPedestalsRcd> dbPed;
+  edm::ESGetToken<CaloGeometry, CaloGeometryRecord> hGeometry;
 
   std::map<int, double, std::less<int> > gainConv_;
 

--- a/Validation/EcalDigis/interface/EcalSelectiveReadoutValidation.h
+++ b/Validation/EcalDigis/interface/EcalSelectiveReadoutValidation.h
@@ -19,6 +19,18 @@
 #include "DataFormats/FEDRawData/interface/FEDRawDataCollection.h"
 #include "DataFormats/EcalDetId/interface/EcalScDetId.h"
 #include "DataFormats/EcalDetId/interface/EcalTrigTowerDetId.h"
+#include "Geometry/CaloGeometry/interface/CaloGeometry.h"
+#include "Geometry/Records/interface/CaloGeometryRecord.h"
+#include "Geometry/CaloTopology/interface/EcalTrigTowerConstituentsMap.h"
+#include "Geometry/EcalMapping/interface/EcalElectronicsMapping.h"
+#include "Geometry/EcalMapping/interface/EcalMappingRcd.h"
+
+#include "CondFormats/EcalObjects/interface/EcalTPGLutIdMap.h"
+#include "CondFormats/EcalObjects/interface/EcalTPGLutGroup.h"
+#include "CondFormats/EcalObjects/interface/EcalTPGPhysicsConst.h"
+#include "CondFormats/DataRecord/interface/EcalTPGLutIdMapRcd.h"
+#include "CondFormats/DataRecord/interface/EcalTPGLutGroupRcd.h"
+#include "CondFormats/DataRecord/interface/EcalTPGPhysicsConstRcd.h"
 
 #include "Validation/EcalDigis/src/CollHandle.h"
 
@@ -392,6 +404,13 @@ private:
     double eta;   ///eta crystal position
     bool gain12;  //all MGPA samples at gain 12?
   };
+
+  edm::ESGetToken<CaloGeometry, CaloGeometryRecord> geoToken;
+  edm::ESGetToken<EcalElectronicsMapping, EcalMappingRcd> ecalmapping;
+  edm::ESGetToken<EcalTrigTowerConstituentsMap, IdealGeometryRecord> hTriggerTowerMap;
+  edm::ESGetToken<EcalTPGPhysicsConst, EcalTPGPhysicsConstRcd> physHandle;
+  edm::ESGetToken<EcalTPGLutGroup, EcalTPGLutGroupRcd> lutGrpHandle;
+  edm::ESGetToken<EcalTPGLutIdMap, EcalTPGLutIdMapRcd> lutMapHandle;
 
   /// number of bytes in 1 kByte:
   static const int kByte_ = 1024;

--- a/Validation/EcalDigis/src/EcalBarrelDigisValidation.cc
+++ b/Validation/EcalDigis/src/EcalBarrelDigisValidation.cc
@@ -15,7 +15,7 @@ using namespace std;
 
 EcalBarrelDigisValidation::EcalBarrelDigisValidation(const ParameterSet& ps)
     : EBdigiCollection_(consumes<EBDigiCollection>(ps.getParameter<edm::InputTag>("EBdigiCollection"))),
-      pAgc(esConsumes()) {
+      pAgc(esConsumes<edm::Transition::BeginRun>()) {
   // verbosity switch
   verbose_ = ps.getUntrackedParameter<bool>("verbose", false);
 

--- a/Validation/EcalDigis/src/EcalBarrelDigisValidation.cc
+++ b/Validation/EcalDigis/src/EcalBarrelDigisValidation.cc
@@ -14,7 +14,8 @@ using namespace edm;
 using namespace std;
 
 EcalBarrelDigisValidation::EcalBarrelDigisValidation(const ParameterSet& ps)
-    : EBdigiCollection_(consumes<EBDigiCollection>(ps.getParameter<edm::InputTag>("EBdigiCollection"))) {
+    : EBdigiCollection_(consumes<EBDigiCollection>(ps.getParameter<edm::InputTag>("EBdigiCollection"))),
+      pAgc(esConsumes()) {
   // verbosity switch
   verbose_ = ps.getUntrackedParameter<bool>("verbose", false);
 
@@ -249,9 +250,7 @@ void EcalBarrelDigisValidation::analyze(Event const& e, EventSetup const& c) {
 
 void EcalBarrelDigisValidation::checkCalibrations(edm::EventSetup const& eventSetup) {
   // ADC -> GeV Scale
-  edm::ESHandle<EcalADCToGeVConstant> pAgc;
-  eventSetup.get<EcalADCToGeVConstantRcd>().get(pAgc);
-  const EcalADCToGeVConstant* agc = pAgc.product();
+  const EcalADCToGeVConstant* agc = &eventSetup.getData(pAgc);
 
   EcalMGPAGainRatio* defaultRatios = new EcalMGPAGainRatio();
 

--- a/Validation/EcalDigis/src/EcalDigisValidation.cc
+++ b/Validation/EcalDigis/src/EcalDigisValidation.cc
@@ -18,6 +18,7 @@ EcalDigisValidation::EcalDigisValidation(const edm::ParameterSet& ps)
       EBdigiCollectionToken_(consumes<EBDigiCollection>(ps.getParameter<edm::InputTag>("EBdigiCollection"))),
       EEdigiCollectionToken_(consumes<EEDigiCollection>(ps.getParameter<edm::InputTag>("EEdigiCollection"))),
       ESdigiCollectionToken_(consumes<ESDigiCollection>(ps.getParameter<edm::InputTag>("ESdigiCollection"))),
+      pAgc(esConsumes()),
       crossingFramePCaloHitEBToken_(consumes<CrossingFrame<PCaloHit> >(edm::InputTag(
           std::string("mix"), ps.getParameter<std::string>("moduleLabelG4") + std::string("EcalHitsEB")))),
       crossingFramePCaloHitEEToken_(consumes<CrossingFrame<PCaloHit> >(edm::InputTag(
@@ -382,9 +383,7 @@ void EcalDigisValidation::analyze(edm::Event const& e, edm::EventSetup const& c)
 
 void EcalDigisValidation::checkCalibrations(edm::EventSetup const& eventSetup) {
   // ADC -> GeV Scale
-  edm::ESHandle<EcalADCToGeVConstant> pAgc;
-  eventSetup.get<EcalADCToGeVConstantRcd>().get(pAgc);
-  const EcalADCToGeVConstant* agc = pAgc.product();
+  const EcalADCToGeVConstant* agc = &eventSetup.getData(pAgc);
 
   EcalMGPAGainRatio* defaultRatios = new EcalMGPAGainRatio();
 

--- a/Validation/EcalDigis/src/EcalDigisValidation.cc
+++ b/Validation/EcalDigis/src/EcalDigisValidation.cc
@@ -18,7 +18,7 @@ EcalDigisValidation::EcalDigisValidation(const edm::ParameterSet& ps)
       EBdigiCollectionToken_(consumes<EBDigiCollection>(ps.getParameter<edm::InputTag>("EBdigiCollection"))),
       EEdigiCollectionToken_(consumes<EEDigiCollection>(ps.getParameter<edm::InputTag>("EEdigiCollection"))),
       ESdigiCollectionToken_(consumes<ESDigiCollection>(ps.getParameter<edm::InputTag>("ESdigiCollection"))),
-      pAgc(esConsumes()),
+      pAgc(esConsumes<edm::Transition::BeginRun>()),
       crossingFramePCaloHitEBToken_(consumes<CrossingFrame<PCaloHit> >(edm::InputTag(
           std::string("mix"), ps.getParameter<std::string>("moduleLabelG4") + std::string("EcalHitsEB")))),
       crossingFramePCaloHitEEToken_(consumes<CrossingFrame<PCaloHit> >(edm::InputTag(

--- a/Validation/EcalDigis/src/EcalEndcapDigisValidation.cc
+++ b/Validation/EcalDigis/src/EcalEndcapDigisValidation.cc
@@ -13,7 +13,8 @@ using namespace edm;
 using namespace std;
 
 EcalEndcapDigisValidation::EcalEndcapDigisValidation(const ParameterSet& ps)
-    : EEdigiCollectionToken_(consumes<EEDigiCollection>(ps.getParameter<edm::InputTag>("EEdigiCollection"))) {
+    : EEdigiCollectionToken_(consumes<EEDigiCollection>(ps.getParameter<edm::InputTag>("EEdigiCollection"))),
+      pAgc(esConsumes()) {
   // verbosity switch
   verbose_ = ps.getUntrackedParameter<bool>("verbose", false);
 
@@ -258,9 +259,7 @@ void EcalEndcapDigisValidation::analyze(Event const& e, EventSetup const& c) {
 
 void EcalEndcapDigisValidation::checkCalibrations(edm::EventSetup const& eventSetup) {
   // ADC -> GeV Scale
-  edm::ESHandle<EcalADCToGeVConstant> pAgc;
-  eventSetup.get<EcalADCToGeVConstantRcd>().get(pAgc);
-  const EcalADCToGeVConstant* agc = pAgc.product();
+  const EcalADCToGeVConstant* agc = &eventSetup.getData(pAgc);
 
   EcalMGPAGainRatio* defaultRatios = new EcalMGPAGainRatio();
 

--- a/Validation/EcalDigis/src/EcalEndcapDigisValidation.cc
+++ b/Validation/EcalDigis/src/EcalEndcapDigisValidation.cc
@@ -14,7 +14,7 @@ using namespace std;
 
 EcalEndcapDigisValidation::EcalEndcapDigisValidation(const ParameterSet& ps)
     : EEdigiCollectionToken_(consumes<EEDigiCollection>(ps.getParameter<edm::InputTag>("EEdigiCollection"))),
-      pAgc(esConsumes()) {
+      pAgc(esConsumes<edm::Transition::BeginRun>()) {
   // verbosity switch
   verbose_ = ps.getUntrackedParameter<bool>("verbose", false);
 

--- a/Validation/EcalDigis/src/EcalMixingModuleValidation.cc
+++ b/Validation/EcalDigis/src/EcalMixingModuleValidation.cc
@@ -27,11 +27,11 @@ EcalMixingModuleValidation::EcalMixingModuleValidation(const edm::ParameterSet& 
           edm::InputTag(std::string("mix"), ps.getParameter<std::string>("hitsProducer") + std::string("EcalHitsEE")))),
       crossingFramePCaloHitESToken_(consumes<CrossingFrame<PCaloHit> >(
           edm::InputTag(std::string("mix"), ps.getParameter<std::string>("hitsProducer") + std::string("EcalHitsES")))),
-      pAgc(esConsumes()),
-      esgain_(esConsumes()),
-      esMIPToGeV_(esConsumes()),
-      esPedestals_(esConsumes()),
-      esMIPs_(esConsumes()),
+      pAgc(esConsumes<edm::Transition::BeginRun>()),
+      esgain_(esConsumes<edm::Transition::BeginRun>()),
+      esMIPToGeV_(esConsumes<edm::Transition::BeginRun>()),
+      esPedestals_(esConsumes<edm::Transition::BeginRun>()),
+      esMIPs_(esConsumes<edm::Transition::BeginRun>()),
       dbPed(esConsumes()),
       hGeometry(esConsumes()) {
   // needed for MixingModule checks

--- a/Validation/EcalDigis/src/EcalMixingModuleValidation.cc
+++ b/Validation/EcalDigis/src/EcalMixingModuleValidation.cc
@@ -25,8 +25,15 @@ EcalMixingModuleValidation::EcalMixingModuleValidation(const edm::ParameterSet& 
           edm::InputTag(std::string("mix"), ps.getParameter<std::string>("hitsProducer") + std::string("EcalHitsEB")))),
       crossingFramePCaloHitEEToken_(consumes<CrossingFrame<PCaloHit> >(
           edm::InputTag(std::string("mix"), ps.getParameter<std::string>("hitsProducer") + std::string("EcalHitsEE")))),
-      crossingFramePCaloHitESToken_(consumes<CrossingFrame<PCaloHit> >(edm::InputTag(
-          std::string("mix"), ps.getParameter<std::string>("hitsProducer") + std::string("EcalHitsES")))) {
+      crossingFramePCaloHitESToken_(consumes<CrossingFrame<PCaloHit> >(
+          edm::InputTag(std::string("mix"), ps.getParameter<std::string>("hitsProducer") + std::string("EcalHitsES")))),
+      pAgc(esConsumes()),
+      esgain_(esConsumes()),
+      esMIPToGeV_(esConsumes()),
+      esPedestals_(esConsumes()),
+      esMIPs_(esConsumes()),
+      dbPed(esConsumes()),
+      hGeometry(esConsumes()) {
   // needed for MixingModule checks
 
   double simHitToPhotoelectronsBarrel = ps.getParameter<double>("simHitToPhotoelectronsBarrel");
@@ -605,9 +612,7 @@ void EcalMixingModuleValidation::analyze(edm::Event const& e, edm::EventSetup co
 
 void EcalMixingModuleValidation::checkCalibrations(edm::EventSetup const& eventSetup) {
   // ADC -> GeV Scale
-  edm::ESHandle<EcalADCToGeVConstant> pAgc;
-  eventSetup.get<EcalADCToGeVConstantRcd>().get(pAgc);
-  const EcalADCToGeVConstant* agc = pAgc.product();
+  const EcalADCToGeVConstant* agc = &eventSetup.getData(pAgc);
 
   EcalMGPAGainRatio* defaultRatios = new EcalMGPAGainRatio();
 
@@ -630,20 +635,10 @@ void EcalMixingModuleValidation::checkCalibrations(edm::EventSetup const& eventS
   LogDebug("EcalDigi") << " Endcap GeV/ADC = " << endcapADCtoGeV_;
 
   // ES condition objects
-  edm::ESHandle<ESGain> esgain_;
-  edm::ESHandle<ESMIPToGeVConstant> esMIPToGeV_;
-  edm::ESHandle<ESPedestals> esPedestals_;
-  edm::ESHandle<ESIntercalibConstants> esMIPs_;
-
-  eventSetup.get<ESGainRcd>().get(esgain_);
-  eventSetup.get<ESMIPToGeVConstantRcd>().get(esMIPToGeV_);
-  eventSetup.get<ESPedestalsRcd>().get(esPedestals_);
-  eventSetup.get<ESIntercalibConstantsRcd>().get(esMIPs_);
-
-  const ESGain* esgain = esgain_.product();
-  m_ESpeds = esPedestals_.product();
-  m_ESmips = esMIPs_.product();
-  const ESMIPToGeVConstant* esMipToGeV = esMIPToGeV_.product();
+  const ESGain* esgain = &eventSetup.getData(esgain_);
+  m_ESpeds = &eventSetup.getData(esPedestals_);
+  m_ESmips = &eventSetup.getData(esMIPs_);
+  const ESMIPToGeVConstant* esMipToGeV = &eventSetup.getData(esMIPToGeV_);
   m_ESgain = (int)esgain->getESGain();
   const double valESMIPToGeV = (m_ESgain == 1) ? esMipToGeV->getESValueLow() : esMipToGeV->getESValueHigh();
 
@@ -657,9 +652,7 @@ void EcalMixingModuleValidation::checkCalibrations(edm::EventSetup const& eventS
 void EcalMixingModuleValidation::checkPedestals(const edm::EventSetup& eventSetup) {
   // Pedestals from event setup
 
-  edm::ESHandle<EcalPedestals> dbPed;
-  eventSetup.get<EcalPedestalsRcd>().get(dbPed);
-  thePedestals = dbPed.product();
+  thePedestals = &eventSetup.getData(dbPed);
 }
 
 void EcalMixingModuleValidation::findPedestal(const DetId& detId, int gainId, double& ped) const {
@@ -708,10 +701,8 @@ void EcalMixingModuleValidation::computeSDBunchDigi(const edm::EventSetup& event
 
   // load the geometry
 
-  edm::ESHandle<CaloGeometry> hGeometry;
-  eventSetup.get<CaloGeometryRecord>().get(hGeometry);
-
-  const CaloGeometry* pGeometry = &*hGeometry;
+  auto hGeomHandle = eventSetup.getHandle(hGeometry);
+  const CaloGeometry* pGeometry = &*hGeomHandle;
 
   // see if we need to update
   if (pGeometry != theGeometry) {

--- a/Validation/EcalDigis/src/EcalSelectiveReadoutValidation.cc
+++ b/Validation/EcalDigis/src/EcalSelectiveReadoutValidation.cc
@@ -25,13 +25,6 @@
 
 #include "DataFormats/Common/interface/Handle.h"
 
-#include "CondFormats/EcalObjects/interface/EcalTPGLutIdMap.h"
-#include "CondFormats/EcalObjects/interface/EcalTPGLutGroup.h"
-#include "CondFormats/EcalObjects/interface/EcalTPGPhysicsConst.h"
-#include "CondFormats/DataRecord/interface/EcalTPGLutIdMapRcd.h"
-#include "CondFormats/DataRecord/interface/EcalTPGLutGroupRcd.h"
-#include "CondFormats/DataRecord/interface/EcalTPGPhysicsConstRcd.h"
-
 using namespace cms;
 using namespace edm;
 using namespace std;
@@ -103,7 +96,13 @@ const int EcalSelectiveReadoutValidation::nDccRus_[nDccs_] = {
     34};
 
 EcalSelectiveReadoutValidation::EcalSelectiveReadoutValidation(const ParameterSet& ps)
-    : collNotFoundWarn_(ps.getUntrackedParameter<bool>("warnIfCollectionNotFound", true)),
+    : geoToken(esConsumes()),
+      ecalmapping(esConsumes()),
+      hTriggerTowerMap(esConsumes()),
+      physHandle(esConsumes()),
+      lutGrpHandle(esConsumes()),
+      lutMapHandle(esConsumes()),
+      collNotFoundWarn_(ps.getUntrackedParameter<bool>("warnIfCollectionNotFound", true)),
       ebDigis_(ps.getParameter<edm::InputTag>("EbDigiCollection"), false, collNotFoundWarn_),
       eeDigis_(ps.getParameter<edm::InputTag>("EeDigiCollection"), false, collNotFoundWarn_),
       ebNoZsDigis_(ps.getParameter<edm::InputTag>("EbUnsuppressedDigiCollection"), false, false /*collNotFoundWarn_*/),
@@ -305,8 +304,7 @@ void EcalSelectiveReadoutValidation::analyzeEE(const edm::Event& event, const ed
   }
 
   // gets the endcap geometry:
-  edm::ESHandle<CaloGeometry> geoHandle;
-  es.get<CaloGeometryRecord>().get(geoHandle);
+  auto geoHandle = es.getHandle(geoToken);
   const CaloSubdetectorGeometry* geometry_p = (*geoHandle).getSubdetectorGeometry(DetId::Ecal, EcalEndcap);
   //CaloSubdetectorGeometry const& geometry = *geometry_p;
 
@@ -575,9 +573,7 @@ void EcalSelectiveReadoutValidation::analyzeEB(const edm::Event& event, const ed
   }
 
   // get the barrel geometry:
-  edm::ESHandle<CaloGeometry> geoHandle;
-
-  es.get<CaloGeometryRecord>().get(geoHandle);
+  auto geoHandle = es.getHandle(geoToken);
   const CaloSubdetectorGeometry* geometry_p = (*geoHandle).getSubdetectorGeometry(DetId::Ecal, EcalBarrel);
   //CaloSubdetectorGeometry const& geometry = *geometry_p;
 
@@ -836,14 +832,10 @@ EcalSelectiveReadoutValidation::~EcalSelectiveReadoutValidation() {}
 
 void EcalSelectiveReadoutValidation::dqmBeginRun(edm::Run const& r, edm::EventSetup const& es) {
   // endcap mapping
-  edm::ESHandle<EcalTrigTowerConstituentsMap> hTriggerTowerMap;
-  es.get<IdealGeometryRecord>().get(hTriggerTowerMap);
-  triggerTowerMap_ = hTriggerTowerMap.product();
+  triggerTowerMap_ = &es.getData(hTriggerTowerMap);
 
   //electronics map
-  ESHandle<EcalElectronicsMapping> ecalmapping;
-  es.get<EcalMappingRcd>().get(ecalmapping);
-  elecMap_ = ecalmapping.product();
+  elecMap_ = &es.getData(ecalmapping);
 
   initAsciiFile();
 }
@@ -1503,17 +1495,11 @@ void EcalSelectiveReadoutValidation::analyzeTP(edm::Event const& event, edm::Eve
     tpEtCount[iEt] = 0;
   }
 
-  edm::ESHandle<EcalTPGPhysicsConst> physHandle;
-  es.get<EcalTPGPhysicsConstRcd>().get(physHandle);
-  const EcalTPGPhysicsConstMap& physMap = physHandle.product()->getMap();
+  const EcalTPGPhysicsConstMap& physMap = es.getData(physHandle).getMap();
 
-  edm::ESHandle<EcalTPGLutGroup> lutGrpHandle;
-  es.get<EcalTPGLutGroupRcd>().get(lutGrpHandle);
-  const EcalTPGGroups::EcalTPGGroupsMap& lutGrpMap = lutGrpHandle.product()->getMap();
+  const EcalTPGGroups::EcalTPGGroupsMap& lutGrpMap = es.getData(lutGrpHandle).getMap();
 
-  edm::ESHandle<EcalTPGLutIdMap> lutMapHandle;
-  es.get<EcalTPGLutIdMapRcd>().get(lutMapHandle);
-  const EcalTPGLutIdMap::EcalTPGLutMap& lutMap = lutMapHandle.product()->getMap();
+  const EcalTPGLutIdMap::EcalTPGLutMap& lutMap = es.getData(lutMapHandle).getMap();
 
   EcalTPGPhysicsConstMapIterator ebItr(physMap.find(DetId(DetId::Ecal, EcalBarrel).rawId()));
   double lsb10bitsEB(ebItr == physMap.end() ? 0. : ebItr->second.EtSat / 1024.);
@@ -1870,8 +1856,8 @@ void EcalSelectiveReadoutValidation::setTtEtSums(const edm::EventSetup& es,
   const CaloSubdetectorGeometry* eeGeometry = nullptr;
   const CaloSubdetectorGeometry* ebGeometry = nullptr;
   if (eeGeometry == nullptr || ebGeometry == nullptr) {
-    edm::ESHandle<CaloGeometry> geoHandle;
-    es.get<CaloGeometryRecord>().get(geoHandle);
+    es.getData(geoToken);
+    auto geoHandle = es.getHandle(geoToken);
     eeGeometry = (*geoHandle).getSubdetectorGeometry(DetId::Ecal, EcalEndcap);
     ebGeometry = (*geoHandle).getSubdetectorGeometry(DetId::Ecal, EcalBarrel);
   }

--- a/Validation/EcalDigis/src/EcalSelectiveReadoutValidation.cc
+++ b/Validation/EcalDigis/src/EcalSelectiveReadoutValidation.cc
@@ -97,8 +97,8 @@ const int EcalSelectiveReadoutValidation::nDccRus_[nDccs_] = {
 
 EcalSelectiveReadoutValidation::EcalSelectiveReadoutValidation(const ParameterSet& ps)
     : geoToken(esConsumes()),
-      ecalmapping(esConsumes()),
-      hTriggerTowerMap(esConsumes()),
+      ecalmapping(esConsumes<edm::Transition::BeginRun>()),
+      hTriggerTowerMap(esConsumes<edm::Transition::BeginRun>()),
       physHandle(esConsumes()),
       lutGrpHandle(esConsumes()),
       lutMapHandle(esConsumes()),

--- a/Validation/EcalRecHits/interface/EcalBarrelRecHitsValidation.h
+++ b/Validation/EcalRecHits/interface/EcalBarrelRecHitsValidation.h
@@ -53,6 +53,7 @@ private:
   // fix for consumes
   edm::EDGetTokenT<EBDigiCollection> EBdigiCollection_token_;
   edm::EDGetTokenT<EBUncalibratedRecHitCollection> EBuncalibrechitCollection_token_;
+  edm::ESGetToken<EcalPedestals, EcalPedestalsRcd> ecalPeds;
 
   MonitorElement *meEBUncalibRecHitsOccupancy_;
   MonitorElement *meEBUncalibRecHitsAmplitude_;

--- a/Validation/EcalRecHits/interface/EcalEndcapRecHitsValidation.h
+++ b/Validation/EcalRecHits/interface/EcalEndcapRecHitsValidation.h
@@ -54,6 +54,7 @@ private:
   // fix for consumes
   edm::EDGetTokenT<EEDigiCollection> EEdigiCollection_token_;
   edm::EDGetTokenT<EEUncalibratedRecHitCollection> EEuncalibrechitCollection_token_;
+  edm::ESGetToken<EcalPedestals, EcalPedestalsRcd> ecalPeds;
 
   MonitorElement *meEEUncalibRecHitsOccupancyPlus_;
   MonitorElement *meEEUncalibRecHitsOccupancyMinus_;

--- a/Validation/EcalRecHits/interface/EcalRecHitsValidation.h
+++ b/Validation/EcalRecHits/interface/EcalRecHitsValidation.h
@@ -34,6 +34,12 @@
 #include "SimDataFormats/CrossingFrame/interface/CrossingFrame.h"
 #include "SimDataFormats/CrossingFrame/interface/MixCollection.h"
 
+#include <Validation/EcalRecHits/interface/EcalRecHitsValidation.h>
+#include "CalibCalorimetry/EcalTrivialCondModules/interface/EcalTrivialConditionRetriever.h"
+#include "Geometry/CaloTopology/interface/EcalTrigTowerConstituentsMap.h"
+#include "Geometry/Records/interface/IdealGeometryRecord.h"
+#include "CondFormats/DataRecord/interface/EcalChannelStatusRcd.h"
+
 #include "DQMServices/Core/interface/DQMEDAnalyzer.h"
 #include <fstream>
 #include <iostream>
@@ -83,6 +89,9 @@ private:
   edm::EDGetTokenT<CrossingFrame<PCaloHit>> EBHits_Token_;
   edm::EDGetTokenT<CrossingFrame<PCaloHit>> EEHits_Token_;
   edm::EDGetTokenT<CrossingFrame<PCaloHit>> ESHits_Token_;
+  edm::ESGetToken<EcalADCToGeVConstant, EcalADCToGeVConstantRcd> pAgc;
+  edm::ESGetToken<EcalChannelStatus, EcalChannelStatusRcd> pEcsToken;
+  edm::ESGetToken<EcalTrigTowerConstituentsMap, IdealGeometryRecord> pttMapToken;
 
   MonitorElement *meGunEnergy_;
   MonitorElement *meGunEta_;

--- a/Validation/EcalRecHits/src/EcalBarrelRecHitsValidation.cc
+++ b/Validation/EcalRecHits/src/EcalBarrelRecHitsValidation.cc
@@ -13,7 +13,7 @@ using namespace cms;
 using namespace edm;
 using namespace std;
 
-EcalBarrelRecHitsValidation::EcalBarrelRecHitsValidation(const ParameterSet &ps) {
+EcalBarrelRecHitsValidation::EcalBarrelRecHitsValidation(const ParameterSet &ps) : ecalPeds(esConsumes()) {
   // ----------------------
   EBdigiCollection_token_ = consumes<EBDigiCollection>(ps.getParameter<edm::InputTag>("EBdigiCollection"));
   EBuncalibrechitCollection_token_ =
@@ -124,9 +124,6 @@ void EcalBarrelRecHitsValidation::analyze(const Event &e, const EventSetup &c) {
     skipDigis = true;
   }
 
-  edm::ESHandle<EcalPedestals> ecalPeds;
-  c.get<EcalPedestalsRcd>().get(ecalPeds);
-
   // ----------------------
   // loop over UncalibRecHits
   for (EcalUncalibratedRecHitCollection::const_iterator uncalibRecHit = EBUncalibRecHit->begin();
@@ -194,7 +191,7 @@ void EcalBarrelRecHitsValidation::analyze(const Event &e, const EventSetup &c) {
         continue;
 
       // ratio uncalibratedRecHit amplitude + ped / max energy digi
-      const EcalPedestals *myped = ecalPeds.product();
+      const EcalPedestals *myped = &c.getData(ecalPeds);
       EcalPedestalsMap::const_iterator it = myped->getMap().find(EBid);
       if (it != myped->getMap().end()) {
         if (eMax > (*it).mean_x1 + 5 * (*it).rms_x1 && eMax != 0) {  // only real signal RecHit

--- a/Validation/EcalRecHits/src/EcalEndcapRecHitsValidation.cc
+++ b/Validation/EcalRecHits/src/EcalEndcapRecHitsValidation.cc
@@ -13,7 +13,7 @@ using namespace cms;
 using namespace edm;
 using namespace std;
 
-EcalEndcapRecHitsValidation::EcalEndcapRecHitsValidation(const ParameterSet &ps) {
+EcalEndcapRecHitsValidation::EcalEndcapRecHitsValidation(const ParameterSet &ps) : ecalPeds(esConsumes()) {
   // ----------------------
   EEdigiCollection_token_ = consumes<EEDigiCollection>(ps.getParameter<edm::InputTag>("EEdigiCollection"));
   EEuncalibrechitCollection_token_ =
@@ -120,9 +120,6 @@ void EcalEndcapRecHitsValidation::analyze(const Event &e, const EventSetup &c) {
     skipDigis = true;
   }
 
-  edm::ESHandle<EcalPedestals> ecalPeds;
-  c.get<EcalPedestalsRcd>().get(ecalPeds);
-
   // ----------------------
   // loop over UncalibRecHits
   for (EcalUncalibratedRecHitCollection::const_iterator uncalibRecHit = EEUncalibRecHit->begin();
@@ -192,7 +189,7 @@ void EcalEndcapRecHitsValidation::analyze(const Event &e, const EventSetup &c) {
         continue;
 
       // ratio uncalibratedRecHit amplitude + ped / max energy digi
-      const EcalPedestals *myped = ecalPeds.product();
+      const EcalPedestals *myped = &c.getData(ecalPeds);
       EcalPedestalsMap::const_iterator it = myped->getMap().find(EEid);
       if (it != myped->getMap().end()) {
         if (eMax > (*it).mean_x1 + 5 * (*it).rms_x1 && eMax != 0) {  // only real signal RecHit


### PR DESCRIPTION
#### PR description:

This PR addresses the migration of ECAL Validation/* codes to use esConsumes as mentioned here: #31061

#### PR validation:
Validation done by running `scram build checker` where the warnings with respect to the ESConsumes go away and also validated by running the relval workflow 136.874 using the runTheMatrix script
`runTheMatrix.py -l 136.874 --ibeos`

#### if this PR is a backport please specify the original PR and why you need to backport that PR:
N/A