### PR TITLE
[Misc2][clang-tidy] make deleted function public

### DIFF
--- a/CalibCalorimetry/EcalTrivialCondModules/interface/ESTrivialConditionRetriever.h
+++ b/CalibCalorimetry/EcalTrivialCondModules/interface/ESTrivialConditionRetriever.h
@@ -40,6 +40,8 @@ namespace edm {
 class ESTrivialConditionRetriever : public edm::ESProducer, public edm::EventSetupRecordIntervalFinder {
 public:
   ESTrivialConditionRetriever(const edm::ParameterSet& pset);
+  ESTrivialConditionRetriever(const ESTrivialConditionRetriever&) = delete;                   // stop default
+  const ESTrivialConditionRetriever& operator=(const ESTrivialConditionRetriever&) = delete;  // stop default
   ~ESTrivialConditionRetriever() override;
 
   // ---------- member functions ---------------------------
@@ -64,9 +66,6 @@ protected:
                       edm::ValidityInterval&) override;
 
 private:
-  ESTrivialConditionRetriever(const ESTrivialConditionRetriever&) = delete;                   // stop default
-  const ESTrivialConditionRetriever& operator=(const ESTrivialConditionRetriever&) = delete;  // stop default
-
   void getWeightsFromConfiguration(const edm::ParameterSet& ps);
 
   // data members

--- a/CalibCalorimetry/EcalTrivialCondModules/interface/EcalTrivialConditionRetriever.h
+++ b/CalibCalorimetry/EcalTrivialCondModules/interface/EcalTrivialConditionRetriever.h
@@ -123,6 +123,8 @@ namespace edm {
 class EcalTrivialConditionRetriever : public edm::ESProducer, public edm::EventSetupRecordIntervalFinder {
 public:
   EcalTrivialConditionRetriever(const edm::ParameterSet& pset);
+  EcalTrivialConditionRetriever(const EcalTrivialConditionRetriever&) = delete;                   // stop default
+  const EcalTrivialConditionRetriever& operator=(const EcalTrivialConditionRetriever&) = delete;  // stop default
   ~EcalTrivialConditionRetriever() override;
 
   // ---------- member functions ---------------------------
@@ -202,9 +204,6 @@ protected:
                       edm::ValidityInterval&) override;
 
 private:
-  EcalTrivialConditionRetriever(const EcalTrivialConditionRetriever&) = delete;                   // stop default
-  const EcalTrivialConditionRetriever& operator=(const EcalTrivialConditionRetriever&) = delete;  // stop default
-
   void getWeightsFromConfiguration(const edm::ParameterSet& ps);
 
   // data members

--- a/CalibCalorimetry/HcalTPGAlgos/interface/XMLProcessor.h
+++ b/CalibCalorimetry/HcalTPGAlgos/interface/XMLProcessor.h
@@ -137,6 +137,8 @@ public:
     return instance;
   }
 
+  XMLProcessor(const XMLProcessor&) = delete;  // stop default
+
   // returns XML std::string if target == "string" otherwise NULL
   XMLCh* serializeDOM(XERCES_CPP_NAMESPACE::DOMNode* node, std::string target = "stdout");
 
@@ -160,8 +162,6 @@ public:
 
 private:
   XMLProcessor();
-
-  XMLProcessor(const XMLProcessor&) = delete;  // stop default
 
   //const XMLProcessor& operator=(const XMLProcessor&); // stop default
 

--- a/CalibTracker/SiStripESProducers/interface/Phase2TrackerCablingESProducer.h
+++ b/CalibTracker/SiStripESProducers/interface/Phase2TrackerCablingESProducer.h
@@ -11,14 +11,13 @@ class Phase2TrackerCablingRcd;
 class Phase2TrackerCablingESProducer : public edm::ESProducer {
 public:
   Phase2TrackerCablingESProducer(const edm::ParameterSet&);
+  Phase2TrackerCablingESProducer(const Phase2TrackerCablingESProducer&) = delete;
+  const Phase2TrackerCablingESProducer& operator=(const Phase2TrackerCablingESProducer&) = delete;
   ~Phase2TrackerCablingESProducer() override;
 
   virtual std::unique_ptr<Phase2TrackerCabling> produce(const Phase2TrackerCablingRcd&);
 
 private:
-  Phase2TrackerCablingESProducer(const Phase2TrackerCablingESProducer&) = delete;
-  const Phase2TrackerCablingESProducer& operator=(const Phase2TrackerCablingESProducer&) = delete;
-
   virtual Phase2TrackerCabling* make(const Phase2TrackerCablingRcd&) = 0;
 };
 

--- a/CalibTracker/SiStripESProducers/interface/SiStripGainESSource.h
+++ b/CalibTracker/SiStripESProducers/interface/SiStripGainESSource.h
@@ -17,6 +17,8 @@ class SiStripApvGainRcd;
 class SiStripGainESSource : public edm::ESProducer, public edm::EventSetupRecordIntervalFinder {
 public:
   SiStripGainESSource(const edm::ParameterSet&);
+  SiStripGainESSource(const SiStripGainESSource&) = delete;
+  const SiStripGainESSource& operator=(const SiStripGainESSource&) = delete;
   ~SiStripGainESSource() override { ; }
 
   virtual std::unique_ptr<SiStripApvGain> produce(const SiStripApvGainRcd&);
@@ -27,9 +29,6 @@ protected:
                       edm::ValidityInterval&) override;
 
 private:
-  SiStripGainESSource(const SiStripGainESSource&) = delete;
-  const SiStripGainESSource& operator=(const SiStripGainESSource&) = delete;
-
   virtual SiStripApvGain* makeGain() = 0;
 };
 

