### PR TITLE
Update test configs for CSCDigitizer to 12_0_X

### DIFF
--- a/SimMuon/CSCDigitizer/test/CSCDigiDump_cfg.py
+++ b/SimMuon/CSCDigitizer/test/CSCDigiDump_cfg.py
@@ -1,63 +1,52 @@
-# Based on cmsDriver.py created file - but needed a LOT of editing - Tim Cox, Feb/Mar 2015
-# 05.03.2015 - runs in 73x-75x (at least) - dumps all CSC digis, but not CSCDigitizer debugging info
+# TEST CSCDIGIDUMP ON RUN3 SIMULATED DATA - DUMPS THE CSC SIM DIGIS IN A RELVAL FILE
+# Based on CSCDigitizerTest_cfg.py once that was working 26.07.2021 - Tim Cox
 
 import FWCore.ParameterSet.Config as cms
 
-process = cms.Process('DIGI')
+from Configuration.Eras.Era_Run3_cff import Run3
+
+process = cms.Process('TIM',Run3)
 
 # import of standard configurations
 process.load('Configuration.StandardSequences.Services_cff')
-process.load('SimGeneral.HepPDTESSource.pythiapdt_cfi')
-
-process.load('Configuration.EventContent.EventContent_cff')
-process.load('SimGeneral.MixingModule.mixNoPU_cfi')
-process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
-process.load('Configuration.StandardSequences.MagneticField_38T_cff')
-process.load('Configuration.StandardSequences.Digi_cff')
+process.load('FWCore.MessageService.MessageLogger_cfi')
 process.load('Configuration.StandardSequences.EndOfProcess_cff')
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 
 process.maxEvents = cms.untracked.PSet(
-    input = cms.untracked.int32( 100 )
+    input = cms.untracked.int32( 10 ),
 )
 
+# Input source
 process.source = cms.Source("PoolSource",
-    dropDescendantsOfDroppedBranches = cms.untracked.bool(False),
     fileNames = cms.untracked.vstring(
-    '/store/relval/CMSSW_7_3_0/RelValSingleMuPt100_UP15/GEN-SIM-DIGI-RAW-HLTDEBUG/MCRUN2_73_V7-v1/00000/0864952B-5781-E411-99D5-0025905964CC.root'
+##   '/store/relval/CMSSW_12_0_0_pre3/RelValSingleMuPt100/GEN-SIM-DIGI-RAW/120X_mcRun3_2021_realistic_v1-v1/00000/a7d8aebc-928d-419e-973f-0d4ee6dde236.root'
+     'file:singlemupt100_10ev.root'
     ),
     secondaryFileNames = cms.untracked.vstring()
 )
 
+# Conditions data
 from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:run3_mc_FULL', '')
 
-process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:run2_mc', '')
-
-# MessageLogger
-
-process.load('FWCore.MessageService.MessageLogger_cfi')
-
-# Activate LogVerbatim output in CSCDigitizer
-# Activate LogVerbatim output in CSC Digis and CSCDigiDump
-
-
+# Activate LogVerbatim messages in CSCDigiDump to cout
 process.MessageLogger.cerr.enable = False
-process.MessageLogger.cout = cms.untracked.PSet(
-    enable    = cms.untracked.bool(True),
-    threshold = cms.untracked.string("INFO"),
-    default   = cms.untracked.PSet( limit = cms.untracked.int32(0)  ),
-    FwkReport = cms.untracked.PSet( limit = cms.untracked.int32(-1) ),
-##    CSCDigitizer = cms.untracked.PSet( limit = cms.untracked.int32(-1) ),
-    CSCDigi      = cms.untracked.PSet( limit = cms.untracked.int32(-1) )
-)
+process.MessageLogger.cout.enable = True
+process.MessageLogger.cout.threshold = "INFO"
+process.MessageLogger.cout.default = dict( limit = 0 )
+process.MessageLogger.cout.INFO = dict (limit = 0 )
+process.MessageLogger.cout.CSCDigi = dict( limit = -1 )
 
-## To dump CSC digis need to include CSCDigiDump, AND activate LogVerbatim for "CSCDigi" above
-process.load("SimMuon.CSCDigitizer.cscDigiDump_cfi")
-# CSCDigiDump - cscDigiDump for real; cscSimDigiDump for sim (both in above cfi)
-##process.digi = cms.Path(process.pdigi)
-process.digi = cms.Path(process.pdigi*process.cscSimDigiDump)
-process.endjob = cms.EndPath(process.endOfProcess)
-process.schedule = cms.Schedule(process.digi,process.endjob)
+## CSCDigiDump - cscDigiDump for real; cscSimDigiDump for sim (both in next cfi)
+## Note that MessageLogger category CSCDigi must also be active (see above)
+process.load('SimMuon.CSCDigitizer.cscDigiDump_cfi')
 
