### PR TITLE
Fix static warnings in CSCDigitizer

### DIFF
--- a/SimMuon/CSCDigitizer/src/CSCCrossGap.cc
+++ b/SimMuon/CSCDigitizer/src/CSCCrossGap.cc
@@ -14,8 +14,7 @@ CSCCrossGap::CSCCrossGap(double mass, float mom, LocalVector gap)
 double CSCCrossGap::logGamma(double mass, float mom) {
   theGamma = sqrt((mom / mass) * (mom / mass) + 1.);
   theBeta2 = 1. - 1. / (theGamma * theGamma);
-  double betgam = sqrt(theGamma * theGamma - 1.);
-  LogTrace("CSCCrossGap") << "gamma = " << theGamma << ", beta2 = " << theBeta2 << ", beta*gamma = " << betgam;
+  LogTrace("CSCCrossGap") << "gamma = " << theGamma << ", beta2 = " << theBeta2 << ", beta*gamma = " << sqrt(theGamma * theGamma - 1.);;
 
   // The lowest value in table (=theGammaBins[0]) is ln(1.1)=0.0953102
   // (Compensate later if lower)

--- a/SimMuon/CSCDigitizer/src/CSCCrossGap.cc
+++ b/SimMuon/CSCDigitizer/src/CSCCrossGap.cc
@@ -14,7 +14,9 @@ CSCCrossGap::CSCCrossGap(double mass, float mom, LocalVector gap)
 double CSCCrossGap::logGamma(double mass, float mom) {
   theGamma = sqrt((mom / mass) * (mom / mass) + 1.);
   theBeta2 = 1. - 1. / (theGamma * theGamma);
-  LogTrace("CSCCrossGap") << "gamma = " << theGamma << ", beta2 = " << theBeta2 << ", beta*gamma = " << sqrt(theGamma * theGamma - 1.);;
+  LogTrace("CSCCrossGap") << "gamma = " << theGamma << ", beta2 = " << theBeta2
+                          << ", beta*gamma = " << sqrt(theGamma * theGamma - 1.);
+  ;
 
   // The lowest value in table (=theGammaBins[0]) is ln(1.1)=0.0953102
   // (Compensate later if lower)

--- a/SimMuon/CSCDigitizer/src/CSCGasCollisions.cc
+++ b/SimMuon/CSCDigitizer/src/CSCGasCollisions.cc
@@ -122,25 +122,22 @@ void CSCGasCollisions::readCollisionTable() {
   // @@ We had better have the right sizes everywhere or all
   // hell will break loose. There's no trapping.
   LogTrace(me) << "Reading gamma bins";
-  int j = 0;
   for (int i = 0; i < N_GAMMA; ++i) {
     fin >> theGammaBins[i];
-    LogTrace(me) << ++j << "   " << theGammaBins[i];
+    LogTrace(me) << i+1 << "   " << theGammaBins[i];
   }
 
-  j = 0;
   LogTrace(me) << "Reading energy bins \n";
   for (int i = 0; i < N_ENERGY; ++i) {
     fin >> theEnergyBins[i];
-    LogTrace(me) << ++j << "   " << theEnergyBins[i];
+    LogTrace(me) << i+1 << "   " << theEnergyBins[i];
   }
 
-  j = 0;
   LogTrace(me) << "Reading collisions table \n";
 
   for (int i = 0; i < N_ENTRIES; ++i) {
     fin >> theCollisionTable[i];
-    LogTrace(me) << ++j << "   " << theCollisionTable[i];
+    LogTrace(me) << i+1 << "   " << theCollisionTable[i];
   }
 
   fin.close();
@@ -170,6 +167,7 @@ void CSCGasCollisions::simulate(const PSimHit &simhit,
     edm::LogError("CSCGasCollisions") << "Cannot find particle of type " << simhit.particleType() << " in the PDT";
   } else {
     mass = particle->mass();
+    LogTrace(me) << "[CSCGasCollisions] Found particle of type " << simhit.particleType() << " in the PDT; mass = " << mass;
   }
 
   theCrossGap = new CSCCrossGap(mass, mom, simhit.exitPoint() - simhit.entryPoint());

--- a/SimMuon/CSCDigitizer/src/CSCGasCollisions.cc
+++ b/SimMuon/CSCDigitizer/src/CSCGasCollisions.cc
@@ -124,20 +124,20 @@ void CSCGasCollisions::readCollisionTable() {
   LogTrace(me) << "Reading gamma bins";
   for (int i = 0; i < N_GAMMA; ++i) {
     fin >> theGammaBins[i];
-    LogTrace(me) << i+1 << "   " << theGammaBins[i];
+    LogTrace(me) << i + 1 << "   " << theGammaBins[i];
   }
 
   LogTrace(me) << "Reading energy bins \n";
   for (int i = 0; i < N_ENERGY; ++i) {
     fin >> theEnergyBins[i];
-    LogTrace(me) << i+1 << "   " << theEnergyBins[i];
+    LogTrace(me) << i + 1 << "   " << theEnergyBins[i];
   }
 
   LogTrace(me) << "Reading collisions table \n";
 
   for (int i = 0; i < N_ENTRIES; ++i) {
     fin >> theCollisionTable[i];
-    LogTrace(me) << i+1 << "   " << theCollisionTable[i];
+    LogTrace(me) << i + 1 << "   " << theCollisionTable[i];
   }
 
   fin.close();
@@ -167,7 +167,8 @@ void CSCGasCollisions::simulate(const PSimHit &simhit,
     edm::LogError("CSCGasCollisions") << "Cannot find particle of type " << simhit.particleType() << " in the PDT";
   } else {
     mass = particle->mass();
-    LogTrace(me) << "[CSCGasCollisions] Found particle of type " << simhit.particleType() << " in the PDT; mass = " << mass;
+    LogTrace(me) << "[CSCGasCollisions] Found particle of type " << simhit.particleType()
+                 << " in the PDT; mass = " << mass;
   }
 
   theCrossGap = new CSCCrossGap(mass, mom, simhit.exitPoint() - simhit.entryPoint());

--- a/SimMuon/CSCDigitizer/src/CSCStripElectronicsSim.cc
+++ b/SimMuon/CSCDigitizer/src/CSCStripElectronicsSim.cc
@@ -14,8 +14,11 @@
 #include "CLHEP/Units/GlobalPhysicalConstants.h"
 #include "CLHEP/Units/GlobalSystemOfUnits.h"
 
+#include <boost/bind/bind.hpp>
 #include <cassert>
 #include <list>
+
+using namespace boost::placeholders;
 
 // This is CSCStripElectronicsSim.cc
 
@@ -383,7 +386,7 @@ void CSCStripElectronicsSim::createDigi(int channel,
 
   result.push_back(newDigi);
   addLinks(channelIndex(channel));
-  LogTrace("CSCStripElectronicsSim") << newDigi;
+  LogTrace("CSCStripElectronicsSim") << "CSCStripElectronicsSim: CSCStripDigi " << newDigi;
 }
 
 void CSCStripElectronicsSim::doSaturation(CSCStripDigi &digi) {

--- a/SimMuon/CSCDigitizer/src/CSCWireElectronicsSim.cc
+++ b/SimMuon/CSCDigitizer/src/CSCWireElectronicsSim.cc
@@ -134,7 +134,7 @@ void CSCWireElectronicsSim::fillDigis(CSCWireDigiCollection &digis, CLHEP::HepRa
     // Only create a wire digi if there is a wire hit within [-6 bx, +9 bx]
     if (timeWord != 0) {
       CSCWireDigi newDigi(wireGroup, timeWord);
-      LogTrace("CSCWireElectronicsSim") << newDigi;
+      LogTrace("CSCWireElectronicsSim") << "CSCWireElectronicsSim: " << newDigi;
       digis.insertDigi(layerId(), newDigi);
       addLinks(channelIndex(wireGroup));
     }


### PR DESCRIPTION
#### PR description:

Fix static warnings in CSCDigitizer. There is one change to a boost/bind header, which I made following the advice given with the warning. The other warnings required the removal of variables used only within LogTrace messages. 

#### PR validation:

I've run CSCDigiProducer with full LogTrace active to verify the fixes work.While doing that I need to make a couple of minor changes to LogTrace statements. I plan to update the test configs used for this and other CSCDigitizer tests in a separate PR.
