### PR TITLE
Temporarily disable the GEM-CSC triggers

### DIFF
--- a/L1Trigger/CSCTriggerPrimitives/python/cscTriggerPrimitiveDigis_cfi.py
+++ b/L1Trigger/CSCTriggerPrimitives/python/cscTriggerPrimitiveDigis_cfi.py
@@ -78,13 +78,11 @@ run3_common.toModify( cscTriggerPrimitiveDigis,
 from Configuration.Eras.Modifier_run3_GEM_cff import run3_GEM
 run3_GEM.toModify( cscTriggerPrimitiveDigis,
                    GEMPadDigiClusterProducer = cms.InputTag("simMuonGEMPadDigiClusters"),
-                   commonParam = dict(runME11ILT = True)
 )
 
 ## GEM-CSC integrated local trigger in ME2/1
 ## enable the Phase-2 ALCT processors
 from Configuration.Eras.Modifier_phase2_muon_cff import phase2_muon
 phase2_muon.toModify( cscTriggerPrimitiveDigis,
-                      commonParam = dict(runME21ILT = True,
-                                         enableAlctPhase2 = True)
+                      commonParam = dict(enableAlctPhase2 = True)
 )

--- a/Validation/MuonCSCDigis/python/cscDigiValidation_cfi.py
+++ b/Validation/MuonCSCDigis/python/cscDigiValidation_cfi.py
@@ -20,7 +20,7 @@ cscDigiValidation = DQMEDAnalyzer(
 )
 
 from Configuration.Eras.Modifier_run3_GEM_cff import run3_GEM
-run3_GEM.toModify(cscDigiValidation, useGEMs = True)
+run3_GEM.toModify(cscDigiValidation, useGEMs = False)
 
 ## do not run GEMs in fastsim sequences
 from Configuration.Eras.Modifier_fastSim_cff import fastSim


### PR DESCRIPTION
#### PR description:

Temporarily disable the GEM-CSC triggers until the GEM-CSC lookup tables (for coordinate conversion and  matching) are contained in a new ES object and are loaded though the eventsetup, rather than through the CSCLUTReader for each chamber in each event.

#### PR validation:

PR https://github.com/cms-sw/cmssw/pull/34597 relval tests are failing only for Run-3 and Phase-2 scenarios, not Run-1 or Run-2. By disabling GEM-CSC temporarily, this should allow those relval tests to run.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N.A.

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
