### PR TITLE
[Misc1][clang-tidy] make deleted function public

### DIFF
--- a/MagneticField/UniformEngine/plugins/UniformMagneticFieldESProducer.h
+++ b/MagneticField/UniformEngine/plugins/UniformMagneticFieldESProducer.h
@@ -20,14 +20,13 @@ namespace magneticfield {
   class UniformMagneticFieldESProducer : public edm::ESProducer {
   public:
     UniformMagneticFieldESProducer(const edm::ParameterSet& pset);
-
-    std::unique_ptr<MagneticField> produce(const IdealMagneticFieldRecord&);
-
-  private:
     // forbid copy ctor and assignment op.
     UniformMagneticFieldESProducer(const UniformMagneticFieldESProducer&) = delete;
     const UniformMagneticFieldESProducer& operator=(const UniformMagneticFieldESProducer&) = delete;
 
+    std::unique_ptr<MagneticField> produce(const IdealMagneticFieldRecord&);
+
+  private:
     float value;
   };
 }  // namespace magneticfield

--- a/PhysicsTools/CondLiteIO/interface/RecordWriter.h
+++ b/PhysicsTools/CondLiteIO/interface/RecordWriter.h
@@ -33,6 +33,11 @@ namespace fwlite {
   class RecordWriter {
   public:
     RecordWriter(const char* iName, TFile* iFile);
+
+    RecordWriter(const RecordWriter&) = delete;  // stop default
+
+    const RecordWriter& operator=(const RecordWriter&) = delete;  // stop default
+
     virtual ~RecordWriter();
 
     struct DataBuffer {
@@ -53,10 +58,6 @@ namespace fwlite {
     void write();
 
   private:
-    RecordWriter(const RecordWriter&) = delete;  // stop default
-
-    const RecordWriter& operator=(const RecordWriter&) = delete;  // stop default
-
     // ---------- member data --------------------------------
     TTree* tree_;
     edm::ESRecordAuxiliary aux_;

--- a/TrackingTools/TrackAssociator/plugins/DetIdAssociatorMaker.h
+++ b/TrackingTools/TrackAssociator/plugins/DetIdAssociatorMaker.h
@@ -29,6 +29,8 @@ class DetIdAssociatorRecord;
 class DetIdAssociatorMaker {
 public:
   DetIdAssociatorMaker() = default;
+  DetIdAssociatorMaker(const DetIdAssociatorMaker&) = delete;
+  const DetIdAssociatorMaker& operator=(const DetIdAssociatorMaker&) = delete;
   virtual ~DetIdAssociatorMaker() = default;
 
   // ---------- const member functions ---------------------
@@ -39,10 +41,6 @@ public:
   // ---------- member functions ---------------------------
 
 private:
-  DetIdAssociatorMaker(const DetIdAssociatorMaker&) = delete;
-
-  const DetIdAssociatorMaker& operator=(const DetIdAssociatorMaker&) = delete;
-
   // ---------- member data --------------------------------
 };
 

--- a/TrackingTools/TrackFitters/interface/KFTrajectoryFitter.h
+++ b/TrackingTools/TrackFitters/interface/KFTrajectoryFitter.h
@@ -63,6 +63,8 @@ public:
       theGeometry = &dummyGeometry;
   }
 
+  KFTrajectoryFitter(KFTrajectoryFitter const&) = delete;
+
   ~KFTrajectoryFitter() override {
     if (owner) {
       delete thePropagator;
@@ -94,8 +96,6 @@ public:
   void setHitCloner(TkCloner const* hc) override { theHitCloner = hc; }
 
 private:
-  KFTrajectoryFitter(KFTrajectoryFitter const&) = delete;
-
   static const DetLayerGeometry dummyGeometry;
   const Propagator* thePropagator;
   const TrajectoryStateUpdator* theUpdator;

--- a/Utilities/StorageFactory/interface/LocalFileSystem.h
+++ b/Utilities/StorageFactory/interface/LocalFileSystem.h
@@ -13,6 +13,11 @@ class LocalFileSystem {
 
 public:
   LocalFileSystem(void);
+  
+  // undefined, no semantics
+  LocalFileSystem(LocalFileSystem &) = delete;
+  void operator=(LocalFileSystem &) = delete;
+
   ~LocalFileSystem(void);
 
   bool isLocalPath(const std::string &path) const;
@@ -27,10 +32,6 @@ private:
 
   std::vector<FSInfo *> fs_;
   std::vector<std::string> fstypes_;
-
-  // undefined, no semantics
-  LocalFileSystem(LocalFileSystem &) = delete;
-  void operator=(LocalFileSystem &) = delete;
 };
 
 #endif  // STORAGE_FACTORY_LOCAL_FILE_SYSTEM_H

--- a/Utilities/StorageFactory/interface/LocalFileSystem.h
+++ b/Utilities/StorageFactory/interface/LocalFileSystem.h
@@ -13,7 +13,7 @@ class LocalFileSystem {
 
 public:
   LocalFileSystem(void);
-  
+
   // undefined, no semantics
   LocalFileSystem(LocalFileSystem &) = delete;
   void operator=(LocalFileSystem &) = delete;

--- a/Utilities/StorageFactory/interface/Storage.h
+++ b/Utilities/StorageFactory/interface/Storage.h
@@ -22,6 +22,11 @@ public:
   enum Relative { SET, CURRENT, END };
 
   Storage(void);
+
+  // undefined, no semantics
+  Storage(const Storage &) = delete;
+  Storage &operator=(const Storage &) = delete;
+
   ~Storage(void) override;
 
   using IOInput::read;
@@ -48,11 +53,6 @@ public:
 
   virtual void flush(void);
   virtual void close(void);
-
-private:
-  // undefined, no semantics
-  Storage(const Storage &) = delete;
-  Storage &operator=(const Storage &) = delete;
 };
 
 #endif  // STORAGE_FACTORY_STORAGE_H

--- a/Utilities/StorageFactory/interface/StorageAccount.h
+++ b/Utilities/StorageFactory/interface/StorageAccount.h
@@ -104,12 +104,12 @@ public:
   class StorageClassToken {
   public:
     StorageClassToken(StorageClassToken const&) = default;
+    StorageClassToken() = delete;
     int value() const { return m_value; }
 
     friend class StorageAccount;
 
   private:
-    StorageClassToken() = delete;
     explicit StorageClassToken(int iValue) : m_value{iValue} {}
 
     int m_value;

--- a/Validation/EcalHits/interface/EcalSimHitsValidProducer.h
+++ b/Validation/EcalHits/interface/EcalSimHitsValidProducer.h
@@ -31,14 +31,13 @@ class EcalSimHitsValidProducer : public SimProducer,
 
 public:
   EcalSimHitsValidProducer(const edm::ParameterSet &);
+  EcalSimHitsValidProducer(const EcalSimHitsValidProducer &) = delete;                   // stop default
+  const EcalSimHitsValidProducer &operator=(const EcalSimHitsValidProducer &) = delete;  // stop default
   ~EcalSimHitsValidProducer() override;
 
   void produce(edm::Event &, const edm::EventSetup &) override;
 
 private:
-  EcalSimHitsValidProducer(const EcalSimHitsValidProducer &) = delete;                   // stop default
-  const EcalSimHitsValidProducer &operator=(const EcalSimHitsValidProducer &) = delete;  // stop default
-
   void update(const BeginOfEvent *) override;
   void update(const G4Step *) override;
   void update(const EndOfEvent *) override;

--- a/Validation/Geometry/src/MaterialBudgetVolume.cc
+++ b/Validation/Geometry/src/MaterialBudgetVolume.cc
@@ -41,6 +41,8 @@ class MaterialBudgetVolume : public SimProducer,
                              public Observer<const EndOfTrack*> {
 public:
   MaterialBudgetVolume(const edm::ParameterSet& p);
+  MaterialBudgetVolume(const MaterialBudgetVolume&) = delete;  // stop default
+  const MaterialBudgetVolume& operator=(const MaterialBudgetVolume&) = delete;
   ~MaterialBudgetVolume() override {}
 
   void produce(edm::Event&, const edm::EventSetup&) override;
@@ -51,9 +53,6 @@ public:
   };
 
 private:
-  MaterialBudgetVolume(const MaterialBudgetVolume&) = delete;  // stop default
-  const MaterialBudgetVolume& operator=(const MaterialBudgetVolume&) = delete;
-
   // observer classes
   void update(const BeginOfRun* run) override;
   void update(const BeginOfEvent* evt) override;

--- a/Validation/HcalHits/interface/SimG4HcalValidation.h
+++ b/Validation/HcalHits/interface/SimG4HcalValidation.h
@@ -39,14 +39,13 @@ class SimG4HcalValidation : public SimProducer,
                             public Observer<const G4Step *> {
 public:
   SimG4HcalValidation(const edm::ParameterSet &p);
+  SimG4HcalValidation(const SimG4HcalValidation &) = delete;  // stop default
+  const SimG4HcalValidation &operator=(const SimG4HcalValidation &) = delete;
   ~SimG4HcalValidation() override;
 
   void produce(edm::Event &, const edm::EventSetup &) override;
 
 private:
-  SimG4HcalValidation(const SimG4HcalValidation &) = delete;  // stop default
-  const SimG4HcalValidation &operator=(const SimG4HcalValidation &) = delete;
-
   void init();
 
   // observer classes


### PR DESCRIPTION
Cleanup for clang-tidy warning `deleted member function should be public [modernize-use-equals-delete]`