### PR TITLE
[GCC 11] Fix error "this pointer is null" in L1Trigger/DTTrigger

### DIFF
--- a/L1Trigger/DTTrigger/src/DTTrigTest.cc
+++ b/L1Trigger/DTTrigger/src/DTTrigTest.cc
@@ -194,11 +194,12 @@ void DTTrigTest::beginJob() {
 }
 
 void DTTrigTest::beginRun(const edm::Run& iRun, const edm::EventSetup& iEventSetup) {
-  if (!my_trig) {
-    my_trig->createTUs(iEventSetup);
-    if (my_debug)
-      cout << "[DTTrigTest] TU's Created" << endl;
-  }
+  if (!my_trig)
+    return;
+
+  my_trig->createTUs(iEventSetup);
+  if (my_debug)
+    cout << "[DTTrigTest] TU's Created" << endl;
 }
 
 void DTTrigTest::analyze(const Event& iEvent, const EventSetup& iEventSetup) {

--- a/L1Trigger/DTTrigger/src/DTTrigTest.cc
+++ b/L1Trigger/DTTrigger/src/DTTrigTest.cc
@@ -194,9 +194,6 @@ void DTTrigTest::beginJob() {
 }
 
 void DTTrigTest::beginRun(const edm::Run& iRun, const edm::EventSetup& iEventSetup) {
-  if (!my_trig)
-    return;
-
   my_trig->createTUs(iEventSetup);
   if (my_debug)
     cout << "[DTTrigTest] TU's Created" << endl;


### PR DESCRIPTION
Log file: https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/slc7_amd64_gcc11/CMSSW_12_1_X_2021-08-02-1100/L1Trigger/DTTrigger
Error message:
```
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/e3e3f354f3bbc00899d20eeb240b2272/opt/cmssw/slc7_amd64_gcc11/cms/cmssw/CMSSW_12_1_X_2021-08-02-1100/src/L1Trigger/DTTrigger/src/DTTrigTest.cc: In member function 'virtual void DTTrigTest::beginRun(const edm::Run&, const edm::EventSetup&)':
  /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/e3e3f354f3bbc00899d20eeb240b2272/opt/cmssw/slc7_amd64_gcc11/cms/cmssw/CMSSW_12_1_X_2021-08-02-1100/src/L1Trigger/DTTrigger/src/DTTrigTest.cc:198:23: error: 'this' pointer is null [-Werror=nonnull]
   198 |     my_trig->createTUs(iEventSetup);
      |     ~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~
In file included from /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/e3e3f354f3bbc00899d20eeb240b2272/opt/cmssw/slc7_amd64_gcc11/cms/cmssw/CMSSW_12_1_X_2021-08-02-1100/src/L1Trigger/DTTrigger/interface/DTTrigTest.h:26,
                 from /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/e3e3f354f3bbc00899d20eeb240b2272/opt/cmssw/slc7_amd64_gcc11/cms/cmssw/CMSSW_12_1_X_2021-08-02-1100/src/L1Trigger/DTTrigger/src/DTTrigTest.cc:17:
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/e3e3f354f3bbc00899d20eeb240b2272/opt/cmssw/slc7_amd64_gcc11/cms/cmssw/CMSSW_12_1_X_2021-08-02-1100/src/L1Trigger/DTTrigger/interface/DTTrig.h:78:8: note: in a call to non-static member function 'void DTTrig::createTUs(const edm::EventSetup&)'
   78 |   void createTUs(const edm::EventSetup& iSetup);
      |        ^~~~~~~~~
```

#### PR description:

<!-- Please replace this text with a description of the feature proposed or problem addressed, specifying:
  - what changes are expected in the output if any, 
  - what other PRs or externals it depends upon if any,
  - link to any additional material useful to provide a documentation for this PR (slides, JIRA tickets, related pull requestes, hypernews, TWiki or Indico pages)  -->

#### PR validation:

<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

<!-- Please replace this text with any link to  -->

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
