### PR TITLE
enforce memory order to avoid crash on Ampere [11.3.x]

### DIFF
--- a/RecoPixelVertexing/PixelTriplets/plugins/GPUCACell.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/GPUCACell.h
@@ -69,6 +69,7 @@ public:
       auto i = cellNeighbors.extend();  // maybe wasted....
       if (i > 0) {
         cellNeighbors[i].reset();
+        __threadfence();
 #ifdef __CUDACC__
         auto zero = (PtrAsInt)(&cellNeighbors[0]);
         atomicCAS((PtrAsInt*)(&theOuterNeighbors),
@@ -89,6 +90,7 @@ public:
       auto i = cellTracks.extend();  // maybe wasted....
       if (i > 0) {
         cellTracks[i].reset();
+        __threadfence();
 #ifdef __CUDACC__
         auto zero = (PtrAsInt)(&cellTracks[0]);
         atomicCAS((PtrAsInt*)(&theTracks), zero, (PtrAsInt)(&cellTracks[i]));  // if fails we cannot give "i" back...


### PR DESCRIPTION
#### PR description:

Add missing memory fences to avoid crashes on Ampere (and potentially other) GPUs.

#### PR validation:

See #34386 .

####PR status:

Backport of #34386 .