### PR TITLE
Adapted EcalRawToDigi and SiPixelRawToCluster GPU code for HIon

### DIFF
--- a/EventFilter/EcalRawToDigi/plugins/EcalRawToDigiGPU.cc
+++ b/EventFilter/EcalRawToDigi/plugins/EcalRawToDigiGPU.cc
@@ -33,6 +33,7 @@ private:
 
   cms::cuda::ContextState cudaState_;
 
+  const uint32_t maxFedSize_;
   std::vector<int> fedsToUnpack_;
 
   ecal::raw::ConfigurationParameters config_;
@@ -44,6 +45,7 @@ void EcalRawToDigiGPU::fillDescriptions(edm::ConfigurationDescriptions& confDesc
   edm::ParameterSetDescription desc;
 
   desc.add<edm::InputTag>("InputLabel", edm::InputTag("rawDataCollector"));
+  desc.add<uint32_t>("maxFedSize", ecal::raw::nbytes_per_fed_max);
   std::vector<int> feds(54);
   for (uint32_t i = 0; i < 54; ++i)
     feds[i] = i + 601;
@@ -62,6 +64,7 @@ EcalRawToDigiGPU::EcalRawToDigiGPU(const edm::ParameterSet& ps)
       digisEBToken_{produces<OutputProduct>(ps.getParameter<std::string>("digisLabelEB"))},
       digisEEToken_{produces<OutputProduct>(ps.getParameter<std::string>("digisLabelEE"))},
       eMappingToken_{esConsumes<ecal::raw::ElectronicsMappingGPU, EcalMappingElectronicsRcd>()},
+      maxFedSize_{ps.getParameter<uint32_t>("maxFedSize")},
       fedsToUnpack_{ps.getParameter<std::vector<int>>("FEDs")} {
   config_.maxChannelsEB = ps.getParameter<uint32_t>("maxChannelsEB");
   config_.maxChannelsEE = ps.getParameter<uint32_t>("maxChannelsEE");
@@ -91,15 +94,15 @@ void EcalRawToDigiGPU::acquire(edm::Event const& event,
 
   // input cpu data
   ecal::raw::InputDataCPU inputCPU = {
-      cms::cuda::make_host_unique<unsigned char[]>(ecal::raw::nfeds_max * ecal::raw::nbytes_per_fed_max, ctx.stream()),
+      cms::cuda::make_host_unique<unsigned char[]>(ecal::raw::nfeds_max * maxFedSize_, ctx.stream()),
       cms::cuda::make_host_unique<uint32_t[]>(ecal::raw::nfeds_max, ctx.stream()),
       cms::cuda::make_host_unique<int[]>(ecal::raw::nfeds_max, ctx.stream())};
 
   // input data gpu
-  ecal::raw::InputDataGPU inputGPU = {cms::cuda::make_device_unique<unsigned char[]>(
-                                          ecal::raw::nfeds_max * ecal::raw::nbytes_per_fed_max, ctx.stream()),
-                                      cms::cuda::make_device_unique<uint32_t[]>(ecal::raw::nfeds_max, ctx.stream()),
-                                      cms::cuda::make_device_unique<int[]>(ecal::raw::nfeds_max, ctx.stream())};
+  ecal::raw::InputDataGPU inputGPU = {
+      cms::cuda::make_device_unique<unsigned char[]>(ecal::raw::nfeds_max * maxFedSize_, ctx.stream()),
+      cms::cuda::make_device_unique<uint32_t[]>(ecal::raw::nfeds_max, ctx.stream()),
+      cms::cuda::make_device_unique<int[]>(ecal::raw::nfeds_max, ctx.stream())};
 
   // output cpu
   outputCPU_ = {cms::cuda::make_host_unique<uint32_t[]>(2, ctx.stream())};

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelRawToClusterGPUKernel.cu
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelRawToClusterGPUKernel.cu
@@ -35,12 +35,9 @@
 
 namespace pixelgpudetails {
 
-  // number of words for all the FEDs
-  constexpr uint32_t MAX_FED_WORDS = pixelgpudetails::MAX_FED * pixelgpudetails::MAX_WORD;
-
-  SiPixelRawToClusterGPUKernel::WordFedAppender::WordFedAppender() {
-    word_ = cms::cuda::make_host_noncached_unique<unsigned int[]>(MAX_FED_WORDS, cudaHostAllocWriteCombined);
-    fedId_ = cms::cuda::make_host_noncached_unique<unsigned char[]>(MAX_FED_WORDS, cudaHostAllocWriteCombined);
+  SiPixelRawToClusterGPUKernel::WordFedAppender::WordFedAppender(uint32_t maxFedWords) {
+    word_ = cms::cuda::make_host_noncached_unique<unsigned int[]>(maxFedWords, cudaHostAllocWriteCombined);
+    fedId_ = cms::cuda::make_host_noncached_unique<unsigned char[]>(maxFedWords, cudaHostAllocWriteCombined);
   }
 
   void SiPixelRawToClusterGPUKernel::WordFedAppender::initializeWordFed(int fedId,
@@ -505,6 +502,7 @@ namespace pixelgpudetails {
                                                        SiPixelFormatterErrors &&errors,
                                                        const uint32_t wordCounter,
                                                        const uint32_t fedCounter,
+                                                       const uint32_t maxFedWords,
                                                        bool useQualityInfo,
                                                        bool includeErrors,
                                                        bool debug,
@@ -512,12 +510,12 @@ namespace pixelgpudetails {
     nDigis = wordCounter;
 
 #ifdef GPU_DEBUG
-    std::cout << "decoding " << wordCounter << " digis. Max is " << pixelgpudetails::MAX_FED_WORDS << std::endl;
+    std::cout << "decoding " << wordCounter << " digis. Max is " << maxFedWords << std::endl;
 #endif
 
-    digis_d = SiPixelDigisCUDA(pixelgpudetails::MAX_FED_WORDS, stream);
+    digis_d = SiPixelDigisCUDA(maxFedWords, stream);
     if (includeErrors) {
-      digiErrors_d = SiPixelDigiErrorsCUDA(pixelgpudetails::MAX_FED_WORDS, std::move(errors), stream);
+      digiErrors_d = SiPixelDigiErrorsCUDA(maxFedWords, std::move(errors), stream);
     }
     clusters_d = SiPixelClustersCUDA(gpuClustering::maxNumModules, stream);
 

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelRawToClusterGPUKernel.h
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelRawToClusterGPUKernel.h
@@ -120,6 +120,7 @@ namespace pixelgpudetails {
     class WordFedAppender {
     public:
       WordFedAppender();
+      WordFedAppender(uint32_t maxFedWords);
       ~WordFedAppender() = default;
 
       void initializeWordFed(int fedId, unsigned int wordCounterGPU, const cms_uint32_t* src, unsigned int length);
@@ -149,6 +150,7 @@ namespace pixelgpudetails {
                            SiPixelFormatterErrors&& errors,
                            const uint32_t wordCounter,
                            const uint32_t fedCounter,
+                           const uint32_t maxFedWords,
                            bool useQualityInfo,
                            bool includeErrors,
                            bool debug,

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/gpuClustering.h
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/gpuClustering.h
@@ -75,7 +75,8 @@ namespace gpuClustering {
       }
 
       //init hist  (ymax=416 < 512 : 9bits)
-      constexpr uint32_t maxPixInModule = 4000;
+      //6000 max pixels required for HI operations with no measurable impact on pp performance
+      constexpr uint32_t maxPixInModule = 6000;
       constexpr auto nbins = phase1PixelTopology::numColsInModule + 2;  //2+2;
       using Hist = cms::cuda::HistoContainer<uint16_t, nbins, maxPixInModule, 9, uint16_t>;
       __shared__ Hist hist;


### PR DESCRIPTION
#### PR description:

This PR include changes needed to run the HIon HLT menu on GPU using 2018 PbPb data.

The changes cover:
- EcalRawToDigiGPU: changed to set the parameter nbytes_per_fed_max at runtime, since the current implementation was causing a std::exception error in UnpackGPU.cu, line 295, in some PbPb events which surpassed the hardcoded threshold set by  ecal::raw::nbytes_per_fed_max .
- SiPixelRawToClusterCUDA: changed to set the parameter MAX_FED_WORDS at runtime, since a cudaErrorInvalidValue: invalid argument error in SiPixelRawToClusterGPUKernel.cu, line 535, appeared in some PbPb events which surpassed the threshold set by pixelgpudetails::MAX_FED_WORDS .
- gpuClustering: increased the value of maxPixInModule to 6000, since a std::bad_alloc exception crash in EcalPulseShapesGPU.cc, line 11 appeared in some few PbPb events that had more than 4000 pixels (e.g. 4194 pixels) in a module.

Since the default values are set to the standard pp ones, no changes are expected in the output.

#### PR validation:

The changes were tested on 2018 PbPb data using the MinimumBias and HardProbe PDs.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

@fwyzard 