### PR TITLE
[Payload Inspector] Miscellaneous improvements for `RunInfo` and `SiStripLatency`

### DIFF
--- a/CondCore/RunInfoPlugins/interface/RunInfoPayloadInspectoHelper.h
+++ b/CondCore/RunInfoPlugins/interface/RunInfoPayloadInspectoHelper.h
@@ -14,11 +14,11 @@
 // for the FED intervals
 #include "DataFormats/FEDRawData/interface/FEDNumbering.h"
 
-#define PAIR(a, b) std::make_pair(a, b)
+#define MK_P(a, b) std::make_pair(a, b)
 
 namespace RunInfoPI {
 
-  enum state { fake = 0, valid = 1, invalid = 2 };
+  enum state { k_fake = 0, k_valid = 1, k_invalid = 2 };
 
   // values are taken from https://github.com/cms-sw/cmssw/blob/master/MagneticField/GeomBuilder/plugins/VolumeBasedMagneticFieldESProducerFromDB.cc#L74-L75
   constexpr std::array<int, 7> nominalCurrents{{-1, 0, 9558, 14416, 16819, 18268, 19262}};
@@ -160,22 +160,22 @@ namespace RunInfoPI {
 
   inline FEDMAP_T buildFEDBounds() {
     static RunInfoPI::FEDMAP_T fb;
-    fb.insert(PAIR(SIPIXEL, PAIR(FEDNumbering::MINSiPixelFEDID, FEDNumbering::MAXSiPixelFEDID)));
-    fb.insert(PAIR(SISTRIP, PAIR(FEDNumbering::MINSiStripFEDID, FEDNumbering::MAXSiStripFEDID)));
-    fb.insert(PAIR(PRESHOWER, PAIR(FEDNumbering::MINPreShowerFEDID, FEDNumbering::MAXPreShowerFEDID)));
-    fb.insert(PAIR(TOTEMRP_H, PAIR(FEDNumbering::MINTotemRPHorizontalFEDID, FEDNumbering::MAXTotemRPHorizontalFEDID)));
-    fb.insert(PAIR(CTPPSDIAMOND, PAIR(FEDNumbering::MINCTPPSDiamondFEDID, FEDNumbering::MAXCTPPSDiamondFEDID)));
-    fb.insert(PAIR(TOTEMRP_V, PAIR(FEDNumbering::MINTotemRPVerticalFEDID, FEDNumbering::MAXTotemRPVerticalFEDID)));
-    fb.insert(PAIR(TOTEMRP_T,
-                   PAIR(FEDNumbering::MINTotemRPTimingVerticalFEDID, FEDNumbering::MAXTotemRPTimingVerticalFEDID)));
-    fb.insert(PAIR(ECAL, PAIR(FEDNumbering::MINECALFEDID, FEDNumbering::MAXECALFEDID)));
-    fb.insert(PAIR(CASTOR, PAIR(FEDNumbering::MINCASTORFEDID, FEDNumbering::MAXCASTORFEDID)));
-    fb.insert(PAIR(HCAL, PAIR(FEDNumbering::MINHCALFEDID, FEDNumbering::MAXHCALFEDID)));
-    fb.insert(PAIR(CSC, PAIR(FEDNumbering::MINCSCFEDID, FEDNumbering::MAXCSCFEDID)));
-    fb.insert(PAIR(RPC, PAIR(FEDNumbering::MINRPCFEDID, FEDNumbering::MAXRPCFEDID)));
-    fb.insert(PAIR(HCALPHASE1, PAIR(FEDNumbering::MINHCALuTCAFEDID, FEDNumbering::MAXHCALuTCAFEDID)));
-    fb.insert(PAIR(SIPIXELPHASE1, PAIR(FEDNumbering::MINSiPixeluTCAFEDID, FEDNumbering::MAXSiPixeluTCAFEDID)));
-    fb.insert(PAIR(GEM, PAIR(FEDNumbering::MINGEMFEDID, FEDNumbering::MAXGEMFEDID)));
+    fb.insert(MK_P(SIPIXEL, MK_P(FEDNumbering::MINSiPixelFEDID, FEDNumbering::MAXSiPixelFEDID)));
+    fb.insert(MK_P(SISTRIP, MK_P(FEDNumbering::MINSiStripFEDID, FEDNumbering::MAXSiStripFEDID)));
+    fb.insert(MK_P(PRESHOWER, MK_P(FEDNumbering::MINPreShowerFEDID, FEDNumbering::MAXPreShowerFEDID)));
+    fb.insert(MK_P(TOTEMRP_H, MK_P(FEDNumbering::MINTotemRPHorizontalFEDID, FEDNumbering::MAXTotemRPHorizontalFEDID)));
+    fb.insert(MK_P(CTPPSDIAMOND, MK_P(FEDNumbering::MINCTPPSDiamondFEDID, FEDNumbering::MAXCTPPSDiamondFEDID)));
+    fb.insert(MK_P(TOTEMRP_V, MK_P(FEDNumbering::MINTotemRPVerticalFEDID, FEDNumbering::MAXTotemRPVerticalFEDID)));
+    fb.insert(MK_P(TOTEMRP_T,
+                   MK_P(FEDNumbering::MINTotemRPTimingVerticalFEDID, FEDNumbering::MAXTotemRPTimingVerticalFEDID)));
+    fb.insert(MK_P(ECAL, MK_P(FEDNumbering::MINECALFEDID, FEDNumbering::MAXECALFEDID)));
+    fb.insert(MK_P(CASTOR, MK_P(FEDNumbering::MINCASTORFEDID, FEDNumbering::MAXCASTORFEDID)));
+    fb.insert(MK_P(HCAL, MK_P(FEDNumbering::MINHCALFEDID, FEDNumbering::MAXHCALFEDID)));
+    fb.insert(MK_P(CSC, MK_P(FEDNumbering::MINCSCFEDID, FEDNumbering::MAXCSCFEDID)));
+    fb.insert(MK_P(RPC, MK_P(FEDNumbering::MINRPCFEDID, FEDNumbering::MAXRPCFEDID)));
+    fb.insert(MK_P(HCALPHASE1, MK_P(FEDNumbering::MINHCALuTCAFEDID, FEDNumbering::MAXHCALuTCAFEDID)));
+    fb.insert(MK_P(SIPIXELPHASE1, MK_P(FEDNumbering::MINSiPixeluTCAFEDID, FEDNumbering::MAXSiPixeluTCAFEDID)));
+    fb.insert(MK_P(GEM, MK_P(FEDNumbering::MINGEMFEDID, FEDNumbering::MAXGEMFEDID)));
     return fb;
   }
 };  // namespace RunInfoPI

--- a/CondCore/RunInfoPlugins/interface/RunInfoPayloadInspectoHelper.h
+++ b/CondCore/RunInfoPlugins/interface/RunInfoPayloadInspectoHelper.h
@@ -11,6 +11,11 @@
 #include "TStyle.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
+// for the FED intervals
+#include "DataFormats/FEDRawData/interface/FEDNumbering.h"
+
+#define PAIR(a, b) std::make_pair(a, b)
+
 namespace RunInfoPI {
 
   enum state { fake = 0, valid = 1, invalid = 2 };
@@ -132,5 +137,46 @@ namespace RunInfoPI {
     }
   }
 
+  // FED bounds
+  enum DET {
+    SIPIXEL,
+    SISTRIP,
+    PRESHOWER,
+    TOTEMRP_H,
+    CTPPSDIAMOND,
+    TOTEMRP_V,
+    TOTEMRP_T,
+    ECAL,
+    CASTOR,
+    HCAL,
+    CSC,
+    RPC,
+    HCALPHASE1,
+    SIPIXELPHASE1,
+    GEM
+  };
+
+  using FEDMAP_T = std::map<RunInfoPI::DET, std::pair<int, int> >;
+
+  inline FEDMAP_T buildFEDBounds() {
+    static RunInfoPI::FEDMAP_T fb;
+    fb.insert(PAIR(SIPIXEL, PAIR(FEDNumbering::MINSiPixelFEDID, FEDNumbering::MAXSiPixelFEDID)));
+    fb.insert(PAIR(SISTRIP, PAIR(FEDNumbering::MINSiStripFEDID, FEDNumbering::MAXSiStripFEDID)));
+    fb.insert(PAIR(PRESHOWER, PAIR(FEDNumbering::MINPreShowerFEDID, FEDNumbering::MAXPreShowerFEDID)));
+    fb.insert(PAIR(TOTEMRP_H, PAIR(FEDNumbering::MINTotemRPHorizontalFEDID, FEDNumbering::MAXTotemRPHorizontalFEDID)));
+    fb.insert(PAIR(CTPPSDIAMOND, PAIR(FEDNumbering::MINCTPPSDiamondFEDID, FEDNumbering::MAXCTPPSDiamondFEDID)));
+    fb.insert(PAIR(TOTEMRP_V, PAIR(FEDNumbering::MINTotemRPVerticalFEDID, FEDNumbering::MAXTotemRPVerticalFEDID)));
+    fb.insert(PAIR(TOTEMRP_T,
+                   PAIR(FEDNumbering::MINTotemRPTimingVerticalFEDID, FEDNumbering::MAXTotemRPTimingVerticalFEDID)));
+    fb.insert(PAIR(ECAL, PAIR(FEDNumbering::MINECALFEDID, FEDNumbering::MAXECALFEDID)));
+    fb.insert(PAIR(CASTOR, PAIR(FEDNumbering::MINCASTORFEDID, FEDNumbering::MAXCASTORFEDID)));
+    fb.insert(PAIR(HCAL, PAIR(FEDNumbering::MINHCALFEDID, FEDNumbering::MAXHCALFEDID)));
+    fb.insert(PAIR(CSC, PAIR(FEDNumbering::MINCSCFEDID, FEDNumbering::MAXCSCFEDID)));
+    fb.insert(PAIR(RPC, PAIR(FEDNumbering::MINRPCFEDID, FEDNumbering::MAXRPCFEDID)));
+    fb.insert(PAIR(HCALPHASE1, PAIR(FEDNumbering::MINHCALuTCAFEDID, FEDNumbering::MAXHCALuTCAFEDID)));
+    fb.insert(PAIR(SIPIXELPHASE1, PAIR(FEDNumbering::MINSiPixeluTCAFEDID, FEDNumbering::MAXSiPixeluTCAFEDID)));
+    fb.insert(PAIR(GEM, PAIR(FEDNumbering::MINGEMFEDID, FEDNumbering::MAXGEMFEDID)));
+    return fb;
+  }
 };  // namespace RunInfoPI
 #endif

