### PR TITLE
[OnlineDB][clang-tidy] make deleted function public

### DIFF
--- a/OnlineDB/EcalCondDB/interface/DateHandler.h
+++ b/OnlineDB/EcalCondDB/interface/DateHandler.h
@@ -39,8 +39,9 @@ public:
    */
   Tm dateToTm(oracle::occi::Date& date) const;
 
-private:
   DateHandler() = delete;  // hide the default constructor
+
+private:
   oracle::occi::Connection* m_conn;
   oracle::occi::Environment* m_env;
 

--- a/OnlineDB/EcalCondDB/interface/EcalCondDBInterface.h
+++ b/OnlineDB/EcalCondDB/interface/EcalCondDBInterface.h
@@ -630,11 +630,12 @@ private:
 
   DateHandler* dh;
 
-  EcalCondDBInterface() = delete;
-  EcalCondDBInterface(const EcalCondDBInterface& copy) = delete;
-
   std::map<int, int> _logicId2DetId;
   std::map<int, int> _detId2LogicId;
+
+public:
+  EcalCondDBInterface() = delete;
+  EcalCondDBInterface(const EcalCondDBInterface& copy) = delete;
 };
 
 #endif


### PR DESCRIPTION
Cleanup for clang-tidy warning `deleted member function should be public [modernize-use-equals-delete]`