--- a/CalibTracker/SiStripESProducers/interface/SiStripNoiseESSource.h
+++ b/CalibTracker/SiStripESProducers/interface/SiStripNoiseESSource.h
@@ -17,6 +17,8 @@ class SiStripNoisesRcd;
 class SiStripNoiseESSource : public edm::ESProducer, public edm::EventSetupRecordIntervalFinder {
 public:
   SiStripNoiseESSource(const edm::ParameterSet&);
+  SiStripNoiseESSource(const SiStripNoiseESSource&) = delete;
+  const SiStripNoiseESSource& operator=(const SiStripNoiseESSource&) = delete;
   ~SiStripNoiseESSource() override { ; }
 
   virtual std::unique_ptr<SiStripNoises> produce(const SiStripNoisesRcd&);
@@ -27,9 +29,6 @@ protected:
                       edm::ValidityInterval&) override;
 
 private:
-  SiStripNoiseESSource(const SiStripNoiseESSource&) = delete;
-  const SiStripNoiseESSource& operator=(const SiStripNoiseESSource&) = delete;
-
   virtual SiStripNoises* makeNoise() = 0;
 };
 

--- a/CalibTracker/SiStripESProducers/interface/SiStripPedestalsESSource.h
+++ b/CalibTracker/SiStripESProducers/interface/SiStripPedestalsESSource.h
@@ -17,6 +17,8 @@ class SiStripPedestalsRcd;
 class SiStripPedestalsESSource : public edm::ESProducer, public edm::EventSetupRecordIntervalFinder {
 public:
   SiStripPedestalsESSource(const edm::ParameterSet&);
+  SiStripPedestalsESSource(const SiStripPedestalsESSource&) = delete;
+  const SiStripPedestalsESSource& operator=(const SiStripPedestalsESSource&) = delete;
   ~SiStripPedestalsESSource() override { ; }
 
   virtual std::unique_ptr<SiStripPedestals> produce(const SiStripPedestalsRcd&);
@@ -27,9 +29,6 @@ protected:
                       edm::ValidityInterval&) override;
 
 private:
-  SiStripPedestalsESSource(const SiStripPedestalsESSource&) = delete;
-  const SiStripPedestalsESSource& operator=(const SiStripPedestalsESSource&) = delete;
-
   virtual SiStripPedestals* makePedestals() = 0;
 };
 

--- a/CalibTracker/SiStripESProducers/plugins/fake/SiStripTemplateEmptyFakeESSource.h
+++ b/CalibTracker/SiStripESProducers/plugins/fake/SiStripTemplateEmptyFakeESSource.h
@@ -20,6 +20,8 @@ template <typename TObject, typename TRecord>
 class SiStripTemplateEmptyFakeESSource : public edm::ESProducer, public edm::EventSetupRecordIntervalFinder {
 public:
   SiStripTemplateEmptyFakeESSource(const edm::ParameterSet&);
+  SiStripTemplateEmptyFakeESSource(const SiStripTemplateEmptyFakeESSource&) = delete;
+  const SiStripTemplateEmptyFakeESSource& operator=(const SiStripTemplateEmptyFakeESSource&) = delete;
   ~SiStripTemplateEmptyFakeESSource() override{};
 
   std::unique_ptr<TObject> produce(const TRecord&);
@@ -28,9 +30,6 @@ private:
   void setIntervalFor(const edm::eventsetup::EventSetupRecordKey&,
                       const edm::IOVSyncValue& iov,
                       edm::ValidityInterval& iValidity) override;
-
-  SiStripTemplateEmptyFakeESSource(const SiStripTemplateEmptyFakeESSource&) = delete;
-  const SiStripTemplateEmptyFakeESSource& operator=(const SiStripTemplateEmptyFakeESSource&) = delete;
 };
 
 template <typename TObject, typename TRecord>

--- a/CaloOnlineTools/HcalOnlineDb/interface/XMLLUTLoader.h
+++ b/CaloOnlineTools/HcalOnlineDb/interface/XMLLUTLoader.h
@@ -50,7 +50,7 @@ public:
   XMLLUTLoader();
   XMLLUTLoader(XMLProcessor::loaderBaseConfig* config,
                std::string templateBase = "HCAL_TRIG_PRIM_LOOKUP_TABLE.XMLloader.template");
-  XMLLUTLoader(const XMLLUTLoader&) = delete;  // stop default
+  XMLLUTLoader(const XMLLUTLoader&) = delete;                   // stop default
   const XMLLUTLoader& operator=(const XMLLUTLoader&) = delete;  // stop default
   ~XMLLUTLoader() override;
 

