### PR TITLE
Payload inspector framework moved to pybind11

### DIFF
--- a/CondCore/EcalPlugins/plugins/EcalPyUtils.cc
+++ b/CondCore/EcalPlugins/plugins/EcalPyUtils.cc
@@ -11,11 +11,6 @@
 #include <pybind11/pybind11.h>
 namespace py = pybind11;
 
-//#include <boost/python.hpp>
-//#include <boost/python/suite/indexing/vector_indexing_suite.hpp>
-
-//using namespace boost::python;
-
 namespace ecalpyutils {
 
   std::vector<int> hashedIndexToEtaPhi(int hashedindex) {

--- a/CondCore/EcalPlugins/plugins/EcalPyUtils.cc
+++ b/CondCore/EcalPlugins/plugins/EcalPyUtils.cc
@@ -8,10 +8,13 @@
 #include "DataFormats/EcalDetId/interface/EBDetId.h"
 #include "DataFormats/EcalDetId/interface/EEDetId.h"
 #include "CondTools/Ecal/interface/EcalFloatCondObjectContainerXMLTranslator.h"
-#include <boost/python.hpp>
-#include <boost/python/suite/indexing/vector_indexing_suite.hpp>
+#include <pybind11/pybind11.h>
+namespace py = pybind11;
 
-using namespace boost::python;
+//#include <boost/python.hpp>
+//#include <boost/python/suite/indexing/vector_indexing_suite.hpp>
+
+//using namespace boost::python;
 
 namespace ecalpyutils {
 
@@ -59,7 +62,7 @@ namespace ecalpyutils {
   }
 }  // namespace ecalpyutils
 
-BOOST_PYTHON_MODULE(pluginEcalPyUtils) {
+PYBIND11_MODULE(pluginEcalPyUtils, m) {
   //   looks like these are already defined somewhere
 
   //   python access to stl integer vectors
@@ -71,12 +74,12 @@ BOOST_PYTHON_MODULE(pluginEcalPyUtils) {
   //     .def(vector_indexing_suite<std::vector<float> >())
   //   ;
 
-  def("hashedIndexToEtaPhi", &ecalpyutils::hashedIndexToEtaPhi);
-  def("hashedIndexToXY", &ecalpyutils::hashedIndexToXY);
-  def("hashedIndex", &ecalpyutils::hashedIndex);
-  def("hashedIndexEE", &ecalpyutils::hashedIndexEE);
-  def("ism", &ecalpyutils::ism);
-  def("barrelfromXML", &EcalFloatCondObjectContainerXMLTranslator::barrelfromXML);
-  def("endcapfromXML", &EcalFloatCondObjectContainerXMLTranslator::endcapfromXML);
-  def("arraystoXML", &ecalpyutils::arraystoXML);
+  m.def("hashedIndexToEtaPhi", &ecalpyutils::hashedIndexToEtaPhi);
+  m.def("hashedIndexToXY", &ecalpyutils::hashedIndexToXY);
+  m.def("hashedIndex", &ecalpyutils::hashedIndex);
+  m.def("hashedIndexEE", &ecalpyutils::hashedIndexEE);
+  m.def("ism", &ecalpyutils::ism);
+  m.def("barrelfromXML", &EcalFloatCondObjectContainerXMLTranslator::barrelfromXML);
+  m.def("endcapfromXML", &EcalFloatCondObjectContainerXMLTranslator::endcapfromXML);
+  m.def("arraystoXML", &ecalpyutils::arraystoXML);
 }

--- a/CondCore/SiPixelPlugins/test/testSiPixelPayloadInspector.cpp
+++ b/CondCore/SiPixelPlugins/test/testSiPixelPayloadInspector.cpp
@@ -132,7 +132,7 @@ int main(int argc, char** argv) {
   histo16.process(connectionString, PI::mk_input(tag, end, end));
   edm::LogPrint("testSiPixelPayloadInspector") << histo16.data() << std::endl;
 
-  boost::python::dict inputs;
+  py::dict inputs;
   inputs["SetLog"] = "True";  // sets to true, 1,True,Yes will work
 
   SiPixelGainCalibrationOfflineGainsValuesBarrel histo17;

--- a/CondCore/SiStripPlugins/test/testSiStripPayloadInspector.cpp
+++ b/CondCore/SiStripPlugins/test/testSiStripPayloadInspector.cpp
@@ -33,7 +33,7 @@ int main(int argc, char** argv) {
   std::string tag = "SiStripApvGain_FromParticles_GR10_v11_offline";
   cond::Time_t start = boost::lexical_cast<unsigned long long>(132440);
   cond::Time_t end = boost::lexical_cast<unsigned long long>(285368);
-  boost::python::dict inputs;
+  py::dict inputs;
 
   edm::LogPrint("testSiStripPayloadInspector") << "## Exercising Gains plots " << std::endl;
 
@@ -112,7 +112,8 @@ int main(int argc, char** argv) {
   edm::LogPrint("testSiStripPayloadInspector") << histo11.data() << std::endl;
 
   SiStripPedestalPerDetId histoPedestalForDetId;
-  inputs["DetIds"] += ",470065830,369121594,369124670,470177668";  // add a bunch of other DetIds
+  inputs["DetIds"] = py::cast<std::string>(inputs["DetIds"]) +
+                     ",470065830,369121594,369124670,470177668";  // add a bunch of other DetIds
   histoPedestalForDetId.setInputParamValues(inputs);
   histoPedestalForDetId.process(connectionString, PI::mk_input(tag, start, start));
   edm::LogPrint("testSiStripPayloadInspector") << histoPedestalForDetId.data() << std::endl;

--- a/CondCore/Utilities/BuildFile.xml
+++ b/CondCore/Utilities/BuildFile.xml
@@ -2,7 +2,6 @@
 <use name="FWCore/Utilities"/>
 <use name="FWCore/PluginManager"/>
 <use name="boost"/>
-<use name="boost_python"/>
 <use name="boost_program_options"/>
 <use name="py3-pybind11"/>
 <use name="python3"/>

--- a/CondCore/Utilities/interface/PayloadInspector.h
+++ b/CondCore/Utilities/interface/PayloadInspector.h
@@ -14,25 +14,27 @@
 #include "FWCore/Utilities/interface/GlobalIdentifier.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
-#include <boost/python/list.hpp>
-#include <boost/python/dict.hpp>
-#include <boost/python/tuple.hpp>
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+namespace py = pybind11;
 
 namespace PI {
-  inline boost::python::list mk_input(const std::string& tagName, cond::Time_t start, cond::Time_t end) {
-    boost::python::list ret;
-    ret.append(boost::python::make_tuple(tagName, std::to_string(start), std::to_string(end)));
+  __attribute__((visibility("default"))) inline py::list mk_input(const std::string& tagName,
+                                                                  cond::Time_t start,
+                                                                  cond::Time_t end) {
+    py::list ret;
+    ret.append(py::make_tuple(tagName, std::to_string(start), std::to_string(end)));
     return ret;
   }
-  inline boost::python::list mk_input(const std::string& tagName0,
-                                      cond::Time_t start0,
-                                      cond::Time_t end0,
-                                      const std::string& tagName1,
-                                      cond::Time_t start1,
-                                      cond::Time_t end1) {
-    boost::python::list ret;
-    ret.append(boost::python::make_tuple(tagName0, std::to_string(start0), std::to_string(end0)));
-    ret.append(boost::python::make_tuple(tagName1, std::to_string(start1), std::to_string(end1)));
+  __attribute__((visibility("default"))) inline py::list mk_input(const std::string& tagName0,
+                                                                  cond::Time_t start0,
+                                                                  cond::Time_t end0,
+                                                                  const std::string& tagName1,
+                                                                  cond::Time_t start1,
+                                                                  cond::Time_t end1) {
+    py::list ret;
+    ret.append(py::make_tuple(tagName0, std::to_string(start0), std::to_string(end0)));
+    ret.append(py::make_tuple(tagName1, std::to_string(start1), std::to_string(end1)));
     return ret;
   }
 }  // namespace PI
@@ -228,16 +230,17 @@ namespace cond {
       bool isSingleIov() const;
 
       // required in the browser
-      boost::python::list inputParams() const;
+      __attribute__((visibility("default"))) py::list inputParams() const;
 
       // required in the browser
-      void setInputParamValues(const boost::python::dict& values);
+      __attribute__((visibility("default"))) void setInputParamValues(const py::dict& values);
 
       // returns the json file with the plot data
       std::string data() const;
 
       // triggers the processing producing the plot
-      bool process(const std::string& connectionString, const boost::python::list& tagsWithTimeBoundaries);
+      __attribute__((visibility("default"))) bool process(const std::string& connectionString,
+                                                          const py::list& tagsWithTimeBoundaries);
 
       // called by the above method - to be used in C++ unit tests...
       bool exec_process(const std::string& connectionString,

--- a/CondCore/Utilities/interface/PayloadInspectorModule.h
+++ b/CondCore/Utilities/interface/PayloadInspectorModule.h
@@ -1,18 +1,21 @@
-#include <boost/python.hpp>
+#include <pybind11/pybind11.h>
+namespace py = pybind11;
 
 #define PPCAT_NX(A, B) A##B
 #define PPCAT(A, B) PPCAT_NX(A, B)
 #define STRINGIZE_NX(A) #A
 #define STRINGIZE(A) STRINGIZE_NX(A)
 
-#define PAYLOAD_INSPECTOR_MODULE(PAYLOAD_TYPENAME) BOOST_PYTHON_MODULE(plugin##PAYLOAD_TYPENAME##_PayloadInspector)
+#define PAYLOAD_INSPECTOR_MODULE(PAYLOAD_TYPENAME) PYBIND11_MODULE(plugin##PAYLOAD_TYPENAME##_PayloadInspector, m)
 
-#define PAYLOAD_INSPECTOR_CLASS(CLASS_NAME)                                                   \
-  boost::python::class_<CLASS_NAME, boost::python::bases<cond::payloadInspector::PlotBase> >( \
-      STRINGIZE(PPCAT(plot_, CLASS_NAME)), boost::python::init<>())                           \
-          .def("process", &cond::payloadInspector::PlotBase::process)                         \
-          .def("payloadType", &cond::payloadInspector::PlotBase::payloadType)                 \
-          .def("title", &cond::payloadInspector::PlotBase::title)                             \
-          .def("isSingleIov", &cond::payloadInspector::PlotBase::isSingleIov)                 \
-          .def("isTwoTags", &cond::payloadInspector::PlotBase::isTwoTags)                     \
+#define PAYLOAD_INSPECTOR_CLASS(CLASS_NAME)                                   \
+  py::class_<CLASS_NAME, cond::payloadInspector::PlotBase>(                   \
+      m,                                                                      \
+      STRINGIZE(PPCAT(plot_, CLASS_NAME)))                                    \
+          .def(py::init<>())                                                  \
+          .def("process", &cond::payloadInspector::PlotBase::process)         \
+          .def("payloadType", &cond::payloadInspector::PlotBase::payloadType) \
+          .def("title", &cond::payloadInspector::PlotBase::title)             \
+          .def("isSingleIov", &cond::payloadInspector::PlotBase::isSingleIov) \
+          .def("isTwoTags", &cond::payloadInspector::PlotBase::isTwoTags)     \
           .def("data", &cond::payloadInspector::PlotBase::data);

--- a/CondCore/Utilities/plugins/BasicP_PayloadInspector.cc
+++ b/CondCore/Utilities/plugins/BasicP_PayloadInspector.cc
@@ -34,15 +34,15 @@ namespace {
       auto paramValues = cond::payloadInspector::PlotBase::inputParamValues();
       auto ip = paramValues.find("Factor");
       if (ip != paramValues.end()) {
-        v = v * boost::lexical_cast<float>(ip->second);
+        v = v * std::stof(ip->second);
       }
       ip = paramValues.find("Offset");
       if (ip != paramValues.end()) {
-        v = v + boost::lexical_cast<float>(ip->second);
+        v = v + std::stof(ip->second);
       }
       ip = paramValues.find("Scale");
       if (ip != paramValues.end()) {
-        v = v * boost::lexical_cast<float>(ip->second);
+        v = v * std::stof(ip->second);
       }
       return v;
     }

--- a/CondCore/Utilities/plugins/BuildFile.xml
+++ b/CondCore/Utilities/plugins/BuildFile.xml
@@ -12,12 +12,13 @@
   <use name="CondCore/Utilities"/>
   <use name="CondCore/CondDB"/>
   <use name="CondFormats/Common"/>
-  <use name="boost_python"/>
+  <use name="py3-pybind11"/>
   <use name="rootgraphics"/>
 </library>
 
 <library file="Module_PayloadInspector.cc" name="Module_PayloadInspector">
   <use name="CondCore/Utilities"/>
+  <use name="py3-pybind11"/>
 </library>
 
 <library file="Module_2XML.cc" name="Utilities_payload2xml">

--- a/CondCore/Utilities/plugins/Module_PayloadInspector.cc
+++ b/CondCore/Utilities/plugins/Module_PayloadInspector.cc
@@ -1,11 +1,11 @@
 #include "CondCore/Utilities/interface/PayloadInspector.h"
-#include <boost/python.hpp>
-#include <boost/python/suite/indexing/vector_indexing_suite.hpp>
+#include <pybind11/pybind11.h>
+namespace py = pybind11;
 
-BOOST_PYTHON_MODULE(pluginModule_PayloadInspector) {
-  boost::python::class_<cond::payloadInspector::ModuleVersion>("ModuleVersion")
-      .def_readonly("label", &cond::payloadInspector::ModuleVersion::label);
-  boost::python::class_<cond::payloadInspector::PlotBase>("PlotBase")
+PYBIND11_MODULE(pluginModule_PayloadInspector, m) {
+  py::class_<cond::payloadInspector::ModuleVersion>(m, "ModuleVersion")
+      .def_readonly_static("label", &cond::payloadInspector::ModuleVersion::label);
+  py::class_<cond::payloadInspector::PlotBase>(m, "PlotBase")
       .def("process", &cond::payloadInspector::PlotBase::process)
       .def("payloadType", &cond::payloadInspector::PlotBase::payloadType)
       .def("type", &cond::payloadInspector::PlotBase::type)

--- a/CondCore/Utilities/src/PayloadInspector.cc
+++ b/CondCore/Utilities/src/PayloadInspector.cc
@@ -5,7 +5,6 @@
 
 #include <sstream>
 #include <iostream>
-#include <boost/python/extract.hpp>
 
 namespace cond {
 
@@ -49,38 +48,39 @@ namespace cond {
 
     bool PlotBase::isTwoTags() const { return m_plotAnnotations.ntags == 2; }
 
-    boost::python::list PlotBase::inputParams() const {
-      boost::python::list tmp;
+    py::list PlotBase::inputParams() const {
+      py::list tmp;
       for (const auto& ip : m_inputParams) {
         tmp.append(ip);
       }
       return tmp;
     }
 
-    void PlotBase::setInputParamValues(const boost::python::dict& values) {
-      for (const auto& ip : m_inputParams) {
-        if (values.has_key(ip)) {
-          std::string val = boost::python::extract<std::string>(values.get(ip));
-          m_inputParamValues.insert(std::make_pair(ip, val));
+    void PlotBase::setInputParamValues(const py::dict& values) {
+      for (auto item : values) {
+        std::string k = item.first.cast<std::string>();
+        std::string v = item.second.cast<std::string>();
+        if (m_inputParams.find(k) != m_inputParams.end()) {
+          m_inputParamValues.insert(std::make_pair(k, v));
         }
       }
     }
 
     std::string PlotBase::data() const { return m_data; }
 
-    bool PlotBase::process(const std::string& connectionString, const boost::python::list& tagsWithTimeBoundaries) {
-      size_t nt = boost::python::len(tagsWithTimeBoundaries);
+    bool PlotBase::process(const std::string& connectionString, const py::list& tagsWithTimeBoundaries) {
+      size_t nt = py::len(tagsWithTimeBoundaries);
       bool ret = false;
       if (nt) {
         std::vector<std::tuple<std::string, cond::Time_t, cond::Time_t> > tags;
         tags.resize(nt);
         for (size_t i = 0; i < nt; i++) {
-          boost::python::tuple entry = boost::python::extract<boost::python::tuple>(tagsWithTimeBoundaries[i]);
-          std::string tagName = boost::python::extract<std::string>(entry[0]);
-          std::string time0s = boost::python::extract<std::string>(entry[1]);
-          std::string time1s = boost::python::extract<std::string>(entry[2]);
-          cond::Time_t time0 = boost::lexical_cast<cond::Time_t>(time0s);
-          cond::Time_t time1 = boost::lexical_cast<cond::Time_t>(time1s);
+          py::tuple entry = tagsWithTimeBoundaries[i].cast<py::tuple>();
+          std::string tagName = entry[0].cast<std::string>();
+          std::string time0s = entry[1].cast<std::string>();
+          std::string time1s = entry[2].cast<std::string>();
+          cond::Time_t time0 = std::stoull(time0s);
+          cond::Time_t time1 = std::stoull(time1s);
           tags[i] = std::make_tuple(tagName, time0, time1);
         }
         ret = exec_process(connectionString, tags);


### PR DESCRIPTION
#### PR description:

In the PayloadInspector module, we have adopted a binding C++/python to provide interoperability between the manipulation of payload data within the C++, and the rendering of plots in a python-based web application. 
In this PR we replace the binding based on boost::python with pybind11.

The macro for the generation of the PayloadInspector plugins has been replaced and can be successfully applied to the various subsystems.

#### PR validation:

Unit/integration test + deployment in the DEMO slot within the Payload Inspector web app (Conddb browser )

