### PR TITLE
[CommonTools][clang-tidy] make deleted function public

### DIFF
--- a/CommonTools/Utils/interface/TH1AddDirectorySentry.h
+++ b/CommonTools/Utils/interface/TH1AddDirectorySentry.h
@@ -26,9 +26,10 @@ public:
   TH1AddDirectorySentry();
   ~TH1AddDirectorySentry();
 
-private:
   TH1AddDirectorySentry(const TH1AddDirectorySentry&) = delete;
   TH1AddDirectorySentry& operator=(const TH1AddDirectorySentry&) = delete;
+
+private:
   bool status_;
 };
 

--- a/CommonTools/Utils/src/formulaBinaryOperatorEvaluator.h
+++ b/CommonTools/Utils/src/formulaBinaryOperatorEvaluator.h
@@ -84,11 +84,11 @@ namespace reco {
         return ret;
       }
 
-    private:
       BinaryOperatorEvaluator(const BinaryOperatorEvaluator&) = delete;
 
       const BinaryOperatorEvaluator& operator=(const BinaryOperatorEvaluator&) = delete;
 
+    private:
       // ---------- member data --------------------------------
       Op m_operator;
     };

--- a/CommonTools/Utils/src/formulaConstantEvaluator.h
+++ b/CommonTools/Utils/src/formulaConstantEvaluator.h
@@ -35,11 +35,11 @@ namespace reco {
       double evaluate(double const* iVariables, double const* iParameters) const final;
       std::vector<std::string> abstractSyntaxTree() const final;
 
-    private:
       ConstantEvaluator(const ConstantEvaluator&) = delete;
 
       const ConstantEvaluator& operator=(const ConstantEvaluator&) = delete;
 
+    private:
       // ---------- member data --------------------------------
       double m_value;
     };

--- a/CommonTools/Utils/src/formulaEvaluatorBase.h
+++ b/CommonTools/Utils/src/formulaEvaluatorBase.h
@@ -57,11 +57,11 @@ namespace reco {
       unsigned int precedence() const { return m_precedence; }
       void setPrecedenceToParenthesis() { m_precedence = static_cast<unsigned int>(Precedence::kParenthesis); }
 
-    private:
       EvaluatorBase(const EvaluatorBase&) = delete;
 
       const EvaluatorBase& operator=(const EvaluatorBase&) = delete;
 
+    private:
       // ---------- member data --------------------------------
       unsigned int m_precedence;
     };

--- a/CommonTools/Utils/src/formulaFunctionOneArgEvaluator.h
+++ b/CommonTools/Utils/src/formulaFunctionOneArgEvaluator.h
@@ -45,11 +45,11 @@ namespace reco {
         return ret;
       }
 
-    private:
       FunctionOneArgEvaluator(const FunctionOneArgEvaluator&) = delete;
 
       const FunctionOneArgEvaluator& operator=(const FunctionOneArgEvaluator&) = delete;
 
+    private:
       // ---------- member data --------------------------------
       std::shared_ptr<EvaluatorBase> m_arg;
       std::function<double(double)> m_function;

--- a/CommonTools/Utils/src/formulaFunctionTwoArgsEvaluator.h
+++ b/CommonTools/Utils/src/formulaFunctionTwoArgsEvaluator.h
@@ -48,11 +48,11 @@ namespace reco {
         return ret;
       }
 
-    private:
       FunctionTwoArgsEvaluator(const FunctionTwoArgsEvaluator&) = delete;
 
       const FunctionTwoArgsEvaluator& operator=(const FunctionTwoArgsEvaluator&) = delete;
 
+    private:
       // ---------- member data --------------------------------
       std::shared_ptr<EvaluatorBase> m_arg1;
       std::shared_ptr<EvaluatorBase> m_arg2;

--- a/CommonTools/Utils/src/formulaParameterEvaluator.h
+++ b/CommonTools/Utils/src/formulaParameterEvaluator.h
@@ -35,11 +35,11 @@ namespace reco {
       double evaluate(double const* iVariables, double const* iParameters) const final;
       std::vector<std::string> abstractSyntaxTree() const final;
 
-    private:
       ParameterEvaluator(const ParameterEvaluator&) = delete;
 
       const ParameterEvaluator& operator=(const ParameterEvaluator&) = delete;
 
+    private:
       // ---------- member data --------------------------------
       unsigned int m_index;
     };

--- a/CommonTools/Utils/src/formulaUnaryMinusEvaluator.h
+++ b/CommonTools/Utils/src/formulaUnaryMinusEvaluator.h
@@ -44,11 +44,11 @@ namespace reco {
         return ret;
       }
 
-    private:
       UnaryMinusEvaluator(const UnaryMinusEvaluator&) = delete;
 
       const UnaryMinusEvaluator& operator=(const UnaryMinusEvaluator&) = delete;
 
+    private:
       // ---------- member data --------------------------------
       std::shared_ptr<EvaluatorBase> m_arg;
     };

--- a/CommonTools/Utils/src/formulaVariableEvaluator.h
+++ b/CommonTools/Utils/src/formulaVariableEvaluator.h
@@ -35,11 +35,11 @@ namespace reco {
       double evaluate(double const* iVariables, double const* iParameters) const final;
       std::vector<std::string> abstractSyntaxTree() const final;
 
-    private:
       VariableEvaluator(const VariableEvaluator&) = delete;
 
       const VariableEvaluator& operator=(const VariableEvaluator&) = delete;
 
+    private:
       // ---------- member data --------------------------------
       unsigned int m_index;
     };


### PR DESCRIPTION
Cleanup for clang-tidy warning `deleted member function should be public [modernize-use-equals-delete]`