### PR TITLE
[GCC 11] Fix error: 'this' pointer is null in Fireworks/Geometry

### DIFF
--- a/Fireworks/Geometry/plugins/DisplayGeom.cc
+++ b/Fireworks/Geometry/plugins/DisplayGeom.cc
@@ -180,7 +180,7 @@ void DisplayGeom::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetu
 
       TEveStraightLineSet* ls = nullptr;
       if (m_MF_plane_draw_dir) {
-        new TEveStraightLineSet("MF_line_direction");
+        ls = new TEveStraightLineSet("MF_line_direction");
         ls->SetPickable(false);
         ls->SetLineColor(kGreen);
         ls->SetMarkerColor(kGreen);


### PR DESCRIPTION
Log file: https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/slc7_amd64_gcc11/CMSSW_12_1_X_2021-08-02-1100/Fireworks/Geometry
Error message: 
```
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/e3e3f354f3bbc00899d20eeb240b2272/opt/cmssw/slc7_amd64_gcc11/cms/cmssw/CMSSW_12_1_X_2021-08-02-1100/src/Fireworks/Geometry/plugins/DisplayGeom.cc: In member function 'virtual void DisplayGeom::analyze(const edm::Event&, const edm::EventSetup&)':
  /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/e3e3f354f3bbc00899d20eeb240b2272/opt/cmssw/slc7_amd64_gcc11/cms/cmssw/CMSSW_12_1_X_2021-08-02-1100/src/Fireworks/Geometry/plugins/DisplayGeom.cc:185:25: error: 'this' pointer is null [-Werror=nonnull]
   185 |         ls->SetLineColor(kGreen);
      |         ~~~~~~~~~~~~~~~~^~~~~~~~
```

#### PR description:

<!-- Please replace this text with a description of the feature proposed or problem addressed, specifying:
  - what changes are expected in the output if any, 
  - what other PRs or externals it depends upon if any,
  - link to any additional material useful to provide a documentation for this PR (slides, JIRA tickets, related pull requestes, hypernews, TWiki or Indico pages)  -->

#### PR validation:

<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

<!-- Please replace this text with any link to  -->

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