--- a/CaloOnlineTools/HcalOnlineDb/interface/XMLLUTLoader.h
+++ b/CaloOnlineTools/HcalOnlineDb/interface/XMLLUTLoader.h
@@ -50,6 +50,8 @@ public:
   XMLLUTLoader();
   XMLLUTLoader(XMLProcessor::loaderBaseConfig* config,
                std::string templateBase = "HCAL_TRIG_PRIM_LOOKUP_TABLE.XMLloader.template");
+  XMLLUTLoader(const XMLLUTLoader&) = delete;  // stop default
+  const XMLLUTLoader& operator=(const XMLLUTLoader&) = delete;  // stop default
   ~XMLLUTLoader() override;
 
   int addLUT(lutDBConfig* config, std::string templateFileName = "HCAL_TRIG_PRIM_LOOKUP_TABLE.dataset.template");
@@ -58,11 +60,6 @@ public:
                    std::string templateFileName = "HCAL_TRIG_PRIM_LOOKUP_TABLE.checksums.template");
 
   int createLoader(const std::vector<int>& crate_number, const std::vector<std::string>& file_name);
-
-private:
-  XMLLUTLoader(const XMLLUTLoader&) = delete;  // stop default
-
-  const XMLLUTLoader& operator=(const XMLLUTLoader&) = delete;  // stop default
 };
 
 #endif

--- a/DQM/SiStripCommissioningSources/interface/SiStripCommissioningSource.h
+++ b/DQM/SiStripCommissioningSources/interface/SiStripCommissioningSource.h
@@ -41,6 +41,10 @@ public:  // ---------- Public interface ----------
   typedef dqm::legacy::MonitorElement MonitorElement;
 
   SiStripCommissioningSource(const edm::ParameterSet&);
+
+  /** Private default constructor. */
+  SiStripCommissioningSource() = delete;
+
   ~SiStripCommissioningSource() override;
 
   void beginRun(edm::Run const&, const edm::EventSetup&) override;
@@ -48,9 +52,6 @@ public:  // ---------- Public interface ----------
   void endJob() override;
 
 private:  // ---------- Private methods ----------
-  /** Private default constructor. */
-  SiStripCommissioningSource() = delete;
-
   /** */
   DQMStore* const dqm(std::string method = "") const;
 

--- a/DQM/SiStripCommissioningSources/plugins/tracking/SiStripFineDelayTOF.h
+++ b/DQM/SiStripCommissioningSources/plugins/tracking/SiStripFineDelayTOF.h
@@ -12,9 +12,10 @@ public:
   static double timeOfFlight(bool cosmics, bool field, double* trackParameters, double* hit, double* phit, bool onDisk);
   static void trackParameters(const reco::Track& tk, double* trackParameters);
 
-private:
   SiStripFineDelayTOF() = delete;
   virtual ~SiStripFineDelayTOF() = delete;
+
+private:
   static double timeOfFlightCosmic(double* hit, double* phit);
   static double timeOfFlightCosmicB(double* trackParameters, double* hit, double* phit, bool onDisk);
   static double timeOfFlightBeam(double* hit, double* phit);

--- a/DQM/SiStripCommon/interface/SiStripHistoId.h
+++ b/DQM/SiStripCommon/interface/SiStripHistoId.h
@@ -25,6 +25,8 @@ class TrackerTopology;
 class SiStripHistoId {
 public:
   SiStripHistoId();
+  SiStripHistoId(const SiStripHistoId&) = delete;                   // stop default
+  const SiStripHistoId& operator=(const SiStripHistoId&) = delete;  // stop default
   virtual ~SiStripHistoId();
   // generally: histoid = description + separator1 + id_type + separator2 + component_id
   std::string createHistoId(std::string description, std::string id_type, uint32_t component_id);
@@ -36,8 +38,6 @@ public:
   std::string getComponentType(std::string histoid);
 
 private:
-  SiStripHistoId(const SiStripHistoId&) = delete;                   // stop default
-  const SiStripHistoId& operator=(const SiStripHistoId&) = delete;  // stop default
   std::string returnIdPart(std::string histoid, uint32_t whichpart);
 };
 

