### PR TITLE
[Fireworks][Clang-tidy] make deleted function public

### DIFF
--- a/Fireworks/Calo/interface/FWBoxRecHit.h
+++ b/Fireworks/Calo/interface/FWBoxRecHit.h
@@ -52,10 +52,10 @@ public:
   bool isTallest() const { return m_isTallest; }
   void setIsTallest();
 
-private:
   FWBoxRecHit(const FWBoxRecHit &) = delete;                   // Disable default
   const FWBoxRecHit &operator=(const FWBoxRecHit &) = delete;  // Disable default
 
+private:
   // --------------------- Member Functions --------------------------
   void setupEveBox(std::vector<TEveVector> &corners, float scale);
   void buildTower(const std::vector<TEveVector> &corners);

--- a/Fireworks/Calo/interface/FWCaloDataProxyBuilderBase.h
+++ b/Fireworks/Calo/interface/FWCaloDataProxyBuilderBase.h
@@ -56,11 +56,12 @@ protected:
   Int_t m_sliceIndex;
   void itemBeingDestroyed(const FWEventItem*) override;
 
-private:
+public:
   FWCaloDataProxyBuilderBase(const FWCaloDataProxyBuilderBase&) = delete;  // stop default
 
   const FWCaloDataProxyBuilderBase& operator=(const FWCaloDataProxyBuilderBase&) = delete;  // stop default
 
+private:
   // ---------- member data --------------------------------
 
   void modelChanges(const FWModelIds&, Product*) override;

--- a/Fireworks/Calo/interface/FWHeatmapProxyBuilderTemplate.h
+++ b/Fireworks/Calo/interface/FWHeatmapProxyBuilderTemplate.h
@@ -166,11 +166,11 @@ protected:
         "implemented by inherited class");
   };
 
-private:
+public:
   FWHeatmapProxyBuilderTemplate(const FWHeatmapProxyBuilderTemplate&) = delete;  // stop default
 
   const FWHeatmapProxyBuilderTemplate& operator=(const FWHeatmapProxyBuilderTemplate&) = delete;  // stop default
-
+private:
   // ---------- member data --------------------------------
 };
 

--- a/Fireworks/Calo/interface/FWTauProxyBuilderBase.h
+++ b/Fireworks/Calo/interface/FWTauProxyBuilderBase.h
@@ -63,11 +63,11 @@ protected:
                          FWViewType::EType viewType,
                          const FWViewContext* vc) override;
 
-private:
+public:
   FWTauProxyBuilderBase(const FWTauProxyBuilderBase&) = delete;  // stop default
 
   const FWTauProxyBuilderBase& operator=(const FWTauProxyBuilderBase&) = delete;  // stop default
-
+private:
   // ---------- member data --------------------------------
   // Add Tracks which passed quality cuts and
   // are inside a tracker signal cone around leading Track

--- a/Fireworks/Calo/plugins/FWCaloClusterProxyBuilder.cc
+++ b/Fireworks/Calo/plugins/FWCaloClusterProxyBuilder.cc
@@ -15,6 +15,9 @@ public:
 
   REGISTER_PROXYBUILDER_METHODS();
 
+  FWCaloClusterProxyBuilder(const FWCaloClusterProxyBuilder &) = delete;                   // stop default
+  const FWCaloClusterProxyBuilder &operator=(const FWCaloClusterProxyBuilder &) = delete;  // stop default
+
 private:
   edm::Handle<edm::ValueMap<std::pair<float, float>>> TimeValueMapHandle;
   double timeLowerBound, timeUpperBound;
@@ -24,9 +27,6 @@ private:
   bool z_plus;
   bool z_minus;
   bool enableTimeFilter;
-
-  FWCaloClusterProxyBuilder(const FWCaloClusterProxyBuilder &) = delete;                   // stop default
-  const FWCaloClusterProxyBuilder &operator=(const FWCaloClusterProxyBuilder &) = delete;  // stop default
 
   void setItem(const FWEventItem *iItem) override;
 

--- a/Fireworks/Calo/plugins/FWCaloRecHitDigitSetProxyBuilder.h
+++ b/Fireworks/Calo/plugins/FWCaloRecHitDigitSetProxyBuilder.h
@@ -22,10 +22,10 @@ public:
   virtual void viewContextBoxScale(
       const float* corners, float scale, bool plotEt, std::vector<float>& scaledCorners, const CaloRecHit*);
 
-private:
   FWCaloRecHitDigitSetProxyBuilder(const FWCaloRecHitDigitSetProxyBuilder&) = delete;
   const FWCaloRecHitDigitSetProxyBuilder& operator=(const FWCaloRecHitDigitSetProxyBuilder&) = delete;
 
+private:
   bool m_invertBox;
   bool m_ignoreGeoShapeSize;
   double m_enlarge;

--- a/Fireworks/Calo/plugins/FWCaloTowerProxyBuilder.h
+++ b/Fireworks/Calo/plugins/FWCaloTowerProxyBuilder.h
@@ -43,10 +43,11 @@ protected:
   FWHistSliceSelector* instantiateSliceSelector() override;
   void build(const FWEventItem* iItem, TEveElementList* product, const FWViewContext*) override;
 
-private:
+public:
   FWCaloTowerProxyBuilderBase(const FWCaloTowerProxyBuilderBase&) = delete;                   // stop default
   const FWCaloTowerProxyBuilderBase& operator=(const FWCaloTowerProxyBuilderBase&) = delete;  // stop default
 
+private:
   const CaloTowerCollection* m_towers;
 };
 
@@ -65,7 +66,6 @@ public:
 
   REGISTER_PROXYBUILDER_METHODS();
 
-private:
   FWECalCaloTowerProxyBuilder(const FWECalCaloTowerProxyBuilder&) = delete;                   // stop default
   const FWECalCaloTowerProxyBuilder& operator=(const FWECalCaloTowerProxyBuilder&) = delete;  // stop default
 };
@@ -85,7 +85,6 @@ public:
 
   REGISTER_PROXYBUILDER_METHODS();
 
-private:
   FWHCalCaloTowerProxyBuilder(const FWHCalCaloTowerProxyBuilder&) = delete;  // stop default
 
   const FWHCalCaloTowerProxyBuilder& operator=(const FWHCalCaloTowerProxyBuilder&) = delete;  // stop default
@@ -106,7 +105,6 @@ public:
 
   REGISTER_PROXYBUILDER_METHODS();
 
-private:
   FWHOCaloTowerProxyBuilder(const FWHOCaloTowerProxyBuilder&) = delete;                   // stop default
   const FWHOCaloTowerProxyBuilder& operator=(const FWHOCaloTowerProxyBuilder&) = delete;  // stop default
 };

--- a/Fireworks/Calo/plugins/FWCastorRecHitProxyBuilder.cc
+++ b/Fireworks/Calo/plugins/FWCastorRecHitProxyBuilder.cc
@@ -17,7 +17,6 @@ public:
 
   REGISTER_PROXYBUILDER_METHODS();
 
-private:
   FWCastorRecHitProxyBuilder(const FWCastorRecHitProxyBuilder&) = delete;
   const FWCastorRecHitProxyBuilder& operator=(const FWCastorRecHitProxyBuilder&) = delete;
 };

--- a/Fireworks/Calo/plugins/FWEcalRecHitProxyBuilder.cc
+++ b/Fireworks/Calo/plugins/FWEcalRecHitProxyBuilder.cc
@@ -19,7 +19,6 @@ public:
 
   REGISTER_PROXYBUILDER_METHODS();
 
-private:
   FWEcalRecHitProxyBuilder(const FWEcalRecHitProxyBuilder&) = delete;
   const FWEcalRecHitProxyBuilder& operator=(const FWEcalRecHitProxyBuilder&) = delete;
 };

--- a/Fireworks/Calo/plugins/FWFTLRecHitProxyBuilder.cc
+++ b/Fireworks/Calo/plugins/FWFTLRecHitProxyBuilder.cc
@@ -8,7 +8,6 @@ public:
 
   REGISTER_PROXYBUILDER_METHODS();
 
-private:
   FWFTLRecHitProxyBuilder(const FWFTLRecHitProxyBuilder&) = delete;
   const FWFTLRecHitProxyBuilder& operator=(const FWFTLRecHitProxyBuilder&) = delete;
 };

--- a/Fireworks/Calo/plugins/FWHBHERecHitProxyBuilder.cc
+++ b/Fireworks/Calo/plugins/FWHBHERecHitProxyBuilder.cc
@@ -8,7 +8,6 @@ public:
 
   REGISTER_PROXYBUILDER_METHODS();
 
-private:
   FWHBHERecHitProxyBuilder(const FWHBHERecHitProxyBuilder&) = delete;
   const FWHBHERecHitProxyBuilder& operator=(const FWHBHERecHitProxyBuilder&) = delete;
 };

--- a/Fireworks/Calo/plugins/FWHFRecHitProxyBuilder.cc
+++ b/Fireworks/Calo/plugins/FWHFRecHitProxyBuilder.cc
@@ -8,7 +8,6 @@ public:
 
   REGISTER_PROXYBUILDER_METHODS();
 
-private:
   FWHFRecHitProxyBuilder(const FWHFRecHitProxyBuilder&) = delete;
   const FWHFRecHitProxyBuilder& operator=(const FWHFRecHitProxyBuilder&) = delete;
 };

--- a/Fireworks/Calo/plugins/FWHFTowerProxyBuilder.h
+++ b/Fireworks/Calo/plugins/FWHFTowerProxyBuilder.h
@@ -49,11 +49,12 @@ protected:
 
   void itemBeingDestroyed(const FWEventItem*) override;
 
-private:
+public:
   FWHFTowerProxyBuilderBase(const FWHFTowerProxyBuilderBase&) = delete;  // stop default
 
   const FWHFTowerProxyBuilderBase& operator=(const FWHFTowerProxyBuilderBase&) = delete;  // stop default
 
+private:
   void build(const FWEventItem* iItem, TEveElementList* product, const FWViewContext*) override;
 
   int fillTowerForDetId(unsigned int rawid, float);

--- a/Fireworks/Calo/plugins/FWHGCRecHitProxyBuilder.cc
+++ b/Fireworks/Calo/plugins/FWHGCRecHitProxyBuilder.cc
@@ -13,10 +13,10 @@ public:
 
   REGISTER_PROXYBUILDER_METHODS();
 
-private:
   FWHGCRecHitProxyBuilder(const FWHGCRecHitProxyBuilder &) = delete;
   const FWHGCRecHitProxyBuilder &operator=(const FWHGCRecHitProxyBuilder &) = delete;
 
