### PR TITLE
[XrdAdaptor] Modifications for xrootd-5.3

### DIFF
--- a/Utilities/XrdAdaptor/BuildFile.xml
+++ b/Utilities/XrdAdaptor/BuildFile.xml
@@ -5,6 +5,4 @@
 <use name="FWCore/Utilities"/>
 <use name="FWCore/MessageLogger"/>
 <use name="xrootd"/>
-<lib name="XrdCl"/>
-<lib name="XrdUtils"/>
 <flags CPPDEFINES="_FILE_OFFSET_BITS=64"/>

--- a/Utilities/XrdAdaptor/plugins/BuildFile.xml
+++ b/Utilities/XrdAdaptor/plugins/BuildFile.xml
@@ -1,7 +1,6 @@
 <library file="XrdStorageMaker.cc" name="UtilitiesXrdAdaptorPlugin">
   <use name="Utilities/StorageFactory"/>
   <use name="Utilities/XrdAdaptor"/>
-  <lib name="XrdCl"/>
   <flags EDM_PLUGIN="1"/>
   <flags CXXFLAGS="-D_FILE_OFFSET_BITS=64"/>
 </library>

--- a/Utilities/XrdAdaptor/plugins/XrdStorageMaker.cc
+++ b/Utilities/XrdAdaptor/plugins/XrdStorageMaker.cc
@@ -28,7 +28,7 @@ public:
     auto status = m_fs.Prepare(m_fileList, XrdCl::PrepareFlags::Stage, 0, this);
     if (!status.IsOK()) {
       LogDebug("StageInError") << "XrdCl::FileSystem::Prepare submit failed with error '" << status.ToStr()
-                                    << "' (errNo = " << status.errNo << ")";
+                               << "' (errNo = " << status.errNo << ")";
       delete this;
     }
   }
@@ -37,7 +37,7 @@ public:
     // Note: Prepare call has a response object.
     if (!status->IsOK()) {
       LogDebug("StageInError") << "XrdCl::FileSystem::Prepare failed with error '" << status->ToStr()
-                                    << "' (errNo = " << status->errNo << ")";
+                               << "' (errNo = " << status->errNo << ")";
     }
     delete response;
     delete status;

