### PR TITLE
[JetMETCorrections][clang-tidy] make deleted function public

### DIFF
--- a/JetMETCorrections/Algorithms/interface/JetCorrectorImplMakerBase.h
+++ b/JetMETCorrections/Algorithms/interface/JetCorrectorImplMakerBase.h
@@ -36,7 +36,7 @@ namespace edm {
 class JetCorrectorImplMakerBase {
 public:
   JetCorrectorImplMakerBase(edm::ParameterSet const&);
-  JetCorrectorImplMakerBase(const JetCorrectorImplMakerBase&) = delete;  // stop default
+  JetCorrectorImplMakerBase(const JetCorrectorImplMakerBase&) = delete;                   // stop default
   const JetCorrectorImplMakerBase& operator=(const JetCorrectorImplMakerBase&) = delete;  // stop default
   virtual ~JetCorrectorImplMakerBase();
 

--- a/JetMETCorrections/Algorithms/interface/JetCorrectorImplMakerBase.h
+++ b/JetMETCorrections/Algorithms/interface/JetCorrectorImplMakerBase.h
@@ -36,6 +36,8 @@ namespace edm {
 class JetCorrectorImplMakerBase {
 public:
   JetCorrectorImplMakerBase(edm::ParameterSet const&);
+  JetCorrectorImplMakerBase(const JetCorrectorImplMakerBase&) = delete;  // stop default
+  const JetCorrectorImplMakerBase& operator=(const JetCorrectorImplMakerBase&) = delete;  // stop default
   virtual ~JetCorrectorImplMakerBase();
 
   // ---------- const member functions ---------------------
@@ -50,10 +52,6 @@ protected:
       edm::EventSetup const&, std::function<void(std::string const&)> levelCheck);
 
 private:
-  JetCorrectorImplMakerBase(const JetCorrectorImplMakerBase&) = delete;  // stop default
-
-  const JetCorrectorImplMakerBase& operator=(const JetCorrectorImplMakerBase&) = delete;  // stop default
-
   // ---------- member data --------------------------------
   std::string level_;
   std::string algo_;

--- a/JetMETCorrections/FFTJetModules/plugins/FFTJetCorrectorDBReader.cc
+++ b/JetMETCorrections/FFTJetModules/plugins/FFTJetCorrectorDBReader.cc
@@ -45,13 +45,12 @@
 class FFTJetCorrectorDBReader : public edm::EDAnalyzer {
 public:
   explicit FFTJetCorrectorDBReader(const edm::ParameterSet&);
-  ~FFTJetCorrectorDBReader() override {}
-
-private:
   FFTJetCorrectorDBReader() = delete;
   FFTJetCorrectorDBReader(const FFTJetCorrectorDBReader&) = delete;
   FFTJetCorrectorDBReader& operator=(const FFTJetCorrectorDBReader&) = delete;
+  ~FFTJetCorrectorDBReader() override {}
 
+private:
   void analyze(const edm::Event&, const edm::EventSetup&) override;
 
   std::string record;

--- a/JetMETCorrections/FFTJetModules/plugins/FFTJetCorrectorDBWriter.cc
+++ b/JetMETCorrections/FFTJetModules/plugins/FFTJetCorrectorDBWriter.cc
@@ -42,13 +42,12 @@
 class FFTJetCorrectorDBWriter : public edm::EDAnalyzer {
 public:
   explicit FFTJetCorrectorDBWriter(const edm::ParameterSet&);
-  ~FFTJetCorrectorDBWriter() override {}
-
-private:
   FFTJetCorrectorDBWriter() = delete;
   FFTJetCorrectorDBWriter(const FFTJetCorrectorDBWriter&) = delete;
   FFTJetCorrectorDBWriter& operator=(const FFTJetCorrectorDBWriter&) = delete;
+  ~FFTJetCorrectorDBWriter() override {}
 
+private:
   void analyze(const edm::Event&, const edm::EventSetup&) override;
 
   std::string inputFile;

--- a/JetMETCorrections/FFTJetObjects/interface/AbsFFTJetScaleCalculator.h
+++ b/JetMETCorrections/FFTJetObjects/interface/AbsFFTJetScaleCalculator.h
@@ -14,6 +14,7 @@ public:
 
   inline explicit AbsFFTJetScaleCalculator(std::shared_ptr<npstat::AbsMultivariateFunctor> f)
       : functor(f), buffer_(f->minDim()) {}
+  AbsFFTJetScaleCalculator() = delete;
 
   inline virtual ~AbsFFTJetScaleCalculator() {}
 
@@ -25,8 +26,6 @@ public:
   }
 
 private:
-  AbsFFTJetScaleCalculator() = delete;
-
   virtual void map(const Jet& jet, const Adjustable& current, double* buf, unsigned dim) const = 0;
 
   std::shared_ptr<npstat::AbsMultivariateFunctor> functor;

--- a/JetMETCorrections/FFTJetObjects/interface/FFTJetCorrectorResult.h
+++ b/JetMETCorrections/FFTJetObjects/interface/FFTJetCorrectorResult.h
@@ -16,6 +16,7 @@ public:
 
   inline FFTJetCorrectorResult(const LorentzVector& v, const double correctionScale, const double systematicUncertainty)
       : vec_(v), scale_(correctionScale), sigma_(systematicUncertainty) {}
+  FFTJetCorrectorResult() = delete;
 
   inline const LorentzVector& vec() const { return vec_; }
   inline double scale() const { return scale_; }
@@ -26,8 +27,6 @@ public:
   inline void setSigma(const double s) { sigma_ = s; }
 
 private:
-  FFTJetCorrectorResult() = delete;
-
   LorentzVector vec_;
   double scale_;
   double sigma_;

--- a/JetMETCorrections/FFTJetObjects/interface/FFTJetCorrectorTransient.h
+++ b/JetMETCorrections/FFTJetObjects/interface/FFTJetCorrectorTransient.h
@@ -20,6 +20,7 @@ public:
                                   const double initialScale = 1.0,
                                   const double initialSigma = 0.0)
       : vec_(v), scale_(initialScale), variance_(initialSigma * initialSigma) {}
+  FFTJetCorrectorTransient() = delete;
 
   inline const LorentzVector& vec() const { return vec_; }
   inline double scale() const { return scale_; }
@@ -39,8 +40,6 @@ public:
   }
 
 private:
-  FFTJetCorrectorTransient() = delete;
-
   LorentzVector vec_;
   double scale_;
   double variance_;

--- a/JetMETCorrections/FFTJetObjects/interface/FFTJetObjectFactory.h
+++ b/JetMETCorrections/FFTJetObjects/interface/FFTJetObjectFactory.h
@@ -42,7 +42,6 @@ struct DefaultFFTJetObjectFactory : public std::map<std::string, AbsFFTJetObject
     return it->second->create(ps);
   }
 
-private:
   DefaultFFTJetObjectFactory(const DefaultFFTJetObjectFactory&) = delete;
   DefaultFFTJetObjectFactory& operator=(const DefaultFFTJetObjectFactory&) = delete;
 };
