### PR TITLE
Allow multiple "--command" in runTheMatrix

### DIFF
--- a/Configuration/PyReleaseValidation/python/MatrixReader.py
+++ b/Configuration/PyReleaseValidation/python/MatrixReader.py
@@ -22,7 +22,7 @@ class MatrixReader(object):
 
         self.wm=opt.wmcontrol
         self.revertDqmio=opt.revertDqmio
-        self.addCommand=opt.command
+        self.addCommand=' '.join(opt.command)
         self.apply=opt.apply
         self.commandLineWf=opt.workflow
         self.overWrite=opt.overWrite

--- a/Configuration/PyReleaseValidation/python/MatrixReader.py
+++ b/Configuration/PyReleaseValidation/python/MatrixReader.py
@@ -22,7 +22,7 @@ class MatrixReader(object):
 
         self.wm=opt.wmcontrol
         self.revertDqmio=opt.revertDqmio
-        self.addCommand=' '.join(opt.command)
+        self.addCommand=opt.command
         self.apply=opt.apply
         self.commandLineWf=opt.workflow
         self.overWrite=opt.overWrite

--- a/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
+++ b/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
@@ -306,6 +306,7 @@ if __name__ == '__main__':
                       action='store')
 
     opt,args = parser.parse_args()
+    if opt.command: opt.command = ' '.join(opt.command)
     os.environ["CMSSW_DAS_QUERY_SITES"]=opt.dasSites
     if opt.IBEos:
       try:from commands import getstatusoutput as run_cmd

--- a/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
+++ b/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
@@ -229,6 +229,7 @@ if __name__ == '__main__':
     parser.add_option('--command',
                       help='provide a way to add additional command to all of the cmsDriver commands in the matrix',
                       dest='command',
+                      action='append',
                       default=None
                       )
     parser.add_option('--apply',


### PR DESCRIPTION
#### PR description:
As discussed in https://github.com/cms-sw/cmssw/pull/34599#issuecomment-890847652
This PR considers `--command` as a list, and join them together. This allows multiple --command(s) to be used in the PR test.

#### PR validation:
`runTheMatrix.py --what upgrade -l 34634.0 --wm init --command '--customise Validation/Performance/TimeMemoryJobReport.customiseWithTimeMemoryJobReport' --command '--procModifiers fineCalo'`
gives the expected output.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:
Not a backport, and no need of backport.