--- a/Utilities/XrdAdaptor/plugins/XrdStorageMaker.cc
+++ b/Utilities/XrdAdaptor/plugins/XrdStorageMaker.cc
@@ -18,38 +18,36 @@
 
 namespace {
 
-class PrepareHandler : public XrdCl::ResponseHandler {
-public:
-  PrepareHandler(const XrdCl::URL &url) : m_fs(url) {
-    m_fileList.push_back(url.GetPath());
-  }
+  class PrepareHandler : public XrdCl::ResponseHandler {
+  public:
+    PrepareHandler(const XrdCl::URL &url) : m_fs(url) { m_fileList.push_back(url.GetPath()); }
 
-  void callAsyncPrepare() {
-    auto status = m_fs.Prepare(m_fileList, XrdCl::PrepareFlags::Stage, 0, this);
-    if (!status.IsOK()) {
-      LogDebug("StageInError") << "XrdCl::FileSystem::Prepare submit failed with error '" << status.ToStr()
-                               << "' (errNo = " << status.errNo << ")";
+    void callAsyncPrepare() {
+      auto status = m_fs.Prepare(m_fileList, XrdCl::PrepareFlags::Stage, 0, this);
+      if (!status.IsOK()) {
+        LogDebug("StageInError") << "XrdCl::FileSystem::Prepare submit failed with error '" << status.ToStr()
+                                 << "' (errNo = " << status.errNo << ")";
+        delete this;
+      }
+    }
+
+    void HandleResponse(XrdCl::XRootDStatus *status, XrdCl::AnyObject *response) override {
+      // Note: Prepare call has a response object.
+      if (!status->IsOK()) {
+        LogDebug("StageInError") << "XrdCl::FileSystem::Prepare failed with error '" << status->ToStr()
+                                 << "' (errNo = " << status->errNo << ")";
+      }
+      delete response;
+      delete status;
       delete this;
     }
-  }
 
-  void HandleResponse(XrdCl::XRootDStatus *status, XrdCl::AnyObject *response) override {
-    // Note: Prepare call has a response object.
-    if (!status->IsOK()) {
-      LogDebug("StageInError") << "XrdCl::FileSystem::Prepare failed with error '" << status->ToStr()
-                               << "' (errNo = " << status->errNo << ")";
-    }
-    delete response;
-    delete status;
-    delete this;
-  }
+  private:
+    XrdCl::FileSystem m_fs;
+    std::vector<std::string> m_fileList;
+  };
 
-private:
-  XrdCl::FileSystem m_fs;
-  std::vector<std::string> m_fileList;
-};
-
-}
+}  // namespace
 
 class XrdStorageMaker final : public StorageMaker {
 public:

--- a/Utilities/XrdAdaptor/plugins/XrdStorageMaker.cc
+++ b/Utilities/XrdAdaptor/plugins/XrdStorageMaker.cc
@@ -75,9 +75,11 @@ public:
     std::string fullpath(proto + ":" + path);
     XrdCl::URL url(fullpath);
     XrdCl::FileSystem fs(url);
+    XrdCl::Buffer *buffer = nullptr;
     std::vector<std::string> fileList;
     fileList.push_back(url.GetPath());
-    auto status = fs.Prepare(fileList, XrdCl::PrepareFlags::Stage, 0, &m_null_handler);
+    auto status = fs.Prepare(fileList, XrdCl::PrepareFlags::Stage, 0, buffer);
+    delete buffer;
     if (!status.IsOK()) {
       edm::LogWarning("StageInError") << "XrdCl::FileSystem::Prepare failed with error '" << status.ToStr()
                                       << "' (errNo = " << status.errNo << ")";

--- a/Utilities/XrdAdaptor/plugins/XrdStorageMaker.cc
+++ b/Utilities/XrdAdaptor/plugins/XrdStorageMaker.cc
@@ -16,14 +16,40 @@
 #include <atomic>
 #include <mutex>
 
-class MakerResponseHandler : public XrdCl::ResponseHandler {
+namespace {
+
+class PrepareHandler : public XrdCl::ResponseHandler {
 public:
+  PrepareHandler(const XrdCl::URL &url) : m_fs(url) {
+    m_fileList.push_back(url.GetPath());
+  }
+
+  void callAsyncPrepare() {
+    auto status = m_fs.Prepare(m_fileList, XrdCl::PrepareFlags::Stage, 0, this);
+    if (!status.IsOK()) {
+      LogDebug("StageInError") << "XrdCl::FileSystem::Prepare submit failed with error '" << status.ToStr()
+                                    << "' (errNo = " << status.errNo << ")";
+      delete this;
+    }
+  }
+
   void HandleResponse(XrdCl::XRootDStatus *status, XrdCl::AnyObject *response) override {
     // Note: Prepare call has a response object.
+    if (!status->IsOK()) {
+      LogDebug("StageInError") << "XrdCl::FileSystem::Prepare failed with error '" << status->ToStr()
+                                    << "' (errNo = " << status->errNo << ")";
+    }
     delete response;
     delete status;
+    delete this;
   }
+
+private:
+  XrdCl::FileSystem m_fs;
+  std::vector<std::string> m_fileList;
 };
+
+}
 
 class XrdStorageMaker final : public StorageMaker {
 public:
@@ -74,16 +100,9 @@ public:
 
     std::string fullpath(proto + ":" + path);
     XrdCl::URL url(fullpath);
-    XrdCl::FileSystem fs(url);
-    XrdCl::Buffer *buffer = nullptr;
-    std::vector<std::string> fileList;
-    fileList.push_back(url.GetPath());
-    auto status = fs.Prepare(fileList, XrdCl::PrepareFlags::Stage, 0, buffer);
-    delete buffer;
-    if (!status.IsOK()) {
-      edm::LogWarning("StageInError") << "XrdCl::FileSystem::Prepare failed with error '" << status.ToStr()
-                                      << "' (errNo = " << status.errNo << ")";
-    }
+
+    auto prep_handler = new PrepareHandler(url);
+    prep_handler->callAsyncPrepare();
   }
 
   bool check(const std::string &proto,
@@ -175,7 +194,6 @@ public:
   }
 
 private:
-  CMS_THREAD_SAFE mutable MakerResponseHandler m_null_handler;
   mutable std::mutex m_envMutex;
   mutable std::atomic<unsigned int> m_lastDebugLevel;
   mutable std::atomic<unsigned int> m_lastTimeout;

--- a/Utilities/XrdAdaptor/src/XrdHostHandler.hh
+++ b/Utilities/XrdAdaptor/src/XrdHostHandler.hh
@@ -4,14 +4,6 @@
 #include "XrdCl/XrdClXRootDResponses.hh"
 #include "FWCore/Utilities/interface/get_underlying_safe.h"
 
-#if defined(__linux__)
-#define HAVE_ATOMICS 1
-#include "XrdSys/XrdSysLinuxSemaphore.hh"
-typedef XrdSys::LinuxSemaphore Semaphore;
-#else
-typedef XrdSysSemaphore Semaphore;
-#endif
-
 /**
  * The SyncResponseHandler from the XrdCl does not
  * preserve the hostinfo list, which we would like to
@@ -53,7 +45,7 @@ private:
   edm::propagate_const<std::unique_ptr<XrdCl::XRootDStatus>> pStatus_;
   edm::propagate_const<std::unique_ptr<XrdCl::AnyObject>> pResponse_;
   edm::propagate_const<std::unique_ptr<XrdCl::HostList>> pHostList_;
-  Semaphore sem;
+  XrdSysSemaphore sem;
 };
 
 #endif

--- a/Utilities/XrdAdaptor/src/XrdRequestManager.cc
+++ b/Utilities/XrdAdaptor/src/XrdRequestManager.cc
@@ -555,9 +555,9 @@ std::string RequestManager::prepareOpaqueString() const {
   struct {
     std::stringstream ss;
     size_t count = 0;
-    bool   has_active = false;
+    bool has_active = false;
 
-    void append_tried(const std::string& id, bool active = false) {
+    void append_tried(const std::string &id, bool active = false) {
       ss << (count ? "," : "tried=") << id;
       count++;
       if (active) {
@@ -579,7 +579,7 @@ std::string RequestManager::prepareOpaqueString() const {
     state.append_tried(it.substr(0, it.find(':')));
   }
   if (state.has_active) {
-      state.ss << "&triedrc=resel";
+    state.ss << "&triedrc=resel";
   }
 
   return state.ss.str();

--- a/Utilities/XrdAdaptor/src/XrdRequestManager.cc
+++ b/Utilities/XrdAdaptor/src/XrdRequestManager.cc
@@ -552,30 +552,37 @@ std::future<IOSize> RequestManager::handle(std::shared_ptr<XrdAdaptor::ClientReq
 }
 
 std::string RequestManager::prepareOpaqueString() const {
-  std::stringstream ss;
-  ss << "tried=";
-  size_t count = 0;
+  struct {
+    std::stringstream ss;
+    size_t count = 0;
+    bool   has_active = false;
+
+    void append_tried(const std::string& id, bool active = false) {
+      ss << (count ? "," : "tried=") << id;
+      count++;
+      if (active) {
+        has_active = true;
+      }
+    }
+  } state;
   {
     std::lock_guard<std::recursive_mutex> sentry(m_source_mutex);
 
     for (const auto &it : m_activeSources) {
-      count++;
-      ss << it->ExcludeID().substr(0, it->ExcludeID().find(':')) << ",";
+      state.append_tried(it->ExcludeID().substr(0, it->ExcludeID().find(':')), true);
     }
     for (const auto &it : m_inactiveSources) {
-      count++;
-      ss << it->ExcludeID().substr(0, it->ExcludeID().find(':')) << ",";
+      state.append_tried(it->ExcludeID().substr(0, it->ExcludeID().find(':')));
     }
   }
   for (const auto &it : m_disabledExcludeStrings) {
-    count++;
-    ss << it.substr(0, it.find(':')) << ",";
+    state.append_tried(it.substr(0, it.find(':')));
   }
-  if (count) {
-    std::string tmp_str = ss.str();
-    return tmp_str.substr(0, tmp_str.size() - 1);
+  if (state.has_active) {
+      state.ss << "&triedrc=resel";
   }
-  return "";
+
+  return state.ss.str();
 }
 
 void XrdAdaptor::RequestManager::handleOpen(XrdCl::XRootDStatus &status, std::shared_ptr<Source> source) {
@@ -1018,6 +1025,13 @@ void XrdAdaptor::RequestManager::OpenHandler::HandleResponseWithHosts(XrdCl::XRo
          << "' (errno=" << status->errNo << ", code=" << status->code << ")";
       ex.addContext("In XrdAdaptor::RequestManager::OpenHandler::HandleResponseWithHosts()");
       manager->addConnections(ex);
+
+      // Brian, should we do something like this:
+      // if (status.status == XrdCl::errRedirectLimit) {
+      //   // The following method does not exist (yet), would probaly need a multiplier for OPEN_DELAY.
+      //   // Note that with XCache cluster one will never get multiple sources.
+      //   manager->increaseMultiSourceInterval();
+      // }
 
       m_promise.set_exception(std::make_exception_ptr(ex));
     }


### PR DESCRIPTION
1. Replace usage of XrdSys::LinuxSemaphore with XrdSysSemaphore. This goes along with cms-sw/cmsdist#7180.
2. When opening additional files for multi-source include triedrc=rese. This addresses #28716.

There is one issue and a possible improvement ... I'll add those as separate comments.
