### PR TITLE
[DataFormat] Cleanup unnecessary includes of DF private headers

### DIFF
--- a/CondFormats/DTObjects/src/DTRecoUncertainties.cc
+++ b/CondFormats/DTObjects/src/DTRecoUncertainties.cc
@@ -6,7 +6,7 @@
  */
 
 #include "CondFormats/DTObjects/interface/DTRecoUncertainties.h"
-#include "DataFormats/MuonDetId/src/DTWireId.cc"
+#include "DataFormats/MuonDetId/interface/DTWireId.h"
 #include <iostream>
 
 using std::cout;

--- a/EventFilter/Phase2TrackerRawToDigi/plugins/Phase2TrackerDigiProducer.cc
+++ b/EventFilter/Phase2TrackerRawToDigi/plugins/Phase2TrackerDigiProducer.cc
@@ -6,8 +6,6 @@
 #include "DataFormats/DetId/interface/DetIdCollection.h"
 #include "DataFormats/FEDRawData/interface/FEDNumbering.h"
 #include "DataFormats/FEDRawData/interface/FEDRawDataCollection.h"
-#include "DataFormats/FEDRawData/src/fed_header.h"
-#include "DataFormats/FEDRawData/src/fed_trailer.h"
 #include "DataFormats/Phase2TrackerDigi/interface/Phase2TrackerDigi.h"
 #include "EventFilter/Phase2TrackerRawToDigi/interface/Phase2TrackerFEDBuffer.h"
 #include "EventFilter/Phase2TrackerRawToDigi/interface/Phase2TrackerFEDChannel.h"

--- a/EventFilter/SiStripRawToDigi/plugins/ExcludedFEDListProducer.cc
+++ b/EventFilter/SiStripRawToDigi/plugins/ExcludedFEDListProducer.cc
@@ -1,8 +1,6 @@
 #include "EventFilter/SiStripRawToDigi/plugins/ExcludedFEDListProducer.h"
 #include "DataFormats/Common/interface/DetSet.h"
 #include "DataFormats/FEDRawData/interface/FEDNumbering.h"
-#include "DataFormats/FEDRawData/src/fed_header.h"
-#include "DataFormats/FEDRawData/src/fed_trailer.h"
 #include "DataFormats/SiStripCommon/interface/SiStripConstants.h"
 #include "DataFormats/SiStripCommon/interface/SiStripEventSummary.h"
 #include "DataFormats/SiStripDigi/interface/SiStripDigi.h"


### PR DESCRIPTION
As reported in #34718 , this PR removes the usage of `DataFormats` private header files
```
      2 src/DataFormats/FEDRawData/src/fed_header.h
      2 src/DataFormats/FEDRawData/src/fed_trailer.h
      1 src/DataFormats/MuonDetId/src/DTWireId.cc
```