### PR TITLE
[HGCAL] Updates on the RelVal campaign scripts due to python3 and other PRs

### DIFF
--- a/Validation/HGCalValidation/python/html.py
+++ b/Validation/HGCalValidation/python/html.py
@@ -161,7 +161,7 @@ summlc = [
 
 #Plots to keep in summary from ticlMultiClustersFromTrackstersEM
 summmcEM = [
-    'ticlTrackstersEM/Efficiencies/globalEfficiencies.png' ,
+    'ticlTrackstersEM/Purities/globalEfficiencies.png' ,
     'ticlTrackstersEM/Duplicates/globalEfficiencies.png' ,
     'ticlTrackstersEM/FakeRate/globalEfficiencies.png' ,
     'ticlTrackstersEM/MergeRate/globalEfficiencies.png'
@@ -169,7 +169,7 @@ summmcEM = [
 
 #Plots to keep in summary from ticlMultiClustersFromTrackstersHAD
 summmcHAD = [
-    'ticlTrackstersHAD/Efficiencies/globalEfficiencies.png' ,
+    'ticlTrackstersHAD/Purities/globalEfficiencies.png' ,
     'ticlTrackstersHAD/Duplicates/globalEfficiencies.png' ,
     'ticlTrackstersHAD/FakeRate/globalEfficiencies.png' ,
     'ticlTrackstersHAD/MergeRate/globalEfficiencies.png'

--- a/Validation/HGCalValidation/python/html.py
+++ b/Validation/HGCalValidation/python/html.py
@@ -97,7 +97,7 @@ _pageNameMap = {
     "summary": "Summary",
     "hitCalibration": "Reconstructed hits calibration",
     "hitValidation" : "Simulated hits, digis, reconstructed hits validation" , 
-    "hgcalLayerClusters": "Layer clusters",
+    "layerClusters": "Layer clusters",
     "tracksters":"Tracksters", 
     "ticlMultiClustersFromTrackstersEM": "Electromagnetic multiclusters",
     "ticlMultiClustersFromTrackstersHAD": "Hadronic multiclusters",
@@ -108,8 +108,8 @@ _pageNameMap = {
 _sectionNameMapOrder = collections.OrderedDict([
     # These are for the summary page
     # Will add later
-    # hgcalLayerClusters
-    ("hgcalLayerClusters", "Layer clusters"),
+    # layerClusters
+    ("layerClusters", "Layer clusters"),
     # ticlMultiClustersFromTrackstersEM
     ("ticlMultiClustersFromTrackstersEM","Electromagnetic multiclusters"),
     # ticlMultiClustersFromTrackstersHAD
@@ -124,8 +124,8 @@ _summary = {}
 
 #Objects to keep in summary
 #_summobj = ['hitCalibration','hitValidation', 'hgcalLayerClusters','ticlMultiClustersFromTrackstersEM','ticlMultiClustersFromTrackstersHAD']
-_summobj = ['hitCalibration','hitValidation', 'hgcalLayerClusters','tracksters']
-#_summobj = ['hitCalibration','hitValidation', 'hgcalLayerClusters']
+_summobj = ['hitCalibration','hitValidation', 'layerClusters','tracksters']
+#_summobj = ['hitCalibration','hitValidation', 'layerClusters']
 
 #Plots to keep in summary from hitCalibration
 summhitcalib=[
@@ -144,14 +144,14 @@ summhitvalid = [
                           
 #Plots to keep in summary from layer clusters
 summlc = [
-    'hgcalLayerClusters_Z-minus: LC_CP association/Efficiencies_vs_layer/globalEfficiencies.png' ,
-    'hgcalLayerClusters_Z-plus: LC_CP association/Efficiencies_vs_layer/globalEfficiencies.png' ,
-    'hgcalLayerClusters_Z-minus: LC_CP association/Duplicates_vs_layer/globalEfficiencies.png' ,
-    'hgcalLayerClusters_Z-plus: LC_CP association/Duplicates_vs_layer/globalEfficiencies.png' ,
-    'hgcalLayerClusters_Z-minus: LC_CP association/FakeRate_vs_layer/globalEfficiencies.png' ,
-    'hgcalLayerClusters_Z-plus: LC_CP association/FakeRate_vs_layer/globalEfficiencies.png' ,
-    'hgcalLayerClusters_Z-minus: LC_CP association/MergeRate_vs_layer/globalEfficiencies.png' ,
-    'hgcalLayerClusters_Z-plus: LC_CP association/MergeRate_vs_layer/globalEfficiencies.png',
+    'layerClusters_Z-minus: LC_CP association/Efficiencies_vs_layer/globalEfficiencies.png' ,
+    'layerClusters_Z-plus: LC_CP association/Efficiencies_vs_layer/globalEfficiencies.png' ,
+    'layerClusters_Z-minus: LC_CP association/Duplicates_vs_layer/globalEfficiencies.png' ,
+    'layerClusters_Z-plus: LC_CP association/Duplicates_vs_layer/globalEfficiencies.png' ,
+    'layerClusters_Z-minus: LC_CP association/FakeRate_vs_layer/globalEfficiencies.png' ,
+    'layerClusters_Z-plus: LC_CP association/FakeRate_vs_layer/globalEfficiencies.png' ,
+    'layerClusters_Z-minus: LC_CP association/MergeRate_vs_layer/globalEfficiencies.png' ,
+    'layerClusters_Z-plus: LC_CP association/MergeRate_vs_layer/globalEfficiencies.png',
     'SelectedCaloParticles_Photons/SelectedCaloParticles_num_caloparticle_eta.png',
     'SelectedCaloParticles_Photons/SelectedCaloParticles_caloparticle_pt.png',
     'SelectedCaloParticles_Photons/SelectedCaloParticles_caloparticle_phi.png',
@@ -187,7 +187,7 @@ for obj in _summobj:
     _summary[obj] = {}
 _summary['hitCalibration'] = summhitcalib
 _summary['hitValidation'] = summhitvalid
-_summary['hgcalLayerClusters'] = summlc
+_summary['layerClusters'] = summlc
 _summary['allTiclMultiClusters'] = summmcTICL
 #_summary['ticlMultiClustersFromTrackstersEM'] = summmcEM
 #_summary['ticlMultiClustersFromTrackstersHAD'] = summmcHAD                          

--- a/Validation/HGCalValidation/python/html.py
+++ b/Validation/HGCalValidation/python/html.py
@@ -98,7 +98,7 @@ _pageNameMap = {
     "hitCalibration": "Reconstructed hits calibration",
     "hitValidation" : "Simulated hits, digis, reconstructed hits validation" , 
     "hgcalLayerClusters": "Layer clusters",
-    "allTiclMultiClusters":"TICL multiclusters", 
+    "tracksters":"Tracksters", 
     "ticlMultiClustersFromTrackstersEM": "Electromagnetic multiclusters",
     "ticlMultiClustersFromTrackstersHAD": "Hadronic multiclusters",
     "hgcalMultiClusters" : "Old multiclusters",
@@ -114,7 +114,7 @@ _sectionNameMapOrder = collections.OrderedDict([
     ("ticlMultiClustersFromTrackstersEM","Electromagnetic multiclusters"),
     # ticlMultiClustersFromTrackstersHAD
     ("ticlMultiClustersFromTrackstersHAD","Hadronic multiclusters"),
-    ("allTiclMultiClusters","TICL multiclusters"),
+    ("tracksters","Tracksters"),
     # hgcalMultiClusters
     ("hgcalMultiClusters","Old multiclusters"),
 ])
@@ -124,7 +124,7 @@ _summary = {}
 
 #Objects to keep in summary
 #_summobj = ['hitCalibration','hitValidation', 'hgcalLayerClusters','ticlMultiClustersFromTrackstersEM','ticlMultiClustersFromTrackstersHAD']
-_summobj = ['hitCalibration','hitValidation', 'hgcalLayerClusters','allTiclMultiClusters']
+_summobj = ['hitCalibration','hitValidation', 'hgcalLayerClusters','tracksters']
 #_summobj = ['hitCalibration','hitValidation', 'hgcalLayerClusters']
 
 #Plots to keep in summary from hitCalibration

--- a/Validation/HGCalValidation/python/html.py
+++ b/Validation/HGCalValidation/python/html.py
@@ -161,18 +161,18 @@ summlc = [
 
 #Plots to keep in summary from ticlMultiClustersFromTrackstersEM
 summmcEM = [
-    'ticlMultiClustersFromTrackstersEM/Efficiencies/globalEfficiencies.png' ,
-    'ticlMultiClustersFromTrackstersEM/Duplicates/globalEfficiencies.png' ,
-    'ticlMultiClustersFromTrackstersEM/FakeRate/globalEfficiencies.png' ,
-    'ticlMultiClustersFromTrackstersEM/MergeRate/globalEfficiencies.png'
+    'ticlTrackstersEM/Efficiencies/globalEfficiencies.png' ,
+    'ticlTrackstersEM/Duplicates/globalEfficiencies.png' ,
+    'ticlTrackstersEM/FakeRate/globalEfficiencies.png' ,
+    'ticlTrackstersEM/MergeRate/globalEfficiencies.png'
 ]
 
 #Plots to keep in summary from ticlMultiClustersFromTrackstersHAD
 summmcHAD = [
-    'ticlMultiClustersFromTrackstersHAD/Efficiencies/globalEfficiencies.png' ,
-    'ticlMultiClustersFromTrackstersHAD/Duplicates/globalEfficiencies.png' ,
-    'ticlMultiClustersFromTrackstersHAD/FakeRate/globalEfficiencies.png' ,
-    'ticlMultiClustersFromTrackstersHAD/MergeRate/globalEfficiencies.png'
+    'ticlTrackstersHAD/Efficiencies/globalEfficiencies.png' ,
+    'ticlTrackstersHAD/Duplicates/globalEfficiencies.png' ,
+    'ticlTrackstersHAD/FakeRate/globalEfficiencies.png' ,
+    'ticlTrackstersHAD/MergeRate/globalEfficiencies.png'
 ]
 
 summmcTICL = summmcEM + summmcHAD
@@ -188,7 +188,8 @@ for obj in _summobj:
 _summary['hitCalibration'] = summhitcalib
 _summary['hitValidation'] = summhitvalid
 _summary['layerClusters'] = summlc
-_summary['allTiclMultiClusters'] = summmcTICL
+_summary['tracksters'] = summmcTICL
+#_summary['allTiclMultiClusters'] = summmcTICL
 #_summary['ticlMultiClustersFromTrackstersEM'] = summmcEM
 #_summary['ticlMultiClustersFromTrackstersHAD'] = summmcHAD                          
 

--- a/Validation/HGCalValidation/python/html.py
+++ b/Validation/HGCalValidation/python/html.py
@@ -144,14 +144,14 @@ summhitvalid = [
                           
 #Plots to keep in summary from layer clusters
 summlc = [
-    'layerClusters_Z-minus: LC_CP association/Efficiencies_vs_layer/globalEfficiencies.png' ,
-    'layerClusters_Z-plus: LC_CP association/Efficiencies_vs_layer/globalEfficiencies.png' ,
-    'layerClusters_Z-minus: LC_CP association/Duplicates_vs_layer/globalEfficiencies.png' ,
-    'layerClusters_Z-plus: LC_CP association/Duplicates_vs_layer/globalEfficiencies.png' ,
-    'layerClusters_Z-minus: LC_CP association/FakeRate_vs_layer/globalEfficiencies.png' ,
-    'layerClusters_Z-plus: LC_CP association/FakeRate_vs_layer/globalEfficiencies.png' ,
-    'layerClusters_Z-minus: LC_CP association/MergeRate_vs_layer/globalEfficiencies.png' ,
-    'layerClusters_Z-plus: LC_CP association/MergeRate_vs_layer/globalEfficiencies.png',
+    'hgcalLayerClusters_Z-minus: LC_CP association/Efficiencies_vs_layer/globalEfficiencies.png' ,
+    'hgcalLayerClusters_Z-plus: LC_CP association/Efficiencies_vs_layer/globalEfficiencies.png' ,
+    'hgcalLayerClusters_Z-minus: LC_CP association/Duplicates_vs_layer/globalEfficiencies.png' ,
+    'hgcalLayerClusters_Z-plus: LC_CP association/Duplicates_vs_layer/globalEfficiencies.png' ,
+    'hgcalLayerClusters_Z-minus: LC_CP association/FakeRate_vs_layer/globalEfficiencies.png' ,
+    'hgcalLayerClusters_Z-plus: LC_CP association/FakeRate_vs_layer/globalEfficiencies.png' ,
+    'hgcalLayerClusters_Z-minus: LC_CP association/MergeRate_vs_layer/globalEfficiencies.png' ,
+    'hgcalLayerClusters_Z-plus: LC_CP association/MergeRate_vs_layer/globalEfficiencies.png',
     'SelectedCaloParticles_Photons/SelectedCaloParticles_num_caloparticle_eta.png',
     'SelectedCaloParticles_Photons/SelectedCaloParticles_caloparticle_pt.png',
     'SelectedCaloParticles_Photons/SelectedCaloParticles_caloparticle_phi.png',

--- a/Validation/HGCalValidation/python/html.py
+++ b/Validation/HGCalValidation/python/html.py
@@ -144,21 +144,20 @@ summhitvalid = [
                           
 #Plots to keep in summary from layer clusters
 summlc = [
-    'hgcalLayerClusters_zminus/Efficiencies_vs_layer/globalEfficiencies.png' ,
-    'hgcalLayerClusters_zplus/Efficiencies_vs_layer/globalEfficiencies.png' ,
-    'hgcalLayerClusters_zminus/Duplicates_vs_layer/globalEfficiencies.png' ,
-    'hgcalLayerClusters_zplus/Duplicates_vs_layer/globalEfficiencies.png' ,
-    'hgcalLayerClusters_zminus/FakeRate_vs_layer/globalEfficiencies.png' ,
-    'hgcalLayerClusters_zplus/FakeRate_vs_layer/globalEfficiencies.png' ,
-    'hgcalLayerClusters_zminus/MergeRate_vs_layer/globalEfficiencies.png' ,
-    'hgcalLayerClusters_zplus/MergeRate_vs_layer/globalEfficiencies.png',
+    'hgcalLayerClusters_Z-minus: LC_CP association/Efficiencies_vs_layer/globalEfficiencies.png' ,
+    'hgcalLayerClusters_Z-plus: LC_CP association/Efficiencies_vs_layer/globalEfficiencies.png' ,
+    'hgcalLayerClusters_Z-minus: LC_CP association/Duplicates_vs_layer/globalEfficiencies.png' ,
+    'hgcalLayerClusters_Z-plus: LC_CP association/Duplicates_vs_layer/globalEfficiencies.png' ,
+    'hgcalLayerClusters_Z-minus: LC_CP association/FakeRate_vs_layer/globalEfficiencies.png' ,
+    'hgcalLayerClusters_Z-plus: LC_CP association/FakeRate_vs_layer/globalEfficiencies.png' ,
+    'hgcalLayerClusters_Z-minus: LC_CP association/MergeRate_vs_layer/globalEfficiencies.png' ,
+    'hgcalLayerClusters_Z-plus: LC_CP association/MergeRate_vs_layer/globalEfficiencies.png',
     'SelectedCaloParticles_Photons/SelectedCaloParticles_num_caloparticle_eta.png',
     'SelectedCaloParticles_Photons/SelectedCaloParticles_caloparticle_pt.png',
     'SelectedCaloParticles_Photons/SelectedCaloParticles_caloparticle_phi.png',
     'SelectedCaloParticles_Photons/SelectedCaloParticles_caloparticle_energy.png',
     'SelectedCaloParticles_Photons/SelectedCaloParticles_Eta vs Zorigin.png'
     ]
-                          
 
 #Plots to keep in summary from ticlMultiClustersFromTrackstersEM
 summmcEM = [

--- a/Validation/HGCalValidation/scripts/hgcalPerformanceValidation.py
+++ b/Validation/HGCalValidation/scripts/hgcalPerformanceValidation.py
@@ -83,7 +83,16 @@ def putype(t):
 #------------------------------------------------------------------------------------------
 #thereleases = { "CMSSW 11_1_X" : ["CMSSW_11_1_0_pre4_GEANT4","CMSSW_11_1_0_pre3","CMSSW_11_1_0_pre2"] }
 thereleases = OrderedDict()
-thereleases = { "CMSSW 11_3_X" : [
+thereleases = { "CMSSW 12_0_X" : [
+    "CMSSW_12_0_0_pre3_vs_CMSSW_12_0_0_pre2",
+    "CMSSW_12_0_0_pre2_vs_CMSSW_12_0_0_pre1",
+    "CMSSW_12_0_0_pre1_vs_CMSSW_11_3_0_pre6"
+                 ],
+                "CMSSW 11_3_X" : [
+    "CMSSW_11_3_0_vs_CMSSW_11_3_0_pre6",
+    "CMSSW_11_3_0_pre6_vs_CMSSW_11_3_0_pre5",
+    "CMSSW_11_3_0_pre5_vs_CMSSW_11_3_0_pre4",
+    "CMSSW_11_3_0_pre4_vs_CMSSW_11_3_0_pre3",
     "CMSSW_11_3_0_pre3_G4VECGEOM_vs_CMSSW_11_3_0_pre3",
     "CMSSW_11_3_0_pre3_D76_vs_CMSSW_11_3_0_pre3",
     "CMSSW_11_3_0_pre3_vs_CMSSW_11_3_0_pre2",
@@ -125,15 +134,16 @@ thereleases = { "CMSSW 11_3_X" : [
 geometryTests = OrderedDict()
 geometryTests = { "Material budget" : [
                 #"Extended2026D49_vs_Extended2026D71",
-                "Extended2026D49_vs_Extended2026D76"
+                "Extended2026D49_vs_Extended2026D76",
+                "Extended2026D76_vs_Extended2026D83"
                 ]
 }
 
-GeoScenario = "Extended2026D49_vs_Extended2026D76"
+GeoScenario = "Extended2026D76_vs_Extended2026D83"
 
-RefRelease='CMSSW_11_3_0_pre3'
+RefRelease='CMSSW_12_0_0_pre2'
 
-NewRelease='CMSSW_11_3_0_pre3_G4VECGEOM'
+NewRelease='CMSSW_12_0_0_pre3'
 
 NotNormalRelease = "normal"
 NotNormalRefRelease = "normal"
@@ -149,7 +159,8 @@ if "raw" in NotNormalRelease:
     #   appendglobaltag = "_2026D49noPU_gcc900"
     appendglobaltag = "_2026D76noPU"
 else: 
-    appendglobaltag = "_2026D49noPU"
+    #   appendglobaltag = "_2026D49noPU"
+    appendglobaltag = "_2026D76noPU"
 
 #Until the final list of RelVals settles down the following sample list is under constant review
 '''
@@ -202,17 +213,17 @@ phase2samples_noPU = [
     #------------------------------
     #version v2 campaign
     #Sample("RelValZpTT_1500", midfix="14", scenario="2026D49", appendGlobalTag=appendglobaltag, version="v2" ),
-    ##Sample("RelValZpTT_1500", midfix="14TeV", scenario="2026D49", appendGlobalTag=appendglobaltag, version="v2" ),
+    #Sample("RelValZpTT_1500", midfix="14TeV", scenario="2026D49", appendGlobalTag=appendglobaltag, version="v2" ),
     #Sample("RelValZTT", midfix="14TeV", scenario="2026D49", appendGlobalTag=appendglobaltag, version="v2" ),
     #Sample("RelValZMM", midfix="14", scenario="2026D49", appendGlobalTag=appendglobaltag, version="v2" ),
     #Sample("RelValZEE", midfix="14", scenario="2026D49", appendGlobalTag=appendglobaltag, version="v2" ),
-    ##Sample("RelValTenTau_15_500_Eta3p1", scenario="2026D49", appendGlobalTag=appendglobaltag, version="v2"  ),
+    #Sample("RelValTenTau_15_500_Eta3p1", scenario="2026D49", appendGlobalTag=appendglobaltag, version="v2"  ),
     #Sample("RelValTenTau_15_500", scenario="2026D49", appendGlobalTag=appendglobaltag, version="v2"  ),
     #Sample("RelValTTbar", midfix="14TeV", scenario="2026D49", appendGlobalTag=appendglobaltag, version="v2" ),
     #Sample("RelValQCD_Pt15To7000_Flat", midfix="14", scenario="2026D49", appendGlobalTag=appendglobaltag, version="v2" ),
-    ##Sample("RelValQCD_Pt15To7000_Flat", midfix="14TeV", scenario="2026D49", appendGlobalTag=appendglobaltag, version="v2" ),
+    #Sample("RelValQCD_Pt15To7000_Flat", midfix="14TeV", scenario="2026D49", appendGlobalTag=appendglobaltag, version="v2" ),
     #Sample("RelValNuGun", scenario="2026D49", appendGlobalTag=appendglobaltag, version="v2" ),
-    ##Sample("RelValMinBias", midfix="14", scenario="2026D49", appendGlobalTag=appendglobaltag, version="v2" ),
+    #Sample("RelValMinBias", midfix="14", scenario="2026D49", appendGlobalTag=appendglobaltag, version="v2" ),
     #Sample("RelValMinBias", midfix="14TeV", scenario="2026D49", appendGlobalTag=appendglobaltag, version="v2" ),
     #Sample("RelValH125GGgluonfusion", midfix="14", scenario="2026D49", appendGlobalTag=appendglobaltag, version="v2" )
 
@@ -245,8 +256,6 @@ phase2samples_noPU_extend = [
     #Sample("RelValSingleMuPt100", scenario="2026D49", appendGlobalTag=appendglobaltag, version="v2" ),
     #Sample("RelValSingleMuPt1000", scenario="2026D49", appendGlobalTag=appendglobaltag, version="v2" )
 
-
-
     Sample("RelValSingleMuPt10", scenario="2026D49", appendGlobalTag=appendglobaltag ),
     Sample("RelValSingleMuPt100", scenario="2026D49", appendGlobalTag=appendglobaltag ),
     Sample("RelValSingleMuPt1000", scenario="2026D49", appendGlobalTag=appendglobaltag )
@@ -260,33 +269,33 @@ phase2samples_noPU_extend_more = [
 
     #------------------------------
     #version v2 campaign
-    Sample("RelValCloseByPGun_CE_H_Fine_300um", scenario="2026D49", appendGlobalTag=appendglobaltag, version="v2" ),
-    Sample("RelValCloseByPGun_CE_H_Fine_200um", scenario="2026D49", appendGlobalTag=appendglobaltag, version="v2" ),
-    Sample("RelValCloseByPGun_CE_H_Fine_120um", scenario="2026D49", appendGlobalTag=appendglobaltag, version="v2" ),
-    Sample("RelValCloseByPGun_CE_H_Coarse_Scint", scenario="2026D49", appendGlobalTag=appendglobaltag, version="v2" ),
-    Sample("RelValCloseByPGun_CE_H_Coarse_300um", scenario="2026D49", appendGlobalTag=appendglobaltag, version="v2" ),
-    Sample("RelValCloseByPGun_CE_E_Front_300um", scenario="2026D49", appendGlobalTag=appendglobaltag, version="v2" ),
-    Sample("RelValCloseByPGun_CE_E_Front_200um", scenario="2026D49", appendGlobalTag=appendglobaltag, version="v2" ),
-    Sample("RelValCloseByPGun_CE_E_Front_120um", scenario="2026D49", appendGlobalTag=appendglobaltag, version="v2" ),
-    Sample("RelValSingleGammaFlatPt8To150", scenario="2026D49", appendGlobalTag=appendglobaltag, version="v2" ),
-    Sample("RelValSingleEFlatPt2To100", scenario="2026D49", appendGlobalTag=appendglobaltag, version="v2" ),
-    Sample("RelValSinglePiFlatPt0p7To10", scenario="2026D49", appendGlobalTag=appendglobaltag, version="v2" )
+    #Sample("RelValCloseByPGun_CE_H_Fine_300um", scenario="2026D49", appendGlobalTag=appendglobaltag, version="v2" ),
+    #Sample("RelValCloseByPGun_CE_H_Fine_200um", scenario="2026D49", appendGlobalTag=appendglobaltag, version="v2" ),
+    #Sample("RelValCloseByPGun_CE_H_Fine_120um", scenario="2026D49", appendGlobalTag=appendglobaltag, version="v2" ),
+    #Sample("RelValCloseByPGun_CE_H_Coarse_Scint", scenario="2026D49", appendGlobalTag=appendglobaltag, version="v2" ),
+    #Sample("RelValCloseByPGun_CE_H_Coarse_300um", scenario="2026D49", appendGlobalTag=appendglobaltag, version="v2" ),
+    #Sample("RelValCloseByPGun_CE_E_Front_300um", scenario="2026D49", appendGlobalTag=appendglobaltag, version="v2" ),
+    #Sample("RelValCloseByPGun_CE_E_Front_200um", scenario="2026D49", appendGlobalTag=appendglobaltag, version="v2" ),
+    #Sample("RelValCloseByPGun_CE_E_Front_120um", scenario="2026D49", appendGlobalTag=appendglobaltag, version="v2" ),
+    #Sample("RelValSingleGammaFlatPt8To150", scenario="2026D49", appendGlobalTag=appendglobaltag, version="v2" ),
+    #Sample("RelValSingleEFlatPt2To100", scenario="2026D49", appendGlobalTag=appendglobaltag, version="v2" ),
+    #Sample("RelValSinglePiFlatPt0p7To10", scenario="2026D49", appendGlobalTag=appendglobaltag, version="v2" )
 
 
 
     #------------------------------
     #NORMAL version v1 campaign
-    #Sample("RelValCloseByPGun_CE_H_Fine_300um", scenario="2026D49", appendGlobalTag=appendglobaltag ),
-    #Sample("RelValCloseByPGun_CE_H_Fine_200um", scenario="2026D49", appendGlobalTag=appendglobaltag ),
-    #Sample("RelValCloseByPGun_CE_H_Fine_120um", scenario="2026D49", appendGlobalTag=appendglobaltag ),
-    #Sample("RelValCloseByPGun_CE_H_Coarse_Scint", scenario="2026D49", appendGlobalTag=appendglobaltag ),
-    #Sample("RelValCloseByPGun_CE_H_Coarse_300um", scenario="2026D49", appendGlobalTag=appendglobaltag ),
-    #Sample("RelValCloseByPGun_CE_E_Front_300um", scenario="2026D49", appendGlobalTag=appendglobaltag ),
-    #Sample("RelValCloseByPGun_CE_E_Front_200um", scenario="2026D49", appendGlobalTag=appendglobaltag ),
-    #Sample("RelValCloseByPGun_CE_E_Front_120um", scenario="2026D49", appendGlobalTag=appendglobaltag ),
-    #Sample("RelValSingleGammaFlatPt8To150", scenario="2026D49", appendGlobalTag=appendglobaltag ),
-    #Sample("RelValSingleEFlatPt2To100", scenario="2026D49", appendGlobalTag=appendglobaltag ),
-    #Sample("RelValSinglePiFlatPt0p7To10", scenario="2026D49", appendGlobalTag=appendglobaltag )
+    Sample("RelValCloseByPGun_CE_H_Fine_300um", scenario="2026D49", appendGlobalTag=appendglobaltag ),
+    Sample("RelValCloseByPGun_CE_H_Fine_200um", scenario="2026D49", appendGlobalTag=appendglobaltag ),
+    Sample("RelValCloseByPGun_CE_H_Fine_120um", scenario="2026D49", appendGlobalTag=appendglobaltag ),
+    Sample("RelValCloseByPGun_CE_H_Coarse_Scint", scenario="2026D49", appendGlobalTag=appendglobaltag ),
+    Sample("RelValCloseByPGun_CE_H_Coarse_300um", scenario="2026D49", appendGlobalTag=appendglobaltag ),
+    Sample("RelValCloseByPGun_CE_E_Front_300um", scenario="2026D49", appendGlobalTag=appendglobaltag ),
+    Sample("RelValCloseByPGun_CE_E_Front_200um", scenario="2026D49", appendGlobalTag=appendglobaltag ),
+    Sample("RelValCloseByPGun_CE_E_Front_120um", scenario="2026D49", appendGlobalTag=appendglobaltag ),
+    Sample("RelValSingleGammaFlatPt8To150", scenario="2026D49", appendGlobalTag=appendglobaltag ),
+    Sample("RelValSingleEFlatPt2To100", scenario="2026D49", appendGlobalTag=appendglobaltag ),
+    Sample("RelValSinglePiFlatPt0p7To10", scenario="2026D49", appendGlobalTag=appendglobaltag )
     #------------------------------
 
     #Sample("RelValCloseByPGun_CE_H_Fine_300um", scenario="2026D49", appendGlobalTag=appendglobaltag + "_HGCal" ),
@@ -370,9 +379,7 @@ if(opt.DOWNLOAD):
 #------------------------------------------------------------------------------------------
 #Objects processing section: The objects defined in --Obj are analyzed here. 
 #------------------------------------------------------------------------------------------
-
-#This is the hgcalLayerClusters, ticlMultiClustersFromTrackstersEM, ticlMultiClustersFromTrackstersHAD, and hitCalibration part
-if (opt.OBJ == 'hgcalLayerClusters' or opt.OBJ == 'hitCalibration' or opt.OBJ == 'ticlMultiClustersFromTrackstersEM' or opt.OBJ == 'ticlMultiClustersFromTrackstersHAD' or opt.OBJ == 'allTiclMultiClusters'):
+if (opt.OBJ == 'layerClusters' or opt.OBJ == 'hitCalibration' or opt.OBJ == 'hitValidation' or opt.OBJ == 'tracksters'):
     fragments = []
     #Now  that we have them in eos lets produce plots
     #Let's loop through RelVals
@@ -402,8 +409,8 @@ if (opt.OBJ == 'hgcalLayerClusters' or opt.OBJ == 'hitCalibration' or opt.OBJ ==
             #cmd = 'python Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py ' +  inputpathRef + infi.filename(RefRelease) + ' ' +  inputpathNew + infi.filename(NewRelease) + ' --outputDir HGCValid_%s_Plots --no-ratio --png --separate --html-sample "%s" ' %(opt.HTMLVALNAME, _sampleName[infi.name()] ) + ' --html-validation-name %s --subdirprefix ' %(opt.HTMLVALNAME) + ' plots_%s' % (samplename) + ' --collection %s' %(opt.HTMLVALNAME)
             cmd = 'python Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py ' +  inputpathRef + infi.filename(RefRelease).replace("_raw1100","_raw1100_rsb") + ' ' +  inputpathNew + infi.filename(NewRelease) + ' --outputDir HGCValid_%s_Plots --no-ratio --png --separate --html-sample "%s" ' %(opt.HTMLVALNAME, _sampleName[infi.name()] ) + ' --html-validation-name %s --subdirprefix ' %(opt.HTMLVALNAME) + ' plots_%s' % (samplename) + ' --collection %s' %(opt.HTMLVALNAME)
         elif "normal" in NotNormalRelease and "normal" in NotNormalRefRelease:
-            #cmd = 'python Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py ' +  inputpathRef + infi.filename(RefRelease) + ' ' +  inputpathNew + infi.filename(NewRelease) + ' --outputDir HGCValid_%s_Plots --no-ratio --png --separate --html-sample "%s" ' %(opt.HTMLVALNAME, _sampleName[infi.name()] ) + ' --html-validation-name %s --subdirprefix ' %(opt.HTMLVALNAME) + ' plots_%s' % (samplename) + ' --collection %s' %(opt.HTMLVALNAME)
-            cmd = 'python Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py ' +  inputpathRef + infi.filename(RefRelease).replace("2026D49noPU-v2","2026D49noPU-v1") + ' ' +  inputpathNew + infi.filename(NewRelease) + ' --outputDir HGCValid_%s_Plots --no-ratio --png --separate --html-sample "%s" ' %(opt.HTMLVALNAME, _sampleName[infi.name()] ) + ' --html-validation-name %s --subdirprefix ' %(opt.HTMLVALNAME) + ' plots_%s' % (samplename) + ' --collection %s' %(opt.HTMLVALNAME)
+            cmd = 'python Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py ' +  inputpathRef + infi.filename(RefRelease) + ' ' +  inputpathNew + infi.filename(NewRelease) + ' --outputDir HGCValid_%s_Plots --no-ratio --png --separate --html-sample "%s" ' %(opt.HTMLVALNAME, _sampleName[infi.name()] ) + ' --html-validation-name %s --subdirprefix ' %(opt.HTMLVALNAME) + ' plots_%s' % (samplename) + ' --collection %s' %(opt.HTMLVALNAME)
+            #cmd = 'python Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py ' +  inputpathRef + infi.filename(RefRelease).replace("2026D49noPU-v2","2026D49noPU-v1") + ' ' +  inputpathNew + infi.filename(NewRelease) + ' --outputDir HGCValid_%s_Plots --no-ratio --png --separate --html-sample "%s" ' %(opt.HTMLVALNAME, _sampleName[infi.name()] ) + ' --html-validation-name %s --subdirprefix ' %(opt.HTMLVALNAME) + ' plots_%s' % (samplename) + ' --collection %s' %(opt.HTMLVALNAME)
         else: 
             #print inputpathRef, infi.filename(RefRelease).replace("D49","D41")
             #YOU SHOULD INSPECT EACH TIME THIS COMMAND AND THE REPLACE
@@ -415,7 +422,7 @@ if (opt.OBJ == 'hgcalLayerClusters' or opt.OBJ == 'hitCalibration' or opt.OBJ ==
             print('Dry-run: ['+cmd+']')
         else:
             output = processCmd(cmd)
-            if opt.OBJ == 'hgcalLayerClusters':
+            if opt.OBJ == 'layerClusters':
                 processCmd('mv HGCValid_%s_Plots/plots_%s_Layer\ Clusters.html HGCValid_%s_Plots/index.html'%(opt.HTMLVALNAME,samplename,opt.HTMLVALNAME))
                 processCmd('awk \'NR>=6&&NR<=589\' HGCValid_%s_Plots/index.html > HGCValid_%s_Plots/index_%s.html '% (opt.HTMLVALNAME,opt.HTMLVALNAME, samplename))
                 processCmd('echo "  <br/>" >> HGCValid_%s_Plots/index_%s.html '%(opt.HTMLVALNAME, samplename) )
@@ -429,8 +436,14 @@ if (opt.OBJ == 'hgcalLayerClusters' or opt.OBJ == 'hitCalibration' or opt.OBJ ==
                 processCmd('echo "  <br/>" >> HGCValid_%s_Plots/index_%s.html '%(opt.HTMLVALNAME, samplename) )
                 processCmd('echo "  <hr>" >> HGCValid_%s_Plots/index_%s.html '%(opt.HTMLVALNAME, samplename) )
 
-            if opt.OBJ == 'ticlMultiClustersFromTrackstersEM' or opt.OBJ == 'ticlMultiClustersFromTrackstersHAD' or opt.OBJ == 'allTiclMultiClusters':
-                processCmd('mv HGCValid_%s_Plots/plots_%s_MultiClusters.html HGCValid_%s_Plots/index.html'%(opt.HTMLVALNAME,samplename,opt.HTMLVALNAME))
+            if opt.OBJ == 'hitValidation':
+                processCmd('mv HGCValid_%s_Plots/plots_%s_Hits.html HGCValid_%s_Plots/index.html'%(opt.HTMLVALNAME,samplename,opt.HTMLVALNAME))
+                processCmd('awk \'NR>=6&&NR<=184\' HGCValid_%s_Plots/index.html > HGCValid_%s_Plots/index_%s.html '% (opt.HTMLVALNAME,opt.HTMLVALNAME, samplename))
+                processCmd('echo "  <br/>" >> HGCValid_%s_Plots/index_%s.html '%(opt.HTMLVALNAME, samplename) )  
+                processCmd('echo "  <hr>" >> HGCValid_%s_Plots/index_%s.html '%(opt.HTMLVALNAME, samplename) )
+                
+            if opt.OBJ == 'tracksters':
+                processCmd('mv HGCValid_%s_Plots/plots_%s_Tracksters.html HGCValid_%s_Plots/index.html'%(opt.HTMLVALNAME,samplename,opt.HTMLVALNAME))
                 processCmd('awk \'NR>=6&&NR<=141\' HGCValid_%s_Plots/index.html > HGCValid_%s_Plots/index_%s.html '% (opt.HTMLVALNAME,opt.HTMLVALNAME, samplename))
                 processCmd('echo "  <br/>" >> HGCValid_%s_Plots/index_%s.html '%(opt.HTMLVALNAME, samplename) )
                 processCmd('echo "  <hr>" >> HGCValid_%s_Plots/index_%s.html '%(opt.HTMLVALNAME, samplename) )
@@ -482,6 +495,7 @@ if (opt.OBJ == 'SimHits'):
         output = processCmd(cmd)
 
 #------------------------------------------------------------------------------------------
+'''
 if (opt.OBJ == 'hitValidation'):
     fragments = []
     #Now  that we have them in eos lets produce plots
@@ -510,8 +524,8 @@ if (opt.OBJ == 'hitValidation'):
             #cmd = 'python Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py ' +  inputpathRef + infi.filename(RefRelease) + ' ' +  inputpathNew + infi.filename(NewRelease) + ' --outputDir HGCValid_%s_Plots --no-ratio --png --separate --html-sample "%s" ' %(opt.HTMLVALNAME, _sampleName[infi.name()] ) + ' --html-validation-name %s --subdirprefix ' %(opt.HTMLVALNAME) + ' plots_%s' % (samplename) + ' --collection %s' %(opt.HTMLVALNAME)
             cmd = 'python Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py ' +  inputpathRef + infi.filename(RefRelease).replace("_raw1100","_raw1100_rsb") + ' ' +  inputpathNew + infi.filename(NewRelease) + ' --outputDir HGCValid_%s_Plots --no-ratio --png --separate --html-sample "%s" ' %(opt.HTMLVALNAME, _sampleName[infi.name()] ) + ' --html-validation-name %s --subdirprefix ' %(opt.HTMLVALNAME) + ' plots_%s' % (samplename) + ' --collection %s' %(opt.HTMLVALNAME)
         elif "normal" in NotNormalRelease and "normal" in NotNormalRefRelease:
-            #cmd = 'python Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py ' +  inputpathRef + infi.filename(RefRelease) + ' ' +  inputpathNew + infi.filename(NewRelease) + ' --outputDir HGCValid_%s_Plots --no-ratio --png --separate --html-sample "%s" ' %(opt.HTMLVALNAME, _sampleName[infi.name()] ) + ' --html-validation-name %s --subdirprefix ' %(opt.HTMLVALNAME) + ' plots_%s' % (samplename) + ' --collection %s' %(opt.HTMLVALNAME)
-            cmd = 'python Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py ' +  inputpathRef + infi.filename(RefRelease).replace("2026D49noPU-v2","2026D49noPU-v1") + ' ' +  inputpathNew + infi.filename(NewRelease) + ' --outputDir HGCValid_%s_Plots --no-ratio --png --separate --html-sample "%s" ' %(opt.HTMLVALNAME, _sampleName[infi.name()] ) + ' --html-validation-name %s --subdirprefix ' %(opt.HTMLVALNAME) + ' plots_%s' % (samplename) + ' --collection %s' %(opt.HTMLVALNAME)
+            cmd = 'python Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py ' +  inputpathRef + infi.filename(RefRelease) + ' ' +  inputpathNew + infi.filename(NewRelease) + ' --outputDir HGCValid_%s_Plots --no-ratio --png --separate --html-sample "%s" ' %(opt.HTMLVALNAME, _sampleName[infi.name()] ) + ' --html-validation-name %s --subdirprefix ' %(opt.HTMLVALNAME) + ' plots_%s' % (samplename) + ' --collection %s' %(opt.HTMLVALNAME)
+            #cmd = 'python Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py ' +  inputpathRef + infi.filename(RefRelease).replace("2026D49noPU-v2","2026D49noPU-v1") + ' ' +  inputpathNew + infi.filename(NewRelease) + ' --outputDir HGCValid_%s_Plots --no-ratio --png --separate --html-sample "%s" ' %(opt.HTMLVALNAME, _sampleName[infi.name()] ) + ' --html-validation-name %s --subdirprefix ' %(opt.HTMLVALNAME) + ' plots_%s' % (samplename) + ' --collection %s' %(opt.HTMLVALNAME)
         else: 
             #cmd = 'python Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py ' +  inputpathRef + infi.filename(RefRelease).replace("D49","D41").replace("200-v2","200-v1") + ' ' +  inputpathNew + infi.filename(NewRelease) + ' --outputDir HGCValid_%s_Plots --no-ratio --png --separate --html-sample "%s" ' %(opt.HTMLVALNAME, _sampleName[infi.name()] ) + ' --html-validation-name %s --subdirprefix ' %(opt.HTMLVALNAME) + ' plots_%s' % (samplename) + ' --collection %s' %(opt.HTMLVALNAME) 
             cmd = 'python Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py ' +  inputpathRef + infi.filename(RefRelease).replace("mcRun4_realistic_v2-v1", "mcRun4_realistic_v2_2026D49noPU-v1") + ' ' +  inputpathNew + infi.filename(NewRelease) + ' --outputDir HGCValid_%s_Plots --no-ratio --png --separate --html-sample "%s" ' %(opt.HTMLVALNAME, _sampleName[infi.name()] ) + ' --html-validation-name %s --subdirprefix ' %(opt.HTMLVALNAME) + ' plots_%s' % (samplename) + ' --collection %s' %(opt.HTMLVALNAME)
@@ -554,6 +568,7 @@ if (opt.OBJ == 'hitValidation'):
     index_file.write(' </body>\n')
     index_file.write('</html>\n')
     index_file.close()
+'''
 
 #-------------------------------------------------------------------------------------------
 #This is the Digis part
@@ -768,9 +783,9 @@ if (opt.GATHER != None) :
                     #print(df[obj][ind])          
                     print(j)
                     #index_file.write(' <li><a href="plots_%s_%s">%s</a></li>   \n' %(samplename, df[obj][ind], df[obj][ind].partition("/")[2] ))
-                    if "Ticl" in j: 
-                        index_file.write(' <li><a href="../HGCValid_%s_Plots/plots_%s_%s">%s</a></li>   \n' %(j, samplename, column, column.replace("ticlMultiClustersFromTracksters","") ))
-                    else: 
+                    if "tracksters" in j:
+                        index_file.write(' <li><a href="../HGCValid_%s_Plots/plots_%s_%s">%s</a></li>   \n' %(j, samplename, column, column.replace("ticlTracksters","") ))
+                    else:
                         index_file.write(' <li><a href="../HGCValid_%s_Plots/plots_%s_%s">%s</a></li>   \n' %(j, samplename, column, column.partition("/")[2] ))
 
                 index_file.write('    </ul>\n')                        

--- a/Validation/HGCalValidation/scripts/hgcalPerformanceValidation.py
+++ b/Validation/HGCalValidation/scripts/hgcalPerformanceValidation.py
@@ -13,7 +13,7 @@
 
 import sys
 import os
-import commands
+import subprocess
 import optparse
 import pandas as pd
 
@@ -48,10 +48,10 @@ parseOptions()
 
 #------------------------------------------------------------------------------------------
 #Some helpful functions
-#Processing the external os commands
+#Processing the external os subprocess
 def processCmd(cmd, quite = 0):
     print(cmd)
-    status, output = commands.getstatusoutput(cmd)
+    status, output = subprocess.getstatusoutput(cmd)
     if (status !=0 and not quite):
         print('Error in processing command:\n   ['+cmd+']')
         print('Output:\n   ['+output+'] \n')
@@ -84,6 +84,7 @@ def putype(t):
 #thereleases = { "CMSSW 11_1_X" : ["CMSSW_11_1_0_pre4_GEANT4","CMSSW_11_1_0_pre3","CMSSW_11_1_0_pre2"] }
 thereleases = OrderedDict()
 thereleases = { "CMSSW 12_0_X" : [
+    "CMSSW_12_0_0_pre4_vs_CMSSW_12_0_0_pre3",
     "CMSSW_12_0_0_pre3_vs_CMSSW_12_0_0_pre2",
     "CMSSW_12_0_0_pre2_vs_CMSSW_12_0_0_pre1",
     "CMSSW_12_0_0_pre1_vs_CMSSW_11_3_0_pre6"
@@ -141,9 +142,9 @@ geometryTests = { "Material budget" : [
 
 GeoScenario = "Extended2026D76_vs_Extended2026D83"
 
-RefRelease='CMSSW_12_0_0_pre2'
+RefRelease='CMSSW_12_0_0_pre3'
 
-NewRelease='CMSSW_12_0_0_pre3'
+NewRelease='CMSSW_12_0_0_pre4'
 
 NotNormalRelease = "normal"
 NotNormalRefRelease = "normal"
@@ -401,21 +402,21 @@ if (opt.OBJ == 'layerClusters' or opt.OBJ == 'hitCalibration' or opt.OBJ == 'hit
         inputpathNew = NewRepository +'/' + NewRelease+ '/'
 
         if RefRelease == None:
-            cmd = 'python Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py ' +  inputpathNew + infi.filename(NewRelease) + ' --outputDir HGCValid_%s_Plots --no-ratio --png --separate --html-sample "%s" ' %(opt.HTMLVALNAME, _sampleName[infi.name()] ) + ' --html-validation-name %s --subdirprefix ' %(opt.HTMLVALNAME) + ' plots_%s' % (samplename)+ ' --collection %s' %(opt.HTMLVALNAME)
+            cmd = 'python3 Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py ' +  inputpathNew + infi.filename(NewRelease) + ' --outputDir HGCValid_%s_Plots --no-ratio --png --separate --html-sample "%s" ' %(opt.HTMLVALNAME, _sampleName[infi.name()] ) + ' --html-validation-name %s --subdirprefix ' %(opt.HTMLVALNAME) + ' plots_%s' % (samplename)+ ' --collection %s' %(opt.HTMLVALNAME)
         elif "raw" in NotNormalRelease and "normal" in NotNormalRefRelease:
-            cmd = 'python Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py ' +  inputpathRef + infi.filename(RefRelease).replace("mcRun4_realistic_v3_2026D76noPU-v1","mcRun4_realistic_v3_2026D49noPU-v1") + ' ' +  inputpathNew + infi.filename(NewRelease) + ' --outputDir HGCValid_%s_Plots --no-ratio --png --separate --html-sample "%s" ' %(opt.HTMLVALNAME, _sampleName[infi.name()] ) + ' --html-validation-name %s --subdirprefix ' %(opt.HTMLVALNAME) + ' plots_%s' % (samplename) + ' --collection %s' %(opt.HTMLVALNAME)
-            #cmd = 'python Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py ' +  inputpathRef + infi.filename(RefRelease).replace("mcRun4_realistic_v3_2026D49noPU_raw1100_rsb-v1","mcRun4_realistic_v3_2026D49noPU-v1") + ' ' +  inputpathNew + infi.filename(NewRelease) + ' --outputDir HGCValid_%s_Plots --no-ratio --png --separate --html-sample "%s" ' %(opt.HTMLVALNAME, _sampleName[infi.name()] ) + ' --html-validation-name %s --subdirprefix ' %(opt.HTMLVALNAME) + ' plots_%s' % (samplename) + ' --collection %s' %(opt.HTMLVALNAME)
+            cmd = 'python3 Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py ' +  inputpathRef + infi.filename(RefRelease).replace("mcRun4_realistic_v3_2026D76noPU-v1","mcRun4_realistic_v3_2026D49noPU-v1") + ' ' +  inputpathNew + infi.filename(NewRelease) + ' --outputDir HGCValid_%s_Plots --no-ratio --png --separate --html-sample "%s" ' %(opt.HTMLVALNAME, _sampleName[infi.name()] ) + ' --html-validation-name %s --subdirprefix ' %(opt.HTMLVALNAME) + ' plots_%s' % (samplename) + ' --collection %s' %(opt.HTMLVALNAME)
+            #cmd = 'python3 Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py ' +  inputpathRef + infi.filename(RefRelease).replace("mcRun4_realistic_v3_2026D49noPU_raw1100_rsb-v1","mcRun4_realistic_v3_2026D49noPU-v1") + ' ' +  inputpathNew + infi.filename(NewRelease) + ' --outputDir HGCValid_%s_Plots --no-ratio --png --separate --html-sample "%s" ' %(opt.HTMLVALNAME, _sampleName[infi.name()] ) + ' --html-validation-name %s --subdirprefix ' %(opt.HTMLVALNAME) + ' plots_%s' % (samplename) + ' --collection %s' %(opt.HTMLVALNAME)
         elif "raw" in NotNormalRelease and "raw" in NotNormalRefRelease:
-            #cmd = 'python Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py ' +  inputpathRef + infi.filename(RefRelease) + ' ' +  inputpathNew + infi.filename(NewRelease) + ' --outputDir HGCValid_%s_Plots --no-ratio --png --separate --html-sample "%s" ' %(opt.HTMLVALNAME, _sampleName[infi.name()] ) + ' --html-validation-name %s --subdirprefix ' %(opt.HTMLVALNAME) + ' plots_%s' % (samplename) + ' --collection %s' %(opt.HTMLVALNAME)
-            cmd = 'python Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py ' +  inputpathRef + infi.filename(RefRelease).replace("_raw1100","_raw1100_rsb") + ' ' +  inputpathNew + infi.filename(NewRelease) + ' --outputDir HGCValid_%s_Plots --no-ratio --png --separate --html-sample "%s" ' %(opt.HTMLVALNAME, _sampleName[infi.name()] ) + ' --html-validation-name %s --subdirprefix ' %(opt.HTMLVALNAME) + ' plots_%s' % (samplename) + ' --collection %s' %(opt.HTMLVALNAME)
+            #cmd = 'python3 Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py ' +  inputpathRef + infi.filename(RefRelease) + ' ' +  inputpathNew + infi.filename(NewRelease) + ' --outputDir HGCValid_%s_Plots --no-ratio --png --separate --html-sample "%s" ' %(opt.HTMLVALNAME, _sampleName[infi.name()] ) + ' --html-validation-name %s --subdirprefix ' %(opt.HTMLVALNAME) + ' plots_%s' % (samplename) + ' --collection %s' %(opt.HTMLVALNAME)
+            cmd = 'python3 Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py ' +  inputpathRef + infi.filename(RefRelease).replace("_raw1100","_raw1100_rsb") + ' ' +  inputpathNew + infi.filename(NewRelease) + ' --outputDir HGCValid_%s_Plots --no-ratio --png --separate --html-sample "%s" ' %(opt.HTMLVALNAME, _sampleName[infi.name()] ) + ' --html-validation-name %s --subdirprefix ' %(opt.HTMLVALNAME) + ' plots_%s' % (samplename) + ' --collection %s' %(opt.HTMLVALNAME)
         elif "normal" in NotNormalRelease and "normal" in NotNormalRefRelease:
-            cmd = 'python Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py ' +  inputpathRef + infi.filename(RefRelease) + ' ' +  inputpathNew + infi.filename(NewRelease) + ' --outputDir HGCValid_%s_Plots --no-ratio --png --separate --html-sample "%s" ' %(opt.HTMLVALNAME, _sampleName[infi.name()] ) + ' --html-validation-name %s --subdirprefix ' %(opt.HTMLVALNAME) + ' plots_%s' % (samplename) + ' --collection %s' %(opt.HTMLVALNAME)
-            #cmd = 'python Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py ' +  inputpathRef + infi.filename(RefRelease).replace("2026D49noPU-v2","2026D49noPU-v1") + ' ' +  inputpathNew + infi.filename(NewRelease) + ' --outputDir HGCValid_%s_Plots --no-ratio --png --separate --html-sample "%s" ' %(opt.HTMLVALNAME, _sampleName[infi.name()] ) + ' --html-validation-name %s --subdirprefix ' %(opt.HTMLVALNAME) + ' plots_%s' % (samplename) + ' --collection %s' %(opt.HTMLVALNAME)
+            cmd = 'python3 Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py ' +  inputpathRef + infi.filename(RefRelease) + ' ' +  inputpathNew + infi.filename(NewRelease) + ' --outputDir HGCValid_%s_Plots --no-ratio --png --separate --html-sample "%s" ' %(opt.HTMLVALNAME, _sampleName[infi.name()] ) + ' --html-validation-name %s --subdirprefix ' %(opt.HTMLVALNAME) + ' plots_%s' % (samplename) + ' --collection %s' %(opt.HTMLVALNAME)
+            #cmd = 'python3 Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py ' +  inputpathRef + infi.filename(RefRelease).replace("2026D49noPU-v2","2026D49noPU-v1") + ' ' +  inputpathNew + infi.filename(NewRelease) + ' --outputDir HGCValid_%s_Plots --no-ratio --png --separate --html-sample "%s" ' %(opt.HTMLVALNAME, _sampleName[infi.name()] ) + ' --html-validation-name %s --subdirprefix ' %(opt.HTMLVALNAME) + ' plots_%s' % (samplename) + ' --collection %s' %(opt.HTMLVALNAME)
         else: 
             #print inputpathRef, infi.filename(RefRelease).replace("D49","D41")
             #YOU SHOULD INSPECT EACH TIME THIS COMMAND AND THE REPLACE
-            #cmd = 'python Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py ' +  inputpathRef + infi.filename(RefRelease).replace("D49","D41").replace("200-v2","200-v1") + ' ' +  inputpathNew + infi.filename(NewRelease) + ' --outputDir HGCValid_%s_Plots --no-ratio --png --separate --html-sample "%s" ' %(opt.HTMLVALNAME, _sampleName[infi.name()] ) + ' --html-validation-name %s --subdirprefix ' %(opt.HTMLVALNAME) + ' plots_%s' % (samplename) + ' --collection %s' %(opt.HTMLVALNAME) .replace("v2__", "v1__")
-            cmd = 'python Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py ' +  inputpathRef + infi.filename(RefRelease).replace("mcRun4_realistic_v2-v1", "mcRun4_realistic_v2_2026D49noPU-v1") + ' ' +  inputpathNew + infi.filename(NewRelease) + ' --outputDir HGCValid_%s_Plots --no-ratio --png --separate --html-sample "%s" ' %(opt.HTMLVALNAME, _sampleName[infi.name()] ) + ' --html-validation-name %s --subdirprefix ' %(opt.HTMLVALNAME) + ' plots_%s' % (samplename) + ' --collection %s' %(opt.HTMLVALNAME) 
+            #cmd = 'python3 Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py ' +  inputpathRef + infi.filename(RefRelease).replace("D49","D41").replace("200-v2","200-v1") + ' ' +  inputpathNew + infi.filename(NewRelease) + ' --outputDir HGCValid_%s_Plots --no-ratio --png --separate --html-sample "%s" ' %(opt.HTMLVALNAME, _sampleName[infi.name()] ) + ' --html-validation-name %s --subdirprefix ' %(opt.HTMLVALNAME) + ' plots_%s' % (samplename) + ' --collection %s' %(opt.HTMLVALNAME) .replace("v2__", "v1__")
+            cmd = 'python3 Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py ' +  inputpathRef + infi.filename(RefRelease).replace("mcRun4_realistic_v2-v1", "mcRun4_realistic_v2_2026D49noPU-v1") + ' ' +  inputpathNew + infi.filename(NewRelease) + ' --outputDir HGCValid_%s_Plots --no-ratio --png --separate --html-sample "%s" ' %(opt.HTMLVALNAME, _sampleName[infi.name()] ) + ' --html-validation-name %s --subdirprefix ' %(opt.HTMLVALNAME) + ' plots_%s' % (samplename) + ' --collection %s' %(opt.HTMLVALNAME) 
             print(cmd)
 
         if(opt.DRYRUN):
@@ -424,7 +425,7 @@ if (opt.OBJ == 'layerClusters' or opt.OBJ == 'hitCalibration' or opt.OBJ == 'hit
             output = processCmd(cmd)
             if opt.OBJ == 'layerClusters':
                 processCmd('mv HGCValid_%s_Plots/plots_%s_Layer\ Clusters.html HGCValid_%s_Plots/index.html'%(opt.HTMLVALNAME,samplename,opt.HTMLVALNAME))
-                processCmd('awk \'NR>=6&&NR<=589\' HGCValid_%s_Plots/index.html > HGCValid_%s_Plots/index_%s.html '% (opt.HTMLVALNAME,opt.HTMLVALNAME, samplename))
+                processCmd('awk \'NR>=6&&NR<=396\' HGCValid_%s_Plots/index.html > HGCValid_%s_Plots/index_%s.html '% (opt.HTMLVALNAME,opt.HTMLVALNAME, samplename))
                 processCmd('echo "  <br/>" >> HGCValid_%s_Plots/index_%s.html '%(opt.HTMLVALNAME, samplename) )
                 processCmd('echo "  <hr>" >> HGCValid_%s_Plots/index_%s.html '%(opt.HTMLVALNAME, samplename) )
 
@@ -444,7 +445,7 @@ if (opt.OBJ == 'layerClusters' or opt.OBJ == 'hitCalibration' or opt.OBJ == 'hit
                 
             if opt.OBJ == 'tracksters':
                 processCmd('mv HGCValid_%s_Plots/plots_%s_Tracksters.html HGCValid_%s_Plots/index.html'%(opt.HTMLVALNAME,samplename,opt.HTMLVALNAME))
-                processCmd('awk \'NR>=6&&NR<=141\' HGCValid_%s_Plots/index.html > HGCValid_%s_Plots/index_%s.html '% (opt.HTMLVALNAME,opt.HTMLVALNAME, samplename))
+                processCmd('awk \'NR>=6&&NR<=209\' HGCValid_%s_Plots/index.html > HGCValid_%s_Plots/index_%s.html '% (opt.HTMLVALNAME,opt.HTMLVALNAME, samplename))
                 processCmd('echo "  <br/>" >> HGCValid_%s_Plots/index_%s.html '%(opt.HTMLVALNAME, samplename) )
                 processCmd('echo "  <hr>" >> HGCValid_%s_Plots/index_%s.html '%(opt.HTMLVALNAME, samplename) )
 
@@ -516,20 +517,20 @@ if (opt.OBJ == 'hitValidation'):
         inputpathNew = NewRepository +'/' + NewRelease+ '/'
 
         if RefRelease == None:
-            cmd = 'python Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py ' +  inputpathNew + infi.filename(NewRelease) + ' --outputDir HGCValid_%s_Plots --no-ratio --png --separate --html-sample "%s" ' %(opt.HTMLVALNAME, _sampleName[infi.name()] ) + ' --html-validation-name %s --subdirprefix ' %(opt.HTMLVALNAME) + ' plots_%s' % (samplename)+ ' --collection %s' %(opt.HTMLVALNAME)
+            cmd = 'python3 Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py ' +  inputpathNew + infi.filename(NewRelease) + ' --outputDir HGCValid_%s_Plots --no-ratio --png --separate --html-sample "%s" ' %(opt.HTMLVALNAME, _sampleName[infi.name()] ) + ' --html-validation-name %s --subdirprefix ' %(opt.HTMLVALNAME) + ' plots_%s' % (samplename)+ ' --collection %s' %(opt.HTMLVALNAME)
         elif "raw" in NotNormalRelease and "normal" in NotNormalRefRelease:
-            cmd = 'python Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py ' +  inputpathRef + infi.filename(RefRelease).replace("mcRun4_realistic_v3_2026D76noPU-v1","mcRun4_realistic_v3_2026D49noPU-v1") + ' ' +  inputpathNew + infi.filename(NewRelease) + ' --outputDir HGCValid_%s_Plots --no-ratio --png --separate --html-sample "%s" ' %(opt.HTMLVALNAME, _sampleName[infi.name()] ) + ' --html-validation-name %s --subdirprefix ' %(opt.HTMLVALNAME) + ' plots_%s' % (samplename) + ' --collection %s' %(opt.HTMLVALNAME)
-            #cmd = 'python Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py ' +  inputpathRef + infi.filename(RefRelease).replace("mcRun4_realistic_v3_2026D49noPU_raw1100_rsb-v1","mcRun4_realistic_v3_2026D49noPU-v1") + ' ' +  inputpathNew + infi.filename(NewRelease) + ' --outputDir HGCValid_%s_Plots --no-ratio --png --separate --html-sample "%s" ' %(opt.HTMLVALNAME, _sampleName[infi.name()] ) + ' --html-validation-name %s --subdirprefix ' %(opt.HTMLVALNAME) + ' plots_%s' % (samplename) + ' --collection %s' %(opt.HTMLVALNAME)
+            cmd = 'python3 Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py ' +  inputpathRef + infi.filename(RefRelease).replace("mcRun4_realistic_v3_2026D76noPU-v1","mcRun4_realistic_v3_2026D49noPU-v1") + ' ' +  inputpathNew + infi.filename(NewRelease) + ' --outputDir HGCValid_%s_Plots --no-ratio --png --separate --html-sample "%s" ' %(opt.HTMLVALNAME, _sampleName[infi.name()] ) + ' --html-validation-name %s --subdirprefix ' %(opt.HTMLVALNAME) + ' plots_%s' % (samplename) + ' --collection %s' %(opt.HTMLVALNAME)
+            #cmd = 'python3 Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py ' +  inputpathRef + infi.filename(RefRelease).replace("mcRun4_realistic_v3_2026D49noPU_raw1100_rsb-v1","mcRun4_realistic_v3_2026D49noPU-v1") + ' ' +  inputpathNew + infi.filename(NewRelease) + ' --outputDir HGCValid_%s_Plots --no-ratio --png --separate --html-sample "%s" ' %(opt.HTMLVALNAME, _sampleName[infi.name()] ) + ' --html-validation-name %s --subdirprefix ' %(opt.HTMLVALNAME) + ' plots_%s' % (samplename) + ' --collection %s' %(opt.HTMLVALNAME)
         elif "raw" in NotNormalRelease and "raw" in NotNormalRefRelease:
-            #cmd = 'python Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py ' +  inputpathRef + infi.filename(RefRelease) + ' ' +  inputpathNew + infi.filename(NewRelease) + ' --outputDir HGCValid_%s_Plots --no-ratio --png --separate --html-sample "%s" ' %(opt.HTMLVALNAME, _sampleName[infi.name()] ) + ' --html-validation-name %s --subdirprefix ' %(opt.HTMLVALNAME) + ' plots_%s' % (samplename) + ' --collection %s' %(opt.HTMLVALNAME)
-            cmd = 'python Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py ' +  inputpathRef + infi.filename(RefRelease).replace("_raw1100","_raw1100_rsb") + ' ' +  inputpathNew + infi.filename(NewRelease) + ' --outputDir HGCValid_%s_Plots --no-ratio --png --separate --html-sample "%s" ' %(opt.HTMLVALNAME, _sampleName[infi.name()] ) + ' --html-validation-name %s --subdirprefix ' %(opt.HTMLVALNAME) + ' plots_%s' % (samplename) + ' --collection %s' %(opt.HTMLVALNAME)
+            #cmd = 'python3 Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py ' +  inputpathRef + infi.filename(RefRelease) + ' ' +  inputpathNew + infi.filename(NewRelease) + ' --outputDir HGCValid_%s_Plots --no-ratio --png --separate --html-sample "%s" ' %(opt.HTMLVALNAME, _sampleName[infi.name()] ) + ' --html-validation-name %s --subdirprefix ' %(opt.HTMLVALNAME) + ' plots_%s' % (samplename) + ' --collection %s' %(opt.HTMLVALNAME)
+            cmd = 'python3 Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py ' +  inputpathRef + infi.filename(RefRelease).replace("_raw1100","_raw1100_rsb") + ' ' +  inputpathNew + infi.filename(NewRelease) + ' --outputDir HGCValid_%s_Plots --no-ratio --png --separate --html-sample "%s" ' %(opt.HTMLVALNAME, _sampleName[infi.name()] ) + ' --html-validation-name %s --subdirprefix ' %(opt.HTMLVALNAME) + ' plots_%s' % (samplename) + ' --collection %s' %(opt.HTMLVALNAME)
         elif "normal" in NotNormalRelease and "normal" in NotNormalRefRelease:
-            cmd = 'python Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py ' +  inputpathRef + infi.filename(RefRelease) + ' ' +  inputpathNew + infi.filename(NewRelease) + ' --outputDir HGCValid_%s_Plots --no-ratio --png --separate --html-sample "%s" ' %(opt.HTMLVALNAME, _sampleName[infi.name()] ) + ' --html-validation-name %s --subdirprefix ' %(opt.HTMLVALNAME) + ' plots_%s' % (samplename) + ' --collection %s' %(opt.HTMLVALNAME)
-            #cmd = 'python Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py ' +  inputpathRef + infi.filename(RefRelease).replace("2026D49noPU-v2","2026D49noPU-v1") + ' ' +  inputpathNew + infi.filename(NewRelease) + ' --outputDir HGCValid_%s_Plots --no-ratio --png --separate --html-sample "%s" ' %(opt.HTMLVALNAME, _sampleName[infi.name()] ) + ' --html-validation-name %s --subdirprefix ' %(opt.HTMLVALNAME) + ' plots_%s' % (samplename) + ' --collection %s' %(opt.HTMLVALNAME)
+            cmd = 'python3 Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py ' +  inputpathRef + infi.filename(RefRelease) + ' ' +  inputpathNew + infi.filename(NewRelease) + ' --outputDir HGCValid_%s_Plots --no-ratio --png --separate --html-sample "%s" ' %(opt.HTMLVALNAME, _sampleName[infi.name()] ) + ' --html-validation-name %s --subdirprefix ' %(opt.HTMLVALNAME) + ' plots_%s' % (samplename) + ' --collection %s' %(opt.HTMLVALNAME)
+            #cmd = 'python3 Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py ' +  inputpathRef + infi.filename(RefRelease).replace("2026D49noPU-v2","2026D49noPU-v1") + ' ' +  inputpathNew + infi.filename(NewRelease) + ' --outputDir HGCValid_%s_Plots --no-ratio --png --separate --html-sample "%s" ' %(opt.HTMLVALNAME, _sampleName[infi.name()] ) + ' --html-validation-name %s --subdirprefix ' %(opt.HTMLVALNAME) + ' plots_%s' % (samplename) + ' --collection %s' %(opt.HTMLVALNAME)
         else: 
-            #cmd = 'python Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py ' +  inputpathRef + infi.filename(RefRelease).replace("D49","D41").replace("200-v2","200-v1") + ' ' +  inputpathNew + infi.filename(NewRelease) + ' --outputDir HGCValid_%s_Plots --no-ratio --png --separate --html-sample "%s" ' %(opt.HTMLVALNAME, _sampleName[infi.name()] ) + ' --html-validation-name %s --subdirprefix ' %(opt.HTMLVALNAME) + ' plots_%s' % (samplename) + ' --collection %s' %(opt.HTMLVALNAME) 
-            cmd = 'python Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py ' +  inputpathRef + infi.filename(RefRelease).replace("mcRun4_realistic_v2-v1", "mcRun4_realistic_v2_2026D49noPU-v1") + ' ' +  inputpathNew + infi.filename(NewRelease) + ' --outputDir HGCValid_%s_Plots --no-ratio --png --separate --html-sample "%s" ' %(opt.HTMLVALNAME, _sampleName[infi.name()] ) + ' --html-validation-name %s --subdirprefix ' %(opt.HTMLVALNAME) + ' plots_%s' % (samplename) + ' --collection %s' %(opt.HTMLVALNAME)
-            #cmd = 'python Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py ' +  inputpathRef + infi.filename(RefRelease) + ' ' +  inputpathNew + infi.filename(NewRelease) + ' --outputDir HGCValid_%s_Plots --no-ratio --png --separate --html-sample "%s" ' %(opt.HTMLVALNAME, _sampleName[infi.name()] ) + ' --html-validation-name %s --subdirprefix ' %(opt.HTMLVALNAME) + ' plots_%s' % (samplename) + ' --collection %s' %(opt.HTMLVALNAME)
+            #cmd = 'python3 Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py ' +  inputpathRef + infi.filename(RefRelease).replace("D49","D41").replace("200-v2","200-v1") + ' ' +  inputpathNew + infi.filename(NewRelease) + ' --outputDir HGCValid_%s_Plots --no-ratio --png --separate --html-sample "%s" ' %(opt.HTMLVALNAME, _sampleName[infi.name()] ) + ' --html-validation-name %s --subdirprefix ' %(opt.HTMLVALNAME) + ' plots_%s' % (samplename) + ' --collection %s' %(opt.HTMLVALNAME) 
+            cmd = 'python3 Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py ' +  inputpathRef + infi.filename(RefRelease).replace("mcRun4_realistic_v2-v1", "mcRun4_realistic_v2_2026D49noPU-v1") + ' ' +  inputpathNew + infi.filename(NewRelease) + ' --outputDir HGCValid_%s_Plots --no-ratio --png --separate --html-sample "%s" ' %(opt.HTMLVALNAME, _sampleName[infi.name()] ) + ' --html-validation-name %s --subdirprefix ' %(opt.HTMLVALNAME) + ' plots_%s' % (samplename) + ' --collection %s' %(opt.HTMLVALNAME)
+            #cmd = 'python3 Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py ' +  inputpathRef + infi.filename(RefRelease) + ' ' +  inputpathNew + infi.filename(NewRelease) + ' --outputDir HGCValid_%s_Plots --no-ratio --png --separate --html-sample "%s" ' %(opt.HTMLVALNAME, _sampleName[infi.name()] ) + ' --html-validation-name %s --subdirprefix ' %(opt.HTMLVALNAME) + ' plots_%s' % (samplename) + ' --collection %s' %(opt.HTMLVALNAME)
 
 
         if(opt.DRYRUN):

--- a/Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py
+++ b/Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py
@@ -15,9 +15,7 @@ simClustersIters = ["ClusterLevel","ticlSimTracksters"]
 trackstersIters = ['ticlTracksters'+iteration for iteration in ticlIterLabelsMerge]
 trackstersIters.extend(["ticlSimTracksters"])
 
-#hitLabel = 'recHits'
-hitValLabel = 'hitValidation'
-hitCalLabel = 'hitCalibration'
+hitLabel = 'recHits'
 layerClustersLabel = 'layerClusters'
 trackstersLabel = 'tracksters'
 trackstersWithEdgesLabel = 'trackstersWithEdges'
@@ -25,7 +23,7 @@ simLabel = 'simulation'
 allLabel = 'all'
 
 collection_choices = [allLabel]
-collection_choices.extend([hitCalLabel]+[hitValLabel]+[layerClustersLabel]+[trackstersLabel]+[trackstersWithEdgesLabel]+[simLabel])
+collection_choices.extend([hitLabel]+[layerClustersLabel]+[trackstersLabel]+[trackstersWithEdgesLabel]+[simLabel])
 
 def main(opts):
 
@@ -103,7 +101,7 @@ def main(opts):
         val.doPlots(hgchitcalib, plotterDrawArgs=drawArgs)
 
 
-    plotDict = {hitCalLabel:[plot_hitCal], hitValLabel:[plot_hitVal], layerClustersLabel:[plot_LC], trackstersLabel:[plot_Tst], trackstersWithEdgesLabel:[plot_TstEdges], simLabel:[plot_SC, plot_CP]}
+    plotDict = {hitLabel:[plot_hitVal, plot_hitCal], layerClustersLabel:[plot_LC], trackstersLabel:[plot_Tst], trackstersWithEdgesLabel:[plot_TstEdges], simLabel:[plot_SC, plot_CP]}
 
     if (opts.collection != allLabel):
         for task in plotDict[opts.collection]:

--- a/Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py
+++ b/Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py
@@ -15,7 +15,9 @@ simClustersIters = ["ClusterLevel","ticlSimTracksters"]
 trackstersIters = ['ticlTracksters'+iteration for iteration in ticlIterLabelsMerge]
 trackstersIters.extend(["ticlSimTracksters"])
 
-hitLabel = 'recHits'
+#hitLabel = 'recHits'
+hitValLabel = 'hitValidation'
+hitCalLabel = 'hitCalibration'
 layerClustersLabel = 'layerClusters'
 trackstersLabel = 'tracksters'
 trackstersWithEdgesLabel = 'trackstersWithEdges'
@@ -23,7 +25,7 @@ simLabel = 'simulation'
 allLabel = 'all'
 
 collection_choices = [allLabel]
-collection_choices.extend([hitLabel]+[layerClustersLabel]+[trackstersLabel]+[trackstersWithEdgesLabel]+[simLabel])
+collection_choices.extend([hitCalLabel]+[hitValLabel]+[layerClustersLabel]+[trackstersLabel]+[trackstersWithEdgesLabel]+[simLabel])
 
 def main(opts):
 
@@ -101,7 +103,7 @@ def main(opts):
         val.doPlots(hgchitcalib, plotterDrawArgs=drawArgs)
 
 
-    plotDict = {hitLabel:[plot_hitVal, plot_hitCal], layerClustersLabel:[plot_LC], trackstersLabel:[plot_Tst], trackstersWithEdgesLabel:[plot_TstEdges], simLabel:[plot_SC, plot_CP]}
+    plotDict = {hitCalLabel:[plot_hitCal], hitValLabel:[plot_hitVal], layerClustersLabel:[plot_LC], trackstersLabel:[plot_Tst], trackstersWithEdgesLabel:[plot_TstEdges], simLabel:[plot_SC, plot_CP]}
 
     if (opts.collection != allLabel):
         for task in plotDict[opts.collection]:


### PR DESCRIPTION
#### PR description:

Due to the python3 migration and a number of PRs, the scripts used for the regular validation report are updated. Specifically: 

1. The links in the summary webpage are broken due to deprecation of multiclusters  (PR [#33488](https://github.com/cms-sw/cmssw/pull/33488)) , tweaks in the basic plotting script (PR [#33639](https://github.com/cms-sw/cmssw/pull/33639))  and reorganization of the layer cluster plots in sub-folders (PR [#33063](https://github.com/cms-sw/cmssw/pull/33063)) . 
2. Due to PRs [#33488](https://github.com/cms-sw/cmssw/pull/33488), [#33639](https://github.com/cms-sw/cmssw/pull/33639) the basic `hgcalPerformanceValidation.py` script options needed renaming. 
3. Due to PR [#34311](https://github.com/cms-sw/cmssw/pull/34311) purities are defined and introduced to `html.py`.

#### PR validation:

We have used these scripts to create the validation report for the ongoing `12_0_0_pre4_phase2`  campaign.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This is not a backport.

@rovere @felicepantaleo @lecriste @ebrondol