@@ -67,7 +66,6 @@ public:
     rd[className] = new ConcreteFFTJetObjectFactory<base_type, T>();
   }
 
-private:
   StaticFFTJetObjectFactory() = delete;
 };
 

--- a/JetMETCorrections/FFTJetObjects/interface/FFTJetRcdMapper.h
+++ b/JetMETCorrections/FFTJetObjects/interface/FFTJetRcdMapper.h
@@ -70,7 +70,6 @@ struct DefaultFFTJetRcdMapper : public std::map<std::string, AbsFFTJetRcdMapper<
     it->second->load(iSetup, label, handle);
   }
 
-private:
   DefaultFFTJetRcdMapper(const DefaultFFTJetRcdMapper&) = delete;
   DefaultFFTJetRcdMapper& operator=(const DefaultFFTJetRcdMapper&) = delete;
 };
@@ -95,7 +94,6 @@ public:
     rd[record] = new ConcreteFFTJetRcdMapper<data_type, Record>();
   }
 
-private:
   StaticFFTJetRcdMapper() = delete;
 };
 

--- a/JetMETCorrections/InterpolationTables/interface/ArrayNDScanner.h
+++ b/JetMETCorrections/InterpolationTables/interface/ArrayNDScanner.h
@@ -42,6 +42,8 @@ namespace npstat {
     inline explicit ArrayNDScanner(const std::vector<unsigned>& shape) {
       initialize(shape.empty() ? static_cast<unsigned*>(nullptr) : &shape[0], shape.size());
     }
+
+    ArrayNDScanner() = delete;
     //@}
 
     /** Dimensionality of the scan */
@@ -79,8 +81,6 @@ namespace npstat {
     inline void setState(const unsigned long state) { state_ = state <= maxState_ ? state : maxState_; }
 
   private:
-    ArrayNDScanner() = delete;
-
     void initialize(const unsigned* shape, unsigned lenShape);
 
     unsigned long strides_[CHAR_BIT * sizeof(unsigned long)];

--- a/JetMETCorrections/InterpolationTables/interface/CoordinateSelector.h
+++ b/JetMETCorrections/InterpolationTables/interface/CoordinateSelector.h
@@ -26,6 +26,8 @@ namespace npstat {
   public:
     inline explicit CoordinateSelector(const unsigned i) : index_(i) {}
 
+    CoordinateSelector() = delete;
+
     inline ~CoordinateSelector() override {}
 
     inline double operator()(const double* point, const unsigned dim) const override {
@@ -39,7 +41,6 @@ namespace npstat {
     inline unsigned maxDim() const override { return UINT_MAX; }
 
   private:
-    CoordinateSelector() = delete;
     unsigned index_;
   };
 }  // namespace npstat

--- a/JetMETCorrections/InterpolationTables/interface/EquidistantSequence.h
+++ b/JetMETCorrections/InterpolationTables/interface/EquidistantSequence.h
@@ -24,7 +24,6 @@ namespace npstat {
     EquidistantInLinearSpace(double minScale, double maxScale, unsigned nScales);
     virtual ~EquidistantInLinearSpace() {}
 
-  private:
     EquidistantInLinearSpace() = delete;
   };
 
@@ -38,7 +37,6 @@ namespace npstat {
     EquidistantInLogSpace(double minScale, double maxScale, unsigned nScales);
     virtual ~EquidistantInLogSpace() {}
 
-  private:
     EquidistantInLogSpace() = delete;
   };
 }  // namespace npstat

--- a/JetMETCorrections/InterpolationTables/interface/HistoND.h
+++ b/JetMETCorrections/InterpolationTables/interface/HistoND.h
@@ -166,6 +166,9 @@ namespace npstat {
         */
     HistoND& operator=(const HistoND&);
 
+    /** Default constructor not implemented **/
+    HistoND() = delete;
+
     /** Histogram dimensionality */
     inline unsigned dim() const { return dim_; }
 
@@ -927,8 +930,6 @@ namespace npstat {
     static HistoND* read(const gs::ClassId& id, std::istream& in);
 
   private:
-    HistoND() = delete;
-
     // Special constructor which speeds up the "transpose" operation.
     // Does not do full error checking (some of it is done in transpose).
     HistoND(const HistoND& r, unsigned ax1, unsigned ax2);

--- a/JetMETCorrections/InterpolationTables/interface/LinInterpolatedTableND.h
+++ b/JetMETCorrections/InterpolationTables/interface/LinInterpolatedTableND.h
@@ -118,6 +118,9 @@ namespace npstat {
     template <class Num2>
     LinInterpolatedTableND(const LinInterpolatedTableND<Num2, Axis>&);
 
+    /** Default constructor not implemented  **/
+    LinInterpolatedTableND() = delete;
+
     /**
         // Basic interpolation result. Argument point dimensionality must be
         // compatible with the interpolator dimensionality.
@@ -230,8 +233,6 @@ namespace npstat {
     static LinInterpolatedTableND* read(const gs::ClassId& id, std::istream& in);
 
   private:
-    LinInterpolatedTableND() = delete;
-
     LinInterpolatedTableND(const ArrayND<Numeric>& data,
                            const std::vector<Axis>& axes,
                            const char* leftInterpolation,

--- a/JetMETCorrections/InterpolationTables/interface/SimpleFunctors.h
+++ b/JetMETCorrections/InterpolationTables/interface/SimpleFunctors.h
@@ -123,6 +123,7 @@ namespace npstat {
     inline Result operator()() const { return fcn_(); }
 
     FcnFunctor0() = delete;
+
   private:
     Result (*fcn_)();
   };
@@ -138,6 +139,7 @@ namespace npstat {
     inline Result operator()(const Arg1& a) const { return fcn_(a); }
 
     FcnFunctor1() = delete;
+
   private:
     Result (*fcn_)(Arg1);
   };
@@ -153,6 +155,7 @@ namespace npstat {
     inline Result operator()(const Arg1& x, const Arg2& y) const { return fcn_(x, y); }
 
     FcnFunctor2() = delete;
+
   private:
     Result (*fcn_)(Arg1, Arg2);
   };
@@ -168,6 +171,7 @@ namespace npstat {
     inline Result operator()(const Arg1& x, const Arg2& y, const Arg3& z) const { return fcn_(x, y, z); }
 
     FcnFunctor3() = delete;
+
   private:
     Result (*fcn_)(Arg1, Arg2, Arg3);
   };
@@ -183,6 +187,7 @@ namespace npstat {
     inline Result operator()(const Container& c) const { return c[idx]; }
 
     Element1D() = delete;
+
   private:
     unsigned long idx;
   };
@@ -198,6 +203,7 @@ namespace npstat {
     inline Result operator()(const Container& c) const { return c.at(idx); }
 
     Element1DAt() = delete;
+
   private:
     unsigned long idx;
   };
@@ -243,6 +249,7 @@ namespace npstat {
     inline T1& operator()(T1& left, const T2& right) const { return left += w_ * right; }
 
     addmul_left() = delete;
+
   private:
     double w_;
   };
@@ -258,6 +265,7 @@ namespace npstat {
     inline T1& operator()(T1& left, const T2& right) const { return right += w_ * left; }
 
     addmul_right() = delete;
+
   private:
     double w_;
   };

--- a/JetMETCorrections/InterpolationTables/interface/SimpleFunctors.h
+++ b/JetMETCorrections/InterpolationTables/interface/SimpleFunctors.h
@@ -122,8 +122,8 @@ namespace npstat {
 
     inline Result operator()() const { return fcn_(); }
 
-  private:
     FcnFunctor0() = delete;
+  private:
     Result (*fcn_)();
   };
 
@@ -137,8 +137,8 @@ namespace npstat {
 
     inline Result operator()(const Arg1& a) const { return fcn_(a); }
 
-  private:
     FcnFunctor1() = delete;
+  private:
     Result (*fcn_)(Arg1);
   };
 
@@ -152,8 +152,8 @@ namespace npstat {
 
     inline Result operator()(const Arg1& x, const Arg2& y) const { return fcn_(x, y); }
 
-  private:
     FcnFunctor2() = delete;
+  private:
     Result (*fcn_)(Arg1, Arg2);
   };
 
@@ -167,8 +167,8 @@ namespace npstat {
 
     inline Result operator()(const Arg1& x, const Arg2& y, const Arg3& z) const { return fcn_(x, y, z); }
 
-  private:
     FcnFunctor3() = delete;
+  private:
     Result (*fcn_)(Arg1, Arg2, Arg3);
   };
 
@@ -182,8 +182,8 @@ namespace npstat {
 
     inline Result operator()(const Container& c) const { return c[idx]; }
 
-  private:
     Element1D() = delete;
+  private:
     unsigned long idx;
   };
 
@@ -197,8 +197,8 @@ namespace npstat {
 
     inline Result operator()(const Container& c) const { return c.at(idx); }
 
-  private:
     Element1DAt() = delete;
+  private:
     unsigned long idx;
   };
 
@@ -242,8 +242,8 @@ namespace npstat {
 
     inline T1& operator()(T1& left, const T2& right) const { return left += w_ * right; }
 
-  private:
     addmul_left() = delete;
+  private:
     double w_;
   };
 
@@ -257,8 +257,8 @@ namespace npstat {
 
     inline T1& operator()(T1& left, const T2& right) const { return right += w_ * left; }
 
-  private:
     addmul_right() = delete;
+  private:
     double w_;
   };
 

--- a/JetMETCorrections/InterpolationTables/interface/StorableHistoNDFunctor.h
+++ b/JetMETCorrections/InterpolationTables/interface/StorableHistoNDFunctor.h
@@ -56,6 +56,9 @@ namespace npstat {
           table_(tab.table_, Same<Num2>(), tab.title().c_str(), tab.accumulatedDataLabel().c_str()),
           deg_(tab.deg_) {}
 
+    /** Default constructor not implemented **/
+    StorableHistoNDFunctor() = delete;
+
     ~StorableHistoNDFunctor() override {}
 
     unsigned minDim() const override { return table_.dim(); };
@@ -104,8 +107,6 @@ namespace npstat {
     }
 
   private:
-    StorableHistoNDFunctor() = delete;
-
     Table table_;
     unsigned deg_;
     Converter conv_;

--- a/JetMETCorrections/InterpolationTables/interface/StorableInterpolationFunctor.h
+++ b/JetMETCorrections/InterpolationTables/interface/StorableInterpolationFunctor.h
@@ -133,6 +133,9 @@ namespace npstat {
                  functionLabel) {}
     //@}
 
+    /** Default constructor not implemented **/
+    StorableInterpolationFunctor() = delete;
+
     ~StorableInterpolationFunctor() override {}
 
     unsigned minDim() const override { return table_.dim(); };
@@ -174,8 +177,6 @@ namespace npstat {
     }
 
   private:
-    StorableInterpolationFunctor() = delete;
-
     Table table_;
     Converter conv_;
   };

--- a/JetMETCorrections/JetCorrector/interface/JetCorrector.h
+++ b/JetMETCorrections/JetCorrector/interface/JetCorrector.h
@@ -39,7 +39,6 @@ namespace reco {
     JetCorrector(const JetCorrector&) = delete;
     JetCorrector& operator=(const JetCorrector&) = delete;
 
-
     typedef reco::Particle::LorentzVector LorentzVector;
 
     // ---------- const member functions ---------------------

--- a/JetMETCorrections/JetCorrector/interface/JetCorrector.h
+++ b/JetMETCorrections/JetCorrector/interface/JetCorrector.h
@@ -36,6 +36,9 @@ namespace reco {
     JetCorrector(std::unique_ptr<JetCorrectorImpl const> fImpl) : impl_(std::move(fImpl)) {}
     JetCorrector(JetCorrector&&) = default;
     JetCorrector& operator=(JetCorrector&&) = default;
+    JetCorrector(const JetCorrector&) = delete;
+    JetCorrector& operator=(const JetCorrector&) = delete;
+
 
     typedef reco::Particle::LorentzVector LorentzVector;
 
@@ -67,10 +70,6 @@ namespace reco {
     // ---------- member functions ---------------------------
 
   private:
-    JetCorrector(const JetCorrector&) = delete;
-
-    JetCorrector& operator=(const JetCorrector&) = delete;
-
     // ---------- member data --------------------------------
     std::unique_ptr<JetCorrectorImpl const> impl_;
   };

--- a/JetMETCorrections/JetCorrector/interface/JetCorrectorImpl.h
+++ b/JetMETCorrections/JetCorrector/interface/JetCorrectorImpl.h
@@ -31,6 +31,9 @@ namespace reco {
   class JetCorrectorImpl {
   public:
     JetCorrectorImpl();
+    JetCorrectorImpl(const JetCorrectorImpl&) = delete;
+    const JetCorrectorImpl& operator=(const JetCorrectorImpl&) = delete;
+
     virtual ~JetCorrectorImpl();
 
     typedef reco::Particle::LorentzVector LorentzVector;
@@ -61,10 +64,6 @@ namespace reco {
     // ---------- member functions ---------------------------
 
   private:
-    JetCorrectorImpl(const JetCorrectorImpl&) = delete;
-
-    const JetCorrectorImpl& operator=(const JetCorrectorImpl&) = delete;
-
     // ---------- member data --------------------------------
   };
 }  // namespace reco

--- a/JetMETCorrections/Modules/plugins/JetCorrectorProducer.h
+++ b/JetMETCorrections/Modules/plugins/JetCorrectorProducer.h
@@ -48,11 +48,11 @@ public:
     T::Maker::fillDescriptions(iDescriptions);
   }
 
-private:
   JetCorrectorProducer(const JetCorrectorProducer&) = delete;  // stop default
 
   const JetCorrectorProducer& operator=(const JetCorrectorProducer&) = delete;  // stop default
 
+private:
   // ---------- member data --------------------------------
   typename T::Maker maker_;
 };


### PR DESCRIPTION
Cleanup for clang-tidy warning `deleted member function should be public [modernize-use-equals-delete]`