### PR TITLE
[DataFormats][clang-tidy] make deleted function public

### DIFF
--- a/DataFormats/Common/interface/ContainerMaskTraits.h
+++ b/DataFormats/Common/interface/ContainerMaskTraits.h
@@ -37,7 +37,7 @@ namespace edm {
 
   public:
     ContainerMaskTraits() = delete;
-    ContainerMaskTraits(const ContainerMaskTraits&) = delete;  // stop default
+    ContainerMaskTraits(const ContainerMaskTraits&) = delete;                   // stop default
     const ContainerMaskTraits& operator=(const ContainerMaskTraits&) = delete;  // stop default
 
   private:

--- a/DataFormats/Common/interface/ContainerMaskTraits.h
+++ b/DataFormats/Common/interface/ContainerMaskTraits.h
@@ -35,7 +35,6 @@ namespace edm {
       return iElement - &(iContainer->front());
     }
 
-  public:
     ContainerMaskTraits() = delete;
     ContainerMaskTraits(const ContainerMaskTraits&) = delete;                   // stop default
     const ContainerMaskTraits& operator=(const ContainerMaskTraits&) = delete;  // stop default

--- a/DataFormats/Common/interface/ContainerMaskTraits.h
+++ b/DataFormats/Common/interface/ContainerMaskTraits.h
@@ -35,12 +35,13 @@ namespace edm {
       return iElement - &(iContainer->front());
     }
 
-  private:
-    //virtual ~ContainerMaskTraits();
+  public:
     ContainerMaskTraits() = delete;
     ContainerMaskTraits(const ContainerMaskTraits&) = delete;  // stop default
-
     const ContainerMaskTraits& operator=(const ContainerMaskTraits&) = delete;  // stop default
+
+  private:
+    //virtual ~ContainerMaskTraits();
 
     // ---------- member data --------------------------------
   };

