### PR TITLE
Fix issues #34648

### DIFF
--- a/Alignment/CommonAlignmentProducer/python/AlignmentProducer_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/AlignmentProducer_cff.py
@@ -78,28 +78,13 @@ looper = cms.Looper("AlignmentProducer",
                     # update alignables if triggered by corresponding input IOV boundary
                     enableAlignableUpdates = cms.bool(False),
                     )
-DTGeometryAlignmentProducer = cms.ESProducer("DTGeometryESModule",
-    appendToDataLabel = cms.string('idealForAlignmentProducerBase'),
-    applyAlignment = cms.bool(False), ## to be abondoned (?)
-    alignmentsLabel = cms.string(''),
-    fromDDD = cms.bool(True)
-)
-CSCGeometryAlignmentProducer = cms.ESProducer("CSCGeometryESModule",
-    appendToDataLabel = cms.string('idealForAlignmentProducerBase'),
-    debugV = cms.untracked.bool(False),
-    useGangedStripsInME1a = cms.bool(False),
-    alignmentsLabel = cms.string(''),
-    useOnlyWiresInME1a = cms.bool(False),
-    useRealWireGeometry = cms.bool(True),
-    useCentreTIOffsets = cms.bool(False),
-    applyAlignment = cms.bool(False), ## GF: to be abandoned
-    fromDDD = cms.bool(True),
-    fromDD4hep = cms.bool(False)
-) 
-GEMGeometryAlignmentProducer = cms.ESProducer("GEMGeometryESModule",
-    appendToDataLabel = cms.string('idealForAlignmentProducerBase'),
-    applyAlignment = cms.bool(False),
-    alignmentsLabel = cms.string(''),
-    fromDDD = cms.bool(True),
-    fromDD4Hep = cms.bool(False)
-)
+
+import Geometry.DTGeometryBuilder.dtGeometryDB_cfi
+DTGeometryAlignmentProducerAsAnalyzer = Geometry.DTGeometryBuilder.dtGeometryDB_cfi.DTGeometryESModule.clone()
+DTGeometryAlignmentProducerAsAnalyzer.appendToDataLabel = 'idealForAlignmentProducerBase'
+import Geometry.CSCGeometryBuilder.cscGeometryDB_cfi
+CSCGeometryAlignmentProducerAsAnalyzer = Geometry.CSCGeometryBuilder.cscGeometryDB_cfi.CSCGeometryESModule.clone()
+CSCGeometryAlignmentProducerAsAnalyzer.appendToDataLabel = 'idealForAlignmentProducerBase'
+import   Geometry.GEMGeometryBuilder.gemGeometryDB_cfi
+GEMGeometryAlignmentProducerAsAnalyzer = Geometry.GEMGeometryBuilder.gemGeometryDB_cfi.GEMGeometryESModule.clone()
+GEMGeometryAlignmentProducerAsAnalyzer.appendToDataLabel = 'idealForAlignmentProducerBase'


### PR DESCRIPTION
#### PR description:

fixes #34648

#### PR validation:

