### PR TITLE
Protect HCAL GPU-related modules against empty events [11.3.x]

### DIFF
--- a/RecoLocalCalo/HcalRecProducers/src/HcalCPURecHitsProducer.cc
+++ b/RecoLocalCalo/HcalRecProducers/src/HcalCPURecHitsProducer.cc
@@ -76,6 +76,11 @@ void HcalCPURecHitsProducer::acquire(edm::Event const& event,
   std::cout << "num rec Hits = " << recHits.size << std::endl;
 #endif
 
+  // do not try to copy the rechits if they are empty
+  if (recHits.size == 0) {
+    return;
+  }
+
   auto lambdaToTransfer = [&ctx](auto& dest, auto* src) {
     using vector_type = typename std::remove_reference<decltype(dest)>::type;
     using src_data_type = typename std::remove_pointer<decltype(src)>::type;

--- a/RecoLocalCalo/HcalRecProducers/src/MahiGPU.cu
+++ b/RecoLocalCalo/HcalRecProducers/src/MahiGPU.cu
@@ -1048,13 +1048,14 @@ namespace hcal {
                     cudaStream_t cudaStream) {
       auto const totalChannels = inputGPU.f01HEDigis.size + inputGPU.f5HBDigis.size + inputGPU.f3HBDigis.size;
 
-      // protections when the detector is out
-      if(totalChannels==0) return;
+      // FIXME: the number of channels in output might change given that some channesl might be filtered out
 
-      // FIXME: may be move this assignment to emphasize this more clearly
-      // FIXME: number of channels for output might change given that
-      //   some channesl might be filtered out
+      // do not run when there are no rechits (e.g. if HCAL is not being read),
+      // but do set the size of the output collection to 0
       outputGPU.recHits.size = totalChannels;
+      if (totalChannels == 0) {
+        return;
+      }
 
       // TODO: this can be lifted by implementing a separate kernel
       // similar to the default one, but properly handling the diff in #sample


### PR DESCRIPTION
#### PR description:

Avoid running the HCAL local reconstruction if there are no HCAL digis - and set the size of the rechit collection to 0.

Avoid copying the rechits from the GPU to the CPU is their size is 0.

#### PR validation:

Running over data without HCAL no longer crashes.

#### PR status:

Backport of #34748.