### PR TITLE
[FWCore][clang-tidy] Fix suggested by modernize-use-nullptr check

### DIFF
--- a/FWCore/PythonParameterSet/src/PyBind11ProcessDesc.cc
+++ b/FWCore/PythonParameterSet/src/PyBind11ProcessDesc.cc
@@ -36,7 +36,7 @@ PyBind11ProcessDesc::PyBind11ProcessDesc(std::string const& config, int argc, ch
     v_argv.reserve(argc);
     vp_argv.reserve(argc);
     for (int i = 0; i < argc; i++) {
-      v_argv.emplace_back(Py_DecodeLocale(argv[i], NULL), &PyMem_RawFree);
+      v_argv.emplace_back(Py_DecodeLocale(argv[i], nullptr), &PyMem_RawFree);
       vp_argv.emplace_back(v_argv.back().get());
     }
 


### PR DESCRIPTION
This was not checked previously as this code was only activated for PY3 ( https://github.com/cms-sw/cmssw/blob/master/FWCore/PythonParameterSet/src/PyBind11ProcessDesc.cc#L32-L46 )