### PR TITLE
Disable vertex smearing for workflows using CloseByParticleGun

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -3355,7 +3355,7 @@ for year,k in [(year,k) for year in upgradeKeys for k in upgradeKeys[year]]:
                                        '--geometry' : geom
                                        }
 
-    upgradeStepDict['GenSimHLBeamSpot14HGCALCloseBy'][k]= {'-s' : 'GEN,SIM',
+    upgradeStepDict['GenSimHLBeamSpotHGCALCloseBy'][k]= {'-s' : 'GEN,SIM',
                                        '-n' : 10,
                                        '--conditions' : gt,
                                        '--beamspot' : 'HGCALCloseBy',

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -3355,6 +3355,15 @@ for year,k in [(year,k) for year in upgradeKeys for k in upgradeKeys[year]]:
                                        '--geometry' : geom
                                        }
 
+    upgradeStepDict['GenSimHLBeamSpot14HGCALCloseBy'][k]= {'-s' : 'GEN,SIM',
+                                       '-n' : 10,
+                                       '--conditions' : gt,
+                                       '--beamspot' : 'HLLHC14TeVHGCALCloseBy',
+                                       '--datatier' : 'GEN-SIM',
+                                       '--eventcontent': 'FEVTDEBUG',
+                                       '--geometry' : geom
+                                       }
+
     upgradeStepDict['Digi'][k] = {'-s':'DIGI:pdigi_valid,L1,DIGI2RAW,HLT:%s'%(hltversion),
                                       '--conditions':gt,
                                       '--datatier':'GEN-SIM-DIGI-RAW',

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -3358,7 +3358,7 @@ for year,k in [(year,k) for year in upgradeKeys for k in upgradeKeys[year]]:
     upgradeStepDict['GenSimHLBeamSpot14HGCALCloseBy'][k]= {'-s' : 'GEN,SIM',
                                        '-n' : 10,
                                        '--conditions' : gt,
-                                       '--beamspot' : 'HLLHC14TeVHGCALCloseBy',
+                                       '--beamspot' : 'HGCALCloseBy',
                                        '--datatier' : 'GEN-SIM',
                                        '--eventcontent': 'FEVTDEBUG',
                                        '--geometry' : geom

--- a/Configuration/PyReleaseValidation/python/relval_upgrade.py
+++ b/Configuration/PyReleaseValidation/python/relval_upgrade.py
@@ -35,7 +35,7 @@ for year in upgradeKeys:
                         if '14TeV' in frag:
                             step = 'GenSimHLBeamSpot14'
                         if 'CloseByParticle' in frag or 'CE_E' in frag or 'CE_H' in frag:
-                            step = 'GenSimHLBeamSpot14HGCALCloseBy'
+                            step = 'GenSimHLBeamSpotHGCALCloseBy'
                     stepMaker = makeStepNameSim
                 
                 if 'HARVEST' in step: hasHarvest = True

--- a/Configuration/PyReleaseValidation/python/relval_upgrade.py
+++ b/Configuration/PyReleaseValidation/python/relval_upgrade.py
@@ -34,7 +34,7 @@ for year in upgradeKeys:
                     if 'HLBeamSpot' in step:
                         if '14TeV' in frag:
                             step = 'GenSimHLBeamSpot14'
-                        if 'CloseByParticle' in frag or 'CE_E' in frag or 'CE_H' in frag:
+                        if 'CloseByParticle' in frag:
                             step = 'GenSimHLBeamSpot14HGCALCloseBy'                
                     stepMaker = makeStepNameSim
                 

--- a/Configuration/PyReleaseValidation/python/relval_upgrade.py
+++ b/Configuration/PyReleaseValidation/python/relval_upgrade.py
@@ -34,8 +34,8 @@ for year in upgradeKeys:
                     if 'HLBeamSpot' in step:
                         if '14TeV' in frag:
                             step = 'GenSimHLBeamSpot14'
-                        if 'CloseByParticle' in frag:
-                            step = 'GenSimHLBeamSpot14HGCALCloseBy'                
+                        if 'CloseByParticle' in frag or 'CE_E' in frag or 'CE_H' in frag:
+                            step = 'GenSimHLBeamSpot14HGCALCloseBy'
                     stepMaker = makeStepNameSim
                 
                 if 'HARVEST' in step: hasHarvest = True

--- a/Configuration/PyReleaseValidation/python/relval_upgrade.py
+++ b/Configuration/PyReleaseValidation/python/relval_upgrade.py
@@ -31,8 +31,11 @@ for year in upgradeKeys:
             for step in upgradeProperties[year][key]['ScenToRun']:                    
                 stepMaker = makeStepName
                 if 'Sim' in step:
-                    if 'HLBeamSpot' in step and '14TeV' in frag:
-                        step = 'GenSimHLBeamSpot14'
+                    if 'HLBeamSpot' in step:
+                        if '14TeV' in frag:
+                            step = 'GenSimHLBeamSpot14'
+                        if 'CloseByParticle' in frag or 'CE_E' in frag or 'CE_H' in frag:
+                            step = 'GenSimHLBeamSpot14HGCALCloseBy'                
                     stepMaker = makeStepNameSim
                 
                 if 'HARVEST' in step: hasHarvest = True

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -157,7 +157,7 @@ upgradeWFs['baseline'] = UpgradeWorkflow_baseline(
         'GenSim',
         'GenSimHLBeamSpot',
         'GenSimHLBeamSpot14',
-        'GenSimHLBeamSpot14CloseBy',
+        'GenSimHLBeamSpot14HGCALCloseBy',
         'Digi',
         'DigiTrigger',
         'RecoLocal',

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -157,6 +157,7 @@ upgradeWFs['baseline'] = UpgradeWorkflow_baseline(
         'GenSim',
         'GenSimHLBeamSpot',
         'GenSimHLBeamSpot14',
+        'GenSimHLBeamSpot14CloseBy',
         'Digi',
         'DigiTrigger',
         'RecoLocal',

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -157,7 +157,7 @@ upgradeWFs['baseline'] = UpgradeWorkflow_baseline(
         'GenSim',
         'GenSimHLBeamSpot',
         'GenSimHLBeamSpot14',
-        'GenSimHLBeamSpot14HGCALCloseBy',
+        'GenSimHLBeamSpotHGCALCloseBy',
         'Digi',
         'DigiTrigger',
         'RecoLocal',

--- a/Configuration/StandardSequences/python/VtxSmeared.py
+++ b/Configuration/StandardSequences/python/VtxSmeared.py
@@ -37,6 +37,7 @@ VtxSmeared = {
     'RealisticPbPBoost5TeV2016Collision':  'GeneratorInterface.HiGenCommon.VtxSmearedPbP5TeVBoost_cff',
     'RealisticPPbBoost8TeV2016Collision':  'GeneratorInterface.HiGenCommon.VtxSmearedPPb8TeVBoost_cff',
     'RealisticPbPBoost8TeV2016Collision':  'GeneratorInterface.HiGenCommon.VtxSmearedPbP8TeVBoost_cff',
+    'HGCALCloseBy'  :                'IOMC.EventVertexGenerators.VtxSmearedHGCALCloseBy_cfi',
     'HLLHC'  :                       'IOMC.EventVertexGenerators.VtxSmearedHLLHC_cfi',
     'HLLHC14TeV'  :                  'IOMC.EventVertexGenerators.VtxSmearedHLLHC14TeV_cfi',
     'HLLHC_CK'  :                    'IOMC.EventVertexGenerators.VtxSmearedHLLHCCrabKissing_cfi',

--- a/IOMC/EventVertexGenerators/python/VtxSmearedHGCALCloseBy_cfi.py
+++ b/IOMC/EventVertexGenerators/python/VtxSmearedHGCALCloseBy_cfi.py
@@ -1,9 +1,10 @@
 import FWCore.ParameterSet.Config as cms
 
 from IOMC.EventVertexGenerators.VtxSmearedParameters_cfi import *
-HLLHCVtxSmearingParameters14TeV = HLLHCVtxSmearingParameters.clone( EprotonInGeV = cms.double(7000) )
 VtxSmeared = cms.EDProducer("HLLHCEvtVtxGenerator",
-    HLLHCVtxSmearingParameters14TeV,
+    GaussVtxSmearingParameters,
     VtxSmearedCommon
 )
+VtxSmeared.SigmaX = cms.double(0)
+VtxSmeared.SigmaY = cms.double(0)
 VtxSmeared.SigmaZ = cms.double(0)

--- a/IOMC/EventVertexGenerators/python/VtxSmearedHGCALCloseBy_cfi.py
+++ b/IOMC/EventVertexGenerators/python/VtxSmearedHGCALCloseBy_cfi.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
 from IOMC.EventVertexGenerators.VtxSmearedParameters_cfi import *
-VtxSmeared = cms.EDProducer("HLLHCEvtVtxGenerator",
+VtxSmeared = cms.EDProducer("GaussEvtVtxGenerator",
     GaussVtxSmearingParameters,
     VtxSmearedCommon
 )

--- a/IOMC/EventVertexGenerators/python/VtxSmearedHLLHC14TeVHGCALCloseBy_cfi.py
+++ b/IOMC/EventVertexGenerators/python/VtxSmearedHLLHC14TeVHGCALCloseBy_cfi.py
@@ -7,5 +7,3 @@ VtxSmeared = cms.EDProducer("HLLHCEvtVtxGenerator",
     VtxSmearedCommon
 )
 VtxSmeared.SigmaZ = cms.double(0)
-
-

--- a/IOMC/EventVertexGenerators/python/VtxSmearedHLLHC14TeVHGCALCloseBy_cfi.py
+++ b/IOMC/EventVertexGenerators/python/VtxSmearedHLLHC14TeVHGCALCloseBy_cfi.py
@@ -1,0 +1,11 @@
+import FWCore.ParameterSet.Config as cms
+
+from IOMC.EventVertexGenerators.VtxSmearedParameters_cfi import *
+HLLHCVtxSmearingParameters14TeV = HLLHCVtxSmearingParameters.clone( EprotonInGeV = cms.double(7000) )
+VtxSmeared = cms.EDProducer("HLLHCEvtVtxGenerator",
+    HLLHCVtxSmearingParameters14TeV,
+    VtxSmearedCommon
+)
+VtxSmeared.SigmaZ = cms.double(0)
+
+


### PR DESCRIPTION
#### PR description:

This PR disables any GEN->SIM vertex smearing for upgrade workflows using the CloseByParticleGun. HLLHC-like vertex smearing, as was the default so far for such workflows, defies the purpose of the CloseByParticleGun. In practical terms: if we want to position the particle gun right in front of the detector (HGCAL), we do not want to have a vertex smearing applied that would move the position of the simulated vertex _into_ the detector, as this would bias our studies and mess with truth definitions etc. If a spread in Z position of the vertex is desired, this can be handled through the config of the CloseByParticleGun. 
Hence, switch to a Gaussian Vertex smearing with width_x/y/z = 0 for all workflows using the CloseByParticleGun.

#### PR validation:

edmConfigDump on step1.py for an upgrade workflow that would previously have the smearing applied, like: `runTheMatrix.py -w upgrade -l 34693.0 -t 10 -j 0 --command '-n 10'` shows that the desired configuration was fetched.

Verified that GEN vertex and SIM vertex positions are identical for 10 events.