--- a/DQMOffline/Trigger/interface/EgHLTOffHelper.h
+++ b/DQMOffline/Trigger/interface/EgHLTOffHelper.h
@@ -157,10 +157,6 @@ namespace egHLT {
 
     std::vector<edm::ParameterSet> trigCutParams_;  //probably the least bad option
 
-  private:  //disabling copy / assignment
-    OffHelper& operator=(const OffHelper&) = delete;
-    OffHelper(const OffHelper&) = delete;
-
   public:
     OffHelper()
         : eleLooseCuts_(),
@@ -169,6 +165,8 @@ namespace egHLT {
           phoCuts_(),
           hltEleTrkIsolAlgo_(nullptr),
           hltPhoTrkIsolAlgo_(nullptr) {}
+    OffHelper& operator=(const OffHelper&) = delete;
+    OffHelper(const OffHelper&) = delete;
     ~OffHelper();
 
     void setup(const edm::ParameterSet& conf, edm::ConsumesCollector&& iC);

--- a/DQMOffline/Trigger/interface/EgHLTOfflineSource.h
+++ b/DQMOffline/Trigger/interface/EgHLTOfflineSource.h
@@ -93,12 +93,13 @@ private:
   bool filterInactiveTriggers_;
   std::string hltTag_;
 
+public:
+  explicit EgHLTOfflineSource(const edm::ParameterSet&);
+
   //disabling copying/assignment (copying this class would be bad, mkay)
   EgHLTOfflineSource(const EgHLTOfflineSource& rhs) = delete;
   EgHLTOfflineSource& operator=(const EgHLTOfflineSource& rhs) = delete;
 
-public:
-  explicit EgHLTOfflineSource(const edm::ParameterSet&);
   ~EgHLTOfflineSource() override;
 
   void bookHistograms(DQMStore::IBooker&, edm::Run const&, edm::EventSetup const&) override;

--- a/DQMServices/FwkIO/plugins/DQMRootSource.cc
+++ b/DQMServices/FwkIO/plugins/DQMRootSource.cc
@@ -311,9 +311,12 @@ struct DQMTTreeIO {
 class DQMRootSource : public edm::PuttableSourceBase, DQMTTreeIO {
 public:
   DQMRootSource(edm::ParameterSet const&, const edm::InputSourceDescription&);
+  DQMRootSource(const DQMRootSource&) = delete;
   ~DQMRootSource() override;
 
   // ---------- const member functions ---------------------
+
+  const DQMRootSource& operator=(const DQMRootSource&) = delete;  // stop default
 
   // ---------- static member functions --------------------
 
@@ -321,8 +324,6 @@ public:
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 private:
-  DQMRootSource(const DQMRootSource&) = delete;
-
   edm::InputSource::ItemType getNextItemType() override;
 
   std::shared_ptr<edm::FileBlock> readFile_() override;
@@ -352,8 +353,6 @@ private:
   // If at least one lumi of a run needs to be kept, per run MEs of that run will also be kept.
   bool keepIt(edm::RunNumber_t, edm::LuminosityBlockNumber_t) const;
   void logFileAction(char const* msg, char const* fileName) const;
-
-  const DQMRootSource& operator=(const DQMRootSource&) = delete;  // stop default
 
   // ---------- member data --------------------------------
 

--- a/EventFilter/GctRawToDigi/src/GctUnpackCollections.h
+++ b/EventFilter/GctRawToDigi/src/GctUnpackCollections.h
@@ -24,7 +24,7 @@ public:
   GctUnpackCollections(edm::Event& event);
 
   /// deliberately not implemented!
-  GctUnpackCollections(const GctUnpackCollections&) = delete;  ///< Copy ctor
+  GctUnpackCollections(const GctUnpackCollections&) = delete;             ///< Copy ctor
   GctUnpackCollections& operator=(const GctUnpackCollections&) = delete;  ///< Assignment op
 
   /// Destructor - the last action of this object is to put the gct collections into the event provided on construction.

--- a/EventFilter/GctRawToDigi/src/GctUnpackCollections.h
+++ b/EventFilter/GctRawToDigi/src/GctUnpackCollections.h
@@ -23,6 +23,10 @@ public:
   /// Construct with an event. The collections get put into the event when the object instance goes out of scope (i.e. in the destructor).
   GctUnpackCollections(edm::Event& event);
 
+  /// deliberately not implemented!
+  GctUnpackCollections(const GctUnpackCollections&) = delete;  ///< Copy ctor
+  GctUnpackCollections& operator=(const GctUnpackCollections&) = delete;  ///< Assignment op
+
   /// Destructor - the last action of this object is to put the gct collections into the event provided on construction.
   ~GctUnpackCollections();
 
@@ -84,10 +88,6 @@ public:
   L1TriggerErrorCollection* const errors() const { return m_errors.get(); }  ///< Unpack error code collection.
 
 private:
-  GctUnpackCollections(const GctUnpackCollections&) = delete;  ///< Copy ctor - deliberately not implemented!
-  GctUnpackCollections& operator=(const GctUnpackCollections&) =
-      delete;  ///< Assignment op - deliberately not implemented!
-
   edm::Event&
       m_event;  ///< The event the collections will be put into on destruction of the GctUnpackCollections instance.
 

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/UCTCTP7RawData.h
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/UCTCTP7RawData.h
@@ -21,6 +21,10 @@ public:
     }
   }
 
+  // No copy constructor and equality operator are needed
+  UCTCTP7RawData(const UCTCTP7RawData&) = delete;
+  const UCTCTP7RawData& operator=(const UCTCTP7RawData& i) = delete;
+
   virtual ~UCTCTP7RawData() { ; }
 
   // Access functions for convenience
@@ -333,11 +337,6 @@ public:
   }
 
 private:
-  // No copy constructor and equality operator are needed
-
-  UCTCTP7RawData(const UCTCTP7RawData&) = delete;
-  const UCTCTP7RawData& operator=(const UCTCTP7RawData& i) = delete;
-
   // Pointer to contiguous array of 192 values
   // We assume instantiator of this class will gurantee that fact
   const uint32_t* myDataPtr;

--- a/EventFilter/L1TXRawToDigi/interface/UCTAMCRawData.h
+++ b/EventFilter/L1TXRawToDigi/interface/UCTAMCRawData.h
@@ -9,7 +9,6 @@ public:
   UCTAMCRawData(const UCTAMCRawData &) = delete;
   const UCTAMCRawData &operator=(const UCTAMCRawData &i) = delete;
 
-
   virtual ~UCTAMCRawData() { ; }
 
   // Access functions for convenience

--- a/EventFilter/L1TXRawToDigi/interface/UCTAMCRawData.h
+++ b/EventFilter/L1TXRawToDigi/interface/UCTAMCRawData.h
@@ -5,6 +5,11 @@ class UCTAMCRawData {
 public:
   UCTAMCRawData(const uint32_t *d) : myDataPtr(d) {}
 
+  // No copy constructor and equality operator are needed
+  UCTAMCRawData(const UCTAMCRawData &) = delete;
+  const UCTAMCRawData &operator=(const UCTAMCRawData &i) = delete;
+
+
   virtual ~UCTAMCRawData() { ; }
 
   // Access functions for convenience
@@ -45,11 +50,6 @@ public:
   }
 
 private:
-  // No copy constructor and equality operator are needed
-
-  UCTAMCRawData(const UCTAMCRawData &) = delete;
-  const UCTAMCRawData &operator=(const UCTAMCRawData &i) = delete;
-
   // RawData data
 
   const uint32_t *myDataPtr;

--- a/EventFilter/L1TXRawToDigi/interface/UCTCTP7RawData.h
+++ b/EventFilter/L1TXRawToDigi/interface/UCTCTP7RawData.h
@@ -16,6 +16,10 @@ public:
     }
   }
 
