### PR TITLE
 Reserve one bit for the flag in pixel digi packing  - bugfix for PR #34509 

### DIFF
--- a/DataFormats/SiPixelDetId/interface/PixelChannelIdentifier.h
+++ b/DataFormats/SiPixelDetId/interface/PixelChannelIdentifier.h
@@ -69,7 +69,7 @@ public:
 public:
   constexpr static Packing packing() { return Packing(8, 9, 4, 11); }
 
-  constexpr static Packing thePacking = {11, 10, 0, 10};
+  constexpr static Packing thePacking = {11, 10, 1, 10};
 };
 
 #endif


### PR DESCRIPTION
#### PR description:

This PR is a follow up (bugfix) of the PR #34509, which was intended to reserve one bit for flagging individual pixels, but failed to do so.
No changes are expected.

#### PR validation:

No failure when running runTheMatrix.py

@veszpv, @mmusich, @cms-sw/reconstruction-l2




