### PR TITLE
add scouting collections to MINIAODSIM Event Content

### DIFF
--- a/Configuration/EventContent/python/EventContent_cff.py
+++ b/Configuration/EventContent/python/EventContent_cff.py
@@ -813,6 +813,7 @@ MINIAODSIMEventContent= cms.PSet(
     compressionLevel=cms.untracked.int32(4)
 )
 MINIAODSIMEventContent.outputCommands.extend(MicroEventContentMC.outputCommands)
+MINIAODSIMEventContent.outputCommands.extend(HLTScouting.outputCommands)
 
 MINIGENEventContent= cms.PSet(
     outputCommands = cms.untracked.vstring('drop *'),


### PR DESCRIPTION
#### PR description:

This PR is to include Run 3 data scouting collections by default in MINIAODSIM event content. This will facilitate much wider usage of data scouting in CMS given the availability of the collections in all officially produced MC samples. I am not sure if this is the correct branch to merge into, but the change is very simple so I can prepare the PR in a different release without any problem

#### PR validation:

The change was checked to correctly include the collections in the MINIAODSIM event content. In a small sample it was checked that this would increase the event size of MINIAOD by about 4%.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:


