### PR TITLE
[Cond][clang-tidy] make deleted function public 

### DIFF
--- a/CondCore/CondDB/plugins/XMLAuthenticationService.h
+++ b/CondCore/CondDB/plugins/XMLAuthenticationService.h
@@ -28,6 +28,9 @@ namespace cond {
     public:
       /// Constructor
       DataSourceEntry(const std::string& serviceName, const std::string& connectionName);
+      DataSourceEntry() = delete;
+      DataSourceEntry(const DataSourceEntry&) = delete;
+      DataSourceEntry& operator=(const DataSourceEntry&) = delete;
 
       /// Destructor
       ~DataSourceEntry();
@@ -65,11 +68,6 @@ namespace cond {
 
       /// The structure with the authentication data for the various roles
       std::map<std::string, coral::AuthenticationCredentials*> m_data;
-
-    private:
-      DataSourceEntry() = delete;
-      DataSourceEntry(const DataSourceEntry&) = delete;
-      DataSourceEntry& operator=(const DataSourceEntry&) = delete;
     };
 
     /**

--- a/CondCore/ESSources/interface/DataProxy.h
+++ b/CondCore/ESSources/interface/DataProxy.h
@@ -31,6 +31,8 @@ public:
                      edm::SerialTaskQueue* iQueue,
                      std::mutex* iMutex)
       : edm::eventsetup::ESSourceDataProxyTemplate<DataT>(iQueue, iMutex), m_data{pdata} {}
+  //DataProxy(); // stop default
+  const DataProxy& operator=(const DataProxy&) = delete;  // stop default
 
   // ---------- const member functions ---------------------
 
@@ -46,9 +48,6 @@ protected:
   DataT const* fetch() const final { return &(*m_data)(); }
 
 private:
-  //DataProxy(); // stop default
-  const DataProxy& operator=(const DataProxy&) = delete;  // stop default
-
   void initializeForNewIOV() override { m_data->initializeForNewIOV(); }
 
   // ---------- member data --------------------------------

--- a/CondFormats/DTObjects/interface/DTBufferTree.h
+++ b/CondFormats/DTObjects/interface/DTBufferTree.h
@@ -44,6 +44,8 @@ public:
   typedef typename std::vector<Key>::const_iterator ElementKey;
 
   DTBufferTree();
+  DTBufferTree(DTBufferTree const&) = delete;
+  DTBufferTree& operator=(DTBufferTree const&) = delete;
   virtual ~DTBufferTree();
 
   void clear();
@@ -56,9 +58,6 @@ public:
   int find(const Key& k, typename DTBufferTreeTrait<Content>::outputTypeOfNonConstFind& cont);
 
 private:
-  DTBufferTree(DTBufferTree const&) = delete;
-  DTBufferTree& operator=(DTBufferTree const&) = delete;
-
   typedef DTBufferTree<Key, Content> map_node;
   typedef typename std::map<Key, DTBufferTree<Key, Content>*> map_cont;
   typedef typename std::map<Key, DTBufferTree<Key, Content>*>::const_iterator map_iter;

--- a/CondFormats/DTObjects/interface/DTCCBConfig.h
+++ b/CondFormats/DTObjects/interface/DTCCBConfig.h
@@ -60,6 +60,8 @@ public:
 class DTCCBConfig {
 public:
   DTCCBConfig();
+  DTCCBConfig(DTCCBConfig const&) = delete;
+  DTCCBConfig& operator=(DTCCBConfig const&) = delete;
   DTCCBConfig(const std::string& version);
 
   virtual ~DTCCBConfig();
@@ -96,9 +98,6 @@ public:
   void initialize();
 
 private:
-  DTCCBConfig(DTCCBConfig const&) = delete;
-  DTCCBConfig& operator=(DTCCBConfig const&) = delete;
-
   int timeStamp;
   std::string dataVersion;
   std::vector<DTConfigKey> fullConfigKey;

--- a/CondFormats/DTObjects/interface/DTDeadFlag.h
+++ b/CondFormats/DTObjects/interface/DTDeadFlag.h
@@ -68,6 +68,8 @@ public:
   /** Constructor
    */
   DTDeadFlag();
+  DTDeadFlag(DTDeadFlag const&) = delete;
+  DTDeadFlag& operator=(DTDeadFlag const&) = delete;
   DTDeadFlag(const std::string& version);
 
   /** Destructor
@@ -171,9 +173,6 @@ public:
   void initialize();
 
 private:
-  DTDeadFlag(DTDeadFlag const&) = delete;
-  DTDeadFlag& operator=(DTDeadFlag const&) = delete;
-
   std::string dataVersion;
 
   std::vector<std::pair<DTDeadFlagId, DTDeadFlagData> > dataList;

--- a/CondFormats/DTObjects/interface/DTHVStatus.h
+++ b/CondFormats/DTObjects/interface/DTHVStatus.h
@@ -72,6 +72,8 @@ public:
   /** Constructor
    */
   DTHVStatus();
+  DTHVStatus(DTHVStatus const&) = delete;
+  DTHVStatus& operator=(DTHVStatus const&) = delete;
   DTHVStatus(const std::string& version);
 
   /** Destructor
@@ -132,9 +134,6 @@ public:
   void initialize();
 
 private:
-  DTHVStatus(DTHVStatus const&) = delete;
-  DTHVStatus& operator=(DTHVStatus const&) = delete;
-
   std::string dataVersion;
 
   std::vector<std::pair<DTHVStatusId, DTHVStatusData> > dataList;

--- a/CondFormats/DTObjects/interface/DTLVStatus.h
+++ b/CondFormats/DTObjects/interface/DTLVStatus.h
@@ -65,6 +65,8 @@ public:
   /** Constructor
    */
   DTLVStatus();
+  DTLVStatus(DTLVStatus const&) = delete;
+  DTLVStatus& operator=(DTLVStatus const&) = delete;
   DTLVStatus(const std::string& version);
 
   /** Destructor
@@ -102,9 +104,6 @@ public:
   void initialize();
 
 private:
-  DTLVStatus(DTLVStatus const&) = delete;
-  DTLVStatus& operator=(DTLVStatus const&) = delete;
-
   std::string dataVersion;
 
   std::vector<std::pair<DTLVStatusId, DTLVStatusData> > dataList;

--- a/CondFormats/DTObjects/interface/DTMtime.h
+++ b/CondFormats/DTObjects/interface/DTMtime.h
@@ -70,6 +70,8 @@ public:
   /** Constructor
    */
   DTMtime();
+  DTMtime(DTMtime const&) = delete;
+  DTMtime& operator=(DTMtime const&) = delete;
   DTMtime(const std::string& version);
 
   /** Destructor
@@ -188,9 +190,6 @@ public:
   void initialize();
 
 private:
-  DTMtime(DTMtime const&) = delete;
-  DTMtime& operator=(DTMtime const&) = delete;
-
   std::string dataVersion;
   float nsPerCount;
 

--- a/CondFormats/DTObjects/interface/DTPerformance.h
+++ b/CondFormats/DTObjects/interface/DTPerformance.h
@@ -70,6 +70,8 @@ public:
   /** Constructor
    */
   DTPerformance();
+  DTPerformance(DTPerformance const&) = delete;
+  DTPerformance& operator=(DTPerformance const&) = delete;
   DTPerformance(const std::string& version);
 
   /** Destructor
@@ -212,9 +214,6 @@ public:
   void initialize();
 
 private:
-  DTPerformance(DTPerformance const&) = delete;
-  DTPerformance& operator=(DTPerformance const&) = delete;
-
   std::string dataVersion;
   float nsPerCount;
 

--- a/CondFormats/DTObjects/interface/DTRangeT0.h
+++ b/CondFormats/DTObjects/interface/DTRangeT0.h
@@ -65,6 +65,8 @@ public:
   /** Constructor
    */
   DTRangeT0();
+  DTRangeT0(DTRangeT0 const&) = delete;
+  DTRangeT0& operator=(DTRangeT0 const&) = delete;
   DTRangeT0(const std::string& version);
 
   /** Destructor
@@ -103,9 +105,6 @@ public:
   void initialize();
 
 private:
-  DTRangeT0(DTRangeT0 const&) = delete;
-  DTRangeT0& operator=(DTRangeT0 const&) = delete;
-
   std::string dataVersion;
 
   std::vector<std::pair<DTRangeT0Id, DTRangeT0Data> > dataList;

--- a/CondFormats/DTObjects/interface/DTReadOutMapping.h
+++ b/CondFormats/DTObjects/interface/DTReadOutMapping.h
@@ -64,6 +64,8 @@ public:
   /** Constructor
    */
   DTReadOutMapping();
+  DTReadOutMapping(DTReadOutMapping const&) = delete;
+  DTReadOutMapping& operator=(DTReadOutMapping const&) = delete;
   DTReadOutMapping(const std::string& cell_map_version, const std::string& rob_map_version);
 
   /** Destructor
@@ -135,9 +137,6 @@ public:
   const DTReadOutMapping* fullMap() const;
 
 private:
-  DTReadOutMapping(DTReadOutMapping const&) = delete;
-  DTReadOutMapping& operator=(DTReadOutMapping const&) = delete;
-
   edm::AtomicPtrCache<DTReadOutMappingCache> const& atomicCache() const { return atomicCache_; }
   edm::AtomicPtrCache<DTReadOutMappingCache>& atomicCache() { return atomicCache_; }
 

--- a/CondFormats/DTObjects/interface/DTStatusFlag.h
+++ b/CondFormats/DTObjects/interface/DTStatusFlag.h
@@ -76,6 +76,8 @@ public:
   /** Constructor
    */
   DTStatusFlag();
+  DTStatusFlag(DTStatusFlag const&) = delete;
+  DTStatusFlag& operator=(DTStatusFlag const&) = delete;
   DTStatusFlag(const std::string& version);
 
   /** Destructor
@@ -196,9 +198,6 @@ public:
   void initialize();
 
 private:
-  DTStatusFlag(DTStatusFlag const&) = delete;
-  DTStatusFlag& operator=(DTStatusFlag const&) = delete;
-
   std::string dataVersion;
 
   std::vector<std::pair<DTStatusFlagId, DTStatusFlagData> > dataList;

--- a/CondFormats/DTObjects/interface/DTTPGParameters.h
+++ b/CondFormats/DTObjects/interface/DTTPGParameters.h
@@ -64,6 +64,7 @@ public:
   /** Constructor
    */
   DTTPGParameters();
+  DTTPGParameters(DTTPGParameters const&) = delete;
   DTTPGParameters(const std::string& version);
 
   /** Destructor
@@ -102,8 +103,6 @@ public:
   DTTPGParameters& operator=(DTTPGParameters const&);
 
 private:
-  DTTPGParameters(DTTPGParameters const&) = delete;
-
   std::string dataVersion;
   float nsPerCount;
   int clockLength;

--- a/CondFormats/DTObjects/interface/DTTtrig.h
+++ b/CondFormats/DTObjects/interface/DTTtrig.h
@@ -70,6 +70,8 @@ public:
   /** Constructor
    */
   DTTtrig();
+  DTTtrig(DTTtrig const&) = delete;
+  DTTtrig& operator=(DTTtrig const&) = delete;
   DTTtrig(const std::string& version);
 
   /** Destructor
@@ -143,9 +145,6 @@ public:
   void initialize();
 
 private:
-  DTTtrig(DTTtrig const&) = delete;
-  DTTtrig& operator=(DTTtrig const&) = delete;
-
   std::string dataVersion;
   float nsPerCount;
 

--- a/CondFormats/JetMETObjects/interface/FactorizedJetCorrector.h
+++ b/CondFormats/JetMETObjects/interface/FactorizedJetCorrector.h
@@ -42,7 +42,6 @@ public:
   FactorizedJetCorrector(const FactorizedJetCorrector&) = delete;
   FactorizedJetCorrector& operator=(const FactorizedJetCorrector&) = delete;
 
-
   void setNPV(int fNPV);
   void setJetEta(float fEta);
   void setJetPt(float fPt);

--- a/CondFormats/JetMETObjects/interface/FactorizedJetCorrector.h
+++ b/CondFormats/JetMETObjects/interface/FactorizedJetCorrector.h
@@ -39,6 +39,9 @@ public:
   FactorizedJetCorrector();
   FactorizedJetCorrector(const std::string& fLevels, const std::string& fTags, const std::string& fOptions = "");
   FactorizedJetCorrector(const std::vector<JetCorrectorParameters>& fParameters);
+  FactorizedJetCorrector(const FactorizedJetCorrector&) = delete;
+  FactorizedJetCorrector& operator=(const FactorizedJetCorrector&) = delete;
+
 
   void setNPV(int fNPV);
   void setJetEta(float fEta);
@@ -60,8 +63,6 @@ public:
 
 private:
   //---- Member Functions ----
-  FactorizedJetCorrector(const FactorizedJetCorrector&) = delete;
-  FactorizedJetCorrector& operator=(const FactorizedJetCorrector&) = delete;
   //---- Member Data ---------
   FactorizedJetCorrectorCalculator::VariableValues mValues;
   FactorizedJetCorrectorCalculator mCalc;

--- a/CondFormats/JetMETObjects/interface/FactorizedJetCorrectorCalculator.h
+++ b/CondFormats/JetMETObjects/interface/FactorizedJetCorrectorCalculator.h
@@ -95,14 +95,14 @@ public:
                                    const std::string& fTags,
                                    const std::string& fOptions = "");
   FactorizedJetCorrectorCalculator(const std::vector<JetCorrectorParameters>& fParameters);
+  FactorizedJetCorrectorCalculator(const FactorizedJetCorrectorCalculator&) = delete;
+  FactorizedJetCorrectorCalculator& operator=(const FactorizedJetCorrectorCalculator&) = delete;
   ~FactorizedJetCorrectorCalculator();
   float getCorrection(VariableValues&) const;
   std::vector<float> getSubCorrections(VariableValues&) const;
 
 private:
   //---- Member Functions ----
-  FactorizedJetCorrectorCalculator(const FactorizedJetCorrectorCalculator&) = delete;
-  FactorizedJetCorrectorCalculator& operator=(const FactorizedJetCorrectorCalculator&) = delete;
   float getLepPt(const VariableValues&) const;
   float getRelLepPt(const VariableValues&) const;
   float getPtRel(const VariableValues&) const;

--- a/CondFormats/JetMETObjects/interface/JetCorrectionUncertainty.h
+++ b/CondFormats/JetMETObjects/interface/JetCorrectionUncertainty.h
@@ -13,6 +13,8 @@ public:
   JetCorrectionUncertainty();
   JetCorrectionUncertainty(const std::string& fDataFile);
   JetCorrectionUncertainty(const JetCorrectorParameters& fParameters);
+  JetCorrectionUncertainty(const JetCorrectionUncertainty&) = delete;
+  JetCorrectionUncertainty& operator=(const JetCorrectionUncertainty&) = delete;
   ~JetCorrectionUncertainty();
 
   void setParameters(const std::string& fDataFile);
@@ -28,8 +30,6 @@ public:
   float getUncertainty(bool fDirection);
 
 private:
-  JetCorrectionUncertainty(const JetCorrectionUncertainty&) = delete;
-  JetCorrectionUncertainty& operator=(const JetCorrectionUncertainty&) = delete;
   std::vector<float> fillVector(const std::vector<std::string>& fNames);
   float getPtRel();
   //---- Member Data ---------

--- a/CondFormats/JetMETObjects/interface/SimpleJetCorrectionUncertainty.h
+++ b/CondFormats/JetMETObjects/interface/SimpleJetCorrectionUncertainty.h
@@ -12,13 +12,13 @@ public:
   SimpleJetCorrectionUncertainty();
   SimpleJetCorrectionUncertainty(const std::string& fDataFile);
   SimpleJetCorrectionUncertainty(const JetCorrectorParameters& fParameters);
+  SimpleJetCorrectionUncertainty(const SimpleJetCorrectionUncertainty&) = delete;
+  SimpleJetCorrectionUncertainty& operator=(const SimpleJetCorrectionUncertainty&) = delete;
   ~SimpleJetCorrectionUncertainty();
   const JetCorrectorParameters& parameters() const { return *mParameters; }
   float uncertainty(const std::vector<float>& fX, float fY, bool fDirection) const;
 
 private:
-  SimpleJetCorrectionUncertainty(const SimpleJetCorrectionUncertainty&) = delete;
-  SimpleJetCorrectionUncertainty& operator=(const SimpleJetCorrectionUncertainty&) = delete;
   int findBin(const std::vector<float>& v, float x) const;
   float uncertaintyBin(unsigned fBin, float fY, bool fDirection) const;
   float linearInterpolation(float fZ, const float fX[2], const float fY[2]) const;

--- a/CondTools/DT/interface/DTKeyedConfigCache.h
+++ b/CondTools/DT/interface/DTKeyedConfigCache.h
@@ -29,6 +29,8 @@ class DTKeyedConfig;
 class DTKeyedConfigCache {
 public:
   DTKeyedConfigCache();
+  DTKeyedConfigCache(const DTKeyedConfigCache& x) = delete;
+  const DTKeyedConfigCache& operator=(const DTKeyedConfigCache& x) = delete;
   virtual ~DTKeyedConfigCache();
 
   int get(const cond::persistency::KeyList& keyList, int cfgId, const DTKeyedConfig*& obj);
@@ -42,9 +44,6 @@ public:
   static const int maxByteNumber;
 
 private:
-  DTKeyedConfigCache(const DTKeyedConfigCache& x) = delete;
-  const DTKeyedConfigCache& operator=(const DTKeyedConfigCache& x) = delete;
-
   typedef std::pair<int, const DTKeyedConfig*> counted_brick;
   std::map<int, counted_brick> brickMap;
   int cachedBrickNumber;

--- a/CondTools/Hcal/interface/StreamOutFormatTarget.h
+++ b/CondTools/Hcal/interface/StreamOutFormatTarget.h
@@ -32,6 +32,8 @@ public:
   /** @name constructors and destructor */
   //@{
   StreamOutFormatTarget(std::ostream& fStream);
+  StreamOutFormatTarget(const StreamOutFormatTarget&) = delete;
+  StreamOutFormatTarget& operator=(const StreamOutFormatTarget&) = delete;
   ~StreamOutFormatTarget() override;
   //@}
 
@@ -47,8 +49,6 @@ private:
   // -----------------------------------------------------------------------
   //  Unimplemented methods.
   // -----------------------------------------------------------------------
-  StreamOutFormatTarget(const StreamOutFormatTarget&) = delete;
-  StreamOutFormatTarget& operator=(const StreamOutFormatTarget&) = delete;
 };
 
 XERCES_CPP_NAMESPACE_END

