### PR TITLE
[HGCAL] Merging tracksters which have same track as seed

### DIFF
--- a/RecoHGCal/TICL/plugins/TrackstersMergeProducer.cc
+++ b/RecoHGCal/TICL/plugins/TrackstersMergeProducer.cc
@@ -228,8 +228,9 @@ void TrackstersMergeProducer::produce(edm::Event &evt, const edm::EventSetup &es
 
   for (auto const &tTRK : trackstersTRK) {
     auto iseed = seedToTracksterAssociator.find(tTRK.seedIndex());
-    if ( iseed != seedToTracksterAssociator.end()) {
-      LogDebug("TrackstersMergeProducer") << "This seed ("<< tTRK.seedIndex() << ") exists already in the map. Merging tracksters. ";
+    if (iseed != seedToTracksterAssociator.end()) {
+      LogDebug("TrackstersMergeProducer")
+          << "This seed (" << tTRK.seedIndex() << ") exists already in the map. Merging tracksters. ";
       Trackster tMerged;
       for (const auto &tracksterIterationPair : seedToTracksterAssociator[tTRK.seedIndex()]) {
         auto tTRKEM = resultTrackstersMerged->at(tracksterIterationPair.first);
@@ -241,15 +242,11 @@ void TrackstersMergeProducer::produce(edm::Event &evt, const edm::EventSetup &es
         tMerged.vertex_multiplicity().reserve(updated_vertices_size);
 
         // merging vertices, TRKEM first
-        std::copy(std::begin(tTRKEM.vertices()),
-                  std::end(tTRKEM.vertices()),
-                  std::back_inserter(tMerged.vertices()));
+        std::copy(std::begin(tTRKEM.vertices()), std::end(tTRKEM.vertices()), std::back_inserter(tMerged.vertices()));
         std::copy(std::begin(tTRKEM.vertex_multiplicity()),
                   std::end(tTRKEM.vertex_multiplicity()),
                   std::back_inserter(tMerged.vertex_multiplicity()));
-        std::copy(std::begin(tTRK.vertices()),
-                  std::end(tTRK.vertices()),
-                  std::back_inserter(tMerged.vertices()));
+        std::copy(std::begin(tTRK.vertices()), std::end(tTRK.vertices()), std::back_inserter(tMerged.vertices()));
         std::copy(std::begin(tTRK.vertex_multiplicity()),
                   std::end(tTRK.vertex_multiplicity()),
                   std::back_inserter(tMerged.vertex_multiplicity()));
@@ -259,7 +256,8 @@ void TrackstersMergeProducer::produce(edm::Event &evt, const edm::EventSetup &es
       }
     } else {
       indexInMergedCollTRK.push_back(resultTrackstersMerged->size());
-      seedToTracksterAssociator[tTRK.seedIndex()].emplace_back(resultTrackstersMerged->size(), TracksterIterIndex::TRKHAD);
+      seedToTracksterAssociator[tTRK.seedIndex()].emplace_back(resultTrackstersMerged->size(),
+                                                               TracksterIterIndex::TRKHAD);
       resultTrackstersMerged->push_back(tTRK);
     }
   }
@@ -275,7 +273,7 @@ void TrackstersMergeProducer::produce(edm::Event &evt, const edm::EventSetup &es
                         rhtools_.getPositionLayer(rhtools_.lastLayerEE()).z());
   energyRegressionAndID(layerClusters, *resultTrackstersMerged);
 
-  LogDebug("TrackstersMergeProducer") << "resultTrackstersMerged: " ;
+  LogDebug("TrackstersMergeProducer") << "resultTrackstersMerged: ";
   printTrackstersDebug(*resultTrackstersMerged);
 
   auto trackstersMergedHandle = evt.put(std::move(resultTrackstersMerged));
@@ -550,7 +548,7 @@ void TrackstersMergeProducer::produce(edm::Event &evt, const edm::EventSetup &es
   assignTimeToCandidates(*resultCandidates);
 
   printCandidatesDebug(*resultCandidates);
-  
+
   evt.put(std::move(resultCandidates));
 }
 
@@ -736,8 +734,7 @@ void TrackstersMergeProducer::globalEndJob(TrackstersCache *cache) {
   cache->eidGraphDef = nullptr;
 }
 
-void TrackstersMergeProducer::printTracksterDebug(const Trackster & t) const {
-
+void TrackstersMergeProducer::printTracksterDebug(const Trackster &t) const {
   auto e_over_h = (t.raw_em_pt() / ((t.raw_pt() - t.raw_em_pt()) != 0. ? (t.raw_pt() - t.raw_em_pt()) : 1.));
   LogDebug("TrackstersMergeProducer")
       << " TrackstersMergeProducer (#iter = " << t.ticlIteration() << ") obj barycenter: " << t.barycenter()
@@ -747,19 +744,17 @@ void TrackstersMergeProducer::printTracksterDebug(const Trackster & t) const {
       << " seedIndex: " << t.seedIndex() << " size: " << t.vertices().size() << " average usage: "
       << (std::accumulate(std::begin(t.vertex_multiplicity()), std::end(t.vertex_multiplicity()), 0.) /
           (float)t.vertex_multiplicity().size())
-      << " raw_energy: " << t.raw_energy() << " raw_em_energy: " << t.raw_em_energy() << " regressed energy: " << t.regressed_energy()
-      << " raw_pt: " << t.raw_pt() << " raw_em_pt: " << t.raw_em_pt() 
-      << " e_over_h: " << e_over_h
-      << " probs(ga/e/mu/np/cp/nh/am/unk): ";
-    for (auto const &p : t.id_probabilities()) {
-      LogTrace("TrackstersMergeProducer") << std::fixed << p << " ";
-    }
-    LogTrace("TrackstersMergeProducer") << " sigmas: ";
-    for (auto const &s : t.sigmas()) {
-      LogTrace("TrackstersMergeProducer") << s << " ";
-    }
-    LogDebug("TrackstersMergeProducer") << std::endl;
-
+      << " raw_energy: " << t.raw_energy() << " raw_em_energy: " << t.raw_em_energy()
+      << " regressed energy: " << t.regressed_energy() << " raw_pt: " << t.raw_pt() << " raw_em_pt: " << t.raw_em_pt()
+      << " e_over_h: " << e_over_h << " probs(ga/e/mu/np/cp/nh/am/unk): ";
+  for (auto const &p : t.id_probabilities()) {
+    LogTrace("TrackstersMergeProducer") << std::fixed << p << " ";
+  }
+  LogTrace("TrackstersMergeProducer") << " sigmas: ";
+  for (auto const &s : t.sigmas()) {
+    LogTrace("TrackstersMergeProducer") << s << " ";
+  }
+  LogDebug("TrackstersMergeProducer") << std::endl;
 }
 
 void TrackstersMergeProducer::printTrackstersDebug(const std::vector<Trackster> &tracksters) const {
@@ -786,7 +781,6 @@ void TrackstersMergeProducer::printCandidatesDebug(std::vector<TICLCandidate> &r
     }
   }
 }
-
 
 void TrackstersMergeProducer::fillDescriptions(edm::ConfigurationDescriptions &descriptions) {
   edm::ParameterSetDescription desc;

--- a/RecoHGCal/TICL/plugins/TrackstersMergeProducer.cc
+++ b/RecoHGCal/TICL/plugins/TrackstersMergeProducer.cc
@@ -230,17 +230,19 @@ void TrackstersMergeProducer::produce(edm::Event &evt, const edm::EventSetup &es
     auto iseed = seedToTracksterAssociator.find(t.seedIndex());
     if ( iseed != seedToTracksterAssociator.end()) {
       LogDebug("TrackstersMergeProducer") << "This seed ("<< t.seedIndex() << ") exists already in the map. Merging tracksters. ";
-      LogTrace("TrackstersMergeProducer") << "Current trackster energy = "<< t.raw_energy() ;
-      Trackster tMerged = t;
+      Trackster tMerged;
       for (const auto &tracksterIterationPair : seedToTracksterAssociator[t.seedIndex()]) {
         auto t2 = resultTrackstersMerged->at(tracksterIterationPair.first);
-        LogTrace("TrackstersMergeProducer") << "Previous trackster energy = "<< t2.raw_energy() ;
-        tMerged.addToRawEnergy(t2.raw_energy());
-        tMerged.addToRawEmEnergy(t2.raw_em_energy());
+        tMerged.setIteration(TracksterIterIndex::TRKHAD);
+        tMerged.setSeed(t.seedID(), t.seedIndex());
         tMerged.setRegressedEnergy(t.regressed_energy() + t2.regressed_energy());
+        tMerged.setRawEnergy(t.raw_energy() + t2.raw_energy());
+        tMerged.setRawEmEnergy(t.raw_em_energy() + t2.raw_em_energy());
+        tMerged.setRawPt(t.raw_pt());
+        tMerged.setRawEmPt(t.raw_em_pt());
+        tMerged.setBarycenter(t.barycenter());
         printTracksterDebug(tMerged);
         resultTrackstersMerged->at(tracksterIterationPair.first) = tMerged;
-//        std::replace(resultTrackstersMerged->begin(), resultTrackstersMerged->end(), t2, tMerged)
         //what about PCA, edges/vertices, barycentre, timing and probabilities?
       }
     } else {


### PR DESCRIPTION
#### PR description:

If the tracksters reconstructed in the TICL iterations TrkEM and Trk are built from the same track, these are merged. Currently this was taken care in the `TICLCandidates` but not in the `TracksterMerged` collection. 
Main result of the [improvement](https://ebrondol.web.cern.ch/ebrondol/HGCal/TrackstersMerge/singlepi/singlepi/plots1_Tracksters.html) w.r.t. the [vanilla](https://ebrondol.web.cern.ch/ebrondol/HGCal/sample_production/CMSSW_12_0_0_pre3_withPurity/singlepi/plots1_Tracksters.html): less tracksters are reconstructed but more energetic, as expected.

#### PR validation:

This PR was tested in 12_0_0_pre3 adding the PR #34311 for validation purposes.

Informing @felicepantaleo @rovere 