### PR TITLE
[Sim][clang-tidy] make deleted function public

### DIFF
--- a/SimDataFormats/Associations/interface/LayerClusterToCaloParticleAssociator.h
+++ b/SimDataFormats/Associations/interface/LayerClusterToCaloParticleAssociator.h
@@ -19,6 +19,10 @@ namespace hgcal {
     LayerClusterToCaloParticleAssociator() = default;
     LayerClusterToCaloParticleAssociator(LayerClusterToCaloParticleAssociator &&) = default;
     LayerClusterToCaloParticleAssociator &operator=(LayerClusterToCaloParticleAssociator &&) = default;
+    LayerClusterToCaloParticleAssociator(const LayerClusterToCaloParticleAssociator &) = delete;  // stop default
+    const LayerClusterToCaloParticleAssociator &operator=(const LayerClusterToCaloParticleAssociator &) =
+        delete;  // stop default
+
     ~LayerClusterToCaloParticleAssociator() = default;
 
     // ---------- const member functions ---------------------
@@ -35,11 +39,6 @@ namespace hgcal {
     }
 
   private:
-    LayerClusterToCaloParticleAssociator(const LayerClusterToCaloParticleAssociator &) = delete;  // stop default
-
-    const LayerClusterToCaloParticleAssociator &operator=(const LayerClusterToCaloParticleAssociator &) =
-        delete;  // stop default
-
     // ---------- member data --------------------------------
     std::unique_ptr<LayerClusterToCaloParticleAssociatorBaseImpl> m_impl;
   };

--- a/SimDataFormats/Associations/interface/LayerClusterToSimTracksterAssociator.h
+++ b/SimDataFormats/Associations/interface/LayerClusterToSimTracksterAssociator.h
@@ -19,6 +19,10 @@ namespace hgcal {
     LayerClusterToSimTracksterAssociator() = default;
     LayerClusterToSimTracksterAssociator(LayerClusterToSimTracksterAssociator &&) = default;
     LayerClusterToSimTracksterAssociator &operator=(LayerClusterToSimTracksterAssociator &&) = default;
+    LayerClusterToSimTracksterAssociator(const LayerClusterToSimTracksterAssociator &) = delete;  // stop default
+    const LayerClusterToSimTracksterAssociator &operator=(const LayerClusterToSimTracksterAssociator &) =
+        delete;  // stop default
+
     ~LayerClusterToSimTracksterAssociator() = default;
 
     // ---------- const member functions ---------------------
@@ -45,11 +49,6 @@ namespace hgcal {
     }
 
   private:
-    LayerClusterToSimTracksterAssociator(const LayerClusterToSimTracksterAssociator &) = delete;  // stop default
-
-    const LayerClusterToSimTracksterAssociator &operator=(const LayerClusterToSimTracksterAssociator &) =
-        delete;  // stop default
-
     // ---------- member data --------------------------------
     std::unique_ptr<LayerClusterToSimTracksterAssociatorBaseImpl> m_impl;
   };

--- a/SimDataFormats/Associations/interface/MultiClusterToCaloParticleAssociator.h
+++ b/SimDataFormats/Associations/interface/MultiClusterToCaloParticleAssociator.h
@@ -19,6 +19,10 @@ namespace hgcal {
     MultiClusterToCaloParticleAssociator() = default;
     MultiClusterToCaloParticleAssociator(MultiClusterToCaloParticleAssociator &&) = default;
     MultiClusterToCaloParticleAssociator &operator=(MultiClusterToCaloParticleAssociator &&) = default;
+    MultiClusterToCaloParticleAssociator(const MultiClusterToCaloParticleAssociator &) = delete;  // stop default
+    const MultiClusterToCaloParticleAssociator &operator=(const MultiClusterToCaloParticleAssociator &) =
+        delete;  // stop default
+
     ~MultiClusterToCaloParticleAssociator() = default;
 
     // ---------- const member functions ---------------------
@@ -37,11 +41,6 @@ namespace hgcal {
     }
 
   private:
-    MultiClusterToCaloParticleAssociator(const MultiClusterToCaloParticleAssociator &) = delete;  // stop default
-
-    const MultiClusterToCaloParticleAssociator &operator=(const MultiClusterToCaloParticleAssociator &) =
-        delete;  // stop default
-
     // ---------- member data --------------------------------
     std::unique_ptr<MultiClusterToCaloParticleAssociatorBaseImpl> m_impl;
   };