```
Using template /afs/cern.ch/work/h/hyunyong/CMSSW_12_0_X_2021-07-26-1100/src/Alignment/TrackerAlignment/test/alignment_forGeomComp_cfg_TEMPLATE.py
and plotting macros from /cvmfs/cms-ib.cern.ch/week1/slc7_amd64_gcc900/cms/cmssw-patch/CMSSW_12_0_X_2021-07-26-1100/src/Alignment/MillePedeAlignmentAlgorithm/macros/
Running in /afs/cern.ch/work/h/hyunyong/CMSSW_12_0_X_2021-07-26-1100/src/Alignment/TrackerAlignment/test/

============================================================
 Run 272011: auto:run2_data / TrackerAlignment_2009_v1_express (=1) vs auto:run2_data / SiPixelAli_PCL_v0_prompt (=2)
============================================================
Removing old file treeFile_auto_run2_data_TrackerAlignment_2009_v1_express_r272011_1.root
Removing old file treeFile_auto_run2_data_SiPixelAli_PCL_v0_prompt_r272011_2.root

Processing allMillePede.C...
Info in <TUnixSystem::ACLiC>: creating shared library /afs/cern.ch/work/h/hyunyong/CMSSW_12_0_X_2021-07-26-1100/src/Alignment/TrackerAlignment/test/PixelBaryCentrePlottingTools/./GFUtils/GFHistManager_C.so
Info in <TUnixSystem::ACLiC>: creating shared library /afs/cern.ch/work/h/hyunyong/CMSSW_12_0_X_2021-07-26-1100/src/Alignment/TrackerAlignment/test/PixelBaryCentrePlottingTools/./MillePedeTrees_C.so
Info in <TUnixSystem::ACLiC>: creating shared library /afs/cern.ch/work/h/hyunyong/CMSSW_12_0_X_2021-07-26-1100/src/Alignment/TrackerAlignment/test/PixelBaryCentrePlottingTools/./PlotMillePede_C.so
Info in <TUnixSystem::ACLiC>: creating shared library /afs/cern.ch/work/h/hyunyong/CMSSW_12_0_X_2021-07-26-1100/src/Alignment/TrackerAlignment/test/PixelBaryCentrePlottingTools/./PlotMillePedeIOV_C.so
Info in <TUnixSystem::ACLiC>: creating shared library /afs/cern.ch/work/h/hyunyong/CMSSW_12_0_X_2021-07-26-1100/src/Alignment/TrackerAlignment/test/PixelBaryCentrePlottingTools/./CompareMillePede_C.so
Info in <TUnixSystem::ACLiC>: creating shared library /afs/cern.ch/work/h/hyunyong/CMSSW_12_0_X_2021-07-26-1100/src/Alignment/TrackerAlignment/test/PixelBaryCentrePlottingTools/./PlotMilleMonitor_C.so
Processing pixelPositionChange.C+("/afs/cern.ch/work/h/hyunyong/CMSSW_12_0_X_2021-07-26-1100/src/Alignment/TrackerAlignment/test/treeFile_auto_run2_data_TrackerAlignment_2009_v1_express_r272011_1.root", "/afs/cern.ch/work/h/hyunyong/CMSSW_12_0_X_2021-07-26-1100/src/Alignment/TrackerAlignment/test/treeFile_auto_run2_data_SiPixelAli_PCL_v0_prompt_r272011_2.root")...
Info in <TUnixSystem::ACLiC>: creating shared library /afs/cern.ch/work/h/hyunyong/CMSSW_12_0_X_2021-07-26-1100/src/Alignment/TrackerAlignment/test/PixelBaryCentrePlottingTools/./pixelPositionChange_C.so
Info in <TCanvas::Print>: pdf file canvas0_0.pdf has been created
Info in <TCanvas::Print>: pdf file canvas0_1.pdf has been created
Info in <TCanvas::Print>: pdf file canvas0_2.pdf has been created
Info in <TCanvas::Print>: pdf file canvas0_3.pdf has been created
Info in <TCanvas::Print>: pdf file canvas0_4.pdf has been created
Info in <TCanvas::Print>: pdf file canvas1_0.pdf has been created
Info in <TCanvas::Print>: pdf file canvas1_1.pdf has been created
Info in <TCanvas::Print>: pdf file canvas1_2.pdf has been created
Info in <TCanvas::Print>: pdf file canvas1_3.pdf has been created
Info in <TCanvas::Print>: pdf file canvas1_4.pdf has been created
====================================================
BPIX:
====================================================
x1 x2: -0.0262721 -0.0262721
y1 y2: -0.0759665 -0.0759665
z1 z2: -0.498492 -0.498492
Delta(x,y,z) = 2-1 = (0,0,0) mum
====================================================
Pixel:
====================================================
x1 x2: -0.0400418 -0.0400418
y1 y2 -0.200817 -0.200817
z1 z2: -0.55104 -0.55104
Delta(x,y,z) = 2-1 = (0,0,0) mum
|  | *treeFile_auto_run2_data_TrackerAlignment_2009_v1_express_r272011_1.root* || *treeFile_auto_run2_data_TrackerAlignment_2009_v1_express_r272011_1.root*||
| *Position* |  *BPIX* | *Full Pixel* | *BPIX* | *Full Pixel* |
|  x  | -0.0262721 | -0.0400418 | -0.0262721 | -0.0400418 |
|  y  | -0.0759665 | -0.200817 | -0.0759665 | -0.200817 |
|  z  | -0.498492 | -0.55104 | -0.498492 | -0.55104 |

====================================================
====================================================
====================================================
```