### PR TITLE
[EventFilter] header cleanup to avoid private header usage

### DIFF
--- a/DQMServices/StreamerIO/test/DQMStreamerOutputRepackerTest.cc
+++ b/DQMServices/StreamerIO/test/DQMStreamerOutputRepackerTest.cc
@@ -179,7 +179,6 @@ namespace dqmservices {
 
 }  // namespace dqmservices
 
-#include "EventFilter/Utilities/plugins/RecoEventWriterForFU.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 
 typedef dqmservices::DQMStreamerOutputRepackerTest DQMStreamerOutputRepackerTest;

--- a/HLTrigger/special/plugins/HLTDummyCollections.cc
+++ b/HLTrigger/special/plugins/HLTDummyCollections.cc
@@ -34,7 +34,8 @@ Implementation:
 #include "DataFormats/EcalRecHit/interface/EcalRecHitCollections.h"
 #include "DataFormats/EcalRecHit/interface/EcalRecHitComparison.h"
 // -- Hcal
-#include "EventFilter/HcalRawToDigi/plugins/HcalRawToDigi.h"
+#include "DataFormats/HcalDigi/interface/HcalDigiCollections.h"
+
 // -- Ecal Preshower
 #include "EventFilter/ESRawToDigi/interface/ESRawToDigi.h"
 // -- Muons DT
@@ -56,7 +57,7 @@ Implementation:
 #include "DataFormats/Common/interface/DetSetVectorNew.h"
 #include "DataFormats/SiStripCluster/interface/SiStripCluster.h"
 // --- GCT
-#include "EventFilter/GctRawToDigi/plugins/GctRawToDigi.h"
+#include "DataFormats/L1GlobalCaloTrigger/interface/L1GctCollections.h"
 
 // -- ObjectMap
 #include "DataFormats/L1GlobalTrigger/interface/L1GlobalTriggerObjectMapRecord.h"


### PR DESCRIPTION
As reported in #34718 , this PR cleanup includes to avoid private header usage for `EventFilter` sub-system
```
      1 src/EventFilter/GctRawToDigi/plugins/GctRawToDigi.h
      1 src/EventFilter/HcalRawToDigi/plugins/HcalRawToDigi.h
      1 src/EventFilter/Utilities/plugins/RecoEventWriterForFU.h
```