+private:
   static constexpr uint8_t gradient_steps = 9;
   static constexpr float gradient[3][gradient_steps] = {{0.2082 * 255,
                                                          0.0592 * 255,

--- a/Fireworks/Calo/plugins/FWHGCalMultiClusterLegoProxyBuilder.h
+++ b/Fireworks/Calo/plugins/FWHGCalMultiClusterLegoProxyBuilder.h
@@ -19,14 +19,13 @@ public:
 
   REGISTER_PROXYBUILDER_METHODS();
 
+  FWHGCalMultiClusterLegoProxyBuilder(const FWHGCalMultiClusterLegoProxyBuilder &) = delete;  // stop default
+  const FWHGCalMultiClusterLegoProxyBuilder &operator=(const FWHGCalMultiClusterLegoProxyBuilder &) = delete;  // stop default
+
 private:
   void fillCaloData() override;
   FWHistSliceSelector *instantiateSliceSelector() override;
   void build(const FWEventItem *iItem, TEveElementList *product, const FWViewContext *) override;
-
-  FWHGCalMultiClusterLegoProxyBuilder(const FWHGCalMultiClusterLegoProxyBuilder &) = delete;  // stop default
-  const FWHGCalMultiClusterLegoProxyBuilder &operator=(const FWHGCalMultiClusterLegoProxyBuilder &) =
-      delete;  // stop default
 
   const std::vector<reco::HGCalMultiCluster> *m_towers;
 };

--- a/Fireworks/Calo/plugins/FWHGCalMultiClusterLegoProxyBuilder.h
+++ b/Fireworks/Calo/plugins/FWHGCalMultiClusterLegoProxyBuilder.h
@@ -20,7 +20,8 @@ public:
   REGISTER_PROXYBUILDER_METHODS();
 
   FWHGCalMultiClusterLegoProxyBuilder(const FWHGCalMultiClusterLegoProxyBuilder &) = delete;  // stop default
-  const FWHGCalMultiClusterLegoProxyBuilder &operator=(const FWHGCalMultiClusterLegoProxyBuilder &) = delete;  // stop default
+  const FWHGCalMultiClusterLegoProxyBuilder &operator=(const FWHGCalMultiClusterLegoProxyBuilder &) =
+      delete;  // stop default
 
 private:
   void fillCaloData() override;

--- a/Fireworks/Calo/plugins/FWHGCalMultiClusterProxyBuilder.cc
+++ b/Fireworks/Calo/plugins/FWHGCalMultiClusterProxyBuilder.cc
@@ -14,10 +14,10 @@ public:
 
   REGISTER_PROXYBUILDER_METHODS();
 
-private:
   FWHGCalMultiClusterProxyBuilder(const FWHGCalMultiClusterProxyBuilder &) = delete;                   // stop default
   const FWHGCalMultiClusterProxyBuilder &operator=(const FWHGCalMultiClusterProxyBuilder &) = delete;  // stop default
 
+private:
   void build(const reco::HGCalMultiCluster &iData,
              unsigned int iIndex,
              TEveElement &oItemHolder,

--- a/Fireworks/Calo/plugins/FWHGCalTriggerCellProxyBuilder.cc
+++ b/Fireworks/Calo/plugins/FWHGCalTriggerCellProxyBuilder.cc
@@ -19,10 +19,10 @@ public:
 
   REGISTER_PROXYBUILDER_METHODS();
 
-private:
   FWHGCalTriggerCellProxyBuilder(const FWHGCalTriggerCellProxyBuilder &) = delete;                   // stop default
   const FWHGCalTriggerCellProxyBuilder &operator=(const FWHGCalTriggerCellProxyBuilder &) = delete;  // stop default
 
+private:
   void build(const l1t::HGCalTriggerCell &iData,
              unsigned int iIndex,
              TEveElement &oItemHolder,

--- a/Fireworks/Calo/plugins/FWHGCalTriggerClusterProxyBuilder.cc
+++ b/Fireworks/Calo/plugins/FWHGCalTriggerClusterProxyBuilder.cc
@@ -22,11 +22,11 @@ public:
 
   REGISTER_PROXYBUILDER_METHODS();
 
-private:
   FWHGCalTriggerClusterProxyBuilder(const FWHGCalTriggerClusterProxyBuilder &) = delete;  // stop default
   const FWHGCalTriggerClusterProxyBuilder &operator=(const FWHGCalTriggerClusterProxyBuilder &) =
       delete;  // stop default
 
+private:
   void build(const l1t::HGCalMulticluster &iData,
              unsigned int iIndex,
              TEveElement &oItemHolder,

--- a/Fireworks/Calo/plugins/FWHGTowerProxyBuilder.h
+++ b/Fireworks/Calo/plugins/FWHGTowerProxyBuilder.h
@@ -49,11 +49,11 @@ protected:
 
   void itemBeingDestroyed(const FWEventItem*) override;
 
-private:
+public:
   FWHGTowerProxyBuilderBase(const FWHGTowerProxyBuilderBase&) = delete;  // stop default
 
   const FWHGTowerProxyBuilderBase& operator=(const FWHGTowerProxyBuilderBase&) = delete;  // stop default
-
+private:
   void build(const FWEventItem* iItem, TEveElementList* product, const FWViewContext*) override;
 
   int fillTowerForDetId(unsigned int rawid, float);

--- a/Fireworks/Calo/plugins/FWHORecHitProxyBuilder.cc
+++ b/Fireworks/Calo/plugins/FWHORecHitProxyBuilder.cc
@@ -8,7 +8,6 @@ public:
 
   REGISTER_PROXYBUILDER_METHODS();
 
-private:
   FWHORecHitProxyBuilder(const FWHORecHitProxyBuilder&) = delete;
   const FWHORecHitProxyBuilder& operator=(const FWHORecHitProxyBuilder&) = delete;
 };

--- a/Fireworks/Calo/plugins/FWJetLegoProxyBuilder.cc
+++ b/Fireworks/Calo/plugins/FWJetLegoProxyBuilder.cc
@@ -13,7 +13,7 @@ protected:
   using FWSimpleProxyBuilderTemplate<reco::Jet>::build;
   void build(const reco::Jet& iData, unsigned int iIndex, TEveElement& oItemHolder, const FWViewContext*) override;
 
-private:
+public:
   FWJetLegoProxyBuilder(const FWJetLegoProxyBuilder&) = delete;                   // stop default
   const FWJetLegoProxyBuilder& operator=(const FWJetLegoProxyBuilder&) = delete;  // stop default
 };

--- a/Fireworks/Calo/plugins/FWJetProxyBuilder.cc
+++ b/Fireworks/Calo/plugins/FWJetProxyBuilder.cc
@@ -64,6 +64,9 @@ public:
 
   REGISTER_PROXYBUILDER_METHODS();
 
+  FWJetProxyBuilder(const FWJetProxyBuilder&) = delete;                   // stop default
+  const FWJetProxyBuilder& operator=(const FWJetProxyBuilder&) = delete;  // stop default
+
 protected:
   using FWSimpleProxyBuilderTemplate<reco::Jet>::buildViewType;
   void buildViewType(const reco::Jet& iData,
@@ -81,9 +84,6 @@ protected:
 
 private:
   typedef std::vector<fireworks::jetScaleMarker> Lines_t;
-
-  FWJetProxyBuilder(const FWJetProxyBuilder&) = delete;                   // stop default
-  const FWJetProxyBuilder& operator=(const FWJetProxyBuilder&) = delete;  // stop default
 
   TEveElementList* requestCommon();
   void setTextPos(fireworks::jetScaleMarker& s, const FWViewContext* vc, FWViewType::EType);

--- a/Fireworks/Calo/plugins/FWL1EmParticleProxyBuilder.cc
+++ b/Fireworks/Calo/plugins/FWL1EmParticleProxyBuilder.cc
@@ -22,10 +22,10 @@ public:
 
   REGISTER_PROXYBUILDER_METHODS();
 
-private:
   FWL1EmParticleProxyBuilder(const FWL1EmParticleProxyBuilder&) = delete;                   // stop default
   const FWL1EmParticleProxyBuilder& operator=(const FWL1EmParticleProxyBuilder&) = delete;  // stop default
 
+private:
   using FWSimpleProxyBuilderTemplate<l1extra::L1EmParticle>::build;
   void build(const l1extra::L1EmParticle& iData,
              unsigned int iIndex,

--- a/Fireworks/Calo/plugins/FWL1EtMissParticleGlimpseProxyBuilder.cc
+++ b/Fireworks/Calo/plugins/FWL1EtMissParticleGlimpseProxyBuilder.cc
@@ -18,11 +18,11 @@ public:
 
   REGISTER_PROXYBUILDER_METHODS();
 
-private:
   FWL1EtMissParticleGlimpseProxyBuilder(const FWL1EtMissParticleGlimpseProxyBuilder&) = delete;  // stop default
   const FWL1EtMissParticleGlimpseProxyBuilder& operator=(const FWL1EtMissParticleGlimpseProxyBuilder&) =
       delete;  // stop default
 
+private:
   using FWSimpleProxyBuilderTemplate<l1extra::L1EtMissParticle>::build;
   void build(const l1extra::L1EtMissParticle& iData,
              unsigned int iIndex,

--- a/Fireworks/Calo/plugins/FWL1EtMissParticleLegoProxyBuilder.cc
+++ b/Fireworks/Calo/plugins/FWL1EtMissParticleLegoProxyBuilder.cc
@@ -18,11 +18,11 @@ public:
 
   REGISTER_PROXYBUILDER_METHODS();
 
-private:
   FWL1EtMissParticleLegoProxyBuilder(const FWL1EtMissParticleLegoProxyBuilder&) = delete;  // stop default
   const FWL1EtMissParticleLegoProxyBuilder& operator=(const FWL1EtMissParticleLegoProxyBuilder&) =
       delete;  // stop default
 
+private:
   using FWSimpleProxyBuilderTemplate<l1extra::L1EtMissParticle>::build;
   void build(const l1extra::L1EtMissParticle& iData,
              unsigned int iIndex,

--- a/Fireworks/Calo/plugins/FWL1EtMissParticleProxyBuilder.cc
+++ b/Fireworks/Calo/plugins/FWL1EtMissParticleProxyBuilder.cc
@@ -22,10 +22,10 @@ public:
 
   REGISTER_PROXYBUILDER_METHODS();
 
-private:
   FWL1EtMissParticleProxyBuilder(const FWL1EtMissParticleProxyBuilder&) = delete;                   // stop default
   const FWL1EtMissParticleProxyBuilder& operator=(const FWL1EtMissParticleProxyBuilder&) = delete;  // stop default
 
+private:
   using FWSimpleProxyBuilderTemplate<l1extra::L1EtMissParticle>::build;
   void build(const l1extra::L1EtMissParticle& iData,
              unsigned int iIndex,

--- a/Fireworks/Calo/plugins/FWL1JetParticleLegoProxyBuilder.cc
+++ b/Fireworks/Calo/plugins/FWL1JetParticleLegoProxyBuilder.cc
@@ -18,10 +18,10 @@ public:
 
   REGISTER_PROXYBUILDER_METHODS();
 
-private:
   FWL1JetParticleLegoProxyBuilder(const FWL1JetParticleLegoProxyBuilder&) = delete;                   // stop default
   const FWL1JetParticleLegoProxyBuilder& operator=(const FWL1JetParticleLegoProxyBuilder&) = delete;  // stop default
 
+private:
   using FWSimpleProxyBuilderTemplate<l1extra::L1JetParticle>::build;
   void build(const l1extra::L1JetParticle& iData,
              unsigned int iIndex,

--- a/Fireworks/Calo/plugins/FWL1JetParticleProxyBuilder.cc
+++ b/Fireworks/Calo/plugins/FWL1JetParticleProxyBuilder.cc
@@ -22,10 +22,10 @@ public:
 
   REGISTER_PROXYBUILDER_METHODS();
 
-private:
   FWL1JetParticleProxyBuilder(const FWL1JetParticleProxyBuilder&) = delete;                   // stop default
   const FWL1JetParticleProxyBuilder& operator=(const FWL1JetParticleProxyBuilder&) = delete;  // stop default
 
+private:
   using FWSimpleProxyBuilderTemplate<l1extra::L1JetParticle>::build;
   void build(const l1extra::L1JetParticle& iData,
              unsigned int iIndex,

--- a/Fireworks/Calo/plugins/FWL1MuonParticleLegoProxyBuilder.cc
+++ b/Fireworks/Calo/plugins/FWL1MuonParticleLegoProxyBuilder.cc
@@ -18,10 +18,10 @@ public:
 
   REGISTER_PROXYBUILDER_METHODS();
 
-private:
   FWL1MuonParticleLegoProxyBuilder(const FWL1MuonParticleLegoProxyBuilder&) = delete;                   // stop default
   const FWL1MuonParticleLegoProxyBuilder& operator=(const FWL1MuonParticleLegoProxyBuilder&) = delete;  // stop default
 
+private:
   using FWSimpleProxyBuilderTemplate<l1extra::L1MuonParticle>::build;
   void build(const l1extra::L1MuonParticle& iData,
              unsigned int iIndex,

--- a/Fireworks/Calo/plugins/FWL1MuonParticleProxyBuilder.cc
+++ b/Fireworks/Calo/plugins/FWL1MuonParticleProxyBuilder.cc
@@ -22,10 +22,10 @@ public:
 
   REGISTER_PROXYBUILDER_METHODS();
 
-private:
   FWL1MuonParticleProxyBuilder(const FWL1MuonParticleProxyBuilder&) = delete;                   // stop default
   const FWL1MuonParticleProxyBuilder& operator=(const FWL1MuonParticleProxyBuilder&) = delete;  // stop default
 
+private:
   using FWSimpleProxyBuilderTemplate<l1extra::L1MuonParticle>::build;
   void build(const l1extra::L1MuonParticle& iData,
              unsigned int iIndex,

--- a/Fireworks/Calo/plugins/FWMET3DProxyBuilder.cc
+++ b/Fireworks/Calo/plugins/FWMET3DProxyBuilder.cc
@@ -68,10 +68,10 @@ public:
 
   REGISTER_PROXYBUILDER_METHODS();
 
-private:
   FWMET3DProxyBuilder(const FWMET3DProxyBuilder&) = delete;                   // stop default
   const FWMET3DProxyBuilder& operator=(const FWMET3DProxyBuilder&) = delete;  // stop default
 
+private:
   using FWSimpleProxyBuilderTemplate<reco::MET>::build;
   void build(const reco::MET&, unsigned int, TEveElement&, const FWViewContext*) override;
 

--- a/Fireworks/Calo/plugins/FWMETGlimpseProxyBuilder.cc
+++ b/Fireworks/Calo/plugins/FWMETGlimpseProxyBuilder.cc
@@ -18,10 +18,10 @@ public:
 
   REGISTER_PROXYBUILDER_METHODS();
 
-private:
   FWMETGlimpseProxyBuilder(const FWMETGlimpseProxyBuilder&) = delete;                   // stop default
   const FWMETGlimpseProxyBuilder& operator=(const FWMETGlimpseProxyBuilder&) = delete;  // stop default
 
+private:
   using FWSimpleProxyBuilderTemplate<reco::MET>::build;
   void build(const reco::MET& iData, unsigned int iIndex, TEveElement& oItemHolder, const FWViewContext*) override;
 };

--- a/Fireworks/Calo/plugins/FWMETLegoProxyBuilder.cc
+++ b/Fireworks/Calo/plugins/FWMETLegoProxyBuilder.cc
@@ -18,10 +18,10 @@ public:
 
   REGISTER_PROXYBUILDER_METHODS();
 
-private:
   FWMETLegoProxyBuilder(const FWMETLegoProxyBuilder&) = delete;                   // stop default
   const FWMETLegoProxyBuilder& operator=(const FWMETLegoProxyBuilder&) = delete;  // stop default
 
+private:
   using FWSimpleProxyBuilderTemplate<reco::MET>::build;
   void build(const reco::MET& iData, unsigned int iIndex, TEveElement& oItemHolder, const FWViewContext*) override;
 };

--- a/Fireworks/Calo/plugins/FWMETProxyBuilder.cc
+++ b/Fireworks/Calo/plugins/FWMETProxyBuilder.cc
@@ -49,10 +49,10 @@ public:
 
   REGISTER_PROXYBUILDER_METHODS();
 
-private:
   FWMETProxyBuilder(const FWMETProxyBuilder&) = delete;                   // stop default
   const FWMETProxyBuilder& operator=(const FWMETProxyBuilder&) = delete;  // stop default
 
+private:
   using FWSimpleProxyBuilderTemplate<reco::MET>::buildViewType;
   void buildViewType(const reco::MET& iData,
                      unsigned int iIndex,

--- a/Fireworks/Calo/plugins/FWPFTauProxyBuilder.cc
+++ b/Fireworks/Calo/plugins/FWPFTauProxyBuilder.cc
@@ -34,10 +34,10 @@ public:
 
   REGISTER_PROXYBUILDER_METHODS();
 
-private:
   FWPFTauProxyBuilder(const FWPFTauProxyBuilder&) = delete;                   // stop default
   const FWPFTauProxyBuilder& operator=(const FWPFTauProxyBuilder&) = delete;  // stop default
 
+private:
   using FWTauProxyBuilderBase::buildViewType;
   void buildViewType(const FWEventItem* iItem,
                      TEveElementList* product,

--- a/Fireworks/Calo/plugins/FWPRCaloTowerProxyBuilder.cc
+++ b/Fireworks/Calo/plugins/FWPRCaloTowerProxyBuilder.cc
@@ -11,10 +11,10 @@ public:
 
   REGISTER_PROXYBUILDER_METHODS();
 
-private:
   FWPRCaloTowerProxyBuilder(const FWPRCaloTowerProxyBuilder&) = delete;                   // stop default
   const FWPRCaloTowerProxyBuilder& operator=(const FWPRCaloTowerProxyBuilder&) = delete;  // stop default
 
+private:
   using FWDigitSetProxyBuilder::build;
   void build(const FWEventItem* iItem, TEveElementList* product, const FWViewContext*) override;
 };

--- a/Fireworks/Calo/plugins/FWTracksterHitsProxyBuilder.cc
+++ b/Fireworks/Calo/plugins/FWTracksterHitsProxyBuilder.cc
@@ -20,6 +20,9 @@ public:
 
   REGISTER_PROXYBUILDER_METHODS();
 
+  FWTracksterHitsProxyBuilder(const FWTracksterHitsProxyBuilder &) = delete;                   // stop default
+  const FWTracksterHitsProxyBuilder &operator=(const FWTracksterHitsProxyBuilder &) = delete;  // stop default
+
 private:
   edm::Handle<edm::ValueMap<std::pair<float, float>>> TimeValueMapHandle;
   edm::Handle<std::vector<reco::CaloCluster>> layerClustersHandle;
@@ -33,9 +36,6 @@ private:
   bool enableSeedLines;
   bool enablePositionLines;
   bool enableEdges;
-
-  FWTracksterHitsProxyBuilder(const FWTracksterHitsProxyBuilder &) = delete;                   // stop default
-  const FWTracksterHitsProxyBuilder &operator=(const FWTracksterHitsProxyBuilder &) = delete;  // stop default
 
   void setItem(const FWEventItem *iItem) override;
 

--- a/Fireworks/Calo/plugins/FWTracksterLayersProxyBuilder.cc
+++ b/Fireworks/Calo/plugins/FWTracksterLayersProxyBuilder.cc
@@ -25,6 +25,9 @@ public:
 
   REGISTER_PROXYBUILDER_METHODS();
 
+  FWTracksterLayersProxyBuilder(const FWTracksterLayersProxyBuilder &) = delete;                   // stop default
+  const FWTracksterLayersProxyBuilder &operator=(const FWTracksterLayersProxyBuilder &) = delete;  // stop default
+
 private:
   edm::Handle<edm::ValueMap<std::pair<float, float>>> TimeValueMapHandle;
   edm::Handle<std::vector<reco::CaloCluster>> layerClustersHandle;
@@ -37,9 +40,6 @@ private:
   bool enableEdges;
   double displayMode;
   double proportionalityFactor;
-
-  FWTracksterLayersProxyBuilder(const FWTracksterLayersProxyBuilder &) = delete;                   // stop default
-  const FWTracksterLayersProxyBuilder &operator=(const FWTracksterLayersProxyBuilder &) = delete;  // stop default
 
   void setItem(const FWEventItem *iItem) override;
 

--- a/Fireworks/Calo/plugins/FWTracksterProxyBuilder.cc
+++ b/Fireworks/Calo/plugins/FWTracksterProxyBuilder.cc
@@ -12,10 +12,10 @@ public:
 
   REGISTER_PROXYBUILDER_METHODS();
 
-private:
   FWTracksterProxyBuilder(const FWTracksterProxyBuilder &) = delete;                   // stop default
   const FWTracksterProxyBuilder &operator=(const FWTracksterProxyBuilder &) = delete;  // stop default
 
+private:
   void build(const ticl::Trackster &iData,
              unsigned int iIndex,
              TEveElement &oItemHolder,

--- a/Fireworks/Calo/plugins/FWZDCRecHitProxyBuilder.cc
+++ b/Fireworks/Calo/plugins/FWZDCRecHitProxyBuilder.cc
@@ -16,7 +16,6 @@ public:
 
   REGISTER_PROXYBUILDER_METHODS();
 
-private:
   FWZDCRecHitProxyBuilder(const FWZDCRecHitProxyBuilder&) = delete;
   const FWZDCRecHitProxyBuilder& operator=(const FWZDCRecHitProxyBuilder&) = delete;
 };

--- a/Fireworks/Calo/src/FWFromTEveCaloDataSelector.h
+++ b/Fireworks/Calo/src/FWFromTEveCaloDataSelector.h
@@ -47,11 +47,10 @@ public:
   void addSliceSelector(int iSlice, FWFromSliceSelector*);
   void resetSliceSelector(int iSlice);
 
-private:
   FWFromTEveCaloDataSelector(const FWFromTEveCaloDataSelector&) = delete;  // stop default
 
   const FWFromTEveCaloDataSelector& operator=(const FWFromTEveCaloDataSelector&) = delete;  // stop default
-
+private:
   // ---------- member data --------------------------------
   std::vector<FWFromSliceSelector*> m_sliceSelectors;
   TEveCaloData* m_data;  // cached

--- a/Fireworks/Candidates/interface/FWLegoCandidate.h
+++ b/Fireworks/Candidates/interface/FWLegoCandidate.h
@@ -41,10 +41,10 @@ public:
   // --------------------- Member Functions --------------------------
   void updateScale(const FWViewContext* vc, const fireworks::Context&);
 
-private:
   FWLegoCandidate(const FWLegoCandidate&) = delete;                   // Disable default copy constructor
   const FWLegoCandidate& operator=(const FWLegoCandidate&) = delete;  // Disable default assignment operator
 
+private:
   // ----------------------- Data Members ----------------------------
   float m_energy;
   float m_et;

--- a/Fireworks/Candidates/plugins/FWCandidateECALDetailView.cc
+++ b/Fireworks/Candidates/plugins/FWCandidateECALDetailView.cc
@@ -6,7 +6,6 @@ public:
   FWCandidateECALDetailView() {}
   ~FWCandidateECALDetailView() override {}
 
-private:
   FWCandidateECALDetailView(const FWCandidateECALDetailView&) = delete;                   // stop default
   const FWCandidateECALDetailView& operator=(const FWCandidateECALDetailView&) = delete;  // stop default
 };

--- a/Fireworks/Candidates/plugins/FWCandidateHGCalLegoProxyBuilder.cc
+++ b/Fireworks/Candidates/plugins/FWCandidateHGCalLegoProxyBuilder.cc
@@ -34,11 +34,11 @@ public:
 
   REGISTER_PROXYBUILDER_METHODS();
 
-private:
   // ----------------------- Data Members ----------------------------
   FWCandidateHGCalLegoProxyBuilder(const FWCandidateHGCalLegoProxyBuilder &) = delete;
   const FWCandidateHGCalLegoProxyBuilder &operator=(const FWCandidateHGCalLegoProxyBuilder &) = delete;
 
+private:
   // --------------------- Member Functions --------------------------
   using FWSimpleProxyBuilderTemplate<reco::HGCalMultiCluster>::build;
   void build(const reco::HGCalMultiCluster &, unsigned int, TEveElement &, const FWViewContext *) override;

--- a/Fireworks/Candidates/plugins/FWCandidateLegoProxyBuilder.cc
+++ b/Fireworks/Candidates/plugins/FWCandidateLegoProxyBuilder.cc
@@ -37,11 +37,11 @@ public:
 
   REGISTER_PROXYBUILDER_METHODS();
 
-private:
   // ----------------------- Data Members ----------------------------
   FWCandidateLegoProxyBuilder(const FWCandidateLegoProxyBuilder &) = delete;
   const FWCandidateLegoProxyBuilder &operator=(const FWCandidateLegoProxyBuilder &) = delete;
 
+private:
   // --------------------- Member Functions --------------------------
   using FWSimpleProxyBuilderTemplate<reco::Candidate>::build;
   void build(const reco::Candidate &, unsigned int, TEveElement &, const FWViewContext *) override;

--- a/Fireworks/Candidates/plugins/FWCandidateProxyBuilder.cc
+++ b/Fireworks/Candidates/plugins/FWCandidateProxyBuilder.cc
@@ -36,10 +36,10 @@ public:
 
   REGISTER_PROXYBUILDER_METHODS();
 
-private:
   FWCandidateProxyBuilder(const FWCandidateProxyBuilder&) = delete;                   // stop default
   const FWCandidateProxyBuilder& operator=(const FWCandidateProxyBuilder&) = delete;  // stop default
 
+private:
   using FWSimpleProxyBuilderTemplate<reco::Candidate>::build;
   void build(const reco::Candidate& iData, unsigned int iIndex, TEveElement& oItemHolder, const FWViewContext*) override;
 };

--- a/Fireworks/Candidates/plugins/FWCandidatePtrProxyBuilder.cc
+++ b/Fireworks/Candidates/plugins/FWCandidatePtrProxyBuilder.cc
@@ -27,10 +27,10 @@ public:
 
   REGISTER_PROXYBUILDER_METHODS();
 
-private:
   FWCandidatePtrProxyBuilder(const FWCandidatePtrProxyBuilder&) = delete;                   // stop default
   const FWCandidatePtrProxyBuilder& operator=(const FWCandidatePtrProxyBuilder&) = delete;  // stop default
 
+private:
   using FWSimpleProxyBuilderTemplate<reco::CandidatePtr>::build;
   void build(const reco::CandidatePtr& iData,
              unsigned int iIndex,

--- a/Fireworks/Candidates/plugins/FWCandidateTowerProxyBuilder.h
+++ b/Fireworks/Candidates/plugins/FWCandidateTowerProxyBuilder.h
@@ -29,10 +29,11 @@ protected:
   FWHistSliceSelector* instantiateSliceSelector() override;
   void build(const FWEventItem* iItem, TEveElementList* product, const FWViewContext*) override;
 
-private:
+public:
   FWCandidateTowerProxyBuilder(const FWCandidateTowerProxyBuilder&) = delete;                   // stop default
   const FWCandidateTowerProxyBuilder& operator=(const FWCandidateTowerProxyBuilder&) = delete;  // stop default
 
+private:
   virtual void itemChangedImp(const FWEventItem*);
   // ---------- member data --------------------------------
   FWSimpleProxyHelper m_helper;

--- a/Fireworks/Core/bin/cmsShow.cc
+++ b/Fireworks/Core/bin/cmsShow.cc
@@ -29,7 +29,6 @@ namespace {
 
     void runCommand(edm::MessageLoggerQ::OpCode opcode, void* operand) override;
 
-  private:
     SilentMLscribe(const SilentMLscribe&) = delete;  // stop default
 
     const SilentMLscribe& operator=(const SilentMLscribe&) = delete;  // stop default

--- a/Fireworks/Core/interface/CSGAction.h
+++ b/Fireworks/Core/interface/CSGAction.h
@@ -99,11 +99,11 @@ public:
 
   sigc::signal<void> activated;
 
-private:
   CSGAction(const CSGAction&) = delete;  // stop default
 
   const CSGAction& operator=(const CSGAction&) = delete;  // stop default
 
+private:
   void enableImp();
   void disableImp();
   // ---------- member data --------------------------------

--- a/Fireworks/Core/interface/CSGActionSupervisor.h
+++ b/Fireworks/Core/interface/CSGActionSupervisor.h
@@ -45,13 +45,13 @@ public:
 
   Long_t getToolTipDelay() const;
 
+  CSGActionSupervisor(const CSGActionSupervisor&) = delete;                   // stop default
+  const CSGActionSupervisor& operator=(const CSGActionSupervisor&) = delete;  // stop default
+
 protected:
   std::vector<CSGAction*> m_actionList;
 
 private:
-  CSGActionSupervisor(const CSGActionSupervisor&) = delete;                   // stop default
-  const CSGActionSupervisor& operator=(const CSGActionSupervisor&) = delete;  // stop default
-
   // ---------- member data --------------------------------
 
   Long_t m_tooltipDelay;

--- a/Fireworks/Core/interface/CSGContinuousAction.h
+++ b/Fireworks/Core/interface/CSGContinuousAction.h
@@ -58,11 +58,11 @@ public:
 
   void switchMode();
 
-private:
   CSGContinuousAction(const CSGContinuousAction&) = delete;  // stop default
 
   const CSGContinuousAction& operator=(const CSGContinuousAction&) = delete;  // stop default
 
+private:
   // ---------- member data --------------------------------
   std::string m_imageFileName;
   std::string m_runningImageFileName;

--- a/Fireworks/Core/interface/CmsAnnotation.h
+++ b/Fireworks/Core/interface/CmsAnnotation.h
@@ -36,10 +36,10 @@ public:
   bool getAllowDestroy() const { return fAllowDestroy; }
   void setAllowDestroy(bool x) { fAllowDestroy = x; }
 
-private:
   CmsAnnotation(const CmsAnnotation&) = delete;                   // stop default
   const CmsAnnotation& operator=(const CmsAnnotation&) = delete;  // stop default
 
+private:
   Float_t fPosX;  // x position [0, 1]
   Float_t fPosY;  // y position [0, 1]
 

--- a/Fireworks/Core/interface/CmsShowCommon.h
+++ b/Fireworks/Core/interface/CmsShowCommon.h
@@ -112,7 +112,7 @@ protected:
   bool m_useBeamSpot;
   TEveVector m_externalEventCenter;  //cached
 
-private:
+public:
   CmsShowCommon(const CmsShowCommon&) = delete;                   // stop default
   const CmsShowCommon& operator=(const CmsShowCommon&) = delete;  // stop default
 };

--- a/Fireworks/Core/interface/Context.h
+++ b/Fireworks/Core/interface/Context.h
@@ -98,10 +98,9 @@ namespace fireworks {
     static float caloTransAngle();
     static double caloMaxEta();
 
-  private:
     Context(const Context&) = delete;                   // stop default
     const Context& operator=(const Context&) = delete;  // stop default
-
+  private:
     // ---------- member data --------------------------------
     FWModelChangeManager* m_changeManager;
     FWSelectionManager* m_selectionManager;

--- a/Fireworks/Core/interface/FW3DView.h
+++ b/Fireworks/Core/interface/FW3DView.h
@@ -41,11 +41,11 @@ public:
 
   // ---------- member functions ---------------------------
 
-private:
   FW3DView(const FW3DView&) = delete;  // stop default
 
   const FW3DView& operator=(const FW3DView&) = delete;  // stop default
 
+private:
   // ---------- member data --------------------------------
   TEveCalo3D* m_calo;
 };

--- a/Fireworks/Core/interface/FW3DViewGeometry.h
+++ b/Fireworks/Core/interface/FW3DViewGeometry.h
@@ -51,11 +51,11 @@ public:
   void showHGCalHSc(bool);
   TEveElementList const* const getHGCalHSc() { return m_HGCalHScElements; }
 
-private:
   FW3DViewGeometry(const FW3DViewGeometry&) = delete;  // stop default
 
   const FW3DViewGeometry& operator=(const FW3DViewGeometry&) = delete;  // stop default
 
+private:
   // ---------- member data --------------------------------
 
   TEveElementList* m_muonBarrelElements;

--- a/Fireworks/Core/interface/FWColorManager.h
+++ b/Fireworks/Core/interface/FWColorManager.h
@@ -105,10 +105,11 @@ public:
   //called after all the slots attached to colorsHaveChanged_ are done
   mutable sigc::signal<void> colorsHaveChangedFinished_;
 
-private:
   FWColorManager(const FWColorManager&) = delete;  // stop default
 
   const FWColorManager& operator=(const FWColorManager&) = delete;  // stop default
+
+public:
   void updateColors();
   void initColorTable();
 

--- a/Fireworks/Core/interface/FWCompositeParameter.h
+++ b/Fireworks/Core/interface/FWCompositeParameter.h
@@ -39,11 +39,11 @@ public:
   // ---------- member functions ---------------------------
   void setFrom(const FWConfiguration&) override;
 
-private:
   FWCompositeParameter(const FWCompositeParameter&) = delete;  // stop default
 
   const FWCompositeParameter& operator=(const FWCompositeParameter&) = delete;  // stop default
 
+private:
   // ---------- member data --------------------------------
   unsigned int m_version;
 };

--- a/Fireworks/Core/interface/FWConfigurable.h
+++ b/Fireworks/Core/interface/FWConfigurable.h
@@ -38,11 +38,10 @@ public:
   // ---------- member functions ---------------------------
   virtual void setFrom(const FWConfiguration&) = 0;
 
-private:
   FWConfigurable(const FWConfigurable&) = delete;  // stop default
 
   const FWConfigurable& operator=(const FWConfigurable&) = delete;  // stop default
-
+private:
   // ---------- member data --------------------------------
 };
 

--- a/Fireworks/Core/interface/FWConfigurableParameterizable.h
+++ b/Fireworks/Core/interface/FWConfigurableParameterizable.h
@@ -40,11 +40,11 @@ public:
   // ---------- member functions ---------------------------
   void setFrom(const FWConfiguration&) override;
 
-private:
   FWConfigurableParameterizable(const FWConfigurableParameterizable&) = delete;  // stop default
 
   const FWConfigurableParameterizable& operator=(const FWConfigurableParameterizable&) = delete;  // stop default
 
+private:
   // ---------- member data --------------------------------
   unsigned int m_version;
 };

--- a/Fireworks/Core/interface/FWConfigurationManager.h
+++ b/Fireworks/Core/interface/FWConfigurationManager.h
@@ -50,10 +50,10 @@ public:
   void setIgnore() { m_ignore = true; }
   bool getIgnore() const { return m_ignore; }
 
-private:
   FWConfigurationManager(const FWConfigurationManager&) = delete;  // stop default
 
   const FWConfigurationManager& operator=(const FWConfigurationManager&) = delete;  // stop default
+private:
   void readFromOldFile(const std::string&) const;
 
   // ---------- member data --------------------------------

--- a/Fireworks/Core/interface/FWCustomIconsButton.h
+++ b/Fireworks/Core/interface/FWCustomIconsButton.h
@@ -58,14 +58,14 @@ public:
   const TGPicture* disabledIcon() const { return m_disabledIcon; }
   const TGPicture* bellowMouseIcon() const { return m_belowMouseIcon; }
 
-protected:
-  void DoRedraw() override;
-
-private:
   FWCustomIconsButton(const FWCustomIconsButton&) = delete;  // stop default
 
   const FWCustomIconsButton& operator=(const FWCustomIconsButton&) = delete;  // stop default
 
+protected:
+  void DoRedraw() override;
+
+private:
   // ---------- member data --------------------------------
   const TGPicture* m_upIcon;
   const TGPicture* m_downIcon;

--- a/Fireworks/Core/interface/FWDetailViewBase.h
+++ b/Fireworks/Core/interface/FWDetailViewBase.h
@@ -49,13 +49,13 @@ public:
   void setItem(const FWEventItem* x) { m_item = x; }
   const fireworks::Context& context() const;
 
+  FWDetailViewBase(const FWDetailViewBase&) = delete;                   // stop default
+  const FWDetailViewBase& operator=(const FWDetailViewBase&) = delete;  // stop default
+
 protected:
   FWDetailViewBase(const std::type_info&);
 
 private:
-  FWDetailViewBase(const FWDetailViewBase&) = delete;                   // stop default
-  const FWDetailViewBase& operator=(const FWDetailViewBase&) = delete;  // stop default
-
   virtual void build(const FWModelId&, const void*) = 0;
 
   const FWEventItem* m_item;

--- a/Fireworks/Core/interface/FWDetailViewManager.h
+++ b/Fireworks/Core/interface/FWDetailViewManager.h
@@ -57,13 +57,13 @@ public:
     ViewFrame& operator=(ViewFrame&&) = default;
   };
 
+  FWDetailViewManager(const FWDetailViewManager&) = delete;                   // stop default
+  const FWDetailViewManager& operator=(const FWDetailViewManager&) = delete;  // stop default
+
 protected:
   fireworks::Context* m_context;
 
 private:
-  FWDetailViewManager(const FWDetailViewManager&) = delete;                   // stop default
-  const FWDetailViewManager& operator=(const FWDetailViewManager&) = delete;  // stop default
-
   std::vector<std::string> findViewersFor(const std::string&) const;
 
   typedef std::vector<ViewFrame> vViews_t;

--- a/Fireworks/Core/interface/FWDigitSetProxyBuilder.h
+++ b/Fireworks/Core/interface/FWDigitSetProxyBuilder.h
@@ -41,6 +41,10 @@ public:
 
   // ---------- member functions ---------------------------
 
+  FWDigitSetProxyBuilder(const FWDigitSetProxyBuilder&) = delete;  // stop default
+
+  const FWDigitSetProxyBuilder& operator=(const FWDigitSetProxyBuilder&) = delete;  // stop default
+
 protected:
   // AMT: temproary structure since TEveBoxSet::BFreeBox_t is protected
   // this workaround should be  removed in next root patch
@@ -56,10 +60,6 @@ protected:
   TEveBoxSet* getBoxSet() const { return m_boxSet; }
 
 private:
-  FWDigitSetProxyBuilder(const FWDigitSetProxyBuilder&) = delete;  // stop default
-
-  const FWDigitSetProxyBuilder& operator=(const FWDigitSetProxyBuilder&) = delete;  // stop default
-
   // ---------- member data --------------------------------
 
   void modelChanges(const FWModelIds&, Product*) override;

--- a/Fireworks/Core/interface/FWEDProductRepresentationChecker.h
+++ b/Fireworks/Core/interface/FWEDProductRepresentationChecker.h
@@ -41,11 +41,11 @@ public:
 
   // ---------- member functions ---------------------------
 
-private:
   FWEDProductRepresentationChecker(const FWEDProductRepresentationChecker&) = delete;  // stop default
 
   const FWEDProductRepresentationChecker& operator=(const FWEDProductRepresentationChecker&) = delete;  // stop default
 
+private:
   // ---------- member data --------------------------------
   const std::string m_typeidName;
 };

--- a/Fireworks/Core/interface/FWEnumParameter.h
+++ b/Fireworks/Core/interface/FWEnumParameter.h
@@ -54,10 +54,10 @@ public:
 
   const std::map<Long_t, std::string>& entryMap() const { return m_enumEntries; }
 
-private:
   FWEnumParameter(const FWEnumParameter&) = delete;                   // stop default
   const FWEnumParameter& operator=(const FWEnumParameter&) = delete;  // stop default
 
+private:
   // ---------- member data --------------------------------
   std::map<Long_t, std::string> m_enumEntries;
 };

--- a/Fireworks/Core/interface/FWEnumParameterSetter.h
+++ b/Fireworks/Core/interface/FWEnumParameterSetter.h
@@ -47,10 +47,10 @@ public:
 
   TGComboBox* getWidget() { return m_widget; }
 
-private:
   FWEnumParameterSetter(const FWEnumParameterSetter&) = delete;                   // stop default
   const FWEnumParameterSetter& operator=(const FWEnumParameterSetter&) = delete;  // stop default
 
+private:
   void attach(FWParameterBase*) override;
 
   // ---------- member data --------------------------------

--- a/Fireworks/Core/interface/FWEveLegoView.h
+++ b/Fireworks/Core/interface/FWEveLegoView.h
@@ -36,11 +36,11 @@ public:
 
   // ---------- member functions ---------------------------
 
-private:
   FWEveLegoView(const FWEveLegoView&) = delete;  // stop default
 
   const FWEveLegoView& operator=(const FWEveLegoView&) = delete;  // stop default
 
+private:
   // ---------- member data --------------------------------
   TEveStraightLineSet* m_boundaries;
 };

--- a/Fireworks/Core/interface/FWEveView.h
+++ b/Fireworks/Core/interface/FWEveView.h
@@ -108,10 +108,11 @@ protected:
 protected:
   const fireworks::Context* m_context;
 
-private:
+public:
   FWEveView(const FWEveView&) = delete;                   // stop default
   const FWEveView& operator=(const FWEveView&) = delete;  // stop default
 
+private:
   // ---------- member data --------------------------------
 
   FWTEveViewer* m_viewer;

--- a/Fireworks/Core/interface/FWEveViewManager.h
+++ b/Fireworks/Core/interface/FWEveViewManager.h
@@ -80,10 +80,11 @@ protected:
   void modelChangesDone() override;
   void colorsChanged() override;
 
-private:
+public:
   FWEveViewManager(const FWEveViewManager&) = delete;                   // stop default
   const FWEveViewManager& operator=(const FWEveViewManager&) = delete;  // stop default
 
+private:
   FWViewBase* buildView(TEveWindowSlot* iParent, const std::string& type);
   FWEveView* finishViewCreate(std::shared_ptr<FWEveView>);
 

--- a/Fireworks/Core/interface/FWEventAnnotation.h
+++ b/Fireworks/Core/interface/FWEventAnnotation.h
@@ -22,10 +22,10 @@ public:
   void setLevel(long x);
   void setEvent();
 
-private:
   FWEventAnnotation(const FWEventAnnotation&) = delete;                   // stop default
   const FWEventAnnotation& operator=(const FWEventAnnotation&) = delete;  // stop default
 
+private:
   void updateOverlayText();
 
   int m_level;

--- a/Fireworks/Core/interface/FWEventItemsManager.h
+++ b/Fireworks/Core/interface/FWEventItemsManager.h
@@ -74,11 +74,12 @@ public:
   sigc::signal<void, const FWEventItem*> removingItem_;
   sigc::signal<void> goingToClearItems_;
 
-private:
-  void removeItem(const FWEventItem*);
   FWEventItemsManager(const FWEventItemsManager&) = delete;  // stop default
 
   const FWEventItemsManager& operator=(const FWEventItemsManager&) = delete;  // stop default
+
+private:
+  void removeItem(const FWEventItem*);
 
   // ---------- member data --------------------------------
   std::vector<FWEventItem*> m_items;

--- a/Fireworks/Core/interface/FWFileEntry.h
+++ b/Fireworks/Core/interface/FWFileEntry.h
@@ -83,10 +83,10 @@ public:
   void NewEventItemCallIn(const FWEventItem* it);
   void RemovingEventItemCallIn(const FWEventItem* it);
 
-private:
   FWFileEntry(const FWFileEntry&) = delete;                   // stop default
   const FWFileEntry& operator=(const FWFileEntry&) = delete;  // stop default
 
+private:
   void runFilter(Filter* fe, const FWEventItemsManager* eiMng);
   bool filterEventsWithCustomParser(Filter* filter);
 

--- a/Fireworks/Core/interface/FWGLEventHandler.h
+++ b/Fireworks/Core/interface/FWGLEventHandler.h
@@ -26,10 +26,10 @@ public:
 
   void setViewer(FWEveView *ev) { m_viewer = ev; }
 
-private:
   FWGLEventHandler(const FWGLEventHandler &) = delete;                   // stop default
   const FWGLEventHandler &operator=(const FWGLEventHandler &) = delete;  // stop default
 
+private:
   FWEveView *m_viewer;
 };
 

--- a/Fireworks/Core/interface/FWGUIManager.h
+++ b/Fireworks/Core/interface/FWGUIManager.h
@@ -214,10 +214,10 @@ public:
   sigc::signal<void> changedEventEntry_;
   sigc::signal<void, Float_t> changedDelayBetweenEvents_;
 
-private:
   FWGUIManager(const FWGUIManager&) = delete;                   // stop default
   const FWGUIManager& operator=(const FWGUIManager&) = delete;  // stop default
 
+private:
   TEveWindow* getSwapCandidate();
 
   void newItem(const FWEventItem*);

--- a/Fireworks/Core/interface/FWGenericParameter.h
+++ b/Fireworks/Core/interface/FWGenericParameter.h
@@ -74,10 +74,10 @@ public:
 
   sigc::signal<void, T> changed_;
 
-private:
   FWGenericParameter(const FWGenericParameter&) = delete;                   // stop default
   const FWGenericParameter& operator=(const FWGenericParameter&) = delete;  // stop default
 
+private:
   // ---------- member data --------------------------------
 
   T m_value;

--- a/Fireworks/Core/interface/FWGlimpseView.h
+++ b/Fireworks/Core/interface/FWGlimpseView.h
@@ -44,10 +44,10 @@ public:
 
   // ---------- static member functions --------------------
 
-private:
   FWGlimpseView(const FWGlimpseView&) = delete;                   // stop default
   const FWGlimpseView& operator=(const FWGlimpseView&) = delete;  // stop default
 
+private:
   void createAxis();
   void showAxes();
   void showCylinder();

--- a/Fireworks/Core/interface/FWHFView.h
+++ b/Fireworks/Core/interface/FWHFView.h
@@ -37,7 +37,6 @@ public:
 
   // ---------- member functions ---------------------------
 
-private:
   FWHFView(const FWHFView&) = delete;  // stop default
 
   const FWHFView& operator=(const FWHFView&) = delete;  // stop default

--- a/Fireworks/Core/interface/FWHLTValidator.h
+++ b/Fireworks/Core/interface/FWHLTValidator.h
@@ -25,10 +25,10 @@ public:
                    const char* iEnd,
                    std::vector<std::pair<std::shared_ptr<std::string>, std::string> >& oOptions) const override;
 
