### PR TITLE
[Alignment][clang-tidy] make deleted function public

### DIFF
--- a/Alignment/CommonAlignment/interface/AlignableComposite.h
+++ b/Alignment/CommonAlignment/interface/AlignableComposite.h
@@ -97,6 +97,10 @@ public:
   /// Return surface deformations
   int surfaceDeformationIdPairs(std::vector<std::pair<int, SurfaceDeformation*> >&) const override;
 
+  // avoid implicit cast of not explicitely defined version to the defined ones
+  template <class T>
+  void update(T) = delete;
+
 protected:
   /// Constructor from GeomDet, only for use in AlignableDet
   explicit AlignableComposite(const GeomDet* geomDet);
@@ -104,10 +108,6 @@ protected:
   /// Updater from GeomDet, only for use in AlignableDet
   /// The given GeomDetUnit id has to match the current id.
   void update(const GeomDet* geomDet);
-
-  // avoid implicit cast of not explicitely defined version to the defined ones
-  template <class T>
-  void update(T) = delete;
 
   void setSurface(const AlignableSurface& s) { theSurface = s; }
 

--- a/Alignment/CommonAlignmentMonitor/interface/AlignmentMonitorBase.h
+++ b/Alignment/CommonAlignmentMonitor/interface/AlignmentMonitorBase.h
@@ -116,10 +116,11 @@ protected:
 
   const edm::InputTag m_beamSpotTag;
 
-private:
+public:
   AlignmentMonitorBase(const AlignmentMonitorBase &) = delete;                   // stop default
   const AlignmentMonitorBase &operator=(const AlignmentMonitorBase &) = delete;  // stop default
 
+private:
   // ---------- member data --------------------------------
 
   int m_iteration;

--- a/Alignment/Geners/interface/AbsReader.hh
+++ b/Alignment/Geners/interface/AbsReader.hh
@@ -73,7 +73,6 @@ namespace gs {
       return it->second->read(id, in);
     }
 
-  private:
     DefaultReader(const DefaultReader &) = delete;
     DefaultReader &operator=(const DefaultReader &) = delete;
   };
@@ -106,7 +105,6 @@ namespace gs {
       rd[id.name()] = new ConcreteReader<InheritanceBase, Derived>();
     }
 
-  private:
     // Disable the constructor
     StaticReader() = delete;
   };

