### PR TITLE
[Reco][clang-tidy] make deleted function public

### DIFF
--- a/RecoJets/FFTJetAlgorithms/interface/EtaAndPtDependentPeakSelector.h
+++ b/RecoJets/FFTJetAlgorithms/interface/EtaAndPtDependentPeakSelector.h
@@ -17,16 +17,15 @@ namespace fftjetcms {
   class EtaAndPtDependentPeakSelector : public fftjet::Functor1<bool, fftjet::Peak> {
   public:
     explicit EtaAndPtDependentPeakSelector(std::istream& in);
+    EtaAndPtDependentPeakSelector() = delete;
+    EtaAndPtDependentPeakSelector(const EtaAndPtDependentPeakSelector&) = delete;
+    EtaAndPtDependentPeakSelector& operator=(const EtaAndPtDependentPeakSelector&) = delete;
     ~EtaAndPtDependentPeakSelector() override;
 
     bool operator()(const fftjet::Peak& peak) const override;
     inline bool isValid() const { return ip_; }
 
   private:
-    EtaAndPtDependentPeakSelector() = delete;
-    EtaAndPtDependentPeakSelector(const EtaAndPtDependentPeakSelector&) = delete;
-    EtaAndPtDependentPeakSelector& operator=(const EtaAndPtDependentPeakSelector&) = delete;
-
     fftjet::LinearInterpolator2d* ip_;
   };
 

--- a/RecoJets/FFTJetAlgorithms/interface/JetConvergenceDistance.h
+++ b/RecoJets/FFTJetAlgorithms/interface/JetConvergenceDistance.h
@@ -11,13 +11,12 @@ namespace fftjetcms {
       : public fftjet::Functor2<double, fftjet::RecombinedJet<VectorLike>, fftjet::RecombinedJet<VectorLike> > {
   public:
     JetConvergenceDistance(double etaToPhiBandwidthRatio, double relativePtBandwidth);
+    JetConvergenceDistance() = delete;
 
     double operator()(const fftjet::RecombinedJet<VectorLike>& jet1,
                       const fftjet::RecombinedJet<VectorLike>& jet2) const override;
 
   private:
-    JetConvergenceDistance() = delete;
-
     double etaBw_;
     double phiBw_;
     double ptBw_;

--- a/RecoJets/FFTJetAlgorithms/interface/LookupTable2d.h
+++ b/RecoJets/FFTJetAlgorithms/interface/LookupTable2d.h
@@ -8,6 +8,7 @@ namespace fftjetcms {
   public:
     LookupTable2d(
         unsigned nx, double xmin, double xmax, unsigned ny, double ymin, double ymax, const std::vector<double>& data);
+    LookupTable2d() = delete;
 
     inline const std::vector<double>& data() const { return data_; }
     inline unsigned nx() const { return nx_; }
@@ -23,8 +24,6 @@ namespace fftjetcms {
     double closest(double x, double y) const;
 
   private:
-    LookupTable2d() = delete;
-
     std::vector<double> data_;
     unsigned nx_;
     unsigned ny_;

--- a/RecoJets/FFTJetAlgorithms/interface/ScaleCalculators.h
+++ b/RecoJets/FFTJetAlgorithms/interface/ScaleCalculators.h
@@ -17,10 +17,10 @@ namespace fftjetcms {
   class ConstDouble : public fftjet::Functor1<double, Arg1> {
   public:
     inline ConstDouble(const double value) : c_(value) {}
+    ConstDouble() = delete;
     inline double operator()(const Arg1&) const override { return c_; }
 
   private:
-    ConstDouble() = delete;
     double c_;
   };
 
@@ -29,10 +29,10 @@ namespace fftjetcms {
   class ProportionalToScale : public fftjet::Functor1<double, T> {
   public:
     inline ProportionalToScale(const double value) : c_(value) {}
+    ProportionalToScale() = delete;
     inline double operator()(const T& r) const override { return r.scale() * c_; }
 
   private:
-    ProportionalToScale() = delete;
     double c_;
   };
 
@@ -42,6 +42,7 @@ namespace fftjetcms {
   public:
     inline MultiplyByConst(const double factor, const fftjet::Functor1<double, T>* f, const bool takeOwnership = false)
         : c_(factor), func_(f), ownsPointer_(takeOwnership) {}
+    MultiplyByConst() = delete;
 
     inline ~MultiplyByConst() override {
       if (ownsPointer_)
@@ -51,7 +52,6 @@ namespace fftjetcms {
     inline double operator()(const T& r) const override { return (*func_)(r)*c_; }
 
   private:
-    MultiplyByConst() = delete;
     double c_;
     const fftjet::Functor1<double, T>* func_;
     const bool ownsPointer_;
@@ -65,6 +65,7 @@ namespace fftjetcms {
                             const fftjet::Functor1<double, T>* f2,
                             const bool takeOwnership = false)
         : f1_(f1), f2_(f2), ownsPointers_(takeOwnership) {}
+    CompositeFunctor() = delete;
 
     inline ~CompositeFunctor() override {
       if (ownsPointers_) {
@@ -76,7 +77,6 @@ namespace fftjetcms {
     inline double operator()(const T& r) const override { return (*f1_)((*f2_)(r)); }
 
   private:
-    CompositeFunctor() = delete;
     const fftjet::Functor1<double, double>* f1_;
     const fftjet::Functor1<double, T>* f2_;
     const bool ownsPointers_;
@@ -90,6 +90,7 @@ namespace fftjetcms {
                           const fftjet::Functor1<double, T>* f2,
                           const bool takeOwnership = false)
         : f1_(f1), f2_(f2), ownsPointers_(takeOwnership) {}
+    ProductFunctor() = delete;
 
     inline ~ProductFunctor() override {
       if (ownsPointers_) {
@@ -101,7 +102,6 @@ namespace fftjetcms {
     inline double operator()(const T& r) const override { return (*f1_)(r) * (*f2_)(r); }
 
   private:
-    ProductFunctor() = delete;
     const fftjet::Functor1<double, T>* f1_;
     const fftjet::Functor1<double, T>* f2_;
     const bool ownsPointers_;
@@ -113,6 +113,7 @@ namespace fftjetcms {
   public:
     inline MagnitudeDependent(const fftjet::Functor1<double, double>* f1, const bool takeOwnership = false)
         : f1_(f1), ownsPointer_(takeOwnership) {}
+    MagnitudeDependent() = delete;
 
     inline ~MagnitudeDependent() override {
       if (ownsPointer_)
@@ -122,7 +123,6 @@ namespace fftjetcms {
     inline double operator()(const T& r) const override { return (*f1_)(r.magnitude()); }
 
   private:
-    MagnitudeDependent() = delete;
     const fftjet::Functor1<double, double>* f1_;
     const bool ownsPointer_;
   };
@@ -132,6 +132,7 @@ namespace fftjetcms {
   public:
     inline PeakEtaDependent(const fftjet::Functor1<double, double>* f1, const bool takeOwnership = false)
         : f1_(f1), ownsPointer_(takeOwnership) {}
+    PeakEtaDependent() = delete;
 
     inline ~PeakEtaDependent() override {
       if (ownsPointer_)
@@ -141,7 +142,6 @@ namespace fftjetcms {
     inline double operator()(const fftjet::Peak& r) const override { return (*f1_)(r.eta()); }
 
   private:
-    PeakEtaDependent() = delete;
     const fftjet::Functor1<double, double>* f1_;
     const bool ownsPointer_;
   };
@@ -154,6 +154,7 @@ namespace fftjetcms {
                                   const bool ownjmp,
                                   const double fc)
         : f1_(f1), ownsPointer_(takeOwnership), jmmp_(jmmp), ownsjmmpPointer_(ownjmp), factor_(fc) {}
+    PeakEtaMagSsqDependent() = delete;
 
     inline ~PeakEtaMagSsqDependent() override {
       if (ownsPointer_)
@@ -171,7 +172,6 @@ namespace fftjetcms {
     }
 
   private:
-    PeakEtaMagSsqDependent() = delete;
     const fftjet::LinearInterpolator2d* f1_;
     const bool ownsPointer_;
     const fftjet::JetMagnitudeMapper2d<fftjet::Peak>* jmmp_;
@@ -184,6 +184,7 @@ namespace fftjetcms {
   public:
     inline JetEtaDependent(const fftjet::Functor1<double, double>* f1, const bool takeOwnership = false)
         : f1_(f1), ownsPointer_(takeOwnership) {}
+    JetEtaDependent() = delete;
 
     inline ~JetEtaDependent() override {
       if (ownsPointer_)
@@ -195,7 +196,6 @@ namespace fftjetcms {
     }
 
   private:
-    JetEtaDependent() = delete;
     const fftjet::Functor1<double, double>* f1_;
     const bool ownsPointer_;
   };
@@ -209,6 +209,7 @@ namespace fftjetcms {
         std::copy(coeffs.begin(), coeffs.end(), coeffs_);
       }
     }
+    Polynomial() = delete;
     inline ~Polynomial() override { delete[] coeffs_; }
 
     inline double operator()(const double& x) const override {
@@ -222,7 +223,6 @@ namespace fftjetcms {
     }
 
   private:
-    Polynomial() = delete;
     double* coeffs_;
     const unsigned nCoeffs;
   };

--- a/RecoJets/FFTJetProducers/interface/FFTJetInterface.h
+++ b/RecoJets/FFTJetProducers/interface/FFTJetInterface.h
@@ -51,6 +51,10 @@
 namespace fftjetcms {
   class FFTJetInterface : public edm::EDProducer {
   public:
+    // Explicitly disable other ways to construct this object
+    FFTJetInterface() = delete;
+    FFTJetInterface(const FFTJetInterface&) = delete;
+    FFTJetInterface& operator=(const FFTJetInterface&) = delete;
     ~FFTJetInterface() override {}
 
   protected:
@@ -103,11 +107,6 @@ namespace fftjetcms {
     edm::Handle<reco::CandidateView> inputCollection;
 
   private:
-    // Explicitly disable other ways to construct this object
-    FFTJetInterface() = delete;
-    FFTJetInterface(const FFTJetInterface&) = delete;
-    FFTJetInterface& operator=(const FFTJetInterface&) = delete;
-
     const bool insertCompleteEvent;
     const double completeEventScale;
     reco::Particle::Point vertex_;

--- a/RecoJets/FFTJetProducers/plugins/FFTJetDijetFilter.cc
+++ b/RecoJets/FFTJetProducers/plugins/FFTJetDijetFilter.cc
@@ -54,14 +54,13 @@ public:
   typedef fftjet::SparseClusteringTree<fftjet::Peak, long> SparseTree;
 
   explicit FFTJetDijetFilter(const edm::ParameterSet&);
+  FFTJetDijetFilter() = delete;
+  FFTJetDijetFilter(const FFTJetDijetFilter&) = delete;
+  FFTJetDijetFilter& operator=(const FFTJetDijetFilter&) = delete;
   ~FFTJetDijetFilter() override;
 
 private:
   typedef reco::PattRecoTree<float, reco::PattRecoPeak<float> > StoredTree;
-
-  FFTJetDijetFilter() = delete;
-  FFTJetDijetFilter(const FFTJetDijetFilter&) = delete;
-  FFTJetDijetFilter& operator=(const FFTJetDijetFilter&) = delete;
 
   void beginJob() override;
   bool filter(edm::Event& iEvent, const edm::EventSetup& iSetup) override;

--- a/RecoJets/FFTJetProducers/plugins/FFTJetEFlowSmoother.cc
+++ b/RecoJets/FFTJetProducers/plugins/FFTJetEFlowSmoother.cc
@@ -51,6 +51,9 @@ using namespace fftjetcms;
 class FFTJetEFlowSmoother : public FFTJetInterface {
 public:
   explicit FFTJetEFlowSmoother(const edm::ParameterSet&);
+  FFTJetEFlowSmoother() = delete;
+  FFTJetEFlowSmoother(const FFTJetEFlowSmoother&) = delete;
+  FFTJetEFlowSmoother& operator=(const FFTJetEFlowSmoother&) = delete;
   ~FFTJetEFlowSmoother() override;
 
 protected:
@@ -60,10 +63,6 @@ protected:
   void endJob() override;
 
 private:
-  FFTJetEFlowSmoother() = delete;
-  FFTJetEFlowSmoother(const FFTJetEFlowSmoother&) = delete;
-  FFTJetEFlowSmoother& operator=(const FFTJetEFlowSmoother&) = delete;
-
   void buildKernelConvolver(const edm::ParameterSet&);
 
   // Storage for convolved energy flow

--- a/RecoJets/FFTJetProducers/plugins/FFTJetPFPileupCleaner.cc
+++ b/RecoJets/FFTJetProducers/plugins/FFTJetPFPileupCleaner.cc
@@ -45,6 +45,9 @@
 class FFTJetPFPileupCleaner : public edm::EDProducer {
 public:
   explicit FFTJetPFPileupCleaner(const edm::ParameterSet&);
+  FFTJetPFPileupCleaner() = delete;
+  FFTJetPFPileupCleaner(const FFTJetPFPileupCleaner&) = delete;
+  FFTJetPFPileupCleaner& operator=(const FFTJetPFPileupCleaner&) = delete;
   ~FFTJetPFPileupCleaner() override;
 
 protected:
@@ -54,10 +57,6 @@ protected:
   void endJob() override;
 
 private:
-  FFTJetPFPileupCleaner() = delete;
-  FFTJetPFPileupCleaner(const FFTJetPFPileupCleaner&) = delete;
-  FFTJetPFPileupCleaner& operator=(const FFTJetPFPileupCleaner&) = delete;
-
   bool isRemovable(reco::PFCandidate::ParticleType ptype) const;
   void setRemovalBit(reco::PFCandidate::ParticleType ptype, bool onOff);
   void buildRemovalMask();

--- a/RecoJets/FFTJetProducers/plugins/FFTJetPatRecoProducer.cc
+++ b/RecoJets/FFTJetProducers/plugins/FFTJetPatRecoProducer.cc
@@ -64,6 +64,9 @@ using namespace fftjetcms;
 class FFTJetPatRecoProducer : public FFTJetInterface {
 public:
   explicit FFTJetPatRecoProducer(const edm::ParameterSet&);
+  FFTJetPatRecoProducer() = delete;
+  FFTJetPatRecoProducer(const FFTJetPatRecoProducer&) = delete;
+  FFTJetPatRecoProducer& operator=(const FFTJetPatRecoProducer&) = delete;
   ~FFTJetPatRecoProducer() override;
 
 protected:
@@ -136,10 +139,6 @@ protected:
   const bool sparsify;
 
 private:
-  FFTJetPatRecoProducer() = delete;
-  FFTJetPatRecoProducer(const FFTJetPatRecoProducer&) = delete;
-  FFTJetPatRecoProducer& operator=(const FFTJetPatRecoProducer&) = delete;
-
   // Members needed for storing grids externally
   std::ofstream externalGridStream;
   bool storeGridsExternally;

--- a/RecoJets/FFTJetProducers/plugins/FFTJetPileupEstimator.cc
+++ b/RecoJets/FFTJetProducers/plugins/FFTJetPileupEstimator.cc
@@ -46,6 +46,9 @@ using namespace fftjetcms;
 class FFTJetPileupEstimator : public edm::EDProducer {
 public:
   explicit FFTJetPileupEstimator(const edm::ParameterSet&);
+  FFTJetPileupEstimator() = delete;
+  FFTJetPileupEstimator(const FFTJetPileupEstimator&) = delete;
+  FFTJetPileupEstimator& operator=(const FFTJetPileupEstimator&) = delete;
   ~FFTJetPileupEstimator() override;
 
 protected:
@@ -55,10 +58,6 @@ protected:
   void endJob() override;
 
 private:
-  FFTJetPileupEstimator() = delete;
-  FFTJetPileupEstimator(const FFTJetPileupEstimator&) = delete;
-  FFTJetPileupEstimator& operator=(const FFTJetPileupEstimator&) = delete;
-
   std::unique_ptr<reco::FFTJetPileupSummary> calibrateFromConfig(double uncalibrated) const;
 
   std::unique_ptr<reco::FFTJetPileupSummary> calibrateFromDB(double uncalibrated, const edm::EventSetup& iSetup) const;

--- a/RecoJets/FFTJetProducers/plugins/FFTJetPileupProcessor.cc
+++ b/RecoJets/FFTJetProducers/plugins/FFTJetPileupProcessor.cc
@@ -53,6 +53,9 @@ using namespace fftjetcms;
 class FFTJetPileupProcessor : public FFTJetInterface {
 public:
   explicit FFTJetPileupProcessor(const edm::ParameterSet&);
+  FFTJetPileupProcessor() = delete;
+  FFTJetPileupProcessor(const FFTJetPileupProcessor&) = delete;
+  FFTJetPileupProcessor& operator=(const FFTJetPileupProcessor&) = delete;
   ~FFTJetPileupProcessor() override;
 
 protected:
@@ -62,10 +65,6 @@ protected:
   void endJob() override;
 
 private:
-  FFTJetPileupProcessor() = delete;
-  FFTJetPileupProcessor(const FFTJetPileupProcessor&) = delete;
-  FFTJetPileupProcessor& operator=(const FFTJetPileupProcessor&) = delete;
-
   void buildKernelConvolver(const edm::ParameterSet&);
   void mixExtraGrid();
   void loadFlatteningFactors(const edm::EventSetup& iSetup);

--- a/RecoJets/FFTJetProducers/plugins/FFTJetProducer.h
+++ b/RecoJets/FFTJetProducers/plugins/FFTJetProducer.h
@@ -93,6 +93,11 @@ public:
   enum Resolution { FIXED = 0, MAXIMALLY_STABLE, GLOBALLY_ADAPTIVE, LOCALLY_ADAPTIVE, FROM_GENJETS };
 
   explicit FFTJetProducer(const edm::ParameterSet&);
+  // Explicitly disable other ways to construct this object
+  FFTJetProducer() = delete;
+  FFTJetProducer(const FFTJetProducer&) = delete;
+  FFTJetProducer& operator=(const FFTJetProducer&) = delete;
+
   ~FFTJetProducer() override;
 
   // Parser for the resolution enum
@@ -170,11 +175,6 @@ protected:
 private:
   typedef fftjet::AbsVectorRecombinationAlg<fftjetcms::VectorLike, fftjetcms::BgData> RecoAlg;
   typedef fftjet::AbsRecombinationAlg<fftjetcms::Real, fftjetcms::VectorLike, fftjetcms::BgData> GridAlg;
-
-  // Explicitly disable other ways to construct this object
-  FFTJetProducer() = delete;
-  FFTJetProducer(const FFTJetProducer&) = delete;
-  FFTJetProducer& operator=(const FFTJetProducer&) = delete;
 
   // Useful local utilities
   template <class Real>

--- a/RecoJets/FFTJetProducers/plugins/FFTJetTreeDump.cc
+++ b/RecoJets/FFTJetProducers/plugins/FFTJetTreeDump.cc
@@ -52,6 +52,9 @@ using namespace fftjetcms;
 class FFTJetTreeDump : public edm::EDAnalyzer {
 public:
   explicit FFTJetTreeDump(const edm::ParameterSet&);
+  FFTJetTreeDump() = delete;
+  FFTJetTreeDump(const FFTJetTreeDump&) = delete;
+  FFTJetTreeDump& operator=(const FFTJetTreeDump&) = delete;
   ~FFTJetTreeDump() override;
 
 private:
@@ -62,10 +65,6 @@ private:
   typedef fftjet::OpenDXPeakTree<long, fftjet::SparseClusteringTree> SparseFormatter;
   typedef fftjet::Functor1<double, fftjet::Peak> PeakProperty;
   typedef reco::PattRecoTree<Real, reco::PattRecoPeak<Real> > StoredTree;
-
-  FFTJetTreeDump() = delete;
-  FFTJetTreeDump(const FFTJetTreeDump&) = delete;
-  FFTJetTreeDump& operator=(const FFTJetTreeDump&) = delete;
 
   void beginJob() override;
   void analyze(const edm::Event&, const edm::EventSetup&) override;

--- a/RecoJets/FFTJetProducers/plugins/FFTJetVertexAdder.cc
+++ b/RecoJets/FFTJetProducers/plugins/FFTJetVertexAdder.cc
@@ -45,6 +45,9 @@
 class FFTJetVertexAdder : public edm::EDProducer {
 public:
   explicit FFTJetVertexAdder(const edm::ParameterSet&);
+  FFTJetVertexAdder() = delete;
+  FFTJetVertexAdder(const FFTJetVertexAdder&) = delete;
+  FFTJetVertexAdder& operator=(const FFTJetVertexAdder&) = delete;
   ~FFTJetVertexAdder() override;
 
 protected:
@@ -54,10 +57,6 @@ protected:
   void endJob() override;
 
 private:
-  FFTJetVertexAdder() = delete;
-  FFTJetVertexAdder(const FFTJetVertexAdder&) = delete;
-  FFTJetVertexAdder& operator=(const FFTJetVertexAdder&) = delete;
-
   const edm::InputTag beamSpotLabel;
   const edm::InputTag existingVerticesLabel;
 

--- a/RecoJets/JetAnalyzers/src/FFTJetImageRecorder.cc
+++ b/RecoJets/JetAnalyzers/src/FFTJetImageRecorder.cc
@@ -47,13 +47,12 @@
 class FFTJetImageRecorder : public edm::EDAnalyzer {
 public:
   explicit FFTJetImageRecorder(const edm::ParameterSet&);
-  ~FFTJetImageRecorder() override;
-
-private:
   FFTJetImageRecorder() = delete;
   FFTJetImageRecorder(const FFTJetImageRecorder&) = delete;
   FFTJetImageRecorder& operator=(const FFTJetImageRecorder&) = delete;
+  ~FFTJetImageRecorder() override;
 
+private:
   void beginJob() override;
   void analyze(const edm::Event&, const edm::EventSetup&) override;
   void endJob() override;

--- a/RecoJets/JetAnalyzers/src/FFTJetPileupAnalyzer.cc
+++ b/RecoJets/JetAnalyzers/src/FFTJetPileupAnalyzer.cc
@@ -52,13 +52,12 @@
 class FFTJetPileupAnalyzer : public edm::EDAnalyzer {
 public:
   explicit FFTJetPileupAnalyzer(const edm::ParameterSet&);
-  ~FFTJetPileupAnalyzer() override;
-
-private:
   FFTJetPileupAnalyzer() = delete;
   FFTJetPileupAnalyzer(const FFTJetPileupAnalyzer&) = delete;
   FFTJetPileupAnalyzer& operator=(const FFTJetPileupAnalyzer&) = delete;
+  ~FFTJetPileupAnalyzer() override;
 
+private:
   // The following method should take all necessary info from
   // PileupSummaryInfo and fill out the ntuple
   void analyzePileup(const std::vector<PileupSummaryInfo>& pInfo);

--- a/RecoJets/JetPlusTracks/plugins/JetPlusTrackCorrector.h
+++ b/RecoJets/JetPlusTracks/plugins/JetPlusTrackCorrector.h
@@ -90,6 +90,8 @@ namespace jpt {
   public:
     Efficiency(const jpt::Map& response, const jpt::Map& efficiency, const jpt::Map& leakage);
 
+    Efficiency() = delete;
+
     typedef std::pair<uint16_t, double> Pair;
 
     uint16_t nTrks(uint32_t eta_bin, uint32_t pt_bin) const;
@@ -109,8 +111,6 @@ namespace jpt {
     void print() const;
 
   private:
-    Efficiency() = delete;
-
     double sumE(uint32_t eta_bin, uint32_t pt_bin) const;
     double meanE(uint32_t eta_bin, uint32_t pt_bin) const;
 

--- a/RecoJets/JetProducers/interface/AnomalousTower.h
+++ b/RecoJets/JetProducers/interface/AnomalousTower.h
@@ -7,14 +7,13 @@
 class AnomalousTower {
 public:
   explicit AnomalousTower(const edm::ParameterSet&);
+  AnomalousTower() = delete;
   virtual ~AnomalousTower() {}
 
   // operator() returns "true" if the tower is anomalous
   virtual bool operator()(const reco::Candidate& input) const;
 
 private:
-  AnomalousTower() = delete;
-
   const unsigned maxBadEcalCells;          // maximum number of bad ECAL cells
   const unsigned maxRecoveredEcalCells;    // maximum number of recovered ECAL cells
   const unsigned maxProblematicEcalCells;  // maximum number of problematic ECAL cells

--- a/RecoLuminosity/LumiProducer/interface/DataPipe.h
+++ b/RecoLuminosity/LumiProducer/interface/DataPipe.h
@@ -8,6 +8,8 @@ namespace lumi {
   class DataPipe {
   public:
     explicit DataPipe(const std::string&);
+    DataPipe(const DataPipe&) = delete;
+    const DataPipe& operator=(const DataPipe&) = delete;
     virtual unsigned long long retrieveData(unsigned int) = 0;
     virtual const std::string dataType() const = 0;
     virtual const std::string sourceType() const = 0;
@@ -31,9 +33,6 @@ namespace lumi {
     bool m_novalidate;
     float m_norm;                 //Lumi2DB specific
     bool m_nocheckingstablebeam;  //Lumi2DB specific
-  private:
-    DataPipe(const DataPipe&) = delete;
-    const DataPipe& operator=(const DataPipe&) = delete;
   };  //class DataPipe
 }  // namespace lumi
 #endif

--- a/RecoLuminosity/LumiProducer/interface/DataPipe.h
+++ b/RecoLuminosity/LumiProducer/interface/DataPipe.h
@@ -33,6 +33,6 @@ namespace lumi {
     bool m_novalidate;
     float m_norm;                 //Lumi2DB specific
     bool m_nocheckingstablebeam;  //Lumi2DB specific
-  };  //class DataPipe
+  };                              //class DataPipe
 }  // namespace lumi
 #endif

--- a/RecoLuminosity/LumiProducer/interface/NormFunctor.h
+++ b/RecoLuminosity/LumiProducer/interface/NormFunctor.h
@@ -6,6 +6,8 @@ namespace lumi {
   class NormFunctor {
   public:
     explicit NormFunctor();
+    NormFunctor(const NormFunctor&) = delete;
+    const NormFunctor& operator=(const NormFunctor&) = delete;
     virtual ~NormFunctor() {}
     void initialize(const std::map<std::string, float>& coeffmap, const std::map<unsigned int, float>& afterglowmap);
     virtual float getCorrection(float luminonorm, float intglumi, unsigned int nBXs) const = 0;
@@ -13,10 +15,6 @@ namespace lumi {
   protected:
     std::map<std::string, float> m_coeffmap;
     std::map<unsigned int, float> m_afterglowmap;
-
-  private:
-    NormFunctor(const NormFunctor&) = delete;
-    const NormFunctor& operator=(const NormFunctor&) = delete;
   };
 }  // namespace lumi
 #endif

--- a/RecoTracker/ConversionSeedGenerators/plugins/CombinedHitQuadrupletGeneratorForPhotonConversion.h
+++ b/RecoTracker/ConversionSeedGenerators/plugins/CombinedHitQuadrupletGeneratorForPhotonConversion.h
@@ -31,6 +31,8 @@ public:
 
 public:
   CombinedHitQuadrupletGeneratorForPhotonConversion(const edm::ParameterSet& cfg, edm::ConsumesCollector& iC);
+  CombinedHitQuadrupletGeneratorForPhotonConversion(const CombinedHitQuadrupletGeneratorForPhotonConversion& cb) =
+      delete;
   ~CombinedHitQuadrupletGeneratorForPhotonConversion();
 
   void hitPairs(const TrackingRegion&, OrderedHitPairs&, const edm::Event&, const edm::EventSetup&);
@@ -41,9 +43,6 @@ public:
 
   /*------------------------*/
 private:
-  CombinedHitQuadrupletGeneratorForPhotonConversion(const CombinedHitQuadrupletGeneratorForPhotonConversion& cb) =
-      delete;
-
   edm::EDGetTokenT<SeedingLayerSetsHits> theSeedingLayerToken;
   const unsigned int theMaxElement;
   LayerCacheType theLayerCache;

--- a/RecoTracker/TkSeedGenerator/interface/ClusterChecker.h
+++ b/RecoTracker/TkSeedGenerator/interface/ClusterChecker.h
@@ -31,6 +31,7 @@ class ClusterChecker {
 public:
   ClusterChecker(const edm::ParameterSet& conf, edm::ConsumesCollector& iC);
   ClusterChecker(const edm::ParameterSet& conf, edm::ConsumesCollector&& iC);
+  ClusterChecker() = delete;  // This is only needed for StringCutObjectSelector
 
   static void fillDescriptions(edm::ParameterSetDescription& description);
 
@@ -38,7 +39,6 @@ public:
   size_t tooManyClusters(const edm::Event& e) const;
 
 private:
-  ClusterChecker() = delete;  // This is only needed for StringCutObjectSelector
   bool doACheck_;
   edm::InputTag clusterCollectionInputTag_;
   edm::InputTag pixelClusterCollectionInputTag_;


### PR DESCRIPTION
Cleanup for clang-tidy warning `deleted member function should be public [modernize-use-equals-delete]`
