### PR TITLE
TkDQM: Fill barycenter plots at EndRun

### DIFF
--- a/DQM/SiPixelPhase1Summary/interface/SiPixelBarycenter.h
+++ b/DQM/SiPixelPhase1Summary/interface/SiPixelBarycenter.h
@@ -42,10 +42,10 @@ public:
 protected:
   void beginRun(edm::Run const& run, edm::EventSetup const& eSetup) override;
 
-  void dqmEndLuminosityBlock(DQMStore::IBooker& iBooker,
-                             DQMStore::IGetter& iGetter,
-                             edm::LuminosityBlock const& lumiSeg,
-                             edm::EventSetup const& c) override;
+  void dqmEndRun(DQMStore::IBooker& iBooker,
+                 DQMStore::IGetter& iGetter,
+                 edm::Run const& iRun,
+                 edm::EventSetup const& c) override;
   void dqmEndJob(DQMStore::IBooker& iBooker, DQMStore::IGetter& iGetter) override;
 
 private:

--- a/DQM/SiPixelPhase1Summary/src/SiPixelBarycenter.cc
+++ b/DQM/SiPixelPhase1Summary/src/SiPixelBarycenter.cc
@@ -27,9 +27,9 @@ using namespace edm;
 
 SiPixelBarycenter::SiPixelBarycenter(const edm::ParameterSet& iConfig)
     : DQMEDHarvester(iConfig),
-      alignmentToken_(esConsumes<edm::Transition::EndLuminosityBlock>()),
-      gprToken_(esConsumes<edm::Transition::EndLuminosityBlock>()),
-      trackerTopologyToken_(esConsumes<edm::Transition::EndLuminosityBlock>()) {
+      alignmentToken_(esConsumes<edm::Transition::EndRun>()),
+      gprToken_(esConsumes<edm::Transition::EndRun>()),
+      trackerTopologyToken_(esConsumes<edm::Transition::EndRun>()) {
   LogInfo("PixelDQM") << "SiPixelBarycenter::SiPixelBarycenter: Got DQM BackEnd interface" << endl;
 }
 
@@ -43,10 +43,10 @@ void SiPixelBarycenter::beginRun(edm::Run const& run, edm::EventSetup const& eSe
 
 void SiPixelBarycenter::dqmEndJob(DQMStore::IBooker& iBooker, DQMStore::IGetter& iGetter) {}
 
-void SiPixelBarycenter::dqmEndLuminosityBlock(DQMStore::IBooker& iBooker,
-                                              DQMStore::IGetter& iGetter,
-                                              const edm::LuminosityBlock& lumiSeg,
-                                              edm::EventSetup const& c) {
+void SiPixelBarycenter::dqmEndRun(DQMStore::IBooker& iBooker,
+                                  DQMStore::IGetter& iGetter,
+                                  const edm::Run& iRun,
+                                  edm::EventSetup const& c) {
   bookBarycenterHistograms(iBooker);
 
   const Alignments* alignments = &c.getData(alignmentToken_);


### PR DESCRIPTION
#### PR description:

The new pixel barycenter plots added in https://github.com/cms-sw/cmssw/pull/34312 are now filled at EndRun and not at EndLuminosityBlock, which enables comparisons between different runs.

#### PR validation:

The changes have been tested by running `runTheMatrix.py -l 136.89`, which run without any failed steps and produces the desired additional histograms.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This PR is not a backport.

cc:
@mmusich, @arossi83, @sroychow