+## Dump CSC sim digis
+process.csc_digi_dump = cms.Path(process.cscSimDigiDump)
 
+process.endjob_step = cms.EndPath(process.endOfProcess)
+
+# Schedule definition
+process.schedule = cms.Schedule(process.csc_digi_dump,process.endjob_step)
 

--- a/SimMuon/CSCDigitizer/test/CSCDigitizerFullDump_cfg.py
+++ b/SimMuon/CSCDigitizer/test/CSCDigitizerFullDump_cfg.py
@@ -1,0 +1,84 @@
+# TEST CSCDIGIPRODUCER (CSCDIGITIZER) BY RE-DIGITIZING A RUN3 SIMULATED DATA SAMPLE                                                           
+# WITH *FULL DUMP* OF CSCDIGITIZER PROCESS (NOT THE DIGIS, BUT THAT COULD BE ACTIVATED)
+
+# Auto generated configuration file JULY 2021 - Tim Cox 
+# - modified until it works on a Run 3 relval file with simhits in 12_0_x.
+# - try to minimize stuff in this config file
+
+# Source: /local/reps/CMSSW/CMSSW/Configuration/Applications/python/ConfigBuilder.py,v 
+# with command line options: TEMP4 --step=DIGI --conditions=auto:run3_mc_FULL --filein=/store/relval/CMSSW_12_0_0_pre3/RelValSingleMuPt100/GEN-SIM-DIGI-RAW/120X_mcRun3_2021_realistic_v1-v1/00000/a7d8aebc-928d-419e-973f-0d4ee6dde236.root --mc --era Run3 --no_exec
+
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Eras.Era_Run3_cff import Run3
+
+process = cms.Process('TIM',Run3)
+
+# import of standard configurations
+process.load('Configuration.StandardSequences.Services_cff')
+process.load('SimGeneral.HepPDTESSource.pythiapdt_cfi')
+process.load('FWCore.MessageService.MessageLogger_cfi')
+process.load('SimGeneral.MixingModule.mixNoPU_cfi')
+process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
+process.load('Configuration.StandardSequences.MagneticField_cff')
+process.load('Configuration.StandardSequences.Digi_cff')
+process.load('Configuration.StandardSequences.EndOfProcess_cff')
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32( 10 ),
+)
+
+# Input source
+process.source = cms.Source("PoolSource",
+    fileNames = cms.untracked.vstring(
+##    '/store/relval/CMSSW_12_0_0_pre3/RelValSingleMuPt100/GEN-SIM-DIGI-RAW/120X_mcRun3_2021_realistic_v1-v1/00000/a7d8aebc-928d-419e-973f-0d4ee6dde236.root'
+     'file:singlemupt100_10ev.root'
+    ),
+    secondaryFileNames = cms.untracked.vstring()
+)
+
+# Conditions data
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:run3_mc_FULL', '')
+
+# Activate LogTrace messages in CSCDigitizer to cout - 
+process.MessageLogger.cerr.enable = False
+process.MessageLogger.cout.enable = True
+process.MessageLogger.cout.threshold = "DEBUG"
+process.MessageLogger.debugModules = ["*"]
+process.MessageLogger.cout.default = dict( limit = 0 )
+process.MessageLogger.cout.INFO = dict (limit = 0 )
+process.MessageLogger.cout.CSCDigitizer = dict( limit = -1 )
+process.MessageLogger.cout.CSCStripElectronicsSim = dict( limit = -1 )
+process.MessageLogger.cout.CSCWireElectronicsSim = dict( limit = -1 )
+process.MessageLogger.cout.CSCBaseElectronicsSim = dict( limit = -1 )
+process.MessageLogger.cout.CSCWireHitSim = dict( limit = -1 )
+process.MessageLogger.cout.CSCDriftSim = dict( limit = -1 )
+process.MessageLogger.cout.CSCCrossGap = dict( limit = -1 )
+process.MessageLogger.cout.CSCGasCollisions = dict( limit = -1 )
+process.MessageLogger.cout.CSCDigi = dict( limit = -1 )
+
+# CSCDigiDump - cscDigiDump for real; cscSimDigiDump for sim (both in next cfi)
+# Note that MessageLogger category CSCDigi must also be active (see above)
+## process.load('SimMuon.CSCDigitizer.cscDigiDump_cfi')
+
+# Dump CSC sim digis from the latest process, i.e. the NEW digis not the OLD ones in the input file
+## process.csc_digi_dump = cms.Path(process.cscSimDigiDump)
+
+# Activate LogVerbatim output from CSCGasCollisions
+process.simMuonCSCDigis.dumpGasCollisions = cms.untracked.bool(True)
+
+# Stuff in a Task is unscheduled - need unscheduled so digitizer will actually run
+# => explicitly add CSC digitizer to the path even though it's already part of 'pdigi'
+# Still need process.pdigi in order to set up the CrossingFrame of PSimHits for CSCDigiProducer 
+
+process.digi_step = cms.Path(process.pdigi)
+process.csc_digi = cms.Path(process.simMuonCSCDigis)
+process.endjob_step = cms.EndPath(process.endOfProcess)
+
+# Schedule definition
+process.schedule = cms.Schedule(process.digi_step,process.csc_digi,process.endjob_step)
+# Replace the above by the following to add dump of the sim digis produced
+## process.schedule = cms.Schedule(process.digi_step,process.csc_digi,process.csc_digi_dump,process.endjob_step)
+

