### PR TITLE
[PF][clang-tidy] fix readability-container-size-empty warnings

### DIFF
--- a/DataFormats/ParticleFlowCandidate/src/CountBits.h
+++ b/DataFormats/ParticleFlowCandidate/src/CountBits.h
@@ -4658,7 +4658,7 @@ enum PFRefMasks {
   size_t index, aIndex;                                                                  \
   typedef edm::Ref<std::vector<_class_> > RefType;                                       \
   if (getRefInfo(_mask_, _bit_, prodID, index, aIndex)) {                                \
-    if (refsCollectionCache_.size() == 0 || refsCollectionCache_[aIndex] == 0)           \
+    if (refsCollectionCache_.empty() || refsCollectionCache_[aIndex] == 0)               \
       return RefType(prodID, index, getter_);                                            \
     else {                                                                               \
       _class_ const* t = reinterpret_cast<_class_ const*>(refsCollectionCache_[aIndex]); \


### PR DESCRIPTION
Thsi shoudl fix clang-tidy check `readability-container-size-empty` warnings which are coming from `GETREF` macro

```
DataFormats/ParticleFlowCandidate/src/PFCandidate.cc:409:48: warning: the 'empty' method should be used to check for emptiness instead of 'size' [readability-container-size-empty]
reco::TrackRef PFCandidate::trackRef() const { GETREF(reco::Track, kRefTrackMask, kRefTrackBit); }
                                               ^
DataFormats/ParticleFlowCandidate/src/CountBits.h:4661:9: note: expanded from macro 'GETREF'
    if (refsCollectionCache_.size() == 0 || refsCollectionCache_[aIndex] == 0)           \

```