### PR TITLE
[FWCore][clang-tidy] make deleted function public

### DIFF
--- a/FWCore/FWLite/interface/AutoLibraryLoader.h
+++ b/FWCore/FWLite/interface/AutoLibraryLoader.h
@@ -24,6 +24,8 @@ public:
 private:
   static bool enabled_;
   AutoLibraryLoader();
+
+public:
   AutoLibraryLoader(const AutoLibraryLoader&) = delete;                   // stop default
   const AutoLibraryLoader& operator=(const AutoLibraryLoader&) = delete;  // stop default
 };

--- a/FWCore/FWLite/interface/AutoLibraryLoader.h
+++ b/FWCore/FWLite/interface/AutoLibraryLoader.h
@@ -21,13 +21,12 @@ public:
   /// load all known libraries holding dictionaries
   static void loadAll();
 
+  AutoLibraryLoader(const AutoLibraryLoader&) = delete;                   // stop default
+  const AutoLibraryLoader& operator=(const AutoLibraryLoader&) = delete;  // stop default
+
 private:
   static bool enabled_;
   AutoLibraryLoader();
-
-public:
-  AutoLibraryLoader(const AutoLibraryLoader&) = delete;                   // stop default
-  const AutoLibraryLoader& operator=(const AutoLibraryLoader&) = delete;  // stop default
 };
 
 #endif

