### PR TITLE
[GCC 11] Fix error "this pointer is null" in DQM/SiStripCommissioningDbClients

### DIFF
--- a/DQM/SiStripCommissioningDbClients/src/FastFedCablingHistosUsingDb.cc
+++ b/DQM/SiStripCommissioningDbClients/src/FastFedCablingHistosUsingDb.cc
@@ -468,7 +468,7 @@ void FastFedCablingHistosUsingDb::connections(SiStripConfigDb::DeviceDescription
     if (idet == detids.end()) {
       continue;
     }
-    if (idet->second) {
+    if (!idet->second) {
       continue;
     }
 


### PR DESCRIPTION
Log file: https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/slc7_amd64_gcc11/CMSSW_12_1_X_2021-07-30-0900/DQM/SiStripCommissioningDbClients
Error message: 
```
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/3f7c5ca595fd8634b26b919adc27f210/opt/cmssw/slc7_amd64_gcc11/cms/cmssw/CMSSW_12_1_X_2021-07-30-0900/src/DQM/SiStripCommissioningDbClients/src/FastFedCablingHistosUsingDb.cc: In member function 'void FastFedCablingHistosUsingDb::connections(SiStripConfigDb::DeviceDescriptionsRange, SiStripConfigDb::DcuDetIdsRange)':
  /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/3f7c5ca595fd8634b26b919adc27f210/opt/cmssw/slc7_amd64_gcc11/cms/cmssw/CMSSW_12_1_X_2021-07-30-0900/src/DQM/SiStripCommissioningDbClients/src/FastFedCablingHistosUsingDb.cc:476:49: error: 'this' pointer is null [-Werror=nonnull]
   476 |     uint16_t npairs = idet->second->getApvNumber() / 2;
      |                       ~~~~~~~~~~~~~~~~~~~~~~~~~~^~
In file included from /data/cmsbld/jenkins/workspace/build-any-ib/w/slc7_amd64_gcc11/external/tkonlinesw/4.2.0-1_gcc7-fc776fdba2d2dc7e5bcd24170ad0d08e/include/TkDcuConversionFactors.h:30,
                 from /data/cmsbld/jenkins/workspace/build-any-ib/w/slc7_amd64_gcc11/external/tkonlinesw/4.2.0-1_gcc7-fc776fdba2d2dc7e5bcd24170ad0d08e/include/deviceType.h:30,
                 from /data/cmsbld/jenkins/workspace/build-any-ib/w/slc7_amd64_gcc11/external/tkonlinesw/4.2.0-1_gcc7-fc776fdba2d2dc7e5bcd24170ad0d08e/include/FecFactory.h:33,
                 from /data/cmsbld/jenkins/workspace/build-any-ib/w/slc7_amd64_gcc11/external/tkonlinesw/4.2.0-1_gcc7-fc776fdba2d2dc7e5bcd24170ad0d08e/include/DeviceFactory.h:26,
                 from /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/3f7c5ca595fd8634b26b919adc27f210/opt/cmssw/slc7_amd64_gcc11/cms/cmssw/CMSSW_12_1_X_2021-07-30-0900/src/OnlineDB/SiStripConfigDb/interface/SiStripConfigDb.h:17,
                 from /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/3f7c5ca595fd8634b26b919adc27f210/opt/cmssw/slc7_amd64_gcc11/cms/cmssw/CMSSW_12_1_X_2021-07-30-0900/src/DQM/SiStripCommissioningDbClients/interface/CommissioningHistosUsingDb.h:8,
                 from /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/3f7c5ca595fd8634b26b919adc27f210/opt/cmssw/slc7_amd64_gcc11/cms/cmssw/CMSSW_12_1_X_2021-07-30-0900/src/DQM/SiStripCommissioningDbClients/interface/FastFedCablingHistosUsingDb.h:5,
                 from /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/3f7c5ca595fd8634b26b919adc27f210/opt/cmssw/slc7_amd64_gcc11/cms/cmssw/CMSSW_12_1_X_2021-07-30-0900/src/DQM/SiStripCommissioningDbClients/src/FastFedCablingHistosUsingDb.cc:2:
/data/cmsbld/jenkins/workspace/build-any-ib/w/slc7_amd64_gcc11/external/tkonlinesw/4.2.0-1_gcc7-fc776fdba2d2dc7e5bcd24170ad0d08e/include/TkDcuInfo.h:126:13: note: in a call to non-static member function 'tscType32 TkDcuInfo::getApvNumber()'
  126 |   tscType32 getApvNumber( ) ;
      |             ^~~~~~~~~~~~
```

#### PR description:

#### PR validation:

<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

<!-- Please replace this text with any link to  -->

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
