### PR TITLE
[L1][clang-tidy] make deleted function public

### DIFF
--- a/L1Trigger/L1GctAnalyzer/src/GctErrorAnalyzer.cc
+++ b/L1Trigger/L1GctAnalyzer/src/GctErrorAnalyzer.cc
@@ -59,6 +59,7 @@ public:
   GctErrorAnalyzer() = delete;
   GctErrorAnalyzer(const GctErrorAnalyzer &) = delete;
   GctErrorAnalyzer operator=(const GctErrorAnalyzer &) = delete;
+
 private:
   void plotRCTRegions(const edm::Handle<L1CaloRegionCollection> &caloRegions);
   void plotIsoEm(const edm::Handle<L1GctEmCandCollection> &data, const edm::Handle<L1GctEmCandCollection> &emu);

--- a/L1Trigger/L1GctAnalyzer/src/GctErrorAnalyzer.cc
+++ b/L1Trigger/L1GctAnalyzer/src/GctErrorAnalyzer.cc
@@ -55,10 +55,11 @@ Implementation:
 //
 
 class GctErrorAnalyzer : public edm::EDAnalyzer {
-private:
+public:
   GctErrorAnalyzer() = delete;
   GctErrorAnalyzer(const GctErrorAnalyzer &) = delete;
   GctErrorAnalyzer operator=(const GctErrorAnalyzer &) = delete;
+private:
   void plotRCTRegions(const edm::Handle<L1CaloRegionCollection> &caloRegions);
   void plotIsoEm(const edm::Handle<L1GctEmCandCollection> &data, const edm::Handle<L1GctEmCandCollection> &emu);
   void plotNonIsoEm(const edm::Handle<L1GctEmCandCollection> &data, const edm::Handle<L1GctEmCandCollection> &emu);

--- a/L1Trigger/L1TCaloLayer1/src/UCTCard.hh
+++ b/L1Trigger/L1TCaloLayer1/src/UCTCard.hh
@@ -11,6 +11,18 @@ class UCTCard {
 public:
   UCTCard(uint32_t crt, uint32_t crd, int fwv);
 
+  // No default constructor is needed
+
+  UCTCard() = delete;
+
+  // No copy constructor is needed
+
+  UCTCard(const UCTCard&) = delete;
+
+  // No equality operator is needed
+
+  const UCTCard& operator=(const UCTCard&) = delete;
+
   virtual ~UCTCard();
 
   // To set up event data before processing
@@ -36,18 +48,6 @@ public:
   friend std::ostream& operator<<(std::ostream&, const UCTCard&);
 
 private:
-  // No default constructor is needed
-
-  UCTCard() = delete;
-
-  // No copy constructor is needed
-
-  UCTCard(const UCTCard&) = delete;
-
-  // No equality operator is needed
-
-  const UCTCard& operator=(const UCTCard&) = delete;
-
   // Helper functions
 
   const UCTRegion* getRegion(bool negativeEta, uint32_t caloEta, uint32_t caloPhi) const;

--- a/L1Trigger/L1TCaloLayer1/src/UCTCrate.hh
+++ b/L1Trigger/L1TCaloLayer1/src/UCTCrate.hh
@@ -11,6 +11,18 @@ class UCTCrate {
 public:
   UCTCrate(uint32_t crt, int fwv);
 
+  // No default constructor is needed
+
+  UCTCrate() = delete;
+
+  // No copy constructor is needed
+
+  UCTCrate(const UCTCrate&) = delete;
+
+  // No equality operator is needed
+
+  const UCTCrate& operator=(const UCTCrate&) = delete;
+
   virtual ~UCTCrate();
 
   // To set up event data before processing
@@ -40,18 +52,6 @@ public:
   friend std::ostream& operator<<(std::ostream&, const UCTCrate&);
 
 private:
-  // No default constructor is needed
-
-  UCTCrate() = delete;
-
-  // No copy constructor is needed
-
-  UCTCrate(const UCTCrate&) = delete;
-
-  // No equality operator is needed
-
-  const UCTCrate& operator=(const UCTCrate&) = delete;
-
   // Owned crate level data
 
   uint32_t crate;

--- a/L1Trigger/L1TCaloLayer1/src/UCTLayer1.hh
+++ b/L1Trigger/L1TCaloLayer1/src/UCTLayer1.hh
@@ -22,6 +22,14 @@ public:
   //
   UCTLayer1(int fwv = 0);
 
+  // No copy constructor is needed
+
+  UCTLayer1(const UCTLayer1&) = delete;
+
+  // No equality operator is needed
+
+  const UCTLayer1& operator=(const UCTLayer1&) = delete;
+
   virtual ~UCTLayer1();
 
   // To access Layer1 information
@@ -47,14 +55,6 @@ public:
   friend std::ostream& operator<<(std::ostream&, const UCTLayer1&);
 
 private:
-  // No copy constructor is needed
-
-  UCTLayer1(const UCTLayer1&) = delete;
-
-  // No equality operator is needed
-
-  const UCTLayer1& operator=(const UCTLayer1&) = delete;
-
   // Helper functions
 
   const UCTRegion* getRegion(int regionEtaIndex, uint32_t regionPhiIndex) const;

--- a/L1Trigger/L1TCaloLayer1/src/UCTRegion.hh
+++ b/L1Trigger/L1TCaloLayer1/src/UCTRegion.hh
@@ -26,6 +26,18 @@ class UCTRegion {
 public:
   UCTRegion(uint32_t crt, uint32_t crd, bool ne, uint32_t rgn, int fwv);
 
+  // No default constructor is needed
+
+  UCTRegion() = delete;
+
+  // No copy constructor is needed
+
+  UCTRegion(const UCTRegion&) = delete;
+
+  // No equality operator is needed
+
+  const UCTRegion& operator=(const UCTRegion&) = delete;
+
   virtual ~UCTRegion();
 
   // To setData for towers before processing
@@ -83,19 +95,6 @@ public:
   const UCTTower* getTower(UCTTowerIndex t) const { return getTower(t.first, t.second); }
 
   friend std::ostream& operator<<(std::ostream&, const UCTRegion&);
-
-private:
-  // No default constructor is needed
-
-  UCTRegion() = delete;
-
-  // No copy constructor is needed
-
-  UCTRegion(const UCTRegion&) = delete;
-
-  // No equality operator is needed
-
-  const UCTRegion& operator=(const UCTRegion&) = delete;
 
 protected:
   // Helper functions

--- a/L1Trigger/L1TCaloLayer1/src/UCTSummaryCard.hh
+++ b/L1Trigger/L1TCaloLayer1/src/UCTSummaryCard.hh
@@ -19,6 +19,14 @@ public:
                  uint32_t eGammaSeedIn = 5,
                  double eGammaIsolationFactorIn = 0.3);
 
+  // No copy constructor is needed
+
+  UCTSummaryCard(const UCTSummaryCard&) = delete;
+
+  // No equality operator is needed
+
+  const UCTSummaryCard& operator=(const UCTSummaryCard&) = delete;
+
   virtual ~UCTSummaryCard();
 
   // To set up event data before processing
@@ -52,14 +60,6 @@ public:
   void print();
 
 private:
-  // No copy constructor is needed
-
-  UCTSummaryCard(const UCTSummaryCard&) = delete;
-
-  // No equality operator is needed
-
-  const UCTSummaryCard& operator=(const UCTSummaryCard&) = delete;
-
   // Helper functions
 
   bool processRegion(UCTRegionIndex regionIndex);

--- a/L1Trigger/L1TCaloLayer1/src/UCTTower.hh
+++ b/L1Trigger/L1TCaloLayer1/src/UCTTower.hh
@@ -49,6 +49,18 @@ public:
 
   UCTTower(uint16_t location, int fwv);
 
+  // No default constructor is needed
+
+  UCTTower() = delete;
+
+  // No copy constructor is needed
+
+  UCTTower(const UCTTower &) = delete;
+
+  // No equality operator is needed
+
+  const UCTTower &operator=(const UCTTower &) = delete;
+
   virtual ~UCTTower() { ; }
 
   bool clearEvent() {
@@ -128,18 +140,6 @@ public:
   friend std::ostream &operator<<(std::ostream &, const UCTTower &);
 
 private:
-  // No default constructor is needed
-
-  UCTTower() = delete;
-
-  // No copy constructor is needed
-
-  UCTTower(const UCTTower &) = delete;
-
-  // No equality operator is needed
-
-  const UCTTower &operator=(const UCTTower &) = delete;
-
   // Tower location definition
 
   uint32_t crate;

--- a/L1Trigger/L1TMuonEndCap/interface/bdt/Node.h
+++ b/L1Trigger/L1TMuonEndCap/interface/bdt/Node.h
@@ -19,7 +19,6 @@ namespace emtf {
     Node(const Node &) = delete;
     Node &operator=(const Node &) = delete;
 
-
     std::string getName();
     void setName(std::string sName);
 

--- a/L1Trigger/L1TMuonEndCap/interface/bdt/Node.h
+++ b/L1Trigger/L1TMuonEndCap/interface/bdt/Node.h
@@ -16,6 +16,9 @@ namespace emtf {
     ~Node();
 
     Node(Node &&) = default;
+    Node(const Node &) = delete;
+    Node &operator=(const Node &) = delete;
+
 
     std::string getName();
     void setName(std::string sName);
@@ -60,9 +63,6 @@ namespace emtf {
     void theMiracleOfChildBirth();
 
   private:
-    Node(const Node &) = delete;
-    Node &operator=(const Node &) = delete;
-
     std::string name;
 
     Node *leftDaughter;

--- a/L1Trigger/RPCTrigger/interface/MuonsGrabber.h
+++ b/L1Trigger/RPCTrigger/interface/MuonsGrabber.h
@@ -54,6 +54,10 @@ class MuonsGrabber {
 public:
   static MuonsGrabber& Instance();
 
+  MuonsGrabber(const MuonsGrabber&) = delete;  // stop default
+
+  const MuonsGrabber& operator=(const MuonsGrabber&) = delete;  // stop default
+
   void setRPCBasicTrigConfig(RPCBasicTrigConfig* c) { m_trigConfig = c; };
 
   void startNewEvent(int event, int bx);
@@ -61,9 +65,6 @@ public:
   void addMuon(RPCTBMuon& mu, int lvl, int region, int hs, int index);
 
 private:
-  MuonsGrabber(const MuonsGrabber&) = delete;  // stop default
-
-  const MuonsGrabber& operator=(const MuonsGrabber&) = delete;  // stop default
   std::string IntToString(int i);
 
   // ---------- member data --------------------------------

--- a/L1Trigger/RegionalCaloTrigger/interface/L1RCTCrate.h
+++ b/L1Trigger/RegionalCaloTrigger/interface/L1RCTCrate.h
@@ -12,6 +12,8 @@ class L1RCTCrate {
 public:
   L1RCTCrate(int crtNo, const L1RCTLookupTables *rctLookupTables);
 
+  L1RCTCrate() = delete;
+
   ~L1RCTCrate();
 
   int crateNumber() { return crtNo; }
@@ -76,8 +78,6 @@ private:
 
   int crtNo;
   const L1RCTLookupTables *rctLookupTables_;
-
-  L1RCTCrate() = delete;
 
   // L1RCTJetCaptureCard jetCaptureCard;
 };

--- a/L1Trigger/RegionalCaloTrigger/interface/L1RCTElectronIsolationCard.h
+++ b/L1Trigger/RegionalCaloTrigger/interface/L1RCTElectronIsolationCard.h
@@ -19,6 +19,7 @@ class L1RCTLookupTables;
 class L1RCTElectronIsolationCard {
 public:
   L1RCTElectronIsolationCard(int crateNumber, int cardNumber, const L1RCTLookupTables *rctLookupTables);
+  L1RCTElectronIsolationCard() = delete;
   ~L1RCTElectronIsolationCard();
 
   int crateNumber() { return crtNo; }
@@ -55,8 +56,6 @@ private:
   std::vector<unsigned short> isoElectrons;
   std::vector<unsigned short> nonIsoElectrons;
   std::vector<L1RCTRegion> regions;
-
-  L1RCTElectronIsolationCard() = delete;
 };
 
 #endif

--- a/L1Trigger/RegionalCaloTrigger/interface/L1RCTJetSummaryCard.h
+++ b/L1Trigger/RegionalCaloTrigger/interface/L1RCTJetSummaryCard.h
@@ -12,6 +12,9 @@ public:
   // for bookeeping purposes.
   L1RCTJetSummaryCard(int crtNo, const L1RCTLookupTables *rctLookupTables);
 
+  // Disabled constructors and operators
+  L1RCTJetSummaryCard() = delete;
+
   int crateNumber() { return crtNo; }
 
   // eGamma Objects
@@ -110,8 +113,5 @@ private:
   void asicSort(std::vector<unsigned short> &electrons);
   void asicCompare(std::vector<unsigned short> &array);
 
-  // Disabled constructors and operators
-
-  L1RCTJetSummaryCard() = delete;
 };
 #endif

--- a/L1Trigger/RegionalCaloTrigger/interface/L1RCTJetSummaryCard.h
+++ b/L1Trigger/RegionalCaloTrigger/interface/L1RCTJetSummaryCard.h
@@ -112,6 +112,5 @@ private:
 
   void asicSort(std::vector<unsigned short> &electrons);
   void asicCompare(std::vector<unsigned short> &array);
-
 };
 #endif

--- a/L1Trigger/RegionalCaloTrigger/interface/L1RCTReceiverCard.h
+++ b/L1Trigger/RegionalCaloTrigger/interface/L1RCTReceiverCard.h
@@ -14,6 +14,11 @@ class L1RCTLookupTables;
 class L1RCTReceiverCard {
 public:
   L1RCTReceiverCard(int crateNumber, int cardNumber, const L1RCTLookupTables *rctLookupTables);
+
+  // No default constructor, no copy constructor,
+  // and no assignment operator
+  L1RCTReceiverCard() = delete;
+
   ~L1RCTReceiverCard();
 
   // Information needed to identify cards
@@ -83,9 +88,5 @@ private:
   std::vector<unsigned short> overFlowBits;
   std::vector<unsigned short> muonBits;
   std::vector<unsigned short> tauBits;
-
-  // No default constructor, no copy constructor,
-  // and no assignment operator
-  L1RCTReceiverCard() = delete;
 };
 #endif


### PR DESCRIPTION
Cleanup for clang-tidy warning `deleted member function should be public [modernize-use-equals-delete]`