--- a/CondTools/Hcal/plugins/BufferedBoostIODBWriter.cc
+++ b/CondTools/Hcal/plugins/BufferedBoostIODBWriter.cc
@@ -25,11 +25,11 @@ public:
   explicit BufferedBoostIODBWriter(const edm::ParameterSet&);
   ~BufferedBoostIODBWriter() override {}
 
-private:
   BufferedBoostIODBWriter() = delete;
   BufferedBoostIODBWriter(const BufferedBoostIODBWriter&) = delete;
   BufferedBoostIODBWriter& operator=(const BufferedBoostIODBWriter&) = delete;
 
+private:
   void analyze(const edm::Event&, const edm::EventSetup&) override;
 
   std::string inputFile;

--- a/CondTools/L1Trigger/interface/OMDSReader.h
+++ b/CondTools/L1Trigger/interface/OMDSReader.h
@@ -82,6 +82,10 @@ namespace l1t {
 
     OMDSReader(const std::string& connectString, const std::string& authenticationPath);
 
+    OMDSReader(const OMDSReader&) = delete;  // stop default
+
+    const OMDSReader& operator=(const OMDSReader&) = delete;  // stop default
+
     ~OMDSReader() override;
 
     // ---------- const member functions ---------------------
@@ -183,10 +187,6 @@ namespace l1t {
     void connect(const std::string& connectString, const std::string& authenticationPath);
 
   private:
-    OMDSReader(const OMDSReader&) = delete;  // stop default
-
-    const OMDSReader& operator=(const OMDSReader&) = delete;  // stop default
-
     // ---------- member data --------------------------------
   };
 


### PR DESCRIPTION
Cleanup for clang-tidy warning `deleted member function should be public [modernize-use-equals-delete]`