### PR TITLE
Fix integer division after migration to python 3

### DIFF
--- a/Validation/RecoTrack/python/plotting/plotting.py
+++ b/Validation/RecoTrack/python/plotting/plotting.py
@@ -446,12 +446,12 @@ def _getYminMaxAroundMedian(obj, coverage, coverageRange=None):
     if nvals < 2:
         # Take median and +- 1 values
         if len(yvals) % 2 == 0:
-            half = len(yvals)/2
+            half = len(yvals) // 2
             return ( yvals[half-1], yvals[half] )
         else:
-            middle = len(yvals)/2
+            middle = len(yvals) // 2
             return ( yvals[middle-1], yvals[middle+1] )
-    ind_min = (len(yvals)-nvals)/2
+    ind_min = (len(yvals)-nvals) // 2
     ind_max = len(yvals)-1 - ind_min
 
     return (yvals[ind_min], yvals[ind_max])


### PR DESCRIPTION
#### PR description:

The migration to python 3 changed the rules for integer divisions to return floating point numbers instead of truncating to the lower integer.
Under some conditions, this change breaks `makeTrackValidation.py`, which ultimately fails with the error:
```
  File "/cvmfs/cms-ib.cern.ch/week1/slc7_amd64_gcc900/cms/cmssw/CMSSW_12_0_X_2021-07-27-2300/python/Validation/RecoTrack/plotting/plotting.py", line 457, in _getYminMaxAroundMedian
    return (yvals[ind_min], yvals[ind_max])
TypeError: list indices must be integers or slices, not float
```
This PR changes the division used to compute the bins to the "integer division" operator `//`, recovering the intended behaviour.

#### PR validation:

With these changes, `makeTrackValidation.py` works as intended on the same DQM files where it was failing before.


#### PR status:

This PR is a backport of #34711 to `CMSSW_12_0_X`