--- a/SimMuon/CSCDigitizer/test/CSCDigitizerTest_cfg.py
+++ b/SimMuon/CSCDigitizer/test/CSCDigitizerTest_cfg.py
@@ -1,67 +1,74 @@
-# Based on cmsDriver.py created file - but needed a LOT of editing - Tim Cox, Feb/Mar 2015
-# 05.03.2015 - runs in 73X-75x (at least) - dumps CSCDigitizer info & can activate dump of all CSC digis
+# TEST CSCDIGIPRODUCER (CSCDIGITIZER) BY RE-DIGITIZING A RUN3 SIMULATED DATA SAMPLE
+# AND DUMP THE *NEW* DIGIS WITH CSCDIGIDUMP
+
+# Auto generated configuration file JULY 2021 - Tim Cox 
+# - modified until it works on a Run 3 relval file with simhits in 12_0_x.
+# - try to minimize stuff in this config file
+
+# Source: /local/reps/CMSSW/CMSSW/Configuration/Applications/python/ConfigBuilder.py,v 
+# with command line options: TEMP4 --step=DIGI --conditions=auto:run3_mc_FULL --filein=/store/relval/CMSSW_12_0_0_pre3/RelValSingleMuPt100/GEN-SIM-DIGI-RAW/120X_mcRun3_2021_realistic_v1-v1/00000/a7d8aebc-928d-419e-973f-0d4ee6dde236.root --mc --era Run3 --no_exec
 
 import FWCore.ParameterSet.Config as cms
 
-process = cms.Process('DIGI')
+from Configuration.Eras.Era_Run3_cff import Run3
+
+process = cms.Process('TIM',Run3)
 
 # import of standard configurations
 process.load('Configuration.StandardSequences.Services_cff')
 process.load('SimGeneral.HepPDTESSource.pythiapdt_cfi')
-
-process.load('Configuration.EventContent.EventContent_cff')
+process.load('FWCore.MessageService.MessageLogger_cfi')
 process.load('SimGeneral.MixingModule.mixNoPU_cfi')
 process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
-process.load('Configuration.StandardSequences.MagneticField_38T_cff')
+process.load('Configuration.StandardSequences.MagneticField_cff')
 process.load('Configuration.StandardSequences.Digi_cff')
 process.load('Configuration.StandardSequences.EndOfProcess_cff')
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 
 process.maxEvents = cms.untracked.PSet(
-    input = cms.untracked.int32( 100 )
+    input = cms.untracked.int32( 10 ),
 )
 
+# Input source
 process.source = cms.Source("PoolSource",
-    dropDescendantsOfDroppedBranches = cms.untracked.bool(False),
     fileNames = cms.untracked.vstring(
-    '/store/relval/CMSSW_7_3_0/RelValSingleMuPt100_UP15/GEN-SIM-DIGI-RAW-HLTDEBUG/MCRUN2_73_V7-v1/00000/0864952B-5781-E411-99D5-0025905964CC.root'
+##    '/store/relval/CMSSW_12_0_0_pre3/RelValSingleMuPt100/GEN-SIM-DIGI-RAW/120X_mcRun3_2021_realistic_v1-v1/00000/a7d8aebc-928d-419e-973f-0d4ee6dde236.root'
+     'file:singlemupt100_10ev.root'
     ),
     secondaryFileNames = cms.untracked.vstring()
 )
 
