### PR TITLE
[RecoParticleFlow] Cleanup for unused/private header

### DIFF
--- a/RecoParticleFlow/PFTracking/src/PFDisplacedVertexFinder.cc
+++ b/RecoParticleFlow/PFTracking/src/PFDisplacedVertexFinder.cc
@@ -12,7 +12,7 @@
 #include "RecoVertex/AdaptiveVertexFit/interface/AdaptiveVertexFitter.h"
 #include "RecoVertex/KalmanVertexFit/interface/KalmanVertexSmoother.h"
 
-#include "PhysicsTools/RecoAlgos/plugins/KalmanVertexFitter.h"
+#include "RecoVertex/KalmanVertexFit/interface/KalmanVertexFitter.h"
 
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 #include "Geometry/CommonDetUnit/interface/TrackingGeometry.h"


### PR DESCRIPTION
As reported in #34718 , this is cleanup of private header usage. Thsi should fix the private issue 
```
1 src/PhysicsTools/RecoAlgos/plugins/KalmanVertexFitter.h
```