### PR TITLE
Fix uploading EventSetup conditions from multiple CUDA streams

### DIFF
--- a/HeterogeneousCore/CUDACore/interface/ESProduct.h
+++ b/HeterogeneousCore/CUDACore/interface/ESProduct.h
@@ -75,6 +75,9 @@ namespace cms {
             transferAsync(data.m_data, cudaStream);
             assert(data.m_fillingStream == nullptr);
             data.m_fillingStream = cudaStream;
+            // Record in the cudaStream an event to mark the readiness of the
+            // EventSetup data on the GPU, so other streams can check for it
+            cudaCheck(cudaEventRecord(data.m_event.get(), cudaStream));
             // Now the filling has been enqueued to the cudaStream, so we
             // can return the GPU data immediately, since all subsequent
             // work must be either enqueued to the cudaStream, or the cudaStream


### PR DESCRIPTION
#### PR description:

When multiple CUDA streams are trying to initialise the same EventSetup object, the first one to do so starts the asynchronous operations, and the others are supposed to wait for it to finish. However, code for recording the CUDA event was missing, so the other streams would find the default- constructed event, which is always "valid".

Adding the missing call to record the event fixes the problem.

#### PR validation:

Without this PR, running multiple jobs with few threads each crashes fairly soon:
```
Running indefinitely over 10100 events with 4 jobs, each with 3 threads, 3 streams and 1 GPUs
   373.5 ±   0.1 ev/s (10000 events, 99.8% overlap)
   366.1 ±   0.1 ev/s (10000 events, 99.8% overlap)
   363.5 ±   0.1 ev/s (10000 events, 99.8% overlap)
   362.4 ±   0.1 ev/s (10000 events, 100.0% overlap)
   362.4 ±   0.1 ev/s (10000 events, 99.7% overlap)
The underlying cmsRun job was killed by signal 6

The last lines of the error log are:
Module: none
Module: CAHitNtupletCUDA:hltPixelTracksCUDA
Module: CAHitNtupletCUDA:hltPixelTracksCUDA
Module: CAHitNtupletCUDA:hltPixelTracksCUDA
Module: CAHitNtupletCUDA:hltPixelTracksCUDA

A fatal system signal has occurred: abort signal
```

With this PR, no crash is observed after a large number of tests:
```
Running indefinitely over 10100 events with 4 jobs, each with 3 threads, 3 streams and 1 GPUs
   372.1 ±   0.1 ev/s (10000 events, 99.9% overlap)
   365.3 ±   0.1 ev/s (10000 events, 99.9% overlap)
   362.5 ±   0.1 ev/s (10000 events, 99.9% overlap)
   361.9 ±   0.1 ev/s (10000 events, 99.6% overlap)
   361.0 ±   0.1 ev/s (10000 events, 99.9% overlap)
   361.3 ±   0.1 ev/s (10000 events, 99.6% overlap)
   361.7 ±   0.1 ev/s (10000 events, 99.9% overlap)
   361.0 ±   0.1 ev/s (10000 events, 99.7% overlap)
   361.2 ±   0.1 ev/s (10000 events, 99.9% overlap)
   361.0 ±   0.1 ev/s (10000 events, 100.0% overlap)
   361.2 ±   0.1 ev/s (10000 events, 99.9% overlap)
   361.8 ±   0.1 ev/s (10000 events, 100.0% overlap)
   361.7 ±   0.1 ev/s (10000 events, 99.8% overlap)
   360.9 ±   0.1 ev/s (10000 events, 99.8% overlap)
   361.2 ±   0.1 ev/s (10000 events, 99.9% overlap)
   361.6 ±   0.1 ev/s (10000 events, 99.9% overlap)
   ...
```
