### PR TITLE
[clang-tidy] Looks like NOLINTNEXTLINE is not working with misc-definitions-in-headers

### DIFF
--- a/TrackingTools/AnalyticalJacobians/src/AnalyticalCurvilinearJacobianSSE.icc
+++ b/TrackingTools/AnalyticalJacobians/src/AnalyticalCurvilinearJacobianSSE.icc
@@ -1,9 +1,9 @@
-// NOLINTNEXTLINE(misc-definitions-in-headers)
-void AnalyticalCurvilinearJacobian::computeFullJacobian(const GlobalTrajectoryParameters& globalParameters,
-                                                        const GlobalPoint& x,
-                                                        const GlobalVector& p,
-                                                        const GlobalVector& h,
-                                                        const double& s) {
+void AnalyticalCurvilinearJacobian::computeFullJacobian(  //NOLINT(misc-definitions-in-headers)
+    const GlobalTrajectoryParameters& globalParameters,
+    const GlobalPoint& x,
+    const GlobalVector& p,
+    const GlobalVector& h,
+    const double& s) {
   using mathSSE::Vec2D;
   using mathSSE::Vec3D;
   using mathSSE::Vec4D;


### PR DESCRIPTION
Looks like there is bug with NOLINTNEXTLINE  and it is not working to disable `misc-definitions-in-headers` check in `AnalyticalCurvilinearJacobianSSE.icc` file. Replacing it with `//NOLINT` works.

```
TrackingTools/AnalyticalJacobians/src/AnalyticalCurvilinearJacobianSSE.icc:3:32: warning: function 'computeFullJacobian' defined in a header file; function definitions in header files can lead to ODR violations [misc-definitions-in-headers]
AnalyticalCurvilinearJacobian::computeFullJacobian(const GlobalTrajectoryParameters& globalParameters,
                               ^
TrackingTools/AnalyticalJacobians/src/AnalyticalCurvilinearJacobianSSE.icc:3:32: note: make as 'inline'
AnalyticalCurvilinearJacobian::computeFullJacobian(const GlobalTrajectoryParameters& globalParameters,

```