-private:
   FWHLTValidator(const FWHLTValidator&) = delete;                   // stop default
   const FWHLTValidator& operator=(const FWHLTValidator&) = delete;  // stop default
 
+private:
   // ---------- member data --------------------------------
   std::string m_process;
   mutable std::vector<std::string> m_triggerNames;

--- a/Fireworks/Core/interface/FWISpyView.h
+++ b/Fireworks/Core/interface/FWISpyView.h
@@ -38,7 +38,6 @@ public:
 
   // ---------- member functions ---------------------------
 
-private:
   FWISpyView(const FWISpyView&) = delete;  // stop default
 
   const FWISpyView& operator=(const FWISpyView&) = delete;  // stop default

--- a/Fireworks/Core/interface/FWIntValueListener.h
+++ b/Fireworks/Core/interface/FWIntValueListener.h
@@ -13,7 +13,6 @@ public:
   void setValueImp(Int_t entry) override;
   sigc::signal<void, Int_t> valueChanged_;
 
-private:
   FWIntValueListener(const FWIntValueListener&) = delete;                   // stop default
   const FWIntValueListener& operator=(const FWIntValueListener&) = delete;  // stop default
 };

--- a/Fireworks/Core/interface/FWInteractionList.h
+++ b/Fireworks/Core/interface/FWInteractionList.h
@@ -49,11 +49,11 @@ public:
   void modelChanges(const std::set<FWModelId>&);
   void itemChanged();
 
-private:
   FWInteractionList(const FWInteractionList&) = delete;  // stop default
 
   const FWInteractionList& operator=(const FWInteractionList&) = delete;  // stop default
 
+private:
   // ---------- member data --------------------------------
 
   std::vector<TEveCompound*> m_compounds;

--- a/Fireworks/Core/interface/FWItemAccessorFactory.h
+++ b/Fireworks/Core/interface/FWItemAccessorFactory.h
@@ -45,7 +45,6 @@ public:
 
   // ---------- member functions ---------------------------
 
-private:
   FWItemAccessorFactory(const FWItemAccessorFactory &) = delete;  // stop default
 
   const FWItemAccessorFactory &operator=(const FWItemAccessorFactory &) = delete;  // stop default

--- a/Fireworks/Core/interface/FWItemRandomAccessor.h
+++ b/Fireworks/Core/interface/FWItemRandomAccessor.h
@@ -45,7 +45,7 @@ protected:
   const TClass *m_modelType;
   mutable void *m_data;
 
-private:
+public:
   FWItemRandomAccessorBase(const FWItemRandomAccessorBase &) = delete;  // stop default
 
   const FWItemRandomAccessorBase &operator=(const FWItemRandomAccessorBase &) = delete;  // stop default

--- a/Fireworks/Core/interface/FWMagField.h
+++ b/Fireworks/Core/interface/FWMagField.h
@@ -44,10 +44,10 @@ public:
   void checkFieldInfo(const edm::EventBase*);
   void setFFFieldMag(float);
 
-private:
   FWMagField(const FWMagField&) = delete;                   // stop default
   const FWMagField& operator=(const FWMagField&) = delete;  // stop default
 
+private:
   ESource m_source;
   float m_userField;
   float m_eventField;

--- a/Fireworks/Core/interface/FWModelChangeManager.h
+++ b/Fireworks/Core/interface/FWModelChangeManager.h
@@ -52,11 +52,11 @@ public:
   void newItemSlot(FWEventItem*);
   void itemsGoingToBeClearedSlot(void);
 
-private:
   FWModelChangeManager(const FWModelChangeManager&) = delete;  // stop default
 
   const FWModelChangeManager& operator=(const FWModelChangeManager&) = delete;  // stop default
 
+private:
   // ---------- member data --------------------------------
   unsigned int m_depth;
   std::vector<FWModelIds> m_changes;

--- a/Fireworks/Core/interface/FWModelExpressionSelector.h
+++ b/Fireworks/Core/interface/FWModelExpressionSelector.h
@@ -40,7 +40,6 @@ public:
 
   // ---------- member functions ---------------------------
 
-private:
   FWModelExpressionSelector(const FWModelExpressionSelector&) = delete;  // stop default
 
   const FWModelExpressionSelector& operator=(const FWModelExpressionSelector&) = delete;  // stop default

--- a/Fireworks/Core/interface/FWNavigatorBase.h
+++ b/Fireworks/Core/interface/FWNavigatorBase.h
@@ -55,9 +55,10 @@ public:
 
   sigc::signal<void> newEvent_;
 
-private:
   FWNavigatorBase(const FWNavigatorBase&) = delete;                   // stop default
   const FWNavigatorBase& operator=(const FWNavigatorBase&) = delete;  // stop default
+
+private:
   // ---------- member data --------------------------------
   // entry is an event index nubmer which runs from 0 to
   // #events or #selected_events depending on if we filter

--- a/Fireworks/Core/interface/FWParameterBase.h
+++ b/Fireworks/Core/interface/FWParameterBase.h
@@ -43,10 +43,9 @@ public:
   // ---------- member functions ---------------------------
   //virtual void setFrom(const FWConfiguration&) = 0;
 
-private:
   FWParameterBase(const FWParameterBase&) = delete;                   // stop default
   const FWParameterBase& operator=(const FWParameterBase&) = delete;  // stop default
-
+private:
   // ---------- member data --------------------------------
 
   std::string m_name;

--- a/Fireworks/Core/interface/FWParameterSetterBase.h
+++ b/Fireworks/Core/interface/FWParameterSetterBase.h
@@ -50,11 +50,12 @@ protected:
   void update() const;
   FWParameterSetterEditorBase* frame() const { return m_frame; }
 
-private:
-  virtual void attach(FWParameterBase*) = 0;
-
+public:
   FWParameterSetterBase(const FWParameterSetterBase&) = delete;                   // stop default
   const FWParameterSetterBase& operator=(const FWParameterSetterBase&) = delete;  // stop default
