### PR TITLE
Drop type specs from Ecal DQM python config files

### DIFF
--- a/DQM/EcalCommon/python/CommonParams_cfi.py
+++ b/DQM/EcalCommon/python/CommonParams_cfi.py
@@ -4,9 +4,13 @@ ecalCommonParams = cms.untracked.PSet(
     onlineMode = cms.untracked.bool(False),
     willConvertToEDM = cms.untracked.bool(True)
 )
+<<<<<<< HEAD
+=======
 
-ecaldqmLaserWavelengths = cms.untracked.vint32(1, 2, 3)
-ecaldqmLedWavelengths = cms.untracked.vint32(1, 2)
-ecaldqmMGPAGains = cms.untracked.vint32(12)
-ecaldqmMGPAGainsPN = cms.untracked.vint32(16)
+#ecaldqmLaserWavelengths = cms.untracked.vint32(1, 2, 3)
+>>>>>>> af90af1e2e742d36094250a06c7d8522d5d7a9c8
+ecaldqmLaserWavelengths = 1, 2, 3
+ecaldqmLedWavelengths = 1, 2
+ecaldqmMGPAGains = 12
+ecaldqmMGPAGainsPN = 16
 

--- a/DQM/EcalCommon/python/CommonParams_cfi.py
+++ b/DQM/EcalCommon/python/CommonParams_cfi.py
@@ -4,11 +4,6 @@ ecalCommonParams = cms.untracked.PSet(
     onlineMode = cms.untracked.bool(False),
     willConvertToEDM = cms.untracked.bool(True)
 )
-<<<<<<< HEAD
-=======
-
-#ecaldqmLaserWavelengths = cms.untracked.vint32(1, 2, 3)
->>>>>>> af90af1e2e742d36094250a06c7d8522d5d7a9c8
 ecaldqmLaserWavelengths = 1, 2, 3
 ecaldqmLedWavelengths = 1, 2
 ecaldqmMGPAGains = 12

--- a/DQM/EcalMonitorClient/python/EcalCertification_cfi.py
+++ b/DQM/EcalMonitorClient/python/EcalCertification_cfi.py
@@ -15,6 +15,6 @@ ecalCertification = DQMEDHarvester("EcalDQMonitorClient",
     workerParameters = cms.untracked.PSet(
         CertificationClient = ecalCertificationClient.clone()
     ),
-    commonParameters = ecalCommonParams.clone(willConvertToEDM = cms.untracked.bool(False)),
+    commonParameters = ecalCommonParams.clone(willConvertToEDM = False),
     verbosity = cms.untracked.int32(0)
 )

--- a/DQM/EcalMonitorClient/python/EcalDaqInfoTask_cfi.py
+++ b/DQM/EcalMonitorClient/python/EcalDaqInfoTask_cfi.py
@@ -13,10 +13,10 @@ ecalDaqInfoTask = DQMEDHarvester("EcalDQMonitorClient",
     ),
     # task parameters (included from indivitual cfis)
     workerParameters =  cms.untracked.PSet(
-        TowerStatusTask = ecalTowerStatusTask.clone()
+        TowerStatusTask = ecalTowerStatusTask.clone(
+	  params = dict(doDCSInfo = False)
+	)
     ),
     commonParameters = ecalCommonParams,
     verbosity = cms.untracked.int32(0)
 )
-
-ecalDaqInfoTask.workerParameters.TowerStatusTask.params.doDCSInfo = False

--- a/DQM/EcalMonitorClient/python/EcalDcsInfoTask_cfi.py
+++ b/DQM/EcalMonitorClient/python/EcalDcsInfoTask_cfi.py
@@ -13,10 +13,10 @@ ecalDcsInfoTask = DQMEDHarvester("EcalDQMonitorClient",
     ),
     # task parameters (included from indivitual cfis)
     workerParameters =  cms.untracked.PSet(
-        TowerStatusTask = ecalTowerStatusTask.clone()
+        TowerStatusTask = ecalTowerStatusTask.clone(
+           params = dict(doDAQInfo = False) 
+        )
     ),
     commonParameters = ecalCommonParams,
     verbosity = cms.untracked.int32(0)
 )
-
-ecalDcsInfoTask.workerParameters.TowerStatusTask.params.doDAQInfo = False

--- a/DQM/EcalMonitorTasks/python/EcalMonitorTaskEcalOnly_cfi.py
+++ b/DQM/EcalMonitorTasks/python/EcalMonitorTaskEcalOnly_cfi.py
@@ -2,7 +2,10 @@ import FWCore.ParameterSet.Config as cms
 
 from DQM.EcalMonitorTasks.EcalMonitorTask_cfi import ecalMonitorTask as _ecalMonitorTask
 
-ecalMonitorTaskEcalOnly = _ecalMonitorTask.clone()
-ecalMonitorTaskEcalOnly.collectionTags.EBSuperCluster = cms.untracked.InputTag("particleFlowSuperClusterECALOnly","particleFlowSuperClusterECALBarrel")
-ecalMonitorTaskEcalOnly.collectionTags.EESuperCluster = cms.untracked.InputTag("particleFlowSuperClusterECALOnly","particleFlowSuperClusterECALEndcapWithPreshower")
-ecalMonitorTaskEcalOnly.workerParameters.ClusterTask.params.doExtra = cms.untracked.bool(False)
+ecalMonitorTaskEcalOnly = _ecalMonitorTask.clone(
+       collectionTags = dict(
+               EBSuperCluster = ("particleFlowSuperClusterECALOnly","particleFlowSuperClusterECALBarrel"),
+               EESuperCluster = ("particleFlowSuperClusterECALOnly","particleFlowSuperClusterECALEndcapWithPreshower")
+       ),
+      workerParameters = dict(ClusterTask = dict(params = dict(doExtra = False)))   
+)


### PR DESCRIPTION
#### PR description:

This PR fulfills the ORP request to drop type specs in  ECAL DQM python configurations files:
When one customizes an existing parameter in clone(), Modifier.toModify(), or in assignment, explicit types on the right hand side should be avoided [](https://cms-sw.github.io/cms_coding_rules.html)

#### PR validation:

The code changes were validated by running the DQM relval workflow 136.874 using the runTheMatrix script
`runTheMatrix.py -l 136.874 -i all --ibeos`

#### if this PR is a backport please specify the original PR and why you need to backport that PR:
N/A