--- a/CondCore/RunInfoPlugins/plugins/RunInfo_PayloadInspector.cc
+++ b/CondCore/RunInfoPlugins/plugins/RunInfo_PayloadInspector.cc
@@ -137,16 +137,16 @@ namespace {
           if ((payload->m_avg_current) <= -1) {
             // go in error state
             h2_RunInfoState->SetBinContent(1, yBin, 0.);
-            theState = RunInfoPI::invalid;
+            theState = RunInfoPI::k_invalid;
           } else {
             // all is OK
             h2_RunInfoState->SetBinContent(1, yBin, 1.);
-            theState = RunInfoPI::valid;
+            theState = RunInfoPI::k_valid;
           }
         } else {
           // this is a fake payload
           h2_RunInfoState->SetBinContent(1, yBin, 0.9);
-          theState = RunInfoPI::fake;
+          theState = RunInfoPI::k_fake;
         }
         yBin--;
       }
@@ -187,13 +187,13 @@ namespace {
       ksPt.SetFillColor(0);
       const char* textToAdd;
       switch (theState) {
-        case RunInfoPI::fake:
+        case RunInfoPI::k_fake:
           textToAdd = "This is a fake RunInfoPayload";
           break;
-        case RunInfoPI::valid:
+        case RunInfoPI::k_valid:
           textToAdd = "This is a valid RunInfoPayload";
           break;
-        case RunInfoPI::invalid:
+        case RunInfoPI::k_invalid:
           textToAdd = "This is an invalid RunInfoPayload";
           break;
         default:

--- a/CondCore/SiStripPlugins/plugins/SiStripLatency_PayloadInspector.cc
+++ b/CondCore/SiStripPlugins/plugins/SiStripLatency_PayloadInspector.cc
@@ -43,9 +43,8 @@ namespace {
   using namespace cond::payloadInspector;
 
   /************************************************
-   ***************  test class ******************
+  // test class
   *************************************************/
-
   class SiStripLatencyTest : public Histogram1D<SiStripLatency, SINGLE_IOV> {
   public:
     SiStripLatencyTest()
@@ -91,10 +90,9 @@ namespace {
     }
   };
 
-  /****************************************************************************
-   *******************1D histo of mode as a function of the run****************
-   *****************************************************************************/
-
+  /************************************************
+  // historic trend plot of mode as a function of the run
+  ************************************************/
   class SiStripLatencyModeHistory : public HistoryPlot<SiStripLatency, uint16_t> {
   public:
     SiStripLatencyModeHistory() : HistoryPlot<SiStripLatency, uint16_t>("Mode vs run number", "Mode vs run number") {}
@@ -105,9 +103,21 @@ namespace {
     }
   };
 
-  /****************************************************************************    
-   *****************number of modes  per run *************************************
-   **************************************************************************/
+  /************************************************
+  // historic trend plot of mode as a function of the run
+  ************************************************/
+  class SiStripIsPeakModeHistory : public HistoryPlot<SiStripLatency, int16_t> {
+  public:
+    SiStripIsPeakModeHistory() : HistoryPlot<SiStripLatency, int16_t>("Mode vs run number", "Mode vs run number") {}
+    int16_t getFromPayload(SiStripLatency& payload) override {
+      uint16_t mode = payload.singleReadOutMode();
+      return mode;
+    }
+  };
+
+  /************************************************
+  // historic trend plot of number of modes per run
+  ************************************************/
   class SiStripLatencyNumbOfModeHistory : public HistoryPlot<SiStripLatency, int> {
   public:
     SiStripLatencyNumbOfModeHistory()
@@ -120,7 +130,6 @@ namespace {
       return modes.size();
     }
   };
-
 }  // namespace
 
 // Register the classes as boost python plugin
@@ -128,5 +137,6 @@ PAYLOAD_INSPECTOR_MODULE(SiStripLatency) {
   PAYLOAD_INSPECTOR_CLASS(SiStripLatencyTest);
   PAYLOAD_INSPECTOR_CLASS(SiStripLatencyMode);
   PAYLOAD_INSPECTOR_CLASS(SiStripLatencyModeHistory);
+  PAYLOAD_INSPECTOR_CLASS(SiStripIsPeakModeHistory);
   PAYLOAD_INSPECTOR_CLASS(SiStripLatencyNumbOfModeHistory);
 }

--- a/CondCore/SiStripPlugins/test/findPeakRuns.py
+++ b/CondCore/SiStripPlugins/test/findPeakRuns.py
@@ -1,19 +1,21 @@
+#!/usr/bin/env python3
+
 '''
-Script used to find all PEAK runs
+Script used to find all Strip Tracker PEAK runs
 
 Usage:
 
-create the list of SiStripLatency::singleReadOutMode() IOVs / values with:
+ create the list of SiStripLatency::singleReadOutMode() IOVs / values with:
 
-getPayloadData.py --plugin pluginSiStripLatency_PayloadInspector --plot plot_SiStripIsPeakModeHistory --tag SiStripLatency_GR10_v2_hlt --time_type Run --iovs '{"start_iov": "1", "end_iov": "400000"}' --db Prod --test > & log.json
+ getPayloadData.py --plugin pluginSiStripLatency_PayloadInspector --plot plot_SiStripIsPeakModeHistory --tag SiStripLatency_GR10_v2_hlt --time_type Run --iovs '{"start_iov": "1", "end_iov": "400000"}' --db Prod --test > & log.json
 
-create the list of runs with the Strip Tracker in global DAQ
+ create the list of runs with the Strip Tracker in global DAQ
 
-getPayloadData.py --plugin pluginRunInfo_PayloadInspector --plot plot_RunInfoTrackerHistory --tag runinfo_31X_hlt --time_type Run --iovs '{"start_iov": "1", "end_iov": "400000"}' --db Prod --test > & isTrackerin.json
+ getPayloadData.py --plugin pluginRunInfo_PayloadInspector --plot plot_RunInfoTrackerHistory --tag runinfo_31X_hlt --time_type Run --iovs '{"start_iov": "1", "end_iov": "400000"}' --db Prod --test > & isTrackerin.json
 
-followed by:
+ followed by:
 
-python findPeakRuns.py -f log.json -r isTrackerIn.json > & allTrackerRuns.csv &
+ python findPeakRuns.py -f log.json -r isTrackerIn.json > & allTrackerRuns.csv &
 '''
 
 from __future__ import print_function
@@ -23,8 +25,9 @@ from pprint import pprint
 from optparse import OptionParser
 import CondCore.Utilities.conddblib as conddb
 
-#__________________________________________
+##############################################
 def findPeakIOVs(values):
+##############################################
     listOfIOVs=[]
     listOfModes=[]
     lastMode=1
@@ -55,61 +58,99 @@ def findPeakIOVs(values):
 
     return dict(zip(listOfIOVs,listOfModes))
 
-parser = OptionParser()
-parser.add_option("-f", "--file", dest="filename",
-                  help="open FILE and extract info", metavar="FILE")
-parser.add_option("-r", "--runfile", dest="runfilename",
-                  help="open RUNFILE and extract info", metavar="RUNFILE")
-parser.add_option("-v", "--verbose",
-                  action="store_true", dest="verbose", default=False,
-                  help="Print PEAK/DECO dictionary")
+##############################################
+def getTkInDict(runvalues):
+##############################################
+    isTrackerIn = {}
+    for entry in runvalues:
+        isTrackerIn[entry['x']]=entry['y']
+    return isTrackerIn
 
-(options, args) = parser.parse_args()
+##############################################
+def getAllRuns():
+##############################################
+    con = conddb.connect(url = conddb.make_url("pro"))
+    session = con.session()
+    RUNINFO = session.get_dbtype(conddb.RunInfo)
+    allRuns = session.query(RUNINFO.run_number, RUNINFO.start_time, RUNINFO.end_time).all()
+    return allRuns
 
-with open(options.filename) as data_file:
-    data = json.load(data_file)
-    values = data["data"]
+##############################################
+def convert_timedelta(duration):
+##############################################
+    days, seconds = duration.days, duration.seconds
+    hours = days * 24 + seconds // 3600
+    minutes = (seconds % 3600) // 60
+    seconds = (seconds % 60)
+    return '{0:02}'.format(hours), '{0:02}'.format(minutes), '{0:02}'.format(seconds)
+
+##############################################
+def main():
+##############################################
+
+    parser = OptionParser()
+    parser.add_option("-f", "--file", dest="filename",
+                      help="open FILE and extract info", metavar="FILE")
+    parser.add_option("-r", "--runfile", dest="runfilename",
+                      help="open RUNFILE and extract info", metavar="RUNFILE")
+    parser.add_option("-v", "--verbose",
+                      action="store_true", dest="verbose", default=False,
+                      help="verbose output")
+    parser.add_option("-p", "--peakOnly",
+                      action="store_true", dest="peakOnly", default=False,
+                      help="Print only runs in PEAK mode")
+    (options, args) = parser.parse_args()
+
+    with open(options.filename) as data_file:
+        data = json.load(data_file)
+        values = data["data"]
     
-IOVs = findPeakIOVs(values)
-if(options.verbose):
-    pprint(IOVs)
+    IOVs = findPeakIOVs(values)
+    if(options.verbose):
+        pprint(IOVs)
 
-with open(options.runfilename) as rundata_file:
-    data = json.load(rundata_file)
-    runvalues = data["data"]
+    with open(options.runfilename) as rundata_file:
+        data = json.load(rundata_file)
+        runvalues = data["data"]
 
-isTrackerIn = {}
-for entry in runvalues:
-    isTrackerIn[entry['x']]=entry['y']
+    isTrackerIn = getTkInDict(runvalues)
 
-# for value in runvalues:
-#     isTrackerIn = bool(value['y'])
-#     runnumber = int(value['x'])
-#     if(not isTrackerIn):
-#         # there was no Tracker in this run
-#         continue
-#     else:
-#         for key, value in IOVs.items():
-#             if(key[0]<runnumber and key[1]>runnumber):
-#                 print(runnumber,",",key[0],"-",key[1],",",value
+    if(options.verbose):
+        for value in runvalues:
+            isTrackerIn = bool(value['y'])
+            runnumber = int(value['x'])
+            if(not isTrackerIn):
+                # there was no Tracker in this run
+                continue
+            else:
+                for key, value in IOVs.items():
+                    if(key[0]<runnumber and key[1]>runnumber):
+                        print(runnumber,",",key[0],"-",key[1],",",value)
 
-####################################
-# Get the whole list of runs
-####################################
-con = conddb.connect(url = conddb.make_url("pro"))
-session = con.session()
-RUNINFO = session.get_dbtype(conddb.RunInfo)
-allRuns = session.query(RUNINFO.run_number, RUNINFO.start_time, RUNINFO.end_time).all()
-for run in allRuns:
-    if run[0] not in isTrackerIn:
-        continue
-    if(isTrackerIn[run[0]]):
-        #print(run[0],"Tracker In")
-        for key, value in IOVs.items():
-            if(key[0]<run[0] and key[1]>run[0]):
-             #if(value=='PEAK'):
-             #    print(run[0],"(",run[1].strftime('%Y-%m-%d'),") [",key[0],"-",key[1],") which is ",value," mode")
-                print(run[0],",",run[1].strftime('%Y-%m-%d'),",",key[0],"-",key[1],",",value)
-    else:
-        pass
-        #print(run[0],"Tracker Out")
+    allRuns = getAllRuns()
+    if(options.verbose):
+        print(allRuns)
+
+    sorted_runs = sorted(allRuns)
+
+    for run in sorted_runs:
+        if run[0] not in isTrackerIn:
+            continue
+        if(isTrackerIn[run[0]]):
+            #print(run[0],"Tracker In")
+            for key, value in IOVs.items():
+                if(key[0]<run[0] and key[1]>run[0]):
+                    hours, minutes, seconds = convert_timedelta(run[2]-run[1])
+                    if(options.peakOnly):
+                        if(value=='PEAK'):
+                            print(run[0],",",run[1].strftime('%Y-%m-%d'),",",'{}:{}:{}'.format(hours,minutes,seconds),",",key[0],"-",key[1],",",value)
+                        else:
+                            pass
+                    else:
+                        print(run[0],",",run[1].strftime('%Y-%m-%d'),",",'{}:{}:{}'.format(hours,minutes,seconds),",",key[0],"-",key[1],",",value)
+        else:
+            pass
+            #print(run[0],"Tracker Out")
+
+if __name__ == "__main__":
+    main()

--- a/CondCore/SiStripPlugins/test/findPeakRuns.py
+++ b/CondCore/SiStripPlugins/test/findPeakRuns.py
@@ -1,0 +1,83 @@
+'''
+Script used to find all PEAK runs
+
+Usage:
+
+create the list of SiStripLatency::singleReadOutMode() IOVs / values with:
+getPayloadData.py --plugin pluginSiStripLatency_PayloadInspector --plot plot_SiStripIsPeakModeHistory --tag SiStripLatency_GR10_v2_hlt --time_type Run --iovs '{"start_iov": "1", "end_iov": "400000"}' --db Prod --test > & log.json 
+
+followed by:
+
+findPeakRuns.py -f log.json > allPeakRuns.log
+'''
+
+
+from __future__ import print_function
+import json
+import ROOT
+from pprint import pprint
+from optparse import OptionParser
+import CondCore.Utilities.conddblib as conddb
+
+#__________________________________________
+def findPeakIOVs(values):
+    listOfIOVs=[]
+    listOfModes=[]
+    lastMode=1
+    lastRun=1
+    
+    latestRun=-1
+    latestMode=-9999
+
+    for value in values:
+        if (value['y']!=lastMode):
+            listOfIOVs.append((lastRun,value['x']))
+            if(lastMode==1):
+                listOfModes.append('PEAK')
+            else:
+                listOfModes.append('DECO')
+            lastMode=value['y']
+            lastRun=value['x']
+        else:
+            latestRun=value['x']
+            if(value['y']==1):
+                latestMode='PEAK'
+            else:
+                latestMode='DECO'
+
+    ## special case for the last open IOV
+    listOfIOVs.append((lastRun,999999))
+    listOfModes.append(latestMode)
+
+    return dict(zip(listOfIOVs,listOfModes))
+
+parser = OptionParser()
+parser.add_option("-f", "--file", dest="filename",
+                  help="open FILE and extract info", metavar="FILE")
+parser.add_option("-v", "--verbose",
+                  action="store_true", dest="verbose", default=False,
+                  help="Print PEAK/DECO dictionary")
+
+(options, args) = parser.parse_args()
+
+with open(options.filename) as data_file:    
+    data = json.load(data_file)
+    values = data["data"]
+    
+IOVs = findPeakIOVs(values)
+if(options.verbose):
+    pprint(IOVs)
+
+con = conddb.connect(url = conddb.make_url("pro"))
+session = con.session()
+RUNINFO = session.get_dbtype(conddb.RunInfo)
+
+####################################
+# Get the whole list of runs
+####################################
+AllRuns = session.query(RUNINFO.run_number, RUNINFO.start_time, RUNINFO.end_time).all()
+for run in AllRuns:
+    for key, value in IOVs.items():
+        if(key[0]<run[0] and key[1]>run[0]):
+            if(value=='PEAK'):
+                print(run[0],"(",run[1],") IOV [",key[0],"-",key[1],") which is ",value," mode")

--- a/CondCore/SiStripPlugins/test/findPeakRuns.py
+++ b/CondCore/SiStripPlugins/test/findPeakRuns.py
@@ -4,13 +4,17 @@ Script used to find all PEAK runs
 Usage:
 
 create the list of SiStripLatency::singleReadOutMode() IOVs / values with:
-getPayloadData.py --plugin pluginSiStripLatency_PayloadInspector --plot plot_SiStripIsPeakModeHistory --tag SiStripLatency_GR10_v2_hlt --time_type Run --iovs '{"start_iov": "1", "end_iov": "400000"}' --db Prod --test > & log.json 
+
+getPayloadData.py --plugin pluginSiStripLatency_PayloadInspector --plot plot_SiStripIsPeakModeHistory --tag SiStripLatency_GR10_v2_hlt --time_type Run --iovs '{"start_iov": "1", "end_iov": "400000"}' --db Prod --test > & log.json
+
+create the list of runs with the Strip Tracker in global DAQ
+
+getPayloadData.py --plugin pluginRunInfo_PayloadInspector --plot plot_RunInfoTrackerHistory --tag runinfo_31X_hlt --time_type Run --iovs '{"start_iov": "1", "end_iov": "400000"}' --db Prod --test > & isTrackerin.json
 
 followed by:
 
-findPeakRuns.py -f log.json > allPeakRuns.log
+python findPeakRuns.py -f log.json -r isTrackerIn.json > & allTrackerRuns.csv &
 '''
-
 
 from __future__ import print_function
 import json
@@ -54,13 +58,15 @@ def findPeakIOVs(values):
 parser = OptionParser()
 parser.add_option("-f", "--file", dest="filename",
                   help="open FILE and extract info", metavar="FILE")
+parser.add_option("-r", "--runfile", dest="runfilename",
+                  help="open RUNFILE and extract info", metavar="RUNFILE")
 parser.add_option("-v", "--verbose",
                   action="store_true", dest="verbose", default=False,
                   help="Print PEAK/DECO dictionary")
 
 (options, args) = parser.parse_args()
 
-with open(options.filename) as data_file:    
+with open(options.filename) as data_file:
     data = json.load(data_file)
     values = data["data"]
     
@@ -68,16 +74,42 @@ IOVs = findPeakIOVs(values)
 if(options.verbose):
     pprint(IOVs)
 
-con = conddb.connect(url = conddb.make_url("pro"))
-session = con.session()
-RUNINFO = session.get_dbtype(conddb.RunInfo)
+with open(options.runfilename) as rundata_file:
+    data = json.load(rundata_file)
+    runvalues = data["data"]
+
+isTrackerIn = {}
+for entry in runvalues:
+    isTrackerIn[entry['x']]=entry['y']
+
+# for value in runvalues:
+#     isTrackerIn = bool(value['y'])
+#     runnumber = int(value['x'])
+#     if(not isTrackerIn):
+#         # there was no Tracker in this run
+#         continue
+#     else:
+#         for key, value in IOVs.items():
+#             if(key[0]<runnumber and key[1]>runnumber):
+#                 print(runnumber,",",key[0],"-",key[1],",",value
 
 ####################################
 # Get the whole list of runs
 ####################################
-AllRuns = session.query(RUNINFO.run_number, RUNINFO.start_time, RUNINFO.end_time).all()
-for run in AllRuns:
-    for key, value in IOVs.items():
-        if(key[0]<run[0] and key[1]>run[0]):
-            if(value=='PEAK'):
-                print(run[0],"(",run[1],") IOV [",key[0],"-",key[1],") which is ",value," mode")
+con = conddb.connect(url = conddb.make_url("pro"))
+session = con.session()
+RUNINFO = session.get_dbtype(conddb.RunInfo)
+allRuns = session.query(RUNINFO.run_number, RUNINFO.start_time, RUNINFO.end_time).all()
+for run in allRuns:
+    if run[0] not in isTrackerIn:
+        continue
+    if(isTrackerIn[run[0]]):
+        #print(run[0],"Tracker In")
+        for key, value in IOVs.items():
+            if(key[0]<run[0] and key[1]>run[0]):
+             #if(value=='PEAK'):
+             #    print(run[0],"(",run[1].strftime('%Y-%m-%d'),") [",key[0],"-",key[1],") which is ",value," mode")
+                print(run[0],",",run[1].strftime('%Y-%m-%d'),",",key[0],"-",key[1],",",value)
+    else:
+        pass
+        #print(run[0],"Tracker Out")


### PR DESCRIPTION
#### PR description:
Added tools to retrieve list of Strip Tracker peak mode runs;

   * adds `RunInfoDetHistory` in `RunInfo_PayloadInspector` to create history plot of given subdetector presence in a run;
   * adds ` SiStripIsPeakModeHistory` in `SiStripLatency_PayloadInspector` to create historic trend plot of mode as a function of the run;
   * adds script to create list of Strip Tracker peak mode runs;

#### PR validation:

Private

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A