+
+private:
+  virtual void attach(FWParameterBase*) = 0;
 
   // ---------- member data --------------------------------
 

--- a/Fireworks/Core/interface/FWParameterSetterEditorBase.h
+++ b/Fireworks/Core/interface/FWParameterSetterEditorBase.h
@@ -37,11 +37,10 @@ public:
 
   virtual void updateEditor();
 
-private:
   FWParameterSetterEditorBase(const FWParameterSetterEditorBase&) = delete;  // stop default
 
   const FWParameterSetterEditorBase& operator=(const FWParameterSetterEditorBase&) = delete;  // stop default
-
+private:
   // ---------- member data --------------------------------
 };
 

--- a/Fireworks/Core/interface/FWParameterizable.h
+++ b/Fireworks/Core/interface/FWParameterizable.h
@@ -43,11 +43,10 @@ public:
   //base class implementation does not take ownership of added parameters
   void add(FWParameterBase*);
 
-private:
   FWParameterizable(const FWParameterizable&) = delete;  // stop default
 
   const FWParameterizable& operator=(const FWParameterizable&) = delete;  // stop default
-
+private:
   // ---------- member data --------------------------------
   std::vector<FWParameterBase*> m_parameters;
 };

--- a/Fireworks/Core/interface/FWProxyBuilderTemplate.h
+++ b/Fireworks/Core/interface/FWProxyBuilderTemplate.h
@@ -41,11 +41,12 @@ public:
 protected:
   const T& modelData(int index) { return *reinterpret_cast<const T*>(m_helper.offsetObject(item()->modelData(index))); }
 
-private:
+public:
   FWProxyBuilderTemplate(const FWProxyBuilderTemplate&) = delete;  // stop default
 
   const FWProxyBuilderTemplate& operator=(const FWProxyBuilderTemplate&) = delete;  // stop default
 
+private:
   virtual void itemChangedImp(const FWEventItem* iItem) {
     if (iItem)
       m_helper.itemChanged(iItem);

--- a/Fireworks/Core/interface/FWRPZView.h
+++ b/Fireworks/Core/interface/FWRPZView.h
@@ -63,10 +63,10 @@ public:
   void shiftOrigin(TEveVector& center);
   void resetOrigin();
 
-private:
   FWRPZView(const FWRPZView&) = delete;                   // stop default
   const FWRPZView& operator=(const FWRPZView&) = delete;  // stop default
 
+private:
   void doPreScaleDistortion();
   void doFishEyeDistortion();
   void doCompression(bool);

--- a/Fireworks/Core/interface/FWRepresentationCheckerBase.h
+++ b/Fireworks/Core/interface/FWRepresentationCheckerBase.h
@@ -46,11 +46,11 @@ public:
 
   // ---------- member functions ---------------------------
 
-private:
   FWRepresentationCheckerBase(const FWRepresentationCheckerBase&) = delete;  // stop default
 
   const FWRepresentationCheckerBase& operator=(const FWRepresentationCheckerBase&) = delete;  // stop default
 
+private:
   // ---------- member data --------------------------------
   const std::string m_purpose;
   const unsigned int m_bitPackedViews;

--- a/Fireworks/Core/interface/FWSelectionManager.h
+++ b/Fireworks/Core/interface/FWSelectionManager.h
@@ -53,6 +53,9 @@ public:
   sigc::signal<void, const FWSelectionManager&> selectionChanged_;
   sigc::signal<void, const FWSelectionManager&> itemSelectionChanged_;
 
+  FWSelectionManager(const FWSelectionManager&) = delete;  // stop default
+
+  const FWSelectionManager& operator=(const FWSelectionManager&) = delete;  // stop default
 private:
   void finishedAllSelections();
   void select(const FWModelId& iId);
@@ -61,10 +64,6 @@ private:
 
   void selectItem(FWEventItem*);
   void unselectItem(FWEventItem*);
-
-  FWSelectionManager(const FWSelectionManager&) = delete;  // stop default
-
-  const FWSelectionManager& operator=(const FWSelectionManager&) = delete;  // stop default
 
   // ---------- member data --------------------------------
   FWModelChangeManager* m_changeManager;

--- a/Fireworks/Core/interface/FWSimpleProxyBuilder.h
+++ b/Fireworks/Core/interface/FWSimpleProxyBuilder.h
@@ -58,11 +58,11 @@ protected:
   void clean() override;
   FWSimpleProxyHelper m_helper;
 
-private:
+public:
   FWSimpleProxyBuilder(const FWSimpleProxyBuilder&) = delete;  // stop default
 
   const FWSimpleProxyBuilder& operator=(const FWSimpleProxyBuilder&) = delete;  // stop default
-
+private:
   virtual void itemChangedImp(const FWEventItem*);
 
   bool visibilityModelChanges(const FWModelId&, TEveElement*, FWViewType::EType, const FWViewContext*) override;

--- a/Fireworks/Core/interface/FWSimpleProxyBuilderTemplate.h
+++ b/Fireworks/Core/interface/FWSimpleProxyBuilderTemplate.h
@@ -75,7 +75,7 @@ protected:
         "implemented by inherited class");
   };
 
-private:
+public:
   FWSimpleProxyBuilderTemplate(const FWSimpleProxyBuilderTemplate&) = delete;  // stop default
 
   const FWSimpleProxyBuilderTemplate& operator=(const FWSimpleProxyBuilderTemplate&) = delete;  // stop default

--- a/Fireworks/Core/interface/FWSimpleRepresentationChecker.h
+++ b/Fireworks/Core/interface/FWSimpleRepresentationChecker.h
@@ -43,11 +43,11 @@ public:
   // ---------- member functions ---------------------------
   static bool inheritsFrom(const edm::TypeWithDict& iChild, const std::string& iParentTypeName, unsigned int& distance);
 
-private:
   FWSimpleRepresentationChecker(const FWSimpleRepresentationChecker&) = delete;  // stop default
 
   const FWSimpleRepresentationChecker& operator=(const FWSimpleRepresentationChecker&) = delete;  // stop default
 
+private:
   // ---------- member data --------------------------------
   const std::string m_typeidName;
 };

--- a/Fireworks/Core/interface/FWSummaryManager.h
+++ b/Fireworks/Core/interface/FWSummaryManager.h
@@ -62,11 +62,11 @@ public:
 
   void colorsChanged();
 
-private:
   FWSummaryManager(const FWSummaryManager&) = delete;  // stop default
 
   const FWSummaryManager& operator=(const FWSummaryManager&) = delete;  // stop default
 
+private:
   void selectionChanged(const FWSelectionManager&);
   void newItem(FWEventItem* iItem);
   void itemChanged(const FWEventItem*);

--- a/Fireworks/Core/interface/FWTEveViewer.h
+++ b/Fireworks/Core/interface/FWTEveViewer.h
@@ -53,11 +53,11 @@ public:
 
   std::future<int> CaptureAndSaveImage(const TString& file, int height = -1);
 
-private:
   FWTEveViewer(const FWTEveViewer&) = delete;  // stop default
 
   const FWTEveViewer& operator=(const FWTEveViewer&) = delete;  // stop default
 
+private:
   void spawn_image_thread();
 
   // ---------- member data --------------------------------

--- a/Fireworks/Core/interface/FWTGLViewer.h
+++ b/Fireworks/Core/interface/FWTGLViewer.h
@@ -50,11 +50,11 @@ public:
 
   TGLFBO* GenerateFbo(Int_t w, Int_t h, Float_t pixel_object_scale);
 
-private:
   FWTGLViewer(const FWTGLViewer&) = delete;  // stop default
 
   const FWTGLViewer& operator=(const FWTGLViewer&) = delete;  // stop default
 
+private:
   // ---------- member data --------------------------------
 
   TGLFBO* m_fbo;

--- a/Fireworks/Core/interface/FWTableView.h
+++ b/Fireworks/Core/interface/FWTableView.h
@@ -77,7 +77,6 @@ public:
   void deleteColumn();
   void modifyColumn();
 
-private:
   FWTableView(const FWTableView &) = delete;                   // stop default
   const FWTableView &operator=(const FWTableView &) = delete;  // stop default
 

--- a/Fireworks/Core/interface/FWTableViewTableManager.h
+++ b/Fireworks/Core/interface/FWTableViewTableManager.h
@@ -114,7 +114,7 @@ protected:
   // bool m_sortOrder;
   mutable bool m_caughtExceptionInCellRender;
 
-private:
+public:
   FWTableViewTableManager(const FWTableViewTableManager &) = delete;                   // stop default
   const FWTableViewTableManager &operator=(const FWTableViewTableManager &) = delete;  // stop default
 };

--- a/Fireworks/Core/interface/FWTriggerTableView.h
+++ b/Fireworks/Core/interface/FWTriggerTableView.h
@@ -69,10 +69,11 @@ protected:
 
   virtual void fillTable(fwlite::Event* event) = 0;
 
-private:
+public:
   FWTriggerTableView(const FWTriggerTableView&) = delete;                   // stop default
   const FWTriggerTableView& operator=(const FWTriggerTableView&) = delete;  // stop default
 
+private:
   bool isProcessValid() const;
   void populateController(ViewerParameterGUI&) const override;
 

--- a/Fireworks/Core/interface/FWTriggerTableViewTableManager.h
+++ b/Fireworks/Core/interface/FWTriggerTableViewTableManager.h
@@ -55,7 +55,7 @@ protected:
   TGGC *m_graphicsContext;
   FWTextTableCellRenderer *m_renderer;
 
-private:
+public:
   FWTriggerTableViewTableManager(const FWTriggerTableViewTableManager &) = delete;                   // stop default
   const FWTriggerTableViewTableManager &operator=(const FWTriggerTableViewTableManager &) = delete;  // stop default
 };

--- a/Fireworks/Core/interface/FWViewBase.h
+++ b/Fireworks/Core/interface/FWViewBase.h
@@ -60,7 +60,7 @@ protected:
   ~FWViewBase() override;
   FWViewType m_type;
 
-private:
+public:
   FWViewBase(const FWViewBase&) = delete;  // stop default
 
   const FWViewBase& operator=(const FWViewBase&) = delete;  // stop default

--- a/Fireworks/Core/interface/FWViewContext.h
+++ b/Fireworks/Core/interface/FWViewContext.h
@@ -41,11 +41,11 @@ public:
 
   mutable sigc::signal<void, const FWViewContext*> scaleChanged_;
 
-private:
   FWViewContext(const FWViewContext&) = delete;  // stop default
 
   const FWViewContext& operator=(const FWViewContext&) = delete;  // stop default
 
+private:
   // ---------- member data --------------------------------
 
   FWViewEnergyScale* m_energyScale;

--- a/Fireworks/Core/interface/FWViewContextMenuHandlerBase.h
+++ b/Fireworks/Core/interface/FWViewContextMenuHandlerBase.h
@@ -55,12 +55,11 @@ public:
     */
   virtual void select(int iEntryIndex, const FWModelId& id, int iX, int iY) = 0;
 
-protected:
-private:
   FWViewContextMenuHandlerBase(const FWViewContextMenuHandlerBase&) = delete;  // stop default
 
   const FWViewContextMenuHandlerBase& operator=(const FWViewContextMenuHandlerBase&) = delete;  // stop default
 
+private:
   ///Called when have to add entries to the context menu
   virtual void init(MenuEntryAdder&, const FWModelId& id) = 0;
 };

--- a/Fireworks/Core/interface/FWViewContextMenuHandlerGL.h
+++ b/Fireworks/Core/interface/FWViewContextMenuHandlerGL.h
@@ -14,10 +14,10 @@ public:
   ~FWViewContextMenuHandlerGL() override {}
   void select(int iEntryIndex, const FWModelId &id, int iX, int iY) override;
 
-private:
   FWViewContextMenuHandlerGL(const FWViewContextMenuHandlerGL &) = delete;                   // stop default
   const FWViewContextMenuHandlerGL &operator=(const FWViewContextMenuHandlerGL &) = delete;  // stop default
 
+private:
   void init(FWViewContextMenuHandlerBase::MenuEntryAdder &, const FWModelId &id) override;
 
   FWEveView *m_view;

--- a/Fireworks/Core/interface/FWViewEnergyScale.h
+++ b/Fireworks/Core/interface/FWViewEnergyScale.h
@@ -62,10 +62,11 @@ protected:
   FWDoubleParameter m_maxTowerHeight;
   FWBoolParameter m_plotEt;
 
-private:
+public:
   FWViewEnergyScale(const FWViewEnergyScale&) = delete;                   // stop default
   const FWViewEnergyScale& operator=(const FWViewEnergyScale&) = delete;  // stop default
 
+private:
   float calculateScaleFactor(float iMaxVal, bool isLego) const;
 
   const std::string m_name;

--- a/Fireworks/Core/interface/FWViewGeometryList.h
+++ b/Fireworks/Core/interface/FWViewGeometryList.h
@@ -47,11 +47,12 @@ protected:
 
   void addToCompound(TEveElement* el, FWGeomColorIndex idx, bool applyTransp = true) const;
 
-private:
+public:
   FWViewGeometryList(const FWViewGeometryList&) = delete;  // stop default
 
   const FWViewGeometryList& operator=(const FWViewGeometryList&) = delete;  // stop default
 
+private:
   // ---------- member data --------------------------------
   sigc::connection m_transpConnection;
   sigc::connection m_colorConnection;

--- a/Fireworks/Core/interface/FWViewManagerBase.h
+++ b/Fireworks/Core/interface/FWViewManagerBase.h
@@ -85,11 +85,12 @@ protected:
   FWModelChangeManager& changeManager() const;
   FWColorManager& colorManager() const;
 
-private:
+public:
   FWViewManagerBase(const FWViewManagerBase&) = delete;  // stop default
 
   const FWViewManagerBase& operator=(const FWViewManagerBase&) = delete;  // stop default
 
+private:
   // ---------- member data --------------------------------
   const fireworks::Context* m_context;
 

--- a/Fireworks/Core/interface/FWViewManagerManager.h
+++ b/Fireworks/Core/interface/FWViewManagerManager.h
@@ -51,11 +51,11 @@ public:
   void eventBegin();
   void eventEnd();
 
-private:
   FWViewManagerManager(const FWViewManagerManager&) = delete;  // stop default
 
   const FWViewManagerManager& operator=(const FWViewManagerManager&) = delete;  // stop default
 
+private:
   // ---------- member data --------------------------------
   std::vector<std::shared_ptr<FWViewManagerBase> > m_viewManagers;
   FWModelChangeManager* m_changeManager;

--- a/Fireworks/Core/src/CmsShowTaskExecutor.h
+++ b/Fireworks/Core/src/CmsShowTaskExecutor.h
@@ -46,11 +46,12 @@ protected:
   void doNextTaskImp() override;
   bool moreTasksAvailable() override;
 
-private:
+public:
   CmsShowTaskExecutor(const CmsShowTaskExecutor&) = delete;  // stop default
 
   const CmsShowTaskExecutor& operator=(const CmsShowTaskExecutor&) = delete;  // stop default
 
+private:
   // ---------- member data --------------------------------
   std::deque<TaskFunctor> m_tasks;
 };

--- a/Fireworks/Core/src/CmsShowTaskExecutorBase.h
+++ b/Fireworks/Core/src/CmsShowTaskExecutorBase.h
@@ -48,11 +48,11 @@ protected:
   virtual void doNextTaskImp() = 0;
   virtual bool moreTasksAvailable() = 0;
 
-private:
+public:
   CmsShowTaskExecutorBase(const CmsShowTaskExecutorBase&) = delete;  // stop default
 
   const CmsShowTaskExecutorBase& operator=(const CmsShowTaskExecutorBase&) = delete;  // stop default
-
+private:
   // ---------- member data --------------------------------
   //TTimer* m_timer;
   CmsShowTaskTimer* m_taskTimer;

--- a/Fireworks/Core/src/CmsShowTaskTimer.h
+++ b/Fireworks/Core/src/CmsShowTaskTimer.h
@@ -38,11 +38,11 @@ public:
   // ---------- member functions ---------------------------
   Bool_t Notify() override;
 
-private:
   CmsShowTaskTimer(const CmsShowTaskTimer&) = delete;  // stop default
 
   const CmsShowTaskTimer& operator=(const CmsShowTaskTimer&) = delete;  // stop default
 
+private:
   // ---------- member data --------------------------------
   CmsShowTaskExecutorBase* m_taskExec;
 };