--- a/Alignment/Geners/interface/AbsReference.hh
+++ b/Alignment/Geners/interface/AbsReference.hh
@@ -14,6 +14,7 @@ namespace gs {
 
   class AbsReference {
   public:
+    AbsReference() = delete;
     inline virtual ~AbsReference() {}
 
     inline AbsArchive &archive() const { return archive_; }
@@ -63,8 +64,6 @@ namespace gs {
 
   private:
     friend class AbsArchive;
-
-    AbsReference() = delete;
 
     void initialize() const;
     void addItemId(unsigned long long id);

--- a/Alignment/Geners/interface/ArrayAdaptor.hh
+++ b/Alignment/Geners/interface/ArrayAdaptor.hh
@@ -41,9 +41,9 @@ namespace gs {
       return (const_cast<T *>(data_))[index];
     }
 
-  private:
     ArrayAdaptor() = delete;
 
+  private:
     const T *data_;
     std::size_t size_;
     bool writetemCl_;

--- a/Alignment/Geners/interface/BZ2Handle.hh
+++ b/Alignment/Geners/interface/BZ2Handle.hh
@@ -17,11 +17,11 @@ namespace gs {
     explicit BZ2InflateHandle(bz_stream &strm);
     ~BZ2InflateHandle();
 
-  private:
     BZ2InflateHandle() = delete;
     BZ2InflateHandle(const BZ2InflateHandle &) = delete;
     BZ2InflateHandle &operator=(const BZ2InflateHandle &) = delete;
 
+  private:
     bz_stream *strm_;
   };
 
@@ -30,11 +30,11 @@ namespace gs {
     explicit BZ2DeflateHandle(bz_stream &strm);
     ~BZ2DeflateHandle();
 
-  private:
     BZ2DeflateHandle() = delete;
     BZ2DeflateHandle(const BZ2DeflateHandle &) = delete;
     BZ2DeflateHandle &operator=(const BZ2DeflateHandle &) = delete;
 
+  private:
     bz_stream *strm_;
   };
 }  // namespace gs

--- a/Alignment/Geners/interface/BinaryArchiveBase.hh
+++ b/Alignment/Geners/interface/BinaryArchiveBase.hh
@@ -165,11 +165,12 @@ namespace gs {
     const ClassId *catalogEntryClassId() const { return storedEntryId_; }
     const ClassId *itemLocationClassId() const { return storedLocationId_; }
 
-  private:
+  public:
     BinaryArchiveBase() = delete;
     BinaryArchiveBase(const BinaryArchiveBase &) = delete;
     BinaryArchiveBase &operator=(const BinaryArchiveBase &) = delete;
 
+  private:
     static bool parseArchiveOptions(std::ostringstream &errmes,
                                     const char *mode,
                                     CStringStream::CompressionMode *m,

--- a/Alignment/Geners/interface/CStringBuf.hh
+++ b/Alignment/Geners/interface/CStringBuf.hh
@@ -11,7 +11,6 @@ namespace gs {
     const char *getGetBuffer(unsigned long long *len) const;
     const char *getPutBuffer(unsigned long long *len) const;
 
-  private:
     CStringBuf(const CStringBuf &) = delete;
     CStringBuf &operator=(const CStringBuf &) = delete;
   };

--- a/Alignment/Geners/interface/CStringStream.hh
+++ b/Alignment/Geners/interface/CStringStream.hh
@@ -65,10 +65,10 @@ namespace gs {
     // String representation of the compression mode
     static std::string compressionModeName(CompressionMode m, bool useShortName = true);
 
-  private:
     CStringStream(const CStringStream &) = delete;
     CStringStream &operator=(const CStringStream &) = delete;
 
+  private:
     CStringBuf buf_;
     CompressionMode mode_;
     int compressionLevel_;

--- a/Alignment/Geners/interface/ItemLocation.hh
+++ b/Alignment/Geners/interface/ItemLocation.hh
@@ -31,9 +31,9 @@ namespace gs {
     static inline unsigned version() { return 1; }
     static ItemLocation *read(const ClassId &id, std::istream &in);
 
-  private:
     ItemLocation() = delete;
 
+  private:
     std::streampos pos_;
     std::string URI_;
     std::string cachedItemURI_;

--- a/Alignment/Geners/interface/Reference.hh
+++ b/Alignment/Geners/interface/Reference.hh
@@ -35,8 +35,9 @@ namespace gs {
     CPP11_auto_ptr<T> get(unsigned long index) const;
     std::shared_ptr<T> getShared(unsigned long index) const;
 
-  private:
     Reference() = delete;
+
+  private:
     T *getPtr(unsigned long index) const;
   };
 }  // namespace gs

--- a/Alignment/Geners/interface/SearchSpecifier.hh
+++ b/Alignment/Geners/interface/SearchSpecifier.hh
@@ -32,9 +32,9 @@ namespace gs {
 
     bool matches(const std::string &sentence) const;
 
-  private:
     SearchSpecifier() = delete;
 
+  private:
     std::string tag_;
     Regex regex_;
     bool useRegex_;

--- a/Alignment/Geners/interface/WriteOnlyCatalog.hh
+++ b/Alignment/Geners/interface/WriteOnlyCatalog.hh
@@ -11,6 +11,9 @@ namespace gs {
   public:
     // The output stream should be dedicated exclusively to this catalog
     WriteOnlyCatalog(std::ostream &os, unsigned long long firstId = 1);
+    WriteOnlyCatalog(const WriteOnlyCatalog &) = delete;
+    WriteOnlyCatalog &operator=(const WriteOnlyCatalog &) = delete;
+
     inline ~WriteOnlyCatalog() override {}
 
     inline unsigned long long size() const override { return count_; }
@@ -56,9 +59,6 @@ namespace gs {
     inline bool isEqual(const AbsCatalog &) const override { return false; }
 
   private:
-    WriteOnlyCatalog(const WriteOnlyCatalog &) = delete;
-    WriteOnlyCatalog &operator=(const WriteOnlyCatalog &) = delete;
-
     std::ostream &os_;
     unsigned long long count_;
     unsigned long long smallestId_;

--- a/Alignment/Geners/interface/ZlibHandle.hh
+++ b/Alignment/Geners/interface/ZlibHandle.hh
@@ -13,10 +13,10 @@ namespace gs {
 
     inline z_stream_s &strm() { return *strm_; }
 
-  private:
     ZlibInflateHandle(const ZlibInflateHandle &) = delete;
     ZlibInflateHandle &operator=(const ZlibInflateHandle &) = delete;
 
+  private:
     z_stream_s *strm_;
   };
 
@@ -28,11 +28,11 @@ namespace gs {
     inline z_stream_s &strm() { return *strm_; }
     inline int level() { return level_; }
 
-  private:
     ZlibDeflateHandle() = delete;
     ZlibDeflateHandle(const ZlibDeflateHandle &) = delete;
     ZlibDeflateHandle &operator=(const ZlibDeflateHandle &) = delete;
 
+  private:
     z_stream_s *strm_;
     int level_;
   };

--- a/Alignment/Geners/src/AbsArchive.cc
+++ b/Alignment/Geners/src/AbsArchive.cc
@@ -36,8 +36,9 @@ namespace {
     inline NotWritableRecord(const gs::ClassId &classId, const char *ioPrototype, const char *name, const char *category)
         : gs::AbsRecord(classId, ioPrototype, name, category) {}
 
-  private:
     NotWritableRecord() = delete;
+
+  private:
     inline bool writeData(std::ostream &) const override { return false; }
   };
 }  // namespace

--- a/Alignment/MuonAlignment/interface/MuonAlignmentInputDB.h
+++ b/Alignment/MuonAlignment/interface/MuonAlignmentInputDB.h
@@ -41,11 +41,11 @@ public:
 
   AlignableMuon *newAlignableMuon(const edm::EventSetup &iSetup) const override;
 
-private:
   MuonAlignmentInputDB(const MuonAlignmentInputDB &) = delete;  // stop default
 
   const MuonAlignmentInputDB &operator=(const MuonAlignmentInputDB &) = delete;  // stop default
 
+private:
   // ---------- member data --------------------------------
 
   std::string m_dtLabel, m_cscLabel, m_gemLabel, idealGeometryLabel;

--- a/Alignment/MuonAlignment/interface/MuonAlignmentInputMethod.h
+++ b/Alignment/MuonAlignment/interface/MuonAlignmentInputMethod.h
@@ -45,11 +45,11 @@ public:
 
   virtual AlignableMuon *newAlignableMuon(const edm::EventSetup &iSetup) const;
 
-private:
   MuonAlignmentInputMethod(const MuonAlignmentInputMethod &) = delete;  // stop default
 
   const MuonAlignmentInputMethod &operator=(const MuonAlignmentInputMethod &) = delete;  // stop default
 
+private:
   // ---------- member data --------------------------------
   std::string idealGeometryLabel;
 };

--- a/Alignment/MuonAlignment/interface/MuonAlignmentInputSurveyDB.h
+++ b/Alignment/MuonAlignment/interface/MuonAlignmentInputSurveyDB.h
@@ -42,11 +42,11 @@ public:
 
   AlignableMuon* newAlignableMuon(const edm::EventSetup& iSetup) const override;
 
-private:
   MuonAlignmentInputSurveyDB(const MuonAlignmentInputSurveyDB&) = delete;  // stop default
 
   const MuonAlignmentInputSurveyDB& operator=(const MuonAlignmentInputSurveyDB&) = delete;  // stop default
 
+private:
   void addSurveyInfo_(Alignable* ali,
                       unsigned int* theSurveyIndex,
                       const Alignments* theSurveyValues,

--- a/Alignment/MuonAlignment/interface/MuonAlignmentInputXML.h
+++ b/Alignment/MuonAlignment/interface/MuonAlignmentInputXML.h
@@ -43,11 +43,11 @@ public:
 
   AlignableMuon *newAlignableMuon(const edm::EventSetup &iSetup) const override;
 
-private:
   MuonAlignmentInputXML(const MuonAlignmentInputXML &) = delete;  // stop default
 
   const MuonAlignmentInputXML &operator=(const MuonAlignmentInputXML &) = delete;  // stop default
 
+private:
   void recursiveGetId(std::map<unsigned int, Alignable *> &alignableNavigator,
                       const align::Alignables &alignables) const;
 

--- a/Alignment/MuonAlignment/interface/MuonAlignmentOutputXML.h
+++ b/Alignment/MuonAlignment/interface/MuonAlignmentOutputXML.h
@@ -45,11 +45,11 @@ public:
 
   void write(AlignableMuon *alignableMuon, const edm::EventSetup &iSetup) const;
 
-private:
   MuonAlignmentOutputXML(const MuonAlignmentOutputXML &) = delete;  // stop default
 
   const MuonAlignmentOutputXML &operator=(const MuonAlignmentOutputXML &) = delete;  // stop default
 
+private:
   void writeComponents(align::Alignables &alignables,
                        align::Alignables &ideals,
                        std::map<align::ID, CLHEP::HepSymMatrix> &errors,


### PR DESCRIPTION
Cleanup for clang-tidy warning `deleted member function should be public [modernize-use-equals-delete]`