--- a/FWCore/FWLite/src/BareRootProductGetter.h
+++ b/FWCore/FWLite/src/BareRootProductGetter.h
@@ -44,7 +44,7 @@ class BareRootProductGetter : public edm::EDProductGetter {
 public:
   BareRootProductGetter();
   ~BareRootProductGetter() override;
-  BareRootProductGetter(BareRootProductGetter const&) = delete;  // stop default
+  BareRootProductGetter(BareRootProductGetter const&) = delete;                   // stop default
   BareRootProductGetter const& operator=(BareRootProductGetter const&) = delete;  // stop default
 
   // ---------- const member functions ---------------------

--- a/FWCore/FWLite/src/BareRootProductGetter.h
+++ b/FWCore/FWLite/src/BareRootProductGetter.h
@@ -44,6 +44,8 @@ class BareRootProductGetter : public edm::EDProductGetter {
 public:
   BareRootProductGetter();
   ~BareRootProductGetter() override;
+  BareRootProductGetter(BareRootProductGetter const&) = delete;  // stop default
+  BareRootProductGetter const& operator=(BareRootProductGetter const&) = delete;  // stop default
 
   // ---------- const member functions ---------------------
   edm::WrapperBase const* getIt(edm::ProductID const&) const override;
@@ -102,10 +104,6 @@ private:
     Long_t eventEntry_;  //the event Entry used with the last GetEntry call
     edm::propagate_const<TClass*> class_;
   };
-
-  BareRootProductGetter(BareRootProductGetter const&) = delete;  // stop default
-
-  BareRootProductGetter const& operator=(BareRootProductGetter const&) = delete;  // stop default
 
   Buffer* createNewBuffer(edm::BranchID const&) const;
   edm::ThinnedAssociation const* getThinnedAssociation(edm::BranchID const& branchID, Long_t eventEntry) const;

--- a/FWCore/FWLite/src/branchToClass.cc
+++ b/FWCore/FWLite/src/branchToClass.cc
@@ -23,7 +23,6 @@ namespace {
   public:
     static TClass* doit(const TBranch* iBranch);
 
-  private:
     ///NOTE: do not call this, it is only here because ROOT demands it
     BranchToClass() = delete;
   };

--- a/FWCore/Framework/interface/ESPreFunctorDecorator.h
+++ b/FWCore/Framework/interface/ESPreFunctorDecorator.h
@@ -33,6 +33,8 @@ namespace edm {
     class ESPreFunctorDecorator {
     public:
       ESPreFunctorDecorator(const TFunctor& iCaller) : caller_(iCaller) {}
+      const ESPreFunctorDecorator& operator=(const ESPreFunctorDecorator&) = delete;  // stop default
+
       //virtual ~ESPreFunctorDecorator();
 
       // ---------- const member functions ---------------------
@@ -46,8 +48,6 @@ namespace edm {
 
     private:
       //ESPreFunctorDecorator(const ESPreFunctorDecorator&); // stop default
-
-      const ESPreFunctorDecorator& operator=(const ESPreFunctorDecorator&) = delete;  // stop default
 
       // ---------- member data --------------------------------
       TFunctor caller_;

--- a/FWCore/Framework/interface/ESProducerLooper.h
+++ b/FWCore/Framework/interface/ESProducerLooper.h
@@ -33,6 +33,9 @@ namespace edm {
   class ESProducerLooper : public ESProducer, public EventSetupRecordIntervalFinder, public EDLooper {
   public:
     ESProducerLooper();
+    ESProducerLooper(const ESProducerLooper&) = delete;  // stop default
+    const ESProducerLooper& operator=(const ESProducerLooper&) = delete;  // stop default
+
     //virtual ~ESProducerLooper();
 
     // ---------- const member functions ---------------------
@@ -53,10 +56,6 @@ namespace edm {
                                 const std::string& iLabel = std::string()) override;
 
   private:
-    ESProducerLooper(const ESProducerLooper&) = delete;  // stop default
-
-    const ESProducerLooper& operator=(const ESProducerLooper&) = delete;  // stop default
-
     // ---------- member data --------------------------------
   };
 }  // namespace edm

--- a/FWCore/Framework/interface/ESProducerLooper.h
+++ b/FWCore/Framework/interface/ESProducerLooper.h
@@ -33,7 +33,7 @@ namespace edm {
   class ESProducerLooper : public ESProducer, public EventSetupRecordIntervalFinder, public EDLooper {
   public:
     ESProducerLooper();
-    ESProducerLooper(const ESProducerLooper&) = delete;  // stop default
+    ESProducerLooper(const ESProducerLooper&) = delete;                   // stop default
     const ESProducerLooper& operator=(const ESProducerLooper&) = delete;  // stop default
 
     //virtual ~ESProducerLooper();

--- a/FWCore/Framework/interface/ESSourceDataProxyTemplate.h
+++ b/FWCore/Framework/interface/ESSourceDataProxyTemplate.h
@@ -41,7 +41,6 @@ namespace edm::eventsetup {
     ESSourceDataProxyTemplate(const ESSourceDataProxyTemplate&) = delete;
     const ESSourceDataProxyTemplate& operator=(const ESSourceDataProxyTemplate&) = delete;
 
-
     // ---------- const member functions ---------------------
 
     // ---------- static member functions --------------------

--- a/FWCore/Framework/interface/ESSourceDataProxyTemplate.h
+++ b/FWCore/Framework/interface/ESSourceDataProxyTemplate.h
@@ -38,6 +38,10 @@ namespace edm::eventsetup {
     ESSourceDataProxyTemplate(edm::SerialTaskQueue* iQueue, std::mutex* iMutex)
         : ESSourceDataProxyBase(iQueue, iMutex) {}
 
+    ESSourceDataProxyTemplate(const ESSourceDataProxyTemplate&) = delete;
+    const ESSourceDataProxyTemplate& operator=(const ESSourceDataProxyTemplate&) = delete;
+
+
     // ---------- const member functions ---------------------
 
     // ---------- static member functions --------------------
@@ -53,10 +57,6 @@ namespace edm::eventsetup {
 
   private:
     void const* getAfterPrefetchImpl() const final { return fetch(); }
-
-    ESSourceDataProxyTemplate(const ESSourceDataProxyTemplate&) = delete;
-
-    const ESSourceDataProxyTemplate& operator=(const ESSourceDataProxyTemplate&) = delete;
   };
 }  // namespace edm::eventsetup
 

--- a/FWCore/Framework/interface/ESWatcher.h
+++ b/FWCore/Framework/interface/ESWatcher.h
@@ -42,6 +42,11 @@ namespace edm {
     template <class TObj, class TMemFunc>
     ESWatcher(TObj const& iObj, TMemFunc iFunc)
         : callback_(std::bind(iFunc, iObj, std::placeholders::_1)), cacheId_(0) {}
+
+    ESWatcher(const ESWatcher&) = delete;  // stop default
+
+    const ESWatcher& operator=(const ESWatcher&) = delete;  // stop default
+
     //virtual ~ESWatcher();
 
     // ---------- const member functions ---------------------
@@ -60,10 +65,6 @@ namespace edm {
     }
 
   private:
-    ESWatcher(const ESWatcher&) = delete;  // stop default
-
-    const ESWatcher& operator=(const ESWatcher&) = delete;  // stop default
-
     // ---------- member data --------------------------------
     std::function<void(const T&)> callback_;
     unsigned long long cacheId_;

--- a/FWCore/Framework/interface/EventSetupImpl.h
+++ b/FWCore/Framework/interface/EventSetupImpl.h
@@ -49,7 +49,7 @@ namespace edm {
   class EventSetupImpl {
   public:
     ~EventSetupImpl();
-
+    EventSetupImpl() = delete;
     EventSetupImpl(EventSetupImpl const&) = delete;
     EventSetupImpl& operator=(EventSetupImpl const&) = delete;
 
@@ -83,7 +83,6 @@ namespace edm {
     void addRecordImpl(const eventsetup::EventSetupRecordImpl& iRecord);
 
   private:
-    EventSetupImpl() = delete;
     explicit EventSetupImpl(tbb::task_arena*);
 
     void insertRecordImpl(const eventsetup::EventSetupRecordKey&, const eventsetup::EventSetupRecordImpl*);

--- a/FWCore/Framework/interface/global/EDAnalyzer.h
+++ b/FWCore/Framework/interface/global/EDAnalyzer.h
@@ -32,6 +32,9 @@ namespace edm {
     class EDAnalyzer : public analyzer::AbilityToImplementor<T>::Type..., public virtual EDAnalyzerBase {
     public:
       EDAnalyzer() = default;
+      EDAnalyzer(const EDAnalyzer&) = delete;
+      const EDAnalyzer& operator=(const EDAnalyzer&) = delete;
+
 // We do this only in the case of the intel compiler as this might
 // end up creating a lot of code bloat due to inline symbols being generated
 // in each DSO which uses this header.
@@ -52,10 +55,6 @@ namespace edm {
       // ---------- member functions ---------------------------
 
     private:
-      EDAnalyzer(const EDAnalyzer&) = delete;
-
-      const EDAnalyzer& operator=(const EDAnalyzer&) = delete;
-
       // ---------- member data --------------------------------
     };
 

--- a/FWCore/Framework/interface/global/EDFilter.h
+++ b/FWCore/Framework/interface/global/EDFilter.h
@@ -38,6 +38,9 @@ namespace edm {
                          T>::Type... {
     public:
       EDFilter() = default;
+      EDFilter(const EDFilter&) = delete;
+      const EDFilter& operator=(const EDFilter&) = delete;
+
 // We do this only in the case of the intel compiler as this might
 // end up creating a lot of code bloat due to inline symbols being generated
 // in each DSO which uses this header.
@@ -71,10 +74,6 @@ namespace edm {
       // ---------- member functions ---------------------------
 
     private:
-      EDFilter(const EDFilter&) = delete;
-
-      const EDFilter& operator=(const EDFilter&) = delete;
-
       // ---------- member data --------------------------------
     };
 

--- a/FWCore/Framework/interface/global/OutputModule.h
+++ b/FWCore/Framework/interface/global/OutputModule.h
@@ -29,7 +29,7 @@ namespace edm {
     public:
       OutputModule(edm::ParameterSet const& iPSet)
           : OutputModuleBase(iPSet), outputmodule::AbilityToImplementor<T>::Type(iPSet)... {}
-      OutputModule(const OutputModule&) = delete;  // stop default
+      OutputModule(const OutputModule&) = delete;                   // stop default
       const OutputModule& operator=(const OutputModule&) = delete;  // stop default
 
       // Required to work around ICC bug, but possible source of bloat in gcc.

--- a/FWCore/Framework/interface/global/OutputModule.h
+++ b/FWCore/Framework/interface/global/OutputModule.h
@@ -29,6 +29,9 @@ namespace edm {
     public:
       OutputModule(edm::ParameterSet const& iPSet)
           : OutputModuleBase(iPSet), outputmodule::AbilityToImplementor<T>::Type(iPSet)... {}
+      OutputModule(const OutputModule&) = delete;  // stop default
+      const OutputModule& operator=(const OutputModule&) = delete;  // stop default
+
       // Required to work around ICC bug, but possible source of bloat in gcc.
       // We do this only in the case of the intel compiler as this might end up
       // creating a lot of code bloat due to inline symbols being generated in
@@ -48,10 +51,6 @@ namespace edm {
       // ---------- member functions ---------------------------
 
     private:
-      OutputModule(const OutputModule&) = delete;  // stop default
-
-      const OutputModule& operator=(const OutputModule&) = delete;  // stop default
-
       // ---------- member data --------------------------------
     };
   }  // namespace global

--- a/FWCore/Framework/interface/limited/OutputModule.h
+++ b/FWCore/Framework/interface/limited/OutputModule.h
@@ -29,7 +29,7 @@ namespace edm {
     public:
       OutputModule(edm::ParameterSet const& iPSet)
           : OutputModuleBase(iPSet), outputmodule::AbilityToImplementor<T>::Type(iPSet)... {}
-      OutputModule(const OutputModule&) = delete;  // stop default
+      OutputModule(const OutputModule&) = delete;                   // stop default
       const OutputModule& operator=(const OutputModule&) = delete;  // stop default
 
       // Required to work around ICC bug, but possible source of bloat in gcc.

--- a/FWCore/Framework/interface/limited/OutputModule.h
+++ b/FWCore/Framework/interface/limited/OutputModule.h
@@ -29,6 +29,9 @@ namespace edm {
     public:
       OutputModule(edm::ParameterSet const& iPSet)
           : OutputModuleBase(iPSet), outputmodule::AbilityToImplementor<T>::Type(iPSet)... {}
+      OutputModule(const OutputModule&) = delete;  // stop default
+      const OutputModule& operator=(const OutputModule&) = delete;  // stop default
+
       // Required to work around ICC bug, but possible source of bloat in gcc.
       // We do this only in the case of the intel compiler as this might end up
       // creating a lot of code bloat due to inline symbols being generated in
@@ -48,10 +51,6 @@ namespace edm {
       // ---------- member functions ---------------------------
 
     private:
-      OutputModule(const OutputModule&) = delete;  // stop default
-
-      const OutputModule& operator=(const OutputModule&) = delete;  // stop default
-
       // ---------- member data --------------------------------
     };
   }  // namespace limited

--- a/FWCore/Framework/interface/one/EDAnalyzer.h
+++ b/FWCore/Framework/interface/one/EDAnalyzer.h
@@ -37,6 +37,9 @@ namespace edm {
                     "Cannot use both WatchLuminosityBlocks and LuminosityBLockCache");
 
       EDAnalyzer() = default;
+      EDAnalyzer(const EDAnalyzer&) = delete;
+      const EDAnalyzer& operator=(const EDAnalyzer&) = delete;
+
 #ifdef __INTEL_COMPILER
       virtual ~EDAnalyzer() = default;
 #endif
@@ -54,9 +57,6 @@ namespace edm {
       SerialTaskQueue* globalLuminosityBlocksQueue() final { return globalLuminosityBlocksQueue_.queue(); }
 
     private:
-      EDAnalyzer(const EDAnalyzer&) = delete;
-      const EDAnalyzer& operator=(const EDAnalyzer&) = delete;
-
       // ---------- member data --------------------------------
       impl::OptionalSerialTaskQueueHolder<WantsSerialGlobalRunTransitions<T...>::value> globalRunsQueue_;
       impl::OptionalSerialTaskQueueHolder<WantsSerialGlobalLuminosityBlockTransitions<T...>::value>

--- a/FWCore/Framework/interface/one/EDFilter.h
+++ b/FWCore/Framework/interface/one/EDFilter.h
@@ -36,6 +36,9 @@ namespace edm {
                         CheckAbility<module::Abilities::kOneWatchLuminosityBlocks, T...>::kHasIt),
                     "Cannot use both WatchLuminosityBlocks and LuminosityBLockCache");
       EDFilter() = default;
+      EDFilter(const EDFilter&) = delete;
+      const EDFilter& operator=(const EDFilter&) = delete;
+
       //virtual ~EDFilter();
 
       // ---------- const member functions ---------------------
@@ -64,9 +67,6 @@ namespace edm {
       SerialTaskQueue* globalLuminosityBlocksQueue() final { return globalLuminosityBlocksQueue_.queue(); }
 
     private:
-      EDFilter(const EDFilter&) = delete;
-      const EDFilter& operator=(const EDFilter&) = delete;
-
       // ---------- member data --------------------------------
       impl::OptionalSerialTaskQueueHolder<WantsSerialGlobalRunTransitions<T...>::value> globalRunsQueue_;
       impl::OptionalSerialTaskQueueHolder<WantsSerialGlobalLuminosityBlockTransitions<T...>::value>

--- a/FWCore/Framework/interface/one/EDProducer.h
+++ b/FWCore/Framework/interface/one/EDProducer.h
@@ -37,6 +37,9 @@ namespace edm {
                     "Cannot use both WatchLuminosityBlocks and LuminosityBLockCache");
 
       EDProducer() = default;
+      EDProducer(const EDProducer&) = delete;
+      const EDProducer& operator=(const EDProducer&) = delete;
+
 #ifdef __INTEL_COMPILER
       virtual ~EDProducer() = default;
 #endif
@@ -69,9 +72,6 @@ namespace edm {
       // ---------- member functions ---------------------------
 
     private:
-      EDProducer(const EDProducer&) = delete;
-      const EDProducer& operator=(const EDProducer&) = delete;
-
       // ---------- member data --------------------------------
       impl::OptionalSerialTaskQueueHolder<WantsSerialGlobalRunTransitions<T...>::value> globalRunsQueue_;
       impl::OptionalSerialTaskQueueHolder<WantsSerialGlobalLuminosityBlockTransitions<T...>::value>

--- a/FWCore/Framework/interface/one/OutputModule.h
+++ b/FWCore/Framework/interface/one/OutputModule.h
@@ -31,6 +31,9 @@ namespace edm {
     public:
       OutputModule(edm::ParameterSet const& iPSet)
           : OutputModuleBase(iPSet), outputmodule::AbilityToImplementor<T>::Type(iPSet)... {}
+      OutputModule(const OutputModule&) = delete;  // stop default
+      const OutputModule& operator=(const OutputModule&) = delete;  // stop default
+
       // Required to work around ICC bug, but possible source of bloat in gcc.
       // We do this only in the case of the intel compiler as this might end up
       // creating a lot of code bloat due to inline symbols being generated in
@@ -53,10 +56,6 @@ namespace edm {
       // ---------- member functions ---------------------------
 
     private:
-      OutputModule(const OutputModule&) = delete;  // stop default
-
-      const OutputModule& operator=(const OutputModule&) = delete;  // stop default
-
       // ---------- member data --------------------------------
       impl::OptionalSerialTaskQueueHolder<WantsSerialGlobalRunTransitions<T...>::value> globalRunsQueue_;
       impl::OptionalSerialTaskQueueHolder<WantsSerialGlobalLuminosityBlockTransitions<T...>::value>

--- a/FWCore/Framework/interface/one/OutputModule.h
+++ b/FWCore/Framework/interface/one/OutputModule.h
@@ -31,7 +31,7 @@ namespace edm {
     public:
       OutputModule(edm::ParameterSet const& iPSet)
           : OutputModuleBase(iPSet), outputmodule::AbilityToImplementor<T>::Type(iPSet)... {}
-      OutputModule(const OutputModule&) = delete;  // stop default
+      OutputModule(const OutputModule&) = delete;                   // stop default
       const OutputModule& operator=(const OutputModule&) = delete;  // stop default
 
       // Required to work around ICC bug, but possible source of bloat in gcc.

--- a/FWCore/MessageLogger/interface/AbstractMLscribe.h
+++ b/FWCore/MessageLogger/interface/AbstractMLscribe.h
@@ -10,14 +10,15 @@ namespace edm {
     public:
       // ---  birth/death:
       AbstractMLscribe();
-      virtual ~AbstractMLscribe();
-
-      // ---  methods needed for logging
-      virtual void runCommand(MessageLoggerQ::OpCode opcode, void *operand);
 
       // --- no copying:
       AbstractMLscribe(AbstractMLscribe const &) = delete;
       void operator=(AbstractMLscribe const &) = delete;
+
+      virtual ~AbstractMLscribe();
+
+      // ---  methods needed for logging
+      virtual void runCommand(MessageLoggerQ::OpCode opcode, void *operand);
 
     };  // AbstractMLscribe
 

--- a/FWCore/MessageLogger/interface/AbstractMLscribe.h
+++ b/FWCore/MessageLogger/interface/AbstractMLscribe.h
@@ -15,7 +15,6 @@ namespace edm {
       // ---  methods needed for logging
       virtual void runCommand(MessageLoggerQ::OpCode opcode, void *operand);
 
-    private:
       // --- no copying:
       AbstractMLscribe(AbstractMLscribe const &) = delete;
       void operator=(AbstractMLscribe const &) = delete;

--- a/FWCore/MessageLogger/src/MessageLoggerQ.cc
+++ b/FWCore/MessageLogger/src/MessageLoggerQ.cc
@@ -62,11 +62,11 @@ namespace {
 
     void runCommand(edm::MessageLoggerQ::OpCode opcode, void *operand) override;
 
-  private:
     StandAloneScribe(const StandAloneScribe &) = delete;  // stop default
 
     const StandAloneScribe &operator=(const StandAloneScribe &) = delete;  // stop default
 
+  private:
     // ---------- member data --------------------------------
   };
 

--- a/FWCore/MessageLogger/src/MessageLoggerQ.cc
+++ b/FWCore/MessageLogger/src/MessageLoggerQ.cc
@@ -58,13 +58,13 @@ namespace {
   public:
     StandAloneScribe() {}
 
-    // ---------- member functions ---------------------------
-
-    void runCommand(edm::MessageLoggerQ::OpCode opcode, void *operand) override;
-
     StandAloneScribe(const StandAloneScribe &) = delete;  // stop default
 
     const StandAloneScribe &operator=(const StandAloneScribe &) = delete;  // stop default
+
+    // ---------- member functions ---------------------------
+
+    void runCommand(edm::MessageLoggerQ::OpCode opcode, void *operand) override;
 
   private:
     // ---------- member data --------------------------------

--- a/FWCore/MessageService/interface/SingleThreadMSPresence.h
+++ b/FWCore/MessageService/interface/SingleThreadMSPresence.h
@@ -10,14 +10,14 @@ namespace edm {
     public:
       // ---  birth/death:
       SingleThreadMSPresence();
+      // --- no copying:
+      SingleThreadMSPresence(SingleThreadMSPresence const &) = delete;
+      void operator=(SingleThreadMSPresence const &) = delete;
+
       ~SingleThreadMSPresence() override;
 
       // --- Access to the scribe
       // REMOVED AbstractMLscribe * scribe_ptr() { return &m; }
-
-      // --- no copying:
-      SingleThreadMSPresence(SingleThreadMSPresence const &) = delete;
-      void operator=(SingleThreadMSPresence const &) = delete;
 
     };  // SingleThreadMSPresence
 

--- a/FWCore/MessageService/interface/SingleThreadMSPresence.h
+++ b/FWCore/MessageService/interface/SingleThreadMSPresence.h
@@ -15,7 +15,6 @@ namespace edm {
       // --- Access to the scribe
       // REMOVED AbstractMLscribe * scribe_ptr() { return &m; }
 
-    private:
       // --- no copying:
       SingleThreadMSPresence(SingleThreadMSPresence const &) = delete;
       void operator=(SingleThreadMSPresence const &) = delete;

--- a/FWCore/MessageService/src/ELdestination.h
+++ b/FWCore/MessageService/src/ELdestination.h
@@ -134,7 +134,7 @@ namespace edm {
 
       // -----  Verboten methods:
       //
-    private:
+    public:
       ELdestination(const ELdestination& orig) = delete;
       ELdestination& operator=(const ELdestination& orig) = delete;
 

--- a/FWCore/MessageService/src/ELdestination.h
+++ b/FWCore/MessageService/src/ELdestination.h
@@ -54,6 +54,8 @@ namespace edm {
 
     public:
       ELdestination();
+      ELdestination(const ELdestination& orig) = delete;
+      ELdestination& operator=(const ELdestination& orig) = delete;
       virtual ~ELdestination();
 
       // -----  Methods invoked by the ELadministrator:
@@ -134,10 +136,6 @@ namespace edm {
 
       // -----  Verboten methods:
       //
-    public:
-      ELdestination(const ELdestination& orig) = delete;
-      ELdestination& operator=(const ELdestination& orig) = delete;
-
     };  // ELdestination
 
     struct close_and_delete {

--- a/FWCore/MessageService/src/ELoutput.h
+++ b/FWCore/MessageService/src/ELoutput.h
@@ -98,6 +98,7 @@ namespace edm {
       bool wantTimestamp, wantModule, wantSubroutine, wantText, wantSomeContext, wantSerial, wantFullContext,
           wantTimeSeparate, wantEpilogueSeparate, preambleMode;
 
+    public:
       // --- Verboten method:
       //
       ELoutput& operator=(const ELoutput& orig) = delete;

--- a/FWCore/MessageService/src/ELoutput.h
+++ b/FWCore/MessageService/src/ELoutput.h
@@ -99,7 +99,6 @@ namespace edm {
       bool wantTimestamp, wantModule, wantSubroutine, wantText, wantSomeContext, wantSerial, wantFullContext,
           wantTimeSeparate, wantEpilogueSeparate, preambleMode;
 
-    private:
       // --- Verboten method:
       //
 

--- a/FWCore/MessageService/src/ELoutput.h
+++ b/FWCore/MessageService/src/ELoutput.h
@@ -48,6 +48,7 @@ namespace edm {
       ELoutput(std::ostream& os, bool emitAtStart = false);  // 6/11/07 mf
       ELoutput(const std::string& fileName, bool emitAtStart = false);
       ELoutput(const ELoutput& orig);
+      ELoutput& operator=(const ELoutput& orig) = delete;
       ~ELoutput() override;
 
       // ---  Methods invoked by the ELadministrator:
@@ -98,10 +99,9 @@ namespace edm {
       bool wantTimestamp, wantModule, wantSubroutine, wantText, wantSomeContext, wantSerial, wantFullContext,
           wantTimeSeparate, wantEpilogueSeparate, preambleMode;
 
-    public:
+    private:
       // --- Verboten method:
       //
-      ELoutput& operator=(const ELoutput& orig) = delete;
 
     };  // ELoutput
 

--- a/FWCore/MessageService/src/ELstatistics.h
+++ b/FWCore/MessageService/src/ELstatistics.h
@@ -56,6 +56,7 @@ namespace edm {
       ELstatistics(int spaceLimit);
       ELstatistics(int spaceLimit, std::ostream& osp);
       ELstatistics(const ELstatistics& orig);
+      ELstatistics& operator=(const ELstatistics& orig) = delete;  // verboten
       ~ELstatistics() override;
 
       // -----  Methods invoked by the ELadministrator:
@@ -100,7 +101,6 @@ namespace edm {
       //
     private:
       std::string dualLogName(std::string const& s);
-      ELstatistics& operator=(const ELstatistics& orig) = delete;  // verboten
 
       void summary(std::ostream& os, std::string_view title);
 

--- a/FWCore/Modules/src/IterateNTimesLooper.cc
+++ b/FWCore/Modules/src/IterateNTimesLooper.cc
@@ -22,7 +22,7 @@ namespace edm {
   class IterateNTimesLooper : public EDLooper {
   public:
     IterateNTimesLooper(ParameterSet const&);
-    IterateNTimesLooper(IterateNTimesLooper const&) = delete;  // stop default
+    IterateNTimesLooper(IterateNTimesLooper const&) = delete;                   // stop default
     IterateNTimesLooper const& operator=(IterateNTimesLooper const&) = delete;  // stop default
     ~IterateNTimesLooper() override;
 

--- a/FWCore/Modules/src/IterateNTimesLooper.cc
+++ b/FWCore/Modules/src/IterateNTimesLooper.cc
@@ -22,6 +22,8 @@ namespace edm {
   class IterateNTimesLooper : public EDLooper {
   public:
     IterateNTimesLooper(ParameterSet const&);
+    IterateNTimesLooper(IterateNTimesLooper const&) = delete;  // stop default
+    IterateNTimesLooper const& operator=(IterateNTimesLooper const&) = delete;  // stop default
     ~IterateNTimesLooper() override;
 
     // ---------- const member functions ---------------------
@@ -34,10 +36,6 @@ namespace edm {
     Status endOfLoop(EventSetup const&, unsigned int) override;
 
   private:
-    IterateNTimesLooper(IterateNTimesLooper const&) = delete;  // stop default
-
-    IterateNTimesLooper const& operator=(IterateNTimesLooper const&) = delete;  // stop default
-
     // ---------- member data --------------------------------
     unsigned int max_;
     unsigned int times_;

--- a/FWCore/Modules/src/NavigateEventsLooper.cc
+++ b/FWCore/Modules/src/NavigateEventsLooper.cc
@@ -29,6 +29,8 @@ namespace edm {
   class NavigateEventsLooper : public EDLooperBase {
   public:
     NavigateEventsLooper(ParameterSet const& pset);
+    NavigateEventsLooper(NavigateEventsLooper const&) = delete;                   // stop default
+    NavigateEventsLooper const& operator=(NavigateEventsLooper const&) = delete;  // stop default
     ~NavigateEventsLooper() override;
 
     void startingNewLoop(unsigned int iIteration) override;
@@ -36,9 +38,6 @@ namespace edm {
     Status endOfLoop(EventSetup const& es, unsigned int iCounter) override;
 
   private:
-    NavigateEventsLooper(NavigateEventsLooper const&) = delete;                   // stop default
-    NavigateEventsLooper const& operator=(NavigateEventsLooper const&) = delete;  // stop default
-
     int maxLoops_;
     int countLoops_;
     bool shouldStopLoop_;

--- a/FWCore/PluginManager/interface/CacheParser.h
+++ b/FWCore/PluginManager/interface/CacheParser.h
@@ -43,7 +43,7 @@ namespace edmplugin {
     typedef std::vector<NameAndType> NameAndTypes;
     typedef std::map<std::filesystem::path, NameAndTypes> LoadableToPlugins;
 
-    CacheParser(const CacheParser&) = delete;  // stop default
+    CacheParser(const CacheParser&) = delete;                   // stop default
     const CacheParser& operator=(const CacheParser&) = delete;  // stop default
 
     // ---------- const member functions ---------------------

--- a/FWCore/PluginManager/interface/CacheParser.h
+++ b/FWCore/PluginManager/interface/CacheParser.h
@@ -43,6 +43,9 @@ namespace edmplugin {
     typedef std::vector<NameAndType> NameAndTypes;
     typedef std::map<std::filesystem::path, NameAndTypes> LoadableToPlugins;
 
+    CacheParser(const CacheParser&) = delete;  // stop default
+    const CacheParser& operator=(const CacheParser&) = delete;  // stop default
+
     // ---------- const member functions ---------------------
 
     // ---------- static member functions --------------------
@@ -61,9 +64,6 @@ namespace edmplugin {
   private:
     //for testing
     friend class ::TestCacheParser;
-    CacheParser(const CacheParser&) = delete;  // stop default
-
-    const CacheParser& operator=(const CacheParser&) = delete;  // stop default
 
     static bool readline(std::istream& iIn,
                          const std::filesystem::path& iDirectory,

--- a/FWCore/PluginManager/interface/PluginCapabilities.h
+++ b/FWCore/PluginManager/interface/PluginCapabilities.h
@@ -33,7 +33,7 @@ namespace edmplugin {
     friend class DummyFriend;
 
   public:
-    PluginCapabilities(const PluginCapabilities&) = delete;  // stop default
+    PluginCapabilities(const PluginCapabilities&) = delete;                   // stop default
     const PluginCapabilities& operator=(const PluginCapabilities&) = delete;  // stop default
     ~PluginCapabilities() override;
 

--- a/FWCore/PluginManager/interface/PluginCapabilities.h
+++ b/FWCore/PluginManager/interface/PluginCapabilities.h
@@ -33,6 +33,8 @@ namespace edmplugin {
     friend class DummyFriend;
 
   public:
+    PluginCapabilities(const PluginCapabilities&) = delete;  // stop default
+    const PluginCapabilities& operator=(const PluginCapabilities&) = delete;  // stop default
     ~PluginCapabilities() override;
 
     // ---------- const member functions ---------------------
@@ -53,9 +55,6 @@ namespace edmplugin {
 
   private:
     PluginCapabilities();
-    PluginCapabilities(const PluginCapabilities&) = delete;  // stop default
-
-    const PluginCapabilities& operator=(const PluginCapabilities&) = delete;  // stop default
 
     // ---------- member data --------------------------------
     std::map<std::string, std::filesystem::path> classToLoadable_;

--- a/FWCore/PluginManager/interface/PluginFactoryManager.h
+++ b/FWCore/PluginManager/interface/PluginFactoryManager.h
@@ -33,7 +33,7 @@ namespace edmplugin {
   public:
     friend class DummyFriend;
 
-    PluginFactoryManager(const PluginFactoryManager&) = delete;  // stop default
+    PluginFactoryManager(const PluginFactoryManager&) = delete;                   // stop default
     const PluginFactoryManager& operator=(const PluginFactoryManager&) = delete;  // stop default
     ~PluginFactoryManager();
 

--- a/FWCore/PluginManager/interface/PluginFactoryManager.h
+++ b/FWCore/PluginManager/interface/PluginFactoryManager.h
@@ -33,6 +33,8 @@ namespace edmplugin {
   public:
     friend class DummyFriend;
 
+    PluginFactoryManager(const PluginFactoryManager&) = delete;  // stop default
+    const PluginFactoryManager& operator=(const PluginFactoryManager&) = delete;  // stop default
     ~PluginFactoryManager();
 
     typedef std::vector<const PluginFactoryBase*>::const_iterator const_iterator;
@@ -49,9 +51,6 @@ namespace edmplugin {
 
   private:
     PluginFactoryManager();
-    PluginFactoryManager(const PluginFactoryManager&) = delete;  // stop default
-
-    const PluginFactoryManager& operator=(const PluginFactoryManager&) = delete;  // stop default
 
     // ---------- member data --------------------------------
     std::vector<const PluginFactoryBase*> factories_;

--- a/FWCore/PluginManager/interface/ProblemTracker.h
+++ b/FWCore/PluginManager/interface/ProblemTracker.h
@@ -17,20 +17,20 @@ namespace edm {
   class ProblemTracker {
   public:
     static ProblemTracker const* instance();
+    ProblemTracker(const ProblemTracker&) = delete;
 
   private:
     ProblemTracker();
     ~ProblemTracker();
-    ProblemTracker(const ProblemTracker&) = delete;
   };
 
   class AssertHandler {
   public:
     AssertHandler();
+    AssertHandler(const AssertHandler&) = delete;
     ~AssertHandler();
 
   private:
-    AssertHandler(const AssertHandler&) = delete;
     ProblemTracker const* pt_;
   };
 

--- a/FWCore/SOA/interface/Column.h
+++ b/FWCore/SOA/interface/Column.h
@@ -72,11 +72,12 @@ namespace edm {
         return {iF};
       }
 
-    private:
-      Column() = default;
       Column(const Column&) = delete;  // stop default
 
       const Column& operator=(const Column&) = delete;  // stop default
+
+    private:
+      Column() = default;
     };
 
   }  // namespace soa

--- a/FWCore/Services/interface/ExternalRandomNumberGeneratorService.h
+++ b/FWCore/Services/interface/ExternalRandomNumberGeneratorService.h
@@ -20,6 +20,8 @@ namespace edm {
   class ExternalRandomNumberGeneratorService : public RandomNumberGenerator {
   public:
     ExternalRandomNumberGeneratorService();
+    ExternalRandomNumberGeneratorService(ExternalRandomNumberGeneratorService const&) = delete;
+    ExternalRandomNumberGeneratorService const& operator=(ExternalRandomNumberGeneratorService const&) = delete;
 
     void setState(std::vector<unsigned long> const&, long seed);
     std::vector<unsigned long> getState() const;
@@ -50,9 +52,6 @@ namespace edm {
     void print(std::ostream& os) const final;
 
   private:
-    ExternalRandomNumberGeneratorService(ExternalRandomNumberGeneratorService const&) = delete;
-    ExternalRandomNumberGeneratorService const& operator=(ExternalRandomNumberGeneratorService const&) = delete;
-
     std::unique_ptr<CLHEP::HepRandomEngine> createFromState(std::vector<unsigned long> const&, long seed) const;
 
     std::unique_ptr<CLHEP::HepRandomEngine> engine_;

--- a/FWCore/Services/plugins/LoadAllDictionaries.cc
+++ b/FWCore/Services/plugins/LoadAllDictionaries.cc
@@ -32,6 +32,9 @@ namespace edm {
     class LoadAllDictionaries {
     public:
       LoadAllDictionaries(const edm::ParameterSet&);
+      LoadAllDictionaries(const LoadAllDictionaries&) = delete;  // stop default
+      const LoadAllDictionaries& operator=(const LoadAllDictionaries&) = delete;  // stop default
+
       //virtual ~LoadAllDictionaries();
 
       // ---------- const member functions ---------------------
@@ -42,10 +45,6 @@ namespace edm {
       // ---------- member functions ---------------------------
 
     private:
-      LoadAllDictionaries(const LoadAllDictionaries&) = delete;  // stop default
-
-      const LoadAllDictionaries& operator=(const LoadAllDictionaries&) = delete;  // stop default
-
       // ---------- member data --------------------------------
     };
   }  // namespace service

--- a/FWCore/Services/plugins/LoadAllDictionaries.cc
+++ b/FWCore/Services/plugins/LoadAllDictionaries.cc
@@ -32,7 +32,7 @@ namespace edm {
     class LoadAllDictionaries {
     public:
       LoadAllDictionaries(const edm::ParameterSet&);
-      LoadAllDictionaries(const LoadAllDictionaries&) = delete;  // stop default
+      LoadAllDictionaries(const LoadAllDictionaries&) = delete;                   // stop default
       const LoadAllDictionaries& operator=(const LoadAllDictionaries&) = delete;  // stop default
 
       //virtual ~LoadAllDictionaries();

--- a/FWCore/Services/plugins/PrintLoadingPlugins.cc
+++ b/FWCore/Services/plugins/PrintLoadingPlugins.cc
@@ -32,7 +32,7 @@
 class PrintLoadingPlugins {
 public:
   PrintLoadingPlugins();
-  PrintLoadingPlugins(const PrintLoadingPlugins&) = delete;  // stop default
+  PrintLoadingPlugins(const PrintLoadingPlugins&) = delete;                   // stop default
   const PrintLoadingPlugins& operator=(const PrintLoadingPlugins&) = delete;  // stop default
 
   virtual ~PrintLoadingPlugins();

--- a/FWCore/Services/plugins/PrintLoadingPlugins.cc
+++ b/FWCore/Services/plugins/PrintLoadingPlugins.cc
@@ -32,6 +32,9 @@
 class PrintLoadingPlugins {
 public:
   PrintLoadingPlugins();
+  PrintLoadingPlugins(const PrintLoadingPlugins&) = delete;  // stop default
+  const PrintLoadingPlugins& operator=(const PrintLoadingPlugins&) = delete;  // stop default
+
   virtual ~PrintLoadingPlugins();
 
   void goingToLoad(const std::filesystem::path&);
@@ -46,10 +49,6 @@ public:
   // ---------- member functions ---------------------------
 
 private:
-  PrintLoadingPlugins(const PrintLoadingPlugins&) = delete;  // stop default
-
-  const PrintLoadingPlugins& operator=(const PrintLoadingPlugins&) = delete;  // stop default
-
   // ---------- member data --------------------------------
 };
 

--- a/FWCore/Sources/interface/PuttableSourceBase.h
+++ b/FWCore/Sources/interface/PuttableSourceBase.h
@@ -30,6 +30,9 @@ namespace edm {
   class PuttableSourceBase : public InputSource, public ProducerBase {
   public:
     PuttableSourceBase(ParameterSet const&, InputSourceDescription const&);
+    PuttableSourceBase(const PuttableSourceBase&) = delete;
+    PuttableSourceBase& operator=(const PuttableSourceBase&) = delete;
+
 
     // ---------- const member functions ---------------------
 
@@ -54,10 +57,6 @@ namespace edm {
 
     virtual void beginRun(Run&);
     virtual void beginLuminosityBlock(LuminosityBlock&);
-
-    PuttableSourceBase(const PuttableSourceBase&) = delete;
-
-    PuttableSourceBase& operator=(const PuttableSourceBase&) = delete;
 
     // ---------- member data --------------------------------
   };

--- a/FWCore/Sources/interface/PuttableSourceBase.h
+++ b/FWCore/Sources/interface/PuttableSourceBase.h
@@ -33,7 +33,6 @@ namespace edm {
     PuttableSourceBase(const PuttableSourceBase&) = delete;
     PuttableSourceBase& operator=(const PuttableSourceBase&) = delete;
 
-
     // ---------- const member functions ---------------------
 
     // ---------- static member functions --------------------

--- a/FWCore/Utilities/interface/CPUServiceBase.h
+++ b/FWCore/Utilities/interface/CPUServiceBase.h
@@ -27,15 +27,14 @@ namespace edm {
   class CPUServiceBase {
   public:
     CPUServiceBase();
+    CPUServiceBase(const CPUServiceBase &) = delete;                   // stop default
+    const CPUServiceBase &operator=(const CPUServiceBase &) = delete;  // stop default
+
     virtual ~CPUServiceBase();
 
     // ---------- member functions ---------------------------
     ///CPU information - the models present and average speed.
     virtual bool cpuInfo(std::string &models, double &avgSpeed) = 0;
-
-    CPUServiceBase(const CPUServiceBase &) = delete;  // stop default
-
-    const CPUServiceBase &operator=(const CPUServiceBase &) = delete;  // stop default
   };
 }  // namespace edm
 

--- a/FWCore/Utilities/interface/CPUServiceBase.h
+++ b/FWCore/Utilities/interface/CPUServiceBase.h
@@ -33,7 +33,6 @@ namespace edm {
     ///CPU information - the models present and average speed.
     virtual bool cpuInfo(std::string &models, double &avgSpeed) = 0;
 
-  private:
     CPUServiceBase(const CPUServiceBase &) = delete;  // stop default
 
     const CPUServiceBase &operator=(const CPUServiceBase &) = delete;  // stop default

--- a/FWCore/Utilities/interface/ConstRespectingPtr.h
+++ b/FWCore/Utilities/interface/ConstRespectingPtr.h
@@ -28,6 +28,8 @@ namespace edm {
   public:
     ConstRespectingPtr();
     explicit ConstRespectingPtr(T*);
+    ConstRespectingPtr(ConstRespectingPtr<T> const&) = delete;
+    ConstRespectingPtr& operator=(ConstRespectingPtr<T> const&) = delete;
     ~ConstRespectingPtr();
 
     T const* operator->() const { return m_data; }
@@ -46,9 +48,6 @@ namespace edm {
     void reset();
 
   private:
-    ConstRespectingPtr(ConstRespectingPtr<T> const&) = delete;
-    ConstRespectingPtr& operator=(ConstRespectingPtr<T> const&) = delete;
-
     edm::propagate_const<T*> m_data;
   };
 

--- a/FWCore/Utilities/interface/SingleConsumerQ.h
+++ b/FWCore/Utilities/interface/SingleConsumerQ.h
@@ -49,6 +49,8 @@ namespace edm {
       void* ptr_;
       int len_;
     };
+    // no copy
+    SingleConsumerQ(const SingleConsumerQ&) = delete;
 
     SingleConsumerQ(int max_event_size, int max_queue_depth);
     ~SingleConsumerQ();
@@ -101,9 +103,6 @@ namespace edm {
     int maxQueueDepth() const { return max_queue_depth_; }
 
   private:
-    // no copy
-    SingleConsumerQ(const SingleConsumerQ&) = delete;
-
     // the memory for the buffers
     typedef std::vector<char> ByteArray;
     // the pool of buffers

--- a/FWCore/Utilities/interface/ThreadSafeRegistry.h
+++ b/FWCore/Utilities/interface/ThreadSafeRegistry.h
@@ -80,14 +80,13 @@ namespace edm {
       /// Print the contents of this registry to the given ostream.
       void print(std::ostream& os) const;
 
+      // The following two are not implemented.
+      ThreadSafeRegistry(ThreadSafeRegistry<KEY, T> const&) = delete;
+      
+      ThreadSafeRegistry<KEY, T>& operator=(ThreadSafeRegistry<KEY, T> const&) = delete;
     private:
       ThreadSafeRegistry();
       ~ThreadSafeRegistry();
-
-      // The following two are not implemented.
-      ThreadSafeRegistry(ThreadSafeRegistry<KEY, T> const&) = delete;
-
-      ThreadSafeRegistry<KEY, T>& operator=(ThreadSafeRegistry<KEY, T> const&) = delete;
 
       mutable std::mutex mutex_;
       collection_type data_;

--- a/FWCore/Utilities/interface/ThreadSafeRegistry.h
+++ b/FWCore/Utilities/interface/ThreadSafeRegistry.h
@@ -82,8 +82,9 @@ namespace edm {
 
       // The following two are not implemented.
       ThreadSafeRegistry(ThreadSafeRegistry<KEY, T> const&) = delete;
-      
+
       ThreadSafeRegistry<KEY, T>& operator=(ThreadSafeRegistry<KEY, T> const&) = delete;
+
     private:
       ThreadSafeRegistry();
       ~ThreadSafeRegistry();

--- a/FWCore/Utilities/interface/ThreadSafeRegistry.h
+++ b/FWCore/Utilities/interface/ThreadSafeRegistry.h
@@ -42,6 +42,11 @@ namespace edm {
 
       static ThreadSafeRegistry* instance();
 
+      // The following two are not implemented.
+      ThreadSafeRegistry(ThreadSafeRegistry<KEY, T> const&) = delete;
+
+      ThreadSafeRegistry<KEY, T>& operator=(ThreadSafeRegistry<KEY, T> const&) = delete;
+
       /// Retrieve the value_type object with the given key.
       /// If we return 'true', then 'result' carries the
       /// value_type object.
@@ -79,11 +84,6 @@ namespace edm {
 
       /// Print the contents of this registry to the given ostream.
       void print(std::ostream& os) const;
-
-      // The following two are not implemented.
-      ThreadSafeRegistry(ThreadSafeRegistry<KEY, T> const&) = delete;
-
-      ThreadSafeRegistry<KEY, T>& operator=(ThreadSafeRegistry<KEY, T> const&) = delete;
 
     private:
       ThreadSafeRegistry();


### PR DESCRIPTION
We have over 25K clang-tidy warnings about `deleted member function should be public [modernize-use-equals-delete]`. 9K of these come from FWCore sub-system.
Locally tested, it build and all of the `modernize-use-equals-delete` warnings are fixed.

[a]
```
FWCore/Framework/interface/EventSetupImpl.h:86:5: warning: deleted member function should be public [modernize-use-equals-delete]
    EventSetupImpl() = delete;
    ^
FWCore/Framework/interface/one/EDAnalyzer.h:57:7: warning: deleted member function should be public [modernize-use-equals-delete]
      EDAnalyzer(const EDAnalyzer&) = delete;
      ^
FWCore/Framework/interface/one/EDAnalyzer.h:58:25: warning: deleted member function should be public [modernize-use-equals-delete]
      const EDAnalyzer& operator=(const EDAnalyzer&) = delete;
```