### PR TITLE
Check DQM plot dependency on specific BuildFiles

### DIFF
--- a/Calibration/EcalAlCaRecoProducers/plugins/BuildFile.xml
+++ b/Calibration/EcalAlCaRecoProducers/plugins/BuildFile.xml
@@ -7,6 +7,7 @@
 <use name="DataFormats/EgammaCandidates"/>
 <use name="DataFormats/RecoCandidate"/>
 <use name="DataFormats/TrackReco"/>
+<use name="DataFormats/HLTReco"/>
 <use name="FWCore/Framework"/>
 <use name="FWCore/MessageLogger"/>
 <use name="FWCore/ParameterSet"/>

--- a/DQMOffline/EGamma/plugins/BuildFile.xml
+++ b/DQMOffline/EGamma/plugins/BuildFile.xml
@@ -12,6 +12,7 @@
 <use name="clhep"/>
 <use name="CommonTools/Statistics"/>
 <use name="CommonTools/UtilAlgos"/>
+<use name="TrackingTools/TrajectoryState"/>
 <use name="root"/>
 <use name="roofit"/>
 <use name="boost"/>

--- a/DataFormats/L1TrackTrigger/BuildFile.xml
+++ b/DataFormats/L1TrackTrigger/BuildFile.xml
@@ -7,6 +7,7 @@
 <use name="DataFormats/TrackerCommon"/>
 <use name="FWCore/MessageLogger"/>
 <use name="FWCore/Utilities"/>
+<use name="hls"/>
 <export>
   <lib name="1"/>
 </export>

--- a/HLTrigger/Muon/test/BuildFile.xml
+++ b/HLTrigger/Muon/test/BuildFile.xml
@@ -1,6 +1,7 @@
 <use name="FWCore/Framework"/>
 <use name="FWCore/ParameterSet"/>
 <use name="DataFormats/Common"/>
+<use name="DataFormats/HLTReco"/>
 <use name="SimDataFormats/GeneratorProducts"/>
 <use name="DataFormats/RecoCandidate"/>
 <use name="root"/>


### PR DESCRIPTION
#### PR description:

This PR adds a single line to three separate BuildFIle.xml. Presumably these additional lines should have been included before this, but weren't, possibly because of CMSSW header-only linkings. Theoretically these changes shouldn't have any effect. However, we have seen an effect on the DQM plots in #34550 and we would like to see if these changes, on their own, will have a similar affect

#### PR validation:

The PR was formed by doing:
```bash
cmsrel CMSSW_12_0_X_2021-07-26-1100
cd CMSSW_12_0_X_2021-07-26-1100/src/
cmsenv
git-cms-init
git-cms-addpkg Calibration/EcalAlCaRecoProducers
git-cms-addpkg DQMOffline/EGamma
git-cms-addpkg HLTrigger/Muon
<edit the relevant lines>
git-cms-checkdeps -a
scram b -j 8
```

Everything compiles just fine and no additional dependencies were checked out, as expected.

@kpedro88 