--- a/Fireworks/Core/src/FW3DViewBase.cc
+++ b/Fireworks/Core/src/FW3DViewBase.cc
@@ -53,11 +53,12 @@ namespace {
   const float fgColor[4] = {1.0, 0.6, 0.2, 0.5};
 
   class Clipsi : public TGLClip {
-  private:
-    TGLRnrCtx* m_rnrCtx;
+  public:
     Clipsi(const Clipsi&) = delete;             // Not implemented
     Clipsi& operator=(const Clipsi&) = delete;  // Not implemented
 
+  private:
+    TGLRnrCtx* m_rnrCtx;
     TGLVertex3 vtx[4];
     TGLVertex3 appexOffset;
 

--- a/Fireworks/Core/src/FWBoolParameterSetter.h
+++ b/Fireworks/Core/src/FWBoolParameterSetter.h
@@ -43,11 +43,11 @@ public:
   void setEnabled(bool) override;
   void doUpdate();
 
-private:
   FWBoolParameterSetter(const FWBoolParameterSetter&) = delete;  // stop default
 
   const FWBoolParameterSetter& operator=(const FWBoolParameterSetter&) = delete;  // stop default
 
+private:
   // ---------- member data --------------------------------
   FWBoolParameter* m_param;
   TGCheckButton* m_widget;

--- a/Fireworks/Core/src/FWBoxIconBase.h
+++ b/Fireworks/Core/src/FWBoxIconBase.h
@@ -38,11 +38,11 @@ public:
 
   // ---------- member functions ---------------------------
 
-private:
   FWBoxIconBase(const FWBoxIconBase&) = delete;  // stop default
 
   const FWBoxIconBase& operator=(const FWBoxIconBase&) = delete;  // stop default
 
+private:
   virtual void drawInsideBox(Drawable_t iID, GContext_t iContext, int iX, int iY, unsigned int iSize) const = 0;
 
   // ---------- member data --------------------------------

--- a/Fireworks/Core/src/FWBoxIconButton.h
+++ b/Fireworks/Core/src/FWBoxIconButton.h
@@ -45,11 +45,12 @@ public:
 protected:
   void DoRedraw() override;
 
-private:
+public:
   FWBoxIconButton(const FWBoxIconButton&) = delete;  // stop default
 
   const FWBoxIconButton& operator=(const FWBoxIconButton&) = delete;  // stop default
 
+private:
   // ---------- member data --------------------------------
   FWBoxIconBase* m_iconBase;
 };

--- a/Fireworks/Core/src/FWCheckBoxIcon.h
+++ b/Fireworks/Core/src/FWCheckBoxIcon.h
@@ -39,11 +39,11 @@ public:
   // ---------- member functions ---------------------------
   void setChecked(bool iChecked) { m_checked = iChecked; }
 
-private:
   FWCheckBoxIcon(const FWCheckBoxIcon&) = delete;  // stop default
 
   const FWCheckBoxIcon& operator=(const FWCheckBoxIcon&) = delete;  // stop default
 
+private:
   void drawInsideBox(Drawable_t iID, GContext_t iContext, int iX, int iY, unsigned int iSize) const override;
 
   // ---------- member data --------------------------------

--- a/Fireworks/Core/src/FWCollectionSummaryModelCellRenderer.h
+++ b/Fireworks/Core/src/FWCollectionSummaryModelCellRenderer.h
@@ -46,12 +46,12 @@ public:
 
   ClickHit clickHit(int iX, int iY) const;
 
-private:
   FWCollectionSummaryModelCellRenderer(const FWCollectionSummaryModelCellRenderer&) = delete;  // stop default
 
   const FWCollectionSummaryModelCellRenderer& operator=(const FWCollectionSummaryModelCellRenderer&) =
       delete;  // stop default
 
+private:
   // ---------- member data --------------------------------
   FWColorBoxIcon* m_colorBox;
   FWCheckBoxIcon* m_checkBox;

--- a/Fireworks/Core/src/FWCollectionSummaryTableManager.h
+++ b/Fireworks/Core/src/FWCollectionSummaryTableManager.h
@@ -59,11 +59,12 @@ public:
 protected:
   void implSort(int iCol, bool iSortOrder) override;
 
-private:
+public:
   FWCollectionSummaryTableManager(const FWCollectionSummaryTableManager&) = delete;  // stop default
 
   const FWCollectionSummaryTableManager& operator=(const FWCollectionSummaryTableManager&) = delete;  // stop default
 
+private:
   void dataChanged();
   // ---------- member data --------------------------------
   FWEventItem* m_collection;

--- a/Fireworks/Core/src/FWColorBoxIcon.h
+++ b/Fireworks/Core/src/FWColorBoxIcon.h
@@ -37,11 +37,11 @@ public:
   // ---------- member functions ---------------------------
   void setColor(GContext_t iColorContext) { m_colorContext = iColorContext; }
 
-private:
   FWColorBoxIcon(const FWColorBoxIcon&) = delete;  // stop default
 
   const FWColorBoxIcon& operator=(const FWColorBoxIcon&) = delete;  // stop default
 
+private:
   void drawInsideBox(Drawable_t iID, GContext_t iContext, int iX, int iY, unsigned int iSize) const override;
 
   // ---------- member data --------------------------------

--- a/Fireworks/Core/src/FWDoubleParameterSetter.h
+++ b/Fireworks/Core/src/FWDoubleParameterSetter.h
@@ -45,11 +45,11 @@ public:
 
   void doUpdate(Long_t);
 
-private:
   FWDoubleParameterSetter(const FWDoubleParameterSetter&) = delete;  // stop default
 
   const FWDoubleParameterSetter& operator=(const FWDoubleParameterSetter&) = delete;  // stop default
 
+private:
   // ---------- member data --------------------------------
   FWDoubleParameter* m_param;
   TGNumberEntry* m_widget;

--- a/Fireworks/Core/src/FWExpressionValidator.h
+++ b/Fireworks/Core/src/FWExpressionValidator.h
@@ -46,11 +46,11 @@ public:
   // ---------- member functions ---------------------------
   void setType(const edm::TypeWithDict&);
 
-private:
   FWExpressionValidator(const FWExpressionValidator&) = delete;  // stop default
 
   const FWExpressionValidator& operator=(const FWExpressionValidator&) = delete;  // stop default
 
+private:
   // ---------- member data --------------------------------
   edm::TypeWithDict m_type;
   std::vector<std::shared_ptr<fireworks::OptionNode> > m_options;

--- a/Fireworks/Core/src/FWGUIEventDataAdder.h
+++ b/Fireworks/Core/src/FWGUIEventDataAdder.h
@@ -62,7 +62,7 @@ public:
 
   void resetNameEntry();
 
-  FWGUIEventDataAdder(const FWGUIEventDataAdder&) = delete;  // stop default
+  FWGUIEventDataAdder(const FWGUIEventDataAdder&) = delete;                   // stop default
   const FWGUIEventDataAdder& operator=(const FWGUIEventDataAdder&) = delete;  // stop default
 
 private:

--- a/Fireworks/Core/src/FWGUIEventDataAdder.h
+++ b/Fireworks/Core/src/FWGUIEventDataAdder.h
@@ -62,12 +62,12 @@ public:
 
   void resetNameEntry();
 
-private:
   FWGUIEventDataAdder(const FWGUIEventDataAdder&) = delete;  // stop default
-  void createWindow();
-
-  void newIndexSelected(int);
   const FWGUIEventDataAdder& operator=(const FWGUIEventDataAdder&) = delete;  // stop default
+
+private:
+  void createWindow();
+  void newIndexSelected(int);
 
   // ---------- member data --------------------------------
   FWEventItemsManager* m_manager;

--- a/Fireworks/Core/src/FWGeoTopNodeScene.h
+++ b/Fireworks/Core/src/FWGeoTopNodeScene.h
@@ -7,7 +7,7 @@ class FWGeoTopNode;
 class TGLViewer;
 
 class FWGeoTopNodeGLScene : public TGLScenePad {
-private:
+public:
   FWGeoTopNodeGLScene(const FWGeoTopNodeGLScene&) = delete;             // Not implemented
   FWGeoTopNodeGLScene& operator=(const FWGeoTopNodeGLScene&) = delete;  // Not implemented
 protected:

--- a/Fireworks/Core/src/FWGeometryTableManager.h
+++ b/Fireworks/Core/src/FWGeometryTableManager.h
@@ -80,10 +80,11 @@ protected:
   //   virtual FWGeometryTableManagerBase::ESelectionState nodeSelectionState(int) const;
   const char* cellName(const NodeInfo& data) const override;
 
-private:
+public:
   FWGeometryTableManager(const FWGeometryTableManager&) = delete;                   // stop default
   const FWGeometryTableManager& operator=(const FWGeometryTableManager&) = delete;  // stop default
 
+private:
   FWGeometryTableView* m_browser;
 
   mutable Volumes_t m_volumes;

--- a/Fireworks/Core/src/FWItemSingleAccessor.h
+++ b/Fireworks/Core/src/FWItemSingleAccessor.h
@@ -43,11 +43,11 @@ public:
   void setData(const edm::ObjectWithDict&) override;
   void reset() override;
 
-private:
   FWItemSingleAccessor(const FWItemSingleAccessor&) = delete;  // stop default
 
   const FWItemSingleAccessor& operator=(const FWItemSingleAccessor&) = delete;  // stop default
 
+private:
   // ---------- member data --------------------------------
   const TClass* m_type;
   const void* m_data;

--- a/Fireworks/Core/src/FWItemTVirtualCollectionProxyAccessor.h
+++ b/Fireworks/Core/src/FWItemTVirtualCollectionProxyAccessor.h
@@ -49,12 +49,12 @@ public:
   void setData(const edm::ObjectWithDict&) override;
   void reset() override;
 
-private:
   FWItemTVirtualCollectionProxyAccessor(const FWItemTVirtualCollectionProxyAccessor&) = delete;  // stop default
 
   const FWItemTVirtualCollectionProxyAccessor& operator=(const FWItemTVirtualCollectionProxyAccessor&) =
       delete;  // stop default
 
+private:
   // ---------- member data --------------------------------
   const TClass* m_type;
   std::shared_ptr<TVirtualCollectionProxy> m_colProxy;  //should be something other than shared_ptr

--- a/Fireworks/Core/src/FWLongParameterSetter.h
+++ b/Fireworks/Core/src/FWLongParameterSetter.h
@@ -44,10 +44,10 @@ public:
 
   void doUpdate(Long_t);
 
-private:
   FWLongParameterSetter(const FWLongParameterSetter&) = delete;                   // stop default
   const FWLongParameterSetter& operator=(const FWLongParameterSetter&) = delete;  // stop default
 
+private:
   // ---------- member data --------------------------------
 
   FWLongParameter* m_param;

--- a/Fireworks/Core/src/FWOverlapTableManager.h
+++ b/Fireworks/Core/src/FWOverlapTableManager.h
@@ -70,10 +70,11 @@ protected:
   bool nodeIsParent(const NodeInfo&) const override;
   //   virtual  const char* cellName(const NodeInfo& data) const;
 
-private:
+public:
   FWOverlapTableManager(const FWOverlapTableManager&) = delete;                   // stop default
   const FWOverlapTableManager& operator=(const FWOverlapTableManager&) = delete;  // stop default
 
+private:
   void addOverlapEntry(TGeoOverlap*, int, int, TGeoHMatrix*);
   FWOverlapTableView* m_browser;
 

--- a/Fireworks/Core/src/FWStringParameterSetter.h
+++ b/Fireworks/Core/src/FWStringParameterSetter.h
@@ -30,11 +30,11 @@ public:
   TGFrame* build(TGFrame* iParent, bool labelBack = true) override;
   void doUpdate();
 
-private:
   FWStringParameterSetter(const FWStringParameterSetter&) = delete;  // stop default
 
   const FWStringParameterSetter& operator=(const FWStringParameterSetter&) = delete;  // stop default
 
+private:
   // ---------- member data --------------------------------
   FWStringParameter* m_param;
   TGTextEntry* m_widget;

--- a/Fireworks/Core/src/FWValidatorBase.h
+++ b/Fireworks/Core/src/FWValidatorBase.h
@@ -44,7 +44,6 @@ public:
 
   // ---------- member functions ---------------------------
 
-private:
   FWValidatorBase(const FWValidatorBase&) = delete;  // stop default
 
   const FWValidatorBase& operator=(const FWValidatorBase&) = delete;  // stop default

--- a/Fireworks/Core/src/SimpleSAXParser.h
+++ b/Fireworks/Core/src/SimpleSAXParser.h
@@ -118,10 +118,10 @@ public:
   virtual void endElement(const std::string & /*name*/) {}
   virtual void data(const std::string & /*data*/) {}
 
-private:
   SimpleSAXParser(const SimpleSAXParser &) = delete;                   // stop default
   const SimpleSAXParser &operator=(const SimpleSAXParser &) = delete;  // stop default
 
+private:
   std::string parseEntity(const std::string &entity);
   std::string getToken(const char *delim) {
     fgettoken(m_in, &m_buffer, &m_bufferSize, delim, &m_nextChar);

--- a/Fireworks/Electrons/plugins/FWConvTrackHitsDetailView.h
+++ b/Fireworks/Electrons/plugins/FWConvTrackHitsDetailView.h
@@ -35,10 +35,10 @@ public:
   void camera3Callback();
   void switchProjection();
 
-private:
   FWConvTrackHitsDetailView(const FWConvTrackHitsDetailView&) = delete;                   // stop default
   const FWConvTrackHitsDetailView& operator=(const FWConvTrackHitsDetailView&) = delete;  // stop default
 
+private:
   using FWDetailViewGL<reco::Conversion>::build;
   void build(const FWModelId& id, const reco::Conversion*) override;
   using FWDetailViewGL<reco::Conversion>::setTextInfo;

--- a/Fireworks/Electrons/plugins/FWConversionProxyBuilder.cc
+++ b/Fireworks/Electrons/plugins/FWConversionProxyBuilder.cc
@@ -41,10 +41,10 @@ public:
 
   REGISTER_PROXYBUILDER_METHODS();
 
-private:
   FWConversionProxyBuilder(const FWConversionProxyBuilder&) = delete;                   // stop default
   const FWConversionProxyBuilder& operator=(const FWConversionProxyBuilder&) = delete;  // stop default
 
+private:
   using FWSimpleProxyBuilderTemplate<reco::Conversion>::buildViewType;
   void buildViewType(const reco::Conversion& iData,
                      unsigned int iIndex,

--- a/Fireworks/Electrons/plugins/FWElectronDetailView.h
+++ b/Fireworks/Electrons/plugins/FWElectronDetailView.h
@@ -33,10 +33,10 @@ public:
   FWElectronDetailView();
   ~FWElectronDetailView() override;
 
-private:
   FWElectronDetailView(const FWElectronDetailView &) = delete;                   // stop default
   const FWElectronDetailView &operator=(const FWElectronDetailView &) = delete;  // stop default
 
+private:
   using FWDetailViewGL<reco::GsfElectron>::build;
   void build(const FWModelId &id, const reco::GsfElectron *) override;
 

--- a/Fireworks/Electrons/plugins/FWElectronLegoProxyBuilder.cc
+++ b/Fireworks/Electrons/plugins/FWElectronLegoProxyBuilder.cc
@@ -24,10 +24,10 @@ public:
 
   REGISTER_PROXYBUILDER_METHODS();
 
-private:
   FWElectronLegoProxyBuilder(const FWElectronLegoProxyBuilder&) = delete;
   const FWElectronLegoProxyBuilder& operator=(const FWElectronLegoProxyBuilder&) = delete;
 
+private:
   using FWSimpleProxyBuilderTemplate<reco::GsfElectron>::build;
   void build(const reco::GsfElectron& iData,
              unsigned int iIndex,

--- a/Fireworks/Electrons/plugins/FWElectronProxyBuilder.cc
+++ b/Fireworks/Electrons/plugins/FWElectronProxyBuilder.cc
@@ -53,10 +53,10 @@ public:
 
   REGISTER_PROXYBUILDER_METHODS();
 
-private:
   FWElectronProxyBuilder(const FWElectronProxyBuilder&) = delete;                   // stop default
   const FWElectronProxyBuilder& operator=(const FWElectronProxyBuilder&) = delete;  // stop default
 
+private:
   TEveElementList* requestCommon();
 
   TEveElementList* m_common;
@@ -134,11 +134,11 @@ public:
 
   REGISTER_PROXYBUILDER_METHODS();
 
-private:
   FWElectronGlimpseProxyBuilder(const FWElectronGlimpseProxyBuilder&) = delete;  // stop default
 
   const FWElectronGlimpseProxyBuilder& operator=(const FWElectronGlimpseProxyBuilder&) = delete;  // stop default
 
+private:
   void build(const reco::GsfElectron& iData,
              unsigned int iIndex,
              TEveElement& oItemHolder,

--- a/Fireworks/Electrons/plugins/FWPhotonDetailView.h
+++ b/Fireworks/Electrons/plugins/FWPhotonDetailView.h
@@ -31,10 +31,10 @@ public:
   using FWDetailViewGL<reco::Photon>::setTextInfo;
   void setTextInfo(const FWModelId& id, const reco::Photon*) override;
 
-private:
   FWPhotonDetailView(const FWPhotonDetailView&) = delete;                   // stop default
   const FWPhotonDetailView& operator=(const FWPhotonDetailView&) = delete;  // stop default
 
+private:
   void addSceneInfo(const reco::Photon*, TEveElementList*);
 
   TEveCaloData* m_data;

--- a/Fireworks/Electrons/plugins/FWPhotonLegoProxyBuilder.cc
+++ b/Fireworks/Electrons/plugins/FWPhotonLegoProxyBuilder.cc
@@ -18,10 +18,10 @@ public:
 
   REGISTER_PROXYBUILDER_METHODS();
 
-private:
   FWPhotonLegoProxyBuilder(const FWPhotonLegoProxyBuilder&) = delete;
   const FWPhotonLegoProxyBuilder& operator=(const FWPhotonLegoProxyBuilder&) = delete;
 
+private:
   using FWSimpleProxyBuilderTemplate<reco::Photon>::build;
   void build(const reco::Photon& iData, unsigned int iIndex, TEveElement& oItemHolder, const FWViewContext*) override;
 };

--- a/Fireworks/Electrons/plugins/FWPhotonProxyBuilder.cc
+++ b/Fireworks/Electrons/plugins/FWPhotonProxyBuilder.cc
@@ -32,10 +32,10 @@ public:
 
   REGISTER_PROXYBUILDER_METHODS();
 
-private:
   FWPhotonProxyBuilder(const FWPhotonProxyBuilder&) = delete;
   const FWPhotonProxyBuilder& operator=(const FWPhotonProxyBuilder&) = delete;
 
+private:
   using FWSimpleProxyBuilderTemplate<reco::Photon>::buildViewType;
   void buildViewType(const reco::Photon& photon,
                      unsigned int iIndex,

--- a/Fireworks/FWInterface/interface/FWFFService.h
+++ b/Fireworks/FWInterface/interface/FWFFService.h
@@ -57,10 +57,10 @@ public:
 
   void quit() override;
 
-private:
   FWFFService(const FWFFService&) = delete;                   // stop default
   const FWFFService& operator=(const FWFFService&) = delete;  // stop default
 
+private:
   // ---------- member data --------------------------------
 
   std::unique_ptr<FWFFNavigator> m_navigator;

--- a/Fireworks/FWInterface/plugins/FWTrackProxyBuilderFullFramework.cc
+++ b/Fireworks/FWInterface/plugins/FWTrackProxyBuilderFullFramework.cc
@@ -40,10 +40,10 @@ public:
   void setItem(const FWEventItem* iItem) override;
   bool visibilityModelChanges(const FWModelId&, TEveElement*, FWViewType::EType, const FWViewContext*) override;
 
-private:
-  FWTrackProxyBuilderFullFramework(const FWTrackProxyBuilderFullFramework&) = delete;                   // stop default
+  FWTrackProxyBuilderFullFramework(const FWTrackProxyBuilderFullFramework&) = delete;                   // stop default
   const FWTrackProxyBuilderFullFramework& operator=(const FWTrackProxyBuilderFullFramework&) = delete;  // stop default
 
+private:
   void build(const FWEventItem* iItem, TEveElementList* product, const FWViewContext*) override;
   void buildTrack(TrajTrackAssociationCollection::const_iterator it, TEveCompound* comp);
 

--- a/Fireworks/FWInterface/plugins/FWTrackingParticleProxyBuilderFullFramework.cc
+++ b/Fireworks/FWInterface/plugins/FWTrackingParticleProxyBuilderFullFramework.cc
@@ -33,11 +33,11 @@ public:
 
   REGISTER_PROXYBUILDER_METHODS();
 
-private:
   FWTrackingParticleProxyBuilderFullFramework(const FWTrackingParticleProxyBuilderFullFramework&) = delete;
   const FWTrackingParticleProxyBuilderFullFramework& operator=(const FWTrackingParticleProxyBuilderFullFramework&) =
       delete;
 
+private:
   using FWSimpleProxyBuilderTemplate<TrackingParticle>::build;
   void build(const FWEventItem* iItem, TEveElementList* product, const FWViewContext*) override;
 

--- a/Fireworks/FWInterface/src/FWPSetTableManager.h
+++ b/Fireworks/FWInterface/src/FWPSetTableManager.h
@@ -82,6 +82,8 @@ public:
 
   FWPSetTableManager();
   ~FWPSetTableManager() override;
+  FWPSetTableManager(const FWPSetTableManager &) = delete;                   // stop default
+  const FWPSetTableManager &operator=(const FWPSetTableManager &) = delete;  // stop default
 
   int unsortedRowNumber(int unsorted) const override;
   int numberOfRows() const override;
@@ -154,9 +156,6 @@ private:
     size_t moduleEnd;
     bool passed;
   };
-
-  FWPSetTableManager(const FWPSetTableManager &) = delete;                   // stop default
-  const FWPSetTableManager &operator=(const FWPSetTableManager &) = delete;  // stop default
 
   void recalculateVisibility();
 

--- a/Fireworks/GenParticle/plugins/FWGenParticleLegoProxyBuilder.cc
+++ b/Fireworks/GenParticle/plugins/FWGenParticleLegoProxyBuilder.cc
@@ -24,11 +24,11 @@ public:
   // ---------- member functions ---------------------------
   REGISTER_PROXYBUILDER_METHODS();
 
-private:
   FWGenParticleLegoProxyBuilder(const FWGenParticleLegoProxyBuilder&) = delete;  // stop default
 
   const FWGenParticleLegoProxyBuilder& operator=(const FWGenParticleLegoProxyBuilder&) = delete;  // stop default
 
+private:
   using FWSimpleProxyBuilderTemplate<reco::GenParticle>::build;
   void build(const reco::GenParticle& iData,
              unsigned int iIndex,

--- a/Fireworks/GenParticle/plugins/FWGenParticleProxyBuilder.cc
+++ b/Fireworks/GenParticle/plugins/FWGenParticleProxyBuilder.cc
@@ -33,11 +33,11 @@ public:
   // ---------- member functions ---------------------------
   REGISTER_PROXYBUILDER_METHODS();
 
-private:
   FWGenParticleProxyBuilder(const FWGenParticleProxyBuilder&) = delete;  // stop default
 
   const FWGenParticleProxyBuilder& operator=(const FWGenParticleProxyBuilder&) = delete;  // stop default
 
+private:
   using FWSimpleProxyBuilderTemplate<reco::GenParticle>::build;
   void build(const reco::GenParticle& iData,
              unsigned int iIndex,

--- a/Fireworks/Geometry/interface/DisplayPlugin.h
+++ b/Fireworks/Geometry/interface/DisplayPlugin.h
@@ -41,7 +41,6 @@ namespace fireworks {
       // ---------- member functions ---------------------------
       virtual void run(const edm::EventSetup&) = 0;
 
-    private:
       DisplayPlugin(const DisplayPlugin&) = delete;  // stop default
 
       const DisplayPlugin& operator=(const DisplayPlugin&) = delete;  // stop default

--- a/Fireworks/Geometry/interface/FWRecoGeometryESProducer.h
+++ b/Fireworks/Geometry/interface/FWRecoGeometryESProducer.h
@@ -29,10 +29,10 @@ public:
 
   std::unique_ptr<FWRecoGeometry> produce(const FWRecoGeometryRecord&);
 
-private:
   FWRecoGeometryESProducer(const FWRecoGeometryESProducer&) = delete;
   const FWRecoGeometryESProducer& operator=(const FWRecoGeometryESProducer&) = delete;
 
+private:
   void addCSCGeometry(FWRecoGeometry&);
   void addDTGeometry(FWRecoGeometry&);
   void addRPCGeometry(FWRecoGeometry&);

--- a/Fireworks/Geometry/interface/TGeoFromDddService.h
+++ b/Fireworks/Geometry/interface/TGeoFromDddService.h
@@ -59,10 +59,10 @@ public:
 
   TGeoManager* getGeoManager();
 
-private:
   TGeoFromDddService(const TGeoFromDddService&) = delete;                   // stop default
   const TGeoFromDddService& operator=(const TGeoFromDddService&) = delete;  // stop default
 
+private:
   TGeoManager* createManager(int level);
 
   TGeoShape* createShape(const std::string& iName, const DDSolid& iSolid);

--- a/Fireworks/Muons/interface/FWMuonBuilder.h
+++ b/Fireworks/Muons/interface/FWMuonBuilder.h
@@ -34,11 +34,11 @@ public:
 
   void setLineWidth(int w) { m_lineWidth = w; }
 
-private:
   FWMuonBuilder(const FWMuonBuilder&) = delete;  // stop default
 
   const FWMuonBuilder& operator=(const FWMuonBuilder&) = delete;  // stop default
 
+private:
   void calculateField(const reco::Muon& iData, FWMagField* field);
 
   // ---------- member data --------------------------------

--- a/Fireworks/Muons/plugins/FWCSCRecHitProxyBuilder.cc
+++ b/Fireworks/Muons/plugins/FWCSCRecHitProxyBuilder.cc
@@ -22,10 +22,10 @@ public:
 
   REGISTER_PROXYBUILDER_METHODS();
 
-private:
   FWCSCRecHitProxyBuilder(const FWCSCRecHitProxyBuilder&) = delete;
   const FWCSCRecHitProxyBuilder& operator=(const FWCSCRecHitProxyBuilder&) = delete;
 
+private:
   using FWSimpleProxyBuilderTemplate<CSCRecHit2D>::build;
   void build(const CSCRecHit2D& iData, unsigned int iIndex, TEveElement& oItemHolder, const FWViewContext*) override;
 };

--- a/Fireworks/Muons/plugins/FWCSCSegmentProxyBuilder.cc
+++ b/Fireworks/Muons/plugins/FWCSCSegmentProxyBuilder.cc
@@ -29,10 +29,10 @@ public:
 
   REGISTER_PROXYBUILDER_METHODS();
 
-private:
   FWCSCSegmentProxyBuilder(const FWCSCSegmentProxyBuilder&) = delete;
   const FWCSCSegmentProxyBuilder& operator=(const FWCSCSegmentProxyBuilder&) = delete;
 
+private:
   using FWSimpleProxyBuilderTemplate<CSCSegment>::build;
   void build(const CSCSegment& iData, unsigned int iIndex, TEveElement& oItemHolder, const FWViewContext*) override;
 };

--- a/Fireworks/Muons/plugins/FWCSCStripDigiProxyBuilder.cc
+++ b/Fireworks/Muons/plugins/FWCSCStripDigiProxyBuilder.cc
@@ -30,6 +30,7 @@ public:
 private:
   using FWProxyBuilderBase::build;
   void build(const FWEventItem* iItem, TEveElementList* product, const FWViewContext*) override;
+public:
   FWCSCStripDigiProxyBuilder(const FWCSCStripDigiProxyBuilder&) = delete;
   const FWCSCStripDigiProxyBuilder& operator=(const FWCSCStripDigiProxyBuilder&) = delete;
 };

--- a/Fireworks/Muons/plugins/FWCSCStripDigiProxyBuilder.cc
+++ b/Fireworks/Muons/plugins/FWCSCStripDigiProxyBuilder.cc
@@ -30,6 +30,7 @@ public:
 private:
   using FWProxyBuilderBase::build;
   void build(const FWEventItem* iItem, TEveElementList* product, const FWViewContext*) override;
+
 public:
   FWCSCStripDigiProxyBuilder(const FWCSCStripDigiProxyBuilder&) = delete;
   const FWCSCStripDigiProxyBuilder& operator=(const FWCSCStripDigiProxyBuilder&) = delete;

--- a/Fireworks/Muons/plugins/FWCSCWireDigiProxyBuilder.cc
+++ b/Fireworks/Muons/plugins/FWCSCWireDigiProxyBuilder.cc
@@ -29,11 +29,12 @@ public:
 
   REGISTER_PROXYBUILDER_METHODS();
 
+  FWCSCWireDigiProxyBuilder(const FWCSCWireDigiProxyBuilder&) = delete;
+  const FWCSCWireDigiProxyBuilder& operator=(const FWCSCWireDigiProxyBuilder&) = delete;
+
 private:
   using FWProxyBuilderBase::build;
   void build(const FWEventItem* iItem, TEveElementList* product, const FWViewContext*) override;
-  FWCSCWireDigiProxyBuilder(const FWCSCWireDigiProxyBuilder&) = delete;
-  const FWCSCWireDigiProxyBuilder& operator=(const FWCSCWireDigiProxyBuilder&) = delete;
 
   // NOTE: these parameters are not available via a public interface
   // from the geometry or topology so must be hard-coded.

--- a/Fireworks/Muons/plugins/FWDTDigiProxyBuilder.cc
+++ b/Fireworks/Muons/plugins/FWDTDigiProxyBuilder.cc
@@ -63,12 +63,12 @@ public:
 
   REGISTER_PROXYBUILDER_METHODS();
 
-private:
   // Disable default copy constructor
   FWDTDigiProxyBuilder(const FWDTDigiProxyBuilder&) = delete;
   // Disable default assignment operator
   const FWDTDigiProxyBuilder& operator=(const FWDTDigiProxyBuilder&) = delete;
 
+private:
   using FWProxyBuilderBase::buildViewType;
   void buildViewType(const FWEventItem* iItem,
                      TEveElementList* product,

--- a/Fireworks/Muons/plugins/FWDTRecHitProxyBuilder.cc
+++ b/Fireworks/Muons/plugins/FWDTRecHitProxyBuilder.cc
@@ -27,12 +27,12 @@ public:
 
   REGISTER_PROXYBUILDER_METHODS();
 
-private:
   // Disable default copy constructor
   FWDTRecHitProxyBuilder(const FWDTRecHitProxyBuilder&) = delete;
   // Disable default assignment operator
   const FWDTRecHitProxyBuilder& operator=(const FWDTRecHitProxyBuilder&) = delete;
 
+private:
   using FWSimpleProxyBuilderTemplate<DTRecHit1DPair>::buildViewType;
   void buildViewType(const DTRecHit1DPair& iData,
                      unsigned int iIndex,

--- a/Fireworks/Muons/plugins/FWDTSegmentProxyBuilder.cc
+++ b/Fireworks/Muons/plugins/FWDTSegmentProxyBuilder.cc
@@ -35,10 +35,10 @@ public:
 
   REGISTER_PROXYBUILDER_METHODS();
 
-private:
   FWDTSegmentProxyBuilder(const FWDTSegmentProxyBuilder&) = delete;
   const FWDTSegmentProxyBuilder& operator=(const FWDTSegmentProxyBuilder&) = delete;
 
+private:
   using FWSimpleProxyBuilderTemplate<DTRecSegment4D>::buildViewType;
   void buildViewType(const DTRecSegment4D& iData,
                      unsigned int iIndex,

--- a/Fireworks/Muons/plugins/FWGEMDigiProxyBuilder.cc
+++ b/Fireworks/Muons/plugins/FWGEMDigiProxyBuilder.cc
@@ -36,6 +36,7 @@ public:
 private:
   using FWProxyBuilderBase::build;
   void build(const FWEventItem* iItem, TEveElementList* product, const FWViewContext*) override;
+public:
   FWGEMDigiProxyBuilder(const FWGEMDigiProxyBuilder&) = delete;
   const FWGEMDigiProxyBuilder& operator=(const FWGEMDigiProxyBuilder&) = delete;
 };
@@ -110,10 +111,11 @@ public:
 
   REGISTER_PROXYBUILDER_METHODS();
 
-private:
-  void build(const FWEventItem* iItem, TEveElementList* product, const FWViewContext*) override;
+public:
   FWGEMPadDigiProxyBuilder(const FWGEMPadDigiProxyBuilder&) = delete;
   const FWGEMPadDigiProxyBuilder& operator=(const FWGEMPadDigiProxyBuilder&) = delete;
+private:
+  void build(const FWEventItem* iItem, TEveElementList* product, const FWViewContext*) override;
 };
 
 void FWGEMPadDigiProxyBuilder::build(const FWEventItem* iItem, TEveElementList* product, const FWViewContext*) {

--- a/Fireworks/Muons/plugins/FWGEMDigiProxyBuilder.cc
+++ b/Fireworks/Muons/plugins/FWGEMDigiProxyBuilder.cc
@@ -36,6 +36,7 @@ public:
 private:
   using FWProxyBuilderBase::build;
   void build(const FWEventItem* iItem, TEveElementList* product, const FWViewContext*) override;
+
 public:
   FWGEMDigiProxyBuilder(const FWGEMDigiProxyBuilder&) = delete;
   const FWGEMDigiProxyBuilder& operator=(const FWGEMDigiProxyBuilder&) = delete;
@@ -114,6 +115,7 @@ public:
 public:
   FWGEMPadDigiProxyBuilder(const FWGEMPadDigiProxyBuilder&) = delete;
   const FWGEMPadDigiProxyBuilder& operator=(const FWGEMPadDigiProxyBuilder&) = delete;
+
 private:
   void build(const FWEventItem* iItem, TEveElementList* product, const FWViewContext*) override;
 };

--- a/Fireworks/Muons/plugins/FWGEMRecHitProxyBuilder.cc
+++ b/Fireworks/Muons/plugins/FWGEMRecHitProxyBuilder.cc
@@ -30,10 +30,10 @@ public:
 
   REGISTER_PROXYBUILDER_METHODS();
 
-private:
   FWGEMRecHitProxyBuilder(const FWGEMRecHitProxyBuilder&) = delete;
   const FWGEMRecHitProxyBuilder& operator=(const FWGEMRecHitProxyBuilder&) = delete;
 
+private:
   using FWSimpleProxyBuilderTemplate<GEMRecHit>::buildViewType;
   void buildViewType(const GEMRecHit& iData,
                      unsigned int iIndex,

--- a/Fireworks/Muons/plugins/FWGEMSegmentProxyBuilder.cc
+++ b/Fireworks/Muons/plugins/FWGEMSegmentProxyBuilder.cc
@@ -19,10 +19,10 @@ public:
 
   REGISTER_PROXYBUILDER_METHODS();
 
-private:
   FWGEMSegmentProxyBuilder(const FWGEMSegmentProxyBuilder&) = delete;
   const FWGEMSegmentProxyBuilder& operator=(const FWGEMSegmentProxyBuilder&) = delete;
 
+private:
   using FWSimpleProxyBuilderTemplate<GEMSegment>::buildViewType;
   void buildViewType(const GEMSegment& iData,
                      unsigned int iIndex,

--- a/Fireworks/Muons/plugins/FWME0DigiProxyBuilder.cc
+++ b/Fireworks/Muons/plugins/FWME0DigiProxyBuilder.cc
@@ -19,10 +19,11 @@ public:
 
   REGISTER_PROXYBUILDER_METHODS();
 
-private:
-  void build(const FWEventItem* iItem, TEveElementList* product, const FWViewContext*) override;
   FWME0DigiProxyBuilder(const FWME0DigiProxyBuilder&) = delete;
   const FWME0DigiProxyBuilder& operator=(const FWME0DigiProxyBuilder&) = delete;
+
+private:
+  void build(const FWEventItem* iItem, TEveElementList* product, const FWViewContext*) override;
 };
 
 void FWME0DigiProxyBuilder::build(const FWEventItem* iItem, TEveElementList* product, const FWViewContext*) {

--- a/Fireworks/Muons/plugins/FWME0RecHitProxyBuilder.cc
+++ b/Fireworks/Muons/plugins/FWME0RecHitProxyBuilder.cc
@@ -18,10 +18,10 @@ public:
 
   REGISTER_PROXYBUILDER_METHODS();
 
-private:
   FWME0RecHitProxyBuilder(const FWME0RecHitProxyBuilder&) = delete;
   const FWME0RecHitProxyBuilder& operator=(const FWME0RecHitProxyBuilder&) = delete;
 
+private:
   void buildViewType(const ME0RecHit& iData,
                      unsigned int iIndex,
                      TEveElement& oItemHolder,

--- a/Fireworks/Muons/plugins/FWME0SegmentProxyBuilder.cc
+++ b/Fireworks/Muons/plugins/FWME0SegmentProxyBuilder.cc
@@ -18,10 +18,10 @@ public:
 
   REGISTER_PROXYBUILDER_METHODS();
 
-private:
   FWME0SegmentProxyBuilder(const FWME0SegmentProxyBuilder&) = delete;
   const FWME0SegmentProxyBuilder& operator=(const FWME0SegmentProxyBuilder&) = delete;
 
+private:
   void build(const ME0Segment& iData, unsigned int iIndex, TEveElement& oItemHolder, const FWViewContext*) override;
 };
 

--- a/Fireworks/Muons/plugins/FWMuonDetailView.h
+++ b/Fireworks/Muons/plugins/FWMuonDetailView.h
@@ -21,10 +21,10 @@ public:
   FWMuonDetailView();
   ~FWMuonDetailView() override;
 
-private:
   FWMuonDetailView(const FWMuonDetailView&) = delete;                   // stop default
   const FWMuonDetailView& operator=(const FWMuonDetailView&) = delete;  // stop default
 
+private:
   void build(const FWModelId& id, const reco::Muon*) override;
   void setTextInfo(const FWModelId&, const reco::Muon*) override;
 

--- a/Fireworks/Muons/plugins/FWMuonGlimpseProxyBuilder.cc
+++ b/Fireworks/Muons/plugins/FWMuonGlimpseProxyBuilder.cc
@@ -17,12 +17,12 @@ public:
 
   REGISTER_PROXYBUILDER_METHODS();
 
-private:
   // Disable default copy constructor
   FWMuonGlimpseProxyBuilder(const FWMuonGlimpseProxyBuilder&) = delete;
   // Disable default assignment operator
   const FWMuonGlimpseProxyBuilder& operator=(const FWMuonGlimpseProxyBuilder&) = delete;
 
+private:
   using FWSimpleProxyBuilderTemplate<reco::Muon>::build;
   void build(const reco::Muon& iData, unsigned int iIndex, TEveElement& oItemHolder, const FWViewContext*) override;
 };

--- a/Fireworks/Muons/plugins/FWMuonLegoProxyBuilder.cc
+++ b/Fireworks/Muons/plugins/FWMuonLegoProxyBuilder.cc
@@ -18,12 +18,12 @@ public:
 
   REGISTER_PROXYBUILDER_METHODS();
 
-private:
   // Disable default copy constructor
   FWMuonLegoProxyBuilder(const FWMuonLegoProxyBuilder&) = delete;
   // Disable default assignment operator
   const FWMuonLegoProxyBuilder& operator=(const FWMuonLegoProxyBuilder&) = delete;
 
+private:
   using FWSimpleProxyBuilderTemplate<reco::Muon>::build;
   void build(const reco::Muon& iData, unsigned int iIndex, TEveElement& oItemHolder, const FWViewContext*) override;
 };

--- a/Fireworks/Muons/plugins/FWMuonProxyBuilder.cc
+++ b/Fireworks/Muons/plugins/FWMuonProxyBuilder.cc
@@ -26,12 +26,12 @@ public:
 
   REGISTER_PROXYBUILDER_METHODS();
 
-private:
   // Disable default copy constructor
   FWMuonProxyBuilder(const FWMuonProxyBuilder&) = delete;
   // Disable default assignment operator
   const FWMuonProxyBuilder& operator=(const FWMuonProxyBuilder&) = delete;
 
+private:
   using FWSimpleProxyBuilderTemplate<reco::Muon>::build;
   void build(const reco::Muon& iData, unsigned int iIndex, TEveElement& oItemHolder, const FWViewContext*) override;
 

--- a/Fireworks/Muons/plugins/FWMuonRhoPhiProxyBuilder.cc
+++ b/Fireworks/Muons/plugins/FWMuonRhoPhiProxyBuilder.cc
@@ -20,12 +20,12 @@ public:
 
   REGISTER_PROXYBUILDER_METHODS();
 
-private:
   // Disable default copy constructor
   FWMuonRhoPhiProxyBuilder(const FWMuonRhoPhiProxyBuilder&) = delete;
   // Disable default assignment operator
   const FWMuonRhoPhiProxyBuilder& operator=(const FWMuonRhoPhiProxyBuilder&) = delete;
 
+private:
   using FWSimpleProxyBuilderTemplate<reco::Muon>::build;
   void build(const reco::Muon& iData, unsigned int iIndex, TEveElement& oItemHolder, const FWViewContext*) override;
 

--- a/Fireworks/Muons/plugins/FWRPCDigiProxyBuilder.cc
+++ b/Fireworks/Muons/plugins/FWRPCDigiProxyBuilder.cc
@@ -31,6 +31,7 @@ public:
 private:
   using FWProxyBuilderBase::build;
   void build(const FWEventItem* iItem, TEveElementList* product, const FWViewContext*) override;
+public:
   FWRPCDigiProxyBuilder(const FWRPCDigiProxyBuilder&) = delete;
   const FWRPCDigiProxyBuilder& operator=(const FWRPCDigiProxyBuilder&) = delete;
 };

--- a/Fireworks/Muons/plugins/FWRPCDigiProxyBuilder.cc
+++ b/Fireworks/Muons/plugins/FWRPCDigiProxyBuilder.cc
@@ -31,6 +31,7 @@ public:
 private:
   using FWProxyBuilderBase::build;
   void build(const FWEventItem* iItem, TEveElementList* product, const FWViewContext*) override;
+
 public:
   FWRPCDigiProxyBuilder(const FWRPCDigiProxyBuilder&) = delete;
   const FWRPCDigiProxyBuilder& operator=(const FWRPCDigiProxyBuilder&) = delete;

--- a/Fireworks/Muons/plugins/FWRPCRecHitProxyBuilder.cc
+++ b/Fireworks/Muons/plugins/FWRPCRecHitProxyBuilder.cc
@@ -28,10 +28,10 @@ public:
 
   REGISTER_PROXYBUILDER_METHODS();
 
-private:
   FWRPCRecHitProxyBuilder(const FWRPCRecHitProxyBuilder&) = delete;
   const FWRPCRecHitProxyBuilder& operator=(const FWRPCRecHitProxyBuilder&) = delete;
 
+private:
   using FWSimpleProxyBuilderTemplate<RPCRecHit>::buildViewType;
   void buildViewType(const RPCRecHit& iData,
                      unsigned int iIndex,

--- a/Fireworks/ParticleFlow/interface/FWPFClusterRPZUtils.h
+++ b/Fireworks/ParticleFlow/interface/FWPFClusterRPZUtils.h
@@ -50,7 +50,6 @@ public:
   TEveScalableStraightLineSet *buildRhoZClusterLineSet(
       const reco::PFCluster &, const FWViewContext *, float caloTransAngle, float e, float et, float r, float z);
 
-private:
   FWPFClusterRPZUtils(const FWPFClusterRPZUtils &) = delete;                   // Disable default copy constructor
   const FWPFClusterRPZUtils &operator=(const FWPFClusterRPZUtils &) = delete;  // Disable default assignment operator
 };

--- a/Fireworks/ParticleFlow/interface/FWPFLegoRecHit.h
+++ b/Fireworks/ParticleFlow/interface/FWPFLegoRecHit.h
@@ -57,10 +57,10 @@ public:
   bool isTallest() const { return m_isTallest; }
   void setIsTallest(bool b);
 
-private:
   FWPFLegoRecHit(const FWPFLegoRecHit &) = delete;                   // Disable default
   const FWPFLegoRecHit &operator=(const FWPFLegoRecHit &) = delete;  // Disable default
 
+private:
   // --------------------- Member Functions --------------------------
   void setupEveBox(std::vector<TEveVector> &corners, float scale);
   void buildTower(const std::vector<TEveVector> &corners, const FWViewContext *vc);

--- a/Fireworks/ParticleFlow/interface/FWPFTrackUtils.h
+++ b/Fireworks/ParticleFlow/interface/FWPFTrackUtils.h
@@ -76,10 +76,10 @@ public:
   TEveTrack *setupTrack(const reco::Track &);
   TEvePointSet *getCollisionMarkers(const TEveTrack *);
 
-private:
   FWPFTrackUtils(const FWPFTrackUtils &) = delete;                   // Stop default copy constructor
   const FWPFTrackUtils &operator=(const FWPFTrackUtils &) = delete;  // Stop default assignment operator
 
+private:
   TEveTrack *getTrack(const reco::Track &);
 
   FWPFTrackSingleton *m_singleton;

--- a/Fireworks/ParticleFlow/plugins/FWPFBlockProxyBuilder.h
+++ b/Fireworks/ParticleFlow/plugins/FWPFBlockProxyBuilder.h
@@ -83,7 +83,6 @@ public:
 
   REGISTER_PROXYBUILDER_METHODS();
 
-private:
   FWPFBlockEcalProxyBuilder(const FWPFBlockEcalProxyBuilder&) = delete;
   const FWPFBlockEcalProxyBuilder& operator=(const FWPFBlockEcalProxyBuilder&) = delete;
 };
@@ -99,7 +98,6 @@ public:
 
   REGISTER_PROXYBUILDER_METHODS();
 
-private:
   FWPFBlockHcalProxyBuilder(const FWPFBlockHcalProxyBuilder&) = delete;
   const FWPFBlockHcalProxyBuilder& operator=(const FWPFBlockHcalProxyBuilder&) = delete;
 };

--- a/Fireworks/ParticleFlow/plugins/FWPFCandidate3DProxyBuilder.cc
+++ b/Fireworks/ParticleFlow/plugins/FWPFCandidate3DProxyBuilder.cc
@@ -35,10 +35,10 @@ public:
 
   REGISTER_PROXYBUILDER_METHODS();
 
-private:
   FWPFCandidate3DProxyBuilder(const FWPFCandidate3DProxyBuilder&) = delete;                   // Stop default
   const FWPFCandidate3DProxyBuilder& operator=(const FWPFCandidate3DProxyBuilder&) = delete;  // Stop default
 
+private:
   // --------------------- Member Functions --------------------------
   using FWSimpleProxyBuilderTemplate<reco::PFCandidate>::build;
   void build(const reco::PFCandidate& iData,

--- a/Fireworks/ParticleFlow/plugins/FWPFCandidateDetailView.h
+++ b/Fireworks/ParticleFlow/plugins/FWPFCandidateDetailView.h
@@ -26,11 +26,10 @@ public:
   FWPFCandidateDetailView();
   ~FWPFCandidateDetailView() override;
 
-protected:
-private:
   FWPFCandidateDetailView(const FWPFCandidateDetailView &) = delete;                   // stop default
   const FWPFCandidateDetailView &operator=(const FWPFCandidateDetailView &) = delete;  // stop default
 
+private:
   using FWDetailView<reco::PFCandidate>::build;
   void build(const FWModelId &id, const reco::PFCandidate *) override;
   void setTextInfo(const FWModelId &id, const reco::PFCandidate *) override;

--- a/Fireworks/ParticleFlow/plugins/FWPFCandidateTowerProxyBuilder.h
+++ b/Fireworks/ParticleFlow/plugins/FWPFCandidateTowerProxyBuilder.h
@@ -34,15 +34,15 @@ public:
 
   virtual double getEt(const reco::PFCandidate&) const = 0;
 
+  FWPFCandidateTowerProxyBuilder(const FWPFCandidateTowerProxyBuilder&) = delete;                   // stop default
+  const FWPFCandidateTowerProxyBuilder& operator=(const FWPFCandidateTowerProxyBuilder&) = delete;  // stop default
+
 protected:
   void fillCaloData() override;
   FWHistSliceSelector* instantiateSliceSelector() override;
   void build(const FWEventItem* iItem, TEveElementList* product, const FWViewContext*) override;
 
 private:
-  FWPFCandidateTowerProxyBuilder(const FWPFCandidateTowerProxyBuilder&) = delete;                   // stop default
-  const FWPFCandidateTowerProxyBuilder& operator=(const FWPFCandidateTowerProxyBuilder&) = delete;  // stop default
-
   // ---------- member data --------------------------------
   const reco::PFCandidateCollection* m_towers;
 };
@@ -64,7 +64,6 @@ public:
 
   REGISTER_PROXYBUILDER_METHODS();
 
-private:
   FWECalPFCandidateProxyBuilder(const FWECalPFCandidateProxyBuilder&) = delete;                   // stop default
   const FWECalPFCandidateProxyBuilder& operator=(const FWECalPFCandidateProxyBuilder&) = delete;  // stop default
 };
@@ -86,7 +85,6 @@ public:
 
   REGISTER_PROXYBUILDER_METHODS();
 
-private:
   FWHCalPFCandidateProxyBuilder(const FWHCalPFCandidateProxyBuilder&) = delete;  // stop default
 
   const FWHCalPFCandidateProxyBuilder& operator=(const FWHCalPFCandidateProxyBuilder&) = delete;  // stop default

--- a/Fireworks/ParticleFlow/plugins/FWPFCandidateWithHitsProxyBuilder.h
+++ b/Fireworks/ParticleFlow/plugins/FWPFCandidateWithHitsProxyBuilder.h
@@ -21,10 +21,10 @@ public:
 
   REGISTER_PROXYBUILDER_METHODS();
 
-private:
   FWPFCandidateWithHitsProxyBuilder(const FWPFCandidateWithHitsProxyBuilder&) = delete;  // Stop default
   const FWPFCandidateWithHitsProxyBuilder& operator=(const FWPFCandidateWithHitsProxyBuilder&) = delete;  // Stop default
 
+private:
   void addHitsForCandidate(const reco::PFCandidate& c, TEveElement* holder, const FWViewContext* vc);
   void initPFRecHitsCollections();
   const reco::PFRecHit* getHitForDetId(unsigned detId);

--- a/Fireworks/ParticleFlow/plugins/FWPFCandidatesLegoProxyBuilder.cc
+++ b/Fireworks/ParticleFlow/plugins/FWPFCandidatesLegoProxyBuilder.cc
@@ -38,10 +38,10 @@ public:
 
   REGISTER_PROXYBUILDER_METHODS();
 
-private:
   FWPFCandidatesLegoProxyBuilder(const FWPFCandidatesLegoProxyBuilder&) = delete;                   // stop default
   const FWPFCandidatesLegoProxyBuilder& operator=(const FWPFCandidatesLegoProxyBuilder&) = delete;  // stop default
 
+private:
   // --------------------- Member Functions --------------------------
   using FWSimpleProxyBuilderTemplate<reco::PFCandidate>::build;
   void build(const reco::PFCandidate&, unsigned int, TEveElement&, const FWViewContext*) override;

--- a/Fireworks/ParticleFlow/plugins/FWPFClusterLegoProxyBuilder.h
+++ b/Fireworks/ParticleFlow/plugins/FWPFClusterLegoProxyBuilder.h
@@ -78,7 +78,6 @@ public:
 
   REGISTER_PROXYBUILDER_METHODS();
 
-private:
   FWPFEcalClusterLegoProxyBuilder(const FWPFEcalClusterLegoProxyBuilder&) = delete;
   const FWPFEcalClusterLegoProxyBuilder& operator=(const FWPFEcalClusterLegoProxyBuilder&) = delete;
 };
@@ -100,7 +99,6 @@ public:
 
   REGISTER_PROXYBUILDER_METHODS();
 
-private:
   FWPFHcalClusterLegoProxyBuilder(const FWPFHcalClusterLegoProxyBuilder&) = delete;
   const FWPFHcalClusterLegoProxyBuilder& operator=(const FWPFHcalClusterLegoProxyBuilder&) = delete;
 };