--- a/SimDataFormats/Associations/interface/MuonToTrackingParticleAssociator.h
+++ b/SimDataFormats/Associations/interface/MuonToTrackingParticleAssociator.h
@@ -21,6 +21,8 @@ namespace reco {
 #endif
     MuonToTrackingParticleAssociator(MuonToTrackingParticleAssociator &&) = default;
     MuonToTrackingParticleAssociator &operator=(MuonToTrackingParticleAssociator &&) = default;
+    MuonToTrackingParticleAssociator(const MuonToTrackingParticleAssociator &) = delete;
+    MuonToTrackingParticleAssociator &operator=(const MuonToTrackingParticleAssociator &) = delete;
 
     void associateMuons(MuonToSimCollection &recoToSim,
                         SimToMuonCollection &simToReco,
@@ -38,9 +40,6 @@ namespace reco {
     }
 
   private:
-    MuonToTrackingParticleAssociator(const MuonToTrackingParticleAssociator &) = delete;
-    MuonToTrackingParticleAssociator &operator=(const MuonToTrackingParticleAssociator &) = delete;
-
     std::unique_ptr<MuonToTrackingParticleAssociatorBaseImpl const> impl_;
   };
 }  // namespace reco

--- a/SimDataFormats/Associations/interface/TrackToGenParticleAssociator.h
+++ b/SimDataFormats/Associations/interface/TrackToGenParticleAssociator.h
@@ -41,6 +41,8 @@ namespace reco {
     ~TrackToGenParticleAssociator() = default;
     TrackToGenParticleAssociator(TrackToGenParticleAssociator &&) = default;
     TrackToGenParticleAssociator &operator=(TrackToGenParticleAssociator &&) = default;
+    TrackToGenParticleAssociator(const TrackToGenParticleAssociator &) = delete;  // stop default
+    const TrackToGenParticleAssociator &operator=(const TrackToGenParticleAssociator &) = delete;  // stop default
 
     /// Association Sim To Reco with Collections (Gen Particle version)
     reco::RecoToGenCollection associateRecoToGen(const edm::RefToBaseVector<reco::Track> &tracks,
@@ -66,10 +68,6 @@ namespace reco {
     }
 
   private:
-    TrackToGenParticleAssociator(const TrackToGenParticleAssociator &) = delete;  // stop default
-
-    const TrackToGenParticleAssociator &operator=(const TrackToGenParticleAssociator &) = delete;  // stop default
-
     std::unique_ptr<TrackToGenParticleAssociatorBaseImpl> m_impl;
   };
 }  // namespace reco