--- a/DataFormats/Common/interface/PtrVectorBase.h
+++ b/DataFormats/Common/interface/PtrVectorBase.h
@@ -41,6 +41,8 @@ namespace edm {
 
     PtrVectorBase(const PtrVectorBase&);
 
+    PtrVectorBase& operator=(const PtrVectorBase&) = delete;
+
     virtual ~PtrVectorBase();
 
     // ---------- const member functions ---------------------
@@ -161,8 +163,6 @@ namespace edm {
 
     //returns false if the cache is not yet set
     bool checkCachedItems() const;
-
-    PtrVectorBase& operator=(const PtrVectorBase&) = delete;
 
     //Used when we need an iterator but cache is not yet set
     static const std::vector<void const*>& emptyCache();

--- a/DataFormats/FWLite/interface/DataGetterHelper.h
+++ b/DataFormats/FWLite/interface/DataGetterHelper.h
@@ -89,10 +89,10 @@ namespace fwlite {
 
     edm::EDProductGetter const* getter() const { return getter_.get(); }
 
-  private:
     DataGetterHelper(const DataGetterHelper&) = delete;                   // stop default
     const DataGetterHelper& operator=(const DataGetterHelper&) = delete;  // stop default
 
+  private:
     typedef std::map<internal::DataKey, std::shared_ptr<internal::Data>> KeyToDataMap;
 
     internal::Data& getBranchDataFor(std::type_info const&, char const*, char const*, char const*) const;

--- a/DataFormats/FWLite/interface/Event.h
+++ b/DataFormats/FWLite/interface/Event.h
@@ -96,6 +96,11 @@ namespace fwlite {
     // himself.
     Event(
         TFile* iFile, bool useCache = true, std::function<void(TBranch const&)> baFunc = [](TBranch const&) {});
+
+    Event(Event const&) = delete;  // stop default
+
+    Event const& operator=(Event const&) = delete;  // stop default
+
     ~Event() override;
 
     ///Advance to next event in the TFile
@@ -188,10 +193,6 @@ namespace fwlite {
     friend class internal::ProductGetter;
     friend class ChainEvent;
     friend class EventHistoryGetter;
-
-    Event(Event const&) = delete;  // stop default
-
-    Event const& operator=(Event const&) = delete;  // stop default
 
     edm::ProcessHistory const& history() const;
     void updateAux(Long_t eventIndex) const;

--- a/DataFormats/FWLite/interface/EventHistoryGetter.h
+++ b/DataFormats/FWLite/interface/EventHistoryGetter.h
@@ -30,11 +30,11 @@ namespace fwlite {
     // ---------- const member functions ---------------------
     const edm::ProcessHistory& history() const override;
 
-  private:
     EventHistoryGetter(const EventHistoryGetter&) = delete;  // stop default
 
     const EventHistoryGetter& operator=(const EventHistoryGetter&) = delete;  // stop default
 
+  private:
     // ---------- member data --------------------------------
     const fwlite::Event* event_;
   };

--- a/DataFormats/FWLite/interface/EventSetup.h
+++ b/DataFormats/FWLite/interface/EventSetup.h
@@ -68,6 +68,11 @@ namespace fwlite {
   class EventSetup {
   public:
     EventSetup(TFile*);
+
+    EventSetup(const EventSetup&) = delete;  // stop default
+
+    const EventSetup& operator=(const EventSetup&) = delete;  // stop default
+
     virtual ~EventSetup();
 
     // ---------- const member functions ---------------------
@@ -97,10 +102,6 @@ namespace fwlite {
     //void autoSyncTo(const edm::EventBase&);
 
   private:
-    EventSetup(const EventSetup&) = delete;  // stop default
-
-    const EventSetup& operator=(const EventSetup&) = delete;  // stop default
-
     // ---------- member data --------------------------------
     edm::EventID m_syncedEvent;
     edm::Timestamp m_syncedTimestamp;

--- a/DataFormats/FWLite/interface/HistoryGetterBase.h
+++ b/DataFormats/FWLite/interface/HistoryGetterBase.h
@@ -29,7 +29,6 @@ namespace fwlite {
     // ---------- const member functions ---------------------
     virtual const edm::ProcessHistory& history() const = 0;
 
-  private:
     HistoryGetterBase(const HistoryGetterBase&) = delete;  // stop default
 
     const HistoryGetterBase& operator=(const HistoryGetterBase&) = delete;  // stop default

--- a/DataFormats/FWLite/interface/LumiHistoryGetter.h
+++ b/DataFormats/FWLite/interface/LumiHistoryGetter.h
@@ -30,11 +30,11 @@ namespace fwlite {
     // ---------- const member functions ---------------------
     const edm::ProcessHistory& history() const override;
 
-  private:
     LumiHistoryGetter(const LumiHistoryGetter&) = delete;  // stop default
 
     const LumiHistoryGetter& operator=(const LumiHistoryGetter&) = delete;  // stop default
 
+  private:
     // ---------- member data --------------------------------
     const fwlite::LuminosityBlock* lumi_;
   };

--- a/DataFormats/FWLite/interface/LuminosityBlock.h
+++ b/DataFormats/FWLite/interface/LuminosityBlock.h
@@ -60,6 +60,9 @@ namespace fwlite {
     // at least as long as LuminosityBlock
     LuminosityBlock(TFile* iFile);
     LuminosityBlock(std::shared_ptr<BranchMapReader> branchMap, std::shared_ptr<RunFactory> runFactory);
+    LuminosityBlock(const LuminosityBlock&) = delete;  // stop default
+    const LuminosityBlock& operator=(const LuminosityBlock&) = delete;  // stop default
+
     ~LuminosityBlock() override;
 
     const LuminosityBlock& operator++() override;
@@ -103,10 +106,6 @@ namespace fwlite {
   private:
     friend class internal::ProductGetter;
     friend class LumiHistoryGetter;
-
-    LuminosityBlock(const LuminosityBlock&) = delete;  // stop default
-
-    const LuminosityBlock& operator=(const LuminosityBlock&) = delete;  // stop default
 
     const edm::ProcessHistory& history() const;
     void updateAux(Long_t lumiIndex) const;

--- a/DataFormats/FWLite/interface/LuminosityBlock.h
+++ b/DataFormats/FWLite/interface/LuminosityBlock.h
@@ -60,7 +60,7 @@ namespace fwlite {
     // at least as long as LuminosityBlock
     LuminosityBlock(TFile* iFile);
     LuminosityBlock(std::shared_ptr<BranchMapReader> branchMap, std::shared_ptr<RunFactory> runFactory);
-    LuminosityBlock(const LuminosityBlock&) = delete;  // stop default
+    LuminosityBlock(const LuminosityBlock&) = delete;                   // stop default
     const LuminosityBlock& operator=(const LuminosityBlock&) = delete;  // stop default
 
     ~LuminosityBlock() override;

--- a/DataFormats/FWLite/interface/Record.h
+++ b/DataFormats/FWLite/interface/Record.h
@@ -47,7 +47,7 @@ namespace fwlite {
   class Record {
   public:
     Record(const char* iName, TTree*);
-    Record(const Record&) = delete;  // stop default
+    Record(const Record&) = delete;                   // stop default
     const Record& operator=(const Record&) = delete;  // stop default
 
     virtual ~Record();

--- a/DataFormats/FWLite/interface/Record.h
+++ b/DataFormats/FWLite/interface/Record.h
@@ -47,6 +47,9 @@ namespace fwlite {
   class Record {
   public:
     Record(const char* iName, TTree*);
+    Record(const Record&) = delete;  // stop default
+    const Record& operator=(const Record&) = delete;  // stop default
+
     virtual ~Record();
 
     // ---------- const member functions ---------------------
@@ -65,10 +68,6 @@ namespace fwlite {
     void syncTo(const edm::EventID&, const edm::Timestamp&);
 
   private:
-    Record(const Record&) = delete;  // stop default
-
-    const Record& operator=(const Record&) = delete;  // stop default
-
     cms::Exception* get(const edm::TypeID&, const char* iLabel, const void*&) const;
     void resetCaches();
     // ---------- member data --------------------------------

--- a/DataFormats/FWLite/interface/Run.h
+++ b/DataFormats/FWLite/interface/Run.h
@@ -57,7 +57,7 @@ namespace fwlite {
     // at least as long as Run
     Run(TFile* iFile);
     Run(std::shared_ptr<BranchMapReader> branchMap);
-    Run(const Run&) = delete;  // stop default
+    Run(const Run&) = delete;                   // stop default
     const Run& operator=(const Run&) = delete;  // stop default
 
     ~Run() override;

--- a/DataFormats/FWLite/interface/Run.h
+++ b/DataFormats/FWLite/interface/Run.h
@@ -57,6 +57,9 @@ namespace fwlite {
     // at least as long as Run
     Run(TFile* iFile);
     Run(std::shared_ptr<BranchMapReader> branchMap);
+    Run(const Run&) = delete;  // stop default
+    const Run& operator=(const Run&) = delete;  // stop default
+
     ~Run() override;
 
     const Run& operator++() override;
@@ -99,10 +102,6 @@ namespace fwlite {
   private:
     friend class internal::ProductGetter;
     friend class RunHistoryGetter;
-
-    Run(const Run&) = delete;  // stop default
-
-    const Run& operator=(const Run&) = delete;  // stop default
 
     const edm::ProcessHistory& history() const;
     void updateAux(Long_t runIndex) const;

--- a/DataFormats/FWLite/interface/RunFactory.h
+++ b/DataFormats/FWLite/interface/RunFactory.h
@@ -32,10 +32,11 @@ namespace fwlite {
     // ---------- const member functions ---------------------
     std::shared_ptr<fwlite::Run> makeRun(std::shared_ptr<BranchMapReader> branchMap) const;
 
-  private:
     RunFactory(const RunFactory&) = delete;  // stop default
 
     const RunFactory& operator=(const RunFactory&) = delete;  // stop default
+
+  private:
     //This class is not inteded to be used across different threads
     CMS_SA_ALLOW mutable std::shared_ptr<fwlite::Run> run_;
 

--- a/DataFormats/FWLite/interface/RunHistoryGetter.h
+++ b/DataFormats/FWLite/interface/RunHistoryGetter.h
@@ -30,11 +30,11 @@ namespace fwlite {
     // ---------- const member functions ---------------------
     const edm::ProcessHistory& history() const override;
 
-  private:
     RunHistoryGetter(const RunHistoryGetter&) = delete;  // stop default
 
     const RunHistoryGetter& operator=(const RunHistoryGetter&) = delete;  // stop default
 
+  private:
     // ---------- member data --------------------------------
     const fwlite::Run* run_;
   };

--- a/DataFormats/ForwardDetId/interface/MTDChannelIdentifier.h
+++ b/DataFormats/ForwardDetId/interface/MTDChannelIdentifier.h
@@ -21,6 +21,11 @@ public:
 
   static int pixelToChannel(int row, int col) { return (row << GetInstance().column_width) | col; }
 
+  MTDChannelIdentifier(const MTDChannelIdentifier&) = delete;
+  MTDChannelIdentifier& operator=(const MTDChannelIdentifier&) = delete;
+  MTDChannelIdentifier(MTDChannelIdentifier&&) = delete;
+  MTDChannelIdentifier& operator=(MTDChannelIdentifier&&) = delete;
+
 private:
   MTDChannelIdentifier(unsigned int row_w, unsigned int column_w, unsigned int time_w, unsigned int adc_w)
       : row_width(row_w),
@@ -40,11 +45,6 @@ private:
         max_adc(adc_mask) {}
 
   ~MTDChannelIdentifier() = default;
-
-  MTDChannelIdentifier(const MTDChannelIdentifier&) = delete;
-  MTDChannelIdentifier& operator=(const MTDChannelIdentifier&) = delete;
-  MTDChannelIdentifier(MTDChannelIdentifier&&) = delete;
-  MTDChannelIdentifier& operator=(MTDChannelIdentifier&&) = delete;
 
   const int row_width;
   const int column_width;

--- a/DataFormats/Math/interface/GraphWalker.h
+++ b/DataFormats/Math/interface/GraphWalker.h
@@ -34,6 +34,7 @@ namespace math {
     //! creates a walker rooted by the node given
     GraphWalker(const Graph<N, E> &, const N &);
 
+    GraphWalker() = delete;
     // operations
 
     result_type firstChild();
@@ -59,9 +60,6 @@ namespace math {
     bfs_type queue_;    // breath first search queue
     edge_list root_;    // root of the walker
     const Graph<N, E> &graph_;
-
-  private:
-    GraphWalker() = delete;
   };
 
   template <class N, class E>


### PR DESCRIPTION
We have over 25K clang-tidy warnings about `deleted member function should be public [modernize-use-equals-delete]`. 8K of these come from DataFormats sub-system.
Locally tested, it build and all of the `modernize-use-equals-delete` warnings are fixed.

[a]
```
DataFormats/Common/interface/PtrVectorBase.h:165:20: warning: deleted member function should be public [modernize-use-equals-delete]
    PtrVectorBase& operator=(const PtrVectorBase&) = delete;
                   ^
DataFormats/Common/interface/ContainerMaskTraits.h:40:5: warning: deleted member function should be public [modernize-use-equals-delete]
    ContainerMaskTraits() = delete;
    ^
DataFormats/Common/interface/ContainerMaskTraits.h:41:5: warning: deleted member function should be public [modernize-use-equals-delete]
    ContainerMaskTraits(const ContainerMaskTraits&) = delete;  // stop default
    ^
DataFormats/Common/interface/ContainerMaskTraits.h:43:32: warning: deleted member function should be public [modernize-use-equals-delete]
    const ContainerMaskTraits& operator=(const ContainerMaskTraits&) = delete;  // stop default
```