--- a/Fireworks/ParticleFlow/plugins/FWPFClusterRPZProxyBuilder.h
+++ b/Fireworks/ParticleFlow/plugins/FWPFClusterRPZProxyBuilder.h
@@ -55,7 +55,7 @@ protected:
                            const FWViewContext *vc,
                            float radius);
 
-private:
+public:
   FWPFClusterRPZProxyBuilder(const FWPFClusterRPZProxyBuilder &) = delete;                   // Disable default
   const FWPFClusterRPZProxyBuilder &operator=(const FWPFClusterRPZProxyBuilder &) = delete;  // Disable default
 };
@@ -80,7 +80,6 @@ public:
 
   REGISTER_PROXYBUILDER_METHODS();
 
-private:
   FWPFEcalClusterRPZProxyBuilder(const FWPFEcalClusterRPZProxyBuilder &) = delete;
   const FWPFEcalClusterRPZProxyBuilder &operator=(const FWPFEcalClusterRPZProxyBuilder &) = delete;
 };
@@ -105,7 +104,6 @@ public:
 
   REGISTER_PROXYBUILDER_METHODS();
 
-private:
   FWPFHcalClusterRPZProxyBuilder(const FWPFHcalClusterRPZProxyBuilder &) = delete;
   const FWPFHcalClusterRPZProxyBuilder &operator=(const FWPFHcalClusterRPZProxyBuilder &) = delete;
 };

