### PR TITLE
[CondFormat][clang-tidy] Fix readability-container-size-empty warnings

### DIFF
--- a/CondFormats/EcalObjects/src/EcalSRSettings.cc
+++ b/CondFormats/EcalObjects/src/EcalSRSettings.cc
@@ -15,7 +15,7 @@ EcalSRSettings::EcalSRSettings()
 #define SR_PRINT(a) o << #a ": " << val.a##_ << "\n";
 #define SR_VPRINT(a)                              \
   o << #a;                                        \
-  if (val.a##_.empty())                            \
+  if (val.a##_.empty())                           \
     o << "[0.." << (val.a##_.size() - 1) << "]:"; \
   else                                            \
     o << "[]: <empty>";                           \
@@ -23,11 +23,11 @@ EcalSRSettings::EcalSRSettings()
     o << "\t" << val.a##_[i];                     \
   o << "\n";
 #define SR_VVPRINT(a)                                  \
-  if (val.a##_.empty())                                 \
+  if (val.a##_.empty())                                \
     o << #a "[][]: <empty>\n";                         \
   for (size_t i = 0; i < val.a##_.size(); ++i) {       \
     o << #a "[" << i << "]";                           \
-    if (val.a##_.empty())                               \
+    if (val.a##_.empty())                              \
       o << "[0.." << (val.a##_[i].size() - 1) << "]:"; \
     else                                               \
       o << "[]: <empty>";                              \

--- a/CondFormats/EcalObjects/src/EcalSRSettings.cc
+++ b/CondFormats/EcalObjects/src/EcalSRSettings.cc
@@ -15,7 +15,7 @@ EcalSRSettings::EcalSRSettings()
 #define SR_PRINT(a) o << #a ": " << val.a##_ << "\n";
 #define SR_VPRINT(a)                              \
   o << #a;                                        \
-  if (val.a##_.size())                            \
+  if (val.a##_.empty())                            \
     o << "[0.." << (val.a##_.size() - 1) << "]:"; \
   else                                            \
     o << "[]: <empty>";                           \
@@ -23,11 +23,11 @@ EcalSRSettings::EcalSRSettings()
     o << "\t" << val.a##_[i];                     \
   o << "\n";
 #define SR_VVPRINT(a)                                  \
-  if (val.a##_.size() == 0)                            \
+  if (val.a##_.empty())                                 \
     o << #a "[][]: <empty>\n";                         \
   for (size_t i = 0; i < val.a##_.size(); ++i) {       \
     o << #a "[" << i << "]";                           \
-    if (val.a##_.size())                               \
+    if (val.a##_.empty())                               \
       o << "[0.." << (val.a##_[i].size() - 1) << "]:"; \
     else                                               \
       o << "[]: <empty>";                              \


### PR DESCRIPTION
This PR should fix the clang-tidy readability-container-size-empty  warnings [a] which are not automatically fixed by clang-tidy as the code is in a macro.

```
CondFormats/EcalObjects/src/EcalSRSettings.cc:48:3: warning: the 'empty' method should be used to check for emptiness instead of 'size' [readability-container-size-empty]
  SR_VPRINT(deltaEta);
  ^
CondFormats/EcalObjects/src/EcalSRSettings.cc:19:7: note: expanded from macro 'SR_VPRINT'
  if (val.a##_.size())                            \
      ^
gcc/9.3.0/lib/gcc/x86_64-unknown-linux-gnu/9.3.0/../../../../include/c++/9.3.0/bits/stl_vector.h:1004:7: note: method 'vector'::empty() defined here
      empty() const _GLIBCXX_NOEXCEPT
      ^

```