### PR TITLE
[TrackingTools] Move public headers to interface directory

### DIFF
--- a/RecoTracker/TkDetLayers/src/TIBLayer.cc
+++ b/RecoTracker/TkDetLayers/src/TIBLayer.cc
@@ -11,7 +11,7 @@
 #include "TrackingTools/DetLayers/interface/DetLayerException.h"
 #include "TrackingTools/DetLayers/interface/MeasurementEstimator.h"
 #include "TrackingTools/GeomPropagators/interface/HelixBarrelCylinderCrossing.h"
-#include "TrackingTools/DetLayers/src/DetLessZ.h"
+#include "TrackingTools/DetLayers/interface/DetLessZ.h"
 
 typedef GeometricSearchDet::DetWithState DetWithState;
 

--- a/RecoTracker/TkNavigation/plugins/BeamHaloNavigationSchool.cc
+++ b/RecoTracker/TkNavigation/plugins/BeamHaloNavigationSchool.cc
@@ -22,7 +22,7 @@ protected:
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
-#include "TrackingTools/DetLayers/src/DetLessZ.h"
+#include "TrackingTools/DetLayers/interface/DetLessZ.h"
 #include "TrackingTools/DetLayers/interface/BarrelDetLayer.h"
 #include "TrackingTools/DetLayers/interface/ForwardDetLayer.h"
 

--- a/RecoTracker/TkNavigation/plugins/CosmicNavigationSchool.cc
+++ b/RecoTracker/TkNavigation/plugins/CosmicNavigationSchool.cc
@@ -66,7 +66,7 @@ private:
 
 #include "TrackingTools/DetLayers/interface/BarrelDetLayer.h"
 #include "TrackingTools/DetLayers/interface/ForwardDetLayer.h"
-#include "TrackingTools/DetLayers/src/DetLessZ.h"
+#include "TrackingTools/DetLayers/interface/DetLessZ.h"
 
 #include <functional>
 #include <algorithm>

--- a/RecoTracker/TkNavigation/plugins/SimpleNavigationSchool.cc
+++ b/RecoTracker/TkNavigation/plugins/SimpleNavigationSchool.cc
@@ -9,7 +9,7 @@
 
 #include "TrackingTools/DetLayers/interface/BarrelDetLayer.h"
 #include "TrackingTools/DetLayers/interface/ForwardDetLayer.h"
-#include "TrackingTools/DetLayers/src/DetLessZ.h"
+#include "TrackingTools/DetLayers/interface/DetLessZ.h"
 
 #include "DataFormats/GeometrySurface/interface/BoundCylinder.h"
 #include "DataFormats/GeometrySurface/interface/BoundDisk.h"

--- a/TrackingTools/DetLayers/interface/DetLessZ.h
+++ b/TrackingTools/DetLayers/interface/DetLessZ.h
@@ -4,7 +4,6 @@
 /** Comparison operator for Dets based on the Z.
  */
 
-#include "TrackingTools/DetLayers/src/DetLessZ.h"
 #include "TrackingTools/DetLayers/interface/GeometricSearchDet.h"
 
 inline bool isDetLessZ(const GeometricSearchDet* a, const GeometricSearchDet* b) {


### PR DESCRIPTION
As reported in #34718 , this PR moves headers in interface directory for `TrackingTools`
```
4 src/TrackingTools/DetLayers/src/DetLessZ.h
```