--- a/SimDataFormats/Associations/interface/TrackToGenParticleAssociator.h
+++ b/SimDataFormats/Associations/interface/TrackToGenParticleAssociator.h
@@ -41,7 +41,7 @@ namespace reco {
     ~TrackToGenParticleAssociator() = default;
     TrackToGenParticleAssociator(TrackToGenParticleAssociator &&) = default;
     TrackToGenParticleAssociator &operator=(TrackToGenParticleAssociator &&) = default;
-    TrackToGenParticleAssociator(const TrackToGenParticleAssociator &) = delete;  // stop default
+    TrackToGenParticleAssociator(const TrackToGenParticleAssociator &) = delete;                   // stop default
     const TrackToGenParticleAssociator &operator=(const TrackToGenParticleAssociator &) = delete;  // stop default
 
     /// Association Sim To Reco with Collections (Gen Particle version)

--- a/SimDataFormats/Associations/interface/TrackToGenParticleAssociatorBaseImpl.h
+++ b/SimDataFormats/Associations/interface/TrackToGenParticleAssociatorBaseImpl.h
@@ -30,7 +30,8 @@ namespace reco {
     /// Constructor
     TrackToGenParticleAssociatorBaseImpl();
     TrackToGenParticleAssociatorBaseImpl(const TrackToGenParticleAssociatorBaseImpl &) = delete;  // stop default
-    const TrackToGenParticleAssociatorBaseImpl &operator=(const TrackToGenParticleAssociatorBaseImpl &) =  delete;  // stop default
+    const TrackToGenParticleAssociatorBaseImpl &operator=(const TrackToGenParticleAssociatorBaseImpl &) =
+        delete;  // stop default
     virtual ~TrackToGenParticleAssociatorBaseImpl();
 
     /// Association Sim To Reco with Collections (Gen Particle version)

--- a/SimDataFormats/Associations/interface/TrackToGenParticleAssociatorBaseImpl.h
+++ b/SimDataFormats/Associations/interface/TrackToGenParticleAssociatorBaseImpl.h
@@ -29,6 +29,8 @@ namespace reco {
   public:
     /// Constructor
     TrackToGenParticleAssociatorBaseImpl();
+    TrackToGenParticleAssociatorBaseImpl(const TrackToGenParticleAssociatorBaseImpl &) = delete;  // stop default
+    const TrackToGenParticleAssociatorBaseImpl &operator=(const TrackToGenParticleAssociatorBaseImpl &) =  delete;  // stop default
     virtual ~TrackToGenParticleAssociatorBaseImpl();
 
     /// Association Sim To Reco with Collections (Gen Particle version)
@@ -48,12 +50,6 @@ namespace reco {
     /// compare reco to sim the handle of reco::Track and GenParticle collections
     virtual reco::GenToRecoCollection associateGenToReco(
         const edm::Handle<edm::View<reco::Track>> &tCH, const edm::Handle<reco::GenParticleCollection> &tPCH) const = 0;
-
-  private:
-    TrackToGenParticleAssociatorBaseImpl(const TrackToGenParticleAssociatorBaseImpl &) = delete;  // stop default
-
-    const TrackToGenParticleAssociatorBaseImpl &operator=(const TrackToGenParticleAssociatorBaseImpl &) =
-        delete;  // stop default
   };
 }  // namespace reco
 

--- a/SimDataFormats/Associations/interface/TrackToTrackingParticleAssociator.h
+++ b/SimDataFormats/Associations/interface/TrackToTrackingParticleAssociator.h
@@ -58,7 +58,7 @@ namespace reco {
     TrackToTrackingParticleAssociator &operator=(TrackToTrackingParticleAssociator &&) = default;
     TrackToTrackingParticleAssociator(const TrackToTrackingParticleAssociator &) = delete;  // stop default
     const TrackToTrackingParticleAssociator &operator=(const TrackToTrackingParticleAssociator &) =
-    delete;  // stop default
+        delete;  // stop default
 
     ~TrackToTrackingParticleAssociator() = default;
 

--- a/SimDataFormats/Associations/interface/TrackToTrackingParticleAssociator.h
+++ b/SimDataFormats/Associations/interface/TrackToTrackingParticleAssociator.h
@@ -56,6 +56,10 @@ namespace reco {
     TrackToTrackingParticleAssociator() = default;
     TrackToTrackingParticleAssociator(TrackToTrackingParticleAssociator &&) = default;
     TrackToTrackingParticleAssociator &operator=(TrackToTrackingParticleAssociator &&) = default;
+    TrackToTrackingParticleAssociator(const TrackToTrackingParticleAssociator &) = delete;  // stop default
+    const TrackToTrackingParticleAssociator &operator=(const TrackToTrackingParticleAssociator &) =
+    delete;  // stop default
+
     ~TrackToTrackingParticleAssociator() = default;
 
     // ---------- const member functions ---------------------
@@ -108,11 +112,6 @@ namespace reco {
     }
 
   private:
-    TrackToTrackingParticleAssociator(const TrackToTrackingParticleAssociator &) = delete;  // stop default
-
-    const TrackToTrackingParticleAssociator &operator=(const TrackToTrackingParticleAssociator &) =
-        delete;  // stop default
-
     // ---------- member data --------------------------------
     std::unique_ptr<TrackToTrackingParticleAssociatorBaseImpl> m_impl;
   };

--- a/SimDataFormats/Associations/interface/TracksterToSimClusterAssociator.h
+++ b/SimDataFormats/Associations/interface/TracksterToSimClusterAssociator.h
@@ -19,6 +19,9 @@ namespace hgcal {
     TracksterToSimClusterAssociator() = default;
     TracksterToSimClusterAssociator(TracksterToSimClusterAssociator &&) = default;
     TracksterToSimClusterAssociator &operator=(TracksterToSimClusterAssociator &&) = default;
+    TracksterToSimClusterAssociator(const TracksterToSimClusterAssociator &) = delete;  // stop default
+    const TracksterToSimClusterAssociator &operator=(const TracksterToSimClusterAssociator &) = delete;  // stop default
+
     ~TracksterToSimClusterAssociator() = default;
 
     // ---------- const member functions ---------------------
@@ -37,10 +40,6 @@ namespace hgcal {
     }
 
   private:
-    TracksterToSimClusterAssociator(const TracksterToSimClusterAssociator &) = delete;  // stop default
-
-    const TracksterToSimClusterAssociator &operator=(const TracksterToSimClusterAssociator &) = delete;  // stop default
-
     // ---------- member data --------------------------------
     std::unique_ptr<TracksterToSimClusterAssociatorBaseImpl> m_impl;
   };

--- a/SimDataFormats/Associations/interface/TracksterToSimClusterAssociator.h
+++ b/SimDataFormats/Associations/interface/TracksterToSimClusterAssociator.h
@@ -19,7 +19,7 @@ namespace hgcal {
     TracksterToSimClusterAssociator() = default;
     TracksterToSimClusterAssociator(TracksterToSimClusterAssociator &&) = default;
     TracksterToSimClusterAssociator &operator=(TracksterToSimClusterAssociator &&) = default;
-    TracksterToSimClusterAssociator(const TracksterToSimClusterAssociator &) = delete;  // stop default
+    TracksterToSimClusterAssociator(const TracksterToSimClusterAssociator &) = delete;                   // stop default
     const TracksterToSimClusterAssociator &operator=(const TracksterToSimClusterAssociator &) = delete;  // stop default
 
     ~TracksterToSimClusterAssociator() = default;

--- a/SimDataFormats/Associations/interface/TracksterToSimTracksterAssociator.h
+++ b/SimDataFormats/Associations/interface/TracksterToSimTracksterAssociator.h
@@ -19,6 +19,10 @@ namespace hgcal {
     TracksterToSimTracksterAssociator() = default;
     TracksterToSimTracksterAssociator(TracksterToSimTracksterAssociator &&) = default;
     TracksterToSimTracksterAssociator &operator=(TracksterToSimTracksterAssociator &&) = default;
+    TracksterToSimTracksterAssociator(const TracksterToSimTracksterAssociator &) = delete;  // stop default
+    const TracksterToSimTracksterAssociator &operator=(const TracksterToSimTracksterAssociator &) =
+        delete;  // stop default
+
     ~TracksterToSimTracksterAssociator() = default;
 
     // ---------- const member functions ---------------------
@@ -39,11 +43,6 @@ namespace hgcal {
     }
 
   private:
-    TracksterToSimTracksterAssociator(const TracksterToSimTracksterAssociator &) = delete;  // stop default
-
-    const TracksterToSimTracksterAssociator &operator=(const TracksterToSimTracksterAssociator &) =
-        delete;  // stop default
-
     // ---------- member data --------------------------------
     std::unique_ptr<TracksterToSimTracksterAssociatorBaseImpl> m_impl;
   };

--- a/SimDataFormats/Associations/interface/VertexToTrackingVertexAssociator.h
+++ b/SimDataFormats/Associations/interface/VertexToTrackingVertexAssociator.h
@@ -14,6 +14,10 @@ namespace reco {
     VertexToTrackingVertexAssociator() = default;
     VertexToTrackingVertexAssociator(VertexToTrackingVertexAssociator &&) = default;
     VertexToTrackingVertexAssociator &operator=(VertexToTrackingVertexAssociator &&) = default;
+    VertexToTrackingVertexAssociator(const VertexToTrackingVertexAssociator &) = delete;  // stop default
+    const VertexToTrackingVertexAssociator &operator=(const VertexToTrackingVertexAssociator &) =
+        delete;  // stop default
+
     ~VertexToTrackingVertexAssociator() = default;
 
     // ---------- const member functions ---------------------
@@ -32,11 +36,6 @@ namespace reco {
     }
 
   private:
-    VertexToTrackingVertexAssociator(const VertexToTrackingVertexAssociator &) = delete;  // stop default
-
-    const VertexToTrackingVertexAssociator &operator=(const VertexToTrackingVertexAssociator &) =
-        delete;  // stop default
-
     // ---------- member data --------------------------------
     std::unique_ptr<VertexToTrackingVertexAssociatorBaseImpl> m_impl;
   };

--- a/SimDataFormats/GeneratorProducts/interface/LHECommonBlocks.h
+++ b/SimDataFormats/GeneratorProducts/interface/LHECommonBlocks.h
@@ -118,7 +118,6 @@ namespace lhef {
       }
     }
 
-  private:
     CommonBlocks() = delete;
     ~CommonBlocks() = delete;
   };

--- a/SimG4CMS/Calo/interface/HFNoseNumberingScheme.h
+++ b/SimG4CMS/Calo/interface/HFNoseNumberingScheme.h
@@ -14,6 +14,7 @@
 class HFNoseNumberingScheme {
 public:
   HFNoseNumberingScheme(const HGCalDDDConstants& hgc);
+  HFNoseNumberingScheme() = delete;
   ~HFNoseNumberingScheme() {}
 
   /**
@@ -24,7 +25,6 @@ public:
 private:
   void checkPosition(uint32_t index, const G4ThreeVector& pos) const;
 
-  HFNoseNumberingScheme() = delete;
   const HGCalDDDConstants& hgcons_;
   const HGCalGeometryMode::GeometryMode mode_;
 };

--- a/SimG4CMS/Calo/interface/HGCNumberingScheme.h
+++ b/SimG4CMS/Calo/interface/HGCNumberingScheme.h
@@ -15,6 +15,7 @@ public:
   enum HGCNumberingParameters { HGCCellSize };
 
   HGCNumberingScheme(const HGCalDDDConstants& hgc, std::string& name);
+  HGCNumberingScheme() = delete;
 
   ~HGCNumberingScheme();
 
@@ -34,7 +35,6 @@ public:
   std::pair<float, float> getLocalCoords(int cell, int layer);
 
 private:
-  HGCNumberingScheme() = delete;
   const HGCalDDDConstants& hgcons_;
 };
 

--- a/SimG4CMS/Calo/interface/HGCalNumberingScheme.h
+++ b/SimG4CMS/Calo/interface/HGCalNumberingScheme.h
@@ -16,6 +16,7 @@
 class HGCalNumberingScheme {
 public:
   HGCalNumberingScheme(const HGCalDDDConstants& hgc, const DetId::Detector& det, const std::string& name);
+  HGCalNumberingScheme() = delete;
   ~HGCalNumberingScheme();
 
   /**
@@ -26,7 +27,6 @@ public:
 private:
   void checkPosition(uint32_t index, const G4ThreeVector& pos, bool matchOnly, bool debug) const;
 
-  HGCalNumberingScheme() = delete;
   const HGCalDDDConstants& hgcons_;
   const HGCalGeometryMode::GeometryMode mode_;
   DetId::Detector det_;

--- a/SimG4CMS/Calo/interface/HcalTestNumberingScheme.h
+++ b/SimG4CMS/Calo/interface/HcalTestNumberingScheme.h
@@ -11,14 +11,13 @@
 class HcalTestNumberingScheme : public HcalNumberingScheme {
 public:
   HcalTestNumberingScheme(bool forTB);
+  HcalTestNumberingScheme() = delete;
   ~HcalTestNumberingScheme() override;
   uint32_t getUnitID(const HcalNumberingFromDDD::HcalID& id) override;
   static uint32_t packHcalIndex(int det, int z, int depth, int eta, int phi, int lay);
   static void unpackHcalIndex(const uint32_t& idx, int& det, int& z, int& depth, int& eta, int& phi, int& lay);
 
 private:
-  HcalTestNumberingScheme() = delete;
-
   bool forTBH2;
 };
 

--- a/SimG4CMS/Forward/plugins/SimG4FluxProducer.h
+++ b/SimG4CMS/Forward/plugins/SimG4FluxProducer.h
@@ -28,14 +28,13 @@ class SimG4FluxProducer : public SimProducer,
                           public Observer<const G4Step *> {
 public:
   SimG4FluxProducer(const edm::ParameterSet &p);
+  SimG4FluxProducer(const SimG4FluxProducer &) = delete;  // stop default
+  const SimG4FluxProducer &operator=(const SimG4FluxProducer &) = delete;
   ~SimG4FluxProducer() override;
 
   void produce(edm::Event &, const edm::EventSetup &) override;
 
 private:
-  SimG4FluxProducer(const SimG4FluxProducer &) = delete;  // stop default
-  const SimG4FluxProducer &operator=(const SimG4FluxProducer &) = delete;
-
   // observer classes
   void update(const BeginOfRun *run) override;
   void update(const BeginOfEvent *evt) override;

--- a/SimG4CMS/HGCalTestBeam/interface/AHCalGeometry.h
+++ b/SimG4CMS/HGCalTestBeam/interface/AHCalGeometry.h
@@ -13,6 +13,7 @@ class AHCalGeometry {
 public:
   /** Create geometry of AHCal */
   AHCalGeometry(edm::ParameterSet const&);
+  AHCalGeometry() = delete;
   ~AHCalGeometry() {}
 
   /// get maximum number of layers
@@ -23,7 +24,6 @@ public:
   double getZ(const AHCalDetId& id) const;
 
 private:
-  AHCalGeometry() = delete;
   std::unique_ptr<AHCalParameters> ahcal_;
 };
 #endif

--- a/SimG4CMS/HGCalTestBeam/plugins/HGCPassive.h
+++ b/SimG4CMS/HGCalTestBeam/plugins/HGCPassive.h
@@ -40,14 +40,13 @@ class HGCPassive : public SimProducer,
                    public Observer<const G4Step *> {
 public:
   HGCPassive(const edm::ParameterSet &p);
+  HGCPassive(const HGCPassive &) = delete;  // stop default
+  const HGCPassive &operator=(const HGCPassive &) = delete;
   ~HGCPassive() override;
 
   void produce(edm::Event &, const edm::EventSetup &) override;
 
 private:
-  HGCPassive(const HGCPassive &) = delete;  // stop default
-  const HGCPassive &operator=(const HGCPassive &) = delete;
-
   // observer classes
   void update(const BeginOfRun *run) override;
   void update(const BeginOfEvent *evt) override;

--- a/SimG4CMS/HGCalTestBeam/plugins/HGCalTBMB.cc
+++ b/SimG4CMS/HGCalTestBeam/plugins/HGCalTBMB.cc
@@ -27,12 +27,11 @@ class HGCalTBMB : public SimWatcher,
                   public Observer<const EndOfTrack*> {
 public:
   HGCalTBMB(const edm::ParameterSet&);
+  HGCalTBMB(const HGCalTBMB&) = delete;                   // stop default
+  const HGCalTBMB& operator=(const HGCalTBMB&) = delete;  // ...
   ~HGCalTBMB() override;
 
 private:
-  HGCalTBMB(const HGCalTBMB&) = delete;                   // stop default
-  const HGCalTBMB& operator=(const HGCalTBMB&) = delete;  // ...
-
   void update(const BeginOfTrack*) override;
   void update(const G4Step*) override;
   void update(const EndOfTrack*) override;

--- a/SimG4CMS/HcalTestBeam/plugins/HcalTB02Analysis.cc
+++ b/SimG4CMS/HcalTestBeam/plugins/HcalTB02Analysis.cc
@@ -61,14 +61,13 @@ namespace CLHEP {
 class HcalTB02Analysis : public SimProducer, public Observer<const BeginOfEvent*>, public Observer<const EndOfEvent*> {
 public:
   HcalTB02Analysis(const edm::ParameterSet& p);
+  HcalTB02Analysis(const HcalTB02Analysis&) = delete;  // stop default
+  const HcalTB02Analysis& operator=(const HcalTB02Analysis&) = delete;
   ~HcalTB02Analysis() override;
 
   void produce(edm::Event&, const edm::EventSetup&) override;
 
 private:
-  HcalTB02Analysis(const HcalTB02Analysis&) = delete;  // stop default
-  const HcalTB02Analysis& operator=(const HcalTB02Analysis&) = delete;
-
   // observer methods
   void update(const BeginOfEvent* evt) override;
   void update(const EndOfEvent* evt) override;

--- a/SimG4CMS/HcalTestBeam/plugins/HcalTB04Analysis.cc
+++ b/SimG4CMS/HcalTestBeam/plugins/HcalTB04Analysis.cc
@@ -75,14 +75,13 @@ class HcalTB04Analysis : public SimProducer,
                          public Observer<const G4Step*> {
 public:
   HcalTB04Analysis(const edm::ParameterSet& p);
+  HcalTB04Analysis(const HcalTB04Analysis&) = delete;  // stop default
+  const HcalTB04Analysis& operator=(const HcalTB04Analysis&) = delete;
   ~HcalTB04Analysis() override;
 
   void produce(edm::Event&, const edm::EventSetup&) override;
 
 private:
-  HcalTB04Analysis(const HcalTB04Analysis&) = delete;  // stop default
-  const HcalTB04Analysis& operator=(const HcalTB04Analysis&) = delete;
-
   void init();
 
   // observer methods

--- a/SimG4CMS/ShowerLibraryProducer/interface/HcalForwardAnalysis.h
+++ b/SimG4CMS/ShowerLibraryProducer/interface/HcalForwardAnalysis.h
@@ -48,14 +48,13 @@ public:
   };
 
   HcalForwardAnalysis(const edm::ParameterSet& p);
+  HcalForwardAnalysis(const HcalForwardAnalysis&) = delete;  // stop default
+  const HcalForwardAnalysis& operator=(const HcalForwardAnalysis&) = delete;
   ~HcalForwardAnalysis() override;
 
   void produce(edm::Event&, const edm::EventSetup&) override;
 
 private:
-  HcalForwardAnalysis(const HcalForwardAnalysis&) = delete;  // stop default
-  const HcalForwardAnalysis& operator=(const HcalForwardAnalysis&) = delete;
-
   void init();
 
   // observer methods

--- a/SimG4Core/CheckSecondary/interface/CheckSecondary.h
+++ b/SimG4Core/CheckSecondary/interface/CheckSecondary.h
@@ -29,12 +29,11 @@ class CheckSecondary : public SimWatcher,
                        public Observer<const G4Step *> {
 public:
   CheckSecondary(const edm::ParameterSet &p);
+  CheckSecondary(const CheckSecondary &) = delete;  // stop default
+  const CheckSecondary &operator=(const CheckSecondary &) = delete;
   ~CheckSecondary() override;
 
 private:
-  CheckSecondary(const CheckSecondary &) = delete;  // stop default
-  const CheckSecondary &operator=(const CheckSecondary &) = delete;
-
   // observer classes
   TTree *bookTree(std::string);
   void endTree();

--- a/SimG4Core/CheckSecondary/interface/StoreSecondary.h
+++ b/SimG4Core/CheckSecondary/interface/StoreSecondary.h
@@ -22,14 +22,13 @@ class StoreSecondary : public SimProducer,
                        public Observer<const G4Step *> {
 public:
   StoreSecondary(const edm::ParameterSet &p);
+  StoreSecondary(const StoreSecondary &) = delete;  // stop default
+  const StoreSecondary &operator=(const StoreSecondary &) = delete;
   ~StoreSecondary() override;
 
   void produce(edm::Event &, const edm::EventSetup &) override;
 
 private:
-  StoreSecondary(const StoreSecondary &) = delete;  // stop default
-  const StoreSecondary &operator=(const StoreSecondary &) = delete;
-
   // observer classes
   void update(const BeginOfEvent *evt) override;
   void update(const BeginOfTrack *trk) override;

--- a/SimG4Core/CheckSecondary/interface/TreatSecondary.h
+++ b/SimG4Core/CheckSecondary/interface/TreatSecondary.h
@@ -16,15 +16,13 @@ class G4ProcessTypeEnumerator;
 class TreatSecondary {
 public:
   TreatSecondary(const edm::ParameterSet &p);
+  TreatSecondary(const TreatSecondary &) = delete;  // stop default
+  const TreatSecondary &operator=(const TreatSecondary &) = delete;
   virtual ~TreatSecondary();
 
   void initTrack(const G4Track *trk);
   std::vector<math::XYZTLorentzVector> tracks(
       const G4Step *step, std::string &procName, int &procID, bool &intr, double &deltaE, std::vector<int> &charges);
-
-private:
-  TreatSecondary(const TreatSecondary &) = delete;  // stop default
-  const TreatSecondary &operator=(const TreatSecondary &) = delete;
 
 private:
   int verbosity, minSec, killAfter;

--- a/SimG4Core/HelpfulWatchers/src/BeginOfTrackCounter.h
+++ b/SimG4Core/HelpfulWatchers/src/BeginOfTrackCounter.h
@@ -38,7 +38,7 @@ namespace simwatcher {
   class BeginOfTrackCounter : public SimProducer, public Observer<const BeginOfTrack *> {
   public:
     BeginOfTrackCounter(const edm::ParameterSet &);
-    BeginOfTrackCounter(const BeginOfTrackCounter &) = delete;  // stop default
+    BeginOfTrackCounter(const BeginOfTrackCounter &) = delete;                   // stop default
     const BeginOfTrackCounter &operator=(const BeginOfTrackCounter &) = delete;  // stop default
 
     // ---------- const member functions ---------------------

--- a/SimG4Core/HelpfulWatchers/src/BeginOfTrackCounter.h
+++ b/SimG4Core/HelpfulWatchers/src/BeginOfTrackCounter.h
@@ -38,6 +38,8 @@ namespace simwatcher {
   class BeginOfTrackCounter : public SimProducer, public Observer<const BeginOfTrack *> {
   public:
     BeginOfTrackCounter(const edm::ParameterSet &);
+    BeginOfTrackCounter(const BeginOfTrackCounter &) = delete;  // stop default
+    const BeginOfTrackCounter &operator=(const BeginOfTrackCounter &) = delete;  // stop default
 
     // ---------- const member functions ---------------------
 
@@ -47,10 +49,6 @@ namespace simwatcher {
     void produce(edm::Event &, const edm::EventSetup &) override;
 
   private:
-    BeginOfTrackCounter(const BeginOfTrackCounter &) = delete;  // stop default
-
-    const BeginOfTrackCounter &operator=(const BeginOfTrackCounter &) = delete;  // stop default
-
     void update(const BeginOfTrack *) override;
     // ---------- member data --------------------------------
     int m_count;

--- a/SimGeneral/MixingModule/interface/DigiAccumulatorMixMod.h
+++ b/SimGeneral/MixingModule/interface/DigiAccumulatorMixMod.h
@@ -42,6 +42,10 @@ class DigiAccumulatorMixMod {
 public:
   DigiAccumulatorMixMod();
 
+  DigiAccumulatorMixMod(DigiAccumulatorMixMod const&) = delete;  // stop default
+
+  DigiAccumulatorMixMod const& operator=(DigiAccumulatorMixMod const&) = delete;  // stop default
+
   virtual ~DigiAccumulatorMixMod();
 
   // ---------- const member functions ---------------------
@@ -90,10 +94,6 @@ public:
   }
 
 private:
-  DigiAccumulatorMixMod(DigiAccumulatorMixMod const&) = delete;  // stop default
-
-  DigiAccumulatorMixMod const& operator=(DigiAccumulatorMixMod const&) = delete;  // stop default
-
   // ---------- member data --------------------------------
 };
 

--- a/SimMuon/MCTruth/plugins/MuonToTrackingParticleAssociatorByHitsImpl.h
+++ b/SimMuon/MCTruth/plugins/MuonToTrackingParticleAssociatorByHitsImpl.h
@@ -35,6 +35,12 @@ public:
                                              MuonAssociatorByHitsHelper::Resources const &iResources,
                                              MuonAssociatorByHitsHelper const *iHelper);
 
+  MuonToTrackingParticleAssociatorByHitsImpl(const MuonToTrackingParticleAssociatorByHitsImpl &) =
+      delete;  // stop default
+
+  const MuonToTrackingParticleAssociatorByHitsImpl &operator=(const MuonToTrackingParticleAssociatorByHitsImpl &) =
+      delete;  // stop default
+
   // ---------- const member functions ---------------------
   void associateMuons(reco::MuonToSimCollection &recoToSim,
                       reco::SimToMuonCollection &simToReco,
@@ -53,12 +59,6 @@ public:
   // ---------- member functions ---------------------------
 
 private:
-  MuonToTrackingParticleAssociatorByHitsImpl(const MuonToTrackingParticleAssociatorByHitsImpl &) =
-      delete;  // stop default
-
-  const MuonToTrackingParticleAssociatorByHitsImpl &operator=(const MuonToTrackingParticleAssociatorByHitsImpl &) =
-      delete;  // stop default
-
   // ---------- member data --------------------------------
   TrackerMuonHitExtractor const *m_hitExtractor;
   MuonAssociatorByHitsHelper::Resources m_resources;

--- a/SimTracker/Common/interface/SiG4UniversalFluctuation.h
+++ b/SimTracker/Common/interface/SiG4UniversalFluctuation.h
@@ -26,6 +26,10 @@ class SiG4UniversalFluctuation {
 public:
   explicit SiG4UniversalFluctuation();
 
+  // hide assignment operator
+  SiG4UniversalFluctuation &operator=(const SiG4UniversalFluctuation &right) = delete;
+  SiG4UniversalFluctuation(const SiG4UniversalFluctuation &) = delete;
+
   ~SiG4UniversalFluctuation();
 
   // momentum in MeV/c, mass in MeV, tmax (delta cut) in MeV,
@@ -38,10 +42,6 @@ public:
                             CLHEP::HepRandomEngine *);
 
 private:
-  // hide assignment operator
-  SiG4UniversalFluctuation &operator=(const SiG4UniversalFluctuation &right) = delete;
-  SiG4UniversalFluctuation(const SiG4UniversalFluctuation &) = delete;
-
   double particleMass;
   double chargeSquare;
 

--- a/SimTracker/TrackerMaterialAnalysis/plugins/MaterialAccountingGroup.h
+++ b/SimTracker/TrackerMaterialAnalysis/plugins/MaterialAccountingGroup.h
@@ -66,7 +66,7 @@ public:
 
   /// stop default assignment operator
   MaterialAccountingGroup& operator=(const MaterialAccountingGroup& layer) = delete;
-      
+
   /// destructor
   ~MaterialAccountingGroup(void);
 

--- a/SimTracker/TrackerMaterialAnalysis/plugins/MaterialAccountingGroup.h
+++ b/SimTracker/TrackerMaterialAnalysis/plugins/MaterialAccountingGroup.h
@@ -61,15 +61,14 @@ public:
   /// explicit constructors
   MaterialAccountingGroup(const std::string& name, const DDCompactView& geometry);
 
-  /// destructor
-  ~MaterialAccountingGroup(void);
-
-private:
   /// stop default copy ctor
   MaterialAccountingGroup(const MaterialAccountingGroup& layer) = delete;
 
   /// stop default assignment operator
   MaterialAccountingGroup& operator=(const MaterialAccountingGroup& layer) = delete;
+      
+  /// destructor
+  ~MaterialAccountingGroup(void);
 
 public:
   /// buffer material from a detector, if the detector is inside the DetLayer bounds


### PR DESCRIPTION
Cleanup for clang-tidy warning `deleted member function should be public [modernize-use-equals-delete]`