+# Conditions data
 from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:run3_mc_FULL', '')
 
-process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:run2_mc', '')
-
-
-# Activate debug printout for CSCDigitizer (must ALSO activate LogVerbatim for "CSCDigitizer")
-process.simMuonCSCDigis.dumpGasCollisions = cms.untracked.bool(True)
-
-# MessageLogger
-
-process.load('FWCore.MessageService.MessageLogger_cfi')
-
-# Activate LogVerbatim output in CSCDigitizer
-# Activate LogVerbatim output in CSC Digis and CSCDigiDump
-
+# Activate LogVerbatim messages in CSCDigitizer and CSCDigiDump to cout
 process.MessageLogger.cerr.enable = False
-process.MessageLogger.cout = cms.untracked.PSet(
-    enable    = cms.untracked.bool(True),
-    threshold = cms.untracked.string("INFO"),
-    default   = cms.untracked.PSet( limit = cms.untracked.int32(0)  ),
-    FwkReport = cms.untracked.PSet( limit = cms.untracked.int32(-1) ),
-    CSCDigitizer = cms.untracked.PSet( limit = cms.untracked.int32(-1) )
-##    CSCDigi      = cms.untracked.PSet( limit = cms.untracked.int32(-1) )
-)
+process.MessageLogger.cout.enable = True
+process.MessageLogger.cout.threshold = "INFO"
+process.MessageLogger.cout.default = dict( limit = 0 )
+process.MessageLogger.cout.INFO = dict (limit = 0 )
+process.MessageLogger.cout.CSCDigitizer = dict( limit = -1 )
+process.MessageLogger.cout.CSCDigi = dict( limit = -1 )
 
-## To dump strip, wire and comparator digis in each event, activate CSCDigiDump...
-##process.load("SimMuon.CSCDigitizer.cscDigiDump_cfi")
-# ... BUT must activate LogVerbatim for "CSCDigi" above too
-# CSCDigiDump - cscDigiDump for real; cscSimDigiDump for sim (both in above cfi)
-##process.digi = cms.Path(process.pdigi*process.cscSimDigiDump)
-process.digi = cms.Path(process.pdigi)
-process.endjob = cms.EndPath(process.endOfProcess)
-process.schedule = cms.Schedule(process.digi,process.endjob)
+## CSCDigiDump - cscDigiDump for real; cscSimDigiDump for sim (both in next cfi)
+## Note that MessageLogger category CSCDigi must also be active (see above)
+process.load('SimMuon.CSCDigitizer.cscDigiDump_cfi')
 
+## Dump CSC sim digis from the latest process, i.e. the NEW digis not the OLD ones in the input file
+process.csc_digi_dump = cms.Path(process.cscSimDigiDump)
 
+# Further info from CSCDigitizer?
+## process.simMuonCSCDigis.dumpGasCollisions = cms.untracked.bool(True)
+
+# Stuff in a Task is unscheduled - need unscheduled so digitizer will actually run
+# => explicitly add CSC digitizer to the path even though it's already part of 'pdigi'
+# Still need process.pdigi in order to set up the CrossingFrame of PSimHits for CSCDigiProducer 
+
+process.digi_step = cms.Path(process.pdigi)
+process.csc_digi = cms.Path(process.simMuonCSCDigis)
+process.endjob_step = cms.EndPath(process.endOfProcess)
+
+# Schedule definition
+process.schedule = cms.Schedule(process.digi_step,process.csc_digi,process.csc_digi_dump,process.endjob_step)
 


### PR DESCRIPTION
#### PR description:

Update test config files in CSCDigitizer:
1) Replace CSCDigitizerTest_cfg.py with updated version to run CSCDigiProducer on simhits in a CMSSW_12_0_X SingleMuPt100 relval file. It also dumps the digis produced.
2) Replace CSCDigiDump_cfg.py with updated version to run CSCDigiDump to dump the digis already in a 12_0_X SingleMuPt100 relval file
3) Add a new test config which activates full LogTrace and LogVerbatim messages to follow CSCDigitizer process when running on a 12_0_X relval file including simhits.

#### PR validation:

Tested thoroughly on a 12_0_0_pre3 relval sample GEN-SIM-DIGI-RAW for SingleMuPt100. 

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Not necessary
