### PR TITLE
Update DQM onlinebeammonitor

### DIFF
--- a/DQM/Integration/python/clients/onlinebeammonitor_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/onlinebeammonitor_dqm_sourceclient-live_cfg.py
@@ -144,7 +144,16 @@ process.load("DQM.Integration.config.FrontierCondition_GT_cfi")
 # Condition for lxplus: change and possibly customise the GT
 #from Configuration.AlCa.GlobalTag import GlobalTag as gtCustomise
 #process.GlobalTag = gtCustomise(process.GlobalTag, 'auto:run2_data', '')
-
+process.GlobalTag.toGet = cms.VPSet(
+  cms.PSet(
+    record = cms.string("BeamSpotOnlineLegacyObjectsRcd"),
+    refreshTime = cms.uint64(1)
+  ),
+  cms.PSet(
+    record = cms.string("BeamSpotOnlineHLTObjectsRcd"),
+    refreshTime = cms.uint64(1)
+  )
+)
 
 process.dqmcommon = cms.Sequence(process.dqmEnv
                                * process.dqmSaver * process.dqmSaverPB)

--- a/DQM/Integration/python/clients/onlinebeammonitor_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/onlinebeammonitor_dqm_sourceclient-live_cfg.py
@@ -144,6 +144,9 @@ process.load("DQM.Integration.config.FrontierCondition_GT_cfi")
 # Condition for lxplus: change and possibly customise the GT
 #from Configuration.AlCa.GlobalTag import GlobalTag as gtCustomise
 #process.GlobalTag = gtCustomise(process.GlobalTag, 'auto:run2_data', '')
+
+# Please *do not* delete this toGet statement as it is needed to fetch BeamSpotOnline
+# information every lumisection (instead of every run as for the other records in the GT)
 process.GlobalTag.toGet = cms.VPSet(
   cms.PSet(
     record = cms.string("BeamSpotOnlineLegacyObjectsRcd"),


### PR DESCRIPTION
#### PR description:
Fixes #34717.
Added a VPSet to `process.GlobalTag` in  `onlinebeammonitor_dqm_sourceclient-live_cfg.py` DQM client:
```
process.GlobalTag.toGet = cms.VPSet(
  cms.PSet(
    record = cms.string("BeamSpotOnlineLegacyObjectsRcd"),
    refreshTime = cms.uint64(1)
  ),
  cms.PSet(
    record = cms.string("BeamSpotOnlineHLTObjectsRcd"),
    refreshTime = cms.uint64(1)
  )
)
```
In this way the information about BeamSpotOnline is fetched every lumisection and the monitoring
actually reflects the behaviour of any other consumer of these tags (most notably the HLT).
Note that only the record name is needed in the toGet, this makes the client configuration resilient for
future changes of the tag names themselves.

#### PR validation:
Compiles.
Also tested online and deployed the same configuration change in the HLT cosmics menu running in P5 (see http://cmsonline.cern.ch/cms-elog/1121707).

#### Backport
Backports to 12_0_X (needed for CRAFT and BeamTest) and 11_3_X (for CRUZET) will be previded shortly.