+  // No copy constructor and equality operator are needed
+  UCTCTP7RawData(const UCTCTP7RawData&) = delete;
+  const UCTCTP7RawData& operator=(const UCTCTP7RawData& i) = delete;
+
   virtual ~UCTCTP7RawData() { ; }
 
   // Access functions for convenience
@@ -330,11 +334,6 @@ public:
   }
 
 private:
-  // No copy constructor and equality operator are needed
-
-  UCTCTP7RawData(const UCTCTP7RawData&) = delete;
-  const UCTCTP7RawData& operator=(const UCTCTP7RawData& i) = delete;
-
   // RawData data
 
   const uint32_t* myDataPtr;

--- a/EventFilter/L1TXRawToDigi/interface/UCTDAQRawData.h
+++ b/EventFilter/L1TXRawToDigi/interface/UCTDAQRawData.h
@@ -20,6 +20,10 @@ public:
     }
   }
 
+  // No copy constructor and equality operator are needed
+  UCTDAQRawData(const UCTDAQRawData &) = delete;
+  const UCTDAQRawData &operator=(const UCTDAQRawData &i) = delete;
+
   virtual ~UCTDAQRawData() { ; }
 
   // Access functions for convenience
@@ -279,11 +283,6 @@ public:
   }
 
 private:
-  // No copy constructor and equality operator are needed
-
-  UCTDAQRawData(const UCTDAQRawData &) = delete;
-  const UCTDAQRawData &operator=(const UCTDAQRawData &i) = delete;
-
   // RawData data
 
   const uint64_t *myDataPtr;

--- a/EventFilter/RctRawToDigi/src/RctUnpackCollections.h
+++ b/EventFilter/RctRawToDigi/src/RctUnpackCollections.h
@@ -21,7 +21,7 @@ public:
   RctUnpackCollections(edm::Event& event);
 
   /// deliberately not implemented!
-  RctUnpackCollections(const RctUnpackCollections&) = delete;  ///< Copy ctor
+  RctUnpackCollections(const RctUnpackCollections&) = delete;             ///< Copy ctor
   RctUnpackCollections& operator=(const RctUnpackCollections&) = delete;  ///< Assignment op
 
   /// Destructor - the last action of this object is to put the rct collections into the event provided on construction.

--- a/EventFilter/RctRawToDigi/src/RctUnpackCollections.h
+++ b/EventFilter/RctRawToDigi/src/RctUnpackCollections.h
@@ -20,6 +20,10 @@ public:
   /// Construct with an event. The collections get put into the event when the object instance goes out of scope (i.e. in the destructor).
   RctUnpackCollections(edm::Event& event);
 
+  /// deliberately not implemented!
+  RctUnpackCollections(const RctUnpackCollections&) = delete;  ///< Copy ctor
+  RctUnpackCollections& operator=(const RctUnpackCollections&) = delete;  ///< Assignment op
+
   /// Destructor - the last action of this object is to put the rct collections into the event provided on construction.
   ~RctUnpackCollections();
 
@@ -30,10 +34,6 @@ public:
   }  ///< Input calo regions from the RCT to the RCT.
 
 private:
