### PR TITLE
[GCC 11] Fix error "this pointer is null" in PhysicsTools/FWLite

### DIFF
--- a/PhysicsTools/FWLite/interface/Scanner.h
+++ b/PhysicsTools/FWLite/interface/Scanner.h
@@ -254,7 +254,7 @@ namespace fwlite {
       if (htemplate != nullptr) {
         if ((strcmp(hname, "htemp") == 0) && (strcmp(hname, htemplate->GetName()) != 0))
           htempDelete();
-        hist = (TH1 *)hist->Clone(hname);
+        hist = (TH1 *)htemplate->Clone(hname);
       } else if (drawopt.Contains("SAME", TString::kIgnoreCase)) {
         hist = getSameH1(hname);
       }


### PR DESCRIPTION
Log file: https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/slc7_amd64_gcc11/CMSSW_12_1_X_2021-08-02-1100/PhysicsTools/FWLite
Error message: 
```
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/e3e3f354f3bbc00899d20eeb240b2272/opt/cmssw/slc7_amd64_gcc11/cms/cmssw/CMSSW_12_1_X_2021-08-02-1100/src/PhysicsTools/FWLite/interface/Scanner.h: In member function 'TH1* fwlite::Scanner<Collection>::draw(const char*, const char*, TString, const char*, const TH1*) [with Collection = std::vector<reco::Track>]':
  /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/e3e3f354f3bbc00899d20eeb240b2272/opt/cmssw/slc7_amd64_gcc11/cms/cmssw/CMSSW_12_1_X_2021-08-02-1100/src/PhysicsTools/FWLite/interface/Scanner.h:257:34: error: 'this' pointer is null [-Werror=nonnull]
   257 |         hist = (TH1 *)hist->Clone(hname);
      |                       ~~~~~~~~~~~^~~~~~~
```

#### PR description:

Method code now matches it's description

#### PR validation:

<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

<!-- Please replace this text with any link to  -->

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
