### PR TITLE
Fix params for Payload Inspector

### DIFF
--- a/CondCore/Utilities/scripts/getPayloadData.py
+++ b/CondCore/Utilities/scripts/getPayloadData.py
@@ -307,6 +307,6 @@ if __name__ == '__main__':
 
                         
         # Else -> output result json string with base 64 encoding
-        else: 
+        else:
             import base64
             os.write( 1, base64.b64encode(bytes(result, 'utf-8')))

--- a/CondCore/Utilities/scripts/getPayloadData.py
+++ b/CondCore/Utilities/scripts/getPayloadData.py
@@ -191,10 +191,10 @@ def discover():
             two_tags = plot_method.isTwoTags()
             output(' - is Two Tags: ', two_tags)
             plot_dict = { 'plot': plot, 'plugin_name': plugin_name, 'title': plot_title, 'plot_type': plot_type, 'single_iov': single_iov, 'two_tags': two_tags }
-            #if modv.label == '2.0':
-            #    input_params = plot_method.inputParams()
-            #    output(' - input params: ', len(input_params))
-            #    plot_dict[ 'input_params'] = input_params
+            if modv.label == '2.0':
+                input_params = plot_method.inputParams()
+                output(' - input params: ', len(input_params))
+                plot_dict[ 'input_params'] = input_params
             result.setdefault(payload_type, []).append( plot_dict )
             output('currently discovered info: ', result)
     output('*** final output:', '')
@@ -307,6 +307,6 @@ if __name__ == '__main__':
 
                         
         # Else -> output result json string with base 64 encoding
-        else:
+        else: 
             import base64
             os.write( 1, base64.b64encode(bytes(result, 'utf-8')))


### PR DESCRIPTION
#### PR description:

When getting all data type for payload inspector, parameters were not being properly added to the returned dictionary. The lines adding these parameters was commented out. By uncommenting these lines the parameters are properly returned in the dictionary and displayed in the Browser.