-  RctUnpackCollections(const RctUnpackCollections&) = delete;  ///< Copy ctor - deliberately not implemented!
-  RctUnpackCollections& operator=(const RctUnpackCollections&) =
-      delete;  ///< Assignment op - deliberately not implemented!
-
   edm::Event&
       m_event;  ///< The event the collections will be put into on destruction of the RctUnpackCollections instance.
 

--- a/EventFilter/SiStripRawToDigi/plugins/SiStripRawToDigiUnpacker.h
+++ b/EventFilter/SiStripRawToDigi/plugins/SiStripRawToDigiUnpacker.h
@@ -45,6 +45,9 @@ namespace sistrip {
                       bool mark_missing_feds,
                       const uint32_t errorThreshold);
 
+    /// private default constructor
+    RawToDigiUnpacker() = delete;
+
     /// default constructor
     ~RawToDigiUnpacker();
 
@@ -85,9 +88,6 @@ namespace sistrip {
     /// fill DetSetVectors using registries
     void update(
         RawDigis& scope_mode, RawDigis& virgin_raw, RawDigis& proc_raw, Digis& zero_suppr, RawDigis& common_mode);
-
-    /// private default constructor
-    RawToDigiUnpacker() = delete;
 
     /// sets the SiStripEventSummary -> not yet implemented for FEDBuffer class
     void updateEventSummary(const sistrip::FEDBuffer&, SiStripEventSummary&);

--- a/GeneratorInterface/Herwig7Interface/interface/Proxy.h
+++ b/GeneratorInterface/Herwig7Interface/interface/Proxy.h
@@ -15,6 +15,10 @@ namespace ThePEG {
   public:
     typedef unsigned long ProxyID;
 
+    // not allowed and not implemented
+    ProxyBase(const ProxyBase &orig) = delete;
+    ProxyBase &operator=(const ProxyBase &orig) = delete;
+
     virtual ~ProxyBase();
 
     ProxyID getID() const { return id; }
@@ -29,10 +33,6 @@ namespace ThePEG {
 
     static std::shared_ptr<ProxyBase> create(ctor_t ctor);
     static std::shared_ptr<ProxyBase> find(ProxyID id);
-
-    // not allowed and not implemented
-    ProxyBase(const ProxyBase &orig) = delete;
-    ProxyBase &operator=(const ProxyBase &orig) = delete;
 
     const ProxyID id;
   };

--- a/GeneratorInterface/HiGenCommon/plugins/BetaBoostEvtVtxGenerator.cc
+++ b/GeneratorInterface/HiGenCommon/plugins/BetaBoostEvtVtxGenerator.cc
@@ -52,6 +52,10 @@ namespace CLHEP {
 class BetaBoostEvtVtxGenerator : public edm::EDProducer {
 public:
   BetaBoostEvtVtxGenerator(const edm::ParameterSet& p);
+  /** Copy constructor */
+  BetaBoostEvtVtxGenerator(const BetaBoostEvtVtxGenerator& p) = delete;
+  /** Copy assignment operator */
+  BetaBoostEvtVtxGenerator& operator=(const BetaBoostEvtVtxGenerator& rhs) = delete;
   ~BetaBoostEvtVtxGenerator() override;
 
   /// return a new event vertex
@@ -85,11 +89,6 @@ public:
   double BetaFunction(double z, double z0);
 
 private:
-  /** Copy constructor */
-  BetaBoostEvtVtxGenerator(const BetaBoostEvtVtxGenerator& p) = delete;
-  /** Copy assignment operator */
-  BetaBoostEvtVtxGenerator& operator=(const BetaBoostEvtVtxGenerator& rhs) = delete;
-
   double alpha_, phi_;
   //TMatrixD boost_;
   double beta_;

--- a/GeneratorInterface/HiGenCommon/plugins/MixBoostEvtVtxGenerator.cc
+++ b/GeneratorInterface/HiGenCommon/plugins/MixBoostEvtVtxGenerator.cc
@@ -50,6 +50,10 @@ class FourVector;
 class MixBoostEvtVtxGenerator : public edm::EDProducer {
 public:
   MixBoostEvtVtxGenerator(const edm::ParameterSet& p);
+  /** Copy constructor */
+  MixBoostEvtVtxGenerator(const MixBoostEvtVtxGenerator& p) = delete;
+  /** Copy assignment operator */
+  MixBoostEvtVtxGenerator& operator=(const MixBoostEvtVtxGenerator& rhs) = delete;
   ~MixBoostEvtVtxGenerator() override;
 
   /// return a new event vertex
@@ -83,11 +87,6 @@ public:
   double BetaFunction(double z, double z0);
 
 private:
-  /** Copy constructor */
-  MixBoostEvtVtxGenerator(const MixBoostEvtVtxGenerator& p) = delete;
-  /** Copy assignment operator */
-  MixBoostEvtVtxGenerator& operator=(const MixBoostEvtVtxGenerator& rhs) = delete;
-
   double alpha_, phi_;
   //TMatrixD boost_;
   double beta_;

--- a/GeneratorInterface/LHEInterface/interface/LHEProxy.h
+++ b/GeneratorInterface/LHEInterface/interface/LHEProxy.h
@@ -13,6 +13,10 @@ namespace lhef {
   public:
     typedef unsigned long ProxyID;
 
+    // not allowed and not implemented
+    LHEProxy(const LHEProxy &orig) = delete;
+    LHEProxy &operator=(const LHEProxy &orig) = delete;
+
     ~LHEProxy();
 
     const std::shared_ptr<LHERunInfo> &getRunInfo() const { return runInfo; }
@@ -42,10 +46,6 @@ namespace lhef {
 
   private:
     LHEProxy(ProxyID id);
-
-    // not allowed and not implemented
-    LHEProxy(const LHEProxy &orig) = delete;
-    LHEProxy &operator=(const LHEProxy &orig) = delete;
 
     const ProxyID id;
 

--- a/GeneratorInterface/LHEInterface/src/XMLUtils.h
+++ b/GeneratorInterface/LHEInterface/src/XMLUtils.h
@@ -48,13 +48,12 @@ namespace lhef {
     class XercesPlatform {
     public:
       XercesPlatform();
-      ~XercesPlatform();
-
-    private:
       // do not make any kind of copies
       XercesPlatform(const XercesPlatform &orig) = delete;
       XercesPlatform &operator=(const XercesPlatform &orig) = delete;
+      ~XercesPlatform();
 
+    private:
       static unsigned int instances;
     };
 

--- a/GeometryReaders/XMLIdealGeometryESSource/interface/XMLIdealGeometryESSource.h
+++ b/GeometryReaders/XMLIdealGeometryESSource/interface/XMLIdealGeometryESSource.h
@@ -16,6 +16,8 @@
 class XMLIdealGeometryESSource : public edm::ESProducer, public edm::EventSetupRecordIntervalFinder {
 public:
   XMLIdealGeometryESSource(const edm::ParameterSet &p);
+  XMLIdealGeometryESSource(const XMLIdealGeometryESSource &) = delete;
+  const XMLIdealGeometryESSource &operator=(const XMLIdealGeometryESSource &) = delete;
   ~XMLIdealGeometryESSource() override;
   std::unique_ptr<DDCompactView> produceGeom(const IdealGeometryRecord &);
   std::unique_ptr<DDCompactView> produceMagField(const IdealMagneticFieldRecord &);
@@ -25,8 +27,6 @@ protected:
   void setIntervalFor(const edm::eventsetup::EventSetupRecordKey &,
                       const edm::IOVSyncValue &,
                       edm::ValidityInterval &) override;
-  XMLIdealGeometryESSource(const XMLIdealGeometryESSource &) = delete;
-  const XMLIdealGeometryESSource &operator=(const XMLIdealGeometryESSource &) = delete;
 
 private:
   std::string rootNodeName_;

--- a/IOMC/EventVertexGenerators/interface/BeamProfileVtxGenerator.h
+++ b/IOMC/EventVertexGenerators/interface/BeamProfileVtxGenerator.h
@@ -19,6 +19,10 @@ namespace CLHEP {
 class BeamProfileVtxGenerator : public BaseEvtVtxGenerator {
 public:
   BeamProfileVtxGenerator(const edm::ParameterSet& p);
+  /** Copy constructor */
+  BeamProfileVtxGenerator(const BeamProfileVtxGenerator& p) = delete;
+  /** Copy assignment operator */
+  BeamProfileVtxGenerator& operator=(const BeamProfileVtxGenerator& rhs) = delete;
   ~BeamProfileVtxGenerator() override;
 
   /// return a new event vertex
@@ -47,12 +51,6 @@ public:
   void psi(double m = 999) { fPsi = m; }
   /// set type
   void setType(bool m = true);
-
-private:
-  /** Copy constructor */
-  BeamProfileVtxGenerator(const BeamProfileVtxGenerator& p) = delete;
-  /** Copy assignment operator */
-  BeamProfileVtxGenerator& operator=(const BeamProfileVtxGenerator& rhs) = delete;
 
 private:
   double fSigmaX, fSigmaY;

--- a/IOMC/EventVertexGenerators/interface/BetafuncEvtVtxGenerator.h
+++ b/IOMC/EventVertexGenerators/interface/BetafuncEvtVtxGenerator.h
@@ -31,6 +31,10 @@ namespace CLHEP {
 class BetafuncEvtVtxGenerator : public BaseEvtVtxGenerator {
 public:
   BetafuncEvtVtxGenerator(const edm::ParameterSet& p);
+  /** Copy constructor */
+  BetafuncEvtVtxGenerator(const BetafuncEvtVtxGenerator& p) = delete;
+  /** Copy assignment operator */
+  BetafuncEvtVtxGenerator& operator=(const BetafuncEvtVtxGenerator& rhs) = delete;
   ~BetafuncEvtVtxGenerator() override;
 
   void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
@@ -60,11 +64,6 @@ public:
   double BetaFunction(double z, double z0) const;
 
 private:
-  /** Copy constructor */
-  BetafuncEvtVtxGenerator(const BetafuncEvtVtxGenerator& p) = delete;
-  /** Copy assignment operator */
-  BetafuncEvtVtxGenerator& operator=(const BetafuncEvtVtxGenerator& rhs) = delete;
-
   void setBoost(double alpha, double phi);
 
 private:

--- a/IOMC/EventVertexGenerators/interface/FlatEvtVtxGenerator.h
+++ b/IOMC/EventVertexGenerators/interface/FlatEvtVtxGenerator.h
@@ -22,6 +22,10 @@ namespace CLHEP {
 class FlatEvtVtxGenerator : public BaseEvtVtxGenerator {
 public:
   FlatEvtVtxGenerator(const edm::ParameterSet& p);
+  /** Copy constructor */
+  FlatEvtVtxGenerator(const FlatEvtVtxGenerator& p) = delete;
+  /** Copy assignment operator */
+  FlatEvtVtxGenerator& operator=(const FlatEvtVtxGenerator& rhs) = delete;
   ~FlatEvtVtxGenerator() override;
 
   /// return a new event vertex
@@ -43,12 +47,6 @@ public:
   void maxY(double m = 0);
   /// set max in Z in cm
   void maxZ(double m = 0);
-
-private:
-  /** Copy constructor */
-  FlatEvtVtxGenerator(const FlatEvtVtxGenerator& p) = delete;
-  /** Copy assignment operator */
-  FlatEvtVtxGenerator& operator=(const FlatEvtVtxGenerator& rhs) = delete;
 
 private:
   double fMinX, fMinY, fMinZ, fMinT;

--- a/IOMC/EventVertexGenerators/interface/GaussEvtVtxGenerator.h
+++ b/IOMC/EventVertexGenerators/interface/GaussEvtVtxGenerator.h
@@ -16,6 +16,10 @@ namespace CLHEP {
 class GaussEvtVtxGenerator : public BaseEvtVtxGenerator {
 public:
   GaussEvtVtxGenerator(const edm::ParameterSet& p);
+  /** Copy constructor */
+  GaussEvtVtxGenerator(const GaussEvtVtxGenerator& p) = delete;
+  /** Copy assignment operator */
+  GaussEvtVtxGenerator& operator=(const GaussEvtVtxGenerator& rhs) = delete;
   ~GaussEvtVtxGenerator() override;
 
   /// return a new event vertex
@@ -37,12 +41,6 @@ public:
   void meanY(double m = 0) { fMeanY = m; }
   /// set mean in Z in cm
   void meanZ(double m = 0) { fMeanZ = m; }
-
-private:
-  /** Copy constructor */
-  GaussEvtVtxGenerator(const GaussEvtVtxGenerator& p) = delete;
-  /** Copy assignment operator */
-  GaussEvtVtxGenerator& operator=(const GaussEvtVtxGenerator& rhs) = delete;
 
 private:
   double fSigmaX, fSigmaY, fSigmaZ;

--- a/IOMC/EventVertexGenerators/interface/HLLHCEvtVtxGenerator.h
+++ b/IOMC/EventVertexGenerators/interface/HLLHCEvtVtxGenerator.h
@@ -27,6 +27,12 @@ class HLLHCEvtVtxGenerator : public BaseEvtVtxGenerator {
 public:
   HLLHCEvtVtxGenerator(const edm::ParameterSet& p);
 
+  /** Copy constructor */
+  HLLHCEvtVtxGenerator(const HLLHCEvtVtxGenerator& p) = delete;
+
+  /** Copy assignment operator */
+  HLLHCEvtVtxGenerator& operator=(const HLLHCEvtVtxGenerator& rhs) = delete;
+
   ~HLLHCEvtVtxGenerator() override;
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
@@ -37,12 +43,6 @@ public:
   TMatrixD const* GetInvLorentzBoost() const override { return nullptr; };
 
 private:
-  /** Copy constructor */
-  HLLHCEvtVtxGenerator(const HLLHCEvtVtxGenerator& p) = delete;
-
-  /** Copy assignment operator */
-  HLLHCEvtVtxGenerator& operator=(const HLLHCEvtVtxGenerator& rhs) = delete;
-
   //spatial and time offset for mean collision
   const double fMeanX, fMeanY, fMeanZ, fTimeOffset;
 

--- a/IOPool/Output/src/RootOutputTree.cc
+++ b/IOPool/Output/src/RootOutputTree.cc
@@ -41,12 +41,12 @@ namespace edm {
   class DuplicateTreeSentry {
   public:
     DuplicateTreeSentry(TTree* tree) : tree_(tree) { dup(); }
+    DuplicateTreeSentry(DuplicateTreeSentry const&) = delete;  // Disallow copying and moving
+    DuplicateTreeSentry& operator=(DuplicateTreeSentry const&) = delete;
 
     TTree* tree() const { return mytree_ ? mytree_.get() : tree_; }
 
   private:
-    DuplicateTreeSentry(DuplicateTreeSentry const&) = delete;  // Disallow copying and moving
-    DuplicateTreeSentry& operator=(DuplicateTreeSentry const&) = delete;
     struct CloseBeforeDelete {
       void operator()(TFile* iFile) const {
         if (iFile) {


### PR DESCRIPTION
Cleanup for clang-tidy warning `deleted member function should be public [modernize-use-equals-delete]`