### PR TITLE
[tidy] Performance-unnecessary-copy-initialization fix

### DIFF
--- a/CommonTools/Utils/interface/MasslessInvariantMass.h
+++ b/CommonTools/Utils/interface/MasslessInvariantMass.h
@@ -6,7 +6,7 @@
 struct MasslessInvariantMass {
   template <typename T1, typename T2>
   double operator()(const T1& t1, const T2& t2) const {
-    math::XYZVector p1 = t1.momentum(), p2 = t2.momentum();
+    const math::XYZVector &p1 = t1.momentum(), &p2 = t2.momentum();
     math::XYZTLorentzVector v1(p1.x(), p1.y(), p1.z(), p1.r()), v2(p2.x(), p2.y(), p2.z(), p2.r());
     return (v1 + v2).mass();
   }


### PR DESCRIPTION
applied clang-tidy suggestions

```
CommonTools/Utils/interface/MasslessInvariantMass.h:9:21: warning: the variable 'p1' is copy-constructed from a const reference but is only used as const reference; consider making it a const reference [performance-unnecessary-copy-initialization]
CommonTools/Utils/interface/MasslessInvariantMass.h:9:48: warning: the const qualified variable 'p2' is copy-constructed from a const reference; consider making it a const reference [performance-unnecessary-copy-initialization]
```