--- a/Fireworks/ParticleFlow/plugins/FWPFEcalRecHitLegoProxyBuilder.h
+++ b/Fireworks/ParticleFlow/plugins/FWPFEcalRecHitLegoProxyBuilder.h
@@ -62,12 +62,13 @@ protected:
                          FWViewType::EType viewType,
                          const FWViewContext* vc) override;
 
-private:
+public:
   // Disable default copy constructor
   FWPFEcalRecHitLegoProxyBuilder(const FWPFEcalRecHitLegoProxyBuilder&) = delete;
   // Disable default assignment operator
   const FWPFEcalRecHitLegoProxyBuilder& operator=(const FWPFEcalRecHitLegoProxyBuilder&) = delete;
 
+private:
   // ----------------------- Data Members ----------------------------
   float m_maxEnergy;
   float m_maxEt;

--- a/Fireworks/ParticleFlow/plugins/FWPFEcalRecHitRPProxyBuilder.h
+++ b/Fireworks/ParticleFlow/plugins/FWPFEcalRecHitRPProxyBuilder.h
@@ -49,10 +49,10 @@ public:
 
   REGISTER_PROXYBUILDER_METHODS();
 
-private:
   FWPFEcalRecHitRPProxyBuilder(const FWPFEcalRecHitRPProxyBuilder &) = delete;                   // Stop default
   const FWPFEcalRecHitRPProxyBuilder &operator=(const FWPFEcalRecHitRPProxyBuilder &) = delete;  // Stop default
 
+private:
   // --------------------- Member Functions --------------------------
   TEveVector calculateCentre(const float *corners);
 

--- a/Fireworks/ParticleFlow/plugins/FWPFPatJet3DProxyBuilder.h
+++ b/Fireworks/ParticleFlow/plugins/FWPFPatJet3DProxyBuilder.h
@@ -36,10 +36,10 @@ public:
   FWPFPatJet3DProxyBuilder();
   ~FWPFPatJet3DProxyBuilder() override;
 
-private:
   FWPFPatJet3DProxyBuilder(const FWPFPatJet3DProxyBuilder&) = delete;                   // Stop default
   const FWPFPatJet3DProxyBuilder& operator=(const FWPFPatJet3DProxyBuilder&) = delete;  // Stop default
 
+private:
   // --------------------- Member Functions --------------------------
   using FWSimpleProxyBuilderTemplate<T>::build;
   void build(const T&, unsigned int, TEveElement&, const FWViewContext*) override;

--- a/Fireworks/ParticleFlow/plugins/FWPFPatJetLegoProxyBuilder.h
+++ b/Fireworks/ParticleFlow/plugins/FWPFPatJetLegoProxyBuilder.h
@@ -46,7 +46,6 @@ public:
   using FWSimpleProxyBuilderTemplate<T>::build;
   void build(const T&, unsigned int, TEveElement&, const FWViewContext*) override;
 
-private:
   FWPFPatJetLegoProxyBuilder(const FWPFPatJetLegoProxyBuilder&) = delete;             //stop default
   const FWPFPatJetLegoProxyBuilder& operator=(FWPFPatJetLegoProxyBuilder&) = delete;  //stop default
 

--- a/Fireworks/ParticleFlow/plugins/FWPFTrack3DProxyBuilder.h
+++ b/Fireworks/ParticleFlow/plugins/FWPFTrack3DProxyBuilder.h
@@ -32,7 +32,6 @@ public:
   void build(const reco::Track& iData, unsigned int iIndex, TEveElement& oItemHolder, const FWViewContext* vc) override;
   REGISTER_PROXYBUILDER_METHODS();
 
-private:
   FWPFTrack3DProxyBuilder(const FWPFTrack3DProxyBuilder&) = delete;
   const FWPFTrack3DProxyBuilder& operator=(const FWPFTrack3DProxyBuilder&) = delete;
 

--- a/Fireworks/ParticleFlow/plugins/FWPFTrackLegoProxyBuilder.h
+++ b/Fireworks/ParticleFlow/plugins/FWPFTrackLegoProxyBuilder.h
@@ -33,10 +33,10 @@ public:
 
   REGISTER_PROXYBUILDER_METHODS();
 
-private:
   FWPFTrackLegoProxyBuilder(const FWPFTrackLegoProxyBuilder&) = delete;
   const FWPFTrackLegoProxyBuilder& operator=(const FWPFTrackLegoProxyBuilder&) = delete;
 
+private:
   // --------------------- Member Functions --------------------------
   using FWSimpleProxyBuilderTemplate<reco::Track>::build;
   void build(const reco::Track& iData, unsigned int iIndex, TEveElement& oItemHolder, const FWViewContext* vc) override;

--- a/Fireworks/ParticleFlow/plugins/FWPFTrackRPZProxyBuilder.h
+++ b/Fireworks/ParticleFlow/plugins/FWPFTrackRPZProxyBuilder.h
@@ -31,7 +31,6 @@ public:
   void build(const reco::Track& iData, unsigned int iIndex, TEveElement& oItemHolder, const FWViewContext* vc) override;
   REGISTER_PROXYBUILDER_METHODS();
 
-private:
   FWPFTrackRPZProxyBuilder(const FWPFTrackRPZProxyBuilder&) = delete;
   const FWPFTrackRPZProxyBuilder& operator=(const FWPFTrackRPZProxyBuilder&) = delete;
 

--- a/Fireworks/SimData/plugins/FWCaloParticleProxyBuilder.cc
+++ b/Fireworks/SimData/plugins/FWCaloParticleProxyBuilder.cc
@@ -22,12 +22,12 @@ public:
 
   REGISTER_PROXYBUILDER_METHODS();
 
-private:
   // Disable default copy constructor
   FWCaloParticleProxyBuilder(const FWCaloParticleProxyBuilder &) = delete;
   // Disable default assignment operator
   const FWCaloParticleProxyBuilder &operator=(const FWCaloParticleProxyBuilder &) = delete;
 
+private:
   void build(const CaloParticle &iData, unsigned int iIndex, TEveElement &oItemHolder, const FWViewContext *) override;
 };
 

--- a/Fireworks/SimData/plugins/FWECaloParticleProxyBuilder.cc
+++ b/Fireworks/SimData/plugins/FWECaloParticleProxyBuilder.cc
@@ -14,12 +14,12 @@ public:
 
   REGISTER_PROXYBUILDER_METHODS();
 
-private:
   // Disable default copy constructor
   FWECaloParticleProxyBuilder(const FWECaloParticleProxyBuilder &) = delete;
   // Disable default assignment operator
   const FWECaloParticleProxyBuilder &operator=(const FWECaloParticleProxyBuilder &) = delete;
 
+private:
   void build(const CaloParticle &iData, unsigned int iIndex, TEveElement &oItemHolder, const FWViewContext *) override;
 };
 

--- a/Fireworks/SimData/plugins/FWPCaloHitProxyBuilder.cc
+++ b/Fireworks/SimData/plugins/FWPCaloHitProxyBuilder.cc
@@ -21,10 +21,10 @@ public:
 
   REGISTER_PROXYBUILDER_METHODS();
 
-private:
   FWPCaloHitProxyBuilder(const FWPCaloHitProxyBuilder&) = delete;
   const FWPCaloHitProxyBuilder& operator=(const FWPCaloHitProxyBuilder&) = delete;
 
+private:
   using FWDigitSetProxyBuilder::build;
   void build(const FWEventItem* iItem, TEveElementList* product, const FWViewContext*) override;
 };

--- a/Fireworks/SimData/plugins/FWPSimHitProxyBuilder.cc
+++ b/Fireworks/SimData/plugins/FWPSimHitProxyBuilder.cc
@@ -24,12 +24,12 @@ public:
 
   REGISTER_PROXYBUILDER_METHODS();
 
-private:
   // Disable default copy constructor
   FWPSimHitProxyBuilder(const FWPSimHitProxyBuilder&) = delete;
   // Disable default assignment operator
   const FWPSimHitProxyBuilder& operator=(const FWPSimHitProxyBuilder&) = delete;
 
+private:
   using FWSimpleProxyBuilderTemplate<PSimHit>::buildViewType;
   void buildViewType(const PSimHit& iData,
                      unsigned int iIndex,

--- a/Fireworks/SimData/plugins/FWSimTrackProxyBuilder.cc
+++ b/Fireworks/SimData/plugins/FWSimTrackProxyBuilder.cc
@@ -27,12 +27,12 @@ public:
 
   REGISTER_PROXYBUILDER_METHODS();
 
-private:
   // Disable default copy constructor
   FWSimTrackProxyBuilder(const FWSimTrackProxyBuilder&) = delete;
   // Disable default assignment operator
   const FWSimTrackProxyBuilder& operator=(const FWSimTrackProxyBuilder&) = delete;
 
+private:
   using FWProxyBuilderBase::build;
   void build(const FWEventItem* iItem, TEveElementList* product, const FWViewContext*) override;
 

--- a/Fireworks/SimData/plugins/FWSimVertexProxyBuilder.cc
+++ b/Fireworks/SimData/plugins/FWSimVertexProxyBuilder.cc
@@ -18,12 +18,12 @@ public:
 
   REGISTER_PROXYBUILDER_METHODS();
 
-private:
   // Disable default copy constructor
   FWSimVertexProxyBuilder(const FWSimVertexProxyBuilder&) = delete;
   // Disable default assignment operator
   const FWSimVertexProxyBuilder& operator=(const FWSimVertexProxyBuilder&) = delete;
 
+private:
   using FWSimpleProxyBuilderTemplate<SimVertex>::build;
   void build(const SimVertex& iData, unsigned int iIndex, TEveElement& oItemHolder, const FWViewContext*) override;
 };

--- a/Fireworks/SimData/plugins/FWTrackingParticleProxyBuilder.cc
+++ b/Fireworks/SimData/plugins/FWTrackingParticleProxyBuilder.cc
@@ -29,12 +29,12 @@ public:
 
   REGISTER_PROXYBUILDER_METHODS();
 
-private:
   // Disable default copy constructor
   FWTrackingParticleProxyBuilder(const FWTrackingParticleProxyBuilder&) = delete;
   // Disable default assignment operator
   const FWTrackingParticleProxyBuilder& operator=(const FWTrackingParticleProxyBuilder&) = delete;
 
+private:
   using FWSimpleProxyBuilderTemplate<TrackingParticle>::build;
   void build(const TrackingParticle& iData,
              unsigned int iIndex,

--- a/Fireworks/SimData/plugins/FWTrackingVertexProxyBuilder.cc
+++ b/Fireworks/SimData/plugins/FWTrackingVertexProxyBuilder.cc
@@ -20,12 +20,12 @@ public:
 
   REGISTER_PROXYBUILDER_METHODS();
 
-private:
   // Disable default copy constructor
   FWTrackingVertexProxyBuilder(const FWTrackingVertexProxyBuilder&) = delete;
   // Disable default assignment operator
   const FWTrackingVertexProxyBuilder& operator=(const FWTrackingVertexProxyBuilder&) = delete;
 
+private:
   using FWSimpleProxyBuilderTemplate<TrackingVertex>::build;
   void build(const TrackingVertex& iData, unsigned int iIndex, TEveElement& oItemHolder, const FWViewContext*) override;
 };

--- a/Fireworks/TableWidget/interface/FWFramedTextTableCellRenderer.h
+++ b/Fireworks/TableWidget/interface/FWFramedTextTableCellRenderer.h
@@ -57,11 +57,11 @@ public:
 
   void draw(Drawable_t iID, int iX, int iY, unsigned int iWidth, unsigned int iHeight) override;
 
-private:
   FWFramedTextTableCellRenderer(const FWFramedTextTableCellRenderer&) = delete;  // stop default
 
   const FWFramedTextTableCellRenderer& operator=(const FWFramedTextTableCellRenderer&) = delete;  // stop default
 
+private:
   // ---------- member data --------------------------------
   const TGGC* m_context;
   const TGGC* m_frameContext;

--- a/Fireworks/TableWidget/interface/FWTableCellRendererBase.h
+++ b/Fireworks/TableWidget/interface/FWTableCellRendererBase.h
@@ -69,7 +69,6 @@ public:
       */
   virtual void buttonEvent(Event_t* iClickEvent, int iRelClickX, int iRelClickY);
 
-private:
   FWTableCellRendererBase(const FWTableCellRendererBase&) = delete;  // stop default
 
   const FWTableCellRendererBase& operator=(const FWTableCellRendererBase&) = delete;  // stop default

--- a/Fireworks/TableWidget/interface/FWTextTableCellRenderer.h
+++ b/Fireworks/TableWidget/interface/FWTextTableCellRenderer.h
@@ -61,11 +61,11 @@ public:
 
   void draw(Drawable_t iID, int iX, int iY, unsigned int iWidth, unsigned int iHeight) override;
 
-private:
   FWTextTableCellRenderer(const FWTextTableCellRenderer&) = delete;  // stop default
 
   const FWTextTableCellRenderer& operator=(const FWTextTableCellRenderer&) = delete;  // stop default
 
+private:
   // ---------- member data --------------------------------
   const TGGC* m_context;
   const TGGC* m_highlightContext;

--- a/Fireworks/TableWidget/src/FWAdapterHeaderTableManager.h
+++ b/Fireworks/TableWidget/src/FWAdapterHeaderTableManager.h
@@ -46,11 +46,11 @@ public:
   // ---------- member functions ---------------------------
   void implSort(int col, bool sortOrder) override;
 
