### PR TITLE
Speed up the CSC trigger emulator for Run-3 and Phase-2

### DIFF
--- a/L1Trigger/CSCTriggerPrimitives/src/CSCALCTCrossCLCT.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCALCTCrossCLCT.cc
@@ -12,21 +12,18 @@ CSCALCTCrossCLCT::CSCALCTCrossCLCT(
   gangedME1a_ = commonParams.getParameter<bool>("gangedME1a");
   ignoreAlctCrossClct_ = ignoreAlctCrossClct;
 
-  const edm::ParameterSet me11luts(conf.getParameter<edm::ParameterSet>("wgCrossHsME11Params"));
-  wgCrossHsME1aFiles_ = me11luts.getParameter<std::vector<std::string>>("wgCrossHsME1aFiles");
-  wgCrossHsME1aGangedFiles_ = me11luts.getParameter<std::vector<std::string>>("wgCrossHsME1aGangedFiles");
-  wgCrossHsME1bFiles_ = me11luts.getParameter<std::vector<std::string>>("wgCrossHsME1bFiles");
-  wg_cross_min_hs_ME1a_ = std::make_unique<CSCLUTReader>(wgCrossHsME1aFiles_[0]);
-  wg_cross_max_hs_ME1a_ = std::make_unique<CSCLUTReader>(wgCrossHsME1aFiles_[1]);
-  wg_cross_min_hs_ME1a_ganged_ = std::make_unique<CSCLUTReader>(wgCrossHsME1aGangedFiles_[0]);
-  wg_cross_max_hs_ME1a_ganged_ = std::make_unique<CSCLUTReader>(wgCrossHsME1aGangedFiles_[1]);
-  wg_cross_min_hs_ME1b_ = std::make_unique<CSCLUTReader>(wgCrossHsME1bFiles_[0]);
-  wg_cross_max_hs_ME1b_ = std::make_unique<CSCLUTReader>(wgCrossHsME1bFiles_[1]);
-
-  const edm::ParameterSet lctCodeluts(conf.getParameter<edm::ParameterSet>("lctCodeParams"));
-  lctCombinationCodeFiles_ = lctCodeluts.getParameter<std::vector<std::string>>("lctCodeFiles");
-  code_to_best_lct_ = std::make_unique<CSCLUTReader>(lctCombinationCodeFiles_[0]);
-  code_to_second_lct_ = std::make_unique<CSCLUTReader>(lctCombinationCodeFiles_[1]);
+  if (!ignoreAlctCrossClct_) {
+    const edm::ParameterSet me11luts(conf.getParameter<edm::ParameterSet>("wgCrossHsME11Params"));
+    wgCrossHsME1aFiles_ = me11luts.getParameter<std::vector<std::string>>("wgCrossHsME1aFiles");
+    wgCrossHsME1aGangedFiles_ = me11luts.getParameter<std::vector<std::string>>("wgCrossHsME1aGangedFiles");
+    wgCrossHsME1bFiles_ = me11luts.getParameter<std::vector<std::string>>("wgCrossHsME1bFiles");
+    wg_cross_min_hs_ME1a_ = std::make_unique<CSCLUTReader>(wgCrossHsME1aFiles_[0]);
+    wg_cross_max_hs_ME1a_ = std::make_unique<CSCLUTReader>(wgCrossHsME1aFiles_[1]);
+    wg_cross_min_hs_ME1a_ganged_ = std::make_unique<CSCLUTReader>(wgCrossHsME1aGangedFiles_[0]);
+    wg_cross_max_hs_ME1a_ganged_ = std::make_unique<CSCLUTReader>(wgCrossHsME1aGangedFiles_[1]);
+    wg_cross_min_hs_ME1b_ = std::make_unique<CSCLUTReader>(wgCrossHsME1bFiles_[0]);
+    wg_cross_max_hs_ME1b_ = std::make_unique<CSCLUTReader>(wgCrossHsME1bFiles_[1]);
+  }
 }
 
 void CSCALCTCrossCLCT::calculateLCTCodes(const CSCALCTDigi& bestALCT,

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCCathodeLCTProcessor.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCCathodeLCTProcessor.cc
@@ -87,6 +87,8 @@ CSCCathodeLCTProcessor::CSCCathodeLCTProcessor(unsigned endcap,
   // which patterns should we use?
   if (runCCLUT_) {
     clct_pattern_ = CSCPatternBank::clct_pattern_run3_;
+    // comparator code lookup table algorithm for Phase-2
+    cclut_ = std::make_unique<ComparatorCodeLUT>(conf);
   } else {
     clct_pattern_ = CSCPatternBank::clct_pattern_legacy_;
   }
@@ -102,9 +104,6 @@ CSCCathodeLCTProcessor::CSCCathodeLCTProcessor(unsigned endcap,
 
   // quality control of stubs
   qualityControl_ = std::make_unique<LCTQualityControl>(endcap, station, sector, subsector, chamber, conf);
-
-  // comparator code lookup table algorithm for Phase-2
-  cclut_ = std::make_unique<ComparatorCodeLUT>(conf);
 }
 
 void CSCCathodeLCTProcessor::setDefaultConfigParameters() {


### PR DESCRIPTION
#### PR description:

Issue #34633 reports a significant slowdown in cmsRun calls in recent IBs, pointing to the startup of the CSC trigger emulator code. A large number of LUTs need to be loaded. A solution is being considered at the moment. In the mean time, I will hide certain LUTs behind if statements. LUTs are then only loaded when an expert flag is set. This should prevent these LUTs from being loaded for now:
```
   2160 L1Trigger/CSCTriggerPrimitives/data/CCLUT/CSCComparatorCodePatternConversionLUT_pat0_v1.txt
   2161 L1Trigger/CSCTriggerPrimitives/data/CCLUT/CSCComparatorCodePatternConversionLUT_pat1_v1.txt
   2160 L1Trigger/CSCTriggerPrimitives/data/CCLUT/CSCComparatorCodePatternConversionLUT_pat2_v1.txt
   2160 L1Trigger/CSCTriggerPrimitives/data/CCLUT/CSCComparatorCodePatternConversionLUT_pat3_v1.txt
   2160 L1Trigger/CSCTriggerPrimitives/data/CCLUT/CSCComparatorCodePatternConversionLUT_pat4_v1.txt
   2160 L1Trigger/CSCTriggerPrimitives/data/CCLUT/CSCComparatorCodePosOffsetLUT_pat0_v1.txt
   2161 L1Trigger/CSCTriggerPrimitives/data/CCLUT/CSCComparatorCodePosOffsetLUT_pat1_v1.txt
   2160 L1Trigger/CSCTriggerPrimitives/data/CCLUT/CSCComparatorCodePosOffsetLUT_pat2_v1.txt
   2160 L1Trigger/CSCTriggerPrimitives/data/CCLUT/CSCComparatorCodePosOffsetLUT_pat3_v1.txt
   2160 L1Trigger/CSCTriggerPrimitives/data/CCLUT/CSCComparatorCodePosOffsetLUT_pat4_v1.txt
   2161 L1Trigger/CSCTriggerPrimitives/data/CCLUT/CSCComparatorCodeSlopeLUT_pat0_v1.txt
   2161 L1Trigger/CSCTriggerPrimitives/data/CCLUT/CSCComparatorCodeSlopeLUT_pat1_v1.txt
   2161 L1Trigger/CSCTriggerPrimitives/data/CCLUT/CSCComparatorCodeSlopeLUT_pat2_v1.txt
   2160 L1Trigger/CSCTriggerPrimitives/data/CCLUT/CSCComparatorCodeSlopeLUT_pat3_v1.txt
   2162 L1Trigger/CSCTriggerPrimitives/data/CCLUT/CSCComparatorCodeSlopeLUT_pat4_v1.txt
   2160 L1Trigger/CSCTriggerPrimitives/data/LCTCode/CSCLUT_code_to_bestLCT.txt
   2161 L1Trigger/CSCTriggerPrimitives/data/LCTCode/CSCLUT_code_to_secondLCT.txt
   2160 L1Trigger/CSCTriggerPrimitives/data/ME11/CSCLUT_wg_max_hs_ME1a.txt
   2161 L1Trigger/CSCTriggerPrimitives/data/ME11/CSCLUT_wg_max_hs_ME1a_ganged.txt
   2160 L1Trigger/CSCTriggerPrimitives/data/ME11/CSCLUT_wg_max_hs_ME1b.txt
   2160 L1Trigger/CSCTriggerPrimitives/data/ME11/CSCLUT_wg_min_hs_ME1a.txt
   2160 L1Trigger/CSCTriggerPrimitives/data/ME11/CSCLUT_wg_min_hs_ME1a_ganged.txt
   2162 L1Trigger/CSCTriggerPrimitives/data/ME11/CSCLUT_wg_min_hs_ME1b.txt
```

GEM-CSC LUTs in folder L1Trigger/CSCTriggerPrimitives/data/GEMCSC/ are unfortunately still being loaded for each ME1/1 chamber. Other than turning off the GEM-CSC trigger itself, I don't have a prompt solution.
 
A longer term solution may be the introduction of ESProducer and ESProduct objects for CSC lookup tables. To be discussed with CSC DPG.

#### PR validation:

Code compiles.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

<!-- Please replace this text with any link to  -->

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
