### PR TITLE
Fix crash of ECAL GPU reco when ECAL is out of the run - 12_0_X

### DIFF
--- a/EventFilter/EcalRawToDigi/plugins/EcalRawToDigiGPU.cc
+++ b/EventFilter/EcalRawToDigi/plugins/EcalRawToDigiGPU.cc
@@ -138,6 +138,10 @@ void EcalRawToDigiGPU::acquire(edm::Event const& event,
   if (counter > 0) {
     ecal::raw::entryPoint(
         inputCPU, inputGPU, outputGPU_, scratchGPU, outputCPU_, conditions, ctx.stream(), counter, currentCummOffset);
+  } else {
+    // reset the number of channels
+    outputCPU_.nchannels[0] = 0;
+    outputCPU_.nchannels[1] = 0;
   }
 }
 

--- a/EventFilter/EcalRawToDigi/plugins/EcalRawToDigiGPU.cc
+++ b/EventFilter/EcalRawToDigi/plugins/EcalRawToDigiGPU.cc
@@ -103,6 +103,9 @@ void EcalRawToDigiGPU::acquire(edm::Event const& event,
 
   // output cpu
   outputCPU_ = {cms::cuda::make_host_unique<uint32_t[]>(2, ctx.stream())};
+  // initialize the number of channels
+  outputCPU_.nchannels[0] = 0;
+  outputCPU_.nchannels[1] = 0;
 
   // output gpu
   outputGPU_.allocate(config_, ctx.stream());
@@ -138,10 +141,6 @@ void EcalRawToDigiGPU::acquire(edm::Event const& event,
   if (counter > 0) {
     ecal::raw::entryPoint(
         inputCPU, inputGPU, outputGPU_, scratchGPU, outputCPU_, conditions, ctx.stream(), counter, currentCummOffset);
-  } else {
-    // reset the number of channels
-    outputCPU_.nchannels[0] = 0;
-    outputCPU_.nchannels[1] = 0;
   }
 }
 

--- a/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitProducerGPU.cc
+++ b/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitProducerGPU.cc
@@ -213,7 +213,9 @@ void EcalUncalibRecHitProducerGPU::acquire(edm::Event const& event,
 
   if ((neb_ > configParameters_.maxNumberHitsEB) || (nee_ > configParameters_.maxNumberHitsEE)) {
     edm::LogError("EcalUncalibRecHitProducerGPU")
-        << "max number of channels exceeded. See options 'maxNumberHitsEB and maxNumberHitsEE' ";
+        << "Max number of channels exceeded in barrel or endcap. Number of barrel channels: " << neb_
+        << " with maxNumberHitsEB=" << configParameters_.maxNumberHitsEB << ", number of endcap channels: " << nee_
+        << " with maxNumberHitsEE=" << configParameters_.maxNumberHitsEE;
   }
 
   // conditions


### PR DESCRIPTION
#### PR description:

Fixes a crash of the EcalUncalibRecHitProducerGPU module when the ECAL is not in the run. The reason for the crash is that the number of channels is not properly initialised to zero in the EcalRawToDigiGPU when there are no FEDs to unpack.
Also improved error message that helped to find the origin of the problem.

#### PR validation:

HLT configuration detailed in https://github.com/cms-sw/cmssw/issues/34197#issuecomment-891987459 runs to completion now.

Backport of #34765 