-private:
   FWAdapterHeaderTableManager(const FWAdapterHeaderTableManager&) = delete;  // stop default
 
   const FWAdapterHeaderTableManager& operator=(const FWAdapterHeaderTableManager&) = delete;  // stop default
 
+private:
   // ---------- member data --------------------------------
   const FWTableManagerBase* m_table;
   FWColumnLabelCellRenderer* m_renderer;

--- a/Fireworks/TableWidget/src/FWAdapterRowHeaderTableManager.h
+++ b/Fireworks/TableWidget/src/FWAdapterRowHeaderTableManager.h
@@ -45,11 +45,11 @@ public:
   // ---------- member functions ---------------------------
   void implSort(int col, bool sortOrder) override;
 
-private:
   FWAdapterRowHeaderTableManager(const FWAdapterRowHeaderTableManager&) = delete;  // stop default
 
   const FWAdapterRowHeaderTableManager& operator=(const FWAdapterRowHeaderTableManager&) = delete;  // stop default
 
+private:
   // ---------- member data --------------------------------
   const FWTableManagerBase* m_table;
 };

--- a/Fireworks/Tracks/plugins/FWBeamSpotOnlineProxyBuilder.cc
+++ b/Fireworks/Tracks/plugins/FWBeamSpotOnlineProxyBuilder.cc
@@ -21,12 +21,12 @@ public:
 
   REGISTER_PROXYBUILDER_METHODS();
 
-private:
   // Disable default copy constructor
   FWBeamSpotOnlineProxyBuilder(const FWBeamSpotOnlineProxyBuilder&) = delete;
   // Disable default assignment operator
   const FWBeamSpotOnlineProxyBuilder& operator=(const FWBeamSpotOnlineProxyBuilder&) = delete;
 
+private:
   using FWSimpleProxyBuilderTemplate<BeamSpotOnline>::build;
   void build(const BeamSpotOnline& iData, unsigned int iIndex, TEveElement& oItemHolder, const FWViewContext*) override;
 };

--- a/Fireworks/Tracks/plugins/FWBeamSpotProxyBuilder.cc
+++ b/Fireworks/Tracks/plugins/FWBeamSpotProxyBuilder.cc
@@ -19,11 +19,12 @@ public:
 
   REGISTER_PROXYBUILDER_METHODS();
 
-private:
   // Disable default copy constructor
   FWBeamSpotProxyBuilder(const FWBeamSpotProxyBuilder&) = delete;
   // Disable default assignment operator
   const FWBeamSpotProxyBuilder& operator=(const FWBeamSpotProxyBuilder&) = delete;
+
+private:
   void localModelChanges(const FWModelId& iId,
                          TEveElement* parent,
                          FWViewType::EType viewType,

--- a/Fireworks/Tracks/plugins/FWPhase2TrackerCluster1DDetProxyBuilder.cc
+++ b/Fireworks/Tracks/plugins/FWPhase2TrackerCluster1DDetProxyBuilder.cc
@@ -24,6 +24,7 @@ public:
 private:
   using FWProxyBuilderBase::build;
   void build(const FWEventItem* iItem, TEveElementList* product, const FWViewContext*) override;
+
 public:
   FWPhase2TrackerCluster1DDetProxyBuilder(const FWPhase2TrackerCluster1DDetProxyBuilder&) = delete;
   const FWPhase2TrackerCluster1DDetProxyBuilder& operator=(const FWPhase2TrackerCluster1DDetProxyBuilder&) = delete;

--- a/Fireworks/Tracks/plugins/FWPhase2TrackerCluster1DDetProxyBuilder.cc
+++ b/Fireworks/Tracks/plugins/FWPhase2TrackerCluster1DDetProxyBuilder.cc
@@ -24,6 +24,7 @@ public:
 private:
   using FWProxyBuilderBase::build;
   void build(const FWEventItem* iItem, TEveElementList* product, const FWViewContext*) override;
+public:
   FWPhase2TrackerCluster1DDetProxyBuilder(const FWPhase2TrackerCluster1DDetProxyBuilder&) = delete;
   const FWPhase2TrackerCluster1DDetProxyBuilder& operator=(const FWPhase2TrackerCluster1DDetProxyBuilder&) = delete;
 };

--- a/Fireworks/Tracks/plugins/FWSiPixelClusterDetProxyBuilder.cc
+++ b/Fireworks/Tracks/plugins/FWSiPixelClusterDetProxyBuilder.cc
@@ -27,6 +27,7 @@ public:
 private:
   using FWProxyBuilderBase::build;
   void build(const FWEventItem* iItem, TEveElementList* product, const FWViewContext*) override;
+public:
   FWSiPixelClusterDetProxyBuilder(const FWSiPixelClusterDetProxyBuilder&) = delete;
   const FWSiPixelClusterDetProxyBuilder& operator=(const FWSiPixelClusterDetProxyBuilder&) = delete;
 };

--- a/Fireworks/Tracks/plugins/FWSiPixelClusterDetProxyBuilder.cc
+++ b/Fireworks/Tracks/plugins/FWSiPixelClusterDetProxyBuilder.cc
@@ -27,6 +27,7 @@ public:
 private:
   using FWProxyBuilderBase::build;
   void build(const FWEventItem* iItem, TEveElementList* product, const FWViewContext*) override;
+
 public:
   FWSiPixelClusterDetProxyBuilder(const FWSiPixelClusterDetProxyBuilder&) = delete;
   const FWSiPixelClusterDetProxyBuilder& operator=(const FWSiPixelClusterDetProxyBuilder&) = delete;

--- a/Fireworks/Tracks/plugins/FWSiPixelClusterProxyBuilder.cc
+++ b/Fireworks/Tracks/plugins/FWSiPixelClusterProxyBuilder.cc
@@ -28,12 +28,12 @@ public:
 
   REGISTER_PROXYBUILDER_METHODS();
 
-private:
   // Disable default copy constructor
   FWSiPixelClusterProxyBuilder(const FWSiPixelClusterProxyBuilder&) = delete;
   // Disable default assignment operator
   const FWSiPixelClusterProxyBuilder& operator=(const FWSiPixelClusterProxyBuilder&) = delete;
 
+private:
   using FWProxyBuilderBase::build;
   void build(const FWEventItem* iItem, TEveElementList* product, const FWViewContext*) override;
 };

--- a/Fireworks/Tracks/plugins/FWSiPixelDigiProxyBuilder.cc
+++ b/Fireworks/Tracks/plugins/FWSiPixelDigiProxyBuilder.cc
@@ -27,12 +27,12 @@ public:
 
   REGISTER_PROXYBUILDER_METHODS();
 
-private:
   // Disable default copy constructor
   FWSiPixelDigiProxyBuilder(const FWSiPixelDigiProxyBuilder&) = delete;
   // Disable default assignment operator
   const FWSiPixelDigiProxyBuilder& operator=(const FWSiPixelDigiProxyBuilder&) = delete;
 
+private:
   using FWProxyBuilderBase::build;
   void build(const FWEventItem* iItem, TEveElementList* product, const FWViewContext*) override;
 };

--- a/Fireworks/Tracks/plugins/FWSiStripClusterProxyBuilder.cc
+++ b/Fireworks/Tracks/plugins/FWSiStripClusterProxyBuilder.cc
@@ -33,10 +33,11 @@ protected:
                          FWViewType::EType viewType,
                          const FWViewContext* vc) override;
 
-private:
+public:
   FWSiStripClusterProxyBuilder(const FWSiStripClusterProxyBuilder&) = delete;
   const FWSiStripClusterProxyBuilder& operator=(const FWSiStripClusterProxyBuilder&) = delete;
 
+private:
   TEveElementList* m_shapeList;
 };
 

--- a/Fireworks/Tracks/plugins/FWSiStripDigiProxyBuilder.cc
+++ b/Fireworks/Tracks/plugins/FWSiStripDigiProxyBuilder.cc
@@ -30,6 +30,7 @@ public:
 private:
   using FWProxyBuilderBase::build;
   void build(const FWEventItem* iItem, TEveElementList* product, const FWViewContext*) override;
+public:
   FWSiStripDigiProxyBuilder(const FWSiStripDigiProxyBuilder&) = delete;
   const FWSiStripDigiProxyBuilder& operator=(const FWSiStripDigiProxyBuilder&) = delete;
 };

--- a/Fireworks/Tracks/plugins/FWSiStripDigiProxyBuilder.cc
+++ b/Fireworks/Tracks/plugins/FWSiStripDigiProxyBuilder.cc
@@ -30,6 +30,7 @@ public:
 private:
   using FWProxyBuilderBase::build;
   void build(const FWEventItem* iItem, TEveElementList* product, const FWViewContext*) override;
+
 public:
   FWSiStripDigiProxyBuilder(const FWSiStripDigiProxyBuilder&) = delete;
   const FWSiStripDigiProxyBuilder& operator=(const FWSiStripDigiProxyBuilder&) = delete;

--- a/Fireworks/Tracks/plugins/FWTrackECALDetailView.cc
+++ b/Fireworks/Tracks/plugins/FWTrackECALDetailView.cc
@@ -6,7 +6,6 @@ public:
   FWTrackECALDetailView() {}
   ~FWTrackECALDetailView() override {}
 
-private:
   FWTrackECALDetailView(const FWTrackECALDetailView&) = delete;                   // stop default
   const FWTrackECALDetailView& operator=(const FWTrackECALDetailView&) = delete;  // stop default
 };

--- a/Fireworks/Tracks/plugins/FWTrackHitsDetailView.h
+++ b/Fireworks/Tracks/plugins/FWTrackHitsDetailView.h
@@ -33,10 +33,11 @@ protected:
   TGSlider* m_slider;
   FWIntValueListener* m_sliderListener;
 
-private:
+public:
   FWTrackHitsDetailView(const FWTrackHitsDetailView&) = delete;                   // stop default
   const FWTrackHitsDetailView& operator=(const FWTrackHitsDetailView&) = delete;  // stop default
 
+private:
   using FWDetailView<reco::Track>::build;
   void build(const FWModelId& id, const reco::Track*) override;
   using FWDetailView<reco::Track>::setTextInfo;

--- a/Fireworks/Tracks/plugins/FWTrackProxyBuilder.cc
+++ b/Fireworks/Tracks/plugins/FWTrackProxyBuilder.cc
@@ -32,11 +32,11 @@ public:
 
   void setItem(const FWEventItem* iItem) override;
 
-private:
   FWTrackProxyBuilder(const FWTrackProxyBuilder&) = delete;  // stop default
 
   const FWTrackProxyBuilder& operator=(const FWTrackProxyBuilder&) = delete;  // stop default
 
+private:
   using FWSimpleProxyBuilderTemplate<reco::Track>::build;
   void build(const reco::Track& iData, unsigned int iIndex, TEveElement& oItemHolder, const FWViewContext*) override;
 };

--- a/Fireworks/Tracks/plugins/FWTrackResidualDetailView.h
+++ b/Fireworks/Tracks/plugins/FWTrackResidualDetailView.h
@@ -49,10 +49,10 @@ public:
   FWTrackResidualDetailView();
   ~FWTrackResidualDetailView() override;
 
-private:
   FWTrackResidualDetailView(const FWTrackResidualDetailView &) = delete;                   // stop default
   const FWTrackResidualDetailView &operator=(const FWTrackResidualDetailView &) = delete;  // stop default
 
+private:
   using FWDetailViewCanvas<reco::Track>::build;
   void build(const FWModelId &id, const reco::Track *) override;
   using FWDetailViewCanvas<reco::Track>::setTextInfo;

--- a/Fireworks/Tracks/plugins/FWTrackTrackingRecHitProxyBuilder.cc
+++ b/Fireworks/Tracks/plugins/FWTrackTrackingRecHitProxyBuilder.cc
@@ -20,7 +20,7 @@ public:
 private:
   using FWSimpleProxyBuilderTemplate<reco::Track>::build;
   void build(const reco::Track& iData, unsigned int iIndex, TEveElement& oItemHolder, const FWViewContext*) override;
-
+public:
   FWTrackTrackingRecHitProxyBuilder(const FWTrackTrackingRecHitProxyBuilder&) = delete;  // stop default
   const FWTrackTrackingRecHitProxyBuilder& operator=(const FWTrackTrackingRecHitProxyBuilder&) = delete;  // stop default
 };

--- a/Fireworks/Tracks/plugins/FWTrackTrackingRecHitProxyBuilder.cc
+++ b/Fireworks/Tracks/plugins/FWTrackTrackingRecHitProxyBuilder.cc
@@ -20,6 +20,7 @@ public:
 private:
   using FWSimpleProxyBuilderTemplate<reco::Track>::build;
   void build(const reco::Track& iData, unsigned int iIndex, TEveElement& oItemHolder, const FWViewContext*) override;
+
 public:
   FWTrackTrackingRecHitProxyBuilder(const FWTrackTrackingRecHitProxyBuilder&) = delete;  // stop default
   const FWTrackTrackingRecHitProxyBuilder& operator=(const FWTrackTrackingRecHitProxyBuilder&) = delete;  // stop default

--- a/Fireworks/Tracks/plugins/FWTracksModulesProxyBuilder.cc
+++ b/Fireworks/Tracks/plugins/FWTracksModulesProxyBuilder.cc
@@ -28,7 +28,7 @@ public:
 private:
   using FWSimpleProxyBuilderTemplate<reco::Track>::build;
   void build(const reco::Track& iData, unsigned int iIndex, TEveElement& oItemHolder, const FWViewContext*) override;
-
+public:
   FWTracksModulesProxyBuilder(const FWTracksModulesProxyBuilder&) = delete;                   // stop default
   const FWTracksModulesProxyBuilder& operator=(const FWTracksModulesProxyBuilder&) = delete;  // stop default
 };

--- a/Fireworks/Tracks/plugins/FWTracksModulesProxyBuilder.cc
+++ b/Fireworks/Tracks/plugins/FWTracksModulesProxyBuilder.cc
@@ -28,6 +28,7 @@ public:
 private:
   using FWSimpleProxyBuilderTemplate<reco::Track>::build;
   void build(const reco::Track& iData, unsigned int iIndex, TEveElement& oItemHolder, const FWViewContext*) override;
+
 public:
   FWTracksModulesProxyBuilder(const FWTracksModulesProxyBuilder&) = delete;                   // stop default
   const FWTracksModulesProxyBuilder& operator=(const FWTracksModulesProxyBuilder&) = delete;  // stop default

--- a/Fireworks/Tracks/plugins/FWTracksRecHitsProxyBuilder.cc
+++ b/Fireworks/Tracks/plugins/FWTracksRecHitsProxyBuilder.cc
@@ -27,6 +27,7 @@ public:
 private:
   using FWSimpleProxyBuilderTemplate<reco::Track>::build;
   void build(const reco::Track& iData, unsigned int iIndex, TEveElement& oItemHolder, const FWViewContext*) override;
+
 public:
   FWTracksRecHitsProxyBuilder(const FWTracksRecHitsProxyBuilder&) = delete;                   // stop default
   const FWTracksRecHitsProxyBuilder& operator=(const FWTracksRecHitsProxyBuilder&) = delete;  // stop default

--- a/Fireworks/Tracks/plugins/FWTracksRecHitsProxyBuilder.cc
+++ b/Fireworks/Tracks/plugins/FWTracksRecHitsProxyBuilder.cc
@@ -27,7 +27,7 @@ public:
 private:
   using FWSimpleProxyBuilderTemplate<reco::Track>::build;
   void build(const reco::Track& iData, unsigned int iIndex, TEveElement& oItemHolder, const FWViewContext*) override;
-
+public:
   FWTracksRecHitsProxyBuilder(const FWTracksRecHitsProxyBuilder&) = delete;                   // stop default
   const FWTracksRecHitsProxyBuilder& operator=(const FWTracksRecHitsProxyBuilder&) = delete;  // stop default
 };

--- a/Fireworks/Tracks/plugins/FWTrajectorySeedProxyBuilder.cc
+++ b/Fireworks/Tracks/plugins/FWTrajectorySeedProxyBuilder.cc
@@ -35,11 +35,11 @@ public:
 
   REGISTER_PROXYBUILDER_METHODS();
 
-private:
   FWTrajectorySeedProxyBuilder(const FWTrajectorySeedProxyBuilder&) = delete;  // stop default
 
   const FWTrajectorySeedProxyBuilder& operator=(const FWTrajectorySeedProxyBuilder&) = delete;  // stop default
 
+private:
   using FWSimpleProxyBuilderTemplate<TrajectorySeed>::build;
   void build(const TrajectorySeed& iData, unsigned int iIndex, TEveElement& oItemHolder, const FWViewContext*) override;
 };

--- a/Fireworks/Vertices/plugins/FWSecVertexCandidateProxyBuilder.cc
+++ b/Fireworks/Vertices/plugins/FWSecVertexCandidateProxyBuilder.cc
@@ -28,10 +28,10 @@ public:
 
   REGISTER_PROXYBUILDER_METHODS();
 
-private:
   FWSecVertexCandidateProxyBuilder(const FWSecVertexCandidateProxyBuilder&) = delete;                   // stop default
   const FWSecVertexCandidateProxyBuilder& operator=(const FWSecVertexCandidateProxyBuilder&) = delete;  // stop default
 
+private:
   // ---------- member data --------------------------------
   using FWSimpleProxyBuilderTemplate<reco::CandSecondaryVertexTagInfo>::build;
   void build(const reco::CandSecondaryVertexTagInfo& iData,

--- a/Fireworks/Vertices/plugins/FWSecVertexProxyBuilder.cc
+++ b/Fireworks/Vertices/plugins/FWSecVertexProxyBuilder.cc
@@ -26,10 +26,10 @@ public:
 
   REGISTER_PROXYBUILDER_METHODS();
 
-private:
   FWSecVertexProxyBuilder(const FWSecVertexProxyBuilder&) = delete;                   // stop default
   const FWSecVertexProxyBuilder& operator=(const FWSecVertexProxyBuilder&) = delete;  // stop default
 
+private:
   // ---------- member data --------------------------------
   using FWSimpleProxyBuilderTemplate<reco::SecondaryVertexTagInfo>::build;
   void build(const reco::SecondaryVertexTagInfo& iData,

--- a/Fireworks/Vertices/plugins/FWVertexCandidateProxyBuilder.cc
+++ b/Fireworks/Vertices/plugins/FWVertexCandidateProxyBuilder.cc
@@ -57,10 +57,10 @@ public:
 
   REGISTER_PROXYBUILDER_METHODS();
 
-private:
   FWVertexCandidateProxyBuilder(const FWVertexCandidateProxyBuilder&) = delete;                   // stop default
   const FWVertexCandidateProxyBuilder& operator=(const FWVertexCandidateProxyBuilder&) = delete;  // stop default
 
+private:
   using FWSimpleProxyBuilderTemplate<reco::VertexCompositePtrCandidate>::build;
   void build(const reco::VertexCompositePtrCandidate& iData,
              unsigned int iIndex,

--- a/Fireworks/Vertices/plugins/FWVertexProxyBuilder.cc
+++ b/Fireworks/Vertices/plugins/FWVertexProxyBuilder.cc
@@ -58,10 +58,10 @@ public:
 
   REGISTER_PROXYBUILDER_METHODS();
 
-private:
   FWVertexProxyBuilder(const FWVertexProxyBuilder&) = delete;                   // stop default
   const FWVertexProxyBuilder& operator=(const FWVertexProxyBuilder&) = delete;  // stop default
 
+private:
   using FWSimpleProxyBuilderTemplate<reco::Vertex>::build;
   void build(const reco::Vertex& iData, unsigned int iIndex, TEveElement& oItemHolder, const FWViewContext*) override;
 


### PR DESCRIPTION
We have over 25K clang-tidy warnings about `deleted member function should be public [modernize-use-equals-delete]`. 7.5K of these come from Fireworks sub-system.
Locally tested, it build and all of the `modernize-use-equals-delete` warnings are fixed.

[a]
```
Fireworks/Core/interface/FWGenericParameter.h:78:3: warning: deleted member function should be public [modernize-use-equals-delete]
  FWGenericParameter(const FWGenericParameter&) = delete;                   // stop default
  ^
Fireworks/Core/interface/FWGenericParameter.h:79:29: warning: deleted member function should be public [modernize-use-equals-delete]
  const FWGenericParameter& operator=(const FWGenericParameter&) = delete;  // stop default
                            ^
Fireworks/Core/interface/FWParameterBase.h:47:3: warning: deleted member function should be public [modernize-use-equals-delete]
  FWParameterBase(const FWParameterBase&) = delete;                   // stop default
  ^
Fireworks/Core/interface/FWParameterBase.h:48:26: warning: deleted member function should be public [modernize-use-equals-delete]
  const FWParameterBase& operator=(const FWParameterBase&) = delete;  // stop default

```