### PR TITLE
[GCC 11] Fix error "array subscript outside array bounds"

### DIFF
--- a/CondCore/EcalPlugins/plugins/EcalFloatCondObjectContainer_PayloadInspector.cc
+++ b/CondCore/EcalPlugins/plugins/EcalFloatCondObjectContainer_PayloadInspector.cc
@@ -109,7 +109,7 @@ namespace {
 
       float xmi[3] = {0.0, 0.24, 0.76};
       float xma[3] = {0.24, 0.76, 1.00};
-      TPad** pad = new TPad*;
+      TPad** pad = new TPad*[3];
       for (int obj = 0; obj < 3; obj++) {
         pad[obj] = new TPad(Form("p_%i", obj), Form("p_%i", obj), xmi[obj], 0.0, xma[obj], 0.94);
         pad[obj]->Draw();
@@ -262,7 +262,7 @@ namespace {
       }
       float xmi[3] = {0.0, 0.24, 0.76};
       float xma[3] = {0.24, 0.76, 1.00};
-      TPad** pad = new TPad*;
+      TPad** pad = new TPad*[3];
       for (int obj = 0; obj < 3; obj++) {
         pad[obj] = new TPad(Form("p_%i", obj), Form("p_%i", obj), xmi[obj], 0.0, xma[obj], 0.94);
         pad[obj]->Draw();


### PR DESCRIPTION
Log file: https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/slc7_amd64_gcc11/CMSSW_12_1_X_2021-07-30-0900/CondCore/EcalPlugins
Error message:
```
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/3f7c5ca595fd8634b26b919adc27f210/opt/cmssw/slc7_amd64_gcc11/cms/cmssw/CMSSW_12_1_X_2021-07-30-0900/src/CondCore/EcalPlugins/plugins/EcalFloatCondObjectContainer_PayloadInspector.cc: In member function 'virtual bool {anonymous}::EcalFloatCondObjectContainerPlot::fill(const std::vector<std::tuple<long long unsigned int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >&)':
  /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/3f7c5ca595fd8634b26b919adc27f210/opt/cmssw/slc7_amd64_gcc11/cms/cmssw/CMSSW_12_1_X_2021-07-30-0900/src/CondCore/EcalPlugins/plugins/EcalFloatCondObjectContainer_PayloadInspector.cc:120:17: error: array subscript 1 is outside array bounds of 'TPad* [1]' [-Werror=array-bounds]
   120 |       pad[1]->cd();
      |       ~~~~~~~~~~^~
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/3f7c5ca595fd8634b26b919adc27f210/opt/cmssw/slc7_amd64_gcc11/cms/cmssw/CMSSW_12_1_X_2021-07-30-0900/src/CondCore/EcalPlugins/plugins/EcalFloatCondObjectContainer_PayloadInspector.cc:112:28: note: referencing an object of size 8 allocated by 'void* operator new(std::size_t)'
  112 |       TPad** pad = new TPad*;
      |                            ^
  /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/3f7c5ca595fd8634b26b919adc27f210/opt/cmssw/slc7_amd64_gcc11/cms/cmssw/CMSSW_12_1_X_2021-07-30-0900/src/CondCore/EcalPlugins/plugins/EcalFloatCondObjectContainer_PayloadInspector.cc:122:17: error: array subscript 2 is outside array bounds of 'TPad* [1]' [-Werror=array-bounds]
   122 |       pad[2]->cd();
      |       ~~~~~~~~~~^~
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/3f7c5ca595fd8634b26b919adc27f210/opt/cmssw/slc7_amd64_gcc11/cms/cmssw/CMSSW_12_1_X_2021-07-30-0900/src/CondCore/EcalPlugins/plugins/EcalFloatCondObjectContainer_PayloadInspector.cc:112:28: note: referencing an object of size 8 allocated by 'void* operator new(std::size_t)'
  112 |       TPad** pad = new TPad*;
      |                            ^
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/3f7c5ca595fd8634b26b919adc27f210/opt/cmssw/slc7_amd64_gcc11/cms/cmssw/CMSSW_12_1_X_2021-07-30-0900/src/CondCore/EcalPlugins/plugins/EcalFloatCondObjectContainer_PayloadInspector.cc: In member function 'bool {anonymous}::EcalFloatCondObjectContainerDiffBase<nIOVs, ntags>::fill() [with cond::payloadInspector::IOVMultiplicity nIOVs = cond::payloadInspector::SINGLE_IOV; int ntags = 1]':
  /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/3f7c5ca595fd8634b26b919adc27f210/opt/cmssw/slc7_amd64_gcc11/cms/cmssw/CMSSW_12_1_X_2021-07-30-0900/src/CondCore/EcalPlugins/plugins/EcalFloatCondObjectContainer_PayloadInspector.cc:273:17: error: array subscript 1 is outside array bounds of 'TPad* [1]' [-Werror=array-bounds]
   273 |       pad[1]->cd();
      |       ~~~~~~~~~~^~
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/3f7c5ca595fd8634b26b919adc27f210/opt/cmssw/slc7_amd64_gcc11/cms/cmssw/CMSSW_12_1_X_2021-07-30-0900/src/CondCore/EcalPlugins/plugins/EcalFloatCondObjectContainer_PayloadInspector.cc:265:20: note: referencing an object of size 8 allocated by 'void* operator new(std::size_t)'
  265 |       TPad** pad = new TPad*;
      |                    ^~~~~~~~~
  /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/3f7c5ca595fd8634b26b919adc27f210/opt/cmssw/slc7_amd64_gcc11/cms/cmssw/CMSSW_12_1_X_2021-07-30-0900/src/CondCore/EcalPlugins/plugins/EcalFloatCondObjectContainer_PayloadInspector.cc:275:17: error: array subscript 2 is outside array bounds of 'TPad* [1]' [-Werror=array-bounds]
   275 |       pad[2]->cd();
      |       ~~~~~~~~~~^~
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/3f7c5ca595fd8634b26b919adc27f210/opt/cmssw/slc7_amd64_gcc11/cms/cmssw/CMSSW_12_1_X_2021-07-30-0900/src/CondCore/EcalPlugins/plugins/EcalFloatCondObjectContainer_PayloadInspector.cc:265:20: note: referencing an object of size 8 allocated by 'void* operator new(std::size_t)'
  265 |       TPad** pad = new TPad*;
      |                    ^~~~~~~~~
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/3f7c5ca595fd8634b26b919adc27f210/opt/cmssw/slc7_amd64_gcc11/cms/cmssw/CMSSW_12_1_X_2021-07-30-0900/src/CondCore/EcalPlugins/plugins/EcalFloatCondObjectContainer_PayloadInspector.cc: In member function 'bool {anonymous}::EcalFloatCondObjectContainerDiffBase<nIOVs, ntags>::fill() [with cond::payloadInspector::IOVMultiplicity nIOVs = cond::payloadInspector::SINGLE_IOV; int ntags = 2]':
  /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/3f7c5ca595fd8634b26b919adc27f210/opt/cmssw/slc7_amd64_gcc11/cms/cmssw/CMSSW_12_1_X_2021-07-30-0900/src/CondCore/EcalPlugins/plugins/EcalFloatCondObjectContainer_PayloadInspector.cc:273:17: error: array subscript 1 is outside array bounds of 'TPad* [1]' [-Werror=array-bounds]
   273 |       pad[1]->cd();
      |       ~~~~~~~~~~^~
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/3f7c5ca595fd8634b26b919adc27f210/opt/cmssw/slc7_amd64_gcc11/cms/cmssw/CMSSW_12_1_X_2021-07-30-0900/src/CondCore/EcalPlugins/plugins/EcalFloatCondObjectContainer_PayloadInspector.cc:265:20: note: referencing an object of size 8 allocated by 'void* operator new(std::size_t)'
  265 |       TPad** pad = new TPad*;
      |                    ^~~~~~~~~
  /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/3f7c5ca595fd8634b26b919adc27f210/opt/cmssw/slc7_amd64_gcc11/cms/cmssw/CMSSW_12_1_X_2021-07-30-0900/src/CondCore/EcalPlugins/plugins/EcalFloatCondObjectContainer_PayloadInspector.cc:275:17: error: array subscript 2 is outside array bounds of 'TPad* [1]' [-Werror=array-bounds]
   275 |       pad[2]->cd();
      |       ~~~~~~~~~~^~
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/3f7c5ca595fd8634b26b919adc27f210/opt/cmssw/slc7_amd64_gcc11/cms/cmssw/CMSSW_12_1_X_2021-07-30-0900/src/CondCore/EcalPlugins/plugins/EcalFloatCondObjectContainer_PayloadInspector.cc:265:20: note: referencing an object of size 8 allocated by 'void* operator new(std::size_t)'
  265 |       TPad** pad = new TPad*;
      |                    ^~~~~~~~~
```

#### PR description:

<!-- Please replace this text with a description of the feature proposed or problem addressed, specifying:
  - what changes are expected in the output if any, 
  - what other PRs or externals it depends upon if any,
  - link to any additional material useful to provide a documentation for this PR (slides, JIRA tickets, related pull requestes, hypernews, TWiki or Indico pages)  -->

#### PR validation:

<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

<!-- Please replace this text with any link to  -->

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
