### PR TITLE
FireWorks: Fix clang-tidy boost-use-to-string warnings and boost header

### DIFF
--- a/Fireworks/Core/interface/register_dataproxybuilder_macro.h
+++ b/Fireworks/Core/interface/register_dataproxybuilder_macro.h
@@ -20,7 +20,6 @@
 
 // system include files
 #include <cstdlib>
-#include "boost/lexical_cast.hpp"
 #include "FWCore/Reflection/interface/TypeWithDict.h"
 
 // forward declarations
@@ -47,7 +46,7 @@
     return s_type;                                                        \
   }                                                                       \
   const std::string& _builder_::classView() {                             \
-    static std::string s_view(boost::lexical_cast<std::string>(_view_));  \
+    static std::string s_view(std::to_string(_view_));  \
     return s_view;                                                        \
   }                                                                       \
   const std::string& _builder_::classPurpose() {                          \

--- a/Fireworks/Core/interface/register_dataproxybuilder_macro.h
+++ b/Fireworks/Core/interface/register_dataproxybuilder_macro.h
@@ -46,7 +46,7 @@
     return s_type;                                                        \
   }                                                                       \
   const std::string& _builder_::classView() {                             \
-    static std::string s_view(std::to_string(_view_));  \
+    static std::string s_view(std::to_string(_view_));                    \
     return s_view;                                                        \
   }                                                                       \
   const std::string& _builder_::classPurpose() {                          \

--- a/Fireworks/Core/test/unittest_changemanager.cc
+++ b/Fireworks/Core/test/unittest_changemanager.cc
@@ -11,7 +11,7 @@
 //
 
 // system include files
-#include <boost/test/auto_unit_test.hpp>
+#include <boost/test/unit_test.hpp>
 #include <boost/test/test_tools.hpp>
 
 #include "TClass.h"

--- a/Fireworks/Core/test/unittest_eventitemsmanager.cc
+++ b/Fireworks/Core/test/unittest_eventitemsmanager.cc
@@ -11,7 +11,7 @@
 //
 
 // system include files
-#include <boost/test/auto_unit_test.hpp>
+#include <boost/test/unit_test.hpp>
 #include <boost/test/test_tools.hpp>
 #include "TClass.h"
 

--- a/Fireworks/Core/test/unittest_fwconfiguration.cc
+++ b/Fireworks/Core/test/unittest_fwconfiguration.cc
@@ -11,7 +11,7 @@
 //
 
 // system include files
-#include <boost/test/auto_unit_test.hpp>
+#include <boost/test/unit_test.hpp>
 #include <boost/test/test_tools.hpp>
 #include <stdexcept>
 #include <iostream>

--- a/Fireworks/Core/test/unittest_fwmodelid.cc
+++ b/Fireworks/Core/test/unittest_fwmodelid.cc
@@ -11,7 +11,7 @@
 //
 
 // system include files
-#include <boost/test/auto_unit_test.hpp>
+#include <boost/test/unit_test.hpp>
 #include <boost/test/test_tools.hpp>
 
 // user include files

--- a/Fireworks/Core/test/unittest_main.cc
+++ b/Fireworks/Core/test/unittest_main.cc
@@ -14,4 +14,4 @@
 
 // user include files
 #define BOOST_AUTO_TEST_MAIN
-#include <boost/test/auto_unit_test.hpp>
+#include <boost/test/unit_test.hpp>

--- a/Fireworks/Core/test/unittest_main.cc
+++ b/Fireworks/Core/test/unittest_main.cc
@@ -2,7 +2,7 @@
 //
 // Package:     Core
 // Class  :     unittest_main
-// 
+//
 // Implementation:
 //     Creates the 'main' routine for the auto tests
 //

--- a/Fireworks/Core/test/unittest_modelexpressionselector.cc
+++ b/Fireworks/Core/test/unittest_modelexpressionselector.cc
@@ -11,7 +11,7 @@
 //
 
 // system include files
-#include <boost/test/auto_unit_test.hpp>
+#include <boost/test/unit_test.hpp>
 #include <boost/test/test_tools.hpp>
 #include "TClass.h"
 

--- a/Fireworks/Core/test/unittest_modelfilter.cc
+++ b/Fireworks/Core/test/unittest_modelfilter.cc
@@ -11,7 +11,7 @@
 //
 
 // system include files
-#include <boost/test/auto_unit_test.hpp>
+#include <boost/test/unit_test.hpp>
 #include <boost/test/test_tools.hpp>
 #include "TClass.h"
 

--- a/Fireworks/Core/test/unittest_parameters.cc
+++ b/Fireworks/Core/test/unittest_parameters.cc
@@ -11,7 +11,7 @@
 //
 
 // system include files
-#include <boost/test/auto_unit_test.hpp>
+#include <boost/test/unit_test.hpp>
 #include <boost/test/test_tools.hpp>
 #include <stdexcept>
 #include <iostream>

--- a/Fireworks/Core/test/unittest_selectionmanager.cc
+++ b/Fireworks/Core/test/unittest_selectionmanager.cc
@@ -11,7 +11,7 @@
 //
 
 // system include files
-//#include <boost/test/auto_unit_test.hpp>
+//#include <boost/test/unit_test.hpp>
 
 #define BOOST_TEST_DYN_LINK
 #define BOOST_TEST_MAIN


### PR DESCRIPTION
clang-tidy `boost-use-to-string` check generated around 120 wranings about
```
Fireworks/Calo/plugins/FWEcalRecHitProxyBuilder.cc:33:1: warning: use std::to_string instead of boost::lexical_cast<std::string> [boost-use-to-string]
REGISTER_FWPROXYBUILDER(FWEcalRecHitProxyBuilder, EcalRecHitCollection, "Ecal RecHit", FWViewType::kISpyBit);
```
but it does not fix these as in this case the code is in a macro. This PR proposes to use `std::to_string()` instead of `boost::lexical_cast<std::string>`

There are also many warnings about deprecated boost header. This PR also fixes this and uses `boost/test/unit_test.hpp` instead
```
>> Compiling edm plugin Fireworks/Tracks/plugins/FWTracksModulesProxyBuilder.cc
In file included from boost/config/header_deprecated.hpp:18,
                 from boost/test/auto_unit_test.hpp:16,
                 from boost/1.75.0-d9c5ee2ea4b2d631c2076f2838e5d91a/include/boost/test/auto_unit_test.hpp:17:1: note: #pragma message: This header is deprecated. Use <boost/test/unit_test.hpp> instead.
   17 | BOOST_HEADER_DEPRECATED( "<boost/test/unit_test.hpp>" )
      | ^~~~~~~~~~~~~~~~~~~~~~~
``` 